### PR TITLE
Research: area-of-circle-oq-07-oq-05-oq-02 — Gaussian second moment as Γ(3/2) via u=x² substitution [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -216,6 +216,7 @@ import Proofs.AreaOfCircleOQ07OQ04
 import Proofs.AreaOfCircleOQ07OQ05
 import Proofs.AreaOfCircleOQ07OQ05OQ01
 import Proofs.AreaOfCircleOQ07OQ05OQ01OQ02
+import Proofs.AreaOfCircleOQ07OQ05OQ02
 import Proofs.ArithmeticSeries
 import Proofs.ArithmeticSeriesOQ00
 import Proofs.ArithmeticSeriesOQ00OQ01

--- a/proofs/Proofs/AreaOfCircleOQ07OQ05OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ05OQ02.lean
@@ -1,0 +1,131 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.MeasureTheory.Integral.IntegralEqImproper
+import Mathlib.Tactic
+import Proofs.AreaOfCircleOQ07OQ05
+
+/-
+# The Gaussian Second Moment as a Gamma Value  (area-of-circle-oq-07-oq-05-oq-02)
+
+## Open Question (area-of-circle-oq-07-oq-05-oq-02)
+"Recover √π/2 as the Gamma value `Γ(3/2)` via the substitution `u = x²` and
+`Real.Gamma`, connecting the parent's Gaussian second moment to the
+special-function world."
+
+## Answer
+
+The parent entry `area-of-circle-oq-07-oq-05` evaluates the **full-line second
+moment** `∫_{ℝ} x² e^{-x²} dx = √π/2` by integration by parts.  This entry
+re-derives the same value through the **Gamma function**, exposing the
+substitution `u = x²` that turns the Gaussian moment into the Euler integral.
+
+### The substitution bridge (the heart of the entry)
+
+Euler's integral for the Gamma function reads
+`Γ(s) = ∫_{0}^{∞} e^{-u} u^{s-1} du`.  For `s = 3/2` the exponent is `u^{1/2}`,
+so substituting `u = x²` (`du = 2x dx`, `u^{1/2} = x` on the half-line) gives
+
+  `Γ(3/2) = ∫_{0}^{∞} e^{-x²} · x · 2x dx = 2 ∫_{0}^{∞} x² e^{-x²} dx`,
+
+i.e. the **half-line second moment equals `½·Γ(3/2)`**:
+
+  **`gaussian_second_moment_Ioi`**:  `∫_{x>0} x² e^{-x²} = Γ(3/2) / 2`.
+
+Lean's change-of-variables `integral_comp_rpow_Ioi_of_pos` (the very lemma
+Mathlib uses for `Γ(1/2) = √π`) supplies the substitution; `Gamma_eq_integral`
+supplies Euler's integral.
+
+### The special value
+
+`Γ(3/2) = √π/2` follows from the functional equation
+`Γ(s+1) = s·Γ(s)` (`Real.Gamma_add_one`) and `Γ(1/2) = √π`
+(`Real.Gamma_one_half_eq`):
+
+  **`gamma_three_half`**:  `Γ(3/2) = √π/2`.
+
+### Resolving the factor of two
+
+The open question's phrasing "`√π/2 = ½·Γ(3/2)`" mixes the two moments: the
+**half-line** moment is `½·Γ(3/2) = √π/4`, while the **full-line** moment — the
+parent's headline value — is its double, `Γ(3/2) = √π/2`.  We record the clean
+identification of the parent value with the Gamma value:
+
+  **`gaussian_second_moment_eq_gamma`**:  `∫_{ℝ} x² e^{-x²} = Γ(3/2)`,
+
+which combined with `gamma_three_half` reproduces the parent's `√π/2` as a
+special value of the Gamma function — the requested connection.
+
+## Relation to Mathlib
+
+Mathlib has the Gamma machinery (`Gamma_eq_integral`, `Gamma_add_one`,
+`Gamma_one_half_eq`, the half-integer values `Gamma_nat_add_one_add_half`) and
+the substitution lemma `integral_comp_rpow_Ioi_of_pos`, but it does not connect
+the Gaussian second moment to `Γ(3/2)`.  We assemble that bridge here, reusing
+the parent's `gaussian_second_moment` for the full-line value.  No new axioms.
+-/
+
+open Real MeasureTheory Filter Topology Set
+open scoped Real
+
+namespace AreaOfCircleOQ07OQ05OQ02
+
+/-! ## Part I: The special value `Γ(3/2) = √π/2` -/
+
+/-- **`Γ(3/2) = √π/2`.** From the functional equation `Γ(s+1) = s·Γ(s)` with
+`s = 1/2` and the Gaussian special value `Γ(1/2) = √π`. -/
+theorem gamma_three_half : Real.Gamma (3 / 2) = Real.sqrt π / 2 := by
+  have h : Real.Gamma (1 / 2 + 1) = (1 / 2 : ℝ) * Real.Gamma (1 / 2) :=
+    Real.Gamma_add_one (by norm_num)
+  rw [show (3 / 2 : ℝ) = 1 / 2 + 1 by norm_num, h, Real.Gamma_one_half_eq]
+  ring
+
+/-! ## Part II: The substitution `u = x²` -/
+
+/-- **The substitution bridge.**  Euler's integral `Γ(3/2) = ∫_{u>0} e^{-u}·u^{1/2}`
+becomes, under `u = x²`, twice the half-line Gaussian second moment.  Hence
+
+  `∫_{x>0} x² e^{-x²} = Γ(3/2) / 2`. -/
+theorem gaussian_second_moment_Ioi :
+    ∫ x in Ioi (0 : ℝ), x ^ 2 * Real.exp (-x ^ 2) = Real.Gamma (3 / 2) / 2 := by
+  -- Euler's integral form of `Γ(3/2)`.
+  have hΓ : Real.Gamma (3 / 2)
+      = ∫ u in Ioi (0 : ℝ), Real.exp (-u) * u ^ ((3 / 2 : ℝ) - 1) :=
+    Real.Gamma_eq_integral (by norm_num)
+  -- Substitute `u = x ^ 2` via the change-of-variables lemma.
+  have hsub := integral_comp_rpow_Ioi_of_pos
+    (g := fun u : ℝ => Real.exp (-u) * u ^ ((3 / 2 : ℝ) - 1)) (p := 2)
+    (by norm_num)
+  -- `hsub : ∫ x>0, (2 * x^(2-1)) • (e^{-x^2} * (x^2)^(1/2)) = ∫ u>0, e^{-u} u^{1/2}`.
+  rw [hΓ, ← hsub]
+  -- Reduce both sides to `∫ x>0, 2 * (x² e^{-x²})`.
+  rw [eq_div_iff (two_ne_zero), mul_comm, ← integral_const_mul]
+  refine setIntegral_congr_fun measurableSet_Ioi (fun x hx => ?_)
+  have hx0 : (0 : ℝ) < x := hx
+  -- rewrite the rpow occurrences `x ^ (2:ℝ)` to the monomial `x ^ 2`.
+  have hpow2 : x ^ (2 : ℝ) = x ^ 2 := by
+    rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num, Real.rpow_natCast]
+  have hexp1 : x ^ ((2 : ℝ) - 1) = x := by
+    rw [show (2 : ℝ) - 1 = 1 by norm_num, Real.rpow_one]
+  have hhalf : (x ^ (2 : ℝ)) ^ ((3 / 2 : ℝ) - 1) = x := by
+    rw [← Real.rpow_mul hx0.le, show (2 : ℝ) * ((3 / 2 : ℝ) - 1) = 1 by norm_num,
+      Real.rpow_one]
+  rw [smul_eq_mul, hexp1]
+  dsimp only
+  rw [hhalf, hpow2]
+  ring
+
+/-! ## Part III: The full-line moment is `Γ(3/2)` -/
+
+/-- **The parent value as a Gamma value.**  The full-line Gaussian second moment
+equals `Γ(3/2)`.  Combined with `gamma_three_half` this reproduces the parent's
+`∫_{ℝ} x² e^{-x²} = √π/2` as a special value of the Gamma function. -/
+theorem gaussian_second_moment_eq_gamma :
+    ∫ x : ℝ, x ^ 2 * Real.exp (-x ^ 2) = Real.Gamma (3 / 2) := by
+  rw [AreaOfCircleOQ07OQ05.gaussian_second_moment, gamma_three_half]
+
+/-- Consistency: the half-line moment is `√π/4`, i.e. `½·Γ(3/2)` — the value the
+open question refers to. -/
+theorem gaussian_second_moment_Ioi_eq :
+    ∫ x in Ioi (0 : ℝ), x ^ 2 * Real.exp (-x ^ 2) = Real.sqrt π / 4 := by
+  rw [gaussian_second_moment_Ioi, gamma_three_half]; ring
+
+end AreaOfCircleOQ07OQ05OQ02

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-02/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "ann-aoc0705oq02-overview",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-02",
+    "range": { "startLine": 6, "endLine": 64 },
+    "type": "concept",
+    "title": "The Gaussian-to-Gamma Substitution u = x²",
+    "content": "The parent entry evaluated the Gaussian second moment $\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\tfrac{\\sqrt\\pi}{2}$ by integration by parts. This entry recovers that value through Euler's Gamma function. The bridge is the change of variables $u = x^2$, which sends Euler's integral $\\Gamma(s) = \\int_0^\\infty e^{-u} u^{s-1}\\,du$ at $s = \\tfrac32$ to twice the half-line Gaussian moment:\n$$\\Gamma\\!\\left(\\tfrac32\\right) = \\int_0^\\infty e^{-u} u^{1/2}\\,du = 2\\int_0^\\infty x^2 e^{-x^2}\\,dx.$$\nThe special value $\\Gamma(\\tfrac32) = \\tfrac{\\sqrt\\pi}{2}$ then identifies the parent's full-line moment with a Gamma value.",
+    "mathContext": "The question's phrasing '$\\sqrt\\pi/2 = \\tfrac12\\Gamma(3/2)$' mixes the two moments. The correct readings: the **half-line** moment is $\\tfrac12\\Gamma(\\tfrac32) = \\tfrac{\\sqrt\\pi}{4}$, while the **full-line** moment — the parent's headline value $\\tfrac{\\sqrt\\pi}{2}$ — is its double, $\\Gamma(\\tfrac32)$. This entry proves both and keeps them straight.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gamma function",
+      "Gaussian integral",
+      "change of variables",
+      "second moment",
+      "Euler integral"
+    ],
+    "prerequisites": [
+      "Euler's integral for Γ",
+      "Gaussian integral ∫ e^{-x²} = √π",
+      "change of variables in improper integrals"
+    ]
+  },
+  {
+    "id": "ann-aoc0705oq02-gamma-value",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-02",
+    "range": { "startLine": 71, "endLine": 79 },
+    "type": "theorem",
+    "title": "gamma_three_half — Γ(3/2) = √π/2",
+    "content": "The first non-trivial half-integer Gamma value. Writing $\\tfrac32 = \\tfrac12 + 1$ and applying the functional equation $\\Gamma(s+1) = s\\,\\Gamma(s)$ at $s = \\tfrac12$ gives $\\Gamma(\\tfrac32) = \\tfrac12\\,\\Gamma(\\tfrac12)$; the Gaussian special value $\\Gamma(\\tfrac12) = \\sqrt\\pi$ then yields $\\Gamma(\\tfrac32) = \\tfrac{\\sqrt\\pi}{2}$.",
+    "mathContext": "Both ingredients are Mathlib: `Real.Gamma_add_one` (the functional equation, requiring $s \\ne 0$) and `Real.Gamma_one_half_eq` ($\\Gamma(1/2) = \\sqrt\\pi$, itself proved in Mathlib from the Gaussian integral via the same $u = x^2$ substitution used in Part II).",
+    "significance": "important",
+    "relatedConcepts": [
+      "Gamma functional equation",
+      "half-integer Gamma values",
+      "Real.Gamma_one_half_eq"
+    ],
+    "prerequisites": [
+      "Γ(s+1) = s·Γ(s)",
+      "Γ(1/2) = √π"
+    ]
+  },
+  {
+    "id": "ann-aoc0705oq02-substitution",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-02",
+    "range": { "startLine": 81, "endLine": 114 },
+    "type": "theorem",
+    "title": "gaussian_second_moment_Ioi — The Substitution Bridge",
+    "content": "The heart of the entry: $\\int_0^\\infty x^2 e^{-x^2}\\,dx = \\tfrac12\\,\\Gamma(\\tfrac32)$. Euler's integral $\\Gamma(\\tfrac32) = \\int_0^\\infty e^{-u} u^{1/2}\\,du$ is transported under $u = x^2$ by Mathlib's `integral_comp_rpow_Ioi_of_pos` (with $p = 2$). The Jacobian contributes $2x$ and the half-power simplifies to $(x^2)^{1/2} = x$ on $x > 0$, so the integrand becomes $2x\\cdot e^{-x^2}\\cdot x = 2x^2 e^{-x^2}$; matching the constant $2$ across the equality gives the result.",
+    "mathContext": "`integral_comp_rpow_Ioi_of_pos` is exactly the lemma Mathlib uses to prove $\\Gamma(1/2) = \\sqrt\\pi$ from the Gaussian integral — this entry runs the same machinery one moment higher. The pointwise step needs rpow bookkeeping: $x^{(2:\\mathbb{R})} = x^2$ via `Real.rpow_natCast`, and $(x^{(2:\\mathbb{R})})^{(1/2)} = x$ via `Real.rpow_mul` with $2\\cdot(\\tfrac32-1) = 1$. The applied integrand lambda must be beta-reduced (`dsimp only`) before the half-power rewrite fires. This half-line value $\\tfrac12\\Gamma(\\tfrac32)$ is the identity Mathlib does not record.",
+    "significance": "key",
+    "relatedConcepts": [
+      "integral_comp_rpow_Ioi_of_pos",
+      "Real.Gamma_eq_integral",
+      "Jacobian / change of variables",
+      "rpow arithmetic"
+    ],
+    "prerequisites": [
+      "Euler's integral Γ(s) = ∫ e^{-x} x^{s-1}",
+      "change of variables u = x^p on (0,∞)",
+      "real power (rpow) identities"
+    ]
+  },
+  {
+    "id": "ann-aoc0705oq02-fullline",
+    "proofId": "area-of-circle-oq-07-oq-05-oq-02",
+    "range": { "startLine": 116, "endLine": 130 },
+    "type": "theorem",
+    "title": "gaussian_second_moment_eq_gamma — Full-Line Moment = Γ(3/2)",
+    "content": "The parent value as a Gamma value: $\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\Gamma(\\tfrac32)$, obtained by rewriting the parent's $\\tfrac{\\sqrt\\pi}{2}$ (`AreaOfCircleOQ07OQ05.gaussian_second_moment`) against `gamma_three_half`. The companion `gaussian_second_moment_Ioi_eq` records the explicit half-line value $\\int_0^\\infty x^2 e^{-x^2} = \\tfrac{\\sqrt\\pi}{4} = \\tfrac12\\Gamma(\\tfrac32)$.",
+    "mathContext": "Two routes to $\\tfrac{\\sqrt\\pi}{2}$ cross-check each other: the parent reaches it by integration by parts on the whole line, this entry as the special value $\\Gamma(\\tfrac32)$. Their agreement links an elementary analytic computation to a special-function evaluation, and confirms the half-line/full-line factor of two.",
+    "significance": "important",
+    "relatedConcepts": [
+      "even symmetry",
+      "special-function value",
+      "consistency cross-check"
+    ],
+    "prerequisites": [
+      "parent's full-line second moment √π/2",
+      "Γ(3/2) = √π/2"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-05-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05-oq-02/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "area-of-circle-oq-07-oq-05-oq-02",
+  "slug": "area-of-circle-oq-07-oq-05-oq-02",
+  "description": "Recovers the parent's Gaussian second moment ∫_ℝ x² e^{-x²} = √π/2 as a value of Euler's Gamma function, through the substitution u = x². The substitution turns the half-line moment ∫_{x>0} x² e^{-x²} into ½·Γ(3/2) = √π/4 via Mathlib's change-of-variables integral_comp_rpow_Ioi_of_pos, and the special value Γ(3/2) = √π/2 follows from Γ(s+1) = s·Γ(s) and Γ(1/2) = √π. Identifies the full-line moment with Γ(3/2).",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.MeasureTheory.Integral.IntegralEqImproper",
+      "Mathlib.Tactic",
+      "Proofs.AreaOfCircleOQ07OQ05"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "Filter",
+      "Topology",
+      "Set"
+    ],
+    "namespace": "AreaOfCircleOQ07OQ05OQ02",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ05OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Gaussian Second Moment as a Gamma Value: ∫ x² e^{-x²} = Γ(3/2) = √π/2 via u = x²",
+  "description": "Connects the parent's Gaussian second moment to the Gamma function. The substitution u = x² turns Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} du into twice the half-line Gaussian moment, giving ∫_{x>0} x² e^{-x²} = Γ(3/2)/2 = √π/4 (the substitution bridge, via Mathlib's integral_comp_rpow_Ioi_of_pos). The special value Γ(3/2) = √π/2 follows from the functional equation Γ(s+1) = s·Γ(s) and Γ(1/2) = √π, and the full-line moment is identified with Γ(3/2), reproducing the parent's √π/2 as a Gamma value. 131 lines, 4 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ05OQ02.lean",
+    "tags": [
+      "analysis",
+      "gaussian-integral",
+      "gamma-function",
+      "change-of-variables",
+      "special-functions",
+      "measure-theory",
+      "substitution",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 131,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "gaussian_second_moment_Ioi: ∫_{x>0} x² e^{-x²} = Γ(3/2)/2 — the substitution bridge and the heart of the entry. Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} du is transported under u = x² (Mathlib's integral_comp_rpow_Ioi_of_pos with p = 2, the very lemma Mathlib uses to prove Γ(1/2) = √π): the Jacobian 2x and the simplification (x²)^{1/2} = x on the half-line turn the integrand into 2 x² e^{-x²}, so Γ(3/2) = 2 ∫_{x>0} x² e^{-x²}. This realizes the half-line Gaussian second moment as ½·Γ(3/2), an identity not recorded in Mathlib.",
+      "gamma_three_half: Γ(3/2) = √π/2 — the half-integer special value, obtained from the functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) at s = 1/2 together with the Gaussian special value Γ(1/2) = √π (Real.Gamma_one_half_eq).",
+      "gaussian_second_moment_eq_gamma: ∫_ℝ x² e^{-x²} = Γ(3/2) — identifies the parent's full-line second moment (AreaOfCircleOQ07OQ05.gaussian_second_moment, value √π/2) with the Gamma value Γ(3/2), reproducing √π/2 = Γ(3/2) and answering the parent's open question of recovering √π/2 through Real.Gamma.",
+      "gaussian_second_moment_Ioi_eq: ∫_{x>0} x² e^{-x²} = √π/4 — the explicit half-line value, i.e. ½·Γ(3/2), recording the factor-of-two relationship between the half-line moment (½·Γ(3/2) = √π/4) and the full-line moment (Γ(3/2) = √π/2) that the parent's open question conflated."
+    ],
+    "prerequisites": [
+      "Euler's integral for the Gamma function: Real.Gamma_eq_integral (Γ(s) = ∫_{x>0} e^{-x} x^{s-1} for s > 0)",
+      "Change of variables u = x^p on Ioi 0: integral_comp_rpow_Ioi_of_pos",
+      "The functional equation Γ(s+1) = s·Γ(s): Real.Gamma_add_one",
+      "The Gaussian special value Γ(1/2) = √π: Real.Gamma_one_half_eq",
+      "rpow arithmetic: Real.rpow_natCast, Real.rpow_mul, Real.rpow_one",
+      "Parent: area-of-circle-oq-07-oq-05 (the second moment ∫ x² e^{-x²} = √π/2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_comp_rpow_Ioi_of_pos",
+        "description": "Change of variables for integrals over Ioi 0: ∫_{x>0} (p·x^{p-1}) • g(x^p) = ∫_{y>0} g(y), for p > 0. With p = 2 and g(u) = e^{-u} u^{1/2} this is the substitution u = x² that turns Euler's Gamma integral into the half-line Gaussian second moment. The same lemma underlies Mathlib's proof of Γ(1/2) = √π.",
+        "module": "Mathlib.MeasureTheory.Integral.IntegralEqImproper"
+      },
+      {
+        "theorem": "Real.Gamma_eq_integral",
+        "description": "Euler's integral Γ(s) = ∫_{x in Ioi 0} e^{-x} · x^{s-1} for s > 0. At s = 3/2 the exponent is x^{1/2}, the form the substitution acts on.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "The functional equation Γ(s+1) = s·Γ(s) for s ≠ 0. At s = 1/2 it reduces Γ(3/2) to ½·Γ(1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "The Gaussian special value Γ(1/2) = √π. Combined with the functional equation it gives Γ(3/2) = √π/2.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_ℝ e^{-x²} dx = √π and its weighted moments ∫_ℝ x^{2n} e^{-x²} dx are, through the substitution x² = t, the half-integer values of Euler's Gamma function: ∫_0^∞ x^{s-1} e^{-x} dx = Γ(s). This change of variables — the same one Euler used to interpolate the factorial — is what unifies the probabilistic Gaussian moments with the analytic special-function table. The value Γ(3/2) = √π/2 is the first non-trivial half-integer Gamma value; it equals the full-line second moment of the standard Gaussian and is half the value ½·Γ(3/2) = √π/4 of the half-line moment. This entry makes the substitution explicit in Lean, formalizing the bridge between the parent's elementary integration-by-parts evaluation of the second moment and its incarnation as a Gamma value.",
+    "problemStatement": "Recover the parent's Gaussian second moment ∫_{-∞}^{∞} x² e^{-x²} dx = √π/2 as a value of Euler's Gamma function via the substitution u = x². Concretely: prove that the half-line moment ∫_{x>0} x² e^{-x²} equals ½·Γ(3/2), that Γ(3/2) = √π/2, and that the full-line moment equals Γ(3/2).",
+    "proofStrategy": "Two independent strands meet. (1) Special value: Γ(3/2) = Γ(1/2 + 1) = ½·Γ(1/2) = ½·√π by the functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) and Γ(1/2) = √π (Real.Gamma_one_half_eq) — this is gamma_three_half. (2) Substitution bridge: Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} (Real.Gamma_eq_integral) is transported by the change of variables u = x² (integral_comp_rpow_Ioi_of_pos with p = 2). The Jacobian contributes 2x and the half-power simplifies as (x²)^{1/2} = x for x > 0 (Real.rpow_mul / Real.rpow_natCast), so the integrand becomes 2·x²·e^{-x²}; matching the constant 2 across the equality gives ∫_{x>0} x² e^{-x²} = Γ(3/2)/2 (gaussian_second_moment_Ioi). Finally, rewriting the parent's full-line value √π/2 against gamma_three_half identifies it with Γ(3/2) (gaussian_second_moment_eq_gamma), and the explicit half-line value √π/4 follows (gaussian_second_moment_Ioi_eq).",
+    "keyInsights": [
+      "The substitution u = x² is the canonical bridge from a Gaussian integral to a Gamma integral. Mathlib already exploits exactly this change of variables (integral_comp_rpow_Ioi_of_pos, p = 2) to prove Γ(1/2) = √π from the Gaussian integral; this entry runs the same machinery one moment higher to reach Γ(3/2).",
+      "The half-power dissolves on the half-line. The Gamma integrand at s = 3/2 carries u^{1/2}; under u = x² it becomes (x²)^{1/2} = x for x > 0, and combined with the Jacobian 2x produces precisely the x² weight of the Gaussian second moment — the reason the substitution lands cleanly on the moment.",
+      "The factor of two distinguishes the two moments. The substitution naturally yields the half-line moment ∫_{x>0} x² e^{-x²} = ½·Γ(3/2) = √π/4; the full-line moment, twice as large by even symmetry, is Γ(3/2) = √π/2 — the parent's headline value. Keeping the two straight resolves the apparent '√π/2 = ½·Γ(3/2)' tension in the question (the correct reading is full-line = Γ(3/2), half-line = ½·Γ(3/2)).",
+      "Two routes to √π/2 cross-check each other. The parent reaches √π/2 by integration by parts on the whole line; this entry reaches it as the special value Γ(3/2). Their agreement (gaussian_second_moment_eq_gamma) is a consistency check linking an elementary analytic computation to a special-function evaluation.",
+      "Honest 'mathlib' badge: every ingredient — Euler's integral, the change-of-variables lemma, the Gamma functional equation, Γ(1/2) = √π — is Mathlib; the original content is the assembly that ties the Gaussian second moment to Γ(3/2). The proof is 0-axiom (propext / Classical.choice / Quot.sound only)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Open Question and Strategy",
+      "startLine": 6,
+      "endLine": 64,
+      "summary": "States the open question — recover √π/2 as Γ(3/2) via u = x² — and outlines the answer: the substitution bridge turning Euler's Γ(3/2) integral into twice the half-line Gaussian moment, the special value Γ(3/2) = √π/2 from the functional equation, and the identification of the full-line moment with Γ(3/2). Clarifies the half-line (½·Γ(3/2) = √π/4) versus full-line (Γ(3/2) = √π/2) factor of two.",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\Gamma\\!\\left(\\tfrac32\\right) = \\tfrac{\\sqrt\\pi}{2}$"
+    },
+    {
+      "id": "special-value",
+      "title": "Part I: The Special Value Γ(3/2) = √π/2",
+      "startLine": 71,
+      "endLine": 79,
+      "summary": "theorem gamma_three_half: Γ(3/2) = √π/2. Writes 3/2 = 1/2 + 1, applies the functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) at s = 1/2 to get ½·Γ(1/2), substitutes Γ(1/2) = √π (Real.Gamma_one_half_eq), and finishes with ring.",
+      "mathContext": "$\\Gamma\\!\\left(\\tfrac32\\right) = \\tfrac12\\,\\Gamma\\!\\left(\\tfrac12\\right) = \\tfrac{\\sqrt\\pi}{2}$"
+    },
+    {
+      "id": "substitution",
+      "title": "Part II: The Substitution u = x²",
+      "startLine": 81,
+      "endLine": 114,
+      "summary": "theorem gaussian_second_moment_Ioi: ∫_{x>0} x² e^{-x²} = Γ(3/2)/2. Rewrites Γ(3/2) as Euler's integral (Real.Gamma_eq_integral), applies the change of variables u = x² (integral_comp_rpow_Ioi_of_pos, p = 2), and reduces both sides to ∫_{x>0} 2·(x² e^{-x²}) by a pointwise computation: the Jacobian factor 2·x^{2-1} = 2x, the simplification (x²)^{1/2} = x via Real.rpow_mul, and x^{(2:ℝ)} = x² via Real.rpow_natCast, closed by ring.",
+      "mathContext": "$\\Gamma\\!\\left(\\tfrac32\\right) = 2\\int_0^\\infty x^2 e^{-x^2}\\,dx$"
+    },
+    {
+      "id": "full-line",
+      "title": "Part III: The Full-Line Moment is Γ(3/2)",
+      "startLine": 116,
+      "endLine": 130,
+      "summary": "theorem gaussian_second_moment_eq_gamma: ∫_ℝ x² e^{-x²} = Γ(3/2), rewriting the parent's value √π/2 (AreaOfCircleOQ07OQ05.gaussian_second_moment) against gamma_three_half. theorem gaussian_second_moment_Ioi_eq: the explicit half-line value ∫_{x>0} x² e^{-x²} = √π/4, i.e. ½·Γ(3/2).",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2} = \\Gamma\\!\\left(\\tfrac32\\right),\\quad \\int_0^\\infty x^2 e^{-x^2} = \\tfrac{\\sqrt\\pi}{4}$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's Gaussian second moment is identified with a value of Euler's Gamma function. The substitution u = x² (Mathlib's integral_comp_rpow_Ioi_of_pos, p = 2) transports Euler's integral Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2} to twice the half-line Gaussian moment, giving ∫_{x>0} x² e^{-x²} = Γ(3/2)/2 = √π/4 (gaussian_second_moment_Ioi, gaussian_second_moment_Ioi_eq). The special value Γ(3/2) = √π/2 follows from Γ(s+1) = s·Γ(s) and Γ(1/2) = √π (gamma_three_half), and the full-line moment is Γ(3/2) (gaussian_second_moment_eq_gamma), reproducing the parent's √π/2 as a Gamma value. 131 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This closes the loop the parent's open question posed: the second moment √π/2, computed there by integration by parts, is exactly the half-integer Gamma value Γ(3/2), reached here through the canonical Gaussian-to-Gamma substitution u = x². It complements sibling oq-05-oq-01, which identifies the general even moment ∫ x^{2n} e^{-x²} with Γ(n+1/2): this entry is the n = 1 case made explicit through the substitution rather than through the double-factorial recursion, exhibiting the change of variables that the general identification leaves implicit.",
+    "openQuestions": [
+      "Run the same substitution u = x² on the scaled half-line integral ∫_{x>0} x^{2n} e^{-a x²} to derive ∫_{x>0} x^{2n} e^{-a x²} = Γ(n+1/2)/(2 a^{n+1/2}) for a > 0, tracking how the Jacobian and the power a^{n+1/2} emerge from the change of variables.",
+      "Use the substitution route to give a second, change-of-variables proof of the half-integer Gamma values Γ(n+1/2) = (2n-1)‼·√π/2ⁿ, complementing the gamma identification in sibling oq-05-oq-01 that goes through the double-factorial recursion."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-05",
+      "relationship": "extends",
+      "description": "Parent. Its full-line second moment ∫_ℝ x² e^{-x²} = √π/2 is the value this entry re-derives as Γ(3/2); the parent's gaussian_second_moment is reused directly in gaussian_second_moment_eq_gamma."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Sibling. It identifies the general even moment ∫ x^{2n} e^{-x²} with Γ(n+1/2) via the double-factorial recursion; this entry is the n = 1 case reached instead through the explicit substitution u = x²."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "related",
+      "description": "Grandparent. The zeroth moment ∫_ℝ e^{-x²} = √π is, by the same u = x² substitution, the special value Γ(1/2) = √π that anchors Γ(3/2) = ½·Γ(1/2)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_one_half_eq (Γ(1/2) = √π) and the substitution proof pattern integral_comp_rpow_Ioi_of_pos that this entry reuses one moment higher."
+    },
+    {
+      "title": "Special Functions",
+      "author": "George E. Andrews, Richard Askey, and Ranjan Roy",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "description": "Standard reference for Euler's Gamma integral, the functional equation Γ(s+1) = s·Γ(s), and the half-integer values Γ(n+1/2) that this entry connects to the Gaussian moments."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the parent open question of **area-of-circle-oq-07-oq-05**: *recover the Gaussian second moment √π/2 as a Gamma value via the substitution u = x².*

The parent evaluated the full-line second moment `∫_ℝ x² e^{-x²} = √π/2` by integration by parts. This entry re-derives that value through Euler's Gamma function, making the canonical Gaussian-to-Gamma substitution explicit in Lean.

## Results (4 theorems, 0 axioms, 0 sorries)

- **`gaussian_second_moment_Ioi`** — *the substitution bridge*: `∫_{x>0} x² e^{-x²} = Γ(3/2)/2`. Euler's integral `Γ(3/2) = ∫_{u>0} e^{-u} u^{1/2}` is transported under `u = x²` via Mathlib's `integral_comp_rpow_Ioi_of_pos` (p = 2) — the very lemma Mathlib uses for `Γ(1/2) = √π`. The Jacobian `2x` and `(x²)^{1/2} = x` turn the integrand into `2x² e^{-x²}`.
- **`gamma_three_half`** — the special value `Γ(3/2) = √π/2`, from `Γ(s+1) = s·Γ(s)` and `Γ(1/2) = √π`.
- **`gaussian_second_moment_eq_gamma`** — the parent's full-line moment is `Γ(3/2)`, reproducing `√π/2` as a Gamma value (reuses the parent's `gaussian_second_moment`).
- **`gaussian_second_moment_Ioi_eq`** — the explicit half-line value `√π/4 = ½·Γ(3/2)`.

## On the factor of two

The parent's open question phrased this as "√π/2 = ½·Γ(3/2)", conflating the two moments. The correct readings, both proved here: the **half-line** moment is `½·Γ(3/2) = √π/4`; the **full-line** moment (the parent's headline value) is its double, `Γ(3/2) = √π/2`.

## Verification

`#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Badge **mathlib** (the analytic engine is entirely Mathlib; the original content is the assembly bridging the Gaussian second moment to `Γ(3/2)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)