### PR TITLE
research(spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01): Newton's fourth power sum tr(A⁴)=λ₁⁴+λ₂⁴+λ₃⁴+λ₄⁴ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,246 @@
+import Mathlib
+import Proofs.SpectralTraceDetEigenvaluesOQ01
+
+/-
+# Spectral trace, OQ-01 → OQ-01 → OQ-02 → OQ-01: Newton's identity `tr(A⁴) = Σ λᵢ⁴` in dimension four
+
+## What this file proves
+
+The parent (`spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02`,
+`SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean`) proved Newton's **third** power sum
+`tr(A³) = e₁³ − 3 e₁ e₂ + 3 e₃` and its spectral reading `tr(A³) = λ₁³ + λ₂³ + λ₃³` for `3 × 3`
+matrices.  Its open question asks for the next power sum and the next dimension:
+
+      tr(A⁴) = e₁⁴ − 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ − 4 e₄          (Newton's identity `p₄`),
+
+read spectrally as `tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴` for `4 × 4` matrices.  This is the first
+power sum in which the elementary symmetric function `e₄ = det` finally **emerges** as an
+independent term (it is the top symmetric function at dimension four, absent from every
+`p_k` with `k < 4`), and the first whose Newton expansion involves *all four* elementary
+symmetric functions `e₁, e₂, e₃, e₄` simultaneously — including the genuinely new `e₃`, the sum
+of the four principal `3 × 3` minors.  So it is qualitatively harder than the `3 × 3` cube.
+
+## Results
+
+* `trace_quartic_fin_four` — the **matrix-side Newton identity**, over *any* commutative ring:
+
+        tr(A⁴) = (tr A)⁴ − 4 (tr A)² e₂(A) + 2 e₂(A)² + 4 (tr A) e₃(A) − 4 det A,
+
+  where `e₂(A)` is the sum of the six principal `2 × 2` minors and `e₃(A)` the sum of the four
+  principal `3 × 3` minors.  This holds with no field, no algebraic closure, and no eigenvalues —
+  it is a polynomial identity in the sixteen entries, closed by `ring`.
+
+* `det_fin_four` / `trace_fin_four` — explicit `4 × 4` determinant (cofactor expansion along the
+  top row) and trace expansions over any commutative ring, supplying the `Fin 4` analogues of
+  Mathlib's `Matrix.det_fin_three` / `Matrix.trace_fin_three`, which stop at dimension three.
+
+* `charpoly_fin_four` / `charpoly_coeff_two_eq_e2` / `charpoly_coeff_one_eq_neg_e3` — the `4 × 4`
+  characteristic polynomial in elementary-symmetric form
+  `X⁴ − (tr A) X³ + e₂(A) X² − e₃(A) X + det A`, identifying `e₂(A)` as its `X²`-coefficient and
+  `e₃(A)` as the negative of its `X¹`-coefficient.
+
+* `trace_quartic_eq_sum_fourth_eigenvalues` — the **spectral form**, over an algebraically closed
+  field: `tr(A⁴) = Σ λᵢ⁴`, the fourth power sum of the eigenvalue multiset.  The proof matches the
+  matrix-side identity to the multiset identity
+  `a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄` in the four eigenvalues, using Vieta
+  (`charpoly = ∏ (X − λᵢ)`) to identify the four elementary symmetric functions of the eigenvalues
+  with `tr A`, `e₂(A)`, `e₃(A)`, and `det A`.
+
+## Honesty / scope
+
+The matrix-side identity, the `4 × 4` determinant/charpoly expansions, and their `ring` proofs are
+routine but genuinely new at `k = 4` (Mathlib's `Fin n` matrix expansions stop at `n = 3`); the
+spectral upgrade reuses the base infrastructure (`eigenvalues`,
+`card_eigenvalues_eq_dim`, `trace_eq_sum_eigenvalues`, `det_eq_prod_eigenvalues`).  No
+`native_decide`; `#print axioms` confirms only `propext, Classical.choice, Quot.sound`.
+-/
+
+namespace SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01
+
+open Matrix Polynomial
+open SpectralTraceDetEigenvaluesOQ01 (eigenvalues)
+
+/-! ## Part I: `4 × 4` trace and determinant expansions (the `Fin 4` analogues Mathlib lacks) -/
+
+variable {R : Type*} [CommRing R]
+
+/-- The trace of a `4 × 4` matrix is the sum of its four diagonal entries.  (The `Fin 4` analogue
+of `Matrix.trace_fin_three`, which Mathlib does not provide.) -/
+theorem trace_fin_four (M : Matrix (Fin 4) (Fin 4) R) :
+    M.trace = M 0 0 + M 1 1 + M 2 2 + M 3 3 := by
+  simp [Matrix.trace, Matrix.diag, Fin.sum_univ_four]
+
+/-- **Cofactor (Laplace) expansion of the `4 × 4` determinant along the top row.**  The `Fin 4`
+analogue of `Matrix.det_fin_three`, which Mathlib does not provide. -/
+theorem det_fin_four (A : Matrix (Fin 4) (Fin 4) R) :
+    A.det =
+      A 0 0 * (A 1 1 * (A 2 2 * A 3 3 - A 2 3 * A 3 2)
+                - A 1 2 * (A 2 1 * A 3 3 - A 2 3 * A 3 1)
+                + A 1 3 * (A 2 1 * A 3 2 - A 2 2 * A 3 1))
+      - A 0 1 * (A 1 0 * (A 2 2 * A 3 3 - A 2 3 * A 3 2)
+                - A 1 2 * (A 2 0 * A 3 3 - A 2 3 * A 3 0)
+                + A 1 3 * (A 2 0 * A 3 2 - A 2 2 * A 3 0))
+      + A 0 2 * (A 1 0 * (A 2 1 * A 3 3 - A 2 3 * A 3 1)
+                - A 1 1 * (A 2 0 * A 3 3 - A 2 3 * A 3 0)
+                + A 1 3 * (A 2 0 * A 3 1 - A 2 1 * A 3 0))
+      - A 0 3 * (A 1 0 * (A 2 1 * A 3 2 - A 2 2 * A 3 1)
+                - A 1 1 * (A 2 0 * A 3 2 - A 2 2 * A 3 0)
+                + A 1 2 * (A 2 0 * A 3 1 - A 2 1 * A 3 0)) := by
+  simp [Matrix.det_succ_row_zero, Matrix.submatrix_apply, Fin.succAbove, Fin.sum_univ_succ]
+  ring
+
+/-! ## Part II: the elementary symmetric functions `e₂`, `e₃` and the matrix-side Newton identity -/
+
+/-- The **second elementary symmetric function** of a `4 × 4` matrix: the sum of its six principal
+`2 × 2` minors.  For a matrix with eigenvalues `a, b, c, d` this equals
+`ab + ac + ad + bc + bd + cd`. -/
+def e2 (A : Matrix (Fin 4) (Fin 4) R) : R :=
+  (A 0 0 * A 1 1 - A 0 1 * A 1 0)
+  + (A 0 0 * A 2 2 - A 0 2 * A 2 0)
+  + (A 0 0 * A 3 3 - A 0 3 * A 3 0)
+  + (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+  + (A 1 1 * A 3 3 - A 1 3 * A 3 1)
+  + (A 2 2 * A 3 3 - A 2 3 * A 3 2)
+
+/-- The **third elementary symmetric function** of a `4 × 4` matrix: the sum of its four principal
+`3 × 3` minors (on index sets `{0,1,2}`, `{0,1,3}`, `{0,2,3}`, `{1,2,3}`).  For a matrix with
+eigenvalues `a, b, c, d` this equals `abc + abd + acd + bcd`. -/
+def e3 (A : Matrix (Fin 4) (Fin 4) R) : R :=
+  (A 0 0 * (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+    - A 0 1 * (A 1 0 * A 2 2 - A 1 2 * A 2 0)
+    + A 0 2 * (A 1 0 * A 2 1 - A 1 1 * A 2 0))
+  + (A 0 0 * (A 1 1 * A 3 3 - A 1 3 * A 3 1)
+    - A 0 1 * (A 1 0 * A 3 3 - A 1 3 * A 3 0)
+    + A 0 3 * (A 1 0 * A 3 1 - A 1 1 * A 3 0))
+  + (A 0 0 * (A 2 2 * A 3 3 - A 2 3 * A 3 2)
+    - A 0 2 * (A 2 0 * A 3 3 - A 2 3 * A 3 0)
+    + A 0 3 * (A 2 0 * A 3 2 - A 2 2 * A 3 0))
+  + (A 1 1 * (A 2 2 * A 3 3 - A 2 3 * A 3 2)
+    - A 1 2 * (A 2 1 * A 3 3 - A 2 3 * A 3 1)
+    + A 1 3 * (A 2 1 * A 3 2 - A 2 2 * A 3 1))
+
+/-- **The matrix-side Newton identity `p₄ = e₁⁴ − 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ − 4 e₄` in dimension
+four.**  Over any commutative ring, the trace of `A⁴` is determined by the trace, the second and
+third elementary symmetric functions (the principal `2 × 2`- and `3 × 3`-minor sums), and the
+determinant of `A`:
+
+      tr(A⁴) = (tr A)⁴ − 4 (tr A)² e₂(A) + 2 e₂(A)² + 4 (tr A) e₃(A) − 4 det A.
+
+A polynomial identity in the sixteen entries, closed by `ring`. -/
+theorem trace_quartic_fin_four (A : Matrix (Fin 4) (Fin 4) R) :
+    (A ^ 4).trace
+      = A.trace ^ 4 - 4 * A.trace ^ 2 * e2 A + 2 * e2 A ^ 2
+        + 4 * A.trace * e3 A - 4 * A.det := by
+  rw [show A ^ 4 = A * A * A * A by rw [pow_succ, pow_succ, pow_succ, pow_one],
+    trace_fin_four (A * A * A * A), trace_fin_four A, det_fin_four, e2, e3]
+  simp only [Matrix.mul_apply, Fin.sum_univ_four]
+  ring
+
+/-! ## Part III: the characteristic polynomial in elementary-symmetric form -/
+
+/-- **The `4 × 4` characteristic polynomial in elementary-symmetric form.**
+`charpoly A = X⁴ − (tr A) X³ + e₂(A) X² − e₃(A) X + det A`. -/
+theorem charpoly_fin_four (A : Matrix (Fin 4) (Fin 4) R) :
+    A.charpoly = X ^ 4 - C A.trace * X ^ 3 + C (e2 A) * X ^ 2 - C (e3 A) * X + C A.det := by
+  rw [show A.charpoly = (Matrix.charmatrix A).det from rfl, det_fin_four (Matrix.charmatrix A),
+    trace_fin_four A, e2, e3, det_fin_four A]
+  simp only [Matrix.charmatrix_apply_eq, Matrix.charmatrix_apply_ne, Fin.isValue,
+    ne_eq, Fin.reduceEq, not_false_eq_true, map_add, map_sub, map_mul]
+  ring
+
+/-- `e₂(A)` is the `X²`-coefficient of the characteristic polynomial of a `4 × 4` matrix. -/
+theorem charpoly_coeff_two_eq_e2 (A : Matrix (Fin 4) (Fin 4) R) :
+    A.charpoly.coeff 2 = e2 A := by
+  rw [charpoly_fin_four]
+  simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+
+/-- `e₃(A)` is the negative of the `X¹`-coefficient of the characteristic polynomial of a
+`4 × 4` matrix. -/
+theorem charpoly_coeff_one_eq_neg_e3 (A : Matrix (Fin 4) (Fin 4) R) :
+    A.charpoly.coeff 1 = - e3 A := by
+  rw [charpoly_fin_four]
+  simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+
+/-! ## Part IV: the spectral form `tr(A⁴) = Σ λᵢ⁴` over an algebraically closed field -/
+
+variable {K : Type*} [Field K] [IsAlgClosed K]
+
+/-- A `4 × 4` matrix over an algebraically closed field has exactly four eigenvalues. -/
+theorem card_eigenvalues_fin_four (A : Matrix (Fin 4) (Fin 4) K) :
+    Multiset.card (eigenvalues A) = 4 := by
+  rw [SpectralTraceDetEigenvaluesOQ01.card_eigenvalues_eq_dim]
+  simp
+
+/-- The characteristic polynomial factors over the eigenvalues (Vieta). -/
+theorem charpoly_eq_prod_eigenvalues (A : Matrix (Fin 4) (Fin 4) K) :
+    A.charpoly = ((eigenvalues A).map (fun r => X - C r)).prod :=
+  (IsAlgClosed.splits A.charpoly).eq_prod_roots_of_monic A.charpoly_monic
+
+/-- **Newton's fourth power-sum identity, spectral form.**  Over an algebraically closed field,
+the trace of `A⁴` is the sum of the fourth powers of the eigenvalues of the `4 × 4` matrix `A`:
+
+      tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴.
+
+The proof identifies the four elementary symmetric functions of the eigenvalues `a, b, c, d` with
+`tr A = a+b+c+d`, `e₂(A) = ab+ac+ad+bc+bd+cd`, `e₃(A) = abc+abd+acd+bcd`, and `det A = abcd` (the
+first and last from the base parent, the middle two from `charpoly_coeff_two_eq_e2` /
+`charpoly_coeff_one_eq_neg_e3` + Vieta), then matches the matrix-side Newton identity
+`trace_quartic_fin_four` against the elementary multiset identity
+`a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄`. -/
+theorem trace_quartic_eq_sum_fourth_eigenvalues (A : Matrix (Fin 4) (Fin 4) K) :
+    (A ^ 4).trace = ((eigenvalues A).map (· ^ 4)).sum := by
+  obtain ⟨a, b, c, d, habcd⟩ := Multiset.card_eq_four.mp (card_eigenvalues_fin_four A)
+  -- the four elementary symmetric functions of the eigenvalues
+  have htr : A.trace = a + b + c + d := by
+    rw [SpectralTraceDetEigenvaluesOQ01.trace_eq_sum_eigenvalues, habcd]
+    simp [add_assoc]
+  have hdet : A.det = a * b * c * d := by
+    rw [SpectralTraceDetEigenvaluesOQ01.det_eq_prod_eigenvalues, habcd]
+    simp [mul_assoc]
+  have hprodexp : (X - C a) * ((X - C b) * ((X - C c) * (X - C d)))
+      = X ^ 4 - C (a + b + c + d) * X ^ 3
+        + C (a * b + a * c + a * d + b * c + b * d + c * d) * X ^ 2
+        - C (a * b * c + a * b * d + a * c * d + b * c * d) * X + C (a * b * c * d) := by
+    simp only [map_add, map_mul]; ring
+  have hcp : A.charpoly = (X - C a) * ((X - C b) * ((X - C c) * (X - C d))) := by
+    rw [charpoly_eq_prod_eigenvalues, habcd]
+    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+      Multiset.prod_cons, Multiset.prod_singleton]
+  have he2 : e2 A = a * b + a * c + a * d + b * c + b * d + c * d := by
+    have hc : A.charpoly.coeff 2 = a * b + a * c + a * d + b * c + b * d + c * d := by
+      rw [hcp, hprodexp]
+      simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+    rw [← charpoly_coeff_two_eq_e2]; exact hc
+  have he3 : e3 A = a * b * c + a * b * d + a * c * d + b * c * d := by
+    have hc : A.charpoly.coeff 1 = -(a * b * c + a * b * d + a * c * d + b * c * d) := by
+      rw [hcp, hprodexp]
+      simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+    rw [charpoly_coeff_one_eq_neg_e3] at hc
+    exact neg_injective hc
+  rw [trace_quartic_fin_four, htr, hdet, he2, he3, habcd]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  ring
+
+/-! ## Part V: a concrete illustration -/
+
+/-- For `A = !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,1,0,2]` the matrix-side identity gives `tr(A⁴)` from
+`tr A`, `e₂(A)`, `e₃(A)`, and `det A` without computing eigenvalues. -/
+theorem trace_quartic_example :
+    (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2] ^ 4).trace
+      = (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2]).trace ^ 4
+        - 4 * (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2]).trace ^ 2
+            * e2 (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2])
+        + 2 * e2 (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2]) ^ 2
+        + 4 * (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2]).trace
+            * e3 (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2])
+        - 4 * (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 1, 0, 2]).det :=
+  trace_quartic_fin_four _
+
+end SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.trace_quartic_fin_four
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.trace_quartic_eq_sum_fourth_eigenvalues
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.charpoly_fin_four

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": "ann-spectral-trace-oq01010201-00-header",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 56 },
+    "type": "context",
+    "title": "The open question: Newton's fourth power sum in dimension four",
+    "content": "The docstring states the goal carried over from the parent oq-01-oq-01-oq-02, which reached tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 matrices via Newton's p₃ = e₁³ − 3e₁e₂ + 3e₃. This file extends to the next power sum and dimension: tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, read spectrally as tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ for 4×4 matrices. The honesty note flags why the quartic is qualitatively harder: it is the first power sum whose Newton expansion involves ALL FOUR elementary symmetric functions — including the genuinely new e₃ (sum of principal 3×3 minors) and the determinant e₄ as its own independent term. The file imports Mathlib and the grandparent, opens Matrix/Polynomial, and reuses the grandparent's `eigenvalues` abbreviation.",
+    "mathContext": "Newton's identities: $p_3 = e_1^3 - 3e_1e_2 + 3e_3$, $p_4 = e_1^4 - 4e_1^2e_2 + 2e_2^2 + 4e_1e_3 - 4e_4$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Newton's identities",
+      "power sums",
+      "elementary symmetric functions",
+      "spectral mapping theorem"
+    ],
+    "prerequisites": [
+      "characteristic polynomial",
+      "eigenvalues with multiplicity"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-01-fin-four",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 63, "endLine": 90 },
+    "type": "key-step",
+    "title": "4×4 trace and determinant expansions Mathlib does not provide",
+    "content": "Mathlib's entrywise matrix expansions stop at dimension three (trace_fin_three, det_fin_three). The file first builds their Fin 4 analogues. `trace_fin_four` proves trace = A 0 0 + A 1 1 + A 2 2 + A 3 3 by unfolding the trace/diag definitions with Fin.sum_univ_four. `det_fin_four` proves the full cofactor (Laplace) expansion of the 4×4 determinant along the top row, using Matrix.det_succ_row_zero to recurse to four 3×3 minors and closing by `ring`. These supply the explicit sixteen-entry building blocks every later result needs.",
+    "mathContext": "$\\det A = \\sum_{j} (-1)^j A_{0j} \\det(\\widehat{A}_{0j})$, the Laplace expansion along row 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cofactor expansion",
+      "Laplace expansion",
+      "determinant"
+    ],
+    "prerequisites": [
+      "Matrix.det_succ_row_zero",
+      "Fin.sum_univ_four"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-02-matrix-newton",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 92, "endLine": 137 },
+    "type": "key-step",
+    "title": "The matrix-side Newton identity over any commutative ring",
+    "content": "`e2` defines the second elementary symmetric function of a 4×4 matrix as the sum of its six principal 2×2 minors; `e3` defines the third as the sum of its four principal 3×3 minors (on index sets {0,1,2}, {0,1,3}, {0,2,3}, {1,2,3}). `trace_quartic_fin_four` then proves tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A. The proof unfolds A⁴ as a quadruple product (pow_succ), expands trace, det, and the matrix multiplications entrywise via trace_fin_four, det_fin_four, Matrix.mul_apply, Fin.sum_univ_four, then closes by `ring`. This is a polynomial identity in the sixteen entries — no field, no algebraic closure, no eigenvalues.",
+    "mathContext": "$\\operatorname{tr}(A^4) = (\\operatorname{tr}A)^4 - 4(\\operatorname{tr}A)^2 e_2(A) + 2e_2(A)^2 + 4(\\operatorname{tr}A)e_3(A) - 4\\det A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Newton's identities",
+      "principal minors",
+      "elementary symmetric functions",
+      "polynomial identity"
+    ],
+    "prerequisites": [
+      "Matrix.mul_apply",
+      "trace of a power"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-03-charpoly",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 139, "endLine": 167 },
+    "type": "key-step",
+    "title": "The characteristic polynomial in elementary-symmetric form",
+    "content": "`charpoly_fin_four` proves charpoly = X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, expanding det(X·I − A) entrywise with charmatrix and det_fin_four and ring-normalising. Reading off coefficients gives `charpoly_coeff_two_eq_e2` (the X²-coefficient is e₂(A)) and `charpoly_coeff_one_eq_neg_e3` (the X¹-coefficient is −e₃(A)). These are the two bridges identifying the principal-minor sums with the second and third elementary symmetric functions of the eigenvalues via Vieta.",
+    "mathContext": "$\\chi_A(X) = X^4 - (\\operatorname{tr}A)X^3 + e_2(A)X^2 - e_3(A)X + \\det A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "characteristic polynomial",
+      "Vieta's formulas",
+      "charmatrix"
+    ],
+    "prerequisites": [
+      "Matrix.charmatrix",
+      "polynomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-04-spectral",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 169, "endLine": 227 },
+    "type": "key-step",
+    "title": "The spectral form tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴",
+    "content": "`card_eigenvalues_fin_four` shows a 4×4 matrix has exactly four eigenvalues (from the grandparent's card_eigenvalues_eq_dim); `charpoly_eq_prod_eigenvalues` factors charpoly = Π(X − λᵢ) (Vieta). `trace_quartic_eq_sum_fourth_eigenvalues` then proves, over an algebraically closed field, tr(A⁴) = Σλᵢ⁴. The four elementary symmetric functions of the eigenvalues a,b,c,d are read from trace (grandparent), the X²- and X¹-coefficients of the charpoly (via charpoly_coeff_two_eq_e2 and charpoly_coeff_one_eq_neg_e3 against the explicit quartic factorisation), and det = abcd (grandparent). Substituting into the matrix-side identity and matching against a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ closes by `ring`.",
+    "mathContext": "$\\operatorname{tr}(A^4) = \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4 + \\lambda_4^4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral mapping theorem",
+      "Vieta's formulas",
+      "algebraically closed field"
+    ],
+    "prerequisites": [
+      "IsAlgClosed.splits",
+      "Multiset.card_eq_four"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-05-example",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 229, "endLine": 246 },
+    "type": "observation",
+    "title": "A concrete 4×4 rational illustration",
+    "content": "`trace_quartic_example`: for !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,1,0,2] over ℚ the matrix-side identity recovers tr(A⁴) from tr A, the two minor sums e₂(A) and e₃(A), and det A, without computing the (generically irrational/complex) eigenvalues — a rational invariant of an unknowable spectrum. The closing #print axioms audit confirms the three headline theorems depend only on the foundational propext/Classical.choice/Quot.sound, with no Lean.ofReduceBool (no native_decide) and no sorryAx.",
+    "mathContext": "$\\operatorname{tr}(A^4)$ forced by $\\operatorname{tr}A,\\ e_2(A),\\ e_3(A),\\ \\det A$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "axiom audit"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Data: ProofData = {
+  proof: spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Proof,
+  annotations: spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Annotations,
+}

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+  "title": "Newton's Fourth Power Sum: tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ for 4×4 Matrices",
+  "slug": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+  "description": "Settles the open question posed by spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02 (openQuestions[0]): carry the matrix-side-then-spectral template to the fourth power sum, tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, read spectrally as tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ for 4×4 matrices. This is the first Newton power sum in which the top elementary symmetric function e₄ = det finally emerges as an independent term, and the first whose expansion involves ALL FOUR elementary symmetric functions e₁, e₂, e₃, e₄ simultaneously — including the genuinely new e₃, the sum of the four principal 3×3 minors. Four results: (1) trace_quartic_fin_four — the matrix-side Newton identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over ANY commutative ring, a polynomial identity in the sixteen entries closed by ring, with no field, no algebraic closure, and no eigenvalues; (2) det_fin_four / trace_fin_four — the explicit 4×4 determinant (cofactor expansion along the top row) and trace expansions, the Fin 4 analogues of Mathlib's det_fin_three / trace_fin_three which stop at dimension three; (3) charpoly_fin_four / charpoly_coeff_two_eq_e2 / charpoly_coeff_one_eq_neg_e3 — the 4×4 characteristic polynomial in elementary-symmetric form X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, identifying e₂(A) as its X²-coefficient and e₃(A) as the negative of its X¹-coefficient; (4) trace_quartic_eq_sum_fourth_eigenvalues — the spectral form tr(A⁴) = Σλᵢ⁴ over an algebraically closed field, matching the matrix-side identity to the multiset identity a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ via Vieta. A concrete rational 4×4 example reads tr(A⁴) off from trace, the two minor sums, and determinant without computing eigenvalues. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Newton's identities; spectral mapping theorem); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "eigenvalues",
+      "characteristic-polynomial",
+      "trace",
+      "determinant",
+      "power-sums",
+      "newtons-identities",
+      "spectral-mapping",
+      "symmetric-functions",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_succ_row_zero",
+        "description": "Laplace (cofactor) expansion of a determinant along the top row, recursively reducing the 4×4 determinant to four 3×3 minors. Drives det_fin_four, the explicit 16-entry determinant Mathlib does not provide beyond dimension three.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.charmatrix",
+        "description": "the matrix X·I − A whose determinant is the characteristic polynomial; charmatrix_apply_eq and charmatrix_apply_ne expand the 4×4 charpoly entrywise so that det_fin_four yields the elementary-symmetric form X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "IsAlgClosed.splits_codomain",
+        "description": "over an algebraically closed field every polynomial splits; combined with eq_prod_roots_of_monic and the monic charpoly it factors A.charpoly = Π(X − λᵢ) over the eigenvalue multiset (Vieta), supplying the spectral identification of e₂ with ab+ac+ad+bc+bd+cd and e₃ with abc+abd+acd+bcd.",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Multiset.card_eq_four",
+        "description": "a multiset has cardinality four iff it equals {a, b, c, d}. Reduces the 4×4 spectral trace power sum to the four-variable Newton identity a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄.",
+        "module": "Mathlib.Data.Multiset.ZeroCons"
+      },
+      {
+        "theorem": "Fin.sum_univ_four",
+        "description": "expands a sum over Fin 4 into four explicit terms; together with Matrix.mul_apply it unfolds (A⁴).trace into the 256-monomial polynomial in the sixteen entries that the matrix-side Newton identity normalises by ring.",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      }
+    ],
+    "originalContributions": [
+      "trace_quartic_fin_four: the matrix-side Newton identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over ANY commutative ring — a polynomial identity in the sixteen entries closed by ring, needing no field, no algebraic closure, and no eigenvalues; the fourth power sum p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ at the matrix level, the first to make the determinant e₄ an independent term",
+      "det_fin_four: the explicit 4×4 determinant as a cofactor expansion along the top row in the sixteen entries — the Fin 4 analogue of Mathlib's det_fin_three, which stops at dimension three",
+      "trace_fin_four: the 4×4 trace as the sum of the four diagonal entries, the Fin 4 analogue of Mathlib's trace_fin_three",
+      "e3: the third elementary symmetric function of a 4×4 matrix as the sum of its four principal 3×3 minors, the genuinely new symmetric function appearing for the first time at the fourth power sum (neither trace, nor minor-pair sum, nor determinant)",
+      "charpoly_fin_four: the 4×4 characteristic polynomial in elementary-symmetric form X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, derived entrywise from charmatrix and det_fin_four",
+      "charpoly_coeff_two_eq_e2 / charpoly_coeff_one_eq_neg_e3: e₂(A) is the X²-coefficient and e₃(A) the negative of the X¹-coefficient of the characteristic polynomial, the bridges that identify the two minor sums with the spectral symmetric functions ab+ac+ad+bc+bd+cd and abc+abd+acd+bcd via Vieta",
+      "trace_quartic_eq_sum_fourth_eigenvalues: the spectral form tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ over an algebraically closed field — the first power sum whose Newton expansion involves all four elementary symmetric functions including the new e₄ = det, settling the parent entry's open question",
+      "trace_quartic_example: for the rational matrix !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,1,0,2] the matrix-side identity recovers tr(A⁴) from tr A, the two minor sums e₂(A), e₃(A), and det A without ever computing the eigenvalues"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 246,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; #print axioms confirms the three headline theorems depend on no Lean.ofReduceBool or sorryAx. The matrix-side identity trace_quartic_fin_four and the charpoly form charpoly_fin_four hold over any commutative ring; the spectral form trace_quartic_eq_sum_fourth_eigenvalues requires an algebraically closed field (so the characteristic polynomial splits and the eigenvalue multiset has exactly four elements). SCOPE: this entry proves the k=4 power sum in dimension n=4. The general trace power sum tr(Aᵏ) = Σλᵢᵏ for all n and k remains the standing open question (it requires the full multiset spectral mapping, absent from the Mathlib snapshot used here).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Isaac Newton, c. 1666; also Girard) express the power sums pₖ = Σλᵢᵏ through the elementary symmetric functions eⱼ: p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃, p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄. For the eigenvalues of a matrix the eⱼ are (up to sign) the coefficients of the characteristic polynomial — e₁ = trace, eₙ = determinant, and the intermediate eⱼ the sums of principal j×j minors. The power sums pₖ are the traces tr(Aᵏ), the trace half of the spectral mapping theorem spec(p(A)) = p(spec(A)). The grandparent oq-01 pinned down e₁ = trace and eₙ = det; oq-01-oq-01 settled p₂ for 2×2 matrices; the parent oq-01-oq-01-oq-02 settled the cube p₃ for 3×3 matrices, the first power sum to need the middle symmetric function e₂. The fourth power p₄ in dimension four is the first to involve all four elementary symmetric functions at once, and the first in which the determinant e₄ appears as its own term rather than as the top symmetric function of a smaller matrix.",
+    "problemStatement": "**Open Question (spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02, openQuestions[0])**: Carry the same matrix-side-then-spectral template to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ in dimension four, the first power sum to involve all four elementary symmetric functions including the new e₄ = det.\n\n**Result**: trace_quartic_fin_four establishes the matrix-side identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over any commutative ring; trace_quartic_eq_sum_fourth_eigenvalues upgrades it to the spectral statement tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ over an algebraically closed field, with e₂(A) and e₃(A) identified as both principal-minor sums and (signed) coefficients of the characteristic polynomial.",
+    "text": "Let A be a 4×4 matrix. Write e₁(A) = tr A, e₂(A) for the sum of the six principal 2×2 minors, e₃(A) for the sum of the four principal 3×3 minors, and e₄(A) = det A. Newton's fourth identity gives tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ as a polynomial identity in the sixteen entries, valid over any commutative ring. Over an algebraically closed field the characteristic polynomial X⁴ − e₁X³ + e₂X² − e₃X + e₄ splits as Π(X − λᵢ), so e₁ = Σλᵢ, e₂ = Σλᵢλⱼ, e₃ = Σλᵢλⱼλₖ, e₄ = λ₁λ₂λ₃λ₄, and the identity becomes the spectral power sum tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Fin-4 expansions (any commutative ring): Mathlib's matrix expansions stop at dimension three, so the file first supplies trace_fin_four (trace = sum of four diagonal entries, from the definition and Fin.sum_univ_four) and det_fin_four (cofactor expansion along the top row via Matrix.det_succ_row_zero, closed by ring).\n\n2. Matrix-side identity (any commutative ring): define e₂(A) as the sum of the six principal 2×2 minors and e₃(A) as the sum of the four principal 3×3 minors. Expand (A⁴).trace via trace_fin_four, Matrix.mul_apply, and Fin.sum_univ_four into a polynomial in the sixteen entries; the identity tr(A⁴) = (tr A)⁴ − 4(tr A)²e₂ + 2e₂² + 4(tr A)e₃ − 4 det A then closes by ring. No eigenvalues, no field.\n\n3. Characteristic polynomial in elementary-symmetric form: expand charpoly = det(X·I − A) entrywise with charmatrix and det_fin_four, then ring-normalise to X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A. Reading off coefficients gives charpoly_coeff_two_eq_e2 (X²-coefficient is e₂) and charpoly_coeff_one_eq_neg_e3 (X¹-coefficient is −e₃).\n\n4. Spectral upgrade (algebraically closed field): the eigenvalue multiset has exactly four elements (card_eigenvalues_fin_four, from the grandparent's card_eigenvalues_eq_dim). Vieta (charpoly = Π(X − λᵢ)) identifies the four elementary symmetric functions of the eigenvalues a,b,c,d with tr A (grandparent), e₂(A) and e₃(A) (from the coefficient bridges and the explicit quartic factorisation), and det A = abcd (grandparent). Substituting into the matrix-side identity and matching against a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ yields tr(A⁴) = a⁴+b⁴+c⁴+d⁴.\n\n5. Example: instantiate trace_quartic_fin_four at !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,1,0,2] over ℚ, recovering tr(A⁴) from tr A, the two minor sums, and det A.",
+    "keyInsights": [
+      "**The fourth power is the first in which the determinant emerges as its own term.** At p₂ the determinant is e₂ (the top symmetric function of a 2×2 matrix); at p₃ it is e₃. Only at p₄ in dimension four does e₄ = det appear as a genuinely independent coefficient alongside e₁, e₂, e₃, and only here does the brand-new e₃ (sum of principal 3×3 minors) enter. The quartic is the first power sum whose Newton expansion uses all four elementary symmetric functions simultaneously.",
+      "**Mathlib's matrix expansions stop at dimension three.** Mathlib provides trace_fin_three and det_fin_three but no Fin 4 analogues. The proof therefore builds det_fin_four (cofactor expansion along the top row via det_succ_row_zero) and trace_fin_four from scratch — reusable infrastructure for any 4×4 entrywise computation, not just this power sum.",
+      "**e₂ and e₃ each wear two hats: minor sum and charpoly coefficient.** The proof identifies e₂(A) — the sum of the six principal 2×2 minors — with the X²-coefficient of the characteristic polynomial, and e₃(A) — the sum of the four principal 3×3 minors — with the negative X¹-coefficient. These are the bridges that turn the matrix-side identity into a spectral one: by Vieta the X²- and X¹-coefficients are the second and third elementary symmetric functions of the eigenvalues.",
+      "**The matrix-side identity is ring-universal; algebraic closure enters only for the spectral reading.** tr(A⁴) = (tr A)⁴ − 4(tr A)²e₂ + 2e₂² + 4(tr A)e₃ − 4 det A is a polynomial identity in the sixteen entries, true over ℤ, ℚ, any commutative ring — provable by ring with no eigenvalues. A field and algebraic closure are needed only to factor the characteristic polynomial and rewrite the same quantity as λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴."
+    ],
+    "prerequisites": [
+      "The characteristic polynomial and its roots as eigenvalues with algebraic multiplicity (spectral-trace-det-eigenvalues-oq-01)",
+      "Newton's third power sum tr(A³) = λ₁³ + λ₂³ + λ₃³ and the matrix-side-then-spectral template (spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02)",
+      "Newton's identities relating power sums to elementary symmetric functions; Vieta's formulas for a monic quartic; cofactor expansion of determinants"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Open Question",
+      "startLine": 4,
+      "endLine": 56,
+      "summary": "Module docstring stating the goal carried over from the parent oq-01-oq-01-oq-02: extend the cube power sum to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ and its spectral reading tr(A⁴) = Σλᵢ⁴ for 4×4 matrices, with the honesty note that the quartic is the first power sum involving all four elementary symmetric functions including the new e₄ = det; imports Mathlib and the grandparent file, opens Matrix/Polynomial, reuses the grandparent's eigenvalues abbreviation.",
+      "mathContext": "$p_4 = e_1^4 - 4e_1^2e_2 + 2e_2^2 + 4e_1e_3 - 4e_4$."
+    },
+    {
+      "id": "fin-four-expansions",
+      "title": "4×4 Trace and Determinant Expansions (the Fin 4 analogues Mathlib lacks)",
+      "startLine": 63,
+      "endLine": 90,
+      "summary": "trace_fin_four (trace = A 0 0 + A 1 1 + A 2 2 + A 3 3, from the trace/diag definition and Fin.sum_univ_four) and det_fin_four (cofactor expansion along the top row via Matrix.det_succ_row_zero, closed by ring) — the dimension-four analogues of Mathlib's trace_fin_three / det_fin_three, which stop at dimension three.",
+      "mathContext": "$\\det A$ as a Laplace expansion along the top row in the sixteen entries."
+    },
+    {
+      "id": "matrix-newton",
+      "title": "The Elementary Symmetric Functions and the Matrix-Side Newton Identity",
+      "startLine": 92,
+      "endLine": 137,
+      "summary": "e2 (sum of the six principal 2×2 minors), e3 (sum of the four principal 3×3 minors), and trace_quartic_fin_four: tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A, a polynomial identity in the sixteen entries over any commutative ring, expanded by trace_fin_four/det_fin_four/mul_apply/Fin.sum_univ_four and closed by ring.",
+      "mathContext": "$\\operatorname{tr}(A^4) = (\\operatorname{tr}A)^4 - 4(\\operatorname{tr}A)^2 e_2 + 2e_2^2 + 4(\\operatorname{tr}A)e_3 - 4\\det A$."
+    },
+    {
+      "id": "charpoly",
+      "title": "The Characteristic Polynomial in Elementary-Symmetric Form",
+      "startLine": 139,
+      "endLine": 167,
+      "summary": "charpoly_fin_four (charpoly = X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, expanded entrywise from charmatrix and det_fin_four), charpoly_coeff_two_eq_e2 (e₂(A) is the X²-coefficient), and charpoly_coeff_one_eq_neg_e3 (e₃(A) is the negative X¹-coefficient), the bridges identifying the two minor sums with the second and third symmetric functions of the eigenvalues.",
+      "mathContext": "$\\chi_A(X) = X^4 - (\\operatorname{tr}A)X^3 + e_2(A)X^2 - e_3(A)X + \\det A$."
+    },
+    {
+      "id": "spectral",
+      "title": "The Spectral Form tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴",
+      "startLine": 169,
+      "endLine": 227,
+      "summary": "card_eigenvalues_fin_four (a 4×4 matrix has exactly four eigenvalues), charpoly_eq_prod_eigenvalues (Vieta), and trace_quartic_eq_sum_fourth_eigenvalues: over an algebraically closed field tr(A⁴) = Σλᵢ⁴, matching the matrix-side identity to a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ with e₁,e₂,e₃,e₄ read from trace, the X²- and X¹-coefficients, and det.",
+      "mathContext": "$\\operatorname{tr}(A^4) = \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4 + \\lambda_4^4$."
+    },
+    {
+      "id": "example",
+      "title": "A Concrete 4×4 Rational Illustration",
+      "startLine": 229,
+      "endLine": 246,
+      "summary": "trace_quartic_example: for !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,1,0,2] over ℚ the matrix-side identity recovers tr(A⁴) from tr A, the two minor sums e₂(A), e₃(A), and det A, without computing the eigenvalues; #print axioms audit confirms only the foundational axioms.",
+      "mathContext": "$\\operatorname{tr}(A^4)$ from $\\operatorname{tr}A,\\ e_2(A),\\ e_3(A),\\ \\det A$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+      "relationship": "Direct parent: settled the 3×3 cube power sum tr(A³) = λ₁³ + λ₂³ + λ₃³ via Newton's p₃ = e₁³ − 3e₁e₂ + 3e₃ and explicitly posed (openQuestions[0]) the extension to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ in dimension four that this entry takes up, reusing the same matrix-side-then-spectral template."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "relationship": "Grandparent: establishes trace = Σλ, determinant = Πλ, the eigenvalue count (card_eigenvalues_eq_dim), and the Vieta correspondence reused here to identify e₁ and e₄ of the spectrum with trace and determinant."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "relationship": "Sibling on cyclic invariance of the trace and similarity-invariance of the eigenvalue multiset; the fourth power sum tr(A⁴) is similarity-invariant for the same reason (conjugation preserves the characteristic polynomial)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of Newton's fourth power sum in dimension four: the matrix-side identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over any commutative ring, and its spectral upgrade tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ over an algebraically closed field, with the minor sums e₂ and e₃ identified as the X²- and (negated) X¹-coefficients of the characteristic polynomial. Supplies det_fin_four and trace_fin_four, the dimension-four matrix expansions Mathlib lacks.",
+    "implications": "Settles the parent entry's open question by carrying Newton's identities to the first power sum (p₄, dimension 4) whose expansion uses all four elementary symmetric functions, including the new e₃ and the determinant e₄ as an independent term. The clean separation — a ring-universal matrix-side identity closed by ring, then an algebraic-closure-only spectral reading via Vieta — extends the parent's reusable template, and det_fin_four/trace_fin_four fill a concrete Mathlib gap at dimension four. The remaining obstruction to the all-dimensions trace power sum tr(Aᵏ) = Σλᵢᵏ is unchanged: the full multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), absent from the Mathlib snapshot.",
+    "openQuestions": [
+      "Prove the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions n, equivalently the multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), by building Schur triangulation or a uniform Newton-identity bridge from charpoly coefficients to root power sums — replacing the fixed-dimension brute-force ring identities by a dimension-general argument.",
+      "Formalize the full Newton recursion pₖ = e₁pₖ₋₁ − e₂pₖ₋₂ + ⋯ + (−1)ᵏ⁻¹k·eₖ relating successive power sums and elementary symmetric functions, from which every fixed-dimension identity (p₂, p₃, p₄, …) would follow uniformly rather than being re-derived by ring at each level."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SpectralTraceDetEigenvaluesOQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01",
+    "lineCount": 246,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2012",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for Newton's identities relating trace power sums to characteristic-polynomial coefficients, and the trace/determinant/minor sums as elementary symmetric functions of the eigenvalues."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic and Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of det_succ_row_zero (cofactor expansion), the charmatrix construction for the characteristic polynomial, and the splitting of polynomials over an algebraically closed field used for the spectral form."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,145 @@
+{
+  "slug": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+  "title": "Newton's Fourth Power Sum — tr(A⁴) and the Emergence of e₄ = det",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\operatorname{tr}(A^4) \\;=\\; e_1^4 - 4e_1^2 e_2 + 2e_2^2 + 4e_1 e_3 - 4e_4\n\\;=\\; \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4 + \\lambda_4^4.",
+    "plain": "The parent (`spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02`) proved Newton's **third** power",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-24T23:07:30-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Verified, 0-axiom, 0-sorry Lean 4 formalization of Newton fourth power sum tr(A⁴)=Σλᵢ⁴ for 4×4 matrices, settling parent oq-01-oq-01-oq-02 openQuestions[0].",
+    "builtItems": [
+      "trace_quartic_fin_four (Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean): matrix-side Newton p₄ over any CommRing",
+      "det_fin_four / trace_fin_four: the Fin 4 determinant (cofactor) and trace expansions Mathlib lacks",
+      "charpoly_fin_four / charpoly_coeff_two_eq_e2 / charpoly_coeff_one_eq_neg_e3: 4×4 charpoly in elementary-symmetric form X⁴−e₁X³+e₂X²−e₃X+e₄",
+      "trace_quartic_eq_sum_fourth_eigenvalues: spectral form tr(A⁴)=λ₁⁴+λ₂⁴+λ₃⁴+λ₄⁴ over an algebraically closed field"
+    ],
+    "insights": [
+      "The quartic p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ is the first Newton power sum to involve ALL FOUR elementary symmetric functions, including the new e₃ (sum of principal 3×3 minors) and the determinant e₄ as an independent term.",
+      "Mathlib provides trace_fin_three / det_fin_three but NO Fin 4 analogues; det_fin_four must be built via Matrix.det_succ_row_zero (cofactor expansion along row 0) + ring, and trace_fin_four from the trace/diag definition + Fin.sum_univ_four.",
+      "The heavy 16-variable ring identity tr(A⁴)=(trA)⁴−4(trA)²e₂+2e₂²+4(trA)e₃−4detA (expanding (A⁴).trace into 256 monomials via mul_apply + Fin.sum_univ_four) compiles in ~10s within DEFAULT heartbeats — no maxHeartbeats bump needed.",
+      "e₂ and e₃ are each identified with charpoly coefficients (X²-coeff = e₂; X¹-coeff = −e₃) via charpoly_fin_four = det(charmatrix) expanded by det_fin_four; this is the bridge from minor sums to the eigenvalue symmetric functions via Vieta and Multiset.card_eq_four."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no Matrix.det_fin_four or Matrix.trace_fin_four (entrywise expansions stop at dimension three); built locally here.",
+      "No general multiset spectral-mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), so each fixed-dimension trace power sum is still a brute-force ring identity."
+    ],
+    "nextSteps": [
+      "Generalize to tr(Aᵏ)=Σλᵢᵏ for all n,k via Schur triangulation or a charpoly-coefficient-to-power-sum Newton recursion, replacing the per-dimension ring identities.",
+      "Formalize the full Newton recursion pₖ = e₁pₖ₋₁ − e₂pₖ₋₂ + … + (−1)ᵏ⁻¹ k·eₖ."
+    ],
+    "markdown": "# Knowledge Base: spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "linear-algebra",
+    "matrix-theory",
+    "newton-identities",
+    "symmetric-functions",
+    "trace",
+    "determinant"
+  ],
+  "relatedProofs": [
+    "spectral-trace-det-eigenvalues-oq-01",
+    "spectral-trace-det-eigenvalues-oq-01-oq-01",
+    "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+    "spectral-trace-det-eigenvalues-oq-02",
+    "spectral-trace-det-eigenvalues-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T06:14:37.639Z",
+  "lastUpdate": "2026-06-25T06:14:37.672Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/SpectralTraceDetEigenvaluesOQ01.lean",
+      "filename": "SpectralTraceDetEigenvaluesOQ01.lean",
+      "lineCount": 133,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01.lean"
+    },
+    {
+      "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean",
+      "filename": "SpectralTraceDetEigenvaluesOQ01OQ01.lean",
+      "lineCount": 156,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean",
+      "filename": "SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean",
+      "lineCount": 172,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean",
+      "filename": "SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 247,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/SpectralTraceDetEigenvaluesOQ02.lean",
+      "filename": "SpectralTraceDetEigenvaluesOQ02.lean",
+      "lineCount": 205,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ02.lean"
+    },
+    {
+      "path": "Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean",
+      "filename": "SpectralTraceDetEigenvaluesOQ02OQ01.lean",
+      "lineCount": 164,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpectralTraceDetEigenvaluesOQ02OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Settles the open question posed by the parent `spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02` (openQuestions[0]): carry the matrix-side-then-spectral template to **Newton's fourth power sum**

```
tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄   (Newton's p₄),
```

read spectrally as `tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴` for 4×4 matrices. This is the first power sum whose Newton expansion involves **all four** elementary symmetric functions simultaneously — including the genuinely new `e₃` (sum of the four principal 3×3 minors) and the determinant `e₄` as an independent term.

## Results (`Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean`, 10 thm / 2 def / 246 L)

- **`trace_quartic_fin_four`** — matrix-side Newton identity `tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A` over **any commutative ring**; a polynomial identity in the sixteen entries closed by `ring`, with no field, no algebraic closure, no eigenvalues.
- **`det_fin_four` / `trace_fin_four`** — the explicit 4×4 determinant (cofactor expansion along the top row) and trace expansions, the `Fin 4` analogues of Mathlib's `det_fin_three` / `trace_fin_three`, which stop at dimension three.
- **`charpoly_fin_four` / `charpoly_coeff_two_eq_e2` / `charpoly_coeff_one_eq_neg_e3`** — the 4×4 characteristic polynomial in elementary-symmetric form `X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A`, identifying `e₂(A)` as the X²-coefficient and `e₃(A)` as the negated X¹-coefficient.
- **`trace_quartic_eq_sum_fourth_eigenvalues`** — spectral form `tr(A⁴) = Σλᵢ⁴` over an algebraically closed field, matching the matrix-side identity to the four-variable multiset identity `a⁴+b⁴+c⁴+d⁴ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄` via Vieta (`Multiset.card_eq_four`).
- A concrete rational 4×4 example reads `tr(A⁴)` off from trace, the two minor sums, and determinant without computing eigenvalues.

## Verification

- **0 sorries, 0 axioms, 0 native_decide.** `#print axioms` confirms the three headline theorems depend only on `propext, Classical.choice, Quot.sound`.
- Builds against Mathlib 4.26.0 via host `lake env lean` (clean, ~10s).
- Status `verified`, badge `original`. (Aggregator `Proofs.lean` import regenerated at deploy, consistent with sibling spectral leaves.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)