### PR TITLE
Enrich squared complex Gaussian integral π/b

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-aoc07oq04-context",
     "proofId": "area-of-circle-oq-07-oq-04",
-    "range": { "startLine": 4, "endLine": 30 },
+    "range": {
+      "startLine": 4,
+      "endLine": 30
+    },
     "type": "concept",
     "title": "Squaring Removes the Branch Cut",
     "content": "The sibling `area-of-circle-oq-07-oq-01` evaluates the complex Gaussian `∫_ℝ e^{-b x²} dx = (π/b)^{1/2}`, a genuine complex principal `(1/2)`-power. This entry observes that its **square** is far simpler: `(∫_ℝ e^{-b x²} dx)² = π/b`, with no fractional power. Over the right half-plane `{b : ℂ | re b > 0}` the base `π/b` is nonzero, so the two half-powers add cleanly. This is the complex-parameter form of the classical two-dimensional identity `(∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π` that computes the Gaussian (and, in the parent, the area of a circle).",
@@ -23,25 +26,47 @@
   {
     "id": "ann-aoc07oq04-sq",
     "proofId": "area-of-circle-oq-07-oq-04",
-    "range": { "startLine": 34, "endLine": 45 },
+    "range": {
+      "startLine": 34,
+      "endLine": 45
+    },
     "type": "technique",
     "title": "Collapsing the Power via Complex.cpow_add",
     "content": "`gaussian_integral_complex_sq` rewrites the integral to `(π/b)^{1/2}` (Mathlib's `integral_gaussian_complex`), expands the square with `pow_two` to `(π/b)^{1/2} · (π/b)^{1/2}`, then applies `Complex.cpow_add` in reverse to fuse the exponents into `(π/b)^{1/2 + 1/2}`. The side condition of `cpow_add` is `π/b ≠ 0`, supplied by `div_ne_zero` from `Real.pi_ne_zero` and `b ≠ 0` (which follows from `0 < re b`). A final `norm_num` evaluates `1/2 + 1/2 = 1` and discharges `(π/b)^1 = π/b`.",
     "mathContext": "The additive law $x^{y+z} = x^y\\,x^z$ for complex principal powers holds precisely when $x \\neq 0$; this is the single hypothesis that the right half-plane guarantees. Without it (e.g. crossing to $b$ with $\\pi/b$ a negative real) the half-powers would not add and the square would pick up a sign from the branch cut.",
-    "significance": "important",
-    "relatedConcepts": ["Complex.cpow_add", "pow_two", "div_ne_zero", "right half-plane re b > 0"],
-    "prerequisites": ["integral_gaussian_complex", "Complex.cpow_add"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Complex.cpow_add",
+      "pow_two",
+      "div_ne_zero",
+      "right half-plane re b > 0"
+    ],
+    "prerequisites": [
+      "integral_gaussian_complex",
+      "Complex.cpow_add"
+    ]
   },
   {
     "id": "ann-aoc07oq04-recover",
     "proofId": "area-of-circle-oq-07-oq-04",
-    "range": { "startLine": 47, "endLine": 64 },
+    "range": {
+      "startLine": 47,
+      "endLine": 64
+    },
     "type": "technique",
     "title": "Recovering π as the b = 1 Case",
     "content": "`gaussian_integral_sq_eq_pi` derives the parent's real value `(∫_ℝ e^{-x²} dx)² = π` from the complex result at `b = 1`. The cast `hLcast` identifies the real integral with its complex image: since the integrand is real-valued, `integral_complex_ofReal` moves the `ℂ`-coercion outside the integral, and pointwise `↑(e^{-x²}) = e^{-1·(↑x)²}` by `Complex.ofReal_exp` plus `push_cast; ring`. With `π/1` simplified to `π` by `div_one`, rewriting the hypothesis and `exact_mod_cast` finishes.",
     "mathContext": "The squared statement is what the parent `area-of-circle-oq-07` actually computes en route to `√π`: the two-dimensional Gaussian integral equals `π` directly, and the square root is extracted afterward. Recovering `π` (rather than `√π`) at `b = 1` makes this entry the faithful complex lift of the parent's central computation.",
-    "significance": "important",
-    "relatedConcepts": ["integral_complex_ofReal", "Complex.ofReal_exp", "div_one", "exact_mod_cast"],
-    "prerequisites": ["gaussian_integral_complex_sq", "Complex.ofReal_exp"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "integral_complex_ofReal",
+      "Complex.ofReal_exp",
+      "div_one",
+      "exact_mod_cast"
+    ],
+    "prerequisites": [
+      "gaussian_integral_complex_sq",
+      "Complex.ofReal_exp"
+    ]
   }
 ]

--- a/src/data/proofs/area-of-circle-oq-07-oq-04/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq07Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq07Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq07Oq04Data: ProofData = {
+  proof: areaOfCircleOq07Oq04Proof,
+  annotations: areaOfCircleOq07Oq04Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04/meta.json
@@ -20,6 +20,34 @@
     "sorries": 0
   },
   "title": "The Squared Complex Gaussian Integral (∫ e^{-b x²})² = π/b",
