### PR TITLE
Enrich Ptolemy Unit-Circle Converse Axiom Discharge (ptolemys-theorem-oq-01-oq-01-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ptolemy-disch-ann-restatements",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 61, "endLine": 91 },
+    "type": "context",
+    "title": "Local restatements and the proportionality wrapper",
+    "content": "IsCWOrder (defined as IsCCWOrder with z₂,z₄ swapped), FourDistinct, and the proportionality wrapper ptolemy_eq_implies_pos_prop are restated verbatim. IsCCWOrder itself is imported from the parent PtolemysTheoremOQ01. The restatement is defensive: the parent leaf PtolemysTheoremOQ01OQ01 — which declares the axiom being discharged — currently fails to elaborate under Mathlib v4.26.0 due to unrelated API drift (Complex.abs_apply, Real.sqrt_eq_iff_sq_eq removed) in a numerical sanity example. The discharged statement is identical to the parent's axiom. denom_ne/numer_ne package the four distinctness facts into the two nonvanishing products the cancellation will need.",
+    "mathContext": "$\\mathrm{IsCWOrder}\\,z_1z_2z_3z_4 := \\mathrm{IsCCWOrder}\\,z_1z_4z_3z_2$; the proportionality wrapper feeds Ptolemy equality into the strict-convexity extraction $\\exists t>0,\\ t\\,(z_1-z_2)(z_3-z_4)=(z_2-z_3)(z_1-z_4)$.",
+    "significance": "context",
+    "relatedConcepts": ["cyclic order", "Ptolemy equality", "strict convexity", "API drift"],
+    "prerequisites": ["complex numbers", "Ptolemy's theorem"]
+  },
+  {
+    "id": "ptolemy-disch-ann-expdiff",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 95, "endLine": 132 },
+    "type": "technique",
+    "title": "The half-angle difference factorisation",
+    "content": "exp_diff_factor re-derives the key identity exp(iα) − exp(iβ) = 2i·sin((α−β)/2)·exp(i(α+β)/2), proved by matching real and imaginary parts: the real part uses cos α − cos β with the sum/difference cosine expansions, the imaginary part uses sin α − sin β. This single factorisation is the bridge that turns each of the four complex differences in the proportionality into a (purely real) half-angle sine times a unit-modulus phase — the move that makes the whole problem real.",
+    "mathContext": "$e^{i\\alpha}-e^{i\\beta} = 2i\\,\\sin\\!\\tfrac{\\alpha-\\beta}{2}\\,e^{i(\\alpha+\\beta)/2}$, the product-to-sum form of the difference of two points on the unit circle.",
+    "significance": "key",
+    "relatedConcepts": ["half-angle identity", "product-to-sum", "Euler's formula", "unit circle"],
+    "prerequisites": ["trigonometric identities", "complex exponential"]
+  },
+  {
+    "id": "ptolemy-disch-ann-signlemmas",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 134, "endLine": 167 },
+    "type": "technique",
+    "title": "Sign of a half-angle sine on a period",
+    "content": "The sign machinery that reads cyclic order off the real equation. sin_neg_aux: sin is negative on (−π,0). half_sin_pos_iff / half_sin_neg_iff: for x ∈ (−2π,2π), sin(x/2) > 0 ⟺ x > 0 and sin(x/2) < 0 ⟺ x < 0. These are exactly the equivalences that convert the sign of each half-angle sine into a strict inequality between the extracted angles φⱼ — i.e. into betweenness, hence into CCW/CW order.",
+    "mathContext": "For $x \\in (-2\\pi, 2\\pi)$: $\\sin(x/2) > 0 \\iff x > 0$. The half-period sign of sine encodes the angular ordering.",
+    "significance": "supporting",
+    "relatedConcepts": ["sign of sine", "monotonicity", "Real.sin_pos_of_pos_of_lt_pi", "betweenness"],
+    "prerequisites": ["properties of sine", "real analysis"]
+  },
+  {
+    "id": "ptolemy-disch-ann-reduce",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 171, "endLine": 224 },
+    "type": "insight",
+    "title": "reduce_to_sines — collapsing the complex proportionality to a real identity",
+    "content": "The algebraic heart. Substituting exp_diff_factor into all four differences, each opposite-side product becomes scalar·(2i)²·(E₁₂E₃₄) or scalar·(2i)²·(E₂₃E₁₄). The phase identity E₁₂·E₃₄ = E₂₃·E₁₄ (both equal exp(i(θ₁+θ₂+θ₃+θ₄)/2) by exp_add) makes the two phase factors identical, and (2i)² = −4 (Complex.I_sq) is common. Cancelling the shared nonzero factor (−4)·(E₂₃E₁₄) via mul_right_cancel₀, then casting down to ℝ, yields t·sin((θ₁−θ₂)/2)·sin((θ₃−θ₄)/2) = sin((θ₂−θ₃)/2)·sin((θ₁−θ₄)/2). No modulus of either product is used — the equality is purely about the half-angle sines.",
+    "mathContext": "$t\\,\\sin\\tfrac{\\theta_1-\\theta_2}{2}\\sin\\tfrac{\\theta_3-\\theta_4}{2} = \\sin\\tfrac{\\theta_2-\\theta_3}{2}\\sin\\tfrac{\\theta_1-\\theta_4}{2}$, the real shadow of the complex proportionality after the phases and $(2i)^2$ cancel.",
+    "significance": "key",
+    "relatedConcepts": ["phase cancellation", "mul_right_cancel₀", "Complex.I_sq", "real-imaginary descent"],
+    "prerequisites": ["complex algebra", "trigonometric factorisation"]
+  },
+  {
+    "id": "ptolemy-disch-ann-angle-extraction",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 228, "endLine": 259 },
+    "type": "technique",
+    "title": "Angle extraction: pinning every point above the anchor",
+    "content": "unit_to_angle writes a unit number w ≠ 1 as exp(iφ) for a unique φ ∈ (0,2π): take φ = arg w (in (−π,π]), and when arg w < 0 shift by 2π using Complex.exp_two_pi_mul_I. ratio_angle applies this to z/z₁ (modulus 1, ≠ 1 since z ≠ z₁), so each point becomes z₁·exp(iφⱼ) = exp(i(θ₁+φⱼ)) with φⱼ ∈ (0,2π). This anchoring is what turns 'cyclic order' into a plain ordering of the real numbers φ₂, φ₃, φ₄ within one period.",
+    "mathContext": "Each $z_j = z_1 e^{i\\varphi_j}$ with $\\varphi_j \\in (0, 2\\pi)$; cyclic order of the $z_j$ ⟺ ordering of the $\\varphi_j$.",
+    "significance": "key",
+    "relatedConcepts": ["polar form", "Complex.arg", "2π-periodicity", "angular ordering"],
+    "prerequisites": ["argument of a complex number", "unit circle"]
+  },
+  {
+    "id": "ptolemy-disch-ann-main",
+    "proofId": "ptolemys-theorem-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 263, "endLine": 372 },
+    "type": "insight",
+    "title": "The discharged axiom and the axiom-free converse",
+    "content": "positive_ratio_implies_cyclic_order_thm assembles everything: extract angles φⱼ, run reduce_to_sines, and note (θ₁−θ₂)/2 = −φ₂/2 and (θ₁−θ₄)/2 = −φ₄/2 lie in (−π,0) so those two sines are negative. With t > 0 the equation t·A·C = B·D (A,D > 0 forced) forces sin((φ₃−φ₄)/2) and sin((φ₂−φ₃)/2) to share a sign; the half_sin_*_iff lemmas turn that into φ₂ < φ₃ < φ₄ (CCW) or φ₄ < φ₃ < φ₂ (CW), supplying the order witnesses. ptolemy_equality_implies_ccw_or_cw_axiomfree then chains Ptolemy equality → positive proportionality → this theorem, reproducing the parent's converse with no trigonometric ordering axiom. #print axioms reports only propext/Classical.choice/Quot.sound.",
+    "mathContext": "A single forced sign places $\\varphi_3$ strictly between $\\varphi_2$ and $\\varphi_4$: $\\varphi_2<\\varphi_3<\\varphi_4$ (CCW) or $\\varphi_4<\\varphi_3<\\varphi_2$ (CW). Ptolemy equality ⇒ cyclic order, axiom-free.",
+    "significance": "key",
+    "relatedConcepts": ["axiom discharge", "cyclic order", "trichotomy", "Ptolemy converse"],
+    "prerequisites": ["sign analysis", "case analysis", "Ptolemy's theorem"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `ptolemys-theorem-oq-01-oq-01-oq-03-oq-02` (discharging the unit-circle converse axiom of Ptolemy's theorem).

This entry previously had **no annotations.json**. Added **6 annotations** covering all five sections of the 373-line proof, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

- local restatements + proportionality wrapper (and why the parent leaf is restated — v4.26.0 drift)
- the half-angle difference factorisation `exp(iα) − exp(iβ) = 2i·sin((α−β)/2)·exp(i(α+β)/2)`
- half-angle sine sign lemmas (`half_sin_pos_iff`/`half_sin_neg_iff`)
- `reduce_to_sines` — collapsing the complex proportionality to a real sine identity (phase + (2i)² cancellation)
- angle extraction (`unit_to_angle`/`ratio_angle`)
- the discharged axiom `positive_ratio_implies_cyclic_order_thm` + the axiom-free converse

meta.json was already exceptionally thorough (overview/proofStrategy/keyInsights/sections-with-mathContext/conclusion/implications present) so it is unchanged. No code or status/badge/axiomCount changes (entry remains verified / original / 0-axiom).

JSON validated; all annotations carry required fields and valid line ranges.