### PR TITLE
research(herons-formula-oq-06-oq-02): Gerretsen inequality s² ≤ 4R²+4Rr+3r² [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3130,6 +3130,8 @@ import Proofs.HeronsFormula
 import Proofs.HeronsFormulaOQ01
 import Proofs.HeronsFormulaOQ03
 import Proofs.HeronsFormulaOQ04
+import Proofs.HeronsFormulaOQ06
+import Proofs.HeronsFormulaOQ06OQ02
 import Proofs.HierholzerAlgorithm
 import Proofs.Hilbert10
 import Proofs.Hilbert10OQ01

--- a/proofs/Proofs/HeronsFormulaOQ06OQ02.lean
+++ b/proofs/Proofs/HeronsFormulaOQ06OQ02.lean
@@ -1,0 +1,183 @@
+/-
+  Gerretsen's Inequality  s² ≤ 4R² + 4Rr + 3r²
+
+  For any nondegenerate triangle with sides a, b, c, semi-perimeter
+  s = (a+b+c)/2, circumradius R and inradius r, Gerretsen's inequality states
+
+      s² ≤ 4R² + 4Rr + 3r².
+
+  This is a child of `herons-formula-oq-06` (Euler's triangle bound).  It uses
+  the *same* Ravi-substitution sum-of-squares engine that powers the parent's
+  Euler inequality `R ≥ 2r`: write x = s-a, y = s-b, z = s-c (all positive for a
+  nondegenerate triangle).  Then a = y+z, b = z+x, c = x+y, the area satisfies
+  Area² = s·xyz, and
+
+      R = abc/(4·Area),   r = Area/s.
+
+  Substituting and clearing denominators (only the *square* Area² = s·xyz ever
+  appears, because the cross term 4Rr = abc/s is already area-free) reduces the
+  whole inequality to the area-free polynomial statement
+
+      4·(x+y+z)³·xyz ≤ ((x+y)(y+z)(z+x))² + 4xyz·(x+y)(y+z)(z+x) + 12(xyz)² ,
+
+  i.e. `0 ≤ gerretsenPoly x y z`.  Concretely, the difference of the two sides
+  of Gerretsen's inequality is exactly `gerretsenPoly (s-a) (s-b) (s-c)/(4·Area²)`.
+
+  The algebraic heart `gerretsenPoly x y z ≥ 0` has the certificate
+
+      E = x⁴(y-z)² + y⁴(z-x)² + z⁴(x-y)²
+            + 2·[ x²(y-z)²(xy+xz-yz) + y²z²(x-y)(x-z) ].
+
+  The bracket is a Schur-type term (it is *negative* for some signed inputs, so
+  positivity of x, y, z is essential); it is settled by a WLOG ordering, under
+  which `xy+xz-yz = y² + (x-y)(y+z) ≥ 0` and `(x-y)(x-z) ≥ 0`.
+
+  Tight (equality) at x = y = z, i.e. the equilateral triangle, matching the
+  classical sharpness of Gerretsen's inequality.
+
+  Builds on the verified parent `Proofs.HeronsFormulaOQ06`
+  (`EulerInequalityHeronOQ06`), reusing its triangle data
+  (`semiperimeter`, `area`, `circumradius`, `inradius`, `area_sq`, …).
+
+  Axioms: 0
+  Sorries: 0
+-/
+import Proofs.HeronsFormulaOQ06
+import Mathlib.Tactic
+
+namespace GerretsenHeronOQ06OQ02
+
+open Real EulerInequalityHeronOQ06
+
+-- ════════════════════════════════════════════════════════════════
+-- PART I: The algebraic core — `gerretsenPoly x y z ≥ 0`
+-- ════════════════════════════════════════════════════════════════
+
+/-- The area-free polynomial whose nonnegativity *is* Gerretsen's inequality.
+    With `x = s-a, y = s-b, z = s-c`, Gerretsen's `4R²+4Rr+3r² - s²` equals
+    `gerretsenPoly x y z / (4·Area²)`. -/
+noncomputable def gerretsenPoly (x y z : ℝ) : ℝ :=
+  ((x + y) * (y + z) * (z + x)) ^ 2
+    + 4 * (x * y * z) * ((x + y) * (y + z) * (z + x))
+    + 12 * (x * y * z) ^ 2
+    - 4 * (x + y + z) ^ 3 * (x * y * z)
+
+/-- The core inequality under a fixed ordering `z ≤ y ≤ x`.  The certificate is
+    `gerretsenPoly = Σ x⁴(y-z)² + 2x²(y-z)²(xy+xz-yz) + 2y²z²(x-y)(x-z)`, and the
+    ordering makes every summand manifestly nonnegative (in particular
+    `xy+xz-yz = y² + (x-y)(y+z) ≥ 0`). -/
+theorem gerretsen_core_ordered {x y z : ℝ}
+    (hz : 0 ≤ z) (hzy : z ≤ y) (hyx : y ≤ x) :
+    0 ≤ ((x + y) * (y + z) * (z + x)) ^ 2
+        + 4 * (x * y * z) * ((x + y) * (y + z) * (z + x))
+        + 12 * (x * y * z) ^ 2
+        - 4 * (x + y + z) ^ 3 * (x * y * z) := by
+  have hy : 0 ≤ y := le_trans hz hzy
+  have hx : 0 ≤ x := le_trans hy hyx
+  -- `xy + xz - yz = y² + (x-y)(y+z) ≥ 0`.
+  have hABC : 0 ≤ x * y + x * z - y * z := by
+    nlinarith [mul_nonneg (sub_nonneg.2 hyx) (show (0:ℝ) ≤ y + z by linarith),
+               sq_nonneg y]
+  nlinarith [mul_nonneg (show (0:ℝ) ≤ x ^ 4 by positivity) (sq_nonneg (y - z)),
+             mul_nonneg (show (0:ℝ) ≤ y ^ 4 by positivity) (sq_nonneg (z - x)),
+             mul_nonneg (show (0:ℝ) ≤ z ^ 4 by positivity) (sq_nonneg (x - y)),
+             mul_nonneg (mul_nonneg (sq_nonneg x) (sq_nonneg (y - z))) hABC,
+             mul_nonneg (mul_nonneg (mul_nonneg (sq_nonneg y) (sq_nonneg z))
+                          (sub_nonneg.2 hyx)) (sub_nonneg.2 (le_trans hzy hyx))]
+
+/-- **Algebraic core of Gerretsen's inequality.** For all nonnegative reals,
+    `0 ≤ gerretsenPoly x y z`.  Reduces to the ordered case by the symmetry of
+    `gerretsenPoly`. -/
+theorem gerretsen_core {x y z : ℝ}
+    (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    0 ≤ gerretsenPoly x y z := by
+  unfold gerretsenPoly
+  obtain hxy | hyx := le_total x y
+  · obtain hyz | hzy := le_total y z
+    · -- x ≤ y ≤ z
+      nlinarith [gerretsen_core_ordered hx hxy hyz]
+    · obtain hxz | hzx := le_total x z
+      · -- x ≤ z ≤ y
+        nlinarith [gerretsen_core_ordered hx hxz hzy]
+      · -- z ≤ x ≤ y
+        nlinarith [gerretsen_core_ordered hz hzx hxy]
+  · obtain hyz | hzy := le_total y z
+    · obtain hxz | hzx := le_total x z
+      · -- y ≤ x ≤ z
+        nlinarith [gerretsen_core_ordered hy hyx hxz]
+      · -- y ≤ z ≤ x
+        nlinarith [gerretsen_core_ordered hy hyz hzx]
+    · -- z ≤ y ≤ x
+      nlinarith [gerretsen_core_ordered hz hzy hyx]
+
+-- ════════════════════════════════════════════════════════════════
+-- PART II: Area-free rewrites of `R²`, `R·r`, `r²`
+-- ════════════════════════════════════════════════════════════════
+
+/-- `R² = (abc)² / (16·Area²)`, with `Area² = heronProduct`. -/
+theorem circumradius_sq {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    circumradius a b c ^ 2 = (a * b * c) ^ 2 / (16 * heronProduct a b c) := by
+  have hA2 : area a b c ^ 2 = heronProduct a b c := area_sq ha hb hc hab hbc hca
+  unfold circumradius
+  rw [div_pow, show (4 * area a b c) ^ 2 = 16 * area a b c ^ 2 by ring, hA2]
+
+/-- `r² = Area² / s² = heronProduct / s²`. -/
+theorem inradius_sq {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    inradius a b c ^ 2 = heronProduct a b c / semiperimeter a b c ^ 2 := by
+  have hA2 : area a b c ^ 2 = heronProduct a b c := area_sq ha hb hc hab hbc hca
+  unfold inradius
+  rw [div_pow, hA2]
+
+/-- The cross term is area-free: `R·r = abc / (4s)`. -/
+theorem circumradius_mul_inradius {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    circumradius a b c * inradius a b c = a * b * c / (4 * semiperimeter a b c) := by
+  have hs : 0 < semiperimeter a b c := semiperimeter_pos ha hb hc
+  have hA : 0 < area a b c := area_pos ha hb hc hab hbc hca
+  unfold circumradius inradius
+  field_simp
+
+-- ════════════════════════════════════════════════════════════════
+-- PART III: Gerretsen's inequality
+-- ════════════════════════════════════════════════════════════════
+
+/-- **Gerretsen's inequality.** For any nondegenerate triangle,
+    `s² ≤ 4R² + 4Rr + 3r²`. -/
+theorem gerretsen {a b c : ℝ}
+    (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (hab : a < b + c) (hbc : b < a + c) (hca : c < a + b) :
+    semiperimeter a b c ^ 2 ≤
+      4 * circumradius a b c ^ 2
+        + 4 * (circumradius a b c * inradius a b c)
+        + 3 * inradius a b c ^ 2 := by
+  have hs : 0 < semiperimeter a b c := semiperimeter_pos ha hb hc
+  have hH : 0 < heronProduct a b c := heronProduct_pos ha hb hc hab hbc hca
+  have hsa : 0 ≤ semiperimeter a b c - a := by unfold semiperimeter; linarith
+  have hsb : 0 ≤ semiperimeter a b c - b := by unfold semiperimeter; linarith
+  have hsc : 0 ≤ semiperimeter a b c - c := by unfold semiperimeter; linarith
+  -- The difference of the two sides is `gerretsenPoly (s-a) (s-b) (s-c) / (4·Area²)`.
+  have hge : 0 ≤ gerretsenPoly (semiperimeter a b c - a) (semiperimeter a b c - b)
+      (semiperimeter a b c - c) / (4 * heronProduct a b c) :=
+    div_nonneg (gerretsen_core hsa hsb hsc) (by linarith)
+  have hEq :
+      4 * circumradius a b c ^ 2
+        + 4 * (circumradius a b c * inradius a b c)
+        + 3 * inradius a b c ^ 2
+        - semiperimeter a b c ^ 2
+      = gerretsenPoly (semiperimeter a b c - a) (semiperimeter a b c - b)
+          (semiperimeter a b c - c) / (4 * heronProduct a b c) := by
+    rw [circumradius_sq ha hb hc hab hbc hca,
+        circumradius_mul_inradius ha hb hc hab hbc hca,
+        inradius_sq ha hb hc hab hbc hca]
+    rw [gerretsenPoly]
+    field_simp
+    unfold heronProduct semiperimeter
+    ring
+  linarith [hEq, hge]
+
+end GerretsenHeronOQ06OQ02

--- a/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
+++ b/src/data/proofs/herons-formula-oq-06-oq-02/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "herons-formula-oq-06-oq-02",
+  "slug": "herons-formula-oq-06-oq-02",
+  "title": "Gerretsen's Inequality s² ≤ 4R² + 4Rr + 3r²",
+  "description": "For any nondegenerate triangle with semi-perimeter s, circumradius R and inradius r, Gerretsen's inequality s² ≤ 4R² + 4Rr + 3r² holds, with equality iff the triangle is equilateral. Using R = abc/(4·Area), r = Area/s and Heron's Area² = s(s-a)(s-b)(s-c), and the Ravi substitution x = s-a, y = s-b, z = s-c, the whole inequality reduces to the area-free polynomial 4(x+y+z)³xyz ≤ ((x+y)(y+z)(z+x))² + 4xyz(x+y)(y+z)(z+x) + 12(xyz)². The difference of the two sides is exactly gerretsenPoly(s-a,s-b,s-c)/(4·Area²).",
+  "conclusion": {
+    "summary": "A complete, axiom-free formalization of Gerretsen's inequality s² ≤ 4R² + 4Rr + 3r², answering the parent Euler-inequality entry's open question on whether the same Ravi-substitution SOS engine extends to the Gerretsen chain. The geometric inequality is reduced to a single area-free symmetric polynomial inequality 0 ≤ gerretsenPoly(s-a,s-b,s-c), with the exact algebraic identity (4R²+4Rr+3r²) - s² = gerretsenPoly(s-a,s-b,s-c)/(4·Area²) making the reduction transparent.",
+    "implications": "Gerretsen's inequality is the standard sharpening of Euler's R ≥ 2r and a key link in the Euler–Gerretsen–Blundon hierarchy bounding s, R, r for a triangle. The core certificate gerretsenPoly = Σ x⁴(y-z)² + 2x²(y-z)²(xy+xz-yz) + 2y²z²(x-y)(x-z) isolates the one genuinely Schur-type term (negative for some signed inputs, hence requiring positivity), settled by a short WLOG ordering. Unlike Euler's inequality, whose reduction is a pure AM-GM, Gerretsen needs this Schur step — the new mathematical content here.",
+    "openQuestions": [
+      "Can Blundon's inequality s ≤ 2R + (3√3 - 4)r (the sharp upper bound on s) be formalized with the same Ravi-substitution machinery, or does its irrational constant require a genuinely different certificate?",
+      "Is there a uniform SOS-with-positivity (Positivstellensatz) certificate for gerretsenPoly that avoids the WLOG case split, e.g. a single Schur-multiplier representation?"
+    ]
+  },
+  "overview": "{\"historicalContext\":\"Gerretsen's inequalities s² ≤ 4R² + 4Rr + 3r² and s² ≥ 16Rr - 5r² (J. C. H. Gerretsen, 1953) refine Euler's inequality R ≥ 2r and form, together with Blundon's inequalities, the classical fundamental constraints among the semi-perimeter s, circumradius R and inradius r of a triangle. The upper bound proved here is sharp, with equality for the equilateral triangle.\",\"problemStatement\":\"For a triangle with side lengths a, b, c (strict triangle inequalities), let s = (a+b+c)/2, Area = √(s(s-a)(s-b)(s-c)) (Heron), R = abc/(4·Area) and r = Area/s. Prove s² ≤ 4R² + 4Rr + 3r².\",\"proofStrategy\":\"As with the parent Euler bound, avoid constructing O and I; argue algebraically from the radius formulas. The cross term is already area-free: 4Rr = abc/s. The square terms 4R² = (abc)²/(4·Area²) and 3r² = 3·Area²/s² each carry only Area² (never a bare Area), so substituting Heron's Area² = s(s-a)(s-b)(s-c) clears every square root. With the Ravi variables x = s-a, y = s-b, z = s-c (all positive), the difference (4R²+4Rr+3r²) - s² equals gerretsenPoly(x,y,z)/(4·Area²), where gerretsenPoly x y z = ((x+y)(y+z)(z+x))² + 4xyz(x+y)(y+z)(z+x) + 12(xyz)² - 4(x+y+z)³xyz. Nonnegativity of gerretsenPoly is the whole content.\",\"keyInsights\":[\"Only Area² (not Area) appears throughout — the cross term 4Rr = abc/s is area-free — so a single Heron substitution removes every square root and reduces the geometric inequality to an area-free polynomial inequality.\",\"gerretsenPoly admits the certificate Σ x⁴(y-z)² + 2[x²(y-z)²(xy+xz-yz) + y²z²(x-y)(x-z)]. The bracket is Schur-type: it is negative for some signed inputs, so unlike the parent's pure AM-GM core, positivity of x,y,z is mathematically essential.\",\"Under a WLOG ordering z ≤ y ≤ x the Schur term becomes manifestly nonnegative because xy+xz-yz = y² + (x-y)(y+z) ≥ 0 and (x-y)(x-z) ≥ 0; symmetry of gerretsenPoly closes the six orderings.\"],\"prerequisites\":[\"Heron's formula Area² = s(s-a)(s-b)(s-c)\",\"Ravi substitution x = s-a, y = s-b, z = s-c\",\"Schur-type / sum-of-squares positivity with a WLOG ordering\"],\"text\":\"This entry formalizes Gerretsen's inequality s² ≤ 4R² + 4Rr + 3r² as an algebraic consequence of Heron's formula, reusing the verified triangle data (semiperimeter, area, circumradius, inradius, Area² = Heron product) from the parent Euler-inequality entry. After substituting the radius formulas and Heron's identity, the inequality becomes the area-free statement 0 ≤ gerretsenPoly(s-a,s-b,s-c), with the exact identity (4R²+4Rr+3r²) - s² = gerretsenPoly(s-a,s-b,s-c)/(4·Area²). The polynomial core is proved from an explicit certificate whose only non-AM-GM ingredient is a Schur-type term handled by a WLOG ordering. The result is machine-checked with 0 axioms and 0 sorries, and directly answers the open question raised by the parent entry.\"}",
+  "mainTheorems": [
+    {
+      "name": "gerretsen_core",
+      "type": "supporting",
+      "description": "Area-free algebraic core: 0 ≤ gerretsenPoly x y z for all x,y,z ≥ 0, reduced to the ordered case by symmetry.",
+      "leanType": "0 ≤ gerretsenPoly x y z"
+    },
+    {
+      "name": "gerretsen_core_ordered",
+      "type": "supporting",
+      "description": "The core inequality under a fixed ordering z ≤ y ≤ x, where the Schur-type term xy+xz-yz = y² + (x-y)(y+z) is manifestly nonnegative.",
+      "leanType": "0 ≤ ((x+y)*(y+z)*(z+x))^2 + 4*(x*y*z)*((x+y)*(y+z)*(z+x)) + 12*(x*y*z)^2 - 4*(x+y+z)^3*(x*y*z)"
+    },
+    {
+      "name": "circumradius_mul_inradius",
+      "type": "supporting",
+      "description": "The cross term is area-free: R·r = abc/(4s).",
+      "leanType": "circumradius a b c * inradius a b c = a * b * c / (4 * semiperimeter a b c)"
+    },
+    {
+      "name": "gerretsen",
+      "type": "main",
+      "description": "Gerretsen's inequality: for any nondegenerate triangle, s² ≤ 4R² + 4Rr + 3r².",
+      "leanType": "semiperimeter a b c ^ 2 ≤ 4 * circumradius a b c ^ 2 + 4 * (circumradius a b c * inradius a b c) + 3 * inradius a b c ^ 2"
+    }
+  ],
+  "sections": [
+    {
+      "id": "algebraic-core",
+      "title": "The Algebraic Core — gerretsenPoly x y z ≥ 0",
+      "startLine": 55,
+      "endLine": 114,
+      "summary": "Defines gerretsenPoly and proves its nonnegativity for nonnegative reals. The ordered lemma uses the certificate Σ x⁴(y-z)² + 2x²(y-z)²(xy+xz-yz) + 2y²z²(x-y)(x-z) (nlinarith on manifestly nonnegative summands); the general case follows by the symmetry of gerretsenPoly over the six orderings.",
+      "mathContext": "The mathematical heart of Gerretsen's inequality, independent of geometry. The Schur-type term requires positivity (it is negative for some signed inputs), so a WLOG ordering — not a pure SOS — is needed, the key difference from the parent Euler core."
+    },
+    {
+      "id": "area-free-rewrites",
+      "title": "Area-free Rewrites of R², R·r, r²",
+      "startLine": 116,
+      "endLine": 148,
+      "summary": "Rewrites circumradius² = (abc)²/(16·Area²), inradius² = Area²/s², and the area-free cross term R·r = abc/(4s), then eliminates Area² via Heron's Area² = heronProduct.",
+      "mathContext": "Isolates the single use of Heron's identity. Because only Area² ever appears, no square root survives these rewrites."
+    },
+    {
+      "id": "gerretsen-inequality",
+      "title": "Gerretsen's Inequality s² ≤ 4R² + 4Rr + 3r²",
+      "startLine": 150,
+      "endLine": 183,
+      "summary": "Combines the area-free rewrites into the exact identity (4R²+4Rr+3r²) - s² = gerretsenPoly(s-a,s-b,s-c)/(4·heronProduct), then concludes by nonnegativity of the numerator (gerretsen_core) and positivity of the denominator.",
+      "mathContext": "The main result. The clean closed-form identity for the slack makes the reduction to the polynomial core transparent and gives the equality case (equilateral) directly."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "herons-formula-oq-06",
+      "relationship": "extends",
+      "description": "Answers the parent Euler-inequality entry's open question on extending the Ravi-substitution SOS technique to Gerretsen; reuses its triangle data (semiperimeter, area, circumradius, inradius, area_sq)."
+    },
+    {
+      "targetId": "herons-formula",
+      "relationship": "related",
+      "description": "Uses Heron's formula Area² = s(s-a)(s-b)(s-c) to eliminate the area from the radius formulas."
+    }
+  ],
+  "references": [
+    {
+      "title": "Gerretsen's inequality / fundamental triangle inequalities",
+      "url": "https://en.wikipedia.org/wiki/List_of_triangle_inequalities"
+    },
+    {
+      "title": "Euler's theorem in geometry (Wikipedia)",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_theorem_in_geometry"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.HeronsFormulaOQ06",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "EulerInequalityHeronOQ06"
+    ],
+    "namespace": "GerretsenHeronOQ06OQ02",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HeronsFormulaOQ06OQ02.lean",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "meta": {
+    "author": "Classical result (Gerretsen, 1953), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/List_of_triangle_inequalities",
+    "date": "1953",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HeronsFormulaOQ06OQ02.lean",
+    "tags": [
+      "geometry",
+      "gerretsen-inequality",
+      "euler-inequality",
+      "triangle",
+      "circumradius",
+      "inradius",
+      "ravi-substitution",
+      "schur-inequality",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext, Classical.choice, Quot.sound).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "sqrt(x)^2 = x for x ≥ 0; used (via the parent's area_sq) to obtain Area² = Heron product.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "originalContributions": [
+      "Gerretsen's inequality s² ≤ 4R² + 4Rr + 3r² formalized directly from the radius formulas and Heron's identity — no circumcenter/incenter construction needed.",
+      "The exact closed-form slack identity (4R²+4Rr+3r²) - s² = gerretsenPoly(s-a,s-b,s-c)/(4·Area²), reducing the geometric inequality to a single area-free polynomial inequality.",
+      "Explicit certificate gerretsenPoly = Σ x⁴(y-z)² + 2[x²(y-z)²(xy+xz-yz) + y²z²(x-y)(x-z)], identifying the one genuinely Schur-type term that distinguishes Gerretsen from the parent's pure AM-GM Euler bound.",
+      "Reuse of the parent Euler-inequality infrastructure (semiperimeter, area, circumradius, inradius, area_sq) so the new file contributes only the Gerretsen-specific content."
+    ],
+    "prerequisites": [
+      "Heron's formula",
+      "Ravi substitution",
+      "Schur-type / sum-of-squares positivity"
+    ],
+    "difficulty": "intermediate",
+    "category": "geometry",
+    "parentSlug": "herons-formula-oq-06",
+    "dateAdded": "2026-06-25",
+    "lineCount": 183,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "mathlib_version": "v4.26"
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes **Gerretsen's inequality** \`s² ≤ 4R² + 4Rr + 3r²\` for any nondegenerate triangle (semi-perimeter \`s\`, circumradius \`R\`, inradius \`r\`), the classical sharpening of Euler's \`R ≥ 2r\`. This **directly answers the open question** raised by the parent entry \`herons-formula-oq-06\` (Euler's inequality): *"Does the same Ravi-substitution SOS technique give a clean Lean proof of the Gerretsen inequalities s² ≤ 4R² + 4Rr + 3r²?"*

## Approach

- **Area-free reduction.** Only \`Area²\` ever appears — the cross term \`4Rr = abc/s\` is already area-free, and \`4R² = (abc)²/(4·Area²)\`, \`3r² = 3·Area²/s²\` carry only \`Area²\`. A single Heron substitution \`Area² = s(s-a)(s-b)(s-c)\` removes every square root.
- **Exact slack identity.** \`(4R²+4Rr+3r²) - s² = gerretsenPoly(s-a, s-b, s-c) / (4·Area²)\`, reducing the geometric inequality to one area-free symmetric polynomial inequality \`0 ≤ gerretsenPoly\`.
- **Certificate.** \`gerretsenPoly = Σ x⁴(y-z)² + 2[ x²(y-z)²(xy+xz-yz) + y²z²(x-y)(x-z) ]\`. The bracket is **Schur-type** (negative for some signed inputs), so — unlike the parent's pure AM-GM Euler core — positivity of \`x,y,z\` is essential; a short WLOG ordering, under which \`xy+xz-yz = y² + (x-y)(y+z) ≥ 0\`, closes it.

Sharp: equality at the equilateral triangle.

## Verification

- \`#print axioms gerretsen\` → \`[propext, Classical.choice, Quot.sound]\` only (no \`sorryAx\`, no \`Lean.ofReduceBool\`).
- 0 sorries, 0 \`axiom\` declarations, 0 structure-encoded assumptions. **verified / original.**
- Builds on host against the verified parent \`Proofs.HeronsFormulaOQ06\` (reuses \`semiperimeter\`, \`area\`, \`circumradius\`, \`inradius\`, \`area_sq\`).
- Also adds the previously-missing parent import (\`Proofs.HeronsFormulaOQ06\`) to the \`Proofs\` aggregator (latent gap).

## Files
- \`proofs/Proofs/HeronsFormulaOQ06OQ02.lean\` (183 lines, 6 theorems, 1 def)
- \`proofs/Proofs.lean\` (aggregator: add OQ06 + OQ06OQ02)
- \`src/data/proofs/herons-formula-oq-06-oq-02/meta.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)