### PR TITLE
Enrich Newton's third power sum tr(A³)=Σλᵢ³ (3×3): annotations + index.ts

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-spectral-trace-oq010102-00-header",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 55 },
+    "type": "context",
+    "title": "The open question: Newton's cube power sum in dimension three",
+    "content": "The docstring states the goal carried over from the sibling oq-01-oq-01, which reached tr(A²) = λ₁² + λ₂² for 2×2 matrices via Newton's p₂ = e₁² − 2e₂ (where e₂ is just the determinant). This file extends to the next power sum and dimension: tr(A³) = e₁³ − 3e₁e₂ + 3e₃, read spectrally as tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 matrices. The honesty note flags why the cube is qualitatively harder: it is the first power sum whose Newton expansion involves the MIDDLE elementary symmetric function e₂ (the sum of principal 2×2 minors), not just trace and determinant. The file imports Mathlib and the parent, opens Matrix/Polynomial, and reuses the parent's `eigenvalues` abbreviation.",
+    "mathContext": "Newton's identities: $p_1 = e_1$, $p_2 = e_1^2 - 2e_2$, $p_3 = e_1^3 - 3e_1e_2 + 3e_3$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Newton's identities",
+      "power sums",
+      "elementary symmetric functions",
+      "spectral mapping theorem"
+    ],
+    "prerequisites": [
+      "characteristic polynomial",
+      "eigenvalues with multiplicity"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq010102-01-matrix-newton",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 79 },
+    "type": "key-step",
+    "title": "The matrix-side Newton identity over any commutative ring",
+    "content": "`e2` defines the second elementary symmetric function of a 3×3 matrix as the sum of its three principal 2×2 minors. `trace_cube_fin_three` then proves tr(A³) = (tr A)³ − 3(tr A)·e₂(A) + 3·det A. The proof unfolds A³ as a triple product (pow_three) and expands trace, det, and the matrix multiplications entrywise via Matrix.trace_fin_three, Matrix.det_fin_three, Matrix.mul_apply, Fin.sum_univ_three, then closes by `ring`. This is a polynomial identity in the nine entries — no field, no algebraic closure, no eigenvalues.",
+    "mathContext": "$\\operatorname{tr}(A^3) = (\\operatorname{tr}A)^3 - 3(\\operatorname{tr}A)\\,e_2(A) + 3\\det A$, with $e_2(A) = $ sum of principal $2\\times2$ minors.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.trace_fin_three",
+      "Matrix.det_fin_three",
+      "principal minors",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "commutative ring",
+      "matrix multiplication"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq010102-02-charpoly",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+    "range": { "startLine": 81, "endLine": 101 },
+    "type": "technique",
+    "title": "The characteristic polynomial in elementary-symmetric form",
+    "content": "charpoly_fin_three proves A.charpoly = X³ − (tr A)X² + e₂(A)X − det A by expanding det(X·I − A) entrywise (charmatrix_apply_eq, charmatrix_apply_ne, det_fin_three) and ring-normalising. charpoly_coeff_one_eq_e2 then reads off A.charpoly.coeff 1 = e₂(A). This is the crucial bridge: it identifies the combinatorially-defined minor sum e₂ with the X¹-coefficient of the characteristic polynomial, which by Vieta is the second symmetric function of the eigenvalues.",
+    "mathContext": "$\\chi_A(X) = X^3 - (\\operatorname{tr}A)X^2 + e_2(A)X - \\det A$, so $[\\![X^1]\\!]\\chi_A = e_2(A)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.charmatrix",
+      "Vieta's formulas",
+      "polynomial coefficients",
+      "characteristic polynomial"
+    ],
+    "prerequisites": [
+      "characteristic polynomial as det(XI − A)",
+      "polynomial coefficient extraction"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq010102-03-spectral",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+    "range": { "startLine": 102, "endLine": 151 },
+    "type": "insight",
+    "title": "The spectral form tr(A³) = λ₁³ + λ₂³ + λ₃³",
+    "content": "Over an algebraically closed field, card_eigenvalues_fin_three gives exactly three eigenvalues and charpoly_eq_prod_eigenvalues factors the charpoly as ∏(X − λᵢ) (Vieta). trace_cube_eq_sum_cube_eigenvalues writes the multiset as {a,b,c} and identifies the three symmetric functions: tr A = a+b+c and det A = abc (from the parent), and e₂(A) = ab+ac+bc (from charpoly_coeff_one_eq_e2 plus the explicit cubic factorisation). Substituting into trace_cube_fin_three and matching a³+b³+c³ = (a+b+c)³ − 3(a+b+c)(ab+ac+bc) + 3abc yields tr(A³) = Σλᵢ³. Algebraic closure enters only here — to split the charpoly.",
+    "mathContext": "$a^3+b^3+c^3 = (a+b+c)^3 - 3(a+b+c)(ab+ac+bc) + 3abc$, the three-variable Newton $p_3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsAlgClosed.splits",
+      "eigenvalue multiset",
+      "Multiset.card_eq_three",
+      "Vieta's formulas"
+    ],
+    "prerequisites": [
+      "algebraically closed field",
+      "splitting of polynomials"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq010102-04-example",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+    "range": { "startLine": 153, "endLine": 171 },
+    "type": "observation",
+    "title": "A trace power sum of an unknowable spectrum",
+    "content": "trace_cube_example instantiates trace_cube_fin_three at the rational matrix !![1,2,0; 0,3,1; 4,0,2] over ℚ. The eigenvalues of this matrix are not rational, yet tr(A³) is forced by tr A = 6, the minor sum e₂(A), and det A — read off without ever solving the cubic. The trailing #print axioms calls audit trace_cube_fin_three, trace_cube_eq_sum_cube_eigenvalues, and charpoly_coeff_one_eq_e2, confirming only the foundational axioms propext / Classical.choice / Quot.sound (no native_decide, no sorryAx).",
+    "mathContext": "$\\operatorname{tr}(A^3)$ is a rational invariant of $A$ even when $\\operatorname{spec}(A)\\not\\subset\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rational invariants",
+      "axiom audit",
+      "#print axioms"
+    ],
+    "prerequisites": [
+      "matrix literals in Lean"
+    ]
+  }
+]

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Data: ProofData = {
+  proof: spectralTraceDetEigenvaluesOq01Oq01Oq02Proof,
+  annotations: spectralTraceDetEigenvaluesOq01Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02` (Newton's cube power sum in dimension three).

Complete `meta.json` (overview, sections, conclusion, references) but **missing `annotations.json` and `index.ts`** — without `index.ts` the page renders 'proof not found' on the live site.

## Changes
- **Created `index.ts`** (sources `Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean?raw`).
- **Created `annotations.json`** — 5 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the open-question header, the ring-universal `trace_cube_fin_three`, the charpoly elementary-symmetric form + `charpoly_coeff_one_eq_e2`, the spectral `trace_cube_eq_sum_cube_eigenvalues`, and the rational worked example.

Line ranges verified against the 171-line Lean source. JSON validated.