### PR TITLE
Enrich Abel Summation of 1−2+3−4+⋯=1/4 (geometric-series-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/annotations.json
@@ -1,26 +1,62 @@
 [
   {
+    "id": "ann-gs-header",
+    "proofId": "geometric-series-oq-01-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 26 },
+    "type": "context",
+    "title": "Euler's Divergent Series and Abel Summation",
+    "content": "Euler's series 1 − 2 + 3 − 4 + ⋯ is the term-by-term derivative of Grandi's series 1 − 1 + 1 − 1 + ⋯ (the parent entry). Both diverge in the ordinary sense; Euler assigned this one the value 1/4 by setting x = 1 in ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)². Abel's method makes that rigorous via the radial boundary limit. The value 1/4 = η(−1), tied to ζ(−1) = −1/12 through η(s) = (1 − 2¹⁻ˢ)ζ(s).",
+    "mathContext": "$1 - 2 + 3 - 4 + \\cdots$ diverges, yet its Abel sum is $\\lim_{x\\to 1^-} \\sum_n (-1)^n (n+1) x^n = \\tfrac14 = \\eta(-1)$.",
+    "significance": "context",
+    "relatedConcepts": ["Grandi's series", "Abel summation", "Dirichlet eta function", "divergent series", "ζ(−1)"],
+    "prerequisites": ["power series", "divergent-series summation methods"]
+  },
+  {
     "id": "ann-closed-form",
     "proofId": "geometric-series-oq-01-oq-01-oq-02",
-    "range": {
-      "startLine": 35,
-      "endLine": 66
-    },
+    "range": { "startLine": 31, "endLine": 56 },
     "type": "insight",
     "title": "The Differentiated Geometric Series Without Calculus",
-    "content": "hasSum_alt_nat builds the closed form ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² by addition rather than differentiation. Setting y = −x (with ‖y‖ = |x| < 1), it adds two Mathlib sums: ∑ n·yⁿ = y/(1−y)² (hasSum_coe_mul_geometric_of_norm_lt_one) and ∑ yⁿ = 1/(1−y) (hasSum_geometric_of_norm_lt_one). The combined general term is n·yⁿ + yⁿ = (n+1)yⁿ and the combined value is y/(1−y)² + 1/(1−y) = 1/(1−y)². Rewriting yⁿ = (−1)ⁿxⁿ (neg_pow) and 1−y = 1+x gives HasSum (fun n => (−1)ⁿ(n+1)xⁿ) (1/(1+x)²); alt_nat_power_series is the tsum form.",
-    "mathContext": "∑ (n+1) yⁿ = 1/(1−y)² is the derivative of the geometric series, obtained here purely by summation."
+    "content": "hasSum_alt_nat builds the closed form ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² by addition rather than differentiation. Setting y = −x (with ‖y‖ = |x| < 1), it adds two Mathlib sums: ∑ n·yⁿ = y/(1−y)² (hasSum_coe_mul_geometric_of_norm_lt_one) and ∑ yⁿ = 1/(1−y) (hasSum_geometric_of_norm_lt_one). The combined general term is n·yⁿ + yⁿ = (n+1)yⁿ and the combined value is y/(1−y)² + 1/(1−y) = 1/(1−y)². Rewriting yⁿ = (−1)ⁿxⁿ (neg_pow) and 1−y = 1+x gives HasSum (fun n => (−1)ⁿ(n+1)xⁿ) (1/(1+x)²).",
+    "mathContext": "$\\sum_n (n+1) y^n = \\frac{1}{(1-y)^2}$ at $y=-x$, i.e. $\\sum_n (-1)^n(n+1)x^n = \\frac{1}{(1+x)^2}$ — the derivative of the geometric series, obtained purely by summation.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series derivative", "HasSum", "hasSum_coe_mul_geometric_of_norm_lt_one", "neg_pow"],
+    "prerequisites": ["summability (HasSum)", "geometric series", "field_simp/ring"]
+  },
+  {
+    "id": "ann-tsum",
+    "proofId": "geometric-series-oq-01-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 61 },
+    "type": "theorem",
+    "title": "The tsum Closed Form",
+    "content": "alt_nat_power_series is the tsum_eq of hasSum_alt_nat: ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x| < 1. Passing from HasSum to tsum is what lets the next step take a limit of the scalar-valued function x ↦ ∑'ₙ … rather than reasoning about summability families.",
+    "mathContext": "$\\sum'_n (-1)^n(n+1)x^n = (1+x)^{-2}$ for $|x| < 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tsum", "HasSum.tsum_eq", "unconditional convergence"],
+    "prerequisites": ["tsum vs. HasSum"]
   },
   {
     "id": "ann-abel-limit",
     "proofId": "geometric-series-oq-01-oq-01-oq-02",
-    "range": {
-      "startLine": 68,
-      "endLine": 91
-    },
+    "range": { "startLine": 62, "endLine": 80 },
     "type": "insight",
     "title": "The Abel Sum Is the Boundary Value 1/4",
-    "content": "abel_tendsto_quarter reads Euler's series as the radial boundary value of 1/(1+x)². On a left-neighborhood of 1 (filter_upwards over 𝓝[<]1, where x < 1 and eventually x > −1 force |x| < 1) the tsum equals 1/(1+x)², so tendsto_congr' transfers the limit; then lim_{x→1} 1/(1+x)² = 1/(1+1)² = 1/4 follows from Tendsto.inv₀ applied to x ↦ (1+x)² → 4. Hence 1 − 2 + 3 − 4 + ⋯ is Abel summable to 1/4, the value Euler assigned and the one matching η(−1).",
-    "mathContext": "The radial boundary limit of 1/(1+x)² at x = 1 is 1/4, the Abel sum of Euler's series."
+    "content": "abel_tendsto_quarter reads Euler's series as the radial boundary value of 1/(1+x)². On a left-neighborhood of 1 (filter_upwards over 𝓝[<]1, where x < 1 and eventually x > −1 force |x| < 1) the tsum equals 1/(1+x)², so tendsto_congr' transfers the limit; then lim_{x→1} 1/(1+x)² = 1/(1+1)² = 1/4 follows from Tendsto.inv₀ applied to x ↦ (1+x)² → 4. The subtlety is purely the eventual-membership bookkeeping that keeps |x| < 1 on the approach to the boundary.",
+    "mathContext": "$\\lim_{x\\to 1^-} (1+x)^{-2} = \\tfrac14$; transferred to $\\sum'_n (-1)^n(n+1)x^n$ via agreement on $\\mathcal{N}[<]1$.",
+    "significance": "key",
+    "relatedConcepts": ["radial boundary limit", "nhdsWithin", "tendsto_congr'", "Filter.Tendsto.inv₀"],
+    "prerequisites": ["filters and nhdsWithin", "continuity of inversion"]
+  },
+  {
+    "id": "ann-package",
+    "proofId": "geometric-series-oq-01-oq-01-oq-02",
+    "range": { "startLine": 81, "endLine": 107 },
+    "type": "concept",
+    "title": "Packaging and the η(−1) Connection",
+    "content": "abel_value_quarter packages the conclusion: 1 − 2 + 3 − 4 + ⋯ is Abel summable to 1/4. The closing remarks situate 1/4 = η(−1) within the analytic continuation of the Dirichlet eta function, η(s) = (1 − 2¹⁻ˢ)ζ(s), connecting this elementary, fully-verified real-analysis computation to the celebrated ζ(−1) = −1/12. Everything stays inside elementary summability — no native_decide, no axioms.",
+    "mathContext": "$1 - 2 + 3 - 4 + \\cdots \\overset{A}{=} \\tfrac14 = \\eta(-1)$, with $\\eta(s) = (1 - 2^{1-s})\\zeta(s)$ giving $\\zeta(-1) = -\\tfrac{1}{12}$.",
+    "significance": "context",
+    "relatedConcepts": ["Dirichlet eta function", "analytic continuation", "ζ(−1) = −1/12", "Abel summability"],
+    "prerequisites": ["Abel summation conclusion"]
   }
 ]

