### PR TITLE
research(solution-of-cubic-oq-03-oq-01-oq-04): discriminant of the general cubic and depression invariance

### DIFF
--- a/proofs/Proofs/SolutionOfCubicOQ03OQ01OQ04.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ03OQ01OQ04.lean
@@ -1,0 +1,190 @@
+/-
+  Discriminant of the General Cubic, Depression Invariance, and the
+  Separability Criterion
+
+  Open question stemming from `SolutionOfCubicOQ03OQ01` (Discriminant of the
+  Depressed Cubic), which proves Δ = -4p³ - 27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)²
+  for the *depressed* cubic x³ + px + q = 0 (the x² coefficient is zero,
+  i.e. e₁ = x₁+x₂+x₃ = 0).
+
+  This file removes the e₁ = 0 restriction and answers the natural follow-ups:
+
+  1. The discriminant of the GENERAL monic cubic x³ + ax² + bx + c,
+        Δ(a,b,c) = 18abc - 4a³c + a²b² - 4b³ - 27c²,
+     equals the same root-separation product (x₁-x₂)²(x₁-x₃)²(x₂-x₃)².
+     The parent is recovered as the a = 0 (depressed) specialization
+     Δ(0,p,q) = -4p³ - 27q².
+
+  2. The discriminant is invariant under translation of the roots
+     x ↦ x + t — equivalently, under the *depression* substitution that
+     sends a general cubic to its depressed form. Depressing a cubic does
+     not change its discriminant; this is why the coefficient formula
+     -4p³ - 27q² of the parent computes the discriminant of the original
+     cubic as well.
+
+  3. Over an integral domain, Δ(a,b,c) ≠ 0 ⟺ the three roots are pairwise
+     distinct (the separability / squarefree criterion). This is a
+     characteristic-free strengthening of the parent's real-sign analysis:
+     it needs no ordering, only that there are no zero divisors.
+
+  Parts 1 and 2 are polynomial identities over an arbitrary commutative
+  ring; part 3 holds over any integral domain. The depressed
+  discriminant and the root-separation product are recalled locally so the
+  file is self-contained.
+-/
+import Mathlib
+
+namespace GeneralCubicDiscriminant
+
+variable {R : Type*} [CommRing R]
+
+-- ============================================================
+-- SECTION I: Discriminants and the Root-Separation Product
+-- ============================================================
+
+/-- The discriminant of the general monic cubic x³ + ax² + bx + c. -/
+def genDiscriminant (a b c : R) : R :=
+  18 * a * b * c - 4 * a ^ 3 * c + a ^ 2 * b ^ 2 - 4 * b ^ 3 - 27 * c ^ 2
+
+/-- The discriminant of the depressed cubic x³ + px + q (the parent's
+    coefficient formula, recalled locally). -/
+def depressedDiscriminant (p q : R) : R := -4 * p ^ 3 - 27 * q ^ 2
+
+/-- The root-separation form of the discriminant
+    (x₁-x₂)²(x₁-x₃)²(x₂-x₃)². -/
+def rootDiscriminant (x₁ x₂ x₃ : R) : R :=
+  (x₁ - x₂) ^ 2 * (x₁ - x₃) ^ 2 * (x₂ - x₃) ^ 2
+
+/-- Vieta's formulas for the general monic cubic x³ + ax² + bx + c = 0:
+    x₁ + x₂ + x₃ = -a, x₁x₂ + x₁x₃ + x₂x₃ = b, x₁x₂x₃ = -c. -/
+structure IsGenRootTriple (a b c : R) (x₁ x₂ x₃ : R) : Prop where
+  sum_roots : x₁ + x₂ + x₃ = -a
+  sum_products : x₁ * x₂ + x₁ * x₃ + x₂ * x₃ = b
+  product : x₁ * x₂ * x₃ = -c
+
+-- ============================================================
+-- SECTION II: Discriminant of the General Cubic = Root Form
+-- ============================================================
+
+/-- The general-cubic discriminant equals the root-separation product:
+    18abc - 4a³c + a²b² - 4b³ - 27c² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)²
+    whenever x₁, x₂, x₃ are roots satisfying Vieta's formulas. -/
+theorem genDiscriminant_eq_root_form (a b c x₁ x₂ x₃ : R)
+    (h : IsGenRootTriple a b c x₁ x₂ x₃) :
+    genDiscriminant a b c = rootDiscriminant x₁ x₂ x₃ := by
+  obtain ⟨hs, hp, hpr⟩ := h
+  -- Express a, b, c via Vieta and reduce to a ring identity in the roots.
+  have ha : a = -(x₁ + x₂ + x₃) := by linear_combination hs
+  have hb : b = x₁ * x₂ + x₁ * x₃ + x₂ * x₃ := hp.symm
+  have hc : c = -(x₁ * x₂ * x₃) := by linear_combination hpr
+  subst ha hb hc
+  unfold genDiscriminant rootDiscriminant
+  ring
+
+-- ============================================================
+-- SECTION III: Recovering the Depressed Cubic (a = 0)
+-- ============================================================
+
+/-- Setting a = 0 in the general discriminant recovers the parent's
+    depressed-cubic discriminant -4p³ - 27q². -/
+theorem genDiscriminant_zero_lead (p q : R) :
+    genDiscriminant 0 p q = depressedDiscriminant p q := by
+  unfold genDiscriminant depressedDiscriminant
+  ring
+
+/-- The depressed-cubic discriminant equals the root form when the roots
+    sum to zero (e₁ = 0) — the parent's statement, recovered as the a = 0
+    case of `genDiscriminant_eq_root_form`. -/
+theorem depressedDiscriminant_eq_root_form (p q x₁ x₂ x₃ : R)
+    (hsum : x₁ + x₂ + x₃ = 0)
+    (hp : x₁ * x₂ + x₁ * x₃ + x₂ * x₃ = p)
+    (hq : x₁ * x₂ * x₃ = -q) :
+    depressedDiscriminant p q = rootDiscriminant x₁ x₂ x₃ := by
+  have h : IsGenRootTriple 0 p q x₁ x₂ x₃ :=
+    { sum_roots := by simpa using hsum, sum_products := hp, product := hq }
+  rw [← genDiscriminant_zero_lead p q, genDiscriminant_eq_root_form 0 p q _ _ _ h]
+
+-- ============================================================
+-- SECTION IV: Depression / Translation Invariance
+-- ============================================================
+
+/-- The root-separation product is invariant under a common translation
+    of all three roots: shifting x ↦ x + t leaves every difference
+    xᵢ - xⱼ unchanged. -/
+theorem rootDiscriminant_translation_invariant (x₁ x₂ x₃ t : R) :
+    rootDiscriminant (x₁ + t) (x₂ + t) (x₃ + t) = rootDiscriminant x₁ x₂ x₃ := by
+  unfold rootDiscriminant
+  ring
+
+/-- Vieta's data is carried along a common translation of the roots:
+    if (a, b, c) are the coefficients of the cubic with roots x₁, x₂, x₃,
+    then the cubic with roots xᵢ + t has the explicit shifted coefficients
+    (a - 3t,  b - 2at + 3t²,  c - bt + at² - t³). -/
+theorem isGenRootTriple_translate (a b c x₁ x₂ x₃ t : R)
+    (h : IsGenRootTriple a b c x₁ x₂ x₃) :
+    IsGenRootTriple (a - 3 * t) (b - 2 * a * t + 3 * t ^ 2)
+      (c - b * t + a * t ^ 2 - t ^ 3) (x₁ + t) (x₂ + t) (x₃ + t) where
+  sum_roots := by
+    have h1 := h.sum_roots; linear_combination h1
+  sum_products := by
+    have h1 := h.sum_roots; have h2 := h.sum_products
+    linear_combination h2 + 2 * t * h1
+  product := by
+    have h1 := h.sum_roots; have h2 := h.sum_products; have h3 := h.product
+    linear_combination h3 + t * h2 + t ^ 2 * h1
+
+/-- **Depression invariance of the discriminant.** Translating all three
+    roots by a common t (in particular, the depression substitution that
+    zeroes out the x² coefficient) does not change the discriminant. The
+    discriminant of a general cubic therefore equals the discriminant of
+    its depressed form. -/
+theorem genDiscriminant_translation_invariant
+    (a b c a' b' c' x₁ x₂ x₃ t : R)
+    (h : IsGenRootTriple a b c x₁ x₂ x₃)
+    (h' : IsGenRootTriple a' b' c' (x₁ + t) (x₂ + t) (x₃ + t)) :
+    genDiscriminant a' b' c' = genDiscriminant a b c := by
+  rw [genDiscriminant_eq_root_form a' b' c' _ _ _ h',
+      genDiscriminant_eq_root_form a b c _ _ _ h,
+      rootDiscriminant_translation_invariant]
+
+-- ============================================================
+-- SECTION V: Separability Criterion over an Integral Domain
+-- ============================================================
+
+/-- Over an integral domain, the general-cubic discriminant vanishes iff
+    two of the roots coincide. This is the characteristic-free separability
+    criterion: no ordering or sign analysis is needed, only the absence of
+    zero divisors. -/
+theorem genDiscriminant_eq_zero_iff
+    {R : Type*} [CommRing R] [IsDomain R]
+    (a b c x₁ x₂ x₃ : R) (h : IsGenRootTriple a b c x₁ x₂ x₃) :
+    genDiscriminant a b c = 0 ↔ x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃ := by
+  rw [genDiscriminant_eq_root_form a b c x₁ x₂ x₃ h]
+  unfold rootDiscriminant
+  constructor
+  · intro hzero
+    -- a product of squares is zero, so one factor is zero
+    rcases mul_eq_zero.mp hzero with h12 | h23
+    · rcases mul_eq_zero.mp h12 with h1 | h2
+      · refine Or.inl (sub_eq_zero.mp ?_)
+        exact pow_eq_zero_iff (n := 2) (by norm_num) |>.mp h1
+      · refine Or.inr (Or.inl (sub_eq_zero.mp ?_))
+        exact pow_eq_zero_iff (n := 2) (by norm_num) |>.mp h2
+    · refine Or.inr (Or.inr (sub_eq_zero.mp ?_))
+      exact pow_eq_zero_iff (n := 2) (by norm_num) |>.mp h23
+  · rintro (h12 | h13 | h23)
+    · simp [sub_eq_zero.mpr h12]
+    · simp [sub_eq_zero.mpr h13]
+    · simp [sub_eq_zero.mpr h23]
+
+/-- Reformulation: over an integral domain the discriminant is nonzero iff
+    all three roots are pairwise distinct (the cubic is separable). -/
+theorem genDiscriminant_ne_zero_iff
+    {R : Type*} [CommRing R] [IsDomain R]
+    (a b c x₁ x₂ x₃ : R) (h : IsGenRootTriple a b c x₁ x₂ x₃) :
+    genDiscriminant a b c ≠ 0 ↔ x₁ ≠ x₂ ∧ x₁ ≠ x₃ ∧ x₂ ≠ x₃ := by
+  rw [ne_eq, genDiscriminant_eq_zero_iff a b c x₁ x₂ x₃ h]
+  push_neg
+  tauto
+
+end GeneralCubicDiscriminant

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01-oq-04/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-gen-discriminant-def",
+    "proofId": "solution-of-cubic-oq-03-oq-01-oq-04",
+    "range": {
+      "startLine": 44,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "Discriminant of the General Cubic and Vieta Data",
+    "content": "`genDiscriminant a b c = 18·a·b·c − 4·a³·c + a²·b² − 4·b³ − 27·c²` is the discriminant of the general monic cubic x³+ax²+bx+c. `depressedDiscriminant p q = −4p³ − 27q²` recalls the parent's depressed formula locally, and `rootDiscriminant x₁ x₂ x₃ = (x₁−x₂)²(x₁−x₃)²(x₂−x₃)²` is the root-separation form. `IsGenRootTriple a b c x₁ x₂ x₃` is a structure bundling Vieta's three relations for the general cubic. Keeping the definitions local makes the file self-contained over an arbitrary commutative ring R.",
+    "mathContext": "$\\Delta(a,b,c) = 18abc - 4a^3c + a^2b^2 - 4b^3 - 27c^2$; Vieta: $x_1+x_2+x_3 = -a$, $x_1x_2+x_1x_3+x_2x_3 = b$, $x_1x_2x_3 = -c$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "discriminant",
+      "Vieta's formulas",
+      "monic cubic"
+    ],
+    "prerequisites": [
+      "commutative ring",
+      "polynomial roots"
+    ]
+  },
+  {
+    "id": "ann-gen-root-form",
+    "proofId": "solution-of-cubic-oq-03-oq-01-oq-04",
+    "range": {
+      "startLine": 72,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "General-Cubic Discriminant Equals the Root-Separation Product",
+    "content": "`genDiscriminant_eq_root_form`: under Vieta's formulas, 18abc − 4a³c + a²b² − 4b³ − 27c² = (x₁−x₂)²(x₁−x₃)²(x₂−x₃)². The proof solves the Vieta relations for a, b, c — a = −(x₁+x₂+x₃), b = x₁x₂+x₁x₃+x₂x₃, c = −(x₁x₂x₃) — using `linear_combination` (an algebraic certificate valid over any commutative ring, unlike `linarith` which needs an order), `subst`s them, and closes the polynomial identity in the three roots by `ring`. This is the core result: the parent's depressed identity is its a = 0 slice.",
+    "mathContext": "A single `ring` identity in x₁,x₂,x₃ after eliminating a,b,c via Vieta. Holds over an arbitrary commutative ring.",
+    "significance": "central",
+    "relatedConcepts": [
+      "discriminant",
+      "root-separation product",
+      "ring identity"
+    ],
+    "prerequisites": [
+      "Vieta's formulas",
+      "linear_combination",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-recover-depressed",
+    "proofId": "solution-of-cubic-oq-03-oq-01-oq-04",
+    "range": {
+      "startLine": 89,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "Recovering the Parent's Depressed Discriminant",
+    "content": "`genDiscriminant_zero_lead`: setting a = 0 gives genDiscriminant 0 p q = −4p³ − 27q² = depressedDiscriminant p q (one `ring` step). `depressedDiscriminant_eq_root_form`: when the roots sum to zero (e₁ = 0), the depressed discriminant equals the root form — the parent's exact statement, here obtained as the a = 0 instance of the general theorem. Together they certify that the general result subsumes the depressed-cubic discriminant.",
+    "mathContext": "$\\Delta(0,p,q) = -4p^3 - 27q^2$; with $x_1+x_2+x_3 = 0$ this equals $(x_1-x_2)^2(x_1-x_3)^2(x_2-x_3)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "depressed cubic",
+      "specialization"
+    ],
+    "prerequisites": [
+      "depressed cubic discriminant"
+    ]
+  },
+  {
+    "id": "ann-translation-invariance",
+    "proofId": "solution-of-cubic-oq-03-oq-01-oq-04",
+    "range": {
+      "startLine": 113,
+      "endLine": 156
+    },
+    "type": "theorem",
+    "title": "Depression Invariance of the Discriminant",
+    "content": "Three results establish that translating the roots — the depression substitution x ↦ x + t — preserves the discriminant. `rootDiscriminant_translation_invariant`: shifting all roots by t leaves the product of squared differences unchanged (pure `ring`, since each x_i − x_j is shift-invariant). `isGenRootTriple_translate`: the shifted roots satisfy Vieta for the explicit coefficients (a−3t, b−2at+3t², c−bt+at²−t³), each field proved by `linear_combination`. `genDiscriminant_translation_invariant`: chaining these through the root form gives genDiscriminant of the shifted coefficients = genDiscriminant of the original. This is the precise justification for computing a cubic's discriminant from its depressed form.",
+    "mathContext": "Under $x_i \\mapsto x_i + t$ the coefficients become $(a-3t,\\,b-2at+3t^2,\\,c-bt+at^2-t^3)$ while $\\prod_{i<j}(x_i-x_j)^2$ is unchanged.",
+    "significance": "central",
+    "relatedConcepts": [
+      "depression substitution",
+      "translation invariance",
+      "Tschirnhaus transformation"
+    ],
+    "prerequisites": [
+      "Vieta's formulas",
+      "change of variable"
+    ]
+  },
+  {
+    "id": "ann-separability",
+    "proofId": "solution-of-cubic-oq-03-oq-01-oq-04",
+    "range": {
+      "startLine": 157,
+      "endLine": 190
+    },
+    "type": "theorem",
+    "title": "Characteristic-Free Separability Criterion",
+    "content": "`genDiscriminant_eq_zero_iff`: over an integral domain, Δ(a,b,c) = 0 ⟺ x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃. The forward direction rewrites to the root form and repeatedly applies `mul_eq_zero` and `pow_eq_zero_iff` (both needing no zero divisors) to isolate a vanishing factor, then `sub_eq_zero` turns it into an equality of roots; the reverse direction `simp`s with the vanishing difference. `genDiscriminant_ne_zero_iff`: the `push_neg` contrapositive — Δ ≠ 0 ⟺ the roots are pairwise distinct. This replaces the parent's real-sign analysis with an ordering-free squarefree/separability test usable in any characteristic.",
+    "mathContext": "Over an integral domain a product of squares vanishes iff a factor does, so $\\Delta = 0 \\iff$ two roots coincide. No ordering or sign is used.",
+    "significance": "central",
+    "relatedConcepts": [
+      "separable polynomial",
+      "integral domain",
+      "repeated roots"
+    ],
+    "prerequisites": [
+      "integral domain",
+      "mul_eq_zero",
+      "pow_eq_zero_iff"
+    ]
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01-oq-04/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "solution-of-cubic-oq-03-oq-01-oq-04",
+  "slug": "solution-of-cubic-oq-03-oq-01-oq-04",
+  "title": "Discriminant of the General Cubic and Depression Invariance",
+  "status": "verified",
+  "badge": "original",
+  "description": "Removes the depressed (e₁ = 0) restriction of the parent: the general-cubic discriminant Δ(a,b,c) = 18abc − 4a³c + a²b² − 4b³ − 27c² equals the root-separation product (x₁−x₂)²(x₁−x₃)²(x₂−x₃)², the discriminant is invariant under translating the roots (the depression substitution), and over any integral domain Δ ≠ 0 ⟺ the roots are pairwise distinct (the characteristic-free separability criterion).",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "GeneralCubicDiscriminant",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 3,
+    "path": "Proofs/SolutionOfCubicOQ03OQ01OQ04.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "The discriminant of the general monic cubic x³ + ax² + bx + c equals the same root-separation product (x₁−x₂)²(x₁−x₃)²(x₂−x₃)² that the parent established only for the depressed cubic, with 0 sorries and 0 axioms. The parent's formula −4p³ − 27q² is recovered exactly as the a = 0 specialization. The discriminant is proved invariant under a common translation of the roots — the depression substitution x ↦ x + t — so depressing a cubic never changes its discriminant. Finally, over any integral domain the discriminant vanishes iff two roots coincide, a characteristic-free separability criterion that strengthens the parent's real-sign analysis (no ordering required).",
+    "implications": "The root-form identity and the translation-invariance lemma justify the standard practice of computing a cubic's discriminant from its depressed form: the depression step is discriminant-preserving. The integral-domain criterion Δ ≠ 0 ⟺ distinct roots is the squarefree/separability test underlying Galois-theoretic arguments about cubic field extensions, and being characteristic-free it applies over ℚ, finite fields (away from characteristic obstructions to depression), and polynomial rings alike.",
+    "openQuestions": [
+      "Express Δ = −Res(f, f') by relating the general-cubic discriminant to the resultant of f and its derivative, recovering the root form via ∏ᵢ f'(xᵢ) = −Δ for the monic cubic.",
+      "Lift the separability criterion to the splitting field: state Δ ≠ 0 ⟺ the cubic is separable (squarefree) directly for a polynomial f : R[X] of degree 3 via Mathlib's Polynomial.discriminant / separability API, rather than for an explicit root triple."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The discriminant of a polynomial — the product of the squares of the differences of its roots, $\\prod_{i<j}(x_i-x_j)^2$ — detects repeated roots and, for the cubic over $\\mathbb{R}$, the number of real roots. For the depressed cubic $x^3+px+q$ the parent entry proved the classical coefficient formula $\\Delta = -4p^3-27q^2$. The general monic cubic $x^3+ax^2+bx+c$ has the richer discriminant $\\Delta = 18abc - 4a^3c + a^2b^2 - 4b^3 - 27c^2$. The two are linked by *depression*: the substitution $x \\mapsto x - a/3$ (over a ring where $3$ is invertible) kills the quadratic term and sends the general cubic to a depressed one. A basic structural fact — implicit whenever one computes a discriminant 'after depressing' — is that this substitution leaves the discriminant unchanged. This entry proves the general root-form identity, the translation-invariance that underlies depression, and the characteristic-free separability criterion, all over an arbitrary commutative ring (or integral domain).",
+    "problemStatement": "Let $x_1,x_2,x_3$ be roots of the general monic cubic $x^3+ax^2+bx+c$, i.e. satisfy Vieta's formulas $x_1+x_2+x_3=-a$, $x_1x_2+x_1x_3+x_2x_3=b$, $x_1x_2x_3=-c$. Then (1) $18abc-4a^3c+a^2b^2-4b^3-27c^2 = (x_1-x_2)^2(x_1-x_3)^2(x_2-x_3)^2$; (2) the discriminant is unchanged when all three roots are translated by a common $t$ (so the cubic with shifted coefficients has the same discriminant), recovering $\\Delta(0,p,q) = -4p^3-27q^2$ as the depressed case; and (3) over an integral domain $\\Delta \\ne 0$ iff $x_1,x_2,x_3$ are pairwise distinct.",
+    "proofStrategy": "All three parts reduce to `ring` identities once Vieta's relations are substituted. `genDiscriminant_eq_root_form` substitutes $a=-(x_1+x_2+x_3)$, $b=x_1x_2+x_1x_3+x_2x_3$, $c=-(x_1x_2x_3)$ (each derived from the Vieta hypotheses by `linear_combination`, since `linarith` is unavailable over a bare commutative ring) and closes by `ring`. `genDiscriminant_zero_lead` is a one-line `ring` evaluation at $a=0$, and `depressedDiscriminant_eq_root_form` packages the $e_1=0$ case back into the parent's statement. Translation invariance splits in two: `rootDiscriminant_translation_invariant` is pure `ring` (every difference $x_i-x_j$ is shift-invariant), and `isGenRootTriple_translate` computes the shifted coefficients $(a-3t,\\,b-2at+3t^2,\\,c-bt+at^2-t^3)$ via `linear_combination`; `genDiscriminant_translation_invariant` chains the two through the root form. The separability criterion `genDiscriminant_eq_zero_iff` rewrites to the root form and peels the product of three squares with `mul_eq_zero` and `pow_eq_zero_iff` (valid over an integral domain), with `sub_eq_zero` converting each vanishing factor to an equality of roots; `genDiscriminant_ne_zero_iff` is its `push_neg` contrapositive.",
+    "keyInsights": [
+      "**The same root-separation product governs the general cubic.** The hand-tuned coefficient polynomial $18abc-4a^3c+a^2b^2-4b^3-27c^2$ is exactly $(x_1-x_2)^2(x_1-x_3)^2(x_2-x_3)^2$ once Vieta's formulas are substituted — the parent's depressed identity is the $a=0$ slice of this one `ring` identity.",
+      "**Depression is discriminant-preserving.** Because every root difference $x_i-x_j$ is invariant under a common shift $x_i \\mapsto x_i+t$, the root-separation product — and hence the discriminant in any coefficient form — is translation-invariant. This is the precise reason one may compute a general cubic's discriminant from its depressed form.",
+      "**The shifted coefficients are explicit.** Translating the roots by $t$ sends $(a,b,c)$ to $(a-3t,\\,b-2at+3t^2,\\,c-bt+at^2-t^3)$; `isGenRootTriple_translate` proves these satisfy Vieta for the shifted roots, making the depression substitution a concrete, fully-verified operation rather than an informal change of variables.",
+      "**`linarith` is unavailable over a commutative ring.** Solving Vieta's relations for $a,b,c$ needs `linear_combination` (an algebraic identity certificate), not `linarith`, which requires a linear order. This keeps every identity valid over an arbitrary commutative ring, not just $\\mathbb{R}$.",
+      "**A characteristic-free separability test.** Over an integral domain, $\\Delta = 0$ iff some $(x_i-x_j)^2 = 0$ iff two roots coincide — proved from `mul_eq_zero` and `pow_eq_zero_iff` with no sign or ordering. This is strictly more general than the parent's $\\Delta>0/\\Delta=0$ real analysis and is the form used in Galois theory."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-defs",
+      "title": "Discriminants and the Root-Separation Product",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Documentation header stating the three follow-ups to the parent. Defines genDiscriminant a b c (the general-cubic coefficient form), depressedDiscriminant p q (the parent's −4p³−27q², recalled locally), rootDiscriminant x₁ x₂ x₃ (the product of squared root differences), and the IsGenRootTriple structure carrying Vieta's formulas for the general monic cubic.",
+      "mathContext": "Works over an arbitrary commutative ring R. IsGenRootTriple a b c x₁ x₂ x₃ bundles x₁+x₂+x₃ = −a, x₁x₂+x₁x₃+x₂x₃ = b, x₁x₂x₃ = −c."
+    },
+    {
+      "id": "general-root-form",
+      "title": "General-Cubic Discriminant Equals the Root Form",
+      "startLine": 66,
+      "endLine": 88,
+      "summary": "genDiscriminant_eq_root_form: substitutes the Vieta relations for a, b, c (each obtained by linear_combination over the commutative ring) and closes the resulting polynomial identity in the three roots by ring.",
+      "mathContext": "18abc − 4a³c + a²b² − 4b³ − 27c² = (x₁−x₂)²(x₁−x₃)²(x₂−x₃)² under Vieta's formulas."
+    },
+    {
+      "id": "recover-depressed",
+      "title": "Recovering the Depressed Cubic (a = 0)",
+      "startLine": 89,
+      "endLine": 112,
+      "summary": "genDiscriminant_zero_lead evaluates the general formula at a = 0 to give the parent's −4p³−27q² by ring. depressedDiscriminant_eq_root_form repackages the e₁ = 0 case as the parent's statement, recovering it as a special case of the general theorem.",
+      "mathContext": "Δ(0,p,q) = −4p³−27q²; with x₁+x₂+x₃ = 0 the depressed discriminant equals the root form."
+    },
+    {
+      "id": "translation-invariance",
+      "title": "Depression / Translation Invariance",
+      "startLine": 113,
+      "endLine": 156,
+      "summary": "rootDiscriminant_translation_invariant: shifting all roots by t leaves the product of squared differences unchanged (pure ring). isGenRootTriple_translate: the explicit shifted coefficients (a−3t, b−2at+3t², c−bt+at²−t³) satisfy Vieta for the shifted roots (linear_combination). genDiscriminant_translation_invariant: chaining these through the root form shows the discriminant is invariant under depression.",
+      "mathContext": "Every difference x_i − x_j is invariant under x ↦ x + t, so the discriminant is preserved by the depression substitution."
+    },
+    {
+      "id": "separability",
+      "title": "Separability Criterion over an Integral Domain",
+      "startLine": 157,
+      "endLine": 190,
+      "summary": "genDiscriminant_eq_zero_iff: over an integral domain the discriminant vanishes iff two roots coincide, proved by peeling the product of three squares with mul_eq_zero / pow_eq_zero_iff and sub_eq_zero. genDiscriminant_ne_zero_iff: the push_neg contrapositive — Δ ≠ 0 iff the roots are pairwise distinct.",
+      "mathContext": "Characteristic-free: Δ = 0 ⟺ ∃ i≠j, x_i = x_j, requiring only the absence of zero divisors."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves Δ = −4p³−27q² = (x₁−x₂)²(x₁−x₃)²(x₂−x₃)² only for the depressed cubic (e₁ = 0) and analyzes the root nature over ℝ by sign. This entry removes the e₁ = 0 restriction (general-cubic discriminant in a, b, c), recovers the parent's formula as the a = 0 case, adds translation/depression invariance, and replaces the real-sign analysis with a characteristic-free integral-domain separability criterion."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-03-oq-05",
+      "relationship": "related",
+      "description": "Provides Vieta's formulas for the general cubic x³+ax²+bx+c, which are exactly the IsGenRootTriple hypotheses used here to pass between the coefficient form and the root form of the discriminant."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-03-oq-04",
+      "relationship": "related",
+      "description": "Newton–Girard identities express power sums of the roots in the elementary symmetric functions; like this entry they connect symmetric data of the roots to the cubic's coefficients."
+    }
+  ],
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ01OQ04.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "cubic-equations",
+      "discriminant",
+      "separability",
+      "vieta-formulas",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 190,
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic-oq-03-oq-01",
+        "relationship": "Parent: discriminant of the depressed cubic; this entry generalizes to the full cubic, adds depression invariance, and gives a characteristic-free separability criterion"
+      },
+      {
+        "id": "solution-of-cubic-oq-03-oq-05",
+        "relationship": "Provides Vieta's formulas for the general cubic used as the bridge between coefficient and root forms"
+      },
+      {
+        "id": "solution-of-cubic-oq-03",
+        "relationship": "Ancestor: Vieta's formulas for the depressed cubic via Cardano's roots"
+      }
+    ],
+    "theoremCount": 8,
+    "definitionCount": 3
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/solution-of-cubic-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/solution-of-cubic-oq-03-oq-01-oq-04.json
@@ -1,0 +1,47 @@
+{
+  "slug": "solution-of-cubic-oq-03-oq-01-oq-04",
+  "status": "active",
+  "phase": "COMPLETED",
+  "tier": "A",
+  "title": "Discriminant of the general cubic and depression invariance",
+  "problemStatement": "Extend the parent's depressed-cubic discriminant (Δ = -4p³ - 27q²) to the general monic cubic x³ + ax² + bx + c: prove Δ(a,b,c) = 18abc - 4a³c + a²b² - 4b³ - 27c² equals the root-separation product, that the discriminant is invariant under the depression substitution, and characterize Δ = 0 over an integral domain.",
+  "tags": [
+    "algebra",
+    "polynomials",
+    "cubic-equations",
+    "discriminant",
+    "separability",
+    "vieta-formulas",
+    "research"
+  ],
+  "leanFiles": [
+    "proofs/Proofs/SolutionOfCubicOQ03OQ01OQ04.lean"
+  ],
+  "relatedProofs": [
+    "solution-of-cubic-oq-03-oq-01",
+    "solution-of-cubic-oq-03-oq-05",
+    "solution-of-cubic-oq-03-oq-04"
+  ],
+  "knownResults": [
+    "Parent proves Δ = -4p³ - 27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² only for the depressed cubic (e₁ = 0) and analyzes root nature over ℝ by sign.",
+    "The general-cubic discriminant 18abc - 4a³c + a²b² - 4b³ - 27c² is standard (Wikipedia: Discriminant)."
+  ],
+  "currentState": "COMPLETE: 0 sorries, 0 axioms (only foundational propext/Classical.choice/Quot.sound). Builds clean via host lake env lean against Mathlib cache.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Generalized the parent's depressed-cubic discriminant to the full monic cubic. Proved genDiscriminant_eq_root_form (18abc-4a³c+a²b²-4b³-27c² = root-separation product under Vieta), recovered the parent's -4p³-27q² as the a=0 case, proved depression/translation invariance of the discriminant with explicit shifted coefficients, and a characteristic-free separability criterion (Δ=0 ⟺ two roots coincide) over any integral domain. 8 theorems, 3 defs, 1 structure, 190 lines, 0 sorries, 0 axioms.",
+    "builtItems": [
+      "genDiscriminant_eq_root_form: general-cubic discriminant = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² under Vieta (ring proof after linear_combination substitution)",
+      "genDiscriminant_zero_lead + depressedDiscriminant_eq_root_form: recover the parent's -4p³-27q² as the a=0 specialization",
+      "rootDiscriminant_translation_invariant: root-separation product is shift-invariant (pure ring)",
+      "isGenRootTriple_translate: shifted roots satisfy Vieta for explicit coefficients (a-3t, b-2at+3t², c-bt+at²-t³)",
+      "genDiscriminant_translation_invariant: depression substitution preserves the discriminant",
+      "genDiscriminant_eq_zero_iff / genDiscriminant_ne_zero_iff: characteristic-free separability criterion over an integral domain"
+    ],
+    "insights": [
+      "linarith is unavailable over a bare CommRing (no order) — solving Vieta for a,b,c needs linear_combination, which produces an algebraic certificate valid in any commutative ring.",
+      "Depression invariance reduces to ring: every root difference x_i - x_j is invariant under a common shift x_i ↦ x_i + t, so the entire discriminant (in any coefficient form) is translation-invariant.",
+      "The integral-domain criterion peels a product of three squares with mul_eq_zero + pow_eq_zero_iff + sub_eq_zero — strictly more general than the parent's ℝ sign analysis (no ordering needed).",
+      "Self-contained file (local depressedDiscriminant/rootDiscriminant defs) avoids depending on the parent's olean, which was absent from the build cache."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Research session for **solution-of-cubic-oq-03-oq-01-oq-04**, the 4th open question stemming from `solution-of-cubic-oq-03-oq-01` (Discriminant of the Depressed Cubic). The parent proves Δ = −4p³−27q² = (x₁−x₂)²(x₁−x₃)²(x₂−x₃)² **only for the depressed cubic** (e₁ = x₁+x₂+x₃ = 0) and analyzes root nature over ℝ by sign. This entry removes the e₁ = 0 restriction and adds two structural follow-ups.

## Progress

New file `proofs/Proofs/SolutionOfCubicOQ03OQ01OQ04.lean` (8 theorems, 3 defs, 1 structure, 190 lines, **0 sorries, 0 axioms**):

- **`genDiscriminant_eq_root_form`** — the general-cubic discriminant `18abc − 4a³c + a²b² − 4b³ − 27c²` equals the root-separation product `(x₁−x₂)²(x₁−x₃)²(x₂−x₃)²` under Vieta's formulas, over an arbitrary commutative ring.
- **`genDiscriminant_zero_lead` / `depressedDiscriminant_eq_root_form`** — recover the parent's `−4p³−27q²` exactly as the `a = 0` specialization.
- **`rootDiscriminant_translation_invariant` + `isGenRootTriple_translate` + `genDiscriminant_translation_invariant`** — **depression invariance**: translating all roots by a common `t` (the depression substitution x ↦ x+t) leaves the discriminant unchanged, with explicit shifted coefficients `(a−3t, b−2at+3t², c−bt+at²−t³)`. This is the precise justification for computing a cubic's discriminant from its depressed form.
- **`genDiscriminant_eq_zero_iff` / `genDiscriminant_ne_zero_iff`** — characteristic-free **separability criterion**: over any integral domain, Δ = 0 ⟺ two roots coincide. Strengthens the parent's real-sign analysis (no ordering required).

## Findings

- `linarith` is unavailable over a bare `CommRing` (no order); solving Vieta for a,b,c uses `linear_combination`, keeping every identity valid in any commutative ring.
- Depression invariance reduces to `ring`: each root difference x_i−x_j is shift-invariant.
- The integral-domain criterion peels a product of three squares with `mul_eq_zero` + `pow_eq_zero_iff` + `sub_eq_zero`.
- File is self-contained (local `depressedDiscriminant`/`rootDiscriminant` defs) to avoid depending on the parent's olean, which was absent from the build cache.

## Verification

`#print axioms` on all main theorems lists only `propext` / `Classical.choice` / `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`. Builds clean via `lake env lean` against the Mathlib cache (Docker was unresponsive this session).

## Status

**Outcome**: completed
**Next Steps**: relate Δ to −Res(f, f') / ∏ f'(xᵢ); lift the separability criterion to Mathlib's `Polynomial.discriminant`/separability API for a degree-3 polynomial directly.

🤖 Generated by researcher-4