### PR TITLE
research(mean-value-theorem-oq-04-oq-03): trapezoidal rule error via the Peano kernel [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ04OQ03.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ04OQ03.lean
@@ -1,0 +1,159 @@
+/-
+# Trapezoidal Rule Error Bound via the Peano Kernel
+
+For a `C²` function `f : ℝ → ℝ`, the error of the trapezoidal quadrature rule
+
+  T(a,b) = (b - a)/2 · (f a + f b)
+
+as an approximation to `∫ₐᵇ f` is given *exactly* by an integral against the
+**Peano kernel** `K(x) = (x - a)(x - b)/2`:
+
+  ∫ₐᵇ K(x) · f''(x) dx = ∫ₐᵇ f(x) dx − T(a,b).
+
+This is the kernel form of the classical trapezoidal error.  It is obtained by
+integrating the kernel integral by parts twice: the kernel and its derivative
+both vanish at the right places to kill the boundary terms, peeling off the
+quadrature weights one factor at a time.  No mean value theorem and no `ξ` is
+needed for the identity itself — it is an exact equality, the starting point
+of every quantitative trapezoidal bound.
+
+Consequences proved here:
+
+* `trapezoid_overestimates_of_convex`: since `K ≤ 0` on `[a,b]`, a convex `f`
+  (`f'' ≥ 0`) makes the trapezoid rule an **over**estimate, `∫ₐᵇ f ≤ T(a,b)`.
+* `trapezoid_underestimates_of_concave`: the concave mirror image.
+
+Mathlib has integration by parts (`integral_mul_deriv_eq_deriv_mul_of_hasDerivAt`)
+and the trapezoid set-up, but no trapezoidal rule error identity; this file
+supplies the Peano-kernel form.
+
+We use the strong, clean hypothesis that `f` is twice differentiable on all of
+`ℝ` with continuous second derivative (a global `C²` assumption), which makes
+every regularity side condition immediate.
+-/
+import Mathlib
+
+open intervalIntegral MeasureTheory Set
+
+namespace TrapezoidalPeanoKernel
+
+variable {f f' f'' : ℝ → ℝ} {a b : ℝ}
+
+/-- Derivative of the Peano kernel `K(x) = (x - a)(x - b)/2`, namely
+`K'(x) = (2x - a - b)/2`. -/
+lemma hasDerivAt_kernel (a b x : ℝ) :
+    HasDerivAt (fun x => (x - a) * (x - b) / 2) ((2 * x - a - b) / 2) x := by
+  have h : HasDerivAt (fun x => (x - a) * (x - b)) (1 * (x - b) + (x - a) * 1) x :=
+    ((hasDerivAt_id x).sub_const a).mul ((hasDerivAt_id x).sub_const b)
+  have h2 := h.div_const 2
+  convert h2 using 1
+  ring
+
+/-- Derivative of the linear factor `(2x - a - b)/2`, which is the constant `1`. -/
+lemma hasDerivAt_kernelDeriv (a b x : ℝ) :
+    HasDerivAt (fun x => (2 * x - a - b) / 2) 1 x := by
+  have h : HasDerivAt (fun x => 2 * x - a - b) 2 x := by
+    have := ((hasDerivAt_id x).const_mul 2).sub_const a |>.sub_const b
+    simpa using this
+  have h2 := h.div_const 2
+  convert h2 using 1
+  norm_num
+
+/-- Continuity of `f` from twice differentiability everywhere. -/
+private lemma continuous_of_hasDerivAt (hf : ∀ x, HasDerivAt f (f' x) x) :
+    Continuous f :=
+  continuous_iff_continuousAt.2 fun x => (hf x).continuousAt
+
+/-- **Trapezoidal rule error via the Peano kernel.**
+
+For a globally `C²` function `f`, the integral of the Peano kernel `K(x) =
+(x-a)(x-b)/2` against `f''` equals the difference between the exact integral of
+`f` and the trapezoidal estimate `(b-a)/2·(f a + f b)`. -/
+theorem trapezoidal_peano_kernel
+    (hf : ∀ x, HasDerivAt f (f' x) x)
+    (hf' : ∀ x, HasDerivAt f' (f'' x) x)
+    (hf'' : Continuous f'') :
+    ∫ x in a..b, ((x - a) * (x - b) / 2) * f'' x
+      = (∫ x in a..b, f x) - (b - a) / 2 * (f a + f b) := by
+  have hfc : Continuous f := continuous_of_hasDerivAt hf
+  have hf'c : Continuous f' := continuous_of_hasDerivAt hf'
+  -- First integration by parts: u = K, v = f', v' = f''.
+  have step1 :
+      ∫ x in a..b, ((x - a) * (x - b) / 2) * f'' x
+        = ((b - a) * (b - b) / 2) * f' b - ((a - a) * (a - b) / 2) * f' a
+            - ∫ x in a..b, ((2 * x - a - b) / 2) * f' x :=
+    integral_mul_deriv_eq_deriv_mul_of_hasDerivAt
+      (u := fun x => (x - a) * (x - b) / 2) (u' := fun x => (2 * x - a - b) / 2)
+      (v := f') (v' := f'')
+      (by fun_prop) hf'c.continuousOn
+      (fun x _ => hasDerivAt_kernel a b x) (fun x _ => hf' x)
+      ((show Continuous (fun x => (2 * x - a - b) / 2) by fun_prop).intervalIntegrable a b)
+      (hf''.intervalIntegrable a b)
+  -- Second integration by parts: u = K', v = f, v' = f'.
+  have step2 :
+      ∫ x in a..b, ((2 * x - a - b) / 2) * f' x
+        = ((2 * b - a - b) / 2) * f b - ((2 * a - a - b) / 2) * f a
+            - ∫ x in a..b, (1 : ℝ) * f x :=
+    integral_mul_deriv_eq_deriv_mul_of_hasDerivAt
+      (u := fun x => (2 * x - a - b) / 2) (u' := fun _ => (1 : ℝ))
+      (v := f) (v' := f')
+      (by fun_prop) hfc.continuousOn
+      (fun x _ => hasDerivAt_kernelDeriv a b x) (fun x _ => hf x)
+      intervalIntegral.intervalIntegrable_const (hf'c.intervalIntegrable a b)
+  rw [step1, step2]
+  simp only [one_mul]
+  ring
+
+/-- On `[a,b]` the Peano kernel `K(x) = (x-a)(x-b)/2` is nonpositive. -/
+lemma kernel_nonpos {x : ℝ} (hx : x ∈ Set.Icc a b) :
+    (x - a) * (x - b) / 2 ≤ 0 := by
+  have h1 : 0 ≤ x - a := by linarith [hx.1]
+  have h2 : x - b ≤ 0 := by linarith [hx.2]
+  have : (x - a) * (x - b) ≤ 0 := mul_nonpos_of_nonneg_of_nonpos h1 h2
+  linarith
+
+/-- **Convex functions are overestimated by the trapezoidal rule.**
+
+If `f'' ≥ 0` on `[a,b]` (so `f` is convex there) and `a ≤ b`, the trapezoidal
+estimate is at least the true integral. -/
+theorem trapezoid_overestimates_of_convex
+    (hf : ∀ x, HasDerivAt f (f' x) x)
+    (hf' : ∀ x, HasDerivAt f' (f'' x) x)
+    (hf'' : Continuous f'')
+    (hab : a ≤ b)
+    (hconv : ∀ x ∈ Set.Icc a b, 0 ≤ f'' x) :
+    (∫ x in a..b, f x) ≤ (b - a) / 2 * (f a + f b) := by
+  have hkey := trapezoidal_peano_kernel (a := a) (b := b) hf hf' hf''
+  -- The kernel integral is ≤ 0 since K ≤ 0 and f'' ≥ 0 on [a,b].
+  have hnonpos : ∫ x in a..b, ((x - a) * (x - b) / 2) * f'' x ≤ 0 := by
+    have h := intervalIntegral.integral_nonneg (μ := volume)
+      (f := fun x => -(((x - a) * (x - b) / 2) * f'' x)) hab
+      (fun u hu => by
+        have hk := kernel_nonpos hu
+        have hc := hconv u hu
+        nlinarith [mul_nonneg (show (0:ℝ) ≤ -((u - a) * (u - b) / 2) by linarith) hc])
+    rw [intervalIntegral.integral_neg] at h
+    linarith
+  rw [hkey] at hnonpos
+  linarith
+
+/-- **Concave functions are underestimated by the trapezoidal rule.** -/
+theorem trapezoid_underestimates_of_concave
+    (hf : ∀ x, HasDerivAt f (f' x) x)
+    (hf' : ∀ x, HasDerivAt f' (f'' x) x)
+    (hf'' : Continuous f'')
+    (hab : a ≤ b)
+    (hconc : ∀ x ∈ Set.Icc a b, f'' x ≤ 0) :
+    (b - a) / 2 * (f a + f b) ≤ ∫ x in a..b, f x := by
+  have hkey := trapezoidal_peano_kernel (a := a) (b := b) hf hf' hf''
+  have hnonneg : 0 ≤ ∫ x in a..b, ((x - a) * (x - b) / 2) * f'' x := by
+    apply intervalIntegral.integral_nonneg hab
+    intro u hu
+    have hk := kernel_nonpos hu
+    have hc := hconc u hu
+    nlinarith [mul_nonneg (show (0:ℝ) ≤ -((u - a) * (u - b) / 2) by linarith)
+      (show (0:ℝ) ≤ -(f'' u) by linarith)]
+  rw [hkey] at hnonneg
+  linarith
+
+end TrapezoidalPeanoKernel

--- a/src/data/proofs/mean-value-theorem-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-04-oq-03/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-hasDerivAt-kernel",
+    "proofId": "mean-value-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
+    "type": "lemma",
+    "title": "hasDerivAt_kernel: K'(x) = (2x-a-b)/2",
+    "content": "The first derivative of the Peano kernel K(x) = (x-a)(x-b)/2. Built from elementary HasDerivAt arithmetic: each linear factor (x-a), (x-b) has derivative 1 via (hasDerivAt_id x).sub_const, their product has derivative 1·(x-b) + (x-a)·1 via HasDerivAt.mul, and dividing by the constant 2 with HasDerivAt.div_const gives the result. The convert ... ; ring step reconciles the product-rule expression with the closed form (2x-a-b)/2.",
+    "mathContext": "$K(x) = \\tfrac{(x-a)(x-b)}{2}, \\quad K'(x) = \\tfrac{2x-a-b}{2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasDerivAt.mul",
+      "HasDerivAt.div_const",
+      "Peano kernel"
+    ],
+    "prerequisites": [
+      "hasDerivAt_id",
+      "HasDerivAt.sub_const",
+      "HasDerivAt.mul"
+    ]
+  },
+  {
+    "id": "ann-hasDerivAt-kernelDeriv",
+    "proofId": "mean-value-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 60
+    },
+    "type": "lemma",
+    "title": "hasDerivAt_kernelDeriv: K''(x) = 1",
+    "content": "The centred linear factor (2x-a-b)/2 has constant derivative 1. This is the second-derivative input that closes the kernel's derivative chain K → K' → 1, and it is what makes the second integration by parts produce the bare integral ∫ 1·f = ∫ f.",
+    "mathContext": "$\\tfrac{d}{dx}\\,\\tfrac{2x-a-b}{2} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasDerivAt.const_mul",
+      "HasDerivAt.div_const"
+    ],
+    "prerequisites": [
+      "hasDerivAt_id",
+      "HasDerivAt.sub_const"
+    ]
+  },
+  {
+    "id": "ann-trapezoidal-peano-kernel",
+    "proofId": "mean-value-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 72,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "trapezoidal_peano_kernel: the exact error identity",
+    "content": "The headline result. For globally C² f, the trapezoidal error equals the integral of f'' against the Peano kernel: ∫ₐᵇ ((x-a)(x-b)/2)·f''(x) dx = ∫ₐᵇ f − (b-a)/2·(f a + f b). The proof is two applications of Mathlib's intervalIntegral.integral_mul_deriv_eq_deriv_mul_of_hasDerivAt. The first (step1, u = K, v' = f'') yields K(b)·f'(b) − K(a)·f'(a) − ∫ K'·f'; the boundary terms vanish because K(a) = K(b) = 0. The second (step2, u = K', v' = f') yields K'(b)·f(b) − K'(a)·f(a) − ∫ 1·f with K'(b) = (b-a)/2, K'(a) = −(b-a)/2. Substituting both and closing with simp [one_mul] and ring gives the identity. The C² hypothesis discharges all ContinuousOn / IntervalIntegrable side conditions immediately. The identity uses no ordering of a and b.",
+    "mathContext": "$\\int_a^b \\tfrac{(x-a)(x-b)}{2}\\,f''(x)\\,dx = \\int_a^b f - \\tfrac{b-a}{2}\\,(f(a)+f(b))$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "integration by parts",
+      "Peano kernel theorem",
+      "trapezoidal rule",
+      "quadrature remainder"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_mul_deriv_eq_deriv_mul_of_hasDerivAt",
+      "Continuous.intervalIntegrable",
+      "HasDerivAt.continuousAt"
+    ]
+  },
+  {
+    "id": "ann-kernel-nonpos",
+    "proofId": "mean-value-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 108,
+      "endLine": 113
+    },
+    "type": "lemma",
+    "title": "kernel_nonpos: K ≤ 0 on [a,b]",
+    "content": "On the closed interval [a,b] the Peano kernel is nonpositive: for a ≤ x ≤ b the factor (x-a) ≥ 0 and (x-b) ≤ 0, so their product is ≤ 0 (mul_nonpos_of_nonneg_of_nonpos) and halving preserves the sign. This single sign fact is what converts the exact error identity into the convexity/concavity over- and under-estimate corollaries.",
+    "mathContext": "$x \\in [a,b] \\implies \\tfrac{(x-a)(x-b)}{2} \\le 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mul_nonpos_of_nonneg_of_nonpos",
+      "sign of the Peano kernel"
+    ],
+    "prerequisites": [
+      "Set.Icc",
+      "mul_nonpos_of_nonneg_of_nonpos"
+    ]
+  },
+  {
+    "id": "ann-trapezoid-overestimates",
+    "proofId": "mean-value-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 119,
+      "endLine": 138
+    },
+    "type": "theorem",
+    "title": "trapezoid_overestimates_of_convex",
+    "content": "For a ≤ b and a convex integrand (f'' ≥ 0 on [a,b]), the trapezoidal estimate exceeds the integral: ∫ₐᵇ f ≤ (b-a)/2·(f a + f b). Proof: since K ≤ 0 and f'' ≥ 0, the integrand K·f'' ≤ 0, so its interval integral is ≤ 0 (via intervalIntegral.integral_nonneg applied to its negation). The Peano-kernel identity then transports this to error ≤ 0. This is the precise, quantitative form of the elementary fact that a chord lies above the graph of a convex function.",
+    "mathContext": "$f'' \\ge 0 \\text{ on } [a,b] \\implies \\int_a^b f \\le \\tfrac{b-a}{2}(f(a)+f(b))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "convexity",
+      "intervalIntegral.integral_nonneg",
+      "trapezoidal overestimate"
+    ],
+    "prerequisites": [
+      "trapezoidal_peano_kernel",
+      "kernel_nonpos",
+      "intervalIntegral.integral_nonneg"
+    ]
+  },
+  {
+    "id": "ann-trapezoid-underestimates",
+    "proofId": "mean-value-theorem-oq-04-oq-03",
+    "range": {
+      "startLine": 141,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "trapezoid_underestimates_of_concave",
+    "content": "The concave mirror image: for a ≤ b and f'' ≤ 0 on [a,b], the trapezoidal estimate is at most the integral, (b-a)/2·(f a + f b) ≤ ∫ₐᵇ f. Here K ≤ 0 and f'' ≤ 0 make K·f'' ≥ 0, so the kernel integral is nonnegative and the identity gives error ≥ 0.",
+    "mathContext": "$f'' \\le 0 \\text{ on } [a,b] \\implies \\tfrac{b-a}{2}(f(a)+f(b)) \\le \\int_a^b f$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "concavity",
+      "intervalIntegral.integral_nonneg",
+      "trapezoidal underestimate"
+    ],
+    "prerequisites": [
+      "trapezoidal_peano_kernel",
+      "kernel_nonpos",
+      "intervalIntegral.integral_nonneg"
+    ]
+  }
+]

--- a/src/data/proofs/mean-value-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-04-oq-03/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "mean-value-theorem-oq-04-oq-03",
+  "title": "Trapezoidal Rule Error Bound via the Peano Kernel",
+  "slug": "mean-value-theorem-oq-04-oq-03",
+  "description": "For a C² function f on ℝ, the error of the trapezoidal quadrature rule T(a,b) = (b-a)/2·(f a + f b) as an approximation to ∫ₐᵇ f is given exactly by an integral against the Peano kernel K(x) = (x-a)(x-b)/2: namely ∫ₐᵇ K(x)·f''(x) dx = ∫ₐᵇ f − T(a,b). The identity is obtained by integrating the kernel integral by parts twice; the kernel vanishes at both endpoints and its derivative is the centred linear factor, so the two boundary terms peel off exactly the quadrature weights. No mean value theorem and no intermediate ξ is needed — it is an exact equality, the starting point of every quantitative trapezoidal bound. Two sign consequences follow immediately from K ≤ 0 on [a,b]: convex f (f'' ≥ 0) is overestimated by the trapezoid rule, concave f underestimated. This answers the parent FTC-via-MVT entry's open question on whether Mathlib's intervalIntegral framework supports a verified trapezoidal error analysis; Mathlib has integration by parts but no trapezoidal rule error identity.",
+  "meta": {
+    "author": "Peano kernel method (classical); formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MeanValueTheoremOQ04OQ03.lean",
+    "tags": [
+      "calculus",
+      "numerical-analysis",
+      "quadrature",
+      "trapezoidal-rule",
+      "peano-kernel",
+      "integration-by-parts",
+      "mean-value-theorem",
+      "analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 159,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (which all Mathlib developments use). #print axioms on trapezoidal_peano_kernel, trapezoid_overestimates_of_convex and trapezoid_underestimates_of_concave reports exactly these three. The hypotheses are a global C² assumption on f (twice differentiable on all of ℝ with continuous second derivative), stated as ∀ x, HasDerivAt f (f' x) x, ∀ x, HasDerivAt f' (f'' x) x, Continuous f''; the two sign corollaries additionally assume a ≤ b and a one-sided bound on f'' over Set.Icc a b. The exact identity is proved from intervalIntegral.integral_mul_deriv_eq_deriv_mul_of_hasDerivAt (Mathlib integration by parts) applied twice.",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Trapezoidal_rule#Error_analysis",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The trapezoidal rule approximates the integral of f over [a,b] by the area of the trapezoid through (a, f a) and (b, f b), namely T(a,b) = (b-a)/2·(f a + f b). Quantifying its error is the prototypical problem of numerical quadrature. The sharp classical statement, ∫ₐᵇ f − T(a,b) = −(b-a)³/12·f''(ξ) for some ξ ∈ (a,b), follows from the mean value theorem for integrals, but its more fundamental and exact form is the Peano kernel representation: the error equals the integral of f'' against the kernel K(x) = (x-a)(x-b)/2. Giuseppe Peano's kernel theorem (1913) expresses the remainder of any linear quadrature or interpolation functional that annihilates polynomials up to a fixed degree as an integral of a derivative against a fixed, problem-independent kernel; the trapezoidal rule, which is exact on linear functions, is its first nontrivial instance. The kernel form is the foundation of every quantitative trapezoidal bound, of the composite (multi-panel) error analysis, and of the Euler–Maclaurin formula, of which the trapezoidal correction is the first term.",
+    "problemStatement": "Let f : ℝ → ℝ be twice continuously differentiable, with f' its derivative and f'' its continuous second derivative. Prove the exact Peano-kernel error identity for the trapezoidal rule: ∫ₐᵇ ((x-a)(x-b)/2)·f''(x) dx = ∫ₐᵇ f(x) dx − (b-a)/2·(f a + f b). Deduce that when a ≤ b and f'' ≥ 0 on [a,b] (f convex) the trapezoidal estimate overestimates the integral, ∫ₐᵇ f ≤ (b-a)/2·(f a + f b), and the reverse when f'' ≤ 0 (f concave).",
+    "text": "The trapezoidal rule error ∫ₐᵇ f − (b-a)/2·(f a + f b) equals ∫ₐᵇ K(x)·f''(x) dx where K(x) = (x-a)(x-b)/2 is the Peano kernel. The proof integrates by parts twice; the boundary terms vanish at the right places and produce the quadrature weights. Since K ≤ 0 on [a,b], convex functions are overestimated and concave functions underestimated.",
+    "proofStrategy": "The identity is two integrations by parts, carried out on the kernel integral ∫ₐᵇ K(x)·f''(x) dx with K(x) = (x-a)(x-b)/2. (1) hasDerivAt_kernel and hasDerivAt_kernelDeriv establish the derivative chain: K'(x) = (2x-a-b)/2 and K''(x) = 1, both by elementary HasDerivAt arithmetic on the polynomial factors. (2) First integration by parts (Mathlib's intervalIntegral.integral_mul_deriv_eq_deriv_mul_of_hasDerivAt, with u = K, v' = f''): ∫ K·f'' = K(b)·f'(b) − K(a)·f'(a) − ∫ K'·f'. The boundary terms vanish because K(a) = (a-a)(a-b)/2 = 0 and K(b) = (b-a)(b-b)/2 = 0, so ∫ K·f'' = −∫ K'·f'. (3) Second integration by parts (u = K', v' = f'): ∫ K'·f' = K'(b)·f(b) − K'(a)·f(a) − ∫ 1·f, with K'(b) = (b-a)/2 and K'(a) = (a-b)/2 = −(b-a)/2. Substituting and simplifying with ring gives ∫ K·f'' = ∫ f − (b-a)/2·(f a + f b), the claimed identity. The regularity side conditions (ContinuousOn on the closed interval, IntervalIntegrable of the derivative factors) are immediate from the global C² hypothesis: f, f' are continuous because differentiable everywhere, f'' is continuous by assumption, and the polynomial kernel factors are continuous, hence all are interval integrable. (4) kernel_nonpos shows K ≤ 0 on [a,b] (product of a nonnegative and a nonpositive factor). Feeding this to intervalIntegral.integral_nonneg gives the sign of the kernel integral, which the identity transports to the sign of the error, yielding trapezoid_overestimates_of_convex (f'' ≥ 0 ⟹ K·f'' ≤ 0 ⟹ error ≤ 0) and trapezoid_underestimates_of_concave (f'' ≤ 0 ⟹ K·f'' ≥ 0 ⟹ error ≥ 0).",
+    "keyInsights": [
+      "**The error is an exact integral, not an existence statement.** The familiar textbook form ∫ₐᵇ f − T = −(b-a)³/12·f''(ξ) hides an intermediate ξ and requires the mean value theorem. The Peano-kernel form ∫ₐᵇ K·f'' is an exact equality with no ξ: it is the genuine remainder functional, and every quantitative bound (the (b-a)³/12 constant, composite-rule bounds, asymptotic Euler–Maclaurin corrections) is recovered from it by estimating ∫|K|. Proving the exact form is both stronger and structurally cleaner than the ξ-form.",
+      "**The kernel vanishing at the endpoints is what produces the quadrature weights.** Both integrations by parts succeed precisely because the relevant boundary factors are zero or evaluate to ±(b-a)/2: K(a) = K(b) = 0 kills the first boundary term entirely, and K'(a) = −(b-a)/2, K'(b) = (b-a)/2 are exactly (the negatives of) the trapezoidal weights. The algebra of the trapezoid rule is encoded in the boundary values of the kernel and its derivative; the interior integral against f'' is the leftover error.",
+      "**K ≤ 0 on [a,b] forces the convexity sign of the error.** Because K(x) = (x-a)(x-b)/2 ≤ 0 throughout [a,b] (one factor ≥ 0, the other ≤ 0), the sign of the kernel integral is opposite to the sign of f''. A convex integrand (f'' ≥ 0) therefore has nonpositive error, i.e. the trapezoid rule overestimates — the precise, quantitative refinement of the elementary picture that a chord lies above the graph of a convex function. The concave case is the mirror image.",
+      "**A global C² hypothesis trivialises every regularity obligation.** Stating the hypotheses as differentiability everywhere on ℝ (rather than only on uIcc a b) makes continuity, interval-integrability, and the open-interval HasDerivAt requirements of Mathlib's integration-by-parts lemma immediate, isolating the genuine mathematical content — the two integrations by parts and the boundary cancellations — from analytic bookkeeping. The identity itself never uses a ≤ b; only the sign corollaries do."
+    ],
+    "prerequisites": [
+      "Interval integrals and the Mathlib intervalIntegral framework",
+      "Integration by parts intervalIntegral.integral_mul_deriv_eq_deriv_mul_of_hasDerivAt",
+      "HasDerivAt arithmetic for polynomial functions",
+      "Sign of an interval integral intervalIntegral.integral_nonneg",
+      "Peano's kernel theorem for linear functionals annihilating low-degree polynomials"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "trapezoidal_peano_kernel",
+      "type": "theorem",
+      "description": "The exact Peano-kernel error identity for the trapezoidal rule: for globally C² f, ∫ₐᵇ ((x-a)(x-b)/2)·f''(x) dx = ∫ₐᵇ f(x) dx − (b-a)/2·(f a + f b). Proved by two integrations by parts with the boundary terms cancelling at the endpoints."
+    },
+    {
+      "name": "trapezoid_overestimates_of_convex",
+      "type": "theorem",
+      "description": "If a ≤ b and f'' ≥ 0 on [a,b] (f convex), the trapezoidal estimate is at least the true integral: ∫ₐᵇ f ≤ (b-a)/2·(f a + f b). Follows from the identity and K ≤ 0 on [a,b]."
+    },
+    {
+      "name": "trapezoid_underestimates_of_concave",
+      "type": "theorem",
+      "description": "If a ≤ b and f'' ≤ 0 on [a,b] (f concave), the trapezoidal estimate is at most the true integral: (b-a)/2·(f a + f b) ≤ ∫ₐᵇ f. The concave mirror of the convex over-estimate."
+    },
+    {
+      "name": "hasDerivAt_kernel",
+      "type": "lemma",
+      "description": "The Peano kernel K(x) = (x-a)(x-b)/2 has derivative K'(x) = (2x-a-b)/2 at every point, by elementary HasDerivAt arithmetic."
+    },
+    {
+      "name": "hasDerivAt_kernelDeriv",
+      "type": "lemma",
+      "description": "The centred linear factor (2x-a-b)/2 has constant derivative 1, the second-derivative input to the kernel construction."
+    },
+    {
+      "name": "kernel_nonpos",
+      "type": "lemma",
+      "description": "On [a,b] the Peano kernel K(x) = (x-a)(x-b)/2 is nonpositive, the geometric fact behind the convexity sign of the error."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Peano, Giuseppe",
+      "title": "Resto nelle formule di quadratura espresso con un integrale definito",
+      "year": "1913",
+      "venue": "Atti della Reale Accademia dei Lincei, Rendiconti (5) 22, 562–569",
+      "note": "Original source of the kernel representation of quadrature remainders; the trapezoidal rule is its first nontrivial instance."
+    },
+    {
+      "authors": "Davis, Philip J.; Rabinowitz, Philip",
+      "title": "Methods of Numerical Integration",
+      "year": "1984",
+      "venue": "Academic Press, 2nd ed.",
+      "note": "Standard modern treatment of the Peano kernel theorem and trapezoidal/Simpson error analysis."
+    },
+    {
+      "authors": "Atkinson, Kendall E.",
+      "title": "An Introduction to Numerical Analysis",
+      "year": "1989",
+      "venue": "Wiley, 2nd ed.",
+      "note": "Develops the trapezoidal rule error, the composite rule, and the Euler–Maclaurin connection."
+    }
+  ],
+  "conclusion": {
+    "summary": "The trapezoidal rule error analysis is fully verified via its Peano-kernel form: 7 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries. For a C² function f, the quadrature error ∫ₐᵇ f − (b-a)/2·(f a + f b) equals exactly the integral of f'' against the kernel K(x) = (x-a)(x-b)/2 (trapezoidal_peano_kernel), proved by integrating by parts twice with the boundary terms cancelling at the endpoints. Because K ≤ 0 on [a,b], convex functions are overestimated (trapezoid_overestimates_of_convex) and concave functions underestimated (trapezoid_underestimates_of_concave) by the trapezoid rule. This answers the parent FTC-via-MVT entry's open question on whether Mathlib's intervalIntegral framework supports a verified trapezoidal error analysis.",
+    "implications": "The exact kernel identity is the foundation from which every quantitative trapezoidal estimate is derived: the classical |error| ≤ (b-a)³/12·sup|f''| bound follows by estimating ∫|K| = (b-a)³/12, the composite-rule O(h²) bound follows by summing over panels, and the first Euler–Maclaurin correction term is the same kernel integral. The proof also exhibits the canonical template for quadrature-error formalization — encode the rule's weights in the boundary values of a polynomial kernel, integrate by parts down to the controlling derivative, and read off the sign from the kernel — which transfers directly to Simpson's rule (a degree-3 Peano kernel) and to higher Newton–Cotes formulas.",
+    "openQuestions": [
+      "Derive the quantitative bound |∫ₐᵇ f − (b-a)/2·(f a + f b)| ≤ (b-a)³/12·M from the kernel identity, by computing ∫ₐᵇ |K| = (b-a)³/12 and applying it to a sup bound |f''| ≤ M on [a,b].",
+      "Formalize the composite trapezoidal rule on a uniform partition and sum the per-panel kernel identities to obtain the global O(h²) error, the form actually used in numerical practice.",
+      "Carry the same Peano-kernel template to Simpson's rule: a degree-3 kernel that annihilates cubics yields the exact ∫ₐᵇ f − Simpson(f) = ∫ₐᵇ K₄·f⁽⁴⁾ identity and the O(h⁴) bound, the OQ-04 open question's Simpson half."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "mean-value-theorem-oq-04",
+      "relationship": "extends",
+      "description": "The parent entry (Fundamental Theorem of Calculus via MVT structure) asks in its open questions whether Mathlib's intervalIntegral framework supports a verified trapezoidal/Simpson quadrature error analysis with O(h²)/O(h⁴) bounds. This entry answers the trapezoidal half by establishing the exact Peano-kernel error identity, the foundation of the O(h²) bound."
+    },
+    {
+      "targetId": "mean-value-theorem",
+      "relationship": "related",
+      "description": "The ordinary Mean Value Theorem underlies the classical ξ-form of the trapezoidal error, ∫ₐᵇ f − T = −(b-a)³/12·f''(ξ). The Peano-kernel identity proved here is the exact, ξ-free statement from which that form is recovered via the mean value theorem for integrals applied to the sign-definite kernel."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "intervalIntegral",
+      "MeasureTheory",
+      "Set"
+    ],
+    "namespace": "TrapezoidalPeanoKernel",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/MeanValueTheoremOQ04OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/mean-value-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/mean-value-theorem-oq-04-oq-03.json
@@ -1,0 +1,28 @@
+{
+  "id": "mean-value-theorem-oq-04-oq-03",
+  "title": "Trapezoidal Rule Error Bound via the Peano Kernel",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "progressSummary": "COMPLETE: exact Peano-kernel trapezoidal error identity verified (0-axiom, 0-sorry), plus convex/concave sign corollaries. Answers parent OQ-04's trapezoidal-quadrature open question.",
+    "insights": [
+      "The trapezoidal error ∫f − (b-a)/2(f a + f b) equals exactly ∫ K·f'' with Peano kernel K(x)=(x-a)(x-b)/2 — an exact equality, no intermediate ξ, stronger than the MVT ξ-form.",
+      "Two integrations by parts suffice: K(a)=K(b)=0 kills the first boundary term; K'(a)=-(b-a)/2, K'(b)=(b-a)/2 reproduce the trapezoidal weights in the second.",
+      "K ≤ 0 on [a,b] gives the convexity sign for free: convex f overestimated, concave f underestimated by the trapezoid rule.",
+      "A global C² hypothesis (HasDerivAt everywhere + Continuous f'') discharges every ContinuousOn / IntervalIntegrable side condition of Mathlib's IBP lemma immediately."
+    ],
+    "builtItems": [
+      "trapezoidal_peano_kernel in Proofs/MeanValueTheoremOQ04OQ03.lean — exact error identity",
+      "trapezoid_overestimates_of_convex / trapezoid_underestimates_of_concave — sign corollaries",
+      "hasDerivAt_kernel, hasDerivAt_kernelDeriv, kernel_nonpos — supporting lemmas"
+    ],
+    "mathlibGaps": [
+      "Mathlib has integration by parts and intervalIntegral but no trapezoidal/Simpson quadrature error identity."
+    ],
+    "nextSteps": [
+      "Derive |error| ≤ (b-a)^3/12·M from the identity by computing ∫|K| = (b-a)^3/12.",
+      "Composite trapezoidal rule: sum per-panel identities for the global O(h^2) bound.",
+      "Simpson's rule via a degree-3 Peano kernel for the O(h^4) bound (parent OQ-04 Simpson half)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **trapezoidal-quadrature open question** of the parent entry `mean-value-theorem-oq-04` (*Fundamental Theorem of Calculus via MVT Structure*), which asks whether Mathlib's `intervalIntegral` framework supports a verified trapezoidal-rule error analysis. Mathlib has integration by parts but **no trapezoidal-rule error identity**; this entry supplies the exact Peano-kernel form.

For a `C²` function `f : ℝ → ℝ`, the error of the trapezoidal rule `T(a,b) = (b-a)/2·(f a + f b)` is given **exactly** by an integral against the Peano kernel `K(x) = (x-a)(x-b)/2`:

> `∫ₐᵇ ((x-a)(x-b)/2)·f''(x) dx = ∫ₐᵇ f(x) dx − (b-a)/2·(f a + f b)`

This is an exact equality — no mean value theorem and no intermediate `ξ` — the starting point of every quantitative trapezoidal bound.

## Mathematical content

- **`trapezoidal_peano_kernel`** — the exact error identity, proved by integrating the kernel integral **by parts twice** (`intervalIntegral.integral_mul_deriv_eq_deriv_mul_of_hasDerivAt`). The kernel vanishes at both endpoints (`K(a)=K(b)=0`), killing the first boundary term; its derivative `K'(a)=-(b-a)/2`, `K'(b)=(b-a)/2` reproduces the quadrature weights in the second.
- **`trapezoid_overestimates_of_convex`** — since `K ≤ 0` on `[a,b]`, a convex integrand (`f'' ≥ 0`) is **over**estimated: `∫ₐᵇ f ≤ (b-a)/2·(f a + f b)`.
- **`trapezoid_underestimates_of_concave`** — the concave mirror image.
- Supporting: `hasDerivAt_kernel`, `hasDerivAt_kernelDeriv`, `kernel_nonpos`.

## Verification

- **7 theorems/lemmas, 0 definitions, 0 sorries, 0 axioms** beyond Lean's foundational `propext` / `Classical.choice` / `Quot.sound`.
- `#print axioms` on all three headline theorems reports exactly those three foundational axioms.
- Builds against Mathlib v4.26.0.

Hypotheses: a global `C²` assumption on `f` (`∀ x, HasDerivAt f (f' x) x`, `∀ x, HasDerivAt f' (f'' x) x`, `Continuous f''`), which makes every regularity side condition immediate; the sign corollaries additionally assume `a ≤ b` and a one-sided bound on `f''` over `Set.Icc a b`. The exact identity itself uses no ordering of `a` and `b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)