### PR TITLE
research(spectral-trace-oq01010202): trace power sum tr(Aᵏ)=Σλᵢᵏ in all dimensions (diagonalizable) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3849,6 +3849,7 @@ import Proofs.SophieGermainOQ03
 import Proofs.SophieGermainOQ04
 import Proofs.SpectralTraceDetEigenvaluesOQ01
 import Proofs.SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ01
+import Proofs.SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02
 import Proofs.SpectralTraceDetEigenvaluesOQ02
 import Proofs.SpernerFreudenthal
 import Proofs.SpernerFreudenthalAristotle

--- a/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,177 @@
+import Mathlib
+import Proofs.SpectralTraceDetEigenvaluesOQ01
+
+/-
+# Spectral trace, OQ-01 → OQ-01 → OQ-02 → OQ-02: the trace power sum `tr(Aᵏ) = Σ λᵢᵏ`
+in **all dimensions** and for **all powers**, via the spectral-mapping technique
+
+## Background and what is new
+
+The parent line proved Newton's power-sum identity one dimension at a time:
+
+* `spectral-trace-det-eigenvalues-oq-01-oq-01` — `tr(A²) = λ₁² + λ₂²` for `2 × 2` matrices,
+* `spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02` — `tr(A³) = λ₁³ + λ₂³ + λ₃³` for `3 × 3`.
+
+Each step matched a **dimension-specific** matrix Newton identity (closed by `ring` on the
+entries) against the corresponding multiset identity, using Vieta to identify the elementary
+symmetric functions.  That route is intrinsically bounded: the `ring` identity has to be
+rewritten by hand for every new `(k, n)`.
+
+This file removes both restrictions at once for **diagonalizable** matrices, replacing the
+per-dimension `ring` computations by the dimension-free **spectral-mapping** mechanism:
+
+      A = M · diag(d) · M⁻¹     ⟹     Aᵏ = M · diag(d)ᵏ · M⁻¹ = M · diag(dᵏ) · M⁻¹,
+
+so the trace is conjugation-invariant and reads off the diagonal:
+
+      tr(Aᵏ) = tr(diag(d)ᵏ) = Σᵢ (dᵢ)ᵏ,
+
+while the eigenvalue multiset (the roots of the characteristic polynomial) is the multiset
+`{dᵢ}` — *with multiplicity* — because `charpoly(diag d) = ∏ᵢ (X − dᵢ)`.  Combining the two:
+
+      tr(Aᵏ) = Σ_{λ ∈ eigenvalues A} λᵏ          for every `k` and every dimension.
+
+## Results
+
+* `trace_diagonal_pow` — for any diagonal matrix and any `k`, `tr(diag(d)ᵏ) = Σᵢ (dᵢ)ᵏ`
+  (over any commutative ring).
+* `units_conj_pow` / `trace_pow_units_conj` — conjugation by a unit commutes with powers, hence
+  the trace of a power is conjugation-invariant: `tr((M A M⁻¹)ᵏ) = tr(Aᵏ)`.
+* `roots_charpoly_diagonal` — the eigenvalue multiset of a diagonal matrix is exactly its
+  diagonal (with multiplicity): `(diag d).charpoly.roots = (univ : Finset n).val.map d`.
+* `trace_pow_eq_sum_pow_eigenvalues` — **the headline spectral identity**, in all dimensions and
+  for all powers, for any matrix `A = M · diag(d) · M⁻¹`:
+
+        tr(Aᵏ) = ((eigenvalues A).map (· ^ k)).sum.
+
+  Specialising `k = 1` recovers the parent headline `trace_eq_sum_eigenvalues`; the genuinely new
+  content is uniformity in both `k` and the dimension.
+* `card_eigenvalues_diagonalizable` — such an `A` has exactly `Fintype.card n` eigenvalues counted
+  with multiplicity, over *any* field (no algebraic closure needed: the characteristic polynomial
+  already splits).
+
+## Honesty / scope
+
+The theorem is stated for **diagonalizable** matrices (`A = M · diag(d) · M⁻¹`).  This is the
+dense/generic case and the natural reach of an elementary spectral-mapping argument that uses only
+conjugation invariance and `charpoly_diagonal`.  The fully general statement (every matrix over an
+algebraically closed field) additionally needs **triangularization** — similarity to an
+upper-triangular matrix with the eigenvalues on the diagonal — which Mathlib does not currently
+expose at the matrix level (only the endomorphism generalized-eigenspace decomposition).  That
+extension is recorded as the open follow-up.  No `native_decide`; `#print axioms` confirms only the
+standard foundational axioms.
+-/
+
+namespace SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02
+
+open Matrix Polynomial
+open SpectralTraceDetEigenvaluesOQ01 (eigenvalues)
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-! ## Part I: the diagonal power sum and conjugation invariance (over any commutative ring) -/
+
+variable {R : Type*} [CommRing R]
+
+/-- **Trace of a power of a diagonal matrix is the power sum of its diagonal entries.**
+`tr(diag(d)ᵏ) = Σᵢ (dᵢ)ᵏ`, over any commutative ring.  The single fact behind every diagonal
+power-sum: `diag(d)ᵏ = diag(dᵏ)` and the trace of a diagonal matrix is the sum of its entries. -/
+theorem trace_diagonal_pow (d : n → R) (k : ℕ) :
+    ((diagonal d) ^ k).trace = ∑ i, (d i) ^ k := by
+  rw [diagonal_pow, trace_diagonal]
+  simp only [Pi.pow_apply]
+
+/-- **Conjugation by a unit commutes with taking powers.**
+`(M · N · M⁻¹)ᵏ = M · Nᵏ · M⁻¹`. -/
+theorem units_conj_pow (M : (Matrix n n R)ˣ) (N : Matrix n n R) (k : ℕ) :
+    ((M : Matrix n n R) * N * (↑M⁻¹ : Matrix n n R)) ^ k
+      = (M : Matrix n n R) * N ^ k * (↑M⁻¹ : Matrix n n R) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      rw [pow_succ, ih, pow_succ]
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (↑M⁻¹ : Matrix n n R) (↑M : Matrix n n R), Units.inv_mul, one_mul]
+
+/-- **The trace of a power is conjugation-invariant.** `tr((M · N · M⁻¹)ᵏ) = tr(Nᵏ)`. -/
+theorem trace_pow_units_conj (M : (Matrix n n R)ˣ) (N : Matrix n n R) (k : ℕ) :
+    (((M : Matrix n n R) * N * (↑M⁻¹ : Matrix n n R)) ^ k).trace = (N ^ k).trace := by
+  rw [units_conj_pow, trace_units_conj]
+
+/-! ## Part II: eigenvalues of a diagonal matrix (over a field) -/
+
+variable {K : Type*} [Field K]
+
+/-- **The eigenvalue multiset of a diagonal matrix is its diagonal, with multiplicity.**
+`(diag d).charpoly.roots = (univ : Finset n).val.map d`.  Repeated diagonal entries appear with
+the correct multiplicity because we use the *multiset* form of `roots (∏ (X − aᵢ)) = {aᵢ}`. -/
+theorem roots_charpoly_diagonal (d : n → K) :
+    (diagonal d).charpoly.roots = (Finset.univ : Finset n).val.map d := by
+  rw [charpoly_diagonal, ← roots_multiset_prod_X_sub_C ((Finset.univ : Finset n).val.map d)]
+  congr 1
+  rw [Multiset.map_map]
+  rfl
+
+/-! ## Part III: the spectral trace power sum in all dimensions and all powers -/
+
+/-- **The trace power sum `tr(Aᵏ) = Σ λᵢᵏ`, uniformly in the power `k` and the dimension `n`,**
+for a diagonalizable matrix `A = M · diag(d) · M⁻¹`.
+
+Over *any* field, the trace of the `k`-th power is the `k`-th power sum of the eigenvalues of `A`
+(the roots of its characteristic polynomial, counted with multiplicity):
+
+      tr(Aᵏ) = ((eigenvalues A).map (· ^ k)).sum.
+
+The trace side is conjugation invariance + the diagonal power sum (`trace_pow_units_conj`,
+`trace_diagonal_pow`); the eigenvalue side is conjugation invariance of the characteristic
+polynomial (`charpoly_units_conj`) + `roots_charpoly_diagonal`.  No algebraic closure is needed:
+the characteristic polynomial of a diagonalizable matrix already splits. -/
+theorem trace_pow_eq_sum_pow_eigenvalues (A : Matrix n n K) (M : (Matrix n n K)ˣ) (d : n → K)
+    (hA : A = (M : Matrix n n K) * diagonal d * (↑M⁻¹ : Matrix n n K)) (k : ℕ) :
+    (A ^ k).trace = ((eigenvalues A).map (· ^ k)).sum := by
+  have htrace : (A ^ k).trace = ∑ i, (d i) ^ k := by
+    rw [hA, trace_pow_units_conj, trace_diagonal_pow]
+  have hroots : eigenvalues A = (Finset.univ : Finset n).val.map d := by
+    show A.charpoly.roots = _
+    rw [hA, charpoly_units_conj]
+    exact roots_charpoly_diagonal d
+  rw [htrace, hroots, Multiset.map_map]
+  rfl
+
+/-- A diagonalizable matrix `A = M · diag(d) · M⁻¹` has exactly `Fintype.card n` eigenvalues counted
+with multiplicity, over *any* field — no algebraic closure required, since its characteristic
+polynomial splits. -/
+theorem card_eigenvalues_diagonalizable (A : Matrix n n K) (M : (Matrix n n K)ˣ) (d : n → K)
+    (hA : A = (M : Matrix n n K) * diagonal d * (↑M⁻¹ : Matrix n n K)) :
+    Multiset.card (eigenvalues A) = Fintype.card n := by
+  have hroots : eigenvalues A = (Finset.univ : Finset n).val.map d := by
+    show A.charpoly.roots = _
+    rw [hA, charpoly_units_conj]
+    exact roots_charpoly_diagonal d
+  rw [hroots, Multiset.card_map, ← Finset.card_def, Finset.card_univ]
+
+/-! ## Part IV: concrete illustrations -/
+
+/-- For the diagonal matrix `diag(2, 3)` the power sum identity gives `tr(A³) = 2³ + 3³ = 35`,
+read directly off the (already diagonal) eigenvalues — with `k = 3` and no `ring` computation. -/
+theorem trace_pow_diagonal_example :
+    ((diagonal ![(2 : ℚ), 3]) ^ 3).trace = 35 := by
+  rw [trace_diagonal_pow]
+  norm_num [Fin.sum_univ_two]
+
+/-- The same diagonal matrix has two eigenvalues `{2, 3}`, and their cubes sum to `35`, matching
+`tr(A³)`. -/
+theorem sum_pow_eigenvalues_example :
+    ((eigenvalues (diagonal ![(2 : ℚ), 3])).map (· ^ 3)).sum = 35 := by
+  show (((diagonal ![(2 : ℚ), 3]).charpoly.roots).map (· ^ 3)).sum = 35
+  rw [roots_charpoly_diagonal, Multiset.map_map]
+  show (∑ i, (![(2 : ℚ), 3] i) ^ 3) = 35
+  norm_num [Fin.sum_univ_two]
+
+end SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.trace_pow_eq_sum_pow_eigenvalues
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.roots_charpoly_diagonal
+#print axioms SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.card_eigenvalues_diagonalizable

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ann-spectral-trace-oq01010202-00-header",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 4, "endLine": 63 },
+    "type": "context",
+    "title": "From per-dimension Vieta to a dimension-free spectral mapping",
+    "content": "The parent line proved Newton's power-sum identity one (power, dimension) pair at a time — tr(A²)=Σλ² for 2×2 and tr(A³)=Σλ³ for 3×3 — each by matching a dimension-specific matrix identity (closed by ring on the entries) against a multiset identity via Vieta. That route is intrinsically bounded. This file removes both restrictions at once for diagonalizable matrices: writing A = M·diag(d)·M⁻¹, the power Aᵏ = M·diag(d)ᵏ·M⁻¹ = M·diag(dᵏ)·M⁻¹ is transparent, so conjugation invariance of the trace reads tr(Aᵏ) off the diagonal, while conjugation invariance of the characteristic polynomial identifies the eigenvalue multiset with the diagonal. The honesty note records that the fully general (non-diagonalizable) case still needs matrix triangularization, absent from this Mathlib snapshot."
+  },
+  {
+    "id": "ann-spectral-trace-oq01010202-01-diagpow",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 72, "endLine": 79 },
+    "type": "key-step",
+    "title": "trace_diagonal_pow: the diagonal power sum",
+    "content": "tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ over any commutative ring. The whole proof rests on two Mathlib facts: diagonal_pow (diag(d)ᵏ = diag(dᵏ), since the diagonal embedding is a ring homomorphism) and trace_diagonal (the trace of a diagonal matrix is the sum of its entries). The entrywise power (dᵏ)ᵢ = (dᵢ)ᵏ is Pi.pow_apply. This is the only place a power sum is computed — everything else is conjugation invariance."
+  },
+  {
+    "id": "ann-spectral-trace-oq01010202-02-conjpow",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 83, "endLine": 104 },
+    "type": "key-step",
+    "title": "Conjugation commutes with powers, so the power-trace is similarity-invariant",
+    "content": "units_conj_pow proves (M·N·M⁻¹)ᵏ = M·Nᵏ·M⁻¹ by induction on k: the successor step reassociates and telescopes the interior M⁻¹·M = 1 (Units.inv_mul). trace_pow_units_conj then composes this with the cyclic trace law trace_units_conj to give tr((M·N·M⁻¹)ᵏ) = tr(Nᵏ). This is the trace half of the similarity invariance of the spectrum, and it is what lets a diagonalization A = M·diag(d)·M⁻¹ pass the trace computation down to the diagonal."
+  },
+  {
+    "id": "ann-spectral-trace-oq01010202-03-rootsdiag",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 112, "endLine": 121 },
+    "type": "key-step",
+    "title": "roots_charpoly_diagonal: eigenvalues of a diagonal matrix, with multiplicity",
+    "content": "(diag d).charpoly.roots = univ.val.map d. From charpoly_diagonal the characteristic polynomial is ∏ᵢ(X − dᵢ); rewriting this as a multiset product and applying roots_multiset_prod_X_sub_C gives the multiset of diagonal entries. The MULTISET form (not the Finset form roots_prod_X_sub_C) is essential: a repeated diagonal entry must appear as a repeated eigenvalue, so diag(2,2,3) has eigenvalue multiset {2,2,3}, not the set {2,3}."
+  },
+  {
+    "id": "ann-spectral-trace-oq01010202-04-main",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 134, "endLine": 145 },
+    "type": "key-step",
+    "title": "trace_pow_eq_sum_pow_eigenvalues: the headline, uniform in k and n",
+    "content": "For A = M·diag(d)·M⁻¹ the trace side rewrites via trace_pow_units_conj then trace_diagonal_pow to Σᵢ(dᵢ)ᵏ; the eigenvalue side rewrites via charpoly_units_conj then roots_charpoly_diagonal to give eigenvalues A = univ.val.map d, whose image under (·^k) sums to the same Σᵢ(dᵢ)ᵏ (Multiset.map_map, then both sides are the same Finset sum definitionally). No algebraic closure is used — the characteristic polynomial of a diagonalizable matrix already splits. Specialising k=1 recovers the grandparent's trace = Σλ."
+  },
+  {
+    "id": "ann-spectral-trace-oq01010202-05-card",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 146, "endLine": 151 },
+    "type": "observation",
+    "title": "Exactly n eigenvalues over any field — no algebraic closure",
+    "content": "card_eigenvalues_diagonalizable reads Multiset.card (eigenvalues A) = Fintype.card n directly off eigenvalues A = univ.val.map d (Multiset.card_map, Finset.card_univ). The parent line needed IsAlgClosed for the eigenvalue count; here it is free, because diagonalizability forces the characteristic polynomial to split with the full count of roots."
+  },
+  {
+    "id": "ann-spectral-trace-oq01010202-06-example",
+    "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 153, "endLine": 167 },
+    "type": "example",
+    "title": "diag(2,3): both sides equal 2³ + 3³ = 35",
+    "content": "trace_pow_diagonal_example computes tr(diag(2,3)³) = 35 via trace_diagonal_pow, and sum_pow_eigenvalues_example computes the eigenvalue cube sum ((eigenvalues (diag(2,3))).map(·^3)).sum = 35 via roots_charpoly_diagonal, exhibiting the headline identity concretely at k=3."
+  }
+]

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spectralTraceDetEigenvaluesOq01Oq01Oq02Oq02Data: ProofData = {
+  proof: spectralTraceDetEigenvaluesOq01Oq01Oq02Oq02Proof,
+  annotations: spectralTraceDetEigenvaluesOq01Oq01Oq02Oq02Annotations,
+}

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+  "title": "Spectral Trace Power Sum tr(Aᵏ) = Σλᵢᵏ in All Dimensions (Diagonalizable Case)",
+  "slug": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
+  "description": "Takes up the standing open question of the spectral-trace line — prove the trace power sum tr(Aᵏ) = Σλᵢᵏ uniformly in the power k and the dimension n, rather than one fixed (k, n) at a time via Vieta. For DIAGONALIZABLE matrices A = M·diag(d)·M⁻¹ this is settled completely by the dimension-free spectral-mapping mechanism: since Aᵏ = M·diag(d)ᵏ·M⁻¹ = M·diag(dᵏ)·M⁻¹, conjugation invariance of the trace reads the answer off the diagonal, tr(Aᵏ) = tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ, while the eigenvalue multiset (roots of the characteristic polynomial) is exactly {dᵢ} with multiplicity because charpoly(diag d) = ∏ᵢ(X − dᵢ). The headline trace_pow_eq_sum_pow_eigenvalues gives tr(Aᵏ) = ((eigenvalues A).map(·^k)).sum for every k and every dimension over ANY field — no algebraic closure is needed, since the characteristic polynomial of a diagonalizable matrix already splits. Supporting results, all reusable: trace_diagonal_pow (tr(diag(d)ᵏ) = Σ(dᵢ)ᵏ over any commutative ring), units_conj_pow and trace_pow_units_conj (conjugation by a unit commutes with powers, so the power-trace is conjugation-invariant), roots_charpoly_diagonal (the eigenvalue multiset of a diagonal matrix is its diagonal with multiplicity), and card_eigenvalues_diagonalizable (a diagonalizable matrix has exactly Fintype.card n eigenvalues over any field). This replaces the parent line's per-dimension ring computations (which proved only k=2,3 in fixed dimensions 2,3) by a single uniform argument. Fully verified, 0 axioms, 0 sorries, no decide/native_decide. SCOPE: the diagonalizable case; the fully general non-diagonalizable case additionally needs matrix triangularization, absent from the Mathlib snapshot.",
+  "meta": {
+    "author": "Classical (spectral mapping theorem; conjugation invariance of the trace); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Spectral_theorem",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "eigenvalues",
+      "characteristic-polynomial",
+      "trace",
+      "power-sums",
+      "spectral-mapping",
+      "diagonalizable",
+      "conjugation-invariance",
+      "all-dimensions",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.diagonal_pow",
+        "description": "diag(d)ᵏ = diag(dᵏ): a power of a diagonal matrix is the diagonal of the entrywise power. With trace_diagonal this gives the diagonal power sum tr(diag(d)ᵏ) = Σ(dᵢ)ᵏ.",
+        "module": "Mathlib.Data.Matrix.Basic"
+      },
+      {
+        "theorem": "Matrix.trace_units_conj",
+        "description": "tr(M·N·M⁻¹) = tr(N) for a unit M: cyclic invariance of the trace under conjugation. Combined with units_conj_pow it yields the conjugation invariance of the power-trace tr((M·N·M⁻¹)ᵏ) = tr(Nᵏ).",
+        "module": "Mathlib.LinearAlgebra.Matrix.Trace"
+      },
+      {
+        "theorem": "Matrix.charpoly_units_conj",
+        "description": "(M·N·M⁻¹).charpoly = N.charpoly: the characteristic polynomial is invariant under conjugation by a unit. This carries the eigenvalue multiset of A = M·diag(d)·M⁻¹ back to that of diag(d).",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "Matrix.charpoly_diagonal",
+        "description": "charpoly(diag d) = ∏ᵢ(X − C(dᵢ)): the characteristic polynomial of a diagonal matrix factors over its diagonal entries. The starting point for identifying the eigenvalue multiset as the diagonal.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "Polynomial.roots_multiset_prod_X_sub_C",
+        "description": "the roots of ∏(X − aᵢ) over a multiset are exactly that multiset; the MULTISET form preserves multiplicity, so repeated diagonal entries give repeated eigenvalues. Turns charpoly_diagonal into roots_charpoly_diagonal: (diag d).charpoly.roots = univ.val.map d.",
+        "module": "Mathlib.Algebra.Polynomial.Roots"
+      }
+    ],
+    "originalContributions": [
+      "trace_pow_eq_sum_pow_eigenvalues: the headline spectral trace power sum tr(Aᵏ) = ((eigenvalues A).map(·^k)).sum for a diagonalizable matrix A = M·diag(d)·M⁻¹, UNIFORMLY in the power k and the dimension n, over any field — the first entry in the line to be dimension-free and power-free, replacing the parent's fixed-(k,n) Vieta computations",
+      "trace_diagonal_pow: tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ over any commutative ring, the diagonal power sum behind the whole argument (diag(d)ᵏ = diag(dᵏ) plus trace = sum of diagonal)",
+      "units_conj_pow: conjugation by a unit commutes with powers, (M·N·M⁻¹)ᵏ = M·Nᵏ·M⁻¹, proved by induction with M⁻¹·M = 1 telescoping the interior",
+      "trace_pow_units_conj: the power-trace is conjugation-invariant, tr((M·N·M⁻¹)ᵏ) = tr(Nᵏ), the trace half of similarity invariance of the spectrum",
+      "roots_charpoly_diagonal: the eigenvalue multiset of a diagonal matrix is its diagonal counted with multiplicity, (diag d).charpoly.roots = univ.val.map d, using the multiset (not Finset) form of roots ∏(X − aᵢ) to keep repeated eigenvalues",
+      "card_eigenvalues_diagonalizable: a diagonalizable matrix has exactly Fintype.card n eigenvalues counted with multiplicity over ANY field, with no algebraic closure assumption because its characteristic polynomial already splits",
+      "trace_pow_diagonal_example / sum_pow_eigenvalues_example: for diag(2,3) both sides read tr(A³) = 2³ + 3³ = 35, the trace power sum and the eigenvalue cube sum agreeing concretely"
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 177,
+    "assumptions": "None beyond a diagonalizable hypothesis on the matrix. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count); #print axioms confirms the headline theorems depend on no Lean.ofReduceBool or sorryAx, and no decide/native_decide is used. The headline trace_pow_eq_sum_pow_eigenvalues, roots_charpoly_diagonal, and card_eigenvalues_diagonalizable hold over ANY field — no algebraic closure is required, because the characteristic polynomial of a diagonalizable matrix splits by construction. trace_diagonal_pow and the conjugation lemmas hold over any commutative ring. SCOPE: the theorem is stated for diagonalizable matrices A = M·diag(d)·M⁻¹ (the dense/generic case). The fully general statement for every matrix over an algebraically closed field additionally requires triangularization — similarity to an upper-triangular matrix with the eigenvalues on the diagonal — which the Mathlib snapshot used here does not expose at the matrix level (only the endomorphism generalized-eigenspace decomposition). That extension is recorded as the standing open follow-up.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The trace power sums tr(Aᵏ) = Σλᵢᵏ are the trace half of the spectral mapping theorem spec(p(A)) = p(spec(A)): the eigenvalues of a polynomial in A are the polynomial evaluated at the eigenvalues of A, and for p(X) = Xᵏ this gives the k-th power sum of the spectrum. The parent spectral-trace-det-eigenvalues-oq-01 fixed the two extreme symmetric functions (trace = Σλ, determinant = Πλ); its descendants oq-01-oq-01 and oq-01-oq-01-oq-02 proved p₂ and p₃ in dimensions 2 and 3 by matching a dimension-specific matrix Newton identity (closed by ring on the entries) against the corresponding multiset identity via Vieta. That route is intrinsically bounded — the ring identity must be rewritten for each new (k, n). The diagonalizable case removes both limits at once: for a diagonalizable matrix the spectral mapping is elementary, since powers act entrywise on the diagonal and conjugation leaves the trace and the characteristic polynomial unchanged.",
+    "problemStatement": "**Open Question (spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02, openQuestions[1])**: Prove the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions n and all powers k, equivalently the multiset spectral mapping (Aᵏ).charpoly.roots = A.charpoly.roots.map(·^k).\n\n**Result (this entry)**: For diagonalizable matrices A = M·diag(d)·M⁻¹, trace_pow_eq_sum_pow_eigenvalues establishes tr(Aᵏ) = ((eigenvalues A).map(·^k)).sum uniformly in k and n over any field. The proof is the spectral-mapping mechanism itself — conjugation invariance plus the diagonal power sum — rather than a per-dimension symmetric-function computation. The remaining non-diagonalizable case is isolated to the missing triangularization infrastructure.",
+    "text": "Let A be an n×n matrix over a field K, and suppose A is diagonalizable: A = M·diag(d)·M⁻¹ for a unit M and a diagonal d : n → K. Because powers commute with conjugation, Aᵏ = M·diag(d)ᵏ·M⁻¹ = M·diag(dᵏ)·M⁻¹, and the trace is conjugation-invariant, so tr(Aᵏ) = tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ. The characteristic polynomial is likewise conjugation-invariant, charpoly(A) = charpoly(diag d) = ∏ᵢ(X − dᵢ), so the eigenvalue multiset A.charpoly.roots equals the diagonal {dᵢ} counted with multiplicity. Therefore tr(Aᵏ) = Σ over the eigenvalue multiset of λᵏ, for every k and every dimension, with no algebraic closure required since the characteristic polynomial already splits.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Diagonal power sum (any commutative ring): diag(d)ᵏ = diag(dᵏ) by diagonal_pow, and the trace of a diagonal matrix is the sum of its entries by trace_diagonal; with (dᵏ)ᵢ = (dᵢ)ᵏ this gives trace_diagonal_pow: tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ.\n\n2. Conjugation invariance of the power-trace (any commutative ring): units_conj_pow proves (M·N·M⁻¹)ᵏ = M·Nᵏ·M⁻¹ by induction on k, telescoping the interior M⁻¹·M = 1; trace_units_conj then gives trace_pow_units_conj: tr((M·N·M⁻¹)ᵏ) = tr(Nᵏ).\n\n3. Eigenvalues of a diagonal matrix (any field): charpoly_diagonal factors charpoly(diag d) = ∏ᵢ(X − dᵢ); rewriting this product as a multiset product and applying roots_multiset_prod_X_sub_C (the MULTISET form, to keep multiplicity) yields roots_charpoly_diagonal: (diag d).charpoly.roots = univ.val.map d.\n\n4. Assembly: for A = M·diag(d)·M⁻¹, the trace side is trace_pow_units_conj + trace_diagonal_pow = Σᵢ(dᵢ)ᵏ; the eigenvalue side is charpoly_units_conj + roots_charpoly_diagonal, giving eigenvalues A = univ.val.map d, so ((eigenvalues A).map(·^k)).sum = Σᵢ(dᵢ)ᵏ as well. The two agree definitionally as Finset sums (Multiset.map_map), proving trace_pow_eq_sum_pow_eigenvalues.\n\n5. Count and examples: card_eigenvalues_diagonalizable reads Multiset.card off univ.val.map d = Fintype.card n; diag(2,3) illustrates both sides equalling 35 at k=3.",
+    "keyInsights": [
+      "**Spectral mapping for diagonalizable matrices is just conjugation invariance plus entrywise powers.** Where the parent had to rewrite a different ring identity for each (k, n), diagonalizability makes the power Aᵏ = M·diag(dᵏ)·M⁻¹ transparent: the trace reads off the diagonal and is unchanged by conjugation, so a single proof covers every power and every dimension.",
+      "**No algebraic closure is needed.** The parent's spectral readings required an algebraically closed field so the characteristic polynomial splits. A diagonalizable matrix's characteristic polynomial already splits — it equals ∏(X − dᵢ) — so the eigenvalue multiset has full cardinality over ANY field, and card_eigenvalues_diagonalizable holds without the IsAlgClosed hypothesis the parent line carried.",
+      "**Multiplicity is preserved by using the multiset form of the roots.** Repeated diagonal entries must produce repeated eigenvalues. roots_charpoly_diagonal uses roots_multiset_prod_X_sub_C (over the multiset univ.val.map d) rather than the Finset form roots_prod_X_sub_C, so a diagonal like diag(2,2,3) correctly yields the eigenvalue multiset {2,2,3} and the power sum 2·2ᵏ + 3ᵏ.",
+      "**The hard residue is exactly triangularization.** The only gap between this diagonalizable result and the fully general theorem is the step 'every matrix over an algebraically closed field is similar to an upper-triangular matrix with its eigenvalues on the diagonal'. Mathlib has the endomorphism generalized-eigenspace decomposition but not this matrix-level Schur form, which pinpoints precisely what the all-cases theorem still needs."
+    ],
+    "prerequisites": [
+      "The characteristic polynomial and its roots as eigenvalues with algebraic multiplicity (spectral-trace-det-eigenvalues-oq-01)",
+      "The fixed-dimension trace power sums tr(A²) = Σλ² and tr(A³) = Σλ³ via Newton's identities and Vieta (spectral-trace-det-eigenvalues-oq-01-oq-01, oq-01-oq-01-oq-02)",
+      "Conjugation (similarity) invariance of the trace and characteristic polynomial; diagonalization A = M·diag(d)·M⁻¹"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Open Question",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Module docstring contrasting the parent line's per-dimension Vieta computations (only k=2,3 in dimensions 2,3) with the dimension-free spectral-mapping mechanism for diagonalizable matrices, stating the headline tr(Aᵏ) = Σλᵢᵏ uniformly in k and n, and the honesty note that the fully general case still needs triangularization; imports Mathlib and the grandparent file, opens Matrix/Polynomial, reuses the eigenvalues abbreviation.",
+      "mathContext": "$A = M\\,\\operatorname{diag}(d)\\,M^{-1}\\ \\Rightarrow\\ \\operatorname{tr}(A^k) = \\sum_i (d_i)^k$."
+    },
+    {
+      "id": "diagonal-conj",
+      "title": "Diagonal Power Sum and Conjugation Invariance",
+      "startLine": 65,
+      "endLine": 104,
+      "summary": "trace_diagonal_pow (tr(diag(d)ᵏ) = Σ(dᵢ)ᵏ over any commutative ring, from diagonal_pow and trace_diagonal), units_conj_pow ((M·N·M⁻¹)ᵏ = M·Nᵏ·M⁻¹ by induction telescoping M⁻¹·M = 1), and trace_pow_units_conj (the power-trace is conjugation-invariant).",
+      "mathContext": "$(M N M^{-1})^k = M N^k M^{-1}$,\\quad $\\operatorname{tr}((MNM^{-1})^k) = \\operatorname{tr}(N^k)$."
+    },
+    {
+      "id": "eigenvalues-diagonal",
+      "title": "Eigenvalues of a Diagonal Matrix, With Multiplicity",
+      "startLine": 105,
+      "endLine": 122,
+      "summary": "roots_charpoly_diagonal: (diag d).charpoly.roots = univ.val.map d, obtained from charpoly_diagonal (charpoly = ∏(X − dᵢ)) and the multiset form roots_multiset_prod_X_sub_C, which keeps repeated diagonal entries as repeated eigenvalues.",
+      "mathContext": "$(\\operatorname{diag} d).\\chi.\\mathrm{roots} = \\{d_i\\}_{i}$ (with multiplicity)."
+    },
+    {
+      "id": "main",
+      "title": "The Spectral Trace Power Sum in All Dimensions and Powers",
+      "startLine": 123,
+      "endLine": 152,
+      "summary": "trace_pow_eq_sum_pow_eigenvalues (tr(Aᵏ) = ((eigenvalues A).map(·^k)).sum for A = M·diag(d)·M⁻¹, uniformly in k and n over any field) and card_eigenvalues_diagonalizable (such an A has exactly Fintype.card n eigenvalues with multiplicity, no algebraic closure needed).",
+      "mathContext": "$\\operatorname{tr}(A^k) = \\sum_{\\lambda \\in \\mathrm{eig}(A)} \\lambda^k$."
+    },
+    {
+      "id": "example",
+      "title": "Concrete Illustrations",
+      "startLine": 153,
+      "endLine": 177,
+      "summary": "trace_pow_diagonal_example and sum_pow_eigenvalues_example: for diag(2,3) the trace cube and the eigenvalue cube sum both equal 2³ + 3³ = 35; #print axioms audit confirms only the foundational axioms.",
+      "mathContext": "$\\operatorname{tr}(\\operatorname{diag}(2,3)^3) = 2^3 + 3^3 = 35$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02",
+      "relationship": "Direct parent: proved tr(A³) = λ₁³ + λ₂³ + λ₃³ for 3×3 matrices via a dimension-specific Newton identity and Vieta, and posed (openQuestions[1]) the general trace power sum tr(Aᵏ) = Σλᵢᵏ for all dimensions and powers — which this entry settles for diagonalizable matrices by the dimension-free spectral-mapping argument."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-01",
+      "relationship": "Grandparent (imported): establishes the eigenvalues abbreviation A.charpoly.roots, trace = Σλ and determinant = Πλ, and the eigenvalue count; the k=1 case of this entry's headline recovers its trace = Σλ."
+    },
+    {
+      "id": "spectral-trace-det-eigenvalues-oq-02",
+      "relationship": "Sibling on cyclic/similarity invariance of the trace and the eigenvalue multiset — exactly the conjugation invariance (trace_pow_units_conj, charpoly_units_conj) that drives the diagonalizable spectral mapping here."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of the trace power sum tr(Aᵏ) = Σλᵢᵏ for diagonalizable matrices, uniformly in the power k and the dimension n, over any field. The proof is the spectral-mapping mechanism itself — conjugation invariance of the trace and characteristic polynomial (trace_pow_units_conj, charpoly_units_conj) plus the diagonal power sum (trace_diagonal_pow) and the diagonal eigenvalue multiset with multiplicity (roots_charpoly_diagonal) — replacing the parent line's fixed-(k,n) symmetric-function computations by a single argument.",
+    "implications": "Advances the spectral-trace line from one fixed (power, dimension) pair at a time to all powers and all dimensions at once for the dense/generic diagonalizable case, and removes the algebraic-closure hypothesis the parent line carried (a diagonalizable matrix's characteristic polynomial already splits). The supporting lemmas — diagonal power sum, conjugation invariance of the power-trace, and the diagonal eigenvalue multiset with multiplicity — are reusable building blocks for any subsequent spectral-mapping work. The result also isolates the exact residue of the fully general theorem: it differs from 'every matrix over an algebraically closed field' only by triangularization (Schur form), which Mathlib does not yet expose at the matrix level.",
+    "openQuestions": [
+      "Remove the diagonalizable hypothesis: prove tr(Aᵏ) = Σλᵢᵏ for EVERY matrix over an algebraically closed field by building matrix triangularization (similarity to an upper-triangular matrix with the eigenvalues on the diagonal), then extending trace_diagonal_pow to the upper-triangular power-trace (the diagonal of Tᵏ is dᵏ).",
+      "Prove the multiset spectral mapping for an arbitrary polynomial p, (p(A)).charpoly.roots = A.charpoly.roots.map(p.eval) for diagonalizable A, generalizing roots_charpoly_diagonal from p = Xᵏ to all p and giving tr(p(A)) = Σ p(λᵢ)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SpectralTraceDetEigenvaluesOQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/SpectralTraceDetEigenvaluesOQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Roger A. Horn and Charles R. Johnson",
+      "title": "Matrix Analysis",
+      "year": "2012",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for the spectral mapping theorem, similarity invariance of the trace and characteristic polynomial, and the trace power sums tr(Aᵏ) as power sums of the eigenvalues."
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.LinearAlgebra.Matrix.Trace, Mathlib.LinearAlgebra.Matrix.Charpoly.Basic, and Mathlib.Algebra.Polynomial.Roots",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Source of diagonal_pow, trace_diagonal, trace_units_conj, charpoly_units_conj, charpoly_diagonal, and roots_multiset_prod_X_sub_C used to assemble the diagonalizable spectral trace power sum."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Settles the parent's standing **open question** (`spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02`, openQuestions[1]): prove the trace power sum `tr(Aᵏ) = Σλᵢᵏ` **uniformly in the power k and the dimension n**, rather than one fixed `(k, n)` pair at a time via Vieta. For **diagonalizable** matrices `A = M·diag(d)·M⁻¹` this is settled completely by the dimension-free spectral-mapping mechanism.

The parent line proved only `k=2` (dim 2) and `k=3` (dim 3), each by rewriting a dimension-specific matrix Newton identity (closed by `ring`) and matching it to a multiset identity. That route is intrinsically bounded. Here a single argument covers **every power and every dimension**:

```
Aᵏ = M·diag(d)ᵏ·M⁻¹ = M·diag(dᵏ)·M⁻¹
  ⟹  tr(Aᵏ) = tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ          (conjugation-invariance of trace)
charpoly(A) = charpoly(diag d) = ∏ᵢ(X − dᵢ)   (conjugation-invariance of charpoly)
  ⟹  eigenvalue multiset = {dᵢ} with multiplicity
```

## Results (8 theorems, 177 lines, 0 sorries, 0 axioms, no native_decide)

- **`trace_pow_eq_sum_pow_eigenvalues`** — the headline: `tr(Aᵏ) = ((eigenvalues A).map (·^k)).sum` for `A = M·diag(d)·M⁻¹`, all `k`, all dimensions, over **any field** (no algebraic closure needed — a diagonalizable charpoly already splits). `k=1` recovers the grandparent's `trace = Σλ`.
- `trace_diagonal_pow` — `tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ` over any commutative ring.
- `units_conj_pow` / `trace_pow_units_conj` — conjugation by a unit commutes with powers, so the power-trace is similarity-invariant.
- `roots_charpoly_diagonal` — the eigenvalue multiset of a diagonal matrix is its diagonal **with multiplicity** (uses the multiset form of `roots ∏(X−aᵢ)`).
- `card_eigenvalues_diagonalizable` — exactly `Fintype.card n` eigenvalues over any field.

## Verification

`#print axioms` on the headline theorems lists only `propext, Classical.choice, Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. Compiled against the Mathlib 4.26.0 snapshot.

## Scope / honesty

Stated for **diagonalizable** matrices (the dense/generic case). The fully general theorem (every matrix over an algebraically closed field) additionally needs **matrix triangularization** (Schur form), which the Mathlib snapshot does not expose at the matrix level — recorded as the standing follow-up. This entry isolates that gap precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)