### PR TITLE
research(dini-theorem-oq-01-oq-02): sharp modulus of non-uniform convergence of xⁿ on [0,1) is exactly 1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1010,6 +1010,7 @@ import Proofs.DilworthTheoremOQ01
 import Proofs.DilworthTheoremOQ01OQ01OQ02
 import Proofs.DiniTheorem
 import Proofs.DiniTheoremOQ01OQ01
+import Proofs.DiniTheoremOQ01OQ02
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
 import Proofs.DirichletApproximationOQ01OQ01

--- a/proofs/Proofs/DiniTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/DiniTheoremOQ01OQ02.lean
@@ -1,0 +1,172 @@
+import Mathlib
+
+/-
+# Dini's Theorem — OQ-01-OQ-02: The Sharp Modulus of Non-Uniform Convergence of xⁿ on [0,1)
+
+## Research Problem: dini-theorem-oq-01-oq-02
+
+The parent file `DiniTheorem.lean` re-exports Dini's theorem and studies the sharpness of
+its hypotheses with the witness sequence `fₙ(x) = xⁿ`.  On the non-compact interval `[0,1)`
+this sequence is continuous, monotone (antitone) in `n`, and converges pointwise to the
+continuous function `0`, yet the convergence is **not uniform** — Dini fails because the
+domain is not compact.  The parent established non-uniformity quantitatively but with a
+*non-sharp* bound: it exhibited, for each `n`, a point of `[0,1)` where `xⁿ ≥ 1/2`, so the
+uniform error stays `≥ 1/2`.
+
+This file answers the parent's open question OQ-02:
+
+> Does a quantitative refinement hold: on `[0,1)` the uniform distance `sup_x |xⁿ|` stays
+> exactly `1`, giving an explicit lower bound on the modulus of non-uniform convergence
+> rather than the value `1/2` used here?
+
+**Answer: yes — the sharp modulus is exactly `1`.**
+
+## What is proved
+
+* `pow_image_Ico_isLUB` — for every `n ≥ 1`, the least upper bound of `{ xⁿ : x ∈ [0,1) }`
+  is `1`.  The supremum is *not attained* (every `xⁿ < 1`), but it is approached along
+  `x = 1 − 1/(k+1) → 1`.
+* `pow_sSup_Ico` — hence `sSup { xⁿ : x ∈ [0,1) } = 1`.
+* `pow_uniform_error_Ico` — the headline: the uniform error
+  `sSup_{x∈[0,1)} |xⁿ − 0| = 1` for every `n ≥ 1`, i.e. the modulus of non-uniform
+  convergence is exactly `1`, sharpening the parent's `1/2`.
+* `pow_exists_gt_of_lt_one` — the LUB unpacked: for any `c < 1` and `n ≥ 1` there is a point
+  of `[0,1)` with `xⁿ > c`.
+* `pow_not_tendstoUniformlyOn_Ico_sharp` — the sharpened non-uniformity: the convergence
+  fails to be uniform with **any** threshold `c ∈ (0,1)`, not merely `1/2`.
+
+The point is that `1` is the *exact* supremum: it cannot be improved (each `xⁿ < 1`, so no
+value `> 1` is even an upper bound, and no value `< 1` is an upper bound either).
+
+Tags: analysis, dini, uniform-convergence, supremum, sharpness, wiedijk
+-/
+
+namespace DiniTheoremOQ01OQ02
+
+open Set Filter Topology
+
+-- ============================================================
+-- Part I: The supremum of xⁿ over [0,1) is exactly 1
+-- ============================================================
+
+/-- **The least upper bound of `{ xⁿ : x ∈ [0,1) }` is `1`** (for `n ≥ 1`).
+
+    Upper bound: every `x ∈ [0,1)` has `xⁿ ≤ 1`.  Least: any upper bound `b` satisfies
+    `1 ≤ b`, because the points `xₖ = 1 − 1/(k+1) ∈ [0,1)` give `xₖⁿ → 1`, and each
+    `xₖⁿ ≤ b`, so the limit `1 ≤ b`.  The supremum is therefore `1`, even though it is
+    never attained (`xⁿ < 1` for all `x ∈ [0,1)`). -/
+theorem pow_image_Ico_isLUB (n : ℕ) (hn : 1 ≤ n) :
+    IsLUB ((fun x : ℝ => x ^ n) '' Ico (0 : ℝ) 1) 1 := by
+  constructor
+  · -- `1` is an upper bound: `xⁿ ≤ 1` on `[0,1)`.
+    rintro y ⟨x, hx, rfl⟩
+    exact pow_le_one₀ hx.1 (le_of_lt hx.2)
+  · -- `1` is the least upper bound: any upper bound `b` has `1 ≤ b`.
+    intro b hb
+    -- `xₖ = 1 − 1/(k+1) → 1`, hence `xₖⁿ → 1`.
+    have hzero : Tendsto (fun k : ℕ => (1 : ℝ) / ((k : ℝ) + 1)) atTop (𝓝 0) :=
+      tendsto_one_div_add_atTop_nhds_zero_nat
+    have hbase : Tendsto (fun k : ℕ => (1 : ℝ) - 1 / ((k : ℝ) + 1)) atTop (𝓝 1) := by
+      simpa using (tendsto_const_nhds.sub hzero)
+    have hseq : Tendsto (fun k : ℕ => ((1 : ℝ) - 1 / ((k : ℝ) + 1)) ^ n) atTop (𝓝 1) := by
+      simpa using hbase.pow n
+    refine le_of_tendsto' hseq ?_
+    intro k
+    -- each `xₖⁿ` is in the image, so is `≤ b`.
+    apply hb
+    have hk : (0 : ℝ) < (k : ℝ) + 1 := by positivity
+    refine ⟨1 - 1 / ((k : ℝ) + 1), ⟨?_, ?_⟩, rfl⟩
+    · -- `0 ≤ xₖ`
+      rw [sub_nonneg, div_le_one hk]
+      have := Nat.cast_nonneg (α := ℝ) k; linarith
+    · -- `xₖ < 1`
+      have hpos : (0 : ℝ) < 1 / ((k : ℝ) + 1) := by positivity
+      linarith
+
+/-- The set `{ xⁿ : x ∈ [0,1) }` is nonempty (contains `0ⁿ = 0`, as `n ≥ 1`). -/
+theorem pow_image_Ico_nonempty (n : ℕ) :
+    ((fun x : ℝ => x ^ n) '' Ico (0 : ℝ) 1).Nonempty :=
+  ⟨(0 : ℝ) ^ n, 0, ⟨le_refl 0, zero_lt_one⟩, rfl⟩
+
+/-- **The supremum of `xⁿ` over `[0,1)` equals `1`** (for `n ≥ 1`). -/
+theorem pow_sSup_Ico (n : ℕ) (hn : 1 ≤ n) :
+    sSup ((fun x : ℝ => x ^ n) '' Ico (0 : ℝ) 1) = 1 :=
+  (pow_image_Ico_isLUB n hn).csSup_eq (pow_image_Ico_nonempty n)
+
+-- ============================================================
+-- Part II: The sharp modulus of non-uniform convergence
+-- ============================================================
+
+/-- **The sharp modulus is `1`.**  For every `n ≥ 1`, the uniform error of `xⁿ` against its
+    pointwise limit `0` on `[0,1)`,
+
+        sup_{x ∈ [0,1)} |xⁿ − 0|,
+
+    equals exactly `1` — the sharp refinement of the parent's lower bound `1/2`.
+
+    On `[0,1)` the error `|xⁿ − 0| = xⁿ` (it is nonnegative), so the error-image coincides
+    with `{ xⁿ : x ∈ [0,1) }`, whose supremum is `1` by `pow_sSup_Ico`. -/
+theorem pow_uniform_error_Ico (n : ℕ) (hn : 1 ≤ n) :
+    sSup ((fun x : ℝ => |x ^ n - 0|) '' Ico (0 : ℝ) 1) = 1 := by
+  have himg : (fun x : ℝ => |x ^ n - 0|) '' Ico (0 : ℝ) 1
+      = (fun x : ℝ => x ^ n) '' Ico (0 : ℝ) 1 := by
+    apply Set.image_congr
+    intro x hx
+    rw [sub_zero, abs_of_nonneg (pow_nonneg hx.1 n)]
+  rw [himg]
+  exact pow_sSup_Ico n hn
+
+/-- **The LUB, unpacked.**  Since `1` is the *least* upper bound, no `c < 1` is an upper
+    bound: for any `c < 1` and `n ≥ 1` there is a point of `[0,1)` with `xⁿ > c`. -/
+theorem pow_exists_gt_of_lt_one (n : ℕ) (hn : 1 ≤ n) {c : ℝ} (hc : c < 1) :
+    ∃ x ∈ Ico (0 : ℝ) 1, c < x ^ n := by
+  by_contra h
+  push_neg at h
+  -- `c` would be an upper bound of the image, forcing `1 ≤ c`, contradicting `c < 1`.
+  have hub : c ∈ upperBounds ((fun x : ℝ => x ^ n) '' Ico (0 : ℝ) 1) := by
+    rintro y ⟨x, hx, rfl⟩
+    exact h x hx
+  have : (1 : ℝ) ≤ c := (pow_image_Ico_isLUB n hn).2 hub
+  linarith
+
+/-- **Sharpened non-uniformity.**  The convergence `xⁿ → 0` on `[0,1)` fails to be uniform
+    with **any** threshold `c ∈ (0,1)` — not merely the parent's `1/2`.  Concretely, for
+    every `c ∈ (0,1)` and every `N`, there is `n ≥ N` and a point `x ∈ [0,1)` whose error
+    `|xⁿ − 0|` exceeds `c`.  Taking `c ↑ 1` recovers the sharp modulus. -/
+theorem pow_not_tendstoUniformlyOn_Ico_sharp {c : ℝ} (hc0 : 0 < c) (hc1 : c < 1) :
+    ¬ TendstoUniformlyOn (fun n (x : ℝ) => x ^ n) (fun _ => (0 : ℝ)) atTop (Ico (0 : ℝ) 1) := by
+  rw [Metric.tendstoUniformlyOn_iff]
+  push_neg
+  refine ⟨c, hc0, ?_⟩
+  rw [Filter.frequently_atTop]
+  intro N
+  refine ⟨N + 1, le_self_add, ?_⟩
+  obtain ⟨x, hx, hxc⟩ := pow_exists_gt_of_lt_one (N + 1) (Nat.le_add_left 1 N) hc1
+  refine ⟨x, hx, ?_⟩
+  have hx0 : (0 : ℝ) ≤ x ^ (N + 1) := pow_nonneg hx.1 _
+  show c ≤ dist (0 : ℝ) (x ^ (N + 1))
+  rw [Real.dist_eq, zero_sub, abs_neg, abs_of_nonneg hx0]
+  linarith [hxc]
+
+#check @pow_image_Ico_isLUB
+#check @pow_sSup_Ico
+#check @pow_uniform_error_Ico
+#check @pow_not_tendstoUniformlyOn_Ico_sharp
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms — self-contained, imports only Mathlib):
+
+* `pow_image_Ico_isLUB` / `pow_sSup_Ico` — `sup_{x∈[0,1)} xⁿ = 1` (LUB, never attained).
+* `pow_uniform_error_Ico` — the sharp modulus: `sup_{x∈[0,1)} |xⁿ − 0| = 1` for all `n ≥ 1`.
+* `pow_exists_gt_of_lt_one` — for any `c < 1`, some `x ∈ [0,1)` has `xⁿ > c`.
+* `pow_not_tendstoUniformlyOn_Ico_sharp` — non-uniformity with any threshold `c ∈ (0,1)`.
+
+This answers `dini-theorem-oq-01-oq-02`: the modulus of non-uniform convergence of `xⁿ` on
+`[0,1)` is exactly `1`, sharpening the parent's `1/2`.  The supremum is approached along
+`x = 1 − 1/(k+1) → 1` but never attained, which is precisely why Dini's compactness
+hypothesis cannot be dropped on `[0,1)`.
+-/
+
+end DiniTheoremOQ01OQ02

