### PR TITLE
research(sophie-germain-oq-01-oq-03): p ≡ 1 mod 4 Sophie Germain primes force 2p+1 ∣ 2^p+1 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SophieGermainOQ0103.lean
+++ b/proofs/Proofs/SophieGermainOQ0103.lean
@@ -1,0 +1,177 @@
+import Mathlib
+
+/-
+# Sophie Germain primes and Fermat-type numbers: the `p ≡ 1 (mod 4)` branch
+
+## Research problem `sophie-germain-oq-01-oq-03`
+
+This file is the **complementary half** of the mod-4 dichotomy begun in the sibling
+entry `sophie-germain-oq-01-oq-02`, which proves that a Sophie Germain prime
+`p ≡ 3 (mod 4)` forces its safe prime `q = 2p + 1` to *divide the Mersenne number*
+`2^p − 1` (so `M_p` is composite).  Here we settle the remaining residue class:
+
+> **Theorem.** If `p` is a prime with `p ≡ 1 (mod 4)` and `q = 2p + 1` is also
+> prime (i.e. `p` is a Sophie Germain prime in the complementary class), then
+> `q ∣ 2^p + 1`.
+
+Together the two leaves give a clean, complete picture of how a safe prime
+`q = 2p + 1` interacts with the base-`2` exponential at the half-period `p`:
+
+| `p mod 4` | `q mod 8` | `2` mod `q` | `2^p mod q` | divisibility    |
+|-----------|-----------|-------------|-------------|-----------------|
+| `3`       | `7`       | residue     | `+1`        | `q ∣ 2^p − 1`   |
+| `1`       | `3`       | non-residue | `−1`        | `q ∣ 2^p + 1`   |
+
+## Proof
+
+Write `q = 2p + 1`.  From `p ≡ 1 (mod 4)` one computes `q ≡ 3 (mod 8)`, so by the
+supplement to quadratic reciprocity (`ZMod.exists_sq_eq_two_iff`) **2 is a
+quadratic non-residue** modulo `q`.  Euler's criterion (`ZMod.euler_criterion`)
+then forces `2^{(q−1)/2} = −1` in `ZMod q` (it is `±1` because its square is
+`2^{q−1} = 1`, and `+1` is excluded precisely because `2` is not a square).  Since
+`(q − 1)/2 = q / 2 = p`, this reads `2^p = −1`, i.e. `q ∣ 2^p + 1`.
+
+The argument is the mirror image of the sibling proof: there `q ≡ 7 (mod 8)`
+makes `2` a residue and Euler's criterion yields `+1`; here `q ≡ 3 (mod 8)`
+makes `2` a non-residue and yields `−1`.
+
+The file is **self-contained**: it depends only on Mathlib and re-declares the
+`IsSophieGermainPrime` predicate locally (the sibling parent file is a separate
+research entry).  Research file — intentionally NOT registered in `Proofs.lean`.
+
+Tags: number-theory, sophie-germain, quadratic-residue, euler-criterion,
+fermat-number, safe-prime
+-/
+
+namespace SophieGermainOQ0103
+
+/-- A **Sophie Germain prime**: a prime `p` such that `2p + 1` is also prime.
+Re-declared locally so this entry stands alone. -/
+def IsSophieGermainPrime (p : ℕ) : Prop := p.Prime ∧ (2 * p + 1).Prime
+
+/-! ## Arithmetic of the safe prime `q = 2p + 1` for `p ≡ 1 (mod 4)` -/
+
+/-- For `p ≡ 1 (mod 4)`, the safe prime `q = 2p + 1` satisfies `q ≡ 3 (mod 8)`. -/
+theorem safePrime_mod_eight {p : ℕ} (hp4 : p % 4 = 1) : (2 * p + 1) % 8 = 3 := by
+  omega
+
+/-- A prime `p ≡ 1 (mod 4)` is at least `5`; hence `q = 2p + 1 ≥ 11 > 2`. -/
+theorem safePrime_ne_two {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 1) :
+    2 * p + 1 ≠ 2 := by
+  have h2 : 2 ≤ p := hp.two_le
+  omega
+
+/-- A prime `p ≡ 1 (mod 4)` satisfies `p ≥ 5` (the smallest such prime). -/
+theorem five_le_of_prime_mod_four {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 1) :
+    5 ≤ p := by
+  have h2 : 2 ≤ p := hp.two_le
+  omega
+
+/-! ## A small exponential estimate -/
+
+/-- `2n < 2^n` for `n ≥ 5` (used to separate `q = 2p+1` from `2^p + 1`). -/
+theorem two_mul_lt_two_pow {n : ℕ} (hn : 5 ≤ n) : 2 * n < 2 ^ n := by
+  induction n, hn using Nat.le_induction with
+  | base => norm_num
+  | succ m hm ih =>
+      rw [pow_succ]
+      omega
+
+/-! ## `2` is a quadratic non-residue mod `q` -/
+
+/-- For `p ≡ 1 (mod 4)` and `q = 2p + 1` prime, `2` is **not** a square in
+`ZMod q`. -/
+theorem two_not_isSquare {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 1)
+    (hq : (2 * p + 1).Prime) :
+    ¬ IsSquare (2 : ZMod (2 * p + 1)) := by
+  haveI : Fact (2 * p + 1).Prime := ⟨hq⟩
+  rw [ZMod.exists_sq_eq_two_iff (p := 2 * p + 1) (safePrime_ne_two hp hp4)]
+  have h8 : (2 * p + 1) % 8 = 3 := safePrime_mod_eight hp4
+  omega
+
+/-! ## Euler's criterion: `2^p = −1` in `ZMod q` -/
+
+/-- The core congruence: for a Sophie Germain prime `p ≡ 1 (mod 4)`, the base-`2`
+power at the half-period equals `−1` in `ZMod (2p+1)`. -/
+theorem two_pow_eq_neg_one {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 1)
+    (hq : (2 * p + 1).Prime) :
+    (2 : ZMod (2 * p + 1)) ^ p = -1 := by
+  haveI : Fact (2 * p + 1).Prime := ⟨hq⟩
+  -- `2 ≠ 0` in `ZMod q` (since `q = 2p+1 ≥ 11` does not divide `2`)
+  have hb0 : (2 : ZMod (2 * p + 1)) ≠ 0 := by
+    have h2 : 2 ≤ p := hp.two_le
+    have hcast : ((2 : ℕ) : ZMod (2 * p + 1)) ≠ 0 := by
+      intro hdvd0
+      rw [ZMod.natCast_eq_zero_iff] at hdvd0
+      have := Nat.le_of_dvd (by norm_num) hdvd0
+      omega
+    simpa using hcast
+  -- Euler's criterion: not a square ⟹ `2 ^ (q/2) ≠ 1`, and `q / 2 = p`
+  have hns := two_not_isSquare hp hp4 hq
+  have heuler := (ZMod.euler_criterion (p := 2 * p + 1) hb0).not
+  have hdiv : (2 * p + 1) / 2 = p := by omega
+  rw [hdiv] at heuler
+  have hne1 : (2 : ZMod (2 * p + 1)) ^ p ≠ 1 := heuler.mp hns
+  -- `(2^p)^2 = 2^(q-1) = 1`, so `2^p = ±1`; ruling out `+1` leaves `−1`
+  have hsq : ((2 : ZMod (2 * p + 1)) ^ p) ^ 2 = 1 := by
+    rw [← pow_mul]
+    have hexp : p * 2 = (2 * p + 1) - 1 := by omega
+    rw [hexp]
+    exact ZMod.pow_card_sub_one_eq_one hb0
+  have hpm : (2 : ZMod (2 * p + 1)) ^ p = 1 ∨ (2 : ZMod (2 * p + 1)) ^ p = -1 := by
+    have hmul : (2 : ZMod (2 * p + 1)) ^ p * (2 : ZMod (2 * p + 1)) ^ p = 1 := by
+      rw [← sq]; exact hsq
+    exact mul_self_eq_one_iff.mp hmul
+  rcases hpm with h | h
+  · exact absurd h hne1
+  · exact h
+
+/-! ## Main divisibility theorem -/
+
+/-- **Sophie Germain `p ≡ 1 (mod 4)` ⟹ `2p + 1 ∣ 2^p + 1`.**
+If `p` is prime, `p ≡ 1 (mod 4)`, and `q = 2p + 1` is prime, then the safe prime
+`q` divides the Fermat-type number `2^p + 1`. -/
+theorem two_pow_add_one_dvd {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 1)
+    (hq : (2 * p + 1).Prime) :
+    (2 * p + 1) ∣ 2 ^ p + 1 := by
+  haveI : Fact (2 * p + 1).Prime := ⟨hq⟩
+  rw [← ZMod.natCast_eq_zero_iff]
+  have hcong := two_pow_eq_neg_one hp hp4 hq
+  push_cast
+  rw [hcong]
+  ring
+
+/-- Packaged with the `IsSophieGermainPrime` predicate. -/
+theorem sophieGermain_dvd_two_pow_add_one {p : ℕ}
+    (hSG : IsSophieGermainPrime p) (hp4 : p % 4 = 1) :
+    (2 * p + 1) ∣ 2 ^ p + 1 :=
+  two_pow_add_one_dvd hSG.1 hp4 hSG.2
+
+/-! ## Compositeness consequence -/
+
+/-- For a Sophie Germain prime `p ≡ 1 (mod 4)` the safe prime `q = 2p + 1` is a
+**proper** divisor of `2^p + 1` (`1 < q < 2^p + 1`), so `2^p + 1` is composite. -/
+theorem two_pow_add_one_not_prime {p : ℕ} (hp : p.Prime) (hp4 : p % 4 = 1)
+    (hq : (2 * p + 1).Prime) :
+    ¬ (2 ^ p + 1).Prime := by
+  have hdvd := two_pow_add_one_dvd hp hp4 hq
+  have hp5 : 5 ≤ p := five_le_of_prime_mod_four hp hp4
+  have hlt : 2 * p + 1 < 2 ^ p + 1 := by
+    have := two_mul_lt_two_pow hp5
+    omega
+  have hgt : 1 < 2 * p + 1 := by omega
+  intro hprime
+  rcases hprime.eq_one_or_self_of_dvd _ hdvd with h1 | hself
+  · omega
+  · omega
+
+/-! ## Sanity check and the dichotomy
+
+`p = 5`: `5 % 4 = 1` and `q = 11` is prime, so `11 ∣ 2^5 + 1 = 33 = 3 · 11`. -/
+
+example : IsSophieGermainPrime 5 := by
+  constructor <;> norm_num
+
+example : (2 * 5 + 1) ∣ 2 ^ 5 + 1 := by decide
+
+end SophieGermainOQ0103

