### PR TITLE
audit: mark 4 fresh proofs clean (sphere-surface/cayley-hamilton/ferrari-quartic/vdw-first-moment)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23763,6 +23763,30 @@
       "lastAudited": "2026-06-25T11:02:57Z",
       "result": "clean",
       "issues": []
+    },
+    "area-of-circle-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:44:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:45:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "solution-of-cubic-oq-03-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:46:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "van-der-waerden-first-moment": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T11:47:59Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

All 4 never-audited gallery proofs verified **clean**. Gallery now 3830/3830 audited, 0 issues.

| Proof | Status/Badge | Verdict |
|-------|-------------|---------|
| area-of-circle-oq-02-oq-03 (sphere surface Sₙ=n·Vₙ) | verified/original | 0 sorry/axiom/stub; genuine Gamma-recurrence identity, not a tautology (independent Gamma closed form) |
| cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01 | axiomatized/axiom | axiomCount=1 matches 1 `axiom` decl; Frobenius dimension bound transparently disclosed in `assumptions` |
| solution-of-cubic-oq-03-oq-03-oq-02 (Ferrari quartic roots) | verified/original | 0 sorry/axiom; substantive root + factorization theorems over ℂ, no vacuous conclusions |
| van-der-waerden-first-moment | verified/original | 0 sorry/axiom; legitimate application of clean sibling `PropertyBFirstMoment` (itself 0-sorry/0-axiom), honest crediting |

### Notes
- Grep `sorry`/`native_decide` hits in the cubic and vdW files were **docstring false positives** ("No `sorry`", "No `native_decide`"). No real occurrences.
- Only `src/data/proofs/audit-tracker.json` changed.

---
Discovered during autonomous gallery integrity audit.