### PR TITLE
research(erdos-633): Heron area degree-2 homogeneity + discharge 3 area-model sorries (8→5); repair Mathlib drift

### DIFF
--- a/proofs/Proofs/Erdos633Problem.lean
+++ b/proofs/Proofs/Erdos633Problem.lean
@@ -64,9 +64,62 @@ noncomputable def Triangle.area (T : Triangle) : ℝ :=
   let s := (T.a + T.b + T.c) / 2
   Real.sqrt (s * (s - T.a) * (s - T.b) * (s - T.c))
 
-/-! ## Dissection Definitions -/
+/-- Scaling all side lengths of a triangle by a positive factor `t`.
+    The result is a triangle similar to `T` with linear scale `t`. -/
+noncomputable def Triangle.scale (T : Triangle) (t : ℝ) (ht : 0 < t) : Triangle where
+  a := t * T.a
+  b := t * T.b
+  c := t * T.c
+  ha := mul_pos ht T.ha
+  hb := mul_pos ht T.hb
+  hc := mul_pos ht T.hc
+  hab := by
+    have h := mul_lt_mul_of_pos_left T.hab ht
+    rw [mul_add] at h; linarith
+  hbc := by
+    have h := mul_lt_mul_of_pos_left T.hbc ht
+    rw [mul_add] at h; linarith
+  hca := by
+    have h := mul_lt_mul_of_pos_left T.hca ht
+    rw [mul_add] at h; linarith
 
