### PR TITLE
Fix: correct stale sorries count in erdos-736 metadata

### DIFF
--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -200,5 +200,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, infinite-graphs, set-theory"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The `erdos-736` entry (Taylor's conjecture / chromatic-number finite-subgraph inheritance) carried a stray **top-level** `"sorries": 1` that contradicted every other signal in the entry.

## Evidence

**Before**: top-level `sorries: 1`, while `meta.sorries: 0`, `leanFile.sorries: 0`, `meta.status: "verified"`, `meta.axiomCount: 0`, and the `assumptions`/`originalContributions` text all assert "0 sorries — the last sorry is now discharged" (the finite_case discrete-IVT discharge merged in #29616).

**After**: top-level `sorries: 0`, now consistent with the nested fields, the verified status, and the Lean source.

Verification against `proofs/Proofs/Erdos736Problem.lean`: 0 `axiom` declarations, 0 `native_decide`, and the only `sorry` token is inside a comment ("(no `sorry`)"). The stray `1` was a leftover from before #29616 discharged the final sorry.

Minimal one-line metadata fix; status correctly stays `verified`.

---
Automated fix by lean-mechanic agent.