### PR TITLE
Enrich Squarefree-Order Classification (sylow-theorems-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/sylow-theorems-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "sylow-theorems-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 38 },
+    "type": "context",
+    "title": "Squarefree-Order Classification via Z-Groups",
+    "content": "The parent entry classifies groups of order pq by hand with Sylow counting; its second open question asks for the general squarefree-order classification (any number of prime factors). This file answers it by routing through Mathlib's IsZGroup theory — a Z-group is a finite group all of whose Sylow subgroups are cyclic. The honest scope is stated up front: the hard mathematics (Z-group structure theory, Schur–Zassenhaus) lives in Mathlib; the contribution is assembling it into the classification narrative, hence the 'mathlib' badge. The exact count of isomorphism classes (governed by the divisibility relations pᵢ ∣ pⱼ − 1) remains open.",
+    "mathContext": "$n = p_1 p_2 \\cdots p_k$ squarefree $\\Rightarrow$ every Sylow $p_i$-subgroup has order exactly $p_i$, so $G$ is a Z-group.",
+    "significance": "context",
+    "relatedConcepts": ["Sylow theorems", "Z-groups", "squarefree integers", "semidirect products", "Schur–Zassenhaus"],
+    "prerequisites": ["Sylow theory", "cyclic groups", "group order"]
+  },
+  {
+    "id": "ann-reduction",
+    "proofId": "sylow-theorems-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 59 },
+    "type": "insight",
+    "title": "The Key Reduction: Squarefree ⇒ Z-Group",
+    "content": "isZGroup_of_squarefree_order is the decisive step (IsZGroup.of_squarefree): when n = p₁⋯pₖ is squarefree, each Sylow pᵢ-subgroup has order exactly pᵢ (the prime appears to the first power), so it is the cyclic group ℤ/pᵢ. sylow_isCyclic records the per-Sylow consequence via instance inference. Once IsZGroup G is in scope, every structural consequence below follows by typeclass inference from Mathlib's Z-group API — the entire classification rests on this one reduction.",
+    "mathContext": "$v_{p_i}(n) = 1 \\Rightarrow |\\mathrm{Syl}_{p_i}(G)| = p_i \\Rightarrow$ cyclic; squarefree $\\Rightarrow$ Z-group.",
+    "significance": "key",
+    "relatedConcepts": ["IsZGroup.of_squarefree", "Sylow subgroup order", "cyclic of prime order", "p-adic valuation"],
+    "prerequisites": ["Sylow subgroups", "squarefree factorization"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "sylow-theorems-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 84 },
+    "type": "theorem",
+    "title": "Structural Consequences of Being a Z-Group",
+    "content": "From IsZGroup G, four standard structural facts follow: isSolvable_of_squarefree_order (Z-groups are solvable), isCyclic_commutator (the commutator subgroup is cyclic, IsZGroup.isCyclic_commutator), isCyclic_abelianization (the abelianization G/[G,G] is cyclic), and exponent_eq_card (the exponent equals the full group order, IsZGroup.exponent_eq_card). The last says a squarefree-order group is 'as close to cyclic as its order allows' — there is an element whose order is the whole group order's worth of distinct prime factors.",
+    "mathContext": "$G$ Z-group $\\Rightarrow$ solvable, $[G,G]$ cyclic, $G/[G,G]$ cyclic, $\\exp(G) = |G|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["solvable groups", "commutator subgroup", "abelianization", "group exponent"],
+    "prerequisites": ["solvability", "commutator subgroups", "exponent of a group"]
+  },
+  {
+    "id": "ann-metacyclic",
+    "proofId": "sylow-theorems-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 94 },
+    "type": "concept",
+    "title": "Metacyclic Structure",
+    "content": "metacyclic_of_squarefree_order packages the cyclic-by-cyclic extension: the commutator subgroup [G,G] is a CYCLIC NORMAL subgroup whose quotient (the abelianization) is also cyclic. A metacyclic group is exactly such a cyclic-normal-with-cyclic-quotient extension. This is the structural skeleton on which the full semidirect-product classification is built.",
+    "mathContext": "$1 \\to [G,G] \\to G \\to G/[G,G] \\to 1$ with both ends cyclic — a metacyclic (cyclic-by-cyclic) extension.",
+    "significance": "supporting",
+    "relatedConcepts": ["metacyclic groups", "group extensions", "normal subgroups", "short exact sequences"],
+    "prerequisites": ["normal subgroups", "quotient groups"]
+  },
+  {
+    "id": "ann-classification",
+    "proofId": "sylow-theorems-oq-01-oq-02",
+    "range": { "startLine": 96, "endLine": 111 },
+    "type": "theorem",
+    "title": "The Classification: Semidirect Product of Cyclic Groups",
+    "content": "semidirectProduct_of_squarefree_order is the punchline the open question asked for: every finite group of squarefree order is isomorphic to a semidirect product N ⋊[φ] H of two CYCLIC subgroups of COPRIME order (isZGroup_iff_exists_mulEquiv). Concretely N is the cyclic commutator subgroup and H a complement isomorphic to the cyclic abelianization; coprimality of |N| and |H| is exactly what lets Schur–Zassenhaus split the extension into a semidirect product. This generalizes the parent's order-pq case to arbitrarily many prime factors.",
+    "mathContext": "$G \\cong N \\rtimes_\\varphi H$, $N, H$ cyclic, $\\gcd(|N|, |H|) = 1$ — Schur–Zassenhaus splits the metacyclic extension.",
+    "significance": "key",
+    "relatedConcepts": ["semidirect product", "isZGroup_iff_exists_mulEquiv", "Schur–Zassenhaus", "coprime orders", "complement subgroup"],
+    "prerequisites": ["semidirect products", "Schur–Zassenhaus theorem"]
+  },
+  {
+    "id": "ann-pq-case",
+    "proofId": "sylow-theorems-oq-01-oq-02",
+    "range": { "startLine": 113, "endLine": 124 },
+    "type": "context",
+    "title": "Specialization to Order pq",
+    "content": "squarefree_card_of_pq is the sanity check tying back to the parent: a group of order p·q with p, q distinct primes has squarefree order (Nat.squarefree_mul from coprimality of the two primes), so the general classification applies and recovers the parent entry's order-pq setting as the two-prime special case. This confirms the generalization is genuine — the parent is the k = 2 instance.",
+    "mathContext": "$p \\ne q$ prime $\\Rightarrow pq$ squarefree, so the order-$pq$ classification is the $k=2$ case.",
+    "significance": "supporting",
+    "relatedConcepts": ["squarefree product", "Nat.squarefree_mul", "coprime primes", "specialization"],
+    "prerequisites": ["squarefree integers", "the general classification"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `sylow-theorems-oq-01-oq-02` (Classification of Groups of Squarefree Order).

## Quality improvements
- Added the missing `annotations.json` (6 annotations with mathContext/significance/relatedConcepts/prerequisites).
- Covers the squarefree ⇒ Z-group reduction, the structural consequences (solvable / cyclic commutator / cyclic abelianization / exponent = order), the metacyclic structure, the semidirect-product-of-cyclic-groups classification, and the order-pq specialization.

`pnpm build` passes. Entry remains verified / 0-axiom (badge: mathlib — honestly assembles Mathlib's IsZGroup theory).