### PR TITLE
Enrich Stark rank-one regulator collapse

### DIFF
--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/annotations.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 4, "endLine": 41 },
     "type": "concept",
     "title": "Rank-One Stark Units: the Regulator is One Logarithm",
-    "content": "Hilbert's 12th problem seeks explicit generators of abelian extensions of a number field K. Beyond ℚ (roots of unity) and imaginary quadratic fields (complex multiplication), the conjectural answer is governed by the **Stark conjectures**. Their simplest instance — the *rank-one abelian Stark conjecture* — applies exactly when the relevant unit rank is 1, and predicts that L'(0, χ) is a rational multiple of a single logarithm log|ε| of one algebraic unit ε, the **Stark unit**.\n\nThis entry machine-checks the structural fact that makes that statement meaningful: in unit rank 1, the regulator of K collapses from a determinant to a single logarithm of the fundamental unit. It does not attempt the open problem of computing Stark units effectively."
+    "content": "Hilbert's 12th problem seeks explicit generators of abelian extensions of a number field K. Beyond ℚ (roots of unity) and imaginary quadratic fields (complex multiplication), the conjectural answer is governed by the **Stark conjectures**. Their simplest instance — the *rank-one abelian Stark conjecture* — applies exactly when the relevant unit rank is 1, and predicts that L'(0, χ) is a rational multiple of a single logarithm log|ε| of one algebraic unit ε, the **Stark unit**.\n\nThis entry machine-checks the structural fact that makes that statement meaningful: in unit rank 1, the regulator of K collapses from a determinant to a single logarithm of the fundamental unit. It does not attempt the open problem of computing Stark units effectively.",
+    "mathContext": "Rank-one abelian Stark: $L'(0,\\chi) = \\tfrac{1}{w}\\sum_{\\sigma} \\chi(\\sigma)\\log|\\varepsilon^\\sigma|$ for a Stark unit $\\varepsilon$; this entry formalizes the regulator side, $R_K = \\mathrm{mult}(w)\\,|\\log w(\\varepsilon)|$ when $\\mathrm{rank}\\,K = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's 12th problem", "Kronecker's Jugendtraum", "Stark conjectures", "Stark units", "abelian extensions"],
+    "prerequisites": ["algebraic number theory", "class field theory", "Artin L-functions"]
   },
   {
     "id": "ann-rank-characterization",
@@ -13,7 +17,11 @@
     "range": { "startLine": 50, "endLine": 56 },
     "type": "technique",
     "title": "Rank One ⟺ Two Infinite Places",
-    "content": "By Dirichlet's unit theorem, the unit rank of K is r₁ + r₂ − 1 = #(InfinitePlace K) − 1. Hence `rank K = 1` is equivalent to K having exactly two infinite places. Concretely these are the **real quadratic fields** (r₁,r₂)=(2,0) and the **mixed-signature cubic fields** (r₁,r₂)=(1,1) — exactly the fields where the rank-one abelian Stark conjecture lives. The proof is `rw [rank]` followed by `omega`, using `Fintype.card_pos` (there is always at least one infinite place) to pin down the natural-number subtraction."
+    "content": "By Dirichlet's unit theorem, the unit rank of K is r₁ + r₂ − 1 = #(InfinitePlace K) − 1. Hence `rank K = 1` is equivalent to K having exactly two infinite places. Concretely these are the **real quadratic fields** (r₁,r₂)=(2,0) and the **mixed-signature cubic fields** (r₁,r₂)=(1,1) — exactly the fields where the rank-one abelian Stark conjecture lives. The proof is `rw [rank]` followed by `omega`, which resolves the natural-number subtraction #(InfinitePlace K) − 1 = 1 ⟺ #(InfinitePlace K) = 2 (there is always at least one infinite place).",
+    "mathContext": "$\\mathrm{rank}\\,K = r_1 + r_2 - 1 = \\#(\\mathrm{InfinitePlace}\\,K) - 1$, so $\\mathrm{rank}\\,K = 1 \\iff \\#(\\mathrm{InfinitePlace}\\,K) = 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet's unit theorem", "infinite places", "real quadratic fields", "signature (r₁,r₂)", "unit rank"],
+    "prerequisites": ["Dirichlet's unit theorem", "infinite places of a number field"]
   },
   {
     "id": "ann-regulator-collapse",
@@ -21,6 +29,10 @@
     "range": { "startLine": 58, "endLine": 77 },
     "type": "technique",
     "title": "Collapsing the Regulator Determinant via Matrix.det_unique",
-    "content": "Mathlib defines the regulator as the covolume of the unit lattice, and `regOfFamily_eq_det` expresses it as the absolute value of the determinant of the (rank × rank) matrix (mult w · log w(uᵢ))_{i,w} of logarithms of a fundamental system of units, with rows/columns indexed by the infinite places other than the distinguished place w₀.\n\nWhen `rank K = 1`, both index types are singletons. Transporting the `Unique (Fin (rank K))` instance along `equivFinRank` gives `Unique {w // w ≠ w₀}`, so `Matrix.det_unique` reduces the determinant to its single diagonal entry `mult(w) · log(w ε)`. Factoring out the positive multiplicity (`abs_of_nonneg`) yields `regulator K = mult(w) · |log(w ε)|` — the regulator as a single archimedean logarithm of the fundamental (Stark) unit ε = fundSystem K."
+    "content": "Mathlib defines the regulator as the covolume of the unit lattice, and `regOfFamily_eq_det` expresses it as the absolute value of the determinant of the (rank × rank) matrix (mult w · log w(uᵢ))_{i,w} of logarithms of a fundamental system of units, with rows/columns indexed by the infinite places other than the distinguished place w₀.\n\nWhen `rank K = 1`, both index types are singletons. Transporting the `Unique (Fin (rank K))` instance along `equivFinRank` gives `Unique {w // w ≠ w₀}`, so `Matrix.det_unique` reduces the determinant to its single diagonal entry `mult(w) · log(w ε)`. Factoring the absolute value over the product (abs_mul) and using that the multiplicity is a nonnegative cast (Nat.abs_cast) yields `regulator K = mult(w) · |log(w ε)|` — the regulator as a single archimedean logarithm of the fundamental (Stark) unit ε = fundSystem K.",
+    "mathContext": "$R_K = \\bigl|\\det\\,(\\mathrm{mult}\\,w \\cdot \\log w(u_i))_{i,w}\\bigr| \\xrightarrow{\\;\\mathrm{rank}=1\\;} \\mathrm{mult}(w)\\,|\\log w(\\varepsilon)|$ via $\\det$ of a $1\\times1$ matrix.",
+    "significance": "key",
+    "relatedConcepts": ["regulator", "unit lattice covolume", "Matrix.det_unique", "equivFinRank", "fundamental system of units", "logarithmic embedding"],
+    "prerequisites": ["determinant of a 1×1 matrix", "the regulator as a determinant of logarithms", "Unique type instances"]
   }
 ]

