### PR TITLE
Gallery audit: buffon-noodle-oq0102 + stirling-oq030201 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23649,8 +23649,20 @@
       "issues": [],
       "lastAudited": "2026-06-25T00:00:00Z",
       "result": "clean"
+    },
+    "buffons-noodle-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:39:40Z",
+      "result": "clean"
+    },
+    "stirling-formula-oq-03-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:39:40Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T00:00:00Z"
+  "lastUpdated": "2026-06-25T09:39:40Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 2 unaudited gallery entries against their Lean sources on `main`. Both **CLEAN** — no integrity issues.

| Slug | Status/Badge | Sorries | Axioms | native_decide | Thm count (meta vs source) |
|------|-------------|---------|--------|---------------|---------------------------|
| `buffons-noodle-oq-01-oq-02` | verified/original | 0 | 0 | 0 | 6 = 6 ✓ |
| `stirling-formula-oq-03-oq-02-oq-01` | verified/original | 0 | 0 | 0 | 6 = 6 ✓ |

### Findings
- **buffons-noodle-oq-01-oq-02** (General Buffon–Laplace, k line families): 6 real theorems + 1 def. Mathlib deps (`Finset.mul_sum`, `Finset.sum_congr`, `Fin.sum_univ_add`, `Real.pi_ne_zero`) are algebraic infrastructure — the k-family identity is proved as a corollary of the machine-checked parent `buffon_noodle_polygon`. `original` badge correct; overview honestly scopes to polygonal noodles and discloses the grandparent's still-axiomatized smooth case as out of scope.
- **stirling-formula-oq-03-oq-02-oq-01** (Catalan asymptotic Cₙ ~ 4ⁿ/(√π·n^{3/2})): 6 theorems + 1 def. Result is not stated by Mathlib; derived from the parent's central-binomial asymptotic times the ratio n/(n+1)→1. Wallis/parent reliance disclosed in overview. `original` badge correct.

Both depend only on the foundational `propext`/`Classical.choice`/`Quot.sound` — consistent with verified/0-axiom claims.

### Skipped (phantom — neither meta nor Lean source on `main`)
- `abel-ruffini-oq-04-oq-01-oq-01` (persistent phantom; untracked in-flight files only)
- `derangements-oq-02-oq-01-oq-01` (untracked in-flight files only)

Tracker updated: both marked `clean`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)