### PR TITLE
research(pell-equation-oq-01-oq-04-oq-03): Pell norm as a MonoidHom; regulator as the minimal positive value [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/PellEquationOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/PellEquationOQ01OQ04OQ03.lean
@@ -1,0 +1,240 @@
+import Mathlib
+
+/-
+# Pell Equation OQ-01-OQ-04-OQ-03: the norm as a `MonoidHom`, and the regulator as a minimal positive value
+
+The grandparent `pell-equation-oq-01-oq-04` built the **Pell norm**
+`pellNorm d x y = x + y√d` and proved its multiplicativity
+(`pellNorm (a·b) = pellNorm a · pellNorm b`, Brahmagupta's identity) together with
+the additivity of the **regulator** `R(a) = log‖a‖` on Mathlib's group of Pell
+solutions `Pell.Solution₁ d`. The siblings `…-oq-01` / `…-oq-02` extended the
+scaling law `R(aⁿ) = n·R(a)` across the whole integer exponent line and turned it
+into a faithfulness/order statement (the regulator strictly orders the powers).
+
+Those entries kept the homomorphism property as *bare lemmas*. This entry does two
+genuinely new things.
+
+## 1. Bundle the norm as an honest homomorphism
+
+`pellNorm_one` and `pellNorm_mul` are exactly the axioms of a `MonoidHom`, so we
+package them:
+
+* `pellNormHom`        : `Solution₁ d →* ℝ`   — the norm as a monoid homomorphism into `(ℝ, ·)`.
+* `pellNormUnitsHom`   : `Solution₁ d →* ℝˣ`  — since the norm is never zero, it lands in the
+  multiplicative **group** of real units; this exhibits the solution group as mapping into `ℝˣ`.
+* `pellRegulatorHom`   : `Solution₁ d →* Multiplicative ℝ` — the regulator as a group homomorphism
+  into the additive group `(ℝ, +)` (the log of `pellNormUnitsHom`).
+
+## 2. The regulator of a fundamental solution is the *minimal positive value*
+
+Mathlib's `Pell.IsFundamental.eq_pow_of_nonneg` says every nonnegative solution is a
+power `a = a₁ⁿ` of the fundamental solution `a₁`. Combined with `R(aⁿ) = n·R(a₁)`
+and `R(a₁) > 0`, this yields the classical regulator characterisation:
+
+* `pellRegulator_fundamental_pos` : `R(a₁) > 0` for a fundamental `a₁`.
+* `pellRegulator_fundamental_le`  : every nontrivial positive solution `a` (`1 < a.x`, `0 < a.y`)
+  has `R(a₁) ≤ R(a)` — the fundamental regulator is a lower bound.
+* `pellRegulator_fundamental_lt`  : the bound is **strict** for `a ≠ a₁`.
+* `isLeast_pellRegulator`          : `R(a₁)` is the **least element** of the set of regulators of
+  nontrivial positive solutions — i.e. the regulator is literally the *minimal positive value*
+  the regulator attains on the solution group.
+
+The mathematical content of part 2 is the bridge from the multiplicative structure
+theorem ("every solution is a power of `a₁`") to a metric extremality statement
+("`a₁` minimises the regulator"): the additive scaling law converts "smallest
+exponent `n ≥ 1`" into "smallest positive regulator `R(a₁)`".
+
+The supporting norm/regulator lemmas (`pellNorm_one`, `pellNorm_mul`,
+`pellNorm_mul_inv`, `pellNorm_ne_zero`, `pellRegulator_mul`, `pellNorm_pow`,
+`pellRegulator_pow`) are restated here verbatim from the grandparent so the file is
+self-contained; the genuinely new content is the bundled-homomorphism layer and the
+`IsLeast` extremality theorem.
+
+`0` axioms.
+-/
+
+namespace PellEquationOQ01OQ04OQ03
+
+open Pell
+
+/-- The Pell norm `x + y√d` (matching the grandparent definition). -/
+noncomputable def pellNorm (d : ℤ) (x y : ℤ) : ℝ :=
+  (x : ℝ) + (y : ℝ) * Real.sqrt (d : ℝ)
+
+/-- The Pell regulator `log(x + y√d)` (matching the grandparent definition). -/
+noncomputable def pellRegulator (d : ℤ) (a : Solution₁ d) : ℝ :=
+  Real.log (pellNorm d a.x a.y)
+
+variable {d : ℤ}
+
+/-! ## Supporting norm/regulator lemmas (restated from the grandparent) -/
+
+/-- The norm of the identity solution `(1, 0)` is `1`. -/
+theorem pellNorm_one (d : ℤ) :
+    pellNorm d (1 : Solution₁ d).x (1 : Solution₁ d).y = 1 := by
+  rw [Solution₁.x_one, Solution₁.y_one]
+  simp [pellNorm]
+
+/-- **Brahmagupta's identity / norm multiplicativity.** For `d ≥ 0`,
+`pellNorm (a·b) = pellNorm a · pellNorm b`. -/
+theorem pellNorm_mul (d : ℤ) (hd : 0 ≤ d) (a b : Solution₁ d) :
+    pellNorm d (a * b).x (a * b).y = pellNorm d a.x a.y * pellNorm d b.x b.y := by
+  simp only [pellNorm, Solution₁.x_mul, Solution₁.y_mul]
+  have hsq : Real.sqrt (d : ℝ) ^ 2 = (d : ℝ) := Real.sq_sqrt (by exact_mod_cast hd)
+  push_cast
+  linear_combination (-((a.y : ℝ) * (b.y : ℝ))) * hsq
+
+/-- **The conjugate identity.** `pellNorm a · pellNorm a⁻¹ = 1`. -/
+theorem pellNorm_mul_inv (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) :
+    pellNorm d a.x a.y * pellNorm d a⁻¹.x a⁻¹.y = 1 := by
+  rw [Solution₁.x_inv, Solution₁.y_inv]
+  simp only [pellNorm]
+  have hsq : Real.sqrt (d : ℝ) ^ 2 = (d : ℝ) := Real.sq_sqrt (by exact_mod_cast hd)
+  have hprop : (a.x : ℝ) ^ 2 - (d : ℝ) * (a.y : ℝ) ^ 2 = 1 := by exact_mod_cast a.prop
+  push_cast
+  linear_combination hprop - ((a.y : ℝ) ^ 2) * hsq
+
+/-- The Pell norm is never zero. -/
+theorem pellNorm_ne_zero (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) :
+    pellNorm d a.x a.y ≠ 0 := by
+  intro h
+  have hkey := pellNorm_mul_inv d hd a
+  rw [h, zero_mul] at hkey
+  exact zero_ne_one hkey
+
+/-- **The regulator is additive.** For `d ≥ 0`, `R(a·b) = R(a) + R(b)`. -/
+theorem pellRegulator_mul (d : ℤ) (hd : 0 ≤ d) (a b : Solution₁ d) :
+    pellRegulator d (a * b) = pellRegulator d a + pellRegulator d b := by
+  unfold pellRegulator
+  rw [pellNorm_mul d hd, Real.log_mul (pellNorm_ne_zero d hd a) (pellNorm_ne_zero d hd b)]
+
+/-- The norm of a power is the power of the norm: `pellNorm (aⁿ) = (pellNorm a)ⁿ`. -/
+theorem pellNorm_pow (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) (n : ℕ) :
+    pellNorm d (a ^ n).x (a ^ n).y = (pellNorm d a.x a.y) ^ n := by
+  induction n with
+  | zero => rw [pow_zero, pow_zero]; exact pellNorm_one d
+  | succ n ih => rw [pow_succ, pellNorm_mul d hd, ih, pow_succ]
+
+/-- **The regulator scales linearly along powers.** `R(aⁿ) = n·R(a)`. -/
+theorem pellRegulator_pow (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) (n : ℕ) :
+    pellRegulator d (a ^ n) = (n : ℝ) * pellRegulator d a := by
+  unfold pellRegulator
+  rw [pellNorm_pow d hd, Real.log_pow]
+
+/-! ## Part 1: the norm and regulator as bundled homomorphisms -/
+
+/-- **The Pell norm as a `MonoidHom`.** For `d ≥ 0`, `pellNorm_one` and `pellNorm_mul`
+are exactly the unit/multiplicativity axioms, so the norm bundles into an honest
+homomorphism `Solution₁ d →* ℝ` from the solution group to the multiplicative monoid
+of reals. -/
+noncomputable def pellNormHom (d : ℤ) (hd : 0 ≤ d) : Solution₁ d →* ℝ where
+  toFun a := pellNorm d a.x a.y
+  map_one' := pellNorm_one d
+  map_mul' := pellNorm_mul d hd
+
+@[simp] theorem pellNormHom_apply (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) :
+    pellNormHom d hd a = pellNorm d a.x a.y := rfl
+
+/-- **The Pell norm as a homomorphism into the group of units `ℝˣ`.** Since the norm
+is never zero (`pellNorm_ne_zero`), it factors through `ℝˣ`, exhibiting the Pell
+solution group as mapping into the multiplicative *group* of real units rather than
+merely the monoid. -/
+noncomputable def pellNormUnitsHom (d : ℤ) (hd : 0 ≤ d) : Solution₁ d →* ℝˣ where
+  toFun a := Units.mk0 (pellNorm d a.x a.y) (pellNorm_ne_zero d hd a)
+  map_one' := by ext; simpa using pellNorm_one d
+  map_mul' a b := by ext; simpa using pellNorm_mul d hd a b
+
+@[simp] theorem pellNormUnitsHom_val (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) :
+    (pellNormUnitsHom d hd a : ℝ) = pellNorm d a.x a.y := rfl
+
+/-- **The regulator as a group homomorphism into `(ℝ, +)`.** Packaging `R(1) = 0`
+and `R(a·b) = R(a) + R(b)` as a `MonoidHom` into `Multiplicative ℝ` (the additive
+group of reals viewed multiplicatively). -/
+noncomputable def pellRegulatorHom (d : ℤ) (hd : 0 ≤ d) :
+    Solution₁ d →* Multiplicative ℝ where
+  toFun a := Multiplicative.ofAdd (pellRegulator d a)
+  map_one' := by
+    show Multiplicative.ofAdd (pellRegulator d (1 : Solution₁ d)) = 1
+    rw [show (1 : Multiplicative ℝ) = Multiplicative.ofAdd (0 : ℝ) from rfl]
+    congr 1
+    unfold pellRegulator
+    rw [pellNorm_one d, Real.log_one]
+  map_mul' a b := by
+    show Multiplicative.ofAdd (pellRegulator d (a * b))
+      = Multiplicative.ofAdd (pellRegulator d a) * Multiplicative.ofAdd (pellRegulator d b)
+    rw [pellRegulator_mul d hd, ← ofAdd_add]
+
+@[simp] theorem pellRegulatorHom_apply (d : ℤ) (hd : 0 ≤ d) (a : Solution₁ d) :
+    Multiplicative.toAdd (pellRegulatorHom d hd a) = pellRegulator d a := rfl
+
+/-! ## Part 2: the regulator as a minimal positive value -/
+
+/-- A nontrivial positive solution (`1 < a.x`, `0 < a.y`, with `d > 0`) has norm
+strictly greater than `1`: `x + y√d > 1`. -/
+theorem one_lt_pellNorm {a : Solution₁ d} (hd : 0 < d) (hx : 1 < a.x) (hy : 0 < a.y) :
+    1 < pellNorm d a.x a.y := by
+  have hsqrt : 0 < Real.sqrt (d : ℝ) := Real.sqrt_pos.mpr (by exact_mod_cast hd)
+  have hxr : (1 : ℝ) < (a.x : ℝ) := by exact_mod_cast hx
+  have hyr : (0 : ℝ) < (a.y : ℝ) := by exact_mod_cast hy
+  have hpos : 0 < (a.y : ℝ) * Real.sqrt (d : ℝ) := mul_pos hyr hsqrt
+  simp only [pellNorm]
+  linarith
+
+/-- **The regulator of a fundamental solution is strictly positive.** -/
+theorem pellRegulator_fundamental_pos {a₁ : Solution₁ d} (h : IsFundamental a₁) :
+    0 < pellRegulator d a₁ := by
+  unfold pellRegulator
+  exact Real.log_pos (one_lt_pellNorm h.d_pos h.1 h.2.1)
+
+/-- **Lower bound / minimality.** For a fundamental solution `a₁`, every nontrivial
+positive solution `a` (`1 < a.x`, `0 < a.y`) satisfies `R(a₁) ≤ R(a)`. The proof
+writes `a = a₁ⁿ` with `n ≥ 1` and uses `R(a₁ⁿ) = n·R(a₁) ≥ R(a₁)`. -/
+theorem pellRegulator_fundamental_le {a₁ : Solution₁ d} (h : IsFundamental a₁)
+    {a : Solution₁ d} (hx : 1 < a.x) (hy : 0 < a.y) :
+    pellRegulator d a₁ ≤ pellRegulator d a := by
+  obtain ⟨n, rfl⟩ := h.eq_pow_of_nonneg (zero_lt_one.trans hx) hy.le
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by
+    rcases Nat.eq_zero_or_pos n with h0 | h0
+    · rw [h0, pow_zero, Solution₁.x_one] at hx; exact absurd hx (lt_irrefl 1)
+    · exact_mod_cast h0
+  rw [pellRegulator_pow d h.d_pos.le]
+  have hR : 0 < pellRegulator d a₁ := pellRegulator_fundamental_pos h
+  calc pellRegulator d a₁ = 1 * pellRegulator d a₁ := (one_mul _).symm
+    _ ≤ (n : ℝ) * pellRegulator d a₁ := mul_le_mul_of_nonneg_right hn1 hR.le
+
+/-- **Strict minimality.** The fundamental solution is the *unique* minimiser: any
+nontrivial positive solution `a ≠ a₁` has `R(a₁) < R(a)` (here `a = a₁ⁿ` with `n ≥ 2`). -/
+theorem pellRegulator_fundamental_lt {a₁ : Solution₁ d} (h : IsFundamental a₁)
+    {a : Solution₁ d} (hx : 1 < a.x) (hy : 0 < a.y) (hne : a ≠ a₁) :
+    pellRegulator d a₁ < pellRegulator d a := by
+  obtain ⟨n, rfl⟩ := h.eq_pow_of_nonneg (zero_lt_one.trans hx) hy.le
+  have hn2 : (2 : ℝ) ≤ (n : ℝ) := by
+    match n, hx, hne with
+    | 0, hx, _ => rw [pow_zero, Solution₁.x_one] at hx; exact absurd hx (lt_irrefl 1)
+    | 1, _, hne => exact absurd (pow_one a₁) hne
+    | (k + 2), _, _ => exact_mod_cast Nat.le_add_left 2 k
+  rw [pellRegulator_pow d h.d_pos.le]
+  have hR : 0 < pellRegulator d a₁ := pellRegulator_fundamental_pos h
+  calc pellRegulator d a₁ = 1 * pellRegulator d a₁ := (one_mul _).symm
+    _ < (n : ℝ) * pellRegulator d a₁ :=
+        mul_lt_mul_of_pos_right (by linarith) hR
+
+/-- **The regulator is the minimal positive value.** For a fundamental solution `a₁`,
+`R(a₁)` is the *least element* of the set of regulators of all nontrivial positive
+Pell solutions. This is the classical statement that the regulator (the period of the
+fundamental unit) is the smallest positive value attained by `log‖a‖` on the solution
+group. -/
+theorem isLeast_pellRegulator {a₁ : Solution₁ d} (h : IsFundamental a₁) :
+    IsLeast {r : ℝ | ∃ a : Solution₁ d, 1 < a.x ∧ 0 < a.y ∧ r = pellRegulator d a}
+            (pellRegulator d a₁) := by
+  constructor
+  · exact ⟨a₁, h.1, h.2.1, rfl⟩
+  · rintro r ⟨a, hax, hay, rfl⟩
+    exact pellRegulator_fundamental_le h hax hay
+
+/-- The minimal value is itself positive: the least regulator over nontrivial positive
+solutions is `> 0`. -/
+theorem isLeast_pellRegulator_pos {a₁ : Solution₁ d} (h : IsFundamental a₁) :
+    0 < (pellRegulator d a₁) := pellRegulator_fundamental_pos h
+
+end PellEquationOQ01OQ04OQ03

--- a/src/data/proofs/pell-equation-oq-01-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04-oq-03/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "ann-pell-oq03-defs",
+    "proofId": "pell-equation-oq-01-oq-04-oq-03",
+    "range": { "startLine": 60, "endLine": 65 },
+    "type": "definition",
+    "title": "The Pell Norm and Regulator (pellNorm, pellRegulator)",
+    "content": "pellNorm d x y = x + y√d is the real embedding of a Pell solution a ∈ Solution₁ d (a pair (x,y) with x² − d·y² = 1) into ℝ under ℤ[√d] ↪ ℝ; pellRegulator d a = log(pellNorm d a.x a.y) is its logarithm. These match the grandparent's definitions and set up both goals of this entry: the multiplicative law pellNorm(a·b) = pellNorm(a)·pellNorm(b) is exactly the data of a MonoidHom, and the logarithm converts it into the additive regulator whose minimal positive value is the regulator of the field.",
+    "mathContext": "$\\|a\\| = x + y\\sqrt d,\\qquad R(a) = \\log\\|a\\|$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Pell's equation x² − d·y² = 1 and Mathlib's Solution₁ d",
+      "The real embedding ℤ[√d] ↪ ℝ",
+      "Logarithm turning products into sums"
+    ],
+    "relatedConcepts": [
+      "Pell's equation",
+      "real quadratic field",
+      "regulator",
+      "fundamental solution"
+    ]
+  },
+  {
+    "id": "ann-pell-oq03-infra",
+    "proofId": "pell-equation-oq-01-oq-04-oq-03",
+    "range": { "startLine": 69, "endLine": 122 },
+    "type": "lemma",
+    "title": "Restated grandparent infrastructure (homomorphism and power laws)",
+    "content": "pellNorm_one (the identity has norm 1), pellNorm_mul (Brahmagupta's identity / multiplicativity, proved by a linear_combination against (√d)² = d), pellNorm_mul_inv and pellNorm_ne_zero (the norm of the conjugate inverts it, so the norm never vanishes), pellRegulator_mul (additivity via Real.log_mul), pellNorm_pow and pellRegulator_pow (R(aⁿ) = n·R(a) via Real.log_pow). Restated verbatim from the grandparent so the file is self-contained; these are exactly the facts the bundled homomorphisms and the minimality theorem consume.",
+    "mathContext": "$\\mathrm{pellNorm}(a\\cdot b) = \\mathrm{pellNorm}(a)\\,\\mathrm{pellNorm}(b),\\qquad R(a^n) = n\\,R(a)$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Brahmagupta's composition identity",
+      "(√d)² = d for d ≥ 0 (Real.sq_sqrt)",
+      "Logarithm laws log(xy) = log x + log y, log(xⁿ) = n log x"
+    ],
+    "relatedConcepts": [
+      "Brahmagupta identity",
+      "norm multiplicativity",
+      "regulator additivity"
+    ]
+  },
+  {
+    "id": "ann-pell-oq03-bundled",
+    "proofId": "pell-equation-oq-01-oq-04-oq-03",
+    "range": { "startLine": 124, "endLine": 169 },
+    "type": "definition",
+    "title": "The norm and regulator as bundled homomorphisms",
+    "content": "The new packaging layer. pellNormHom : Solution₁ d →* ℝ takes pellNorm_one and pellNorm_mul as its map_one'/map_mul' fields — the grandparent's bare lemmas ARE a monoid homomorphism. Because pellNorm_ne_zero holds, Units.mk0 lifts it to pellNormUnitsHom : Solution₁ d →* ℝˣ, landing in the multiplicative group of real units rather than just the monoid. Finally pellRegulatorHom : Solution₁ d →* Multiplicative ℝ views the additive regulator (R(1)=0, R(a·b)=R(a)+R(b)) as a homomorphism into the additive group (ℝ,+) presented multiplicatively via Multiplicative.ofAdd. Three @[simp] lemmas expose the underlying values.",
+    "mathContext": "$N : \\mathrm{Solution}_1 d \\to^* \\mathbb{R}^\\times,\\qquad R : \\mathrm{Solution}_1 d \\to^* (\\mathbb{R}, +)$.",
+    "significance": "central",
+    "prerequisites": [
+      "MonoidHom structure (map_one', map_mul')",
+      "Units.mk0 for a nonzero element of a field",
+      "Multiplicative ℝ and Multiplicative.ofAdd"
+    ],
+    "relatedConcepts": [
+      "monoid homomorphism",
+      "unit group ℝˣ",
+      "additive vs multiplicative groups"
+    ]
+  },
+  {
+    "id": "ann-pell-oq03-bound",
+    "proofId": "pell-equation-oq-01-oq-04-oq-03",
+    "range": { "startLine": 171, "endLine": 190 },
+    "type": "lemma",
+    "title": "Norm bound and positivity of the fundamental regulator",
+    "content": "one_lt_pellNorm: a nontrivial positive solution (1 < x, 0 < y, d > 0) has ‖a‖ = x + y√d > 1, since x > 1 and y√d > 0. pellRegulator_fundamental_pos: a fundamental solution a₁ — which by definition has 1 < a₁.x, 0 < a₁.y, and forces d > 0 (IsFundamental.d_pos) — therefore has R(a₁) = log‖a₁‖ > 0 by Real.log_pos. This strict positivity is the only inequality the minimality argument needs: it is the floor below which no positive regulator can fall.",
+    "mathContext": "$1 < a.x,\\; 0 < a.y \\;\\Rightarrow\\; \\|a\\| > 1,\\qquad R(a_1) > 0$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Real.sqrt_pos: 0 < √d for d > 0",
+      "Real.log_pos: 1 < x ⟹ 0 < log x",
+      "IsFundamental.d_pos"
+    ],
+    "relatedConcepts": [
+      "fundamental solution",
+      "logarithm positivity"
+    ]
+  },
+  {
+    "id": "ann-pell-oq03-minimality",
+    "proofId": "pell-equation-oq-01-oq-04-oq-03",
+    "range": { "startLine": 192, "endLine": 240 },
+    "type": "theorem",
+    "title": "The regulator as a minimal positive value (IsLeast)",
+    "content": "The headline result. pellRegulator_fundamental_le: for any nontrivial positive solution a, Mathlib's IsFundamental.eq_pow_of_nonneg writes a = a₁ⁿ; the exponent satisfies n ≥ 1 (n = 0 would give a = 1, contradicting 1 < a.x), so R(a) = n·R(a₁) ≥ R(a₁) because R(a₁) > 0. pellRegulator_fundamental_lt sharpens this to strict inequality for a ≠ a₁ (then n ≥ 2), so a₁ is the unique minimiser. isLeast_pellRegulator assembles membership (a₁ is itself a nontrivial positive solution) and the lower-bound property into IsLeast {R(a) : 1 < a.x, 0 < a.y} (R(a₁)) — a faithful, machine-checked rendering of the textbook regulator as the smallest positive value of log‖a‖ on the solution group. isLeast_pellRegulator_pos records that this minimum is itself positive.",
+    "mathContext": "$\\mathrm{IsLeast}\\,\\{\\,R(a) : 1 < a.x,\\, 0 < a.y\\,\\}\\;\\bigl(R(a_1)\\bigr),\\qquad R(a_1) > 0$.",
+    "significance": "central",
+    "prerequisites": [
+      "Pell.IsFundamental.eq_pow_of_nonneg (every nonnegative solution is a₁ⁿ)",
+      "The scaling law R(aⁿ) = n·R(a)",
+      "IsLeast and lowerBounds"
+    ],
+    "relatedConcepts": [
+      "regulator of a real quadratic field",
+      "fundamental unit",
+      "minimal positive value",
+      "structure theorem for Pell solutions"
+    ]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04-oq-03/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "pell-equation-oq-01-oq-04-oq-03",
+  "title": "The Pell Norm as a MonoidHom, and the Regulator as the Minimal Positive Value",
+  "slug": "pell-equation-oq-01-oq-04-oq-03",
+  "description": "Bundles the Pell norm into honest homomorphisms and identifies the fundamental regulator as a minimal positive value, answering the sibling entry's first open question. The norm ‖a‖ = x + y√d satisfies pellNorm_one and pellNorm_mul (Brahmagupta), exactly the axioms of a monoid homomorphism, so it bundles as pellNormHom : Solution₁ d →* ℝ; since it is never zero it factors through the unit group as pellNormUnitsHom : Solution₁ d →* ℝˣ, and its logarithm bundles as pellRegulatorHom : Solution₁ d →* Multiplicative ℝ — the regulator as a group homomorphism into (ℝ, +). Using Mathlib's structure theorem Pell.IsFundamental.eq_pow_of_nonneg (every nonnegative solution is a power a₁ⁿ of the fundamental solution) together with R(aⁿ) = n·R(a) and R(a₁) > 0, the fundamental regulator is shown to be the least value the regulator attains on nontrivial positive solutions: R(a₁) ≤ R(a) (strict for a ≠ a₁), packaged as IsLeast. 16 theorems, 5 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "researcher-7",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ01OQ04OQ03.lean",
+    "tags": [
+      "pell-equation",
+      "number-theory",
+      "regulator",
+      "real-quadratic-field",
+      "monoid-hom",
+      "fundamental-unit",
+      "minimal-positive-value",
+      "is-least"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 240,
+    "theoremCount": 16,
+    "definitionCount": 5,
+    "assumptions": "None. All theorems proved, 0 axioms. Verified axiom-free: #print axioms on isLeast_pellRegulator, pellRegulator_fundamental_lt, pellNormHom and pellRegulatorHom reports only propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Pell.IsFundamental.eq_pow_of_nonneg",
+        "description": "Every solution with 0 < x and 0 ≤ y is a natural-number power a₁ⁿ of the fundamental solution a₁ — the multiplicative structure theorem that turns minimality of the regulator into minimality of the exponent n ≥ 1",
+        "module": "Mathlib.NumberTheory.Pell"
+      },
+      {
+        "theorem": "Pell.IsFundamental.d_pos",
+        "description": "A fundamental solution forces d > 0, supplying positivity of √d for the norm bound ‖a₁‖ > 1",
+        "module": "Mathlib.NumberTheory.Pell"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "1 < x → 0 < Real.log x — converts ‖a₁‖ > 1 into a strictly positive regulator R(a₁), the floor for the minimal positive value",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_mul / Real.log_pow / Real.log_one",
+        "description": "Logarithm laws turning norm multiplicativity into regulator additivity (pellRegulator_mul) and the scaling law R(aⁿ) = n·R(a) (pellRegulator_pow)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "mul_lt_mul_of_pos_right",
+        "description": "a < b → 0 < c → a·c < b·c — gives the strict bound R(a₁) < n·R(a₁) for n ≥ 2 in the strict-minimality theorem",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "MonoidHom (structure) / Units.mk0 / Multiplicative.ofAdd",
+        "description": "The bundled-homomorphism interface: MonoidHom fields map_one'/map_mul', Units.mk0 for the nonzero norm into ℝˣ, and Multiplicative.ofAdd to view the additive regulator as a multiplicative-group target",
+        "module": "Mathlib.Algebra.Group.Hom.Defs"
+      },
+      {
+        "theorem": "IsLeast (definition)",
+        "description": "IsLeast S x ↔ x ∈ S ∧ x ∈ lowerBounds S — the order-theoretic packaging of 'R(a₁) is the minimal positive value of the regulator on nontrivial positive solutions'",
+        "module": "Mathlib.Order.Bounds.Basic"
+      },
+      {
+        "theorem": "Pell.Solution₁ group structure (x_mul/y_mul/x_inv/y_inv/x_one/y_one/prop)",
+        "description": "The Brahmagupta group law on Pell solutions, restated to make the norm/regulator infrastructure self-contained (grandparent infrastructure)",
+        "module": "Mathlib.NumberTheory.Pell"
+      }
+    ],
+    "dateAdded": "2026-06-24"
+  },
+  "overview": {
+    "historicalContext": "The solutions of Pell's equation x² − d·y² = 1 (for non-square d > 0) form an infinite group generated up to sign by a fundamental solution; the embedding (x, y) ↦ x + y√d sends it into the units of the real quadratic order ℤ[√d], and the logarithm of that embedding is the regulator. Classically the regulator of a real quadratic field is the smallest positive value of |log ε| over units ε of norm 1 — equivalently the log of the fundamental unit. The grandparent entry pell-equation-oq-01-oq-04 built the regulator as an additive invariant and proved the Pell norm multiplicative (Brahmagupta); the siblings extended the scaling law R(aⁿ) = n·R(a) and used it to show solutions beyond 1 have infinite order. The sibling pell-equation-oq-01-oq-04-oq-02 explicitly posed as an open question whether the fundamental solution realizes the minimal positive regulator. This entry answers that question and, separately, packages the norm and regulator as bundled Mathlib homomorphisms.",
+    "problemStatement": "First, bundle the Pell norm and regulator as honest homomorphisms: a MonoidHom Solution₁ d →* ℝ, a MonoidHom into the unit group ℝˣ, and the regulator as a MonoidHom Solution₁ d →* Multiplicative ℝ. Second, prove that for a fundamental solution a₁ the regulator R(a₁) = log‖a₁‖ is the minimal positive value attained by the regulator on nontrivial positive Pell solutions: R(a₁) ≤ R(a) for every solution a with 1 < a.x and 0 < a.y, strictly when a ≠ a₁, and package this as IsLeast.",
+    "proofStrategy": "Part 1 (bundling): pellNorm_one and pellNorm_mul are precisely the unit and multiplicativity axioms of a MonoidHom, so pellNormHom : Solution₁ d →* ℝ is immediate; pellNorm_ne_zero lets Units.mk0 lift it to pellNormUnitsHom : Solution₁ d →* ℝˣ; and R(1) = 0, R(a·b) = R(a) + R(b) make Multiplicative.ofAdd ∘ pellRegulator a MonoidHom into Multiplicative ℝ. Part 2 (minimality): one_lt_pellNorm shows a nontrivial positive solution has ‖a‖ = x + y√d > 1, so pellRegulator_fundamental_pos gives R(a₁) > 0 via Real.log_pos. For any nontrivial positive a, Mathlib's IsFundamental.eq_pow_of_nonneg writes a = a₁ⁿ; the exponent satisfies n ≥ 1 (else a = 1 contradicts 1 < a.x), so R(a) = n·R(a₁) ≥ R(a₁) (pellRegulator_pow plus mul_le_mul_of_nonneg_right). Strictness for a ≠ a₁ forces n ≥ 2. Finally isLeast_pellRegulator assembles membership (witnessed by a₁ itself) and the lower-bound property into IsLeast.",
+    "keyInsights": [
+      "**The homomorphism laws were already the bundling data.** pellNorm_one and pellNorm_mul are verbatim the map_one'/map_mul' fields of a MonoidHom, so packaging the norm as Solution₁ d →* ℝ requires no new mathematics — only recognizing that the grandparent's bare lemmas constitute a bundled homomorphism. The nonvanishing pellNorm_ne_zero upgrades the target from the monoid ℝ to the group ℝˣ.",
+      "**Minimality of the regulator = minimality of the exponent.** Mathlib's structure theorem a = a₁ⁿ converts 'smallest positive regulator' into 'smallest n ≥ 1'. Since R(a) = n·R(a₁) is an order-preserving relabelling (R(a₁) > 0), the least exponent n = 1 yields the least regulator R(a₁); there is nothing analytic to optimize once the multiplicative structure is in hand.",
+      "**Positivity of R(a₁) is the only inequality needed.** The whole extremality argument rests on R(a₁) > 0, i.e. ‖a₁‖ > 1, which comes from the fundamental solution's defining inequalities 1 < x, 0 < y together with √d > 0. Everything else is the monotonicity of n ↦ n·R(a₁).",
+      "**IsLeast packages 'minimal positive value' exactly.** The classical phrase 'the regulator is the smallest positive value of log‖a‖' is captured precisely by IsLeast of the set {R(a) : 1 < a.x, 0 < a.y}: a₁ is both a member (it is a nontrivial positive solution) and a lower bound. This is a faithful, machine-checkable rendering of the textbook definition of the regulator.",
+      "**The fundamental solution is the unique minimiser.** Strict minimality (a ≠ a₁ ⟹ R(a₁) < R(a)) shows the minimum is attained only at a₁: the exponent jumps to n ≥ 2 and R(a) = n·R(a₁) > R(a₁). Uniqueness pins the minimal positive value to a single solution."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Pell norm and regulator",
+      "startLine": 60,
+      "endLine": 65,
+      "summary": "Restates pellNorm d x y = x + y√d and pellRegulator d a = log(pellNorm), matching the grandparent definitions so the file is self-contained.",
+      "mathContext": "$\\mathrm{pellNorm}(x,y) = x + y\\sqrt d,\\quad R(a) = \\log\\mathrm{pellNorm}(a)$."
+    },
+    {
+      "id": "parent-infra",
+      "title": "Restated grandparent infrastructure (norm homomorphism and power law)",
+      "startLine": 69,
+      "endLine": 122,
+      "summary": "pellNorm_one, pellNorm_mul (Brahmagupta), pellNorm_mul_inv, pellNorm_ne_zero, pellRegulator_mul, pellNorm_pow and pellRegulator_pow — the grandparent's homomorphism and scaling facts, restated verbatim as the engine for the bundling and minimality layers.",
+      "mathContext": "$\\mathrm{pellNorm}(a\\cdot b) = \\mathrm{pellNorm}(a)\\,\\mathrm{pellNorm}(b),\\quad R(a^n) = n\\,R(a)$."
+    },
+    {
+      "id": "bundled-homs",
+      "title": "The norm and regulator as bundled homomorphisms",
+      "startLine": 124,
+      "endLine": 169,
+      "summary": "pellNormHom : Solution₁ d →* ℝ (the norm as a monoid homomorphism), pellNormUnitsHom : Solution₁ d →* ℝˣ (factoring through the unit group since the norm is nonzero), and pellRegulatorHom : Solution₁ d →* Multiplicative ℝ (the regulator as a group homomorphism into (ℝ, +)), with their @[simp] application lemmas.",
+      "mathContext": "$N : \\mathrm{Solution}_1 d \\to^* \\mathbb{R}^\\times,\\qquad R : \\mathrm{Solution}_1 d \\to^* (\\mathbb{R}, +)$."
+    },
+    {
+      "id": "norm-bound",
+      "title": "Norm bound and positivity of the fundamental regulator",
+      "startLine": 171,
+      "endLine": 190,
+      "summary": "one_lt_pellNorm: a nontrivial positive solution (1 < x, 0 < y, d > 0) has ‖a‖ > 1. pellRegulator_fundamental_pos: hence a fundamental solution has R(a₁) > 0 via Real.log_pos — the floor of the minimal positive value.",
+      "mathContext": "$1 < a.x,\\; 0 < a.y \\;\\Rightarrow\\; \\lVert a\\rVert > 1,\\qquad R(a_1) > 0$."
+    },
+    {
+      "id": "minimality",
+      "title": "The regulator as a minimal positive value",
+      "startLine": 192,
+      "endLine": 240,
+      "summary": "pellRegulator_fundamental_le: every nontrivial positive solution a has R(a₁) ≤ R(a), via a = a₁ⁿ with n ≥ 1 and R(aⁿ) = n·R(a₁). pellRegulator_fundamental_lt: strict for a ≠ a₁ (n ≥ 2). isLeast_pellRegulator: R(a₁) is the least element of the set of regulators of nontrivial positive solutions; isLeast_pellRegulator_pos records that this minimum is positive.",
+      "mathContext": "$\\mathrm{IsLeast}\\,\\{\\,R(a) : 1 < a.x,\\, 0 < a.y\\,\\}\\;\\bigl(R(a_1)\\bigr)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Pell norm bundles as a MonoidHom Solution₁ d →* ℝ and, being nonzero, into the unit group ℝˣ, while its logarithm bundles as a group homomorphism into (ℝ, +). For a fundamental solution a₁, the regulator R(a₁) = log‖a₁‖ is the minimal positive value the regulator attains on nontrivial positive Pell solutions: R(a₁) ≤ R(a) for all such a (strict for a ≠ a₁), packaged as IsLeast. The proof reduces the metric extremality to the multiplicative structure theorem a = a₁ⁿ plus positivity of R(a₁). 16 theorems, 5 definitions, 0 sorries, 0 axioms.",
+    "implications": "Gives a machine-checked rendering of the textbook definition of the regulator of a real quadratic field — the smallest positive value of log‖unit‖ — directly on Mathlib's Solution₁ group, and equips it with bundled homomorphism objects (Solution₁ d →* ℝˣ and →* Multiplicative ℝ) suitable for further structural work. The fundamental solution is exhibited as the unique minimiser, pinning the minimal positive value to a single solution.",
+    "openQuestions": [
+      "Promote the lower bound to a generator statement: every nontrivial positive solution has regulator n·R(a₁) for a unique n ≥ 1, so the image of pellRegulatorHom is exactly the discrete subgroup R(a₁)·ℤ of (ℝ, +).",
+      "Combine pellNormUnitsHom with the structure theorem to compute the kernel and image of the norm homomorphism on Solution₁ d, identifying the solution group with R(a₁)·ℤ ≅ ℤ as an ordered group."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Pell"
+    ],
+    "namespace": "PellEquationOQ01OQ04OQ03",
+    "lineCount": 240,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 5,
+    "path": "Proofs/PellEquationOQ01OQ04OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-01-oq-04-oq-02",
+      "relationship": "extends",
+      "description": "Sibling proves solutions beyond 1 have infinite order and explicitly asks whether the fundamental solution realizes the minimal positive regulator; this entry answers that question via IsLeast and the structure theorem a = a₁ⁿ"
+    },
+    {
+      "targetId": "pell-equation-oq-01-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Sibling extends the regulator scaling law R(aⁿ) = n·R(a) to all integer exponents; this entry reuses the natural-number form to relate R(a) to R(a₁)"
+    },
+    {
+      "targetId": "pell-equation-oq-01-oq-04",
+      "relationship": "ancestor",
+      "description": "Grandparent proves the Pell norm is a homomorphism (Brahmagupta) and the regulator additive — bundled here into MonoidHom objects"
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "ancestor",
+      "description": "Root Pell equation entry"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "pellNormUnitsHom",
+      "type": "definition",
+      "statement": "pellNormUnitsHom (d : ℤ) (hd : 0 ≤ d) : Solution₁ d →* ℝˣ",
+      "description": "The Pell norm as a homomorphism into the multiplicative group of real units, via Units.mk0 applied to the never-zero norm.",
+      "significance": "Exhibits the Pell solution group as mapping into the group ℝˣ, upgrading the grandparent's bare multiplicativity lemmas to a bundled group homomorphism"
+    },
+    {
+      "name": "pellRegulator_fundamental_le",
+      "type": "core",
+      "statement": "IsFundamental a₁ → 1 < a.x → 0 < a.y → pellRegulator d a₁ ≤ pellRegulator d a",
+      "description": "Every nontrivial positive Pell solution has regulator at least that of the fundamental solution, via a = a₁ⁿ (eq_pow_of_nonneg) with n ≥ 1 and R(aⁿ) = n·R(a₁).",
+      "significance": "The lower-bound half of 'the regulator is the minimal positive value'"
+    },
+    {
+      "name": "pellRegulator_fundamental_lt",
+      "type": "core",
+      "statement": "IsFundamental a₁ → 1 < a.x → 0 < a.y → a ≠ a₁ → pellRegulator d a₁ < pellRegulator d a",
+      "description": "The fundamental solution is the unique minimiser: any other nontrivial positive solution is a₁ⁿ with n ≥ 2, giving R(a) = n·R(a₁) > R(a₁).",
+      "significance": "Uniqueness of the minimiser pins the minimal positive value to the fundamental solution"
+    },
+    {
+      "name": "isLeast_pellRegulator",
+      "type": "core",
+      "statement": "IsFundamental a₁ → IsLeast {r | ∃ a, 1 < a.x ∧ 0 < a.y ∧ r = pellRegulator d a} (pellRegulator d a₁)",
+      "description": "R(a₁) is the least element of the set of regulators of nontrivial positive Pell solutions — a faithful rendering of the textbook regulator as the smallest positive value of log‖a‖.",
+      "significance": "Packages the minimal-positive-value characterization of the regulator as a single IsLeast statement"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **pell-equation-oq-01-oq-04-oq-03**, building on the verified Pell-norm/regulator family (grandparent `…-oq-04`, siblings `…-oq-01`/`…-oq-02`).

Two genuinely new contributions over the siblings (which kept the homomorphism property as bare lemmas):

**1. Bundle the norm/regulator as honest Mathlib homomorphisms**
- `pellNormHom : Solution₁ d →* ℝ` — `pellNorm_one`/`pellNorm_mul` are exactly the `MonoidHom` axioms.
- `pellNormUnitsHom : Solution₁ d →* ℝˣ` — since the norm is never zero (`pellNorm_ne_zero`), it factors through the unit **group** via `Units.mk0`.
- `pellRegulatorHom : Solution₁ d →* Multiplicative ℝ` — the regulator as a group hom into `(ℝ, +)`.

**2. The regulator as the minimal positive value** (answers sibling `…-oq-02`'s first open question)
- Using Mathlib's `Pell.IsFundamental.eq_pow_of_nonneg` (every nonnegative solution is `a₁ⁿ`) plus `R(aⁿ) = n·R(a)` and `R(a₁) > 0`:
  - `pellRegulator_fundamental_le` : `R(a₁) ≤ R(a)` for every nontrivial positive solution.
  - `pellRegulator_fundamental_lt` : strict for `a ≠ a₁` (unique minimiser).
  - `isLeast_pellRegulator` : `IsLeast {R(a) : 1 < a.x, 0 < a.y} (R(a₁))` — a faithful, machine-checked rendering of the textbook regulator as the smallest positive value of `log‖a‖` on the solution group.

## Verification
- Builds clean against Mathlib 4.26 (host `lake env lean`).
- **0 sorries, 0 axioms** — `#print axioms` on `isLeast_pellRegulator`, `pellRegulator_fundamental_lt`, `pellNormHom`, `pellRegulatorHom` reports only `propext, Classical.choice, Quot.sound`.
- 16 theorems, 5 definitions, 240 lines. Gallery `meta.json` + `annotations.json` included; enrichment step processes the entry cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)