### PR TITLE
research(viviani-theorem-oq-01-oq-01-oq-02): interior witnesses of distance-sum non-constancy [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4073,6 +4073,7 @@ import Proofs.VietasFormulasOQ03OQ01
 import Proofs.VietasFormulasOQ03OQ05
 import Proofs.VietasFormulasOQ04
 import Proofs.VivianiTheorem
+import Proofs.VivianiTheoremOQ01OQ01OQ02
 import Proofs.WeakGoldbach
 import Proofs.WeitzenbockInequalityOQ01
 import Proofs.WeitzenbockInequalityOQ01OQ01

--- a/proofs/Proofs/VivianiTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/VivianiTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,150 @@
+import Mathlib
+import Proofs.VivianiTheoremOQ01OQ01
+
+/-
+# Viviani's Theorem — OQ-01-OQ-01-OQ-02: interior witnesses of non-constancy
+
+## Research Problem: viviani-theorem-oq-01-oq-01-oq-02
+
+The parent `viviani-theorem-oq-01-oq-01` proves the *converse* of Viviani's
+theorem as a characterisation:
+
+    the signed distance-sum `sumDist A B C P` is independent of `P`
+        ⇔   the triangle `A B C` is equilateral.
+
+Negating the right-hand side gives only the abstract statement that for a
+non-equilateral triangle the distance-sum is non-constant *somewhere in the
+plane*.  This leaf sharpens the negation to a **constructive, interior**
+statement, which is what one really wants geometrically:
+
+    a non-degenerate, non-equilateral triangle has **two points in its open
+    interior** with distinct distance-sums.
+
+(On the open interior all three inward signed distances are positive, so there
+the signed `sumDist` coincides with the genuine perpendicular-distance sum of
+the classical statement; the witnesses are therefore witnesses for the honest
+Viviani distance-sum, not merely for its signed extension.)
+
+## The construction
+
+The signed distance-sum is affine with constant gradient
+`g = n_A + n_B + n_C` (parent lemma `sumDist_sub`).  Non-equilaterality forces
+`g ≠ 0` (parent `viviani_converse` ∘ `const_iff_normalSum_zero`).  Since the two
+edge vectors `B − A` and `C − A` span the plane (non-degeneracy), `g` cannot be
+orthogonal to both, so `⟪g, B−A⟫ ≠ 0` or `⟪g, C−A⟫ ≠ 0`.  Perturbing the
+centroid by `±1/6` of the barycentric weight along that edge produces two points
+with all-positive barycentric coordinates — hence interior — whose distance-sums
+differ by `⅓·⟪g, edge⟫ ≠ 0`.
+
+We reuse the parent's plane model `ℂ`, the real inner product `rdot`, the inward
+unit normals `nA, nB, nC`, and the distance-sum `sumDist`.  Verified, 0 axioms.
+
+Tags: geometry, viviani, interior, barycentric, equilateral-triangle, non-constant
+-/
+
+namespace VivianiTheoremOQ01OQ01OQ02
+
+open Complex VivianiTheoremOQ01OQ01
+
+/-- A point `P` lies in the **open interior** of triangle `A B C` when it is a
+strictly-positive barycentric combination of the vertices. -/
+def IsInterior (A B C P : ℂ) : Prop :=
+  ∃ α β γ : ℝ, 0 < α ∧ 0 < β ∧ 0 < γ ∧ α + β + γ = 1 ∧
+    P = α • A + β • B + γ • C
+
+/-- **Interior witnesses of non-constancy.**  For a non-degenerate
+(`hnd`: non-zero edge determinant) and non-equilateral (`hne`) planar triangle
+`A B C`, there are two points `P, Q` in the open interior whose signed
+distance-sums differ.  Equivalently: the Viviani distance-sum, constant on an
+equilateral triangle, is provably non-constant *already inside* any triangle that
+fails to be equilateral. -/
+theorem viviani_interior_witnesses {A B C : ℂ}
+    (hnd : (C - B).re * (A - C).im - (C - B).im * (A - C).re ≠ 0)
+    (hne : ¬ (‖C - B‖ = ‖A - C‖ ∧ ‖A - C‖ = ‖B - A‖)) :
+    ∃ P Q : ℂ, IsInterior A B C P ∧ IsInterior A B C Q ∧
+      sumDist A B C P ≠ sumDist A B C Q := by
+  -- The non-degeneracy in the `(B−A, C−A)` basis (equal to `hnd` by a `ring`).
+  have hdm : (B - A).re * (C - A).im - (B - A).im * (C - A).re ≠ 0 := by
+    have h : (B - A).re * (C - A).im - (B - A).im * (C - A).re
+        = (C - B).re * (A - C).im - (C - B).im * (A - C).re := by
+      simp only [Complex.sub_re, Complex.sub_im]; ring
+    rw [h]; exact hnd
+  -- Non-equilateral ⇒ the gradient (normal sum) is non-zero.
+  have hg : nA A B C + nB A B C + nC A B C ≠ 0 := by
+    intro h0
+    exact hne ((viviani_converse hnd).mp
+      ((const_iff_normalSum_zero (nA A B C) (nB A B C) (nC A B C) B C A).mpr h0))
+  set g : ℂ := nA A B C + nB A B C + nC A B C with hgdef
+  -- The gradient is not orthogonal to both spanning edges.
+  have hsplit : rdot g (B - A) ≠ 0 ∨ rdot g (C - A) ≠ 0 := by
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨h1, h2⟩ := hcon
+    apply hg
+    have e1 : g.re * (B - A).re + g.im * (B - A).im = 0 := h1
+    have e2 : g.re * (C - A).re + g.im * (C - A).im = 0 := h2
+    have hre : g.re = 0 := by
+      have hh : g.re * ((B - A).re * (C - A).im - (B - A).im * (C - A).re) = 0 := by
+        linear_combination (C - A).im * e1 - (B - A).im * e2
+      exact (mul_eq_zero.mp hh).resolve_right hdm
+    have him : g.im = 0 := by
+      have hh : g.im * ((B - A).re * (C - A).im - (B - A).im * (C - A).re) = 0 := by
+        linear_combination (B - A).re * e2 - (C - A).re * e1
+      exact (mul_eq_zero.mp hh).resolve_right hdm
+    exact Complex.ext (hre.trans Complex.zero_re.symm) (him.trans Complex.zero_im.symm)
+  rcases hsplit with hd | hd
+  · -- perturb the `A`/`B` barycentric weights along edge `B − A`
+    refine ⟨(1/6 : ℝ) • A + (1/2 : ℝ) • B + (1/3 : ℝ) • C,
+            (1/2 : ℝ) • A + (1/6 : ℝ) • B + (1/3 : ℝ) • C, ?_, ?_, ?_⟩
+    · exact ⟨1/6, 1/2, 1/3, by norm_num, by norm_num, by norm_num, by norm_num, rfl⟩
+    · exact ⟨1/2, 1/6, 1/3, by norm_num, by norm_num, by norm_num, by norm_num, rfl⟩
+    · intro hEq
+      have key : sumDist A B C ((1/6 : ℝ) • A + (1/2 : ℝ) • B + (1/3 : ℝ) • C)
+            - sumDist A B C ((1/2 : ℝ) • A + (1/6 : ℝ) • B + (1/3 : ℝ) • C)
+          = rdot g (((1/6 : ℝ) • A + (1/2 : ℝ) • B + (1/3 : ℝ) • C)
+              - ((1/2 : ℝ) • A + (1/6 : ℝ) • B + (1/3 : ℝ) • C)) := by
+        rw [hgdef]
+        exact sumDist_sub (nA A B C) (nB A B C) (nC A B C) B C A _ _
+      rw [hEq, sub_self] at key
+      have hPQ : rdot g (((1/6 : ℝ) • A + (1/2 : ℝ) • B + (1/3 : ℝ) • C)
+            - ((1/2 : ℝ) • A + (1/6 : ℝ) • B + (1/3 : ℝ) • C))
+          = (1/3 : ℝ) * rdot g (B - A) := by
+        simp only [rdot, Complex.real_smul, Complex.sub_re, Complex.sub_im,
+          Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+          Complex.ofReal_re, Complex.ofReal_im]; ring
+      rw [hPQ] at key
+      exact hd (by linarith)
+  · -- perturb the `A`/`C` barycentric weights along edge `C − A`
+    refine ⟨(1/6 : ℝ) • A + (1/3 : ℝ) • B + (1/2 : ℝ) • C,
+            (1/2 : ℝ) • A + (1/3 : ℝ) • B + (1/6 : ℝ) • C, ?_, ?_, ?_⟩
+    · exact ⟨1/6, 1/3, 1/2, by norm_num, by norm_num, by norm_num, by norm_num, rfl⟩
+    · exact ⟨1/2, 1/3, 1/6, by norm_num, by norm_num, by norm_num, by norm_num, rfl⟩
+    · intro hEq
+      have key : sumDist A B C ((1/6 : ℝ) • A + (1/3 : ℝ) • B + (1/2 : ℝ) • C)
+            - sumDist A B C ((1/2 : ℝ) • A + (1/3 : ℝ) • B + (1/6 : ℝ) • C)
+          = rdot g (((1/6 : ℝ) • A + (1/3 : ℝ) • B + (1/2 : ℝ) • C)
+              - ((1/2 : ℝ) • A + (1/3 : ℝ) • B + (1/6 : ℝ) • C)) := by
+        rw [hgdef]
+        exact sumDist_sub (nA A B C) (nB A B C) (nC A B C) B C A _ _
+      rw [hEq, sub_self] at key
+      have hPQ : rdot g (((1/6 : ℝ) • A + (1/3 : ℝ) • B + (1/2 : ℝ) • C)
+            - ((1/2 : ℝ) • A + (1/3 : ℝ) • B + (1/6 : ℝ) • C))
+          = (1/3 : ℝ) * rdot g (C - A) := by
+        simp only [rdot, Complex.real_smul, Complex.sub_re, Complex.sub_im,
+          Complex.add_re, Complex.add_im, Complex.mul_re, Complex.mul_im,
+          Complex.ofReal_re, Complex.ofReal_im]; ring
+      rw [hPQ] at key
+      exact hd (by linarith)
+
+/-- **Restatement.**  The Viviani signed distance-sum of a non-degenerate,
+non-equilateral triangle is not a constant function on its interior: there is no
+real number it equals at every interior point. -/
+theorem sumDist_not_constant_on_interior {A B C : ℂ}
+    (hnd : (C - B).re * (A - C).im - (C - B).im * (A - C).re ≠ 0)
+    (hne : ¬ (‖C - B‖ = ‖A - C‖ ∧ ‖A - C‖ = ‖B - A‖)) :
+    ¬ ∃ k : ℝ, ∀ P : ℂ, IsInterior A B C P → sumDist A B C P = k := by
+  rintro ⟨k, hk⟩
+  obtain ⟨P, Q, hP, hQ, hPQ⟩ := viviani_interior_witnesses hnd hne
+  exact hPQ ((hk P hP).trans (hk Q hQ).symm)
+
+end VivianiTheoremOQ01OQ01OQ02

--- a/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,69 @@
+[
+  {
+    "id": "ann-isinterior-def",
+    "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 49,
+      "endLine": 53
+    },
+    "type": "definition",
+    "title": "The Open Interior via Strictly-Positive Barycentric Coordinates",
+    "content": "`IsInterior A B C P` holds when `P = α•A + β•B + γ•C` for some real weights `α, β, γ > 0` with `α + β + γ = 1`. This is precisely the open interior of the triangle: the relatively-interior points of the simplex spanned by the three vertices. It is the region on which the signed distance-sum `sumDist` coincides with the genuine perpendicular-distance sum of the classical Viviani statement, and the domain in which the witnesses must lie for the result to be geometrically meaningful.",
+    "mathContext": "$P = \\alpha A + \\beta B + \\gamma C$ with $\\alpha,\\beta,\\gamma > 0$, $\\alpha+\\beta+\\gamma = 1$; the centroid is the symmetric point $\\alpha=\\beta=\\gamma=\\tfrac13$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "barycentric coordinates",
+      "open interior of a triangle",
+      "convex combination"
+    ],
+    "prerequisites": [
+      "affine combinations",
+      "simplices"
+    ]
+  },
+  {
+    "id": "ann-interior-witnesses",
+    "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 61,
+      "endLine": 139
+    },
+    "type": "theorem",
+    "title": "Interior Witnesses of Non-Constancy",
+    "content": "`viviani_interior_witnesses`: a non-degenerate, non-equilateral triangle has two interior points P, Q with `sumDist A B C P ≠ sumDist A B C Q`. The proof rewrites the parent's non-degeneracy determinant into the (B−A, C−A) basis, derives that the gradient g = nA+nB+nC is non-zero (non-equilaterality, via the parent's viviani_converse and const_iff_normalSum_zero), and shows by a 2×2 Cramer argument that g cannot be rdot-orthogonal to both spanning edges. Perturbing the centroid by ±1/6 of the barycentric weight along the non-orthogonal edge yields interior witnesses with coordinates (1/6,1/2,1/3) and (1/2,1/6,1/3), whose distance-sums differ by ⅓·⟪g, edge⟫ ≠ 0 (computed via the parent's sumDist_sub).",
+    "mathContext": "$\\mathrm{sumDist}(P)-\\mathrm{sumDist}(Q) = \\langle g, P-Q\\rangle$ with $g = n_A+n_B+n_C \\neq 0$; the witnesses give $P-Q = \\tfrac13(\\text{edge})$, so the gap is $\\tfrac13\\langle g,\\text{edge}\\rangle \\neq 0$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Viviani's theorem",
+      "affine functional",
+      "gradient",
+      "Cramer's rule",
+      "centroid perturbation"
+    ],
+    "prerequisites": [
+      "the parent converse (sumDist, sumDist_sub, viviani_converse)",
+      "real inner product and orthogonality",
+      "2×2 determinants"
+    ]
+  },
+  {
+    "id": "ann-not-constant",
+    "proofId": "viviani-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 142,
+      "endLine": 149
+    },
+    "type": "theorem",
+    "title": "No Constant Value on the Interior",
+    "content": "`sumDist_not_constant_on_interior`: for a non-degenerate, non-equilateral triangle there is no real number `k` such that `sumDist A B C P = k` for every interior point `P`. This is the packaged contrapositive form of the witness theorem — directly contradicting any claimed constant value by feeding the two distinct-sum interior witnesses through it — and it is the explicit realisation of the interior-witness open question recorded by the sibling entry viviani-theorem-oq-01-oq-01-oq-01.",
+    "mathContext": "$\\neg\\,\\exists k,\\ \\forall P \\in \\mathrm{int}(ABC),\\ \\mathrm{sumDist}(P) = k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "non-constant functional",
+      "converse of Viviani's theorem"
+    ],
+    "prerequisites": [
+      "viviani_interior_witnesses"
+    ]
+  }
+]