--- a/src/data/proofs/dini-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "dini-oq0102-ann-overview",
+    "proofId": "dini-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "concept",
+    "title": "The Sharp Modulus Question",
+    "content": "The header frames OQ-02. The parent (dini-theorem-oq-01) uses xⁿ on the non-compact [0,1) as a witness that Dini's compactness hypothesis is necessary: xⁿ is continuous, antitone in n, and converges pointwise to the continuous function 0, yet not uniformly. The parent's non-uniformity bound was the non-sharp 1/2 (a value attained via the intermediate value theorem). This file asks for the exact modulus: the uniform error sup_x |xⁿ| on [0,1), and proves it equals exactly 1.",
+    "mathContext": "$\\sup_{x\\in[0,1)}|x^n-0| = 1$ for every $n\\ge 1$ — sharpening the parent's $1/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Dini's theorem", "uniform convergence", "compactness", "supremum"],
+    "prerequisites": ["pointwise vs uniform convergence", "supremum / least upper bound"]
+  },
+  {
+    "id": "dini-oq0102-ann-lub",
+    "proofId": "dini-theorem-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 105 },
+    "type": "insight",
+    "title": "The Supremum of xⁿ over [0,1) is Exactly 1",
+    "content": "pow_image_Ico_isLUB proves IsLUB { xⁿ : x ∈ [0,1) } 1 for n ≥ 1. Upper bound: x ∈ [0,1) ⟹ xⁿ ≤ 1 (pow_le_one₀). Least: for any upper bound b, the explicit sequence xₖ = 1 − 1/(k+1) lies in [0,1) and tends to 1 (since 1/(k+1) → 0 via tendsto_one_div_add_atTop_nhds_zero_nat), so xₖⁿ → 1ⁿ = 1; each xₖⁿ ≤ b, and le_of_tendsto' passes to the limit to give 1 ≤ b. Hence 1 is the least upper bound and pow_sSup_Ico concludes sSup = 1 (IsLUB.csSup_eq on the nonempty image). Crucially the supremum is never attained — every xⁿ < 1 — which is the analytic signature of the missing compactness.",
+    "mathContext": "$\\operatorname{IsLUB}\\{x^n : x\\in[0,1)\\}\\,1$; approached along $x_k=1-\\tfrac{1}{k+1}\\to 1$, never attained.",
+    "significance": "critical",
+    "relatedConcepts": ["least upper bound", "passing to the limit", "approximating sequence"],
+    "prerequisites": ["limits of sequences", "monotone power functions"]
+  },
+  {
+    "id": "dini-oq0102-ann-modulus",
+    "proofId": "dini-theorem-oq-01-oq-02",
+    "range": { "startLine": 106, "endLine": 172 },
+    "type": "insight",
+    "title": "The Sharp Modulus and Sharpened Non-Uniformity",
+    "content": "pow_uniform_error_Ico reads off the headline: since |xⁿ − 0| = xⁿ on [0,1) (image_congr after abs_of_nonneg), the error-supremum equals the xⁿ-supremum, namely 1 — the exact modulus of non-uniform convergence. pow_exists_gt_of_lt_one unpacks the LUB: any c < 1 fails to be an upper bound, so some x ∈ [0,1) has xⁿ > c. Feeding this into the negated ε-criterion (Metric.tendstoUniformlyOn_iff) gives pow_not_tendstoUniformlyOn_Ico_sharp: the convergence is non-uniform with ANY threshold c ∈ (0,1), not merely the parent's 1/2.",
+    "mathContext": "For all $c\\in(0,1)$ and $N$, some $n\\ge N$ and $x\\in[0,1)$ have $|x^n-0|>c$; taking $c\\uparrow 1$ gives the sharp modulus.",
+    "significance": "critical",
+    "relatedConcepts": ["modulus of convergence", "uniform convergence criterion", "sharpness"],
+    "prerequisites": ["ε-N definition of uniform convergence", "least upper bound"]
+  }
+]

