### PR TITLE
Enrich Positive-Definite Conics vs stdConic (Pascal's Hexagon OQ-03): index.ts + annotations

### DIFF
--- a/src/data/proofs/pascals-hexagon-incomplete-01-oq-03/index.ts
+++ b/src/data/proofs/pascals-hexagon-incomplete-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PascalsHexagonIncomplete01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pascalsHexagonIncomplete01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pascalsHexagonIncomplete01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pascalsHexagonIncomplete01Oq03Data: ProofData = {
+  proof: pascalsHexagonIncomplete01Oq03Proof,
+  annotations: pascalsHexagonIncomplete01Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pascals-hexagon-incomplete-01-oq-03`.

**Critical fix:** the entry was missing both `index.ts` and `annotations.json` — without `index.ts` the page showed *'proof not found'* on the live site.

Changes:
- **Created `index.ts`** — the Vite entry point for `PascalsHexagonIncomplete01OQ03.lean`.
- **Created `annotations.json`** (5 annotations, full-file coverage): the definite-vs-indefinite obstruction framing, the minimal conic API, the `conicQuadraticForm_eq_dotProduct` bridge to Mathlib's `Matrix.PosDef`, the vanishes-only-at-0 anisotropy result, and the main non-equivalence theorem with the parent recovered via `Matrix.PosDef.one`.

All annotations include `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, checked line-by-line against the Lean source.

Status unchanged: `verified` / `original`, 0 sorries, 0 axioms. JSON validated; pnpm build fails only at the known `tsc: command not found` (node_modules absent in worktree).