### PR TITLE
Enrich Gauss–Wantzel arithmetic core (angle-trisection oq-02³): index.ts + overview + annotation schema fix

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/annotations.json
@@ -6,42 +6,57 @@
     "type": "concept",
     "title": "Isolating the assumption-free core of Gauss–Wantzel",
     "content": "Gauss–Wantzel has two halves: a GEOMETRIC equivalence (a regular n-gon is constructible ⇔ φ(n) is a power of two), and an ARITHMETIC characterization (φ(n) is a power of two ⇔ n = 2^a · product of distinct Fermat primes). The parent entry axiomatizes the geometric equivalence and verifies individual polygons by native_decide; a sibling enumerates the arithmetic condition only for n ≤ 50. This file proves the arithmetic characterization in full generality, for arbitrary n, with 0 axioms and no native_decide. It is the part of Gauss–Wantzel that requires no geometry and no unproven assumptions.",
-    "mathContext": "$\\varphi(n) = 2^k \\iff$ the odd part of $n$ is a squarefree product of Fermat primes."
+    "mathContext": "$\\varphi(n) = 2^k \\iff$ the odd part of $n$ is a squarefree product of Fermat primes.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient function", "Fermat primes", "constructible polygons", "Gauss–Wantzel theorem"],
+    "prerequisites": ["elementary number theory", "the totient function φ"]
   },
   {
     "id": "ann-oq02oq02oq02-toolbox",
     "proofId": "angle-trisection-oq-02-oq-02-oq-02",
     "range": { "startLine": 39, "endLine": 63 },
-    "type": "technique",
+    "type": "lemma",
     "title": "Powers of two: closed under products, downward-closed under division, odd only at 1",
     "content": "Three small lemmas drive everything. IsPow2.mul (2^i · 2^j = 2^(i+j)) gives the sufficiency direction once each factor is a power of two. isPow2_of_dvd_pow2 uses Nat.dvd_prime_pow: any divisor of 2^k is 2^j for some j ≤ k — this is how 'p^(e-1)·(p-1) divides φ(n) = 2^k' is turned into structural information. eq_one_of_odd_isPow2 is proved by parity (m % 2 = 0 from evenness of 2^k with k ≥ 1 contradicts m % 2 = 1 from oddness), avoiding the renamed Nat.odd_iff_not_even.",
-    "mathContext": "A divisor of $2^k$ is a $2^j$; the only odd power of two is $2^0 = 1$."
+    "mathContext": "A divisor of $2^k$ is a $2^j$; the only odd power of two is $2^0 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility of prime powers", "Nat.dvd_prime_pow", "parity"],
+    "prerequisites": ["prime factorization", "divisibility"]
   },
   {
     "id": "ann-oq02oq02oq02-necessity",
     "proofId": "angle-trisection-oq-02-oq-02-oq-02",
     "range": { "startLine": 65, "endLine": 129 },
-    "type": "key-step",
+    "type": "theorem",
     "title": "Wantzel necessity: every odd prime factor is a squarefree Fermat prime",
     "content": "For an odd prime p ∣ n with multiplicity e = v_p(n) ≥ 1, the prime-power part p^e divides n, so by Nat.totient_dvd_of_dvd and Nat.totient_prime_pow we get φ(p^e) = p^(e-1)·(p-1) ∣ φ(n) = 2^k. Splitting the product: p^(e-1) ∣ 2^k forces e = 1 (an odd prime power dividing 2^k must be p^0, else p ∣ 2), giving squarefreeness; and (p-1) ∣ 2^k forces p = 2^m + 1. Feeding p = 2^m + 1 (prime) into Mathlib's Nat.pow_of_pow_add_prime upgrades this to the genuine Fermat form p = 2^(2^j) + 1 in odd_prime_factor_is_fermat.",
-    "mathContext": "$p^{e-1}(p-1)\\mid 2^k \\Rightarrow e = 1$ and $p - 1 = 2^m$; primality of $2^m+1 \\Rightarrow m = 2^j$."
+    "mathContext": "$p^{e-1}(p-1)\\mid 2^k \\Rightarrow e = 1$ and $p - 1 = 2^m$; primality of $2^m+1 \\Rightarrow m = 2^j$.",
+    "significance": "critical",
+    "relatedConcepts": ["Wantzel's theorem", "Fermat primes", "squarefree integers", "totient of a prime power", "Nat.pow_of_pow_add_prime"],
+    "prerequisites": ["multiplicativity of φ", "p-adic valuation v_p(n)", "Fermat primes 2^(2^j)+1"]
   },
   {
     "id": "ann-oq02oq02oq02-sufficiency",
     "proofId": "angle-trisection-oq-02-oq-02-oq-02",
     "range": { "startLine": 131, "endLine": 179 },
-    "type": "key-step",
+    "type": "theorem",
     "title": "Gauss sufficiency by induction over a finset of distinct Fermat primes",
     "content": "totient_pow2_of_oddFermat_prod proceeds by Finset.induction. At each insertion of a prime a ∉ s, distinctness makes a coprime to every prime already in s (Nat.coprime_primes), hence coprime to their product (Nat.Coprime.prod_right), so Nat.totient_mul splits φ(a · ∏) = φ(a)·φ(∏); φ(a) = a − 1 is a power of two by hypothesis and φ(∏) is one by induction. totient_pow2_two_pow_mul prepends a 2^a factor, coprime to the odd product, with φ(2^a) a power of two (φ(2^a) = 2^(a-1)).",
-    "mathContext": "Distinct primes are coprime, so $\\varphi$ multiplies across $2^a\\prod p$; each factor is a power of two."
+    "mathContext": "Distinct primes are coprime, so $\\varphi$ multiplies across $2^a\\prod p$; each factor is a power of two.",
+    "significance": "critical",
+    "relatedConcepts": ["multiplicativity of the totient", "coprimality of distinct primes", "Finset.induction", "Gauss's constructibility theorem"],
+    "prerequisites": ["Nat.totient_mul (coprime multiplicativity)", "induction over finsets", "coprimality"]
   },
   {
     "id": "ann-oq02oq02oq02-instances",
     "proofId": "angle-trisection-oq-02-oq-02-oq-02",
     "range": { "startLine": 181, "endLine": 246 },
-    "type": "observation",
+    "type": "insight",
     "title": "Polygon constructibility as corollaries of the general theorems",
     "content": "Rather than recomputing φ, the constructibility of the 15-gon (15 = 3·5) and 240-gon (240 = 2^4·3·5) is obtained by instantiating totient_pow2_of_oddFermat_prod and totient_pow2_two_pow_mul on the finset {3, 5}, with the Fermat-prime hypotheses fermat_data_three and fermat_data_five. Non-constructibility of the 7-gon follows from necessity: 7 is an odd prime factor of itself that is not of the form 2^m + 1 (that would need 2^m = 6). The single-prime equivalence totient_prime_pow2_iff packages both directions for prime n.",
-    "mathContext": "$\\varphi(15), \\varphi(240)$ are powers of two; $\\varphi(7) = 6$ is not."
+    "mathContext": "$\\varphi(15), \\varphi(240)$ are powers of two; $\\varphi(7) = 6$ is not.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructible 15-gon", "constructible 17-gon (Gauss)", "regular heptagon non-constructibility", "corollaries of a general theorem"],
+    "prerequisites": ["the general theorems above", "small explicit totient computations"]
   }
 ]

