### PR TITLE
Enrich The Iterative Digital Root Equals its Closed Form (divisibility-by-3-oq-03-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/annotations.json
@@ -44,11 +44,11 @@
     "id": "ann-digitalrootbase-modeq",
     "proofId": "divisibility-by-3-oq-03-oq-02-oq-01",
     "range": { "startLine": 136, "endLine": 145 },
-    "type": "lemma",
+    "type": "theorem",
     "title": "Closed Form Depends Only on the Residue mod (b-1)",
     "content": "`digitalRootBase_modEq_eq`: if $m, n > 0$ and $m \\equiv n \\pmod{b-1}$ then $\\mathrm{dr}_b(m) = \\mathrm{dr}_b(n)$. The proof peels a successor off each positive input and cancels it with `Nat.ModEq.add_right_cancel'`, reducing $m \\equiv n$ to $(m-1) \\equiv (n-1)$ and hence $(m-1)\\bmod(b-1) = (n-1)\\bmod(b-1)$. This is the bridge that lets a residue-preserving digit-sum step leave the closed form unchanged.",
     "mathContext": "$\\mathrm{dr}_b(n) = 1 + ((n-1)\\bmod(b-1))$ for $n>0$, so equal residues mod $b-1$ force equal digital roots.",
-    "significance": "important",
+    "significance": "supporting",
     "prerequisites": [
       "Nat.ModEq",
       "Nat.ModEq.add_right_cancel'",


### PR DESCRIPTION
Enrichment pass for `divisibility-by-3-oq-03-oq-02-oq-01`.

## Quality improvements
- **overview**: converted from a **plain string** (which renders nothing — the page component reads `overview.historicalContext` etc.) into a structured object with `historicalContext` (casting out nines, Fibonacci/Liber Abaci, the mod-(b−1) mechanism), `problemStatement`, `proofStrategy` (the 5-part flow), and 4 `keyInsights`.
- **conclusion**: converted from a **plain string** into an object with `summary`, `implications`, and 3 `openQuestions`.
- **sections**: added (none before) — 6 parts covering the full 203-line Lean file.
- **annotations**: fixed a baseline misalignment — one annotation had type `lemma` (line 136 is a `theorem`) and an invalid `significance: important`; corrected to `theorem`/`supporting`. Now 5/5 aligned per `scripts/annotations/resolver.ts`.

Axiom integrity verified against source: `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries, no `native_decide`.

`pnpm build` passes.