### PR TITLE
research(area-of-circle-oq-02-oq-03): unit-sphere surface area Sₙ = n·Vₙ

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ02OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ02OQ03.lean
@@ -1,0 +1,164 @@
+/-
+  Surface Area of the Unit Sphere: S_n = n · V_n
+  Open Question: area-of-circle-oq-02-oq-03
+  Parent:        area-of-circle-oq-02  (N-Dimensional Ball Volume Formula)
+
+  The parent `AreaOfCircleOQ02.lean` establishes the closed form for the volume of
+  the unit n-ball,
+
+      V_n = π^(n/2) / Γ(n/2 + 1).
+
+  This file supplies the companion closed form for the (n-1)-dimensional measure of
+  the unit sphere S^{n-1} (the boundary of the unit n-ball),
+
+      S_n = 2 · π^(n/2) / Γ(n/2),
+
+  and proves the classical scaling/divergence-theorem identity relating the two:
+
+      S_n = n · V_n.                          (`surface_eq_n_mul_volume`)
+
+  ## Why this is not a tautology
+
+  An earlier gallery file (`AreaOfCircleOQ01OQ02OQ01.lean`) *defines* the surface
+  area differentially, as `nSphereArea n r = n · ω_n · r^(n-1)`, the derivative of
+  the volume; there `S = n·V` holds by definition.  Here, by contrast, the surface
+  area is defined by its own independent Gamma closed form `2·π^(n/2)/Γ(n/2)`, the
+  one-half-dimension-down analogue of the volume formula.  The identity `S_n = n·V_n`
+  then carries genuine content: it is *exactly* the Gamma functional equation
+
+      Γ(n/2 + 1) = (n/2) · Γ(n/2)
+
+  in disguise.
+
+  The edge case `n = 0` is handled by Mathlib's junk-value convention `Γ(0) = 0`:
+  the surface formula gives `2/Γ(0) = 2/0 = 0`, which matches `0 · V_0 = 0`.
+
+  Special values double-check the formula:
+      S_1 = 2      (the two endpoints of [-1,1], a 0-dimensional measure)
+      S_2 = 2π     (the circumference of the unit circle)
+      S_3 = 4π     (the surface area of the unit sphere)
+
+  Status: 0 sorries, 0 axioms (beyond Mathlib's foundations).
+
+  References:
+  - Mathlib: Real.Gamma_add_one, Real.Gamma_zero, Real.Gamma_one_half_eq, Real.Gamma_two
+  - Classical: surface area of S^{n-1} = 2 π^(n/2) / Γ(n/2)
+-/
+
+import Mathlib
+
+open MeasureTheory Real
+
+namespace NSphereSurface
+
+noncomputable section
+
+/-- The unit n-ball volume `V_n = π^(n/2) / Γ(n/2 + 1)`.
+    Matches `AreaOfCircleOQ02.unitBallVolume`; restated here to be self-contained. -/
+def unitBallVolume (n : ℕ) : ℝ :=
+  π ^ ((n : ℝ) / 2) / Gamma ((n : ℝ) / 2 + 1)
+
+/-- The (n-1)-sphere surface measure `S_n = 2 · π^(n/2) / Γ(n/2)`, the
+    one-half-dimension-down analogue of the volume formula. -/
+def unitSphereSurface (n : ℕ) : ℝ :=
+  2 * π ^ ((n : ℝ) / 2) / Gamma ((n : ℝ) / 2)
+
+/-- `Γ(3/2) = √π / 2`, the value used for the odd-dimensional special cases. -/
+private lemma gamma_three_div_two : Gamma (3 / 2 : ℝ) = √π / 2 := by
+  have h := Real.Gamma_add_one (show (1 / 2 : ℝ) ≠ 0 from by norm_num)
+  rw [show (1 : ℝ) / 2 + 1 = 3 / 2 from by ring] at h
+  rw [h, Real.Gamma_one_half_eq]; ring
+
+/-! ## Basic positivity -/
+
+/-- The unit ball volume is positive. -/
+theorem unitBallVolume_pos (n : ℕ) : 0 < unitBallVolume n := by
+  unfold unitBallVolume
+  exact div_pos (rpow_pos_of_pos pi_pos _) (Gamma_pos_of_pos (by positivity))
+
+/-- For `n ≥ 1` the sphere surface is strictly positive. -/
+theorem unitSphereSurface_pos {n : ℕ} (hn : 1 ≤ n) : 0 < unitSphereSurface n := by
+  unfold unitSphereSurface
+  have hgn : (0 : ℝ) < (n : ℝ) / 2 := by positivity
+  refine div_pos ?_ (Gamma_pos_of_pos hgn)
+  have : (0 : ℝ) < π ^ ((n : ℝ) / 2) := rpow_pos_of_pos pi_pos _
+  linarith
+
+/-! ## The main identity: `S_n = n · V_n` -/
+
+/-- **Surface–volume scaling identity.**  The (n-1)-dimensional measure of the unit
+    sphere equals `n` times the volume of the unit n-ball:
+
+        2 · π^(n/2) / Γ(n/2)  =  n · ( π^(n/2) / Γ(n/2 + 1) ).
+
+    This is the Gamma functional equation `Γ(n/2 + 1) = (n/2)·Γ(n/2)` made geometric.
+    The `n = 0` case holds via Mathlib's convention `Γ(0) = 0` (both sides are `0`). -/
+theorem surface_eq_n_mul_volume (n : ℕ) :
+    unitSphereSurface n = (n : ℝ) * unitBallVolume n := by
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn
+    simp [unitSphereSurface, unitBallVolume, Real.Gamma_zero]
+  · unfold unitSphereSurface unitBallVolume
+    have hn2 : ((n : ℝ) / 2) ≠ 0 := by positivity
+    have hgpos : (0 : ℝ) < Gamma ((n : ℝ) / 2) := Gamma_pos_of_pos (by positivity)
+    rw [Real.Gamma_add_one hn2]
+    field_simp
+
+/-- The surface-to-volume ratio of the unit n-ball is exactly `n`. -/
+theorem surface_div_volume (n : ℕ) :
+    unitSphereSurface n / unitBallVolume n = (n : ℝ) := by
+  rw [surface_eq_n_mul_volume, mul_div_assoc, div_self (ne_of_gt (unitBallVolume_pos n)),
+      mul_one]
+
+/-! ## Volume special values (mirroring the parent `AreaOfCircleOQ02`) -/
+
+/-- `V_1 = 2` (length of `[-1, 1]`). -/
+theorem unitBallVolume_one : unitBallVolume 1 = 2 := by
+  unfold unitBallVolume
+  simp only [Nat.cast_one]
+  rw [show (1 : ℝ) / 2 + 1 = 3 / 2 from by ring, gamma_three_div_two,
+      ← Real.sqrt_eq_rpow]
+  have h : (0 : ℝ) < √π := Real.sqrt_pos.mpr Real.pi_pos
+  field_simp [h.ne']
+
+/-- `V_2 = π` (area of the unit disk). -/
+theorem unitBallVolume_two : unitBallVolume 2 = π := by
+  unfold unitBallVolume
+  rw [show ((2 : ℕ) : ℝ) / 2 + 1 = 2 from by norm_num,
+      show ((2 : ℕ) : ℝ) / 2 = 1 from by norm_num, rpow_one, Real.Gamma_two, div_one]
+
+/-- `V_3 = 4π/3` (volume of the unit ball). -/
+theorem unitBallVolume_three : unitBallVolume 3 = 4 * π / 3 := by
+  unfold unitBallVolume
+  rw [show ((3 : ℕ) : ℝ) / 2 + 1 = 3 / 2 + 1 from by norm_num,
+      Real.Gamma_add_one (show (3 / 2 : ℝ) ≠ 0 from by norm_num), gamma_three_div_two,
+      show ((3 : ℕ) : ℝ) / 2 = 1 / 2 + 1 from by norm_num,
+      Real.rpow_add Real.pi_pos, Real.rpow_one, ← Real.sqrt_eq_rpow]
+  have h : (0 : ℝ) < √π := Real.sqrt_pos.mpr Real.pi_pos
+  have hsq : √π * √π = π := Real.mul_self_sqrt (le_of_lt Real.pi_pos)
+  field_simp
+  nlinarith [hsq, h]
+
+/-! ## Surface special values (via the main identity) -/
+
+/-- `S_1 = 2`: the boundary of `[-1, 1]` is two points, total `0`-measure `2`. -/
+theorem unitSphereSurface_one : unitSphereSurface 1 = 2 := by
+  rw [surface_eq_n_mul_volume, unitBallVolume_one]; norm_num
+
+/-- `S_2 = 2π`: the circumference of the unit circle. -/
+theorem unitSphereSurface_two : unitSphereSurface 2 = 2 * π := by
+  rw [surface_eq_n_mul_volume, unitBallVolume_two]; push_cast; ring
+
+/-- `S_3 = 4π`: the surface area of the unit sphere. -/
+theorem unitSphereSurface_three : unitSphereSurface 3 = 4 * π := by
+  rw [surface_eq_n_mul_volume, unitBallVolume_three]; push_cast; ring
+
+/-- A direct check that the surface *closed form* (not the identity) gives the
+    circumference at `n = 2`: `2 · π^1 / Γ(1) = 2π`. -/
+theorem unitSphereSurface_two_direct : unitSphereSurface 2 = 2 * π := by
+  unfold unitSphereSurface
+  rw [show ((2 : ℕ) : ℝ) / 2 = 1 from by norm_num, rpow_one, Real.Gamma_one, div_one]
+
+end
+
+end NSphereSurface

--- a/src/data/proofs/area-of-circle-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-aoc-oq02-oq03-defs",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 58,
+      "endLine": 65
+    },
+    "type": "concept",
+    "title": "Two Independent Gamma Closed Forms",
+    "content": "The unit n-ball volume is Vₙ = π^(n/2)/Γ(n/2+1) (restated from the parent), and the unit (n−1)-sphere surface measure is defined here by its own closed form Sₙ = 2·π^(n/2)/Γ(n/2). The only difference is the half-dimension shift in the Gamma denominator: Γ(n/2+1) for the volume, Γ(n/2) for the surface. Crucially, Sₙ is NOT defined as the derivative of the volume — it is given its own formula, so the relation Sₙ = n·Vₙ is something to be proved.",
+    "mathContext": "$V_n = \\dfrac{\\pi^{n/2}}{\\Gamma(n/2+1)}$, $\\quad S_n = \\dfrac{2\\,\\pi^{n/2}}{\\Gamma(n/2)}$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Gamma function",
+      "n-ball volume",
+      "sphere surface area"
+    ],
+    "prerequisites": [
+      "Gamma function closed forms",
+      "real powers (rpow)"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-main",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 96,
+      "endLine": 106
+    },
+    "type": "key-step",
+    "title": "Sₙ = n·Vₙ is the Gamma Functional Equation",
+    "content": "The headline identity is proved by case split on n. For n ≥ 1, n/2 ≠ 0, so Real.Gamma_add_one rewrites Γ(n/2+1) = (n/2)·Γ(n/2). The goal 2·π^(n/2)/Γ(n/2) = n·π^(n/2)/((n/2)·Γ(n/2)) then closes by field_simp, since Γ(n/2) > 0. This is the entire mathematical content: the proportionality constant n is exactly the factor produced by one step of the Gamma recurrence. The degenerate n=0 case is handled separately via Γ(0)=0, which makes the surface formula 2/Γ(0)=0 equal to 0·V₀.",
+    "mathContext": "$\\dfrac{2\\pi^{n/2}}{\\Gamma(n/2)} = n\\cdot\\dfrac{\\pi^{n/2}}{\\Gamma(n/2+1)} \\iff \\Gamma(n/2+1) = \\tfrac{n}{2}\\,\\Gamma(n/2).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Gamma functional equation",
+      "divergence theorem",
+      "surface-to-volume ratio"
+    ],
+    "prerequisites": [
+      "Real.Gamma_add_one",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-not-tautology",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 108,
+      "endLine": 114
+    },
+    "type": "insight",
+    "title": "Why This Is Not a Definitional Identity",
+    "content": "An earlier gallery file (area-of-circle-oq-01-oq-02-oq-01) defines the radius-dependent surface area differentially as nSphereArea n r = n·ωₙ·r^(n−1) — the derivative of the volume V_n(r) = ωₙ·rⁿ. With that definition, S = n·V holds by construction and carries no Gamma-theoretic content. Here, by contrast, the surface area has its own closed form, and surface_div_volume (Sₙ/Vₙ = n) together with surface_eq_n_mul_volume express the genuine fact that the two independently-defined Gamma formulas are in the ratio n:1. That ratio is the dimensional signature of the divergence theorem on the ball.",
+    "mathContext": "Differential definition: $S = \\frac{d}{dr}(\\omega_n r^n)\\big|_{r=1} = n\\omega_n$ (tautological). Closed-form definition: $S_n = 2\\pi^{n/2}/\\Gamma(n/2)$, and $S_n/V_n = n$ is a theorem.",
+    "significance": "major",
+    "relatedConcepts": [
+      "definitional vs proved identities",
+      "divergence theorem",
+      "originality framing"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-aoc-oq02-oq03-special",
+    "proofId": "area-of-circle-oq-02-oq-03",
+    "range": {
+      "startLine": 144,
+      "endLine": 164
+    },
+    "type": "example",
+    "title": "Special Values: Endpoints, Circumference, Sphere",
+    "content": "Instantiating the identity gives S₁ = 1·V₁ = 2 (the two endpoints of [−1,1], a 0-dimensional measure), S₂ = 2·V₂ = 2π (the circumference of the unit circle), and S₃ = 3·V₃ = 3·(4π/3) = 4π (the surface area of the unit sphere). The final theorem unitSphereSurface_two_direct re-derives S₂ = 2π straight from the surface closed form using Γ(1)=1, confirming that 2π^(2/2)/Γ(1) really is the unit-circle circumference, independently of the main identity.",
+    "mathContext": "$S_1 = 2,\\quad S_2 = 2\\pi,\\quad S_3 = 4\\pi.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "circumference",
+      "sphere surface area",
+      "Hausdorff measure"
+    ],
+    "prerequisites": [
+      "Gamma special values"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-02-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-03/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "area-of-circle-oq-02-oq-03",
+  "title": "Surface Area of the Unit Sphere: Sₙ = n·Vₙ",
+  "slug": "area-of-circle-oq-02-oq-03",
+  "description": "Defines the (n−1)-sphere surface measure by its own Gamma closed form Sₙ = 2·π^(n/2)/Γ(n/2) — the half-dimension-down analogue of the parent's ball-volume formula Vₙ = π^(n/2)/Γ(n/2+1) — and proves the scaling/divergence-theorem identity Sₙ = n·Vₙ. Unlike an earlier gallery file that defines surface area differentially as n·ωₙ·r^(n−1) (making Sₙ=n·Vₙ true by definition), here the identity carries genuine content: it is exactly the Gamma functional equation Γ(n/2+1)=(n/2)·Γ(n/2). The n=0 edge case is handled by Mathlib's junk-value convention Γ(0)=0 (both sides are 0).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "n-ball-volume",
+      "sphere-surface-area",
+      "gamma-function",
+      "special-functions",
+      "divergence-theorem"
+    ],
+    "proofRepoPath": "Proofs/AreaOfCircleOQ02OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 164,
+    "originalContributions": [
+      "unitSphereSurface: the (n−1)-sphere surface measure defined by its own Gamma closed form 2·π^(n/2)/Γ(n/2), independent of the volume formula",
+      "surface_eq_n_mul_volume: Sₙ = n·Vₙ for all n ≥ 0, proved via the Gamma functional equation Γ(n/2+1)=(n/2)·Γ(n/2), with the n=0 case via Γ(0)=0",
+      "surface_div_volume: the surface-to-volume ratio Sₙ/Vₙ equals exactly n",
+      "unitSphereSurface_one/two/three: special values S₁=2, S₂=2π, S₃=4π recovering endpoint count, circumference, and sphere area",
+      "unitSphereSurface_two_direct: S₂=2π straight from the Gamma closed form (Γ(1)=1), independent of the main identity"
+    ],
+    "assumptions": "0 axiom(s) and 0 sorry(s). #print axioms reports only propext, Classical.choice, Quot.sound. Fully verified.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "The Gamma functional equation Γ(s+1)=s·Γ(s) for s≠0 — the algebraic heart of Sₙ=n·Vₙ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "Γ(1/2)=√π, used for the odd-dimensional special values S₁ and S₃",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_zero",
+        "description": "Γ(0)=0 (junk value), making the n=0 edge case 2/Γ(0)=0=0·V₀ hold",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      }
+    ],
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The closed forms for the volume of the unit n-ball, Vₙ = π^(n/2)/Γ(n/2+1), and the surface measure of the unit (n−1)-sphere, Sₙ = 2π^(n/2)/Γ(n/2), were obtained in the 19th century via Gaussian-integral techniques and the Gamma function (Liouville). They are linked by the elementary scaling identity Sₙ = n·Vₙ, the integral form of the divergence theorem applied to the radial vector field on the ball: the boundary of the n-ball of radius r has measure dVₙ(r)/dr, and at r=1 this is n·Vₙ. Equivalently, integrating shells, Vₙ = ∫₀¹ Sₙ rⁿ⁻¹ dr = Sₙ/n.\n\nThe parent entry (area-of-circle-oq-02) established the volume closed form Vₙ = π^(n/2)/Γ(n/2+1). A separate gallery file (area-of-circle-oq-01-oq-02-oq-01) defines a radius-dependent surface function differentially, nSphereArea n r = n·ωₙ·r^(n−1), as the derivative of the volume; with that definition Sₙ = n·Vₙ holds by construction and so contains no Gamma-theoretic content. The present entry instead gives the surface area its own independent Gamma closed form and proves Sₙ = n·Vₙ as a genuine theorem, namely a restatement of the Gamma functional equation Γ(n/2+1) = (n/2)·Γ(n/2).",
+    "problemStatement": "Building on the closed form for the volume Vₙ of the unit n-ball, define the unit (n−1)-sphere surface measure by its own Gamma closed form Sₙ = 2π^(n/2)/Γ(n/2) and prove the surface-area relation Sₙ = n·Vₙ — the scaling/divergence-theorem identity underlying the Gamma-function formulas for sphere area.",
+    "proofStrategy": "Unfold both Gamma closed forms. For n ≥ 1, since n/2 ≠ 0, rewrite Γ(n/2+1) = (n/2)·Γ(n/2) with Real.Gamma_add_one; the goal 2π^(n/2)/Γ(n/2) = n·π^(n/2)/((n/2)·Γ(n/2)) then closes by field_simp (Γ(n/2) > 0). The degenerate n=0 case is handled separately: Γ(0)=0 makes the surface formula 2/Γ(0)=0, which equals 0·V₀. Special values S₁,S₂,S₃ follow from the identity together with the parent's volume values V₁=2, V₂=π, V₃=4π/3; S₂=2π is additionally checked straight from the surface closed form via Γ(1)=1.",
+    "text": "The parent entry proved Vₙ = π^(n/2)/Γ(n/2+1). This entry supplies the companion (n−1)-sphere surface closed form Sₙ = 2π^(n/2)/Γ(n/2) and proves Sₙ = n·Vₙ. The identity is exactly the Gamma functional equation Γ(n/2+1) = (n/2)·Γ(n/2) in geometric disguise — genuine content, since the surface area here is defined independently of the volume (not as its derivative). Special values recover S₁=2 (two endpoints), S₂=2π (circumference), and S₃=4π (sphere area).",
+    "keyInsights": [
+      "Defining Sₙ via its own Gamma closed form 2π^(n/2)/Γ(n/2) makes Sₙ=n·Vₙ a theorem, not a definitional tautology — it reduces precisely to Γ(n/2+1)=(n/2)·Γ(n/2)",
+      "The half-dimension shift between the volume denominator Γ(n/2+1) and the surface denominator Γ(n/2) is exactly one application of the Gamma recurrence, which is why the proportionality constant is n",
+      "Mathlib's junk value Γ(0)=0 makes the n=0 case work automatically: the surface formula gives 2/0=0, matching 0·V₀=0, so no hypothesis n≥1 is needed",
+      "The surface-to-volume ratio Sₙ/Vₙ = n is the dimensional signature of the divergence theorem on the ball",
+      "S₂ = 2π can be read straight off the closed form (Γ(1)=1), independently confirming the formula gives the unit-circle circumference"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Header, Imports, and Definitions",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Documentation header contrasting the Gamma-closed-form surface area with the earlier differential definition. Imports Mathlib, opens MeasureTheory/Real, namespace NSphereSurface. Defines unitBallVolume = π^(n/2)/Γ(n/2+1) and unitSphereSurface = 2π^(n/2)/Γ(n/2).",
+      "mathContext": "$V_n = \\pi^{n/2}/\\Gamma(n/2+1)$ (parent's form) and $S_n = 2\\pi^{n/2}/\\Gamma(n/2)$ (this entry's independent surface form)."
+    },
+    {
+      "id": "gamma-half",
+      "title": "Helper: Γ(3/2) = √π/2 and Positivity",
+      "startLine": 67,
+      "endLine": 94,
+      "summary": "Private lemma gamma_three_div_two (Γ(3/2)=√π/2 via Gamma_add_one + Gamma_one_half_eq). Positivity lemmas: unitBallVolume_pos (all n) and unitSphereSurface_pos (n≥1).",
+      "mathContext": "$\\Gamma(3/2) = \\tfrac12\\Gamma(1/2) = \\tfrac{\\sqrt\\pi}{2}$; both closed forms are positive (the volume for all $n$, the surface for $n\\ge 1$)."
+    },
+    {
+      "id": "main-identity",
+      "title": "Main Theorem: Sₙ = n·Vₙ",
+      "startLine": 96,
+      "endLine": 114,
+      "summary": "surface_eq_n_mul_volume: Sₙ = n·Vₙ for all n. The n=0 branch uses Γ(0)=0 (both sides 0); the n≥1 branch rewrites Γ(n/2+1)=(n/2)·Γ(n/2) and closes by field_simp. surface_div_volume: the ratio Sₙ/Vₙ = n.",
+      "mathContext": "$2\\pi^{n/2}/\\Gamma(n/2) = n\\cdot\\pi^{n/2}/\\Gamma(n/2+1)$ iff $\\Gamma(n/2+1)=(n/2)\\Gamma(n/2)$ — the Gamma functional equation."
+    },
+    {
+      "id": "volume-values",
+      "title": "Volume Special Values V₁, V₂, V₃",
+      "startLine": 115,
+      "endLine": 143,
+      "summary": "unitBallVolume_one (=2), unitBallVolume_two (=π), unitBallVolume_three (=4π/3), mirroring the parent's verified computations using Γ(3/2)=√π/2, Γ(2)=1, and rpow laws.",
+      "mathContext": "$V_1=2,\\ V_2=\\pi,\\ V_3=\\tfrac{4\\pi}{3}$ — the line segment, disk, and ball."
+    },
+    {
+      "id": "surface-values",
+      "title": "Surface Special Values S₁, S₂, S₃",
+      "startLine": 144,
+      "endLine": 164,
+      "summary": "unitSphereSurface_one (=2), unitSphereSurface_two (=2π), unitSphereSurface_three (=4π) derived from the main identity and the volume values; unitSphereSurface_two_direct re-derives S₂=2π straight from the surface closed form via Γ(1)=1.",
+      "mathContext": "$S_1=2$ (two endpoints), $S_2=2\\pi$ (circumference), $S_3=4\\pi$ (sphere surface)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms) proof that the unit (n−1)-sphere surface measure Sₙ = 2π^(n/2)/Γ(n/2) equals n times the unit n-ball volume Vₙ = π^(n/2)/Γ(n/2+1). Defining surface area by its own Gamma closed form makes Sₙ=n·Vₙ a genuine theorem — a restatement of the Gamma functional equation Γ(n/2+1)=(n/2)·Γ(n/2) — rather than a definitional identity. Special values recover S₁=2, S₂=2π, S₃=4π.",
+    "implications": "Completes the volume–surface pair of Gamma closed forms for the n-ball/sphere, exhibiting the divergence-theorem scaling Sₙ=n·Vₙ at the level of the explicit formulas. The half-dimension shift Γ(n/2+1)↔Γ(n/2) is identified as the source of the proportionality constant n.",
+    "openQuestions": [
+      "Connect this algebraic identity to a measure-theoretic statement: that 2π^(n/2)/Γ(n/2) is the actual (n−1)-Hausdorff measure of the unit sphere in ℝⁿ, via Mathlib's surface-measure API.",
+      "Derive the radial-shell integral Vₙ = ∫₀¹ Sₙ rⁿ⁻¹ dr directly, recovering Sₙ=n·Vₙ from the Fundamental Theorem of Calculus rather than the Gamma recurrence."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-02",
+      "relationship": "extends",
+      "description": "Builds on the parent's unit n-ball volume closed form Vₙ = π^(n/2)/Γ(n/2+1), adding the companion sphere surface closed form and the relation Sₙ=n·Vₙ."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01",
+      "relationship": "complements",
+      "description": "That file defines surface area differentially (n·ωₙ·r^(n−1)); this file defines it via an independent Gamma closed form, so Sₙ=n·Vₙ becomes a theorem rather than a definition."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "NSphereSurface",
+    "lineCount": 164,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/AreaOfCircleOQ02OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes open question **area-of-circle-oq-02-oq-03**. Building on the parent's unit n-ball volume closed form `Vₙ = π^(n/2)/Γ(n/2+1)`, this entry supplies the companion **(n−1)-sphere surface measure** by its *own independent Gamma closed form*

```
Sₙ = 2·π^(n/2) / Γ(n/2)
```

and proves the scaling/divergence-theorem identity

```
Sₙ = n · Vₙ                  (surface_eq_n_mul_volume)
```

## Why this is not a tautology

An earlier gallery file (`area-of-circle-oq-01-oq-02-oq-01`) defines surface area *differentially* as `nSphereArea n r = n·ωₙ·r^(n−1)`, the derivative of the volume — there `S = n·V` holds by definition. Here the surface area has its **own** Gamma formula, so `Sₙ = n·Vₙ` carries genuine content: it is *exactly* the Gamma functional equation `Γ(n/2+1) = (n/2)·Γ(n/2)` in geometric disguise. The half-dimension shift `Γ(n/2+1) ↔ Γ(n/2)` is precisely what produces the proportionality constant `n`.

## Contents (12 theorems/lemmas, 2 defs, 164 lines)

- `surface_eq_n_mul_volume` — `Sₙ = n·Vₙ` for **all** `n` (the `n=0` case via Mathlib's junk value `Γ(0)=0`, giving `2/0 = 0 = 0·V₀`).
- `surface_div_volume` — the surface-to-volume ratio `Sₙ/Vₙ = n`.
- `unitSphereSurface_one/two/three` — special values `S₁=2` (endpoints), `S₂=2π` (circumference), `S₃=4π` (sphere surface), via the identity + volume values.
- `unitSphereSurface_two_direct` — `S₂=2π` straight from the surface closed form (`Γ(1)=1`), independent of the main identity.
- positivity lemmas + volume special values `V₁=2, V₂=π, V₃=4π/3`.

## Verification

- **Status:** `verified`, badge `original`
- **0 sorries, 0 axiom declarations.** `#print axioms surface_eq_n_mul_volume` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiles cleanly under Lean v4.26.0 / Mathlib (`lake env lean`, zero diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)