### PR TITLE
Enrich Lucas–Lehmer test (lucas-lehmer-test-oq-01): index.ts + overview/sections + schema fixes

### DIFF
--- a/src/data/proofs/lucas-lehmer-test-oq-01/annotations.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01/annotations.json
@@ -1,69 +1,62 @@
 [
   {
-    "id": "ann-recurrence",
+    "id": "ann-ll-context",
     "proofId": "lucas-lehmer-test-oq-01",
-    "range": {
-      "startLine": 40,
-      "endLine": 57
-    },
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "context",
+    "title": "What Mathlib Has, and What This Entry Adds",
+    "content": "The Lucas–Lehmer test states that for an odd prime p, the Mersenne number M_p = 2^p − 1 is prime iff the residue s_{p-2} vanishes mod M_p, where s₀ = 4, s_{i+1} = s_i² − 2. Mathlib supplies the two implications separately (lucas_lehmer_sufficiency for 1 < p, lucas_lehmer_necessity for 3 ≤ p) plus a norm_num extension that evaluates the test by kernel reduction — but it does not package the full biconditional, nor record worked instances. This entry assembles exactly that missing content. Crucially, decisions go through norm_num's evalLucasLehmerTest (rfl on a tail-recursive residue), not native_decide, so the file is axiom-free in the foundational sense: no Lean.ofReduceBool.",
+    "mathContext": "$M_p = 2^p - 1$ is prime $\\iff s_{p-2} \\equiv 0 \\pmod{M_p}$, with $s_0 = 4,\\; s_{i+1} = s_i^2 - 2$.",
+    "significance": "context",
+    "relatedConcepts": ["Mersenne primes", "primality testing", "norm_num vs native_decide", "axiom-free verification"],
+    "prerequisites": ["Mersenne numbers", "modular arithmetic", "the Lean.ofReduceBool caveat"]
+  },
+  {
+    "id": "ann-ll-recurrence",
+    "proofId": "lucas-lehmer-test-oq-01",
+    "range": { "startLine": 39, "endLine": 57 },
     "type": "definition",
-    "title": "The Lucas–Lehmer recurrence sᵢ (s_zero, s_succ, s_one/s_two/s_three, lucasLehmerTest_iff_residue)",
-    "content": "The test inspects the integer sequence s₀ = 4, s_{i+1} = s_i² − 2. s_zero and s_succ expose the two defining clauses (both definitional, closed by rfl), and s_one/s_two/s_three compute the first iterates 14, 194, 37634 by unfolding the recurrence with norm_num. lucasLehmerTest_iff_residue records the definition of the test itself: LucasLehmerTest p holds iff the Lucas–Lehmer residue lucasLehmerResidue p — the iterate s_{p-2} taken in ZMod (2^p − 1) — equals 0. This is the object whose vanishing the whole criterion turns on.",
+    "title": "The Lucas–Lehmer Recurrence sᵢ and the Test's Definition",
+    "content": "The test inspects the integer sequence s₀ = 4, s_{i+1} = s_i² − 2. s_zero and s_succ expose the two defining clauses (both definitional, closed by rfl), and s_one/s_two/s_three compute the first iterates 14, 194, 37634 by unfolding the recurrence with norm_num. lucasLehmerTest_iff_residue records the definition of the test itself (Iff.rfl): LucasLehmerTest p holds iff the Lucas–Lehmer residue lucasLehmerResidue p — the iterate s_{p-2} taken in ZMod (2^p − 1) — equals 0. This is the object whose vanishing the whole criterion turns on.",
     "mathContext": "$s_0 = 4,\\quad s_{i+1} = s_i^2 - 2;\\qquad \\mathrm{LucasLehmerTest}(p) \\iff s_{p-2} \\equiv 0 \\pmod{2^p - 1}.$",
-    "prerequisites": [
-      "The Mathlib definitions LucasLehmer.s, LucasLehmer.lucasLehmerResidue",
-      "Definitional unfolding (rfl) and norm_num for the integer recurrence values"
-    ],
-    "relatedConcepts": [
-      "Lucas sequences",
-      "quadratic recurrence",
-      "residue mod a Mersenne number"
-    ],
-    "significance": "Fixes the concrete arithmetic engine of the test — a single quadratic recurrence whose (p−2)-nd term modulo 2^p − 1 certifies primality of the Mersenne number."
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas sequences", "quadratic recurrence", "residue mod a Mersenne number", "ZMod"],
+    "prerequisites": ["LucasLehmer.s / lucasLehmerResidue", "rfl and norm_num on integer recurrences"]
   },
   {
-    "id": "ann-biconditional",
+    "id": "ann-ll-biconditional",
     "proofId": "lucas-lehmer-test-oq-01",
-    "range": {
-      "startLine": 59,
-      "endLine": 69
-    },
-    "type": "theorem",
-    "title": "The Lucas–Lehmer criterion as a biconditional (mersenne_prime_iff_lucasLehmerTest)",
-    "content": "Mathlib proves the two halves of the criterion under different hypotheses: lucas_lehmer_sufficiency (LucasLehmerTest p → (mersenne p).Prime) needs only 1 < p, while lucas_lehmer_necessity ((mersenne p).Prime → LucasLehmerTest p) needs 3 ≤ p. Packaging them under the single hypothesis 3 ≤ p gives the textbook statement (mersenne p).Prime ↔ LucasLehmerTest p: necessity supplies the forward map directly, and sufficiency the backward map after weakening 3 ≤ p to 1 < p by omega. This bundled biconditional is the form actually used to certify the concrete witnesses below and is not stated as such in Mathlib.",
-    "mathContext": "For $3 \\le p$: $\\;(2^p - 1)\\text{ is prime} \\iff \\mathrm{LucasLehmerTest}(p).$",
-    "prerequisites": [
-      "lucas_lehmer_sufficiency (1 < p) and lucas_lehmer_necessity (3 ≤ p)",
-      "omega to weaken 3 ≤ p to 1 < p for the sufficiency direction"
-    ],
-    "relatedConcepts": [
-      "Mersenne primes",
-      "primality criteria",
-      "if-and-only-if packaging"
-    ],
-    "significance": "The keystone of the entry: the deterministic primality criterion for Mersenne numbers in its standard biconditional form, assembled from Mathlib's two one-directional theorems."
+    "range": { "startLine": 59, "endLine": 69 },
+    "type": "insight",
+    "title": "The Criterion as a Single Biconditional",
+    "content": "Mathlib proves the two halves under different hypotheses: lucas_lehmer_sufficiency (LucasLehmerTest p → (mersenne p).Prime) needs only 1 < p, while lucas_lehmer_necessity ((mersenne p).Prime → LucasLehmerTest p) needs 3 ≤ p. Packaging them under the single hypothesis 3 ≤ p gives the textbook statement (mersenne p).Prime ↔ LucasLehmerTest p: necessity supplies the forward map directly, and sufficiency the backward map after weakening 3 ≤ p to 1 < p by omega. This bundled biconditional — the keystone of the entry — is the form used to certify every concrete witness below, and is not stated as such in Mathlib.",
+    "mathContext": "For $3 \\le p$: $\\;(2^p - 1)\\text{ prime} \\iff \\mathrm{LucasLehmerTest}(p).$",
+    "significance": "key",
+    "relatedConcepts": ["Mersenne primes", "primality criteria", "biconditional packaging", "hypothesis weakening"],
+    "prerequisites": ["lucas_lehmer_sufficiency / necessity", "omega"]
   },
   {
-    "id": "ann-witnesses",
+    "id": "ann-ll-prime-witnesses",
     "proofId": "lucas-lehmer-test-oq-01",
-    "range": {
-      "startLine": 71,
-      "endLine": 109
-    },
-    "type": "theorem",
-    "title": "Prime and composite witnesses decided through the test (mersenne_*_prime, lucasLehmerTest_eleven_false, mersenne_eleven_*)",
-    "content": "Each Mersenne prime is certified by rewriting the goal (mersenne p).Prime along mersenne_prime_iff_lucasLehmerTest and then discharging LucasLehmerTest p with norm_num, which fires the evalLucasLehmerTest extension: it computes the residue by kernel reduction of the tail-recursive sModNatTR and closes the goal by rfl (no native_decide, so no Lean.ofReduceBool). This certifies M₅ = 31, M₇ = 127, M₁₃ = 8191, and M₁₇ = 131071. The composite direction is exercised at p = 11: lucasLehmerTest_eleven_false shows the test fails (norm_num), mersenne_eleven_not_prime rewrites along the biconditional to conclude M₁₁ is not prime, and mersenne_eleven_factorization confirms it explicitly with M₁₁ = 2047 = 23·89. The same biconditional thus reads in both directions — passing test ⇒ prime, failing test ⇒ composite.",
-    "mathContext": "$M_5=31,\\;M_7=127,\\;M_{13}=8191,\\;M_{17}=131071$ are prime; $M_{11}=2047=23\\cdot 89$ is not, and the test fails there.",
-    "prerequisites": [
-      "mersenne_prime_iff_lucasLehmerTest for the rewrite in both directions",
-      "The norm_num extension evalLucasLehmerTest deciding LucasLehmerTest p by kernel reduction",
-      "norm_num [mersenne] for the explicit factorization 2¹¹ − 1 = 23·89"
-    ],
-    "relatedConcepts": [
-      "Mersenne primes",
-      "compositeness certificate",
-      "kernel-reduction decision procedure"
-    ],
-    "significance": "Demonstrates the criterion as an effective algorithm: concrete Mersenne numbers are settled — prime and composite alike — purely through the Lucas–Lehmer residue, with verification by kernel reduction keeping the whole development axiom-free."
+    "range": { "startLine": 71, "endLine": 91 },
+    "type": "technique",
+    "title": "Four Mersenne Primes Decided Through the Test",
+    "content": "Each Mersenne prime is certified by rewriting the goal (mersenne p).Prime along mersenne_prime_iff_lucasLehmerTest and then discharging LucasLehmerTest p with norm_num, which fires the evalLucasLehmerTest extension: it computes the residue by kernel reduction of the tail-recursive sModNatTR and closes the goal by rfl. Because this is kernel reduction rather than native_decide, no Lean.ofReduceBool axiom is introduced. This certifies M₅ = 31, M₇ = 127, M₁₃ = 8191, and M₁₇ = 131071 — the test used as an effective primality algorithm, not just an abstract criterion.",
+    "mathContext": "$M_5 = 31,\\; M_7 = 127,\\; M_{13} = 8191,\\; M_{17} = 131071$ each pass the test and are prime.",
+    "significance": "key",
+    "relatedConcepts": ["Mersenne primes", "kernel-reduction decision", "evalLucasLehmerTest", "effective primality test"],
+    "prerequisites": ["the biconditional rewrite", "norm_num extension for LucasLehmerTest"]
+  },
+  {
+    "id": "ann-ll-composite-witness",
+    "proofId": "lucas-lehmer-test-oq-01",
+    "range": { "startLine": 93, "endLine": 109 },
+    "type": "insight",
+    "title": "A Composite Witness: M₁₁ = 2047 = 23·89",
+    "content": "The converse direction is exercised at p = 11, which is prime but whose Mersenne number is not. lucasLehmerTest_eleven_false shows the test fails (norm_num), mersenne_eleven_not_prime rewrites along the biconditional to conclude M₁₁ is not prime, and mersenne_eleven_factorization confirms it explicitly with M₁₁ = 2047 = 23·89. The same biconditional thus reads in both directions — a passing test certifies primality, a failing test certifies compositeness — which is what makes the Lucas–Lehmer test a genuine decision procedure rather than a one-sided sufficient condition.",
+    "mathContext": "$M_{11} = 2047 = 23 \\cdot 89$ is composite, and $\\mathrm{LucasLehmerTest}(11)$ correctly fails.",
+    "significance": "supporting",
+    "relatedConcepts": ["compositeness certificate", "contrapositive of necessity", "decision procedure", "explicit factorization"],
+    "prerequisites": ["the biconditional rewrite", "norm_num [mersenne] for the factorization"]
   }
 ]

