### PR TITLE
research(buffons-noodle-oq-01-oq-02): general Buffon–Laplace for k line families E=(2L/π)·Σ 1/dⱼ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -552,6 +552,7 @@ import Proofs.BuffonsNeedleOQ02OQ02OQ01OQ01OQ01
 import Proofs.BuffonsNeedleOQ02OQ03
 import Proofs.BuffonsNoodle
 import Proofs.BuffonsNoodleOQ01
+import Proofs.BuffonsNoodleOQ01OQ02
 import Proofs.BuffonsNoodleOQ02
 import Proofs.BuffonsNoodleOQ03
 import Proofs.BurnsideCounting

--- a/proofs/Proofs/BuffonsNoodleOQ01OQ02.lean
+++ b/proofs/Proofs/BuffonsNoodleOQ01OQ02.lean
@@ -1,0 +1,179 @@
+/-
+  # Buffon–Laplace for `k` Non-Parallel Line Families (Cauchy–Crofton Discretization)
+
+  The parent leaf (`BuffonsNoodleOQ01`) proves the **two-family** Buffon–Laplace grid
+  theorem: a polygonal noodle `N` of total length `L` dropped on a grid of two
+  perpendicular line families with spacings `dh, dv` crosses, in expectation,
+
+  `E[crossings] = 2L/(π·dh) + 2L/(π·dv)`,
+
+  obtained by additivity of expectation from the single-family polygonal Buffon
+  theorem `buffon_noodle_polygon : N.expectedCrossings d = 2L/(π·d)`.
+
+  This file answers `buffons-noodle-oq-01-oq-02`:
+
+  > Extend the Buffon grid identity to `k` non-parallel families at angles
+  > `θ₁, …, θ_k`, with expected crossings `(2L/π)·Σ_j 1/d_j`
+  > (general Buffon–Laplace / Cauchy–Crofton discretization).
+
+  ## What is proved
+
+  * **`expectedMultiCrossings`** — the expected total number of crossings of `N`
+    against `k` line families with spacings `d : Fin k → ℝ`, defined (by additivity
+    of expectation) as `∑ j, N.expectedCrossings (d j)`.
+
+  * **`buffon_noodle_multi_family`** (headline) — for positive spacings,
+    `E[crossings] = (2L/π)·Σ_j (d_j)⁻¹`. Each family contributes `2L/(π·d_j)` by the
+    parent's single-family theorem, and the total is their sum by linearity.
+
+  * **Specializations and structure.** Recovery of the two-family grid as the
+    `k = 2` case (`expectedGridCrossings_eq_multi`), the equal-spacing count
+    `2kL/(π·d)` (`buffon_noodle_multi_family_const`), additivity (`…_eq_sum`),
+    nonnegativity, and monotonicity in the number of families.
+
+  ## Why the angles `θ_j` do not appear
+
+  The candidate speaks of families "at angles `θ₁, …, θ_k`", yet the formula has no
+  angle dependence. This is the crux of Buffon–Laplace, not an omission. The noodle is
+  dropped at a uniformly random *position and orientation*, so the expected number of
+  crossings with a *single* family depends only on the noodle's length and the family
+  spacing — never on the family's orientation (this is exactly the content of the
+  parent's `buffon_noodle_polygon`, whose statement carries no angle). By linearity of
+  expectation, `E[Σ_j crossings_j] = Σ_j E[crossings_j] = Σ_j 2L/(π·d_j)`, regardless
+  of how the `k` families are angled relative to one another. The orientation-free
+  formula `(2L/π)·Σ_j 1/d_j` is therefore the honest and complete answer; modelling the
+  families by their spacings `d : Fin k → ℝ` loses no information.
+
+  Tags: buffon-laplace, cauchy-crofton, geometric-probability, expectation-linearity,
+        integral-geometry
+-/
+import Proofs.BuffonsNoodleOQ01
+import Mathlib.Tactic
+
+open Real Finset BigOperators BuffonsNoodle BuffonsNoodleOQ01
+
+/- ============================================================
+   § 1 : Expected crossings against `k` line families
+   ============================================================ -/
+
+namespace BuffonsNoodle
+
+/-- The expected total number of crossings of a polygonal noodle `N` with `k` families
+    of parallel lines, the `j`-th family having spacing `d j`. By additivity of
+    expectation it is the sum of the single-family expected crossings against each
+    family. The families' *orientations* do not enter: each single-family term is the
+    orientation-free quantity `N.expectedCrossings (d j)` (see the module docstring).
+
+    Declared in the `BuffonsNoodle` namespace (alongside the parent's
+    `expectedGridCrossings`) so that dot-notation `N.expectedMultiCrossings` resolves. -/
+noncomputable def PolygonalNoodle.expectedMultiCrossings {n k : ℕ}
+    (N : PolygonalNoodle n) (d : Fin k → ℝ) : ℝ :=
+  ∑ j, N.expectedCrossings (d j)
+
+end BuffonsNoodle
+
+namespace BuffonsNoodleOQ01OQ02
+
+/-- Additivity of expectation across families, made definitionally explicit
+    (the `k`-family analogue of the parent's `buffon_noodle_grid_eq_sum`). -/
+theorem expectedMultiCrossings_eq_sum {n k : ℕ} (N : PolygonalNoodle n) (d : Fin k → ℝ) :
+    N.expectedMultiCrossings d = ∑ j, N.expectedCrossings (d j) := rfl
+
+/- ============================================================
+   § 2 : The general Buffon–Laplace formula
+   ============================================================ -/
+
+/-- **General Buffon–Laplace theorem (`k` families).**
+
+For a polygonal noodle `N` of total length `L` and `k` families of parallel lines with
+positive spacings `d₁, …, d_k`, the expected total number of crossings is
+
+`E[crossings] = (2L/π) · Σ_j 1/d_j`,
+
+depending only on the total length and the spacings — not on the noodle's shape, nor on
+the families' orientations. The proof rewrites each family's contribution with the
+parent single-family theorem `buffon_noodle_polygon` and sums by linearity. -/
+theorem buffon_noodle_multi_family {n k : ℕ} (N : PolygonalNoodle n) (d : Fin k → ℝ)
+    (hd : ∀ j, 0 < d j) :
+    N.expectedMultiCrossings d = 2 * N.totalLength / π * ∑ j, (d j)⁻¹ := by
+  rw [PolygonalNoodle.expectedMultiCrossings, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun j _ => ?_)
+  rw [buffon_noodle_polygon N (d j) (hd j)]
+  have hdj : d j ≠ 0 := (hd j).ne'
+  have hpi : π ≠ 0 := Real.pi_ne_zero
+  field_simp
+
+/- ============================================================
+   § 3 : Specializations and structural properties
+   ============================================================ -/
+
+/-- **Recovery of the two-family grid.** The parent's perpendicular grid expectation is
+    the `k = 2` case of the multi-family count, with spacings `![dh, dv]`. -/
+theorem expectedGridCrossings_eq_multi {n : ℕ} (N : PolygonalNoodle n) (dh dv : ℝ) :
+    N.expectedGridCrossings dh dv = N.expectedMultiCrossings ![dh, dv] := by
+  simp [PolygonalNoodle.expectedGridCrossings, PolygonalNoodle.expectedMultiCrossings,
+    Fin.sum_univ_two]
+
+/-- **Equal spacings.** For `k` families all of spacing `d`, the expected crossings are
+    `2kL/(π·d)` — the count scales linearly in the number of families. -/
+theorem buffon_noodle_multi_family_const {n k : ℕ} (N : PolygonalNoodle n) (d : ℝ)
+    (hd : 0 < d) :
+    N.expectedMultiCrossings (fun _ : Fin k => d) = 2 * k * N.totalLength / (π * d) := by
+  rw [buffon_noodle_multi_family N _ (fun _ => hd)]
+  simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  have hd' : d ≠ 0 := hd.ne'
+  have hpi : π ≠ 0 := Real.pi_ne_zero
+  field_simp
+
+/-- The multi-family expected-crossing count is nonnegative. -/
+theorem buffon_noodle_multi_family_nonneg {n k : ℕ} (N : PolygonalNoodle n)
+    (d : Fin k → ℝ) (hd : ∀ j, 0 < d j) :
+    0 ≤ N.expectedMultiCrossings d := by
+  rw [buffon_noodle_multi_family N d hd]
+  apply mul_nonneg
+  · exact div_nonneg (by have := N.totalLength_nonneg; linarith) (le_of_lt Real.pi_pos)
+  · exact Finset.sum_nonneg fun j _ => le_of_lt (inv_pos.mpr (hd j))
+
+/-- **Monotonicity in the family set.** Adding more families (over a larger index set
+    via an injection) can only increase the expected number of crossings, since every
+    single-family term is nonnegative. Stated for the canonical inclusion
+    `Fin k ↪ Fin (k + m)` of the first `k` families. -/
+theorem buffon_noodle_multi_family_mono {n k m : ℕ} (N : PolygonalNoodle n)
+    (d : Fin (k + m) → ℝ) (hd : ∀ j, 0 < d j) :
+    N.expectedMultiCrossings (fun j : Fin k => d (Fin.castAdd m j))
+      ≤ N.expectedMultiCrossings d := by
+  rw [buffon_noodle_multi_family N _ (fun j => hd (Fin.castAdd m j)),
+      buffon_noodle_multi_family N d hd]
+  have hbase : 0 ≤ 2 * N.totalLength / π :=
+    div_nonneg (by have := N.totalLength_nonneg; linarith) (le_of_lt Real.pi_pos)
+  apply mul_le_mul_of_nonneg_left _ hbase
+  -- `Σ_{j : Fin k} 1/d(castAdd j) ≤ Σ_{j : Fin (k+m)} 1/d j`: a subsum of nonneg terms
+  rw [Fin.sum_univ_add]
+  have : 0 ≤ ∑ j : Fin m, (d (Fin.natAdd k j))⁻¹ :=
+    Finset.sum_nonneg fun j _ => le_of_lt (inv_pos.mpr (hd _))
+  linarith
+
+/- ============================================================
+   § 4 : Worked instances
+   ============================================================ -/
+
+section Examples
+
+variable {n : ℕ} (N : PolygonalNoodle n)
+
+/-- Three families with spacings `1, 2, 3`: expected crossings `(2L/π)(1 + 1/2 + 1/3)`. -/
+example :
+    N.expectedMultiCrossings ![(1 : ℝ), 2, 3]
+      = 2 * N.totalLength / π * (1 + 2⁻¹ + 3⁻¹) := by
+  rw [buffon_noodle_multi_family N _ (by
+    intro j; fin_cases j <;> norm_num)]
+  simp [Fin.sum_univ_three]
+
+/-- A square grid (`k = 2`, equal spacing `d`) gives `4L/(πd)`, matching the parent. -/
+example (d : ℝ) (hd : 0 < d) :
+    N.expectedMultiCrossings (fun _ : Fin 2 => d) = 4 * N.totalLength / (π * d) := by
+  rw [buffon_noodle_multi_family_const (k := 2) N d hd]; push_cast; ring
+
+end Examples
+
+end BuffonsNoodleOQ01OQ02

--- a/src/data/proofs/buffons-noodle-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/buffons-noodle-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-buffons-noodle-oq-01-oq-02-01",
+    "proofId": "buffons-noodle-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "From a Grid to k Line Families — and Why the Angles Disappear",
+    "content": "The parent leaf proved the two-family Buffon–Laplace grid identity E = 2L/(πdₕ) + 2L/(πdᵥ). This file answers its open question: extend to k families of parallel lines at angles θ₁,…,θ_k with spacings d₁,…,d_k. The candidate poses the families 'at angles', yet the answer (2L/π)·Σⱼ 1/dⱼ has no angle dependence — and that is the crux, not an omission. Because the noodle is dropped at a uniformly random position AND orientation, the expected number of crossings with a single family depends only on the noodle's length and the family's spacing (Barbier's orientation-invariance), never on the family's angle. By linearity of expectation the total is Σⱼ 2L/(πdⱼ) no matter how the families are angled. Modelling families by their spacings d : Fin k → ℝ therefore loses no information.",
+    "mathContext": "Two families: 2L/(πdₕ) + 2L/(πdᵥ). k families: (2L/π)·Σⱼ 1/dⱼ. No θ-dependence by orientation-invariance + linearity.",
+    "significance": "Generalizes the whole Buffon → Buffon–Laplace lineage to its natural endpoint, the discrete Cauchy–Crofton sum, while making explicit why the family orientations are irrelevant.",
+    "relatedConcepts": ["Buffon–Laplace problem", "Cauchy–Crofton formula", "linearity of expectation", "integral geometry", "orientation invariance"],
+    "prerequisites": ["Buffon's noodle (single family)", "Buffon–Laplace two-family grid", "additivity of expectation"]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-01-oq-02-02",
+    "proofId": "buffons-noodle-oq-01-oq-02",
+    "range": { "startLine": 59, "endLine": 80 },
+    "type": "definition",
+    "title": "expectedMultiCrossings: Additivity Across an Arbitrary Index Set",
+    "content": "expectedMultiCrossings N d := Σⱼ N.expectedCrossings (d j), a sum over the finite index set Fin k of the parent's single-family expected counts. This encodes additivity of expectation across the families definitionally — no new probabilistic primitive is introduced. A subtle Lean point: the definition is placed in the BuffonsNoodle namespace (alongside the parent's expectedGridCrossings), not in the leaf namespace, so that dot-notation N.expectedMultiCrossings resolves against the structure BuffonsNoodle.PolygonalNoodle. expectedMultiCrossings_eq_sum then records the additive structure by rfl.",
+    "mathContext": "expectedMultiCrossings(N, d) := Σ_{j : Fin k} E[crossings vs family with spacing dⱼ].",
+    "significance": "The single definitional sum is the entire probabilistic content; everything downstream is algebra over it.",
+    "relatedConcepts": ["linearity of expectation", "finite sums", "expectedGridCrossings", "dot notation resolution"],
+    "prerequisites": ["expectedCrossings (parent)", "Finset.sum over Fin k"]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-01-oq-02-03",
+    "proofId": "buffons-noodle-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 104 },
+    "type": "theorem",
+    "title": "The General Buffon–Laplace Identity (2L/π)·Σⱼ 1/dⱼ",
+    "content": "buffon_noodle_multi_family is the headline result: for positive spacings, E = (2L/π)·Σⱼ 1/dⱼ. The proof is three moves. (1) Finset.mul_sum pulls the common factor 2L/π out of the target sum, reducing the goal to a termwise equality. (2) Finset.sum_congr replaces each summand using the parent single-family theorem buffon_noodle_polygon, which supplies N.expectedCrossings (dⱼ) = 2L/(πdⱼ). (3) field_simp clears the denominators (using π ≠ 0 and dⱼ ≠ 0), closing the goal — no ring needed. The depends-on-axioms check returns only propext / Classical.choice / Quot.sound: verified and axiom-free.",
+    "mathContext": "E = Σⱼ 2L/(πdⱼ) = (2L/π)·Σⱼ 1/dⱼ. Each term from buffon_noodle_polygon; sum by linearity.",
+    "significance": "The discrete Cauchy–Crofton crossing count, proved entirely as an algebraic corollary of the machine-checked single-family theorem.",
+    "relatedConcepts": ["Finset.mul_sum", "Finset.sum_congr", "buffon_noodle_polygon", "Cauchy–Crofton formula"],
+    "prerequisites": ["buffon_noodle_polygon", "finite-sum distribution", "field_simp"]
+  },
+  {
+    "id": "ann-buffons-noodle-oq-01-oq-02-04",
+    "proofId": "buffons-noodle-oq-01-oq-02",
+    "range": { "startLine": 110, "endLine": 154 },
+    "type": "theorem",
+    "title": "Grid Recovery, Linear Scaling, and Monotonicity in the Family Set",
+    "content": "Four structural corollaries. expectedGridCrossings_eq_multi shows the parent's perpendicular two-family grid is exactly the k=2 instance with spacings ![dₕ, dᵥ], unifying the earlier result into the general framework. buffon_noodle_multi_family_const gives the equal-spacing count 2kL/(πd) — the expected crossings scale linearly in the number of families. buffon_noodle_multi_family_nonneg proves nonnegativity. buffon_noodle_multi_family_mono proves that adding families over a larger index set (the canonical inclusion Fin k ↪ Fin (k+m)) can only increase the expected crossings: Fin.sum_univ_add splits off the extra m terms, each nonnegative, so the subsum is bounded by the full sum.",
+    "mathContext": "k=2 grid recovered via ![dₕ,dᵥ]; equal spacing → 2kL/(πd); subsum ≤ full sum over Fin (k+m).",
+    "significance": "Confirms the k-family functional behaves like a genuine expected count (nonneg, monotone) and that it strictly generalizes the parent's grid.",
+    "relatedConcepts": ["Fin.sum_univ_add", "Fin.castAdd", "subsum monotonicity", "square grid"],
+    "prerequisites": ["buffon_noodle_multi_family", "Finset.sum_nonneg", "Fin index arithmetic"]
+  }
+]

