### PR TITLE
research(feuerbachs-theorem-defs-oq-05): uniqueness of the nine-point circle [verified, 0-ax, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2897,6 +2897,7 @@ import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ02OQ01OQ01OQ01OQ01OQ01
 import Proofs.FeuerbachsTheoremDefsOQ03
 import Proofs.FeuerbachsTheoremDefsOQ04
+import Proofs.FeuerbachsTheoremDefsOQ05
 import Proofs.FeuerbachsTheoremOQ01
 import Proofs.FeuerbachsTheoremOQ01Aristotle
 import Proofs.FeuerbachsTheoremOQ01OQ03

--- a/proofs/Proofs/FeuerbachsTheoremDefsOQ05.lean
+++ b/proofs/Proofs/FeuerbachsTheoremDefsOQ05.lean
@@ -1,0 +1,184 @@
+/-
+  Feuerbach's Theorem DefsOQ05: Uniqueness of the Nine-Point Circle
+
+  ## The Open Question
+
+  The parent file `FeuerbachsTheoremDefs` proves that all nine special points of a
+  triangle (the three side midpoints, the three altitude feet, and the three Euler
+  midpoints of the vertex-to-orthocenter segments) lie on a single circle: the
+  nine-point circle, with centre `N = midpoint(O, H)` and radius `R/2`.
+
+  Establishing membership shows the nine-point circle is *a* circle through these
+  points.  It leaves open whether it is the *only* one.  OQ-05 closes that gap:
+
+      The nine-point circle is the UNIQUE circle through the nine special points.
+
+  Because a circle is determined by any three of its non-collinear points, it
+  suffices to look at the three side midpoints `M_a, M_b, M_c`.  In a
+  non-degenerate triangle these are themselves non-collinear, so any circle through
+  all three — a fortiori through all nine points — must coincide with the
+  nine-point circle.
+
+  ## What This File Proves
+
+  Working purely in the coordinate framework of `FeuerbachsTheoremDefs`:
+
+  ### The algebraic core
+  `equidistant_center_unique` :  given three non-collinear points `P₁ P₂ P₃`, a
+  point equidistant from all three is unique.  Equivalently, the three
+  perpendicular bisectors meet in at most one point.  This is the linear-algebra
+  heart of circle uniqueness: subtracting the squared-distance equations turns the
+  problem into a 2×2 linear system whose determinant is exactly the
+  non-collinearity determinant of `P₁ P₂ P₃`.
+
+  ### The geometric input
+  `midpoints_noncollinear` :  the three side midpoints of a non-degenerate triangle
+  are non-collinear.  Their orientation determinant is `1/4` of the triangle's own
+  non-degeneracy determinant, hence non-zero.
+
+  ### The uniqueness theorem
+  `ninePointCircle_unique` :  if a circle with centre `Q` and radius `ρ` passes
+  through the three side midpoints `M_a, M_b, M_c`, then `Q = N` (the nine-point
+  centre) and `ρ = R/2` (the nine-point radius).  In particular the nine-point
+  circle is the unique circle through the nine special points.
+
+  `ninePointCircle_unique_of_nine` :  the same conclusion phrased against a circle
+  asserted to pass through all nine special points (it only ever uses the three
+  midpoints, witnessing that three non-collinear points already pin the circle).
+
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Proofs.FeuerbachsTheoremDefs
+
+set_option linter.unusedVariables false
+
+noncomputable section
+
+namespace FeuerbachNinePointUniqueness
+
+open FeuerbachsTheorem
+
+/-- The squared distance equals the square of the (root) distance. -/
+lemma dist2_sq_eq_dist2_sq (Q P : Point) : dist2_sq Q P = (dist2 Q P) ^ 2 := by
+  unfold dist2_sq dist2
+  rw [Real.sq_sqrt (by positivity)]
+
+/-- If two points are at equal `dist2` from a centre `Q`, they are at equal
+    squared distance from `Q`. -/
+lemma dist2_sq_of_dist2_eq {Q P P' : Point} (h : dist2 Q P = dist2 Q P') :
+    dist2_sq Q P = dist2_sq Q P' := by
+  rw [dist2_sq_eq_dist2_sq, dist2_sq_eq_dist2_sq, h]
+
+/-- **Uniqueness of an equidistant centre.**
+    Given three non-collinear points `P₁ P₂ P₃` (orientation determinant nonzero),
+    any two points `Q`, `Q'` each equidistant (in squared distance) from all three
+    must be equal.  Geometrically: the perpendicular bisectors of a triangle meet in
+    at most one point, so a triangle's vertices lie on at most one circle. -/
+theorem equidistant_center_unique
+    (P₁ P₂ P₃ Q Q' : Point)
+    (hdet : (P₂.1 - P₁.1) * (P₃.2 - P₁.2) - (P₃.1 - P₁.1) * (P₂.2 - P₁.2) ≠ 0)
+    (hQ12 : dist2_sq Q P₁ = dist2_sq Q P₂)
+    (hQ13 : dist2_sq Q P₁ = dist2_sq Q P₃)
+    (hQ12' : dist2_sq Q' P₁ = dist2_sq Q' P₂)
+    (hQ13' : dist2_sq Q' P₁ = dist2_sq Q' P₃) :
+    Q = Q' := by
+  simp only [dist2_sq] at hQ12 hQ13 hQ12' hQ13'
+  -- Subtracting the squared-distance equations for `Q` and `Q'` kills the quadratic
+  -- terms, leaving two linear equations in the difference `(Q - Q')`.
+  have e1 : (P₂.1 - P₁.1) * (Q.1 - Q'.1) + (P₂.2 - P₁.2) * (Q.2 - Q'.2) = 0 := by
+    linear_combination (1 / 2) * hQ12 - (1 / 2) * hQ12'
+  have e2 : (P₃.1 - P₁.1) * (Q.1 - Q'.1) + (P₃.2 - P₁.2) * (Q.2 - Q'.2) = 0 := by
+    linear_combination (1 / 2) * hQ13 - (1 / 2) * hQ13'
+  -- Cramer's rule: multiply through by the determinant.
+  have hu : (Q.1 - Q'.1) *
+      ((P₂.1 - P₁.1) * (P₃.2 - P₁.2) - (P₃.1 - P₁.1) * (P₂.2 - P₁.2)) = 0 := by
+    linear_combination (P₃.2 - P₁.2) * e1 - (P₂.2 - P₁.2) * e2
+  have hv : (Q.2 - Q'.2) *
+      ((P₂.1 - P₁.1) * (P₃.2 - P₁.2) - (P₃.1 - P₁.1) * (P₂.2 - P₁.2)) = 0 := by
+    linear_combination (P₂.1 - P₁.1) * e2 - (P₃.1 - P₁.1) * e1
+  have hQ1 : Q.1 = Q'.1 := by
+    rcases mul_eq_zero.mp hu with h | h
+    · linarith
+    · exact absurd h hdet
+  have hQ2 : Q.2 = Q'.2 := by
+    rcases mul_eq_zero.mp hv with h | h
+    · linarith
+    · exact absurd h hdet
+  exact Prod.ext_iff.mpr ⟨hQ1, hQ2⟩
+
+/-- **The three side midpoints are non-collinear.**
+    Their orientation determinant is exactly one quarter of the triangle's own
+    non-degeneracy determinant, hence non-zero for a non-degenerate triangle. -/
+theorem midpoints_noncollinear (T : Triangle) :
+    (T.midpoint_b.1 - T.midpoint_a.1) * (T.midpoint_c.2 - T.midpoint_a.2)
+      - (T.midpoint_c.1 - T.midpoint_a.1) * (T.midpoint_b.2 - T.midpoint_a.2) ≠ 0 := by
+  simp only [Triangle.midpoint_a, Triangle.midpoint_b, Triangle.midpoint_c, pointMidpoint]
+  intro h
+  apply T.nondegenerate
+  linear_combination 4 * h
+
+/-- **Uniqueness of the nine-point circle.**
+    Any circle with centre `Q` and radius `ρ` passing through the three side
+    midpoints `M_a, M_b, M_c` of a non-degenerate triangle is the nine-point
+    circle: `Q` is the nine-point centre `N` and `ρ` is the nine-point radius
+    `R/2`.  Since the nine-point circle is known (parent file) to pass through all
+    nine special points, this pins it down as the unique such circle. -/
+theorem ninePointCircle_unique (T : Triangle) (Q : Point) (ρ : ℝ)
+    (hMa : dist2 Q T.midpoint_a = ρ)
+    (hMb : dist2 Q T.midpoint_b = ρ)
+    (hMc : dist2 Q T.midpoint_c = ρ) :
+    Q = T.ninePointCenter ∧ ρ = T.ninePointRadius := by
+  -- `Q` is equidistant from the three midpoints.
+  have hQ12 : dist2_sq Q T.midpoint_a = dist2_sq Q T.midpoint_b :=
+    dist2_sq_of_dist2_eq (by rw [hMa, hMb])
+  have hQ13 : dist2_sq Q T.midpoint_a = dist2_sq Q T.midpoint_c :=
+    dist2_sq_of_dist2_eq (by rw [hMa, hMc])
+  -- So is the nine-point centre `N` (parent membership theorems).
+  have hNa := midpoint_a_on_ninePointCircle T
+  have hNb := midpoint_b_on_ninePointCircle T
+  have hNc := midpoint_c_on_ninePointCircle T
+  have hN12 : dist2_sq T.ninePointCenter T.midpoint_a
+      = dist2_sq T.ninePointCenter T.midpoint_b :=
+    dist2_sq_of_dist2_eq (by rw [hNa, hNb])
+  have hN13 : dist2_sq T.ninePointCenter T.midpoint_a
+      = dist2_sq T.ninePointCenter T.midpoint_c :=
+    dist2_sq_of_dist2_eq (by rw [hNa, hNc])
+  -- Two equidistant centres through three non-collinear points coincide.
+  have hQN : Q = T.ninePointCenter :=
+    equidistant_center_unique T.midpoint_a T.midpoint_b T.midpoint_c Q T.ninePointCenter
+      (midpoints_noncollinear T) hQ12 hQ13 hN12 hN13
+  refine ⟨hQN, ?_⟩
+  -- The radius is then forced as the common distance to `M_a`.
+  rw [← hMa, hQN, hNa]
+
+/-- **Uniqueness phrased against all nine points.**
+    A circle (centre `Q`, radius `ρ`) through all nine special points is the
+    nine-point circle.  The proof only consumes the three side-midpoint
+    memberships, witnessing that three non-collinear points already determine the
+    circle. -/
+theorem ninePointCircle_unique_of_nine (T : Triangle) (Q : Point) (ρ : ℝ)
+    (hMa : dist2 Q T.midpoint_a = ρ) (hMb : dist2 Q T.midpoint_b = ρ)
+    (hMc : dist2 Q T.midpoint_c = ρ)
+    (hMaH : dist2 Q T.midpoint_AH = ρ) (hMbH : dist2 Q T.midpoint_BH = ρ)
+    (hMcH : dist2 Q T.midpoint_CH = ρ)
+    (hFa : dist2 Q T.foot_a = ρ) (hFb : dist2 Q T.foot_b = ρ)
+    (hFc : dist2 Q T.foot_c = ρ) :
+    Q = T.ninePointCenter ∧ ρ = T.ninePointRadius :=
+  ninePointCircle_unique T Q ρ hMa hMb hMc
+
+/-- Sanity check on the 3-4-5 triangle: the unique circle through its three side
+    midpoints is centred at `(3/4, 1)` with radius `5/4`. -/
+example :
+    ∀ (Q : Point) (ρ : ℝ),
+      dist2 Q triangle_345.midpoint_a = ρ →
+      dist2 Q triangle_345.midpoint_b = ρ →
+      dist2 Q triangle_345.midpoint_c = ρ →
+      Q = (3 / 4, 1) ∧ ρ = 5 / 4 := by
+  intro Q ρ h1 h2 h3
+  obtain ⟨hQ, hρ⟩ := ninePointCircle_unique triangle_345 Q ρ h1 h2 h3
+  rw [triangle_345_ninePointCenter] at hQ
+  rw [triangle_345_ninePointRadius] at hρ
+  exact ⟨hQ, hρ⟩
+
+end FeuerbachNinePointUniqueness

--- a/research/problems/feuerbachs-theorem-defs-oq-02/knowledge.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-02/knowledge.md
@@ -19,3 +19,30 @@ Insights accumulated during research on this problem.
 ## Dead Ends
 
 [Approaches known not to work will be documented here]
+
+---
+
+## Resolution (2026-06-25, researcher-1)
+
+**SOLVED** — shipped as gallery slug `feuerbachs-theorem-defs-oq-05`
+(`Proofs/FeuerbachsTheoremDefsOQ05.lean`), PR #29810. The candidate slug
+`feuerbachs-theorem-defs-oq-02` was already occupied in the gallery by Euler's
+triangle formula (OI² = R² − 2Rr), so the nine-point-uniqueness deliverable this
+candidate describes was minted under the next free top-level slug oq-05.
+
+### Proof architecture (verified, 0 axioms, 0 sorries)
+- `equidistant_center_unique`: two points equidistant (squared distance) from
+  three non-collinear points coincide. Subtracting the squared-distance equations
+  cancels quadratics → 2×2 linear system; its determinant is the orientation
+  determinant of the three points; Cramer via `linear_combination`.
+- `midpoints_noncollinear`: side-midpoint orientation determinant = (1/4) × the
+  triangle's non-degeneracy determinant (since M_b−M_a=(A−B)/2, M_c−M_a=(A−C)/2).
+- `ninePointCircle_unique`: any circle through the 3 side midpoints is the
+  nine-point circle (centre N, radius R/2). Only 3 of the 9 points are needed.
+
+### Key facts
+- Worked entirely in the parent's coordinate API (Point=ℝ×ℝ, dist2, dist2_sq).
+- `dist2_sq Q P = (dist2 Q P)^2` (Real.sq_sqrt) bridges parent's sqrt membership
+  to the polynomial linear system.
+- Mathlib's abstract circumcircle uniqueness was NOT used — a self-contained
+  coordinate proof was cleaner and matches the parent framework.

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-05/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-05/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "feuerbachs-theorem-defs-oq-05",
+  "title": "Feuerbach's Theorem: Uniqueness of the Nine-Point Circle",
+  "slug": "feuerbachs-theorem-defs-oq-05",
+  "description": "Proves the nine-point circle is the UNIQUE circle through the nine special points of a non-degenerate triangle. The parent file establishes that the nine points lie on the nine-point circle; this file closes the converse: any circle through the three side midpoints must be the nine-point circle (centre N, radius R/2). The algebraic core is uniqueness of an equidistant centre, reduced to a 2x2 linear system whose determinant is the triangle's non-degeneracy determinant. 6 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FeuerbachsTheoremDefsOQ05.lean",
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ],
+    "tags": [
+      "geometry",
+      "euclidean-geometry",
+      "feuerbach",
+      "nine-point-circle",
+      "uniqueness",
+      "triangle",
+      "perpendicular-bisector"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). Inherits the nine-point membership theorems from FeuerbachsTheoremDefs.lean, which is also 0-sorry, 0-axiom.",
+    "lineCount": 184,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "equidistant_center_unique: any two points equidistant (in squared distance) from three non-collinear points coincide — the linear-algebra heart of circle uniqueness, proved by reducing to a 2x2 linear system and applying Cramer's rule",
+      "midpoints_noncollinear: the three side midpoints of a non-degenerate triangle are non-collinear; their orientation determinant is exactly 1/4 of the triangle's own non-degeneracy determinant",
+      "ninePointCircle_unique: any circle through the three side midpoints has centre = ninePointCenter and radius = R/2",
+      "ninePointCircle_unique_of_nine: the same conclusion against a circle through all nine special points, witnessing that three of them already pin down the circle",
+      "dist2_sq_of_dist2_eq: equal root-distances to a centre give equal squared distances, bridging the parent's sqrt-based membership to the polynomial linear system"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Feuerbach's theorem (1822) concerns the nine-point circle of a triangle, which passes through nine special points: the three side midpoints, the three altitude feet, and the three midpoints of the vertex-to-orthocenter segments. The parent gallery proof FeuerbachsTheoremDefs.lean establishes that all nine points lie on a single circle of centre N = midpoint(O, H) and radius R/2. That makes the nine-point circle *a* circle through the points. The classical fact that a circle is determined by any three of its non-collinear points means it is the *only* one — but that uniqueness was not previously formalized in the gallery's coordinate framework.",
+    "problemStatement": "For a non-degenerate triangle, is the nine-point circle the unique circle through the nine special points? Equivalently: if a circle with centre Q and radius rho passes through the three side midpoints M_a, M_b, M_c, must Q equal the nine-point centre N and rho equal R/2? The reduction is: (1) the three side midpoints are non-collinear, and (2) three non-collinear points lie on at most one circle.",
+    "text": "A 184-line file working purely in the coordinate API of FeuerbachsTheoremDefs (Point = R x R, dist2 = sqrt distance, dist2_sq = squared distance). It proves uniqueness of an equidistant centre, the non-collinearity of the side midpoints, and assembles them into the uniqueness of the nine-point circle, with a 3-4-5 numerical sanity check.",
+    "proofStrategy": "Three steps:\n1. **Equidistant-centre uniqueness** (equidistant_center_unique): For non-collinear P1 P2 P3, subtracting the squared-distance equations dist2_sq Q P1 = dist2_sq Q P2 (etc.) for two candidate centres Q, Q' cancels the quadratic terms, leaving two linear equations in (Q - Q'). The 2x2 coefficient determinant is exactly the orientation determinant of P1 P2 P3; Cramer's rule (encoded via linear_combination) forces Q - Q' = 0.\n2. **Midpoint non-collinearity** (midpoints_noncollinear): The orientation determinant of M_a, M_b, M_c equals 1/4 of the triangle's non-degeneracy determinant (since M_b - M_a = (A-B)/2 and M_c - M_a = (A-C)/2), hence non-zero. Proved by linear_combination 4*h against T.nondegenerate.\n3. **Assembly** (ninePointCircle_unique): The nine-point centre N is equidistant from the three midpoints (parent membership theorems), and so is any circle's centre Q. Both are equidistant centres through three non-collinear points, so Q = N; the radius is then the common distance to M_a, which the parent computes as R/2.",
+    "keyInsights": [
+      "Uniqueness of a circle through three points is, after cancelling the common quadratic terms, a purely linear phenomenon: the perpendicular bisectors form a 2x2 linear system whose determinant is the orientation (twice-signed-area) determinant of the three points.",
+      "The non-degeneracy hypothesis already baked into the Triangle structure is exactly what is needed — the midpoints' orientation determinant is a constant (1/4) multiple of it, so no new geometric assumption is introduced.",
+      "Only the three side midpoints are used; the altitude feet and Euler midpoints are redundant for uniqueness. ninePointCircle_unique_of_nine makes this explicit by accepting all nine memberships but consuming only three.",
+      "The bridge dist2_sq_of_dist2_eq lets the proof move between the parent's sqrt-based membership statements (dist2 Q M = rho) and the polynomial form (dist2_sq) on which linear_combination and ring operate.",
+      "linear_combination with explicit Cramer coefficients ((P3.2 - P1.2)*e1 - (P2.2 - P1.2)*e2, etc.) discharges the linear-algebra step without invoking any matrix machinery, keeping the proof self-contained over the coordinate API."
+    ],
+    "prerequisites": [
+      "FeuerbachsTheoremDefs.lean — coordinate-based nine-point circle membership theorems (midpoint_a/b/c_on_ninePointCircle), Triangle structure with non-degeneracy, dist2 and dist2_sq",
+      "Real.sq_sqrt — squaring a square root of a non-negative real",
+      "mul_eq_zero — a product is zero iff a factor is zero",
+      "linear_combination tactic — verifying polynomial identities from hypotheses"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring explaining the uniqueness question and the reduction to three non-collinear midpoints; imports FeuerbachsTheoremDefs; opens the FeuerbachsTheorem namespace.",
+      "mathContext": "Works in the parent's coordinate API: Point = R x R, dist2 P Q = sqrt((Q.1-P.1)^2+(Q.2-P.2)^2), dist2_sq P Q = (Q.1-P.1)^2+(Q.2-P.2)^2."
+    },
+    {
+      "id": "bridge",
+      "title": "Part I: Distance Bridge",
+      "startLine": 62,
+      "endLine": 76,
+      "summary": "dist2_sq_eq_dist2_sq and dist2_sq_of_dist2_eq relate the sqrt distance to the squared distance, so equal radii give equal squared distances.",
+      "mathContext": "dist2_sq Q P = (dist2 Q P)^2 via Real.sq_sqrt; hence dist2 Q P = dist2 Q P' implies dist2_sq Q P = dist2_sq Q P'."
+    },
+    {
+      "id": "center-unique",
+      "title": "Part II: Uniqueness of an Equidistant Centre",
+      "startLine": 78,
+      "endLine": 111,
+      "summary": "equidistant_center_unique: two centres equidistant (squared) from three non-collinear points are equal.",
+      "mathContext": "Subtracting squared-distance equations cancels quadratics, yielding linear equations e1, e2 in (Q - Q'); Cramer's rule against the non-zero orientation determinant forces the difference to vanish; Prod.ext_iff assembles the coordinate equalities."
+    },
+    {
+      "id": "noncollinear",
+      "title": "Part III: Non-Collinearity of the Side Midpoints",
+      "startLine": 113,
+      "endLine": 125,
+      "summary": "midpoints_noncollinear: the orientation determinant of M_a, M_b, M_c is 1/4 of the triangle's non-degeneracy determinant, hence non-zero.",
+      "mathContext": "M_b - M_a = (A - B)/2 and M_c - M_a = (A - C)/2, so the midpoint determinant equals (1/4) of the vertex determinant; linear_combination 4*h reduces to T.nondegenerate."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Part IV: Uniqueness of the Nine-Point Circle",
+      "startLine": 127,
+      "endLine": 170,
+      "summary": "ninePointCircle_unique and ninePointCircle_unique_of_nine: any circle through the side midpoints (a fortiori through all nine points) is the nine-point circle.",
+      "mathContext": "N and any circle-centre Q are both equidistant from M_a, M_b, M_c (the former by the parent membership theorems), so equidistant_center_unique gives Q = N; the radius equals the common distance dist2 N M_a = R/2."
+    },
+    {
+      "id": "example",
+      "title": "Part V: 3-4-5 Sanity Check",
+      "startLine": 172,
+      "endLine": 184,
+      "summary": "The unique circle through the side midpoints of the 3-4-5 triangle is centred at (3/4, 1) with radius 5/4.",
+      "mathContext": "Specializes ninePointCircle_unique to triangle_345 and rewrites with the parent's computed ninePointCenter and ninePointRadius."
+    }
+  ],
+  "conclusion": {
+    "summary": "Establishes that the nine-point circle is the unique circle through the nine special points of a non-degenerate triangle. The 184-line file proves uniqueness of an equidistant centre (the linear-algebra core), non-collinearity of the three side midpoints (a 1/4-multiple of the triangle's non-degeneracy determinant), and assembles them with the parent's membership theorems into ninePointCircle_unique. 6 theorems, 0 axioms, 0 sorries.",
+    "implications": "**Completes the definitional picture**: with both membership (parent) and uniqueness (this file), 'the nine-point circle' is now a canonically determined object in the gallery's coordinate framework, not merely 'a circle through these points'.\n\n**Reusable circle-uniqueness lemma**: equidistant_center_unique is stated for arbitrary points and can be reused for circumcircle uniqueness or any 'three non-collinear points determine a circle' argument in the coordinate API.\n\n**Minimal hypotheses**: uniqueness consumes only the three side-midpoint memberships, making explicit that three of the nine points suffice.",
+    "openQuestions": [
+      "Transport ninePointCircle_unique across the toEuclidean bridge of feuerbachs-theorem-defs-oq-04 to obtain uniqueness for Mathlib's Metric.sphere formulation.",
+      "Prove that the nine-point centre N is the unique point equidistant from any three of the nine points (not just the side midpoints), e.g. from the three altitude feet.",
+      "Derive a general 'three non-collinear points determine a unique circle' theorem in the coordinate API from equidistant_center_unique and apply it to the circumcircle."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "feuerbachs-theorem-defs",
+      "relationship": "extends",
+      "description": "proves the converse of the parent's nine-point membership theorems: the nine-point circle is the unique circle through the special points"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-04",
+      "relationship": "related",
+      "description": "the Mathlib sphere formulation; uniqueness could be transported across its toEuclidean bridge"
+    },
+    {
+      "targetId": "feuerbachs-theorem-defs-oq-03",
+      "relationship": "related",
+      "description": "uniqueness of the Feuerbach (tangency) point, a companion uniqueness result for the same configuration"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.FeuerbachsTheoremDefs"],
+    "opens": ["FeuerbachsTheorem"],
+    "namespace": "FeuerbachNinePointUniqueness",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/FeuerbachsTheoremDefsOQ05.lean",
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefs.lean"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "ninePointCircle_unique",
+      "type": "core",
+      "description": "Any circle through the three side midpoints of a non-degenerate triangle is the nine-point circle (centre N, radius R/2)",
+      "leanType": "dist2 Q T.midpoint_a = rho -> dist2 Q T.midpoint_b = rho -> dist2 Q T.midpoint_c = rho -> Q = T.ninePointCenter and rho = T.ninePointRadius"
+    },
+    {
+      "name": "equidistant_center_unique",
+      "type": "lemma",
+      "description": "Two points equidistant (squared) from three non-collinear points coincide",
+      "leanType": "det != 0 -> (Q equidistant from P1 P2 P3) -> (Q' equidistant from P1 P2 P3) -> Q = Q'"
+    },
+    {
+      "name": "midpoints_noncollinear",
+      "type": "lemma",
+      "description": "The three side midpoints of a non-degenerate triangle are non-collinear",
+      "leanType": "(M_b.1-M_a.1)*(M_c.2-M_a.2) - (M_c.1-M_a.1)*(M_b.2-M_a.2) != 0"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/feuerbachs-theorem-defs-oq-02.json
+++ b/src/data/research/problems/feuerbachs-theorem-defs-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "feuerbachs-theorem-defs-oq-02",
   "title": "Nine-Point Circle Uniqueness",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED. Nine-point circle uniqueness proven and shipped under gallery slug feuerbachs-theorem-defs-oq-05 (FeuerbachsTheoremDefsOQ05.lean, PR #29810) because the oq-02 slug was already taken by Euler's triangle formula. Verified, 0 axioms, 0 sorries, 6 theorems.",
+    "builtItems": [
+      "equidistant_center_unique: uniqueness of a point equidistant (squared) from three non-collinear points, via 2x2 linear system + Cramer (linear_combination)",
+      "midpoints_noncollinear: side-midpoint orientation determinant = 1/4 of the triangle non-degeneracy determinant",
+      "ninePointCircle_unique / ninePointCircle_unique_of_nine: any circle through the 3 side midpoints is the nine-point circle (centre N, radius R/2)"
+    ],
+    "insights": [
+      "Circle-through-three-points uniqueness is linear after cancelling the common quadratic terms; the system determinant IS the orientation/twice-signed-area determinant.",
+      "The Triangle structure's built-in non-degeneracy is exactly sufficient: the midpoints' determinant is a constant (1/4) multiple of it, so no new geometric hypothesis is introduced.",
+      "Only 3 of the 9 special points (the side midpoints) are needed for uniqueness; the altitude feet and Euler midpoints are redundant.",
+      "dist2_sq Q P = (dist2 Q P)^2 (Real.sq_sqrt) bridges the parent's sqrt-based membership statements to the polynomial form linear_combination/ring operate on."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Transport ninePointCircle_unique across the toEuclidean bridge (oq-04) to Mathlib Metric.sphere.",
+      "Generalize equidistant_center_unique to a reusable 'three non-collinear points determine a unique circle' lemma and apply to the circumcircle."
+    ],
     "markdown": "# Knowledge Base: feuerbachs-theorem-defs-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Proves the **nine-point circle is the unique circle** through the nine special points of a non-degenerate triangle — the converse of the parent file (`feuerbachs-theorem-defs`), which establishes only that the nine points *lie on* the nine-point circle.

This is the problem described by the candidate `feuerbachs-theorem-defs-oq-02` (problem.md: "Nine-Point Circle Uniqueness"). That slug was already occupied in the gallery by Euler's triangle formula (`FeuerbachsTheoremDefsOQ02.lean`), so the deliverable is shipped under the next free top-level slug `feuerbachs-theorem-defs-oq-05`.

## What's proved (`Proofs/FeuerbachsTheoremDefsOQ05.lean`, 184 lines)

- **`equidistant_center_unique`** — the algebraic core. For three non-collinear points `P₁ P₂ P₃`, any two points equidistant (in squared distance) from all three coincide. Subtracting the squared-distance equations cancels the quadratic terms, leaving a 2×2 linear system whose determinant is exactly the orientation determinant of `P₁ P₂ P₃`; Cramer's rule (encoded via `linear_combination`) forces the centres equal.
- **`midpoints_noncollinear`** — the three side midpoints of a non-degenerate triangle are non-collinear; their orientation determinant equals `1/4` of the triangle's own non-degeneracy determinant.
- **`ninePointCircle_unique`** — any circle (centre `Q`, radius `ρ`) through the three side midpoints has `Q = ninePointCenter` and `ρ = R/2`.
- **`ninePointCircle_unique_of_nine`** — the same conclusion against a circle through all nine points, consuming only three of the memberships.
- 3-4-5 numerical sanity check.

## Verification

- **6 theorems, 0 sorries, 0 `axiom` declarations.**
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (foundational) — no `Lean.ofReduceBool`, no `sorryAx`. Reported as **verified / original / 0-axiom**.
- Built with host `lake env lean` (docker daemon down); olean produced, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)