-/-- A dissection of triangle T into n congruent copies of triangle S -/
+/-- **Heron's area is homogeneous of degree 2 in the side lengths.**
+    Scaling a triangle's sides by `t > 0` scales its area by `t²`.
+
+    This is the genuine geometric fact underlying Erdős #633's background result
+    that "every triangle dissects into `n²` congruent copies": a copy similar to
+    `T` with linear scale `1/n` has area `T.area / n²`, so `n²` of them match `T`'s
+    area exactly. The proof factors `(t²)²` out of all four Heron factors and pulls
+    it through the square root. -/
+theorem Triangle.area_scale (T : Triangle) (t : ℝ) (ht : 0 < t) :
+    (T.scale t ht).area = t ^ 2 * T.area := by
+  have ht2 : (0:ℝ) ≤ t ^ 2 := le_of_lt (pow_pos ht 2)
+  simp only [Triangle.area, Triangle.scale]
+  rw [← Real.sqrt_sq ht2, ← Real.sqrt_mul (sq_nonneg (t ^ 2))]
+  congr 1
+  ring
+
+/-! ## Dissection Definitions
+
+  NOTE ON THE MODEL: `CongruentDissection` below captures only the two
+  *necessary* numeric conditions for a congruent dissection — area
+  compatibility (`area T = n · area S`) and shared side ratios (`S` similar to
+  `T`). It does NOT encode an actual geometric tiling. As a consequence this
+  simplified model OVER-counts: by `Triangle.area_scale`, the scaled copy
+  `T.scale (1/√n)` satisfies both conditions for *every* `n ≥ 1`, so in this
+  model `DissectionCounts T = {n | n ≥ 1}` for all `T`.
+
+  The theorems proved against this model (`universal_square_dissection`,
+  `equilateral_dissects_to_3`, `right_isoceles_dissects_to_2`) are therefore
+  genuine *area-compatibility* statements, not full geometric dissection
+  results. The square-only theorems (`soifer_square_only`,
+  `soifer_family_square_only`, …) are FALSE in this over-counting model and
+  remain `sorry`: capturing them faithfully requires a real geometric
+  dissection predicate (the open, hard content of Erdős #633). -/
+
+/-- A dissection of triangle T into n congruent copies of triangle S.
+    (Simplified model: area compatibility + similarity only — see the note
+    above; this is a necessary condition for, not a witness of, a tiling.) -/
 structure CongruentDissection (T S : Triangle) (n : ℕ) where
   -- The n copies tile T exactly
   covers : T.area = n * S.area
@@ -97,10 +150,27 @@ def SquareOnlyTriangles : Set Triangle :=
 
 /-! ## Universal Dissection into Squares -/
 
-/-- Every triangle can be dissected into n² congruent triangles for any n ≥ 1 -/
+/-- Every triangle can be dissected into n² congruent triangles for any n ≥ 1.
+
+    Witnessed by the similar copy `S = T.scale (1/n)`: by area-homogeneity
+    (`Triangle.area_scale`) it has area `T.area / n²`, so `n²` copies of `S`
+    match `T`'s area, and `S` shares `T`'s side ratios. This is the
+    area-compatibility ("necessary condition") form of the classical grid
+    construction, in the simplified dissection model used in this file. -/
 theorem universal_square_dissection (T : Triangle) (n : ℕ) (hn : n ≥ 1) :
     CanDissectInto T (n^2) := by
-  sorry
+  have hn0 : (0:ℝ) < (n:ℝ) := by exact_mod_cast (show 0 < n by omega)
+  have hne : (n:ℝ) ≠ 0 := ne_of_gt hn0
+  refine ⟨T.scale (1 / (n:ℝ)) (one_div_pos.mpr hn0), ⟨⟨?_, ?_, ?_⟩⟩⟩
+  · rw [Triangle.area_scale]
+    push_cast
+    rw [div_pow, one_pow, ← mul_assoc, mul_one_div, div_self (pow_ne_zero 2 hne), one_mul]
+  · simp only [Triangle.scale]
+    rw [mul_div_assoc, div_self (ne_of_gt T.ha), mul_one,
+        mul_div_assoc, div_self (ne_of_gt T.hb), mul_one]
+  · simp only [Triangle.scale]
+    rw [mul_div_assoc, div_self (ne_of_gt T.hb), mul_one,
+        mul_div_assoc, div_self (ne_of_gt T.hc), mul_one]
 
 /-- This means every triangle has all square numbers in its dissection set -/
 theorem squares_always_achievable (T : Triangle) :
@@ -168,15 +238,61 @@ theorem integral_independence_implies_square_only (T : TriangleByAngles)
 def HasNonSquareDissection (T : Triangle) : Prop :=
   ∃ n : ℕ, n ∈ DissectionCounts T ∧ ¬IsSquare n
 
-/-- Equilateral triangles can be dissected into 3 congruent triangles -/
+/-- The unit equilateral triangle (all sides 1). -/
+noncomputable def unitEquilateral : Triangle :=
+  ⟨1, 1, 1, one_pos, one_pos, one_pos, by norm_num, by norm_num, by norm_num⟩
+
+/-- The unit right isosceles triangle (legs 1, hypotenuse √2). -/
+noncomputable def unitRightIso : Triangle :=
+  ⟨1, 1, Real.sqrt 2, one_pos, one_pos, Real.sqrt_pos.mpr (by norm_num),
+    by nlinarith [Real.sq_sqrt (show (0:ℝ) ≤ 2 by norm_num),
+                  Real.sqrt_nonneg 2, sq_nonneg (Real.sqrt 2 - 2)],
+    by linarith [Real.sqrt_pos.mpr (show (0:ℝ) < 2 by norm_num)],
+    by linarith [Real.sqrt_pos.mpr (show (0:ℝ) < 2 by norm_num)]⟩
+
+/-- Equilateral triangles can be dissected into 3 congruent triangles.
+
+    In the area-compatibility model: the similar copy `scale (1/√3)` has area
+    `area/3`, so 3 copies match — a *non-square* count, witnessing that the
+    equilateral triangle does NOT have the square-only property. -/
 theorem equilateral_dissects_to_3 : ∃ T : Triangle,
     T.a = T.b ∧ T.b = T.c ∧ 3 ∈ DissectionCounts T := by
-  sorry
+  refine ⟨unitEquilateral, rfl, rfl, ?_⟩
+  simp only [DissectionCounts, Set.mem_setOf_eq]
+  refine ⟨by norm_num, ?_⟩
+  have h3 : (0:ℝ) < Real.sqrt 3 := Real.sqrt_pos.mpr (by norm_num)
+  refine ⟨unitEquilateral.scale (1 / Real.sqrt 3) (one_div_pos.mpr h3), ⟨⟨?_, ?_, ?_⟩⟩⟩
+  · rw [Triangle.area_scale, div_pow, one_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 3)]
+    push_cast; ring
+  · simp only [Triangle.scale]
+    rw [mul_div_assoc, div_self (ne_of_gt unitEquilateral.ha), mul_one,
+        mul_div_assoc, div_self (ne_of_gt unitEquilateral.hb), mul_one]
+  · simp only [Triangle.scale]
+    rw [mul_div_assoc, div_self (ne_of_gt unitEquilateral.hb), mul_one,
+        mul_div_assoc, div_self (ne_of_gt unitEquilateral.hc), mul_one]
 
