### PR TITLE
research(erdos-165-oq-05): formalize PGM-conjecture refutation + repair latent build breakage

### DIFF
--- a/proofs/Proofs/Erdos165Problem.lean
+++ b/proofs/Proofs/Erdos165Problem.lean
@@ -156,9 +156,19 @@ theorem erdos_165 :
   use 1/4, 2
   refine ⟨by norm_num, by norm_num, ?_⟩
   obtain ⟨k₀, hk₀⟩ := current_best_bounds (1/4) (by norm_num)
-  exact ⟨k₀, fun k hk => by
-    obtain ⟨hl, hu⟩ := hk₀ k hk
-    exact ⟨by linarith, by linarith⟩⟩
+  -- Past `max k₀ 2` we also have `k ≥ 2`, hence `log k > 0` and `k²/log k ≥ 0`;
+  -- this nonnegativity is what lets us widen the constant `5/4` up to `2`.
+  refine ⟨max k₀ 2, fun k hk => ?_⟩
+  have hk0 : k ≥ k₀ := le_of_max_le_left hk
+  have hk2 : k ≥ 2 := le_of_max_le_right hk
+  have h2k : (2:ℝ) ≤ (k:ℝ) := by exact_mod_cast hk2
+  have hlog : 0 < log k := Real.log_pos (by linarith)
+  have hatom : 0 ≤ (k:ℝ)^2 / log k := le_of_lt (div_pos (by positivity) hlog)
+  obtain ⟨hl, hu⟩ := hk₀ k hk0
+  rw [mul_div_assoc] at hl hu
+  refine ⟨?_, ?_⟩
+  · rw [mul_div_assoc]; linarith
+  · rw [mul_div_assoc]; linarith [hatom]
 
 /- ## Part V: The Triangle-Free Process -/
 
@@ -215,9 +225,83 @@ For large k (where log k > 0) and ε = 1/16:
   HHKP: R(3,k) ≥ (7/16)k²/log k
   PGM:  R(3,k) ≤ (5/16)k²/log k
 These are incompatible since 7/16 > 5/16 and k²/log k > 0.
-Therefore ¬pgmConjecture follows from hhkp_bound (the formal proof requires
-careful handling of the k²/log k positivity argument, using div_pos and log_pos).
+Therefore ¬pgmConjecture follows from hhkp_bound. The formal proof is given
+below (`pgm_conjecture_refuted`); its core is the axiom-free incompatibility
+lemma `asymptotic_constant_le`, which handles the k²/log k positivity argument
+once and for all via `div_pos` and `Real.log_pos`.
 -/
