### PR TITLE
audit: 6 fresh proofs re-confirmed clean (abel-ruffini/birthday/fta/pascals/pell/shannon)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23727,6 +23727,42 @@
       "issues": [],
       "lastAudited": "2026-06-25T10:50:06Z",
       "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:02:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:02:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:02:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pascals-hexagon-incomplete-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:02:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pell-equation-oq-01-oq-04-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:02:57Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-channel-coding-awgn-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:02:57Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 6 never-audited proofs in the queue. **All 6 CLEAN.**

| Proof | status/badge | sorry | axiom | nd | stubs | struct |
|-------|-------------|-------|-------|----|----|--------|
| abel-ruffini-oq-04-oq-01-oq-01-oq-01 | verified/original | 0 | 0 | 0 | 0 | 0 |
| birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03 | verified/original | 0 | 0 | 0 | 0 | 0 |
| fundamental-theorem-algebra-oq-04-oq-03-oq-01-oq-02 | verified/original | 0 | 0 | 0 | 0 | 0 |
| pascals-hexagon-incomplete-01-oq-03 | verified/original | 0 | 0 | 0 | 0 | 0 |
| pell-equation-oq-01-oq-04-oq-02-oq-01 | verified/original | 0 | 0 | 0 | 0 | 0 |
| shannon-channel-coding-awgn-oq-02 | verified/original | 0 | 0 | 0 | 0 | 0 |

### Checks performed
- **Lean source vs meta**: all 6 `.lean` files present on `main`, scanned (nesting-aware comment strip) for `sorry`, `sorryAx`, `axiom` declarations, `native_decide`, `:= trivial`/`: True` stubs, and assumption-carrying `structure`/`class` fields — none found.
- **Badge/claim review**: `verified/original` accurate. The FTA entry references Mathlib's `zmodCyclicMulEquiv` in its title; its description **explicitly credits Mathlib** and the `original` badge covers the independently-proved rigidity/uniqueness theorems (`any_equiv_ofAdd_one`, `eq_galoisGroupEquivZMod2_symm`) — no delegation opacity.
- meta `sorries: 0`, `axiomCount: 0` match source.

Updates `audit-tracker.json` with 6 clean rows (+36 lines).

---
Discovered during gallery integrity audit.