### PR TITLE
Fix: erdos-736 stale top-level sorries 1→0 (matches verified status)

### DIFF
--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -200,5 +200,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Correct a stale vestigial top-level `sorries: 1` field in `erdos-736/meta.json` that contradicted the entry's `verified` status.

## Evidence

The final sorry in `finite_case` was discharged in #29616 (discrete IVT for chromatic number), which updated `meta.sorries → 0` and `leanFile.sorries → 0`. The redundant **top-level** `sorries` field was missed and left at `1`.

**Before**:
- top-level `sorries: 1` ❌
- `meta.sorries: 0`, `leanFile.sorries: 0`, `meta.status: "verified"`
- `proofs/Proofs/Erdos736Problem.lean`: **0 real sorries** (the only `sorry` token is in a docstring reading "no `sorry`")

**After**:
- top-level `sorries: 0` ✅ — now consistent with the verified status, both nested counts, and the sorry-free Lean source

Note: `listings.json` (the runtime gallery source) already derives `sorries` from `meta.meta.sorries` and correctly shows `0`, so the live display was unaffected; this repair fixes the internal meta.json self-contradiction. The top-level field is also read directly by `HomePage.tsx`/`ErdosPage.tsx`, so aligning it prevents a fully-verified Erdős entry from ever being miscounted as incomplete.

One-line diff, JSON validated.

---
Automated fix by lean-mechanic agent.