### PR TITLE
Research: beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02 — low-order moments of the integer Beta(m+1,n+1) distribution [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -216,6 +216,7 @@ import Proofs.AreaOfCircleOQ07OQ04
 import Proofs.AreaOfCircleOQ07OQ05
 import Proofs.AreaOfCircleOQ07OQ05OQ01
 import Proofs.AreaOfCircleOQ07OQ05OQ01OQ02
+import Proofs.AreaOfCircleOQ07OQ05OQ02
 import Proofs.ArithmeticSeries
 import Proofs.ArithmeticSeriesOQ00
 import Proofs.ArithmeticSeriesOQ00OQ01
@@ -344,6 +345,8 @@ import Proofs.BertrandsPostulateOQ03OQ04OQ03
 import Proofs.BetaCentralBinomial
 import Proofs.BetaIntegralHalfValue
 import Proofs.BetaIntegralRecurrence
+import Proofs.BetaIntegralRecurrenceOQ01OQ02OQ01
+import Proofs.BetaIntegralRecurrenceOQ01OQ02OQ01OQ01
 import Proofs.BetaIntegralRecurrenceOQ01OQ03OQ01
 import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01
@@ -374,6 +377,7 @@ import Proofs.BezoutIdentityOQ03OQ01OQ01
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ02
 import Proofs.BezoutIdentityOQ03OQ01OQ02
+import Proofs.BezoutIdentityOQ03OQ01OQ02OQ01
 import Proofs.BezoutIdentityOQ03OQ02
 import Proofs.BezoutIdentityOQ03OQ02OQ01
 import Proofs.BezoutIdentityOQ03OQ03
@@ -729,6 +733,7 @@ import Proofs.CayleyHamiltonMinpolyOQ07
 import Proofs.CayleyHamiltonMinpolyOQ07OQ01
 import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
+import Proofs.CayleyHamiltonOQ01OQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ03
 import Proofs.CayleyHamiltonOQ01OQ04
 import Proofs.CayleyHamiltonOQ02
@@ -3254,6 +3259,7 @@ import Proofs.IntermediateValueTheoremOQ03
 import Proofs.InverseGalois
 import Proofs.InverseGaloisA5
 import Proofs.InverseGaloisA5Dedekind
+import Proofs.InverseGaloisA5DedekindInstantiation
 import Proofs.InverseGaloisA5OQ02
 import Proofs.InverseGaloisA5OQ03
 import Proofs.InverseGaloisA5Resultant

--- a/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01OQ02.lean
@@ -1,0 +1,122 @@
+/-
+# Beta Integral OQ-01 (leaf oq-03-oq-01-oq-02): low-order moments of the integer Beta distribution
+
+The parent leaf `BetaIntegralRecurrenceOQ01OQ03OQ01` supplied the **off-diagonal real Euler
+Beta integral at integer arguments**
+
+  `∫₀¹ xᵐ(1-x)ⁿ dx = m!·n! / (m+n+1)!`     (`integral_offdiag_eq_factorial`).
+
+This is exactly the normalising constant `B(m+1, n+1)` of the Beta(m+1, n+1) distribution,
+whose density on `[0,1]` is `xᵐ(1-x)ⁿ / B(m+1,n+1)`.  This leaf answers the parent's open
+question OQ[1] — *can the mean be read off as a one-line corollary by shifting `m ↦ m+1`?* —
+and then pushes through the **full low-order moment structure** of the distribution, all from
+the single parent integral:
+
+* `mean_eq`            — `E[X]   = (m+1) / (m+n+2)`               (the requested corollary),
+* `second_moment_eq`  — `E[X²]  = (m+1)(m+2) / ((m+n+2)(m+n+3))`,
+* `variance_eq`       — `Var(X) = E[X²] − E[X]² = (m+1)(n+1) / ((m+n+2)²(m+n+3))`.
+
+Each moment is a ratio of weighted integrals `∫₀¹ xʲ·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ`, and the weight
+`xʲ` is absorbed by the index shift `m ↦ m+j` so that the parent's closed form applies to both
+numerator and denominator.  The factorial bookkeeping then collapses to elementary algebra.
+
+Specialising to `α = m+1`, `β = n+1`, these are the textbook moments of `Beta(α, β)`:
+`α/(α+β)`, `α(α+1)/((α+β)(α+β+1))`, and `αβ/((α+β)²(α+β+1))`.
+
+*Reference:* moments of the Beta distribution; Euler Beta function at integer arguments.
+-/
+
+import Proofs.BetaIntegralRecurrenceOQ01OQ03OQ01
+import Mathlib.Tactic
+
+open intervalIntegral MeasureTheory
+
+namespace BetaIntegralRecurrenceOQ01OQ03OQ01OQ02
+
+/-- Shorthand for the parent's off-diagonal integer Beta integral. -/
+private alias offdiag := BetaIntegralRecurrenceOQ01OQ03OQ01.integral_offdiag_eq_factorial
+
+/-! ## The normalising constant is positive
+
+The denominator `∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! ` is strictly positive, so every moment ratio
+below is a genuine division (not `x/0`). -/
+
+/-- `B(m+1, n+1) = ∫₀¹ xᵐ(1-x)ⁿ dx > 0`. -/
+theorem normalising_pos (m n : ℕ) :
+    (0:ℝ) < ∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n := by
+  rw [offdiag m n]
+  have hm : (0:ℝ) < (m.factorial : ℝ) := by exact_mod_cast Nat.factorial_pos m
+  have hn : (0:ℝ) < (n.factorial : ℝ) := by exact_mod_cast Nat.factorial_pos n
+  have hd : (0:ℝ) < ((m + n + 1).factorial : ℝ) := by exact_mod_cast Nat.factorial_pos _
+  positivity
+
+/-! ## The mean (parent OQ[1])
+
+`E[X] = ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2)`. The numerator weight `x` shifts
+`m ↦ m+1`, and `(m+1)!·(m+n+1)! / (m!·(m+n+2)!) = (m+1)/(m+n+2)`. -/
+theorem mean_eq (m n : ℕ) :
+    (∫ x in (0:ℝ)..1, x * (x ^ m * (1 - x) ^ n))
+        / (∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n)
+      = ((m : ℝ) + 1) / ((m : ℝ) + n + 2) := by
+  rw [show (∫ x in (0:ℝ)..1, x * (x ^ m * (1 - x) ^ n))
+        = ∫ x in (0:ℝ)..1, x ^ (m + 1) * (1 - x) ^ n from
+        integral_congr (fun x _ => by ring)]
+  rw [offdiag (m + 1) n, offdiag m n]
+  -- index normalisation and factorial peeling
+  have hidx : m + 1 + n + 1 = (m + n + 1) + 1 := by ring
+  have h1 : ((m + 1).factorial : ℝ) = ((m : ℝ) + 1) * (m.factorial : ℝ) := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  have h2 : (((m + n + 1) + 1).factorial : ℝ)
+      = ((m : ℝ) + n + 2) * ((m + n + 1).factorial : ℝ) := by
+    rw [Nat.factorial_succ]; push_cast; ring
+  rw [hidx, h1, h2]
+  have hm : (m.factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos m).ne'
+  have hn : (n.factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos n).ne'
+  have hc : ((m + n + 1).factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos _).ne'
+  have hd : ((m : ℝ) + n + 2) ≠ 0 := by positivity
+  field_simp
+
+/-! ## The second raw moment
+
+`E[X²] = ∫₀¹ x²·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)(m+2)/((m+n+2)(m+n+3))`. The weight `x²`
+shifts `m ↦ m+2`. -/
+theorem second_moment_eq (m n : ℕ) :
+    (∫ x in (0:ℝ)..1, x ^ 2 * (x ^ m * (1 - x) ^ n))
+        / (∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n)
+      = ((m : ℝ) + 1) * ((m : ℝ) + 2) / (((m : ℝ) + n + 2) * ((m : ℝ) + n + 3)) := by
+  rw [show (∫ x in (0:ℝ)..1, x ^ 2 * (x ^ m * (1 - x) ^ n))
+        = ∫ x in (0:ℝ)..1, x ^ (m + 2) * (1 - x) ^ n from
+        integral_congr (fun x _ => by ring)]
+  rw [offdiag (m + 2) n, offdiag m n]
+  have hidx : m + 2 + n + 1 = (m + n + 1) + 1 + 1 := by ring
+  have h1 : ((m + 2).factorial : ℝ)
+      = ((m : ℝ) + 2) * ((m : ℝ) + 1) * (m.factorial : ℝ) := by
+    rw [Nat.factorial_succ, Nat.factorial_succ]; push_cast; ring
+  have h2 : ((((m + n + 1) + 1) + 1).factorial : ℝ)
+      = ((m : ℝ) + n + 3) * ((m : ℝ) + n + 2) * ((m + n + 1).factorial : ℝ) := by
+    rw [Nat.factorial_succ, Nat.factorial_succ]; push_cast; ring
+  rw [hidx, h1, h2]
+  have hm : (m.factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos m).ne'
+  have hn : (n.factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos n).ne'
+  have hc : ((m + n + 1).factorial : ℝ) ≠ 0 := by exact_mod_cast (Nat.factorial_pos _).ne'
+  have hd2 : ((m : ℝ) + n + 2) ≠ 0 := by positivity
+  have hd3 : ((m : ℝ) + n + 3) ≠ 0 := by positivity
+  field_simp
+
+/-! ## The variance
+
+`Var(X) = E[X²] − E[X]² = (m+1)(n+1) / ((m+n+2)²(m+n+3))`, combining the two moments above. -/
+theorem variance_eq (m n : ℕ) :
+    (∫ x in (0:ℝ)..1, x ^ 2 * (x ^ m * (1 - x) ^ n))
+        / (∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n)
+      - ((∫ x in (0:ℝ)..1, x * (x ^ m * (1 - x) ^ n))
+        / (∫ x in (0:ℝ)..1, x ^ m * (1 - x) ^ n)) ^ 2
+      = ((m : ℝ) + 1) * ((n : ℝ) + 1)
+          / ((((m : ℝ) + n + 2) ^ 2) * ((m : ℝ) + n + 3)) := by
+  rw [second_moment_eq, mean_eq]
+  have hd2 : ((m : ℝ) + n + 2) ≠ 0 := by positivity
+  have hd3 : ((m : ℝ) + n + 3) ≠ 0 := by positivity
+  field_simp
+  ring
+
+end BetaIntegralRecurrenceOQ01OQ03OQ01OQ02

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "concept",
+    "title": "Moments of the integer Beta distribution from one integral",
+    "content": "The parent leaf established ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, the normalising constant B(m+1,n+1) of the Beta(m+1,n+1) distribution with density xᵐ(1-x)ⁿ/B on [0,1]. This entry answers the parent's second open question — the mean is a one-line corollary of an index shift — and then derives the full low-order moment structure (mean, second moment, variance) from that single identity, with no new integration. Each moment E[Xʲ] is a ratio ∫₀¹ xʲ·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ in which the weight xʲ merely shifts m ↦ m+j."
+  },
+  {
+    "id": "ann-normalising",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+    "range": { "startLine": 39, "endLine": 51 },
+    "type": "theorem",
+    "title": "The normalising constant is positive",
+    "content": "normalising_pos: 0 < ∫₀¹ xᵐ(1-x)ⁿ. Rewrite the integral to its closed form m!·n!/(m+n+1)! via the parent's integral_offdiag_eq_factorial, then positivity follows from Nat.factorial_pos on numerator and denominator. This certifies every moment below is a genuine quotient by a nonzero Beta value rather than a vacuous division by zero."
+  },
+  {
+    "id": "ann-mean",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 77 },
+    "type": "theorem",
+    "title": "The mean (parent's open question)",
+    "content": "mean_eq: ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2). The numerator integrand x·xᵐ(1-x)ⁿ equals xᵐ⁺¹(1-x)ⁿ (integral_congr with ring), so the parent's closed form applies at index m+1 to the numerator and m to the denominator. Index normalisation m+1+n+1 = (m+n+1)+1 plus Nat.factorial_succ peels (m+1)! = (m+1)·m! and (m+n+2)! = (m+n+2)·(m+n+1)!; field_simp leaves (m+1)/(m+n+2). This is exactly the parent leaf's second open question, confirmed as the index shift m ↦ m+1."
+  },
+  {
+    "id": "ann-second-moment",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 104 },
+    "type": "theorem",
+    "title": "The second raw moment",
+    "content": "second_moment_eq: ∫₀¹ x²·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)(m+2)/((m+n+2)(m+n+3)). The weight x² shifts m ↦ m+2; applying Nat.factorial_succ twice peels (m+2)! = (m+2)(m+1)·m! and (m+n+3)! = (m+n+3)(m+n+2)·(m+n+1)!, and field_simp produces the ascending-factor ratio E[X²] = α(α+1)/((α+β)(α+β+1)) at α = m+1, β = n+1."
+  },
+  {
+    "id": "ann-variance",
+    "proofId": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+    "range": { "startLine": 106, "endLine": 122 },
+    "type": "theorem",
+    "title": "The variance",
+    "content": "variance_eq: E[X²] − E[X]² = (m+1)(n+1)/((m+n+2)²(m+n+3)). Rewriting by the two proven moments, the difference is (m+1)/(m+n+2)·[(m+2)/(m+n+3) − (m+1)/(m+n+2)]; the bracket numerator (m+2)(m+n+2) − (m+1)(m+n+3) collapses to exactly n+1 (field_simp, ring), giving the symmetric Beta variance αβ/((α+β)²(α+β+1)) at α = m+1, β = n+1."
+  }
+]

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/meta.json
@@ -1,0 +1,126 @@
+{
+  "slug": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+  "id": "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02",
+  "title": "Low-Order Moments of the Integer Beta(m+1,n+1) Distribution: Mean, Second Moment, and Variance",
+  "description": "Answers the parent leaf's second open question — derive the mean ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2) of the Beta(m+1,n+1) distribution as a one-line corollary by shifting m ↦ m+1 — and then pushes through the full low-order moment structure from the same single parent integral ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!. Each moment E[Xʲ] is a ratio of weighted integrals ∫₀¹ xʲ·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ; the polynomial weight xʲ is absorbed by the index shift m ↦ m+j so the parent's closed form applies to both numerator and denominator, and the factorial bookkeeping collapses to elementary algebra. Results: mean_eq (E[X] = (m+1)/(m+n+2)), second_moment_eq (E[X²] = (m+1)(m+2)/((m+n+2)(m+n+3))), variance_eq (Var(X) = E[X²] − E[X]² = (m+1)(n+1)/((m+n+2)²(m+n+3))), with normalising_pos certifying the denominator is strictly positive so every ratio is a genuine division. Specialising α = m+1, β = n+1 recovers the textbook Beta(α,β) moments α/(α+β), α(α+1)/((α+β)(α+β+1)), αβ/((α+β)²(α+β+1)). Fully verified: 0 axioms, 0 sorries.",
+  "leanFile": {
+    "imports": [
+      "Proofs.BetaIntegralRecurrenceOQ01OQ03OQ01",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "BetaIntegralRecurrenceOQ01OQ03OQ01OQ02",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01OQ02.lean",
+    "tags": [
+      "special-functions",
+      "beta-function",
+      "beta-distribution",
+      "interval-integral",
+      "moments",
+      "variance",
+      "factorial",
+      "probability"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_congr",
+        "description": "Equality of interval integrals from pointwise equality of integrands on [0,1]; absorbs each polynomial weight x·xᵐ(1-x)ⁿ = xᵐ⁺¹(1-x)ⁿ and x²·xᵐ(1-x)ⁿ = xᵐ⁺²(1-x)ⁿ so the parent closed form applies after the index shift",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(k+1)! = (k+1)·k!; the only number-theoretic input — peels (m+1)!, (m+2)!, and (m+n+2)!, (m+n+3)! down to m! and (m+n+1)! so the factorial ratios collapse to the rational moment formulas",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_pos",
+        "description": "0 < k!; supplies strict positivity of the normalising integral (normalising_pos) and the nonzero denominators for field_simp",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "BetaIntegralRecurrenceOQ01OQ03OQ01.integral_offdiag_eq_factorial",
+        "description": "Parent leaf: ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! — the single integral identity this entry is built on, applied at indices m, m+1, m+2 for the three moments",
+        "module": "Proofs.BetaIntegralRecurrenceOQ01OQ03OQ01"
+      }
+    ],
+    "originalContributions": [
+      "mean_eq: the mean of the integer Beta(m+1,n+1) distribution, ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2), exactly the parent leaf's second open question — obtained as the index shift m ↦ m+1 forces (m+1)!·(m+n+1)!/(m!·(m+n+2)!) = (m+1)/(m+n+2).",
+      "second_moment_eq: the second raw moment ∫₀¹ x²·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)(m+2)/((m+n+2)(m+n+3)), via the weight x² shifting m ↦ m+2.",
+      "variance_eq: the variance Var(X) = E[X²] − E[X]² = (m+1)(n+1)/((m+n+2)²(m+n+3)), combining the two moments — the algebraic cancellation (m+2)(m+n+2) − (m+1)(m+n+3) = n+1 is what produces the (m+1)(n+1) numerator.",
+      "normalising_pos: the normalising constant ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! is strictly positive, certifying every moment is a genuine ratio (division by a nonzero Beta value) rather than a vacuous x/0."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. #print axioms reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) for mean_eq, second_moment_eq, variance_eq, and normalising_pos. No native_decide, so no Lean.ofReduceBool dependency. The entry imports only the parent leaf BetaIntegralRecurrenceOQ01OQ03OQ01 (for its integer Beta integral) and Mathlib.Tactic. Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 122,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Beta(α,β) distribution has density x^(α-1)(1-x)^(β-1)/B(α,β) on [0,1] and is the conjugate prior for the binomial proportion. Its moments are textbook: E[X] = α/(α+β), E[X²] = α(α+1)/((α+β)(α+β+1)), Var(X) = αβ/((α+β)²(α+β+1)). At integer shape parameters α = m+1, β = n+1 the normalising Beta value is the rational m!·n!/(m+n+1)!, which the parent gallery leaf established over ℝ. The parent's second open question asked specifically whether the mean drops out as a one-line corollary by shifting m ↦ m+1. This entry confirms that and, with the same mechanism, records the second moment and the variance — the complete low-order moment structure of the integer Beta distribution — without any new integral.",
+    "problemStatement": "From the parent identity ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, derive the mean, second raw moment, and variance of the Beta(m+1,n+1) distribution as ratios of weighted integrals, in closed rational form in m and n.",
+    "proofStrategy": "Each moment E[Xʲ] is the ratio (∫₀¹ xʲ·xᵐ(1-x)ⁿ)/(∫₀¹ xᵐ(1-x)ⁿ). The numerator integrand xʲ·xᵐ(1-x)ⁿ equals xᵐ⁺ʲ(1-x)ⁿ pointwise on [0,1] (integral_congr with ring), so the parent's closed form integral_offdiag_eq_factorial applies at index m+j to the numerator and at index m to the denominator. For the mean (j=1) the ratio is (m+1)!·n!/(m+n+2)! over m!·n!/(m+n+1)!; index normalisation m+1+n+1 = (m+n+1)+1 plus Nat.factorial_succ peels (m+1)! = (m+1)·m! and (m+n+2)! = (m+n+2)·(m+n+1)!, and field_simp closes (m+1)/(m+n+2). For the second moment (j=2) the same peeling applied twice gives (m+2)(m+1)·m! and (m+n+3)(m+n+2)·(m+n+1)!, yielding (m+1)(m+2)/((m+n+2)(m+n+3)). The variance rewrites E[X²] and E[X] by the two proven moments and reduces E[X²] − E[X]² by field_simp and ring, the cancellation (m+2)(m+n+2) − (m+1)(m+n+3) = n+1 producing the numerator (m+1)(n+1). normalising_pos rewrites the denominator to m!·n!/(m+n+1)! and concludes positivity from Nat.factorial_pos.",
+    "keyInsights": [
+      "**The polynomial weight is just an index shift.** Multiplying the density by xʲ turns the moment integral ∫₀¹ xʲ·xᵐ(1-x)ⁿ into ∫₀¹ xᵐ⁺ʲ(1-x)ⁿ — the *same* family of integrals at parameter m+j. So the single parent identity, applied at m, m+1, m+2, supplies the numerator and denominator of every low-order moment; no new integration is needed.",
+      "**Every moment ratio is a telescoping factorial quotient.** The j-th raw moment is (m+j)!·(m+n+1)! / (m!·(m+n+j+1)!), a ratio that cancels to a product of j ascending factors over j ascending factors: (m+1)···(m+j) / ((m+n+2)···(m+n+j+1)). Nat.factorial_succ is the only arithmetic lemma required.",
+      "**The variance numerator is a one-line cancellation.** Var = E[X²] − E[X]² = (m+1)/(m+n+2)·[(m+2)/(m+n+3) − (m+1)/(m+n+2)], and the bracket's numerator (m+2)(m+n+2) − (m+1)(m+n+3) collapses to exactly n+1, giving the symmetric form (m+1)(n+1)/((m+n+2)²(m+n+3)) = αβ/((α+β)²(α+β+1)).",
+      "**Positivity makes the ratios meaningful.** Because the normalising integral equals m!·n!/(m+n+1)! > 0 (normalising_pos), each E[Xʲ] is a genuine quotient by a nonzero value — the moments are not vacuously asserting facts about division by zero."
+    ],
+    "prerequisites": [
+      "The integer Euler Beta integral ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! (the parent leaf)",
+      "The Beta(α,β) distribution and its moments E[X] = α/(α+β), Var = αβ/((α+β)²(α+β+1))",
+      "Nat.factorial_succ and factorial positivity",
+      "Pointwise rewriting of interval integrands (integral_congr) and field_simp/ring arithmetic"
+    ]
+  },
+  "conclusion": {
+    "summary": "From the single parent identity ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, the low-order moments of the integer Beta(m+1,n+1) distribution are established in closed rational form: the mean E[X] = (m+1)/(m+n+2) (mean_eq, the parent's second open question), the second raw moment E[X²] = (m+1)(m+2)/((m+n+2)(m+n+3)) (second_moment_eq), and the variance Var(X) = (m+1)(n+1)/((m+n+2)²(m+n+3)) (variance_eq), with normalising_pos certifying the denominator is strictly positive. All four theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Confirms the parent's conjecture that the mean is a one-line corollary of the integer Beta value via the index shift m ↦ m+1, and shows the same shift mechanism delivers the entire low-order moment structure. Specialising α = m+1, β = n+1 these match the standard Beta(α,β) moments, so the entry connects the gallery's elementary real Beta integral to the probabilistic moment formulas. The index-shift technique generalises directly to higher raw moments E[Xᵏ] = ∏_{i<k}(m+1+i)/∏_{i<k}(m+n+2+i).",
+    "openQuestions": [
+      "Do the same index shifts give the closed form for every raw moment E[Xᵏ] = (m+k)!·(m+n+1)!/(m!·(m+n+k+1)!), expressed as a ratio of Pochhammer symbols (m+1)_k/(m+n+2)_k, by induction on k?",
+      "Does the variance formula (m+1)(n+1)/((m+n+2)²(m+n+3)) reproduce, after the substitution m ↦ a-1, n ↦ b-1, Mathlib's real Beta-distribution variance for integer a, b, and can the equality be stated against a Mathlib pdf if one is added?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Johnson, N. L.; Kotz, S.; Balakrishnan, N.",
+      "title": "Continuous Univariate Distributions, Volume 2",
+      "year": "1995",
+      "note": "Chapter 25: the Beta distribution and its moments E[X] = α/(α+β), Var = αβ/((α+β)²(α+β+1))."
+    },
+    {
+      "authors": "Whittaker, E. T.; Watson, G. N.",
+      "title": "A Course of Modern Analysis",
+      "year": "1927",
+      "note": "The Euler Beta integral at integer arguments, m!·n!/(m+n+1)!, the normalising constant underlying these moments."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Parent leaf 'The Off-Diagonal Real Euler Beta Integral'. Its second open question asks whether the mean (m+1)/(m+n+2) of the Beta(m+1,n+1) distribution follows as a one-line corollary by shifting m ↦ m+1; this entry answers it and adds the second moment and variance via the same mechanism."
+    },
+    {
+      "targetId": "beta-integral-recurrence-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Grandparent leaf 'The Symmetric Beta Density on [0,1]', the origin of the Beta-distribution framing whose integer-parameter moments this entry computes."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the second open question of the parent leaf `beta-integral-recurrence-oq-01-oq-03-oq-01` (the off-diagonal real Euler Beta integral): **the mean of the Beta(m+1,n+1) distribution is a one-line corollary** of the parent identity `∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!` via the index shift `m ↦ m+1`. The same shift mechanism then delivers the **full low-order moment structure** from that single integral, with no new integration.

## Results (4 theorems, 122 lines, 0 axioms, 0 sorries)

| Theorem | Statement |
|---------|-----------|
| `normalising_pos` | `0 < ∫₀¹ xᵐ(1-x)ⁿ` (so every moment is a genuine quotient) |
| `mean_eq` | `E[X] = ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2)` ← parent OQ |
| `second_moment_eq` | `E[X²] = (m+1)(m+2)/((m+n+2)(m+n+3))` |
| `variance_eq` | `Var(X) = E[X²] − E[X]² = (m+1)(n+1)/((m+n+2)²(m+n+3))` |

Specialising `α = m+1`, `β = n+1` these are the textbook Beta(α,β) moments `α/(α+β)`, `α(α+1)/((α+β)(α+β+1))`, `αβ/((α+β)²(α+β+1))`.

## Method

Each moment `E[Xʲ]` is a ratio `∫₀¹ xʲ·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ`. The weight `xʲ` equals `xᵐ⁺ʲ(1-x)ⁿ` pointwise on `[0,1]` (`integral_congr`/`ring`), so the parent's closed form applies at index `m+j` to the numerator and `m` to the denominator. `Nat.factorial_succ` peels the factorials and `field_simp` finishes. The variance's `(m+1)(n+1)` numerator comes from the cancellation `(m+2)(m+n+2) − (m+1)(m+n+3) = n+1`.

## Verification

`#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for all four theorems — no `sorryAx`, no `native_decide` (no `Lean.ofReduceBool`). Kernel-verified on Mathlib 4.26.0. Built via host `lake env lean` against existing oleans (parent + Mathlib present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)