--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/index.ts
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/KroneckersJugendtraumStarkRankOne.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const kroneckersJugendtraumOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const kroneckersJugendtraumOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const kroneckersJugendtraumOq02Data: ProofData = {
+  proof: kroneckersJugendtraumOq02Proof,
+  annotations: kroneckersJugendtraumOq02Annotations,
+}

--- a/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum-oq-02/meta.json
@@ -71,5 +71,30 @@
       "The regulator as the covolume of the unit lattice under the logarithmic embedding.",
       "Stark conjectures (rank-one abelian case) for the L-function interpretation."
     ]
+  },
+  "sections": [
+    {
+      "id": "rank-characterization",
+      "title": "Rank One ⟺ Two Infinite Places",
+      "startLine": 50,
+      "endLine": 56,
+      "summary": "rank_eq_one_iff_card_infinitePlace_eq_two: since rank K = #(InfinitePlace K) − 1 by Dirichlet's unit theorem, rank K = 1 holds exactly when K has two infinite places — the real quadratic (2,0) and mixed-signature cubic (1,1) fields where the rank-one Stark conjecture lives. Proved by `rw [rank]; omega`."
+    },
+    {
+      "id": "regulator-collapse",
+      "title": "The Rank-One Regulator is a Single Logarithm",
+      "startLine": 58,
+      "endLine": 77,
+      "summary": "regulator_eq_single_log_of_rank_eq_one: when rank K = 1, the regulator collapses from a determinant of logarithms to mult(w)·|log(w ε)| for the fundamental (Stark) unit ε. Transports the Unique instance along equivFinRank and applies Matrix.det_unique to read off the single 1×1 entry."
+    }
+  ],
+  "conclusion": {
+    "summary": "Two machine-checked results isolate the linear-algebra core of the rank-one abelian Stark conjecture: rank K = 1 is equivalent to K having exactly two infinite places (Dirichlet's unit theorem), and in that case the regulator of K collapses from an (r×r) determinant of logarithms to the single archimedean logarithm mult(w)·|log(w ε)| of the fundamental (Stark) unit. 79 lines, 2 theorems, 0 sorries, 0 axioms (only propext/Classical.choice/Quot.sound).",
+    "implications": "This formalizes exactly the structural fact that makes the rank-one Stark statement 'L'(0,χ) is a rational multiple of one log|ε| of one unit' well-posed: it is precisely the regime where Mathlib's regulator determinant is 1×1. It cleanly separates the (now-verified) linear-algebra collapse from the genuinely open arithmetic content — the effective computation of the Stark unit itself, which Hilbert's 12th problem leaves unsolved in general.",
+    "openQuestions": [
+      "Connect this regulator collapse to the L-function side: state and (conditionally) relate L'(0,χ) to mult(w)·log|w ε| for the rank-one abelian Stark conjecture, making the unit ε the Stark unit predicted by the L-value.",
+      "Specialize to real quadratic fields, where ε is the classical fundamental unit, and produce explicit numerical witnesses of the rank-one regulator formula.",
+      "Address the open effective-computation problem: exhibit, for a mixed-signature cubic field, the Stark unit generating the predicted abelian extension — the actual content of Hilbert's 12th problem here."
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `kroneckers-jugendtraum-oq-02`.

**Critical fix:** added the missing `index.ts` — without it the proof page renders 'proof not found' on the live site.

**Depth added to meta.json:** added `sections` (2, covering both theorems) and a full `conclusion` (summary, implications, 3 openQuestions on the L-function connection, real-quadratic witnesses, and the open effective-computation problem) — both were absent.

**Annotation depth:** the 3 existing annotations had no `mathContext`/`significance`/`relatedConcepts`/`prerequisites`; added all four fields to each while keeping full line coverage (overview, rank characterization, regulator collapse).

**Axiom integrity:** verified — 0 sorries / 0 axioms (only propext/Classical.choice/Quot.sound). `badge: "original"` is justified (the rank-one collapse is not a Mathlib headline result); the honest framing that effective Stark-unit computation remains open is preserved. status=verified retained.

JSON validated with python (node_modules absent so `pnpm build` cannot run).