### PR TITLE
Gallery audit: 2 entries clean (hilbert-9-reciprocity-oq04, ptolemy-inversion-circle-line)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23523,6 +23523,20 @@
       "lastAudited": "2026-06-25T08:00:00Z",
       "result": "clean",
       "notes": "verified/mathlib/0-axiom/0-sorry all accurate. 9 theorems + 0 defs, 124 lines, 0 sorry/admit/axiom/native_decide/True-stub. Squarefree-order classification assembled from Mathlib IsZGroup theory (of_squarefree, isZGroup_iff_exists_mulEquiv, Schur-Zassenhaus). Badge=mathlib CORRECT; docstring has explicit Honest scope section + overview discloses routing through Mathlib Z-group theory. Counts match meta; deeper iso-class-count remains open (disclosed)."
+    },
+    "hilbert-9-reciprocity-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:05:00Z",
+      "result": "clean",
+      "notes": "Constant reciprocity slice (a/P)=chi_q(a)^deg P; verified/original/0-ax/0-sorry, 5 theorems match meta. Mathlib Euler-criterion reliance disclosed in overview+assumptions; original assembly of constant-reciprocity statement. CLEAN."
+    },
+    "ptolemys-theorem-oq-01-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:05:00Z",
+      "result": "clean",
+      "notes": "Inversion carries circle-through-centre to a line (cospherical iff images on hyperplane); verified/original/0-ax/0-sorry, 5 theorems match meta. Original. CLEAN."
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 2 previously-unaudited gallery entries. Both **CLEAN** — public claims match the Lean source.

| Slug | Status/Badge | sorry | axiom | native_decide | theorems |
|------|-------------|-------|-------|---------------|----------|
| `hilbert-9-reciprocity-oq-04` | verified/original | 0 | 0 | 0 | 5 ✓ |
| `ptolemys-theorem-oq-01-oq-01-oq-03-oq-01` | verified/original | 0 | 0 | 0 | 5 ✓ |

### Findings
- **hilbert-9-reciprocity-oq-04** — "Constant Reciprocity in Function Fields: (a/P) = χ_q(a)^{deg P}". Comment-stripped Lean source has 0 sorry / 0 axiom / 0 native_decide / 0 True-stubs. theoremCount=5 matches. Honestly scoped to the constant-reciprocity *slice* (not full Artin reciprocity); Mathlib's Euler criterion reliance is disclosed in the overview and `assumptions`. `original` badge justified by the specific constant-reciprocity statement assembled here.
- **ptolemys-theorem-oq-01-oq-01-oq-03-oq-01** — "Inversion Carries a Circle Through Its Centre to a Line (Cospherical ⇔ Images on a Hyperplane)". 0 sorry / 0 axiom / 0 native_decide / 0 True-stubs. theoremCount=5 matches (1 example not counted). Original inversion-duality result.

Tracker-only change (`src/data/proofs/audit-tracker.json`): marks both `clean`.

Note: stirling-formula-oq-03-oq-02 and sylow-theorems-oq-01-oq-02 (covered by merged #29821) already landed in the tracker on main; the cauchy-...-oq-03-oq-02-oq-02 target is a phantom (no meta on origin/main, in-flight research). The other 4 unaudited entries are covered by open #29818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)