### PR TITLE
research: Erdős #12 local divisibility obstruction in divisibility-free sets

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1525,6 +1525,7 @@ import Proofs.Erdos129Problem
 import Proofs.Erdos12Problem
 import Proofs.Erdos12ProblemAPNPartI
 import Proofs.Erdos12ProblemAPNPartII
+import Proofs.Erdos12WIP01
 import Proofs.Erdos130Problem
 import Proofs.Erdos130WIP01
 import Proofs.Erdos131DavenportPower

--- a/proofs/Proofs/Erdos12WIP01.lean
+++ b/proofs/Proofs/Erdos12WIP01.lean
@@ -1,0 +1,90 @@
+import Mathlib
+
+/-
+# Erdős Problem #12: Local Divisibility Structure of Divisibility-Free Sets
+
+## Problem
+A set `A ⊆ ℕ` is **divisibility-free** when there are no distinct `a, b, c ∈ A`
+with `b, c > a` and `a ∣ (b + c)`. Erdős asked how large such sets can be; the
+density questions (i)/(ii) were resolved in 2026 and the reciprocal-sum question
+(iii) remains open (see the gallery entry `erdos-12`).
+
+## What this file proves
+This is a self-contained leaf isolating the **local obstruction** that forces
+divisibility-free sets to be sparse — the elementary combinatorial core
+underneath the (hard) density theorems:
+
+* `no_two_larger_multiples` — for `a ∈ A`, no two *distinct* larger elements of
+  `A` are both multiples of `a` (else their sum is a multiple of `a`).
+* `unique_larger_multiple` / `largerMultiples_subsingleton` — consequently each
+  `a ∈ A` has **at most one** larger multiple in `A`.
+* `no_antipodal_pair` — no two distinct larger elements are "antipodal mod `a`"
+  (i.e. sum to `0 mod a`). This is the residue-level statement of the
+  obstruction.
+* `IsDivisibilityFree.mono` — the property is inherited by subsets.
+* `divFree_456` — a concrete nonempty witness, `{4, 5, 6}`, showing the property
+  is satisfiable non-vacuously.
+
+The definition `IsDivisibilityFree` reproduces the one used by the Erdős #12
+gallery entry (`Proofs/Erdos12Problem.lean`), kept local so this leaf is
+self-contained.
+-/
+
+namespace Erdos12WIP01
+
+/-- The divisibility-free property of Erdős #12: no `a ∣ (b + c)` for distinct
+`a < b, c` in `A`. -/
+def IsDivisibilityFree (A : Set ℕ) : Prop :=
+  ∀ a b c : ℕ, a ∈ A → b ∈ A → c ∈ A →
+    a ≠ b → a ≠ c → b ≠ c → a < b → a < c → ¬(a ∣ (b + c))
+
+variable {A : Set ℕ}
+
+/-- Divisibility-freeness is inherited by subsets. -/
+theorem IsDivisibilityFree.mono (h : IsDivisibilityFree A) {B : Set ℕ}
+    (hBA : B ⊆ A) : IsDivisibilityFree B :=
+  fun a b c ha hb hc => h a b c (hBA ha) (hBA hb) (hBA hc)
+
+/-- **Core local obstruction.** For `a ∈ A`, two *distinct* elements of `A`
+larger than `a` cannot both be multiples of `a`: their sum would be a multiple
+of `a`, contradicting divisibility-freeness. -/
+theorem no_two_larger_multiples (h : IsDivisibilityFree A)
+    {a b c : ℕ} (ha : a ∈ A) (hb : b ∈ A) (hc : c ∈ A)
+    (hab : a < b) (hac : a < c) (hbc : b ≠ c)
+    (hdb : a ∣ b) (hdc : a ∣ c) : False :=
+  h a b c ha hb hc (ne_of_lt hab) (ne_of_lt hac) hbc hab hac (dvd_add hdb hdc)
+
+/-- **At most one larger multiple.** Any two larger multiples of `a` in `A`
+coincide. -/
+theorem unique_larger_multiple (h : IsDivisibilityFree A)
+    {a b c : ℕ} (ha : a ∈ A) (hb : b ∈ A) (hc : c ∈ A)
+    (hab : a < b) (hac : a < c) (hdb : a ∣ b) (hdc : a ∣ c) : b = c := by
+  by_contra hbc
+  exact no_two_larger_multiples h ha hb hc hab hac hbc hdb hdc
+
+/-- The set of larger multiples of a fixed `a ∈ A` is a subsingleton:
+`{b ∈ A : a < b ∧ a ∣ b}` has at most one element. -/
+theorem largerMultiples_subsingleton (h : IsDivisibilityFree A) {a : ℕ}
+    (ha : a ∈ A) : {b | b ∈ A ∧ a < b ∧ a ∣ b}.Subsingleton := by
+  intro b hb c hc
+  exact unique_larger_multiple h ha hb.1 hc.1 hb.2.1 hc.2.1 hb.2.2 hc.2.2
+
+/-- **Residue-level obstruction.** Two distinct elements of `A` larger than
+`a ∈ A` are never "antipodal mod `a`": their sum is never `0 mod a`. -/
+theorem no_antipodal_pair (h : IsDivisibilityFree A)
+    {a b c : ℕ} (ha : a ∈ A) (hb : b ∈ A) (hc : c ∈ A)
+    (hab : a < b) (hac : a < c) (hbc : b ≠ c) : (b + c) % a ≠ 0 := by
+  intro hmod
+  exact h a b c ha hb hc (ne_of_lt hab) (ne_of_lt hac) hbc hab hac
+    (Nat.dvd_of_mod_eq_zero hmod)
+
+/-- A concrete divisibility-free set, witnessing that the property is
+non-vacuously satisfiable: `{4, 5, 6}` (the only nontrivial check is
+`4 ∤ 5 + 6 = 11`). -/
+theorem divFree_456 : IsDivisibilityFree ({4, 5, 6} : Set ℕ) := by
+  intro a b c ha hb hc _ _ hbc hab hac
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at ha hb hc
+  rcases ha with rfl | rfl | rfl <;> rcases hb with rfl | rfl | rfl <;>
+    rcases hc with rfl | rfl | rfl <;> omega
+
+end Erdos12WIP01

