### PR TITLE
Enrich The Reals Are Uncountable (cantor-diagonalization-oq-06)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-06/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06/annotations.json
@@ -2,34 +2,73 @@
   {
     "id": "cantoroq06-header",
     "proofId": "cantor-diagonalization-oq-06",
-    "range": {
-      "startLine": 1,
-      "endLine": 22
-    },
+    "range": { "startLine": 1, "endLine": 22 },
     "type": "concept",
     "title": "Module Header and Problem Setup",
-    "content": "The open question asks for $\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$ (equivalently, no surjection $\\mathbb{N} \\to \\mathbb{R}$). Cantor's 1874 result, sharpened by the 1891 diagonal argument, is formalized in Mathlib via the binary-expansion injection $\\{0,1\\}^{\\mathbb{N}} \\hookrightarrow \\mathbb{R}$, giving $\\#\\mathbb{R} = 2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$."
+    "content": "The open question asks for ¬ Countable ℝ (equivalently, no surjection ℕ → ℝ). Cantor's 1874 result, sharpened by the 1891 diagonal argument, is formalized in Mathlib via the binary-expansion injection {0,1}^ℕ ↪ ℝ, giving #ℝ = 2^ℵ₀ = 𝔠 > ℵ₀. This entry lifts Mathlib's Set.univ-level statement to the type level, derives the enumeration form, and records the continuum cardinality.",
+    "mathContext": "$\\#\\mathbb{R} = 2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$, so the reals form a strictly larger infinity than the naturals.",
+    "significance": "context",
+    "relatedConcepts": ["Cantor's diagonal argument", "binary expansion", "continuum 𝔠", "cardinal exponentiation"],
+    "prerequisites": ["cardinality", "countable vs. uncountable sets"]
   },
   {
-    "id": "cantoroq06-uncountable",
+    "id": "cantoroq06-univ",
     "proofId": "cantor-diagonalization-oq-06",
-    "range": {
-      "startLine": 23,
-      "endLine": 44
-    },
-    "type": "theorem",
-    "title": "Uncountability of ℝ",
-    "content": "`not_countable_univ_real` re-exports Mathlib's `Cardinal.not_countable_real` (about `Set.univ`). `not_countable_real` lifts it to the type level via `Set.countable_univ_iff`, giving $\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$ as the open question requests; `uncountable_real` packages the `Uncountable ℝ` instance. `not_surjective_nat_real` is the enumeration form — Cantor's original statement — proved by noting a surjection from the countable naturals would force ℝ countable (`Function.Surjective.countable`)."
+    "range": { "startLine": 24, "endLine": 26 },
+    "type": "context",
+    "title": "Mathlib's set-level statement",
+    "content": "not_countable_univ_real re-exports Mathlib's Cardinal.not_countable_real, which states that the universal set of reals is not countable. Mathlib phrases uncountability at the level of Set.univ rather than the type ℝ; this re-export names the starting point everything else is built from.",
+    "mathContext": "$\\neg\\,(\\mathrm{Set.univ} : \\mathrm{Set}\\,\\mathbb{R}).\\mathrm{Countable}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.Countable", "Cardinal.not_countable_real"],
+    "prerequisites": ["Set.Countable in Mathlib"]
   },
   {
-    "id": "cantoroq06-cardinality",
+    "id": "cantoroq06-typelevel",
     "proofId": "cantor-diagonalization-oq-06",
-    "range": {
-      "startLine": 46,
-      "endLine": 52
-    },
+    "range": { "startLine": 28, "endLine": 35 },
+    "type": "technique",
+    "title": "Lifting to the type level",
+    "content": "not_countable_real converts the Set.univ statement into the type-level ¬ Countable ℝ that the open question asks for, using Set.countable_univ_iff (the bridge (Set.univ).Countable ↔ Countable α). uncountable_real then packages the Uncountable ℝ typeclass instance via Set.not_countable_univ_iff. The subtlety here is purely organizational — set-level vs. type-level countability — but it is exactly what makes ℝ usable with the Uncountable typeclass downstream.",
+    "mathContext": "$(\\mathrm{Set.univ}).\\mathrm{Countable} \\iff \\mathrm{Countable}\\,\\alpha$, hence $\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$ and the $\\mathrm{Uncountable}\\,\\mathbb{R}$ instance.",
+    "significance": "key",
+    "relatedConcepts": ["Set.countable_univ_iff", "Countable typeclass", "Uncountable typeclass"],
+    "prerequisites": ["typeclass vs. predicate formulations", "Set.Countable"]
+  },
+  {
+    "id": "cantoroq06-nosurj",
+    "proofId": "cantor-diagonalization-oq-06",
+    "range": { "startLine": 37, "endLine": 41 },
+    "type": "insight",
+    "title": "The enumeration form — Cantor's original statement",
+    "content": "not_surjective_nat_real says no function f : ℕ → ℝ is surjective — Cantor's theorem in the 1874 dress that the reals cannot be listed. The proof is a one-liner: if f were surjective, hf.countable (Function.Surjective.countable) would make ℝ countable, contradicting not_countable_real. This is the form that most directly captures 'you cannot enumerate the reals', and the diagonal construction is what classically witnesses the missing real.",
+    "mathContext": "For every $f : \\mathbb{N} \\to \\mathbb{R}$, $\\neg\\,\\mathrm{Surjective}\\,f$; a surjection from a countable domain would force the codomain countable.",
+    "significance": "key",
+    "relatedConcepts": ["Function.Surjective.countable", "enumeration", "diagonal argument"],
+    "prerequisites": ["surjections and cardinality"]
+  },
+  {
+    "id": "cantoroq06-mkreal",
+    "proofId": "cantor-diagonalization-oq-06",
+    "range": { "startLine": 43, "endLine": 45 },
     "type": "theorem",
-    "title": "Continuum Cardinality",
-    "content": "`mk_real_eq_continuum` records $\\#\\mathbb{R} = \\mathfrak{c}$ (Mathlib's `Cardinal.mk_real`), and `aleph0_lt_mk_real` gives $\\aleph_0 < \\#\\mathbb{R}$ via `Cardinal.aleph0_lt_continuum` — the quantitative form of uncountability, exhibiting ℝ as a strictly larger infinity than ℕ."
+    "title": "Cardinality of the continuum",
+    "content": "mk_real_eq_continuum records #ℝ = 𝔠 (Mathlib's Cardinal.mk_real). The continuum cardinal 𝔠 is defined as 2^ℵ₀, so this identity is precisely the bridge between 'the reals' and Cantor's powerset cardinal 2^ℵ₀ = #𝒫(ℕ). It upgrades the qualitative 'uncountable' to a specific named cardinal.",
+    "mathContext": "$\\#\\mathbb{R} = \\mathfrak{c} = 2^{\\aleph_0} = \\#\\mathcal{P}(\\mathbb{N})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cardinal.mk_real", "continuum 𝔠", "powerset cardinality"],
+    "prerequisites": ["cardinal arithmetic", "definition of 𝔠"]
+  },
+  {
+    "id": "cantoroq06-aleph0lt",
+    "proofId": "cantor-diagonalization-oq-06",
+    "range": { "startLine": 47, "endLine": 52 },
+    "type": "theorem",
+    "title": "The quantitative inequality ℵ₀ < #ℝ",
+    "content": "aleph0_lt_mk_real gives ℵ₀ < #ℝ by rewriting with mk_real_eq_continuum and invoking Cardinal.aleph0_lt_continuum. This is the sharpest statement of uncountability: not merely '#ℝ ≠ ℵ₀' but a strict order in the cardinal hierarchy, exhibiting ℝ as a genuinely larger infinity. It is Cantor's theorem #A < #𝒫(A) specialized to A = ℕ.",
+    "mathContext": "$\\aleph_0 < \\#\\mathbb{R} = \\mathfrak{c}$ — strict inequality of cardinals, the instance of $\\#A < \\#\\mathcal{P}(A)$ at $A = \\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.aleph0_lt_continuum", "Cantor's theorem", "cardinal hierarchy"],
+    "prerequisites": ["strict cardinal inequality", "ℵ₀ and 𝔠"]
   }
 ]

