### PR TITLE
Enrich Factor–Remainder Multiplicity Theorem: add index.ts, deepen annotations

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01/annotations.json
@@ -1,35 +1,50 @@
 [
   {
-    "id": "ann-main",
-    "proofId": "factor-remainder-theorem-oq-01",
-    "range": {
-      "startLine": 40,
-      "endLine": 55
-    },
-    "type": "insight",
-    "title": "Multiplicity Is the Order of Vanishing of the Taylor Expansion",
-    "content": "pow_dvd_iff_iterate_derivative_eval_eq_zero is the OQ's target: over a characteristic-zero field, (X − a)ᵏ ∣ p iff p and its first k − 1 derivatives all vanish at a. The proof factors through rootMultiplicity: writing k = n + 1, divisibility ↔ n + 1 ≤ rootMultiplicity a p (le_rootMultiplicity_iff) ↔ n < rootMultiplicity a p ↔ all iterated derivatives up to order n vanish at a (Mathlib's iterate-derivative characterization). This is exactly the statement that the Taylor expansion of p at a begins at order k — the analytic reading of the algebraic multiplicity the parent's OQ asked to connect."
-  },
-  {
     "id": "ann-charzero",
     "proofId": "factor-remainder-theorem-oq-01",
-    "range": {
-      "startLine": 31,
-      "endLine": 38
-    },
+    "range": { "startLine": 31, "endLine": 38 },
     "type": "concept",
     "title": "Why Characteristic Zero Is Essential",
-    "content": "factorial_mem_nonZeroDivisors supplies the hypothesis the derivative characterization needs: in a characteristic-zero field every factorial (n! : K) is nonzero, hence a nonzerodivisor. This is not a technicality — in characteristic p the derivative of Xᵖ is zero, so a polynomial can have vanishing derivatives at a without a being a high-multiplicity root, and the equivalence fails. The correct positive-characteristic statement uses Hasse (divided-power) derivatives instead."
+    "content": "factorial_mem_nonZeroDivisors supplies the hypothesis the derivative characterization needs: in a characteristic-zero field every factorial (n! : K) is nonzero, hence a nonzerodivisor. This is not a technicality — in characteristic p the derivative of Xᵖ is zero, so a polynomial can have vanishing derivatives at a without a being a high-multiplicity root, and the equivalence fails. The correct positive-characteristic statement uses Hasse (divided-power) derivatives instead, where p^{(m)}/m! is replaced by a derivation that does not introduce the factorial denominators.",
+    "mathContext": "$n! \\ne 0$ in $K$ when $\\mathrm{char}\\,K = 0$; in $\\mathrm{char}\\,p$, $\\frac{d}{dX}X^p = pX^{p-1} = 0$, so derivatives lose multiplicity information.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic of a field", "nonzerodivisor", "Hasse derivative", "formal derivative"],
+    "prerequisites": ["field characteristic", "polynomial derivatives"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "factor-remainder-theorem-oq-01",
+    "range": { "startLine": 40, "endLine": 55 },
+    "type": "insight",
+    "title": "Multiplicity Is the Order of Vanishing of the Taylor Expansion",
+    "content": "pow_dvd_iff_iterate_derivative_eval_eq_zero is the OQ's target: over a characteristic-zero field, (X − a)ᵏ ∣ p iff p and its first k − 1 derivatives all vanish at a. The proof factors through rootMultiplicity: writing k = n + 1, divisibility ↔ n + 1 ≤ rootMultiplicity a p (le_rootMultiplicity_iff) ↔ n < rootMultiplicity a p ↔ all iterated derivatives up to order n vanish at a (Mathlib's lt_rootMultiplicity_iff_isRoot_iterate_derivative...). This is exactly the statement that the Taylor expansion of p at a begins at order k — the analytic reading of the algebraic multiplicity the parent's OQ asked to connect. The final `simp` just unfolds IsRoot and rewrites n < k as m ≤ n, m < k.",
+    "mathContext": "$(X-a)^k \\mid p \\iff p(a)=p'(a)=\\cdots=p^{(k-1)}(a)=0$; equivalently the Taylor expansion $p(X)=\\sum_m \\frac{p^{(m)}(a)}{m!}(X-a)^m$ has its first $k$ coefficients zero.",
+    "significance": "key",
+    "relatedConcepts": ["root multiplicity", "Taylor expansion", "iterated derivative", "order of vanishing"],
+    "prerequisites": ["polynomial division", "formal derivatives", "Taylor's theorem for polynomials"]
+  },
+  {
+    "id": "ann-factor",
+    "proofId": "factor-remainder-theorem-oq-01",
+    "range": { "startLine": 53, "endLine": 55 },
+    "type": "definition",
+    "title": "The Factor Theorem as the k = 1 Base Case",
+    "content": "factor_theorem is the classical k = 1 instance, (X − a) ∣ p ↔ p(a) = 0 — exactly Mathlib's dvd_iff_isRoot. It is the parent entry's headline result, recovered here as the bottom rung of the multiplicity ladder: zero-th order vanishing (the value alone) detects a simple root. Stating it alongside the general theorem makes explicit that pow_dvd_iff... at k = 1 collapses to the original Factor Theorem.",
+    "mathContext": "$(X-a)\\mid p \\iff p(a)=0$ — the $k=1$ case of $(X-a)^k\\mid p \\iff \\forall m<k,\\ p^{(m)}(a)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["factor theorem", "polynomial roots", "dvd_iff_isRoot"],
+    "prerequisites": ["polynomial evaluation", "divisibility of polynomials"]
   },
   {
     "id": "ann-double-root",
     "proofId": "factor-remainder-theorem-oq-01",
-    "range": {
-      "startLine": 57,
-      "endLine": 69
-    },
+    "range": { "startLine": 57, "endLine": 69 },
     "type": "concept",
-    "title": "The Factor Theorem and Repeated-Root Criterion",
-    "content": "factor_theorem is the classical k = 1 case ((X − a) ∣ p ↔ p(a) = 0), Mathlib's dvd_iff_isRoot. double_root_iff is the k = 2 workhorse: (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0 — a has multiplicity at least two iff both p and its derivative vanish there. This is the standard test for repeated roots, behind discriminant criteria and the fact that a polynomial is squarefree iff it shares no root with its derivative (gcd(p, p′) = 1)."
+    "title": "The Repeated-Root Criterion (k = 2)",
+    "content": "double_root_iff is the k = 2 workhorse: (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0 — a has multiplicity at least two iff both p and its derivative vanish there. The proof specializes the main theorem and discharges the two-element ∀ m < 2 by interval_cases. This is the standard test for repeated roots, behind discriminant criteria and the fact that a polynomial is squarefree iff it shares no root with its derivative, i.e. gcd(p, p′) = 1. It also underlies the Newton's-method observation that double roots slow quadratic convergence to linear.",
+    "mathContext": "$(X-a)^2 \\mid p \\iff p(a)=0 \\wedge p'(a)=0$; squarefree $\\iff \\gcd(p,p')=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["repeated roots", "discriminant", "squarefree polynomial", "gcd of polynomial and derivative"],
+    "prerequisites": ["polynomial derivatives", "greatest common divisor of polynomials"]
   }
 ]

