### PR TITLE
research(spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02): Newton's third power sum tr(A³)=λ₁³+λ₂³+λ₃³ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean
@@ -1,0 +1,171 @@
+import Mathlib
+import Proofs.SpectralTraceDetEigenvaluesOQ01
+
+/-
+# Spectral trace, OQ-01 → OQ-01 → OQ-02: Newton's identity `tr(A³) = Σ λᵢ³` in dimension three
+
+## What this file proves
+
+The sibling `spectral-trace-det-eigenvalues-oq-01-oq-01`
+(`SpectralTraceDetEigenvaluesOQ01OQ01.lean`) reached the first power-sum identity
+`tr(A²) = λ₁² + λ₂²` for `2 × 2` matrices, via **Newton's identity** `p₂ = e₁² − 2 e₂` — there
+`e₂` is just the determinant, the *top* elementary symmetric function, so no intermediate
+symmetric function appears.  Its open question asks to extend this to the next power sum and the
+next dimension:
+
+      tr(A³) = e₁³ − 3 e₁ e₂ + 3 e₃          (Newton's identity `p₃`),
+
+and to read it as the genuinely spectral statement `tr(A³) = λ₁³ + λ₂³ + λ₃³` for `3 × 3`
+matrices.  This is the first power sum whose Newton expansion involves the *middle* elementary
+symmetric function `e₂` (the sum of the principal `2 × 2` minors, equivalently the `X¹`
+coefficient of the characteristic polynomial), so it is qualitatively harder than the `2 × 2`
+case.
+
+## Results
+
+* `trace_cube_fin_three` — the **matrix-side Newton identity**, over *any* commutative ring:
+
+        tr(A³) = (tr A)³ − 3 (tr A) e₂(A) + 3 det A,
+
+  where `e₂(A)` is the sum of the principal `2 × 2` minors.  This holds with no field, no
+  algebraic closure, and no eigenvalues — it is a polynomial identity in the nine entries,
+  closed by `ring`.
+
+* `charpoly_fin_three` / `charpoly_coeff_one_eq_e2` — the `3 × 3` characteristic polynomial in
+  elementary-symmetric form `X³ − (tr A) X² + e₂(A) X − det A`, identifying `e₂(A)` as its
+  `X¹`-coefficient.
+
+* `trace_cube_eq_sum_cube_eigenvalues` — the **spectral form**, over an algebraically closed
+  field: `tr(A³) = Σ λᵢ³`, the third power sum of the eigenvalue multiset.  The proof matches the
+  matrix-side identity to the multiset identity `a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc)+3abc`,
+  using Vieta (`charpoly = ∏ (X − λᵢ)`) to identify the three elementary symmetric functions of
+  the eigenvalues with `tr A`, `e₂(A)`, and `det A`.
+
+## Honesty / scope
+
+The matrix-side identity and its `ring` proof are routine but genuinely new at `k = 3`; the
+spectral upgrade reuses the sibling/parent infrastructure (`eigenvalues`,
+`charpoly_coeff_eq_esymm_eigenvalues`, `trace_eq_sum_eigenvalues`, `det_eq_prod_eigenvalues`).
+No `native_decide`; `#print axioms` confirms only `propext, Classical.choice, Quot.sound`.
+-/
+
+namespace SpectralTraceDetEigenvaluesOQ01OQ01OQ02
+
+open Matrix Polynomial
+open SpectralTraceDetEigenvaluesOQ01 (eigenvalues)
+
+/-! ## Part I: the second elementary symmetric function and the matrix-side Newton identity -/
+
+variable {R : Type*} [CommRing R]
+
+/-- The **second elementary symmetric function** of a `3 × 3` matrix: the sum of its three
+principal `2 × 2` minors.  For a matrix with eigenvalues `a, b, c` this equals `ab + ac + bc`. -/
+def e2 (A : Matrix (Fin 3) (Fin 3) R) : R :=
+  (A 0 0 * A 1 1 - A 0 1 * A 1 0)
+    + (A 0 0 * A 2 2 - A 0 2 * A 2 0)
+    + (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+
+/-- **The matrix-side Newton identity `p₃ = e₁³ − 3 e₁ e₂ + 3 e₃` in dimension three.**
+Over any commutative ring, the trace of `A³` is determined by the trace, the second elementary
+symmetric function (minor sum), and the determinant of `A`:
+
+      tr(A³) = (tr A)³ − 3 (tr A) e₂(A) + 3 det A.
+
+A polynomial identity in the nine entries, closed by `ring`. -/
+theorem trace_cube_fin_three (A : Matrix (Fin 3) (Fin 3) R) :
+    (A ^ 3).trace = A.trace ^ 3 - 3 * A.trace * e2 A + 3 * A.det := by
+  simp only [pow_three, Matrix.trace_fin_three, Matrix.det_fin_three, Matrix.mul_apply,
+    Fin.sum_univ_three, e2]
+  ring
+
+/-! ## Part II: the characteristic polynomial in elementary-symmetric form -/
+
+/-- **The `3 × 3` characteristic polynomial in elementary-symmetric form.**
+`charpoly A = X³ − (tr A) X² + e₂(A) X − det A`. -/
+theorem charpoly_fin_three (A : Matrix (Fin 3) (Fin 3) R) :
+    A.charpoly = X ^ 3 - C A.trace * X ^ 2 + C (e2 A) * X - C A.det := by
+  have htr : A.trace = A 0 0 + A 1 1 + A 2 2 := Matrix.trace_fin_three A
+  have hdet : A.det = A 0 0 * A 1 1 * A 2 2 - A 0 0 * A 1 2 * A 2 1
+      - A 0 1 * A 1 0 * A 2 2 + A 0 1 * A 1 2 * A 2 0
+      + A 0 2 * A 1 0 * A 2 1 - A 0 2 * A 1 1 * A 2 0 := Matrix.det_fin_three A
+  rw [show A.charpoly = (Matrix.charmatrix A).det from rfl, Matrix.det_fin_three, htr, hdet, e2]
+  simp only [Matrix.charmatrix_apply_eq, Matrix.charmatrix_apply_ne, Fin.isValue,
+    ne_eq, Fin.reduceEq, not_false_eq_true, map_add, map_sub, map_mul]
+  ring
+
+/-- `e₂(A)` is the `X¹`-coefficient of the characteristic polynomial of a `3 × 3` matrix. -/
+theorem charpoly_coeff_one_eq_e2 (A : Matrix (Fin 3) (Fin 3) R) :
+    A.charpoly.coeff 1 = e2 A := by
+  rw [charpoly_fin_three]
+  simp [coeff_X_pow, coeff_C, coeff_C_mul, coeff_sub, coeff_add]
+
+/-! ## Part III: the spectral form `tr(A³) = Σ λᵢ³` over an algebraically closed field -/
+
+variable {K : Type*} [Field K] [IsAlgClosed K]
+
+/-- A `3 × 3` matrix over an algebraically closed field has exactly three eigenvalues. -/
+theorem card_eigenvalues_fin_three (A : Matrix (Fin 3) (Fin 3) K) :
+    Multiset.card (eigenvalues A) = 3 := by
+  rw [SpectralTraceDetEigenvaluesOQ01.card_eigenvalues_eq_dim]
+  simp
+
+/-- The characteristic polynomial factors over the eigenvalues (Vieta). -/
+theorem charpoly_eq_prod_eigenvalues (A : Matrix (Fin 3) (Fin 3) K) :
+    A.charpoly = ((eigenvalues A).map (fun r => X - C r)).prod :=
+  (IsAlgClosed.splits A.charpoly).eq_prod_roots_of_monic A.charpoly_monic
+
+/-- **Newton's third power-sum identity, spectral form.**  Over an algebraically closed field,
+the trace of `A³` is the sum of the cubes of the eigenvalues of the `3 × 3` matrix `A`:
+
+      tr(A³) = λ₁³ + λ₂³ + λ₃³.
+
+The proof identifies the three elementary symmetric functions of the eigenvalues `a, b, c` with
+`tr A = a+b+c`, `e₂(A) = ab+ac+bc`, and `det A = abc` (the first and last from the parent, the
+middle one from `charpoly_coeff_one_eq_e2` + Vieta), then matches the matrix-side Newton identity
+`trace_cube_fin_three` against the elementary multiset identity
+`a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc`. -/
+theorem trace_cube_eq_sum_cube_eigenvalues (A : Matrix (Fin 3) (Fin 3) K) :
+    (A ^ 3).trace = ((eigenvalues A).map (· ^ 3)).sum := by
+  obtain ⟨a, b, c, habc⟩ := Multiset.card_eq_three.mp (card_eigenvalues_fin_three A)
+  -- the three elementary symmetric functions of the eigenvalues
+  have htr : A.trace = a + b + c := by
+    rw [SpectralTraceDetEigenvaluesOQ01.trace_eq_sum_eigenvalues, habc]
+    simp [add_assoc]
+  have hdet : A.det = a * b * c := by
+    rw [SpectralTraceDetEigenvaluesOQ01.det_eq_prod_eigenvalues, habc]
+    simp [mul_assoc]
+  have he2 : e2 A = a * b + a * c + b * c := by
+    have hcoeff : A.charpoly.coeff 1 = a * b + a * c + b * c := by
+      rw [charpoly_eq_prod_eigenvalues, habc]
+      simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+        Multiset.prod_cons, Multiset.prod_singleton]
+      have : (X - C a) * ((X - C b) * (X - C c))
+          = X ^ 3 - C (a + b + c) * X ^ 2 + C (a * b + a * c + b * c) * X - C (a * b * c) := by
+        simp only [map_add, map_mul]; ring
+      rw [this]
+      simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+    rw [← charpoly_coeff_one_eq_e2]; exact hcoeff
+  rw [trace_cube_fin_three, htr, hdet, he2, habc]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  ring
+
+/-! ## Part IV: a concrete illustration -/
+
+/-- For `A = !![1,2,0; 0,3,1; 4,0,2]` the matrix-side identity gives `tr(A³)` from
+`tr A = 6`, `e₂(A)`, and `det A` without computing eigenvalues. -/
+theorem trace_cube_example :
+    (!![(1 : ℚ), 2, 0; 0, 3, 1; 4, 0, 2] ^ 3).trace
+      = (!![(1 : ℚ), 2, 0; 0, 3, 1; 4, 0, 2]).trace ^ 3
+        - 3 * (!![(1 : ℚ), 2, 0; 0, 3, 1; 4, 0, 2]).trace
+            * e2 (!![(1 : ℚ), 2, 0; 0, 3, 1; 4, 0, 2])
+        + 3 * (!![(1 : ℚ), 2, 0; 0, 3, 1; 4, 0, 2]).det :=
+  trace_cube_fin_three _
+
+end SpectralTraceDetEigenvaluesOQ01OQ01OQ02
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02.trace_cube_fin_three
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02.trace_cube_eq_sum_cube_eigenvalues
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02.charpoly_coeff_one_eq_e2

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+  "title": "Newton's Third Power Sum: tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 Matrices",
+  "slug": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+  "description": "Settles the open question posed by spectral-trace-det-eigenvalues-oq-01-oq-01: extend the 2×2 trace power sum tr(A²) = λ₁² + λ₂² to the next power sum and the next dimension, tr(A³) = e₁³ − 3e₁e₂ + 3e₃, read spectrally as tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 matrices. This is the first Newton power sum whose expansion involves the MIDDLE elementary symmetric function e₂ (the sum of the principal 2×2 minors, equivalently the X¹-coefficient of the characteristic polynomial), so it is qualitatively harder than the 2×2 case where only the determinant e₂ appears. Three results: (1) trace_cube_fin_three — the matrix-side Newton identity tr(A³) = (tr A)³ − 3(tr A)·e₂(A) + 3·det A over ANY commutative ring, a polynomial identity in the nine entries closed by ring, with no field, no algebraic closure, and no eigenvalues; (2) charpoly_fin_three / charpoly_coeff_one_eq_e2 — the 3×3 characteristic polynomial in elementary-symmetric form X³ − (tr A)X² + e₂(A)X − det A, identifying e₂(A) as its X¹-coefficient; (3) trace_cube_eq_sum_cube_eigenvalues — the spectral form tr(A³) = Σλᵢ³ over an algebraically closed field, matching the matrix-side identity to the multiset identity a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc via Vieta. A concrete rational 3×3 example reads tr(A³) off from trace, minor sum, and determinant without computing eigenvalues. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Newton's identities; spectral mapping theorem); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "eigenvalues",
+      "characteristic-polynomial",
+      "trace",
+      "determinant",
+      "power-sums",
+      "newtons-identities",
+      "spectral-mapping",
+      "symmetric-functions",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.trace_fin_three",
+        "description": "trace of a 3×3 matrix is A 0 0 + A 1 1 + A 2 2. With det_fin_three and mul_apply it drives the matrix-side Newton identity tr(A³) = (tr A)³ − 3(tr A)e₂ + 3 det A.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Trace"
+      },
+      {
+        "theorem": "Matrix.det_fin_three",
+        "description": "explicit Sarrus expansion of the 3×3 determinant in the nine entries. Used both to expand det A in the matrix-side identity and to pin down the X⁰-coefficient (−det A) of the characteristic polynomial.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.charmatrix",
+        "description": "the matrix X·I − A whose determinant is the characteristic polynomial; charmatrix_apply_eq and charmatrix_apply_ne expand the 3×3 charpoly entrywise so that det_fin_three yields the elementary-symmetric form X³ − (tr A)X² + e₂(A)X − det A.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "IsAlgClosed.splits_codomain",
+        "description": "over an algebraically closed field every polynomial splits; combined with eq_prod_roots_of_monic and the monic charpoly it factors A.charpoly = Π(X − λᵢ) over the eigenvalue multiset (Vieta), supplying the spectral identification of e₂ with ab+ac+bc.",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Multiset.card_eq_three",
+        "description": "a multiset has cardinality three iff it equals {a, b, c}. Reduces the 3×3 spectral trace power sum to the three-variable Newton identity a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc.",
+        "module": "Mathlib.Data.Multiset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "trace_cube_fin_three: the matrix-side Newton identity tr(A³) = (tr A)³ − 3(tr A)·e₂(A) + 3·det A over ANY commutative ring — a polynomial identity in the nine entries closed by ring, needing no field, no algebraic closure, and no eigenvalues; the third power sum p₃ = e₁³ − 3e₁e₂ + 3e₃ at the matrix level",
+      "e2: the second elementary symmetric function of a 3×3 matrix as the sum of its three principal 2×2 minors, the first MIDDLE elementary symmetric function to appear (absent from the 2×2 case where e₂ = det)",
+      "charpoly_fin_three: the 3×3 characteristic polynomial in elementary-symmetric form X³ − (tr A)X² + e₂(A)X − det A, derived entrywise from charmatrix and det_fin_three",
+      "charpoly_coeff_one_eq_e2: e₂(A) is exactly the X¹-coefficient of the characteristic polynomial, the bridge that identifies the minor sum with the spectral symmetric function ab+ac+bc via Vieta",
+      "trace_cube_eq_sum_cube_eigenvalues: the spectral form tr(A³) = λ₁³ + λ₂³ + λ₃³ over an algebraically closed field — the genuine power-sum statement in the first dimension whose Newton expansion is not determined by trace and determinant alone, settling the sibling entry's open question",
+      "trace_cube_example: for the rational matrix !![1,2,0; 0,3,1; 4,0,2] the matrix-side identity recovers tr(A³) from tr A = 6, e₂(A), and det A without ever computing the (irrational/complex) eigenvalues"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 171,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; #print axioms confirms the three headline theorems depend on no Lean.ofReduceBool or sorryAx. The matrix-side identity trace_cube_fin_three holds over any commutative ring; the spectral form trace_cube_eq_sum_cube_eigenvalues requires an algebraically closed field (so the characteristic polynomial splits and the eigenvalue multiset has exactly three elements). SCOPE: this entry proves the k=3 power sum in dimension n=3. The general trace power sum tr(Aᵏ) = Σλᵢᵏ for all n and k remains the standing open question (it requires the full multiset spectral mapping, absent from the Mathlib snapshot used here).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Isaac Newton, c. 1666; also Girard) express the power sums pₖ = Σλᵢᵏ of a collection of numbers through their elementary symmetric functions eⱼ: p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃, and so on. For the eigenvalues of a matrix the eⱼ are (up to sign) the coefficients of the characteristic polynomial — e₁ = trace, eₙ = determinant, and the intermediate eⱼ the sums of principal j×j minors. The power sums pₖ are the traces tr(Aᵏ), the trace half of the spectral mapping theorem spec(p(A)) = p(spec(A)). The parent spectral-trace-det-eigenvalues-oq-01 pinned down e₁ = trace and eₙ = det; its child oq-01-oq-01 settled p₂ for 2×2 matrices, where only those two extreme symmetric functions appear. The cube p₃ is the first power sum to require the middle symmetric function e₂.",
+    "problemStatement": "**Open Question (spectral-trace-det-eigenvalues-oq-01-oq-01, openQuestions[1])**: Extend the 2×2 Newton identity to a uniform tr(A³) = e₁³ − 3e₁e₂ + 3e₃ in fixed small dimensions, expressing each trace power sum through the elementary symmetric functions of the spectrum.\n\n**Result**: trace_cube_fin_three establishes the matrix-side identity tr(A³) = (tr A)³ − 3(tr A)·e₂(A) + 3·det A over any commutative ring; trace_cube_eq_sum_cube_eigenvalues upgrades it to the spectral statement tr(A³) = λ₁³ + λ₂³ + λ₃³ over an algebraically closed field, with e₂(A) identified as both the principal-minor sum and the X¹-coefficient of the characteristic polynomial.",
+    "text": "Let A be a 3×3 matrix. Write e₁(A) = tr A, e₂(A) for the sum of the three principal 2×2 minors, and e₃(A) = det A. Newton's third identity gives tr(A³) = e₁³ − 3e₁e₂ + 3e₃ as a polynomial identity in the nine entries, valid over any commutative ring. Over an algebraically closed field the characteristic polynomial X³ − e₁X² + e₂X − e₃ splits as Π(X − λᵢ), so e₁ = λ₁+λ₂+λ₃, e₂ = λ₁λ₂+λ₁λ₃+λ₂λ₃, e₃ = λ₁λ₂λ₃, and the identity becomes the spectral power sum tr(A³) = λ₁³ + λ₂³ + λ₃³.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Matrix-side identity (any commutative ring): define e₂(A) as the sum of the three principal 2×2 minors. Expand (A^3).trace, A.trace, e₂(A), and A.det via trace_fin_three, det_fin_three, mul_apply, and Fin.sum_univ_three into explicit polynomials in the nine entries; the identity tr(A³) = (tr A)³ − 3(tr A)e₂ + 3 det A then closes by ring. No eigenvalues, no field.\n\n2. Characteristic polynomial in elementary-symmetric form: expand charpoly = det(X·I − A) entrywise with charmatrix and det_fin_three, then ring-normalise to X³ − (tr A)X² + e₂(A)X − det A. Reading off the X¹-coefficient gives charpoly_coeff_one_eq_e2: A.charpoly.coeff 1 = e₂(A).\n\n3. Spectral upgrade (algebraically closed field): the eigenvalue multiset has exactly three elements (card_eigenvalues_fin_three, from the parent's card_eigenvalues_eq_dim). Vieta (charpoly = Π(X − λᵢ)) identifies the three elementary symmetric functions of the eigenvalues a,b,c with tr A = a+b+c (parent), det A = abc (parent), and e₂(A) = ab+ac+bc (from charpoly_coeff_one_eq_e2 and the explicit cubic factorisation). Substituting into the matrix-side identity and matching against a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc yields tr(A³) = a³+b³+c³.\n\n4. Example: instantiate trace_cube_fin_three at !![1,2,0; 0,3,1; 4,0,2] over ℚ, recovering tr(A³) from tr A = 6, e₂(A), and det A.",
+    "keyInsights": [
+      "**The cube is the first power sum that needs the middle symmetric function.** For 2×2 matrices Newton's p₂ = e₁² − 2e₂ uses only e₁ = trace and e₂ = determinant — the two extreme symmetric functions. At p₃ in dimension three the expansion e₁³ − 3e₁e₂ + 3e₃ involves e₂ = sum of principal 2×2 minors, a genuinely intermediate invariant that is neither trace nor determinant, making the cube qualitatively harder than the square.",
+      "**e₂ wears two hats: minor sum and charpoly coefficient.** The proof identifies e₂(A) — defined combinatorially as the sum of the three principal 2×2 minors — with the X¹-coefficient of the characteristic polynomial (charpoly_coeff_one_eq_e2). This is exactly the bridge that turns the matrix-side identity into a spectral one: by Vieta the X¹-coefficient is the second elementary symmetric function ab+ac+bc of the eigenvalues.",
+      "**The matrix-side identity is ring-universal; algebraic closure enters only for the spectral reading.** tr(A³) = (tr A)³ − 3(tr A)e₂ + 3 det A is a polynomial identity in the nine entries, true over ℤ, ℚ, any commutative ring — provable by ring with no eigenvalues in sight. A field and algebraic closure are needed only to factor the characteristic polynomial and rewrite the same quantity as λ₁³ + λ₂³ + λ₃³.",
+      "**A trace power sum of an unknowable spectrum is a rational invariant.** For !![1,2,0; 0,3,1; 4,0,2] the eigenvalues are not rational, yet tr(A³) is forced by tr A = 6, the minor sum e₂, and det A — read off without ever solving the cubic."
+    ],
+    "prerequisites": [
+      "The characteristic polynomial and its roots as eigenvalues with algebraic multiplicity (spectral-trace-det-eigenvalues-oq-01)",
+      "The 2×2 trace power sum tr(A²) = λ₁² + λ₂² and Newton's identity p₂ = e₁² − 2e₂ (spectral-trace-det-eigenvalues-oq-01-oq-01)",
+      "Newton's identities relating power sums to elementary symmetric functions; Vieta's formulas for a monic cubic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Open Question",
+      "startLine": 1,
+      "endLine": 59,
+      "summary": "Module docstring stating the goal — extend the 2×2 trace power sum to tr(A³) = e₁³ − 3e₁e₂ + 3e₃ and its spectral reading tr(A³) = Σλᵢ³ — and the honesty note that the cube is the first power sum involving the middle symmetric function e₂; imports Mathlib and the parent file, opens Matrix/Polynomial, reuses the parent's eigenvalues abbreviation.",
+      "mathContext": "$p_3 = e_1^3 - 3e_1e_2 + 3e_3$; $e_2 = $ sum of principal $2\\times2$ minors."
+    },
+    {
+      "id": "matrix-newton",
+      "title": "The Matrix-Side Newton Identity over any Commutative Ring",
+      "startLine": 60,
+      "endLine": 80,
+      "summary": "e2 (the second elementary symmetric function as the sum of the three principal 2×2 minors) and trace_cube_fin_three: tr(A³) = (tr A)³ − 3(tr A)·e₂(A) + 3·det A, a polynomial identity in the nine entries over any commutative ring, expanded by trace_fin_three/det_fin_three/mul_apply and closed by ring.",
+      "mathContext": "$\\operatorname{tr}(A^3) = (\\operatorname{tr}A)^3 - 3(\\operatorname{tr}A)\\,e_2(A) + 3\\det A$."
+    },
+    {
+      "id": "charpoly",
+      "title": "The Characteristic Polynomial in Elementary-Symmetric Form",
+      "startLine": 81,
+      "endLine": 101,
+      "summary": "charpoly_fin_three (charpoly = X³ − (tr A)X² + e₂(A)X − det A, expanded entrywise from charmatrix and det_fin_three) and charpoly_coeff_one_eq_e2 (e₂(A) is the X¹-coefficient), the bridge identifying the minor sum with the second symmetric function of the eigenvalues.",
+      "mathContext": "$\\chi_A(X) = X^3 - (\\operatorname{tr}A)X^2 + e_2(A)X - \\det A$."
+    },
+    {
+      "id": "spectral",
+      "title": "The Spectral Form tr(A³) = λ₁³ + λ₂³ + λ₃³",
+      "startLine": 102,
+      "endLine": 151,
+      "summary": "card_eigenvalues_fin_three (a 3×3 matrix has exactly three eigenvalues), charpoly_eq_prod_eigenvalues (Vieta), and trace_cube_eq_sum_cube_eigenvalues: over an algebraically closed field tr(A³) = Σλᵢ³, matching the matrix-side identity to a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc with e₁,e₂,e₃ read from trace, the X¹-coefficient, and det.",
+      "mathContext": "$\\operatorname{tr}(A^3) = \\lambda_1^3 + \\lambda_2^3 + \\lambda_3^3$."
+    },
+    {
+      "id": "example",
+      "title": "A Concrete 3×3 Rational Illustration",
+      "startLine": 152,
+      "endLine": 171,
+      "summary": "trace_cube_example: for !![1,2,0; 0,3,1; 4,0,2] over ℚ the matrix-side identity recovers tr(A³) from tr A = 6, the minor sum e₂(A), and det A, without computing the eigenvalues; #print axioms audit confirms only the foundational axioms.",
+      "mathContext": "$\\operatorname{tr}(A^3)$ from $\\operatorname{tr}A=6,\\ e_2(A),\\ \\det A$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01",
+      "relationship": "Direct parent: settled the 2×2 trace power sum tr(A²) = λ₁² + λ₂² via Newton's p₂ = e₁² − 2e₂ and explicitly posed (openQuestions[1]) the extension to tr(A³) = e₁³ − 3e₁e₂ + 3e₃ in fixed small dimensions that this entry takes up."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "relationship": "Grandparent: establishes trace = Σλ, determinant = Πλ, the eigenvalue count, and the Vieta correspondence reused here to identify e₁ and e₃ of the spectrum with trace and determinant."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "relationship": "Sibling on cyclic invariance of the trace and similarity-invariance of the eigenvalue multiset; the cube power sum tr(A³) is similarity-invariant for the same reason (conjugation preserves the characteristic polynomial)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of Newton's third power sum in dimension three: the matrix-side identity tr(A³) = (tr A)³ − 3(tr A)·e₂(A) + 3·det A over any commutative ring, and its spectral upgrade tr(A³) = λ₁³ + λ₂³ + λ₃³ over an algebraically closed field, with the middle symmetric function e₂ identified as both the principal-minor sum and the X¹-coefficient of the characteristic polynomial.",
+    "implications": "Settles the parent entry's open question by carrying Newton's identities to the first power sum (p₃, dimension 3) whose expansion uses the middle elementary symmetric function, not just trace and determinant. The clean separation — a ring-universal matrix-side identity closed by ring, then an algebraic-closure-only spectral reading via Vieta — gives a reusable template for higher power sums in fixed dimension. The remaining obstruction to the all-dimensions trace power sum tr(Aᵏ) = Σλᵢᵏ is unchanged: the full multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), absent from the Mathlib snapshot.",
+    "openQuestions": [
+      "Carry the same matrix-side-then-spectral template to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ in dimension four, the first power sum to involve all four elementary symmetric functions including the new e₄ = det.",
+      "Prove the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions n, equivalently the multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), by building Schur triangulation or a Newton-identity bridge from charpoly coefficients to root power sums."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SpectralTraceDetEigenvaluesOQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "SpectralTraceDetEigenvaluesOQ01OQ01OQ02",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2012",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for Newton's identities relating trace power sums to characteristic-polynomial coefficients, and the trace/determinant/minor sums as elementary symmetric functions of the eigenvalues."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic and Mathlib.LinearAlgebra.Matrix.Trace",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of the fin-three trace/determinant expansions, the charmatrix construction for the characteristic polynomial, and the splitting of polynomials over an algebraically closed field used for the spectral form."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Settles the open question posed by the sibling gallery entry **spectral-trace-det-eigenvalues-oq-01-oq-01** (its `openQuestions[1]`): extend the 2×2 trace power sum `tr(A²) = λ₁² + λ₂²` to the **cube** and the **next dimension**. This is the first Newton power sum whose expansion involves the *middle* elementary symmetric function `e₂` (the sum of the principal 2×2 minors, equivalently the `X¹`-coefficient of the characteristic polynomial), so it is qualitatively harder than the 2×2 case where only the determinant appears.

## Results (`proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean`)

- **`trace_cube_fin_three`** — the matrix-side Newton identity over **any commutative ring**:
  `tr(A³) = (tr A)³ − 3 (tr A)·e₂(A) + 3·det A`, a polynomial identity in the nine entries closed by `ring` (no field, no algebraic closure, no eigenvalues).
- **`charpoly_fin_three` / `charpoly_coeff_one_eq_e2`** — the 3×3 characteristic polynomial in elementary-symmetric form `X³ − (tr A)X² + e₂(A)X − det A`, identifying `e₂(A)` as its `X¹`-coefficient.
- **`trace_cube_eq_sum_cube_eigenvalues`** — the spectral form `tr(A³) = λ₁³ + λ₂³ + λ₃³` over an algebraically closed field, matching the matrix-side identity to the multiset identity `a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc` via Vieta.
- A concrete rational 3×3 example recovers `tr(A³)` from `tr A`, the minor sum, and `det A` without computing eigenvalues.

## Verification

- 7 theorems, 1 definition, 171 lines.
- `#print axioms` on the three headline theorems shows only `propext, Classical.choice, Quot.sound`.
- **0 axioms, 0 sorries, no `decide`/`native_decide`.** Status `verified`, badge `original`.
- Built locally with the host Lean toolchain against the Mathlib v4.26.0 cache (Docker daemon was unavailable this cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)