### PR TITLE
research(beta-integral-recurrence-oq-01-oq-02-oq-01): half-integer Beta diagonal B(n+1/2,n+1/2)=π·C(2n,n)/4^(2n) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01.lean
@@ -1,0 +1,173 @@
+import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Tactic
+
+/-
+# The Symmetric Beta Value at Half-Integers: `B(n+½, n+½) = π·C(2n,n)/4^{2n}`
+
+## What This Proves
+
+The sibling entry `beta-integral-recurrence-oq-01-oq-02` computed the first two
+half-integer Beta values `B(½,½) = π` and `B(3/2,3/2) = π/8` one at a time. This
+entry closes the **entire diagonal** in one formula:
+
+  **`betaIntegral_diag_half`**:
+    `B(n+½, n+½) = π · (2n)! / (4^{2n} · (n!)²)`,
+
+equivalently (`betaIntegral_diag_half_centralBinom`):
+
+    `B(n+½, n+½) = π · C(2n, n) / 4^{2n}`
+
+with `C(2n,n) = Nat.centralBinom n` the central binomial coefficient.
+
+## A striking contrast
+
+The gallery already has the **integer** diagonal
+(`BetaCentralBinomial.betaIntegral_diag_central_binom`):
+
+    `B(n+1, n+1) = 1 / ((2n+1) · C(2n, n))`,
+
+a *rational* number with the central binomial in the **denominator**. The
+half-integer diagonal is its mirror image: a *transcendental* multiple of `π`
+with the very same central binomial in the **numerator**. The two diagonals of
+the Beta lattice are governed by reciprocal appearances of `C(2n,n)`.
+
+Setting `n = 0` recovers `B(½,½) = π` and `n = 1` recovers `B(3/2,3/2) = π/8`
+(`C(0,0)=1`, `C(2,1)=2`, `4²=16`, `2/16 = 1/8`), so this single theorem subsumes
+both values proved separately in the sibling entry.
+
+## Relation to Mathlib
+
+Mathlib provides the Beta–Gamma division formula
+`Complex.betaIntegral_eq_Gamma_mul_div`, the real/complex bridge
+`Complex.Gamma_ofReal`, `Complex.Gamma_nat_eq_factorial`, and the half-integer
+Gamma value `Real.Gamma_nat_add_half` (in *double-factorial* form
+`Γ(k+½) = (2k-1)‼·√π / 2^k`). It does **not** state the factorial form of
+`Γ(n+½)`, nor any half-integer Beta value. The new content here is:
+
+  * `gamma_nat_add_half_eq` : the **factorial closed form**
+    `Γ(n+½) = √π · (2n)! / (4^n · n!)`, proved directly by induction on the
+    Gamma functional equation `Γ(s+1) = s·Γ(s)` (independent of Mathlib's
+    double-factorial route); and
+  * the assembly of the diagonal Beta value from it.
+
+## Approach
+
+`gamma_nat_add_half_eq` is an induction: the base case is the Gauss value
+`Γ(½) = √π`, and the step multiplies by `(n+½)` via `Real.Gamma_add_one`,
+matching `(2n+2)(2n+1)/(4(n+1)) = (2n+1)/2 = (n+½)` on the closed form.
+
+`betaIntegral_diag_half` then applies `betaIntegral_eq_Gamma_mul_div` (both real
+parts are `n+½ > 0`), rewrites the argument sum `(n+½)+(n+½) = (2n)+1` so the
+denominator collapses to `Γ(2n+1) = (2n)!`, transfers each `Γ(n+½)` to the real
+line via `Gamma_ofReal`, substitutes the closed form, and finishes with a real
+field computation using `√π·√π = π` and `4^{2n} = (4^n)²`.
+-/
+
+namespace BetaIntegralRecurrenceOQ01OQ02OQ01
+
+open scoped Nat
+open Real
+
+/-- **Factorial closed form of the half-integer Gamma value (new).**
+
+`Γ(n + ½) = √π · (2n)! / (4ⁿ · n!)`.
+
+Proved by induction on `n` using only the Gauss value `Γ(½) = √π` and the
+functional equation `Γ(s+1) = s·Γ(s)`; this is the factorial counterpart of
+Mathlib's double-factorial `Real.Gamma_nat_add_half`. -/
+theorem gamma_nat_add_half_eq (n : ℕ) :
+    Real.Gamma ((n : ℝ) + 1 / 2) = Real.sqrt π * (2 * n)! / (4 ^ n * n !) := by
+  induction n with
+  | zero =>
+    rw [Nat.cast_zero, zero_add, Real.Gamma_one_half_eq]
+    norm_num
+  | succ k ih =>
+    have hk : ((k : ℝ) + 1 / 2) ≠ 0 := by positivity
+    have hrec : Real.Gamma ((k : ℝ) + 1 / 2 + 1)
+        = ((k : ℝ) + 1 / 2) * Real.Gamma ((k : ℝ) + 1 / 2) := Real.Gamma_add_one hk
+    have hcast : (((k + 1 : ℕ) : ℝ) + 1 / 2) = ((k : ℝ) + 1 / 2) + 1 := by push_cast; ring
+    -- factorials of the successor, computed in ℕ then cast to ℝ
+    have hf : ((2 * (k + 1))! : ℝ) = (2 * k + 2) * ((2 * k + 1) * (2 * k)!) := by
+      rw [show 2 * (k + 1) = 2 * k + 1 + 1 by ring, Nat.factorial_succ,
+        Nat.factorial_succ (2 * k)]
+      push_cast; ring
+    have hnf : ((k + 1)! : ℝ) = ((k : ℝ) + 1) * k ! := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    have hkfac : ((k ! : ℝ)) ≠ 0 := by exact_mod_cast (Nat.factorial_pos k).ne'
+    have h4k : (4 : ℝ) ^ k ≠ 0 := by positivity
+    have hk1 : ((k : ℝ) + 1) ≠ 0 := by positivity
+    rw [hcast, hrec, ih, hf, hnf]
+    field_simp
+    ring
+
+/-- **The symmetric half-integer Beta value (new).**
+
+`B(n+½, n+½) = π · (2n)! / (4^{2n} · (n!)²)`. The full diagonal of half-integer
+Beta values, subsuming the sibling entry's `B(½,½)=π` and `B(3/2,3/2)=π/8`. -/
+theorem betaIntegral_diag_half (n : ℕ) :
+    Complex.betaIntegral ((n : ℂ) + 1 / 2) ((n : ℂ) + 1 / 2)
+      = (π : ℂ) * (2 * n)! / (4 ^ (2 * n) * (n ! : ℂ) ^ 2) := by
+  have hre : (0 : ℝ) < ((n : ℂ) + 1 / 2).re := by
+    simp; positivity
+  -- The real value of `Γ(n+½)²/(2n)!`.
+  have hreal : Real.Gamma ((n : ℝ) + 1 / 2) ^ 2 / ((2 * n)! : ℝ)
+      = π * (2 * n)! / (4 ^ (2 * n) * (n ! : ℝ) ^ 2) := by
+    rw [gamma_nat_add_half_eq]
+    have hsqrt : Real.sqrt π ^ 2 = π := Real.sq_sqrt Real.pi_nonneg
+    have h4 : (4 : ℝ) ^ (2 * n) = (4 ^ n) ^ 2 := by rw [← pow_mul, mul_comm]
+    have hn : ((n ! : ℝ)) ≠ 0 := by exact_mod_cast (Nat.factorial_pos n).ne'
+    have hfac : ((2 * n)! : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos (2 * n)).ne'
+    have h4n : (4 : ℝ) ^ n ≠ 0 := by positivity
+    simp only [div_pow, mul_pow]
+    rw [hsqrt, h4]
+    field_simp
+  rw [Complex.betaIntegral_eq_Gamma_mul_div _ _ hre hre,
+    show ((n : ℂ) + 1 / 2) + ((n : ℂ) + 1 / 2) = ((2 * n : ℕ) : ℂ) + 1 by push_cast; ring,
+    Complex.Gamma_nat_eq_factorial,
+    show ((n : ℂ) + 1 / 2) = (((n : ℝ) + 1 / 2 : ℝ) : ℂ) by push_cast; ring,
+    Complex.Gamma_ofReal]
+  rw [show (((Real.Gamma ((n : ℝ) + 1 / 2) : ℝ) : ℂ)
+        * ((Real.Gamma ((n : ℝ) + 1 / 2) : ℝ) : ℂ) / ((2 * n)! : ℂ))
+      = (((Real.Gamma ((n : ℝ) + 1 / 2) ^ 2 / ((2 * n)! : ℝ) : ℝ)) : ℂ) by
+    push_cast; ring]
+  rw [hreal]
+  push_cast
+  ring
+
+/-- The same value with Mathlib's central binomial coefficient:
+`B(n+½, n+½) = π · C(2n, n) / 4^{2n}`.
+
+The mirror of the integer diagonal `B(n+1,n+1) = 1/((2n+1)·C(2n,n))`: here the
+central binomial sits in the **numerator**, scaled by the transcendental `π`. -/
+theorem betaIntegral_diag_half_centralBinom (n : ℕ) :
+    Complex.betaIntegral ((n : ℂ) + 1 / 2) ((n : ℂ) + 1 / 2)
+      = (π : ℂ) * (Nat.centralBinom n : ℂ) / 4 ^ (2 * n) := by
+  rw [betaIntegral_diag_half]
+  have hbinom : ((2 * n)! : ℂ) = (Nat.centralBinom n : ℂ) * ((n ! : ℂ) ^ 2) := by
+    have h := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+    rw [show 2 * n - n = n by omega] at h
+    rw [Nat.centralBinom_eq_two_mul_choose]
+    have : (2 * n)! = (2 * n).choose n * n ! * n ! := by rw [h]
+    rw [this]; push_cast; ring
+  rw [hbinom]
+  have hn : ((n ! : ℂ)) ≠ 0 := by
+    have : (0 : ℕ) < n ! := Nat.factorial_pos n
+    exact_mod_cast this.ne'
+  field_simp
+
+/-- Sanity check: `n = 0` recovers the sibling entry's `B(½,½) = π`. -/
+theorem betaIntegral_half_half : Complex.betaIntegral (1 / 2) (1 / 2) = (π : ℂ) := by
+  have h := betaIntegral_diag_half_centralBinom 0
+  norm_num [Nat.centralBinom] at h
+  simpa using h
+
+/-- Sanity check: `n = 1` recovers the sibling entry's `B(3/2, 3/2) = π/8`. -/
+theorem betaIntegral_three_half_three_half :
+    Complex.betaIntegral (3 / 2) (3 / 2) = (π : ℂ) / 8 := by
+  have h := betaIntegral_diag_half_centralBinom 1
+  norm_num [Nat.centralBinom, Nat.choose] at h
+  rw [h]; ring
+
+end BetaIntegralRecurrenceOQ01OQ02OQ01

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "betadiag-ann-header",
+    "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 66
+    },
+    "type": "context",
+    "title": "The Half-Integer Beta Diagonal in Closed Form",
+    "content": "Closes the entire half-integer diagonal of the Euler Beta function: B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n), for every n. This is the transcendental mirror of the gallery's integer diagonal B(n+1,n+1) = 1/((2n+1)·C(2n,n)): the SAME central binomial coefficient governs both, but here it sits in the NUMERATOR scaled by π, rather than in the denominator of a rational value. The crossover between the rational and transcendental diagonals is the single Gauss value Γ(1/2)=√π. Mathlib has no half-integer Beta value and does not store the factorial form of Γ(n+1/2); both are produced here.",
+    "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\,(2n)!}{4^{2n}(n!)^2} = \\dfrac{\\pi\\binom{2n}{n}}{4^{2n}}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Euler Beta function",
+      "Beta–Gamma relation",
+      "central binomial coefficient",
+      "half-integer Gamma values",
+      "Gauss value Γ(1/2)=√π"
+    ],
+    "prerequisites": [
+      "the Beta and Gamma functions",
+      "the central binomial coefficient C(2n,n)"
+    ]
+  },
+  {
+    "id": "betadiag-ann-gammaclosed",
+    "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 73,
+      "endLine": 103
+    },
+    "type": "technique",
+    "title": "Factorial Closed Form of Γ(n+1/2) by Induction",
+    "content": "gamma_nat_add_half_eq proves Γ(n+1/2) = √π·(2n)!/(4^n·n!) directly by induction, the analytic core of the entry. Base case: Γ(0+1/2) = Γ(1/2) = √π (Real.Gamma_one_half_eq). Inductive step: Real.Gamma_add_one gives Γ((k+1/2)+1) = (k+1/2)·Γ(k+1/2); expanding the successor factorials (2(k+1))! = (2k+2)(2k+1)(2k)! and (k+1)! = (k+1)·k! in ℕ and then casting, field_simp/ring verify the closed form propagates via (2k+2)(2k+1)/(4(k+1)) = (2k+1)/2 = k+1/2. Mathlib stores Γ(n+1/2) only in double-factorial form (2n-1)‼·√π/2^n; this factorial form — the one that meets factorials and central binomials — is reproved from scratch, never converted.",
+    "mathContext": "$\\Gamma(n+\\tfrac12) = \\dfrac{\\sqrt\\pi\\,(2n)!}{4^n\\,n!}$, step multiplies by $(k+\\tfrac12)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gamma functional equation Γ(s+1)=s·Γ(s)",
+      "Gauss value Γ(1/2)=√π",
+      "mathematical induction",
+      "factorial vs double-factorial form"
+    ],
+    "prerequisites": [
+      "the Gamma functional equation",
+      "induction on the natural numbers"
+    ]
+  },
+  {
+    "id": "betadiag-ann-diagonal",
+    "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 137
+    },
+    "type": "technique",
+    "title": "Assembling the Diagonal Beta Value",
+    "content": "betaIntegral_diag_half applies the Beta–Gamma relation B(n+1/2,n+1/2) = Γ(n+1/2)²/Γ((n+1/2)+(n+1/2)) (both real parts n+1/2 > 0), rewrites the argument sum to (2n)+1 so the denominator collapses to Γ(2n+1) = (2n)! (Complex.Gamma_nat_eq_factorial), and transfers the two numerator Gamma factors onto the real line through Complex.Gamma_ofReal. There the closed form gamma_nat_add_half_eq applies, reducing the goal to the real identity Γ(n+1/2)²/(2n)! = π·(2n)!/(4^(2n)·(n!)²), closed using (√π)² = π and 4^(2n) = (4^n)². No integral is ever evaluated — the value is bought algebraically from Gamma.",
+    "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\Gamma(n+\\tfrac12)^2}{\\Gamma(2n+1)} = \\dfrac{\\pi(2n)!}{4^{2n}(n!)^2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Beta–Gamma relation",
+      "Complex.Gamma_ofReal real/complex bridge",
+      "Γ(n+1)=n!",
+      "algebraic evaluation of an integral"
+    ],
+    "prerequisites": [
+      "the Beta–Gamma division formula",
+      "real-to-complex coercion of Gamma"
+    ]
+  },
+  {
+    "id": "betadiag-ann-central",
+    "proofId": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 139,
+      "endLine": 172
+    },
+    "type": "insight",
+    "title": "Central Binomial Form and the Mirror to the Integer Diagonal",
+    "content": "betaIntegral_diag_half_centralBinom rewrites (2n)!/(n!)² = C(2n,n) (via Nat.choose_mul_factorial_mul_factorial and Nat.centralBinom_eq_two_mul_choose) to present the value as π·C(2n,n)/4^(2n). Placed beside the gallery's integer diagonal B(n+1,n+1) = 1/((2n+1)·C(2n,n)), the symmetry is exact: one and the same central binomial coefficient controls both diagonals, rationally in the denominator on the integers and transcendentally in the numerator (times π) on the half-integers. The two sanity theorems specialize n=0 and n=1 to recover the sibling entry's B(1/2,1/2)=π (C(0,0)=1) and B(3/2,3/2)=π/8 (C(2,1)=2, 4²=16), confirming the general formula subsumes both.",
+    "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\binom{2n}{n}}{4^{2n}}$ vs. $B(n+1,n+1) = \\dfrac{1}{(2n+1)\\binom{2n}{n}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "integer vs half-integer Beta diagonal",
+      "Nat.choose_mul_factorial_mul_factorial",
+      "specialization to known values"
+    ],
+    "prerequisites": [
+      "the central binomial coefficient",
+      "the integer diagonal Beta value"
+    ]
+  }
+]

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+  "slug": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BetaIntegralRecurrenceOQ01OQ02OQ01",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Integer Beta Diagonal: B(n+1/2, n+1/2) = π·C(2n,n)/4^(2n)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "beta-function",
+      "gamma-function",
+      "central-binomial-coefficient",
+      "pi",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 173,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "gamma_nat_add_half_eq: the FACTORIAL closed form of the half-integer Gamma value Γ(n+1/2) = √π·(2n)!/(4^n·n!), proved by an independent induction on the Gamma functional equation Γ(s+1)=s·Γ(s) (base case the Gauss value Γ(1/2)=√π; step multiplies by (n+1/2), matching (2n+2)(2n+1)/(4(n+1)) = (2n+1)/2). Mathlib has only the double-factorial form Real.Gamma_nat_add_half (Γ(k+1/2)=(2k-1)‼·√π/2^k); the factorial form — the one that bridges directly to factorials and central binomials — is not in Mathlib and is reproved here from scratch rather than converted from the double-factorial version.",
+      "betaIntegral_diag_half: the general half-integer Beta diagonal B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)^2), valid for every n. This is the full diagonal closure of the sibling entry's case-by-case values B(1/2,1/2)=π and B(3/2,3/2)=π/8; Mathlib states no half-integer Beta value. Assembled from Mathlib's Beta–Gamma division formula and the new closed form via Complex.Gamma_ofReal to transfer the computation onto the real line.",
+      "betaIntegral_diag_half_centralBinom: the same value as π·C(2n,n)/4^(2n) with C the central binomial coefficient (Nat.centralBinom). This is the exact mirror of the gallery's integer diagonal B(n+1,n+1)=1/((2n+1)·C(2n,n)) (BetaCentralBinomial): the same central binomial coefficient appears, but in the NUMERATOR scaled by the transcendental π, rather than in the denominator of a rational value.",
+      "betaIntegral_half_half and betaIntegral_three_half_three_half: the n=0 and n=1 specializations, recovering the sibling entry's B(1/2,1/2)=π and B(3/2,3/2)=π/8 as corollaries of the general formula, confirming the diagonal closure subsumes the individually-proved values."
+    ],
+    "prerequisites": [
+      "Euler Beta integral Complex.betaIntegral u v = ∫₀¹ tᵘ⁻¹ (1−t)ᵛ⁻¹ dt",
+      "Beta–Gamma relation Complex.betaIntegral_eq_Gamma_mul_div: B(u,v) = Γu·Γv/Γ(u+v) for Re u, Re v > 0",
+      "Gauss value Real.Gamma_one_half_eq: Γ(1/2) = √π",
+      "Gamma functional equation Real.Gamma_add_one: Γ(s+1) = s·Γ(s) for s ≠ 0",
+      "Real/Complex Gamma bridge Complex.Gamma_ofReal: Γ(↑s) = ↑(Real.Gamma s); and Complex.Gamma_nat_eq_factorial",
+      "Central binomial factorization Nat.choose_mul_factorial_mul_factorial and Nat.centralBinom_eq_two_mul_choose"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.betaIntegral_eq_Gamma_mul_div",
+        "description": "Beta–Gamma division formula B(u,v) = Γu·Γv/Γ(u+v) for Re u, Re v > 0, the bridge turning the diagonal Beta value into a Gamma quotient.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "The Gauss value Γ(1/2) = √π (proved in Mathlib from the Gaussian integral), the base case of the closed-form induction and the source of π.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Gamma functional equation Γ(s+1) = s·Γ(s) for s ≠ 0, the inductive step that climbs the half-integer lattice from Γ(1/2) to Γ(n+1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Complex.Gamma_ofReal",
+        "description": "The real/complex bridge Γ(↑s) = ↑(Real.Gamma s), used to transfer the half-integer Gamma factors of the Beta quotient onto the real line where the closed form lives.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Complex.Gamma_nat_eq_factorial",
+        "description": "Γ(n+1) = n! for n : ℕ, used to evaluate the denominator Γ((n+1/2)+(n+1/2)) = Γ(2n+1) = (2n)!.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "The factorization C(2n,n)·n!·n! = (2n)!, used to rewrite the factorial form as the central-binomial form π·C(2n,n)/4^(2n).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Euler Beta integral B(u,v) = ∫₀¹ t^(u−1)(1−t)^(v−1) dt has two natural diagonals. On the INTEGER diagonal B(n+1,n+1) = 1/((2n+1)·C(2n,n)) the value is a rational number, the reciprocal of (2n+1) times the central binomial coefficient; this is the normalization constant of the symmetric Beta(n+1,n+1) density and is already in the gallery. On the HALF-INTEGER diagonal the value turns transcendental: B(n+1/2,n+1/2) = π·C(2n,n)/4^(2n). The crossover is the single Gauss value Γ(1/2) = √π, discovered by Euler and given its definitive form by the Gaussian integral. The half-integer diagonal is exactly the constant appearing in the volume of the n-ball and in Wallis-type products: π·C(2n,n)/4^(2n) is the n-th term of the sequence that, by Stirling, decays like √(π/n). The sibling entry computed the first two values B(1/2,1/2)=π and B(3/2,3/2)=π/8 one at a time; this entry closes the whole diagonal in one induction.",
+    "problemStatement": "Establish the general half-integer closed form of the symmetric Euler Beta value: for every n, B(n+1/2, n+1/2) = π·(2n)!/(4^(2n)·(n!)^2) = π·C(2n,n)/4^(2n), exhibiting the uniform π-dependence of the diagonal half-integer Beta values and the central binomial coefficient in the numerator. This answers open question oq-01 of the sibling entry beta-integral-recurrence-oq-01-oq-02 verbatim.",
+    "proofStrategy": "The analytic core is the factorial closed form gamma_nat_add_half_eq: Γ(n+1/2) = √π·(2n)!/(4^n·n!), proved by induction on n. The base case is the Gauss value Γ(1/2)=√π; the inductive step applies the Gamma functional equation Γ(s+1)=s·Γ(s) at s = k+1/2, and the algebraic identity (2k+2)(2k+1)/(4(k+1)) = (2k+1)/2 = (k+1/2) shows the closed form propagates. The main theorem betaIntegral_diag_half then applies the Beta–Gamma relation B(n+1/2,n+1/2) = Γ(n+1/2)²/Γ(2n+1), collapses the denominator Γ(2n+1) = (2n)! via Gamma_nat_eq_factorial, transfers both numerator Gamma factors to the real line via Complex.Gamma_ofReal, substitutes the closed form, and finishes with a real field computation using (√π)² = π and 4^(2n) = (4^n)². The central-binomial form follows by rewriting (2n)!/(n!)² = C(2n,n) through Nat.choose_mul_factorial_mul_factorial.",
+    "keyInsights": [
+      "The two diagonals of the Beta lattice are reciprocal images of the same central binomial coefficient. Integer diagonal: B(n+1,n+1) = 1/((2n+1)·C(2n,n)) — rational, C(2n,n) in the DENOMINATOR. Half-integer diagonal: B(n+1/2,n+1/2) = π·C(2n,n)/4^(2n) — transcendental, the same C(2n,n) in the NUMERATOR, scaled by π. The crossover constant is the lone Gauss value Γ(1/2)=√π.",
+      "The factorial closed form Γ(n+1/2) = √π·(2n)!/(4^n·n!) is the right shape for combinatorics. Mathlib stores Γ(n+1/2) only as a double factorial (2n-1)‼·√π/2^n; converting (2n-1)‼ = (2n)!/(2^n·n!) lands on the factorial form, but here it is reproved directly by induction, giving a self-contained route that never mentions double factorials.",
+      "No integration is performed anywhere. The entire half-integer diagonal is bought algebraically from two Mathlib facts — the Beta–Gamma relation and Γ(1/2)=√π — exactly as the parent's integer values come from Γ(n+1)=n!. The functional equation Γ(s+1)=s·Γ(s) does all the climbing.",
+      "The single formula subsumes the sibling's two hand-computed values: n=0 gives C(0,0)=1, 4^0=1, hence π; n=1 gives C(2,1)=2, 4^2=16, hence 2π/16 = π/8. The general theorem is strictly stronger and recovers both as one-line corollaries.",
+      "By Stirling, C(2n,n)/4^(2n) ~ 1/√(πn), so B(n+1/2,n+1/2) ~ √(π/n) → 0: the symmetric half-integer Beta values shrink like 1/√n, the same rate that governs the central limit normalization and the n-ball volume's eventual decay."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Half-Integer Beta Diagonal",
+      "startLine": 6,
+      "endLine": 66,
+      "summary": "States the general half-integer diagonal value B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n) and frames it as the transcendental mirror of the gallery's rational integer diagonal B(n+1,n+1)=1/((2n+1)·C(2n,n)): the same central binomial coefficient, moved from denominator to numerator and scaled by π. Notes that Mathlib has neither the factorial form of Γ(n+1/2) nor any half-integer Beta value, and outlines the induction-plus-assembly strategy.",
+      "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\,(2n)!}{4^{2n}(n!)^2} = \\dfrac{\\pi\\binom{2n}{n}}{4^{2n}}$."
+    },
+    {
+      "id": "gamma-closed-form",
+      "title": "Factorial Closed Form of Γ(n+1/2)",
+      "startLine": 73,
+      "endLine": 103,
+      "summary": "gamma_nat_add_half_eq proves Γ(n+1/2) = √π·(2n)!/(4^n·n!) by induction. The base case rewrites Γ(0+1/2)=Γ(1/2)=√π (Real.Gamma_one_half_eq). The inductive step uses Real.Gamma_add_one at s=k+1/2 to get Γ(k+1+1/2)=(k+1/2)·Γ(k+1/2), expands the successor factorials (2(k+1))! and (k+1)! in ℕ, and closes by field_simp/ring — capturing the identity (2k+2)(2k+1)/(4(k+1)) = k+1/2.",
+      "mathContext": "$\\Gamma(n+\\tfrac12) = \\dfrac{\\sqrt\\pi\\,(2n)!}{4^n\\,n!}$, base $\\Gamma(\\tfrac12)=\\sqrt\\pi$, step $\\times(n+\\tfrac12)$."
+    },
+    {
+      "id": "diagonal-value",
+      "title": "The General Diagonal Beta Value",
+      "startLine": 105,
+      "endLine": 137,
+      "summary": "betaIntegral_diag_half applies the Beta–Gamma relation at u=v=n+1/2 (real part n+1/2 > 0), rewrites the argument sum (n+1/2)+(n+1/2)=(2n)+1 so the denominator collapses to Γ(2n+1)=(2n)!, transfers the two Γ(n+1/2) factors onto the real line via Complex.Gamma_ofReal, substitutes the closed form, and reduces to the real identity Γ(n+1/2)²/(2n)! = π·(2n)!/(4^(2n)·(n!)²) using (√π)²=π and 4^(2n)=(4^n)².",
+      "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\Gamma(n+\\tfrac12)^2}{\\Gamma(2n+1)} = \\dfrac{\\pi(2n)!}{4^{2n}(n!)^2}$."
+    },
+    {
+      "id": "central-binomial",
+      "title": "Central Binomial Form and Sanity Checks",
+      "startLine": 139,
+      "endLine": 172,
+      "summary": "betaIntegral_diag_half_centralBinom rewrites (2n)! = C(2n,n)·n!·n! (Nat.choose_mul_factorial_mul_factorial) to express the value as π·C(2n,n)/4^(2n). The two sanity theorems specialize n=0 and n=1, recovering the sibling entry's B(1/2,1/2)=π (C(0,0)=1) and B(3/2,3/2)=π/8 (C(2,1)=2, 4²=16).",
+      "mathContext": "$B(n+\\tfrac12,n+\\tfrac12) = \\dfrac{\\pi\\binom{2n}{n}}{4^{2n}}$; $n{=}0\\to\\pi$, $n{=}1\\to\\pi/8$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-01",
+      "question": "Use the diagonal value B(n+1/2,n+1/2) = π·C(2n,n)/4^(2n) together with Stirling's formula to prove the asymptotic B(n+1/2,n+1/2) ~ √(π/n) as n → ∞, making precise the 1/√n decay of the symmetric half-integer Beta values.",
+      "significance": "medium"
+    },
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-02-oq-01-oq-02",
+      "question": "Connect the closed form Γ(n+1/2) = √π·(2n)!/(4^n·n!) to the volume of the unit n-ball Vol(Bⁿ) = π^(n/2)/Γ(n/2+1), deriving the explicit even/odd-dimension formulas and identifying where the central binomial coefficient enters the ball volume.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The sibling entry proves the first two half-integer Beta values B(1/2,1/2)=π and B(3/2,3/2)=π/8 individually and explicitly lists this general diagonal closure as its open question oq-01. This entry answers that question verbatim, proving B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) for all n and recovering both sibling values as corollaries."
+    },
+    {
+      "targetId": "beta-integral-recurrence-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent entry evaluates the Beta function on the integer lattice (B(m+1,n+1)=m!·n!/(m+n+1)!, purely factorial). This entry evaluates the half-integer diagonal, where the Gauss value Γ(1/2)=√π makes every value a transcendental multiple of π."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "related",
+      "description": "Both entries evaluate Gamma at rational arguments. The reflection formula's s=1/2 case gives Γ(1/2)²=π; here that same squared Gauss value, propagated up the half-integer lattice by the functional equation, becomes the π-factor of the whole Beta diagonal."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta, Gaussian.GaussianIntegral, Data.Nat.Choose.Central",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.betaIntegral_eq_Gamma_mul_div, Real.Gamma_one_half_eq, Real.Gamma_add_one, Complex.Gamma_ofReal, Complex.Gamma_nat_eq_factorial, and Nat.centralBinom."
+    },
+    {
+      "title": "Special Functions (Beta and Gamma functions)",
+      "author": "Andrews, Askey, Roy",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "description": "Standard reference for the Beta integral, the Beta–Gamma relation, the half-integer Gamma values Γ(n+1/2), and their appearance in n-ball volumes."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The full half-integer diagonal of the Euler Beta function is evaluated in closed form: B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n) for every n. The analytic core is the factorial form Γ(n+1/2) = √π·(2n)!/(4^n·n!), reproved by induction on the Gamma functional equation (independent of Mathlib's double-factorial form); the main value is assembled from it via the Beta–Gamma relation and a real-line transfer. 173 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The Beta–Gamma relation, the Gauss value Γ(1/2)=√π (resting on the Gaussian integral), and the functional equation are Mathlib's; the new content is the factorial closed form of Γ(n+1/2), the general diagonal Beta value (no half-integer Beta value is in Mathlib), and the central-binomial form. The result mirrors the gallery's integer diagonal B(n+1,n+1)=1/((2n+1)·C(2n,n)): the same central binomial coefficient governs both diagonals, rationally in the denominator on the integers and transcendentally (via π) in the numerator on the half-integers.",
+    "openQuestions": [
+      "Prove the Stirling asymptotic B(n+1/2,n+1/2) ~ √(π/n).",
+      "Connect the closed form to the volume of the unit n-ball."
+    ]
+  },
+  "description": "The general half-integer diagonal of the Euler Beta function in closed form: B(n+1/2,n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n), for every n. The analytic heart is the factorial closed form Γ(n+1/2) = √π·(2n)!/(4^n·n!), proved here by an independent induction on the Gamma functional equation rather than converted from Mathlib's double-factorial version, then assembled into the Beta value through the Beta–Gamma relation. The result is the transcendental mirror of the gallery's integer diagonal B(n+1,n+1)=1/((2n+1)·C(2n,n)): the same central binomial coefficient, moved to the numerator and scaled by π. Answers the sibling entry's open question oq-01 verbatim and recovers B(1/2,1/2)=π and B(3/2,3/2)=π/8 as corollaries. 5 theorems, 0 sorries, 0 axioms."
+}


