### PR TITLE
research(erdos-985): repair broken file + verified primitive-root infrastructure [axiomatized, 0-sorry]

### DIFF
--- a/proofs/Proofs/Erdos985Problem.lean
+++ b/proofs/Proofs/Erdos985Problem.lean
@@ -41,82 +41,119 @@ def primesWithPrimePrimitiveRoot : Set ℕ :=
 
 /- ## Basic Properties of Primitive Roots -/
 
-/-- For any prime p > 2, there exists at least one primitive root modulo p.
-    This follows from the fact that (ℤ/pℤ)× is cyclic. -/
-/-- The multiplicative group of a finite field is cyclic.
+/-- The multiplicative group `(ℤ/pℤ)ˣ` of a finite prime field is cyclic.
     Proved via Mathlib's instance for finite fields. -/
 theorem zmod_units_cyclic (p : ℕ) (hp : p.Prime) :
     IsCyclic (ZMod p)ˣ := by
   haveI : Fact p.Prime := ⟨hp⟩
   infer_instance
 
-/- ## Small Prime Examples -/
+/-- **Every prime `p` has a primitive root in the range `0 < g < p`.**
 
-/-- Example: 2 is a primitive root modulo 3.
-    ord_3(2) = 2 = 3 - 1. -/
-theorem primitiveRoot_2_mod_3 : orderOf (2 : ZMod 3) = 2 := by native_decide
+    This is the *unconditional* counterpart of Erdős 985: the existence of a
+    primitive root below `p` is automatic, because `(ℤ/pℤ)ˣ` is cyclic of order
+    `p - 1`, so a generator exists and its canonical representative lies in
+    `{1, …, p-1}`. The entire difficulty of Erdős 985 is therefore concentrated
+    in the single extra requirement that the witness `g` be **prime** — this
+    theorem strips that requirement away and shows the rest is free.
 
-/-- Example: 2 is a primitive root modulo 5.
-    ord_5(2) = 4 = 5 - 1. -/
-theorem primitiveRoot_2_mod_5 : orderOf (2 : ZMod 5) = 4 := by native_decide
+    Proof: take a generator `u` of `(ℤ/pℤ)ˣ` (cyclicity), so `orderOf u = p - 1`
+    by `orderOf_eq_card_of_forall_mem_zpowers` together with `ZMod.card_units`.
+    Its underlying value `g := (u : ZMod p).val` satisfies `0 < g < p` (it is a
+    unit, hence nonzero, and `val < p`), and
+    `orderOf (g : ZMod p) = orderOf u = p - 1` via `orderOf_units`. -/
+theorem exists_primitiveRoot_lt (p : ℕ) (hp : p.Prime) :
+    ∃ g : ℕ, 0 < g ∧ g < p ∧ orderOf (g : ZMod p) = p - 1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  obtain ⟨u, hu⟩ := IsCyclic.exists_generator (α := (ZMod p)ˣ)
+  have hord : orderOf u = p - 1 := by
+    rw [orderOf_eq_card_of_forall_mem_zpowers hu, Nat.card_eq_fintype_card,
+      ZMod.card_units p]
+  set g : ℕ := (u : ZMod p).val with hg
+  have hcast : (g : ZMod p) = (u : ZMod p) := by rw [hg, ZMod.natCast_zmod_val]
+  refine ⟨g, ?_, ZMod.val_lt _, ?_⟩
+  · have hne : (g : ZMod p) ≠ 0 := by rw [hcast]; exact u.ne_zero
+    refine Nat.pos_of_ne_zero (fun h0 => hne ?_)
+    rw [h0, Nat.cast_zero]
+  · rw [hcast, orderOf_units, hord]
 
-/-- Example: 3 is a primitive root modulo 7.
-    ord_7(3) = 6 = 7 - 1. -/
-theorem primitiveRoot_3_mod_7 : orderOf (3 : ZMod 7) = 6 := by native_decide
+/- ## Small Prime Examples
 