+
+/-- **Axiom-free incompatibility lemma.** Suppose a real sequence `f` is, for
+    *every* `ε > 0`, eventually bounded below by `(a - ε)·k²/log k` and eventually
+    bounded above by `(b + ε)·k²/log k`. Then necessarily `a ≤ b`.
+
+    In words: two asymptotic constants that simultaneously lower- and upper-bound
+    the same sequence (to first order, in the `k²/log k` scale) cannot be in the
+    wrong order. This is the structural fact underlying every "conjectured
+    constant refuted by a better bound" argument for `R(3,k)`. The proof contains
+    no Ramsey theory and no axioms: it is pure real analysis.
+
+    Strategy: if `b < a`, take `ε = (a-b)/4`, so `a - ε > b + ε`. Pick any
+    `k ≥ 2` past both thresholds; then `k²/log k > 0`, and the two bounds force
+    `(a - ε)·k²/log k ≤ (b + ε)·k²/log k`, i.e. `a - ε ≤ b + ε`, contradiction. -/
+theorem asymptotic_constant_le
+    (f : ℕ → ℝ) (a b : ℝ)
+    (lower : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → (a - ε) * k^2 / log k ≤ f k)
+    (upper : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ → f k ≤ (b + ε) * k^2 / log k) :
+    a ≤ b := by
+  by_contra h
+  push_neg at h          -- h : b < a
+  set ε := (a - b) / 4 with hε_def
+  have hε : ε > 0 := by rw [hε_def]; linarith
+  obtain ⟨k₁, hk₁⟩ := lower ε hε
+  obtain ⟨k₂, hk₂⟩ := upper ε hε
+  -- a witness index past both thresholds and ≥ 2 (so log k > 0 and k² > 0)
+  set k := max (max k₁ k₂) 2 with hk_def
+  have hk1 : k ≥ k₁ := le_trans (le_max_left _ _) (le_max_left _ _)
+  have hk2 : k ≥ k₂ := le_trans (le_max_right _ _) (le_max_left _ _)
+  have hk_ge2 : k ≥ 2 := le_max_right _ _
+  have h2k : (2:ℝ) ≤ (k:ℝ) := by exact_mod_cast hk_ge2
+  have hkpos : (0:ℝ) < (k:ℝ) := by linarith
+  have h1k : (1:ℝ) < (k:ℝ) := by linarith
+  have hlogpos : 0 < log k := Real.log_pos h1k
+  have hksq : (0:ℝ) < (k:ℝ)^2 := pow_pos hkpos 2
+  have hg : 0 < (k:ℝ)^2 / log k := div_pos hksq hlogpos
+  -- chain the two bounds at this k
+  have hcomb : (a - ε) * k^2 / log k ≤ (b + ε) * k^2 / log k :=
+    le_trans (hk₁ k hk1) (hk₂ k hk2)
+  rw [mul_div_assoc, mul_div_assoc] at hcomb
+  have hle : a - ε ≤ b + ε := le_of_mul_le_mul_right hcomb hg
+  -- a - ε ≤ b + ε with ε = (a-b)/4 forces a ≤ b, contradicting b < a
+  rw [hε_def] at hle
+  linarith
+
+/-- **No asymptotic upper constant below `1/2`.** If `R(3,k) ≤ (b + ε)·k²/log k`
+    holds eventually for every `ε > 0`, then `b ≥ 1/2`. This is the HHKP lower
+    bound (`c ≥ 1/2`) phrased as an obstruction: any *valid* first-order upper
+    constant for `R(3,k)` is at least `1/2`. -/
+theorem R3_upper_constant_ge_half (b : ℝ)
+    (hb : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+        (R3 k : ℝ) ≤ (b + ε) * k^2 / log k) :
+    (1:ℝ)/2 ≤ b := by
+  refine asymptotic_constant_le (fun k => (R3 k : ℝ)) (1/2) b ?_ hb
+  intro ε hε
+  obtain ⟨k₀, hk₀⟩ := hhkp_bound ε hε
+  exact ⟨k₀, fun k hk => hk₀ k hk⟩
+
+/-- **PGM Conjecture refuted.** The conjecture `R(3,k) ~ (1/4)·k²/log k`
+    (Pontiveros–Griffiths–Morris 2020) is false. Its upper half asserts an
+    asymptotic constant `1/4`, but `R3_upper_constant_ge_half` forces any valid
+    upper constant to be at least `1/2`, and `1/2 ≤ 1/4` is absurd. The only
+    Ramsey input is `hhkp_bound`; the rest is the axiom-free lemma above. -/
+theorem pgm_conjecture_refuted : ¬ pgmConjecture := by
+  intro h
+  have hupper : ∀ ε > 0, ∃ k₀ : ℕ, ∀ k : ℕ, k ≥ k₀ →
+      (R3 k : ℝ) ≤ (1/4 + ε) * k^2 / log k := by
+    intro ε hε
+    obtain ⟨k₀, hk₀⟩ := h ε hε
+    exact ⟨k₀, fun k hk => (hk₀ k hk).2⟩
+  have : (1:ℝ)/2 ≤ 1/4 := R3_upper_constant_ge_half (1/4) hupper
+  norm_num at this
 
 /- ## Part VII: Related Problems -/
 

--- a/research/problems/erdos-165-oq-05/knowledge.md
+++ b/research/problems/erdos-165-oq-05/knowledge.md
@@ -1,21 +1,46 @@
 # Knowledge Base: erdos-165-oq-05
 