--- a/src/data/proofs/erdos-12-wip-01/annotations.json
+++ b/src/data/proofs/erdos-12-wip-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-divfree-def",
+    "proofId": "erdos-12-wip-01",
+    "range": { "startLine": 39, "endLine": 46 },
+    "type": "definition",
+    "title": "Divisibility-Free Predicate",
+    "content": "`IsDivisibilityFree A` says no distinct a, b, c ∈ A with a < b and a < c satisfy a ∣ (b + c). This reproduces the predicate of the Erdős #12 gallery entry, kept local so this leaf is self-contained. The `a < b`, `a < c` hypotheses make `a` the smallest of the three and encode 'b, c larger than a'.",
+    "mathContext": "$\\forall a,b,c \\in A$ distinct, $a < b \\wedge a < c \\Rightarrow a \\nmid (b+c)$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility-free set", "sum-free set", "Erdős–Sárközy theorem"],
+    "prerequisites": ["divisibility on ℕ"]
+  },
+  {
+    "id": "ann-no-two-larger-multiples",
+    "proofId": "erdos-12-wip-01",
+    "range": { "startLine": 51, "endLine": 60 },
+    "type": "theorem",
+    "title": "Core Local Obstruction: No Two Larger Multiples",
+    "content": "If a ∈ A and two distinct elements b, c ∈ A larger than a were both multiples of a, then a ∣ b and a ∣ c give a ∣ (b + c) via `dvd_add`, contradicting divisibility-freeness. This is the one-line heart of the file; everything else specializes it.",
+    "mathContext": "$a \\mid b,\\ a \\mid c \\Rightarrow a \\mid (b+c)$, contradicting $a \\nmid (b+c)$.",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility", "local density obstruction"],
+    "prerequisites": ["dvd_add"]
+  },
+  {
+    "id": "ann-no-antipodal-pair",
+    "proofId": "erdos-12-wip-01",
+    "range": { "startLine": 73, "endLine": 78 },
+    "type": "theorem",
+    "title": "Residue-Level Obstruction: No Antipodal Pair mod a",
+    "content": "Rephrasing a ∣ (b + c) as (b + c) % a = 0, no two distinct larger elements are antipodal mod a. This is the residue picture: around each a ∈ A, the larger elements avoid complementary residue pairs mod a — the local reason these sets are sparse.",
+    "mathContext": "No distinct $b, c > a$ in $A$ with $b + c \\equiv 0 \\pmod a$.",
+    "significance": "important",
+    "relatedConcepts": ["residues mod a", "additive combinatorics", "complementary residue pairs"],
+    "prerequisites": ["Nat.dvd_of_mod_eq_zero"]
+  }
+]

