### PR TITLE
research(birthday-sharp-k3): pin triple-coincidence threshold to (6d²ln2)^(1/3)+1+o(1) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -460,6 +460,7 @@ import Proofs.BirthdayProblemOQ03
 import Proofs.BirthdayProblemOQ03OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01OQ03
+import Proofs.BirthdayProblemOQ03OQ01OQ01OQ03OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01OQ03OQ03
 import Proofs.BirthdayProblemOQ03OQ01OQ01OQ05
 import Proofs.BirthdayProblemOQ03OQ01OQ02

--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean
@@ -1,0 +1,162 @@
+import Mathlib
+
+/-
+# Birthday Problem — OQ-03-OQ-01-OQ-01-OQ-03-OQ-01: The Sharp k = 3 Threshold Constant
+
+## Research Problem: birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01
+
+The parent (`birthday-problem-oq-03-oq-01-oq-01-oq-03`) proves the leading-order *triple*
+coincidence threshold: the `n ≥ 2` solving the expected-triple balance
+
+      n(n-1)(n-2) = 6 d² ln 2
+
+satisfies `(6 d² ln 2)^{1/3} ≤ n ≤ (6 d² ln 2)^{1/3} + 2`, i.e. `n = (6 d² ln 2)^{1/3} + O(1)`
+with the additive error only bounded by the constant `2`.  The sibling general-`k` file
+recovers the same loose `± (k-1) = ± 2` window for `k = 3`.
+
+**This file sharpens the `k = 3` case: it pins the lower-order term to *exactly* `1`, with a
+remainder that *provably vanishes* as `d → ∞`.**  Writing `c := (6 d² ln 2)^{1/3}`,
+
+      c + 1  ≤  n  ≤  c + 1 + 1/(3 c).
+
+Hence `n = (6 d² ln 2)^{1/3} + 1 + θ` with `0 ≤ θ ≤ 1/(3 c) = O(d^{-2/3}) → 0`.  So the true
+threshold is `(6 d² ln 2)^{1/3} + 1 + o(1)`, a strict refinement of the parent's `± 2` band.
+
+## The sharpening idea — a *centered* cube instead of a corner cube
+
+The parent sandwiches the falling factorial between the corner cubes `(n-2)³` and `n³`, which
+are a distance `2` apart, so the cube-root sandwich can only pin `n` to within `2`.  The key
+new observation is the exact *centered* factorisation
+
+      n(n-1)(n-2) = (n-1)³ - (n-1).
+
+Setting `m := n - 1`, the balance equation becomes the depressed cubic `m³ - m = c³` (where
+`c³ = 6 d² ln 2`).  Then:
+
+* **Lower bound.**  `m³ = c³ + m ≥ c³` (as `m ≥ 0`), so `m ≥ c`, i.e. `n ≥ c + 1`.
+* **Upper bound.**  With `a := c + 1/(3c)` one computes the clean identity
+  `a³ - a = c³ + 1/(27 c³) ≥ c³ = m³ - m`.  Equivalently, multiplying the target
+  `3 c (m - c) ≤ 1` by `m² + mc + c² > 0` and using `m³ - c³ = m` collapses it to
+  `(m - c)² ≥ 0`.  Hence `m ≤ c + 1/(3c)`, i.e. `n ≤ c + 1 + 1/(3c)`.
+
+The whole improvement is bought by replacing the corner cube `n³` with the centered cube
+`(n-1)³`: the centered cube touches the falling factorial to within the bounded correction
+`(n-1)`, which is exactly what upgrades the `O(1)` error to `1 + o(1)`.  (This trick is special
+to `k = 3`; for general `k` the centered monomial `(n - (k-1)/2)^k` no longer divides the
+falling factorial exactly, which is why the general-`k` file keeps the loose `± (k-1)` band.)
+
+## What is proved
+
+* `cubeRoot_cube` — `(x³)^{1/3} = x` for `x ≥ 0` (same helper as the parent).
+* `birthday_triple_threshold_sharp` — the two-sided bound `c + 1 ≤ n ≤ c + 1 + 1/(3c)`.
+* `birthday_triple_threshold_const_one` — packaged as `|n - (c + 1)| ≤ 1/(3c)`, exhibiting the
+  exact constant term `1` and the `d`-dependent (vanishing) remainder.
+
+Tags: probability, birthday-problem, asymptotics, sharp-threshold, depressed-cubic, cube-root
+-/
+
+namespace BirthdayProblemOQ03OQ01OQ01OQ03OQ01
+
+open Real
+
+/-- **Cube-root identity.**  `(x³)^{1/3} = x` for `x ≥ 0`. -/
+theorem cubeRoot_cube {x : ℝ} (hx : 0 ≤ x) : (x ^ 3) ^ ((1 : ℝ) / 3) = x := by
+  rw [show (1 : ℝ) / 3 = ((3 : ℕ) : ℝ)⁻¹ by norm_num]
+  exact Real.pow_rpow_inv_natCast hx (by norm_num)
+
+/-- **The sharp k = 3 coincidence threshold.**
+
+    If `n ≥ 2` solves the expected-triple balance `n(n-1)(n-2) = 6 d² ln 2`, then, writing
+    `c := (6 d² ln 2)^{1/3}`,
+
+        c + 1 ≤ n ≤ c + 1 + 1/(3 c).
+
+    So the lower-order term is *exactly* `1` up to a remainder `≤ 1/(3c) = O(d^{-2/3})` that
+    vanishes as `d → ∞` — a strict refinement of the parent's `c ≤ n ≤ c + 2` band. -/
+theorem birthday_triple_threshold_sharp (d n : ℝ) (hd : 0 < d) (hn : 2 ≤ n)
+    (hbal : n * (n - 1) * (n - 2) = 6 * d ^ 2 * Real.log 2) :
+    (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3) + 1 ≤ n ∧
+    n ≤ (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3) + 1
+        + 1 / (3 * (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3)) := by
+  set L := 6 * d ^ 2 * Real.log 2 with hLdef
+  have hlog : 0 < Real.log 2 := Real.log_pos (by norm_num)
+  have hL : 0 < L := by rw [hLdef]; positivity
+  set c := L ^ ((1 : ℝ) / 3) with hc
+  have hcpos : 0 < c := by rw [hc]; exact Real.rpow_pos_of_pos hL _
+  have hcnn : 0 ≤ c := le_of_lt hcpos
+  set m := n - 1 with hm_def
+  have hm1 : 1 ≤ m := by rw [hm_def]; linarith
+  have hmnn : 0 ≤ m := by linarith
+  -- Centered form of the balance equation: m³ - m = L (= c³).
+  have hrel0 : m ^ 3 - m = L := by rw [← hbal, hm_def]; ring
+  -- c³ = L.
+  have hc3 : c ^ 3 = L := by
+    rw [hc, ← Real.rpow_natCast (L ^ ((1 : ℝ) / 3)) 3, ← Real.rpow_mul (le_of_lt hL),
+        show (1 : ℝ) / 3 * ((3 : ℕ) : ℝ) = 1 by norm_num, Real.rpow_one]
+  have hrel : m ^ 3 - m = c ^ 3 := by rw [hc3]; exact hrel0
+  have hpos : 0 < m ^ 2 + m * c + c ^ 2 := by positivity
+  refine ⟨?_, ?_⟩
+  · -- Lower bound: c ≤ m, hence c + 1 ≤ n.
+    have hLm : L ≤ m ^ 3 := by linarith [hrel0, hmnn]
+    have hcm : c ≤ m := by
+      have h := Real.rpow_le_rpow (le_of_lt hL) hLm (by norm_num : (0 : ℝ) ≤ (1 : ℝ) / 3)
+      rwa [← hc, cubeRoot_cube hmnn] at h
+    rw [hm_def] at hcm; linarith
+  · -- Upper bound: 3 c (m - c) ≤ 1, hence m ≤ c + 1/(3c), hence n ≤ c + 1 + 1/(3c).
+    have hident : (m ^ 2 + m * c + c ^ 2) * (1 - 3 * c * (m - c)) = (m - c) ^ 2 := by
+      linear_combination (-3 * c) * hrel
+    have hub : 3 * c * (m - c) ≤ 1 := by
+      nlinarith [hident, hpos, sq_nonneg (m - c)]
+    have h3c : (0 : ℝ) < 3 * c := by positivity
+    rw [← sub_nonneg]
+    have expand : c + 1 + 1 / (3 * c) - n = (1 - 3 * c * (m - c)) / (3 * c) := by
+      rw [hm_def]; field_simp [hcpos.ne']; ring
+    rw [expand]
+    exact div_nonneg (by linarith [hub]) (le_of_lt h3c)
+
+/-- **The exact lower-order constant.**  The balance-equation solution `n` sits a distance
+    *exactly* `1` above the leading term `(6 d² ln 2)^{1/3}`, up to a one-sided remainder that
+    is at most `1/(3 c) = O(d^{-2/3})` and therefore vanishes as `d → ∞`:
+
+        |n - ((6 d² ln 2)^{1/3} + 1)| ≤ 1 / (3 (6 d² ln 2)^{1/3}).
+
+    This is the precise asymptotic `n = (6 d² ln 2)^{1/3} + 1 + o(1)`. -/
+theorem birthday_triple_threshold_const_one (d n : ℝ) (hd : 0 < d) (hn : 2 ≤ n)
+    (hbal : n * (n - 1) * (n - 2) = 6 * d ^ 2 * Real.log 2) :
+    |n - ((6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3) + 1)| ≤
+      1 / (3 * (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3)) := by
+  obtain ⟨hlo, hhi⟩ := birthday_triple_threshold_sharp d n hd hn hbal
+  have hL : 0 < 6 * d ^ 2 * Real.log 2 := by
+    have : 0 < Real.log 2 := Real.log_pos (by norm_num)
+    positivity
+  have hcpos : 0 < (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3) := Real.rpow_pos_of_pos hL _
+  have hinv : 0 ≤ 1 / (3 * (6 * d ^ 2 * Real.log 2) ^ ((1 : ℝ) / 3)) := by positivity
+  rw [abs_le]
+  constructor <;> linarith
+
+#check @cubeRoot_cube
+#check @birthday_triple_threshold_sharp
+#check @birthday_triple_threshold_const_one
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms — self-contained, imports only Mathlib):
+
+* `cubeRoot_cube` — `(x³)^{1/3} = x` for `x ≥ 0`.
+* `birthday_triple_threshold_sharp` — for `n ≥ 2` solving `n(n-1)(n-2) = 6 d² ln 2`, with
+  `c := (6 d² ln 2)^{1/3}`,  `c + 1 ≤ n ≤ c + 1 + 1/(3 c)`.
+* `birthday_triple_threshold_const_one` — equivalently `|n - (c + 1)| ≤ 1/(3 c)`.
+
+This sharpens the parent's `c ≤ n ≤ c + 2` (additive error `2`) to the asymptotically exact
+`n = (6 d² ln 2)^{1/3} + 1 + o(1)`: the lower-order term is the explicit constant `1`, with a
+remainder bounded by `1/(3 c) = O(d^{-2/3})`.  The improvement comes from the centered cube
+identity `n(n-1)(n-2) = (n-1)³ - (n-1)`, which turns the balance into the depressed cubic
+`m³ - m = c³` (`m = n - 1`); the lower bound is `m³ ≥ c³` and the upper bound collapses to
+`(m - c)² ≥ 0` after multiplying `3c(m-c) ≤ 1` by `m² + mc + c² > 0`.
+-/
+
+end BirthdayProblemOQ03OQ01OQ01OQ03OQ01
+
+#print axioms BirthdayProblemOQ03OQ01OQ01OQ03OQ01.birthday_triple_threshold_sharp
+#print axioms BirthdayProblemOQ03OQ01OQ01OQ03OQ01.birthday_triple_threshold_const_one

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 3, "endLine": 56 },
+    "type": "context",
+    "title": "Sharpening the k=3 Threshold via a Centered Cube",
+    "content": "The parent pins the k=3 birthday threshold to (6d²ln2)^{1/3} within an additive 2, using the corner-cube sandwich (n-2)³ ≤ n(n-1)(n-2) ≤ n³. Its open question asks to sharpen this band. The key new idea is the exact centered factorization n(n-1)(n-2) = (n-1)³ - (n-1): substituting m = n-1 turns the balance n(n-1)(n-2) = 6d²ln2 =: c³ into the depressed cubic m³ - m = c³. Because the centered cube (n-1)³ touches the falling factorial to within the bounded correction (n-1), the resulting bound c + 1 ≤ n ≤ c + 1 + 1/(3c) pins the lower-order term to exactly 1, with a remainder O(d^{-2/3}) → 0.",
+    "mathContext": "$n(n-1)(n-2)=(n-1)^3-(n-1)\\;\\Rightarrow\\; m^3-m=c^3,\\quad m=n-1,\\ c=(6d^2\\ln 2)^{1/3}$",
+    "significance": "context",
+    "relatedConcepts": ["birthday problem", "k-fold coincidence", "depressed cubic", "centered cube", "sharp threshold"],
+    "prerequisites": ["probability heuristics", "asymptotics"]
+  },
+  {
+    "id": "ann-cuberoot",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 62, "endLine": 65 },
+    "type": "technique",
+    "title": "The Cube-Root Identity",
+    "content": "`cubeRoot_cube`: $(x^3)^{1/3}=x$ for $x\\ge 0$, from Mathlib's `Real.pow_rpow_inv_natCast` after rewriting $1/3=(3:\\mathbb{N})^{-1}$. The same helper as the parent. Treating the cube root as the real power $t\\mapsto t^{1/3}$ keeps it monotone on the nonnegatives and inverse to cubing there, which is exactly what the lower bound needs.",
+    "mathContext": "$(x^3)^{1/3}=x \\quad (x\\ge 0)$",
+    "significance": "supporting",
+    "relatedConcepts": ["rpow", "cube root", "Real.pow_rpow_inv_natCast"],
+    "prerequisites": ["real powers (rpow)"]
+  },
+  {
+    "id": "ann-c-cubed",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 84, "endLine": 91 },
+    "type": "technique",
+    "title": "c³ = L and the Depressed Cubic",
+    "content": "Writing c = L^{1/3} with L = 6d²ln2, the identity c³ = L is obtained by `Real.rpow_natCast` (turning the natural cube into a real power) and `Real.rpow_mul` (collapsing (L^{1/3})³ = L^{(1/3)·3} = L^1 = L). Combined with the centered identity, this recasts the balance as the depressed cubic m³ - m = c³ — the no-quadratic-term form that makes the centered analysis clean.",
+    "mathContext": "$c=L^{1/3}\\Rightarrow c^3=L^{(1/3)\\cdot 3}=L;\\qquad m^3-m=c^3$",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow_mul", "Real.rpow_natCast", "depressed cubic", "rpow arithmetic"],
+    "prerequisites": ["real powers (rpow)"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 100, "endLine": 107 },
+    "type": "technique",
+    "title": "Lower Bound: c + 1 ≤ n",
+    "content": "From the depressed cubic, m³ = c³ + m ≥ c³ because m ≥ 0. Applying the cube root — monotone via `Real.rpow_le_rpow` and inverse to cubing via `cubeRoot_cube` — gives c = L^{1/3} ≤ (m³)^{1/3} = m. Since m = n - 1, this is the sharpened lower bound n ≥ c + 1, a full unit above the parent's n ≥ c.",
+    "mathContext": "$m^3=c^3+m\\ge c^3 \\;\\Rightarrow\\; c\\le m \\;\\Rightarrow\\; n\\ge c+1$",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow_le_rpow", "cube-root monotonicity", "depressed cubic"],
+    "prerequisites": ["monotone powers"]
+  },
+  {
+    "id": "ann-upper-bound",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 108, "endLine": 116 },
+    "type": "key-step",
+    "title": "Upper Bound Collapses to (m−c)² ≥ 0",
+    "content": "The target 3c(m-c) ≤ 1 is, after multiplying by the positive quantity m² + mc + c² and using m³ - c³ = m, exactly the trivial inequality (m-c)² ≥ 0. The algebraic identity (m² + mc + c²)(1 - 3c(m-c)) = (m-c)² is proved by `linear_combination (-3c)·(m³ - m = c³)`, and the sign conclusion by `nlinarith` with `sq_nonneg (m-c)` and the positivity of m² + mc + c². Hence m ≤ c + 1/(3c), i.e. n ≤ c + 1 + 1/(3c). The remainder 1/(3c) is sharp for this argument — it is the slack in (m-c)² ≥ 0.",
+    "mathContext": "$(m^2+mc+c^2)\\,(1-3c(m-c))=(m-c)^2\\ge 0 \\;\\Rightarrow\\; 3c(m-c)\\le 1 \\;\\Rightarrow\\; n\\le c+1+\\tfrac{1}{3c}$",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination", "nlinarith", "completing the square", "sharp remainder"],
+    "prerequisites": ["polynomial inequalities"]
+  },
+  {
+    "id": "ann-const-one",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+    "range": { "startLine": 118, "endLine": 140 },
+    "type": "context",
+    "title": "The Exact Lower-Order Constant",
+    "content": "`birthday_triple_threshold_const_one` packages the two-sided bound as |n − (c + 1)| ≤ 1/(3c) with c = (6d²ln2)^{1/3}. This exhibits the lower-order term as the explicit constant 1, with a one-sided remainder bounded by 1/(3c) = O(d^{-2/3}) that vanishes as d → ∞. So the threshold is n = (6d²ln2)^{1/3} + 1 + o(1) — a strict refinement of the parent's O(1) band, not merely a smaller constant.",
+    "mathContext": "$\\left|\\,n-\\big((6d^2\\ln 2)^{1/3}+1\\big)\\right|\\le \\frac{1}{3(6d^2\\ln 2)^{1/3}}=O(d^{-2/3})$",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic expansion", "vanishing remainder", "sharp constant"],
+    "prerequisites": ["asymptotics", "absolute value bounds"]
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const birthdayProblemOq03Oq01Oq01Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const birthdayProblemOq03Oq01Oq01Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const birthdayProblemOq03Oq01Oq01Oq03Oq01Data: ProofData = {
+  proof: birthdayProblemOq03Oq01Oq01Oq03Oq01Proof,
+  annotations: birthdayProblemOq03Oq01Oq01Oq03Oq01Annotations,
+}

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+  "title": "The Sharp k = 3 Birthday Threshold: n = (6d²ln2)^(1/3) + 1 + o(1)",
+  "slug": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01",
+  "description": "Sharpens the parent's k=3 birthday threshold from an O(1) error band to an asymptotically exact constant. Writing c = (6d²ln2)^(1/3), the n ≥ 2 solving the expected-triple balance n(n-1)(n-2) = 6d²ln2 satisfies c + 1 ≤ n ≤ c + 1 + 1/(3c), i.e. n = (6d²ln2)^(1/3) + 1 + o(1): the lower-order term is the explicit constant 1, with a remainder bounded by 1/(3c) = O(d^(-2/3)) that vanishes as d → ∞. Improves the parent's c ≤ n ≤ c + 2 (additive error 2). Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean",
+    "tags": [
+      "probability",
+      "birthday-problem",
+      "asymptotics",
+      "sharp-threshold",
+      "depressed-cubic",
+      "cube-root",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 163,
+    "assumptions": "None. Fully machine-verified: the Docker Lean build of Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean exits 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for birthday_triple_threshold_sharp and birthday_triple_threshold_const_one. The file imports only Mathlib and is self-contained. Scope note: as in the parent, this proves the threshold from the expected-count balance equation; it does not re-derive that balance equation from a probabilistic limit theorem (Poisson approximation), which is the heuristic modeling input.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.pow_rpow_inv_natCast",
+        "description": "(x ^ n) ^ (n⁻¹ : ℝ) = x for 0 ≤ x, n ≠ 0 — the cube-root identity (x³)^(1/3) = x used for the lower bound",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNRpow"
+      },
+      {
+        "theorem": "Real.rpow_natCast",
+        "description": "x ^ (↑n : ℝ) = x ^ n — converts the natural cube to a real power so that (L^(1/3))³ = L^((1/3)·3) = L can be computed via rpow_mul",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "x ^ (y·z) = (x^y)^z for 0 ≤ x — collapses (L^(1/3))³ to L, giving c³ = L for the depressed-cubic balance",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "monotonicity of t ↦ t^z on the nonnegatives for z ≥ 0 — passes the cube root through L ≤ m³ to obtain c ≤ m",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "0 < log x for 1 < x — positivity of ln 2, hence of c = (6d²ln2)^(1/3)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Sharpens the k=3 birthday threshold from the parent's O(1) band c ≤ n ≤ c + 2 to the asymptotically exact n = (6d²ln2)^(1/3) + 1 + o(1), pinning the lower-order term to the explicit constant 1",
+      "Identifies the centered cube identity n(n-1)(n-2) = (n-1)³ - (n-1) as the mechanism: it turns the balance equation into the depressed cubic m³ - m = c³ (m = n-1)",
+      "birthday_triple_threshold_sharp: c + 1 ≤ n ≤ c + 1 + 1/(3c) for n solving the balance equation — the lower bound from m³ ≥ c³, the upper bound collapsing to (m-c)² ≥ 0 after multiplying 3c(m-c) ≤ 1 by m² + mc + c² > 0",
+      "birthday_triple_threshold_const_one: the packaged statement |n − ((6d²ln2)^(1/3) + 1)| ≤ 1/(3(6d²ln2)^(1/3)), with remainder O(d^(-2/3)) → 0"
+    ],
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The k=3 birthday problem asks when three of n people are likely to share a day among d equally likely days; the folklore threshold is n ≈ (6d²ln2)^(1/3). The parent entry (birthday-problem-oq-03-oq-01-oq-01-oq-03) proves this to leading order with an explicit additive error of at most 2, via the corner-cube sandwich (n-2)³ ≤ n(n-1)(n-2) ≤ n³, and its open questions ask to 'sharpen the additive O(1) error: locate n within a smaller window'. This entry answers that question for k=3.",
+    "problemStatement": "Sharpen the additive O(1) error in the k=3 birthday threshold: locate the balance-equation solution n within a window smaller than [(6d²ln2)^(1/3), (6d²ln2)^(1/3)+2].",
+    "text": "Shows that the n ≥ 2 solving n(n-1)(n-2) = 6d²ln2 satisfies (6d²ln2)^(1/3) + 1 ≤ n ≤ (6d²ln2)^(1/3) + 1 + 1/(3(6d²ln2)^(1/3)), so n = (6d²ln2)^(1/3) + 1 + o(1) — the lower-order term is exactly 1.",
+    "proofStrategy": "Replace the parent's corner cube n³ with the centered cube (n-1)³. The exact identity n(n-1)(n-2) = (n-1)³ - (n-1) turns the balance n(n-1)(n-2) = 6d²ln2 =: c³ into the depressed cubic m³ - m = c³ with m := n - 1. Lower bound: m³ = c³ + m ≥ c³ (since m ≥ 0), so taking cube roots (Real.rpow_le_rpow with (x³)^(1/3) = x) gives m ≥ c, i.e. n ≥ c + 1. Upper bound: the target 3c(m-c) ≤ 1, multiplied by the positive quantity m² + mc + c² and using m³ - c³ = m, collapses to the trivial (m-c)² ≥ 0 (verified by linear_combination and nlinarith); hence m ≤ c + 1/(3c), i.e. n ≤ c + 1 + 1/(3c). The identity c³ = (6d²ln2)^((1/3)·3) = 6d²ln2 is established by Real.rpow_natCast and Real.rpow_mul.",
+    "keyInsights": [
+      "The centered cube (n-1)³ touches the falling factorial to within the bounded correction (n-1): n(n-1)(n-2) = (n-1)³ - (n-1). This is what upgrades the parent's O(1) error to the exact constant 1 + o(1) — the corner cubes (n-2)³ and n³ are a fixed distance 2 apart and can only pin n to within 2.",
+      "Substituting m = n - 1 turns the balance into the depressed cubic m³ - m = c³, where c = (6d²ln2)^(1/3); the depressed (no quadratic term) form is exactly what makes the centered analysis clean.",
+      "The upper bound is not an analytic estimate but an algebraic identity: 3c(m-c) ≤ 1 is equivalent, after clearing the positive factor m² + mc + c², to (m-c)² ≥ 0. The remainder 1/(3c) is therefore sharp for this argument.",
+      "The remainder 1/(3c) = O(d^(-2/3)) vanishes as d → ∞, so the constant term is genuinely exactly 1 in the limit — a strict refinement, not merely a smaller constant in an O(1) bound.",
+      "The sharpening is special to k = 3: for general k the centered monomial (n - (k-1)/2)^k does not divide the falling factorial exactly, which is why the sibling general-k entry retains the loose ±(k-1) band."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-cuberoot",
+      "title": "Problem Statement and the Cube-Root Identity",
+      "summary": "Module docstring explaining the centered-cube sharpening and the depressed cubic m³ - m = c³; cubeRoot_cube: (x³)^(1/3) = x for x ≥ 0 via Real.pow_rpow_inv_natCast",
+      "startLine": 1,
+      "endLine": 65
+    },
+    {
+      "id": "sharp-threshold",
+      "title": "The Sharp Two-Sided Bound",
+      "summary": "birthday_triple_threshold_sharp: c + 1 ≤ n ≤ c + 1 + 1/(3c). Establishes c³ = L via rpow, recasts the balance as m³ - m = c³, derives the lower bound from m³ ≥ c³ and the upper bound by collapsing 3c(m-c) ≤ 1 to (m-c)² ≥ 0",
+      "startLine": 67,
+      "endLine": 116
+    },
+    {
+      "id": "const-one",
+      "title": "The Exact Lower-Order Constant",
+      "summary": "birthday_triple_threshold_const_one: |n − (c + 1)| ≤ 1/(3c), exhibiting the exact constant term 1 and the vanishing remainder O(d^(-2/3))",
+      "startLine": 118,
+      "endLine": 140
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; self-contained, imports only Mathlib): the k=3 birthday-coincidence threshold is (6d²ln2)^(1/3) + 1 + o(1). The n ≥ 2 solving the expected-triple balance n(n-1)(n-2) = 6d²ln2 satisfies (6d²ln2)^(1/3) + 1 ≤ n ≤ (6d²ln2)^(1/3) + 1 + 1/(3(6d²ln2)^(1/3)), via the centered cube identity n(n-1)(n-2) = (n-1)³ - (n-1) and the depressed cubic m³ - m = c³.",
+    "implications": "Answers the parent's open question on sharpening the O(1) error for k=3: the lower-order term is the explicit constant 1, not merely a bounded quantity. The centered-cube technique — trading a corner power for a centered power to expose an exact lower-order constant — transfers to other expected-count thresholds governed by falling factorials with a usable centered factorization.",
+    "openQuestions": [
+      "Is the constant 1 itself the start of an exact asymptotic series n = (6d²ln2)^(1/3) + 1 + a/(d^(2/3)) + ...? Compute the next coefficient from the depressed cubic m³ - m = c³.",
+      "Derive the balance equation n(n-1)(n-2) = 6d²ln2 from a Poisson approximation for the number of triples, upgrading the heuristic input to a theorem.",
+      "Does a centered factorization yield a sharp constant term for any specific small k beyond 3 (e.g. k=4 via (n - 3/2) shifts), or is k=3 genuinely exceptional?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+      "relationship": "parent-problem",
+      "description": "Parent: the k=3 threshold to leading order with O(1) error (c ≤ n ≤ c + 2); its open question asks to sharpen this band, which this entry does to c + 1 ≤ n ≤ c + 1 + 1/(3c)"
+    },
+    {
+      "targetId": "birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-03",
+      "relationship": "related",
+      "description": "Sibling: the general-k threshold (k!·d^(k-1)·ln2)^(1/k) with loose ±(k-1) band; for k=3 it recovers the parent's ±2, which this entry sharpens using the k=3-specific centered cube"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "E. H. McKinney"
+      ],
+      "title": "Generalized Birthday Problem",
+      "year": "1966",
+      "venue": "American Mathematical Monthly 73, 385–387",
+      "note": "Multiple-coincidence birthday problem"
+    },
+    {
+      "authors": [
+        "Anirban DasGupta"
+      ],
+      "title": "The matching, birthday and the strong birthday problem: a contemporary review",
+      "year": "2005",
+      "venue": "Journal of Statistical Planning and Inference 130, 377–389",
+      "note": "Asymptotics of k-fold birthday coincidences"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BirthdayProblemOQ03OQ01OQ01OQ03OQ01",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Problem

`birthday-problem-oq-03-oq-01-oq-01-oq-03-oq-01` — sharpen the `k = 3` triple-coincidence birthday threshold.

The parent (`…-oq-03`) proves only the loose band `c ≤ n ≤ c + 2` (additive error **2**) for the `n ≥ 2` solving the expected-triple balance `n(n-1)(n-2) = 6d²ln2`, where `c := (6d²ln2)^(1/3)`. This PR pins the lower-order term to the **exact constant 1** with a provably vanishing remainder.

## Result

For `n ≥ 2` solving `n(n-1)(n-2) = 6d²ln2`, writing `c := (6d²ln2)^(1/3)`:

```
c + 1  ≤  n  ≤  c + 1 + 1/(3c).
```

So `n = (6d²ln2)^(1/3) + 1 + o(1)`, with remainder `1/(3c) = O(d^(-2/3)) → 0` — a strict refinement of the parent's `± 2` window.

## Idea — centered cube, not corner cube

The parent sandwiches the falling factorial between the corner cubes `(n-2)³` and `n³`, a distance 2 apart, so cube-root can only pin `n` to within 2. The new observation is the exact **centered** factorisation

```
n(n-1)(n-2) = (n-1)³ - (n-1).
```

With `m := n-1` the balance becomes the depressed cubic `m³ - m = c³`. Then:
- **Lower bound:** `m³ = c³ + m ≥ c³` (since `m ≥ 0`), so `m ≥ c`, i.e. `n ≥ c+1`.
- **Upper bound:** the target `3c(m-c) ≤ 1`, multiplied by `m²+mc+c² > 0` and using `m³-c³ = m`, collapses to `(m-c)² ≥ 0`. Hence `m ≤ c + 1/(3c)`, i.e. `n ≤ c+1+1/(3c)`.

This trick is special to `k = 3`: for general `k` the centered monomial `(n-(k-1)/2)^k` no longer divides the falling factorial exactly.

## Theorems (`proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ03OQ01.lean`)

- `cubeRoot_cube` — `(x³)^(1/3) = x` for `x ≥ 0`.
- `birthday_triple_threshold_sharp` — the two-sided bound `c+1 ≤ n ≤ c+1+1/(3c)`.
- `birthday_triple_threshold_const_one` — packaged as `|n - (c+1)| ≤ 1/(3c)`.

## Verification

- `lake env lean` exits **0** against pinned Mathlib **v4.26.0** (self-contained, imports only `Mathlib`).
- `#print axioms` reports only `propext / Classical.choice / Quot.sound` for both main theorems — **no `sorryAx`, no `Lean.ofReduceBool`**.
- `status: verified`, `badge: original`, `axiomCount: 0`.

**Scope note:** as in the parent, the threshold is derived from the expected-count balance equation; this file does not re-derive that balance from a Poisson limit theorem (the heuristic modeling input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)