### PR TITLE
research(cauchy-group-...oq03020 1): exponent governs the power map — image equality in every group [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -611,6 +611,7 @@ import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ02
 import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchyInterlacingOQ01OQ01

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01.lean
@@ -1,0 +1,153 @@
+import Mathlib.Tactic
+
+/-
+# Power map over a general group: the exponent governs kernel *and* image
+
+The parent entry (`gcd(n,m)` recovers the power map) established, for a finite
+group of order `m`:
+
+* **kernel**, in any finite group: `xⁿ = 1 ↔ x^(gcd(n,m)) = 1`;
+* **image**, only in the *cyclic* case: the `n`-th powers are the
+  `gcd(n,m)`-th powers.
+
+It left open (parent open question 1) the image equality for a *general finite
+abelian* group, noting that the cyclic proof used the group order `m` and the
+counting identity `#range · #ker = m`, neither of which behaves the same once
+the group is a nontrivial product of cyclic factors.
+
+This file answers that question — and overshoots it. The right invariant is not
+the order `m = |G|` but the **exponent** `e = exp G`. Against the exponent the
+image equality
+
+      range (x ↦ xⁿ)  =  range (x ↦ x^(gcd(n, e)))
+
+holds **in every group** (no commutativity, no finiteness needed), because the
+hard inclusion is a single Bézout identity: writing
+`gcd(n, e) = n·A + e·B` over `ℤ` and using `x^e = 1`, every `gcd(n,e)`-th power
+`x^(gcd(n,e)) = (x^A)ⁿ` is already an `n`-th power.
+
+For a finite **abelian** group this recovers exactly the structural picture the
+parent asked for:
+
+* the power map `x ↦ xⁿ` is a homomorphism whose kernel is the
+  `gcd(n, e)`-torsion subgroup (constant fibre size `#ker`), and
+* the partition identity becomes `#range · #ker = |G|` — first-isomorphism
+  bookkeeping that holds verbatim for every finite abelian group, with the
+  cyclic identity `#(n-th powers) · gcd(n, m) = m` the special case where
+  `#ker = gcd(n, m)`.
+
+Everything is over `Mathlib.Tactic` only; `Monoid.exponent` is the sole new
+ingredient relative to the parent.
+-/
+
+variable {α : Type*}
+
+/-! ### A `ℤ`-power form of `x ^ exponent = 1` -/
+
+/-- `x` raised to the (integer-cast) exponent is the identity, in any monoid.
+This is the `zpow` companion of `Monoid.pow_exponent_eq_one`, packaged for the
+Bézout computation below. -/
+theorem zpow_exponent_eq_one [Group α] (x : α) :
+    x ^ (Monoid.exponent α : ℤ) = 1 := by
+  rw [zpow_natCast]
+  exact Monoid.pow_exponent_eq_one x
+
+/-! ### Kernel: the `n`-torsion is the `gcd(n, exp)`-torsion (any group) -/
+
+/-- **Element-level kernel recovery against the exponent (any group).**
+`orderOf x` divides the exponent, so `xⁿ = 1` (i.e. `orderOf x ∣ n`) is
+unchanged by replacing `n` with `gcd(n, exp G)`. This is the parent's
+`pow_eq_one_iff_pow_gcd` with the *exponent* in place of the order, and it no
+longer needs finiteness. -/
+theorem pow_eq_one_iff_pow_gcd_exponent [Group α] {n : ℕ} (x : α) :
+    x ^ n = 1 ↔ x ^ Nat.gcd n (Monoid.exponent α) = 1 := by
+  rw [← orderOf_dvd_iff_pow_eq_one, ← orderOf_dvd_iff_pow_eq_one,
+    Nat.dvd_gcd_iff]
+  exact (and_iff_left (Monoid.order_dvd_exponent x)).symm
+
+/-! ### Image: the `n`-th powers are the `gcd(n, exp)`-th powers (any group) -/
+
+/-- **Image recovery against the exponent (any group).** As *sets*, the `n`-th
+powers coincide with the `gcd(n, exp G)`-th powers. Unlike the parent's cyclic
+argument (which compared subgroup cardinalities), this holds with no
+commutativity and no finiteness: the easy inclusion uses `gcd(n,e) ∣ n`, and the
+hard inclusion is the Bézout identity `gcd(n,e) = n·A + e·B` together with
+`x^e = 1`, which exhibits `x^(gcd(n,e)) = (x^A)ⁿ`. -/
+theorem range_pow_eq_range_pow_gcd_exponent [Group α] (n : ℕ) :
+    Set.range (fun x : α => x ^ n)
+      = Set.range (fun x : α => x ^ Nat.gcd n (Monoid.exponent α)) := by
+  set e := Monoid.exponent α with he
+  set d := Nat.gcd n e with hd
+  apply Set.Subset.antisymm
+  · -- `range (·ⁿ) ⊆ range (·^d)`:  `d ∣ n`, so `xⁿ = (x^(n/d))^d`.
+    rintro _ ⟨x, rfl⟩
+    obtain ⟨k, hk⟩ := Nat.gcd_dvd_left n e
+    exact ⟨x ^ k, by show (x ^ k) ^ d = x ^ n; rw [← pow_mul', ← hk]⟩
+  · -- `range (·^d) ⊆ range (·ⁿ)`:  Bézout `d = n·A + e·B` gives `x^d = (x^A)ⁿ`.
+    rintro _ ⟨x, rfl⟩
+    refine ⟨x ^ (Nat.gcdA n e), ?_⟩
+    show (x ^ Nat.gcdA n e) ^ n = x ^ d
+    have hbez : (d : ℤ) = n * Nat.gcdA n e + e * Nat.gcdB n e := by
+      rw [hd]; exact Nat.gcd_eq_gcd_ab n e
+    have hx : x ^ (e : ℤ) = 1 := zpow_exponent_eq_one x
+    have hxe : x ^ ((e : ℤ) * Nat.gcdB n e) = 1 := by rw [zpow_mul, hx, one_zpow]
+    calc (x ^ Nat.gcdA n e) ^ n
+          = (x ^ Nat.gcdA n e) ^ (n : ℤ) := (zpow_natCast _ n).symm
+      _ = x ^ ((n : ℤ) * Nat.gcdA n e) := by rw [← zpow_mul, mul_comm]
+      _ = x ^ ((n : ℤ) * Nat.gcdA n e) * x ^ ((e : ℤ) * Nat.gcdB n e) := by
+            rw [hxe, mul_one]
+      _ = x ^ ((n : ℤ) * Nat.gcdA n e + (e : ℤ) * Nat.gcdB n e) := (zpow_add x _ _).symm
+      _ = x ^ (d : ℤ) := by rw [← hbez]
+      _ = x ^ d := zpow_natCast x d
+
+/-! ### Abelian packaging: kernel and image as subgroups, and the partition -/
+
+/-- **Kernel subgroup recovery (abelian).** In a commutative group the kernel of
+`x ↦ xⁿ` is the `gcd(n, exp G)`-torsion subgroup. -/
+theorem ker_powMonoidHom_eq_gcd_exponent [CommGroup α] (n : ℕ) :
+    (powMonoidHom n : α →* α).ker
+      = (powMonoidHom (Nat.gcd n (Monoid.exponent α)) : α →* α).ker := by
+  ext x
+  simp only [MonoidHom.mem_ker, powMonoidHom_apply]
+  exact pow_eq_one_iff_pow_gcd_exponent x
+
+/-- **Image subgroup recovery (abelian).** In a commutative group the subgroup of
+`n`-th powers equals the subgroup of `gcd(n, exp G)`-th powers — the open
+question's image equality, now for *every* abelian group (finite or not), with
+`exp G` the correct invariant in place of `|G|`. -/
+theorem range_powMonoidHom_eq_gcd_exponent [CommGroup α] (n : ℕ) :
+    (powMonoidHom n : α →* α).range
+      = (powMonoidHom (Nat.gcd n (Monoid.exponent α)) : α →* α).range := by
+  ext y
+  constructor
+  · rintro ⟨x, rfl⟩
+    have : (powMonoidHom n x) ∈ Set.range (fun x : α => x ^ n) := ⟨x, rfl⟩
+    rw [range_pow_eq_range_pow_gcd_exponent n] at this
+    obtain ⟨z, hz⟩ := this
+    exact ⟨z, hz⟩
+  · rintro ⟨x, rfl⟩
+    have : (powMonoidHom (Nat.gcd n (Monoid.exponent α)) x)
+        ∈ Set.range (fun x : α => x ^ Nat.gcd n (Monoid.exponent α)) := ⟨x, rfl⟩
+    rw [← range_pow_eq_range_pow_gcd_exponent n] at this
+    obtain ⟨z, hz⟩ := this
+    exact ⟨z, hz⟩
+
+/-- **Partition identity (finite abelian).** For a finite abelian group the power
+map `x ↦ xⁿ` is a homomorphism, so its image and kernel cardinalities multiply to
+`|G|`. The non-empty fibres all have the constant size `#ker = #(gcd(n,exp)-th
+roots of unity)`, and there are `#range` of them. This is the parent's partition
+identity `#range · #ker = |G|` in the form that survives the passage to a
+non-cyclic group: the constant fibre size is `#ker`, which equals `gcd(n, |G|)`
+exactly when `G` is cyclic. -/
+theorem card_range_mul_card_ker_powMonoidHom [CommGroup α] [Fintype α] (n : ℕ) :
+    Nat.card (powMonoidHom n : α →* α).range
+        * Nat.card (powMonoidHom n : α →* α).ker
+      = Fintype.card α := by
+  set f := (powMonoidHom n : α →* α) with hf
+  have hidx : f.ker.index = Nat.card f.range := by
+    rw [Subgroup.index_eq_card]
+    exact Nat.card_congr (QuotientGroup.quotientKerEquivRange f).toEquiv
+  have key : Nat.card f.ker * f.ker.index = Nat.card α := Subgroup.card_mul_index f.ker
+  rw [hidx] at key
+  rw [← Nat.card_eq_fintype_card, mul_comm]
+  exact key

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "The Exponent, Not the Order, Governs the Power Map",
+    "content": "The parent proved the kernel equality xⁿ = 1 ⟺ x^gcd(n,m) = 1 in any finite group, but the matching image equality only in the cyclic case, where the order m and the count #range·#ker = m carry the proof. Its first open question asked for the image equality in a general finite abelian group. The resolution is to change the invariant from the order m = |G| to the exponent e = exp G: against the exponent the image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n,e)) holds in EVERY group, because the hard inclusion is a single Bézout identity gcd(n,e) = n·A + e·B together with x^e = 1.",
+    "mathContext": "$$\\operatorname{range}(x\\mapsto x^n)=\\operatorname{range}\\!\\left(x\\mapsto x^{\\gcd(n,\\exp G)}\\right)\\quad\\text{in every group.}$$",
+    "significance": "context",
+    "relatedConcepts": [
+      "monoid exponent",
+      "power map endomorphism",
+      "Bézout's identity",
+      "gcd reduction of exponents"
+    ],
+    "prerequisites": [
+      "group exponent",
+      "order of an element",
+      "Bézout coefficients"
+    ]
+  },
+  {
+    "id": "ann-kernel",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "Kernel Recovery Against the Exponent",
+    "content": "pow_eq_one_iff_pow_gcd_exponent reduces xⁿ = 1 ↔ x^gcd(n, exp G) = 1 to the arithmetic equivalence orderOf x ∣ n ↔ orderOf x ∣ gcd(n, exp G). Nat.dvd_gcd_iff splits the right side into orderOf x ∣ n ∧ orderOf x ∣ exp G, and the second conjunct is automatic via Monoid.order_dvd_exponent. Unlike the parent's version (which used orderOf x ∣ |G| and hence needed finiteness), this works in any group.",
+    "mathContext": "$$x^n=1\\iff \\operatorname{ord}(x)\\mid n\\iff \\operatorname{ord}(x)\\mid\\gcd(n,\\exp G)\\iff x^{\\gcd(n,\\exp G)}=1.$$",
+    "significance": "technique",
+    "relatedConcepts": [
+      "order divides exponent",
+      "torsion subgroup",
+      "gcd divisibility"
+    ],
+    "prerequisites": [
+      "orderOf_dvd_iff_pow_eq_one",
+      "Monoid.order_dvd_exponent"
+    ]
+  },
+  {
+    "id": "ann-bezout-image",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 101
+    },
+    "type": "key-step",
+    "title": "The Bézout Identity Behind the Image Equality",
+    "content": "The hard inclusion range(x ↦ x^gcd(n,e)) ⊆ range(x ↦ xⁿ) is proved by exhibiting an explicit witness. Bézout's identity gives integers A = gcdA n e and B = gcdB n e with gcd(n,e) = n·A + e·B over ℤ. Since x^e = 1 (zpow_exponent_eq_one), the term x^(e·B) vanishes, so x^gcd(n,e) = x^(n·A) = (x^A)ⁿ via zpow_mul and zpow_add. Thus the witness x^A is an n-th root of x^gcd(n,e). The reverse inclusion is the elementary gcd(n,e) ∣ n. No cardinality comparison, no commutativity, no finiteness.",
+    "mathContext": "$$x^{\\gcd(n,e)} = x^{nA+eB} = (x^A)^n\\,(x^e)^B = (x^A)^n,\\qquad e=\\exp G,\\ x^e=1.$$",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "Bézout coefficients",
+      "integer powers (zpow)",
+      "image of the power map"
+    ],
+    "prerequisites": [
+      "Nat.gcd_eq_gcd_ab",
+      "zpow_mul",
+      "zpow_add"
+    ]
+  },
+  {
+    "id": "ann-partition",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 142,
+      "endLine": 152
+    },
+    "type": "result",
+    "title": "The Partition Identity #range · #ker = |G|",
+    "content": "card_range_mul_card_ker_powMonoidHom gives the partition analogue the parent requested. For a finite abelian group the power map is a homomorphism, so Subgroup.card_mul_index applied to its kernel together with the first isomorphism theorem (index ker = #range) yields #range · #ker = |G|. The non-empty fibres all have the constant size #ker; this recovers the cyclic identity #(n-th powers)·gcd(n, m) = m exactly when #ker = gcd(n, m), i.e. when G is cyclic.",
+    "mathContext": "$$\\#\\operatorname{range}(x\\mapsto x^n)\\cdot\\#\\ker(x\\mapsto x^n)=|G|.$$",
+    "significance": "result",
+    "relatedConcepts": [
+      "first isomorphism theorem",
+      "Lagrange's theorem",
+      "fibre partition"
+    ],
+    "prerequisites": [
+      "QuotientGroup.quotientKerEquivRange",
+      "Subgroup.card_mul_index"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01",
+  "title": "The exponent governs the power map: range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) in every group",
+  "description": "The parent showed that in a finite group of order m the power map x ↦ xⁿ has the same kernel as x ↦ x^gcd(n,m), but could only prove the corresponding image equality in the cyclic case, where the order m and the counting identity #range · #ker = m do the work. Its first open question asked for the image equality in a general finite abelian group and for the right partition analogue. This entry answers it by changing the invariant: the controlling number is not the order m = |G| but the exponent e = exp G. Against the exponent the image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n,e)) holds in EVERY group — no commutativity, no finiteness — because the hard inclusion is a single Bézout identity. Writing gcd(n,e) = n·A + e·B over ℤ and using x^e = 1 (Monoid.pow_exponent_eq_one) exhibits x^gcd(n,e) = (x^A)ⁿ, so every gcd(n,e)-th power is already an n-th power; the reverse inclusion is the elementary gcd(n,e) ∣ n. The kernel equality xⁿ = 1 ↔ x^gcd(n,e) = 1 is likewise upgraded from gcd-with-order to gcd-with-exponent (orderOf x ∣ exp G always), again with no finiteness. For a finite abelian group these specialize to subgroup equalities of ker and range of powMonoidHom, and the partition identity becomes #range · #ker = |G| via the first isomorphism theorem — the constant fibre size #ker replaces the cyclic value gcd(n, m), with which it agrees exactly when G is cyclic.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean formalization original (exponent governs the power map: image equality and partition for every finite abelian group)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "abelian-groups",
+      "power-map",
+      "monoid-exponent",
+      "bezout",
+      "gcd",
+      "kernel",
+      "image",
+      "first-isomorphism-theorem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Monoid.pow_exponent_eq_one",
+        "description": "g ^ Monoid.exponent M = 1; the defining property of the exponent that makes x^e = 1 hold for every element, supplying the e·B term that vanishes in the Bézout computation.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.order_dvd_exponent",
+        "description": "orderOf x ∣ Monoid.exponent G; the exponent-analogue of orderOf_dvd_card that upgrades the kernel equivalence from gcd-with-order to gcd-with-exponent, with no finiteness hypothesis.",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Nat.gcd_eq_gcd_ab",
+        "description": "Bézout's identity ↑(gcd a b) = a · gcdA a b + b · gcdB a b over ℤ; the heart of the hard inclusion range(·^gcd) ⊆ range(·ⁿ), writing gcd(n,e) as an integer combination of n and e.",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "zpow_mul",
+        "description": "x^(p·q) = (x^p)^q for integer powers; reassociates the Bézout exponent so that x^(n·A) becomes (x^A)ⁿ and x^(e·B) becomes (x^e)^B = 1.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf a ∣ k ↔ aᵏ = 1; converts both sides of the kernel equivalence xⁿ = 1 ↔ x^gcd(n,e) = 1 into divisibility statements about orderOf x.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Nat.dvd_gcd_iff",
+        "description": "k ∣ gcd m n ↔ k ∣ m ∧ k ∣ n; reduces orderOf x ∣ gcd(n, exp G) to orderOf x ∣ n, the second conjunct orderOf x ∣ exp G being automatic.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "QuotientGroup.quotientKerEquivRange",
+        "description": "Noether's first isomorphism theorem G ⧸ ker φ ≃* range φ; combined with Subgroup.card_mul_index it gives the partition identity #range · #ker = |G| for the abelian power homomorphism.",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "Subgroup.card_mul_index",
+        "description": "Nat.card H · H.index = Nat.card G; with index ker = #range (via the first isomorphism theorem) yields #range · #ker = |G|.",
+        "module": "Mathlib.GroupTheory.Index"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Frobenius, Ferdinand Georg",
+        "title": "Verallgemeinerung des Sylow'schen Satzes",
+        "year": "1895",
+        "note": "Sitzungsberichte der Königlich Preußischen Akademie der Wissenschaften zu Berlin — the divisibility theorem for #{xⁿ = 1}; the present entry traces the gcd reduction of the power map to the group exponent rather than the order."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — the exponent of a finite group and the structure of endomorphisms x ↦ xⁿ of finite abelian groups; kernels, images, and equinumerous fibres."
+      },
+      {
+        "authors": "Ireland, Kenneth; Rosen, Michael",
+        "title": "A Classical Introduction to Modern Number Theory",
+        "year": "1990",
+        "note": "Springer GTM 84 — n-th power residues and the role of gcd against the group order/exponent; the cyclic case (ℤ/mℤ) is the special case where exp G = m."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "For a finite abelian group the power map x ↦ xⁿ is an endomorphism: its kernel is the n-torsion subgroup, its image is the subgroup of n-th powers, and its fibres are the cosets of the kernel, hence all of equal size. The parent line of work pinned the cyclic fibre size to gcd(n, |G|), the abelian shadow of Frobenius' 1895 divisibility theorem, and showed kernel and image are both recovered by gcd(n, |G|) — but the image step used the order m and the cyclic cardinality formula #range = m/gcd(n,m), which has no clean analogue once the group is a nontrivial product of cyclic factors. The conceptual fix is to replace the group order by the group exponent exp G, the least common multiple of all element orders. Against the exponent the gcd reduction of the power map is purely elementary and dimension-free: it is the multiplicative face of Bézout's identity, and it never uses commutativity or finiteness.",
+    "problemStatement": "In an arbitrary group, compare the power map x ↦ xⁿ with x ↦ x^gcd(n, exp G), where exp G is the monoid exponent. Show they have the same kernel and the same image as sets (no commutativity, no finiteness), then package these for a commutative group as equalities of the kernel and range subgroups of powMonoidHom, and for a finite abelian group as the partition identity #range · #ker = |G|.",
+    "proofStrategy": "Kernel (any group): pow_eq_one_iff_pow_gcd_exponent reduces xⁿ = 1 ↔ x^gcd(n,e) = 1 through orderOf_dvd_iff_pow_eq_one to orderOf x ∣ n ↔ orderOf x ∣ gcd(n, e); Nat.dvd_gcd_iff splits the right side, and the spare conjunct orderOf x ∣ e is Monoid.order_dvd_exponent. Image (any group): range_pow_eq_range_pow_gcd_exponent is an antisymmetry of sets. The easy inclusion range(·ⁿ) ⊆ range(·^d) uses d = gcd(n,e) ∣ n, so n = d·k and xⁿ = (x^k)^d. The hard inclusion range(·^d) ⊆ range(·ⁿ) takes the witness x^A with A = gcdA n e: by Bézout (Nat.gcd_eq_gcd_ab) d = n·A + e·B over ℤ, and since x^e = 1 (zpow_exponent_eq_one, the zpow form of Monoid.pow_exponent_eq_one) the e·B term drops, leaving x^d = (x^A)ⁿ after reassociating with zpow_mul/zpow_add. Abelian packaging: ker_powMonoidHom_eq_gcd_exponent and range_powMonoidHom_eq_gcd_exponent lift the element-level equalities through MonoidHom.mem_ker and MonoidHom.mem_range. Partition: card_range_mul_card_ker_powMonoidHom combines Subgroup.card_mul_index for ker with the first isomorphism theorem QuotientGroup.quotientKerEquivRange (giving index ker = #range) to conclude #range · #ker = |G|.",
+    "keyInsights": [
+      "The correct invariant for the power map's image is the group EXPONENT, not the order: range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) holds in every group, whereas the parent's order-based proof was confined to the cyclic case.",
+      "The hard inclusion is a one-line Bézout identity: gcd(n, exp G) = n·A + exp G·B over ℤ, and x^exp G = 1 collapses the second term, so x^gcd(n,exp G) = (x^A)ⁿ is manifestly an n-th power.",
+      "No commutativity or finiteness is needed for the set-level kernel and image equalities; commutativity enters only to phrase them as subgroup equalities, and finiteness only for the counting partition #range · #ker = |G|.",
+      "The partition analogue the parent asked for is first-isomorphism bookkeeping: in a finite abelian group the constant fibre size is #ker, and #range · #ker = |G|; the cyclic identity #(n-th powers) · gcd(n, m) = m is the special case #ker = gcd(n, m), exp G = m."
+    ]
+  },
+  "sections": [
+    {
+      "id": "zpow-exponent",
+      "title": "A ℤ-power form of x ^ exponent = 1",
+      "startLine": 50,
+      "endLine": 53,
+      "summary": "zpow_exponent_eq_one: x ^ (↑(Monoid.exponent α)) = 1 as an integer power, the zpow companion of Monoid.pow_exponent_eq_one, packaged for the Bézout computation where the exponent appears as an integer coefficient.",
+      "mathContext": "x^(exp G) = 1 holds for every element; rephrased as a zpow it can be multiplied into integer Bézout exponents."
+    },
+    {
+      "id": "kernel-recovery",
+      "title": "Kernel: the n-torsion is the gcd(n, exp)-torsion (any group)",
+      "startLine": 62,
+      "endLine": 72,
+      "summary": "pow_eq_one_iff_pow_gcd_exponent: in any group, xⁿ = 1 ↔ x^gcd(n, exp G) = 1, via orderOf_dvd_iff_pow_eq_one, Nat.dvd_gcd_iff, and Monoid.order_dvd_exponent (orderOf x ∣ exp G always). This is the parent's kernel result with the exponent in place of the order, and with no finiteness assumption.",
+      "mathContext": "xⁿ = 1 ⟺ x^gcd(n,exp G) = 1; orderOf x divides the exponent, so passing from n to gcd(n, exp G) leaves the torsion solution set unchanged."
+    },
+    {
+      "id": "image-recovery",
+      "title": "Image: the n-th powers are the gcd(n, exp)-th powers (any group)",
+      "startLine": 76,
+      "endLine": 101,
+      "summary": "range_pow_eq_range_pow_gcd_exponent: as sets, range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) in any group. Easy inclusion: gcd(n,e) ∣ n gives xⁿ = (x^k)^gcd. Hard inclusion: Bézout gcd(n,e) = n·A + e·B with x^e = 1 yields x^gcd(n,e) = (x^A)ⁿ, computed via zpow_mul and zpow_add.",
+      "mathContext": "The image equality the parent proved only for cyclic groups, now general — the controlling invariant is the exponent, and the argument is a single Bézout identity rather than a cardinality comparison."
+    },
+    {
+      "id": "abelian-packaging",
+      "title": "Abelian packaging: subgroups and the partition identity",
+      "startLine": 107,
+      "endLine": 152,
+      "summary": "ker_powMonoidHom_eq_gcd_exponent and range_powMonoidHom_eq_gcd_exponent recast the element-level equalities as equalities of the kernel and range subgroups of powMonoidHom in a commutative group (finite or not). card_range_mul_card_ker_powMonoidHom, for a finite abelian group, derives the partition identity #range · #ker = |G| from Subgroup.card_mul_index and the first isomorphism theorem.",
+      "mathContext": "For abelian G the power map is a homomorphism; #range · #ker = |G| is the partition analogue the parent requested, with the constant fibre size #ker generalizing the cyclic value gcd(n, m)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The single number that governs the power map x ↦ xⁿ on a group is gcd(n, exp G), the gcd of n with the group exponent. It fixes the kernel in every group — xⁿ = 1 ⟺ x^gcd(n, exp G) = 1 — and, crucially, it also fixes the image in every group: range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)), with the hard inclusion a single Bézout identity gcd(n, exp G) = n·A + exp G·B combined with x^(exp G) = 1 to write x^gcd(n, exp G) = (x^A)ⁿ. This removes both restrictions of the parent's image theorem (cyclic and finite): the set-level statements need neither commutativity nor finiteness, the exponent being the correct invariant in place of the order. For a finite abelian group the statements become subgroup equalities for ker and range of powMonoidHom, and the fibre partition becomes the first-isomorphism identity #range · #ker = |G|, with the constant fibre size #ker agreeing with the cyclic value gcd(n, |G|) exactly when G is cyclic.",
+    "implications": [
+      "The image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) answers the parent's first open question affirmatively for every finite abelian group — and in fact for every group — once the gcd is taken against the exponent rather than the order.",
+      "The whole gcd reduction of the power map (kernel and image) is commutativity-free and finiteness-free at the level of sets; these hypotheses are needed only to package the result as subgroups or to count fibres.",
+      "The partition analogue is #range · #ker = |G|: in a finite abelian group every non-empty fibre has the constant size #ker, generalizing the cyclic identity #(n-th powers) · gcd(n, m) = m, which is recovered when exp G = |G| and #ker = gcd(n, m)."
+    ],
+    "openQuestions": [
+      "Quantify the gap between exp G and |G|: for a finite abelian group with invariant factors d₁ ∣ ⋯ ∣ d_k (so exp G = d_k and |G| = ∏ dᵢ), express #range = |G| / #ker and the constant fibre size #ker = #{x : x^gcd(n, exp G) = 1} explicitly as ∏ gcd(n, dᵢ), and characterize when this equals the cyclic surrogate gcd(n, |G|).",
+      "Does the set-level image equality range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G)) extend to monoids in which x^(exp M) = 1 fails for non-units — i.e. is there a correct exponent-gcd statement for the image of the power map on a finite commutative monoid, restricted to its group of units or otherwise?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Directly answers the parent's first open question. The parent proved the image equality range(·ⁿ) = range(·^gcd) only in the cyclic case using the order m and the cardinality formula; this entry proves it for every group by replacing the order with the exponent, and supplies the partition analogue #range · #ker = |G| for all finite abelian groups."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "related",
+      "description": "The grandparent counts the homogeneous fibre #{x | xⁿ = 1} = gcd(n, |G|) on a cyclic group; that count is the kernel size whose image-side complement m/gcd(n, m) is the cyclic instance of the partition #range · #ker = |G| established here in the exponent formulation."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers parent **open question 1** of `cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02` (`gcd(n,m)` recovers the power map).

The parent proved the kernel equality `xⁿ = 1 ⟺ x^gcd(n,m) = 1` in any finite group, but the matching **image** equality `range(x↦xⁿ) = range(x↦x^gcd(n,m))` only in the **cyclic** case — where the order `m` and the counting identity `#range·#ker = m` carry the proof. It asked for the image equality in a general finite abelian group.

**Resolution: change the invariant from the order `|G|` to the exponent `e = exp G`.** Against the exponent the image equality

```
range(x ↦ xⁿ) = range(x ↦ x^gcd(n, exp G))
```

holds in **every group** — no commutativity, no finiteness — because the hard inclusion is a single **Bézout identity**: `gcd(n,e) = n·A + e·B` over ℤ, together with `x^e = 1` (`Monoid.pow_exponent_eq_one`), exhibits `x^gcd(n,e) = (x^A)ⁿ`. The reverse inclusion is the elementary `gcd(n,e) ∣ n`.

## Theorems (6, 0 defs, 153 lines, `Mathlib.Tactic` only)

| Theorem | Statement | Hypotheses |
|---|---|---|
| `pow_eq_one_iff_pow_gcd_exponent` | `xⁿ = 1 ↔ x^gcd(n, exp G) = 1` | any `Group` |
| `range_pow_eq_range_pow_gcd_exponent` | image equality as **sets** | any `Group` |
| `ker_powMonoidHom_eq_gcd_exponent` | kernel subgroup equality | `CommGroup` |
| `range_powMonoidHom_eq_gcd_exponent` | range subgroup equality | `CommGroup` |
| `card_range_mul_card_ker_powMonoidHom` | partition `#range · #ker = |G|` | finite `CommGroup` |

The partition identity is the analogue the parent requested: the constant fibre size is `#ker`, recovering the cyclic `#(n-th powers)·gcd(n,m) = m` exactly when `G` is cyclic.

## Verification
- `lake env lean` compiles clean (exit 0, 0 sorries).
- `#print axioms` on all main results: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **verified, 0-axiom, original**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)