### PR TITLE
Enrich x⁵−x−1 Dedekind mod-2 route (Abel–Ruffini OQ-04-01-01-01): index.ts + annotations + depth

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "The Dedekind mod-2 Route to a Transposition",
+    "content": "The header continues the x⁵−x−1 story. The parent (abel-ruffini-oq-04-oq-01-oq-01) showed complex conjugation gives an even (2,2) double transposition — useless for parity — and flagged the mod-2 reduction as the correct source of a transposition. This entry machine-checks the prime-2 input to Dedekind's theorem: $x^5-x-1 \\equiv (x^2+x+1)(x^3+x^2+1)\\pmod 2$, a product of an irreducible quadratic and irreducible cubic. Dedekind reads the factor degrees as the Frobenius cycle type $(2,3)$; the cube of a $(2,3)$-element is a transposition. Combined with a 5-cycle (from the mod-3 reduction, a separate entry), a transposition and a 5-cycle generate $S_5$. Honest scope: Dedekind's theorem itself, the mod-3 5-cycle, and Gal ≅ S₅ are NOT formalized here.",
+    "mathContext": "$x^5-x-1 \\equiv (x^2+x+1)(x^3+x^2+1) \\pmod 2 \\;\\Rightarrow\\; \\text{cycle type }(2,3)$",
+    "significance": "context",
+    "relatedConcepts": ["Dedekind's theorem", "Frobenius cycle type", "transposition", "S₅ generation", "finite fields"],
+    "prerequisites": ["Galois theory", "factorization mod p"]
+  },
+  {
+    "id": "ann-defs",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 57 },
+    "type": "definition",
+    "title": "The Factors and the Reduction over 𝔽₂",
+    "content": "Three definitions in $(\\mathbb{Z}/2)[X]$: the quadratic $a = X^2+X+1$, the cubic $b = X^3+X^2+1$, and the reduction $q_2 = X^5-X-1$. All are `noncomputable` (polynomials over a field). Working directly in $(\\mathbb{Z}/2)[X]$ rather than reducing from $\\mathbb{Z}[X]$ keeps the arithmetic in characteristic two, where the factorization becomes an identity.",
+    "mathContext": "$a=X^2+X+1,\\ b=X^3+X^2+1,\\ q_2=X^5-X-1 \\in (\\mathbb{Z}/2)[X]$",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod 2", "polynomial ring over a field", "reduction mod p"],
+    "prerequisites": ["finite fields", "polynomial rings"]
+  },
+  {
+    "id": "ann-factorization",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 70 },
+    "type": "technique",
+    "title": "The Factorization Is an Identity in Characteristic Two",
+    "content": "`factor_mod2` proves $a\\cdot b = q_2$. The slick proof avoids expanding by hand: it forms the difference $(X^2+X+1)(X^3+X^2+1) - (X^5-X-1)$ and shows by `ring` that it equals $2\\cdot(X^4+X^3+X^2+X+1)$ — a ring identity valid over any commutative ring. Then `CharTwo.two_eq_zero` (available since $(\\mathbb{Z}/2)[X]$ inherits `CharP _ 2`) kills the factor 2, so the difference is 0 and `sub_eq_zero.mp` concludes equality. Equivalently $x^5-x-1 \\equiv x^5+x+1$ mod 2: the cross terms simply vanish.",
+    "mathContext": "$(X^2+X+1)(X^3+X^2+1)-(X^5-X-1)=2(X^4+X^3+X^2+X+1)\\xrightarrow{\\mathrm{char}\\,2}0$",
+    "significance": "key",
+    "relatedConcepts": ["characteristic two", "CharTwo.two_eq_zero", "ring tactic", "sub_eq_zero"],
+    "prerequisites": ["characteristic of a ring", "ring identities"]
+  },
+  {
+    "id": "ann-irreducible",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 104 },
+    "type": "technique",
+    "title": "Both Factors Irreducible: Degree ≤ 3 with No Root",
+    "content": "Over a field, a polynomial of degree 2 or 3 is irreducible iff it has no root (a nontrivial factorization would force a linear factor, i.e. a root). `quadratic_natDegree`/`cubic_natDegree` fix the degrees (2, 3) via `compute_degree!`. `quadratic_no_roots`/`cubic_no_roots` check no root exists by `fin_cases` over the two elements of $\\mathbb{Z}/2$, simplifying `eval` and closing with `decide` (kernel decision — note: not `native_decide`, so axiom-clean). `quadratic_irreducible`/`cubic_irreducible` then invoke Mathlib's `irreducible_of_degree_le_three_of_not_isRoot`, supplying the degree bound (via `Finset.mem_Icc` + `omega`) and the no-root hypothesis.",
+    "mathContext": "$\\deg p\\in\\{2,3\\} \\wedge p \\text{ has no root over a field} \\Rightarrow p \\text{ irreducible}$",
+    "significance": "key",
+    "relatedConcepts": ["irreducibility criterion", "irreducible_of_degree_le_three_of_not_isRoot", "fin_cases", "kernel decide"],
+    "prerequisites": ["irreducibility over fields", "low-degree factorization"]
+  },
+  {
+    "id": "ann-distinct",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 116 },
+    "type": "insight",
+    "title": "Distinct Factors ⟹ Squarefree ⟹ Cycle Type (2,3)",
+    "content": "`factors_not_associated` proves $a$ and $b$ are not associate: associated polynomials have equal degree (`degree_eq_degree_of_associated` → `natDegree_eq_of_degree_eq`), but $2\\ne 3$ (`norm_num`). Distinct irreducible factors mean the mod-2 factorization is squarefree — precisely the input Dedekind's theorem requires to read the factor degrees as the Frobenius cycle type $(2,3)$. This is the conceptual payoff: a squarefree factorization into a quadratic and a cubic over $\\mathbb{F}_2$ certifies an element of cycle type $(2,3)$ in the Galois group, whose cube is the sought transposition.",
+    "mathContext": "$\\neg\\,\\mathrm{Associated}\\,a\\,b \\;(\\deg 2\\neq\\deg 3) \\Rightarrow \\text{squarefree} \\Rightarrow \\text{Frobenius cycle type }(2,3)$",
+    "significance": "key",
+    "relatedConcepts": ["associated polynomials", "squarefree factorization", "Frobenius element", "cycle type"],
+    "prerequisites": ["associates in a ring", "Dedekind's theorem (conceptual)"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq01Oq01Oq01Data: ProofData = {
+  proof: abelRuffiniOq04Oq01Oq01Oq01Proof,
+  annotations: abelRuffiniOq04Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -34,26 +34,58 @@
   "overview": {
     "historicalContext": "Dedekind's theorem (1878) links the factorization of an integer polynomial modulo an unramified prime p to the cycle type of the corresponding Frobenius element in the Galois group acting on the roots: the degrees of the distinct irreducible factors mod p are the cycle lengths. For x⁵ - x - 1 the prime p = 2 is the smallest convenient prime: the reduction factors as a quadratic times a cubic, both irreducible, giving cycle type (2,3). This is the standard textbook computation (Selmer 1956; van der Waerden) used to certify the Galois group is S₅.",
     "keyInsight": "Over 𝔽₂ the additive bookkeeping is trivial: expanding (x²+x+1)(x³+x²+1) produces x⁵ + 2x⁴ + 2x³ + 2x² + x + 1, and the three coefficient-2 cross terms vanish in characteristic two, leaving x⁵ + x + 1 = x⁵ - x - 1. Both factors avoid the only two field elements 0 and 1 as roots, so — being of degree ≤ 3 over a field — they are irreducible. Because the factors have different degrees they are not associate, so the factorization is squarefree: the precise input Dedekind's theorem needs to declare the cycle type (2,3) for Frobenius at 2.",
+    "keyInsights": [
+      "Characteristic two does the algebra for free: the difference between the product and the quintic is exactly 2·(x⁴+x³+x²+x+1), and the leading 2 vanishes — so the factorization is a clean identity rather than a tedious coefficient match.",
+      "For degree ≤ 3 over a field, irreducibility is equivalent to having no root, because any nontrivial factor would have to be linear. This reduces both irreducibility proofs to a two-element case check (fin_cases over 𝔽₂) closed by kernel decide.",
+      "Distinctness of the factors is the load-bearing fact for Dedekind: different degrees ⟹ not associate ⟹ squarefree factorization, and only a squarefree factorization lets the theorem read the degrees as cycle lengths (2,3) rather than a repeated-factor cycle structure.",
+      "The cube of a (2,3)-element is a transposition: this is exactly the odd permutation the parent's complex-conjugation argument failed to produce, so the mod-2 certificate repairs the parent's broken parity step by an arithmetic route.",
+      "kernel decide (not native_decide) keeps the entry axiom-clean — #print axioms shows only propext/Classical.choice/Quot.sound, with no Lean.ofReduceBool — so the 'verified/original' badge is honest."
+    ],
     "proofStrategy": "Work entirely inside (ZMod 2)[X]. (1) Prove the factorization by subtracting the two sides, observing the difference is 2·(x⁴+x³+x²+x+1) by ring, and killing the factor 2 with CharTwo.two_eq_zero. (2) Pin both factor degrees with compute_degree!. (3) Show neither factor has a root by case-splitting on the two elements of ZMod 2 (fin_cases) and reducing eval with the standard simp lemmas, then decide. (4) Conclude irreducibility via Polynomial.irreducible_of_degree_le_three_of_not_isRoot. (5) Rule out associate factors by comparing degrees (degree_eq_degree_of_associated)."
   },
   "sections": [
     {
-      "title": "The factorization in characteristic two",
-      "content": "factor_mod2 proves a·b = q2 in (ZMod 2)[X], where a = x²+x+1, b = x³+x²+1 and q2 = x⁵-x-1. The proof subtracts the sides: (x²+x+1)(x³+x²+1) − (x⁵-x-1) = 2·(x⁴+x³+x²+x+1) as a ring identity over any commutative ring, and the leading factor 2 is zero in characteristic two (CharTwo.two_eq_zero, available because (ZMod 2)[X] inherits CharP _ 2 from ZMod 2). So the difference is 0 and the two polynomials agree. Equivalently x⁵-x-1 ≡ x⁵+x+1 mod 2."
+      "id": "definitions",
+      "title": "The Factors and Reduction over 𝔽₂",
+      "startLine": 44,
+      "endLine": 57,
+      "summary": "Defines a = X²+X+1, b = X³+X²+1, and q2 = X⁵−X−1 in (ZMod 2)[X], working directly in characteristic two so the factorization becomes an identity.",
+      "mathContext": "$a,b,q_2 \\in (\\mathbb{Z}/2)[X]$"
     },
     {
-      "title": "Both factors are irreducible over 𝔽₂",
-      "content": "quadratic_natDegree and cubic_natDegree fix the degrees (2 and 3) via compute_degree!. quadratic_no_roots and cubic_no_roots check, by fin_cases over the two elements of ZMod 2, that each factor evaluates to 1 (never 0) — so neither has a root. For a polynomial of degree 2 or 3 over a field, having no root is equivalent to irreducibility, which Mathlib packages as Polynomial.irreducible_of_degree_le_three_of_not_isRoot; quadratic_irreducible and cubic_irreducible apply it."
+      "id": "factorization",
+      "title": "The Factorization in Characteristic Two",
+      "startLine": 59,
+      "endLine": 70,
+      "summary": "factor_mod2 proves a·b = q2: the difference (X²+X+1)(X³+X²+1) − (X⁵−X−1) equals 2·(X⁴+X³+X²+X+1) by ring, and CharTwo.two_eq_zero kills the factor 2, so the polynomials agree. Equivalently x⁵−x−1 ≡ x⁵+x+1 mod 2.",
+      "mathContext": "$ab - q_2 = 2(X^4+X^3+X^2+X+1) \\xrightarrow{\\mathrm{char}\\,2} 0$"
     },
     {
-      "title": "Distinct factors and the Dedekind conclusion",
-      "content": "factors_not_associated shows the quadratic and cubic are not associate: associate polynomials have equal degree (degree_eq_degree_of_associated), but 2 ≠ 3. So x⁵-x-1 mod 2 is a product of two DISTINCT irreducible factors — a squarefree factorization. Dedekind's theorem (not itself formalized in Mathlib) then reads the degrees off as the Frobenius cycle type (2,3). The cube of an element of cycle type (2,3) is a transposition: this supplies the odd permutation the parent's complex-conjugation argument could not, and together with a 5-cycle (from the mod-3 reduction, a separate entry) it generates S₅."
+      "id": "irreducibility",
+      "title": "Both Factors Irreducible over 𝔽₂",
+      "startLine": 72,
+      "endLine": 104,
+      "summary": "quadratic_natDegree/cubic_natDegree fix the degrees (compute_degree!); quadratic_no_roots/cubic_no_roots check no root by fin_cases over ZMod 2 + decide; quadratic_irreducible/cubic_irreducible conclude via irreducible_of_degree_le_three_of_not_isRoot (degree ≤ 3, no root ⟹ irreducible over a field).",
+      "mathContext": "$\\deg\\in\\{2,3\\}\\wedge\\text{no root}\\Rightarrow\\text{irreducible}$"
+    },
+    {
+      "id": "distinct-dedekind",
+      "title": "Distinct Factors and the Dedekind Conclusion",
+      "startLine": 106,
+      "endLine": 116,
+      "summary": "factors_not_associated: the quadratic and cubic are not associate (degrees 2 ≠ 3 via degree_eq_degree_of_associated), so the mod-2 factorization is into DISTINCT irreducibles — a squarefree factorization. Dedekind's theorem then reads the degrees as Frobenius cycle type (2,3), whose cube is a transposition.",
+      "mathContext": "$\\neg\\,\\mathrm{Associated}\\,a\\,b \\Rightarrow \\text{squarefree} \\Rightarrow \\text{cycle type }(2,3)$"
     }
   ],
   "conclusion": {
     "summary": "Formalizes the prime-2 half of the Dedekind certificate for Gal(x⁵ - x - 1) ≅ S₅: the mod-2 factorization (x²+x+1)(x³+x²+1) into two distinct irreducibles, hence Frobenius cycle type (2,3). All six theorems are machine-checked with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound; no native_decide).",
     "implications": "Turns the parent's documented sketch into checked Lean: the transposition route via Dedekind mod 2 now has its concrete hypotheses verified. The remaining gaps toward the full S₅ statement are Dedekind's theorem itself (absent from Mathlib) and the mod-3 5-cycle.",
-    "honestStatement": "Gal(x⁵ - x - 1) ≅ S₅ is NOT proved here. Dedekind's theorem is invoked only at the level of its concrete inputs for p = 2; the theorem itself, the mod-3 reduction giving a 5-cycle, and irreducibility of x⁵ - x - 1 over ℚ are not formalized in this entry."
+    "honestStatement": "Gal(x⁵ - x - 1) ≅ S₅ is NOT proved here. Dedekind's theorem is invoked only at the level of its concrete inputs for p = 2; the theorem itself, the mod-3 reduction giving a 5-cycle, and irreducibility of x⁵ - x - 1 over ℚ are not formalized in this entry.",
+    "openQuestions": [
+      "Formalize the companion mod-3 certificate: x⁵ − x − 1 stays irreducible over 𝔽₃, giving a 5-cycle; together with the (2,3)-element here (whose cube is a transposition) this yields generators of S₅.",
+      "Once Dedekind's theorem (or a sufficient special case) lands in Mathlib, connect this squarefree-factorization data to an actual element of Gal(x⁵ − x − 1) of cycle type (2,3), completing the transposition route.",
+      "Generalize the degree-≤-3 no-root irreducibility check into a reusable 'mod-p factorization certificate' tactic that, given a candidate factorization over 𝔽ₚ, verifies the factors are distinct irreducibles and emits the cycle type."
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-01-oq-01-oq-01`.

**Critical fix:** the entry was missing both `index.ts` and `annotations.json` — without `index.ts` the page showed *'proof not found'* on the live site.

Changes:
- **Created `index.ts`** — the Vite entry point for `AbelRuffiniOQ04OQ01OQ01OQ01.lean`.
- **Created `annotations.json`** (5 annotations, full-file coverage): the Dedekind-route framing, the 𝔽₂ definitions, the characteristic-two factorization identity (`factor_mod2`), the degree-≤-3 no-root irreducibility of both factors, and distinct-factors ⟹ squarefree ⟹ cycle type (2,3).
- **Upgraded `meta.json`:**
  - Added `overview.keyInsights` (array of 5) alongside the legacy singular `keyInsight`.
  - Converted `sections` to the standard `{id, title, startLine, endLine, summary, mathContext}` schema covering lines 44–116.
  - Added `conclusion.openQuestions` (3: the mod-3 5-cycle companion, connecting to an actual Galois element once Dedekind lands in Mathlib, and a reusable mod-p certificate tactic).
- All annotations carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, checked line-by-line against the Lean source.

Status unchanged: `verified` / `original`, 0 sorries, 0 axioms (kernel `decide`, not `native_decide`); the entry honestly does not claim Gal ≅ S₅. JSON validated; pnpm build fails only at the known `tsc: command not found` (node_modules absent in worktree).