--- a/src/data/proofs/lucas-lehmer-test-oq-01/meta.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "lucas-lehmer-test-oq-01",
   "slug": "lucas-lehmer-test-oq-01",
+  "description": "The Lucas–Lehmer primality test for Mersenne numbers, assembled as the full biconditional (mersenne p).Prime ↔ LucasLehmerTest p for 3 ≤ p from Mathlib's separately-stated sufficiency and necessity halves. The recurrence s₀ = 4, s_{i+1} = s_i² − 2 is spelled out and identified with the vanishing of the residue s_{p-2} mod 2^p − 1. Four Mersenne primes (M₅ = 31, M₇ = 127, M₁₃ = 8191, M₁₇ = 131071) are decided through the test, and a composite witness (p = 11, where the test fails so M₁₁ = 2047 = 23·89 is not prime) exercises the converse. Every witness is discharged by norm_num's kernel-reducing extension — no native_decide, hence no Lean.ofReduceBool — keeping the entry axiom-free.",
   "leanFile": {
     "imports": [
       "Mathlib"
@@ -115,6 +116,65 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Édouard Lucas introduced primality criteria for Mersenne numbers via second-order recurrences in 1878 and famously used them to certify M₁₂₇ = 2¹²⁷ − 1 prime by hand — the largest prime found by hand calculation, a record that stood until the computer era. Derrick Lehmer rigorised and simplified the criterion in 1930 into the modern test: M_p = 2^p − 1 is prime iff the residue s_{p-2} vanishes mod M_p, where s₀ = 4 and s_{i+1} = s_i² − 2. The test underlies the Great Internet Mersenne Prime Search (GIMPS) and the discovery of every record prime for decades. Its theoretical backbone is that the sequence lives in the ring ℤ[√3], where divisibility of M_p by s_{p-2} is equivalent to a unit having the right multiplicative order modulo M_p.",
+    "problemStatement": "Package the Lucas–Lehmer test as a usable biconditional and demonstrate it on concrete instances: prove (mersenne p).Prime ↔ LucasLehmerTest p for 3 ≤ p, exhibit the recurrence and its identification with the residue, and decide several Mersenne numbers — prime and composite — purely through the test, all axiom-free.",
+    "proofStrategy": "Combine Mathlib's lucas_lehmer_necessity (needs 3 ≤ p) and lucas_lehmer_sufficiency (needs 1 < p) under the single hypothesis 3 ≤ p (weakened to 1 < p by omega for the sufficiency direction) to obtain the biconditional mersenne_prime_iff_lucasLehmerTest. The recurrence theorems s_zero/s_succ are rfl; s_one/s_two/s_three unfold by norm_num; lucasLehmerTest_iff_residue is Iff.rfl. Each concrete Mersenne number is settled by rewriting (mersenne p).Prime along the biconditional and discharging LucasLehmerTest p with norm_num's evalLucasLehmerTest extension, which kernel-reduces the tail-recursive residue sModNatTR (no native_decide). The composite case p = 11 negates the test (lucasLehmerTest_eleven_false) and rewrites to non-primality, with an explicit 23·89 factorization.",
+    "keyInsights": [
+      "Mathlib carries the two implications of the criterion separately under mismatched hypotheses; the textbook biconditional under one hypothesis is genuinely new content, and it is the form every witness actually uses.",
+      "The test is an effective algorithm, not just an abstract equivalence: norm_num's evalLucasLehmerTest decides each instance by kernel reduction of a tail-recursive residue, so M₅/M₇/M₁₃/M₁₇ are certified prime by computation through the criterion.",
+      "Using kernel reduction (rfl) rather than native_decide keeps the development axiom-free — no Lean.ofReduceBool — which is the conservative, fully-trusted reading of 'verified' for a computational primality certificate.",
+      "The same biconditional reads in both directions: the failing test at p = 11 certifies compositeness of M₁₁ = 2047 = 23·89, demonstrating the criterion as a true decision procedure rather than a one-sided sufficient condition."
+    ],
+    "prerequisites": [
+      "Mathlib's lucas_lehmer_sufficiency and lucas_lehmer_necessity",
+      "The norm_num extension evalLucasLehmerTest (kernel reduction, no native_decide)",
+      "The recurrence LucasLehmer.s and residue lucasLehmerResidue",
+      "Mersenne numbers and ZMod (2^p − 1) arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Scope: the Missing Biconditional and Witnesses",
+      "startLine": 3,
+      "endLine": 31,
+      "summary": "States the test, what Mathlib already provides (the two one-directional theorems and the deciding norm_num extension), and what this entry assembles: the bundled biconditional and worked prime/composite instances, all axiom-free (no native_decide / Lean.ofReduceBool).",
+      "mathContext": "$M_p$ prime $\\iff s_{p-2}\\equiv 0\\pmod{M_p}$, $s_0=4$, $s_{i+1}=s_i^2-2$."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Recurrence sᵢ and the Test's Definition",
+      "startLine": 37,
+      "endLine": 57,
+      "summary": "s_zero/s_succ give the two defining clauses (rfl); s_one/s_two/s_three compute 14, 194, 37634; lucasLehmerTest_iff_residue (Iff.rfl) identifies the test with the vanishing of s_{p-2} in ZMod (2^p − 1).",
+      "mathContext": "$s_0=4,\\ s_1=14,\\ s_2=194,\\ s_3=37634$; test $\\iff$ residue $=0$."
+    },
+    {
+      "id": "biconditional",
+      "title": "The Biconditional Criterion",
+      "startLine": 59,
+      "endLine": 69,
+      "summary": "mersenne_prime_iff_lucasLehmerTest: bundles lucas_lehmer_necessity (3 ≤ p) and lucas_lehmer_sufficiency (1 < p, reached by omega) into (mersenne p).Prime ↔ LucasLehmerTest p for 3 ≤ p.",
+      "mathContext": "$3\\le p \\Rightarrow ((2^p-1)\\text{ prime} \\iff \\mathrm{LucasLehmerTest}(p))$."
+    },
+    {
+      "id": "prime-witnesses",
+      "title": "Four Mersenne Primes via the Test",
+      "startLine": 71,
+      "endLine": 91,
+      "summary": "M₅ = 31, M₇ = 127, M₁₃ = 8191, M₁₇ = 131071 are each certified prime by rewriting along the biconditional and discharging the test with norm_num's kernel-reducing evalLucasLehmerTest.",
+      "mathContext": "$M_5{=}31,\\ M_7{=}127,\\ M_{13}{=}8191,\\ M_{17}{=}131071$ prime."
+    },
+    {
+      "id": "composite-witness",
+      "title": "A Composite Witness at p = 11",
+      "startLine": 93,
+      "endLine": 109,
+      "summary": "The test fails at p = 11 (lucasLehmerTest_eleven_false), so M₁₁ is not prime (mersenne_eleven_not_prime), confirmed by the explicit factorization M₁₁ = 2047 = 23·89.",
+      "mathContext": "$M_{11} = 2047 = 23\\cdot 89$, test fails."
+    }
+  ],
   "openQuestions": [
     {
       "id": "lucas-lehmer-test-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `lucas-lehmer-test-oq-01` (quality 57, passes 0).

## Gaps fixed
- **Missing `index.ts`** — directory had `meta.json`/`annotations.json` but no entry point, so the page showed "proof not found" live. Added it (and the top-level `description` it reads).
- **meta.json had no `overview` or `sections`** — added a full overview (Lucas 1878 / Lehmer 1930 history, GIMPS context, problemStatement, proofStrategy, 4 keyInsights) and 5 sections covering the 110-line file.

## Accuracy / schema fixes
- The 3 existing annotations had **invalid schema**: `type: "theorem"` is not a permitted annotation type, and `significance` held prose paragraphs instead of an enum value. Rewrote to 5 annotations with valid `type` (context/definition/insight/technique) and `significance` (key/supporting/context), preserving the prose substance in `content`. Added a header-context annotation and split the prime vs composite witnesses.
- Corrected the conclusion's theorem count ("11 theorems" → "14 theorems") to match `leanFile.theoremCount` and the actual source (14 theorems, 0 definitions).

## Notes
- `badge: "mathlib"` / `status: verified` / `axiomCount: 0` left intact and consistent with the source. The overview/annotations stress that decisions use norm_num kernel reduction (not native_decide), so no Lean.ofReduceBool — the entry is axiom-free in the foundational sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)