### PR TITLE
research(group-order-prime-squared-abelian-oq-01-oq-01-oq-02): explicit isomorphisms ℤ/p² and (ℤ/p)² — structure theorem for order-p² groups [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/GroupOrderPrimeSquaredAbelianIsoOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GroupOrderPrimeSquaredAbelianIsoOQ01OQ01OQ02.lean
@@ -1,0 +1,154 @@
+/-
+  Explicit Isomorphisms for Groups of Order p² — the Structure Theorem
+
+  Follow-up open question OQ-01-OQ-01-OQ-02
+  (parent: group-order-prime-squared-abelian-oq-01-oq-01, the *exponent* refinement,
+   grandparent: group-order-prime-squared-abelian-oq-01).
+
+  The grandparent proves that a group `G` of order `p²` (`p` prime) is abelian and splits
+  into two isomorphism types; the parent recasts the split through the single numerical
+  invariant `Monoid.exponent G ∈ {p, p²}`. Those entries characterise the two types
+  *up to a predicate* (cyclic vs. exponent-`p`). This follow-up upgrades the invariant
+  characterisation to an honest **structure theorem**: it produces the explicit group
+  isomorphisms
+
+      exponent p²  (cyclic)        G ≃* Multiplicative (ZMod (p²))
+      exponent p   (elem. abelian) G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p)
+
+  so the abstract dichotomy becomes a concrete identification of `G` with one of the two
+  groups `ℤ/p²` and `(ℤ/p)²`.
+
+  ## Contents
+
+  * `cyclicMulEquiv` — the cyclic case: a cyclic group of order `p²` is `≃*` to
+    `Multiplicative (ZMod (p²))`. Built from Mathlib's `zmodCyclicMulEquiv` by rewriting
+    `Nat.card G = p²`.
+  * `elemAbelianMulEquiv` — the non-cyclic case: an order-`p²` group with `gᵖ = 1` for all
+    `g` is `≃*` to `Multiplicative (ZMod p) × Multiplicative (ZMod p)`. The additive group
+    `Additive G` is annihilated by `p`, hence a `ZMod p`-vector space; its cardinality `p²`
+    forces dimension `2`, giving a basis `≅ (ZMod p)²`, which is transported back to `G`.
+  * `mulEquiv_zmod_sq_or_prod` — every group of order `p²` is isomorphic to exactly one of
+    the two groups `ℤ/p²`, `(ℤ/p)²`.
+  * `mulEquiv_zmod_sq_of_exponent_sq` / `mulEquiv_prod_of_exponent_prime` — the structure
+    theorem stated through the parent's exponent invariant: `exponent G = p²` pins `G` to
+    `ℤ/p²`, and `exponent G = p` pins `G` to `(ℤ/p)²`.
+
+  Everything is elementary; no axioms, no sorries. The abelian-ness and the dichotomy are
+  imported from the ancestor files.
+-/
+import Mathlib
+import Proofs.GroupOrderPrimeSquaredAbelian
+import Proofs.GroupOrderPrimeSquaredAbelianExponentOQ01
+
+namespace GroupOrderPrimeSqIso
+
+open GroupOrderPrimeSq GroupOrderPrimeSqExponent
+open Module
+
+variable {G : Type*} [Group G]
+
+/-! ## Finiteness helper -/
+
+omit [Group G] in
+/-- A group of cardinality `p²` (`p` prime) is finite. -/
+private theorem finite_of_card_eq_prime_sq {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) : Finite G :=
+  Nat.finite_of_card_ne_zero (hG ▸ pow_ne_zero 2 hp.pos.ne')
+
+/-! ## The cyclic case: `G ≃* ℤ/p²` -/
+
+/-- **A cyclic group of order `p²` is isomorphic to `Multiplicative (ZMod (p²))`.**
+Mathlib's `zmodCyclicMulEquiv` gives `Multiplicative (ZMod (Nat.card G)) ≃* G` for any
+cyclic `G`; rewriting `Nat.card G = p²` and inverting yields the explicit isomorphism.
+(Primality of `p` plays no role here — only the value `Nat.card G = p²` is used.) -/
+noncomputable def cyclicMulEquiv {p : ℕ} (hG : Nat.card G = p ^ 2)
+    (hc : IsCyclic G) : G ≃* Multiplicative (ZMod (p ^ 2)) := by
+  have e : Multiplicative (ZMod (Nat.card G)) ≃* G := zmodCyclicMulEquiv hc
+  rw [hG] at e
+  exact e.symm
+
+/-! ## The elementary-abelian case: `G ≃* (ℤ/p)²`
+
+The core analytic input is that the *additive* group `Additive G` of a non-cyclic
+order-`p²` group is annihilated by `p`, so it carries a `ZMod p`-module (vector-space)
+structure. Counting cardinalities pins the dimension at `2`. -/
+
+/-- **A non-cyclic group of order `p²` is isomorphic to
+`Multiplicative (ZMod p) × Multiplicative (ZMod p)`.**
+
+`Additive G` is a `ZMod p`-vector space (every element is `p`-torsion), and
+`Nat.card (Additive G) = p² = (Nat.card (ZMod p)) ^ 2`, so its dimension is `2`. A basis
+indexed by `Fin 2` gives `Additive G ≃ₗ (Fin 2 → ZMod p) ≃ₗ ZMod p × ZMod p`; transporting
+across the `Additive`/`Multiplicative` adjunction and splitting the product yields the
+isomorphism. -/
+noncomputable def elemAbelianMulEquiv {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2)
+    (hnc : ¬ IsCyclic G) :
+    G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Finite G := finite_of_card_eq_prime_sq hp hG
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
+  -- `G` is abelian (grandparent), so the canonical `Additive G` is an `AddCommGroup`.
+  letI : CommGroup G :=
+    { (inferInstance : Group G) with mul_comm := mul_comm_of_card_eq_prime_sq hp hG }
+  -- `Additive G` is annihilated by `p`, hence a `ZMod p`-module. The instance is named
+  -- (`inst`) and threaded explicitly downstream: `AddCommMonoid.zmodModule` is a reducible
+  -- non-instance, so derived-instance search (`Module.Finite`/`Module.Free`) cannot rebuild
+  -- it on its own and would otherwise get stuck.
+  letI inst : Module (ZMod p) (Additive G) :=
+    AddCommMonoid.zmodModule (fun x => by
+      calc p • x
+          = Additive.ofMul (x.toMul ^ p) := (ofMul_pow p x.toMul).symm
+        _ = Additive.ofMul (1 : G) := by rw [pow_prime_eq_one_of_not_isCyclic hp hG hnc]
+        _ = 0 := ofMul_one)
+  haveI : Finite (Additive G) := inferInstanceAs (Finite G)
+  haveI hmf : @Module.Finite (ZMod p) (Additive G) _ _ inst := Module.Finite.of_finite
+  haveI hfree : @Module.Free (ZMod p) (Additive G) _ _ inst :=
+    @Module.Free.of_divisionRing (ZMod p) (Additive G) _ _ inst
+  -- Dimension is exactly `2`: `p² = (Nat.card (ZMod p)) ^ finrank = p ^ finrank`.
+  have hcardZ : Nat.card (ZMod p) = p := by
+    rw [Nat.card_eq_fintype_card, ZMod.card]
+  have hcard : Nat.card (Additive G) = Nat.card (ZMod p) ^ finrank (ZMod p) (Additive G) :=
+    @Module.natCard_eq_pow_finrank (ZMod p) (Additive G) _ _ inst hmf
+  have hcardG : Nat.card (Additive G) = p ^ 2 := hG
+  rw [hcardG, hcardZ] at hcard
+  have hrank : finrank (ZMod p) (Additive G) = 2 :=
+    (Nat.pow_right_injective hp.two_le hcard).symm
+  -- Basis of size `2` ⇒ linear equivalence to `(ZMod p)²`.
+  let b : Basis (Fin 2) (ZMod p) (Additive G) :=
+    @Module.finBasisOfFinrankEq (ZMod p) (Additive G) _ _ _ inst hfree hmf 2 hrank
+  let eLin : Additive G ≃ₗ[ZMod p] ZMod p × ZMod p :=
+    b.equivFun.trans (LinearEquiv.finTwoArrow (ZMod p) (ZMod p))
+  -- Transport across `Additive ⊣ Multiplicative` and split the product.
+  exact (AddEquiv.toMultiplicativeRight eLin.toAddEquiv).trans
+    (MulEquiv.prodMultiplicative (ZMod p) (ZMod p))
+
+/-! ## The structure theorem -/
+
+/-- **Classification by explicit isomorphism.** A group of order `p²` (`p` prime) is
+isomorphic either to `Multiplicative (ZMod (p²))` (the cyclic type `ℤ/p²`) or to
+`Multiplicative (ZMod p) × Multiplicative (ZMod p)` (the elementary-abelian type
+`(ℤ/p)²`). The two cases are mutually exclusive (grandparent dichotomy). -/
+theorem mulEquiv_zmod_sq_or_prod {p : ℕ} (hp : p.Prime) (hG : Nat.card G = p ^ 2) :
+    Nonempty (G ≃* Multiplicative (ZMod (p ^ 2))) ∨
+      Nonempty (G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p)) := by
+  by_cases hc : IsCyclic G
+  · exact Or.inl ⟨cyclicMulEquiv hG hc⟩
+  · exact Or.inr ⟨elemAbelianMulEquiv hp hG hc⟩
+
+/-- **Exponent `p²` ⟹ `G ≃* ℤ/p²`.** Stated through the parent's invariant: the value
+`exponent G = p²` is, by the parent, equivalent to `G` being cyclic, which pins the
+isomorphism type to `Multiplicative (ZMod (p²))`. -/
+noncomputable def mulEquiv_zmod_sq_of_exponent_sq {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) (hexp : Monoid.exponent G = p ^ 2) :
+    G ≃* Multiplicative (ZMod (p ^ 2)) :=
+  cyclicMulEquiv hG ((exponent_eq_sq_iff_isCyclic hp hG).mp hexp)
+
+/-- **Exponent `p` ⟹ `G ≃* (ℤ/p)²`.** Dually, the value `exponent G = p` characterises
+the non-cyclic (elementary-abelian) type, pinning the isomorphism type to
+`Multiplicative (ZMod p) × Multiplicative (ZMod p)`. -/
+noncomputable def mulEquiv_prod_of_exponent_prime {p : ℕ} (hp : p.Prime)
+    (hG : Nat.card G = p ^ 2) (hexp : Monoid.exponent G = p) :
+    G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p) :=
+  elemAbelianMulEquiv hp hG ((exponent_eq_prime_iff_not_isCyclic hp hG).mp hexp)
+
+end GroupOrderPrimeSqIso

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-cyclic-equiv",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 68
+    },
+    "type": "technique",
+    "title": "The Cyclic Isomorphism via zmodCyclicMulEquiv",
+    "content": "**`cyclicMulEquiv`**: a cyclic group of order `p²` is `G ≃* Multiplicative (ZMod (p²))`.\n\nMathlib's `zmodCyclicMulEquiv` provides, for any cyclic group, the canonical isomorphism\n```\nMultiplicative (ZMod (Nat.card G)) ≃* G.\n```\nThe entire proof is to rewrite `Nat.card G = p²` inside this equivalence and invert it. Note that **primality is not used** — only the cardinality *value* `p²` matters — so the hypothesis is stated as `Nat.card G = p ^ 2` with no `p.Prime`. This is the easy half of the structure theorem; all the work is in the elementary-abelian case."
+  },
+  {
+    "id": "ann-zmod-module",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 91,
+      "endLine": 102
+    },
+    "type": "insight",
+    "title": "The Non-Cyclic Group is a 𝔽_p-Vector Space",
+    "content": "The non-cyclic case rests on a reinterpretation: the predicate `gᵖ = 1 for all g` (imported as `pow_prime_eq_one_of_not_isCyclic`) says exactly that the additive group `Additive G` is **annihilated by `p`**, hence carries a module structure over the field `ZMod p`.\n\n`AddCommMonoid.zmodModule` builds this module from the `p`-torsion proof; the `calc` discharges `p • x = 0` by translating it through the `Additive`/`Multiplicative` bridge `ofMul_pow : ofMul (a^p) = p • ofMul a` and the imported relation `(toMul x)^p = 1`. Once `Additive G` is a vector space, the classification of the non-cyclic group becomes pure linear algebra."
+  },
+  {
+    "id": "ann-instance-threading",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 97,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "Threading the Module Instance Explicitly",
+    "content": "A formalization subtlety: `AddCommMonoid.zmodModule` is a *reducible non-instance* (it is an `abbrev`, deliberately not registered as a global instance to avoid runaway search). Consequently the local `Module (ZMod p) (Additive G)` it produces cannot be rediscovered by typeclass resolution when downstream lemmas (`Module.Finite`, `Module.Free`, `Module.natCard_eq_pow_finrank`, `Module.finBasisOfFinrankEq`) demand it — search gets *stuck on metavariables*.\n\nThe fix is to **name the instance** (`letI inst := …`) and pass it (together with the derived `hmf : Module.Finite` and `hfree : Module.Free`) explicitly via `@`. This is the difference between a stuck proof and a clean one."
+  },
+  {
+    "id": "ann-dimension-count",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 107,
+      "endLine": 115
+    },
+    "type": "insight",
+    "title": "Cardinality Forces Dimension 2",
+    "content": "For a finite module over a finite field, `Module.natCard_eq_pow_finrank` gives `Nat.card V = (Nat.card K)^(finrank K V)`. With `K = ZMod p` (so `Nat.card K = p`) and `V = Additive G` (so `Nat.card V = Nat.card G = p²`), this reads\n```\np² = p ^ finrank (ZMod p) (Additive G).\n```\nSince `m ↦ p^m` is injective for `p ≥ 2` (`Nat.pow_right_injective`), the dimension is forced to be exactly `2`. This single numerical step is what pins the isomorphism type: a 2-dimensional 𝔽_p-vector space is `(ℤ/p)²`."
+  },
+  {
+    "id": "ann-transport",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 116,
+      "endLine": 123
+    },
+    "type": "technique",
+    "title": "Basis, finTwoArrow, and the Additive/Multiplicative Transport",
+    "content": "With `finrank = 2`, `Module.finBasisOfFinrankEq` yields a `Basis (Fin 2) (ZMod p) (Additive G)`. Its coordinate equivalence `b.equivFun : Additive G ≃ₗ (Fin 2 → ZMod p)` composes with `LinearEquiv.finTwoArrow : (Fin 2 → ZMod p) ≃ₗ ZMod p × ZMod p` to give an additive identification `Additive G ≃+ ZMod p × ZMod p`.\n\nThe final step carries this back to the multiplicative world: `AddEquiv.toMultiplicativeRight` turns `Additive G ≃+ H` into `G ≃* Multiplicative H`, and `MulEquiv.prodMultiplicative` splits `Multiplicative (ZMod p × ZMod p)` into `Multiplicative (ZMod p) × Multiplicative (ZMod p)`. Working additively to use module theory and then transporting back is what keeps the multiplicative argument free of hand computation."
+  },
+  {
+    "id": "ann-structure-theorem",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 131,
+      "endLine": 152
+    },
+    "type": "concept",
+    "title": "From Invariant to Structure Theorem",
+    "content": "`mulEquiv_zmod_sq_or_prod` is the classification proper: a `by_cases` on `IsCyclic G` dispatches to the two explicit isomorphisms, so every group of order `p²` is isomorphic to one of `ℤ/p²`, `(ℤ/p)²` (mutual exclusivity is the grandparent's sharp dichotomy).\n\n`mulEquiv_zmod_sq_of_exponent_sq` and `mulEquiv_prod_of_exponent_prime` then restate this through the **parent's exponent invariant**: composing with `exponent_eq_sq_iff_isCyclic` / `exponent_eq_prime_iff_not_isCyclic` maps the two exponent values `p²` and `p` to the two isomorphism types. This closes the parent chain — the exponent computation the parent introduced now delivers a concrete group identification."
+  }
+]

