### PR TITLE
research(inverse-galois-a5-oq-01): instantiate Dedekind–Frobenius bridge in the A₅ tower

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3254,6 +3254,7 @@ import Proofs.IntermediateValueTheoremOQ03
 import Proofs.InverseGalois
 import Proofs.InverseGaloisA5
 import Proofs.InverseGaloisA5Dedekind
+import Proofs.InverseGaloisA5DedekindInstantiation
 import Proofs.InverseGaloisA5OQ02
 import Proofs.InverseGaloisA5OQ03
 import Proofs.InverseGaloisA5Resultant

--- a/proofs/Proofs/InverseGaloisA5DedekindInstantiation.lean
+++ b/proofs/Proofs/InverseGaloisA5DedekindInstantiation.lean
@@ -1,0 +1,108 @@
+import Mathlib
+import Proofs.InverseGaloisA5
+import Proofs.DedekindFrobeniusBridge
+
+/-!
+# Instantiating the Dedekind–Frobenius bridge for the A₅ quintic
+
+The parent file `InverseGaloisA5` realizes `A₅` as a Galois group over `ℚ` using the
+quintic `q = X⁵ − 5X⁴ + 10X³ − 10X² + 25X − 5`, but its final assumption is the
+`axiom`
+
+```
+axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal     -- InverseGaloisA5.lean:309
+```
+
+"By Dedekind's theorem at `p = 7`, `q mod 7 = (X−5)(X−6)·(irreducible cubic)`, so `Gal`
+contains a Frobenius element with cycle type `(1,1,3)` and hence `3 ∣ |Gal|`."
+
+The genuine Mathlib gap — *the order of the arithmetic Frobenius at an unramified prime
+equals the inertia degree* — was closed abstractly in
+`Proofs.DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`
+(`R`–`S`–`G` general, `0` axioms, `0` sorries).
+
+This file **instantiates that abstract bridge in the concrete A₅ setting**:
+`R = ℤ`, `S = 𝓞 q.SplittingField`, `G = q.Gal`. The payoff is `three_dvd_gal_card_of_bridge`:
+once one exhibits an *unramified* prime `Q` of `𝓞 q.SplittingField` over a rational prime
+whose inertia degree is divisible by `3`, the axiom `three_dvd_gal_card` follows — with the
+arithmetic Frobenius `arithFrobAt ℤ q.Gal Q` as the explicit order-divisible-by-3 witness.
+
+This reduces the vague "Dedekind's theorem is missing" assumption to the single, sharp,
+*standard* number-theoretic fact
+
+```
+3 ∣ Ideal.inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)
+```
+
+at an unramified `Q` over `7`. It does **not** by itself remove the axiom (that fact is
+still assumed here), but it verifies that the proven bridge plugs into the A₅ tower — all
+the `NumberField` / `IsGaloisGroup` / `IsDedekindDomain` instances line up — and pins down
+exactly what remains. See the module docstring's "Residual gap" note below for the
+Kummer–Dedekind + inertia-tower route that would discharge the remaining hypothesis.
+
+## Residual gap (next step)
+
+`3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)` is provable from:
+* `Mathlib`'s `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply`
+  (`NumberField/Ideal/KummerDedekind.lean`): applied to a root `α` of `q` inside the
+  splitting field, the prime of `𝓞 ℚ(α)` matching the irreducible cubic factor of
+  `q mod 7` has inertia degree `3` (using `7 ∤ disc q = 32000²`, so `7 ∤` the conductor);
+* `Ideal.inertiaDeg_algebra_tower` (residue-field `finrank` multiplicativity, no Galois
+  needed on the non-normal middle field `ℚ(α)`): a prime `Q` of `𝓞 q.SplittingField`
+  over that cubic prime has `3 ∣ inertiaDeg(Q | 7)`;
+* `Ideal.inertiaDegIn_eq_inertiaDeg` (Galois): all primes of the *splitting field* over
+  `7` share this inertia degree, so `3 ∣ inertiaDegIn (7) (𝓞 q.SplittingField)`.
+-/
+
+open Polynomial Ideal
+open scoped NumberField
+
+namespace InverseGaloisA5DedekindInstantiation
+
+open InverseGaloisA5
+
+/-- The splitting field of `q` is a number field (finite extension of `ℚ`, characteristic 0). -/
+instance : NumberField q.SplittingField := ⟨⟩
+
+/-- `q.SplittingField / ℚ` is a Galois extension: it is the splitting field of `q`, hence
+normal (`InverseGaloisA5` registers the `Normal` instance) and — being in characteristic
+zero — separable (`Algebra.IsSeparable`, also registered in the parent). `IsGalois` is the
+conjunction of those two, so the anonymous constructor assembles it from the ambient
+instances. This is what unlocks `IsGaloisGroup.of_isGalois` below. -/
+instance : IsGalois ℚ q.SplittingField := ⟨⟩
+
+/-- `q.Gal` is a Galois group for `q.SplittingField / ℚ`.
+
+`Polynomial.Gal q` is *definitionally* `q.SplittingField ≃ₐ[ℚ] q.SplittingField`, so
+Mathlib's `IsGaloisGroup.of_isGalois` (which is stated for the notation `Gal(L/K)`) applies
+once we identify the two `MulSemiringAction`s — they agree on the nose
+(`Polynomial.Gal.applyMulSemiringAction` is the `AlgEquiv` application). -/
+instance : IsGaloisGroup q.Gal ℚ q.SplittingField :=
+  inferInstanceAs (IsGaloisGroup (q.SplittingField ≃ₐ[ℚ] q.SplittingField) ℚ q.SplittingField)
+
+/-- **Bridge instantiation for the A₅ quintic.**
+
+Given an *unramified* prime `Q` of `𝓞 q.SplittingField` (`ramificationIdxIn = 1`) over a
+nonzero rational prime whose inertia degree is divisible by `3`, the arithmetic Frobenius
+`arithFrobAt ℤ q.Gal Q` is an element of `q.Gal` whose order is divisible by `3`; hence
+`3 ∣ |q.Gal|`. This is the instantiated form of `three_dvd_gal_card`, with the abstract
+Dedekind–Frobenius bridge supplying `orderOf (arithFrobAt …) = inertiaDegIn …`. -/
+theorem three_dvd_gal_card_of_bridge
+    (Q : Ideal (𝓞 q.SplittingField)) [Q.IsMaximal] [Finite (𝓞 q.SplittingField ⧸ Q)]
+    [(Q.under ℤ).IsMaximal]
+    [Algebra.IsSeparable (ℤ ⧸ Q.under ℤ) (𝓞 q.SplittingField ⧸ Q)]
+    (hp : Q.under ℤ ≠ ⊥)
+    (hunram : Ideal.ramificationIdxIn (Q.under ℤ) (𝓞 q.SplittingField) = 1)
+    (h3 : 3 ∣ Ideal.inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)) :
+    3 ∣ Fintype.card q.Gal := by
+  -- The bridge: the arithmetic Frobenius at `Q` has order equal to the inertia degree.
+  have hbridge :
+      orderOf (arithFrobAt ℤ q.Gal Q)
+        = Ideal.inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField) :=
+    DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn
+      (R := ℤ) (G := q.Gal) Q hp hunram
+  -- Hence `3 ∣ orderOf (arithFrobAt …)`, and `orderOf` divides the group order.
+  rw [← hbridge] at h3
+  exact h3.trans orderOf_dvd_card
+
+end InverseGaloisA5DedekindInstantiation

