### PR TITLE
research(birthday-oq-03-01-01-03-03): general k-fold coincidence threshold n=(k!·d^{k-1}·ln2)^{1/k}+O(1) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean
@@ -1,0 +1,203 @@
+import Mathlib
+
+/-
+# Birthday Problem — OQ-03-OQ-01-OQ-01-OQ-03-OQ-03: The General k-Fold Coincidence Threshold
+
+## Research Problem: birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03
+
+The parent file (`birthday-problem-oq-03-oq-01-oq-01-oq-03`) proved the `k = 3` triple
+coincidence threshold by a *cube-root sandwich* `(n-2)³ ≤ n(n-1)(n-2) ≤ n³`.  Its open
+question OQ-03 asks:
+
+> Generalize the `k = 3` coincidence threshold to general `k`: show the `k`-fold
+> birthday-coincidence threshold is `n = (k! · d^{k-1} · ln 2)^{1/k} + O(1)` via the analogous
+> falling-factorial sandwich `(n-k+1)^k ≤ n^{\underline{k}} ≤ n^k` combined with `rpow`
+> monotonicity.
+
+The heuristic is the standard Poisson/expected-count balance: the expected number of
+unordered `k`-tuples sharing a day is
+
+      C(n,k) / d^{k-1} = n^{\underline{k}} / (k! · d^{k-1}),
+
+where `n^{\underline{k}} = n(n-1)⋯(n-k+1)` is the falling factorial.  The 50%-chance threshold
+is where this expected count equals `ln 2`:
+
+      n^{\underline{k}} / (k! · d^{k-1}) = ln 2,   i.e.   n^{\underline{k}} = k! · d^{k-1} · ln 2.
+
+This file proves, **rigorously and with an explicit O(1) error bound**, that the `n` solving
+this balance equation is exactly the claimed threshold to leading order:
+
+      (k! · d^{k-1} · ln 2)^{1/k}  ≤  n  ≤  (k! · d^{k-1} · ln 2)^{1/k} + (k - 1).
+
+So `n = (k! · d^{k-1} · ln 2)^{1/k} + O(1)`, the lower-order term bounded by the constant
+`k - 1`, **independent of `d`**.  Specializing `k = 3` recovers the parent's
+`(6 d² ln 2)^{1/3} + O(1)` with the same additive slack `2 = k - 1`.
+
+The proof is the `k`-fold generalization of the parent's cube-root sandwich:
+
+* `n^{\underline{k}} ≤ n^k` (each falling factor `n - i ≤ n`) gives the lower bound
+  `(k! · d^{k-1} · ln 2)^{1/k} ≤ n`;
+* `(n-k+1)^k ≤ n^{\underline{k}}` (each falling factor `n - i ≥ n - (k-1)`) gives the upper
+  bound `n ≤ (k! · d^{k-1} · ln 2)^{1/k} + (k-1)`.
+
+## What is proved
+
+* `fallingR` — the real falling factorial `n^{\underline{k}} = ∏_{i<k} (n - i)`.
+* `kthRoot_pow` — the `k`-th-root identity `(x^k)^{1/k} = x` for `x ≥ 0`, `k ≥ 1`.
+* `falling_sandwich` — the two-sided bound `(n-(k-1))^k ≤ n^{\underline{k}} ≤ n^k`.
+* `birthday_kfold_threshold` — the two-sided threshold bound above.
+* `birthday_kfold_threshold_gap` — packaged as `|n − (k! d^{k-1} ln 2)^{1/k}| ≤ k - 1`.
+
+Tags: probability, birthday-problem, asymptotics, threshold, falling-factorial, real-analysis
+-/
+
+namespace BirthdayProblemOQ03OQ01OQ01OQ03OQ03
+
+open Real Finset
+
+/-- **Real falling factorial.**  `n^{\underline{k}} = ∏_{i<k} (n - i) = n(n-1)⋯(n-k+1)`. -/
+noncomputable def fallingR (n : ℝ) (k : ℕ) : ℝ := ∏ i ∈ Finset.range k, (n - (i : ℝ))
+
+@[simp] lemma fallingR_zero (n : ℝ) : fallingR n 0 = 1 := by simp [fallingR]
+
+/-- `n^{\underline{3}} = n(n-1)(n-2)`, matching the parent file's cube product. -/
+lemma fallingR_three (n : ℝ) : fallingR n 3 = n * (n - 1) * (n - 2) := by
+  simp [fallingR, Finset.prod_range_succ]
+
+/-- **k-th-root identity.**  `(x^k)^{1/k} = x` for `x ≥ 0` and `k ≥ 1`. -/
+theorem kthRoot_pow {x : ℝ} (hx : 0 ≤ x) {k : ℕ} (hk : 1 ≤ k) :
+    (x ^ k) ^ ((1 : ℝ) / k) = x := by
+  rw [one_div]
+  exact Real.pow_rpow_inv_natCast hx (by omega)
+
+/-- **The falling-factorial sandwich.**  For `n ≥ k - 1` (so every falling factor
+    `n - i` with `i < k` is nonnegative),
+
+        (n - (k-1))^k  ≤  n^{\underline{k}}  ≤  n^k.
+
+    The lower bound replaces each factor `n - i` by its smallest value `n - (k-1)`; the upper
+    bound replaces each factor by its largest value `n`. -/
+theorem falling_sandwich (n : ℝ) (k : ℕ) (hn : (k : ℝ) - 1 ≤ n) :
+    (n - ((k : ℝ) - 1)) ^ k ≤ fallingR n k ∧ fallingR n k ≤ n ^ k := by
+  -- For `i ∈ range k` we have `(i : ℝ) ≤ k - 1`, hence `0 ≤ n - (k-1) ≤ n - i ≤ n`.
+  have hi_le : ∀ i ∈ Finset.range k, (i : ℝ) ≤ (k : ℝ) - 1 := by
+    intro i hi
+    have : i + 1 ≤ k := Finset.mem_range.mp hi
+    have : (i : ℝ) + 1 ≤ (k : ℝ) := by exact_mod_cast this
+    linarith
+  have hfac_nonneg : ∀ i ∈ Finset.range k, 0 ≤ n - (i : ℝ) := by
+    intro i hi; have := hi_le i hi; linarith
+  constructor
+  · -- lower bound: (n-(k-1))^k = ∏ (n-(k-1)) ≤ ∏ (n-i)
+    have hbase : (n - ((k : ℝ) - 1)) ^ k
+        = ∏ _i ∈ Finset.range k, (n - ((k : ℝ) - 1)) := by
+      rw [Finset.prod_const, Finset.card_range]
+    rw [hbase]
+    refine Finset.prod_le_prod (fun i _ => by linarith [hn]) ?_
+    intro i hi; have := hi_le i hi; linarith
+  · -- upper bound: ∏ (n-i) ≤ ∏ n = n^k
+    have htop : n ^ k = ∏ _i ∈ Finset.range k, n := by
+      rw [Finset.prod_const, Finset.card_range]
+    rw [htop]
+    refine Finset.prod_le_prod hfac_nonneg ?_
+    intro i _; have : (0 : ℝ) ≤ (i : ℝ) := Nat.cast_nonneg i; linarith
+
+/-- **The general `k`-fold coincidence threshold, to leading order with explicit O(1) error.**
+
+    Fix `k ≥ 1`, `d > 0`, and suppose `n ≥ k - 1` solves the expected-`k`-tuple balance
+    equation
+
+        n^{\underline{k}} = k! · d^{k-1} · ln 2
+
+    (the expected number of coincident `k`-tuples equals `ln 2`, the 50%-chance criterion).
+    Then, writing `L := k! · d^{k-1} · ln 2`,
+
+        L^{1/k}  ≤  n  ≤  L^{1/k} + (k - 1).
+
+    Hence `n = (k! · d^{k-1} · ln 2)^{1/k} + O(1)`: the threshold is `(k! d^{k-1} ln 2)^{1/k}`
+    up to a bounded additive constant `k - 1`, independent of `d`.  This is the rigorous form
+    of the asymptotic `n ≈ (k! d^{k-1} ln 2)^{1/k}`, and specializes at `k = 3` to the parent's
+    `(6 d² ln 2)^{1/3} + O(1)`. -/
+theorem birthday_kfold_threshold (k : ℕ) (d n : ℝ) (hk : 1 ≤ k) (hd : 0 < d)
+    (hn : (k : ℝ) - 1 ≤ n)
+    (hbal : fallingR n k = (k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) :
+    ((k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) ^ ((1 : ℝ) / k) ≤ n ∧
+    n ≤ ((k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) ^ ((1 : ℝ) / k) + ((k : ℝ) - 1) := by
+  set L := (k.factorial : ℝ) * d ^ (k - 1) * Real.log 2 with hLdef
+  have hlog : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hL : 0 ≤ L := by rw [hLdef]; positivity
+  have hk1 : (0 : ℝ) ≤ (k : ℝ) - 1 := by
+    have : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+    linarith
+  have hn0 : 0 ≤ n := le_trans hk1 hn
+  have hnm : 0 ≤ n - ((k : ℝ) - 1) := by linarith
+  have hexp : (0 : ℝ) ≤ (1 : ℝ) / k := by positivity
+  obtain ⟨hlo, hhi⟩ := falling_sandwich n k hn
+  rw [hbal] at hlo hhi
+  refine ⟨?_, ?_⟩
+  · -- Lower bound: L ≤ n^k, so L^{1/k} ≤ (n^k)^{1/k} = n.
+    calc L ^ ((1 : ℝ) / k)
+        ≤ (n ^ k) ^ ((1 : ℝ) / k) := Real.rpow_le_rpow hL hhi hexp
+      _ = n := kthRoot_pow hn0 hk
+  · -- Upper bound: (n-(k-1))^k ≤ L, so n-(k-1) = (((n-(k-1))^k)^{1/k} ≤ L^{1/k}.
+    have hstep : n - ((k : ℝ) - 1) ≤ L ^ ((1 : ℝ) / k) := by
+      calc n - ((k : ℝ) - 1)
+          = ((n - ((k : ℝ) - 1)) ^ k) ^ ((1 : ℝ) / k) := (kthRoot_pow hnm hk).symm
+        _ ≤ L ^ ((1 : ℝ) / k) := Real.rpow_le_rpow (pow_nonneg hnm k) hlo hexp
+    linarith
+
+/-- **Packaged threshold gap.**  The balance-equation solution `n` is within `k - 1` of the
+    leading-order threshold `(k! d^{k-1} ln 2)^{1/k}` — a bounded, `d`-independent error. -/
+theorem birthday_kfold_threshold_gap (k : ℕ) (d n : ℝ) (hk : 1 ≤ k) (hd : 0 < d)
+    (hn : (k : ℝ) - 1 ≤ n)
+    (hbal : fallingR n k = (k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) :
+    |n - ((k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) ^ ((1 : ℝ) / k)| ≤ (k : ℝ) - 1 := by
+  obtain ⟨hlo, hhi⟩ := birthday_kfold_threshold k d n hk hd hn hbal
+  rw [abs_le]
+  constructor <;> linarith
+
+/-- **Consistency with the parent.**  At `k = 3` the general threshold reduces exactly to the
+    parent's cube-root statement `(6 d² ln 2)^{1/3} ≤ n ≤ (6 d² ln 2)^{1/3} + 2`. -/
+theorem birthday_kfold_threshold_k3 (d n : ℝ) (hd : 0 < d) (hn : 2 ≤ n)
+    (hbal : n * (n - 1) * (n - 2) = 6 * d ^ 2 * Real.log 2) :
+    (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3) ≤ n ∧
+    n ≤ (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3) + 2 := by
+  have hbal' : fallingR n 3 = ((Nat.factorial 3 : ℝ)) * d ^ (3 - 1) * Real.log 2 := by
+    rw [fallingR_three]; norm_num [Nat.factorial]; linarith [hbal]
+  obtain ⟨hlo, hhi⟩ :=
+    birthday_kfold_threshold 3 d n (by norm_num) hd (by norm_num; linarith) hbal'
+  norm_num [Nat.factorial] at hlo hhi
+  exact ⟨hlo, hhi⟩
+
+#check @fallingR
+#check @kthRoot_pow
+#check @falling_sandwich
+#check @birthday_kfold_threshold
+#check @birthday_kfold_threshold_gap
+#check @birthday_kfold_threshold_k3
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms — self-contained, imports only Mathlib):
+
+* `fallingR` — real falling factorial `n^{\underline{k}} = ∏_{i<k}(n-i)`.
+* `kthRoot_pow` — `(x^k)^{1/k} = x` for `x ≥ 0`, `k ≥ 1`.
+* `falling_sandwich` — `(n-(k-1))^k ≤ n^{\underline{k}} ≤ n^k` for `n ≥ k-1`.
+* `birthday_kfold_threshold` — for `k ≥ 1`, `d > 0`, `n ≥ k-1` solving
+  `n^{\underline{k}} = k! d^{k-1} ln 2`,
+  `(k! d^{k-1} ln 2)^{1/k} ≤ n ≤ (k! d^{k-1} ln 2)^{1/k} + (k-1)`.
+* `birthday_kfold_threshold_gap` — equivalently `|n − (k! d^{k-1} ln 2)^{1/k}| ≤ k-1`.
+* `birthday_kfold_threshold_k3` — the `k = 3` specialization recovers the parent verbatim.
+
+This answers the parent's OQ-03: the general `k`-fold coincidence threshold is
+`(k! d^{k-1} ln 2)^{1/k}` to leading order, with a bounded additive error of at most `k - 1`
+(independent of `d`), proved by the falling-factorial sandwich
+`(n-k+1)^k ≤ n^{\underline{k}} ≤ n^k` and `rpow` monotonicity — the exact `k`-fold lift of the
+parent's cube-root sandwich, with the `k = 3` slack `2 = k - 1` recovered as a special case.
+-/
+
+end BirthdayProblemOQ03OQ01OQ01OQ03OQ03
+
+#print axioms BirthdayProblemOQ03OQ01OQ01OQ03OQ03.birthday_kfold_threshold
+#print axioms BirthdayProblemOQ03OQ01OQ01OQ03OQ03.birthday_kfold_threshold_gap

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "bday-oq0301010303-ann-falling",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 71 },
+    "type": "concept",
+    "title": "The Falling Factorial and the k-th-Root Identity",
+    "content": "The header frames the parent's OQ-03: for k-fold birthday coincidences among d days, the threshold group size is n ≈ (k!·d^{k-1}·ln2)^{1/k}, from the expected-count balance C(n,k)/d^{k-1} = n^{underline k}/(k!·d^{k-1}) = ln2 at the 50%-chance point, i.e. n^{underline k} = k!·d^{k-1}·ln2. The falling factorial is carried as an explicit product fallingR n k = ∏_{i<k}(n-i); fallingR_three checks it equals the parent's cubic n(n-1)(n-2) at k=3. k-th roots are the real power t ↦ t^{1/k}; kthRoot_pow gives the identity (x^k)^{1/k} = x for x ≥ 0, k ≥ 1 via Real.pow_rpow_inv_natCast (rewriting 1/k = (k:ℕ)⁻¹).",
+    "mathContext": "Balance: $\\binom{n}{k}/d^{k-1} = \\ln 2 \\iff n^{\\underline{k}} = k!\\,d^{k-1}\\ln 2$, with $n^{\\underline{k}} = \\prod_{i<k}(n-i)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["birthday problem", "falling factorial", "expected count", "Poisson heuristic", "real powers"],
+    "prerequisites": ["binomial coefficients", "logarithm", "rpow", "finite products"]
+  },
+  {
+    "id": "bday-oq0301010303-ann-sandwich",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+    "range": { "startLine": 72, "endLine": 104 },
+    "type": "insight",
+    "title": "The Falling-Factorial Sandwich",
+    "content": "falling_sandwich proves (n-(k-1))^k ≤ n^{underline k} ≤ n^k whenever n ≥ k-1. The key observation: for each i ∈ range k we have 0 ≤ i ≤ k-1, hence 0 ≤ n-(k-1) ≤ n-i ≤ n. The upper bound replaces every factor n-i by its maximum n (so ∏ ≤ n^k via Finset.prod_const and card_range); the lower bound replaces every factor by its minimum n-(k-1) (so (n-(k-1))^k ≤ ∏). Both directions are a single Finset.prod_le_prod with the per-factor bound — the uniform-in-k replacement for the parent's two nlinarith cubic calculations.",
+    "mathContext": "$\\forall i<k:\\ n-(k-1)\\le n-i\\le n\\ \\Rightarrow\\ (n-(k-1))^k \\le \\prod_{i<k}(n-i) \\le n^k$.",
+    "significance": "critical",
+    "relatedConcepts": ["sandwich argument", "monotonicity of products", "falling factorial"],
+    "prerequisites": ["Finset.prod_le_prod", "Finset.prod_const", "nonnegativity"]
+  },
+  {
+    "id": "bday-oq0301010303-ann-threshold",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+    "range": { "startLine": 105, "endLine": 158 },
+    "type": "insight",
+    "title": "The Threshold Sandwich and Packaged Gap",
+    "content": "birthday_kfold_threshold turns the falling-factorial sandwich into the threshold bound. Writing L = k!·d^{k-1}·ln2 (positive since log 2 > 0), the balance gives n^{underline k} = L, so the sandwich reads (n-(k-1))^k ≤ L ≤ n^k. k-th-root monotonicity (Real.rpow_le_rpow at exponent 1/k ≥ 0) with (x^k)^{1/k}=x turns L ≤ n^k into L^{1/k} ≤ n, and (n-(k-1))^k ≤ L into n-(k-1) ≤ L^{1/k}; together L^{1/k} ≤ n ≤ L^{1/k} + (k-1). birthday_kfold_threshold_gap restates this as |n − (k!·d^{k-1}·ln2)^{1/k}| ≤ k-1: a bounded, d-independent O(1) error, the rigorous form of n ≈ (k!·d^{k-1}·ln2)^{1/k}.",
+    "mathContext": "$(n-(k-1))^k \\le L \\le n^k \\Rightarrow L^{1/k} \\le n \\le L^{1/k}+(k-1)$, i.e. $\\bigl|n - (k!\\,d^{k-1}\\ln 2)^{1/k}\\bigr| \\le k-1$.",
+    "significance": "critical",
+    "relatedConcepts": ["asymptotic equivalence", "error bound", "monotonicity of roots", "rpow"],
+    "prerequisites": ["k-th-root identity", "Real.rpow_le_rpow", "abs_le"]
+  },
+  {
+    "id": "bday-oq0301010303-ann-k3",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+    "range": { "startLine": 159, "endLine": 203 },
+    "type": "insight",
+    "title": "Consistency with the k = 3 Parent",
+    "content": "birthday_kfold_threshold_k3 instantiates the general theorem at k=3 and checks it reproduces the parent verbatim: from n(n-1)(n-2) = 6d²ln2 it recovers (6d²ln2)^{1/3} ≤ n ≤ (6d²ln2)^{1/3} + 2. The bridge is fallingR_three (n^{underline 3} = n(n-1)(n-2)) and factorial 3 = 6, d^{3-1} = d², k-1 = 2 — so the parent's additive slack 2 is exactly the general k-1 at k=3. This confirms the generalization is a faithful lift, not a divergent restatement.",
+    "mathContext": "$k=3:\\ (6 d^2 \\ln 2)^{1/3} \\le n \\le (6 d^2 \\ln 2)^{1/3} + 2$, the parent's bound, with $2 = k-1$.",
+    "significance": "important",
+    "relatedConcepts": ["specialization", "consistency check", "parent recovery"],
+    "prerequisites": ["the general threshold", "factorial evaluation"]
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+  "title": "The General k-Fold Birthday-Coincidence Threshold n ≈ (k!·d^{k-1}·ln2)^{1/k}",
+  "slug": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+  "description": "Generalizes the parent's k=3 cube-root threshold to arbitrary k. For k ≥ 1, d > 0, and n ≥ k-1 solving the expected-k-tuple balance n^{underline k} = k!·d^{k-1}·ln2 (expected coincident k-tuples = ln2, the 50%-chance criterion), proves (k!·d^{k-1}·ln2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln2)^{1/k} + (k-1), i.e. n = (k!·d^{k-1}·ln2)^{1/k} + O(1) with d-independent additive error at most k-1. Proved by the falling-factorial sandwich (n-k+1)^k ≤ n^{underline k} ≤ n^k and rpow monotonicity — the exact k-fold lift of the parent's cube-root sandwich. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean",
+    "tags": [
+      "probability",
+      "birthday-problem",
+      "asymptotics",
+      "threshold",
+      "falling-factorial",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 203,
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for birthday_kfold_threshold and birthday_kfold_threshold_gap. The file imports only Mathlib and is self-contained. Scope note: this proves the threshold to leading order with an explicit additive O(1) bound (≤ k-1, independent of d) from the expected-count balance equation; it does not re-derive the balance equation from a probabilistic limit theorem (Poisson approximation for the number of coincident k-tuples), which is the heuristic input — exactly as in the k=3 parent.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.pow_rpow_inv_natCast",
+        "description": "(x ^ n) ^ (n⁻¹ : ℝ) = x for 0 ≤ x, n ≠ 0 — the k-th-root identity (x^k)^{1/k} = x underlying kthRoot_pow",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "monotonicity of t ↦ t^z on the nonnegatives for z ≥ 0 — passes the k-th root through the sandwich inequalities at exponent 1/k",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Finset.prod_le_prod",
+        "description": "monotonicity of finite products of nonnegatives — both directions of the falling-factorial sandwich (replace each factor n-i by its min n-(k-1) or its max n)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "0 < log x for 1 < x — positivity of ln 2, hence of k!·d^{k-1}·ln2",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Rigorous leading-order proof of the general k-fold birthday-coincidence threshold (k!·d^{k-1}·ln2)^{1/k} with an explicit, d-independent additive error bound of at most k-1, generalizing the parent's k=3 result",
+      "fallingR: the real falling factorial n^{underline k} = ∏_{i<k}(n-i), with fallingR_three recovering the parent's cubic product n(n-1)(n-2)",
+      "kthRoot_pow: the k-th-root identity (x^k)^{1/k} = x for x ≥ 0, k ≥ 1",
+      "falling_sandwich: (n-(k-1))^k ≤ n^{underline k} ≤ n^k for n ≥ k-1, by monotonicity of finite products (each factor n-i trapped in [n-(k-1), n])",
+      "birthday_kfold_threshold: (k!·d^{k-1}·ln2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln2)^{1/k} + (k-1) for n solving the balance equation, via the falling-factorial sandwich and rpow monotonicity",
+      "birthday_kfold_threshold_gap: the packaged statement |n − (k!·d^{k-1}·ln2)^{1/k}| ≤ k-1",
+      "birthday_kfold_threshold_k3: the k=3 specialization recovers the parent's (6d²ln2)^{1/3} ≤ n ≤ (6d²ln2)^{1/3} + 2 verbatim"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The classical birthday problem (k=2) has threshold n ≈ √(2d ln2); the k-fold coincidence problem — when are k people likely to share a day among d days? — has folklore threshold n ≈ (k!·d^{k-1}·ln2)^{1/k}, obtained from the expected number of coincident k-tuples. The parent (birthday-problem-oq-03-oq-01-oq-01-oq-03) proved the k=3 case rigorously by a cube-root sandwich and asked, in its OQ-03, for the general-k lift. This entry supplies it: the same sandwich, now over the k-fold falling factorial, with the additive slack 2 of the parent reappearing as the general k-1.",
+    "problemStatement": "Generalize the k=3 coincidence threshold to general k: show the k-fold birthday-coincidence threshold is n = (k!·d^{k-1}·ln2)^{1/k} + O(1) via the falling-factorial sandwich (n-k+1)^k ≤ n^{underline k} ≤ n^k combined with rpow monotonicity.",
+    "text": "Shows that, for k ≥ 1 and d > 0, the n ≥ k-1 solving the expected-k-tuple balance n^{underline k} = k!·d^{k-1}·ln2 satisfies (k!·d^{k-1}·ln2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln2)^{1/k} + (k-1), the rigorous form of n ≈ (k!·d^{k-1}·ln2)^{1/k}.",
+    "proofStrategy": "The 50%-chance heuristic sets the expected number of coincident k-tuples C(n,k)/d^{k-1} = n^{underline k}/(k!·d^{k-1}) equal to ln2, i.e. n^{underline k} = k!·d^{k-1}·ln2 =: L, where n^{underline k} = ∏_{i<k}(n-i) is the real falling factorial fallingR. The sandwich falling_sandwich traps it between perfect k-th powers: for n ≥ k-1 every factor n-i (i < k) lies in [n-(k-1), n], so by monotonicity of finite products of nonnegatives (Finset.prod_le_prod) (n-(k-1))^k ≤ n^{underline k} ≤ n^k. Taking k-th roots — monotone on the nonnegatives (Real.rpow_le_rpow at exponent 1/k) with the identity (x^k)^{1/k} = x (kthRoot_pow, from Real.pow_rpow_inv_natCast) — turns L ≤ n^k into L^{1/k} ≤ n and (n-(k-1))^k ≤ L into n-(k-1) ≤ L^{1/k}. Hence L^{1/k} ≤ n ≤ L^{1/k} + (k-1). Specializing k=3 (fallingR_three, factorial 3 = 6) reproduces the parent verbatim.",
+    "keyInsights": [
+      "The k-fold threshold n is trapped between two consecutive perfect k-th powers, n^{underline k} ∈ [(n-(k-1))^k, n^k], so a single k-th-root sandwich pins it to (k!·d^{k-1}·ln2)^{1/k} within an additive k-1.",
+      "The error bound k-1 is the gap between the k-th roots of the two bounding powers and is independent of d — so the asymptotic n ∼ (k!·d^{k-1}·ln2)^{1/k} holds with an explicit, uniform lower-order term, recovering the parent's slack 2 = k-1 at k=3.",
+      "The cube-root sandwich of the parent generalizes verbatim once the cubic is recast as a product ∏_{i<k}(n-i): the two endpoint replacements n-i ↦ n and n-i ↦ n-(k-1) are exactly two applications of Finset.prod_le_prod, replacing the parent's two nlinarith calls.",
+      "k-th roots are handled uniformly as the real power t ↦ t^{1/k}: monotone on the nonnegatives and inverse to the k-th power there, avoiding any bespoke nth-root development for varying k.",
+      "Carrying the falling factorial as an explicit Finset product (fallingR) makes the argument uniform in k, where the parent could expand the k=3 product into a fixed cubic and call nlinarith."
+    ]
+  },
+  "sections": [
+    {
+      "id": "falling-and-roots",
+      "title": "The Falling Factorial and the k-th-Root Identity",
+      "summary": "Module docstring framing OQ-03 (the general-k threshold and the expected-count balance); fallingR (n^{underline k} = ∏_{i<k}(n-i)) with fallingR_three recovering n(n-1)(n-2); kthRoot_pow: (x^k)^{1/k} = x for x ≥ 0, k ≥ 1, via Real.pow_rpow_inv_natCast",
+      "startLine": 1,
+      "endLine": 71
+    },
+    {
+      "id": "sandwich",
+      "title": "The Falling-Factorial Sandwich",
+      "summary": "falling_sandwich: for n ≥ k-1, (n-(k-1))^k ≤ n^{underline k} ≤ n^k, by monotonicity of finite products — each factor n-i (i < k) lies in [n-(k-1), n], two applications of Finset.prod_le_prod",
+      "startLine": 72,
+      "endLine": 104
+    },
+    {
+      "id": "threshold",
+      "title": "The Threshold Sandwich and Packaged Gap",
+      "summary": "birthday_kfold_threshold: (k!·d^{k-1}·ln2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln2)^{1/k} + (k-1) from L ≤ n^k and (n-(k-1))^k ≤ L via k-th-root monotonicity; birthday_kfold_threshold_gap: |n − (k!·d^{k-1}·ln2)^{1/k}| ≤ k-1",
+      "startLine": 105,
+      "endLine": 158
+    },
+    {
+      "id": "k3-consistency",
+      "title": "Consistency with the k = 3 Parent",
+      "summary": "birthday_kfold_threshold_k3: instantiating k=3 recovers the parent's statement (6d²ln2)^{1/3} ≤ n ≤ (6d²ln2)^{1/3} + 2 verbatim, with slack 2 = k-1",
+      "startLine": 159,
+      "endLine": 203
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; self-contained, imports only Mathlib): the general k-fold birthday-coincidence threshold is (k!·d^{k-1}·ln2)^{1/k} to leading order, with explicit additive error at most k-1 (independent of d). For k ≥ 1, d > 0, the n ≥ k-1 solving the expected-k-tuple balance n^{underline k} = k!·d^{k-1}·ln2 satisfies (k!·d^{k-1}·ln2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln2)^{1/k} + (k-1), by the falling-factorial sandwich (n-k+1)^k ≤ n^{underline k} ≤ n^k. The k=3 specialization recovers the parent verbatim.",
+    "implications": "Lifts the parent's rigorous, machine-checked k=3 threshold to all k, cleanly separating the proved algebraic/analytic core (the falling-factorial sandwich) from the probabilistic balance heuristic. The falling-factorial-sandwich technique transfers to any expected-count threshold where a k-fold falling factorial is trapped between consecutive perfect k-th powers; the additive error k-1 is sharp for the sandwich (achieved at the endpoints).",
+    "openQuestions": [
+      "Derive the balance equation n^{underline k} = k!·d^{k-1}·ln2 from a probabilistic limit theorem (Poisson approximation for the number of coincident k-tuples), closing the gap between heuristic and theorem uniformly in k.",
+      "Sharpen the additive O(1) error below k-1: locate n within a smaller window via a second-order expansion of the falling factorial n^{underline k} = n^k - C(k,2)·n^{k-1} + ⋯, refining the leading term to (k!·d^{k-1}·ln2)^{1/k} − (k-1)/2 + o(1)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+      "relationship": "parent-problem",
+      "description": "Parent: the rigorous k=3 cube-root threshold (6d²ln2)^{1/3} + O(1); its OQ-03 asks for the general-k lift proved here, with the parent's slack 2 reappearing as k-1"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "The base birthday problem (k=2 coincidence, threshold n ≈ √(2d ln2)); this is the general k-fold analogue"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "E. H. McKinney"
+      ],
+      "title": "Generalized Birthday Problem",
+      "year": "1966",
+      "venue": "American Mathematical Monthly 73, 385–387",
+      "note": "Multiple-coincidence birthday problem"
+    },
+    {
+      "authors": [
+        "Anirban DasGupta"
+      ],
+      "title": "The matching, birthday and the strong birthday problem: a contemporary review",
+      "year": "2005",
+      "venue": "Journal of Statistical Planning and Inference 130, 377–389",
+      "note": "Asymptotics of k-fold birthday coincidences, including the (k!·d^{k-1}·ln2)^{1/k} threshold"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "BirthdayProblemOQ03OQ01OQ01OQ03OQ03",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's (`birthday-problem-oq-03-oq-01-oq-01-oq-03`) **OQ-03**: generalize the just-shipped **k = 3** cube-root threshold to **general k**.

For `k ≥ 1`, `d > 0`, and `n ≥ k-1` solving the expected-`k`-tuple balance equation
```
n^{underline k} = k! · d^{k-1} · ln 2     (expected coincident k-tuples = ln 2, the 50%-chance criterion)
```
the file proves the two-sided threshold
```
(k!·d^{k-1}·ln2)^{1/k}  ≤  n  ≤  (k!·d^{k-1}·ln2)^{1/k} + (k-1)
```
i.e. `n = (k!·d^{k-1}·ln2)^{1/k} + O(1)` with **d-independent additive error at most k-1** — packaged as `|n − (k!·d^{k-1}·ln2)^{1/k}| ≤ k-1`.

## Proof

The exact **k-fold lift of the parent's cube-root sandwich**:
- carry the falling factorial as an explicit product `fallingR n k = ∏_{i<k}(n-i)`;
- `falling_sandwich`: for `n ≥ k-1`, each factor `n-i` lies in `[n-(k-1), n]`, so two applications of `Finset.prod_le_prod` give `(n-(k-1))^k ≤ n^{underline k} ≤ n^k` (replacing the parent's two `nlinarith` cubic calls, now uniform in k);
- take `k`-th roots via `Real.rpow_le_rpow` at exponent `1/k` and `kthRoot_pow` (`(x^k)^{1/k}=x`).

`birthday_kfold_threshold_k3` instantiates `k=3` and recovers the parent's `(6d²ln2)^{1/3} ≤ n ≤ (6d²ln2)^{1/3}+2` **verbatim** — the parent's slack `2` is exactly the general `k-1`.

## Verification

- `lake env lean` (pinned Mathlib v4.26.0) exits 0; no errors, no warnings.
- `#print axioms` for `birthday_kfold_threshold` / `birthday_kfold_threshold_gap` reports only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries**, no `Lean.ofReduceBool`/`sorryAx`.
- 203 lines, 1 def + 7 theorems/lemmas; imports only Mathlib.

**Status**: verified · **Badge**: original

Scope note: proves the threshold to leading order from the expected-count balance equation; does not re-derive that balance from a Poisson limit theorem (the heuristic input), exactly as in the k=3 parent.