### PR TITLE
research(sophie-germain-oq-01-oq-02): Sophie Germain primes force Mersenne factors — 2p+1 ∣ 2^p−1 for p ≡ 3 mod 4 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3762,6 +3762,7 @@ import Proofs.VietaGeneralOQ030505OQ01
 import Proofs.SolutionOfCubicOQ05
 import Proofs.SophieGermain
 import Proofs.SophieGermainOQ01
+import Proofs.SophieGermainOQ01OQ02
 import Proofs.SophieGermainOQ02
 import Proofs.SophieGermainOQ03
 import Proofs.SophieGermainOQ04

--- a/proofs/Proofs/SophieGermainOQ01OQ02.lean
+++ b/proofs/Proofs/SophieGermainOQ01OQ02.lean
@@ -1,0 +1,150 @@
+import Mathlib.NumberTheory.LegendreSymbol.QuadraticReciprocity
+import Mathlib.Tactic
+
+/-
+# Sophie Germain Primes and Mersenne Compositeness (sophie-germain-oq-01-oq-02)
+
+The parent open question (sophie-germain-oq-01) asks whether there are infinitely
+many Sophie Germain primes.  Its companion file already records the historical
+motivation: Sophie Germain primes first arose in the study of Fermat's Last
+Theorem.  A second, equally classical reason these primes matter is their effect
+on **Mersenne numbers** `2^p - 1`.
+
+## Result
+
+Let `p` be a prime with `p ≡ 3 (mod 4)` such that `q = 2p + 1` is also prime
+(so `p` is a Sophie Germain prime).  Then
+
+    q = 2p + 1   divides   the Mersenne number   2^p - 1.
+
+In particular, whenever `p > 3` the Mersenne number `2^p - 1` is **composite**:
+it has the proper factor `2p + 1`.
+
+This is the theorem behind Euler's and Lagrange's observation (1750s–1770s) that,
+e.g., `M₁₁ = 2^11 - 1 = 2047 = 23 · 89` is composite — here `p = 11` is a Sophie
+Germain prime with `11 ≡ 3 (mod 4)` and `2·11 + 1 = 23` is the predicted factor.
+
+## Proof idea
+
+Write `q = 2p + 1`.  From `p ≡ 3 (mod 4)` one computes `q ≡ 7 (mod 8)`, so by the
+second supplement to quadratic reciprocity `2` is a quadratic residue modulo `q`.
+Euler's criterion then gives
+
+    2^((q-1)/2) ≡ 1 (mod q),   and   (q - 1)/2 = p,
+
+hence `2^p ≡ 1 (mod q)`, i.e. `q ∣ 2^p - 1`.
+
+Mathlib already knows that `2` is a square mod `q` exactly when `q ≡ ±1 (mod 8)`
+(`ZMod.exists_sq_eq_two_iff`) and Euler's criterion (`ZMod.euler_criterion`); the
+arithmetic linking Sophie Germain primes to Mersenne factors is original here.
+
+All results are fully machine-checked with no axioms beyond Lean/Mathlib's
+foundations.
+-/
+
+namespace SophieGermainOQ01OQ02
+
+/-- A natural number `p` is a Sophie Germain prime if both `p` and `2p + 1` are prime.
+(Mirror of `SophieGermain.IsSophieGermainPrime`; restated here to keep this file
+self-contained.) -/
+def IsSophieGermainPrime (p : ℕ) : Prop := Nat.Prime p ∧ Nat.Prime (2 * p + 1)
+
+/-- For `p ≡ 3 (mod 4)`, the safe prime `q = 2p + 1` satisfies `q ≡ 7 (mod 8)`. -/
+theorem safe_prime_mod_eight {p : ℕ} (hp4 : p % 4 = 3) : (2 * p + 1) % 8 = 7 := by
+  omega
+
+/-- `2` is a quadratic residue modulo the safe prime `q = 2p + 1` when `p ≡ 3 (mod 4)`.
+This is the second supplement to quadratic reciprocity specialized to `q ≡ 7 (mod 8)`. -/
+theorem two_isSquare_mod_safe {p : ℕ} (hp4 : p % 4 = 3)
+    (hq : Nat.Prime (2 * p + 1)) : IsSquare (2 : ZMod (2 * p + 1)) := by
+  haveI : Fact (Nat.Prime (2 * p + 1)) := ⟨hq⟩
+  have hq2 : (2 * p + 1) ≠ 2 := by omega
+  exact (ZMod.exists_sq_eq_two_iff hq2).mpr (Or.inr (safe_prime_mod_eight hp4))
+
+/-- `2` is a unit (nonzero) in `ZMod q` for the safe prime `q = 2p + 1`. -/
+theorem two_ne_zero_mod_safe {p : ℕ} (hp4 : p % 4 = 3)
+    (hq : Nat.Prime (2 * p + 1)) : (2 : ZMod (2 * p + 1)) ≠ 0 := by
+  haveI : Fact (Nat.Prime (2 * p + 1)) := ⟨hq⟩
+  have h : ((2 : ℕ) : ZMod (2 * p + 1)) ≠ 0 := by
+    rw [Ne, ZMod.natCast_eq_zero_iff]
+    intro hdvd
+    have := Nat.le_of_dvd (by norm_num) hdvd
+    omega
+  simpa using h
+
+/-- **Sophie Germain ⟹ Mersenne factor.**
+If `p ≡ 3 (mod 4)` is prime and `q = 2p + 1` is also prime (i.e. `p` is a Sophie
+Germain prime), then `q` divides the Mersenne number `2^p - 1`. -/
+theorem safe_prime_dvd_mersenne {p : ℕ} (hp4 : p % 4 = 3)
+    (hq : Nat.Prime (2 * p + 1)) : (2 * p + 1) ∣ 2 ^ p - 1 := by
+  haveI : Fact (Nat.Prime (2 * p + 1)) := ⟨hq⟩
+  -- 2 is a quadratic residue mod q, so Euler's criterion gives 2^((q-1)/2) = 1
+  have hsq : IsSquare (2 : ZMod (2 * p + 1)) := two_isSquare_mod_safe hp4 hq
+  have h2ne : (2 : ZMod (2 * p + 1)) ≠ 0 := two_ne_zero_mod_safe hp4 hq
+  have heuler : (2 : ZMod (2 * p + 1)) ^ ((2 * p + 1) / 2) = 1 :=
+    (ZMod.euler_criterion (2 * p + 1) h2ne).mp hsq
+  have hhalf : (2 * p + 1) / 2 = p := by omega
+  rw [hhalf] at heuler
+  -- transport 2^p ≡ 1 (mod q) to a divisibility statement
+  have hcast : ((2 ^ p : ℕ) : ZMod (2 * p + 1)) = ((1 : ℕ) : ZMod (2 * p + 1)) := by
+    push_cast
+    exact heuler
+  rw [ZMod.natCast_eq_natCast_iff] at hcast
+  have h1 : (1 : ℕ) ≤ 2 ^ p := Nat.one_le_pow _ _ (by norm_num)
+  exact (Nat.modEq_iff_dvd' h1).mp hcast.symm
+
+/-- **Capstone, stated for Sophie Germain primes.**
+If `p` is a Sophie Germain prime with `p ≡ 3 (mod 4)`, then the safe prime
+`2p + 1` divides the Mersenne number `2^p - 1`. -/
+theorem sophie_germain_dvd_mersenne {p : ℕ} (hsg : IsSophieGermainPrime p)
+    (hp4 : p % 4 = 3) : (2 * p + 1) ∣ 2 ^ p - 1 :=
+  safe_prime_dvd_mersenne hp4 hsg.2
+
+/-- Auxiliary growth bound: `2p + 2 < 2^p` for `p ≥ 5`. Used to show the divisor
+`2p + 1` is proper, hence the Mersenne number is composite. -/
+theorem two_mul_add_two_lt_two_pow : ∀ {p : ℕ}, 5 ≤ p → 2 * p + 2 < 2 ^ p := by
+  intro p
+  induction p with
+  | zero => intro h; omega
+  | succ n ih =>
+    intro h
+    rcases Nat.lt_or_ge n 5 with hn | hn
+    · have hn4 : n = 4 := by omega
+      subst hn4
+      norm_num
+    · have hih := ih hn
+      have hpow : 2 ^ (n + 1) = 2 * 2 ^ n := by rw [pow_succ]; ring
+      omega
+
+/-- **Mersenne compositeness.**
+If `p ≡ 3 (mod 4)` is a Sophie Germain prime with `p ≥ 5`, then `2^p - 1` is not
+prime: the safe prime `q = 2p + 1` is a proper divisor. -/
+theorem mersenne_not_prime {p : ℕ} (hp4 : p % 4 = 3) (hp5 : 5 ≤ p)
+    (hq : Nat.Prime (2 * p + 1)) : ¬ Nat.Prime (2 ^ p - 1) := by
+  intro hM
+  have hdvd : (2 * p + 1) ∣ 2 ^ p - 1 := safe_prime_dvd_mersenne hp4 hq
+  rcases (Nat.Prime.eq_one_or_self_of_dvd hM _ hdvd) with h1 | hself
+  · omega
+  · have hlt : 2 * p + 2 < 2 ^ p := two_mul_add_two_lt_two_pow hp5
+    omega
+
+/-! ## Concrete instances
+
+These exhibit the predicted Mersenne factors for the first Sophie Germain primes
+`p ≡ 3 (mod 4)`. -/
+
+/-- `11` is a Sophie Germain prime with `11 ≡ 3 (mod 4)`, so `23 = 2·11 + 1`
+divides `2^11 - 1 = 2047`.  (Indeed `2047 = 23 · 89`.) -/
+theorem twentythree_dvd_mersenne_eleven : (2 * 11 + 1) ∣ 2 ^ 11 - 1 :=
+  safe_prime_dvd_mersenne (by norm_num) (by norm_num)
+
+/-- Hence `2^11 - 1` is composite. -/
+theorem mersenne_eleven_not_prime : ¬ Nat.Prime (2 ^ 11 - 1) :=
+  mersenne_not_prime (by norm_num) (by norm_num) (by norm_num)
+
+/-- `23` is a Sophie Germain prime with `23 ≡ 3 (mod 4)`, so `47 = 2·23 + 1`
+divides `2^23 - 1 = 8388607`.  (Indeed `8388607 = 47 · 178481`.) -/
+theorem fortyseven_dvd_mersenne_twentythree : (2 * 23 + 1) ∣ 2 ^ 23 - 1 :=
+  safe_prime_dvd_mersenne (by norm_num) (by norm_num)
+
+end SophieGermainOQ01OQ02

--- a/src/data/proofs/sophie-germain-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/sophie-germain-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sophie-germain-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 48 },
+    "type": "concept",
+    "title": "Sophie Germain Primes and Mersenne Compositeness",
+    "content": "Sophie Germain primes (p with 2p+1 also prime) are usually met through Fermat's Last Theorem, but they also govern which Mersenne numbers 2^p − 1 are composite. When p ≡ 3 (mod 4) and q = 2p+1 is prime, q automatically divides 2^p − 1. The smallest case is p = 11: M₁₁ = 2047 = 23·89, and the factor 23 = 2·11+1 is precisely the safe prime. This entry proves the general divisibility and reads the explicit factors off it.",
+    "mathContext": "$p\\equiv 3\\ (\\mathrm{mod}\\ 4),\\ q=2p+1\\ \\text{prime}\\ \\Rightarrow\\ q\\mid 2^p-1.$",
+    "significance": "key",
+    "relatedConcepts": ["Sophie Germain primes", "Mersenne numbers", "quadratic residues"],
+    "prerequisites": ["modular arithmetic", "elementary number theory"]
+  },
+  {
+    "id": "ann-residue-qr",
+    "proofId": "sophie-germain-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 63 },
+    "type": "key-step",
+    "title": "p ≡ 3 (mod 4) ⟹ q ≡ 7 (mod 8) ⟹ 2 is a Quadratic Residue",
+    "content": "`safe_prime_mod_eight` is a single `omega` computation: writing p = 4k+3 gives q = 2p+1 = 8k+7, so q ≡ 7 (mod 8). The second supplement to quadratic reciprocity says 2 is a square mod an odd prime exactly when the prime is ≡ ±1 (mod 8). Mathlib packages this as `ZMod.exists_sq_eq_two_iff`, and `two_isSquare_mod_safe` applies it to the residue 7 to conclude 2 is a quadratic residue modulo q.",
+    "mathContext": "$q\\equiv 7\\ (\\mathrm{mod}\\ 8)\\ \\Rightarrow\\ \\left(\\tfrac{2}{q}\\right)=+1.$",
+    "significance": "key",
+    "relatedConcepts": ["quadratic reciprocity", "second supplement", "Legendre symbol"],
+    "prerequisites": ["quadratic residues mod p"]
+  },
+  {
+    "id": "ann-two-unit",
+    "proofId": "sophie-germain-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "technique",
+    "title": "2 is a Unit Modulo the Safe Prime",
+    "content": "Euler's criterion is stated for a nonzero element. `two_ne_zero_mod_safe` checks (2 : ZMod (2p+1)) ≠ 0: via `ZMod.natCast_eq_zero_iff`, that would force 2p+1 ∣ 2, but `Nat.le_of_dvd` then gives 2p+1 ≤ 2, contradicting p ≥ 3 (`omega`). So 2 is a unit and Euler's criterion applies.",
+    "mathContext": "$q\\nmid 2 \\Rightarrow (2:\\mathbb{Z}/q\\mathbb{Z})\\ne 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["units in ZMod", "divisibility"],
+    "prerequisites": ["ZMod arithmetic"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "sophie-germain-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 103 },
+    "type": "key-step",
+    "title": "Euler's Criterion Lands the Exponent on p",
+    "content": "`safe_prime_dvd_mersenne` is the heart of the entry. Euler's criterion (`ZMod.euler_criterion`) turns '2 is a square mod q' into 2^((q−1)/2) = 1 in ZMod q. The safe-prime structure makes the exponent collapse: (2p+1 − 1)/2 = p by `omega`, so the statement is 2^p = 1 in ZMod q. `ZMod.natCast_eq_natCast_iff` reads this as 2^p ≡ 1 (mod q), and `Nat.modEq_iff_dvd'` converts the congruence to q ∣ 2^p − 1. `sophie_germain_dvd_mersenne` then restates the result under the explicit `IsSophieGermainPrime` hypothesis.",
+    "mathContext": "$2^{(q-1)/2}=1\\ \\text{in }\\mathbb{Z}/q\\mathbb{Z},\\ \\tfrac{q-1}{2}=p\\ \\Rightarrow\\ q\\mid 2^p-1.$",
+    "significance": "key",
+    "relatedConcepts": ["Euler's criterion", "Mersenne numbers", "order of an element"],
+    "prerequisites": ["Euler's criterion", "modular congruences"]
+  },
+  {
+    "id": "ann-composite",
+    "proofId": "sophie-germain-oq-01-oq-02",
+    "range": { "startLine": 105, "endLine": 136 },
+    "type": "key-step",
+    "title": "Properness of the Factor ⟹ Compositeness",
+    "content": "To upgrade 'q divides' to '2^p − 1 is composite', q must be a proper factor. `two_mul_add_two_lt_two_pow` proves 2p+2 < 2^p for p ≥ 5 by induction (base p = 5: 12 < 32; step: doubling 2^n dominates the linear growth). `mersenne_not_prime` feeds the divisor 2p+1 to `Nat.Prime.eq_one_or_self_of_dvd`: it is neither 1 (p ≥ 5) nor 2^p − 1 (by the bound), so 2^p − 1 cannot be prime. The threshold matters — at p = 3, 2·3+1 = 7 = 2³ − 1 is itself the Mersenne prime, which is exactly why p ≥ 5 is required.",
+    "mathContext": "$5\\le p \\Rightarrow 2p+1 < 2^p-1,\\ \\text{a proper divisor}.$",
+    "significance": "key",
+    "relatedConcepts": ["compositeness", "induction", "proper divisors"],
+    "prerequisites": ["primality in ℕ", "exponential growth bounds"]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "sophie-germain-oq-01-oq-02",
+    "range": { "startLine": 138, "endLine": 150 },
+    "type": "concept",
+    "title": "Explicit Factors: 23 ∣ M₁₁ and 47 ∣ M₂₃",
+    "content": "The first Sophie Germain primes with p ≡ 3 (mod 4) are 11 and 23. `twentythree_dvd_mersenne_eleven` gives 23 ∣ 2¹¹ − 1 = 2047 (= 23·89) and `mersenne_eleven_not_prime` records that 2¹¹ − 1 is composite; `fortyseven_dvd_mersenne_twentythree` gives 47 ∣ 2²³ − 1 = 8388607 (= 47·178481). Each is obtained by instantiating the general theorem — the factor is predicted, not searched for.",
+    "mathContext": "$23\\mid 2^{11}-1=23\\cdot 89;\\quad 47\\mid 2^{23}-1=47\\cdot 178481.$",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "Mersenne factorization"],
+    "prerequisites": ["the main theorem"]
+  }
+]

