### PR TITLE
Enrich A Genuine Multi-Dimensional Fourier Coefficient on the n-Torus

### DIFF
--- a/src/data/proofs/fourier-series-oq-04-wip-01/annotations.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01/annotations.json
@@ -1,25 +1,78 @@
 [
   {
+    "id": "ann-model",
+    "proofId": "fourier-series-oq-04-wip-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 47
+    },
+    "type": "definition",
+    "title": "Modelling the n-Torus and Its Dual Lattice",
+    "content": "The torus is modelled as Torus n = Fin n → AddCircle (1:ℝ), a finite product of unit circles ℝ/ℤ, and the index set as MultiIndex n = Fin n → ℤ, the dual lattice ℤⁿ. This product-type choice is the crux of OQ-04: it lets Mathlib's automatically-derived product measure serve as the Haar measure, and it makes every n-dimensional object a coordinatewise lift of a one-dimensional one. Pontryagin duality is visible already in the types — the character group of Tⁿ is exactly ℤⁿ, the index of the multi-indices k.",
+    "mathContext": "$\\mathbb{T}^n = (\\mathbb{R}/\\mathbb{Z})^n$, with dual lattice $\\widehat{\\mathbb{T}^n} \\cong \\mathbb{Z}^n$ via $k \\mapsto (x \\mapsto e^{2\\pi i\\, k\\cdot x})$.",
+    "significance": "context",
+    "relatedConcepts": ["n-torus", "Pontryagin duality", "product measure", "character lattice"],
+    "prerequisites": ["quotient groups ℝ/ℤ", "finite product types", "Haar measure on compact groups"]
+  },
+  {
     "id": "ann-genuine-def",
     "proofId": "fourier-series-oq-04-wip-01",
     "range": {
       "startLine": 49,
-      "endLine": 64
+      "endLine": 59
     },
     "type": "insight",
     "title": "Replacing the Placeholder with a Real Definition",
-    "content": "The parent scaffold defined fourierCoeff := 0 — a literal placeholder, so every downstream statement was vacuous. Here torusChar k x = ∏ᵢ fourier(kᵢ)(xᵢ) is the actual n-dimensional Fourier kernel, built from Mathlib's one-dimensional character fourier : ℤ → C(AddCircle T, ℂ), and fourierCoeffND f k = ∫ f(x)·conj(e_k(x)) dHaar is a genuine Bochner integral over the product torus Fin n → AddCircle (1:ℝ). The default volume on this product type is exactly the product Haar measure the OQ requested (for T = 1 the circle's Haar measure coincides with volume)."
+    "content": "The parent scaffold defined fourierCoeff := 0 — a literal placeholder, so every downstream statement was vacuous. Here torusChar k x = ∏ᵢ fourier(kᵢ)(xᵢ) is the actual n-dimensional Fourier kernel, built from Mathlib's one-dimensional character fourier : ℤ → C(AddCircle T, ℂ), and fourierCoeffND f k = ∫ f(x)·conj(e_k(x)) dHaar is a genuine Bochner integral over the product torus Fin n → AddCircle (1:ℝ). The default volume on this product type is exactly the product Haar measure the OQ requested (for T = 1 the circle's Haar measure coincides with volume). Replacing := 0 with a real definition is the substantive step: only now does any statement about the scaffold carry mathematical content.",
+    "mathContext": "$e_k(x) = \\prod_{i} e^{2\\pi i\\, k_i x_i}$,  $\\hat f(k) = \\int_{\\mathbb{T}^n} f(x)\\,\\overline{e_k(x)}\\,d\\mathrm{Haar}(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Fourier coefficient", "Bochner integral", "character", "product Haar measure"],
+    "prerequisites": ["Bochner integration", "complex conjugation", "AddCircle Fourier character"]
   },
   {
-    "id": "ann-coordinatewise",
+    "id": "ann-norm-fourier",
+    "proofId": "fourier-series-oq-04-wip-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 64
+    },
+    "type": "technique",
+    "title": "The One-Dimensional Building Block: Unimodularity",
+    "content": "norm_fourier_apply proves ‖fourier n x‖ = 1 — each 1D character takes values on the unit circle. The proof unfolds fourier_apply (which exhibits the value as a Circle element coerced into ℂ) and applies Circle.norm_coe. This single lemma is the atom from which the n-dimensional unimodularity norm_torusChar is assembled: a product of unit-modulus factors has modulus 1. Working through the Circle type rather than computing e^{2πiθ} directly keeps the argument algebraic and avoids any analysis.",
+    "mathContext": "$\\|e^{2\\pi i n x}\\| = 1$ for all $x$, since $e^{2\\pi i n x} \\in S^1 \\subset \\mathbb{C}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["unit circle", "unimodular", "complex norm", "Circle type"],
+    "prerequisites": ["complex modulus", "Mathlib Circle / AddCircle API"]
+  },
+  {
+    "id": "ann-char-homomorphism",
     "proofId": "fourier-series-oq-04-wip-01",
     "range": {
       "startLine": 66,
-      "endLine": 106
+      "endLine": 90
     },
     "type": "insight",
-    "title": "All Structure Descends Coordinatewise from the 1D Character",
-    "content": "Because e_k is a finite product ∏ᵢ fourier(kᵢ)(xᵢ), each character law is a product of the corresponding 1D law: e_0 = ∏ fourier 0 = ∏ 1 = 1 (fourier_zero, prod_eq_one); e_{j+k} = ∏ fourier(jᵢ+kᵢ) = ∏ (fourier jᵢ · fourier kᵢ) = e_j·e_k (fourier_add + prod_mul_distrib); e_{-k} = ∏ fourier(-kᵢ) = ∏ conj(fourier kᵢ) = conj(∏…) (fourier_neg + map_prod, conj a ring hom); ‖e_k‖ = ∏ ‖fourier kᵢ‖ = 1 (Circle.norm_coe). torusCharHom then packages e as a monoid homomorphism Multiplicative (ℤⁿ) →* ℂ — the abstract statement that the Fourier kernel is a unimodular character of the group ℤⁿ."
+    "title": "Character Laws Descend Coordinatewise from 1D",
+    "content": "Because e_k is the finite product ∏ᵢ fourier(kᵢ)(xᵢ), each homomorphism law is the product of the corresponding 1D law: torusChar_zero gives e_0 = ∏ fourier 0 = ∏ 1 = 1 (fourier_zero + Finset.prod_eq_one); torusChar_add gives e_{j+k} = ∏ fourier(jᵢ+kᵢ) = ∏ (fourier jᵢ · fourier kᵢ) = e_j·e_k (fourier_add + prod_mul_distrib); torusChar_neg gives e_{-k} = ∏ fourier(-kᵢ) = ∏ conj(fourier kᵢ) = conj(∏…) (fourier_neg + map_prod, since conj is a ring homomorphism commuting with finite products). No analysis appears beyond the AddCircle character facts — the entire group structure is formal.",
+    "mathContext": "$e_0 \\equiv 1$,  $e_{j+k} = e_j\\,e_k$,  $e_{-k} = \\overline{e_k}$ — i.e. $k \\mapsto e_k(x)$ is a group homomorphism $(\\mathbb{Z}^n,+) \\to (\\mathbb{C}^\\times,\\cdot)$.",
+    "significance": "key",
+    "relatedConcepts": ["group homomorphism", "character", "Finset.prod", "complex conjugation"],
+    "prerequisites": ["homomorphism laws of fourier", "finite products in a commutative monoid", "ring homomorphisms preserve products"]
+  },
+  {
+    "id": "ann-unimodular-hom",
+    "proofId": "fourier-series-oq-04-wip-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 106
+    },
+    "type": "concept",
+    "title": "Unimodularity and Packaging as a Monoid Homomorphism",
+    "content": "norm_torusChar lifts unimodularity to n dimensions: ‖e_k(x)‖ = ∏ᵢ ‖fourier(kᵢ)(xᵢ)‖ = ∏ 1 = 1 (norm_prod + norm_fourier_apply). torusCharHom then bundles torusChar_zero (as map_one') and torusChar_add (as map_mul') into a bona fide bundled morphism Multiplicative (ℤⁿ) →* ℂ. The Multiplicative wrapper converts the additive group ℤⁿ into a multiplicative one so the additive character law e_{j+k}=e_j·e_k becomes the multiplicative map_mul' Mathlib's MonoidHom expects. This is the abstract assertion that the Fourier kernel is a unitary character of the discrete group ℤⁿ.",
+    "mathContext": "$\\|e_k(x)\\| = 1$ and $e_{(\\cdot)}(x) \\in \\mathrm{Hom}\\big(\\mathrm{Multiplicative}(\\mathbb{Z}^n),\\,\\mathbb{C}^\\times\\big)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["MonoidHom", "Multiplicative", "unitary character", "Pontryagin dual"],
+    "prerequisites": ["bundled morphisms in Mathlib", "Multiplicative / Additive type synonyms", "norm of a finite product"]
   },
   {
     "id": "ann-linearity",
@@ -30,6 +83,10 @@
     },
     "type": "concept",
     "title": "Linearity of the Genuine Coefficient",
