### PR TITLE
Enrich The Unified 7-11-13 Divisibility Rule

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01/annotations.json
@@ -39,8 +39,44 @@
     "title": "Coprimality Fusion: All Three Primes ↔ 1001",
     "content": "`all_three_dvd_iff_dvd_1001` shows 7 ∣ n ∧ 11 ∣ n ∧ 13 ∣ n ↔ 1001 ∣ n. The forward direction chains `Nat.Coprime.mul_dvd_of_dvd_of_dvd` twice (first 7·11 = 77, then 77·13 = 1001), each coprimality discharged by `norm_num`; the reverse is three `dvd_trans` from 1001. Composing this with the m = 1001 instance of the parametric lemma gives `all_three_dvd_iff_blockAltSum`: the conjunction of the three single-prime tests is equivalent to a single 1001-divisibility test on blockAltSum n. This is why the three rules genuinely fuse into one.",
     "mathContext": "Since $7, 11, 13$ are pairwise coprime, $\\mathrm{lcm} = 7\\cdot 11\\cdot 13 = 1001$, so $7\\mid n \\wedge 11\\mid n \\wedge 13\\mid n \\iff 1001 \\mid n$. Combined with the $m=1001$ rule, $1001 \\mid n \\iff (1001:\\mathbb{Z}) \\mid \\mathrm{blockAltSum}\\,n$.",
-    "significance": "important",
+    "significance": "supporting",
     "relatedConcepts": ["Nat.Coprime.mul_dvd_of_dvd_of_dvd", "lcm of coprimes", "1001 = 7·11·13"],
     "prerequisites": ["pairwise coprimality", "Nat.Coprime.mul_dvd_of_dvd_of_dvd"]
+  },
+  {
+    "id": "ann-droq0401-blockaltsum",
+    "proofId": "divisibility-rules-oq-04-oq-01",
+    "range": { "startLine": 34, "endLine": 41 },
+    "type": "definition",
+    "title": "blockAltSum: the shared divisibility certificate",
+    "content": "blockAltSum n is defined as the alternating sum of the base-1000 digits of n — Nat.digits 1000 n cast to ℤ, then List.alternatingSum. Reading from the least-significant block, it computes b₀ - b₁ + b₂ - ⋯ where each bₖ is a three-decimal-digit group (0–999). This single integer is the certificate every rule reads off: there is no per-prime quantity, only this one alternating sum. The companion fact one_thousand_one_eq records 1001 = 7·11·13 by norm_num, pinning down which moduli the construction serves.",
+    "mathContext": "$\\mathrm{blockAltSum}(n) = \\sum_{k\\ge 0} (-1)^k b_k$ where $n = \\sum_{k} b_k\\,1000^k$ and $0 \\le b_k < 1000$. For example $1\\,234\\,567 \\mapsto 567 - 234 + 1 = 334$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.digits", "List.alternatingSum", "base-1000 blocks"],
+    "prerequisites": ["positional numeral systems", "List.alternatingSum"]
+  },
+  {
+    "id": "ann-droq0401-instances",
+    "proofId": "divisibility-rules-oq-04-oq-01",
+    "range": { "startLine": 56, "endLine": 75 },
+    "type": "insight",
+    "title": "Three rules as one-line instances of the parametric lemma",
+    "content": "seven_dvd_iff, eleven_dvd_iff and thirteen_dvd_iff are each a single application of dvd_iff_dvd_blockAltSum with the side condition (m:ℤ) ∣ 1001 discharged by norm_num — 7, 11 and 13 all divide 1001. unified_7_11_13 simply tuples the three together. The pedagogical point is that none of these re-derives anything: the mathematical content lives entirely in the parametric lemma, and the three classical 'tricks' are revealed as the same theorem evaluated at three divisors of 1001. The parent oq-04 had to treat 11 by a separate computation.",
+    "mathContext": "$7 \\mid n \\iff (7:\\mathbb{Z}) \\mid \\mathrm{blockAltSum}\\,n$, and identically for $11$ and $13$, because $\\{7,11,13\\} \\subset \\{d : d \\mid 1001\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["instantiation", "divisors of 1001", "uniform proof"],
+    "prerequisites": ["the parametric lemma dvd_iff_dvd_blockAltSum"]
+  },
+  {
+    "id": "ann-droq0401-modeq",
+    "proofId": "divisibility-rules-oq-04-oq-01",
+    "range": { "startLine": 97, "endLine": 104 },
+    "type": "insight",
+    "title": "The residue identity powering every rule",
+    "content": "modEq_blockAltSum strengthens the divisibility tests to a full congruence: n ≡ blockAltSum n modulo 1001, not merely 'divisible-or-not'. It is proved from 1000 ≡ -1 [ZMOD 1001] (Int.modEq_iff_dvd plus norm_num) fed into Nat.zmodeq_ofDigits_digits, then rewritten by Nat.ofDigits_neg_one. This congruence is the true engine: every divisibility rule above is the special case 'the residue is 0 modulo m' for m ∣ 1001, and it additionally lets one compute n mod 1001 (hence mod 7, 11, 13) directly from the block alternating sum.",
+    "mathContext": "$n \\equiv \\mathrm{blockAltSum}(n) \\pmod{1001}$, from $1000 \\equiv -1 \\pmod{1001}$. Reducing mod $7$, $11$ or $13$ recovers each single-prime rule as a corollary.",
+    "significance": "key",
+    "relatedConcepts": ["Int.ModEq", "Nat.zmodeq_ofDigits_digits", "complete residue vs. divisibility"],
+    "prerequisites": ["integer congruences", "Nat.zmodeq_ofDigits_digits"]
   }
 ]

