### PR TITLE
Enrich annotations: 9 research/gallery entries

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "qvandermonde-dual-header",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 49 },
+    "type": "context",
+    "title": "Making the hidden symmetries of q-Vandermonde explicit",
+    "content": "The parent entry proves the Gauss q-Vandermonde convolution (V). The single form (V) hides two involutive symmetries of the Gaussian binomial convolution: swapping the summand roles m ↔ n, and reflecting the summation index k ↦ r−k. This file makes both explicit and — crucially — proves the resulting dual/reflected sums equal as ring elements, so the apparent asymmetry of the q-exponent q^{k(m+k−r)} is shown to be a genuine identity rather than a cosmetic relabelling. All results are corollaries of the parent's qVandermonde; the only new machinery is Nat.add_comm and Finset.sum_range_reflect.",
+    "mathContext": "$\\genfrac{[}{]}{0pt}{}{m+n}{r}_q = \\sum_{k=0}^{r} q^{k(m+k-r)} \\genfrac{[}{]}{0pt}{}{m}{r-k}_q \\genfrac{[}{]}{0pt}{}{n}{k}_q \\tag{V}$",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian binomial coefficient", "q-Vandermonde identity", "involution", "convolution symmetry"],
+    "prerequisites": ["q-analogues", "Gaussian binomial coefficients"]
+  },
+  {
+    "id": "qvandermonde-dual-setup",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 51, "endLine": 58 },
+    "type": "definition",
+    "title": "Working over an arbitrary commutative ring",
+    "content": "The dual forms are stated for the Gaussian binomial qBinom q n k over an arbitrary commutative ring R, with q a ring element — q is a formal parameter, not required to be a prime power or to lie in any special domain. The infrastructure (qBinom, the identity V) is imported unchanged from the parent files via open GaussianBinomial qVandermondeProof, so this file adds only the symmetry arguments.",
+    "mathContext": "$q \\in R$ a commutative ring; $\\genfrac{[}{]}{0pt}{}{n}{k}_q = \\texttt{qBinom}\\,q\\,n\\,k$.",
+    "significance": "technical",
+    "relatedConcepts": ["commutative ring", "formal parameter q", "q-binomial coefficient"],
+    "prerequisites": ["commutative algebra"]
+  },
+  {
+    "id": "qvandermonde-dual-swap",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 60, "endLine": 69 },
+    "type": "theorem",
+    "title": "Dual form: swapping m ↔ n",
+    "content": "qVandermonde_swap. Since the binomial argument m+n is symmetric (m+n = n+m on ℕ), rewriting via Nat.add_comm reduces the claim to the parent identity (V) applied with the arguments n and m exchanged. The left-hand side is unchanged, while the two binomial factors trade roles and the q-exponent transforms k(m+k−r) ↦ k(n+k−r). The proof is a one-line rewrite followed by the parent theorem — the symmetry is structural, inherited from commutativity of addition.",
+    "mathContext": "$\\genfrac{[}{]}{0pt}{}{m+n}{r}_q = \\sum_{k=0}^{r} q^{k(n+k-r)} \\genfrac{[}{]}{0pt}{}{n}{r-k}_q \\genfrac{[}{]}{0pt}{}{m}{k}_q$",
+    "significance": "key",
+    "relatedConcepts": ["commutativity of addition", "symmetry of binomial convolution", "dual identity"],
+    "prerequisites": ["q-Vandermonde identity"]
+  },
+  {
+    "id": "qvandermonde-dual-sum-symm",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 71, "endLine": 80 },
+    "type": "insight",
+    "title": "Sum equivalence: the q-exponent symmetry is a real identity",
+    "content": "qVandermonde_sum_symm. The original convolution sum and its m↔n swap are equal as ring elements — both compute [m+n choose r]_q. This is the precise content of the symmetry: it is not that the two sums are rearrangements of each other term-by-term (they are not — the q-exponents k(m+k−r) and k(n+k−r) differ summand by summand), but that they have the same total. The proof rewrites the right side back through (V) and applies qVandermonde_swap, closing the loop.",
+    "mathContext": "$\\sum_{k} q^{k(m+k-r)} \\genfrac{[}{]}{0pt}{}{m}{r-k}_q \\genfrac{[}{]}{0pt}{}{n}{k}_q = \\sum_{k} q^{k(n+k-r)} \\genfrac{[}{]}{0pt}{}{n}{r-k}_q \\genfrac{[}{]}{0pt}{}{m}{k}_q$",
+    "significance": "key",
+    "relatedConcepts": ["identity of ring elements", "term-by-term vs total equality", "q-exponent symmetry"],
+    "prerequisites": ["finite sums over a ring"]
+  },
+  {
+    "id": "qvandermonde-dual-reflect",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 82, "endLine": 96 },
+    "type": "technique",
+    "title": "Reflected-index form via Finset.sum_range_reflect",
+    "content": "qVandermonde_reflect. Applying the involution k ↦ r−k to the summation range via Finset.sum_range_reflect re-expresses (V) with the q-exponent in the dual shape (r−k)(m−k) and the two binomial factors index-reflected. The technical core is three ℕ-arithmetic rewrites discharged by omega: r+1−1−k = r−k, m+(r−k)−r = m−k, and r−(r−k) = k — these reconcile the reflected index bookkeeping (note the truncated subtraction on ℕ is what makes omega necessary rather than ring). Finset.sum_congr then matches the summands.",
+    "mathContext": "$\\genfrac{[}{]}{0pt}{}{m+n}{r}_q = \\sum_{k=0}^{r} q^{(r-k)(m-k)} \\genfrac{[}{]}{0pt}{}{m}{k}_q \\genfrac{[}{]}{0pt}{}{n}{r-k}_q$",
+    "significance": "key",
+    "relatedConcepts": ["index reflection", "Finset.sum_range_reflect", "truncated natural subtraction", "omega tactic"],
+    "prerequisites": ["finite sum reindexing", "natural number arithmetic"]
+  },
+  {
+    "id": "qvandermonde-dual-reflect-symm",
+    "proofId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+    "range": { "startLine": 98, "endLine": 105 },
+    "type": "insight",
+    "title": "Sum equivalence of the reflected form",
+    "content": "qVandermonde_reflect_sum_symm. The original q-Vandermonde sum and its k ↦ r−k reflection are equal ring elements, completing the picture: both the m↔n swap and the index reflection are genuine identities on the convolution total. Proved, like the swap version, by rewriting back through (V) and invoking qVandermonde_reflect. Together the four theorems exhibit the full symmetry group acting on the q-Vandermonde convolution.",
+    "mathContext": "$\\sum_{k} q^{k(m+k-r)} \\genfrac{[}{]}{0pt}{}{m}{r-k}_q \\genfrac{[}{]}{0pt}{}{n}{k}_q = \\sum_{k} q^{(r-k)(m-k)} \\genfrac{[}{]}{0pt}{}{m}{k}_q \\genfrac{[}{]}{0pt}{}{n}{r-k}_q$",
+    "significance": "supporting",
+    "relatedConcepts": ["index reflection", "identity of ring elements", "symmetry group of an identity"],
+    "prerequisites": ["finite sum reindexing"]
+  }
+]

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "cantor-bendixson-header",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "Removing the perfectness hypothesis from the parent's continuum bound",
+    "content": "The parent entry shows a perfect Polish space has cardinality ≥ 𝔠, but perfectness fails the moment the space has a single isolated point. The Cantor–Bendixson theorem removes that hypothesis: every closed subset C of a second-countable space splits as C = V ∪ D with V countable and D perfect. Mathlib's exists_perfect_nonempty_of_isClosed_of_not_countable keeps only that D is nonempty and discards the remainder V, so it says nothing about the size of D. This file keeps V and pushes two steps further — D is itself uncountable, and (in a complete metric space) has cardinality at least the continuum.",
+    "mathContext": "$C = V \\cup D$, $V$ countable, $D$ perfect; $C$ uncountable $\\Rightarrow D$ uncountable and $\\mathfrak{c} \\le \\#D$.",
+    "significance": "context",
+    "relatedConcepts": ["Cantor–Bendixson theorem", "perfect set", "perfect kernel", "Polish space", "isolated point"],
+    "prerequisites": ["descriptive set theory", "cardinal arithmetic"]
+  },
+  {
+    "id": "cantor-bendixson-subset",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 44, "endLine": 57 },
+    "type": "theorem",
+    "title": "Strengthened Cantor–Bendixson: the perfect kernel is uncountable",
+    "content": "exists_perfect_not_countable_subset. From the decomposition C = V ∪ D (exists_countable_union_perfect_of_isClosed) with V countable and D perfect, the proof forces D uncountable: if D were countable then C = V ∪ D would be a union of two countable sets, hence countable (hV.union hDc), contradicting hunc. This is the exact sharpening the open question requested — Mathlib's library lemma gives only nonemptiness, not uncountability of the kernel.",
+    "mathContext": "$C$ closed, $\\neg\\,C\\text{ countable} \\Rightarrow \\exists D \\subseteq C,\\ \\mathrm{Perfect}(D) \\wedge \\neg\\,D\\text{ countable}.$",
+    "significance": "key",
+    "relatedConcepts": ["countable union", "perfect set", "second-countable space", "proof by contradiction"],
+    "prerequisites": ["countability of unions", "closed sets in topology"]
+  },
+  {
+    "id": "cantor-bendixson-wholespace",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 59, "endLine": 66 },
+    "type": "theorem",
+    "title": "Whole-space form",
+    "content": "exists_perfect_not_countable. Specialising the subset version to C = univ: an uncountable second-countable space (¬ Countable α, equivalently ¬ univ.Countable via countable_univ_iff) contains a perfect, uncountable subset. univ is closed (isClosed_univ), so this is a direct corollary.",
+    "mathContext": "$\\neg\\,\\text{Countable}\\,\\alpha \\Rightarrow \\exists D,\\ \\mathrm{Perfect}(D) \\wedge \\neg\\,D\\text{ countable}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["universal set", "countable_univ_iff", "second-countable space"],
+    "prerequisites": ["closed sets"]
+  },
+  {
+    "id": "cantor-bendixson-cardinal-arith",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 70, "endLine": 72 },
+    "type": "technique",
+    "title": "The cardinal arithmetic 2^ℵ₀ = 𝔠",
+    "content": "mk_nat_arrow_bool. The Cantor space ℕ → Bool has cardinality #(ℕ→Bool) = 2^ℵ₀ = 𝔠, assembled from mk_arrow, mk_bool, mk_nat and two_power_aleph0. This is the source of the continuum: the Cantor-scheme injection lands a copy of ℕ→Bool inside any nonempty perfect set.",
+    "mathContext": "$\\#(\\mathbb{N} \\to \\mathrm{Bool}) = 2^{\\aleph_0} = \\mathfrak{c}.$",
+    "significance": "technical",
+    "relatedConcepts": ["Cantor space", "continuum", "cardinal exponentiation", "two_power_aleph0"],
+    "prerequisites": ["cardinal arithmetic"]
+  },
+  {
+    "id": "cantor-bendixson-scheme-bound",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 74, "endLine": 84 },
+    "type": "technique",
+    "title": "Cantor-scheme bound: a perfect set has size ≥ 𝔠",
+    "content": "continuum_le_mk_of_perfect. A nonempty perfect set in a complete metric space admits a Cantor-scheme injection (ℕ→Bool) ↪ C (Perfect.exists_nat_bool_injection); completeness is what makes the nested-closed-ball scheme converge. The injection is corestricted to the subtype C (mapping x ↦ ⟨f x, hmem x⟩, injective because f is), giving 𝔠 = #(ℕ→Bool) ≤ #C via mk_le_of_injective. Reproved inline so the file is self-contained.",
+    "mathContext": "$\\mathrm{Perfect}(C),\\ C \\ne \\emptyset \\Rightarrow \\mathfrak{c} = \\#(\\mathbb{N}\\to\\mathrm{Bool}) \\le \\#C.$",
+    "significance": "key",
+    "relatedConcepts": ["Cantor scheme", "perfect set", "completeness", "injection into a subtype", "nested closed balls"],
+    "prerequisites": ["complete metric spaces", "perfect sets", "cardinal injections"]
+  },
+  {
+    "id": "cantor-bendixson-cardinal-form",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 86, "endLine": 97 },
+    "type": "concept",
+    "title": "Cantor–Bendixson, cardinal form",
+    "content": "exists_perfect_continuum_le_mk. Combining the two strands: an uncountable Polish space (complete + second-countable metric) contains a perfect subset D that is uncountable and has 𝔠 ≤ #D. The nonemptiness of D needed to apply the scheme bound is recovered for free — an uncountable set cannot be empty (countable_empty would contradict ¬ D.Countable).",
+    "mathContext": "$\\neg\\,\\text{Countable}\\,\\alpha \\Rightarrow \\exists D,\\ \\mathrm{Perfect}(D) \\wedge \\neg\\,D\\text{ countable} \\wedge \\mathfrak{c} \\le \\#D.$",
+    "significance": "key",
+    "relatedConcepts": ["Polish space", "perfect kernel", "continuum hypothesis context", "cardinality of the reals"],
+    "prerequisites": ["complete metric spaces", "second-countable spaces"]
+  },
+  {
+    "id": "cantor-bendixson-space-bound",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 99, "endLine": 104 },
+    "type": "insight",
+    "title": "The space itself has cardinality at least the continuum",
+    "content": "continuum_le_mk. Since the perfect subset D satisfies 𝔠 ≤ #D and D ⊆ α gives #D ≤ #α (mk_set_le), transitivity yields 𝔠 ≤ #α. So every uncountable Polish space has at least continuum-many points — there is no Polish space of cardinality strictly between ℵ₀ and 𝔠. This is the perfect-set property, the classical reason the Continuum Hypothesis holds for closed (indeed Borel/analytic) subsets of Polish spaces.",
+    "mathContext": "$\\mathfrak{c} \\le \\#D \\le \\#\\alpha \\Rightarrow \\mathfrak{c} \\le \\#\\alpha.$",
+    "significance": "key",
+    "relatedConcepts": ["perfect set property", "Continuum Hypothesis", "Borel sets", "no intermediate cardinality"],
+    "prerequisites": ["cardinal inequalities", "subset cardinality"]
+  },
+  {
+    "id": "cantor-bendixson-real",
+    "proofId": "baire-category-theorem-oq-01-oq-02-oq-02",
+    "range": { "startLine": 106, "endLine": 115 },
+    "type": "concept",
+    "title": "Motivating instance: ℝ",
+    "content": "exists_perfect_continuum_le_mk_real. ℝ is uncountable (not_countable_real), so it contains a perfect uncountable subset of cardinality 𝔠. ℝ happens to be perfect itself, but the point of the theorem is that the conclusion needs no such hypothesis: it applies verbatim to uncountable Polish spaces with isolated points, where the parent entry's PerfectSpace bound does not.",
+    "mathContext": "$\\exists D \\subseteq \\mathbb{R},\\ \\mathrm{Perfect}(D) \\wedge \\neg\\,D\\text{ countable} \\wedge \\mathfrak{c} \\le \\#D.$",
+    "significance": "context",
+    "relatedConcepts": ["uncountability of ℝ", "concrete instance", "perfect subset of the reals"],
+    "prerequisites": ["the real line as a Polish space"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03-oq-01-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "cauchy-interlacing-oq030102-header",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "context",
+    "title": "A-posteriori certification of a computed eigenpair",
+    "content": "The file proves the converse of the parent entry's Weyl perturbation bound. Weyl's a-priori bound certifies that the exact eigenvalues of two nearby operators are close; the residual bound here certifies a single approximately-computed eigenpair (λ, x) from data the solver already holds. If the residual ‖T x − λ·x‖ is small, then some genuine eigenvalue μ(k) must lie within that residual of λ. The presentation T(b i) = μ i • b i with b orthonormal and μ real is exactly the spectral content of a Hermitian operator, taken as input rather than derived, so the argument never needs an adjoint.",
+    "mathContext": "$\\operatorname{dist}(\\lambda, \\sigma(T)) \\le \\dfrac{\\lVert T x - \\lambda x\\rVert}{\\lVert x\\rVert}$ — the Hermitian/normal case of the Bauer–Fike theorem (1960).",
+    "significance": "context",
+    "relatedConcepts": ["Bauer–Fike theorem", "a-posteriori error estimate", "residual norm", "spectral theorem", "Weyl perturbation bound"],
+    "prerequisites": ["spectral theory of Hermitian operators", "numerical linear algebra"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-setup",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 53 },
+    "type": "definition",
+    "title": "Working over an RCLike scalar field with an inner product space",
+    "content": "The development is stated for an arbitrary scalar field 𝕜 satisfying RCLike (so 𝕜 is ℝ or ℂ) and a complex/real inner product space E. Eigenvalues μ are taken to be real-valued (μ : Fin n → ℝ) and coerced into 𝕜 where needed — reflecting that a Hermitian operator has real spectrum. Keeping 𝕜 abstract means the same proof serves both the real-symmetric and complex-Hermitian cases.",
+    "mathContext": "$\\mathbb{K} \\in \\{\\mathbb{R}, \\mathbb{C}\\}$, $E$ an inner product space over $\\mathbb{K}$, eigenvalues $\\mu_i \\in \\mathbb{R}$.",
+    "significance": "technical",
+    "relatedConcepts": ["RCLike", "inner product space", "real spectrum of self-adjoint operators"],
+    "prerequisites": ["inner product spaces", "complex vs real scalar fields"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-parseval",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "technique",
+    "title": "Parseval's identity from the coordinate isometry",
+    "content": "Parseval's identity ‖v‖² = ∑ᵢ ‖⟪bᵢ, v⟫‖² is obtained, not by re-deriving the orthogonal expansion, but by transporting the norm through the linear isometry b.repr : E ≃ₗᵢ EuclideanSpace. Since b.repr preserves norms (LinearIsometryEquiv.norm_map) and EuclideanSpace.norm_sq_eq says the squared norm is the sum of squared coordinates, identifying the coordinate b.repr v i with ⟪bᵢ, v⟫ (repr_apply_apply) finishes in two rewrites. This single identity supplies both the normalisation ∑|cᵢ|² = 1 and the residual energy decomposition used later.",
+    "mathContext": "$\\lVert v\\rVert^2 = \\sum_i \\lvert\\langle b_i, v\\rangle\\rvert^2$, with $b_i$-coordinate $c_i = \\langle b_i, v\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": ["Parseval's identity", "orthonormal basis", "linear isometry", "EuclideanSpace", "Bessel's inequality"],
+    "prerequisites": ["orthonormal bases", "Hilbert space coordinates"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-inner-eigen",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 68, "endLine": 89 },
+    "type": "insight",
+    "title": "The eigen-coordinate identity needs no adjoint",
+    "content": "The structural heart of the proof: ⟪bᵢ, T x⟫ = μᵢ · ⟪bᵢ, x⟫ for every x. Rather than moving T across the inner product (which would require self-adjointness), x is expanded in the eigenbasis x = ∑ⱼ cⱼ bⱼ (sum_repr'), T is pushed through the finite sum by linearity (map_sum, map_smul) using T bⱼ = μⱼ bⱼ, and the resulting double sum collapses to its diagonal term by orthonormality (Finset.sum_eq_single together with orthonormal_iff_ite, which gives ⟪bᵢ, bⱼ⟫ = δᵢⱼ). The bᵢ-coordinate of T x is therefore exactly μᵢ times the bᵢ-coordinate of x.",
+    "mathContext": "$\\langle b_i, T x\\rangle = \\Big\\langle b_i, \\sum_j c_j \\mu_j b_j\\Big\\rangle = \\sum_j c_j \\mu_j \\langle b_i, b_j\\rangle = \\mu_i c_i.$",
+    "significance": "key",
+    "relatedConcepts": ["eigenbasis expansion", "orthonormality", "linearity of operators", "Kronecker delta", "diagonalization"],
+    "prerequisites": ["eigenvectors and eigenvalues", "linear operators on inner product spaces"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-coordinatewise",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 110, "endLine": 120 },
+    "type": "technique",
+    "title": "Coordinatewise residual and its squared norm",
+    "content": "Combining linearity of the inner product (inner_sub_right) with the eigen-coordinate identity gives the residual's coordinates in closed form: ⟪bᵢ, T x − λ·x⟫ = (μᵢ − λ)·cᵢ. Taking the squared norm and using RCLike.norm_ofReal (‖(↑r : 𝕜)‖ = |r|) together with sq_abs turns the scalar factor into the real number (μᵢ − λ)², yielding ‖⟪bᵢ, T x − λ·x⟫‖² = (μᵢ − λ)²·|cᵢ|². Each squared residual coordinate is a squared eigenvalue gap weighted by the squared coordinate magnitude.",
+    "mathContext": "$\\langle b_i, T x - \\lambda x\\rangle = (\\mu_i - \\lambda)c_i, \\qquad \\lVert\\langle b_i, T x - \\lambda x\\rangle\\rVert^2 = (\\mu_i - \\lambda)^2\\lvert c_i\\rvert^2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["sesquilinearity", "real eigenvalues", "norm of a scalar multiple"],
+    "prerequisites": ["inner product linearity", "norms of complex scalars"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-main",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 93, "endLine": 151 },
+    "type": "concept",
+    "title": "The residual eigenvalue bound: a weighted average dominates its minimum",
+    "content": "The main theorem dist_to_spectrum_le_residual. Parseval converts both quantities into sums over the eigenbasis: ∑ᵢ|cᵢ|² = 1 from ‖x‖ = 1, and ∑ᵢ(μᵢ − λ)²|cᵢ|² = ε² for the residual ε = ‖T x − λ·x‖. The set Fin n is nonempty (an empty index would force ‖x‖ = 0, contradicting the unit constraint), so Finset.exists_min_image selects an index k minimising (μᵢ − λ)². Because the weights |cᵢ|² are nonnegative and sum to 1, the minimum value (μ(k) − λ)² is at most the weighted average ∑ᵢ(μᵢ − λ)²|cᵢ|² = ε². Monotonicity of the square root (sqrt_sq_eq_abs, sqrt_sq) then delivers |μ(k) − λ| ≤ ε. The witness index k makes the result constructive.",
+    "mathContext": "$(\\mu_k - \\lambda)^2 = (\\mu_k-\\lambda)^2\\sum_i|c_i|^2 = \\sum_i (\\mu_k-\\lambda)^2|c_i|^2 \\le \\sum_i (\\mu_i-\\lambda)^2|c_i|^2 = \\lVert T x - \\lambda x\\rVert^2.$",
+    "significance": "key",
+    "relatedConcepts": ["weighted average bound", "minimising index", "convex combination", "distance to spectrum", "constructive witness"],
+    "prerequisites": ["convex combinations", "monotonicity of the square root", "finite sums"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-epsilon-form",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 153, "endLine": 163 },
+    "type": "concept",
+    "title": "Practical ε-form: a computed residual bound suffices",
+    "content": "In practice a solver computes only an upper bound ε on the residual, not its exact value. residual_eigenvalue_bound packages this: if ‖T x − λ·x‖ ≤ ε then some eigenvalue lies within ε of λ. It follows from the main theorem by a single transitivity step (le_trans). This is the form used as a stopping criterion in iterative eigensolvers — once the computed residual drops below a tolerance ε, the algorithm certifies an eigenvalue to within ε.",
+    "mathContext": "$\\lVert T x - \\lambda x\\rVert \\le \\varepsilon \\;\\Longrightarrow\\; \\exists k,\\; \\lvert\\mu_k - \\lambda\\rvert \\le \\varepsilon.$",
+    "significance": "supporting",
+    "relatedConcepts": ["stopping criterion", "Lanczos algorithm", "Davidson method", "inverse iteration", "transitivity"],
+    "prerequisites": ["iterative eigenvalue algorithms"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-gap",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 167, "endLine": 180 },
+    "type": "concept",
+    "title": "Spectral-gap lower bound: rejecting a candidate eigenvalue",
+    "content": "The contrapositive, residual_gt_of_spectral_gap: if λ is strictly more than ε away from every eigenvalue, then no unit vector can have residual ≤ ε. Proved by by_contra + push_neg, feeding the negated hypothesis into the ε-form to contradict the gap assumption. This is the exact statement a solver uses to reject a candidate — a large spectral gap forces a large residual, so an observed small residual rules out the candidate being far from the spectrum.",
+    "mathContext": "$\\big(\\forall i,\\; \\varepsilon < \\lvert\\mu_i - \\lambda\\rvert\\big) \\;\\Longrightarrow\\; \\varepsilon < \\lVert T x - \\lambda x\\rVert.$",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive", "spectral gap", "lower bound", "candidate rejection"],
+    "prerequisites": ["proof by contradiction", "logical contraposition"]
+  },
+  {
+    "id": "cauchy-interlacing-oq030102-sharpness",
+    "proofId": "cauchy-interlacing-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 182, "endLine": 192 },
+    "type": "insight",
+    "title": "Sharpness: an exact eigenpair has zero residual",
+    "content": "The closing example certifies sharpness. Taking x = b j (an exact eigenvector, automatically a unit vector by b.orthonormal.1 j) and λ = μ j makes the residual exactly 0, and the bound reads |μ(j) − μ(j)| = 0 ≤ 0 — attained with equality. The estimate therefore cannot be improved in general: there is no slack to remove when the input is an exact eigenpair.",
+    "mathContext": "$x = b_j,\\ \\lambda = \\mu_j \\;\\Rightarrow\\; \\lVert T b_j - \\mu_j b_j\\rVert = 0,\\quad \\lvert\\mu_j - \\mu_j\\rvert = 0 \\le 0.$",
+    "significance": "context",
+    "relatedConcepts": ["sharpness of an inequality", "exact eigenpair", "tightness", "equality case"],
+    "prerequisites": ["eigenvectors"]
+  }
+]

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "dilworth-es-header",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "A common min–max framework from Mirsky to Erdős–Szekeres",
+    "content": "The companion files supply the two halves of the Dilworth/Mirsky picture: the easy directions (a chain meets an antichain in ≤ 1 point) and Mirsky's hard direction (the height decomposition covers the poset by maxChainLen antichains). This file ties them together through a single counting inequality card α ≤ maxChainLen · maxAntichainLen, whose contrapositive is the Erdős–Szekeres dichotomy, and specialises it to sequence positions to recover the classical Erdős–Szekeres theorem.",
+    "mathContext": "$|\\alpha| \\le \\mathrm{maxChainLen}\\cdot\\mathrm{maxAntichainLen}$; contrapositive $\\Rightarrow$ a long chain or a long antichain.",
+    "significance": "context",
+    "relatedConcepts": ["Mirsky's theorem", "Dilworth's theorem", "Erdős–Szekeres theorem", "min–max duality", "poset height and width"],
+    "prerequisites": ["partial orders", "chains and antichains"]
+  },
+  {
+    "id": "dilworth-es-maxantichain",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 49, "endLine": 75 },
+    "type": "definition",
+    "title": "The dual width invariant: maxAntichainLen",
+    "content": "maxAntichainLen is defined as the supremum of cardinalities over allAntichains — the finite set of antichains, carved out of the powerset by the IsAntichainOn predicate. Two facts are recorded: every antichain has card ≤ maxAntichainLen (Finset.le_sup), and the sup is attained by an actual antichain (Finset.exists_mem_eq_sup, using that the empty set is vacuously an antichain so the family is nonempty). This is the width of the poset, dual to the chain-length (height) invariant maxChainLen from the companion file.",
+    "mathContext": "$\\mathrm{maxAntichainLen} = \\max\\{|A| : A \\text{ an antichain}\\}$ — the width of the poset.",
+    "significance": "supporting",
+    "relatedConcepts": ["antichain", "poset width", "Finset.sup", "supremum attained", "powerset filter"],
+    "prerequisites": ["finite suprema", "Finset operations"]
+  },
+  {
+    "id": "dilworth-es-counting",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 79, "endLine": 98 },
+    "type": "theorem",
+    "title": "The common min–max counting bound",
+    "content": "card_le_maxChainLen_mul_maxAntichainLen. The keystone: a finite poset has at most maxChainLen · maxAntichainLen elements. Mirsky's cover 𝒜 (mirsky_antichain_cover) consists of at most maxChainLen antichains whose union is the whole poset; bounding |univ| ≤ |⋃𝒜| ≤ ∑_{A∈𝒜}|A| ≤ |𝒜|·maxAntichainLen ≤ maxChainLen·maxAntichainLen via Finset.card_biUnion_le and Finset.sum_le_sum gives the product bound. This is the multiplicative analogue of the additive Dilworth/Mirsky equalities.",
+    "mathContext": "$|\\alpha| \\le |\\textstyle\\bigcup\\mathcal{A}| \\le \\sum_{A\\in\\mathcal{A}}|A| \\le |\\mathcal{A}|\\cdot\\mathrm{maxAntichainLen} \\le \\mathrm{maxChainLen}\\cdot\\mathrm{maxAntichainLen}.$",
+    "significance": "key",
+    "relatedConcepts": ["Mirsky antichain cover", "biUnion cardinality", "covering bound", "pigeonhole"],
+    "prerequisites": ["antichain cover", "cardinality of unions"]
+  },
+  {
+    "id": "dilworth-es-dichotomy",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 100, "endLine": 118 },
+    "type": "theorem",
+    "title": "The Erdős–Szekeres dichotomy (poset form)",
+    "content": "exists_long_chain_or_antichain. The contrapositive of the counting bound: if a poset has more than r·s elements, it has a chain of size > r or an antichain of size > s. Proved by by_contra + push_neg — if every chain had ≤ r and every antichain ≤ s elements, then maxChainLen ≤ r and maxAntichainLen ≤ s (using that both invariants are attained), so card α ≤ r·s by the bound, contradicting r·s < card α. The pure pigeonhole core of Erdős–Szekeres.",
+    "mathContext": "$r\\cdot s < |\\alpha| \\Rightarrow (\\exists\\text{ chain } |C| > r) \\vee (\\exists\\text{ antichain } |A| > s).$",
+    "significance": "key",
+    "relatedConcepts": ["contrapositive", "dichotomy", "pigeonhole principle", "extremal combinatorics"],
+    "prerequisites": ["proof by contradiction", "the counting bound"]
+  },
+  {
+    "id": "dilworth-es-seqpos",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 122, "endLine": 171 },
+    "type": "definition",
+    "title": "The dominance order on sequence positions",
+    "content": "SeqPos f wraps a position i ∈ Fin N and carries the product (dominance) order i ≼ j ↔ i ≤ j ∧ f i ≤ f j. Antisymmetry holds because equal positions force equal SeqPos (the wrapper is essentially Fin N, hence equivFin : SeqPos f ≃ Fin N and card_eq : card (SeqPos f) = N). This poset is the bridge: ordering sequence positions by both index and value turns subsequence structure into chain/antichain structure.",
+    "mathContext": "$i \\preccurlyeq j \\iff i \\le j \\wedge f_i \\le f_j$, with $\\mathrm{SeqPos}\\,f \\simeq \\mathrm{Fin}\\,N$.",
+    "significance": "key",
+    "relatedConcepts": ["product order", "dominance order", "Fin N", "poset on indices"],
+    "prerequisites": ["partial order axioms", "product of orders"]
+  },
+  {
+    "id": "dilworth-es-chains-subseq",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 173, "endLine": 204 },
+    "type": "insight",
+    "title": "Chains ↔ non-decreasing, antichains ↔ strictly decreasing",
+    "content": "The translation lemmas. image_pos_nondecr: a chain's positions form a non-decreasing subsequence — comparable positions with i ≤ j satisfy f i ≤ f j (the off-diagonal case b ≤ a collapses by antisymmetry of indices). image_pos_strictdecr: an antichain's positions form a strictly decreasing subsequence — incomparable positions with i < j must have f j < f i, since i ≤ j in index but ¬(a ≼ b) forces the value to drop. card_image_pos records that the position map is injective so cardinalities transfer. This is exactly where the two-dimensional dominance order pays off.",
+    "mathContext": "chain $\\Rightarrow$ ($i\\le j \\Rightarrow f_i \\le f_j$);  antichain $\\Rightarrow$ ($i < j \\Rightarrow f_j < f_i$).",
+    "significance": "key",
+    "relatedConcepts": ["non-decreasing subsequence", "strictly decreasing subsequence", "incomparability", "monotone subsequences"],
+    "prerequisites": ["antisymmetry", "antichain incomparability"]
+  },
+  {
+    "id": "dilworth-es-classical",
+    "proofId": "dilworth-theorem-oq-01-oq-01-oq-03",
+    "range": { "startLine": 208, "endLine": 226 },
+    "type": "theorem",
+    "title": "Erdős–Szekeres for sequences",
+    "content": "erdos_szekeres_seq. Transporting the poset dichotomy through the position map: any sequence of length N > r·s over a linear order has a non-decreasing run on more than r positions or a strictly decreasing run on more than s positions. Taking N = r·s + 1 recovers the classical 1935 statement — a sequence of r·s + 1 terms has a monotone subsequence of length r+1 or s+1. The proof rewrites card (SeqPos f) = N, applies the dichotomy, and maps the resulting chain/antichain to its position set with cardinality preserved.",
+    "mathContext": "$N > r\\cdot s \\Rightarrow$ non-decreasing run of length $> r$ or strictly decreasing run of length $> s$;  $N = rs+1$ gives the classical bound.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős–Szekeres theorem", "monotone subsequence", "Ramsey-type theorem", "1935 result"],
+    "prerequisites": ["linear orders", "the poset dichotomy"]
+  }
+]