### PR DESCRIPTION
## Summary

Closes the entire **half-integer diagonal** of the Euler Beta function in one closed form, for every `n`:

  **B(n+1/2, n+1/2) = π·(2n)!/(4^(2n)·(n!)²) = π·C(2n,n)/4^(2n).**

This is the transcendental **mirror** of the gallery's existing *integer* diagonal `B(n+1,n+1) = 1/((2n+1)·C(2n,n))` (`BetaCentralBinomial`): one and the same central binomial coefficient governs both diagonals — rationally in the **denominator** on the integers, transcendentally (times π) in the **numerator** on the half-integers. The crossover is the single Gauss value `Γ(1/2)=√π`.

It answers open question `oq-01` of the sibling entry `beta-integral-recurrence-oq-01-oq-02` **verbatim**, and recovers that entry's hand-computed `B(1/2,1/2)=π` and `B(3/2,3/2)=π/8` as one-line corollaries.

## New content (not in Mathlib)

- **`gamma_nat_add_half_eq`** — the *factorial* closed form `Γ(n+1/2) = √π·(2n)!/(4^n·n!)`, reproved by an independent induction on the Gamma functional equation `Γ(s+1)=s·Γ(s)`. Mathlib stores `Γ(n+1/2)` only in double-factorial form (`Real.Gamma_nat_add_half`); the factorial form — the one that bridges to central binomials — is derived here from scratch.
- **`betaIntegral_diag_half`** — the general diagonal value (Mathlib states no half-integer Beta value), assembled via `Complex.betaIntegral_eq_Gamma_mul_div` and a real-line transfer through `Complex.Gamma_ofReal`.
- **`betaIntegral_diag_half_centralBinom`** — the central-binomial form `π·C(2n,n)/4^(2n)`.
- **`betaIntegral_half_half`**, **`betaIntegral_three_half_three_half`** — the `n=0`, `n=1` corollaries recovering the sibling values.

## Verification

- 5 theorems, 173 lines, **0 sorries, 0 `axiom` declarations, 0 `native_decide`**.
- `#print axioms` on the two main theorems: only `propext`, `Classical.choice`, `Quot.sound` (the standard foundational axioms; no `sorryAx`, no `Lean.ofReduceBool`).
- Builds clean via `lake env lean Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01.lean`.
- Status `verified`, badge `original` (the factorial-form induction and the diagonal value are genuine new content; the Beta–Gamma relation, `Γ(1/2)=√π`, and the functional equation are honestly credited to Mathlib in `mathlibDependencies`).

## Files

- `proofs/Proofs/BetaIntegralRecurrenceOQ01OQ02OQ01.lean`
- `src/data/proofs/beta-integral-recurrence-oq-01-oq-02-oq-01/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)