### PR TITLE
research(euler-totient-oq-01-oq-01-oq-02): Carmichael's theorem and the sharp universal exponent λ(n) ∣ φ(n) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2811,6 +2811,7 @@ import Proofs.EulerTotientOQ01OQ02OQ01
 import Proofs.EulerTotientOQ01OQ02OQ03
 import Proofs.EulerTotientOQ01OQ01
 import Proofs.EulerTotientOQ01OQ01OQ01
+import Proofs.EulerTotientOQ01OQ01OQ02
 import Proofs.EulerTotientOQ01OQ03
 import Proofs.EulerTotientOQ01OQ03Keygen
 import Proofs.EulerTotientOQ01OQ03Minimal

--- a/proofs/Proofs/EulerTotientOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/EulerTotientOQ01OQ01OQ02.lean
@@ -1,0 +1,82 @@
+import Mathlib
+import Proofs.EulerTotientOQ01OQ01
+
+/-
+# Euler's Totient — OQ-01-OQ-01-OQ-02: Carmichael's theorem and the sharp universal exponent
+
+## Research Problem: euler-totient-oq-01-oq-01-oq-02
+
+The parent `euler-totient-oq-01-oq-01` introduced Carmichael's function
+λ(n) = exponent of the unit group (ℤ/nℤ)* and proved its **multiplicativity**
+λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n.  The sibling
+`euler-totient-oq-01-oq-01-oq-01` derived the **explicit value**
+λ(n) = lcm_p p^(k−1)(p−1).  This leaf supplies the missing *operational content*:
+the theorem that gives λ its name and its meaning as a refinement of Euler's
+totient theorem.
+
+**Carmichael's theorem.**  For every unit `a` of ℤ/nℤ,
+
+    a ^ λ(n) = 1.
+
+Moreover λ(n) is the *sharp* universal exponent:
+
+* **Minimality.**  Any `k` with `a^k = 1` for all units `a` is a multiple of λ(n).
+* **Attainment.**  There is a unit of order exactly λ(n) (so the bound is met).
+* **Refinement of Euler.**  λ(n) ∣ φ(n), and feeding this back recovers the
+  Fermat–Euler theorem `a ^ φ(n) = 1` — with λ(n), generally smaller than φ(n),
+  as the true period.
+
+We reuse the parent's definition `carmichael n = Monoid.exponent (ZMod n)ˣ`, so
+each statement is a clean specialisation of Mathlib's monoid-exponent API to the
+unit group, with the totient bridge `ZMod.card_units_eq_totient`.  Verified,
+0 axioms.
+
+Tags: number-theory, carmichael-function, euler-totient, exponent, units, fermat-euler
+-/
+
+namespace EulerTotientOQ01OQ01OQ02
+
+open CarmichaelMultiplicative
+
+/-- **Carmichael's theorem.**  Every unit of `ℤ/nℤ` is killed by λ(n):
+`a ^ λ(n) = 1`.  This is the universal-exponent statement underlying
+Carmichael's function (a sharpening of Euler's `a ^ φ(n) = 1`). -/
+theorem unit_pow_carmichael (n : ℕ) (a : (ZMod n)ˣ) :
+    a ^ carmichael n = 1 := by
+  unfold carmichael
+  exact Monoid.pow_exponent_eq_one a
+
+/-- **Minimality of λ(n).**  Any common exponent `k` of the unit group — i.e. any
+`k` with `a ^ k = 1` for every unit `a` — is a multiple of λ(n).  Together with
+`unit_pow_carmichael` this says λ(n) is the *least* positive universal exponent. -/
+theorem carmichael_dvd_of_forall_pow_eq_one (n : ℕ) {k : ℕ}
+    (hk : ∀ a : (ZMod n)ˣ, a ^ k = 1) : carmichael n ∣ k := by
+  unfold carmichael
+  exact Monoid.exponent_dvd_iff_forall_pow_eq_one.mpr hk
+
+/-- **Attainment / sharpness.**  For `n ≥ 1` there is a unit of `ℤ/nℤ` whose order
+is exactly λ(n) (a "λ-primitive" element).  Hence the universal-exponent bound
+`a ^ λ(n) = 1` is met by some element and cannot be lowered. -/
+theorem exists_unit_orderOf_eq_carmichael (n : ℕ) [NeZero n] :
+    ∃ a : (ZMod n)ˣ, orderOf a = carmichael n := by
+  unfold carmichael
+  exact Monoid.exists_orderOf_eq_exponent Monoid.ExponentExists.of_finite
+
+/-- **λ refines φ:** Carmichael's function divides Euler's totient,
+`λ(n) ∣ φ(n)`.  The exponent of a finite group divides its order, and the unit
+group of `ℤ/nℤ` has order φ(n). -/
+theorem carmichael_dvd_totient (n : ℕ) [NeZero n] :
+    carmichael n ∣ n.totient := by
+  unfold carmichael
+  rw [← ZMod.card_units_eq_totient n, ← Nat.card_eq_fintype_card]
+  exact Group.exponent_dvd_nat_card
+
+/-- **Euler's theorem recovered from Carmichael.**  Since λ(n) ∣ φ(n) and
+`a ^ λ(n) = 1`, every unit satisfies `a ^ φ(n) = 1` — the Fermat–Euler theorem,
+now seen as a corollary of the sharper Carmichael period λ(n). -/
+theorem unit_pow_totient (n : ℕ) [NeZero n] (a : (ZMod n)ˣ) :
+    a ^ n.totient = 1 := by
+  obtain ⟨m, hm⟩ := carmichael_dvd_totient n
+  rw [hm, pow_mul, unit_pow_carmichael, one_pow]
+
+end EulerTotientOQ01OQ01OQ02

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-carmichael-theorem",
+    "proofId": "euler-totient-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 50
+    },
+    "type": "theorem",
+    "title": "Carmichael's Theorem",
+    "content": "`unit_pow_carmichael`: every unit `a` of `ℤ/nℤ` satisfies `a ^ λ(n) = 1`. Because the parent defines `carmichael n = Monoid.exponent (ZMod n)ˣ`, this is the defining property of the group exponent, specialised from Mathlib's `Monoid.pow_exponent_eq_one`. It is the universal-exponent statement that names Carmichael's function and refines the Fermat–Euler theorem `a ^ φ(n) = 1`.",
+    "mathContext": "$a^{\\lambda(n)} \\equiv 1 \\pmod n$ for every $a$ coprime to $n$, where $\\lambda(n) = \\exp\\big((\\mathbb{Z}/n\\mathbb{Z})^\\times\\big)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Carmichael's function",
+      "group exponent",
+      "Fermat–Euler theorem"
+    ],
+    "prerequisites": [
+      "the parent definition λ(n) = exponent of the unit group",
+      "Monoid.pow_exponent_eq_one"
+    ]
+  },
+  {
+    "id": "ann-minimality",
+    "proofId": "euler-totient-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 52,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "Minimality of λ(n)",
+    "content": "`carmichael_dvd_of_forall_pow_eq_one`: any `k` such that `a ^ k = 1` for every unit `a` is a multiple of `λ(n)`. This is the (⇐) direction of `Monoid.exponent_dvd_iff_forall_pow_eq_one`. Combined with Carmichael's theorem it says λ(n) is the LEAST positive universal exponent of the unit group — no smaller exponent kills all units.",
+    "mathContext": "$\\big(\\forall a,\\ a^k = 1\\big) \\implies \\lambda(n) \\mid k$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "least universal exponent",
+      "divisibility characterisation of the exponent"
+    ],
+    "prerequisites": [
+      "Monoid.exponent_dvd_iff_forall_pow_eq_one"
+    ]
+  },
+  {
+    "id": "ann-attainment",
+    "proofId": "euler-totient-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 60,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Attainment of the Exponent (Sharpness)",
+    "content": "`exists_unit_orderOf_eq_carmichael`: for `n ≥ 1` there is a unit of `ℤ/nℤ` whose order is exactly `λ(n)`. The finite unit group satisfies `Monoid.ExponentExists.of_finite`, so `Monoid.exists_orderOf_eq_exponent` produces the witness. Together with minimality this pins λ(n) as the sharp universal exponent: the bound `a^λ(n)=1` is attained and cannot be lowered.",
+    "mathContext": "$\\exists a \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times,\\ \\operatorname{ord}(a) = \\lambda(n)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "exponent attainment",
+      "maximal order",
+      "finite abelian groups"
+    ],
+    "prerequisites": [
+      "Monoid.exists_orderOf_eq_exponent",
+      "Monoid.ExponentExists.of_finite",
+      "finiteness of (ℤ/nℤ)* for n ≥ 1"
+    ]
+  },
+  {
+    "id": "ann-dvd-totient",
+    "proofId": "euler-totient-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "λ(n) Divides φ(n)",
+    "content": "`carmichael_dvd_totient`: `λ(n) ∣ φ(n)`. The exponent of a finite group divides its order (`Group.exponent_dvd_nat_card`), and the unit group of `ℤ/nℤ` has order `φ(n)` (`ZMod.card_units_eq_totient`). This single divisibility is exactly why Carmichael's theorem refines Euler's.",
+    "mathContext": "$\\lambda(n) \\mid \\varphi(n)$; e.g. $\\lambda(8) = 2 \\mid 4 = \\varphi(8)$, $\\lambda(561) = 80 \\mid 320 = \\varphi(561)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "exponent divides order",
+      "Euler's totient",
+      "order of the unit group"
+    ],
+    "prerequisites": [
+      "Group.exponent_dvd_nat_card",
+      "ZMod.card_units_eq_totient"
+    ]
+  },
+  {
+    "id": "ann-euler-recovered",
+    "proofId": "euler-totient-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Euler's Theorem Recovered from Carmichael",
+    "content": "`unit_pow_totient`: `a ^ φ(n) = 1` for every unit, derived from `a^λ(n)=1` and `λ(n) ∣ φ(n)` by writing `φ(n) = λ(n)·m` and collapsing `(a^λ(n))^m = 1`. This exhibits the Fermat–Euler theorem as a corollary of the sharper Carmichael period λ(n), generally smaller than φ(n).",
+    "mathContext": "$a^{\\varphi(n)} = (a^{\\lambda(n)})^{m} = 1$ where $\\varphi(n) = \\lambda(n)\\,m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat–Euler theorem",
+      "corollary of Carmichael's theorem"
+    ],
+    "prerequisites": [
+      "unit_pow_carmichael",
+      "carmichael_dvd_totient"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "euler-totient-oq-01-oq-01-oq-02",
+  "title": "Carmichael's Theorem: λ(n) is the Sharp Universal Exponent Dividing φ(n)",
+  "slug": "euler-totient-oq-01-oq-01-oq-02",
+  "description": "The operational content of Carmichael's function for the gallery's λ. The parent (euler-totient-oq-01-oq-01) defined λ(n) as the exponent of the unit group (ℤ/nℤ)* and proved multiplicativity λ(m·n)=lcm(λ(m),λ(n)); the sibling (euler-totient-oq-01-oq-01-oq-01) computed the explicit value λ(n)=lcm_p p^(k−1)(p−1). This leaf assembles the theorem that gives λ its meaning: Carmichael's theorem a^λ(n)=1 for every unit a, together with the three facts that make λ the SHARP universal exponent — minimality (any common exponent of the unit group is a multiple of λ(n)), attainment (some unit has order exactly λ(n)), and the refinement of Euler λ(n)∣φ(n), from which the Fermat–Euler theorem a^φ(n)=1 is recovered as a corollary with λ(n) ≤ φ(n) as the true period. Each statement is a specialisation of Mathlib's monoid-exponent API (Monoid.pow_exponent_eq_one, exponent_dvd_iff_forall_pow_eq_one, exists_orderOf_eq_exponent, Group.exponent_dvd_nat_card) to the unit group, bridged to the totient via ZMod.card_units_eq_totient. Fully machine-checked, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Robb Walters (researcher-3)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ01OQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "carmichael-function",
+      "euler-totient",
+      "exponent",
+      "units",
+      "fermat-euler",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 82,
+    "assumptions": "No axioms or sorries. Theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (the Lean/Mathlib standard, which do not count as assumptions). Verified via #print axioms. The proofs are short specialisations of Mathlib's monoid-exponent API (Monoid.pow_exponent_eq_one, Monoid.exponent_dvd_iff_forall_pow_eq_one, Monoid.exists_orderOf_eq_exponent, Monoid.ExponentExists.of_finite, Group.exponent_dvd_nat_card) applied to the parent's definition carmichael n = Monoid.exponent (ZMod n)ˣ, with the totient bridge ZMod.card_units_eq_totient; the contribution is the assembly of Carmichael's theorem, its sharpness, and the λ∣φ refinement as a coherent named package, which Mathlib does not provide for an ℕ-indexed Carmichael function. The card/totient and attainment statements carry the standard hypothesis NeZero n (n ≥ 1), not an axiom.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "unit_pow_carmichael — Carmichael's theorem for the gallery's λ: every unit of ℤ/nℤ satisfies a ^ λ(n) = 1, the universal-exponent statement underlying λ (specialising Monoid.pow_exponent_eq_one to the unit group)",
+      "carmichael_dvd_of_forall_pow_eq_one — minimality: any k with a^k = 1 for all units a is a multiple of λ(n), so with Carmichael's theorem λ(n) is the LEAST positive universal exponent",
+      "exists_unit_orderOf_eq_carmichael — attainment/sharpness: for n ≥ 1 some unit has order exactly λ(n), so the bound a^λ(n)=1 is met and cannot be lowered (via exists_orderOf_eq_exponent and ExponentExists.of_finite)",
+      "carmichael_dvd_totient — λ refines φ: λ(n) ∣ φ(n), from the exponent dividing the group order Group.exponent_dvd_nat_card together with #(ℤ/nℤ)* = φ(n)",
+      "unit_pow_totient — Euler recovered from Carmichael: a ^ φ(n) = 1 deduced from a^λ(n)=1 and λ(n)∣φ(n), exhibiting the Fermat–Euler theorem as a corollary of the sharper Carmichael period"
+    ],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.EulerTotientOQ01OQ01"
+    ],
+    "namespace": "EulerTotientOQ01OQ01OQ02",
+    "lineCount": 82,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/EulerTotientOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Carmichael's function λ(n), introduced by Robert Carmichael in 1910, is the exponent of the multiplicative group (ℤ/nℤ)*: the least positive integer m such that a^m ≡ 1 (mod n) for every a coprime to n. Carmichael's theorem a^λ(n) ≡ 1 (mod n) sharpens the Fermat–Euler theorem a^φ(n) ≡ 1 (mod n), because λ(n) divides φ(n) and is often strictly smaller (for example λ(8) = 2 while φ(8) = 4, and λ(561) = 80 while φ(561) = 320). The gallery's parent chain established λ as a group exponent and proved it multiplicative, then computed its explicit prime-power value; what remained was the theorem that justifies the name and the precise sense in which λ(n) is the best possible exponent. Mathlib provides the Fermat–Euler theorem and a full monoid-exponent API but no ℕ-indexed Carmichael function, so the named package is assembled here.",
+    "problemStatement": "Working with the parent's definition λ(n) = exponent of (ℤ/nℤ)*, prove Carmichael's theorem a^λ(n) = 1 for every unit a, and establish that λ(n) is the sharp universal exponent: it is the least positive m with a^m = 1 for all units (minimality), it is attained as the order of some unit (attainment), it divides Euler's totient λ(n) ∣ φ(n), and the Fermat–Euler theorem a^φ(n) = 1 follows as a corollary.",
+    "text": "Since λ(n) is defined as Monoid.exponent (ℤ/nℤ)*, Carmichael's theorem is the specialisation of Mathlib's Monoid.pow_exponent_eq_one. Minimality is Monoid.exponent_dvd_iff_forall_pow_eq_one, which characterises divisors of the exponent as the common exponents of the group. Attainment uses Monoid.exists_orderOf_eq_exponent — valid because (ℤ/nℤ)* is finite for n ≥ 1, supplying Monoid.ExponentExists.of_finite. The refinement λ(n) ∣ φ(n) is the exponent dividing the group order (Group.exponent_dvd_nat_card) once #(ℤ/nℤ)* is rewritten to φ(n) via ZMod.card_units_eq_totient and Nat.card_eq_fintype_card. Finally a^φ(n) = 1 follows by writing φ(n) = λ(n)·m and collapsing (a^λ(n))^m = 1.",
+    "proofStrategy": "1. unit_pow_carmichael: unfold λ and apply Monoid.pow_exponent_eq_one. 2. carmichael_dvd_of_forall_pow_eq_one: unfold λ and apply the (⇐) direction of Monoid.exponent_dvd_iff_forall_pow_eq_one. 3. exists_unit_orderOf_eq_carmichael: unfold λ and apply Monoid.exists_orderOf_eq_exponent with Monoid.ExponentExists.of_finite (finiteness from NeZero n). 4. carmichael_dvd_totient: unfold λ, rewrite #units = φ(n) (ZMod.card_units_eq_totient) and to Nat.card (Nat.card_eq_fintype_card), then Group.exponent_dvd_nat_card. 5. unit_pow_totient: obtain φ(n) = λ(n)·m from step 4, rewrite with pow_mul and unit_pow_carmichael, close by one_pow.",
+    "keyInsights": [
+      "Defining λ(n) as the group exponent makes Carmichael's theorem a^λ(n)=1 the exponent's defining property — the mathematical work lives in the definition (parent) and the explicit value (sibling); this leaf packages the consequence and its sharpness.",
+      "λ(n) is sharp from both sides: minimality (every common exponent is a multiple of λ) and attainment (some element has order exactly λ) together pin λ(n) as the least universal exponent and show the bound is met.",
+      "The single inequality λ(n) ∣ φ(n) is the exponent dividing the group order; it is exactly why Carmichael's theorem refines Euler's, and feeding it back recovers a^φ(n)=1 with λ(n) ≤ φ(n) as the genuine period.",
+      "The totient enters only through the order of the unit group #(ℤ/nℤ)* = φ(n); no arithmetic of φ is needed, only this cardinality bridge, which keeps the refinement of Euler purely group-theoretic."
+    ],
+    "prerequisites": [
+      "The parent definition λ(n) = exponent of (ℤ/nℤ)* (euler-totient-oq-01-oq-01)",
+      "Monoid/Group exponent: pow_exponent_eq_one, exponent_dvd_iff_forall_pow_eq_one, exists_orderOf_eq_exponent, ExponentExists.of_finite, Group.exponent_dvd_nat_card",
+      "The unit group of ℤ/nℤ, its finiteness for n ≥ 1, and the cardinality #(ℤ/nℤ)* = φ(n) (ZMod.card_units_eq_totient)",
+      "Fermat–Euler theorem as the classical statement being refined"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-carmichael-theorem",
+      "title": "Part I: Carmichael's Theorem and Minimality",
+      "startLine": 44,
+      "endLine": 58,
+      "summary": "unit_pow_carmichael gives a^λ(n)=1 for every unit (specialising Monoid.pow_exponent_eq_one); carmichael_dvd_of_forall_pow_eq_one shows any common exponent of the unit group is a multiple of λ(n), so λ(n) is the least positive universal exponent."
+    },
+    {
+      "id": "part2-sharpness",
+      "title": "Part II: Attainment of the Exponent",
+      "startLine": 60,
+      "endLine": 66,
+      "summary": "exists_unit_orderOf_eq_carmichael: for n ≥ 1 the finite unit group has an element of order exactly λ(n) (Monoid.exists_orderOf_eq_exponent with ExponentExists.of_finite), so the bound a^λ(n)=1 is sharp and met."
+    },
+    {
+      "id": "part3-refines-euler",
+      "title": "Part III: λ ∣ φ and Euler Recovered",
+      "startLine": 68,
+      "endLine": 82,
+      "summary": "carmichael_dvd_totient proves λ(n) ∣ φ(n) from the exponent dividing the unit-group order and #(ℤ/nℤ)* = φ(n); unit_pow_totient then recovers the Fermat–Euler theorem a^φ(n)=1 as a corollary of the sharper Carmichael period."
+    }
+  ],
+  "conclusion": {
+    "summary": "Carmichael's theorem and the sharpness of λ(n) are established for the gallery's Carmichael function: every unit of ℤ/nℤ satisfies a^λ(n)=1, λ(n) is the least positive universal exponent (minimality plus attainment), and λ(n) ∣ φ(n), from which the Fermat–Euler theorem a^φ(n)=1 follows with λ(n) ≤ φ(n) as the true period. The proofs are short specialisations of Mathlib's monoid-exponent API to the unit group; the contribution is the coherent named package, completing the operational picture of λ left open by the parent (multiplicativity) and sibling (explicit value). Fully machine-checked, 0 axioms, 0 sorries.",
+    "openQuestions": [
+      "Strictness: characterise exactly when λ(n) < φ(n) (equivalently when (ℤ/nℤ)* is not cyclic) and quantify the gap φ(n)/λ(n).",
+      "Carmichael numbers: use a^λ(n)=1 with the explicit λ to formalise that a composite n is a Carmichael number iff λ(n) ∣ n−1 (Korselt's criterion), e.g. λ(561) = 80 ∣ 560.",
+      "Lift the unit-group statements a^λ(n)=1 to the congruence form a^λ(n) ≡ 1 (mod n) on integers coprime to n, packaging the ZMod-units result as a statement about ℤ."
+    ],
+    "implications": "Supplies the theorem that justifies Carmichael's function and pins down the precise sense in which λ(n) improves on Euler's φ(n): it is the least universal exponent, attained, and a divisor of φ(n). Together with the parent's multiplicativity and the sibling's explicit formula, the gallery now has λ as a fully operational object — definition, value, and governing theorem — ready for downstream uses such as Korselt's criterion for Carmichael numbers and primitive-root / cyclicity questions."
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-01-oq-01",
+      "relationship": "parent-problem",
+      "description": "Uses the parent's definition λ(n) = exponent of (ℤ/nℤ)* and complements its multiplicativity theorem with the operational content: Carmichael's theorem a^λ(n)=1, sharpness, and λ(n) ∣ φ(n)."
+    },
+    {
+      "targetId": "euler-totient-oq-01-oq-01-oq-01",
+      "relationship": "sibling-problem",
+      "description": "Companion to the sibling's explicit value λ(n) = lcm_p p^(k−1)(p−1): that entry computes λ, this one proves the theorem a^λ(n)=1 and the sense in which λ is the sharp universal exponent dividing φ(n)."
+    }
+  ],
+  "references": [
+    {
+      "author": "Robert D. Carmichael",
+      "title": "Note on a new number theory function",
+      "year": 1910,
+      "note": "Introduces λ(n) and the theorem a^λ(n) ≡ 1 (mod n) refining the Fermat–Euler theorem."
+    }
+  ]
+}

