### PR TITLE
Enrich gallery entries: structured metadata + annotations (enricher-2)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/annotations.json
@@ -1,26 +1,62 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "bezout-identity-oq-04-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "The Two SNF Axioms and the Open Question",
+    "content": "The parent entry bezout-identity-oq-04-oq-01 formalized linear Diophantine systems by taking two axioms: snf_exists (every integer matrix A admits A = U·D·V with U, V unimodular and D diagonal) and snf_solvability_criterion (A·x = b is solvable iff a divisibility condition holds on a transformed right-hand side). The open question: can either axiom be discharged from Mathlib? The finding is two-part — existence is genuinely missing from Mathlib in matrix form (only the module-theoretic SNF exists), but the solvability criterion is derivable from the decomposition alone, so the parent's axiom count drops 2 → 1.",
+    "mathContext": "Smith Normal Form: $A = U D V$, $\\det U, \\det V \\in \\{\\pm 1\\}$, $D$ rectangular diagonal with invariant factors $d_1 \\mid d_2 \\mid \\cdots$.",
+    "significance": "context",
+    "relatedConcepts": ["Smith Normal Form", "linear Diophantine systems", "axiom elimination", "unimodular matrices", "invariant factors"],
+    "prerequisites": ["integer matrices", "matrix decomposition", "Lean axioms"]
+  },
+  {
+    "id": "ann-diag-mulvec",
+    "proofId": "bezout-identity-oq-04-oq-01-oq-03",
+    "range": { "startLine": 50, "endLine": 85 },
+    "type": "definition",
+    "title": "The Diagonal Entry and Its mulVec Action",
+    "content": "dEntry D i picks out the i-th diagonal entry D i ⟨i,_⟩ when the column i is in range (i < n) and 0 otherwise — the bookkeeping needed because D is rectangular (Fin m × Fin n), so 'diagonal' allows slack rows/columns. diag_mulVec_apply shows that for a diagonal matrix the matrix–vector product collapses to a single per-row product (D·y) i = D i ⟨i,_⟩ · y ⟨i,_⟩ (or 0 out of range), proved by Finset.sum_eq_single killing every off-diagonal term via the diagonality hypothesis hD.",
+    "mathContext": "$\\mathrm{dEntry}\\,D\\,i = \\begin{cases} D_{i,i} & i < n \\\\ 0 & i \\ge n\\end{cases}$, and $(D\\cdot_v y)_i = \\mathrm{dEntry}\\,D\\,i \\cdot y_i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["rectangular diagonal matrix", "Matrix.mulVec", "Finset.sum_eq_single", "dot product"],
+    "prerequisites": ["matrix-vector multiplication", "Fin index types"]
+  },
+  {
     "id": "ann-diag-core",
     "proofId": "bezout-identity-oq-04-oq-01-oq-03",
-    "range": { "startLine": 93, "endLine": 127 },
+    "range": { "startLine": 87, "endLine": 127 },
     "type": "technique",
-    "title": "The diagonal core: solvability is entrywise divisibility",
-    "content": "**`diag_solvable_iff`**: for a rectangular *diagonal* `D`, the system `D ·ᵥ y = c` is solvable over `ℤ` iff `dEntry D i ∣ c i` for every row `i`.\n\nOver `ℤ` a single divisibility already encodes both branches of the classical criterion: when `dEntry D i ≠ 0` it is ordinary divisibility, and when `dEntry D i = 0` it is exactly `c i = 0` (since `0 ∣ x ↔ x = 0`). The **forward** direction reads divisibility off a given solution; the **backward** direction builds the witness column vector entrywise, choosing `y` on each in-range column by integer division `c / d` and closing the divisibility equation with `Int.mul_ediv_cancel'`. Out-of-range rows and columns (the rectangular slack when `m ≠ n`) carry diagonal entry `0`, where `0 ∣ c` forces `c = 0` and the contribution vanishes."
+    "title": "The Diagonal Core: Solvability Is Entrywise Divisibility",
+    "content": "diag_solvable_iff: for a rectangular diagonal D, the system D·y = c is solvable over ℤ iff dEntry D i ∣ c i for every row i. Over ℤ a single divisibility already encodes both branches of the classical criterion: when dEntry D i ≠ 0 it is ordinary divisibility, and when dEntry D i = 0 it is exactly c i = 0 (since 0 ∣ c ↔ c = 0). The forward direction reads divisibility off a given solution; the backward direction builds the witness column vector entrywise, choosing y on each in-range column by integer division c/d and closing the divisibility equation with Int.mul_ediv_cancel'. Out-of-range rows/columns (the rectangular slack when m ≠ n) carry diagonal entry 0, where 0 ∣ c forces c = 0.",
+    "mathContext": "$\\exists y,\\ D\\cdot_v y = c \\iff \\forall i,\\ \\mathrm{dEntry}\\,D\\,i \\mid c_i$; over $\\mathbb{Z}$, $0 \\mid c \\iff c = 0$ folds both branches into one.",
+    "significance": "key",
+    "relatedConcepts": ["divisibility", "Int.mul_ediv_cancel'", "zero_dvd_iff", "witness construction"],
+    "prerequisites": ["divisibility over ℤ", "integer division", "existential witnesses"]
   },
   {
     "id": "ann-derive-criterion",
     "proofId": "bezout-identity-oq-04-oq-01-oq-03",
-    "range": { "startLine": 146, "endLine": 172 },
+    "range": { "startLine": 129, "endLine": 171 },
     "type": "insight",
-    "title": "Deriving snf_solvability_criterion from snf_exists",
-    "content": "**`diophantine_solvable_iff`**: assuming only the decomposition `A = U · D · V` (the content of the parent's `snf_exists` axiom), the solvability criterion is a *theorem*, not a second axiom.\n\nThe reduction is three reversible moves: (1) `A ·ᵥ x = b ↔ U ·ᵥ (D ·ᵥ (V ·ᵥ x)) = b` by associativity (`mulVec_mulVec`); (2) strip `U` by left-multiplying with `U⁻¹` (`nonsing_inv_mul`, valid over `ℤ` because `det U = ±1` is a unit), turning the right side into `U⁻¹ ·ᵥ b`; (3) strip `V` by the change of variable `y = V ·ᵥ x`, a bijection of `ℤⁿ` since `V` is invertible. What remains is the diagonal system handled by `diag_solvable_iff`. **Consequence:** the parent entry's honest axiom count drops from 2 to 1 — only matrix-form SNF *existence* still needs to be assumed."
+    "title": "Deriving the Criterion from the Decomposition",
+    "content": "diophantine_solvable_iff: assuming only the decomposition A = U·D·V (the content of the parent's snf_exists axiom), the solvability criterion is a THEOREM, not a second axiom. The reduction is three reversible moves: (1) A·x = b ↔ U·(D·(V·x)) = b by associativity (mulVec_mulVec); (2) strip U by left-multiplying with U⁻¹ (nonsing_inv_mul, valid over ℤ because det U = ±1 is a unit), turning the right side into U⁻¹·b; (3) strip V by the change of variable y = V·x, a bijection of ℤⁿ since V is invertible. What remains is the diagonal system handled by diag_solvable_iff. Consequence: the parent entry's honest axiom count drops from 2 to 1 — only matrix-form SNF existence still needs assuming.",
+    "mathContext": "$A\\cdot_v x = b \\iff \\exists\\, y{=}V x,\\ D\\cdot_v y = U^{-1}\\cdot_v b$, since $U, V$ are invertible over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Matrix.nonsing_inv_mul", "change of variables", "mulVec_mulVec", "axiom reduction"],
+    "prerequisites": ["matrix inverse over ℤ", "IsUnit determinant", "reversible reductions"]
   },
   {
     "id": "ann-convention",
     "proofId": "bezout-identity-oq-04-oq-01-oq-03",
-    "range": { "startLine": 188, "endLine": 201 },
+    "range": { "startLine": 173, "endLine": 201 },
     "type": "insight",
-    "title": "Convention correction: U⁻¹·b, not U·b",
-    "content": "**`diophantine_solvable_iff_branches`** restates the criterion in the parent axiom's exact two-pronged shape `(d ≠ 0 → d ∣ c) ∧ (d = 0 → c = 0)` (shown equal to `d ∣ c` over `ℤ` by `int_dvd_iff_branches`), so the comparison with `snf_solvability_criterion` is line-for-line.\n\nCarrying the proof through pins the transformed right-hand side to the *genuine inverse* `U⁻¹ ·ᵥ b` for the convention `A = U · D · V`. The parent's axiom writes `snf.U ·ᵥ b`; under `A = U·D·V` that is the `U⁻¹` of this convention, so the axiom as stated is convention-inconsistent. The derived theorem is the corrected form."
+    "title": "Convention Correction: U⁻¹·b, not U·b",
+    "content": "diophantine_solvable_iff_branches restates the criterion in the parent axiom's exact two-pronged shape (d ≠ 0 → d ∣ c) ∧ (d = 0 → c = 0) — shown equal to d ∣ c over ℤ by int_dvd_iff_branches — so the comparison with snf_solvability_criterion is line-for-line. Carrying the proof through pins the transformed right-hand side to the genuine inverse U⁻¹·b for the convention A = U·D·V. The parent's axiom writes snf.U·b; under A = U·D·V that is the U⁻¹ of this convention, so the axiom as stated is convention-inconsistent. The derived theorem is the corrected form.",
+    "mathContext": "$d \\mid c \\iff (d \\ne 0 \\to d \\mid c) \\wedge (d = 0 \\to c = 0)$; transformed RHS is $U^{-1}\\cdot_v b$, not $U\\cdot_v b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["convention consistency", "two-pronged divisibility", "int_dvd_iff_branches", "forall_congr'"],
+    "prerequisites": ["divisibility over ℤ", "logical equivalences"]
   }
 ]

