### PR TITLE
research(greens-theorem-oq-01-oq-03-oq-02): Green's theorem glues across a 2D grid of cells [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3085,6 +3085,8 @@ import Proofs.GreensTheoremOQ01OQ01OQ02OQ02
 import Proofs.GreensTheoremOQ01OQ01OQ02OQ03
 import Proofs.GreensTheoremOQ01OQ01OQ03
 import Proofs.GreensTheoremOQ01OQ02
+import Proofs.GreensTheoremOQ01OQ03
+import Proofs.GreensTheoremOQ01OQ03OQ02
 import Proofs.GreensTheoremOQ02
 import Proofs.GreensTheoremOQ02Corrected
 import Proofs.GreensTheoremOQ02Counterexample

--- a/proofs/Proofs/GreensTheoremOQ01OQ03OQ02.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ03OQ02.lean
@@ -1,0 +1,199 @@
+import Mathlib
+import Proofs.GreensTheoremOQ01OQ03
+
+/-
+# OQ-03 → OQ-02: Green's Theorem Glues Across a 2D Grid of Cells
+
+## The Open Question (greens-theorem-oq-01-oq-03-oq-02)
+
+The parent `greens-theorem-oq-01-oq-03` (`GreensTheoremOQ01OQ03.lean`) proved that
+both sides of the concrete Green identity are **additive under a single cut** — a
+vertical cut `x = e` *or* a horizontal cut `y = g` — and packaged the vertical
+direction into the gluing capstone `greens_additive_vertical`: if Green's theorem
+holds on the left and right sub-rectangles meeting along the interior edge `x = e`,
+it holds on their union.  It left two natural next steps:
+
+1. the **horizontal** companion capstone `greens_additive_horizontal` (mirror of
+   the vertical one, gluing a bottom cell and a top cell across `y = g`);
+2. a **two-dimensional** gluing lemma — the first genuine *grid* statement —
+   showing Green's theorem tiles across **both** cut directions at once.
+
+This file supplies both.
+
+## Results
+
+* `greens_additive_horizontal` — Green's theorem is preserved by a horizontal cut.
+  Given the identity on a bottom cell `[a,b]×[c,g]` and a top cell `[a,b]×[g,d]`,
+  it holds on `[a,b]×[c,d]`.  The proof mirrors `greens_additive_vertical`,
+  rewriting through the already-verified `rectLineIntegral_hsplit` and
+  `rectDoubleIntegral_hsplit`; the shared horizontal edge `y = g` cancels by
+  orientation with no extra input.
+
+* `greens_grid_2x2` — **the 2D grid capstone.**  Cut `[a,b]×[c,d]` by the vertical
+  line `x = e` *and* the horizontal line `y = g`, producing the four cells
+
+        BL = [a,e]×[c,g]   BR = [e,b]×[c,g]
+        TL = [a,e]×[g,d]   TR = [e,b]×[g,d].
+
+  If Green's theorem holds on each of the four cells, it holds on the whole
+  rectangle.  The proof first glues the two bottom cells and the two top cells into
+  horizontal strips (`greens_additive_vertical`, twice), then glues the two strips
+  along `y = g` (`greens_additive_horizontal`).  Both interior edges — the vertical
+  `x = e` and the horizontal `y = g` — cancel automatically.
+
+* `area_grid_2x2_unit_square` — a fully concrete sanity check: the area of `[0,1]²`
+  is the sum of its four quarter-cells.
+
+## What is new relative to the gallery
+
+The parent and all its siblings glue along a **single** cut in **one** direction.
+`greens_grid_2x2` is the first statement in the gallery where the region is tiled in
+**two** directions simultaneously: it is the `2 × 2` prototype of "tile a rectangle
+with a grid and add the cellwise Green identities," with *both* families of interior
+edges cancelling by orientation.  This is exactly the base case from which Green's
+theorem on an arbitrary `m × n` rectangular grid follows by iterating the two
+single-cut steps.
+
+## Proof Status
+
+- [x] Horizontal gluing capstone (0 sorries)
+- [x] 2×2 grid gluing capstone (0 sorries)
+- [x] Concrete `[0,1]²` area grid check (0 sorries)
+- No `axiom`, no `sorry`, no `native_decide`.
+-/
+
+namespace GreensTheoremOQ01OQ03OQ02
+
+open MeasureTheory intervalIntegral
+open GreensTheoremOQ01
+open GreensTheoremOQ01OQ03
+
+/-!
+## Part I: Horizontal gluing capstone
+
+The mirror of `greens_additive_vertical`.  The interior edge is the horizontal
+segment `y = g`, shared with opposite orientation by the bottom cell `[a,b]×[c,g]`
+and the top cell `[a,b]×[g,d]`.  Both sides of Green's identity are additive across
+this cut (`rectLineIntegral_hsplit`, `rectDoubleIntegral_hsplit`), so once the
+identity holds on each cell the union follows by a pure rewrite.
+-/
+
+/-- **Green's theorem is preserved by horizontal subdivision (gluing).**
+
+    Given that the concrete Green identity holds on the bottom cell `[a,b]×[c,g]`
+    and the top cell `[a,b]×[g,d]` for the curl field `F`, it holds on the whole
+    rectangle `[a,b]×[c,d]`.  The four line-integral and two double-integral
+    integrability hypotheses are exactly those that make the two sides additive
+    across `y = g`. -/
+theorem greens_additive_horizontal (P Q F : ℝ × ℝ → ℝ) (a b c g d : ℝ)
+    -- gluing data for the line integral (vertical edges `x = b`, `x = a`)
+    (hQb_cg : IntervalIntegrable (fun y => Q (b, y)) volume c g)
+    (hQb_gd : IntervalIntegrable (fun y => Q (b, y)) volume g d)
+    (hQa_cg : IntervalIntegrable (fun y => Q (a, y)) volume c g)
+    (hQa_gd : IntervalIntegrable (fun y => Q (a, y)) volume g d)
+    -- gluing data for the double integral (outer `y`-integral)
+    (hFo_cg : IntervalIntegrable (fun y => ∫ x in a..b, F (x, y)) volume c g)
+    (hFo_gd : IntervalIntegrable (fun y => ∫ x in a..b, F (x, y)) volume g d)
+    -- Green's theorem on each cell
+    (hB : rectLineIntegral P Q a b c g = rectDoubleIntegral F a b c g)
+    (hT : rectLineIntegral P Q a b g d = rectDoubleIntegral F a b g d) :
+    rectLineIntegral P Q a b c d = rectDoubleIntegral F a b c d := by
+  rw [← rectLineIntegral_hsplit P Q a b c g d hQb_cg hQb_gd hQa_cg hQa_gd,
+      ← rectDoubleIntegral_hsplit F a b c g d hFo_cg hFo_gd, hB, hT]
+
+/-!
+## Part II: The 2×2 grid capstone
+
+Cut `[a,b]×[c,d]` by `x = e` and `y = g`.  We glue the two bottom cells and the two
+top cells into horizontal strips with `greens_additive_vertical`, then glue the two
+strips with `greens_additive_horizontal`.  The vertical interior edge `x = e` is
+handled in the two strip glues, the horizontal interior edge `y = g` in the final
+glue; neither requires any cancellation input beyond the integrability data.
+-/
+
+/-- **Green's theorem glues across a 2×2 grid.**
+
+    With `[a,b]×[c,d]` cut at `x = e` and `y = g` into the four cells
+
+        BL = [a,e]×[c,g]   BR = [e,b]×[c,g]
+        TL = [a,e]×[g,d]   TR = [e,b]×[g,d],
+
+    if Green's identity holds on each of the four cells (`hBL, hBR, hTL, hTR`) then
+    it holds on the whole rectangle.  The integrability hypotheses are exactly those
+    consumed by the two vertical strip glues and the final horizontal glue. -/
+theorem greens_grid_2x2 (P Q F : ℝ × ℝ → ℝ) (a e b c g d : ℝ)
+    -- horizontal-edge line integrability (P integrated in x over the two columns)
+    (hPc_ae : IntervalIntegrable (fun x => P (x, c)) volume a e)
+    (hPc_eb : IntervalIntegrable (fun x => P (x, c)) volume e b)
+    (hPg_ae : IntervalIntegrable (fun x => P (x, g)) volume a e)
+    (hPg_eb : IntervalIntegrable (fun x => P (x, g)) volume e b)
+    (hPd_ae : IntervalIntegrable (fun x => P (x, d)) volume a e)
+    (hPd_eb : IntervalIntegrable (fun x => P (x, d)) volume e b)
+    -- vertical-edge line integrability (Q integrated in y over the two rows)
+    (hQb_cg : IntervalIntegrable (fun y => Q (b, y)) volume c g)
+    (hQb_gd : IntervalIntegrable (fun y => Q (b, y)) volume g d)
+    (hQa_cg : IntervalIntegrable (fun y => Q (a, y)) volume c g)
+    (hQa_gd : IntervalIntegrable (fun y => Q (a, y)) volume g d)
+    -- inner double-integral integrability of F (in x) over each cell's `y`-range
+    (hF_ae_cg : ∀ y ∈ Set.uIcc c g, IntervalIntegrable (fun x => F (x, y)) volume a e)
+    (hF_eb_cg : ∀ y ∈ Set.uIcc c g, IntervalIntegrable (fun x => F (x, y)) volume e b)
+    (hF_ae_gd : ∀ y ∈ Set.uIcc g d, IntervalIntegrable (fun x => F (x, y)) volume a e)
+    (hF_eb_gd : ∀ y ∈ Set.uIcc g d, IntervalIntegrable (fun x => F (x, y)) volume e b)
+    -- outer double-integral integrability for the two vertical strip glues
+    (hFo_ae_cg : IntervalIntegrable (fun y => ∫ x in a..e, F (x, y)) volume c g)
+    (hFo_eb_cg : IntervalIntegrable (fun y => ∫ x in e..b, F (x, y)) volume c g)
+    (hFo_ae_gd : IntervalIntegrable (fun y => ∫ x in a..e, F (x, y)) volume g d)
+    (hFo_eb_gd : IntervalIntegrable (fun y => ∫ x in e..b, F (x, y)) volume g d)
+    -- outer double-integral integrability for the final horizontal glue
+    (hFo_ab_cg : IntervalIntegrable (fun y => ∫ x in a..b, F (x, y)) volume c g)
+    (hFo_ab_gd : IntervalIntegrable (fun y => ∫ x in a..b, F (x, y)) volume g d)
+    -- Green's theorem on each of the four cells
+    (hBL : rectLineIntegral P Q a e c g = rectDoubleIntegral F a e c g)
+    (hBR : rectLineIntegral P Q e b c g = rectDoubleIntegral F e b c g)
+    (hTL : rectLineIntegral P Q a e g d = rectDoubleIntegral F a e g d)
+    (hTR : rectLineIntegral P Q e b g d = rectDoubleIntegral F e b g d) :
+    rectLineIntegral P Q a b c d = rectDoubleIntegral F a b c d := by
+  -- bottom strip `[a,b]×[c,g]`: glue BL + BR across the vertical edge `x = e`
+  have hBottom : rectLineIntegral P Q a b c g = rectDoubleIntegral F a b c g :=
+    greens_additive_vertical P Q F a e b c g
+      hPc_ae hPc_eb hPg_ae hPg_eb
+      hF_ae_cg hF_eb_cg hFo_ae_cg hFo_eb_cg
+      hBL hBR
+  -- top strip `[a,b]×[g,d]`: glue TL + TR across the vertical edge `x = e`
+  have hTop : rectLineIntegral P Q a b g d = rectDoubleIntegral F a b g d :=
+    greens_additive_vertical P Q F a e b g d
+      hPg_ae hPg_eb hPd_ae hPd_eb
+      hF_ae_gd hF_eb_gd hFo_ae_gd hFo_eb_gd
+      hTL hTR
+  -- whole rectangle: glue the two strips across the horizontal edge `y = g`
+  exact greens_additive_horizontal P Q F a b c g d
+    hQb_cg hQb_gd hQa_cg hQa_gd hFo_ab_cg hFo_ab_gd hBottom hTop
+
+/-!
+## Part III: Concrete sanity check
+
+The area of the unit square `[0,1]²` equals the sum of its four quarter-cells of
+area `1/4` each, computed through `rectDoubleIntegral` of the constant `1`.
+-/
+
+/-- The double integral of `1` over `[0,1]²` equals the sum over the four quarter
+    cells `[0,½]×[0,½]`, `[½,1]×[0,½]`, `[0,½]×[½,1]`, `[½,1]×[½,1]`. -/
+theorem area_grid_2x2_unit_square :
+    rectDoubleIntegral (fun _ => 1) 0 (1/2) 0 (1/2) +
+    rectDoubleIntegral (fun _ => 1) (1/2) 1 0 (1/2) +
+    rectDoubleIntegral (fun _ => 1) 0 (1/2) (1/2) 1 +
+    rectDoubleIntegral (fun _ => 1) (1/2) 1 (1/2) 1 =
+    rectDoubleIntegral (fun _ => 1) 0 1 0 1 := by
+  rw [area_double_integral, area_double_integral, area_double_integral,
+      area_double_integral, area_double_integral]
+  ring
+
+#check @greens_additive_horizontal
+#check @greens_grid_2x2
+
+end GreensTheoremOQ01OQ03OQ02
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms GreensTheoremOQ01OQ03OQ02.greens_additive_horizontal
+#print axioms GreensTheoremOQ01OQ03OQ02.greens_grid_2x2

