### PR TITLE
research(van-der-waerden-first-moment): verified first-moment lower bound for van der Waerden numbers [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4116,6 +4116,7 @@ import Proofs.UrysohnsLemmaOQ01OQ01OQ02OQ01
 import Proofs.UrysohnsLemmaOQ01OQ01OQ02OQ02
 import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01
+import Proofs.VanDerWaerdenFirstMoment
 import Proofs.VandermondeInterpolationOQ01
 import Proofs.VandermondeInterpolationOQ01OQ01
 import Proofs.VandermondeInterpolationOQ01OQ02

--- a/proofs/Proofs/VanDerWaerdenFirstMoment.lean
+++ b/proofs/Proofs/VanDerWaerdenFirstMoment.lean
@@ -1,0 +1,137 @@
+/-
+  The First-Moment Lower Bound for van der Waerden Numbers
+
+  Van der Waerden's theorem guarantees that for every `k` there is an `N` such
+  that every 2-colouring of `{0, …, N-1}` contains a monochromatic arithmetic
+  progression of length `k`; the least such `N` is the van der Waerden number
+  `W(k)`.  The classical *lower* bound on `W(k)` is a first-moment (union-bound)
+  argument: colour each point independently and uniformly at random; a fixed
+  length-`k` AP is monochromatic with probability `2^(1-k)`, so if the number of
+  length-`k` APs that fit in `[n]` is `< 2^(k-1)` then some 2-colouring leaves
+  *every* AP non-monochromatic, witnessing `W(k) > n`.
+
+  This file derives that bound as a verified theorem.  The observation that makes
+  it cheap is structural: a length-`k` arithmetic progression is simply a
+  `k`-element subset of the ground set, and "monochromatic AP" is exactly
+  "monochromatic edge" of the hypergraph whose edges are the AP-subsets.  So the
+  van der Waerden lower bound is **Property B applied to the AP-hypergraph**, and
+  we obtain it by instantiating the gallery's verified Erdős-1963 Property-B
+  engine `ProbMethod.PropertyB.property_b_two_colorable` rather than redoing the
+  counting.
+
+  New content here:
+    * `vdwAP`     — the length-`k` AP `{a, a+d, …, a+(k-1)d}` as a `Finset (Fin n)`.
+    * `card_vdwAP`— a fitting AP with positive step has exactly `k` elements.
+    * `vdwFamily` — the family of all length-`k` APs that fit in `[n]`.
+    * `card_vdwFamily_le` — at most `n²` of them.
+    * `vdw_two_coloring_exists` / `vdw_lower_bound` — the first-moment lower
+      bound: when the AP family is small there is a 2-colouring of `[n]` with no
+      monochromatic length-`k` AP.
+
+  CONTRAST WITH THE GALLERY.  The van der Waerden lower bound is currently only
+  *axiomatized* (entry `erdos-138`, 8 axioms).  This file proves the elementary
+  first-moment form outright.  The bound `n² < 2^(k-1)` it delivers is the clean
+  union-bound threshold (`W(k) ≳ 2^((k-1)/2)`); it is deliberately loose in the
+  AP count (every `(a,d)` pair is allowed) but fully verified.
+
+  Status: 0 sorries, 0 axioms, no `native_decide`.  #print axioms reports only
+  `propext, Classical.choice, Quot.sound`.
+-/
+import Mathlib
+import Proofs.PropertyBFirstMoment
+
+namespace ProbMethod.VanDerWaerden
+
+open Finset
+open ProbMethod.PropertyB (Mono property_b_two_colorable)
+open scoped Fin.NatCast
+
+variable {n : ℕ} [NeZero n]
+
+/-- The length-`k` arithmetic progression with first term `a` and common
+difference `d`, as a subset of `Fin n`: `{a, a+d, …, a+(k-1)d}`. -/
+def vdwAP (n : ℕ) [NeZero n] (a d k : ℕ) : Finset (Fin n) :=
+  (Finset.range k).image (fun i => (Nat.cast (a + i * d) : Fin n))
+
+/-- **A fitting AP with positive step has exactly `k` elements.**
+If the top term `a + (k-1)d` is `< n` and the step `d` is positive, the map
+`i ↦ a + i·d` is injective on `{0, …, k-1}` (its values are distinct naturals
+all below `n`), so the AP has `k` distinct points. -/
+theorem card_vdwAP {a d k : ℕ} (hd : 1 ≤ d) (hbound : a + (k - 1) * d < n) :
+    (vdwAP n a d k).card = k := by
+  unfold vdwAP
+  rw [Finset.card_image_of_injOn, Finset.card_range]
+  -- the index map is injective on range k
+  intro i hi j hj hij
+  rw [Finset.mem_coe, Finset.mem_range] at hi hj
+  -- the i-th and j-th terms are below n, so the casts recover the naturals
+  have hbi : a + i * d < n := by
+    have : i * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    omega
+  have hbj : a + j * d < n := by
+    have : j * d ≤ (k - 1) * d := Nat.mul_le_mul_right d (by omega)
+    omega
+  have hval : a + i * d = a + j * d := by
+    have := congrArg Fin.val hij
+    rwa [Fin.val_cast_of_lt hbi, Fin.val_cast_of_lt hbj] at this
+  -- cancel: a + i·d = a + j·d, d > 0 ⟹ i = j
+  have : i * d = j * d := by omega
+  exact Nat.eq_of_mul_eq_mul_right (by omega) this
+
+/-- The family of all length-`k` arithmetic progressions that fit in `[n]`:
+ranging over first term `a < n` and positive step `d ≤ n` with `a + (k-1)d < n`. -/
+def vdwFamily (n : ℕ) [NeZero n] (k : ℕ) : Finset (Finset (Fin n)) :=
+  (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+      (fun p => p.1 + (k - 1) * p.2 < n)).image (fun p => vdwAP n p.1 p.2 k)
+
+/-- Every member of the AP family is a genuine `k`-element set. -/
+theorem vdwFamily_uniform (k : ℕ) :
+    ∀ e ∈ vdwFamily n k, e.card = k := by
+  intro e he
+  rw [vdwFamily, Finset.mem_image] at he
+  obtain ⟨p, hp, rfl⟩ := he
+  rw [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc] at hp
+  obtain ⟨⟨_, hd1, _⟩, hbound⟩ := hp
+  exact card_vdwAP hd1 hbound
+
+/-- **At most `n²` length-`k` APs fit in `[n]`.**
+The family is the image of a set of `(a, d)` pairs drawn from
+`{0,…,n-1} × {1,…,n}`, of which there are `n · n`. -/
+theorem card_vdwFamily_le (k : ℕ) : (vdwFamily n k).card ≤ n * n := by
+  calc (vdwFamily n k).card
+      ≤ (((Finset.range n) ×ˢ (Finset.Icc 1 n)).filter
+          (fun p => p.1 + (k - 1) * p.2 < n)).card := Finset.card_image_le
+    _ ≤ ((Finset.range n) ×ˢ (Finset.Icc 1 n)).card := Finset.card_filter_le _ _
+    _ = n * n := by rw [Finset.card_product, Finset.card_range, Nat.card_Icc,
+                        Nat.add_sub_cancel]
+
+/-- **First-moment van der Waerden lower bound (hypergraph form).**
+If fewer than `2^(k-1)` length-`k` APs fit in `[n]`, there is a 2-colouring of
+`[n]` under which no length-`k` AP is monochromatic.  This is exactly Erdős'
+Property B for the AP-hypergraph. -/
+theorem vdw_two_coloring_exists {k : ℕ} (hk : 1 ≤ k)
+    (hsmall : (vdwFamily n k).card < 2 ^ (k - 1)) :
+    ∃ c : Fin n → Bool, ∀ e ∈ vdwFamily n k, ¬ Mono e c :=
+  property_b_two_colorable (vdwFamily n k) k hk (vdwFamily_uniform k) hsmall
+
+/-- **First-moment van der Waerden lower bound, AP form.**
+If `n² < 2^(k-1)` (so `n < 2^((k-1)/2)`, i.e. `W(k) > n`), there is a
+2-colouring of `[n]` under which every length-`k` arithmetic progression with
+positive step contains both colours.  Combining `card_vdwFamily_le` with the
+hypergraph form. -/
+theorem vdw_lower_bound {k : ℕ} (hk : 2 ≤ k) (hnk : n * n < 2 ^ (k - 1)) :
+    ∃ c : Fin n → Bool, ∀ a d : ℕ, 1 ≤ d → a + (k - 1) * d < n →
+      ¬ Mono (vdwAP n a d k) c := by
+  obtain ⟨c, hc⟩ :=
+    vdw_two_coloring_exists (by omega) (lt_of_le_of_lt (card_vdwFamily_le k) hnk)
+  refine ⟨c, fun a d hd hb => ?_⟩
+  apply hc
+  -- the AP `vdwAP n a d k` belongs to the family
+  rw [vdwFamily, Finset.mem_image]
+  refine ⟨(a, d), ?_, rfl⟩
+  rw [Finset.mem_filter, Finset.mem_product, Finset.mem_Icc, Finset.mem_range]
+  -- d ≤ n since (k-1) ≥ 1, and a < n since a ≤ a + (k-1)d
+  have hdn : d ≤ (k - 1) * d := Nat.le_mul_of_pos_left d (by omega)
+  exact ⟨⟨by omega, hd, by omega⟩, hb⟩
+
+end ProbMethod.VanDerWaerden

--- a/src/data/proofs/van-der-waerden-first-moment/meta.json
+++ b/src/data/proofs/van-der-waerden-first-moment/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "van-der-waerden-first-moment",
+  "title": "The First-Moment Lower Bound for van der Waerden Numbers",
+  "slug": "van-der-waerden-first-moment",
+  "description": "Van der Waerden's theorem says every finite colouring of a long enough interval of integers contains a long monochromatic arithmetic progression; the least length forcing a monochromatic length-k AP under 2-colourings is the van der Waerden number W(k). The classical lower bound on W(k) is a first-moment (union-bound) argument: colour each point of [n] independently at random, note a fixed length-k AP is monochromatic with probability 2^(1-k), and conclude that if fewer than 2^(k-1) length-k APs fit in [n] then some 2-colouring leaves every AP non-monochromatic, witnessing W(k) > n. This entry proves that bound as a verified theorem. The key observation is structural: a length-k AP is just a k-element subset of the ground set, and 'monochromatic AP' is exactly 'monochromatic edge' of the hypergraph whose edges are the AP-subsets. So the van der Waerden lower bound is Property B applied to the AP-hypergraph, and it is obtained by instantiating the gallery's verified Erdős-1963 Property B engine (property-b-first-moment) on that hypergraph rather than redoing the counting. The new content is the AP→k-subset reduction: defining the length-k AP {a, a+d, …, a+(k-1)d} as a Finset (Fin n), proving a fitting AP with positive step has exactly k elements (an injectivity/no-wraparound argument), bounding the AP family by n², and assembling the lower bound. HONESTY: the probabilistic core (the exact monochromatic-coloring count and the first-moment principle) is the verified gallery entry property-b-first-moment, consumed here as a black box; the n² family bound is deliberately loose (every (a,d) pair is allowed), giving the clean union-bound threshold n² < 2^(k-1), i.e. W(k) ≳ 2^((k-1)/2). The van der Waerden lower bound is otherwise only axiomatized in the gallery (entry erdos-138, 8 axioms); this entry proves the elementary first-moment form outright.",
+  "meta": {
+    "author": "Lean Genius researcher-1",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VanDerWaerdenFirstMoment.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 137,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The hypotheses (k ≥ 1 or k ≥ 2, and the smallness bound on the AP family) are inputs to the statements, not standing assumptions. #print axioms reports only propext, Classical.choice, Quot.sound for all five theorems. The probabilistic core is the gallery's verified entry property-b-first-moment (ProbMethod.PropertyB.property_b_two_colorable), consumed as a black box and disclosed in crossReferences; this entry contributes the arithmetic-progression-to-hypergraph reduction and the AP combinatorics on top of it. Badged 'original' because the new content (AP construction, exact-cardinality proof, family bound, and the reduction) is not a Mathlib headline theorem; the consumed engine is itself a verified original gallery result, not external.",
+    "tags": [
+      "combinatorics",
+      "probabilistic-method",
+      "first-moment-method",
+      "van-der-waerden",
+      "arithmetic-progressions",
+      "ramsey-theory",
+      "hypergraph-coloring"
+    ],
+    "dateAdded": "2026-06-25",
+    "originalContributions": [
+      "vdw_lower_bound: if n² < 2^(k-1) (so n < 2^((k-1)/2), i.e. W(k) > n) then there is a 2-colouring of [n] under which every length-k arithmetic progression with positive step contains both colours — the verified first-moment lower bound for van der Waerden numbers",
+      "vdw_two_coloring_exists: the hypergraph form — if fewer than 2^(k-1) length-k APs fit in [n], some 2-colouring of [n] leaves no length-k AP monochromatic; a direct instantiation of the gallery's Property B engine on the AP-hypergraph",
+      "card_vdwAP: a length-k arithmetic progression with positive step whose top term a+(k-1)d is below n has exactly k elements — proved via injectivity of i ↦ a+i·d on {0,…,k-1} (distinct naturals below n, no wraparound in Fin n)",
+      "card_vdwFamily_le: at most n² length-k APs fit in [n], the loose-but-clean union-bound count obtained from the (a,d)-parameterization",
+      "vdwAP / vdwFamily: the length-k AP as a Finset (Fin n) and the family of all fitting length-k APs, exhibiting van der Waerden's monochromatic-AP question as a hypergraph 2-coloring (Property B) problem"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.val_cast_of_lt",
+        "description": "for a < n, the Fin n cast of a has value a — the no-wraparound fact underlying card_vdwAP's injectivity. Requires the scoped Fin.NatCast instance.",
+        "module": "Mathlib.Data.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "an injective-on-its-domain image preserves cardinality — turns the injectivity of i ↦ a+i·d into card_vdwAP = k.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_filter_le / Finset.card_image_le / Finset.card_product",
+        "description": "the monotonicity and product cardinality facts assembling the n² bound on the AP family.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/VanDerWaerdenFirstMoment.lean",
+    "namespace": "ProbMethod.VanDerWaerden",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 137,
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Van der Waerden (1927) proved that for every r and k there is an N such that every r-colouring of {1,…,N} contains a monochromatic arithmetic progression of length k. The growth of the associated van der Waerden numbers W(k) is a central open problem: the best lower bounds come from the probabilistic method, beginning with the elementary first-moment (union-bound) argument and improving via the Lovász Local Lemma. Erdős' 1963 Property B theorem — every k-uniform hypergraph with fewer than 2^(k-1) edges is 2-colourable — is the same first-moment argument stated for hypergraphs; viewing length-k APs as the edges of a hypergraph makes the van der Waerden lower bound a corollary of Property B.",
+    "problemStatement": "Prove, in Lean, the elementary probabilistic lower bound on van der Waerden numbers: if the number of length-k arithmetic progressions fitting in [n] is below 2^(k-1), then [n] admits a 2-colouring with no monochromatic length-k AP, i.e. W(k) > n. Concretely, since at most n² such APs fit, n² < 2^(k-1) already forces a good colouring, giving W(k) ≳ 2^((k-1)/2).",
+    "proofStrategy": "Model the ground set as Fin n and a length-k AP {a, a+d, …, a+(k-1)d} as vdwAP n a d k = (range k).image (i ↦ (a + i·d : Fin n)). When the step d is positive and the top term a+(k-1)d is below n, the index map i ↦ a+i·d is injective on {0,…,k-1}: its values are distinct naturals all below n, so the Fin n casts are distinct (Fin.val_cast_of_lt), and Finset.card_image_of_injOn gives exactly k elements (card_vdwAP). The family vdwFamily n k of all fitting APs is the image of the (a,d) pairs from {0,…,n-1} × {1,…,n}; card_image_le and card_filter_le bound it by n² (card_vdwFamily_le). Every member is a genuine k-set (vdwFamily_uniform). Feeding the family to the gallery's verified Property B engine ProbMethod.PropertyB.property_b_two_colorable yields a 2-colouring with no monochromatic member (vdw_two_coloring_exists); combining with the n² bound and a membership check (each fitting AP lies in the family) gives the AP-form lower bound vdw_lower_bound.",
+    "keyInsights": [
+      "Van der Waerden's monochromatic-AP question is a hypergraph 2-coloring (Property B) problem: the vertices are the points of [n] and the edges are the length-k AP-subsets. 'No monochromatic AP' is exactly 'proper 2-coloring of the AP-hypergraph'.",
+      "This reduction lets the verified Property B first-moment engine be reused verbatim — the probabilistic counting (exact number of colorings monochromatic on a k-set) is not redone here, only the AP-specific combinatorics is new.",
+      "The only genuinely AP-specific work is showing a fitting positive-step AP has exactly k elements. The subtlety is wraparound in Fin n: the count is k only because the top term stays below n, so no two indices collide modulo n. This is captured by Fin.val_cast_of_lt and an injectivity argument.",
+      "The n² bound on the number of APs is loose (it ignores that the step is at most n/(k-1)), but it is clean and already yields the standard union-bound shape W(k) ≳ 2^((k-1)/2). Sharper counts would improve the constant, not the method.",
+      "Honesty about provenance: the entry consumes a prior verified gallery result as a black box. The lower bound is otherwise only axiomatized in the gallery (erdos-138); here the elementary form is fully machine-checked."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and Scope",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "States the first-moment van der Waerden lower bound and the structural observation that a length-k AP is a k-subset, so the bound is Property B for the AP-hypergraph. Explicit about scope: the probabilistic core is the verified property-b-first-moment engine; the n² count is loose-but-clean."
+    },
+    {
+      "id": "ap-construction",
+      "title": "The AP as a Finset and its Cardinality",
+      "startLine": 52,
+      "endLine": 81,
+      "summary": "vdwAP defines the length-k AP as an image over {0,…,k-1}; card_vdwAP proves a fitting positive-step AP has exactly k elements via injectivity of i ↦ a+i·d (no wraparound, using Fin.val_cast_of_lt)."
+    },
+    {
+      "id": "family",
+      "title": "The AP Family and its Size",
+      "startLine": 82,
+      "endLine": 110,
+      "summary": "vdwFamily collects all fitting length-k APs as an image over (a,d) pairs; vdwFamily_uniform shows each is a k-set, and card_vdwFamily_le bounds the family by n²."
+    },
+    {
+      "id": "lower-bound",
+      "title": "The First-Moment Lower Bound",
+      "startLine": 111,
+      "endLine": 137,
+      "summary": "vdw_two_coloring_exists instantiates the Property B engine on the AP-hypergraph; vdw_lower_bound combines it with the n² bound to conclude that n² < 2^(k-1) forces a 2-colouring of [n] with no monochromatic length-k AP."
+    }
+  ],
+  "conclusion": {
+    "summary": "5 theorems, 2 definitions, 0 sorries, 0 axioms, no native_decide. The first-moment lower bound for van der Waerden numbers is proved by exhibiting the monochromatic-AP question as Property B for the hypergraph of length-k AP-subsets and instantiating the gallery's verified Erdős-1963 Property B engine. When fewer than 2^(k-1) length-k APs fit in [n] — in particular when n² < 2^(k-1) — there is a 2-colouring of [n] with no monochromatic length-k AP, so W(k) > n.",
+    "implications": "Provides a verified, machine-checked instance of the elementary probabilistic lower bound for van der Waerden numbers, which the gallery otherwise only axiomatizes (erdos-138). It also demonstrates reuse of the Property B first-moment engine across problems (Property B, Ramsey, now van der Waerden), reinforcing the AP/clique/edge-set-as-hypergraph pattern at the heart of the probabilistic method.",
+    "openQuestions": [
+      "Sharpen card_vdwFamily_le from n² to ~n²/(k-1) (the step is at most n/(k-1)), improving the threshold constant — a purely combinatorial refinement of the AP count.",
+      "Strengthen the lower bound from the union bound to the Lovász Local Lemma form W(k) ≳ 2^k/(ek), which requires a verified symmetric-LLL statement and a bound on AP-overlap degrees.",
+      "Connect this verified elementary bound to the axiomatized growth statements in erdos-138, eliminating the corresponding axiom there."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "property-b-first-moment",
+      "relationship": "engine — this entry's probabilistic core is property_b_two_colorable (Erdős 1963 Property B via the first moment method), instantiated here on the arithmetic-progression hypergraph"
+    },
+    {
+      "targetId": "erdos-138",
+      "relationship": "related — the gallery's van der Waerden entry, which axiomatizes growth/lower-bound statements; this entry proves the elementary first-moment lower bound outright"
+    },
+    {
+      "targetId": "prob-method-applications",
+      "relationship": "context — the probabilistic-method applications gallery whose vacuous ramsey/property-B placeholders are superseded by verified dedicated entries such as this one"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## First-Moment Lower Bound for van der Waerden Numbers

A verified, machine-checked proof of the elementary probabilistic lower bound on van der Waerden numbers `W(k)`:

> If fewer than `2^(k-1)` length-`k` arithmetic progressions fit in `[n]`, then `[n]` admits a 2-colouring with **no monochromatic length-`k` AP** — i.e. `W(k) > n`. Since at most `n²` such APs fit, `n² < 2^(k-1)` already forces a good colouring, giving `W(k) ≳ 2^((k-1)/2)`.

### Key idea — van der Waerden's lower bound *is* Property B
A length-`k` AP is just a `k`-element subset, and "monochromatic AP" = "monochromatic edge" of the hypergraph whose edges are the AP-subsets. So the bound is **Erdős' 1963 Property B applied to the AP-hypergraph**. This entry instantiates the gallery's *already-verified* Property B first-moment engine (`ProbMethod.PropertyB.property_b_two_colorable` from `property-b-first-moment`) rather than redoing the probabilistic counting.

### New content (5 theorems / 2 definitions)
- `vdwAP` / `vdwFamily` — the length-`k` AP `{a, a+d, …, a+(k-1)d}` as a `Finset (Fin n)`, and the family of all fitting APs.
- `card_vdwAP` — a fitting positive-step AP has **exactly `k`** elements; the crux is no-wraparound injectivity of `i ↦ a+i·d` in `Fin n` (`Fin.val_cast_of_lt`).
- `card_vdwFamily_le` — at most `n²` fitting APs.
- `vdw_two_coloring_exists` / `vdw_lower_bound` — the hypergraph and AP forms of the bound.

### Honesty / scope
The probabilistic core (exact monochromatic-coloring count + first-moment principle) is the **verified gallery entry `property-b-first-moment`**, consumed here as a black box and disclosed in `crossReferences`. The `n²` family count is deliberately loose (every `(a,d)` pair allowed), yielding the clean union-bound threshold. The van der Waerden lower bound is otherwise only **axiomatized** in the gallery (`erdos-138`, 8 axioms); this proves the elementary first-moment form outright. Badged `original` — the AP→hypergraph reduction and AP combinatorics are new; the consumed engine is itself a verified original gallery result.

### Verification
- `#print axioms`: `propext, Classical.choice, Quot.sound` for all five theorems — no `sorryAx`, no `native_decide`.
- 5 theorems, 2 definitions, 0 sorries, 0 axiom declarations, 137 lines.
- Built against `leanprover/lean4:v4.26.0` + Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)