--- a/src/data/proofs/dini-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "dini-theorem-oq-01-oq-02",
+  "title": "The Sharp Modulus of Non-Uniform Convergence of xⁿ on [0,1)",
+  "slug": "dini-theorem-oq-01-oq-02",
+  "description": "Sharpens the parent Dini sharpness witness: on the non-compact interval [0,1), the sequence xⁿ converges pointwise to 0 but not uniformly, and the uniform error sup_{x∈[0,1)} |xⁿ| equals exactly 1 for every n ≥ 1 — the sharp modulus of non-uniform convergence, improving the parent's lower bound of 1/2. The supremum is approached along x = 1 − 1/(k+1) → 1 but never attained. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DiniTheoremOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "dini",
+      "uniform-convergence",
+      "supremum",
+      "sharpness",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 172,
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/DiniTheoremOQ01OQ02.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for pow_uniform_error_Ico and pow_not_tendstoUniformlyOn_Ico_sharp. The file imports only Mathlib and is self-contained.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsLUB.csSup_eq",
+        "description": "an IsLUB witness equals the sSup on a nonempty set",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "le_of_tendsto'",
+        "description": "if f → a and f n ≤ b for all n, then a ≤ b — used to pass to the limit along x = 1 − 1/(k+1)",
+        "module": "Mathlib.Order.Topology.Basic"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0, the source of the approximating sequence 1 − 1/(k+1) → 1",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "pow_le_one₀",
+        "description": "0 ≤ a, a ≤ 1 ⟹ aⁿ ≤ 1 — the upper-bound half of the LUB",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Metric.tendstoUniformlyOn_iff",
+        "description": "ε-characterization of uniform convergence on a set, negated for the non-uniformity witness",
+        "module": "Mathlib.Topology.UniformSpace.UniformConvergence"
+      }
+    ],
+    "originalContributions": [
+      "pow_image_Ico_isLUB: the least upper bound of { xⁿ : x ∈ [0,1) } is exactly 1 (for n ≥ 1), proved by approaching it along x = 1 − 1/(k+1) → 1 and passing to the limit",
+      "pow_sSup_Ico: sSup { xⁿ : x ∈ [0,1) } = 1, the supremum that is never attained",
+      "pow_uniform_error_Ico: the sharp modulus — sup_{x∈[0,1)} |xⁿ − 0| = 1 for every n ≥ 1, improving the parent's 1/2",
+      "pow_exists_gt_of_lt_one: for any c < 1, a point of [0,1) with xⁿ > c (the LUB unpacked)",
+      "pow_not_tendstoUniformlyOn_Ico_sharp: non-uniformity with ANY threshold c ∈ (0,1), not merely 1/2"
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Dini's theorem gives a compactness condition under which pointwise convergence of a monotone sequence of continuous functions to a continuous limit is automatically uniform. The parent entry (dini-theorem-oq-01) studies the sharpness of its hypotheses with the textbook witness fₙ(x) = xⁿ: on the compact [0,1] the limit is discontinuous (so uniformity fails through the continuity-of-limit obstruction), while on the non-compact [0,1) the limit 0 is continuous yet uniformity still fails — showing compactness of the domain cannot be dropped. The parent quantified the [0,1) failure with the non-sharp bound 1/2. This entry (OQ-02) determines the exact modulus.",
+    "problemStatement": "Does a quantitative refinement hold: on [0,1) the uniform distance sup_x |xⁿ| stays exactly 1, giving an explicit lower bound on the modulus of non-uniform convergence rather than the value 1/2 used in the parent?",
+    "text": "Proves sup_{x∈[0,1)} xⁿ = 1 (a least upper bound, never attained), hence the uniform error sup_{x∈[0,1)} |xⁿ − 0| = 1 for every n ≥ 1, and that non-uniformity holds with any threshold c ∈ (0,1).",
+    "proofStrategy": "The crux is the least-upper-bound computation pow_image_Ico_isLUB. Upper bound: for x ∈ [0,1), xⁿ ≤ 1 (pow_le_one₀). Least: for any upper bound b, the points xₖ = 1 − 1/(k+1) ∈ [0,1) satisfy xₖ → 1 (from 1/(k+1) → 0), hence xₖⁿ → 1ⁿ = 1; since each xₖⁿ ≤ b, passing to the limit (le_of_tendsto') gives 1 ≤ b. Thus 1 is the LUB and sSup = 1 (IsLUB.csSup_eq). The error sup equals the xⁿ sup because |xⁿ − 0| = xⁿ on [0,1) (image_congr). Finally, c < 1 = LUB means c is not an upper bound, giving a point with xⁿ > c, which feeds the negated ε-criterion of uniform convergence for every threshold c ∈ (0,1).",
+    "keyInsights": [
+      "The exact modulus is 1, not 1/2: the parent's IVT argument produced an attained value 1/2, but the true supremum of the error is the unattained 1.",
+      "The supremum is approached but never attained — every xⁿ < 1 on [0,1), while x = 1 − 1/(k+1) → 1 drives xⁿ → 1. This 'approached-but-not-attained' behaviour is exactly the failure of compactness that Dini's theorem rules out.",
+      "Sharpness is a least-upper-bound statement: 1 cannot be lowered (no c < 1 is an upper bound) nor is it exceeded (no value > 1 occurs), so it is the precise modulus.",
+      "Passing to the limit along an explicit sequence (le_of_tendsto') turns the supremum into a clean, fully constructive computation, avoiding any appeal to the abstract structure of conditionally complete lattices beyond IsLUB.csSup_eq.",
+      "Once the LUB is in hand, every downstream statement — the error sup, the for-all-c<1 threshold, the negated uniform-convergence criterion — is a short corollary."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-setup",
+      "title": "Problem Statement and Setup",
+      "summary": "Module docstring framing OQ-02 (the sharp modulus 1 vs the parent's 1/2), the witness xⁿ on [0,1), and the namespace/imports (Mathlib; open Set Filter Topology)",
+      "startLine": 1,
+      "endLine": 52
+    },
+    {
+      "id": "supremum-is-one",
+      "title": "The Supremum of xⁿ over [0,1) is Exactly 1",
+      "summary": "pow_image_Ico_isLUB (least upper bound 1 via the approaching sequence x = 1 − 1/(k+1)), pow_image_Ico_nonempty, and pow_sSup_Ico (sSup = 1)",
+      "startLine": 53,
+      "endLine": 105
+    },
+    {
+      "id": "sharp-modulus",
+      "title": "The Sharp Modulus of Non-Uniform Convergence",
+      "summary": "pow_uniform_error_Ico (sup of |xⁿ − 0| = 1), pow_exists_gt_of_lt_one (any c < 1 is exceeded), and pow_not_tendstoUniformlyOn_Ico_sharp (non-uniformity with any threshold c ∈ (0,1))",
+      "startLine": 106,
+      "endLine": 172
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; self-contained, imports only Mathlib): the modulus of non-uniform convergence of xⁿ on [0,1) is exactly 1. The supremum sup_{x∈[0,1)} xⁿ = 1 is a least upper bound approached along x = 1 − 1/(k+1) → 1 but never attained, so the uniform error sup_{x∈[0,1)} |xⁿ − 0| = 1 for every n ≥ 1, sharpening the parent's 1/2; non-uniformity holds with any threshold c ∈ (0,1).",
+    "implications": "The exact modulus pins down precisely how badly uniform convergence fails on the non-compact domain, confirming that Dini's compactness hypothesis cannot be relaxed on [0,1). The least-upper-bound-via-approaching-sequence pattern (upper bound + le_of_tendsto' along an explicit sequence + IsLUB.csSup_eq) is a reusable recipe for computing unattained suprema of pointwise limits.",
+    "openQuestions": [
+      "Rate of approach: quantify how fast sup_{x∈[0,1−δ]} xⁿ → 0 as the domain is shrunk to a compact subinterval [0,1−δ], recovering uniform convergence with an explicit modulus in δ and n.",
+      "General monotone families: for a continuous, antitone-in-n family converging pointwise to 0 on [0,1) with discontinuous-at-1 'limit envelope', is the uniform-error supremum always the boundary value, and when is it attained?",
+      "Higher-dimensional or operator analogues: identify the sharp non-uniformity modulus for xⁿ-type contractions on non-compact subsets of a Banach space."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dini-theorem-oq-01",
+      "relationship": "parent-problem",
+      "description": "Parent: Dini's theorem and the sharpness of its hypotheses; established non-uniformity of xⁿ on [0,1) with the non-sharp bound 1/2 that this entry improves to 1"
+    },
+    {
+      "targetId": "dini-theorem-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling open question of the same parent witness"
+    },
+    {
+      "targetId": "dini-theorem",
+      "relationship": "related",
+      "description": "The base Dini's theorem (uniform convergence of monotone sequences on compact sets) whose compactness hypothesis this sharpness witness shows to be necessary"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ulisse Dini"
+      ],
+      "title": "Fondamenti per la teorica delle funzioni di variabili reali",
+      "year": "1878",
+      "venue": "Pisa",
+      "note": "Origin of Dini's theorem"
+    },
+    {
+      "authors": [
+        "Walter Rudin"
+      ],
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "note": "Theorem 7.13 (Dini) and the xⁿ counterexample on [0,1)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DiniTheoremOQ01OQ02",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/DiniTheoremOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/dini-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/dini-theorem-oq-01-oq-02.json
@@ -1,0 +1,113 @@
+{
+  "slug": "dini-theorem-oq-01-oq-02",
+  "title": "The Sharp Modulus of Non-Uniform Convergence of xⁿ on [0,1)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For every n ≥ 1, sSup { xⁿ : x ∈ [0,1) } = 1 (a least upper bound, never attained), hence sup_{x∈[0,1)} |xⁿ − 0| = 1; and xⁿ → 0 on [0,1) fails to converge uniformly with any threshold c ∈ (0,1).",
+    "plain": "On the non-compact interval [0,1), the sequence xⁿ converges pointwise to 0 but not uniformly. The exact modulus of this non-uniform convergence is sup_x |xⁿ| = 1 (not the 1/2 the parent used). The supremum is approached along x = 1 − 1/(k+1) → 1 but never attained.",
+    "whyMatters": [
+      "Answers the parent's open question OQ-02: the sharp modulus is exactly 1, improving the parent's 1/2",
+      "The unattained supremum is the analytic signature of the missing compactness that Dini's theorem requires",
+      "Provides a reusable recipe for computing unattained suprema of pointwise limits (upper bound + le_of_tendsto' along an explicit sequence + IsLUB.csSup_eq)"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "xⁿ → 0 pointwise on [0,1) but not uniformly, error ≥ 1/2 (DiniTheorem.lean)"
+    ],
+    "open": [],
+    "goal": "Determine the exact uniform-error supremum sup_{x∈[0,1)} |xⁿ| and show it equals 1."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Saturated and machine-verified: sup = 1 via IsLUB, sharp modulus, and sharpened non-uniformity, 0 sorry/0 axiom, registered in Proofs.lean, gallery entry verified/original.",
+    "blockers": [],
+    "nextAction": "None required. Optional: quantify the rate sup_{x∈[0,1−δ]} xⁿ → 0 as the domain shrinks to a compact subinterval.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "MATH COMPLETE. Proved sSup { xⁿ : x ∈ [0,1) } = 1 (IsLUB, unattained), hence the uniform error sup_{x∈[0,1)} |xⁿ − 0| = 1 for all n ≥ 1, and non-uniformity with any threshold c ∈ (0,1). Self-contained (imports only Mathlib); lake env lean exits 0; #print axioms reports only propext/Classical.choice/Quot.sound. Gallery meta + annotations written. Status verified/original.",
+    "builtItems": [
+      "pow_image_Ico_isLUB (IsLUB { xⁿ : x ∈ [0,1) } 1 for n ≥ 1, via approaching sequence x = 1 − 1/(k+1) → 1 and le_of_tendsto')",
+      "pow_image_Ico_nonempty (image contains 0ⁿ = 0)",
+      "pow_sSup_Ico (sSup = 1 via IsLUB.csSup_eq)",
+      "pow_uniform_error_Ico (sup_{x∈[0,1)} |xⁿ − 0| = 1, the sharp modulus)",
+      "pow_exists_gt_of_lt_one (for any c < 1, a point with xⁿ > c)",
+      "pow_not_tendstoUniformlyOn_Ico_sharp (non-uniformity with any threshold c ∈ (0,1))"
+    ],
+    "insights": [
+      "The exact modulus is 1, not 1/2: the parent's IVT produced an attained value 1/2, but the true supremum of the error is the unattained 1.",
+      "Least-upper-bound recipe: upper bound xⁿ ≤ 1 (pow_le_one₀) plus passing to the limit along xₖ = 1 − 1/(k+1) → 1 (le_of_tendsto', xₖⁿ → 1) gives 1 ≤ any upper bound; IsLUB.csSup_eq then yields sSup = 1.",
+      "The error sup equals the xⁿ sup because |xⁿ − 0| = xⁿ on [0,1) (Set.image_congr after abs_of_nonneg).",
+      "Sharpness is exactly the LUB statement: no c < 1 is an upper bound (pow_exists_gt_of_lt_one), so 1 cannot be lowered, and xⁿ < 1 means it is never exceeded.",
+      "tendsto_one_div_add_atTop_nhds_zero_nat gives 1/(k+1) → 0, the engine of the approximating sequence; Filter.Tendsto.pow lifts xₖ → 1 to xₖⁿ → 1."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Quantify the rate sup_{x∈[0,1−δ]} xⁿ → 0 as the domain shrinks to a compact subinterval [0,1−δ], recovering a uniform modulus in δ and n.",
+      "Generalize to continuous antitone-in-n families with a discontinuous-at-1 limit envelope."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "dini",
+    "uniform-convergence",
+    "supremum",
+    "sharpness"
+  ],
+  "relatedProofs": [
+    "dini-theorem",
+    "dini-theorem-oq-01",
+    "dini-theorem-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [
+      "Rudin, Principles of Mathematical Analysis, Thm 7.13 (Dini) and the xⁿ example on [0,1)"
+    ],
+    "urls": [],
+    "mathlib": [
+      "IsLUB.csSup_eq",
+      "le_of_tendsto'",
+      "tendsto_one_div_add_atTop_nhds_zero_nat",
+      "pow_le_one₀",
+      "Metric.tendstoUniformlyOn_iff"
+    ]
+  },
+  "started": "2026-06-25T00:00:00.000Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/DiniTheorem.lean",
+      "filename": "DiniTheorem.lean",
+      "lineCount": 180,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DiniTheorem.lean"
+    },
+    {
+      "path": "Proofs/DiniTheoremOQ01OQ02.lean",
+      "filename": "DiniTheoremOQ01OQ02.lean",
+      "lineCount": 172,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DiniTheoremOQ01OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers research problem **dini-theorem-oq-01-oq-02** — the parent Dini-sharpness witness's open question OQ-02:

> Does a quantitative refinement hold: on `[0,1)` the uniform distance `sup_x |xⁿ|` stays exactly `1`, giving an explicit lower bound on the modulus of non-uniform convergence rather than the value `1/2` used here?

**Yes — the sharp modulus is exactly `1`.**

## Context

On the non-compact interval `[0,1)`, `xⁿ` is continuous, antitone in `n`, and converges pointwise to the continuous function `0`, yet **not uniformly** (Dini fails because the domain is not compact). The parent `DiniTheorem.lean` quantified this with the non-sharp bound `1/2` (a value attained via the IVT). This entry pins the exact modulus.

## What is proved (6 theorems, 172 lines)

- `pow_image_Ico_isLUB` — `IsLUB { xⁿ : x ∈ [0,1) } 1` for `n ≥ 1`. Upper bound: `xⁿ ≤ 1` (`pow_le_one₀`). Least: the points `xₖ = 1 − 1/(k+1) ∈ [0,1)` satisfy `xₖ → 1`, hence `xₖⁿ → 1`; each `xₖⁿ ≤ b`, so `le_of_tendsto'` gives `1 ≤ b`.
- `pow_sSup_Ico` — `sSup { xⁿ : x ∈ [0,1) } = 1` (`IsLUB.csSup_eq`). **Never attained** (every `xⁿ < 1`).
- `pow_uniform_error_Ico` — the headline: `sup_{x∈[0,1)} |xⁿ − 0| = 1` for every `n ≥ 1`, sharpening the parent's `1/2`.
- `pow_exists_gt_of_lt_one` — for any `c < 1`, a point of `[0,1)` with `xⁿ > c`.
- `pow_not_tendstoUniformlyOn_Ico_sharp` — non-uniformity holds with **any** threshold `c ∈ (0,1)`.

The unattained supremum — every `xⁿ < 1` while `x → 1⁻` drives `xⁿ → 1` — is precisely the failure of compactness that Dini's theorem rules out.

## Verification

- `lake env lean Proofs/DiniTheoremOQ01OQ02.lean` exits **0** (Mathlib v4.26.0).
- `#print axioms pow_uniform_error_Ico` / `pow_not_tendstoUniformlyOn_Ico_sharp` → only `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
- 0 sorries, 0 axiom declarations, no structure-encoded assumptions → **status: verified, badge: original**.
- Registered in `proofs/Proofs.lean`; gallery `meta.json` + `annotations.json` added; self-contained (imports only Mathlib).

## Files
- `proofs/Proofs/DiniTheoremOQ01OQ02.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/dini-theorem-oq-01-oq-02/{meta,annotations}.json` (new)
- `src/data/research/problems/dini-theorem-oq-01-oq-02.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)