### PR TITLE
Enrich Gaussian integral = √π

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-aoc07-context",
     "proofId": "area-of-circle-oq-07",
-    "range": { "startLine": 1, "endLine": 27 },
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
     "type": "concept",
     "title": "The Gaussian Integral and Its Place in the Gallery",
     "content": "This entry answers open question 7 of the `area-of-circle` parent: the total integral of the Gaussian bell curve `e^{-x²}` over all of ℝ is `√π`. Rather than redo the classical squaring-and-polar-coordinates evaluation, it specializes Mathlib's already-proved parametrized Gaussian integral `integral_gaussian (b) : ∫ x, exp (-b·x²) = √(π/b)` at `b = 1`. This is deliberately a *routine specialization* — the analytic content lives entirely inside Mathlib — but it is the iconic case: `√π` is the normalization constant of the standard normal distribution and the simplest definite integral whose value carries a factor of π with no circle in sight.",
@@ -23,25 +26,47 @@
   {
     "id": "ann-aoc07-main",
     "proofId": "area-of-circle-oq-07",
-    "range": { "startLine": 31, "endLine": 35 },
+    "range": {
+      "startLine": 31,
+      "endLine": 35
+    },
     "type": "technique",
     "title": "Specializing integral_gaussian at b = 1",
     "content": "The whole proof is two lines. `have h := integral_gaussian 1` instantiates Mathlib's lemma to `∫ x, exp (-1 * x ^ 2) = √(π / 1)`. The goal differs only cosmetically: its integrand is `exp (-x ^ 2)` and its value is `√π`. `simpa only [neg_one_mul, div_one] using h` closes the gap — `neg_one_mul` rewrites `-1 * x ^ 2` to `-(x ^ 2)` (definitionally `-x ^ 2`, since `^` binds tighter than unary `-`), and `div_one` rewrites `π / 1` to `π`. No measure-theoretic reasoning is reproduced here; it is inherited wholesale from `integral_gaussian`.",
     "mathContext": "Specialization of a parametrized result is the cheapest possible kind of formal proof, but it is only valid when the syntactic match is exact. The only real obligations are the coefficient `1 *` in the exponent and the `/ 1` in the value — both discharged by `simp` normal-form lemmas.",
-    "significance": "important",
-    "relatedConcepts": ["parametrized lemma specialization", "neg_one_mul", "div_one", "simpa"],
-    "prerequisites": ["integral_gaussian", "simp normal forms"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parametrized lemma specialization",
+      "neg_one_mul",
+      "div_one",
+      "simpa"
+    ],
+    "prerequisites": [
+      "integral_gaussian",
+      "simp normal forms"
+    ]
   },
   {
     "id": "ann-aoc07-sq",
     "proofId": "area-of-circle-oq-07",
-    "range": { "startLine": 37, "endLine": 41 },
+    "range": {
+      "startLine": 37,
+      "endLine": 41
+    },
     "type": "technique",
     "title": "The Squared Identity (∫ e^{-x²})² = π",
     "content": "`gaussian_integral_sq` records the value that the classical polar-coordinate computation actually produces: the *square* of the integral is exactly `π`. It follows immediately from the main theorem by `rw [gaussian_integral_eq_sqrt_pi, Real.sq_sqrt Real.pi_nonneg]`, since `√π ^ 2 = π` whenever `π ≥ 0`. This is the algebraic heart of the squaring argument — the step where, in the from-scratch derivation, the two-dimensional integral over ℝ² in polar coordinates evaluates to `π` via the `r dr dθ` Jacobian of the parent `area-of-circle` entry.",
     "mathContext": "Squaring is the natural object: $I^2$ is a genuine planar integral that polar coordinates evaluate cleanly, whereas $I$ itself has no elementary antiderivative. Stating the squared identity separately makes the connection to the parent's circle-area Jacobian explicit and isolates the one place a factor of $\\pi$ is created.",
-    "significance": "important",
-    "relatedConcepts": ["Real.sq_sqrt", "squaring the Gaussian integral", "polar-coordinate Jacobian"],
-    "prerequisites": ["gaussian_integral_eq_sqrt_pi", "Real.sq_sqrt", "Real.pi_nonneg"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.sq_sqrt",
+      "squaring the Gaussian integral",
+      "polar-coordinate Jacobian"
+    ],
+    "prerequisites": [
+      "gaussian_integral_eq_sqrt_pi",
+      "Real.sq_sqrt",
+      "Real.pi_nonneg"
+    ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-07/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Data: ProofData = {
+  proof: areaOfCircleOq07Proof,
+  annotations: areaOfCircleOq07Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07/meta.json
@@ -19,6 +19,34 @@
     "sorries": 0
   },
   "title": "The Gaussian Integral Equals √π",
+  "description": "Answers open question 7 of the area-of-circle parent: the total integral of the Gaussian bell curve e^{-x²} over all of ℝ equals √π. Rather than redo the classical squaring-and-polar-coordinates evaluation, the proof specializes Mathlib's parametrized Gaussian integral integral_gaussian at b = 1, and a short corollary squares the result to (∫ e^{-x²})² = π — the algebraic heart of the polar argument, where the parent's circle-area Jacobian r dr dθ appears.",
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_ℝ e^{-x²} dx = √π is one of the most celebrated definite integrals in analysis. It has no elementary antiderivative, yet its value over the whole line is exactly √π. The standard evaluation — squaring the integral and passing to polar coordinates — is usually credited to Laplace (Théorie analytique des probabilités, 1812) and Poisson, and the result is foundational to probability: √π (more precisely √(2π)) is the normalization constant of the normal distribution. In the gallery it is the natural companion to area-of-circle, because the factor of π it produces enters through exactly the circle-area Jacobian of the polar substitution.",
+    "problemStatement": "Prove that $\\int_{-\\infty}^{\\infty} e^{-x^2}\\, dx = \\sqrt{\\pi}$, the b = 1 case of the parametrized Gaussian integral $\\int_{\\mathbb{R}} e^{-b x^2}\\,dx = \\sqrt{\\pi/b}$, and record the squared identity $\\left(\\int_{\\mathbb{R}} e^{-x^2}\\,dx\\right)^2 = \\pi$.",
+    "proofStrategy": "Both theorems are short specializations of existing Mathlib results, not from-scratch analysis. gaussian_integral_eq_sqrt_pi instantiates integral_gaussian at b = 1: the integrand exp(-1·x²) normalizes to exp(-x²) via neg_one_mul and the value √(π/1) normalizes to √π via div_one, closed by `simpa only [neg_one_mul, div_one]`. gaussian_integral_sq then squares the value with Real.sq_sqrt Real.pi_nonneg, since (√π)² = π for π ≥ 0. The measure-theoretic content (the actual polar-coordinate evaluation) is inherited wholesale from integral_gaussian.",
+    "keyInsights": [
+      "The Gaussian integral has no elementary antiderivative, so the integral I itself cannot be evaluated by the fundamental theorem of calculus; only its square I² — a genuine planar integral — admits a clean polar evaluation, which is why the squared identity is stated separately.",
+      "Squaring and switching to polar coordinates produces the factor π through the Jacobian r dr dθ — exactly the circle-area object of the parent entry — so the appearance of π here is not coincidental but the same geometric fact in analytic disguise.",
+      "Formalization-wise this is an honest, routine specialization: Mathlib's integral_gaussian already encapsulates the hard analytic work, so the entry's value is curatorial (the iconic b = 1 case) rather than a new proof. The badge 'mathlib' reflects this honestly.",
+      "The b = 1 value √π is the seed from which the standard-normal normalization √(2π) (the b = 1/2 case) and the whole normal-distribution density follow — flagged as the first open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "main",
+      "title": "The Gaussian Integral Equals √π",
+      "startLine": 31,
+      "endLine": 35,
+      "summary": "gaussian_integral_eq_sqrt_pi specializes Mathlib's integral_gaussian at b = 1: exp(-1·x²) → exp(-x²) by neg_one_mul and √(π/1) → √π by div_one, closed in one `simpa`."
+    },
+    {
+      "id": "squared",
+      "title": "The Squared Identity (∫ e^{-x²})² = π",
+      "startLine": 37,
+      "endLine": 41,
+      "summary": "gaussian_integral_sq squares the value to π via Real.sq_sqrt — the algebraic value the classical polar-coordinate computation produces, linking back to the parent's circle-area Jacobian."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07`.

**Critical fixes:**
- Added the missing `index.ts` — without it the proof page renders 'proof not found' on the live site.
- Added a top-level `description` field — `index.ts` reads `meta.description`, which was previously `undefined` (blank on the page).

**Depth added to meta.json (previously had neither):**
- `overview` with historicalContext (Laplace/Poisson, normal-distribution normalization), problemStatement, proofStrategy, and 4 keyInsights.
- `sections` covering both theorems (the b = 1 specialization and the squared identity).

**Annotation hygiene:** normalized `significance: "important"` → `"supporting"` (the schema enum is key|supporting|technical|context). The existing 3 annotations already carried rich mathContext/relatedConcepts/prerequisites and cover the full 41-line file, so no new annotations were needed.

**Axiom integrity:** verified accurate — 0 sorries / 0 axioms; `badge: "mathlib"` correctly reflects that this is an honest specialization of Mathlib's integral_gaussian rather than original analysis. status=verified retained.

JSON validated with python (node_modules absent in worktree so `pnpm build` cannot run).