### PR TITLE
Enrich Erdős #435 Non-Prime-Power Case / Converse (erdos-435-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/erdos-435-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-435-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "erdos435npp-ann-lucas-setup",
+    "proofId": "erdos-435-oq-01-oq-01",
+    "range": { "startLine": 42, "endLine": 49 },
+    "type": "technique",
+    "title": "Specializing Lucas' theorem to k = pᵃ",
+    "content": "The core lemma not_dvd_choose_ordProj sets a = v_p(n) and instantiates Mathlib's Lucas theorem (choose_modEq_choose_mul_prod_range_choose) at k = pᵃ. The genius of the index choice: the base-p digits of pᵃ are a single 1 in position a and 0 everywhere else, so Lucas' digit-product collapses to one nontrivial factor. The congruence is then cast from Int.ModEq into ZMod p (a field, since p is prime) via ZMod.intCast_eq_intCast_iff so the rest is an equation, not a congruence.",
+    "mathContext": "Lucas: $\\binom{n}{k} \\equiv \\prod_i \\binom{n_i}{k_i} \\pmod p$ over base-$p$ digits. With $k = p^a$, only digit $a$ of $k$ is nonzero, isolating a single block.",
+    "significance": "key",
+    "relatedConcepts": ["Lucas' theorem", "p-adic valuation", "base-p digits", "ZMod p"],
+    "prerequisites": ["Lucas' theorem", "binomial coefficients", "modular arithmetic"]
+  },
+  {
+    "id": "erdos435npp-ann-block-eval",
+    "proofId": "erdos-435-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 66 },
+    "type": "insight",
+    "title": "Collapsing the Lucas product to n/pᵃ",
+    "content": "The two block computations that make the lemma work. The top quotient pᵃ/pᵃ = 1 (Nat.div_self), so the top factor is C(n/pᵃ, 1) = n/pᵃ (choose_one_right). For each lower block i < a, pᵃ/pⁱ = p^(a−i) with a−i ≥ 1, so p^(a−i) % p = 0 (pow_succ' + mul_mod_right), making that factor C(·, 0) = 1 (choose_zero_right). The whole product reduces to 1, leaving the clean congruence C(n, pᵃ) ≡ n/pᵃ (mod p).",
+    "mathContext": "$\\binom{n}{p^a} \\equiv \\binom{n/p^a}{1}\\cdot\\prod_{i<a}\\binom{\\cdot}{0} = \\dfrac{n}{p^a}\\cdot 1 = \\dfrac{n}{p^a} \\pmod p$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficient identities", "telescoping product", "Finset.prod_eq_one"],
+    "prerequisites": ["binomial coefficients", "integer division"]
+  },
+  {
+    "id": "erdos435npp-ann-ordcompl",
+    "proofId": "erdos-435-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 74 },
+    "type": "concept",
+    "title": "ordCompl carries the coprimality for free",
+    "content": "The payoff of the core lemma: n/pᵃ = ordCompl[p] n is by definition the prime-to-p part of n, so Nat.not_dvd_ordCompl gives p ∤ n/pᵃ with no extra computation. Combined with the congruence C(n, pᵃ) ≡ n/pᵃ (mod p), translated to ZMod via ZMod.natCast_eq_zero_iff (which says (a : ZMod p) = 0 ↔ p ∣ a), the non-divisibility transfers directly: p ∤ C(n, pᵃ).",
+    "mathContext": "$n/p^{v_p(n)} = \\operatorname{ordCompl}_p(n)$, the largest divisor of $n$ coprime to $p$; so $p \\nmid n/p^a$ and hence $p \\nmid \\binom{n}{p^a}$.",
+    "significance": "key",
+    "relatedConcepts": ["ordCompl", "p-adic valuation", "coprimality", "Nat.not_dvd_ordCompl"],
+    "prerequisites": ["p-adic valuation", "divisibility"]
+  },
+  {
+    "id": "erdos435npp-ann-gcd-contradiction",
+    "proofId": "erdos-435-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 116 },
+    "type": "insight",
+    "title": "gcd = 1 by contradiction, with pᵃ a valid witness index",
+    "content": "The headline gcd_generators_eq_one argues by contradiction. If the gcd g ≠ 1 it has a prime factor p (exists_prime_and_dvd); p ∣ g ∣ C(n,1) = n, so a = v_p(n) ≥ 1. The crucial step is showing the witness index pᵃ is a genuine interior index 1 ≤ pᵃ ≤ n−1: since n is not a prime power, n/pᵃ ≥ 2 (otherwise n = pᵃ·1 = pᵃ would be a prime power), giving 2·pᵃ ≤ n and so pᵃ ≤ n−1. Then p ∣ g ∣ C(n, pᵃ), contradicting the core lemma's p ∤ C(n, pᵃ). Hence g has no prime factor: g = 1.",
+    "mathContext": "If prime $p \\mid \\gcd$, then $p \\mid n$ so $a = v_p(n)\\ge 1$; non-prime-power forces $n/p^a \\ge 2$, so $p^a \\le n-1$ is a valid index, yet $p \\nmid \\binom{n}{p^a}$ — contradiction. Thus $\\gcd = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "IsPrimePow", "Finset.gcd_dvd", "numerical semigroup", "global coprimality"],
+    "prerequisites": ["gcd of a finite set", "prime power characterization", "binomial coefficients"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-435-oq-01-oq-01` (the converse to the prime-power obstruction behind Erdős Problem #435).

This entry previously had **no annotations.json**. Added **4 annotations** covering the proof, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

- specializing Lucas' theorem to `k = pᵃ` (single-digit index isolates one block)
- collapsing the Lucas product to `n/pᵃ` (top block C(n/pᵃ,1), lower blocks C(·,0)=1)
- `ordCompl` carries the coprimality for free (`Nat.not_dvd_ordCompl`)
- the `gcd = 1` contradiction argument, with `pᵃ` shown to be a valid interior index exactly because `n` is not a prime power

meta.json was already thorough (overview/proofStrategy/keyInsights/mainTheorems/conclusion/implications present) so it is unchanged. No code or status/badge/axiomCount changes (entry remains verified / original / 0-axiom).

JSON validated; all annotations carry required fields and valid line ranges.