### PR TITLE
research(erdos-160): discharge h_sublinear & h_superlog sorries + repair v4.26.0 build [axiomatized, 3-axiom]

### DIFF
--- a/proofs/Proofs/Erdos160Problem.lean
+++ b/proofs/Proofs/Erdos160Problem.lean
@@ -25,9 +25,13 @@ import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
+import Mathlib.Order.Filter.AtTopBot.Field
 import Mathlib.Tactic
 
-open Finset
+open Finset Real Filter Topology
 
 namespace Erdos160
 
@@ -130,12 +134,12 @@ noncomputable def h (n : ℕ) : ℕ :=
 
 /-- h(N) is achievable: the minimum is attained (Nat.sInf_mem). -/
 theorem h_achievable (n : ℕ) : Achievable n (h n) :=
-  Nat.sInf_mem ⟨n, achievable_self n⟩
+  Nat.sInf_mem (s := {k | Achievable n k}) ⟨n, achievable_self n⟩
 
 /-- h(N) is minimal: no smaller k works (Nat.sInf_le). -/
 theorem h_minimal (n : ℕ) : ∀ k < h n, ¬Achievable n k := by
   intro k hk hak
-  exact absurd (Nat.sInf_le hak) (not_le_of_lt hk)
+  exact absurd (Nat.sInf_le hak) (not_le_of_gt hk)
 
 /-- h(N) ≥ 1 for N ≥ 4 (at least one color needed, and the problem
     is nontrivial once there exist 4-APs). -/
@@ -210,14 +214,52 @@ axiom lower_bound_exp :
     statement would be h(n) ≤ n^(2/3+ε) for any ε > 0. -/
 theorem h_sublinear : ∀ ε > (0 : ℝ), ε < 1/3 → ∃ N₀ : ℕ, ∀ n ≥ N₀,
     (h n : ℝ) ≤ (n : ℝ) ^ (1 - ε) := by
-  sorry -- Follows from upper_bound_two_thirds for ε < 1/3; needs rpow_le_rpow
+  obtain ⟨C, _hC, hub⟩ := upper_bound_two_thirds
+  intro ε _hε hε3
+  -- Let δ = 1/3 - ε > 0.  Since n^δ → ∞, eventually C ≤ n^δ, so
+  -- C · n^{2/3} ≤ n^δ · n^{2/3} = n^{δ + 2/3} = n^{1-ε}.
+  have hδ : (0 : ℝ) < 1 / 3 - ε := by linarith
+  have htends : Tendsto (fun n : ℕ => (n : ℝ) ^ (1 / 3 - ε)) atTop atTop :=
+    (tendsto_rpow_atTop hδ).comp tendsto_natCast_atTop_atTop
+  have hev := htends.eventually_ge_atTop C
+  rw [Filter.eventually_atTop] at hev
+  obtain ⟨N₁, hN₁⟩ := hev
+  refine ⟨max N₁ 1, fun n hn => ?_⟩
+  have hn1 : n ≥ N₁ := le_trans (le_max_left _ _) hn
+  have hnpos : n ≥ 1 := le_trans (le_max_right _ _) hn
+  have hnR : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hnpos
+  calc (h n : ℝ) ≤ C * (n : ℝ) ^ ((2 : ℝ) / 3) := hub n hnpos
+    _ ≤ (n : ℝ) ^ (1 / 3 - ε) * (n : ℝ) ^ ((2 : ℝ) / 3) :=
+        mul_le_mul_of_nonneg_right (hN₁ n hn1) (by positivity)
+    _ = (n : ℝ) ^ (1 - ε) := by
+        rw [← Real.rpow_add hnR]
+        congr 1
+        ring
 
 /-- The lower bound implies h grows without bound: for any C,
     h(n) ≥ C for all sufficiently large n. Proof: the exponential
     lower bound exp(c · (log n)^{1/9}) → ∞ as n → ∞. -/
 theorem h_superlog : ∀ C : ℝ, ∃ N₀ : ℕ, ∀ n ≥ N₀,
     (h n : ℝ) ≥ C := by
-  sorry -- Requires showing exp(c · (log n)^{1/9}) → ∞, needs Filter.Tendsto infrastructure
+  obtain ⟨c, hc, hlb⟩ := lower_bound_exp
+  -- exp(c · (log n)^{1/9}) → ∞ : compose natCast → log → (·)^{1/9} → c·(·) → exp.
+  have hlog : Tendsto (fun n : ℕ => Real.log n) atTop atTop :=
+    Real.tendsto_log_atTop.comp tendsto_natCast_atTop_atTop
+  have hrpow : Tendsto (fun n : ℕ => (Real.log n) ^ ((1 : ℝ) / 9)) atTop atTop :=
+    (tendsto_rpow_atTop (by norm_num : (0 : ℝ) < 1 / 9)).comp hlog
+  have hmul : Tendsto (fun n : ℕ => c * (Real.log n) ^ ((1 : ℝ) / 9)) atTop atTop :=
+    hrpow.const_mul_atTop hc
+  have htends : Tendsto (fun n : ℕ => Real.exp (c * (Real.log n) ^ ((1 : ℝ) / 9)))
+      atTop atTop := Real.tendsto_exp_atTop.comp hmul
+  intro C
+  have hev := htends.eventually_ge_atTop C
+  rw [Filter.eventually_atTop] at hev
+  obtain ⟨N₁, hN₁⟩ := hev
+  refine ⟨max N₁ 2, fun n hn => ?_⟩
+  have hn1 : n ≥ N₁ := le_trans (le_max_left _ _) hn
+  have hn2 : n ≥ 2 := le_trans (le_max_right _ _) hn
+  calc C ≤ Real.exp (c * (Real.log n) ^ ((1 : ℝ) / 9)) := hN₁ n hn1
+    _ ≤ (h n : ℝ) := hlb n hn2
 
 /-- The Hunter upper bound improves on the LeechLattice bound
     (log 3 / log 22 < 2/3). Proof: log 3 < (2/3) · log 22 since
