### PR TITLE
Enrich The Catalan Number Asymptotic: Cₙ ~ 4ⁿ/(√π·n^{3/2})

### DIFF
--- a/src/data/proofs/stirling-formula-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/stirling-formula-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-strategy",
+    "proofId": "stirling-formula-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 45
+    },
+    "type": "context",
+    "title": "One Ratio Limit on Top of the Parent",
+    "content": "The header lays out the whole strategy: the parent module StirlingFormulaOQ03OQ02 already proves the central binomial asymptotic C(2n,n)·√(πn)/4ⁿ → 1. Catalan numbers satisfy the exact Mathlib identity (n+1)·catalan n = C(2n,n), so catalan n = C(2n,n)/(n+1). Multiplying the parent limit by the elementary ratio n/(n+1) → 1 transfers the asymptotic to the Catalan numbers. The file `open`s the four parent lemmas it reuses (cb, cb_pos, cb_ne_zero, centralBinom_asymptotic), so the only genuinely new mathematics is the ratio limit and the cast bookkeeping. Mathlib has the Catalan↔central-binomial identity but not the Catalan asymptotic itself.",
+    "mathContext": "$C_n = \\binom{2n}{n}/(n+1)$, and $\\binom{2n}{n} \\sim 4^n/\\sqrt{\\pi n}$ (parent) times $\\tfrac{n}{n+1}\\to 1$ gives $C_n \\sim 4^n/(\\sqrt\\pi\\, n^{3/2})$.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "asymptotic equivalence", "module reuse"],
+    "prerequisites": ["asymptotic notation ~", "Catalan closed form", "sequence limits"]
+  },
+  {
+    "id": "ann-cat-def",
+    "proofId": "stirling-formula-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 47,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "The Real-Cast Catalan Number and Its Positivity",
+    "content": "cat n = (catalan n : ℝ) lifts the natural-number Catalan value into ℝ so it can sit inside limits. cat_pos proves cat n > 0 by an indirect argument that is sharper than it looks: if catalan n were 0, then (n+1)·catalan n = 0, contradicting C(2n,n) > 0 (Nat.centralBinom_pos). So positivity of the Catalan number is itself a consequence of the bridge identity, not assumed separately. cat_ne_zero then records the nonvanishing needed to divide by cat n later.",
+    "mathContext": "$\\mathrm{cat}\\,n = (C_n : \\mathbb{R})$; $C_n > 0$ since $(n+1)C_n = \\binom{2n}{n} > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["natural number cast", "positivity", "nonvanishing"],
+    "prerequisites": ["Nat → ℝ coercion", "Nat.centralBinom_pos", "proof by contradiction"]
+  },
+  {
+    "id": "ann-cat-eq",
+    "proofId": "stirling-formula-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "The Exact Bridge: catalan n = C(2n,n)/(n+1)",
+    "content": "cat_eq casts Mathlib's natural-number identity (n+1)·catalan n = C(2n,n) (Nat.succ_mul_catalan_eq_centralBinom) into ℝ via congrArg + push_cast, then divides by the nonzero (n+1) using eq_div_iff and closes with linear_combination. This identity is exact for every n — there is no error term — which is precisely why the asymptotic transfers verbatim: an exact algebraic relation composed with a convergent ratio preserves the limit. The whole proof rests on turning this equality into the division catalan n = C(2n,n)/(n+1).",
+    "mathContext": "$(n+1)\\,C_n = \\binom{2n}{n} \\;\\Longrightarrow\\; C_n = \\dfrac{\\binom{2n}{n}}{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["exact identity", "cast lemmas", "linear_combination"],
+    "prerequisites": ["push_cast / Nat.cast", "eq_div_iff", "Nat.succ_mul_catalan_eq_centralBinom"]
+  },
+  {
+    "id": "ann-ratio",
+    "proofId": "stirling-formula-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 87
+    },
+    "type": "insight",
+    "title": "The Only New Asymptotic Content: n/(n+1) → 1",
+    "content": "ratio_tendsto is the single piece of genuinely new convergence in the file. It writes n/(n+1) = 1 − 1/(n+1) and shows the reciprocal vanishes: (n+1) → +∞ (tendsto_natCast_atTop_atTop with a constant shift), so (n+1)⁻¹ → 0 (inv_tendsto_atTop), hence 1 − (n+1)⁻¹ → 1. The eventual equality n/(n+1) = 1 − (n+1)⁻¹ is discharged by field_simp + ring under filter_upwards. This limit is exactly what shifts the polynomial power: dividing C(2n,n) ~ 4ⁿ/n^{1/2} by (n+1) turns n^{1/2} into n^{3/2}.",
+    "mathContext": "$\\dfrac{n}{n+1} = 1 - \\dfrac{1}{n+1} \\to 1$ because $\\dfrac{1}{n+1}\\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["limit at infinity", "reciprocal of divergent sequence", "eventual equality"],
+    "prerequisites": ["Filter.Tendsto", "inv_tendsto_atTop", "filter_upwards / eventually"]
+  },
+  {
+    "id": "ann-asymptotic",
+    "proofId": "stirling-formula-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 89,
+      "endLine": 101
+    },
+    "type": "concept",
+    "title": "The Catalan Asymptotic by Multiplying Two Limits",
+    "content": "catalan_asymptotic is the main result: catalan n · n · √(πn)/4ⁿ → 1, i.e. Cₙ ~ 4ⁿ/(√π·n^{3/2}). It takes the product of the parent's centralBinom_asymptotic (→1) with ratio_tendsto (→1) via Tendsto.mul, giving a sequence → 1, then shows that sequence is pointwise equal to the target after substituting cat_eq and clearing denominators with field_simp. Stating the bound as n·√(πn)/4ⁿ rather than n^{3/2}/4ⁿ deliberately avoids any rpow reasoning, since n·√(πn) = √π·n^{3/2} keeps everything in the √(πn) already supplied by the parent.",
+    "mathContext": "$C_n\\, n\\,\\sqrt{\\pi n}/4^n = \\big[\\binom{2n}{n}\\sqrt{\\pi n}/4^n\\big]\\cdot\\big[n/(n+1)\\big] \\to 1\\cdot 1 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["product of limits", "asymptotic growth", "avoiding rpow", "Tendsto.mul"],
+    "prerequisites": ["Filter.Tendsto.mul", "field_simp", "the parent central binomial asymptotic"]
+  },
+  {
+    "id": "ann-inv",
+    "proofId": "stirling-formula-oq-03-oq-02-oq-01",
+    "range": {
+      "startLine": 103,
+      "endLine": 111
+    },
+    "type": "concept",
+    "title": "The Equivalent Reciprocal Form",
+    "content": "catalan_asymptotic_inv records 4ⁿ/(catalan n · n · √(πn)) → 1, the form one often wants when bounding 1/Cₙ. Because the limit 1 is nonzero, Tendsto.inv₀ applies directly: the reciprocal of a sequence tending to 1 tends to 1⁻¹ = 1. The pointwise rewrite (a/b)⁻¹ = b/a (inv_div) turns the reciprocal of the previous statement into the displayed quotient. This is a free corollary — no new estimate, just the fact that inversion is continuous away from 0.",
+    "mathContext": "$\\dfrac{4^n}{C_n\\, n\\,\\sqrt{\\pi n}} \\to 1$, since $x_n\\to 1\\neq 0 \\Rightarrow x_n^{-1}\\to 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["reciprocal limit", "continuity of inversion", "inv_div"],
+    "prerequisites": ["Filter.Tendsto.inv₀", "nonzero limit", "inv_div"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `stirling-formula-oq-03-oq-02-oq-01`.

## Quality improvements

**Added annotations.json (previously absent).** The entry had no inline annotations at all. Created 6, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, with line ranges partitioning the full Lean file (1–111):
1. **Strategy** — the result is one ratio limit on top of the parent's central binomial asymptotic.
2. **Definition** — the real-cast `cat n` and the contradiction-based positivity `cat_pos`.
3. **Bridge identity** — `catalan n = C(2n,n)/(n+1)` from `Nat.succ_mul_catalan_eq_centralBinom` (exact, hence the asymptotic transfers verbatim).
4. **Ratio limit** — `n/(n+1) → 1`, the only new convergence; it is what shifts `n^{1/2}` to `n^{3/2}`.
5. **Main asymptotic** — product of two limits, deliberately phrased to avoid rpow.
6. **Reciprocal form** — free corollary via `Tendsto.inv₀` at the nonzero limit 1.

## Notes
- No `index.ts` added: per-proof shims are obsolete since the build-perf phase-2 work (#20993); the runtime loader fetches `meta.json`/`annotations.json` by slug.
- Axiom integrity verified accurate: `status: verified`, `badge: original`, `axiomCount: 0` — 0 sorries, 0 axiom declarations, no assumption-carrying structures (depends only on propext/Classical.choice/Quot.sound).
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)