--- a/src/data/proofs/erdos-12-wip-01/meta.json
+++ b/src/data/proofs/erdos-12-wip-01/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "erdos-12-wip-01",
+  "title": "Erdős #12: Local Divisibility Obstruction in Divisibility-Free Sets",
+  "slug": "erdos-12-wip-01",
+  "description": "The elementary local obstruction behind the sparsity of divisibility-free sets (Erdős #12): for each element a, at most one larger element of the set is a multiple of a, and no two larger elements are antipodal mod a.",
+  "meta": {
+    "author": "Paul Erdős",
+    "sourceUrl": "https://erdosproblems.com/12",
+    "date": "1970",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos12WIP01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "combinatorics",
+      "divisibility",
+      "additive-combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "dvd_add",
+        "description": "Divisibility is preserved under addition: a ∣ b → a ∣ c → a ∣ (b + c)",
+        "module": "Mathlib.Algebra.Divisibility.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_of_mod_eq_zero",
+        "description": "n % m = 0 → m ∣ n",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "IsDivisibilityFree: the Erdős #12 divisibility-free predicate (matching the gallery erdos-12 definition), kept local for a self-contained leaf",
+      "no_two_larger_multiples: for a in A, no two distinct larger elements are both multiples of a (the core local obstruction)",
+      "unique_larger_multiple & largerMultiples_subsingleton: each a has at most one larger multiple in A",
+      "no_antipodal_pair: no two distinct larger elements are antipodal mod a (the residue-level statement)",
+      "IsDivisibilityFree.mono: the property is inherited by subsets",
+      "divFree_456: a concrete nonempty witness {4, 5, 6} (non-vacuous satisfiability)"
+    ],
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 90,
+    "assumptions": "0 axioms, 0 sorries. All six theorems are fully machine-checked; #print axioms reports only the standard foundational axioms (propext, Quot.sound) — no sorryAx, no Lean.ofReduceBool. The divisibility-free predicate is reproduced locally to keep the file self-contained (it matches the definition in the erdos-12 gallery entry).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #12 asks how large a 'divisibility-free' set A ⊆ ℕ can be — one with no distinct a, b, c ∈ A such that b, c > a and a ∣ (b + c). Erdős–Sárközy (1970) proved such sets have density 0. The two principal density questions (positive liminf of |A ∩ [1,N]| / √N, and whether |A ∩ [1,N]| < N^{1-c} infinitely often) were resolved in 2026; the reciprocal-sum question Σ 1/n < ∞ remains open. This leaf does not touch the hard density theorems: it isolates the elementary LOCAL obstruction that is the combinatorial seed of all of them.",
+    "problemStatement": "A set A ⊆ ℕ is divisibility-free when for all distinct a, b, c ∈ A with a < b and a < c, a ∤ (b + c). Establish the local divisibility structure such a set must have around each of its elements.",
+    "proofStrategy": "All results are direct consequences of the defining property. If two distinct larger elements b, c are both multiples of a, then a ∣ b and a ∣ c give a ∣ (b + c) (dvd_add), contradicting divisibility-freeness — this yields 'at most one larger multiple' and the subsingleton statement. The residue version rephrases a ∣ (b + c) as (b + c) % a = 0. Subset closure is immediate. The concrete witness {4, 5, 6} is dispatched by a finite case split plus omega (the only live constraint is 4 ∤ 11).",
+    "keyInsights": [
+      "The defining property is exactly a constraint on residues mod a: among elements of A larger than a, no two are antipodal mod a (sum ≡ 0).",
+      "Specializing antipodality to the residue 0 gives the cleanest consequence: at most one larger element of A is a multiple of a.",
+      "This is the local reason divisibility-free sets are sparse — each element forbids a positive fraction of residues for its larger neighbours — and is the elementary core beneath the (hard) global density theorems.",
+      "The obstruction is purely a one-line application of dvd_add; the value is in naming and packaging the structure, not in proof depth."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Divisibility-Free Predicate",
+      "startLine": 39,
+      "endLine": 46,
+      "summary": "IsDivisibilityFree A: no distinct a, b, c ∈ A with a < b, a < c and a ∣ (b + c). Matches the erdos-12 gallery definition.",
+      "mathContext": "$A$ is divisibility-free iff $\\forall a,b,c \\in A$ distinct with $a < b, a < c$, $a \\nmid (b+c)$."
+    },
+    {
+      "id": "obstruction",
+      "title": "The Local Obstruction",
+      "startLine": 47,
+      "endLine": 78,
+      "summary": "no_two_larger_multiples (two distinct larger multiples of a are impossible), unique_larger_multiple, largerMultiples_subsingleton, and the residue form no_antipodal_pair; plus subset closure IsDivisibilityFree.mono.",
+      "mathContext": "If $a \\mid b$ and $a \\mid c$ with $b, c > a$ distinct, then $a \\mid (b+c)$ — forbidden. Hence the larger multiples of $a$ in $A$ form a subsingleton, and no two larger elements satisfy $b + c \\equiv 0 \\pmod a$."
+    },
+    {
+      "id": "witness",
+      "title": "A Concrete Witness",
+      "startLine": 79,
+      "endLine": 90,
+      "summary": "divFree_456: {4, 5, 6} is divisibility-free, shown by a finite case split (the only nontrivial check is 4 ∤ 5 + 6 = 11).",
+      "mathContext": "$\\{4,5,6\\}$ is divisibility-free: the single live constraint is $4 \\nmid 11$."
+    }
+  ],
+  "conclusion": {
+    "summary": "For any divisibility-free set A and any a ∈ A, at most one element of A larger than a is a multiple of a, and no two larger elements are antipodal mod a. These elementary structural facts are fully machine-checked with 0 axioms and 0 sorries, with a concrete witness {4, 5, 6}.",
+    "implications": "This packages the local combinatorial obstruction that makes divisibility-free sets sparse: each element forbids antipodal residue pairs (in particular, repeated multiples) among its larger neighbours. It is the elementary seed of the Erdős–Sárközy density-zero theorem and of the 2026 resolutions of the two density questions, all of which remain far deeper than this local statement.",
+    "openQuestions": [
+      "Can the residue obstruction be sharpened into a quantitative local density bound (≈ at most half the residues mod a are available to larger elements), as a first step toward a self-contained density-zero proof?",
+      "Question (iii) of Erdős #12 — whether Σ(1/n : n ∈ A) converges for every divisibility-free A — remains open.",
+      "Does the antipodal-pair obstruction extend usefully to k-fold sums a ∣ (b₁ + ⋯ + b_k)?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "no_two_larger_multiples",
+      "type": "core",
+      "description": "For a ∈ A in a divisibility-free set, no two distinct elements of A larger than a are both multiples of a."
+    },
+    {
+      "name": "unique_larger_multiple",
+      "type": "core",
+      "description": "Each a ∈ A has at most one larger multiple in A (any two coincide)."
+    },
+    {
+      "name": "no_antipodal_pair",
+      "type": "supporting",
+      "description": "No two distinct elements of A larger than a sum to 0 mod a — the residue-level form of the obstruction."
+    },
+    {
+      "name": "divFree_456",
+      "type": "supporting",
+      "description": "The concrete set {4, 5, 6} is divisibility-free, witnessing non-vacuous satisfiability."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-12",
+      "relationship": "extends",
+      "description": "Isolates the elementary local divisibility obstruction underlying the Erdős #12 density results; reuses the divisibility-free predicate of the parent gallery entry."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "Erdos12WIP01",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/Erdos12WIP01.lean",
+    "additionalFiles": []
+  }
+}

