### PR TITLE
research(fundamental-theorem-algebra-oq-04-oq-03-oq-01): explicit iso Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2), generator = complex conjugation [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2996,6 +2996,7 @@ import Proofs.FundamentalTheoremAlgebra
 import Proofs.FundamentalTheoremAlgebraOQ02
 import Proofs.FundamentalTheoremAlgebraOQ04
 import Proofs.FundamentalTheoremAlgebraOQ04OQ03
+import Proofs.FundamentalTheoremAlgebraOQ04OQ03OQ01
 import Proofs.FundamentalTheoremAlgebraOQ04OQ04
 import Proofs.FundamentalTheoremAlgebraOQ06
 import Proofs.FundamentalTheoremAlgebraOQ06OQ01

--- a/proofs/Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01.lean
@@ -1,0 +1,164 @@
+import Mathlib
+
+/-
+# The explicit isomorphism `Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2)`
+
+## What This Proves
+
+This is the leaf `oq-04-oq-03-oq-01` of `fundamental-theorem-algebra-oq-04`
+("ℂ is the unique algebraic closure of ℝ").  The parent leaf
+`FundamentalTheoremAlgebraOQ04OQ03` proved, via the Galois correspondence, that
+`Gal(ℂ/ℝ)` has **order 2** and is **cyclic** (`IsCyclic`), hence *abstractly*
+`≅ ℤ/2ℤ`.  Cyclicity alone is an existence statement: Mathlib's
+`zmodCyclicMulEquiv` even produces an isomorphism `Multiplicative (ZMod 2) ≃* G`,
+but only by `Classical.choice`-ing some generator — it says nothing about *which*
+automorphism the nontrivial element maps to.
+
+This leaf answers the parent's open question OQ[0] by constructing the iso
+**explicitly and naming the generator**:
+
+* `galoisGroupEquivZMod2 : (ℂ ≃ₐ[ℝ] ℂ) ≃* Multiplicative (ZMod 2)` — a fully
+  spelled-out multiplicative equivalence, no choice of generator hidden inside;
+* `galoisGroupEquivZMod2_conjAe` : the iso sends **complex conjugation**
+  `Complex.conjAe` to the nontrivial element `Multiplicative.ofAdd 1`;
+* `galoisGroupEquivZMod2_symm_ofAdd_one` : conversely, the nontrivial element of
+  `Multiplicative (ZMod 2)` is realized by complex conjugation.
+
+The mathematical heart is the elementary structure theorem
+`eq_one_or_conjAe`: in the order-2 group `Gal(ℂ/ℝ)` the only automorphisms are the
+identity and complex conjugation (a three-distinct-elements counting argument
+against `Fintype.card = 2`), together with the involutivity
+`conjAe * conjAe = 1` (`Complex.conj_conj`) and the non-triviality
+`conjAe ≠ 1` (because `conjAe I = -I ≠ I`).
+
+This pins down the abstract `IsCyclic` of the parent to a concrete labelled
+isomorphism, which is exactly the "named iso sending the generator to
+conjugation" the open question requested.
+
+This file is self-contained: it re-establishes `IsAlgClosure ℝ ℂ` and
+`IsGalois ℝ ℂ` (as the parent does) so it does not depend on the parent's
+compiled object file.
+
+*Reference:* Galois theory of `ℂ/ℝ`; Mathlib
+`Mathlib.FieldTheory.Galois.Basic`, `Mathlib.Analysis.RCLike.Basic`.
+-/
+
+open Complex
+open scoped Classical
+
+namespace FTAGaloisIso
+
+/-! ## Setup: ℂ as an algebraic closure of ℝ, and `IsGalois ℝ ℂ` -/
+
+/-- ℂ is algebraic over ℝ (finite extension ⇒ algebraic). -/
+instance : Algebra.IsAlgebraic ℝ ℂ := Algebra.IsAlgebraic.of_finite ℝ ℂ
+
+/-- ℂ is an algebraic closure of ℝ — the instance that supplies `Normal ℝ ℂ`. -/
+instance : IsAlgClosure ℝ ℂ where
+  isAlgClosed := Complex.isAlgClosed
+  isAlgebraic := inferInstance
+
+/-- **`ℂ / ℝ` is a Galois extension.** Finite + separable (char 0) + normal
+    (algebraic closure). -/
+instance galois_complex_real : IsGalois ℝ ℂ := IsGalois.mk
+
+/-- **`|Gal(ℂ/ℝ)| = 2`.** For a Galois extension the automorphism group has order
+    equal to the degree, and `[ℂ:ℝ] = 2`. -/
+theorem card_galoisGroup_eq_two : Nat.card (ℂ ≃ₐ[ℝ] ℂ) = 2 := by
+  rw [IsGalois.card_aut_eq_finrank ℝ ℂ, Complex.finrank_real_complex]
+
+/-! ## The two automorphisms: identity and complex conjugation -/
+
+/-- **Complex conjugation is a nontrivial automorphism.** It moves `I` to `-I`. -/
+theorem conjAe_ne_one : (Complex.conjAe : ℂ ≃ₐ[ℝ] ℂ) ≠ 1 := by
+  intro h
+  have h2 := DFunLike.congr_fun h Complex.I
+  rw [AlgEquiv.one_apply] at h2
+  -- `conjAe I = conj I = -I`, so `-I = I`, forcing `I = 0`.
+  rw [Complex.conjAe_coe, Complex.conj_I] at h2
+  have h3 : (2 : ℂ) * Complex.I = 0 := by linear_combination -h2
+  rw [mul_eq_zero] at h3
+  rcases h3 with h | h
+  · norm_num at h
+  · exact Complex.I_ne_zero h
+
+/-- **Complex conjugation is an involution:** `conjAe * conjAe = 1`. -/
+theorem conjAe_mul_self : (Complex.conjAe : ℂ ≃ₐ[ℝ] ℂ) * Complex.conjAe = 1 := by
+  ext z
+  simp [AlgEquiv.mul_apply, Complex.conjAe_coe]
+
+/-- **Structure of `Gal(ℂ/ℝ)`.** The only `ℝ`-automorphisms of `ℂ` are the identity
+    and complex conjugation. Proof: a third distinct automorphism would give three
+    elements in a group of order `2`. -/
+theorem eq_one_or_conjAe (g : ℂ ≃ₐ[ℝ] ℂ) : g = 1 ∨ g = Complex.conjAe := by
+  by_contra hcon
+  push_neg at hcon
+  obtain ⟨h1, hc⟩ := hcon
+  have hcard : Fintype.card (ℂ ≃ₐ[ℝ] ℂ) = 2 := by
+    rw [← Nat.card_eq_fintype_card]; exact card_galoisGroup_eq_two
+  have hsub : ({1, Complex.conjAe, g} : Finset (ℂ ≃ₐ[ℝ] ℂ)).card ≤ 2 := by
+    rw [← hcard]; exact Finset.card_le_univ _
+  have e1 : (1 : ℂ ≃ₐ[ℝ] ℂ) ∉ ({Complex.conjAe, g} : Finset (ℂ ≃ₐ[ℝ] ℂ)) := by
+    simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+    exact ⟨fun h => conjAe_ne_one h.symm, fun h => h1 h.symm⟩
+  have e2 : Complex.conjAe ∉ ({g} : Finset (ℂ ≃ₐ[ℝ] ℂ)) := by
+    simp only [Finset.mem_singleton]; exact fun h => hc h.symm
+  rw [Finset.card_insert_of_notMem e1, Finset.card_insert_of_notMem e2,
+    Finset.card_singleton] at hsub
+  omega
+
+/-! ## Helper facts in `Multiplicative (ZMod 2)` -/
+
+/-- The nontrivial element `ofAdd 1` of `Multiplicative (ZMod 2)` is not the unit. -/
+theorem ofAdd_one_ne_one : (Multiplicative.ofAdd (1 : ZMod 2)) ≠ 1 := by decide
+
+/-- `Multiplicative (ZMod 2)` has exactly the two elements `1` and `ofAdd 1`. -/
+theorem zmod2_eq_one_or (x : Multiplicative (ZMod 2)) :
+    x = 1 ∨ x = Multiplicative.ofAdd 1 := by revert x; decide
+
+/-! ## The explicit isomorphism -/
+
+/-- **The explicit isomorphism `Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2)`.**
+    The identity maps to the unit and complex conjugation maps to the nontrivial
+    element `ofAdd 1`. Unlike `zmodCyclicMulEquiv`, every component is spelled out;
+    no generator is chosen by `Classical.choice`. -/
+noncomputable def galoisGroupEquivZMod2 : (ℂ ≃ₐ[ℝ] ℂ) ≃* Multiplicative (ZMod 2) where
+  toFun g := if g = 1 then 1 else Multiplicative.ofAdd 1
+  invFun x := if x = 1 then 1 else Complex.conjAe
+  left_inv g := by
+    rcases eq_one_or_conjAe g with h | h
+    · subst h; simp
+    · subst h
+      simp only [if_neg conjAe_ne_one, if_neg ofAdd_one_ne_one]
+  right_inv x := by
+    rcases zmod2_eq_one_or x with h | h
+    · subst h; simp
+    · subst h
+      simp only [if_neg ofAdd_one_ne_one, if_neg conjAe_ne_one]
+  map_mul' a b := by
+    rcases eq_one_or_conjAe a with ha | ha <;> rcases eq_one_or_conjAe b with hb | hb <;>
+      subst ha <;> subst hb
+    · simp
+    · simp
+    · simp
+    · -- conjAe * conjAe = 1
+      rw [conjAe_mul_self]
+      simp only [if_neg conjAe_ne_one]
+      decide
+
+/-- **The iso sends complex conjugation to the nontrivial element `ofAdd 1`.** -/
+@[simp] theorem galoisGroupEquivZMod2_conjAe :
+    galoisGroupEquivZMod2 Complex.conjAe = Multiplicative.ofAdd 1 :=
+  if_neg conjAe_ne_one
+
+/-- **The iso sends the identity to the unit.** -/
+@[simp] theorem galoisGroupEquivZMod2_one :
+    galoisGroupEquivZMod2 1 = 1 :=
+  map_one galoisGroupEquivZMod2
+
+/-- **The nontrivial element of `Multiplicative (ZMod 2)` is complex conjugation.** -/
+theorem galoisGroupEquivZMod2_symm_ofAdd_one :
+    galoisGroupEquivZMod2.symm (Multiplicative.ofAdd 1) = Complex.conjAe := by
+  rw [MulEquiv.symm_apply_eq, galoisGroupEquivZMod2_conjAe]
+
+end FTAGaloisIso

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+    "range": { "startLine": 4, "endLine": 49 },
+    "type": "context",
+    "title": "From Abstract Cyclicity to a Named Isomorphism",
+    "content": "The parent entry proved Gal(ℂ/ℝ) is cyclic of order 2 — abstractly ≅ ℤ/2ℤ — but cyclicity is an existence statement that does not name which automorphism is the generator. Mathlib's zmodCyclicMulEquiv even produces an isomorphism Multiplicative (ZMod 2) ≃* G, but only by Classical.choice-ing some generator. This file answers the parent's first open question by constructing the isomorphism explicitly: every component is spelled out, and complex conjugation Complex.conjAe is named as the image of the nontrivial element ofAdd 1.",
+    "mathContext": "$\\mathrm{Gal}(\\mathbb{C}/\\mathbb{R}) \\;\\simeq^*\\; \\mathrm{Multiplicative}(\\mathbb{Z}/2\\mathbb{Z})$, sending $\\mathrm{conjAe} \\mapsto \\mathrm{ofAdd}\\,1$ and $\\mathrm{id} \\mapsto 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Galois theory", "group isomorphism", "complex conjugation", "cyclic groups", "Multiplicative (ZMod 2)"],
+    "prerequisites": ["Galois group of ℂ/ℝ", "MulEquiv", "complex conjugation"]
+  },
+  {
+    "id": "ann-card-two",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+    "range": { "startLine": 51, "endLine": 68 },
+    "type": "theorem",
+    "title": "The Galois Group Has Order 2",
+    "content": "After re-establishing IsAlgClosure ℝ ℂ and IsGalois ℝ ℂ self-contained (as in the parent), card_galoisGroup_eq_two computes |Gal(ℂ/ℝ)| = 2 from IsGalois.card_aut_eq_finrank (for a Galois extension the automorphism group has order equal to the degree) and Complex.finrank_real_complex ([ℂ:ℝ] = 2). This cardinality is the only input the rest of the file needs about ℂ.",
+    "mathContext": "$|\\mathrm{Gal}(\\mathbb{C}/\\mathbb{R})| = [\\mathbb{C}:\\mathbb{R}] = 2$.",
+    "significance": "key",
+    "relatedConcepts": ["IsGalois.card_aut_eq_finrank", "Complex.finrank_real_complex", "IsGalois"],
+    "prerequisites": ["Galois extensions", "automorphism groups"]
+  },
+  {
+    "id": "ann-two-automorphisms",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+    "range": { "startLine": 70, "endLine": 108 },
+    "type": "theorem",
+    "title": "The Only Automorphisms Are Identity and Conjugation",
+    "content": "conjAe_ne_one shows complex conjugation is nontrivial (it sends I to -I, so -I = I would force I = 0). conjAe_mul_self records the involution conjAe * conjAe = 1 (Complex.conj_conj). The structure theorem eq_one_or_conjAe then proves the only ℝ-automorphisms of ℂ are 1 and conjAe: a third distinct automorphism g would make {1, conjAe, g} three distinct elements inside a group of cardinality 2 (Fintype.card = 2), a contradiction by Finset.card_le_univ. This pure cardinality count, not the abstract cyclic structure, is what pins down the group.",
+    "mathContext": "$g = 1 \\ \\vee\\ g = \\mathrm{conjAe}$ for every $g \\in \\mathrm{Gal}(\\mathbb{C}/\\mathbb{R})$; $\\mathrm{conjAe} \\neq 1$ and $\\mathrm{conjAe}^2 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["complex conjugation", "involution", "Fintype.card", "counting argument", "Complex.conj_conj"],
+    "prerequisites": ["finite groups", "complex conjugation as an automorphism"]
+  },
+  {
+    "id": "ann-zmod2-helpers",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+    "range": { "startLine": 110, "endLine": 117 },
+    "type": "technique",
+    "title": "The Target Group Has Two Elements",
+    "content": "ofAdd_one_ne_one (the nontrivial element ofAdd 1 is not the unit) and zmod2_eq_one_or (every element of Multiplicative (ZMod 2) is 1 or ofAdd 1) are the mirror facts on the target side, both discharged by kernel `decide` over the finite type — not `native_decide`, so no Lean.ofReduceBool axiom is introduced.",
+    "mathContext": "$\\mathrm{Multiplicative}(\\mathbb{Z}/2\\mathbb{Z}) = \\{1, \\mathrm{ofAdd}\\,1\\}$, $\\mathrm{ofAdd}\\,1 \\neq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiplicative (ZMod 2)", "decide", "finite types"],
+    "prerequisites": ["ZMod n", "Multiplicative"]
+  },
+  {
+    "id": "ann-explicit-iso",
+    "proofId": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+    "range": { "startLine": 119, "endLine": 163 },
+    "type": "insight",
+    "title": "The Explicit Isomorphism and Its Generator",
+    "content": "galoisGroupEquivZMod2 is the hand-built MulEquiv: g ↦ (if g = 1 then 1 else ofAdd 1), with inverse x ↦ (if x = 1 then 1 else conjAe). The two inverse laws and map_mul each reduce to a finite case split over {1, conjAe} (resp. {1, ofAdd 1}); the only nontrivial multiplication, conjAe·conjAe = 1 ↦ ofAdd 1 · ofAdd 1 = 1, closes by decide. The characterizing lemmas galoisGroupEquivZMod2_conjAe (conjAe ↦ ofAdd 1), galoisGroupEquivZMod2_one (1 ↦ 1), and galoisGroupEquivZMod2_symm_ofAdd_one (ofAdd 1 ↦ conjAe) make the iso canonical by naming the generator — the content the open question asked for.",
+    "mathContext": "$\\varphi(g) = \\begin{cases}1 & g = 1\\\\ \\mathrm{ofAdd}\\,1 & g = \\mathrm{conjAe}\\end{cases}$, $\\varphi(\\mathrm{conjAe}) = \\mathrm{ofAdd}\\,1$, $\\varphi^{-1}(\\mathrm{ofAdd}\\,1) = \\mathrm{conjAe}$.",
+    "significance": "key",
+    "relatedConcepts": ["MulEquiv", "group isomorphism", "complex conjugation as generator", "case analysis"],
+    "prerequisites": ["MulEquiv construction", "finite group multiplication tables"]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+  "slug": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+  "title": "The Explicit Isomorphism Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2)",
+  "description": "Constructs the explicit, fully spelled-out multiplicative isomorphism between the Galois group of ℂ/ℝ and Multiplicative (ZMod 2), naming the generator: the identity maps to the unit and complex conjugation Complex.conjAe maps to the nontrivial element ofAdd 1. This upgrades the parent's abstract 'Gal(ℂ/ℝ) is cyclic of order 2' to a labelled isomorphism, answering the parent's first open question.",
+  "meta": {
+    "author": "Lean Genius (researcher-3)",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01.lean",
+    "tags": [
+      "galois-theory",
+      "complex-conjugation",
+      "cyclic-groups",
+      "group-isomorphism",
+      "complex-numbers",
+      "field-extensions"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "lineCount": 164,
+    "mathlib_version": "4.26.0",
+    "assumptions": "0 axioms, 0 sorries. Fully machine-checked; all results depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound). The two finite checks (ofAdd_one_ne_one, zmod2_eq_one_or) use kernel `decide`, not `native_decide`, so no `Lean.ofReduceBool` is introduced.",
+    "originalContributions": [
+      "galoisGroupEquivZMod2: the explicit MulEquiv (ℂ ≃ₐ[ℝ] ℂ) ≃* Multiplicative (ZMod 2), with every component (toFun, invFun, both inverse laws, map_mul) spelled out — no generator chosen by Classical.choice, unlike Mathlib's zmodCyclicMulEquiv",
+      "galoisGroupEquivZMod2_conjAe: the iso sends complex conjugation Complex.conjAe to the nontrivial element Multiplicative.ofAdd 1",
+      "galoisGroupEquivZMod2_symm_ofAdd_one: conversely, the nontrivial element of Multiplicative (ZMod 2) is realized by complex conjugation",
+      "eq_one_or_conjAe: the structure theorem — the only ℝ-automorphisms of ℂ are the identity and complex conjugation (a three-distinct-elements count against Fintype.card = 2)",
+      "conjAe_ne_one: complex conjugation is a nontrivial automorphism (it sends I to -I ≠ I)",
+      "conjAe_mul_self: complex conjugation is an involution, conjAe * conjAe = 1 (Complex.conj_conj)",
+      "card_galoisGroup_eq_two: |Gal(ℂ/ℝ)| = 2 via IsGalois.card_aut_eq_finrank and [ℂ:ℝ] = 2"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry (fundamental-theorem-algebra-oq-04-oq-03, 'The Galois Correspondence for ℂ/ℝ') proved that Gal(ℂ/ℝ) is cyclic of order 2 — i.e. abstractly isomorphic to ℤ/2ℤ — and used this to recover the no-intermediate-fields theorem. Cyclicity is an existence statement: it does not name which automorphism plays the role of the generator. This entry answers the parent's first open question by building the isomorphism explicitly and pinning the generator to complex conjugation.",
+    "problemStatement": "Construct an explicit multiplicative isomorphism Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2) that sends complex conjugation Complex.conjAe to the nontrivial element ofAdd 1 (and the identity to the unit).",
+    "proofStrategy": "Three ingredients. (1) Identify the group: eq_one_or_conjAe shows the only ℝ-automorphisms of ℂ are 1 and conjAe, by a counting argument — a third distinct automorphism would give three elements in {1, conjAe, g} ⊆ Gal(ℂ/ℝ), contradicting Fintype.card = 2 (which comes from IsGalois.card_aut_eq_finrank and [ℂ:ℝ] = 2). (2) Record the multiplication: conjAe ≠ 1 (it sends I to -I) and conjAe * conjAe = 1 (Complex.conj_conj). (3) Assemble the MulEquiv by hand, mapping g ↦ (if g = 1 then 1 else ofAdd 1) with inverse x ↦ (if x = 1 then 1 else conjAe); the two inverse laws and the map_mul law each reduce to the finite case split over {1, conjAe} (resp. {1, ofAdd 1}), closed by decide in the one nontrivial multiplication case conjAe·conjAe = 1 ↦ ofAdd 1 · ofAdd 1 = 1.",
+    "keyInsights": [
+      "Cyclicity is existence; the explicit iso is structure. Mathlib's zmodCyclicMulEquiv produces a Multiplicative (ZMod 2) ≃* G but only after Classical.choice-ing a generator, so it cannot tell you the generator is conjugation.",
+      "The Galois group of ℂ/ℝ has exactly two elements, 1 and complex conjugation, recovered by a pure cardinality count rather than from the abstract cyclic structure.",
+      "Complex conjugation is the canonical generator: it is the unique nontrivial automorphism, it is an involution, and naming it makes the isomorphism canonical.",
+      "Once the group is reduced to {1, conjAe}, every equivariance obligation (left/right inverse, multiplicativity) is a finite check decidable by case analysis."
+    ],
+    "prerequisites": [
+      "Galois theory of ℂ/ℝ (the Galois group, its order)",
+      "Group isomorphisms (MulEquiv) and Multiplicative (ZMod n)",
+      "Complex conjugation as an ℝ-algebra automorphism (Complex.conjAe)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: IsGalois ℝ ℂ and |Gal(ℂ/ℝ)| = 2",
+      "summary": "Re-establishes IsAlgClosure ℝ ℂ and IsGalois ℝ ℂ (self-contained), and computes the order of the Galois group as 2.",
+      "startLine": 51,
+      "endLine": 68
+    },
+    {
+      "id": "two-automorphisms",
+      "title": "The two automorphisms: identity and conjugation",
+      "summary": "conjAe_ne_one (sends I to -I), conjAe_mul_self (involution), and eq_one_or_conjAe: the only ℝ-automorphisms of ℂ are 1 and complex conjugation.",
+      "startLine": 70,
+      "endLine": 108
+    },
+    {
+      "id": "zmod2-helpers",
+      "title": "Helper facts in Multiplicative (ZMod 2)",
+      "summary": "ofAdd_one_ne_one and zmod2_eq_one_or: the target group has exactly the two elements 1 and ofAdd 1.",
+      "startLine": 110,
+      "endLine": 117
+    },
+    {
+      "id": "explicit-iso",
+      "title": "The explicit isomorphism",
+      "summary": "galoisGroupEquivZMod2 (the hand-built MulEquiv) plus the characterizing lemmas: conjAe ↦ ofAdd 1, 1 ↦ 1, and the symm direction ofAdd 1 ↦ conjAe.",
+      "startLine": 119,
+      "endLine": 163
+    }
+  ],
+  "conclusion": {
+    "summary": "Gal(ℂ/ℝ) is explicitly isomorphic to Multiplicative (ZMod 2) via a hand-built MulEquiv that sends the identity to the unit and complex conjugation to the nontrivial element ofAdd 1. The construction names the generator and spells out every component, turning the parent's abstract cyclicity into a concrete labelled isomorphism.",
+    "implications": "Naming the generator is what makes the isomorphism canonical and usable: any computation in Gal(ℂ/ℝ) can now be transported to arithmetic in ZMod 2 with conjugation as the explicit witness of the nontrivial class. The same hand-built template — identify the finite group, record its multiplication, assemble the MulEquiv by case analysis — applies to the Galois group of any quadratic or, more generally, prime-degree extension, and to the Artin–Schreier setting Gal(R(√-1)/R) for a real-closed field R.",
+    "openQuestions": [
+      "Generalize to an arbitrary real-closed field R: build the explicit iso Gal(R(√-1)/R) ≃* Multiplicative (ZMod 2) with the Artin–Schreier conjugation as generator.",
+      "Identify galoisGroupEquivZMod2 with Mathlib's zmodCyclicMulEquiv up to the choice of generator, exhibiting that the canonical generator there can be taken to be conjugation."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra-oq-04-oq-03",
+      "relationship": "parent",
+      "description": "Parent entry: the Galois correspondence for ℂ/ℝ, proving Gal(ℂ/ℝ) is cyclic of order 2. This entry answers its first open question by constructing the explicit isomorphism to Multiplicative (ZMod 2) and naming complex conjugation as the generator."
+    }
+  ],
+  "references": [
+    {
+      "key": "Artin1942",
+      "authors": ["E. Artin"],
+      "title": "Galois Theory",
+      "venue": "Notre Dame Mathematical Lectures",
+      "year": "1942",
+      "note": "Classical reference for the Galois theory of ℂ/ℝ."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01.lean",
+    "filePath": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01.lean",
+    "imports": ["Mathlib"],
+    "opens": ["Complex", "Classical"],
+    "namespace": "FTAGaloisIso",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `fundamental-theorem-algebra-oq-04-oq-03` ("The Galois Correspondence for ℂ/ℝ"), which reads verbatim:

> *Formalize the explicit isomorphism `Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2)` sending the nontrivial element to complex conjugation `Complex.conjAe`.*

The parent proved `Gal(ℂ/ℝ)` is **cyclic of order 2** — abstractly `≅ ℤ/2ℤ` — but cyclicity is an *existence* statement. Mathlib's `zmodCyclicMulEquiv` even yields a `Multiplicative (ZMod 2) ≃* G`, but only after `Classical.choice`-ing some generator, so it never names conjugation. This entry constructs the isomorphism **explicitly**, with every component spelled out, and pins the generator.

## Results (9 theorems, 1 def, 164 lines, 0 sorries)

- **`galoisGroupEquivZMod2 : (ℂ ≃ₐ[ℝ] ℂ) ≃* Multiplicative (ZMod 2)`** — the hand-built `MulEquiv` (`toFun`, `invFun`, both inverse laws, `map_mul` all explicit).
- **`galoisGroupEquivZMod2_conjAe`** — the iso sends `Complex.conjAe ↦ Multiplicative.ofAdd 1`.
- **`galoisGroupEquivZMod2_symm_ofAdd_one`** — conversely, the nontrivial element is realized by complex conjugation.
- **`eq_one_or_conjAe`** — structure theorem: the only ℝ-automorphisms of ℂ are the identity and conjugation, via a three-distinct-elements count against `Fintype.card = 2`.
- **`conjAe_ne_one`** (`conjAe I = -I ≠ I`), **`conjAe_mul_self`** (involution, `Complex.conj_conj`), **`card_galoisGroup_eq_two`**.

## Verification

```
#print axioms FTAGaloisIso.galoisGroupEquivZMod2
  ⊢ [propext, Classical.choice, Quot.sound]
```

Only the three standard foundational axioms — **0 declared axioms, 0 sorries**. The two finite checks (`ofAdd_one_ne_one`, `zmod2_eq_one_or`) use kernel `decide`, **not** `native_decide`, so no `Lean.ofReduceBool` is introduced. Compiled against Mathlib (lean4 v4.26.0).

## Notes

- Self-contained: re-establishes `IsAlgClosure ℝ ℂ` / `IsGalois ℝ ℂ` (as the parent does), so it does not depend on the parent's compiled object file.
- Aggregator `Proofs.lean` import added.
- Gallery data added under `src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01/` (meta + annotations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)