### PR TITLE
Gallery audit: 2 entries clean (newton-girard-k6, pell-ordered-subgroup)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23441,8 +23441,20 @@
       "issues": [],
       "lastAudited": "2026-06-25T06:54:44Z",
       "result": "clean"
+    },
+    "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T06:59:35Z",
+      "result": "clean"
+    },
+    "pell-equation-oq-01-oq-04-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T06:59:35Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T06:54:44Z"
+  "lastUpdated": "2026-06-25T06:59:35Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the two remaining unaudited gallery entries. The other 5 unaudited entries are already covered by open PR #29784. Both entries here audit **CLEAN** — public claims match the Lean kernel guarantees.

### amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01-oq-02
*Newton-Girard k=6 Closed Form over Any CommRing (incl. e₂³ and e₃² terms)*
- `verified` / `original`, axiomCount 0, sorries 0 ✓
- Source: `Proofs/AmgmInequalityOQ02OQ01OQ03OQ01OQ01OQ02.lean` — 6 theorems + 2 defs (matches meta)
- 0 actual sorry / 0 admit / 0 axiom / 0 native_decide / 0 True-stub
- Headline `newton_girard_six_finset` is a genuine k=6 closed-form identity over an arbitrary CommRing — not a thin wrapper. The `assumptions` field honestly discloses reliance on Mathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum` and the sibling k=1..5 closed forms. `#print axioms` reports only `propext`/`Classical.choice`/`Quot.sound`.

### pell-equation-oq-01-oq-04-oq-02-oq-02
*The Pell Cyclic Subgroup ⟨a⟩ as an Ordered Group: (ℤ, <) ≃o ⟨a⟩*
- `verified` / `original`, axiomCount 0, sorries 0 ✓
- Source: `Proofs/PellEquationOQ01OQ04OQ02OQ02.lean` — 12 theorems + 4 defs (matches meta)
- 0 sorry / 0 admit / 0 axiom / 0 native_decide / 0 True-stub
- Headline `pellPowOrderIso` is an original ordered-group isomorphism. `#print axioms` reports only the three foundational axioms.

### Note
The amgm `grep sorry` hit was a false positive — the string "0-sorry" appears in the file's docstring, not as a tactic.

---
Discovered during gallery integrity audit. Tracker updated: both marked `clean`.