### PR TITLE
research(combinations-formula-oq-01-oq-02): terminating Gauss ₂F₁ summation (Chu–Vandermonde) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -839,6 +839,7 @@ import Proofs.CombinationsFormulaOQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01
 import Proofs.CombinationsFormulaOQ01OQ01OQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ01OQ02
+import Proofs.CombinationsFormulaOQ01OQ02
 import Proofs.CombinationsFormulaOQ01OQ04
 import Proofs.CombinationsFormulaOQ02
 import Proofs.CombinationsFormulaOQ02Aristotle

--- a/proofs/Proofs/CombinationsFormulaOQ01OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ01OQ02.lean
@@ -1,0 +1,203 @@
+import Mathlib
+
+/-
+# Combinations Formula OQ-01-OQ-02: the terminating Gauss ₂F₁ summation
+
+The parent entry `combinations-formula-oq-01` proves the classical
+**Vandermonde convolution** for binomial coefficients,
+`C(m + n, r) = ∑_{k} C(m, k) · C(n, r − k)`, a purely natural-number identity.
+This file lifts that identity to the level of the **Gauss (ordinary)
+hypergeometric series** `₂F₁`, of which Vandermonde is the terminating special
+case.
+
+Mathlib already provides `descPochhammer_smeval_add` (a Vandermonde convolution
+for descending Pochhammer symbols, phrased through `smeval`) and
+`ordinaryHypergeometric` (notation `₂F₁`, the analytic series
+`∑ (a)_n (b)_n / (c)_n · xⁿ/n!`). It does **not** provide any *summation
+theorem* giving a closed form for the value of `₂F₁`. The cornerstone such
+result is **Gauss's second / terminating theorem** (Chu–Vandermonde):
+
+  `₂F₁(−n, b; c; 1) = (c − b)_n / (c)_n`,
+
+valid because the upper parameter `−n` makes the series terminate. Clearing
+denominators turns it into a polynomial identity valid over *any* commutative
+ring, with no positivity, division, or convergence hypotheses:
+
+  `∑_{i+j=n} (−1)ⁱ C(n,i) · (b)ᵢ · (c+i)ⱼ  =  (c − b)_n`,        (★)
+
+where `(z)_m = (ascPochhammer _ m).eval z` is the rising factorial.
+
+## What is proved here
+
+* `descPochhammer_eval_vandermonde` / `ascPochhammer_eval_vandermonde` — the
+  Vandermonde convolution in `.eval` form over a commutative ring, for falling
+  and rising factorials respectively (the polynomial backbone). The rising form
+  is the Chu–Vandermonde identity that generalizes the parent's binomial one.
+* `ascPochhammer_eval_eq_descPochhammer'` — the bridge `(z)_m = (z+m−1)^{≤m}`.
+* `neg_one_pow_mul_ascPochhammer_eval` — the sign bridge `(−1)ⁱ (b)ᵢ = (−b)^{≤i}`.
+* `gauss_terminating_ring` — the ring-level terminating identity (★).
+* `gauss_terminating_field` — the genuine quotient form
+  `∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ / (c)ᵢ = (c − b)_n / (c)_n` over a field, under
+  the single nonvanishing hypothesis `(c)_n ≠ 0`.
+
+## Method
+
+Because `(z)_m = (z+m−1)^{≤m}` (rising = falling shifted) and
+`(−1)ⁱ (b)ᵢ = (−b)^{≤i}`, every summand of (★) becomes a *falling* Pochhammer
+with a base independent of the summation index `i`:
+`(−1)ⁱ (b)ᵢ · (c+i)_{n−i} = (−b)^{≤i} · (c+n−1)^{≤(n−i)}`. So (★) is exactly the
+falling Vandermonde convolution evaluated at `α = −b`, `β = c + n − 1`, since
+`α + β = c − b + n − 1` and `(c−b)_n = (c−b+n−1)^{≤n}`. The quotient form then
+follows by clearing `(c)_n` via the split `(c)_n = (c)ᵢ · (c+i)_{n−i}`.
+-/
+
+open Finset Polynomial
+
+namespace CombinationsFormulaOQ01OQ02
+
+variable {R : Type*} [CommRing R]
+
+/-! ## The descending-Pochhammer Vandermonde convolution (polynomial backbone) -/
+
+/-- **Descending-Pochhammer Vandermonde convolution**, evaluated form over a
+commutative ring:
+`(α+β)^{\underline n} = ∑_{i+j=n} C(n,i) · α^{\underline i} · β^{\underline j}`. -/
+theorem descPochhammer_eval_vandermonde (α β : R) (n : ℕ) :
+    (descPochhammer R n).eval (α + β)
+      = ∑ ij ∈ antidiagonal n,
+          (n.choose ij.1 : R)
+            * ((descPochhammer R ij.1).eval α * (descPochhammer R ij.2).eval β) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [sum_antidiagonal_choose_succ_mul
+          (fun i j => (descPochhammer R i).eval α * (descPochhammer R j).eval β) n,
+        descPochhammer_succ_eval, ih, Finset.sum_mul, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl ?_
+    intro ij hmem
+    obtain ⟨i, j⟩ := ij
+    have hij : i + j = n := Finset.mem_antidiagonal.mp hmem
+    have hsum : (i : R) + (j : R) = (n : R) := by rw [← Nat.cast_add, hij]
+    have hsymm : (n.choose j : R) = (n.choose i : R) := by
+      have hji : n = j + i := by omega
+      rw [Nat.choose_symm_of_eq_add hji]
+    rw [descPochhammer_succ_eval, descPochhammer_succ_eval, hsymm, ← hsum]
+    ring
+
+/-! ## Rising / falling factorial bridge -/
+
+/-- The rising factorial as a shifted falling factorial:
+`(z)_m = (z + m − 1)^{\underline m}`. -/
+theorem ascPochhammer_eval_eq_descPochhammer' (z : R) (m : ℕ) :
+    (ascPochhammer R m).eval z = (descPochhammer R m).eval (z + m - 1) := by
+  rw [descPochhammer_eval_eq_ascPochhammer]
+  congr 1
+  ring
+
+/-- The signed rising factorial as a falling factorial at the negated base:
+`(−1)ⁱ · (b)ᵢ = (−b)^{\underline i}`. -/
+theorem neg_one_pow_mul_ascPochhammer_eval (b : R) (i : ℕ) :
+    (-1) ^ i * (ascPochhammer R i).eval b = (descPochhammer R i).eval (-b) := by
+  have h := ascPochhammer_eval_neg_eq_descPochhammer R (-b) i
+  rw [neg_neg] at h
+  rw [h, ← mul_assoc]
+  have h2 : ((-1 : R)) ^ i * (-1) ^ i = 1 := by
+    rw [← pow_add]; exact Even.neg_one_pow ⟨i, by ring⟩
+  rw [h2, one_mul]
+
+/-! ## The rising-factorial Vandermonde convolution -/
+
+/-- **Rising-Pochhammer Vandermonde convolution**, evaluated form over a
+commutative ring:
+`(x+y)_n = ∑_{i+j=n} C(n,i) · (x)ᵢ · (y)ⱼ`.
+
+This is the Chu–Vandermonde identity for rising factorials; the parent's
+natural-number Vandermonde is its specialization at integer arguments. -/
+theorem ascPochhammer_eval_vandermonde (x y : R) (n : ℕ) :
+    (ascPochhammer R n).eval (x + y)
+      = ∑ ij ∈ antidiagonal n,
+          (n.choose ij.1 : R)
+            * ((ascPochhammer R ij.1).eval x * (ascPochhammer R ij.2).eval y) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [sum_antidiagonal_choose_succ_mul
+          (fun i j => (ascPochhammer R i).eval x * (ascPochhammer R j).eval y) n,
+        ascPochhammer_succ_eval, ih, Finset.sum_mul, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl ?_
+    intro ij hmem
+    obtain ⟨i, j⟩ := ij
+    have hij : i + j = n := Finset.mem_antidiagonal.mp hmem
+    have hsum : (i : R) + (j : R) = (n : R) := by rw [← Nat.cast_add, hij]
+    have hsymm : (n.choose j : R) = (n.choose i : R) := by
+      have hji : n = j + i := by omega
+      rw [Nat.choose_symm_of_eq_add hji]
+    rw [ascPochhammer_succ_eval, ascPochhammer_succ_eval, hsymm, ← hsum]
+    ring
+
+/-! ## The terminating Gauss ₂F₁ summation (Chu–Vandermonde) -/
+
+/-- **Terminating Gauss ₂F₁ summation, ring form** (Chu–Vandermonde).
+
+For all `b c : R` and `n : ℕ`,
+`∑_{i+j=n} (−1)ⁱ C(n,i) · (b)ᵢ · (c+i)ⱼ = (c − b)_n`.
+
+This is `₂F₁(−n, b; c; 1) = (c−b)_n / (c)_n` with denominators cleared, hence
+valid over an *arbitrary* commutative ring with no nonvanishing hypotheses.
+Each summand collapses to a falling factorial with index-independent base
+(`(−b)^{\underline i}` and `(c+n−1)^{\underline{\,j}}`), so the whole sum is the
+descending Vandermonde convolution at `α = −b`, `β = c + n − 1`. -/
+theorem gauss_terminating_ring (b c : R) (n : ℕ) :
+    ∑ ij ∈ antidiagonal n,
+        ((-1) ^ ij.1 * (n.choose ij.1 : R))
+          * ((ascPochhammer R ij.1).eval b * (ascPochhammer R ij.2).eval (c + ij.1))
+      = (ascPochhammer R n).eval (c - b) := by
+  rw [ascPochhammer_eval_eq_descPochhammer' (c - b) n,
+      show (c - b) + (n : R) - 1 = (-b) + (c + (n : R) - 1) by ring,
+      descPochhammer_eval_vandermonde (-b) (c + (n : R) - 1) n]
+  refine Finset.sum_congr rfl ?_
+  intro ij hmem
+  obtain ⟨i, j⟩ := ij
+  have hij : i + j = n := Finset.mem_antidiagonal.mp hmem
+  have hsum : (i : R) + (j : R) = (n : R) := by rw [← Nat.cast_add, hij]
+  rw [ascPochhammer_eval_eq_descPochhammer' (c + (i : R)) j,
+      show (c + (i : R)) + (j : R) - 1 = c + (n : R) - 1 by rw [← hsum]; ring,
+      ← neg_one_pow_mul_ascPochhammer_eval b i]
+  ring
+
+/-- Multiplicative splitting of the rising factorial:
+`(c)_{k+m} = (c)_k · (c+k)_m`. -/
+theorem ascPochhammer_eval_split (c : R) (k m : ℕ) :
+    (ascPochhammer R (k + m)).eval c
+      = (ascPochhammer R k).eval c * (ascPochhammer R m).eval (c + k) := by
+  rw [← ascPochhammer_mul, eval_mul, eval_comp, eval_add, eval_X, eval_natCast]
+
+/-- **Terminating Gauss ₂F₁ summation, quotient form** over a field:
+
+`∑_{i+j=n} (−1)ⁱ C(n,i) · (b)ᵢ / (c)ᵢ = (c − b)_n / (c)_n`,
+
+i.e. `₂F₁(−n, b; c; 1) = (c − b)_n / (c)_n`, under the single nonvanishing
+hypothesis `(c)_n ≠ 0` (which forces every `(c)ᵢ ≠ 0` for `i ≤ n`, since
+`(c)ᵢ` divides `(c)_n`). This is the classical statement of Gauss's second
+theorem; it follows from the ring form by clearing `(c)_n` and using the
+split `(c)_n = (c)ᵢ · (c+i)_{n−i}`. -/
+theorem gauss_terminating_field {K : Type*} [Field K] (b c : K) (n : ℕ)
+    (hc : (ascPochhammer K n).eval c ≠ 0) :
+    ∑ ij ∈ antidiagonal n,
+        ((-1) ^ ij.1 * (n.choose ij.1 : K))
+          * ((ascPochhammer K ij.1).eval b / (ascPochhammer K ij.1).eval c)
+      = (ascPochhammer K n).eval (c - b) / (ascPochhammer K n).eval c := by
+  rw [eq_div_iff hc, Finset.sum_mul, ← gauss_terminating_ring b c n]
+  refine Finset.sum_congr rfl ?_
+  intro ij hmem
+  obtain ⟨i, j⟩ := ij
+  have hij : i + j = n := Finset.mem_antidiagonal.mp hmem
+  have hsplit : (ascPochhammer K n).eval c
+      = (ascPochhammer K i).eval c * (ascPochhammer K j).eval (c + i) := by
+    rw [← hij]; exact ascPochhammer_eval_split c i j
+  have hci : (ascPochhammer K i).eval c ≠ 0 := by
+    intro h; apply hc; rw [hsplit, h, zero_mul]
+  rw [hsplit]
+  field_simp
+
+end CombinationsFormulaOQ01OQ02

--- a/src/data/proofs/combinations-formula-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-02/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "ann-2f1-header",
+    "proofId": "combinations-formula-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "concept",
+    "title": "From Vandermonde to the Gauss ₂F₁ Summation",
+    "content": "The parent entry proves the natural-number Vandermonde convolution C(m+n,r) = ∑ C(m,k)C(n,r−k). This file lifts it to Gauss's hypergeometric series ₂F₁. When the upper parameter of ₂F₁(a,b;c;z) is a non-positive integer a = −n, the otherwise-infinite series terminates, and Gauss's theorem ₂F₁(a,b;c;1) = Γ(c)Γ(c−a−b)/(Γ(c−a)Γ(c−b)) specializes to the purely algebraic Chu–Vandermonde value ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n. Mathlib already defines the analytic ₂F₁ and a Pochhammer Vandermonde convolution, but provides NO summation theorem — no closed form for the value of ₂F₁ at any point. This file supplies the cornerstone terminating case.",
+    "mathContext": "Rising factorial (z)_m = z(z+1)⋯(z+m−1) = (ascPochhammer R m).eval z. Terminating Gauss/Chu–Vandermonde: ₂F₁(−n,b;c;1) = ∑_{k=0}^{n} (−1)^k \\binom{n}{k} (b)_k/(c)_k = (c−b)_n/(c)_n.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gauss 1812 hypergeometric summation",
+      "Zhu Shijie (1303) / Vandermonde (1772) convolution",
+      "ordinaryHypergeometric (Mathlib ₂F₁)",
+      "ascPochhammer / descPochhammer"
+    ],
+    "prerequisites": [
+      "Binomial coefficients and the Vandermonde convolution (parent entry)",
+      "Rising and falling factorials (Pochhammer symbols)",
+      "Hypergeometric series ₂F₁(a,b;c;z) = ∑ (a)_n(b)_n/((c)_n n!) zⁿ"
+    ]
+  },
+  {
+    "id": "ann-desc-vandermonde",
+    "proofId": "combinations-formula-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 89 },
+    "type": "insight",
+    "title": "Vandermonde Convolution by Antidiagonal Induction",
+    "content": "descPochhammer_eval_vandermonde proves (α+β)^{≤n} = ∑_{i+j=n} C(n,i) α^{≤i} β^{≤j} over an arbitrary commutative ring, in clean evaluated form. The induction uses Mathlib's Pascal split `Finset.sum_antidiagonal_choose_succ_mul`, which rewrites a binomial-weighted antidiagonal sum at rank n+1 as two sums at rank n. Combined with the falling recurrence z^{≤m+1} = z^{≤m}(z−m) (descPochhammer_succ_eval) and the symmetry C(n,j)=C(n,i) for i+j=n, each successor term reassembles into (α+β−n) times the rank-n sum, matching the left side. This is the polynomial backbone for the Gauss summation.",
+    "mathContext": "(α+β)^{\\underline n} = ∑_{i+j=n} \\binom{n}{i} α^{\\underline i} β^{\\underline j}. The Pascal split contributes f(i,j+1) and f(i+1,j) terms; the recurrences supply factors (β−j) and (α−i), summing to (α+β−(i+j)) = (α+β−n).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_antidiagonal_choose_succ_mul",
+      "descPochhammer_succ_eval",
+      "Nat.choose_symm_of_eq_add",
+      "descPochhammer_smeval_add (Mathlib smeval analogue)"
+    ],
+    "prerequisites": [
+      "Falling factorial recurrence z^{≤(m+1)} = z^{≤m}(z−m)",
+      "Antidiagonal sums over ℕ",
+      "Pascal's rule in antidiagonal form"
+    ]
+  },
+  {
+    "id": "ann-bridges",
+    "proofId": "combinations-formula-oq-01-oq-02",
+    "range": { "startLine": 90, "endLine": 114 },
+    "type": "insight",
+    "title": "Two Bridges That Fix the Base",
+    "content": "The reduction of the alternating Gauss sum to an ordinary Vandermonde convolution rests on two bridges. ascPochhammer_eval_eq_descPochhammer' expresses the rising factorial as a shifted falling one, (z)_m = (z+m−1)^{≤m} (from Mathlib's descPochhammer_eval_eq_ascPochhammer). neg_one_pow_mul_ascPochhammer_eval expresses the signed rising factorial as a falling factorial at the negated base, (−1)ⁱ(b)ᵢ = (−b)^{≤i} (from Mathlib's ascPochhammer_eval_neg_eq_descPochhammer). Applying both, the summand (−1)ⁱ(b)ᵢ·(c+i)_{n−i} becomes (−b)^{≤i}·(c+n−1)^{≤(n−i)} — crucially, BOTH falling-factorial bases (−b and c+n−1) are independent of the summation index i.",
+    "mathContext": "(z)_m = (z+m−1)^{\\underline m};  (−1)^i (b)_i = (−b)^{\\underline i}. Then (−1)^i (b)_i (c+i)_{n−i} = (−b)^{\\underline i} (c+n−1)^{\\underline{\\,n−i}} since (c+i)+(n−i)−1 = c+n−1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "descPochhammer_eval_eq_ascPochhammer",
+      "ascPochhammer_eval_neg_eq_descPochhammer",
+      "Reflection of factorials: (−z)^{\\underline k} = (−1)^k (z)_k"
+    ],
+    "prerequisites": [
+      "Relation between rising and falling factorials",
+      "(−1)^{2i} = 1"
+    ]
+  },
+  {
+    "id": "ann-gauss-ring",
+    "proofId": "combinations-formula-oq-01-oq-02",
+    "range": { "startLine": 149, "endLine": 168 },
+    "type": "insight",
+    "title": "Gauss's Terminating Summation, Denominator-Cleared",
+    "content": "gauss_terminating_ring is the headline result: ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n, over ANY commutative ring with no nonvanishing, positivity, or convergence hypotheses. Using the two bridges termwise, the alternating sum equals ∑_{i+j=n} C(n,i) (−b)^{≤i} (c+n−1)^{≤j}, which is exactly descPochhammer_eval_vandermonde at α=−b, β=c+n−1. Its value (−b+c+n−1)^{≤n} = (c−b)_n by the rising/falling bridge. This is Gauss's second theorem with denominators cleared.",
+    "mathContext": "∑_{i+j=n} (−1)^i \\binom{n}{i} (b)_i (c+i)_j = (c−b)_n. Equivalent to ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n after dividing by (c)_n.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chu–Vandermonde identity",
+      "Gauss's second theorem",
+      "Pfaff–Saalschütz (terminating ₃F₂)",
+      "Zeilberger's algorithm"
+    ],
+    "prerequisites": [
+      "descPochhammer_eval_vandermonde",
+      "The two factorial bridges"
+    ]
+  },
+  {
+    "id": "ann-gauss-field",
+    "proofId": "combinations-formula-oq-01-oq-02",
+    "range": { "startLine": 169, "endLine": 203 },
+    "type": "insight",
+    "title": "The Classical Quotient Form and a Single Hypothesis",
+    "content": "gauss_terminating_field is the recognizable statement ₂F₁(−n,b;c;1) = ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ/(c)ᵢ = (c−b)_n/(c)_n over a field. It follows from the ring form by clearing (c)_n using ascPochhammer_eval_split, the multiplicative law (c)_{k+m} = (c)_k (c+k)_m. A pleasant subtlety: only (c)_n ≠ 0 is assumed, not (c)ₖ ≠ 0 for each k — because the split exhibits each (c)ₖ as a factor of the nonzero (c)_n, so every (c)ₖ is automatically nonzero.",
+    "mathContext": "₂F₁(−n,b;c;1) = (c−b)_n/(c)_n, requiring only (c)_n ≠ 0. The split (c)_n = (c)_i (c+i)_{n−i} turns (c+i)_{n−i} into (c)_n/(c)_i.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ascPochhammer_eval_split",
+      "(c)_i divides (c)_n",
+      "field_simp / eq_div_iff"
+    ],
+    "prerequisites": [
+      "gauss_terminating_ring",
+      "Multiplicative split of the rising factorial",
+      "Division in a field"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-02/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "combinations-formula-oq-01-oq-02",
+  "title": "The Terminating Gauss ₂F₁ Summation (Chu–Vandermonde)",
+  "slug": "combinations-formula-oq-01-oq-02",
+  "description": "Gauss's terminating hypergeometric summation ₂F₁(−n, b; c; 1) = (c−b)_n/(c)_n, proved as a polynomial Chu–Vandermonde identity over an arbitrary commutative ring and as the classical quotient form over a field. Generalizes the parent's natural-number Vandermonde convolution to rising factorials and the Gauss hypergeometric series.",
+  "meta": {
+    "author": "Lean Genius Research Team",
+    "date": "2026-06-24",
+    "dateAdded": "2026-06-24",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "combinatorics",
+      "hypergeometric",
+      "gauss-2f1",
+      "chu-vandermonde",
+      "pochhammer",
+      "rising-factorial",
+      "binomial-coefficients",
+      "special-functions"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 203,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ01OQ02.lean",
+    "originalContributions": [
+      "gauss_terminating_ring: the terminating Gauss ₂F₁ summation ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n, denominator-cleared and valid over ANY commutative ring (no positivity/division/convergence hypotheses) — Gauss's second theorem absent from Mathlib",
+      "gauss_terminating_field: the classical quotient form ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ/(c)ᵢ = (c−b)_n/(c)_n over a field, i.e. ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n, under the single hypothesis (c)_n ≠ 0",
+      "ascPochhammer_eval_vandermonde: the rising-factorial Chu–Vandermonde convolution (x+y)_n = ∑_{i+j=n} C(n,i) (x)ᵢ (y)ⱼ in .eval form over a commutative ring — the generalization of the parent's binomial Vandermonde",
+      "descPochhammer_eval_vandermonde: the falling-factorial Vandermonde convolution in .eval form over a commutative ring (the polynomial backbone), proved by antidiagonal induction",
+      "ascPochhammer_eval_eq_descPochhammer': the rising/falling bridge (z)_m = (z+m−1)^{≤m}",
+      "neg_one_pow_mul_ascPochhammer_eval: the sign bridge (−1)ⁱ (b)ᵢ = (−b)^{≤i} casting a signed rising factorial as a falling factorial at the negated base",
+      "ascPochhammer_eval_split: the multiplicative split (c)_{k+m} = (c)_k (c+k)_m used to clear denominators in the quotient form"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Carl Friedrich Gauss introduced the hypergeometric series ₂F₁(a,b;c;z) = ∑ (a)_n(b)_n/((c)_n n!) zⁿ in his 1812 memoir 'Disquisitiones generales circa seriem infinitam', where he proved the celebrated summation ₂F₁(a,b;c;1) = Γ(c)Γ(c−a−b)/(Γ(c−a)Γ(c−b)) for Re(c−a−b) > 0. When the upper parameter a = −n is a non-positive integer the series terminates and Gauss's theorem specializes to the purely algebraic identity ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n, which is equivalent to the Chu–Vandermonde convolution. The convolution itself predates Gauss: Zhu Shijie (朱世杰) recorded it in his 1303 'Jade Mirror of the Four Unknowns' (the 'Zhu Vandermonde' identity), and Alexandre-Théophile Vandermonde rediscovered the binomial case in 1772. The terminating ₂F₁ summation is the gateway to the entire theory of summation and transformation formulas for hypergeometric series (Pfaff–Saalschütz, Dixon, Watson, Whipple), which underpins the modern algorithmic theory of Zeilberger and Petkovšek.",
+    "problemStatement": "Generalize the parent's natural-number Vandermonde convolution C(m+n,r) = ∑_k C(m,k) C(n,r−k) to the Gauss hypergeometric series ₂F₁. Concretely, establish Gauss's terminating summation: for the rising factorial (z)_m = z(z+1)⋯(z+m−1), prove ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n over an arbitrary commutative ring (the denominator-cleared form), and the classical quotient ₂F₁(−n,b;c;1) = ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ/(c)ᵢ = (c−b)_n/(c)_n over a field.",
+    "proofStrategy": "Although Mathlib provides `descPochhammer_smeval_add` (a Vandermonde convolution for descending Pochhammer symbols via `smeval`) and `ordinaryHypergeometric` (notation `₂F₁`), it contains NO summation theorem for ₂F₁. We first reprove the Vandermonde convolution in clean evaluated (`.eval`) form over a commutative ring by an antidiagonal induction, using the Pascal split `Finset.sum_antidiagonal_choose_succ_mul` together with the Pochhammer recurrences `ascPochhammer_succ_eval` / `descPochhammer_succ_eval`. The key insight reduces Gauss's terminating identity to this convolution: because (z)_m = (z+m−1)^{≤m} (rising = shifted falling, via Mathlib's `descPochhammer_eval_eq_ascPochhammer`) and (−1)ⁱ(b)ᵢ = (−b)^{≤i} (via Mathlib's `ascPochhammer_eval_neg_eq_descPochhammer`), each summand of the alternating sum collapses to a FALLING Pochhammer with a base independent of the summation index i: (−1)ⁱ(b)ᵢ·(c+i)_{n−i} = (−b)^{≤i}·(c+n−1)^{≤(n−i)}. Hence the whole sum is the falling Vandermonde convolution evaluated at α = −b, β = c+n−1, whose value (−b+c+n−1)^{≤n} equals (c−b)_n. The quotient (field) form follows by clearing (c)_n with the multiplicative split (c)_n = (c)ᵢ·(c+i)_{n−i}; note (c)_n ≠ 0 forces every (c)ᵢ ≠ 0 since (c)ᵢ divides (c)_n.",
+    "keyInsights": [
+      "**Vandermonde is the terminating ₂F₁**: Gauss's hypergeometric summation, normally an analytic theorem about an infinite series with a Gamma-function value, becomes a finite algebraic identity precisely when the upper parameter is a non-positive integer −n. In that regime it IS the Chu–Vandermonde convolution — the parent's binomial identity is the integer specialization.",
+      "**Index-independent base trick**: The seemingly index-dependent summand (−1)ⁱ(b)ᵢ·(c+i)_{n−i} hides a falling-factorial structure with a FIXED base. Rewriting via (z)_m = (z+m−1)^{≤m} and (−1)ⁱ(b)ᵢ = (−b)^{≤i} turns it into (−b)^{≤i}·(c+n−1)^{≤(n−i)} — both bases (−b and c+n−1) are independent of i, so the alternating sum is an ordinary Vandermonde convolution. This is what makes the elementary reduction possible without generating-function machinery.",
+      "**Denominator-clearing buys full generality**: Stating the identity as ∑ (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n (rather than the quotient ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n) removes every hypothesis: the ring form holds over an arbitrary commutative ring, with no nonvanishing, positivity, or convergence assumption. The classical quotient form is then recovered over a field under the single hypothesis (c)_n ≠ 0.",
+      "**One nonvanishing hypothesis suffices**: For the quotient form, only (c)_n ≠ 0 is needed — not (c)ₖ ≠ 0 for each k — because the multiplicative split (c)_n = (c)ₖ·(c+k)_{n−k} exhibits each (c)ₖ as a factor of the nonzero (c)_n.",
+      "**Mathlib gap**: Mathlib has the analytic ₂F₁ object and a Pochhammer Vandermonde convolution, but no closed-form *evaluation* of ₂F₁ at any point. This entry supplies the cornerstone terminating case, the springboard for the classical summation/transformation hierarchy (Pfaff–Saalschütz, Dixon, …)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "desc-vandermonde",
+      "title": "Part I: The Falling-Pochhammer Vandermonde Convolution",
+      "startLine": 56,
+      "endLine": 89,
+      "summary": "descPochhammer_eval_vandermonde proves (α+β)^{≤n} = ∑_{i+j=n} C(n,i) α^{≤i} β^{≤j} over any commutative ring, by an antidiagonal induction using the Pascal split sum_antidiagonal_choose_succ_mul and descPochhammer_succ_eval.",
+      "mathContext": "The polynomial backbone. For falling factorials z^{≤m} = z(z−1)⋯(z−m+1), the convolution (α+β)^{≤n} = ∑_{i+j=n} \\binom{n}{i} α^{≤i} β^{≤j} holds over an arbitrary commutative ring."
+    },
+    {
+      "id": "bridges",
+      "title": "Part II: Rising/Falling and Sign Bridges",
+      "startLine": 90,
+      "endLine": 114,
+      "summary": "ascPochhammer_eval_eq_descPochhammer' gives (z)_m = (z+m−1)^{≤m}; neg_one_pow_mul_ascPochhammer_eval gives (−1)ⁱ (b)ᵢ = (−b)^{≤i}. Together they turn each alternating summand into a falling factorial with index-independent base.",
+      "mathContext": "(z)_m = (z+m−1)^{\\underline m} and (−1)^i (b)_i = (−b)^{\\underline i}. The latter is the reflection (−b)(−b−1)⋯(−b−i+1) = (−1)^i b(b+1)⋯(b+i−1)."
+    },
+    {
+      "id": "asc-vandermonde",
+      "title": "Part III: The Rising-Pochhammer Chu–Vandermonde Convolution",
+      "startLine": 115,
+      "endLine": 148,
+      "summary": "ascPochhammer_eval_vandermonde proves (x+y)_n = ∑_{i+j=n} C(n,i) (x)ᵢ (y)ⱼ over any commutative ring — the rising-factorial Chu–Vandermonde identity generalizing the parent's binomial convolution.",
+      "mathContext": "For rising factorials (z)_m = z(z+1)⋯(z+m−1): (x+y)_n = ∑_{i+j=n} \\binom{n}{i} (x)_i (y)_j. The parent's C(m+n,r) = ∑_k C(m,k)C(n,r−k) is the integer specialization."
+    },
+    {
+      "id": "gauss-ring",
+      "title": "Part IV: The Terminating Gauss ₂F₁ Summation (Ring Form)",
+      "startLine": 149,
+      "endLine": 168,
+      "summary": "gauss_terminating_ring proves ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n over any commutative ring, by rewriting each summand into falling factorials with index-independent bases and applying descPochhammer_eval_vandermonde at α=−b, β=c+n−1.",
+      "mathContext": "Gauss's second theorem, denominator-cleared: ∑_{i+j=n} (−1)^i \\binom{n}{i} (b)_i (c+i)_j = (c−b)_n, valid over an arbitrary commutative ring."
+    },
+    {
+      "id": "gauss-field",
+      "title": "Part V: The Classical Quotient Form over a Field",
+      "startLine": 169,
+      "endLine": 203,
+      "summary": "ascPochhammer_eval_split gives (c)_{k+m} = (c)_k (c+k)_m; gauss_terminating_field then derives ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ/(c)ᵢ = (c−b)_n/(c)_n over a field under the single hypothesis (c)_n ≠ 0.",
+      "mathContext": "₂F₁(−n,b;c;1) = ∑_{i+j=n} (−1)^i \\binom{n}{i} (b)_i/(c)_i = (c−b)_n/(c)_n, the standard statement of Gauss's terminating theorem, requiring only (c)_n ≠ 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "Gauss's terminating hypergeometric summation ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n is formalized both as a denominator-cleared polynomial identity over an arbitrary commutative ring and as the classical quotient form over a field. The proof reduces the alternating hypergeometric sum to an ordinary Vandermonde convolution via two factorial bridges that expose an index-independent falling-factorial structure, requiring no generating-function or analytic machinery.",
+    "implications": "This is the cornerstone closed-form evaluation of the Gauss hypergeometric series — the first such summation theorem on top of Mathlib's analytic ₂F₁ definition. The terminating Chu–Vandermonde is the base case of the classical hierarchy of hypergeometric summation and transformation identities (Pfaff–Saalschütz, Dixon, Watson, Whipple) and the algebraic engine behind the Gosper–Zeilberger algorithmic theory of binomial-sum identities. The ring-level form, free of any nonvanishing hypothesis, is directly reusable as a polynomial identity in symbolic computations.",
+    "openQuestions": [
+      "Can the terminating identity be connected to Mathlib's analytic `ordinaryHypergeometric` by proving that, for a non-positive integer upper parameter, the series sum equals the finite Chu–Vandermonde sum?",
+      "Does the same index-independent-base reduction prove the Pfaff–Saalschütz theorem (the terminating balanced ₃F₂ summation)?",
+      "Can the q-analogue (the terminating q-Chu–Vandermonde / q-Gauss summation) be proved by an analogous antidiagonal induction over a commutative ring with a q-Pochhammer symbol?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-01",
+      "relationship": "parent",
+      "description": "Extended Binomial Coefficient Identities — provides the natural-number Vandermonde convolution that this entry generalizes to ₂F₁"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-01-oq-01-oq-03",
+      "relationship": "related",
+      "description": "The q-Vandermonde (Gaussian-binomial) identity — a q-deformation of the same convolution"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ01OQ02.lean",
+    "namespace": "CombinationsFormulaOQ01OQ02",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Polynomial"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 203,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/combinations-formula-oq-01-oq-02.json
+++ b/src/data/research/problems/combinations-formula-oq-01-oq-02.json
@@ -1,0 +1,84 @@
+{
+  "slug": "combinations-formula-oq-01-oq-02",
+  "title": "Zhu-Vandermonde identity generalized to 2F1 hypergeometric",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "completed": "2026-06-24T23:40:00.000Z",
+  "started": "2026-06-24T23:00:00.000Z",
+  "lastUpdate": "2026-06-24T23:40:00.000Z",
+  "significance": 5,
+  "tractability": 5,
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "summary": "Generalize the parent's Zhu/Chu-Vandermonde convolution identity to the Gauss hypergeometric series 2F1, with Vandermonde as the terminating special case.",
+    "formal": "Prove Gauss's terminating summation ₂F₁(−n, b; c; 1) = (c−b)_n/(c)_n, where (z)_m is the rising factorial. Equivalently, the denominator-cleared polynomial identity ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n over an arbitrary commutative ring."
+  },
+  "currentState": {
+    "summary": "COMPLETE. Proved both the ring-level (denominator-cleared) and field-level (quotient) forms of Gauss's terminating ₂F₁ summation, plus the rising/falling Vandermonde convolutions in .eval form over a commutative ring. Verified, 0 axioms, 0 sorries.",
+    "lastApproach": "Reduce the alternating hypergeometric sum to an ordinary Vandermonde convolution via two factorial bridges that expose an index-independent falling-factorial base."
+  },
+  "knownResults": {
+    "mathlib": "Mathlib provides descPochhammer_smeval_add (a Pochhammer Vandermonde convolution via smeval) and ordinaryHypergeometric (notation ₂F₁) but NO summation theorem evaluating ₂F₁ at any point. The rising/falling and sign bridges (descPochhammer_eval_eq_ascPochhammer, ascPochhammer_eval_neg_eq_descPochhammer) and the Pascal split (Finset.sum_antidiagonal_choose_succ_mul) are available.",
+    "literature": "Gauss (1812) hypergeometric summation; Chu-Vandermonde convolution (Zhu Shijie 1303, Vandermonde 1772); the terminating ₂F₁ is the base case of the Pfaff-Saalschütz / Dixon / Watson / Whipple hierarchy."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: proved the terminating Gauss ₂F₁ summation ₂F₁(−n,b;c;1) = (c−b)_n/(c)_n (ring + field forms) and the rising/falling Vandermonde convolutions over a commutative ring. Verified, 0-axiom, original (7 theorems, 203 lines).",
+    "insights": [
+      "Gauss's hypergeometric summation, normally an analytic theorem with a Gamma-function value, becomes a finite algebraic Chu-Vandermonde identity exactly when the upper parameter is a non-positive integer −n; the parent's binomial Vandermonde is the integer specialization.",
+      "The index-dependent summand (−1)ⁱ(b)ᵢ·(c+i)_{n−i} hides a falling-factorial structure with an index-INDEPENDENT base: via (z)_m=(z+m−1)^{≤m} and (−1)ⁱ(b)ᵢ=(−b)^{≤i} it becomes (−b)^{≤i}·(c+n−1)^{≤(n−i)}, so the alternating sum is an ordinary Vandermonde convolution at α=−b, β=c+n−1.",
+      "Stating the identity in denominator-cleared form removes ALL hypotheses (no positivity/division/convergence), giving a polynomial identity over an arbitrary commutative ring; the classical quotient form is recovered over a field.",
+      "For the quotient form only (c)_n ≠ 0 is needed (not (c)ₖ ≠ 0 for each k), because the multiplicative split (c)_n = (c)ₖ·(c+k)_{n−k} exhibits each (c)ₖ as a factor of the nonzero (c)_n.",
+      "Mathlib has the analytic ₂F₁ object but no closed-form evaluation of it at any point; this entry supplies the cornerstone terminating case."
+    ],
+    "builtItems": [
+      "gauss_terminating_ring (CombinationsFormulaOQ01OQ02.lean:150): ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ (c+i)ⱼ = (c−b)_n over any CommRing",
+      "gauss_terminating_field (CombinationsFormulaOQ01OQ02.lean:184): ∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ/(c)ᵢ = (c−b)_n/(c)_n over a field, hypothesis (c)_n ≠ 0",
+      "ascPochhammer_eval_vandermonde (CombinationsFormulaOQ01OQ02.lean:116): rising Chu-Vandermonde (x+y)_n = ∑_{i+j=n} C(n,i)(x)ᵢ(y)ⱼ over a CommRing",
+      "descPochhammer_eval_vandermonde (CombinationsFormulaOQ01OQ02.lean:65): falling Vandermonde convolution over a CommRing (antidiagonal induction)",
+      "ascPochhammer_eval_eq_descPochhammer' (line 91), neg_one_pow_mul_ascPochhammer_eval (line 99), ascPochhammer_eval_split (line 170): the bridge lemmas"
+    ],
+    "mathlibGaps": [
+      "Mathlib's ordinaryHypergeometric (₂F₁) has no summation theorem — no closed form for the value of ₂F₁ at any point (e.g. z=1).",
+      "No ascending-Pochhammer Vandermonde convolution in clean .eval form over a general commutative ring (only the descending smeval version descPochhammer_smeval_add)."
+    ],
+    "nextSteps": [
+      "Connect to Mathlib's analytic ordinaryHypergeometric by showing that, for a non-positive integer upper parameter, the series sum equals this finite Chu-Vandermonde sum.",
+      "Prove the Pfaff-Saalschütz theorem (terminating balanced ₃F₂) by the same index-independent-base reduction.",
+      "Prove the q-analogue (terminating q-Chu-Vandermonde / q-Gauss) by an analogous antidiagonal induction with a q-Pochhammer symbol."
+    ],
+    "markdown": ""
+  },
+  "references": {
+    "papers": [
+      "C. F. Gauss, Disquisitiones generales circa seriem infinitam (1812)",
+      "Andrews, Askey, Roy, Special Functions (1999), Ch. 2-3 (Gauss summation, Chu-Vandermonde)"
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/CombinationsFormulaOQ01OQ02.lean",
+      "filename": "CombinationsFormulaOQ01OQ02.lean",
+      "lineCount": 203,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ01OQ02.lean"
+    }
+  ],
+  "relatedProofs": [
+    "combinations-formula-oq-01",
+    "combinations-formula-oq-01-oq-04",
+    "arithmetic-series-oq-02-oq-01-oq-01-oq-03"
+  ],
+  "tags": [
+    "combinatorics",
+    "hypergeometric",
+    "gauss-2f1",
+    "chu-vandermonde",
+    "pochhammer",
+    "special-functions"
+  ]
+}


### PR DESCRIPTION
## Summary

Lifts the parent entry's natural-number **Vandermonde convolution** `C(m+n,r) = ∑ C(m,k)C(n,r−k)` to the **Gauss hypergeometric series ₂F₁**, of which Vandermonde is the terminating special case.

Mathlib already provides the analytic `ordinaryHypergeometric` (notation `₂F₁`) and a Pochhammer Vandermonde convolution (`descPochhammer_smeval_add`), but **no summation theorem** — no closed form for the value of `₂F₁` at any point. This entry supplies the cornerstone such result: **Gauss's terminating / second theorem**

  `₂F₁(−n, b; c; 1) = (c − b)_n / (c)_n`.

## Results (7 theorems, 203 lines, verified / 0-axiom / 0-sorry)

- **`gauss_terminating_ring`** — the headline, denominator-cleared and valid over an **arbitrary commutative ring** (no positivity/division/convergence hypotheses):
  `∑_{i+j=n} (−1)ⁱ C(n,i) · (b)ᵢ · (c+i)ⱼ = (c − b)_n`.
- **`gauss_terminating_field`** — the classical quotient form over a field, `∑_{i+j=n} (−1)ⁱ C(n,i) (b)ᵢ/(c)ᵢ = (c−b)_n/(c)_n`, under the single hypothesis `(c)_n ≠ 0`.
- **`ascPochhammer_eval_vandermonde`** / **`descPochhammer_eval_vandermonde`** — rising & falling Vandermonde convolutions in `.eval` form over a commutative ring (the rising form generalizes the parent's binomial convolution).
- Bridge lemmas (`ascPochhammer_eval_eq_descPochhammer'`, `neg_one_pow_mul_ascPochhammer_eval`, `ascPochhammer_eval_split`).

## Method

Because `(z)_m = (z+m−1)^{≤m}` and `(−1)ⁱ(b)ᵢ = (−b)^{≤i}`, each summand of the alternating sum collapses to a *falling* factorial with **index-independent base**: `(−1)ⁱ(b)ᵢ·(c+i)_{n−i} = (−b)^{≤i}·(c+n−1)^{≤(n−i)}`. So the whole sum is the falling Vandermonde convolution at `α = −b`, `β = c+n−1`, whose value is `(c−b)_n`. The quotient form follows by clearing `(c)_n` via `(c)_n = (c)ᵢ·(c+i)_{n−i}`. No generating-function or analytic machinery.

## Verification

`#print axioms` on all main results lists only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`). Status **verified**, badge **original**, axiomCount **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)