### PR TITLE
research(bezout-identity-oq-03-oq-01-oq-02-oq-01): iterated CRT — k congruences solvable iff pairwise compatible, via a gcd-over-lcm distributivity lemma

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -374,6 +374,7 @@ import Proofs.BezoutIdentityOQ03OQ01OQ01
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ02
 import Proofs.BezoutIdentityOQ03OQ01OQ02
+import Proofs.BezoutIdentityOQ03OQ01OQ02OQ01
 import Proofs.BezoutIdentityOQ03OQ02
 import Proofs.BezoutIdentityOQ03OQ02OQ01
 import Proofs.BezoutIdentityOQ03OQ03

--- a/proofs/Proofs/BezoutIdentityOQ03OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ03OQ01OQ02OQ01.lean
@@ -1,0 +1,289 @@
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Data.Int.GCD
+import Proofs.BezoutIdentityOQ03OQ01OQ02
+import Mathlib.Tactic
+
+/-
+# Iterated CRT for k Congruences (bezout-identity-oq-03-oq-01-oq-02-oq-01)
+
+## Problem
+The parent (`bezout-identity-oq-03-oq-01-oq-02`) characterizes the image of
+ℤ → ℤ/mℤ × ℤ/nℤ for **two** non-coprime moduli: the system
+x ≡ a (mod m), x ≡ b (mod n) is solvable iff gcd(m,n) ∣ (a-b), with the solution
+unique mod lcm(m,n).
+
+This file generalizes to a **system of k congruences** x ≡ aᵢ (mod mᵢ):
+
+> The system is solvable **iff** it is *pairwise compatible*:
+>   gcd(mᵢ, mⱼ) ∣ (aᵢ - aⱼ)  for all i, j.
+> When solvable, the solution is **unique modulo lcm(m₁, …, mₖ)**.
+
+## Method
+The whole result reduces to ONE lemma that Mathlib does **not** provide: the
+distributivity of `gcd` over `lcm` on ℕ,
+  gcd(a, lcm(b,c)) = lcm(gcd(a,b), gcd(a,c)),
+proved here via prime factorizations (`min` distributes over `max`).
+Everything else is a clean induction on the list of congruences, reusing the
+parent's two-modulus merge (`gcd_dvd_implies_solvable`) and uniqueness
+(`crt_unique_mod_lcm`).
+
+The naive induction "merge the first two, recurse" needs exactly this
+distributivity: after merging the tail into a single congruence mod the running
+lcm L, compatibility of the head m₀ with L is
+  gcd(m₀, L) = gcd(m₀, lcm mᵢ) = lcm gcd(m₀, mᵢ),
+and each gcd(m₀, mᵢ) ∣ (a₀ - aᵢ), so their lcm divides it too.
+
+## Status
+- All theorems proved (0 sorries, 0 axioms).
+-/
+
+namespace IteratedCRT
+
+open NonCoprimeCRT
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: gcd DISTRIBUTES OVER lcm  (the Mathlib gap)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **gcd/lcm distributivity on ℕ** (not in Mathlib). For nonzero a, b, c,
+    `gcd a (lcm b c) = lcm (gcd a b) (gcd a c)`.
+    Proof: compare prime-exponent vectors; `min` distributes over `max`. -/
+theorem nat_gcd_lcm_distrib {a b c : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) :
+    Nat.gcd a (Nat.lcm b c) = Nat.lcm (Nat.gcd a b) (Nat.gcd a c) := by
+  have hbc : Nat.lcm b c ≠ 0 := Nat.lcm_ne_zero hb hc
+  have hab : Nat.gcd a b ≠ 0 := fun h => ha (Nat.eq_zero_of_gcd_eq_zero_left h)
+  have hac : Nat.gcd a c ≠ 0 := fun h => ha (Nat.eq_zero_of_gcd_eq_zero_left h)
+  have hL : Nat.gcd a (Nat.lcm b c) ≠ 0 := fun h => ha (Nat.eq_zero_of_gcd_eq_zero_left h)
+  have hR : Nat.lcm (Nat.gcd a b) (Nat.gcd a c) ≠ 0 := Nat.lcm_ne_zero hab hac
+  apply Nat.eq_of_factorization_eq hL hR
+  intro p
+  rw [Nat.factorization_gcd ha hbc, Nat.factorization_lcm hb hc,
+      Nat.factorization_lcm hab hac, Nat.factorization_gcd ha hb, Nat.factorization_gcd ha hc]
+  simp only [Finsupp.inf_apply, Finsupp.sup_apply]
+  exact inf_sup_left _ _ _
+
+/-- **Int version of distributivity**: `gcd a (lcm b c) = lcm (gcd a b) (gcd a c)`
+    as natural numbers, where the inner `lcm b c` is taken in ℤ. -/
+theorem int_gcd_lcm_distrib {a b c : ℤ} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) :
+    Int.gcd a (Int.lcm b c : ℤ) = Nat.lcm (Int.gcd a b) (Int.gcd a c) := by
+  have hna : a.natAbs ≠ 0 := Int.natAbs_ne_zero.mpr ha
+  have hnb : b.natAbs ≠ 0 := Int.natAbs_ne_zero.mpr hb
+  have hnc : c.natAbs ≠ 0 := Int.natAbs_ne_zero.mpr hc
+  unfold Int.gcd Int.lcm
+  simp only [Int.natAbs_natCast]
+  exact nat_gcd_lcm_distrib hna hnb hnc
+
+/-- If `(u:ℤ) ∣ d` and `(v:ℤ) ∣ d` then `(lcm u v : ℤ) ∣ d`. -/
+theorem int_natLcm_dvd {u v : ℕ} {d : ℤ} (hu : (u : ℤ) ∣ d) (hv : (v : ℤ) ∣ d) :
+    (Nat.lcm u v : ℤ) ∣ d := by
+  rw [Int.natCast_dvd] at *
+  exact Nat.lcm_dvd hu hv
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: lcm OF A LIST OF MODULI
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The lcm of all the moduli appearing in a list of congruences `(aᵢ, mᵢ)`. -/
+def lcmList : List (ℤ × ℤ) → ℤ
+  | [] => 1
+  | p :: ps => (Int.lcm p.2 (lcmList ps) : ℤ)
+
+@[simp] theorem lcmList_nil : lcmList [] = 1 := rfl
+
+theorem lcmList_cons (p : ℤ × ℤ) (ps : List (ℤ × ℤ)) :
+    lcmList (p :: ps) = (Int.lcm p.2 (lcmList ps) : ℤ) := rfl
+
+/-- The list lcm is nonzero when all moduli are nonzero. -/
+theorem lcmList_ne_zero {l : List (ℤ × ℤ)} (hl : ∀ p ∈ l, p.2 ≠ 0) : lcmList l ≠ 0 := by
+  induction l with
+  | nil => simp
+  | cons p ps ih =>
+    rw [lcmList_cons]
+    have hp : p.2 ≠ 0 := hl p (List.mem_cons_self)
+    have hps : lcmList ps ≠ 0 := ih (fun q hq => hl q (List.mem_cons_of_mem _ hq))
+    have : Int.lcm p.2 (lcmList ps) ≠ 0 := by
+      rw [Int.lcm_def]
+      exact Nat.lcm_ne_zero (Int.natAbs_ne_zero.mpr hp) (Int.natAbs_ne_zero.mpr hps)
+    exact_mod_cast this
+
+/-- Each modulus divides the list lcm. -/
+theorem dvd_lcmList {l : List (ℤ × ℤ)} {p : ℤ × ℤ} (hp : p ∈ l) : p.2 ∣ lcmList l := by
+  induction l with
+  | nil => exact absurd hp List.not_mem_nil
+  | cons q qs ih =>
+    rw [lcmList_cons]
+    rcases List.mem_cons.mp hp with h | h
+    · -- p = q : q.2 ∣ lcm q.2 (lcmList qs)
+      subst h
+      rw [Int.lcm_def, ← Int.natAbs_dvd, Int.natCast_dvd_natCast]
+      exact Nat.dvd_lcm_left _ _
+    · -- p ∈ qs : p.2 ∣ lcmList qs ∣ lcm q.2 (lcmList qs)
+      refine dvd_trans (ih h) ?_
+      rw [Int.lcm_def]
+      rw [show ((Nat.lcm q.2.natAbs (lcmList qs).natAbs : ℕ) : ℤ)
+            = (Int.lcm q.2 (lcmList qs) : ℤ) from by rw [Int.lcm_def]]
+      have : lcmList qs ∣ (Int.lcm q.2 (lcmList qs) : ℤ) := by
+        rw [Int.lcm_def, ← Int.natAbs_dvd, Int.natCast_dvd_natCast]
+        exact Nat.dvd_lcm_right _ _
+      simpa [Int.lcm_def] using this
+
+/-- **Key divisibility step.** If each `gcd(m₀, mᵢ)` divides `d`, then so does
+    `gcd(m₀, lcm mᵢ)`. This is where distributivity is used. -/
+theorem gcd_lcmList_dvd (m₀ : ℤ) (hm₀ : m₀ ≠ 0) :
+    ∀ (l : List (ℤ × ℤ)), (∀ p ∈ l, p.2 ≠ 0) → ∀ {d : ℤ},
+      (∀ p ∈ l, (Int.gcd m₀ p.2 : ℤ) ∣ d) → (Int.gcd m₀ (lcmList l) : ℤ) ∣ d := by
+  intro l
+  induction l with
+  | nil =>
+    intro _ d _
+    simp only [lcmList_nil]
+    have : Int.gcd m₀ (1 : ℤ) = 1 := by simp [Int.gcd]
+    rw [this]; simp
+  | cons p ps ih =>
+    intro hl d h
+    have hp : p.2 ≠ 0 := hl p (List.mem_cons_self)
+    have hps_ne : ∀ q ∈ ps, q.2 ≠ 0 := fun q hq => hl q (List.mem_cons_of_mem _ hq)
+    have hLps : lcmList ps ≠ 0 := lcmList_ne_zero hps_ne
+    rw [lcmList_cons, int_gcd_lcm_distrib hm₀ hp hLps]
+    apply int_natLcm_dvd
+    · exact h p (List.mem_cons_self)
+    · exact ih hps_ne (fun q hq => h q (List.mem_cons_of_mem _ hq))
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: THE SYSTEM AND ITS SOLVABILITY
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- `x` solves the system `l` of congruences `(aᵢ, mᵢ)`: `x ≡ aᵢ (mod mᵢ)` for all i. -/
+def CongSolves (x : ℤ) (l : List (ℤ × ℤ)) : Prop :=
+  ∀ p ∈ l, x ≡ p.1 [ZMOD p.2]
+
+/-- The system `l` is **pairwise compatible**: `gcd(mᵢ, mⱼ) ∣ (aᵢ - aⱼ)` for all i, j. -/
+def Compatible (l : List (ℤ × ℤ)) : Prop :=
+  ∀ p ∈ l, ∀ q ∈ l, (Int.gcd p.2 q.2 : ℤ) ∣ (p.1 - q.1)
+
+/-- **Necessity**: any common solution forces pairwise compatibility.
+    (Holds for *all* moduli, no nonzero hypothesis needed.) -/
+theorem compatible_of_solves {x : ℤ} {l : List (ℤ × ℤ)} (hx : CongSolves x l) :
+    Compatible l := by
+  intro p hp q hq
+  exact solvable_implies_gcd_dvd p.2 q.2 p.1 q.1 x (hx p hp) (hx q hq)
+
+/-- **Sufficiency (existence)**: a pairwise-compatible system with nonzero moduli
+    has a common solution. Proved by induction, merging the head congruence with
+    the inductively-built solution of the tail via the parent's two-modulus CRT. -/
+theorem solves_of_compatible :
+    ∀ (l : List (ℤ × ℤ)), (∀ p ∈ l, p.2 ≠ 0) → Compatible l → ∃ x, CongSolves x l := by
+  intro l
+  induction l with
+  | nil =>
+    intro _ _
+    exact ⟨0, by intro p hp; exact absurd hp List.not_mem_nil⟩
+  | cons p ps ih =>
+    intro hl hcompat
+    have hp : p.2 ≠ 0 := hl p (List.mem_cons_self)
+    have hps_ne : ∀ q ∈ ps, q.2 ≠ 0 := fun q hq => hl q (List.mem_cons_of_mem _ hq)
+    -- compatibility restricts to the tail
+    have hcompat_ps : Compatible ps := by
+      intro a ha b hb
+      exact hcompat a (List.mem_cons_of_mem _ ha) b (List.mem_cons_of_mem _ hb)
+    obtain ⟨Y, hY⟩ := ih hps_ne hcompat_ps
+    -- need gcd(p.2, lcmList ps) ∣ (p.1 - Y)
+    have hdvd : (Int.gcd p.2 (lcmList ps) : ℤ) ∣ (p.1 - Y) := by
+      apply gcd_lcmList_dvd p.2 hp ps hps_ne
+      intro q hq
+      -- gcd(p.2, q.2) ∣ (p.1 - q.1) and ∣ (q.1 - Y), so ∣ (p.1 - Y)
+      have h1 : (Int.gcd p.2 q.2 : ℤ) ∣ (p.1 - q.1) :=
+        hcompat p (List.mem_cons_self) q (List.mem_cons_of_mem _ hq)
+      have hqY : q.2 ∣ (q.1 - Y) := by
+        have := hY q hq            -- Y ≡ q.1 [ZMOD q.2]
+        exact (Int.modEq_iff_dvd.mp this)
+      have h2 : (Int.gcd p.2 q.2 : ℤ) ∣ (q.1 - Y) :=
+        dvd_trans (Int.gcd_dvd_right p.2 q.2) hqY
+      have : p.1 - Y = (p.1 - q.1) + (q.1 - Y) := by ring
+      rw [this]; exact dvd_add h1 h2
+    -- merge head congruence with the tail solution mod lcmList ps
+    obtain ⟨x, hx_p, hx_L⟩ := gcd_dvd_implies_solvable p.2 (lcmList ps) p.1 Y hdvd
+    refine ⟨x, ?_⟩
+    intro r hr
+    rcases List.mem_cons.mp hr with h | h
+    · subst h; exact hx_p
+    · -- r ∈ ps : x ≡ Y (mod lcmList ps) and r.2 ∣ lcmList ps, and Y ≡ r.1 (mod r.2)
+      have hr2L : r.2 ∣ lcmList ps := dvd_lcmList h
+      have hxY : x ≡ Y [ZMOD r.2] := by
+        rw [Int.modEq_iff_dvd] at hx_L ⊢
+        exact dvd_trans hr2L hx_L
+      exact hxY.trans (hY r h)
+
+/-- **Generalized CRT — solvability criterion.**
+    A system of congruences with nonzero moduli is solvable **iff** it is
+    pairwise compatible. -/
+theorem solvable_iff_compatible (l : List (ℤ × ℤ)) (hl : ∀ p ∈ l, p.2 ≠ 0) :
+    (∃ x, CongSolves x l) ↔ Compatible l :=
+  ⟨fun ⟨_, hx⟩ => compatible_of_solves hx, solves_of_compatible l hl⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: UNIQUENESS MODULO THE LIST lcm
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Uniqueness**: any two solutions of the same system agree modulo
+    `lcm(m₁, …, mₖ)`. -/
+theorem solutions_unique_mod_lcmList {l : List (ℤ × ℤ)} {x y : ℤ}
+    (hx : CongSolves x l) (hy : CongSolves y l) :
+    x ≡ y [ZMOD lcmList l] := by
+  induction l with
+  | nil => simp only [lcmList_nil]; exact Int.modEq_one
+  | cons p ps ih =>
+    rw [lcmList_cons]
+    have hxp : x ≡ p.1 [ZMOD p.2] := hx p (List.mem_cons_self)
+    have hyp : y ≡ p.1 [ZMOD p.2] := hy p (List.mem_cons_self)
+    have hp : x ≡ y [ZMOD p.2] := hxp.trans hyp.symm
+    have hxps : CongSolves x ps := fun q hq => hx q (List.mem_cons_of_mem _ hq)
+    have hyps : CongSolves y ps := fun q hq => hy q (List.mem_cons_of_mem _ hq)
+    have hL : x ≡ y [ZMOD lcmList ps] := ih hxps hyps
+    exact crt_unique_mod_lcm p.2 (lcmList ps) x y hp hL
+
+/-- **Full generalized CRT**: existence + uniqueness modulo the list lcm. -/
+theorem iterated_crt_full (l : List (ℤ × ℤ)) (hl : ∀ p ∈ l, p.2 ≠ 0)
+    (hcompat : Compatible l) :
+    ∃ x, CongSolves x l ∧ ∀ y, CongSolves y l → x ≡ y [ZMOD lcmList l] := by
+  obtain ⟨x, hx⟩ := solves_of_compatible l hl hcompat
+  exact ⟨x, hx, fun y hy => solutions_unique_mod_lcmList hx hy⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART V: SANITY EXAMPLES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+section Examples
+
+/-- Three pairwise-coprime congruences x ≡ 2 (mod 3), x ≡ 3 (mod 5), x ≡ 2 (mod 7).
+    x = 23 is the classical Sun-Tzu solution. -/
+example : CongSolves 23 [(2, 3), (3, 5), (2, 7)] := by
+  intro p hp
+  fin_cases hp <;> decide
+
+/-- A non-coprime but compatible system: x ≡ 1 (mod 4), x ≡ 3 (mod 6), x ≡ 0 (mod 9).
+    gcd(4,6)=2 ∣ (1-3), gcd(4,9)=1 ∣ (1-0), gcd(6,9)=3 ∣ (3-0). x = 9 works. -/
+example : CongSolves 9 [(1, 4), (3, 6), (0, 9)] := by
+  intro p hp
+  fin_cases hp <;> decide
+
+/-- The distributivity lemma on a concrete instance: gcd(12, lcm(8,18)) = lcm(gcd 12 8, gcd 12 18). -/
+example : Nat.gcd 12 (Nat.lcm 8 18) = Nat.lcm (Nat.gcd 12 8) (Nat.gcd 12 18) := by decide
+
+end Examples
+
+#check @nat_gcd_lcm_distrib
+#check @int_gcd_lcm_distrib
+#check @gcd_lcmList_dvd
+#check @compatible_of_solves
+#check @solves_of_compatible
+#check @solvable_iff_compatible
+#check @solutions_unique_mod_lcmList
+#check @iterated_crt_full
+
+end IteratedCRT

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,157 @@
+[
+  {
+    "id": "ann-gcd-lcm-distrib",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 52, "endLine": 65 },
+    "type": "concept",
+    "title": "The Keystone: gcd Distributes over lcm (a Mathlib gap)",
+    "content": "nat_gcd_lcm_distrib proves gcd(a, lcm(b,c)) = lcm(gcd(a,b), gcd(a,c)) on ℕ — a lemma Mathlib does not provide. The proof compares the two numbers through their prime factorizations using Nat.eq_of_factorization_eq: a natural number is determined by its exponent vector. Nat.factorization_gcd rewrites a gcd's factorization as the pointwise infimum (min) of the factorizations, and Nat.factorization_lcm as the pointwise supremum (max). After Finsupp.inf_apply / sup_apply expose the scalar form, the goal becomes min(α, max(β,γ)) = max(min(α,β), min(α,γ)), which is exactly inf_sup_left — the distributive law of the linear order ℕ.",
+    "mathContext": "$\\gcd(a,\\operatorname{lcm}(b,c)) = \\operatorname{lcm}(\\gcd(a,b),\\gcd(a,c))$, equivalently $\\min(\\alpha,\\max(\\beta,\\gamma)) = \\max(\\min(\\alpha,\\beta),\\min(\\alpha,\\gamma))$ on each prime exponent.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.eq_of_factorization_eq",
+      "Nat.factorization_gcd",
+      "Nat.factorization_lcm",
+      "inf_sup_left",
+      "Finsupp.inf_apply"
+    ],
+    "prerequisites": [
+      "prime factorization as a Finsupp ℕ →₀ ℕ",
+      "distributive lattice law on a linear order",
+      "gcd = min and lcm = max on prime exponents"
+    ]
+  },
+  {
+    "id": "ann-int-lift",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 68, "endLine": 83 },
+    "type": "technique",
+    "title": "Lifting Distributivity to ℤ Moduli via natAbs",
+    "content": "int_gcd_lcm_distrib transfers the ℕ distributivity to integer moduli. Since Int.gcd and Int.lcm are defined through natAbs (Int.lcm_def: lcm i j = Nat.lcm i.natAbs j.natAbs), unfolding both and simplifying (↑n).natAbs = n with Int.natAbs_natCast reduces the integer statement to the natural one applied to the natAbs values, with the nonzero hypotheses carried across by Int.natAbs_ne_zero. The companion int_natLcm_dvd packages a small but essential fact: if (u:ℤ) and (v:ℤ) both divide d, so does (Nat.lcm u v : ℤ) — proved by pushing through Int.natCast_dvd to ℕ divisibility of d.natAbs and applying Nat.lcm_dvd.",
+    "mathContext": "$\\gcd_\\mathbb{Z}(a,\\operatorname{lcm}_\\mathbb{Z}(b,c)) = \\operatorname{lcm}_\\mathbb{N}(\\gcd(a,b),\\gcd(a,c))$ via $|\\cdot|$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Int.lcm_def",
+      "Int.natAbs_natCast",
+      "Int.natCast_dvd",
+      "Nat.lcm_dvd"
+    ],
+    "prerequisites": [
+      "ℤ gcd/lcm defined via natAbs",
+      "cast divisibility bridges between ℤ and ℕ"
+    ]
+  },
+  {
+    "id": "ann-lcmlist",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 89, "endLine": 130 },
+    "type": "definition",
+    "title": "The List lcm and Its Basic Properties",
+    "content": "lcmList folds Int.lcm over the moduli of a list of congruences, giving the modulus to which the simultaneous solution is unique. lcmList_ne_zero shows the fold stays nonzero when every modulus is nonzero (each lcm step preserves nonvanishing via Nat.lcm_ne_zero). dvd_lcmList shows every individual modulus divides the fold, by induction: the head divides the outer lcm (Nat.dvd_lcm_left), and any tail modulus divides lcmList of the tail and hence the outer lcm by transitivity (Nat.dvd_lcm_right). These two facts are what let a solution mod lcmList specialize back to each component congruence.",
+    "mathContext": "$\\operatorname{lcmList}(l) = \\operatorname{lcm}_i m_i$, with $m_i \\mid \\operatorname{lcmList}(l)$ for every $i$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.foldr",
+      "Nat.dvd_lcm_left",
+      "Nat.dvd_lcm_right",
+      "Nat.lcm_ne_zero"
+    ],
+    "prerequisites": [
+      "structural recursion over lists",
+      "lcm divisibility lattice"
+    ]
+  },
+  {
+    "id": "ann-gcd-lcmlist-dvd",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 134, "endLine": 155 },
+    "type": "key-step",
+    "title": "Promoting Distributivity to a List: the Divisibility Engine",
+    "content": "gcd_lcmList_dvd is where distributivity does its work for the existence proof. It shows that if gcd(m₀, mᵢ) divides d for every modulus mᵢ in the list, then gcd(m₀, lcm of all mᵢ) divides d. The induction step rewrites gcd(m₀, lcm(m_head, lcm rest)) as lcm(gcd(m₀,m_head), gcd(m₀, lcm rest)) via int_gcd_lcm_distrib, then int_natLcm_dvd combines the head divisibility (hypothesis) with the tail divisibility (induction hypothesis). This is exactly the statement gcd(a, lcm bᵢ) = lcm gcd(a,bᵢ), specialized to 'all of them divide d'.",
+    "mathContext": "$\\bigl(\\forall i,\\ \\gcd(m_0,m_i)\\mid d\\bigr) \\implies \\gcd(m_0,\\operatorname{lcm}_i m_i)\\mid d$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "int_gcd_lcm_distrib",
+      "int_natLcm_dvd",
+      "list induction"
+    ],
+    "prerequisites": [
+      "gcd/lcm distributivity",
+      "lcm of divisors divides the common multiple"
+    ]
+  },
+  {
+    "id": "ann-necessity",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 160, "endLine": 174 },
+    "type": "concept",
+    "title": "Necessity: A Common Solution Forces Pairwise Compatibility",
+    "content": "CongSolves x l asserts x solves every congruence; Compatible l is the symmetric predicate that every pair of congruences satisfies gcd(mᵢ,mⱼ) | (aᵢ-aⱼ). compatible_of_solves is the easy direction: applying the parent's two-modulus forward lemma solvable_implies_gcd_dvd to the single witness x and any pair (i,j) gives the required divisibility immediately. No nonzero hypothesis is needed here — compatibility is a genuine necessary condition for any moduli.",
+    "mathContext": "If $x\\equiv a_i\\ (m_i)$ for all $i$, then for any pair $\\gcd(m_i,m_j)\\mid (a_i-a_j)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "NonCoprimeCRT.solvable_implies_gcd_dvd",
+      "symmetric compatibility predicate"
+    ],
+    "prerequisites": [
+      "parent two-modulus forward direction"
+    ]
+  },
+  {
+    "id": "ann-sufficiency",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 177, "endLine": 221 },
+    "type": "key-step",
+    "title": "Sufficiency: Building a Solution by Iterated Merge",
+    "content": "solves_of_compatible is the hard direction, by induction on the list. Given a solution Y of the tail (valid modulo L = lcmList of the tail), the head congruence a₀ mod m₀ is merged with Y mod L using the parent's two-modulus gcd_dvd_implies_solvable. The merge condition gcd(m₀, L) | (a₀ - Y) is exactly what gcd_lcmList_dvd delivers: for each tail modulus mᵢ, gcd(m₀,mᵢ) divides both a₀-aᵢ (pairwise compatibility) and aᵢ-Y (since Y solves the tail), hence divides a₀-Y. The merged x then solves the head directly and every tail congruence because x ≡ Y mod L and each tail modulus divides L.",
+    "mathContext": "Merge $a_0\\ (m_0)$ with $Y\\ (L)$; solvable since $\\gcd(m_0,L)=\\operatorname{lcm}_i\\gcd(m_0,m_i)\\mid (a_0-Y)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "NonCoprimeCRT.gcd_dvd_implies_solvable",
+      "gcd_lcmList_dvd",
+      "Int.modEq_iff_dvd",
+      "induction on lists"
+    ],
+    "prerequisites": [
+      "parent two-modulus merge",
+      "list-level divisibility engine"
+    ]
+  },
+  {
+    "id": "ann-criterion",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 223, "endLine": 232 },
+    "type": "theorem",
+    "title": "Main Theorem: Solvable iff Pairwise Compatible",
+    "content": "solvable_iff_compatible assembles the two directions into the generalized CRT solvability criterion for k congruences with nonzero moduli: a common solution exists if and only if every pair of congruences is compatible, gcd(mᵢ,mⱼ) | (aᵢ-aⱼ). This is the working form of the Chinese Remainder Theorem used in computational number theory, now fully machine-checked for arbitrary non-coprime moduli.",
+    "mathContext": "$\\bigl(\\exists x,\\ \\forall i,\\ x\\equiv a_i\\ (m_i)\\bigr) \\iff \\bigl(\\forall i,j,\\ \\gcd(m_i,m_j)\\mid(a_i-a_j)\\bigr)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "compatible_of_solves",
+      "solves_of_compatible",
+      "Chinese Remainder Theorem"
+    ],
+    "prerequisites": [
+      "necessity and sufficiency directions"
+    ]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+    "range": { "startLine": 234, "endLine": 258 },
+    "type": "theorem",
+    "title": "Uniqueness Modulo the List lcm and the Full Theorem",
+    "content": "solutions_unique_mod_lcmList shows any two solutions of the same system agree modulo lcmList of the moduli, by iterating the parent's crt_unique_mod_lcm down the list: at each step two solutions agree modulo the head modulus and (by induction) modulo the tail lcm, hence modulo their lcm. iterated_crt_full then bundles existence and uniqueness: a pairwise-compatible system with nonzero moduli has a solution, unique modulo lcm(m₁,…,mₖ) — the complete iterated Chinese Remainder Theorem.",
+    "mathContext": "Two solutions agree mod $\\operatorname{lcm}(m_1,\\dots,m_k)$; existence + uniqueness packaged together.",
+    "significance": "important",
+    "relatedConcepts": [
+      "NonCoprimeCRT.crt_unique_mod_lcm",
+      "iterated_crt_full",
+      "uniqueness modulo lcm"
+    ],
+    "prerequisites": [
+      "parent two-modulus uniqueness",
+      "existence theorem"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,90 @@
+{
+  "id": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+  "slug": "bezout-identity-oq-03-oq-01-oq-02-oq-01",
+  "title": "Iterated CRT: Solvability of k Simultaneous Congruences",
+  "description": "Generalizes the parent's two-modulus non-coprime CRT to a system of k congruences x ≡ aᵢ (mod mᵢ). Proves the full solvability criterion — the system is solvable if and only if it is pairwise compatible, gcd(mᵢ,mⱼ) | (aᵢ-aⱼ) for all i,j — together with uniqueness of the solution modulo lcm(m₁,…,mₖ). The proof reduces the whole result to a single lemma absent from Mathlib: the distributivity of gcd over lcm on ℕ, gcd(a,lcm(b,c)) = lcm(gcd(a,b),gcd(a,c)), proved via prime factorizations. 13 theorems, 3 definitions, 0 axioms.",
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Sunzi's 3rd–5th century puzzle and Gauss's Disquisitiones Arithmeticae (1801) treat the Chinese Remainder Theorem for two and, implicitly, finitely many moduli. The pairwise-compatibility criterion for a system of k simultaneous congruences with arbitrary (non-coprime) moduli — solvable iff gcd(mᵢ,mⱼ) divides aᵢ-aⱼ for every pair — is the standard general form found in any modern number-theory text, but its mechanically verified proof is subtle: the naive 'merge two congruences and recurse' induction silently requires that gcd distributes over lcm, an identity Mathlib does not provide. This entry supplies that missing lattice law (gcd of a number with an lcm equals the lcm of the pairwise gcds) and uses it to drive the iterated merge, reusing the parent's two-modulus solvability and uniqueness theorems as the inductive step.",
+    "problemStatement": "Given k congruences x ≡ aᵢ (mod mᵢ) with nonzero moduli, determine exactly when a common solution exists, and to what modulus it is unique.",
+    "text": "The central theorem solvable_iff_compatible states: (∃ x, ∀ i, x ≡ aᵢ mod mᵢ) ↔ (∀ i j, gcd(mᵢ,mⱼ) | (aᵢ-aⱼ)). Necessity (compatible_of_solves) is immediate from the parent's two-modulus forward direction applied to each pair. Sufficiency (solves_of_compatible) is an induction on the list of congruences: assuming a solution Y of the tail (valid mod L = lcm of the tail moduli), the head congruence a₀ mod m₀ merges with Y mod L precisely when gcd(m₀,L) | (a₀-Y). Each pairwise gcd(m₀,mᵢ) divides a₀-Y (combining a₀≡aᵢ and Y≡aᵢ), and gcd(m₀,L) = gcd(m₀, lcm mᵢ) = lcm gcd(m₀,mᵢ) divides a₀-Y as the lcm of divisors. The parent's gcd_dvd_implies_solvable then produces the merged solution. Uniqueness (solutions_unique_mod_lcmList) iterates the parent's crt_unique_mod_lcm down the list. iterated_crt_full packages existence and uniqueness modulo the list lcm.",
+    "proofStrategy": "The keystone is nat_gcd_lcm_distrib: gcd(a,lcm(b,c)) = lcm(gcd(a,b),gcd(a,c)) on ℕ, proved by Nat.eq_of_factorization_eq — comparing prime-exponent vectors reduces it to min(α,max(β,γ)) = max(min(α,β),min(α,γ)), the distributive law of a linear order (inf_sup_left). int_gcd_lcm_distrib lifts it to ℤ moduli via natAbs. gcd_lcmList_dvd promotes the two-element law to a list by induction (each lcm step uses int_natLcm_dvd: two ℤ-divisors share their Nat.lcm as a divisor). The list machinery (lcmList, lcmList_ne_zero, dvd_lcmList) and the two existence/uniqueness inductions complete the result on top of the parent file, imported directly.",
+    "keyInsights": [
+      "The entire k-congruence theorem reduces to ONE lemma missing from Mathlib: gcd distributes over lcm, gcd(a,lcm(b,c)) = lcm(gcd(a,b),gcd(a,c)). Without it the pairwise-compatibility criterion cannot be proved by the natural induction — product-of-moduli is too coarse, only the lcm is fine enough, and reasoning about gcd-with-an-lcm forces distributivity.",
+      "Distributivity is proved at the level of prime-exponent vectors: gcd is pointwise min, lcm is pointwise max, and on a linear order min distributes over max (inf_sup_left). Nat.eq_of_factorization_eq turns the equality of two natural numbers into the equality of their factorizations, which Finsupp.inf_apply / sup_apply reduce to the scalar lattice identity.",
+      "The induction strengthens the merge: after collapsing the tail into a single residue Y modulo L = lcm of the tail, compatibility of the head with the WHOLE tail (a single gcd(m₀,L) condition) is recovered from the k-1 pairwise conditions gcd(m₀,mᵢ)|(a₀-Y) exactly because gcd(m₀,L) = lcm of those gcds.",
+      "Working with a List (ℤ × ℤ) of (residue, modulus) pairs and a symmetric 'all pairs compatible' predicate (rather than List.Pairwise) keeps both the necessity and sufficiency proofs free of ordering bookkeeping while still capturing the full pairwise criterion.",
+      "The result is built directly on the parent file by import: gcd_dvd_implies_solvable supplies the two-modulus merge and crt_unique_mod_lcm supplies the two-modulus uniqueness, so the iterated theorems are genuine extensions, not re-derivations."
+    ],
+    "prerequisites": [
+      "Parent two-modulus non-coprime CRT: NonCoprimeCRT.gcd_dvd_implies_solvable, crt_unique_mod_lcm, solvable_implies_gcd_dvd",
+      "Prime factorization of ℕ: Nat.factorization_gcd, Nat.factorization_lcm, Nat.eq_of_factorization_eq",
+      "Lattice distributivity: inf_sup_left; Finsupp.inf_apply / sup_apply",
+      "ℤ/ℕ divisibility bridges: Int.natCast_dvd, Int.lcm_def, Nat.lcm_dvd"
+    ]
+  },
+  "conclusion": {
+    "summary": "The k-congruence (iterated) CRT: a system x ≡ aᵢ (mod mᵢ) with nonzero moduli is solvable iff it is pairwise compatible (gcd(mᵢ,mⱼ) | aᵢ-aⱼ for all i,j), and the solution is unique modulo lcm(m₁,…,mₖ). The proof is reduced to a single new lemma — distributivity of gcd over lcm on ℕ, proved via prime factorizations — that fills a genuine Mathlib gap. 13 theorems, 0 axioms, 289 lines.",
+    "implications": "The pairwise-compatibility criterion is the working form of CRT used throughout computational number theory (modular algorithms, Hensel lifting, multi-modular arithmetic). The standalone gcd/lcm distributivity lemma is reusable wherever divisibility lattices appear.",
+    "openQuestions": [
+      "Package the system as a Finset/Fin-indexed family and connect to the ℤ → ∏ ℤ/mᵢℤ ring map, characterizing its image as the pairwise-compatible diagonal.",
+      "Derive an explicit computable solution for the k-congruence system by folding the parent's genCRTSolution, with a complexity bound."
+    ]
+  },
+  "leanFile": {
+    "namespace": "IteratedCRT",
+    "lineCount": 289,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/BezoutIdentityOQ03OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-03-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Two-modulus non-coprime CRT (solvability iff gcd | difference, uniqueness mod lcm) that this entry iterates to k congruences"
+    },
+    {
+      "targetId": "bezout-identity-oq-03",
+      "relationship": "related",
+      "description": "Coprime CRT via Bézout's identity — the classical special case where every pairwise gcd is 1, so all systems are solvable"
+    },
+    {
+      "targetId": "bezout-identity-oq-03-oq-01",
+      "relationship": "related",
+      "description": "CRT ring isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ — the algebraic structure underlying simultaneous-congruence solvability"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ03OQ01OQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "chinese-remainder-theorem",
+      "bezout-identity",
+      "modular-arithmetic",
+      "gcd",
+      "lcm",
+      "prime-factorization"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified. The only hypothesis is that the moduli are nonzero, the natural condition for a system of congruences. Builds on the parent file and Mathlib's Int.gcd/Int.lcm and Nat.factorization.",
+    "lineCount": 289,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "originalContributions": [
+      "nat_gcd_lcm_distrib: gcd(a,lcm(b,c)) = lcm(gcd(a,b),gcd(a,c)) on ℕ — a distributivity lemma not present in Mathlib, proved via prime factorizations",
+      "solvable_iff_compatible: a system of k congruences with nonzero moduli is solvable iff it is pairwise compatible (gcd(mᵢ,mⱼ) | aᵢ-aⱼ)",
+      "solutions_unique_mod_lcmList: any two solutions agree modulo lcm(m₁,…,mₖ)",
+      "iterated_crt_full: combined existence + uniqueness for the k-congruence system",
+      "gcd_lcmList_dvd: the list-level divisibility step gcd(m₀,lcm mᵢ) | d from the pairwise gcd(m₀,mᵢ) | d, the engine of the existence induction"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Generalizes the parent **bezout-identity-oq-03-oq-01-oq-02** (two-modulus non-coprime CRT) to a **system of k congruences** `x ≡ aᵢ (mod mᵢ)`.

**Main theorem** (`solvable_iff_compatible`): a system with nonzero moduli has a common solution **iff** it is *pairwise compatible*,
> `gcd(mᵢ, mⱼ) ∣ (aᵢ − aⱼ)` for all i, j.

Plus **uniqueness modulo `lcm(m₁,…,mₖ)`** (`solutions_unique_mod_lcmList`) and the packaged existence+uniqueness theorem (`iterated_crt_full`).

## The mathematical content

The natural "merge the first two, recurse" induction silently needs a fact Mathlib **does not have**: the distributivity of gcd over lcm. After collapsing the tail into one residue `Y` modulo `L = lcm` of the tail moduli, the head merges iff `gcd(m₀, L) ∣ (a₀ − Y)`, and
> `gcd(m₀, L) = gcd(m₀, lcm mᵢ) = lcm gcd(m₀, mᵢ)`,

with each `gcd(m₀, mᵢ) ∣ (a₀ − Y)`. So the whole result reduces to:

- **`nat_gcd_lcm_distrib`** — `gcd(a, lcm(b,c)) = lcm(gcd(a,b), gcd(a,c))` on ℕ, proved via prime factorizations (`Nat.eq_of_factorization_eq`): on each prime exponent it is `min(α, max(β,γ)) = max(min(α,β), min(α,γ))`, i.e. `inf_sup_left`.

The two-modulus engine is reused directly from the parent file (imported): `gcd_dvd_implies_solvable` for the merge, `crt_unique_mod_lcm` for uniqueness.

## Verification

- **13 theorems, 3 definitions, 289 lines.**
- **0 sorries, 0 axioms** — `#print axioms` on every main theorem lists only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`; examples use kernel `decide`, not `native_decide`).
- Compiles clean on Lean 4.26 / Mathlib (no warnings).
- Badge: **original** (the gcd/lcm distributivity lemma fills a genuine Mathlib gap).

## Files
- `proofs/Proofs/BezoutIdentityOQ03OQ01OQ02OQ01.lean` — the proof
- `proofs/Proofs.lean` — import registration
- `src/data/proofs/bezout-identity-oq-03-oq-01-oq-02-oq-01/{meta,annotations}.json` — gallery data

🤖 Generated with [Claude Code](https://claude.com/claude-code)