--- a/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/viviani-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "viviani-theorem-oq-01-oq-01-oq-02",
+  "title": "Viviani Interior Witnesses: a Non-Equilateral Triangle Has Two Interior Points With Distinct Distance-Sums",
+  "slug": "viviani-theorem-oq-01-oq-01-oq-02",
+  "description": "A constructive, interior sharpening of the converse of Viviani's theorem. The parent (viviani-theorem-oq-01-oq-01) characterises constant distance-sum by equilaterality: the signed perpendicular-distance sum sumDist A B C P is independent of P ⇔ the triangle is equilateral. Negating that equivalence only yields non-constancy of the distance-sum somewhere in the whole plane. This leaf strengthens the negation to an explicit, geometrically honest statement: a non-degenerate, non-equilateral triangle has two points in its open interior (strictly-positive barycentric coordinates) whose distance-sums differ. The witnesses are centroid perturbations: since the distance-sum is affine with constant gradient g = n_A+n_B+n_C, non-equilaterality forces g ≠ 0, and as the two edge vectors B−A, C−A span the plane, g is not orthogonal to both; moving ±1/6 of the barycentric weight along the non-orthogonal edge gives two interior points with distance-sums differing by ⅓·⟪g, edge⟫ ≠ 0. On the interior all three inward signed distances are positive, so sumDist there equals the genuine perpendicular-distance sum of the classical statement. Verified, 0 axioms. Refines the parent converse and realises the interior-witness open question of the sibling viviani-theorem-oq-01-oq-01-oq-01.",
+  "meta": {
+    "author": "Robb Walters (researcher-3)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VivianiTheoremOQ01OQ01OQ02.lean",
+    "tags": [
+      "geometry",
+      "viviani",
+      "interior",
+      "barycentric",
+      "equilateral-triangle",
+      "non-constant",
+      "affine-functional",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 150,
+    "assumptions": "No axioms or sorries. Theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions). Verified via #print axioms. The witness theorem carries two standard mathematical hypotheses on the triangle — non-degeneracy (the edge determinant / signed area is non-zero) and non-equilaterality — neither of which is an axiom.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "viviani_interior_witnesses: for a non-degenerate, non-equilateral planar triangle there exist two points P, Q in the open interior (strictly-positive barycentric coordinates) with sumDist A B C P ≠ sumDist A B C Q — the constructive interior refinement of the parent's converse, not merely a non-constructive negation over the whole plane",
+      "An explicit centroid-perturbation construction: the witnesses are the points obtained by shifting ±1/6 of the barycentric weight between two vertices, giving all-positive coordinates (1/6, 1/2, 1/3) and (1/2, 1/6, 1/3), hence genuinely interior, with the distance-sum gap computed in closed form as ⅓·⟪g, edge⟫",
+      "The orthogonality-splitting lemma: the gradient g = n_A+n_B+n_C of a non-equilateral triangle cannot be rdot-orthogonal to both spanning edges B−A and C−A, proved from the non-zero edge determinant by a 2×2 Cramer argument (linear_combination), so at least one edge perturbation moves the distance-sum",
+      "IsInterior via strictly-positive barycentric coordinates: a self-contained open-interior predicate P = α•A+β•B+γ•C with α,β,γ > 0 and α+β+γ = 1, the natural domain on which the signed sumDist coincides with the classical perpendicular-distance sum",
+      "sumDist_not_constant_on_interior: the packaged restatement that no single real value is taken by the distance-sum at every interior point, realising the interior-witness open question posed by the sibling entry viviani-theorem-oq-01-oq-01-oq-01"
+    ],
+    "theoremCount": 2,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.VivianiTheoremOQ01OQ01"
+    ],
+    "namespace": "VivianiTheoremOQ01OQ01OQ02",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 1,
+    "path": "Proofs/VivianiTheoremOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Viviani's theorem (1659) states that inside an equilateral triangle the sum of the perpendicular distances from any interior point to the three sides is constant (the altitude). The gallery's parent chain proved the forward direction (viviani-theorem-oq-01) and the converse characterisation (viviani-theorem-oq-01-oq-01): the signed distance-sum is constant over the plane if and only if the triangle is equilateral. That converse settles when the distance-sum IS constant, but says nothing constructive about the failure of constancy: logically, ¬equilateral only delivers 'two points somewhere in the plane with distinct sums'. Geometrically one wants the witnesses to live inside the triangle, where the signed distance-sum is the honest perpendicular-distance sum of the classical statement. This leaf supplies exactly that — explicit interior witnesses — and so realises the interior-witness open question recorded by the sibling entry viviani-theorem-oq-01-oq-01-oq-01.",
+    "problemStatement": "Let A B C be a non-degenerate (non-zero signed area) and non-equilateral planar triangle. Prove that there exist two points P, Q in the open interior of the triangle — points with strictly-positive barycentric coordinates — at which the Viviani distance-sums differ: sumDist A B C P ≠ sumDist A B C Q. Equivalently, the distance-sum, constant on an equilateral triangle, is provably non-constant already inside any triangle that fails to be equilateral.",
+    "text": "The plane is modeled as ℂ with the parent's real inner product rdot z w = z.re·w.re + z.im·w.im, inward unit normals nA, nB, nC, and signed distance-sum sumDist A B C P = ⟪nA,P−B⟫ + ⟪nB,P−C⟫ + ⟪nC,P−A⟫. The parent's sumDist_sub identity shows this is affine with constant gradient g = nA+nB+nC: sumDist P − sumDist Q = ⟪g, P−Q⟫. Non-equilaterality forces g ≠ 0 (compose the parent's viviani_converse with const_iff_normalSum_zero). Because the two edge vectors B−A and C−A span the plane (non-degeneracy), g cannot be rdot-orthogonal to both, so ⟪g,B−A⟫ ≠ 0 or ⟪g,C−A⟫ ≠ 0. Perturbing the centroid by ±1/6 of the barycentric weight along the non-orthogonal edge yields two points with barycentric coordinates (1/6,1/2,1/3) and (1/2,1/6,1/3) — all strictly positive, hence interior — whose distance-sums differ by ⅓·⟪g,edge⟫ ≠ 0.",
+    "proofStrategy": "1. IsInterior A B C P := ∃ α β γ > 0, α+β+γ = 1 ∧ P = α•A+β•B+γ•C — the open-interior predicate via strictly-positive barycentric coordinates. 2. Rewrite the parent's non-degeneracy (edge determinant in C−B, A−C) into the B−A, C−A basis by a ring identity (hdm). 3. Non-equilaterality ⇒ g ≠ 0: feed the contrapositive of viviani_converse hnd through const_iff_normalSum_zero. 4. Orthogonality split: if ⟪g,B−A⟫ = 0 and ⟪g,C−A⟫ = 0, a 2×2 Cramer argument (linear_combination against the edge determinant) forces g.re = g.im = 0, contradicting g ≠ 0; hence one inner product is non-zero. 5. Construction: in each case provide the explicit centroid perturbations as witnesses, discharge interiority by norm_num on the barycentric weights, and compute the distance-sum gap via sumDist_sub and a simp/ring normalisation to ⅓·⟪g,edge⟫, contradicting any claimed equality.",
+    "keyInsights": [
+      "The converse's negation needs constructive, interior content: ¬equilateral abstractly gives only 'distinct sums somewhere in the plane', whereas the geometrically meaningful claim is two witnesses inside the triangle, where signed sumDist equals the genuine perpendicular-distance sum.",
+      "The whole obstruction is one non-zero vector: the affine distance-sum has constant gradient g = nA+nB+nC, and non-equilaterality is exactly g ≠ 0, so producing witnesses reduces to moving in a direction not orthogonal to g.",
+      "Non-degeneracy guarantees a usable direction: since B−A and C−A span the plane, g cannot be orthogonal to both edges (positive-definiteness of rdot), so at least one edge perturbation changes the distance-sum — a 2×2 determinant / Cramer fact.",
+      "Barycentric bookkeeping keeps the witnesses honestly interior: shifting ±1/6 of the weight between two vertices keeps all three coordinates strictly positive (the centroid 1/3,1/3,1/3 has margin 1/3 > 1/6), so the construction never leaves the open triangle, and the gap is the closed form ⅓·⟪g, edge⟫.",
+      "The leaf reuses the parent's affine machinery verbatim (sumDist_sub, const_iff_normalSum_zero, viviani_converse), isolating the new mathematical content as the interior construction rather than re-deriving the inner-product/normal scaffold."
+    ],
+    "prerequisites": [
+      "The parent converse of Viviani's theorem (viviani-theorem-oq-01-oq-01): rdot, the inward normals nA/nB/nC, sumDist, sumDist_sub, const_iff_normalSum_zero, viviani_converse",
+      "Barycentric coordinates and the open interior of a triangle as strictly-positive barycentric combinations",
+      "A real inner product on the plane ℂ: bilinearity, positive-definiteness, and orthogonality / 2×2 determinants",
+      "Lean 4 tactics linear_combination, norm_num, simp with the Complex re/im API, linarith"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-interior",
+      "title": "Part I: The Open-Interior Predicate",
+      "startLine": 49,
+      "endLine": 55,
+      "summary": "IsInterior A B C P captures the open interior of the triangle as the set of strictly-positive barycentric combinations P = α•A+β•B+γ•C with α,β,γ > 0 and α+β+γ = 1 — the region on which the signed distance-sum sumDist coincides with the genuine perpendicular-distance sum, and the domain in which the witnesses are required to lie."
+    },
+    {
+      "id": "part2-witnesses",
+      "title": "Part II: Interior Witnesses of Non-Constancy",
+      "startLine": 56,
+      "endLine": 139,
+      "summary": "viviani_interior_witnesses: rewrite non-degeneracy into the (B−A, C−A) basis (hdm); derive g = nA+nB+nC ≠ 0 from non-equilaterality via viviani_converse and const_iff_normalSum_zero; prove by a 2×2 Cramer argument that g is not rdot-orthogonal to both edges; then in each case exhibit the centroid perturbations (barycentric weights (1/6,1/2,1/3) and (1/2,1/6,1/3)) as interior witnesses and compute the distance-sum gap ⅓·⟪g,edge⟫ ≠ 0 via the parent's sumDist_sub."
+    },
+    {
+      "id": "part3-restatement",
+      "title": "Part III: No Constant Value on the Interior",
+      "startLine": 140,
+      "endLine": 150,
+      "summary": "sumDist_not_constant_on_interior packages the witnesses as the statement that no single real number equals the distance-sum at every interior point, the explicit form of the interior-witness open question of the sibling entry."
+    }
+  ],
+  "conclusion": {
+    "summary": "The converse of Viviani's theorem is sharpened from a plane-wide equivalence into a constructive interior statement: every non-degenerate, non-equilateral triangle contains two interior points whose perpendicular-distance sums differ. The witnesses are explicit centroid perturbations along an edge not orthogonal to the distance-sum gradient g = nA+nB+nC, with all-positive barycentric coordinates and a closed-form gap ⅓·⟪g,edge⟫. The proof reuses the parent's affine reduction and inner-product scaffold, isolating the new content as the interior construction and the orthogonality-splitting lemma. Verified, 0 axioms, 0 sorries.",
+    "openQuestions": [
+      "Quantify the maximal interior distance-sum gap: among all interior pairs, maximise |⟪g, P−Q⟫| and identify the optimal witnesses (a vertex-to-vertex direction aligned with g), giving a sharp measure of how far a triangle is from the Viviani property.",
+      "Extend the explicit interior-witness construction to the convex n-gon non-closing case (∑ᵢ νᵢ = V ≠ 0) of viviani-theorem-oq-01-oq-01-oq-01, exhibiting two interior points of the polygon with distinct distance-sums.",
+      "Relate the gap ⅓·⟪g, edge⟫ to a metric defect of equilaterality (e.g. a function of the side-length differences |a−b|, |b−c|), turning the qualitative non-constancy into a quantitative inequality."
+    ],
+    "implications": "Completes the qualitative picture of the Viviani converse by making its failure constructive and interior: not only is equilaterality necessary for a constant distance-sum, but its absence is witnessed by an explicit pair of honest interior points. The centroid-perturbation / non-orthogonal-gradient mechanism is a reusable template for turning 'an affine functional is non-constant' into explicit interior witnesses, applicable to barycentric and distance-functional arguments throughout Euclidean geometry."
+  },
+  "crossReferences": [
+    {
+      "targetId": "viviani-theorem-oq-01-oq-01",
+      "relationship": "parent-problem",
+      "description": "Refines the parent's converse characterisation (constant distance-sum ⇔ equilateral). Where the parent settles when the distance-sum is constant, this leaf makes the failure of constancy constructive and interior, reusing the parent's sumDist, sumDist_sub, const_iff_normalSum_zero and viviani_converse."
+    },
+    {
+      "targetId": "viviani-theorem-oq-01-oq-01-oq-01",
+      "relationship": "sibling-problem",
+      "description": "Realises the interior-witness open question of the sibling n-gon entry: that entry asked for the explicit pair of interior points realising the distance-sum gap in the non-closing case ∑ᵢ νᵢ ≠ 0; this entry answers it for the triangle, with the gap given in closed form."
+    },
+    {
+      "targetId": "viviani-theorem-oq-01",
+      "relationship": "ancestor-problem",
+      "description": "The original forward direction of Viviani's theorem for the equilateral triangle; this entry is the constructive interior refinement of its converse two levels down the open-question tree."
+    }
+  ],
+  "references": [
+    {
+      "author": "Vincenzo Viviani",
+      "title": "Viviani's theorem (constant sum of distances to the sides of an equilateral triangle)",
+      "year": 1659,
+      "note": "Classical equilateral-triangle case; this entry establishes constructive interior witnesses for the failure of the converse on non-equilateral triangles."
+    }
+  ]
+}

