### PR TITLE
research(spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01): Newton's fourth power sum tr(A⁴)=λ₁⁴+λ₂⁴+λ₃⁴+λ₄⁴ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3773,6 +3773,7 @@ import Proofs.SophieGermainOQ02
 import Proofs.SophieGermainOQ03
 import Proofs.SophieGermainOQ04
 import Proofs.SpectralTraceDetEigenvaluesOQ01
+import Proofs.SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01
 import Proofs.SpectralTraceDetEigenvaluesOQ02
 import Proofs.SpernerFreudenthal
 import Proofs.SpernerFreudenthalAristotle

--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,250 @@
+import Mathlib
+import Proofs.SpectralTraceDetEigenvaluesOQ01
+
+/-
+# Spectral trace, OQ-01 → OQ-01 → OQ-02 → OQ-01: Newton's identity `tr(A⁴) = Σ λᵢ⁴` in dimension four
+
+## What this file proves
+
+The parent `spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02`
+(`SpectralTraceDetEigenvaluesOQ01OQ01OQ02.lean`) reached Newton's **third** power-sum identity
+`tr(A³) = e₁³ − 3 e₁ e₂ + 3 e₃` for `3 × 3` matrices — the first power sum whose Newton expansion
+involves the *middle* elementary symmetric function `e₂`.  Its open question asks for the next
+power sum and the next dimension:
+
+      tr(A⁴) = e₁⁴ − 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ − 4 e₄          (Newton's identity `p₄`),
+
+read as the genuinely spectral statement `tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴` for `4 × 4` matrices.
+
+This is the **first power sum whose Newton expansion involves all four elementary symmetric
+functions** `e₁, e₂, e₃, e₄` of a `4 × 4` matrix — including the new top function `e₄ = det`,
+which appears here for the first time in the power-sum hierarchy (`p₂` reaches `e₂`, `p₃` reaches
+`e₃`, and only `p₄` reaches `e₄`).  It also exhibits the first *quadratic* symmetric term `2 e₂²`,
+absent from every lower power sum.  Mathlib provides `det_fin_two`/`det_fin_three` and
+`trace_fin_two`/`trace_fin_three` but **neither `det_fin_four` nor `trace_fin_four`**, so the
+`4 × 4` determinant expansion is built here from the cofactor rule `det_succ_row_zero`.
+
+## Results
+
+* `det_fin_four` — the full `4 × 4` Leibniz expansion (24 signed terms), built from the cofactor
+  rule and `det_fin_three`.  Used to unfold `e₄ = det` into matrix entries.
+
+* `trace_fourth_fin_four` — the **matrix-side Newton identity**, over *any* commutative ring:
+
+        tr(A⁴) = (tr A)⁴ − 4 (tr A)² e₂(A) + 2 e₂(A)² + 4 (tr A) e₃(A) − 4 det A,
+
+  where `e₂(A)` is the sum of the six principal `2 × 2` minors and `e₃(A)` the sum of the four
+  principal `3 × 3` minors.  No field, no algebraic closure, no eigenvalues — a polynomial
+  identity in the sixteen entries, closed by `ring`.
+
+* `charpoly_fin_four` / `charpoly_coeff_two_eq_e2` / `charpoly_coeff_one_eq_neg_e3` — the `4 × 4`
+  characteristic polynomial in elementary-symmetric form
+  `X⁴ − (tr A) X³ + e₂(A) X² − e₃(A) X + det A`, identifying `e₂(A)` and `e₃(A)` as its `X²`- and
+  `X¹`-coefficients.
+
+* `trace_fourth_eq_sum_fourth_eigenvalues` — the **spectral form**, over an algebraically closed
+  field: `tr(A⁴) = Σ λᵢ⁴`, the fourth power sum of the eigenvalue multiset.  The proof matches
+  the matrix-side identity to the multiset identity, using Vieta (`charpoly = ∏ (X − λᵢ)`) to
+  identify the four elementary symmetric functions of the eigenvalues with `tr A`, `e₂(A)`,
+  `e₃(A)`, and `det A`.
+
+## Honesty / scope
+
+The matrix-side identity and its `ring` proof are routine in spirit but genuinely new at `k = 4`,
+and require building `det_fin_four` (absent from Mathlib).  The spectral upgrade reuses the
+parent/grandparent infrastructure (`eigenvalues`, `trace_eq_sum_eigenvalues`,
+`det_eq_prod_eigenvalues`).  No `native_decide`; `#print axioms` confirms only
+`propext, Classical.choice, Quot.sound`.
+-/
+
+namespace SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01
+
+open Matrix Polynomial
+open SpectralTraceDetEigenvaluesOQ01 (eigenvalues)
+
+/-! ## Part I: the `4 × 4` determinant expansion (built — Mathlib stops at `det_fin_three`) -/
+
+variable {R : Type*} [CommRing R]
+
+/-- **The full `4 × 4` Leibniz expansion** (24 signed terms).  Mathlib provides `det_fin_two` and
+`det_fin_three` but not `det_fin_four`; we derive it from the cofactor rule `det_succ_row_zero`
+followed by `det_fin_three` on each of the four `3 × 3` minors. -/
+theorem det_fin_four (A : Matrix (Fin 4) (Fin 4) R) :
+    A.det =
+      A 0 0 * (A 1 1 * A 2 2 * A 3 3 - A 1 1 * A 2 3 * A 3 2 - A 1 2 * A 2 1 * A 3 3
+        + A 1 2 * A 2 3 * A 3 1 + A 1 3 * A 2 1 * A 3 2 - A 1 3 * A 2 2 * A 3 1)
+      - A 0 1 * (A 1 0 * A 2 2 * A 3 3 - A 1 0 * A 2 3 * A 3 2 - A 1 2 * A 2 0 * A 3 3
+        + A 1 2 * A 2 3 * A 3 0 + A 1 3 * A 2 0 * A 3 2 - A 1 3 * A 2 2 * A 3 0)
+      + A 0 2 * (A 1 0 * A 2 1 * A 3 3 - A 1 0 * A 2 3 * A 3 1 - A 1 1 * A 2 0 * A 3 3
+        + A 1 1 * A 2 3 * A 3 0 + A 1 3 * A 2 0 * A 3 1 - A 1 3 * A 2 1 * A 3 0)
+      - A 0 3 * (A 1 0 * A 2 1 * A 3 2 - A 1 0 * A 2 2 * A 3 1 - A 1 1 * A 2 0 * A 3 2
+        + A 1 1 * A 2 2 * A 3 0 + A 1 2 * A 2 0 * A 3 1 - A 1 2 * A 2 1 * A 3 0) := by
+  rw [det_succ_row_zero, Fin.sum_univ_four]
+  simp only [det_fin_three, submatrix_apply]
+  simp only [Fin.isValue, Fin.succAbove, Fin.castSucc, Fin.castAdd, Fin.castLE, Fin.lt_def,
+    Fin.succ]
+  norm_num
+  have h2 : ∀ (h : 2 < 4), (⟨2, h⟩ : Fin 4) = 2 := fun _ => rfl
+  have h3 : ∀ (h : 3 < 4), (⟨3, h⟩ : Fin 4) = 3 := fun _ => rfl
+  simp only [h2, h3]
+  ring
+
+/-! ## Part II: the elementary symmetric functions `e₂`, `e₃` of a `4 × 4` matrix -/
+
+/-- The **second elementary symmetric function** of a `4 × 4` matrix: the sum of its six principal
+`2 × 2` minors.  For eigenvalues `a, b, c, d` this is `ab+ac+ad+bc+bd+cd`. -/
+def e2 (A : Matrix (Fin 4) (Fin 4) R) : R :=
+  (A 0 0 * A 1 1 - A 0 1 * A 1 0)
+    + (A 0 0 * A 2 2 - A 0 2 * A 2 0)
+    + (A 0 0 * A 3 3 - A 0 3 * A 3 0)
+    + (A 1 1 * A 2 2 - A 1 2 * A 2 1)
+    + (A 1 1 * A 3 3 - A 1 3 * A 3 1)
+    + (A 2 2 * A 3 3 - A 2 3 * A 3 2)
+
+/-- The **third elementary symmetric function** of a `4 × 4` matrix: the sum of its four principal
+`3 × 3` minors (rows/cols `{1,2,3}`, `{0,2,3}`, `{0,1,3}`, `{0,1,2}`).  For eigenvalues
+`a, b, c, d` this is `abc+abd+acd+bcd`. -/
+def e3 (A : Matrix (Fin 4) (Fin 4) R) : R :=
+  (A 1 1 * A 2 2 * A 3 3 - A 1 1 * A 2 3 * A 3 2 - A 1 2 * A 2 1 * A 3 3
+    + A 1 2 * A 2 3 * A 3 1 + A 1 3 * A 2 1 * A 3 2 - A 1 3 * A 2 2 * A 3 1)
+  + (A 0 0 * A 2 2 * A 3 3 - A 0 0 * A 2 3 * A 3 2 - A 0 2 * A 2 0 * A 3 3
+    + A 0 2 * A 2 3 * A 3 0 + A 0 3 * A 2 0 * A 3 2 - A 0 3 * A 2 2 * A 3 0)
+  + (A 0 0 * A 1 1 * A 3 3 - A 0 0 * A 1 3 * A 3 1 - A 0 1 * A 1 0 * A 3 3
+    + A 0 1 * A 1 3 * A 3 0 + A 0 3 * A 1 0 * A 3 1 - A 0 3 * A 1 1 * A 3 0)
+  + (A 0 0 * A 1 1 * A 2 2 - A 0 0 * A 1 2 * A 2 1 - A 0 1 * A 1 0 * A 2 2
+    + A 0 1 * A 1 2 * A 2 0 + A 0 2 * A 1 0 * A 2 1 - A 0 2 * A 1 1 * A 2 0)
+
+/-! ## Part III: the matrix-side Newton identity `p₄` -/
+
+/-- **The matrix-side Newton identity `p₄ = e₁⁴ − 4 e₁² e₂ + 2 e₂² + 4 e₁ e₃ − 4 e₄` in
+dimension four.**  Over any commutative ring,
+
+      tr(A⁴) = (tr A)⁴ − 4 (tr A)² e₂(A) + 2 e₂(A)² + 4 (tr A) e₃(A) − 4 det A.
+
+This is the first power sum reaching the top function `e₄ = det` (and the first with a `2 e₂²`
+term).  A polynomial identity in the sixteen entries, closed by `ring`. -/
+theorem trace_fourth_fin_four (A : Matrix (Fin 4) (Fin 4) R) :
+    (A ^ 4).trace
+      = A.trace ^ 4 - 4 * A.trace ^ 2 * e2 A + 2 * e2 A ^ 2
+        + 4 * A.trace * e3 A - 4 * A.det := by
+  have hpow : A ^ 4 = A * A * A * A := by
+    rw [pow_succ, pow_succ, pow_succ, pow_one]
+  rw [hpow, det_fin_four]
+  simp only [Matrix.trace, Matrix.diag_apply, Fin.sum_univ_four, Matrix.mul_apply, e2, e3]
+  ring
+
+/-! ## Part IV: the characteristic polynomial in elementary-symmetric form -/
+
+/-- **The `4 × 4` characteristic polynomial in elementary-symmetric form.**
+`charpoly A = X⁴ − (tr A) X³ + e₂(A) X² − e₃(A) X + det A`. -/
+theorem charpoly_fin_four (A : Matrix (Fin 4) (Fin 4) R) :
+    A.charpoly = X ^ 4 - C A.trace * X ^ 3 + C (e2 A) * X ^ 2 - C (e3 A) * X + C A.det := by
+  have htr : A.trace = A 0 0 + A 1 1 + A 2 2 + A 3 3 := by
+    simp [Matrix.trace, Matrix.diag_apply, Fin.sum_univ_four]
+  rw [show A.charpoly = (Matrix.charmatrix A).det from rfl, det_fin_four, htr, e2, e3,
+    det_fin_four]
+  simp only [Matrix.charmatrix_apply_eq, Matrix.charmatrix_apply_ne, Fin.isValue,
+    ne_eq, Fin.reduceEq, not_false_eq_true, map_add, map_sub, map_mul]
+  ring
+
+/-- `e₂(A)` is the `X²`-coefficient of the characteristic polynomial of a `4 × 4` matrix. -/
+theorem charpoly_coeff_two_eq_e2 (A : Matrix (Fin 4) (Fin 4) R) :
+    A.charpoly.coeff 2 = e2 A := by
+  rw [charpoly_fin_four]
+  simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+
+/-- `e₃(A)` is *minus* the `X¹`-coefficient of the characteristic polynomial of a `4 × 4`
+matrix (the sign alternates with the elementary symmetric functions). -/
+theorem charpoly_coeff_one_eq_neg_e3 (A : Matrix (Fin 4) (Fin 4) R) :
+    A.charpoly.coeff 1 = -e3 A := by
+  rw [charpoly_fin_four]
+  simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow', coeff_mul_X]
+
+/-! ## Part V: the spectral form `tr(A⁴) = Σ λᵢ⁴` over an algebraically closed field -/
+
+variable {K : Type*} [Field K] [IsAlgClosed K]
+
+/-- A `4 × 4` matrix over an algebraically closed field has exactly four eigenvalues. -/
+theorem card_eigenvalues_fin_four (A : Matrix (Fin 4) (Fin 4) K) :
+    Multiset.card (eigenvalues A) = 4 := by
+  rw [SpectralTraceDetEigenvaluesOQ01.card_eigenvalues_eq_dim]
+  simp
+
+/-- The characteristic polynomial factors over the eigenvalues (Vieta). -/
+theorem charpoly_eq_prod_eigenvalues (A : Matrix (Fin 4) (Fin 4) K) :
+    A.charpoly = ((eigenvalues A).map (fun r => X - C r)).prod :=
+  (IsAlgClosed.splits A.charpoly).eq_prod_roots_of_monic A.charpoly_monic
+
+/-- **Newton's fourth power-sum identity, spectral form.**  Over an algebraically closed field,
+the trace of `A⁴` is the sum of the fourth powers of the eigenvalues of the `4 × 4` matrix `A`:
+
+      tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴.
+
+The proof identifies the four elementary symmetric functions of the eigenvalues `a, b, c, d` with
+`tr A = a+b+c+d`, `e₂(A) = ab+ac+ad+bc+bd+cd`, `e₃(A) = abc+abd+acd+bcd`, and `det A = abcd`
+(the first and last from the grandparent, the middle two from the charpoly coefficients + Vieta),
+then matches the matrix-side Newton identity `trace_fourth_fin_four` against the elementary
+multiset identity for `a⁴+b⁴+c⁴+d⁴`. -/
+theorem trace_fourth_eq_sum_fourth_eigenvalues (A : Matrix (Fin 4) (Fin 4) K) :
+    (A ^ 4).trace = ((eigenvalues A).map (· ^ 4)).sum := by
+  obtain ⟨a, b, c, d, habcd⟩ := Multiset.card_eq_four.mp (card_eigenvalues_fin_four A)
+  -- the four elementary symmetric functions of the eigenvalues, via Vieta
+  have hexpand : A.charpoly
+      = X ^ 4 - C (a + b + c + d) * X ^ 3
+        + C (a*b + a*c + a*d + b*c + b*d + c*d) * X ^ 2
+        - C (a*b*c + a*b*d + a*c*d + b*c*d) * X + C (a*b*c*d) := by
+    rw [charpoly_eq_prod_eigenvalues, habcd]
+    simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+      Multiset.prod_cons, Multiset.prod_singleton]
+    have : (X - C a) * ((X - C b) * ((X - C c) * (X - C d)))
+        = X ^ 4 - C (a + b + c + d) * X ^ 3
+          + C (a*b + a*c + a*d + b*c + b*d + c*d) * X ^ 2
+          - C (a*b*c + a*b*d + a*c*d + b*c*d) * X + C (a*b*c*d) := by
+      simp only [map_add, map_mul]; ring
+    rw [this]
+  have htr : A.trace = a + b + c + d := by
+    rw [SpectralTraceDetEigenvaluesOQ01.trace_eq_sum_eigenvalues, habcd]
+    simp [add_assoc]
+  have hdet : A.det = a * b * c * d := by
+    rw [SpectralTraceDetEigenvaluesOQ01.det_eq_prod_eigenvalues, habcd]
+    simp [mul_assoc]
+  have he2 : e2 A = a*b + a*c + a*d + b*c + b*d + c*d := by
+    have h := charpoly_coeff_two_eq_e2 A
+    rw [hexpand] at h
+    simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow',
+      coeff_mul_X] at h
+    linear_combination -h
+  have he3 : e3 A = a*b*c + a*b*d + a*c*d + b*c*d := by
+    have h := charpoly_coeff_one_eq_neg_e3 A
+    rw [hexpand] at h
+    simp [coeff_X_pow, coeff_C, coeff_sub, coeff_add, coeff_mul_X_pow',
+      coeff_mul_X] at h
+    linear_combination h
+  rw [trace_fourth_fin_four, htr, hdet, he2, he3, habcd]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.sum_cons, Multiset.sum_singleton]
+  ring
+
+/-! ## Part VI: a concrete illustration -/
+
+/-- For `A = !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,0,0,2]` the matrix-side identity gives `tr(A⁴)`
+from `tr A`, `e₂(A)`, `e₃(A)`, and `det A` without computing eigenvalues. -/
+theorem trace_fourth_example :
+    (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2] ^ 4).trace
+      = (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2]).trace ^ 4
+        - 4 * (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2]).trace ^ 2
+            * e2 (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2])
+        + 2 * e2 (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2]) ^ 2
+        + 4 * (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2]).trace
+            * e3 (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2])
+        - 4 * (!![(1 : ℚ), 2, 0, 1; 0, 3, 1, 0; 4, 0, 2, 1; 1, 0, 0, 2]).det :=
+  trace_fourth_fin_four _
+
+end SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.trace_fourth_fin_four
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.trace_fourth_eq_sum_fourth_eigenvalues
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.charpoly_coeff_two_eq_e2
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.det_fin_four

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "ann-spectral-trace-oq01010201-00-header",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 58 },
+    "type": "context",
+    "title": "The open question: Newton's fourth power sum in dimension four",
+    "content": "The docstring states the goal carried over from the parent oq-01-oq-01-oq-02, which reached tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 matrices via Newton's p₃ = e₁³ − 3e₁e₂ + 3e₃. This file extends to the next power sum and dimension: tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, read spectrally as tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴. The honesty note flags why p₄ is special: it is the FIRST power sum whose Newton expansion involves all four elementary symmetric functions e₁,e₂,e₃,e₄ — including the top function e₄ = det, which appears here for the first time (p₂ reaches e₂, p₃ reaches e₃, only p₄ reaches e₄) — and the first with a quadratic symmetric term 2e₂². Mathlib has neither det_fin_four nor trace_fin_four, so the 4×4 determinant is built from the cofactor rule det_succ_row_zero. Imports Mathlib and the grandparent, opens Matrix/Polynomial, reuses the `eigenvalues` abbreviation.",
+    "mathContext": "Newton's identities: $p_3 = e_1^3 - 3e_1e_2 + 3e_3$, $p_4 = e_1^4 - 4e_1^2e_2 + 2e_2^2 + 4e_1e_3 - 4e_4$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Newton's identities",
+      "power sums",
+      "elementary symmetric functions",
+      "spectral mapping theorem"
+    ],
+    "prerequisites": [
+      "characteristic polynomial",
+      "eigenvalues with multiplicity"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-01-det-fin-four",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 65, "endLine": 91 },
+    "type": "key-step",
+    "title": "Building the 4×4 determinant — Mathlib stops at det_fin_three",
+    "content": "`det_fin_four` proves the full 24-term Leibniz expansion of the 4×4 determinant, which Mathlib does not provide (it ships det_fin_two and det_fin_three only). The proof applies the cofactor rule `det_succ_row_zero` once to expand along row 0, then `Fin.sum_univ_four` to make the four cofactor terms explicit and `det_fin_three` to expand each 3×3 principal minor. The leftover Fin.succAbove / Fin.succ index arithmetic from the submatrices is normalised by simp + norm_num, and two proof-irrelevant rewrites (⟨2,_⟩ = 2 and ⟨3,_⟩ = 3) convert the Fin.mk forms to the OfNat literals so that `ring` recognises all sixteen entries as a single polynomial and closes the goal.",
+    "mathContext": "Cofactor expansion along row 0: $\\det A = \\sum_{j=0}^{3} (-1)^j A_{0j}\\,M_{0j}$, $M_{0j}$ the $3\\times3$ principal minor omitting row 0 and column $j$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Laplace/cofactor expansion",
+      "Leibniz formula",
+      "Fin.succAbove index bookkeeping"
+    ],
+    "prerequisites": [
+      "determinant of a 3×3 matrix",
+      "minors and cofactors"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-02-elem-sym",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 92, "endLine": 116 },
+    "type": "definition",
+    "title": "The second and third elementary symmetric functions of a 4×4 matrix",
+    "content": "`e2` is the sum of the six principal 2×2 minors (one for each pair from {0,1,2,3}); for eigenvalues a,b,c,d it equals ab+ac+ad+bc+bd+cd. `e3` is the sum of the four principal 3×3 minors (one for each triple {1,2,3}, {0,2,3}, {0,1,3}, {0,1,2}), each written in Sarrus form; for eigenvalues a,b,c,d it equals abc+abd+acd+bcd. These are the genuinely intermediate elementary symmetric functions — e₃ in particular is the first that is neither trace, determinant, nor a 2×2-minor sum.",
+    "mathContext": "$e_2 = \\sum_{i<j}\\lambda_i\\lambda_j$ (six principal $2\\times2$ minors); $e_3 = \\sum_{i<j<k}\\lambda_i\\lambda_j\\lambda_k$ (four principal $3\\times3$ minors).",
+    "significance": "standard",
+    "relatedConcepts": [
+      "elementary symmetric polynomials",
+      "principal minors",
+      "Vieta's formulas"
+    ],
+    "prerequisites": [
+      "minors of a matrix"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-03-matrix-newton",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 117, "endLine": 135 },
+    "type": "key-step",
+    "title": "The matrix-side Newton identity p₄ over any commutative ring",
+    "content": "`trace_fourth_fin_four` proves tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A. The proof rewrites A⁴ as the quadruple product A·A·A·A (via pow_succ), then expands the trace, the matrix multiplications, e₂, e₃, and (through the built det_fin_four) the determinant entrywise via Matrix.trace, Matrix.mul_apply, and Fin.sum_univ_four, and closes by `ring`. This is a polynomial identity in the sixteen entries — no field, no algebraic closure, no eigenvalues. It is the fourth power sum p₄ at the matrix level: the first to reach the top symmetric function e₄ = det, and the first to carry a quadratic symmetric term 2e₂².",
+    "mathContext": "$\\operatorname{tr}(A^4) = (\\operatorname{tr}A)^4 - 4(\\operatorname{tr}A)^2 e_2(A) + 2e_2(A)^2 + 4(\\operatorname{tr}A)e_3(A) - 4\\det A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Newton's identities",
+      "trace of a matrix power",
+      "polynomial identity over a commutative ring"
+    ],
+    "prerequisites": [
+      "matrix multiplication and trace",
+      "the ring tactic"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-04-charpoly",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 136, "endLine": 162 },
+    "type": "key-step",
+    "title": "The characteristic polynomial in elementary-symmetric form",
+    "content": "`charpoly_fin_four` proves charpoly = X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, expanded entrywise from charmatrix (X·I − A) and the built det_fin_four and ring-normalised. `charpoly_coeff_two_eq_e2` reads off e₂(A) as the X²-coefficient, while `charpoly_coeff_one_eq_neg_e3` reads off e₃(A) as MINUS the X¹-coefficient — the alternating signs of the characteristic polynomial put a minus sign on the odd elementary symmetric functions. These two coefficient identities are the bridge that turns the matrix-side minor sums into the spectral symmetric functions of the eigenvalues via Vieta.",
+    "mathContext": "$\\chi_A(X) = X^4 - (\\operatorname{tr}A)X^3 + e_2(A)X^2 - e_3(A)X + \\det A$; coeff $2 = e_2$, coeff $1 = -e_3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "characteristic polynomial",
+      "charmatrix",
+      "Vieta's formulas",
+      "alternating signs of symmetric functions"
+    ],
+    "prerequisites": [
+      "polynomial coefficients",
+      "the charmatrix construction"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-05-spectral",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 163, "endLine": 227 },
+    "type": "key-step",
+    "title": "The spectral form tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴",
+    "content": "`card_eigenvalues_fin_four` (a 4×4 matrix has exactly four eigenvalues, from the grandparent's card_eigenvalues_eq_dim) and `charpoly_eq_prod_eigenvalues` (Vieta: charpoly = Π(X − λᵢ)) set up the spectral identification. `trace_fourth_eq_sum_fourth_eigenvalues` then proves tr(A⁴) = Σλᵢ⁴ over an algebraically closed field: writing the eigenvalue multiset as {a,b,c,d}, the four elementary symmetric functions are identified with tr A = a+b+c+d (grandparent), e₂(A) = ab+ac+ad+bc+bd+cd (from coeff 2), e₃(A) = abc+abd+acd+bcd (from −coeff 1), and det A = abcd (grandparent). Substituting into the matrix-side identity trace_fourth_fin_four and matching against the four-variable Newton identity for a⁴+b⁴+c⁴+d⁴ closes the goal by ring.",
+    "mathContext": "$\\operatorname{tr}(A^4) = \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4 + \\lambda_4^4$, with $e_1,e_2,e_3,e_4$ the symmetric functions of the spectrum.",
+    "significance": "key",
+    "relatedConcepts": [
+      "spectral mapping theorem",
+      "Vieta's formulas",
+      "Newton's identities",
+      "algebraically closed field"
+    ],
+    "prerequisites": [
+      "eigenvalues as charpoly roots",
+      "splitting of polynomials over an algebraically closed field"
+    ]
+  },
+  {
+    "id": "ann-spectral-trace-oq01010201-06-example",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 228, "endLine": 245 },
+    "type": "example",
+    "title": "A concrete 4×4 rational illustration",
+    "content": "`trace_fourth_example`: for the rational matrix !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,0,0,2] the matrix-side identity recovers tr(A⁴) from the trace, the two minor sums e₂(A) and e₃(A), and the determinant — without ever computing the (irrational/complex) eigenvalues. The closing #print axioms audit confirms the headline theorems depend only on the foundational propext/Classical.choice/Quot.sound, with no Lean.ofReduceBool or sorryAx.",
+    "mathContext": "$\\operatorname{tr}(A^4)$ recovered from $\\operatorname{tr}A,\\ e_2(A),\\ e_3(A),\\ \\det A$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "rational invariants of an irrational spectrum",
+      "axiom audit"
+    ],
+    "prerequisites": [
+      "matrix literals in Lean"
+    ]
+  }
+]

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Data: ProofData = {
+  proof: spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Proof,
+  annotations: spectralTraceDetEigenvaluesOq01Oq01Oq02Oq01Annotations,
+}

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,202 @@
+{
+  "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+  "title": "Newton's Fourth Power Sum: tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ for 4×4 Matrices",
+  "slug": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-01",
+  "description": "Settles the open question posed by spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02 (openQuestions[0]): carry the matrix-side-then-spectral Newton template to the fourth power sum in dimension four, tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, read spectrally as tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴. This is the FIRST power sum whose Newton expansion involves ALL FOUR elementary symmetric functions e₁,e₂,e₃,e₄ of a 4×4 matrix — including the top function e₄ = det, which appears in the power-sum hierarchy for the first time here (p₂ reaches e₂, p₃ reaches e₃, only p₄ reaches e₄), and the first quadratic symmetric term 2e₂², absent from every lower power sum. Because Mathlib provides det_fin_two/det_fin_three but NEITHER det_fin_four NOR trace_fin_four, the 4×4 determinant expansion is built here from the cofactor rule det_succ_row_zero. Results: (1) det_fin_four — the full 24-term Leibniz expansion of the 4×4 determinant (Mathlib stops at 3×3); (2) trace_fourth_fin_four — the matrix-side Newton identity tr(A⁴) = (tr A)⁴ − 4(tr A)²e₂(A) + 2e₂(A)² + 4(tr A)e₃(A) − 4 det A over ANY commutative ring, a polynomial identity in the sixteen entries closed by ring; (3) charpoly_fin_four / charpoly_coeff_two_eq_e2 / charpoly_coeff_one_eq_neg_e3 — the 4×4 characteristic polynomial in elementary-symmetric form X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, identifying e₂(A) and e₃(A) as its X²- and X¹-coefficients (the latter with the sign flip e₃ = −coeff 1); (4) trace_fourth_eq_sum_fourth_eigenvalues — the spectral form tr(A⁴) = Σλᵢ⁴ over an algebraically closed field via Vieta. A concrete rational 4×4 example reads tr(A⁴) off from trace, the two minor sums, and the determinant without computing eigenvalues. Fully verified, 0 axioms, 0 sorries, no decide/native_decide.",
+  "meta": {
+    "author": "Classical (Newton's identities; spectral mapping theorem); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_identities",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "eigenvalues",
+      "characteristic-polynomial",
+      "trace",
+      "determinant",
+      "power-sums",
+      "newtons-identities",
+      "spectral-mapping",
+      "symmetric-functions",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_succ_row_zero",
+        "description": "cofactor (Laplace) expansion of an (n+1)×(n+1) determinant along the zeroth row. Since Mathlib has no det_fin_four, this is applied once to the 4×4 determinant and then det_fin_three to each of the four 3×3 minors, after resolving the Fin.succAbove index bookkeeping, to build the explicit 24-term det_fin_four expansion.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_three",
+        "description": "explicit Sarrus expansion of the 3×3 determinant, applied to each of the four principal 3×3 minors produced by the cofactor expansion of the 4×4 determinant, and reused to expand the four principal 3×3 minors that make up e₃(A).",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.charmatrix",
+        "description": "the matrix X·I − A whose determinant is the characteristic polynomial; charmatrix_apply_eq and charmatrix_apply_ne expand the 4×4 charpoly entrywise so that the built det_fin_four yields the elementary-symmetric form X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "IsAlgClosed.splits_codomain",
+        "description": "over an algebraically closed field every polynomial splits; combined with eq_prod_roots_of_monic and the monic charpoly it factors A.charpoly = Π(X − λᵢ) over the eigenvalue multiset (Vieta), supplying the spectral identification of e₂ and e₃ with the second and third symmetric functions of the four eigenvalues.",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Multiset.card_eq_four",
+        "description": "a multiset has cardinality four iff it equals {a, b, c, d}. Reduces the 4×4 spectral trace power sum to the four-variable Newton identity for a⁴+b⁴+c⁴+d⁴ in the elementary symmetric functions of a,b,c,d.",
+        "module": "Mathlib.Data.Multiset.ZeroCons"
+      }
+    ],
+    "originalContributions": [
+      "det_fin_four: the full 24-term Leibniz expansion of the 4×4 determinant, built from the cofactor rule det_succ_row_zero and det_fin_three — Mathlib ships det_fin_two and det_fin_three but no det_fin_four, so this fills a genuine gap and is what lets ring see e₄ = det as a polynomial in the sixteen entries",
+      "trace_fourth_fin_four: the matrix-side Newton identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over ANY commutative ring — a polynomial identity in the sixteen entries closed by ring, needing no field, no algebraic closure, and no eigenvalues; the fourth power sum p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ at the matrix level, the first to reach the top symmetric function e₄ and the first with a quadratic symmetric term 2e₂²",
+      "e2, e3: the second and third elementary symmetric functions of a 4×4 matrix as the sum of the six principal 2×2 minors and the sum of the four principal 3×3 minors respectively; e₃ is the first symmetric function that is neither trace, determinant, nor a 2×2-minor sum",
+      "charpoly_fin_four: the 4×4 characteristic polynomial in elementary-symmetric form X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, derived entrywise from charmatrix and the built det_fin_four",
+      "charpoly_coeff_two_eq_e2 and charpoly_coeff_one_eq_neg_e3: e₂(A) is the X²-coefficient and e₃(A) is MINUS the X¹-coefficient of the characteristic polynomial — the alternating-sign bridge that identifies the minor sums with the spectral symmetric functions ab+ac+ad+bc+bd+cd and abc+abd+acd+bcd via Vieta",
+      "trace_fourth_eq_sum_fourth_eigenvalues: the spectral form tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ over an algebraically closed field — the first power-sum statement that genuinely exercises every elementary symmetric function of the spectrum, settling the parent entry's open question",
+      "trace_fourth_example: for the rational matrix !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,0,0,2] the matrix-side identity recovers tr(A⁴) from the trace, both minor sums e₂(A), e₃(A), and det A without ever computing the (irrational/complex) eigenvalues"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 250,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used; #print axioms confirms the headline theorems (trace_fourth_fin_four, trace_fourth_eq_sum_fourth_eigenvalues, charpoly_coeff_two_eq_e2, det_fin_four) depend on no Lean.ofReduceBool or sorryAx. The matrix-side identity trace_fourth_fin_four and the expansion det_fin_four hold over any commutative ring; the spectral form trace_fourth_eq_sum_fourth_eigenvalues requires an algebraically closed field (so the characteristic polynomial splits and the eigenvalue multiset has exactly four elements). SCOPE: this entry proves the k=4 power sum in dimension n=4. The general trace power sum tr(Aᵏ) = Σλᵢᵏ for all n and k remains the standing open question (it requires the full multiset spectral mapping, absent from the Mathlib snapshot used here).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Newton's identities (Isaac Newton, c. 1666; also Girard) express the power sums pₖ = Σλᵢᵏ through the elementary symmetric functions eⱼ: p₁ = e₁, p₂ = e₁² − 2e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃, p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄. For the eigenvalues of a matrix the eⱼ are (up to sign) the coefficients of the characteristic polynomial — e₁ = trace, eₙ = determinant, and the intermediate eⱼ the sums of principal j×j minors. The power sums pₖ are the traces tr(Aᵏ), the trace half of the spectral mapping theorem spec(p(A)) = p(spec(A)). The chain spectral-trace-det-eigenvalues-oq-01 → oq-01-oq-01 → oq-01-oq-01-oq-02 settled p₁ (trace), p₂ for 2×2, and p₃ for 3×3; the cube was the first power sum to need a middle symmetric function (e₂). The fourth power sum p₄ in dimension four is the first to reach the TOP symmetric function e₄ = det and the first to carry a quadratic symmetric term 2e₂².",
+    "problemStatement": "**Open Question (spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02, openQuestions[0])**: Carry the same matrix-side-then-spectral template to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ in dimension four, the first power sum to involve all four elementary symmetric functions including the new e₄ = det.\n\n**Result**: trace_fourth_fin_four establishes the matrix-side identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over any commutative ring; trace_fourth_eq_sum_fourth_eigenvalues upgrades it to the spectral statement tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ over an algebraically closed field, with e₂(A) and e₃(A) identified as principal-minor sums and as the X²- and (negated) X¹-coefficients of the characteristic polynomial. The 4×4 determinant expansion det_fin_four, absent from Mathlib, is built from the cofactor rule.",
+    "text": "Let A be a 4×4 matrix. Write e₁(A) = tr A, e₂(A) for the sum of the six principal 2×2 minors, e₃(A) for the sum of the four principal 3×3 minors, and e₄(A) = det A. Newton's fourth identity gives tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ as a polynomial identity in the sixteen entries, valid over any commutative ring. Over an algebraically closed field the characteristic polynomial X⁴ − e₁X³ + e₂X² − e₃X + e₄ splits as Π(X − λᵢ), so the eⱼ become the elementary symmetric functions of λ₁,λ₂,λ₃,λ₄ and the identity becomes the spectral power sum tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Build det_fin_four (Mathlib stops at det_fin_three): one cofactor expansion det_succ_row_zero turns the 4×4 determinant into Σⱼ (−1)ʲ A 0 j · det(minor j); Fin.sum_univ_four makes the four terms explicit, det_fin_three expands each 3×3 minor, and the Fin.succAbove/Fin.succ index bookkeeping is discharged by simp + norm_num plus two proof-irrelevant rewrites ⟨2,_⟩ = 2, ⟨3,_⟩ = 3 so that ring sees a polynomial in the sixteen entries.\n\n2. Matrix-side identity (any commutative ring): define e₂(A) and e₃(A) as the principal 2×2- and 3×3-minor sums. Expand (A^4).trace via A⁴ = A·A·A·A, Matrix.trace, mul_apply, Fin.sum_univ_four, and unfold e₂, e₃, det via det_fin_four; the identity tr(A⁴) = (tr A)⁴ − 4(tr A)²e₂ + 2e₂² + 4(tr A)e₃ − 4 det A then closes by ring. No eigenvalues, no field.\n\n3. Characteristic polynomial in elementary-symmetric form: expand charpoly = det(X·I − A) entrywise with charmatrix and det_fin_four, then ring-normalise to X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A. Reading off coefficients gives charpoly_coeff_two_eq_e2 (coeff 2 = e₂) and charpoly_coeff_one_eq_neg_e3 (coeff 1 = −e₃).\n\n4. Spectral upgrade (algebraically closed field): the eigenvalue multiset has exactly four elements (card_eigenvalues_fin_four, from the grandparent's card_eigenvalues_eq_dim). Vieta (charpoly = Π(X − λᵢ)) identifies the four elementary symmetric functions of a,b,c,d with tr A (grandparent), e₂(A) (from coeff 2), e₃(A) (from −coeff 1), and det A (grandparent). Substituting into the matrix-side identity and matching against the four-variable Newton identity for a⁴+b⁴+c⁴+d⁴ yields tr(A⁴) = a⁴+b⁴+c⁴+d⁴.\n\n5. Example: instantiate trace_fourth_fin_four at !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,0,0,2] over ℚ.",
+    "keyInsights": [
+      "**The fourth power is the first to reach the determinant.** The power-sum hierarchy climbs the elementary symmetric functions one step at a time: p₂ = e₁² − 2e₂ first uses e₂, p₃ = e₁³ − 3e₁e₂ + 3e₃ first uses e₃, and only p₄ = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ first uses the TOP function e₄ = det. So tr(A⁴) in dimension four is the first trace power sum that genuinely exercises every elementary symmetric function of the matrix at once.",
+      "**The quadratic term 2e₂² is new.** Every lower Newton expansion is linear in each eⱼ; p₄ is the first to carry a square, 2e₂². At the matrix level this is 2·(sum of six principal 2×2 minors)², a degree-four invariant that has no analogue in p₁, p₂, or p₃.",
+      "**Mathlib's determinant expansions stop at 3×3 — det_fin_four had to be built.** Mathlib provides det_fin_two and det_fin_three (and trace_fin_two/trace_fin_three) but neither det_fin_four nor trace_fin_four. The 24-term Leibniz expansion is assembled here from the cofactor rule det_succ_row_zero plus det_fin_three, with the Fin.succAbove index bookkeeping resolved so that ring can treat the determinant as an honest polynomial in the sixteen entries.",
+      "**The signs alternate: e₂ is +coeff 2 but e₃ is −coeff 1.** The characteristic polynomial X⁴ − e₁X³ + e₂X² − e₃X + e₄ alternates signs, so the third minor sum e₃(A) equals MINUS the X¹-coefficient of the charpoly. This sign is exactly what makes the +4e₁e₃ term of p₄ come out right when the matrix-side identity is matched to the spectral one.",
+      "**A trace power sum of an unknowable spectrum is a rational invariant.** For !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,0,0,2] the eigenvalues are not rational, yet tr(A⁴) is forced by tr A, the two minor sums e₂, e₃, and det A — read off without ever solving the quartic."
+    ],
+    "prerequisites": [
+      "The characteristic polynomial and its roots as eigenvalues with algebraic multiplicity (spectral-trace-det-eigenvalues-oq-01)",
+      "The 3×3 trace power sum tr(A³) = Σλᵢ³ and Newton's identity p₃ = e₁³ − 3e₁e₂ + 3e₃ (spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02)",
+      "Newton's identities relating power sums to elementary symmetric functions; Vieta's formulas for a monic quartic; cofactor (Laplace) expansion of a determinant"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Open Question",
+      "startLine": 4,
+      "endLine": 58,
+      "summary": "Module docstring stating the goal carried over from the parent oq-01-oq-01-oq-02 (which reached tr(A³) = Σλᵢ³): extend to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄, the first power sum involving all four elementary symmetric functions including the new e₄ = det. Notes that Mathlib has neither det_fin_four nor trace_fin_four, so the 4×4 determinant is built from the cofactor rule; imports Mathlib and the grandparent file, opens Matrix/Polynomial, reuses the eigenvalues abbreviation.",
+      "mathContext": "$p_4 = e_1^4 - 4e_1^2e_2 + 2e_2^2 + 4e_1e_3 - 4e_4$."
+    },
+    {
+      "id": "det-fin-four",
+      "title": "Building the 4×4 Determinant Expansion (absent from Mathlib)",
+      "startLine": 65,
+      "endLine": 91,
+      "summary": "det_fin_four: the full 24-term Leibniz expansion of the 4×4 determinant, derived from one cofactor expansion det_succ_row_zero followed by det_fin_three on each of the four 3×3 minors, with the Fin.succAbove/Fin.succ index bookkeeping resolved by simp + norm_num and two proof-irrelevant rewrites so that ring closes the goal.",
+      "mathContext": "$\\det A = \\sum_{j} (-1)^j A_{0j}\\,M_{0j}$, the cofactor expansion along row 0."
+    },
+    {
+      "id": "elem-sym",
+      "title": "The Elementary Symmetric Functions e₂ and e₃ of a 4×4 Matrix",
+      "startLine": 92,
+      "endLine": 116,
+      "summary": "e2 (sum of the six principal 2×2 minors) and e3 (sum of the four principal 3×3 minors, one for each three-element subset of {0,1,2,3}), the second and third elementary symmetric functions; for eigenvalues a,b,c,d these are ab+ac+ad+bc+bd+cd and abc+abd+acd+bcd.",
+      "mathContext": "$e_2 = \\sum_{i<j}\\lambda_i\\lambda_j$, $e_3 = \\sum_{i<j<k}\\lambda_i\\lambda_j\\lambda_k$."
+    },
+    {
+      "id": "matrix-newton",
+      "title": "The Matrix-Side Newton Identity p₄ over any Commutative Ring",
+      "startLine": 117,
+      "endLine": 135,
+      "summary": "trace_fourth_fin_four: tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A, a polynomial identity in the sixteen entries over any commutative ring. The proof rewrites A⁴ = A·A·A·A, expands trace, the matrix products, e₂, e₃ and (via det_fin_four) det entrywise, then closes by ring — the first power sum reaching e₄ = det and the first with a quadratic 2e₂² term.",
+      "mathContext": "$\\operatorname{tr}(A^4) = (\\operatorname{tr}A)^4 - 4(\\operatorname{tr}A)^2 e_2 + 2e_2^2 + 4(\\operatorname{tr}A)e_3 - 4\\det A$."
+    },
+    {
+      "id": "charpoly",
+      "title": "The Characteristic Polynomial in Elementary-Symmetric Form",
+      "startLine": 136,
+      "endLine": 162,
+      "summary": "charpoly_fin_four (charpoly = X⁴ − (tr A)X³ + e₂(A)X² − e₃(A)X + det A, expanded entrywise from charmatrix and the built det_fin_four), charpoly_coeff_two_eq_e2 (e₂ is the X²-coefficient), and charpoly_coeff_one_eq_neg_e3 (e₃ is MINUS the X¹-coefficient) — the alternating-sign bridges identifying the minor sums with the second and third symmetric functions of the eigenvalues.",
+      "mathContext": "$\\chi_A(X) = X^4 - (\\operatorname{tr}A)X^3 + e_2(A)X^2 - e_3(A)X + \\det A$."
+    },
+    {
+      "id": "spectral",
+      "title": "The Spectral Form tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴",
+      "startLine": 163,
+      "endLine": 227,
+      "summary": "card_eigenvalues_fin_four (a 4×4 matrix has exactly four eigenvalues), charpoly_eq_prod_eigenvalues (Vieta), and trace_fourth_eq_sum_fourth_eigenvalues: over an algebraically closed field tr(A⁴) = Σλᵢ⁴, identifying the four symmetric functions of a,b,c,d with tr A, e₂ (coeff 2), e₃ (−coeff 1), det (= abcd) and matching the matrix-side identity to the four-variable Newton identity for a⁴+b⁴+c⁴+d⁴.",
+      "mathContext": "$\\operatorname{tr}(A^4) = \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4 + \\lambda_4^4$."
+    },
+    {
+      "id": "example",
+      "title": "A Concrete 4×4 Rational Illustration",
+      "startLine": 228,
+      "endLine": 245,
+      "summary": "trace_fourth_example: for !![1,2,0,1; 0,3,1,0; 4,0,2,1; 1,0,0,2] over ℚ the matrix-side identity recovers tr(A⁴) from tr A, the minor sums e₂(A), e₃(A), and det A, without computing the eigenvalues; #print axioms audit confirms only the foundational axioms.",
+      "mathContext": "$\\operatorname{tr}(A^4)$ from $\\operatorname{tr}A,\\ e_2(A),\\ e_3(A),\\ \\det A$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+      "relationship": "Direct parent: settled the 3×3 trace power sum tr(A³) = Σλᵢ³ via Newton's p₃ = e₁³ − 3e₁e₂ + 3e₃ and explicitly posed (openQuestions[0]) the extension to tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄ in dimension four that this entry takes up."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "relationship": "Grandparent: establishes trace = Σλ, determinant = Πλ, the eigenvalue count card_eigenvalues_eq_dim, and the Vieta correspondence reused here to identify e₁ and e₄ of the spectrum with trace and determinant."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "relationship": "Sibling on cyclic invariance of the trace and similarity-invariance of the eigenvalue multiset; the fourth power sum tr(A⁴) is similarity-invariant for the same reason (conjugation preserves the characteristic polynomial)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of Newton's fourth power sum in dimension four: the matrix-side identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂(A) + 2·e₂(A)² + 4(tr A)·e₃(A) − 4·det A over any commutative ring, and its spectral upgrade tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴ over an algebraically closed field, together with a from-scratch det_fin_four expansion (Mathlib stops at 3×3) and the identification of e₂ and e₃ as the X²- and (negated) X¹-coefficients of the characteristic polynomial.",
+    "implications": "Settles the parent entry's open question by carrying Newton's identities to the first power sum (p₄, dimension 4) whose expansion uses every elementary symmetric function including the top one e₄ = det, and the first with a quadratic symmetric term 2e₂². The reusable det_fin_four expansion fills a real Mathlib gap for 4×4 work. The remaining obstruction to the all-dimensions trace power sum tr(Aᵏ) = Σλᵢᵏ is unchanged: the full multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), absent from the Mathlib snapshot.",
+    "openQuestions": [
+      "Prove the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions n and exponents k, equivalently the multiset spectral mapping (A^k).charpoly.roots = A.charpoly.roots.map(·^k), by building Schur triangulation or a Newton-identity bridge from charpoly coefficients to root power sums — superseding the fixed-dimension ladder p₂ (2×2), p₃ (3×3), p₄ (4×4).",
+      "Generalise det_fin_four to a uniform det_fin_n / trace_fin_n in Mathlib style, or derive the elementary-symmetric form of the characteristic polynomial in arbitrary dimension directly from Matrix.charpoly_coeff and the principal-minor sums, removing the per-dimension entrywise expansion."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SpectralTraceDetEigenvaluesOQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01",
+    "lineCount": 250,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2012",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for Newton's identities relating trace power sums to characteristic-polynomial coefficients, and the trace/determinant/minor sums as elementary symmetric functions of the eigenvalues."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic and Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of det_succ_row_zero (cofactor expansion) and det_fin_three used to build the 4×4 determinant, the charmatrix construction for the characteristic polynomial, and the splitting of polynomials over an algebraically closed field used for the spectral form."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Settles the open question posed by parent `spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02` (openQuestions[0]): carry the matrix-side-then-spectral Newton template to the **fourth power sum in dimension four**,
```
tr(A⁴) = e₁⁴ − 4e₁²e₂ + 2e₂² + 4e₁e₃ − 4e₄,
```
read spectrally as **tr(A⁴) = λ₁⁴ + λ₂⁴ + λ₃⁴ + λ₄⁴**.

This is the **first power sum whose Newton expansion involves all four elementary symmetric functions** e₁,e₂,e₃,e₄ — including the top function **e₄ = det**, appearing in the power-sum hierarchy for the first time (p₂ reaches e₂, p₃ reaches e₃, only p₄ reaches e₄) — and the first with a quadratic symmetric term **2e₂²**.

## Why it needed real work

Mathlib provides `det_fin_two`/`det_fin_three` and `trace_fin_two`/`trace_fin_three` but **neither `det_fin_four` nor `trace_fin_four`**, so the 4×4 determinant expansion is built here from the cofactor rule `det_succ_row_zero` + `det_fin_three` (resolving the `Fin.succAbove` index bookkeeping).

## Results (9 theorems, 2 defs, 250 lines)

- **`det_fin_four`** — full 24-term Leibniz expansion of the 4×4 determinant (fills a Mathlib gap).
- **`trace_fourth_fin_four`** — matrix-side Newton identity tr(A⁴) = (tr A)⁴ − 4(tr A)²·e₂ + 2·e₂² + 4(tr A)·e₃ − 4·det over **any commutative ring**, a polynomial identity in the 16 entries closed by `ring`.
- **`charpoly_fin_four` / `charpoly_coeff_two_eq_e2` / `charpoly_coeff_one_eq_neg_e3`** — charpoly = X⁴ − (tr A)X³ + e₂X² − e₃X + det, with e₂ = coeff 2 and e₃ = −coeff 1 (alternating signs).
- **`trace_fourth_eq_sum_fourth_eigenvalues`** — spectral form tr(A⁴) = Σλᵢ⁴ over an algebraically closed field via Vieta + `Multiset.card_eq_four`.
- **`trace_fourth_example`** — concrete 4×4 rational matrix recovers tr(A⁴) from trace, both minor sums, and det without computing eigenvalues.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` confirms the headline theorems depend only on `propext`, `Classical.choice`, `Quot.sound` — no `native_decide`/`Lean.ofReduceBool`/`sorryAx`.
- Compiles against Mathlib 4.26.0 via the Docker-safe host `lake env lean` toolchain.
- Gallery data (meta.json, index.ts, annotations.json) added; aggregator import registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)