--- a/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01-oq-03/meta.json
@@ -61,5 +61,72 @@
         "module": "Mathlib.LinearAlgebra.FreeModule.PID"
       }
     ]
-  }
+  },
+  "overview": {
+    "historicalContext": "The Smith Normal Form, introduced by H. J. S. Smith in 1861, states that every integer matrix A can be written A = U·D·V with U, V unimodular (determinant ±1, hence invertible over ℤ) and D a rectangular diagonal matrix whose diagonal entries — the invariant factors — form a divisibility chain. It is the matrix incarnation of the structure theorem for finitely generated modules over a PID, and it is the standard tool for solving systems of linear Diophantine equations: A·x = b is solvable over ℤ exactly when each invariant factor divides the corresponding component of the transformed right-hand side. The parent gallery entry bezout-identity-oq-04-oq-01 formalized linear Diophantine systems by taking BOTH the existence of the decomposition (snf_exists) and the solvability criterion (snf_solvability_criterion) as axioms, and asked whether either could be discharged from Mathlib. This entry settles that question.",
+    "problemStatement": "Can the two Smith-Normal-Form axioms of the parent entry be eliminated using Mathlib's existing infrastructure? Concretely: (1) is the matrix existence statement A = U·D·V available in Mathlib, and (2) is the solvability criterion an independent assumption, or does it follow from the decomposition alone?",
+    "proofStrategy": "Take only the decomposition A = U·D·V as a hypothesis (the content of snf_exists) and derive the solvability criterion as a theorem. Reduce A·x = b in three reversible steps: peel off U by left-multiplying with U⁻¹ (valid over ℤ since det U is a unit, nonsing_inv_mul), turning the right side into the genuine inverse U⁻¹·b; absorb V by the bijective change of variable y = V·x; and solve the remaining diagonal system D·y = c. The diagonal core diag_solvable_iff proves D·y = c is solvable iff dEntry D i ∣ c i for each row — forward by reading divisibility off a solution, backward by constructing the witness entrywise via integer division (Int.mul_ediv_cancel'), with the rectangular slack rows/columns carrying diagonal entry 0 where 0 ∣ c forces c = 0. The two-pronged restatement diophantine_solvable_iff_branches matches the parent axiom's exact shape via int_dvd_iff_branches.",
+    "keyInsights": [
+      "The solvability criterion is NOT a second axiom: given the decomposition A = U·D·V, it is a theorem of elementary matrix algebra with zero axioms. The parent's honest axiom count therefore drops from 2 to 1.",
+      "Over ℤ a single divisibility d ∣ c silently encodes both branches of the classical criterion: when d ≠ 0 it is ordinary divisibility, and when d = 0 it is exactly c = 0, since 0 ∣ c ↔ c = 0. This collapses the parent's two-pronged condition into one clean statement.",
+      "A convention bug surfaces from carrying the proof through: with A = U·D·V the transformed right-hand side is the genuine inverse U⁻¹·b, not U·b as the parent axiom writes. The U·b form is the U⁻¹ of this convention, so the parent axiom was convention-inconsistent.",
+      "Existence (snf_exists) genuinely cannot be discharged from current Mathlib: Mathlib has the module-theoretic Smith Normal Form (Module.Basis.SmithNormalForm over a PID) but NOT the explicit unimodular-matrix factorization. Bridging the two is a substantial matrix↔module task left out of scope.",
+      "The whole derivation is rectangular (Fin m × Fin n), so the parent's 1×2 Bézout specialization is just a particular case — the dEntry helper isolates the column-index bookkeeping the rectangular case forces."
+    ]
+  },
+  "sections": [
+    {
+      "id": "diagonal-entry",
+      "title": "The Diagonal Entry of a Rectangular Matrix",
+      "startLine": 50,
+      "endLine": 85,
+      "summary": "dEntry D i = D i ⟨i,_⟩ when the column i is in range, else 0; diag_mulVec_apply shows a diagonal matrix acts by mulVec as a single per-row product, isolating the rectangular column-index bookkeeping.",
+      "mathContext": "$(D \\cdot_v y)_i = D_{i,i}\\, y_i$ when $i < n$, else $0$."
+    },
+    {
+      "id": "diagonal-core",
+      "title": "Solvability of a Diagonal System",
+      "startLine": 87,
+      "endLine": 127,
+      "summary": "diag_solvable_iff: ∃y, D·y = c ↔ ∀i, dEntry D i ∣ c i. Forward reads divisibility off a solution; backward builds the witness entrywise via Int.mul_ediv_cancel', with 0-rows forcing c = 0.",
+      "mathContext": "$\\exists y,\\ D\\cdot_v y = c \\iff \\forall i,\\ \\mathrm{dEntry}\\,D\\,i \\mid c_i$."
+    },
+    {
+      "id": "derived-criterion",
+      "title": "The Solvability Criterion, Derived from the Decomposition",
+      "startLine": 129,
+      "endLine": 171,
+      "summary": "isUnit_det_of_unimodular (±1 det is a ℤ-unit) and diophantine_solvable_iff: from A = U·D·V alone, ∃x, A·x = b ↔ ∀i, dEntry D i ∣ (U⁻¹·b) i, by stripping U (nonsing_inv_mul), the change of variable y = V·x, and the diagonal core.",
+      "mathContext": "$\\exists x,\\ A\\cdot_v x = b \\iff \\forall i,\\ \\mathrm{dEntry}\\,D\\,i \\mid (U^{-1}\\cdot_v b)_i$."
+    },
+    {
+      "id": "two-pronged-form",
+      "title": "The Parent Axiom's Two-Pronged Shape",
+      "startLine": 173,
+      "endLine": 201,
+      "summary": "int_dvd_iff_branches shows d ∣ c ⟺ (d≠0 → d∣c) ∧ (d=0 → c=0) over ℤ; diophantine_solvable_iff_branches restates the criterion in the parent axiom's exact form with the corrected U⁻¹·b right-hand side.",
+      "mathContext": "$d \\mid c \\iff (d \\ne 0 \\to d \\mid c) \\wedge (d = 0 \\to c = 0)$ over $\\mathbb{Z}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Taking the Smith-Normal-Form decomposition A = U·D·V as a hypothesis, the linear-Diophantine solvability criterion ∃x, A·x = b ↔ ∀i, dEntry D i ∣ (U⁻¹·b) i is derived as a zero-axiom theorem (diophantine_solvable_iff), together with its parent-shaped two-pronged restatement (diophantine_solvable_iff_branches) and the diagonal core (diag_solvable_iff). This shows the parent entry's snf_solvability_criterion is not an independent axiom, lowering its honest axiom count from 2 to 1, and corrects the transformed right-hand side from U·b to the genuine inverse U⁻¹·b. The matrix-form existence axiom snf_exists is shown to be genuinely absent from current Mathlib and is deliberately left in place.",
+    "implications": "Axiom hygiene: a formalization that axiomatized both existence and solvability needs only the first, because solvability is elementary matrix algebra once the decomposition is granted. The result is fully general over rectangular integer matrices, so it subsumes the parent's 1×2 Bézout case and any linear Diophantine system. It also pinpoints exactly what Mathlib still lacks — the explicit unimodular-matrix factorization D = U·A·V bridging Module.Basis.SmithNormalForm to matrices.",
+    "openQuestions": [
+      "Close snf_exists by building the matrix↔module bridge: derive A = U·D·V with unimodular U, V from Mathlib's Submodule.smithNormalForm / Module.Basis.SmithNormalForm, showing the change-of-basis matrices are unimodular.",
+      "Upgrade the criterion to count or enumerate the solution set (the kernel of A is V⁻¹ applied to the free directions of D), not just decide solvability.",
+      "Generalize from ℤ to an arbitrary PID, where the same three-step reduction and the divisibility-of-invariant-factors criterion hold verbatim."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Parent (Linear Diophantine Systems via Smith Normal Form): derives its snf_solvability_criterion axiom as a theorem from the decomposition alone, dropping the parent's axiom count from 2 to 1 and correcting U·b to U⁻¹·b."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "ancestor",
+      "description": "Root Bézout identity entry: the 1×2 linear Diophantine case ax + by = c is the specialization covered here."
+    }
+  ]
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "brouwer-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "context",
+    "title": "1D Sperner Lemma: Scope and the Sperner → Brouwer Program",
+    "content": "Sperner's lemma is the combinatorial counterpart of Brouwer's fixed point theorem, proved by induction on dimension; its base case is this 1-dimensional parity statement. The module docstring is honest about scope: full 2D Brouwer via Sperner needs simplicial complexes, triangulations and vertex labelings that Mathlib lacks (its Combinatorics.SetFamily 'Sperner' is the unrelated antichain theorem). This file formalizes only the 1D heart — color a path 0,…,n by c : ℕ → Bool, call an edge {i,i+1} bichromatic when c i ≠ c(i+1) — and does NOT claim the 2D theorem.",
+    "mathContext": "An edge $\\{i, i+1\\}$ is bichromatic when $c(i) \\ne c(i+1)$; the 1D Sperner lemma is the discrete IVT: a $\\mathit{false}\\to\\mathit{true}$ path has a bichromatic edge.",
+    "significance": "context",
+    "relatedConcepts": ["Sperner's lemma", "Brouwer fixed point theorem", "discrete IVT", "combinatorial topology"],
+    "prerequisites": ["graph paths", "two-colorings", "Brouwer's theorem"]
+  },
+  {
+    "id": "ann-edges",
+    "proofId": "brouwer-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 70 },
+    "type": "definition",
+    "title": "Bichromatic Edges and the Count Recurrence",
+    "content": "spernerEdges c n = {i < n : c i ≠ c(i+1)} is the finite set of bichromatic edges among the first n edges; colorChanges c n is its cardinality. colorChanges_succ proves the one-step recurrence: extending the path by one vertex adds a bichromatic edge iff the new vertex differs in color from the previous one. The proof rewrites range (n+1) as insert n (range n) and uses Finset.filter_insert: a monochromatic step drops n from the filter (+0), a bichromatic step inserts a fresh n (card_insert_of_notMem, +1).",
+    "mathContext": "$\\mathrm{colorChanges}(c, n+1) = \\mathrm{colorChanges}(c, n) + [\\,c(n) \\ne c(n+1)\\,]$, where $[\\cdot]$ is the Iverson bracket.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.filter", "Finset.card", "Finset.filter_insert", "recurrence relation"],
+    "prerequisites": ["finite sets", "filtering and cardinality"]
+  },
+  {
+    "id": "ann-parity",
+    "proofId": "brouwer-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 99 },
+    "type": "insight",
+    "title": "The Parity Identity: Endpoints Determine Everything",
+    "content": "even_colorChanges_iff is the crux: Even (colorChanges c n) ↔ c 0 = c n — the bichromatic-edge count is even exactly when the two endpoints share a color, regardless of all interior structure. The induction has two cases on the recurrence: a monochromatic step preserves both the count parity and the endpoint equality; a bichromatic step flips the count parity (Nat.even_add_one) AND flips the endpoint-equality predicate, the latter a finite Boolean tautology closed by cases … decide. oddColorChanges_of_ne then reads off: differing endpoints ⟹ odd count. This is the discrete telescoping that mirrors 'a function returns to its starting sign iff it crosses zero an even number of times'.",
+    "mathContext": "$\\mathrm{Even}(\\mathrm{colorChanges}(c,n)) \\iff c(0) = c(n)$; all interior colors cancel, leaving only the two endpoints.",
+    "significance": "key",
+    "relatedConcepts": ["parity", "telescoping", "Nat.even_add_one", "induction invariant", "Boolean tautology"],
+    "prerequisites": ["parity of natural numbers", "induction", "Bool case analysis"]
+  },
+  {
+    "id": "ann-sperner",
+    "proofId": "brouwer-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 130 },
+    "type": "theorem",
+    "title": "The 1D Sperner Lemma = Discrete IVT",
+    "content": "exists_sperner_edge is the 1D Sperner lemma: a path colored false at 0 and true at n has a bichromatic edge {i,i+1}. Since the endpoints differ, oddColorChanges_of_ne makes the count odd, hence positive (an odd number is nonzero), so by Finset.card_pos the edge set is nonempty and yields an explicit crossing index i. colorChanges_pos_of_ne records the quantitative positivity. Read analytically, this is the discrete intermediate value theorem: a walk from region 0 to region 1 must cross the boundary an odd — hence nonzero — number of times, the exact combinatorial shadow of the analytic IVT the parent used for continuous 1D Brouwer.",
+    "mathContext": "$c(0)=\\mathit{false},\\ c(n)=\\mathit{true} \\Rightarrow \\exists\\, i < n,\\ c(i)\\ne c(i+1)$ — odd count $\\Rightarrow$ positive $\\Rightarrow$ nonempty edge set.",
+    "significance": "key",
+    "relatedConcepts": ["intermediate value theorem", "Finset.card_pos", "Odd implies nonzero", "boundary crossing"],
+    "prerequisites": ["nonemptiness from positive cardinality", "parity to positivity"]
+  },
+  {
+    "id": "ann-toward-2d",
+    "proofId": "brouwer-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 136 },
+    "type": "context",
+    "title": "Why This Is Genuine Progress Toward 2D Brouwer",
+    "content": "This base case is non-cosmetic: the inductive step of the full Sperner lemma counts bichromatic edges on the boundary of a 2D triangulation and feeds exactly this 1D parity argument across that boundary. Establishing it honestly (0 axioms, 0 sorries, no native_decide) supplies the combinatorial engine — boundary parity counting — on which the Sperner → Brouwer program runs, without overclaiming the 2D theorem. The remaining blockers are the missing triangulation/labeling infrastructure and the 2D Sperner lemma itself.",
+    "mathContext": "2D Sperner: a Sperner coloring of a triangulation of a triangle has an odd number of fully-colored cells, proved by inducting this 1D boundary parity over the triangulation's edges.",
+    "significance": "context",
+    "relatedConcepts": ["dimension induction", "triangulations", "Sperner coloring", "mesh refinement"],
+    "prerequisites": ["simplicial complexes", "Sperner's lemma in higher dimension"]
+  }
+]

