### PR TITLE
audit: mark 2 gallery proofs clean (area-of-circle-oq070502, bezout-oq03010201)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23661,8 +23661,20 @@
       "issues": [],
       "lastAudited": "2026-06-25T09:39:40Z",
       "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-05-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:51:14Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-03-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T09:51:14Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T09:39:40Z"
+  "lastUpdated": "2026-06-25T09:51:14Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited 2 never-before-audited gallery proofs against their Lean source. Both **CLEAN** — claims match the kernel.

| Proof | status/badge | thm | def | sorry | axiom | native_decide | verdict |
|-------|--------------|-----|-----|-------|-------|---------------|---------|
| area-of-circle-oq-07-oq-05-oq-02 | verified/mathlib | 4 | 0 | 0 | 0 | 0 | clean |
| bezout-identity-oq-03-oq-01-oq-02-oq-01 | verified/original | 13 | 3 | 0 | 0 | 0 | clean |

### area-of-circle-oq-07-oq-05-oq-02
Gaussian second moment recovered as `Γ(3/2) = √π/2` via the `u = x²` substitution. Badge `mathlib` is correct: the overview explicitly discloses reliance on Mathlib's Gamma machinery (`Gamma_eq_integral`, `Gamma_add_one`, `Gamma_one_half_eq`, `integral_comp_rpow_Ioi_of_pos`) and reuses the parent's `gaussian_second_moment`. theoremCount 4 matches.

### bezout-identity-oq-03-oq-01-oq-02-oq-01
Iterated CRT for k congruences: solvable iff pairwise compatible, unique mod lcm. Badge `original` is correct: the core `gcd a (lcm b c) = lcm (gcd a b) (gcd a c)` distributivity lemma is genuinely not in Mathlib (proved via prime factorizations), and the result reuses the parent's two-modulus CRT. theoremCount 13 matches (the 13th, `@[simp] theorem lcmList_nil`, is masked by anchored grep). `decide` in sanity examples is kernel-decide (not native_decide), so 0-axiom holds.

Two other unaudited targets (abel-ruffini-oq-04-oq-01-oq-01, derangements-oq-02-oq-01-oq-01) are **phantom** (untracked on main, in-flight) and were skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)