### PR TITLE
Enrich Apéry numbers: index.ts, overview, annotation depth

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -6,7 +6,18 @@
     "type": "concept",
     "title": "Closing the parent's two open questions, axiom-free",
     "content": "The parent companion pinned the Apéry numbers bₙ = ∑ C(n,k)²·C(n+k,k)² from below (4ⁿ ≤ bₙ) but left two things open and axiom-free: a matching geometric UPPER bound, and the parity of bₙ. The grandparent ζ(3) irrationality file supplies the upper half only as an axiom (bₙ ≤ 34ⁿ). This file removes the need for that axiom on the elementary side — proving bₙ ≤ 64ⁿ from scratch — and shows every Apéry number is odd. Together with 4ⁿ ≤ bₙ the exponential base is now bracketed in [4, 64] with zero axioms; the true base is the irrational (1+√2)⁴ = 17+12√2 ≈ 33.97.",
-    "mathContext": "$4^n\\le b_n\\le 64^n$ and $b_n$ odd, both with $0$ axioms."
+    "mathContext": "$4^n\\le b_n\\le 64^n$ and $b_n$ odd, both with $0$ axioms.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Apéry numbers",
+      "ζ(3) irrationality",
+      "geometric squeeze",
+      "axiom-free formalization"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "irrationality proofs"
+    ]
   },
   {
     "id": "ann-basel-oq0101020101-vandermonde",
@@ -15,7 +26,18 @@
     "type": "key-step",
     "title": "Vandermonde on the diagonal keeps the bound geometric",
     "content": "sum_choose_sq proves ∑_{k≤n} C(n,k)² = C(2n,n). Writing centralBinom n = (n+n).choose n and expanding over the antidiagonal (Nat.add_choose_eq) produces ∑ C(n,k)·C(n,n-k); pairing each term with its mirror via Nat.choose_symm turns it into ∑ C(n,k)². This exact cancellation is what stops the upper bound from leaking an n-fold polynomial factor: the squared-binomial row is precisely the central coefficient, not merely bounded by it.",
-    "mathContext": "$\\sum_{k=0}^n\\binom{n}{k}^2=\\sum_k\\binom{n}{k}\\binom{n}{n-k}=\\binom{2n}{n}.$"
+    "mathContext": "$\\sum_{k=0}^n\\binom{n}{k}^2=\\sum_k\\binom{n}{k}\\binom{n}{n-k}=\\binom{2n}{n}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vandermonde's identity",
+      "central binomial coefficient",
+      "antidiagonal expansion",
+      "Nat.choose_symm"
+    ],
+    "prerequisites": [
+      "Vandermonde's convolution",
+      "Finset sums"
+    ]
   },
   {
     "id": "ann-basel-oq0101020101-upper",
@@ -24,7 +46,18 @@
     "type": "technique",
     "title": "bₙ ≤ C(2n,n)³ ≤ 64ⁿ",
     "content": "aperyB_le_centralBinom_cube bounds each factor C(n+k,k) (for k ≤ n) by the central coefficient C(2n,n) — via Nat.choose_le_choose then Nat.choose_le_centralBinom — so bₙ ≤ ∑ C(n,k)²·C(2n,n)² = (∑ C(n,k)²)·C(2n,n)² = C(2n,n)·C(2n,n)² = C(2n,n)³ using the Vandermonde collapse. Then centralBinom_le_four_pow gives C(2n,n) ≤ 4ⁿ by keeping a single term of ∑_i C(2n,i) = 2^(2n), and aperyB_le_64_pow chains to bₙ ≤ (4ⁿ)³ = 64ⁿ — a fully axiom-free geometric upper bound.",
-    "mathContext": "$b_n\\le\\binom{2n}{n}^3\\le(4^n)^3=64^n.$"
+    "mathContext": "$b_n\\le\\binom{2n}{n}^3\\le(4^n)^3=64^n.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "Nat.choose_le_centralBinom",
+      "Finset.single_le_sum",
+      "geometric growth"
+    ],
+    "prerequisites": [
+      "binomial coefficient monotonicity",
+      "row-sum identity ∑ C(2n,i) = 4ⁿ"
+    ]
   },
   {
     "id": "ann-basel-oq0101020101-parity",
@@ -33,7 +66,18 @@
     "type": "key-step",
     "title": "Every Apéry number is odd, via trinomial revision",
     "content": "two_dvd_choose_mul shows C(n,k)·C(n+k,k) is even for k ≥ 1: the subset-of-a-subset identity Nat.choose_mul, instantiated at C(n+k,2k)·C(2k,k) = C(n+k,k)·C(n,k), exposes the central binomial factor C(2k,k), even for k ≥ 1 (Nat.two_dvd_centralBinom_of_one_le). Each summand of bₙ is the square of this product, hence also even (two_dvd_aperyB_term). aperyB_odd then peels the k = 0 term (= 1) with Finset.sum_range_succ' and absorbs the even remainder: bₙ ≡ 1 (mod 2).",
-    "mathContext": "$\\binom{n}{k}\\binom{n+k}{k}=\\binom{n+k}{2k}\\binom{2k}{k}$, and $2\\mid\\binom{2k}{k}$ for $k\\ge1$."
+    "mathContext": "$\\binom{n}{k}\\binom{n+k}{k}=\\binom{n+k}{2k}\\binom{2k}{k}$, and $2\\mid\\binom{2k}{k}$ for $k\\ge1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "trinomial revision identity",
+      "Nat.choose_mul",
+      "even central binomial",
+      "Finset.sum_range_succ'"
+    ],
+    "prerequisites": [
+      "divisibility in ℕ",
+      "subset-of-a-subset identity"
+    ]
   },
   {
     "id": "ann-basel-oq0101020101-bracket",
@@ -42,6 +86,16 @@
     "type": "observation",
     "title": "A two-sided geometric bracket with no axioms",
     "content": "Combining aperyB_le_64_pow with the parent's four_pow_le_aperyB gives 4ⁿ ≤ bₙ ≤ 64ⁿ entirely without axioms. On the elementary side this makes the grandparent ζ(3) file's axiomatic bₙ ≤ 34ⁿ unnecessary for establishing geometric growth. The gap between the crude base 64 and the true 17+12√2 ≈ 33.97 comes from bounding every C(n+k,k) by C(2n,n) uniformly rather than near the dominant index k ≈ 0.8n — the natural next sharpening.",
-    "mathContext": "$4^n\\le b_n\\le 64^n$; true base $(1+\\sqrt2)^4=17+12\\sqrt2\\approx 33.97$."
+    "mathContext": "$4^n\\le b_n\\le 64^n$; true base $(1+\\sqrt2)^4=17+12\\sqrt2\\approx 33.97$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "two-sided bounds",
+      "exponential growth rate",
+      "Apéry's irrationality squeeze",
+      "Pell numbers (1+√2)"
+    ],
+    "prerequisites": [
+      "exponential asymptotics"
+    ]
   }
 ]

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOq01Oq01Oq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOq01Oq01Oq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOq01Oq01Oq02Oq01Oq01Data: ProofData = {
+  proof: baselProblemOq01Oq01Oq02Oq01Oq01Proof,
+  annotations: baselProblemOq01Oq01Oq02Oq01Oq01Annotations,
+}

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -59,6 +59,24 @@
     "mathlib_version": "4.26.0",
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "The Apéry numbers bₙ = ∑_{k=0}^n C(n,k)²·C(n+k,k)² (1, 5, 73, 1445, 33001, …) were introduced by Roger Apéry in his celebrated 1978–1979 proof that ζ(3) = ∑ 1/m³ is irrational — a result Euler had sought but never obtained, and which Henri Cohen and Alfred van der Poorten reconstructed in van der Poorten's famous 1979 account 'A proof that Euler missed'. Apéry's argument hinges on a delicate growth estimate: the bₙ must grow geometrically with base strictly less than the cube of the denominator growth e³ so that the rational approximations to ζ(3) converge fast enough to violate Liouville-type bounds for rationals. The exact exponential base of bₙ is the irrational (1+√2)⁴ = 17 + 12√2 ≈ 33.97, the square of the dominant root of Apéry's three-term recurrence (n+1)³ uₙ₊₁ = (2n+1)(17n²+17n+5) uₙ − n³ uₙ₋₁. Capturing that base elementarily — without invoking the recurrence as an axiom — is exactly what this entry's two-sided bracket 4ⁿ ≤ bₙ ≤ 64ⁿ accomplishes on the formalization side.",
+    "problemStatement": "**Parent's open questions (basel-problem-oq-01-oq-01-oq-02-oq-01).** The parent proved the axiom-free lower bound 4ⁿ ≤ bₙ but left open (i) a matching axiom-free geometric UPPER bound bₙ ≤ Cⁿ, and (ii) the parity of bₙ. The grandparent ζ(3) file supplies the upper half only as an axiom (bₙ ≤ 34ⁿ).\n\n**Headline (aperyB_le_64_pow):** for all n, aperyB n ≤ 64 ^ n.\n\n**Parity (aperyB_odd):** for all n, Odd (aperyB n).",
+    "proofStrategy": "**Upper bound.** (1) sum_choose_sq: the diagonal Vandermonde identity ∑_{k≤n} C(n,k)² = C(2n,n), via the antidiagonal expansion of (n+n).choose n paired through Nat.choose_symm. (2) aperyB_le_centralBinom_cube: bound each C(n+k,k) ≤ C(2n,n) (Nat.choose_le_choose then Nat.choose_le_centralBinom), so bₙ ≤ (∑ C(n,k)²)·C(2n,n)² = C(2n,n)³ — the Vandermonde collapse is what keeps it geometric, not merely sub-exponential. (3) centralBinom_le_four_pow: C(2n,n) ≤ 4ⁿ by keeping a single term of ∑_i C(2n,i) = 2^(2n). (4) Chain to bₙ ≤ (4ⁿ)³ = 64ⁿ.\n\n**Parity.** two_dvd_choose_mul: the trinomial-revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) (Nat.choose_mul) exposes the central factor C(2k,k), even for k ≥ 1. Squaring keeps each k ≥ 1 summand even; aperyB_odd peels the k = 0 term (= 1) with Finset.sum_range_succ' and absorbs the even remainder.",
+    "keyInsights": [
+      "The Vandermonde collapse ∑ C(n,k)² = C(2n,n) is the crux: bounding each C(n+k,k) by C(2n,n) leaves a residual squared-binomial row that is EXACTLY the central coefficient, so no n-fold polynomial factor leaks and the upper bound stays geometric (bₙ ≤ C(2n,n)³) rather than degrading to C(2n,n)³·poly(n)",
+      "The whole upper bound is built from off-the-shelf central-binomial facts (C(n+k,k) ≤ C(2n,n) and C(2n,n) ≤ 4ⁿ), so it is fully axiom-free — it replaces the grandparent ζ(3) file's axiomatic bₙ ≤ 34ⁿ on the elementary side without re-deriving Apéry's recurrence",
+      "Parity reduces to a single divisibility: the trinomial-revision identity C(n,k)·C(n+k,k) = C(n+k,2k)·C(2k,k) surfaces the even central binomial C(2k,k) (k ≥ 1), so every summand but k = 0 vanishes mod 2 and bₙ ≡ 1",
+      "The crude base 64 versus the true (1+√2)⁴ ≈ 33.97 measures the slack in bounding every C(n+k,k) uniformly by C(2n,n); the dominant index is near k ≈ 0.8n, and a peak-localized estimate is the route to a sharper constant",
+      "Working entirely over ℕ with Nat.choose keeps the argument decidable and axiom-free (no native_decide, no real analysis), in contrast to the analytic recurrence-based bound it supersedes"
+    ],
+    "prerequisites": [
+      "Binomial coefficients and the central binomial coefficient",
+      "Vandermonde's convolution identity",
+      "Apéry's proof of the irrationality of ζ(3)",
+      "Elementary divisibility and parity arguments"
+    ]
+  },
   "leanFile": {
     "imports": [
       "Proofs.BaselProblemOQ01OQ01OQ02OQ01",


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01` (Apéry numbers axiom-free geometric bound + parity).

## Changes
- **Created `index.ts`** — was missing, so the page rendered 'proof not found' on the live site.
- **Added an `overview` block** to meta.json (the entry had none): `historicalContext` (Apéry 1979, van der Poorten 'A proof that Euler missed', the true base (1+√2)⁴≈33.97 and the three-term recurrence), `problemStatement`, `proofStrategy`, 5 `keyInsights`, `prerequisites`.
- **Enriched all 5 annotations** with `significance`, `relatedConcepts`, and `prerequisites`.

Line ranges verified against the 159-line Lean source. JSON validated. Axiom-free/odd claims confirmed against the source.