### PR TITLE
Enrich Divisibility Rules for 11 (divisibility-rules-oq-04): index.ts + overview/sections

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-04/annotations.json
+++ b/src/data/proofs/divisibility-rules-oq-04/annotations.json
@@ -27,7 +27,7 @@
     "title": "Block-Sum Rule from 100 ≡ 1",
     "content": "`eleven_dvd_iff_block_sum` is `Nat.dvd_iff_dvd_digits_sum 11 100 (by norm_num) n`. The lemma `dvd_iff_dvd_digits_sum b b' (h : b' % b = 1)` states `b ∣ n ↔ b ∣ (digits b' n).sum` whenever the base reduces to 1 modulo b. Here `100 % 11 = 1`, discharged by `norm_num`, so summing the base-100 digits (the two-decimal-digit blocks read from the right) detects divisibility by 11. This is a new specialization — the sibling entries only treat single digits.",
     "mathContext": "Because $100 \\equiv 1 \\pmod{11}$, all powers $100^k \\equiv 1$, so $n = \\sum c_k 100^k \\equiv \\sum c_k \\pmod{11}$ where the $c_k$ are the two-digit blocks. Hence $11 \\mid n$ iff $11$ divides their plain sum.",
-    "significance": "important",
+    "significance": "supporting",
     "relatedConcepts": ["dvd_iff_dvd_digits_sum", "base-100 digits", "100 ≡ 1 mod 11"],
     "prerequisites": ["Nat.dvd_iff_dvd_digits_sum", "norm_num on residues"]
   },
@@ -42,5 +42,29 @@
     "significance": "key",
     "relatedConcepts": ["dvd_iff_dvd_ofDigits", "ofDigits_neg_one", "1001 = 7·11·13", "alternating block sum"],
     "prerequisites": ["Nat.dvd_iff_dvd_ofDigits", "Nat.ofDigits_neg_one"]
+  },
+  {
+    "id": "ann-droq04-single-alt",
+    "proofId": "divisibility-rules-oq-04",
+    "range": { "startLine": 42, "endLine": 50 },
+    "type": "insight",
+    "title": "The Schoolbook Rule, Now Axiom-Free",
+    "content": "`eleven_dvd_iff_alternating` records the classical single-digit rule `11 ∣ n ↔ (11:ℤ) ∣ (d₀ - d₁ + d₂ - ⋯)` as a one-line application of Mathlib's `Nat.eleven_dvd_iff`. The point is not novelty of the statement but its *provenance*: the sibling `divisibility-rules-oq-01` proves only the weaker congruence form `11 ∣ n - altSum` and leans on `native_decide`, which depends on the `Lean.ofReduceBool` axiom. Here the full biconditional is obtained directly from the digit machinery with **no** axioms beyond the standard kernel triple — a strictly cleaner record of the same schoolbook fact.",
+    "mathContext": "$10 \\equiv -1 \\pmod{11}$, so $n = \\sum d_k 10^k \\equiv \\sum d_k(-1)^k = d_0 - d_1 + d_2 - \\cdots \\pmod{11}$; thus $11\\mid n \\iff 11 \\mid \\sum (-1)^k d_k$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.eleven_dvd_iff", "alternating digit sum", "native_decide vs axiom-free", "10 ≡ -1 mod 11"],
+    "prerequisites": ["alternating digit sum", "Lean.ofReduceBool / native_decide caveat"]
+  },
+  {
+    "id": "ann-droq04-congruence",
+    "proofId": "divisibility-rules-oq-04",
+    "range": { "startLine": 62, "endLine": 66 },
+    "type": "concept",
+    "title": "The Underlying Congruence",
+    "content": "`eleven_modEq_alternating` exposes the residue fact powering all three rules in its rawest form: `n ≡ (alternating digit sum) [ZMOD 11]`, via `Nat.modEq_eleven_digits_sum`. Every biconditional above is the divisibility shadow of this single congruence — the rules differ only in which base (10, 100, 1000) is used to group the digits before reducing mod 11. Stating the congruence separately makes explicit that the divisibility rules are not independent tricks but consequences of one modular identity.",
+    "mathContext": "$n \\equiv \\sum_k (-1)^k d_k \\pmod{11}$ as integers; divisibility ($11\\mid n$) is the special case where the residue is $0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.ModEq / ZMOD", "modEq_eleven_digits_sum", "congruence vs divisibility"],
+    "prerequisites": ["integer congruences", "modular arithmetic"]
   }
 ]

--- a/src/data/proofs/divisibility-rules-oq-04/index.ts
+++ b/src/data/proofs/divisibility-rules-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DivisibilityRulesOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const divisibilityRulesOQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const divisibilityRulesOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const divisibilityRulesOQ04Data: ProofData = {
+  proof: divisibilityRulesOQ04Proof,
+  annotations: divisibilityRulesOQ04Annotations,
+}

--- a/src/data/proofs/divisibility-rules-oq-04/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-04/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "divisibility-rules-oq-04",
   "slug": "divisibility-rules-oq-04",