--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ02OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const angleTrisectionOq02Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionOq02Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionOq02Oq02Oq02Data: ProofData = {
+  proof: angleTrisectionOq02Oq02Oq02Proof,
+  annotations: angleTrisectionOq02Oq02Oq02Annotations,
+}

--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
@@ -100,6 +100,23 @@
       "significance": "Clean two-way statement for the prime case."
     }
   ],
+  "overview": {
+    "historicalContext": "Carl Friedrich Gauss showed in 1796 (aged 19) that the regular 17-gon is constructible with compass and straightedge, and stated in Disquisitiones Arithmeticae (1801) that a regular n-gon is constructible iff n is a power of two times a product of distinct Fermat primes. Pierre Wantzel supplied the necessity direction in 1837, the same paper that proved the impossibility of trisecting a general angle and doubling the cube. The arithmetic heart of the theorem is the totient condition: φ(n) is a power of two exactly when the odd part of n is a squarefree product of Fermat primes 2^(2^j)+1. Only five Fermat primes are known (3, 5, 17, 257, 65537), and whether there are infinitely many remains open — Fermat himself wrongly conjectured every 2^(2^j)+1 is prime, refuted by Euler's factorization of 2^32+1.",
+    "problemStatement": "Characterize, for arbitrary n, when Euler's totient φ(n) is a power of two — the number-theoretic condition equivalent to constructibility of the regular n-gon. Prove both directions in full generality (not by case enumeration) with no axioms, and recover specific polygon (non-)constructibility as corollaries.",
+    "proofStrategy": "Necessity (totient_pow2_structure): for each odd prime p ∣ n with multiplicity e, φ(p^e) = p^(e-1)(p-1) divides φ(n) = 2^k; the odd factor p^(e-1) forces e=1 (squarefree), and (p-1) ∣ 2^k forces p = 2^m+1, then Mathlib's Nat.pow_of_pow_add_prime upgrades this to the Fermat form p = 2^(2^j)+1. Sufficiency (totient_pow2_two_pow_mul): Finset.induction over distinct odd Fermat-form primes, using coprimality of distinct primes and multiplicativity of φ, prepended with a 2^a factor. Specific polygons (15, 240, 7) drop out by instantiating the general theorems.",
+    "keyInsights": [
+      "The constructibility question reduces entirely to a statement about the totient φ(n) being a power of two — no geometry is needed once that reduction is made.",
+      "Necessity hinges on splitting φ(p^e) = p^(e-1)(p-1): the odd part p^(e-1) dividing 2^k forces squarefreeness, and the even part (p-1) dividing 2^k forces the Fermat shape.",
+      "Sufficiency is a clean induction over a finset of distinct primes, where distinctness gives coprimality for free and multiplicativity of φ does the rest.",
+      "Proving the characterization for general n (rather than enumerating n ≤ 50) means specific polygons like the 15-gon and 240-gon become one-line corollaries instead of separate computations.",
+      "Isolating the arithmetic core cleanly separates the 0-axiom number theory from the geometric equivalence that the parent entry must axiomatize."
+    ],
+    "prerequisites": [
+      "Euler's totient function and its multiplicativity over coprime arguments.",
+      "Fermat primes 2^(2^j)+1 and the fact that 2^m+1 prime forces m a power of two.",
+      "p-adic valuation and squarefreeness via prime-power multiplicity."
+    ]
+  },
   "sections": [
     {
       "id": "ispow2-toolbox",


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-02-oq-02` (quality 58, 0 prior passes).

## What changed
- **Added missing `index.ts`** — without it the proof renders 'proof not found' on the live site (highest-impact gap; meta/annotations were already rich).
- **Added `overview` block** — meta.json had `mainTheorems` but no overview. Added `historicalContext` (Gauss 1796 / Disquisitiones / Wantzel 1837 / 5 known Fermat primes), `problemStatement`, `proofStrategy`, 5 `keyInsights`, and `prerequisites`.
- **Fixed annotation schema** — the existing annotations used `type` values outside the `AnnotationType` union (`technique`, `key-step`, `observation`) and were missing the required `significance` field. Remapped to valid types (`lemma`/`theorem`/`insight`) and added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations.

## Integrity
No mathematical claims altered. meta keeps `status: verified`, `badge: original`, `axiomCount: 0` — consistent with the Lean file (16 theorems, 1 def, 0 sorries, 0 axioms; kernel `decide` only for the finite 15=3·5 / 240=2⁴·3·5 instances, no native_decide).

JSON validated; `pnpm build` skipped (no node_modules in worktree).