### PR TITLE
Enrich The Wilf–Zeilberger Method in Lean (arithmetic-series-oq-02-oq-02-oq-03-oq-04)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "wz-ann-telescope-engine",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 80, "endLine": 94 },
+    "type": "technique",
+    "title": "wz_telescope — the abstract creative-telescoping engine",
+    "content": "The reusable heart of the file, stated over an arbitrary AddCommGroup α so it commits to nothing about the specific identity. Given the WZ equation F(n+1,k) − F(n,k) = G(n,k+1) − G(n,k) for all k and the two boundary conditions G(n,0) = G(n,N) = 0, it concludes that consecutive windowed row sums are equal. The proof sums the WZ equation over the window, recognises the right side as a telescoping sum collapsed by Finset.sum_range_sub to G(n,N) − G(n,0) = 0, then uses Finset.sum_sub_distrib and sub_eq_zero to read off equality of the two row sums.",
+    "mathContext": "$\\sum_{k<N}\\bigl(F(n{+}1,k)-F(n,k)\\bigr) = \\sum_{k<N}\\bigl(G(n,k{+}1)-G(n,k)\\bigr) = G(n,N)-G(n,0) = 0$, hence $\\sum_{k<N}F(n{+}1,k) = \\sum_{k<N}F(n,k)$.",
+    "significance": "key",
+    "relatedConcepts": ["creative telescoping", "telescoping sum", "Wilf–Zeilberger pair", "AddCommGroup", "Finset.sum_range_sub"],
+    "prerequisites": ["telescoping sums", "finite sums in an additive group"]
+  },
+  {
+    "id": "wz-ann-summand",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 104, "endLine": 112 },
+    "type": "definition",
+    "title": "The normalized summand F and its WZ mate G",
+    "content": "F(n,k) = C(n,k)/2ⁿ is the WZ-normalization of the binomial summand: dividing by the target 2ⁿ turns the identity ∑ₖ C(n,k) = 2ⁿ into the normalized form ∑ₖ F(n,k) = 1. The mate G(n,k) = −C(n,k−1)/2ⁿ⁺¹ is G = R·F for the rational certificate R(n,k) = −k/(2(n−k+1)). The `if k = 0 then 0` guard is essential: in ℕ-arithmetic k−1 at k=0 underflows to 0, so C(n,0−1) would wrongly read as C(n,0); the guard restores the true value C(n,−1) = 0.",
+    "mathContext": "$F(n,k) = \\dfrac{\\binom{n}{k}}{2^n}$, $\\quad G(n,k) = -\\dfrac{\\binom{n}{k-1}}{2^{n+1}} = R(n,k)\\,F(n,k)$ with certificate $R(n,k) = -\\dfrac{k}{2(n-k+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["hypergeometric term", "WZ certificate", "normalized summand", "ℕ-subtraction guard"],
+    "prerequisites": ["binomial coefficients", "rational certificates"]
+  },
+  {
+    "id": "wz-ann-boundary",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 114, "endLine": 123 },
+    "type": "technique",
+    "title": "Boundary lemmas: G vanishes at both window ends",
+    "content": "G_zero (G(n,0) = 0 by rfl, from the guard) and G_top (G(n,N) = 0 when n+1 < N) supply the two hypotheses wz_telescope needs. G_top uses Nat.choose_eq_zero_of_lt: above the binomial support C(n,N−1) = 0, so the mate vanishes past the diagonal. These are exactly the two boundary conditions that make the telescoped right-hand side collapse to 0.",
+    "mathContext": "$G(n,0)=0$ (guard); for $n+1<N$, $\\binom{n}{N-1}=0$ so $G(n,N)=0$. Together: $G(n,N)-G(n,0)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial support", "vanishing above the diagonal", "boundary conditions"],
+    "prerequisites": ["binomial coefficients"]
+  },
+  {
+    "id": "wz-ann-equation",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 136, "endLine": 151 },
+    "type": "insight",
+    "title": "wz_equation — verifying the certificate by hand",
+    "content": "The single nontrivial pointwise identity, and the only place the specific certificate is checked. It is exactly what a computer-algebra WZ implementation (Gosper/Zeilberger) outputs; here Lean re-checks it independently. The proof splits on k: at k = 0 the ℕ-subtraction guard governs (handled via G_zero/G_one and field_simp); for k = m+1 Pascal's rule C(n+1,m+1) = C(n,m) + C(n,m+1) supplies the algebra, after which clearing 2ⁿ⁺¹ = 2·2ⁿ and `ring` close it. This division of labour — certificate produced elsewhere, verified here — is the essence of the WZ method.",
+    "mathContext": "$F(n{+}1,k)-F(n,k)=G(n,k{+}1)-G(n,k)$. Step $k=m{+}1$ uses Pascal: $\\binom{n+1}{m+1}=\\binom{n}{m}+\\binom{n}{m+1}$, and $2^{n+1}=2\\cdot 2^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's rule", "certificate verification", "Zeilberger's algorithm", "case analysis"],
+    "prerequisites": ["Pascal's rule", "field arithmetic over ℚ"]
+  },
+  {
+    "id": "wz-ann-recurrence",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 157, "endLine": 175 },
+    "type": "technique",
+    "title": "rowSum_succ — the WZ recurrence from the engine",
+    "content": "Feeding the verified pair (F, G) into wz_telescope with window N = n+2 yields ∑_{k<n+2} F(n+1,k) = ∑_{k<n+2} F(n,k). The left side is rowSum(n+1) definitionally; the right side's window is one term too wide, trimmed back to the support by F_above (F(n,n+1) = 0 via Nat.choose_eq_zero_of_lt) and Finset.sum_range_succ. The result rowSum(n+1) = rowSum(n) is the constancy that drives the whole identity, obtained purely from telescoping — no binomial identity assumed.",
+    "mathContext": "With $N=n+2$ and $F(n,n+1)=0$: $\\text{rowSum}(n{+}1)=\\sum_{k\\le n+1}F(n{+}1,k)=\\sum_{k\\le n}F(n,k)=\\text{rowSum}(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["recurrence relation", "window trimming", "Finset.sum_range_succ", "creative telescoping"],
+    "prerequisites": ["finite sums", "binomial support"]
+  },
+  {
+    "id": "wz-ann-main",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+    "range": { "startLine": 182, "endLine": 208 },
+    "type": "insight",
+    "title": "binomial_sum_eq_pow — the identity from recurrence + base case",
+    "content": "rowSum_eq_one inducts on the recurrence from the base case rowSum(0) = 1 to get rowSum(n) = 1 for all n — the WZ-normalized identity. binomial_sum_eq_pow then unwinds the normalization: since rowSum(n) = (∑_{k≤n} C(n,k))/2ⁿ, clearing the denominator over ℚ and casting back to ℕ gives ∑_{k≤n} C(n,k) = 2ⁿ. The closing `example` cross-checks the result against Mathlib's Nat.sum_range_choose, confirming the WZ route reaches the same theorem by an independent path.",
+    "mathContext": "$\\text{rowSum}(n)=1$ and $\\text{rowSum}(n)=\\dfrac{\\sum_{k\\le n}\\binom{n}{k}}{2^n}$ give $\\sum_{k\\le n}\\binom{n}{k}=2^n$, re-derived without Nat.sum_range_choose.",
+    "significance": "key",
+    "relatedConcepts": ["induction", "binomial theorem", "normalization", "Nat.sum_range_choose"],
+    "prerequisites": ["mathematical induction", "casting ℚ ↔ ℕ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-02-oq-02-oq-03-oq-04` (The Wilf–Zeilberger Method in Lean).

This entry previously had **no annotations.json**. Added **6 annotations** covering the full proof, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

- `wz_telescope` — the abstract creative-telescoping engine over any AddCommGroup
- the normalized summand `F = C(n,k)/2ⁿ` and its WZ mate `G` (with the ℕ-subtraction guard explained)
- boundary lemmas `G_zero`/`G_top`
- `wz_equation` — the by-hand certificate verification (Pascal's rule + case split)
- `rowSum_succ` — the WZ recurrence read off the engine
- `binomial_sum_eq_pow` — the identity from recurrence + base case, cross-checked vs Nat.sum_range_choose

meta.json was already thorough (overview/proofStrategy/conclusion/implications/references all present) so it is unchanged. No code or status/badge/axiomCount changes (entry remains verified / original / 0-axiom).

JSON validated; all annotations carry required fields.