-/-- Right isoceles triangles can be dissected into 2 congruent triangles -/
+/-- Right isoceles triangles can be dissected into 2 congruent triangles.
+
+    In the area-compatibility model: the similar copy `scale (1/√2)` has area
+    `area/2`, so 2 copies match — a *non-square* count, witnessing that the
+    right isosceles triangle does NOT have the square-only property. -/
 theorem right_isoceles_dissects_to_2 : ∃ T : Triangle,
     T.a = T.b ∧ T.c = T.a * Real.sqrt 2 ∧ 2 ∈ DissectionCounts T := by
-  sorry
+  refine ⟨unitRightIso, rfl, ?_, ?_⟩
+  · show Real.sqrt 2 = (1:ℝ) * Real.sqrt 2
+    rw [one_mul]
+  · simp only [DissectionCounts, Set.mem_setOf_eq]
+    refine ⟨by norm_num, ?_⟩
+    have h2 : (0:ℝ) < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+    refine ⟨unitRightIso.scale (1 / Real.sqrt 2) (one_div_pos.mpr h2), ⟨⟨?_, ?_, ?_⟩⟩⟩
+    · rw [Triangle.area_scale, div_pow, one_pow, Real.sq_sqrt (by norm_num : (0:ℝ) ≤ 2)]
+      push_cast; ring
+    · simp only [Triangle.scale]
+      rw [mul_div_assoc, div_self (ne_of_gt unitRightIso.ha), mul_one,
+          mul_div_assoc, div_self (ne_of_gt unitRightIso.hb), mul_one]
+    · simp only [Triangle.scale]
+      rw [mul_div_assoc, div_self (ne_of_gt unitRightIso.hb), mul_one,
+          mul_div_assoc, div_self (ne_of_gt unitRightIso.hc), mul_one]
 
 /-! ## Similar vs Congruent Dissections -/
 

--- a/proofs/Proofs/Erdos633Problem.lean
+++ b/proofs/Proofs/Erdos633Problem.lean
@@ -136,13 +136,15 @@ def DissectionCounts (T : Triangle) : Set ℕ :=
 
 /-! ## Square Number Property -/
 
-/-- A number is a perfect square -/
-def IsSquare (n : ℕ) : Prop := ∃ k : ℕ, n = k^2
+/-- A number is a perfect square.
+    (Named `IsPerfectSquare` to avoid clashing with Mathlib's `IsSquare`,
+    which was introduced into the root namespace after this file was written.) -/
+def IsPerfectSquare (n : ℕ) : Prop := ∃ k : ℕ, n = k^2
 
 /-- A triangle has the "square-only" property if it can only be dissected
     into square numbers of congruent copies -/
 def HasSquareOnlyProperty (T : Triangle) : Prop :=
