### PR TITLE
fix(deploy): tolerate int-valued insights/builtItems in listings sync

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -561,8 +561,22 @@ for problem_file in problems_dir.glob("*.json"):
         continue
 
     knowledge = problem.get("knowledge", {})
-    insights = len(knowledge.get("insights", []))
-    built = len(knowledge.get("builtItems", []))
+    if not isinstance(knowledge, dict):
+        knowledge = {}
+
+    # Some problem files store insights/builtItems as a literal count (int)
+    # rather than a list of entries. Tolerate both shapes.
+    def _count(v):
+        if isinstance(v, (list, str, dict)):
+            return len(v)
+        if isinstance(v, bool):
+            return 0
+        if isinstance(v, (int, float)):
+            return int(v)
+        return 0
+
+    insights = _count(knowledge.get("insights", []))
+    built = _count(knowledge.get("builtItems", []))
 
     if insights == 0 and built == 0:
         continue


### PR DESCRIPTION
The research-listings sync step in `sync-and-deploy.sh` crashed with
`TypeError: object of type 'int' has no len()` because a problem file
(`greens-theorem-oq-01-oq-03-oq-02.json`) stores `knowledge.insights`
and `knowledge.builtItems` as literal integer counts instead of lists.

Adds a `_count()` helper that tolerates both shapes (len for
list/str/dict, value for int/float) and guards against a non-dict
`knowledge` block. Verified against all 2321 problem files — processes
cleanly. Unblocks the deploy pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)