### PR TITLE
audit(gallery): 8 proofs CLEAN — abel-ruffini/area-circle/beta/bezout/burnside/derangements/dini/quadratic-reciprocity

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23679,8 +23679,56 @@
       "issues": [],
       "lastAudited": "2026-06-25T10:02:26Z",
       "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-07-oq-05-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "bezout-identity-oq-03-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "burnside-counting-oq-03-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "derangements-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "dini-theorem-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
+    },
+    "quadratic-reciprocity-algorithm-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T10:50:06Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T10:02:26Z"
+  "lastUpdated": "2026-06-25T10:50:06Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 8 proofs CLEAN

Audited 8 previously-unaudited gallery entries against `origin/main` Lean source. All pass every integrity check.

| Slug | status/badge | thm | Verdict |
|------|--------------|-----|---------|
| abel-ruffini-oq-04-oq-01-oq-01 | verified/original | 10 | clean |
| area-of-circle-oq-07-oq-05-oq-02 | verified/mathlib | 4 | clean |
| beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02 | verified/original | 4 | clean |
| bezout-identity-oq-03-oq-01-oq-02-oq-01 | verified/original | 12 | clean |
| burnside-counting-oq-03-oq-02-oq-01-oq-02 | verified/original | 3 | clean |
| derangements-oq-02-oq-01-oq-01 | verified/original | 4 | clean |
| dini-theorem-oq-01-oq-02-oq-01-oq-01 | verified/original | 6 | clean |
| quadratic-reciprocity-algorithm-oq-03-oq-01 | verified/mathlib | 2 | clean |

### Checks (comment-stripped, nesting-aware)
- **0 sorry / 0 admit / 0 axiom declarations / 0 native_decide / 0 True-stubs** in all 8 files.
- **No structures/classes** → no structure-encoded assumptions hiding behind a 0-axiom claim.
- Badge appropriateness:
  - 6 `original` entries prove bespoke self-contained results (no single Mathlib headline theorem doing the core work).
  - 2 `mathlib` entries correctly disclose Mathlib reliance. The quadratic-reciprocity capstone is exemplary: it explicitly leans on `legendreSym.quadratic_reciprocity` for the arithmetic side and scopes the genuinely-new Zolotarev grid-transpose sign equality in `originalContributions`.

6 of these were audited clean previously in #29894 but the tracker rows never landed; this PR records all 8 so they leave the unaudited queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