-  ∀ n ∈ DissectionCounts T, IsSquare n
+  ∀ n ∈ DissectionCounts T, IsPerfectSquare n
 
 /-- The set of triangles with the square-only property -/
 def SquareOnlyTriangles : Set Triangle :=
@@ -177,7 +179,7 @@ theorem squares_always_achievable (T : Triangle) :
     ∀ k ≥ 1, k^2 ∈ DissectionCounts T := by
   intro k hk
   constructor
-  · positivity
+  · exact Nat.one_le_pow 2 k (by omega)
   · exact universal_square_dissection T k hk
 
 /-! ## Soifer's Example -/
@@ -191,26 +193,22 @@ noncomputable def soiferTriangle : Triangle where
   hb := Real.sqrt_pos.mpr (by norm_num : (3 : ℝ) > 0)
   hc := Real.sqrt_pos.mpr (by norm_num : (4 : ℝ) > 0)
   hab := by
-    simp only [Real.sqrt_four]
+    rw [show (4:ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0:ℝ) ≤ 2)]
     have h1 : Real.sqrt 2 > 1 := by
-      rw [Real.one_lt_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
-      norm_num
+      nlinarith [Real.sq_sqrt (show (0:ℝ) ≤ 2 by norm_num), Real.sqrt_nonneg 2]
     have h2 : Real.sqrt 3 > 1 := by
-      rw [Real.one_lt_sqrt (by norm_num : (0 : ℝ) ≤ 3)]
-      norm_num
+      nlinarith [Real.sq_sqrt (show (0:ℝ) ≤ 3 by norm_num), Real.sqrt_nonneg 3]
     linarith
   hbc := by
-    simp only [Real.sqrt_four]
+    rw [show (4:ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0:ℝ) ≤ 2)]
     have h : Real.sqrt 2 < 2 := by
-      rw [Real.sqrt_lt' (by norm_num : (2 : ℝ) ≥ 0)]
-      norm_num
+      nlinarith [Real.sq_sqrt (show (0:ℝ) ≤ 2 by norm_num), Real.sqrt_nonneg 2]
     have h3 : Real.sqrt 3 > 0 := Real.sqrt_pos.mpr (by norm_num : (3 : ℝ) > 0)
     linarith
   hca := by
-    simp only [Real.sqrt_four]
+    rw [show (4:ℝ) = 2 ^ 2 by norm_num, Real.sqrt_sq (by norm_num : (0:ℝ) ≤ 2)]
     have h3 : Real.sqrt 3 < 2 := by
-      rw [Real.sqrt_lt' (by norm_num : (2 : ℝ) ≥ 0)]
-      norm_num
+      nlinarith [Real.sq_sqrt (show (0:ℝ) ≤ 3 by norm_num), Real.sqrt_nonneg 3]
     have h2 : Real.sqrt 2 > 0 := Real.sqrt_pos.mpr (by norm_num : (2 : ℝ) > 0)
     linarith
 
@@ -236,7 +234,7 @@ theorem integral_independence_implies_square_only (T : TriangleByAngles)
 
 /-- Most triangles can be dissected into non-square numbers -/
 def HasNonSquareDissection (T : Triangle) : Prop :=
-  ∃ n : ℕ, n ∈ DissectionCounts T ∧ ¬IsSquare n
+  ∃ n : ℕ, n ∈ DissectionCounts T ∧ ¬IsPerfectSquare n
 
 /-- The unit equilateral triangle (all sides 1). -/
 noncomputable def unitEquilateral : Triangle :=

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -18,7 +18,7 @@
       "tiling-theory"
     ],
     "badge": "wip",
-    "sorries": 8,
+    "sorries": 5,
     "erdosNumber": 633,
     "erdosUrl": "https://erdosproblems.com/633",
     "erdosProblemStatus": "open",
@@ -43,20 +43,22 @@
       "CongruentDissection structure with area compatibility and tiling",
       "CanDissectInto and DissectionCounts predicates",
       "HasSquareOnlyProperty definition (square-only dissection counts)",
-      "universal_square_dissection: n² always works",
+      "Triangle.area_scale: Heron's area is homogeneous of degree 2 in the side lengths (scaling sides by t scales area by t²) — fully verified, 0 sorries",
+      "Triangle.scale: positive scaling of a triangle's side lengths",
+      "universal_square_dissection: n² always works (now PROVED via area_scale in the area-compatibility model)",
+      "equilateral_dissects_to_3 and right_isoceles_dissects_to_2 (now PROVED via area_scale)",
       "soiferTriangle construction with (√2, √3, √4) sides",
       "IntegrallyIndependent definition for angle triples",
-      "Counterexamples: equilateral (3 pieces), right isosceles (2 pieces)",
       "similar_dissection_complete: characterization for similar case",
       "erdos_633_classification: formal statement of the open problem",
       "SoiferFamily generalization to (√p, √q, √r) triangles"
     ],
     "axiomCount": 0,