--- a/src/data/proofs/buffons-noodle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-noodle-oq-01-oq-02/meta.json
@@ -1,0 +1,228 @@
+{
+  "id": "buffons-noodle-oq-01-oq-02",
+  "title": "General Buffon–Laplace for k Line Families (Cauchy–Crofton Discretization)",
+  "slug": "buffons-noodle-oq-01-oq-02",
+  "description": "Extends the Buffon–Laplace grid identity from two perpendicular line families to k families with arbitrary spacings d₁,…,d_k. For a polygonal noodle of total length L, the expected total number of crossings is (2L/π)·Σⱼ 1/dⱼ, depending only on the total length and the spacings — never on the noodle's shape nor on the families' orientations. Proved by additivity of expectation: each family contributes 2L/(πdⱼ) via the parent single-family theorem, and the total is their sum by linearity. The two-family grid is recovered as the k=2 case, and equal spacings give 2kL/(πd). Fully machine-checked: 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BuffonsNoodleOQ01OQ02.lean",
+    "tags": [
+      "geometric-probability",
+      "integral-geometry",
+      "buffon",
+      "buffon-laplace",
+      "cauchy-crofton",
+      "linearity-of-expectation"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "Distributes the common factor 2L/π over the sum Σⱼ 1/dⱼ, reducing the k-family identity to a per-family rewrite",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_congr",
+        "description": "Rewrites each family's term with the parent single-family theorem under the sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Fin.sum_univ_add",
+        "description": "Splits Σ over Fin (k+m) into the first-k subsum plus the last-m subsum, used for monotonicity in the number of families",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Real.pi_ne_zero",
+        "description": "π ≠ 0, used to clear the spacing factor π in the closed-form crossing count",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ],
+    "originalContributions": [
+      "PolygonalNoodle.expectedMultiCrossings: DEFINED the expected total number of crossings against k line families as Σⱼ N.expectedCrossings (dⱼ) — additivity of expectation across an arbitrary index set Fin k",
+      "buffon_noodle_multi_family: PROVED the general Buffon–Laplace / Cauchy–Crofton identity E = (2L/π)·Σⱼ 1/dⱼ for positive spacings, for a polygonal noodle of any shape",
+      "expectedGridCrossings_eq_multi: PROVED the parent's two-family perpendicular grid is exactly the k=2 case with spacings ![dₕ, dᵥ]",
+      "buffon_noodle_multi_family_const: PROVED the equal-spacing count 2kL/(πd), so the expected crossings scale linearly in the number of families",
+      "buffon_noodle_multi_family_nonneg: PROVED nonnegativity of the k-family functional",
+      "buffon_noodle_multi_family_mono: PROVED monotonicity under the canonical inclusion Fin k ↪ Fin (k+m) — adding more families can only increase the expected crossings"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Buffon's Noodle (polygonal case): expected single-family crossings 2L/(πd) — the parent theorem buffon_noodle_polygon",
+      "Buffon–Laplace two-family grid (parent buffons-noodle-oq-01)",
+      "Additivity of expectation over a finite index set (no independence needed)",
+      "Elementary field algebra and finite-sum manipulation"
+    ],
+    "lineCount": 179,
+    "relatedProblems": [
+      {
+        "id": "buffons-noodle-oq-01",
+        "relationship": "Direct parent: the two-family grid identity, recovered here as the k=2 specialization. This file answers its openQuestions[1] (extend to k non-parallel families)."
+      },
+      {
+        "id": "buffons-noodle",
+        "relationship": "Grandparent: supplies the single-family polygonal theorem buffon_noodle_polygon reused once per family."
+      }
+    ],
+    "assumptions": "None. 0 axioms, 0 sorries (depends only on the foundational propext / Classical.choice / Quot.sound). The per-segment crossing probability 2ℓ/(πd) is inherited from the grandparent's segmentCrossingProb definition (Buffon's Needle); this file adds no new axioms and proves the k-family identity as an algebraic corollary of the machine-checked buffon_noodle_polygon. Scope is polygonal noodles; the smooth/C¹ generalization (depending on the grandparent's still-axiomatized kinematic-measure functional) is deliberately out of scope.",
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "structureCount": 0
+  },
+  "overview": {
+    "historicalContext": "Georges-Louis Leclerc, Comte de Buffon (1777), computed the probability 2ℓ/(πd) that a needle of length ℓ crosses one family of parallel lines spaced d apart. Joseph Barbier (1860) reframed it through the additivity/invariance principle: the expected number of crossings of any rectifiable curve depends only on its length, so a bent wire — a 'noodle' — crosses as often as a straight needle of equal length. Pierre-Simon Laplace (1812) dropped the curve on a GRID of two perpendicular rulings, lowering the variance of the resulting Monte-Carlo estimate of π. The natural endpoint of this lineage is the general Buffon–Laplace problem: k families of parallel lines at arbitrary angles and spacings. The orientation-independence built into Barbier's theorem makes the answer strikingly clean — the family angles drop out entirely, leaving (2L/π)·Σⱼ 1/dⱼ. This is exactly the discrete shadow of the Cauchy–Crofton formula of integral geometry, which expresses a curve's length as an integral of its intersection counts against all lines in the plane. This entry formalizes the k-family identity for polygonal noodles as a corollary of the gallery's two-family grid theorem, by additivity of expectation across the families.",
+    "problemStatement": "Prove that a polygonal noodle of total length L dropped against k families of parallel lines with positive spacings d₁,…,d_k has expected total crossings (2L/π)·Σⱼ 1/dⱼ, recovering the two-family grid as k=2 and the equal-spacing count 2kL/(πd).",
+    "text": "A 179-line file that defines the k-family expected-crossing functional and proves the general Buffon–Laplace identity (2L/π)·Σⱼ 1/dⱼ, the recovery of the parent's perpendicular grid as the k=2 case, the equal-spacing count 2kL/(πd), nonnegativity, and monotonicity in the number of families — all as corollaries of the parent's buffon_noodle_polygon via additivity of expectation across the families.",
+    "proofStrategy": "Additivity of expectation across an arbitrary finite index set. expectedMultiCrossings is defined as Σⱼ N.expectedCrossings (dⱼ); the headline theorem distributes the common factor 2L/π over the sum (Finset.mul_sum), then rewrites each summand with the parent single-family theorem buffon_noodle_polygon (Finset.sum_congr) and clears denominators (field_simp). Every downstream result — grid recovery, equal-spacing count, nonnegativity, monotonicity — is a short rewrite through the headline identity plus finite-sum algebra.",
+    "keyInsights": [
+      "**The angles vanish.** Although the candidate poses k families 'at angles θ₁,…,θ_k', the formula carries no angle dependence. Each single-family expected count depends only on length and spacing (Barbier orientation-invariance), so by linearity the total is Σⱼ 2L/(πdⱼ) regardless of how the families are angled. Modelling families by their spacings d : Fin k → ℝ loses no information.",
+      "**Additivity needs no independence.** The k crossing tallies come from the same drop of the same noodle and are strongly correlated, yet E[ΣXⱼ] = ΣE[Xⱼ] holds unconditionally — so the k-family expectation is literally a sum of k single-family theorems.",
+      "**The grid is the k=2 case.** The parent's perpendicular two-family grid is recovered exactly by instantiating the index set with ![dₕ, dᵥ], unifying the earlier result into the general framework.",
+      "**Linear scaling in the family count.** With equal spacings the count is 2kL/(πd) — k families give exactly k times the single-family count.",
+      "**Cauchy–Crofton discretization.** Summing intersection counts over finitely many line families is the discrete analogue of integrating intersection counts over the full kinematic measure on lines; the formula (2L/π)·Σⱼ 1/dⱼ is the integral-geometric content made elementary."
+    ],
+    "prerequisites": [
+      "Buffon's Noodle polygonal theorem (grandparent)",
+      "Buffon–Laplace two-family grid (parent)",
+      "Additivity of expectation",
+      "Finite-sum algebra"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "buffons-noodle-oq-01",
+      "relationship": "extends",
+      "description": "Generalizes the two-family perpendicular grid to k families with arbitrary spacings; the parent identity is recovered as the k=2 case (expectedGridCrossings_eq_multi). Answers the parent's openQuestions[1]."
+    },
+    {
+      "targetId": "buffons-noodle",
+      "relationship": "extends",
+      "description": "Reuses the grandparent's single-family polygonal theorem buffon_noodle_polygon (2L/(πd)) once per family; the k-family result is the additive composition of k instances of it."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 179,
+    "namespace": "BuffonsNoodleOQ01OQ02",
+    "opens": [
+      "Real",
+      "Finset",
+      "BigOperators",
+      "BuffonsNoodle",
+      "BuffonsNoodleOQ01"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "substantiveTheoremCount": 5,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Proofs.BuffonsNoodleOQ01",
+      "Mathlib.Tactic"
+    ],
+    "path": "Proofs/BuffonsNoodleOQ01OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 1
+  },
+  "mainTheorems": [
+    {
+      "name": "buffon_noodle_multi_family",
+      "type": "core",
+      "description": "General Buffon–Laplace / Cauchy–Crofton identity: for k families with positive spacings, E[crossings] = (2L/π)·Σⱼ 1/dⱼ (PROVED, 0 axioms)",
+      "leanType": "∀ {n k : ℕ} (N : PolygonalNoodle n) (d : Fin k → ℝ), (∀ j, 0 < d j) → N.expectedMultiCrossings d = 2 * N.totalLength / π * ∑ j, (d j)⁻¹"
+    },
+    {
+      "name": "expectedGridCrossings_eq_multi",
+      "type": "core",
+      "description": "Recovery of the parent's perpendicular two-family grid as the k=2 case with spacings ![dₕ, dᵥ] (PROVED, 0 axioms)",
+      "leanType": "∀ {n : ℕ} (N : PolygonalNoodle n) (dh dv : ℝ), N.expectedGridCrossings dh dv = N.expectedMultiCrossings ![dh, dv]"
+    },
+    {
+      "name": "buffon_noodle_multi_family_const",
+      "type": "core",
+      "description": "Equal-spacing count: k families all of spacing d give 2kL/(πd) — linear scaling in the family count (PROVED, 0 axioms)",
+      "leanType": "∀ {n k : ℕ} (N : PolygonalNoodle n) (d : ℝ), 0 < d → N.expectedMultiCrossings (fun _ : Fin k => d) = 2 * k * N.totalLength / (π * d)"
+    },
+    {
+      "name": "buffon_noodle_multi_family_mono",
+      "type": "supporting",
+      "description": "Monotonicity in the family set: adding families over a larger index set (Fin k ↪ Fin (k+m)) can only increase the expected crossings (PROVED, 0 axioms)",
+      "leanType": "∀ {n k m : ℕ} (N : PolygonalNoodle n) (d : Fin (k + m) → ℝ), (∀ j, 0 < d j) → N.expectedMultiCrossings (fun j : Fin k => d (Fin.castAdd m j)) ≤ N.expectedMultiCrossings d"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-overview",
+      "title": "Overview: General Buffon–Laplace and Why the Angles Vanish",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Frames the extension from the two-family perpendicular grid (E = 2L/(πdₕ) + 2L/(πdᵥ)) to k families with arbitrary spacings (E = (2L/π)·Σⱼ 1/dⱼ, the general Buffon–Laplace / Cauchy–Crofton discretization). Explains the crux: the family angles θⱼ do not appear because each single-family expected count is orientation-free (Barbier), so by linearity the total depends only on length and spacings. Scope is polygonal noodles (0 axioms, 0 sorries)."
+    },
+    {
+      "id": "multi-definition",
+      "title": "§1 Definition: expectedMultiCrossings",
+      "startLine": 55,
+      "endLine": 80,
+      "summary": "Defines PolygonalNoodle.expectedMultiCrossings N d := Σⱼ N.expectedCrossings (d j) over the index set Fin k, encoding additivity of expectation across the families. Declared in the BuffonsNoodle namespace (alongside the parent's expectedGridCrossings) so dot-notation N.expectedMultiCrossings resolves. expectedMultiCrossings_eq_sum records the definitional additivity by rfl."
+    },
+    {
+      "id": "multi-formula",
+      "title": "§2 The General Buffon–Laplace Formula",
+      "startLine": 82,
+      "endLine": 104,
+      "summary": "buffon_noodle_multi_family: for positive spacings, E = (2L/π)·Σⱼ 1/dⱼ. The proof distributes the factor 2L/π over the sum (Finset.mul_sum), rewrites each term with the parent buffon_noodle_polygon under Finset.sum_congr, and clears denominators with field_simp using π ≠ 0 and dⱼ ≠ 0."
+    },
+    {
+      "id": "specializations",
+      "title": "§3 Specializations and Structural Properties",
+      "startLine": 106,
+      "endLine": 154,
+      "summary": "expectedGridCrossings_eq_multi recovers the parent's perpendicular grid as the k=2 case with ![dₕ, dᵥ]; buffon_noodle_multi_family_const gives the equal-spacing count 2kL/(πd) (linear in k); buffon_noodle_multi_family_nonneg proves nonnegativity; buffon_noodle_multi_family_mono proves monotonicity under the canonical inclusion Fin k ↪ Fin (k+m) via Fin.sum_univ_add and nonnegativity of the dropped terms."
+    },
+    {
+      "id": "examples",
+      "title": "§4 Worked Instances",
+      "startLine": 156,
+      "endLine": 179,
+      "summary": "Two concrete checks: three families with spacings 1,2,3 give (2L/π)(1 + 1/2 + 1/3); a square grid (k=2, equal spacing d) gives 4L/(πd), matching the parent."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully machine-checked (0 sorries, 0 axioms) formalization of the general Buffon–Laplace / Cauchy–Crofton crossing identity (2L/π)·Σⱼ 1/dⱼ for a polygonal noodle against k line families, obtained by additivity of expectation across the families. Includes recovery of the two-family grid as the k=2 case, the equal-spacing count 2kL/(πd), nonnegativity, monotonicity in the number of families, and worked instances.",
+    "implications": "Closes the parent's open question of extending the grid identity to k non-parallel families, and exhibits the orientation-independence that makes the family angles drop out — the elementary, discrete face of the Cauchy–Crofton formula. The linearity-of-expectation machinery composes cleanly over an arbitrary finite index set, a reusable pattern for integral-geometry formalizations.",
+    "openQuestions": [
+      "Generalize the k-family identity to the smooth/C¹ case once the grandparent's kinematic-measure functional smoothExpectedCrossings is discharged.",
+      "Take the continuum limit over family angles to recover the full Cauchy–Crofton formula length = (1/2)∫ n(θ,p) dθ dp as an integral rather than a finite sum.",
+      "Quantify the variance reduction of the k-family estimator of π versus the single-family and two-family estimators for a fixed number of trials."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Barbier, Joseph-Émile",
+      "title": "Note sur le problème de l'aiguille et le jeu du joint couvert",
+      "year": "1860",
+      "venue": "Journal de mathématiques pures et appliquées, 2e série, tome 5",
+      "note": "Establishes the orientation-invariance (length-only dependence) that makes the family angles drop out of the k-family formula."
+    },
+    {
+      "authors": "Laplace, Pierre-Simon",
+      "title": "Théorie analytique des probabilités",
+      "year": "1812",
+      "venue": "Courcier, Paris",
+      "note": "Introduces the doubly-ruled grid variant generalized here to k families."
+    },
+    {
+      "authors": "Santaló, Luis A.",
+      "title": "Integral Geometry and Geometric Probability",
+      "year": "2004",
+      "venue": "Cambridge Mathematical Library, 2nd edition",
+      "note": "Standard reference for the Cauchy–Crofton formula and the kinematic measure on lines, of which the k-family sum is the discretization."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question **buffons-noodle-oq-01-oq-02** (parent `buffons-noodle-oq-01` `openQuestions[1]`): extend the two-family Buffon–Laplace grid identity to **k families** of parallel lines with arbitrary spacings `d₁,…,d_k`.

**Headline:** for a polygonal noodle of total length `L` and positive spacings,
```
E[crossings] = (2L/π) · Σⱼ 1/dⱼ
```
depending only on total length and the spacings — never on the noodle's shape nor on the family angles.

## Why the angles vanish

The candidate poses families "at angles θ₁,…,θ_k", yet the formula carries no angle. By Barbier's orientation-invariance each single-family expected count depends only on length and spacing, so by **additivity of expectation** the total is `Σⱼ 2L/(πdⱼ)` regardless of orientation. This is the discrete shadow of the Cauchy–Crofton formula.

## What's proved (6 theorems, 1 def, 179 lines)

- `PolygonalNoodle.expectedMultiCrossings` — k-family functional `Σⱼ N.expectedCrossings (dⱼ)`
- `buffon_noodle_multi_family` — the headline identity `(2L/π)·Σⱼ 1/dⱼ`
- `expectedGridCrossings_eq_multi` — recovers the parent's perpendicular grid as the `k=2` case `![dₕ, dᵥ]`
- `buffon_noodle_multi_family_const` — equal-spacing count `2kL/(πd)` (linear in k)
- `buffon_noodle_multi_family_nonneg` / `_mono` — nonnegativity and monotonicity under `Fin k ↪ Fin (k+m)`

## Verification

- Compiles clean under Lean 4.26.0 / Mathlib (host `lake env lean`; docker wrapper unavailable this session).
- `#print axioms` for all theorems: `[propext, Classical.choice, Quot.sound]` only — **verified, 0-axiom, original**. No `sorry`, no `native_decide`.
- Proof is a pure algebraic corollary of the grandparent's machine-checked `buffon_noodle_polygon`.

Gallery entry (`meta.json` + `annotations.json`) added; aggregator `Proofs.lean` import added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)