### PR TITLE
audit(gallery): 5 fresh entries clean (2×amgm/erdos-1168/greens/menelaus)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23255,6 +23255,36 @@
       "lastAudited": "2026-06-25T04:54:52Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:14:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:14:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1168-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:14:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "greens-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:14:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "menelaus-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:14:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 5 remaining unaudited gallery entries. **All clean** — no integrity issues.

| Slug | Status/Badge | Verdict |
|------|--------------|---------|
| amgm-inequality-oq-03-oq-01-oq-01 | verified/original | clean |
| amgm-inequality-oq-05-oq-02 | verified/original | clean |
| erdos-1168-oq-01 | verified/original | clean |
| greens-theorem-oq-01-oq-03 | verified/original | clean |
| menelaus-theorem-oq-01-oq-03 | verified/original | clean |

### Checks performed (per entry)
- **Code-clean** (comment-stripped): 0 sorry, 0 admit, 0 `axiom` declarations, 0 `native_decide`, 0 `True` stubs, no structure-encoded assumptions.
- **Substantive theorems** present (not placeholders/wrappers).
- **No delegation opacity**: each entry's Mathlib dependencies are explicitly credited in `assumptions`/`originalContributions`; `originalContributions` scoped to what the file actually proves.
  - `amgm-oq-03`: new mixed-sign power-mean monotonicity M_r ≤ M_s; credits Mathlib weighted AM-GM as the sole analytic input.
  - `amgm-oq-05-oq-02`: weighted AM-GM equality characterization via strict concavity of log (`StrictConcaveOn.map_sum_eq_iff`).
  - `erdos-1168-oq-01`: ZFC interval [ℵ_{ω+1}, 2^{ℵ_ω}] for ℵ_ω^{ℵ₀} via König (Mathlib `Cardinal.lt_power_cof`); axiom-free vs sibling axiomatized form.
  - `greens-oq-01-oq-03`: subdivision additivity of the concrete Green identity (new); built on intervalIntegral lemmas.
  - `menelaus-oq-01-oq-03`: Routh signed-area formula + Ceva concurrency criterion; reference-triangle scoping with affine-invariance argument stated.
- **#print axioms** disclosures honest (propext/Classical.choice/Quot.sound only; no sorryAx/ofReduceBool).

Clears unaudited **5 → 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)