### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-04-oq-03): signVariations invariant under order embeddings; constructive Descartes bound upgraded from rational to real roots [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -982,6 +982,7 @@ import Proofs.DescartesRuleOfSigns
 import Proofs.DescartesRuleOfSignsOQ01
 import Proofs.DescartesRuleOfSignsOQ01OQ01
 import Proofs.DescartesRuleOfSignsOQ01OQ02
+import Proofs.DescartesRuleOfSignsOQ01OQ04OQ03
 import Proofs.DescartesRuleOfSignsOQ02
 import Proofs.DescartesRuleOfSignsOQ02OQ03
 import Proofs.DescartesRuleOfSignsOQ02OQ04

--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean
@@ -1,0 +1,202 @@
+import Mathlib
+
+/-
+# Sign Variations over an Arbitrary Ordered Field, and Invariance under Order Embeddings
+
+*Open question from `DescartesRuleOfSignsOQ01OQ04`* (the constructive sign-variation count):
+the parent built a **computable** `signVarList : List ℚ → ℕ` mirroring Mathlib's abstract
+`Polynomial.signVariations`, certified by the definitional bridge
+`signVarList P.coeffList = P.signVariations`, and used it to bound the *rational* positive-root
+count of `P : ℚ[X]`.  Two things were left hanging:
+
+1. **The coefficient field was pinned to `ℚ`.**  Nothing in the construction is special to `ℚ`;
+   it works verbatim over any `LinearOrderedField` whose order is decidable (`ℚ`, the computable
+   algebraic reals, …).  The point of `ℚ` was only that its order instances actually *reduce* in
+   the kernel.  We generalise the definition and the `rfl` bridge to an arbitrary ordered field.
+
+2. **The bound was only about *rational* roots.**  For `P : ℚ[X]`, `P.roots` lives in `ℚ`, so the
+   parent's `posRoots_le_signVarList` bounds the *rational* positive roots — a strictly weaker
+   statement than Descartes' rule, which is about *real* roots.  (Indeed the count is genuinely
+   ℝ-valued: `X² − 2` has one sign variation but **zero** rational positive roots.)  To connect the
+   computable ℚ-side count to the real-root content of Descartes one needs to know that passing
+   `ℚ ↪ ℝ` does **not** change the sign-variation count.
+
+The hinge for (2) — and the genuinely new piece of infrastructure here — is:
+
+      **`signVariations` is invariant under any strictly monotone ring homomorphism**
+      (`signVariations_map`): for `φ : F →+* K` with `StrictMono φ`,
+      `(P.map φ).signVariations = P.signVariations`.
+
+This is not in Mathlib.  It holds because the sign-variation count reads only the *signs* of the
+coefficient list, and a strictly monotone ring hom preserves signs (`sign (φ x) = sign x`) and,
+being injective, preserves the coefficient list up to the pointwise application of `φ`.
+
+## Results
+
+* `signVarList` — the computable count generalised to any `[Field F] [LinearOrder F]
+  [IsStrictOrderedRing F]`; reduces in the kernel exactly when `F`'s order instances are computable.
+* `signVarList_coeffList` — the bridge `signVarList P.coeffList = P.signVariations`, still by `rfl`.
+* `coeffList_map_of_injective` — `(P.map φ).coeffList = P.coeffList.map φ` for injective `φ`.
+* `sign_map_of_strictMono` — `sign (φ x) = sign x` for a strictly monotone ring hom.
+* `signVariations_map` — **the headline**: invariance of `signVariations` under `StrictMono` ring
+  homs.
+* `signVarList_eq_signVariations_ratCast` — the `ℚ → ℝ` bridge: the computable ℚ-coefficient count
+  equals the sign-variation count of the *real* polynomial.
+* `realRoots_countP_pos_le_signVarList` — Descartes' bound for **real** positive roots, computed
+  from the rational coefficient list (the honest Descartes statement, now on the computable side).
+
+Fully verified: 0 sorries, 0 `axiom`s, no `native_decide` (worked examples use `decide`).
+-/
+
+namespace DescartesConstructiveGeneral
+
+open Polynomial
+
+-- Several lemmas below are stated in the ordered-field context for uniformity but are genuinely
+-- more general (they need only injectivity/strict-monotonicity, not strict ordering); silence the
+-- resulting "unused section variable" lint.
+set_option linter.unusedSectionVars false
+
+/-! ## Part I: the computable count over an arbitrary ordered field
+
+`signVariations` is defined in Mathlib for any `[Semiring R] [LinearOrder R]`, and the sign map it
+uses is computable whenever the order on `R` is decidable.  A `LinearOrderedField` (now spelled
+`[Field F] [LinearOrder F] [IsStrictOrderedRing F]`) supplies exactly that, so the parent's
+`ℚ`-specific construction lifts unchanged. -/
+
+variable {F : Type*} [Field F] [LinearOrder F] [IsStrictOrderedRing F]
+
+/-- The **computable sign-variation count** on a list of coefficients (leading term first), now
+over an arbitrary ordered field `F`.  Every operation — `SignType.sign`, the `· ≠ 0` filter, and
+`List.destutter (· ≠ ·)` — is decidable, so the whole function reduces in the kernel precisely when
+`F`'s order instances are computable (`ℚ`, computable algebraic reals, …).  This is the verbatim
+generalisation of the parent's `ℚ`-only definition. -/
+def signVarList (l : List F) : ℕ :=
+  (((l.map SignType.sign).filter (· ≠ 0)).destutter (· ≠ ·)).length - 1
+
+/-- **The bridge, still by `rfl`.**  Feeding `signVarList` the coefficient list of a polynomial
+recovers Mathlib's abstract `signVariations` — definitionally, over *any* ordered field, exactly as
+in the `ℚ` case. -/
+theorem signVarList_coeffList (P : F[X]) :
+    signVarList P.coeffList = P.signVariations := rfl
+
+/-- **Descartes' bound, computable form (rational/own-field roots).**  The number of positive roots
+of `P` *that lie in `F`* is at most the computable sign-variation count of its coefficient list. -/
+theorem posRoots_le_signVarList (P : F[X]) :
+    P.roots.countP (0 < ·) ≤ signVarList P.coeffList := by
+  rw [signVarList_coeffList]
+  exact P.roots_countP_pos_le_signVariations
+
+/-- A decidable, sound certificate of "no positive roots in `F`". -/
+theorem no_pos_roots_of_signVarList_zero (P : F[X]) (h : signVarList P.coeffList = 0) :
+    P.roots.countP (0 < ·) = 0 :=
+  Nat.le_zero.mp (h ▸ posRoots_le_signVarList P)
+
+/-! ## Part II: invariance under a strictly monotone ring homomorphism
+
+This is the new infrastructure.  A strictly monotone ring hom `φ : F →+* K` is injective, hence
+preserves the coefficient list (up to applying `φ` pointwise), and it preserves signs, hence the
+sign-variation count is unchanged. -/
+
+section Map
+
+variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K]
+
+/-- The coefficient list commutes with an **injective** ring hom: mapping the polynomial and then
+listing coefficients is the same as listing coefficients and then mapping the entries.  Injectivity
+is what keeps the degree (hence the list length) fixed. -/
+theorem coeffList_map_of_injective (φ : F →+* K) (hφ : Function.Injective φ) (P : F[X]) :
+    (P.map φ).coeffList = P.coeffList.map φ := by
+  simp only [Polynomial.coeffList, Polynomial.degree_map_eq_of_injective hφ, List.map_map]
+  exact List.map_congr_left fun i _ => Polynomial.coeff_map φ i
+
+/-- **A strictly monotone ring hom preserves signs.**  `sign (φ x) = sign x`, by trichotomy on `x`:
+`φ` fixes `0` and is order-preserving, so it sends positives to positives and negatives to
+negatives. -/
+theorem sign_map_of_strictMono (φ : F →+* K) (hφ : StrictMono φ) (x : F) :
+    SignType.sign (φ x) = SignType.sign x := by
+  rcases lt_trichotomy x 0 with hlt | heq | hgt
+  · rw [sign_neg hlt, sign_neg]
+    simpa only [map_zero] using hφ hlt
+  · subst heq; rw [map_zero, sign_zero, sign_zero]
+  · rw [sign_pos hgt, sign_pos]
+    simpa only [map_zero] using hφ hgt
+
+/-- **Headline: `signVariations` is invariant under a strictly monotone ring homomorphism.**
+Mapping the coefficients of `P` through an order-embedding `φ : F →+* K` changes neither the
+coefficient list's signs (`sign_map_of_strictMono`) nor its length (`φ` injective), so the number of
+sign changes is identical:
+
+      `(P.map φ).signVariations = P.signVariations`.
+
+In particular the sign-variation count is intrinsic to the *ordered-field-agnostic* sign data of the
+coefficients, not to the field they live in. -/
+theorem signVariations_map (φ : F →+* K) (hφ : StrictMono φ) (P : F[X]) :
+    (P.map φ).signVariations = P.signVariations := by
+  have key : ((P.map φ).coeffList).map SignType.sign = P.coeffList.map SignType.sign := by
+    rw [coeffList_map_of_injective φ hφ.injective, List.map_map]
+    exact List.map_congr_left fun x _ => sign_map_of_strictMono φ hφ x
+  unfold Polynomial.signVariations
+  rw [key]
+
+end Map
+
+/-! ## Part III: the `ℚ → ℝ` bridge — the computable count sees the *real* roots
+
+The parent could only bound the *rational* roots of `P : ℚ[X]`.  Combining the field-genericity of
+Part I with the map-invariance of Part II, the computable ℚ-coefficient count equals the
+sign-variation count of the corresponding *real* polynomial, and therefore bounds the count of
+positive *real* roots — which is the actual content of Descartes' rule. -/
+
+/-- `ℚ → ℝ` is a strictly monotone ring homomorphism (it *is* the rational cast). -/
+private theorem strictMono_algebraMap_rat_real :
+    StrictMono (algebraMap ℚ ℝ) := by
+  intro a b h
+  simp only [eq_ratCast]
+  exact_mod_cast h
+
+/-- **The bridge.**  For a rational polynomial, the *computable* sign-variation count of its
+coefficient list equals the sign-variation count of the polynomial pushed forward to `ℝ`.  This is
+the precise sense in which the kernel-reducible ℚ-side count "sees" the real polynomial. -/
+theorem signVarList_eq_signVariations_ratCast (P : ℚ[X]) :
+    signVarList P.coeffList = (P.map (algebraMap ℚ ℝ)).signVariations := by
+  rw [signVarList_coeffList, signVariations_map (algebraMap ℚ ℝ) strictMono_algebraMap_rat_real P]
+
+/-- **Descartes' bound for *real* positive roots, computed from rational coefficients.**  The number
+of positive *real* roots of `P : ℚ[X]` (i.e. of its image in `ℝ[X]`) is at most the computable
+sign-variation count of its rational coefficient list.  Unlike the parent's `posRoots_le_signVarList`
+— which only bounded the *rational* positive roots — this is the genuine Descartes statement on the
+constructive side. -/
+theorem realRoots_countP_pos_le_signVarList (P : ℚ[X]) :
+    (P.map (algebraMap ℚ ℝ)).roots.countP (0 < ·) ≤ signVarList P.coeffList := by
+  rw [signVarList_eq_signVariations_ratCast]
+  exact (P.map (algebraMap ℚ ℝ)).roots_countP_pos_le_signVariations
+
+/-! ## Part IV: worked computable examples
+
+`signVarList` over `ℚ` reduces in the kernel, so these are discharged by `decide` (no
+`native_decide`, hence no extra axioms).  They recover the parent's `ℚ`-specific examples as
+instances of the now field-generic definition. -/
+
+/-- `x³ - x² - x + 1`: coefficients `[1,-1,-1,1]`, two sign changes. -/
+example : signVarList ([1, -1, -1, 1] : List ℚ) = 2 := by decide
+
+/-- `x² + 3x + 2`: no sign changes — the no-positive-roots certificate fires. -/
+example : signVarList ([1, 3, 2] : List ℚ) = 0 := by decide
+
+/-- `x² - 1`: one sign change (interior structure irrelevant). -/
+example : signVarList ([1, 0, -1] : List ℚ) = 1 := by decide
+
+/-- Fully alternating `+ - + -`: three sign changes. -/
+example : signVarList ([1, -2, 3, -4] : List ℚ) = 3 := by decide
+
+/-- Interior zeros are ignored: `[2, 0, -3, 0, 1]` reduces to signs `+ - +`, two sign changes. -/
+example : signVarList ([2, 0, -3, 0, 1] : List ℚ) = 2 := by decide
+
+end DescartesConstructiveGeneral
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms DescartesConstructiveGeneral.signVariations_map
+#print axioms DescartesConstructiveGeneral.signVarList_eq_signVariations_ratCast
+#print axioms DescartesConstructiveGeneral.realRoots_countP_pos_le_signVarList

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-drs-oq010403-header",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 3, "endLine": 49 },
+    "type": "concept",
+    "title": "Module Header: Two Loose Threads and the Hinge",
+    "content": "The parent built a computable signVarList : List ℚ → ℕ certified by rfl against Mathlib's Polynomial.signVariations. It left two threads. (1) The coefficient field was pinned to ℚ, though nothing in the construction needs more than a decidable order. (2) For P : ℚ[X], the multiset P.roots lives in ℚ, so the parent's bound only constrained the RATIONAL positive roots — strictly weaker than Descartes' Rule, which is about REAL roots. The example X² − 2 makes the gap concrete: one sign variation, but zero rational positive roots (its positive root √2 is irrational). The hinge that closes both threads is a single fact, absent from Mathlib: signVariations is invariant under any strictly monotone ring homomorphism.",
+    "mathContext": "Descartes' Rule: positiveRealRoots ≤ signVariations. The left side counts roots in ℝ; a faithful constructive version must therefore reach ℝ, not stop at the coefficient field.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructive mathematics", "ordered fields", "order embeddings", "real vs rational roots"],
+    "prerequisites": ["Polynomial.signVariations", "Polynomial.roots over a field"]
+  },
+  {
+    "id": "ann-drs-oq010403-generic",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 74, "endLine": 98 },
+    "type": "definition",
+    "title": "signVarList over an Arbitrary Ordered Field",
+    "content": "signVarList (l : List F) : ℕ := (((l.map SignType.sign).filter (· ≠ 0)).destutter (· ≠ ·)).length - 1, now stated for any [Field F] [LinearOrder F] [IsStrictOrderedRing F] (the modern spelling of LinearOrderedField). The bridge signVarList_coeffList still holds by rfl, because Mathlib's signVariations is itself defined at the generality [Semiring R] [LinearOrder R] — feeding it the coefficient list is definitionally the list function. The transported bound posRoots_le_signVarList and the certificate no_pos_roots_of_signVarList_zero come along unchanged.",
+    "mathContext": "Computability is not part of the type signature: signVarList type-checks over any ordered field, and reduces in the kernel exactly when F's order instances are computable — true for ℚ and computable algebraic reals, false for ℝ with its classical instances.",
+    "significance": "central",
+    "relatedConcepts": ["LinearOrderedField", "decidable order", "SignType.sign", "List.destutter"],
+    "prerequisites": ["typeclass generalization", "Polynomial.signVariations"]
+  },
+  {
+    "id": "ann-drs-oq010403-coefflist-map",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 108, "endLine": 114 },
+    "type": "technique",
+    "title": "The Coefficient List Commutes with an Injective Hom",
+    "content": "coeffList_map_of_injective: (P.map φ).coeffList = P.coeffList.map φ for injective φ. coeffList is (List.range degree.succ).reverse.map coeff; an injective ring hom preserves the degree (degree_map_eq_of_injective), so the list keeps its length, and coeff_map gives (P.map φ).coeff i = φ (P.coeff i) entrywise. The proof is a simp with those two facts plus List.map_map, closed by List.map_congr_left.",
+    "mathContext": "Injectivity is essential: a non-injective hom could collapse the leading coefficient to 0 and shorten the list, changing the count.",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial.coeffList", "degree_map_eq_of_injective", "coeff_map", "List.map_congr_left"],
+    "prerequisites": ["Polynomial.map", "injective ring homomorphisms"]
+  },
+  {
+    "id": "ann-drs-oq010403-sign-map",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 116, "endLine": 132 },
+    "type": "technique",
+    "title": "Strictly Monotone Ring Homs Preserve Sign",
+    "content": "sign_map_of_strictMono: SignType.sign (φ x) = SignType.sign x for a StrictMono ring hom φ. By trichotomy on x relative to 0: if x = 0 then φ 0 = 0 (map_zero) and both signs are 0; if 0 < x then 0 = φ 0 < φ x by strict monotonicity, so sign (φ x) = 1 = sign x (sign_pos); symmetrically for x < 0 (sign_neg). The only inputs are map_zero and the order-preservation of φ.",
+    "mathContext": "This is the precise reason the sign-variation count is a field-agnostic invariant: it depends on coefficients only through their three-valued signs, which an order embedding fixes.",
+    "significance": "central",
+    "relatedConcepts": ["SignType.sign", "sign_pos", "sign_neg", "StrictMono", "trichotomy"],
+    "prerequisites": ["lt_trichotomy", "map_zero"]
+  },
+  {
+    "id": "ann-drs-oq010403-signvariations-map",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 134, "endLine": 141 },
+    "type": "key-step",
+    "title": "Headline: Invariance of signVariations under StrictMono Ring Homs",
+    "content": "signVariations_map: (P.map φ).signVariations = P.signVariations for any StrictMono ring hom φ. The proof shows the two map-sign lists coincide — ((P.map φ).coeffList).map sign = P.coeffList.map sign — by combining coeffList_map_of_injective (φ injective from strict mono) with sign_map_of_strictMono entrywise (List.map_congr_left). Unfolding signVariations and rewriting that subterm makes both sides identical. This theorem is not in Mathlib.",
+    "mathContext": "It says the sign-variation count is intrinsic to the ordered-field-agnostic sign data of the coefficients. It is the lemma that lets a computable subfield certify facts about a larger ordered field.",
+    "significance": "central",
+    "relatedConcepts": ["signVariations", "order embedding", "polynomial map", "invariant"],
+    "prerequisites": ["coeffList_map_of_injective", "sign_map_of_strictMono", "List.map_congr_left"]
+  },
+  {
+    "id": "ann-drs-oq010403-bridge",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 152, "endLine": 178 },
+    "type": "key-step",
+    "title": "The ℚ → ℝ Bridge and the Real-Root Bound",
+    "content": "Specializing φ = algebraMap ℚ ℝ (strictly monotone, since it is the rational cast Rat.cast_strictMono) gives signVarList_eq_signVariations_ratCast: the computable ℚ-coefficient count equals the sign-variation count of the polynomial pushed forward to ℝ. From it, realRoots_countP_pos_le_signVarList bounds the number of positive REAL roots of P : ℚ[X] by its computable rational coefficient count — the genuine Descartes statement, where the parent could only bound rational roots.",
+    "mathContext": "X² − 2 : ℚ[X] has signVarList = 1 and zero rational positive roots, but exactly one positive REAL root (√2); the real bound is the one that captures it.",
+    "significance": "central",
+    "relatedConcepts": ["algebraMap ℚ ℝ", "Rat.cast_strictMono", "positive real roots", "Descartes bound"],
+    "prerequisites": ["signVariations_map", "roots_countP_pos_le_signVariations", "eq_ratCast"]
+  },
+  {
+    "id": "ann-drs-oq010403-examples",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+    "range": { "startLine": 182, "endLine": 195 },
+    "type": "concept",
+    "title": "ℚ Examples as Instances of the Generic Definition",
+    "content": "The parent's ℚ-specific worked examples reappear as instances of the now field-generic signVarList, each discharged by kernel decide (not native_decide, so no Lean.ofReduceBool): [1,-1,-1,1]→2, [1,3,2]→0, [1,0,-1]→1, [1,-2,3,-4]→3, and [2,0,-3,0,1]→2 (interior zeros ignored).",
+    "mathContext": "decide reduces because ℚ's order instances are computable; the same theorems hold abstractly over any ordered field, but only computable fields admit decide.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide", "kernel reduction", "SignType.sign on ℚ"],
+    "prerequisites": ["decidable order on ℚ"]
+  }
+]

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/meta.json
@@ -1,0 +1,142 @@
+{
+  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+  "id": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+  "title": "Sign Variations over an Arbitrary Ordered Field, Invariant under Order Embeddings",
+  "description": "Answers the parent's open question: generalize the computable sign-variation count signVarList from ℚ to any LinearOrderedField with decidable order (ℚ, computable algebraic reals, …), keeping the rfl bridge to Mathlib's abstract signVariations. The substantive new infrastructure is a theorem absent from Mathlib — signVariations is invariant under any strictly monotone ring homomorphism (signVariations_map) — because the count reads only the signs of the coefficient list, and a strict-mono ring hom preserves both signs and (being injective) the list length. As payoff this bridges ℚ to ℝ: the kernel-reducible ℚ-coefficient count equals the sign-variation count of the real polynomial, so it bounds the number of positive REAL roots (the genuine Descartes statement), not merely the rational ones the parent could reach.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "Descartes rule",
+      "constructive",
+      "computability",
+      "ordered fields",
+      "ring homomorphisms"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 202,
+    "assumptions": "None. All results proved from Mathlib. The worked examples are discharged by kernel `decide` (not `native_decide`), so the only axioms are the foundational propext / Classical.choice / Quot.sound (confirmed by #print axioms on signVariations_map, signVarList_eq_signVariations_ratCast, realRoots_countP_pos_le_signVarList).",
+    "theoremCount": 8,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.signVariations",
+        "description": "The abstract sign-variation count, defined for any [Semiring R] [LinearOrder R]; the generalized signVarList mirrors it over an arbitrary ordered field"
+      },
+      {
+        "theorem": "Polynomial.coeffList",
+        "description": "The coefficient list; coeffList_map_of_injective shows it commutes with an injective ring hom (degree preserved, entries mapped pointwise)"
+      },
+      {
+        "theorem": "Polynomial.degree_map_eq_of_injective",
+        "description": "Injective ring homs preserve degree — the reason the coefficient list keeps its length under map"
+      },
+      {
+        "theorem": "Polynomial.coeff_map",
+        "description": "coeff (P.map f) n = f (P.coeff n); the pointwise action of the hom on coefficients"
+      },
+      {
+        "theorem": "SignType.sign",
+        "description": "The three-valued sign map; sign_map_of_strictMono proves it is preserved by a strictly monotone ring hom (sign (φ x) = sign x)"
+      },
+      {
+        "theorem": "Polynomial.roots_countP_pos_le_signVariations",
+        "description": "Mathlib's Descartes upper bound; combined with the ℚ→ℝ bridge it yields a bound on positive REAL roots computed from rational coefficients"
+      },
+      {
+        "theorem": "Rat.cast_strictMono",
+        "description": "ℚ → ℝ is strictly monotone — the instance of an order embedding used in the bridge"
+      }
+    ],
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DescartesConstructiveGeneral",
+    "lineCount": 202,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "problemStatement": "Can the constructive sign-variation count signVarList be generalized from ℚ to an arbitrary computable LinearOrderedField while keeping the rfl bridge to the abstract count — and does the resulting count actually see the real-root behaviour Descartes' Rule is about, rather than just the roots living in the coefficient field?",
+    "historicalContext": "Descartes' Rule (La Géométrie, 1637) bounds the number of positive REAL roots of a polynomial by the number of sign changes in its coefficient sequence. The parent file built a computable mirror signVarList : List ℚ → ℕ of Mathlib's noncomputable Polynomial.signVariations and certified it by rfl. But it left two threads: the construction was pinned to ℚ, and — more subtly — for P : ℚ[X] the multiset P.roots lives in ℚ, so the parent's bound only constrained the RATIONAL positive roots. That is strictly weaker than Descartes' Rule: X² − 2 has one sign variation but no rational positive root at all (its positive root √2 is irrational). To recover the genuine statement one must transport the count along ℚ ↪ ℝ, which requires knowing the count is invariant under that embedding.",
+    "keyInsights": [
+      "Nothing in signVarList is special to ℚ. Polynomial.signVariations is defined for any [Semiring R] [LinearOrder R], and the sign map is computable whenever the order is decidable. A LinearOrderedField (now spelled [Field F] [LinearOrder F] [IsStrictOrderedRing F]) supplies exactly this, so the definition and the rfl bridge signVarList P.coeffList = P.signVariations lift verbatim.",
+      "The sign-variation count reads only the SIGNS of the coefficient list. So it should be unchanged by any map that preserves signs and the list length — namely a strictly monotone (hence injective) ring homomorphism. This is the conceptual core.",
+      "signVariations_map: (P.map φ).signVariations = P.signVariations for any StrictMono ring hom φ. Proof = coeffList_map_of_injective (the list commutes with φ) + sign_map_of_strictMono (φ preserves signs) ⟹ the map-sign lists coincide ⟹ everything downstream is identical. This invariance theorem is not in Mathlib.",
+      "The count is genuinely ℝ-valued, not ℚ-valued: the bridge signVarList P.coeffList = (P.map (algebraMap ℚ ℝ)).signVariations shows the kernel-reducible rational count equals the count of the real polynomial. Hence realRoots_countP_pos_le_signVarList bounds the positive REAL roots — the actual content of Descartes — using only the rational coefficient list.",
+      "Computability is a property of the field's instances, not of the abstract definition: signVarList : List F → ℕ type-checks for any ordered field, and reduces in the kernel exactly when F's order is computable (true for ℚ; false for ℝ with its classical instances)."
+    ],
+    "proofStrategy": "(1) Re-state signVarList and the rfl bridge over a generic [Field F] [LinearOrder F] [IsStrictOrderedRing F]; transport Mathlib's bound and the no-positive-roots certificate. (2) Prove coeffList_map_of_injective via degree_map_eq_of_injective + coeff_map + List.map_congr_left. (3) Prove sign_map_of_strictMono by trichotomy on x using sign_pos/sign_neg/sign_zero and map_zero. (4) Combine into signVariations_map by rewriting the map-sign list. (5) Specialize φ = algebraMap ℚ ℝ (strictly monotone via Rat.cast_strictMono) to get the ℚ→ℝ bridge and the real-root bound. (6) Recover the parent's ℚ examples as instances of the generic definition, by kernel decide.",
+    "prerequisites": [
+      "Polynomial.signVariations and its pipeline (coeffList, SignType.sign, List.filter, List.destutter)",
+      "Polynomial.degree_map_eq_of_injective and Polynomial.coeff_map",
+      "SignType.sign and the lemmas sign_pos / sign_neg / sign_zero",
+      "Rat.cast_strictMono and eq_ratCast (algebraMap ℚ ℝ is the rational cast)",
+      "Polynomial.roots_countP_pos_le_signVariations (Mathlib's Descartes bound)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module: Genericity and Map-Invariance",
+      "summary": "Frames the two loose threads of the parent — the ℚ-pinned coefficient field and the merely-rational root bound — and states the hinge result: signVariations is invariant under strictly monotone ring homs."
+    },
+    {
+      "id": "generic-count",
+      "title": "Part I: The Computable Count over an Arbitrary Ordered Field",
+      "summary": "signVarList : List F → ℕ for [Field F] [LinearOrder F] [IsStrictOrderedRing F], the rfl bridge signVarList_coeffList, the transported bound posRoots_le_signVarList, and the no-positive-roots certificate — all field-generic."
+    },
+    {
+      "id": "map-invariance",
+      "title": "Part II: Invariance under a Strictly Monotone Ring Homomorphism",
+      "summary": "coeffList_map_of_injective (the coefficient list commutes with an injective hom), sign_map_of_strictMono (signs are preserved), and the headline signVariations_map combining them: (P.map φ).signVariations = P.signVariations."
+    },
+    {
+      "id": "rat-real-bridge",
+      "title": "Part III: The ℚ → ℝ Bridge — Seeing the Real Roots",
+      "summary": "signVarList_eq_signVariations_ratCast: the computable ℚ count equals the real polynomial's sign-variation count. realRoots_countP_pos_le_signVarList: Descartes' bound for positive REAL roots, computed from rational coefficients."
+    },
+    {
+      "id": "worked-examples",
+      "title": "Part IV: Worked Computable Examples",
+      "summary": "The parent's ℚ examples recovered as instances of the now field-generic definition, discharged by kernel decide (no native_decide)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "descartes-rule-of-signs-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "Answers the parent's third open question: generalize signVarList from ℚ to an arbitrary computable LinearOrderedField while keeping the rfl bridge — and additionally upgrades the bound from rational to real roots via map-invariance."
+    },
+    {
+      "targetId": "descartes-rule-of-signs-oq-01",
+      "relationship": "foundational",
+      "description": "Supplies the ℝ-side Descartes bound and parity infrastructure that motivate connecting the computable count to real roots."
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "foundational",
+      "description": "The classical Descartes rule of signs — root of the OQ chain studied here."
+    }
+  ],
+  "conclusion": {
+    "summary": "YES: the computable sign-variation count generalizes verbatim to any ordered field with decidable order, with the rfl bridge intact, because Mathlib's signVariations already lives at that generality and the count is purely combinatorial on signs. The substantive new result is that signVariations is invariant under any strictly monotone ring homomorphism (signVariations_map) — a fact not in Mathlib. Specializing to ℚ ↪ ℝ shows the kernel-reducible rational count equals the real polynomial's count, so it bounds the positive REAL roots, repairing the gap left by the parent (whose bound only constrained rational roots). All with 0 axioms; examples by kernel decide.",
+    "implications": "Map-invariance of signVariations is reusable infrastructure: it lets any computable subfield (ℚ, computable algebraic reals) certify sign-variation facts about polynomials over a larger ordered field by pushing forward along an order embedding. It is also exactly the lemma needed to make the constructive Descartes bound a statement about real roots rather than coefficient-field roots. The trichotomy proof that a strict-mono ring hom preserves SignType.sign is a small lemma of independent use for any sign-driven polynomial invariant.",
+    "openQuestions": [
+      "Can map-invariance be strengthened to an order-reflecting equivalence, characterizing exactly which (not-necessarily-injective) ring homs preserve signVariations?",
+      "Combined with a formalization of Sturm's theorem over ℚ, does the real-root bound realRoots_countP_pos_le_signVarList upgrade to an exact computable count of positive real roots?"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04-oq-03.json
@@ -1,0 +1,256 @@
+{
+  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-03",
+  "title": "signVarList over an arbitrary computable LinearOrderedField (keeping the rfl bridge)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Generalize } \\mathrm{signVarList} \\text{ from } \\mathbb{Q} \\text{ to any computable } \\mathrm{LinearOrderedField}\\ K,",
+    "plain": "The parent built a constructive, computable count of sign variations of a coefficient list over the rationals, with a definitional bridge (provable by rfl) to the abstract sign-variation count used in Descartes' rule. This problem asks whether the same construction works over an arbitrary computable linearly ordered field — for instance the computable algebraic reals — rather than being tied to the rationals, while keeping the rfl bridge intact.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-24T23:20:00-07:00",
+    "iteration": 2,
+    "focus": "Solved: generalized signVarList to any ordered field; proved signVariations map-invariance under strict-mono ring homs; bridged Q to R.",
+    "blockers": [],
+    "nextAction": "Complete - PR opened.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: signVarList generalized to [Field F][LinearOrder F][IsStrictOrderedRing F] with rfl bridge intact; new theorem signVariations_map (invariance under StrictMono ring homs, not in Mathlib); Q->R bridge upgrades the constructive Descartes bound from rational to REAL positive roots. Verified, 0 axioms.",
+    "builtItems": [
+      "DescartesConstructiveGeneral.signVarList : List F -> N generalized to arbitrary ordered field (Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean:74)",
+      "signVarList_coeffList - rfl bridge preserved over any ordered field (line 80)",
+      "coeffList_map_of_injective - (P.map phi).coeffList = P.coeffList.map phi for injective phi (line 108)",
+      "sign_map_of_strictMono - sign (phi x) = sign x for StrictMono ring hom (line 116)",
+      "signVariations_map - HEADLINE: (P.map phi).signVariations = P.signVariations for StrictMono ring hom; not in Mathlib (line 134)",
+      "signVarList_eq_signVariations_ratCast - computable Q count = sign variations of the real polynomial (line 161)",
+      "realRoots_countP_pos_le_signVarList - Descartes bound for positive REAL roots from rational coefficients (line 170)"
+    ],
+    "insights": [
+      "Mathlib signVariations is already defined for [Semiring R][LinearOrder R], so the Q-pinned parent generalizes verbatim; the rfl bridge survives because signVarList (coeffList P) is definitionally signVariations P.",
+      "The count reads only coefficient SIGNS, so it is invariant under any sign-preserving, length-preserving map - precisely a strictly monotone (hence injective) ring hom. This is the conceptual key (signVariations_map).",
+      "The parent bound was secretly only about RATIONAL roots (P.roots for P:Q[X] lives in Q). x^2-2 exposes the gap: signVarList=1 but zero rational positive roots. Map-invariance along Q->R repairs this to a bound on positive REAL roots.",
+      "LinearOrderedField is deprecated in Mathlib v4.26 -> use [Field F][LinearOrder F][IsStrictOrderedRing F]. Computability is a property of F's instances, not of the definition.",
+      "Q division literals like 3/2 do not reduce under kernel decide; use integer-coefficient lists for decide examples."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks invariance of Polynomial.signVariations under ring homomorphisms (provided here as signVariations_map).",
+      "Mathlib lacks coeffList_map (commutation of Polynomial.coeffList with an injective map); derived from degree_map_eq_of_injective + coeff_map."
+    ],
+    "nextSteps": [
+      "Combine realRoots_countP_pos_le_signVarList with a Q-Sturm formalization for an exact computable real-root count.",
+      "Characterize exactly which (non-injective) ring homs preserve signVariations."
+    ],
+    "markdown": "# Knowledge Base: descartes-rule-of-signs-oq-01-oq-04-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "polynomials",
+    "descartes-rule",
+    "sign-variations",
+    "computable",
+    "linear-ordered-field"
+  ],
+  "relatedProofs": [
+    "descartes-rule-of-signs",
+    "descartes-rule-of-signs-oq-01",
+    "descartes-rule-of-signs-oq-01-oq-01",
+    "descartes-rule-of-signs-oq-01-oq-01-oq-02",
+    "descartes-rule-of-signs-oq-01-oq-01-oq-03",
+    "descartes-rule-of-signs-oq-01-oq-02",
+    "descartes-rule-of-signs-oq-01-oq-04",
+    "descartes-rule-of-signs-oq-02",
+    "descartes-rule-of-signs-oq-02-oq-01",
+    "descartes-rule-of-signs-oq-02-oq-01-oq-02",
+    "descartes-rule-of-signs-oq-02-oq-03",
+    "descartes-rule-of-signs-oq-02-oq-04",
+    "descartes-rule-of-signs-oq-03",
+    "descartes-rule-of-signs-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T06:24:55.409Z",
+  "lastUpdate": "2026-06-25T06:24:55.449Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/DescartesRuleOfSigns.lean",
+      "filename": "DescartesRuleOfSigns.lean",
+      "lineCount": 577,
+      "theoremCount": 35,
+      "axiomCount": 8,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSigns.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
+      "filename": "DescartesRuleOfSignsOQ01.lean",
+      "lineCount": 1100,
+      "theoremCount": 31,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ01.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ01.lean",
+      "lineCount": 155,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ01OQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ01OQ02.lean",
+      "lineCount": 248,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ01OQ03.lean",
+      "lineCount": 148,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ02.lean",
+      "lineCount": 318,
+      "theoremCount": 13,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ04.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ04.lean",
+      "lineCount": 135,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ02.lean",
+      "lineCount": 699,
+      "theoremCount": 30,
+      "axiomCount": 3,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
+      "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
+      "lineCount": 258,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ02OQ01OQ02.lean",
+      "lineCount": 585,
+      "theoremCount": 29,
+      "axiomCount": 1,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02OQ03.lean",
+      "filename": "DescartesRuleOfSignsOQ02OQ03.lean",
+      "lineCount": 94,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02OQ04.lean",
+      "filename": "DescartesRuleOfSignsOQ02OQ04.lean",
+      "lineCount": 286,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02Parity.lean",
+      "filename": "DescartesRuleOfSignsOQ02Parity.lean",
+      "lineCount": 91,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02Parity.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ03.lean",
+      "filename": "DescartesRuleOfSignsOQ03.lean",
+      "lineCount": 441,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ03.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ04.lean",
+      "filename": "DescartesRuleOfSignsOQ04.lean",
+      "lineCount": 496,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ04.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `descartes-rule-of-signs-oq-01-oq-04` (the constructive computable sign-variation count): *generalize `signVarList` from ℚ to an arbitrary computable `LinearOrderedField`, keeping the `rfl` bridge*. Along the way it repairs a subtle gap in the parent.

- **Genericity.** `signVarList : List F → ℕ` now lives over any `[Field F] [LinearOrder F] [IsStrictOrderedRing F]` (the modern spelling of `LinearOrderedField`). The bridge `signVarList P.coeffList = P.signVariations` still holds **by `rfl`**, because Mathlib's `signVariations` is already defined at that generality. Computability is a property of `F`'s instances (true for ℚ and computable algebraic reals).

- **New infrastructure (not in Mathlib): `signVariations_map`.** For any strictly monotone ring hom `φ : F →+* K`,
  `(P.map φ).signVariations = P.signVariations`. The count reads only coefficient *signs*, and a strict-mono hom preserves both signs (`sign_map_of_strictMono`) and the list length (`coeffList_map_of_injective`, via `degree_map_eq_of_injective` + `coeff_map`).

- **ℚ → ℝ bridge — the payoff.** The parent's bound `posRoots_le_signVarList` was secretly only about *rational* roots (`P.roots` for `P : ℚ[X]` lives in ℚ). `X² − 2` exposes the gap: one sign variation, **zero** rational positive roots (its root √2 is irrational). Map-invariance along `ℚ ↪ ℝ` gives:
  - `signVarList_eq_signVariations_ratCast` — the computable ℚ count equals the **real** polynomial's count;
  - `realRoots_countP_pos_le_signVarList` — Descartes' bound for positive **real** roots, computed from the rational coefficient list. This is the genuine Descartes statement on the constructive side.

## Verification

- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- `#print axioms` on `signVariations_map`, `signVarList_eq_signVariations_ratCast`, `realRoots_countP_pos_le_signVarList` → `propext, Classical.choice, Quot.sound` only.
- Compiles against Mathlib v4.26.0 (host `lake env lean`, clean — no errors/warnings).
- Worked ℚ examples discharged by kernel `decide`.

## Files

- `proofs/Proofs/DescartesRuleOfSignsOQ01OQ04OQ03.lean` (202 lines, 8 theorems + 1 def)
- `src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-03/{meta,annotations}.json`
- `src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04-oq-03.json`
- `proofs/Proofs.lean` (aggregator import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)