### PR TITLE
Enrich Ferrari's Four Quartic Roots: add index.ts + annotations

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ferrari-ann-factorization",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 52, "endLine": 62 },
+    "type": "technique",
+    "title": "The Ferrari Factorization is One linear_combination",
+    "content": "`ferrari_factorization` is the algebraic heart of the whole file: the depressed quartic equals the product of the two Ferrari quadratics, and the entire proof is a single `linear_combination x^2*hw - x*hwe + he2`. The three hypotheses `w²=2s`, `2we=q`, `e²=(s+p/2)²-r` are exactly the relations Ferrari's completing-the-square construction imposes, and the identity holds *modulo* the ideal they generate — so subtracting the right ℂ-linear combination of them (weighted by `x²`, `-x`, `1`) reduces both sides to a `ring`-closable identity. Everything downstream specialises this one theorem; no further quartic algebra is ever redone.",
+    "mathContext": "$x^4+px^2+qx+r = \\left(x^2 - wx + (s+\\tfrac p2+e)\\right)\\left(x^2 + wx + (s+\\tfrac p2-e)\\right)$, valid when $w^2=2s,\\; 2we=q,\\; e^2=(s+\\tfrac p2)^2-r$.",
+    "significance": "key",
+    "relatedConcepts": ["Ferrari's method", "completing the square", "polynomial identities", "linear_combination", "ideal membership"],
+    "prerequisites": ["quartic equations", "ring identities in Lean"]
+  },
+  {
+    "id": "ferrari-ann-monic-quad",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 68, "endLine": 73 },
+    "type": "technique",
+    "title": "Discriminant Form of the Quadratic Formula",
+    "content": "`monic_quadratic_root` packages the quadratic formula in its purest verification form: a monic `x²+bx+c` vanishes at `(-b±d)/2` whenever `d²=b²-4c`. The proof `rcases hx <;> subst h <;> linear_combination hd/4` handles both signs uniformly — substitute the closed form, then the discriminant hypothesis `hd` divided by 4 cancels the remaining algebra. This reusable lemma is why each of the four root verifications below collapses to a one-line discriminant substitution rather than a fresh quartic computation.",
+    "mathContext": "$x^2 + bx + c = 0$ at $x = \\dfrac{-b \\pm d}{2}$ exactly when $d^2 = b^2 - 4c$ (the discriminant $\\Delta = b^2-4c$, $d = \\sqrt{\\Delta}$).",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic formula", "discriminant", "completing the square"],
+    "prerequisites": ["quadratic equations", "linear_combination"]
+  },
+  {
+    "id": "ferrari-ann-root-q1q2",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 79, "endLine": 101 },
+    "type": "insight",
+    "title": "Each Closed Form is a Genuine Root by Substitution",
+    "content": "`ferrari_root_Q1` and `ferrari_root_Q2` verify that `(w±d₁)/2` and `(-w±d₂)/2` actually solve the quartic — not by appealing to abstract root-counting, but by direct substitution. Each rewrites the quartic via `ferrari_factorization`, shows the relevant Ferrari quadratic vanishes at the closed form (again `linear_combination hd/4` over both signs), and concludes `0 * (other factor) = 0`. This is the constructive content the parent's reduction chain lacked: explicit numbers shown to be roots, with the discriminant hypotheses `d₁²=w²-4(s+p/2+e)` and `d₂²=w²-4(s+p/2-e)` doing the work.",
+    "mathContext": "Roots of $Q_1$: $x=\\dfrac{w\\pm d_1}{2}$ with $d_1^2 = w^2-4(s+\\tfrac p2+e)$. Roots of $Q_2$: $x=\\dfrac{-w\\pm d_2}{2}$ with $d_2^2 = w^2-4(s+\\tfrac p2-e)$.",
+    "significance": "key",
+    "relatedConcepts": ["root verification", "Ferrari quadratics", "mul_eq_zero", "substitution"],
+    "prerequisites": ["polynomial roots", "factor theorem"]
+  },
+  {
+    "id": "ferrari-ann-four-roots",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 103, "endLine": 118 },
+    "type": "concept",
+    "title": "All Four Roots Collected as a Set",
+    "content": "`ferrari_four_roots` bundles the four closed forms into a single `Set ℂ` membership statement: every element of `{(w+d₁)/2, (w-d₁)/2, (-w+d₂)/2, (-w-d₂)/2}` is a root. The proof destructures membership into four cases and dispatches each to the appropriate `ferrari_root_Q1`/`ferrari_root_Q2` instance. This is the clean enumerated form of 'the quartic has these four roots', stated without yet asserting they are distinct or exhaustive (`ferrari_splits` supplies exhaustiveness via the full factorization).",
+    "mathContext": "$\\forall x \\in \\left\\{\\tfrac{w+d_1}{2}, \\tfrac{w-d_1}{2}, \\tfrac{-w+d_2}{2}, \\tfrac{-w-d_2}{2}\\right\\},\\quad x^4+px^2+qx+r = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["solution set", "Set membership", "case analysis"],
+    "prerequisites": ["Set.mem_insert_iff", "case splitting"]
+  },
+  {
+    "id": "ferrari-ann-splits",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 120, "endLine": 138 },
+    "type": "insight",
+    "title": "Complete Splitting into Four Linear Factors",
+    "content": "`ferrari_splits` is the strongest factorization statement: the depressed quartic equals the product of four explicit linear factors `(x - ρᵢ)`. It rewrites via `ferrari_factorization`, then splits each Ferrari quadratic into two linears using its discriminant root (`linear_combination hd/4` again), and finishes with `ring`. Because the quartic is monic of degree 4 and now written as a product of exactly four monic linears, this proves the four Ferrari roots are *all* the roots (counted with multiplicity) — the quartic splits completely over ℂ, as it must over an algebraically closed field.",
+    "mathContext": "$x^4+px^2+qx+r = \\left(x-\\tfrac{w+d_1}{2}\\right)\\left(x-\\tfrac{w-d_1}{2}\\right)\\left(x-\\tfrac{-w+d_2}{2}\\right)\\left(x-\\tfrac{-w-d_2}{2}\\right)$.",
+    "significance": "key",
+    "relatedConcepts": ["splitting field", "complete factorization", "fundamental theorem of algebra", "monic polynomials"],
+    "prerequisites": ["algebraically closed fields", "polynomial factorization"]
+  },
+  {
+    "id": "ferrari-ann-resolvent-shift",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 144, "endLine": 157 },
+    "type": "definition",
+    "title": "The Resolvent Cubic and the Ferrari Shift",
+    "content": "`IsResolventRoot` records Ferrari's resolvent cubic `8m³+20pm²+(16p²-8r)m+(4p³-4pr-q²)=0` in the *parent's* convention, so this file plugs directly into `SolutionOfCubicOQ03OQ03`. `resolvent_shift_eq` shows the substitution `s = m + p/2` turns that cubic into the perfect-square parameter equation `8s³+8ps²+(2p²-8r)s = q²` — a single `linear_combination h`. This shifted equation is the *only* consequence of the resolvent ever used downstream: it is exactly what makes `e² = (s+p/2)²-r` solvable, i.e. what makes Ferrari's auxiliary quadratic a perfect square.",
+    "mathContext": "Resolvent: $8m^3+20pm^2+(16p^2-8r)m+(4p^3-4pr-q^2)=0$. After $s=m+\\tfrac p2$: $8s^3+8ps^2+(2p^2-8r)s = q^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["resolvent cubic", "Ferrari's method", "change of variable", "perfect square"],
+    "prerequisites": ["cubic equations", "Cardano's method"]
+  },
+  {
+    "id": "ferrari-ann-bridge",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 159, "endLine": 175 },
+    "type": "technique",
+    "title": "Bridge: Resolvent Root Supplies the Ferrari Data",
+    "content": "`exists_ferrari_data` is the connective tissue between the resolvent cubic and the factorization: given a resolvent root `m` with nonzero shift `s` and a nonzero square root `w` of `2s`, it produces `e = q/(2w)` satisfying both `2we=q` (immediate, by `field_simp`) and `e²=(s+p/2)²-r`. The second relation is where the shifted resolvent equation is consumed: clearing denominators via `(2w)²=8s` (from `w²=2s`) and `div_eq_iff`, the goal becomes exactly `-resolvent_shift_eq`, closed by `linear_combination -hres`. This is why a *single* resolvent root is enough to unlock all four quartic roots.",
+    "mathContext": "$e = \\dfrac{q}{2w}$ with $w^2=2s$ gives $e^2 = \\dfrac{q^2}{4w^2} = \\dfrac{q^2}{8s}$, and the shifted resolvent $8s^3+8ps^2+(2p^2-8r)s=q^2$ rearranges to $e^2 = (s+\\tfrac p2)^2 - r$.",
+    "significance": "key",
+    "relatedConcepts": ["field_simp", "div_eq_iff", "resolvent cubic", "Ferrari data"],
+    "prerequisites": ["field arithmetic in Lean", "clearing denominators"]
+  },
+  {
+    "id": "ferrari-ann-solvable",
+    "proofId": "solution-of-cubic-oq-03-oq-03-oq-02",
+    "range": { "startLine": 181, "endLine": 200 },
+    "type": "insight",
+    "title": "Explicit Solvability over ℂ",
+    "content": "`ferrari_solvable` is the headline corollary: every depressed quartic with a nonzero-shift resolvent root has an explicitly constructed root over ℂ. It uses `IsAlgClosed.exists_pow_nat_eq` three times conceptually — to produce the square root `w` of `2s`, then (via the bridge) the data `e`, then `d₁` — and feeds them to `ferrari_root_Q1`, returning `(w+d₁)/2` as a witnessed root. The `hw0 : w ≠ 0` step is a small but necessary argument: if `w=0` then `2s=0`, contradicting the nonzero-shift hypothesis. This is Ferrari's method made fully constructive and machine-checked.",
+    "mathContext": "Over an algebraically closed field every element has a square root, so $w,d$ with $w^2=2s$ and $d^2=w^2-4(s+\\tfrac p2+e)$ exist; then $\\dfrac{w+d}{2}$ is a verified root.",
+    "significance": "key",
+    "relatedConcepts": ["algebraically closed field", "IsAlgClosed.exists_pow_nat_eq", "constructive solvability", "existence of square roots"],
+    "prerequisites": ["field theory", "existential witnesses in Lean"]
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/index.ts
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SolutionOfCubicOQ03OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const solutionOfCubicOQ03OQ03OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const solutionOfCubicOQ03OQ03OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const solutionOfCubicOQ03OQ03OQ02Data: ProofData = {
+  proof: solutionOfCubicOQ03OQ03OQ02Proof,
+  annotations: solutionOfCubicOQ03OQ03OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-03-oq-03-oq-02` (quality 45, passes 0).

## Gaps fixed
- **Missing `index.ts`** — the directory had only `meta.json`, so Vite's `import.meta.glob` could not discover the proof and the page showed "proof not found" on the live site. Added the standard entry point.
- **Missing `annotations.json`** — added 8 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering every section of the 200-line Lean file: the one-`linear_combination` Ferrari factorization, the discriminant quadratic-root lemma, the four-root verification by substitution, the complete linear splitting, the resolvent-cubic bridge (`exists_ferrari_data`), and explicit solvability over ℂ.

## Notes
- Annotation line ranges verified within the Lean file (1–200) and aligned to the existing `sections` boundaries.
- `status: verified` / `badge: original` / `axiomCount: 0` are consistent with the source (0 sorries, 0 axioms, no `native_decide`; #print axioms = propext/Classical.choice/Quot.sound). No assumptions introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)