@@ -226,7 +268,7 @@ theorem h_superlog : ∀ C : ℝ, ∃ N₀ : ℕ, ∀ n ≥ N₀,
 theorem hunter_improves_leechlattice :
     Real.log 3 / Real.log 22 < (2 : ℝ) / 3 := by
   have hlog22_pos : (0 : ℝ) < Real.log 22 := Real.log_pos (by norm_num)
-  rw [div_lt_div_iff hlog22_pos (by norm_num : (0 : ℝ) < 3)]
+  rw [div_lt_div_iff₀ hlog22_pos (by norm_num : (0 : ℝ) < 3)]
   -- Goal: Real.log 3 * 3 < 2 * Real.log 22
   -- Equivalently: log(3^3) < log(22^2), i.e., log 27 < log 484
   rw [show Real.log 3 * 3 = Real.log (3 ^ 3) by rw [Real.log_pow]; ring,

--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -12,7 +12,7 @@
     "erdosUrl": "https://erdosproblems.com/160",
     "erdosProblemStatus": "open",
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -23,8 +23,8 @@
     ],
     "axiomCount": 3,
     "theoremCount": 16,
-    "lineCount": 256,
-    "assumptions": "3 axioms (upper_bound_two_thirds, upper_bound_hunter, lower_bound_exp \u2014 deep published results) and 2 sorries (h_sublinear, h_superlog). Former axioms h, h_achievable, h_minimal eliminated via constructive sInf definition.",
+    "lineCount": 298,
+    "assumptions": "3 axioms (upper_bound_two_thirds, upper_bound_hunter, lower_bound_exp \u2014 deep published results) (h_sublinear and h_superlog are now fully proved as consequences of the axioms; 0 sorries). Former axioms h, h_achievable, h_minimal eliminated via constructive sInf definition.",
     "mathlib_version": "4.26.0",
     "definitionCount": 6,
     "additionalFiles": [
@@ -62,7 +62,7 @@
       "title": "The Function h(N)",
       "startLine": 107,
       "endLine": 175,
-      "summary": "Defines $h(N)$ constructively via `sInf` (well-ordering of ℕ) as the minimum colors for 3-diverse coloring — not an axiom. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring.",
+      "summary": "Defines $h(N)$ constructively via `sInf` (well-ordering of \u2115) as the minimum colors for 3-diverse coloring \u2014 not an axiom. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring.",
       "mathContext": "Verified: $h(N)$ is a constructive `def` (via `sInf`), eliminating 3 former axioms. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring."
     },
     {
@@ -137,12 +137,12 @@
       "Finset"
     ],
     "namespace": "Erdos160",
-    "lineCount": 256,
+    "lineCount": 298,
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 6,
     "path": "Proofs/Erdos160Problem.lean",
-    "sorries": 2,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos160Aristotle.lean",
       "Proofs/Erdos160ProblemAristotle.lean"
@@ -183,5 +183,5 @@
       "note": "Survey of rainbow-free colorings and anti-Ramsey problems in arithmetic settings"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Erdős Problem #160 — rainbow-free colorings of 4-term APs. `h(N)` is the least number of colors so every 4-AP in `{1,…,N}` uses ≥ 3 distinct colors. The problem is **OPEN**; this file constructively defines `h` via `sInf`, axiomatizes the three known literature bounds, and derives consequences. This PR discharges the two remaining `sorry`s in the consequences section and repairs the file to build on toolchain v4.26.0.

## What changed

**Discharged 2 sorries (the deliverable):**

- **`h_sublinear`** — from LeechLattice's `h(n) ≤ C·n^{2/3}`, for any `0 < ε < 1/3` eventually `h(n) ≤ n^{1-ε}`. Since `n^{1/3-ε} → ∞` (`tendsto_rpow_atTop ∘ tendsto_natCast_atTop_atTop`, `eventually_ge_atTop`), the constant `C` is absorbed: `C·n^{2/3} ≤ n^{1/3-ε}·n^{2/3} = n^{1-ε}` via `Real.rpow_add`.
- **`h_superlog`** — from the exponential lower bound, `h` grows without bound. Compose the tendsto chain `natCast → log → (·)^{1/9} → c·(·) → exp` to `atTop`, then `eventually_ge_atTop` dominates any `C`.

**Repaired v4.26.0 API bitrot in pre-existing code** (the file did not build on host lean before this PR):

- `Nat.sInf_mem` now given explicit `(s := {k | Achievable n k})` — higher-order unification was failing.
- `div_lt_div_iff` → `div_lt_div_iff₀` (renamed).
- `not_le_of_lt` → `not_le_of_gt` (deprecation).

## Verification

Built on host `lake env lean` v4.26.0 (docker unavailable this session): **0 errors, 0 warnings, 0 sorries**.

`#print axioms`:
- `h_sublinear` → `propext, Classical.choice, Quot.sound, Erdos160.upper_bound_two_thirds`
- `h_superlog` → `propext, Classical.choice, Quot.sound, Erdos160.lower_bound_exp`
- `h_achievable`, `hunter_improves_leechlattice` → only `propext, Classical.choice, Quot.sound`

No `sorryAx`, no `Lean.ofReduceBool`. The two new theorems legitimately depend only on the file's stated literature-bound axioms.

## Status

**Remains `axiomatized`** (badge `axiom`, axiomCount 3) — correct for an open problem whose bounds are deep published results (LeechLattice, Hunter, Kelley–Meka). meta updated: `sorries` 2→0, `lineCount` 256→298, `assumptions` text corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)