### PR TITLE
Research: Frobenius power subgroups recover the divisor lattice (⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3116,6 +3116,7 @@ import Proofs.FrobeniusEndomorphismOQ01OQ02
 import Proofs.FrobeniusEndomorphismOQ01OQ03
 import Proofs.FrobeniusEndomorphismOQ02
 import Proofs.FrobeniusEndomorphismOQ02OQ01OQ01
+import Proofs.FrobeniusEndomorphismOQ02OQ01OQ01OQ02
 import Proofs.FrobeniusNumber
 import Proofs.FrobeniusNumberOQ01
 import Proofs.FrobeniusNumberOQ01OQ03OQ01

--- a/proofs/Proofs/FrobeniusEndomorphismOQ02OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/FrobeniusEndomorphismOQ02OQ01OQ01OQ02.lean
@@ -1,0 +1,150 @@
+/-
+  The Frobenius power subgroups recover the divisor lattice:
+  `⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e`.
+
+  Let `K` be a finite field of characteristic `p`, an extension of its prime
+  subfield `𝔽_p = ZMod p` of degree `n = [K : 𝔽_p]`.  The Galois group
+  `Gal(K / 𝔽_p) = ⟨frob⟩` is cyclic of order `n`, and the parent entry
+  (`FrobeniusEndomorphismOQ02OQ01OQ01`) identified its rung-by-rung fixed fields:
+  for every divisor `d ∣ n` the cyclic subgroup `⟨frob^d⟩` has fixed field the
+  unique copy of `𝔽_{p^d}` inside `K`, and the assignment `d ↦ fixedField⟨frob^d⟩`
+  is injective on the divisors of `n`.
+
+  That gives the *set-level* bijection `{subfields} ↔ {divisors of n}`.  This file
+  upgrades it to the **lattice** statement on the subgroup side: it pins down the
+  inclusions among the subgroups `⟨frob^d⟩` themselves, purely in terms of
+  divisibility of the exponents.  This is exactly the second open question left by
+  the parent: *identify the subfield containment `𝔽_{p^d} ⊆ 𝔽_{p^e} ⇔ d ∣ e`
+  directly in terms of Frobenius powers, as `⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e`,
+  recovering the lattice (not just set) isomorphism.*
+
+  ## The mathematics
+
+  The result is not special to the Frobenius — it is the lattice of cyclic
+  subgroups of a finite cyclic group, expressed through `orderOf`.  The clean
+  general fact is:
+
+  > For an element `g` of a group and `d ∣ orderOf g`,
+  > `g ^ e ∈ ⟨g ^ d⟩ ⇔ d ∣ e`.
+
+  The `⟸` direction is structural: if `e = d·m` then `g^e = (g^d)^m ∈ ⟨g^d⟩`.
+  The `⟹` direction is the arithmetic heart.  Writing `g^e = (g^d)^k` for an
+  integer `k` gives `g^(d·k − e) = 1`, hence `orderOf g ∣ d·k − e`; since
+  `d ∣ orderOf g` we get `d ∣ d·k − e`, and as `d ∣ d·k` this forces `d ∣ e`.
+
+  Passing to subgroups (`Subgroup.zpowers_le`) turns membership into containment,
+  and feeding in `orderOf (frob p) = n` (the order of the Frobenius) specialises
+  everything to the Galois group.
+
+  ## Results
+
+  * `pow_mem_zpowers_pow_iff_dvd` — the general group lemma
+    `g ^ e ∈ ⟨g ^ d⟩ ⇔ d ∣ e` for `d ∣ orderOf g`;
+  * `zpowers_pow_le_iff` — its subgroup form
+    `⟨g ^ e⟩ ≤ ⟨g ^ d⟩ ⇔ d ∣ e`;
+  * `zpowers_frob_pow_le_iff` — **the headline**: for `d ∣ n`,
+    `⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e`, the order-reversing divisor lattice in the
+    Galois group;
+  * `zpowers_frob_pow_eq_iff` — the resulting injectivity on the subgroup side:
+    for `d, e ∣ n`, `⟨frob^d⟩ = ⟨frob^e⟩ ⇔ d = e`.
+
+  Together with the parent's `fixedField_frob_pow_injOn_divisors`, the inclusions
+  `⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e` make `d ↦ ⟨frob^d⟩` an order-reversing
+  embedding of the divisors of `n` into the subgroup lattice — the lattice
+  isomorphism behind the Galois correspondence for finite fields.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.  Built on Mathlib's
+  `orderOf_dvd_iff_zpow_eq_one`, `Subgroup.zpowers_le`, `Subgroup.mem_zpowers_iff`
+  and the parent's `orderOf_frob`.
+-/
+import Mathlib
+-- Only `frob` and `orderOf_frob` from the grandparent are needed; the divisor-lattice
+-- *fixed fields* are the subject of the direct parent `FrobeniusEndomorphismOQ02OQ01OQ01`.
+import Proofs.FrobeniusEndomorphismOQ02
+
+namespace FrobeniusEndomorphismOQ02OQ01OQ01OQ02
+
+open FrobeniusEndomorphismOQ02
+open Module (finrank)
+
+/-! ### Part I: the general group lemma -/
+
+/-- **The cyclic-subgroup lattice, membership form.**  For an element `g` of a
+group and a divisor `d ∣ orderOf g`, the power `g ^ e` lies in the cyclic
+subgroup `⟨g ^ d⟩` exactly when `d ∣ e`.
+
+`⟸` is structural (`g^(d·m) = (g^d)^m`).  `⟹` is arithmetic: from
+`g^e = (g^d)^k` one gets `g^(d·k − e) = 1`, so `orderOf g ∣ d·k − e`; with
+`d ∣ orderOf g` this gives `d ∣ d·k − e`, and `d ∣ d·k` forces `d ∣ e`. -/
+theorem pow_mem_zpowers_pow_iff_dvd {G : Type*} [Group G] {g : G} {d e : ℕ}
+    (hd : d ∣ orderOf g) :
+    g ^ e ∈ Subgroup.zpowers (g ^ d) ↔ d ∣ e := by
+  constructor
+  · intro hmem
+    rw [Subgroup.mem_zpowers_iff] at hmem
+    obtain ⟨k, hk⟩ := hmem
+    -- `hk : (g ^ d) ^ k = g ^ e` (with `k : ℤ`); rewrite to a single `zpow`.
+    rw [← zpow_natCast g d, ← zpow_mul, ← zpow_natCast g e] at hk
+    -- `hk : g ^ ((d : ℤ) * k) = g ^ (e : ℤ)`, hence `g ^ ((d : ℤ) * k − e) = 1`.
+    have h1 : g ^ ((d : ℤ) * k - (e : ℤ)) = 1 := by
+      rw [zpow_sub, hk, mul_inv_cancel]
+    rw [← orderOf_dvd_iff_zpow_eq_one] at h1
+    -- `h1 : (orderOf g : ℤ) ∣ (d : ℤ) * k − e`.
+    have hdord : (d : ℤ) ∣ (orderOf g : ℤ) := Int.natCast_dvd_natCast.mpr hd
+    have hdsub : (d : ℤ) ∣ ((d : ℤ) * k - (e : ℤ)) := hdord.trans h1
+    have hde : (d : ℤ) ∣ (e : ℤ) := by
+      have hdk : (d : ℤ) ∣ (d : ℤ) * k := dvd_mul_right _ _
+      have := dvd_sub hdk hdsub
+      simpa using this
+    exact_mod_cast hde
+  · rintro ⟨m, rfl⟩
+    rw [pow_mul]
+    exact pow_mem (Subgroup.mem_zpowers _) m
+
+/-- **The cyclic-subgroup lattice, subgroup form.**  For `d ∣ orderOf g`,
+`⟨g ^ e⟩ ≤ ⟨g ^ d⟩ ⇔ d ∣ e`. -/
+theorem zpowers_pow_le_iff {G : Type*} [Group G] {g : G} {d e : ℕ}
+    (hd : d ∣ orderOf g) :
+    Subgroup.zpowers (g ^ e) ≤ Subgroup.zpowers (g ^ d) ↔ d ∣ e := by
+  rw [Subgroup.zpowers_le]
+  exact pow_mem_zpowers_pow_iff_dvd hd
+
+/-! ### Part II: the Frobenius / Galois specialisation -/
+
+variable (p : ℕ) [Fact p.Prime]
+variable {K : Type*} [Field K] [Fintype K] [Algebra (ZMod p) K]
+
+/-- **The headline.**  In the cyclic Galois group `Gal(K / 𝔽_p) = ⟨frob⟩` of
+order `n = [K : 𝔽_p]`, for a divisor `d ∣ n` the subgroup inclusion
+`⟨frob^e⟩ ≤ ⟨frob^d⟩` holds exactly when `d ∣ e`.
+
+This is the order-reversing divisor lattice on the subgroup side of the Galois
+correspondence: larger fields `𝔽_{p^e}` (`d ∣ e`) correspond to smaller
+stabilising subgroups `⟨frob^e⟩ ≤ ⟨frob^d⟩`. -/
+theorem zpowers_frob_pow_le_iff {d e : ℕ} (hd : d ∣ finrank (ZMod p) K) :
+    Subgroup.zpowers (frob p ^ e : K ≃ₐ[ZMod p] K)
+        ≤ Subgroup.zpowers (frob p ^ d) ↔ d ∣ e := by
+  apply zpowers_pow_le_iff
+  rw [orderOf_frob]
+  exact hd
+
+/-- **Injectivity on the subgroup side.**  For divisors `d, e ∣ n` the cyclic
+subgroups `⟨frob^d⟩` and `⟨frob^e⟩` coincide exactly when `d = e`: distinct
+divisors give distinct subgroups.  This is the subgroup-lattice counterpart of
+the parent's `fixedField_frob_pow_injOn_divisors`, and combined with the
+`≤`-criterion it makes `d ↦ ⟨frob^d⟩` an order-reversing embedding of the
+divisors of `n`. -/
+theorem zpowers_frob_pow_eq_iff {d e : ℕ}
+    (hd : d ∣ finrank (ZMod p) K) (he : e ∣ finrank (ZMod p) K) :
+    Subgroup.zpowers (frob p ^ d : K ≃ₐ[ZMod p] K)
+        = Subgroup.zpowers (frob p ^ e) ↔ d = e := by
+  constructor
+  · intro h
+    -- `⟨frob^d⟩ ≤ ⟨frob^e⟩` gives `e ∣ d`; the reverse gives `d ∣ e`.
+    have h1 : e ∣ d := (zpowers_frob_pow_le_iff p he).mp (le_of_eq h)
+    have h2 : d ∣ e := (zpowers_frob_pow_le_iff p hd).mp (le_of_eq h.symm)
+    exact Nat.dvd_antisymm h2 h1
+  · rintro rfl
+    rfl
+
+end FrobeniusEndomorphismOQ02OQ01OQ01OQ02

--- a/src/data/proofs/frobenius-endomorphism-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "frobenius-endomorphism-oq-02-oq-01-oq-01-oq-02",
+  "slug": "frobenius-endomorphism-oq-02-oq-01-oq-01-oq-02",
+  "title": "Frobenius Power Subgroups Recover the Divisor Lattice: ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e",
+  "description": "In the cyclic Galois group Gal(K/𝔽_p) = ⟨frob⟩ of a finite field with |K| = p^n, the cyclic subgroups ⟨frob^d⟩ are ordered by reverse divisibility of their exponents: for a divisor d ∣ n, ⟨frob^e⟩ ≤ ⟨frob^d⟩ holds exactly when d ∣ e. This is the lattice (not merely set-level) half of the Galois correspondence for finite fields, and it answers the parent's second open question verbatim. The underlying fact is purely group-theoretic — the lattice of cyclic subgroups of a finite cyclic group, expressed through orderOf — so the result is proved first in full generality and then specialised to the Frobenius.",
+  "overview": "The parent entry (FrobeniusEndomorphismOQ02OQ01OQ01) identified the fixed fields rung by rung: for every divisor d ∣ n the cyclic subgroup ⟨frob^d⟩ has fixed field the unique copy of 𝔽_{p^d} inside K, and d ↦ fixedField⟨frob^d⟩ is injective on the divisors of n — the set-level bijection {subfields} ↔ {divisors of n}. This entry upgrades that to the order structure on the subgroup side: it pins down the inclusions among the subgroups ⟨frob^d⟩ themselves, purely in terms of divisibility of exponents, giving the order-reversing divisor lattice that underlies the correspondence.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Finite_field#Frobenius_automorphism_and_Galois_theory",
+    "date": "Évariste Galois / Ferdinand Georg Frobenius (19th century)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "galois-theory",
+      "finite-fields",
+      "characteristic-p",
+      "frobenius",
+      "group-theory",
+      "cyclic-group",
+      "divisor-lattice",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ02OQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 4 theorems are fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count — confirmed by #print axioms on pow_mem_zpowers_pow_iff_dvd, zpowers_frob_pow_le_iff, and zpowers_frob_pow_eq_iff). No native_decide, so no Lean.ofReduceBool. The cyclic-group / order machinery (orderOf_dvd_iff_zpow_eq_one, Subgroup.zpowers_le, Subgroup.mem_zpowers_iff) is supplied by Mathlib; the new content is the arithmetic argument turning the membership g^e ∈ ⟨g^d⟩ into the divisibility d ∣ e for d ∣ orderOf g, and its specialisation to the Frobenius via the grandparent's orderOf_frob = n.",
+    "originalContributions": [
+      "pow_mem_zpowers_pow_iff_dvd: the general group lemma g^e ∈ ⟨g^d⟩ ⇔ d ∣ e for any d ∣ orderOf g. The ⟸ direction is structural (g^(d·m) = (g^d)^m ∈ ⟨g^d⟩). The ⟹ direction is the arithmetic heart: writing g^e = (g^d)^k for an integer k gives g^(d·k − e) = 1, hence orderOf g ∣ d·k − e; since d ∣ orderOf g we get d ∣ d·k − e, and d ∣ d·k forces d ∣ e. This is the lattice of cyclic subgroups of a finite cyclic group, isolated from any field theory.",
+      "zpowers_pow_le_iff: the subgroup form ⟨g^e⟩ ≤ ⟨g^d⟩ ⇔ d ∣ e (for d ∣ orderOf g), obtained from the membership criterion via Subgroup.zpowers_le. Stated in full generality so the Frobenius statement is a one-line specialisation rather than a bespoke argument.",
+      "zpowers_frob_pow_le_iff: THE HEADLINE — for a divisor d ∣ n = [K : 𝔽_p], ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e, the order-reversing divisor lattice on the subgroup side of the Galois correspondence (larger fields 𝔽_{p^e} with d ∣ e correspond to smaller stabilising subgroups ⟨frob^e⟩ ≤ ⟨frob^d⟩). Specialises zpowers_pow_le_iff by feeding in orderOf(frob) = n.",
+      "zpowers_frob_pow_eq_iff: the injectivity consequence — for divisors d, e ∣ n, ⟨frob^d⟩ = ⟨frob^e⟩ ⇔ d = e. Antisymmetry of the ≤-criterion in both directions (d ∣ e and e ∣ d) collapses to d = e. This is the subgroup-lattice counterpart of the parent's fixedField_frob_pow_injOn_divisors, and with the ≤-criterion it makes d ↦ ⟨frob^d⟩ an order-reversing embedding of the divisors of n into the subgroup lattice."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "orderOf_dvd_iff_zpow_eq_one",
+        "description": "(orderOf x : ℤ) ∣ i ↔ x ^ i = 1. Converts the relation g^(d·k − e) = 1 into the divisibility orderOf g ∣ d·k − e, the bridge from the group equation to the arithmetic of exponents.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Subgroup.zpowers_le",
+        "description": "zpowers g ≤ H ↔ g ∈ H. Turns subgroup containment ⟨g^e⟩ ≤ ⟨g^d⟩ into the single membership g^e ∈ ⟨g^d⟩.",
+        "module": "Mathlib.Algebra.Group.Subgroup.ZPowers.Basic"
+      },
+      {
+        "theorem": "Subgroup.mem_zpowers_iff",
+        "description": "h ∈ zpowers g ↔ ∃ k : ℤ, g ^ k = h. Unpacks the membership g^e ∈ ⟨g^d⟩ into an integer exponent k with (g^d)^k = g^e.",
+        "module": "Mathlib.Algebra.Group.Subgroup.ZPowers.Basic"
+      },
+      {
+        "theorem": "zpow_mul / zpow_sub / zpow_natCast",
+        "description": "The integer-power identities a^(m·n) = (a^m)^n, a^(m−n) = a^m·(a^n)⁻¹ and a^(↑n) = a^n, used to rewrite (g^d)^k into the single power g^(d·k) and to produce g^(d·k − e) = 1.",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ],
+    "parentDependencies": [
+      {
+        "theorem": "FrobeniusEndomorphismOQ02.orderOf_frob",
+        "description": "orderOf(frob) = finrank (ZMod p) K = n. The single input that specialises the general cyclic-subgroup lemma to the Frobenius: d ∣ n becomes d ∣ orderOf(frob).",
+        "module": "Proofs/FrobeniusEndomorphismOQ02.lean"
+      }
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 150,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.FrobeniusEndomorphismOQ02"
+    ],
+    "namespace": "FrobeniusEndomorphismOQ02OQ01OQ01OQ02",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FrobeniusEndomorphismOQ02OQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "zpowers_frob_pow_le_iff",
+      "type": "core",
+      "statement": "$d \\mid n \\Rightarrow \\big(\\langle\\mathrm{frob}^e\\rangle \\le \\langle\\mathrm{frob}^d\\rangle \\iff d \\mid e\\big)$",
+      "significance": "The headline: the cyclic subgroups of the Galois group are ordered by reverse divisibility of their Frobenius exponents — the order-reversing divisor lattice underlying the Galois correspondence for finite fields.",
+      "description": "For d ∣ n, ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e."
+    },
+    {
+      "name": "pow_mem_zpowers_pow_iff_dvd",
+      "type": "core",
+      "statement": "$d \\mid \\operatorname{ord}(g) \\Rightarrow \\big(g^e \\in \\langle g^d\\rangle \\iff d \\mid e\\big)$",
+      "significance": "The general group lemma behind the result: membership in a cyclic subgroup ⟨g^d⟩ of a finite cyclic group is governed by divisibility of exponents. Field-theory-free, hence reusable.",
+      "description": "g^e ∈ ⟨g^d⟩ ⇔ d ∣ e, for any group element g with d ∣ orderOf g."
+    },
+    {
+      "name": "zpowers_pow_le_iff",
+      "type": "supporting",
+      "statement": "$d \\mid \\operatorname{ord}(g) \\Rightarrow \\big(\\langle g^e\\rangle \\le \\langle g^d\\rangle \\iff d \\mid e\\big)$",
+      "significance": "The subgroup form of the membership criterion, stated in full generality so the Frobenius statement is a one-line specialisation.",
+      "description": "⟨g^e⟩ ≤ ⟨g^d⟩ ⇔ d ∣ e, for d ∣ orderOf g."
+    },
+    {
+      "name": "zpowers_frob_pow_eq_iff",
+      "type": "supporting",
+      "statement": "$d, e \\mid n \\Rightarrow \\big(\\langle\\mathrm{frob}^d\\rangle = \\langle\\mathrm{frob}^e\\rangle \\iff d = e\\big)$",
+      "significance": "Distinct divisors give distinct subgroups — the subgroup-lattice counterpart of the parent's injectivity on fixed fields, making d ↦ ⟨frob^d⟩ an order-reversing embedding of the divisors of n.",
+      "description": "For d, e ∣ n, ⟨frob^d⟩ = ⟨frob^e⟩ ⇔ d = e."
+    }
+  ],
+  "sections": [
+    {
+      "title": "Overview and Setup",
+      "content": "K is a finite field of characteristic p with prime subfield 𝔽_p = ZMod p and degree n = [K : 𝔽_p], so |K| = p^n. Its Galois group Gal(K/𝔽_p) = ⟨frob⟩ is cyclic of order n, generated by the Frobenius frob : x ↦ x^p. The parent pinned the fixed fields of all subgroups ⟨frob^d⟩ (the unique 𝔽_{p^d} ⊆ K, for d ∣ n); this entry pins the inclusions among those subgroups themselves."
+    },
+    {
+      "title": "Part I: the cyclic-subgroup lattice in any group",
+      "content": "pow_mem_zpowers_pow_iff_dvd proves g^e ∈ ⟨g^d⟩ ⇔ d ∣ e whenever d ∣ orderOf g. Forward: from g^e = (g^d)^k one rewrites to g^(d·k − e) = 1, so orderOf g ∣ d·k − e; combined with d ∣ orderOf g and d ∣ d·k this forces d ∣ e. Backward: e = d·m gives g^e = (g^d)^m ∈ ⟨g^d⟩. zpowers_pow_le_iff repackages this as ⟨g^e⟩ ≤ ⟨g^d⟩ ⇔ d ∣ e via Subgroup.zpowers_le."
+    },
+    {
+      "title": "Part II: the Frobenius / Galois specialisation",
+      "content": "Feeding the grandparent's orderOf(frob) = n into the general lemma yields zpowers_frob_pow_le_iff: ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e for d ∣ n — the order-reversing divisor lattice. Applying the criterion in both directions and using antisymmetry of divisibility gives zpowers_frob_pow_eq_iff: ⟨frob^d⟩ = ⟨frob^e⟩ ⇔ d = e for d, e ∣ n."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "frobenius-endomorphism-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent computes the fixed fields fixedField⟨frob^d⟩ = 𝔽_{p^d} for all d ∣ n and shows d ↦ fixedField⟨frob^d⟩ is injective on divisors (the set-level bijection {subfields} ↔ {divisors of n}). It lists as its second open question exactly this lattice statement — ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e — which this entry proves, recovering the order structure and not just the underlying set."
+    },
+    {
+      "proofId": "frobenius-endomorphism-oq-02",
+      "relationship": "extends",
+      "description": "The grandparent proves frob generates the cyclic Gal(K/𝔽_p) and orderOf(frob) = n. This entry uses orderOf_frob = n as the single bridge that turns the general cyclic-subgroup lattice lemma into the Frobenius-specific divisor lattice."
+    }
+  ],
+  "references": [
+    {
+      "text": "Galois group of a finite field — cyclic of order n, generated by Frobenius; the subfield lattice is the divisor lattice of n, with 𝔽_{p^d} ⊆ 𝔽_{p^n} iff d ∣ n, dually ⟨frob^e⟩ ≤ ⟨frob^d⟩ iff d ∣ e.",
+      "url": "https://en.wikipedia.org/wiki/Galois_group"
+    },
+    {
+      "text": "Finite field — Frobenius automorphism and Galois theory: the order-reversing correspondence between subgroups of the cyclic Galois group and intermediate subfields.",
+      "url": "https://en.wikipedia.org/wiki/Finite_field#Frobenius_automorphism_and_Galois_theory"
+    },
+    {
+      "text": "Mathlib4: orderOf_dvd_iff_zpow_eq_one, Subgroup.zpowers_le, Subgroup.mem_zpowers_iff.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes the subgroup-lattice half of the finite-field Galois correspondence: for a divisor d ∣ n, ⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e (zpowers_frob_pow_le_iff), and consequently ⟨frob^d⟩ = ⟨frob^e⟩ ⇔ d = e for d, e ∣ n (zpowers_frob_pow_eq_iff). The content is isolated as a general group lemma, pow_mem_zpowers_pow_iff_dvd: g^e ∈ ⟨g^d⟩ ⇔ d ∣ e for d ∣ orderOf g — the lattice of cyclic subgroups of a finite cyclic group. 4 theorems, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "Together with the parent's injectivity on fixed fields, the inclusion criterion makes d ↦ ⟨frob^d⟩ an order-reversing embedding of the divisors of n into the subgroup lattice — the lattice (not just set) isomorphism behind the Galois correspondence for finite fields. The general lemma is field-theory-free and applies to any finite cyclic group: it is the abstract statement that the subgroup lattice of ℤ/n is the (opposite) divisor lattice of n.",
+    "openQuestions": [
+      "Assemble zpowers_frob_pow_le_iff and the parent's fixedField correspondence into a packaged order isomorphism (OrderIso) between the divisors of n (under divisibility) and the subgroups of Gal(K/𝔽_p) (under reverse inclusion), or equivalently the intermediate fields under inclusion.",
+      "Prove the surjective half left open by the parent: every intermediate field 𝔽_p ⊆ L ⊆ K equals fixedField⟨frob^d⟩ for d = [L : 𝔽_p], so that the embedding of divisors is onto and the lattice isomorphism is complete."
+    ]
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers **openQuestions[1]** of `frobenius-endomorphism-oq-02-oq-01-oq-01` verbatim: identify the subfield containment lattice **directly in terms of Frobenius powers**, as `⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e`, recovering the lattice (not just set) isomorphism behind the Galois correspondence for finite fields.

In the cyclic Galois group `Gal(K/𝔽_p) = ⟨frob⟩` of a finite field with `|K| = p^n`, the cyclic subgroups `⟨frob^d⟩` are ordered by **reverse divisibility** of their exponents.

## Results (`Proofs/FrobeniusEndomorphismOQ02OQ01OQ01OQ02.lean`, 4 theorems, 150 lines)

- `pow_mem_zpowers_pow_iff_dvd` — the **general group lemma**: `g^e ∈ ⟨g^d⟩ ⇔ d ∣ e` for any `d ∣ orderOf g`. This is the lattice of cyclic subgroups of a finite cyclic group, isolated from any field theory and hence reusable.
- `zpowers_pow_le_iff` — its subgroup form `⟨g^e⟩ ≤ ⟨g^d⟩ ⇔ d ∣ e`.
- `zpowers_frob_pow_le_iff` — **the headline**: for `d ∣ n`, `⟨frob^e⟩ ≤ ⟨frob^d⟩ ⇔ d ∣ e`.
- `zpowers_frob_pow_eq_iff` — injectivity on the subgroup side: for `d, e ∣ n`, `⟨frob^d⟩ = ⟨frob^e⟩ ⇔ d = e`.

## Proof idea

The arithmetic heart (`⟹`): from `g^e = (g^d)^k` (integer `k`) one gets `g^(d·k − e) = 1`, so `orderOf g ∣ d·k − e`; since `d ∣ orderOf g` and `d ∣ d·k`, this forces `d ∣ e`. The converse is structural (`g^(d·m) = (g^d)^m`). Passing to subgroups via `Subgroup.zpowers_le` and feeding in the grandparent's `orderOf(frob) = n` specialises everything to the Frobenius.

## Verification

- 0 sorries, 0 axioms (only Lean's `propext` / `Classical.choice` / `Quot.sound`), no `native_decide` — confirmed by `#print axioms` on all three core theorems.
- Builds against Mathlib 4.26.0 via `lake env lean`. Gallery `meta.json` added; aggregator import wired in (the `FrobeniusEndomorphism` family was previously absent from the auto-generated `Proofs.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)