--- a/src/data/research/problems/erdos-12-wip-01.json
+++ b/src/data/research/problems/erdos-12-wip-01.json
@@ -1,0 +1,66 @@
+{
+  "slug": "erdos-12-wip-01",
+  "title": "Erdős #12: local divisibility obstruction in divisibility-free sets",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "Proofs/Erdos12WIP01.lean",
+  "started": "2026-06-24",
+  "lastUpdate": "2026-06-24T00:00:00.000Z",
+  "problemStatement": "Erdős #12: how large can a divisibility-free set A ⊆ ℕ be (no distinct a, b, c ∈ A with a < b, a < c and a ∣ (b + c))? Density questions (i)/(ii) resolved in 2026; reciprocal-sum question (iii) open. This leaf isolates the elementary local obstruction that makes such sets sparse.",
+  "knownResults": {
+    "proven": [
+      "no_two_larger_multiples: no two distinct larger elements of A are both multiples of a (a ∈ A).",
+      "unique_larger_multiple / largerMultiples_subsingleton: each a ∈ A has at most one larger multiple in A.",
+      "no_antipodal_pair: no two distinct larger elements sum to 0 mod a (residue form).",
+      "IsDivisibilityFree.mono: subset closure.",
+      "divFree_456: {4,5,6} is divisibility-free (concrete witness)."
+    ],
+    "open": [
+      "Quantitative local density bound (≈ half the residues mod a forbidden) toward a self-contained density-zero proof.",
+      "Erdős #12 question (iii): convergence of Σ 1/n on a divisibility-free set (OPEN).",
+      "Extension of the antipodal obstruction to k-fold sums a ∣ (b₁ + ⋯ + b_k)."
+    ]
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Shipped a self-contained 0-axiom gallery entry isolating the local divisibility obstruction of Erdős #12 divisibility-free sets.",
+    "blockers": [],
+    "nextAction": "None — entry complete and verified. The open density/reciprocal-sum questions are far deeper, separate problems.",
+    "attemptCounts": { "total": 1, "currentApproach": 1, "approachesTried": 1 }
+  },
+  "knowledge": {
+    "progressSummary": "Created Erdos12WIP01.lean (90 lines, 6 theorems, 1 definition), a 0-axiom/0-sorry self-contained gallery entry isolating the elementary LOCAL obstruction behind the sparsity of Erdős #12 divisibility-free sets: for any a ∈ A, at most one larger element of A is a multiple of a, and no two larger elements are antipodal mod a. All theorems depend only on the standard foundational axioms (propext, Quot.sound). The parent Erdos12Problem.lean (which imports all of Mathlib) currently has its own Mathlib-v4.26.0 drift errors, so the predicate was reproduced locally to keep the leaf self-contained and decoupled.",
+    "builtItems": [
+      "IsDivisibilityFree (def): the Erdős #12 divisibility-free predicate, local copy of the gallery definition.",
+      "no_two_larger_multiples: a∈A, distinct b,c>a both multiples of a ⟹ False (via dvd_add contradicting the def).",
+      "unique_larger_multiple: any two larger multiples of a coincide.",
+      "largerMultiples_subsingleton: {b ∈ A | a < b ∧ a ∣ b} is a subsingleton.",
+      "no_antipodal_pair: (b+c) % a ≠ 0 for distinct b,c>a (residue-level obstruction via Nat.dvd_of_mod_eq_zero).",
+      "IsDivisibilityFree.mono: subset closure.",
+      "divFree_456: {4,5,6} divisibility-free, via finite case split + omega (only live check 4 ∤ 11)."
+    ],
+    "insights": [
+      "The divisibility-free property is exactly an antipodal-residue constraint: among elements of A larger than a, no two sum to 0 mod a — so the residues mod a avoid complementary pairs.",
+      "Specializing to residue 0 gives the cleanest structural fact: at most one larger multiple of a, i.e. multiples of a in A beyond a itself form a subsingleton.",
+      "This is the local seed of the global Erdős–Sárközy density-zero theorem and the 2026 density resolutions; the local statement is a one-line dvd_add application, the global ones are deep.",
+      "The dvd ↔ mod-zero bridge (Nat.dvd_of_mod_eq_zero) cleanly converts the obstruction into a residue statement without needing a > 0.",
+      "Reproducing a small parent definition locally is the right call when the parent file no longer compiles (Erdos12Problem.lean has Mathlib drift and imports all of Mathlib) — keeps the leaf verifiable and self-contained."
+    ],
+    "mathlibGaps": [
+      "No general theory of divisibility-free / B_h-type sparse sets in Mathlib.",
+      "Parent Erdos12Problem.lean has unrepaired Mathlib-v4.26.0 drift (5 errors); leaf decoupled to avoid it."
+    ],
+    "nextSteps": [
+      "Turn the antipodal-residue obstruction into a quantitative |A ∩ residues mod a| bound.",
+      "Attempt a self-contained density-zero (Erdős–Sárközy) proof from the local obstruction.",
+      "State the k-fold-sum generalization of the obstruction."
+    ],
+    "markdown": "## Local divisibility obstruction (Erdős #12)\n\nA set `A ⊆ ℕ` is **divisibility-free** when no distinct `a, b, c ∈ A` with `b, c > a` satisfy `a ∣ (b + c)`. This leaf isolates the elementary LOCAL reason such sets are sparse, decoupled from the (hard) global density theorems:\n\n- **`no_two_larger_multiples`** — for `a ∈ A`, two distinct larger elements cannot both be multiples of `a` (else `a ∣ b + c`).\n- **`unique_larger_multiple` / `largerMultiples_subsingleton`** — hence each `a` has at most one larger multiple in `A`.\n- **`no_antipodal_pair`** — no two distinct larger elements sum to `0 mod a`: the residue picture of the obstruction.\n- **`divFree_456`** — `{4, 5, 6}` is a concrete witness.\n\nEverything is a one-line consequence of `dvd_add`; the value is in naming and packaging the local structure that seeds Erdős–Sárközy density-zero and the 2026 density resolutions. The reciprocal-sum question (iii) remains open."
+  },
+  "tags": ["erdos", "number-theory", "combinatorics", "divisibility", "additive-combinatorics"],
+  "relatedProofs": ["erdos-12", "erdos-12-wip-01"],
+  "references": ["https://erdosproblems.com/12"]
+}


