### PR TITLE
Gallery audit: gcd-algorithm-oq-05 clean (Gauss–Kuzmin distribution)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23619,8 +23619,14 @@
       "issues": [],
       "lastAudited": "2026-06-25T08:54:07Z",
       "result": "clean"
+    },
+    "gcd-algorithm-oq-05": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:40:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T08:54:07Z"
+  "lastUpdated": "2026-06-25T09:40:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited **gcd-algorithm-oq-05** — *The Gauss–Kuzmin Distribution is a Probability Distribution*. Result: **CLEAN**. Recorded in `audit-tracker.json`.

### meta.json claims vs Lean source

| Field | meta.json | `Proofs/GCDAlgorithmOQ05.lean` |
|-------|-----------|-------------------------------|
| status | `verified` | — |
| badge | `original` | — |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 axiom decls ✓ |
| native_decide | (none claimed) | 0 ✓ |
| theoremCount | 9 | 9 named theorems ✓ |

- Named theorems cited in `assumptions` (`gaussKuzmin_tsum`, `gaussKuzmin_pos`) exist; `#print axioms` claim of only propext/Classical.choice/Quot.sound is consistent with 0 native_decide.
- 2 real `def`s (`gaussKuzmin`, `G`) — no definition sorries.
- No `True` stubs.
- **Scope honesty:** the assumptions note correctly limits the claim to the *normalized probability distribution* (weights sum to 1, positive) and explicitly excludes the full Gauss–Kuzmin–Lévy ergodic theorem (Gauss-map ergodicity / measure invariance, not in Mathlib). Title and badge are appropriately scoped — Tier A original.

No overclaim detected.

---
Discovered during gallery integrity audit. Tracker-only change (one entry appended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)