### PR TITLE
Enrich The Full Multinomial Covariance Matrix (binomial-theorem-oq-02-oq-01-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-04/meta.json
@@ -34,6 +34,23 @@
     "substantiveTheoremCount": 4,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "The multinomial distribution — the joint law of the counts $X_1,\\dots,X_m$ obtained when $n$ independent trials each land in one of $m$ categories with probabilities $p_1,\\dots,p_m$ — is the canonical multivariate generalization of the binomial. Its second-order structure has been known since the 19th-century development of correlation theory: each coordinate is marginally $\\mathrm{Binomial}(n, p_i)$ with variance $n p_i(1-p_i)$, and distinct coordinates are negatively correlated, $\\mathrm{Cov}(X_i, X_j) = -n p_i p_j$, because the fixed total $\\sum_i X_i = n$ forces categories to compete. Packaged together these give the singular covariance matrix $\\Sigma = n\\,(\\operatorname{diag}(p) - p p^{\\mathsf T})$, whose rows sum to zero. This entry completes the gallery's formalization of that matrix: the parent (binomial-theorem-oq-02-oq-01-oq-01) deliberately proved only the off-diagonal ($i \\neq j$) entries, leaving the diagonal — the variance — as a recorded follow-up. Here the diagonal is supplied and the two cases are unified into a single $\\delta_{ij}$ formula.",
+    "problemStatement": "**Open Question (binomial-theorem-oq-02-oq-01-oq-01-oq-04)**: the parent proves $E[X_i] = n p_i$, $E[X_i X_j] = n(n-1)p_i p_j$, and $\\mathrm{Cov}(X_i,X_j) = -n p_i p_j$, all for $i \\neq j$ only. Prove the missing diagonal — the variance $\\mathrm{Var}(X_i) = n p_i(1-p_i)$ — and assemble the full covariance matrix valid for all $i,j$.\n\n**Result**: $\\mathrm{Cov}(X_i, X_j) = n\\,p_i\\,(\\delta_{ij} - p_j)$ for all $i, j$ — i.e. $\\Sigma = n(\\operatorname{diag}(p) - p p^{\\mathsf T})$ — together with the supporting diagonal second factorial moment, second moment, and variance.",
+    "text": "A 329-line, fully verified (0 sorries, 0 axioms) file completing the second-order theory of the multinomial distribution: the diagonal second factorial moment $E[X_i(X_i-1)] = n(n-1)p_i^2$, the second moment $E[X_i^2]$, the variance $\\mathrm{Var}(X_i) = n p_i(1-p_i)$, and the unified covariance matrix $\\mathrm{Cov}(X_i,X_j) = n p_i(\\delta_{ij} - p_j)$.",
+    "proofStrategy": "**Part 1 — the absorption engine.** The private lemmas `absorb` (ℕ-level) and `absorb_weighted` (ℝ-level) re-derive the combinatorial identity $k_i \\cdot \\mathrm{multinomial}(s,k) = n \\cdot \\mathrm{multinomial}(s, k')$, where $k'$ lowers the $i$-th count by one. (The parent's copies are private, so they are reproved locally.)\n\n**Part 2 — the diagonal second factorial moment.** `multinomial_second_factorial_moment` applies the absorption bijection $k \\mapsto \\mathrm{update}\\,k\\,i\\,(k_i-1)$ to coordinate $i$: the surviving factor $(k_i-1)$ becomes the lowered count $k'_i$, reducing $E[X_i(X_i-1)]$ to $n p_i$ times the $(n-1)$-mean of $X_i$, namely $n(n-1)p_i^2$.\n\n**Part 3 — assembling the matrix.** `multinomial_second_moment` uses $X_i^2 = X_i(X_i-1) + X_i$. `multinomial_variance` expands the centred square $(X_i - n p_i)^2 = X_i(X_i-1) + (1 - 2n p_i)X_i + (n p_i)^2$ and combines the factorial moment, the mean, and total mass $1$ to get $n p_i(1-p_i)$. `multinomial_covariance_matrix` then case-splits on $i = j$: the diagonal is the variance just proved, while the off-diagonal is routed through the parent's `multinomial_covariance` via a mass-zero correction (the centred and parent summands differ by a combination of $X_i\\!\\cdot\\!w$ and $X_j\\!\\cdot\\!w$ whose totals $n p_i$, $n p_j$ cancel).",
+    "keyInsights": [
+      "The whole second-order theory rests on one combinatorial identity — absorption, $k_i\\cdot\\mathrm{multinomial}(s,k) = n\\cdot\\mathrm{multinomial}(s,k')$ — applied once to a pair of coordinates (parent, cross moment) and once to a single coordinate (here, the factorial moment).",
+      "Factorial moments linearize the combinatorics: $E[X_i(X_i-1)]$ falls straight out of absorption, whereas $E[X_i^2]$ does not — so the variance is reached via $X_i^2 = X_i(X_i-1) + X_i$ rather than directly.",
+      "The Kronecker-delta form $\\mathrm{Cov}(X_i,X_j) = n p_i(\\delta_{ij}-p_j)$ unifies two genuinely different proofs (a new absorption computation on the diagonal, a reduction to the parent off-diagonal) into one statement — the $n(\\operatorname{diag}(p)-p p^{\\mathsf T})$ matrix in coordinate form.",
+      "The off-diagonal case needs no new combinatorics: the centred summand and the parent's raw-moment summand differ only by terms whose total mass vanishes (each sums to a mean), so the covariance equals the parent's value by a linear, mass-conservation argument."
+    ],
+    "prerequisites": [
+      "The multinomial PMF and the parent's mean/cross-moment formalization (binomial-theorem-oq-02-oq-01-oq-01)",
+      "Factorial moments and the identity Var(X) = E[X(X-1)] + E[X] - E[X]²",
+      "Finset.piAntidiag and reindexing sums by a bijection in Lean 4/Mathlib"
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -79,6 +96,49 @@
       "leanType": "(s : Finset α) (p : α → ℝ) (n : ℕ) (hp_sum : ∑ i ∈ s, p i = 1) (hp_nonneg : ∀ i ∈ s, 0 ≤ p i) (i : α) (hi : i ∈ s) → ∑ k ∈ s.piAntidiag n, (k i : ℝ) ^ 2 * ((Nat.multinomial s k : ℝ) * ∏ l ∈ s, p l ^ k l) = (n : ℝ) * ((n - 1 : ℕ) : ℝ) * p i * p i + (n : ℝ) * p i"
     }
   ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Setup: The Missing Diagonal",
+      "startLine": 4,
+      "endLine": 50,
+      "summary": "Module docstring: the parent proves mean/cross-moment/off-diagonal covariance for i≠j only, leaving the variance (diagonal) absent; this file closes the gap and unifies the covariance matrix. States the four results, the parent connection, and the 0-axiom status; namespace and opens.",
+      "mathContext": "Σ = n·(diag(p) − p·pᵀ); the diagonal Var(Xᵢ) = n·pᵢ(1−pᵢ) is the missing entry."
+    },
+    {
+      "id": "absorption-engine",
+      "title": "Part 1 — The Absorption Engine",
+      "startLine": 58,
+      "endLine": 142,
+      "summary": "Private lemmas absorb (ℕ-level) and absorb_weighted (ℝ-level) re-derive the combinatorial identity kᵢ·multinomial(s,k) = n·multinomial(s,k'), lowering the i-th count by one — the engine behind every moment computation.",
+      "mathContext": "kᵢ · multinomial(s,k) = n · multinomial(s, k'), where k' = update k i (kᵢ−1)."
+    },
+    {
+      "id": "factorial-moment",
+      "title": "Part 2 — The Diagonal Second Factorial Moment",
+      "startLine": 143,
+      "endLine": 235,
+      "summary": "multinomial_second_factorial_moment: E[Xᵢ(Xᵢ−1)] = n(n−1)pᵢ², via the absorption bijection on coordinate i — the surviving (kᵢ−1) becomes the lowered count, reducing to n·pᵢ times the (n−1)-mean of Xᵢ.",
+      "mathContext": "E[Xᵢ(Xᵢ−1)] = n(n−1)pᵢ²."
+    },
+    {
+      "id": "variance-covariance",
+      "title": "Part 3 — Second Moment, Variance, and the Covariance Matrix",
+      "startLine": 236,
+      "endLine": 329,
+      "summary": "multinomial_second_moment (E[Xᵢ²] = n(n−1)pᵢ² + n·pᵢ via Xᵢ²=Xᵢ(Xᵢ−1)+Xᵢ), multinomial_variance (n·pᵢ(1−pᵢ) by expanding the centred square), and multinomial_covariance_matrix (the unified δᵢⱼ formula: diagonal = variance, off-diagonal routed through the parent by a mass-zero correction).",
+      "mathContext": "Cov(Xᵢ,Xⱼ) = n·pᵢ·(δᵢⱼ − pⱼ) for all i,j."
+    }
+  ],
+  "conclusion": {
+    "summary": "Completes the second-order theory of the multinomial distribution: the diagonal second factorial moment E[Xᵢ(Xᵢ−1)] = n(n−1)pᵢ², the second moment E[Xᵢ²], the variance Var(Xᵢ) = n·pᵢ(1−pᵢ), and the unified covariance matrix Cov(Xᵢ,Xⱼ) = n·pᵢ(δᵢⱼ − pⱼ) valid for all i,j — the n·(diag(p) − p·pᵀ) matrix in coordinate form. Fully verified, 0 sorries, 0 axioms.",
+    "implications": "Supplies the complete covariance structure that a joint (Cramér–Wold) multinomial CLT requires, the input flagged as missing by the sibling marginal-CLT entry. The δᵢⱼ formula exhibits the singular, rank-(m−1) covariance whose row sums vanish — the algebraic shadow of the constraint ∑ᵢ Xᵢ = n — and demonstrates how a single combinatorial identity (absorption) governs all first- and second-order multinomial moments.",
+    "openQuestions": [
+      "Prove a joint multinomial CLT (Cramér–Wold) using this covariance matrix, identifying the limit as a degenerate Gaussian supported on the hyperplane ∑ xᵢ = 0.",
+      "Formalize higher mixed factorial moments E[∏ᵢ Xᵢ^{(rᵢ)}] = n^{(∑rᵢ)} ∏ᵢ pᵢ^{rᵢ} by iterating absorption over several coordinates, recovering all multinomial moments uniformly.",
+      "Express the result as an explicit matrix identity Σ = n(diag(p) − p·pᵀ) over Matrix s s ℝ and compute its rank and null space."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "binomial-theorem-oq-02-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-02-oq-01-oq-01-oq-04`.

## Quality improvements
The entry had **no `overview`, no `sections`, and no `conclusion`** (annotations were already strong). Added all three:
- **overview**: full `historicalContext` (the multinomial second-order/correlation theory, the singular n·(diag(p)−p·pᵀ) covariance), `problemStatement`, `proofStrategy` (the 3-part absorption→factorial-moment→variance→matrix flow), and 4 `keyInsights`.
- **sections**: 4 parts covering the full 329-line file (header, absorption engine, diagonal factorial moment, variance + covariance matrix).
- **conclusion**: `summary`, `implications` (joint Cramér–Wold CLT input; rank-(m−1) singular covariance), and 3 `openQuestions`.

Annotations (6, already carrying mathContext/significance/relatedConcepts/prerequisites) re-verified aligned 6/6 via `scripts/annotations/resolver.ts`.

Axiom integrity verified against source: `status: verified`, `axiomCount: 0`, 0 sorries — the probabilistic hypotheses ∑p=1, 0≤pᵢ are ordinary theorem hypotheses, not assumptions.

`pnpm build` passes.