### PR TITLE
Enrich Perfect Numbers abundancy index (perfect-numbers-oq-02)

### DIFF
--- a/src/data/proofs/perfect-numbers-oq-02/annotations.json
+++ b/src/data/proofs/perfect-numbers-oq-02/annotations.json
@@ -1,35 +1,62 @@
 [
   {
+    "id": "ann-context",
+    "proofId": "perfect-numbers-oq-02",
+    "range": { "startLine": 3, "endLine": 32 },
+    "type": "context",
+    "title": "The Abundancy Index as a Convention-Free Perfectness Test",
+    "content": "The docstring positions this file relative to the parent Euclid–Euler classification: rather than the asymmetric σ(n) = 2n (which double-counts n itself), it expresses perfectness through the abundancy index I(n) = σ(n)/n written as the sum of divisor reciprocals ∑_{d∣n} 1/d. This form is scale-free and generalizes verbatim: k-perfect (multiply perfect) numbers are exactly those with reciprocal-divisor sum k. The aesthetic payoff is that 'perfect' becomes the clean threshold ∑_{d∣n} 1/d = 2.",
+    "mathContext": "$I(n) = \\dfrac{\\sigma(n)}{n} = \\sum_{d\\mid n} \\dfrac1d;\\quad n\\text{ perfect} \\iff I(n) = 2.$",
+    "significance": "context",
+    "relatedConcepts": ["perfect numbers", "Euclid–Euler theorem", "abundancy index", "multiply perfect numbers", "sum of divisors σ"],
+    "prerequisites": ["divisors", "sum-of-divisors function", "definition of perfect number"]
+  },
+  {
+    "id": "ann-definition",
+    "proofId": "perfect-numbers-oq-02",
+    "range": { "startLine": 38, "endLine": 40 },
+    "type": "definition",
+    "title": "abundancyIndex n = ∑_{d∣n} 1/d Over ℚ",
+    "content": "abundancyIndex n is defined as the rational sum ∑_{d ∈ n.divisors} (d:ℚ)⁻¹. Working in ℚ (not ℝ) keeps the value exact and lets the perfectness criterion be a decidable rational equation. It is noncomputable only because of the rational-inverse coercion; the underlying divisor set n.divisors is a concrete Finset. For n > 0 this equals σ(n)/n, proved next.",
+    "mathContext": "$\\mathrm{abundancyIndex}(n) := \\sum_{d \\in n.\\mathrm{divisors}} d^{-1} \\in \\mathbb{Q}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["divisor set", "rational numbers", "Finset summation", "noncomputable definitions"],
+    "prerequisites": ["finite sums over Finsets", "rationals"]
+  },
+  {
     "id": "ann-index",
     "proofId": "perfect-numbers-oq-02",
-    "range": {
-      "startLine": 44,
-      "endLine": 56
-    },
+    "range": { "startLine": 42, "endLine": 55 },
     "type": "insight",
     "title": "The Divisor Involution Turns Reciprocals into σ(n)/n",
-    "content": "`abundancyIndex_eq_sigma_div` proves I(n) = ∑_{d∣n} 1/d = σ(n)/n. The mechanism is the involution d ↦ n/d on the divisors of n: each reciprocal 1/d equals the cofactor (n/d)/n (since for d ∣ n the natural cofactor n/d casts exactly to (n:ℚ)/(d:ℚ)), so factoring 1/n out leaves (1/n)·∑_{d∣n} (n/d) = (1/n)·∑_{d∣n} d = σ(n)/n. Mathlib packages the involution as Nat.sum_div_divisors: ∑_{d∣n} f(n/d) = ∑_{d∣n} f(d)."
+    "content": "abundancyIndex_eq_sigma_div proves I(n) = ∑_{d∣n} 1/d = σ(n)/n. The mechanism is the involution d ↦ n/d on the divisors of n: each reciprocal 1/d equals the cofactor (n/d)/n (for d ∣ n the natural cofactor n/d casts exactly to (n:ℚ)/(d:ℚ), via Nat.cast_div + field_simp), so factoring 1/n out leaves (1/n)·∑_{d∣n} (n/d) = (1/n)·∑_{d∣n} d = σ(n)/n. Mathlib packages the involution as Nat.sum_div_divisors: ∑_{d∣n} f(n/d) = ∑_{d∣n} f(d), so reindexing the cofactor sum back to the plain divisor sum is one rewrite.",
+    "mathContext": "$\\sum_{d\\mid n} \\dfrac1d = \\dfrac1n\\sum_{d\\mid n} \\dfrac{n}{d} = \\dfrac1n\\sum_{d\\mid n} d = \\dfrac{\\sigma(n)}{n}.$",
+    "significance": "key",
+    "relatedConcepts": ["divisor involution d↦n/d", "Nat.sum_div_divisors", "cofactors", "sigma function", "reindexing sums"],
+    "prerequisites": ["divisibility", "Nat.cast_div", "sum reindexing"]
   },
   {
     "id": "ann-characterization",
     "proofId": "perfect-numbers-oq-02",
-    "range": {
-      "startLine": 62,
-      "endLine": 73
-    },
+    "range": { "startLine": 57, "endLine": 67 },
     "type": "insight",
     "title": "Perfect ⟺ Divisor Reciprocals Sum to 2",
-    "content": "`perfect_iff_abundancyIndex_eq_two` is the headline: n is perfect exactly when ∑_{d∣n} 1/d = 2. The proof rewrites perfectness as σ(n) = 2n (Nat.perfect_iff_sum_divisors_eq_two_mul) and the index as σ(n)/n, clears the denominator, and matches the two integer equations by casting. This convention-free form generalizes immediately: a k-perfect number is one with ∑_{d∣n} 1/d = k, so multiply perfect numbers fit the same template."
+    "content": "perfect_iff_abundancyIndex_eq_two is the headline: n is perfect exactly when ∑_{d∣n} 1/d = 2. The proof rewrites perfectness as σ(n) = 2n (Nat.perfect_iff_sum_divisors_eq_two_mul) and the index as σ(n)/n, clears the denominator with div_eq_iff (n ≠ 0), and matches the two integer equations by casting (push_cast/exact_mod_cast). The convention-free form generalizes immediately: a k-perfect number is one with ∑_{d∣n} 1/d = k, so multiply perfect numbers fit the same template. abundancyIndex_eq_two_of_perfect is the forward direction extracted for reuse.",
+    "mathContext": "$n.\\mathrm{Perfect} \\iff \\sigma(n) = 2n \\iff \\dfrac{\\sigma(n)}{n} = 2 \\iff \\sum_{d\\mid n}\\dfrac1d = 2.$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.perfect_iff_sum_divisors_eq_two_mul", "k-perfect numbers", "clearing denominators", "biconditional", "casting ℕ↔ℚ"],
+    "prerequisites": ["definition of perfect number", "div_eq_iff", "the index identity above"]
   },
   {
     "id": "ann-concrete",
     "proofId": "perfect-numbers-oq-02",
-    "range": {
-      "startLine": 82,
-      "endLine": 100
-    },
+    "range": { "startLine": 74, "endLine": 90 },
     "type": "concept",
     "title": "6 and 28, Checked by Kernel Decide",
-    "content": "perfect_six and perfect_twentyEight establish that 6 and 28 are perfect using ordinary kernel `decide` on the divisor-sum condition ∑_{d∣n} d = 2n — no native_decide, so the entry stays axiom-free. Feeding them into the characterization gives 1/1 + 1/2 + 1/3 + 1/6 = 2 and the analogous identity for 28, the smallest concrete witnesses of the reciprocal-sum-equals-2 property."
+    "content": "perfect_six and perfect_twentyEight establish that 6 and 28 are perfect using ordinary kernel `decide` on the divisor-sum condition ∑_{d∣n} d = 2n — NOT native_decide, so the entry stays axiom-free (no Lean.ofReduceBool). Feeding them through the characterization gives abundancyIndex_six (1/1 + 1/2 + 1/3 + 1/6 = 2) and abundancyIndex_twentyEight, the smallest concrete witnesses of the reciprocal-sum-equals-2 property. These are the first two even perfect numbers 2^(p−1)(2^p−1) for p = 2, 3 (Mersenne primes 3, 7).",
+    "mathContext": "$\\tfrac11+\\tfrac12+\\tfrac13+\\tfrac16 = 2;\\quad 6 = 2^1(2^2-1),\\ 28 = 2^2(2^3-1).$",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "axiom-free verification", "Mersenne primes", "even perfect numbers", "concrete witnesses"],
+    "prerequisites": ["decidability of finite arithmetic", "the characterization above"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `perfect-numbers-oq-02`.

The entry's 3 existing annotations had good prose but were missing `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` (all four absent).

**Changes to `annotations.json`:**
- Upgraded all 3 existing annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- Added 2 new annotations (the docstring framing of the abundancy index; the `abundancyIndex` definition over ℚ), for 5 total covering the full file.
- All 5 align to Lean constructs (resolver: Valid 5, Misaligned 0).

This raises the entry from annotations carrying no LaTeX/significance/related-concept signal to the full schema. No prose content removed — only added to.

**Axiom integrity:** `status: verified`, `axiomCount: 0` confirmed — 6 and 28 use kernel `decide` (not native_decide), so no Lean.ofReduceBool; stays axiom-free.