### PR TITLE
Enrich Necklace Burnside Divisor Form (OQ-03-02-01-02): add index.ts + annotations

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "From Integer-Form Total to the Textbook Divisor Sum",
+    "content": "The module docstring states exactly the open question being answered. The parent entry (burnside-counting-oq-03-oq-02-oq-01) proved the cyclic cycle count $\\mathrm{cyc}(\\text{rotation } r) = \\gcd(n,r)$ and assembled the integer-form Burnside total $\\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r)} = (\\#\\text{necklaces})\\cdot n$ (its result (C)). Its openQuestions[1] asked to push this to the standard divisor form $\\sum_{d\\mid n}\\varphi(n/d)\\,k^d$. The mechanism is fiber-counting: the residues $r\\in[0,n)$ with $\\gcd(n,r)=d$ are exactly the multiples $d\\cdot s$ with $\\gcd(n/d,s)=1$, of which there are $\\varphi(n/d)$. Three results follow: (D) over range n, (E) over ZMod n, (F) the necklace count.",
+    "mathContext": "$\\sum_{r=0}^{n-1} k^{\\gcd(n,r)} = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "necklace counting", "Euler's totient", "divisor sum", "cyclic group"],
+    "prerequisites": ["Burnside/orbit counting", "Euler's totient function"]
+  },
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 38, "endLine": 45 },
+    "type": "context",
+    "title": "Imports and the Parent's Reused Lemma",
+    "content": "`import Proofs.BurnsideCountingOQ03OQ02OQ01` pulls in the parent development, and the selective `open BurnsideCountingOQ03OQ02OQ01 (Rot rotation sum_pow_gcd_eq_card_necklaces_mul)` brings into scope exactly the three names this file consumes: the rotation action `Rot n`, the `rotation` map, and — crucially — the parent's integer-form Burnside total `sum_pow_gcd_eq_card_necklaces_mul` reused verbatim for result (F). `open Finset BigOperators MulAction` enables the big-operator $\\sum$ notation, the `Finset` regrouping lemmas, and the `orbitRel.Quotient` orbit-space construction used to phrase the necklace count.",
+    "mathContext": "$\\text{parent (C):}\\quad \\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r)} = (\\#\\text{necklaces})\\cdot n$",
+    "significance": "technical",
+    "relatedConcepts": ["module dependencies", "namespace management", "MulAction", "orbit space"],
+    "prerequisites": ["Lean 4 module system", "Mathlib big operators"]
+  },
+  {
+    "id": "ann-fiberwise-regroup",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 62 },
+    "type": "technique",
+    "title": "Regrouping range n Along gcd(n, ·)",
+    "content": "The heart of result (D). `Finset.sum_fiberwise_of_maps_to'` rewrites $\\sum_{r\\in\\text{range }n} f(g\\,r)$ as $\\sum_{d\\in t}\\sum_{r\\in\\text{range }n,\\,g\\,r=d} f\\,d$, provided $g$ maps range n into the index set $t$. Here $g = \\gcd(n,\\cdot)$, $f\\,d = k^d$, and $t = n.\\text{divisors}$. The side condition — that $\\gcd(n,r)$ is always a divisor of $n$ — is discharged by `Nat.mem_divisors.2 ⟨Nat.gcd_dvd_left n r, hn.ne'⟩`: $\\gcd(n,r)\\mid n$ holds for free, and $n\\neq 0$ comes from the hypothesis $0 < n$. After this rewrite the sum is organized by cycle count $d$ rather than by rotation $r$.",
+    "mathContext": "$\\sum_{r<n} k^{\\gcd(n,r)} = \\sum_{d\\mid n}\\ \\sum_{\\substack{r<n\\\\ \\gcd(n,r)=d}} k^{d}$",
+    "significance": "key",
+    "relatedConcepts": ["fiberwise summation", "Finset.sum_fiberwise_of_maps_to'", "gcd divides", "divisor set"],
+    "prerequisites": ["finite sums over Finsets", "gcd properties"]
+  },
+  {
+    "id": "ann-fiber-cardinality",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 63, "endLine": 65 },
+    "type": "insight",
+    "title": "Each Fiber Has φ(n/d) Elements — Gauss's Counting",
+    "content": "Once the sum is grouped by cycle count, each inner fiber $\\{r<n : \\gcd(n,r)=d\\}$ is summed over a constant summand $k^d$, so `Finset.sum_const` collapses it to $\\#(\\text{fiber})\\cdot k^d$ (with `smul_eq_mul` converting the `nsmul` to multiplication). The cardinality is then read off by `Nat.totient_div_of_dvd`, which states $\\#\\{r<n : \\gcd(n,r)=d\\} = \\varphi(n/d)$ for $d\\mid n$. This is precisely the fiber count Gauss used to prove $\\sum_{d\\mid n}\\varphi(d)=n$: the residues with gcd exactly $d$ correspond bijectively to the totatives of $n/d$. This single number-theoretic fact is the only non-formal ingredient in the whole proof.",
+    "mathContext": "$\\#\\{r<n:\\gcd(n,r)=d\\} = \\varphi(n/d)\\quad(d\\mid n)$",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "Nat.totient_div_of_dvd", "Gauss divisor-sum identity", "constant-summand collapse"],
+    "prerequisites": ["Euler's totient function", "Finset cardinality"]
+  },
+  {
+    "id": "ann-zmod-transport",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 86 },
+    "type": "technique",
+    "title": "Transporting to ZMod n via the val ≃ range Bijection",
+    "content": "Result (E) restates (D) over $\\mathbb{Z}/n$, the index set the parent works in (rotations are residues $r.\\text{val}$). The two phrasings are matched by `Finset.sum_bij'` along the bijection $\\mathbb{Z}/n \\simeq \\text{range }n$: the forward map is $r\\mapsto r.\\text{val}$ (landing in range n by `ZMod.val_lt`), the inverse is $i\\mapsto (i:\\mathbb{Z}/n)$ (`Nat.cast`), and the two round-trips are witnessed by `ZMod.natCast_zmod_val` ($\\uparrow(r.\\text{val}) = r$) and `ZMod.val_natCast_of_lt` ($(\\uparrow i).\\text{val} = i$ for $i<n$). The summand equality is `rfl` because $\\gcd(n, r.\\text{val})$ is literally the term being summed. `NeZero n` supplies $0<n$ for the underlying (D).",
+    "mathContext": "$\\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r.\\mathrm{val})} = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_bij'", "ZMod.val", "reindexing sums", "bijection of index sets"],
+    "prerequisites": ["ZMod n arithmetic", "sum reindexing"]
+  },
+  {
+    "id": "ann-necklace-count",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 96, "endLine": 99 },
+    "type": "insight",
+    "title": "The Textbook Necklace Count as a Divisor Sum",
+    "content": "Result (F) is a two-rewrite finish that pays off the entire chain. The parent's `sum_pow_gcd_eq_card_necklaces_mul` gives $\\sum_{r:\\mathbb{Z}/n} k^{\\gcd(n,r.\\text{val})} = \\#\\big(\\text{orbitRel.Quotient }(Rot\\,n)\\,(Rot\\,n\\to\\text{Fin }k)\\big)\\cdot n$; rewriting it backwards exposes the Burnside sum, which (E) then rewrites to the divisor form. The conclusion $(\\#\\text{necklaces})\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$ is the textbook cyclic necklace count: dividing by $n$ yields $(1/n)\\sum_{d\\mid n}\\varphi(n/d)\\,k^d$, the formula in every combinatorics text — now grounded in the same Burnside machinery rather than derived separately.",
+    "mathContext": "$\\#\\text{necklaces}\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d \\;\\Longrightarrow\\; \\#\\text{necklaces} = \\tfrac1n\\sum_{d\\mid n}\\varphi(n/d)\\,k^d$",
+    "significance": "key",
+    "relatedConcepts": ["orbit counting", "necklace polynomial", "Burnside average", "quotient by group action"],
+    "prerequisites": ["orbit-stabilizer / Burnside's lemma", "the parent integer-form total"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/index.ts
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BurnsideCountingOQ03OQ02OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const burnsideCountingOq03Oq02Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const burnsideCountingOq03Oq02Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const burnsideCountingOq03Oq02Oq01Oq02Data: ProofData = {
+  proof: burnsideCountingOq03Oq02Oq01Oq02Proof,
+  annotations: burnsideCountingOq03Oq02Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-03-oq-02-oq-01-oq-02`.

**Critical fix:** this entry was missing both `index.ts` and `annotations.json`. Without `index.ts`, Vite's `import.meta.glob` cannot discover the proof, so the page showed *'proof not found'* on the live site despite appearing in the gallery listing.

Changes:
- **Created `index.ts`** — the required Vite entry point (loads meta.json, annotations.json, and the raw Lean source for `BurnsideCountingOQ03OQ02OQ01OQ02.lean`).
- **Created `annotations.json`** with 6 substantive annotations covering the full 105-line proof:
  1. Docstring / open-question framing (answering the parent's openQuestions[1])
  2. Imports + the reused parent lemma `sum_pow_gcd_eq_card_necklaces_mul`
  3. Fiberwise regrouping of `range n` along `gcd(n,·)` via `Finset.sum_fiberwise_of_maps_to'`
  4. The φ(n/d) fiber-count via `Nat.totient_div_of_dvd` (Gauss's counting)
  5. Transport to `ZMod n` via `Finset.sum_bij'` along the `val ≃ range` bijection
  6. The textbook necklace count (F) as a divisor sum

All annotations include `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, and are checked against the actual Lean source line-by-line.

Status unchanged: `verified` / `original`, 0 sorries, 0 axioms. JSON validated; pnpm data-enrichment step passes (the tsc failure is the known node_modules-absent-in-worktree environmental issue).