### PR TITLE
research: inversion maps a circle through its centre to a line (ptolemys-theorem-oq-01-oq-01-oq-03-oq-01)

### DIFF
--- a/proofs/Proofs/PtolemysTheoremOQ01OQ01OQ03OQ01.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ01OQ01OQ03OQ01.lean
@@ -1,0 +1,161 @@
+import Mathlib
+
+/-!
+# Inversion carries a circle through its centre to a line
+
+## What this proves
+
+Fix a point `a` in a real inner-product (Euclidean) space and invert about `a` with radius `1`.
+The classical statement *"inversion centred at `a` maps every circle (sphere) through `a` to a
+line (hyperplane) not through `a`, and conversely"* is made precise and **axiom-free** here.
+
+The single computational heart is
+
+  `inversion_inner_eq_half_iff`:
+    for `x ≠ a` and any `o`,
+      `dist x o = dist a o  ↔  ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2`.
+
+The left-hand side says `x` lies on the sphere **through `a`** centred at `o`
+(`dist a o` is the radius). The right-hand side says the inversion image `x' = inversion a 1 x`
+lies on the fixed **affine hyperplane**
+
+  `H_o = { p | ⟪p -ᵥ a, o -ᵥ a⟫ = 1/2 }`,
+
+whose normal is `o -ᵥ a` and which does **not** contain `a` (there the inner product is `0`).
+In a plane `H_o` is exactly a line, so this is "circle-through-centre ↦ line".
+
+From this one equivalence we read off both halves of the bijection:
+
+* `cospherical_imp_inversion_image_inner_eq_half` — every cospherical set containing `a` has all
+  its other points sent into one common hyperplane `H_o` (circle → line);
+* `inner_eq_half_imp_inversion_image_cospherical` — conversely, the inversion images of any set of
+  points lying on a hyperplane `H = {⟪· -ᵥ a, n⟫ = 1/2}` (with `n ≠ 0`) are cospherical with `a`
+  (line → circle), the centre being `n +ᵥ a`.
+
+The four-point specialisation `cospherical_four_imp_inversion_images_collinear_witness` records the
+shape relevant to Ptolemy: if `a, b, c, d` are concyclic then the three images
+`b', c', d'` share a common hyperplane normal — the line their circle becomes.
+
+## Relation to the parent entry
+
+The parent `ptolemys-theorem-oq-01-oq-01-oq-03` (`PtolemysTheoremOQ01OQ01OQ03.lean`) proves the
+*ordered* facet, `ptolemy_eq_iff_wbtw_inversion`, characterising **equality** in Ptolemy's
+inequality by `Wbtw` of the three inversion images and, as a corollary, their `Collinear`-ity.
+That `Collinear` conclusion is the *image-side* "line". This file supplies the complementary
+*source-side* statement, tying that line back to genuine **concyclicity** (`Cospherical`) of the
+four original points — and it does so without the trigonometric ordering axiom
+(`positive_ratio_implies_cyclic_order`) that the unit-circle leaf `ptolemys-theorem-oq-01-oq-01`
+relied on. Both files are 0-axiom / 0-sorry.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open EuclideanGeometry
+
+namespace Ptolemy.InversionCircleLine
+
+variable {V P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
+  [NormedAddTorsor V P]
+
+/-! ## A scalar helper -/
+
+/-- For nonnegative reals, equality is equivalent to equality of squares. -/
+private theorem nonneg_sq_iff {p q : ℝ} (hp : 0 ≤ p) (hq : 0 ≤ q) :
+    p = q ↔ p ^ 2 = q ^ 2 := by
+  constructor
+  · intro h; rw [h]
+  · intro h; rw [← Real.sqrt_sq hp, ← Real.sqrt_sq hq, h]
+
+/-! ## The core equivalence: sphere-through-centre ⇔ image-on-hyperplane -/
+
+/-- **Inversion sends the sphere through the centre to a hyperplane.** For `x ≠ a` and any point
+`o`, the point `x` lies on the sphere through `a` centred at `o` (i.e. `dist x o = dist a o`, the
+radius being `dist a o`) **iff** its inversion image lies on the fixed affine hyperplane with
+normal `o -ᵥ a` at affine level `1/2`:
+
+`dist x o = dist a o ↔ ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2`.
+
+In a plane the hyperplane is a line — this is the analytic form of "a circle through the centre of
+inversion maps to a line." -/
+theorem inversion_inner_eq_half_iff (a o x : P) (hx : x ≠ a) :
+    dist x o = dist a o ↔ inner ℝ (inversion a 1 x -ᵥ a) (o -ᵥ a) = (1 / 2 : ℝ) := by
+  set y : V := x -ᵥ a with hyy
+  set m : V := o -ᵥ a with hmm
+  have hy0 : y ≠ 0 := vsub_ne_zero.mpr hx
+  have hnpos : 0 < ‖y‖ := norm_pos_iff.mpr hy0
+  have hnsq : 0 < ‖y‖ ^ 2 := pow_pos hnpos 2
+  -- the image inner product, expressed through `y` and `m`
+  have himg : inner ℝ (inversion a 1 x -ᵥ a) m
+      = (1 / ‖y‖) ^ 2 * inner ℝ y m := by
+    rw [inversion_vsub_center, real_inner_smul_left, dist_eq_norm_vsub V x a, ← hyy]
+  -- the distance condition, reduced to a single scalar equation
+  have hcentral : (dist x o = dist a o) ↔ ‖y‖ ^ 2 = 2 * inner ℝ y m := by
+    rw [nonneg_sq_iff dist_nonneg dist_nonneg,
+        dist_eq_norm_vsub V x o, dist_eq_norm_vsub V a o]
+    have e1 : x -ᵥ o = y - m := by rw [hyy, hmm]; exact (vsub_sub_vsub_cancel_right x o a).symm
+    have e2 : a -ᵥ o = -m := by rw [hmm]; exact (neg_vsub_eq_vsub_rev o a).symm
+    rw [e1, e2, norm_neg, norm_sub_sq_real]
+    constructor <;> intro h <;> linarith
+  rw [hcentral, himg, div_pow, one_pow, div_mul_eq_mul_div, one_mul,
+      div_eq_div_iff hnsq.ne' (two_ne_zero)]
+  constructor <;> intro h <;> linarith
+
+/-! ## Circle → line: a cospherical set maps into one hyperplane -/
+
+/-- **A circle through `a` maps to a line.** If `ps` is cospherical and contains `a`, then there is
+a single normal vector `n = o -ᵥ a` such that the inversion image of every other point of `ps`
+satisfies `⟪· -ᵥ a, n⟫ = 1/2`; i.e. all images lie on one affine hyperplane (a line in the plane). -/
+theorem cospherical_imp_inversion_image_inner_eq_half
+    {ps : Set P} (a : P) (ha : a ∈ ps) (hcs : Cospherical ps) :
+    ∃ n : V, ∀ p ∈ ps, p ≠ a → inner ℝ (inversion a 1 p -ᵥ a) n = (1 / 2 : ℝ) := by
+  obtain ⟨o, r, hor⟩ := hcs
+  refine ⟨o -ᵥ a, fun p hp hpa => ?_⟩
+  have hp_o : dist p o = dist a o := by rw [hor p hp, hor a ha]
+  exact (inversion_inner_eq_half_iff a o p hpa).mp hp_o
+
+/-! ## Line → circle: a hyperplane maps to a circle through `a` -/
+
+/-- **A line maps to a circle through `a`.** If every point of `qs` differs from `a` and lies on
+the hyperplane `{ p | ⟪p -ᵥ a, n⟫ = 1/2 }` (a genuine hyperplane when `n ≠ 0`), then the inversion
+images of `qs`, together with `a`, are cospherical — the circle through `a` with centre `n +ᵥ a`. -/
+theorem inner_eq_half_imp_inversion_image_cospherical
+    {qs : Set P} (a : P) (n : V)
+    (hq : ∀ q ∈ qs, q ≠ a ∧ inner ℝ (q -ᵥ a) n = (1 / 2 : ℝ)) :
+    Cospherical (insert a (inversion a 1 '' qs)) := by
+  refine ⟨n +ᵥ a, dist a (n +ᵥ a), ?_⟩
+  intro p hp
+  simp only [Set.mem_insert_iff, Set.mem_image] at hp
+  rcases hp with rfl | ⟨q, hqs, rfl⟩
+  · rfl
+  · obtain ⟨hqa, hqn⟩ := hq q hqs
+    have hxa : inversion a 1 q ≠ a := by
+      rw [Ne, inversion_eq_center (one_ne_zero)]; exact hqa
+    refine (inversion_inner_eq_half_iff a (n +ᵥ a) (inversion a 1 q) hxa).mpr ?_
+    rw [inversion_inversion a (one_ne_zero) q, vadd_vsub]
+    exact hqn
+
+/-! ## Four-point form (the Ptolemy shape) -/
+
+/-- **Concyclic ⇒ inversion images share a line.** If `a, b, c, d` are cospherical (e.g. concyclic),
+the three inversion images `b', c', d'` of `b, c, d` about `a` share one hyperplane normal `n`,
+each satisfying `⟪· -ᵥ a, n⟫ = 1/2`. This is the unordered "the circle through `a, b, c, d` becomes
+the line through `b', c', d'`" — the source-side companion to the parent's `Collinear` corollary. -/
+theorem cospherical_four_imp_inversion_images_collinear_witness
+    (a b c d : P) (hb : b ≠ a) (hc : c ≠ a) (hd : d ≠ a)
+    (hcs : Cospherical ({a, b, c, d} : Set P)) :
+    ∃ n : V, inner ℝ (inversion a 1 b -ᵥ a) n = (1 / 2 : ℝ)
+           ∧ inner ℝ (inversion a 1 c -ᵥ a) n = (1 / 2 : ℝ)
+           ∧ inner ℝ (inversion a 1 d -ᵥ a) n = (1 / 2 : ℝ) := by
+  obtain ⟨n, hn⟩ :=
+    cospherical_imp_inversion_image_inner_eq_half a (Set.mem_insert a _) hcs
+  exact ⟨n, hn b (by simp) hb, hn c (by simp) hc, hn d (by simp) hd⟩
+
+/-! ## Sanity check -/
+
+/-- Consistency: a point already on the hyperplane (here the image of a sphere point) lands at the
+prescribed level `1/2`, matching the core equivalence. -/
+example (a o x : P) (hx : x ≠ a) (h : dist x o = dist a o) :
+    inner ℝ (inversion a 1 x -ᵥ a) (o -ᵥ a) = (1 / 2 : ℝ) :=
+  (inversion_inner_eq_half_iff a o x hx).mp h
+
+end Ptolemy.InversionCircleLine

--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-01",
+  "slug": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-01",
+  "title": "Inversion Carries a Circle Through Its Centre to a Line (Cospherical ⇔ Images on a Hyperplane)",
+  "description": "Makes precise, and proves 0-axiom, the classical fact that inversion centred at a maps every circle (sphere) through a to a line (hyperplane) not through a, and conversely. The single computational heart is inversion_inner_eq_half_iff: for x ≠ a and any o, dist x o = dist a o ↔ ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2. The left side says x lies on the sphere THROUGH a centred at o (radius dist a o); the right side says the image x' = inversion a 1 x lies on the fixed affine hyperplane H_o = { p | ⟪p -ᵥ a, o -ᵥ a⟫ = 1/2 }, whose normal is o -ᵥ a and which never contains a (there the inner product is 0). In a plane H_o is exactly a line, so this is 'circle-through-centre ↦ line'. From the one equivalence both halves of the bijection follow: cospherical_imp_inversion_image_inner_eq_half (every cospherical set containing a sends its other points into one common hyperplane — circle → line) and inner_eq_half_imp_inversion_image_cospherical (conversely the inversion images of any hyperplane points are cospherical with a, centre n +ᵥ a — line → circle). The four-point form cospherical_four_imp_inversion_images_collinear_witness records the Ptolemy shape: if a, b, c, d are concyclic, the three images b', c', d' share one hyperplane normal — the line their circle becomes. This is exactly the inversion↔circle duality the parent entry flagged as an open question (and which Mathlib's Ptolemy TODO leaves open), now proved without any cyclic-order axiom: #print axioms reports only propext, Classical.choice, Quot.sound.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "EuclideanGeometry"
+    ],
+    "namespace": "Ptolemy.InversionCircleLine",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/PtolemysTheoremOQ01OQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Inversive geometry, developed by Steiner, Möbius and Apollonius-era ideas and systematised in the 19th century, rests on one structural fact: inversion in a sphere centred at a point a is a conformal involution of the one-point compactification that interchanges spheres-through-a with hyperplanes-not-through-a (and fixes spheres/hyperplanes setwise otherwise). This single fact is the engine of the classical proof of Ptolemy's inequality — inversion at a vertex turns the circumcircle into a straight line and Ptolemy becomes the triangle inequality among the images. Mathlib formalises inversion (EuclideanGeometry.inversion), its image-distance law dist_inversion_inversion, and Ptolemy's inequality, but its source explicitly lacks a 'cyclic polygon' concept and never states the circle↦line correspondence itself. This entry supplies that correspondence in coordinate-free, axiom-free form, closing the inversion↔circle duality that the parent equality-case entry (ptolemys-theorem-oq-01-oq-01-oq-03) listed as its first open question.",
+    "problemStatement": "Formalise, in an arbitrary real inner-product (Euclidean) space, that inversion centred at a with radius 1 carries the sphere through a centred at o to a fixed affine hyperplane (a line in the plane) and conversely; in particular characterise membership of the image in that hyperplane purely by the inner product ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2, and prove the full circle⇔line bijection 0-axiom / 0-sorry.",
+    "text": "Write y = x -ᵥ a and m = o -ᵥ a. By inversion_vsub_center, inversion a 1 x -ᵥ a = (1/‖y‖)² • y, so ⟪inversion a 1 x -ᵥ a, m⟫ = ⟪y, m⟫ / ‖y‖² (real_inner_smul_left). The point x lies on the sphere through a centred at o exactly when dist x o = dist a o, i.e. ‖y - m‖ = ‖m‖; expanding with norm_sub_sq_real gives ‖y‖² - 2⟪y, m⟫ + ‖m‖² = ‖m‖², i.e. ‖y‖² = 2⟪y, m⟫. Since ‖y‖² > 0 (because x ≠ a), this is equivalent to ⟪y, m⟫ / ‖y‖² = 1/2, which is the hyperplane condition. Both directions are the same algebra, so the equivalence is an honest iff. The circle→line corollary takes o, radius from the cospherical witness; the line→circle converse runs the equivalence backwards through the inversion involution inversion_inversion (inversion a 1 (inversion a 1 q) = q) and recovers the centre as n +ᵥ a from the hyperplane normal n.",
+    "proofStrategy": "CORE (inversion_inner_eq_half_iff): set y = x -ᵥ a, m = o -ᵥ a; record himg : ⟪inversion a 1 x -ᵥ a, m⟫ = (1/‖y‖)² ⟪y, m⟫ via inversion_vsub_center + real_inner_smul_left + dist_eq_norm_vsub; record hcentral : dist x o = dist a o ↔ ‖y‖² = 2⟪y, m⟫ by squaring through the helper nonneg_sq_iff, rewriting x -ᵥ o = y - m (vsub_sub_vsub_cancel_right) and a -ᵥ o = -m (neg_vsub_eq_vsub_rev), then norm_sub_sq_real and linarith; finish by rewriting both sides into ‖y‖² = 2⟪y, m⟫ and clearing the positive denominator ‖y‖² with div_eq_div_iff. CIRCLE→LINE (cospherical_imp_inversion_image_inner_eq_half): destruct Cospherical to centre o, radius r; the common normal is o -ᵥ a; each point's hyperplane membership is the forward direction of the core iff. LINE→CIRCLE (inner_eq_half_imp_inversion_image_cospherical): centre n +ᵥ a, radius dist a (n +ᵥ a); for an image inversion a 1 q use inversion_eq_center for q ≠ a, then the backward core iff after rewriting with inversion_inversion and vadd_vsub. FOUR-POINT (cospherical_four_imp_inversion_images_collinear_witness): apply the circle→line corollary to {a, b, c, d}.",
+    "keyInsights": [
+      "**The whole duality is one inner-product identity.** ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2 is necessary and sufficient for x to lie on the sphere through a centred at o. The constant 1/2 is forced by the radius-1 inversion and is independent of x — that x-independence is precisely why a whole sphere collapses onto a single fixed hyperplane.",
+      "**Through-the-centre is what makes the image flat.** Inversion sends a generic sphere to another sphere; it is only the spheres passing through the centre a that flatten to hyperplanes. Algebraically, the sphere-through-a condition ‖y - m‖ = ‖m‖ has the ‖m‖² terms cancel, leaving the AFFINE-LINEAR relation ‖y‖² = 2⟪y, m⟫ — linear after dividing by ‖y‖² — whereas a sphere missing a would leave a quadratic, i.e. another sphere.",
+      "**The converse is the same statement read through the involution.** Because inversion a 1 is an involution (inversion_inversion), a point on the hyperplane is the image of its own image, so line→circle needs no new computation: it is the backward direction of the core iff applied to inversion a 1 q, with the centre recovered as n +ᵥ a directly from the hyperplane normal n.",
+      "**Source-side companion to the parent's image-side line.** The parent equality-case entry derives Collinear ℝ {b', c', d'} from Ptolemy EQUALITY (the ordered, Wbtw facet). This entry ties that same line back to genuine concyclicity (Cospherical) of the four ORIGINAL points, the unordered facet — and, like the parent, avoids the trigonometric ordering axiom positive_ratio_implies_cyclic_order of the unit-circle leaf."
+    ],
+    "prerequisites": [
+      "Euclidean inversion EuclideanGeometry.inversion and inversion_vsub_center: inversion c R x -ᵥ c = (R / dist x c)² • (x -ᵥ c)",
+      "The inversion involution inversion_inversion (R ≠ 0) and inversion_eq_center: inversion c R x = c ↔ x = c",
+      "Inner-product algebra: real_inner_smul_left and the polarisation identity norm_sub_sq_real: ‖x - y‖² = ‖x‖² - 2⟪x, y⟫ + ‖y‖²",
+      "AddTorsor vsub arithmetic: dist_eq_norm_vsub, vsub_sub_vsub_cancel_right, neg_vsub_eq_vsub_rev, vadd_vsub",
+      "Mathlib's Cospherical (a set is equidistant from some centre) and its destructuring"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core-equivalence",
+      "title": "The Core Equivalence: Sphere-Through-Centre ⇔ Image-on-Hyperplane",
+      "startLine": 69,
+      "endLine": 101,
+      "summary": "inversion_inner_eq_half_iff: for x ≠ a and any o, dist x o = dist a o ↔ ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2. Proved by expressing the image inner product as ⟪y, m⟫/‖y‖² (inversion_vsub_center, real_inner_smul_left), reducing the distance condition to ‖y‖² = 2⟪y, m⟫ via the nonneg-square helper and norm_sub_sq_real, and clearing the positive denominator ‖y‖² with div_eq_div_iff.",
+      "mathContext": "The single inner-product identity from which the whole circle⇔line duality follows; the constant 1/2 is the radius-1 signature and is independent of x."
+    },
+    {
+      "id": "circle-to-line",
+      "title": "Circle → Line: A Cospherical Set Maps Into One Hyperplane",
+      "startLine": 103,
+      "endLine": 114,
+      "summary": "cospherical_imp_inversion_image_inner_eq_half: if ps is cospherical and contains a, there is one normal n = o -ᵥ a with ⟪inversion a 1 p -ᵥ a, n⟫ = 1/2 for every other p ∈ ps. The images of the whole circle land on a single affine hyperplane (a line in the plane).",
+      "mathContext": "The forward half of the inversion duality: the sphere through the centre flattens to a hyperplane."
+    },
+    {
+      "id": "line-to-circle",
+      "title": "Line → Circle: A Hyperplane Maps to a Circle Through a",
+      "startLine": 116,
+      "endLine": 135,
+      "summary": "inner_eq_half_imp_inversion_image_cospherical: if every point of qs differs from a and satisfies ⟪· -ᵥ a, n⟫ = 1/2, then the inversion images of qs together with a are cospherical with centre n +ᵥ a. Runs the core iff backwards through the inversion involution; the centre is read straight off the hyperplane normal.",
+      "mathContext": "The converse half: a hyperplane (line) maps to a circle through the centre of inversion."
+    },
+    {
+      "id": "four-point-form",
+      "title": "Four-Point Form (the Ptolemy Shape)",
+      "startLine": 137,
+      "endLine": 152,
+      "summary": "cospherical_four_imp_inversion_images_collinear_witness: if a, b, c, d are cospherical (e.g. concyclic), the three inversion images b', c', d' share one hyperplane normal n, each at level 1/2 — the unordered 'the circle through a, b, c, d becomes the line through b', c', d''. A closing example re-derives the forward image condition from the sphere condition.",
+      "mathContext": "The source-side companion to the parent's Collinear-of-images corollary, specialised to four points."
+    }
+  ],
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof that, in any real inner-product (Euclidean) space, inversion centred at a with radius 1 sets up a bijection between spheres through a and affine hyperplanes not through a. The pivot is inversion_inner_eq_half_iff: dist x o = dist a o ↔ ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2 for x ≠ a. From it follow the circle→line direction (cospherical sets containing a map into one hyperplane), the line→circle converse (hyperplane points map to a circle through a, via the inversion involution), and the four-point Ptolemy form. The file is 0-axiom, 0-sorry (#print axioms: propext, Classical.choice, Quot.sound only).",
+    "implications": "Closes the inversion↔circle duality flagged as the first open question of the parent equality-case entry and noted as missing in Mathlib's Ptolemy source: it states and proves, axiom-free and in full Euclidean generality, that inversion maps a circle through its centre to a line. This is the source-side (concyclicity) companion to the parent's image-side (Collinear-of-images) certificate, and together they give the unordered Cospherical ⇔ images-on-a-line correspondence underlying the classical inversive proof of Ptolemy's theorem, without the cyclic-order axiom of the unit-circle leaf.",
+    "openQuestions": [
+      "Upgrade the shared-hyperplane conclusion to genuine Collinear ℝ {b', c', d'} under coplanarity: combine the common normal here with Coplanar ℝ {a, b, c, d} (so the images lie in a 2-plane meeting the hyperplane in a line) to recover the parent's collinearity directly from concyclicity, with no ordering hypothesis.",
+      "Glue the unordered Cospherical ⇔ images-on-a-hyperplane statement to the parent's ordered Wbtw ⇔ Ptolemy-equality criterion, obtaining a single Cospherical-with-separation ⇔ Ptolemy-equality theorem and thereby discharging the unit-circle leaf's axiom positive_ratio_implies_cyclic_order.",
+      "Express the hyperplane H_o = { p | ⟪p -ᵥ a, o -ᵥ a⟫ = 1/2 } as a Mathlib AffineSubspace and state the full bijection as an explicit inverse pair between the sphere through a and that affine hyperplane (a map-level, not just membership-level, circle↔line duality)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "slug": "ptolemys-theorem-oq-01-oq-01-oq-03",
+      "relation": "Parent entry (Ptolemy's equality case via inversion/betweenness). Its first open question asks exactly for this inversion↔circle duality — Wbtw/Collinear of the inversion images ⇔ concyclicity of a, b, c, d. This entry answers the unordered (Cospherical ⇔ images-on-a-line) half, axiom-free, supplying the source-side companion to the parent's image-side Collinear certificate."
+    },
+    {
+      "slug": "ptolemys-theorem-oq-01-oq-01",
+      "relation": "Sibling unit-circle leaf — proves the Ptolemy-equality converse for four points on the unit circle behind the axiom positive_ratio_implies_cyclic_order. The circle↔line duality proved here is the axiom-free, fully general mechanism that the unit-circle argument uses only implicitly."
+    },
+    {
+      "slug": "ptolemys-theorem",
+      "relation": "Root entry — Ptolemy's theorem for cyclic quadrilaterals; inversion mapping the circumcircle through a vertex to a line is the geometric core of its classical proof, formalised here."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib: EuclideanGeometry.inversion, inversion_vsub_center, inversion_inversion, dist_inversion_inversion",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Euclidean/Inversion/Basic.html"
+    },
+    {
+      "title": "Mathlib: EuclideanGeometry.Cospherical and the Euclidean sphere API",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Euclidean/Sphere/Basic.html"
+    },
+    {
+      "title": "Mathlib: inner-product polarisation norm_sub_sq_real and real_inner_smul_left",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/InnerProductSpace/Basic.html"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PtolemysTheoremOQ01OQ01OQ03OQ01.lean",
+    "tags": [
+      "geometry",
+      "inversive-geometry",
+      "euclidean-geometry",
+      "ptolemy",
+      "inversion",
+      "concyclicity",
+      "cospherical",
+      "inner-product-space",
+      "hyperplane",
+      "circle-to-line-duality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 161,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None beyond the pointwise non-degeneracy needed for the inversion images to be defined (x ≠ a in the core equivalence; p ≠ a / q ≠ a for the set-level statements). The ambient space is an arbitrary real inner-product (Euclidean) space presented as a NormedAddTorsor over it. Verified 0 axioms, 0 sorries: #print axioms on inversion_inner_eq_half_iff, cospherical_imp_inversion_image_inner_eq_half, inner_eq_half_imp_inversion_image_cospherical and cospherical_four_imp_inversion_images_collinear_witness reports only [propext, Classical.choice, Quot.sound] (no sorryAx, no Lean.ofReduceBool).",
+    "originalContributions": [
+      "inversion_inner_eq_half_iff: the core circle⇔line identity — for x ≠ a and any o, dist x o = dist a o ↔ ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2. x lies on the sphere THROUGH a centred at o exactly when its inversion image lies on the fixed affine hyperplane with normal o -ᵥ a at level 1/2 (a line in the plane). Proved by reducing the sphere condition to the affine-linear relation ‖y‖² = 2⟪y, m⟫ and clearing the positive denominator ‖y‖².",
+      "cospherical_imp_inversion_image_inner_eq_half: circle → line — every cospherical set containing a sends its other points, under inversion at a, into one common hyperplane with normal o -ᵥ a (the centre witnessing cosphericity).",
+      "inner_eq_half_imp_inversion_image_cospherical: line → circle — the inversion images of any set of points on a hyperplane { ⟪· -ᵥ a, n⟫ = 1/2 }, together with a, are cospherical with centre n +ᵥ a; proved by running the core iff backwards through the inversion involution, so no new computation is needed.",
+      "cospherical_four_imp_inversion_images_collinear_witness: the four-point Ptolemy form — concyclic a, b, c, d force the three inversion images b', c', d' to share one hyperplane normal, the unordered 'the circle through a, b, c, d becomes the line through b', c', d''; the source-side companion to the parent's Collinear-of-images corollary.",
+      "The structural observation that 'through the centre' is exactly the flatness condition: the ‖o -ᵥ a‖² terms cancel for a sphere through a, turning a quadratic sphere equation into an affine-linear hyperplane equation, while the inversion involution makes the converse free."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "EuclideanGeometry.inversion_vsub_center",
+        "description": "inversion c R x -ᵥ c = (R / dist x c)² • (x -ᵥ c) — expresses the image displacement as a scalar multiple of x -ᵥ c, the starting point for the inner-product computation",
+        "module": "Mathlib.Geometry.Euclidean.Inversion.Basic"
+      },
+      {
+        "theorem": "EuclideanGeometry.inversion_inversion",
+        "description": "inversion c R (inversion c R x) = x for R ≠ 0 — the inversion involution; makes the line→circle converse a backward application of the core iff with no extra work",
+        "module": "Mathlib.Geometry.Euclidean.Inversion.Basic"
+      },
+      {
+        "theorem": "norm_sub_sq_real",
+        "description": "‖x - y‖² = ‖x‖² - 2⟪x, y⟫ + ‖y‖² — the real polarisation identity that turns the sphere-through-centre condition ‖y - m‖ = ‖m‖ into the affine-linear relation ‖y‖² = 2⟪y, m⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "real_inner_smul_left",
+        "description": "⟪r • x, y⟫ = r ⟪x, y⟫ — pulls the inversion scalar (1/‖y‖)² out of the inner product",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "EuclideanGeometry.Cospherical",
+        "description": "a set is cospherical iff its points are equidistant from a common centre — the hypothesis (circle → line) and conclusion (line → circle) of the duality",
+        "module": "Mathlib.Geometry.Euclidean.Sphere.Basic"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves, **0-axiom / 0-sorry**, the classical inversive-geometry fact that **inversion centred at `a` carries every circle (sphere) through `a` to a line (hyperplane) not through `a`, and conversely** — in an arbitrary real inner-product (Euclidean) space.

This directly answers the **first open question** of the parent entry `ptolemys-theorem-oq-01-oq-01-oq-03` (the missing inversion↔circle duality, also flagged in Mathlib's Ptolemy source TODO).

## Results (`Proofs/PtolemysTheoremOQ01OQ01OQ03OQ01.lean`, namespace `Ptolemy.InversionCircleLine`)

- **`inversion_inner_eq_half_iff`** (core): for `x ≠ a` and any `o`,
  `dist x o = dist a o ↔ ⟪inversion a 1 x -ᵥ a, o -ᵥ a⟫ = 1/2`.
  The LHS says `x` is on the sphere **through `a`** centred at `o`; the RHS says the image lies on the fixed affine hyperplane with normal `o -ᵥ a` at level `1/2` (a line in the plane).
- **`cospherical_imp_inversion_image_inner_eq_half`** — circle → line: a cospherical set containing `a` has all its other points' images on one common hyperplane.
- **`inner_eq_half_imp_inversion_image_cospherical`** — line → circle: the images of any hyperplane points, with `a`, are cospherical (centre `n +ᵥ a`), via the inversion involution.
- **`cospherical_four_imp_inversion_images_collinear_witness`** — four-point Ptolemy form: concyclic `a,b,c,d` ⇒ the images `b',c',d'` share one hyperplane normal.

## Proof idea

With `y = x -ᵥ a`, `m = o -ᵥ a`: the sphere-through-`a` condition `‖y - m‖ = ‖m‖` has the `‖m‖²` terms cancel (`norm_sub_sq_real`), leaving the affine-linear `‖y‖² = 2⟪y,m⟫`; dividing by `‖y‖² > 0` gives `⟪y,m⟫/‖y‖² = 1/2`, which is exactly the image inner product (`inversion_vsub_center`, `real_inner_smul_left`). Both directions are the same algebra, so it is an honest iff; the converse reuses it through `inversion_inversion`.

## Verification

`#print axioms` on all four theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Builds against Mathlib 4.26.0 (`lake env lean`, 0 errors/warnings). 5 theorems (4 public + 1 private helper), 161 lines, 0 defs, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)