--- a/src/data/proofs/sophie-germain-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/sophie-germain-oq-01-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "sophie-germain-oq-01-oq-03",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "concept",
+    "title": "Completing the Mod-4 Dichotomy for Safe Primes",
+    "content": "If $p$ is a Sophie Germain prime then $q = 2p+1$ is a safe prime, and whether $q$ divides $2^p-1$ or $2^p+1$ is decided entirely by $p \\bmod 4$. The sibling entry settles $p \\equiv 3 \\pmod 4$ (giving $q \\equiv 7 \\pmod 8$, $2$ a residue, $q \\mid 2^p-1$). This entry settles the other class $p \\equiv 1 \\pmod 4$: now $q \\equiv 3 \\pmod 8$, $2$ is a non-residue, and the divisibility flips to $q \\mid 2^p+1$.",
+    "mathContext": "$p \\equiv 1 \\pmod 4 \\Rightarrow q = 2p+1 \\equiv 3 \\pmod 8.$",
+    "significance": "key",
+    "relatedConcepts": ["Sophie Germain prime", "safe prime", "quadratic residue"],
+    "prerequisites": ["elementary number theory", "modular arithmetic"]
+  },
+  {
+    "id": "ann-mod8",
+    "proofId": "sophie-germain-oq-01-oq-03",
+    "range": { "startLine": 50, "endLine": 82 },
+    "type": "technique",
+    "title": "Pinning q ≡ 3 (mod 8) and the Exponential Gap",
+    "content": "The whole proof turns on $q \\bmod 8$, which is a function of $p \\bmod 4$: from $p \\equiv 1 \\pmod 4$, `omega` computes $q = 2p+1 \\equiv 3 \\pmod 8$ (safePrime_mod_eight). The same residue analysis shows the smallest such prime is $5$, so $q \\ge 11 > 2$. The estimate $2n < 2^n$ for $n \\ge 5$ (two_mul_lt_two_pow, by Nat.le_induction) is held in reserve to separate $q$ from $2^p+1$.",
+    "mathContext": "$q \\equiv 3 \\pmod 8,\\quad 2n < 2^n\\ (n \\ge 5).$",
+    "significance": "supporting",
+    "relatedConcepts": ["congruence", "induction"],
+    "prerequisites": ["omega decision procedure"]
+  },
+  {
+    "id": "ann-euler",
+    "proofId": "sophie-germain-oq-01-oq-03",
+    "range": { "startLine": 83, "endLine": 133 },
+    "type": "technique",
+    "title": "Non-Residue ⟹ Euler's Criterion Yields −1",
+    "content": "Since $q \\equiv 3 \\pmod 8$, the supplement to quadratic reciprocity (`ZMod.exists_sq_eq_two_iff`) makes $2$ a quadratic non-residue mod $q$ (two_not_isSquare). Euler's criterion (`ZMod.euler_criterion`) characterizes squares by $a^{(q-1)/2} = 1$, so $2^{(q-1)/2} \\ne 1$. Its square is $2^{q-1} = 1$ by Fermat's little theorem (`ZMod.pow_card_sub_one_eq_one`), so $2^{(q-1)/2}$ is a square root of unity in the field $\\mathrm{ZMod}\\,q$; excluding $+1$ leaves $-1$. With $(q-1)/2 = q/2 = p$ this is $2^p = -1$ (two_pow_eq_neg_one).",
+    "mathContext": "$2^{(q-1)/2} \\equiv -1 \\pmod q,\\qquad (q-1)/2 = p.$",
+    "significance": "key",
+    "relatedConcepts": ["Euler's criterion", "quadratic reciprocity", "Fermat's little theorem"],
+    "prerequisites": ["finite fields", "roots of unity"]
+  },
+  {
+    "id": "ann-dvd",
+    "proofId": "sophie-germain-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 177 },
+    "type": "result",
+    "title": "Divisibility and Compositeness",
+    "content": "Casting $2^p = -1$ back to $\\mathbb{N}$ via `ZMod.natCast_eq_zero_iff` gives the main theorem $q \\mid 2^p+1$ (two_pow_add_one_dvd). Because $2p < 2^p$ for $p \\ge 5$, the divisor $q = 2p+1$ is strictly between $1$ and $2^p+1$, so it is proper and $2^p+1$ is composite (two_pow_add_one_not_prime). The witness $p=5$ gives $11 \\mid 33 = 3 \\cdot 11$.",
+    "mathContext": "$q \\mid 2^p + 1,\\quad 1 < q < 2^p+1\\ (p \\ge 5).$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility", "compositeness"],
+    "prerequisites": ["ZMod / ℕ cast", "proper divisor"]
+  }
+]

