### PR TITLE
Enrich complex Gaussian integral (π/b)^{1/2}

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-aoc07oq01-context",
     "proofId": "area-of-circle-oq-07-oq-01",
-    "range": { "startLine": 4, "endLine": 41 },
+    "range": {
+      "startLine": 4,
+      "endLine": 28
+    },
     "type": "concept",
     "title": "From the Real Gaussian to the Complex Right Half-Plane",
     "content": "This entry answers open question 1 of the `area-of-circle-oq-07` parent (the real Gaussian `∫ e^{-x²} = √π`): it extends the parameter from the single real value `b = 1` to every complex `b` with `0 < re b`, giving `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`. The value is now a complex principal `(1/2)`-power rather than a real square root. The genuine content is twofold: the move to complex `b` is the analytic continuation that links the absolutely convergent Gaussian regime to the Fresnel oscillatory integrals on the boundary `re b = 0`, and the bridge theorem shows this complex statement strictly subsumes the real parent.",
@@ -23,25 +26,46 @@
   {
     "id": "ann-aoc07oq01-complex",
     "proofId": "area-of-circle-oq-07-oq-01",
-    "range": { "startLine": 44, "endLine": 51 },
+    "range": {
+      "startLine": 32,
+      "endLine": 38
+    },
     "type": "technique",
     "title": "Restating integral_gaussian_complex",
     "content": "`gaussian_integral_complex` is a direct restatement of Mathlib's `integral_gaussian_complex`: under the hypothesis `0 < re b` it returns `∫ x : ℝ, exp (-b · x²) = (π/b)^{1/2}`. All analytic work — differentiating the Gaussian under the integral sign and the polar-coordinate evaluation — is inherited wholesale; the entry contributes the gallery framing and, in the companion theorem, the explicit recovery of the parent.",
     "mathContext": "Stating the lemma with `b : ℂ` rather than `b : ℝ` is what makes the result a generalization rather than a notation variant: the codomain value `(π/b)^{1/2}` is a `Complex.cpow`, and only on the positive real axis does it reduce to a real square root.",
-    "significance": "important",
-    "relatedConcepts": ["integral_gaussian_complex", "Complex.cpow", "right half-plane re b > 0"],
-    "prerequisites": ["integral_gaussian_complex"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integral_gaussian_complex",
+      "Complex.cpow",
+      "right half-plane re b > 0"
+    ],
+    "prerequisites": [
+      "integral_gaussian_complex"
+    ]
   },
   {
     "id": "ann-aoc07oq01-bridge",
     "proofId": "area-of-circle-oq-07-oq-01",
-    "range": { "startLine": 53, "endLine": 60 },
+    "range": {
+      "startLine": 40,
+      "endLine": 60
+    },
     "type": "technique",
     "title": "Recovering √π as the b = 1 Case",
     "content": "`gaussian_integral_eq_sqrt_pi_via_complex` derives the parent's real value `∫_ℝ e^{-x²} dx = √π` from the complex result at `b = 1`. The proof has two casting steps. `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` by `Complex.ofReal_exp` plus `push_cast; ring` on the exponent. `hRcast` collapses the principal power: `Real.sqrt_eq_rpow` writes `√π = π^{1/2}` (real rpow), `Complex.ofReal_cpow π_nonneg` turns `↑(π^{1/2})` into `(↑π)^{(1/2 : ℂ)}`, matching `(π/1)^{1/2}`. Rewriting both sides of the specialized hypothesis and `exact_mod_cast` finishes.",
     "mathContext": "The non-trivial part of relating a complex statement to a real one is precisely the two identifications performed here: that a real-valued integral equals the real part of (here, the `ℂ`-coercion of) its complex form, and that a complex principal `(1/2)`-power of a positive real equals that real's square root. Both are exactly where a careless 'just set b = 1' would go wrong.",
-    "significance": "important",
-    "relatedConcepts": ["integral_complex_ofReal", "Complex.ofReal_cpow", "Real.sqrt_eq_rpow", "exact_mod_cast"],
-    "prerequisites": ["gaussian_integral_complex", "Complex.ofReal_exp", "Complex.ofReal_cpow"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integral_complex_ofReal",
+      "Complex.ofReal_cpow",
+      "Real.sqrt_eq_rpow",
+      "exact_mod_cast"
+    ],
+    "prerequisites": [
+      "gaussian_integral_complex",
+      "Complex.ofReal_exp",
+      "Complex.ofReal_cpow"
+    ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq01Data: ProofData = {
+  proof: areaOfCircleOq07Oq01Proof,
+  annotations: areaOfCircleOq07Oq01Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-01/meta.json
@@ -20,6 +20,34 @@
     "sorries": 0
   },
   "title": "The Complex Gaussian Integral (π/b)^{1/2}",
+  "description": "Generalizes the parent's real Gaussian ∫_ℝ e^{-x²} dx = √π (the b = 1 case) to the complex parameter: for every b : ℂ with 0 < re b, ∫_ℝ e^{-b x²} dx = (π/b)^{1/2}, a restatement of Mathlib's integral_gaussian_complex over the right half-plane. A bridge theorem recovers the real √π as the b = 1 specialization, pushing the real-valued integral through ℂ and collapsing the complex principal power (π/1)^{1/2} to (√π : ℂ). This is the analytic continuation underlying the Fresnel oscillatory integrals reached as re b → 0⁺.",
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_ℝ e^{-b x²} dx = √(π/b) is classically stated for real b > 0, but its extension to complex b with positive real part is the analytic continuation that connects the absolutely convergent Gaussian regime to the conditionally convergent Fresnel integrals ∫ cos(t x²), ∫ sin(t x²) reached on the imaginary axis re b = 0. This continuation is standard in Fourier analysis (Stein–Shakarchi) and is the key to evaluating oscillatory integrals; over the complex right half-plane the value (π/b)^{1/2} is a principal (1/2)-power, reducing to a real square root only on the positive real axis.",
+    "problemStatement": "Extend the real Gaussian integral $\\int_{\\mathbb{R}} e^{-x^2}\\,dx = \\sqrt{\\pi}$ (the $b = 1$ case) to the complex-parameter Gaussian $\\int_{\\mathbb{R}} e^{-b x^2}\\,dx = (\\pi/b)^{1/2}$ for every $b : \\mathbb{C}$ with $0 < \\operatorname{re} b$, and recover the real parent as the $b = 1$ specialization.",
+    "proofStrategy": "gaussian_integral_complex restates Mathlib's integral_gaussian_complex directly under the hypothesis 0 < re b. The bridge gaussian_integral_eq_sqrt_pi_via_complex recovers the real value at b = 1 in two casting steps: hLcast identifies the real integral with its ℂ-image (integral_complex_ofReal moves the coercion outside, then Complex.ofReal_exp + push_cast/ring match the exponent), and hRcast collapses the complex principal power (π/1)^{1/2} to (√π : ℂ) via Real.sqrt_eq_rpow and Complex.ofReal_cpow. Rewriting and exact_mod_cast then transfer the complex equality back to ℝ.",
+    "keyInsights": [
+      "Working over b : ℂ rather than b : ℝ is what makes this a genuine generalization rather than a notation change: the value (π/b)^{1/2} is a Complex.cpow (principal branch), reducing to a real square root only on the positive real axis.",
+      "The recovery of the real parent is not a trivial 'set b = 1' — it requires identifying a real-valued integral with the ℂ-coercion of its complex form (integral_complex_ofReal) and a complex principal (1/2)-power of a positive real with that real's square root (Complex.ofReal_cpow). These two casts are exactly where naive specialization fails.",
+      "The right half-plane re b > 0 is precisely the region of absolute convergence; the continuation to the boundary re b = 0 is what yields the Fresnel integrals, so this entry is the analytic bridge between the Gaussian and oscillatory regimes.",
+      "As with the parent, the hard analysis (differentiating under the integral, polar evaluation) is inherited from Mathlib; the entry's contribution is the gallery framing and the explicit, correctly-cast parent recovery — honestly badged 'mathlib'."
+    ]
+  },
+  "sections": [
+    {
+      "id": "complex-gaussian",
+      "title": "The Complex Gaussian Integral",
+      "startLine": 32,
+      "endLine": 38,
+      "summary": "gaussian_integral_complex restates Mathlib's integral_gaussian_complex: for 0 < re b, ∫ x : ℝ, exp(-b·x²) = (π/b)^{1/2} over the complex right half-plane."
+    },
+    {
+      "id": "parent-recovery",
+      "title": "Recovering √π as the b = 1 Case",
+      "startLine": 40,
+      "endLine": 60,
+      "summary": "gaussian_integral_eq_sqrt_pi_via_complex derives the real ∫ e^{-x²} = √π from the complex result at b = 1 via two casting lemmas (hLcast through integral_complex_ofReal, hRcast through Complex.ofReal_cpow) and exact_mod_cast."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-01`.

**Critical fixes:**
- Added the missing `index.ts` — without it the proof page renders 'proof not found' on the live site.
- Added a top-level `description` field — `index.ts` reads `meta.description`, previously `undefined` (blank on the page).

**Depth added to meta.json (previously had neither):**
- `overview` with historicalContext (analytic continuation, Fresnel link, Stein–Shakarchi), problemStatement, proofStrategy, and 4 keyInsights.
- `sections` covering both theorems (the complex restatement and the b = 1 parent recovery).

**Annotation hygiene:** corrected the 3 annotations' line ranges to match the actual theorem locations (docstring 4–28, complex theorem 32–38, bridge 40–60) and normalized `significance: "important"` → `"supporting"` (schema enum). The annotations already carried rich mathContext/relatedConcepts/prerequisites.

**Axiom integrity:** verified accurate — 0 sorries / 0 axioms; `badge: "mathlib"` correctly reflects an honest restatement + cast of Mathlib's integral_gaussian_complex. status=verified retained.

JSON validated with python (node_modules absent in worktree so `pnpm build` cannot run).