### PR TITLE
audit(gallery): 9 fresh entries clean (basel/beta/bezout/cevas/erdos-211/group-p²/trapezoid/cubic/newton)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23285,6 +23285,60 @@
       "lastAudited": "2026-06-25T05:14:05Z",
       "result": "clean",
       "issues": []
+    },
+    "basel-problem-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "beta-integral-recurrence-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-non-euclidean-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-211-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "group-order-prime-squared-abelian-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "mean-value-theorem-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "solution-of-cubic-oq-03-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T05:49:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 9 fresh entries, all CLEAN

Audited 9 never-before-audited gallery entries. All verified clean: meta claims match the Lean source exactly.

| Slug | Result |
|------|--------|
| basel-problem-oq-03-oq-01 (stuffle ζ(2)²=ζ(4)+2ζ(2,2)) | clean |
| beta-integral-recurrence-oq-01-oq-02-oq-01 (half-integer Beta diagonal) | clean |
| bezout-identity-oq-03-oq-01-oq-01-oq-02-oq-02 (k-fold CRT unit count) | clean |
| cevas-theorem-non-euclidean-oq-01-oq-02 (Menelaus at curvature κ) | clean |
| erdos-211-incomplete-01 (Steiner triple system line count) | clean |
| group-order-prime-squared-abelian-oq-01-oq-01-oq-02 (order-p² classification) | clean |
| mean-value-theorem-oq-04-oq-03 (trapezoidal error via Peano kernel) | clean |
| solution-of-cubic-oq-03-oq-01-oq-04 (cubic discriminant) | clean |
| spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02 (Newton tr(A³) power sum) | clean |

### Checks performed (each entry)
- **Code-clean**: comment-stripped Lean shows 0 sorry/admit, 0 `axiom`, 0 `native_decide`, 0 `True`-stub.
- **Status match**: all claim `verified/original/0-axiom/0-sorry` — confirmed against source.
- **Narrative honesty** (higher-risk entries):
  - `erdos-211`: title scopes it as the *extremal 1/6 constant* (an STS has n(n-1)/6 lines via incidence double-counting), **not** a solution to Erdős #211. `IsLineCover` is honestly declared an antecedent predicate, not an axiom.
  - `bezout` (CRT) and `group-order p²`: Mathlib pieces (`MulEquiv.prodUnits`, `Units.mapEquiv`, `ZMod.card_units_eq_totient`, `AddCommMonoid.zmodModule`, `Module.natCard_eq_pow_finrank`) are explicitly credited in `originalContributions`. The genuinely new work (k-fold assembly / explicit isomorphism classification) is what carries the `original` badge — no delegation opacity.

No issues found. Tracker updated (additive only).

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)