### PR TITLE
Enrich Jacobi's σ* Reduction (four-square-distribution-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-01-oq-01/annotations.json
@@ -6,33 +6,57 @@
     "type": "concept",
     "title": "Jacobi's σ* and the Eisenstein decomposition",
     "content": "Jacobi's four-square formula is r4(n) = 8·σ*(n), where σ*(n) = Σ_{d|n, 4∤d} d drops every divisor divisible by 4. The modern proof identifies θ^4 with a weight-2 Eisenstein series on Γ0(4); the parent entry states the formula as an axiom. This file resolves the arithmetic component axiom-free: an exact closed-form relation between σ* and the ordinary divisor sum σ(n) = Σ_{d|n} d.",
-    "mathContext": "The weight-2 Eisenstein space on $\\Gamma_0(4)$ is spanned by $E_2(\\tau) - 2E_2(2\\tau)$ and $E_2(\\tau) - 4E_2(4\\tau)$, whose $q$-coefficients are divisor sums with the $4 \\mid d$ terms removed — exactly $\\sigma^*$."
+    "mathContext": "The weight-2 Eisenstein space on $\\Gamma_0(4)$ is spanned by $E_2(\\tau) - 2E_2(2\\tau)$ and $E_2(\\tau) - 4E_2(4\\tau)$, whose $q$-coefficients are divisor sums with the $4 \\mid d$ terms removed — exactly $\\sigma^*$.",
+    "significance": "context",
+    "relatedConcepts": ["Jacobi four-square theorem", "theta series", "Eisenstein series", "Γ0(4) modular forms", "axiom reduction"],
+    "prerequisites": ["sums of squares", "modular forms (for context)"]
   },
   {
     "id": "eq-filter",
     "proofId": "four-square-distribution-oq-01-oq-01",
-    "range": { "startLine": 56, "endLine": 70 },
+    "range": { "startLine": 55, "endLine": 69 },
     "type": "definition",
     "title": "σ* as a filtered divisor sum",
-    "content": "σ*(n) is defined (verbatim from the parent) as Σ_{d|n} (if 4∣d then 0 else d). sigmaStar_eq_filter recasts this as the honest filtered sum Σ_{d|n, 4∤d} d by case-splitting the if-then-else, which is the convenient form for the reduction below.",
-    "mathContext": "$\\sigma^*(n) = \\sum_{d \\mid n,\\ 4 \\nmid d} d$ and $\\sigma(n) = \\sum_{d \\mid n} d$."
+    "content": "σ*(n) is defined (verbatim from the parent) as Σ_{d|n} (if 4∣d then 0 else d), with σ(n) = Σ_{d|n} d the ordinary divisor sum. sigmaStar_eq_filter recasts the if-then-else form as the honest filtered sum Σ_{d|n, 4∤d} d by case-splitting via Finset.sum_filter — the convenient shape for the reduction below.",
+    "mathContext": "$\\sigma^*(n) = \\sum_{d \\mid n,\\ 4 \\nmid d} d$ and $\\sigma(n) = \\sum_{d \\mid n} d$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisor sum", "Finset.sum_filter", "if-then-else normalization"],
+    "prerequisites": ["Nat.divisors", "Finset big operators"]
   },
   {
     "id": "reduction",
     "proofId": "four-square-distribution-oq-01-oq-01",
-    "range": { "startLine": 72, "endLine": 95 },
+    "range": { "startLine": 71, "endLine": 94 },
     "type": "theorem",
     "title": "σ*(n) = σ(n) when 4 ∤ n",
     "content": "The key reduction. If 4 ∤ n, then any divisor d | n with 4 | d would force 4 | n — a contradiction — so the filter drops nothing and σ*(n) = σ(n). This covers the residue classes n ≡ 1, 2, 3 (mod 4). The corollaries sigmaStar_odd and sigmaStar_two_mul_odd specialise to odd n and n = 2·(odd), discharged via Nat.odd_iff and omega.",
-    "mathContext": "For $4 \\nmid n$: $d \\mid n \\wedge 4 \\mid d \\Rightarrow 4 \\mid n$, contradiction. Hence $\\sigma^*(n) = \\sigma(n)$ for $n \\not\\equiv 0 \\pmod 4$."
+    "mathContext": "For $4 \\nmid n$: $d \\mid n \\wedge 4 \\mid d \\Rightarrow 4 \\mid n$, contradiction. Hence $\\sigma^*(n) = \\sigma(n)$ for $n \\not\\equiv 0 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["divisibility transitivity", "residue classes mod 4", "Nat.dvd_of_mem_divisors"],
+    "prerequisites": ["divisibility", "Nat.odd_iff", "omega tactic"]
   },
   {
     "id": "correction",
     "proofId": "four-square-distribution-oq-01-oq-01",
-    "range": { "startLine": 97, "endLine": 114 },
+    "range": { "startLine": 96, "endLine": 106 },
     "type": "theorem",
     "title": "The 4 | n correction: σ*(n) + Σ_{4|d} d = σ(n)",
-    "content": "Splitting σ(n) into its 4-divisible and non-4-divisible parts (Finset.sum_filter_add_sum_filter_not) shows σ*(n) together with the sum of the divisors of n divisible by 4 recovers σ(n). Equivalently σ*(n) = σ(n) − Σ_{d|n, 4|d} d: the entire deviation of σ* from σ is the dropped part. sigmaStar_le_sigma (σ*(n) ≤ σ(n)) follows immediately, and kernel-decide checks confirm σ*(8)=3, σ*(12)=12, σ(12)=28.",
-    "mathContext": "$\\sigma^*(n) + \\sum_{d \\mid n,\\ 4 \\mid d} d = \\sigma(n)$. For example $\\sigma^*(12) = 1+2+3+6 = 12 = \\sigma(12) - 4\\sigma(3) = 28 - 16$."
+    "content": "Splitting σ(n) into its 4-divisible and non-4-divisible parts (Finset.sum_filter_add_sum_filter_not) shows σ*(n) together with the sum of the divisors of n divisible by 4 recovers σ(n). Equivalently σ*(n) = σ(n) − Σ_{d|n, 4|d} d: the entire deviation of σ* from σ is the dropped part. sigmaStar_le_sigma (σ*(n) ≤ σ(n)) follows immediately from the additive split.",
+    "mathContext": "$\\sigma^*(n) + \\sum_{d \\mid n,\\ 4 \\mid d} d = \\sigma(n)$, hence $\\sigma^*(n) \\le \\sigma(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_filter_add_sum_filter_not", "additive decomposition", "monotonicity"],
+    "prerequisites": ["Finset filter splits", "Nat.le_add_right"]
+  },
+  {
+    "id": "sanity",
+    "proofId": "four-square-distribution-oq-01-oq-01",
+    "range": { "startLine": 108, "endLine": 114 },
+    "type": "technique",
+    "title": "Kernel-decide sanity checks (axiom integrity)",
+    "content": "Three example checks confirm the formulas at small n: σ*(12) = 1+2+3+6 = 12, σ(12) = 28, σ*(8) = 3 (divisors 1,2,4,8 keep only 1,2). These use kernel `decide`, NOT native_decide, so they introduce no Lean.ofReduceBool axiom — the entry remains genuinely axiom-free. The n = 12 case illustrates the correction concretely: σ*(12) = 12 = 28 − 16 = σ(12) − (4+8+12+... 4-divisible divisors).",
+    "mathContext": "$\\sigma^*(12) = 1+2+3+6 = 12 = \\sigma(12) - 16 = 28 - 16$; $\\sigma^*(8) = 1+2 = 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide vs. native_decide", "axiom integrity", "worked example"],
+    "prerequisites": ["decidable equality", "Lean kernel reduction"]
   }
 ]