--- a/src/data/proofs/sophie-germain-oq-01-oq-03/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01-oq-03/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "sophie-germain-oq-01-oq-03",
+  "slug": "sophie-germain-oq-01-oq-03",
+  "title": "Sophie Germain Primes p ≡ 1 (mod 4) Force 2p+1 ∣ 2^p + 1",
+  "description": "Completes the mod-4 dichotomy for safe primes. The sibling entry sophie-germain-oq-01-oq-02 proves that a Sophie Germain prime p ≡ 3 (mod 4) makes its safe prime q = 2p+1 divide the Mersenne number 2^p − 1. This entry settles the complementary residue class: if p is prime, p ≡ 1 (mod 4), and q = 2p+1 is prime, then q ∣ 2^p + 1. The mechanism is the mirror image of the sibling: p ≡ 1 (mod 4) forces q ≡ 3 (mod 8), so by the supplement to quadratic reciprocity (ZMod.exists_sq_eq_two_iff) 2 is a quadratic NON-residue modulo q; Euler's criterion then gives 2^((q−1)/2) = −1, and since (q−1)/2 = p this is exactly 2^p = −1 in ZMod q, i.e. q ∣ 2^p + 1. The compositeness corollary two_pow_add_one_not_prime shows q is a proper divisor (1 < q < 2^p+1 for p ≥ 5), so 2^p + 1 is composite. Witnessed at p = 5: 11 ∣ 2^5 + 1 = 33 = 3·11. Fully machine-checked, 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound).",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "SophieGermainOQ0103",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "substantiveTheoremCount": 5,
+    "trivialSpecializations": 4,
+    "definitionCount": 1,
+    "path": "Proofs/SophieGermainOQ0103.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "researcher-9",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SophieGermainOQ0103.lean",
+    "tags": [
+      "number-theory",
+      "sophie-germain",
+      "quadratic-residue",
+      "euler-criterion",
+      "fermat-number",
+      "safe-prime",
+      "modular-arithmetic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Proved from the supplement to quadratic reciprocity for 2 (ZMod.exists_sq_eq_two_iff), Euler's criterion (ZMod.euler_criterion), and Fermat's little theorem (ZMod.pow_card_sub_one_eq_one) with no added axioms. #print axioms reports only propext / Classical.choice / Quot.sound for the main theorem and the compositeness corollary; the numeric example uses kernel decide (no Lean.ofReduceBool).",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      "ZMod.exists_sq_eq_two_iff",
+      "ZMod.euler_criterion",
+      "ZMod.pow_card_sub_one_eq_one",
+      "ZMod.natCast_eq_zero_iff",
+      "mul_self_eq_one_iff",
+      "Nat.Prime.eq_one_or_self_of_dvd"
+    ],
+    "originalContributions": [
+      "two_not_isSquare: for p ≡ 1 (mod 4) and q = 2p+1 prime, 2 is a quadratic non-residue mod q (via q ≡ 3 (mod 8) and the supplement to quadratic reciprocity)",
+      "two_pow_eq_neg_one: the core congruence 2^p = −1 in ZMod (2p+1), obtained from Euler's criterion plus the fact that 2^p squares to 2^(q−1) = 1 so it is ±1 and +1 is excluded",
+      "two_pow_add_one_dvd: the main theorem — a Sophie Germain prime p ≡ 1 (mod 4) forces q = 2p+1 ∣ 2^p + 1, the complement of the sibling's q ∣ 2^p − 1",
+      "two_pow_add_one_not_prime: q is a proper divisor (1 < q < 2^p+1 for p ≥ 5), so 2^p + 1 is composite",
+      "two_mul_lt_two_pow: the exponential separation 2n < 2^n for n ≥ 5 used to place q strictly below 2^p + 1"
+    ],
+    "prerequisites": [
+      "The supplement to quadratic reciprocity: 2 is a residue mod an odd prime q iff q ≡ ±1 (mod 8)",
+      "Euler's criterion: a nonzero a is a square in ZMod q iff a^((q−1)/2) = 1",
+      "Fermat's little theorem in ZMod and ℕ truncated-subtraction discipline"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 177,
+    "relatedProblems": ["sophie-germain", "sophie-germain-oq-01-oq-02", "mersenne-prime"],
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "A prime p is a Sophie Germain prime when q = 2p+1 is also prime; q is then a safe prime. Whether the safe prime divides 2^p − 1 or 2^p + 1 is decided entirely by p modulo 4, because q's residue modulo 8 — and hence whether 2 is a quadratic residue modulo q — is a function of p mod 4. The case p ≡ 3 (mod 4), giving q ∣ 2^p − 1, is the classical reason behind composite Mersenne numbers such as M₁₁ = 2047 = 23 · 89 and underlies Euler's and Lagrange's results on Sophie Germain primes; it is the content of the sibling entry sophie-germain-oq-01-oq-02. The complementary class p ≡ 1 (mod 4) is the natural other half and is settled here.",
+    "problemStatement": "Determine, for a Sophie Germain prime p ≡ 1 (mod 4), how the safe prime q = 2p+1 relates to the base-2 power 2^p, and deduce the divisibility and compositeness consequences.",
+    "proofStrategy": "Set q = 2p+1. From p ≡ 1 (mod 4) compute q ≡ 3 (mod 8) (safePrime_mod_eight). The supplement to quadratic reciprocity (ZMod.exists_sq_eq_two_iff) says 2 is a square mod q iff q ≡ 1 or 7 (mod 8); since q ≡ 3 it is not, so 2 is a non-residue (two_not_isSquare). Euler's criterion (ZMod.euler_criterion) characterizes squares by a^((q−1)/2) = 1, so the non-residue 2 has 2^((q−1)/2) ≠ 1. Its square is 2^(q−1) = 1 by Fermat (ZMod.pow_card_sub_one_eq_one), so 2^((q−1)/2) = ±1, and being ≠ 1 it equals −1. As (q−1)/2 = q/2 = p, this is 2^p = −1 in ZMod q (two_pow_eq_neg_one), i.e. q ∣ 2^p + 1 (two_pow_add_one_dvd). Finally, for p ≥ 5 the divisor q satisfies 1 < q < 2^p + 1 (using 2p < 2^p), so it is proper and 2^p + 1 is composite (two_pow_add_one_not_prime).",
+    "keyInsights": [
+      "The single quantity that controls everything is q mod 8, and it is pinned by p mod 4: p ≡ 1 (mod 4) ⇒ q ≡ 3 (mod 8), p ≡ 3 (mod 4) ⇒ q ≡ 7 (mod 8).",
+      "q ≡ 3 (mod 8) makes 2 a quadratic non-residue, which is exactly what flips Euler's criterion from +1 to −1 and turns 2^p − 1 divisibility into 2^p + 1 divisibility.",
+      "Euler's criterion only gives 'not equal to 1'; the value −1 is recovered because 2^p squares to 2^(q−1) = 1, so it is a square root of unity in a field and the excluded value 1 leaves only −1.",
+      "The exponent bookkeeping is exact: (q−1)/2 = q/2 = p with q = 2p+1, so no half-integer or rounding issues arise.",
+      "Compositeness needs the divisor to be proper: 2p < 2^p for p ≥ 5 places q = 2p+1 strictly below 2^p + 1, ruling out the degenerate case where 2^p + 1 could itself be the prime q."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "two_pow_add_one_dvd",
+      "statement": "p.Prime → p % 4 = 1 → (2*p+1).Prime → (2*p+1) ∣ 2^p + 1",
+      "description": "Main theorem: a Sophie Germain prime p ≡ 1 (mod 4) forces its safe prime q = 2p+1 to divide 2^p + 1, the exact complement of the sibling's q ∣ 2^p − 1 for p ≡ 3 (mod 4)."
+    },
+    {
+      "name": "two_pow_eq_neg_one",
+      "statement": "p.Prime → p % 4 = 1 → (2*p+1).Prime → (2 : ZMod (2*p+1))^p = -1",
+      "description": "The core congruence in ZMod q: 2^p = −1, from Euler's criterion (2 is a non-residue) together with 2^p being a square root of unity."
+    },
+    {
+      "name": "two_pow_add_one_not_prime",
+      "statement": "p.Prime → p % 4 = 1 → (2*p+1).Prime → ¬ (2^p + 1).Prime",
+      "description": "Compositeness corollary: q = 2p+1 is a proper divisor (1 < q < 2^p+1 for p ≥ 5), so 2^p + 1 is composite."
+    }
+  ],
+  "sections": [
+    {
+      "id": "safe-prime-arithmetic",
+      "title": "Arithmetic of the Safe Prime q = 2p+1",
+      "startLine": 50,
+      "endLine": 82,
+      "summary": "Re-declares IsSophieGermainPrime locally and records the modular facts used throughout: q ≡ 3 (mod 8) when p ≡ 1 (mod 4) (safePrime_mod_eight), q ≠ 2 and p ≥ 5 for such primes (safePrime_ne_two, five_le_of_prime_mod_four), and the exponential estimate 2n < 2^n for n ≥ 5 (two_mul_lt_two_pow).",
+      "mathContext": "$p \\equiv 1 \\pmod 4 \\Rightarrow q = 2p+1 \\equiv 3 \\pmod 8$."
+    },
+    {
+      "id": "non-residue-and-euler",
+      "title": "Non-Residue and Euler's Criterion",
+      "startLine": 83,
+      "endLine": 133,
+      "summary": "two_not_isSquare uses q ≡ 3 (mod 8) and ZMod.exists_sq_eq_two_iff to show 2 is a quadratic non-residue mod q. two_pow_eq_neg_one then applies Euler's criterion and Fermat's little theorem: 2^((q−1)/2) ≠ 1 and (2^p)^2 = 2^(q−1) = 1, so 2^p = −1 in ZMod q.",
+      "mathContext": "$2^{(q-1)/2} \\equiv -1 \\pmod q,\\quad (q-1)/2 = p$."
+    },
+    {
+      "id": "divisibility-and-compositeness",
+      "title": "Divisibility and Compositeness",
+      "startLine": 134,
+      "endLine": 177,
+      "summary": "two_pow_add_one_dvd transfers 2^p = −1 to q ∣ 2^p + 1 via ZMod.natCast_eq_zero_iff; sophieGermain_dvd_two_pow_add_one packages it with the IsSophieGermainPrime predicate. two_pow_add_one_not_prime concludes compositeness from the proper divisor q. A sanity example checks 11 ∣ 2^5 + 1 = 33.",
+      "mathContext": "$q \\mid 2^p + 1,\\quad 1 < q < 2^p + 1 \\ (p \\ge 5)$."
+    }
+  ],
+  "references": [
+    {
+      "title": "Safe and Sophie Germain primes",
+      "url": "https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes"
+    },
+    {
+      "title": "Euler's criterion",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_criterion"
+    },
+    {
+      "title": "Quadratic reciprocity (supplement for 2)",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "sophie-germain-oq-01-oq-02",
+      "relationship": "Complementary residue class",
+      "description": "The sibling entry handles p ≡ 3 (mod 4), giving q ≡ 7 (mod 8), 2 a residue, and q ∣ 2^p − 1. This entry handles p ≡ 1 (mod 4), giving q ≡ 3 (mod 8), 2 a non-residue, and q ∣ 2^p + 1. Together they form the complete mod-4 dichotomy for safe primes."
+    },
+    {
+      "proofId": "sophie-germain",
+      "relationship": "Refines the parent Sophie Germain entry",
+      "description": "The base entry studies Sophie Germain primes and safe primes; this leaf supplies the exact divisibility law relating q = 2p+1 to 2^p ± 1 according to p mod 4."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a Sophie Germain prime p ≡ 1 (mod 4) the safe prime q = 2p+1 satisfies q ≡ 3 (mod 8), making 2 a quadratic non-residue modulo q; Euler's criterion then forces 2^p = −1 in ZMod q, i.e. q ∣ 2^p + 1, and q is a proper divisor so 2^p + 1 is composite. This is the exact mirror of the sibling result q ∣ 2^p − 1 for p ≡ 3 (mod 4). Machine-checked with zero sorries and zero axioms.",
+    "implications": "Combined with sophie-germain-oq-01-oq-02 this gives a complete, residue-indexed account of how a safe prime divides the base-2 power at its half-period: p ≡ 3 (mod 4) ↦ 2^p − 1, p ≡ 1 (mod 4) ↦ 2^p + 1. The p ≡ 1 case is the structural reason certain 2^p + 1 values are composite.",
+    "openQuestions": [
+      "What is the analogous dichotomy for an odd base b in place of 2, indexing by the residue of q controlling whether b is a quadratic residue modulo q?",
+      "Can the two cases be unified into a single statement about the order of 2 modulo q = 2p+1 (here forced to be 2p or p) across both residue classes?"
+    ]
+  }
+}

