### PR TITLE
Gallery audit: 2 entries clean (stirling central-binom asymptotic, sylow squarefree classification)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23509,8 +23509,22 @@
       "issues": [],
       "lastAudited": "2026-06-25T07:27:00Z",
       "result": "clean"
+    },
+    "stirling-formula-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:00:00Z",
+      "result": "clean",
+      "notes": "verified/original/0-axiom/0-sorry all accurate. 7 theorems + 1 def (cb=real central binom), 128 lines, 0 sorry/admit/axiom/native_decide/True-stub. Genuine new result: central binomial asymptotic C(2n,n)~4ⁿ/√(πn) (centralBinom_asymptotic), NOT stated by Mathlib. Reliance on Mathlib Wallis (W_eq_factorial_ratio, tendsto_W_nhds_pi_div_two, choose_mul_factorial_mul_factorial) fully disclosed in docstring, overview AND originalContributions → original badge defensible. #print axioms = propext/Classical.choice/Quot.sound only."
+    },
+    "sylow-theorems-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:00:00Z",
+      "result": "clean",
+      "notes": "verified/mathlib/0-axiom/0-sorry all accurate. 9 theorems + 0 defs, 124 lines, 0 sorry/admit/axiom/native_decide/True-stub. Squarefree-order classification assembled from Mathlib IsZGroup theory (of_squarefree, isZGroup_iff_exists_mulEquiv, Schur-Zassenhaus). Badge=mathlib CORRECT; docstring has explicit Honest scope section + overview discloses routing through Mathlib Z-group theory. Counts match meta; deeper iso-class-count remains open (disclosed)."
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T07:27:00Z"
+  "lastUpdated": "2026-06-25T08:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 2 remaining never-audited gallery entries not already covered by open audit PRs #29808 / #29818. Both **CLEAN** — public claims match the Lean kernel.

| Slug | Status/Badge | thm/def | Lines | Verdict |
|------|--------------|---------|-------|---------|
| `stirling-formula-oq-03-oq-02` | verified/original | 7 / 1 | 128 | clean |
| `sylow-theorems-oq-01-oq-02` | verified/mathlib | 9 / 0 | 124 | clean |

### stirling-formula-oq-03-oq-02
- 0 sorry / admit / axiom / native_decide / True-stub. `#print axioms` = propext / Classical.choice / Quot.sound only.
- Headline `centralBinom_asymptotic`: `C(2n,n)·√(πn)/4ⁿ → 1`, i.e. `C(2n,n) ~ 4ⁿ/√(πn)` — a genuine new statement **not** in Mathlib.
- Built on Mathlib's Wallis machinery (`W_eq_factorial_ratio`, `tendsto_W_nhds_pi_div_two`, `choose_mul_factorial_mul_factorial`). This reliance is disclosed in the docstring, the overview ("obtained directly from Mathlib's factorial form of the Wallis sequence"), and per-contribution notes → `original` badge defensible (the assembled asymptotic is the new work).
- theoremCount 7 + definitionCount 1 match meta.

### sylow-theorems-oq-01-oq-02
- 0 sorry / admit / axiom / native_decide / True-stub.
- Squarefree-order classification (every group of squarefree order ≅ semidirect product of cyclic groups) assembled from Mathlib `IsZGroup` theory (`IsZGroup.of_squarefree`, `isZGroup_iff_exists_mulEquiv`, Schur–Zassenhaus).
- File has an explicit **"Honest scope"** section ("The hard mathematics ... lives in Mathlib. The contribution here is to assemble it"); overview discloses routing through Mathlib Z-group theory. `mathlib` badge is correct.
- The harder iso-class-count ("structure determined by divisibility relations among the pᵢ") is correctly left open and disclosed.
- theoremCount 9 + definitionCount 0 match meta.

Tracker updated; both recorded as `clean`.

---
Discovered during gallery integrity audit.