--- a/src/data/research/problems/euler-totient-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-01-oq-02.json
@@ -1,0 +1,45 @@
+{
+  "slug": "euler-totient-oq-01-oq-01-oq-02",
+  "status": "active",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "title": "Carmichael's theorem: λ(n) is the sharp universal exponent dividing φ(n)",
+  "problemStatement": "Working with the parent's definition λ(n) = exponent of (ℤ/nℤ)*, prove Carmichael's theorem a^λ(n)=1 for every unit a, and establish that λ(n) is the sharp universal exponent: minimality (any common exponent is a multiple of λ(n)), attainment (some unit has order exactly λ(n)), λ(n) ∣ φ(n), and the Fermat–Euler theorem a^φ(n)=1 as a corollary.",
+  "tags": [
+    "number-theory",
+    "carmichael-function",
+    "euler-totient",
+    "exponent",
+    "units",
+    "fermat-euler",
+    "research"
+  ],
+  "leanFiles": [
+    "proofs/Proofs/EulerTotientOQ01OQ01OQ02.lean"
+  ],
+  "relatedProofs": [
+    "euler-totient-oq-01-oq-01",
+    "euler-totient-oq-01-oq-01-oq-01"
+  ],
+  "knownResults": [
+    "Parent euler-totient-oq-01-oq-01 defines carmichael n = Monoid.exponent (ZMod n)ˣ and proves multiplicativity λ(m·n)=lcm(λ(m),λ(n)) for coprime m,n.",
+    "Sibling euler-totient-oq-01-oq-01-oq-01 computes the explicit value λ(n)=lcm_p p^(k−1)(p−1) and λ(561)=80.",
+    "Mathlib provides the Fermat–Euler theorem (ZMod.pow_totient) and a full monoid-exponent API but no ℕ-indexed Carmichael function; the named theorem package is assembled here."
+  ],
+  "currentState": "COMPLETE: 0 sorries, 0 axioms (only foundational propext/Classical.choice/Quot.sound). 5 theorems, 0 definitions, 82 lines. Builds clean via host lake env lean against the Mathlib cache, importing the parent Proofs.EulerTotientOQ01OQ01. Proofs are short specialisations of Mathlib's monoid-exponent API; badge set to 'verified' (not 'original') to reflect that the value is the coherent assembly rather than new proof technique.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Assembled the operational content of the gallery's Carmichael function. Proved Carmichael's theorem (unit_pow_carmichael: a^λ(n)=1), minimality (carmichael_dvd_of_forall_pow_eq_one), attainment/sharpness (exists_unit_orderOf_eq_carmichael), the refinement λ(n)∣φ(n) (carmichael_dvd_totient), and Euler recovered (unit_pow_totient: a^φ(n)=1). Each is a specialisation of Mathlib's monoid-exponent API to the unit group, bridged to the totient via ZMod.card_units_eq_totient. Badge 'verified'.",
+    "builtItems": [
+      "unit_pow_carmichael: a ^ λ(n) = 1 for every unit (Monoid.pow_exponent_eq_one specialised)",
+      "carmichael_dvd_of_forall_pow_eq_one: any universal exponent k satisfies λ(n) ∣ k (minimality)",
+      "exists_unit_orderOf_eq_carmichael: ∃ unit of order exactly λ(n) for n ≥ 1 (attainment/sharpness)",
+      "carmichael_dvd_totient: λ(n) ∣ φ(n) (exponent divides group order; #units = φ(n))",
+      "unit_pow_totient: a ^ φ(n) = 1 recovered from Carmichael's theorem plus λ ∣ φ"
+    ],
+    "insights": [
+      "Because the parent defines λ(n) as the group exponent, Carmichael's theorem a^λ(n)=1 is the exponent's defining property — the mathematical work is the definition (parent) and the explicit value (sibling); this leaf packages the governing theorem and its sharpness.",
+      "λ(n) is sharp from both sides: minimality (every common exponent is a multiple of λ) plus attainment (some element has order λ) together pin λ(n) as the least universal exponent with the bound met.",
+      "The totient enters only as the order of the unit group (#(ℤ/nℤ)* = φ(n)); the refinement λ(n)∣φ(n) is purely the exponent dividing the order, and feeding it back recovers a^φ(n)=1 with λ(n) ≤ φ(n) as the true period."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Supplies the **operational content** of the gallery's Carmichael function `λ(n)` — the theorem that names it and its precise sense as a sharpening of Euler's totient theorem.

The parent `euler-totient-oq-01-oq-01` defines `λ(n) = exponent of (ℤ/nℤ)*` and proves multiplicativity; the sibling `euler-totient-oq-01-oq-01-oq-01` computes the explicit value `λ(n)=lcm_p p^(k−1)(p−1)`. This leaf adds **Carmichael's theorem and its sharpness**.

## Results

- **`unit_pow_carmichael`** — Carmichael's theorem: `a ^ λ(n) = 1` for every unit `a`.
- **`carmichael_dvd_of_forall_pow_eq_one`** — minimality: any `k` with `a^k = 1` for all units is a multiple of `λ(n)`, so `λ(n)` is the **least** positive universal exponent.
- **`exists_unit_orderOf_eq_carmichael`** — attainment: for `n ≥ 1` some unit has order exactly `λ(n)`; the bound is met and cannot be lowered.
- **`carmichael_dvd_totient`** — `λ(n) ∣ φ(n)` (λ refines φ).
- **`unit_pow_totient`** — Euler recovered: `a ^ φ(n) = 1` follows from `a^λ(n)=1` and `λ ∣ φ`, exhibiting Fermat–Euler as a corollary of the sharper Carmichael period.

## Honest scope / badge

Each proof is a **short specialisation of Mathlib's monoid-exponent API** (`Monoid.pow_exponent_eq_one`, `exponent_dvd_iff_forall_pow_eq_one`, `exists_orderOf_eq_exponent`, `ExponentExists.of_finite`, `Group.exponent_dvd_nat_card`) applied to the parent's `carmichael` definition, bridged to the totient via `ZMod.card_units_eq_totient`. Mathlib has no ℕ-indexed Carmichael function, so the contribution is the **coherent named package** (Carmichael's theorem + sharpness + λ∣φ + Euler recovery), not new proof technique. The badge is intentionally set to **`verified`** rather than `original` to reflect this.

## Verification

- 5 theorems, 0 definitions, 82 lines, **0 sorries, 0 axioms**.
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`.
- Builds clean via host `lake env lean` against the Mathlib cache, importing the parent `Proofs.EulerTotientOQ01OQ01`.
- `card`/attainment statements carry the standard hypothesis `NeZero n` (n ≥ 1), not an axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)