### PR TITLE
research(knights-tour-oblique-oq-04): 2-regular structure of the oblique turn graph [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ04.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ04.lean
@@ -1,0 +1,148 @@
+/-
+  Knight's Tour Oblique Angles: structure of the oblique turn graph (OQ-04)
+
+  Open question OQ-04 of the parent entry `knights-tour-oblique` asks:
+
+      "What is the maximum number of oblique turns in a closed tour?"
+
+  Where the MINIMUM is exactly 4 (proved in the base file, generalized to n×n
+  in OQ-01), the MAXIMUM is a search-heavy question over the ~1.3×10¹³ closed
+  knight's tours of the 8×8 board and is genuinely open: no elementary closed
+  form is known.  This file does NOT claim to resolve it.
+
+  Instead it establishes, by finite enumeration, the local and global structure
+  of the oblique relation on the eight knight directions -- the combinatorial
+  substrate from which any oblique count is assembled.  The file is deliberately
+  self-contained (it imports only Mathlib, mirroring the self-contained OQ-01),
+  so every result is assumption-free: 0 axioms, 0 sorries, no `native_decide`.
+
+  We index the eight knight directions 0..7 counterclockwise, matching
+  `allMoveVectors` in the base file `KnightsTourOblique.lean`:
+
+      0:(1,2) 1:(2,1) 2:(2,-1) 3:(1,-2) 4:(-1,-2) 5:(-2,-1) 6:(-2,1) 7:(-1,2)
+
+  A turn from direction `i` to direction `j` is *oblique* (obtuse) iff the dot
+  product `vec i ⬝ vec j` is negative; this matches `isOblique` in the base
+  file.  Direction `i + 4 (mod 8)` is the *antipode* `neg i`, and the turn to
+  the antipode is the reversal (dot = -5), which cannot occur in a tour because
+  it would revisit the previous square -- the base file's `no_turn_angle_4_all`.
+
+  Main results (all proved by `decide` over the finite index set):
+
+    * `dot_neg`             -- the turn to the antipode has dot product -5;
+    * `oblique_iff_dot`     -- a legal (non-reversal) turn is oblique iff its
+                               dot product is exactly -3 or -4;
+    * `dot_legal_spectrum`  -- the legal dot spectrum is {-4,-3,0,3,4,5};
+    * `legal_successors_card`         -- 7 legal successors per direction;
+    * `oblique_successors_card`       -- 3 oblique successors per direction;
+    * `legal_oblique_successors_card` -- exactly 2 LEGAL oblique successors:
+                               the oblique relation is 2-regular on legal turns;
+    * `oblique_pairs_card` / `legal_oblique_pairs_card` -- the global oblique
+                               densities 24/64 = 3/8 and 16/56 = 2/7.
+
+  The exact maximum oblique count (OQ-04 proper) remains open; the local
+  structure here constrains per-step choices but does not by itself bound the
+  global maximum below the trivial 64.
+-/
+import Mathlib
+
+namespace KnightsTourObliqueOQ04
+
+open Finset
+
+/-- The eight knight move directions, indexed 0..7 counterclockwise, matching
+    `allMoveVectors` in the base entry `KnightsTourOblique.lean`. -/
+def vec : Fin 8 → Int × Int
+  | 0 => (1, 2)
+  | 1 => (2, 1)
+  | 2 => (2, -1)
+  | 3 => (1, -2)
+  | 4 => (-1, -2)
+  | 5 => (-2, -1)
+  | 6 => (-2, 1)
+  | 7 => (-1, 2)
+
+/-- Dot product of two knight directions. -/
+def dot (i j : Fin 8) : Int := (vec i).1 * (vec j).1 + (vec i).2 * (vec j).2
+
+/-- A turn from direction `i` to direction `j` is oblique (obtuse) iff the dot
+    product of the two move vectors is negative. -/
+def isOblique (i j : Fin 8) : Bool := decide (dot i j < 0)
+
+/-- The antipodal (reversed) direction: `i + 4 (mod 8)`. -/
+def neg (i : Fin 8) : Fin 8 := i + 4
+
+/-! ### The antipode is the reversal -/
+
+/-- `neg` is an involution: the antipode of the antipode is the original. -/
+theorem neg_neg (i : Fin 8) : neg (neg i) = i := by
+  revert i; decide
+
+/-- The antipode really is the negated vector. -/
+theorem vec_neg (i : Fin 8) : vec (neg i) = (-(vec i).1, -(vec i).2) := by
+  revert i; decide
+
+/-- The turn to the antipode is the reversal: its dot product is `-5`, the
+    unique most-negative value.  In a tour this turn cannot occur (it would
+    revisit the previous square), so the antipode is the one oblique successor
+    that is always forbidden. -/
+theorem dot_neg (i : Fin 8) : dot i (neg i) = -5 := by
+  revert i; decide
+
+/-! ### Per-turn refinement on legal (non-reversal) moves -/
+
+/-- A legal (non-reversal) turn is oblique iff its dot product is exactly `-3`
+    or `-4`.  This sharpens the base file's `oblique_iff_large_turn`
+    (turn angle ∈ {3,4,5}, dot ∈ {-3,-4,-5}) by deleting the reversal value
+    `-5`, consistent with `no_turn_angle_4_all`. -/
+theorem oblique_iff_dot (i j : Fin 8) (h : j ≠ neg i) :
+    isOblique i j = true ↔ dot i j = -3 ∨ dot i j = -4 := by
+  revert i j h; decide
+
+/-- For legal turns the dot-product spectrum loses the reversal value `-5`:
+    it is exactly `{-4,-3,0,3,4,5}`. -/
+theorem dot_legal_spectrum (i j : Fin 8) (h : j ≠ neg i) :
+    dot i j = -4 ∨ dot i j = -3 ∨ dot i j = 0 ∨
+    dot i j = 3 ∨ dot i j = 4 ∨ dot i j = 5 := by
+  revert i j h; decide
+
+/-! ### Local successor counts -/
+
+/-- Every knight direction has exactly seven legal successors: all directions
+    except its own antipode. -/
+theorem legal_successors_card (i : Fin 8) :
+    (univ.filter (fun j => j ≠ neg i)).card = 7 := by
+  fin_cases i <;> decide
+
+/-- Every knight direction has exactly three oblique successors (dot product
+    `< 0`): the two genuine obtuse turns plus the reversal. -/
+theorem oblique_successors_card (i : Fin 8) :
+    (univ.filter (fun j => isOblique i j = true)).card = 3 := by
+  fin_cases i <;> decide
+
+/-- **2-regularity of the legal oblique relation.**  Removing the forbidden
+    reversal from the three oblique successors leaves exactly two: every
+    direction has precisely two legal oblique successors.  This is the uniform
+    local constraint underlying any bound on the oblique-turn count of a tour
+    (and it explains the global legal density `2/7` structurally). -/
+theorem legal_oblique_successors_card (i : Fin 8) :
+    (univ.filter (fun j => j ≠ neg i ∧ isOblique i j = true)).card = 2 := by
+  fin_cases i <;> decide
+
+/-! ### Global counts -/
+
+/-- Among all `8 * 8 = 64` ordered pairs of knight directions, exactly `24` are
+    oblique: a global oblique density of `24/64 = 3/8`. -/
+theorem oblique_pairs_card :
+    (univ.filter
+      (fun p : Fin 8 × Fin 8 => isOblique p.1 p.2 = true)).card = 24 := by
+  decide
+
+/-- Among the `8 * 7 = 56` legal (non-reversal) ordered pairs, exactly `16` are
+    oblique: a legal oblique density of `16/56 = 2/7`. -/
+theorem legal_oblique_pairs_card :
+    (univ.filter
+      (fun p : Fin 8 × Fin 8 => p.2 ≠ neg p.1 ∧ isOblique p.1 p.2 = true)).card = 16 := by
+  decide
+
+end KnightsTourObliqueOQ04

--- a/src/data/proofs/knights-tour-oblique-oq-04/annotations.json
+++ b/src/data/proofs/knights-tour-oblique-oq-04/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-ktoq04-header",
+    "proofId": "knights-tour-oblique-oq-04",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 74
+    },
+    "title": "OQ-04: the maximum oblique count, and what is provable about it",
+    "content": "Open question OQ-04 of the parent entry asks for the MAXIMUM number of oblique (obtuse) turns in a closed knight's tour. Unlike the minimum (exactly 4, proved in the base file and generalized in OQ-01), the maximum is a search-heavy question over the ~1.3×10¹³ closed tours of the 8×8 board and is genuinely open — no elementary closed form is known. This file is deliberately honest about that: it does NOT claim to resolve OQ-04. Instead it pins down, by finite enumeration over the eight knight directions, the local and global structure of the oblique relation that any oblique count is assembled from. To stay assumption-free it is self-contained (imports only Mathlib, like the self-contained sibling OQ-01): the eight directions are reconstructed as vec : Fin 8 → ℤ×ℤ (counterclockwise, matching allMoveVectors in the base file), with dot product dot, oblique predicate isOblique i j := dot i j < 0, and antipode neg i := i + 4 (mod 8). Every result is then a finite `decide` check depending only on propext / Classical.choice / Quot.sound — no native_decide, no enumeration axiom.",
+    "mathContext": "Maximum oblique count over $\\sim 1.3\\times10^{13}$ tours is open; this file proves the structure of the oblique relation on the 8 directions, with $\\mathrm{neg}\\,i = i+4 \\pmod 8$ the antipode.",
+    "significance": "key",
+    "relatedConcepts": [
+      "oblique turn (obtuse angle, dot product < 0)",
+      "knight move directions as Fin 8",
+      "finite enumeration / decide",
+      "open combinatorial maximum"
+    ],
+    "prerequisites": [
+      "knight moves and their dot product",
+      "the oblique predicate (dot < 0)",
+      "the reversal turn (antipodal direction)"
+    ]
+  },
+  {
+    "id": "ann-ktoq04-antipode",
+    "proofId": "knights-tour-oblique-oq-04",
+    "type": "theorem",
+    "range": {
+      "startLine": 75,
+      "endLine": 96
+    },
+    "title": "The antipode is the reversal (dot product -5)",
+    "content": "neg_neg proves neg is an involution (neg (neg i) = i); vec_neg proves vec (neg i) = -vec i, so neg i genuinely points the opposite way; and dot_neg proves dot i (neg i) = -5 — the unique most-negative dot product among the seven non-trivial values. The antipodal turn is therefore the reversal: going to the antipode means the next move undoes the previous one, returning to the square just left, which is impossible in a Hamiltonian tour (the base file proves exactly this as no_turn_angle_4_all). Identifying the antipode with the dot=-5 reversal is what lets the next sections separate the always-forbidden oblique successor from the two that a tour may actually use. All three are `decide` checks over the 8 directions.",
+    "mathContext": "$\\mathrm{vec}(\\mathrm{neg}\\,i) = -\\mathrm{vec}\\,i$ and $\\mathrm{dot}\\,i\\,(\\mathrm{neg}\\,i) = -5$: the antipodal turn is the forbidden reversal.",
+    "significance": "important",
+    "relatedConcepts": [
+      "antipodal direction",
+      "reversal turn",
+      "involution",
+      "no-reversal in a tour"
+    ],
+    "prerequisites": [
+      "the dot product of move vectors",
+      "Fin 8 arithmetic (mod 8)",
+      "Hamiltonian cycle (no immediate backtrack)"
+    ]
+  },
+  {
+    "id": "ann-ktoq04-per-turn",
+    "proofId": "knights-tour-oblique-oq-04",
+    "type": "theorem",
+    "range": {
+      "startLine": 97,
+      "endLine": 111
+    },
+    "title": "Per-turn refinement on legal moves: oblique ⇔ dot ∈ {-3,-4}",
+    "content": "oblique_iff_dot proves that for a legal (non-reversal) turn — j ≠ neg i — the turn is oblique iff its dot product is exactly -3 or -4. The base file's oblique_iff_large_turn classifies oblique turns by turn angle ∈ {3,4,5} (dot ∈ {-3,-4,-5}); here the reversal value -5 (the antipode) is deleted, because the reversal never occurs in a tour. dot_legal_spectrum records the companion fact that the full legal dot-product spectrum is {-4,-3,0,3,4,5} rather than the unconstrained {-5,-4,-3,0,3,4,5}. Both are 64-case decide computations over Fin 8 × Fin 8: with i and j ranging over all directions, the dot product and inequality reduce to closed integer arithmetic, and the hypothesis j ≠ neg i discharges the single antipodal case.",
+    "mathContext": "On legal turns the oblique dot values are exactly $\\{-3,-4\\}$; the antipodal value $-5$ is excluded, matching $\\mathrm{no\\_turn\\_angle\\_4\\_all}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "dot product spectrum",
+      "turn angle in ℤ/8",
+      "no-reversal in a tour",
+      "decide over Fin 8 × Fin 8"
+    ],
+    "prerequisites": [
+      "the antipode = reversal (dot -5)",
+      "isOblique = (dot < 0)",
+      "case analysis by decide"
+    ]
+  },
+  {
+    "id": "ann-ktoq04-successor-counts",
+    "proofId": "knights-tour-oblique-oq-04",
+    "type": "theorem",
+    "range": {
+      "startLine": 112,
+      "endLine": 134
+    },
+    "title": "2-regularity of the legal oblique relation",
+    "content": "The structural heart of the entry. In the direction graph on the eight knight directions: legal_successors_card proves every direction has exactly 7 legal successors (all but its own antipode); oblique_successors_card proves every direction has exactly 3 oblique successors (those with dot product < 0); and legal_oblique_successors_card combines them — exactly 2 legal oblique successors per direction. So the legal oblique relation is 2-REGULAR: at each step a tour may turn obliquely into precisely two of its seven legal continuations, the third oblique direction being the forbidden antipode (dot -5). Each theorem filters Finset.univ over Fin 8 by the relevant decidable predicate and evaluates the cardinality by decide for all 8 directions via fin_cases. This uniform local out-degree is the combinatorial constraint any oblique-count argument must respect, and it explains the global legal density 2/7 structurally rather than by tabulation. Note it does NOT by itself bound the global maximum: a tour can in principle take an oblique successor at every free step.",
+    "mathContext": "Out-degrees in the direction graph: legal $7$, oblique $3$, legal-oblique $2$ — uniform over all 8 directions (2-regular).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "regular graph / uniform out-degree",
+      "Finset.card by decide",
+      "antipodal direction excluded",
+      "local structure of oblique turns"
+    ],
+    "prerequisites": [
+      "Fintype Fin 8",
+      "Finset.filter and Finset.card",
+      "decidability of the oblique predicate"
+    ]
+  },
+  {
+    "id": "ann-ktoq04-global-counts",
+    "proofId": "knights-tour-oblique-oq-04",
+    "type": "theorem",
+    "range": {
+      "startLine": 135,
+      "endLine": 148
+    },
+    "title": "Global oblique densities 3/8 and 2/7",
+    "content": "oblique_pairs_card and legal_oblique_pairs_card give the exact global oblique densities by deciding over all ordered pairs of directions: 24 of the 64 pairs are oblique (3/8), and 16 of the 56 legal (non-reversal) pairs are oblique (2/7). These are the global shadow of the per-direction 2-regularity: 8 directions × 3 oblique successors = 24, and 8 × 2 legal oblique successors = 16. The densities quantify how 'often' an unconstrained or legality-constrained turn is oblique, the local statistic against which the (open) global maximum over actual tours must be compared. The entry stops here: it does not claim any tour-level bound beyond the trivial 64 turns, and flags the global tour constraints (closure, simplicity, board geometry) as the missing ingredient for the true maximum.",
+    "mathContext": "$24/64 = 3/8$ over all pairs, $16/56 = 2/7$ over legal pairs — the global form of 2-regularity.",
+    "significance": "important",
+    "relatedConcepts": [
+      "global oblique density",
+      "Finset.card over a product Fintype",
+      "2-regularity (global shadow)",
+      "open global maximum"
+    ],
+    "prerequisites": [
+      "Finset.card over Fin 8 × Fin 8",
+      "the per-direction successor counts",
+      "decide on a finite product"
+    ]
+  }
+]

