### PR TITLE
research(cayley-hamilton-oq-01-oq-01-oq-01): cyclic vector exists in the non-derogatory case [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -726,6 +726,7 @@ import Proofs.CayleyHamiltonMinpolyOQ07
 import Proofs.CayleyHamiltonMinpolyOQ07OQ01
 import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
+import Proofs.CayleyHamiltonOQ01OQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ03
 import Proofs.CayleyHamiltonOQ01OQ04
 import Proofs.CayleyHamiltonOQ02

--- a/proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean
@@ -31,22 +31,25 @@ The whole statement reduces to a single **general** module-theoretic fact
 
 This is the classical *existence of a vector of maximal order* — a vector whose
 annihilator ideal is exactly the minimal polynomial (the module's exponent). It
-holds in any finitely generated module over the PID `K[X]`.
+holds in any finitely generated module over the PID `K[X]`, and is supplied by
+Mathlib's `Module.exists_ker_toSpanSingleton_eq_annihilator` (a corollary of the
+PID structure theorem) applied to the finite `K[X]`-module `Module.AEval' M.mulVecLin`.
 
 Given such a `v`, the reduction is elementary: if a polynomial `p` with
 `p.natDegree < n` kills `v`, then `p ∈ vecAnnIdeal M v = span {minpoly K M}`, so
 `minpoly K M ∣ p`; but `(minpoly K M).natDegree = n > p.natDegree` forces `p = 0`.
 Hence `v` is cyclic.
 
-`exists_vecAnnIdeal_eq_minpoly` carries no Mathlib counterpart and is left as the
-one outstanding lemma (delegated to Aristotle / future work). Everything else is
-machine-checked here against the parent's annihilator infrastructure.
+The whole development is fully machine-checked (no `sorry`, no extra axioms) against
+the parent's annihilator infrastructure.
 
 ## Depends on
-`Proofs.CayleyHamiltonOQ01OQ01` (the `vecAnnIdeal` / `IsCyclicVector` framework).
+`Proofs.CayleyHamiltonOQ01OQ01` (the `vecAnnIdeal` / `IsCyclicVector` framework) and
+Mathlib's `Module.exists_ker_toSpanSingleton_eq_annihilator` (PID structure theorem).
 -/
 
 import Proofs.CayleyHamiltonOQ01OQ01
+import Mathlib.Algebra.Module.PID
 
 open Matrix Polynomial Module BigOperators
 open CayleyHamiltonOQ01OQ01
@@ -93,16 +96,30 @@ theorem isCyclicVector_of_vecAnnIdeal_eq_minpoly (M : Matrix (Fin n) (Fin n) K)
   rw [hM] at hle
   exact absurd hp (not_lt.mpr hle)
 
-/-! ## III. The outstanding general lemma (maximal-order vector) -/
+/-! ## III. Existence of a vector of maximal order -/
 
 /-- **Existence of a vector of maximal order.** For every `M`, some vector `v`
 has annihilator ideal exactly `Ideal.span {minpoly K M}` — i.e. its order is the
 minimal polynomial.  This is the classical structure-theoretic fact that a
 finitely generated `K[X]`-module contains an element whose order equals the
-module exponent.  No direct Mathlib counterpart; delegated as the sole open lemma. -/
+module exponent.
+
+Proof: Mathlib's `Module.exists_ker_toSpanSingleton_eq_annihilator` (the PID
+structure theorem applied to the finite `K[X]`-module `Module.AEval' M.mulVecLin`)
+hands us a single `x` whose cyclic-submodule annihilator equals the whole module's
+annihilator.  The parent's `kn_module_annihilator_eq_minpoly` identifies that module
+annihilator with `Ideal.span {minpoly K M}`; transporting `x` back along the
+`Module.AEval'.of` equivalence and unwinding `vecAnnIdeal` (= the annihilator of the
+cyclic submodule, both characterised by `r • x = 0`) closes the goal. -/
 theorem exists_vecAnnIdeal_eq_minpoly (M : Matrix (Fin n) (Fin n) K) :
     ∃ v : Fin n → K, vecAnnIdeal M v = Ideal.span {minpoly K M} := by
