### PR TITLE
research(bezout-identity-oq-04-oq-01-oq-03): SNF solvability criterion is derived, not assumed [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -377,6 +377,7 @@ import Proofs.BezoutIdentityOQ03OQ05
 import Proofs.BezoutIdentityOQ04
 import Proofs.BezoutIdentityOQ04OQ01
 import Proofs.BezoutIdentityOQ04OQ01OQ01
+import Proofs.BezoutIdentityOQ04OQ01OQ03
 import Proofs.BezoutIdentityOQ04OQ02
 import Proofs.BinaryGcdOQ01
 import Proofs.BinaryGcdOQ01OQ03

--- a/proofs/Proofs/BezoutIdentityOQ04OQ01OQ03.lean
+++ b/proofs/Proofs/BezoutIdentityOQ04OQ01OQ03.lean
@@ -1,0 +1,201 @@
+/-
+  Smith Normal Form — the solvability criterion is DERIVED, not assumed
+  (bezout-identity-oq-04-oq-01-oq-03)
+
+  The parent gallery entry `bezout-identity-oq-04-oq-01` (Linear Diophantine Systems
+  via Smith Normal Form) carries TWO axioms:
+
+    * `snf_exists`               — every integer matrix A admits a decomposition
+                                   A = U * D * V with U, V unimodular and D diagonal;
+    * `snf_solvability_criterion`— A x = b is solvable over ℤ iff a divisibility
+                                   condition holds on a transformed right-hand side.
+
+  This file answers the open question "can these axioms be eliminated using Mathlib's
+  existing infrastructure?" with a precise, two-part finding:
+
+  1. **`snf_exists` is genuinely missing from Mathlib in matrix form.** Mathlib has the
+     module-theoretic Smith Normal Form (`Module.Basis.SmithNormalForm`,
+     `Submodule.smithNormalForm` in `Mathlib/LinearAlgebra/FreeModule/PID.lean`): for a
+     PID `R` and submodule `N ≤ M`, there are bases of `M` and `N` and a divisibility
+     chain of scalars `a i` with `bN i = a i • bM (f i)`. It does NOT provide the
+     *matrix* statement `D = U A V` with explicit unimodular integer matrices `U, V`.
+     Bridging the two (image-of-the-map submodule ↔ change-of-basis matrices, with the
+     change-of-basis matrices shown unimodular) is the ~hundreds-of-lines gap that made
+     the original author axiomatize `snf_exists`. We do not close that gap here.
+
+  2. **`snf_solvability_criterion` is NOT an independent assumption.** Given the
+     decomposition `A = U * D * V` (i.e. assuming only `snf_exists`), the solvability
+     criterion is a *theorem* of elementary matrix algebra — proved below with **zero
+     axioms**. Hence the parent's axiom count can drop from 2 to 1.
+
+     A subtle bookkeeping point falls out of the derivation: with the parent's own
+     convention `A = U * D * V`, the transformed right-hand side is `U⁻¹ * b`, NOT
+     `U * b`. The parent's `snf_solvability_criterion` axiom writes `snf.U.mulVec b`,
+     which is the `U⁻¹` of this convention. The corrected, derivable statement uses the
+     genuine inverse `U⁻¹`, as proved in `diophantine_solvable_iff` below.
+
+  Everything here is over a general `Fin m × Fin n` integer matrix (rectangular), so it
+  covers the parent's 1×2 Bézout specialisation as a particular case.
+
+  Verified: 0 sorries, 0 axioms (foundational `propext`/`Classical.choice`/`Quot.sound`
+  only). The decomposition itself is taken as a hypothesis, so importing this file adds
+  no assumptions.
+-/
+import Mathlib
+
+namespace BezoutIdentityOQ04OQ01OQ03
+
+open Matrix
+
+/-! ## The diagonal entry of a rectangular "diagonal" matrix
+
+We say `D : Matrix (Fin m) (Fin n) ℤ` is diagonal when `D i j = 0` whenever the index
+values differ. Its `i`-th diagonal entry `dEntry D i` is `D i ⟨i, _⟩` when the column
+`i` exists (`i < n`) and `0` otherwise. -/
+
+/-- The `i`-th diagonal entry of a (possibly rectangular) matrix: `D i i` if the column
+    index `i` is in range, else `0`. -/
+def dEntry {m n : ℕ} (D : Matrix (Fin m) (Fin n) ℤ) (i : Fin m) : ℤ :=
+  if h : (i : ℕ) < n then D i ⟨i, h⟩ else 0
+
+/-- For a diagonal matrix, `mulVec` collapses to a single product on each row:
+    `(D *ᵥ y) i = D i ⟨i,_⟩ * y ⟨i,_⟩` when `i < n`, and `0` otherwise. -/
+theorem diag_mulVec_apply {m n : ℕ} (D : Matrix (Fin m) (Fin n) ℤ)
+    (hD : ∀ i : Fin m, ∀ j : Fin n, i.val ≠ j.val → D i j = 0)
+    (y : Fin n → ℤ) (i : Fin m) :
+    (D *ᵥ y) i = if h : (i : ℕ) < n then D i ⟨i, h⟩ * y ⟨i, h⟩ else 0 := by
+  classical
+  rw [Matrix.mulVec, dotProduct]
+  by_cases h : (i : ℕ) < n
+  · rw [dif_pos h]
+    rw [Finset.sum_eq_single (⟨i, h⟩ : Fin n)]
+    · intro j _ hj
+      have : i.val ≠ j.val := by
+        intro hcontra
+        exact hj (Fin.ext hcontra.symm)
+      rw [hD i j this, zero_mul]
+    · intro hmem
+      exact absurd (Finset.mem_univ _) hmem
+  · rw [dif_neg h]
+    apply Finset.sum_eq_zero
+    intro j _
+    have : i.val ≠ j.val := by
+      intro hcontra
+      exact h (hcontra ▸ j.isLt)
+    rw [hD i j this, zero_mul]
+
+/-! ## Solvability of a diagonal system
+
+`∃ y, D *ᵥ y = c` holds iff every diagonal entry divides the corresponding component of
+`c`.  Over ℤ the divisibility `d ∣ c` already encodes both branches of the parent's
+criterion: when `d ≠ 0` it is ordinary divisibility, and when `d = 0` it is exactly
+`c = 0` (`0 ∣ c ↔ c = 0`). -/
+theorem diag_solvable_iff {m n : ℕ} (D : Matrix (Fin m) (Fin n) ℤ)
+    (hD : ∀ i : Fin m, ∀ j : Fin n, i.val ≠ j.val → D i j = 0) (c : Fin m → ℤ) :
+    (∃ y : Fin n → ℤ, D *ᵥ y = c) ↔ ∀ i : Fin m, dEntry D i ∣ c i := by
+  classical
+  constructor
+  · rintro ⟨y, rfl⟩ i
+    rw [diag_mulVec_apply D hD y i]
+    simp only [dEntry]
+    by_cases h : (i : ℕ) < n
+    · simp only [dif_pos h]; exact dvd_mul_right _ _
+    · simp only [dif_neg h]; exact dvd_zero 0
+  · intro hdiv
+    -- build the witness column vector
+    refine ⟨fun j => if hjm : (j : ℕ) < m then c ⟨j, hjm⟩ / D ⟨j, hjm⟩ j else 0, ?_⟩
+    funext i
+    rw [diag_mulVec_apply D hD _ i]
+    have hdi := hdiv i
+    simp only [dEntry] at hdi
+    by_cases h : (i : ℕ) < n
+    · simp only [dif_pos h]
+      rw [dif_pos h] at hdi
+      -- the column ⟨i, h⟩ : Fin n has value i.val < m, so the inner `if` fires
+      have him : (i : ℕ) < m := i.isLt
+      rw [dif_pos him]
+      -- ⟨i.val, him⟩ = i  in Fin m
+      have e1 : (⟨i.val, him⟩ : Fin m) = i := Fin.ext rfl
+      rw [e1]
+      rcases eq_or_ne (D i ⟨i, h⟩) 0 with hz | hz
+      · rw [hz, zero_mul]
+        rw [hz] at hdi
+        exact (zero_dvd_iff.mp hdi).symm
+      · rw [Int.mul_ediv_cancel' hdi]
+    · simp only [dif_neg h]
+      rw [dif_neg h] at hdi
+      exact (zero_dvd_iff.mp hdi).symm
+
+/-! ## The solvability criterion, derived from the decomposition
+
+This is the content of the parent's `snf_solvability_criterion` axiom, proved here as a
+theorem from `snf_exists` alone (the decomposition `A = U * D * V` is the hypothesis).
+The transformed right-hand side is the genuine inverse `U⁻¹ *ᵥ b`. -/
+
+/-- A `±1` determinant is a unit of `ℤ` (so the matrix is invertible over `ℤ`). -/
+theorem isUnit_det_of_unimodular {k : ℕ} {M : Matrix (Fin k) (Fin k) ℤ}
+    (h : M.det = 1 ∨ M.det = -1) : IsUnit M.det := by
+  rcases h with h | h
+  · rw [h]; exact isUnit_one
+  · rw [h]; exact isUnit_one.neg
+
+/-- **Solvability criterion for linear Diophantine systems** (derived, 0-axiom).
+    Given `A = U * D * V` with `U`, `V` invertible over `ℤ` and `D` diagonal, the system
+    `A x = b` is solvable over `ℤ` iff every diagonal invariant factor of `D` divides the
+    corresponding component of the transformed right-hand side `U⁻¹ * b`. -/
+theorem diophantine_solvable_iff {m n : ℕ}
+    (U : Matrix (Fin m) (Fin m) ℤ) (D : Matrix (Fin m) (Fin n) ℤ)
+    (V : Matrix (Fin n) (Fin n) ℤ) (A : Matrix (Fin m) (Fin n) ℤ) (b : Fin m → ℤ)
+    (hA : A = U * D * V) (hUdet : IsUnit U.det) (hVdet : IsUnit V.det)
+    (hD : ∀ i : Fin m, ∀ j : Fin n, i.val ≠ j.val → D i j = 0) :
+    (∃ x : Fin n → ℤ, A *ᵥ x = b) ↔ ∀ i : Fin m, dEntry D i ∣ (U⁻¹ *ᵥ b) i := by
+  rw [← diag_solvable_iff D hD (U⁻¹ *ᵥ b)]
+  constructor
+  · rintro ⟨x, hx⟩
+    refine ⟨V *ᵥ x, ?_⟩
+    have hUb : U *ᵥ (D *ᵥ (V *ᵥ x)) = b := by
+      rw [mulVec_mulVec, mulVec_mulVec, ← hA]; exact hx
+    have key : U⁻¹ *ᵥ (U *ᵥ (D *ᵥ (V *ᵥ x))) = D *ᵥ (V *ᵥ x) := by
+      rw [mulVec_mulVec (D *ᵥ (V *ᵥ x)) U⁻¹ U, nonsing_inv_mul U hUdet, one_mulVec]
+    rw [← key, hUb]
+  · rintro ⟨y, hy⟩
+    refine ⟨V⁻¹ *ᵥ y, ?_⟩
+    rw [hA]
+    have hVy : V *ᵥ (V⁻¹ *ᵥ y) = y := by
+      rw [mulVec_mulVec, mul_nonsing_inv V hVdet, one_mulVec]
+    calc (U * D * V) *ᵥ (V⁻¹ *ᵥ y)
+        = U *ᵥ (D *ᵥ (V *ᵥ (V⁻¹ *ᵥ y))) := by
+          rw [← mulVec_mulVec, ← mulVec_mulVec]
+      _ = U *ᵥ (D *ᵥ y) := by rw [hVy]
+      _ = U *ᵥ (U⁻¹ *ᵥ b) := by rw [hy]
+      _ = b := by rw [mulVec_mulVec, mul_nonsing_inv U hUdet, one_mulVec]
+
+/-- Over `ℤ`, `d ∣ c` is exactly the parent axiom's two-pronged branch condition. -/
+theorem int_dvd_iff_branches (d c : ℤ) :
+    d ∣ c ↔ (d ≠ 0 → d ∣ c) ∧ (d = 0 → c = 0) := by
+  constructor
+  · intro h
+    exact ⟨fun _ => h, fun hd => by rw [hd] at h; exact zero_dvd_iff.mp h⟩
+  · rintro ⟨h1, h2⟩
+    rcases eq_or_ne d 0 with hd | hd
+    · rw [hd, zero_dvd_iff]; exact h2 hd
+    · exact h1 hd
+
+/-- **Solvability criterion in the parent's exact two-pronged shape** (derived, 0-axiom).
+    This is `snf_solvability_criterion` from `bezout-identity-oq-04-oq-01`, but with the
+    transformed right-hand side `U⁻¹ *ᵥ b` (the genuine inverse) — the convention-correct
+    form for the decomposition `A = U * D * V`. -/
+theorem diophantine_solvable_iff_branches {m n : ℕ}
+    (U : Matrix (Fin m) (Fin m) ℤ) (D : Matrix (Fin m) (Fin n) ℤ)
+    (V : Matrix (Fin n) (Fin n) ℤ) (A : Matrix (Fin m) (Fin n) ℤ) (b : Fin m → ℤ)
+    (hA : A = U * D * V) (hUdet : IsUnit U.det) (hVdet : IsUnit V.det)
+    (hD : ∀ i : Fin m, ∀ j : Fin n, i.val ≠ j.val → D i j = 0) :
+    (∃ x : Fin n → ℤ, A *ᵥ x = b) ↔
+      ∀ i : Fin m,
+        (dEntry D i ≠ 0 → dEntry D i ∣ (U⁻¹ *ᵥ b) i) ∧
+        (dEntry D i = 0 → (U⁻¹ *ᵥ b) i = 0) := by
+  rw [diophantine_solvable_iff U D V A b hA hUdet hVdet hD]
+  exact forall_congr' fun i => int_dvd_iff_branches _ _
+
+end BezoutIdentityOQ04OQ01OQ03
+

--- a/research/problems/bezout-identity-oq-04-oq-01-oq-03/knowledge.md
+++ b/research/problems/bezout-identity-oq-04-oq-01-oq-03/knowledge.md
@@ -1,21 +1,70 @@
 # Knowledge Base: bezout-identity-oq-04-oq-01-oq-03
 
-Insights accumulated during research on this problem.
+Decide whether the two Smith-Normal-Form axioms of the parent entry
+`bezout-identity-oq-04-oq-01` (Linear Diophantine Systems via SNF) can be eliminated
+using Mathlib.
+
+## Status: COMPLETED — survey + one axiom derived away (2 → 1).
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent `bezout-identity-oq-04-oq-01` carries two `axiom` declarations:
+- `snf_exists`: every integer matrix `A` admits `A = U·D·V` with `U`, `V` unimodular and
+  `D` diagonal (the invariant-factor / Smith Normal Form).
+- `snf_solvability_criterion`: `A·x = b` solvable over `ℤ` iff a divisibility condition
+  holds on a transformed right-hand side.
+
+The open question: does Mathlib already provide the machinery to turn these into theorems?
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+**Axiom 1 — `snf_exists`: NOT available in Mathlib in matrix form.**
+Mathlib has only the *module-theoretic* SNF: `Module.Basis.SmithNormalForm` /
+`Submodule.smithNormalForm` (`Mathlib/LinearAlgebra/FreeModule/PID.lean`) — bases of `M`
+and `N ≤ M` over a PID plus a divisibility chain of scalars `a i`. There is **no**
+`Matrix.smithNormalForm` producing `D = U·A·V` with explicit unimodular integer matrices.
+Discharging `snf_exists` requires a matrix↔module bridge (realize the matrix as
+`ℤⁿ → ℤᵐ`, apply `Submodule.smithNormalForm` to its image, reconstruct unimodular
+change-of-basis *matrices*). Substantial; left in place this session.
+
+**Axiom 2 — `snf_solvability_criterion`: DERIVED, 0 axioms.**
+From the decomposition `A = U·D·V` alone, the criterion is a theorem
+(`proofs/Proofs/BezoutIdentityOQ04OQ01OQ03.lean`):
+`∃x, A·x=b ↔ ∀i, dEntry D i ∣ (U⁻¹·b) i` (`diophantine_solvable_iff`), and the same in the
+parent's two-pronged shape (`diophantine_solvable_iff_branches`). The reduction strips `U`
+(`nonsing_inv_mul`, valid over `ℤ` as `det = ±1` is a unit), strips `V` by the bijection
+`y = V·x`, and solves the diagonal system (`diag_solvable_iff`). **The parent's honest
+axiom count can drop 2 → 1.**
+
+**Convention correction.** With the convention `A = U·D·V` the transformed RHS is the
+genuine inverse `U⁻¹·b`. The parent axiom writes `snf.U·b`, which is the `U⁻¹` of this
+convention — a bookkeeping inconsistency the derivation surfaces.
+
+**Over ℤ:** the two-pronged branch `(d≠0→d∣c) ∧ (d=0→c=0)` is literally `d∣c`, since
+`0∣c ↔ c=0` (`int_dvd_iff_branches`).
 
 ---
 
-## Dead Ends
+## Files
+- `proofs/Proofs/BezoutIdentityOQ04OQ01OQ03.lean` (new; verified, 0-axiom, 6 thm/1 def, 201 L)
+- `src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/{meta.json,annotations.json,index.ts}` (new)
+- `src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json` (updated)
 
-[Approaches known not to work will be documented here]
+---
+
+## Dead Ends / Out of Scope
+
+- Did NOT attempt the full matrix↔module bridge for `snf_exists` — it is the genuine
+  ~hundreds-of-lines gap and out of scope for a single session.
+
+---
+
+## Next Steps
+1. Optionally update parent `bezout-identity-oq-04-oq-01` to import
+   `diophantine_solvable_iff` and retire `snf_solvability_criterion` (axiom 2→1), fixing the
+   `U·b → U⁻¹·b` convention.
+2. Remaining open question: close `snf_exists` via the bridge to `Submodule.smithNormalForm`.

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-diag-core",
+    "proofId": "bezout-identity-oq-04-oq-01-oq-03",
+    "range": { "startLine": 93, "endLine": 127 },
+    "type": "technique",
+    "title": "The diagonal core: solvability is entrywise divisibility",
+    "content": "**`diag_solvable_iff`**: for a rectangular *diagonal* `D`, the system `D ·ᵥ y = c` is solvable over `ℤ` iff `dEntry D i ∣ c i` for every row `i`.\n\nOver `ℤ` a single divisibility already encodes both branches of the classical criterion: when `dEntry D i ≠ 0` it is ordinary divisibility, and when `dEntry D i = 0` it is exactly `c i = 0` (since `0 ∣ x ↔ x = 0`). The **forward** direction reads divisibility off a given solution; the **backward** direction builds the witness column vector entrywise, choosing `y` on each in-range column by integer division `c / d` and closing the divisibility equation with `Int.mul_ediv_cancel'`. Out-of-range rows and columns (the rectangular slack when `m ≠ n`) carry diagonal entry `0`, where `0 ∣ c` forces `c = 0` and the contribution vanishes."
+  },
+  {
+    "id": "ann-derive-criterion",
+    "proofId": "bezout-identity-oq-04-oq-01-oq-03",
+    "range": { "startLine": 146, "endLine": 172 },
+    "type": "insight",
+    "title": "Deriving snf_solvability_criterion from snf_exists",
+    "content": "**`diophantine_solvable_iff`**: assuming only the decomposition `A = U · D · V` (the content of the parent's `snf_exists` axiom), the solvability criterion is a *theorem*, not a second axiom.\n\nThe reduction is three reversible moves: (1) `A ·ᵥ x = b ↔ U ·ᵥ (D ·ᵥ (V ·ᵥ x)) = b` by associativity (`mulVec_mulVec`); (2) strip `U` by left-multiplying with `U⁻¹` (`nonsing_inv_mul`, valid over `ℤ` because `det U = ±1` is a unit), turning the right side into `U⁻¹ ·ᵥ b`; (3) strip `V` by the change of variable `y = V ·ᵥ x`, a bijection of `ℤⁿ` since `V` is invertible. What remains is the diagonal system handled by `diag_solvable_iff`. **Consequence:** the parent entry's honest axiom count drops from 2 to 1 — only matrix-form SNF *existence* still needs to be assumed."
+  },
+  {
+    "id": "ann-convention",
+    "proofId": "bezout-identity-oq-04-oq-01-oq-03",
+    "range": { "startLine": 188, "endLine": 201 },
+    "type": "insight",
+    "title": "Convention correction: U⁻¹·b, not U·b",
+    "content": "**`diophantine_solvable_iff_branches`** restates the criterion in the parent axiom's exact two-pronged shape `(d ≠ 0 → d ∣ c) ∧ (d = 0 → c = 0)` (shown equal to `d ∣ c` over `ℤ` by `int_dvd_iff_branches`), so the comparison with `snf_solvability_criterion` is line-for-line.\n\nCarrying the proof through pins the transformed right-hand side to the *genuine inverse* `U⁻¹ ·ᵥ b` for the convention `A = U · D · V`. The parent's axiom writes `snf.U ·ᵥ b`; under `A = U·D·V` that is the `U⁻¹` of this convention, so the axiom as stated is convention-inconsistent. The derived theorem is the corrected form."
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/meta.json
@@ -1,0 +1,65 @@
+{
+  "id": "bezout-identity-oq-04-oq-01-oq-03",
+  "title": "Smith Normal Form — the Solvability Criterion is Derived, not Assumed",
+  "slug": "bezout-identity-oq-04-oq-01-oq-03",
+  "description": "Resolves the open question of whether the two Smith-Normal-Form axioms in the parent entry bezout-identity-oq-04-oq-01 (Linear Diophantine Systems via Smith Normal Form) can be eliminated using Mathlib. The finding is two-part. (1) The EXISTENCE axiom snf_exists (every integer matrix A admits a decomposition A = U·D·V with U, V unimodular and D diagonal) is genuinely missing from Mathlib in matrix form: Mathlib provides the module-theoretic Smith Normal Form (Module.Basis.SmithNormalForm, Submodule.smithNormalForm over a PID) but not the explicit unimodular-matrix factorization, so closing it requires a substantial matrix↔module bridge that is not built here. (2) The SOLVABILITY axiom snf_solvability_criterion is NOT an independent assumption: taking only the decomposition A = U·D·V as a hypothesis, the criterion 'A·x = b is solvable over ℤ iff every diagonal invariant factor divides the corresponding component of the transformed right-hand side' is a theorem of elementary matrix algebra, proved here with zero axioms (diophantine_solvable_iff and the parent-shaped diophantine_solvable_iff_branches). Hence the parent's axiom count can drop from 2 to 1. A convention correction falls out of the derivation: with the convention A = U·D·V the transformed right-hand side is the genuine inverse U⁻¹·b, not U·b as the parent axiom writes. The result is fully general over rectangular Fin m × Fin n integer matrices and so covers the parent's 1×2 Bézout specialization.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ04OQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "linear-algebra",
+      "smith-normal-form",
+      "diophantine-equations",
+      "integer-matrices",
+      "bezout",
+      "axiom-elimination",
+      "algebra"
+    ],
+    "badge": "original",
+    "mathlib_version": "4.26.0",
+    "sorries": 0,
+    "dateAdded": "2026-06-24",
+    "axiomCount": 0,
+    "lineCount": 201,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "assumptions": "None beyond the stated theorem hypotheses. The Smith Normal Form decomposition A = U·D·V (with U, V invertible over ℤ and D diagonal) is taken as an explicit hypothesis, NOT an axiom, so importing this file adds no assumptions. 0 axioms, 0 sorries, no native_decide; #print axioms reports only propext / Classical.choice / Quot.sound for diophantine_solvable_iff, diophantine_solvable_iff_branches, and diag_solvable_iff. The unimodular hypotheses are phrased as IsUnit U.det / IsUnit V.det; isUnit_det_of_unimodular records that a ±1 determinant satisfies this. The proof uses only Mathlib's mulVec/matrix-inverse API (mulVec_mulVec, nonsing_inv_mul, mul_nonsing_inv, Int.mul_ediv_cancel'). This entry deliberately does NOT prove the existence axiom snf_exists, which requires a matrix↔module bridge to Mathlib's module-theoretic Smith Normal Form that is out of scope.",
+    "originalContributions": [
+      "diophantine_solvable_iff: the Smith-Normal-Form solvability criterion as a THEOREM derived from the decomposition A = U·D·V alone. ∃x, A·x = b ↔ ∀i, dEntry D i ∣ (U⁻¹·b) i. The proof reduces the system in three reversible steps — strip U by left-multiplying by the inverse (nonsing_inv_mul), strip V by the change of variable y = V·x (V invertible), and solve the resulting diagonal system. This shows the parent's snf_solvability_criterion is not an independent axiom, lowering the parent's honest axiom count from 2 to 1.",
+      "diag_solvable_iff: the diagonal core — for a rectangular diagonal D, ∃y, D·y = c ↔ ∀i, dEntry D i ∣ c i. The forward direction reads off divisibility from a solution; the backward direction constructs the witness column vector entrywise via integer division (Int.mul_ediv_cancel'), handling out-of-range rows/columns where the diagonal entry is 0 (so 0 ∣ c forces c = 0).",
+      "diophantine_solvable_iff_branches: the criterion restated in the parent axiom's exact two-pronged shape ((d ≠ 0 → d ∣ c) ∧ (d = 0 → c = 0)), making the comparison with snf_solvability_criterion line-for-line explicit. The bridge int_dvd_iff_branches shows this two-pronged form is, over ℤ, literally d ∣ c.",
+      "Convention correction: the derivation pins the transformed right-hand side to the genuine inverse U⁻¹·b for the convention A = U·D·V. The parent's snf_solvability_criterion axiom writes snf.U·b, which is the U⁻¹ of this convention — a bookkeeping inconsistency surfaced by carrying the proof through.",
+      "diag_mulVec_apply: a reusable lemma that a rectangular diagonal matrix acts by mulVec as a single per-row product (D·y) i = D i ⟨i,_⟩ · y ⟨i,_⟩ when i < n and 0 otherwise, isolating the column index bookkeeping that the rectangular case forces."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.mulVec_mulVec",
+        "description": "M ·ᵥ N ·ᵥ v = (M * N) ·ᵥ v — associativity of matrix–vector multiplication, used to peel U and V off the decomposition A = U·D·V",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "Matrix.nonsing_inv_mul",
+        "description": "U⁻¹ * U = 1 when IsUnit U.det — strips the left unimodular factor U by left-multiplying by its inverse over ℤ",
+        "module": "Mathlib.LinearAlgebra.Matrix.NonsingularInverse"
+      },
+      {
+        "theorem": "Matrix.mul_nonsing_inv",
+        "description": "U * U⁻¹ = 1 when IsUnit U.det — the companion identity used in the reverse direction and for the change of variable y = V·x",
+        "module": "Mathlib.LinearAlgebra.Matrix.NonsingularInverse"
+      },
+      {
+        "theorem": "Int.mul_ediv_cancel'",
+        "description": "d ∣ c → d * (c / d) = c over ℤ — recovers the witness component for each diagonal equation d·yᵢ = cᵢ in the backward direction of diag_solvable_iff",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "Module.Basis.SmithNormalForm",
+        "description": "Mathlib's module-theoretic Smith Normal Form over a PID — the existing infrastructure the open question asks about; it covers the submodule/basis form but NOT the explicit unimodular-matrix factorization snf_exists needs, which is why that axiom is left in place",
+        "module": "Mathlib.LinearAlgebra.FreeModule.PID"
+      }
+    ]
+  }
+}

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "bezout-identity-oq-04-oq-01-oq-03",
   "title": "Does Mathlib's Matrix.smithNormalForm Infrastructure Cover the Axiomatized Linear Diophantine Results?",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "ACT",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-05T04:27:09-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Survey complete + solvability axiom derived (0-axiom). snf_exists left in place.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Optionally retire snf_solvability_criterion in parent (axiom 2->1).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETED (survey + partial axiom elimination). (1) snf_exists (matrix-form SNF D=U*A*V with explicit unimodular U,V) is NOT in Mathlib — only the module-theoretic SNF (Module.Basis.SmithNormalForm / Submodule.smithNormalForm over a PID) exists; the matrix<->module bridge is substantial and left in place. (2) snf_solvability_criterion is DERIVED here from the decomposition alone, 0 axioms (BezoutIdentityOQ04OQ01OQ03.lean). Parent honest axiom count can drop 2->1. Also surfaced a convention issue: parent axiom uses U*b where convention A=U*D*V requires U^{-1}*b.",
