### PR TITLE
research(descartes-rule-of-signs-oq-01-oq-04-oq-02): boundary exact positive-root count via IVT [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1026,6 +1026,7 @@ import Proofs.DescartesRuleOfSigns
 import Proofs.DescartesRuleOfSignsOQ01
 import Proofs.DescartesRuleOfSignsOQ01OQ01
 import Proofs.DescartesRuleOfSignsOQ01OQ02
+import Proofs.DescartesRuleOfSignsOQ01OQ04OQ02
 import Proofs.DescartesRuleOfSignsOQ01OQ04OQ03
 import Proofs.DescartesRuleOfSignsOQ02
 import Proofs.DescartesRuleOfSignsOQ02OQ01
@@ -3253,6 +3254,7 @@ import Proofs.HodgeConjecture
 import Proofs.HurwitzOnlyIf
 import Proofs.HurwitzTheorem
 import Proofs.HurwitzTheoremOQ04
+import Proofs.HyperbolicLawCosinesModelOQ0301
 import Proofs.IncidenceCauchySchwarz
 import Proofs.InclusionExclusion
 import Proofs.InclusionExclusionBonferroniGeneral
@@ -3405,7 +3407,6 @@ import Proofs.LawOfCosinesOQ01OQ01OQ01OQ02
 import Proofs.LawOfCosinesOQ01OQ01OQ03
 import Proofs.LawOfCosinesOQ01OQ02
 import Proofs.LawOfCosinesOQ01OQ04
-import Proofs.HyperbolicLawCosinesModelOQ0301
 import Proofs.LawOfCosinesOQ03
 import Proofs.LawOfCosinesOQ03OQ02
 import Proofs.LawOfCosinesOQ04

--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ04OQ02.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ04OQ02.lean
@@ -1,0 +1,192 @@
+import Mathlib
+
+/-
+# Descartes' Rule of Signs, OQ-01-OQ-04-OQ-02: exact positive-root count in the boundary cases
+
+## Background
+
+Descartes' Rule of Signs (Mathlib's `Polynomial.roots_countP_pos_le_signVariations`) gives only an
+*upper bound*: the number of positive roots of a real polynomial is at most its number of sign
+variations,
+
+      #{positive roots} ≤ signVariations P.
+
+The *parity refinement* sharpens this to `#{positive roots} ≡ signVariations P (mod 2)`, which would
+pin the count exactly in the two boundary cases `signVariations P ∈ {0, 1}`. But the parity
+refinement is the genuinely hard, FTA-flavoured content of Descartes' Rule (the statement
+`[sign p(a) ≠ sign p(b)] ⟺ Odd #{roots in (a,b)}`), and it is *not* available in Mathlib nor in the
+gallery — every gallery file that uses parity takes `Even (signVariations + #pos)` as a hypothesis.
+
+## What this file proves (and why it sidesteps the open parity)
+
+The key observation is that the **boundary cases need only the sign-change root *existence*, not the
+full odd-multiplicity parity**:
+
+* `signVariations P = 0` ⟹ `#{positive roots} = 0` — immediate from Descartes' bound alone
+  (`no_pos_roots_of_signVariations_zero`).
+* `signVariations P = 1` ⟹ `#{positive roots} = 1` — the bound gives `≤ 1`; the *lower* bound `≥ 1`
+  needs only that *one* positive root exists. And a positive root exists as soon as the leading and
+  trailing coefficients have **opposite signs**, by the Intermediate Value Theorem
+  (`exists_pos_root_of_sign_opposition`, `exactly_one_pos_root_of_sign_opposition`).
+
+The analytic argument is the content. Factor out the largest power of `X`, writing `P = Xᵐ · Q` with
+`Q.eval 0 = trailingCoeff ≠ 0` and `Q.leadingCoeff = P.leadingCoeff`. The deflated `Q` has positive
+degree (else `P` is a monomial, whose leading and trailing coefficients coincide — excluded by the
+sign opposition), so `Q.eval` tends to `±∞` with the sign of its leading coefficient; pick `b > 0`
+where `Q.eval b` carries that sign. Since `Q.eval 0` carries the opposite (trailing) sign, the
+Intermediate Value Theorem produces `c ∈ (0, b)` with `Q.eval c = 0`, hence `P.eval c = cᵐ·Q.eval c =
+0`. **This existence-by-IVT is exactly what replaces the unavailable parity argument in the boundary
+case, and it is fully machine-checked here.**
+
+## Honesty / scope
+
+Stated over `ℝ` (not `ℚ`): over `ℚ` the exact count is *false* — `X² - 2` has one sign variation but
+no rational positive root. The "exactly one" statement is genuinely a real-closed-field phenomenon,
+recovered here from completeness via the IVT.
+
+The sign opposition `sign(leadingCoeff) ≠ sign(trailingCoeff)` is taken as a hypothesis: it is the
+purely combinatorial consequence of a single sign variation (the coefficient sign-sequence changes
+exactly once, so its endpoints lie in opposite blocks), and carries no analytic or FTA content. The
+file therefore reduces the open boundary-exact-count to that one combinatorial bridge plus the
+*verified* IVT existence — entirely bypassing the open parity refinement.
+
+Main results:
+* `no_pos_roots_of_signVariations_zero`        — `0` sorries, `0` axioms
+* `exists_pos_root_of_sign_opposition`         — `0` sorries, `0` axioms
+* `exactly_one_pos_root_of_sign_opposition`    — `0` sorries, `0` axioms
+-/
+
+namespace DescartesExactCount
+
+open Polynomial Filter
+
+variable {P : ℝ[X]}
+
+/-! ## The easy boundary case: zero sign variations ⟹ no positive roots -/
+
+/-- **Boundary case `signVariations = 0`.** A real polynomial with no sign variations has no positive
+roots. Immediate from Descartes' bound — no parity needed. -/
+theorem no_pos_roots_of_signVariations_zero (h : P.signVariations = 0) :
+    P.roots.countP (0 < ·) = 0 := by
+  have hle := P.roots_countP_pos_le_signVariations
+  rw [h] at hle
+  exact Nat.le_zero.mp hle
+
+/-! ## Existence of a positive root from opposite leading/trailing signs (IVT) -/
+
+/-- **Opposite leading/trailing signs force a positive root.** If the leading and trailing
+coefficients of a nonzero real polynomial have strictly opposite signs, then `P` has a root in
+`(0, ∞)`. This is the Intermediate Value Theorem applied to the polynomial deflated by the largest
+power of `X`; it is the analytic core that replaces the parity argument in the boundary case. -/
+theorem exists_pos_root_of_sign_opposition (hP : P ≠ 0)
+    (hopp : SignType.sign P.leadingCoeff ≠ SignType.sign P.trailingCoeff) :
+    ∃ x : ℝ, 0 < x ∧ P.eval x = 0 := by
+  -- factor out the largest power of X:  P = X^m * Q
+  obtain ⟨Q, hPQ⟩ := pow_rootMultiplicity_dvd P 0
+  rw [map_zero, sub_zero] at hPQ
+  set m := rootMultiplicity 0 P with hm
+  have hQne : Q ≠ 0 := by
+    rintro rfl; rw [mul_zero] at hPQ; exact hP hPQ
+  -- maximality of the root multiplicity ⟹ deflated constant term is nonzero
+  have hmax : ¬ (X : ℝ[X]) ^ (m + 1) ∣ P := by
+    have h1 := (rootMultiplicity_le_iff hP 0 m).mp le_rfl
+    rwa [map_zero, sub_zero] at h1
+  have hQ0 : Q.eval 0 ≠ 0 := by
+    intro hQe
+    refine hmax ?_
+    have hdvd : (X : ℝ[X]) ∣ Q := by
+      have hr : IsRoot Q 0 := hQe
+      rw [← dvd_iff_isRoot] at hr
+      rwa [map_zero, sub_zero] at hr
+    obtain ⟨R, rfl⟩ := hdvd
+    exact ⟨R, by rw [hPQ]; ring⟩
+  -- leading coefficient is unchanged by deflation
+  have hlead : P.leadingCoeff = Q.leadingCoeff := by
+    rw [hPQ, leadingCoeff_mul, leadingCoeff_X_pow, one_mul]
+  -- trailing coefficient equals the deflated constant term
+  have hQ0coeff : Q.coeff 0 ≠ 0 := by rwa [coeff_zero_eq_eval_zero]
+  have htrail : P.trailingCoeff = Q.eval 0 := by
+    have hQnT : Q.natTrailingDegree = 0 := natTrailingDegree_eq_zero.mpr (Or.inr hQ0coeff)
+    have hPnT : P.natTrailingDegree = m := by
+      rw [hPQ, show (X : ℝ[X]) ^ m * Q = Q * X ^ m from by ring,
+        natTrailingDegree_mul_X_pow hQne, hQnT, zero_add]
+    have hcoeff : (X ^ m * Q).coeff m = Q.coeff 0 := by
+      have := coeff_X_pow_mul Q m 0
+      rwa [zero_add] at this
+    rw [trailingCoeff, hPnT, hPQ, hcoeff, coeff_zero_eq_eval_zero]
+  -- the deflated polynomial has positive degree (else P is a monomial: leading = trailing sign)
+  have hQdeg : 0 < Q.degree := by
+    rw [← natDegree_pos_iff_degree_pos]
+    by_contra hcon
+    push_neg at hcon
+    have hnd : Q.natDegree = 0 := Nat.le_zero.mp hcon
+    have hlc_eq : Q.leadingCoeff = Q.eval 0 := by
+      rw [leadingCoeff, hnd, coeff_zero_eq_eval_zero]
+    exact hopp (by rw [hlead, htrail, hlc_eq])
+  -- abbreviations
+  have hcont : Continuous fun x : ℝ => Q.eval x := Q.continuous
+  rw [hlead, htrail] at hopp
+  have hQlc : Q.leadingCoeff ≠ 0 := leadingCoeff_ne_zero.mpr hQne
+  -- the deflated root transports back to a root of P
+  have hback : ∀ c : ℝ, Q.eval c = 0 → P.eval c = 0 := fun c hc => by
+    rw [hPQ, eval_mul, hc, mul_zero]
+  -- split on the sign of the leading coefficient; the opposition fixes the other sign
+  rcases lt_or_gt_of_ne hQlc with hlcneg | hlcpos
+  · -- leadingCoeff < 0, hence Q.eval 0 > 0
+    have hQ0pos : 0 < Q.eval 0 := by
+      rcases lt_or_gt_of_ne hQ0 with h | h
+      · exact absurd (by rw [sign_eq_neg_one_iff.mpr hlcneg, sign_eq_neg_one_iff.mpr h]) hopp
+      · exact h
+    -- Q.eval → -∞, so some b > 0 has Q.eval b < 0
+    have hT : Tendsto (fun x : ℝ => Q.eval x) atTop atBot :=
+      Q.tendsto_atBot_of_leadingCoeff_nonpos hQdeg hlcneg.le
+    obtain ⟨b, hb0, hbneg⟩ : ∃ b : ℝ, 0 < b ∧ Q.eval b < 0 :=
+      ((eventually_gt_atTop 0).and (hT.eventually (eventually_lt_atBot 0))).exists
+    -- IVT: 0 lies between Q.eval b < 0 and Q.eval 0 > 0
+    obtain ⟨c, hcmem, hc0⟩ :=
+      intermediate_value_Icc' hb0.le hcont.continuousOn ⟨hbneg.le, hQ0pos.le⟩
+    have hcne : c ≠ 0 := by rintro rfl; exact hQ0 hc0
+    exact ⟨c, hcmem.1.lt_of_ne (Ne.symm hcne), hback c hc0⟩
+  · -- leadingCoeff > 0, hence Q.eval 0 < 0
+    have hQ0neg : Q.eval 0 < 0 := by
+      rcases lt_or_gt_of_ne hQ0 with h | h
+      · exact h
+      · exact absurd (by rw [sign_eq_one_iff.mpr hlcpos, sign_eq_one_iff.mpr h]) hopp
+    -- Q.eval → +∞, so some b > 0 has Q.eval b > 0
+    have hT : Tendsto (fun x : ℝ => Q.eval x) atTop atTop :=
+      Q.tendsto_atTop_of_leadingCoeff_nonneg hQdeg hlcpos.le
+    obtain ⟨b, hb0, hbpos⟩ : ∃ b : ℝ, 0 < b ∧ 0 < Q.eval b :=
+      ((eventually_gt_atTop 0).and (hT.eventually (eventually_gt_atTop 0))).exists
+    -- IVT: 0 lies between Q.eval 0 < 0 and Q.eval b > 0
+    obtain ⟨c, hcmem, hc0⟩ :=
+      intermediate_value_Icc hb0.le hcont.continuousOn ⟨hQ0neg.le, hbpos.le⟩
+    have hcne : c ≠ 0 := by rintro rfl; exact hQ0 hc0
+    exact ⟨c, hcmem.1.lt_of_ne (Ne.symm hcne), hback c hc0⟩
+
+/-! ## The boundary result, conditional on the sign opposition -/
+
+/-- **Boundary case `signVariations = 1`, given the sign opposition.** A real polynomial with exactly
+one sign variation whose leading and trailing coefficients have opposite signs has exactly one
+positive root (with multiplicity). The upper bound `≤ 1` is Descartes' Rule; the lower bound `≥ 1` is
+the IVT existence of a positive root. No parity refinement is used.
+
+The hypothesis `hopp` is the only non-analytic input; it is the purely combinatorial consequence of a
+single sign variation. -/
+theorem exactly_one_pos_root_of_sign_opposition (h : P.signVariations = 1)
+    (hopp : SignType.sign P.leadingCoeff ≠ SignType.sign P.trailingCoeff) :
+    P.roots.countP (0 < ·) = 1 := by
+  have hP : P ≠ 0 := by rintro rfl; simp at h
+  have hle : P.roots.countP (0 < ·) ≤ 1 := by
+    have := P.roots_countP_pos_le_signVariations; rw [h] at this; exact this
+  obtain ⟨x, hx0, hxroot⟩ := exists_pos_root_of_sign_opposition hP hopp
+  have hxmem : x ∈ P.roots := (mem_roots hP).mpr hxroot
+  have hge : 1 ≤ P.roots.countP (0 < ·) := Multiset.countP_pos_of_mem hxmem hx0
+  omega
+
+end DescartesExactCount
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms DescartesExactCount.no_pos_roots_of_signVariations_zero
+#print axioms DescartesExactCount.exists_pos_root_of_sign_opposition
+#print axioms DescartesExactCount.exactly_one_pos_root_of_sign_opposition

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-descartes-oq010402-zero-case",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "concept",
+    "title": "Zero sign variations ⟹ no positive roots",
+    "content": "no_pos_roots_of_signVariations_zero settles the first boundary case directly from Mathlib's Descartes bound roots_countP_pos_le_signVariations: if signVariations P = 0 then the positive-root count is ≤ 0, hence = 0. No parity refinement and no analysis are needed — the upper bound alone is decisive at zero.",
+    "mathContext": "$\\#\\{x>0 : P(x)=0\\} \\le \\operatorname{signVariations}(P) = 0$, so the count is $0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Descartes rule", "sign variations", "root counting"]
+  },
+  {
+    "id": "ann-descartes-oq010402-deflation",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+    "range": { "startLine": 81, "endLine": 117 },
+    "type": "insight",
+    "title": "Deflating by the largest power of X",
+    "content": "To make the Intermediate Value Theorem applicable even when the constant term vanishes, the polynomial is deflated as P = Xᵐ·Q with m = rootMultiplicity 0 P (pow_rootMultiplicity_dvd). Maximality of the root multiplicity (rootMultiplicity_le_iff) forces Q.eval 0 = trailingCoeff ≠ 0, while leadingCoeff is unchanged (leadingCoeff_mul, leadingCoeff_X_pow) and trailingCoeff P is identified with Q.eval 0 via natTrailingDegree bookkeeping. Positive roots of P in (0,∞) coincide with those of Q, since Xᵐ has its only root at 0.",
+    "mathContext": "Write $P = X^m Q$ with $Q(0)\\neq 0$; then $\\operatorname{sign}P(\\text{near }0^+) = \\operatorname{sign}Q(0) = \\operatorname{sign}(\\text{trailingCoeff})$.",
+    "significance": "key",
+    "relatedConcepts": ["root multiplicity", "trailing coefficient", "polynomial deflation"]
+  },
+  {
+    "id": "ann-descartes-oq010402-monomial-excluded",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+    "range": { "startLine": 118, "endLine": 130 },
+    "type": "insight",
+    "title": "Sign opposition excludes the monomial case",
+    "content": "The deflated Q must have positive degree for the ±∞ asymptotics to apply. If Q were constant, then P = c·Xᵐ is a monomial whose leading and trailing coefficients coincide (both c), giving equal signs — contradicting the hypothesis sign(leadingCoeff) ≠ sign(trailingCoeff). Thus the opposite-sign hypothesis is exactly what rules out the degenerate monomial and guarantees 0 < degree Q.",
+    "mathContext": "A monomial $cX^m$ has $\\operatorname{leadingCoeff} = \\operatorname{trailingCoeff} = c$, so opposite signs force $\\deg Q > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monomial", "leading coefficient", "degree"]
+  },
+  {
+    "id": "ann-descartes-oq010402-ivt",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+    "range": { "startLine": 134, "endLine": 165 },
+    "type": "insight",
+    "title": "Intermediate Value Theorem supplies the positive root",
+    "content": "With opposite signs in hand, the proof splits on the sign of the leading coefficient. The ±∞ asymptotics (tendsto_atTop_of_leadingCoeff_nonneg / tendsto_atBot_of_leadingCoeff_nonpos) produce a point b > 0 where Q.eval b carries the leading sign, while Q.eval 0 carries the opposite trailing sign. intermediate_value_Icc (resp. its primed variant) then yields c ∈ [0, b] with Q.eval c = 0; since Q.eval 0 ≠ 0, the root c is strictly positive. This existence-by-IVT is precisely what substitutes for the unavailable parity refinement in the boundary case.",
+    "mathContext": "$Q(0)$ and $Q(b)$ have opposite signs $\\Rightarrow \\exists\\, c\\in(0,b),\\ Q(c)=0$, hence $P(c)=c^m Q(c)=0$.",
+    "significance": "key",
+    "relatedConcepts": ["intermediate value theorem", "completeness of ℝ", "polynomial asymptotics"]
+  },
+  {
+    "id": "ann-descartes-oq010402-boundary-count",
+    "proofId": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+    "range": { "startLine": 175, "endLine": 188 },
+    "type": "concept",
+    "title": "One sign variation ⟹ exactly one positive root",
+    "content": "exactly_one_pos_root_of_sign_opposition assembles the boundary count: Descartes' bound gives ≤ 1, the IVT existence gives ≥ 1 (a positive root lies in the root multiset, so countP_pos_of_mem), and omega closes it at exactly 1. The only non-analytic input is the combinatorial hypothesis sign(leadingCoeff) ≠ sign(trailingCoeff) — the consequence of a single sign variation — so the open parity refinement is entirely bypassed.",
+    "mathContext": "$\\#\\{x>0:P(x)=0\\} \\le 1$ (Descartes) and $\\ge 1$ (IVT) $\\Rightarrow\\ = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Descartes rule", "boundary case", "root counting"]
+  }
+]

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-04-oq-02/meta.json
@@ -1,0 +1,130 @@
+{
+  "slug": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+  "id": "descartes-rule-of-signs-oq-01-oq-04-oq-02",
+  "title": "Descartes Boundary Exact Count: One Sign Variation Forces Exactly One Positive Root (via IVT, sidestepping parity)",
+  "description": "Addresses the parent's open question of whether the exact positive-root count can be pinned down in the boundary cases signVariations ∈ {0,1}. The textbook route is the parity refinement (#positive roots ≡ signVariations mod 2), but that is the hard FTA-flavoured content of Descartes' Rule and is unavailable in both Mathlib and the gallery (every gallery file takes the parity as a hypothesis). The key observation here is that the boundary cases need only root EXISTENCE, not the full odd-multiplicity parity: signVariations = 0 forces zero positive roots from Descartes' bound alone, and signVariations = 1 forces exactly one positive root because the bound gives ≤ 1 while the Intermediate Value Theorem supplies ≥ 1. The IVT existence argument — deflate by the largest power of X, then cross zero between the trailing-coefficient sign at 0 and the leading-coefficient sign near +∞ — is fully machine-checked. The single combinatorial fact that one sign variation forces opposite leading/trailing signs is taken as an explicit hypothesis (it carries no analytic content), so the entry reduces the open boundary-exact-count to that one bridge plus a verified IVT core, entirely bypassing the open parity refinement. Stated over ℝ, since over ℚ the exact count is false (X²−2 has one sign variation but no rational root).",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ02.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "Descartes rule",
+      "intermediate value theorem",
+      "real analysis",
+      "root counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 192,
+    "assumptions": "None beyond Mathlib's foundational axioms (propext / Classical.choice / Quot.sound; verified by #print axioms — no native_decide, no sorryAx). The boundary case signVariations = 1 is proved CONDITIONAL on the explicit hypothesis sign(leadingCoeff) ≠ sign(trailingCoeff): this is the purely combinatorial consequence of a single sign variation (a statement about List.destutter of the coefficient sign-list) and is taken as a hypothesis rather than re-derived. All analytic content — the IVT existence of a positive root, which is what replaces the unavailable parity argument — is fully proved.",
+    "theoremCount": 3,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.roots_countP_pos_le_signVariations",
+        "description": "Mathlib's Descartes upper bound (positive roots ≤ sign variations); supplies the ≤ 1 half of the boundary count and the entire signVariations = 0 case"
+      },
+      {
+        "theorem": "Polynomial.pow_rootMultiplicity_dvd",
+        "description": "Factoring out the largest power of X at the root 0, deflating P = Xᵐ·Q so the constant term of Q is nonzero"
+      },
+      {
+        "theorem": "Polynomial.tendsto_atTop_of_leadingCoeff_nonneg",
+        "description": "Polynomial tends to +∞ (or −∞ via the nonpos companion) with the sign of its leading coefficient; locates a far point carrying the leading sign"
+      },
+      {
+        "theorem": "intermediate_value_Icc",
+        "description": "The Intermediate Value Theorem; produces the positive root between the trailing-sign endpoint at 0 and the leading-sign endpoint at b"
+      },
+      {
+        "theorem": "Multiset.countP_pos_of_mem",
+        "description": "A positive root in the root multiset gives the ≥ 1 lower bound on the positive-root count"
+      }
+    ],
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DescartesExactCount",
+    "lineCount": 192,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ04OQ02.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "problemStatement": "Can the exact number of positive roots be determined in the boundary cases signVariations ∈ {0, 1}, lifting Descartes' bound from an inequality to an equality there — given that the textbook tool, the parity refinement #positive roots ≡ signVariations (mod 2), is unavailable in Mathlib and the gallery?",
+    "historicalContext": "Descartes' Rule of Signs (La Géométrie, 1637) bounds the number of positive real roots by the number of sign changes in the coefficient sequence, and asserts the two differ by an even number — the parity refinement. Mathlib formalizes only the inequality (roots_countP_pos_le_signVariations). The parity half is the genuinely hard, fundamental-theorem-of-algebra-flavoured content: it amounts to 'a sign change of the polynomial across an interval occurs iff an odd number of roots lies inside'. Across the gallery's Descartes development, that parity is consistently assumed as a hypothesis (Even (signVariations + positive roots)) rather than proved. The parent OQ-01-OQ-04 made the sign-variation count computable over ℚ and explicitly asked whether the parity refinement lifts to a computable exact count when the count is 0 or 1. This entry answers the structural part of that question without the parity, by recognizing that the boundary cases need only root existence.",
+    "keyInsights": [
+      "The boundary cases of Descartes' Rule do not need the full parity refinement — they need only EXISTENCE of one positive root. signVariations = 0 gives 0 positive roots from the upper bound directly; signVariations = 1 gives exactly one because the bound forces ≤ 1 and one positive root must exist.",
+      "Existence of a positive root follows from the Intermediate Value Theorem the moment the leading and trailing coefficients have opposite signs: the polynomial carries the trailing sign near 0 and the leading sign near +∞, so it crosses zero in (0, ∞).",
+      "To handle a vanishing constant term cleanly, deflate by the largest power of X: P = Xᵐ·Q with Q.eval 0 = trailingCoeff ≠ 0 and Q.leadingCoeff = P.leadingCoeff. Positive roots of P in (0,∞) coincide with those of Q, and the IVT applies to Q on [0, b].",
+      "The opposite-sign condition itself excludes the degenerate monomial case: a monomial has equal leading and trailing coefficients (same sign), so the hypothesis sign(leadingCoeff) ≠ sign(trailingCoeff) forces the deflated polynomial to have positive degree, which is what makes the ±∞ asymptotics apply.",
+      "The statement is genuinely real (not rational): over ℚ it is false, since X² − 2 has one sign variation but no rational positive root. The exact count is recovered from the completeness of ℝ through the IVT — completeness is doing the work that parity would otherwise do.",
+      "What remains to an unconditional theorem is purely combinatorial: signVariations = 1 ⟹ sign(leadingCoeff) ≠ sign(trailingCoeff), a fact about List.destutter of the coefficient sign-list with no analytic or FTA content. Isolating it as a hypothesis keeps the analytic core — the actual replacement for the missing parity — fully verified."
+    ],
+    "proofStrategy": "(1) no_pos_roots_of_signVariations_zero: signVariations = 0 gives positive roots ≤ 0 from Mathlib's bound, hence = 0. (2) exists_pos_root_of_sign_opposition: given sign(leadingCoeff) ≠ sign(trailingCoeff), factor P = Xᵐ·Q via pow_rootMultiplicity_dvd; show Q.eval 0 = trailingCoeff ≠ 0 (maximality of root multiplicity), Q.leadingCoeff = P.leadingCoeff, and that Q has positive degree (else P is a monomial with equal-sign leading/trailing coefficients). Convert the sign opposition to strict inequalities, use tendsto_atTop/atBot_of_leadingCoeff to find b > 0 carrying the leading sign, and apply intermediate_value_Icc/Icc' to get a root of Q in (0, b); transport it to P. (3) exactly_one_pos_root_of_sign_opposition: combine the ≤ 1 bound with the ≥ 1 existence and finish by omega.",
+    "prerequisites": [
+      "Polynomial.roots_countP_pos_le_signVariations (Mathlib's Descartes upper bound)",
+      "Polynomial.pow_rootMultiplicity_dvd and rootMultiplicity_le_iff (deflation by the largest power of X)",
+      "Polynomial.tendsto_atTop_of_leadingCoeff_nonneg / tendsto_atBot_of_leadingCoeff_nonpos (sign at ±∞)",
+      "intermediate_value_Icc / intermediate_value_Icc' (the IVT on closed intervals)",
+      "SignType.sign and sign_eq_one_iff / sign_eq_neg_one_iff (sign opposition ⟷ strict inequalities)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module: Boundary Exact Count via IVT",
+      "summary": "Module docstring framing the boundary cases of Descartes' Rule, why the parity refinement is unavailable (hard FTA content, only ever assumed in the gallery), and how root existence — not parity — settles signVariations ∈ {0,1}. Notes the ℝ-only scope (X²−2 counterexample over ℚ)."
+    },
+    {
+      "id": "zero-case",
+      "title": "Part 1: Zero Sign Variations ⟹ No Positive Roots",
+      "summary": "no_pos_roots_of_signVariations_zero: from Mathlib's Descartes bound, signVariations = 0 forces the positive-root count to 0. No parity, no analysis."
+    },
+    {
+      "id": "ivt-existence",
+      "title": "Part 2: Opposite Leading/Trailing Signs Force a Positive Root (IVT)",
+      "summary": "exists_pos_root_of_sign_opposition: the analytic heart. Deflate P = Xᵐ·Q (largest power of X), establish Q.eval 0 = trailingCoeff ≠ 0, Q.leadingCoeff = P.leadingCoeff, and positive degree of Q. Use the ±∞ asymptotics to find a far point carrying the leading sign, then the Intermediate Value Theorem to cross zero in (0, ∞)."
+    },
+    {
+      "id": "boundary-count",
+      "title": "Part 3: One Sign Variation ⟹ Exactly One Positive Root",
+      "summary": "exactly_one_pos_root_of_sign_opposition: combine Descartes' upper bound (≤ 1) with the IVT existence (≥ 1) to pin the count at exactly 1, conditional on the combinatorial sign opposition. No parity refinement used."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "descartes-rule-of-signs-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "Answers the parent's open question on whether the exact count can be recovered in the boundary cases signVarList ∈ {0,1}; does so via IVT existence rather than the (unavailable) parity refinement"
+    },
+    {
+      "targetId": "descartes-rule-of-signs-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling parity-arithmetic file: it assembles the exact count FROM Even(signVariations + positive roots); this entry instead avoids the parity hypothesis by using root existence in the boundary cases"
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "foundational",
+      "description": "The classical Descartes Rule of Signs at the root of the OQ chain"
+    }
+  ],
+  "conclusion": {
+    "summary": "In the boundary cases the exact positive-root count is recovered without the parity refinement: signVariations = 0 gives 0 roots from Descartes' bound, and signVariations = 1 gives exactly one root from the bound (≤ 1) together with the Intermediate Value Theorem (≥ 1). The IVT existence argument — deflate by Xᵐ, then cross zero between the trailing sign at 0 and the leading sign at +∞ — is fully machine-checked with 0 sorries and 0 axioms. The only non-analytic input, that one sign variation forces opposite leading/trailing signs, is taken as an explicit combinatorial hypothesis.",
+    "implications": "Shows the boundary cases of Descartes' Rule are strictly easier than the general parity refinement: they require only existence of a sign-change root, a completeness/IVT phenomenon, not the odd-multiplicity FTA argument the gallery has consistently left open. The deflate-then-IVT pattern (P = Xᵐ·Q with nonzero constant term, sign at 0 vs sign at +∞) is reusable for other sign-change root-existence facts. Reduces the open unconditional boundary count to a single, analysis-free combinatorial lemma about List.destutter.",
+    "openQuestions": [
+      "Prove the combinatorial bridge signVariations P = 1 ⟹ sign(leadingCoeff) ≠ sign(trailingCoeff) (the destuttered nonzero-sign list has length 2, so its endpoints differ), making exactly_one_pos_root unconditional.",
+      "Generalize the existence argument from sign-change endpoints to an arbitrary real-closed field, replacing the IVT with the order-completeness available there.",
+      "Combine with a Sturm-style oddness count to extend the exact count beyond the boundary cases signVariations ∈ {0,1}."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Addresses the **parent's open question** (descartes-rule-of-signs-oq-01-oq-04, openQuestion #2): can the exact positive-root count be pinned down in the boundary cases `signVariations ∈ {0,1}`?

The textbook tool is the **parity refinement** (`#positive roots ≡ signVariations mod 2`), but that is the genuinely hard, FTA-flavoured content of Descartes' Rule — it is **not available** in Mathlib nor anywhere in the gallery (every gallery file takes `Even (signVariations + #pos)` as a *hypothesis*). 

**Key insight:** the boundary cases need only root **existence**, not the full odd-multiplicity parity.

## Results (all `0` sorries, `0` axioms — `#print axioms` shows only `propext/Classical.choice/Quot.sound`)

- `no_pos_roots_of_signVariations_zero` — `sv = 0 ⟹ 0` positive roots, straight from Mathlib's Descartes bound.
- `exists_pos_root_of_sign_opposition` — **the analytic core.** If `sign(leadingCoeff) ≠ sign(trailingCoeff)`, a positive root exists. Proof: deflate `P = Xᵐ·Q` (largest power of `X`), so `Q.eval 0 = trailingCoeff ≠ 0` and `Q.leadingCoeff = P.leadingCoeff`; the sign opposition excludes the monomial case (forcing `deg Q > 0`); the `±∞` asymptotics give a point `b > 0` with the leading sign while `Q.eval 0` carries the opposite trailing sign; the **Intermediate Value Theorem** then crosses zero in `(0, b)`. This IVT existence is exactly what replaces the unavailable parity argument.
- `exactly_one_pos_root_of_sign_opposition` — `sv = 1 ⟹` exactly one positive root: bound gives `≤ 1`, IVT gives `≥ 1`.

## Honesty / scope

- Stated over **ℝ**: over ℚ the exact count is *false* (`X² − 2` has one sign variation but no rational root). The exact count is recovered from completeness via the IVT — completeness does the work parity would.
- The `sv = 1` result is **conditional** on the explicit hypothesis `sign(leadingCoeff) ≠ sign(trailingCoeff)`. This is the purely combinatorial consequence of a single sign variation (a `List.destutter` fact about the coefficient sign-list) and carries **no analytic content**; it is taken as a hypothesis rather than re-derived. The entry thus **reduces the open boundary-exact-count to that one combinatorial bridge plus a fully-verified IVT core, bypassing the open parity refinement**. Closing the bridge (left as an open question in the entry) makes the result unconditional.

## Verification

Built with host `lake env lean` (Docker unavailable) against Mathlib 4.26.0; all three theorems machine-checked, `0` sorry / `0` `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)