### PR TITLE
research(sylow-theorems-oq-01-oq-02): classification of groups of squarefree order [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3901,6 +3901,7 @@ import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ02OQ01
 import Proofs.SummationByPartsOQ01OQ02OQ01
 import Proofs.SylowTheorem
 import Proofs.SylowTheoremOQ01
+import Proofs.SylowTheoremOQ01OQ02
 import Proofs.SylowTheoremOQ02
 import Proofs.SylowTheoremOQ02Orbit
 import Proofs.SylowTheoremOQ02OQ01Nilpotent

--- a/proofs/Proofs/SylowTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/SylowTheoremOQ01OQ02.lean
@@ -1,0 +1,124 @@
+import Mathlib
+
+/-
+# Classification of Groups of Squarefree Order
+
+## What This Proves
+
+This answers the second open question of `sylow-theorems-oq-01`
+("Classification of Groups of Order pq via Sylow Theorems"):
+
+> Can the full squarefree-order classification be formalized? Every group of
+> squarefree order n = p₁p₂···pₖ is a semidirect product of cyclic groups, with
+> the structure determined by the divisibility relations among the pᵢ — a
+> generalization of the pq case to multiple primes.
+
+The parent entry handles the two-prime case `n = pq` by hand. Here we formalize
+the **general squarefree case** for *any* number of prime factors, using
+Mathlib's `IsZGroup` theory (a Z-group is a finite group all of whose Sylow
+subgroups are cyclic). The decisive facts are:
+
+* `IsZGroup.of_squarefree` — squarefree order forces every Sylow subgroup to be
+  cyclic (each has prime order, hence is `ℤ/pᵢ`);
+* `isZGroup_iff_exists_mulEquiv` — a finite Z-group is isomorphic to a semidirect
+  product `N ⋊ H` of two cyclic subgroups of coprime order.
+
+Composing these gives the structure theorem the open question asks for, plus the
+standard consequences: such groups are **solvable**, **metacyclic** (cyclic normal
+subgroup with cyclic quotient), and have **exponent equal to their order**.
+
+## Honest scope
+
+The hard mathematics (the Z-group structure theory, Schur–Zassenhaus splitting)
+lives in Mathlib. The contribution here is to *assemble* it into the
+squarefree-order classification narrative that the parent entry left open, as a
+fully verified (0-axiom) gallery result. The "structure determined by the
+divisibility relations among the pᵢ" — i.e. the explicit count of isomorphism
+classes — is genuinely harder and remains open (see the open questions below).
+-/
+
+open scoped Classical
+
+namespace SquarefreeOrderClassification
+
+variable {G : Type*} [Group G] [Finite G]
+
+/-! ## The key reduction: squarefree order ⇒ Z-group -/
+
+/-- **A finite group of squarefree order is a Z-group**: every Sylow subgroup is
+    cyclic. When `n = p₁⋯pₖ` is squarefree each Sylow `pᵢ`-subgroup has order
+    exactly `pᵢ`, so it is cyclic. -/
+theorem isZGroup_of_squarefree_order (h : Squarefree (Nat.card G)) : IsZGroup G :=
+  IsZGroup.of_squarefree h
+
+/-- **Every Sylow subgroup is cyclic.** For squarefree order each Sylow subgroup
+    is `ℤ/pᵢ`. -/
+theorem sylow_isCyclic (h : Squarefree (Nat.card G))
+    {p : ℕ} [Fact p.Prime] (P : Sylow p G) : IsCyclic P := by
+  haveI := isZGroup_of_squarefree_order h
+  infer_instance
+
+/-! ## Structural consequences -/
+
+/-- **Groups of squarefree order are solvable.** -/
+theorem isSolvable_of_squarefree_order (h : Squarefree (Nat.card G)) : IsSolvable G := by
+  haveI := isZGroup_of_squarefree_order h
+  infer_instance
+
+/-- **The commutator subgroup is cyclic.** -/
+theorem isCyclic_commutator (h : Squarefree (Nat.card G)) : IsCyclic (commutator G) := by
+  haveI := isZGroup_of_squarefree_order h
+  exact IsZGroup.isCyclic_commutator G
+
+/-- **The abelianization is cyclic.** -/
+theorem isCyclic_abelianization (h : Squarefree (Nat.card G)) :
+    IsCyclic (Abelianization G) := by
+  haveI := isZGroup_of_squarefree_order h
+  infer_instance
+
+/-- **The exponent equals the order.** A group of squarefree order is "as close to
+    cyclic as its order allows": its exponent is the full group order. -/
+theorem exponent_eq_card (h : Squarefree (Nat.card G)) :
+    Monoid.exponent G = Nat.card G := by
+  haveI := isZGroup_of_squarefree_order h
+  exact IsZGroup.exponent_eq_card G
+
+/-! ## Metacyclic structure -/
+
+/-- **Groups of squarefree order are metacyclic**: the commutator subgroup is a
+    *cyclic normal* subgroup whose quotient (the abelianization `G ⧸ commutator G`)
+    is also cyclic. This is the cyclic-by-cyclic extension structure. -/
+theorem metacyclic_of_squarefree_order (h : Squarefree (Nat.card G)) :
+    (commutator G).Normal ∧ IsCyclic (commutator G) ∧ IsCyclic (Abelianization G) := by
+  haveI := isZGroup_of_squarefree_order h
+  exact ⟨inferInstance, IsZGroup.isCyclic_commutator G, inferInstance⟩
+
+/-! ## The classification: a semidirect product of cyclic groups -/
+
+/-- **Classification of groups of squarefree order.** Every finite group whose
+    order is squarefree is isomorphic to a semidirect product `N ⋊[φ] H` of two
+    *cyclic* subgroups whose orders are *coprime*. This is precisely the
+    "semidirect product of cyclic groups" structure the open question asks for,
+    now for an arbitrary number of prime factors (the parent entry covered only
+    `n = pq`).
+
+    Concretely `N` may be taken to be the (cyclic) commutator subgroup and `H` a
+    complement isomorphic to the (cyclic) abelianization; coprimality of their
+    orders is what lets Schur–Zassenhaus split the extension. -/
+theorem semidirectProduct_of_squarefree_order (h : Squarefree (Nat.card G)) :
+    ∃ (N H : Subgroup G) (φ : H →* MulAut N) (_ : G ≃* N ⋊[φ] H),
+      IsCyclic H ∧ IsCyclic N ∧ (Nat.card N).Coprime (Nat.card H) :=
+  isZGroup_iff_exists_mulEquiv.mp (isZGroup_of_squarefree_order h)
+
+/-! ## Specialization back to the order-`pq` case -/
+
+/-- Sanity check: a group of order `p * q` with `p, q` distinct primes has
+    squarefree order, so the classification above applies and recovers the parent
+    entry's setting as the two-prime special case. -/
+theorem squarefree_card_of_pq {p q : ℕ} (hp : p.Prime) (hq : q.Prime) (hpq : p ≠ q)
+    (h : Nat.card G = p * q) : Squarefree (Nat.card G) := by
+  rw [h]
+  exact (Nat.squarefree_mul (by simpa using (Nat.coprime_primes hp hq).mpr hpq)).mpr
+    ⟨hp.squarefree, hq.squarefree⟩
+
+end SquarefreeOrderClassification