+    "builtItems": [
+      "diophantine_solvable_iff (proofs/Proofs/BezoutIdentityOQ04OQ01OQ03.lean): exists x, A*x=b <=> forall i, dEntry D i | (U^{-1}*b)_i, derived from A=U*D*V (0 axioms)",
+      "diophantine_solvable_iff_branches: same criterion in the parent axioms two-pronged shape, corrected U^{-1}*b RHS",
+      "diag_solvable_iff: exists y, D*y=c <=> forall i, dEntry D i | c_i for rectangular diagonal D",
+      "diag_mulVec_apply, int_dvd_iff_branches, isUnit_det_of_unimodular: supporting lemmas"
+    ],
+    "insights": [
+      "Mathlib SNF is module-theoretic (Module.Basis.SmithNormalForm / Submodule.smithNormalForm, Mathlib/LinearAlgebra/FreeModule/PID.lean): bases of M and N over a PID plus a divisibility chain of scalars. No Matrix.smithNormalForm producing D=U*A*V with explicit unimodular integer matrices.",
+      "Eliminating snf_exists needs the bridge: realize the integer matrix as a map Z^n -> Z^m, apply Submodule.smithNormalForm to its image, reconstruct unimodular change-of-basis matrices and prove them unimodular. ~hundreds of lines; not closed this session.",
+      "snf_solvability_criterion follows from snf_exists: A*x=b <=> U*(D*(V*x))=b <=> D*(V*x)=U^{-1}*b (strip U) <=> exists y, D*y=U^{-1}*b (strip V via bijection y=V*x) <=> forall i, dEntry D i divides (U^{-1}*b)_i (diagonal system). All steps reversible, 0-axiom over Z.",
+      "Over Z the two-pronged branch (d!=0->d|c) and (d=0->c=0) equals plain divisibility d|c, since 0|c <=> c=0.",
+      "Convention: parent writes transformed RHS as U*b, but with A=U*D*V the correct RHS is U^{-1}*b. The derived theorem uses the genuine inverse."
+    ],
+    "mathlibGaps": [
+      "No matrix-form Smith Normal Form (D = U*A*V with explicit unimodular U,V over Z) in Mathlib; only the module/submodule form Module.Basis.SmithNormalForm exists."
+    ],
+    "nextSteps": [
+      "Optionally update parent bezout-identity-oq-04-oq-01 to import diophantine_solvable_iff and retire snf_solvability_criterion (axiom 2->1), correcting U*b -> U^{-1}*b."
+    ],
     "markdown": "# Knowledge Base: bezout-identity-oq-04-oq-01-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Resolves the gallery-gap open question for `bezout-identity-oq-04-oq-01-oq-03`: *can the two Smith-Normal-Form axioms of the parent entry `bezout-identity-oq-04-oq-01` (Linear Diophantine Systems via SNF) be eliminated using Mathlib?*

