### PR TITLE
research(erdos-435-oq-01-oq-01): converse — non-prime-power ⟹ gcd of interior binomials = 1 [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1975,6 +1975,7 @@ import Proofs.Erdos433Aristotle
 import Proofs.Erdos433Problem
 import Proofs.Erdos434Aristotle
 import Proofs.Erdos434Problem
+import Proofs.Erdos435NonPrimePower
 import Proofs.Erdos435PrimePowerObstruction
 import Proofs.Erdos435Problem
 import Proofs.Erdos436Improvements

--- a/proofs/Proofs/Erdos435NonPrimePower.lean
+++ b/proofs/Proofs/Erdos435NonPrimePower.lean
@@ -1,0 +1,118 @@
+/-
+Erdős Problem #435 — The Non-Prime-Power Case (companion to Erdos435Problem.lean
+and Erdos435PrimePowerObstruction.lean)
+
+The restriction in Erdős #435 to integers `n` that are NOT prime powers is sharp.
+The companion file `Erdos435PrimePowerObstruction.lean` proves the easy half: if
+`n = p^k` then `p` divides every middle binomial coefficient `C(n, j)`
+(`1 ≤ j < n`), so the gcd of the generators is `> 1` and no Frobenius number
+exists.
+
+This file proves the converse — the *reason* the problem is well-posed for
+non-prime-powers:
+
+    if `n` is not a prime power, then `gcd{C(n,1), …, C(n,n-1)} = 1`.
+
+A numerical semigroup whose generators have gcd `1` has finite complement, so a
+largest non-representable integer (the quantity the Hwang–Song formula computes)
+exists. Together with the obstruction file this gives the full dichotomy:
+
+    gcd{C(n,1), …, C(n,n-1)} = 1   ⟺   n is not a prime power.
+
+The proof rests on Lucas' theorem (`Mathlib.Data.Nat.Choose.Lucas`). For each
+prime `p ∣ n`, set `a = v_p(n)`. Then `C(n, p^a) ≡ n / p^a (mod p)` and
+`n / p^a = ordCompl[p] n` is coprime to `p`, so `p ∤ C(n, p^a)`. Hence no prime
+can divide all generators, i.e. the gcd is `1`.
+-/
+import Mathlib.Data.Nat.Choose.Lucas
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+namespace Erdos435.NonPrimePower
+
+open Finset
+
+/-- **Lucas core lemma.**
+For a prime `p` and `n > 0`, writing `a = v_p(n)` for the `p`-adic valuation of
+`n`, the prime `p` does *not* divide `C(n, p^a)`.
+
+By Lucas' theorem `C(n, p^a) ≡ C(n / p^a, 1) · ∏_{i<a} C(·, 0) ≡ n / p^a (mod p)`,
+and `n / p^a = ordCompl[p] n` is coprime to `p`. -/
+theorem not_dvd_choose_ordProj {p n : ℕ} (hp : p.Prime) (hn : 0 < n) :
+    ¬ p ∣ n.choose (p ^ (n.factorization p)) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  set a := n.factorization p with ha
+  -- Lucas' theorem, separating the top base-`p` block:
+  --   C(n, p^a) ≡ C(n/p^a, p^a/p^a) · ∏_{i<a} C(n/p^i % p, p^a/p^i % p)  (mod p)
+  have hl := Choose.choose_modEq_choose_mul_prod_range_choose (n := n) (k := p ^ a) (p := p) a
+  rw [← ZMod.intCast_eq_intCast_iff] at hl
+  -- The top quotient `p^a / p^a = 1`, and every lower block index `p^a / p^i % p = 0`.
+  have hdiv : p ^ a / p ^ a = 1 := Nat.div_self (pow_pos hp.pos a)
+  have hprod : (∏ i ∈ range a,
+      ((n / p ^ i % p).choose (p ^ a / p ^ i % p) : ZMod p)) = 1 := by
+    apply Finset.prod_eq_one
+    intro i hi
+    rw [Finset.mem_range] at hi
+    have hpd : p ^ a / p ^ i = p ^ (a - i) := Nat.pow_div (le_of_lt hi) hp.pos
+    have hz : p ^ (a - i) % p = 0 := by
+      have h1 : a - i = (a - i - 1) + 1 := by omega
+      rw [h1, pow_succ']
+      exact Nat.mul_mod_right p _
+    rw [hpd, hz, Nat.choose_zero_right, Nat.cast_one]
+  -- Cast the Lucas congruence into `ZMod p` and simplify.
+  have key : ((n.choose (p ^ a) : ℕ) : ZMod p) = ((n / p ^ a : ℕ) : ZMod p) := by
+    push_cast at hl
+    rw [hl, hdiv, hprod, mul_one, Nat.choose_one_right]
+  -- `p ∤ n / p^a = ordCompl[p] n`.
+  have hco : ¬ p ∣ (n / p ^ a) := Nat.not_dvd_ordCompl hp hn.ne'
+  -- Conclude.
+  intro hdvd
+  have : ((n.choose (p ^ a) : ℕ) : ZMod p) = 0 :=
+    (ZMod.natCast_eq_zero_iff _ _).mpr hdvd
+  rw [key] at this
+  exact hco ((ZMod.natCast_eq_zero_iff _ _).mp this)
+
+/-- **The non-prime-power case.**
+If `n ≥ 2` is not a prime power, then the generators `C(n,1), …, C(n,n-1)` are
+globally coprime:
+`gcd{C(n,1), …, C(n,n-1)} = 1`. -/
+theorem gcd_generators_eq_one {n : ℕ} (hn2 : 2 ≤ n) (hnp : ¬ IsPrimePow n) :
+    (Finset.Icc 1 (n - 1)).gcd (fun j => n.choose j) = 1 := by
+  by_contra hg
+  -- The gcd is `≠ 1`, so it has a prime factor `p`.
+  obtain ⟨p, hp, hpg⟩ := Nat.exists_prime_and_dvd hg
+  -- `p ∣ gcd ∣ C(n,1) = n`.
+  have h1mem : (1 : ℕ) ∈ Finset.Icc 1 (n - 1) := by rw [Finset.mem_Icc]; omega
+  have hgdvd1 : (Finset.Icc 1 (n - 1)).gcd (fun j => n.choose j) ∣ n.choose 1 :=
+    Finset.gcd_dvd h1mem
+  rw [Nat.choose_one_right] at hgdvd1
+  have hpn : p ∣ n := hpg.trans hgdvd1
+  set a := n.factorization p with ha
+  have hn0 : n ≠ 0 := by omega
+  -- `a = v_p(n) ≥ 1` since `p ∣ n`.
+  have hple : 1 ≤ a := hp.factorization_pos_of_dvd hn0 hpn
+  -- `p^a · (n/p^a) = n`.
+  have hsplit : p ^ a * (n / p ^ a) = n := Nat.ordProj_mul_ordCompl_eq_self n p
+  have hpa_pos : 1 ≤ p ^ a := Nat.one_le_pow _ _ hp.pos
+  -- `n/p^a ≥ 2`: otherwise `n = p^a`, a prime power, contradiction.
+  have hoc_pos : 0 < n / p ^ a := Nat.ordCompl_pos p hn0
+  have hoc_ne1 : n / p ^ a ≠ 1 := by
+    intro h1
+    apply hnp
+    refine ⟨p, a, hp.prime, hple, ?_⟩
+    rw [h1, mul_one] at hsplit
+    exact hsplit
+  have hoc2 : 2 ≤ n / p ^ a := by omega
+  -- `p^a ≤ n - 1`: from `2 · p^a ≤ p^a · (n/p^a) = n`.
+  have h2pa : p ^ a * 2 ≤ n := by
+    calc p ^ a * 2 ≤ p ^ a * (n / p ^ a) := by gcongr
+      _ = n := hsplit
+  have hpa_le : p ^ a ≤ n - 1 := by omega
+  -- `p^a` is a valid generator index.
+  have hpa_mem : p ^ a ∈ Finset.Icc 1 (n - 1) := by rw [Finset.mem_Icc]; exact ⟨hpa_pos, hpa_le⟩
+  -- `p ∣ gcd ∣ C(n, p^a)`, but the Lucas lemma says `p ∤ C(n, p^a)`.
+  have hpdvd : p ∣ n.choose (p ^ a) := hpg.trans (Finset.gcd_dvd hpa_mem)
+  exact not_dvd_choose_ordProj hp (by omega) hpdvd
+
+end Erdos435.NonPrimePower

--- a/proofs/Proofs/Erdos435PrimePowerObstruction.lean
+++ b/proofs/Proofs/Erdos435PrimePowerObstruction.lean
@@ -37,7 +37,7 @@ theorem prime_pow_dvd_choose {p k j : ℕ} (hp : p.Prime) (hk : 1 ≤ k)
   have hjle : j ≤ p ^ k := le_of_lt hjn
   -- Kummer: v_p(C(p^k, j)) = k - v_p(j)
   have hfact : ((p ^ k).choose j).factorization p = k - j.factorization p :=
-    Nat.factorization_choose_prime_pow hp.prime hjle hj0
+    Nat.factorization_choose_prime_pow hp hjle hj0
   -- v_p(j) < k, otherwise p^k ∣ j would contradict j < p^k
   have hjfact_lt : j.factorization p < k := by
     by_contra h

--- a/research/problems/erdos-435-oq-01/knowledge.md
+++ b/research/problems/erdos-435-oq-01/knowledge.md
@@ -21,6 +21,38 @@ session — it is the irreducible deep content of the problem.
 
 ---
 
+## Insights (Session 2026-06-25, researcher-6, CONVERSE SHIPPED + drift fix)
+
+- **Next Step 2 (the converse) is DONE.** New file
+  `proofs/Proofs/Erdos435NonPrimePower.lean` (118 lines, 0 sorries, 0 axioms,
+  verified/original) proves `gcd_generators_eq_one`: for `n ≥ 2` not a prime
+  power, `gcd{C(n,1),…,C(n,n-1)} = 1`. Together with the obstruction file this
+  is the full dichotomy `gcd = 1 ⟺ n not a prime power`. New gallery entry
+  `src/data/proofs/erdos-435-oq-01-oq-01/` (answers oq-01 openQuestions[0]).
+- **Lucas core lemma** `not_dvd_choose_ordProj`: for prime `p`, `n>0`,
+  `a = v_p(n)`, then `p ∤ C(n, p^a)`. Key trick: specialize Mathlib's
+  `Choose.choose_modEq_choose_mul_prod_range_choose a` to `k = p^a`. Top block
+  `p^a/p^a = 1` → factor `C(n/p^a, 1) = n/p^a`; lower blocks `p^a/p^i = p^(a-i)`,
+  `% p = 0` → `C(·,0) = 1`. So `C(n,p^a) ≡ n/p^a (mod p)`, and `n/p^a =
+  ordCompl[p] n` is `¬ p ∣ ·` by `Nat.not_dvd_ordCompl`. Cast bridge: ZMOD →
+  ZMod via `ZMod.intCast_eq_intCast_iff`; back to dvd via
+  `ZMod.natCast_eq_zero_iff` (note: `ZMod.natCast_zmod_eq_zero_iff_dvd`
+  DEPRECATED in 4.26.0).
+- **DRIFT FIX (integrity):** the shipped obstruction file
+  `Erdos435PrimePowerObstruction.lean` did NOT compile against pinned Mathlib
+  4.26.0 — `Nat.factorization_choose_prime_pow` now takes `Nat.Prime p`, not
+  `Prime p`, so the `hp.prime` arg was a type mismatch. It was committed
+  "build-pending" and shipped as verified without ever building. Fixed
+  `hp.prime → hp` (1 token); now `lake env lean` exits 0. The oq-01 entry's
+  "verified" claim is now actually true.
+- **Build env GOTCHA:** worktree `proofs/.lake` is a symlink to MAIN's
+  `proofs/.lake` (not circular as a prior note feared). Build with
+  `cd <worktree>/proofs && LAKE_UNSAFE=1 lake env lean Proofs/<F>.lean` — must
+  cd into the WORKTREE proofs dir, not main's, or you typecheck the wrong copy.
+  Mathlib oleans (7382) cached under `.lake/build/lib/lean/Mathlib/...` incl
+  `Choose/Lucas.olean`. `Nat.mod_eq_zero_iff_dvd` does NOT exist — for
+  `p^m % p = 0` rewrite `pow_succ'` then `Nat.mul_mod_right p _`.
+
 ## Insights (Session 2026-06-15, s1, FRESH)
 
 - **The 2-generator Sylvester–Frobenius case is already done.** The gallery has

--- a/src/data/proofs/erdos-435-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-435-oq-01-oq-01/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "erdos-435-oq-01-oq-01",
+  "title": "Erdős Problem #435 (OQ-01/OQ-01): The Non-Prime-Power Case (Converse)",
+  "slug": "erdos-435-oq-01-oq-01",
+  "description": "A machine-checked proof of the converse to the prime-power obstruction behind Erdős Problem #435: if n is NOT a prime power, then the generators {C(n,1), …, C(n,n-1)} are globally coprime, gcd = 1. Together with the obstruction entry this gives the full dichotomy gcd = 1 ⟺ n is not a prime power, so the numerical semigroup complement is finite exactly when the Hwang–Song Frobenius formula applies. The proof rests on Lucas' theorem: for each prime p ∣ n, C(n, p^(v_p n)) ≡ n / p^(v_p n) (mod p), and n / p^(v_p n) = ordCompl[p] n is coprime to p.",
+  "meta": {
+    "author": "lean-genius contributors (companion to Hwang–Song 2024 formalization)",
+    "sourceUrl": "https://erdosproblems.com/435",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos435NonPrimePower.lean",
+    "badge": "original",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "binomial-coefficients",
+      "frobenius-number",
+      "numerical-semigroups",
+      "lucas-theorem",
+      "p-adic-valuation",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "erdosNumber": 435,
+    "erdosUrl": "https://erdosproblems.com/435",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Choose.choose_modEq_choose_mul_prod_range_choose",
+        "description": "Lucas' theorem, top-block form: C(n,k) ≡ C(n/p^a, k/p^a) · ∏_{i<a} C(n/p^i % p, k/p^i % p) (mod p)",
+        "module": "Mathlib.Data.Nat.Choose.Lucas"
+      },
+      {
+        "theorem": "Nat.not_dvd_ordCompl",
+        "description": "p ∤ ordCompl[p] n = n / p^(v_p n): the prime-to-p part of n is coprime to p",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.ordProj_mul_ordCompl_eq_self",
+        "description": "p^(v_p n) · (n / p^(v_p n)) = n: the p-adic factorization split of n",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod p) = 0 ↔ p ∣ a, transporting the Lucas congruence to divisibility",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.gcd_dvd",
+        "description": "The Finset gcd divides every term, used to push p ∣ gcd onto the witness generator C(n, p^a)",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      }
+    ],
+    "assumptions": "None. Fully machine-checked with 0 axioms, 0 sorries, and no native_decide; the entire import closure is Mathlib-only. The result is unconditional: for any n ≥ 2 that is not a prime power it proves gcd{C(n,1), …, C(n,n-1)} = 1.",
+    "originalContributions": [
+      "Answers openQuestions[0] of the prime-power obstruction entry (erdos-435-oq-01): formalizes the converse for non-prime-powers, completing the dichotomy gcd = 1 ⟺ n is not a prime power.",
+      "not_dvd_choose_ordProj: for any prime p and n > 0, p ∤ C(n, p^(v_p n)). Proved by specializing Lucas' theorem to k = p^(v_p n): the top base-p block contributes C(n/p^a, 1) = n/p^a, every lower block contributes C(·, 0) = 1, so C(n, p^a) ≡ n/p^a (mod p), and n/p^a = ordCompl[p] n is coprime to p.",
+      "gcd_generators_eq_one: for n ≥ 2 not a prime power, gcd{C(n,1), …, C(n,n-1)} = 1. Any prime p dividing the gcd would divide C(n,1) = n, hence n; the witness generator C(n, p^(v_p n)) is a valid index (since n is not a prime power forces p^(v_p n) ≤ n−1) but is not divisible by p — contradiction.",
+      "Not a named Mathlib result: Mathlib has Lucas' theorem but no statement that the interior binomial coefficients of a non-prime-power are globally coprime; the reduction and packaging are supplied by the formalization."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #435 asks for the largest integer not representable as a non-negative integer combination of the binomial coefficients C(n,1), …, C(n,n-1), and is posed only for n that are NOT prime powers. The companion entry erdos-435-oq-01 formalizes why prime powers must be excluded — for n = p^k all interior coefficients share the factor p, so the gcd exceeds 1 and the numerical semigroup is not cofinite. The natural converse, raised as the first open question of that entry, is that the exclusion is exactly sharp: for every other n the interior coefficients are globally coprime. This entry supplies that converse with a short, fully verified Lucas-theorem argument, completing the dichotomy.",
+    "problemStatement": "**Non-prime-power case (converse).** Let $n \\geq 2$ be an integer that is not a prime power. Then\n$$\\gcd\\left\\{ \\binom{n}{1}, \\binom{n}{2}, \\ldots, \\binom{n}{n-1} \\right\\} = 1.$$\nEquivalently, no prime divides all of the interior binomial coefficients of $n$. Combined with the prime-power obstruction this yields the dichotomy $\\gcd = 1 \\iff n$ is not a prime power, so the associated numerical semigroup has finite complement — and a largest non-representable integer (the Hwang–Song quantity) exists — precisely for the $n$ in the scope of Erdős #435.",
+    "text": "A Lean 4 / Mathlib formalization (118 lines, 0 sorries, 0 axioms, Mathlib-only import closure) of the converse to the prime-power obstruction behind Erdős #435. The core lemma not_dvd_choose_ordProj specializes Mathlib's Lucas theorem Choose.choose_modEq_choose_mul_prod_range_choose to the binomial coefficient C(n, p^a) where a = v_p(n): the top base-p block evaluates to C(n/p^a, 1) = n/p^a, each lower block to C(·, 0) = 1, giving C(n, p^a) ≡ n/p^a (mod p); since n/p^a = ordCompl[p] n is coprime to p (Nat.not_dvd_ordCompl), p does not divide C(n, p^a). The headline gcd_generators_eq_one then argues by contradiction: a prime p dividing the gcd divides C(n,1) = n, and the witness index p^a lies in [1, n−1] exactly because n is not a prime power (so n/p^a ≥ 2), yet p ∤ C(n, p^a) — contradiction. Hence the gcd is 1.",
+    "proofStrategy": "1. **Lucas specialization.** For prime p and n > 0, set a = v_p(n). Lucas' theorem (top-block form) gives C(n, p^a) ≡ C(n/p^a, p^a/p^a) · ∏_{i<a} C(n/p^i % p, p^a/p^i % p) (mod p).\n\n2. **Evaluate the blocks.** p^a/p^a = 1 so the top factor is C(n/p^a, 1) = n/p^a; for i < a, p^a/p^i = p^(a−i) with a−i ≥ 1 so p^(a−i) % p = 0 and each lower factor is C(·, 0) = 1.\n\n3. **Congruence to ordCompl.** Hence C(n, p^a) ≡ n/p^a (mod p), i.e. (C(n,p^a) : ZMod p) = (n/p^a : ZMod p).\n\n4. **Coprimality.** n/p^a = ordCompl[p] n satisfies p ∤ n/p^a (Nat.not_dvd_ordCompl), so p ∤ C(n, p^a).\n\n5. **gcd = 1 by contradiction.** Suppose a prime p divides g = gcd{C(n,1),…,C(n,n-1)}. Then p ∣ g ∣ C(n,1) = n, so a = v_p(n) ≥ 1. Since n is not a prime power, n/p^a ≥ 2 (else n = p^a), giving 2·p^a ≤ n and so p^a ≤ n−1; thus p^a is a valid generator index. Then p ∣ g ∣ C(n, p^a), contradicting step 4. Hence g has no prime factor and g = 1.",
+    "keyInsights": [
+      "**Lucas isolates the right digit.** Choosing k = p^(v_p n) makes the base-p digits of k a single 1 in position a and zeros elsewhere. Lucas' theorem then collapses the whole product to one factor, C(n/p^a, 1) = n/p^a, turning a statement about a binomial coefficient into a statement about ordCompl[p] n.",
+      "**ordCompl carries the coprimality for free.** The quantity n/p^(v_p n) is by definition the prime-to-p part of n, so Nat.not_dvd_ordCompl gives p ∤ n/p^a with no extra work — the non-divisibility of C(n, p^a) is inherited directly.",
+      "**Why 'not a prime power' is exactly what is needed.** The argument requires the witness index p^a to be a genuine interior index, p^a ≤ n−1. This holds iff n/p^a ≥ 2, i.e. iff n has a second prime factor. For n = p^k the only candidate index p^a = n itself escapes the range — precisely the boundary handled by the obstruction entry.",
+      "**Sharp dichotomy.** Combined with erdos-435-oq-01 (gcd ≠ 1 for prime powers), this proves gcd{C(n,1),…,C(n,n-1)} = 1 ⟺ n is not a prime power. The Erdős #435 hypothesis is therefore not a convenience but the exact cofiniteness boundary for the underlying numerical semigroup.",
+      "**ZMod as the congruence bridge.** Mathlib's Lucas theorem is stated as an Int.ModEq; casting through ZMod p (a field, since p is prime) via ZMod.intCast_eq_intCast_iff turns the congruence into an equation, and ZMod.natCast_eq_zero_iff converts the final non-vanishing back into the divisibility statement p ∤ C(n, p^a)."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Lucas' theorem (base-p digit product)",
+      "p-adic valuation: Nat.factorization, ordProj, ordCompl",
+      "Numerical semigroups, global coprimality, and the Frobenius number"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "not_dvd_choose_ordProj",
+      "type": "core",
+      "description": "For a prime p and n > 0, with a = v_p(n) the p-adic valuation, the prime p does not divide C(n, p^a). Proved by specializing Lucas' theorem: C(n, p^a) ≡ n/p^a (mod p) and n/p^a = ordCompl[p] n is coprime to p.",
+      "leanType": "(hp : p.Prime) (hn : 0 < n) : ¬ p ∣ n.choose (p ^ (n.factorization p))"
+    },
+    {
+      "name": "gcd_generators_eq_one",
+      "type": "headline",
+      "description": "For n ≥ 2 that is not a prime power, the generators {C(n,1), …, C(n,n-1)} are globally coprime: gcd = 1. The converse to the prime-power obstruction, completing the dichotomy gcd = 1 ⟺ n is not a prime power.",
+      "leanType": "(hn2 : 2 ≤ n) (hnp : ¬ IsPrimePow n) : (Finset.Icc 1 (n - 1)).gcd (fun j => n.choose j) = 1"
+    }
+  ],
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "The module docstring states the converse behind Erdős #435: if n is not a prime power then gcd{C(n,1),…,C(n,n-1)} = 1, so the numerical semigroup complement is finite and the Hwang–Song Frobenius number exists. Records the proof idea: for each prime p ∣ n, Lucas' theorem gives C(n, p^(v_p n)) ≡ n/p^(v_p n) (mod p) and n/p^(v_p n) = ordCompl[p] n is coprime to p. Notes the full dichotomy with the obstruction file.",
+      "mathContext": "The Erdős #435 hypothesis 'n not a prime power' is exactly the cofiniteness boundary for the numerical semigroup generated by the interior binomial coefficients."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports & Namespace",
+      "startLine": 27,
+      "endLine": 34,
+      "summary": "Imports Mathlib's Lucas theorem (Nat.Choose.Lucas), the p-adic factorization API (Factorization.Basic, Prime.Basic) and Tactic, then opens the Erdos435.NonPrimePower namespace and Finset.",
+      "mathContext": "The decisive import is Nat.Choose.Lucas, which supplies the base-p digit-product congruence underlying the core lemma."
+    },
+    {
+      "id": "core-lemma",
+      "title": "Lucas Core Lemma",
+      "startLine": 36,
+      "endLine": 74,
+      "summary": "`not_dvd_choose_ordProj`: for prime p and n > 0, p ∤ C(n, p^(v_p n)). Specializes `Choose.choose_modEq_choose_mul_prod_range_choose` to k = p^a, evaluates the top block to C(n/p^a, 1) = n/p^a and the lower blocks to C(·, 0) = 1, casts through ZMod p, and concludes via `Nat.not_dvd_ordCompl`.",
+      "mathContext": "$\\binom{n}{p^a} \\equiv n/p^a \\pmod p$ with $a = v_p(n)$, and $n/p^a = \\operatorname{ordCompl}_p(n)$ is coprime to $p$, so $p \\nmid \\binom{n}{p^a}$."
+    },
+    {
+      "id": "non-prime-power",
+      "title": "The Non-Prime-Power Case",
+      "startLine": 76,
+      "endLine": 118,
+      "summary": "`gcd_generators_eq_one`: for n ≥ 2 not a prime power, gcd{C(n,1),…,C(n,n-1)} = 1. By contradiction: a prime p dividing the gcd divides C(n,1) = n; the witness index p^(v_p n) lies in [1, n−1] because n is not a prime power (n/p^a ≥ 2), yet the core lemma gives p ∤ C(n, p^a) — contradiction.",
+      "mathContext": "$\\gcd\\{\\binom{n}{j} : 1 \\le j \\le n-1\\} = 1$ for non-prime-power $n$; the semigroup complement is finite and the Frobenius number exists."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-435-oq-01",
+      "relationship": "extends",
+      "description": "Proves openQuestions[0] of the prime-power obstruction entry: the converse that for non-prime-powers the generator gcd is 1, completing the dichotomy gcd = 1 ⟺ n is not a prime power."
+    },
+    {
+      "targetId": "erdos-435",
+      "relationship": "extends",
+      "description": "Supplies the cofiniteness side condition of the main Erdős #435 entry: the gcd-1 result is exactly what makes the numerical semigroup complement finite, so the Hwang–Song Frobenius formula is well-posed for the n in scope."
+    }
+  ],
+  "conclusion": {
+    "summary": "The converse to the prime-power obstruction behind Erdős Problem #435 is formalized in 118 lines with 0 sorries and 0 axioms. For every n ≥ 2 that is not a prime power, gcd{C(n,1), …, C(n,n-1)} = 1: no prime divides all interior binomial coefficients, the witness being C(n, p^(v_p n)) ≡ ordCompl[p] n ≢ 0 (mod p) via Lucas' theorem. The numerical semigroup generated by the interior coefficients therefore has finite complement, so a largest non-representable integer exists.",
+    "implications": "Together with erdos-435-oq-01 (gcd ≠ 1 for prime powers) this completes the dichotomy gcd{C(n,1),…,C(n,n-1)} = 1 ⟺ n is not a prime power. The Erdős #435 restriction to non-prime-powers is thus exactly the boundary at which the underlying numerical semigroup becomes cofinite and the Hwang–Song Frobenius formula applies.",
+    "openQuestions": [
+      "Can the cofinite-complement consequence be connected formally to the main entry's representableSet, deriving existence of frobeniusBinomial n for non-prime-powers from gcd = 1?",
+      "Does the gcd-1 characterization extend to q-binomial (Gaussian) coefficients, with cyclotomic polynomials playing the role of the prime p?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Lucas",
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos435.NonPrimePower",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos435NonPrimePower.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **openQuestions[0]** of the prime-power obstruction entry
(`erdos-435-oq-01`): the converse for non-prime-powers, completing the dichotomy

> `gcd{C(n,1), …, C(n,n-1)} = 1  ⟺  n is not a prime power.`

The numerical semigroup generated by the interior binomial coefficients is
therefore cofinite — and the Hwang–Song Frobenius number exists — **exactly** for
the `n` in the scope of Erdős #435.

## What's new

`proofs/Proofs/Erdos435NonPrimePower.lean` (118 lines, 0 sorries, 0 axioms, verified/original):

- **`not_dvd_choose_ordProj`** — for a prime `p` and `n > 0` with `a = v_p(n)`,
  `p ∤ C(n, p^a)`. Specializes Mathlib's Lucas theorem
  (`Choose.choose_modEq_choose_mul_prod_range_choose`) to `k = p^a`: the top
  base-`p` block evaluates to `C(n/p^a, 1) = n/p^a`, every lower block to
  `C(·, 0) = 1`, so `C(n, p^a) ≡ n/p^a (mod p)`; and `n/p^a = ordCompl[p] n` is
  coprime to `p` (`Nat.not_dvd_ordCompl`).
- **`gcd_generators_eq_one`** — for `n ≥ 2` not a prime power,
  `gcd{C(n,1), …, C(n,n-1)} = 1`. By contradiction: a prime `p` dividing the
  gcd divides `C(n,1) = n`; the witness index `p^(v_p n)` lies in `[1, n-1]`
  precisely because `n` is not a prime power (so `n/p^a ≥ 2`), yet
  `p ∤ C(n, p^a)` — contradiction.

## Integrity fix (in scope)

`Erdos435PrimePowerObstruction.lean` (the `erdos-435-oq-01` entry, marked
`verified`) did **not** compile against the pinned Mathlib 4.26.0:
`Nat.factorization_choose_prime_pow` now takes `Nat.Prime p`, not `Prime p`, so
the `hp.prime` argument was a type mismatch. The file had been committed
"build-pending" and shipped as verified without ever building. Fixed
`hp.prime → hp` (1 token); `lake env lean` now exits 0, so the entry's
`verified` claim is now actually true.

## Verification

Both files typecheck via `lake env lean` against pinned Mathlib v4.26.0 (0 errors,
0 warnings). `#print axioms` on both new theorems lists only
`propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

## Files

- `proofs/Proofs/Erdos435NonPrimePower.lean` (new)
- `proofs/Proofs/Erdos435PrimePowerObstruction.lean` (drift fix)
- `proofs/Proofs.lean` (aggregator imports)
- `src/data/proofs/erdos-435-oq-01-oq-01/meta.json` (new gallery entry)
- `research/problems/erdos-435-oq-01/knowledge.md` (session notes)

## Status

**Outcome**: completed — converse proved, dichotomy closed, drift fixed.
**Next**: connect gcd = 1 formally to the main entry's `representableSet`
(existence of `frobeniusBinomial n` for non-prime-powers).

🤖 Generated by researcher-6