### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03): general k-fold coincidence threshold n=(k!·d^{k-1}·ln2)^{1/k}+O(1)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -460,6 +460,7 @@ import Proofs.BirthdayProblemOQ03
 import Proofs.BirthdayProblemOQ03OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01OQ03
+import Proofs.BirthdayProblemOQ03OQ01OQ01OQ03OQ03
 import Proofs.BirthdayProblemOQ03OQ01OQ01OQ05
 import Proofs.BirthdayProblemOQ03OQ01OQ02
 import Proofs.BirthdayProblemOQ03OQ03

--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean
@@ -1,0 +1,195 @@
+import Mathlib
+
+/-
+# Birthday Problem — OQ-03-OQ-01-OQ-01-OQ-03-OQ-03: The general k-fold Coincidence Threshold
+
+## Research Problem: birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03
+
+The parent (`birthday-problem-oq-03-oq-01-oq-01-oq-03`) proved the **k = 3** (triple)
+coincidence threshold `n ≈ (6 d² ln 2)^{1/3}` via the cube-root sandwich
+`(n-2)³ ≤ n(n-1)(n-2) ≤ n³`.  Its open question OQ-03 asks to **generalize to arbitrary k**:
+
+> Show the k-fold birthday-coincidence threshold is `n = (k!·d^{k-1}·ln 2)^{1/k} + O(1)` via
+> the analogous falling-factorial sandwich `(n-k+1)^k ≤ n^{\underline{k}} ≤ n^k` combined with
+> rpow monotonicity, mirroring the parent's cube-root sandwich for `k = 3`.
+
+The heuristic is the standard Poisson/expected-count balance: with `d` equally likely days, the
+probability that a *fixed* set of `k` people all share a day is `1/d^{k-1}`, so the expected
+number of `k`-wise coincidences is
+
+      C(n,k) / d^{k-1}  =  n(n-1)⋯(n-k+1) / (k!·d^{k-1})  =  n^{\underline{k}} / (k!·d^{k-1}),
+
+where `n^{\underline{k}} = ∏_{i=0}^{k-1} (n-i)` is the falling factorial.  The 50%-chance
+threshold is where this expected count equals `ln 2`:
+
+      n^{\underline{k}} / (k!·d^{k-1}) = ln 2,   i.e.   ∏_{i=0}^{k-1} (n - i) = k!·d^{k-1}·ln 2.
+
+This file proves, **rigorously and with an explicit O(1) error bound**, that the `n` solving this
+balance equation is exactly the claimed threshold to leading order:
+
+      (k!·d^{k-1}·ln 2)^{1/k}  ≤  n  ≤  (k!·d^{k-1}·ln 2)^{1/k} + (k-1).
+
+So `n = (k!·d^{k-1}·ln 2)^{1/k} + O(1)`, the lower order term bounded by the constant `k-1`,
+**independent of `d`**.  The proof is the falling-factorial sandwich requested by OQ-03:
+
+* `∏_{i<k} (n-i) ≤ n^k`               gives the lower bound `(k!·d^{k-1}·ln 2)^{1/k} ≤ n`;
+* `(n-(k-1))^k ≤ ∏_{i<k} (n-i)`       gives the upper bound `n ≤ (k!·d^{k-1}·ln 2)^{1/k} + (k-1)`.
+
+For `k = 3` this specializes to the parent's `(n-2)³ ≤ n(n-1)(n-2) ≤ n³` and the error bound
+`k-1 = 2`, recovering the parent result exactly.
+
+## What is proved
+
+* `kthRoot_pow`       — the k-th-root identity `(x^k)^{1/k} = x` for `x ≥ 0`, `k ≠ 0`.
+* `falling_le_pow`    — upper sandwich `∏_{i<k} (n-i) ≤ n^k`.
+* `pow_le_falling`    — lower sandwich `(n-(k-1))^k ≤ ∏_{i<k} (n-i)`.
+* `birthday_kfold_threshold`     — the two-sided bound above.
+* `birthday_kfold_threshold_gap` — packaged as `|n − (k!·d^{k-1}·ln 2)^{1/k}| ≤ k-1`.
+
+Tags: probability, birthday-problem, asymptotics, threshold, k-th-root, falling-factorial,
+real-analysis
+-/
+
+namespace BirthdayProblemOQ03OQ01OQ01OQ03OQ03
+
+open Real
+
+/-- **k-th-root identity.**  `(x^k)^{1/k} = x` for `x ≥ 0` and `k ≠ 0`.  Generalizes the
+parent's `cubeRoot_cube` (`k = 3`). -/
+theorem kthRoot_pow {x : ℝ} {k : ℕ} (hx : 0 ≤ x) (hk : k ≠ 0) :
+    (x ^ k) ^ ((k : ℝ)⁻¹) = x :=
+  Real.pow_rpow_inv_natCast hx hk
+
+/-- **Upper sandwich.**  Every factor of the falling factorial `∏_{i<k} (n-i)` is `≤ n` and is
+nonnegative (as `n ≥ k-1`), so the product is `≤ nᵏ`. -/
+theorem falling_le_pow (k : ℕ) (n : ℝ) (hn : (k : ℝ) - 1 ≤ n) :
+    ∏ i ∈ Finset.range k, (n - (i : ℝ)) ≤ n ^ k := by
+  calc ∏ i ∈ Finset.range k, (n - (i : ℝ))
+      ≤ ∏ _i ∈ Finset.range k, n := by
+        refine Finset.prod_le_prod (fun i hi => ?_) (fun i hi => ?_)
+        · -- 0 ≤ n - i
+          simp only [Finset.mem_range] at hi
+          have : (i : ℝ) + 1 ≤ (k : ℝ) := by exact_mod_cast hi
+          linarith
+        · -- n - i ≤ n
+          have : (0 : ℝ) ≤ (i : ℝ) := Nat.cast_nonneg i
+          linarith
+    _ = n ^ k := by rw [Finset.prod_const, Finset.card_range]
+
+/-- **Lower sandwich.**  Every factor `n-i` (`i < k`) is `≥ n-(k-1) ≥ 0`, so the falling
+factorial `∏_{i<k} (n-i)` is `≥ (n-(k-1))ᵏ`. -/
+theorem pow_le_falling (k : ℕ) (n : ℝ) (hn : (k : ℝ) - 1 ≤ n) :
+    (n - ((k : ℝ) - 1)) ^ k ≤ ∏ i ∈ Finset.range k, (n - (i : ℝ)) := by
+  calc (n - ((k : ℝ) - 1)) ^ k
+      = ∏ _i ∈ Finset.range k, (n - ((k : ℝ) - 1)) := by
+        rw [Finset.prod_const, Finset.card_range]
+    _ ≤ ∏ i ∈ Finset.range k, (n - (i : ℝ)) := by
+        refine Finset.prod_le_prod (fun i hi => ?_) (fun i hi => ?_)
+        · -- 0 ≤ n - (k-1)
+          linarith
+        · -- n - (k-1) ≤ n - i,  i.e.  i ≤ k-1
+          simp only [Finset.mem_range] at hi
+          have : (i : ℝ) + 1 ≤ (k : ℝ) := by exact_mod_cast hi
+          linarith
+
+/-- **The general k-fold coincidence threshold, to leading order with explicit O(1) error.**
+
+    If `n ≥ k-1` solves the expected-coincidence balance equation
+    `∏_{i<k} (n-i) = k!·d^{k-1}·ln 2` (i.e. the expected number of `k`-wise coincidences
+    equals `ln 2`, the 50%-chance criterion), then
+
+        (k!·d^{k-1}·ln 2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln 2)^{1/k} + (k-1).
+
+    Hence `n = (k!·d^{k-1}·ln 2)^{1/k} + O(1)`: the threshold is `(k!·d^{k-1}·ln 2)^{1/k}` up to a
+    bounded additive constant `k-1`, independent of `d`.  This is the rigorous form of the
+    asymptotic `n ≈ (k!·d^{k-1}·ln 2)^{1/k}` and generalizes the parent's `k = 3` result. -/
+theorem birthday_kfold_threshold (k : ℕ) (d n : ℝ) (hk : 1 ≤ k) (hd : 0 < d)
+    (hn : (k : ℝ) - 1 ≤ n)
+    (hbal : ∏ i ∈ Finset.range k, (n - (i : ℝ))
+        = (k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) :
+    ((k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) ^ ((k : ℝ)⁻¹) ≤ n ∧
+    n ≤ ((k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) ^ ((k : ℝ)⁻¹) + ((k : ℝ) - 1) := by
+  set L := (k.factorial : ℝ) * d ^ (k - 1) * Real.log 2 with hLdef
+  have hk0 : k ≠ 0 := by omega
+  have hk1 : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk
+  have hlog : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hL : 0 ≤ L := by rw [hLdef]; positivity
+  have hn0 : 0 ≤ n := by linarith
+  have hnk : 0 ≤ n - ((k : ℝ) - 1) := by linarith
+  refine ⟨?_, ?_⟩
+  · -- Lower bound: L ≤ nᵏ, so L^{1/k} ≤ (nᵏ)^{1/k} = n.
+    have hub : L ≤ n ^ k := by rw [← hbal]; exact falling_le_pow k n hn
+    calc L ^ ((k : ℝ)⁻¹)
+        ≤ (n ^ k) ^ ((k : ℝ)⁻¹) := Real.rpow_le_rpow hL hub (by positivity)
+      _ = n := kthRoot_pow hn0 hk0
+  · -- Upper bound: (n-(k-1))ᵏ ≤ L, so n-(k-1) = ((n-(k-1))ᵏ)^{1/k} ≤ L^{1/k}.
+    have hlb : (n - ((k : ℝ) - 1)) ^ k ≤ L := by rw [← hbal]; exact pow_le_falling k n hn
+    have hstep : n - ((k : ℝ) - 1) ≤ L ^ ((k : ℝ)⁻¹) := by
+      calc n - ((k : ℝ) - 1)
+          = ((n - ((k : ℝ) - 1)) ^ k) ^ ((k : ℝ)⁻¹) := (kthRoot_pow hnk hk0).symm
+        _ ≤ L ^ ((k : ℝ)⁻¹) := Real.rpow_le_rpow (pow_nonneg hnk k) hlb (by positivity)
+    linarith
+
+/-- **Packaged threshold gap.**  The balance-equation solution `n` is within `k-1` of the
+    leading-order threshold `(k!·d^{k-1}·ln 2)^{1/k}` — a bounded, `d`-independent error. -/
+theorem birthday_kfold_threshold_gap (k : ℕ) (d n : ℝ) (hk : 1 ≤ k) (hd : 0 < d)
+    (hn : (k : ℝ) - 1 ≤ n)
+    (hbal : ∏ i ∈ Finset.range k, (n - (i : ℝ))
+        = (k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) :
+    |n - ((k.factorial : ℝ) * d ^ (k - 1) * Real.log 2) ^ ((k : ℝ)⁻¹)| ≤ (k : ℝ) - 1 := by
+  obtain ⟨hlo, hhi⟩ := birthday_kfold_threshold k d n hk hd hn hbal
+  rw [abs_le]
+  constructor <;> linarith
+
+/-- **Consistency check.**  For `k = 3` the general threshold reduces to the parent's
+    `(6 d² ln 2)^{1/3}` two-sided bound, since `3! = 6`, `d^{3-1} = d²`, and `k-1 = 2`. -/
+theorem birthday_kfold_threshold_k3 (d n : ℝ) (hd : 0 < d) (hn : 2 ≤ n)
+    (hbal : n * (n - 1) * (n - 2) = 6 * d ^ 2 * Real.log 2) :
+    (6 * d ^ 2 * Real.log 2) ^ (((3 : ℕ) : ℝ)⁻¹) ≤ n ∧
+    n ≤ (6 * d ^ 2 * Real.log 2) ^ (((3 : ℕ) : ℝ)⁻¹) + 2 := by
+  have hexpand : ∏ i ∈ Finset.range 3, (n - (i : ℝ)) = n * (n - 1) * (n - 2) := by
+    simp only [Finset.prod_range_succ, Finset.prod_range_zero, Nat.cast_zero,
+      Nat.cast_one, Nat.cast_ofNat, one_mul]
+    ring
+  have hprod : ∏ i ∈ Finset.range 3, (n - (i : ℝ))
+      = (Nat.factorial 3 : ℝ) * d ^ (3 - 1) * Real.log 2 := by
+    rw [hexpand, hbal]; norm_num [Nat.factorial]
+  have hn3 : ((3 : ℕ) : ℝ) - 1 ≤ n := by push_cast; linarith
+  have h := birthday_kfold_threshold 3 d n (by norm_num) hd hn3 hprod
+  have hc : (Nat.factorial 3 : ℝ) * d ^ (3 - 1) * Real.log 2 = 6 * d ^ 2 * Real.log 2 := by
+    norm_num [Nat.factorial]
+  have he : ((3 : ℕ) : ℝ) - 1 = 2 := by norm_num
+  rw [hc, he] at h
+  exact h
+
+#check @kthRoot_pow
+#check @falling_le_pow
+#check @pow_le_falling
+#check @birthday_kfold_threshold
+#check @birthday_kfold_threshold_gap
+#check @birthday_kfold_threshold_k3
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms — self-contained, imports only Mathlib):
+
+* `kthRoot_pow`       — `(x^k)^{1/k} = x` for `x ≥ 0`, `k ≠ 0` (generalizes parent `cubeRoot_cube`).
+* `falling_le_pow`    — `∏_{i<k} (n-i) ≤ n^k`.
+* `pow_le_falling`    — `(n-(k-1))^k ≤ ∏_{i<k} (n-i)`.
+* `birthday_kfold_threshold`     — for `n ≥ k-1` solving `∏_{i<k}(n-i) = k!·d^{k-1}·ln 2`,
+  `(k!·d^{k-1}·ln 2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln 2)^{1/k} + (k-1)`.
+* `birthday_kfold_threshold_gap` — equivalently `|n − (k!·d^{k-1}·ln 2)^{1/k}| ≤ k-1`.
+* `birthday_kfold_threshold_k3`  — specializes to the parent's `k = 3` `(6 d² ln 2)^{1/3}` bound.
+
+This answers the parent's OQ-03: the general k-fold coincidence threshold is
+`(k!·d^{k-1}·ln 2)^{1/k}` to leading order, with a bounded additive error of at most `k-1`
+(independent of `d`), proved by the falling-factorial sandwich
+`(n-(k-1))^k ≤ ∏_{i<k}(n-i) ≤ n^k` and rpow monotonicity — the exact generalization of the
+parent's cube-root sandwich for `k = 3`.
+-/
+
+end BirthdayProblemOQ03OQ01OQ01OQ03OQ03
+
+#print axioms BirthdayProblemOQ03OQ01OQ01OQ03OQ03.birthday_kfold_threshold
+#print axioms BirthdayProblemOQ03OQ01OQ01OQ03OQ03.birthday_kfold_threshold_gap

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+  "title": "The General k-fold Birthday-Coincidence Threshold n ≈ (k!·d^(k-1)·ln2)^(1/k)",
+  "slug": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+  "description": "Generalizes the parent's k=3 triple-coincidence threshold to arbitrary k, answering its open question OQ-03. For n ≥ k-1 solving the expected-coincidence balance ∏_{i<k}(n-i) = k!·d^(k-1)·ln2 (expected k-wise coincidences = ln2, the 50%-chance criterion), proves (k!·d^(k-1)·ln2)^(1/k) ≤ n ≤ (k!·d^(k-1)·ln2)^(1/k) + (k-1), i.e. n = (k!·d^(k-1)·ln2)^(1/k) + O(1) with d-independent additive error at most k-1. Proved by the falling-factorial sandwich (n-(k-1))^k ≤ ∏_{i<k}(n-i) ≤ n^k and rpow monotonicity — the exact generalization of the parent's cube-root sandwich. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean",
+    "tags": [
+      "probability",
+      "birthday-problem",
+      "asymptotics",
+      "threshold",
+      "k-th-root",
+      "falling-factorial",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 195,
+    "assumptions": "None. Fully machine-verified: lake env lean of Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for birthday_kfold_threshold and birthday_kfold_threshold_gap. The file imports only Mathlib and is self-contained. Scope note: this proves the threshold to leading order with an explicit additive O(1) bound (≤ k-1) from the expected-count balance equation; it does not re-derive the balance equation from a probabilistic limit theorem (Poisson approximation), which is the heuristic modeling input.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.pow_rpow_inv_natCast",
+        "description": "(x ^ k) ^ (k⁻¹ : ℝ) = x for 0 ≤ x, k ≠ 0 — the k-th-root identity, generalizing the parent's cube-root identity",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "monotonicity of t ↦ t^z on the nonnegatives for z ≥ 0 — passes the k-th root through the sandwich inequalities",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Finset.prod_le_prod",
+        "description": "∏ f ≤ ∏ g from 0 ≤ f i and f i ≤ g i — the engine of the falling-factorial sandwich against the constant products n^k and (n-(k-1))^k",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "0 < log x for 1 < x — positivity of ln 2, hence of k!·d^(k-1)·ln2",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Rigorous leading-order proof of the general k-fold birthday threshold with an explicit, d-independent additive error bound of at most k-1, answering the parent's open question OQ-03 verbatim",
+      "kthRoot_pow: the k-th-root identity (x^k)^(1/k) = x for x ≥ 0, k ≠ 0 (generalizes the parent's cubeRoot_cube)",
+      "falling_le_pow and pow_le_falling: the falling-factorial sandwich (n-(k-1))^k ≤ ∏_{i<k}(n-i) ≤ n^k via Finset.prod_le_prod against constant products",
+      "birthday_kfold_threshold: (k!·d^(k-1)·ln2)^(1/k) ≤ n ≤ (k!·d^(k-1)·ln2)^(1/k) + (k-1) for n solving the balance equation",
+      "birthday_kfold_threshold_gap: the packaged statement |n − (k!·d^(k-1)·ln2)^(1/k)| ≤ k-1",
+      "birthday_kfold_threshold_k3: a machine-checked consistency check that the general theorem specializes to the parent's k=3 (6d²ln2)^(1/3) two-sided bound"
+    ],
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical birthday problem (k=2) has threshold n ≈ √(2d ln2); the parent chain proved the triple-coincidence (k=3) threshold n ≈ (6 d² ln2)^(1/3) by a cube-root sandwich. Its open question OQ-03 asks for the general k case: the k-fold coincidence threshold n ≈ (k!·d^(k-1)·ln2)^(1/k), a folklore asymptotic obtained by balancing the expected number of k-wise coincidences against ln2. This entry gives the rigorous, machine-checked leading-order proof for arbitrary k with an explicit O(1) error bound.",
+    "problemStatement": "Show the general k-fold birthday-coincidence threshold is n = (k!·d^(k-1)·ln2)^(1/k) + O(1) via the falling-factorial sandwich (n-k+1)^k ≤ n^{underline k} ≤ n^k.",
+    "text": "Shows that for n ≥ k-1 solving the expected-coincidence balance ∏_{i<k}(n-i) = k!·d^(k-1)·ln2, one has (k!·d^(k-1)·ln2)^(1/k) ≤ n ≤ (k!·d^(k-1)·ln2)^(1/k) + (k-1), the rigorous form of n ≈ (k!·d^(k-1)·ln2)^(1/k).",
+    "proofStrategy": "The 50%-chance heuristic sets the expected number of k-wise coincidences C(n,k)/d^(k-1) = ∏_{i<k}(n-i)/(k!·d^(k-1)) equal to ln2, i.e. ∏_{i<k}(n-i) = k!·d^(k-1)·ln2 =: L. Sandwich the falling factorial between two perfect k-th powers: every factor n-i (i<k) satisfies n-(k-1) ≤ n-i ≤ n and all are nonnegative since n ≥ k-1, so by Finset.prod_le_prod against the constant products, (n-(k-1))^k ≤ ∏_{i<k}(n-i) ≤ n^k. Taking k-th roots — monotone on the nonnegatives (Real.rpow_le_rpow with exponent 1/k) together with the identity (x^k)^(1/k) = x (Real.pow_rpow_inv_natCast) — turns L ≤ n^k into L^(1/k) ≤ n and (n-(k-1))^k ≤ L into n-(k-1) ≤ L^(1/k). Hence L^(1/k) ≤ n ≤ L^(1/k) + (k-1).",
+    "keyInsights": [
+      "The threshold n is trapped between two consecutive perfect k-th powers, ∏_{i<k}(n-i) ∈ [(n-(k-1))^k, n^k], so a single k-th-root sandwich pins it to (k!·d^(k-1)·ln2)^(1/k) within an additive k-1.",
+      "The error bound k-1 is the gap between the k-th roots of the two bounding powers and is independent of d — so the asymptotic n ∼ (k!·d^(k-1)·ln2)^(1/k) holds with an explicit, uniform lower-order term.",
+      "The whole sandwich is one application of Finset.prod_le_prod each way: comparing the falling-factorial product factor-by-factor against the constant products n^k and (n-(k-1))^k (via Finset.prod_const and Finset.card_range), so no induction on k is needed.",
+      "k-th roots are handled uniformly as the real power t ↦ t^(1/k): monotone on the nonnegatives and inverse to k-th powering there, avoiding any bespoke nth-root development — the same Real.pow_rpow_inv_natCast that served k=3.",
+      "Setting k=3 recovers the parent exactly (3!=6, d^(3-1)=d², k-1=2), verified in-file by birthday_kfold_threshold_k3, confirming the generalization is faithful."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-kthroot",
+      "title": "Problem Statement and the k-th-Root Identity",
+      "summary": "Module docstring framing OQ-03 (the general k threshold and the expected-count balance), and kthRoot_pow: (x^k)^(1/k) = x for x ≥ 0, k ≠ 0 via Real.pow_rpow_inv_natCast",
+      "startLine": 3,
+      "endLine": 61
+    },
+    {
+      "id": "sandwich",
+      "title": "The Falling-Factorial Sandwich",
+      "summary": "falling_le_pow (∏_{i<k}(n-i) ≤ n^k) and pow_le_falling ((n-(k-1))^k ≤ ∏_{i<k}(n-i)), each a single Finset.prod_le_prod against a constant product",
+      "startLine": 63,
+      "endLine": 93
+    },
+    {
+      "id": "threshold",
+      "title": "The Threshold and the Gap",
+      "summary": "birthday_kfold_threshold: (k!·d^(k-1)·ln2)^(1/k) ≤ n ≤ (k!·d^(k-1)·ln2)^(1/k) + (k-1) from the sandwich via k-th-root monotonicity; birthday_kfold_threshold_gap packages it as |n − threshold| ≤ k-1",
+      "startLine": 95,
+      "endLine": 142
+    },
+    {
+      "id": "k3-check",
+      "title": "k = 3 Consistency Check",
+      "summary": "birthday_kfold_threshold_k3: the general theorem specializes to the parent's (6d²ln2)^(1/3) two-sided bound, confirming the generalization is faithful",
+      "startLine": 144,
+      "endLine": 170
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; self-contained, imports only Mathlib): the general k-fold birthday-coincidence threshold is (k!·d^(k-1)·ln2)^(1/k) to leading order, with explicit additive error at most k-1 (independent of d). The n ≥ k-1 solving the expected-coincidence balance ∏_{i<k}(n-i) = k!·d^(k-1)·ln2 satisfies (k!·d^(k-1)·ln2)^(1/k) ≤ n ≤ (k!·d^(k-1)·ln2)^(1/k) + (k-1), by the falling-factorial sandwich (n-(k-1))^k ≤ ∏_{i<k}(n-i) ≤ n^k. Specializing k=3 recovers the parent's cube-root result.",
+    "implications": "Completes the parent chain's OQ-03 by extending the rigorous, machine-checked threshold from k=3 to all k in one uniform argument. The falling-factorial-sandwich technique transfers to other expected-count thresholds where a k-fold falling factorial is trapped between consecutive perfect powers, with the error controlled uniformly by the degree.",
+    "openQuestions": [
+      "Derive the balance equation ∏_{i<k}(n-i) = k!·d^(k-1)·ln2 from a probabilistic limit theorem (Poisson approximation for the number of k-wise coincidences), closing the gap between heuristic and theorem.",
+      "Sharpen the additive O(1) error: locate n within a window smaller than [threshold, threshold + (k-1)], e.g. via a second-order (Stirling-type) expansion of the falling factorial."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+      "relationship": "parent-problem",
+      "description": "Parent: the k=3 triple-coincidence threshold (6d²ln2)^(1/3) by a cube-root sandwich; its open question OQ-03 (generalize to general k) is answered here"
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "The base birthday problem (k=2 coincidence, threshold n ≈ √(2d ln2)); this is the general k-fold analogue"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "E. H. McKinney"
+      ],
+      "title": "Generalized Birthday Problem",
+      "year": "1966",
+      "venue": "American Mathematical Monthly 73, 385–387",
+      "note": "Multiple-coincidence birthday problem"
+    },
+    {
+      "authors": [
+        "Anirban DasGupta"
+      ],
+      "title": "The matching, birthday and the strong birthday problem: a contemporary review",
+      "year": "2005",
+      "venue": "Journal of Statistical Planning and Inference 130, 377–389",
+      "note": "Asymptotics of k-fold birthday coincidences"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BirthdayProblemOQ03OQ01OQ01OQ03OQ03",
+    "lineCount": 195,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question **OQ-03 verbatim**: generalize the `k = 3` triple-coincidence birthday threshold to **arbitrary k**.

For `n ≥ k-1` solving the expected-coincidence balance equation
```
∏_{i<k} (n - i) = k!·d^{k-1}·ln 2     (expected k-wise coincidences = ln 2, the 50%-chance criterion)
```
the file proves the two-sided leading-order bound with explicit, **d-independent** O(1) error:
```
(k!·d^{k-1}·ln 2)^{1/k} ≤ n ≤ (k!·d^{k-1}·ln 2)^{1/k} + (k-1)
```
i.e. `n = (k!·d^{k-1}·ln 2)^{1/k} + O(1)` with additive error at most `k-1`.

## Method
The exact generalization of the parent's cube-root sandwich — the **falling-factorial sandwich**
```
(n-(k-1))^k ≤ ∏_{i<k} (n-i) ≤ n^k
```
proved factor-by-factor with `Finset.prod_le_prod` against the constant products `n^k` and `(n-(k-1))^k` (no induction on `k`), then k-th-root monotonicity (`Real.rpow_le_rpow` + `Real.pow_rpow_inv_natCast`).

## Theorems (6, 195 lines)
- `kthRoot_pow` — `(x^k)^{1/k} = x` for `x ≥ 0`, `k ≠ 0` (generalizes parent's `cubeRoot_cube`)
- `falling_le_pow` / `pow_le_falling` — the sandwich
- `birthday_kfold_threshold` — the two-sided bound
- `birthday_kfold_threshold_gap` — packaged as `|n − threshold| ≤ k-1`
- `birthday_kfold_threshold_k3` — machine-checked consistency check that `k=3` recovers the parent's `(6d²ln2)^{1/3}` bound

## Verification
- **0 sorries, 0 custom axioms.** `lake env lean` exits 0 against pinned Mathlib v4.26.0.
- `#print axioms` reports only `propext / Classical.choice / Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
- Self-contained: imports only Mathlib.
- Status `verified`, badge `original`.

Scope note: proves the threshold to leading order from the expected-count balance; does not re-derive the balance equation from a Poisson limit theorem (the modeling input).