--- a/src/data/proofs/four-square-distribution-oq-01-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01-oq-01/meta.json
@@ -68,7 +68,8 @@
       "Jacobi's modification only ever acts when 4 | n: for the other three residue classes mod 4, σ* coincides exactly with the ordinary divisor sum.",
       "The full deviation of σ* from σ is concentrated in the dropped 4-divisible divisors, captured by the clean additive identity σ*(n) + Σ_{d|n, 4|d} d = σ(n).",
       "This σ* ↔ σ relation is precisely what the weight-2 Eisenstein decomposition on Γ0(4) encodes: the 'level-4 correction' E2(τ) − 4E2(4τ) removes the 4 | d divisors.",
-      "Everything is elementary divisor combinatorics — no native_decide, so the result is genuinely axiom-free (the numeric sanity checks use kernel decide)."
+      "Everything is elementary divisor combinatorics — no native_decide, so the result is genuinely axiom-free (the numeric sanity checks use kernel decide).",
+      "The reduction strictly separates the easy arithmetic of σ* (fully formalized here) from the deep analytic identity r4 = 8σ* (still an axiom needing modular forms): the σ* ↔ σ bridge is exactly the part of Jacobi's theorem that does NOT require θ^4 = Eisenstein, so it can be discharged unconditionally while the analytic core waits for Mathlib's modular-forms library."
     ],
     "prerequisites": [
       "Divisor sums and Jacobi's σ*",
@@ -80,23 +81,46 @@
     {
       "id": "definitions",
       "title": "σ* and σ",
-      "startLine": 56,
-      "endLine": 70,
+      "startLine": 55,
+      "endLine": 69,
       "summary": "Jacobi's modified divisor sum σ*(n) (verbatim from the parent) and the ordinary divisor sum σ(n); sigmaStar_eq_filter recasts σ* as a filtered divisor sum."
     },
     {
       "id": "reduction",
       "title": "σ*(n) = σ(n) when 4 ∤ n",
-      "startLine": 72,
-      "endLine": 95,
-      "summary": "sigmaStar_of_not_four_dvd and the odd / 2-mod-4 corollaries: outside the residue class 0 mod 4, Jacobi's modification is inert."
+      "startLine": 71,
+      "endLine": 80,
+      "summary": "sigmaStar_of_not_four_dvd: outside residue class 0 mod 4, no divisor is 4-divisible, so Jacobi's modification is inert and σ* = σ."
+    },
+    {
+      "id": "corollaries",
+      "title": "Odd and 2-mod-4 corollaries",
+      "startLine": 82,
+      "endLine": 94,
+      "summary": "sigmaStar_odd and sigmaStar_two_mul_odd specialize the reduction to odd n and n = 2·(odd), each discharged via Nat.odd_iff + omega."
     },
     {
       "id": "correction",
       "title": "The 4 | n correction and the bound",
-      "startLine": 97,
+      "startLine": 96,
+      "endLine": 106,
+      "summary": "sigmaStar_add_four_part isolates the σ*-vs-σ deviation into the 4-divisible divisor sum; sigmaStar_le_sigma gives σ*(n) ≤ σ(n)."
+    },
+    {
+      "id": "sanity",
+      "title": "Kernel-decide sanity checks",
+      "startLine": 108,
       "endLine": 114,
-      "summary": "sigmaStar_add_four_part isolates the σ*-vs-σ deviation into the 4-divisible divisor sum; sigmaStar_le_sigma gives σ*(n) ≤ σ(n); kernel-decide sanity checks at n = 8, 12."
+      "summary": "Example checks σ*(12)=12, σ(12)=28, σ*(8)=3 using kernel decide (no native_decide), confirming the formulas and keeping the entry axiom-free."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "An axiom-free, fully machine-checked determination of how Jacobi's modified divisor sum σ*(n) = Σ_{d|n, 4∤d} d relates to the ordinary divisor sum σ(n). σ*(n) = σ(n) for n ≡ 1, 2, 3 (mod 4) (sigmaStar_of_not_four_dvd, with odd and 2-mod-4 corollaries), and for 4 | n the deviation is exactly the dropped 4-divisible part: σ*(n) + Σ_{d|n, 4|d} d = σ(n) (sigmaStar_add_four_part), whence σ*(n) ≤ σ(n). 114 lines, 6 theorems, 2 definitions, 0 axioms, 0 sorries; the sanity checks use kernel decide, so no Lean.ofReduceBool.",
+    "implications": "This isolates and discharges the elementary arithmetic component of Jacobi's four-square theorem — precisely the σ* ↔ σ relation that the weight-2 Eisenstein decomposition on Γ0(4) encodes — without touching the deep analytic identity r4(n) = 8σ*(n), which remains an axiom (axiom jacobi_r4_formula) pending Mathlib modular-forms infrastructure. It is a model of honest axiom reduction: the part that can be proved unconditionally is, while the genuinely hard analytic core is left clearly demarcated as the remaining assumption.",
+    "openQuestions": [
+      "Replace axiom jacobi_r4_formula with a proof identifying θ^4 as the Γ0(4) weight-2 Eisenstein combination, once Mathlib has the modular-forms infrastructure (q-expansions of E2(τ), E2(2τ), E2(4τ) and the dimension of M2(Γ0(4))).",
+      "Generalize the σ*-vs-σ split to the analogous modified divisor sums appearing in the r2, r6, r8 sum-of-squares formulas (e.g. the χ-twisted sums for r2 and the σ3-based formula for r8).",
+      "Derive an explicit closed form for Σ_{d|n, 4|d} d = 4·σ(n/4) when 4 | n, turning the additive correction into a multiplicative recursion σ*(n) = σ(n) − 4σ(n/4)."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for **four-square-distribution-oq-01-oq-01**. Quality score 54 → 100.

## Quality improvements
- **Added `conclusion`** (was missing): `summary`, `implications` (honest axiom-reduction framing — the σ* ↔ σ arithmetic is discharged while the deep r4 = 8σ* analytic identity remains a clearly-demarcated axiom), and 3 `openQuestions`.
- **Annotations enriched.** Added `significance`, `relatedConcepts`, `prerequisites` to all four (were missing); added a 5th annotation for the kernel-`decide` sanity checks (axiom-integrity point).
- **Sections 3 → 5.** Split into definitions / reduction / corollaries / correction / sanity for theorem-level coverage.
- **keyInsights 4 → 5.** Added the separation of the elementary arithmetic from the analytic core.

## Notes
- Axiom integrity verified and emphasized: `status: verified`, `axiomCount: 0`; the sanity checks use **kernel `decide`, not `native_decide`**, so no `Lean.ofReduceBool`. This entry does NOT replace the parent's `axiom jacobi_r4_formula` — it formalizes the arithmetic the Eisenstein decomposition expresses, which the PR body and conclusion state explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)