--- a/research/problems/sylow-theorems-oq-01-oq-02/knowledge.md
+++ b/research/problems/sylow-theorems-oq-01-oq-02/knowledge.md
@@ -1,0 +1,33 @@
+# Knowledge Base: sylow-theorems-oq-01-oq-02
+
+## Problem Understanding
+
+oq-01-oq-02 = openQuestions[2] of sylow-theorems-oq-01 ("Classification of Groups
+of Order pq"): formalize the full squarefree-order classification — every group of
+squarefree order n = p₁···pₖ is a semidirect product of cyclic groups, generalizing
+the pq case.
+
+## Deliverables (verified, 0-axiom)
+
+`Proofs/SylowTheoremOQ01OQ02.lean` — 9 thm / 0 axioms / 0 sorries / 124 lines.
+Routes entirely through Mathlib's `IsZGroup` theory.
+
+- `isZGroup_of_squarefree_order` — IsZGroup.of_squarefree
+- `sylow_isCyclic` — every Sylow subgroup cyclic
+- `isSolvable_of_squarefree_order`
+- `isCyclic_commutator` / `isCyclic_abelianization`
+- `exponent_eq_card`
+- `metacyclic_of_squarefree_order` — cyclic normal commutator + cyclic abelianization
+- `semidirectProduct_of_squarefree_order` — G ≃* N ⋊ H, N,H cyclic, coprime orders
+  (via `isZGroup_iff_exists_mulEquiv`) — THE classification
+- `squarefree_card_of_pq` — recovers the parent two-prime case
+
+## Gotchas
+
+- `IsZGroup.isCyclic_commutator` / `exponent_eq_card` take `G` EXPLICIT.
+- `IsCyclic (G ⧸ commutator G)` doesn't synthesize; use `Abelianization G` (defeq, has instance).
+- `omit [..] in` must precede the docstring, not sit between docstring and theorem.
+
+## Still open
+
+- Explicit count of isomorphism classes via divisibility relations pᵢ ∣ (pⱼ−1).

--- a/research/problems/sylow-theorems-oq-01-oq-02/problem.json
+++ b/research/problems/sylow-theorems-oq-01-oq-02/problem.json
@@ -1,0 +1,55 @@
+{
+  "slug": "sylow-theorems-oq-01-oq-02",
+  "title": "Classification of Groups of Squarefree Order",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{Squarefree}(|G|) \\implies G \\cong N \\rtimes H,\\ N,H \\text{ cyclic},\\ \\gcd(|N|,|H|)=1",
+    "plain": "Every finite group of squarefree order is a semidirect product of two cyclic groups of coprime order; it is solvable, metacyclic, and has exponent equal to its order. Generalizes the parent order-pq classification to any number of prime factors.",
+    "whyMatters": ["Answers open question 2 of sylow-theorems-oq-01 (squarefree-order classification beyond the pq case)."]
+  },
+  "knownResults": {
+    "proven": [
+      "squarefree order implies Z-group (all Sylow subgroups cyclic)",
+      "solvable",
+      "cyclic commutator and cyclic abelianization",
+      "exponent equals order",
+      "metacyclic (cyclic-by-cyclic)",
+      "semidirect product of cyclic groups of coprime order"
+    ],
+    "open": ["explicit count of isomorphism classes via divisibility among the primes"],
+    "goal": "Formalize the squarefree-order classification as a semidirect product of cyclic groups."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: New verified/0-axiom/mathlib entry SylowTheoremOQ01OQ02.lean (9 thm, 0 axioms, 124 lines). Routes through Mathlib IsZGroup theory: IsZGroup.of_squarefree, IsSolvable instance, isCyclic_commutator/abelianization, exponent_eq_card, and isZGroup_iff_exists_mulEquiv for the semidirect-product-of-cyclic-groups classification.",
+    "builtItems": [
+      "isZGroup_of_squarefree_order",
+      "sylow_isCyclic",
+      "isSolvable_of_squarefree_order",
+      "isCyclic_commutator / isCyclic_abelianization",
+      "exponent_eq_card",
+      "metacyclic_of_squarefree_order",
+      "semidirectProduct_of_squarefree_order",
+      "squarefree_card_of_pq"
+    ],
+    "insights": [
+      "Mathlib's Mathlib.GroupTheory.SpecificGroups.ZGroup has IsZGroup.of_squarefree and isZGroup_iff_exists_mulEquiv (G is a finite Z-group iff G is a semidirect product N rtimes H of cyclic subgroups of coprime order) — directly the requested classification.",
+      "IsZGroup.isCyclic_commutator and IsZGroup.exponent_eq_card take G as an EXPLICIT argument.",
+      "IsCyclic (G / commutator G) does not synthesize directly; use Abelianization G (defeq but has the instance).",
+      "[Finite G] / [Group G] linter warnings on theorems where unused: omit ... in must come BEFORE the docstring, not between docstring and theorem (parser error otherwise) — left as harmless warnings here.",
+      "The exact isomorphism-class count (divisibility relations among primes) remains genuinely open."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Explicit count of isomorphism classes of squarefree-order groups.",
+      "Characterize Z-groups of non-squarefree order with the same semidirect structure."
+    ],
+    "markdown": ""
+  },
+  "tags": ["group-theory", "sylow-theorems", "z-groups", "semidirect-product"],
+  "relatedProofs": ["sylow-theorems-oq-01", "sylow-theorems"],
+  "references": {"papers": [], "urls": [], "mathlib": ["IsZGroup.of_squarefree", "isZGroup_iff_exists_mulEquiv", "IsZGroup.isCyclic_commutator"]},
+  "lastUpdate": "2026-06-25T00:00:00.000Z"
+}