+  "description": "Three fully verified (0-axiom) digit rules for divisibility by 11, each keyed to a different residue of a power of 10 modulo 11: the new two-digit block-sum rule (100 ≡ 1), the classical single-digit alternating rule recorded as a clean axiom-free biconditional (10 ≡ -1), and the three-digit block-alternating rule (1000 ≡ -1, the shared 1001 = 7·11·13 grouping that also tests 7 and 13). All three are uniform specializations of Mathlib's base-b digit machinery; the entry upgrades the sibling's native_decide-based, congruence-only treatment to axiom-free iffs.",
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Digits.Div",
@@ -70,6 +71,57 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Divisibility rules are among the oldest pieces of elementary number theory taught in schools: the digit-sum tests for 3 and 9 and the alternating-sum test for 11 appear in Fibonacci's Liber Abaci (1202) and were folklore long before. Their modern explanation is uniform — a base-b digit rule for a modulus m exists exactly when b is congruent to a simple residue (±1) modulo m, propagated through b^k ≡ (±1)^k. For 11 the decimal base gives 10 ≡ -1 (alternating digits); grouping digits in pairs gives 100 ≡ 1 (block sum); grouping in triples gives 1000 ≡ -1, and the factorization 1001 = 7·11·13 is the classical reason a single three-digit alternating test simultaneously detects 7, 11, and 13. Mathlib's Data.Nat.Digits.Div packages this base-b machinery; this entry specializes it to record all three rules for 11 as clean, axiom-free biconditionals.",
+    "problemStatement": "Determine the base-b digit rules that detect divisibility by 11, and derive them uniformly from the residues of powers of 10 modulo 11. Specifically, prove (with 0 axioms) the block-sum rule 11 ∣ n ↔ 11 ∣ (digits 100 n).sum, the single-digit alternating rule, and the three-digit block-alternating rule, each as a biconditional rather than a mere congruence.",
+    "proofStrategy": "Each rule is a one-residue specialization of Mathlib. The block-sum rule is `Nat.dvd_iff_dvd_digits_sum 11 100` whose hypothesis 100 % 11 = 1 is closed by norm_num. The single-digit alternating rule is `Nat.eleven_dvd_iff` verbatim. The three-digit block-alternating rule is `Nat.dvd_iff_dvd_ofDigits 11 1000 (-1)`, whose side condition (11:ℤ) ∣ 1001 is closed by norm_num, then rewritten from ofDigits form to an explicit alternatingSum via `Nat.ofDigits_neg_one`. A fourth theorem, `eleven_modEq_alternating`, records the underlying congruence n ≡ altSum [ZMOD 11] that all three rules are the divisibility shadow of.",
+    "keyInsights": [
+      "All digit divisibility rules for 11 are the same theorem at different bases: choosing the base b' in digits b' n selects the residue r = b' mod 11 (r = 1 → block sum, r = -1 → alternating sum).",
+      "The two-digit block-sum rule (base 100) and three-digit block-alternating rule (base 1000) are genuine specializations absent from Mathlib and the sibling entries, which treat only single digits.",
+      "1001 = 7·11·13 is the arithmetic heart of the three-digit rule and explains why one alternating block test works for all three primes at once — the simultaneous 7-11-13 divisibility test.",
+      "Provenance matters: the sibling oq-01 proves only the congruence form and relies on native_decide (hence the Lean.ofReduceBool axiom); recording the biconditionals straight from the digit machinery yields the same facts with zero axioms beyond the kernel triple."
+    ],
+    "prerequisites": [
+      "Nat.digits in an arbitrary base and Nat.ofDigits",
+      "Mathlib's base-b divisibility machinery (dvd_iff_dvd_digits_sum, dvd_iff_dvd_ofDigits)",
+      "Residues of powers of 10 modulo 11 (10 ≡ -1, 100 ≡ 1, 1000 ≡ -1)",
+      "List.alternatingSum and Nat.ofDigits_neg_one"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Residue Principle",
+      "startLine": 5,
+      "endLine": 28,
+      "summary": "States the open question and the unifying principle: each rule for 11 corresponds to a power of 10's residue mod 11 (10 ≡ -1, 100 ≡ 1, 1000 ≡ -1). Contrasts with the sibling oq-01's congruence-only, native_decide treatment.",
+      "mathContext": "$b'^k \\equiv (b' \\bmod 11)^k$, so the base selects digit-sum vs alternating-sum form."
+    },
+    {
+      "id": "block-sum",
+      "title": "Two-Digit Block-Sum Rule (100 ≡ 1)",
+      "startLine": 34,
+      "endLine": 40,
+      "summary": "eleven_dvd_iff_block_sum: 11 ∣ n ↔ 11 ∣ (digits 100 n).sum, a direct application of Nat.dvd_iff_dvd_digits_sum since 100 % 11 = 1. A new specialization not in Mathlib or the siblings.",
+      "mathContext": "$100 \\equiv 1 \\pmod{11} \\Rightarrow 11 \\mid n \\iff 11 \\mid \\sum(\\text{2-digit blocks})$."
+    },
+    {
+      "id": "single-alternating",
+      "title": "Classical Single-Digit Alternating Rule (10 ≡ -1)",
+      "startLine": 42,
+      "endLine": 50,
+      "summary": "eleven_dvd_iff_alternating: the schoolbook rule 11 ∣ n ↔ (11:ℤ) ∣ (d₀ - d₁ + d₂ - ⋯), recorded as a clean axiom-free biconditional via Nat.eleven_dvd_iff, upgrading the sibling's native_decide congruence form.",
+      "mathContext": "$10 \\equiv -1 \\pmod{11} \\Rightarrow 11 \\mid n \\iff 11 \\mid (d_0 - d_1 + d_2 - \\cdots)$."
+    },
+    {
+      "id": "block-alternating",
+      "title": "Three-Digit Block-Alternating Rule (1000 ≡ -1)",
+      "startLine": 52,
+      "endLine": 66,
+      "summary": "eleven_dvd_iff_block_alternating: 11 ∣ n ↔ (11:ℤ) ∣ alternatingSum of three-digit blocks, via Nat.dvd_iff_dvd_ofDigits (side condition 11 ∣ 1001 = 7·11·13) and Nat.ofDigits_neg_one. The closing eleven_modEq_alternating records the underlying congruence n ≡ altSum [ZMOD 11].",
+      "mathContext": "$1000 \\equiv -1 \\pmod{11}$ (since $1001 = 7\\cdot11\\cdot13$) $\\Rightarrow$ alternating sum of 3-digit blocks; the same grouping tests 7 and 13."
+    }
+  ],
   "openQuestions": [
     {
       "id": "divisibility-rules-oq-04-oq-01",
@@ -107,7 +159,7 @@
   ],
   "sorries": 0,
   "conclusion": {
-    "summary": "Three fully verified (0-axiom) divisibility rules for 11, each keyed to a residue of a power of 10 modulo 11: the two-digit block-sum rule 11 ∣ n ↔ 11 ∣ (digits 100 n).sum (100 ≡ 1, via Nat.dvd_iff_dvd_digits_sum), the classical single-digit alternating rule 11 ∣ n ↔ (11:ℤ) ∣ (d₀ - d₁ + d₂ - ⋯) (10 ≡ -1, via Nat.eleven_dvd_iff), and the three-digit block alternating rule (1000 ≡ -1, 1001 = 7·11·13, via Nat.dvd_iff_dvd_ofDigits and Nat.ofDigits_neg_one). 68 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "summary": "Three fully verified (0-axiom) divisibility rules for 11, each keyed to a residue of a power of 10 modulo 11: the two-digit block-sum rule 11 ∣ n ↔ 11 ∣ (digits 100 n).sum (100 ≡ 1, via Nat.dvd_iff_dvd_digits_sum), the classical single-digit alternating rule 11 ∣ n ↔ (11:ℤ) ∣ (d₀ - d₁ + d₂ - ⋯) (10 ≡ -1, via Nat.eleven_dvd_iff), and the three-digit block alternating rule (1000 ≡ -1, 1001 = 7·11·13, via Nat.dvd_iff_dvd_ofDigits and Nat.ofDigits_neg_one), plus the underlying congruence n ≡ altSum [ZMOD 11]. 68 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The block-sum (base 100) and block-alternating (base 1000) rules are new specializations not in Mathlib or the sibling entries, and the entry upgrades the sibling's native_decide-based, congruence-only treatment of the single-digit rule to a clean axiom-free biconditional. The three-digit grouping exposes the shared 1001 = 7·11·13 mechanism behind the simultaneous 7-11-13 divisibility test.",
     "openQuestions": [
       "Prove the unified 7-11-13 rule from the single base-1000 grouping."


### PR DESCRIPTION
Enrichment pass for `divisibility-rules-oq-04` (quality 57, passes 0).

## Gaps fixed
- **Missing `index.ts`** — directory had `meta.json`/`annotations.json` but no entry point, so the page showed "proof not found" live. Added it (and a top-level `description` it reads).
- **meta.json had no `overview` or `sections`** — added a full overview (historicalContext on the Fibonacci-era rules and the b ≡ ±1 residue principle, problemStatement, proofStrategy, 4 keyInsights) and 4 sections covering the 68-line file.
- **Annotations covered only 3 of 4 theorems** — added annotations for the single-digit axiom-free rule (`eleven_dvd_iff_alternating`) and the underlying congruence (`eleven_modEq_alternating`); now 5.

## Accuracy fixes
- Fixed an invalid `significance` enum value (`"important"` → `"supporting"`).
- Corrected the conclusion's theorem count ("5 theorems" → "4 theorems") to match `leanFile.theoremCount` and the actual source (4 theorems, 0 definitions).

## Notes
- `badge: "mathlib"` / `status: verified` / `axiomCount: 0` left intact and consistent with the source. A keyInsight and annotation make explicit that this entry's value over the sibling oq-01 is provenance: axiom-free biconditionals vs the sibling's native_decide (Lean.ofReduceBool) congruence form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)