### PR TITLE
Enrich Iterative Digital Root (divisibility-by-3-oq-03-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03-oq-02-oq-01/meta.json
@@ -9,8 +9,74 @@
   "badge": "original",
   "axiomCount": 0,
   "sorries": 0,
-  "overview": "We define digitalRootIter b n by well-founded recursion: if n is already a single digit (n < b) return n, otherwise recurse on the digit sum. Termination is justified by digitSum_lt: for 2 <= b <= n the base-b digit sum strictly decreases. We then prove the headline digitalRootIter_eq_base: digitalRootIter b n = digitalRootBase b n for all b >= 2, by strong induction. Each digit-sum step preserves the residue mod (b-1) (sumDigits_modEq, from Mathlib's Nat.modEq_digits_sum) and keeps the value positive (sumDigits_pos, from getLast_digit_ne_zero), while the closed form depends only on that residue (digitalRootBase_modEq_eq). Corollaries: the iterate is always a single digit (digitalRootIter_lt_base), is congruent to its input mod (b-1) (digitalRootIter_modEq), and base-10 specializes to the decimal digital root with casting out nines (digitalRootIter_ten_nine_mul).",
-  "conclusion": "The iterative digital root is a total, terminating function that provably computes the closed form 1 + ((n-1) mod (b-1)) in every base b >= 2. The single ingredient making both the definition and the proof go through is the strict digit-sum drop (digits b n).sum < n for n >= b. Everything is kernel-checked and axiom-free (no native_decide; only the standard propext / Classical.choice / Quot.sound).",
+  "overview": {
+    "historicalContext": "The digital root — repeatedly sum a number's digits until a single digit remains — is one of the oldest pieces of recreational arithmetic, popularized by Fibonacci's Liber Abaci (1202) as 'casting out nines', a check on hand calculations: a number and its digit sum leave the same remainder mod 9, so an arithmetic error usually shows up as a mismatch of digital roots. Hardy and Wright (Theory of Numbers, §9.9) record the general base-b congruence n ≡ (digit sum) mod (b−1). The digital root has a clean closed form, dr_b(n) = 1 + ((n−1) mod (b−1)), but the schoolbook definition is a *process* — iterate the digit sum — and the equivalence of process and closed form is exactly the kind of 'obvious' folklore fact that benefits from machine verification, since it hides a genuine termination argument.",
+    "problemStatement": "Formalize the iterative digital root in Lean 4 — repeatedly replace n by the sum of its base-b digits until a single digit remains — prove it terminates for every base b ≥ 2, and prove it computes the closed form dr_b(n) = 1 + ((n−1) mod (b−1)). Recover casting out nines (base 10) as the b = 10 instance.",
+    "proofStrategy": "Define digitalRootIter b n by well-founded recursion: if n is already a single digit (n < b) return n, otherwise recurse on the digit sum. Termination is justified by digitSum_lt: for 2 ≤ b ≤ n the base-b digit sum strictly decreases (sharpening Mathlib's non-strict Nat.digit_sum_le). Prove the headline digitalRootIter_eq_base: digitalRootIter b n = digitalRootBase b n for all b ≥ 2, by strong induction. Each digit-sum step preserves the residue mod (b−1) (sumDigits_modEq, from Nat.modEq_digits_sum) and keeps the value positive (sumDigits_pos, from getLast_digit_ne_zero), while the closed form depends only on that residue (digitalRootBase_modEq_eq). Corollaries: the iterate is always a single digit (digitalRootIter_lt_base), is congruent to its input mod (b−1) (digitalRootIter_modEq), and base 10 specializes to the decimal digital root with casting out nines (digitalRootIter_ten_nine_mul).",
+    "keyInsights": [
+      "A single lemma does double duty: the strict digit-sum drop (digits b n).sum < n for n ≥ b is simultaneously the well-founded termination measure for the recursive definition AND the engine of the strong-induction equivalence proof.",
+      "Two invariants of one digit-sum step are all that is needed: the residue mod (b−1) is preserved (so the closed form, which depends only on that residue, is unchanged) and positivity is preserved (so the induction never hits 0).",
+      "The closed form dr_b(n) = 1 + ((n−1) mod (b−1)) factors through the residue alone, so the process and the formula agree the moment the process reaches a single digit — there is no arithmetic to match beyond the congruence.",
+      "Formalizing the actual iterative *process* (not just re-stating the closed form) is the contribution: it turns the informal 'keep summing digits' algorithm into a verified total function with a machine-checked termination proof.",
+      "Casting out nines is the b = 10, mod 9 shadow of the general residue invariant — digitalRootIter_ten_nine_mul recovers it as a corollary, connecting the medieval check to the general theorem."
+    ],
+    "prerequisites": [
+      "Base-b digit expansions (Nat.digits) and the digit-sum congruence n ≡ (digit sum) mod (b−1)",
+      "Well-founded recursion and termination measures in Lean 4",
+      "Strong induction (Nat.strong_induction_on)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The iterative digital root is formalized as a total, terminating Lean function digitalRootIter and proved to compute the closed form 1 + ((n−1) mod (b−1)) in every base b ≥ 2 (digitalRootIter_eq_base). Supporting results give the strict digit-sum drop, the single-digit range, the residue invariant mod (b−1), and the base-10 casting-out-nines specialization. 203 lines, 15 theorems, 2 definitions, 0 axioms, 0 sorries.",
+    "implications": "The single ingredient making both the definition and the proof go through is the strict digit-sum drop (digits b n).sum < n for n ≥ b — a small sharpening of Mathlib's non-strict bound that unlocks well-founded recursion. The result turns the informal digital-root algorithm into a verified function and recovers casting out nines as the b = 10 instance, completing the parent's closed-form-only treatment with the missing process half. Everything is kernel-checked and axiom-free (no native_decide).",
+    "openQuestions": [
+      "Bound the number of iterations of the digit-sum process (it is O(log_b log_b n) steps to reach a single digit) and formalize that complexity.",
+      "Generalize to the iterated digit sum in mixed-radix or non-standard numeral systems where the residue invariant takes a different modulus.",
+      "Formalize the additive persistence (the count of iterations) and its known irregular behaviour as a function of n."
+    ]
+  },
+  "sections": [
+    {
+      "id": "part-i",
+      "title": "Part I — Strict Digit-Sum Bound",
+      "startLine": 49,
+      "endLine": 65,
+      "summary": "digitSum_lt: (digits b n).sum < n for 2 ≤ b ≤ n — the strict sharpening of Mathlib's non-strict bound that serves as both the termination measure and the induction engine.",
+      "mathContext": "$\\sum \\mathrm{digits}_b(n) < n$ for $n \\ge b \\ge 2$."
+    },
+    {
+      "id": "part-ii",
+      "title": "Part II — The Iterative Digital Root",
+      "startLine": 66,
+      "endLine": 91,
+      "summary": "digitalRootIter by well-founded recursion (return n if n < b, else recurse on the digit sum), with defining equations digitalRootIter_of_lt / digitalRootIter_of_ge.",
+      "mathContext": "digitalRootIter b n = n if n < b, else digitalRootIter b (∑ digits_b n)."
+    },
+    {
+      "id": "part-iii",
+      "title": "Part III — Invariants of One Digit-Sum Step",
+      "startLine": 92,
+      "endLine": 115,
+      "summary": "sumDigits_modEq (residue mod (b−1) preserved, from Nat.modEq_digits_sum) and sumDigits_pos (positivity preserved, from getLast_digit_ne_zero) — the two invariants the equivalence proof consumes.",
+      "mathContext": "n ≡ ∑ digits_b n (mod b−1), and ∑ digits_b n > 0 for n > 0."
+    },
+    {
+      "id": "part-iv",
+      "title": "Part IV — The Closed Form and the Equivalence",
+      "startLine": 116,
+      "endLine": 182,
+      "summary": "digitalRootBase (the closed form 1 + ((n−1) mod (b−1))), the residue-only dependence (digitalRootBase_modEq_eq), the headline digitalRootIter_eq_base by strong induction, and the single-digit range digitalRootIter_lt_base.",
+      "mathContext": "digitalRootIter b n = 1 + ((n−1) mod (b−1)) for all b ≥ 2."
+    },
+    {
+      "id": "part-v",
+      "title": "Part V — The Decimal Specialization",
+      "startLine": 183,
+      "endLine": 203,
+      "summary": "digitalRootIter_ten and the worked example digitalRootIter_ten_12345 = 6; digitalRootIter_ten_nine_mul recovers casting out nines as the b = 10 instance.",
+      "mathContext": "Base 10: the decimal digital root and casting out nines (mod 9)."
+    }
+  ],
   "leanFile": {
     "path": "Proofs/DivisibilityBy3OQ03OQ02OQ01.lean",
     "lineCount": 203,


### PR DESCRIPTION
Enrichment pass for **divisibility-by-3-oq-03-oq-02-oq-01**. Quality score 55 → 100.

## Quality improvements
- **`overview` was a bare string → now a structured object** with `historicalContext` (casting-out-nines / Fibonacci's Liber Abaci / Hardy–Wright), `problemStatement`, `proofStrategy` (original text preserved), and 5 `keyInsights`. As a string it scored 0 on every overview metric.
- **`conclusion` was a bare string → now an object** with `summary`, `implications`, 3 `openQuestions`.
- **`sections` was missing → 5 sections** covering Parts I–V (strict digit-sum bound / iterative definition / step invariants / closed-form equivalence / decimal specialization).

The existing 5 annotations already had full `mathContext`/`significance`/`relatedConcepts`; preserved. crossReferences already used `targetId` (3 targets verified to exist).

## Notes
- Axiom integrity verified: `status: verified`, `badge: original`, `axiomCount: 0` match the Lean source (0 sorries, no `axiom`, no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)