-    "lineCount": 236,
-    "assumptions": "0 axiom(s) and 8 sorry(s). See the Lean source for details.",
+    "lineCount": 350,
+    "assumptions": "0 axiom(s) and 5 sorry(s). The 3 area-compatibility theorems (universal_square_dissection, equilateral_dissects_to_3, right_isoceles_dissects_to_2) and the homogeneity lemma Triangle.area_scale are fully verified. The 5 remaining sorries are the genuinely open/hard geometric content of Erdős #633 (soifer_square_only, integral_independence_implies_square_only, similar_dissection_characterization, exceptional_similar_cases, soifer_family_square_only), which cannot be captured by the file's simplified area+similarity dissection model. See the Lean source for details.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
-    "definitionCount": 15,
+    "theoremCount": 12,
+    "definitionCount": 18,
     "additionalFiles": [
       "Proofs/Erdos633Aristotle.lean"
     ]
@@ -65,7 +67,7 @@
     "historicalContext": "This problem concerns the geometry of triangle dissections — partitioning a triangle into congruent triangular pieces. Every triangle can be dissected into n² congruent copies by subdividing each side into n equal segments and connecting corresponding points, forming an n × n grid of congruent sub-triangles.\n\nThe question is: are there triangles where n² is the ONLY achievable dissection count? Alexander Soifer investigated this systematically in his book 'How Does One Cut a Triangle?' (2009). He showed that the triangle with sides √2, √3, √4 has this 'square-only' property — it cannot be dissected into any non-square number of congruent triangles. The key constraint comes from the irrational side lengths: any tiling must respect algebraic relationships between the sides, and the only way to achieve area compatibility with matching angles forces the count to be a perfect square.\n\nSoifer's analysis connects to the concept of 'integral independence' of angles: if the three angles α, β, γ of a triangle satisfy no non-trivial integer linear relation (beyond α + β + γ = π), then dissection constraints force square-only counts. Equilateral triangles (angles π/3, π/3, π/3 — integrally dependent via α = β = γ) can be dissected into 3 pieces, and right isosceles triangles (π/4, π/4, π/2 — integrally dependent via α = β, γ = 2α) can be dissected into 2 pieces.\n\nThe complete classification of square-only triangles remains OPEN with a $25 Erdős prize. The conjecture is that integral independence of angles is the precise characterization.",
     "problemStatement": "**Classification Problem (OPEN, $25 prize):**\n\nCharacterize all triangles T such that: if T can be dissected into n congruent triangles, then n must be a perfect square.\n\n**Known:**\n- Every triangle can be dissected into n² copies (for any n >= 1)\n- The triangle with sides √2, √3, √4 can ONLY be dissected into square counts\n- Triangles with 'integrally independent' angles have this property\n- Equilateral (3 pieces) and right isosceles (2 pieces) do NOT have this property\n\n**Unknown:**\n- Complete characterization of square-only triangles\n- Whether integral independence is necessary and sufficient",
     "text": "Which triangles can ONLY be cut into a perfect square number of congruent triangles? Classification remains OPEN with $25 prize.",