--- a/src/data/proofs/sophie-germain-oq-01-oq-02/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "sophie-germain-oq-01-oq-02",
+  "slug": "sophie-germain-oq-01-oq-02",
+  "title": "Sophie Germain Primes Force Mersenne Factors: 2p+1 ∣ 2ᵖ−1 for p ≡ 3 (mod 4)",
+  "description": "If p ≡ 3 (mod 4) is a Sophie Germain prime, the safe prime q = 2p+1 divides the Mersenne number 2^p − 1, so 2^p − 1 is composite for p ≥ 5. This is the theorem behind Euler's and Lagrange's eighteenth-century observation that, e.g., M₁₁ = 2¹¹ − 1 = 2047 = 23·89 is composite — here p = 11 is a Sophie Germain prime with 11 ≡ 3 (mod 4) and 2·11+1 = 23 is the predicted factor. Proof: from p ≡ 3 (mod 4) one gets q ≡ 7 (mod 8), so 2 is a quadratic residue mod q (ZMod.exists_sq_eq_two_iff); Euler's criterion then gives 2^((q−1)/2) = 1 in ZMod q with (q−1)/2 = p, i.e. 2^p ≡ 1 (mod q), hence q ∣ 2^p − 1. Concrete factors are exhibited for p = 11 (23 ∣ 2¹¹−1) and p = 23 (47 ∣ 2²³−1), plus a growth bound 2p+2 < 2^p giving compositeness. Fully machine-checked, 0 sorries, 0 axioms.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "SophieGermainOQ01OQ02",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 4,
+    "trivialSpecializations": 3,
+    "definitionCount": 1,
+    "path": "Proofs/SophieGermainOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Researcher Agent (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SophieGermainOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "sophie-germain",
+      "mersenne-numbers",
+      "quadratic-residues",
+      "euler-criterion",
+      "primality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. #print axioms reports only propext / Classical.choice / Quot.sound on every theorem; no sorry, no native_decide, no Lean.ofReduceBool. The concrete-instance primality side conditions (Nat.Prime 23, Nat.Prime 47) are discharged by norm_num (kernel-checked).",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      "ZMod.exists_sq_eq_two_iff",
+      "ZMod.euler_criterion",
+      "ZMod.natCast_eq_natCast_iff",
+      "ZMod.natCast_eq_zero_iff",
+      "Nat.modEq_iff_dvd'",
+      "Nat.Prime.eq_one_or_self_of_dvd",
+      "Nat.one_le_pow"
+    ],
+    "originalContributions": [
+      "safe_prime_dvd_mersenne: the main bridge — p ≡ 3 (mod 4) prime with 2p+1 prime ⟹ (2p+1) ∣ 2^p − 1, connecting Sophie Germain primes to Mersenne factors. This arithmetic is absent from Mathlib (which has Fermat-number prime-factor forms and a^n−1 primality criteria, but not this Sophie Germain ⟹ Mersenne result).",
+      "safe_prime_mod_eight: p ≡ 3 (mod 4) ⟹ (2p+1) ≡ 7 (mod 8), the residue feeding the second supplement to quadratic reciprocity.",
+      "two_isSquare_mod_safe: 2 is a quadratic residue mod the safe prime q = 2p+1 when p ≡ 3 (mod 4).",
+      "mersenne_not_prime: for a Sophie Germain prime p ≡ 3 (mod 4) with p ≥ 5, the Mersenne number 2^p − 1 is composite, with 2p+1 as a certified proper factor.",
+      "sophie_germain_dvd_mersenne: capstone restatement under the explicit Sophie Germain hypothesis (both p and 2p+1 prime).",
+      "Concrete factor witnesses 23 ∣ 2¹¹−1 and 47 ∣ 2²³−1, derived from the general theorem rather than by direct computation."
+    ],
+    "prerequisites": [
+      "Quadratic residues and the second supplement to quadratic reciprocity (2 is a QR mod p iff p ≡ ±1 mod 8)",
+      "Euler's criterion a^((p−1)/2) = 1 ⟺ a is a nonzero square in ZMod p",
+      "ZMod arithmetic and the natCast ≡ MOD bridge",
+      "Elementary divisibility and primality in ℕ"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 150,
+    "relatedProblems": ["sophie-germain", "sophie-germain-oq-01", "sophie-germain-oq-04"],
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Sophie Germain primes — primes p with 2p+1 also prime — are best known for Sophie Germain's nineteenth-century work on Fermat's Last Theorem. But the same primes appear in a much older question: which Mersenne numbers 2^p − 1 are composite? In the 1750s–1770s Euler and Lagrange observed that when p ≡ 3 (mod 4) and q = 2p+1 is prime, q automatically divides 2^p − 1. The smallest non-trivial case is p = 11: M₁₁ = 2047 is not prime, and the factor 23 = 2·11+1 is exactly the safe prime. This explained away one of the first 'surprising' Mersenne composites and connected primality of 2^p − 1 to the arithmetic of the auxiliary prime 2p+1.",
+    "problemStatement": "Show that if p ≡ 3 (mod 4) is a Sophie Germain prime then the safe prime q = 2p+1 divides the Mersenne number 2^p − 1, and deduce that 2^p − 1 is composite whenever p ≥ 5. Exhibit the explicit factors for the first such primes.",
+    "proofStrategy": "Set q = 2p+1. From p ≡ 3 (mod 4) a one-line omega computation gives q ≡ 7 (mod 8). By the second supplement to quadratic reciprocity (Mathlib's ZMod.exists_sq_eq_two_iff), 2 is a quadratic residue modulo q. Euler's criterion (ZMod.euler_criterion) then yields 2^((q−1)/2) = 1 in ZMod q; since (q−1)/2 = p (an omega fact about q = 2p+1), this is 2^p = 1 in ZMod q. Transporting through ZMod.natCast_eq_natCast_iff gives 2^p ≡ 1 (mod q), and Nat.modEq_iff_dvd' converts this to q ∣ 2^p − 1. For compositeness, q is a divisor of 2^p − 1 that is neither 1 nor 2^p − 1: the growth bound 2p+2 < 2^p (p ≥ 5, by induction) shows q < 2^p − 1, so Nat.Prime.eq_one_or_self_of_dvd is contradicted.",
+    "keyInsights": [
+      "The residue p ≡ 3 (mod 4) is exactly what is needed to push q = 2p+1 into the class q ≡ 7 (mod 8), where 2 becomes a quadratic residue — the entire result hinges on this one modular coincidence.",
+      "Euler's criterion converts 'is 2 a square mod q' into 'is 2^((q−1)/2) = 1', and the safe-prime structure makes the exponent (q−1)/2 land exactly on p, the Mersenne exponent.",
+      "Mathlib already proves both ingredients (2-is-a-QR characterization and Euler's criterion); the new content is the arithmetic identification (q−1)/2 = p that ties them to Mersenne numbers.",
+      "Compositeness needs the divisor to be proper, which fails precisely at p = 3 (there 2·3+1 = 7 = 2^3 − 1 is the Mersenne prime itself); the p ≥ 5 hypothesis and the 2p+2 < 2^p bound encode this boundary.",
+      "The same mechanism is why p ≡ 3 (mod 4) Sophie Germain primes never give Mersenne primes — the safe prime is always a built-in factor."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "safe_prime_dvd_mersenne",
+      "statement": "p % 4 = 3 → Nat.Prime (2p+1) → (2p+1) ∣ 2^p − 1",
+      "description": "The main result: for p ≡ 3 (mod 4) with 2p+1 prime, the safe prime 2p+1 divides the Mersenne number 2^p − 1. Proved via 2-is-a-QR mod 2p+1 and Euler's criterion."
+    },
+    {
+      "name": "sophie_germain_dvd_mersenne",
+      "statement": "IsSophieGermainPrime p → p % 4 = 3 → (2p+1) ∣ 2^p − 1",
+      "description": "Capstone restatement under the full Sophie Germain hypothesis (both p and 2p+1 prime)."
+    },
+    {
+      "name": "mersenne_not_prime",
+      "statement": "p % 4 = 3 → 5 ≤ p → Nat.Prime (2p+1) → ¬ Nat.Prime (2^p − 1)",
+      "description": "Compositeness: for a Sophie Germain prime p ≡ 3 (mod 4) with p ≥ 5, 2^p − 1 is composite with 2p+1 a certified proper factor."
+    },
+    {
+      "name": "twentythree_dvd_mersenne_eleven",
+      "statement": "(2·11+1) ∣ 2^11 − 1",
+      "description": "The first non-trivial instance: 23 divides 2^11 − 1 = 2047 (= 23·89), derived from the general theorem."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "`import Mathlib`, the module docstring stating the Sophie Germain ⟹ Mersenne factor result with the M₁₁ = 23·89 motivation and the full proof sketch (q ≡ 7 mod 8 ⟹ 2 is a QR ⟹ Euler's criterion), and `namespace SophieGermainOQ01OQ02`.",
+      "mathContext": "$p\\equiv 3\\ (\\mathrm{mod}\\ 4),\\ q=2p+1\\ \\text{prime}\\ \\Rightarrow\\ q\\mid 2^p-1.$"
+    },
+    {
+      "id": "residue-qr",
+      "title": "Residue Computation and 2 as a Quadratic Residue",
+      "startLine": 50,
+      "endLine": 63,
+      "summary": "Defines IsSophieGermainPrime, proves safe_prime_mod_eight ((2p+1) ≡ 7 mod 8 from p ≡ 3 mod 4 by omega), and two_isSquare_mod_safe (2 is a square mod 2p+1 via ZMod.exists_sq_eq_two_iff applied to the residue 7).",
+      "mathContext": "$q\\equiv 7\\ (\\mathrm{mod}\\ 8)\\ \\Rightarrow\\ 2\\ \\text{is a QR mod } q.$"
+    },
+    {
+      "id": "two-unit",
+      "title": "2 is a Unit mod the Safe Prime",
+      "startLine": 65,
+      "endLine": 76,
+      "summary": "two_ne_zero_mod_safe: (2 : ZMod (2p+1)) ≠ 0, since 2p+1 is prime and exceeds 2, so it cannot divide 2 (ZMod.natCast_eq_zero_iff plus Nat.le_of_dvd). This is the nonzero hypothesis Euler's criterion requires.",
+      "mathContext": "$q\\nmid 2 \\Rightarrow (2:\\mathbb{Z}/q\\mathbb{Z})\\ne 0.$"
+    },
+    {
+      "id": "main",
+      "title": "Main Theorem and Sophie Germain Capstone",
+      "startLine": 78,
+      "endLine": 103,
+      "summary": "safe_prime_dvd_mersenne: Euler's criterion gives 2^((q−1)/2) = 1 in ZMod q; the omega fact (q−1)/2 = p turns this into 2^p = 1, transported through ZMod.natCast_eq_natCast_iff and Nat.modEq_iff_dvd' to q ∣ 2^p − 1. sophie_germain_dvd_mersenne restates it under the IsSophieGermainPrime hypothesis.",
+      "mathContext": "$2^{(q-1)/2}=1\\ \\text{in }\\mathbb{Z}/q\\mathbb{Z},\\ (q-1)/2=p\\ \\Rightarrow\\ q\\mid 2^p-1.$"
+    },
+    {
+      "id": "compositeness",
+      "title": "Growth Bound and Mersenne Compositeness",
+      "startLine": 105,
+      "endLine": 136,
+      "summary": "two_mul_add_two_lt_two_pow proves 2p+2 < 2^p for p ≥ 5 by induction (base p = 5, step doubling). mersenne_not_prime uses it with Nat.Prime.eq_one_or_self_of_dvd to rule out the divisor 2p+1 being trivial or the whole number, so 2^p − 1 is composite.",
+      "mathContext": "$5\\le p \\Rightarrow 2p+2<2^p \\Rightarrow 2p+1<2^p-1.$"
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Mersenne Factors",
+      "startLine": 138,
+      "endLine": 150,
+      "summary": "twentythree_dvd_mersenne_eleven (23 ∣ 2¹¹−1), mersenne_eleven_not_prime (2¹¹−1 composite), and fortyseven_dvd_mersenne_twentythree (47 ∣ 2²³−1) — all instances of the general theorems for the first Sophie Germain primes p ≡ 3 (mod 4).",
+      "mathContext": "$23\\mid 2^{11}-1=2047=23\\cdot 89;\\quad 47\\mid 2^{23}-1=8388607=47\\cdot 178481.$"
+    }
+  ],
+  "references": [
+    {
+      "title": "Safe and Sophie Germain primes",
+      "url": "https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes"
+    },
+    {
+      "title": "Mersenne prime",
+      "url": "https://en.wikipedia.org/wiki/Mersenne_prime"
+    },
+    {
+      "title": "Quadratic residue (second supplement to reciprocity)",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_residue"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sophie-germain",
+      "relationship": "Structural consequence of the Sophie Germain prime definition",
+      "description": "The base entry establishes that Sophie Germain primes p > 3 satisfy p ≡ 5 (mod 6); this entry adds a different structural consequence — when additionally p ≡ 3 (mod 4), the safe prime 2p+1 is a guaranteed factor of the Mersenne number 2^p − 1."
+    },
+    {
+      "proofId": "sophie-germain-oq-01",
+      "relationship": "Sibling under the infinitude open question",
+      "description": "Where oq-01 studies whether Sophie Germain primes are infinite and their equivalence with safe primes, this leaf records a concrete arithmetic property each such prime (with p ≡ 3 mod 4) imposes on Mersenne numbers."
+    },
+    {
+      "proofId": "sophie-germain-oq-04",
+      "relationship": "Companion compositeness result",
+      "description": "Both entries manufacture composite numbers from Sophie Germain's name: oq-04 via the algebraic identity n⁴ + 4, this entry via the Mersenne factor 2p+1 ∣ 2^p − 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a Sophie Germain prime p ≡ 3 (mod 4), the safe prime q = 2p+1 always divides the Mersenne number 2^p − 1, so 2^p − 1 is composite for p ≥ 5. The proof routes p ≡ 3 (mod 4) into q ≡ 7 (mod 8), invokes the second supplement to quadratic reciprocity to make 2 a quadratic residue mod q, and applies Euler's criterion with the exponent (q−1)/2 landing exactly on p. Concrete factors 23 ∣ 2¹¹−1 and 47 ∣ 2²³−1 fall out as instances. Everything is machine-checked with zero sorries and zero axioms.",
+    "implications": "The result gives an infinite (conjecturally) family of explicitly-factored composite Mersenne numbers tied to Sophie Germain primes, and explains the classical Euler/Lagrange Mersenne composites. It also shows that p ≡ 3 (mod 4) Sophie Germain primes can never yield Mersenne primes, since the safe prime is a built-in factor.",
+    "openQuestions": [
+      "What is the multiplicative order of 2 modulo q = 2p+1 — exactly p or 2p — and how does the case p ≡ 1 (mod 4) (where 2 is a non-residue) differ?",
+      "Can the companion statement for p ≡ 1 (mod 4) be formalized, where instead 2p+1 ∣ 2^p + 1?",
+      "How does this factor interact with the known prime-factor congruences for Mersenne numbers (every prime factor of 2^p − 1 is ≡ 1 mod 2p and ≡ ±1 mod 8)?"
+    ]
+  }
+}

