### PR TITLE
research(bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02): unit-group cardinality under k-fold CRT [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ03OQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/BezoutIdentityOQ03OQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,152 @@
+/-
+# Unit-group cardinality under the k-fold CRT
+# (bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02)
+
+## Open Question
+The parent (oq-03-oq-01-oq-01-oq-02) proved the *element*-count is preserved by
+the k-fold Chinese Remainder isomorphism:
+  |ℤ/(∏nᵢ)ℤ| = ∏ᵢ |ℤ/nᵢℤ| = ∏ᵢ nᵢ.
+Carry the same transport one functor up, to the **unit groups**:
+  |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ |(ℤ/nᵢℤ)ˣ|,
+and express the right-hand side in terms of Euler's totient.
+
+## Answer: YES
+
+The new content is the **unit-group cardinality preservation**
+(`card_units_preservation`). It is obtained by applying the *units functor* to
+the parent's ring isomorphism `crtKFold ns h : ℤ/(∏nᵢ)ℤ ≃+* CRTProd ns`. A ring
+isomorphism is in particular a multiplicative isomorphism, so `Units.mapEquiv`
+lifts it to a group isomorphism on units; transporting `Nat.card` along it
+reduces the count to the nested product type `CRTProd`. There the units of a
+product factor by `MulEquiv.prodUnits : (α × β)ˣ ≃* αˣ × βˣ`, and an induction
+peels off one factor at a time (`Nat.card_prod`).
+
+This mirrors the parent's element-count proof exactly one functor up: where the
+parent factored `Nat.card (CRTProd ns)` through `Nat.card_prod`, we factor
+`Nat.card (CRTProd ns)ˣ` through `MulEquiv.prodUnits` and then `Nat.card_prod`.
+Unlike the element count, the *unit* count does **not** read off from `Nat.card`
+alone — the order of `(ℤ/nℤ)ˣ` is Euler's `φ n`, which is genuinely sensitive to
+the factorization of `n` — so the CRT route is the substance, not a coincidence.
+
+The totient bridge `Nat.card (ℤ/nℤ)ˣ = φ n` (`natCard_units_zmod`, valid for
+`n > 0` via `ZMod.card_units_eq_totient`) then lets us read the right-hand side
+as `∏ᵢ φ(nᵢ)`, giving the headline payoff
+  |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ φ(nᵢ)            (`card_units_eq_totient_prod`).
+
+Multiplicativity of `φ` *itself* — `φ(∏nᵢ) = ∏φ(nᵢ)` — is **not** new: it is in
+Mathlib (`Nat.totient_mul`) and is already proved unconditionally in the parent
+file as `totient_prod_pairwise_coprime` (by `Nat.totient_mul` induction). We do
+not re-derive it; instead `card_units_eq_totient_prod` exhibits the *same product*
+`∏φ(nᵢ)` as the order of the unit group of `ℤ/(∏nᵢ)ℤ`, i.e. as the unit-count
+shadow of the explicit k-fold CRT isomorphism.
+
+We use `Nat.card` throughout, so the pure unit-count statement
+(`card_units_CRTProd`, `card_units_preservation`) needs no positivity hypothesis.
+Only the totient reading requires `0 < nᵢ`, because `ℤ/0ℤ = ℤ` has the two units
+`±1` whereas `φ 0 = 0`.
+
+## Status
+- All theorems proved (0 sorries, 0 axioms)
+- Reuses `crtKFold` / `CRTProd` from `Proofs.BezoutIdentityOQ03OQ01OQ01`
+-/
+
+import Mathlib
+import Proofs.BezoutIdentityOQ03OQ01OQ01
+
+namespace BezoutCRTUnits
+
+open BezoutCRTKFold
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: UNIT-GROUP CARDINALITY OF THE NESTED PRODUCT TYPE
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The unit count of the nested product type `CRTProd ns` factors as the
+    product of the unit counts of its `ZMod` factors. Proved by induction on
+    `ns`: at each `cons`, `MulEquiv.prodUnits` splits the units of a product
+    into a product of unit groups, and `Nat.card_prod` splits the count. -/
+theorem card_units_CRTProd (ns : List ℕ) :
+    Nat.card (CRTProd ns)ˣ = (ns.map (fun n => Nat.card (ZMod n)ˣ)).prod := by
+  induction ns with
+  | nil =>
+      -- `CRTProd [] = PUnit`; its unit group is a subsingleton with one element.
+      simp only [CRTProd, List.map_nil, List.prod_nil]
+      exact Nat.card_eq_one_iff_unique.mpr ⟨inferInstance, inferInstance⟩
+  | cons n ns ih =>
+      -- `CRTProd (n :: ns) = ZMod n × CRTProd ns`.
+      simp only [CRTProd, List.map_cons, List.prod_cons]
+      -- Units of a product ≃* product of unit groups.
+      rw [Nat.card_congr (MulEquiv.prodUnits (M := ZMod n) (N := CRTProd ns)).toEquiv,
+          Nat.card_prod, ih]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: TRANSPORT OF THE UNIT COUNT ALONG THE CRT ISOMORPHISM
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Unit-group cardinality preservation.** For pairwise-coprime moduli, the
+    unit count of `ℤ/(∏nᵢ)ℤ` equals the product of the unit counts of the
+    factors `ℤ/nᵢℤ`. Obtained by transporting `Nat.card` along the units of the
+    k-fold CRT ring isomorphism. No positivity hypothesis is needed. -/
+theorem card_units_preservation (ns : List ℕ) (h : List.Pairwise Nat.Coprime ns) :
+    Nat.card (ZMod ns.prod)ˣ = (ns.map (fun n => Nat.card (ZMod n)ˣ)).prod := by
+  -- The ring iso `crtKFold` is in particular a multiplicative iso, so its
+  -- units functor gives `(ℤ/(∏nᵢ)ℤ)ˣ ≃* (CRTProd ns)ˣ`.
+  rw [Nat.card_congr (Units.mapEquiv (crtKFold ns h).toMulEquiv).toEquiv,
+      card_units_CRTProd]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: THE UNIT COUNT AS A PRODUCT OF TOTIENTS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- For a positive modulus, `Nat.card (ℤ/nℤ)ˣ` is Euler's totient `φ n`.
+    Bridges the `Nat.card`-based unit count to Mathlib's `Nat.totient`. -/
+theorem natCard_units_zmod (n : ℕ) (hn : 0 < n) :
+    Nat.card (ZMod n)ˣ = n.totient := by
+  haveI : NeZero n := ⟨hn.ne'⟩
+  rw [Nat.card_eq_fintype_card, ZMod.card_units_eq_totient]
+
+/-- **Headline payoff.** The order of the unit group of `ℤ/(∏nᵢ)ℤ` equals the
+    product of the totients `∏ᵢ φ(nᵢ)` (pairwise-coprime, positive moduli).
+    Combines the unit-count preservation with the termwise totient bridge.
+
+    Together with the standard `φ N = |(ℤ/Nℤ)ˣ|` this *re-expresses* the parent's
+    `totient_prod_pairwise_coprime` (`φ(∏nᵢ)=∏φ(nᵢ)`) as the unit-count shadow of
+    the CRT isomorphism; we do not re-prove the totient identity itself. -/
+theorem card_units_eq_totient_prod (ns : List ℕ)
+    (h : List.Pairwise Nat.Coprime ns) (hpos : ∀ n ∈ ns, 0 < n) :
+    Nat.card (ZMod ns.prod)ˣ = (ns.map Nat.totient).prod := by
+  rw [card_units_preservation ns h]
+  -- Termwise replace `Nat.card (ℤ/nᵢℤ)ˣ` by `φ nᵢ` (each nᵢ is positive).
+  exact congrArg List.prod (List.map_congr_left (fun n hn => natCard_units_zmod n (hpos n hn)))
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: WORKED EXAMPLE  (30 = 2 · 3 · 5)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- `[2, 3, 5]` is pairwise coprime. -/
+theorem coprime_2_3_5' : List.Pairwise Nat.Coprime [2, 3, 5] := by decide
+
+/-- Unit-count preservation for `30 = 2 · 3 · 5`:
+    `|(ℤ/30ℤ)ˣ| = |(ℤ/2ℤ)ˣ| · |(ℤ/3ℤ)ˣ| · |(ℤ/5ℤ)ˣ|`. -/
+theorem card_units_2_3_5 :
+    Nat.card (ZMod ([2, 3, 5].prod))ˣ
+      = ([2, 3, 5].map (fun n => Nat.card (ZMod n)ˣ)).prod :=
+  card_units_preservation [2, 3, 5] coprime_2_3_5'
+
+/-- The headline payoff at `[2, 3, 5]`:
+    `|(ℤ/30ℤ)ˣ| = φ(2)·φ(3)·φ(5)`. -/
+theorem card_units_30_eq_totient_prod :
+    Nat.card (ZMod ([2, 3, 5].prod))ˣ = ([2, 3, 5].map Nat.totient).prod :=
+  card_units_eq_totient_prod [2, 3, 5] coprime_2_3_5' (by decide)
+
+/-- Numeric check: `|(ℤ/30ℤ)ˣ| = φ(2)·φ(3)·φ(5) = 1·2·4 = 8`. -/
+theorem card_units_30_eq_8 : Nat.card (ZMod 30)ˣ = 8 := by
+  have h : Nat.card (ZMod ([2, 3, 5].prod))ˣ = 8 := by
+    rw [card_units_30_eq_totient_prod]; decide
+  simpa using h
+
+end BezoutCRTUnits

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02",
+  "title": "Unit-group cardinality under the k-fold CRT: |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| = ∏ᵢφ(nᵢ)",
+  "slug": "bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02",
+  "description": "Answers the parent's stated open question: carry the k-fold Chinese Remainder cardinality transport one functor up, from the rings to their unit groups. The new content is the unit-group cardinality preservation |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ|, obtained by applying the units functor (Units.mapEquiv) to the parent's k-fold CRT ring isomorphism crtKFold, then factoring Nat.card over the nested product type via MulEquiv.prodUnits ((α×β)ˣ ≃* αˣ×βˣ) and Nat.card_prod. Unlike the parent's element count — which reads off Nat.card alone — the unit count genuinely requires the CRT decomposition, since |（ℤ/nℤ)ˣ| = φ(n) is sensitive to the factorization of n. Via the bridge Nat.card (ℤ/nℤ)ˣ = φ(n) (positive moduli), the headline payoff card_units_eq_totient_prod reads the right-hand side as ∏ᵢφ(nᵢ), exhibiting that product as the order of the unit group of ℤ/(∏nᵢ)ℤ. Multiplicativity of φ itself is NOT re-proved here — it is Mathlib's Nat.totient_mul and is already established unconditionally in the parent file as totient_prod_pairwise_coprime; this entry recovers it as the unit-count shadow of the explicit CRT isomorphism.",
+  "meta": {
+    "author": "Euler, Gauss; formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function",
+    "date": "1801",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "chinese-remainder",
+      "ring-theory",
+      "group-of-units",
+      "euler-totient",
+      "cardinality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Units.mapEquiv",
+        "description": "Lifts a multiplicative equivalence M ≃* N to a group isomorphism Mˣ ≃* Nˣ on units — the units functor applied to the CRT ring isomorphism",
+        "module": "Mathlib.Algebra.Group.Units.Equiv"
+      },
+      {
+        "theorem": "MulEquiv.prodUnits",
+        "description": "(α × β)ˣ ≃* αˣ × βˣ — units of a product factor as a product of unit groups",
+        "module": "Mathlib.Algebra.Group.Units.Equiv"
+      },
+      {
+        "theorem": "Nat.card_congr",
+        "description": "An equivalence α ≃ β gives Nat.card α = Nat.card β — transports the unit count along the CRT-induced units isomorphism",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Nat.card_prod",
+        "description": "Nat.card (α × β) = Nat.card α * Nat.card β — factors the unit count of the nested product factor-by-factor",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "ZMod.card_units_eq_totient",
+        "description": "Fintype.card (ZMod n)ˣ = φ n for NeZero n — the bridge from the unit count to Euler's totient",
+        "module": "Mathlib.Data.ZMod.Units"
+      }
+    ],
+    "originalContributions": [
+      "card_units_CRTProd: Nat.card (CRTProd ns)ˣ = ∏ᵢ Nat.card (ZMod nᵢ)ˣ by induction, splitting units of a product with MulEquiv.prodUnits then Nat.card_prod at each cons",
+      "card_units_preservation: |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| by transporting Nat.card along the units functor Units.mapEquiv applied to crtKFold — the substantive new result, hypothesis-free",
+      "natCard_units_zmod: Nat.card (ℤ/nℤ)ˣ = φ(n) for 0 < n, bridging the Nat.card unit count to Mathlib's Nat.totient via ZMod.card_units_eq_totient",
+      "card_units_eq_totient_prod: headline payoff |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢφ(nᵢ) for pairwise-coprime positive moduli — exhibits ∏φ(nᵢ) as the order of the unit group of ℤ/(∏nᵢ)ℤ",
+      "card_units_2_3_5, card_units_30_eq_totient_prod, card_units_30_eq_8: concrete instances for 30 = 2·3·5, |(ℤ/30ℤ)ˣ| = φ(2)·φ(3)·φ(5) = 1·2·4 = 8"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries — verified via #print axioms (depends only on the foundational propext / Classical.choice / Quot.sound; no sorryAx, no Lean.ofReduceBool). The decide-discharged facts (coprimality of [2,3,5], φ(2)·φ(3)·φ(5)=8) use kernel decidability, NOT native_decide. The pure unit-count statements (card_units_CRTProd, card_units_preservation) are hypothesis-free (Nat.card throughout); the totient reading (natCard_units_zmod, card_units_eq_totient_prod) requires 0 < nᵢ, since ℤ/0ℤ = ℤ has units {±1} (count 2) whereas φ(0) = 0. Reuses the parent's crtKFold isomorphism and CRTProd product type from Proofs/BezoutIdentityOQ03OQ01OQ01.lean. Multiplicativity of φ itself is Mathlib's Nat.totient_mul and is NOT re-proved here; this entry's new content is the unit-group cardinality transport.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Chinese Remainder Theorem, as a ring isomorphism ℤ/(∏nᵢ)ℤ ≅ ∏ᵢ ℤ/nᵢℤ, is multiplicative as well as additive, so it restricts to an isomorphism of unit groups (ℤ/(∏nᵢ)ℤ)ˣ ≅ ∏ᵢ (ℤ/nᵢℤ)ˣ. Counting both sides gives the multiplicativity of |(ℤ/nℤ)ˣ|, and since |(ℤ/nℤ)ˣ| = φ(n) this is exactly the classical multiplicativity of Euler's totient — historically Euler's own route to φ(mn) = φ(m)φ(n) for coprime m, n. The parent entry established the additive (element-count) form |ℤ/(∏nᵢ)ℤ| = ∏nᵢ; this entry establishes the multiplicative (unit-count) form, which is the arithmetically substantive one because the order of the unit group, unlike the order of the ring, is not a function of n alone.",
+    "problemStatement": "**Open question (stated verbatim in the parent bezout-identity-oq-03-oq-01-oq-01-oq-02):** Derive the k-fold unit-group cardinality |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| from the ring isomorphism, recovering φ(∏nᵢ) = ∏φ(nᵢ) purely as a counting corollary.\n\n**Headline (card_units_preservation):** For a list ns of pairwise coprime natural numbers,\n  Nat.card (ZMod ns.prod)ˣ = (ns.map (fun n => Nat.card (ZMod n)ˣ)).prod.\n\n**Payoff (card_units_eq_totient_prod):** for additionally positive moduli,\n  Nat.card (ZMod ns.prod)ˣ = (ns.map Nat.totient).prod.",
+    "text": "A 152-line formalization answering the parent's stated unit-group open question. The new content is card_units_preservation: |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ|, obtained by applying the units functor Units.mapEquiv to the parent's ring isomorphism crtKFold (a RingEquiv, hence a MulEquiv) and transporting Nat.card. The supporting card_units_CRTProd factors the unit count of the nested product type CRTProd by induction, using MulEquiv.prodUnits ((α×β)ˣ ≃* αˣ×βˣ) and Nat.card_prod at each cons. The totient bridge natCard_units_zmod (Nat.card (ℤ/nℤ)ˣ = φ(n) for n > 0) then yields the payoff card_units_eq_totient_prod: |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢφ(nᵢ). Multiplicativity of φ itself is Mathlib's Nat.totient_mul (and is already proved unconditionally in the parent file); this entry does not re-derive it, but re-expresses the product ∏φ(nᵢ) as the order of a unit group. Fully verified: 0 sorries, 0 axioms.",
+    "proofStrategy": "**Unit-count preservation (card_units_preservation):**\n1. The parent's crtKFold ns h : ℤ/(∏nᵢ)ℤ ≃+* CRTProd ns is a ring isomorphism, hence in particular a multiplicative isomorphism (.toMulEquiv). The units functor Units.mapEquiv lifts it to (ℤ/(∏nᵢ)ℤ)ˣ ≃* (CRTProd ns)ˣ; Nat.card_congr on its underlying equivalence transports the count.\n2. card_units_CRTProd: Nat.card (CRTProd ns)ˣ = ∏ᵢ Nat.card (ZMod nᵢ)ˣ, by induction on ns. Base: CRTProd [] = PUnit, whose unit group is a one-element subsingleton (Nat.card_eq_one_iff_unique). Step: CRTProd (n :: ns) = ZMod n × CRTProd ns; MulEquiv.prodUnits splits its units as (ZMod n)ˣ × (CRTProd ns)ˣ, Nat.card_prod splits the count, then the inductive hypothesis.\n\n**Totient reading (card_units_eq_totient_prod):** rewrite by card_units_preservation, then termwise replace Nat.card (ℤ/nᵢℤ)ˣ by φ(nᵢ) via natCard_units_zmod (needs 0 < nᵢ), using List.map_congr_left under List.prod.\n\n**Bridge (natCard_units_zmod):** for 0 < n, NeZero n makes ZMod n finite, so Nat.card_eq_fintype_card reduces to ZMod.card_units_eq_totient.",
+    "keyInsights": [
+      "The unit count is the arithmetically substantive transport: unlike |ℤ/nℤ| = n, the order |(ℤ/nℤ)ˣ| = φ(n) is NOT a function of n alone, so the equality |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| genuinely depends on the CRT decomposition rather than on a coincidence of two independent evaluations",
+      "The whole result is 'the parent's proof one functor up': where the parent factored Nat.card (CRTProd ns) through Nat.card_prod, this entry factors Nat.card (CRTProd ns)ˣ through MulEquiv.prodUnits and then Nat.card_prod",
+      "A RingEquiv is in particular a MulEquiv (.toMulEquiv), so Units.mapEquiv applies directly to crtKFold — no bespoke unit-group isomorphism needs to be built",
+      "Using Nat.card keeps the pure unit-count statement hypothesis-free; only the totient reading needs 0 < nᵢ, because ℤ/0ℤ = ℤ has the two units ±1 while φ(0) = 0",
+      "Multiplicativity of φ is not re-proved (it is Mathlib's Nat.totient_mul, already in the parent as totient_prod_pairwise_coprime); the contribution is exhibiting ∏φ(nᵢ) concretely as the order of (ℤ/(∏nᵢ)ℤ)ˣ via the explicit isomorphism"
+    ],
+    "prerequisites": [
+      "Number theory (the Chinese Remainder Theorem, Euler's totient)",
+      "Group of units of a ring and the units functor",
+      "Cardinality of finite types (Nat.card)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "card-units-crtprod",
+      "title": "Unit-Group Cardinality of the Nested Product Type",
+      "startLine": 69,
+      "endLine": 90,
+      "summary": "card_units_CRTProd: Nat.card (CRTProd ns)ˣ = ∏ᵢ Nat.card (ZMod nᵢ)ˣ, by induction on the modulus list. Base case Nat.card PUnitˣ = 1 (one-element subsingleton); inductive step splits the units of CRTProd (n :: ns) = ZMod n × CRTProd ns via MulEquiv.prodUnits and Nat.card_prod.",
+      "mathContext": "The units of a product ring factor as the product of the unit groups: (α × β)ˣ ≅ αˣ × βˣ. Iterating this over the right-associated CRTProd gives the unit count as a product of per-factor unit counts, with no finiteness hypotheses threaded through the recursion."
+    },
+    {
+      "id": "unit-transport",
+      "title": "Transport of the Unit Count Along the CRT Isomorphism",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "card_units_preservation: |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| for pairwise coprime moduli — the substantive new result. The parent's crtKFold ring isomorphism is a MulEquiv, so Units.mapEquiv lifts it to the unit groups and Nat.card_congr transports the count to CRTProd, where card_units_CRTProd finishes.",
+      "mathContext": "An isomorphism of rings restricts to an isomorphism of unit groups. Applying the units functor to crtKFold and counting gives the multiplicativity of the unit-group order under the CRT — the genuinely arithmetic content, since |(ℤ/nℤ)ˣ| = φ(n) is not determined by n alone."
+    },
+    {
+      "id": "totient-bridge",
+      "title": "The Unit Count as a Product of Totients",
+      "startLine": 105,
+      "endLine": 129,
+      "summary": "natCard_units_zmod: Nat.card (ℤ/nℤ)ˣ = φ(n) for n > 0 (via ZMod.card_units_eq_totient). card_units_eq_totient_prod: the headline payoff |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢφ(nᵢ) for pairwise-coprime positive moduli, by rewriting the preservation result and replacing each factor termwise.",
+      "mathContext": "Reading |(ℤ/nℤ)ˣ| as φ(n) turns the unit-count preservation into a statement about totients: the product ∏φ(nᵢ) is exhibited as the order of the unit group of ℤ/(∏nᵢ)ℤ. Combined with the standard φ(N) = |(ℤ/Nℤ)ˣ|, this re-expresses the parent's totient multiplicativity as the unit-count shadow of the CRT isomorphism."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Example (30 = 2·3·5)",
+      "startLine": 130,
+      "endLine": 152,
+      "summary": "coprime_2_3_5'; card_units_2_3_5 (preservation at [2,3,5]); card_units_30_eq_totient_prod (|(ℤ/30ℤ)ˣ| = φ(2)·φ(3)·φ(5)); card_units_30_eq_8 (the numeric value |(ℤ/30ℤ)ˣ| = 1·2·4 = 8).",
+      "mathContext": "For 30 = 2·3·5, the unit group (ℤ/30ℤ)ˣ has order φ(30) = φ(2)·φ(3)·φ(5) = 1·2·4 = 8, a concrete witness of the general theorem; the numeric facts are discharged by kernel decidability (decide), not native_decide."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-03-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Direct parent: cardinality (element-count) preservation under the k-fold CRT, |ℤ/(∏nᵢ)ℤ| = ∏ᵢnᵢ. This entry answers that parent's explicitly stated open question by carrying the transport up to the unit groups, reusing its crtKFold isomorphism and CRTProd product type."
+    },
+    {
+      "targetId": "bezout-identity-oq-03-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the k-fold CRT ring isomorphism ℤ/(∏nᵢ)ℤ ≅ ∏ᵢ ℤ/nᵢℤ and its totient corollary totient_prod_pairwise_coprime. The units functor is applied directly to its crtKFold isomorphism here."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "Provides the unit-group view of totient multiplicativity: ∏ᵢφ(nᵢ) is the order of (ℤ/(∏nᵢ)ℤ)ˣ. The totient identity φ(∏nᵢ)=∏φ(nᵢ) itself is Mathlib's Nat.totient_mul and is not re-proved here."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's stated unit-group open question with 0 axioms and 0 sorries: |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| for pairwise coprime moduli, obtained by applying the units functor (Units.mapEquiv) to the parent's crtKFold ring isomorphism and factoring Nat.card over the nested product with MulEquiv.prodUnits. Via the bridge |(ℤ/nℤ)ˣ| = φ(n) it reads the right-hand side as ∏ᵢφ(nᵢ), exhibiting that product as the order of the unit group of ℤ/(∏nᵢ)ℤ.",
+    "implications": "**For number theory**: this is the multiplicative half of the CRT counting principle and the structural source of Euler's φ(mn) = φ(m)φ(n); it generalizes that to a list of pairwise-coprime moduli with the product realized concretely as a unit-group order.\n\n**For formalization**: shows that the units functor (Units.mapEquiv + MulEquiv.prodUnits) transports a CRT ring isomorphism to its unit groups with no bespoke construction, and that Nat.card keeps the pure unit-count statement free of finiteness side conditions.",
+    "openQuestions": [
+      "Prove the structure-level isomorphism (ℤ/(∏nᵢ)ℤ)ˣ ≃* ∏ᵢ (ℤ/nᵢℤ)ˣ as a packaged MulEquiv (not just the cardinality), exposing the explicit unit-group decomposition behind the count.",
+      "Specialize to prime-power moduli to recover the Euler-product formula φ(n) = n·∏_{p∣n}(1 - 1/p) as a corollary of unit-count multiplicativity."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BezoutIdentityOQ03OQ01OQ01"
+    ],
+    "opens": [
+      "BezoutCRTKFold"
+    ],
+    "namespace": "BezoutCRTUnits",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "venue": "Gerhard Fleischer, Leipzig",
+      "note": "Articles 32-39: congruences, the Chinese Remainder Theorem, and the multiplicativity of φ"
+    },
+    {
+      "authors": "Ireland, Kenneth; Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer Graduate Texts in Mathematics",
+      "note": "Chapter 3: the CRT as a ring isomorphism, with the unit-group and Euler-totient corollaries"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **explicitly stated open question** of the parent entry `bezout-identity-oq-03-oq-01-oq-01-oq-02`:

> *Derive the k-fold unit-group cardinality |(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ| from the ring isomorphism, recovering φ(∏nᵢ) = ∏φ(nᵢ) purely as a counting corollary.*

The parent established the **element**-count transport |ℤ/(∏nᵢ)ℤ| = ∏nᵢ. This entry carries the same transport **one functor up**, to the **unit groups**.

## New content (not in parent / Mathlib)

- `card_units_CRTProd` — `Nat.card (CRTProd ns)ˣ = ∏ᵢ Nat.card (ZMod nᵢ)ˣ`, by induction, splitting the units of a product with `MulEquiv.prodUnits : (α×β)ˣ ≃* αˣ×βˣ` then `Nat.card_prod`.
- `card_units_preservation` — **headline**: `|(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢ|(ℤ/nᵢℤ)ˣ|`, by transporting `Nat.card` along `Units.mapEquiv` applied to the parent's `crtKFold` ring isomorphism. Hypothesis-free (Nat.card).
- `natCard_units_zmod` — bridge `Nat.card (ℤ/nℤ)ˣ = φ(n)` for `n > 0`.
- `card_units_eq_totient_prod` — payoff: `|(ℤ/(∏nᵢ)ℤ)ˣ| = ∏ᵢφ(nᵢ)` (pairwise-coprime positive moduli).
- Worked example for `30 = 2·3·5`: `|(ℤ/30ℤ)ˣ| = φ(2)·φ(3)·φ(5) = 1·2·4 = 8`.

## Why this is substantive, not a wrapper

Unlike `|ℤ/nℤ| = n`, the order `|(ℤ/nℤ)ˣ| = φ(n)` is **not a function of n alone**, so the equality genuinely depends on the CRT decomposition rather than on a coincidence of two independent evaluations. It is the parent's proof exactly one functor up: where the parent factored `Nat.card (CRTProd ns)` through `Nat.card_prod`, this factors `Nat.card (CRTProd ns)ˣ` through `MulEquiv.prodUnits` then `Nat.card_prod`.

**Honesty note:** multiplicativity of φ *itself* (`φ(∏nᵢ)=∏φ(nᵢ)`) is **not** re-proved — it is Mathlib's `Nat.totient_mul` and is already proved unconditionally in the parent file as `totient_prod_pairwise_coprime`. The contribution here is exhibiting `∏φ(nᵢ)` concretely as the **order of the unit group** of `ℤ/(∏nᵢ)ℤ` via the explicit isomorphism.

## Verification

- 8 theorems, 152 lines, **0 sorries, 0 axioms**.
- `#print axioms` on the main results lists only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- `decide`-discharged facts use **kernel** decidability, not `native_decide`.
- Type-checks against the v4.26.0 Mathlib cache (`lake env lean`); the deployer build gate performs the authoritative kernel rebuild before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)