### PR TITLE
Enrich Gaussian second moment (area-of-circle oq-07-oq-05): index.ts + overview/sections

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-05/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/annotations.json
@@ -2,7 +2,7 @@
   {
     "id": "ann-aoc07oq05-context",
     "proofId": "area-of-circle-oq-07-oq-05",
-    "range": { "startLine": 4, "endLine": 52 },
+    "range": { "startLine": 5, "endLine": 35 },
     "type": "concept",
     "title": "The Second Moment of the Gaussian",
     "content": "The parent `area-of-circle-oq-07` evaluates the zeroth moment of the Gaussian weight, `∫_ℝ e^{-x²} dx = √π`. This entry adds the first nontrivial weighted moment: `∫_ℝ x² e^{-x²} dx = √π/2`. Where the siblings oq-01…oq-04 vary the parameter, the domain (half-line), or square the value — all still the zeroth moment — here the integrand carries the genuine polynomial weight `x²`. The value √π/2 is exactly half the parent's √π, a coincidence explained by integration by parts: the x² weight is `traded` for a derivative that recovers the bare Gaussian.",
@@ -22,12 +22,12 @@
   {
     "id": "ann-aoc07oq05-decay",
     "proofId": "area-of-circle-oq-07-oq-05",
-    "range": { "startLine": 54, "endLine": 67 },
+    "range": { "startLine": 41, "endLine": 51 },
     "type": "technique",
     "title": "The Boundary Term Vanishes: Gaussian Decay",
     "content": "`tendsto_mul_gaussian_cocompact` proves `x e^{-x²} → 0` at both ends of the real line — the boundary product of the integration by parts. It is repackaged from Mathlib's `tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact` (with exponent s = 1, rate a = 1), which gives `|x|^1 e^{-x²} → 0` along the cocompact filter. Stripping the absolute value uses `tendsto_zero_iff_norm_tendsto_zero` together with `‖x e^{-x²}‖ = |x| e^{-x²}` (the Gaussian factor is positive). The single cocompact statement is later split into the `atBot` and `atTop` limits the IBP lemma requires, via `cocompact_eq_atBot_atTop` and `le_sup_left/right`.",
     "mathContext": "On $\\mathbb R$ the cocompact filter equals $\\text{atBot} \\sqcup \\text{atTop}$, so a single cocompact limit packages both one-sided boundary terms. Gaussian decay $e^{-x^2}$ dominates every polynomial, so $x^k e^{-x^2}\\to 0$ at $\\pm\\infty$ for all $k$.",
-    "significance": "important",
+    "significance": "supporting",
     "relatedConcepts": [
       "cocompact filter",
       "tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact",
@@ -42,7 +42,7 @@
   {
     "id": "ann-aoc07oq05-ibp",
     "proofId": "area-of-circle-oq-07-oq-05",
-    "range": { "startLine": 69, "endLine": 118 },
+    "range": { "startLine": 53, "endLine": 118 },
     "type": "technique",
     "title": "Integration by Parts on the Whole Line",
     "content": "`gaussian_second_moment` applies `MeasureTheory.integral_mul_deriv_eq_deriv_mul` with `u = x` (derivative 1) and `v = -½ e^{-x²}` (derivative `v' = x e^{-x²}`, built from `hasDerivAt_pow`, `HasDerivAt.exp`, and `HasDerivAt.const_mul`). The integrand factors as `u·v' = x·(x e^{-x²}) = x² e^{-x²}`, so the formula `∫ u v' = b' - a' - ∫ u' v` becomes `∫ x² e^{-x²} = 0 - 0 - ∫ 1·(-½ e^{-x²}) = ½∫ e^{-x²} = ½√π`. The two integrability side-conditions use `integrable_rpow_mul_exp_neg_mul_sq` (for x² e^{-x²}, identifying `x^(2:ℝ)` with `x²` via `Real.rpow_natCast`) and `integrable_exp_neg_mul_sq` (for the bare Gaussian); the boundary limits come from `tendsto_mul_gaussian_cocompact`. The final `∫ e^{-x²} = √π` is the parent value `integral_gaussian 1`.",

--- a/src/data/proofs/area-of-circle-oq-07-oq-05/index.ts
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ07OQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ07OQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ07OQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ07OQ05Data: ProofData = {
+  proof: areaOfCircleOQ07OQ05Proof,
+  annotations: areaOfCircleOQ07OQ05Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-05/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "area-of-circle-oq-07-oq-05",
   "slug": "area-of-circle-oq-07-oq-05",
+  "description": "The second moment of the standard Gaussian weight, ∫_ℝ x² e^{-x²} dx = √π/2, evaluated as a real Lebesgue integral. Integration by parts on the whole real line trades the x² weight for a derivative: writing the integrand as x·(x e^{-x²}) and recognizing x e^{-x²} = d/dx(-½ e^{-x²}), the boundary term vanishes by Gaussian decay and the second moment reduces to exactly half the parent's zeroth moment √π. This is the Γ(3/2) = √π/2 moment realized directly, the n = 1 base case of the even-moment double-factorial recursion ∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n.",
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
@@ -76,6 +77,49 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The Gaussian integral ∫_ℝ e^{-x²} dx = √π, first evaluated by Laplace and Poisson, is the keystone of probability theory, where e^{-x²/2}/√(2π) is the standard normal density. Its higher moments ∫ x^{2n} e^{-x²} dx encode the variance, kurtosis, and all even cumulants of the Gaussian, and satisfy the double-factorial law (2n-1)!!·√π/2^n. These moments are equivalently values of the Gamma function: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n + ½), and the substitution u = x² turns each into a Beta/Gamma evaluation. This entry computes the n = 1 moment √π/2 = Γ(3/2) directly as a real Lebesgue integral, fitting it into the gallery's Gaussian-integral family alongside the parent zeroth moment.",
+    "problemStatement": "Evaluate the second moment of the standard (unnormalized) Gaussian weight over the whole real line: prove ∫_{-∞}^{∞} x² e^{-x²} dx = √π/2 as a verified Lebesgue integral, reducing it to the parent zeroth moment ∫ e^{-x²} = √π.",
+    "proofStrategy": "Integration by parts on (-∞, ∞) via MeasureTheory.integral_mul_deriv_eq_deriv_mul, with u = x (so u' = 1) and v = -½ e^{-x²} (so v' = x e^{-x²}). Then u·v' = x·(x e^{-x²}) = x² e^{-x²} is the target integrand, and the parts formula ∫ u v' = [u v]_{-∞}^{∞} - ∫ u' v gives ∫ x² e^{-x²} = 0 - ∫ 1·(-½ e^{-x²}) = ½ ∫ e^{-x²} = ½·√π. The two boundary terms x·(-½ e^{-x²}) vanish at ±∞ because the Gaussian factor decays faster than the linear weight (tendsto_mul_gaussian_cocompact, repackaged from Mathlib's cocompact decay lemma and split across atBot/atTop). Integrability of x² e^{-x²} and e^{-x²} is supplied by integrable_rpow_mul_exp_neg_mul_sq and integrable_exp_neg_mul_sq; the final ∫ e^{-x²} = √π is the parent value integral_gaussian 1.",
+    "keyInsights": [
+      "The 'coincidence' √π/2 = ½·√π is no accident: integration by parts with u' = 1 trades the entire x² weight for the bare Gaussian, so the second moment is structurally half the zeroth moment.",
+      "On ℝ the cocompact filter equals atBot ⊔ atTop, so a single cocompact decay statement (x e^{-x²} → 0) discharges both one-sided boundary terms of the integration by parts at once.",
+      "Establishing √π/2 as a genuine real Lebesgue integral — rather than as the Gamma special value Γ(3/2) — gives a self-contained base case for the double-factorial recursion ∫ x^{2n} e^{-x²} = (2n-1)!!·√π/2^n, where each parts step lowers the power by two.",
+      "The badge is 'mathlib': every step is a routine consequence of existing Mathlib results (the IBP lemma, the parent integral_gaussian, and the Gaussian-decay tendsto), assembled rather than newly invented — but the assembly itself is the contribution, since Mathlib does not state the weighted second moment directly."
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ (MeasureTheory)",
+      "Integration by parts on (-∞, ∞)",
+      "The parent zeroth moment ∫ e^{-x²} = √π",
+      "Filters atBot/atTop/cocompact and Gaussian decay of polynomial weights"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem and Strategy",
+      "startLine": 5,
+      "endLine": 35,
+      "summary": "States the open question (the second moment ∫ x² e^{-x²}), the answer √π/2, and the integration-by-parts strategy that reduces it to half the parent zeroth moment √π. Notes the equivalent Gamma form Γ(3/2).",
+      "mathContext": "$\\int_{-\\infty}^{\\infty} x^2 e^{-x^2}\\,dx = \\tfrac{\\sqrt\\pi}{2} = \\Gamma(3/2)$."
+    },
+    {
+      "id": "decay",
+      "title": "The Vanishing Boundary Term",
+      "startLine": 41,
+      "endLine": 51,
+      "summary": "tendsto_mul_gaussian_cocompact: x e^{-x²} → 0 along the cocompact filter, repackaged from Mathlib's tendsto_rpow_abs_mul_exp_neg_mul_sq_cocompact by stripping the absolute value. This is the boundary product that vanishes in the integration by parts.",
+      "mathContext": "$x e^{-x^2} \\to 0$ as $x \\to \\pm\\infty$ (Gaussian decay beats the linear factor)."
+    },
+    {
+      "id": "second-moment",
+      "title": "Integration by Parts on the Whole Line",
+      "startLine": 53,
+      "endLine": 118,
+      "summary": "gaussian_second_moment: builds the derivatives u = x, v = -½ e^{-x²}, verifies the two integrability conditions and the two boundary limits, applies integral_mul_deriv_eq_deriv_mul, and evaluates the surviving ½ ∫ e^{-x²} = ½√π via the parent integral_gaussian.",
+      "mathContext": "$\\int u\\,v' = [uv]_{-\\infty}^{\\infty} - \\int u'\\,v = 0 - \\int 1\\cdot(-\\tfrac12 e^{-x^2}) = \\tfrac12\\sqrt\\pi$."
+    }
+  ],
   "openQuestions": [
     {
       "id": "area-of-circle-oq-07-oq-05-oq-01",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-05` (quality 57, passes 0).

## Gaps fixed
- **Missing `index.ts`** — the directory had `meta.json` and `annotations.json` but no entry point, so the page showed "proof not found" on the live site. Added it.
- **meta.json had no `description`, `overview`, or `sections`** — `index.ts` reads `meta.description` (was undefined). Added a top-level description, a full overview (historicalContext tying the moment to Γ(n+½) and the normal distribution, problemStatement, proofStrategy, 4 keyInsights), and 3 sections covering the 118-line file.

## Accuracy fixes
- Corrected three annotation line ranges: the 'Gaussian decay' annotation pointed at lines 54–67, which fall **inside** `gaussian_second_moment` rather than the `tendsto_mul_gaussian_cocompact` theorem it describes. Reanchored to 5–35 (docstring), 41–51 (decay theorem), 53–118 (second-moment theorem).
- Fixed an invalid `significance` enum value (`"important"` → `"supporting"`; the schema allows key/supporting/technical/context).

## Notes
- `badge: "mathlib"` / `status: verified` / `axiomCount: 0` left intact and consistent with the source (0 sorries, 0 axioms; assembles existing Mathlib lemmas). The keyInsight on the badge makes the 'assembly is the contribution' framing explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)