### PR TITLE
Gallery audit: 7 entries clean (alg-numbers, buffon, burnside gcd, cauchy power-map, erdos-435, feuerbach, fta-galois)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23565,8 +23565,50 @@
       "lastAudited": "2026-06-25T08:20:00Z",
       "result": "clean",
       "notes": "Discharges parent unit-circle converse axiom positive_ratio_implies_cyclic_order as a theorem; verified/original/0-ax/0-sorry, 12 theorems + 2 defs (1 def + 1 structure) match meta. #print axioms confirms axiom absent. CLEAN."
+    },
+    "algebraic-numbers-countable-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
+    },
+    "buffons-needle-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
+    },
+    "cauchy-group-theorem-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
+    },
+    "erdos-435-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
+    },
+    "feuerbachs-theorem-defs-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
+    },
+    "fundamental-theorem-algebra-oq-04-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T08:20:00Z"
+  "lastUpdated": "2026-06-25T09:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 7 previously-unaudited gallery entries against their Lean sources. **All clean** — no integrity issues found.

| Slug | Status/Badge | thm/lemma | sorry/axiom/native_decide | Notes |
|------|-------------|-----------|---------------------------|-------|
| `algebraic-numbers-countable-oq-01-oq-01` | verified/original | 5 thm + 2 instances (=7) | 0/0/0 | ℚ-alg is alg-closed field; self-contained transitivity |
| `buffons-needle-oq-01-oq-02-oq-01` | verified/original | 9 thm | 0/0/0 | consecutive-product Cauchy invariant |
| `burnside-counting-oq-03-oq-02-oq-01` | verified/original | 3 thm + 2 lemma (=5) | 0/0/0 | cyc(rotation r)=gcd(n,r) |
| `cauchy-group-…-oq-03-oq-02-oq-01` | verified/original | 6 thm | 0/0/0 | range(xⁿ)=range(x^gcd(n,exp G)) |
| `erdos-435-oq-01-oq-01` | verified/original | 2 thm | 0/0/0 | non-prime-power converse; uses Mathlib Lucas, disclosed; honestly scoped (not full #435) |
| `feuerbachs-theorem-defs-oq-05` | verified/original | 4 thm + 2 lemma (=6) | 0/0/0 | nine-point circle uniqueness |
| `fundamental-theorem-algebra-oq-04-oq-03` | verified/original | 5 thm | 0/0/0 | Galois correspondence ℂ/ℝ; Mathlib FTGT reliance disclosed in overview |

### Checks performed
- **True-stub**: none in any file
- **Sorry count**: meta `sorries: 0` matches Lean source (0) for all
- **Axiom count**: meta `axiomCount: 0` matches (no `axiom` decls, no structure-encoded assumptions)
- **native_decide**: none — `Lean.ofReduceBool` not in any closure
- **theorem/lemma counts**: match meta (instances counted as theorem-level facts for alg-numbers)
- **Badge honesty**: `original` justified; entries that lean on a major Mathlib theorem (erdos-435 → Lucas; fta-oq0403 → Fundamental Theorem of Galois Theory) disclose it in overview/contributions, so the original framing scopes to the genuine new assembly.

### Excluded
- `abel-ruffini-oq-04-oq-01-oq-01`: **phantom** — neither meta.json nor the Lean source is tracked in `origin/main` (in-flight, unmerged local files). Not audited.
- `arithmetic-series-oq-02-oq-02-oq-03-oq-04`, `cauchy-…-oq-03-oq-02-oq-02`, `dini-theorem-oq-01-oq-02`, `ptolemys-theorem-oq-01-oq-01-oq-03-oq-02`: covered by open audit PR #29832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)