### PR TITLE
Enrich Vandermonde Interpolation (vandermonde-interpolation-oq-01)

### DIFF
--- a/src/data/proofs/vandermonde-interpolation-oq-01/annotations.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01/annotations.json
@@ -3,44 +3,60 @@
     "id": "vandermonde-interpolation-oq-01-module-header",
     "proofId": "vandermonde-interpolation-oq-01",
     "type": "concept",
-    "range": {
-      "startLine": 1,
-      "endLine": 26
-    },
+    "range": { "startLine": 1, "endLine": 26 },
     "title": "Module Header: Vandermonde and Interpolation",
-    "content": "Over a field with $n$ **distinct** nodes $v : \\mathrm{Fin}\\,n \\to F$, the Vandermonde matrix $V_{ij} = v_i^j$ has determinant $\\prod_{i<j}(v_j - v_i) \\ne 0$, so evaluation at the nodes is injective on polynomials of degree $< n$. Two consequences: the **finite identity theorem** (a degree-$<n$ polynomial vanishing at $n$ points is $0$) and **interpolation uniqueness** (degree-$<n$ polynomials agreeing at $n$ points are equal). Mathlib proves the coefficient-vector form but stops short of the `Polynomial.eval` bridge — supplied here."
+    "content": "Over a field with n distinct nodes v : Fin n → F, the Vandermonde matrix V_{ij} = v_i^j has determinant ∏_{i<j}(v_j − v_i) ≠ 0, so evaluation at the nodes is injective on polynomials of degree < n. Two consequences: the finite identity theorem (a degree-<n polynomial vanishing at n points is 0) and interpolation uniqueness (degree-<n polynomials agreeing at n points are equal). Mathlib proves the coefficient-vector form but stops short of the Polynomial.eval bridge — supplied here.",
+    "mathContext": "$\\det V = \\prod_{i<j}(v_j - v_i) \\ne 0$ for distinct nodes, so evaluation is injective on $\\{p : \\deg p < n\\}$.",
+    "significance": "context",
+    "relatedConcepts": ["Vandermonde matrix", "polynomial interpolation", "identity theorem", "evaluation map"],
+    "prerequisites": ["polynomials over a field", "determinants"]
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-setup",
+    "proofId": "vandermonde-interpolation-oq-01",
+    "type": "definition",
+    "range": { "startLine": 26, "endLine": 29 },
+    "title": "Setup: Field, Nodes, and Distinctness",
+    "content": "The namespace fixes a field F, a count n, and nodes v : Fin n → F. Throughout, 'distinct nodes' is encoded as Function.Injective v — the single hypothesis that drives every result. Working over an arbitrary field (not just ℝ or ℂ) means the interpolation theory applies to finite fields and function fields as well.",
+    "mathContext": "$F$ a field, $v : \\mathrm{Fin}\\,n \\to F$, distinctness as $\\mathrm{Injective}\\,v$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Function.Injective", "field genericity", "Fin n indexing"],
+    "prerequisites": ["fields", "injective functions"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-det",
     "proofId": "vandermonde-interpolation-oq-01",
     "type": "theorem",
-    "range": {
-      "startLine": 30,
-      "endLine": 36
-    },
+    "range": { "startLine": 30, "endLine": 36 },
     "title": "Vandermonde Nonvanishing",
-    "content": "`vandermonde_det_ne_zero`: for injective (distinct) nodes, $\\det(\\mathrm{vandermonde}\\,v) \\ne 0$ — a specialization of Mathlib's `det_vandermonde_ne_zero_iff`. The determinant is $\\prod_{i<j}(v_j - v_i)$, which is nonzero precisely when the nodes are pairwise distinct. This invertibility is what makes the evaluation-at-nodes map a bijection on degree-$<n$ polynomials."
+    "content": "vandermonde_det_ne_zero: for injective (distinct) nodes, det(vandermonde v) ≠ 0 — a specialization of Mathlib's det_vandermonde_ne_zero_iff. The determinant is ∏_{i<j}(v_j − v_i), which is nonzero precisely when the nodes are pairwise distinct. This invertibility is what makes the evaluation-at-nodes map a bijection on degree-<n polynomials.",
+    "mathContext": "$\\det(\\mathrm{vandermonde}\\,v) = \\prod_{i<j}(v_j - v_i) \\ne 0 \\iff v$ injective.",
+    "significance": "key",
+    "relatedConcepts": ["det_vandermonde_ne_zero_iff", "invertibility", "distinct nodes"],
+    "prerequisites": ["Vandermonde determinant formula"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-identity",
     "proofId": "vandermonde-interpolation-oq-01",
     "type": "theorem",
-    "range": {
-      "startLine": 38,
-      "endLine": 57
-    },
+    "range": { "startLine": 37, "endLine": 55 },
     "title": "The Finite Identity Theorem",
-    "content": "`eq_zero_of_eval_eq_zero`: a polynomial $p$ of degree $< n$ vanishing at $n$ distinct points is the zero polynomial.\n\n**Bridge.** For each node $j$, `eval_eq_sum_range'` writes $p(v_j) = \\sum_{i<n} p_i\\,v_j^{\\,i}$, and `Fin.sum_univ_eq_sum_range` converts the range-sum to a $\\mathrm{Fin}\\,n$ sum. This is exactly the hypothesis of Mathlib's `eq_zero_of_forall_index_sum_mul_pow_eq_zero`, which — from node injectivity (Vandermonde nonvanishing) — forces the coefficient vector $i \\mapsto p_i$ to vanish on $\\mathrm{Fin}\\,n$. Coefficients of index $\\ge n$ vanish since $\\deg p < n$, so every coefficient is $0$ and $p = 0$."
+    "content": "eq_zero_of_eval_eq_zero: a polynomial p of degree < n vanishing at n distinct points is the zero polynomial. Bridge: for each node j, eval_eq_sum_range' writes p(v_j) = ∑_{i<n} p_i v_j^i, and Fin.sum_univ_eq_sum_range converts the range-sum to a Fin n sum — exactly the hypothesis of Mathlib's eq_zero_of_forall_index_sum_mul_pow_eq_zero, which from node injectivity forces the coefficient vector i ↦ p_i to vanish on Fin n. Coefficients of index ≥ n vanish since deg p < n, so every coefficient is 0 and p = 0. This eval→coefficient bridge is the content Mathlib lacks.",
+    "mathContext": "$\\deg p < n$ and $p(v_j) = 0\\ \\forall j \\Rightarrow p = 0$; the $n$ values over-determine a degree-$<n$ polynomial.",
+    "significance": "key",
+    "relatedConcepts": ["identity theorem", "eval_eq_sum_range'", "eq_zero_of_forall_index_sum_mul_pow_eq_zero", "coefficient vector"],
+    "prerequisites": ["Polynomial.eval", "degree bounds"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-uniqueness",
     "proofId": "vandermonde-interpolation-oq-01",
     "type": "theorem",
-    "range": {
-      "startLine": 59,
-      "endLine": 65
-    },
+    "range": { "startLine": 56, "endLine": 65 },
     "title": "Interpolation Uniqueness",
-    "content": "`eq_of_eval_eq`: two polynomials $p, q$ of degree $< n$ that agree at $n$ distinct points are equal — there is at most one interpolant of degree $< n$ through $n$ given values.\n\nThe difference $p - q$ has $\\deg(p-q) \\le \\max(\\deg p, \\deg q) < n$ (`natDegree_sub_le`) and vanishes at every node, so $p - q = 0$ by the finite identity theorem; `sub_eq_zero` gives $p = q$."
+    "content": "eq_of_eval_eq: two polynomials p, q of degree < n that agree at n distinct points are equal — there is at most one interpolant of degree < n through n given values. The difference p − q has deg(p−q) ≤ max(deg p, deg q) < n (natDegree_sub_le) and vanishes at every node, so p − q = 0 by the finite identity theorem; sub_eq_zero gives p = q.",
+    "mathContext": "$\\deg p, \\deg q < n$ and $p(v_j) = q(v_j)\\ \\forall j \\Rightarrow p = q$.",
+    "significance": "key",
+    "relatedConcepts": ["interpolation uniqueness", "natDegree_sub_le", "sub_eq_zero", "Lagrange interpolation"],
+    "prerequisites": ["the finite identity theorem", "degree of a difference"]
   }
 ]

--- a/src/data/proofs/vandermonde-interpolation-oq-01/meta.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01/meta.json
@@ -54,9 +54,51 @@
   },
   "crossReferences": [
     {
-      "proofId": "integral-root-theorem-oq-01",
+      "targetId": "integral-root-theorem-oq-01",
       "relationship": "related",
       "description": "Both constrain polynomials by their roots: the rational root theorem restricts the rational roots of an integer polynomial, while the finite identity theorem says a degree-< n polynomial with n roots must vanish. Together they reflect the principle that a low-degree polynomial cannot have too many roots."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Vandermonde and Interpolation",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Docstring: distinct nodes make the Vandermonde determinant nonzero, so evaluation is injective on degree-<n polynomials — yielding the finite identity theorem and interpolation uniqueness. Notes the eval-bridge Mathlib lacks.",
+      "mathContext": "det V = ∏_{i<j}(v_j − v_i) ≠ 0 for distinct nodes."
+    },
+    {
+      "id": "setup",
+      "title": "Setup: Field, Nodes, Distinctness",
+      "startLine": 26,
+      "endLine": 29,
+      "summary": "Namespace and variables: a field F, count n, nodes v : Fin n → F, with distinctness encoded as Function.Injective v — the single driving hypothesis, valid over any field.",
+      "mathContext": "F a field, v : Fin n → F, Injective v."
+    },
+    {
+      "id": "det",
+      "title": "Vandermonde Nonvanishing",
+      "startLine": 30,
+      "endLine": 36,
+      "summary": "vandermonde_det_ne_zero: distinct nodes ⟹ det(vandermonde v) ≠ 0, the invertibility making evaluation-at-nodes a bijection on degree-<n polynomials.",
+      "mathContext": "det(vandermonde v) ≠ 0 ⟺ v injective."
+    },
+    {
+      "id": "identity",
+      "title": "The Finite Identity Theorem",
+      "startLine": 37,
+      "endLine": 55,
+      "summary": "eq_zero_of_eval_eq_zero: a degree-<n polynomial vanishing at n distinct nodes is 0, via the eval→coefficient bridge (eval_eq_sum_range' + eq_zero_of_forall_index_sum_mul_pow_eq_zero) — the content Mathlib lacks.",
+      "mathContext": "deg p < n and p(v_j)=0 ∀j ⟹ p = 0."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Interpolation Uniqueness",
+      "startLine": 56,
+      "endLine": 65,
+      "summary": "eq_of_eval_eq: degree-<n polynomials agreeing at n distinct points are equal, since their difference has degree <n and vanishes at every node — at most one interpolant.",
+      "mathContext": "deg p, deg q < n and p(v_j)=q(v_j) ∀j ⟹ p = q."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for **vandermonde-interpolation-oq-01**. Quality score 55 → 100.

## Quality improvements
- **Annotations 4 → 5, all fields added.** The originals had only `content`; each now carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Added a setup annotation (field/nodes/distinctness).
- **`sections` was missing → 5 sections** (header / setup / Vandermonde nonvanishing / finite identity theorem / interpolation uniqueness).
- **Fixed `crossReferences`**: key was `proofId` (gallery doesn't resolve it) → `targetId`; the target `integral-root-theorem-oq-01` verified to exist.

The overview and conclusion were already structured objects with 5 keyInsights; preserved.

## Notes
- Axiom integrity verified: `status: verified`, `axiomCount: 0` match the Lean source (0 sorries, no `axiom`, no `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)