+  "description": "Squares the complex Gaussian integral of the sibling area-of-circle-oq-07-oq-01: for every b : ℂ with 0 < re b, (∫_ℝ e^{-b x²} dx)² = π/b. Squaring removes the branch-cut subtlety of the principal (1/2)-power — (π/b)^{1/2}·(π/b)^{1/2} = (π/b)^1 via Complex.cpow_add, valid because π/b ≠ 0 on the right half-plane. This is the complex-parameter form of the classical two-dimensional trick (∫ e^{-x²})² = ∫∫ e^{-(x²+y²)} = π; the parent's real value (∫ e^{-x²})² = π is recovered as the b = 1 case.",
+  "overview": {
+    "historicalContext": "The two-dimensional squaring trick — writing (∫ e^{-x²})² as a planar integral ∫∫ e^{-(x²+y²)} and evaluating it in polar coordinates to get π — is the standard derivation of the Gaussian integral and the place where the area-of-a-circle Jacobian r dr dθ of the parent entry appears. Stated for a complex parameter b over the right half-plane, the squared identity (∫ e^{-b x²})² = π/b is single-valued and rational in b, in contrast to the integral itself, whose value (π/b)^{1/2} carries the principal branch that governs the Fresnel phase on the imaginary axis.",
+    "problemStatement": "For the complex Gaussian $\\int_{\\mathbb{R}} e^{-b x^2}\\,dx = (\\pi/b)^{1/2}$ (sibling area-of-circle-oq-07-oq-01), prove that its square is the clean rational value $\\left(\\int_{\\mathbb{R}} e^{-b x^2}\\,dx\\right)^2 = \\pi/b$ for every $b : \\mathbb{C}$ with $0 < \\operatorname{re} b$, and recover the real $(\\int e^{-x^2})^2 = \\pi$ as the $b = 1$ case.",
+    "proofStrategy": "gaussian_integral_complex_sq rewrites the integral to (π/b)^{1/2} (integral_gaussian_complex), expands the square with pow_two, and fuses the exponents via Complex.cpow_add in reverse to (π/b)^{1/2+1/2}; its side condition π/b ≠ 0 comes from div_ne_zero (Real.pi_ne_zero and b ≠ 0, the latter from 0 < re b), and norm_num evaluates 1/2+1/2 = 1. The bridge gaussian_integral_sq_eq_pi recovers the real value at b = 1: hLcast identifies the real integral with its ℂ-image (integral_complex_ofReal + Complex.ofReal_exp + push_cast/ring), div_one simplifies π/1, and exact_mod_cast transfers back to ℝ.",
+    "keyInsights": [
+      "Squaring removes the branch-cut subtlety: the integral itself is the single-valued-only-after-fixing-a-branch power (π/b)^{1/2}, but its square π/b is a single-valued rational function of b on the half-plane — which is why downstream normalization constants are stated via the square.",
+      "The additive law x^{y+z} = x^y·x^z for complex principal powers holds precisely when x ≠ 0; the right half-plane re b > 0 is exactly the region guaranteeing π/b ≠ 0, so the two half-powers add without picking up a sign from the branch cut.",
+      "Recovering π (not √π) at b = 1 makes this the faithful complex lift of the parent's central computation: the two-dimensional Gaussian integral equals π directly, and the square root is extracted only afterward.",
+      "As in the rest of the family, the hard analysis is inherited from Mathlib's integral_gaussian_complex; the contribution is the clean squared identity and the correctly-cast parent recovery — honestly badged 'mathlib'."
+    ]
+  },
+  "sections": [
+    {
+      "id": "squared-complex",
+      "title": "The Squared Complex Gaussian Integral",
+      "startLine": 34,
+      "endLine": 45,
+      "summary": "gaussian_integral_complex_sq: for 0 < re b, (∫ e^{-b x²})² = π/b, by rewriting to (π/b)^{1/2}, expanding with pow_two, and fusing exponents via Complex.cpow_add (side condition π/b ≠ 0) then norm_num."
+    },
+    {
+      "id": "parent-recovery",
+      "title": "Recovering π as the b = 1 Case",
+      "startLine": 47,
+      "endLine": 65,
+      "summary": "gaussian_integral_sq_eq_pi: the real (∫ e^{-x²})² = π from the complex result at b = 1, via hLcast (integral_complex_ofReal) and div_one, finished by exact_mod_cast."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04`.

**Critical fixes:** added the missing `index.ts` (page rendered 'proof not found' live without it) and a top-level `description` (`index.ts` read `meta.description` → `undefined`, blank on the page).

**Depth added to meta.json (previously had neither):** `overview` (historicalContext on the 2-D squaring trick + polar Jacobian, problemStatement, proofStrategy, 4 keyInsights on the branch-cut/cpow_add subtlety) and `sections` covering both theorems.

**Annotation hygiene:** normalized `significance: "important"` → `"supporting"` (schema enum). The 3 existing annotations already had correct ranges and rich mathContext/relatedConcepts/prerequisites.

**Axiom integrity:** verified — 0 sorries / 0 axioms; `badge: "mathlib"` correctly reflects a squaring+cast of Mathlib's integral_gaussian_complex. status=verified retained.

JSON validated with python (node_modules absent so `pnpm build` cannot run).