### PR TITLE
research(amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02): Newton–Girard k=6 closed form over any CommRing [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -86,6 +86,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03Finset
 import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02
 import Proofs.AmgmInequalityOQ02OQ01OQ04
 import Proofs.AmgmInequalityOQ02OQ01OQ05
 import Proofs.AmgmInequalityOQ02OQ02

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02.lean
@@ -1,0 +1,221 @@
+/-
+  Newton–Girard k=6 Closed Form:
+      p₆ = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃²
+             − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆.
+
+  Open Question (amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02), the next rung after
+  the k=5 closed form `amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01`.
+
+  Establish the fully reduced k=6 Newton–Girard identity expressing the sixth power sum
+  p₆ purely in terms of the elementary symmetric polynomials e₁, …, e₆:
+      p₆ = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃²
+             − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆.
+  For concrete values (a Finset) this is the symmetric-function form of
+      a⁶+b⁶+c⁶+d⁶+e⁶+g⁶
+        = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃²
+             − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆.
+
+  Lineage:
+  • Parent     amgm-inequality-oq-02-oq-01             : k=2 identity p₂ = e₁² − 2e₂.
+  • Recurrence amgm-inequality-oq-02-oq-01-oq-02-oq-01 : p₃ recurrence and the k=1,2 corollaries.
+  • k=3 closed amgm-inequality-oq-02-oq-01-oq-03       : `psum_three_closed`.
+  • k=4 closed amgm-inequality-oq-02-oq-01-oq-03-oq-01 : `psum_four_closed`.
+  • k=5 closed amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01 : `psum_five_closed` + the concrete
+                                                         general-Finset form `newton_girard_five_finset`
+                                                         and the e₅/p₅ aeval bridges.
+
+  This file adds the next rung.  Two complementary forms, each 0-sorry / 0-axiom:
+
+  (1) UNIVERSAL (MvPolynomial).  `psum_six_recurrence` extracts the k=6 Newton recurrence
+        p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆
+      directly from `MvPolynomial.psum_eq_mul_esymm_sub_sum` (antidiagonal filter
+      {(1,5),(2,4),(3,3),(4,2),(5,1)}, lead term (−1)⁷·6·e₆ = −6·e₆).  Substituting the proven
+      closed forms for p₅, p₄, p₃, p₂, p₁ and ring-normalising yields `psum_six_closed`.
+
+  (2) CONCRETE general-Finset, over an ARBITRARY CommRing (every characteristic included).
+      Reusing the already-built, n-general `aeval` bridges (`aeval_psum_subtype`,
+      `aeval_esymm_subtype`) and the e₁..e₅ bridges from the ancestor files, the universal
+      closed form transports onto the subtype {x // x ∈ s} to give `newton_girard_six_finset`
+      with the e₆/p₆ bridge lemmas instantiated at n=6.  No characteristic hypothesis is
+      required — the same transport that bypassed the char-2 obstruction at k=3 works verbatim.
+
+  The closed-form coefficients are cross-checked here against the recurrence (the `ring`
+  closing `psum_six_closed`) and independently against an explicit 6-variable instance
+  (`sixth_power_sum_six`, closed by `ring`).
+
+  Status: PROVED — 0 sorries, 0 axioms.  Holds over any `CommRing`.
+  Tags: algebra, symmetric-functions, newton-girard, power-sums, finset, characteristic-two
+-/
+
+import Mathlib
+import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03
+import Proofs.AmgmInequalityOQ02OQ01OQ03Finset
+import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ03OQ01OQ01
+
+namespace AMGMInequalityOQ02OQ01OQ03OQ01OQ01OQ02
+
+open MvPolynomial Finset BigOperators Set
+
+-- ============================================================
+-- Universal closed form (MvPolynomial setting)
+-- ============================================================
+
+section Universal
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+/-- **Newton–Girard k=6, recurrence form** (universal / MvPolynomial setting):
+      p₆ = e₁·p₅ − e₂·p₄ + e₃·p₃ − e₄·p₂ + e₅·p₁ − 6·e₆.
+
+    Proof: apply `psum_eq_mul_esymm_sub_sum` at n = 6.  The antidiagonal
+    {a : a.1 + a.2 = 6, 0 < a.1 < 6} = {(1,5), (2,4), (3,3), (4,2), (5,1)}, and the lead term is
+    (−1)⁷·6·e₆ = −6·e₆, so
+      p₆ = −6e₆ − ((−1)¹e₁p₅ + (−1)²e₂p₄ + (−1)³e₃p₃ + (−1)⁴e₄p₂ + (−1)⁵e₅p₁)
+         = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆. -/
+theorem psum_six_recurrence :
+    psum σ R 6 =
+      esymm σ R 1 * psum σ R 5 - esymm σ R 2 * psum σ R 4
+        + esymm σ R 3 * psum σ R 3 - esymm σ R 4 * psum σ R 2
+        + esymm σ R 5 * psum σ R 1 - 6 * esymm σ R 6 := by
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 6 (by norm_num)]
+  have hfilt : (Finset.antidiagonal 6).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 6) =
+               {(1, 5), (2, 4), (3, 3), (4, 2), (5, 1)} := by
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, Finset.mem_antidiagonal, Set.mem_Ioo,
+               Finset.mem_insert, Finset.mem_singleton, Prod.mk.injEq]
+    omega
+  simp only [hfilt,
+    Finset.sum_insert (by decide : (1, 5) ∉ ({(2, 4), (3, 3), (4, 2), (5, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_insert (by decide : (2, 4) ∉ ({(3, 3), (4, 2), (5, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_insert (by decide : (3, 3) ∉ ({(4, 2), (5, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_insert (by decide : (4, 2) ∉ ({(5, 1)} : Finset (ℕ × ℕ))),
+    Finset.sum_singleton]
+  ring
+
+/-- **Newton–Girard k=6, closed form** (universal / MvPolynomial setting):
+      p₆ = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃²
+             − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆.
+    Substitute the proven closed forms `psum_five_closed` (p₅), `psum_four_closed` (p₄),
+    `psum_three_closed` (p₃), `psum_two_eq` (p₂ = e₁² − 2e₂) and `psum_one_eq_esymm_one`
+    (p₁ = e₁) into the recurrence `psum_six_recurrence`, then ring-normalise. -/
+theorem psum_six_closed :
+    psum σ R 6 =
+      esymm σ R 1 ^ 6 - 6 * (esymm σ R 1 ^ 4 * esymm σ R 2)
+        + 9 * (esymm σ R 1 ^ 2 * esymm σ R 2 ^ 2) - 2 * esymm σ R 2 ^ 3
+        + 6 * (esymm σ R 1 ^ 3 * esymm σ R 3) - 12 * (esymm σ R 1 * esymm σ R 2 * esymm σ R 3)
+        + 3 * esymm σ R 3 ^ 2 - 6 * (esymm σ R 1 ^ 2 * esymm σ R 4)
+        + 6 * (esymm σ R 2 * esymm σ R 4) + 6 * (esymm σ R 1 * esymm σ R 5)
+        - 6 * esymm σ R 6 := by
+  have h6 := psum_six_recurrence σ R
+  have h5 := AMGMInequalityOQ02OQ01OQ03OQ01OQ01.psum_five_closed σ R
+  have h4 := AMGMInequalityOQ02OQ01OQ03OQ01.psum_four_closed σ R
+  have h3 := AMGMInequalityOQ02OQ01OQ03.psum_three_closed σ R
+  have h2 := AMGMInequalityOQ02OQ01OQ02OQ01.psum_two_eq σ R
+  have h1 := AMGMInequalityOQ02OQ01OQ02OQ01.psum_one_eq_esymm_one σ R
+  rw [h6, h5, h4, h3, h2, h1]; ring
+
+end Universal
+
+-- ============================================================
+-- Concrete general-Finset form, over ANY CommRing (every characteristic)
+-- ============================================================
+
+section Concrete
+
+open AMGMInequalityOQ02OQ01OQ03Finset
+open AMGMInequalityOQ02OQ01OQ03OQ01
+open AMGMInequalityOQ02OQ01OQ03OQ01OQ01
+
+variable {ι R : Type*} [CommRing R] [DecidableEq ι]
+
+/-- e₆ = Σ over 6-subsets of the product (concrete `powersetCard` form). -/
+def e6 (s : Finset ι) (f : ι → R) : R := ∑ t ∈ s.powersetCard 6, ∏ i ∈ t, f i
+/-- p₆ = Σ fᵢ⁶. -/
+def p6 (s : Finset ι) (f : ι → R) : R := ∑ i ∈ s, f i ^ 6
+
+omit [DecidableEq ι] in
+/-- Bridge at degree 6:  `aeval (esymm … 6) = e₆`  (definitional, from the n-general
+    `aeval_esymm_subtype`). -/
+theorem e6_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.esymm {x // x ∈ s} R 6) = e6 s f :=
+  aeval_esymm_subtype s f 6
+
+omit [DecidableEq ι] in
+/-- Bridge for the sixth power sum:  `aeval (psum … 6) = p₆`  (definitional, from the
+    n-general `aeval_psum_subtype`). -/
+theorem p6_bridge (s : Finset ι) (f : ι → R) :
+    aeval (fun i : {x // x ∈ s} => f i.1) (MvPolynomial.psum {x // x ∈ s} R 6) = p6 s f :=
+  aeval_psum_subtype s f 6
+
+omit [DecidableEq ι] in
+/-- **Concrete general-Finset Newton–Girard k=6** over an arbitrary `CommRing`:
+      p₆ = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃²
+             − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆.
+    Transport of the universal `psum_six_closed` across the (characteristic-safe) aeval
+    bridges onto the subtype {x // x ∈ s}.  No characteristic hypothesis is required. -/
+theorem newton_girard_six_finset (s : Finset ι) (f : ι → R) :
+    p6 s f =
+      e1 s f ^ 6 - 6 * (e1 s f ^ 4 * e2 s f) + 9 * (e1 s f ^ 2 * e2 s f ^ 2)
+        - 2 * e2 s f ^ 3 + 6 * (e1 s f ^ 3 * e3 s f)
+        - 12 * (e1 s f * e2 s f * e3 s f) + 3 * e3 s f ^ 2
+        - 6 * (e1 s f ^ 2 * e4 s f) + 6 * (e2 s f * e4 s f)
+        + 6 * (e1 s f * e5 s f) - 6 * e6 s f := by
+  have H := congrArg (aeval (fun i : {x // x ∈ s} => f i.1))
+    (psum_six_closed {x // x ∈ s} R)
+  simpa only [map_add, map_sub, map_mul, map_pow, map_ofNat,
+    p6_bridge, e1_bridge, e2_bridge, e3_bridge, e4_bridge, e5_bridge, e6_bridge] using H
+
+end Concrete
+
+-- ============================================================
+-- Concrete 6-variable instance (smallest nondegenerate case)
+-- ============================================================
+
+section Explicit
+
+variable {R : Type*} [CommRing R]
+
+/-- **Concrete 6-variable instance** — sum of sixth powers:
+      a⁶ + b⁶ + c⁶ + d⁶ + e⁶ + g⁶
+        = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃²
+             − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆,
+    where e₁ = Σ, e₂ = Σ pairs, e₃ = Σ triples, e₄ = Σ quadruples, e₅ = Σ quintuples,
+    e₆ = abcdeg.  This is the n = 6 Finset case of `psum_six_closed`. -/
+theorem sixth_power_sum_six (a b c d e g : R) :
+    a ^ 6 + b ^ 6 + c ^ 6 + d ^ 6 + e ^ 6 + g ^ 6 =
+      (a + b + c + d + e + g) ^ 6
+        - 6 * ((a + b + c + d + e + g) ^ 4 *
+            (a*b + a*c + a*d + a*e + a*g + b*c + b*d + b*e + b*g + c*d + c*e + c*g
+              + d*e + d*g + e*g))
+        + 9 * ((a + b + c + d + e + g) ^ 2 *
+            (a*b + a*c + a*d + a*e + a*g + b*c + b*d + b*e + b*g + c*d + c*e + c*g
+              + d*e + d*g + e*g) ^ 2)
+        - 2 * (a*b + a*c + a*d + a*e + a*g + b*c + b*d + b*e + b*g + c*d + c*e + c*g
+              + d*e + d*g + e*g) ^ 3
+        + 6 * ((a + b + c + d + e + g) ^ 3 *
+            (a*b*c + a*b*d + a*b*e + a*b*g + a*c*d + a*c*e + a*c*g + a*d*e + a*d*g + a*e*g
+              + b*c*d + b*c*e + b*c*g + b*d*e + b*d*g + b*e*g + c*d*e + c*d*g + c*e*g + d*e*g))
+        - 12 * ((a + b + c + d + e + g) *
+            (a*b + a*c + a*d + a*e + a*g + b*c + b*d + b*e + b*g + c*d + c*e + c*g
+              + d*e + d*g + e*g) *
+            (a*b*c + a*b*d + a*b*e + a*b*g + a*c*d + a*c*e + a*c*g + a*d*e + a*d*g + a*e*g
+              + b*c*d + b*c*e + b*c*g + b*d*e + b*d*g + b*e*g + c*d*e + c*d*g + c*e*g + d*e*g))
+        + 3 * (a*b*c + a*b*d + a*b*e + a*b*g + a*c*d + a*c*e + a*c*g + a*d*e + a*d*g + a*e*g
+              + b*c*d + b*c*e + b*c*g + b*d*e + b*d*g + b*e*g + c*d*e + c*d*g + c*e*g + d*e*g) ^ 2
+        - 6 * ((a + b + c + d + e + g) ^ 2 *
+            (a*b*c*d + a*b*c*e + a*b*c*g + a*b*d*e + a*b*d*g + a*b*e*g + a*c*d*e + a*c*d*g
+              + a*c*e*g + a*d*e*g + b*c*d*e + b*c*d*g + b*c*e*g + b*d*e*g + c*d*e*g))
+        + 6 * ((a*b + a*c + a*d + a*e + a*g + b*c + b*d + b*e + b*g + c*d + c*e + c*g
+              + d*e + d*g + e*g) *
+            (a*b*c*d + a*b*c*e + a*b*c*g + a*b*d*e + a*b*d*g + a*b*e*g + a*c*d*e + a*c*d*g
+              + a*c*e*g + a*d*e*g + b*c*d*e + b*c*d*g + b*c*e*g + b*d*e*g + c*d*e*g))
+        + 6 * ((a + b + c + d + e + g) *
+            (a*b*c*d*e + a*b*c*d*g + a*b*c*e*g + a*b*d*e*g + a*c*d*e*g + b*c*d*e*g))
+        - 6 * (a*b*c*d*e*g) := by
+  ring
+
+end Explicit
+
+end AMGMInequalityOQ02OQ01OQ03OQ01OQ01OQ02

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ng6-overview",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "Newton–Girard k=6: the sixth rung, first with a cube and a square",
+    "content": "The module docstring states the target identity p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆ and situates it in a lineage (k=2 → recurrence → k=3 → k=4 → k=5 → k=6). Newton's identities relate the power sums pₖ = Σxᵢᵏ to the elementary symmetric polynomials eₖ; the k=6 rung is the first whose reduced expression carries a pure cube (−2e₂³) and a pure square (+3e₃²), alongside the new e₆ term. The file delivers two complementary forms — a universal MvPolynomial statement and a concrete Finset statement over an arbitrary CommRing — each 0-sorry, 0-axiom.",
+    "mathContext": "$p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$",
+    "significance": "context",
+    "prerequisites": ["elementary symmetric polynomials", "power sums", "the lower closed forms p₁..p₅"],
+    "relatedConcepts": ["Newton–Girard identities", "symmetric function theory", "Vieta's formulas"]
+  },
+  {
+    "id": "ng6-recurrence",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 77, "endLine": 101 },
+    "type": "theorem",
+    "title": "psum_six_recurrence — extracting the k=6 Newton recurrence",
+    "content": "Specialises Mathlib's general Newton identity `MvPolynomial.psum_eq_mul_esymm_sub_sum` at n=6 to get p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆. The work is purely combinatorial: the antidiagonal filter {a : a.1+a.2=6, 0<a.1<6} is shown by `ext`+`omega` to equal {(1,5),(2,4),(3,3),(4,2),(5,1)}, the five-term sum is unfolded with `Finset.sum_insert` (non-membership by `decide`) and `Finset.sum_singleton`, and `ring` evaluates the alternating (−1)ᵏ coefficients and the lead term (−1)⁷·6·e₆ = −6·e₆. This mirrors the k=2/3/4/5 derivations exactly, with the sign of the lead term now negative.",
+    "mathContext": "$p_6 = e_1 p_5 - e_2 p_4 + e_3 p_3 - e_4 p_2 + e_5 p_1 - 6 e_6$, with lead term $(-1)^{7}\\cdot 6\\, e_6 = -6 e_6$.",
+    "significance": "key",
+    "prerequisites": ["MvPolynomial.psum_eq_mul_esymm_sub_sum", "Finset.antidiagonal / sum_insert", "omega, decide, ring"],
+    "relatedConcepts": ["Newton recurrence", "antidiagonal", "alternating signs"]
+  },
+  {
+    "id": "ng6-closed",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 103, "endLine": 117 },
+    "type": "theorem",
+    "title": "psum_six_closed — the universal reduced closed form",
+    "content": "The headline universal identity in MvPolynomial σ R: substitute the proven lower closed forms — `psum_five_closed` (p₅), `psum_four_closed` (p₄), `psum_three_closed` (p₃), `psum_two_eq` (p₂ = e₁² − 2e₂), and `psum_one_eq_esymm_one` (p₁ = e₁) — into the recurrence and let `ring` normalise. The result expresses p₆ purely in e₁,…,e₆, and is the first rung to display a pure cube −2e₂³ and a pure square +3e₃². Because it lives at the level of polynomial coefficients (before any evaluation), it holds in every commutative ring with no characteristic hypothesis.",
+    "mathContext": "$p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$ in $\\mathrm{MvPolynomial}\\,\\sigma\\,R$",
+    "significance": "critical",
+    "prerequisites": ["psum_six_recurrence", "the lower closed forms p₁..p₅", "ring"],
+    "relatedConcepts": ["closed form", "universal symmetric-function identity", "characteristic independence"]
+  },
+  {
+    "id": "ng6-defs",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 134, "endLine": 137 },
+    "type": "definition",
+    "title": "e₆ and p₆ — concrete powersetCard / power-sum definitions",
+    "content": "e6 s f = Σ over 6-element subsets t ⊆ s of ∏_{i∈t} f i (the sixth elementary symmetric polynomial of the values f over s), and p6 s f = Σ_{i∈s} (f i)⁶ (the sixth power sum). These are the concrete, evaluation-side counterparts of the universal MvPolynomial esymm/psum, defined via Finset.powersetCard.",
+    "mathContext": "$e_6 = \\sum_{t \\subseteq s,\\ |t|=6} \\prod_{i \\in t} f_i$, $\\quad p_6 = \\sum_{i \\in s} f_i^6$",
+    "significance": "supporting",
+    "prerequisites": ["Finset.powersetCard", "Finset.prod / Finset.sum"],
+    "relatedConcepts": ["elementary symmetric polynomial", "power sum"]
+  },
+  {
+    "id": "ng6-bridges",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 141, "endLine": 155 },
+    "type": "theorem",
+    "title": "e6_bridge / p6_bridge — degree-6 instances of the n-general aeval bridge",
+    "content": "e6_bridge := aeval_esymm_subtype s f 6 and p6_bridge := aeval_psum_subtype s f 6. These are simply the degree-6 instantiations of the k=3 entry's already-degree-general aeval bridge, identifying aeval (fun i : {x // x ∈ s} => f i.1) of the universal esymm/psum at degree 6 with the concrete e₆/p₆. No new bridge machinery is built — a third confirmation (after k=4, k=5) that the bridge is degree-uniform.",
+    "mathContext": "$\\mathrm{aeval}\\,(\\mathrm{esymm}\\,\\{x // x\\in s\\}\\,R\\,6) = e_6$, $\\quad \\mathrm{aeval}\\,(\\mathrm{psum}\\,\\{x // x\\in s\\}\\,R\\,6) = p_6$",
+    "significance": "key",
+    "prerequisites": ["aeval_esymm_subtype", "aeval_psum_subtype (both n-general, from the k=3 entry)"],
+    "relatedConcepts": ["aeval transport", "subtype evaluation", "degree-uniform bridge"]
+  },
+  {
+    "id": "ng6-finset",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 158, "endLine": 168 },
+    "type": "theorem",
+    "title": "newton_girard_six_finset — the concrete identity over any CommRing",
+    "content": "Transports the universal psum_six_closed across the aeval bridges onto the membership subtype {x // x ∈ s}: take congrArg of aeval applied to the universal identity, then simp with map_add/map_sub/map_mul/map_pow/map_ofNat and the seven bridge lemmas (e1..e6, p6). The result is the fully reduced k=6 closed form for the concrete e₁,…,e₆ and p₆ over an arbitrary commutative ring. Because the transport occurs at the level of polynomial coefficients, there is no characteristic restriction.",
+    "mathContext": "Over any CommRing $R$: $p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$",
+    "significance": "critical",
+    "prerequisites": ["psum_six_closed", "e1..e6 / p6 bridges", "congrArg, aeval, map_* simp lemmas"],
+    "relatedConcepts": ["transport of identities", "characteristic independence", "Finset symmetric functions"]
+  },
+  {
+    "id": "ng6-explicit",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+    "range": { "startLine": 186, "endLine": 217 },
+    "type": "theorem",
+    "title": "sixth_power_sum_six — explicit 6-variable instance and coefficient check",
+    "content": "The smallest nondegenerate Finset instance, with the six elementary symmetric polynomials written out in six explicit variables a,b,c,d,e,g: a⁶+b⁶+c⁶+d⁶+e⁶+g⁶ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆, closed by `ring`. This is an independent, fully expanded confirmation of every coefficient in the closed form (the ring normaliser would reject any incorrect coefficient).",
+    "mathContext": "$a^6+b^6+c^6+d^6+e^6+g^6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$",
+    "significance": "supporting",
+    "prerequisites": ["ring"],
+    "relatedConcepts": ["explicit symmetric polynomials", "independent verification"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+  "title": "Newton-Girard k=6 Closed Form over Any CommRing (incl. e₂³ and e₃² terms)",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02",
+  "description": "Establishes the fully reduced sixth Newton-Girard identity p₆ = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃² − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆ in two complementary forms: (1) the universal MvPolynomial statement, derived by extracting the k=6 Newton recurrence p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆ from Mathlib's psum_eq_mul_esymm_sub_sum and substituting the proven closed forms for p₅, p₄, p₃, p₂, p₁; and (2) a concrete general-Finset form over an arbitrary CommRing obtained by reusing the n-general aeval bridge built for the k=3 entry — transporting the universal identity onto the subtype {x // x ∈ s} with the e₆/p₆ bridge lemmas instantiated at degree 6. The k=6 rung is the first to feature the pure cube e₂³ and the square e₃² in the reduced expression. The concrete form holds over any commutative ring, every characteristic included, where the −6 coefficients vanish modulo small primes. Specializes to the sum-of-sixth-powers identity a⁶+b⁶+c⁶+d⁶+e⁶+g⁶ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-24",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02.lean",
+    "additionalFiles": [],
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "finset",
+      "characteristic-two",
+      "mv-polynomial"
+    ],
+    "badge": "original",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "The general Newton-Girard recurrence pₙ = (−1)^(n+1)·n·eₙ − Σ_{0<a.1<n} (−1)^a.1 e_{a.1} p_{a.2}; instantiated at n=6 to extract p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆.",
+        "module": "Mathlib.RingTheory.MvPolynomial.NewtonIdentities"
+      },
+      {
+        "theorem": "MvPolynomial.aeval_esymm_eq_multiset_esymm",
+        "description": "aeval of the universal elementary symmetric polynomial equals the multiset elementary symmetric sum of the evaluated variables — the engine of the inherited concrete-Finset bridge (degree 6 instance).",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      },
+      {
+        "theorem": "Finset.esymm_map_val",
+        "description": "Identifies the multiset elementary symmetric sum over s.val.map f with the powersetCard sum Σ_{t ⊆ s, |t|=n} ∏_{i ∈ t} f i.",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.Defs"
+      }
+    ],
+    "originalContributions": [
+      "psum_six_recurrence: the k=6 Newton recurrence p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆, extracted from Mathlib's psum_eq_mul_esymm_sub_sum by computing the antidiagonal filter {(1,5),(2,4),(3,3),(4,2),(5,1)} and the lead term (−1)⁷·6·e₆ = −6·e₆.",
+      "psum_six_closed: the universal MvPolynomial closed form p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆, obtained by substituting the proven lower closed forms (p₅, p₄, p₃, p₂, p₁) into the recurrence and ring-normalising. This is the first rung carrying the pure cube e₂³ and the square e₃².",
+      "newton_girard_six_finset: the concrete general-Finset closed form over ANY CommRing, obtained by transporting psum_six_closed across the aeval bridge — a third confirmation (after k=4, k=5) that the k=3 bridge is genuinely degree-general (e6_bridge/p6_bridge are the n=6 instances of aeval_esymm_subtype/aeval_psum_subtype).",
+      "sixth_power_sum_six: the explicit 6-variable instance a⁶+b⁶+c⁶+d⁶+e⁶+g⁶ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆ over any CommRing, an independent ring-level check of every closed-form coefficient."
+    ],
+    "dateAdded": "2026-06-24",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 221,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only [propext, Classical.choice, Quot.sound] for both psum_six_closed and newton_girard_six_finset (no sorryAx, no Lean.ofReduceBool). The universal identity is a ring-level corollary of Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum together with the sibling k=1..5 closed forms; the concrete-Finset form reuses the k=3 entry's aeval bridge and holds over an arbitrary CommRing.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Newton-Girard identities) relate the power sums pₖ = Σ xᵢᵏ to the elementary symmetric polynomials eₖ. Girard stated them around 1629 and Newton independently around 1666 (Arithmetica Universalis, 1707). The sixth identity, p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆, is the first rung involving the sixth elementary symmetric polynomial e₆ and, more notably, the first whose reduced form carries a pure cube e₂³ and a pure square e₃². While Mathlib provides the general recurrence MvPolynomial.psum_eq_mul_esymm_sub_sum, the fully reduced k=6 closed form purely in e₁,…,e₆ — and its concrete Finset incarnation valid in every commutative ring — is not present in Mathlib.",
+    "problemStatement": "**Open Question (amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02)**: Continue the Newton-Girard chain to k=6: establish the fully reduced identity\n\np₆ = e₁⁶ − 6·e₁⁴·e₂ + 9·e₁²·e₂² − 2·e₂³ + 6·e₁³·e₃ − 12·e₁·e₂·e₃ + 3·e₃² − 6·e₁²·e₄ + 6·e₂·e₄ + 6·e₁·e₅ − 6·e₆\n\nexpressing the sixth power sum purely in terms of e₁,…,e₆, both as the universal MvPolynomial statement and as a concrete identity over a Finset of values in an arbitrary commutative ring. This is the explicit next rung after the k=5 closed form (which named this very question as its follow-up), the first to feature the cubic e₂³ term and the e₃² square.\n\n**Answer**: Proved in both forms. The universal form extracts the k=6 recurrence from Mathlib's general Newton identity and substitutes the lower closed forms p₅,…,p₁. The concrete general-Finset form reuses the k=3 entry's aeval bridge (already stated for arbitrary degree n) at degree 6, and holds over any CommRing.",
+    "text": "The file AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02.lean resolves the question. The universal section proves psum_six_recurrence (p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆) by instantiating Mathlib's psum_eq_mul_esymm_sub_sum at n=6, computing the antidiagonal filter {(1,5),(2,4),(3,3),(4,2),(5,1)}, and ring-normalising; psum_six_closed then substitutes the proven closed forms for p₅, p₄, p₃, p₂, p₁ and closes with ring. The concrete section reuses the k=3 Finset definitions and aeval bridge plus the k=4/k=5 e₄, e₅ definitions and bridges, adds e₆ and p₆ with their degree-6 bridge instances, and proves newton_girard_six_finset over an arbitrary CommRing by congrArg of psum_six_closed under aeval onto the subtype {x // x ∈ s}. The explicit 6-variable sum-of-sixth-powers instance is recorded as sixth_power_sum_six.",
+    "proofStrategy": "**Universal recurrence**: psum_six_recurrence rewrites with MvPolynomial.psum_eq_mul_esymm_sub_sum σ R 6. The antidiagonal {a : a.1+a.2=6, 0<a.1<6} = {(1,5),(2,4),(3,3),(4,2),(5,1)} is established by ext + omega; the five-term sum is unfolded by Finset.sum_insert (mem facts by decide) and Finset.sum_singleton, and ring evaluates the (−1)^k coefficients and the lead term (−1)⁷·6·e₆ = −6·e₆.\n\n**Universal closed form**: psum_six_closed rewrites the recurrence with psum_five_closed, psum_four_closed, psum_three_closed, psum_two_eq, psum_one_eq_esymm_one and closes with ring. The resulting coefficients (−6, +9, −2, +6, −12, +3, −6, +6, +6, −6) are cross-checked at the level of MvPolynomial coefficients by ring.\n\n**Concrete Finset form**: e6_bridge and p6_bridge are the degree-6 instances of the k=3 entry's aeval_esymm_subtype / aeval_psum_subtype, so no new bridge machinery is needed. newton_girard_six_finset is the congrArg image of psum_six_closed under aeval (fun i : {x // x ∈ s} => f i.1), simplified by map_add/map_sub/map_mul/map_pow/map_ofNat and the seven bridge lemmas (e1..e6, p6). Because the transport happens at the level of polynomial coefficients, the identity holds over rings of arbitrary characteristic.\n\n**Independent check**: sixth_power_sum_six expands all six elementary symmetric polynomials in six explicit variables and verifies the full closed form by ring — a second, fully concrete confirmation of every coefficient.",
+    "keyInsights": [
+      "The k=6 closed form is the first rung whose reduced expression contains a pure cube of a non-leading symmetric polynomial (−2·e₂³) and a pure square (+3·e₃²), alongside the new e₆ term — qualitatively richer than the linear-in-eₖ tails of k≤5.",
+      "Every closed-form coefficient is pinned by two independent ring computations: substitution into the recurrence (psum_six_closed) and a fully expanded 6-variable identity (sixth_power_sum_six). The hand-derived coefficients (1, −6, 9, −2, 6, −12, 3, −6, 6, 6, −6) are exactly those forced by e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆.",
+      "The aeval bridge built for the k=3 entry (aeval_psum_subtype / aeval_esymm_subtype) is already stated for arbitrary degree n. The k=6 concrete form therefore needs only e6_bridge := aeval_esymm_subtype s f 6 and p6_bridge := aeval_psum_subtype s f 6 — a third confirmation (after k=4, k=5) that the bridge is a reusable, degree-uniform transport.",
+      "Extracting the k=6 recurrence from psum_eq_mul_esymm_sub_sum is purely mechanical once the antidiagonal filter {(1,5),(2,4),(3,3),(4,2),(5,1)} and the sign of the lead term (−1)^(n+1)·n·eₙ = (−1)⁷·6·e₆ = −6e₆ are pinned down, mirroring the k=2..5 derivations exactly."
+    ],
+    "prerequisites": [
+      "k=5 closed form AmgmInequalityOQ02OQ01OQ03OQ01OQ01: psum_five_closed and the e₅ definition / e5_bridge.",
+      "k=4 closed form AmgmInequalityOQ02OQ01OQ03OQ01: psum_four_closed (p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄) and the e₄ definition / e4_bridge.",
+      "k=3 closed form AmgmInequalityOQ02OQ01OQ03: psum_three_closed (p₃ = e₁³ − 3e₁e₂ + 3e₃).",
+      "k=3 Finset bridge AmgmInequalityOQ02OQ01OQ03Finset: the n-general aeval_psum_subtype / aeval_esymm_subtype and the e₁,e₂,e₃ definitions and bridge lemmas.",
+      "Recurrence sibling AmgmInequalityOQ02OQ01OQ02OQ01: psum_two_eq (p₂ = e₁² − 2e₂) and psum_one_eq_esymm_one (p₁ = e₁).",
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum — the general Newton-Girard recurrence (Mathlib).",
+      "Finset.powersetCard — fixed-cardinality subsets, the concrete definition of eₖ (Mathlib)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: Newton-Girard k=6 Closed Form",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "States the target identity p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆, its lineage from the k=2..5 entries, the two-form strategy (universal recurrence/substitution + concrete aeval transport), and the proof status (PROVED, 0 sorries, 0 axioms).",
+      "mathContext": "$p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$."
+    },
+    {
+      "id": "universal",
+      "title": "Universal Closed Form (MvPolynomial)",
+      "startLine": 65,
+      "endLine": 119,
+      "summary": "psum_six_recurrence extracts p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆ from psum_eq_mul_esymm_sub_sum at n=6 (antidiagonal {(1,5),(2,4),(3,3),(4,2),(5,1)}). psum_six_closed substitutes the proven p₅, p₄, p₃, p₂, p₁ closed forms and ring-normalises.",
+      "mathContext": "In MvPolynomial σ R: $p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete General-Finset Form (any characteristic)",
+      "startLine": 125,
+      "endLine": 170,
+      "summary": "Defines e₆, p₆ over a Finset via powersetCard, adds the degree-6 bridge instances e6_bridge/p6_bridge (reusing the k=3 n-general aeval bridge), and proves newton_girard_six_finset over an arbitrary CommRing by transporting psum_six_closed across aeval onto the membership subtype.",
+      "mathContext": "Over any CommRing: $p_6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$."
+    },
+    {
+      "id": "explicit",
+      "title": "Concrete 6-Variable Instance (Sum of Sixth Powers)",
+      "startLine": 176,
+      "endLine": 219,
+      "summary": "sixth_power_sum_six: a⁶+b⁶+c⁶+d⁶+e⁶+g⁶ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆ over any CommRing, closed by ring — the smallest nondegenerate Finset instance and an independent check of all coefficients.",
+      "mathContext": "$a^6+b^6+c^6+d^6+e^6+g^6 = e_1^6 - 6 e_1^4 e_2 + 9 e_1^2 e_2^2 - 2 e_2^3 + 6 e_1^3 e_3 - 12 e_1 e_2 e_3 + 3 e_3^2 - 6 e_1^2 e_4 + 6 e_2 e_4 + 6 e_1 e_5 - 6 e_6$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Resolves the open question in both the universal MvPolynomial setting and the concrete general-Finset setting. The universal identity p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃² − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆ is extracted from Mathlib's general Newton recurrence plus the lower closed forms; the concrete Finset form reuses the k=3 entry's degree-general aeval bridge at degree 6 and holds over an arbitrary CommRing. The file is machine-verified with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound).",
+    "implications": "**For symmetric function theory**: completes the reduced k=6 Newton-Girard identity, the first whose reduced form carries a pure cube e₂³ and a pure square e₃², extending the gallery's k=2 → k=3 → k=4 → k=5 → k=6 chain of explicit closed forms.\n\n**For formalization technique**: gives a third confirmation, after k=4 and k=5, that the k=3 aeval bridge (concrete powersetCard / power-sum defs = aeval of universal MvPolynomial symmetric functions on the membership subtype) is degree-uniform: the k=6 concrete form again costs only two one-line bridge instantiations.",
+    "openQuestions": [
+      "Continue the chain to k=7: p₇ involves e₇ and the first product of two distinct cubics-and-squares cross terms; the recurrence antidiagonal grows to {(1,6),…,(6,1)}.",
+      "Replace the per-degree wrappers (e6_bridge, p6_bridge, …) by a single degree-uniform transport lemma that pushes the entire Newton recurrence through aeval at once, then specialise to each k mechanically."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The k=5 closed form psum_five_closed and its e₅ definition / e5_bridge, which this entry substitutes into the k=6 recurrence and reuses at degree 6. This entry is the direct next rung the k=5 entry named as its follow-up open question."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The k=4 closed form psum_four_closed and its e₄ definition / e4_bridge, also substituted into the k=6 recurrence."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "The k=3 closed form and its n-general aeval bridge (aeval_psum_subtype / aeval_esymm_subtype), which this entry reuses verbatim at degree 6 — a third confirmation that the bridge is degree-general."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Provides the closed forms p₂ = e₁² − 2e₂, p₁ = e₁ and the pattern for extracting Newton recurrences from MvPolynomial.psum_eq_mul_esymm_sub_sum; this entry repeats that pattern at n=6."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "related",
+      "description": "The e₁,…,e₆ appearing here are exactly Vieta's elementary symmetric polynomials in the roots; the identity expresses the sixth power sum of roots via coefficients."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam: Guillaume Iansson Blaeuw",
+      "note": "Earliest known statement of the identities relating power sums to elementary symmetric polynomials."
+    },
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge (manuscript ~1666)",
+      "note": "Newton's independent treatment of the power-sum / elementary-symmetric identities."
+    },
+    {
+      "authors": "Macdonald, I. G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition, Chapter I §2",
+      "note": "Canonical reference; the Newton-Girard identities appear as (2.11′)/(2.11″)."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02.lean",
+    "lineCount": 221,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "axiomCount": 0,
+    "sorries": 0,
+    "additionalFiles": []
+  }
+}


### PR DESCRIPTION
## Newton–Girard k=6 Closed Form over Any CommRing

Resolves open question **amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02** — the explicit next rung after the k=5 closed form, which named this very question as its follow-up. The k=6 identity is the first whose **reduced** form carries a pure cube (−2·e₂³) and a pure square (+3·e₃²):

```
p₆ = e₁⁶ − 6e₁⁴e₂ + 9e₁²e₂² − 2e₂³ + 6e₁³e₃ − 12e₁e₂e₃ + 3e₃²
       − 6e₁²e₄ + 6e₂e₄ + 6e₁e₅ − 6e₆
```

### Two complementary forms (each 0-sorry / 0-axiom)

1. **Universal (MvPolynomial).** `psum_six_recurrence` extracts
   `p₆ = e₁p₅ − e₂p₄ + e₃p₃ − e₄p₂ + e₅p₁ − 6e₆` from Mathlib's
   `MvPolynomial.psum_eq_mul_esymm_sub_sum` (antidiagonal filter
   `{(1,5),(2,4),(3,3),(4,2),(5,1)}`, lead term `(−1)⁷·6·e₆ = −6e₆`).
   `psum_six_closed` substitutes the proven p₅..p₁ closed forms and `ring`-normalises.

2. **Concrete general-Finset over any CommRing.** `newton_girard_six_finset`
   transports `psum_six_closed` across the k=3 entry's *degree-general* aeval bridge
   at degree 6 (`e6_bridge`/`p6_bridge` = `aeval_*_subtype s f 6`) — a third
   confirmation (after k=4, k=5) that the bridge is degree-uniform. No characteristic
   hypothesis. The explicit 6-variable instance `sixth_power_sum_six` independently
   checks every coefficient by `ring`.

### Verification
- `#print axioms psum_six_closed` / `newton_girard_six_finset`: only
  `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- 6 theorems, 2 definitions, 221 lines. Builds against the existing k=2..5 chain.
- Coefficients verified twice independently: substitution into the recurrence, and a fully expanded 6-variable `ring` identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)