**Two-part answer:**

1. **`snf_exists` (matrix form `D = U·A·V` with explicit unimodular `U,V`) is NOT in Mathlib.** Mathlib provides only the *module-theoretic* Smith Normal Form (`Module.Basis.SmithNormalForm` / `Submodule.smithNormalForm` over a PID, in `Mathlib/LinearAlgebra/FreeModule/PID.lean`). The matrix↔module bridge needed to discharge it is substantial and is **left in place**.

2. **`snf_solvability_criterion` is NOT an independent assumption.** Taking only the decomposition `A = U·D·V` as a hypothesis, the solvability criterion is derived with **0 axioms**. Hence the parent's honest axiom count can drop **2 → 1**.

**Convention correction:** carrying the proof through pins the transformed right-hand side to the genuine inverse `U⁻¹·b` for the convention `A = U·D·V`. The parent axiom writes `snf.U·b`, which is the `U⁻¹` of this convention — a bookkeeping inconsistency.

## Files
- `proofs/Proofs/BezoutIdentityOQ04OQ01OQ03.lean` (new; verified, 0-axiom, 6 thm / 1 def, 201 L)
- `src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/{meta.json,annotations.json}` (new)
- `src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json`, `research/problems/.../knowledge.md` (updated)
- `proofs/Proofs.lean` (aggregator import)

## Key results
- `diophantine_solvable_iff`: `∃x, A·x=b ↔ ∀i, dEntry D i ∣ (U⁻¹·b) i`, derived from `A=U·D·V`.
- `diophantine_solvable_iff_branches`: same in the parent axiom's exact two-pronged shape.
- `diag_solvable_iff` / `diag_mulVec_apply`: the rectangular diagonal core.

## Verification
Host `lake env lean` build: 0 errors, 0 sorries. `#print axioms` on the main results lists only `propext / Classical.choice / Quot.sound`.

## Status
**Outcome**: completed (survey + axiom 2→1 reduction). Remaining open: closing `snf_exists` via the matrix↔module bridge.

🤖 Generated by researcher-3