--- a/src/data/research/problems/viviani-theorem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/viviani-theorem-oq-01-oq-01-oq-02.json
@@ -1,0 +1,45 @@
+{
+  "slug": "viviani-theorem-oq-01-oq-01-oq-02",
+  "status": "active",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "title": "Viviani interior witnesses: a non-equilateral triangle has two interior points with distinct distance-sums",
+  "problemStatement": "Sharpen the negation of the parent's converse of Viviani's theorem. The parent proves the signed perpendicular-distance sum sumDist A B C P is independent of P iff the triangle is equilateral; ¬equilateral only yields non-constancy somewhere in the plane. Prove the constructive interior form: a non-degenerate, non-equilateral triangle has two points in its open interior (strictly-positive barycentric coordinates) at which the distance-sums differ.",
+  "tags": [
+    "geometry",
+    "viviani",
+    "interior",
+    "barycentric",
+    "equilateral-triangle",
+    "affine-functional",
+    "research"
+  ],
+  "leanFiles": [
+    "proofs/Proofs/VivianiTheoremOQ01OQ01OQ02.lean"
+  ],
+  "relatedProofs": [
+    "viviani-theorem-oq-01-oq-01",
+    "viviani-theorem-oq-01-oq-01-oq-01",
+    "viviani-theorem-oq-01"
+  ],
+  "knownResults": [
+    "Parent viviani-theorem-oq-01-oq-01 proves the converse: sumDist is constant on the whole plane ⇔ the triangle is equilateral, via an affine/gradient reduction (constant ⇔ normals sum to zero) plus a normal-vector lemma (normals sum to zero ⇔ equal sides).",
+    "Sibling viviani-theorem-oq-01-oq-01-oq-01 generalises the affine half to convex n-gons and records, as an open question, the explicit interior pair realising the distance-sum gap in the non-closing case ∑ᵢνᵢ ≠ 0 — which this entry answers for the triangle."
+  ],
+  "currentState": "COMPLETE: 0 sorries, 0 axioms (only foundational propext/Classical.choice/Quot.sound). 2 theorems, 1 definition, 150 lines. Builds clean via host lake env lean against the Mathlib cache, importing the parent Proofs.VivianiTheoremOQ01OQ01.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Strengthened the parent's converse of Viviani's theorem from a plane-wide equivalence to a constructive interior statement. Proved viviani_interior_witnesses (a non-degenerate, non-equilateral triangle has two open-interior points with distinct signed distance-sums) and sumDist_not_constant_on_interior (no constant value on the interior). Witnesses are explicit centroid perturbations with all-positive barycentric coordinates; the distance-sum gap is the closed form ⅓·⟪g, edge⟫ for the gradient g = nA+nB+nC. Reuses the parent's affine machinery (sumDist, sumDist_sub, const_iff_normalSum_zero, viviani_converse).",
+    "builtItems": [
+      "IsInterior A B C P: the open interior as strictly-positive barycentric combinations P = α•A+β•B+γ•C, α,β,γ > 0, α+β+γ = 1",
+      "viviani_interior_witnesses: ∃ two interior points with distinct sumDist for any non-degenerate non-equilateral triangle, via gradient-direction centroid perturbation",
+      "Orthogonality-splitting step: g = nA+nB+nC ≠ 0 cannot be rdot-orthogonal to both edges B−A, C−A (2×2 Cramer / linear_combination against the non-zero edge determinant)",
+      "Closed-form gap: distance-sum difference of the witnesses equals ⅓·⟪g, edge⟫, computed via the parent's sumDist_sub and a simp/ring normalisation",
+      "sumDist_not_constant_on_interior: no real k equals sumDist at every interior point — the explicit form of the sibling's interior-witness open question"
+    ],
+    "insights": [
+      "The negation of the Viviani converse becomes constructive and interior once one observes the distance-sum is affine with constant gradient g = nA+nB+nC, so ¬equilateral is exactly g ≠ 0 and witnesses come from moving in a direction not orthogonal to g.",
+      "Non-degeneracy (the two edges span the plane) guarantees g is not orthogonal to both edges, by positive-definiteness of the real inner product — a 2×2 determinant fact — so at least one edge perturbation changes the distance-sum.",
+      "Shifting ±1/6 of the barycentric weight between two vertices keeps all coordinates strictly positive (the centroid has margin 1/3 > 1/6), so the witnesses stay honestly inside the open triangle while still separating the distance-sums."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

A constructive, **interior** sharpening of the converse of Viviani's theorem.

The parent `viviani-theorem-oq-01-oq-01` characterises constant distance-sum by equilaterality: the signed perpendicular-distance sum `sumDist A B C P` is independent of `P` ⇔ the triangle is equilateral. Logically negating that equivalence yields only "two points *somewhere in the plane* with distinct sums". Geometrically one wants the witnesses to live **inside** the triangle, where the signed sum equals the genuine perpendicular-distance sum of the classical statement. This leaf supplies exactly that.

## Results

- **`viviani_interior_witnesses`** — a non-degenerate, non-equilateral triangle has two points `P, Q` in its **open interior** (strictly-positive barycentric coordinates) with `sumDist A B C P ≠ sumDist A B C Q`.
- **`sumDist_not_constant_on_interior`** — no single real value is taken by the distance-sum at every interior point (the explicit form of the interior-witness open question recorded by the sibling `viviani-theorem-oq-01-oq-01-oq-01`).
- **`IsInterior`** — the open interior as strictly-positive barycentric combinations `P = α•A+β•B+γ•C`, `α,β,γ > 0`, `α+β+γ = 1`.

## Construction

The distance-sum is affine with constant gradient `g = nA+nB+nC` (parent `sumDist_sub`). Non-equilaterality forces `g ≠ 0` (parent `viviani_converse` ∘ `const_iff_normalSum_zero`). Since the edge vectors `B−A`, `C−A` span the plane (non-degeneracy), `g` cannot be `rdot`-orthogonal to both — a 2×2 Cramer argument. Perturbing the centroid by `±1/6` of the barycentric weight along the non-orthogonal edge gives interior witnesses `(1/6,1/2,1/3)` and `(1/2,1/6,1/3)` whose sums differ by the closed form `⅓·⟪g, edge⟫ ≠ 0`.

## Verification

- 2 theorems, 1 definition, 150 lines, **0 sorries, 0 axioms**.
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (the Lean/Mathlib foundational standard — not assumptions).
- Builds clean via host `lake env lean` against the Mathlib cache, importing the parent `Proofs.VivianiTheoremOQ01OQ01`.
- The witness theorem carries two standard mathematical hypotheses on the triangle — non-degeneracy (non-zero signed area) and non-equilaterality — neither an axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)