### PR TITLE
research(chebyshev-bounds-oq-02-oq-02): ψ and θ share the same main term [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -792,6 +792,7 @@ import Proofs.ChebyshevBounds
 import Proofs.ChebyshevBoundsOQ03
 import Proofs.ChebyshevBoundsOQ02
 import Proofs.ChebyshevBoundsOQ02OQ01
+import Proofs.ChebyshevBoundsOQ02OQ02
 import Proofs.ChebyshevBoundsOQ04
 import Proofs.ChebyshevBoundsOQ04Aristotle
 import Proofs.ChebyshevBoundsOQ04OQ01

--- a/proofs/Proofs/ChebyshevBoundsOQ02OQ02.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ02OQ02.lean
@@ -1,0 +1,146 @@
+/-
+# Chebyshev Bounds OQ-02 (leaf oq-02): ψ and θ share the same main term
+
+## Open question (from `chebyshev-bounds-oq-02`)
+
+The parent `ChebyshevBoundsOQ02` introduced the second Chebyshev function
+`ψ(n) = ∑_{m≤n} Λ(m) = ∑_{p^k≤n} log p` in von Mangoldt form (and Legendre's identity), as a
+self-contained ℕ-indexed development that does **not** reference Mathlib's Chebyshev API. A
+natural next step is to compare it with the **first** Chebyshev function `θ(n) = ∑_{p≤n} log p`
+and show the two share the **same main term**: their difference is supported entirely on the
+*proper* prime powers `p^k` with `k ≥ 2`, and is `O(√n · log n)`.
+
+## What this file proves (0 sorries, 0 axioms)
+
+**Gallery-facing statements over the parent's `chebyshevPsi`:**
+
+* `chebyshevTheta n = ∑_{p ≤ n, p prime} log p` — the first Chebyshev function.
+* `psi_sub_theta` : `ψ(n) − θ(n) = ∑_{m≤n, ¬ m prime} Λ(m)` — the difference is supported on the
+  higher prime powers `m = p^k`, `k ≥ 2` (proved directly, the structural "same main term").
+* `psi_sub_theta_nonneg`, `theta_le_psi`.
+* `psi_sub_theta_eq_proper_prime_powers` : the difference as a sum over the prime powers in
+  `[1,n]` that are not prime (the `k ≥ 2` support made explicit via `IsPrimePow`).
+
+**The bridge to Mathlib + the quantitative content.** Mathlib's `Mathlib.NumberTheory.Chebyshev`
+already proves the deep facts — the decomposition, the identity `ψ(x) = ∑_{k≥1} θ(x^{1/k})`, and
+the sharp bound `|ψ(x) − θ(x)| ≤ 2√x·log x`. This file's genuine contribution is to **connect**
+the parent's self-contained ℕ-indexed `chebyshevPsi` to Mathlib's `Chebyshev.psi` (and likewise
+for θ), and then to **transport** those two results to the gallery's functions:
+
+* `chebyshevPsi_eq_mathlib` : `chebyshevPsi n = Chebyshev.psi n`.
+* `chebyshevTheta_eq_mathlib` : `chebyshevTheta n = Chebyshev.theta n`.
+* **`psi_sub_theta_eq_sum_theta`** : `ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k})` — the exact
+  "`Σ_{k≥2} θ(n^{1/k})`" same-main-term identity, for `n ≥ 2`.
+* **`abs_psi_sub_theta_le`** : `|ψ(n) − θ(n)| ≤ 2·√n·log n` for `n ≥ 1` — the quantitative
+  same-main-term bound (`O(√n·log n)`, sharper than the `O(√n log²n)` originally targeted).
+
+The substantive analytic number theory in the last two results is **Mathlib's**
+(`Chebyshev.psi_eq_theta_add_sum_theta`, `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log`); the
+work here is the formal bridge that makes the gallery's elementary `chebyshevPsi` inherit them.
+
+*Reference:* Chebyshev's elementary method; `Mathlib.NumberTheory.Chebyshev`,
+`Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt`.
+-/
+
+import Proofs.ChebyshevBoundsOQ02
+import Mathlib
+
+open Finset ArithmeticFunction
+
+namespace ChebyshevBoundsOQ02OQ02
+
+open ChebyshevBoundsOQ02
+
+/-! ## I. The first Chebyshev function θ -/
+
+/-- The **first Chebyshev function** `θ(n) = ∑_{p ≤ n, p prime} log p`. -/
+noncomputable def chebyshevTheta (n : ℕ) : ℝ :=
+  ∑ p ∈ (Finset.Icc 1 n).filter Nat.Prime, Real.log (p : ℝ)
+
+/-- `[1,n] = (0,n]` as finsets of naturals — used to line up the parent's `Icc 1 n` indexing
+    with Mathlib's `Ioc 0 ⌊x⌋₊` indexing. -/
+private theorem Icc_one_eq_Ioc_zero (n : ℕ) : Finset.Icc 1 n = Finset.Ioc 0 n :=
+  Finset.ext fun m => by simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+
+/-- θ in von Mangoldt form: `θ(n) = ∑_{m≤n} [m prime] · Λ(m)`. The prime part of `ψ` is `θ`,
+    because `Λ(p) = log p` for a prime `p`. -/
+theorem chebyshevTheta_eq_sum_vonMangoldt (n : ℕ) :
+    chebyshevTheta n = ∑ m ∈ Finset.Icc 1 n, (if m.Prime then Λ m else 0) := by
+  rw [chebyshevTheta, Finset.sum_filter]
+  refine Finset.sum_congr rfl fun m _ => ?_
+  by_cases hm : m.Prime
+  · rw [if_pos hm, if_pos hm, vonMangoldt_apply_prime hm]
+  · rw [if_neg hm, if_neg hm]
+
+/-! ## II. The difference ψ − θ: same main term (direct, gallery-facing) -/
+
+/-- **The structural heart.** `ψ(n) − θ(n) = ∑_{m≤n, ¬ m prime} Λ(m)`: the two Chebyshev
+    functions share the same main term and differ only by the contribution of the higher
+    prime powers (`m = p^k`, `k ≥ 2`). -/
+theorem psi_sub_theta (n : ℕ) :
+    chebyshevPsi n - chebyshevTheta n =
+      ∑ m ∈ Finset.Icc 1 n, (if m.Prime then 0 else Λ m) := by
+  rw [chebyshevPsi, chebyshevTheta_eq_sum_vonMangoldt, ← Finset.sum_sub_distrib]
+  refine Finset.sum_congr rfl fun m _ => ?_
+  by_cases hm : m.Prime <;> simp [hm]
+
+/-- Every term of `ψ − θ` is nonnegative. -/
+theorem psi_sub_theta_nonneg (n : ℕ) : 0 ≤ chebyshevPsi n - chebyshevTheta n := by
+  rw [psi_sub_theta]
+  refine Finset.sum_nonneg fun m _ => ?_
+  by_cases hm : m.Prime <;> simp [hm, vonMangoldt_nonneg]
+
+/-- `θ(n) ≤ ψ(n)`. -/
+theorem theta_le_psi (n : ℕ) : chebyshevTheta n ≤ chebyshevPsi n := by
+  have := psi_sub_theta_nonneg n; linarith
+
+/-- The difference, written explicitly over the *proper* prime powers in `[1,n]` (prime powers
+    that are not themselves prime, i.e. `m = p^k` with `k ≥ 2`). A summand is nonzero iff
+    `IsPrimePow m ∧ ¬ m.Prime`. -/
+theorem psi_sub_theta_eq_proper_prime_powers (n : ℕ) :
+    chebyshevPsi n - chebyshevTheta n =
+      ∑ m ∈ (Finset.Icc 1 n).filter (fun m => IsPrimePow m ∧ ¬ m.Prime), Λ m := by
+  rw [psi_sub_theta, Finset.sum_filter]
+  refine Finset.sum_congr rfl fun m _ => ?_
+  by_cases hm : m.Prime
+  · rw [if_pos hm]; simp [hm]
+  · rw [if_neg hm]
+    by_cases hpp : IsPrimePow m
+    · rw [if_pos ⟨hpp, hm⟩]
+    · rw [if_neg (fun h => hpp h.1)]
+      exact vonMangoldt_eq_zero_iff.mpr hpp
+
+/-! ## III. Bridge to Mathlib's `Chebyshev` and transported quantitative results -/
+
+/-- **Bridge.** The parent's elementary ℕ-indexed second Chebyshev function agrees with
+    Mathlib's `Chebyshev.psi`. -/
+theorem chebyshevPsi_eq_mathlib (n : ℕ) : chebyshevPsi n = Chebyshev.psi (n : ℝ) := by
+  rw [Chebyshev.psi, Nat.floor_natCast, chebyshevPsi]
+  exact Finset.sum_congr (Icc_one_eq_Ioc_zero n) (fun _ _ => rfl)
+
+/-- **Bridge.** `chebyshevTheta` agrees with Mathlib's `Chebyshev.theta`. -/
+theorem chebyshevTheta_eq_mathlib (n : ℕ) : chebyshevTheta n = Chebyshev.theta (n : ℝ) := by
+  rw [Chebyshev.theta, Nat.floor_natCast, chebyshevTheta]
+  exact Finset.sum_congr (by rw [Icc_one_eq_Ioc_zero]) (fun _ _ => rfl)
+
+/-- **Same-main-term identity** (the `Σ_{k≥2} θ(n^{1/k})` form). For `n ≥ 2`,
+    `ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k})`.
+
+    Transported from Mathlib's `Chebyshev.psi_eq_theta_add_sum_theta` via the bridge. -/
+theorem psi_sub_theta_eq_sum_theta (n : ℕ) (hn : 2 ≤ n) :
+    chebyshevPsi n - chebyshevTheta n =
+      ∑ k ∈ Finset.Icc 2 ⌊Real.log n / Real.log 2⌋₊,
+        Chebyshev.theta ((n : ℝ) ^ ((1 : ℝ) / k)) := by
+  rw [chebyshevPsi_eq_mathlib, chebyshevTheta_eq_mathlib,
+      Chebyshev.psi_eq_theta_add_sum_theta (by exact_mod_cast hn), add_sub_cancel_left]
+
+/-- **Quantitative same-main-term bound.** For `n ≥ 1`,
+    `|ψ(n) − θ(n)| ≤ 2·√n·log n` — so `ψ` and `θ` agree up to `O(√n·log n)`.
+
+    Transported from Mathlib's `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log` via the bridge. -/
+theorem abs_psi_sub_theta_le (n : ℕ) (hn : 1 ≤ n) :
+    |chebyshevPsi n - chebyshevTheta n| ≤ 2 * Real.sqrt n * Real.log n := by
+  rw [chebyshevPsi_eq_mathlib, chebyshevTheta_eq_mathlib]
+  exact Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log (by exact_mod_cast hn)
+
+end ChebyshevBoundsOQ02OQ02

--- a/research/problems/chebyshev-bounds-oq-02/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-02/knowledge.md
@@ -1,0 +1,57 @@
+# chebyshev-bounds-oq-02 — knowledge
+
+## Problem
+
+Parent `chebyshev-bounds-oq-02` (the second Chebyshev function ψ + Legendre's identity) had an
+open direction: compare ψ to the first Chebyshev function θ and quantify their difference
+(`ψ − θ = ∑_{k≥2} θ(n^{1/k}) = O(√n·log²n)`, the "same main term" statement). This is the leaf
+`chebyshev-bounds-oq-02-oq-02`.
+
+## Session 2026-06-25 (Session 1) — FRESH — COMPLETED (verified, Mathlib-reliant)
+
+**Mode**: FRESH. **Outcome**: completed as a verified bridge entry.
+
+### Key finding — Mathlib already has the deep content
+
+`Mathlib.NumberTheory.Chebyshev` (present in Mathlib 4.26.0) already provides:
+- `Chebyshev.psi`, `Chebyshev.theta` (ℝ-argument).
+- `Chebyshev.psi_sub_theta_eq_sum_not_prime` — the ψ − θ = ∑_{¬prime} Λ decomposition.
+- `Chebyshev.psi_eq_theta_add_sum_theta` — ψ(x) = θ(x) + ∑_{k=2}^{⌊log₂x⌋} θ(x^{1/k}) (the exact
+  `∑_{k≥2} θ(x^{1/k})` identity).
+- `Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log` — `|ψ(x) − θ(x)| ≤ 2·√x·log x`, which is
+  **sharper** than the `O(√n·log²n)` the candidate targeted.
+
+So the candidate's mathematical content is fully subsumed by Mathlib. Re-deriving it from scratch
+over the parent's ℕ-indexed ψ would be dishonest duplication.
+
+### What was delivered (`Proofs/ChebyshevBoundsOQ02OQ02.lean`, 146 lines, 0 sorry/0 axiom)
+
+The honest, non-duplicative contribution is a **bridge** plus a direct decomposition:
+- `chebyshevTheta` def + `chebyshevTheta_eq_sum_vonMangoldt` (θ = prime part of ψ via
+  `vonMangoldt_apply_prime`).
+- `psi_sub_theta` : ψ(n) − θ(n) = ∑_{m≤n, ¬prime} Λ(m) — direct, gallery-facing decomposition;
+  plus `psi_sub_theta_nonneg`, `theta_le_psi`, and `psi_sub_theta_eq_proper_prime_powers`
+  (support = {IsPrimePow ∧ ¬prime}).
+- `chebyshevPsi_eq_mathlib` / `chebyshevTheta_eq_mathlib` : bridges identifying the parent's
+  self-contained ℕ ψ/θ with Mathlib's `Chebyshev.psi`/`theta` at integer arguments (one-line
+  `Finset.sum_congr` along `Icc 1 n = Ioc 0 n` after `Nat.floor_natCast`).
+- `psi_sub_theta_eq_sum_theta` and `abs_psi_sub_theta_le` : the candidate's headline identity and
+  bound, transported to the gallery's ψ via the bridge + the two Mathlib theorems.
+
+Gallery entry uses **badge `verified` (not `original`)** because the deep analytic results are
+Mathlib's; the entry's own content is the bridge and the elementary decomposition.
+
+### Technique
+
+- Bridge pattern: `rw [<gallery def>, Nat.floor_natCast, <Mathlib def>]; Finset.sum_congr (index-set eq)`.
+- The parent's `chebyshevPsi` (∑ over `Icc 1 n`) and Mathlib's `Chebyshev.psi` (∑ over `Ioc 0 ⌊x⌋`)
+  coincide at integer x; `Icc 1 n = Ioc 0 n` is the only index-set lemma needed.
+
+### Mathlib gaps
+
+None — Mathlib's Chebyshev development is complete for this comparison and sharper than targeted.
+
+### Next steps
+
+None for this leaf. Future Chebyshev-thread work should build on Mathlib's `Chebyshev` API
+directly (now bridged in) rather than re-deriving over the parent's elementary ψ.

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-theta",
+    "proofId": "chebyshev-bounds-oq-02-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "The First Chebyshev Function and Its von Mangoldt Form",
+    "content": "θ(x) = ∑_{p ≤ x} log p sums log p over primes only. The key to comparing it with ψ(n) = ∑_{m ≤ n} Λ(m) is that the von Mangoldt function satisfies Λ(p) = log p on a prime p (vonMangoldt_apply_prime). Hence θ(n) is exactly the 'prime part' of ψ: θ(n) = ∑_{m ≤ n} (if m prime then Λ(m) else 0). This identity (chebyshevTheta_eq_sum_vonMangoldt) is what lets the difference ψ − θ be computed termwise in a single uniform sum."
+  },
+  {
+    "id": "ann-decomposition",
+    "proofId": "chebyshev-bounds-oq-02-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 95
+    },
+    "type": "insight",
+    "title": "ψ − θ Lives on the Higher Prime Powers",
+    "content": "Subtracting the two von Mangoldt forms gives ψ(n) − θ(n) = ∑_{m ≤ n} (Λ(m) − [m prime]·Λ(m)) = ∑_{m ≤ n} [¬ m prime]·Λ(m). Because Λ vanishes off the prime powers, the surviving terms are exactly the m that are prime powers but not primes, i.e. m = p^k with k ≥ 2. This is the precise 'same main term' statement: θ already captures all of ψ except the contribution of squares, cubes, … of primes. Nonnegativity of every term gives θ(n) ≤ ψ(n) for free."
+  },
+  {
+    "id": "ann-proper-prime-powers",
+    "proofId": "chebyshev-bounds-oq-02-oq-02",
+    "range": {
+      "startLine": 97,
+      "endLine": 111
+    },
+    "type": "insight",
+    "title": "Making the k ≥ 2 Support Explicit",
+    "content": "psi_sub_theta_eq_proper_prime_powers rewrites the difference as a sum of Λ over the filtered set {m ∈ [1,n] : IsPrimePow m ∧ ¬ m.Prime}. The step that discards the non-prime-power m uses vonMangoldt_eq_zero_iff (Λ(m) = 0 ↔ ¬ IsPrimePow m). The resulting index set is literally the proper prime powers ≤ n — the objects responsible for the entire gap between the first and second Chebyshev functions."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "chebyshev-bounds-oq-02-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "Bridging the Gallery's ψ to Mathlib's Chebyshev API",
+    "content": "The parent built a self-contained ℕ-indexed ψ as ∑ over [1,n]; Mathlib's Chebyshev.psi is an ℝ-argument sum over (0, ⌊x⌋]. At an integer argument these coincide: Nat.floor_natCast turns ⌊(n:ℝ)⌋₊ into n, and Icc 1 n = Ioc 0 n identifies the index sets, so a one-line Finset.sum_congr proves chebyshevPsi n = Chebyshev.psi n (and likewise for θ). This small bridge is what unlocks Mathlib's entire Chebyshev development for the gallery's elementary functions."
+  },
+  {
+    "id": "ann-transported-bound",
+    "proofId": "chebyshev-bounds-oq-02-oq-02",
+    "range": {
+      "startLine": 126,
+      "endLine": 145
+    },
+    "type": "concept",
+    "title": "Transporting the Identity and the Sharp Bound",
+    "content": "With the bridge, two of Mathlib's results become statements about the gallery's ψ. psi_sub_theta_eq_sum_theta rewrites by Chebyshev.psi_eq_theta_add_sum_theta (ψ = θ + ∑_{k=2}^{⌊log₂ x⌋} θ(x^{1/k})) and cancels θ to give the exact tail identity ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}). abs_psi_sub_theta_le rewrites by Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log to give |ψ(n) − θ(n)| ≤ 2·√n·log n — an O(√n·log n) bound, in fact sharper than the O(√n log²n) originally targeted. The deep analytic work is Mathlib's; the entry supplies the bridge that makes it apply to the gallery's ψ."
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "chebyshev-bounds-oq-02-oq-02",
+  "title": "ψ and θ Share the Same Main Term: ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}) = O(√n·log n)",
+  "slug": "chebyshev-bounds-oq-02-oq-02",
+  "description": "Compares the second Chebyshev function ψ(n) = ∑_{m≤n} Λ(m) (from the parent ChebyshevBoundsOQ02, a self-contained ℕ-indexed development) with the first Chebyshev function θ(n) = ∑_{p≤n} log p, and shows the two share the same main term. Directly proves the structural decomposition ψ(n) − θ(n) = ∑_{m≤n, ¬ m prime} Λ(m) — the difference is supported entirely on the higher prime powers p^k (k ≥ 2). It then bridges the parent's elementary chebyshevPsi to Mathlib's Chebyshev.psi/theta and transports two results to the gallery's functions: the exact identity ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k}) and the sharp quantitative bound |ψ(n) − θ(n)| ≤ 2·√n·log n = O(√n·log n). The deep analytic content of the last two is Mathlib's (Chebyshev.psi_eq_theta_add_sum_theta, abs_psi_sub_theta_le_sqrt_mul_log); the contribution here is the formal bridge that lets the gallery's self-contained ψ inherit them. Answers chebyshev-bounds-oq-02's openQuestion on the ψ−θ comparison.",
+  "meta": {
+    "author": "Pafnuty Chebyshev (1852); formalized in Lean 4",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "chebyshev",
+      "von-mangoldt",
+      "prime-counting",
+      "analytic-number-theory"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` on the headline results reports only the three ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. The substantive analytic number theory behind the two quantitative results — the identity ψ(x) = θ(x) + ∑_{k≥2} θ(x^{1/k}) and the bound |ψ(x) − θ(x)| ≤ 2√x·log x — is supplied by Mathlib's `Mathlib.NumberTheory.Chebyshev` (theorems `psi_eq_theta_add_sum_theta` and `abs_psi_sub_theta_le_sqrt_mul_log`); this entry's own contribution is the bridge `chebyshevPsi n = Chebyshev.psi n` (and the θ analogue) plus the direct decomposition `ψ − θ = ∑_{¬prime} Λ`. Badge is `verified` (not `original`) precisely because the deep bound is Mathlib's, not new here. All results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log",
+        "description": "|ψ(x) − θ(x)| ≤ 2·√x·log x — the sharp O(√x·log x) same-main-term bound, transported to the gallery's ψ via the bridge",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.psi_eq_theta_add_sum_theta",
+        "description": "ψ(x) = θ(x) + ∑_{k=2}^{⌊log₂ x⌋} θ(x^{1/k}) — the exact ψ = ∑_{k≥1} θ(x^{1/k}) decomposition, giving ψ − θ = ∑_{k≥2} θ(x^{1/k})",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_apply_prime",
+        "description": "Λ(p) = log p for prime p — identifies the prime part of ψ with θ",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_eq_zero_iff",
+        "description": "Λ(n) = 0 ↔ ¬ IsPrimePow n — pins the support of ψ − θ to the proper prime powers",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "Nat.floor_natCast",
+        "description": "⌊(n : ℝ)⌋₊ = n — aligns the parent's Icc 1 n indexing with Mathlib's Ioc 0 ⌊x⌋₊",
+        "module": "Mathlib.Algebra.Order.Floor"
+      }
+    ],
+    "dateAdded": "2026-06-25",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's two functions are θ(x) = ∑_{p ≤ x} log p (first) and ψ(x) = ∑_{p^k ≤ x} log p (second). They agree to leading order — both are asymptotic to x, which is the content of the Prime Number Theorem — because ψ counts the contribution of every prime power p^k while θ counts only the primes p themselves (k = 1). The extra mass in ψ comes from squares, cubes, … of primes, and is tiny: collecting prime powers by exponent gives the classical identity ψ(x) = ∑_{k ≥ 1} θ(x^{1/k}), whose tail ∑_{k ≥ 2} θ(x^{1/k}) is O(√x·log x). So θ and ψ may be used interchangeably as the 'main term' in elementary proofs toward the PNT — the substitution that turns bounds on ψ into bounds on θ and on the prime-counting function π.",
+    "problemStatement": "**Open Question (parent chebyshev-bounds-oq-02)**: Relate the second Chebyshev function ψ to the first, θ, and quantify their difference.\n\n**Result**: With θ(n) = ∑_{p ≤ n} log p, the difference ψ(n) − θ(n) is proved equal to ∑_{m ≤ n, ¬ m prime} Λ(m) — supported on the proper prime powers (k ≥ 2). Bridging the parent's elementary ℕ-indexed ψ to Mathlib's Chebyshev API then yields the exact identity ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k}) and the sharp bound |ψ(n) − θ(n)| ≤ 2·√n·log n.",
+    "text": "A 146-line, fully verified (0 sorries, 0 axioms, no native_decide) file in three parts. Part I defines chebyshevTheta n = ∑_{p ∈ [1,n], p prime} log p and shows it equals the prime part of ψ in von Mangoldt form (chebyshevTheta_eq_sum_vonMangoldt), using Λ(p) = log p. Part II proves, directly over the parent's chebyshevPsi, the structural decomposition psi_sub_theta: ψ(n) − θ(n) = ∑_{m ∈ [1,n]} (if m prime then 0 else Λ m) — i.e. the difference is exactly the contribution of the m that are prime powers but not primes — together with nonnegativity (psi_sub_theta_nonneg), θ ≤ ψ (theta_le_psi), and an explicit restatement of the difference as a sum over {m ∈ [1,n] : IsPrimePow m ∧ ¬ m prime} (psi_sub_theta_eq_proper_prime_powers). Part III bridges to Mathlib: chebyshevPsi_eq_mathlib (chebyshevPsi n = Chebyshev.psi n) and chebyshevTheta_eq_mathlib are one-line Finset.sum_congr arguments lining up [1,n] with (0,⌊n⌋]. With the bridge in hand, psi_sub_theta_eq_sum_theta transports Mathlib's ψ = θ + ∑_{k≥2} θ(x^{1/k}) to give ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k}), and abs_psi_sub_theta_le transports Mathlib's |ψ − θ| ≤ 2√x·log x to give |ψ(n) − θ(n)| ≤ 2·√n·log n.",
+    "proofStrategy": "The decomposition psi_sub_theta is a termwise split: ψ(n) − θ(n) = ∑_{m∈[1,n]} (Λ m − [m prime]·Λ m) = ∑_{m∈[1,n]} [¬ m prime]·Λ m, closed by case-splitting on m.Prime. psi_sub_theta_eq_proper_prime_powers further uses Λ(m) = 0 ↔ ¬IsPrimePow m (vonMangoldt_eq_zero_iff) to drop the m that are not prime powers, exposing the k ≥ 2 support. The bridges chebyshevPsi_eq_mathlib / chebyshevTheta_eq_mathlib unfold both sides and apply Finset.sum_congr along Icc 1 n = Ioc 0 n (after Nat.floor_natCast turns ⌊(n:ℝ)⌋₊ into n). The two quantitative theorems are then `rw` of the bridges followed by `exact`/`rw` of the corresponding Mathlib lemma (psi_eq_theta_add_sum_theta with add_sub_cancel_left; abs_psi_sub_theta_le_sqrt_mul_log), with the real hypotheses discharged by exact_mod_cast.",
+    "keyInsights": [
+      "ψ − θ is supported precisely on the proper prime powers: writing both functions in von Mangoldt form, ψ = ∑ Λ and θ = ∑ [prime]·Λ, so the difference is ∑ [¬prime]·Λ, and Λ(m) ≠ 0 forces m to be a prime power — hence m = p^k with k ≥ 2.",
+      "Grouping prime powers by exponent gives ψ(x) = ∑_{k≥1} θ(x^{1/k}); the k = 1 term is θ(x), so ψ − θ = ∑_{k≥2} θ(x^{1/k}), a sum of only ⌊log₂ x⌋ − 1 terms.",
+      "Each tail term θ(x^{1/k}) ≤ θ(√x) for k ≥ 2, so the whole tail is O(√x·log x): ψ and θ are interchangeable as the main term in elementary prime-counting estimates.",
+      "The parent's self-contained ℕ-indexed ψ (∑ over [1,n]) and Mathlib's ℝ-argument Chebyshev.psi (∑ over (0,⌊x⌋]) coincide at integer x once [1,n] is identified with (0,n]; this one-line bridge imports Mathlib's full Chebyshev development into the gallery's thread."
+    ],
+    "prerequisites": [
+      "The von Mangoldt function Λ (Λ(p^k) = log p, else 0) and its support being the prime powers",
+      "First and second Chebyshev functions θ and ψ",
+      "Finset summation congruence and case analysis in Lean 4/Mathlib",
+      "Mathlib's Mathlib.NumberTheory.Chebyshev development (psi, theta, the ψ = ∑θ identity, and the √x·log x bound)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "theta-def",
+      "title": "The First Chebyshev Function θ",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "chebyshevTheta n = ∑_{p∈[1,n] prime} log p, and its von Mangoldt form θ(n) = ∑_{m≤n} [m prime]·Λ(m) via Λ(p) = log p.",
+      "mathContext": "θ(x) = ∑_{p ≤ x} log p — the prime part of ψ."
+    },
+    {
+      "id": "decomposition",
+      "title": "Same Main Term: ψ − θ on the Higher Prime Powers",
+      "startLine": 75,
+      "endLine": 111,
+      "summary": "psi_sub_theta: ψ(n) − θ(n) = ∑_{m≤n, ¬ m prime} Λ(m); nonnegativity; θ ≤ ψ; and the explicit proper-prime-power (IsPrimePow ∧ ¬prime) restatement.",
+      "mathContext": "The difference of the two Chebyshev functions is exactly the contribution of the prime powers p^k with k ≥ 2."
+    },
+    {
+      "id": "bridge",
+      "title": "Bridge to Mathlib and the Quantitative Bound",
+      "startLine": 113,
+      "endLine": 145,
+      "summary": "chebyshevPsi_eq_mathlib / chebyshevTheta_eq_mathlib identify the gallery functions with Mathlib's Chebyshev.psi/theta; psi_sub_theta_eq_sum_theta and abs_psi_sub_theta_le transport Mathlib's ψ = ∑θ(x^{1/k}) identity and |ψ − θ| ≤ 2√x·log x bound.",
+      "mathContext": "ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}) and |ψ(n) − θ(n)| ≤ 2√n·log n = O(√n log n)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers `chebyshev-bounds-oq-02`'s open direction comparing the **second** Chebyshev function `ψ(n) = ∑_{m≤n} Λ(m)` (the parent's self-contained ℕ-indexed development) with the **first**, `θ(n) = ∑_{p≤n} log p`, and shows they share the **same main term**.

**Proof file:** `proofs/Proofs/ChebyshevBoundsOQ02OQ02.lean` (146 lines, 0 sorries, 0 axioms, no `native_decide`).

### Results
- `psi_sub_theta` — **structural decomposition**: `ψ(n) − θ(n) = ∑_{m≤n, ¬ m prime} Λ(m)`. The difference is supported entirely on the proper prime powers `p^k` (`k ≥ 2`). With `psi_sub_theta_nonneg`, `theta_le_psi`, and `psi_sub_theta_eq_proper_prime_powers` (support `= {IsPrimePow ∧ ¬prime}`).
- `chebyshevPsi_eq_mathlib` / `chebyshevTheta_eq_mathlib` — **bridges** identifying the parent's elementary ψ/θ with Mathlib's `Chebyshev.psi`/`theta` at integer arguments.
- `psi_sub_theta_eq_sum_theta` — the exact identity `ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k})`.
- `abs_psi_sub_theta_le` — the sharp bound `|ψ(n) − θ(n)| ≤ 2·√n·log n` = `O(√n·log n)` (sharper than the `O(√n log²n)` originally targeted).

### Honesty / originality

The **deep analytic content** of the last two results is **Mathlib's** (`Mathlib.NumberTheory.Chebyshev`: `psi_eq_theta_add_sum_theta`, `abs_psi_sub_theta_le_sqrt_mul_log`). This entry's own contribution is the **bridge** that lets the gallery's elementary, Legendre-identity-based ψ inherit Mathlib's Chebyshev development, plus the direct `ψ − θ = ∑_{¬prime} Λ` decomposition. Accordingly the badge is **`verified`, not `original`**.

### Verification
- `#print axioms` on `abs_psi_sub_theta_le`, `psi_sub_theta_eq_sum_theta`, `psi_sub_theta` → `[propext, Classical.choice, Quot.sound]` only (foundational; `axiomCount: 0` per policy).
- Built via host `lake env lean` against the prebuilt Mathlib + parent oleans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)