--- a/src/data/proofs/erdos-415-oq-01/annotations.json
+++ b/src/data/proofs/erdos-415-oq-01/annotations.json
@@ -1,35 +1,62 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "erdos-415-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Erdős #415 and the Ordering-Pattern Function F(n)",
+    "content": "Erdős Problem #415 studies the local order of Euler's totient. For a window of k consecutive values φ(m+1),…,φ(m+k), their relative order is one of the k! permutations; F(n) is the largest k such that every one of the k! orderings is realized by some window inside [1,n]. Erdős proved F(n) ≍ log log log n — one of the slowest growth rates in number theory — with the exact constant still open (the parent's first open question). This file pins the explicit small end: a constructive F(n) ≥ 3, with a witness table for all six orderings of three consecutive totients.",
+    "mathContext": "$F(n) = \\max\\{k : \\text{all } k!\\text{ orderings of some } (\\varphi(m+1),\\dots,\\varphi(m+k))\\subseteq[1,n] \\text{ occur}\\}$, with $F(n) \\asymp \\log\\log\\log n$.",
+    "significance": "context",
+    "relatedConcepts": ["Euler's totient", "permutation patterns", "Erdős problems", "iterated logarithm growth"],
+    "prerequisites": ["Euler's totient function", "permutations", "asymptotic notation"]
+  },
+  {
     "id": "ann-k2",
     "proofId": "erdos-415-oq-01",
-    "range": {
-      "startLine": 35,
-      "endLine": 42
-    },
+    "range": { "startLine": 35, "endLine": 42 },
     "type": "concept",
     "title": "The Base Case: Both Adjacent Orderings",
-    "content": "pattern_lt and pattern_gt give the two 2! = 2 orderings of adjacent totients: an increasing pair φ(2)=1 < 2=φ(3) and a decreasing pair φ(5)=4 > 2=φ(6). Both occur within [1,6], so F(n) ≥ 2 for every n ≥ 6 — the smallest nontrivial instance of the ordering-pattern problem."
+    "content": "pattern_lt and pattern_gt give the two 2! = 2 orderings of adjacent totients: an increasing pair φ(2)=1 < 2=φ(3) and a decreasing pair φ(5)=4 > 2=φ(6). Both occur within [1,6], so F(n) ≥ 2 for every n ≥ 6 — the smallest nontrivial instance of the ordering-pattern problem. Each is a single kernel decide on small totient values.",
+    "mathContext": "$\\varphi(2)=1 < 2=\\varphi(3)$ (increasing) and $\\varphi(5)=4 > 2=\\varphi(6)$ (decreasing); both within $[1,6]$, so $F(n)\\ge 2$ for $n\\ge 6$.",
+    "significance": "supporting",
+    "relatedConcepts": ["base case", "totient values", "adjacent comparison"],
+    "prerequisites": ["Euler's totient function"]
   },
   {
     "id": "ann-monotone-runs",
     "proofId": "erdos-415-oq-01",
-    "range": {
-      "startLine": 44,
-      "endLine": 77
-    },
+    "range": { "startLine": 44, "endLine": 71 },
     "type": "insight",
     "title": "The Rare Monotone Runs",
-    "content": "Of the six orderings of three consecutive totients, four are 'mixed' and appear almost immediately (m ≤ 16). The two strictly monotone runs are rare. The first strictly increasing run is φ(105)=48 < φ(106)=52 < φ(107)=106 (φ(107)=106 because 107 is prime); the first strictly decreasing run is φ(313)=312 > φ(314)=156 > φ(315)=144. The proofs use kernel decide with a raised maxRecDepth (the totient of 315 exceeds the default recursion limit) — still kernel decide, not native_decide, so no Lean.ofReduceBool is introduced."
+    "content": "Of the six orderings of three consecutive totients, four are 'mixed' (pattern_acb at m=6, pattern_bac at m=5, pattern_bca at m=13, pattern_cab at m=16) and appear almost immediately (m ≤ 16). The two strictly monotone runs are rare. The first strictly increasing run is φ(105)=48 < φ(106)=52 < φ(107)=106 (φ(107)=106 because 107 is prime, so φ(p)=p−1); the first strictly decreasing run is φ(313)=312 > φ(314)=156 > φ(315)=144 (313 prime gives the large φ; 315=3²·5·7 highly composite gives the small φ). Monotone runs are hard precisely because φ swings between p−1 at primes and small values at highly composite numbers.",
+    "mathContext": "Increasing: $\\varphi(105){=}48 < \\varphi(106){=}52 < \\varphi(107){=}106$. Decreasing: $\\varphi(313){=}312 > \\varphi(314){=}156 > \\varphi(315){=}144$. Large $\\varphi$ at primes $p{-}1$, small $\\varphi$ at composites.",
+    "significance": "key",
+    "relatedConcepts": ["monotone runs", "totient at primes", "highly composite numbers", "permutation patterns"],
+    "prerequisites": ["Euler's totient at primes and prime powers", "factorization"]
+  },
+  {
+    "id": "ann-decide-integrity",
+    "proofId": "erdos-415-oq-01",
+    "range": { "startLine": 47, "endLine": 71 },
+    "type": "technique",
+    "title": "Kernel decide vs native_decide: Staying Axiom-Free",
+    "content": "Every comparison is closed by kernel decide, which evaluates Nat.totient by trusted kernel reduction. For the two large windows (m=105 and m=313) the evaluation exceeds Lean's default recursion limit, so a local set_option maxRecDepth (4000 for pattern_abc, 8000 for pattern_cba) is used — this only raises the recursion budget, it remains kernel decide. Crucially it is NOT native_decide: native_decide would compile to native code and add the Lean.ofReduceBool axiom, which (per the project's axiom-integrity policy) counts as an assumption and would force status 'axiomatized'. Kernel decide depends only on propext / Classical.choice / Quot.sound, so the entry is genuinely verified / 0-axiom.",
+    "mathContext": "$\\texttt{decide}$ trusts kernel reduction (foundational axioms only); $\\texttt{native\\_decide}$ adds $\\texttt{Lean.ofReduceBool}$. Here only $\\texttt{maxRecDepth}$ is raised, so the proofs stay axiom-free.",
+    "significance": "technical",
+    "relatedConcepts": ["decidability", "kernel reduction", "native_decide", "axiom integrity", "maxRecDepth"],
+    "prerequisites": ["Lean decide tactic", "Lean axiom system"]
   },
   {
     "id": "ann-bound",
     "proofId": "erdos-415-oq-01",
-    "range": {
-      "startLine": 79,
-      "endLine": 97
-    },
+    "range": { "startLine": 73, "endLine": 97 },
     "type": "insight",
     "title": "F(n) ≥ 3, Explicitly",
-    "content": "all_six_orderings_realized bundles the six witnesses: since all 3! = 6 orderings of three consecutive totients are realized by windows inside [1,315], F(n) ≥ 3 for every n ≥ 315. This is the explicit lower-bound counterpart to the parent's asymptotic F(n) ≍ log log log n. extreme_runs_are_late isolates the two monotone runs — their lateness (m = 105, 313 versus m ≤ 16 for the mixed patterns) is the elementary reason F(n) grows only triple-logarithmically: building longer monotone runs of totients requires looking exponentially further out."
+    "content": "all_six_orderings_realized bundles the six pattern witnesses by the anonymous constructor: since all 3! = 6 orderings of three consecutive totients are realized by windows inside [1,315], F(n) ≥ 3 for every n ≥ 315. This is the explicit lower-bound counterpart to the parent's asymptotic F(n) ≍ log log log n. extreme_runs_are_late destructures the bundle to isolate the two monotone runs — their lateness (m = 105, 313 versus m ≤ 16 for the mixed patterns) is the elementary reason F(n) grows only triple-logarithmically: forcing a longer monotone run of totients requires looking exponentially further out.",
+    "mathContext": "All six orderings realized within $[1,315] \\Rightarrow F(n)\\ge 3$ for $n\\ge 315$. The gap between $m\\le 16$ (mixed) and $m=105,313$ (monotone) is the fingerprint of $\\log\\log\\log n$ growth.",
+    "significance": "key",
+    "relatedConcepts": ["constructive lower bound", "anonymous constructor", "asymptotic vs explicit", "triple logarithm"],
+    "prerequisites": ["logical conjunction", "Euler's totient function"]
   }
 ]


### PR DESCRIPTION
Accumulating enrichment pass (enricher-2). Each commit enriches one gallery entry.

## Entries
1. **erdos-415-oq-01** (Erdős #415: constructive F(n) ≥ 3) — deepened annotations 3 → 5 (mathContext/significance/relatedConcepts/prerequisites + header + axiom-integrity note). Verified kernel `decide`, not `native_decide`.
2. **bezout-identity-oq-04-oq-01-oq-03** (SNF solvability criterion is derived) — added missing structured `overview`/`conclusion`/`sections`/`crossReferences`; annotations 3 → 5.
3. **brouwer-fixed-point-oq-01-oq-01** (1D Sperner lemma / discrete IVT) — added missing `annotations.json` (5 annotations) covering the edge recurrence, parity identity, the 1D Sperner lemma, and the path toward 2D Brouwer.

`pnpm build` passes. No axiom-integrity changes — all entries remain verified / 0-axiom.