--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
@@ -60,25 +60,50 @@
       "Euler's series is the derivative of Grandi's: differentiating ∑ (−1)ⁿxⁿ = 1/(1+x) term by term gives ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)².",
       "The closed form is obtained without calculus, by adding the two standard sums ∑ n·yⁿ and ∑ yⁿ at y = −x — keeping the proof inside elementary summability.",
       "The Abel sum is the boundary value of 1/(1+x)², continuous at x = 1 with value 1/4.",
-      "The value 1/4 = η(−1) is consistent with the analytic continuation of the Dirichlet eta function, linking this elementary computation to ζ(−1) = −1/12 via η(s) = (1 − 2¹⁻ˢ)ζ(s)."
+      "The value 1/4 = η(−1) is consistent with the analytic continuation of the Dirichlet eta function, linking this elementary computation to ζ(−1) = −1/12 via η(s) = (1 − 2¹⁻ˢ)ζ(s).",
+      "The proof never differentiates: replacing term-by-term differentiation (which would require justifying interchange of limit and sum) with a sum of two known closed forms keeps every step inside elementary, already-formalized summability — a cleaner route than the heuristic 'differentiate the geometric series' that motivates the result."
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Euler's Series and Abel Summation",
+      "startLine": 3,
+      "endLine": 26,
+      "summary": "Docstring: Euler's 1 − 2 + 3 − 4 + ⋯ is the derivative of Grandi's series; diverges ordinarily but is Abel summable to 1/4 = η(−1), tied to ζ(−1) = −1/12.",
+      "mathContext": "Abel sum of $1 - 2 + 3 - 4 + \\cdots$ is $\\tfrac14 = \\eta(-1)$."
+    },
+    {
       "id": "closed-form",
       "title": "The Differentiated Geometric Series",
-      "startLine": 35,
-      "endLine": 66,
-      "summary": "hasSum_alt_nat / alt_nat_power_series: ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x| < 1.",
-      "mathContext": "Sum of ∑ n·yⁿ = y/(1−y)² and ∑ yⁿ = 1/(1−y) at y = −x gives ∑ (n+1)yⁿ = 1/(1−y)²."
+      "startLine": 31,
+      "endLine": 56,
+      "summary": "hasSum_alt_nat: ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x| < 1, built by adding ∑ n·yⁿ and ∑ yⁿ at y = −x rather than by differentiation.",
+      "mathContext": "$\\sum_n (n+1)y^n = (1-y)^{-2}$ at $y = -x$."
+    },
+    {
+      "id": "tsum",
+      "title": "The tsum Closed Form",
+      "startLine": 57,
+      "endLine": 61,
+      "summary": "alt_nat_power_series: the tsum form ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)², enabling the boundary-limit step on a scalar-valued function.",
+      "mathContext": "$\\sum'_n (-1)^n(n+1)x^n = (1+x)^{-2}$."
     },
     {
       "id": "abel-limit",
       "title": "The Abel Limit 1/4",
-      "startLine": 68,
-      "endLine": 91,
-      "summary": "abel_tendsto_quarter: lim_{x→1⁻} ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/4, the boundary value of 1/(1+x)². abel_value_quarter packages it.",
-      "mathContext": "The radial boundary limit of 1/(1+x)² at x = 1 is 1/4, the Abel sum of 1 − 2 + 3 − 4 + ⋯."
+      "startLine": 62,
+      "endLine": 80,
+      "summary": "abel_tendsto_quarter: lim_{x→1⁻} ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/4, the radial boundary value of 1/(1+x)², via tendsto_congr' on 𝓝[<]1 and Tendsto.inv₀.",
+      "mathContext": "$\\lim_{x\\to 1^-}(1+x)^{-2} = \\tfrac14$."
+    },
+    {
+      "id": "package",
+      "title": "Packaging and η(−1)",
+      "startLine": 81,
+      "endLine": 107,
+      "summary": "abel_value_quarter packages the conclusion; closing remarks connect 1/4 = η(−1) to ζ(−1) = −1/12 via η(s) = (1 − 2¹⁻ˢ)ζ(s).",
+      "mathContext": "$1 - 2 + 3 - 4 + \\cdots \\overset{A}{=} \\tfrac14 = \\eta(-1)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for **geometric-series-oq-01-oq-01-oq-02**. Quality score 53 → 100.

## Quality improvements
- **Annotations 2 → 5, all fields added.** Each now carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Split to theorem granularity: header/context, the differentiated-geometric-series closed form, the tsum form, the Abel boundary limit, and the packaging + η(−1) connection.
- **Sections 2 → 5** to match the theorem-level split (full file coverage including header and closing remarks).
- **keyInsights 4 → 5.** Added the methodological point that the proof avoids term-by-term differentiation entirely, staying inside already-formalized elementary summability.

## Notes
- Axiom integrity verified: `status: verified`, `axiomCount: 0` match the Lean source (0 sorries, no `axiom` declarations, no `native_decide`). The η(−1)/ζ(−1) connection is presented as context, not a formalized claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)