-  sorry
+  obtain ⟨x, hx⟩ := Module.exists_ker_toSpanSingleton_eq_annihilator
+    (R := K[X]) (M := Module.AEval' M.mulVecLin)
+  refine ⟨(Module.AEval'.of M.mulVecLin).symm x, ?_⟩
+  rw [kn_module_annihilator_eq_minpoly M, ← hx]
+  ext r
+  rw [mem_vecAnnIdeal_iff, LinearEquiv.apply_symm_apply, LinearMap.mem_ker]
+  rfl
 
 /-! ## IV. Main theorems -/
 

--- a/proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean
@@ -1,0 +1,124 @@
+/-
+# Existence of a Cyclic Vector in the Non-Derogatory Case
+
+## Source
+Open question from `cayley-hamilton-oq-01-oq-01` (OQ[0]):
+> Prove existence of a cyclic vector when the minimal and characteristic
+> polynomials coincide (the non-derogatory case).
+
+## What This Proves
+
+For an `n × n` matrix `M` over a field `K`, viewing `Kⁿ` as a `K[X]`-module via
+`M` (the parent's `Module.AEval'` framework), a vector `v` is **cyclic** when no
+nonzero polynomial of degree `< n` annihilates it (parent's `IsCyclicVector`).
+
+The non-derogatory hypothesis is `minpoly K M = M.charpoly`, equivalently
+`(minpoly K M).natDegree = n` (since `M.charpoly.natDegree = n`).
+
+**Main results:**
+- `exists_cyclicVector_of_minpoly_natDegree_eq`:
+    `(minpoly K M).natDegree = n → ∃ v, IsCyclicVector M v`.
+- `exists_cyclicVector_of_minpoly_eq_charpoly`:
+    `minpoly K M = M.charpoly → ∃ v, IsCyclicVector M v`.
+
+## Structure of the Argument
+
+The whole statement reduces to a single **general** module-theoretic fact
+(true for *every* `M`, derogatory or not):
+
+  `exists_vecAnnIdeal_eq_minpoly`:
+    `∃ v, vecAnnIdeal M v = Ideal.span {minpoly K M}`.
+
+This is the classical *existence of a vector of maximal order* — a vector whose
+annihilator ideal is exactly the minimal polynomial (the module's exponent). It
+holds in any finitely generated module over the PID `K[X]`.
+
+Given such a `v`, the reduction is elementary: if a polynomial `p` with
+`p.natDegree < n` kills `v`, then `p ∈ vecAnnIdeal M v = span {minpoly K M}`, so
+`minpoly K M ∣ p`; but `(minpoly K M).natDegree = n > p.natDegree` forces `p = 0`.
+Hence `v` is cyclic.
+
+`exists_vecAnnIdeal_eq_minpoly` carries no Mathlib counterpart and is left as the
+one outstanding lemma (delegated to Aristotle / future work). Everything else is
+machine-checked here against the parent's annihilator infrastructure.
+
+## Depends on
+`Proofs.CayleyHamiltonOQ01OQ01` (the `vecAnnIdeal` / `IsCyclicVector` framework).
+-/
+
+import Proofs.CayleyHamiltonOQ01OQ01
+
+open Matrix Polynomial Module BigOperators
+open CayleyHamiltonOQ01OQ01
+
+namespace CayleyHamiltonOQ01OQ01OQ01
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-! ## I. Bridging aeval-annihilation and the vector annihilator ideal -/
+
+/-- A polynomial `p` annihilates `v` under the `M`-action (`p(M)·v = 0`) iff it
+lies in the vector annihilator ideal `vecAnnIdeal M v`.  Mirrors the parent's
+membership/aeval translation through the `Module.AEval'` equivalence. -/
+theorem aeval_eq_zero_iff_mem_vecAnnIdeal (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K)
+    (p : K[X]) : aeval M.mulVecLin p v = 0 ↔ p ∈ vecAnnIdeal M v := by
+  rw [mem_vecAnnIdeal_iff]
+  constructor
+  · intro h
+    apply (Module.AEval'.of M.mulVecLin).symm.injective
+    simp only [LinearEquiv.map_zero, Module.AEval.of_symm_smul, LinearEquiv.symm_apply_apply]
+    exact h
+  · intro h
+    have h2 := congr_arg (Module.AEval'.of M.mulVecLin).symm h
+    simpa only [LinearEquiv.map_zero, Module.AEval.of_symm_smul,
+                LinearEquiv.symm_apply_apply] using h2
+
+/-! ## II. The reduction: a maximal-order vector is cyclic -/
+
+/-- If `v` realizes the minimal polynomial as its order
+(`vecAnnIdeal M v = span {minpoly K M}`) and the minimal polynomial has full
+degree `n`, then `v` is a cyclic vector.
+
+Proof: a degree-`< n` polynomial `p` killing `v` lies in `span {minpoly K M}`, so
+`minpoly K M ∣ p`; a nonzero such `p` would have degree `≥ n`, contradiction. -/
+theorem isCyclicVector_of_vecAnnIdeal_eq_minpoly (M : Matrix (Fin n) (Fin n) K)
+    (v : Fin n → K) (hv : vecAnnIdeal M v = Ideal.span {minpoly K M})
+    (hM : (minpoly K M).natDegree = n) : IsCyclicVector M v := by
+  intro p hp hpv
+  have hmem : p ∈ vecAnnIdeal M v := (aeval_eq_zero_iff_mem_vecAnnIdeal M v p).mp hpv
+  rw [hv, Ideal.mem_span_singleton] at hmem
+  by_contra hpne
+  have hle : (minpoly K M).natDegree ≤ p.natDegree :=
+    Polynomial.natDegree_le_of_dvd hmem hpne
+  rw [hM] at hle
+  exact absurd hp (not_lt.mpr hle)
+
+/-! ## III. The outstanding general lemma (maximal-order vector) -/
+
+/-- **Existence of a vector of maximal order.** For every `M`, some vector `v`
+has annihilator ideal exactly `Ideal.span {minpoly K M}` — i.e. its order is the
+minimal polynomial.  This is the classical structure-theoretic fact that a
+finitely generated `K[X]`-module contains an element whose order equals the
+module exponent.  No direct Mathlib counterpart; delegated as the sole open lemma. -/
+theorem exists_vecAnnIdeal_eq_minpoly (M : Matrix (Fin n) (Fin n) K) :
+    ∃ v : Fin n → K, vecAnnIdeal M v = Ideal.span {minpoly K M} := by
+  sorry
+
+/-! ## IV. Main theorems -/
+
+/-- **Cyclic vector in the non-derogatory case (degree form).**
+If `(minpoly K M).natDegree = n`, then `M` admits a cyclic vector. -/
+theorem exists_cyclicVector_of_minpoly_natDegree_eq (M : Matrix (Fin n) (Fin n) K)
+    (hM : (minpoly K M).natDegree = n) : ∃ v : Fin n → K, IsCyclicVector M v := by
+  obtain ⟨v, hv⟩ := exists_vecAnnIdeal_eq_minpoly M
+  exact ⟨v, isCyclicVector_of_vecAnnIdeal_eq_minpoly M v hv hM⟩
+
+/-- **Cyclic vector in the non-derogatory case.**
+If the minimal and characteristic polynomials coincide, then `M` admits a cyclic
+vector — the converse direction of the cyclic-vector ⟺ `μ = χ` equivalence. -/
+theorem exists_cyclicVector_of_minpoly_eq_charpoly (M : Matrix (Fin n) (Fin n) K)
+    (hM : minpoly K M = M.charpoly) : ∃ v : Fin n → K, IsCyclicVector M v := by
+  apply exists_cyclicVector_of_minpoly_natDegree_eq
+  rw [hM, Matrix.charpoly_natDegree_eq_dim, Fintype.card_fin]
+
+end CayleyHamiltonOQ01OQ01OQ01

--- a/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/knowledge.md
@@ -35,41 +35,63 @@ minpoly).
 - Non-derogatory ⇒ full degree: `Matrix.charpoly_natDegree_eq_dim` +
   `Fintype.card_fin` give `(minpoly K M).natDegree = n` from `minpoly = charpoly`.
 
-## Status (Session 2, 2026-06-25)
+## Status (Session 3, 2026-06-25) — COMPLETE, fully verified
 
-- **VERIFIED scaffold built** in `proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean`,
-  compiles via host `lake env lean` with the **single** `sorry` being
-  `exists_vecAnnIdeal_eq_minpoly` (line ~103). Both main theorems
-  (`exists_cyclicVector_of_minpoly_natDegree_eq`,
-  `exists_cyclicVector_of_minpoly_eq_charpoly`) type-check modulo that one lemma.
-- Aristotle MCP is **DOWN** this session ("Resource not found" on both
-  `prove_file` and `prove`). Could not delegate the hard lemma.
-- No PR opened (file carries a `sorry`; gallery requires verified).
+- **DONE.** `proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean` (141 lines, 5 theorems,
+  0 defs) compiles via host `lake env lean` with **0 sorries**. `#print axioms` on
+  all three main theorems returns only `[propext, Classical.choice, Quot.sound]`
+  — no `sorryAx`, no `Lean.ofReduceBool`. Status = verified, badge = original.
+- The outstanding lemma `exists_vecAnnIdeal_eq_minpoly` was discharged **directly
+  from Mathlib**, NOT by the hand-built combination route below: there IS a Mathlib
+  counterpart after all.
+- Gallery integration added: `src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01/`
+  (meta.json + annotations.json). Added to `proofs/Proofs.lean` aggregator.
 
-## Proof strategy for the outstanding lemma (next session / Aristotle)
+## How the maximal-order lemma was actually proved
 
-`exists_vecAnnIdeal_eq_minpoly` via *maximal-order vector*:
-1. **Order arithmetic** in a cyclic `K[X]`-submodule: for the order `f = ord(u)`,
-   `ord(p • u) = f / gcd(f, p)`.
-2. **Coprime combination (CRT)**: if `ord(u)=f`, `ord(w)=g`, `gcd(f,g)=1`, then
-   `ord(u+w) = f·g`.
-3. **Pairwise lcm**: combine (1)+(2) to get, from `u` (order `f`) and `w` (order
-   `g`), a vector of order `lcm(f,g)` (split `f,g` into coprime parts whose product
-   is `lcm`).
-4. **Iterate over the standard basis** `e₁,…,eₙ`: `minpoly K M = lcm_i ord(eᵢ)`
-   (minpoly = lcm of orders of a generating set), so folding the pairwise
-   combination yields a vector of order `minpoly`, i.e. `vecAnnIdeal = span{minpoly}`.
-   Use `minpoly_ideal_le_vecAnnIdeal` for the `≤` half; the constructed order gives `≥`.
+The key Mathlib lemma (found by deeper search, Session 3):
 
-No direct Mathlib counterpart was found (searched `LinearAlgebra/FreeModule/PID`,
-`AnnihilatingPolynomial`, `Matrix/Charpoly/*`). Mathlib's PID structure theorem
-(`Mathlib/Algebra/Module/PID`) gives the decomposition existentially but extracting
-a concrete maximal-order vector is itself work; the combination route above is more
-direct in the parent's `vecAnnIdeal` language.
+  `Module.exists_ker_toSpanSingleton_eq_annihilator [Module.Finite R M] :`
+  `  ∃ x : M, LinearMap.ker (LinearMap.toSpanSingleton R _ x) = Module.annihilator R M`
+  (in `Mathlib/Algebra/Module/PID.lean`, a corollary of the PID structure theorem).
+
+Apply it with `R := K[X]`, `M := Module.AEval' M.mulVecLin` (finite via the
+instance `Module.Finite R[X] (AEval' φ)` at `Mathlib/.../Module/AEval.lean:211`).
+Transport the element `x` back via `(Module.AEval'.of M.mulVecLin).symm` to a
+concrete `v : Fin n → K`. Then:
+- `vecAnnIdeal M v = annihilator K[X] (AEval' M.mulVecLin)` because both ideals are
+  `{r | r • x = 0}` — the cyclic-submodule annihilator (parent's `mem_vecAnnIdeal_iff`)
+  vs `ker (toSpanSingleton x)` (`mem_ker` + `toSpanSingleton ... r = r • x` by `rfl`).
+  After `rw [mem_vecAnnIdeal_iff, LinearEquiv.apply_symm_apply, LinearMap.mem_ker]`
+  the goal closes by `rfl`.
+- `annihilator K[X] (AEval' M.mulVecLin) = span{minpoly K M}` by the parent's
+  `kn_module_annihilator_eq_minpoly` (rewritten forward, NOT `←`).
+
+Proof body (the whole lemma):
+```
+obtain ⟨x, hx⟩ := Module.exists_ker_toSpanSingleton_eq_annihilator
+  (R := K[X]) (M := Module.AEval' M.mulVecLin)
+refine ⟨(Module.AEval'.of M.mulVecLin).symm x, ?_⟩
+rw [kn_module_annihilator_eq_minpoly M, ← hx]
+ext r
+rw [mem_vecAnnIdeal_iff, LinearEquiv.apply_symm_apply, LinearMap.mem_ker]
+rfl
+```
+
+## Strategy NOT needed (the hand-built combination route, kept for reference)
+
+The order-arithmetic / coprime-combination / pairwise-lcm construction
+(`ord(p•u)=f/gcd(f,p)`, CRT for coprime orders, fold over the basis) is a valid
+but unnecessary ~150-line alternative. Mathlib's `exists_ker_toSpanSingleton_eq_annihilator`
+gives the maximal-order element directly.
 
 ---
 
-## Dead Ends
+## Lessons
 
-- No Mathlib lemma for "cyclic vector exists" / "vector of maximal order" /
-  "minpoly = charpoly ⟺ cyclic". Must be built (≈150–250 lines) or delegated.
+- The "no Mathlib counterpart" claim in Session 2 was WRONG. `Module.exists_
+  ker_toSpanSingleton_eq_annihilator` is exactly the maximal-order-vector lemma.
+  Search `Mathlib/Algebra/Module/PID.lean` and `Mathlib/.../FieldTheory/Galois/
+  NormalBasis.lean` (which applies it) before concluding a structure fact is absent.
+- `rw [← kn_module_annihilator_eq_minpoly]` fails (pattern not in goal); the
+  forward direction is correct since the lemma reads `span{minpoly} = annihilator`.

--- a/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,75 @@
+# Knowledge Base: cayley-hamilton-oq-01-oq-01-oq-01
+
+Existence of a cyclic vector in the non-derogatory case (minpoly = charpoly).
+
+---
+
+## Problem Understanding
+
+Goal: for an `n×n` matrix `M` over a field `K`, if `minpoly K M = M.charpoly`
+(equivalently `(minpoly K M).natDegree = n`), produce a cyclic vector `v`
+(parent's `IsCyclicVector M v`: no nonzero polynomial of degree `< n` kills `v`).
+
+The parent `CayleyHamiltonOQ01OQ01` already built the `K[X]`-module framework:
+`Module.AEval' M.mulVecLin`, the vector annihilator ideal `vecAnnIdeal M v`,
+`mem_vecAnnIdeal_iff`, `minpoly_ideal_le_vecAnnIdeal` (span{minpoly} ≤ vecAnnIdeal
+always), and `cyclic_vecAnnIdeal_eq_minpoly` (the EASY direction: cyclic ⟹ order =
+minpoly).
+
+---
+
+## Insights
+
+- **The whole theorem reduces to ONE general lemma** (true for every `M`):
+  `exists_vecAnnIdeal_eq_minpoly : ∃ v, vecAnnIdeal M v = Ideal.span {minpoly K M}`.
+  This is the classical *existence of a vector of maximal order* — a vector whose
+  order (monic generator of its annihilator ideal) is exactly the minimal
+  polynomial = the module exponent.
+- Given such a `v`, cyclicity is **elementary** and is fully proved here
+  (`isCyclicVector_of_vecAnnIdeal_eq_minpoly`): a degree-`< n` poly `p` killing `v`
+  lies in `span{minpoly}`, so `minpoly ∣ p`; nonzero `p` would have degree
+  `≥ n = deg minpoly`, contradiction.
+- The bridge `aeval M.mulVecLin p v = 0 ↔ p ∈ vecAnnIdeal M v`
+  (`aeval_eq_zero_iff_mem_vecAnnIdeal`) is proved by mirroring the parent's
+  `Module.AEval'.of … symm` / `Module.AEval.of_symm_smul` translation.
+- Non-derogatory ⇒ full degree: `Matrix.charpoly_natDegree_eq_dim` +
+  `Fintype.card_fin` give `(minpoly K M).natDegree = n` from `minpoly = charpoly`.
+
+## Status (Session 2, 2026-06-25)
+
+- **VERIFIED scaffold built** in `proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean`,
+  compiles via host `lake env lean` with the **single** `sorry` being
+  `exists_vecAnnIdeal_eq_minpoly` (line ~103). Both main theorems
+  (`exists_cyclicVector_of_minpoly_natDegree_eq`,
+  `exists_cyclicVector_of_minpoly_eq_charpoly`) type-check modulo that one lemma.
+- Aristotle MCP is **DOWN** this session ("Resource not found" on both
+  `prove_file` and `prove`). Could not delegate the hard lemma.
+- No PR opened (file carries a `sorry`; gallery requires verified).
+
+## Proof strategy for the outstanding lemma (next session / Aristotle)
+
+`exists_vecAnnIdeal_eq_minpoly` via *maximal-order vector*:
+1. **Order arithmetic** in a cyclic `K[X]`-submodule: for the order `f = ord(u)`,
+   `ord(p • u) = f / gcd(f, p)`.
+2. **Coprime combination (CRT)**: if `ord(u)=f`, `ord(w)=g`, `gcd(f,g)=1`, then
+   `ord(u+w) = f·g`.
+3. **Pairwise lcm**: combine (1)+(2) to get, from `u` (order `f`) and `w` (order
+   `g`), a vector of order `lcm(f,g)` (split `f,g` into coprime parts whose product
+   is `lcm`).
+4. **Iterate over the standard basis** `e₁,…,eₙ`: `minpoly K M = lcm_i ord(eᵢ)`
+   (minpoly = lcm of orders of a generating set), so folding the pairwise
+   combination yields a vector of order `minpoly`, i.e. `vecAnnIdeal = span{minpoly}`.
+   Use `minpoly_ideal_le_vecAnnIdeal` for the `≤` half; the constructed order gives `≥`.
+
+No direct Mathlib counterpart was found (searched `LinearAlgebra/FreeModule/PID`,
+`AnnihilatingPolynomial`, `Matrix/Charpoly/*`). Mathlib's PID structure theorem
+(`Mathlib/Algebra/Module/PID`) gives the decomposition existentially but extracting
+a concrete maximal-order vector is itself work; the combination route above is more
+direct in the parent's `vecAnnIdeal` language.
+
+---
+
+## Dead Ends
+
+- No Mathlib lemma for "cyclic vector exists" / "vector of maximal order" /
+  "minpoly = charpoly ⟺ cyclic". Must be built (≈150–250 lines) or delegated.

--- a/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/state.md
@@ -1,29 +1,27 @@
 # Research State: cayley-hamilton-oq-01-oq-01-oq-01
 
 ## Current State
-**Phase**: ACT
+**Phase**: DONE
 **Path**: fast
 **Since**: 2026-06-25T02:20:00-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Closing `exists_vecAnnIdeal_eq_minpoly` (existence of a vector of maximal order),
-the sole outstanding lemma. The full reduction is verified.
+COMPLETE. `exists_vecAnnIdeal_eq_minpoly` discharged directly from Mathlib's
+`Module.exists_ker_toSpanSingleton_eq_annihilator`. Whole file is 0-sorry,
+0-axiom (propext/Classical.choice/Quot.sound only), verified.
 
-## Active Approach
-Maximal-order vector via pairwise lcm/coprime-combination folded over the standard
-basis. See knowledge.md "Proof strategy for the outstanding lemma".
+## Resolution
+- `proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean`: 141 lines, 5 theorems, 0 sorries.
+- Gallery entry added (meta.json + annotations.json); aggregator updated.
+- See knowledge.md "How the maximal-order lemma was actually proved".
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1
+- Total attempts: 2
+- Approaches tried: 2 (Session 2 reduction scaffold; Session 3 Mathlib discharge)
 
 ## Blockers
-- Aristotle MCP down this session (could not delegate the hard lemma).
-- The outstanding lemma has no Mathlib counterpart (must be built or delegated).
+- None remaining.
 
 ## Next Action
-Either (a) retry Aristotle on CayleyHamiltonOQ01OQ01OQ01.lean when the MCP is back
-up, or (b) build the combination-lemma chain (steps 1–4 in knowledge.md) manually.
-Then verify 0-sorry/0-axiom and ship the gallery entry.
+Ship: commit + PR to main (research label, no loom:review-requested).

--- a/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/cayley-hamilton-oq-01-oq-01-oq-01/state.md
@@ -1,0 +1,29 @@
+# Research State: cayley-hamilton-oq-01-oq-01-oq-01
+
+## Current State
+**Phase**: ACT
+**Path**: fast
+**Since**: 2026-06-25T02:20:00-07:00
+**Iteration**: 2
+
+## Current Focus
+Closing `exists_vecAnnIdeal_eq_minpoly` (existence of a vector of maximal order),
+the sole outstanding lemma. The full reduction is verified.
+
+## Active Approach
+Maximal-order vector via pairwise lcm/coprime-combination folded over the standard
+basis. See knowledge.md "Proof strategy for the outstanding lemma".
+
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Blockers
+- Aristotle MCP down this session (could not delegate the hard lemma).
+- The outstanding lemma has no Mathlib counterpart (must be built or delegated).
+
+## Next Action
+Either (a) retry Aristotle on CayleyHamiltonOQ01OQ01OQ01.lean when the MCP is back
+up, or (b) build the combination-lemma chain (steps 1–4 in knowledge.md) manually.
+Then verify 0-sorry/0-axiom and ship the gallery entry.

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-choq010101-00-header",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 59
+    },
+    "type": "concept",
+    "title": "Overview: Existence of a Cyclic Vector When μ = χ",
+    "content": "An n×n matrix M is non-derogatory when its minimal polynomial has full degree n, equivalently minpoly K M = charpoly M. This file proves the structural hallmark of that case: M admits a cyclic vector — a vector no nonzero polynomial of degree < n annihilates, whose K[X]-orbit spans all of Kⁿ. The whole statement reduces to one general fact (true for every M): the existence of a vector of maximal order, whose annihilator ideal is exactly span{minpoly K M}. The file builds on the parent cayley-hamilton-oq-01-oq-01, which supplied the vecAnnIdeal / IsCyclicVector framework and the whole-space annihilator identity kn_module_annihilator_eq_minpoly.",
+    "mathContext": "Non-derogatory ⟺ deg(minpoly K M) = n ⟺ M has a cyclic vector ⟺ M ∼ companion matrix of charpoly.",
+    "significance": "central",
+    "relatedConcepts": [
+      "cyclic vector",
+      "non-derogatory matrix",
+      "rational canonical form",
+      "vector of maximal order",
+      "K[X]-module structure"
+    ],
+    "prerequisites": [
+      "cayley-hamilton-oq-01-oq-01 (vecAnnIdeal, IsCyclicVector)",
+      "Module.AEval'",
+      "modules over a PID"
+    ]
+  },
+  {
+    "id": "ann-choq010101-01-bridge",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 77
+    },
+    "type": "technique",
+    "title": "Bridging p(M)·v = 0 and Membership in vecAnnIdeal",
+    "content": "aeval_eq_zero_iff_mem_vecAnnIdeal proves the equivalence aeval M.mulVecLin p v = 0 ↔ p ∈ vecAnnIdeal M v. It rewrites with the parent's mem_vecAnnIdeal_iff (membership ↔ p • (AEval'.of v) = 0) and transports both directions through the Module.AEval'.of M.mulVecLin linear equivalence, using Module.AEval.of_symm_smul to turn the formal scalar action f • m back into the concrete aeval φ f applied in Kⁿ. This is the translation layer that lets the concrete annihilation statement of cyclicity be reasoned about as ideal membership.",
+    "mathContext": "p annihilates v in Kⁿ ⟺ p lies in the cyclic-submodule annihilator vecAnnIdeal M v.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Module.AEval'",
+      "Module.AEval.of_symm_smul",
+      "annihilator ideal"
+    ],
+    "prerequisites": [
+      "mem_vecAnnIdeal_iff (parent)",
+      "LinearEquiv injectivity"
+    ]
+  },
+  {
+    "id": "ann-choq010101-02-reduction",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 97
+    },
+    "type": "key-step",
+    "title": "A Maximal-Order Vector Is Cyclic (Degree Argument)",
+    "content": "isCyclicVector_of_vecAnnIdeal_eq_minpoly is the elementary reduction. Given a vector v whose annihilator ideal is exactly span{minpoly K M}, and deg(minpoly K M) = n, suppose a polynomial p with deg p < n kills v. Then p ∈ vecAnnIdeal M v = span{minpoly K M}, so minpoly K M ∣ p (Ideal.mem_span_singleton). If p were nonzero, natDegree_le_of_dvd would force deg(minpoly K M) ≤ deg p, i.e. n ≤ deg p < n — a contradiction. Hence p = 0 and v is cyclic. The non-derogatory hypothesis enters precisely as deg(minpoly) = n.",
+    "mathContext": "p ∈ span{minpoly}, deg p < n = deg minpoly, p ≠ 0 ⟹ deg minpoly ≤ deg p — impossible; so p = 0.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "Ideal.mem_span_singleton",
+      "Polynomial.natDegree_le_of_dvd",
+      "divisibility and degree"
+    ],
+    "prerequisites": [
+      "aeval_eq_zero_iff_mem_vecAnnIdeal",
+      "IsCyclicVector (parent)"
+    ]
+  },
+  {
+    "id": "ann-choq010101-03-maxorder",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 99,
+      "endLine": 122
+    },
+    "type": "key-step",
+    "title": "Existence of a Vector of Maximal Order (PID Structure Theorem)",
+    "content": "exists_vecAnnIdeal_eq_minpoly is the one nontrivial ingredient, and it holds for every M, derogatory or not. Kⁿ is presented as the finite K[X]-module Module.AEval' M.mulVecLin, so Mathlib's Module.exists_ker_toSpanSingleton_eq_annihilator (a corollary of the PID structure theorem) yields an element x whose cyclic-submodule annihilator ker(toSpanSingleton x) equals the whole module's annihilator. The parent's kn_module_annihilator_eq_minpoly identifies that module annihilator with span{minpoly K M}. Transporting x back to a concrete v ∈ Kⁿ via (AEval'.of M.mulVecLin).symm and unfolding vecAnnIdeal, the two ideals coincide because both are characterised by r • x = 0 — the final equality is definitional (rfl) after the mem_vecAnnIdeal_iff / mem_ker rewrites.",
+    "mathContext": "Module.exists_ker_toSpanSingleton_eq_annihilator on Module.AEval' M.mulVecLin gives v with vecAnnIdeal M v = annihilator = span{minpoly K M}.",
+    "significance": "essential",
+    "relatedConcepts": [
+      "Module.exists_ker_toSpanSingleton_eq_annihilator",
+      "PID structure theorem",
+      "LinearMap.toSpanSingleton",
+      "kn_module_annihilator_eq_minpoly (parent)"
+    ],
+    "prerequisites": [
+      "finitely generated modules over a PID",
+      "Module.AEval' finiteness instance"
+    ]
+  },
+  {
+    "id": "ann-choq010101-04-main",
+    "proofId": "cayley-hamilton-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 141
+    },
+    "type": "concept",
+    "title": "Main Theorems: From μ = χ to a Cyclic Vector",
+    "content": "The two headline results compose the pieces. exists_cyclicVector_of_minpoly_natDegree_eq takes deg(minpoly K M) = n, obtains the maximal-order vector from exists_vecAnnIdeal_eq_minpoly, and upgrades it to cyclic via isCyclicVector_of_vecAnnIdeal_eq_minpoly. exists_cyclicVector_of_minpoly_eq_charpoly handles the non-derogatory hypothesis in its natural form minpoly K M = charpoly M, converting it to deg(minpoly) = n through Matrix.charpoly_natDegree_eq_dim and Fintype.card_fin. This is the converse direction of the cyclic-vector ⟺ μ = χ equivalence and the per-block engine of the rational canonical form.",
+    "mathContext": "minpoly = charpoly ⟹ deg minpoly = card(Fin n) = n ⟹ ∃ cyclic vector.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Matrix.charpoly_natDegree_eq_dim",
+      "rational canonical form",
+      "companion matrix"
+    ],
+    "prerequisites": [
+      "exists_vecAnnIdeal_eq_minpoly",
+      "isCyclicVector_of_vecAnnIdeal_eq_minpoly"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "cayley-hamilton-oq-01-oq-01-oq-01",
+  "title": "Existence of a Cyclic Vector in the Non-Derogatory Case",
+  "slug": "cayley-hamilton-oq-01-oq-01-oq-01",
+  "description": "Resolves the open question from cayley-hamilton-oq-01-oq-01: when the minimal and characteristic polynomials of an n×n matrix M coincide (the non-derogatory case), M admits a cyclic vector. The whole statement reduces to the classical existence of a vector of maximal order — supplied by Mathlib's PID structure theorem — after which cyclicity follows by an elementary degree argument in the parent's vecAnnIdeal framework.",
+  "meta": {
+    "author": "researcher-2 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclic_module",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ01OQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "module-theory",
+      "annihilator-ideal",
+      "cyclic-vector",
+      "rational-canonical-form",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Module.exists_ker_toSpanSingleton_eq_annihilator",
+        "description": "for a finite module over a PID, some element x has ker(toSpanSingleton x) = the whole module's annihilator — existence of a vector of maximal order",
+        "module": "Mathlib.Algebra.Module.PID"
+      },
+      {
+        "theorem": "Module.AEval'.instModuleFinitePolynomial",
+        "description": "Module.AEval' φ is a finite K[X]-module when the base is a finite K-module, supplying the finiteness hypothesis of the PID structure theorem",
+        "module": "Mathlib.Algebra.Polynomial.Module.AEval"
+      },
+      {
+        "theorem": "Submodule.mem_annihilator_span_singleton",
+        "description": "f annihilates span{m} iff f • m = 0",
+        "module": "Mathlib.LinearAlgebra.Span"
+      },
+      {
+        "theorem": "Polynomial.natDegree_le_of_dvd",
+        "description": "if p ∣ q and q ≠ 0 then deg p ≤ deg q, used to derive the degree contradiction",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "Matrix.charpoly_natDegree_eq_dim",
+        "description": "the characteristic polynomial of an n×n matrix has degree n, converting minpoly = charpoly into deg minpoly = n",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff"
+      }
+    ],
+    "originalContributions": [
+      "aeval_eq_zero_iff_mem_vecAnnIdeal: a polynomial p annihilates v under the M-action (p(M)·v = 0) iff p lies in the parent's vector-annihilator ideal vecAnnIdeal M v",
+      "isCyclicVector_of_vecAnnIdeal_eq_minpoly: a maximal-order vector (vecAnnIdeal M v = span{minpoly K M}) with deg(minpoly) = n is cyclic — a degree-<n annihilating polynomial would be divisible by minpoly yet have smaller degree, forcing it to vanish",
+      "exists_vecAnnIdeal_eq_minpoly: every M admits a vector whose annihilator ideal is exactly span{minpoly K M}, obtained by transporting Mathlib's maximal-order element along the Module.AEval'.of equivalence and identifying the module annihilator via the parent's kn_module_annihilator_eq_minpoly",
+      "exists_cyclicVector_of_minpoly_natDegree_eq: deg(minpoly K M) = n ⟹ M admits a cyclic vector",
+      "exists_cyclicVector_of_minpoly_eq_charpoly: minpoly K M = charpoly M ⟹ M admits a cyclic vector — the converse direction of the cyclic-vector ⟺ μ = χ equivalence"
+    ],
+    "references": [
+      {
+        "authors": "Dummit, David S.; Foote, Richard M.",
+        "title": "Abstract Algebra",
+        "year": "2004",
+        "venue": "Wiley",
+        "note": "Chapter 12: modules over a PID, invariant factors, rational canonical form, cyclic vectors and non-derogatory matrices"
+      },
+      {
+        "authors": "Hoffman, Kenneth; Kunze, Ray",
+        "title": "Linear Algebra",
+        "year": "1971",
+        "venue": "Prentice-Hall",
+        "note": "Cyclic subspaces and cyclic vectors; M has a cyclic vector iff its minimal and characteristic polynomials coincide"
+      }
+    ],
+    "prerequisites": [
+      "The parent entry cayley-hamilton-oq-01-oq-01 (vecAnnIdeal, IsCyclicVector, kn_module_annihilator_eq_minpoly)",
+      "Kⁿ as a module over K[X] via a fixed endomorphism (Module.AEval')",
+      "Structure theory of finitely generated modules over a PID (existence of a maximal-order element)",
+      "Minimal and characteristic polynomials; Cayley-Hamilton"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 141,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "An n×n matrix M over a field K turns Kⁿ into a module over K[X] (X acting as M). Because K[X] is a PID, this module decomposes into cyclic pieces K[X]/(d₁) ⊇ ... ⊇ K[X]/(dₖ), the invariant factors, with dₖ the minimal polynomial of M. M is called non-derogatory when its minimal polynomial has full degree n, equivalently when minpoly K M = charpoly M; this is exactly the case in which the decomposition is a single cyclic block and M is similar to the companion matrix of its characteristic polynomial. The structural hallmark of this situation is the existence of a cyclic vector: a vector v whose K[X]-orbit {p(M)·v} spans all of Kⁿ, equivalently a vector that no nonzero polynomial of degree < n annihilates.\n\nThe parent entry cayley-hamilton-oq-01-oq-01 built the per-vector annihilator theory (the ideal vecAnnIdeal M v of polynomials killing v) and proved the easy direction: a cyclic vector has vector-annihilator ideal exactly span{minpoly K M}. This entry settles the converse existence statement — that a cyclic vector actually exists whenever μ = χ — which is the heart of the rational-canonical-form theorem for a single block.",
+    "problemStatement": "**Open Question (from parent proof cayley-hamilton-oq-01-oq-01)**: Prove existence of a cyclic vector when the minimal and characteristic polynomials coincide (the non-derogatory case).\n\n**Resolution**: We prove that for every M there is a vector of maximal order (vecAnnIdeal M v = span{minpoly K M}); when deg(minpoly K M) = n this vector is cyclic; and minpoly K M = charpoly M supplies deg(minpoly K M) = n. Hence M admits a cyclic vector.",
+    "text": "A 141-line, axiom-free development (5 theorems) extending the parent's annihilator framework. aeval_eq_zero_iff_mem_vecAnnIdeal bridges the concrete annihilation p(M)·v = 0 with membership in vecAnnIdeal M v, mirroring the parent's Module.AEval'.of translation. isCyclicVector_of_vecAnnIdeal_eq_minpoly performs the elementary reduction: if a polynomial p of degree < n kills a maximal-order vector v, then p ∈ vecAnnIdeal M v = span{minpoly K M} so minpoly K M ∣ p; since a nonzero multiple of minpoly has degree ≥ n, p must be 0, so v is cyclic. The existence of the maximal-order vector exists_vecAnnIdeal_eq_minpoly is supplied by Mathlib's PID structure theorem Module.exists_ker_toSpanSingleton_eq_annihilator applied to the finite K[X]-module Module.AEval' M.mulVecLin: its maximal-order element x is transported back along the Module.AEval'.of equivalence, and the parent's kn_module_annihilator_eq_minpoly identifies the module annihilator with span{minpoly K M}. The two main theorems then chain these facts, with minpoly = charpoly converted to deg minpoly = n via charpoly_natDegree_eq_dim.",
+    "proofStrategy": "The argument is a reduction to a single general module-theoretic fact, true for every M (derogatory or not): there exists a vector of maximal order, i.e. one whose annihilator ideal equals span{minpoly K M}. (1) exists_vecAnnIdeal_eq_minpoly obtains this vector from Mathlib's Module.exists_ker_toSpanSingleton_eq_annihilator on the finite K[X]-module Module.AEval' M.mulVecLin, transporting the abstract element back to a concrete v ∈ Kⁿ and rewriting the module annihilator as span{minpoly K M} via the parent's kn_module_annihilator_eq_minpoly; the equality of the cyclic-submodule annihilator with the kernel of toSpanSingleton is definitional (both are {r : r • x = 0}). (2) isCyclicVector_of_vecAnnIdeal_eq_minpoly upgrades a maximal-order vector to a cyclic one whenever deg(minpoly) = n, by the divisibility/degree contradiction. (3) The main theorems compose (1) and (2); the non-derogatory hypothesis minpoly = charpoly yields deg(minpoly) = n through Matrix.charpoly_natDegree_eq_dim and Fintype.card_fin.",
+    "keyInsights": [
+      "The existence of a cyclic vector in the non-derogatory case reduces entirely to one general fact — existence of a vector of maximal order — which holds for every matrix, not just non-derogatory ones.",
+      "That general fact is exactly Mathlib's Module.exists_ker_toSpanSingleton_eq_annihilator (a corollary of the PID structure theorem), once Kⁿ is presented as the finite K[X]-module Module.AEval' M.mulVecLin.",
+      "The parent's kn_module_annihilator_eq_minpoly is the glue: it identifies the whole-module annihilator (kernel of toSpanSingleton for the maximal-order element) with span{minpoly K M}.",
+      "Cyclicity from maximal order is a pure degree argument: a degree-<n annihilator would be a proper-degree multiple of the degree-n minimal polynomial, which is impossible unless it is zero.",
+      "Non-derogatory (minpoly = charpoly) is equivalent to deg(minpoly) = n, the precise hypothesis the degree argument needs."
+    ],
+    "prerequisites": [
+      "Linear algebra (minimal/characteristic polynomial, non-derogatory matrices, rational canonical form)",
+      "Module theory over a PID (annihilators, cyclic modules, vectors of maximal order)",
+      "Polynomial algebra (divisibility and degree)"
+    ]
+  },
+  "conclusion": {
+    "summary": "When minpoly K M = charpoly M (the non-derogatory case), M admits a cyclic vector. The proof reduces to the existence of a vector of maximal order — vecAnnIdeal M v = span{minpoly K M} — obtained from Mathlib's PID structure theorem on the finite K[X]-module Module.AEval' M.mulVecLin; a degree argument then shows any such vector is cyclic when deg(minpoly) = n. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This completes the converse direction of the cyclic-vector ⟺ μ = χ equivalence and, together with the parent entry, the per-vector annihilator picture: a non-derogatory matrix is similar to a single companion matrix, the rank-1 building block of the rational canonical form. The reduction isolates the only nontrivial ingredient — a vector of maximal order — and discharges it via Mathlib's PID machinery.",
+    "openQuestions": [
+      "Assemble the invariant factors d₁ | ... | dₖ = minpoly and the full rational canonical form from the cyclic decomposition (not just the single non-derogatory block).",
+      "Give an explicit construction of a maximal-order vector (e.g. by combining basis vectors of coprime orders) rather than invoking the abstract PID structure theorem.",
+      "Relate the vector orders to the elementary divisors of M and quantify how many matrices over a finite field are non-derogatory."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Resolves the parent's stated open question, reusing its vecAnnIdeal / IsCyclicVector framework and kn_module_annihilator_eq_minpoly"
+    },
+    {
+      "targetId": "cayley-hamilton-oq-01",
+      "relationship": "related",
+      "description": "The grandparent annihilator-reduction entry behind the whole-space module-annihilator theory"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Cayley-Hamilton underlies the identification deg(charpoly) = n used to convert non-derogatory into deg(minpoly) = n"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.CayleyHamiltonOQ01OQ01",
+      "Mathlib.Algebra.Module.PID"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial",
+      "Module",
+      "BigOperators",
+      "CayleyHamiltonOQ01OQ01"
+    ],
+    "namespace": "CayleyHamiltonOQ01OQ01OQ01",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/CayleyHamiltonOQ01OQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the open question from **cayley-hamilton-oq-01-oq-01**: when an n×n matrix M over a field K is **non-derogatory** (minimal polynomial = characteristic polynomial), M admits a **cyclic vector**. This is the converse direction of the cyclic-vector ⟺ μ = χ equivalence and the per-block engine of the rational canonical form.

A prior WIP commit had reduced the statement to a single outstanding lemma (`exists_vecAnnIdeal_eq_minpoly`, existence of a vector of maximal order) and left it `sorry`. This PR **discharges that lemma directly from Mathlib**, completing the entry to a fully verified, 0-axiom proof.

## How the last lemma was closed

The maximal-order-vector fact — for every M there is a `v` with `vecAnnIdeal M v = span{minpoly K M}` — turned out to have a Mathlib counterpart:

```
Module.exists_ker_toSpanSingleton_eq_annihilator [Module.Finite R M] :
  ∃ x, ker (toSpanSingleton R _ x) = annihilator R M
```

Applied with `R := K[X]`, `M := Module.AEval' M.mulVecLin` (finite via the existing `Module.Finite K[X] (AEval' φ)` instance). Transport the element back along `(Module.AEval'.of M.mulVecLin).symm`; then `vecAnnIdeal M v = ker (toSpanSingleton x)` is **definitional** (both are `{r | r • x = 0}`), and the parent's `kn_module_annihilator_eq_minpoly` identifies the module annihilator with `span{minpoly K M}`.

Given that vector, cyclicity is the elementary degree argument already in the scaffold: a degree-`< n` annihilator would be a proper-degree multiple of the degree-`n` minimal polynomial, hence zero.

## Verification

- `proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean`: **141 lines, 5 theorems, 0 defs, 0 sorries**.
- Compiles via host `lake env lean` against the parent's olean.
- `#print axioms` on all three main results (`exists_vecAnnIdeal_eq_minpoly`, `exists_cyclicVector_of_minpoly_natDegree_eq`, `exists_cyclicVector_of_minpoly_eq_charpoly`): `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. **Status: verified / original / 0-axiom.**

## Changes
- `proofs/Proofs/CayleyHamiltonOQ01OQ01OQ01.lean` — discharge the sorry; updated docstrings.
- `proofs/Proofs.lean` — add the entry to the aggregator import list.
- `src/data/proofs/cayley-hamilton-oq-01-oq-01-oq-01/{meta.json,annotations.json}` — gallery integration.
- `research/problems/cayley-hamilton-oq-01-oq-01-oq-01/{knowledge.md,state.md}` — working notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)