### PR TITLE
research: Mathlib's generic zmodCyclicMulEquiv = the explicit Gal(ℂ/ℝ) iso (generator = conjAe)

### DIFF
--- a/proofs/Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02.lean
+++ b/proofs/Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02.lean
@@ -1,0 +1,111 @@
+import Mathlib
+import Proofs.FundamentalTheoremAlgebraOQ04OQ03OQ01
+
+/-
+# Identifying the explicit `Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2)` with Mathlib's generic iso
+
+## What This Proves
+
+This is the leaf `oq-04-oq-03-oq-01-oq-02` of `fundamental-theorem-algebra-oq-04`.
+The parent leaf `FundamentalTheoremAlgebraOQ04OQ03OQ01` built, *by hand and with
+the generator named*, the isomorphism
+
+  `galoisGroupEquivZMod2 : (ℂ ≃ₐ[ℝ] ℂ) ≃* Multiplicative (ZMod 2)`,
+
+sending complex conjugation `Complex.conjAe` to the nontrivial element `ofAdd 1`.
+Mathlib also offers a *generic* construction `zmodCyclicMulEquiv`, which for any
+cyclic group `G` produces `Multiplicative (ZMod (Nat.card G)) ≃* G` — but only by
+`Classical.choice`-ing some generator, so a priori it is opaque about *which*
+automorphism the nontrivial element lands on.
+
+The parent's open question OQ[2] asks to **identify the two**: to show the generic
+Mathlib iso, once specialised to `Gal(ℂ/ℝ)` (where `Nat.card = 2`), coincides with
+the explicit one, and that its canonical generator can be taken to be complex
+conjugation.
+
+The mathematical content is a **rigidity / uniqueness** statement:
+
+* `any_equiv_ofAdd_one` : *every* group isomorphism
+  `e : Multiplicative (ZMod 2) ≃* (ℂ ≃ₐ[ℝ] ℂ)` sends the generator `ofAdd 1` to
+  `Complex.conjAe`. (A group of order two has a unique non-identity element, and a
+  group iso must carry the unique non-identity element `ofAdd 1` to it.)
+* `eq_galoisGroupEquivZMod2_symm` : *every* such `e` is **equal** to
+  `galoisGroupEquivZMod2.symm`. There is therefore only one isomorphism
+  `Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ)` at all — the explicit one — and any choice
+  of generator made elsewhere is forced to agree with it.
+
+Specialising this rigidity to Mathlib's `zmodCyclicMulEquiv` (transported along
+`|Gal(ℂ/ℝ)| = 2`) yields the requested identification:
+
+* `mathlibGaloisIso_eq` : `zmodCyclicMulEquiv` (so transported) **equals**
+  `galoisGroupEquivZMod2.symm`;
+* `mathlibGaloisIso_ofAdd_one` : its generator `ofAdd 1` maps to `Complex.conjAe`.
+
+Note the rigidity theorems treat the Mathlib iso as an *arbitrary* `e`, so no
+`Classical.choice`-built data has to be unfolded — the cast transporting the type
+along `Nat.card = 2` never needs to reduce.
+
+*Reference:* `Mathlib.GroupTheory.SpecificGroups.Cyclic` (`zmodCyclicMulEquiv`,
+`isCyclic_of_prime_card`); parent leaf `FundamentalTheoremAlgebraOQ04OQ03OQ01`.
+-/
+
+open Complex
+open scoped Classical
+
+namespace FTAGaloisIso
+
+/-! ## `Gal(ℂ/ℝ)` is cyclic -/
+
+/-- **`Gal(ℂ/ℝ)` is cyclic**, being a group of prime order `2`. This is the
+    hypothesis Mathlib's `zmodCyclicMulEquiv` consumes. -/
+instance galoisGroup_isCyclic : IsCyclic (ℂ ≃ₐ[ℝ] ℂ) :=
+  isCyclic_of_prime_card card_galoisGroup_eq_two
+
+/-! ## Rigidity of order-two isomorphisms -/
+
+/-- **Every** isomorphism `Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ)` sends the generator
+    `ofAdd 1` to complex conjugation. The non-identity element `ofAdd 1` must map to a
+    non-identity automorphism, and `Complex.conjAe` is the only one. -/
+theorem any_equiv_ofAdd_one (e : Multiplicative (ZMod 2) ≃* (ℂ ≃ₐ[ℝ] ℂ)) :
+    e (Multiplicative.ofAdd 1) = Complex.conjAe := by
+  rcases eq_one_or_conjAe (e (Multiplicative.ofAdd 1)) with h | h
+  · -- `e (ofAdd 1) = 1` would force `ofAdd 1 = 1` by injectivity, impossible.
+    exfalso
+    have hbad : Multiplicative.ofAdd (1 : ZMod 2) = 1 :=
+      e.injective (h.trans (map_one e).symm)
+    exact ofAdd_one_ne_one hbad
+  · exact h
+
+/-- **Uniqueness of the order-two iso.** Any isomorphism
+    `Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ)` equals the explicit `galoisGroupEquivZMod2.symm`.
+    Both agree on the two elements `1` and `ofAdd 1`. -/
+theorem eq_galoisGroupEquivZMod2_symm (e : Multiplicative (ZMod 2) ≃* (ℂ ≃ₐ[ℝ] ℂ)) :
+    e = galoisGroupEquivZMod2.symm := by
+  ext x
+  rcases zmod2_eq_one_or x with h | h
+  · subst h; simp
+  · subst h
+    rw [any_equiv_ofAdd_one e, galoisGroupEquivZMod2_symm_ofAdd_one]
+
+/-! ## Specialisation to Mathlib's generic `zmodCyclicMulEquiv` -/
+
+/-- **Mathlib's generic cyclic iso, specialised to `Gal(ℂ/ℝ)`.** Transporting
+    `zmodCyclicMulEquiv` along `Nat.card (ℂ ≃ₐ[ℝ] ℂ) = 2` gives an isomorphism
+    `Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ)`. -/
+noncomputable def mathlibGaloisIso : Multiplicative (ZMod 2) ≃* (ℂ ≃ₐ[ℝ] ℂ) :=
+  card_galoisGroup_eq_two ▸ zmodCyclicMulEquiv galoisGroup_isCyclic
+
+/-- **Identification.** Mathlib's generic iso (transported along `|Gal(ℂ/ℝ)| = 2`)
+    is *exactly* the explicit hand-built isomorphism `galoisGroupEquivZMod2.symm`. The
+    `Classical.choice` of a generator hidden inside `zmodCyclicMulEquiv` is therefore
+    forced to be the canonical one. -/
+theorem mathlibGaloisIso_eq : mathlibGaloisIso = galoisGroupEquivZMod2.symm :=
+  eq_galoisGroupEquivZMod2_symm mathlibGaloisIso
+
+/-- **The canonical generator is complex conjugation.** Under Mathlib's generic iso,
+    the generator `ofAdd 1` of `Multiplicative (ZMod 2)` maps to `Complex.conjAe`. -/
+theorem mathlibGaloisIso_ofAdd_one :
+    mathlibGaloisIso (Multiplicative.ofAdd 1) = Complex.conjAe :=
+  any_equiv_ofAdd_one mathlibGaloisIso
+
+end FTAGaloisIso

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-02/meta.json
@@ -1,0 +1,111 @@
+{
+  "id": "fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-02",
+  "slug": "fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-02",
+  "title": "Identifying the Explicit Gal(ℂ/ℝ) Iso with Mathlib's Generic zmodCyclicMulEquiv",
+  "description": "Shows the hand-built isomorphism galoisGroupEquivZMod2 of the parent coincides with Mathlib's generic zmodCyclicMulEquiv once specialised to Gal(ℂ/ℝ). The mathematical content is a rigidity theorem: every group isomorphism Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ) equals galoisGroupEquivZMod2.symm and sends the generator ofAdd 1 to complex conjugation Complex.conjAe. Since Mathlib's zmodCyclicMulEquiv is one such isomorphism, its Classical.choice-built generator is forced to be conjugation — answering the parent's second open question.",
+  "meta": {
+    "author": "Lean Genius (researcher-3)",
+    "sourceUrl": "https://erdosproblems.com",
+    "date": "2026",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02.lean",
+    "tags": [
+      "galois-theory",
+      "complex-conjugation",
+      "cyclic-groups",
+      "group-isomorphism",
+      "rigidity",
+      "uniqueness"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "lineCount": 111,
+    "mathlib_version": "4.26.0",
+    "assumptions": "0 axioms, 0 sorries. Fully machine-checked; all results (any_equiv_ofAdd_one, eq_galoisGroupEquivZMod2_symm, mathlibGaloisIso_eq, mathlibGaloisIso_ofAdd_one) depend only on Lean's foundational axioms (propext, Classical.choice, Quot.sound). Classical.choice enters solely through Mathlib's noncomputable zmodCyclicMulEquiv (which the parent's explicit iso deliberately avoided); it is a foundational axiom and does not count against the 0-axiom status. No `Lean.ofReduceBool` and no `native_decide`: the cyclic instance comes from isCyclic_of_prime_card and the finite checks reuse the parent's kernel `decide`.",
+    "originalContributions": [
+      "any_equiv_ofAdd_one: rigidity — EVERY group isomorphism Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ) sends the generator ofAdd 1 to complex conjugation Complex.conjAe (the unique non-identity element must receive the unique non-identity automorphism)",
+      "eq_galoisGroupEquivZMod2_symm: uniqueness — EVERY such isomorphism equals the parent's explicit galoisGroupEquivZMod2.symm, so there is only one isomorphism Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ) at all",
+      "mathlibGaloisIso: Mathlib's generic zmodCyclicMulEquiv transported along Nat.card (ℂ ≃ₐ[ℝ] ℂ) = 2 into an isomorphism Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ)",
+      "mathlibGaloisIso_eq: the requested identification — Mathlib's generic iso equals the explicit galoisGroupEquivZMod2.symm, so its hidden Classical.choice generator is forced to be the canonical one",
+      "mathlibGaloisIso_ofAdd_one: Mathlib's generic generator ofAdd 1 maps to complex conjugation Complex.conjAe",
+      "galoisGroup_isCyclic: Gal(ℂ/ℝ) is cyclic via isCyclic_of_prime_card applied to |Gal(ℂ/ℝ)| = 2 (the IsCyclic hypothesis zmodCyclicMulEquiv consumes)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry (fundamental-theorem-algebra-oq-04-oq-03-oq-01) built, by hand and with the generator named, the isomorphism galoisGroupEquivZMod2 : Gal(ℂ/ℝ) ≃* Multiplicative (ZMod 2), deliberately avoiding Mathlib's generic zmodCyclicMulEquiv because the latter only produces such an iso after Classical.choice-ing some generator and says nothing about which automorphism the nontrivial element lands on. This entry closes the loop by proving the two constructions are in fact the same map, so the generic generator is pinned to conjugation after all.",
+    "problemStatement": "Identify the parent's hand-built galoisGroupEquivZMod2 with Mathlib's generic zmodCyclicMulEquiv (cyclic group of order 2), up to choice of generator, exhibiting that the canonical generator there can be taken to be complex conjugation (conjAe).",
+    "proofStrategy": "The key observation is that an order-two group has a UNIQUE non-identity element, so there is only one isomorphism Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ). (1) any_equiv_ofAdd_one: for an arbitrary e, the value e(ofAdd 1) is 1 or conjAe by the parent's eq_one_or_conjAe; it cannot be 1 because injectivity of e plus map_one would force ofAdd 1 = 1 (false), so it is conjAe. (2) eq_galoisGroupEquivZMod2_symm: two such isomorphisms agreeing on the two elements 1 (both ↦ 1) and ofAdd 1 (both ↦ conjAe, by (1) and the parent's galoisGroupEquivZMod2_symm_ofAdd_one) are equal by MulEquiv extensionality and zmod2_eq_one_or. (3) Specialise: mathlibGaloisIso is zmodCyclicMulEquiv transported along Nat.card = 2; because the rigidity theorems treat it as an arbitrary e, the type-transport cast never has to reduce — feeding mathlibGaloisIso into (1) and (2) yields the identification with the explicit iso and the conjugation generator.",
+    "keyInsights": [
+      "Rigidity beats construction: for a group of order two there is exactly one isomorphism from Multiplicative (ZMod 2), so naming the generator of any one such map (the parent did, via conjAe) pins down all of them — including Mathlib's choice-built one.",
+      "The non-identity element ofAdd 1 must map to a non-identity automorphism, and Gal(ℂ/ℝ) has a unique one (complex conjugation), so the generator's image is forced.",
+      "Treating zmodCyclicMulEquiv as an opaque arbitrary isomorphism avoids unfolding any Classical.choice data: the cast transporting ZMod (Nat.card G) to ZMod 2 is never reduced, only consumed by a universally-quantified rigidity lemma.",
+      "Identifying a hand-built object with a library object turns a bespoke construction into the canonical one — the explicit iso IS Mathlib's generic iso, with the choice of generator resolved."
+    ],
+    "prerequisites": [
+      "The parent's explicit isomorphism galoisGroupEquivZMod2 and its structure theorem eq_one_or_conjAe",
+      "Mathlib's zmodCyclicMulEquiv and isCyclic_of_prime_card",
+      "Group isomorphism extensionality (MulEquiv.ext) and injectivity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cyclic",
+      "title": "Gal(ℂ/ℝ) is cyclic",
+      "summary": "galoisGroup_isCyclic: the Galois group is cyclic as a group of prime order 2, supplying the IsCyclic hypothesis that Mathlib's zmodCyclicMulEquiv requires.",
+      "startLine": 57,
+      "endLine": 62
+    },
+    {
+      "id": "rigidity",
+      "title": "Rigidity of order-two isomorphisms",
+      "summary": "any_equiv_ofAdd_one (every iso sends the generator to conjugation) and eq_galoisGroupEquivZMod2_symm (every iso equals the explicit galoisGroupEquivZMod2.symm).",
+      "startLine": 64,
+      "endLine": 88
+    },
+    {
+      "id": "specialise",
+      "title": "Specialisation to Mathlib's generic iso",
+      "summary": "mathlibGaloisIso (zmodCyclicMulEquiv transported along |Gal(ℂ/ℝ)| = 2), mathlibGaloisIso_eq (it equals the explicit iso) and mathlibGaloisIso_ofAdd_one (its generator is conjugation).",
+      "startLine": 90,
+      "endLine": 110
+    }
+  ],
+  "conclusion": {
+    "summary": "Mathlib's generic zmodCyclicMulEquiv, specialised to Gal(ℂ/ℝ), is exactly the parent's explicit hand-built isomorphism galoisGroupEquivZMod2.symm, and its canonical generator ofAdd 1 maps to complex conjugation. This holds because an order-two group admits a unique isomorphism from Multiplicative (ZMod 2): the generic construction's Classical.choice of a generator is therefore forced to agree with the canonical conjugation generator.",
+    "implications": "The bespoke isomorphism and the library isomorphism coincide, so results proved with either can be transported to the other for free, and the apparent indeterminacy of zmodCyclicMulEquiv's generator vanishes in the order-two case. The rigidity argument — unique non-identity element forces the generator's image — generalises to identify any order-p (p prime) labelled isomorphism with the generic cyclic one once one nontrivial value is named.",
+    "openQuestions": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "fundamental-theorem-algebra-oq-04-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: the explicit hand-built isomorphism galoisGroupEquivZMod2. This entry answers its second open question by identifying that iso with Mathlib's generic zmodCyclicMulEquiv and showing the generic generator is complex conjugation."
+    }
+  ],
+  "references": [
+    {
+      "key": "Artin1942",
+      "authors": ["E. Artin"],
+      "title": "Galois Theory",
+      "venue": "Notre Dame Mathematical Lectures",
+      "year": "1942",
+      "note": "Classical reference for the Galois theory of ℂ/ℝ."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02.lean",
+    "filePath": "Proofs/FundamentalTheoremAlgebraOQ04OQ03OQ01OQ02.lean",
+    "imports": ["Mathlib", "Proofs.FundamentalTheoremAlgebraOQ04OQ03OQ01"],
+    "opens": ["Complex", "Classical"],
+    "namespace": "FTAGaloisIso",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the second open question of `fundamental-theorem-algebra-oq-04-oq-03-oq-01` (PR #29846): **identify the parent's hand-built `galoisGroupEquivZMod2` with Mathlib's generic `zmodCyclicMulEquiv`, exhibiting that the canonical generator can be taken to be complex conjugation.**

The parent deliberately avoided `zmodCyclicMulEquiv` because it `Classical.choice`-es a generator and is opaque about *which* automorphism the nontrivial element lands on. This entry closes the loop by a **rigidity** argument: an order-two group admits a *unique* isomorphism from `Multiplicative (ZMod 2)`, so the choice-built generator is forced to agree with conjugation.

## Results (`FTAGaloisIso`)

- `any_equiv_ofAdd_one` — **every** iso `Multiplicative (ZMod 2) ≃* Gal(ℂ/ℝ)` sends the generator `ofAdd 1` to `Complex.conjAe`.
- `eq_galoisGroupEquivZMod2_symm` — **every** such iso equals the parent's explicit `galoisGroupEquivZMod2.symm` (uniqueness).
- `mathlibGaloisIso` — `zmodCyclicMulEquiv` transported along `Nat.card (ℂ ≃ₐ[ℝ] ℂ) = 2`.
- `mathlibGaloisIso_eq` — **the identification**: Mathlib's generic iso *equals* the explicit hand-built one.
- `mathlibGaloisIso_ofAdd_one` — its generator maps to complex conjugation.

The rigidity lemmas treat the Mathlib iso as an arbitrary `e`, so the type-transport cast (`ZMod (Nat.card G)` → `ZMod 2`) never has to reduce.

## Verification

- Builds against Mathlib `v4.26.0` (host `lean`, parent olean emitted first).
- `#print axioms` on all four theorems: `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`, no `native_decide`. (`Classical.choice` enters only via Mathlib's noncomputable `zmodCyclicMulEquiv`; it is foundational and does not count against 0-axiom.)
- **verified · 0-axiom · original** — 4 theorems / 1 def / 111 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)