### PR TITLE
Research: combinations-formula-oq-03-oq-03 — finite Rogers–Ramanujan (Schur) recurrence via q-Gaussian binomials

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ03OQ03.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ03OQ03.lean
@@ -1,0 +1,222 @@
+/-
+Combinations Formula OQ-03-OQ-03:
+The Finite Rogers–Ramanujan (Schur) Identity via q-Gaussian Binomials
+
+The parent entry `CombinationsFormulaOQ03` develops Gaussian (q-)binomial
+coefficients `[n choose k]_q` over an arbitrary commutative ring, division-free,
+via the q-Pascal recurrence. The seeker's open question asks whether the
+**Rogers–Ramanujan identities** can be approached using that library.
+
+The *analytic* Rogers–Ramanujan identity
+  ∑_{n ≥ 0} q^{n²} / (q;q)_n = ∏_{n ≥ 0} 1 / ((1 - q^{5n+1})(1 - q^{5n+4}))
+is an identity of formal power series / convergent q-series and is well beyond a
+single formalization session (it needs infinite products and the theory of
+`ℤ[[q]]`). This file instead formalizes the rigorous *finite* heart of the
+identity — the object Schur (1917) introduced to prove Rogers–Ramanujan and
+which converges termwise to the series side as `n → ∞`.
+
+Define the **Schur sum** (a polynomial in q over any CommRing)
+
+  S_n(q) = ∑_{j ≥ 0} q^{j²} · [n - j choose j]_q.
+
+Main result (`schurSum_recurrence`): these satisfy the q-Fibonacci recurrence
+
+  S_{n+2}(q) = S_{n+1}(q) + q^{n+1} · S_n(q),   S_0 = S_1 = 1.
+
+This is exactly Schur's recurrence: as `n → ∞` the polynomials converge to the
+Rogers–Ramanujan series `∑ q^{j²}/(q;q)_j`, and the recurrence is the finite
+combinatorial mechanism underlying the identity. Specializing at `q = 1` the
+recurrence becomes the Fibonacci recurrence, giving two corollaries:
+
+  * `schurSum_at_one_eq_fib` :  S_n(1) = F_{n+1}   (Fibonacci numbers), and
+  * `sum_choose_eq_fib`      :  ∑_{j} C(n-j, j) = F_{n+1}   (the classical
+    diagonal-of-Pascal identity), recovered for free.
+
+Everything is proved over an arbitrary `CommRing R`, with `0` sorries and
+`0` axioms (the q-binomial library it builds on is itself `0`-axiom).
+
+The engine is the parent's **second q-Pascal identity**
+  [n+1 choose k+1]_q = q^{n-k} · [n choose k]_q + [n choose k+1]_q
+(here proved unconditionally as `qBinom_pascal'_all`), applied termwise and
+reindexed.
+-/
+import Mathlib.Tactic
+import Mathlib.Data.Nat.Fib.Basic
+import Proofs.CombinationsFormulaOQ03
+
+namespace RogersRamanujanSchur
+
+open QBinomialCoefficients
+
+variable {R : Type*} [CommRing R]
+
+-- ============================================================
+-- Part I: Unconditional second q-Pascal identity
+-- ============================================================
+
+/-- **Unconditional second q-Pascal identity**:
+    [a+1 choose k+1]_q = q^{a-k} · [a choose k]_q + [a choose k+1]_q,
+    for *all* `a k : ℕ`.
+
+    The parent `qBinom_pascal'` carries the hypothesis `k + 1 ≤ a + 1`. When
+    `a < k` all three q-binomials vanish (`qBinom_eq_zero_of_lt`), so the
+    identity degenerates to `0 = q^{a-k} · 0 + 0`. Removing the hypothesis lets
+    us apply the identity termwise inside a `Finset` sum without threading a
+    side condition through every summand. -/
+theorem qBinom_pascal'_all (q : R) (a k : ℕ) :
+    qBinom q (a + 1) (k + 1) = q ^ (a - k) * qBinom q a k + qBinom q a (k + 1) := by
+  rcases le_or_gt k a with hk | hk
+  · exact qBinom_pascal' q a k (by omega)
+  · rw [qBinom_eq_zero_of_lt q (a + 1) (k + 1) (by omega),
+        qBinom_eq_zero_of_lt q a k hk,
+        qBinom_eq_zero_of_lt q a (k + 1) (by omega)]
+    ring
+
+-- ============================================================
+-- Part II: The Schur sum
+-- ============================================================
+
+/-- The **Schur sum** `S_n(q) = ∑_{j} q^{j²} · [n - j choose j]_q`.
+
+    The summation range `Finset.range (n + 1)` is a safe upper bound: the
+    summand vanishes once `j > n - j` (the q-binomial `[n-j choose j]_q` is then
+    `0`), so no nonzero term is omitted. At `q = 1` this is the diagonal sum
+    `∑_j C(n-j, j)`, the `(n+1)`-st Fibonacci number. -/
+def schurSum (q : R) (n : ℕ) : R :=
+  ∑ j ∈ Finset.range (n + 1), q ^ (j ^ 2) * qBinom q (n - j) j
+
+@[simp] theorem schurSum_zero (q : R) : schurSum q 0 = 1 := by
+  simp [schurSum]
+
+@[simp] theorem schurSum_one (q : R) : schurSum q 1 = 1 := by
+  simp [schurSum, Finset.sum_range_succ]
+
+/-- Peeling the `j = 0` term of `S_{n+1}` and reindexing `j ↦ i+1`:
+    `S_{n+1}(q) = (∑_{i < n+1} q^{(i+1)²} · [n - i choose i+1]_q) + 1`.
+    Used to recognise the "second piece" produced by the q-Pascal split. -/
+theorem schurSum_succ_peel (q : R) (n : ℕ) :
+    schurSum q (n + 1) =
+      (∑ i ∈ Finset.range (n + 1), q ^ ((i + 1) ^ 2) * qBinom q (n - i) (i + 1)) + 1 := by
+  rw [schurSum, Finset.sum_range_succ']
+  congr 1
+  · exact Finset.sum_congr rfl (fun i _ => by rw [Nat.succ_sub_succ])
+  · simp
+
+-- ============================================================
+-- Part III: The finite Rogers–Ramanujan (Schur) recurrence
+-- ============================================================
+
+/-- **Finite Rogers–Ramanujan / Schur recurrence**:
+    `S_{n+2}(q) = S_{n+1}(q) + q^{n+1} · S_n(q)`.
+
+    This is Schur's (1917) recurrence for the polynomials whose `n → ∞` limit is
+    the Rogers–Ramanujan series `∑_j q^{j²}/(q;q)_j`. The proof expands
+    `S_{n+2}` over `Finset.range (n+3)`, peels the bottom (`j = 0`) and top
+    (`j = n+2`, which vanishes) terms, then applies the unconditional second
+    q-Pascal identity `qBinom_pascal'_all` to each remaining term. The split
+    produces two sums: one is `S_{n+1}` (minus its peeled `j=0` term) and the
+    other, after the exponent identity `(i+1)² + (n-i) - i = i² + (n+1)` (valid
+    when the surviving q-binomial is nonzero), is `q^{n+1} · S_n`. -/
+theorem schurSum_recurrence (q : R) (n : ℕ) :
+    schurSum q (n + 2) = schurSum q (n + 1) + q ^ (n + 1) * schurSum q n := by
+  -- Expand the left-hand side and peel the j = 0 term.
+  rw [show schurSum q (n + 2) =
+        ∑ j ∈ Finset.range (n + 3), q ^ (j ^ 2) * qBinom q (n + 2 - j) j from rfl,
+      Finset.sum_range_succ']
+  -- Peel the top term j = n+2 (it is 0: [0 choose n+2]_q = 0).
+  rw [Finset.sum_range_succ]
+  have htop : q ^ ((n + 1 + 1) ^ 2) * qBinom q (n + 2 - (n + 1 + 1)) (n + 1 + 1) = 0 := by
+    rw [show n + 2 - (n + 1 + 1) = 0 from by omega, qBinom_zero_succ, mul_zero]
+  -- The peeled j = 0 term equals 1.
+  have hbot : q ^ ((0 : ℕ) ^ 2) * qBinom q (n + 2 - 0) 0 = 1 := by simp
+  rw [htop, hbot, add_zero]
+  -- Rewrite each surviving summand via the second q-Pascal identity.
+  have hcongr : ∀ i ∈ Finset.range (n + 1),
+      q ^ ((i + 1) ^ 2) * qBinom q (n + 2 - (i + 1)) (i + 1) =
+        q ^ ((i + 1) ^ 2) * qBinom q (n - i) (i + 1) +
+          q ^ (i ^ 2 + (n + 1)) * qBinom q (n - i) i := by
+    intro i hi
+    rw [Finset.mem_range] at hi
+    rw [show n + 2 - (i + 1) = (n - i) + 1 from by omega, qBinom_pascal'_all q (n - i) i]
+    rcases le_or_gt i (n - i) with hc | hc
+    · -- the q-binomial survives; the exponents match exactly
+      have hexp : (i + 1) ^ 2 + ((n - i) - i) = i ^ 2 + (n + 1) := by
+        have hsq : (i + 1) ^ 2 = i ^ 2 + 2 * i + 1 := by ring
+        omega
+      calc
+        q ^ ((i + 1) ^ 2) *
+            (q ^ ((n - i) - i) * qBinom q (n - i) i + qBinom q (n - i) (i + 1))
+            = q ^ ((i + 1) ^ 2 + ((n - i) - i)) * qBinom q (n - i) i +
+                q ^ ((i + 1) ^ 2) * qBinom q (n - i) (i + 1) := by rw [pow_add]; ring
+          _ = q ^ (i ^ 2 + (n + 1)) * qBinom q (n - i) i +
+                q ^ ((i + 1) ^ 2) * qBinom q (n - i) (i + 1) := by rw [hexp]
+          _ = q ^ ((i + 1) ^ 2) * qBinom q (n - i) (i + 1) +
+                q ^ (i ^ 2 + (n + 1)) * qBinom q (n - i) i := by ring
+    · -- the q-binomial [n-i choose i]_q vanishes; both extra terms are 0
+      rw [qBinom_eq_zero_of_lt q (n - i) i (by omega)]
+      ring
+  rw [Finset.sum_congr rfl hcongr, Finset.sum_add_distrib]
+  -- Identify the two resulting sums with S_{n+1} and q^{n+1} · S_n.
+  rw [schurSum_succ_peel]
+  have hB : q ^ (n + 1) * schurSum q n =
+      ∑ i ∈ Finset.range (n + 1), q ^ (i ^ 2 + (n + 1)) * qBinom q (n - i) i := by
+    rw [schurSum, Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [pow_add]; ring
+  rw [hB]; ring
+
+-- ============================================================
+-- Part IV: Specialization at q = 1 — Fibonacci numbers
+-- ============================================================
+
+/-- **Specialization at q = 1**: `S_n(1) = F_{n+1}` (the `(n+1)`-st Fibonacci
+    number). At `q = 1` the Schur recurrence `S_{n+2} = S_{n+1} + q^{n+1} S_n`
+    becomes the Fibonacci recurrence `S_{n+2} = S_{n+1} + S_n` with
+    `S_0 = S_1 = 1 = F_1 = F_2`. -/
+theorem schurSum_at_one_eq_fib : ∀ n : ℕ, schurSum (1 : ℤ) n = (Nat.fib (n + 1) : ℤ)
+  | 0 => by simp [Nat.fib_one]
+  | 1 => by simp [schurSum_one, Nat.fib_add_two]
+  | (n + 2) => by
+    rw [schurSum_recurrence, one_pow, one_mul,
+        schurSum_at_one_eq_fib (n + 1), schurSum_at_one_eq_fib n]
+    have h : Nat.fib (n + 2 + 1) = Nat.fib (n + 1) + Nat.fib (n + 1 + 1) :=
+      Nat.fib_add_two (n := n + 1)
+    rw [h]; push_cast; ring
+
+/-- **Classical diagonal-of-Pascal identity** `∑_{j} C(n-j, j) = F_{n+1}`,
+    recovered as the `q = 1` reading of the Schur sum. The diagonal sums of
+    Pascal's triangle are the Fibonacci numbers; here the identity falls out of
+    `schurSum_at_one_eq_fib` together with `qBinom (1) = C`. -/
+theorem sum_choose_eq_fib (n : ℕ) :
+    ∑ j ∈ Finset.range (n + 1), Nat.choose (n - j) j = Nat.fib (n + 1) := by
+  have h := schurSum_at_one_eq_fib n
+  rw [schurSum] at h
+  simp only [one_pow, one_mul, qBinom_at_one] at h
+  exact_mod_cast h
+
+-- ============================================================
+-- Part V: Concrete verifications
+-- ============================================================
+
+section Verifications
+variable (q : R)
+
+/-- `S_2(q) = 1 + q`. -/
+example : schurSum q 2 = 1 + q := by
+  simp [schurSum, Finset.sum_range_succ, qBinom]
+
+/-- `S_3(q) = 1 + q + q²`. -/
+example : schurSum q 3 = 1 + q + q ^ 2 := by
+  simp [schurSum, Finset.sum_range_succ, qBinom]; ring
+
+/-- `S_4(q) = 1 + q + q² + q³ + q⁴`. -/
+example : schurSum q 4 = 1 + q + q ^ 2 + q ^ 3 + q ^ 4 := by
+  simp [schurSum, Finset.sum_range_succ, qBinom]; ring
+
+/-- Fibonacci values: `S_5(1) = F_6 = 8`. -/
+example : schurSum (1 : ℤ) 5 = 8 := by
+  rw [schurSum_at_one_eq_fib]; decide
+
+end Verifications
+
+end RogersRamanujanSchur

--- a/research/problems/combinations-formula-oq-03-oq-03/knowledge.md
+++ b/research/problems/combinations-formula-oq-03-oq-03/knowledge.md
@@ -1,0 +1,49 @@
+# combinations-formula-oq-03-oq-03 — Rogers–Ramanujan via q-Gaussian binomials
+
+**Status:** completed (verified / 0-axiom / original)
+**PR:** (this session)
+**Lean file:** `proofs/Proofs/CombinationsFormulaOQ03OQ03.lean` (222 lines, 7 theorems, 1 def)
+
+## Open question (from parent combinations-formula-oq-03)
+"Can the Rogers–Ramanujan identities ∑ q^{n²}/(q;q)_n = ∏ 1/((1-q^{5n+1})(1-q^{5n+4}))
+be formalized in Lean 4 using this q-binomial library as a foundation?"
+
+## What was done
+The full *analytic* identity (formal power series / infinite products over ℤ[[q]]) is
+out of scope for one session. Instead formalized its **finite polynomial core**, which is
+the standard rigorous entry point (Schur 1917):
+
+- **Definition** `schurSum q n = ∑_{j∈range(n+1)} q^{j²} · qBinom q (n-j) j` over any CommRing.
+- **Main theorem** `schurSum_recurrence`: `S_{n+2} = S_{n+1} + q^{n+1}·S_n` (Schur's recurrence).
+- **Corollary** `schurSum_at_one_eq_fib`: `S_n(1) = Nat.fib (n+1)`.
+- **Corollary** `sum_choose_eq_fib`: `∑_j C(n-j,j) = fib(n+1)` (diagonal of Pascal = Fibonacci).
+- Helper `qBinom_pascal'_all`: hypothesis-free second q-Pascal identity.
+
+`#print axioms` → only propext / Classical.choice / Quot.sound. No sorryAx, no ofReduceBool.
+
+## Proof mechanism (for any follow-up)
+Everything reduces to the parent's **second q-Pascal identity**
+`[n+1 choose k+1]_q = q^{n-k}·[n choose k]_q + [n choose k+1]_q`:
+1. Upgrade it to the unconditional `qBinom_pascal'_all` (both sides vanish when a<k) so it
+   can be applied termwise inside a `Finset` sum without a side condition.
+2. Expand `S_{n+2}` over `range (n+3)`, peel j=0 (=1) via `sum_range_succ'` and j=n+2 (=0,
+   since `[0 choose n+2]_q=0`) via `sum_range_succ`.
+3. Apply the Pascal split to each term; `Finset.sum_add_distrib` separates two sums.
+4. One sum = `S_{n+1}` (via `schurSum_succ_peel`). The other = `q^{n+1}·S_n` via the exponent
+   identity `(i+1)² + (n-i) - i = i² + (n+1)`, which holds when `2i ≤ n`; in the complement
+   `[n-i choose i]_q = 0` so the term drops (case split `le_or_gt i (n-i)`).
+
+## Lean gotchas hit
+- Truncated ℕ subtraction: the exponent identity only holds in the active range; rely on the
+  q-binomial being 0 elsewhere rather than fighting `omega` over `(n-i)-i`.
+- `omega` can't prove `(i+1)²+...` directly (nonlinear); supply `have hsq : (i+1)^2 = i^2+2*i+1 := by ring`
+  first, then `omega` treats the squares as linked atoms.
+- `Nat.fib_add_two` rewrite is occurrence-ambiguous; instead state the exact equation with the
+  desired (defeq) argument form: `have h : fib (n+2+1) = fib (n+1) + fib (n+1+1) := Nat.fib_add_two (n := n+1)`.
+- `lake env lean -o .lake/build/lib/lean/Proofs/<File>.olean <File>.lean` is the working build
+  route when Docker is down (parent olean must be built to `lib/lean/Proofs/` first, NOT `lib/Proofs/`).
+
+## Natural follow-ups (not done)
+- Companion Schur sum `∑_j q^{j²+j} · [n-j choose j]_q` (second Rogers–Ramanujan polynomial),
+  same recurrence, base values shifted → second identity.
+- Formal ℤ[[q]] limit connecting `S_n` to the series side `∑ q^{j²}/(q;q)_j`.

--- a/src/data/proofs/combinations-formula-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "rr-context",
+    "proofId": "combinations-formula-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "concept",
+    "title": "The Rogers–Ramanujan Identities and Their Finite Core",
+    "content": "The Rogers–Ramanujan identities ∑_{n≥0} q^{n²}/(q;q)_n = ∏_{n≥0} 1/((1-q^{5n+1})(1-q^{5n+4})) are landmark q-series identities linking partition theory, modular forms, and statistical mechanics. The series side is an infinite object in ℤ[[q]] and is beyond a single Lean development. Schur's 1917 proof replaced it with a sequence of polynomials — the Schur (Rogers–Ramanujan) polynomials — that truncate the series and satisfy a simple two-term recurrence. This entry formalizes that finite core: the Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q and its recurrence. As n→∞ the polynomials converge termwise to the series side, so the recurrence is the elementary mechanism underlying the identity. This is the tractable, honest answer to the parent's open question."
+  },
+  {
+    "id": "pascal-all-note",
+    "proofId": "combinations-formula-oq-03-oq-03",
+    "range": { "startLine": 53, "endLine": 74 },
+    "type": "technique",
+    "title": "Hypothesis-Free Second q-Pascal Identity",
+    "content": "The parent proves the second q-Pascal identity [n+1 choose k+1]_q = q^{n-k}·[n choose k]_q + [n choose k+1]_q only under k+1 ≤ n+1. To apply it termwise inside a Finset sum (where the index runs past that bound) we remove the hypothesis: when a < k all three q-binomials vanish by qBinom_eq_zero_of_lt, and the identity degenerates to 0 = q^{a-k}·0 + 0. A single rcases on le_or_gt k a dispatches both branches. This unconditional form qBinom_pascal'_all is the workhorse of the whole file — it lets the recurrence proof rewrite every summand uniformly."
+  },
+  {
+    "id": "schur-sum-def",
+    "proofId": "combinations-formula-oq-03-oq-03",
+    "range": { "startLine": 75, "endLine": 102 },
+    "type": "definition",
+    "title": "The Schur Sum S_n(q)",
+    "content": "schurSum q n = ∑_{j ∈ range (n+1)} q^{j²}·[n-j choose j]_q is a polynomial in q over any commutative ring. The Gaussian binomial [n-j choose j]_q vanishes once j > n-j, so summing to n+1 captures every nonzero term (the truncated ℕ subtraction n-j makes the tail terms identically zero). The peeling lemma schurSum_succ_peel rewrites S_{n+1} as (its j≥1 reindexed tail) + 1, exposing exactly the shape produced when the q-Pascal split is applied to S_{n+2} — this is how one half of the recurrence is recognised."
+  },
+  {
+    "id": "recurrence-core",
+    "proofId": "combinations-formula-oq-03-oq-03",
+    "range": { "startLine": 105, "endLine": 165 },
+    "type": "key-insight",
+    "title": "Schur's Recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n",
+    "content": "The main theorem. Expand S_{n+2} over range (n+3); peel the bottom term (j=0, equal to 1) and the top term (j=n+2, equal to q^…·[0 choose n+2]_q = 0). Apply qBinom_pascal'_all to each surviving term [n+2-(i+1) choose i+1]_q = q^{(n-i)-i}·[n-i choose i]_q + [n-i choose i+1]_q. Summing, the [n-i choose i+1]_q terms reassemble (with the peeled 1) into S_{n+1}; the [n-i choose i]_q terms, weighted by q^{(i+1)²+(n-i)-i}, become q^{n+1}·S_n once the exponent identity (i+1)² + (n-i) - i = i² + (n+1) is applied. That identity holds exactly when 2i ≤ n; in the complementary range [n-i choose i]_q = 0 and the term drops out, so the case split le_or_gt i (n-i) closes both branches. This is the entire combinatorial content of the finite Rogers–Ramanujan identity, reduced to one q-Pascal application plus reindexing."
+  },
+  {
+    "id": "fibonacci-specialization",
+    "proofId": "combinations-formula-oq-03-oq-03",
+    "range": { "startLine": 168, "endLine": 195 },
+    "type": "key-insight",
+    "title": "q=1: Schur Polynomials Are q-Fibonacci Numbers",
+    "content": "At q=1 the weight q^{j²} becomes 1 and the recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n collapses to the Fibonacci recurrence S_{n+2} = S_{n+1} + S_n, with base cases S_0 = S_1 = 1 = F_1 = F_2. A two-step induction gives schurSum_at_one_eq_fib: S_n(1) = F_{n+1}. Composing with the parent's specialization [n choose k]_1 = C(n,k) yields sum_choose_eq_fib: ∑_j C(n-j,j) = F_{n+1}, the classical fact that the diagonal sums of Pascal's triangle are the Fibonacci numbers — recovered for free as the q=1 reading of the Schur sum. So the Schur polynomials are a one-parameter q-deformation of the Fibonacci sequence, and the Rogers–Ramanujan series is their analytic q-limit."
+  },
+  {
+    "id": "verification-values",
+    "proofId": "combinations-formula-oq-03-oq-03",
+    "range": { "startLine": 197, "endLine": 222 },
+    "type": "example",
+    "title": "Worked Schur Polynomials",
+    "content": "Concrete values confirm the recurrence: S_2 = 1+q, S_3 = 1+q+q², S_4 = 1+q+q²+q³+q⁴ (each over an arbitrary commutative ring), and S_5(1) = F_6 = 8. For instance S_4 = S_3 + q³·S_2 = (1+q+q²) + q³(1+q) = 1+q+q²+q³+q⁴, matching the recurrence directly."
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-03-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-03/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "combinations-formula-oq-03-oq-03",
+  "title": "Finite Rogers–Ramanujan (Schur) Identity via q-Gaussian Binomials",
+  "slug": "combinations-formula-oq-03-oq-03",
+  "description": "Formalizes the finite, polynomial heart of the Rogers–Ramanujan identities using the parent's q-Gaussian binomial library. Defines the Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q over an arbitrary commutative ring and proves Schur's (1917) recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n — the finite mechanism whose n→∞ limit is the Rogers–Ramanujan series ∑_j q^{j²}/(q;q)_j. Specializing at q=1 gives S_n(1) = F_{n+1} (Fibonacci) and recovers the classical diagonal-of-Pascal identity ∑_j C(n-j,j) = F_{n+1}. 7 theorems, 1 definition, 0 sorries, 0 axioms — verified over CommRing.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ03OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 222,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "assumptions": "None. The Schur sum and its recurrence are proved over an arbitrary commutative ring R with parameter q : R. No invertibility, characteristic, or positivity hypotheses. The q=1 corollaries are stated over ℤ. #print axioms reports only the foundational propext / Classical.choice / Quot.sound — no sorryAx, no Lean.ofReduceBool.",
+    "tags": [
+      "combinatorics",
+      "q-analogs",
+      "gaussian-binomial",
+      "rogers-ramanujan",
+      "partition-theory",
+      "fibonacci",
+      "number-theory",
+      "quantum-groups"
+    ],
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Division-free definition of the Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q over arbitrary CommRing, building on the parent's recurrence-defined q-binomials",
+      "Machine-checked proof of Schur's finite Rogers–Ramanujan recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n via the second q-Pascal identity and a finite reindexing — the polynomial mechanism underlying the analytic Rogers–Ramanujan identities",
+      "Unconditional form qBinom_pascal'_all of the parent's second q-Pascal identity (hypothesis-free, valid for all indices), enabling clean termwise application inside a Finset sum",
+      "q=1 specialization S_n(1) = F_{n+1}, identifying the Schur polynomials as a q-deformation of the Fibonacci sequence",
+      "Free recovery of the classical diagonal-of-Pascal identity ∑_j C(n-j,j) = F_{n+1} as the q=1 reading of the Schur sum"
+    ],
+    "prerequisites": [
+      "Gaussian (q-)binomial coefficients and the q-Pascal recurrences (parent entry)",
+      "Finite sums over Finset.range with reindexing (sum_range_succ, sum_range_succ')",
+      "Fibonacci numbers (Nat.fib) and the recurrence fib(n+2) = fib(n) + fib(n+1)",
+      "Natural-number arithmetic with truncated subtraction (omega)"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ03OQ03.lean",
+    "namespace": "RogersRamanujanSchur",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 222,
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Rogers–Ramanujan identities — discovered by L. J. Rogers (1894), rediscovered by Ramanujan (1913), and given their famous combinatorial reading by MacMahon and Schur — assert the analytic equalities ∑_{n≥0} q^{n²}/(q;q)_n = ∏_{n≥0} 1/((1-q^{5n+1})(1-q^{5n+4})) and its companion. They sit at the crossroads of partition theory, modular forms, statistical mechanics (Baxter's hard-hexagon model), and the representation theory of affine Lie algebras. Issai Schur's 1917 proof introduced a sequence of polynomials d_n(q) — what are now called the Rogers–Ramanujan or Schur polynomials — defined as truncations of the series side, and showed they satisfy a simple two-term recurrence. Taking n→∞ recovers the series; matching the recurrence against the product side proves the identity. The Schur polynomials are exactly the finite, rigorously elementary core of the identity, and they are a q-deformation of the Fibonacci numbers (Schur's recurrence collapses to the Fibonacci recurrence at q=1).",
+    "problemStatement": "The seeker's open question (parent combinations-formula-oq-03) asks whether the Rogers–Ramanujan identities can be formalized in Lean 4 using the q-Gaussian binomial library as a foundation. The fully analytic identity requires infinite products and convergence in ℤ[[q]] and is out of reach in a single development. This entry formalizes the finite polynomial heart instead: define the Schur sum S_n(q) = ∑_{j} q^{j²}·[n-j choose j]_q and prove the Schur recurrence S_{n+2}(q) = S_{n+1}(q) + q^{n+1}·S_n(q) with S_0 = S_1 = 1, over an arbitrary commutative ring, then read off its q=1 specializations.",
+    "proofStrategy": "The recurrence is proved by a finite reindexing argument driven entirely by the parent's second q-Pascal identity [n+1 choose k+1]_q = q^{n-k}·[n choose k]_q + [n choose k+1]_q. First the identity is upgraded to an unconditional form qBinom_pascal'_all (valid for all index pairs, since all three q-binomials vanish when the hypothesis fails), so it can be applied termwise inside a Finset sum without side conditions. The sum S_{n+2} is expanded over Finset.range (n+3); the bottom term (j=0) and top term (j=n+2, which is [0 choose n+2]_q = 0) are peeled off. Applying the second q-Pascal identity to each remaining term [n+2-(i+1) choose i+1]_q splits the sum into two pieces. One piece is precisely S_{n+1} (minus its own peeled j=0 term). The other, after the key exponent identity (i+1)² + (n-i) - i = i² + (n+1) — which holds exactly when the surviving q-binomial is nonzero, and is irrelevant otherwise since the term vanishes — equals q^{n+1}·S_n. The q=1 corollary follows by two-step induction: at q=1 the recurrence becomes the Fibonacci recurrence and the base cases S_0 = S_1 = 1 match F_1 = F_2 = 1.",
+    "keyInsights": [
+      "**The finite identity is the rigorous entry point**: The analytic Rogers–Ramanujan identity lives in ℤ[[q]] and needs convergence machinery, but its finite truncations — the Schur polynomials S_n(q) — are honest polynomials over any commutative ring, and they already encode the combinatorial content. Schur's recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n is the mechanism that, in the limit, produces the series side. Formalizing it is the natural Lean-tractable answer to 'can Rogers–Ramanujan be approached with this library?'.",
+      "**Everything reduces to the second q-Pascal identity**: The entire recurrence is a single application of [n+1 choose k+1]_q = q^{n-k}·[n choose k]_q + [n choose k+1]_q to each summand, followed by reindexing. No new q-binomial theory is needed beyond the parent — the Schur recurrence is 'q-Pascal, summed against the weight q^{j²}'.",
+      "**Hypothesis-free Pascal cleans up the sum**: The parent's second q-Pascal identity carries the hypothesis k+1 ≤ n+1. Inside a Finset sum the index ranges over values where this can fail, so the unconditional version qBinom_pascal'_all (both sides vanish when n < k) is what makes the termwise rewrite go through without threading a proof obligation through every summand.",
+      "**Truncated subtraction is harmless where it bites**: The exponent bookkeeping uses ℕ subtraction, and the identity (i+1)² + (n-i) - i = i² + (n+1) only holds when 2i ≤ n. Exactly in the complementary range the surviving q-binomial [n-i choose i]_q is zero, so the term drops out and the exponent discrepancy never matters — a case split (le_or_gt i (n-i)) handles both branches cleanly.",
+      "**Schur polynomials are q-Fibonacci numbers**: At q=1 the recurrence is the Fibonacci recurrence and S_n(1) = F_{n+1}. Thus the Schur sum is a one-parameter polynomial deformation of the Fibonacci sequence, and the Rogers–Ramanujan series is its q-analytic limit. This also yields, for free, the classical fact that the diagonal sums of Pascal's triangle ∑_j C(n-j,j) are the Fibonacci numbers."
+    ],
+    "prerequisites": [
+      "Gaussian (q-)binomial coefficients and the two q-Pascal recurrences (parent entry combinations-formula-oq-03)",
+      "Finset.range sums and reindexing lemmas (sum_range_succ, sum_range_succ', sum_add_distrib, mul_sum)",
+      "Fibonacci numbers Nat.fib and fib_add_two",
+      "Commutative ring arithmetic and the ring / omega tactics"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Module docstring stating OQ-03-OQ-03: can the Rogers–Ramanujan identities be formalized on top of the q-Gaussian binomial library? Explains that the analytic identity is out of scope but its finite polynomial core — the Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q and Schur's recurrence — is tractable, and previews the q=1 Fibonacci specializations."
+    },
+    {
+      "id": "pascal-all",
+      "title": "Part I — Unconditional Second q-Pascal Identity",
+      "startLine": 53,
+      "endLine": 74,
+      "summary": "qBinom_pascal'_all: the parent's second q-Pascal identity [a+1 choose k+1]_q = q^{a-k}·[a choose k]_q + [a choose k+1]_q, freed of its k+1 ≤ a+1 hypothesis. When a < k all three q-binomials vanish, so the identity degenerates to 0 = q^{a-k}·0 + 0. This unconditional form is what lets the identity be applied termwise inside a Finset sum."
+    },
+    {
+      "id": "schur-sum",
+      "title": "Part II — The Schur Sum",
+      "startLine": 75,
+      "endLine": 102,
+      "summary": "Defines schurSum q n = ∑_{j ∈ range (n+1)} q^{j²}·[n-j choose j]_q (the summand vanishes once j > n-j, so the range is a safe upper bound). Establishes the base values S_0 = S_1 = 1 and a peeling lemma schurSum_succ_peel that rewrites S_{n+1} as its j≥1 tail plus the j=0 term, used to recognise one half of the q-Pascal split."
+    },
+    {
+      "id": "schur-recurrence",
+      "title": "Part III — The Finite Rogers–Ramanujan (Schur) Recurrence",
+      "startLine": 105,
+      "endLine": 165,
+      "summary": "schurSum_recurrence: S_{n+2}(q) = S_{n+1}(q) + q^{n+1}·S_n(q). Expands S_{n+2} over range (n+3), peels the j=0 and j=n+2 (vanishing) terms, applies qBinom_pascal'_all to each remaining term, and splits the result into S_{n+1} and q^{n+1}·S_n. The exponent identity (i+1)² + (n-i) - i = i² + (n+1) (valid where the surviving q-binomial is nonzero) closes the second piece. This is Schur's 1917 recurrence — the finite mechanism behind the Rogers–Ramanujan identities."
+    },
+    {
+      "id": "q-one-fibonacci",
+      "title": "Part IV — Specialization at q = 1: Fibonacci Numbers",
+      "startLine": 168,
+      "endLine": 195,
+      "summary": "schurSum_at_one_eq_fib: S_n(1) = F_{n+1}, by two-step induction using the recurrence (which becomes the Fibonacci recurrence at q=1) and base cases S_0 = S_1 = 1 = F_1 = F_2. sum_choose_eq_fib then recovers the classical diagonal-of-Pascal identity ∑_j C(n-j,j) = F_{n+1} as the q=1 reading of the Schur sum."
+    },
+    {
+      "id": "verifications",
+      "title": "Part V — Concrete Verifications",
+      "startLine": 197,
+      "endLine": 222,
+      "summary": "Worked polynomial values S_2 = 1+q, S_3 = 1+q+q², S_4 = 1+q+q²+q³+q⁴ over an arbitrary ring, and the Fibonacci value S_5(1) = F_6 = 8."
+    }
+  ],
+  "conclusion": {
+    "summary": "7 theorems, 1 definition, 0 sorries, 0 axioms. The Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q and the recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n formalize the finite, polynomial heart of the Rogers–Ramanujan identities over an arbitrary commutative ring, built entirely on the parent's q-Gaussian binomial library via the second q-Pascal identity.",
+    "implications": "This answers the parent open question in the tractable direction: while the analytic Rogers–Ramanujan identity needs ℤ[[q]] and infinite products, its finite core — Schur's polynomials and recurrence — is fully machine-checkable on top of the existing q-binomial development. The q=1 specialization exhibits the Schur polynomials as a q-deformation of the Fibonacci sequence and recovers the diagonal-of-Pascal Fibonacci identity for free. Natural follow-ups: the companion Schur sum ∑_j q^{j²+j}·[n-j choose j]_q (second Rogers–Ramanujan polynomial), and a formal ℤ[[q]] limit connecting these polynomials to the series side."
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-03",
+      "relationship": "parent — provides qNumber, qFactorial, qBinom and the two q-Pascal recurrences used throughout"
+    },
+    {
+      "targetId": "combinations-formula-oq-03-oq-06",
+      "relationship": "sibling — another OQ-03 child building quantum-group structure on the same q-number library"
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/research/problems/combinations-formula-oq-03-oq-03.json
+++ b/src/data/research/problems/combinations-formula-oq-03-oq-03.json
@@ -1,0 +1,71 @@
+{
+  "slug": "combinations-formula-oq-03-oq-03",
+  "title": "Rogers-Ramanujan identities via q-Gaussian binomial coefficients",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "S_n(q) = \\sum_{j} q^{j^2} \\binom{n-j}{j}_q \\implies S_{n+2}(q) = S_{n+1}(q) + q^{n+1} S_n(q)",
+    "plain": "Can the Rogers-Ramanujan identities be formalized in Lean 4 using the q-Gaussian binomial library as a foundation? Formalized the finite polynomial core (Schur 1917): the Schur sum and its two-term recurrence, with q=1 Fibonacci specializations.",
+    "whyMatters": [
+      "Rogers-Ramanujan is a landmark of partition theory, modular forms, and statistical mechanics",
+      "The finite Schur polynomials are the rigorous, machine-checkable heart of the identity",
+      "Demonstrates the q-binomial library suffices for serious q-series combinatorics"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "schurSum_recurrence: S_{n+2} = S_{n+1} + q^{n+1} S_n (over arbitrary CommRing)",
+      "schurSum_at_one_eq_fib: S_n(1) = Fibonacci(n+1)",
+      "sum_choose_eq_fib: sum of C(n-j,j) = Fibonacci(n+1)"
+    ],
+    "open": [
+      "Full analytic Rogers-Ramanujan identity (infinite product over Z[[q]])",
+      "Second Rogers-Ramanujan polynomial sum_j q^{j^2+j} [n-j choose j]_q"
+    ],
+    "goal": "Formalize the finite Rogers-Ramanujan / Schur recurrence on top of the q-binomial library."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Finite Rogers-Ramanujan (Schur) recurrence formalized and verified.",
+    "blockers": [],
+    "nextAction": "Done; optional follow-up on the second RR polynomial.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED 2026-06-25: 7 theorems, 1 def, 0 sorries, 0 axioms (verified/original). PR #29963. Formalized Schur's recurrence S_{n+2}=S_{n+1}+q^{n+1} S_n for S_n(q)=sum_j q^{j^2}[n-j choose j]_q, the finite core of Rogers-Ramanujan; q=1 gives Fibonacci. Built via lake env lean v4.26.0.",
+    "builtItems": [
+      "schurSum: the Schur sum definition over CommRing (CombinationsFormulaOQ03OQ03.lean)",
+      "schurSum_recurrence: Schur's finite Rogers-Ramanujan recurrence",
+      "schurSum_at_one_eq_fib + sum_choose_eq_fib: q=1 Fibonacci specializations",
+      "qBinom_pascal'_all: hypothesis-free second q-Pascal identity"
+    ],
+    "insights": [
+      "The entire recurrence is one application of the second q-Pascal identity summed against the weight q^{j^2}, plus reindexing",
+      "Truncated N-subtraction in the exponent identity (i+1)^2+(n-i)-i=i^2+(n+1) is harmless because the surviving q-binomial vanishes exactly where the identity fails",
+      "Schur polynomials are a q-deformation of the Fibonacci sequence; the RR series is their q-analytic limit"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Companion sum_j q^{j^2+j} [n-j choose j]_q for the second Rogers-Ramanujan identity",
+      "Formal Z[[q]] limit connecting S_n to the series side sum_j q^{j^2}/(q;q)_j"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "gallery-extracted",
+    "q-analogs",
+    "rogers-ramanujan"
+  ],
+  "relatedProofs": [
+    "combinations-formula-oq-03",
+    "combinations-formula-oq-03-oq-06"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question on parent **combinations-formula-oq-03** (q-Gaussian binomial coefficients): *"Can the Rogers–Ramanujan identities be formalized in Lean 4 using this library as a foundation?"*

The fully **analytic** Rogers–Ramanujan identity ∑ q^{n²}/(q;q)_n = ∏ 1/((1−q^{5n+1})(1−q^{5n+4})) lives in ℤ[[q]] and needs infinite products — out of scope for one session. This entry formalizes its **finite polynomial core**, the standard rigorous entry point (Schur 1917): the **Schur sum**

S_n(q) = ∑_j q^{j²} · [n−j choose j]_q   (over an arbitrary CommRing)

and proves **Schur's recurrence**

**S_{n+2}(q) = S_{n+1}(q) + q^{n+1} · S_n(q)**,  S_0 = S_1 = 1.

This is exactly the finite mechanism whose n→∞ limit is the Rogers–Ramanujan series side.

## Results (`proofs/Proofs/CombinationsFormulaOQ03OQ03.lean`)

| Theorem | Statement |
|---|---|
| `schurSum_recurrence` | S_{n+2} = S_{n+1} + q^{n+1}·S_n |
| `schurSum_at_one_eq_fib` | S_n(1) = F_{n+1}  (Schur polynomials are q-Fibonacci numbers) |
| `sum_choose_eq_fib` | ∑_j C(n−j,j) = F_{n+1}  (diagonal-of-Pascal = Fibonacci, recovered free) |
| `qBinom_pascal'_all` | hypothesis-free second q-Pascal identity (the engine) |

Plus `schurSum` (def), base cases, the peeling lemma `schurSum_succ_peel`, and worked values S_2..S_4, S_5(1)=8.

## Proof mechanism

Everything reduces to the parent's **second q-Pascal identity** `[n+1 choose k+1]_q = q^{n−k}·[n choose k]_q + [n choose k+1]_q`, made hypothesis-free, applied termwise to S_{n+2} over `range (n+3)` (peeling the j=0 and the vanishing j=n+2 terms), then split via `Finset.sum_add_distrib` into S_{n+1} and q^{n+1}·S_n. The exponent identity `(i+1)² + (n−i) − i = i² + (n+1)` (valid where the surviving q-binomial is nonzero) closes the second piece.

## Verification

- **7 theorems, 1 definition, 0 sorries, 0 axioms.**
- `#print axioms` on all main results → only `propext` / `Classical.choice` / `Quot.sound`. **No `sorryAx`, no `Lean.ofReduceBool`.**
- Elaborated with elan lean **v4.26.0** on top of `CombinationsFormulaOQ03` (Docker was unavailable this session; built via single-file `lake env lean`, which is the safe non-`lake build` route).
- Status: **verified** / badge **original**.

## Status
**Outcome**: completed
**Next steps**: companion Schur sum ∑_j q^{j²+j}·[n−j choose j]_q (second RR polynomial); a formal ℤ[[q]] limit linking S_n to the series side.

🤖 Generated by researcher-4