--- a/src/data/proofs/dilworth-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dilworth-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "dilworth-hard-header",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 65 },
+    "type": "context",
+    "title": "The hard direction of Dilworth's theorem — not in Mathlib",
+    "content": "The companion files supply the easy direction (an antichain is no larger than any chain cover, width ≤ min chain cover) and the hard direction of Mirsky's theorem. The hard direction of Dilworth's theorem — that a chain cover whose size equals the maximum antichain width actually exists — is the genuinely deep combinatorial content and is not available in Mathlib. This file proves it in full via the Galvin/Perles down-set/up-set decomposition, organised around a maximum antichain.",
+    "mathContext": "Dilworth (1950): in a finite poset, $\\min(\\text{chain cover}) = \\max(\\text{antichain})$. This file proves the hard $\\ge$ inequality.",
+    "significance": "context",
+    "relatedConcepts": ["Dilworth's theorem", "Galvin–Perles proof", "chain cover", "antichain width", "min–max duality"],
+    "prerequisites": ["partial orders", "chains and antichains"]
+  },
+  {
+    "id": "dilworth-hard-chainpartition-def",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 83 },
+    "type": "definition",
+    "title": "Chain partition: a disjoint covering chain family",
+    "content": "IsChainPartition strengthens a chain cover with a disjointness clause: every element of s lies in a unique member chain. This is exactly what the Dilworth induction needs — disjointness lets the gluing step match each chain to the unique element of the maximum antichain it contains, so down-parts and up-parts can be welded bijectively. Proving the partition form (not just a cover) is essential to the induction; the cover form is recovered at the end by forgetting disjointness.",
+    "mathContext": "$\\mathcal{C}$ a family of chains $\\subseteq s$ that covers $s$ with each $x \\in s$ in a unique $C \\in \\mathcal{C}$.",
+    "significance": "key",
+    "relatedConcepts": ["partition", "chain cover", "disjointness", "unique membership"],
+    "prerequisites": ["Finset families", "covers"]
+  },
+  {
+    "id": "dilworth-hard-downup-def",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 89, "endLine": 119 },
+    "type": "definition",
+    "title": "Down-set / up-set of an antichain",
+    "content": "downSet A s collects the elements of s below some element of A; upSet A s those above some element of A. Both are subsets of s, and (when A ⊆ s) both contain A itself (each a ∈ A witnesses its own membership by reflexivity). These two sets are the stage on which the whole Galvin/Perles argument plays out — the maximum antichain A sits in their intersection.",
+    "mathContext": "$\\mathrm{downSet}\\,A\\,s = \\{x\\in s : \\exists y\\in A,\\ x\\le y\\}$, $\\ \\mathrm{upSet}\\,A\\,s = \\{x\\in s : \\exists y\\in A,\\ y\\le x\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["down-set", "up-set", "order ideal", "order filter"],
+    "prerequisites": ["order ideals and filters"]
+  },
+  {
+    "id": "dilworth-hard-chain-confinement",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 121, "endLine": 142 },
+    "type": "insight",
+    "title": "A chain through a' ∈ A is confined below (resp. above) a'",
+    "content": "le_of_mem_chain_downSet: in a chain C ⊆ downSet A s containing a' ∈ A, every element x lies below a'. If x is not already ≤ a' by chain comparability, then a' ≤ x ≤ (witness y), so the antichain forces a' = y and hence x = a'. ge_of_mem_chain_upSet is the dual. These confinement facts are what make gluing valid: a down-chain stays under its antichain element and an up-chain stays over it.",
+    "mathContext": "$C \\subseteq \\mathrm{downSet}\\,A\\,s,\\ a'\\in A\\cap C \\Rightarrow \\forall x\\in C,\\ x\\le a'.$",
+    "significance": "key",
+    "relatedConcepts": ["chain comparability", "antichain incomparability", "confinement", "antisymmetry"],
+    "prerequisites": ["chains", "antichains"]
+  },
+  {
+    "id": "dilworth-hard-inter-union-glue",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 144, "endLine": 216 },
+    "type": "theorem",
+    "title": "Decomposition: meet in A, cover s, and glue",
+    "content": "Three structural pillars. downSet_inter_upSet: the two sets meet exactly in A (an element in both is squeezed y₂ ≤ x ≤ y₁ between antichain elements, forcing it into A). downSet_union_upSet: for a maximum antichain they cover all of s — an element missed by both is incomparable to all of A, so A ∪ {x} would be a strictly larger antichain, contradicting maximality. glue_isChain: a down-chain and an up-chain through the same a' ∈ A union to a chain, since any cross-pair is comparable through a' (x ≤ a' ≤ y).",
+    "mathContext": "$\\mathrm{downSet}\\cap\\mathrm{upSet}=A;\\quad \\mathrm{downSet}\\cup\\mathrm{upSet}=s\\ (A\\text{ maximum});\\quad C\\cup C' \\text{ is a chain}.$",
+    "significance": "key",
+    "relatedConcepts": ["maximum antichain", "covering", "gluing chains", "comparability through a pivot"],
+    "prerequisites": ["antichain maximality", "chain unions"]
+  },
+  {
+    "id": "dilworth-hard-saturation",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 218, "endLine": 263 },
+    "type": "theorem",
+    "title": "Saturation pigeonhole: every chain meets the antichain",
+    "content": "chain_meets_antichain_of_card_le. If a chain family 𝒞 covers an antichain A and |𝒞| ≤ |A|, then every chain of 𝒞 meets A. The map a ↦ (a chain containing a) is injective on A (two antichain elements in the same chain would coincide, by chain∩antichain ≤ 1), so its image has card |A| ≤ |𝒞| and, by equal cardinalities, equals 𝒞 — i.e. the map is onto, so every chain is hit. This bridges the easy bound to the gluing step: it guarantees the inductive down/up sub-covers are indexed by A.",
+    "mathContext": "$|\\mathcal{C}| \\le |A|$ and $\\mathcal{C}$ covers $A$ $\\Rightarrow$ every $C\\in\\mathcal{C}$ contains exactly one element of $A$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "injective-then-bijective", "saturation", "chain–antichain intersection"],
+    "prerequisites": ["pigeonhole", "card-le forcing equality"]
+  },
+  {
+    "id": "dilworth-hard-induction",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 267, "endLine": 518 },
+    "type": "theorem",
+    "title": "Dilworth's hard direction by strong induction: glue or chain-removal",
+    "content": "dilworth_chainPartition. Strong induction on s (strict subset). Fix a maximum antichain A of size m. Either some maximum antichain B is NON-EXTREME (downSet B s ≠ s and upSet B s ≠ s) — then both are proper subsets, induction partitions each into ≤ m chains, saturation indexes both partitions by B, and glue_isChain welds the down-part and up-part through their shared element of B (the long hcross argument verifies the welded parts are pairwise disjoint). Or every maximum antichain is EXTREME (the set of all minimal or all maximal elements) — then delete a minimal-to-maximal chain {x, y}; every maximum antichain contains x or y, so s ∖ {x,y} has width ≤ m−1, and induction plus reinserting {x,y} gives ≤ m chains.",
+    "mathContext": "width $\\le w$ $\\Rightarrow$ $s$ partitions into $\\le w$ chains; the case split is on existence of a non-extreme maximum antichain.",
+    "significance": "critical",
+    "relatedConcepts": ["strong induction", "Galvin–Perles", "case analysis", "minimal and maximal elements", "chain removal"],
+    "prerequisites": ["strong induction on finsets", "the decomposition and saturation lemmas"]
+  },
+  {
+    "id": "dilworth-hard-cover",
+    "proofId": "dilworth-theorem-oq-01-oq-02",
+    "range": { "startLine": 520, "endLine": 538 },
+    "type": "theorem",
+    "title": "Cover form and the min–max equality",
+    "content": "dilworth_chainCover. The headline cover form — width ≤ w implies s is covered by ≤ w chains — obtained immediately from the partition by forgetting disjointness. Combined with the companion easy direction antichain_card_le_of_chainCover, taking w to be the maximum antichain width yields the classical Dilworth equality: the minimum number of chains needed to cover a finite poset equals the maximum size of an antichain.",
+    "mathContext": "$\\min(\\text{chain cover}) = \\max(\\text{antichain width}).$",
+    "significance": "key",
+    "relatedConcepts": ["Dilworth equality", "chain cover", "duality", "Mirsky's theorem (transpose)"],
+    "prerequisites": ["the partition form", "the easy direction"]
+  }
+]


