### PR TITLE
research(dini-theorem-oq-01-oq-02-oq-01-oq-01): exact optimality of the modulus ⌈log ε / log(1−δ)⌉ [verified/0-axiom/original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1029,6 +1029,7 @@ import Proofs.DiniTheorem
 import Proofs.DiniTheoremOQ01OQ01
 import Proofs.DiniTheoremOQ01OQ02
 import Proofs.DiniTheoremOQ01OQ02OQ01
+import Proofs.DiniTheoremOQ01OQ02OQ01OQ01
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
 import Proofs.DirichletApproximationOQ01OQ01

--- a/proofs/Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# Dini's Theorem — OQ-01-OQ-02-OQ-01-OQ-01: Exact Optimality of the Modulus `⌈log ε / log(1−δ)⌉`
+
+## Research Problem: dini-theorem-oq-01-oq-02-oq-01-oq-01
+
+The parent `DiniTheoremOQ01OQ02OQ01.lean` recovered uniform convergence of `xⁿ → 0` on the
+compact subinterval `[0,1−δ]` with the explicit modulus
+
+> `N(ε,δ) = ⌈log ε / log(1−δ)⌉₊`,
+
+proving the *sufficiency* half: `N(ε,δ) ≤ n  ⟹  (1−δ)ⁿ ≤ ε` (`pow_lt_of_ceil_modulus`).
+
+This file answers the parent's open question OQ-01:
+
+> Is `N = ⌈log ε / log(1−δ)⌉` the **smallest** `N` with `(1−δ)^N ≤ ε`, or only the smallest
+> under the log-threshold derivation?  Pin down the off-by-one from `Nat.le_ceil` exactly:
+> show `(1−δ)^{N−1} > ε` (minimality) alongside the parent's `(1−δ)^N ≤ ε`.
+
+**Answer — yes, it is exactly minimal, and the ceiling is forced.**  The key is to upgrade the
+parent's one-way estimate to a clean *biconditional*.  Writing `r = 1−δ` (so `0 < r < 1`,
+`log r < 0`):
+
+* dividing the equivalent `m · log r ≤ log ε` by the negative `log r` reverses the inequality,
+  giving the sharp real characterisation
+  `(1−δ)^m ≤ ε  ⟺  log ε / log(1−δ) ≤ m`;
+* `Nat.ceil_le` then converts this into the **discrete** characterisation
+  `(1−δ)^m ≤ ε  ⟺  ⌈log ε / log(1−δ)⌉₊ ≤ m`.
+
+From the biconditional everything about minimality is immediate:
+
+* `N(ε,δ) = ⌈log ε / log(1−δ)⌉₊` is the **least** exponent with `(1−δ)^m ≤ ε`
+  (`isLeast_modulus`);
+* every strictly smaller exponent **fails**: `m < N ⟹ ε < (1−δ)^m` (`lt_pow_of_lt_modulus`);
+* in particular the headline off-by-one `ε < (1−δ)^{N−1}` for `ε < 1` (`lt_pow_pred_modulus`),
+  pinning the modulus exactly: the parent's `(1−δ)^N ≤ ε` cannot be improved to `N−1`.
+
+## What is proved
+
+* `pow_le_iff_log_le` — the sharp real biconditional `(1−δ)^m ≤ ε ⟺ log ε / log(1−δ) ≤ m`.
+* `pow_le_iff_ceil_le` — the discrete biconditional `(1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m`.
+* `isLeast_modulus` — `⌈log ε / log(1−δ)⌉₊` is the least `m` with `(1−δ)^m ≤ ε`.
+* `lt_pow_of_lt_modulus` — every smaller exponent is insufficient: `m < N ⟹ ε < (1−δ)^m`.
+* `lt_pow_pred_modulus` — the exact off-by-one `ε < (1−δ)^{N−1}` (for `ε < 1`, where `N ≥ 1`).
+
+Tags: analysis, dini, uniform-convergence, modulus, optimality, ceiling, logarithm, wiedijk
+-/
+
+namespace DiniTheoremOQ01OQ02OQ01OQ01
+
+open Set Filter Topology
+
+-- ============================================================
+-- Part I: The sharp biconditional characterising `(1−δ)^m ≤ ε`
+-- ============================================================
+
+/-- **The sharp real characterisation.**  For `δ ∈ (0,1)` and `ε > 0`,
+    `(1−δ)^m ≤ ε` holds **iff** `log ε / log(1−δ) ≤ m`.
+
+    This upgrades the parent's one-way `pow_lt_of_log_modulus` to a biconditional: taking
+    logarithms turns `(1−δ)^m ≤ ε` into `m · log(1−δ) ≤ log ε`, and since `log(1−δ) < 0`
+    dividing by it reverses the inequality, yielding the threshold `m ≥ log ε / log(1−δ)`. -/
+theorem pow_le_iff_log_le {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) (m : ℕ) :
+    (1 - δ) ^ m ≤ ε ↔ Real.log ε / Real.log (1 - δ) ≤ (m : ℝ) := by
+  set r : ℝ := 1 - δ with hr
+  have hr0 : 0 < r := by rw [hr]; linarith
+  have hr1 : r < 1 := by rw [hr]; linarith
+  have hlogr : Real.log r < 0 := Real.log_neg hr0 hr1
+  -- compare via the strictly monotone `log`, then divide by the negative `log r`.
+  rw [← Real.log_le_log_iff (pow_pos hr0 m) hε, Real.log_pow, div_le_iff_of_neg hlogr]
+
+/-- **The discrete characterisation.**  For `δ ∈ (0,1)` and `ε > 0`,
+    `(1−δ)^m ≤ ε` holds **iff** `⌈log ε / log(1−δ)⌉₊ ≤ m`.
+
+    `Nat.ceil_le` converts the real threshold of `pow_le_iff_log_le` into the discrete one. -/
+theorem pow_le_iff_ceil_le {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) (m : ℕ) :
+    (1 - δ) ^ m ≤ ε ↔ ⌈Real.log ε / Real.log (1 - δ)⌉₊ ≤ m := by
+  rw [pow_le_iff_log_le hδ0 hδ1 hε, Nat.ceil_le]
+
+-- ============================================================
+-- Part II: Exact minimality of the modulus
+-- ============================================================
+
+/-- **The modulus is exactly minimal.**  `N(ε,δ) = ⌈log ε / log(1−δ)⌉₊` is the *least* natural
+    number `m` for which `(1−δ)^m ≤ ε`: it satisfies the bound, and no smaller exponent does.
+    Immediate from the discrete biconditional `pow_le_iff_ceil_le`. -/
+theorem isLeast_modulus {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) :
+    IsLeast {m : ℕ | (1 - δ) ^ m ≤ ε} ⌈Real.log ε / Real.log (1 - δ)⌉₊ := by
+  constructor
+  · -- `(1−δ)^N ≤ ε`: apply the biconditional at `m = N` (reflexivity).
+    rw [Set.mem_setOf_eq, pow_le_iff_ceil_le hδ0 hδ1 hε]
+  · -- every member of the set dominates `N`.
+    intro m hm
+    rw [Set.mem_setOf_eq, pow_le_iff_ceil_le hδ0 hδ1 hε] at hm
+    exact hm
+
+/-- **Every smaller exponent is insufficient.**  For `m < N(ε,δ)` we have `ε < (1−δ)^m`: the
+    uniform error has not yet dropped to `ε`.  This is the contrapositive of minimality. -/
+theorem lt_pow_of_lt_modulus {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) {m : ℕ}
+    (hm : m < ⌈Real.log ε / Real.log (1 - δ)⌉₊) :
+    ε < (1 - δ) ^ m := by
+  by_contra h
+  push_neg at h
+  rw [pow_le_iff_ceil_le hδ0 hδ1 hε] at h
+  omega
+
+/-- **The exact off-by-one.**  When `ε < 1` the modulus satisfies `N(ε,δ) ≥ 1`, and the
+    predecessor *fails* the bound: `ε < (1−δ)^{N−1}`.  Together with the parent's
+    `(1−δ)^N ≤ ε` this pins the modulus exactly — it cannot be lowered to `N−1`. -/
+theorem lt_pow_pred_modulus {δ ε : ℝ} (hδ0 : 0 < δ) (hδ1 : δ < 1) (hε : 0 < ε) (hε1 : ε < 1) :
+    ε < (1 - δ) ^ (⌈Real.log ε / Real.log (1 - δ)⌉₊ - 1) := by
+  have hr0 : (0 : ℝ) < 1 - δ := by linarith
+  have hr1 : 1 - δ < 1 := by linarith
+  have hlogr : Real.log (1 - δ) < 0 := Real.log_neg hr0 hr1
+  -- `0 < log ε / log(1−δ)` (a negative over a negative), so `N = ⌈·⌉₊ ≥ 1`.
+  have hcpos : 0 < Real.log ε / Real.log (1 - δ) := by
+    rw [div_pos_iff]
+    exact Or.inr ⟨Real.log_neg hε hε1, hlogr⟩
+  have hN1 : 1 ≤ ⌈Real.log ε / Real.log (1 - δ)⌉₊ := Nat.one_le_ceil_iff.mpr hcpos
+  -- the predecessor is strictly below `N`, hence insufficient.
+  exact lt_pow_of_lt_modulus hδ0 hδ1 hε (by omega)
+
+#check @pow_le_iff_log_le
+#check @pow_le_iff_ceil_le
+#check @isLeast_modulus
+#check @lt_pow_of_lt_modulus
+#check @lt_pow_pred_modulus
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms — self-contained, imports only Mathlib):
+
+* `pow_le_iff_log_le` — the sharp real biconditional `(1−δ)^m ≤ ε ⟺ log ε / log(1−δ) ≤ m`
+  (upgrades the parent's one-way `pow_lt_of_log_modulus`).
+* `pow_le_iff_ceil_le` — the discrete biconditional `(1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m`.
+* `isLeast_modulus` — `⌈log ε / log(1−δ)⌉₊` is the **least** exponent with `(1−δ)^m ≤ ε`.
+* `lt_pow_of_lt_modulus` — every smaller exponent fails: `m < N ⟹ ε < (1−δ)^m`.
+* `lt_pow_pred_modulus` — the exact off-by-one `ε < (1−δ)^{N−1}` for `ε < 1` (where `N ≥ 1`).
+
+This answers `dini-theorem-oq-01-oq-02-oq-01` OQ-01: the modulus `N = ⌈log ε / log(1−δ)⌉` is
+**exactly minimal** — the parent's `(1−δ)^N ≤ ε` holds, while `(1−δ)^{N−1} > ε`, so the
+ceiling is forced and the off-by-one is sharp.  The whole optimality statement flows from one
+biconditional obtained by dividing the log-linearised inequality by the negative `log(1−δ)`.
+-/
+
+end DiniTheoremOQ01OQ02OQ01OQ01

--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "dini-oq01020101-ann-overview",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "type": "concept",
+    "title": "Is the Dini Modulus Optimal?",
+    "content": "The header frames OQ-01 of the parent (dini-theorem-oq-01-oq-02-oq-01). The parent recovered uniform convergence of xⁿ on the compact subinterval [0,1−δ] and gave the explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉, proving the sufficiency half (1−δ)^N ≤ ε. The open question: is this N the SMALLEST exponent that works, or merely the smallest the log-threshold derivation happens to produce? This file answers it — N is exactly minimal — by upgrading the parent's one-way estimate to a sharp biconditional.",
+    "mathContext": "$N(\\varepsilon,\\delta)=\\lceil \\log\\varepsilon/\\log(1-\\delta)\\rceil$ is the least $m$ with $(1-\\delta)^m\\le\\varepsilon$, and $(1-\\delta)^{N-1}>\\varepsilon$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dini's theorem",
+      "modulus of convergence",
+      "optimality",
+      "ceiling function"
+    ],
+    "prerequisites": [
+      "geometric decay",
+      "logarithms",
+      "ceiling / floor"
+    ]
+  },
+  {
+    "id": "dini-oq01020101-ann-biconditional",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 86
+    },
+    "type": "technique",
+    "title": "From One-Way Estimate to Sharp Biconditional",
+    "content": "The core upgrade. The parent's pow_lt_of_log_modulus took logs of (1−δ)^m ≤ ε to reach m·log(1−δ) ≤ log ε, then divided by the negative log(1−δ) — an implication. Here every step is run as an equivalence: Real.log_le_log_iff makes (1−δ)^m ≤ ε ⟺ log((1−δ)^m) ≤ log ε, Real.log_pow rewrites the left log as m·log(1−δ), and div_le_iff_of_neg (valid since log(1−δ) < 0 by Real.log_neg) turns m·log(1−δ) ≤ log ε into log ε / log(1−δ) ≤ m. That is pow_le_iff_log_le. Then Nat.ceil_le (⌈a⌉₊ ≤ n ↔ a ≤ ↑n) converts the real threshold into the discrete biconditional pow_le_iff_ceil_le.",
+    "mathContext": "$(1-\\delta)^m\\le\\varepsilon \\iff \\log\\varepsilon/\\log(1-\\delta)\\le m \\iff \\lceil\\log\\varepsilon/\\log(1-\\delta)\\rceil_+\\le m$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "monotonicity of log",
+      "dividing by a negative",
+      "Nat.ceil_le"
+    ],
+    "prerequisites": [
+      "Real.log_le_log_iff",
+      "div_le_iff_of_neg"
+    ]
+  },
+  {
+    "id": "dini-oq01020101-ann-minimality",
+    "proofId": "dini-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 148
+    },
+    "type": "key-step",
+    "title": "Exact Minimality and the Off-by-One",
+    "content": "With membership in {m : (1−δ)^m ≤ ε} literally synonymous with ⌈c⌉₊ ≤ m, the solution set is the up-set [⌈c⌉₊, ∞), so isLeast_modulus reads off directly: the membership half is the biconditional at m = N (reflexivity), the lower-bound half is its forward direction. lt_pow_of_lt_modulus is the contrapositive — m < N forces ε < (1−δ)^m. Finally lt_pow_pred_modulus handles the headline off-by-one: for ε < 1, c = log ε / log(1−δ) is a negative-over-negative, hence positive (div_pos_iff), so N ≥ 1 (Nat.one_le_ceil_iff) and N−1 < N gives ε < (1−δ)^{N−1}. Paired with the parent's (1−δ)^N ≤ ε, the threshold is bracketed exactly.",
+    "mathContext": "$\\varepsilon<(1-\\delta)^{N-1}$ and $(1-\\delta)^{N}\\le\\varepsilon$: $N$ is the unique crossing exponent.",
+    "significance": "central",
+    "relatedConcepts": [
+      "IsLeast",
+      "up-set",
+      "contrapositive",
+      "div_pos_iff"
+    ],
+    "prerequisites": [
+      "Nat.one_le_ceil_iff",
+      "omega"
+    ]
+  }
+]