--- a/src/data/proofs/factor-remainder-theorem-oq-01/index.ts
+++ b/src/data/proofs/factor-remainder-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FactorRemainderTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const factorRemainderTheoremOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const factorRemainderTheoremOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const factorRemainderTheoremOq01Data: ProofData = {
+  proof: factorRemainderTheoremOq01Proof,
+  annotations: factorRemainderTheoremOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01` (the multiplicity Factor Theorem: $(X-a)^k \mid p \iff p(a)=\cdots=p^{(k-1)}(a)=0$).

## Quality improvements
- **Added missing `index.ts`** — without it the proof page renders "proof not found" on the live site.
- **Deepened all annotations** — the three existing annotations had only `title`/`content` (no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`). All now carry full LaTeX `mathContext` and metadata.
- **Added a fourth annotation** isolating `factor_theorem` (the $k=1$ base case) so the multiplicity ladder is visible from the simple-root rung up.
- mathContext now surfaces: the Taylor-expansion reading of multiplicity, the characteristic-$p$ failure ($\frac{d}{dX}X^p=0$), and the squarefree/discriminant connection ($\gcd(p,p')=1$).

meta.json was already solid (verified/original, 0 axioms/sorries, 5 keyInsights, overview + conclusion present); status/badge consistent with the Lean source.

Note: `pnpm build` could not run in this worktree (`node_modules` absent); JSON validated with Python and `index.ts` follows the established gallery template.