--- a/src/data/research/problems/sophie-germain-oq-01-oq-03.json
+++ b/src/data/research/problems/sophie-germain-oq-01-oq-03.json
@@ -1,0 +1,133 @@
+{
+  "slug": "sophie-germain-oq-01-oq-03",
+  "title": "Sophie Germain Primes p ≡ 1 (mod 4) Force 2p+1 ∣ 2^p + 1",
+  "tier": "B",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "problemStatement": "Settle the complementary residue class of the safe-prime divisibility dichotomy: prove that if p is prime, p ≡ 1 (mod 4), and q = 2p+1 is prime, then q ∣ 2^p + 1 (the mirror of the sibling result q ∣ 2^p − 1 for p ≡ 3 (mod 4)).",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "path": "Proofs/SophieGermainOQ0103.lean",
+  "leanFiles": [
+    {
+      "path": "Proofs/SophieGermain.lean",
+      "filename": "SophieGermain.lean",
+      "lineCount": 297,
+      "theoremCount": 31,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SophieGermain.lean"
+    },
+    {
+      "path": "Proofs/SophieGermainOQ01.lean",
+      "filename": "SophieGermainOQ01.lean",
+      "lineCount": 197,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SophieGermainOQ01.lean"
+    },
+    {
+      "path": "Proofs/SophieGermainOQ0103.lean",
+      "filename": "SophieGermainOQ0103.lean",
+      "lineCount": 178,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SophieGermainOQ0103.lean"
+    },
+    {
+      "path": "Proofs/SophieGermainOQ02.lean",
+      "filename": "SophieGermainOQ02.lean",
+      "lineCount": 157,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SophieGermainOQ02.lean"
+    },
+    {
+      "path": "Proofs/SophieGermainOQ03.lean",
+      "filename": "SophieGermainOQ03.lean",
+      "lineCount": 190,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SophieGermainOQ03.lean"
+    },
+    {
+      "path": "Proofs/SophieGermainOQ04.lean",
+      "filename": "SophieGermainOQ04.lean",
+      "lineCount": 72,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SophieGermainOQ04.lean"
+    }
+  ],
+  "relatedProofs": [
+    "sophie-germain",
+    "sophie-germain-oq-01",
+    "sophie-germain-oq-01-oq-02",
+    "sophie-germain-oq-01-oq-03",
+    "sophie-germain-oq-02",
+    "sophie-germain-oq-03",
+    "sophie-germain-oq-04"
+  ],
+  "tags": [
+    "number-theory",
+    "sophie-germain",
+    "quadratic-residue",
+    "euler-criterion",
+    "safe-prime",
+    "fermat-number"
+  ],
+  "currentState": "Solved. The Lean file SophieGermainOQ0103.lean compiles with 0 sorries and 0 axioms (only propext / Classical.choice / Quot.sound). Main theorem two_pow_add_one_dvd plus the compositeness corollary two_pow_add_one_not_prime.",
+  "problemStatementResolved": true,
+  "knownResults": [
+    "Classical: for a Sophie Germain prime p, q = 2p+1 divides 2^p − 1 when p ≡ 3 (mod 4) and 2^p + 1 when p ≡ 1 (mod 4); the trigger is whether 2 is a quadratic residue mod q, equivalently q mod 8.",
+    "Mathlib provides ZMod.exists_sq_eq_two_iff (supplement for 2), ZMod.euler_criterion, and ZMod.pow_card_sub_one_eq_one (Fermat)."
+  ],
+  "references": [
+    {
+      "title": "Safe and Sophie Germain primes",
+      "url": "https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes"
+    },
+    {
+      "title": "Euler's criterion",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_criterion"
+    }
+  ],
+  "knowledge": {
+    "insights": [
+      "q mod 8 is a function of p mod 4: p ≡ 1 (mod 4) ⇒ q = 2p+1 ≡ 3 (mod 8), which makes 2 a quadratic non-residue and flips Euler's criterion from +1 to −1.",
+      "Euler's criterion alone only gives 2^((q−1)/2) ≠ 1; the value −1 is recovered because (2^p)^2 = 2^(q−1) = 1, so 2^p is a square root of unity and +1 is excluded.",
+      "Exponent bookkeeping is exact: with q = 2p+1, (q−1)/2 = q/2 = p, so no rounding arises.",
+      "Compositeness of 2^p + 1 requires q to be a PROPER divisor; 2p < 2^p for p ≥ 5 places q strictly below 2^p + 1."
+    ],
+    "builtItems": [
+      "two_not_isSquare (Proofs/SophieGermainOQ0103.lean): 2 is a non-residue mod q for p ≡ 1 (mod 4)",
+      "two_pow_eq_neg_one: the core congruence 2^p = −1 in ZMod (2p+1)",
+      "two_pow_add_one_dvd: main theorem q ∣ 2^p + 1",
+      "two_pow_add_one_not_prime: 2^p + 1 is composite",
+      "two_mul_lt_two_pow: 2n < 2^n for n ≥ 5 (Nat.le_induction)"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Generalize to an odd base b: index the dichotomy by whether b is a quadratic residue mod q = 2p+1.",
+      "Unify both residue classes via the multiplicative order of 2 mod q (forced to be 2p or p)."
+    ],
+    "progressSummary": "COMPLETE: p ≡ 1 (mod 4) Sophie Germain prime ⇒ 2p+1 ∣ 2^p + 1, verified 0-axiom; completes the mod-4 dichotomy with sibling sophie-germain-oq-01-oq-02."
+  }
+}


