### PR TITLE
research(cauchy-group-oq...-oq-03-oq-02-oq-02): power-map fibre sizes are constant on any finite abelian group; ∏gcd(n,mᵢ) on a product of cyclics

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -612,7 +612,9 @@ import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ01
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02
 import Proofs.CauchyGroupTheoremOQ01OQ02
 import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchyInterlacingOQ01OQ01

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02.lean
@@ -1,0 +1,202 @@
+import Mathlib.Tactic
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02
+
+/-
+# Fibre sizes of the power map on a finite abelian group are constant
+
+## The question
+
+The parent file `CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02` analysed the power
+map `x ↦ xⁿ` on a finite **cyclic** group of order `m`: every non-empty fibre
+has exactly `gcd(n, m)` elements, so the unordered multiset of fibre sizes is the
+single value `gcd(n, m)` repeated `m / gcd(n, m)` times. From that multiset one
+"recovers `gcd(n, m)` exactly". The open question asked whether, over a *product*
+of cyclic groups, the fibre-size multiset becomes strictly more informative, and
+which residues of `n` modulo the invariant factors it pins down.
+
+## What this file proves
+
+The premise of the open question — that the multiset gets richer on a product —
+is **false**, and this file makes the reason precise.
+
+* **Constant fibres (any finite abelian group).** Because `x ↦ xⁿ` is a group
+  *endomorphism* of an abelian group, every non-empty fibre is a coset of the
+  `n`-torsion subgroup, so they **all have the same size**, namely the number of
+  solutions of `xⁿ = 1`. The fibre-size multiset therefore degenerates to a
+  single value repeated `#(n-th powers)` times — on a product just as much as on
+  a cyclic group (`card_fiber_pow_eq_card_torsion`).
+
+* **Partition identity (any finite abelian group).** Counting the group through
+  its fibres gives `#(n-th powers) · #{x : xⁿ = 1} = |G|`
+  (`card_image_pow_mul_torsion`), strictly generalising the parent's cyclic
+  identity `#(n-th powers) · gcd(n, m) = m`.
+
+* **The single value, on a product of cyclics.** For `G = ∏ᵢ Gᵢ` with each `Gᵢ`
+  finite cyclic, the `n`-torsion count multiplies over the factors:
+  `#{x : xⁿ = 1} = ∏ᵢ gcd(n, |Gᵢ|)` (`card_torsion_pi_cyclic`). Hence the common
+  fibre size on the product is `∏ᵢ gcd(n, |Gᵢ|)` and the number of `n`-th powers
+  is `∏ᵢ |Gᵢ| / gcd(n, |Gᵢ|)` (`card_fiber_pow_pi_cyclic`,
+  `card_image_pow_pi_cyclic`).
+
+## Answer to the open question
+
+The fibre-size multiset on a product of cyclic groups is **not** more
+informative than its single value: it is the constant `∏ᵢ gcd(n, |Gᵢ|)`. That
+number determines the product of the per-factor gcds, but — exactly as in the
+cyclic case where `gcd(n, m)` does not determine `n mod m` — it pins down **no**
+residue of `n` modulo any invariant factor. The genuine information content of
+the map `x ↦ xⁿ` on a product is the *tuple* `(gcd(n, |Gᵢ|))ᵢ`, which the bare
+fibre size collapses into a single product.
+
+## Proof strategy
+
+`card_fiber_pow_eq_card_torsion` is a translation bijection: left-multiplication
+by a fixed preimage `a` (with `aⁿ = b`) carries the torsion set `{xⁿ = 1}` onto
+the fibre `{xⁿ = b}`, using only `mul_pow` in the abelian group. The partition
+identity then feeds this uniform count into `Finset.card_eq_sum_card_image`. The
+product formula transports the torsion subtype across
+`Equiv.subtypePiEquivPi` and reads each factor off the parent's cyclic count
+`gcd(n, |Gᵢ|)` via `card_fiber_pow`.
+-/
+
+namespace CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02
+
+open Finset
+
+/-! ### Constant fibres on any finite abelian group -/
+
+/-- **Uniform fibres (any finite abelian group).** Every non-empty fibre of the
+power map `x ↦ xⁿ` has the same number of elements: the number of solutions of
+`xⁿ = 1`. Indeed if `aⁿ = b` then `x ↦ a⁻¹ · x` is a bijection from the fibre
+`{xⁿ = b}` onto the torsion set `{xⁿ = 1}`, because `(a⁻¹x)ⁿ = (aⁿ)⁻¹ · xⁿ`. No
+cyclicity is used — only that `x ↦ xⁿ` is an endomorphism of the abelian group,
+so its fibres are the cosets of the `n`-torsion subgroup. -/
+theorem card_fiber_pow_eq_card_torsion {α : Type*} [CommGroup α] [Fintype α]
+    [DecidableEq α] (n : ℕ) {b : α} (hb : ∃ a, a ^ n = b) :
+    (univ.filter (fun x : α => x ^ n = b)).card
+      = (univ.filter (fun x : α => x ^ n = 1)).card := by
+  obtain ⟨a, rfl⟩ := hb
+  refine Finset.card_bij' (fun x _ => a⁻¹ * x) (fun y _ => a * y) ?_ ?_ ?_ ?_
+  · intro x hx
+    rw [mem_filter] at hx
+    rw [mem_filter]
+    refine ⟨mem_univ _, ?_⟩
+    rw [mul_pow, inv_pow, hx.2, inv_mul_cancel]
+  · intro y hy
+    rw [mem_filter] at hy
+    rw [mem_filter]
+    refine ⟨mem_univ _, ?_⟩
+    rw [mul_pow, hy.2, mul_one]
+  · intro x _
+    simp only [mul_inv_cancel_left]
+  · intro y _
+    simp only [inv_mul_cancel_left]
+
+/-- **Constant fibre value as the kernel cardinality.** The shared fibre size of
+the previous theorem is exactly the order of the kernel of the power
+homomorphism `powMonoidHom n`, i.e. the `n`-torsion subgroup. -/
+theorem card_torsion_eq_card_ker {α : Type*} [CommGroup α] [Fintype α]
+    [DecidableEq α] (n : ℕ) :
+    (univ.filter (fun x : α => x ^ n = 1)).card
+      = Fintype.card (powMonoidHom n : α →* α).ker := by
+  rw [Fintype.card_subtype]
+  congr 1
+  apply Finset.filter_congr
+  intro x _
+  simp only [MonoidHom.mem_ker, powMonoidHom_apply]
+
+/-! ### The partition identity for any finite abelian group -/
+
+/-- **Partition identity (any finite abelian group).** The power map `x ↦ xⁿ`
+partitions the group into its fibres, every non-empty one having the same size
+`#{x : xⁿ = 1}`. Counting the group two ways gives
+`#(n-th powers) · #{x : xⁿ = 1} = |G|`. This generalises the parent's cyclic
+identity `#(n-th powers) · gcd(n, m) = m`, replacing `gcd(n, m)` by the general
+torsion count. -/
+theorem card_image_pow_mul_torsion {α : Type*} [CommGroup α] [Fintype α]
+    [DecidableEq α] (n : ℕ) :
+    (univ.image (fun x : α => x ^ n)).card
+        * (univ.filter (fun x : α => x ^ n = 1)).card
+      = Fintype.card α := by
+  have key : ∀ b ∈ univ.image (fun x : α => x ^ n),
+      (univ.filter (fun a : α => a ^ n = b)).card
+        = (univ.filter (fun x : α => x ^ n = 1)).card := by
+    intro b hb
+    rw [Finset.mem_image] at hb
+    obtain ⟨a, _, ha⟩ := hb
+    exact card_fiber_pow_eq_card_torsion n ⟨a, ha⟩
+  have hsum : Fintype.card α
+      = ∑ b ∈ univ.image (fun x : α => x ^ n),
+          (univ.filter (fun a : α => a ^ n = b)).card := by
+    rw [← Finset.card_univ]
+    exact Finset.card_eq_sum_card_image _ _
+  rw [hsum, Finset.sum_congr rfl key, Finset.sum_const, smul_eq_mul]
+
+/-! ### The single fibre value on a product of cyclic groups -/
+
+/-- **Torsion count is multiplicative over a product (general factors).** For a
+finite product `∀ i, G i` of finite abelian groups, the number of solutions of
+`xⁿ = 1` is the product over the factors of the per-factor torsion counts:
+`xⁿ = 1` holds in the product iff `(xᵢ)ⁿ = 1` for every `i`. -/
+theorem card_torsion_pi {ι : Type*} [DecidableEq ι] [Fintype ι] (G : ι → Type*)
+    [∀ i, CommGroup (G i)] [∀ i, Fintype (G i)] [∀ i, DecidableEq (G i)] (n : ℕ) :
+    (univ.filter (fun x : (∀ i, G i) => x ^ n = 1)).card
+      = ∏ i, (univ.filter (fun y : G i => y ^ n = 1)).card := by
+  have e : {x : (∀ i, G i) // x ^ n = 1} ≃ ∀ i, {y : G i // y ^ n = 1} :=
+    (Equiv.subtypeEquivRight (fun x => by
+      rw [funext_iff]; simp only [Pi.pow_apply, Pi.one_apply])).trans
+      Equiv.subtypePiEquivPi
+  calc (univ.filter (fun x : (∀ i, G i) => x ^ n = 1)).card
+      = Fintype.card {x : (∀ i, G i) // x ^ n = 1} := (Fintype.card_subtype _).symm
+    _ = Fintype.card (∀ i, {y : G i // y ^ n = 1}) := Fintype.card_congr e
+    _ = ∏ i, Fintype.card {y : G i // y ^ n = 1} := Fintype.card_pi
+    _ = ∏ i, (univ.filter (fun y : G i => y ^ n = 1)).card :=
+        Finset.prod_congr rfl (fun i _ => Fintype.card_subtype _)
+
+/-- **Per-factor torsion count on a cyclic group.** On a finite cyclic group of
+order `m`, the number of solutions of `xⁿ = 1` is `gcd(n, m)` (the kernel of the
+power map), reading the parent's uniform fibre count over the basepoint `b = 1`. -/
+theorem card_torsion_cyclic {α : Type*} [CommGroup α] [Fintype α] [DecidableEq α]
+    [IsCyclic α] (n : ℕ) :
+    (univ.filter (fun x : α => x ^ n = 1)).card = Nat.gcd n (Fintype.card α) :=
+  CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02.card_fiber_pow ⟨1, one_pow n⟩
+
+/-- **The fibre value on a product of cyclic groups (the answer).** For
+`G = ∏ᵢ Gᵢ` with each `Gᵢ` finite cyclic of order `mᵢ`, the number of solutions
+of `xⁿ = 1` — equivalently the common size of every non-empty fibre of
+`x ↦ xⁿ` — is `∏ᵢ gcd(n, mᵢ)`. The fibre-size multiset is therefore the single
+constant value `∏ᵢ gcd(n, mᵢ)`, not a richer object. -/
+theorem card_torsion_pi_cyclic {ι : Type*} [DecidableEq ι] [Fintype ι] (G : ι → Type*)
+    [∀ i, CommGroup (G i)] [∀ i, Fintype (G i)] [∀ i, DecidableEq (G i)]
+    [∀ i, IsCyclic (G i)] (n : ℕ) :
+    (univ.filter (fun x : (∀ i, G i) => x ^ n = 1)).card
+      = ∏ i, Nat.gcd n (Fintype.card (G i)) := by
+  rw [card_torsion_pi]
+  exact Finset.prod_congr rfl (fun i _ => card_torsion_cyclic n)
+
+/-- **Common fibre size on a product of cyclic groups.** Every non-empty fibre of
+`x ↦ xⁿ` on `∏ᵢ Gᵢ` (each `Gᵢ` cyclic) has exactly `∏ᵢ gcd(n, |Gᵢ|)` elements. -/
+theorem card_fiber_pow_pi_cyclic {ι : Type*} [DecidableEq ι] [Fintype ι] (G : ι → Type*)
+    [∀ i, CommGroup (G i)] [∀ i, Fintype (G i)] [∀ i, DecidableEq (G i)]
+    [∀ i, IsCyclic (G i)] (n : ℕ) {b : ∀ i, G i} (hb : ∃ a, a ^ n = b) :
+    (univ.filter (fun x : (∀ i, G i) => x ^ n = b)).card
+      = ∏ i, Nat.gcd n (Fintype.card (G i)) := by
+  rw [card_fiber_pow_eq_card_torsion n hb, card_torsion_pi_cyclic]
+
+/-- **Number of `n`-th powers on a product of cyclic groups.** Dividing the
+partition identity by the common fibre size: the product `∏ᵢ Gᵢ` of finite cyclic
+groups has exactly `(∏ᵢ |Gᵢ|) / (∏ᵢ gcd(n, |Gᵢ|)) = ∏ᵢ |Gᵢ| / gcd(n, |Gᵢ|)`
+distinct `n`-th powers. -/
+theorem card_image_pow_pi_cyclic {ι : Type*} [DecidableEq ι] [Fintype ι] (G : ι → Type*)
+    [∀ i, CommGroup (G i)] [∀ i, Fintype (G i)] [∀ i, DecidableEq (G i)]
+    [∀ i, IsCyclic (G i)] (n : ℕ) :
+    (univ.image (fun x : (∀ i, G i) => x ^ n)).card
+      = (∏ i, Fintype.card (G i)) / ∏ i, Nat.gcd n (Fintype.card (G i)) := by
+  have h := card_image_pow_mul_torsion (α := (∀ i, G i)) n
+  rw [card_torsion_pi_cyclic] at h
+  rw [Fintype.card_pi] at h
+  have hpos : 0 < ∏ i, Nat.gcd n (Fintype.card (G i)) :=
+    Finset.prod_pos (fun i _ => Nat.gcd_pos_of_pos_right _ Fintype.card_pos)
+  exact (Nat.div_eq_of_eq_mul_right hpos (by rw [mul_comm]; exact h.symm)).symm
+
+end CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 60
+    },
+    "type": "context",
+    "title": "Fibre Sizes of the Power Map Are Constant",
+    "content": "Answers the parent's second open question: does the fibre-size multiset of x ↦ xⁿ become more informative on a product of cyclic groups than on a single cyclic group? It does not. Because x ↦ xⁿ is a group endomorphism, every non-empty fibre is a coset of the n-torsion subgroup, so all fibres share the size #{x | xⁿ = 1} on ANY finite abelian group. The multiset is one repeated number. On a product ∏ᵢ Gᵢ of cyclics that number factors as ∏ᵢ gcd(n, mᵢ), recovering the product of per-factor kernel sizes but no residue of n.",
+    "mathContext": "$$\\#\\{x: x^n=b\\}=\\#\\{x: x^n=1\\}=|\\ker(x\\mapsto x^n)|,\\qquad \\#\\{x\\in\\textstyle\\prod_i G_i: x^n=1\\}=\\prod_i\\gcd(n,m_i).$$",
+    "significance": "Identifies the structural reason the open question's premise fails — endomorphisms have equinumerous fibres — and generalises the parent's cyclic-only counts to all finite abelian groups.",
+    "relatedConcepts": [
+      "power map endomorphism",
+      "equinumerous fibres",
+      "n-torsion subgroup",
+      "product of cyclic groups",
+      "invariant factors"
+    ],
+    "prerequisites": [
+      "finite abelian groups",
+      "group homomorphisms and kernels",
+      "cosets",
+      "gcd"
+    ]
+  },
+  {
+    "id": "ann-constant-fibres",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+    "range": {
+      "startLine": 66,
+      "endLine": 106
+    },
+    "type": "key-step",
+    "title": "Constant Fibres on Any Finite Abelian Group",
+    "content": "card_fiber_pow_eq_card_torsion proves every non-empty fibre {x | xⁿ = b} is equinumerous with the torsion set {x | xⁿ = 1}: choosing a with aⁿ = b, the translation x ↦ a⁻¹·x is a bijection between them because (a⁻¹x)ⁿ = (aⁿ)⁻¹·xⁿ = b⁻¹·b = 1, packaged by Finset.card_bij'. Only mul_pow is used — no cyclicity — so this holds for every finite abelian group. card_torsion_eq_card_ker identifies the common value with the order of the kernel of powMonoidHom n.",
+    "mathContext": "$$x\\mapsto a^{-1}x:\\;\\{x:x^n=b\\}\\xrightarrow{\\sim}\\{x:x^n=1\\},\\qquad \\#\\{x:x^n=1\\}=|\\ker(\\mathrm{powMonoidHom}\\,n)|.$$",
+    "significance": "The crux: fibres of an endomorphism are cosets of the kernel, hence all the same size, so the fibre-size multiset is a single repeated value regardless of how the group factors.",
+    "relatedConcepts": [
+      "translation bijection",
+      "kernel cosets",
+      "Finset.card_bij'",
+      "n-torsion subgroup"
+    ],
+    "prerequisites": [
+      "group endomorphisms",
+      "cosets and Lagrange's theorem",
+      "bijective counting"
+    ]
+  },
+  {
+    "id": "ann-partition-identity",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 133
+    },
+    "type": "key-step",
+    "title": "The Partition Identity for Any Finite Abelian Group",
+    "content": "card_image_pow_mul_torsion counts the group through its fibres: Finset.card_eq_sum_card_image writes |G| as the sum over the image of the fibre cardinalities, the uniformity lemma collapses each summand to #{xⁿ=1}, and summing a constant gives #(n-th powers)·#{xⁿ=1} = |G|. This is the parent's cyclic identity #(n-th powers)·gcd(n, m) = m with gcd(n, m) replaced by the general torsion count, now valid for every finite abelian group.",
+    "mathContext": "$$\\#\\{x\\mapsto x^n\\ \\text{image}\\}\\cdot\\#\\{x:x^n=1\\}=|G|.$$",
+    "significance": "The first-isomorphism bookkeeping for the power map, freed from the cyclic hypothesis: kernel size times image size equals group order.",
+    "relatedConcepts": [
+      "first isomorphism theorem",
+      "fibrewise counting",
+      "image of the power map"
+    ],
+    "prerequisites": [
+      "Finset.card_eq_sum_card_image",
+      "sum of a constant",
+      "image and kernel cardinalities"
+    ]
+  },
+  {
+    "id": "ann-product-of-cyclics",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+    "range": {
+      "startLine": 135,
+      "endLine": 201
+    },
+    "type": "key-step",
+    "title": "The Single Fibre Value on a Product of Cyclic Groups",
+    "content": "card_torsion_pi splits the torsion count of ∏ᵢ Gᵢ: xⁿ = 1 holds coordinatewise (funext_iff with Pi.pow_apply, Pi.one_apply), so Equiv.subtypeEquivRight ∘ Equiv.subtypePiEquivPi exhibits the torsion subtype as ∏ᵢ (per-factor torsion subtype), and Fintype.card_pi multiplies the cardinalities. card_torsion_cyclic reads each factor as gcd(n, mᵢ) from the parent's card_fiber_pow at b = 1, giving #{xⁿ=1} = ∏ᵢ gcd(n, mᵢ). card_fiber_pow_pi_cyclic transports this constant to every fibre and card_image_pow_pi_cyclic divides the partition identity to count n-th powers as ∏ᵢ mᵢ/gcd(n, mᵢ).",
+    "mathContext": "$$\\#\\{x:x^n=1\\}=\\prod_i\\gcd(n,m_i),\\qquad \\#\\{n\\text{-th powers}\\}=\\frac{\\prod_i m_i}{\\prod_i\\gcd(n,m_i)}=\\prod_i\\frac{m_i}{\\gcd(n,m_i)}.$$",
+    "significance": "Pins the single fibre value on a product to ∏ᵢ gcd(n, mᵢ): the multiset is the constant product of per-factor kernel sizes, which recovers that product but not the per-factor tuple and not residues of n.",
+    "relatedConcepts": [
+      "Equiv.subtypePiEquivPi",
+      "Fintype.card_pi",
+      "coordinatewise torsion",
+      "invariant factors",
+      "multiplicativity of gcd over factors"
+    ],
+    "prerequisites": [
+      "products of groups",
+      "subtype equivalences",
+      "Fintype cardinality of a product"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+  "title": "Fibre sizes of the power map are constant: on any finite abelian group #(fibre) = #{xⁿ=1}, and on a product of cyclics this is ∏ gcd(n, mᵢ)",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02"
+    ],
+    "opens": ["Finset"],
+    "namespace": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02",
+    "lineCount": 202,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "description": "Answers the parent's second open question, on inverting the power map x ↦ xⁿ from its fibre-size multiset over a product of cyclic groups. The open question conjectured that, passing from a cyclic group to a product of cyclics, the multiset of fibre sizes becomes strictly more informative. This entry shows that premise is FALSE and explains why. (1) Constant fibres on ANY finite abelian group: because x ↦ xⁿ is a group endomorphism, every non-empty fibre is a coset of the n-torsion subgroup, so all fibres have the same cardinality, namely #{x | xⁿ = 1} (card_fiber_pow_eq_card_torsion, proved by the translation bijection x ↦ a⁻¹·x using only mul_pow; no cyclicity). That common value is the order of the kernel powMonoidHom n (card_torsion_eq_card_ker). The fibre-size multiset therefore degenerates to a single value repeated #(n-th powers) times — on a product exactly as on a cyclic group. (2) Partition identity for ANY finite abelian group: counting the group through its fibres via Finset.card_eq_sum_card_image gives #(n-th powers)·#{xⁿ=1} = |G| (card_image_pow_mul_torsion), strictly generalising the parent's cyclic identity #(n-th powers)·gcd(n,m) = m. (3) The single value on a product of cyclics: for G = ∏ᵢ Gᵢ with each Gᵢ finite cyclic of order mᵢ, the n-torsion count factors as ∏ᵢ gcd(n, mᵢ) — transport the torsion subtype across Equiv.subtypePiEquivPi (card_torsion_pi) and read each factor off the parent's cyclic count gcd(n, mᵢ) (card_torsion_cyclic, card_torsion_pi_cyclic). Hence every non-empty fibre on the product has size ∏ᵢ gcd(n, mᵢ) (card_fiber_pow_pi_cyclic) and the number of n-th powers is (∏ᵢ mᵢ)/(∏ᵢ gcd(n, mᵢ)) = ∏ᵢ mᵢ/gcd(n, mᵢ) (card_image_pow_pi_cyclic). The fibre-size multiset over a product is the constant ∏ᵢ gcd(n, mᵢ); it recovers that product but — exactly as gcd(n,m) does not determine n mod m in the cyclic case — pins down no residue of n modulo any invariant factor. The genuine information content of x ↦ xⁿ on a product is the tuple (gcd(n, mᵢ))ᵢ, which the bare fibre size collapses into a single product.",
+  "overview": {
+    "historicalContext": "The power map x ↦ xⁿ on a finite abelian group is an endomorphism: its kernel is the n-torsion subgroup {x | xⁿ = 1}, its image is the subgroup of n-th powers, and — being cosets of the kernel — its fibres are all equinumerous. The parent leaf computed the cyclic fibre size as gcd(n, m), the abelian shadow of Frobenius' 1895 theorem #{x | xⁿ = 1} = gcd(n, |G|) for cyclic G, and asked whether moving to a product of cyclic groups makes the fibre-size data richer. This entry answers in the negative for the structural reason that an endomorphism has equinumerous fibres: the multiset of fibre sizes is constant for any finite abelian group, so it carries exactly one number of information. On a product G = ∏ᵢ ℤ/mᵢℤ in invariant-factor form, that number is the multiplicative ∏ᵢ gcd(n, mᵢ), the product of the per-factor kernel sizes — the additive face of the Smith-normal-form decomposition of a finite abelian group into cyclic factors.",
+    "problemStatement": "Determine the fibre-size multiset of the power map x ↦ xⁿ on a finite abelian group, and in particular on a product of cyclic groups ∏ᵢ Gᵢ. Decide whether the product case is strictly more informative than the cyclic case, and identify exactly what data the fibre sizes pin down.",
+    "proofStrategy": "Constant fibres: for a basepoint b = aⁿ, left-multiplication x ↦ a⁻¹·x is a bijection from the fibre {xⁿ = b} onto the torsion set {xⁿ = 1}, since (a⁻¹x)ⁿ = (aⁿ)⁻¹·xⁿ = b⁻¹·b = 1 by mul_pow and inv_pow; Finset.card_bij' packages the bijection (card_fiber_pow_eq_card_torsion). Identifying the torsion count with the kernel order goes through Fintype.card_subtype and MonoidHom.mem_ker (card_torsion_eq_card_ker). Partition: Finset.card_eq_sum_card_image writes |G| as the sum over the image of the fibre cardinalities, each equal to #{xⁿ=1} by the uniformity lemma, so the sum of a constant gives #(n-th powers)·#{xⁿ=1} = |G| (card_image_pow_mul_torsion). Product: the predicate xⁿ = 1 on ∏ᵢ Gᵢ is, via funext_iff with Pi.pow_apply and Pi.one_apply, the conjunction ∀ i, (xᵢ)ⁿ = 1, so Equiv.subtypeEquivRight and Equiv.subtypePiEquivPi exhibit the torsion subtype as ∏ᵢ (per-factor torsion subtype); Fintype.card_pi multiplies the cardinalities (card_torsion_pi), and each factor is gcd(n, mᵢ) by the parent's card_fiber_pow over b = 1 (card_torsion_cyclic). Dividing the partition identity by the positive product ∏ᵢ gcd(n, mᵢ) yields the count of n-th powers (card_image_pow_pi_cyclic).",
+    "keyInsights": [
+      "An endomorphism has equinumerous fibres. Because x ↦ xⁿ is a homomorphism of the abelian group, every non-empty fibre is a coset of the kernel and so has size #{x | xⁿ = 1}; the fibre-size multiset is therefore a single value repeated, no matter how the group factors.",
+      "The open question's premise is false. Passing from a cyclic group to a product of cyclics does NOT make the fibre-size multiset more informative: it is still the constant ∏ᵢ gcd(n, mᵢ), one number, not a richer object.",
+      "The constant-fibre count and the partition identity #(n-th powers)·#{xⁿ=1} = |G| hold for ANY finite abelian group, strictly generalising the parent's cyclic-only gcd(n, m) statements.",
+      "On a product the single value factors multiplicatively, ∏ᵢ gcd(n, mᵢ), because xⁿ = 1 holds coordinatewise and the torsion subtype splits as a product across Equiv.subtypePiEquivPi.",
+      "Fibre size recovers only the product ∏ᵢ gcd(n, mᵢ), not the per-factor gcds and certainly not residues of n: the real invariant of x ↦ xⁿ on a product is the tuple (gcd(n, mᵢ))ᵢ, which a single fibre size cannot resolve."
+    ]
+  },
+  "sections": [
+    {
+      "id": "constant-fibres",
+      "title": "Constant Fibres on Any Finite Abelian Group",
+      "startLine": 66,
+      "endLine": 106,
+      "summary": "card_fiber_pow_eq_card_torsion: every non-empty fibre {x | xⁿ = b} of the power map has the same cardinality as the torsion set {x | xⁿ = 1}. With aⁿ = b, the map x ↦ a⁻¹·x is a bijection fibre → torsion because (a⁻¹x)ⁿ = (aⁿ)⁻¹·xⁿ, packaged by Finset.card_bij'; only mul_pow is used, so no cyclicity is needed. card_torsion_eq_card_ker identifies that common value with the order of the kernel of powMonoidHom n via Fintype.card_subtype and MonoidHom.mem_ker.",
+      "mathContext": "Fibres of the endomorphism x ↦ xⁿ are cosets of the n-torsion subgroup, hence all of size #{x | xⁿ = 1} = |ker(powMonoidHom n)|."
+    },
+    {
+      "id": "partition-identity",
+      "title": "The Partition Identity for Any Finite Abelian Group",
+      "startLine": 108,
+      "endLine": 133,
+      "summary": "card_image_pow_mul_torsion: Finset.card_eq_sum_card_image writes |G| as the sum over the image of the fibre cardinalities; the uniformity lemma collapses each summand to #{xⁿ=1}, and the sum of a constant gives #(n-th powers)·#{xⁿ=1} = |G|. This generalises the parent's cyclic identity #(n-th powers)·gcd(n, m) = m, replacing gcd(n, m) by the general torsion count.",
+      "mathContext": "#(n-th powers)·#{x | xⁿ = 1} = |G| for every finite abelian group — the first-isomorphism bookkeeping for the power map."
+    },
+    {
+      "id": "product-of-cyclics",
+      "title": "The Single Fibre Value on a Product of Cyclic Groups",
+      "startLine": 135,
+      "endLine": 201,
+      "summary": "card_torsion_pi: the torsion count over ∏ᵢ Gᵢ is ∏ᵢ (per-factor torsion count), because xⁿ = 1 holds coordinatewise (funext_iff, Pi.pow_apply) and Equiv.subtypeEquivRight ∘ Equiv.subtypePiEquivPi splits the torsion subtype as a product whose cardinality is ∏ᵢ via Fintype.card_pi. card_torsion_cyclic reads each factor as gcd(n, mᵢ) from the parent's card_fiber_pow at b = 1, giving card_torsion_pi_cyclic: #{xⁿ=1} = ∏ᵢ gcd(n, mᵢ). card_fiber_pow_pi_cyclic transports this to every fibre, and card_image_pow_pi_cyclic divides the partition identity to give #(n-th powers) = (∏ᵢ mᵢ)/(∏ᵢ gcd(n, mᵢ)).",
+      "mathContext": "On ∏ᵢ Gᵢ with Gᵢ cyclic of order mᵢ: every fibre has size ∏ᵢ gcd(n, mᵢ) and there are ∏ᵢ mᵢ/gcd(n, mᵢ) distinct n-th powers."
+    }
+  ],
+  "conclusion": {
+    "summary": "The fibre-size multiset of the power map x ↦ xⁿ is constant on every finite abelian group: since the map is an endomorphism, all non-empty fibres are cosets of the n-torsion subgroup and have the common size #{x | xⁿ = 1} = |ker(powMonoidHom n)|, so counting the group two ways gives #(n-th powers)·#{xⁿ=1} = |G|. On a product of cyclic groups ∏ᵢ Gᵢ that single value factors as ∏ᵢ gcd(n, mᵢ), and the number of n-th powers is ∏ᵢ mᵢ/gcd(n, mᵢ). This answers the parent's second open question: a product is NOT more informative than a cyclic group at the level of fibre sizes — the multiset is one repeated number either way. That number recovers the product ∏ᵢ gcd(n, mᵢ) but, just as gcd(n, m) fails to determine n mod m in the cyclic case, it pins down no residue of n modulo any invariant factor; the true invariant of the map on a product is the tuple (gcd(n, mᵢ))ᵢ, which a bare fibre size collapses.",
+    "implications": [
+      "Generalises the parent's cyclic results to ALL finite abelian groups: the uniform-fibre count and the partition identity #(n-th powers)·#{xⁿ=1} = |G| hold without any cyclicity hypothesis, the structural reason being that x ↦ xⁿ is an endomorphism.",
+      "Settles the parent's second open question negatively: the fibre-size multiset over a product of cyclic groups is the constant ∏ᵢ gcd(n, mᵢ) — no richer than the single value it determines.",
+      "Separates the recoverable from the unrecoverable: fibre size recovers ∏ᵢ gcd(n, mᵢ) only, so the per-factor tuple (gcd(n, mᵢ))ᵢ — the genuine invariant of x ↦ xⁿ on a product — is strictly finer than the fibre data, and residues of n are not determined at all."
+    ],
+    "openQuestions": [
+      "The fibre-size multiset collapses the tuple (gcd(n, mᵢ))ᵢ into its product; by unique factorisation across primes the product still recovers each gcd(n, mᵢ) when the orders mᵢ are pairwise coprime. For general invariant factors m₁ | m₂ | … | mₖ, characterise exactly which tuples (gcd(n, mᵢ))ᵢ are recoverable from the single product ∏ᵢ gcd(n, mᵢ), and formalise the prime-by-prime reconstruction.",
+      "The number of n-th powers ∏ᵢ mᵢ/gcd(n, mᵢ) is the index of the kernel; relate it to the structure of the image subgroup ∏ᵢ (Gᵢ)^n as an explicit product of cyclic groups, and determine its own invariant factors as a function of n and the mᵢ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Directly answers the parent's second open question, on inverting the power map from its fibre-size multiset over a product of cyclic groups. The parent proved uniform fibres of size gcd(n, m) only in the cyclic case; this entry shows fibres are uniform on ANY finite abelian group (size #{xⁿ=1}) and computes that size as ∏ᵢ gcd(n, mᵢ) on a product, refuting the conjecture that the product multiset is more informative."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "related",
+      "description": "The parent-of-parent counts the homogeneous cyclic fibre #{x | xⁿ = 1} = gcd(n, |G|); that count is reused here as card_torsion_cyclic to evaluate each factor of the product torsion count ∏ᵢ gcd(n, mᵢ)."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (constant fibres of the power map on a finite abelian group; product-of-cyclics fibre size ∏ gcd(n, mᵢ))",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02OQ02.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "abelian-groups",
+      "cyclic-groups",
+      "power-map",
+      "endomorphism",
+      "fibre-partition",
+      "torsion-subgroup",
+      "gcd",
+      "invariant-factors"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_bij'",
+        "description": "Builds the equality of two Finset cardinalities from a bijection with an explicit inverse; packages the translation x ↦ a⁻¹·x between a fibre {xⁿ = b} and the torsion set {xⁿ = 1}.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "mul_pow",
+        "description": "(a·b)ⁿ = aⁿ·bⁿ in a commutative monoid; the one algebraic fact behind the translation bijection, giving (a⁻¹x)ⁿ = (aⁿ)⁻¹·xⁿ.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Finset.card_eq_sum_card_image",
+        "description": "#s = ∑ b ∈ s.image f, #{a ∈ s | f a = b}; the fibrewise count of the whole group that, with the uniform fibre size, yields the partition identity #(n-th powers)·#{xⁿ=1} = |G|.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Equiv.subtypePiEquivPi",
+        "description": "{f : ∀ i, β i // ∀ i, p i (f i)} ≃ ∀ i, {x // p i x}; splits the torsion subtype of a product group as a product of per-factor torsion subtypes.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Fintype.card_pi",
+        "description": "card (∀ i, α i) = ∏ i, card (α i); multiplies the per-factor torsion cardinalities into the product torsion count.",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      },
+      {
+        "theorem": "Fintype.card_subtype",
+        "description": "card {a // p a} = #(univ.filter p); converts between the subtype cardinality and the Finset-filter count of the torsion set, and identifies the kernel order with #{xⁿ=1}.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02.card_fiber_pow",
+        "description": "The parent's uniform cyclic fibre count #{x | xⁿ = b} = gcd(n, |G|) for b an n-th power; read at b = 1 it gives the per-factor torsion count gcd(n, mᵢ) used in the product formula.",
+        "module": "Proofs.CauchyGroupTheoremOQ01OQ01OQ01OQ01OQ03OQ02"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Frobenius, Ferdinand Georg",
+        "title": "Verallgemeinerung des Sylow'schen Satzes",
+        "year": "1895",
+        "note": "Sitzungsberichte der Königlich Preußischen Akademie der Wissenschaften zu Berlin — the divisibility theorem #{x | xⁿ = 1} = gcd(n, |G|) for cyclic G whose product form ∏ᵢ gcd(n, mᵢ) is established here."
+      },
+      {
+        "authors": "Dummit, David S.; Foote, Richard M.",
+        "title": "Abstract Algebra",
+        "year": "2004",
+        "note": "Wiley, 3rd ed. — fundamental theorem of finite abelian groups (invariant factors / elementary divisors) and the coordinatewise behaviour of endomorphisms on a product of cyclic groups."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — equinumerous fibres of endomorphisms of finite abelian groups as cosets of the kernel."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's (`cauchy-group-theorem-...-oq-03-oq-02`) **second open question**: does the fibre-size multiset of the power map `x ↦ xⁿ` become strictly more informative on a *product* of cyclic groups than on a single cyclic group?

**It does not** — and this file makes the reason precise.

## What is proved (8 theorems, 0 sorries, 0 axioms)

- **Constant fibres on ANY finite abelian group** (`card_fiber_pow_eq_card_torsion`): since `x ↦ xⁿ` is a group endomorphism, every non-empty fibre is a coset of the n-torsion subgroup, so they all have the common size `#{x | xⁿ = 1}`. Proved by the translation bijection `x ↦ a⁻¹·x` (only `mul_pow`, no cyclicity). The common value is the kernel order (`card_torsion_eq_card_ker`).
- **Partition identity for ANY finite abelian group** (`card_image_pow_mul_torsion`): `#(n-th powers) · #{xⁿ=1} = |G|`, strictly generalising the parent's cyclic-only `#(n-th powers)·gcd(n,m) = m`.
- **The single value on a product of cyclics** (`card_torsion_pi_cyclic`): for `G = ∏ᵢ Gᵢ` with each `Gᵢ` cyclic of order `mᵢ`, `#{xⁿ=1} = ∏ᵢ gcd(n, mᵢ)`, via `Equiv.subtypePiEquivPi` + the parent's cyclic count. Hence every fibre has size `∏ᵢ gcd(n, mᵢ)` (`card_fiber_pow_pi_cyclic`) and there are `∏ᵢ mᵢ/gcd(n, mᵢ)` distinct n-th powers (`card_image_pow_pi_cyclic`).

## Answer to the open question

The fibre-size multiset over a product of cyclic groups is the **constant** `∏ᵢ gcd(n, mᵢ)` — one repeated number, no richer than on a cyclic group. It recovers that product but, exactly as `gcd(n,m)` fails to determine `n mod m` in the cyclic case, pins down **no** residue of `n` modulo any invariant factor. The genuine invariant of the map on a product is the *tuple* `(gcd(n, mᵢ))ᵢ`, which the bare fibre size collapses into a single product.

## Verification

- `lake env lean` compiles clean; `#print axioms` on all 8 theorems lists only `propext, Classical.choice, Quot.sound`.
- meta.json: `status: verified`, `badge: original`, 8 theorems / 0 defs / 0 axioms / 0 sorries; 4 annotations.
- Adds the (previously missing) aggregator import for the parent `...OQ03OQ02` alongside the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)