### PR TITLE
research(burnside-counting-oq-03-oq-02-oq-01-oq-02): necklace divisor-sum ∑_r k^{gcd(n,r)} = ∑_{d|n} φ(n/d)·k^d [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -564,6 +564,7 @@ import Proofs.BurnsideCountingOQ03
 import Proofs.BurnsideCountingOQ03Aristotle
 import Proofs.BurnsideCountingOQ03OQ02
 import Proofs.BurnsideCountingOQ03OQ02OQ01
+import Proofs.BurnsideCountingOQ03OQ02OQ01OQ02
 import Proofs.BurnsideCountingOQ03OQ03
 import Proofs.BurnsideCountingOQ04
 import Proofs.BurnsideCountingOQ04OQ01

--- a/proofs/Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean
@@ -1,0 +1,123 @@
+/-
+# Necklace Divisor-Sum: ∑_{r} k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d
+## (burnside-counting-oq-03-oq-02-oq-01-oq-02)
+
+**Open question** (from `burnside-counting-oq-03-oq-02-oq-01`): the parent proves the
+cyclic Burnside count in the *raw rotation-indexed* form
+`∑_{r : ZMod n} k ^ gcd(n, r.val) = (#necklaces) · n` — every one of the `n` rotations
+contributes `k ^ gcd(n, r)` fixed colorings. Push this to the classical **divisor-sum**
+shape by grouping the `n` rotations according to their order.
+
+The order of rotation `r` is `n / gcd(n, r)`, so rotations of order `n/d` are exactly the
+`r` with `gcd(n, r) = d`, and there are `φ(n/d)` of them (Euler's totient counts the
+generators of the cyclic subgroup of index `d`). Collecting the `n` rotations into these
+fibres turns the flat sum into a sum over divisors:
+
+* **(A) Fibre-collapse** (`sum_pow_gcd_eq_divisor_sum`):
+    `∑_{r : ZMod n} k ^ gcd(n, r.val) = ∑_{d ∈ n.divisors} φ(n/d) · k ^ d`.
+  Reindex `ZMod n` along `ZMod.val` to `range n`, fibre the sum over the divisor-valued
+  map `i ↦ gcd(n, i)` (`Finset.sum_fiberwise_of_maps_to`, since `gcd n i ∣ n`), and read off
+  each fibre's size as `φ(n/d)` via Mathlib's `Nat.totient_div_of_dvd`.
+
+* **(B) Divisor-form necklace count** (`divisor_sum_eq_card_necklaces_mul`):
+    `∑_{d ∈ n.divisors} φ(n/d) · k ^ d = (#necklaces up to rotation) · n`,
+  the parent's count (C) rewritten in divisor form by chaining `(A)` with the parent's
+  `sum_pow_gcd_eq_card_necklaces_mul`.
+
+* **(C) Textbook form** (`divisor_sum_swap`):
+    `∑_{d ∈ n.divisors} φ(n/d) · k ^ d = ∑_{d ∈ n.divisors} φ(d) · k ^ (n/d)`,
+  the familiar `(1/n) ∑_{d∣n} φ(d) · k^{n/d}` necklace formula, obtained from the
+  divisor involution `d ↦ n/d` (`Nat.sum_div_divisors`).
+
+This converts the parent's per-rotation value `k^{gcd(n,r)}` into the standard closed form
+quoted in every combinatorics text for the number of `k`-colored `n`-bead necklaces.
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+import Mathlib
+import Proofs.BurnsideCountingOQ03OQ02OQ01
+
+open Finset BigOperators
+
+namespace BurnsideCountingOQ03OQ02OQ01OQ02
+
+open BurnsideCountingOQ03OQ02OQ01 (Rot rotation sum_pow_gcd_eq_card_necklaces_mul)
+
+variable {n : ℕ} [NeZero n]
+
+/-! ## Section I: reindex the rotation sum over `range n`
+
+`ZMod.val` is a bijection from `ZMod n` onto `{0, …, n-1} = range n` (for `n ≠ 0`), so the
+sum over all `n` rotations is literally the sum over `range n` of `k ^ gcd(n, i)`. -/
+
+/-- The flat sum over `ZMod n` equals the sum over `range n` along `ZMod.val`. -/
+lemma sum_zmod_eq_sum_range (k : ℕ) :
+    (∑ r : ZMod n, k ^ Nat.gcd n r.val) = ∑ i ∈ range n, k ^ Nat.gcd n i := by
+  refine Finset.sum_bij (fun r _ => r.val) ?_ ?_ ?_ ?_
+  · -- maps `univ` into `range n`
+    intro r _
+    exact mem_range.2 (ZMod.val_lt r)
+  · -- injective
+    intro a _ b _ hab
+    exact ZMod.val_injective n hab
+  · -- surjective onto `range n`
+    intro i hi
+    exact ⟨(i : ZMod n), mem_univ _, ZMod.val_cast_of_lt (mem_range.1 hi)⟩
+  · -- value agreement
+    intro r _
+    rfl
+
+/-! ## Section II: (A) fibre-collapse to the divisor sum -/
+
+/-- **(A)** Grouping the `n` rotations by `gcd(n, r)` collapses the flat sum into a divisor
+sum, the fibre over `d ∣ n` having size `φ(n/d)`. -/
+theorem sum_pow_gcd_eq_divisor_sum (k : ℕ) :
+    (∑ r : ZMod n, k ^ Nat.gcd n r.val)
+      = ∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d := by
+  rw [sum_zmod_eq_sum_range]
+  have hn : n ≠ 0 := NeZero.ne n
+  -- fibre `range n` over the divisor-valued map `i ↦ gcd n i`
+  have hmaps : ∀ i ∈ range n, Nat.gcd n i ∈ n.divisors := by
+    intro i _
+    exact Nat.mem_divisors.2 ⟨Nat.gcd_dvd_left _ _, hn⟩
+  rw [← Finset.sum_fiberwise_of_maps_to hmaps (fun i => k ^ Nat.gcd n i)]
+  -- each fibre is constant `k ^ d` with cardinality `φ(n/d)`
+  refine Finset.sum_congr rfl (fun d hd => ?_)
+  have hdvd : d ∣ n := Nat.dvd_of_mem_divisors hd
+  rw [Finset.sum_congr rfl (fun i hi => by rw [(mem_filter.1 hi).2]),
+      Finset.sum_const, Nat.totient_div_of_dvd hdvd, smul_eq_mul]
+
+/-! ## Section III: (B) divisor-form necklace count -/
+
+/-- **(B)** The classical cyclic necklace count in divisor form:
+`∑_{d∣n} φ(n/d) · k^d = (#necklaces up to rotation) · n`. -/
+theorem divisor_sum_eq_card_necklaces_mul (k : ℕ) :
+    (∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d)
+      = Nat.card (MulAction.orbitRel.Quotient (Rot n) (Rot n → Fin k)) * n := by
+  rw [← sum_pow_gcd_eq_divisor_sum, sum_pow_gcd_eq_card_necklaces_mul]
+
+/-! ## Section IV: (C) textbook `∑ φ(d)·k^{n/d}` form -/
+
+/-- **(C)** The divisor involution `d ↦ n/d` rewrites the sum into the standard textbook
+shape `∑_{d∣n} φ(d) · k^{n/d}`, whose `1/n`-average is the usual necklace formula. -/
+theorem divisor_sum_swap (k : ℕ) :
+    (∑ d ∈ n.divisors, Nat.totient (n / d) * k ^ d)
+      = ∑ d ∈ n.divisors, Nat.totient d * k ^ (n / d) := by
+  rw [← Nat.sum_div_divisors n (fun d => Nat.totient d * k ^ (n / d))]
+  refine Finset.sum_congr rfl (fun d hd => ?_)
+  have hdvd : d ∣ n := Nat.dvd_of_mem_divisors hd
+  rw [Nat.div_div_self hdvd (NeZero.ne n)]
+
+/-- **(B′)** Textbook necklace count: `∑_{d∣n} φ(d) · k^{n/d} = (#necklaces) · n`. -/
+theorem textbook_necklace_count (k : ℕ) :
+    (∑ d ∈ n.divisors, Nat.totient d * k ^ (n / d))
+      = Nat.card (MulAction.orbitRel.Quotient (Rot n) (Rot n → Fin k)) * n := by
+  rw [← divisor_sum_swap, divisor_sum_eq_card_necklaces_mul]
+
+#check @sum_pow_gcd_eq_divisor_sum
+#check @divisor_sum_eq_card_necklaces_mul
+#check @divisor_sum_swap
+#check @textbook_necklace_count
+
+end BurnsideCountingOQ03OQ02OQ01OQ02

--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "burnside-oq03020102-header",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "From rotation-indexed sum to the divisor-sum closed form",
+    "content": "The header states the parent's explicit request (openQuestions[1]): push the cyclic Burnside count from its raw rotation-indexed shape Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n to the classical divisor-sum closed form Σ_{d|n} φ(n/d)·k^d. The mechanism is grouping the n rotations by their order: a rotation r has order n/gcd(n,r), so the rotations with gcd(n,r) = d are exactly the φ(n/d) generators of the cyclic subgroup of index d. Four results follow: (A) the fibre-collapse Σ_r k^{gcd(n,r)} = Σ_{d|n} φ(n/d)·k^d; (B) the same count in divisor form = (#necklaces)·n; (C) the divisor-involution swap to Σ_{d|n} φ(d)·k^{n/d}; and (B′) the textbook count Σ_{d|n} φ(d)·k^{n/d} = (#necklaces)·n. Verified: 0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound, no native_decide).",
+    "mathContext": "$\\sum_{r\\in\\mathbb{Z}/n} k^{\\gcd(n,r)} = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d = \\sum_{d\\mid n}\\varphi(d)\\,k^{n/d} = \\#\\text{necklaces}\\cdot n$",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "necklace counting", "Euler totient", "divisor sum", "gcd"],
+    "prerequisites": ["the parent's Σ_r k^{gcd(n,r)} = (#necklaces)·n", "Euler's totient φ", "divisors of n"]
+  },
+  {
+    "id": "burnside-oq03020102-reindex",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 70 },
+    "type": "technique",
+    "title": "sum_zmod_eq_sum_range: ZMod.val bijects ZMod n with range n",
+    "content": "The parent's sum is indexed by ZMod n, but the fibre/divisor machinery (Finset.sum_fiberwise_of_maps_to, Nat.totient_div_of_dvd) lives on Finset.range n. The lemma sum_zmod_eq_sum_range bridges them: ZMod.val is a bijection ZMod n ≃ range n for n ≠ 0. Finset.sum_bij with the map r ↦ r.val discharges the four obligations off the shelf — codomain via ZMod.val_lt (r.val < n), injectivity via ZMod.val_injective, surjectivity onto range n via ZMod.val_cast_of_lt ((↑i).val = i for i < n), and value agreement by rfl since the summand depends only on r.val. The result Σ_{r:ZMod n} k^{gcd(n,r.val)} = Σ_{i∈range n} k^{gcd(n,i)} exposes exactly the range-n form needed for fibring.",
+    "mathContext": "$\\mathbb{Z}/n \\xrightarrow{\\ \\mathrm{val}\\ }\\sim \\mathrm{range}\\,n,\\qquad \\sum_{r} k^{\\gcd(n,r.\\mathrm{val})} = \\sum_{i\\in\\mathrm{range}\\,n} k^{\\gcd(n,i)}$",
+    "significance": "standard",
+    "relatedConcepts": ["ZMod.val", "Finset.sum_bij", "bijection of index sets"],
+    "prerequisites": ["ZMod n as residues 0..n-1", "Finset.range", "reindexing a finite sum"]
+  },
+  {
+    "id": "burnside-oq03020102-fibre-collapse",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 72, "endLine": 96 },
+    "type": "theorem",
+    "title": "(A) sum_pow_gcd_eq_divisor_sum: grouping by gcd value",
+    "content": "The headline identity Σ_{i∈range n} k^{gcd(n,i)} = Σ_{d∈n.divisors} φ(n/d)·k^d. Since gcd(n,i) ∣ n and n ≠ 0, the map i ↦ gcd(n,i) sends range n into n.divisors, so Finset.sum_fiberwise_of_maps_to partitions the sum over the fibres {i ∈ range n | gcd(n,i) = d} indexed by d ∈ n.divisors. On each fibre the summand k^{gcd(n,i)} is the constant k^d (Finset.sum_congr rewriting by the filter membership), so Finset.sum_const collapses the inner sum to (#fibre) • k^d = (#fibre)·k^d. The fibre size is supplied verbatim by Mathlib's Nat.totient_div_of_dvd: for d ∣ n, φ(n/d) = #{k ∈ range n | gcd(n,k) = d} — the same totient-counting fact Mathlib uses to prove Σ_{d|n} φ(d) = n. This single lemma carries the entire arithmetic of the regrouping.",
+    "mathContext": "$\\sum_{i\\in\\mathrm{range}\\,n} k^{\\gcd(n,i)} = \\sum_{d\\mid n} \\#\\{i : \\gcd(n,i)=d\\}\\cdot k^d = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_fiberwise_of_maps_to", "Nat.totient_div_of_dvd", "Finset.sum_const", "fibre partition by gcd"],
+    "prerequisites": ["gcd n i ∣ n", "fibrewise summation", "Euler totient counts residues of fixed gcd"]
+  },
+  {
+    "id": "burnside-oq03020102-divisor-count",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 98, "endLine": 106 },
+    "type": "theorem",
+    "title": "(B) divisor_sum_eq_card_necklaces_mul: the count in divisor form",
+    "content": "Chaining the fibre-collapse (A) with the parent's sum_pow_gcd_eq_card_necklaces_mul (Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n) restates the classical cyclic necklace count directly in divisor form: Σ_{d|n} φ(n/d)·k^d = Nat.card (orbitRel.Quotient (Rot n) (Rot n → Fin k))·n. Dividing by n gives the number of k-colored n-bead necklaces up to rotation as (1/n)·Σ_{d|n} φ(n/d)·k^d — a one-line consequence once (A) is in hand.",
+    "mathContext": "$\\sum_{d\\mid n}\\varphi(n/d)\\,k^d = \\#\\big(\\text{necklaces up to rotation}\\big)\\cdot n$",
+    "significance": "key",
+    "relatedConcepts": ["necklace count", "orbit quotient cardinality", "Burnside average"],
+    "prerequisites": ["fibre-collapse (A)", "the parent's rotation-indexed necklace count"]
+  },
+  {
+    "id": "burnside-oq03020102-textbook-swap",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 108, "endLine": 123 },
+    "type": "theorem",
+    "title": "(C) divisor_sum_swap and the textbook Σ φ(d)·k^{n/d} form",
+    "content": "The two standard closed forms Σ_{d|n} φ(n/d)·k^d and Σ_{d|n} φ(d)·k^{n/d} are equal by the divisor involution d ↦ n/d. divisor_sum_swap applies Nat.sum_div_divisors to f(d) = φ(d)·k^{n/d}: Σ_{d|n} f(n/d) = Σ_{d|n} f(d), and since n/(n/d) = d for d ∣ n (Nat.div_div_self), the left side is exactly Σ_{d|n} φ(n/d)·k^d. Composing with (B) gives textbook_necklace_count: Σ_{d|n} φ(d)·k^{n/d} = (#necklaces)·n — the familiar (1/n)·Σ_{d|n} φ(d)·k^{n/d} formula quoted in every combinatorics text, now in fully verified integer form.",
+    "mathContext": "$\\sum_{d\\mid n}\\varphi(n/d)\\,k^d = \\sum_{d\\mid n}\\varphi(d)\\,k^{n/d} = \\#\\text{necklaces}\\cdot n$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.sum_div_divisors", "divisor involution d ↦ n/d", "textbook necklace formula"],
+    "prerequisites": ["divisor sums over n.divisors", "n/(n/d) = d for d ∣ n", "divisor-form count (B)"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+  "title": "Necklace Divisor-Sum: ∑_r k^{gcd(n,r)} = ∑_{d∣n} φ(n/d)·k^d",
+  "slug": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+  "description": "Pushes the parent's raw rotation-indexed cyclic Burnside count ∑_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n to the classical divisor-sum closed form ∑_{d|n} φ(n/d)·k^d by grouping the n rotations according to their order. A rotation r has order n/gcd(n,r), so the rotations with gcd(n,r) = d are exactly the φ(n/d) generators of the cyclic subgroup of index d; collecting the flat sum into these fibres turns it into a sum over divisors. (A) sum_pow_gcd_eq_divisor_sum: reindex ZMod n along ZMod.val to range n, fibre the sum over the divisor-valued map i ↦ gcd(n,i) (Finset.sum_fiberwise_of_maps_to, valid since gcd n i ∣ n), and read off each fibre's size as φ(n/d) via Mathlib's Nat.totient_div_of_dvd. (B) divisor_sum_eq_card_necklaces_mul: chaining (A) with the parent's necklace count gives ∑_{d|n} φ(n/d)·k^d = (#necklaces)·n. (C) divisor_sum_swap: the divisor involution d ↦ n/d (Nat.sum_div_divisors) rewrites this into the textbook ∑_{d|n} φ(d)·k^{n/d}, whose 1/n-average is the formula quoted in every combinatorics text for the number of k-colored n-bead necklaces.",
+  "meta": {
+    "author": "Cauchy–Frobenius–Burnside / Euler (necklace divisor-sum); formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Necklace_(combinatorics)",
+    "date": "1887",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-theory",
+      "number-theory",
+      "necklaces",
+      "burnside",
+      "orbit-counting",
+      "totient",
+      "divisor-sum",
+      "cyclic-group",
+      "gcd",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. Fully machine-checked: all four main theorems (sum_pow_gcd_eq_divisor_sum, divisor_sum_eq_card_necklaces_mul, divisor_sum_swap, textbook_necklace_count) depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide is used.",
+    "dateAdded": "2026-06-25",
+    "lineCount": 123,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_div_of_dvd",
+        "description": "For d ∣ n, φ(n/d) = #{k ∈ range n | gcd(n,k) = d}: the count of residues with a fixed gcd. This is the fibre-size fact that turns the grouped sum into a totient-weighted divisor sum; Mathlib's own sum_totient is proven through it.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.sum_fiberwise_of_maps_to",
+        "description": "∑_{y∈t} ∑_{x∈s, g x = y} f x = ∑_{x∈s} f x for g mapping s into t; applied with s = range n, t = n.divisors, g = (gcd n ·) to partition the rotation sum by gcd value.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.sum_div_divisors",
+        "description": "∑_{d∈n.divisors} f(n/d) = ∑_{d∈n.divisors} f(d): the divisor involution d ↦ n/d reindexes a sum over divisors, converting ∑ φ(n/d)·k^d into the textbook ∑ φ(d)·k^{n/d}.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "ZMod.val_cast_of_lt",
+        "description": "For a < n, (↑a : ZMod n).val = a; with ZMod.val_lt and ZMod.val_injective it establishes the bijection ZMod n ≃ range n along ZMod.val used to recast the rotation sum as a sum over range n.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "∑_{x∈s} c = s.card • c; collapses each constant fibre ∑_{i, gcd n i = d} k^d to (#fibre)·k^d.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sum_pow_gcd_eq_divisor_sum (A): ∑_{r:ZMod n} k^{gcd(n,r)} = ∑_{d|n} φ(n/d)·k^d — the fibre-collapse identity grouping the n rotations by gcd value, the content the parent flagged as openQuestions[1]",
+      "sum_zmod_eq_sum_range: the rotation sum over ZMod n equals the sum over range n along ZMod.val (Finset.sum_bij with val_lt / val_injective / val_cast_of_lt), the bridge that exposes the fibre structure",
+      "divisor_sum_eq_card_necklaces_mul (B): ∑_{d|n} φ(n/d)·k^d = (#necklaces up to rotation)·n, the parent's necklace count restated in divisor form",
+      "divisor_sum_swap (C): ∑_{d|n} φ(n/d)·k^d = ∑_{d|n} φ(d)·k^{n/d}, the divisor involution turning the result into the standard textbook shape",
+      "textbook_necklace_count (B′): ∑_{d|n} φ(d)·k^{n/d} = (#necklaces)·n — the familiar (1/n)∑_{d|n} φ(d)·k^{n/d} necklace formula in integer form"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The number of k-colored n-bead necklaces up to rotation is the textbook first application of Burnside's lemma, classically stated in the closed form (1/n)·Σ_{d|n} φ(d)·k^{n/d}. Equivalently it is (1/n)·Σ_{r∈Z/n} k^{gcd(n,r)}: each rotation r fixes exactly k^{gcd(n,r)} colorings, and the two expressions agree because the n rotations group by order — a rotation has order n/gcd(n,r), so exactly φ(n/d) of them satisfy gcd(n,r) = d for each divisor d. The parent gallery entry burnside-counting-oq-03-oq-02-oq-01 proved the raw rotation-indexed identity Σ_r k^{gcd(n,r)} = (#necklaces)·n and explicitly asked (openQuestions[1]) to push it to the divisor-sum closed form. This entry supplies that step, reducing the regrouping to Euler's totient counting the residues with a fixed gcd — the same fact behind Mathlib's Nat.sum_totient.",
+    "problemStatement": "Starting from the parent's Σ_{r∈ZMod n} k^{gcd(n,r)} = (#necklaces up to rotation)·n, prove the divisor-sum form (A) Σ_{r∈ZMod n} k^{gcd(n,r)} = Σ_{d|n} φ(n/d)·k^d; deduce (B) Σ_{d|n} φ(n/d)·k^d = (#necklaces)·n; and (C) Σ_{d|n} φ(n/d)·k^d = Σ_{d|n} φ(d)·k^{n/d}, the standard textbook closed form whose 1/n-average counts the necklaces.",
+    "proofStrategy": "**(A) Fibre-collapse.** First recast the sum over ZMod n as a sum over range n: ZMod.val is a bijection ZMod n ≃ range n (val_lt gives the codomain, val_injective injectivity, val_cast_of_lt surjectivity), so Σ_{r:ZMod n} k^{gcd(n,r.val)} = Σ_{i∈range n} k^{gcd(n,i)} (Finset.sum_bij). The map i ↦ gcd(n,i) sends range n into n.divisors (gcd n i ∣ n and n ≠ 0), so Finset.sum_fiberwise_of_maps_to partitions the sum: Σ_{i∈range n} k^{gcd(n,i)} = Σ_{d∈n.divisors} Σ_{i∈range n, gcd(n,i)=d} k^{gcd(n,i)}. On each fibre gcd(n,i) = d, so the inner summand is the constant k^d and Finset.sum_const collapses it to (#fibre)·k^d. Finally Mathlib's Nat.totient_div_of_dvd identifies #{i∈range n | gcd(n,i)=d} = φ(n/d) for d ∣ n, giving Σ_{d|n} φ(n/d)·k^d.\n\n**(B) Divisor-form count.** Chain (A) with the parent's sum_pow_gcd_eq_card_necklaces_mul.\n\n**(C) Textbook swap.** Apply Nat.sum_div_divisors to f(d) = φ(d)·k^{n/d}: Σ_{d|n} f(n/d) = Σ_{d|n} f(d). Since n/(n/d) = d for d ∣ n (Nat.div_div_self), the left side is Σ_{d|n} φ(n/d)·k^d and the right is Σ_{d|n} φ(d)·k^{n/d}. Composing with (B) yields the textbook necklace count textbook_necklace_count.",
+    "keyInsights": [
+      "**Grouping rotations by order IS a divisor sum.** The flat sum Σ_r k^{gcd(n,r)} ranges over all n rotations; partitioning them by their common gcd value d — equivalently by their order n/d — turns the index set range n into the divisor set n.divisors, with each fibre weighted by how many rotations share that order.",
+      "**Euler's totient counts the fibres.** The number of residues r ∈ [0,n) with gcd(n,r) = d is exactly φ(n/d): scaling by d identifies {r : gcd(n,r)=d} with the φ(n/d) units mod n/d. This single Mathlib lemma (Nat.totient_div_of_dvd) carries the entire arithmetic of the regrouping.",
+      "**Two closed forms, one involution.** Σ_{d|n} φ(n/d)·k^d and Σ_{d|n} φ(d)·k^{n/d} are the same number, related purely by the divisor involution d ↦ n/d; the first arises naturally from grouping rotations, the second is the form quoted in textbooks.",
+      "**val bridges ZMod n and range n.** The rotation sum is indexed by ZMod n but the fibre/divisor machinery lives on range n; ZMod.val is the off-the-shelf bijection between them, so no bespoke reindexing is needed."
+    ],
+    "prerequisites": [
+      "The parent entry's Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n (burnside-counting-oq-03-oq-02-oq-01)",
+      "Euler's totient and the fibre count φ(n/d) = #{k<n | gcd(n,k)=d} (Nat.totient_div_of_dvd)",
+      "Fibrewise summation Finset.sum_fiberwise_of_maps_to and Finset.sum_const",
+      "Divisor sums and the involution d ↦ n/d (Nat.sum_div_divisors, Nat.divisors)",
+      "The ZMod n ≃ range n bijection via ZMod.val"
+    ],
+    "what": "The divisor-sum closed form of the cyclic necklace count: Σ_{r∈ZMod n} k^{gcd(n,r)} = Σ_{d|n} φ(n/d)·k^d = Σ_{d|n} φ(d)·k^{n/d}, so the number of k-colored n-bead necklaces up to rotation equals (1/n)·Σ_{d|n} φ(d)·k^{n/d}.",
+    "how": "Recast the ZMod n sum over range n via ZMod.val, fibre it over the divisor-valued map i ↦ gcd(n,i) (Finset.sum_fiberwise_of_maps_to), collapse each constant fibre with Finset.sum_const, and identify the fibre size as φ(n/d) by Nat.totient_div_of_dvd; the divisor involution Nat.sum_div_divisors then produces the textbook Σ φ(d)·k^{n/d} form.",
+    "significance": "Closes the parent entry's openQuestions[1]: it converts the parent's per-rotation value k^{gcd(n,r)} into the standard closed form Σ_{d|n} φ(d)·k^{n/d} quoted in every combinatorics text, completing the bridge from the abstract Burnside orbit-count all the way down to the classical necklace-counting formula. The regrouping is reduced to one Mathlib totient-counting lemma, exhibiting the divisor sum as a direct consequence of the orbit-count rather than a separately derived identity."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Results",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring: the parent's request (openQuestions[1]) to push the rotation-indexed count Σ_r k^{gcd(n,r)} to the divisor-sum form Σ_{d|n} φ(n/d)·k^d by grouping rotations by order, and the four results — (A) the fibre-collapse, (B) the divisor-form necklace count, (C) the textbook-swap, and (B′) the textbook count.",
+      "mathContext": "$\\sum_{r} k^{\\gcd(n,r)} = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d = \\sum_{d\\mid n}\\varphi(d)\\,k^{n/d}$"
+    },
+    {
+      "id": "reindex",
+      "title": "Section I: Reindex the Rotation Sum over range n",
+      "startLine": 49,
+      "endLine": 70,
+      "summary": "sum_zmod_eq_sum_range: ZMod.val is a bijection ZMod n ≃ range n (val_lt for the codomain, val_injective for injectivity, val_cast_of_lt for surjectivity), so Σ_{r:ZMod n} k^{gcd(n,r.val)} = Σ_{i∈range n} k^{gcd(n,i)} via Finset.sum_bij — exposing the fibre structure the divisor machinery needs.",
+      "mathContext": "$\\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r.\\mathrm{val})} = \\sum_{i\\in\\mathrm{range}\\,n} k^{\\gcd(n,i)}$"
+    },
+    {
+      "id": "fibre-collapse",
+      "title": "Section II: (A) Fibre-Collapse to the Divisor Sum",
+      "startLine": 72,
+      "endLine": 96,
+      "summary": "sum_pow_gcd_eq_divisor_sum: the map i ↦ gcd(n,i) sends range n into n.divisors, so Finset.sum_fiberwise_of_maps_to partitions the sum by gcd value; each fibre is the constant k^d (Finset.sum_const) with cardinality φ(n/d) by Nat.totient_div_of_dvd, giving Σ_{d|n} φ(n/d)·k^d.",
+      "mathContext": "$\\sum_{i\\in\\mathrm{range}\\,n} k^{\\gcd(n,i)} = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$"
+    },
+    {
+      "id": "divisor-count",
+      "title": "Section III: (B) Divisor-Form Necklace Count",
+      "startLine": 98,
+      "endLine": 106,
+      "summary": "divisor_sum_eq_card_necklaces_mul: chaining (A) with the parent's sum_pow_gcd_eq_card_necklaces_mul restates the classical cyclic necklace count in divisor form Σ_{d|n} φ(n/d)·k^d = (#necklaces up to rotation)·n.",
+      "mathContext": "$\\sum_{d\\mid n}\\varphi(n/d)\\,k^d = \\#\\text{necklaces}\\cdot n$"
+    },
+    {
+      "id": "textbook-swap",
+      "title": "Section IV: (C) Textbook Σ φ(d)·k^{n/d} Form",
+      "startLine": 108,
+      "endLine": 123,
+      "summary": "divisor_sum_swap: the divisor involution d ↦ n/d (Nat.sum_div_divisors with n/(n/d) = d) rewrites Σ φ(n/d)·k^d into the textbook Σ φ(d)·k^{n/d}; textbook_necklace_count then gives Σ_{d|n} φ(d)·k^{n/d} = (#necklaces)·n, the familiar (1/n)·Σ φ(d)·k^{n/d} formula in integer form.",
+      "mathContext": "$\\sum_{d\\mid n}\\varphi(n/d)\\,k^d = \\sum_{d\\mid n}\\varphi(d)\\,k^{n/d} = \\#\\text{necklaces}\\cdot n$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Converts the parent's rotation-indexed cyclic Burnside count Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n into the classical divisor-sum closed form. (A) groups the n rotations by gcd value via Finset.sum_fiberwise_of_maps_to and reads each fibre's size as φ(n/d) (Nat.totient_div_of_dvd), giving Σ_{d|n} φ(n/d)·k^d; (B) restates the necklace count in this form; (C) the divisor involution (Nat.sum_div_divisors) yields the textbook Σ_{d|n} φ(d)·k^{n/d}, whose 1/n-average is the standard necklace formula. Fully verified with 0 sorries and 0 axioms.",
+    "implications": "Answers the parent entry's openQuestions[1] verbatim, completing the chain from the abstract group-agnostic Burnside count down to the closed form Σ_{d|n} φ(d)·k^{n/d} quoted in every combinatorics text. The whole regrouping reduces to a single Mathlib totient-counting lemma, exhibiting the divisor sum as an immediate corollary of the orbit-count rather than an independently derived identity.",
+    "openQuestions": [
+      "Specialize the divisor-sum count to prime n: for n = p prime the formula collapses to (k^p + (p-1)·k)/p, recovering Fermat's little theorem k^p ≡ k (mod p) as the integrality of the necklace count — a clean number-theoretic corollary of the combinatorial identity.",
+      "Derive the analogous bracelet (dihedral) closed form by combining this rotation divisor-sum with the reflection contributions, obtaining (1/2n)(Σ_{d|n} φ(d)·k^{n/d} + reflection terms) for the number of k-colored n-bead bracelets up to rotation and reflection."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-burnside-oq0302010-parent",
+      "targetId": "burnside-counting-oq-03-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's openQuestions[1]: push the rotation-indexed count Σ_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n to the divisor form Σ_{d|n} φ(n/d)·k^d. Reuses the parent's sum_pow_gcd_eq_card_necklaces_mul and the Rot n / rotation framing directly."
+    },
+    {
+      "id": "xref-burnside-oq0302",
+      "targetId": "burnside-counting-oq-03-oq-02",
+      "relationship": "specializes",
+      "description": "The grandparent's group-agnostic master formula |Fix(g)| = k^{cyc(g)} drives the per-rotation value k^{gcd(n,r)} that this entry sums into the divisor closed form, grounding the textbook necklace formula Σ_{d|n} φ(d)·k^{n/d} in the abstract orbit-counting API."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 123,
+    "path": "Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 5
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry **burnside-counting-oq-03-oq-02-oq-01** `openQuestions[1]`: push the cyclic Burnside count from its raw rotation-indexed shape `∑_{r:ZMod n} k^{gcd(n,r)} = (#necklaces)·n` to the classical **divisor-sum closed form** by grouping the n rotations according to their order.

A rotation r has order n/gcd(n,r), so the rotations with gcd(n,r) = d are exactly the φ(n/d) generators of the cyclic subgroup of index d. Collecting the flat sum into these fibres turns it into a sum over divisors.

## Results (`BurnsideCountingOQ03OQ02OQ01OQ02.lean`)

- **(A)** `sum_pow_gcd_eq_divisor_sum`: `∑_{r:ZMod n} k^{gcd(n,r)} = ∑_{d|n} φ(n/d)·k^d` — reindex ZMod n → range n along `ZMod.val`, fibre over `i ↦ gcd(n,i)` (`Finset.sum_fiberwise_of_maps_to`), read each fibre's size as φ(n/d) via Mathlib's `Nat.totient_div_of_dvd`.
- **(B)** `divisor_sum_eq_card_necklaces_mul`: `∑_{d|n} φ(n/d)·k^d = (#necklaces)·n` — chains (A) with the parent's count.
- **(C)** `divisor_sum_swap`: `∑_{d|n} φ(n/d)·k^d = ∑_{d|n} φ(d)·k^{n/d}` — divisor involution d ↦ n/d (`Nat.sum_div_divisors`).
- **(B′)** `textbook_necklace_count`: `∑_{d|n} φ(d)·k^{n/d} = (#necklaces)·n` — the familiar (1/n)·∑ φ(d)·k^{n/d} formula in integer form.

## Verification

- **0 sorries, 0 axioms.** All four theorems depend only on `propext`, `Classical.choice`, `Quot.sound` (verified via `#print axioms`). No `native_decide`.
- Builds against Mathlib (v4.26.0) on top of the parent olean.
- 123 lines, 5 theorem/lemma decls, 0 defs.

## Gallery

- `src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/meta.json` + `annotations.json`
- Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)