--- a/src/data/proofs/knights-tour-oblique-oq-04/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-04/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "knights-tour-oblique-oq-04",
+  "title": "Knight's Tour Oblique Angles: 2-regular structure of the oblique turn graph",
+  "slug": "knights-tour-oblique-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "KnightsTourObliqueOQ04",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 4,
+    "path": "Proofs/KnightsTourObliqueOQ04.lean",
+    "sorries": 0
+  },
+  "description": "Open question OQ-04 asks for the MAXIMUM number of oblique (obtuse) turns in a closed knight's tour — a search-heavy question over the ~1.3×10¹³ closed tours of the 8×8 board, which is genuinely open. This entry does not resolve it; instead it pins down, by finite enumeration over the eight knight directions, the local and global structure of the oblique relation that any oblique count is built from. The headline result is 2-REGULARITY: legal_oblique_successors_card proves every knight direction has exactly two legal (non-reversal) oblique successors, isolated from oblique_successors_card (three oblique successors overall) and legal_successors_card (seven legal successors). dot_neg shows the third, forbidden, oblique successor is the antipode (dot = -5, the reversal). oblique_iff_dot sharpens the oblique characterization to dot ∈ {-3,-4} on legal turns; dot_legal_spectrum gives the reduced spectrum {-4,-3,0,3,4,5}. Globally, oblique_pairs_card / legal_oblique_pairs_card give the exact densities 24/64 = 3/8 (all pairs) and 16/56 = 2/7 (legal pairs). The file is self-contained (imports only Mathlib, like sibling OQ-01): all 10 theorems are machine-checked, 0 axioms, 0 sorries, no native_decide (confirmed by #print axioms: only propext / Classical.choice / Quot.sound).",
+  "meta": {
+    "author": "Lean Genius researchers (2026)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KnightsTourObliqueOQ04.lean",
+    "tags": [
+      "knights-tour",
+      "combinatorics",
+      "graph-theory",
+      "chessboard",
+      "enumeration",
+      "dot-product",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "None. The file is self-contained — it imports only Mathlib (mirroring the self-contained sibling OQ-01) and reconstructs the eight knight directions as Fin 8 with their dot product, so it does not depend on the lineage base file (which uses native_decide and an enumeration axiom). All ten theorems are proved by `decide` / `fin_cases` over the finite index set and depend only on Lean's foundational axioms propext, Classical.choice, Quot.sound — confirmed via #print axioms. No axiom declarations, no native_decide (no Lean.ofReduceBool), no sorries.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.filter / Finset.card",
+        "description": "Cardinality of filtered subsets of Finset.univ over Fin 8 (and Fin 8 × Fin 8) — the form of the successor-count and pair-count theorems, evaluated by decide",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Fintype.decidableForallFintype",
+        "description": "Decidability of ∀ over a Fintype, making the per-direction statements decidable and closing them by `decide`",
+        "module": "Mathlib.Data.Fintype.Basic"
+      }
+    ],
+    "additionalFiles": [],
+    "originalContributions": [
+      "legal_oblique_successors_card: 2-REGULARITY — every knight direction has exactly two legal (non-reversal) oblique successors. This is the uniform local constraint underlying any count of oblique turns: at each step a tour may turn obliquely into at most two of its seven legal continuations.",
+      "oblique_successors_card / legal_successors_card / dot_neg: the unconstrained oblique out-degree is 3 (dot < 0), the legal out-degree is 7 (all but the antipode), and dot_neg pins the third oblique successor as the antipode with dot product -5 (the reversal); together these isolate the single forbidden reversal among the oblique successors.",
+      "oblique_iff_dot: on legal turns, oblique ⇔ dot ∈ {-3,-4}, sharpening the base file's oblique_iff_large_turn ({3,4,5}) by deleting the reversal value -5, consistent with no_turn_angle_4_all. dot_legal_spectrum gives the matching reduced spectrum {-4,-3,0,3,4,5}.",
+      "oblique_pairs_card / legal_oblique_pairs_card: exact global oblique densities 24/64 = 3/8 over all ordered direction pairs and 16/56 = 2/7 over legal pairs — the global shadow of 2-regularity."
+    ],
+    "theoremCount": 10,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Donald Knuth's 29th Annual Christmas Lecture (December 4, 2025), 'The Knight's Adventure', proved that every closed knight's tour on the 8×8 board has at least 4 oblique (obtuse) turns, achieved uniquely up to the board's dihedral symmetry D₄. The base Lean formalization (KnightsTourOblique.lean) captures that lower bound and the uniqueness (the latter as an axiom backed by enumeration). The open follow-ups study the full histogram of oblique counts; OQ-04 asks for its right endpoint — the maximum oblique count.",
+    "problemStatement": "What is the maximum number of oblique turns in a closed knight's tour? The exact value is a search question over ~1.3×10¹³ tours and is open. This entry instead establishes the local/global structure of the oblique relation on the eight knight directions — the substrate from which any oblique count is assembled — as fully machine-checked enumeration facts.",
+    "proofStrategy": "The eight knight directions are reconstructed as Fin 8 with vector vec, dot product dot, oblique predicate isOblique (dot < 0), and antipode neg i = i + 4 (mod 8). Every statement about the oblique relation is then a finite check. neg_neg / vec_neg / dot_neg fix the antipode as the reversal (dot -5). The per-turn refinement oblique_iff_dot and the reduced spectrum dot_legal_spectrum are 64-case decide computations (the reversal hypothesis discharges the antipodal case). The successor counts filter Finset.univ by the relevant predicate and evaluate the cardinality by decide for each of the 8 directions; the global counts decide over the 64 ordered pairs directly.",
+    "keyInsights": [
+      "**2-regularity is the heart.** Of a direction's seven legal continuations, exactly two are oblique. This uniform local out-degree (legal_oblique_successors_card) is the structural fact any oblique-count argument must respect, and it explains the 2/7 global legal density combinatorially rather than empirically.",
+      "**The reversal is the third, forbidden, oblique successor.** Unconstrained there are three oblique successors (dot < 0); one is the antipode neg i, whose turn has dot -5 (dot_neg) — the reversal that revisits the previous square and so never occurs in a tour (base file's no_turn_angle_4_all). Deleting it leaves exactly two and sharpens the dot spectrum to {-3,-4} on legal turns.",
+      "**Honest scope.** The maximum oblique count is a genuine search question with no known elementary closed form; this entry deliberately does not claim it. What is contributed is verified structure, not an inflated bound.",
+      "**Local structure does not bound the global maximum.** 2-regularity constrains choices, not forced counts: a tour could in principle turn obliquely at every step it is free to, so the local data alone gives no maximum below the trivial 64. Pinning the true maximum needs the global tour constraints (closure Σ move vectors = 0, simplicity, board geometry), which is why OQ-04 stays open."
+    ],
+    "prerequisites": [
+      "Knight moves and the eight move directions (base entry knights-tour-oblique)",
+      "The dot product of move vectors and the oblique predicate (turn with dot product < 0)",
+      "Finset.filter / Finset.card over a Fintype, and decision by `decide` / `fin_cases`",
+      "The notion that the reversal turn (antipodal direction) never occurs in a tour"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "legal_oblique_successors_card",
+      "type": "theorem",
+      "description": "(univ.filter (fun j => j ≠ neg i ∧ isOblique i j)).card = 2: every knight direction has exactly two legal (non-reversal) oblique successors — the oblique relation is 2-regular on legal turns."
+    },
+    {
+      "name": "oblique_successors_card",
+      "type": "theorem",
+      "description": "(univ.filter (fun j => isOblique i j)).card = 3: every direction has exactly three oblique successors overall (dot product < 0), one of which is the forbidden reversal."
+    },
+    {
+      "name": "legal_successors_card",
+      "type": "theorem",
+      "description": "(univ.filter (fun j => j ≠ neg i)).card = 7: every direction has exactly seven legal successors — all directions except its own antipode."
+    },
+    {
+      "name": "dot_neg",
+      "type": "theorem",
+      "description": "dot i (neg i) = -5: the turn to the antipode is the reversal, with the unique most-negative dot product; this is the always-forbidden oblique successor."
+    },
+    {
+      "name": "oblique_iff_dot",
+      "type": "theorem",
+      "description": "For j ≠ neg i, isOblique i j ⇔ dot i j = -3 ∨ dot i j = -4: a legal turn is oblique iff its dot product is exactly -3 or -4 (the reversal value -5 cannot occur)."
+    },
+    {
+      "name": "oblique_pairs_card",
+      "type": "theorem",
+      "description": "Exactly 24 of the 64 ordered direction pairs are oblique: global oblique density 24/64 = 3/8."
+    },
+    {
+      "name": "legal_oblique_pairs_card",
+      "type": "theorem",
+      "description": "Exactly 16 of the 56 legal (non-reversal) ordered pairs are oblique: legal oblique density 16/56 = 2/7."
+    }
+  ],
+  "references": [
+    {
+      "type": "lecture",
+      "citation": "Knuth, D. E. (2025). 29th Annual Christmas Lecture: 'The Knight's Adventure'. Stanford University, December 4, 2025.",
+      "relevance": "Source of the oblique-turn problem; OQ-04 asks for the maximum of the oblique-count histogram introduced there."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.Data.Finset.Card\", \"Mathlib.Data.Fintype.Basic\". (accessed 2026)",
+      "relevance": "Finset cardinality and Fintype decidability lemmas underlying the enumeration counts proved by `decide`."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "File Header and Scope",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring stating OQ-04 (the maximum oblique count), declaring that the exact maximum is open and not claimed here, and listing the structural results: the antipode/reversal facts, the per-turn refinement, the successor counts (2-regularity), and the global densities. The file is self-contained, importing only Mathlib.",
+      "mathContext": "Maximum oblique count is open; this file proves the local/global structure of the oblique relation on the 8 directions."
+    },
+    {
+      "id": "definitions",
+      "title": "The eight directions, dot product, oblique predicate, antipode",
+      "startLine": 53,
+      "endLine": 74,
+      "summary": "vec : Fin 8 → ℤ×ℤ enumerates the eight knight directions counterclockwise (matching allMoveVectors in the base file); dot is their integer dot product; isOblique i j := dot i j < 0; neg i := i + 4 (mod 8) is the antipode.",
+      "mathContext": "Directions indexed $0..7$; $\\mathrm{neg}\\,i = i+4 \\pmod 8$ is the antipode."
+    },
+    {
+      "id": "antipode",
+      "title": "The antipode is the reversal",
+      "startLine": 75,
+      "endLine": 96,
+      "summary": "neg_neg: neg is an involution; vec_neg: vec (neg i) = -vec i; dot_neg: dot i (neg i) = -5, the unique most-negative dot product. The antipode is therefore the reversal turn, which never occurs in a tour.",
+      "mathContext": "$\\mathrm{dot}\\,i\\,(\\mathrm{neg}\\,i) = -5$; the antipodal turn is the forbidden reversal."
+    },
+    {
+      "id": "per-turn",
+      "title": "Per-turn refinement on legal moves",
+      "startLine": 97,
+      "endLine": 111,
+      "summary": "oblique_iff_dot: a legal (non-reversal) turn is oblique iff its dot product is -3 or -4; dot_legal_spectrum: the legal dot spectrum is {-4,-3,0,3,4,5}. Both are 64-case decide checks, the reversal hypothesis discharging the antipodal case.",
+      "mathContext": "On legal turns the oblique values are exactly $\\{-3,-4\\}$; the reversal value $-5$ is removed."
+    },
+    {
+      "id": "successor-counts",
+      "title": "Local successor counts and 2-regularity",
+      "startLine": 112,
+      "endLine": 134,
+      "summary": "legal_successors_card = 7 (all but the antipode), oblique_successors_card = 3 (dot < 0), and legal_oblique_successors_card = 2 (the 2-regularity result). Each filters Finset.univ over Fin 8 and evaluates the cardinality by decide for all 8 directions.",
+      "mathContext": "Out-degrees in the direction graph: legal $7$, oblique $3$, legal-oblique $2$."
+    },
+    {
+      "id": "global-counts",
+      "title": "Global oblique densities",
+      "startLine": 135,
+      "endLine": 148,
+      "summary": "oblique_pairs_card = 24 (of 64) and legal_oblique_pairs_card = 16 (of 56): the exact oblique densities 3/8 and 2/7, decided over all ordered pairs of directions.",
+      "mathContext": "$24/64 = 3/8$ over all pairs; $16/56 = 2/7$ over legal pairs."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-04 (the maximum oblique count of a closed knight's tour) is open. This entry contributes the verified local and global structure of the oblique relation on the eight knight directions: every direction has exactly two legal oblique successors (2-regularity), three oblique successors overall (the third being the reversal, dot -5), and seven legal successors; on legal turns oblique ⇔ dot ∈ {-3,-4}; and the global oblique densities are 3/8 over all pairs and 2/7 over legal pairs. All ten results are self-contained, axiom-free, and native_decide-free.",
+    "implications": "The 2-regularity and density facts quantify the per-step combinatorics that any oblique-count argument is built on, and the spectrum refinement aligns the dot-product and turn-angle views of obliqueness with the base file's no-reversal theorem. They mark the honest local starting point for the open maximum.",
+    "openQuestions": [
+      "Determine the exact maximum oblique count over all closed 8×8 knight's tours (OQ-04 proper) — currently only bounded by the trivial 64.",
+      "Find a non-trivial upper bound below 64 from the global tour constraints (closure Σ move vectors = 0, simplicity, board geometry), beyond the local 2-regularity.",
+      "Exhibit an explicit high-oblique tour to certify a strong lower bound on the maximum, complementing the minimal 4-oblique tour of the base file."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "knights-tour-oblique",
+      "relationship": "ancestor",
+      "description": "The base file, whose oblique predicate, dot product, and no_turn_angle_4_all (the reversal turn never occurs) this entry reconstructs self-containedly and quantifies."
+    },
+    {
+      "targetId": "knights-tour-oblique-oq-01",
+      "relationship": "complementary",
+      "description": "Sibling on the n×n generalization of the oblique MINIMUM (lower bound 4), also self-contained; this entry concerns the structure behind the MAXIMUM."
+    },
+    {
+      "targetId": "knights-tour-oblique-oq-02",
+      "relationship": "complementary",
+      "description": "The OQ-02 histogram/distribution skeleton; OQ-04 is the right endpoint (maximum) of that histogram, whose local substrate is quantified here."
+    }
+  ]
+}

--- a/src/data/research/problems/knights-tour-oblique-oq-04.json
+++ b/src/data/research/problems/knights-tour-oblique-oq-04.json
@@ -1,0 +1,78 @@
+{
+  "slug": "knights-tour-oblique-oq-04",
+  "title": "Knight's Tour Oblique Angles: maximum oblique count — structure of the oblique turn graph",
+  "problemStatement": "Open question OQ-04 of the parent knights-tour-oblique asks for the MAXIMUM number of oblique (obtuse) turns in a closed knight's tour on the 8x8 board. Where the minimum is exactly 4, the maximum is a search-heavy question over the ~1.3x10^13 closed tours and is genuinely open. This entry establishes the local and global structure of the oblique relation on the eight knight directions — the combinatorial substrate of any oblique count — as fully verified enumeration facts.",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "C",
+  "tractability": "structural sub-result tractable; exact maximum open",
+  "significance": "Right endpoint of the oblique-count histogram (OQ-02 program); complements the proven minimum of 4.",
+  "started": "2026-06-24T00:00:00.000Z",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "path": "src/data/proofs/knights-tour-oblique-oq-04",
+  "leanFiles": [
+    "proofs/Proofs/KnightsTourObliqueOQ04.lean"
+  ],
+  "relatedProofs": [
+    "knights-tour-oblique",
+    "knights-tour-oblique-oq-01",
+    "knights-tour-oblique-oq-02"
+  ],
+  "tags": [
+    "knights-tour",
+    "combinatorics",
+    "graph-theory",
+    "chessboard",
+    "enumeration",
+    "dot-product",
+    "research"
+  ],
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Establish the verifiable structure of the oblique relation underlying the open maximum.",
+    "blockers": [
+      "Exact maximum oblique count requires a search over ~1.3x10^13 tours; no elementary closed form known."
+    ],
+    "nextAction": "Pursue a non-trivial upper bound below 64 from global tour constraints, or an explicit high-oblique tour for a strong lower bound on the maximum.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED (structural sub-result): Did NOT resolve the open maximum, but proved the full local/global structure of the oblique relation on the 8 knight directions. Headline: 2-regularity — every direction has exactly two legal (non-reversal) oblique successors. Shipped as verified/0-axiom/original gallery entry knights-tour-oblique-oq-04 (PR #29740).",
+    "builtItems": [
+      "Created proofs/Proofs/KnightsTourObliqueOQ04.lean (self-contained, imports only Mathlib): 10 theorems, 4 defs, 148 lines, 0 sorries, 0 axioms, no native_decide",
+      "legal_oblique_successors_card: every knight direction has exactly 2 legal (non-reversal) oblique successors (2-regularity)",
+      "oblique_successors_card = 3, legal_successors_card = 7, dot_neg = -5 (antipode is the reversal)",
+      "oblique_iff_dot: legal turn oblique iff dot in {-3,-4}; dot_legal_spectrum: legal spectrum {-4,-3,0,3,4,5}",
+      "oblique_pairs_card = 24/64 (3/8), legal_oblique_pairs_card = 16/56 (2/7) — exact global oblique densities",
+      "Created gallery entry meta.json + annotations.json (status verified, badge original)"
+    ],
+    "insights": [
+      "The oblique relation on the 8 knight directions is 2-REGULAR on legal turns: of a direction's 7 legal continuations, exactly 2 are oblique. This is uniform across all 8 directions.",
+      "Of the 3 oblique successors (dot < 0) of any direction, exactly one is the antipode (dot = -5), whose turn is the reversal that revisits the previous square and so never occurs in a tour. Deleting it leaves the 2 legal oblique successors.",
+      "Global oblique density is 24/64 = 3/8 over all ordered direction pairs and 16/56 = 2/7 over legal pairs — the global shadow of per-direction 2-regularity (8x3 = 24, 8x2 = 16).",
+      "On legal turns the oblique dot values are exactly {-3,-4}; the reversal value -5 is excluded, refining the base file's oblique_iff_large_turn ({3,4,5}) consistently with no_turn_angle_4_all.",
+      "Local 2-regularity constrains per-step CHOICES, not forced counts, so it does NOT bound the global maximum below the trivial 64. A tour could in principle turn obliquely at every free step.",
+      "Reconstructing the 8 directions as Fin 8 (with neg i = i+4 mod 8) makes every statement a fast `decide` check and keeps the file self-contained / assumption-free, unlike importing the native_decide+axiom base lineage."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Find a non-trivial upper bound below 64 from the global tour constraints (closure sum of move vectors = 0, simplicity, board geometry), beyond the local 2-regularity.",
+      "Exhibit an explicit high-oblique closed tour and compute its oblique count by decide/native to certify a strong lower bound on the maximum.",
+      "Relate the maximum oblique endpoint to the OQ-02 histogram support and any reversal/D4 symmetry of the high-oblique tours."
+    ],
+    "markdown": "# Knowledge Base: knights-tour-oblique-oq-04\n\n## Problem Understanding\n\nOQ-04 asks for the MAXIMUM oblique count of a closed 8x8 knight's tour. Unlike the minimum (exactly 4), the maximum is a search over ~1.3x10^13 tours and is open.\n\n## Result Shipped (2026-06-24)\n\nVerified the local/global structure of the oblique relation on the 8 knight directions (2-regularity; densities 3/8 and 2/7), self-contained and 0-axiom. Did NOT resolve the open maximum. PR #29740.\n\n## Dead Ends / Open\n\nLocal 2-regularity does not bound the global maximum below 64; the genuine maximum needs global tour constraints (closure, simplicity, board geometry).\n"
+  },
+  "knownResults": [
+    "Minimum oblique count is exactly 4 (base file knights-tour-oblique; generalized to n*n in OQ-01).",
+    "The reversal turn (dot = -5, turn angle 4) never occurs in a closed tour (base file no_turn_angle_4_all)."
+  ],
+  "references": [
+    "Knuth, D. E. (2025). 29th Annual Christmas Lecture: 'The Knight's Adventure'. Stanford University, December 4, 2025."
+  ]
+}