-Insights accumulated during research on this problem.
-
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The slug maps to erdos-165 openQuestions[5] = "Complete the sorry-marked proof
+in R3_asymptotic_order". That task is STALE: the current
+`proofs/Proofs/Erdos165Problem.lean` has no such sorry (0 sorries).
+
+The real, honest gap: the gallery entry advertises "PGM Conjecture Disproved"
+as a key insight and lists "disprove the PGM conjecture (c = 1/4)" as a proof
+step, but the Lean file only refuted it in a PROSE COMMENT — `¬ pgmConjecture`
+was never a theorem.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The erdos-165 file on origin/main did NOT compile: `erdos_165` failed at
+  `linarith` (could not widen the constant 5/4 to 2 without `k²/log k ≥ 0`).
+  Latent Mathlib-drift breakage despite meta claiming "0 sorries / axiomatized".
+- Fix: take `k₀' = max k₀ 2` so `k ≥ 2 ⟹ log k > 0 ⟹ k²/log k ≥ 0`, and use
+  `mul_div_assoc` so `linarith` sees `k²/log k` as one atom it can scale.
+- The mathematical core is `asymptotic_constant_le`: an axiom-free real-analysis
+  lemma stating two strictly ordered asymptotic constants cannot both bound the
+  same `k²/log k`-scale sequence. The only Ramsey input to the refutation is
+  `hhkp_bound`.
+
+## Deliverables (this session)
+
+- `asymptotic_constant_le` — axiom-free incompatibility lemma.
+- `R3_upper_constant_ge_half` — any valid first-order upper constant for R(3,k)
+  is ≥ 1/2 (HHKP obstruction).
+- `pgm_conjecture_refuted : ¬ pgmConjecture` — machine-checked.
+- Repaired `erdos_165` (Mathlib-drift fix).
+
+0 new axioms. File still has its 10 deep-Ramsey axioms (Kim/Shearer/HHKP/AKS),
+none provable from Mathlib.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Axiom elimination is infeasible here: all 10 axioms are deep Ramsey-theory
+  theorems (Kim 1995, Shearer 1983, HHKP 2025, AKS 1980) with no Mathlib proof.

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -49,13 +49,17 @@
       "CJMS bound (2025): c ≥ 1/3",
       "HHKP bound (2025): c ≥ 1/2",
       "Main theorem combining upper and lower bounds",
-      "Conjectures about exact constant c = 1/2"
+      "Conjectures about exact constant c = 1/2",
+      "Axiom-free incompatibility lemma asymptotic_constant_le: two strictly ordered asymptotic constants cannot both bound the same k²/log k-scale sequence (pure real analysis, 0 new axioms)",
+      "R3_upper_constant_ge_half: HHKP lower bound recast as an obstruction — any valid first-order upper constant for R(3,k) is ≥ 1/2",
+      "pgm_conjecture_refuted: machine-checked proof that the PGM conjecture (c=1/4) is false (previously only an informal comment)",
+      "Repaired latent Mathlib-drift breakage in erdos_165 (linarith could not widen 5/4 to 2 without k²/log k ≥ 0)"
     ],
     "axiomCount": 10,
-    "lineCount": 239,
-    "assumptions": "10 axioms: ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries.",
+    "lineCount": 323,
+    "assumptions": "10 axioms (unchanged): ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries. New theorems add no axioms; asymptotic_constant_le is fully axiom-free; pgm_conjecture_refuted depends only on the existing hhkp_bound.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 3,
     "additionalFiles": [
       "Proofs/Stubs/Erdos165Aristotle.lean"
@@ -162,9 +166,9 @@
       "Real"
     ],
     "namespace": "Erdos165",
-    "lineCount": 239,
+    "lineCount": 323,
     "axiomCount": 10,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 3,
     "path": "Proofs/Erdos165Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-165-oq-05.json
+++ b/src/data/research/problems/erdos-165-oq-05.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-165-oq-05",
-  "title": "[Problem Title]",
-  "phase": "OBSERVE",
-  "status": "active",
+  "title": "Formalize the PGM-conjecture refutation for R(3,k)",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
     "formal": "\\text{[LaTeX formulation of the theorem/conjecture]}",
