### PR TITLE
Enrich Pell Finiteness Trichotomy (Pell OQ-04-01): index.ts + deepen annotations

### DIFF
--- a/src/data/proofs/pell-equation-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/pell-equation-oq-04-oq-01/annotations.json
@@ -1,11 +1,27 @@
 [
   {
+    "id": "ann-orbit-machinery",
+    "proofId": "pell-equation-oq-04-oq-01",
+    "range": { "startLine": 40, "endLine": 122 },
+    "type": "technique",
+    "title": "Self-Contained Norm Form, Composition, and Orbit",
+    "content": "To keep the file importing only Mathlib, the parent's infrastructure is re-derived locally: `normForm D x y = x²−Dy²`, `comp` (multiplication in ℤ[√D]), `normForm_comp` (Brahmagupta multiplicativity), and the orbit machinery `orbit`/`orbit_sol`/`orbit_pos`/`orbit_fst_strictMono`/`infinite_solutions`. The orbit of a seed under repeated composition with a unit (u≥2) has a strictly increasing first coordinate, so it injects ℕ into the solution set — the engine for the infinite branch of the classification.",
+    "mathContext": "$\\mathrm{orbit}_k=(a,b)\\cdot(u,v)^k,\\ u\\ge 2 \\Rightarrow \\text{fst}\\uparrow\\ \\Rightarrow\\ S_N\\text{ infinite}$",
+    "significance": "supporting",
+    "relatedConcepts": ["norm form", "Brahmagupta composition", "orbit", "strict monotonicity", "self-contained re-derivation"],
+    "prerequisites": ["the parent norm-form theory", "group orbits"]
+  },
+  {
     "id": "ann-engines",
     "proofId": "pell-equation-oq-04-oq-01",
     "range": { "startLine": 124, "endLine": 191 },
     "type": "insight",
     "title": "Two Arithmetic Engines: A Unit Exists, and the Form is Anisotropic",
-    "content": "The classification rests on two Mathlib facts about non-square D. `exists_unit` takes the nontrivial Pell solution from `Pell.exists_of_not_isSquare` (Lagrange's theorem) and normalizes it by absolute values to a unit (|x|,|y|) with |x| ≥ 2 — the bound |x| ≥ 2 holds because x² = 1 + Dy² ≥ 2 when D,y² ≥ 1. `solutions_zero` handles the degenerate right-hand side: identifying normForm D x y with the ℤ[√D]-norm of ⟨x,y⟩, `Zsqrtd.norm_eq_zero` (the norm is anisotropic for non-square D) forces x = y = 0, so x²−Dy²=0 has only the trivial solution (0,0). These are exactly the two places non-squareness is used — for square D both fail."
+    "content": "The classification rests on two Mathlib facts about non-square D. `exists_unit` takes the nontrivial Pell solution from `Pell.exists_of_not_isSquare` (Lagrange's theorem) and normalizes it by absolute values to a unit (|x|,|y|) with |x| ≥ 2 — the bound |x| ≥ 2 holds because x² = 1 + Dy² ≥ 2 when D,y² ≥ 1. `solutions_zero` handles the degenerate right-hand side: identifying normForm D x y with the ℤ[√D]-norm of ⟨x,y⟩, `Zsqrtd.norm_eq_zero` (the norm is anisotropic for non-square D) forces x = y = 0, so x²−Dy²=0 has only the trivial solution (0,0). These are exactly the two places non-squareness is used — for square D both fail.",
+    "mathContext": "$x^2=1+Dy^2\\ge 2 \\Rightarrow |x|\\ge 2;\\quad \\text{non-square }D:\\ x^2-Dy^2=0 \\Rightarrow x=y=0$",
+    "significance": "key",
+    "relatedConcepts": ["Pell.exists_of_not_isSquare", "Zsqrtd.norm_eq_zero", "anisotropy", "fundamental unit", "non-square hypothesis"],
+    "prerequisites": ["Lagrange's theorem on Pell units", "norms in ℤ[√D]"]
   },
   {
     "id": "ann-pos-seed",
@@ -13,14 +29,34 @@
     "range": { "startLine": 178, "endLine": 191 },
     "type": "insight",
     "title": "Infinitude Needs Only One Solution — Not a Positive One",
-    "content": "The parent proved infinitude from a *positive* seed; here `exists_pos_seed` removes that restriction. Given any solution (x,y) of x²−Dy²=N with N ≠ 0, it produces a positive seed (first coordinate ≥ 1, second ≥ 0) of the same norm. If x ≠ 0, take (|x|,|y|) — the norm is unchanged because |x|²=x². If x = 0, then N = −Dy² ≠ 0 forces y ≠ 0, and a single composition of (0,|y|) with the unit yields (D|y|v, |y|u), whose first coordinate D|y|v ≥ 1 and whose norm is still N·1 = N (a one-line `linear_combination` over the unit and seed norm equations). This is what upgrades the parent's seed-dependent infinitude into the clean dichotomy."
+    "content": "The parent proved infinitude from a *positive* seed; here `exists_pos_seed` removes that restriction. Given any solution (x,y) of x²−Dy²=N with N ≠ 0, it produces a positive seed (first coordinate ≥ 1, second ≥ 0) of the same norm. If x ≠ 0, take (|x|,|y|) — the norm is unchanged because |x|²=x². If x = 0, then N = −Dy² ≠ 0 forces y ≠ 0, and a single composition of (0,|y|) with the unit yields (D|y|v, |y|u), whose first coordinate D|y|v ≥ 1 and whose norm is still N·1 = N (a one-line `linear_combination` over the unit and seed norm equations). This is what upgrades the parent's seed-dependent infinitude into the clean dichotomy.",
+    "mathContext": "$(x,y),\\ N\\neq 0 \\Rightarrow \\exists (a,b),\\ a\\ge 1,\\ b\\ge 0,\\ a^2-Db^2=N$",
+    "significance": "key",
+    "relatedConcepts": ["positive seed normalization", "absolute value", "composition with unit", "linear_combination"],
+    "prerequisites": ["the parent's seed-based infinitude"]
   },
   {
     "id": "ann-trichotomy",
     "proofId": "pell-equation-oq-04-oq-01",
-    "range": { "startLine": 230, "endLine": 261 },
+    "range": { "startLine": 192, "endLine": 261 },
     "type": "insight",
     "title": "The Complete Trichotomy: Empty, {(0,0)}, or Infinite",
-    "content": "Assembling the engines gives the full finiteness picture for positive non-square D. `solutions_infinite` says a nonempty nonzero-N set is infinite (normalize to a positive seed, then run the orbit). `infinite_iff` packages this as the sharp equivalence: the set is infinite ⟺ N ≠ 0 and it is nonempty — so deciding infinitude reduces entirely to deciding solvability. `nonempty_finite_iff_zero` says a nonempty set is finite ⟺ N = 0. Finally `solution_set_trichotomy` case-splits on N=0 (→ {(0,0)}) and otherwise on emptiness, concluding every solution set is empty, the single point {(0,0)}, or infinite — there is no nontrivial finite solution set."
+    "content": "Assembling the engines gives the full finiteness picture for positive non-square D. `solutions_infinite` says a nonempty nonzero-N set is infinite (normalize to a positive seed, then run the orbit). `infinite_iff` packages this as the sharp equivalence: the set is infinite ⟺ N ≠ 0 and it is nonempty — so deciding infinitude reduces entirely to deciding solvability. `nonempty_finite_iff_zero` says a nonempty set is finite ⟺ N = 0. Finally `solution_set_trichotomy` case-splits on N=0 (→ {(0,0)}) and otherwise on emptiness, concluding every solution set is empty, the single point {(0,0)}, or infinite — there is no nontrivial finite solution set.",
+    "mathContext": "$S_N=\\varnothing\\ \\vee\\ S_N=\\{(0,0)\\}\\ (\\Leftrightarrow N=0)\\ \\vee\\ S_N\\text{ infinite}$",
+    "significance": "key",
+    "relatedConcepts": ["trichotomy", "finiteness classification", "0-or-∞ dichotomy", "case analysis"],
+    "prerequisites": ["Set.Infinite vs Set.Finite"]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "pell-equation-oq-04-oq-01",
+    "range": { "startLine": 262, "endLine": 276 },
+    "type": "context",
+    "title": "Worked Instances over ℤ[√2]",
+    "content": "The file closes with concrete instances illustrating all three branches of the trichotomy for D = 2 (¬IsSquare 2 via `Prime.not_isSquare` and `Int.prime_two`): x²−2y²=0 has only (0,0) (the single-point case), x²−2y²=7 is infinite (nonempty via the seed (3,1), nonzero N), and x²−2y²=2 is infinite (seed (2,1)). These ground the abstract classification in computable examples and double as regression checks that the headline theorems fire on real data.",
+    "mathContext": "$x^2-2y^2=0:\\{(0,0)\\};\\quad x^2-2y^2=7,\\ x^2-2y^2=2:\\ \\text{infinite}$",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "Prime.not_isSquare", "ℤ[√2]", "regression check"],
+    "prerequisites": ["the trichotomy theorem"]
   }
 ]

--- a/src/data/proofs/pell-equation-oq-04-oq-01/index.ts
+++ b/src/data/proofs/pell-equation-oq-04-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ04OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOq04Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOq04Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOq04Oq01Data: ProofData = {
+  proof: pellEquationOq04Oq01Proof,
+  annotations: pellEquationOq04Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-04-oq-01`.

**Critical fix:** the entry was missing `index.ts` — without it the page showed *'proof not found'* on the live site (annotations.json already existed).

Changes:
- **Created `index.ts`** — the Vite entry point for `PellEquationOQ04OQ01.lean`.
- **Deepened `annotations.json`** from 3 to 5, and added `mathContext`, `significance`, `relatedConcepts`, `prerequisites` to every annotation (the existing 3 had only `content`): added a self-contained orbit-machinery annotation and a worked-ℤ[√2]-instances annotation, alongside the engines, positive-seed, and trichotomy annotations.

All annotations are checked line-by-line against the Lean source.

Status unchanged: `verified`, 0 sorries, 0 axioms. JSON validated; pnpm build fails only at the known `tsc: command not found` (node_modules absent in worktree).