-    "content": "fourierCoeffND_const_mul shows (c·f)̂(k) = c·f̂(k): pulling the constant c out of the Bochner integral via integral_const_mul (which needs no integrability hypothesis, since both sides vanish in the non-integrable case). fourierCoeffND_zero_fun records f̂(k) = 0 for the zero function. These are the first structural properties exhibiting f̂ as a linear functional of f — the foundation on which Parseval/Plancherel and the L²-convergence theory would build."
+    "content": "fourierCoeffND_const_mul shows (c·f)̂(k) = c·f̂(k): pulling the constant c out of the Bochner integral via integral_const_mul (which needs no integrability hypothesis, since both sides vanish in the non-integrable case), then matching integrands almost everywhere with integral_congr_ae and ring. fourierCoeffND_zero_fun records f̂(k) = 0 for the zero function. Together these exhibit f̂ as (the start of) a linear functional of f — the structural foothold on which Parseval/Plancherel and the L²-convergence theory would build.",
+    "mathContext": "$\\widehat{(cf)}(k) = c\\,\\hat f(k)$ and $\\hat 0(k) = 0$; linearity of $f \\mapsto \\hat f(k) = \\int f\\,\\overline{e_k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["linear functional", "integral linearity", "Parseval's identity", "Bochner integral"],
+    "prerequisites": ["linearity of the Bochner integral", "almost-everywhere equality", "MeasureTheory.integral_const_mul"]
   }
 ]