-/-- Example: 2 is NOT a primitive root modulo 7.
-    ord_7(2) = 3 ≠ 6. -/
-theorem not_primitiveRoot_2_mod_7 : orderOf (2 : ZMod 7) ≠ 6 := by native_decide
+   The multiplicative order of a concrete element is *not* evaluable by
+   `decide`/`native_decide` (Mathlib's `orderOf` carries no executable code).
+   Instead we rewrite with `orderOf_eq_iff`, which reduces `orderOf x = n` to
+   the *bounded*, decidable claim `x ^ n = 1 ∧ ∀ m < n, 0 < m → x ^ m ≠ 1`;
+   powers in `ZMod p` are computable, so `decide` closes each goal. -/
 
-/-- Example: 3 is a primitive root modulo 11.
-    ord_11(3) = 10 = 11 - 1. This means 3 generates (ℤ/11ℤ)×. -/
-theorem primitiveRoot_3_mod_11 : orderOf (3 : ZMod 11) = 10 := by native_decide
+/-- Example: 2 is a primitive root modulo 3.  ord_3(2) = 2 = 3 - 1. -/
+theorem primitiveRoot_2_mod_3 : orderOf (2 : ZMod 3) = 2 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
 
-/-- Example: 2 is a primitive root modulo 11.
-    ord_11(2) = 10 = 11 - 1. -/
-theorem primitiveRoot_2_mod_11 : orderOf (2 : ZMod 11) = 10 := by native_decide
+/-- Example: 2 is a primitive root modulo 5.  ord_5(2) = 4 = 5 - 1. -/
+theorem primitiveRoot_2_mod_5 : orderOf (2 : ZMod 5) = 4 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
 
-/-- Example: 2 is a primitive root modulo 13.
-    ord_13(2) = 12 = 13 - 1. -/
-theorem primitiveRoot_2_mod_13 : orderOf (2 : ZMod 13) = 12 := by native_decide
+/-- Example: 3 is a primitive root modulo 7.  ord_7(3) = 6 = 7 - 1. -/
+theorem primitiveRoot_3_mod_7 : orderOf (3 : ZMod 7) = 6 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
 
-/-- Example: 5 is a primitive root modulo 23.
-    ord_23(5) = 22 = 23 - 1. -/
-theorem primitiveRoot_5_mod_23 : orderOf (5 : ZMod 23) = 22 := by native_decide
+/-- Example: 2 is NOT a primitive root modulo 7.  ord_7(2) = 3 ≠ 6. -/
+theorem not_primitiveRoot_2_mod_7 : orderOf (2 : ZMod 7) ≠ 6 := by
+  have h : orderOf (2 : ZMod 7) = 3 := by rw [orderOf_eq_iff (by norm_num)]; decide
+  omega
+
+/-- Example: 3 is **not** a primitive root modulo 11: ord_11(3) = 5 ≠ 10,
+    since 3^5 = 1 (mod 11). This illustrates exactly the subtlety of Erdős 985 —
+    not every prime `q < p` is a primitive root, so finding a *prime* witness
+    is a genuine constraint. (Here 2 works instead; see the next lemma.) -/
+theorem orderOf_3_mod_11 : orderOf (3 : ZMod 11) = 5 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
+
+/-- Example: 2 is a primitive root modulo 11.  ord_11(2) = 10 = 11 - 1. -/
+theorem primitiveRoot_2_mod_11 : orderOf (2 : ZMod 11) = 10 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
+
+/-- Example: 2 is a primitive root modulo 13.  ord_13(2) = 12 = 13 - 1. -/
+theorem primitiveRoot_2_mod_13 : orderOf (2 : ZMod 13) = 12 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
+
+/-- Example: 5 is a primitive root modulo 23.  ord_23(5) = 22 = 23 - 1. -/
+theorem primitiveRoot_5_mod_23 : orderOf (5 : ZMod 23) = 22 := by
+  rw [orderOf_eq_iff (by norm_num)]; decide
 
 /- ## Verification of Erdős Conjecture for Small Primes -/
 
 /-- For p = 3: q = 2 is a prime primitive root (ord_3(2) = 2). -/
-theorem erdos985_for_3 : ∃ q, q.Prime ∧ q < 3 ∧ orderOf (q : ZMod 3) = 2 :=
-  ⟨2, Nat.prime_two, by norm_num, primitiveRoot_2_mod_3⟩
+theorem erdos985_for_3 : ∃ q : ℕ, q.Prime ∧ q < 3 ∧ orderOf (q : ZMod 3) = 2 :=
+  ⟨2, Nat.prime_two, by norm_num, by rw [orderOf_eq_iff (by norm_num)]; decide⟩
 
 /-- For p = 5: q = 2 is a prime primitive root (ord_5(2) = 4). -/
-theorem erdos985_for_5 : ∃ q, q.Prime ∧ q < 5 ∧ orderOf (q : ZMod 5) = 4 :=
-  ⟨2, Nat.prime_two, by norm_num, primitiveRoot_2_mod_5⟩
+theorem erdos985_for_5 : ∃ q : ℕ, q.Prime ∧ q < 5 ∧ orderOf (q : ZMod 5) = 4 :=
+  ⟨2, Nat.prime_two, by norm_num, by rw [orderOf_eq_iff (by norm_num)]; decide⟩
 
 /-- For p = 7: q = 3 is a prime primitive root (ord_7(3) = 6). -/
-theorem erdos985_for_7 : ∃ q, q.Prime ∧ q < 7 ∧ orderOf (q : ZMod 7) = 6 :=
-  ⟨3, Nat.prime_three, by norm_num, primitiveRoot_3_mod_7⟩
+theorem erdos985_for_7 : ∃ q : ℕ, q.Prime ∧ q < 7 ∧ orderOf (q : ZMod 7) = 6 :=
+  ⟨3, Nat.prime_three, by norm_num, by rw [orderOf_eq_iff (by norm_num)]; decide⟩
 
 /-- For p = 11: q = 2 is a prime primitive root (ord_11(2) = 10). -/
-theorem erdos985_for_11 : ∃ q, q.Prime ∧ q < 11 ∧ orderOf (q : ZMod 11) = 10 :=
-  ⟨2, Nat.prime_two, by norm_num, primitiveRoot_2_mod_11⟩
+theorem erdos985_for_11 : ∃ q : ℕ, q.Prime ∧ q < 11 ∧ orderOf (q : ZMod 11) = 10 :=
+  ⟨2, Nat.prime_two, by norm_num, by rw [orderOf_eq_iff (by norm_num)]; decide⟩
 
 /-- For p = 13: q = 2 is a prime primitive root (ord_13(2) = 12). -/
-theorem erdos985_for_13 : ∃ q, q.Prime ∧ q < 13 ∧ orderOf (q : ZMod 13) = 12 :=
-  ⟨2, Nat.prime_two, by norm_num, primitiveRoot_2_mod_13⟩
+theorem erdos985_for_13 : ∃ q : ℕ, q.Prime ∧ q < 13 ∧ orderOf (q : ZMod 13) = 12 :=
+  ⟨2, Nat.prime_two, by norm_num, by rw [orderOf_eq_iff (by norm_num)]; decide⟩
 
 /-- For p = 23: q = 5 is a prime primitive root (ord_23(5) = 22). -/
-theorem erdos985_for_23 : ∃ q, q.Prime ∧ q < 23 ∧ orderOf (q : ZMod 23) = 22 :=
-  ⟨5, by decide, by norm_num, primitiveRoot_5_mod_23⟩
+theorem erdos985_for_23 : ∃ q : ℕ, q.Prime ∧ q < 23 ∧ orderOf (q : ZMod 23) = 22 :=
+  ⟨5, by decide, by norm_num, by rw [orderOf_eq_iff (by norm_num)]; decide⟩
 
 /- ## Artin's Conjecture and Related Results -/
 
-/-- Artin's Conjecture (1927): For any integer a ≠ -1, 0, 1 that is not a
-    perfect square, there are infinitely many primes p for which a is a
-    primitive root modulo p.
+/- Artin's Conjecture (1927): For any integer a ≠ -1, 0, 1 that is not a
+   perfect square, there are infinitely many primes p for which a is a
+   primitive root modulo p.  This is still open unconditionally, but Hooley
+   proved it assuming GRH. -/
 
-    This is still open unconditionally, but Hooley proved it assuming GRH. -/
 /-- Heath-Brown's Theorem (1986): At least one of 2, 3, or 5 is a primitive
     root for infinitely many primes. This is an unconditional result. -/
 axiom heath_brown_theorem :
@@ -133,8 +170,9 @@ axiom heath_brown_theorem :
     Status: OPEN
 
     This is a stronger statement than asking whether there exists ANY
-    primitive root less than p (which is always true). Erdős asks
-    specifically for a PRIME primitive root.
+    primitive root less than p (which is always true, see
+    `exists_primitiveRoot_lt`). Erdős asks specifically for a PRIME primitive
+    root.
 
     The conjecture has been verified computationally for small primes,
     but a proof or counterexample remains elusive. -/
@@ -170,28 +208,62 @@ theorem erdos_985_iff_all_odd_primes :
 
 /- ## Density Considerations -/
 
-/-- Among the primitive roots modulo p, the proportion that are prime
-    is roughly 1/log(p) by the prime number theorem. Since there are
-    φ(p-1) primitive roots among 1,...,p-1, we expect roughly
-    φ(p-1)/log(p) prime primitive roots.
+/- Among the primitive roots modulo p, the proportion that are prime is roughly
+   1/log(p) by the prime number theorem. Since there are φ(p-1) primitive roots
+   among 1,...,p-1, we expect roughly φ(p-1)/log(p) prime primitive roots. For p
+   large enough, this is > 0, suggesting the conjecture should hold. -/
 
-    For p large enough, this is > 0, suggesting the conjecture should hold. -/
 /- ## Connection to Other Problems -/
 
-/-- If Artin's conjecture holds for all primes q, then Erdős 985 follows.
-    Indeed, by Artin, each prime q < p is a primitive root for infinitely
-    many primes. For large enough p, at least one prime q < p must be
-    a primitive root modulo p. -/
-theorem artin_implies_erdos_985 :
-    (∀ q, q.Prime → Set.Infinite {p : ℕ | p.Prime ∧ orderOf (q : ZMod p) = p - 1}) →
-    ∀ p, p.Prime → p ≠ 2 → ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1 := by
-  intro h_artin p hp hp2
-  -- Deriving Erdős 985 from Artin's conjecture requires a quantitative step:
-  -- the Artin hypothesis gives infinitely many p' for which each prime q is a
-  -- primitive root, but we need to find such a prime q < p specifically for p.
-  -- This gap requires a Linnik-type upper bound (smallest p' ≤ f(q)) and is
-  -- not yet formalized here.
-  sorry
+/- **Caveat on Artin's conjecture.** It is tempting to claim that the
+   *qualitative* Artin conjecture — "each prime `q` is a primitive root for
+   infinitely many primes `p`" — implies Erdős 985. It does **not**: knowing
+   that each fixed `q` is a primitive root for infinitely many `p` says nothing
+   about whether *some* prime `q < p` is a primitive root for a *given* `p`.
+   Bridging that gap requires an *effective* (Linnik-type) version of Artin
+   bounding the least such `p` in terms of `q`, which is not available
+   unconditionally. We therefore do **not** state a spurious
+   `artin_implies_erdos_985`; instead we extract the genuine unconditional
+   consequence of Heath-Brown's theorem below. -/
+
+/-- A prime `q ∈ {2, 3, 5}` that is a primitive root modulo `p` (with `p > 5`,
+    so that `q < p`) witnesses Erdős 985 at `p`. This is the elementary engine
+    that turns Heath-Brown's `{2, 3, 5}` covering into actual cases of Erdős
+    985. -/
+theorem erdos985_of_heathBrown_witness (p : ℕ) (_hp : p.Prime) (hp5 : 5 < p)
+    (h : orderOf (2 : ZMod p) = p - 1 ∨ orderOf (3 : ZMod p) = p - 1 ∨
+         orderOf (5 : ZMod p) = p - 1) :
+    ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1 := by
+  rcases h with h2 | h3 | h5
+  · exact ⟨2, Nat.prime_two, by omega, h2⟩
+  · exact ⟨3, Nat.prime_three, by omega, h3⟩
+  · exact ⟨5, by decide, by omega, h5⟩
+
+/-- **Heath-Brown's theorem yields infinitely many primes satisfying Erdős 985.**
+
+    For every prime `p > 5` in the Heath-Brown set, one of `2, 3, 5` is a prime
+    primitive root below `p`, so Erdős 985 holds at `p`. Since the Heath-Brown
+    set is infinite and we discard only the finitely many primes `≤ 5`, the set
+    of primes confirmed to satisfy Erdős 985 is itself infinite.
+
+    This is the honest unconditional progress available toward Erdős 985: not a
+    proof of the full conjecture (which remains the axiom `erdos_985_conjecture`),
+    but a verified derivation of infinitely many of its instances from the
+    Heath-Brown axiom alone. -/
+theorem infinitely_many_erdos985_primes :
+    Set.Infinite {p : ℕ | p.Prime ∧
+      ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1} := by
+  have hHB := heath_brown_theorem
+  have hsub :
+      ({p : ℕ | p.Prime ∧
+          (orderOf (2 : ZMod p) = p - 1 ∨ orderOf (3 : ZMod p) = p - 1 ∨
+           orderOf (5 : ZMod p) = p - 1)} \ {p : ℕ | p ≤ 5})
+        ⊆ {p : ℕ | p.Prime ∧
+            ∃ q, q.Prime ∧ q < p ∧ orderOf (q : ZMod p) = p - 1} := by
+    rintro p ⟨⟨hp, hcov⟩, hle⟩
+    simp only [Set.mem_setOf_eq, not_le] at hle ⊢
+    exact ⟨hp, erdos985_of_heathBrown_witness p hp hle hcov⟩
+  exact Set.Infinite.mono hsub (hHB.diff (Set.finite_le_nat 5))
 
 /- ## Summary -/
 
@@ -206,16 +278,17 @@ theorem artin_implies_erdos_985 :
 
     **Related Results**:
     - Artin's Conjecture (conditional on GRH via Hooley)
-    - Heath-Brown's unconditional result for {2, 3, 5}
+    - Heath-Brown's unconditional result for {2, 3, 5}, from which we derive
+      infinitely many confirmed instances (`infinitely_many_erdos985_primes`)
 
     **Heuristic**: Should be true based on prime number theorem estimates -/
 theorem erdos_985_summary :
     -- Verified for several small primes
-    (∃ q, q.Prime ∧ q < 3 ∧ orderOf (q : ZMod 3) = 2) ∧
-    (∃ q, q.Prime ∧ q < 5 ∧ orderOf (q : ZMod 5) = 4) ∧
-    (∃ q, q.Prime ∧ q < 7 ∧ orderOf (q : ZMod 7) = 6) ∧
-    (∃ q, q.Prime ∧ q < 11 ∧ orderOf (q : ZMod 11) = 10) ∧
-    (∃ q, q.Prime ∧ q < 13 ∧ orderOf (q : ZMod 13) = 12) ∧
+    (∃ q : ℕ, q.Prime ∧ q < 3 ∧ orderOf (q : ZMod 3) = 2) ∧
+    (∃ q : ℕ, q.Prime ∧ q < 5 ∧ orderOf (q : ZMod 5) = 4) ∧
+    (∃ q : ℕ, q.Prime ∧ q < 7 ∧ orderOf (q : ZMod 7) = 6) ∧
+    (∃ q : ℕ, q.Prime ∧ q < 11 ∧ orderOf (q : ZMod 11) = 10) ∧
+    (∃ q : ℕ, q.Prime ∧ q < 13 ∧ orderOf (q : ZMod 13) = 12) ∧
     -- Heath-Brown's result holds
     Set.Infinite {p : ℕ | p.Prime ∧
       (orderOf (2 : ZMod p) = p - 1 ∨

--- a/src/data/proofs/erdos-985/annotations.json
+++ b/src/data/proofs/erdos-985/annotations.json
@@ -166,12 +166,12 @@
     "id": "ann-e985-verified-cases",
     "proofId": "erdos-985",
     "range": {
-      "startLine": 87,
-      "endLine": 111
+      "startLine": 124,
+      "endLine": 149
     },
     "type": "concept",
     "title": "Verified Cases of Erdős 985",
-    "content": "**Computational Verification:**\n\nWe verify Erdős 985 for several small primes:\n\n| p | Prime primitive root q | Order |\n|---|------------------------|-------|\n| 3 | 2 | 2 |\n| 5 | 2 | 4 |\n| 7 | 3 | 6 |\n| 11 | 2 | 10 |\n| 13 | 2 | 12 |\n| 23 | 5 | 22 |\n\nIn each case, we find a prime q < p with ord_p(q) = p - 1.\n\nProved using `native_decide` for computational verification.",
+    "content": "**Computational Verification:**\n\nWe verify Erdős 985 for several small primes:\n\n| p | Prime primitive root q | Order |\n|---|------------------------|-------|\n| 3 | 2 | 2 |\n| 5 | 2 | 4 |\n| 7 | 3 | 6 |\n| 11 | 2 | 10 |\n| 13 | 2 | 12 |\n| 23 | 5 | 22 |\n\nIn each case we exhibit a prime q < p with ord_p(q) = p - 1.\n\n**Verification method:** the multiplicative order `orderOf` carries no executable code, so `native_decide` cannot evaluate it. We instead rewrite with `orderOf_eq_iff`, reducing `orderOf x = n` to the bounded decidable claim `x^n = 1 ∧ ∀ m < n, 0 < m → x^m ≠ 1`, which kernel `decide` closes — keeping these results free of `Lean.ofReduceBool`.",
     "significance": "key",
     "mathContext": "See annotation content for formal details of verified cases of erdős 985",
     "relatedConcepts": [
@@ -301,21 +301,21 @@
     ]
   },
   {
-    "id": "ann-e985-artin-implies",
+    "id": "ann-e985-heathbrown-consequence",
     "proofId": "erdos-985",
     "range": {
-      "startLine": 185,
-      "endLine": 198
+      "startLine": 216,
+      "endLine": 264
     },
     "type": "concept",
-    "title": "Artin Implies Erdős 985",
-    "content": "**artin_implies_erdos_985:**\n\nIf Artin's conjecture holds for all primes, then Erdős 985 follows.\n\n**Argument:**\n- Each prime q is a primitive root for infinitely many primes (by Artin)\n- Given p, at least one of the primes 2, 3, 5, ..., q_k < p must be a primitive root mod p\n- By quantitative versions of Artin, this happens for large p\n\n**Note:** The actual implication requires quantitative bounds not just infinity.",
+    "title": "Honest Consequence of Heath-Brown (not a spurious Artin reduction)",
+    "content": "**Why there is no `artin_implies_erdos_985`:**\n\nIt is tempting to claim the qualitative Artin conjecture — each prime q is a primitive root for infinitely many primes p — implies Erdős 985. It does **not**: that each fixed q works for infinitely many p says nothing about whether some prime q < p works for a *given* p. Closing that gap needs an effective (Linnik-type) bound on the least such p, unavailable unconditionally. The earlier `artin_implies_erdos_985` theorem asserted this invalid implication behind a `sorry`; it has been removed.\n\n**What we prove instead (verified):**\n- `erdos985_of_heathBrown_witness`: for p > 5, if one of 2, 3, 5 is a primitive root mod p, that q is a prime primitive root < p — so Erdős 985 holds at p.\n- `infinitely_many_erdos985_primes`: since the Heath-Brown set is infinite, infinitely many primes satisfy Erdős 985 (the only assumption is the Heath-Brown axiom).",
     "significance": "key",
     "relatedConcepts": [
       "Artin's conjecture",
       "Quantitative number theory"
     ],
-    "mathContext": "See annotation content for formal details of artin implies erdős 985",
+    "mathContext": "Heath-Brown (1986): {2,3,5} contains a primitive root for infinitely many primes. Intersecting with p > 5 keeps the set infinite (Set.Infinite.diff) and supplies a prime witness < p.",
     "prerequisites": [
       "Artin's conjecture statement",
       "erdos_985_conjecture statement",

--- a/src/data/proofs/erdos-985/meta.json
+++ b/src/data/proofs/erdos-985/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 985,
     "erdosUrl": "https://erdosproblems.com/985",
     "erdosProblemStatus": "open",
@@ -46,30 +46,33 @@
       }
     ],
     "originalContributions": [
-      "isPrimitiveRoot definition: ord_p(g) = p - 1",
-      "isPrimePrimitiveRoot definition: prime q with q < p a primitive root",
-      "primesWithPrimePrimitiveRoot set: primes having prime primitive roots",
-      "Verified examples: p = 3, 5, 7, 11, 13, 23",
-      "heath_brown_theorem axiom: {2, 3, 5} covers infinitely many primes",
+      "isPrimitiveRoot / isPrimePrimitiveRoot / primesWithPrimePrimitiveRoot definitions",
+      "exists_primitiveRoot_lt: every prime p has a primitive root g with 0<g<p (verified, 0-axiom) — isolates that the ONLY difficulty of Erdős 985 is requiring the witness to be PRIME",
+      "Verified small-prime cases p = 3,5,7,11,13,23 via orderOf_eq_iff + kernel decide (replacing broken native_decide on noncomputable orderOf)",
+      "orderOf_3_mod_11: corrected a FALSE original example — ord_11(3)=5, so 3 is NOT a primitive root mod 11 (illustrates the primality subtlety)",
+      "erdos985_of_heathBrown_witness: a prime q∈{2,3,5} that is a primitive root mod p (p>5) witnesses Erdős 985 at p",
+      "infinitely_many_erdos985_primes: derives infinitely many CONFIRMED instances of Erdős 985 from the Heath-Brown axiom (verified)",
+      "Removed the mathematically invalid artin_implies_erdos_985 (qualitative Artin does NOT imply the pointwise conclusion); replaced with an honest caveat and the genuine Heath-Brown consequence",
+      "heath_brown_theorem axiom: {2,3,5} covers infinitely many primes",
       "erdos_985_conjecture axiom: main open conjecture",
       "erdos_985_iff_all_odd_primes equivalence theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 225,
-    "assumptions": "2 axioms: heath_brown_theorem, erdos_985_conjecture. 1 sorry (in artin_implies_erdos_985, awaiting Linnik-type quantitative step).",
-    "theoremCount": 18,
+    "lineCount": 298,
+    "assumptions": "2 axioms: heath_brown_theorem (Heath-Brown 1986, unconditional) and erdos_985_conjecture (the open problem itself). 0 sorries. All non-axiom results are machine-checked over [propext, Classical.choice, Quot.sound] only — no native_decide / Lean.ofReduceBool (concrete orders use kernel `decide` via `orderOf_eq_iff`).",
+    "theoremCount": 20,
     "definitionCount": 3
   },
   "overview": {
     "historicalContext": "**Erdős Problem #985: Prime Primitive Roots**\n\nThis problem asks whether every odd prime p admits a prime primitive root less than itself.\n\n**Key History:**\n- Artin (1927): Conjectured that any non-square integer is a primitive root for infinitely many primes\n- Hooley (1967): Proved Artin's conjecture assuming the Generalized Riemann Hypothesis\n- Heath-Brown (1986): Proved unconditionally that at least one of 2, 3, or 5 is a primitive root for infinitely many primes\n\n**Mathematical Setting:**\nA primitive root modulo p is an integer g whose multiplicative order equals p - 1. This means g generates the entire multiplicative group (ℤ/pℤ)×. Erdős's question asks specifically for PRIME primitive roots, a natural but difficult restriction.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nIs it true that, for every prime p > 2, there is a prime q < p which is a primitive root modulo p?\n\n**Status: OPEN**\n\nThe conjecture has been verified computationally for many small primes, but no general proof or counterexample is known.\n\n**Related Result (Heath-Brown 1986):**\nAt least one of 2, 3, or 5 is a primitive root for infinitely many primes. This is the strongest unconditional result toward Artin's conjecture.",
     "text": "Is it true that for every prime p, there is a prime q < p which is a primitive root modulo p?",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Primitive Root Definition:** Define ord_p(g) = p - 1 using Mathlib's orderOf\n\n2. **Prime Primitive Root:** q is prime and a primitive root modulo p\n\n3. **Verified Examples:** Computationally verify the conjecture for p = 3, 5, 7, 11, 13, 23 using native_decide\n\n4. **Related Results:** Axiomatize Heath-Brown's theorem and Artin's conjecture\n\n5. **Main Conjecture:** State Erdős 985 as an axiom (open problem)\n\n6. **Connections:** Show how Artin's conjecture would imply Erdős 985",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Primitive Root Definition:** Define ord_p(g) = p - 1 using Mathlib's `orderOf`\n\n2. **Prime Primitive Root:** q is prime and a primitive root modulo p\n\n3. **Unconditional existence:** prove `exists_primitiveRoot_lt` — a primitive root always exists in {1,…,p-1} (cyclicity of (ℤ/pℤ)×), so only the *primality* of the witness is open\n\n4. **Verified examples:** confirm p = 3, 5, 7, 11, 13, 23 by rewriting with `orderOf_eq_iff` and discharging the resulting bounded goal with kernel `decide` (orderOf is not `native_decide`-able)\n\n5. **Axiomatize** Heath-Brown's theorem and state Erdős 985 itself as the open axiom\n\n6. **Honest Heath-Brown consequence:** derive infinitely many confirmed instances (`infinitely_many_erdos985_primes`); note that qualitative Artin does NOT suffice to imply the full conjecture, so no spurious `artin_implies_erdos_985` is claimed",
     "keyInsights": [
       "**Primitive Root**: An element g with ord_p(g) = p - 1 generates (ℤ/pℤ)×",
       "**Existence Guaranteed**: Every odd prime has primitive roots, but finding PRIME ones is harder",
       "**Heath-Brown's Breakthrough**: At least one of {2, 3, 5} works for infinitely many primes",
-      "**Artin's Conjecture**: If true, would imply Erdős 985 via density arguments",
+      "**Artin's Conjecture**: an *effective* (Linnik-type) form would imply Erdős 985; the qualitative \"infinitely many primes\" form alone does not (no pointwise control)",
       "**Heuristic Argument**: φ(p-1)/log(p) prime primitive roots expected by PNT",
       "**Computational Evidence**: Verified for all small primes tested"
     ],
@@ -90,10 +93,10 @@
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "summary": "zmod_units_cyclic theorem: (ℤ/pℤ)× is cyclic",
+      "summary": "zmod_units_cyclic: (ℤ/pℤ)× is cyclic; exists_primitiveRoot_lt: a primitive root exists in {1,…,p-1} (only primality of the witness is open)",
       "startLine": 42,
       "endLine": 52,
-      "mathContext": "Proved via Mathlib: zmod_units_cyclic theorem"
+      "mathContext": "Proved via Mathlib: zmod_units_cyclic; exists_primitiveRoot_lt (verified, 0-axiom) shows the unconditional existence of a primitive root below p."
     },
     {
       "id": "small-examples",
@@ -138,10 +141,10 @@
     {
       "id": "connections",
       "title": "Connections to Other Problems",
-      "summary": "artin_implies_erdos_985 theorem",
+      "summary": "erdos985_of_heathBrown_witness + infinitely_many_erdos985_primes: infinitely many confirmed instances from Heath-Brown",
       "startLine": 179,
       "endLine": 193,
-      "mathContext": "artin_implies_erdos_985 theorem with sorry: deriving Erdős 985 from Artin's conjecture requires a Linnik-type quantitative step (smallest p' ≤ f(q)) not yet formalized"
+      "mathContext": "Caveat: qualitative Artin does NOT imply Erdős 985 pointwise (the prior artin_implies_erdos_985 sorry was mathematically invalid and has been removed). Verified replacement: erdos985_of_heathBrown_witness turns the Heath-Brown {2,3,5} covering into actual cases, and infinitely_many_erdos985_primes proves the set of primes satisfying Erdős 985 is infinite."
     },
     {
       "id": "summary",
@@ -153,8 +156,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #985 asks whether every odd prime p has a prime primitive root q < p. This elegant question remains OPEN. We verify the conjecture computationally for p = 3, 5, 7, 11, 13, 23, and formalize Heath-Brown's theorem that at least one of {2, 3, 5} is a primitive root for infinitely many primes.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Artin's Conjecture:** If Artin's conjecture holds, Erdős 985 follows\n\n2. **Generalized Riemann Hypothesis:** Hooley's conditional result connects to GRH\n\n**3. Primitive Root Distribution:** Understanding which integers are primitive roots\n\n4. **Computational Number Theory:** Can test the conjecture for larger primes\n\n5. **Cyclic Group Structure:** Deep connection to (ℤ/pℤ)× being cyclic.",
+    "summary": "Erdős Problem #985 asks whether every odd prime p has a prime primitive root q < p. It remains OPEN. We verify the conjecture for p = 3, 5, 7, 11, 13, 23, prove unconditionally that a primitive root always exists below p (so only the primality of the witness is at issue), and derive from Heath-Brown's theorem that infinitely many primes satisfy the conjecture.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Artin's Conjecture:** an effective form would imply Erdős 985 (the qualitative form does not — see `infinitely_many_erdos985_primes` for the genuine unconditional progress via Heath-Brown)\n\n2. **Generalized Riemann Hypothesis:** Hooley's conditional result connects to GRH\n\n**3. Primitive Root Distribution:** Understanding which integers are primitive roots\n\n4. **Computational Number Theory:** Can test the conjecture for larger primes\n\n5. **Cyclic Group Structure:** Deep connection to (ℤ/pℤ)× being cyclic.",
     "openQuestions": [
       "Is there a prime p with no prime primitive root < p?",
       "What is the density of primes for which 2 is a primitive root?",
@@ -173,12 +176,12 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 225,
+    "lineCount": 298,
     "axiomCount": 2,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 3,
     "path": "Proofs/Erdos985Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -197,5 +200,5 @@
       "description": "Related Erdős problem sharing themes: number-theory, open, primes"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Erdős Problem **#985** — *does every prime p have a prime primitive root q < p?* — is **OPEN**. The gallery entry (`erdos-985-incomplete-01`) did **not build** and contained a mathematically invalid theorem. This PR makes it compile cleanly and replaces the bogus content with honest, machine-checked results.

## Repairs (the file previously failed to elaborate)

- **`native_decide` on `orderOf` failed** — `orderOf` carries no executable code in Mathlib 4.26, so neither `native_decide` nor `decide` can evaluate it. Replaced all 8 small-prime order computations with `orderOf_eq_iff` + kernel `decide` over the *bounded* goal `x^n = 1 ∧ ∀ m < n, 0 < m → x^m ≠ 1` (powers in `ZMod p` are computable). No `Lean.ofReduceBool`.
- **A false example.** `primitiveRoot_3_mod_11` claimed `ord₁₁(3) = 10`, but `3⁵ = 1 (mod 11)`, so `ord₁₁(3) = 5` — 3 is **not** a primitive root mod 11. Corrected to the true `orderOf_3_mod_11 : orderOf (3 : ZMod 11) = 5` (a nice illustration of exactly the subtlety Erdős 985 is about). The `decide` tactic caught the false claim.
- **Type-inference bug.** `erdos985_for_*` and the summary inferred the witness `q : ZMod n` instead of `ℕ`, making `q.Prime` / `q < n` ill-typed. Annotated `∃ q : ℕ`.
- **Parse errors.** Stacked `/-- -/` doc-comments (documentation not attached to a declaration) are now `/- -/` block comments.

## New verified content

Axiom footprint of all non-axiom results: `[propext, Classical.choice, Quot.sound]` only.

- **`exists_primitiveRoot_lt`** — every prime `p` has a primitive root `g` with `0 < g < p` (cyclicity of `(ℤ/pℤ)ˣ`). This isolates that the *entire* difficulty of Erdős 985 is the extra requirement that the witness be **prime**.
- **Removed the invalid `artin_implies_erdos_985`.** The *qualitative* Artin conjecture ("each prime is a primitive root for infinitely many primes") does **not** imply the *pointwise* conclusion — its `sorry` could never be honestly discharged. This theorem has a history of failed mechanic patches (#13321, #13346, #13353). Replaced with an explicit caveat.
- **`erdos985_of_heathBrown_witness` + `infinitely_many_erdos985_primes`** — derive **infinitely many confirmed instances** of Erdős 985 from the Heath-Brown axiom: for `p > 5`, a witness `q ∈ {2,3,5}` is a prime primitive root `< p`.

## Status

Stays **`axiomatized`** (2 axioms: `heath_brown_theorem`, `erdos_985_conjecture` — the open problem itself). Now **0 sorries** and a **clean build**.

- `#print axioms exists_primitiveRoot_lt` → `[propext, Classical.choice, Quot.sound]`
- `#print axioms infinitely_many_erdos985_primes` → `[heath_brown_theorem, propext, Classical.choice, Quot.sound]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)