### PR TITLE
Gallery audit: 4 entries clean (WZ method, cauchy power-map fibres, dini sharp modulus, ptolemy converse-axiom discharge)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23537,8 +23537,36 @@
       "lastAudited": "2026-06-25T08:05:00Z",
       "result": "clean",
       "notes": "Inversion carries circle-through-centre to a line (cospherical iff images on hyperplane); verified/original/0-ax/0-sorry, 5 theorems match meta. Original. CLEAN."
+    },
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:20:00Z",
+      "result": "clean",
+      "notes": "WZ/creative-telescoping engine + hand-verified WZ certificate for Σ C(n,k)=2ⁿ; verified/original/0-ax/0-sorry/0-native_decide, 10 theorems + 3 defs (def F, def G, abbrev rowSum) match meta. Mathlib telescoping deps disclosed in assumptions. Original infrastructure, not a wrapper. CLEAN."
+    },
+    "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:20:00Z",
+      "result": "clean",
+      "notes": "Power-map fibre sizes constant on finite abelian groups; #fibre·#{xⁿ=1}=|G| and product-of-cyclics ∏gcd(n,mᵢ); verified/original/0-ax/0-sorry, 8 theorems match leanFile. Builds on parent card_fiber_pow (disclosed). CLEAN."
+    },
+    "dini-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:20:00Z",
+      "result": "clean",
+      "notes": "Sharp modulus sup_{x∈[0,1)}|xⁿ|=1 improving parent 1/2; verified/original/0-ax/0-sorry, 6 theorems match meta. #print axioms reports only foundational axioms (disclosed). CLEAN."
+    },
+    "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T08:20:00Z",
+      "result": "clean",
+      "notes": "Discharges parent unit-circle converse axiom positive_ratio_implies_cyclic_order as a theorem; verified/original/0-ax/0-sorry, 12 theorems + 2 defs (1 def + 1 structure) match meta. #print axioms confirms axiom absent. CLEAN."
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T08:00:00Z"
+  "lastUpdated": "2026-06-25T08:20:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 4 freshly-merged research entries (never previously audited). All **clean** — no overclaims.

| slug | status/badge | sorries | axioms | native_decide | counts |
|------|-------------|---------|--------|---------------|--------|
| arithmetic-series-oq-02-oq-02-oq-03-oq-04 | verified/original | 0 | 0 | 0 | 10 thm + 3 def ✓ |
| cauchy-group-…-oq-03-oq-02-oq-02 | verified/original | 0 | 0 | 0 | 8 thm ✓ |
| dini-theorem-oq-01-oq-02 | verified/original | 0 | 0 | 0 | 6 thm ✓ |
| ptolemys-theorem-oq-01-oq-01-oq-03-oq-02 | verified/original | 0 | 0 | 0 | 12 thm + 2 def ✓ |

### Checks performed (comment-stripped Lean source)
- **0 sorries**, **0 `axiom` declarations**, **0 `native_decide`**, **0 `True`/`trivial` stubs** in all four files.
- Theorem/definition counts match meta (arithmetic defCount 3 = `def F` + `def G` + `abbrev rowSum`; ptolemy defCount 2 = 1 `def` + 1 `structure`).
- All four are genuine **original contributions**, not Mathlib delegation-opacity wrappers:
  - WZ entry builds a reusable creative-telescoping engine + hand-verified certificate.
  - cauchy entry derives constant power-map fibre sizes (builds on parent `card_fiber_pow`, disclosed).
  - dini entry proves a sharp modulus improving the parent's 1/2 bound.
  - ptolemy entry **discharges the parent's `positive_ratio_implies_cyclic_order` axiom as a theorem** (`#print axioms` confirms axiom absent).
- Mathlib reliance honestly disclosed in each `assumptions` field; `#print axioms` claims report only foundational `propext`/`Classical.choice`/`Quot.sound`.

The other 4 currently-unaudited slugs are covered by open PR #29818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)