### PR DESCRIPTION
Enrichment pass adding or deepening the `annotations.json` inline-annotation layer across nine entries. Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, line-anchored to the actual proof structure. No `meta.json` changes — each entry's metadata was already comprehensive and accurate against its verified Lean source.

| Entry | Topic | Annotations |
|---|---|---|
| `cauchy-interlacing-theorem-oq-03-oq-01-oq-02` | Residual (Bauer–Fike) eigenvalue bound | 9 (new) |
| `arithmetic-series-oq-02-oq-01-oq-01-oq-03` | q-Vandermonde dual/symmetric forms | 6 (new) |
| `baire-category-theorem-oq-01-oq-02-oq-02` | Cantor–Bendixson cardinal form | 8 (new) |
| `dilworth-theorem-oq-01-oq-01-oq-03` | Mirsky→Erdős–Szekeres min–max framework | 7 (new) |
| `dilworth-theorem-oq-01-oq-02` | Dilworth hard direction (Galvin/Perles) | 8 (new) |
| `binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01` | Degree-one multinomial support | 4→6 (deepened) |
| `cramers-rule-oq-04-oq-01` | Adjugate behind Cramer's rule & Cayley–Hamilton | 3 (metadata added) |
| `de-moivre-oq-03-oq-01-oq-01` | De Moivre for irrational exponents | 3 (metadata added) |
| `descartes-rule-of-signs-oq-02-oq-03` | Conjugate-pair roots of real polynomials | 3 (metadata added) |

Five entries received brand-new annotation layers (they shipped with zero); four had existing annotations deepened with the missing `mathContext`/`significance`/`relatedConcepts`/`prerequisites` fields or additional coverage. All Lean sources are verified, 0-axiom, 0-sorry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)