-    "proofStrategy": "The formalization proceeds in eight sections:\n\n1. **Triangle representations**: Triangle (by sides) and TriangleByAngles (by angles), with heronArea\n2. **Dissection definitions**: CongruentDissection, CanDissectInto, DissectionCounts\n3. **Square-only property**: IsSquare, HasSquareOnlyProperty\n4. **Universal result**: universal_square_dissection (n² always works)\n5. **Soifer's example**: soiferTriangle (√2, √3, √4), soifer_square_only\n6. **Integral independence**: IntegrallyIndependent, connection to angles\n7. **Counterexamples**: equilateral (3 pieces), right isosceles (2 pieces)\n8. **Open problem**: erdos_633_classification, SoiferFamily generalization",
+    "proofStrategy": "The formalization proceeds in eight sections:\n\n1. **Triangle representations**: Triangle (by sides) and TriangleByAngles (by angles), with heronArea\n2. **Dissection definitions**: CongruentDissection, CanDissectInto, DissectionCounts\n3. **Square-only property**: IsPerfectSquare, HasSquareOnlyProperty\n4. **Universal result**: universal_square_dissection (n² always works)\n5. **Soifer's example**: soiferTriangle (√2, √3, √4), soifer_square_only\n6. **Integral independence**: IntegrallyIndependent, connection to angles\n7. **Counterexamples**: equilateral (3 pieces), right isosceles (2 pieces)\n8. **Open problem**: erdos_633_classification, SoiferFamily generalization",
     "keyInsights": [
       "**Universal n² dissections**: Every triangle can be subdivided into n² congruent copies by grid construction — the question is whether NON-square counts are also achievable",
       "**Soifer's example**: The triangle (√2, √3, √4) can only be dissected into square counts — irrational side lengths severely constrain tiling possibilities",
@@ -111,7 +113,7 @@
       "title": "Square Number Property",
       "startLine": 84,
       "endLine": 97,
-      "summary": "Defines IsSquare n (n = k²), HasSquareOnlyProperty T (every achievable dissection count is a perfect square), and the set SquareOnlyTriangles of triangles with that property — the central object Erdős #633 asks to classify.",
+      "summary": "Defines IsPerfectSquare n (n = k²), HasSquareOnlyProperty T (every achievable dissection count is a perfect square), and the set SquareOnlyTriangles of triangles with that property — the central object Erdős #633 asks to classify.",
       "mathContext": "$\\mathrm{HasSquareOnlyProperty}(T) :\\Leftrightarrow \\forall n \\in \\mathrm{DissectionCounts}(T),\\ \\exists k,\\ n=k^2$. SquareOnlyTriangles is the subset of all such $T$; the open problem is to characterize it geometrically."
     },
     {
@@ -119,7 +121,7 @@
       "title": "Universal Dissection into Squares",
       "startLine": 98,
       "endLine": 112,
-      "summary": "universal_square_dissection (sorry): every triangle dissects into n² congruent copies for any n ≥ 1. squares_always_achievable (proved from it): every perfect square ≥ 1 lies in DissectionCounts T, so the square numbers are always achievable.",
+      "summary": "Triangle.scale and Triangle.area_scale (degree-2 homogeneity of Heron's area, fully verified) provide the engine. universal_square_dissection (now PROVED): every triangle dissects into n² congruent copies for any n ≥ 1, witnessed by the similar copy of linear scale 1/n. squares_always_achievable (proved from it): every perfect square ≥ 1 lies in DissectionCounts T.",
       "mathContext": "The $n \\times n$ scaling subdivision gives $k^2 \\in \\mathrm{DissectionCounts}(T)$ for all $k\\geq 1$ and every triangle $T$. Thus square counts are universal; the problem is whether any *non-square* count is also achievable."
     },
     {
@@ -143,7 +145,7 @@
       "title": "Non-Square Dissections for Generic Triangles",
       "startLine": 165,
       "endLine": 180,
-      "summary": "Defines HasNonSquareDissection (some achievable count is not a perfect square) and gives two existence witnesses (both sorry): equilateral triangles dissect into 3 copies, and right isosceles triangles (legs equal, hypotenuse = leg·√2) dissect into 2 copies.",
+      "summary": "Defines HasNonSquareDissection (some achievable count is not a perfect square) and gives two existence witnesses (both now PROVED via area_scale): equilateral triangles dissect into 3 copies, and right isosceles triangles (legs equal, hypotenuse = leg·√2) dissect into 2 copies — both non-square counts in the area-compatibility model.",
       "mathContext": "Generic triangles admit non-square counts: equilaterals give $3\\in\\mathrm{DissectionCounts}$, right isosceles give $2$. These are the obstructions that a square-only triangle must avoid."
     },
     {
@@ -210,11 +212,11 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 236,
+    "lineCount": 350,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 15,
-    "sorries": 8,
+    "theoremCount": 12,
+    "definitionCount": 18,
+    "sorries": 5,
     "path": "Proofs/Erdos633Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos633Aristotle.lean"
@@ -256,5 +258,5 @@
       "description": "Related Erdős problem sharing themes: dissection, geometry"
     }
   ],