--- a/src/data/proofs/cantor-diagonalization-oq-06/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-06/meta.json
@@ -65,7 +65,9 @@
     "keyInsights": [
       "**Uncountability is a cardinal inequality.** ¬ Countable ℝ is exactly ℵ₀ < #ℝ; since #ℝ = 2^ℵ₀, this is Cantor's theorem #A < #𝒫(A) at A = ℕ.",
       "**Set-level vs. type-level countability.** Mathlib states uncountability for Set.univ; `Set.countable_univ_iff` is the bridge to the type-level `Countable ℝ` the open question asks for.",
-      "**Enumeration form is a corollary.** 'No surjection ℕ → ℝ' is the diagonal statement in its original 1874 dress, immediate from countability being preserved under surjections from ℕ."
+      "**Enumeration form is a corollary.** 'No surjection ℕ → ℝ' is the diagonal statement in its original 1874 dress, immediate from countability being preserved under surjections from ℕ.",
+      "**The diagonal argument is what makes #ℝ = 2^ℵ₀.** Mathlib's route is not an evasion of diagonalization: the binary-expansion injection {0,1}^ℕ ↪ ℝ is precisely the encoding under which Cantor's diagonal real (flip the n-th binary digit) witnesses the missing element, so the cardinal identity #ℝ = 𝔠 carries the diagonal content.",
+      "**Uncountability is robust across formulations.** The same fact appears here in four guises — ¬ Countable ℝ, the Uncountable instance, 'no surjection ℕ → ℝ', and ℵ₀ < #ℝ — each the most convenient handle for a different downstream use (typeclass resolution, contradiction proofs, cardinal arithmetic). Collecting them is what makes the entry reusable rather than a single isolated lemma."
     ],
     "prerequisites": [
       "Cardinal arithmetic in Mathlib (Cardinal.mk, ℵ₀, 𝔠)",
@@ -83,19 +85,35 @@
       "mathContext": "Cantor's diagonal argument: the reals are uncountable because $\\#\\mathbb{R} = 2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$."
     },
     {
-      "id": "uncountable",
-      "title": "Uncountability of ℝ",
-      "startLine": 23,
-      "endLine": 44,
-      "summary": "not_countable_univ_real (re-export), not_countable_real (type-level, via Set.countable_univ_iff), uncountable_real (the Uncountable typeclass), and not_surjective_nat_real (no surjection ℕ → ℝ).",
-      "mathContext": "$\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$, and equivalently no surjection $\\mathbb{N} \\to \\mathbb{R}$."
+      "id": "set-level",
+      "title": "Mathlib's Set-Level Statement",
+      "startLine": 24,
+      "endLine": 26,
+      "summary": "not_countable_univ_real re-exports Cardinal.not_countable_real, the starting point: the universal set of reals is not countable.",
+      "mathContext": "$\\neg\\,(\\mathrm{Set.univ} : \\mathrm{Set}\\,\\mathbb{R}).\\mathrm{Countable}$."
+    },
+    {
+      "id": "type-level",
+      "title": "Lifting to the Type Level",
+      "startLine": 28,
+      "endLine": 35,
+      "summary": "not_countable_real lifts the Set.univ statement to ¬ Countable ℝ via Set.countable_univ_iff; uncountable_real packages the Uncountable ℝ typeclass instance.",
+      "mathContext": "$\\neg\\,\\mathrm{Countable}\\,\\mathbb{R}$ and the $\\mathrm{Uncountable}\\,\\mathbb{R}$ instance."
+    },
+    {
+      "id": "no-surjection",
+      "title": "Enumeration Form: No Surjection ℕ → ℝ",
+      "startLine": 37,
+      "endLine": 41,
+      "summary": "not_surjective_nat_real — Cantor's original 1874 statement that the reals cannot be listed, a one-line corollary of not_countable_real via Function.Surjective.countable.",
+      "mathContext": "For every $f : \\mathbb{N} \\to \\mathbb{R}$, $\\neg\\,\\mathrm{Surjective}\\,f$."
     },
     {
       "id": "cardinality",
       "title": "Continuum Cardinality",
-      "startLine": 46,
+      "startLine": 43,
       "endLine": 52,
-      "summary": "mk_real_eq_continuum (#ℝ = 𝔠) and aleph0_lt_mk_real (ℵ₀ < #ℝ), the quantitative form of uncountability.",
+      "summary": "mk_real_eq_continuum (#ℝ = 𝔠) and aleph0_lt_mk_real (ℵ₀ < #ℝ), the quantitative form of uncountability — Cantor's theorem at A = ℕ.",
       "mathContext": "$\\#\\mathbb{R} = \\mathfrak{c}$ and $\\aleph_0 < \\#\\mathbb{R}$."
     }
   ],


### PR DESCRIPTION
Enrichment pass for **cantor-diagonalization-oq-06**. Quality score 52 → 100.

## Quality improvements
- **Annotations 3 → 6, all fields added.** The originals had only `content`; each now carries `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. Split into finer units tracking the proof: header, Mathlib's set-level statement, the type-level lift, the no-surjection enumeration form, `#ℝ = 𝔠`, and `ℵ₀ < #ℝ`.
- **Sections 3 → 5.** One section per theorem group so the whole 52-line file is covered at theorem granularity.
- **keyInsights 3 → 5.** Added: (a) the binary-expansion injection carries the diagonal content, so `#ℝ = 2^ℵ₀` is not an evasion of diagonalization; (b) the four equivalent formulations each serve a distinct downstream use, which is what makes the entry reusable.

## Notes
- Axiom integrity verified: `status: verified`, `badge: mathlib`, `axiomCount: 0` match the Lean source (0 sorries, no `axiom` declarations, no assumption-carrying structures; entry honestly routes through `Cardinal.not_countable_real`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)