--- a/src/data/proofs/divisibility-rules-oq-04-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-04-oq-01/meta.json
@@ -72,6 +72,68 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Digit-based divisibility rules are among the oldest pieces of elementary number theory: the casting-out-nines rule for 3 and 9 is recorded by the 12th-century mathematician Bhāskara II and appears throughout medieval Indian and Arabic arithmetic, while the alternating-digit-sum rule for 11 is a Renaissance staple. The 'three-digit block' test for 7, 11 and 13 — group the decimal digits into threes and alternately add and subtract — is a 20th-century recreational-mathematics favorite, popularized in problem-solving columns precisely because one operation simultaneously settles three primes. Its secret is the factorization 1001 = 7·11·13 (a number already singled out in the 'Arabian Nights' framing of 1001), which makes 1000 ≡ -1 modulo each of the three primes. This entry formalizes the rule in the unified parametric form the recreational literature only hints at.",
+    "problemStatement": "Prove the unified 7-11-13 rule directly: a natural number n is divisible by each of 7, 11, 13 iff that prime divides the alternating sum of the base-1000 (three-decimal-digit) blocks of n, exhibiting the single base-1000 grouping 1001 = 7·11·13 behind all three tests. Make the role of the 1001 factorization explicit rather than verifying each prime by a separate computation.",
+    "proofStrategy": "Factor the entire argument through one parametric lemma. dvd_iff_dvd_blockAltSum proves that for ANY modulus m with (m:ℤ) ∣ 1001, m ∣ n ↔ (m:ℤ) ∣ blockAltSum n, by specializing Mathlib's Nat.dvd_iff_dvd_ofDigits at base 1000 and digit -1 (whose side condition (m:ℤ) ∣ 1000-(-1)=1001 is exactly the hypothesis) and rewriting ofDigits(-1) into the alternating sum via Nat.ofDigits_neg_one. The 7, 11, 13 rules are then norm_num instances; their conjunction fuses to 1001-divisibility by two applications of Nat.Coprime.mul_dvd_of_dvd_of_dvd; and the underlying congruence n ≡ blockAltSum n [ZMOD 1001] comes from Nat.zmodeq_ofDigits_digits.",
+    "keyInsights": [
+      "One arithmetic fact, 1000 ≡ -1 (mod m), does all the work — and it holds precisely when m divides 1000-(-1) = 1001, so the set of moduli served by a single base-1000 grouping is exactly the divisor set of 1001 = 7·11·13.",
+      "Parametrizing on the hypothesis m ∣ 1001 instead of fixing a prime turns three separate 'divisibility tricks' into one theorem evaluated at three points; the shared structure becomes visible in the statement rather than hidden in per-prime norm_num calls.",
+      "The three single-prime tests fuse into one 1001-divisibility test because 7, 11, 13 are pairwise coprime, so their simultaneous divisibility is divisibility by their product (lcm = 1001).",
+      "The result is not merely a yes/no test: modEq_blockAltSum gives the full congruence n ≡ blockAltSum n (mod 1001), from which n mod 7, mod 11 and mod 13 can all be read off the same alternating block sum.",
+      "The proof reuses Mathlib's general base-b digit machinery wholesale; the mathematical novelty is the packaging that exposes 1001 as the organizing principle, answering the parent oq-04 which only handled m = 11."
+    ],
+    "prerequisites": [
+      "Nat.digits in an arbitrary base and Nat.ofDigits",
+      "Mathlib's base-b divisibility/congruence machinery (dvd_iff_dvd_ofDigits, zmodeq_ofDigits_digits)",
+      "the factorization 1001 = 7·11·13 and pairwise coprimality of 7, 11, 13",
+      "List.alternatingSum and Nat.ofDigits_neg_one"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Approach",
+      "startLine": 5,
+      "endLine": 28,
+      "summary": "States the parent's open question — prove the unified 7-11-13 rule directly — and the strategy: factor everything through one parametric lemma keyed to m ∣ 1001, with 1000 ≡ -1 (mod m) as the single underlying fact."
+    },
+    {
+      "id": "definition",
+      "title": "Definition: blockAltSum and 1001 = 7·11·13",
+      "startLine": 34,
+      "endLine": 41,
+      "summary": "Defines blockAltSum n as the alternating sum of the base-1000 digits of n (the shared divisibility certificate), and records 1001 = 7·11·13 by norm_num."
+    },
+    {
+      "id": "parametric",
+      "title": "The Parametric Lemma",
+      "startLine": 43,
+      "endLine": 54,
+      "summary": "dvd_iff_dvd_blockAltSum: for any m with (m:ℤ) ∣ 1001, m ∣ n ↔ (m:ℤ) ∣ blockAltSum n. Proved by specializing Nat.dvd_iff_dvd_ofDigits at base 1000, digit -1, then rewriting via Nat.ofDigits_neg_one."
+    },
+    {
+      "id": "instances",
+      "title": "The 7, 11, 13 Rules and Their Conjunction",
+      "startLine": 56,
+      "endLine": 75,
+      "summary": "seven/eleven/thirteen_dvd_iff are one-line norm_num instances of the parametric lemma; unified_7_11_13 packages all three, each reading off the same blockAltSum n."
+    },
+    {
+      "id": "fusion",
+      "title": "Coprimality Fusion to 1001",
+      "startLine": 77,
+      "endLine": 95,
+      "summary": "all_three_dvd_iff_dvd_1001 fuses the three primes into 1001-divisibility via pairwise coprimality; all_three_dvd_iff_blockAltSum then gives the combined 1001-rule on blockAltSum n."
+    },
+    {
+      "id": "congruence",
+      "title": "The Underlying Congruence",
+      "startLine": 97,
+      "endLine": 104,
+      "summary": "modEq_blockAltSum: n ≡ blockAltSum n [ZMOD 1001], the residue identity (from 1000 ≡ -1 mod 1001) that powers every rule and lets one compute n mod 7/11/13 from the block sum."
+    }
+  ],
   "openQuestions": [],
   "crossReferences": [
     {
@@ -100,6 +162,10 @@
   "conclusion": {
     "summary": "A fully verified (0-axiom) derivation of the unified 7-11-13 divisibility rule from a single base-1000 grouping. The parametric lemma dvd_iff_dvd_blockAltSum proves that for ANY modulus m ∣ 1001, m ∣ n ↔ (m:ℤ) ∣ blockAltSum n, where blockAltSum n is the alternating sum of the three-decimal-digit blocks; the side condition 1000 ≡ -1 (mod m) holds precisely when m ∣ 1001 = 7·11·13. The 7, 11 and 13 rules, their conjunction (unified_7_11_13), the coprimality fusion all_three_dvd_iff_dvd_1001, the combined 1001-rule all_three_dvd_iff_blockAltSum, and the residue identity modEq_blockAltSum are all one- or few-line corollaries. 105 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The parent oq-04 established only the m = 11 instance; this entry exhibits the genuinely unifying mechanism — a single base-1000 alternating block sum is the divisibility certificate for every divisor of 1001 simultaneously — and proves that the three single-prime tests are equivalent to one 1001-divisibility test via pairwise coprimality. The parametric form makes the role of the 1001 = 7·11·13 factorization explicit rather than hidden inside a per-prime norm_num computation.",
-    "openQuestions": []
+    "openQuestions": [
+      "The same scheme works for any base-grouping b' with b' ≡ ±1 (mod m): grouping into k-digit blocks (b' = 10^k) tests every divisor of 10^k - 1 (when b' ≡ 1, a plain block sum) or 10^k + 1 (when b' ≡ -1, an alternating block sum). Can the parametric lemma be generalized once to cover both signs and arbitrary block widths, recovering the 9/11/99/101/… families uniformly?",
+      "1001 = 7·11·13 is the smallest repunit-adjacent product giving three distinct primes from one grouping. Which other factorizations of 10^k ± 1 (e.g. 10^6 - 1 = 999999 = 3^3·7·11·13·37) yield similarly 'efficient' multi-prime divisibility tests, and is there an optimal trade-off between block width and number of primes detected?",
+      "Can the congruence n ≡ blockAltSum n [ZMOD 1001] be packaged as a fast residue-computation algorithm with a verified complexity bound, rather than only a divisibility predicate?"
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for **divisibility-rules-oq-04-oq-01**. Quality score 52 → 100.

## Quality improvements
- **Added `overview`** (was missing): `historicalContext` tracing the casting-out-nines lineage and the 1001 = 7·11·13 structure, plus `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **Added `sections`** (was missing): 6 sections covering the full Lean file — header, definition, parametric lemma, the 7/11/13 instances, coprimality fusion, and the underlying congruence.
- **Expanded annotations** 3 → 6: added the `blockAltSum` definition, the one-line 7/11/13 instances, and the `modEq_blockAltSum` residue identity. All annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- **Filled `conclusion.openQuestions`** with 3 genuine extension questions.
- Fixed an invalid `significance` enum value (`"important"` → `"supporting"`).

## Notes
- Axiom integrity verified: `status: verified`, `badge: mathlib`, `axiomCount: 0` match the Lean source (0 sorries, no `axiom` declarations, no assumption-carrying structures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)