### PR TITLE
research(arithmetic-series-oq-02-oq-01-oq-01-oq-03): dual & symmetric forms of the q-Vandermonde identity [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean
@@ -1,0 +1,106 @@
+import Mathlib
+import Proofs.ArithmeticSeriesOQ02OQ01OQ01
+
+/-
+# Dual and symmetric forms of the q-Vandermonde identity
+  (arithmetic-series-oq-02-oq-01-oq-01-oq-03)
+
+The parent entry `arithmetic-series-oq-02-oq-01-oq-01` proves the **Gauss
+q-Vandermonde convolution identity**
+
+  `[m+n choose r]_q = ∑_{k=0}^{r} q^{k(m+k−r)} · [m choose r−k]_q · [n choose k]_q`.   (V)
+
+The Gaussian binomial `[n choose k]_q = qBinom q n k` is symmetric in its two
+*summand* roles in a way the single form (V) hides: it is invariant under the
+involutions `m ↔ n` and `k ↦ r−k`. This file makes both symmetries explicit and
+proves the resulting **dual / reflected forms equivalent to (V)** — answering the
+open question *"derive the dual/symmetric forms of the q-Vandermonde identity
+(swap m↔n, or reflect r↦m+n−r) and prove their equivalence, exposing the
+symmetry of the q-exponent q^{k(m+k−r)}."*
+
+## What is proved
+
+* `qVandermonde_swap` — the **dual form** obtained by swapping the two factors
+  `m ↔ n`. The convolution is symmetric because `m+n = n+m`, so the left-hand
+  side is unchanged while the roles of `[m choose ·]` and `[n choose ·]` (and the
+  q-exponent `k(m+k−r) ↦ k(n+k−r)`) are exchanged.
+
+* `qVandermonde_sum_symm` — the **equivalence of the two convolution sums**: the
+  original sum of (V) and the `m↔n`-swapped sum are *equal as ring elements*
+  (both compute `[m+n choose r]_q`). This is the precise statement that the
+  q-exponent symmetry `k(m+k−r) ↔ k(n+k−r)` is a genuine identity, not just a
+  cosmetic relabelling.
+
+* `qVandermonde_reflect` — the **reflected-index form** obtained by the
+  involution `k ↦ r−k` on the summation range. It re-exposes (V) with the
+  q-exponent in the dual shape `(r−k)(m−k)` and the two binomial factors
+  index-reflected:
+  `[m+n choose r]_q = ∑_{k=0}^{r} q^{(r−k)(m−k)} · [m choose k]_q · [n choose r−k]_q`.
+
+* `qVandermonde_reflect_sum_symm` — the corresponding **sum equivalence** for the
+  reflected form.
+
+All four results are corollaries of the parent's `qVandermonde` (no new spectral
+or analytic input); the only manipulations are `add_comm` on `ℕ` and
+`Finset.sum_range_reflect`. The Gaussian binomial `qBinom` and the identity (V)
+are imported unchanged from the parent files.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open GaussianBinomial qVandermondeProof Finset BigOperators
+
+namespace qVandermondeDual
+
+variable {R : Type*} [CommRing R]
+
+/-- **Dual q-Vandermonde (swap `m ↔ n`).** Because the binomial argument `m + n`
+is symmetric, the convolution may be written with the roles of `m` and `n`
+exchanged; the q-exponent transforms `k(m+k−r) ↦ k(n+k−r)`. -/
+theorem qVandermonde_swap (q : R) (m n r : ℕ) :
+    qBinom q (m + n) r =
+      ∑ k ∈ Finset.range (r + 1),
+        q ^ (k * (n + k - r)) * qBinom q n (r - k) * qBinom q m k := by
+  rw [show m + n = n + m from Nat.add_comm m n]
+  exact qVandermonde q n m r
+
+/-- **Symmetry of the convolution sum.** The original q-Vandermonde sum and its
+`m ↔ n`-swap are equal ring elements (both equal `[m+n choose r]_q`). This is the
+exact statement that the q-exponent symmetry `k(m+k−r) ↔ k(n+k−r)` is an
+identity. -/
+theorem qVandermonde_sum_symm (q : R) (m n r : ℕ) :
+    (∑ k ∈ Finset.range (r + 1),
+        q ^ (k * (m + k - r)) * qBinom q m (r - k) * qBinom q n k) =
+      ∑ k ∈ Finset.range (r + 1),
+        q ^ (k * (n + k - r)) * qBinom q n (r - k) * qBinom q m k := by
+  rw [← qVandermonde q m n r]
+  exact qVandermonde_swap q m n r
+
+/-- **Reflected-index q-Vandermonde (involution `k ↦ r−k`).** Reflecting the
+summation index re-expresses (V) with the q-exponent in the dual shape
+`(r−k)(m−k)` and the two binomial factors index-reflected. -/
+theorem qVandermonde_reflect (q : R) (m n r : ℕ) :
+    qBinom q (m + n) r =
+      ∑ k ∈ Finset.range (r + 1),
+        q ^ ((r - k) * (m - k)) * qBinom q m k * qBinom q n (r - k) := by
+  rw [qVandermonde q m n r,
+    ← Finset.sum_range_reflect
+      (fun k => q ^ (k * (m + k - r)) * qBinom q m (r - k) * qBinom q n k) (r + 1)]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  simp only [Finset.mem_range, Nat.lt_succ_iff] at hk
+  have h1 : r + 1 - 1 - k = r - k := by omega
+  have h2 : m + (r - k) - r = m - k := by omega
+  have h3 : r - (r - k) = k := by omega
+  simp only [h1, h2, h3]
+
+/-- **Symmetry of the reflected convolution sum.** The original q-Vandermonde sum
+and its `k ↦ r−k` reflection are equal ring elements. -/
+theorem qVandermonde_reflect_sum_symm (q : R) (m n r : ℕ) :
+    (∑ k ∈ Finset.range (r + 1),
+        q ^ (k * (m + k - r)) * qBinom q m (r - k) * qBinom q n k) =
+      ∑ k ∈ Finset.range (r + 1),
+        q ^ ((r - k) * (m - k)) * qBinom q m k * qBinom q n (r - k) := by
+  rw [← qVandermonde q m n r]
+  exact qVandermonde_reflect q m n r
+
+end qVandermondeDual

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,134 @@
+{
+  "id": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+  "title": "Dual and Symmetric Forms of the q-Vandermonde Identity",
+  "slug": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+  "description": "Derives the dual (m↔n swap) and reflected-index (k↦r−k) forms of the q-Vandermonde convolution [m+n choose r]_q = ∑_{k=0}^{r} q^{k(m+k−r)} [m choose r−k]_q [n choose k]_q proved in the parent entry, and proves the two re-indexed convolution sums equal as ring elements. This exposes the hidden symmetry of the q-exponent k(m+k−r) ↔ k(n+k−r) and (r−k)(m−k): different-looking q-weighted sums that nonetheless both compute the same Gaussian binomial. All four results are corollaries of the parent's qVandermonde via add_comm on ℕ and Finset.sum_range_reflect; no new analytic input. 4 theorems, 0 axioms, 0 sorries.",
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient#q-Vandermonde_identity",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "q-analogs",
+      "gaussian-binomial",
+      "vandermonde",
+      "quantum-calculus",
+      "symmetry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "assumptions": "None. Axiom-free and sorry-free (depends only on propext, Classical.choice, Quot.sound — the standard Lean foundations).",
+    "lineCount": 106,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "qVandermonde_swap: dual form [m+n choose r]_q = ∑_{k=0}^{r} q^{k(n+k−r)} [n choose r−k]_q [m choose k]_q, obtained by the m↔n involution (q-exponent k(m+k−r) ↦ k(n+k−r))",
+      "qVandermonde_sum_symm: the original and m↔n-swapped convolution sums are equal ring elements (both equal [m+n choose r]_q) — the precise statement that the q-exponent symmetry is a genuine identity",
+      "qVandermonde_reflect: reflected-index form [m+n choose r]_q = ∑_{k=0}^{r} q^{(r−k)(m−k)} [m choose k]_q [n choose r−k]_q, obtained by the k↦r−k involution on the summation range via Finset.sum_range_reflect",
+      "qVandermonde_reflect_sum_symm: the original and k↦r−k-reflected convolution sums are equal ring elements"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Gauss q-Vandermonde identity (parent entry arithmetic-series-oq-02-oq-01-oq-01) generalizes the classical Vandermonde convolution to Gaussian binomial coefficients. A single algebraic form hides the symmetry that the Gaussian binomial enjoys under exchanging its two summand factors and under reflecting the summation index. This entry, answering open question 3 of the parent, makes both involutions explicit and verifies the resulting dual / reflected identities are equivalent within Lean. The phenomenon is the q-analog of the elementary fact that the classical Vandermonde sum ∑_k C(m,k)C(n,r−k) is manifestly symmetric in m and n and under k↦r−k; in the q-deformed setting the symmetry is no longer manifest because the q-exponent k(m+k−r) is not symmetric on its face.",
+    "problemStatement": "Derive the dual/symmetric forms of the q-Vandermonde identity (swapping the roles of m and n, or reflecting r ↦ m+n−r / k ↦ r−k) and verify they are equivalent within Lean, exposing the hidden symmetry of the q-exponent q^{k(m+k−r)}.",
+    "text": "The parent proves [m+n choose r]_q = S(m,n,r) where S(m,n,r) = ∑_{k=0}^{r} q^{k(m+k−r)} [m choose r−k]_q [n choose k]_q. Because the binomial argument m+n is symmetric in m and n, evaluating the parent identity at the swapped arguments (n,m,r) yields the same left-hand side, hence S(m,n,r) = S(n,m,r): the m↔n-swapped sum — whose q-exponent is k(n+k−r) and whose binomial factors are exchanged — equals the original. Independently, reflecting the summation index k ↦ r−k (an involution on the range {0,…,r}) re-expresses S(m,n,r) with the q-exponent in the dual shape (r−k)(m−k) and the binomial factors index-reflected. Both re-indexings produce identities whose q-weighted summands look different term by term yet sum to the same Gaussian binomial.",
+    "proofStrategy": "Each result is a short corollary of the parent's qVandermonde. (1) qVandermonde_swap rewrites m+n = n+m (Nat.add_comm) and applies qVandermonde at (n,m,r). (2) qVandermonde_sum_symm chains qVandermonde and qVandermonde_swap through the common value [m+n choose r]_q. (3) qVandermonde_reflect rewrites the parent sum by Finset.sum_range_reflect (the involution k ↦ (r+1)−1−k = r−k on Finset.range (r+1)) and simplifies the resulting ℕ subtractions r−(r−k)=k and m+(r−k)−r=m−k (omega) for indices k ≤ r. (4) qVandermonde_reflect_sum_symm chains qVandermonde and qVandermonde_reflect.",
+    "keyInsights": [
+      "The m↔n symmetry of the q-Vandermonde sum is forced purely by the symmetry of the binomial argument m+n; no property of the q-binomial beyond the parent identity is needed, so qVandermonde_swap is a one-line rewrite.",
+      "The non-trivial content is qVandermonde_sum_symm / qVandermonde_reflect_sum_symm: two q-weighted sums with structurally different exponents (k(m+k−r) vs k(n+k−r), and k(m+k−r) vs (r−k)(m−k)) are equal as ring elements. The equality is invisible term by term and only emerges through the shared closed value [m+n choose r]_q.",
+      "Finset.sum_range_reflect supplies the k↦r−k involution cleanly; the only care needed is the truncated ℕ subtraction, where for in-range indices k ≤ r one has r−(r−k)=k and m+(r−k)−r=m−k, both discharged by omega.",
+      "These corollary forms are deliberately lightweight: they add no new spectral or analytic machinery, only re-index the established convolution. Their value is conceptual — pinning down, as machine-checked statements, the two involutive symmetries that the single algebraic form of the q-Vandermonde identity obscures."
+    ],
+    "prerequisites": [
+      "q-Vandermonde identity: arithmetic-series-oq-02-oq-01-oq-01 (qVandermonde)",
+      "q-binomial coefficients: arithmetic-series-oq-02-oq-01 (qBinom, q-Pascal rule)",
+      "Finset.sum_range_reflect (reflection involution on a finite range)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The q-Vandermonde convolution is recast under the two involutions m↔n and k↦r−k, and the resulting dual / reflected sums are proved equal to the original as ring elements. Four theorems, all corollaries of the parent qVandermonde via Nat.add_comm and Finset.sum_range_reflect. Fully verified: 0 axioms, 0 sorries.",
+    "implications": "Records, as machine-checked identities, the hidden symmetry of the q-exponent k(m+k−r): different-looking q-weighted convolution sums compute the same Gaussian binomial. This is the symmetry that becomes manifest at q=1 (classical Vandermonde) but is obscured by the q-deformation, and it underlies the standard combinatorial (subspace-counting) interpretation where exchanging the two factor spaces or complementing the chosen dimension leaves the count invariant.",
+    "openQuestions": [
+      "Prove the reflection symmetry of the Gaussian binomial itself, [n choose k]_q = [n choose n−k]_q (the 'second q-Pascal recursion'), and use it to derive the full r ↦ m+n−r reflected form of the q-Vandermonde identity as a fifth equivalent shape.",
+      "Combine the two involutions (m↔n then k↦r−k) to exhibit the dihedral symmetry group acting on the family of equivalent q-Vandermonde sums, and identify the orbit structure of the q-exponent."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ArithmeticSeriesOQ02OQ01OQ01"
+    ],
+    "opens": [
+      "GaussianBinomial",
+      "qVandermondeProof",
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "qVandermondeDual",
+    "lineCount": 106,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the q-Vandermonde Identity, from which all four dual/reflected forms are derived"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Grandparent: q-Pascal rule and qBinom (Gaussian binomial) infrastructure"
+    },
+    {
+      "targetId": "binomial-theorem-oq-04",
+      "relationship": "related",
+      "description": "Classical Vandermonde Identity: the q=1 specialization where the m↔n and k↦r−k symmetries are manifest"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Symmetry Overview",
+      "startLine": 4,
+      "endLine": 49,
+      "summary": "Documents the two involutions (m↔n swap and k↦r−k reflection), the four results, and that all are corollaries of the parent qVandermonde via add_comm and Finset.sum_range_reflect."
+    },
+    {
+      "id": "sec-swap",
+      "title": "Dual Form (m↔n Swap)",
+      "startLine": 60,
+      "endLine": 69,
+      "summary": "qVandermonde_swap: rewriting m+n = n+m and applying qVandermonde at (n,m,r) yields the swapped convolution with q-exponent k(n+k−r) and exchanged binomial factors."
+    },
+    {
+      "id": "sec-sum-symm",
+      "title": "Symmetry of the Convolution Sum",
+      "startLine": 71,
+      "endLine": 80,
+      "summary": "qVandermonde_sum_symm: the original and m↔n-swapped sums are equal ring elements, both equal to [m+n choose r]_q — the precise statement of the q-exponent symmetry k(m+k−r) ↔ k(n+k−r)."
+    },
+    {
+      "id": "sec-reflect",
+      "title": "Reflected-Index Form (k↦r−k)",
+      "startLine": 82,
+      "endLine": 96,
+      "summary": "qVandermonde_reflect: applying Finset.sum_range_reflect to the parent sum, then simplifying the ℕ subtractions r−(r−k)=k and m+(r−k)−r=m−k (omega), gives the dual-shape q-exponent (r−k)(m−k)."
+    },
+    {
+      "id": "sec-reflect-sum-symm",
+      "title": "Symmetry of the Reflected Sum",
+      "startLine": 98,
+      "endLine": 105,
+      "summary": "qVandermonde_reflect_sum_symm: the original and k↦r−k-reflected sums are equal ring elements via the shared value [m+n choose r]_q."
+    }
+  ]
+}

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01-oq-03.json
@@ -1,0 +1,449 @@
+{
+  "slug": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+  "title": "Dual and Symmetric Forms of the q-Vandermonde Identity",
+  "problemStatement": {
+    "formal": "qVandermonde_swap : qBinom q (m+n) r = ∑ k ∈ Finset.range (r+1), q ^ (k * (n + k - r)) * qBinom q n (r - k) * qBinom q m k ; and qVandermonde_sum_symm / qVandermonde_reflect / qVandermonde_reflect_sum_symm establishing equality of the re-indexed convolution sums.",
+    "plain": "Derive the dual/symmetric forms of the q-Vandermonde identity (swap m↔n, reflect k↦r−k) and prove they are equivalent within Lean, exposing the hidden symmetry of the q-exponent q^{k(m+k−r)}.",
+    "whyMatters": [
+      "Pins down, as machine-checked statements, the two involutive symmetries (m↔n and k↦r−k) that the single algebraic form of the q-Vandermonde identity obscures",
+      "The q-deformation hides the symmetry that is manifest at q=1 (classical Vandermonde); the equality of structurally different q-weighted sums is the precise content recovered",
+      "Underlies the subspace-counting interpretation: exchanging the two factor spaces or complementing the chosen dimension leaves the F_q-subspace count invariant"
+    ]
+  },
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 5,
+  "started": "2026-06-24T00:00:00-07:00",
+  "path": "full",
+  "tags": [
+    "combinatorics",
+    "q-analogs",
+    "gaussian-binomial",
+    "vandermonde",
+    "quantum-calculus",
+    "symmetry"
+  ],
+  "references": {
+    "papers": [
+      "V. Kac, P. Cheung, 'Quantum Calculus' (Springer, 2002), Chapter 10"
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient#q-Vandermonde_identity"
+    ],
+    "mathlib": [
+      "Finset.sum_range_reflect (reflection involution on a finite range)",
+      "qVandermondeProof.qVandermonde from ArithmeticSeriesOQ02OQ01OQ01.lean"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "qVandermonde_swap: dual form via Nat.add_comm + parent qVandermonde at (n,m,r)",
+      "qVandermonde_sum_symm: original and m↔n-swapped sums equal as ring elements (shared value [m+n choose r]_q)",
+      "qVandermonde_reflect: reflected-index form via Finset.sum_range_reflect + omega simplification of ℕ subtractions (r−(r−k)=k, m+(r−k)−r=m−k for k≤r)",
+      "qVandermonde_reflect_sum_symm: original and k↦r−k-reflected sums equal as ring elements"
+    ],
+    "open": [
+      "Reflection symmetry of the Gaussian binomial itself, [n choose k]_q = [n choose n−k]_q (the 'second q-Pascal recursion'), which would unlock the full r↦m+n−r reflected form"
+    ],
+    "goal": "Dual/symmetric forms derived and proved equivalent; the r↦m+n−r form additionally requires qBinom reflection symmetry (deferred)."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Four dual/reflected forms verified, 0 sorries, 0 axioms",
+    "blockers": [],
+    "nextAction": "Optional: prove qBinom_symm ([n choose k]_q = [n choose n−k]_q) to add the r↦m+n−r reflected form as a fifth equivalent shape.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: dual (m↔n) and reflected-index (k↦r−k) forms of q-Vandermonde derived and proved equivalent; 0 axioms, 0 sorries.",
+    "insights": [
+      "The m↔n symmetry of the q-Vandermonde sum is forced purely by the symmetry of the binomial argument m+n; qVandermonde_swap is a one-line rewrite needing no q-binomial property beyond the parent identity.",
+      "The substantive content is the sum-equivalence theorems: two q-weighted sums with structurally different exponents (k(m+k−r) vs k(n+k−r), and k(m+k−r) vs (r−k)(m−k)) are equal as ring elements — invisible term by term, emerging only through the shared closed value [m+n choose r]_q.",
+      "Finset.sum_range_reflect cleanly supplies the k↦r−k involution; the only care is truncated ℕ subtraction, where for in-range indices k≤r one has r−(r−k)=k and m+(r−k)−r=m−k (omega).",
+      "The full r↦m+n−r reflection (rather than the k↦r−k index reflection) requires the Gaussian-binomial reflection symmetry [n choose k]_q = [n choose n−k]_q, which is NOT a corollary of the single q-Pascal recursion (rule A) used to define qBinom — it needs the alternate recursion (rule B) and an intertwined induction, deferred as a follow-up."
+    ],
+    "builtItems": [
+      "qVandermonde_swap in Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean:60",
+      "qVandermonde_sum_symm in Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean:71",
+      "qVandermonde_reflect in Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean:82",
+      "qVandermonde_reflect_sum_symm in Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean:98"
+    ],
+    "mathlibGaps": [
+      "This file's qBinom (parent's own definition) has no reflection-symmetry lemma; Mathlib's own Gaussian binomial API is not used by the parent chain, so qBinom_symm must be proved in-house if the r↦m+n−r form is wanted."
+    ],
+    "nextSteps": [
+      "Prove qBinom_symm: [n choose k]_q = [n choose n−k]_q via the second q-Pascal recursion, then derive the r↦m+n−r reflected q-Vandermonde form.",
+      "Compose the m↔n and k↦r−k involutions to exhibit the dihedral symmetry group on the family of equivalent q-Vandermonde sums."
+    ],
+    "markdown": "## Session 2026-06-24 (Session 1) - Dual/symmetric q-Vandermonde forms\n\n**Mode**: FRESH\n**Outcome**: completed\n\n### What I Did\n- Derived the dual (m↔n swap) and reflected-index (k↦r−k) forms of the parent q-Vandermonde convolution.\n- Proved both re-indexed convolution sums equal the original as ring elements (qVandermonde_sum_symm, qVandermonde_reflect_sum_symm).\n- All four results are corollaries of the parent qVandermonde via Nat.add_comm and Finset.sum_range_reflect.\n\n### Key Findings\n- m↔n symmetry is forced by symmetry of m+n; the sum-equivalence is the real content (term-by-term invisible).\n- k↦r−k reflection via Finset.sum_range_reflect; truncated ℕ subtraction handled by omega for in-range k≤r.\n- The full r↦m+n−r reflection needs Gaussian-binomial reflection symmetry [n choose k]_q=[n choose n−k]_q, which requires the alternate q-Pascal recursion (not a corollary of rule A) — deferred.\n\n### Files Modified\n- proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean (new, 106 lines, 4 theorems, 0 sorries, 0 axioms)\n- src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/meta.json (new)\n\n### Next Steps\n- Prove qBinom_symm to unlock the r↦m+n−r form."
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/ArithmeticSeries.lean",
+      "filename": "ArithmeticSeries.lean",
+      "lineCount": 181,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeries.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ00.lean",
+      "filename": "ArithmeticSeriesOQ00.lean",
+      "lineCount": 161,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
+      "filename": "ArithmeticSeriesOQ00OQ01.lean",
+      "lineCount": 283,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ00OQ02.lean",
+      "filename": "ArithmeticSeriesOQ00OQ02.lean",
+      "lineCount": 121,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ00OQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ00OQ02OQ01.lean",
+      "lineCount": 140,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ00OQ02OQ02.lean",
+      "filename": "ArithmeticSeriesOQ00OQ02OQ02.lean",
+      "lineCount": 135,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ00OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02.lean",
+      "filename": "ArithmeticSeriesOQ02.lean",
+      "lineCount": 210,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01.lean",
+      "lineCount": 174,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 218,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01OQ03.lean",
+      "lineCount": 107,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02.lean",
+      "lineCount": 155,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ01.lean",
+      "lineCount": 166,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ02.lean",
+      "lineCount": 103,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03.lean",
+      "lineCount": 208,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 508,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ02.lean",
+      "lineCount": 244,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ03.lean",
+      "lineCount": 164,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean",
+      "filename": "ArithmeticSeriesOQ02OQ03Aristotle.lean",
+      "lineCount": 40,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04.lean",
+      "lineCount": 157,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01.lean",
+      "lineCount": 170,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ01.lean",
+      "lineCount": 150,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean",
+      "lineCount": 221,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean",
+      "lineCount": 119,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean",
+      "lineCount": 564,
+      "theoremCount": 21,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04OQ01.lean",
+      "filename": "ArithmeticSeriesOQ04OQ01.lean",
+      "lineCount": 306,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04OQ02.lean",
+      "filename": "ArithmeticSeriesOQ04OQ02.lean",
+      "lineCount": 164,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04OQ03.lean",
+      "filename": "ArithmeticSeriesOQ04OQ03.lean",
+      "lineCount": 216,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04OQ03.lean"
+    }
+  ],
+  "relatedProofs": [
+    "arithmetic-series",
+    "arithmetic-series-oq-00",
+    "arithmetic-series-oq-00-oq-02",
+    "arithmetic-series-oq-00-oq-02-oq-01",
+    "arithmetic-series-oq-00-oq-02-oq-02",
+    "arithmetic-series-oq-02",
+    "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "arithmetic-series-oq-02-oq-02",
+    "arithmetic-series-oq-02-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-02-oq-02",
+    "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-02",
+    "arithmetic-series-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "arithmetic-series-oq-04",
+    "arithmetic-series-oq-04-oq-01",
+    "arithmetic-series-oq-04-oq-02",
+    "arithmetic-series-oq-04-oq-03"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **open question 3** of the q-Vandermonde parent entry (`arithmetic-series-oq-02-oq-01-oq-01`):

> *Derive the dual/symmetric forms of the identity (swapping m↔n, or reflecting r↦m+n−r) and verify they are equivalent within Lean, exposing the hidden symmetry of the q-exponent q^{k(m+k−r)}.*

The parent proves `[m+n choose r]_q = ∑_{k=0}^{r} q^{k(m+k−r)} [m choose r−k]_q [n choose k]_q`. A single algebraic form hides the two involutive symmetries the Gaussian binomial convolution enjoys. This entry makes both explicit and proves the re-indexed sums equal.

## Results (4 theorems, 0 axioms, 0 sorries)

All corollaries of the parent's `qVandermonde` via `Nat.add_comm` and `Finset.sum_range_reflect`:

| Theorem | Content |
|---------|---------|
| `qVandermonde_swap` | Dual form under the `m↔n` involution (q-exponent `k(m+k−r) ↦ k(n+k−r)`) |
| `qVandermonde_sum_symm` | Original and `m↔n`-swapped sums equal as ring elements |
| `qVandermonde_reflect` | Reflected-index form under `k ↦ r−k` (q-exponent in dual shape `(r−k)(m−k)`) |
| `qVandermonde_reflect_sum_symm` | Original and `k↦r−k`-reflected sums equal as ring elements |

The substantive content is the **sum-equivalence** theorems: two q-weighted sums whose exponents differ structurally (`k(m+k−r)` vs `k(n+k−r)`, and `k(m+k−r)` vs `(r−k)(m−k)`) are equal despite being term-by-term distinct — the equality emerges only through the shared closed value `[m+n choose r]_q`. This is the q-analog symmetry that becomes manifest at q=1 (classical Vandermonde) but is obscured by the q-deformation.

## Verification

- Compiles against Mathlib (Lean v4.26.0); `#print axioms` on all four shows only `[propext, Classical.choice, Quot.sound]` — genuinely **0-axiom, 0-sorry**.
- New file: `proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01OQ03.lean` (106 lines).
- Gallery: `src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/meta.json` + research problem json.

## Honest scope

These are lightweight corollary forms — they add no new analytic machinery, only re-index the established convolution. Their value is conceptual: pinning down, as machine-checked statements, the two involutive symmetries that the single algebraic form obscures. The full `r ↦ m+n−r` reflection is deferred (it needs the Gaussian-binomial reflection symmetry `[n choose k]_q = [n choose n−k]_q`, which is not a corollary of the single q-Pascal recursion used to define `qBinom`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)