--- a/src/data/research/problems/sophie-germain-oq-01-oq-02.json
+++ b/src/data/research/problems/sophie-germain-oq-01-oq-02.json
@@ -1,0 +1,72 @@
+{
+  "slug": "sophie-germain-oq-01-oq-02",
+  "title": "Sophie Germain Primes Force Mersenne Factors (p ≡ 3 mod 4 ⟹ 2p+1 ∣ 2^p − 1)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "p \\equiv 3 \\pmod 4 \\text{ prime},\\ q=2p+1 \\text{ prime} \\implies q \\mid 2^p - 1",
+    "plain": "Show that for a Sophie Germain prime p with p ≡ 3 (mod 4), the safe prime q = 2p+1 divides the Mersenne number 2^p − 1, hence 2^p − 1 is composite for p ≥ 5.",
+    "whyMatters": [
+      "Explains classical Euler/Lagrange Mersenne composites such as M₁₁ = 2047 = 23·89.",
+      "Connects the arithmetic of Sophie Germain primes to the primality of Mersenne numbers."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Mathlib: ZMod.exists_sq_eq_two_iff (2 is a QR mod p iff p ≡ ±1 mod 8)",
+      "Mathlib: ZMod.euler_criterion (a is a nonzero square iff a^((p-1)/2) = 1)"
+    ],
+    "open": [],
+    "goal": "Bridge Sophie Germain primes to Mersenne factors via quadratic residues and Euler's criterion."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Gallery proof verified — 150 lines, 0 sorries, 0 axioms (only propext/Classical.choice/Quot.sound), 10 theorems + 1 def",
+    "blockers": [],
+    "nextAction": "None — proof complete and verified.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "Created SophieGermainOQ01OQ02.lean (150 lines, 0 sorries, 0 axioms). Proves the main bridge safe_prime_dvd_mersenne: for p ≡ 3 (mod 4) with 2p+1 prime, the safe prime 2p+1 divides the Mersenne number 2^p − 1. Route: omega shows q = 2p+1 ≡ 7 (mod 8); ZMod.exists_sq_eq_two_iff makes 2 a quadratic residue mod q; ZMod.euler_criterion gives 2^((q−1)/2) = 1 in ZMod q with (q−1)/2 = p (omega), i.e. 2^p ≡ 1 (mod q), transported to q ∣ 2^p − 1 via natCast_eq_natCast_iff + Nat.modEq_iff_dvd'. Adds compositeness (mersenne_not_prime, p ≥ 5) using the growth bound 2p+2 < 2^p, plus explicit factor witnesses 23 ∣ 2¹¹−1 and 47 ∣ 2²³−1. Self-contained (Mathlib only); the Sophie Germain ⟹ Mersenne arithmetic is absent from Mathlib.",
+    "builtItems": [
+      "safe_prime_dvd_mersenne: p % 4 = 3 → Nat.Prime (2p+1) → (2p+1) ∣ 2^p − 1 (main theorem)",
+      "safe_prime_mod_eight: p % 4 = 3 → (2p+1) % 8 = 7 (residue feeding QR)",
+      "two_isSquare_mod_safe: 2 is a quadratic residue mod the safe prime 2p+1",
+      "two_ne_zero_mod_safe: (2 : ZMod (2p+1)) ≠ 0 (nonzero hypothesis for Euler's criterion)",
+      "mersenne_not_prime: p % 4 = 3 → 5 ≤ p → Nat.Prime (2p+1) → ¬ Nat.Prime (2^p − 1)",
+      "two_mul_add_two_lt_two_pow: 5 ≤ p → 2p+2 < 2^p (growth bound, induction)",
+      "sophie_germain_dvd_mersenne: capstone under the IsSophieGermainPrime hypothesis",
+      "twentythree_dvd_mersenne_eleven / fortyseven_dvd_mersenne_twentythree: explicit Mersenne factors"
+    ],
+    "insights": [
+      "The residue p ≡ 3 (mod 4) is exactly what pushes q = 2p+1 into q ≡ 7 (mod 8), the class where 2 is a quadratic residue — the whole result hinges on this single modular coincidence.",
+      "Euler's criterion converts 'is 2 a square mod q' into '2^((q−1)/2) = 1', and the safe-prime structure makes the exponent (q−1)/2 collapse to exactly p, the Mersenne exponent.",
+      "Compositeness needs a proper divisor, which fails at p = 3 (there 2·3+1 = 7 = 2³ − 1 is the Mersenne prime itself); the p ≥ 5 hypothesis plus the 2p+2 < 2^p bound encode this boundary.",
+      "Mathlib has Fermat-number prime-factor congruences and a^n−1 primality criteria but not the Sophie Germain ⟹ Mersenne factor result — the QR + Euler ingredients exist, the arithmetic identification (q−1)/2 = p is the new glue.",
+      "p ≡ 3 (mod 4) Sophie Germain primes can never yield Mersenne primes, since the safe prime is a built-in factor of 2^p − 1."
+    ],
+    "mathlibGaps": [
+      "No lemma in Mathlib linking Sophie Germain / safe primes to Mersenne-number factorization."
+    ],
+    "nextSteps": [
+      "Companion case p ≡ 1 (mod 4): then 2 is a non-residue and 2p+1 ∣ 2^p + 1 instead.",
+      "Determine the exact multiplicative order of 2 modulo q (p or 2p)."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "sophie-germain",
+    "mersenne-numbers",
+    "quadratic-residues",
+    "euler-criterion"
+  ],
+  "relatedProofs": [
+    "sophie-germain",
+    "sophie-germain-oq-01",
+    "sophie-germain-oq-04"
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **sophie-germain-oq-01-oq-02**: a Sophie Germain prime `p ≡ 3 (mod 4)` forces the safe prime `q = 2p+1` to divide the Mersenne number `2^p − 1`, so `2^p − 1` is composite for `p ≥ 5`. This is the eighteenth-century Euler/Lagrange theorem explaining why, e.g., `M₁₁ = 2¹¹ − 1 = 2047 = 23·89` is composite — `p = 11` is a Sophie Germain prime with `11 ≡ 3 (mod 4)` and `2·11+1 = 23` is the predicted factor.

## Proof

`q = 2p+1`. From `p ≡ 3 (mod 4)`, `omega` gives `q ≡ 7 (mod 8)`, so by the second supplement to quadratic reciprocity (`ZMod.exists_sq_eq_two_iff`) `2` is a quadratic residue mod `q`. Euler's criterion (`ZMod.euler_criterion`) yields `2^((q−1)/2) = 1` in `ZMod q`, and `(q−1)/2 = p`, so `2^p ≡ 1 (mod q)`, hence `q ∣ 2^p − 1`. Compositeness follows from the growth bound `2p+2 < 2^p` (`p ≥ 5`) making `q` a proper divisor.

## Originality

Mathlib has Fermat-number prime-factor congruences and `a^n − 1` primality criteria, but **not** the Sophie Germain ⟹ Mersenne factor result. The QR + Euler ingredients exist in Mathlib; the new content is the arithmetic identification `(q−1)/2 = p` that ties them to Mersenne numbers, plus the compositeness corollary.

## Verification

- **10 theorems + 1 def, 150 lines, 0 sorries, 0 axioms** (`#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound`; no `native_decide`, no `sorryAx`).
- Self-contained: imports Mathlib only.
- Explicit factor witnesses derived from the general theorem: `23 ∣ 2¹¹ − 1`, `47 ∣ 2²³ − 1`.

## Main theorems

- `safe_prime_dvd_mersenne` — `p % 4 = 3 → Nat.Prime (2p+1) → (2p+1) ∣ 2^p − 1`
- `mersenne_not_prime` — `p % 4 = 3 → 5 ≤ p → Nat.Prime (2p+1) → ¬ Nat.Prime (2^p − 1)`
- `sophie_germain_dvd_mersenne` — capstone under `IsSophieGermainPrime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)