--- a/src/data/proofs/fourier-series-oq-04-wip-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-wip-01/meta.json
@@ -154,6 +154,16 @@
       "targetId": "fourier-series-oq-04",
       "relationship": "extends",
       "description": "Parent: multi-dimensional Fourier convergence scaffold whose fourierCoeff is a placeholder := 0. This entry implements that coefficient genuinely on Fin n → AddCircle (1:ℝ) with the product Haar measure, exactly the concrete path the parent's OQ-04 proposed."
+    },
+    {
+      "targetId": "fourier-series-oq-04-wip-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Child: proves the tensor characters e_k = ∏ᵢ fourier(kᵢ) defined here are orthonormal, ∫_{Tⁿ} e_j·conj(e_k) = δ_{j,k} — the next structural step toward Parseval/Plancherel on the n-torus, building directly on this entry's character and coefficient."
+    },
+    {
+      "targetId": "fourier-series",
+      "relationship": "related",
+      "description": "The classical one-dimensional theory: a periodic function as ∑ₙ f̂(n) e^{2πinx}. This entry is the n-dimensional generalisation, with the kernel assembled as a finite product of the 1D characters that underlie the classical case."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `fourier-series-oq-04-wip-01`.

## Quality improvements

**Annotations (3 → 6, all with structured fields).** Every annotation now carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` — none did before. New annotations were added for:
- the n-torus / dual-lattice modelling choice (Pontryagin duality visible in the types),
- the 1D unimodularity building block `norm_fourier_apply`,
- the `MonoidHom` packaging `torusCharHom` and n-dimensional unimodularity.

The existing definition, character-law, and linearity annotations were kept and tightened, and line ranges now partition the full Lean file (lines 43–121).

**Cross-references (1 → 3).** Added links to:
- `fourier-series-oq-04-wip-01-oq-01` (`extended-by`) — the child that proves the tensor characters defined here are orthonormal,
- `fourier-series` (`related`) — the classical 1D theory this generalises.

## Notes
- The prompt's `index.ts` step is obsolete: per-proof shims were removed in the build-perf phase-2 work (#20993). The runtime loader fetches `meta.json`/`annotations.json` by slug via the build-generated, gitignored `data-manifest.json`; 3457/3807 proof dirs have no `index.ts`. No shim was added.
- Axiom integrity unchanged and verified accurate: `status: verified`, `badge: original`, `axiomCount: 0` — the Lean file has 0 sorries, 0 axiom declarations, and no assumption-carrying structures (`#print axioms` reports only propext/Classical.choice/Quot.sound).
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)