### PR TITLE
research(dini-theorem-oq-01-oq-02-oq-01): explicit modulus of uniform convergence of xⁿ on compact [0,1−δ] [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1019,6 +1019,7 @@ import Proofs.DilworthTheoremOQ01OQ01OQ02
 import Proofs.DiniTheorem
 import Proofs.DiniTheoremOQ01OQ01
 import Proofs.DiniTheoremOQ01OQ02
+import Proofs.DiniTheoremOQ01OQ02OQ01
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
 import Proofs.DirichletApproximationOQ01OQ01

--- a/proofs/Proofs/DiniTheoremOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/DiniTheoremOQ01OQ02OQ01.lean
@@ -1,0 +1,194 @@
+import Mathlib
+
+/-
+# Dini's Theorem — OQ-01-OQ-02-OQ-01: The Explicit Modulus of Uniform Convergence of xⁿ on the Compact Subinterval [0, 1−δ]
+
+## Research Problem: dini-theorem-oq-01-oq-02-oq-01
+
+The grandparent file `DiniTheorem.lean` studies the sharpness of Dini's compactness
+hypothesis through the witness sequence `fₙ(x) = xⁿ`.  On the *non-compact* interval `[0,1)`
+this sequence is continuous, antitone in `n`, and converges pointwise to the continuous
+function `0`, yet **fails to converge uniformly** — and the parent
+`DiniTheoremOQ01OQ02.lean` sharpened this to its extreme: the uniform error
+`sup_{x∈[0,1)} xⁿ` stays *exactly* `1` for every `n`, the supremum being approached along
+`x = 1 − 1/(k+1) → 1` but **never attained**.
+
+This file answers the parent's open question OQ-01:
+
+> Rate of approach: quantify how fast `sup_{x∈[0,1−δ]} xⁿ → 0` as the domain is shrunk to a
+> compact subinterval `[0,1−δ]`, recovering uniform convergence with an explicit modulus in
+> `δ` and `n`.
+
+**Answer.**  On the compact subinterval `[0,1−δ]` (with `δ ∈ (0,1]`) everything changes:
+
+* the supremum is **attained** at the right endpoint, `sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ`
+  (contrast the parent's never-attained `1`);
+* `(1−δ)ⁿ → 0` geometrically, so convergence **is** uniform — Dini's conclusion is
+  recovered the moment compactness is restored;
+* the rate is explicit: `(1−δ)ⁿ < ε` as soon as `n ≥ log ε / log(1−δ)`, i.e. with modulus
+  `N(ε,δ) = ⌈log ε / log(1−δ)⌉`.
+
+## What is proved
+
+* `pow_le_endpoint` — `xⁿ ≤ (1−δ)ⁿ` for `x ∈ [0,1−δ]` (the endpoint dominates).
+* `isGreatest_pow_image_Icc` — `(1−δ)ⁿ` is the **greatest** value of `{ xⁿ : x ∈ [0,1−δ] }`,
+  i.e. the supremum is attained (at `x = 1−δ`).
+* `pow_sSup_Icc` / `pow_uniform_error_Icc` — hence `sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ` and the
+  uniform error `sup_{x∈[0,1−δ]} |xⁿ − 0| = (1−δ)ⁿ`.
+* `pow_tendsto_zero` — `(1−δ)ⁿ → 0` (geometric decay).
+* `pow_tendstoUniformlyOn_Icc` — the headline: `xⁿ ⇉ 0` **uniformly** on `[0,1−δ]`, the
+  recovery of Dini's conclusion once compactness is restored — directly contrasting the
+  parent's `pow_not_tendstoUniformlyOn_Ico_sharp`.
+* `pow_lt_of_log_modulus` — the explicit modulus (real threshold): `log ε / log(1−δ) ≤ n`
+  forces `(1−δ)ⁿ ≤ ε`.
+* `pow_lt_of_ceil_modulus` — packaged as a concrete natural-number modulus
+  `N(ε,δ) = ⌈log ε / log(1−δ)⌉`.
+
+Tags: analysis, dini, uniform-convergence, supremum, modulus, geometric-decay, wiedijk
+-/
+
+namespace DiniTheoremOQ01OQ02OQ01
+
+open Set Filter Topology
+
+-- ============================================================
+-- Part I: The supremum of xⁿ over [0, 1−δ] is attained, equal to (1−δ)ⁿ
+-- ============================================================
+
+/-- On the compact subinterval `[0,1−δ]` the right endpoint dominates: `xⁿ ≤ (1−δ)ⁿ`. -/
+theorem pow_le_endpoint {δ : ℝ} {x : ℝ} (hx : x ∈ Icc (0 : ℝ) (1 - δ)) (n : ℕ) :
+    x ^ n ≤ (1 - δ) ^ n :=
+  pow_le_pow_left₀ hx.1 hx.2 n
+
+/-- **The supremum is attained.**  For `δ ≤ 1`, `(1−δ)ⁿ` is the *greatest* element of
+    `{ xⁿ : x ∈ [0,1−δ] }`: it lies in the set (take `x = 1−δ`) and dominates every member.
+
+    This is the sharp contrast with the parent's `[0,1)` picture, where the supremum `1` is
+    a least upper bound that is *never* attained. -/
+theorem isGreatest_pow_image_Icc {δ : ℝ} (hδ1 : δ ≤ 1) (n : ℕ) :
+    IsGreatest ((fun x : ℝ => x ^ n) '' Icc (0 : ℝ) (1 - δ)) ((1 - δ) ^ n) := by
+  have h0 : (0 : ℝ) ≤ 1 - δ := by linarith
+  constructor
+  · -- `(1−δ)ⁿ` is in the image, attained at the right endpoint `x = 1−δ`.
+    exact ⟨1 - δ, ⟨h0, le_refl _⟩, rfl⟩
+  · -- it is an upper bound.
+    rintro y ⟨x, hx, rfl⟩
+    exact pow_le_endpoint hx n
+
+/-- **The supremum equals the endpoint value** `(1−δ)ⁿ` (attained, for `δ ≤ 1`). -/
+theorem pow_sSup_Icc {δ : ℝ} (hδ1 : δ ≤ 1) (n : ℕ) :
+    sSup ((fun x : ℝ => x ^ n) '' Icc (0 : ℝ) (1 - δ)) = (1 - δ) ^ n :=
+  (isGreatest_pow_image_Icc hδ1 n).csSup_eq
+
+/-- **The uniform error on `[0,1−δ]` equals `(1−δ)ⁿ`.**  Since `xⁿ ≥ 0`, the error
+    `|xⁿ − 0| = xⁿ`, so the error-image coincides with `{ xⁿ : x ∈ [0,1−δ] }`, whose
+    supremum is the attained endpoint value `(1−δ)ⁿ`. -/
+theorem pow_uniform_error_Icc {δ : ℝ} (hδ1 : δ ≤ 1) (n : ℕ) :
+    sSup ((fun x : ℝ => |x ^ n - 0|) '' Icc (0 : ℝ) (1 - δ)) = (1 - δ) ^ n := by
+  have himg : (fun x : ℝ => |x ^ n - 0|) '' Icc (0 : ℝ) (1 - δ)
+      = (fun x : ℝ => x ^ n) '' Icc (0 : ℝ) (1 - δ) := by
+    apply Set.image_congr
+    intro x hx
+    rw [sub_zero, abs_of_nonneg (pow_nonneg hx.1 n)]
+  rw [himg]
+  exact pow_sSup_Icc hδ1 n
+
+-- ============================================================
+-- Part II: Geometric decay and the recovery of uniform convergence
+-- ============================================================
+
+/-- **Geometric decay.**  For `δ ∈ (0,1]`, the endpoint value `(1−δ)ⁿ → 0` as `n → ∞`,
+    because the base satisfies `0 ≤ 1−δ < 1`. -/
+theorem pow_tendsto_zero {δ : ℝ} (hδ0 : 0 < δ) (hδ1 : δ ≤ 1) :
+    Tendsto (fun n : ℕ => (1 - δ) ^ n) atTop (𝓝 0) :=
+  tendsto_pow_atTop_nhds_zero_of_lt_one (by linarith) (by linarith)
+
+/-- **The recovery of Dini's conclusion.**  On the *compact* subinterval `[0,1−δ]`
+    (`δ ∈ (0,1]`), the sequence `xⁿ` converges to `0` **uniformly** — exactly the conclusion
+    that fails on the non-compact `[0,1)` (cf. the parent's
+    `pow_not_tendstoUniformlyOn_Ico_sharp`).
+
+    The proof is the rate estimate: `xⁿ ≤ (1−δ)ⁿ` uniformly in `x`, and `(1−δ)ⁿ → 0`, so the
+    uniform error is eventually below any `ε > 0`. -/
+theorem pow_tendstoUniformlyOn_Icc {δ : ℝ} (hδ0 : 0 < δ) (hδ1 : δ ≤ 1) :
+    TendstoUniformlyOn (fun n (x : ℝ) => x ^ n) (fun _ => (0 : ℝ)) atTop
+      (Icc (0 : ℝ) (1 - δ)) := by
+  rw [Metric.tendstoUniformlyOn_iff]
+  intro ε hε
+  -- eventually `(1−δ)ⁿ < ε`.
+  have hev : ∀ᶠ n : ℕ in atTop, (1 - δ) ^ n < ε :=
+    (pow_tendsto_zero hδ0 hδ1).eventually (Iio_mem_nhds hε)
+  filter_upwards [hev] with n hn x hx
+  -- `dist 0 (xⁿ) = xⁿ ≤ (1−δ)ⁿ < ε`.
+  have hx0 : (0 : ℝ) ≤ x ^ n := pow_nonneg hx.1 n
+  rw [Real.dist_eq, zero_sub, abs_neg, abs_of_nonneg hx0]
+  calc x ^ n ≤ (1 - δ) ^ n := pow_le_endpoint hx n
+    _ < ε := hn
+
+-- ============================================================
+-- Part III: The explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉
+-- ============================================================
+
+/-- **The explicit modulus (real threshold).**  For `δ ∈ (0,1)` and `ε > 0`, once
+    `n ≥ log ε / log(1−δ)` we have `(1−δ)ⁿ ≤ ε`.
+
+    Taking logarithms turns `(1−δ)ⁿ ≤ ε` into `n · log(1−δ) ≤ log ε`; since
+    `log(1−δ) < 0` (as `0 < 1−δ < 1`), dividing by it reverses the inequality and yields the
+    threshold `n ≥ log ε / log(1−δ)`. -/
+theorem pow_lt_of_log_modulus {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) {n : ℕ}
+    (hn : Real.log ε / Real.log (1 - δ) ≤ (n : ℝ)) :
+    (1 - δ) ^ n ≤ ε := by
+  set r : ℝ := 1 - δ with hr
+  have hr0 : 0 < r := by rw [hr]; linarith
+  have hr1 : r < 1 := by rw [hr]; linarith
+  have hlogr : Real.log r < 0 := Real.log_neg hr0 hr1
+  -- `n · log r ≤ log ε`.
+  have hmul : (n : ℝ) * Real.log r ≤ Real.log ε :=
+    (div_le_iff_of_neg hlogr).mp hn
+  -- exponentiate: `rⁿ = exp(log(rⁿ)) ≤ exp(log ε) = ε`.
+  have hpow_pos : (0 : ℝ) < r ^ n := pow_pos hr0 n
+  rw [← Real.exp_log hpow_pos, ← Real.exp_log hε]
+  apply Real.exp_le_exp.mpr
+  rw [Real.log_pow]
+  exact hmul
+
+/-- **The explicit modulus (natural-number form).**  Define `N(ε,δ) = ⌈log ε / log(1−δ)⌉`.
+    Then for every `n ≥ N(ε,δ)` we have `(1−δ)ⁿ ≤ ε`.  This packages
+    `pow_lt_of_log_modulus` with the standard `Nat.le_ceil` bound. -/
+theorem pow_lt_of_ceil_modulus {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) {n : ℕ}
+    (hn : ⌈Real.log ε / Real.log (1 - δ)⌉₊ ≤ n) :
+    (1 - δ) ^ n ≤ ε := by
+  apply pow_lt_of_log_modulus hδ0 hδ1 hε
+  calc Real.log ε / Real.log (1 - δ)
+      ≤ (⌈Real.log ε / Real.log (1 - δ)⌉₊ : ℝ) := Nat.le_ceil _
+    _ ≤ (n : ℝ) := by exact_mod_cast hn
+
+#check @isGreatest_pow_image_Icc
+#check @pow_sSup_Icc
+#check @pow_uniform_error_Icc
+#check @pow_tendstoUniformlyOn_Icc
+#check @pow_lt_of_log_modulus
+#check @pow_lt_of_ceil_modulus
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms — self-contained, imports only Mathlib):
+
+* `pow_le_endpoint` — `xⁿ ≤ (1−δ)ⁿ` on `[0,1−δ]`.
+* `isGreatest_pow_image_Icc` / `pow_sSup_Icc` — `sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ`, **attained**
+  at the right endpoint (contrast the parent's never-attained `1` on `[0,1)`).
+* `pow_uniform_error_Icc` — the uniform error `sup_{x∈[0,1−δ]} |xⁿ − 0| = (1−δ)ⁿ`.
+* `pow_tendsto_zero` — geometric decay `(1−δ)ⁿ → 0`.
+* `pow_tendstoUniformlyOn_Icc` — **uniform** convergence `xⁿ ⇉ 0` on `[0,1−δ]`: Dini's
+  conclusion is recovered once compactness is restored.
+* `pow_lt_of_log_modulus` / `pow_lt_of_ceil_modulus` — the explicit modulus
+  `N(ε,δ) = ⌈log ε / log(1−δ)⌉`.
+
+This answers `dini-theorem-oq-01-oq-02` OQ[0]: on the compact subinterval `[0,1−δ]` the
+uniform error decays geometrically as `(1−δ)ⁿ` (attained, not merely a supremum), recovering
+uniform convergence with the explicit modulus `⌈log ε / log(1−δ)⌉` — the precise quantitative
+counterpart to the parent's never-attained boundary supremum `1` on the full `[0,1)`.
+-/
+
+end DiniTheoremOQ01OQ02OQ01

--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "dini-oq010201-ann-overview",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Recovering Uniform Convergence on a Compact Subinterval",
+    "content": "The header frames OQ-01 of the parent (dini-theorem-oq-01-oq-02). The parent showed that on the non-compact [0,1) the witness xⁿ fails to converge uniformly to 0, with the sharp unattained supremum sup_{x∈[0,1)} |xⁿ| = 1. This file restores compactness by retreating to [0,1−δ] (δ ∈ (0,1]) and asks how fast uniform convergence is repaired. The answer is governed by a single quantity, (1−δ)ⁿ: the supremum becomes ATTAINED at the right endpoint, decays geometrically, and yields uniform convergence with an explicit modulus.",
+    "mathContext": "$\\sup_{x\\in[0,1-\\delta]} x^n = (1-\\delta)^n \\to 0$, with explicit modulus $N(\\varepsilon,\\delta)=\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Dini's theorem", "uniform convergence", "compactness", "geometric decay"],
+    "prerequisites": ["pointwise vs uniform convergence", "supremum / maximum"]
+  },
+  {
+    "id": "dini-oq010201-ann-attained",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 57, "endLine": 97 },
+    "type": "insight",
+    "title": "The Supremum is Attained at the Right Endpoint",
+    "content": "pow_le_endpoint records the one inequality everything rests on: for x ∈ [0,1−δ], xⁿ ≤ (1−δ)ⁿ (pow_le_pow_left₀, since 0 ≤ x ≤ 1−δ). Because the right endpoint 1−δ lies IN the interval (δ ≤ 1 ⟹ 0 ≤ 1−δ), the value (1−δ)ⁿ is both a member of { xⁿ : x ∈ [0,1−δ] } and an upper bound of it — i.e. its greatest element (isGreatest_pow_image_Icc). IsGreatest.csSup_eq then gives pow_sSup_Icc: sSup = (1−δ)ⁿ, an ATTAINED maximum. This is the structural contrast with the parent's [0,1), where the supremum 1 is a least upper bound approached but never attained — exactly the compactness that Dini's theorem requires. pow_uniform_error_Icc rewrites |xⁿ − 0| = xⁿ to read the uniform error off as (1−δ)ⁿ.",
+    "mathContext": "$\\operatorname{IsGreatest}\\{x^n:x\\in[0,1-\\delta]\\}\\,(1-\\delta)^n$; attained at $x=1-\\delta$.",
+    "significance": "critical",
+    "relatedConcepts": ["greatest element", "attained maximum", "monotone power functions"],
+    "prerequisites": ["supremum vs maximum", "upper bounds"]
+  },
+  {
+    "id": "dini-oq010201-ann-uniform",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 98, "endLine": 133 },
+    "type": "insight",
+    "title": "Geometric Decay and Uniform Convergence Recovered",
+    "content": "pow_tendsto_zero: since 0 ≤ 1−δ < 1 (from δ ∈ (0,1]), the endpoint value (1−δ)ⁿ → 0 (tendsto_pow_atTop_nhds_zero_of_lt_one). pow_tendstoUniformlyOn_Icc is the headline: feeding the uniform bound xⁿ ≤ (1−δ)ⁿ and the geometric decay into the ε-criterion (Metric.tendstoUniformlyOn_iff) gives xⁿ ⇉ 0 uniformly on [0,1−δ]. This is the exact positive counterpart of the parent's pow_not_tendstoUniformlyOn_Ico_sharp: the SAME witness sequence, opposite verdict, separated only by whether the boundary point 1 is included in the closure of the domain.",
+    "mathContext": "$x^n \\rightrightarrows 0$ on $[0,1-\\delta]$, because $\\sup_x x^n = (1-\\delta)^n \\to 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["uniform convergence criterion", "geometric sequences", "Dini's theorem"],
+    "prerequisites": ["ε-N definition of uniform convergence", "limits of geometric sequences"]
+  },
+  {
+    "id": "dini-oq010201-ann-modulus",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 134, "endLine": 194 },
+    "type": "insight",
+    "title": "The Explicit Modulus via Logarithms",
+    "content": "pow_lt_of_log_modulus makes the rate explicit. Set r = 1−δ ∈ (0,1) (needs δ < 1), so log r < 0 (Real.log_neg). Taking logs, (1−δ)ⁿ ≤ ε ⟺ n·log r ≤ log ε (Real.log_pow plus monotonicity of exp/log); since log r < 0, dividing reverses the inequality (div_le_iff_of_neg), giving the threshold n ≥ log ε / log(1−δ). pow_lt_of_ceil_modulus packages this as the natural-number modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉ via Nat.le_ceil. As δ → 0 the threshold blows up (log(1−δ) → 0⁻), interpolating to the parent's non-uniformity on [0,1).",
+    "mathContext": "$n \\ge \\dfrac{\\log\\varepsilon}{\\log(1-\\delta)} \\implies (1-\\delta)^n \\le \\varepsilon$; modulus $\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil$.",
+    "significance": "critical",
+    "relatedConcepts": ["modulus of convergence", "logarithms", "geometric decay rate"],
+    "prerequisites": ["properties of log", "ceiling function", "sign-flip when dividing by a negative"]
+  }
+]

