### PR TITLE
Enrich Green's Theorem is Additive Under Subdivision (greens-theorem-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "greensoq0103-header",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 63 },
+    "type": "context",
+    "title": "Open Question and Tiling Strategy",
+    "content": "The parent `greens_theorem_concrete` (greens-theorem-oq-01) proves Green's theorem on a *single* rectangle. The standard route from one rectangle to a general region is to **tile** the region with rectangles and add the cell-wise identities — relying on the fact that contributions along shared interior edges cancel because each interior edge is traversed once in each direction. This file isolates and proves exactly that cancellation for the concrete `rectLineIntegral` / `rectDoubleIntegral` formulation, with no ordering hypothesis ($a \\le e \\le b$ is never assumed).",
+    "mathContext": "$\\oint_{\\partial R} = \\oint_{\\partial R_1} + \\oint_{\\partial R_2}$ when $R = R_1 \\cup R_2$, the shared edge cancelling",
+    "significance": "context",
+    "relatedConcepts": ["region tiling", "orientation", "staircase approximation", "interior edge cancellation"],
+    "prerequisites": ["Green's theorem on a rectangle", "boundary orientation conventions"]
+  },
+  {
+    "id": "greensoq0103-line-vsplit",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 78, "endLine": 100 },
+    "type": "theorem",
+    "title": "Line Integral Additive Under a Vertical Cut",
+    "content": "`rectLineIntegral_vsplit` cuts $[a,b]\\times[c,d]$ at $x=e$. The shared interior edge $x=e$ is the right edge of the left cell (contributing $+\\int_c^d Q(e,y)\\,dy$) and the left edge of the right cell (contributing $-\\int_c^d Q(e,y)\\,dy$); these cancel by pure `ring`/`linarith` with **no hypothesis**. Only the outer edges $P(\\cdot,c)$ and $P(\\cdot,d)$, integrated in $x$, genuinely combine into longer integrals — hence the four `IntervalIntegrable` hypotheses feeding `integral_add_adjacent_intervals`.",
+    "mathContext": "$\\int_c^d Q(e,y)\\,dy - \\int_c^d Q(e,y)\\,dy = 0$; outer edges glue via $\\int_a^e + \\int_e^b = \\int_a^b$",
+    "significance": "key",
+    "relatedConcepts": ["orientation cancellation", "integral_add_adjacent_intervals", "boundary line integral"],
+    "prerequisites": ["interval integral additivity", "signed line integrals"]
+  },
+  {
+    "id": "greensoq0103-double-vsplit",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 102, "endLine": 120 },
+    "type": "theorem",
+    "title": "Double Integral Additive Under a Vertical Cut",
+    "content": "`rectDoubleIntegral_vsplit` splits the iterated double integral $\\iint_{[a,b]\\times[c,d]} f$ at $x=e$. The inner additivity $\\int_a^e f(\\cdot,y) + \\int_e^b f(\\cdot,y) = \\int_a^b f(\\cdot,y)$ holds pointwise in $y$ (via `integral_add_adjacent_intervals`), and is lifted through the outer $y$-integral with `integral_add` and `integral_congr`. Unlike the line integral, there is no cancellation here — the cut simply concatenates the two $x$-ranges.",
+    "mathContext": "$\\iint_{[a,b]\\times[c,d]} f = \\iint_{[a,e]\\times[c,d]} f + \\iint_{[e,b]\\times[c,d]} f$",
+    "significance": "key",
+    "relatedConcepts": ["iterated integral", "integral_congr", "Fubini-style additivity"],
+    "prerequisites": ["iterated integration", "pointwise-to-integral lifting"]
+  },
+  {
+    "id": "greensoq0103-line-hsplit",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 130, "endLine": 149 },
+    "type": "theorem",
+    "title": "Line Integral Additive Under a Horizontal Cut",
+    "content": "`rectLineIntegral_hsplit` is the symmetric statement for a horizontal cut at $y=g$. Now the shared edge $y=g$ contributes $-\\int_a^b P(x,g)\\,dx$ to the bottom cell and $+\\int_a^b P(x,g)\\,dx$ to the top cell, again cancelling by `linarith`. The outer edges $Q(b,\\cdot)$ and $Q(a,\\cdot)$, integrated in $y$, glue via `integral_add_adjacent_intervals`. The roles of $P$/$Q$ and $x$/$y$ swap relative to the vertical case.",
+    "mathContext": "$\\int_a^b P(x,g)\\,dx - \\int_a^b P(x,g)\\,dx = 0$ (the $y=g$ edge cancels)",
+    "significance": "supporting",
+    "relatedConcepts": ["horizontal subdivision", "symmetry of P and Q", "orientation cancellation"],
+    "prerequisites": ["interval integral additivity"]
+  },
+  {
+    "id": "greensoq0103-double-hsplit",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 151, "endLine": 161 },
+    "type": "theorem",
+    "title": "Double Integral Additive Under a Horizontal Cut",
+    "content": "`rectDoubleIntegral_hsplit` is the simplest of the four: cutting at $y=g$ splits the *outer* integral directly, so the proof is a single application of `integral_add_adjacent_intervals` on $\\int_c^d (\\cdots)\\,dy$. No inner manipulation is needed because the cut variable is already the outer one.",
+    "mathContext": "$\\iint_{[a,b]\\times[c,d]} f = \\iint_{[a,b]\\times[c,g]} f + \\iint_{[a,b]\\times[g,d]} f$",
+    "significance": "supporting",
+    "relatedConcepts": ["outer-integral additivity", "iterated integral"],
+    "prerequisites": ["interval integral additivity"]
+  },
+  {
+    "id": "greensoq0103-capstone",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 173, "endLine": 195 },
+    "type": "insight",
+    "title": "Capstone: Green's Theorem Glues Across a Cut",
+    "content": "`greens_additive_vertical` is the payoff. Given that the concrete Green identity holds on the left cell and the right cell, it holds on their union — proved by a pure rewrite: replace each whole-rectangle side by its two-cell split (`rectLineIntegral_vsplit`, `rectDoubleIntegral_vsplit`), then substitute the two cell-wise identities `hL`, `hR`. The interior edge takes care of itself. This is exactly the **inductive step** for proving Green's theorem on any rectangle-tiled (staircase) region by working cell by cell.",
+    "mathContext": "$\\big(\\text{Green on }R_1\\big) \\wedge \\big(\\text{Green on }R_2\\big) \\Rightarrow \\big(\\text{Green on }R_1\\cup R_2\\big)$",
+    "significance": "key",
+    "relatedConcepts": ["induction over a tiling", "gluing lemma", "staircase region", "structural rewrite"],
+    "prerequisites": ["additivity lemmas above", "Green's theorem on a cell"]
+  },
+  {
+    "id": "greensoq0103-sanity",
+    "proofId": "greens-theorem-oq-01-oq-03",
+    "range": { "startLine": 204, "endLine": 211 },
+    "type": "technique",
+    "title": "Concrete Sanity Check: Splitting the Unit Square",
+    "content": "`area_vsplit_unit_square` is a fully concrete instance: the area of $[0,1]^2$, computed as $\\iint 1$, splits at $x=\\tfrac12$ into two half-rectangles of area $\\tfrac12$ each. It closes by `area_double_integral` (from the parent) plus `ring`, confirming the abstract additivity lemmas reduce correctly on a numeric example.",
+    "mathContext": "$\\tfrac12 + \\tfrac12 = 1$, i.e. $\\iint_{[0,\\frac12]\\times[0,1]} 1 + \\iint_{[\\frac12,1]\\times[0,1]} 1 = \\iint_{[0,1]^2} 1$",
+    "significance": "technical",
+    "relatedConcepts": ["sanity check", "area as double integral"],
+    "prerequisites": ["area_double_integral from greens-theorem-oq-01"]
+  }
+]

