### PR TITLE
research(sperner-ndim-oq-01-oq-01): boundary facets bound one simplex + unified door-count [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ01OQ01.lean
+++ b/proofs/Proofs/SpernerNDimOQ01OQ01.lean
@@ -1,0 +1,283 @@
+/-
+# Freudenthal Door-Counting: Every Facet Bounds One or Two Simplices
+
+This file proves the **door-counting parity fact** underlying the combinatorial proof of
+Sperner's lemma for the Freudenthal (Kuhn) triangulation, *unifying* the interior and
+boundary cases into a single statement.
+
+## Model
+
+A Freudenthal simplex is a nodup list `l` of all elements of `Fin n` — equivalently a
+maximal chain (complete flag) in the Boolean lattice `2^(Fin n)`:
+  `∅ = V₀ ⊂ V₁ ⊂ ⋯ ⊂ Vₙ = Fin n`,   `Vₖ = (l.take k).toFinset = prefixSet l k`.
+A *facet* of the simplex drops one vertex `Vₖ`. The number of simplices sharing that facet
+equals the number of `k`-element sets `S` that can replace `Vₖ`, i.e. with
+  `prefixSet l (k-1) ⊆ S ⊆ prefixSet l (k+1)`  and  `|S| = k`.
+
+## Main results
+
+* `intermediate_sets_card_eq_two` — abstract counting core: if `|B \ A| = 2`, there are
+  exactly `2` sets `S` with `A ⊆ S ⊆ B` and `|S| = |A| + 1`.
+* `freudenthal_adjacency_theorem` — **interior** facet (`0 < k < n`): exactly `2` simplices.
+* `freudenthal_boundary_bottom` — facet dropping `V₀ = ∅` (`k = 0`): exactly `1` simplex.
+* `freudenthal_boundary_top` — facet dropping `Vₙ = Fin n` (`k = n`): exactly `1` simplex.
+* `freudenthal_door_count` — **unified door-counting theorem**: for every `k ≤ n` the facet
+  count is `if 0 < k ∧ k < n then 2 else 1`. Interior doors are shared by two simplices; the
+  two boundary doors bound exactly one. This is the parity input to Sperner's lemma.
+* `freudenthal_boundary_unique_bottom` / `freudenthal_boundary_unique_top` — the
+  `ExistsUnique` form of the two boundary facts.
+
+A pleasant feature of the `Fin`/`ℕ` encoding: because truncated subtraction gives
+`0 - 1 = 0`, the boundary cases are literally the interior filter formula at `k = 0` and
+`k = n`, so `freudenthal_door_count` covers interior and boundary uniformly.
+
+The interior infrastructure (`prefixSet` and the intermediate-set counting lemma) reprises
+the construction of `Proofs/SpernerNDimOQ01.lean` but is reproved here from current Mathlib
+so the file stands on its own.
+
+## Status
+
+0 sorries, 0 axioms (only `propext`, `Classical.choice`, `Quot.sound`).
+
+## Tags
+
+Freudenthal, triangulation, simplex, door-counting, Sperner, boundary, combinatorics
+-/
+
+import Mathlib
+
+namespace FreudenthalDoorCount
+
+open Finset
+
+variable {n : ℕ}
+
+-- ============================================================
+-- SECTION I: Prefix-set vertices of a Freudenthal simplex
+-- ============================================================
+
+/-- The first `k` elements of list `l`, as a Finset — the `k`-th vertex of the simplex. -/
+def prefixSet (l : List (Fin n)) (k : ℕ) : Finset (Fin n) :=
+  (l.take k).toFinset
+
+/-- For a nodup list, the prefix set has cardinality `min k l.length`. -/
+theorem prefixSet_card {l : List (Fin n)} (hl : l.Nodup) (k : ℕ) :
+    (prefixSet l k).card = min k l.length := by
+  rw [prefixSet, List.toFinset_card_of_nodup ((List.take_sublist k l).nodup hl),
+    List.length_take]
+
+/-- For `k ≤ l.length`, the prefix set has cardinality exactly `k`. -/
+theorem prefixSet_card_eq {l : List (Fin n)} (hl : l.Nodup) {k : ℕ} (hk : k ≤ l.length) :
+    (prefixSet l k).card = k := by
+  rw [prefixSet_card hl, Nat.min_eq_left hk]
+
+/-- Prefix sets form a chain under inclusion. -/
+theorem prefixSet_mono {l : List (Fin n)} (k : ℕ) :
+    prefixSet l k ⊆ prefixSet l (k + 1) := by
+  intro x
+  simp only [prefixSet, List.mem_toFinset]
+  intro hx
+  have hxk : x ∈ (l.take (k + 1)).take k := by
+    rwa [List.take_take, Nat.min_eq_left (Nat.le_succ k)]
+  exact List.mem_of_mem_take hxk
+
+/-- The gap `prefixSet l (k+1) \ prefixSet l (k-1)` has exactly 2 elements (`0 < k < length`).
+    This is the geometric fact that removing an interior vertex creates a 2-element gap. -/
+theorem prefixSet_skip_sdiff_card {l : List (Fin n)} (hl : l.Nodup)
+    (k : ℕ) (hk0 : 0 < k) (hk1 : k < l.length) :
+    (prefixSet l (k + 1) \ prefixSet l (k - 1)).card = 2 := by
+  have hAB : prefixSet l (k - 1) ⊆ prefixSet l (k + 1) := by
+    refine (prefixSet_mono (k - 1)).trans ?_
+    rw [Nat.sub_add_cancel hk0]; exact prefixSet_mono k
+  have hA_card : (prefixSet l (k - 1)).card = k - 1 := prefixSet_card_eq hl (by omega)
+  have hB_card : (prefixSet l (k + 1)).card = k + 1 := prefixSet_card_eq hl (by omega)
+  rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hAB, hA_card, hB_card]
+  omega
+
+-- ============================================================
+-- SECTION II: The counting lemma for intermediate sets
+-- ============================================================
+
+/-- The abstract counting core: if `B \ A` has 2 elements, there are exactly 2 sets `S`
+    with `A ⊆ S ⊆ B` and `|S| = |A| + 1`. -/
+theorem intermediate_sets_card_eq_two {A B : Finset (Fin n)} (hAB : A ⊆ B)
+    (hBA : (B \ A).card = 2) :
+    (B.powerset.filter (fun S => A ⊆ S ∧ S.card = A.card + 1)).card = 2 := by
+  obtain ⟨a, b, hab, hBA_eq⟩ := Finset.card_eq_two.mp hBA
+  have ha_BA : a ∈ B \ A := by rw [hBA_eq]; simp
+  have hb_BA : b ∈ B \ A := by rw [hBA_eq]; simp
+  have ha_notA : a ∉ A := (Finset.mem_sdiff.mp ha_BA).2
+  have hb_notA : b ∉ A := (Finset.mem_sdiff.mp hb_BA).2
+  have ha_B : a ∈ B := (Finset.mem_sdiff.mp ha_BA).1
+  have hb_B : b ∈ B := (Finset.mem_sdiff.mp hb_BA).1
+  have hpair_ne : A ∪ {a} ≠ A ∪ {b} := by
+    intro h
+    have : a ∈ A ∪ {b} := h ▸ Finset.mem_union_right A (Finset.mem_singleton_self a)
+    simp only [Finset.mem_union, Finset.mem_singleton] at this
+    rcases this with h | h
+    · exact ha_notA h
+    · exact hab h
+  have hfilter : B.powerset.filter (fun S => A ⊆ S ∧ S.card = A.card + 1)
+      = ({A ∪ {a}, A ∪ {b}} : Finset (Finset (Fin n))) := by
+    ext S
+    simp only [mem_filter, mem_powerset, mem_insert, mem_singleton]
+    constructor
+    · intro ⟨hSB, hAS, hScard⟩
+      have hSdiff_card : (S \ A).card = 1 := by
+        rw [Finset.card_sdiff, Finset.inter_eq_left.mpr hAS, hScard]; omega
+      obtain ⟨e, he⟩ := Finset.card_eq_one.mp hSdiff_card
+      have he_BA : e ∈ B \ A := by
+        have he_S : e ∈ S \ A := he ▸ Finset.mem_singleton_self e
+        exact Finset.mem_sdiff.mpr ⟨hSB (Finset.mem_sdiff.mp he_S).1,
+          (Finset.mem_sdiff.mp he_S).2⟩
+      rw [hBA_eq] at he_BA
+      simp only [mem_insert, mem_singleton] at he_BA
+      have hS_eq : S = A ∪ {e} := by
+        ext x
+        simp only [mem_union, mem_singleton]
+        constructor
+        · intro hx
+          by_cases hxA : x ∈ A
+          · exact Or.inl hxA
+          · have : x ∈ S \ A := Finset.mem_sdiff.mpr ⟨hx, hxA⟩
+            rw [he, mem_singleton] at this
+            exact Or.inr this
+        · rintro (hx | hxe)
+          · exact hAS hx
+          · rw [hxe]; exact (Finset.mem_sdiff.mp (he ▸ Finset.mem_singleton_self e)).1
+      rcases he_BA with rfl | rfl
+      · left; exact hS_eq
+      · right; exact hS_eq
+    · rintro (rfl | rfl) <;> refine ⟨?_, Finset.subset_union_left, ?_⟩
+      · intro x; simp only [mem_union, mem_singleton]; rintro (hx | rfl); exact hAB hx; exact ha_B
+      · rw [Finset.card_union_of_disjoint (by simp [ha_notA])]; simp
+      · intro x; simp only [mem_union, mem_singleton]; rintro (hx | rfl); exact hAB hx; exact hb_B
+      · rw [Finset.card_union_of_disjoint (by simp [hb_notA])]; simp
+  rw [hfilter, Finset.card_pair hpair_ne]
+
+-- ============================================================
+-- SECTION III: Interior facets (parent result, reproved)
+-- ============================================================
+
+/-- **Freudenthal Adjacency Theorem** (interior facet, `0 < k < n`):
+    each interior `(n-1)`-facet of the Freudenthal triangulation belongs to exactly 2
+    simplices. -/
+theorem freudenthal_adjacency_theorem
+    (l : List (Fin n)) (hl : l.Nodup) (hl_len : l.length = n)
+    (k : ℕ) (hk0 : 0 < k) (hk1 : k < n) :
+    ((prefixSet l (k + 1)).powerset.filter
+      (fun S => prefixSet l (k - 1) ⊆ S ∧ S.card = k)).card = 2 := by
+  have hA_card : (prefixSet l (k - 1)).card = k - 1 := prefixSet_card_eq hl (by omega)
+  have hAB : prefixSet l (k - 1) ⊆ prefixSet l (k + 1) := by
+    refine (prefixSet_mono (k - 1)).trans ?_
+    rw [Nat.sub_add_cancel hk0]; exact prefixSet_mono k
+  have hgap : (prefixSet l (k + 1) \ prefixSet l (k - 1)).card = 2 :=
+    prefixSet_skip_sdiff_card hl k hk0 (by rw [hl_len]; exact hk1)
+  -- `intermediate_sets_card_eq_two` gives the count with bound `(prefixSet l (k-1)).card + 1`;
+  -- rewrite that exponent back to `k` using `|prefixSet l (k-1)| = k - 1` and `k - 1 + 1 = k`.
+  have key := intermediate_sets_card_eq_two hAB hgap
+  rw [hA_card, Nat.sub_add_cancel hk0] at key
+  exact key
+
+-- ============================================================
+-- SECTION IV: Boundary facets bound exactly one simplex
+-- ============================================================
+
+/-- **Bottom boundary facet** (`k = 0`): the facet of a Freudenthal simplex that drops the
+    apex vertex `V₀ = ∅` bounds exactly one simplex. The only `0`-element set `S` with
+    `prefixSet l 0 ⊆ S ⊆ prefixSet l 1` is `S = ∅`, so the door-count is `1`. -/
+theorem freudenthal_boundary_bottom (l : List (Fin n)) :
+    ((prefixSet l (0 + 1)).powerset.filter
+      (fun S => prefixSet l (0 - 1) ⊆ S ∧ S.card = 0)).card = 1 := by
+  have hset : (prefixSet l (0 + 1)).powerset.filter
+      (fun S => prefixSet l (0 - 1) ⊆ S ∧ S.card = 0) = {∅} := by
+    ext S
+    simp only [mem_filter, mem_powerset, mem_singleton]
+    constructor
+    · rintro ⟨_, _, hc⟩
+      exact Finset.card_eq_zero.mp hc
+    · rintro rfl
+      exact ⟨Finset.empty_subset _, by simp [prefixSet], Finset.card_empty⟩
+  rw [hset, Finset.card_singleton]
+
+/-- **Top boundary facet** (`k = n`): the facet that drops the maximal vertex `Vₙ = Fin n`
+    bounds exactly one simplex. The only `n`-element subset of `Fin n` is `Finset.univ`, so
+    the door-count is `1`. -/
+theorem freudenthal_boundary_top (l : List (Fin n)) (hl : l.Nodup) (hl_len : l.length = n) :
+    ((prefixSet l (n + 1)).powerset.filter
+      (fun S => prefixSet l (n - 1) ⊆ S ∧ S.card = n)).card = 1 := by
+  have huniv : prefixSet l (n + 1) = (Finset.univ : Finset (Fin n)) := by
+    apply Finset.eq_univ_of_card
+    rw [prefixSet_card hl, hl_len, Fintype.card_fin]
+    omega
+  have hset : (prefixSet l (n + 1)).powerset.filter
+      (fun S => prefixSet l (n - 1) ⊆ S ∧ S.card = n) = {Finset.univ} := by
+    ext S
+    simp only [mem_filter, mem_powerset, huniv, Finset.subset_univ, true_and, mem_singleton]
+    constructor
+    · rintro ⟨_, hc⟩
+      exact Finset.eq_univ_of_card S (by rw [hc, Fintype.card_fin])
+    · rintro rfl
+      exact ⟨Finset.subset_univ _, by rw [Finset.card_univ, Fintype.card_fin]⟩
+  rw [hset, Finset.card_singleton]
+
+-- ============================================================
+-- SECTION V: The unified door-counting theorem
+-- ============================================================
+
+/-- **Freudenthal door-counting theorem** (the parity input to Sperner's lemma).
+
+    For every `k ≤ n`, the `k`-th facet of the Freudenthal simplex `l` is shared by
+      * `2` simplices when the facet is **interior** (`0 < k < n`), and
+      * `1` simplex when the facet is on the **boundary** (`k = 0` or `k = n`).
+
+    Counting facet–simplex incidences this way, every facet is a door between either two
+    rooms (interior) or one room and the outside (boundary): exactly the parity bookkeeping
+    that drives the combinatorial Sperner argument. -/
+theorem freudenthal_door_count
+    (l : List (Fin n)) (hl : l.Nodup) (hl_len : l.length = n)
+    (k : ℕ) (hk : k ≤ n) :
+    ((prefixSet l (k + 1)).powerset.filter
+      (fun S => prefixSet l (k - 1) ⊆ S ∧ S.card = k)).card =
+      if 0 < k ∧ k < n then 2 else 1 := by
+  by_cases hint : 0 < k ∧ k < n
+  · rw [if_pos hint]
+    exact freudenthal_adjacency_theorem l hl hl_len k hint.1 hint.2
+  · rw [if_neg hint]
+    rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+    · subst hk0
+      exact freudenthal_boundary_bottom l
+    · have hkn : k = n := by
+        rcases lt_or_eq_of_le hk with h | h
+        · exact absurd ⟨hkpos, h⟩ hint
+        · exact h
+      subst hkn
+      exact freudenthal_boundary_top l hl hl_len
+
+-- ============================================================
+-- SECTION VI: ExistsUnique forms of the boundary facts
+-- ============================================================
+
+/-- The bottom boundary facet has a **unique** completing vertex set (namely `∅`). -/
+theorem freudenthal_boundary_unique_bottom (l : List (Fin n)) :
+    ∃! S : Finset (Fin n), S ⊆ prefixSet l 1 ∧ prefixSet l 0 ⊆ S ∧ S.card = 0 := by
+  refine ⟨∅, ⟨Finset.empty_subset _, by simp [prefixSet], Finset.card_empty⟩, ?_⟩
+  rintro S ⟨_, _, hc⟩
+  exact Finset.card_eq_zero.mp hc
+
+/-- The top boundary facet has a **unique** completing vertex set (namely `Finset.univ`). -/
+theorem freudenthal_boundary_unique_top
+    (l : List (Fin n)) (hl : l.Nodup) (hl_len : l.length = n) :
+    ∃! S : Finset (Fin n),
+      prefixSet l (n - 1) ⊆ S ∧ S ⊆ prefixSet l (n + 1) ∧ S.card = n := by
+  have huniv : prefixSet l (n + 1) = (Finset.univ : Finset (Fin n)) := by
+    apply Finset.eq_univ_of_card
+    rw [prefixSet_card hl, hl_len, Fintype.card_fin]
+    omega
+  refine ⟨Finset.univ, ⟨Finset.subset_univ _, ?_, ?_⟩, ?_⟩
+  · rw [huniv]
+  · rw [Finset.card_univ, Fintype.card_fin]
+  · rintro S ⟨_, _, hc⟩
+    exact Finset.eq_univ_of_card S (by rw [hc, Fintype.card_fin])
+
+end FreudenthalDoorCount

--- a/src/data/proofs/sperner-ndim-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/sperner-ndim-oq-01-oq-01/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "ann-sperner0101-header",
+    "proofId": "sperner-ndim-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 60 },
+    "type": "concept",
+    "title": "Door-Counting Model: Simplices as Maximal Flags",
+    "content": "The header sets up the Freudenthal model used throughout: a simplex is a nodup list l of all of Fin n, and its k-th vertex is the prefix set Vₖ = (l.take k).toFinset, so the vertices form a maximal flag ∅ = V₀ ⊂ V₁ ⊂ ⋯ ⊂ Vₙ = Fin n. A facet drops one vertex Vₖ; the simplices sharing that facet correspond to the k-element sets S that refill it, i.e. those with prefixSet l (k-1) ⊆ S ⊆ prefixSet l (k+1) and |S| = k. The parent entry counted interior facets (2 simplices); this file adds the boundary count (1 simplex) and unifies both. The file is self-contained because the parent's Lean source bit-rotted against a Mathlib List-API rename.",
+    "mathContext": "Simplex $l \\leftrightarrow$ flag $\\emptyset = V_0 \\subset \\cdots \\subset V_n = \\mathrm{Fin}\\,n$ with $V_k = \\mathrm{prefixSet}(l,k)$. Refills of the dropped vertex $V_k$ count simplices on the facet.",
+    "significance": "concept",
+    "relatedConcepts": [
+      "Sperner's lemma",
+      "room-and-door argument",
+      "Freudenthal triangulation",
+      "maximal flag in a Boolean lattice"
+    ],
+    "prerequisites": [
+      "Finsets and powersets in Mathlib",
+      "List.take and List.toFinset"
+    ]
+  },
+  {
+    "id": "ann-sperner0101-prefix-card",
+    "proofId": "sperner-ndim-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 100 },
+    "type": "technique",
+    "title": "Prefix-Set Cardinality and the Two-Element Gap",
+    "content": "prefixSet_card proves |prefixSet l k| = min k l.length by exhibiting (l.take k) as a Sublist of l (List.take_sublist) whose nodup-ness gives toFinset.card = length. prefixSet_mono establishes the inclusion chain using List.take_take and List.mem_of_mem_take. prefixSet_skip_sdiff_card then shows the gap prefixSet l (k+1) \\ prefixSet l (k-1) has exactly 2 elements for 0 < k < l.length — purely from the cardinalities (k+1) and (k-1). Note the use of the unconditional Finset.card_sdiff (|s \\ t| = |s| - |t ∩ s|) plus Finset.inter_eq_left.mpr, since this Mathlib no longer ships the subset-hypothesis form of card_sdiff.",
+    "mathContext": "$|\\mathrm{prefixSet}(l,k)| = \\min(k, |l|)$; for $0<k<|l|$, $|\\mathrm{prefixSet}(l,k+1)\\setminus\\mathrm{prefixSet}(l,k-1)| = (k+1)-(k-1) = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.Sublist.nodup",
+      "Finset.card_sdiff",
+      "cardinality of set difference"
+    ],
+    "prerequisites": [
+      "List.take_take and take monotonicity",
+      "Finset.inter_eq_left"
+    ]
+  },
+  {
+    "id": "ann-sperner0101-counting-core",
+    "proofId": "sperner-ndim-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 157 },
+    "type": "key-step",
+    "title": "intermediate_sets_card_eq_two: The Abstract Door Count",
+    "content": "The combinatorial core: if B \\ A = {a, b} with a ≠ b, then the k-element sets S with A ⊆ S ⊆ B and |S| = |A| + 1 are exactly A ∪ {a} and A ∪ {b}. The proof shows the filtered powerset equals the explicit pair {A ∪ {a}, A ∪ {b}}: forward, any such S has |S \\ A| = 1, so S \\ A = {e} with e ∈ B \\ A = {a, b}, hence S = A ∪ {e}; backward, both A ∪ {a} and A ∪ {b} satisfy the constraints (disjoint-union cardinality). Counting the pair with Finset.card_pair gives 2. This abstract lemma is what makes the interior facet count fall out for prefix sets whose gap has 2 elements.",
+    "mathContext": "$B\\setminus A=\\{a,b\\}\\ (a\\neq b) \\Rightarrow \\#\\{S : A\\subseteq S\\subseteq B,\\ |S|=|A|+1\\} = \\#\\{A\\cup\\{a\\}, A\\cup\\{b\\}\\} = 2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.card_pair",
+      "Finset.card_eq_one",
+      "explicit characterization of a filtered set"
+    ],
+    "prerequisites": [
+      "Finset.card_sdiff and disjoint-union cardinality",
+      "set extensionality on Finsets"
+    ]
+  },
+  {
+    "id": "ann-sperner0101-interior",
+    "proofId": "sperner-ndim-oq-01-oq-01",
+    "range": { "startLine": 158, "endLine": 181 },
+    "type": "key-step",
+    "title": "Interior Facets Are Shared by Exactly Two Simplices",
+    "content": "freudenthal_adjacency_theorem reproves the parent result for 0 < k < n. It feeds the 2-element gap prefixSet l (k+1) \\ prefixSet l (k-1) into intermediate_sets_card_eq_two, obtaining a count of 2 with bound (prefixSet l (k-1)).card + 1. The exponent is then rewritten back to k using |prefixSet l (k-1)| = k - 1 and Nat.sub_add_cancel (k - 1 + 1 = k, valid since 0 < k). Geometrically the two simplices differ by swapping the adjacent permutation entries l[k-1] and l[k].",
+    "mathContext": "For $0<k<n$ the $k$-th facet is shared by exactly 2 simplices: $l$ and the permutation swapping $l[k-1]$ and $l[k]$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "adjacent transposition of permutation entries",
+      "interior facet of a triangulation"
+    ],
+    "prerequisites": [
+      "intermediate_sets_card_eq_two",
+      "Nat.sub_add_cancel"
+    ]
+  },
+  {
+    "id": "ann-sperner0101-boundary",
+    "proofId": "sperner-ndim-oq-01-oq-01",
+    "range": { "startLine": 182, "endLine": 228 },
+    "type": "key-step",
+    "title": "Boundary Facets Bound Exactly One Simplex",
+    "content": "The new contribution. freudenthal_boundary_bottom (k = 0): the facet dropping V₀ = ∅ admits only the 0-element refill ∅, so the filter equals {∅} and the count is 1 — no nondegeneracy hypothesis is needed, since |S| = 0 forces S = ∅. freudenthal_boundary_top (k = n): the facet dropping Vₙ = Fin n has prefixSet l (n+1) = Finset.univ (a nodup list of length n exhausts Fin n, so card = n = card univ), and the only n-element subset of Fin n is univ, so the filter equals {univ} and the count is 1. These two endpoints are the only boundary facet positions in the flag model.",
+    "mathContext": "$k=0$: only refill is $\\emptyset$. $k=n$: $\\mathrm{prefixSet}(l,n+1)=\\mathrm{univ}$ and the only $n$-subset of $\\mathrm{Fin}\\,n$ is $\\mathrm{univ}$. Each boundary facet $\\to$ exactly 1 simplex.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "boundary facet of a triangulation",
+      "Finset.eq_univ_of_card",
+      "uniqueness of the empty / full subset"
+    ],
+    "prerequisites": [
+      "Finset.card_eq_zero",
+      "Finset.eq_univ_of_card and Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "ann-sperner0101-unified",
+    "proofId": "sperner-ndim-oq-01-oq-01",
+    "range": { "startLine": 229, "endLine": 283 },
+    "type": "concept",
+    "title": "The Unified Parity Theorem and Uniqueness Corollaries",
+    "content": "freudenthal_door_count packages all three cases: for every k ≤ n the facet count is (if 0 < k ∧ k < n then 2 else 1). The proof case-splits on the interior predicate, dispatching to the adjacency theorem or to the two boundary lemmas — which it can do because ℕ-truncated subtraction makes the boundary cases literally the interior filter formula at k = 0 and k = n. This 2-vs-1 dichotomy is exactly the parity input summed (mod 2) in the room-and-door proof of Sperner's lemma. The closing freudenthal_boundary_unique_bottom / _top give the ExistsUnique form: each boundary facet has a unique refill (∅ and univ).",
+    "mathContext": "$\\#\\{\\text{simplices on the }k\\text{-th facet}\\} = \\begin{cases}2,& 0<k<n\\\\ 1,& k\\in\\{0,n\\}\\end{cases}$ — the door-counting parity fact behind Sperner's lemma.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Sperner's lemma parity argument",
+      "ExistsUnique",
+      "ℕ-truncated subtraction"
+    ],
+    "prerequisites": [
+      "case analysis on decidable propositions",
+      "the interior and boundary lemmas above"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-ndim-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-01-oq-01/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "sperner-ndim-oq-01-oq-01",
+  "title": "Freudenthal Door-Counting: Every Facet Bounds One or Two Simplices",
+  "slug": "sperner-ndim-oq-01-oq-01",
+  "description": "Completes the door-counting parity fact underlying the combinatorial proof of Sperner's lemma for the Freudenthal triangulation. A simplex is a maximal flag ∅ = V₀ ⊂ V₁ ⊂ ⋯ ⊂ Vₙ = Fin n; a facet drops one vertex Vₖ, and the number of simplices sharing it equals the number of k-element refills S with prefixSet l (k-1) ⊆ S ⊆ prefixSet l (k+1). The parent proved the interior case (0 < k < n → 2 simplices). This entry proves the two boundary cases — dropping V₀ = ∅ or Vₙ = Fin n leaves exactly 1 refill — and packages all three into a single unified theorem: the facet count is `if 0 < k ∧ k < n then 2 else 1`. Because ℕ-truncated subtraction gives 0 - 1 = 0, the boundary cases are literally the interior filter formula at k = 0 and k = n. Self-contained: the prefix-set infrastructure and the intermediate-set counting lemma are reproved from current Mathlib.",
+  "meta": {
+    "author": "Freudenthal (1942); formalization by researcher-5",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma",
+    "date": "1942-2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SpernerNDimOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "topology",
+      "Freudenthal-triangulation",
+      "Sperner-lemma",
+      "door-counting",
+      "boundary",
+      "triangulation",
+      "simplex",
+      "advanced"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No axioms. All results are fully proved from Mathlib primitives; #print axioms reports only propext, Classical.choice, Quot.sound for every theorem.",
+    "originalContributions": [
+      "freudenthal_boundary_bottom: the facet dropping the apex vertex V₀ = ∅ (k = 0) bounds exactly 1 simplex — the only 0-element refill is ∅",
+      "freudenthal_boundary_top: the facet dropping the maximal vertex Vₙ = Fin n (k = n) bounds exactly 1 simplex — the only n-element refill is Finset.univ",
+      "freudenthal_door_count: the unified door-counting theorem — for every k ≤ n the facet count is (if 0 < k ∧ k < n then 2 else 1), covering interior and boundary uniformly via ℕ-truncated subtraction",
+      "freudenthal_boundary_unique_bottom / freudenthal_boundary_unique_top: ExistsUnique forms of the two boundary facts, mirroring the parent's existence corollary",
+      "Self-contained re-derivation of prefixSet, prefixSet_card, prefixSet_mono, prefixSet_skip_sdiff_card, intermediate_sets_card_eq_two, and freudenthal_adjacency_theorem from current Mathlib (the parent file SpernerNDimOQ01.lean had bit-rotted against a List-API rename and no longer compiled)"
+    ],
+    "lineCount": 283,
+    "theoremCount": 11,
+    "defCount": 1,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Sperner's lemma (Emanuel Sperner, 1928) is the combinatorial heart of Brouwer's fixed-point theorem: any 'Sperner labeling' of the vertices of a triangulated simplex contains an odd number of fully-labeled ('rainbow') cells, hence at least one. The standard proof is a door-counting (or 'room-and-door') argument: regard each full-dimensional simplex as a room and each (n-1)-facet carrying a distinguished label pattern as a door. The argument turns on a parity fact about how facets sit between simplices — every interior facet is a door between exactly two rooms, while every boundary facet borders exactly one room and the outside. Summing incidences mod 2 then forces an odd number of rainbow rooms. Hans Freudenthal's 1942 triangulation of the n-cube, in which the n! simplices are indexed by permutations and the k-th vertex of permutation l is the prefix set {l[0],…,l[k-1]}, is the canonical setting for making this concrete. The parent entry formalized the interior half of the parity fact (each interior facet → 2 simplices). This entry supplies the boundary half (each boundary facet → 1 simplex) and unifies both into a single counting theorem, completing the parity input that Sperner's lemma consumes.",
+    "problemStatement": "In the Freudenthal triangulation, how many simplices share a given (n-1)-facet? An interior facet (dropping vertex Vₖ with 0 < k < n) is shared by exactly 2 simplices; a boundary facet (dropping V₀ = ∅ or Vₙ = Fin n) bounds exactly 1. Equivalently, for every k ≤ n the count of k-element refills S with prefixSet l (k-1) ⊆ S ⊆ prefixSet l (k+1) is 2 in the interior and 1 on the boundary.",
+    "text": "Representing the simplex l as a nodup list of all of Fin n, the vertices are the prefix Finsets Vₖ = (l.take k).toFinset = prefixSet l k, forming a maximal flag ∅ = V₀ ⊂ ⋯ ⊂ Vₙ = Fin n. Dropping vertex Vₖ yields a facet; refilling it with a k-element set S sandwiched between Vₖ₋₁ and Vₖ₊₁ recovers a complete flag, i.e. a simplex through the facet. The number of refills is the number of simplices on that facet. The interior count is 2 (parent); the boundary counts are 1 (this entry); the unified theorem states the count is `if 0 < k ∧ k < n then 2 else 1`.",
+    "proofStrategy": "The bottom boundary (k = 0): the only 0-element refill is ∅, so the filter equals {∅} and the count is 1 — no nondegeneracy hypothesis is needed, since a cardinality-0 Finset is forced to be empty. The top boundary (k = n): prefixSet l (n+1) is all of Fin n (card = min (n+1) n = n = card univ), and the only n-element subset of an n-element type is Finset.univ, so the filter equals {univ} and the count is 1. The unified door_count theorem case-splits on whether 0 < k ∧ k < n: the interior branch is the (reproved) Freudenthal Adjacency Theorem, and the complementary branch is k = 0 or k = n, dispatched to the two boundary lemmas. Crucially, because ℕ-truncated subtraction gives 0 - 1 = 0, the boundary cases are syntactically the same filter formula as the interior case at the endpoints, so a single uniform statement covers all k.",
+    "keyInsights": [
+      "The boundary facets are exactly the two endpoint positions k = 0 and k = n of the flag — the facets opposite the empty vertex and the full vertex — and each admits a unique refill (∅ and Finset.univ respectively), giving door-count 1",
+      "ℕ-truncated subtraction makes the unification free: the parent's interior filter `prefixSet l (k-1) ⊆ S ∧ S.card = k` reduces at k = 0 to `prefixSet l 0 ⊆ S ∧ S.card = 0` (forcing S = ∅) and at k = n to the top constraint (forcing S = univ), so one theorem freudenthal_door_count states the whole dichotomy",
+      "Door counting is a parity statement: interior facets contribute 2 (a door between two rooms) and boundary facets contribute 1 (a door to the outside); this 2-vs-1 dichotomy is exactly the input the room-and-door argument for Sperner's lemma sums modulo 2",
+      "The top boundary reduces to a pure cardinality fact: prefixSet l (n+1) = Finset.univ because a nodup list of length n exhausts Fin n, and Finset.eq_univ_of_card upgrades 'card = n' to 'equals univ'",
+      "The entry is self-contained: the parent SpernerNDimOQ01.lean had bit-rotted (it referenced List.get?_eq_get and List.take_succ, both renamed in later Mathlib), so the prefix infrastructure and the abstract intermediate-set counting lemma were reproved here against current Mathlib, using the unconditional Finset.card_sdiff together with inter_eq_left rather than the removed subset-hypothesis form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Door-Counting Model",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Docstring explaining the Freudenthal flag model (simplex = maximal chain of prefix sets), the facet-refill correspondence, the four headline results, and the ℕ-subtraction trick that unifies interior and boundary. Imports Mathlib, namespace FreudenthalDoorCount.",
+      "mathContext": "Simplex l ↔ flag $\\emptyset = V_0 \\subset \\cdots \\subset V_n = \\mathrm{Fin}\\,n$, $V_k = \\mathrm{prefixSet}\\,l\\,k$. Facet drops $V_k$; refills $S$ with $V_{k-1}\\subseteq S\\subseteq V_{k+1}$, $|S|=k$ count simplices on the facet."
+    },
+    {
+      "id": "prefix-sets",
+      "title": "Prefix-Set Vertices (reproved infrastructure)",
+      "startLine": 61,
+      "endLine": 100,
+      "summary": "Defines prefixSet l k = (l.take k).toFinset and reproves prefixSet_card (card = min k l.length via a Sublist nodup argument), prefixSet_card_eq, prefixSet_mono (inclusion chain via take_take), and prefixSet_skip_sdiff_card (the 2-element gap, via the unconditional Finset.card_sdiff and inter_eq_left).",
+      "mathContext": "$\\mathrm{prefixSet}(l,k)=\\{l_0,\\ldots,l_{k-1}\\}$; for $0<k<|l|$, $|\\,\\mathrm{prefixSet}(l,k+1)\\setminus\\mathrm{prefixSet}(l,k-1)\\,| = (k+1)-(k-1)=2$."
+    },
+    {
+      "id": "counting-lemma",
+      "title": "intermediate_sets_card_eq_two: Abstract Counting Core",
+      "startLine": 101,
+      "endLine": 157,
+      "summary": "Proves: if |B \\ A| = 2 then exactly 2 sets S satisfy A ⊆ S ⊆ B and |S| = |A| + 1. The filter is shown equal to the explicit pair {A ∪ {a}, A ∪ {b}} where {a,b} = B \\ A, then counted by Finset.card_pair.",
+      "mathContext": "If $B\\setminus A=\\{a,b\\}$ with $a\\neq b$, the intermediate sets of size $|A|+1$ are exactly $A\\cup\\{a\\}$ and $A\\cup\\{b\\}$."
+    },
+    {
+      "id": "interior",
+      "title": "freudenthal_adjacency_theorem: Interior Facets → 2 Simplices",
+      "startLine": 158,
+      "endLine": 181,
+      "summary": "Reproves the parent result: for 0 < k < n, the count of k-element refills between prefixSet l (k-1) and prefixSet l (k+1) is exactly 2. Obtained by feeding the 2-element gap into intermediate_sets_card_eq_two and rewriting the exponent (prefixSet l (k-1)).card + 1 back to k.",
+      "mathContext": "Interior facet at position $k$ ($0<k<n$) is shared by the simplex $l$ and the one obtained by swapping $l[k-1]$ and $l[k]$ — exactly 2 simplices."
+    },
+    {
+      "id": "boundary",
+      "title": "Boundary Facets → 1 Simplex",
+      "startLine": 182,
+      "endLine": 228,
+      "summary": "freudenthal_boundary_bottom (k = 0): the filter equals {∅}, so count 1. freudenthal_boundary_top (k = n): prefixSet l (n+1) = univ and the only n-element subset is univ, so the filter equals {univ} and the count is 1.",
+      "mathContext": "Dropping $V_0=\\emptyset$ forces refill $\\emptyset$; dropping $V_n=\\mathrm{Fin}\\,n$ forces refill $\\mathrm{univ}$. Each boundary facet borders exactly one simplex."
+    },
+    {
+      "id": "unified",
+      "title": "freudenthal_door_count: The Unified Parity Theorem",
+      "startLine": 229,
+      "endLine": 252,
+      "summary": "For every k ≤ n the facet count equals (if 0 < k ∧ k < n then 2 else 1). Case-splits on interior vs. boundary, dispatching to the adjacency theorem or the two boundary lemmas. This is the door-counting parity fact that Sperner's lemma consumes.",
+      "mathContext": "$\\#\\{\\text{simplices on the }k\\text{-th facet}\\} = \\begin{cases}2 & 0<k<n\\\\ 1 & k\\in\\{0,n\\}\\end{cases}$."
+    },
+    {
+      "id": "unique",
+      "title": "ExistsUnique Boundary Forms",
+      "startLine": 253,
+      "endLine": 283,
+      "summary": "freudenthal_boundary_unique_bottom and freudenthal_boundary_unique_top: the unique completing vertex set of each boundary facet is ∅ and Finset.univ respectively, mirroring the parent's freudenthal_two_intermediate_sets.",
+      "mathContext": "$\\exists!\\,S$ refilling the bottom (resp. top) boundary facet, namely $S=\\emptyset$ (resp. $S=\\mathrm{univ}$)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Completes the **door-counting parity fact** for the Freudenthal (Kuhn) triangulation that underlies the combinatorial proof of **Sperner's lemma**.

A simplex is a maximal flag `∅ = V₀ ⊂ V₁ ⊂ ⋯ ⊂ Vₙ = Fin n` with `Vₖ = (l.take k).toFinset`. A facet drops one vertex `Vₖ`; the number of simplices sharing it equals the number of `k`-element refills `S` with `prefixSet l (k-1) ⊆ S ⊆ prefixSet l (k+1)`.

- **Parent** (`sperner-ndim-oq-01`) proved the **interior** case `0 < k < n` → **2** simplices.
- **This PR** adds the **boundary** case: dropping `V₀ = ∅` (`k=0`) or `Vₙ = Fin n` (`k=n`) each leave exactly **1** refill (`∅` and `Finset.univ`), and unifies all cases:

  `freudenthal_door_count : count = if 0 < k ∧ k < n then 2 else 1`

Because ℕ-truncated subtraction gives `0 - 1 = 0`, the boundary cases are literally the interior filter formula at the endpoints — one theorem covers the whole 2-vs-1 dichotomy that Sperner's room-and-door argument sums mod 2.

## Note on the parent

The parent `Proofs/SpernerNDimOQ01.lean` no longer compiles against current Mathlib (it references the renamed `List.get?_eq_get` / `List.take_succ`). This entry is therefore **self-contained**: `prefixSet`, the counting lemma `intermediate_sets_card_eq_two`, and `freudenthal_adjacency_theorem` are reproved here from current Mathlib (using the unconditional `Finset.card_sdiff` + `inter_eq_left`). A follow-up to repair the parent's bit-rot is worth filing.

## Verification

- `lake env lean` (Mathlib v4.26.0): exit 0, no errors/warnings.
- `#print axioms` for every theorem: only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms, 0 sorries**.
- 283 lines, 1 def + 11 theorems.

## Files

- `proofs/Proofs/SpernerNDimOQ01OQ01.lean` (new)
- `src/data/proofs/sperner-ndim-oq-01-oq-01/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
