### PR TITLE
audit(gallery): 8 fresh entries clean (arith-series/cauchy-interlacing/dilworth/erdos-211/pell/ptolemy/sophie-germain/viviani)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23285,8 +23285,56 @@
       "lastAudited": "2026-06-25T05:14:05Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq-02-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "cauchy-interlacing-theorem-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "dilworth-theorem-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "erdos-211-incomplete-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-01-oq-04-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "ptolemys-theorem-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "sophie-germain-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
+    },
+    "viviani-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T00:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T04:30:00Z"
+  "lastUpdated": "2026-06-24T00:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 8 entries clean

Audited 8 freshly-merged research entries (the uncovered half of the 16 currently-unaudited; the other 8 are on open PR #29737).

| Slug | Verdict |
|------|---------|
| arithmetic-series-oq-02-oq-01-oq-01-oq-03 | clean |
| cauchy-interlacing-theorem-oq-03-oq-01-oq-02 | clean |
| dilworth-theorem-oq-01-oq-01-oq-03 | clean |
| erdos-211-incomplete-01 | clean |
| pell-equation-oq-01-oq-04-oq-03 | clean |
| ptolemys-theorem-oq-01-oq-01-oq-03 | clean |
| sophie-germain-oq-01-oq-02 | clean |
| viviani-theorem-oq-01-oq-01-oq-02 | clean |

### Checks performed
- **meta.json**: all 8 are `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`.
- **Lean source (comment-stripped)**: 0 sorry, 0 admit, 0 `axiom` decls, 0 `native_decide`, 0 `True`-stubs across all files (2–13 real theorems each).
- **Scope honesty**: titles describe the specific OQ-leaf result, not the parent conjecture. `erdos-211-incomplete-01` is honestly scoped to the Steiner line-count constant `n(n-1)/6` (`card_lines_real`), not the Erdős #211 conjecture. `ptolemy`/`sophie-germain` build genuine bridging content on top of Mathlib primitives rather than thinly wrapping a single theorem.
- **No delegation opacity / axiom masking / inequality-as-theorem / pipeline inflation** detected.

Only `src/data/proofs/audit-tracker.json` is modified.

---
Discovered during gallery integrity audit.