--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+  "title": "Explicit Isomorphisms for Groups of Order p² — the Structure Theorem",
+  "slug": "group-order-prime-squared-abelian-oq-01-oq-01-oq-02",
+  "description": "Upgrades the order-p² classification from an invariant characterization to an honest structure theorem with explicit group isomorphisms. For a group G with Nat.card G = p² (p prime): if G is cyclic then G ≃* Multiplicative (ZMod (p²)) (the type ℤ/p²); if G is not cyclic then G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p) (the elementary-abelian type (ℤ/p)²). The non-cyclic isomorphism is built by giving Additive G a ZMod p-vector-space structure (every element is p-torsion), counting its cardinality p² to pin the dimension at 2, choosing a basis, and transporting the resulting (ZMod p)² identification back across the Additive/Multiplicative adjunction. Stated also through the parent's exponent invariant: exponent p² pins G to ℤ/p², exponent p pins G to (ℤ/p)².",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GroupOrderPrimeSquaredAbelianIsoOQ01OQ01OQ02.lean",
+    "tags": [
+      "group-theory",
+      "finite-groups",
+      "p-groups",
+      "cyclic-groups",
+      "elementary-abelian",
+      "structure-theorem",
+      "vector-spaces",
+      "algebra"
+    ],
+    "badge": "original",
+    "mathlib_version": "4.26.0",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 154,
+    "theoremCount": 1,
+    "definitionCount": 4,
+    "assumptions": "None beyond the stated theorem hypotheses (Nat.card G = p² with p prime). 0 axioms, 0 sorries, no native_decide; #print axioms reports only propext / Classical.choice / Quot.sound for all five public results. The abelian-ness (mul_comm_of_card_eq_prime_sq) and the cyclic/exponent-p dichotomy (pow_prime_eq_one_of_not_isCyclic) are imported from the grandparent file Proofs/GroupOrderPrimeSquaredAbelian.lean; the exponent characterizations (exponent_eq_sq_iff_isCyclic, exponent_eq_prime_iff_not_isCyclic) are imported from the parent Proofs/GroupOrderPrimeSquaredAbelianExponentOQ01.lean. The cyclic isomorphism reuses Mathlib's zmodCyclicMulEquiv; the elementary-abelian isomorphism is assembled here from the ZMod p-module structure (AddCommMonoid.zmodModule), the finite-field dimension count (Module.natCard_eq_pow_finrank), a Fin 2 basis (Module.finBasisOfFinrankEq), LinearEquiv.finTwoArrow, and the Additive/Multiplicative adjunction (AddEquiv.toMultiplicativeRight, MulEquiv.prodMultiplicative). One private helper lemma (finiteness from the cardinality) is not counted among the substantive results. Counts: 4 explicit-isomorphism definitions (cyclicMulEquiv, elemAbelianMulEquiv, mulEquiv_zmod_sq_of_exponent_sq, mulEquiv_prod_of_exponent_prime) and 1 classification theorem (mulEquiv_zmod_sq_or_prod).",
+    "originalContributions": [
+      "elemAbelianMulEquiv (the heart of the entry): a non-cyclic group of order p² is G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p). The construction equips Additive G with a ZMod p-module structure from the p-torsion relation gᵖ = 1 (AddCommMonoid.zmodModule), observes Nat.card (Additive G) = p² = (Nat.card (ZMod p))^finrank to force finrank = 2 (Nat.pow_right_injective on Module.natCard_eq_pow_finrank), produces a Fin 2 basis, composes the basis coordinate equivalence with LinearEquiv.finTwoArrow to land in (ZMod p)², and transports back with AddEquiv.toMultiplicativeRight followed by MulEquiv.prodMultiplicative. This is the elementary-abelian half the parent entries only characterized by a predicate.",
+      "cyclicMulEquiv: a cyclic group of order p² is G ≃* Multiplicative (ZMod (p²)), obtained from Mathlib's zmodCyclicMulEquiv by rewriting Nat.card G = p² and inverting. Stated without a primality hypothesis, since only the cardinality value is used — a small sharpening over the surrounding API.",
+      "mulEquiv_zmod_sq_or_prod: the structure theorem proper — every group of order p² is isomorphic to exactly one of Multiplicative (ZMod (p²)) and Multiplicative (ZMod p) × Multiplicative (ZMod p), by a by_cases on cyclicity dispatching to the two explicit isomorphisms. The mutual exclusivity is the grandparent's sharp dichotomy.",
+      "mulEquiv_zmod_sq_of_exponent_sq: the structure theorem stated through the parent's numerical invariant — the value exponent G = p² (equivalently, G cyclic) pins the isomorphism type to ℤ/p². Closes the loop the parent opened: an exponent computation now yields a concrete group identification.",
+      "mulEquiv_prod_of_exponent_prime: dually, the value exponent G = p (equivalently, G non-cyclic) pins the isomorphism type to (ℤ/p)². Together with the previous definition this turns the parent's two-valued invariant into a two-element list of explicit isomorphism types."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "zmodCyclicMulEquiv",
+        "description": "for a cyclic group G, Multiplicative (ZMod (Nat.card G)) ≃* G — supplies the cyclic-case isomorphism after rewriting Nat.card G = p²",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      },
+      {
+        "theorem": "AddCommMonoid.zmodModule",
+        "description": "a commutative monoid all of whose elements are killed by n carries a ZMod n-module structure — turns the p-torsion relation gᵖ = 1 on Additive G into a ZMod p-vector-space structure",
+        "module": "Mathlib.Algebra.Module.ZMod"
+      },
+      {
+        "theorem": "Module.natCard_eq_pow_finrank",
+        "description": "Nat.card V = (Nat.card K)^(finrank K V) for a finite module over a finite field — with K = ZMod p, V = Additive G it gives p² = p^finrank, forcing finrank = 2",
+        "module": "Mathlib.FieldTheory.Finiteness"
+      },
+      {
+        "theorem": "Module.finBasisOfFinrankEq",
+        "description": "a finite free module of known finrank n has a Basis (Fin n) — produces the Fin 2 basis of Additive G used to coordinatize it as (ZMod p)²",
+        "module": "Mathlib.LinearAlgebra.Dimension.Free"
+      },
+      {
+        "theorem": "LinearEquiv.finTwoArrow",
+        "description": "(Fin 2 → M) ≃ₗ M × M — splits the basis coordinate vector into an ordered pair, giving Additive G ≃ₗ ZMod p × ZMod p",
+        "module": "Mathlib.LinearAlgebra.Pi"
+      },
+      {
+        "theorem": "AddEquiv.toMultiplicativeRight / MulEquiv.prodMultiplicative",
+        "description": "the Additive/Multiplicative type-tag adjunction: an Additive G ≃+ H becomes G ≃* Multiplicative H, and Multiplicative (A × B) splits as Multiplicative A × Multiplicative B — transports the additive (ZMod p)² identification back to the multiplicative target",
+        "module": "Mathlib.Algebra.Group.Equiv.TypeTags"
+      },
+      {
+        "theorem": "Module.Free.of_divisionRing",
+        "description": "every vector space over a division ring is free — supplies the freeness needed by finBasisOfFinrankEq for the ZMod p-module Additive G",
+        "module": "Mathlib.LinearAlgebra.Basis.VectorSpace"
+      }
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GroupOrderPrimeSquaredAbelian",
+      "Proofs.GroupOrderPrimeSquaredAbelianExponentOQ01"
+    ],
+    "opens": [
+      "GroupOrderPrimeSq",
+      "GroupOrderPrimeSqExponent",
+      "Module"
+    ],
+    "namespace": "GroupOrderPrimeSqIso",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 4,
+    "path": "Proofs/GroupOrderPrimeSquaredAbelianIsoOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The classification of groups of order p² is a textbook landmark: every such group is abelian, and there are exactly two isomorphism types, ℤ/p² and (ℤ/p)². The grandparent entry proves abelian-ness and the cyclic/elementary-abelian dichotomy; the parent entry recasts that dichotomy through the single invariant Monoid.exponent G ∈ {p, p²}. Both stop at a predicate — 'G is cyclic' or '∀ g, gᵖ = 1'. The remaining step, and the content of this entry, is to exhibit the actual isomorphisms G ≃* ℤ/p² and G ≃* (ℤ/p)², turning the classification into a genuine structure theorem.",
+    "problemStatement": "Let G be a group with Nat.card G = p² for a prime p. Construct explicit group isomorphisms: G ≃* Multiplicative (ZMod (p²)) when G is cyclic, and G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p) when G is not cyclic; and package these as a classification stating every order-p² group is isomorphic to exactly one of the two. State the same result through the exponent invariant.",
+    "text": "The two halves require different machinery. The cyclic half is a one-line consequence of Mathlib's zmodCyclicMulEquiv after rewriting the cardinality. The non-cyclic half is the substance: a non-cyclic group of order p² has every element satisfying gᵖ = 1, so its additive avatar Additive G is annihilated by p and therefore a vector space over the field ZMod p. A finite vector space over a field of q elements has cardinality q^(dimension); here p² = p^(dimension) forces dimension 2, so a basis identifies Additive G with (ZMod p)², and the Additive/Multiplicative adjunction carries this back to a multiplicative isomorphism G ≃* (ℤ/p)².",
+    "proofStrategy": "Cyclic case: zmodCyclicMulEquiv gives Multiplicative (ZMod (Nat.card G)) ≃* G; rewrite Nat.card G = p² and invert. Non-cyclic case: install the field instance Fact p.Prime; build AddCommGroup (Additive G) from the imported commutativity; install Module (ZMod p) (Additive G) via AddCommMonoid.zmodModule using the imported pow_prime_eq_one_of_not_isCyclic to discharge p • x = 0; derive Module.Finite and Module.Free for this module; compute Nat.card (Additive G) = p² = (Nat.card (ZMod p))^finrank via Module.natCard_eq_pow_finrank and conclude finrank = 2 by injectivity of p^(·); take a Fin 2 basis (Module.finBasisOfFinrankEq), compose its coordinate equivalence with LinearEquiv.finTwoArrow to reach ZMod p × ZMod p, and transport with AddEquiv.toMultiplicativeRight followed by MulEquiv.prodMultiplicative. The classification is a by_cases on IsCyclic; the exponent-indexed statements compose the explicit isomorphisms with the parent's exponent_eq_sq_iff_isCyclic / exponent_eq_prime_iff_not_isCyclic.",
+    "keyInsights": [
+      "**The elementary-abelian group IS a 2-dimensional 𝔽_p-vector space.** The bare predicate 'gᵖ = 1 for all g' is exactly the statement that Additive G is a ZMod p-module; the whole classification of the non-cyclic case is then linear algebra — count the cardinality to get the dimension, pick a basis, and read off (ZMod p)².",
+      "**Cardinality determines dimension over a finite field.** Module.natCard_eq_pow_finrank turns the group-order hypothesis Nat.card G = p² into p² = p^finrank, and injectivity of m ↦ p^m (p ≥ 2) forces finrank = 2 with no further argument — the single numerical input that fixes the isomorphism type.",
+      "**The Additive/Multiplicative adjunction does the transport for free.** Working additively to exploit module theory and then mapping back multiplicatively (AddEquiv.toMultiplicativeRight, MulEquiv.prodMultiplicative) avoids reproving anything about the multiplicative group; the vector-space isomorphism becomes a group isomorphism mechanically.",
+      "**Primality is needed only for the non-cyclic half.** The cyclic isomorphism uses just the cardinality value p², not p prime; primality enters solely to make ZMod p a field so that the p-torsion abelian group is a vector space — a clean separation of where the arithmetic hypothesis actually bites.",
+      "**A naming subtlety: the ZMod p-module instance must be threaded explicitly.** AddCommMonoid.zmodModule is a reducible non-instance, so derived-instance search (Module.Finite, Module.Free) cannot rebuild it and gets stuck; naming the instance and passing it by hand to natCard_eq_pow_finrank and finBasisOfFinrankEq is what makes the dimension count and basis go through."
+    ],
+    "prerequisites": [
+      "The grandparent results: a group of order p² is abelian and is cyclic or has exponent p (imported)",
+      "The parent results: exponent G = p² ⟺ cyclic and exponent G = p ⟺ non-cyclic (imported)",
+      "Mathlib's cyclic-group identification Multiplicative (ZMod (Nat.card G)) ≃* G",
+      "Finite-dimensional vector spaces over a finite field: cardinality = (field size)^dimension, and existence of a finite basis",
+      "The Additive/Multiplicative type-tag adjunction for transporting additive equivalences to multiplicative ones"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Docstring framing the entry as the structure-theorem upgrade of the parent's invariant characterization; imports Mathlib and the grandparent/parent files, opens their namespaces and Module, fixes a group variable G, and proves a private finiteness helper from the cardinality.",
+      "mathContext": "Goal: explicit G ≃* ℤ/p² (cyclic) and G ≃* (ℤ/p)² (non-cyclic)."
+    },
+    {
+      "id": "cyclic-case",
+      "title": "The Cyclic Case",
+      "startLine": 57,
+      "endLine": 68,
+      "summary": "cyclicMulEquiv: a cyclic group of order p² is Multiplicative (ZMod (p²)), from Mathlib's zmodCyclicMulEquiv by rewriting Nat.card G = p² and inverting. No primality hypothesis is needed.",
+      "mathContext": "IsCyclic G, Nat.card G = p² ⟹ G ≃* Multiplicative (ZMod (p²))."
+    },
+    {
+      "id": "elementary-abelian-case",
+      "title": "The Elementary-Abelian Case",
+      "startLine": 69,
+      "endLine": 123,
+      "summary": "elemAbelianMulEquiv: a non-cyclic group of order p² is Multiplicative (ZMod p) × Multiplicative (ZMod p). Additive G is made a ZMod p-vector space (p-torsion), its cardinality p² forces dimension 2, a Fin 2 basis coordinatizes it as (ZMod p)² via LinearEquiv.finTwoArrow, and the Additive/Multiplicative adjunction transports the result back.",
+      "mathContext": "¬IsCyclic G, Nat.card G = p² ⟹ G ≃* (ℤ/p)²; via Module (ZMod p) (Additive G), finrank = 2."
+    },
+    {
+      "id": "structure-theorem",
+      "title": "The Structure Theorem",
+      "startLine": 124,
+      "endLine": 154,
+      "summary": "mulEquiv_zmod_sq_or_prod classifies every order-p² group as one of the two explicit types by a by_cases on cyclicity. mulEquiv_zmod_sq_of_exponent_sq and mulEquiv_prod_of_exponent_prime restate the structure theorem through the parent's exponent invariant, mapping the values p² and p to the isomorphism types ℤ/p² and (ℤ/p)².",
+      "mathContext": "exponent p² ↦ ℤ/p²; exponent p ↦ (ℤ/p)²."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 structure theorem for groups of order p² (p prime): explicit isomorphisms G ≃* Multiplicative (ZMod (p²)) in the cyclic case and G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p) in the non-cyclic case, packaged as a two-type classification and restated through the parent's exponent invariant. 4 isomorphism definitions and 1 classification theorem, 154 lines, 0 axioms, 0 sorries, no native_decide; the dichotomy and exponent characterizations are imported from the ancestor files.",
+    "implications": "Completes the parent chain by turning the invariant characterization (cyclic vs. exponent p) into concrete group identifications, the elementary-abelian half via the observation that the non-cyclic group is literally a 2-dimensional 𝔽_p-vector space. The vector-space route is reusable: the same cardinality-forces-dimension argument identifies any elementary-abelian group of order pⁿ with (ℤ/p)ⁿ.",
+    "openQuestions": [
+      "Generalise to order p³: classify the (for odd p, two non-abelian) isomorphism types and produce explicit isomorphisms, where the exponent p versus p² no longer separates all types.",
+      "State the elementary-abelian isomorphism for general exponent: an abelian group of order pⁿ and exponent p is G ≃* (Multiplicative (ZMod p))ⁿ, by the identical 'p-torsion ⟹ 𝔽_p-vector space of dimension n' argument with finrank = n.",
+      "Make the two isomorphism types provably non-isomorphic at the structure-theorem level (ℤ/p² has an element of order p², (ℤ/p)² does not), upgrading the grandparent's mutual-exclusivity from a predicate dichotomy to a ≄* statement."
+    ]
+  },
+  "references": [
+    {
+      "authors": [
+        "Dummit, D.S.",
+        "Foote, R.M."
+      ],
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "John Wiley & Sons, 3rd ed.",
+      "note": "§5.2 fundamental theorem of finite abelian groups; the two groups of order p² as ℤ/p² and (ℤ/p)²"
+    },
+    {
+      "authors": [
+        "Rotman, J.J."
+      ],
+      "title": "An Introduction to the Theory of Groups",
+      "year": "1995",
+      "venue": "Springer GTM 148, 4th ed.",
+      "note": "groups of order p² are abelian; elementary-abelian p-groups as vector spaces over 𝔽_p"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "group-order-prime-squared-abelian-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "supplies the exponent characterizations exponent_eq_sq_iff_isCyclic and exponent_eq_prime_iff_not_isCyclic through which this entry restates the structure theorem"
+    },
+    {
+      "id": "group-order-prime-squared-abelian-oq-01",
+      "relationship": "grandparent",
+      "description": "supplies abelian-ness (mul_comm_of_card_eq_prime_sq) and the cyclic/exponent-p dichotomy (pow_prime_eq_one_of_not_isCyclic) consumed by the elementary-abelian construction"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Upgrades the order-$p^2$ classification from an **invariant characterization** (the grandparent's cyclic/exponent-$p$ dichotomy, the parent's `exponent ∈ {p, p²}`) to an honest **structure theorem with explicit group isomorphisms**:

| case | isomorphism |
|------|-------------|
| cyclic (exponent $p^2$) | `G ≃* Multiplicative (ZMod (p^2))`  — the type $\mathbb{Z}/p^2$ |
| non-cyclic (exponent $p$) | `G ≃* Multiplicative (ZMod p) × Multiplicative (ZMod p)` — the type $(\mathbb{Z}/p)^2$ |

This answers the parent entry's 2nd open question verbatim.

## Mathematical content

- **Cyclic case** (`cyclicMulEquiv`): a one-liner from Mathlib's `zmodCyclicMulEquiv` after rewriting `Nat.card G = p²`. Primality is not needed here — only the cardinality value — so the hypothesis is just `Nat.card G = p ^ 2`.
- **Elementary-abelian case** (`elemAbelianMulEquiv`, the substance): the imported predicate `gᵖ = 1 for all g` says exactly that `Additive G` is annihilated by $p$, hence a **$\mathbb{F}_p$-vector space** (`AddCommMonoid.zmodModule`). Then `Nat.card (Additive G) = p² = p^(finrank)` forces `finrank = 2` (`Module.natCard_eq_pow_finrank` + injectivity of $m \mapsto p^m$), a `Fin 2` basis coordinatizes it as $(\mathbb{Z}/p)^2$ via `LinearEquiv.finTwoArrow`, and the result is transported back with `AddEquiv.toMultiplicativeRight` + `MulEquiv.prodMultiplicative`.
- **Classification** (`mulEquiv_zmod_sq_or_prod`): every order-$p^2$ group is isomorphic to exactly one of the two types (`by_cases` on cyclicity; mutual exclusivity is the grandparent's sharp dichotomy).
- **Through the exponent invariant** (`mulEquiv_zmod_sq_of_exponent_sq`, `mulEquiv_prod_of_exponent_prime`): the parent's values $p^2$ and $p$ are mapped to the concrete isomorphism types, closing the parent chain.

## Verification

- **154 lines**, 4 isomorphism definitions + 1 classification theorem (+1 private helper).
- **0 axioms, 0 sorries, no `native_decide`.** `#print axioms` on all five public results reports only `propext`, `Classical.choice`, `Quot.sound`.
- Builds against Mathlib 4.26.0; the dichotomy and exponent characterizations are imported from the ancestor files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)