### PR TITLE
research(hilbert-9-reciprocity-oq-04): constant reciprocity in function fields [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3186,6 +3186,7 @@ import Proofs.Hilbert4Geodesics
 import Proofs.Hilbert5LieGroups
 import Proofs.Hilbert5OQ02
 import Proofs.Hilbert6PhysicsAxioms
+import Proofs.Hilbert9ConstantReciprocity
 import Proofs.Hilbert9Reciprocity
 import Proofs.HodgeConjecture
 import Proofs.HurwitzOnlyIf

--- a/proofs/Proofs/Hilbert9ConstantReciprocity.lean
+++ b/proofs/Proofs/Hilbert9ConstantReciprocity.lean
@@ -1,0 +1,186 @@
+/-
+  Constant reciprocity in function fields F_q[T] over finite fields.
+
+  This file answers a concrete, fully verified slice of the open question
+  "What reciprocity-type phenomena exist in function fields?" raised by the
+  gallery entry on Hilbert's Ninth Problem (the most general reciprocity law).
+
+  Background.  In the polynomial ring F_q[T] (q an odd prime power) the role of
+  the rational primes is played by the monic irreducible polynomials P, and the
+  quadratic residue symbol (a / P) is defined through the residue field
+  F_q[T]/(P) ≅ F_{q^{deg P}}.  For a *constant* a ∈ F_q^× the symbol (a / P)
+  therefore measures whether a, viewed inside F_{q^{deg P}}, is a square.  The
+  classical "constant reciprocity" law states that this depends only on the
+  parity of deg P:
+
+      (a / P) = χ_q(a) ^ {deg P},
+
+  where χ_q is the quadratic character of F_q.  Equivalently, a constant that is
+  a nonsquare in F_q becomes a square in F_{q^d} exactly when d is even.
+
+  We formalize this as a relation between the quadratic characters of a finite
+  field `F` and a finite extension `K`:
+
+      quadraticChar K (algebraMap F K a) = (quadraticChar F a) ^ [K : F].
+
+  Everything is derived from Mathlib's Euler criterion
+  (`quadraticChar_eq_pow_of_char_ne_two'`); there are no axioms and no `sorry`.
+
+  Main results:
+  * `quadraticChar_algebraMap_eq_pow` — the constant reciprocity law above.
+  * `isSquare_algebraMap_iff` — a constant `a` is a square in `K` iff it is a
+    square in `F` or `[K : F]` is even.
+  * `isSquare_algebraMap_of_even_finrank` — every constant becomes a square in an
+    even-degree extension (e.g. all of F_q is square in F_{q^2}).
+-/
+import Mathlib
+
+open Finset
+
+namespace Hilbert9ConstantReciprocity
+
+variable {F K : Type*} [Field F] [Fintype F] [DecidableEq F]
+  [Field K] [Fintype K] [DecidableEq K] [Algebra F K]
+
+omit [Fintype K] [DecidableEq K] in
+/-- Two integers drawn from `{1, -1}` that agree after casting into a field of
+characteristic `≠ 2` are equal.  This is the injectivity we need to pass from an
+equality of character *values in `K`* back to an equality of integers. -/
+private theorem cast_pm_inj (hcharK : ringChar K ≠ 2) {x y : ℤ}
+    (hx : x = 1 ∨ x = -1) (hy : y = 1 ∨ y = -1) (h : (x : K) = (y : K)) : x = y := by
+  have hne : (-1 : K) ≠ 1 := Ring.neg_one_ne_one_of_char_ne_two hcharK
+  rcases hx with rfl | rfl <;> rcases hy with rfl | rfl
+  · rfl
+  · push_cast at h; exact absurd h.symm hne
+  · push_cast at h; exact absurd h hne
+  · rfl
+
+omit [Fintype F] [DecidableEq F] [DecidableEq K] in
+/-- The characteristic is unchanged when passing to an extension field. -/
+private theorem ringChar_extension_ne_two (hF : ringChar F ≠ 2) : ringChar K ≠ 2 := by
+  have hinj : Function.Injective (algebraMap F K) := FaithfulSMul.algebraMap_injective F K
+  have hcK : CharP K (ringChar F) := charP_of_injective_algebraMap hinj (ringChar F)
+  rwa [CharP.eq K (ringChar.charP K) hcK]
+
+/--
+**Constant reciprocity law.**  For a constant `a ∈ F` and a finite extension `K`
+of a finite field `F` of odd characteristic, the quadratic character of `a`
+computed in `K` is the `[K : F]`-th power of its quadratic character in `F`:
+
+    quadraticChar K (algebraMap F K a) = (quadraticChar F a) ^ (finrank F K).
+
+This is the function-field analogue of the statement that the residue symbol of a
+*constant* depends only on the degree of the place modulo 2.
+-/
+theorem quadraticChar_algebraMap_eq_pow (hF : ringChar F ≠ 2) (a : F) :
+    quadraticChar K (algebraMap F K a)
+      = (quadraticChar F a) ^ (Module.finrank F K) := by
+  have hcharK : ringChar K ≠ 2 := ringChar_extension_ne_two hF
+  set d : ℕ := Module.finrank F K with hd
+  have hdpos : 0 < d := Module.finrank_pos
+  -- The `a = 0` case is degenerate: both sides vanish.
+  by_cases ha : a = 0
+  · subst ha
+    rw [map_zero, MulChar.map_zero, MulChar.map_zero, zero_pow hdpos.ne']
+  -- From now on `a ≠ 0`.
+  set q : ℕ := Fintype.card F with hq
+  set A : K := algebraMap F K a with hA
+  have haA : A ≠ 0 := by
+    rw [hA]; exact (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F K)).mpr ha
+  -- Abbreviations for the half-cardinalities appearing in Euler's criterion.
+  have hcard : Fintype.card K = q ^ d := Module.card_eq_pow_finrank
+  have hq2 : 2 ≤ q := Fintype.one_lt_card
+  have hqodd : q % 2 = 1 := FiniteField.odd_card_of_char_ne_two hF
+  have hQodd : (q ^ d) % 2 = 1 := Nat.odd_iff.mp ((Nat.odd_iff.mpr hqodd).pow)
+  -- `S = 1 + q + … + q^{d-1}`, the geometric sum.
+  set S : ℕ := ∑ i ∈ range d, q ^ i with hS
+  -- (1) `2 * (q / 2) = q - 1` because `q` is odd.
+  have hM : 2 * (q / 2) = q - 1 := by
+    have := Nat.div_add_mod q 2; omega
+  -- (2) `(q - 1) * S = q^d - 1` (geometric series).
+  have hdvd : (q - 1) ∣ (q ^ d - 1) := by
+    simpa using Nat.sub_dvd_pow_sub_pow q 1 d
+  have hgeom : (q - 1) * S = q ^ d - 1 := by
+    rw [hS, Nat.geomSum_eq hq2 d, Nat.mul_div_cancel' hdvd]
+  -- (3) The half-cardinality of `K` factors as `(q / 2) * S`.
+  have hN : Fintype.card K / 2 = (q / 2) * S := by
+    have e1 : 2 * (Fintype.card K / 2) = q ^ d - 1 := by
+      have := Nat.div_add_mod (Fintype.card K) 2
+      rw [hcard] at this ⊢; omega
+    have key : 2 * (Fintype.card K / 2) = 2 * ((q / 2) * S) := by
+      rw [e1, ← mul_assoc, hM, hgeom]
+    exact Nat.eq_of_mul_eq_mul_left (by norm_num) key
+  -- Euler's criterion in `F`, transported into `K` along the algebra map.
+  have eulerF : ((quadraticChar F a : ℤ) : F) = a ^ (q / 2) :=
+    quadraticChar_eq_pow_of_char_ne_two' hF a
+  have hAM : ((quadraticChar F a : ℤ) : K) = A ^ (q / 2) := by
+    have := congrArg (algebraMap F K) eulerF
+    rwa [map_intCast, map_pow, ← hA] at this
+  -- `A ^ (q - 1) = 1`, hence `(A ^ (q/2))^2 = 1`.
+  have hAq1 : A ^ (q - 1) = 1 := by
+    rw [hA, ← map_pow, FiniteField.pow_card_sub_one_eq_one a ha, map_one]
+  have hu2 : (A ^ (q / 2)) ^ 2 = 1 := by
+    rw [← pow_mul, mul_comm, hM, hAq1]
+  -- For `u` with `u^2 = 1`, `u^n` depends only on `n` mod 2.
+  have hgen : ∀ n : ℕ, (A ^ (q / 2)) ^ n = (A ^ (q / 2)) ^ (n % 2) := by
+    intro n
+    conv_lhs => rw [← Nat.div_add_mod n 2, pow_add, pow_mul, hu2, one_pow, one_mul]
+  -- `S ≡ d (mod 2)` since each `q^i` is odd.
+  have hSd : S % 2 = d % 2 := by
+    have hterm : ∀ i ∈ range d, q ^ i % 2 = 1 := fun i _ =>
+      Nat.odd_iff.mp ((Nat.odd_iff.mpr hqodd).pow)
+    calc S % 2 = (∑ i ∈ range d, q ^ i % 2) % 2 := by rw [hS, Finset.sum_nat_mod]
+      _ = (∑ _i ∈ range d, 1) % 2 := by rw [Finset.sum_congr rfl hterm]
+      _ = d % 2 := by rw [Finset.sum_const, card_range, smul_eq_mul, mul_one]
+  have hpow_eq : (A ^ (q / 2)) ^ S = (A ^ (q / 2)) ^ d := by
+    rw [hgen S, hgen d, hSd]
+  -- Assemble the equality of character values inside `K`.
+  have hcast : (quadraticChar K A : K) = (((quadraticChar F a) ^ d : ℤ) : K) := by
+    rw [quadraticChar_eq_pow_of_char_ne_two' hcharK A, hN, pow_mul, hpow_eq]
+    push_cast
+    rw [hAM]
+  -- Pass back to an equality of integers using `cast_pm_inj`.
+  refine cast_pm_inj hcharK (quadraticChar_dichotomy haA) ?_ hcast
+  rcases quadraticChar_dichotomy ha with h | h <;> rw [h]
+  · left; exact one_pow d
+  · rcases Nat.even_or_odd d with he | ho
+    · left; exact he.neg_one_pow
+    · right; exact ho.neg_one_pow
+
+/--
+**Constant square criterion.**  A nonzero constant `a ∈ F` becomes a square in a
+finite extension `K` (of a finite field of odd characteristic) if and only if it
+is already a square in `F` or the degree `[K : F]` is even.
+
+In F_q[T] terms: a constant `a` is a quadratic residue modulo a monic irreducible
+`P` iff `a` is a square in F_q or `deg P` is even.
+-/
+theorem isSquare_algebraMap_iff (hF : ringChar F ≠ 2) {a : F} (ha : a ≠ 0) :
+    IsSquare (algebraMap F K a) ↔ (IsSquare a ∨ Even (Module.finrank F K)) := by
+  have haA : algebraMap F K a ≠ 0 :=
+    (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F K)).mpr ha
+  rw [← quadraticChar_one_iff_isSquare haA, quadraticChar_algebraMap_eq_pow hF a]
+  rcases quadraticChar_dichotomy ha with h | h
+  · rw [h, one_pow]
+    simp [(quadraticChar_one_iff_isSquare ha).mp h]
+  · rw [h]
+    have hns : ¬ IsSquare a := quadraticChar_neg_one_iff_not_isSquare.mp h
+    constructor
+    · intro hpow
+      refine Or.inr ?_
+      by_contra hodd
+      rw [(Nat.not_even_iff_odd.mp hodd).neg_one_pow] at hpow
+      exact (by norm_num : (-1 : ℤ) ≠ 1) hpow
+    · rintro (hsq | hev)
+      · exact absurd hsq hns
+      · rw [hev.neg_one_pow]
+
+/-- Every constant is a square in an even-degree extension; in particular all of
+F_q is a square in the quadratic extension F_{q^2}. -/
+theorem isSquare_algebraMap_of_even_finrank (hF : ringChar F ≠ 2)
+    (hev : Even (Module.finrank F K)) (a : F) : IsSquare (algebraMap F K a) := by
+  by_cases ha : a = 0
+  · rw [ha, map_zero]; exact IsSquare.zero
+  · exact (isSquare_algebraMap_iff hF ha).mpr (Or.inr hev)
+
+end Hilbert9ConstantReciprocity

--- a/src/data/proofs/hilbert-9-reciprocity-oq-04/meta.json
+++ b/src/data/proofs/hilbert-9-reciprocity-oq-04/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "hilbert-9-reciprocity-oq-04",
+  "slug": "hilbert-9-reciprocity-oq-04",
+  "title": "Constant Reciprocity in Function Fields: (a/P) = χ_q(a)^{deg P}",
+  "description": "Answers the open question 'What reciprocity-type phenomena exist in function fields?' from the gallery entry on Hilbert's Ninth Problem, with a concrete, fully verified slice. In the polynomial ring F_q[T] (q an odd prime power) the role of the rational primes is played by the monic irreducible polynomials P, and the quadratic residue symbol (a/P) of a CONSTANT a ∈ F_q^× is computed in the residue field F_q[T]/(P) ≅ F_{q^{deg P}}. The classical constant reciprocity law says this depends only on the parity of deg P: (a/P) = χ_q(a)^{deg P}, where χ_q is the quadratic character of F_q. Equivalently, a constant that is a nonsquare in F_q becomes a square in F_{q^d} exactly when d is even. We formalize this as a relation between the quadratic characters of a finite field F and any finite extension K: quadraticChar K (algebraMap F K a) = (quadraticChar F a)^{[K:F]}. The proof is pure Euler-criterion bookkeeping — the half-cardinality of K factors through the geometric sum 1+q+…+q^{d-1}, whose parity is that of d because q is odd — so the sign χ_q(a)^d is recovered. Fully machine-checked, 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound).",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Finset"],
+    "namespace": "Hilbert9ConstantReciprocity",
+    "lineCount": 186,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "trivialSpecializations": 0,
+    "definitionCount": 0,
+    "path": "Proofs/Hilbert9ConstantReciprocity.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "researcher-1",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Quadratic_reciprocity#Other_rings",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert9ConstantReciprocity.lean",
+    "tags": [
+      "number-theory",
+      "function-fields",
+      "reciprocity",
+      "quadratic-character",
+      "finite-fields",
+      "euler-criterion",
+      "hilbert-problems"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Proved from Mathlib's Euler criterion (quadraticChar_eq_pow_of_char_ne_two'), the cardinality formula for finite extensions (Module.card_eq_pow_finrank), the geometric-sum identity (Nat.geomSum_eq), and Fermat's little theorem in a finite field (FiniteField.pow_card_sub_one_eq_one), with no added axioms. #print axioms reports only propext / Classical.choice / Quot.sound for all three public theorems.",
+    "dateAdded": "2026-06-25",
+    "mathlibDependencies": [
+      "quadraticChar_eq_pow_of_char_ne_two'",
+      "quadraticChar_one_iff_isSquare",
+      "quadraticChar_dichotomy",
+      "Module.card_eq_pow_finrank",
+      "FiniteField.pow_card_sub_one_eq_one",
+      "FiniteField.odd_card_of_char_ne_two",
+      "Nat.geomSum_eq",
+      "charP_of_injective_algebraMap"
+    ],
+    "originalContributions": [
+      "quadraticChar_algebraMap_eq_pow: the constant reciprocity law quadraticChar K (algebraMap F K a) = (quadraticChar F a)^{finrank F K} for any finite extension K of a finite field F of odd characteristic — the function-field analogue of (a/P) = χ_q(a)^{deg P}",
+      "isSquare_algebraMap_iff: a nonzero constant a is a square in K iff it is a square in F or [K:F] is even — the F_q[T] statement that a constant is a quadratic residue mod a monic irreducible P iff a is a square in F_q or deg P is even",
+      "isSquare_algebraMap_of_even_finrank: every constant becomes a square in any even-degree extension (in particular all of F_q is a square in the quadratic extension F_{q^2})",
+      "Self-contained transfer of odd characteristic from a base field to an extension (ringChar_extension_ne_two) and the {±1}-cast injectivity lemma (cast_pm_inj) used to descend an equality of character values in K to an equality of integers"
+    ],
+    "prerequisites": [
+      "Euler's criterion for the quadratic character: for nonzero a, (quadraticChar F a : F) = a^(card F / 2)",
+      "Finite-field arithmetic: card K = (card F)^{[K:F]} and a^(card F − 1) = 1 for a ≠ 0",
+      "The geometric series 1 + q + … + q^{d−1} and its parity for odd q"
+    ],
+    "mathlib_version": "4.26.0",
+    "lineCount": 186,
+    "relatedProblems": ["hilbert-9-reciprocity", "quadratic-reciprocity", "sophie-germain-oq-01-oq-03"],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Hilbert's Ninth Problem asked for the most general reciprocity law in algebraic number fields; the answer, Artin reciprocity, also governs the global function fields F_q(T). The parent gallery entry closes with four open questions, the last being 'What reciprocity-type phenomena exist in function fields?'. The cleanest function-field reciprocity is Dedekind–Artin–Carlitz reciprocity for the quadratic residue symbol over F_q[T], the exact analogue of Gauss's law, with the monic irreducibles playing the role of the primes and a degree/leading-coefficient sign replacing the (p−1)/2·(q−1)/2 sign. Before the full reciprocity law one isolates the behavior of a CONSTANT a ∈ F_q^× — the simplest, and the only piece that is purely local at the residue field. This constant law, (a/P) = χ_q(a)^{deg P}, is the content formalized here.",
+    "problemStatement": "Let F = F_q be a finite field of odd characteristic and K a finite extension (so K ≅ F_{q^d} with d = [K:F]). For a constant a ∈ F, relate the quadratic residue behavior of a inside K to its behavior in F. Concretely, express quadraticChar K (algebraMap F K a) in terms of quadraticChar F a and the degree d, and deduce exactly when a nonsquare constant becomes a square in K.",
+    "proofStrategy": "Both characters are computed by Euler's criterion: (quadraticChar F a : F) = a^{q/2} and (quadraticChar K A : K) = A^{(q^d)/2}, where A = algebraMap F K a and q = card F. Transport the F-identity into K along the algebra map to get (quadraticChar F a : K) = A^{q/2}. The exponents are reconciled by a Nat identity: card K / 2 = (q/2)·S with S = 1 + q + … + q^{d−1}, proved from card K = q^d, the geometric-series factorization (q−1)·S = q^d − 1, and 2·(q/2) = q − 1 (q odd). Hence A^{card K/2} = (A^{q/2})^S. Since (A^{q/2})^2 = A^{q−1} = 1 and S ≡ d (mod 2) — each q^i is odd, so S ≡ d — we get (A^{q/2})^S = (A^{q/2})^d. Casting back, the value equals (quadraticChar F a)^d in K; as both sides lie in {±1} and char K ≠ 2, the integers agree.",
+    "keyInsights": [
+      "The only obstruction to a constant a being a square in F_{q^d} is parity: F_q^× ↪ F_{q^d}^× embeds the cyclic group of order q−1 into the cyclic group of order q^d−1, and a nonsquare a (with a^{(q−1)/2} = −1) satisfies a^{(q^d−1)/2} = (−1)^S = (−1)^d.",
+      "The geometric sum S = 1 + q + … + q^{d−1} is the bridge between the two Euler exponents, and because q is odd S ≡ d (mod 2) — so the entire reciprocity sign is just the parity of the extension degree.",
+      "Characteristic is preserved by the algebra map, which lets Euler's criterion be applied in K with the same odd-characteristic hypothesis assumed on F.",
+      "Descending from an equality of character values in K to an equality of integers needs only that 1 and −1 stay distinct in K (char ≠ 2); both characters are forced into {±1} by the dichotomy for nonzero arguments.",
+      "This is exactly the constant part of full F_q[T] reciprocity; the remaining content (reciprocity between two nonconstant irreducibles) carries the Carlitz sign and is genuinely deeper."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "quadraticChar_algebraMap_eq_pow",
+      "statement": "ringChar F ≠ 2 → quadraticChar K (algebraMap F K a) = (quadraticChar F a) ^ (Module.finrank F K)",
+      "description": "Constant reciprocity law: the quadratic character of a constant a computed in a finite extension K is the [K:F]-th power of its character in F. Function-field analogue of (a/P) = χ_q(a)^{deg P}."
+    },
+    {
+      "name": "isSquare_algebraMap_iff",
+      "statement": "ringChar F ≠ 2 → a ≠ 0 → (IsSquare (algebraMap F K a) ↔ (IsSquare a ∨ Even (Module.finrank F K)))",
+      "description": "A nonzero constant a is a square in K iff it is already a square in F or the degree [K:F] is even — i.e. a is a quadratic residue mod a monic irreducible P iff a is a square in F_q or deg P is even."
+    },
+    {
+      "name": "isSquare_algebraMap_of_even_finrank",
+      "statement": "ringChar F ≠ 2 → Even (Module.finrank F K) → IsSquare (algebraMap F K a)",
+      "description": "Every constant becomes a square in any even-degree extension; in particular all of F_q is a square in the quadratic extension F_{q^2}."
+    }
+  ],
+  "sections": [
+    {
+      "id": "characteristic-and-casts",
+      "title": "Characteristic Transfer and {±1}-Cast Injectivity",
+      "startLine": 47,
+      "endLine": 67,
+      "summary": "Two helper lemmas. cast_pm_inj: integers in {1,−1} that agree after casting into a field of characteristic ≠ 2 are equal. ringChar_extension_ne_two: the algebra map preserves characteristic, so odd characteristic of F passes to K (via charP_of_injective_algebraMap).",
+      "mathContext": "$\\mathrm{ringChar}\\,K = \\mathrm{ringChar}\\,F \\neq 2.$"
+    },
+    {
+      "id": "constant-reciprocity",
+      "title": "The Constant Reciprocity Law",
+      "startLine": 68,
+      "endLine": 156,
+      "summary": "quadraticChar_algebraMap_eq_pow. After the degenerate a = 0 case, Euler's criterion in F and K plus the Nat identity card K / 2 = (q/2)·S (from card K = q^d, (q−1)·S = q^d−1, and q odd) give A^{card K/2} = (A^{q/2})^S; then (A^{q/2})^2 = A^{q−1} = 1 and S ≡ d (mod 2) collapse the exponent to d, and the {±1}-cast injectivity descends the value equality to the integer identity.",
+      "mathContext": "$\\chi_K(a) = \\chi_F(a)^{[K:F]},\\quad [K:F] = d.$"
+    },
+    {
+      "id": "square-criterion",
+      "title": "Square Criterion and the Even-Degree Corollary",
+      "startLine": 157,
+      "endLine": 186,
+      "summary": "isSquare_algebraMap_iff reads the reciprocity law through quadraticChar_one_iff_isSquare: a nonsquare a (χ_F(a) = −1) has χ_K(a) = (−1)^d = 1 iff d is even. isSquare_algebraMap_of_even_finrank specializes to even degree, covering all constants (including 0) and in particular the quadratic extension.",
+      "mathContext": "$\\text{nonsquare } a \\text{ becomes a square in } F_{q^d} \\iff 2 \\mid d.$"
+    }
+  ],
+  "references": [
+    {
+      "title": "Quadratic reciprocity over polynomial rings (Other rings)",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity#Other_rings"
+    },
+    {
+      "authors": "Rosen, Michael",
+      "title": "Number Theory in Function Fields",
+      "year": "2002",
+      "venue": "Graduate Texts in Mathematics 210, Springer",
+      "note": "Chapters 1 and 3 develop the quadratic residue symbol over F_q[T] and the reciprocity law of Dedekind–Artin–Carlitz; the constant law (a/P) = χ_q(a)^{deg P} is the degree-dependent piece."
+    },
+    {
+      "title": "Euler's criterion",
+      "url": "https://en.wikipedia.org/wiki/Euler%27s_criterion"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "hilbert-9-reciprocity",
+      "relationship": "Answers an open question of the parent",
+      "description": "The parent entry on Hilbert's Ninth Problem closes with the open question 'What reciprocity-type phenomena exist in function fields?'. This leaf supplies a concrete, fully verified instance: the constant reciprocity law for the quadratic residue symbol over F_q[T]."
+    },
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "Function-field analogue",
+      "description": "Where Gauss's law relates the residue symbols of two rational primes with the sign (−1)^{(p−1)/2·(q−1)/2}, the function-field theory relates symbols of monic irreducibles; the constant part isolated here replaces that sign with the parity of the degree of the place."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a finite field F of odd characteristic and any finite extension K, the quadratic character of a constant a satisfies quadraticChar K (algebraMap F K a) = (quadraticChar F a)^{[K:F]}. Consequently a nonsquare constant becomes a square in K exactly when [K:F] is even. This is the constant (degree-dependent) component of the Dedekind–Artin–Carlitz reciprocity law over F_q[T], and a concrete verified answer to the parent's open question on function-field reciprocity. Machine-checked with zero sorries and zero axioms.",
+    "implications": "The result pins the residue symbol (a/P) of a constant a to the single datum deg P mod 2, decoupling it from the arithmetic of P itself. It is the local piece on top of which the full F_q[T] reciprocity law (between two nonconstant monic irreducibles, carrying the Carlitz sign) is built, and it makes precise the slogan that 'constants behave by degree parity' in function-field arithmetic.",
+    "openQuestions": [
+      "Can the full quadratic reciprocity law for two monic irreducibles P, Q over F_q[T] — (P/Q) = (Q/P)·(−1)^{((q−1)/2)·(deg P)·(deg Q)} — be formalized, with this constant law as the leading-coefficient/degree input?",
+      "Is there an analogous degree-parity statement for higher power residue symbols (cubic, quartic) of constants in F_q[T] when F_q contains the relevant roots of unity?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **open question** `What reciprocity-type phenomena exist in function fields?` from the gallery entry on **Hilbert's Ninth Problem** (`hilbert-9-reciprocity`, openQuestions[3]) with a concrete, fully verified slice.

For a finite field `F` of odd characteristic and **any** finite extension `K` (so `K ≅ F_{q^d}`, `d = [K:F]`), the quadratic character of a **constant** `a ∈ F` computed in `K` is the `[K:F]`-th power of its character in `F`:

```
quadraticChar K (algebraMap F K a) = (quadraticChar F a) ^ (finrank F K)
```

This is the **constant (degree-dependent) part** of the Dedekind–Artin–Carlitz reciprocity law over `F_q[T]`: the residue symbol `(a/P)` of a constant `a` modulo a monic irreducible `P` depends only on `deg P` mod 2. Equivalently, a constant that is a nonsquare in `F_q` becomes a square in `F_{q^d}` exactly when `d` is even.

## Theorems (3 public, all verified)

| Theorem | Statement |
|---|---|
| `quadraticChar_algebraMap_eq_pow` | `χ_K(a) = χ_F(a)^{[K:F]}` — the constant reciprocity law |
| `isSquare_algebraMap_iff` | `IsSquare (algebraMap F K a) ↔ (IsSquare a ∨ Even [K:F])` |
| `isSquare_algebraMap_of_even_finrank` | every constant is a square in an even-degree extension (e.g. all of `F_q` is square in `F_{q^2}`) |

## Proof idea

Both characters are computed by **Euler's criterion**. Transporting the `F`-identity into `K` along the algebra map and reconciling the two exponents needs the Nat identity `card K / 2 = (q/2)·S` with `S = 1 + q + … + q^{d−1}` (from `card K = q^d`, `(q−1)·S = q^d − 1`, and `q` odd). Then `(A^{q/2})^2 = A^{q−1} = 1` and `S ≡ d (mod 2)` collapse the exponent to `d`, recovering the sign `χ_F(a)^d`. A `{±1}`-cast injectivity lemma descends the equality of character values in `K` to the integer identity.

## Verification

- **186 lines**, 3 public theorems, 0 definitions
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext / Classical.choice / Quot.sound` for all three public theorems
- Builds against Mathlib 4.26.0 (host `lake env lean`; docker daemon down this cycle)
- Key Mathlib deps: `quadraticChar_eq_pow_of_char_ne_two'`, `Module.card_eq_pow_finrank`, `Nat.geomSum_eq`, `FiniteField.pow_card_sub_one_eq_one`

Gallery entry added at `src/data/proofs/hilbert-9-reciprocity-oq-04/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)