### PR TITLE
Enrich AGM quadratic convergence: annotation depth

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-04/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-preamble",
+    "proofId": "amgm-inequality-oq-04-oq-04",
+    "range": {
+      "startLine": 4,
+      "endLine": 30
+    },
+    "type": "context",
+    "title": "The Open Question: Doubly Exponential AGM Convergence",
+    "content": "The docstring states the parent's open question: prove that the arithmetic–geometric mean iteration aₙ₊₁ = (aₙ+bₙ)/2, bₙ₊₁ = √(aₙbₙ) contracts the gap aₙ − bₙ DOUBLY exponentially (rate (·)^{2ⁿ}), not merely geometrically. The whole file rests on a single per-step algebraic identity expressing the new gap as proportional to the SQUARE of the old gap, plus an abstract lemma turning any such quadratic recursion into the (·)^{2ⁿ} rate. Imports are analysis-only (Real.sqrt and tactics); everything is proved with 0 axioms.",
+    "mathContext": "$a_{n+1} = \\tfrac{a_n+b_n}{2}$, $b_{n+1} = \\sqrt{a_n b_n}$; goal: $a_n - b_n = O\\big(M(a,b)\\,(b/a)^{2^n}\\big)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "arithmetic-geometric mean",
+      "quadratic convergence",
+      "Gauss's AGM",
+      "doubly exponential decay"
+    ],
+    "prerequisites": [
+      "AGM iteration",
+      "rates of convergence"
+    ]
+  },
+  {
     "id": "ann-gap-squares",
     "proofId": "amgm-inequality-oq-04-oq-04",
     "range": {
@@ -8,7 +31,19 @@
     },
     "type": "insight",
     "title": "Each AGM Step Squares the Gap",
-    "content": "agm_gap_eq proves the one-step identity (a+b)/2 − √(ab) = (√a − √b)²/2: the gap after a step is half the square of the difference of square roots (expand √(ab) = √a·√b and (√a)² = a). agm_gap_quadratic then factors (√a − √b)(√a + √b) = a − b to rewrite this as (a − b)²/(2(√a + √b)²) — the new gap is proportional to the SQUARE of the old gap. Squaring the error each step is precisely quadratic convergence, the source of the doubly exponential rate."
+    "content": "agm_gap_eq proves the one-step identity (a+b)/2 − √(ab) = (√a − √b)²/2: the gap after a step is half the square of the difference of square roots (expand √(ab) = √a·√b and (√a)² = a, closed by nlinarith). agm_gap_quadratic then factors (√a − √b)(√a + √b) = a − b to rewrite this as (a − b)²/(2(√a + √b)²) — the new gap is proportional to the SQUARE of the old gap. Squaring the error each step is precisely quadratic convergence, the source of the doubly exponential rate.",
+    "mathContext": "$\\frac{a+b}{2} - \\sqrt{ab} = \\frac{(\\sqrt a - \\sqrt b)^2}{2} = \\frac{(a-b)^2}{2(\\sqrt a + \\sqrt b)^2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic convergence",
+      "Real.sq_sqrt",
+      "difference of squares",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "properties of √ over ℝ",
+      "algebraic manipulation of square roots"
+    ]
   },
   {
     "id": "ann-bound",
@@ -19,7 +54,19 @@
     },
     "type": "concept",
     "title": "A Clean Recursion gₙ₊₁ ≤ gₙ²/(8b)",
-    "content": "agm_gap_le bounds the step by (a − b)²/(8b) for 0 < b ≤ a. Since √a ≥ √b, (√a + √b)² ≥ (2√b)² = 4b, so 2(√a + √b)² ≥ 8b and the quadratic form is at most (a − b)²/(8b). This packages the squaring into a recursion gₙ₊₁ ≤ gₙ²/(8b) whose denominator is controlled by the smaller term — exactly the shape needed to iterate."
+    "content": "agm_gap_le bounds the step by (a − b)²/(8b) for 0 < b ≤ a. Since √a ≥ √b, (√a + √b)² ≥ (2√b)² = 4b, so 2(√a + √b)² ≥ 8b and the quadratic form is at most (a − b)²/(8b) (gcongr after the denominator bound). This packages the squaring into a recursion gₙ₊₁ ≤ gₙ²/(8b) whose denominator is controlled by the smaller term — exactly the shape needed to iterate.",
+    "mathContext": "$\\frac{a+b}{2} - \\sqrt{ab} \\le \\frac{(a-b)^2}{8b}$ for $0 < b \\le a$, since $2(\\sqrt a + \\sqrt b)^2 \\ge 8b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotonicity of √",
+      "gcongr",
+      "recursive bounds",
+      "error contraction"
+    ],
+    "prerequisites": [
+      "Real.sqrt_le_sqrt",
+      "inequality reasoning"
+    ]
   },
   {
     "id": "ann-doubly-exp",
@@ -30,6 +77,18 @@
     },
     "type": "insight",
     "title": "Recursion to Rate: the Doubly Exponential Bound",
-    "content": "quadratic_iteration is the geometry-free engine: any nonnegative sequence with gₙ₊₁ ≤ gₙ²/C satisfies gₙ ≤ C·(g₀/C)^{2ⁿ}. The induction squares the inductive bound and uses 2^(n+1) = 2^n·2 (pow_succ, pow_mul) to land on the next exponent. This is the doubly exponential rate the problem asks for — the gap raised to the 2ⁿ power, far faster than any geometric decay — and the same lemma governs Newton's method and other quadratically convergent iterations."
+    "content": "quadratic_iteration is the geometry-free engine: any nonnegative sequence with gₙ₊₁ ≤ gₙ²/C satisfies gₙ ≤ C·(g₀/C)^{2ⁿ}. The induction squares the inductive bound and uses 2^(n+1) = 2^n·2 (pow_succ, pow_mul) to land on the next exponent. This is the doubly exponential rate the problem asks for — the gap raised to the 2ⁿ power, far faster than any geometric decay — and the same lemma governs Newton's method and other quadratically convergent iterations.",
+    "mathContext": "$g_{n+1} \\le g_n^2/C \\Rightarrow g_n \\le C\\,(g_0/C)^{2^n}$; the exponent doubles each step via $2^{n+1} = 2^n \\cdot 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Newton's method",
+      "doubly exponential decay",
+      "induction on ℕ",
+      "pow_mul / pow_succ"
+    ],
+    "prerequisites": [
+      "mathematical induction",
+      "manipulation of exponents"
+    ]
   }
 ]


### PR DESCRIPTION
Deepening enrichment for `amgm-inequality-oq-04-oq-04` (doubly exponential AGM convergence).

The entry already had annotations.json + overview + sections, but the 3 annotations carried only `title` + `content`. This pass adds the structured fields the gallery renders.

## Changes
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` to every annotation.
- Added a preamble annotation for the open-question docstring (3 → 4 annotations).

No index.ts (obsolete since the loader refactor #20993). Line ranges verified against the 100-line Lean source. JSON validated.