--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "dini-theorem-oq-01-oq-02-oq-01",
+  "title": "The Explicit Modulus of Uniform Convergence of xⁿ on the Compact Subinterval [0, 1−δ]",
+  "slug": "dini-theorem-oq-01-oq-02-oq-01",
+  "description": "Answers the parent's open question: on the compact subinterval [0,1−δ] (δ ∈ (0,1]) the supremum of xⁿ is ATTAINED at the right endpoint, sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ — contrasting the parent's never-attained supremum 1 on [0,1). Since (1−δ)ⁿ → 0 geometrically, convergence is uniform (Dini's conclusion recovered once compactness is restored), with the explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DiniTheoremOQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "dini",
+      "uniform-convergence",
+      "supremum",
+      "modulus",
+      "geometric-decay",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 194,
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/DiniTheoremOQ01OQ02OQ01.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for isGreatest_pow_image_Icc, pow_sSup_Icc, pow_uniform_error_Icc, pow_tendstoUniformlyOn_Icc, and pow_lt_of_ceil_modulus. The file imports only Mathlib and is self-contained.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "pow_le_pow_left₀",
+        "description": "0 ≤ a, a ≤ b ⟹ aⁿ ≤ bⁿ — the endpoint x = 1−δ dominates every x ∈ [0,1−δ]",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "IsGreatest.csSup_eq",
+        "description": "the greatest element of a set equals its sSup — turns the attained maximum (1−δ)ⁿ into the supremum",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "tendsto_pow_atTop_nhds_zero_of_lt_one",
+        "description": "0 ≤ r < 1 ⟹ rⁿ → 0 — geometric decay of the endpoint value (1−δ)ⁿ",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Metric.tendstoUniformlyOn_iff",
+        "description": "ε-characterization of uniform convergence on a set — used positively to recover uniform convergence on [0,1−δ]",
+        "module": "Mathlib.Topology.UniformSpace.UniformConvergence"
+      },
+      {
+        "theorem": "Real.log_pow",
+        "description": "log(rⁿ) = n · log r — converts the geometric bound into the linear log-threshold of the explicit modulus",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "div_le_iff_of_neg",
+        "description": "dividing by the negative quantity log(1−δ) reverses the inequality, producing the threshold n ≥ log ε / log(1−δ)",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "isGreatest_pow_image_Icc: (1−δ)ⁿ is the GREATEST element of { xⁿ : x ∈ [0,1−δ] } (for δ ≤ 1) — the supremum is attained at the right endpoint, the sharp contrast with the parent's never-attained 1 on [0,1)",
+      "pow_sSup_Icc / pow_uniform_error_Icc: sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ and the uniform error sup_{x∈[0,1−δ]} |xⁿ − 0| = (1−δ)ⁿ",
+      "pow_tendstoUniformlyOn_Icc: xⁿ ⇉ 0 UNIFORMLY on [0,1−δ] — Dini's conclusion recovered the moment compactness is restored, the positive counterpart to the parent's pow_not_tendstoUniformlyOn_Ico_sharp",
+      "pow_lt_of_log_modulus: the explicit modulus (real threshold) — log ε / log(1−δ) ≤ n forces (1−δ)ⁿ ≤ ε",
+      "pow_lt_of_ceil_modulus: the packaged natural-number modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉"
+    ],
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Dini's theorem says a monotone sequence of continuous functions converging pointwise to a continuous limit on a COMPACT set converges uniformly. The grandparent entry (dini-theorem-oq-01) probes the necessity of compactness with the textbook witness fₙ(x) = xⁿ; the parent (dini-theorem-oq-01-oq-02) showed that on the non-compact [0,1) the uniform error sup_{x∈[0,1)} |xⁿ| equals exactly 1 for every n, an unattained supremum approached along x = 1 − 1/(k+1) → 1. This entry (OQ-01) restores compactness by passing to [0,1−δ] and quantifies exactly how the failure is repaired.",
+    "problemStatement": "Quantify how fast sup_{x∈[0,1−δ]} xⁿ → 0 as the domain is shrunk to a compact subinterval [0,1−δ], recovering uniform convergence with an explicit modulus in δ and n.",
+    "text": "Proves that on [0,1−δ] the supremum of xⁿ is the attained endpoint value (1−δ)ⁿ, that (1−δ)ⁿ → 0 geometrically, that xⁿ → 0 uniformly on [0,1−δ], and that (1−δ)ⁿ ≤ ε once n ≥ ⌈log ε / log(1−δ)⌉.",
+    "proofStrategy": "The whole picture flows from one monotonicity fact, pow_le_endpoint: for x ∈ [0,1−δ], xⁿ ≤ (1−δ)ⁿ (pow_le_pow_left₀). Hence (1−δ)ⁿ, which lies in the image (take x = 1−δ, valid since δ ≤ 1 ⟹ 0 ≤ 1−δ), is the greatest element (isGreatest_pow_image_Icc), so it equals the supremum (IsGreatest.csSup_eq) — attained, unlike the parent's least-upper-bound 1. Geometric decay (1−δ)ⁿ → 0 follows from 0 ≤ 1−δ < 1 (tendsto_pow_atTop_nhds_zero_of_lt_one). Uniform convergence is then the ε-criterion (Metric.tendstoUniformlyOn_iff): xⁿ ≤ (1−δ)ⁿ uniformly in x and (1−δ)ⁿ eventually < ε. The explicit modulus comes from taking logs: (1−δ)ⁿ ≤ ε ⟺ n·log(1−δ) ≤ log ε, and since log(1−δ) < 0 (Real.log_neg) dividing reverses the inequality (div_le_iff_of_neg) to give the threshold n ≥ log ε / log(1−δ), packaged via Nat.le_ceil as ⌈log ε / log(1−δ)⌉.",
+    "keyInsights": [
+      "Restoring compactness turns the parent's unattained supremum into an attained maximum: on [0,1−δ] the right endpoint x = 1−δ is included, so sup xⁿ = (1−δ)ⁿ is realized — the structural reason Dini's hypothesis works.",
+      "The single inequality xⁿ ≤ (1−δ)ⁿ (the endpoint dominates) drives everything: the maximum, the supremum, the uniform error, and the uniform-convergence estimate are all immediate corollaries.",
+      "Uniform convergence on [0,1−δ] is the exact positive counterpart to the parent's pow_not_tendstoUniformlyOn_Ico_sharp on [0,1): the same witness sequence, opposite verdict, separated only by whether the boundary point 1 is approached.",
+      "The modulus is genuinely explicit and δ-dependent: as δ → 0 the threshold ⌈log ε / log(1−δ)⌉ blows up (log(1−δ) → 0⁻), recovering the parent's non-uniformity in the limit — the modulus encodes the full transition from uniform to non-uniform.",
+      "Taking logarithms is the natural linearization: geometric decay (1−δ)ⁿ becomes the linear condition n·log(1−δ) ≤ log ε, and the sign of log(1−δ) is exactly what flips the inequality into a lower bound on n."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-setup",
+      "title": "Problem Statement and Setup",
+      "summary": "Module docstring framing OQ-01 (uniform convergence recovered on the compact [0,1−δ] vs the parent's non-uniformity on [0,1)), the witness xⁿ, and the namespace/imports (Mathlib; open Set Filter Topology)",
+      "startLine": 1,
+      "endLine": 56
+    },
+    {
+      "id": "supremum-attained",
+      "title": "The Supremum over [0,1−δ] is Attained, Equal to (1−δ)ⁿ",
+      "summary": "pow_le_endpoint (the endpoint dominates), isGreatest_pow_image_Icc (the maximum is attained at x = 1−δ), pow_sSup_Icc (sSup = (1−δ)ⁿ), and pow_uniform_error_Icc (uniform error = (1−δ)ⁿ)",
+      "startLine": 57,
+      "endLine": 97
+    },
+    {
+      "id": "uniform-convergence",
+      "title": "Geometric Decay and the Recovery of Uniform Convergence",
+      "summary": "pow_tendsto_zero (geometric decay (1−δ)ⁿ → 0) and pow_tendstoUniformlyOn_Icc (xⁿ ⇉ 0 uniformly on [0,1−δ], the headline recovery of Dini's conclusion)",
+      "startLine": 98,
+      "endLine": 133
+    },
+    {
+      "id": "explicit-modulus",
+      "title": "The Explicit Modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉",
+      "summary": "pow_lt_of_log_modulus (real-threshold modulus via logarithms and div_le_iff_of_neg) and pow_lt_of_ceil_modulus (packaged natural-number modulus via Nat.le_ceil)",
+      "startLine": 134,
+      "endLine": 194
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; self-contained, imports only Mathlib): on the compact subinterval [0,1−δ] (δ ∈ (0,1]) the supremum sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ is ATTAINED at the right endpoint, decays geometrically to 0, so xⁿ → 0 uniformly on [0,1−δ] — recovering Dini's conclusion — with the explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉.",
+    "implications": "This pins the exact rate at which uniform convergence is repaired as the domain retreats from the boundary point 1, and shows the transition is governed by the single quantity (1−δ)ⁿ. The endpoint-dominates → IsGreatest.csSup_eq → tendsto_pow → ε-criterion → log-threshold pipeline is a reusable recipe for explicit moduli of geometric decay. Together with the parent (never-attained supremum 1 on [0,1)) it gives a complete attained/unattained dichotomy for the witness xⁿ.",
+    "openQuestions": [
+      "Optimality of the modulus: is ⌈log ε / log(1−δ)⌉ the smallest N with (1−δ)ᴺ ≤ ε for every ε, δ, or only the smallest under the log-threshold derivation, and can the off-by-one from Nat.le_ceil be pinned down exactly?",
+      "Uniform-in-δ rate: characterize the joint modulus N(ε,δ) as a function of both arguments and identify the δ → 0 blow-up rate that interpolates to the parent's non-uniformity on [0,1).",
+      "General antitone families: for a continuous antitone-in-n family converging pointwise to 0 on [0,1), is the uniform error on [0,1−δ] always the boundary-restricted value f_n(1−δ), with an analogous explicit modulus?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dini-theorem-oq-01-oq-02",
+      "relationship": "parent-problem",
+      "description": "Parent: the sharp modulus of NON-uniform convergence of xⁿ on the non-compact [0,1) (unattained supremum 1); this entry answers its OQ[0] by quantifying the compact-subinterval case"
+    },
+    {
+      "targetId": "dini-theorem-oq-01",
+      "relationship": "related",
+      "description": "Grandparent: Dini's theorem and the sharpness of its compactness hypothesis via the witness xⁿ"
+    },
+    {
+      "targetId": "dini-theorem",
+      "relationship": "related",
+      "description": "The base Dini's theorem (uniform convergence of monotone sequences on compact sets) whose conclusion this entry recovers on the compact [0,1−δ]"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Ulisse Dini"
+      ],
+      "title": "Fondamenti per la teorica delle funzioni di variabili reali",
+      "year": "1878",
+      "venue": "Pisa",
+      "note": "Origin of Dini's theorem"
+    },
+    {
+      "authors": [
+        "Walter Rudin"
+      ],
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "note": "Theorem 7.13 (Dini) and the xⁿ counterexample; uniform convergence on compact subintervals"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DiniTheoremOQ01OQ02OQ01",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/DiniTheoremOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ[0]** of the parent `dini-theorem-oq-01-oq-02` ("quantify how fast `sup_{x∈[0,1−δ]} xⁿ → 0` as the domain is shrunk to a compact subinterval, recovering uniform convergence with an explicit modulus").

The parent established the sharp *non*-uniformity on the non-compact `[0,1)`: the uniform error `sup_{x∈[0,1)} |xⁿ|` is exactly `1`, an **unattained** supremum approached along `x = 1 − 1/(k+1) → 1`. This child restores compactness by retreating to `[0,1−δ]` (`δ ∈ (0,1]`) and shows everything is governed by the single quantity `(1−δ)ⁿ`:

- **Supremum attained.** `isGreatest_pow_image_Icc` / `pow_sSup_Icc`: `sup_{x∈[0,1−δ]} xⁿ = (1−δ)ⁿ`, attained at the right endpoint `x = 1−δ` — the structural contrast with the parent's never-attained `1`.
- **Uniform convergence recovered.** `pow_tendstoUniformlyOn_Icc`: `xⁿ ⇉ 0` uniformly on `[0,1−δ]` — the positive counterpart to the parent's `pow_not_tendstoUniformlyOn_Ico_sharp`.
- **Explicit modulus.** `pow_lt_of_log_modulus` / `pow_lt_of_ceil_modulus`: `(1−δ)ⁿ ≤ ε` once `n ≥ log ε / log(1−δ)`, packaged as `N(ε,δ) = ⌈log ε / log(1−δ)⌉`.

The whole picture flows from one inequality, `pow_le_endpoint` (`xⁿ ≤ (1−δ)ⁿ` on `[0,1−δ]`), via `IsGreatest.csSup_eq → tendsto_pow → ε-criterion → log-threshold`.

## Verification

- `lake env lean Proofs/DiniTheoremOQ01OQ02OQ01.lean` exits **0** against pinned Mathlib v4.26.0.
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- **0 sorries, 0 axioms**, self-contained (imports only Mathlib). 8 theorems, 0 definitions, 194 lines.

## Files

- `proofs/Proofs/DiniTheoremOQ01OQ02OQ01.lean` (new)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/dini-theorem-oq-01-oq-02-oq-01/{meta.json,annotations.json}` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)