### PR DESCRIPTION
## Knight's Tour Oblique Angles — OQ-04: structure of the oblique turn graph

**Open question OQ-04** of the parent `knights-tour-oblique` asks: *what is the maximum number of oblique (obtuse) turns in a closed knight's tour?* Unlike the **minimum** (exactly 4 — base file + OQ-01), the **maximum** is a search over the ~1.3×10¹³ closed tours of the 8×8 board and is **genuinely open**. This entry **does not claim it**. It contributes the verified local/global structure of the oblique relation on the eight knight directions — the substrate any oblique count is assembled from.

### Headline: 2-regularity
`legal_oblique_successors_card` — every knight direction has **exactly two** legal (non-reversal) oblique successors. Isolated from:
- `oblique_successors_card` = 3 (oblique successors overall, dot < 0),
- `legal_successors_card` = 7 (all but the antipode),
- `dot_neg`: `dot i (neg i) = -5` — the third, forbidden, oblique successor is the **antipode** (the reversal turn, which never occurs in a tour).

### Supporting results
- `oblique_iff_dot`: on legal turns, oblique ⇔ dot ∈ {-3,-4} (sharpens the base file's `oblique_iff_large_turn` {3,4,5} by deleting the reversal -5).
- `dot_legal_spectrum`: legal dot spectrum is {-4,-3,0,3,4,5}.
- `oblique_pairs_card` / `legal_oblique_pairs_card`: exact global densities **24/64 = 3/8** (all pairs) and **16/56 = 2/7** (legal pairs).

### Honest scope
The local 2-regularity constrains per-step *choices*, not forced counts, so it does **not** bound the global maximum below the trivial 64. Pinning the true maximum needs the global tour constraints (closure Σ move vectors = 0, simplicity, board geometry) — left as open questions.

### Verification
- **Self-contained**: imports only Mathlib (like sibling OQ-01); reconstructs the 8 directions as `Fin 8`.
- 10 theorems, 4 defs, 148 lines, **0 sorries, 0 axioms, no `native_decide`**.
- `#print axioms` on all key theorems shows only `propext` / `Classical.choice` / `Quot.sound`.
- Builds clean (`lake env lean`, exit 0) against Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)