--- a/src/data/proofs/sylow-theorems-oq-01-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01-oq-02/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "sylow-theorems-oq-01-oq-02",
+  "slug": "sylow-theorems-oq-01-oq-02",
+  "title": "Classification of Groups of Squarefree Order",
+  "description": "Every finite group of squarefree order n = p₁p₂···pₖ is a semidirect product of two cyclic subgroups of coprime order, and is solvable, metacyclic, and has exponent equal to its order. This generalizes the parent entry's order-pq classification to an arbitrary number of prime factors, via Mathlib's Z-group theory (a Z-group is a finite group whose Sylow subgroups are all cyclic).",
+  "meta": {
+    "author": "Lean Genius (researcher-5)",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "2026",
+    "status": "verified",
+    "badge": "mathlib",
+    "proofRepoPath": "Proofs/SylowTheoremOQ01OQ02.lean",
+    "tags": [
+      "group-theory",
+      "sylow-theorems",
+      "z-groups",
+      "squarefree-order",
+      "semidirect-product",
+      "metacyclic-groups",
+      "solvable-groups"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "lineCount": 124,
+    "mathlib_version": "4.26.0",
+    "assumptions": "0 axioms, 0 sorries. Fully machine-checked; all results depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound).",
+    "originalContributions": [
+      "isZGroup_of_squarefree_order: squarefree order ⇒ every Sylow subgroup is cyclic (Z-group)",
+      "sylow_isCyclic: each Sylow subgroup of a squarefree-order group is cyclic",
+      "isSolvable_of_squarefree_order: groups of squarefree order are solvable",
+      "isCyclic_commutator / isCyclic_abelianization: cyclic commutator subgroup and cyclic abelianization",
+      "exponent_eq_card: the exponent equals the group order",
+      "metacyclic_of_squarefree_order: cyclic normal commutator subgroup with cyclic quotient (cyclic-by-cyclic extension)",
+      "semidirectProduct_of_squarefree_order: G ≃* N ⋊[φ] H with N, H cyclic of coprime order — the full semidirect-product-of-cyclic-groups classification the parent open question asked for",
+      "squarefree_card_of_pq: the order-pq case is the two-prime specialization"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry (sylow-theorems-oq-01, 'Classification of Groups of Order pq') classifies groups of order n = pq by hand using the Sylow counting arguments. Its second open question asks whether the full squarefree-order classification — every group of squarefree order is a semidirect product of cyclic groups — can be formalized for an arbitrary number of prime factors. This entry does so by routing through Mathlib's Z-group theory.",
+    "problemStatement": "Formalize that every finite group of squarefree order n = p₁p₂···pₖ is a semidirect product of cyclic groups, generalizing the order-pq case to multiple primes.",
+    "keyInsights": [
+      "Squarefree order forces every Sylow pᵢ-subgroup to have order exactly pᵢ, hence be cyclic — i.e. the group is a Z-group (IsZGroup.of_squarefree).",
+      "A finite Z-group is solvable, with cyclic commutator subgroup and cyclic abelianization.",
+      "isZGroup_iff_exists_mulEquiv states a finite Z-group is isomorphic to a semidirect product N ⋊ H of two cyclic subgroups of coprime order — exactly the requested structure.",
+      "Concretely N is the cyclic commutator subgroup and H a complement isomorphic to the cyclic abelianization; coprimality of orders lets Schur–Zassenhaus split the extension.",
+      "The exact count of isomorphism classes (determined by the divisibility relations among the pᵢ) is genuinely harder and remains open."
+    ],
+    "prerequisites": [
+      "Sylow theory and Z-groups (cyclic Sylow subgroups)",
+      "Semidirect products and Schur–Zassenhaus splitting",
+      "Commutator subgroups, solvability, group exponent"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reduction",
+      "title": "Squarefree order ⇒ Z-group",
+      "summary": "isZGroup_of_squarefree_order and sylow_isCyclic: every Sylow subgroup is cyclic.",
+      "startLine": 42,
+      "endLine": 60
+    },
+    {
+      "id": "consequences",
+      "title": "Structural consequences",
+      "summary": "Solvable, cyclic commutator, cyclic abelianization, exponent = order.",
+      "startLine": 62,
+      "endLine": 90
+    },
+    {
+      "id": "metacyclic",
+      "title": "Metacyclic structure",
+      "summary": "metacyclic_of_squarefree_order: cyclic normal commutator subgroup with cyclic quotient.",
+      "startLine": 92,
+      "endLine": 100
+    },
+    {
+      "id": "classification",
+      "title": "Semidirect product of cyclic groups",
+      "summary": "semidirectProduct_of_squarefree_order: G ≃* N ⋊ H with N, H cyclic of coprime order.",
+      "startLine": 102,
+      "endLine": 113
+    },
+    {
+      "id": "pq-case",
+      "title": "Specialization to order pq",
+      "summary": "squarefree_card_of_pq: the parent's two-prime case is recovered.",
+      "startLine": 114,
+      "endLine": 124
+    }
+  ],
+  "conclusion": {
+    "summary": "Every finite group of squarefree order is a Z-group, hence solvable, metacyclic, of exponent equal to its order, and — crucially — isomorphic to a semidirect product of two cyclic subgroups of coprime order. This generalizes the parent entry's order-pq classification to arbitrarily many prime factors, as a fully verified (0-axiom) result.",
+    "openQuestions": [
+      "Count the isomorphism classes of groups of squarefree order n = p₁⋯pₖ explicitly in terms of the divisibility relations pᵢ ∣ (pⱼ - 1) (the number of conjugacy classes of homomorphisms determining the semidirect product).",
+      "Formalize the converse direction: a group with all Sylow subgroups cyclic need not have squarefree order, but exhibits the same semidirect structure — characterize when the two coincide."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sylow-theorems-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: classification of groups of order pq. This entry answers its second open question — the general squarefree-order classification."
+    },
+    {
+      "targetId": "sylow-theorems",
+      "relationship": "related",
+      "description": "Foundational Sylow theorems underlying the Z-group reduction."
+    }
+  ],
+  "references": [
+    {
+      "key": "Hall1959",
+      "authors": ["M. Hall"],
+      "title": "The Theory of Groups",
+      "venue": "Macmillan",
+      "year": "1959",
+      "note": "Classical treatment of Z-groups (groups with cyclic Sylow subgroups) and their metacyclic structure."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/SylowTheoremOQ01OQ02.lean",
+    "filePath": "Proofs/SylowTheoremOQ01OQ02.lean",
+    "imports": ["Mathlib"],
+    "opens": ["Classical"],
+    "namespace": "SquarefreeOrderClassification",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/sylow-theorems-oq-01-oq-02.json
+++ b/src/data/research/problems/sylow-theorems-oq-01-oq-02.json
@@ -1,0 +1,55 @@
+{
+  "slug": "sylow-theorems-oq-01-oq-02",
+  "title": "Classification of Groups of Squarefree Order",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{Squarefree}(|G|) \\implies G \\cong N \\rtimes H,\\ N,H \\text{ cyclic},\\ \\gcd(|N|,|H|)=1",
+    "plain": "Every finite group of squarefree order is a semidirect product of two cyclic groups of coprime order; it is solvable, metacyclic, and has exponent equal to its order. Generalizes the parent order-pq classification to any number of prime factors.",
+    "whyMatters": ["Answers open question 2 of sylow-theorems-oq-01 (squarefree-order classification beyond the pq case)."]
+  },
+  "knownResults": {
+    "proven": [
+      "squarefree order implies Z-group (all Sylow subgroups cyclic)",
+      "solvable",
+      "cyclic commutator and cyclic abelianization",
+      "exponent equals order",
+      "metacyclic (cyclic-by-cyclic)",
+      "semidirect product of cyclic groups of coprime order"
+    ],
+    "open": ["explicit count of isomorphism classes via divisibility among the primes"],
+    "goal": "Formalize the squarefree-order classification as a semidirect product of cyclic groups."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: New verified/0-axiom/mathlib entry SylowTheoremOQ01OQ02.lean (9 thm, 0 axioms, 124 lines). Routes through Mathlib IsZGroup theory: IsZGroup.of_squarefree, IsSolvable instance, isCyclic_commutator/abelianization, exponent_eq_card, and isZGroup_iff_exists_mulEquiv for the semidirect-product-of-cyclic-groups classification.",
+    "builtItems": [
+      "isZGroup_of_squarefree_order",
+      "sylow_isCyclic",
+      "isSolvable_of_squarefree_order",
+      "isCyclic_commutator / isCyclic_abelianization",
+      "exponent_eq_card",
+      "metacyclic_of_squarefree_order",
+      "semidirectProduct_of_squarefree_order",
+      "squarefree_card_of_pq"
+    ],
+    "insights": [
+      "Mathlib's Mathlib.GroupTheory.SpecificGroups.ZGroup has IsZGroup.of_squarefree and isZGroup_iff_exists_mulEquiv (G is a finite Z-group iff G is a semidirect product N rtimes H of cyclic subgroups of coprime order) — directly the requested classification.",
+      "IsZGroup.isCyclic_commutator and IsZGroup.exponent_eq_card take G as an EXPLICIT argument.",
+      "IsCyclic (G / commutator G) does not synthesize directly; use Abelianization G (defeq but has the instance).",
+      "[Finite G] / [Group G] linter warnings on theorems where unused: omit ... in must come BEFORE the docstring, not between docstring and theorem (parser error otherwise) — left as harmless warnings here.",
+      "The exact isomorphism-class count (divisibility relations among primes) remains genuinely open."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Explicit count of isomorphism classes of squarefree-order groups.",
+      "Characterize Z-groups of non-squarefree order with the same semidirect structure."
+    ],
+    "markdown": ""
+  },
+  "tags": ["group-theory", "sylow-theorems", "z-groups", "semidirect-product"],
+  "relatedProofs": ["sylow-theorems-oq-01", "sylow-theorems"],
+  "references": {"papers": [], "urls": [], "mathlib": ["IsZGroup.of_squarefree", "isZGroup_iff_exists_mulEquiv", "IsZGroup.isCyclic_commutator"]},
+  "lastUpdate": "2026-06-25T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

Answers **open question 2** of `sylow-theorems-oq-01` ("Classification of Groups of Order pq"):

> Can the full squarefree-order classification be formalized? Every group of squarefree order n = p₁p₂···pₖ is a semidirect product of cyclic groups... a generalization of the pq case to multiple primes.

The parent entry handles `n = pq` by hand. This entry formalizes the **general squarefree case** for any number of prime factors, via Mathlib's `IsZGroup` theory (a Z-group = finite group all of whose Sylow subgroups are cyclic).

## New file `Proofs/SylowTheoremOQ01OQ02.lean`

9 theorems, **0 axioms, 0 sorries**, 124 lines:

- `isZGroup_of_squarefree_order` — squarefree order ⇒ every Sylow subgroup cyclic.
- `sylow_isCyclic` — each Sylow subgroup is cyclic.
- `isSolvable_of_squarefree_order` — such groups are solvable.
- `isCyclic_commutator`, `isCyclic_abelianization`, `exponent_eq_card`.
- `metacyclic_of_squarefree_order` — cyclic normal commutator subgroup with cyclic quotient.
- **`semidirectProduct_of_squarefree_order`** — `G ≃* N ⋊[φ] H` with `N, H` cyclic of coprime order: precisely the "semidirect product of cyclic groups" structure the open question asks for.
- `squarefree_card_of_pq` — recovers the parent's order-pq setting as the two-prime case.

## Axiom integrity & honest scope

`#print axioms` on every result lists only `propext`, `Classical.choice`, `Quot.sound` — **fully verified, 0 axioms, 0 sorries**. Status `verified` / badge `mathlib` (the deep Z-group structure theory lives in Mathlib; the contribution is assembling it into the squarefree classification the parent left open).

The exact **count of isomorphism classes** (determined by divisibility relations `pᵢ ∣ (pⱼ−1)`) is genuinely harder and is left as a documented open question. Builds clean via host `lake env lean`; aggregator import added (alpha-sorted).

## Status
**Outcome**: completed

🤖 Generated by researcher-5