### PR TITLE
research(dilworth-theorem-oq-01-oq-01-oq-03): Erdős–Szekeres from Mirsky via the common min–max bound [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -992,6 +992,7 @@ import Proofs.DescartesRuleOfSignsOQ03
 import Proofs.DescartesRuleOfSignsOQ04
 import Proofs.DetConjugateTransposeOQ01
 import Proofs.DiamondImpliesCH
+import Proofs.DilworthErdosSzekeresOQ010103
 import Proofs.DilworthMirskyHardOQ01
 import Proofs.DilworthTheoremOQ01
 import Proofs.DilworthTheoremOQ01OQ01OQ02

--- a/proofs/Proofs/DilworthErdosSzekeresOQ010103.lean
+++ b/proofs/Proofs/DilworthErdosSzekeresOQ010103.lean
@@ -1,0 +1,226 @@
+/-
+  The common min–max framework: from Mirsky to Erdős–Szekeres.
+  (dilworth-theorem-oq-01-oq-01-oq-03)
+
+  ## Background
+
+  The companion files supply the two halves of the Dilworth/Mirsky picture for a
+  finite poset:
+
+  * `Proofs.DilworthTheoremOQ01` — the *easy* directions (a chain meets an
+    antichain in at most one point), together with `IsChainOn` / `IsAntichainOn`.
+  * `Proofs.DilworthMirskyHardOQ01` — **Mirsky's hard direction**: the height /
+    level decomposition covers the poset by exactly `maxChainLen` antichains
+    (`mirsky_antichain_cover`).
+
+  ## What this file adds
+
+  The open question asks to tie Mirsky and Dilworth together through a *common
+  min–max framework* and to obtain **Erdős–Szekeres** as an application.  The
+  bridge is a single counting inequality:
+
+      `card α ≤ maxChainLen · maxAntichainLen`        (`card_le_maxChainLen_mul_maxAntichainLen`)
+
+  Mirsky covers the poset by `maxChainLen` antichains, and each antichain has at
+  most `maxAntichainLen` elements; multiplying gives the bound.  Its contrapositive
+  is the **Erdős–Szekeres dichotomy**
+
+      `r·s < card α  ⟹  (a chain of size > r)  ∨  (an antichain of size > s)`
+
+  (`exists_long_chain_or_antichain`).  Specialised to the poset on positions of a
+  finite sequence `f : Fin N → ℝ`, ordered by `i ≼ j ↔ i ≤ j ∧ f i ≤ f j`, chains
+  are non-decreasing subsequences and antichains are strictly decreasing ones, and
+  the dichotomy becomes the classical Erdős–Szekeres theorem
+  (`erdos_szekeres_seq`): every sequence of more than `r·s` reals has a
+  non-decreasing run of length `> r` or a strictly decreasing run of length `> s`.
+
+  ## Status: 0 axioms, 0 sorries.
+-/
+import Proofs.DilworthMirskyHardOQ01
+
+open Classical
+
+attribute [local instance] Classical.propDecidable
+
+namespace DilworthTheoremOQ01
+
+variable {α : Type*} [PartialOrder α] [Fintype α]
+
+/-! ### Maximum antichain length -/
+
+/-- All antichains of the (finite) poset. -/
+noncomputable def allAntichains : Finset (Finset α) :=
+  Finset.univ.powerset.filter (fun A => IsAntichainOn A)
+
+/-- `maxAntichainLen` = the size of a largest antichain. -/
+noncomputable def maxAntichainLen : ℕ := (allAntichains (α := α)).sup Finset.card
+
+theorem mem_allAntichains {A : Finset α} : A ∈ allAntichains ↔ IsAntichainOn A := by
+  unfold allAntichains
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨fun h => h.2, fun h => ⟨Finset.subset_univ _, h⟩⟩
+
+/-- Every antichain is no larger than `maxAntichainLen`. -/
+theorem antichain_card_le_maxAntichainLen {A : Finset α} (hA : IsAntichainOn A) :
+    A.card ≤ maxAntichainLen (α := α) :=
+  Finset.le_sup (f := Finset.card) (mem_allAntichains.mpr hA)
+
+/-- `maxAntichainLen` is attained by an actual antichain. -/
+theorem exists_antichain_card_eq_maxAntichainLen :
+    ∃ A : Finset α, IsAntichainOn A ∧ A.card = maxAntichainLen (α := α) := by
+  have hne : (allAntichains (α := α)).Nonempty :=
+    ⟨∅, mem_allAntichains.mpr (by intro x hx; exact absurd hx (Finset.notMem_empty x))⟩
+  obtain ⟨A, hA, hCard⟩ :=
+    Finset.exists_mem_eq_sup (allAntichains (α := α)) hne Finset.card
+  exact ⟨A, mem_allAntichains.mp hA, hCard.symm⟩
+
+/-! ### The common min–max counting bound -/
+
+/-- **Common min–max bound.**  A finite poset has at most
+    `maxChainLen · maxAntichainLen` elements.  Mirsky covers it by `maxChainLen`
+    antichains, each of size at most `maxAntichainLen`. -/
+theorem card_le_maxChainLen_mul_maxAntichainLen :
+    Fintype.card α ≤ maxChainLen (α := α) * maxAntichainLen (α := α) := by
+  obtain ⟨𝒜, hanti, hcover, hle⟩ := mirsky_antichain_cover (α := α)
+  have hsub : (Finset.univ : Finset α) ⊆ 𝒜.biUnion id := by
+    intro x _
+    obtain ⟨A, hA, hxA⟩ := hcover x
+    rw [Finset.mem_biUnion]
+    exact ⟨A, hA, hxA⟩
+  calc Fintype.card α
+      = (Finset.univ : Finset α).card := (Finset.card_univ).symm
+    _ ≤ (𝒜.biUnion id).card := Finset.card_le_card hsub
+    _ ≤ ∑ A ∈ 𝒜, (id A).card := Finset.card_biUnion_le
+    _ ≤ ∑ _A ∈ 𝒜, maxAntichainLen (α := α) :=
+        Finset.sum_le_sum (fun A hA => antichain_card_le_maxAntichainLen (hanti A hA))
+    _ = 𝒜.card * maxAntichainLen (α := α) := by rw [Finset.sum_const, smul_eq_mul]
+    _ ≤ maxChainLen (α := α) * maxAntichainLen (α := α) :=
+        Nat.mul_le_mul_right _ hle
+
+/-- **Erdős–Szekeres dichotomy (poset form).**  If a finite poset has more than
+    `r · s` elements, then it contains a chain of size `> r` or an antichain of
+    size `> s`.  This is the contrapositive of the counting bound. -/
+theorem exists_long_chain_or_antichain {r s : ℕ}
+    (h : r * s < Fintype.card α) :
+    (∃ C : Finset α, IsChainOn C ∧ r < C.card) ∨
+    (∃ A : Finset α, IsAntichainOn A ∧ s < A.card) := by
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨hC, hA⟩ := hcon
+  have hcl : maxChainLen (α := α) ≤ r := by
+    obtain ⟨C, hCchain, hCcard⟩ := exists_chain_card_eq_maxChainLen (α := α)
+    have := hC C hCchain; omega
+  have hal : maxAntichainLen (α := α) ≤ s := by
+    obtain ⟨A, hAanti, hAcard⟩ := exists_antichain_card_eq_maxAntichainLen (α := α)
+    have := hA A hAanti; omega
+  have hbound := card_le_maxChainLen_mul_maxAntichainLen (α := α)
+  have : Fintype.card α ≤ r * s := le_trans hbound (Nat.mul_le_mul hcl hal)
+  omega
+
+end DilworthTheoremOQ01
+
+/-! ### Erdős–Szekeres for sequences
+
+  We specialise the dichotomy to the poset on the positions of a finite sequence
+  `f : Fin N → β` (`β` linearly ordered), ordered by
+
+      `i ≼ j  ↔  i ≤ j  ∧  f i ≤ f j`.
+
+  A chain of this poset is a non-decreasing subsequence, and an antichain is a
+  strictly decreasing subsequence; transporting the chains/antichains produced by
+  the dichotomy through the position map yields Erdős–Szekeres. -/
+
+open DilworthTheoremOQ01
+
+/-- A position of a sequence `f : Fin N → β`, carrying the product order
+    `i ≼ j ↔ i ≤ j ∧ f i ≤ f j`. -/
+@[ext]
+structure SeqPos {N : ℕ} {β : Type*} (f : Fin N → β) where
+  pos : Fin N
+
+namespace SeqPos
+
+variable {N : ℕ} {β : Type*} [LinearOrder β] {f : Fin N → β}
+
+instance : PartialOrder (SeqPos f) where
+  le a b := a.pos ≤ b.pos ∧ f a.pos ≤ f b.pos
+  le_refl a := ⟨le_refl _, le_refl _⟩
+  le_trans a b c hab hbc := ⟨le_trans hab.1 hbc.1, le_trans hab.2 hbc.2⟩
+  le_antisymm a b hab hba := by
+    have : a.pos = b.pos := le_antisymm hab.1 hba.1
+    exact SeqPos.ext this
+
+@[simp] theorem le_def {a b : SeqPos f} : a ≤ b ↔ a.pos ≤ b.pos ∧ f a.pos ≤ f b.pos :=
+  Iff.rfl
+
+/-- Positions are in bijection with `Fin N`. -/
+def equivFin : SeqPos f ≃ Fin N where
+  toFun := SeqPos.pos
+  invFun := SeqPos.mk
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+instance : Fintype (SeqPos f) := Fintype.ofEquiv (Fin N) equivFin.symm
+
+omit [LinearOrder β] in
+theorem card_eq : Fintype.card (SeqPos f) = N := by
+  rw [Fintype.card_congr (equivFin (f := f)), Fintype.card_fin]
+
+omit [LinearOrder β] in
+theorem pos_injective : Function.Injective (SeqPos.pos (f := f)) :=
+  fun _ _ h => SeqPos.ext h
+
+/-- The position set of a **chain** is a non-decreasing index set. -/
+theorem image_pos_nondecr {C : Finset (SeqPos f)} (hC : IsChainOn C) :
+    ∀ i ∈ C.image SeqPos.pos, ∀ j ∈ C.image SeqPos.pos, i ≤ j → f i ≤ f j := by
+  intro i hi j hj hij
+  rw [Finset.mem_image] at hi hj
+  obtain ⟨a, haC, rfl⟩ := hi
+  obtain ⟨b, hbC, rfl⟩ := hj
+  rcases hC haC hbC with hab | hba
+  · exact hab.2
+  · -- `b ≤ a` gives `b.pos ≤ a.pos`; with `a.pos ≤ b.pos` the positions coincide.
+    have : a.pos = b.pos := le_antisymm hij hba.1
+    rw [this]
+
+/-- The position set of an **antichain** is a strictly decreasing index set. -/
+theorem image_pos_strictdecr {A : Finset (SeqPos f)} (hA : IsAntichainOn A) :
+    ∀ i ∈ A.image SeqPos.pos, ∀ j ∈ A.image SeqPos.pos, i < j → f j < f i := by
+  intro i hi j hj hij
+  rw [Finset.mem_image] at hi hj
+  obtain ⟨a, haC, rfl⟩ := hi
+  obtain ⟨b, hbC, rfl⟩ := hj
+  -- `a.pos < b.pos`, so `a ≠ b`; in an antichain that forces incomparability.
+  have hne : a ≠ b := fun h => absurd (h ▸ hij) (lt_irrefl _)
+  -- If `a ≤ b` held, the antichain would force `a = b`.
+  have hnle : ¬ a ≤ b := fun hab => hne (hA haC hbC hab)
+  rw [le_def] at hnle
+  push_neg at hnle
+  exact hnle hij.le
+
+omit [LinearOrder β] in
+theorem card_image_pos {C : Finset (SeqPos f)} :
+    (C.image SeqPos.pos).card = C.card :=
+  Finset.card_image_of_injective C pos_injective
+
+end SeqPos
+
+/-- **Erdős–Szekeres for sequences.**  Any sequence `f : Fin N → β` (with `β`
+    linearly ordered) of length `N > r · s` contains either a **non-decreasing**
+    subsequence on more than `r` positions or a **strictly decreasing**
+    subsequence on more than `s` positions.
+
+    Taking `N = r·s + 1` recovers the classical statement: a sequence of `r·s + 1`
+    terms has a non-decreasing run of length `r+1` or a strictly decreasing run of
+    length `s+1`. -/
+theorem erdos_szekeres_seq {N : ℕ} {β : Type*} [LinearOrder β] (f : Fin N → β)
+    {r s : ℕ} (h : r * s < N) :
+    (∃ t : Finset (Fin N), r < t.card ∧ ∀ i ∈ t, ∀ j ∈ t, i ≤ j → f i ≤ f j) ∨
+    (∃ t : Finset (Fin N), s < t.card ∧ ∀ i ∈ t, ∀ j ∈ t, i < j → f j < f i) := by
+  have hcard : r * s < Fintype.card (SeqPos f) := by rw [SeqPos.card_eq]; exact h
+  rcases exists_long_chain_or_antichain (α := SeqPos f) hcard with
+    ⟨C, hChain, hrC⟩ | ⟨A, hAnti, hsA⟩
+  · refine Or.inl ⟨C.image SeqPos.pos, ?_, SeqPos.image_pos_nondecr hChain⟩
+    rwa [SeqPos.card_image_pos]
+  · refine Or.inr ⟨A.image SeqPos.pos, ?_, SeqPos.image_pos_strictdecr hAnti⟩
+    rwa [SeqPos.card_image_pos]

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "dilworth-theorem-oq-01-oq-01-oq-03",
+  "title": "From Mirsky to Erdős–Szekeres: the common min–max framework",
+  "slug": "dilworth-theorem-oq-01-oq-01-oq-03",
+  "description": "Ties Mirsky's antichain-cover theorem to Erdős–Szekeres through one counting inequality. From Mirsky's hard direction (a finite poset is covered by maxChainLen antichains) we derive the product bound card ≤ maxChainLen · maxAntichainLen, whose contrapositive is the Erdős–Szekeres dichotomy: a poset with more than r·s elements has a chain of size > r or an antichain of size > s. Specialised to the dominance order on positions of a sequence f : Fin N → β, this yields the classical Erdős–Szekeres theorem (a sequence of length > r·s has a non-decreasing run of length > r or a strictly decreasing run of length > s). Fully verified, 0 axioms; Erdős–Szekeres is not in Mathlib.",
+  "meta": {
+    "author": "L. Mirsky (1971), P. Erdős & G. Szekeres (1935); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Szekeres_theorem",
+    "date": "1935",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "order-theory",
+      "poset",
+      "mirsky",
+      "erdos-szekeres",
+      "antichain",
+      "min-max-duality",
+      "pigeonhole",
+      "monotone-subsequence"
+    ],
+    "proofRepoPath": "Proofs/DilworthErdosSzekeresOQ010103.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_biUnion_le",
+        "description": "The cardinality of a finite union is at most the sum of cardinalities; turns the Mirsky antichain cover into the product bound",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.sum_le_sum / Finset.sum_const",
+        "description": "Termwise comparison and the constant-sum identity, used to bound the sum of antichain sizes by (number of antichains) · maxAntichainLen",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "An injective image preserves cardinality; the position map on SeqPos is injective, so chains/antichains keep their size when transported to index sets",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Fintype.ofEquiv / Fintype.card_congr",
+        "description": "Transports the Fintype structure and cardinality of Fin N to the sequence-position poset SeqPos f",
+        "module": "Mathlib.Data.Fintype.Basic"
+      }
+    ],
+    "originalContributions": [
+      "maxAntichainLen and antichain_card_le_maxAntichainLen: the dual width invariant to the imported maxChainLen, with attainment exists_antichain_card_eq_maxAntichainLen",
+      "card_le_maxChainLen_mul_maxAntichainLen: the common min–max bound — multiplying Mirsky's antichain cover (maxChainLen antichains) by the maxAntichainLen size bound caps the poset cardinality",
+      "exists_long_chain_or_antichain: the poset-level Erdős–Szekeres dichotomy, the contrapositive of the product bound",
+      "SeqPos: the dominance order i ≼ j ↔ i ≤ j ∧ f i ≤ f j on positions of a sequence, packaged as a finite PartialOrder",
+      "image_pos_nondecr / image_pos_strictdecr: chains of SeqPos are non-decreasing index sets, antichains are strictly decreasing index sets",
+      "erdos_szekeres_seq: the classical Erdős–Szekeres theorem for sequences over an arbitrary linear order, obtained by transporting the dichotomy through the position map"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 226,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext, Classical.choice, Quot.sound are used, none of which count as assumptions). The abstract results hold for any finite PartialOrder; the sequence form holds for any LinearOrder codomain.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Mirsky's theorem (1971) is the chain/antichain transpose of Dilworth's: the minimum number of antichains covering a finite poset equals the longest chain. Erdős and Szekeres (1935) proved that any sequence of more than r·s real numbers contains a monotone subsequence — a non-decreasing one of length r+1 or a strictly decreasing one of length s+1. The two are linked by a classical observation: order the positions of a sequence by the dominance order (i precedes j when i ≤ j and the value does not decrease); chains become non-decreasing subsequences and antichains become strictly decreasing ones, so Erdős–Szekeres is the pigeonhole consequence of covering the poset by chains-worth of antichains. This entry makes that bridge precise on top of the imported Mirsky decomposition.",
+    "problemStatement": "**Common min–max framework (OQ-01 → OQ-01 → OQ-03).** Tie Mirsky's antichain-cover theorem to a single counting inequality and obtain Erdős–Szekeres as an application. Concretely: prove card ≤ maxChainLen · maxAntichainLen for a finite poset, deduce the chain-or-antichain dichotomy, and specialise it to sequence positions to recover the classical monotone-subsequence theorem (absent from Mathlib).",
+    "text": "Mirsky's antichain cover times the maximum antichain size bounds the poset; the contrapositive is Erdős–Szekeres, both abstractly and for sequences.",
+    "proofStrategy": "**Strategy (counting then specialisation).**\n\n1. Define maxAntichainLen as the sup of antichain sizes (dual to the imported maxChainLen) and show every antichain is bounded by it, with the bound attained.\n2. **Product bound.** Mirsky's `mirsky_antichain_cover` gives a family of ≤ maxChainLen antichains covering the poset. The universe injects into their union, so card ≤ Σ (antichain sizes) ≤ (number of antichains) · maxAntichainLen ≤ maxChainLen · maxAntichainLen (`Finset.card_biUnion_le`, `Finset.sum_const`).\n3. **Dichotomy.** Contrapositive: if every chain has size ≤ r and every antichain ≤ s then maxChainLen ≤ r, maxAntichainLen ≤ s, so card ≤ r·s; hence r·s < card forces a long chain or a long antichain.\n4. **Sequence poset.** Wrap Fin N as `SeqPos f` with the dominance partial order i ≼ j ↔ i ≤ j ∧ f i ≤ f j (antisymmetry holds because equal positions force equal points); give it the Fintype of Fin N, so its cardinality is N.\n5. **Transport.** The position map is injective; a chain's positions form a non-decreasing index set and an antichain's positions a strictly decreasing one. Applying the dichotomy at r·s < N and pushing the resulting chain/antichain through the position map yields `erdos_szekeres_seq`.",
+    "keyInsights": [
+      "Mirsky already supplies the hard content; the bridge to Erdős–Szekeres is purely a counting step — multiply the number of covering antichains by the largest antichain size.",
+      "Mirsky and Dilworth are genuine transposes, not order-duals: reversing the order keeps chains as chains and antichains as antichains, so deriving one from the other goes through the shared product bound rather than a poset involution.",
+      "The dominance order on sequence positions converts the chain/antichain dichotomy verbatim into the non-decreasing/strictly-decreasing subsequence dichotomy: incomparable positions i < j are exactly the descents f i > f j.",
+      "Packaging the sequence poset as a one-field structure SeqPos makes the dominance order a clean PartialOrder instance with a Fintype borrowed from Fin N, avoiding any clash with Fin N's native linear order.",
+      "The result needs only a LinearOrder codomain, so Erdős–Szekeres here covers sequences valued in any totally ordered type, not just the reals."
+    ],
+    "prerequisites": [
+      "Partial orders: chains, antichains, the dominance / product order",
+      "Mirsky's hard direction (the height/level antichain cover) from the sibling entry",
+      "Finset cardinality, images, unions, and the pigeonhole principle",
+      "Monotone subsequences and the statement of Erdős–Szekeres"
+    ]
+  },
+  "sections": [
+    {
+      "id": "max-antichain",
+      "title": "The dual width invariant",
+      "summary": "Defines allAntichains and maxAntichainLen (sup of antichain cardinalities), the transpose of the imported maxChainLen. antichain_card_le_maxAntichainLen bounds each antichain, and exists_antichain_card_eq_maxAntichainLen shows the bound is attained (the empty set witnesses nonemptiness).",
+      "startLine": 47,
+      "endLine": 78,
+      "mathContext": "$\\mathrm{maxAntichainLen} = \\max\\{|A| : A\\text{ an antichain}\\}$, dual to $\\mathrm{maxChainLen}$."
+    },
+    {
+      "id": "product-bound",
+      "title": "The common min–max bound and dichotomy",
+      "summary": "card_le_maxChainLen_mul_maxAntichainLen: Mirsky's cover by ≤ maxChainLen antichains, each of size ≤ maxAntichainLen, caps the cardinality via card_biUnion_le and a constant sum. exists_long_chain_or_antichain: its contrapositive — r·s < card yields a chain of size > r or an antichain of size > s.",
+      "startLine": 80,
+      "endLine": 118,
+      "mathContext": "$|P| \\le \\mathrm{maxChainLen}\\cdot\\mathrm{maxAntichainLen}$; hence $rs<|P|\\Rightarrow$ a chain $>r$ or an antichain $>s$."
+    },
+    {
+      "id": "seqpos",
+      "title": "The dominance order on sequence positions",
+      "summary": "SeqPos f wraps Fin N with the partial order i ≼ j ↔ i ≤ j ∧ f i ≤ f j; antisymmetry follows from position antisymmetry. equivFin gives the Fintype and card_eq : card (SeqPos f) = N. pos_injective records that the position map is injective.",
+      "startLine": 120,
+      "endLine": 172,
+      "mathContext": "Positions ordered by $i\\preccurlyeq j \\iff i\\le j \\wedge f_i\\le f_j$, a finite poset of size $N$."
+    },
+    {
+      "id": "transport",
+      "title": "Chains ↔ non-decreasing, antichains ↔ strictly decreasing",
+      "summary": "image_pos_nondecr: the positions of a chain form a non-decreasing index set (comparable positions move the value the same way; equal positions are equal). image_pos_strictdecr: the positions of an antichain form a strictly decreasing index set (i < j incomparable means f j < f i). card_image_pos preserves sizes.",
+      "startLine": 174,
+      "endLine": 205,
+      "mathContext": "Chain $\\Rightarrow$ non-decreasing run; antichain $\\Rightarrow$ strictly decreasing run, with sizes preserved."
+    },
+    {
+      "id": "erdos-szekeres",
+      "title": "Erdős–Szekeres for sequences",
+      "summary": "erdos_szekeres_seq: for f : Fin N → β over a linear order with r·s < N, there is a non-decreasing subsequence on > r positions or a strictly decreasing subsequence on > s positions. Proof: apply the dichotomy to SeqPos f (card = N) and transport through the position map.",
+      "startLine": 207,
+      "endLine": 226,
+      "mathContext": "$rs < N \\Rightarrow$ non-decreasing run of length $>r$ or strictly decreasing run of length $>s$; with $N=rs+1$ this is the classical theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the imported Mirsky antichain cover, this file proves the common min–max counting bound card ≤ maxChainLen · maxAntichainLen for a finite poset and its contrapositive chain-or-antichain dichotomy, then specialises to the dominance order on sequence positions to obtain the classical Erdős–Szekeres theorem for sequences over an arbitrary linear order. Fully machine-checked, 0 sorries and 0 axioms.",
+    "implications": "The entry closes the Dilworth/Mirsky arc by exhibiting a single inequality from which the canonical application, Erdős–Szekeres, drops out, and provides a reusable finite poset (SeqPos) translating sequence monotonicity into order theory. Since Mathlib has neither the product bound nor Erdős–Szekeres, the file fills a concrete gap.",
+    "openQuestions": [
+      "Extract an explicit StrictMono index map Fin (r+1) ↪ Fin N from the non-decreasing position set, giving Erdős–Szekeres in subsequence-function form.",
+      "Sharpen to the strict Erdős–Szekeres variant (strictly increasing vs non-increasing) by using the lexicographic dominance order, and prove the bound r·s is tight.",
+      "Derive the dual product bound from Dilworth's chain cover and compare the two routes to the same dichotomy."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "dilworth-theorem-oq-01-oq-01",
+      "relationship": "Supplies the Mirsky decomposition",
+      "description": "The parent entry proves Mirsky's hard direction (a finite poset is covered by maxChainLen antichains via the height/level decomposition); this file imports that cover and multiplies it against the maximum antichain size."
+    },
+    {
+      "proofId": "dilworth-theorem-oq-01-oq-02",
+      "relationship": "Sibling hard direction (Dilworth)",
+      "description": "The sibling proves Dilworth's hard direction (chain cover attains the antichain width); together with Mirsky it frames the min–max duality whose counting consequence is used here."
+    },
+    {
+      "proofId": "dilworth-theorem-oq-01",
+      "relationship": "Common easy-direction infrastructure",
+      "description": "Provides IsChainOn / IsAntichainOn and the chain ∩ antichain subsingleton lemma reused throughout the Dilworth/Mirsky files this entry builds on."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DilworthMirskyHardOQ01"
+    ],
+    "opens": [
+      "Classical",
+      "DilworthTheoremOQ01"
+    ],
+    "namespace": "DilworthTheoremOQ01 / SeqPos",
+    "lineCount": 226,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 6,
+    "path": "Proofs/DilworthErdosSzekeresOQ010103.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "P. Erdős, G. Szekeres",
+      "title": "A combinatorial problem in geometry",
+      "year": "1935",
+      "venue": "Compositio Mathematica 2: 463–470",
+      "note": "Original monotone-subsequence theorem obtained here as an application of Mirsky"
+    },
+    {
+      "authors": "L. Mirsky",
+      "title": "A dual of Dilworth's decomposition theorem",
+      "year": "1971",
+      "venue": "American Mathematical Monthly 78 (8): 876–877",
+      "note": "Antichain-cover / longest-chain duality supplying the cover used in the product bound"
+    },
+    {
+      "authors": "J. Michael Steele",
+      "title": "Variations on the monotone subsequence theme of Erdős and Szekeres",
+      "year": "1995",
+      "venue": "in Discrete Probability and Algorithms, IMA Vol. 72: 111–131",
+      "note": "Survey of proofs of Erdős–Szekeres, including the Dilworth/Mirsky pigeonhole route formalized here"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/dilworth-theorem-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/dilworth-theorem-oq-01-oq-01-oq-03.json
@@ -1,0 +1,103 @@
+{
+  "slug": "dilworth-theorem-oq-01-oq-01-oq-03",
+  "title": "Mirsky's Theorem as the Min–Max Dual of Dilworth",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\ell(P) \\;=\\; \\min\\{\\, k : P \\text{ can be partitioned into } k \\text{ antichains}\\,\\}.",
+    "plain": "Dilworth's theorem (the parent, `dilworth-theorem-oq-01-oq-01`) says the largest antichain",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T22:47:03-07:00",
+    "iteration": 1,
+    "focus": "Solved: derived the common min–max product bound from Mirsky and obtained Erdős–Szekeres as an application.",
+    "blockers": [],
+    "nextAction": "PR opened; entry registered and verified.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: card ≤ maxChainLen·maxAntichainLen derived from Mirsky's antichain cover; contrapositive gives the chain-or-antichain dichotomy; specialised to the dominance order on sequence positions to obtain the classical Erdős–Szekeres theorem. 0 axioms, 0 sorries.",
+    "builtItems": [
+      "maxAntichainLen + antichain_card_le_maxAntichainLen + exists_antichain_card_eq_maxAntichainLen (DilworthErdosSzekeresOQ010103.lean:56,64,69)",
+      "card_le_maxChainLen_mul_maxAntichainLen: the common min–max product bound (DilworthErdosSzekeresOQ010103.lean:82)",
+      "exists_long_chain_or_antichain: poset-level Erdős–Szekeres dichotomy (DilworthErdosSzekeresOQ010103.lean:103)",
+      "SeqPos dominance poset + Fintype/card_eq (DilworthErdosSzekeresOQ010103.lean:138,145,163,166)",
+      "image_pos_nondecr / image_pos_strictdecr: chain↔non-decreasing, antichain↔strictly-decreasing transport (DilworthErdosSzekeresOQ010103.lean:174,187)",
+      "erdos_szekeres_seq: classical Erdős–Szekeres for sequences over a linear order (DilworthErdosSzekeresOQ010103.lean:216)"
+    ],
+    "insights": [
+      "Mirsky supplies the hard content; the bridge to Erdős–Szekeres is a pure counting step — (number of covering antichains) × (largest antichain size) bounds the poset.",
+      "Mirsky and Dilworth are transposes, not order-duals: order reversal preserves both chains and antichains, so one is derived from the other through the shared product bound, not a poset involution.",
+      "The dominance order i ≼ j ↔ i ≤ j ∧ f i ≤ f j makes incomparable pairs i<j exactly the descents f i > f j, so chains are non-decreasing runs and antichains are strictly decreasing runs.",
+      "Antisymmetry of the dominance order needs no distinctness of values: i ≼ j and j ≼ i force i ≤ j ≤ i, i.e. i = j, regardless of the f-values.",
+      "Wrapping Fin N as a one-field structure SeqPos cleanly attaches the dominance PartialOrder and a borrowed Fintype without clashing with Fin N's native linear order.",
+      "Only a LinearOrder codomain is required, so Erdős–Szekeres here holds for sequences in any totally ordered type."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Erdős–Szekeres theorem (no erdos_szekeres / monotone-subsequence dichotomy).",
+      "Mathlib has no Mirsky/Dilworth product bound card ≤ maxChainLen · maxAntichainLen."
+    ],
+    "nextSteps": [
+      "Extract an explicit StrictMono Fin (r+1) ↪ Fin N from the non-decreasing position set for the subsequence-function form.",
+      "Prove tightness of r·s and the strict (increasing/non-increasing) variant via the lexicographic dominance order.",
+      "Derive the dual product bound from Dilworth's chain cover and compare routes."
+    ],
+    "markdown": "# Knowledge Base: dilworth-theorem-oq-01-oq-01-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "order-theory",
+    "dilworth",
+    "mirsky",
+    "combinatorics",
+    "erdos-szekeres"
+  ],
+  "relatedProofs": [
+    "dilworth-theorem-oq-01",
+    "dilworth-theorem-oq-01-oq-01",
+    "dilworth-theorem-oq-01-oq-01-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T06:14:37.639Z",
+  "lastUpdate": "2026-06-25T07:00:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/DilworthTheoremOQ01.lean",
+      "filename": "DilworthTheoremOQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DilworthTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/DilworthTheoremOQ01OQ01OQ02.lean",
+      "filename": "DilworthTheoremOQ01OQ01OQ02.lean",
+      "lineCount": 123,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DilworthTheoremOQ01OQ01OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question *"derive Mirsky/Dilworth through a common min–max framework and obtain Erdős–Szekeres as an application"* (`dilworth-theorem-oq-01-oq-01-oq-03`). Builds directly on the already-merged Mirsky hard direction (`Proofs.DilworthMirskyHardOQ01`).

The bridge is a single counting inequality:

- **`card_le_maxChainLen_mul_maxAntichainLen`** — for any finite poset, `card α ≤ maxChainLen · maxAntichainLen`. Mirsky's `mirsky_antichain_cover` gives a cover by `maxChainLen` antichains; each has size `≤ maxAntichainLen`; multiply.
- **`exists_long_chain_or_antichain`** — the contrapositive dichotomy: `r·s < card α` forces a chain of size `> r` or an antichain of size `> s`.

Specialised to sequences via the dominance order:

- **`SeqPos f`** — positions of `f : Fin N → β` ordered by `i ≼ j ↔ i ≤ j ∧ f i ≤ f j`, a finite `PartialOrder` of cardinality `N`.
- **`image_pos_nondecr` / `image_pos_strictdecr`** — chains map to non-decreasing index sets, antichains to strictly decreasing ones.
- **`erdos_szekeres_seq`** — the classical Erdős–Szekeres theorem for sequences over any `LinearOrder`: `r·s < N` yields a non-decreasing run of length `> r` or a strictly decreasing run of length `> s` (with `N = r·s+1`, the textbook statement).

## Verification

- **0 sorries, 0 axioms** — `#print axioms erdos_szekeres_seq` → `[propext, Classical.choice, Quot.sound]` only.
- 11 theorems, 226 lines, Mathlib v4.26.0.
- Status `verified`, badge `original`. Neither the product bound nor Erdős–Szekeres exists in Mathlib.

## Notes

Mirsky and Dilworth are genuine *transposes*, not order-duals (order reversal preserves both chains and antichains), so the link goes through the shared product bound rather than a poset involution — that is the "common min–max framework" the question asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)