--- a/src/data/proofs/greens-theorem-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-03-oq-02/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "greens-theorem-oq-01-oq-03-oq-02",
+  "title": "Green's Theorem Glues Across a 2D Grid of Cells",
+  "slug": "greens-theorem-oq-01-oq-03-oq-02",
+  "description": "The horizontal companion to the parent's vertical gluing capstone, plus the first genuinely two-dimensional grid statement: cutting a rectangle by both a vertical line x=e and a horizontal line y=g into four cells, Green's theorem on each cell glues into the identity on the whole rectangle. Both families of interior edges — the vertical x=e and the horizontal y=g — cancel by orientation.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GreensTheoremOQ01OQ03OQ02.lean",
+    "tags": [
+      "analysis",
+      "multivariable-calculus",
+      "integration",
+      "greens-theorem",
+      "additivity",
+      "grid"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No axioms. 0 sorries. Both gluing capstones and the concrete area check are fully machine-checked. #print axioms reports only propext / Classical.choice / Quot.sound (the standard foundational axioms) for greens_additive_horizontal and greens_grid_2x2 — no Lean.ofReduceBool, no native_decide. Reuses the already-verified single-cut split lemmas from greens-theorem-oq-01-oq-03.",
+    "dateAdded": "2026-06-24",
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_add_adjacent_intervals",
+        "description": "∫_a^b f + ∫_b^c f = ∫_a^c f for interval-integrable f — the engine behind the parent's single-cut split lemmas that this file composes",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      }
+    ],
+    "originalContributions": [
+      "greens_additive_horizontal: the horizontal companion to the parent's vertical gluing capstone — Green's theorem on a bottom cell [a,b]×[c,g] and a top cell [a,b]×[g,d] glues into the identity on [a,b]×[c,d] across the shared edge y=g",
+      "greens_grid_2x2: the first two-dimensional grid statement in the gallery — Green's theorem on the four cells of a rectangle cut at x=e and y=g glues into the identity on the whole rectangle, with BOTH interior edges (vertical x=e and horizontal y=g) cancelling by orientation",
+      "Proof architecture composing two vertical strip glues with one horizontal glue: the 2×2 base case from which Green's theorem on an arbitrary m×n rectangular grid follows by iterating the two single-cut steps",
+      "area_grid_2x2_unit_square: concrete check that the area of [0,1]² is the sum of its four quarter-cells"
+    ],
+    "lineCount": 199,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Extending Green's theorem from a single rectangle to a general region proceeds by tiling the region with a grid of rectangles and adding the cell-wise identities; the interior edges shared by adjacent cells cancel because each is traversed once in each direction. The parent greens-theorem-oq-01-oq-03 isolated this cancellation for a single cut (vertical or horizontal) and packaged the vertical direction into a gluing capstone. The remaining step toward a genuine grid is to handle cuts in both directions at once.",
+    "problemStatement": "Open Question (greens-theorem-oq-01-oq-03-oq-02): prove the horizontal companion capstone greens_additive_horizontal, and a mixed-grid gluing lemma combining horizontal and vertical splits to handle a full 2D grid of cells. Answer: both are proved; the 2×2 grid is the prototype, with both interior edges cancelling by orientation.",
+    "text": "Cutting [a,b]×[c,d] by a horizontal line y=g splits both sides of the concrete Green identity additively (parent lemmas), so greens_additive_horizontal glues a bottom cell and a top cell exactly as the vertical capstone glues a left and right cell. Cutting by BOTH x=e and y=g produces four cells; greens_grid_2x2 first glues the two bottom cells and the two top cells into horizontal strips (vertical capstone, twice), then glues the strips along y=g (horizontal capstone). Both interior edges cancel automatically.",
+    "proofStrategy": "greens_additive_horizontal mirrors the parent's greens_additive_vertical: rewrite the goal through the verified rectLineIntegral_hsplit and rectDoubleIntegral_hsplit, then substitute the bottom-cell and top-cell Green identities; the shared edge y=g cancels with no extra input. greens_grid_2x2 is pure composition: apply greens_additive_vertical to {BL,BR} to obtain Green on the bottom strip [a,b]×[c,g], apply it again to {TL,TR} for the top strip [a,b]×[g,d], then apply greens_additive_horizontal to the two strips. The integrability hypotheses are exactly those consumed by the three gluing steps (shared where the same edge appears in two steps, e.g. P(·,g) over the two columns). area_grid_2x2_unit_square evaluates the four quarter-cells via area_double_integral and closes by ring.",
+    "keyInsights": [
+      "A 2D grid tiles because both families of interior edges cancel: the vertical edge x=e is handled by the two strip glues, the horizontal edge y=g by the final glue — no cancellation input is needed beyond integrability of the outer edges.",
+      "The 2×2 grid is exactly two vertical glues plus one horizontal glue; no new analytic content is required beyond the parent's single-cut lemmas, only their composition in the right order.",
+      "Gluing first within rows (vertical cut) and then across rows (horizontal cut) makes the orientation cancellation of each interior segment automatic and local to one gluing step.",
+      "This is the base case for Green's theorem on an arbitrary m×n rectangular grid: iterate the vertical capstone along each row, then the horizontal capstone across rows."
+    ],
+    "prerequisites": [
+      "Green's theorem additive under a single subdivision (greens-theorem-oq-01-oq-03)",
+      "Green's theorem for a rectangle via concrete intervalIntegrals (greens-theorem-oq-01)",
+      "Additivity of the interval integral over adjacent intervals"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Grid Strategy",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Module docstring: the two next steps left by the parent (horizontal capstone and a 2D grid lemma), what is new relative to the gallery (first two-direction tiling), imports (Mathlib + Proofs.GreensTheoremOQ01OQ03), namespace, and opens.",
+      "mathContext": "Tile a rectangle with a grid; both vertical and horizontal interior edges cancel by orientation."
+    },
+    {
+      "id": "part-i-horizontal",
+      "title": "Part I — Horizontal Gluing Capstone",
+      "startLine": 72,
+      "endLine": 103,
+      "summary": "greens_additive_horizontal: the mirror of the parent's greens_additive_vertical, gluing a bottom cell and a top cell across y=g via the verified horizontal-split lemmas.",
+      "mathContext": "Green on $[a,b]\\times[c,g]$ and on $[a,b]\\times[g,d]$ $\\Rightarrow$ Green on $[a,b]\\times[c,d]$."
+    },
+    {
+      "id": "part-ii-grid",
+      "title": "Part II — The 2×2 Grid Capstone",
+      "startLine": 105,
+      "endLine": 171,
+      "summary": "greens_grid_2x2: Green's theorem on the four cells of a rectangle cut at x=e and y=g glues into the identity on the whole rectangle, by two vertical strip glues followed by one horizontal glue.",
+      "mathContext": "Green on BL, BR, TL, TR $\\Rightarrow$ Green on $[a,b]\\times[c,d]$."
+    },
+    {
+      "id": "part-iii-sanity",
+      "title": "Part III — Concrete Sanity Check",
+      "startLine": 173,
+      "endLine": 199,
+      "summary": "area_grid_2x2_unit_square: the area of [0,1]² as ∬1 equals the sum of its four quarter-cells of area ¼ each, plus #check and #print axioms commands.",
+      "mathContext": "$\\tfrac14 + \\tfrac14 + \\tfrac14 + \\tfrac14 = 1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Green's theorem tiles across a two-dimensional grid: the horizontal gluing capstone greens_additive_horizontal mirrors the parent's vertical one, and greens_grid_2x2 composes two vertical strip glues with one horizontal glue to prove the identity on a rectangle cut in both directions into four cells. Both families of interior edges cancel by orientation.",
+    "implications": "This is the 2×2 base case for Green's theorem on an arbitrary rectangle grid: iterating the vertical capstone along each row and the horizontal capstone across rows yields the identity on any m×n tiling, axiom-free. Together with the parent's single-cut additivity it closes the structural gap between the single-rectangle result (OQ-01) and general rectangle-tiled regions.",
+    "openQuestions": [
+      "Iterate the two capstones over an m×n grid via Finset.sum to obtain Green's theorem on an arbitrary rectangle-tiled region by double induction.",
+      "Discharge the per-cell integrability side-conditions automatically for continuously differentiable P, Q, F so the grid capstone applies with a single regularity hypothesis."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GreensTheoremOQ01OQ03"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "intervalIntegral",
+      "GreensTheoremOQ01",
+      "GreensTheoremOQ01OQ03"
+    ],
+    "namespace": "GreensTheoremOQ01OQ03OQ02",
+    "lineCount": 199,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/GreensTheoremOQ01OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "greens-theorem-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Adds the horizontal gluing capstone the parent left open and composes the parent's single-cut split lemmas into the first 2D grid statement"
+    },
+    {
+      "targetId": "greens-theorem-oq-01",
+      "relationship": "related",
+      "description": "The concrete intervalIntegral Green identity on a single rectangle that is here tiled across a 2×2 grid"
+    },
+    {
+      "targetId": "greens-theorem",
+      "relationship": "related",
+      "description": "Two-direction edge cancellation is the structural mechanism behind Green's theorem on general rectangle-tiled regions"
+    }
+  ],
+  "references": [
+    {
+      "title": "Green's theorem",
+      "url": "https://en.wikipedia.org/wiki/Green%27s_theorem"
+    },
+    {
+      "title": "Mathlib: intervalIntegral.integral_add_adjacent_intervals",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.html"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/greens-theorem-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-03-oq-02.json
@@ -1,0 +1,51 @@
+{
+  "slug": "greens-theorem-oq-01-oq-03-oq-02",
+  "title": "Does Green's theorem glue across a full 2D grid of cells?",
+  "tier": "verified",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24",
+  "path": "proofs/Proofs/GreensTheoremOQ01OQ03OQ02.lean",
+  "problemStatement": "The parent greens-theorem-oq-01-oq-03 proved both sides of the concrete Green identity are additive under a single cut (vertical or horizontal) and packaged the vertical direction into the gluing capstone greens_additive_vertical. It left two next steps (its openQuestions[1]): prove the horizontal companion capstone greens_additive_horizontal, and a mixed-grid gluing lemma combining horizontal and vertical splits for a full 2D grid of cells. Do both hold, with both families of interior edges cancelling by orientation?",
+  "tags": [
+    "analysis",
+    "multivariable-calculus",
+    "integration",
+    "greens-theorem",
+    "additivity",
+    "grid"
+  ],
+  "leanFiles": [
+    "proofs/Proofs/GreensTheoremOQ01OQ03OQ02.lean"
+  ],
+  "relatedProofs": [
+    "greens-theorem-oq-01-oq-03",
+    "greens-theorem-oq-01",
+    "greens-theorem-oq-01-oq-01",
+    "greens-theorem"
+  ],
+  "knowledge": {
+    "progressSummary": "COMPLETED in one session: proved greens_additive_horizontal (the horizontal companion to the parent's vertical gluing capstone) and greens_grid_2x2 (the first two-dimensional grid statement in the gallery). greens_additive_horizontal mirrors greens_additive_vertical, rewriting through the parent's verified rectLineIntegral_hsplit / rectDoubleIntegral_hsplit. greens_grid_2x2 cuts a rectangle at x=e and y=g into four cells and composes two vertical strip glues (greens_additive_vertical, over each row) with one horizontal glue (greens_additive_horizontal, across rows); both interior edges — vertical x=e and horizontal y=g — cancel automatically. area_grid_2x2_unit_square is a concrete check. 3 theorems, 199 lines, 0 axioms, 0 sorries; #print axioms shows only propext/Classical.choice/Quot.sound.",
+    "insights": 4,
+    "builtItems": 3,
+    "techniques": [
+      "Composition of the parent's single-cut gluing capstones (two vertical row-glues + one horizontal glue) to tile a 2D grid",
+      "Sharing edge-integrability hypotheses across gluing steps (e.g. P(·,g) over both columns serves both the bottom-strip and top-strip glue)",
+      "Pure rewrite through verified split lemmas — no new analytic content, only ordered composition"
+    ]
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24",
+    "iteration": 1,
+    "focus": "Horizontal capstone and 2×2 grid capstone fully proved. 0 axioms, 0 sorries.",
+    "blockers": [],
+    "nextAction": "None - results complete. Follow-ups: m×n grid induction via Finset.sum; automatic discharge of per-cell integrability for C¹ fields.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question (`greens-theorem-oq-01-oq-03`, openQuestions[1]): *prove a horizontal companion capstone `greens_additive_horizontal` and a mixed-grid gluing lemma combining horizontal and vertical splits for a full 2D grid of cells.*

**New file:** `proofs/Proofs/GreensTheoremOQ01OQ03OQ02.lean` (199 lines, 3 theorems, 0 axioms, 0 sorries).

### Results
- **`greens_additive_horizontal`** — the horizontal mirror of the parent's vertical gluing capstone. If Green's identity holds on a bottom cell `[a,b]×[c,g]` and a top cell `[a,b]×[g,d]`, it holds on `[a,b]×[c,d]`. Proved by rewriting through the parent's already-verified `rectLineIntegral_hsplit` / `rectDoubleIntegral_hsplit`; the shared edge `y=g` cancels by orientation with no extra input.
- **`greens_grid_2x2`** — the first genuinely two-dimensional grid statement in the gallery. Cut `[a,b]×[c,d]` at `x=e` **and** `y=g` into four cells; Green's theorem on each cell glues into the identity on the whole rectangle. The proof composes two vertical strip glues (`greens_additive_vertical`, over each row) with one horizontal glue (`greens_additive_horizontal`, across rows). **Both** interior edges — vertical `x=e` and horizontal `y=g` — cancel automatically.
- **`area_grid_2x2_unit_square`** — concrete check: area of `[0,1]²` = sum of its four quarter-cells.

### Why this is new
Every prior file in the family glues along a **single** cut in **one** direction. `greens_grid_2x2` is the `2×2` prototype of tiling a rectangle with a grid in **both** directions at once — the base case from which Green's theorem on an arbitrary `m×n` rectangular grid follows by iterating the two single-cut capstones.

### Verification
- Built via host `lake env lean` (Docker unavailable).
- `#print axioms` for `greens_additive_horizontal` and `greens_grid_2x2` reports only `propext, Classical.choice, Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. **verified / 0-axiom / original.**
- Also wires the parent `Proofs.GreensTheoremOQ01OQ03` import into the aggregator (it was a latent gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)