-  "sorries": 8
+  "sorries": 5
 }


### PR DESCRIPTION
## Summary

Advances the **Erdős #633** gallery entry (square-number triangle dissections, OPEN, \$25 prize) and repairs pre-existing Mathlib drift that had silently broken the file.

### New verified content (0 sorries, 0 axioms beyond `propext`/`Classical.choice`/`Quot.sound`)
- **`Triangle.area_scale`** — *Heron's area is homogeneous of degree 2 in the side lengths*: scaling a triangle's sides by `t > 0` scales its area by `t²`. Proved by factoring `(t²)²` out of all four Heron factors and pulling it through `Real.sqrt`. This is the genuine geometric fact underlying the problem's background result that "every triangle dissects into `n²` congruent copies".
- **`Triangle.scale`** — positive scaling of a triangle.
- Used `area_scale` to **discharge 3 of the 8 sorries** (now fully proved, `#print axioms` clean):
  - `universal_square_dissection` (n² always works)
  - `equilateral_dissects_to_3`
  - `right_isoceles_dissects_to_2`

### Honesty / scope
These three are **area-compatibility** statements in the file's *simplified* dissection model (`CongruentDissection` encodes only area equality + similarity, not a real geometric tiling). I added a prominent **NOTE ON THE MODEL** documenting that this model over-counts (every `n` is achievable by scaling), so the *square-only* theorems (`soifer_square_only`, `soifer_family_square_only`, …) are **false in this model** and remain `sorry` — they are the genuinely open/hard content of #633 and require a faithful geometric dissection predicate. **No open-problem sorry was filled or overclaimed.**

### Mathlib drift repair (the entry no longer built against current Mathlib 4.26)
- `IsSquare` → `IsPerfectSquare` (Mathlib introduced a root-namespace `IsSquare` that clashed)
- `Real.sqrt_four` (removed) → `rw [show (4:ℝ) = 2^2, Real.sqrt_sq]`
- `Real.one_lt_sqrt` / `Real.sqrt_lt'` (removed / signature change) → robust `nlinarith` with `Real.sq_sqrt`
- `positivity` on a `≥ 1` goal → `Nat.one_le_pow`

### Status
- Sorries: **8 → 5**; theorems 11 → 12; defs 15 → 18; lines 236 → 350
- `status` stays `formalized` / badge `wip` (5 genuinely-open sorries remain); `axiomCount` 0
- Verified via `lake env lean` (Docker daemon was down): only the 5 expected `sorry` warnings, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)