--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "dini-theorem-oq-01-oq-02-oq-01-oq-01",
+  "title": "Exact Optimality of the Dini Modulus ⌈log ε / log(1−δ)⌉",
+  "slug": "dini-theorem-oq-01-oq-02-oq-01-oq-01",
+  "description": "Answers the parent's open question: the explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉ recovering uniform convergence of xⁿ on the compact subinterval [0,1−δ] is EXACTLY minimal. The parent proved sufficiency, (1−δ)^N ≤ ε; this entry upgrades the one-way log-threshold estimate to a sharp biconditional (1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m, from which N is the LEAST exponent with (1−δ)^m ≤ ε, every smaller exponent fails, and in particular (1−δ)^{N−1} > ε for ε < 1 — the off-by-one from Nat.le_ceil pinned down exactly. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "dini",
+      "uniform-convergence",
+      "modulus",
+      "optimality",
+      "ceiling",
+      "logarithm",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for pow_le_iff_log_le, pow_le_iff_ceil_le, isLeast_modulus, lt_pow_of_lt_modulus, and lt_pow_pred_modulus. The file imports only Mathlib and is self-contained.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_le_log_iff",
+        "description": "0 < x, 0 < y ⟹ (log x ≤ log y ↔ x ≤ y) — runs the comparison (1−δ)^m ≤ ε as an equivalence through the monotone log",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_neg",
+        "description": "0 < x < 1 ⟹ log x < 0 — the sign of log(1−δ) is what reverses the inequality when dividing",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "div_le_iff_of_neg",
+        "description": "dividing by the negative quantity log(1−δ) reverses the inequality, turning m·log(1−δ) ≤ log ε into the threshold log ε / log(1−δ) ≤ m — the biconditional version",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Real.log_pow",
+        "description": "log(rⁿ) = n · log r — linearizes the geometric bound (1−δ)^m ≤ ε after applying log monotonicity",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.ceil_le",
+        "description": "⌈a⌉₊ ≤ n ↔ a ≤ ↑n — converts the sharp real threshold into the discrete biconditional, the key to exact minimality",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Nat.one_le_ceil_iff",
+        "description": "1 ≤ ⌈a⌉₊ ↔ 0 < a — gives N ≥ 1 from 0 < log ε / log(1−δ) when ε < 1, so the predecessor N−1 is well-defined",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "div_pos_iff",
+        "description": "0 < a/b ↔ (0<a ∧ 0<b) ∨ (a<0 ∧ b<0) — the negative-over-negative case gives 0 < log ε / log(1−δ) for ε < 1",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "pow_le_iff_log_le: the SHARP real biconditional (1−δ)^m ≤ ε ⟺ log ε / log(1−δ) ≤ m — upgrades the parent's one-way pow_lt_of_log_modulus to an equivalence by running the log comparison through Real.log_le_log_iff and dividing the log-linearized inequality by the negative log(1−δ)",
+      "pow_le_iff_ceil_le: the DISCRETE biconditional (1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m, via Nat.ceil_le — the master statement from which all optimality follows",
+      "isLeast_modulus: ⌈log ε / log(1−δ)⌉₊ is the LEAST exponent m with (1−δ)^m ≤ ε (IsLeast of the solution set)",
+      "lt_pow_of_lt_modulus: every smaller exponent is insufficient — m < N ⟹ ε < (1−δ)^m",
+      "lt_pow_pred_modulus: the exact off-by-one ε < (1−δ)^{N−1} for ε < 1 (where N ≥ 1) — pins the modulus exactly, showing the parent's (1−δ)^N ≤ ε cannot be lowered to N−1"
+    ],
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Dini's theorem says a monotone sequence of continuous functions converging pointwise to a continuous limit on a COMPACT set converges uniformly. The grandparent (dini-theorem-oq-01) probes the necessity of compactness with the witness fₙ(x) = xⁿ; the great-grandparent's child (dini-theorem-oq-01-oq-02) showed the uniform error on the non-compact [0,1) stays exactly 1; and the parent (dini-theorem-oq-01-oq-02-oq-01) restored compactness on [0,1−δ] and gave the explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉ for which (1−δ)ⁿ ≤ ε. This entry (OQ-01) answers whether that modulus is the best possible.",
+    "problemStatement": "Is N = ⌈log ε / log(1−δ)⌉ the smallest N with (1−δ)^N ≤ ε for every ε, δ, or only the smallest under the log-threshold derivation? Pin down the off-by-one from Nat.le_ceil exactly: show (1−δ)^{N−1} > ε (minimality) alongside the parent's (1−δ)^N ≤ ε.",
+    "text": "Proves the modulus is exactly minimal. The core upgrade is a biconditional: (1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m. From it, N = ⌈log ε / log(1−δ)⌉ is the least exponent with (1−δ)^m ≤ ε, every smaller exponent fails, and (1−δ)^{N−1} > ε for ε < 1.",
+    "proofStrategy": "Write r = 1−δ so that 0 < r < 1 and log r < 0 (Real.log_neg). The parent proved one direction by exp/log monotonicity and dividing m·log r ≤ log ε by the negative log r. Running every step as an equivalence — Real.log_le_log_iff (log monotone) turning (1−δ)^m ≤ ε into log((1−δ)^m) ≤ log ε, Real.log_pow rewriting the left side as m·log r, then div_le_iff_of_neg — yields the SHARP real biconditional pow_le_iff_log_le: (1−δ)^m ≤ ε ⟺ log ε / log r ≤ m. Nat.ceil_le (⌈a⌉₊ ≤ n ↔ a ≤ ↑n) then turns the real threshold into the discrete biconditional pow_le_iff_ceil_le. Exact minimality is now immediate: the membership half of isLeast_modulus is the biconditional at m = N (reflexivity ⌈c⌉₊ ≤ ⌈c⌉₊), and the lower-bound half reads off ⌈c⌉₊ ≤ m from (1−δ)^m ≤ ε. lt_pow_of_lt_modulus is the contrapositive (m < N forces ε < (1−δ)^m by omega). For lt_pow_pred_modulus, ε < 1 makes log ε / log r a negative-over-negative, hence positive (div_pos_iff), so N ≥ 1 (Nat.one_le_ceil_iff) and N−1 < N, giving ε < (1−δ)^{N−1}.",
+    "keyInsights": [
+      "The whole optimality statement is one biconditional. The parent's analysis was an implication; rerunning the same log-monotone/divide-by-negative chain as a chain of iffs (every lemma used is already an equivalence) gives (1−δ)^m ≤ ε ⟺ log ε / log(1−δ) ≤ m for free.",
+      "Nat.ceil_le is exactly the bridge between the continuous and discrete thresholds: ⌈a⌉₊ ≤ n ↔ a ≤ n. It converts the sharp real characterization into the sharp discrete one with no loss, which is why the ceiling — not the ceiling-plus-one — is the true minimum.",
+      "Minimality is a structural consequence, not a separate computation: once membership in {m : (1−δ)^m ≤ ε} is literally synonymous with ⌈c⌉₊ ≤ m, the set is the up-set [⌈c⌉₊, ∞), whose least element is ⌈c⌉₊ by definition.",
+      "The off-by-one ε < (1−δ)^{N−1} is the contrapositive of minimality at m = N−1, valid precisely when N ≥ 1, i.e. when c = log ε / log(1−δ) > 0, i.e. when ε < 1 — exactly the regime where a nontrivial modulus is needed.",
+      "Pairing this entry's (1−δ)^{N−1} > ε with the parent's (1−δ)^N ≤ ε brackets the threshold tightly: N is the unique integer at which the geometric error crosses below ε, so the modulus is forced, not merely sufficient."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-setup",
+      "title": "Problem Statement and Setup",
+      "summary": "Module docstring framing OQ-01 (exact optimality of the parent's modulus), the reduction r = 1−δ, and the namespace/imports (Mathlib; open Set Filter Topology)",
+      "startLine": 1,
+      "endLine": 50
+    },
+    {
+      "id": "biconditional",
+      "title": "The Sharp Biconditional Characterising (1−δ)^m ≤ ε",
+      "summary": "pow_le_iff_log_le (the real biconditional (1−δ)^m ≤ ε ⟺ log ε / log(1−δ) ≤ m via Real.log_le_log_iff and div_le_iff_of_neg) and pow_le_iff_ceil_le (the discrete version via Nat.ceil_le)",
+      "startLine": 51,
+      "endLine": 86
+    },
+    {
+      "id": "minimality",
+      "title": "Exact Minimality of the Modulus",
+      "summary": "isLeast_modulus (⌈log ε / log(1−δ)⌉₊ is the least exponent with (1−δ)^m ≤ ε), lt_pow_of_lt_modulus (every smaller exponent fails), and lt_pow_pred_modulus (the exact off-by-one ε < (1−δ)^{N−1} for ε < 1)",
+      "startLine": 87,
+      "endLine": 148
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; self-contained, imports only Mathlib): the explicit modulus N(ε,δ) = ⌈log ε / log(1−δ)⌉ recovering uniform convergence of xⁿ on the compact [0,1−δ] is EXACTLY minimal. The master biconditional (1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m makes N the least exponent with (1−δ)^m ≤ ε, with every smaller exponent failing and (1−δ)^{N−1} > ε for ε < 1.",
+    "implications": "The parent's modulus is not merely sufficient but optimal: N is the unique integer at which the geometric uniform error crosses below ε. The off-by-one from Nat.le_ceil is pinned exactly by the matching pair (1−δ)^N ≤ ε (parent) and (1−δ)^{N−1} > ε (here). The pattern — rerun a one-way log-threshold estimate as a biconditional, then bridge to ⌈·⌉₊ via Nat.ceil_le to extract IsLeast — is a reusable recipe for proving discrete moduli of geometric decay are sharp.",
+    "openQuestions": [
+      "Closed form for the threshold-crossing exponent in special cases (e.g. δ = 1 − 2^{-1} or ε = (1−δ)^k) where ⌈log ε / log(1−δ)⌉ collapses to an explicit integer, and the behaviour exactly at integer values of log ε / log(1−δ).",
+      "Sharp two-sided bracket as δ → 0: combine N = ⌈log ε / log(1−δ)⌉ with the asymptotic log(1−δ) ~ −δ to give N ~ ⌈−log ε / δ⌉ and quantify the error of this approximation, interpolating to the parent's non-uniformity.",
+      "Generalize the minimality argument to arbitrary strictly-decreasing geometric-type errors a^n (0 < a < 1): is the least n with a^n ≤ ε always ⌈log ε / log a⌉₊, and does the same biconditional-via-Nat.ceil_le proof transfer verbatim?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dini-theorem-oq-01-oq-02-oq-01",
+      "relationship": "parent-problem",
+      "description": "Parent: recovered uniform convergence of xⁿ on the compact [0,1−δ] with the explicit modulus ⌈log ε / log(1−δ)⌉ (sufficiency, (1−δ)^N ≤ ε); this entry answers its OQ[0] by proving that modulus is exactly minimal"
+    },
+    {
+      "targetId": "dini-theorem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Grandparent: the sharp NON-uniform convergence of xⁿ on the non-compact [0,1) (unattained supremum 1)"
+    },
+    {
+      "targetId": "dini-theorem",
+      "relationship": "related",
+      "description": "The base Dini's theorem (uniform convergence of monotone sequences on compact sets) whose quantitative modulus this chain sharpens"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Walter Rudin"
+      ],
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "note": "Theorem 7.13 (Dini) and the xⁿ counterexample; uniform convergence on compact subintervals"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DiniTheoremOQ01OQ02OQ01OQ01",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of the parent `dini-theorem-oq-01-oq-02-oq-01`: is the explicit modulus `N(ε,δ) = ⌈log ε / log(1−δ)⌉` recovering uniform convergence of `xⁿ` on the compact subinterval `[0,1−δ]` the **smallest** exponent that works, or only the smallest the log-threshold derivation produces?

**It is exactly minimal.** The parent proved sufficiency `(1−δ)^N ≤ ε`; this entry upgrades the one-way estimate to a sharp **biconditional**

`(1−δ)^m ≤ ε  ⟺  ⌈log ε / log(1−δ)⌉₊ ≤ m`,

obtained by rerunning the parent's log-monotone/divide-by-negative chain as a chain of *iffs* (`Real.log_le_log_iff`, `Real.log_pow`, `div_le_iff_of_neg` with `log(1−δ) < 0`) and bridging to the ceiling via `Nat.ceil_le`. From it the whole optimality statement is immediate.

## Theorems (5, 148 lines, 0 sorries, 0 axioms)

- `pow_le_iff_log_le` — the sharp real biconditional `(1−δ)^m ≤ ε ⟺ log ε / log(1−δ) ≤ m`.
- `pow_le_iff_ceil_le` — the discrete biconditional `(1−δ)^m ≤ ε ⟺ ⌈log ε / log(1−δ)⌉₊ ≤ m`.
- `isLeast_modulus` — `⌈log ε / log(1−δ)⌉₊` is the **least** exponent with `(1−δ)^m ≤ ε`.
- `lt_pow_of_lt_modulus` — every smaller exponent fails: `m < N ⟹ ε < (1−δ)^m`.
- `lt_pow_pred_modulus` — the exact off-by-one `ε < (1−δ)^{N−1}` for `ε < 1` (where `N ≥ 1`).

Paired with the parent's `(1−δ)^N ≤ ε`, the threshold is bracketed tightly: `N` is the unique integer at which the geometric error crosses below `ε`.

## Verification

- `lake env lean Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean` exits 0 (Mathlib v4.26.0); docker build also green.
- `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` for all 5 theorems — no `sorryAx`, no `Lean.ofReduceBool`.
- Self-contained, imports only Mathlib.

## Files

- `proofs/Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean` (new) + aggregator import in `proofs/Proofs.lean`
- `src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)