### PR TITLE
Enrich closure of (pre)connected sets: index.ts + annotation depth

### DIFF
--- a/src/data/proofs/connected-space-oq-01/annotations.json
+++ b/src/data/proofs/connected-space-oq-01/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "insight",
     "title": "Connectedness Survives Closure",
-    "content": "preconnected_closure and connected_closure record that the closure of a (pre)connected set is (pre)connected. The reason is that connectedness cannot be destroyed by adding limit points: any pair of open sets separating closure s would already separate the dense original set s, contradicting its preconnectedness. These are Mathlib's IsPreconnected.closure / IsConnected.closure, restated in gallery form."
+    "content": "preconnected_closure and connected_closure record that the closure of a (pre)connected set is (pre)connected. The reason is that connectedness cannot be destroyed by adding limit points: any pair of open sets separating closure s would already separate the dense original set s, contradicting its preconnectedness. These are Mathlib's IsPreconnected.closure / IsConnected.closure, restated in gallery form.",
+    "mathContext": "If $s$ is preconnected then $\\overline{s}$ is preconnected; an open separation $U \\cup V \\supseteq \\overline{s}$ restricts to one of $s$, which is dense in $\\overline{s}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsPreconnected.closure",
+      "IsConnected.closure",
+      "limit points",
+      "open separation"
+    ],
+    "prerequisites": [
+      "closure of a set",
+      "preconnected and connected sets"
+    ]
   },
   {
     "id": "ann-bark-tree",
@@ -19,7 +31,19 @@
     },
     "type": "concept",
     "title": "Bark and Tree: the Sharp Form",
-    "content": "preconnected_of_subset_closure is strictly stronger than the closure statement: ANY set t with s ⊆ t ⊆ closure s is preconnected, not just t = closure s. Picturesquely, everything between the 'bark' (s) and the 'tree' (closure s) inherits connectedness. The full-closure result is the special case t = closure s; conversely this sharp form is what powers downstream arguments where one only knows a set lies between a connected core and its closure."
+    "content": "preconnected_of_subset_closure is strictly stronger than the closure statement: ANY set t with s ⊆ t ⊆ closure s is preconnected, not just t = closure s. Picturesquely, everything between the 'bark' (s) and the 'tree' (closure s) inherits connectedness. The full-closure result is the special case t = closure s; conversely this sharp form is what powers downstream arguments where one only knows a set lies between a connected core and its closure. connected_of_subset_closure is the connected analogue.",
+    "mathContext": "$s \\subseteq t \\subseteq \\overline{s}$ with $s$ preconnected $\\Rightarrow$ $t$ preconnected; taking $t = \\overline{s}$ recovers the closure result.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsPreconnected.subset_closure",
+      "density",
+      "intermediate sets",
+      "closure"
+    ],
+    "prerequisites": [
+      "subset relations",
+      "closure of a set"
+    ]
   },
   {
     "id": "ann-dense",
@@ -30,6 +54,18 @@
     },
     "type": "insight",
     "title": "Dense Connected Subset ⟹ Connected Space",
-    "content": "connectedSpace_of_dense_connected is the practical corollary: if a space has a dense connected subset, the whole space is connected. The proof reduces ConnectedSpace α to IsConnected (univ) (connectedSpace_iff_univ); density gives closure s = univ (Dense.closure_eq), so univ is the closure of a connected set, which is connected (IsConnected.closure). This is a standard and reusable route to proving connectedness — establish it on a dense, easier-to-analyze part and let closure do the rest."
+    "content": "connectedSpace_of_dense_connected is the practical corollary: if a space has a dense connected subset, the whole space is connected. The proof reduces ConnectedSpace α to IsConnected (univ) (connectedSpace_iff_univ); density gives closure s = univ (Dense.closure_eq), so univ is the closure of a connected set, which is connected (IsConnected.closure). This is a standard and reusable route to proving connectedness — establish it on a dense, easier-to-analyze part and let closure do the rest. preconnectedSpace_of_dense_preconnected is the preconnected analogue.",
+    "mathContext": "$s$ dense $\\Rightarrow \\overline{s} = \\mathrm{univ}$; $s$ connected $\\Rightarrow \\overline{s}$ connected; hence $\\mathrm{univ}$ is connected, i.e. $\\alpha$ is a ConnectedSpace.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dense.closure_eq",
+      "connectedSpace_iff_univ",
+      "ConnectedSpace",
+      "dense subsets"
+    ],
+    "prerequisites": [
+      "dense subsets",
+      "connected spaces vs connected sets"
+    ]
   }
 ]

--- a/src/data/proofs/connected-space-oq-01/index.ts
+++ b/src/data/proofs/connected-space-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ConnectedSpaceOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const connectedSpaceOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const connectedSpaceOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const connectedSpaceOq01Data: ProofData = {
+  proof: connectedSpaceOq01Proof,
+  annotations: connectedSpaceOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `connected-space-oq-01` (closure preserves (pre)connectedness; bark-and-tree; dense corollary).

## Changes
- **Created `index.ts`** — was missing, so the page rendered 'proof not found' on the live site (sources `Proofs/ConnectedSpaceOQ01.lean?raw`).
- **Enriched all 3 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` (they previously had only title + content).

Line ranges verified against the 75-line Lean source. JSON validated.