### PR TITLE
Enrich gallery entries: structured metadata + annotations (enricher-2)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 3, "endLine": 34 },
+    "type": "context",
+    "title": "Multinomial Support and the Degree-One Case",
+    "content": "The parent entry sums multinomial probabilities over Finset.piAntidiag s n — the functions k : ι → ℕ supported on s with ∑_{i∈s} k i = n, i.e. the compositions of n over the category set s. The name generalises the classical antidiagonal {(a,b) : a+b=n}. This file isolates n = 1, where the support degenerates to the index set s itself: a single trial lands in exactly one category. The variable s : Finset ι requires only DecidableEq ι, and scoped Classical is opened for the membership decisions; the whole file rests solely on Mathlib's piAntidiag API and is axiom-free.",
+    "mathContext": "$\\texttt{piAntidiag}\\,s\\,n = \\{k : \\iota \\to \\mathbb{N} \\mid \\operatorname{supp} k \\subseteq s,\\ \\sum_{i \\in s} k_i = n\\}$; the multinomial support. At $n=1$ this is shown to be $\\{e_i : i \\in s\\} \\cong s$.",
+    "significance": "context",
+    "relatedConcepts": ["multinomial distribution", "compositions of an integer", "Finset.piAntidiag", "antidiagonal"],
+    "prerequisites": ["finite sets", "multinomial coefficient", "support of a function"]
+  },
+  {
     "id": "ann-single-mem",
     "proofId": "binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01",
     "range": { "startLine": 37, "endLine": 51 },

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -52,8 +52,27 @@
     "definitionCount": 1
   },
   "description": "For the multinomial distribution of n trials over a finite category set s, the support is Mathlib's `Finset.piAntidiag s n` — the functions k : ι → ℕ supported on s with ∑_{i∈s} k i = n. This entry treats the degree-one case n = 1: a single trial must land in exactly one category, so each composition is an indicator Pi.single i 1 for a unique i ∈ s. We prove the structural characterisation s.piAntidiag 1 = s.image (Pi.single · 1), deduce the cardinality (s.piAntidiag 1).card = s.card, and package the canonical bijection ↥s ≃ ↥(s.piAntidiag 1). This isolates a clean combinatorial leaf of the parent Multinomial Entropy formalization, where the n = 1 support underlies the recovery of the source entropy.",
