### PR TITLE
Enrich: ψ and θ Share the Same Main Term (chebyshev-bounds-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "The First Chebyshev Function and Its von Mangoldt Form",
-    "content": "θ(x) = ∑_{p ≤ x} log p sums log p over primes only. The key to comparing it with ψ(n) = ∑_{m ≤ n} Λ(m) is that the von Mangoldt function satisfies Λ(p) = log p on a prime p (vonMangoldt_apply_prime). Hence θ(n) is exactly the 'prime part' of ψ: θ(n) = ∑_{m ≤ n} (if m prime then Λ(m) else 0). This identity (chebyshevTheta_eq_sum_vonMangoldt) is what lets the difference ψ − θ be computed termwise in a single uniform sum."
+    "content": "θ(x) = ∑_{p ≤ x} log p sums log p over primes only. The key to comparing it with ψ(n) = ∑_{m ≤ n} Λ(m) is that the von Mangoldt function satisfies Λ(p) = log p on a prime p (vonMangoldt_apply_prime). Hence θ(n) is exactly the 'prime part' of ψ: θ(n) = ∑_{m ≤ n} (if m prime then Λ(m) else 0). This identity (chebyshevTheta_eq_sum_vonMangoldt) is what lets the difference ψ − θ be computed termwise in a single uniform sum.",
+    "mathContext": "$\\theta(x) = \\sum_{p \\le x} \\log p = \\sum_{m \\le n} [m \\text{ prime}]\\,\\Lambda(m), \\qquad \\Lambda(p) = \\log p$",
+    "significance": "supporting",
+    "relatedConcepts": ["von Mangoldt function", "first Chebyshev function θ", "prime-counting", "indicator of primality"],
+    "prerequisites": ["von Mangoldt function Λ", "Finset summation over [1,n]", "Λ(p) = log p on primes"]
   },
   {
     "id": "ann-decomposition",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "ψ − θ Lives on the Higher Prime Powers",
-    "content": "Subtracting the two von Mangoldt forms gives ψ(n) − θ(n) = ∑_{m ≤ n} (Λ(m) − [m prime]·Λ(m)) = ∑_{m ≤ n} [¬ m prime]·Λ(m). Because Λ vanishes off the prime powers, the surviving terms are exactly the m that are prime powers but not primes, i.e. m = p^k with k ≥ 2. This is the precise 'same main term' statement: θ already captures all of ψ except the contribution of squares, cubes, … of primes. Nonnegativity of every term gives θ(n) ≤ ψ(n) for free."
+    "content": "Subtracting the two von Mangoldt forms gives ψ(n) − θ(n) = ∑_{m ≤ n} (Λ(m) − [m prime]·Λ(m)) = ∑_{m ≤ n} [¬ m prime]·Λ(m). Because Λ vanishes off the prime powers, the surviving terms are exactly the m that are prime powers but not primes, i.e. m = p^k with k ≥ 2. This is the precise 'same main term' statement: θ already captures all of ψ except the contribution of squares, cubes, … of primes. Nonnegativity of every term gives θ(n) ≤ ψ(n) for free.",
+    "mathContext": "$\\psi(n) - \\theta(n) = \\sum_{\\substack{m \\le n \\\\ m \\text{ not prime}}} \\Lambda(m) = \\sum_{\\substack{p^k \\le n \\\\ k \\ge 2}} \\log p \\;\\ge\\; 0$",
+    "significance": "key",
+    "relatedConcepts": ["second Chebyshev function ψ", "proper prime powers", "termwise sum splitting", "nonnegativity of Λ"],
+    "prerequisites": ["von Mangoldt form of ψ and θ", "support of Λ on prime powers", "case analysis on m.Prime"]
   },
   {
     "id": "ann-proper-prime-powers",
@@ -30,7 +38,11 @@
     },
     "type": "insight",
     "title": "Making the k ≥ 2 Support Explicit",
