### PR TITLE
research(kummer-theorem-oq-02-oq-01): q-Kummer theorem for q-multinomial coefficients [axiomatized]

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ02OQ01.lean
@@ -1,0 +1,237 @@
+/-
+Kummer's Theorem OQ-02-OQ-01: q-Kummer for q-Multinomial Coefficients
+
+The parent entry `KummerTheoremOQ02` ("q-Kummer Theorem: Cyclotomic
+Factorization of q-Binomials") establishes the q-analog of Kummer's theorem for
+q-*binomial* coefficients:
+
+  [n choose k]_q = ∏_{d ≥ 2} Φ_d(q) ^ (⌊n/d⌋ - ⌊k/d⌋ - ⌊(n-k)/d⌋).
+
+This file answers the parent's first listed open question — *"Can the q-Kummer
+theorem be extended to q-multinomial coefficients?"* — in the affirmative, by
+lifting the result from two parts to an arbitrary number of parts:
+
+  [k₁ + ⋯ + kᵣ ; k₁, …, kᵣ]_q = [n]_q! / ([k₁]_q! ⋯ [kᵣ]_q!).
+
+The mechanism is the one the question hints at: the q-multinomial telescopes
+into a chain of q-binomials,
+
+  [k₁+⋯+kᵣ ; k₁,…,kᵣ]_q = [k₁+⋯+kᵣ choose k₁]_q · [k₂+⋯+kᵣ ; k₂,…,kᵣ]_q,
+
+so applying the parent's q-Kummer factorization to each q-binomial factor and
+multiplying gives the multinomial cyclotomic factorization, with exponent
+
+  multiDeficiency(k₁,…,kᵣ ; d) = ⌊(Σ kᵢ)/d⌋ - Σ ⌊kᵢ/d⌋
+
+(the total number of carries when adding k₁, …, kᵣ in base d).
+
+## Axioms (the parent's q-binomial interface)
+
+The three facts this extension consumes from the parent are stated here as
+`axiom`s rather than imported, because the parent source file
+`KummerTheoremOQ02.lean` uses the pre-`∈` big-operator notation and several
+since-renamed `Nat`/`Finset` lemmas, so it no longer compiles under the current
+Mathlib (v4.26.0) toolchain (a repository-wide bit-rot affecting the legacy
+`∑ … in` files; out of scope for this entry).  The axioms are exactly the
+parent's `theorem`s `qBinomial_factorial`, `qKummer`, and `qFactorial_eval_one`,
+which are mathematically established there:
+
+* `qBinomial_factorial`  — the quotient formula `[n choose k]_q · [k]_q! · [n-k]_q! = [n]_q!`.
+* `qKummer`              — the two-part q-Kummer cyclotomic factorization.
+* `qFactorial_eval_one`  — `[n]_q!` evaluated at `q = 1` equals `n!`.
+
+Everything in `Part XI` (the q-multinomial results) is proved from these with
+**no `sorry`s**; the only assumptions are the three axioms above.
+
+## New results (Part XI)
+* `qMultinomial`            — the q-multinomial as a chain of q-binomials.
+* `qMultinomial_factorial`  — quotient form `qMultinomial · ∏[kᵢ]_q! = [Σkᵢ]_q!`.
+* `qMultinomial_cyclotomic` — **the q-Kummer theorem for q-multinomials**.
+* `qMultinomial_eval_one`   — at `q = 1`, recovers `multinomial · ∏ kᵢ! = (Σkᵢ)!`.
+-/
+
+import Mathlib
+
+namespace KummerTheoremOQ02OQ01
+
+open Polynomial Finset Nat
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Definitions (q-number, q-factorial, q-binomial, floor deficiency)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The q-number `[n]_q = 1 + q + q² + ⋯ + q^(n-1)` as a polynomial in `ℤ[X]`. -/
+noncomputable def qNumber (n : ℕ) : ℤ[X] :=
+  ∑ i ∈ Finset.range n, X ^ i
+
+/-- The q-factorial `[n]_q! = [1]_q · [2]_q · ⋯ · [n]_q`. -/
+noncomputable def qFactorial : ℕ → ℤ[X]
+  | 0 => 1
+  | n + 1 => qFactorial n * qNumber (n + 1)
+
+/-- The q-binomial (Gaussian binomial) coefficient, via the q-Pascal recurrence. -/
+noncomputable def qBinomial : ℕ → ℕ → ℤ[X]
+  | _, 0 => 1
+  | 0, _ + 1 => 0
+  | n + 1, k + 1 => qBinomial n k + X ^ (k + 1) * qBinomial n (k + 1)
+
+/-- The two-part floor deficiency `⌊n/d⌋ - ⌊k/d⌋ - ⌊(n-k)/d⌋` (carry count for the
+q-binomial). -/
+def floorDeficiency (n k d : ℕ) : ℕ := n / d - k / d - (n - k) / d
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Parent interface (axiomatized — see header)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Quotient formula (parent `KummerTheoremOQ02.qBinomial_factorial`):
+`[n choose k]_q · [k]_q! · [n-k]_q! = [n]_q!`. -/
+axiom qBinomial_factorial (n k : ℕ) (hkn : k ≤ n) :
+    qBinomial n k * qFactorial k * qFactorial (n - k) = qFactorial n
+
+/-- The two-part q-Kummer cyclotomic factorization (parent `KummerTheoremOQ02.qKummer`):
+`[n choose k]_q = ∏_{d=2}^{n} Φ_d ^ floorDeficiency(n,k,d)`. -/
+axiom qKummer (n k : ℕ) (hkn : k ≤ n) :
+    qBinomial n k = ∏ d ∈ Icc 2 n, (cyclotomic d ℤ) ^ floorDeficiency n k d
+
+/-- Evaluation of the q-factorial at `q = 1` (parent `KummerTheoremOQ02.qFactorial_eval_one`):
+`[n]_q!|_{q=1} = n!`. -/
+axiom qFactorial_eval_one (n : ℕ) : (qFactorial n).eval 1 = (n ! : ℤ)
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Floor-division arithmetic (self-contained)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Subadditivity of floor division: `⌊a/d⌋ + ⌊b/d⌋ ≤ ⌊(a+b)/d⌋`. -/
+private lemma div_add_div_le (a b d : ℕ) (hd : 0 < d) : a / d + b / d ≤ (a + b) / d := by
+  rw [Nat.le_div_iff_mul_le hd]
+  calc (a / d + b / d) * d = a / d * d + b / d * d := by ring
+    _ ≤ a + b := Nat.add_le_add (Nat.div_mul_le_self a d) (Nat.div_mul_le_self b d)
+
+/-- The sum of the parts' floor-divisions is at most the floor-division of the
+total: `Σ ⌊kᵢ/d⌋ ≤ ⌊(Σ kᵢ)/d⌋` (iterated subadditivity). -/
+private lemma sum_div_le : ∀ (ks : List ℕ) (d : ℕ), 0 < d →
+    (ks.map (· / d)).sum ≤ ks.sum / d
+  | [], _, _ => by simp
+  | k :: ks, d, hd => by
+    have ih := sum_div_le ks d hd
+    simp only [List.map_cons, List.sum_cons]
+    calc k / d + (ks.map (· / d)).sum
+          ≤ k / d + ks.sum / d := Nat.add_le_add_left ih _
+      _ ≤ (k + ks.sum) / d := div_add_div_le k ks.sum d hd
+
+-- ══════════════════════════════════════════════════════════════════
+-- § Part XI: q-Multinomial Coefficients  (NEW — OQ-02-OQ-01)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The **q-multinomial coefficient** of a list of parts `[k₁, …, kᵣ]`, defined by
+the telescoping chain of q-binomials
+
+  `[k₁+⋯+kᵣ ; k₁,…,kᵣ]_q = [k₁+⋯+kᵣ choose k₁]_q · [k₂+⋯+kᵣ ; k₂,…,kᵣ]_q`,
+
+so the empty list gives `1`.  This is a polynomial in `q` with integer coefficients. -/
+noncomputable def qMultinomial : List ℕ → ℤ[X]
+  | [] => 1
+  | k :: ks => qBinomial (k + ks.sum) k * qMultinomial ks
+
+/-- The **multinomial floor deficiency** at `d`:
+`multiDeficiency(k₁,…,kᵣ ; d) = ⌊(Σ kᵢ)/d⌋ - Σ ⌊kᵢ/d⌋`, the total number of
+carries when adding `k₁, …, kᵣ` in base `d`. -/
+def multiDeficiency (ks : List ℕ) (d : ℕ) : ℕ :=
+  ks.sum / d - (ks.map (· / d)).sum
+
+/-- The deficiency obeys the chain recursion mirroring the q-multinomial:
+`multiDeficiency(k::ks ; d) = floorDeficiency(k+Σks, k, d) + multiDeficiency(ks ; d)`,
+where `floorDeficiency` is the parent's two-part (q-binomial) carry count. -/
+theorem multiDeficiency_cons (k : ℕ) (ks : List ℕ) (d : ℕ) (hd : 0 < d) :
+    multiDeficiency (k :: ks) d
+      = floorDeficiency (k + ks.sum) k d + multiDeficiency ks d := by
+  have hbc := div_add_div_le k ks.sum d hd
+  have htc := sum_div_le ks d hd
+  simp only [multiDeficiency, floorDeficiency, List.map_cons, List.sum_cons,
+    Nat.add_sub_cancel_left]
+  omega
+
+/-- The q-analog of `multinomial · k₁! ⋯ kᵣ! = (Σ kᵢ)!`:
+`qMultinomial ks · ∏ᵢ [kᵢ]_q! = [Σ kᵢ]_q!`.  This shows the chain definition is
+the genuine q-multinomial (the quotient `[n]_q! / ∏ [kᵢ]_q!` performed honestly
+inside `ℤ[X]`). -/
+theorem qMultinomial_factorial : ∀ ks : List ℕ,
+    qMultinomial ks * (ks.map qFactorial).prod = qFactorial ks.sum
+  | [] => by simp [qMultinomial, qFactorial]
+  | k :: ks => by
+    have ih := qMultinomial_factorial ks
+    have hbf := qBinomial_factorial (k + ks.sum) k (Nat.le_add_right k ks.sum)
+    simp only [Nat.add_sub_cancel_left] at hbf
+    rw [show qMultinomial (k :: ks)
+          = qBinomial (k + ks.sum) k * qMultinomial ks from rfl,
+        List.map_cons, List.prod_cons, List.sum_cons]
+    linear_combination (qBinomial (k + ks.sum) k * qFactorial k) * ih + hbf
+
+/-- **The q-Kummer Theorem for q-multinomial coefficients.**
+
+  `qMultinomial ks = ∏_{d=2}^{Σ kᵢ} Φ_d(q) ^ multiDeficiency(ks ; d)`.
+
+Each factor's exponent counts carries in base `d` when adding the parts; this
+generalizes the parent's two-part q-Kummer theorem to arbitrarily many parts.
+The proof is induction along the q-binomial chain: apply the parent `qKummer`
+to the head q-binomial, fold in the inductive factorization of the tail, and
+merge exponents via `multiDeficiency_cons`. -/
+theorem qMultinomial_cyclotomic : ∀ ks : List ℕ,
+    qMultinomial ks
+      = ∏ d ∈ Icc 2 ks.sum, (cyclotomic d ℤ) ^ multiDeficiency ks d
+  | [] => by
+    simp only [List.sum_nil, qMultinomial]
+    rw [Finset.Icc_eq_empty (by decide : ¬ (2 : ℕ) ≤ 0)]
+    simp
+  | k :: ks => by
+    have ih := qMultinomial_cyclotomic ks
+    have hbin := qKummer (k + ks.sum) k (Nat.le_add_right k ks.sum)
+    -- Extend the tail's factorization from `Icc 2 (Σks)` up to `Icc 2 (k+Σks)`:
+    -- the new factors carry exponent 0 since their `d` exceeds `Σks`.
+    have ih' : (∏ d ∈ Icc 2 ks.sum, (cyclotomic d ℤ) ^ multiDeficiency ks d)
+        = ∏ d ∈ Icc 2 (k + ks.sum), (cyclotomic d ℤ) ^ multiDeficiency ks d := by
+      apply Finset.prod_subset (Finset.Icc_subset_Icc_right (Nat.le_add_left ks.sum k))
+      intro d hd hdS
+      simp only [Finset.mem_Icc] at hd hdS
+      have hdgt : ks.sum < d := by omega
+      have hz : multiDeficiency ks d = 0 := by
+        simp [multiDeficiency, Nat.div_eq_of_lt hdgt]
+      rw [hz, pow_zero]
+    rw [show qMultinomial (k :: ks)
+          = qBinomial (k + ks.sum) k * qMultinomial ks from rfl,
+        List.sum_cons, hbin, ih, ih', ← Finset.prod_mul_distrib]
+    apply Finset.prod_congr rfl
+    intro d hd
+    simp only [Finset.mem_Icc] at hd
+    rw [← pow_add, multiDeficiency_cons k ks d (by omega)]
+
+/-- Evaluating a chain of q-factorials at `q = 1` gives the chain of ordinary
+factorials. -/
+private theorem eval_one_prod_qFactorial : ∀ l : List ℕ,
+    (Polynomial.eval (1 : ℤ)) (l.map qFactorial).prod
+      = (l.map (fun k => (k ! : ℤ))).prod
+  | [] => by simp
+  | a :: as => by
+    simp [List.map_cons, List.prod_cons, Polynomial.eval_mul, qFactorial_eval_one,
+      eval_one_prod_qFactorial as]
+
+/-- **Specialization at `q = 1`.**  The q-multinomial evaluated at `q = 1` is the
+ordinary multinomial coefficient, witnessed by
+
+  `(qMultinomial ks)(1) · ∏ᵢ kᵢ! = (Σ kᵢ)!`.
+
+Together with `qMultinomial_cyclotomic`, this exhibits `[n]_q! / ∏ [kᵢ]_q!` as a
+genuine polynomial recovering `(Σ kᵢ)! / ∏ kᵢ!` at `q = 1`. -/
+theorem qMultinomial_eval_one (ks : List ℕ) :
+    (qMultinomial ks).eval 1 * (ks.map (fun k => (k ! : ℤ))).prod
+      = ((ks.sum)! : ℤ) := by
+  have h := congrArg (Polynomial.eval (1 : ℤ)) (qMultinomial_factorial ks)
+  rw [Polynomial.eval_mul, qFactorial_eval_one, eval_one_prod_qFactorial ks] at h
+  exact h
+
+#check @qMultinomial
+#check @qMultinomial_factorial
+#check @qMultinomial_cyclotomic
+#check @qMultinomial_eval_one
+
+end KummerTheoremOQ02OQ01

--- a/src/data/proofs/kummer-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-qmultinomial-def",
+    "title": "q-Multinomial via the Telescoping Chain of q-Binomials",
+    "type": "concept",
+    "startLine": 132,
+    "endLine": 142,
+    "mathContext": "The q-multinomial of a list of parts is defined by the chain recursion [k₁+⋯+kᵣ ; k₁,…,kᵣ]_q = [k₁+⋯+kᵣ choose k₁]_q · [k₂+⋯+kᵣ ; k₂,…,kᵣ]_q, with the empty list giving 1. This avoids polynomial division: each factor is the parent's polynomial q-binomial.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Gaussian binomial coefficients",
+      "q-multinomial coefficients",
+      "telescoping products"
+    ],
+    "prerequisites": [
+      "q-analogs (Gaussian binomial coefficients)",
+      "structural recursion over lists"
+    ],
+    "content": "qMultinomial is defined on List ℕ by qMultinomial (k :: ks) = qBinomial (k + ks.sum) k * qMultinomial ks. The recursion mirrors the combinatorial fact that choosing an ordered set partition can be done one block at a time.",
+    "proofId": "kummer-theorem-oq-02-oq-01",
+    "range": { "startLine": 132, "endLine": 136 }
+  },
+  {
+    "id": "ann-multideficiency-cons",
+    "title": "Multinomial Carry Count and its Chain Recursion",
+    "type": "concept",
+    "startLine": 139,
+    "endLine": 156,
+    "mathContext": "multiDeficiency(ks, d) = ⌊(Σ kᵢ)/d⌋ - Σ ⌊kᵢ/d⌋ is the total number of carries when adding all parts in base d. Its chain recursion multiDeficiency(k::ks, d) = floorDeficiency(k+Σks, k, d) + multiDeficiency(ks, d) reduces it to the parent's two-part deficiency, and is lossless precisely because Σ⌊kᵢ/d⌋ ≤ ⌊(Σ kᵢ)/d⌋ (iterated subadditivity of floor division).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Kummer's theorem (carries)",
+      "floor division subadditivity",
+      "floor deficiency"
+    ],
+    "prerequisites": [
+      "floor-division arithmetic",
+      "natural-number truncated subtraction"
+    ],
+    "content": "The exponent recursion is proved by feeding the two floor-division bounds (div_add_div_le and the iterated sum_div_le) to omega, so every natural-number subtraction is genuine rather than truncated.",
+    "proofId": "kummer-theorem-oq-02-oq-01",
+    "range": { "startLine": 145, "endLine": 156 }
+  },
+  {
+    "id": "ann-qmultinomial-cyclotomic",
+    "title": "The q-Kummer Theorem for q-Multinomials",
+    "type": "theorem",
+    "startLine": 179,
+    "endLine": 208,
+    "mathContext": "qMultinomial ks = ∏_{d=2}^{Σ kᵢ} Φ_d(q)^{multiDeficiency(ks, d)}. The head q-binomial is factored by the parent's two-part qKummer over Icc 2 (k+Σks); the tail's factorization (inductive hypothesis) is extended to the same range (new factors have exponent 0 since their d exceeds Σ(tail)); the products merge factor-by-factor, and multiDeficiency_cons identifies the summed exponents.",
+    "significance": "core",
+    "relatedConcepts": [
+      "cyclotomic polynomials",
+      "q-Kummer theorem",
+      "multiplicativity over q-binomial factors"
+    ],
+    "prerequisites": [
+      "the two-part q-Kummer theorem (parent)",
+      "Finset product manipulations"
+    ],
+    "content": "Induction along the q-binomial chain propagates the parent's two-part cyclotomic factorization multiplicatively; no new cyclotomic input is required. This is the headline result answering the parent's first open question.",
+    "proofId": "kummer-theorem-oq-02-oq-01",
+    "range": { "startLine": 179, "endLine": 208 }
+  },
+  {
+    "id": "ann-qmultinomial-eval-one",
+    "title": "Specialization at q = 1: the Ordinary Multinomial Identity",
+    "type": "theorem",
+    "startLine": 225,
+    "endLine": 233,
+    "mathContext": "Evaluating the quotient form at q = 1 (via qFactorial_eval_one) gives (qMultinomial ks)(1) · ∏ᵢ kᵢ! = (Σ kᵢ)!, exhibiting the q-multinomial as a genuine polynomial whose value at q=1 is the ordinary multinomial coefficient (Σ kᵢ)! / ∏ kᵢ!.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multinomial coefficients",
+      "evaluation at q = 1",
+      "ring homomorphism eval"
+    ],
+    "prerequisites": [
+      "q-factorial at q = 1 equals n!",
+      "evaluation of polynomial products"
+    ],
+    "content": "The chain of q-factorials evaluates termwise to ordinary factorials, so the q=1 specialization of the quotient form is exactly the classical identity multinomial · ∏ kᵢ! = (Σ kᵢ)!.",
+    "proofId": "kummer-theorem-oq-02-oq-01",
+    "range": { "startLine": 225, "endLine": 233 }
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-02-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "kummer-theorem-oq-02-oq-01",
+  "title": "q-Kummer Theorem for q-Multinomial Coefficients",
+  "slug": "kummer-theorem-oq-02-oq-01",
+  "description": "The q-multinomial coefficient [k1+...+kr ; k1,...,kr]_q factors as a product of cyclotomic polynomials, Phi_d^E_d, where E_d = floor((sum ki)/d) - sum floor(ki/d) counts the total carries when adding k1,...,kr in base d. This lifts the parent's two-part q-Kummer theorem to arbitrarily many parts via the telescoping chain of q-binomials, answering the parent's first open question.",
+  "meta": {
+    "author": "Gauss (q-binomials, 1808), Kummer (carries, 1852); q-multinomial extension formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/KummerTheoremOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "q-analogs",
+      "cyclotomic-polynomials",
+      "multinomial-coefficients",
+      "polynomial-algebra",
+      "extension",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "assumptions": "3 axioms, 0 sorries. The three axioms — qBinomial_factorial (the q-binomial quotient formula), qKummer (the two-part q-Kummer cyclotomic factorization), and qFactorial_eval_one (q-factorial at q=1 equals n!) — are exactly the established theorems of the parent entry kummer-theorem-oq-02 (KummerTheoremOQ02.lean). They are stated here as axioms rather than imported because the parent source uses the pre-Mathlib-`∈` big-operator notation `∑ … in` and several since-renamed Nat/Finset lemmas, so it no longer compiles under the current Mathlib v4.26.0 toolchain (a repository-wide bit-rot affecting the legacy `∑ … in` files). All q-multinomial results in this file (Part XI) are proved from these axioms with no sorries; #print axioms confirms the only non-foundational dependencies are these three axioms (no sorryAx, no Lean.ofReduceBool).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.cyclotomic",
+        "description": "Cyclotomic polynomials over Z, the factors in the q-Kummer factorization",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Finset.prod_subset",
+        "description": "Extends the tail's cyclotomic product to a larger index range (new factors have exponent 0)",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.le_div_iff_mul_le",
+        "description": "Subadditivity of floor division, iterated to bound the sum of part deficiencies",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "qMultinomial: q-multinomial coefficient defined over a list of parts via the telescoping chain of q-binomials, no polynomial division",
+      "qMultinomial_factorial: the q-analog of multinomial * prod(ki!) = (sum ki)!, proved by induction along the chain with linear_combination",
+      "multiDeficiency / multiDeficiency_cons: the multinomial carry-count exponent and its chain recursion onto the parent's two-part floorDeficiency, via iterated subadditivity of floor division",
+      "qMultinomial_cyclotomic: THE q-KUMMER THEOREM FOR q-MULTINOMIALS — qMultinomial ks = prod Phi_d^multiDeficiency(ks,d), by inducting along the chain and merging per-factor q-Kummer factorizations",
+      "qMultinomial_eval_one: specialization at q=1 recovering the ordinary multinomial identity multinomial * prod(ki!) = (sum ki)!"
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 237,
+    "prerequisites": [
+      "q-analogs: q-numbers, q-factorials, and Gaussian (q-)binomial coefficients",
+      "Cyclotomic polynomials over Z and their nonvanishing",
+      "The two-part q-Kummer theorem (parent entry kummer-theorem-oq-02)",
+      "Floor-division arithmetic and Finset product manipulations",
+      "Structural recursion / induction over lists"
+    ],
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "Gauss introduced q-binomial (Gaussian binomial) coefficients in 1808; they count subspaces of vector spaces over finite fields and specialize to ordinary binomials at q=1. Kummer's 1852 theorem expresses the p-adic valuation of a binomial coefficient as a carry count. The parent entry kummer-theorem-oq-02 unified these into a q-Kummer theorem: the q-binomial factors into cyclotomic polynomials with carry-count exponents valid in ALL bases d >= 2. A natural next question — explicitly raised as the parent's first open question — is whether the same holds for q-MULTINOMIAL coefficients, which count flags of subspaces over F_q.",
+    "problemStatement": "**Open Question (parent OQ-01)**: Can the q-Kummer theorem be extended to q-multinomial coefficients?\n\n**Answer**: Yes. Writing the q-multinomial as the telescoping product of q-binomials [k1+...+kr ; k1,...,kr]_q = prod_i [k1+...+ki choose ki]_q, the parent's two-part q-Kummer factorization applies to each factor and the exponents add, giving\n  [k1+...+kr ; k1,...,kr]_q = prod_{d>=2} Phi_d(q)^{E_d},   E_d = floor((sum ki)/d) - sum_i floor(ki/d).",
+    "text": "The q-multinomial coefficient factors into cyclotomic polynomials whose exponents count the total carries when adding all the parts in base d, generalizing the two-part q-Kummer theorem to arbitrarily many parts.",
+    "proofStrategy": "**Definition**: qMultinomial is defined on a list of parts by the chain recursion qMultinomial (k::ks) = qBinomial (k + sum ks) k * qMultinomial ks.\n\n**Quotient form**: qMultinomial ks * prod (qFactorial ki) = qFactorial (sum ki), by list induction; the cons step combines the inductive hypothesis with the parent's qBinomial_factorial via linear_combination.\n\n**Carry-count exponent**: multiDeficiency(ks,d) = floor((sum ki)/d) - sum floor(ki/d). Its chain recursion multiDeficiency(k::ks,d) = floorDeficiency(k+sum ks, k, d) + multiDeficiency(ks,d) follows from iterated subadditivity of floor division (so all natural-number subtractions are genuine).\n\n**Cyclotomic factorization**: by list induction. The head q-binomial is factored by the parent's qKummer over Icc 2 (k+sum ks); the tail's factorization (inductive hypothesis) is extended from Icc 2 (sum ks) to the same range (new factors have exponent 0); the two products merge factor-by-factor, and multiDeficiency_cons identifies the summed exponents.\n\n**q=1 specialization**: evaluating the quotient form at q=1 (using qFactorial_eval_one) recovers the ordinary multinomial identity.",
+    "keyInsights": [
+      "The q-multinomial telescopes into a chain of q-binomials, so the two-part q-Kummer theorem propagates multiplicatively — no new cyclotomic input is needed beyond the parent's",
+      "The right exponent is the MULTINOMIAL floor deficiency floor((sum ki)/d) - sum floor(ki/d), the total carry count across all parts in base d",
+      "Subadditivity of floor division (sum of floors <= floor of sum), iterated over the list, is exactly what makes the natural-number subtraction in the exponent recursion lossless",
+      "Extending the tail product to the larger index range is sound because factors with d > sum(tail) have exponent 0",
+      "At q=1 the factorization degenerates to the classical multinomial coefficient identity"
+    ],
+    "prerequisites": [
+      "q-analogs and Gaussian (q-)binomial coefficients",
+      "The two-part q-Kummer theorem (parent)",
+      "Cyclotomic polynomials over Z",
+      "Floor-division arithmetic"
+    ]
+  },
+  "sections": [],
+  "conclusion": {
+    "summary": "The q-Kummer theorem extends from q-binomials to q-multinomials: the q-multinomial coefficient of any list of parts factors into cyclotomic polynomials whose exponents are the total base-d carry counts. The proof telescopes the q-multinomial into a chain of q-binomials and propagates the parent's two-part factorization multiplicatively, with the carry-count exponents adding via subadditivity of floor division.",
+    "implications": "1. **All bases, all parts**: the carry-count factorization holds for every base d >= 2 and any number of parts.\n2. **Multiplicativity**: the q-multinomial inherits its cyclotomic structure entirely from its q-binomial factors.\n3. **q=1 recovery**: degenerates to the ordinary multinomial identity multinomial * prod(ki!) = (sum ki)!.",
+    "openQuestions": [
+      "Does the cyclotomic factorization refine to a representation-theoretic statement about flags of subspaces over F_q?",
+      "Can the multinomial carry-count exponents be read off a single mixed-radix carry process?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "KummerTheoremOQ02OQ01",
+    "lineCount": 237,
+    "axiomCount": 3,
+    "theoremCount": 8,
+    "definitionCount": 6,
+    "path": "Proofs/KummerTheoremOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the two-part q-Kummer theorem (cyclotomic factorization of q-binomials). This entry answers its first open question by lifting the result to q-multinomial coefficients; the parent's qBinomial_factorial, qKummer, and qFactorial_eval_one are the three axioms consumed here."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gauss, Carl Friedrich",
+      "title": "Summatio quarumdam serierum singularium",
+      "year": "1808",
+      "venue": "Commentationes Societatis Regiae Scientiarum Gottingensis",
+      "note": "Introduction of Gaussian binomial coefficients"
+    },
+    {
+      "authors": "Kummer, Ernst Eduard",
+      "title": "Über die Ergänzungssätze zu den allgemeinen Reciprocitätsgesetzen",
+      "year": "1852",
+      "venue": "Journal für die reine und angewandte Mathematik 44, 93-146",
+      "note": "Classical Kummer's theorem: carries in base-p addition"
+    },
+    {
+      "authors": "Konvalinka, Matjaž; Pak, Igor",
+      "title": "Non-commutative extensions of the MacMahon Master Theorem",
+      "year": "2007",
+      "venue": "Advances in Mathematics",
+      "note": "q-analogs of classical combinatorial identities"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "qMultinomial_cyclotomic",
+      "type": "core",
+      "description": "The q-multinomial factors as a product of cyclotomic polynomials with multinomial carry-count exponents",
+      "leanType": "qMultinomial ks = prod (Icc 2 ks.sum) (fun d => (cyclotomic d Z) ^ multiDeficiency ks d)"
+    },
+    {
+      "name": "qMultinomial_factorial",
+      "type": "supporting",
+      "description": "Quotient form: qMultinomial ks * prod (map qFactorial ks) = qFactorial ks.sum",
+      "leanType": "qMultinomial ks * (ks.map qFactorial).prod = qFactorial ks.sum"
+    },
+    {
+      "name": "multiDeficiency_cons",
+      "type": "supporting",
+      "description": "Chain recursion of the multinomial carry count onto the two-part floor deficiency",
+      "leanType": "multiDeficiency (k :: ks) d = floorDeficiency (k + ks.sum) k d + multiDeficiency ks d"
+    },
+    {
+      "name": "qMultinomial_eval_one",
+      "type": "supporting",
+      "description": "At q=1 recovers the ordinary multinomial identity",
+      "leanType": "(qMultinomial ks).eval 1 * (ks.map (fun k => (k ! : Z))).prod = ((ks.sum)! : Z)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **kummer-theorem-oq-02**'s first listed open question — *"Can the q-Kummer theorem be extended to q-multinomial coefficients?"* — in the affirmative.

The q-multinomial telescopes into a chain of q-binomials, so the parent's two-part q-Kummer factorization propagates multiplicatively:

```
qMultinomial ks = ∏_{d=2}^{Σkᵢ} Φ_d(q) ^ multiDeficiency(ks, d)
```

where `multiDeficiency(ks, d) = ⌊(Σkᵢ)/d⌋ - Σ⌊kᵢ/d⌋` is the total number of carries when adding all parts in base `d`.

## New results (`Proofs/KummerTheoremOQ02OQ01.lean`, 237 lines)
- `qMultinomial` — q-multinomial over a list of parts via the telescoping chain of q-binomials (no polynomial division).
- `qMultinomial_factorial` — quotient form `qMultinomial ks · ∏ [kᵢ]_q! = [Σkᵢ]_q!`.
- `multiDeficiency_cons` — chain recursion of the multinomial carry count onto the parent's two-part `floorDeficiency`, lossless by iterated subadditivity of floor division.
- **`qMultinomial_cyclotomic`** — the headline q-Kummer theorem for q-multinomials.
- `qMultinomial_eval_one` — q=1 specialization recovering `multinomial · ∏ kᵢ! = (Σkᵢ)!`.

## Verification status: `axiomatized` (badge `axiom`), 0 sorries, 3 axioms

The three axioms — `qBinomial_factorial`, `qKummer`, `qFactorial_eval_one` — are exactly the **established theorems of the parent** `KummerTheoremOQ02.lean`. They are stated here as `axiom`s rather than imported because the parent source uses the pre-`∈` big-operator notation `∑ … in` and several since-renamed `Nat`/`Finset` lemmas, so **the parent no longer compiles under the current Mathlib v4.26.0 toolchain** (a repository-wide bit-rot affecting the legacy `∑ … in` files — see note below). All Part XI results are proved from these axioms with no `sorry`s.

`#print axioms` confirms the only non-foundational dependencies are these three axioms (no `sorryAx`, no `Lean.ofReduceBool`):
```
qMultinomial_cyclotomic depends on axioms: [propext, Classical.choice, qKummer, Quot.sound]
qMultinomial_factorial  depends on axioms: [propext, Classical.choice, qBinomial_factorial, Quot.sound]
qMultinomial_eval_one   depends on axioms: [propext, Classical.choice, qBinomial_factorial, qFactorial_eval_one, Quot.sound]
```

Built with elan `leanprover/lean4:v4.26.0`.

## Note for Mechanic / Auditor
The parent `KummerTheoremOQ02.lean` (and the whole legacy cohort of ~69 `Proofs/*.lean` files using the old `∑ … in` notation) no longer compiles at Mathlib v4.26.0: hard parse errors on `∑ … in`, renamed lemmas (`Nat.mod_eq_zero_iff_dvd`, `Finset.prod_ne_zero`), and `omega`-over-variable-division in `succ_div_step`. These entries are sorry-free but bit-rotted; reviving them is a separate repair task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)