--- a/src/data/proofs/greens-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-03/meta.json
@@ -68,12 +68,54 @@
       "Orientation conventions for boundary line integrals"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Tiling Strategy",
+      "startLine": 1,
+      "endLine": 68,
+      "summary": "Module docstring: the tiling route from one rectangle to general regions, the shared-edge cancellation it relies on, what is new relative to the parent and Fubini-discharged siblings, imports (Mathlib + Proofs.GreensTheoremOQ01), namespace, and opens.",
+      "mathContext": "Tile a region with rectangles and add cell-wise Green identities; interior edges cancel by orientation."
+    },
+    {
+      "id": "part-i-vertical",
+      "title": "Part I — Vertical Subdivision (cut at x = e)",
+      "startLine": 70,
+      "endLine": 120,
+      "summary": "rectLineIntegral_vsplit (shared edge x=e cancels by ring; outer P-edges glue) and rectDoubleIntegral_vsplit (inner x-additivity lifted through the outer y-integral).",
+      "mathContext": "$\\oint_{[a,b]} = \\oint_{[a,e]} + \\oint_{[e,b]}$ and $\\iint_{[a,b]} f = \\iint_{[a,e]} f + \\iint_{[e,b]} f$."
+    },
+    {
+      "id": "part-ii-horizontal",
+      "title": "Part II — Horizontal Subdivision (cut at y = g)",
+      "startLine": 122,
+      "endLine": 161,
+      "summary": "rectLineIntegral_hsplit (shared edge y=g cancels; outer Q-edges glue) and rectDoubleIntegral_hsplit (single adjacent-interval additivity on the outer integral). Symmetric to Part I with P/Q and x/y swapped.",
+      "mathContext": "$\\oint_{[c,d]} = \\oint_{[c,g]} + \\oint_{[g,d]}$ and $\\iint_{[c,d]} f = \\iint_{[c,g]} f + \\iint_{[g,d]} f$."
+    },
+    {
+      "id": "part-iii-capstone",
+      "title": "Part III — Capstone: Green's Theorem Glues Across a Cut",
+      "startLine": 163,
+      "endLine": 195,
+      "summary": "greens_additive_vertical: if the concrete Green identity holds on the left and right cells, it holds on their union — a pure rewrite via the vertical-split lemmas plus the two cell identities. The inductive step toward Green's theorem on rectangle-tiled regions.",
+      "mathContext": "Green on $R_1$ and on $R_2$ $\\Rightarrow$ Green on $R_1 \\cup R_2$."
+    },
+    {
+      "id": "part-iv-sanity",
+      "title": "Part IV — Concrete Sanity Check",
+      "startLine": 197,
+      "endLine": 219,
+      "summary": "area_vsplit_unit_square: the area of the unit square as ∬1 splits at x=½ into two half-rectangles of area ½ each, plus #check commands listing the five exported subdivision lemmas.",
+      "mathContext": "$\\tfrac12 + \\tfrac12 = 1$."
+    }
+  ],
   "conclusion": {
     "summary": "The concrete Green's-theorem identity is additive under subdivision: both the boundary line integral and the double integral of curl split into adjacent sub-rectangles, with the shared interior edge cancelling by orientation. The capstone greens_additive_vertical shows Green's theorem glues across a cut, giving the inductive step toward Green's theorem on rectangle-tiled regions.",
     "implications": "This isolates the structural ingredient — orientation-driven edge cancellation — that lets the single-rectangle result (OQ-01) extend to general regions. Combined with the discharged-Fubini siblings (OQ-01-OQ-01, OQ-01-OQ-02), it points toward an axiom-free Green's theorem on staircase domains.",
-    "futureDirections": [
+    "openQuestions": [
       "Iterate greens_additive_vertical over a finite grid to obtain Green's theorem on an arbitrary rectangle-tiled region by induction (Finset.sum form).",
-      "Combine horizontal and vertical splits to handle 2D grids of cells.",
+      "Combine horizontal and vertical splits to handle full 2D grids of cells, proving a capstone greens_additive_horizontal and a mixed-grid gluing lemma.",
       "Quantify the staircase approximation error to reach Green's theorem on regions with curved boundary."
     ]
   },


### PR DESCRIPTION
Enrichment pass for `greens-theorem-oq-01-oq-03`.

## Quality improvements
- **Annotations**: created `annotations.json` from scratch (the entry had none). **7 per-theorem annotations**, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering all six theorems plus the header: `rectLineIntegral_vsplit`, `rectDoubleIntegral_vsplit`, `rectLineIntegral_hsplit`, `rectDoubleIntegral_hsplit`, `greens_additive_vertical` (capstone), and `area_vsplit_unit_square`.
- **Sections**: added the `sections` array (5 parts) covering the full 219-line Lean file — previously absent.
- **Conclusion**: converted `futureDirections` (a non-rendered field) into `openQuestions` (3, the schema-supported field).

Axiom integrity verified against source: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries — consistent (only foundational propext/Classical.choice/Quot.sound; built on Mathlib interval-integral additivity, no structure-encoded assumptions).

`pnpm build` passes.