### PR TITLE
Enrich x⁵−x−1 S₅ witness correction (Abel-Ruffini OQ-04-OQ-01-OQ-01)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-the-witness-polynomial",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "definition",
+    "title": "The Quintic q = X⁵ − X − 1 and Its Shape",
+    "content": "q is the Selmer trinomial x⁵ − x − 1 over ℚ, the second textbook quintic with Galois group S₅. q_natDegree (compute_degree!) and q_monic (monicity!) pin the basic shape that every later argument depends on. Monicity matters specifically for the rational root theorem: for a MONIC integer polynomial, any rational root must be an integer dividing the constant term. Here the constant term is −1, so the only candidate rational roots are ±1 — which the next two lemmas eliminate.",
+    "mathContext": "$q = X^5 - X - 1 \\in \\mathbb{Q}[X]$, $\\deg q = 5$, $q$ monic.",
+    "significance": "supporting",
+    "relatedConcepts": ["Selmer trinomial", "monic polynomial", "rational root theorem", "compute_degree", "Abel–Ruffini theorem"],
+    "prerequisites": ["polynomials over a field", "degree of a polynomial"]
+  },
+  {
+    "id": "ann-no-rational-roots",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 75 },
+    "type": "technique",
+    "title": "±1 Are Not Roots ⇒ No Linear Factor Over ℚ",
+    "content": "q_eval_one and q_eval_neg_one compute q(1) = −1 and q(−1) = −1, both nonzero. Combined with monicity (the rational root theorem restricts candidates to ±1), this proves q has no rational root, hence no degree-1 factor over ℚ. This is the first step toward irreducibility, though it is not the whole story: ruling out linear factors does not rule out a (2,3) split into a quadratic times a cubic over ℚ. Full irreducibility is the genuinely hard step, deferred to a mod-3 reduction (documented, not formalized here).",
+    "mathContext": "$q(1) = q(-1) = -1 \\neq 0$; by the monic rational root theorem the only candidates are $\\pm 1$, so $q$ has no rational root.",
+    "significance": "supporting",
+    "relatedConcepts": ["rational root theorem", "irreducibility", "linear factors", "Gauss's lemma"],
+    "prerequisites": ["evaluation of polynomials", "divisibility of integers"]
+  },
+  {
+    "id": "ann-one-real-root-ivt",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 98 },
+    "type": "insight",
+    "title": "A Real Root in (1,2) by the Intermediate Value Theorem",
+    "content": "The real function f(x) = x⁵ − x − 1 is continuous (fun_prop) with f(1) = −1 < 0 < 29 = f(2), so intermediate_value_Ioo delivers a root strictly inside (1,2). This is the crux of the entry's correction: existence is all the IVT gives, but the header's derivative analysis shows this root is UNIQUE. f′(x) = 5x⁴ − 1 has critical points at x = ±5^(−1/4), and the local maximum f(−5^(−1/4)) ≈ −0.465 already sits below the axis — so the curve crosses zero exactly once. One real root means two complex-conjugate pairs, the geometric fact that breaks the parent's argument.",
+    "mathContext": "$f(1) = -1 < 0 < 29 = f(2) \\Rightarrow \\exists x \\in (1,2),\\ f(x) = 0$. Local max $f(-5^{-1/4}) \\approx -0.465 < 0 \\Rightarrow$ exactly one real root.",
+    "significance": "key",
+    "relatedConcepts": ["intermediate value theorem", "continuity", "critical points", "real root counting", "sign of the discriminant"],
+    "prerequisites": ["intermediate value theorem", "first derivative test"]
+  },
+  {
+    "id": "ann-conjugation-is-even",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 98 },
+    "type": "concept",
+    "title": "Why the Parent's Argument Fails: Conjugation Lands in A₅",
+    "content": "With r real roots and (5−r)/2 conjugate pairs, complex conjugation permutes the five roots as a product of (5−r)/2 disjoint transpositions. For the parent x⁵ − 4x + 2 (r = 3) that is ONE transposition — an odd permutation, the engine that forces Gal ⊄ A₅. For x⁵ − x − 1 (r = 1) it is TWO transpositions — a (2,2) double transposition, which is EVEN and lies in A₅. So conjugation supplies no parity information here and the parent's route collapses. A correct S₅ proof must obtain a transposition elsewhere: via Dedekind's theorem mod 2, where q ≡ (x²+x+1)(x³+x²+1) gives Frobenius cycle type (2,3) whose cube is a transposition, with mod-3 irreducibility supplying a 5-cycle.",
+    "mathContext": "$r=1 \\Rightarrow$ conjugation $= (2,2)$ double transposition $\\in A_5$ (even); $r=3 \\Rightarrow$ single transposition $\\notin A_5$ (odd).",
+    "significance": "key",
+    "relatedConcepts": ["complex conjugation as a permutation", "alternating group A₅", "parity of permutations", "Dedekind's theorem", "Frobenius cycle type"],
+    "prerequisites": ["Galois theory", "symmetric and alternating groups", "cycle decomposition"]
+  },
+  {
+    "id": "ann-discriminant-value",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 103 },
+    "type": "technique",
+    "title": "The Bring–Jerrard Discriminant Value 2869",
+    "content": "For a depressed quintic x⁵ + px + q the discriminant is 256p⁵ + 3125q⁴. At (p,q) = (−1,−1) this is 256·(−1)⁵ + 3125·(−1)⁴ = −256 + 3125 = 2869. The sign is the consistency check: a quintic with an even number of conjugate pairs has positive discriminant, and indeed 2869 > 0 matches the two-conjugate-pair geometry (whereas the parent's x⁵ − 4x + 2 has negative discriminant, one conjugate pair). The discriminant being a perfect square is exactly the criterion Gal ⊆ A₅; the next lemma shows it is not.",
+    "mathContext": "$\\Delta = 256p^5 + 3125q^4 \\big|_{(p,q)=(-1,-1)} = -256 + 3125 = 2869 > 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["discriminant of a polynomial", "Bring–Jerrard form", "depressed quintic", "sign of the discriminant", "real-root parity"],
+    "prerequisites": ["discriminant", "elementary symmetric functions"]
+  },
+  {
+    "id": "ann-nonsquare-finite-check",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 110 },
+    "type": "technique",
+    "title": "2869 Is Not a Perfect Square ⇒ Gal ⊄ A₅",
+    "content": "not_isSquare_2869 rules out r·r = 2869 by a finite search: any root r satisfies r ≤ 53 (since 54² = 2916 > 2869), bounded by nlinarith, then interval_cases r exhausts r = 0..53 and omega kills each case (53² = 2809, 54² = 2916, so 2869 falls strictly between consecutive squares). A non-square discriminant means the Galois group is NOT contained in the alternating group A₅ — consistent with the full group being S₅. This is a kernel-checked decision (no native_decide), keeping the entry at 0 axioms beyond propext/Classical.choice/Quot.sound.",
+    "mathContext": "$53^2 = 2809 < 2869 < 2916 = 54^2 \\Rightarrow 2869 \\notin \\{n^2\\}$; non-square $\\Delta \\Rightarrow \\mathrm{Gal} \\not\\subseteq A_5.$",
+    "significance": "key",
+    "relatedConcepts": ["perfect squares", "discriminant criterion for A₅", "interval_cases", "decidable finite search", "Galois group membership"],
+    "prerequisites": ["square numbers", "bounded case analysis"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq01Oq01Data: ProofData = {
+  proof: abelRuffiniOq04Oq01Oq01Proof,
+  annotations: abelRuffiniOq04Oq01Oq01Annotations,
+}

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01/meta.json
@@ -31,27 +31,55 @@
     }
   ],
   "overview": {
-    "historicalContext": "Selmer (1956) noted x⁵ - x - 1 as a clean example of an irreducible quintic with Galois group S₅, hence unsolvable by radicals. It is a recurring textbook witness alongside x⁵ - 4x + 2. The two polynomials differ in real-root geometry: x⁵ - 4x + 2 has three real roots and one conjugate pair (discriminant negative), while x⁵ - x - 1 has one real root and two conjugate pairs (discriminant positive, 2869 = 19·151). This difference is exactly what makes the parent's complex-conjugation argument inapplicable to x⁵ - x - 1.",
-    "keyInsight": "Real-root count controls the cycle type of complex conjugation. With r real roots and (5-r)/2 conjugate pairs, complex conjugation is a product of (5-r)/2 transpositions. For x⁵ - 4x + 2 (r = 3) that is one transposition — odd, the engine of the parent proof. For x⁵ - x - 1 (r = 1) it is two transpositions — an even element of A₅, useless for proving Gal ⊄ A₅ via parity. The discriminant agrees: it is negative for the parent (odd number of conjugate pairs) and the positive non-square 2869 here.",
-    "proofStrategy": "Document the obstruction and machine-check the elementary supporting facts that any future S₅ proof for x⁵ - x - 1 will reuse: the polynomial is monic of degree 5; ±1 (the only candidate rational roots of a monic integer polynomial with constant term -1) are not roots; a real root exists in (1,2) by the intermediate value theorem; the Bring-Jerrard discriminant formula 256p⁵ + 3125q⁴ evaluates to 2869 at (p,q) = (-1,-1); and 2869 is not a perfect square."
+    "historicalContext": "Selmer (1956) noted x⁵ - x - 1 as a clean example of an irreducible quintic with Galois group S₅, hence unsolvable by radicals — a result that traces back to the Abel–Ruffini theorem (Ruffini 1799, Abel 1824) on the non-existence of a radical formula for the general quintic, made effective by Galois's correspondence between field automorphisms and permutation groups. x⁵ - x - 1 is a recurring textbook witness alongside x⁵ - 4x + 2. The two polynomials differ in real-root geometry: x⁵ - 4x + 2 has three real roots and one conjugate pair (discriminant negative), while x⁵ - x - 1 has one real root and two conjugate pairs (discriminant positive, 2869 = 19·151). This difference is exactly what makes the parent's complex-conjugation argument inapplicable to x⁵ - x - 1.",
+    "problemStatement": "The parent entry (abel-ruffini-oq-04-oq-01) proves Gal(x⁵ - 4x + 2) ≅ S₅ and asks, as its first open question, whether x⁵ - x - 1 is a second concrete S₅ witness handled 'by the same argument used here' after a sign analysis claiming '3 real roots'. Formally: is the complex-conjugation step that supplies a transposition for x⁵ - 4x + 2 reusable for q = x⁵ - x - 1? This entry answers no, and machine-checks the elementary facts a correct proof would reuse: $q = X^5 - X - 1$ is monic of degree 5, has no rational root, has a real root in $(1,2)$, and has discriminant $\\Delta = 2869$, a non-square.",
+    "proofStrategy": "Document the obstruction and machine-check the elementary supporting facts that any future S₅ proof for x⁵ - x - 1 will reuse: the polynomial is monic of degree 5; ±1 (the only candidate rational roots of a monic integer polynomial with constant term -1) are not roots; a real root exists in (1,2) by the intermediate value theorem; the Bring-Jerrard discriminant formula 256p⁵ + 3125q⁴ evaluates to 2869 at (p,q) = (-1,-1); and 2869 is not a perfect square.",
+    "keyInsights": [
+      "Real-root count controls the cycle type of complex conjugation. With r real roots and (5-r)/2 conjugate pairs, complex conjugation is a product of (5-r)/2 transpositions. For x⁵ - 4x + 2 (r = 3) that is one transposition — odd, the engine of the parent proof. For x⁵ - x - 1 (r = 1) it is two transpositions — an even element of A₅, useless for proving Gal ⊄ A₅ via parity.",
+      "The discriminant's sign agrees with the geometry: it is negative for the parent (odd number of conjugate pairs) and the positive non-square 2869 here (even number of conjugate pairs). A non-square discriminant is exactly the criterion Gal ⊄ A₅, so the parity obstruction and the discriminant tell a consistent story.",
+      "The one-real-root fact is a derivative statement, not an IVT statement: f′(x) = 5x⁴ − 1 has critical points at ±5^(−1/4), and the local maximum f(−5^(−1/4)) ≈ −0.465 already lies below the axis, forcing exactly one crossing. The IVT only certifies existence; uniqueness needs the calculus.",
+      "The correct transposition comes from arithmetic, not geometry: Dedekind's theorem applied to q ≡ (x²+x+1)(x³+x²+1) (mod 2) yields Frobenius cycle type (2,3), whose cube is a transposition, while irreducibility mod 3 supplies a 5-cycle. A transposition and a 5-cycle generate S₅ — the route that does transfer.",
+      "An open question in a verified gallery entry can be wrong. The discipline of separating 'documented/argued' from 'machine-checked' lets this entry correct a sibling's stated premise without overclaiming the hard irreducibility result it does not formalize."
+    ]
   },
   "sections": [
     {
-      "title": "The parent's open question and why its premise is false",
-      "content": "The parent (abel-ruffini-oq-04-oq-01) closes by asking whether x⁵ - x - 1 is a second concrete S₅ witness, asserting that 'sign analysis shows 3 real roots, giving Gal ≅ S₅ by the same argument used here.' Numerically and by calculus this is wrong: f(x) = x⁵ - x - 1 has critical points at x = ±5^(-1/4) ≈ ±0.6687, and the local maximum f(-5^(-1/4)) = -(5^(-1/4))/5 + 5^(-1/4) - 1 ≈ -0.465 is already negative. A quintic whose local maximum is below the axis crosses it exactly once, so x⁵ - x - 1 has exactly ONE real root and two complex-conjugate pairs."
+      "id": "witness-polynomial",
+      "title": "The witness polynomial and its shape",
+      "startLine": 57,
+      "endLine": 67,
+      "summary": "Defines q = X⁵ − X − 1 over ℚ and machine-checks degree 5 (compute_degree!) and monicity (monicity!). Monicity is what licenses the rational root theorem: any rational root of a monic integer polynomial is an integer dividing the constant term −1, so the only candidates are ±1."
     },
     {
-      "title": "Consequence for the Galois argument",
-      "content": "The parent obtains an odd permutation in the Galois group from complex conjugation: with three real roots and one conjugate pair, conjugation swaps a single pair — a transposition (odd). For x⁵ - x - 1 conjugation swaps two pairs simultaneously — a (2,2) double transposition, which is EVEN and lies in A₅. Thus conjugation gives no parity information here and the parent's route to Gal ⊄ A₅ collapses. A correct proof must supply a transposition differently, e.g. via Dedekind's theorem: x⁵ - x - 1 ≡ (x²+x+1)(x³+x²+1) (mod 2) has Frobenius cycle type (2,3), whose cube is a transposition, while x⁵ - x - 1 stays irreducible mod 3, supplying a 5-cycle; a transposition and a 5-cycle generate S₅."
+      "id": "no-rational-roots",
+      "title": "±1 are not roots ⇒ no linear factor over ℚ",
+      "startLine": 69,
+      "endLine": 75,
+      "summary": "q_eval_one and q_eval_neg_one compute q(1) = q(−1) = −1 ≠ 0. With monicity restricting candidates to ±1, q has no rational root and hence no degree-1 factor over ℚ — the first step toward (but not the whole of) irreducibility."
     },
     {
-      "title": "Machine-checked supporting facts",
-      "content": "q_natDegree and q_monic fix the shape; q_eval_one and q_eval_neg_one show ±1 are not roots (these are the only candidate rational roots of a monic ℤ-polynomial with constant term -1, so x⁵ - x - 1 has no rational root and no linear factor over ℚ); exists_real_root_Ioo proves a real root lies in (1,2) by the intermediate value theorem; disc_value records 256·(-1)⁵ + 3125·(-1)⁴ = 2869; not_isSquare_2869 shows 2869 is not a perfect square, so the discriminant is a non-square and Gal ⊄ A₅ — consistent with S₅."
+      "id": "one-real-root",
+      "title": "A real root in (1,2) and why there is only one",
+      "startLine": 77,
+      "endLine": 98,
+      "summary": "f(x) = x⁵ − x − 1 is continuous with f(1) = −1 < 0 < 29 = f(2), so intermediate_value_Ioo gives a root in (1,2). The header's derivative analysis (local maximum f(−5^(−1/4)) ≈ −0.465 < 0) upgrades existence to exactly one real root, hence two complex-conjugate pairs — the geometric fact that defeats the parent's argument."
+    },
+    {
+      "id": "discriminant",
+      "title": "The discriminant 2869 and the A₅ criterion",
+      "startLine": 100,
+      "endLine": 110,
+      "summary": "disc_value computes the Bring–Jerrard discriminant 256·(−1)⁵ + 3125·(−1)⁴ = 2869 > 0 (positive, matching two conjugate pairs); not_isSquare_2869 rules out r·r = 2869 by a bounded finite search (r ≤ 53, interval_cases, omega). A non-square discriminant means Gal ⊄ A₅ — consistent with the full group S₅."
     }
   ],
   "conclusion": {
     "summary": "This entry corrects the parent's first open question: x⁵ - x - 1 is indeed an S₅ witness, but NOT 'by the same argument used here'. It has one real root, not three, so complex conjugation is an even double transposition and the parent's parity argument does not transfer. The elementary facts a future S₅ proof will need are machine-checked with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound; no native_decide).",
-    "implications": "Distinguishes two textbook S₅ quintics by their real-root geometry and identifies the precise step (transposition from conjugation) that fails for the one-real-root case. The correct route is flagged (Dedekind mod 2 for the transposition, mod 3 irreducibility for the 5-cycle).",
+    "implications": "Distinguishes two textbook S₅ quintics by their real-root geometry and identifies the precise step (transposition from conjugation) that fails for the one-real-root case. The correct route is flagged (Dedekind mod 2 for the transposition, mod 3 irreducibility for the 5-cycle). More broadly it shows how a gallery entry can audit and correct the stated assumptions of a sibling entry while staying scrupulous about what is and is not formalized.",
+    "openQuestions": [
+      "Can the full Gal(x⁵ - x - 1) ≅ S₅ be formalized via the Dedekind route — a transposition from the mod-2 factorization (2,3) cycle type and a 5-cycle from mod-3 irreducibility — within Mathlib's current Galois-theory API?",
+      "Is there a cheap Lean decision procedure for irreducibility of x⁵ - x - 1 over 𝔽₃ (and hence over ℚ), or does it require a hand proof that no quadratic·cubic factorization exists?",
+      "Can 'exactly one real root' be promoted from the documented derivative sketch to a machine-checked theorem (e.g. via strict monotonicity outside the critical interval plus the negative local maximum)?"
+    ],
     "honestStatement": "Gal(x⁵ - x - 1) ≅ S₅ is NOT proved in this entry. Irreducibility of x⁵ - x - 1 over ℚ and the exact real-root count (= 1) are documented and argued but not formalized as Lean theorems this session (Aristotle was unavailable; Mathlib offers no cheap decision procedure for irreducibility over 𝔽₃). Only the listed elementary facts are machine-checked."
   },
   "mainTheorems": [


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-01`.

**Critical fix:** added missing `index.ts` — without it the proof page renders 'proof not found' on the live site despite appearing in the gallery listing.

**Additions:**
- `annotations.json` (new): 6 substantive annotations covering the full Lean file (witness polynomial & shape, no rational roots, IVT real root + uniqueness, conjugation-lands-in-A₅ obstruction, Bring–Jerrard discriminant 2869, non-square finite check). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- `meta.json` schema conformance: `overview.keyInsight` → `keyInsights` array (5 insights); added `overview.problemStatement`; `sections` converted to `id/startLine/endLine/summary` (4 sections, full file coverage); added `conclusion.openQuestions` (3) flagging the Dedekind-route formalization gap.

**Axiom integrity:** `status: verified`, `badge: original`, `axiomCount: 0` confirmed against the Lean file (only propext/Classical.choice/Quot.sound; no native_decide, no structure-encoded assumptions). Entry honestly does NOT claim Gal(x⁵−x−1) ≅ S₅; preserved in `honestStatement`.