### PR DESCRIPTION
## Erdős #12: Local Divisibility Obstruction

A set `A ⊆ ℕ` is **divisibility-free** when no distinct `a, b, c ∈ A` with `b, c > a` satisfy `a ∣ (b + c)`. Erdős asked how large such sets can be; the density questions (i)/(ii) were resolved in 2026, and the reciprocal-sum question (iii) remains open (gallery entry `erdos-12`).

This self-contained leaf `erdos-12-wip-01` isolates the **elementary local obstruction** that is the combinatorial seed of the (hard) global sparsity results:

| Theorem | Statement |
|---|---|
| `no_two_larger_multiples` | for `a ∈ A`, no two distinct larger elements are both multiples of `a` |
| `unique_larger_multiple` / `largerMultiples_subsingleton` | each `a` has **at most one** larger multiple in `A` |
| `no_antipodal_pair` | no two distinct larger elements sum to `0 mod a` (residue form) |
| `IsDivisibilityFree.mono` | the property is inherited by subsets |
| `divFree_456` | `{4, 5, 6}` is a concrete witness (non-vacuous) |

The obstruction is a one-line application of `dvd_add`; the value is in naming and packaging the local structure — around each `a`, the larger elements avoid antipodal residue pairs mod `a`, in particular repeated multiples. This is the local reason divisibility-free sets are sparse.

### Verification
- `Proofs/Erdos12WIP01.lean` — 90 lines, 6 theorems, 1 def: **0 axioms, 0 sorries**. `#print axioms` → only `[propext, Quot.sound]`.
- Built via `./bin/lake env lean` against Mathlib v4.26.0.

### Note
The divisibility-free predicate is reproduced locally (matching the `erdos-12` gallery definition) rather than imported: the parent `Erdos12Problem.lean` imports all of Mathlib and currently has v4.26.0 tactic drift, so the leaf is kept decoupled and independently verifiable. The open reciprocal-sum question (iii) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)