-    "content": "psi_sub_theta_eq_proper_prime_powers rewrites the difference as a sum of Λ over the filtered set {m ∈ [1,n] : IsPrimePow m ∧ ¬ m.Prime}. The step that discards the non-prime-power m uses vonMangoldt_eq_zero_iff (Λ(m) = 0 ↔ ¬ IsPrimePow m). The resulting index set is literally the proper prime powers ≤ n — the objects responsible for the entire gap between the first and second Chebyshev functions."
+    "content": "psi_sub_theta_eq_proper_prime_powers rewrites the difference as a sum of Λ over the filtered set {m ∈ [1,n] : IsPrimePow m ∧ ¬ m.Prime}. The step that discards the non-prime-power m uses vonMangoldt_eq_zero_iff (Λ(m) = 0 ↔ ¬ IsPrimePow m). The resulting index set is literally the proper prime powers ≤ n — the objects responsible for the entire gap between the first and second Chebyshev functions.",
+    "mathContext": "$\\psi(n) - \\theta(n) = \\sum_{\\substack{m \\le n \\\\ \\mathrm{IsPrimePow}\\,m \\,\\wedge\\, \\neg\\,m\\text{ prime}}} \\Lambda(m), \\qquad \\Lambda(m) = 0 \\iff \\neg\\,\\mathrm{IsPrimePow}\\,m$",
+    "significance": "supporting",
+    "relatedConcepts": ["IsPrimePow predicate", "Finset.filter", "support of an arithmetic function", "prime powers p^k, k ≥ 2"],
+    "prerequisites": ["vonMangoldt_eq_zero_iff", "Finset filtering", "definition of IsPrimePow"]
   },
   {
     "id": "ann-bridge",
@@ -39,9 +51,13 @@
       "startLine": 115,
       "endLine": 124
     },
-    "type": "insight",
+    "type": "technique",
     "title": "Bridging the Gallery's ψ to Mathlib's Chebyshev API",
-    "content": "The parent built a self-contained ℕ-indexed ψ as ∑ over [1,n]; Mathlib's Chebyshev.psi is an ℝ-argument sum over (0, ⌊x⌋]. At an integer argument these coincide: Nat.floor_natCast turns ⌊(n:ℝ)⌋₊ into n, and Icc 1 n = Ioc 0 n identifies the index sets, so a one-line Finset.sum_congr proves chebyshevPsi n = Chebyshev.psi n (and likewise for θ). This small bridge is what unlocks Mathlib's entire Chebyshev development for the gallery's elementary functions."
+    "content": "The parent built a self-contained ℕ-indexed ψ as ∑ over [1,n]; Mathlib's Chebyshev.psi is an ℝ-argument sum over (0, ⌊x⌋]. At an integer argument these coincide: Nat.floor_natCast turns ⌊(n:ℝ)⌋₊ into n, and Icc 1 n = Ioc 0 n identifies the index sets, so a one-line Finset.sum_congr proves chebyshevPsi n = Chebyshev.psi n (and likewise for θ). This small bridge is what unlocks Mathlib's entire Chebyshev development for the gallery's elementary functions.",
+    "mathContext": "$\\text{chebyshevPsi}\\,n = \\mathrm{Chebyshev.psi}\\,n, \\qquad \\lfloor (n:\\mathbb{R}) \\rfloor_+ = n, \\qquad \\mathrm{Icc}\\,1\\,n = \\mathrm{Ioc}\\,0\\,n$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_congr", "Nat.floor_natCast", "Icc / Ioc index alignment", "interoperability with Mathlib"],
+    "prerequisites": ["Mathlib's Chebyshev.psi/theta definitions", "Finset interval lemmas", "natural-number floor of a cast"]
   },
   {
     "id": "ann-transported-bound",
@@ -52,6 +68,10 @@
     },
     "type": "concept",
     "title": "Transporting the Identity and the Sharp Bound",
-    "content": "With the bridge, two of Mathlib's results become statements about the gallery's ψ. psi_sub_theta_eq_sum_theta rewrites by Chebyshev.psi_eq_theta_add_sum_theta (ψ = θ + ∑_{k=2}^{⌊log₂ x⌋} θ(x^{1/k})) and cancels θ to give the exact tail identity ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}). abs_psi_sub_theta_le rewrites by Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log to give |ψ(n) − θ(n)| ≤ 2·√n·log n — an O(√n·log n) bound, in fact sharper than the O(√n log²n) originally targeted. The deep analytic work is Mathlib's; the entry supplies the bridge that makes it apply to the gallery's ψ."
+    "content": "With the bridge, two of Mathlib's results become statements about the gallery's ψ. psi_sub_theta_eq_sum_theta rewrites by Chebyshev.psi_eq_theta_add_sum_theta (ψ = θ + ∑_{k=2}^{⌊log₂ x⌋} θ(x^{1/k})) and cancels θ to give the exact tail identity ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}). abs_psi_sub_theta_le rewrites by Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log to give |ψ(n) − θ(n)| ≤ 2·√n·log n — an O(√n·log n) bound, in fact sharper than the O(√n log²n) originally targeted. The deep analytic work is Mathlib's; the entry supplies the bridge that makes it apply to the gallery's ψ.",
+    "mathContext": "$\\psi(n) - \\theta(n) = \\sum_{k=2}^{\\lfloor \\log_2 n \\rfloor} \\theta(n^{1/k}), \\qquad |\\psi(n) - \\theta(n)| \\le 2\\sqrt{n}\\,\\log n = O(\\sqrt{n}\\,\\log n)$",
+    "significance": "key",
+    "relatedConcepts": ["ψ = ∑_{k≥1} θ(x^{1/k}) identity", "Prime Number Theorem", "main-term interchangeability", "O(√x log x) tail bound"],
+    "prerequisites": ["Chebyshev.psi_eq_theta_add_sum_theta", "Chebyshev.abs_psi_sub_theta_le_sqrt_mul_log", "the gallery↔Mathlib bridge lemmas"]
   }
 ]

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/index.ts
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevBoundsOQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevBoundsOq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevBoundsOq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevBoundsOq02Oq02Data: ProofData = {
+  proof: chebyshevBoundsOq02Oq02Proof,
+  annotations: chebyshevBoundsOq02Oq02Annotations,
+}

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-02/meta.json
@@ -96,5 +96,26 @@
       "summary": "chebyshevPsi_eq_mathlib / chebyshevTheta_eq_mathlib identify the gallery functions with Mathlib's Chebyshev.psi/theta; psi_sub_theta_eq_sum_theta and abs_psi_sub_theta_le transport Mathlib's ψ = ∑θ(x^{1/k}) identity and |ψ − θ| ≤ 2√x·log x bound.",
       "mathContext": "ψ(n) − θ(n) = ∑_{k≥2} θ(n^{1/k}) and |ψ(n) − θ(n)| ≤ 2√n·log n = O(√n log n)."
     }
