### PR TITLE
research(beta-integral-oq010301): off-diagonal real Euler Beta integral, two ways [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -340,6 +340,7 @@ import Proofs.BertrandsPostulateOQ03OQ04OQ03
 import Proofs.BetaCentralBinomial
 import Proofs.BetaIntegralHalfValue
 import Proofs.BetaIntegralRecurrence
+import Proofs.BetaIntegralRecurrenceOQ01OQ03OQ01
 import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01
 import Proofs.BezoutIdentityOQ01Aristotle

--- a/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01.lean
@@ -1,0 +1,169 @@
+/-
+# Beta Integral OQ-01 (leaf oq-03-oq-01): the off-diagonal real Euler Beta integral
+
+The parent leaf `BetaIntegralRecurrenceOQ01OQ03` supplied the **diagonal** real integral
+`∫₀¹ xⁿ(1-x)ⁿ dx = (n!)²/(2n+1)!`. This leaf supplies the full **off-diagonal** real
+Euler Beta integral at integer arguments:
+
+  `∫₀¹ xᵐ(1-x)ⁿ dx = m!·n! / (m+n+1)!`.
+
+It is proved **two independent ways**, which is the point of the entry:
+
+1. `integral_offdiag_eq_factorial` — via the complex bridge.  Cast the real integral into
+   ℂ, recognise it as `Complex.betaIntegral (m+1) (n+1)` (the integrand `x^(u-1)(1-x)^(v-1)`
+   collapses to monoid powers on `[0,1]` via `Complex.cpow_natCast`), and read off the
+   closed form from the parent's `betaIntegral_nat_nat`.  This generalises the parent's
+   diagonal bridge `ofReal_integral_diag` to `m ≠ n`.
+
+2. `integral_offdiag_via_ibp` — a **self-contained real-analysis proof** that never leaves
+   ℝ.  The single recurrence
+
+     `integral_recurrence : ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ`
+
+   is genuine integration by parts (`integral_mul_deriv_eq_deriv_mul`, boundary terms
+   vanish), and induction on `n` down to the base `∫₀¹ xᵐ⁺ⁿ = 1/(m+n+1)` gives the closed
+   form independently of Mathlib's `Complex.Gamma`.  `agreement` checks the two routes
+   coincide.
+
+Neither the off-diagonal real integral nor this recurrence is in Mathlib (which has only the
+complex analytic `betaIntegral`).
+
+*Reference:* Euler Beta function at integer arguments; Mathlib
+`Mathlib.Analysis.SpecialFunctions.Gamma.Beta`.
+-/
+
+import Proofs.BetaIntegralRecurrence
+import Mathlib.Tactic
+
+open Complex intervalIntegral MeasureTheory
+
+namespace BetaIntegralRecurrenceOQ01OQ03OQ01
+
+/-! ## Route 1 — the complex bridge -/
+
+/-- **Bridge to the real line, off-diagonal.** The complex Beta integral `B(m+1,n+1)` is the
+real integral of `xᵐ(1-x)ⁿ`, cast into ℂ.  On `[0,1]` the complex powers
+`(x:ℂ)^((m+1)-1)`, `(1-x)^((n+1)-1)` collapse to monoid powers via `Complex.cpow_natCast`,
+and the integral descends through `ofReal`. -/
+theorem ofReal_integral_offdiag (m n : ℕ) :
+    (((∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n) : ℝ) : ℂ)
+      = betaIntegral ((m : ℂ) + 1) ((n : ℂ) + 1) := by
+  rw [betaIntegral, ← intervalIntegral.integral_ofReal]
+  refine intervalIntegral.integral_congr (fun x _ => ?_)
+  have hm : ((m : ℂ) + 1) - 1 = (m : ℂ) := by ring
+  have hn : ((n : ℂ) + 1) - 1 = (n : ℂ) := by ring
+  rw [hm, hn, Complex.cpow_natCast, Complex.cpow_natCast]
+  push_cast
+  ring
+
+/-- **The off-diagonal real Euler Beta integral.**
+`∫₀¹ xᵐ(1-x)ⁿ dx = m!·n! / (m+n+1)!`.  Proof via the complex closed form. -/
+theorem integral_offdiag_eq_factorial (m n : ℕ) :
+    ∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n
+      = (m.factorial : ℝ) * (n.factorial : ℝ) / ((m + n + 1).factorial : ℝ) := by
+  have h := ofReal_integral_offdiag m n
+  rw [BetaIntegralRecurrence.betaIntegral_nat_nat m n] at h
+  have hrhs :
+      (m.factorial : ℂ) * (n.factorial : ℂ) / ((m + n + 1).factorial : ℂ)
+        = (((m.factorial : ℝ) * (n.factorial : ℝ) / ((m + n + 1).factorial : ℝ)) : ℂ) := by
+    push_cast; ring
+  rw [hrhs] at h
+  exact_mod_cast h
+
+/-! ## Route 2 — a self-contained real integration-by-parts proof -/
+
+/-- **Base case.** `∫₀¹ xᵏ(1-x)⁰ = 1/(k+1)`, i.e. `∫₀¹ xᵏ = 1/(k+1)`. -/
+theorem integral_base (k : ℕ) :
+    ∫ x in (0:ℝ)..1, x ^ k * (1 - x) ^ 0 = 1 / ((k : ℝ) + 1) := by
+  simp only [pow_zero, mul_one]
+  rw [integral_pow]
+  simp
+
+/-- **Integration-by-parts recurrence (pure real analysis).**
+`∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1)) · ∫₀¹ xᵐ⁺¹(1-x)ⁿ`.
+
+Integrate by parts with `u = (1-x)ⁿ⁺¹`, `v = xᵐ⁺¹/(m+1)`; both boundary terms vanish. -/
+theorem integral_recurrence (m n : ℕ) :
+    ∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ (n + 1)
+      = ((n : ℝ) + 1) / ((m : ℝ) + 1) * ∫ x in (0:ℝ)..1, x ^ (m + 1) * (1 - x) ^ n := by
+  -- derivative of u = (1-x)^(n+1)
+  have hu : ∀ x ∈ Set.uIcc (0:ℝ) 1,
+      HasDerivAt (fun y : ℝ => (1 - y) ^ (n + 1))
+        (((n : ℝ) + 1) * (1 - x) ^ n * (-1)) x := by
+    intro x _
+    have h1 : HasDerivAt (fun y : ℝ => 1 - y) (-1) x := by
+      simpa using (hasDerivAt_id x).const_sub (1 : ℝ)
+    have h2 := h1.pow (n + 1)
+    simp only [Nat.add_sub_cancel] at h2
+    convert h2 using 1
+    push_cast; ring
+  -- derivative of v = x^(m+1)/(m+1)
+  have hv : ∀ x ∈ Set.uIcc (0:ℝ) 1,
+      HasDerivAt (fun y : ℝ => y ^ (m + 1) / ((m : ℝ) + 1)) (x ^ m) x := by
+    intro x _
+    have h := (hasDerivAt_pow (m + 1) x).div_const ((m : ℝ) + 1)
+    simp only [Nat.add_sub_cancel] at h
+    convert h using 1
+    push_cast
+    field_simp
+  have hu' : IntervalIntegrable (fun x => ((n : ℝ) + 1) * (1 - x) ^ n * (-1)) volume 0 1 := by
+    apply Continuous.intervalIntegrable; fun_prop
+  have hv' : IntervalIntegrable (fun x : ℝ => x ^ m) volume 0 1 := by
+    apply Continuous.intervalIntegrable; fun_prop
+  have key := integral_mul_deriv_eq_deriv_mul hu hv hu' hv'
+  -- rewrite the target integrand into the IBP order  u * v'
+  rw [show (∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ (n + 1))
+        = ∫ x in (0:ℝ)..1, (1 - x) ^ (n + 1) * x ^ m from
+        integral_congr (fun x _ => by ring)]
+  rw [key]
+  -- boundary terms vanish
+  have e1 : ((1:ℝ) - 1) ^ (n + 1) = 0 := by rw [sub_self]; exact zero_pow (Nat.succ_ne_zero n)
+  have e2 : ((0:ℝ)) ^ (m + 1) = 0 := zero_pow (Nat.succ_ne_zero m)
+  rw [e1, e2]
+  -- pull the constant out of the remaining integral
+  rw [show (∫ x in (0:ℝ)..1,
+            ((n : ℝ) + 1) * (1 - x) ^ n * (-1) * (x ^ (m + 1) / ((m : ℝ) + 1)))
+        = ∫ x in (0:ℝ)..1,
+            (-(((n : ℝ) + 1) / ((m : ℝ) + 1))) * (x ^ (m + 1) * (1 - x) ^ n) from
+        integral_congr (fun x _ => by ring)]
+  rw [intervalIntegral.integral_const_mul]
+  ring
+
+/-- **The off-diagonal real Euler Beta integral, proved without leaving ℝ.**
+Induction on `n` via `integral_recurrence`, base case `integral_base`. -/
+theorem integral_offdiag_via_ibp (m n : ℕ) :
+    ∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n
+      = (m.factorial : ℝ) * (n.factorial : ℝ) / ((m + n + 1).factorial : ℝ) := by
+  induction n generalizing m with
+  | zero =>
+    rw [integral_base m]
+    simp only [Nat.factorial_zero, Nat.cast_one, mul_one, Nat.add_zero]
+    have hfac : ((m + 1).factorial : ℝ) = ((m : ℝ) + 1) * (m.factorial : ℝ) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    have hmf : (m.factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos m).ne'
+    have hm1 : ((m : ℝ) + 1) ≠ 0 := by positivity
+    rw [hfac]
+    field_simp
+  | succ n ih =>
+    rw [integral_recurrence m n, ih (m + 1)]
+    -- ((n+1)/(m+1)) * ((m+1)! (n)! / (m+1+n+1)!) = m! (n+1)! / (m+(n+1)+1)!
+    have hm1 : ((m + 1).factorial : ℝ) = (m.factorial : ℝ) * ((m : ℝ) + 1) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    have hn1 : ((n + 1).factorial : ℝ) = (n.factorial : ℝ) * ((n : ℝ) + 1) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    have hidx : m + 1 + n + 1 = m + (n + 1) + 1 := by ring
+    have hmpos : (0:ℝ) < (m.factorial : ℝ) := by exact_mod_cast Nat.factorial_pos m
+    have hfac : (0:ℝ) < ((m + (n + 1) + 1).factorial : ℝ) := by
+      exact_mod_cast Nat.factorial_pos _
+    rw [hidx, hm1, hn1]
+    field_simp
+
+/-- **Symmetry `m ↔ n`** of the off-diagonal Beta integral, read off the closed form. -/
+theorem integral_offdiag_symm (m n : ℕ) :
+    (∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n)
+      = ∫ x in (0:ℝ)..1, x ^ n * (1 - x) ^ m := by
+  rw [integral_offdiag_eq_factorial, integral_offdiag_eq_factorial,
+      Nat.add_comm n m]
+  ring
+
+end BetaIntegralRecurrenceOQ01OQ03OQ01

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "The off-diagonal real Beta integral, two ways",
+    "content": "The parent leaf brought the diagonal Beta value ∫₀¹ xⁿ(1-x)ⁿ = (n!)²/(2n+1)! down to ℝ. This entry answers its first open question: the full off-diagonal value ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! for independent m, n. It is proved two independent ways — Route 1 reuses Mathlib's complex Beta theory via a ℂ→ℝ bridge; Route 2 is a self-contained real proof using a single integration by parts and induction, invoking no complex analysis at all."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 44, "endLine": 57 },
+    "type": "theorem",
+    "title": "Route 1: the off-diagonal ℂ → ℝ bridge",
+    "content": "ofReal_integral_offdiag: ↑(∫ x in 0..1, xᵐ(1-x)ⁿ) = Complex.betaIntegral (m+1)(n+1). The complex integrand is (x:ℂ)^((m+1)-1)·(1-x)^((n+1)-1); each exponent reduces to a natural (m, n), so Complex.cpow_natCast turns the complex powers into monoid powers with no positivity side condition, and the integrand becomes ↑(xᵐ(1-x)ⁿ). intervalIntegral.integral_ofReal (via integral_congr on [0,1]) descends the integral. This generalizes the parent's diagonal bridge by treating the two exponents separately."
+  },
+  {
+    "id": "ann-value",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 59, "endLine": 71 },
+    "type": "theorem",
+    "title": "The closed form from the complex value",
+    "content": "integral_offdiag_eq_factorial: ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!. Rewrite the bridge's right side with the grandparent's betaIntegral_nat_nat (= m!·n!/(m+n+1)! over ℂ), recognize the real and complex casts agree (push_cast), and transfer the equality back to ℝ by injectivity of the ℝ→ℂ cast (exact_mod_cast). This is the parent's open question, answered."
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 82, "endLine": 130 },
+    "type": "theorem",
+    "title": "Route 2: the integration-by-parts recurrence",
+    "content": "integral_recurrence: ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ. Apply integral_mul_deriv_eq_deriv_mul with u = (1-x)ⁿ⁺¹ (derivative via HasDerivAt.pow) and v = xᵐ⁺¹/(m+1) (derivative via hasDerivAt_pow.div_const, value x^m). Both boundary terms vanish: at x=1, (1-1)ⁿ⁺¹ = 0; at x=0, 0ᵐ⁺¹ = 0 (zero_pow on a successor). Pulling the constant out with integral_const_mul leaves the pure recurrence. This recurrence is not in Mathlib and is the engine of the independent real proof."
+  },
+  {
+    "id": "ann-induction",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 132, "endLine": 159 },
+    "type": "theorem",
+    "title": "Closed form without leaving ℝ",
+    "content": "integral_offdiag_via_ibp: the same closed form m!·n!/(m+n+1)!, proved by induction on n with m generalized. Base case: ∫₀¹ xᵐ = 1/(m+1) (integral_base) matches m!·0!/(m+1)!. Successor: apply integral_recurrence and the induction hypothesis ih(m+1), then close with factorial arithmetic (Nat.factorial_succ, field_simp). This route uses only the fundamental theorem of calculus over ℝ — no Complex.Gamma — giving an independent confirmation of the value from Route 1."
+  },
+  {
+    "id": "ann-symmetry",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+    "range": { "startLine": 161, "endLine": 169 },
+    "type": "theorem",
+    "title": "The m ↔ n symmetry",
+    "content": "integral_offdiag_symm: ∫₀¹ xᵐ(1-x)ⁿ = ∫₀¹ xⁿ(1-x)ᵐ. Both sides equal m!·n!/(m+n+1)! (commutativity of m+n in the denominator), so the symmetry — geometrically the substitution x ↦ 1-x — is read directly off the closed form."
+  }
+]

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+  "title": "The Off-Diagonal Real Euler Beta Integral ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, proved two ways",
+  "slug": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+  "description": "Answers the parent leaf's first open question: generalize the diagonal real Beta integral to the full off-diagonal value ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!. The result is proved two independent ways. Route 1 (integral_offdiag_eq_factorial) generalizes the parent's ℂ→ℝ bridge: the real integral cast into ℂ is Complex.betaIntegral (m+1)(n+1) — the complex powers (x:ℂ)^((m+1)-1), (1-x)^((n+1)-1) collapse to monoid powers via Complex.cpow_natCast on [0,1], the integral descends through intervalIntegral.integral_ofReal — and the closed form is read off the parent's betaIntegral_nat_nat. Route 2 (integral_offdiag_via_ibp) is a self-contained real-analysis proof that never leaves ℝ: the single integration-by-parts recurrence ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ (integral_recurrence, via integral_mul_deriv_eq_deriv_mul with both boundary terms vanishing) plus induction on n down to the base ∫₀¹ xᵐ⁺ⁿ = 1/(m+n+1) gives the closed form independently of Mathlib's Complex.Gamma. integral_offdiag_symm records the m↔n symmetry. Neither the off-diagonal real integral nor the recurrence is in Mathlib. Fully verified: 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01.lean",
+    "tags": [
+      "special-functions",
+      "beta-function",
+      "interval-integral",
+      "integration-by-parts",
+      "measure-theory",
+      "factorial",
+      "euler-integral"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.betaIntegral",
+        "description": "B(u,v) = ∫ x:ℝ in 0..1, (x:ℂ)^(u-1)·(1-x)^(v-1); recognized as the off-diagonal real integrand cast into ℂ at u=m+1, v=n+1",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.cpow_natCast",
+        "description": "z^(n:ℂ) = z^n; collapses the complex powers (x:ℂ)^((m+1)-1), (1-x)^((n+1)-1) to the monoid powers (x:ℂ)^m, (1-x)^n on [0,1]",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
+      },
+      {
+        "theorem": "intervalIntegral.integral_ofReal",
+        "description": "∫ x in a..b, (f x : ℂ) = ↑(∫ x in a..b, f x); descends the complex Beta integral to the real integral once the integrand is a cast real function",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "intervalIntegral.integral_mul_deriv_eq_deriv_mul",
+        "description": "Integration by parts ∫ u·v' = u·v |ₐᵇ − ∫ u'·v for functions with HasDerivAt everywhere; the engine of the self-contained real recurrence with u=(1-x)ⁿ⁺¹, v=xᵐ⁺¹/(m+1)",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts"
+      },
+      {
+        "theorem": "intervalIntegral.integral_pow",
+        "description": "∫ x in a..b, xᵏ = (bᵏ⁺¹−aᵏ⁺¹)/(k+1); supplies the induction base ∫₀¹ xᵏ = 1/(k+1) for the IBP route",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrals.Basic"
+      },
+      {
+        "theorem": "HasDerivAt.pow",
+        "description": "(d/dx) f(x)ᵏ = k·f(x)ᵏ⁻¹·f'(x); used to differentiate (1-x)ⁿ⁺¹ for the integration-by-parts setup",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Pow"
+      },
+      {
+        "theorem": "BetaIntegralRecurrence.betaIntegral_nat_nat",
+        "description": "Parent (grandparent leaf): B(m+1,n+1) = m!·n!/(m+n+1)! over ℂ; supplies the closed-form value reused after the ℂ→ℝ bridge in Route 1",
+        "module": "Proofs.BetaIntegralRecurrence"
+      }
+    ],
+    "originalContributions": [
+      "integral_offdiag_eq_factorial: the off-diagonal real Euler Beta integral ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! — the m ≠ n generalization of the parent leaf's diagonal integral, and exactly the parent's first open question. Mathlib has only the ℂ-valued Complex.betaIntegral; this is the real integral of the polynomial integrand for independent m, n.",
+      "ofReal_integral_offdiag: the off-diagonal ℂ→ℝ bridge ↑(∫₀¹ xᵐ(1-x)ⁿ) = Complex.betaIntegral (m+1)(n+1), generalizing the parent's diagonal bridge by collapsing each complex power separately via Complex.cpow_natCast.",
+      "integral_recurrence: a self-contained real integration-by-parts recurrence ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ, proved directly over ℝ (integral_mul_deriv_eq_deriv_mul, both boundary terms vanishing). This is not in Mathlib and is the key new technical ingredient of the alternative route.",
+      "integral_offdiag_via_ibp: a second, fully independent proof of the closed form by induction on n via integral_recurrence and the base ∫₀¹ xᵐ⁺ⁿ = 1/(m+n+1) — deriving the off-diagonal Beta value without leaving ℝ and without invoking Mathlib's Complex.Gamma at all.",
+      "integral_offdiag_symm: the m↔n symmetry ∫₀¹ xᵐ(1-x)ⁿ = ∫₀¹ xⁿ(1-x)ᵐ, read off the closed form (the substitution x ↦ 1-x at the level of values)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) for integral_offdiag_eq_factorial, integral_offdiag_via_ibp, and integral_recurrence. No native_decide, so no Lean.ofReduceBool dependency. Route 1 imports the grandparent BetaIntegralRecurrence to reuse the complex closed form; Route 2 is independent of it. Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 169,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Euler Beta integral B(u,v) = ∫₀¹ x^(u-1)(1-x)^(v-1) dx at integer arguments gives the rational value m!·n!/(m+n+1)!, a staple of combinatorics, probability (the Beta distribution), and Bayesian statistics (the Beta–Binomial conjugacy). Mathlib develops the Beta function analytically as the ℂ-valued Complex.betaIntegral and relates it to Gamma, but it does not record the real-variable integer integral, and it has no integration-by-parts recurrence for it. The parent gallery leaf brought the diagonal value B(n+1,n+1) = (n!)²/(2n+1)! down to ℝ; its first open question asks whether the descent generalizes to the off-diagonal integral. This entry answers that question, and then proves the same value a second time by a self-contained real argument.",
+    "problemStatement": "Prove the off-diagonal real Euler Beta integral ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! for all naturals m, n, generalizing the parent's diagonal case, ideally by the elementary integration-by-parts recurrence (m,n) ↦ reduce n.",
+    "proofStrategy": "Two independent routes. Route 1 (complex bridge): ofReal_integral_offdiag unfolds Complex.betaIntegral (m+1)(n+1); the exponents (m+1)-1, (n+1)-1 are the naturals m, n, so Complex.cpow_natCast turns the complex powers into monoid powers and the integrand equals ↑(xᵐ(1-x)ⁿ); intervalIntegral.integral_ofReal (via integral_congr on [0,1]) descends the integral. integral_offdiag_eq_factorial then rewrites with the grandparent's betaIntegral_nat_nat and transfers to ℝ by exact_mod_cast. Route 2 (pure real): integral_recurrence integrates ∫₀¹ xᵐ(1-x)ⁿ⁺¹ by parts with u = (1-x)ⁿ⁺¹, v = xᵐ⁺¹/(m+1); u(1) = 0 and v(0) = 0 kill both boundary terms, leaving ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ. integral_offdiag_via_ibp inducts on n: the base case ∫₀¹ xᵐ⁺⁰ = 1/(m+1) (integral_base, from integral_pow) matches m!·0!/(m+1)!, and the inductive step applies the recurrence and ih(m+1), closing with factorial arithmetic (Nat.factorial_succ, field_simp). integral_offdiag_symm reads the m↔n symmetry off the closed form.",
+    "keyInsights": [
+      "**The off-diagonal integrand is still a cast real polynomial.** For u = m+1, v = n+1 the cpow exponents (m+1)-1 = m and (n+1)-1 = n are naturals, so each complex power (x:ℂ)^(m:ℂ) is the monoid power (x:ℂ)^m (Complex.cpow_natCast) — no branch cuts. The whole complex integrand is ↑(xᵐ(1-x)ⁿ), so the descent that worked on the diagonal works verbatim off-diagonal; only the exponents differ.",
+      "**One integration by parts is the entire content of the real route.** Writing the integrand as (1-x)ⁿ⁺¹ · d/dx(xᵐ⁺¹/(m+1)), integration by parts moves one factor of (1-x) onto x: both endpoint contributions vanish (xᵐ⁺¹ at 0, (1-x)ⁿ⁺¹ at 1), giving the clean recurrence ((n+1)/(m+1)) that decrements the second exponent. The Beta value is then forced by induction and the trivial base ∫₀¹ xᵏ = 1/(k+1).",
+      "**Two independent proofs pin the same rational value.** Route 1 routes through Mathlib's analytic Gamma/Beta theory over ℂ; Route 2 uses nothing beyond the fundamental theorem of calculus over ℝ. That a purely real, elementary argument reproduces the value obtained from the complex special-function machinery is a useful cross-check and makes the result robust to either dependency.",
+      "**Boundary terms vanish by exponent positivity.** In integral_recurrence the surviving exponents are n+1 ≥ 1 and m+1 ≥ 1, so (1-1)ⁿ⁺¹ = 0 and 0ᵐ⁺¹ = 0 (zero_pow on a successor); this is exactly why integration by parts produces a pure recurrence with no leftover constant.",
+      "**Factorial bookkeeping is the only arithmetic.** The inductive step reduces to ((n+1)/(m+1))·((m+1)!·n!/(m+1+n+1)!) = m!·(n+1)!/(m+(n+1)+1)!, which Nat.factorial_succ + field_simp discharge after recording factorial positivity for the nonzero denominators."
+    ],
+    "prerequisites": [
+      "The Euler Beta integral and its integer closed form m!·n!/(m+n+1)!",
+      "Complex powers (cpow) versus monoid powers, and Complex.cpow_natCast",
+      "Integration by parts for interval integrals (integral_mul_deriv_eq_deriv_mul) and HasDerivAt for polynomials",
+      "Induction with a strengthened parameter (generalizing m while inducting on n)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "complex-bridge",
+      "title": "Route 1 — the complex bridge",
+      "startLine": 42,
+      "endLine": 72,
+      "summary": "ofReal_integral_offdiag casts the real integral ∫₀¹ xᵐ(1-x)ⁿ into ℂ and identifies it with Complex.betaIntegral (m+1)(n+1): the exponents (m+1)-1, (n+1)-1 reduce to m, n, Complex.cpow_natCast collapses the complex powers to monoid powers, and intervalIntegral.integral_ofReal descends the integral. integral_offdiag_eq_factorial rewrites the right side with the grandparent's betaIntegral_nat_nat and transfers the equality to ℝ by exact_mod_cast, giving ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!.",
+      "mathContext": "↑(∫₀¹ xᵐ(1-x)ⁿ) = Complex.betaIntegral (m+1)(n+1) = m!·n!/(m+n+1)!."
+    },
+    {
+      "id": "ibp-recurrence",
+      "title": "Route 2 — integration-by-parts recurrence",
+      "startLine": 73,
+      "endLine": 131,
+      "summary": "integral_base gives the induction base ∫₀¹ xᵏ(1-x)⁰ = 1/(k+1) from integral_pow. integral_recurrence integrates ∫₀¹ xᵐ(1-x)ⁿ⁺¹ by parts with u = (1-x)ⁿ⁺¹ and v = xᵐ⁺¹/(m+1) (derivatives via HasDerivAt.pow and hasDerivAt_pow.div_const); both boundary terms vanish because (1-1)ⁿ⁺¹ = 0 and 0ᵐ⁺¹ = 0, leaving the pure recurrence ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ after pulling the constant out (integral_const_mul).",
+      "mathContext": "∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ."
+    },
+    {
+      "id": "induction-and-symmetry",
+      "title": "Closed form by induction, and symmetry",
+      "startLine": 132,
+      "endLine": 169,
+      "summary": "integral_offdiag_via_ibp inducts on n (generalizing m): the base case matches m!·0!/(m+1)! and the successor case applies integral_recurrence and the induction hypothesis ih(m+1), closing with Nat.factorial_succ and field_simp — a proof of the closed form that never leaves ℝ. integral_offdiag_symm reads the m↔n symmetry ∫₀¹ xᵐ(1-x)ⁿ = ∫₀¹ xⁿ(1-x)ᵐ off the closed form.",
+      "mathContext": "∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! = ∫₀¹ xⁿ(1-x)ᵐ."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Whittaker, E. T.; Watson, G. N.",
+      "title": "A Course of Modern Analysis",
+      "year": "1927",
+      "note": "The Euler Beta integral B(u,v) = ∫₀¹ x^(u-1)(1-x)^(v-1) dx and its reduction to Gamma; integer arguments give m!·n!/(m+n+1)!."
+    },
+    {
+      "authors": "Artin, E.",
+      "title": "The Gamma Function",
+      "year": "1964",
+      "note": "Elementary development of the Beta and Gamma functions, including the integration-by-parts recurrence underlying the integer evaluation."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Parent leaf 'The Symmetric Beta Density on [0,1]'. Its first open question asks whether the diagonal ℂ→ℝ descent generalizes to the off-diagonal integral ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!; this entry answers it and adds an independent real integration-by-parts proof."
+    },
+    {
+      "targetId": "beta-integral-recurrence-oq-01",
+      "relationship": "related",
+      "description": "Grandparent entry establishing the integer Beta closed form B(m+1,n+1) = m!·n!/(m+n+1)! over ℂ (betaIntegral_nat_nat), reused as the value in Route 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The off-diagonal real Euler Beta integral ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! is established for all naturals m, n, two independent ways: by descending Mathlib's Complex.betaIntegral to ℝ and reusing the grandparent's complex closed form (integral_offdiag_eq_factorial), and by a self-contained real proof — one integration by parts (integral_recurrence) plus induction on n from the base ∫₀¹ xᵏ = 1/(k+1) (integral_offdiag_via_ibp) — that never invokes Complex.Gamma. The m↔n symmetry follows (integral_offdiag_symm). All six theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Completes the parent's first open question and supplies the integer Beta value in the form combinatorics and probability use, with a fully elementary real derivation alongside the analytic one. The integration-by-parts recurrence ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))∫₀¹ xᵐ⁺¹(1-x)ⁿ is reusable for Beta-related moment computations.",
+    "openQuestions": [
+      "Does the integration-by-parts recurrence extend to the real Beta integral B(a,b) = ∫₀¹ x^(a-1)(1-x)^(b-1) for real a, b > 0 using Mathlib's real rpow, recovering the functional equation a·B(a+1,b) = ... ?",
+      "Can the mean ∫₀¹ x·xᵐ(1-x)ⁿ/B = (m+1)/(m+n+2) of the Beta(m+1,n+1) distribution be derived as a one-line corollary by shifting m ↦ m+1?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.BetaIntegralRecurrence",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Complex",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "BetaIntegralRecurrenceOQ01OQ03OQ01",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent leaf `beta-integral-recurrence-oq-01-oq-03` ("Can the descent be generalized to the off-diagonal real integral ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!?"). The off-diagonal real Euler Beta integral

  `∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!`

is proved **two independent ways**.

### Route 1 — complex bridge (`integral_offdiag_eq_factorial`)
Generalizes the parent's diagonal ℂ→ℝ bridge: the real integral cast into ℂ equals `Complex.betaIntegral (m+1)(n+1)` (complex powers collapse to monoid powers via `Complex.cpow_natCast`, integral descends through `intervalIntegral.integral_ofReal`), and the closed form is read off the grandparent's `betaIntegral_nat_nat`.

### Route 2 — self-contained real analysis (`integral_offdiag_via_ibp`)
Never leaves ℝ. A single integration by parts (`integral_recurrence`, via `integral_mul_deriv_eq_deriv_mul`, both boundary terms vanishing) gives
`∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ`,
and induction on `n` from the base `∫₀¹ xᵏ = 1/(k+1)` forces the value — **independent of `Complex.Gamma`**. `integral_offdiag_symm` records the m↔n symmetry.

Neither the off-diagonal real integral nor the integration-by-parts recurrence is in Mathlib (which has only the analytic complex `betaIntegral`).

## Verification
- **6 theorems, 169 lines, 0 axioms, 0 sorries** (Mathlib 4.26.0)
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for the headline theorems and the recurrence — no `native_decide`/`Lean.ofReduceBool`.
- Added to the `Proofs.lean` aggregator.

## Files
- `proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01.lean`
- `src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/{meta,annotations}.json`
- `proofs/Proofs.lean` (aggregator import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)