### PR TITLE
Enrich Dini Modulus Optimality (OQ-01-02-01-01): add index.ts + annotations

### DIFF
--- a/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/dini-theorem-oq-01-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DiniTheoremOQ01OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const diniTheoremOq01Oq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const diniTheoremOq01Oq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const diniTheoremOq01Oq02Oq01Oq01Data: ProofData = {
+  proof: diniTheoremOq01Oq02Oq01Oq01Proof,
+  annotations: diniTheoremOq01Oq02Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `dini-theorem-oq-01-oq-02-oq-01-oq-01`.

**Critical fix:** the entry was missing both `index.ts` and `annotations.json` — without `index.ts` the page showed *'proof not found'* on the live site.

Changes:
- **Created `index.ts`** — the Vite entry point for `DiniTheoremOQ01OQ02OQ01OQ01.lean`.
- **Created `annotations.json`** (5 annotations, full-file coverage):
  1. Sufficiency → optimality framing of OQ-01
  2. The sharp no-slack characterisation `pow_le_iff_log_div` (exp-log order-iso + `div_le_iff_of_neg`)
  3. Lifting to the integer modulus via `Nat.ceil_le` (`pow_le_iff_ceil_le`)
  4. The optimality theorem `isLeast_modulus` (IsLeast) + strict minimality
  5. The explicit off-by-one `(1−δ)^{N−1} > ε` (incl. the N ≥ 1 sign computation)

All annotations include `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, checked line-by-line against the Lean source.

Status unchanged: `verified` / `original`, 0 sorries, 0 axioms. JSON validated; pnpm build fails only at the known `tsc: command not found` (node_modules absent in worktree).