### PR TITLE
Enrich Cubic Sine Limit (L'Hôpital OQ-05): add index.ts, deepen annotations

### DIFF
--- a/src/data/proofs/lhopital-oq-05/annotations.json
+++ b/src/data/proofs/lhopital-oq-05/annotations.json
@@ -2,34 +2,37 @@
   {
     "id": "ann-deviation-bound",
     "proofId": "lhopital-oq-05",
-    "range": {
-      "startLine": 33,
-      "endLine": 47
-    },
+    "range": { "startLine": 33, "endLine": 47 },
     "type": "insight",
     "title": "Divide the Taylor Remainder by x³",
-    "content": "abs_sub_le is the quantitative heart of the limit. Mathlib's Real.sin_bound says |sin x − (x − x³/6)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the cubic Maclaurin remainder. Rewriting the deviation as −(sin x − (x − x³/6))/x³ (field_simp; ring), then using |a/b| = |a|/|b| and |x³| = |x|³, the deviation equals |sin x − (x − x³/6)|/|x|³. Dividing the degree-4 numerator bound by the degree-3 denominator leaves (5/96)·|x|: a bound that is linear in x and hence visibly vanishes. No differentiation, no L'Hôpital."
+    "content": "abs_sub_le is the quantitative heart of the limit. Mathlib's Real.sin_bound says |sin x − (x − x³/6)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the cubic Maclaurin remainder. Rewriting the deviation as −(sin x − (x − x³/6))/x³ (field_simp; ring), then using |a/b| = |a|/|b| and |x³| = |x|³, the deviation equals |sin x − (x − x³/6)|/|x|³. Dividing the degree-4 numerator bound by the degree-3 denominator leaves (5/96)·|x|: a bound linear in x that visibly vanishes. No differentiation, no L'Hôpital — the indeterminate 0/0 is resolved by a single off-the-shelf Taylor estimate.",
+    "mathContext": "$\\left|\\dfrac{x-\\sin x}{x^3} - \\dfrac16\\right| = \\dfrac{|\\sin x - (x - x^3/6)|}{|x|^3} \\le \\dfrac{(5/96)|x|^4}{|x|^3} = \\tfrac{5}{96}|x|.$",
+    "significance": "key",
+    "relatedConcepts": ["Taylor remainder", "Maclaurin series of sine", "error bounds", "Real.sin_bound"],
+    "prerequisites": ["Taylor's theorem with remainder", "absolute value algebra"]
   },
   {
     "id": "ann-the-limit",
     "proofId": "lhopital-oq-05",
-    "range": {
-      "startLine": 49,
-      "endLine": 69
-    },
+    "range": { "startLine": 49, "endLine": 69 },
     "type": "insight",
     "title": "One Squeeze Finishes It",
-    "content": "tendsto_cubic_sine reduces the limit-to-1/6 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|. The bound |deviation| ≤ a x of abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The envelope tends to 0 since |x| → 0 (continuity of absolute value) scaled by 5/96. The two-sided control sits inside a single absolute value, so one squeeze — not separate upper and lower envelopes — suffices."
+    "content": "tendsto_cubic_sine reduces the limit-to-1/6 to a limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope a x = (5/96)·|x|. The bound |deviation| ≤ a x from abs_sub_le needs |x| ≤ 1, which holds eventually on 𝓝[≠] 0 because the closed unit ball is a neighbourhood of 0 (Metric.closedBall_mem_nhds). The envelope tends to 0 since |x| → 0 (continuity of absolute value) scaled by 5/96. The two-sided control sits inside a single absolute value, so one squeeze — not separate upper and lower envelopes — suffices.",
+    "mathContext": "$0 \\le \\left|\\tfrac{x-\\sin x}{x^3} - \\tfrac16\\right| \\le \\tfrac{5}{96}|x| \\to 0$ on $\\mathcal{N}_{\\neq}(0)$ (squeeze).",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "punctured neighbourhood filter", "eventual bounds", "continuity of absolute value"],
+    "prerequisites": ["squeeze/sandwich theorem", "filters and neighbourhoods"]
   },
   {
     "id": "ann-taylor-coefficient",
     "proofId": "lhopital-oq-05",
-    "range": {
-      "startLine": 71,
-      "endLine": 81
-    },
+    "range": { "startLine": 71, "endLine": 81 },
     "type": "concept",
-    "title": "1/6 Is the Third Taylor Coefficient",
-    "content": "tendsto_cubic_sine_factorial restates the value 1/6 as 1/3!. This is not cosmetic: x − sin x = x³/6 − x⁵/120 + ⋯, so its leading nonvanishing Maclaurin term is x³/3!, and the limit of (x − sin x)/x³ is exactly that coefficient 1/3!. It mirrors the order-1 sibling entry (OQ-04), where the limit is the ratio of first Taylor coefficients f'(a)/1! — here the single third coefficient is read off directly."
+    "title": "1/6 Is the Third Taylor Coefficient (1/3!)",
+    "content": "tendsto_cubic_sine_factorial restates the value 1/6 as 1/3!. This is not cosmetic: x − sin x = x³/6 − x⁵/120 + ⋯, so its leading nonvanishing Maclaurin term is x³/3!, and the limit of (x − sin x)/x³ is exactly that coefficient 1/3!. It mirrors the order-1 sibling entry (lhopital-oq-04), where the limit is the ratio of first Taylor coefficients f′(a)/1! — here the single third coefficient is read off directly, exhibiting L'Hôpital-at-order-k as Taylor-coefficient extraction.",
+    "mathContext": "$\\dfrac{x-\\sin x}{x^3} \\to \\dfrac{1}{3!} = \\dfrac16$, the order-3 Maclaurin coefficient of $x-\\sin x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Taylor coefficients", "factorial denominators", "higher-order L'Hôpital", "Maclaurin series"],
+    "prerequisites": ["Maclaurin expansion", "factorials"]
   }
 ]

--- a/src/data/proofs/lhopital-oq-05/index.ts
+++ b/src/data/proofs/lhopital-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LHopitalOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lhopitalOq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lhopitalOq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lhopitalOq05Data: ProofData = {
+  proof: lhopitalOq05Proof,
+  annotations: lhopitalOq05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-05` ($\lim_{x\to0}(x-\sin x)/x^3 = 1/6$, via Mathlib's cubic Taylor bound + a squeeze — no thrice-applied L'Hôpital).

## Quality improvements
- **Added missing `index.ts`** — without it the proof page renders "proof not found" on the live site.
- **Deepened all annotations** with LaTeX `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` (previously bare title+content). Surfaced the degree-4-over-degree-3 remainder division, the single-absolute-value squeeze, and the $1/3!$ Taylor-coefficient reading (linking to sibling lhopital-oq-04).

meta.json was already solid (verified, 0 axioms/sorries). status/badge consistent with the Lean source.

Note: `pnpm build` could not run in this worktree (`node_modules` absent); JSON validated with Python and `index.ts` follows the established gallery template.