### PR TITLE
Enrich Ferrari's Four Quartic Roots

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-factorization",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 52, "endLine": 62 },
+    "type": "insight",
+    "title": "The whole method is one polynomial identity",
+    "content": "ferrari_factorization is the algebraic heart: the depressed quartic equals the product of the two Ferrari quadratics Q₁ = x² − wx + (s+p/2+e) and Q₂ = x² + wx + (s+p/2−e). Ferrari's classical insight is to introduce an auxiliary parameter (here e, with s a resolvent shift) so that completing the square produces a difference of two squares, which factors. In Lean this collapses to a single `linear_combination x²·hw − x·hwe + he2`: the identity holds modulo the three relations w²=2s, 2we=q, e²=(s+p/2)²−r, and the tactic certifies it by exhibiting exactly those coefficients. No case analysis, no square roots yet — purely formal manipulation over any commutative ring.",
+    "mathContext": "$x^4+px^2+qx+r = (x^2 - wx + (s+\\tfrac p2+e))(x^2 + wx + (s+\\tfrac p2-e))$ given $w^2=2s,\\ 2we=q,\\ e^2=(s+\\tfrac p2)^2-r$",
+    "significance": "key",
+    "relatedConcepts": ["Ferrari's method", "completing the square", "difference of squares", "linear_combination", "resolvent cubic"],
+    "prerequisites": ["polynomial algebra", "quartic equations"]
+  },
+  {
+    "id": "ann-quadratic-root",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 68, "endLine": 73 },
+    "type": "technique",
+    "title": "The quadratic formula as a discriminant substitution",
+    "content": "monic_quadratic_root states that x² + bx + c vanishes at (−b ± d)/2 whenever d² = b² − 4c — i.e. d plays the role of the square root of the discriminant. The proof substitutes each closed form and closes with `linear_combination hd/4`, since after substitution the goal differs from the hypothesis d² = b²−4c only by the factor 1/4. This is the reusable atom underlying every root verification below: a root is checked not by deriving it but by plugging it in.",
+    "mathContext": "$d^2 = b^2 - 4c \\;\\Rightarrow\\; \\left(\\tfrac{-b\\pm d}{2}\\right)^2 + b\\left(\\tfrac{-b\\pm d}{2}\\right) + c = 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic formula", "discriminant", "monic polynomial"],
+    "prerequisites": ["quadratic equations"]
+  },
+  {
+    "id": "ann-four-roots",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 79, "endLine": 118 },
+    "type": "concept",
+    "title": "Each of the four closed forms is a genuine root",
+    "content": "ferrari_root_Q1 and ferrari_root_Q2 verify the two roots of each Ferrari quadratic: substituting (w±d₁)/2 into Q₁ (resp. (−w±d₂)/2 into Q₂) gives 0 via the discriminant identity hd₁ (resp. hd₂), and the factorization plus the vanishing factor force the whole quartic to vanish (rw the factor to 0, then `ring`). ferrari_four_roots bundles all four into a single statement over the finite root set {(w+d₁)/2, (w−d₁)/2, (−w+d₂)/2, (−w−d₂)/2}, dispatching membership by `rcases` into the two per-quadratic lemmas. Verification (substitute and simplify) is logically cheaper and more robust than derivation.",
+    "mathContext": "$d_1^2 = w^2 - 4(s+\\tfrac p2+e),\\quad d_2^2 = w^2 - 4(s+\\tfrac p2-e)$; the four roots are $\\tfrac{w\\pm d_1}{2},\\ \\tfrac{-w\\pm d_2}{2}$",
+    "significance": "key",
+    "relatedConcepts": ["root verification by substitution", "factor theorem", "mul_eq_zero", "closed-form roots"],
+    "prerequisites": ["polynomial roots", "quadratic formula"]
+  },
+  {
+    "id": "ann-splits",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 120, "endLine": 138 },
+    "type": "insight",
+    "title": "Complete splitting into four linear factors",
+    "content": "ferrari_splits upgrades root-by-root verification to a single factorization: the depressed quartic equals (x − (w+d₁)/2)(x − (w−d₁)/2)(x − (−w+d₂)/2)(x − (−w−d₂)/2). Each Ferrari quadratic is rewritten as a product of its two linear factors (again via `linear_combination hd/4`, since x²+bx+c = (x − r₁)(x − r₂) exactly when d² = b²−4c), and `ring` reassembles them. This exhibits the quartic as fully split over ℂ and makes the four roots simultaneously visible as the factor roots — the strongest form of the solvability statement.",
+    "mathContext": "$x^4+px^2+qx+r = \\prod_{i}(x-\\rho_i),\\quad \\rho_i \\in \\{\\tfrac{w\\pm d_1}{2}, \\tfrac{-w\\pm d_2}{2}\\}$",
+    "significance": "key",
+    "relatedConcepts": ["splitting field", "linear factorization", "algebraically closed field"],
+    "prerequisites": ["polynomial factorization", "field theory"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 144, "endLine": 175 },
+    "type": "technique",
+    "title": "Bridge: a resolvent root supplies the Ferrari data",
+    "content": "IsResolventRoot fixes the parent's resolvent cubic 8m³ + 20pm² + (16p²−8r)m + (4p³−4pr−q²) = 0. resolvent_shift_eq shows the Ferrari shift s = m + p/2 turns this exactly into the perfect-square parameter equation 8s³ + 8ps² + (2p²−8r)s = q² — the only consequence of the resolvent ever used. exists_ferrari_data then constructs e = q/(2w): the relation 2we = q is immediate by field_simp once w ≠ 0, and e² = (s+p/2)²−r follows by clearing the (2w)² = 8s denominator (div_eq_iff) and reducing to the shifted resolvent equation (linear_combination −hres). This is where the auxiliary parameter e acquires its meaning: it is forced by the resolvent root, not free.",
+    "mathContext": "$s = m + \\tfrac p2,\\quad 8s^3 + 8ps^2 + (2p^2-8r)s = q^2,\\quad e = \\tfrac{q}{2w}$",
+    "significance": "supporting",
+    "relatedConcepts": ["resolvent cubic", "parameter shift", "field_simp", "div_eq_iff", "Cardano chain"],
+    "prerequisites": ["cubic equations", "field arithmetic"]
+  },
+  {
+    "id": "ann-solvable",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 181, "endLine": 200 },
+    "type": "concept",
+    "title": "Explicit solvability of the depressed quartic over ℂ",
+    "content": "ferrari_solvable assembles the constructive existence statement: every depressed quartic with a nonzero-shift resolvent root has an explicit root over ℂ. Algebraic closure (IsAlgClosed.exists_pow_nat_eq) supplies the square roots w of 2s and d of the first discriminant; w ≠ 0 is forced because otherwise 2(m+p/2) = 0 contradicts the nonzero-shift hypothesis. Feeding the constructed data to ferrari_root_Q1 yields (w+d)/2 as a verified root. The nonzero-shift hypothesis s ≠ 0 excludes only the degenerate biquadratic case (q = 0), handled separately — flagged as an open question in the conclusion.",
+    "mathContext": "$\\exists x \\in \\mathbb{C},\\ x^4+px^2+qx+r = 0$ via $w^2 = 2(m+\\tfrac p2),\\ d^2 = w^2 - 4(s+\\tfrac p2+e)$",
+    "significance": "key",
+    "relatedConcepts": ["constructive existence", "IsAlgClosed", "square roots in ℂ", "solvability by radicals", "biquadratic degenerate case"],
+    "prerequisites": ["algebraically closed fields", "existence of roots"]
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/index.ts
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SolutionOfCubicOQ03OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const ferrariQuarticRootsProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const ferrariQuarticRootsAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const ferrariQuarticRootsData: ProofData = {
+  proof: ferrariQuarticRootsProof,
+  annotations: ferrariQuarticRootsAnnotations,
+}


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-03-oq-03-oq-02`.

**Critical fix:** added the missing `index.ts` — without it the proof page renders 'proof not found' on the live site. Also added `annotations.json` (6 inline annotations, each with mathContext/significance/relatedConcepts/prerequisites): the single-`linear_combination` factorization, the discriminant quadratic-root atom, the four-root verification-by-substitution, complete splitting into linear factors, the resolvent-cubic bridge, and constructive solvability over ℂ.

The meta.json was already comprehensive (overview with keyInsights/problemStatement/proofStrategy, 6 sections with line ranges and mathContext, conclusion with openQuestions, crossReferences), so this pass adds the two missing files that block rendering and annotation coverage.

**Axiom integrity:** verified accurate — 0 sorries / 0 axioms over ℂ (#print axioms reports only propext/Classical.choice/Quot.sound). status=verified / badge=original retained.

JSON validated with python (node_modules absent in worktree so `pnpm build` cannot run).