+  ],
+  "conclusion": {
+    "summary": "A 146-line, fully machine-checked file (0 sorries, 0 axioms, no native_decide) establishing that the first and second Chebyshev functions θ and ψ share the same main term. It proves directly, over the parent's self-contained ℕ-indexed ψ, the structural decomposition ψ(n) − θ(n) = ∑_{m ≤ n, ¬ m prime} Λ(m) (with nonnegativity and θ ≤ ψ, and an explicit restatement over the proper prime powers), then bridges chebyshevPsi/chebyshevTheta to Mathlib's Chebyshev.psi/theta to transport the exact identity ψ(n) − θ(n) = ∑_{k=2}^{⌊log₂ n⌋} θ(n^{1/k}) and the sharp bound |ψ(n) − θ(n)| ≤ 2·√n·log n = O(√n·log n).",
+    "implications": "The result answers the parent chebyshev-bounds-oq-02's open question on the ψ−θ comparison and is the technical justification for treating θ and ψ interchangeably in elementary approaches to the Prime Number Theorem: since their difference is only O(√n·log n) while each is asymptotic to n, an asymptotic ψ(n) ∼ n immediately yields θ(n) ∼ n, and bounds on ψ transfer to bounds on the prime-counting function π. The gallery↔Mathlib bridge is reusable infrastructure — it imports Mathlib's full Chebyshev development into the parent's elementary thread through a single Finset.sum_congr identification.",
+    "openQuestions": [
+      "Quantify the tail term-by-term in the gallery's own ℕ-indexed setting: bound each θ(n^{1/k}) ≤ θ(√n) directly to re-derive O(√n·log n) without invoking Mathlib's abs_psi_sub_theta_le_sqrt_mul_log.",
+      "Use the same-main-term equivalence to transport the parent chain's bounds on ψ to explicit Chebyshev-type bounds c·n ≤ θ(n) ≤ C·n on the first Chebyshev function, and onward to π(n)·log n ∼ θ(n).",
+      "Combine with the abscissa of convergence of ∑ Λ(n)/nˢ to connect the ψ−θ gap to the zero-free region of the Riemann zeta function."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds-oq-02",
+      "relationship": "extends",
+      "description": "Parent: introduces the second Chebyshev function ψ in von Mangoldt form as a self-contained ℕ-indexed development. This entry answers its open question comparing ψ with the first Chebyshev function θ and quantifying their difference."
+    },
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "related",
+      "description": "Root of the Chebyshev-bounds chain: the elementary upper and lower bounds on the prime-counting function that the ψ/θ machinery refines toward the Prime Number Theorem."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-02-oq-02` (quality 49, pass 0).

## Changes
- **Added missing `index.ts`** — the directory had no Vite entry point, so the page would render "proof not found" on the live site.
- **Added `conclusion`** — summary, mathematical implications (θ↔ψ interchangeability for the PNT, the reusable gallery↔Mathlib bridge), and 3 genuine open questions.
- **Added `crossReferences`** — to the parent `chebyshev-bounds-oq-02` (extends) and the root `chebyshev-bounds` (related).
- **Enriched all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- meta.json and annotations.json validate as JSON.
- crossReference targets exist as gallery entries.
- No claims changed: status `verified`, badge `verified` (deep bound is Mathlib's, correctly not `original`), axiomCount 0 — accurate vs the Lean source.