-  "overview": "The parent entry sums the multinomial probability over `s.piAntidiag n`. At n = 1 the support collapses to the index set s: this file proves that collapse explicitly, from Mathlib's `mem_piAntidiag` characterisation, with no axioms and no sorries.",
-  "conclusion": "Every degree-one composition over a finite set s is the indicator of exactly one element of s; hence s.piAntidiag 1 is canonically in bijection with s and has cardinality |s|.",
+  "overview": {
+    "historicalContext": "The multinomial distribution generalises the binomial to more than two outcomes: n independent trials, each landing in one of |s| categories with fixed probabilities. Its support — the set of attainable count-vectors — is the set of compositions of n over s, formalised in Mathlib as Finset.piAntidiag s n (functions k : ι → ℕ supported on s with ∑_{i∈s} k i = n). The name 'antidiagonal' generalises the classical fact that the pairs (a,b) with a+b=n form the antidiagonal of an n×n grid; piAntidiag is the |s|-fold analogue. The combinatorics of these compositions underlies the multinomial coefficient n!/∏ kᵢ! and, in the parent entry, the Shannon entropy of the multinomial source. The degenerate degree-one case n=1 is where the recursion bottoms out: a single trial is a single category choice.",
+    "problemStatement": "Characterise the support s.piAntidiag 1 of the multinomial distribution with a single trial. Concretely: show s.piAntidiag 1 = s.image (fun i => Pi.single i 1), deduce (s.piAntidiag 1).card = s.card, and exhibit the canonical bijection ↥s ≃ ↥(s.piAntidiag 1), i ↦ Pi.single i 1.",
+    "proofStrategy": "Work through Mathlib's mem_piAntidiag characterisation (membership ⇔ the entries sum to n and the support lies in s). For the forward, non-trivial direction of the structural lemma, observe that a natural-number tuple summing to 1 over s must have a unique entry equal to 1 and all others 0: one index carries nonzero mass (else the sum is 0≠1), that mass is squeezed to exactly 1 by Finset.single_le_sum together with ∑=1, and any second nonzero index would push the two-element partial sum f i + f j above 1 (Finset.sum_pair plus sum_le_sum_of_subset). Hence the tuple equals Pi.single i 1. Injectivity of i ↦ Pi.single i 1 is by evaluation at a distinguishing coordinate; cardinality follows via Finset.card_image_of_injective; the Equiv is packaged with Equiv.ofBijective, surjectivity reusing the image characterisation.",
+    "keyInsights": [
+      "Over the naturals, the equation ∑_{i∈s} k i = 1 has exactly the indicator solutions: a single unit of probability mass placed on one category. The natural-number constraint is essential — over ℝ or ℤ the solution set is infinite, but ℕ-positivity forces a unique support point.",
+      "The proof that no second coordinate can be nonzero is a clean 'two terms already saturate the budget' argument: f i + f j ≤ ∑_s f = 1 with f i = 1 forces f j = 0, encapsulated by Finset.sum_pair and sum_le_sum_of_subset rather than ad hoc casework.",
+      "Pi.single i 1 is the bridge between the analytic object (a probability count-vector) and the combinatorial index i; the entire entry is the statement that this bridge is a bijection at n=1.",
+      "This is the base case of the multinomial support recursion: |s.piAntidiag n| counts compositions, and at n=1 it collapses to |s|, the seed from which the parent's entropy recovery at a single trial proceeds.",
+      "Realising the support as an Equiv (not merely an equation of cardinalities) lets downstream sums over s.piAntidiag 1 be re-indexed by s directly — the computationally useful form for entropy and probability calculations."
+    ]
+  },
+  "conclusion": {
+    "summary": "Every degree-one composition over a finite set s is the indicator Pi.single i 1 of exactly one element i ∈ s. The file proves this structural characterisation s.piAntidiag 1 = s.image (Pi.single · 1), deduces the cardinality (s.piAntidiag 1).card = s.card, and packages the canonical bijection ↥s ≃ ↥(s.piAntidiag 1). All four results are axiom-free and rest only on Mathlib's Finset.piAntidiag API.",
+    "implications": "Identifying the single-trial multinomial support with the category set itself is the base case for the multinomial support recursion and for the parent's entropy computation at n=1, where the source entropy is recovered from a single observation. Phrasing the result as an explicit Equiv (rather than just |s.piAntidiag 1| = |s|) lets sums over the degree-one support be re-indexed directly by s, which is the form consumed downstream.",
+    "openQuestions": [
+      "Characterise s.piAntidiag 2 explicitly: degree-two compositions are either a single category with count 2 or an unordered pair of distinct categories with count 1 each, suggesting a bijection with s ⊕ (s.powersetCard 2).",
+      "Give a uniform Equiv for s.piAntidiag n parameterised by n, recovering the multinomial coefficient count |s.piAntidiag n| = (n + |s| - 1).choose (|s| - 1) (stars and bars).",
+      "Lift the bijection to a measure-preserving identification so the single-trial multinomial entropy is computed by transport along piAntidiagOneEquiv."
+    ]
+  },
   "sorries": [],
   "mainTheorems": [
     "piAntidiag_one_eq_image",
@@ -62,16 +81,32 @@
   ],
   "sections": [
     {
-      "title": "Indicators are degree-one tuples",
-      "description": "single_mem_piAntidiag_one: Pi.single i 1 lies in s.piAntidiag 1 for i ∈ s, via mem_piAntidiag (sum 1, support ⊆ s)."
+      "id": "header",
+      "title": "Open Question and Setup",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Module docstring framing the degree-one case of the parent multinomial support, the four main results, imports (Mathlib), opens (Finset, scoped Classical), namespace, and the variable s : Finset ι over a DecidableEq index type."
     },
     {
-      "title": "Structural characterisation",
-      "description": "piAntidiag_one_eq_image: a degree-one tuple over s, having natural-number entries summing to 1, has exactly one entry equal to 1 and is therefore an indicator; conversely every indicator qualifies."
+      "id": "indicators-are-tuples",
+      "title": "Indicators Are Degree-One Tuples",
+      "startLine": 36,
+      "endLine": 50,
+      "summary": "single_mem_piAntidiag_one: Pi.single i 1 lies in s.piAntidiag 1 for i ∈ s, via mem_piAntidiag — the entries sum to 1 (Finset.sum_eq_single) and the support is ⊆ s."
     },
     {
-      "title": "Cardinality and the explicit bijection",
-      "description": "single_one_injective + card_piAntidiag_one give |s.piAntidiag 1| = |s|; piAntidiagOneEquiv packages i ↦ Pi.single i 1 as an Equiv ↥s ≃ ↥(s.piAntidiag 1)."
+      "id": "structural-characterisation",
+      "title": "Structural Characterisation",
+      "startLine": 52,
+      "endLine": 95,
+      "summary": "piAntidiag_one_eq_image: a degree-one tuple over s, with natural-number entries summing to 1, has exactly one entry equal to 1 and is therefore an indicator; conversely every indicator qualifies. The forward direction squeezes the unique nonzero entry to 1 and zeroes the rest via a two-element partial-sum bound."
+    },
+    {
+      "id": "cardinality-and-bijection",
+      "title": "Cardinality and the Explicit Bijection",
+      "startLine": 97,
+      "endLine": 123,
+      "summary": "single_one_injective (evaluate at a distinguishing coordinate) and card_piAntidiag_one give |s.piAntidiag 1| = |s| via Finset.card_image_of_injective; piAntidiagOneEquiv packages i ↦ Pi.single i 1 as an Equiv ↥s ≃ ↥(s.piAntidiag 1) through Equiv.ofBijective."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/pell-equation-oq-01-oq-04-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/pell-equation-oq-01-oq-04-oq-02-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-defs",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02-oq-02",
+    "range": { "startLine": 46, "endLine": 54 },
+    "type": "definition",
+    "title": "Pell Norm and Regulator",
+    "content": "pellNorm d x y = x + y√d is the real embedding of the Pell solution (x,y) into the real quadratic field ℝ(√d); pellRegulator d a = log(pellNorm a) is its logarithm. These restate the grandparent definitions verbatim so the file is self-contained. The regulator turns the multiplicative structure of solutions into an additive one: R(a·b) = R(a) + R(b), which is what makes the cyclic subgroup look like (ℤ, +).",
+    "mathContext": "$\\lVert(x,y)\\rVert = x + y\\sqrt d$, $\\quad R(a) = \\log\\lVert a\\rVert$. The regulator is an additive character: $R(ab) = R(a) + R(b)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["real quadratic field", "regulator", "logarithm", "Pell's equation"],
+    "prerequisites": ["Pell's equation", "real embeddings of quadratic fields"]
+  },
+  {
+    "id": "ann-brahmagupta",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02-oq-02",
+    "range": { "startLine": 62, "endLine": 95 },
+    "type": "technique",
+    "title": "Brahmagupta Multiplicativity and the Conjugate Inverse",
+    "content": "pellNorm_mul is Brahmagupta's identity: the norm is multiplicative, ‖a·b‖ = ‖a‖·‖b‖, proved by linear_combination against √d² = d. pellNorm_mul_inv uses the defining relation x² − d·y² = 1 (a.prop) to show ‖a‖·‖a⁻¹‖ = 1, whence pellNorm_ne_zero and pellNorm_inv (‖a⁻¹‖ = ‖a‖⁻¹). Together these make g ↦ ‖g‖ a homomorphism from the Pell solution group into (ℝˣ, ·), the analytic engine for everything downstream.",
+    "mathContext": "$\\lVert ab\\rVert = \\lVert a\\rVert\\,\\lVert b\\rVert$ (Brahmagupta), and from $x^2 - d y^2 = 1$, $\\lVert a\\rVert\\,\\lVert a^{-1}\\rVert = 1$ so $\\lVert a^{-1}\\rVert = \\lVert a\\rVert^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Brahmagupta identity", "norm multiplicativity", "group homomorphism", "Solution₁"],
+    "prerequisites": ["Pell solution group law", "field norm"]
+  },
+  {
+    "id": "ann-zpow-scaling",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02-oq-02",
+    "range": { "startLine": 97, "endLine": 128 },
+    "type": "insight",
+    "title": "The Regulator Ruler: R(aⁿ) = n·R(a), Strictly Monotone",
+    "content": "pellNorm_zpow extends multiplicativity to all integer powers (‖aⁿ‖ = ‖a‖ⁿ) by Int.induction_on, and pellRegulator_zpow takes logs to get the ℤ-linear scaling R(aⁿ) = n·R(a) via Real.log_zpow. When ‖a‖ > 1 the regulator R(a) is strictly positive (pellRegulator_pos = Real.log_pos), so pellRegulator_zpow_strictMono shows n ↦ R(aⁿ) is strictly increasing — the 'regulator ruler' that linearly measures exponents. This is the parent's content, restated as the order engine.",
+    "mathContext": "$R(a^n) = n\\,R(a)$ with $R(a) > 0$ when $\\lVert a\\rVert > 1$, so $n \\mapsto R(a^n)$ is strictly increasing: a faithful $\\mathbb{Z}$-linear ruler on the exponents.",
+    "significance": "key",
+    "relatedConcepts": ["strict monotonicity", "linear scaling", "Real.log_zpow", "infinite order element"],
+    "prerequisites": ["integer power induction", "properties of logarithm"]
+  },
+  {
+    "id": "ann-linear-order",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02-oq-02",
+    "range": { "startLine": 132, "endLine": 149 },
+    "type": "definition",
+    "title": "Pulling the Order Back: a LinearOrder on ⟨a⟩",
+    "content": "pellPowLinearOrder equips the cyclic subgroup ⟨a⟩ = Subgroup.zpowers a with the order pulled back from (ℝ, ≤) along g ↦ R(g), using LinearOrder.lift'. The lift' requires the map to be injective on the subgroup: every g ∈ ⟨a⟩ is aᵏ for some k (Subgroup.mem_zpowers_iff), and the strictly monotone ruler separates distinct exponents (StrictMono.injective), so distinct subgroup elements get distinct regulator values. The hypothesis ‖a‖ > 1 enters exactly here — a torsion a would collapse distinct powers to the same regulator value, destroying antisymmetry.",
+    "mathContext": "$g \\preceq h \\iff R(g) \\le R(h)$; a total order on $\\langle a\\rangle$. Injectivity of $R$ on $\\langle a\\rangle$ (needing $\\lVert a\\rVert > 1$) is what makes $\\preceq$ antisymmetric.",
+    "significance": "key",
+    "relatedConcepts": ["LinearOrder.lift'", "order pullback", "Subgroup.zpowers", "torsion-free"],
+    "prerequisites": ["linear orders", "cyclic subgroups", "injectivity"]
+  },
+  {
+    "id": "ann-order-iso",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02-oq-02",
+    "range": { "startLine": 151, "endLine": 174 },
+    "type": "theorem",
+    "title": "The Order Isomorphism (ℤ, <) ≃o ⟨a⟩",
+    "content": "pellPowOrderIso builds the explicit order isomorphism n ↦ aⁿ. The forward map sends n to ⟨aⁿ, _⟩; the inverse extracts the exponent via Classical.choose of the zpowers-membership witness. left_inv is the regulator's injectivity, right_inv is Classical.choose_spec, and map_rel_iff' — order-preservation in BOTH directions — is exactly StrictMono.le_iff_le applied to the regulator ruler. This is the upgrade from the parent's bare injectivity (a bijection of sets) to a full isomorphism of ordered sets.",
+    "mathContext": "$e : (\\mathbb{Z}, <) \\;\\simeq_o\\; (\\langle a\\rangle, \\preceq)$, $e(n) = a^n$, with $a^m \\preceq a^n \\iff R(a^m) \\le R(a^n) \\iff m \\le n$.",
+    "significance": "key",
+    "relatedConcepts": ["OrderIso", "StrictMono.le_iff_le", "Classical.choose", "Subgroup.mem_zpowers_iff"],
+    "prerequisites": ["order isomorphisms", "bijections", "strict monotonicity"]
+  },
+  {
+    "id": "ann-group-hom",
+    "proofId": "pell-equation-oq-01-oq-04-oq-02-oq-02",
+    "range": { "startLine": 176, "endLine": 201 },
+    "type": "theorem",
+    "title": "It Is Also a Group Isomorphism: Ordered-Group Iso",
+    "content": "pellPowOrderIso_apply confirms e(n) = aⁿ definitionally (rfl). pellPowOrderIso_map_mul shows e(m+n) = e(m)·e(n) (via zpow_add) and pellPowOrderIso_map_zero shows e(0) = 1 (via zpow_zero). So the same map e is simultaneously an order isomorphism and a group homomorphism: (ℤ, +, <) ≃ (⟨a⟩, ·, ⪯) is an isomorphism of ordered GROUPS, not merely of ordered sets. The additive exponent line and the multiplicative cyclic subgroup are literally the same ordered group, identified by the single positive number R(a).",
+    "mathContext": "$e(m+n) = e(m)\\cdot e(n)$, $e(0) = 1$: so $(\\mathbb{Z}, +, <) \\cong (\\langle a\\rangle, \\cdot, \\preceq)$ as ordered groups, with $\\langle a\\rangle \\cong R(a)\\cdot\\mathbb{Z} \\subset (\\mathbb{R}, +, <)$.",
+    "significance": "key",
+    "relatedConcepts": ["ordered group", "group isomorphism", "zpow_add", "discrete subgroup of ℝ"],
+    "prerequisites": ["group homomorphisms", "ordered groups"]
+  }
+]


### PR DESCRIPTION
Accumulating enrichment pass (enricher-2). Each commit enriches one gallery entry.

## Entries
1. **binomial-theorem-oq-02-oq-01-oq-01-oq-02-oq-01** (The Degree-One Multinomial Support Is the Index Set) — upgraded flat-string `overview`/`conclusion` to structured `ProofOverview`/`ProofConclusion` objects (historicalContext, problemStatement, proofStrategy, 5 keyInsights; summary, implications, 3 openQuestions), added line-ranged `sections`, and a 5th context annotation.
2. **pell-equation-oq-01-oq-04-oq-02-oq-02** (The Pell Cyclic Subgroup ⟨a⟩ as an Ordered Group) — added the missing `annotations.json` with 6 annotations (mathContext, significance, relatedConcepts, prerequisites) covering the norm/regulator engine, the LinearOrder pullback, the order isomorphism, and the ordered-group iso layer.

`pnpm build` passes. No axiom-integrity changes — both entries remain verified / 0-axiom, accurately reflected in meta.json.