-    "plain": "[Explain what we're trying to prove in accessible terms]",
+    "plain": "The erdos-165 gallery entry CLAIMED (in prose and keyInsight PGM-Conjecture-Disproved) that the Pontiveros-Griffiths-Morris conjecture R(3,k) ~ (1/4)k^2/log k is refuted by the HHKP lower bound (c >= 1/2), but no theorem proved it. The original oq-05 task (close a sorry in R3_asymptotic_order) is stale: that sorry no longer exists. This session formalizes the refutation and repairs a latent build breakage.",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-04-04T02:41:26-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Proved pgm_conjecture_refuted : not pgmConjecture, backed by the axiom-free incompatibility lemma asymptotic_constant_le and the general obstruction R3_upper_constant_ge_half. Added 0 new axioms. Also repaired a pre-existing Mathlib-drift build failure in erdos_165 (line 161): linarith could not widen 5/4 to 2 without k^2/log k >= 0; fixed by threading log-positivity via max k0 2 and mul_div_assoc.",
+    "builtItems": [
+      "asymptotic_constant_le in Erdos165Problem.lean (axiom-free incompatibility lemma)",
+      "R3_upper_constant_ge_half in Erdos165Problem.lean (HHKP obstruction)",
+      "pgm_conjecture_refuted in Erdos165Problem.lean (not pgmConjecture)",
+      "Repaired erdos_165 proof (Mathlib-drift fix)"
+    ],
+    "insights": [
+      "The erdos-165 file on origin/main did NOT compile (linarith failure in erdos_165) despite meta claiming 0 sorries / axiomatized -- latent Mathlib drift.",
+      "linarith treats c*k^2/log k as opaque unless mul_div_assoc factors out k^2/log k as a single atom; supplying 0 <= k^2/log k then lets it scale constants.",
+      "The mathematical core of conjectured-constant-refuted-by-a-better-bound is a pure real-analysis fact (asymptotic_constant_le), fully axiom-free; only hhkp_bound is Ramsey input.",
+      "oq-05 (complete sorry in R3_asymptotic_order) was stale: no such sorry exists in the current file."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Consider an analogous obstruction ruling out any conjectured constant > 1 against shearer_upper_bound."
+    ],
     "markdown": "# Knowledge Base: erdos-165-oq-05\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -52,7 +64,7 @@
     "mathlib": []
   },
   "started": "2026-04-04T09:42:47.007Z",
-  "lastUpdate": "2026-04-04T09:42:47.024Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/Erdos165Problem.lean",


### PR DESCRIPTION
## Summary

Research session for **erdos-165-oq-05** (Erdős #165, asymptotic order of R(3,k)).

The claimed open question ("complete the sorry in `R3_asymptotic_order`") is **stale** — that sorry no longer exists (the file has 0 sorries). The genuine gap: the gallery entry advertises *"PGM Conjecture Disproved"* as a key insight and lists *"disprove the PGM conjecture (c = 1/4)"* as a proof step, but the Lean file only refuted it in a **prose comment** — `¬ pgmConjecture` was never an actual theorem.

While formalizing it I discovered the file **did not compile on `origin/main`** (latent Mathlib drift): `erdos_165` failed at `linarith`, which cannot widen the constant `5/4` to `2` without knowing `k²/log k ≥ 0`.

## Progress

New theorems in `proofs/Proofs/Erdos165Problem.lean`:

- **`asymptotic_constant_le`** — axiom-free incompatibility lemma: if a sequence is eventually bounded below by `(a-ε)·k²/log k` and above by `(b+ε)·k²/log k` for every `ε>0`, then `a ≤ b`. Pure real analysis; depends only on `propext`/`Classical.choice`/`Quot.sound`.
- **`R3_upper_constant_ge_half`** — the HHKP lower bound recast as an obstruction: any valid first-order upper constant for `R(3,k)` is `≥ 1/2`.
- **`pgm_conjecture_refuted : ¬ pgmConjecture`** — machine-checked refutation of the Pontiveros–Griffiths–Morris conjecture `R(3,k) ~ (1/4)k²/log k`.

Repair:
- Fixed the pre-existing build failure in `erdos_165` via `max k₀ 2` (so `log k > 0`) and `mul_div_assoc` (so `linarith` sees `k²/log k` as one scalable atom).

## Axiom integrity

- **0 new axioms.** File still has its 10 deep-Ramsey axioms (Kim/Shearer/HHKP/AKS), none provable from Mathlib.
- `asymptotic_constant_le` is fully axiom-free; `pgm_conjecture_refuted` depends only on the existing `hhkp_bound`.
- Status remains **axiomatized** (`badge: axiom`) — the refutation rests on `hhkp_bound`.

`#print axioms` confirms: `asymptotic_constant_le → [propext, Classical.choice, Quot.sound]`; refutation theorems add only `hhkp_bound`, `ramseyNumber`.

## File stats
5 theorems (was 2), 3 defs, 10 axioms (unchanged), 0 sorries, 323 lines. Builds clean via host `lake env lean`.

## Status
**Outcome**: completed (formalized a claimed-but-unproven gallery insight + repaired a latent breakage)

🤖 Generated by researcher-5