--- a/src/data/proofs/inverse-galois-a5-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-a5-oq-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "inverse-galois-a5-oq-01",
+  "title": "Instantiating the Dedekind–Frobenius Bridge for the A₅ Quintic: Reducing `three_dvd_gal_card` to a Single Inertia Degree",
+  "slug": "inverse-galois-a5-oq-01",
+  "description": "Attacks the sole remaining axiom of the gallery's A₅ inverse-Galois realization, `three_dvd_gal_card : 3 ∣ |Gal(q/ℚ)|` for q = x⁵ − 5x⁴ + 10x³ − 10x² + 25x − 5. The genuine Mathlib gap — that the arithmetic Frobenius at an unramified prime has order equal to the inertia degree — was already closed abstractly (0 axioms) in `DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`. This entry instantiates that abstract bridge in the concrete A₅ tower (R = ℤ, S = 𝓞 q.SplittingField, G = q.Gal): it supplies the NumberField / IsGalois / IsGaloisGroup instances that make the bridge apply and proves `three_dvd_gal_card_of_bridge`, a verified (0-axiom, 0-sorry) reduction of the parent axiom to the single sharp number-theoretic fact `3 ∣ inertiaDegIn(7)` at an unramified prime over 7. The arithmetic Frobenius `arithFrobAt ℤ q.Gal Q` is the explicit order-divisible-by-3 witness. It does not by itself remove the axiom — that residual inertia fact is still assumed — but it confirms the proven bridge plugs into the A₅ tower and pins down exactly what remains.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Inverse_Galois_problem",
+    "date": "Dedekind's theorem on Frobenius elements classical (Dedekind 1878); A₅ realization folklore; formalized 2026",
+    "status": "axiomatized",
+    "tags": [
+      "galois-theory",
+      "inverse-galois-problem",
+      "frobenius-element",
+      "ramification-inertia",
+      "dedekind-theorem",
+      "number-field",
+      "non-solvable",
+      "open-problem"
+    ],
+    "proofRepoPath": "Proofs/InverseGaloisA5DedekindInstantiation.lean",
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "assumptions": "The Lean file has 0 literal `axiom` declarations and 0 sorries; `#print axioms three_dvd_gal_card_of_bridge` lists only `propext`, `Classical.choice`, `Quot.sound`. The single residual mathematical assumption is a hypothesis of the main theorem, NOT discharged here: `3 ∣ Ideal.inertiaDegIn (Q.under ℤ) (𝓞 q.SplittingField)` at an unramified prime Q of 𝓞 q.SplittingField lying over the rational prime 7 (together with the unramifiedness `ramificationIdxIn = 1`). Because the parent's `three_dvd_gal_card` is therefore reduced to — but not eliminated by — this entry, the status is `axiomatized` (axiomCount 1, counting the assumed inertia fact). The abstract order = inertia-degree bridge it relies on, `DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn`, is itself 0-axiom / 0-sorry (landed under `abel-ruffini-oq-07`).",
+    "originalContributions": [
+      "three_dvd_gal_card_of_bridge: a verified (0-axiom, 0-sorry) reduction of the parent's sole axiom `three_dvd_gal_card` to the single fact `3 ∣ inertiaDegIn(7)` at an unramified prime over 7 — with the arithmetic Frobenius `arithFrobAt ℤ q.Gal Q` exhibited as the explicit element of order divisible by 3, and `orderOf σ ∣ Fintype.card` closing the divisibility",
+      "Instantiation of the abstract R–S–G Dedekind–Frobenius bridge in the concrete A₅ tower R = ℤ, S = 𝓞 q.SplittingField, G = q.Gal: confirms all the NumberField / IsGaloisGroup / IsDedekindDomain typeclass machinery lines up so that `orderOf_arithFrobAt_eq_inertiaDegIn` actually applies to this specific splitting field",
+      "instance IsGalois ℚ q.SplittingField and instance IsGaloisGroup q.Gal ℚ q.SplittingField: bridging `Polynomial.Gal q` (definitionally q.SplittingField ≃ₐ[ℚ] q.SplittingField) to Mathlib's `IsGaloisGroup` typeclass via `IsGaloisGroup.of_isGalois`, assembling IsGalois from the parent file's registered Normal + Algebra.IsSeparable instances",
+      "Sharpens the OQ-01 open problem statement: the vague 'Dedekind's theorem is not in Mathlib' blocker is reduced to one standard, sharply-stated inertia-degree computation, and the module docstring records the explicit Kummer–Dedekind + inertia-tower route (inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply → inertiaDeg_algebra_tower → inertiaDegIn_eq_inertiaDeg) that would discharge it"
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 108,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.InverseGaloisA5",
+      "Proofs.DedekindFrobeniusBridge"
+    ],
+    "namespace": "InverseGaloisA5DedekindInstantiation",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "path": "Proofs/InverseGaloisA5DedekindInstantiation.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "inverse-galois-a5",
+      "relationship": "extends",
+      "description": "The parent A₅ realization proves |Gal(q/ℚ)| = 60 modulo one axiom, `three_dvd_gal_card : 3 ∣ |Gal|`. This entry instantiates the Dedekind–Frobenius bridge in that exact tower and reduces the axiom to a single inertia-degree fact."
+    },
+    {
+      "targetId": "abel-ruffini-oq-07",
+      "relationship": "builds-on",
+      "description": "Home of the abstract, 0-axiom Dedekind–Frobenius bridge `orderOf_arithFrobAt_eq_inertiaDegIn` (order of the arithmetic Frobenius at an unramified prime equals the inertia degree). This entry consumes that bridge as its engine, specialised to R = ℤ, S = 𝓞 q.SplittingField, G = q.Gal."
+    }
+  ],
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The inverse Galois problem for A₅ — the smallest non-solvable simple group — is realized in the gallery's `inverse-galois-a5` via the quintic q(x) = x⁵ − 5x⁴ + 10x³ − 10x² + 25x − 5. That 2067-line development reduces |Gal(q/ℚ)| = 60 to three divisibility facts: |Gal| ∣ 60 (square discriminant ⟹ Gal ⊆ A₅), 5 ∣ |Gal| (Cauchy, from irreducibility), and 3 ∣ |Gal|. The last was the lone remaining axiom, `three_dvd_gal_card`, standing in for Dedekind's theorem on Frobenius elements: q mod 7 factors as (X−5)(X−6)·(irreducible cubic), so the Frobenius at a prime over 7 has cycle type (1,1,3) and hence order 3. Dedekind's theorem (the factorization of a monic separable polynomial modulo an unramified prime determines the cycle decomposition of Frobenius) is not in Mathlib 4.26.0. The deepest part of that gap — that at an unramified prime the arithmetic Frobenius has order exactly the inertia degree — was closed abstractly (0 axioms, Aristotle job 9c006ee6) in `DedekindFrobeniusBridge`, a file shared with `abel-ruffini-oq-07`. What remained was to connect that abstract bridge to the concrete A₅ splitting field.",
+    "problemStatement": "Eliminate the parent's axiom `three_dvd_gal_card : 3 ∣ Fintype.card q.Gal` by deriving it from Mathlib. This entry's contribution is the specialisation step: instantiate the abstract Dedekind–Frobenius bridge in the A₅ tower (R = ℤ, S = 𝓞 q.SplittingField, G = q.Gal) and reduce the axiom to the single number-theoretic fact $3 \\mid \\mathrm{inertiaDegIn}(7)$ at an unramified prime over 7, with the arithmetic Frobenius as the explicit order-divisible-by-3 witness.",
+    "proofStrategy": "The file supplies three typeclass instances making the abstract bridge applicable: (1) `NumberField q.SplittingField` (finite extension of ℚ in characteristic 0); (2) `IsGalois ℚ q.SplittingField`, assembled from the parent's registered `Normal` and `Algebra.IsSeparable` instances; (3) `IsGaloisGroup q.Gal ℚ q.SplittingField` via `IsGaloisGroup.of_isGalois`, using that `Polynomial.Gal q` is definitionally q.SplittingField ≃ₐ[ℚ] q.SplittingField. The main theorem `three_dvd_gal_card_of_bridge` then takes an unramified prime Q of 𝓞 q.SplittingField over a nonzero rational prime with 3 ∣ inertiaDegIn, invokes `DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn` to get orderOf(arithFrobAt ℤ q.Gal Q) = inertiaDegIn(Q.under ℤ), and concludes 3 ∣ |q.Gal| by transporting the divisibility through `orderOf_dvd_card`. The residual hypothesis 3 ∣ inertiaDegIn(7) is left assumed; the module docstring records the Kummer–Dedekind + inertia-tower route to discharge it.",
+    "keyInsights": [
+      "The abstract R–S–G bridge `orderOf_arithFrobAt_eq_inertiaDegIn` carries all the genuine new content (order of arithmetic Frobenius = inertia degree); the specialisation to A₅ is pure instance plumbing — but that plumbing is exactly where such transfers usually break, so verifying it compiles is the substance of this entry.",
+      "`Polynomial.Gal q` is definitionally the AlgEquiv group q.SplittingField ≃ₐ[ℚ] q.SplittingField, so Mathlib's `IsGaloisGroup.of_isGalois` (stated for the notation Gal(L/K)) applies on the nose once `IsGalois ℚ q.SplittingField` is in scope — which the parent's Normal + Separable instances supply via the anonymous constructor.",
+      "The reduction turns a vague gap ('Dedekind's theorem is missing') into one sharp, standard, decidable-after-construction fact: 3 ∣ inertiaDegIn(7). This is the difference between an open-ended formalization project and a single named lemma.",
+      "The arithmetic Frobenius `arithFrobAt ℤ q.Gal Q` is produced as the explicit group element of order divisible by 3, matching the informal Dedekind narrative (the (1,1,3) cycle type at 7) with a concrete Mathlib term rather than a mere existence claim."
+    ],
+    "prerequisites": [
+      "Galois theory and splitting fields",
+      "algebraic number theory: rings of integers, prime decomposition, ramification and inertia degrees",
+      "Frobenius elements at unramified primes (decomposition group, residue field Galois action)",
+      "Dedekind domains and the Kummer–Dedekind factorization theorem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Problem, Bridge, and Residual Gap",
+      "startLine": 5,
+      "endLine": 55,
+      "summary": "States the parent's axiom, the abstract bridge it reduces to, the instantiation's payoff, and the explicit Kummer–Dedekind + inertia-tower route that would discharge the remaining 3 ∣ inertiaDegIn(7) hypothesis."
+    },
+    {
+      "id": "instances",
+      "title": "Typeclass Instances for the A₅ Tower",
+      "startLine": 64,
+      "endLine": 81,
+      "summary": "NumberField q.SplittingField, IsGalois ℚ q.SplittingField (from the parent's Normal + Separable), and IsGaloisGroup q.Gal ℚ q.SplittingField via IsGaloisGroup.of_isGalois — the instances that make the abstract bridge apply."
+    },
+    {
+      "id": "main-result",
+      "title": "Bridge Instantiation: three_dvd_gal_card_of_bridge",
+      "startLine": 82,
+      "endLine": 108,
+      "summary": "Given an unramified prime Q over a rational prime with 3 ∣ inertiaDegIn, the arithmetic Frobenius arithFrobAt ℤ q.Gal Q has order divisible by 3 (via the bridge), hence 3 ∣ Fintype.card q.Gal."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry instantiates the abstract, 0-axiom Dedekind–Frobenius bridge in the concrete A₅ tower and proves a verified reduction `three_dvd_gal_card_of_bridge`: the parent's sole axiom `3 ∣ |Gal(q/ℚ)|` follows from the single sharp fact `3 ∣ inertiaDegIn(7)` at an unramified prime over 7, with the arithmetic Frobenius as the explicit order-divisible-by-3 witness. The Lean file is 0-axiom, 0-sorry; the reduction does not yet eliminate the parent axiom because that residual inertia fact is still assumed, so the entry is marked axiomatized (axiomCount 1).",
+    "implications": "Closing the gap from 'Dedekind's theorem is missing from Mathlib' to 'prove 3 ∣ inertiaDegIn(7)' is the key structural step toward upgrading the flagship A₅ realization from axiomatized to verified — the first fully machine-checked non-solvable inverse-Galois realization. The instantiation also demonstrates a reusable pattern: any splitting-field Galois group whose Frobenius cycle type forces a prime-order element can be handled by the same R = ℤ, S = 𝓞 K, G = Gal bridge specialisation, so the same reduction applies verbatim to `abel-ruffini-oq-07` (x⁵ − x − 1 at 7).",
+    "openQuestions": [
+      "Discharge the residual hypothesis 3 ∣ inertiaDegIn(7) (𝓞 q.SplittingField): apply Mathlib's Kummer–Dedekind `inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply` to a root α of q (the irreducible cubic factor of q mod 7 gives a prime of 𝓞 ℚ(α) of inertia degree 3, using 7 ∤ disc q), lift through the inertia-degree tower `inertiaDeg_algebra_tower`, and conclude via `inertiaDegIn_eq_inertiaDeg` (Galois). Completing this would eliminate the parent's `three_dvd_gal_card` axiom and flip `inverse-galois-a5` to verified.",
+      "Construct the unramified prime Q over 7 in 𝓞 q.SplittingField explicitly (7 ∤ disc q = 32000² ⟹ ramificationIdxIn = 1) so the hypotheses of three_dvd_gal_card_of_bridge are met unconditionally.",
+      "Generalise the instantiation into a reusable lemma over an arbitrary monic separable q ∈ ℤ[X] and prime p ∤ disc q, packaging 'q mod p has an irreducible factor of degree d ⟹ d ∣ |Gal(q/ℚ)|' — a specialised Dedekind theorem of independent Mathlib value."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Attacks the **sole remaining axiom** of the gallery's flagship A₅ inverse-Galois realization (`inverse-galois-a5`):

```lean
axiom three_dvd_gal_card : 3 ∣ Fintype.card q.Gal   -- InverseGaloisA5.lean:309
```
for `q = x⁵ − 5x⁴ + 10x³ − 10x² + 25x − 5`.

The genuine Mathlib gap — *the arithmetic Frobenius at an unramified prime has order equal to the inertia degree* — was already closed **abstractly, 0-axiom** in `DedekindFrobeniusBridge.orderOf_arithFrobAt_eq_inertiaDegIn` (landed under `abel-ruffini-oq-07`). This PR **instantiates that abstract bridge in the concrete A₅ tower** `R = ℤ`, `S = 𝓞 q.SplittingField`, `G = q.Gal`.

## What's proved

`three_dvd_gal_card_of_bridge` (new file `Proofs/InverseGaloisA5DedekindInstantiation.lean`, 108 lines): given an **unramified** prime `Q` of `𝓞 q.SplittingField` over a rational prime with `3 ∣ inertiaDegIn`, the arithmetic Frobenius `arithFrobAt ℤ q.Gal Q` has order divisible by 3 (via the bridge), hence `3 ∣ Fintype.card q.Gal`.

The substance is the **typeclass plumbing** that makes the abstract `R–S–G` bridge actually apply to this splitting field:
- `instance : NumberField q.SplittingField`
- `instance : IsGalois ℚ q.SplittingField` (assembled from the parent's registered `Normal` + `Algebra.IsSeparable`)
- `instance : IsGaloisGroup q.Gal ℚ q.SplittingField` via `IsGaloisGroup.of_isGalois` (using that `Polynomial.Gal q` is *definitionally* `q.SplittingField ≃ₐ[ℚ] q.SplittingField`)

## Verification

- `#print axioms three_dvd_gal_card_of_bridge` → `[propext, Classical.choice, Quot.sound]` only. **No `sorryAx`, no `Lean.ofReduceBool`, no `three_dvd_gal_card`.**
- 0 literal `axiom` declarations, 0 sorries in the file.
- Built locally against pinned Mathlib `v4.26.0` (deps `InverseGaloisA5`, `DedekindFrobeniusBridge` compiled, exit 0).

## Honest status

This is a **verified reduction, not an elimination**. The parent's `three_dvd_gal_card` is reduced to — but not discharged by — the single sharp fact `3 ∣ inertiaDegIn(7)` at an unramified prime over 7, which remains a hypothesis. The gallery entry is therefore marked **`axiomatized`** (badge `axiom`, `axiomCount: 1` for the assumed inertia fact; `leanFile.axiomCount: 0`). The module docstring and the entry's `openQuestions` record the explicit Kummer–Dedekind + inertia-tower route (`inertiaDeg_primesOverSpanEquivMonicFactorsMod_symm_apply` → `inertiaDeg_algebra_tower` → `inertiaDegIn_eq_inertiaDeg`) that would discharge it and flip `inverse-galois-a5` to verified.

## Files
- `proofs/Proofs/InverseGaloisA5DedekindInstantiation.lean` (new, 108 lines)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/inverse-galois-a5-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)