### PR TITLE
research: Chebyshev lower density for all m (chebyshev-pnt-bridge-oq-05)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -791,6 +791,7 @@ import Proofs.ChebyshevPNTBridgeOQ01Aristotle
 import Proofs.ChebyshevPNTBridgeOQ01OQ02
 import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChebyshevPNTBridgeOQ03
+import Proofs.ChebyshevPNTBridgeOQ05
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevPolynomialsOQ01OQ01OQ01
 import Proofs.ChebyshevSumMonotoneOQ01

--- a/proofs/Proofs/ChebyshevPNTBridgeOQ05.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ05.lean
@@ -1,0 +1,158 @@
+/-
+# Chebyshev–PNT Bridge OQ-05: Lower Bound on π(m) for ALL m (not just even)
+
+Parent (`ChebyshevPNTBridge.lean`) proved the lower bound only along the
+even-integer subsequence:
+
+    4^n ≤ (2n+1) · (2n)^{π(2n)}          (`four_pow_le_mul_pow_primeCounting`)
+
+which controls π(x)·log(x)/x ≥ log 2 − o(1) only when x = 2n runs over even
+integers. The parent's open question OQ-05 asks to extend this to *arbitrary*
+m (equivalently arbitrary real x ≥ 1, since π is the step function
+π(x) = π(⌊x⌋)) via the monotonicity π(m) ≥ π(2⌊m/2⌋).
+
+This file carries out that extension. The key new content:
+
+* **`four_pow_half_le_mul_pow_primeCounting`** — for every m ≥ 2,
+
+      4^{⌊m/2⌋} ≤ (m+1) · m^{π(m)},
+
+  a single inequality valid for ODD and EVEN m alike. The parent's even-only
+  bound is transferred to m by collapsing the even integer 2⌊m/2⌋ ≤ m into m
+  on both the base (2⌊m/2⌋ ≤ m) and the exponent (π(2⌊m/2⌋) ≤ π(m)).
+
+* **`primeCounting_mul_log_lower`** — the real-logarithmic form
+
+      ⌊m/2⌋ · log 4 − log(m+1) ≤ π(m) · log m,
+
+  obtained by taking `Real.log` of the previous inequality. Since log 4 =
+  2 log 2 and ⌊m/2⌋/m → 1/2, log(m+1)/log m → 0, this gives the Chebyshev
+  lower density π(m)·log(m)/m ≥ log 2 − o(1) along the FULL sequence m → ∞,
+  answering OQ-05.
+
+Everything is derived from the parent results plus `Real.log` monotonicity;
+no new axioms. `0 sorries, 0 axioms`.
+-/
+
+import Mathlib.NumberTheory.Primorial
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Tactic
+import Proofs.ChebyshevPNTBridge
+
+namespace ChebyshevPNTBridgeOQ05
+
+open Nat
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: NATURAL-NUMBER LOWER BOUND FOR ALL m
+
+The parent bound `four_pow_le_mul_pow_primeCounting` holds at the even integer
+2n. Writing n = ⌊m/2⌋ gives an even integer 2n ≤ m, and monotonicity of π
+upgrades the bound from 2n to m.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- π is monotone in its argument (more integers ≤ b can be prime than ≤ a). -/
+theorem primeCounting_mono {a b : ℕ} (hab : a ≤ b) :
+    Nat.primeCounting a ≤ Nat.primeCounting b :=
+  Nat.monotone_primeCounting hab
+
+/-- **Lower bound on π(m) valid for every m ≥ 2 (odd or even).**
+
+    4^{⌊m/2⌋} ≤ (m+1) · m^{π(m)}.
+
+The parent file establishes this only for even arguments via
+`four_pow_le_mul_pow_primeCounting`; here we transfer it to an arbitrary m by
+taking n = ⌊m/2⌋ and absorbing the even integer 2n ≤ m into m on both the base
+and the exponent. -/
+theorem four_pow_half_le_mul_pow_primeCounting (m : ℕ) (hm : 2 ≤ m) :
+    4 ^ (m / 2) ≤ (m + 1) * m ^ Nat.primeCounting m := by
+  set n := m / 2 with hn_def
+  have hn1 : 1 ≤ n := by
+    rw [hn_def]; omega
+  -- 2n is the even integer just below (or equal to) m
+  have h2n_le : 2 * n ≤ m := by
+    rw [hn_def]; omega
+  have hm_pos : 0 < m := by omega
+  -- Parent even-only bound at n
+  have hparent : 4 ^ n ≤ (2 * n + 1) * (2 * n) ^ Nat.primeCounting (2 * n) :=
+    ChebyshevPNTBridge.four_pow_le_mul_pow_primeCounting n hn1
+  -- Step 1: collapse the prefactor 2n+1 ≤ m+1
+  have hpre : (2 * n + 1 : ℕ) ≤ m + 1 := by omega
+  -- Step 2: collapse the base (2n)^k ≤ m^k for the same exponent k = π(2n)
+  have hbase : (2 * n) ^ Nat.primeCounting (2 * n) ≤ m ^ Nat.primeCounting (2 * n) :=
+    Nat.pow_le_pow_left h2n_le _
+  -- Step 3: raise the exponent π(2n) ≤ π(m)
+  have hexp : m ^ Nat.primeCounting (2 * n) ≤ m ^ Nat.primeCounting m :=
+    Nat.pow_le_pow_right hm_pos (primeCounting_mono h2n_le)
+  calc 4 ^ n
+      ≤ (2 * n + 1) * (2 * n) ^ Nat.primeCounting (2 * n) := hparent
+    _ ≤ (m + 1) * m ^ Nat.primeCounting m := by
+        apply Nat.mul_le_mul hpre
+        exact le_trans hbase hexp
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: REAL-LOGARITHMIC FORM (CHEBYSHEV LOWER DENSITY)
+
+Taking `Real.log` of the Nat inequality turns it into a linear lower bound on
+π(m)·log(m), which is the form in which the Chebyshev constant log 2 appears.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Real-logarithmic lower bound, all m ≥ 2.**
+
+    ⌊m/2⌋ · log 4 − log(m+1) ≤ π(m) · log m.
+
+This is `Real.log` applied to `four_pow_half_le_mul_pow_primeCounting`. Since
+log 4 = 2 log 2, the leading term is (⌊m/2⌋/m)·m·log 4 ≈ m·log 2, so dividing
+by m gives π(m)·log(m)/m ≥ log 2 − o(1) over the full integer sequence. -/
+theorem primeCounting_mul_log_lower (m : ℕ) (hm : 2 ≤ m) :
+    (m / 2 : ℕ) * Real.log 4 - Real.log (m + 1)
+      ≤ (Nat.primeCounting m : ℝ) * Real.log m := by
+  have hnat := four_pow_half_le_mul_pow_primeCounting m hm
+  have hm1 : (1 : ℝ) ≤ (m : ℝ) := by exact_mod_cast (by omega : 1 ≤ m)
+  have hmp1_pos : (0 : ℝ) < (m : ℝ) + 1 := by positivity
+  -- Cast the Nat inequality into ℝ and take logs.
+  have hcast : (4 : ℝ) ^ (m / 2) ≤ ((m : ℝ) + 1) * (m : ℝ) ^ Nat.primeCounting m := by
+    have := hnat
+    have h4 : ((4 ^ (m / 2) : ℕ) : ℝ) = (4 : ℝ) ^ (m / 2) := by push_cast; ring
+    have hr : (((m + 1) * m ^ Nat.primeCounting m : ℕ) : ℝ)
+        = ((m : ℝ) + 1) * (m : ℝ) ^ Nat.primeCounting m := by push_cast; ring
+    calc (4 : ℝ) ^ (m / 2) = ((4 ^ (m / 2) : ℕ) : ℝ) := h4.symm
+      _ ≤ (((m + 1) * m ^ Nat.primeCounting m : ℕ) : ℝ) := by exact_mod_cast this
+      _ = ((m : ℝ) + 1) * (m : ℝ) ^ Nat.primeCounting m := hr
+  -- Both sides positive, so log is monotone and additive.
+  have hlhs_pos : (0 : ℝ) < (4 : ℝ) ^ (m / 2) := by positivity
+  have hlog := Real.log_le_log hlhs_pos hcast
+  rw [Real.log_mul (by positivity) (by positivity)] at hlog
+  rw [Real.log_pow, Real.log_pow] at hlog
+  -- hlog : ↑(m/2) * log 4 ≤ log (m+1) + ↑(π m) * log m
+  -- Rearrange.
+  have : ((m / 2 : ℕ) : ℝ) * Real.log 4
+      ≤ Real.log ((m : ℝ) + 1) + (Nat.primeCounting m : ℝ) * Real.log m := hlog
+  linarith
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART III: EXPLICIT CHEBYSHEV LOWER DENSITY (clean denominator-free form)
+
+Dividing the previous bound by log m (positive for m ≥ 2) records the lower
+density directly.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The Chebyshev lower density in quotient form: for m ≥ 2,
+
+    π(m) ≥ (⌊m/2⌋ · log 4 − log(m+1)) / log m. -/
+theorem primeCounting_ge_div_log (m : ℕ) (hm : 2 ≤ m) :
+    ((m / 2 : ℕ) * Real.log 4 - Real.log (m + 1)) / Real.log m
+      ≤ (Nat.primeCounting m : ℝ) := by
+  have hlogm_pos : 0 < Real.log m := by
+    apply Real.log_pos
+    exact_mod_cast (by omega : 1 < m)
+  rw [div_le_iff₀ hlogm_pos]
+  exact primeCounting_mul_log_lower m hm
+
+#check four_pow_half_le_mul_pow_primeCounting  -- Nat lower bound, all m
+#check primeCounting_mul_log_lower             -- real-log form
+#check primeCounting_ge_div_log                -- quotient form
+#check ChebyshevPNTBridge.four_pow_le_mul_pow_primeCounting  -- parent (even only)
+
+end ChebyshevPNTBridgeOQ05

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-05",
+  "title": "Chebyshev Lower Density for All m: π(m)·log m ≥ m·log 2 − o(1)",
+  "slug": "chebyshev-pnt-bridge-oq-05",
+  "description": "Extends the Chebyshev lower bound on the prime-counting function from the even-integer subsequence x = 2n to ALL integers m (odd and even alike), answering the parent's fifth open question. The parent proved 4^n ≤ (2n+1)·(2n)^{π(2n)} only at even arguments; here monotonicity of π collapses the even integer 2⌊m/2⌋ ≤ m into m on both base and exponent, giving 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} for every m ≥ 2. Taking logarithms yields ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m, the Chebyshev lower density log 2 − o(1) over the full sequence m → ∞. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Pafnuty Chebyshev",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ05.lean",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.monotone_primeCounting",
+        "description": "π(n) = #{primes ≤ n} is monotone; the engine that transfers the even-only bound at 2⌊m/2⌋ up to m",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_left",
+        "description": "a ≤ b ⟹ a^k ≤ b^k; collapses the base (2⌊m/2⌋)^k ≤ m^k",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_right",
+        "description": "1 ≤ a, j ≤ k ⟹ a^j ≤ a^k; raises the exponent π(2⌊m/2⌋) ≤ π(m)",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Real.log_le_log",
+        "description": "monotonicity of Real.log on positives; converts the Nat product inequality into the additive log form",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_mul / Real.log_pow",
+        "description": "log(ab) = log a + log b and log(a^k) = k·log a; expands log((m+1)·m^{π m})",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "four_pow_half_le_mul_pow_primeCounting: 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} for EVERY m ≥ 2 — a single inequality valid for odd and even m, where the parent ChebyshevPNTBridge.four_pow_le_mul_pow_primeCounting only covered even arguments x = 2n. The transfer absorbs the even integer 2⌊m/2⌋ ≤ m into m on the prefactor (2n+1 ≤ m+1), the base ((2n)^k ≤ m^k), and the exponent (π(2n) ≤ π(m))",
+      "primeCounting_mul_log_lower: ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m, the real-logarithmic form obtained by applying Real.log monotonicity to the Nat inequality; since log 4 = 2 log 2 and ⌊m/2⌋/m → 1/2 the leading term is m·log 2, giving the Chebyshev lower density log 2 − o(1) along the full integer sequence rather than the even subsequence",
+      "primeCounting_ge_div_log: the denominator-free quotient form π(m) ≥ (⌊m/2⌋·log 4 − log(m+1))/log m for m ≥ 2"
+    ],
+    "axiomCount": 0,
+    "lineCount": 158,
+    "assumptions": "None — fully verified from Mathlib and the parent bridge with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The full PNT limit π(x)·log x / x → 1 and the sharper Chebyshev constants 0.921/1.106 remain out of scope (separate open questions of the parent).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 memoir bracketed π(x)·log(x)/x between two explicit constants by analysing the prime factorization of central binomial coefficients. The elementary lower bound naturally lands on even arguments x = 2n (where the central binomial C(2n,n) lives), and a separate, easy step is needed to spread the estimate to every x — the observation that π is a non-decreasing step function, so a bound at the even integer just below x already controls π(x). This file performs that classical 'fill in the gaps' step in the formalized bridge.",
+    "problemStatement": "The parent bridge proves 4^n ≤ (2n+1)·(2n)^{π(2n)} only for even arguments 2n. Extend the resulting lower density π(x)·log(x)/x ≥ log 2 − o(1) from the even-integer subsequence to all m (equivalently all real x ≥ 1, since π(x) = π(⌊x⌋)).",
+    "text": "Lifts the even-only Chebyshev lower bound to all m via monotonicity of π, giving 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} and the log-form ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m.",
+    "proofStrategy": "Set n = ⌊m/2⌋, so 2n ≤ m is the even integer just below m and n ≥ 1 for m ≥ 2. Feed n into the parent's even-only bound to get 4^n ≤ (2n+1)·(2n)^{π(2n)}. Then make three monotone collapses, all into m: 2n+1 ≤ m+1 (prefactor, omega), (2n)^{π(2n)} ≤ m^{π(2n)} (base, Nat.pow_le_pow_left from 2n ≤ m), and m^{π(2n)} ≤ m^{π(m)} (exponent, Nat.pow_le_pow_right from π(2n) ≤ π(m), itself monotonicity of π at 2n ≤ m). Multiplying gives 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)}. Casting to ℝ and applying Real.log (monotone, with log_mul and log_pow) produces the additive lower bound on π(m)·log m; dividing by log m > 0 gives the quotient form.",
+    "keyInsights": [
+      "π is a non-decreasing step function, so its value at any real x equals its value at ⌊x⌋, and a lower bound at the largest even integer ≤ m already bounds π(m) — no new analytic input is needed to leave the even subsequence",
+      "The even-only deficit costs only o(1): replacing 2n = 2⌊m/2⌋ by m changes the base by at most one factor and ⌊m/2⌋/m → 1/2, so the Chebyshev constant log 2 survives intact in the limit",
+      "All three places where the even integer 2n appears (prefactor, base, exponent) move monotonically in the right direction, so the transfer is a pure inequality chain with no error term to track",
+      "Real.log turns the multiplicative Nat bound 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} into the linear estimate ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m, the shape in which the density constant log 2 = ½ log 4 is read off"
+    ],
+    "prerequisites": [
+      "the prime-counting function π and its monotonicity",
+      "the parent Chebyshev–PNT bridge even-integer lower bound",
+      "monotonicity and the product/power laws of Real.log"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring framing OQ#5: extend the even-only Chebyshev lower bound to all m via monotonicity of π."
+    },
+    {
+      "id": "nat-bound",
+      "title": "Natural-Number Lower Bound for All m",
+      "startLine": 51,
+      "endLine": 101,
+      "summary": "four_pow_half_le_mul_pow_primeCounting: 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} for all m ≥ 2, transferring the parent's even-only bound by collapsing 2⌊m/2⌋ into m on prefactor, base, and exponent.",
+      "mathContext": "n = ⌊m/2⌋ gives 2n ≤ m; Nat.pow_le_pow_left/right and monotone_primeCounting do the three collapses."
+    },
+    {
+      "id": "log-form",
+      "title": "Real-Logarithmic Form",
+      "startLine": 103,
+      "endLine": 145,
+      "summary": "primeCounting_mul_log_lower: ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m, obtained by applying Real.log to the cast Nat inequality.",
+      "mathContext": "log 4 = 2 log 2 makes the leading term m·log 2, the Chebyshev lower density."
+    },
+    {
+      "id": "quotient",
+      "title": "Quotient Form",
+      "startLine": 147,
+      "endLine": 158,
+      "summary": "primeCounting_ge_div_log: π(m) ≥ (⌊m/2⌋·log 4 − log(m+1))/log m for m ≥ 2.",
+      "mathContext": "Dividing the log-form by log m > 0 (m ≥ 2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) extension of the Chebyshev lower bound from even arguments to all m ≥ 2. The Nat inequality 4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)} and its logarithmic form ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m deliver the lower density π(m)·log(m)/m ≥ log 2 − o(1) over the entire integer sequence, not merely the even subsequence the parent controlled.",
+    "implications": "Removes the even-integer restriction in the parent's lower bound, so the Chebyshev lower density now holds for every m (equivalently every real x ≥ 1 via π(x) = π(⌊x⌋)). This is the elementary 'fill the gaps' step that any honest statement of π(x) = Θ(x/log x) requires before invoking the full PNT limit.",
+    "openQuestions": [
+      "Pair this lower density with the parent's upper bound to state the two-sided π(x)·log(x)/x ∈ [log 2 − o(1), 2 log 4 + o(1)] for all real x ≥ 2.",
+      "Sharpen ⌊m/2⌋·log 4 to Chebyshev's original constant 0.921·x by analysing the binomial valuations more carefully.",
+      "Formalize the full PNT limit π(x)·log x / x → 1 — a separate open question of the parent."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "parent",
+      "description": "Parent proving explicit Chebyshev bounds π(x) = Θ(x/log x); this entry answers its fifth open question by extending the even-only lower bound to all m via monotonicity of π"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Primorial",
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Tactic",
+      "Proofs.ChebyshevPNTBridge"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ05",
+    "lineCount": 158,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPNTBridgeOQ05.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-05** of the parent `chebyshev-pnt-bridge`: *"Extend π(x) bound from π(2n) to arbitrary x via monotonicity π(x) ≥ π(2⌊x/2⌋), yielding π(x)·log(x)/x ≥ log(2) − o(1) for all x → ∞ rather than just along the even-integer subsequence."*

The parent proved the lower bound **only at even arguments**:
`four_pow_le_mul_pow_primeCounting : 4^n ≤ (2n+1)·(2n)^{π(2n)}`.

This leaf transfers it to **every m ≥ 2** (odd and even alike).

## New results (`Proofs/ChebyshevPNTBridgeOQ05.lean`, 4 thm, 158 L)

- **`four_pow_half_le_mul_pow_primeCounting`** — `4^{⌊m/2⌋} ≤ (m+1)·m^{π(m)}` for all `m ≥ 2`. Setting `n = ⌊m/2⌋` gives an even integer `2n ≤ m`; the parent's bound is absorbed into `m` on the prefactor (`2n+1 ≤ m+1`), the base (`(2n)^k ≤ m^k`), and the exponent (`π(2n) ≤ π(m)`) — all monotone collapses.
- **`primeCounting_mul_log_lower`** — `⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m`, via `Real.log` of the Nat inequality. Since `log 4 = 2 log 2` and `⌊m/2⌋/m → 1/2`, the leading term is `m·log 2` — the Chebyshev lower density `log 2 − o(1)` over the **full** sequence `m → ∞`.
- **`primeCounting_ge_div_log`** — quotient form `π(m) ≥ (⌊m/2⌋·log 4 − log(m+1))/log m`.

## Verification

- **0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), **0 sorries**, no `native_decide`.
- Builds against the parent `Proofs.ChebyshevPNTBridge`; aggregator import added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)