### PR TITLE
research(burnside-counting-oq-03-oq-02-oq-01-oq-02): necklace Burnside sum in divisor form ∑ k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -557,6 +557,7 @@ import Proofs.BurnsideCountingOQ03
 import Proofs.BurnsideCountingOQ03Aristotle
 import Proofs.BurnsideCountingOQ03OQ02
 import Proofs.BurnsideCountingOQ03OQ02OQ01
+import Proofs.BurnsideCountingOQ03OQ02OQ01OQ02
 import Proofs.BurnsideCountingOQ03OQ03
 import Proofs.BurnsideCountingOQ04
 import Proofs.BurnsideCountingOQ04OQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3884,6 +3884,7 @@ import Proofs.StirlingFormulaOQ02
 import Proofs.StirlingFormulaOQ03
 import Proofs.StirlingFormulaOQ03OQ01
 import Proofs.StirlingFormulaOQ03OQ02
+import Proofs.StirlingFormulaOQ03OQ02OQ01
 import Proofs.StirlingSecondKindOQ01
 import Proofs.StirlingSecondKindOQ01OQ01
 import Proofs.StirlingSecondKindOQ01OQ02

--- a/proofs/Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean
@@ -1,0 +1,105 @@
+/-
+# Necklace Burnside Sum in Divisor Form: ∑_{r} k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d
+## (burnside-counting-oq-03-oq-02-oq-01-oq-02)
+
+**Open question** (from `burnside-counting-oq-03-oq-02-oq-01`, OQ[2]): the parent
+proves the concrete cyclic cycle-count `cyc (rotation r) = gcd(n, r)` and assembles the
+integer-form Burnside total
+`∑_{r : ZMod n} k^{gcd(n,r)} = (#necklaces up to rotation) · n`  (its result `(C)`).
+Push this to the **standard number-theoretic divisor form** by grouping the `n`
+rotations according to the value of their cycle count.
+
+The classical statement is
+  `∑_{r=0}^{n-1} k^{gcd(n,r)} = ∑_{d ∣ n} φ(n/d) · k^d`.
+The mechanism is fiber-counting: a rotation `r` contributes `k^{gcd(n,r)}`, the
+positions `r ∈ [0, n)` with `gcd(n, r) = d` are exactly the multiples `d·s` with
+`gcd(n/d, s) = 1`, and there are `φ(n/d)` of them. We prove:
+
+* **(D) Range form** (`sum_range_pow_gcd_eq_sum_divisors`):
+    `∑_{r ∈ range n} k^{gcd(n,r)} = ∑_{d ∣ n} φ(n/d) · k^d`.
+  Regroup `range n` along the map `r ↦ gcd(n,r)` (whose values are divisors of `n`)
+  via `Finset.sum_fiberwise_of_maps_to'`; each fiber is constant `k^d`, and its
+  cardinality is `φ(n/d)` by Mathlib's `Nat.totient_div_of_dvd` — the exact
+  combinatorial input behind Gauss's `∑_{d∣n} φ(d) = n`.
+
+* **(E) ZMod form** (`sum_pow_gcd_eq_sum_divisors_totient`):
+    `∑_{r : ZMod n} k^{gcd(n, r.val)} = ∑_{d ∣ n} φ(n/d) · k^d`,
+  obtained from `(D)` by the bijection `ZMod.val : ZMod n ≃ range n`.
+
+* **(F) Necklace count in divisor form** (`card_necklaces_mul_eq_sum_divisors`):
+    `(#necklaces up to rotation) · n = ∑_{d ∣ n} φ(n/d) · k^d`,
+  combining `(E)` with the parent's integer-form Burnside total `(C)`. Dividing by
+  `n` gives the textbook cyclic necklace formula
+  `(1/n) ∑_{d∣n} φ(n/d) k^d`.
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+import Mathlib
+import Proofs.BurnsideCountingOQ03OQ02OQ01
+
+open Finset BigOperators MulAction
+
+namespace BurnsideCountingOQ03OQ02OQ01OQ02
+
+open BurnsideCountingOQ03OQ02OQ01 (Rot rotation sum_pow_gcd_eq_card_necklaces_mul)
+
+/-! ## Section I: (D) The divisor-sum identity over `range n`
+
+This is the purely number-theoretic heart of the matter: grouping the `n` residues by
+the value of `gcd(n, ·)` turns the Burnside sum into a sum over divisors, weighted by
+totients. -/
+
+/-- **(D)** The cyclic Burnside sum in divisor form:
+`∑_{r < n} k^{gcd(n,r)} = ∑_{d ∣ n} φ(n/d) · k^d`. -/
+theorem sum_range_pow_gcd_eq_sum_divisors (n k : ℕ) (hn : 0 < n) :
+    (∑ r ∈ Finset.range n, k ^ Nat.gcd n r)
+      = ∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d := by
+  -- Regroup `range n` along `r ↦ gcd(n, r)`, whose values lie in `n.divisors`.
+  rw [← Finset.sum_fiberwise_of_maps_to'
+        (s := Finset.range n) (t := n.divisors) (g := fun r => Nat.gcd n r)
+        (fun r _ => Nat.mem_divisors.2 ⟨Nat.gcd_dvd_left n r, hn.ne'⟩)
+        (f := fun d => k ^ d)]
+  -- Each fiber is a constant `k^d`; its cardinality is `φ(n/d)`.
+  refine Finset.sum_congr rfl (fun d hd => ?_)
+  rw [Finset.sum_const, smul_eq_mul, Nat.totient_div_of_dvd (Nat.dvd_of_mem_divisors hd)]
+
+/-! ## Section II: (E) The same identity summed over `ZMod n`
+
+The parent's Burnside total is phrased over `ZMod n` (residues `r.val`), so we transport
+`(D)` along the bijection `ZMod.val : ZMod n ≃ range n`. -/
+
+variable {n : ℕ} [NeZero n]
+
+/-- **(E)** The cyclic Burnside sum over `ZMod n` in divisor form. -/
+theorem sum_pow_gcd_eq_sum_divisors_totient (k : ℕ) :
+    (∑ r : ZMod n, k ^ Nat.gcd n r.val)
+      = ∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d := by
+  have hn : 0 < n := Nat.pos_of_ne_zero (NeZero.ne n)
+  rw [← sum_range_pow_gcd_eq_sum_divisors n k hn]
+  -- `ZMod.val` bijects `univ : Finset (ZMod n)` with `range n`.
+  refine Finset.sum_bij' (fun (r : ZMod n) _ => r.val) (fun (i : ℕ) _ => (i : ZMod n))
+    (fun r _ => Finset.mem_range.2 (ZMod.val_lt r))
+    (fun i _ => Finset.mem_univ _)
+    (fun r _ => ZMod.natCast_zmod_val r)
+    (fun i hi => ZMod.val_natCast_of_lt (Finset.mem_range.1 hi))
+    (fun r _ => rfl)
+
+/-! ## Section III: (F) Necklace count in divisor form
+
+Combining `(E)` with the parent's integer-form Burnside total `(C)` gives the textbook
+divisor-sum formula for the number of `k`-colored `n`-bead necklaces. -/
+
+/-- **(F)** The number of `k`-colored `n`-bead necklaces (up to rotation), times `n`,
+equals the totient-weighted divisor sum `∑_{d ∣ n} φ(n/d) · k^d`. Dividing by `n`
+recovers the classical cyclic necklace count `(1/n) ∑_{d∣n} φ(n/d) k^d`. -/
+theorem card_necklaces_mul_eq_sum_divisors (k : ℕ) :
+    Nat.card (orbitRel.Quotient (Rot n) (Rot n → Fin k)) * n
+      = ∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d := by
+  rw [← sum_pow_gcd_eq_card_necklaces_mul (k := k), sum_pow_gcd_eq_sum_divisors_totient]
+
+#check @sum_range_pow_gcd_eq_sum_divisors
+#check @sum_pow_gcd_eq_sum_divisors_totient
+#check @card_necklaces_mul_eq_sum_divisors
+
+end BurnsideCountingOQ03OQ02OQ01OQ02

--- a/proofs/Proofs/StirlingFormulaOQ03OQ02OQ01.lean
+++ b/proofs/Proofs/StirlingFormulaOQ03OQ02OQ01.lean
@@ -1,0 +1,112 @@
+/-
+The Catalan Number Asymptotic:  catalan n · n · √(πn) / 4ⁿ → 1,  i.e.  Cₙ ~ 4ⁿ / (√π · n^{3/2})
+
+Source: Open question from stirling-formula-oq-03-oq-02 (the central binomial asymptotic)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent entry `StirlingFormulaOQ03OQ02` establishes the asymptotics of the central
+binomial coefficient,
+
+  **`centralBinom_asymptotic`**:  `C(2n,n) · √(πn) / 4ⁿ → 1`,   i.e.  `C(2n,n) ~ 4ⁿ/√(πn)`.
+
+This file derives the corresponding asymptotic for the **Catalan numbers**
+`Cₙ = catalan n`.  The bridge is the exact Mathlib identity
+
+  `(n+1) · catalan n = C(2n,n)`   (`Nat.succ_mul_catalan_eq_centralBinom`),
+
+equivalently `catalan n = C(2n,n)/(n+1)`.  Multiplying the parent limit by the elementary
+ratio `n/(n+1) → 1` and folding the cast identity in gives
+
+  **`catalan_asymptotic`**:  `catalan n · n · √(πn) / 4ⁿ → 1`.
+
+Since `n · √(πn) = √π · n^{3/2}`, this is exactly the textbook statement
+
+  `Cₙ ~ 4ⁿ / (√π · n^{3/2})`.
+
+We also record the equivalent reciprocal form `4ⁿ / (catalan n · n · √(πn)) → 1`.
+
+## Relation to Mathlib
+
+Mathlib has the exact relation between the Catalan number and the central binomial
+coefficient (`Nat.succ_mul_catalan_eq_centralBinom`, `Nat.catalan_eq_centralBinom_div`) and
+the central binomial/Wallis machinery, but it does **not** state the *asymptotic* growth of
+the Catalan numbers. We assemble it from the parent's `centralBinom_asymptotic` and the
+elementary limit `n/(n+1) → 1`.
+-/
+
+import Mathlib
+import Proofs.StirlingFormulaOQ03OQ02
+
+open Filter Topology Nat
+open scoped Real
+
+namespace StirlingFormulaOQ03OQ02OQ01
+
+open StirlingFormulaOQ03OQ02 (cb cb_pos cb_ne_zero centralBinom_asymptotic)
+
+/-- Real-valued Catalan number, for convenience. -/
+noncomputable def cat (n : ℕ) : ℝ := (catalan n : ℝ)
+
+/-- The Catalan numbers are positive (follows from `(n+1)·catalan n = C(2n,n) > 0`). -/
+theorem cat_pos (n : ℕ) : 0 < cat n := by
+  have hpos : 0 < catalan n := by
+    rcases Nat.eq_zero_or_pos (catalan n) with h | h
+    · exfalso
+      have hid := succ_mul_catalan_eq_centralBinom n
+      rw [h, Nat.mul_zero] at hid
+      exact (Nat.centralBinom_pos n).ne' hid.symm
+    · exact h
+  unfold cat; exact_mod_cast hpos
+
+theorem cat_ne_zero (n : ℕ) : cat n ≠ 0 := (cat_pos n).ne'
+
+/-! ## Part I: The exact bridge to the central binomial coefficient -/
+
+/-- `catalan n = C(2n,n)/(n+1)`, cast to `ℝ`. -/
+theorem cat_eq (n : ℕ) : cat n = cb n / (n + 1) := by
+  have hne : ((n : ℝ) + 1) ≠ 0 := by positivity
+  rw [eq_div_iff hne]
+  unfold cat cb
+  have hc := congrArg (Nat.cast (R := ℝ)) (succ_mul_catalan_eq_centralBinom n)
+  push_cast at hc
+  linear_combination hc
+
+/-! ## Part II: The asymptotics -/
+
+/-- The elementary ratio `n/(n+1) → 1`. -/
+theorem ratio_tendsto : Tendsto (fun n : ℕ => (n : ℝ) / ((n : ℝ) + 1)) atTop (𝓝 1) := by
+  have htop : Tendsto (fun n : ℕ => (n : ℝ) + 1) atTop atTop :=
+    tendsto_atTop_add_const_right _ 1 tendsto_natCast_atTop_atTop
+  have hinv : Tendsto (fun n : ℕ => ((n : ℝ) + 1)⁻¹) atTop (𝓝 0) := htop.inv_tendsto_atTop
+  have h := (tendsto_const_nhds (x := (1 : ℝ))).sub hinv
+  rw [sub_zero] at h
+  refine h.congr' ?_
+  filter_upwards [eventually_ge_atTop 0] with n _
+  have hne : ((n : ℝ) + 1) ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- **Catalan number asymptotic.** `catalan n · n · √(πn) / 4ⁿ → 1`, i.e.
+`Cₙ ~ 4ⁿ / (√π · n^{3/2})` (using `n · √(πn) = √π · n^{3/2}`). -/
+theorem catalan_asymptotic :
+    Tendsto (fun n : ℕ => cat n * n * Real.sqrt (π * n) / (4 : ℝ) ^ n) atTop (𝓝 1) := by
+  have hprod := centralBinom_asymptotic.mul ratio_tendsto
+  rw [mul_one] at hprod
+  refine hprod.congr' ?_
+  filter_upwards [eventually_gt_atTop 0] with n _
+  have hne : ((n : ℝ) + 1) ≠ 0 := by positivity
+  have h4 : (4 : ℝ) ^ n ≠ 0 := by positivity
+  have hcb := cb_ne_zero n
+  rw [cat_eq]
+  field_simp
+
+/-- Equivalent reciprocal form: `4ⁿ / (catalan n · n · √(πn)) → 1`. -/
+theorem catalan_asymptotic_inv :
+    Tendsto (fun n : ℕ => (4 : ℝ) ^ n / (cat n * n * Real.sqrt (π * n))) atTop (𝓝 1) := by
+  have h := catalan_asymptotic.inv₀ one_ne_zero
+  rw [inv_one] at h
+  refine h.congr ?_
+  intro n
+  rw [inv_div]
+
+end StirlingFormulaOQ03OQ02OQ01

--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+  "title": "Necklace Burnside Sum in Divisor Form: ∑ k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d",
+  "slug": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+  "description": "Pushes the parent's integer-form cyclic Burnside total ∑_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n to the standard number-theoretic divisor form ∑_{d∣n} φ(n/d)·k^d by grouping the n rotations according to their cycle count. The mechanism is fiber-counting along r ↦ gcd(n,r): each value d is a divisor of n (Nat.gcd_dvd_left), the residues r ∈ [0,n) with gcd(n,r) = d are exactly the multiples d·s with gcd(n/d, s) = 1, and there are φ(n/d) of them — Mathlib's Nat.totient_div_of_dvd, the same combinatorial input that underlies Gauss's ∑_{d∣n} φ(d) = n. (D) Range form ∑_{r∈range n} k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d via Finset.sum_fiberwise_of_maps_to' (each fiber constant k^d, cardinality φ(n/d)); (E) the same over ZMod n via the bijection ZMod.val : ZMod n ≃ range n; (F) combining (E) with the parent's (C) gives the textbook (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d.",
+  "meta": {
+    "author": "Cauchy–Frobenius–Burnside / Gauss (totient divisor sum); formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Necklace_(combinatorics)",
+    "date": "1887",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-theory",
+      "number-theory",
+      "necklaces",
+      "burnside",
+      "orbit-counting",
+      "cyclic-group",
+      "gcd",
+      "totient",
+      "divisor-sum",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. Fully machine-checked: all three theorems (sum_range_pow_gcd_eq_sum_divisors, sum_pow_gcd_eq_sum_divisors_totient, card_necklaces_mul_eq_sum_divisors) depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide is used.",
+    "dateAdded": "2026-06-25",
+    "lineCount": 105,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_div_of_dvd",
+        "description": "For d ∣ n, φ(n/d) = #{k ∈ range n | gcd(n,k) = d}; supplies the cardinality of each gcd-fiber — the combinatorial heart of the divisor form and of Gauss's ∑_{d∣n} φ(d) = n",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.sum_fiberwise_of_maps_to'",
+        "description": "∑_{j∈t} ∑_{i∈s, g i = j} f j = ∑_{i∈s} f(g i); regroups range n along g = gcd(n,·) into divisor-indexed fibers on which the summand k^{g i} is the constant k^d",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_bij'",
+        "description": "Reindexes a finite sum along an explicit bijection with inverse; used with ZMod.val / Nat.cast to transport the range-n identity to a sum over ZMod n",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "ZMod.val_natCast_of_lt / ZMod.natCast_zmod_val",
+        "description": "The mutually-inverse maps witnessing ZMod n ≃ range n for NeZero n: (↑(r.val)) = r and (↑i).val = i for i < n",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "BurnsideCountingOQ03OQ02OQ01.sum_pow_gcd_eq_card_necklaces_mul",
+        "description": "The parent's integer-form Burnside total ∑_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n, combined with the divisor identity to obtain the necklace count in closed divisor form (F)",
+        "module": "Proofs.BurnsideCountingOQ03OQ02OQ01"
+      }
+    ],
+    "originalContributions": [
+      "sum_range_pow_gcd_eq_sum_divisors (D): ∑_{r∈range n} k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d — regroup range n along r ↦ gcd(n,r) (values in n.divisors via Nat.gcd_dvd_left) with Finset.sum_fiberwise_of_maps_to', collapse each constant fiber by Finset.sum_const, and read its cardinality off Nat.totient_div_of_dvd",
+      "sum_pow_gcd_eq_sum_divisors_totient (E): the divisor identity over ZMod n, transported from (D) by Finset.sum_bij' along the bijection ZMod.val : ZMod n ≃ range n (inverse Nat.cast, with ZMod.val_lt / val_natCast_of_lt / natCast_zmod_val)",
+      "card_necklaces_mul_eq_sum_divisors (F): (#necklaces up to rotation)·n = ∑_{d∣n} φ(n/d)·k^d — combine (E) with the parent's integer-form Burnside total, yielding the textbook cyclic necklace count (1/n)·∑_{d∣n} φ(n/d) k^d as a divisor sum rather than a sum over all n rotations"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of k-colored n-bead necklaces up to rotation is the canonical first application of Burnside's lemma, (1/n)·Σ_{r∈Z/n} k^{gcd(n,r)}. Collecting the n rotations by their cycle count d = gcd(n,r) rewrites this in the closed divisor form (1/n)·Σ_{d∣n} φ(n/d) k^d, the version found in every combinatorics text. The reindexing rests on a single number-theoretic fact: among the residues 0,…,n−1, exactly φ(n/d) have gcd d with n — the same counting Gauss used to prove Σ_{d∣n} φ(d) = n. The parent entry burnside-counting-oq-03-oq-02-oq-01 proved the cyclic cycle-count cyc(rotation r) = gcd(n,r) and assembled the integer-form total Σ_r k^{gcd(n,r)} = (#necklaces)·n, and explicitly asked (openQuestions[1]) to push it to the divisor form. This entry supplies that step.",
+    "problemStatement": "Prove (D) Σ_{r∈range n} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d)·k^d; (E) the same identity with the sum taken over r : ZMod n via r.val; and (F) that the parent's Burnside total equals the divisor sum, i.e. (#necklaces up to rotation)·n = Σ_{d∣n} φ(n/d)·k^d.",
+    "proofStrategy": "**(D) Range form.** The map g : r ↦ gcd(n,r) sends range n into n.divisors (gcd(n,r) ∣ n by Nat.gcd_dvd_left, and gcd ≠ 0 since n > 0). Apply Finset.sum_fiberwise_of_maps_to' with this g and the weight f d = k^d: it rewrites Σ_{r∈range n} k^{gcd(n,r)} = Σ_{r∈range n} f(g r) as Σ_{d∈n.divisors} Σ_{r∈range n, gcd(n,r)=d} k^d. The inner sum is over a fiber on which the summand is the constant k^d, so Finset.sum_const turns it into #(fiber)·k^d, and Nat.totient_div_of_dvd identifies #{r∈range n | gcd(n,r)=d} = φ(n/d). Each term becomes φ(n/d)·k^d.\n\n**(E) ZMod form.** For NeZero n, ZMod.val is a bijection from univ : Finset (ZMod n) onto range n with inverse Nat.cast. Finset.sum_bij' with forward map r ↦ r.val (membership ZMod.val_lt), inverse i ↦ (↑i) (membership trivial), the two round-trips ZMod.natCast_zmod_val and ZMod.val_natCast_of_lt, and value-equality by rfl transports (D) to Σ_{r:ZMod n} k^{gcd(n,r.val)} = Σ_{d∣n} φ(n/d)·k^d.\n\n**(F) Necklace count.** Rewrite the parent's sum_pow_gcd_eq_card_necklaces_mul (Σ_{r:ZMod n} k^{gcd(n,r.val)} = (#necklaces)·n) backwards and apply (E) to its left-hand side.",
+    "keyInsights": [
+      "**The divisor form is pure fiber-counting.** Σ_r k^{gcd(n,r)} = Σ_{d∣n} (#{r : gcd(n,r)=d})·k^d is just the partition of range n by the value of gcd(n,·); the only non-formal ingredient is that each fiber has φ(n/d) elements.",
+      "**Gauss's lemma is the engine.** Nat.totient_div_of_dvd (#{k<n : gcd(n,k)=d} = φ(n/d) for d∣n) is exactly the fiber count that proves Σ_{d∣n} φ(d) = n; here it converts the Burnside sum into the textbook totient-weighted divisor sum.",
+      "**ZMod n ≃ range n bridges the two phrasings.** The parent works over ZMod n (residues r.val), the number theory is cleanest over range n; Finset.sum_bij' along ZMod.val moves the identity between them with no recomputation.",
+      "**One reduction subsumes n separate terms.** Where the integer-form total sums over all n rotations, the divisor form sums over only the divisors of n, weighting by totients — the closed expression used in practice."
+    ],
+    "prerequisites": [
+      "The parent entry's cyc(rotation r) = gcd(n,r) and integer-form Burnside total (burnside-counting-oq-03-oq-02-oq-01)",
+      "Euler's totient and the gcd-fiber count Nat.totient_div_of_dvd (the core of Gauss's Σ_{d∣n} φ(d) = n)",
+      "Finite-sum fiberwise regrouping (Finset.sum_fiberwise_of_maps_to') and constant-summand collapse (Finset.sum_const)",
+      "Reindexing a finite sum along a bijection (Finset.sum_bij') and the ZMod n ≃ range n maps (ZMod.val, ZMod.val_natCast_of_lt, ZMod.natCast_zmod_val)"
+    ],
+    "what": "The closed divisor-sum form of the cyclic necklace count: Σ_{r} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d)·k^d, both over range n and over ZMod n, and the resulting (#necklaces up to rotation)·n = Σ_{d∣n} φ(n/d)·k^d.",
+    "how": "Group the residues by the value of gcd(n,·) into divisor-indexed fibers (Finset.sum_fiberwise_of_maps_to'), collapse each constant fiber to #(fiber)·k^d, count the fiber by Nat.totient_div_of_dvd = φ(n/d), transport to ZMod n via Finset.sum_bij' along ZMod.val, and combine with the parent's Burnside total.",
+    "significance": "Answers the parent entry's openQuestions[1] verbatim — converting the integer-form cyclic Burnside total into the standard closed expression Σ_{d∣n} φ(n/d) k^d that appears in every treatment of necklace counting. It grounds the textbook formula in the same Burnside machinery the parent chain built, exhibiting it as a totient-reindexing of one orbit-count rather than a separate derivation, and ties the gallery's group-theoretic necklace count to Gauss's divisor-sum identity for the totient."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Results",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring: the parent's request to push the integer-form Burnside total to divisor form, and the three results — (D) the range-form identity Σ_{r<n} k^{gcd(n,r)} = Σ_{d∣n} φ(n/d) k^d, (E) its ZMod n version, and (F) the necklace count (#necklaces)·n = Σ_{d∣n} φ(n/d) k^d.",
+      "mathContext": "$\\sum_{r} k^{\\gcd(n,r)} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^d$"
+    },
+    {
+      "id": "divisor-form",
+      "title": "Section I: (D) The Divisor-Sum Identity over range n",
+      "startLine": 47,
+      "endLine": 65,
+      "summary": "sum_range_pow_gcd_eq_sum_divisors: regroup range n along r ↦ gcd(n,r) (values in n.divisors) with Finset.sum_fiberwise_of_maps_to', collapse each constant fiber by Finset.sum_const, and identify the cardinality #{r∈range n | gcd(n,r)=d} = φ(n/d) via Nat.totient_div_of_dvd.",
+      "mathContext": "$\\sum_{r\\in[0,n)} k^{\\gcd(n,r)} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^d$"
+    },
+    {
+      "id": "zmod-form",
+      "title": "Section II: (E) The Identity over ZMod n",
+      "startLine": 67,
+      "endLine": 86,
+      "summary": "sum_pow_gcd_eq_sum_divisors_totient: transport (D) along the bijection ZMod.val : ZMod n ≃ range n using Finset.sum_bij' (forward r.val with ZMod.val_lt, inverse Nat.cast, round-trips ZMod.natCast_zmod_val and ZMod.val_natCast_of_lt).",
+      "mathContext": "$\\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r.\\mathrm{val})} = \\sum_{d\\mid n} \\varphi(n/d)\\,k^d$"
+    },
+    {
+      "id": "necklace-divisor-form",
+      "title": "Section III: (F) Necklace Count in Divisor Form",
+      "startLine": 88,
+      "endLine": 105,
+      "summary": "card_necklaces_mul_eq_sum_divisors: combine (E) with the parent's integer-form Burnside total sum_pow_gcd_eq_card_necklaces_mul to obtain (#necklaces up to rotation)·n = Σ_{d∣n} φ(n/d)·k^d, the textbook cyclic necklace count as a divisor sum.",
+      "mathContext": "$\\#\\text{necklaces}\\cdot n = \\sum_{d\\mid n} \\varphi(n/d)\\,k^d$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Converts the parent's integer-form cyclic Burnside total Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n into the standard closed divisor form Σ_{d∣n} φ(n/d)·k^d. The range-form identity (D) groups range n by the value of gcd(n,·) into divisor-indexed fibers (Finset.sum_fiberwise_of_maps_to'), each constant k^d with cardinality φ(n/d) (Nat.totient_div_of_dvd); (E) transports it to ZMod n via the bijection ZMod.val (Finset.sum_bij'); (F) combines (E) with the parent's total to give (#necklaces)·n = Σ_{d∣n} φ(n/d)·k^d. Fully verified with 0 sorries and 0 axioms.",
+    "implications": "Answers the parent entry's openQuestions[1] verbatim — the textbook divisor-sum formula for k-colored necklaces, (1/n)·Σ_{d∣n} φ(n/d) k^d, now a totient-reindexing of the parent's single orbit-count rather than a separate computation. It links the gallery's group-theoretic necklace machinery to Gauss's classical divisor-sum identity for Euler's totient through the shared fiber-counting lemma Nat.totient_div_of_dvd.",
+    "openQuestions": [
+      "Specialize the divisor form at k = 1 (and combine with the parent chain) to recover Gauss's identity Σ_{d∣n} φ(d) = n as a corollary of the necklace count, closing the loop between Burnside averaging and the totient divisor sum.",
+      "Establish the Möbius-inverse aperiodic-necklace (Lyndon word) count (1/n)·Σ_{d∣n} μ(d) k^{n/d} alongside the totient form, exhibiting both classical closed expressions within the same Burnside framework."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-burnside-oq030201-parent",
+      "targetId": "burnside-counting-oq-03-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's openQuestions[1]: push the integer-form cyclic Burnside total Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n to the divisor form Σ_{d∣n} φ(n/d)·k^d. Reuses the parent's sum_pow_gcd_eq_card_necklaces_mul directly for result (F)."
+    },
+    {
+      "id": "xref-burnside-oq0302",
+      "targetId": "burnside-counting-oq-03-oq-02",
+      "relationship": "specializes",
+      "description": "Grandparent's group-agnostic master formula |Fix(g)| = k^{cyc(g)} drives the whole chain; this entry expresses its cyclic Burnside average in the closed totient-divisor form used in textbooks."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 105,
+    "path": "Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/stirling-formula-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-03-oq-02-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "stirling-formula-oq-03-oq-02-oq-01",
+  "title": "The Catalan Number Asymptotic: Cₙ ~ 4ⁿ/(√π·n^{3/2})",
+  "slug": "stirling-formula-oq-03-oq-02-oq-01",
+  "description": "Derives the asymptotic growth of the Catalan numbers, catalan n · n · √(πn) / 4ⁿ → 1 (equivalently Cₙ ~ 4ⁿ/(√π·n^{3/2})), directly from the parent's central binomial asymptotic. The bridge is Mathlib's exact identity (n+1)·catalan n = C(2n,n), so catalan n = C(2n,n)/(n+1); multiplying the parent limit by the elementary ratio n/(n+1) → 1 yields the result. Mathlib relates the Catalan number to the central binomial coefficient but does not state its asymptotic.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingFormulaOQ03OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "combinatorics",
+      "asymptotics",
+      "catalan-numbers",
+      "central-binomial",
+      "pi",
+      "limits"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.succ_mul_catalan_eq_centralBinom",
+        "description": "The exact relation (n+1)·catalan n = C(2n,n), equivalently catalan n = C(2n,n)/(n+1)",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Filter.Tendsto.inv_tendsto_atTop",
+        "description": "Reciprocal of a sequence tending to +∞ tends to 0: f → atTop ⟹ f⁻¹ → 0",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      },
+      {
+        "theorem": "tendsto_natCast_atTop_atTop",
+        "description": "The natural-number cast diverges: (n : ℝ) → +∞",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "Filter.Tendsto.inv₀",
+        "description": "Reciprocal of a convergent sequence with nonzero limit: f → a ≠ 0 ⟹ f⁻¹ → a⁻¹",
+        "module": "Mathlib.Topology.Algebra.Field"
+      }
+    ],
+    "originalContributions": [
+      "cat_eq: the real-cast Catalan identity catalan n = C(2n,n)/(n+1), obtained from Nat.succ_mul_catalan_eq_centralBinom",
+      "ratio_tendsto: the elementary limit n/(n+1) → 1, written as 1 − (n+1)⁻¹ with (n+1)⁻¹ → 0",
+      "catalan_asymptotic: the textbook Catalan asymptotic catalan n · n · √(πn) / 4ⁿ → 1, i.e. Cₙ ~ 4ⁿ/(√π·n^{3/2}) — not stated by Mathlib; obtained as the parent's central binomial limit times n/(n+1)",
+      "catalan_asymptotic_inv: the equivalent reciprocal form 4ⁿ/(catalan n · n · √(πn)) → 1, via Tendsto.inv₀ and inv_div"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound.",
+    "lineCount": 112,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Catalan numbers Cₙ = 1, 1, 2, 5, 14, 42, … count an enormous family of combinatorial objects: balanced bracket sequences, triangulations of a polygon, full binary trees, Dyck paths, and non-crossing partitions, among hundreds of others. Their closed form Cₙ = C(2n,n)/(n+1) ties them directly to the central binomial coefficient, and their growth rate Cₙ ~ 4ⁿ/(√π·n^{3/2}) is the standard estimate quoted whenever one needs the order of magnitude of a Catalan-counted family. The extra factor n^{3/2} in the denominator (rather than the n^{1/2} of the central binomial coefficient) is exactly the contribution of the 1/(n+1) normalization — asymptotically n/(n+1) → 1 shifts the polynomial power by one. The parent entry established C(2n,n) ~ 4ⁿ/√(πn) from Wallis' product; this entry shows the Catalan asymptotic is one elementary ratio limit away.",
+    "problemStatement": "Derive the asymptotic growth of the Catalan numbers, Cₙ = C(2n,n)/(n+1) ~ 4ⁿ/(√π·n^{3/2}), from the parent's central binomial asymptotic.\n\n**Answer:** catalan n · n · √(πn) / 4ⁿ → 1. Since catalan n = C(2n,n)/(n+1), this equals the parent limit C(2n,n)·√(πn)/4ⁿ → 1 multiplied by the ratio n/(n+1) → 1.",
+    "text": "The textbook Catalan asymptotic Cₙ ~ 4ⁿ/(√π·n^{3/2}), obtained from the central binomial asymptotic and the exact identity catalan n = C(2n,n)/(n+1) — no rpow manipulation, since n·√(πn) = √π·n^{3/2}.",
+    "proofStrategy": "1. cat_eq: cast Mathlib's (n+1)·catalan n = C(2n,n) (Nat.succ_mul_catalan_eq_centralBinom) to ℝ and divide, giving catalan n = C(2n,n)/(n+1).\n2. ratio_tendsto: (n+1) → +∞ (tendsto_natCast_atTop_atTop + const), so (n+1)⁻¹ → 0 (inv_tendsto_atTop); hence n/(n+1) = 1 − (n+1)⁻¹ → 1.\n3. catalan_asymptotic: multiply the parent's centralBinom_asymptotic (C·√(πn)/4ⁿ → 1) by ratio_tendsto (→1) to get a product → 1; the product equals catalan n · n · √(πn)/4ⁿ pointwise, because (C/(n+1))·n = catalan n · n and the √(πn)/4ⁿ factors match (field_simp).\n4. catalan_asymptotic_inv: apply Tendsto.inv₀ with nonzero limit 1 and rewrite (a/b)⁻¹ = b/a (inv_div) to obtain 4ⁿ/(catalan n · n · √(πn)) → 1.",
+    "keyInsights": [
+      "**The 1/(n+1) shifts the polynomial power by one**: dividing C(2n,n) ~ 4ⁿ/n^{1/2} by (n+1) turns the n^{1/2} into n^{3/2}. Asymptotically the only effect of the normalization is the ratio n/(n+1) → 1.",
+      "**Avoiding rpow**: stating the bound as catalan n · n · √(πn)/4ⁿ → 1 uses n·√(πn) = √π·n^{3/2}, keeping everything in terms of the already-available √(πn) from the parent and a single extra integer factor n — no real-power (rpow) reasoning is needed.",
+      "**One ratio limit on top of the parent**: the entire result is the parent's limit times n/(n+1). The mathematical content beyond the parent is exactly the elementary fact n/(n+1) → 1 plus the exact Catalan identity.",
+      "**Exact identity, then limit algebra**: (n+1)·catalan n = C(2n,n) holds for every n with no error term, so the asymptotic transfers verbatim through a convergent multiplicative factor."
+    ],
+    "prerequisites": [
+      "Catalan numbers and their relation Cₙ = C(2n,n)/(n+1)",
+      "The central binomial asymptotic C(2n,n) ~ 4ⁿ/√(πn) (parent entry)",
+      "Limits of sequences (Filter.Tendsto, 𝓝), products and reciprocals of limits",
+      "The elementary limit n/(n+1) → 1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-cat",
+      "title": "Imports and the Real Catalan Number",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "File-level docstring deriving the plan, imports Mathlib and the parent module Proofs.StirlingFormulaOQ03OQ02 (reusing cb, cb_pos, cb_ne_zero, centralBinom_asymptotic), opens Filter/Topology/Nat and scoped Real. Defines cat n = (catalan n : ℝ) with positivity lemmas cat_pos, cat_ne_zero.",
+      "mathContext": "cat n = catalan n cast to ℝ; cat n > 0 since (n+1)·catalan n = C(2n,n) > 0 forces catalan n > 0."
+    },
+    {
+      "id": "catalan-identity",
+      "title": "The Exact Bridge to the Central Binomial Coefficient",
+      "startLine": 63,
+      "endLine": 72,
+      "summary": "cat_eq: the real identity catalan n = C(2n,n)/(n+1), obtained by casting Nat.succ_mul_catalan_eq_centralBinom and dividing by the nonzero (n+1) (linear_combination).",
+      "mathContext": "(n+1)·catalan n = C(2n,n) over ℕ casts to ((n:ℝ)+1)·catalan n = cb n, hence catalan n = cb n/(n+1)."
+    },
+    {
+      "id": "ratio-limit",
+      "title": "The Ratio Limit n/(n+1) → 1",
+      "startLine": 74,
+      "endLine": 86,
+      "summary": "ratio_tendsto: n/(n+1) → 1. Shows (n+1) → +∞ via tendsto_natCast_atTop_atTop, so (n+1)⁻¹ → 0 (inv_tendsto_atTop); then n/(n+1) = 1 − (n+1)⁻¹ → 1 (field_simp on the eventual equality).",
+      "mathContext": "1 − 1/(n+1) = n/(n+1), and 1/(n+1) → 0, so n/(n+1) → 1 — the only asymptotic content beyond the parent limit."
+    },
+    {
+      "id": "catalan-asymptotic",
+      "title": "The Catalan Asymptotic and its Reciprocal Form",
+      "startLine": 88,
+      "endLine": 112,
+      "summary": "catalan_asymptotic (catalan n · n · √(πn)/4ⁿ → 1, the parent limit times n/(n+1), pointwise-equal after rewriting catalan n = cb n/(n+1) and field_simp) and catalan_asymptotic_inv (4ⁿ/(catalan n · n · √(πn)) → 1 via Tendsto.inv₀ at the nonzero limit 1 and inv_div).",
+      "mathContext": "catalan n · n · √(πn)/4ⁿ = [C(2n,n)·√(πn)/4ⁿ]·[n/(n+1)] → 1·1 = 1, i.e. Cₙ ~ 4ⁿ/(√π·n^{3/2}); the reciprocal limit follows since the limit 1 is nonzero."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Catalan Numbers",
+      "year": "2015",
+      "note": "Comprehensive treatment of the Catalan numbers, including Cₙ = C(2n,n)/(n+1) and the asymptotic Cₙ ~ 4ⁿ/(√π·n^{3/2})"
+    },
+    {
+      "authors": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Central binomial and Catalan asymptotics via the 1/(n+1) normalization"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-formula-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Reuses the parent's centralBinom_asymptotic (C(2n,n)·√(πn)/4ⁿ → 1) and multiplies by n/(n+1) → 1 to obtain the Catalan asymptotic"
+    },
+    {
+      "targetId": "ballot-problem-oq-04",
+      "relationship": "supports",
+      "description": "The Catalan numbers count Dyck paths and non-crossing partitions; this entry supplies their growth rate"
+    }
+  ],
+  "conclusion": {
+    "summary": "The Catalan numbers satisfy catalan n · n · √(πn)/4ⁿ → 1 (catalan_asymptotic), i.e. Cₙ ~ 4ⁿ/(√π·n^{3/2}), with the equivalent reciprocal form 4ⁿ/(catalan n · n · √(πn)) → 1 (catalan_asymptotic_inv). The proof uses Mathlib's exact identity (n+1)·catalan n = C(2n,n) to write catalan n = C(2n,n)/(n+1) (cat_eq) and multiplies the parent's central binomial asymptotic by the elementary ratio n/(n+1) → 1 (ratio_tendsto).",
+    "implications": "Provides a directly citable Lean statement of the standard Catalan growth rate, completing the chain Wallis' product → central binomial asymptotic → Catalan asymptotic. The proof isolates the only new ingredient — the ratio n/(n+1) → 1 — showing the n^{3/2} power is purely an artifact of the 1/(n+1) normalization.",
+    "openQuestions": [
+      "Can the asymptotic be sharpened to the next-order Catalan expansion Cₙ = 4ⁿ/(√π·n^{3/2})·(1 − 9/(8n) + O(1/n²))?",
+      "Does the same identity route give a Tendsto-level asymptotic for the super-Catalan / Motzkin numbers, which share a central-binomial-style closed form?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.StirlingFormulaOQ03OQ02"
+    ],
+    "opens": [
+      "Filter",
+      "Topology",
+      "Nat",
+      "Real (scoped)"
+    ],
+    "namespace": "StirlingFormulaOQ03OQ02OQ01",
+    "lineCount": 112,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/StirlingFormulaOQ03OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's **openQuestions[1]** (`burnside-counting-oq-03-oq-02-oq-01`): push the parent's integer-form cyclic Burnside total
`∑_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n` to the **standard closed divisor form**
`∑_{d∣n} φ(n/d)·k^d` by grouping the `n` rotations according to their cycle count.

## Results (3 theorems, 105 lines, 0 sorries, 0 axioms)

- **(D) `sum_range_pow_gcd_eq_sum_divisors`** — `∑_{r∈range n} k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d`. Regroup `range n` along `r ↦ gcd(n,r)` (values land in `n.divisors` by `Nat.gcd_dvd_left`) via `Finset.sum_fiberwise_of_maps_to'`; each fiber is the constant `k^d` and its cardinality is `φ(n/d)` by Mathlib's `Nat.totient_div_of_dvd` — the very fiber count behind Gauss's `∑_{d∣n} φ(d) = n`.
- **(E) `sum_pow_gcd_eq_sum_divisors_totient`** — the same identity over `ZMod n`, transported from (D) by `Finset.sum_bij'` along the bijection `ZMod.val : ZMod n ≃ range n`.
- **(F) `card_necklaces_mul_eq_sum_divisors`** — `(#necklaces up to rotation)·n = ∑_{d∣n} φ(n/d)·k^d`, combining (E) with the parent's integer-form Burnside total `sum_pow_gcd_eq_card_necklaces_mul`. Dividing by `n` gives the textbook cyclic necklace count `(1/n)·∑_{d∣n} φ(n/d) k^d`.

## Verification

`#print axioms` on all three theorems lists only `propext`, `Classical.choice`, `Quot.sound` (the ordinary foundational axioms). **0 literal `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`.** Status `verified`, badge `original`.

Builds on host via `lake env lean` (parent olean rebuilt first). Aggregator `Proofs.lean` import added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)