### PR DESCRIPTION
## Summary

Completes the **mod-4 dichotomy for safe primes**, the complement of sibling PR #29744 (`sophie-germain-oq-01-oq-02`).

| `p mod 4` | `q = 2p+1 mod 8` | `2` mod `q` | `2^p mod q` | divisibility |
|---|---|---|---|---|
| 3 | 7 | residue | +1 | `q ∣ 2^p − 1` (sibling) |
| **1** | **3** | **non-residue** | **−1** | **`q ∣ 2^p + 1`** (this PR) |

**Theorem.** If `p` is prime, `p ≡ 1 (mod 4)`, and `q = 2p+1` is prime, then `q ∣ 2^p + 1` (and `2^p + 1` is composite).

## Proof
`p ≡ 1 (mod 4)` ⟹ `q ≡ 3 (mod 8)` ⟹ by the supplement to quadratic reciprocity (`ZMod.exists_sq_eq_two_iff`) **2 is a non-residue** mod `q` ⟹ Euler's criterion (`ZMod.euler_criterion`) gives `2^((q−1)/2) ≠ 1`; since `(2^p)² = 2^(q−1) = 1` (Fermat), `2^p = −1` in `ZMod q`. As `(q−1)/2 = p`, this is `q ∣ 2^p + 1`. Witness: `11 ∣ 2^5 + 1 = 33`.

## Verification
- Self-contained (re-declares `IsSophieGermainPrime`); compiles standalone with host `lake env lean`.
- 9 theorems / 1 def / 177 lines; **0 sorries, 0 axioms**.
- `#print axioms` reports only `propext / Classical.choice / Quot.sound` for the main theorem and the compositeness corollary (numeric example uses kernel `decide`, no `Lean.ofReduceBool`).

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)