### PR TITLE
Enrich Beta(m+1,n+1) moments (beta-integral oq-01³-oq-02): index.ts + sections + annotation fields

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 32 },
     "type": "concept",
     "title": "Moments of the integer Beta distribution from one integral",
-    "content": "The parent leaf established ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, the normalising constant B(m+1,n+1) of the Beta(m+1,n+1) distribution with density xᵐ(1-x)ⁿ/B on [0,1]. This entry answers the parent's second open question — the mean is a one-line corollary of an index shift — and then derives the full low-order moment structure (mean, second moment, variance) from that single identity, with no new integration. Each moment E[Xʲ] is a ratio ∫₀¹ xʲ·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ in which the weight xʲ merely shifts m ↦ m+j."
+    "content": "The parent leaf established ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, the normalising constant B(m+1,n+1) of the Beta(m+1,n+1) distribution with density xᵐ(1-x)ⁿ/B on [0,1]. This entry answers the parent's second open question — the mean is a one-line corollary of an index shift — and then derives the full low-order moment structure (mean, second moment, variance) from that single identity, with no new integration. Each moment E[Xʲ] is a ratio ∫₀¹ xʲ·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ in which the weight xʲ merely shifts m ↦ m+j.",
+    "mathContext": "$B(m+1,n+1)=\\int_0^1 x^m(1-x)^n\\,dx = \\dfrac{m!\\,n!}{(m+n+1)!}$; $\\;E[X^j]=\\dfrac{\\int_0^1 x^{m+j}(1-x)^n}{\\int_0^1 x^m(1-x)^n}$.",
+    "significance": "key",
+    "relatedConcepts": ["Beta distribution", "Euler Beta function", "raw moments", "conjugate prior", "index shift"],
+    "prerequisites": ["the integer Euler Beta integral (parent leaf)", "definition of distribution moments"]
   },
   {
     "id": "ann-normalising",
@@ -13,7 +17,11 @@
     "range": { "startLine": 39, "endLine": 51 },
     "type": "theorem",
     "title": "The normalising constant is positive",
-    "content": "normalising_pos: 0 < ∫₀¹ xᵐ(1-x)ⁿ. Rewrite the integral to its closed form m!·n!/(m+n+1)! via the parent's integral_offdiag_eq_factorial, then positivity follows from Nat.factorial_pos on numerator and denominator. This certifies every moment below is a genuine quotient by a nonzero Beta value rather than a vacuous division by zero."
+    "content": "normalising_pos: 0 < ∫₀¹ xᵐ(1-x)ⁿ. Rewrite the integral to its closed form m!·n!/(m+n+1)! via the parent's integral_offdiag_eq_factorial, then positivity follows from Nat.factorial_pos on numerator and denominator. This certifies every moment below is a genuine quotient by a nonzero Beta value rather than a vacuous division by zero.",
+    "mathContext": "$0 < \\dfrac{m!\\,n!}{(m+n+1)!}$ since $k! > 0$ for all $k$ (Nat.factorial_pos).",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity of factorials", "well-defined ratios", "Nat.factorial_pos"],
+    "prerequisites": ["the parent closed-form Beta integral", "positivity of a quotient of positives"]
   },
   {
     "id": "ann-mean",
@@ -21,7 +29,11 @@
     "range": { "startLine": 53, "endLine": 77 },
     "type": "theorem",
     "title": "The mean (parent's open question)",
-    "content": "mean_eq: ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2). The numerator integrand x·xᵐ(1-x)ⁿ equals xᵐ⁺¹(1-x)ⁿ (integral_congr with ring), so the parent's closed form applies at index m+1 to the numerator and m to the denominator. Index normalisation m+1+n+1 = (m+n+1)+1 plus Nat.factorial_succ peels (m+1)! = (m+1)·m! and (m+n+2)! = (m+n+2)·(m+n+1)!; field_simp leaves (m+1)/(m+n+2). This is exactly the parent leaf's second open question, confirmed as the index shift m ↦ m+1."
+    "content": "mean_eq: ∫₀¹ x·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)/(m+n+2). The numerator integrand x·xᵐ(1-x)ⁿ equals xᵐ⁺¹(1-x)ⁿ (integral_congr with ring), so the parent's closed form applies at index m+1 to the numerator and m to the denominator. Index normalisation m+1+n+1 = (m+n+1)+1 plus Nat.factorial_succ peels (m+1)! = (m+1)·m! and (m+n+2)! = (m+n+2)·(m+n+1)!; field_simp leaves (m+1)/(m+n+2). This is exactly the parent leaf's second open question, confirmed as the index shift m ↦ m+1.",
+    "mathContext": "$E[X]=\\dfrac{(m+1)!\\,n!/(m+n+2)!}{m!\\,n!/(m+n+1)!}=\\dfrac{m+1}{m+n+2}=\\dfrac{\\alpha}{\\alpha+\\beta}$ at $\\alpha=m+1,\\beta=n+1$.",
+    "significance": "critical",
+    "relatedConcepts": ["expected value", "index shift m ↦ m+1", "Nat.factorial_succ", "intervalIntegral.integral_congr"],
+    "prerequisites": ["the parent Beta integral", "pointwise rewriting of integrands", "field_simp / ring arithmetic"]
   },
   {
     "id": "ann-second-moment",
@@ -29,7 +41,11 @@
     "range": { "startLine": 79, "endLine": 104 },
     "type": "theorem",
     "title": "The second raw moment",
-    "content": "second_moment_eq: ∫₀¹ x²·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)(m+2)/((m+n+2)(m+n+3)). The weight x² shifts m ↦ m+2; applying Nat.factorial_succ twice peels (m+2)! = (m+2)(m+1)·m! and (m+n+3)! = (m+n+3)(m+n+2)·(m+n+1)!, and field_simp produces the ascending-factor ratio E[X²] = α(α+1)/((α+β)(α+β+1)) at α = m+1, β = n+1."
+    "content": "second_moment_eq: ∫₀¹ x²·xᵐ(1-x)ⁿ / ∫₀¹ xᵐ(1-x)ⁿ = (m+1)(m+2)/((m+n+2)(m+n+3)). The weight x² shifts m ↦ m+2; applying Nat.factorial_succ twice peels (m+2)! = (m+2)(m+1)·m! and (m+n+3)! = (m+n+3)(m+n+2)·(m+n+1)!, and field_simp produces the ascending-factor ratio E[X²] = α(α+1)/((α+β)(α+β+1)) at α = m+1, β = n+1.",
+    "mathContext": "$E[X^2]=\\dfrac{(m+1)(m+2)}{(m+n+2)(m+n+3)}=\\dfrac{\\alpha(\\alpha+1)}{(\\alpha+\\beta)(\\alpha+\\beta+1)}$.",
+    "significance": "key",
+    "relatedConcepts": ["second raw moment", "Pochhammer / ascending factorials", "index shift m ↦ m+2"],
+    "prerequisites": ["the mean computation", "repeated use of Nat.factorial_succ"]
   },
   {
     "id": "ann-variance",
@@ -37,6 +53,10 @@
     "range": { "startLine": 106, "endLine": 122 },
     "type": "theorem",
     "title": "The variance",
-    "content": "variance_eq: E[X²] − E[X]² = (m+1)(n+1)/((m+n+2)²(m+n+3)). Rewriting by the two proven moments, the difference is (m+1)/(m+n+2)·[(m+2)/(m+n+3) − (m+1)/(m+n+2)]; the bracket numerator (m+2)(m+n+2) − (m+1)(m+n+3) collapses to exactly n+1 (field_simp, ring), giving the symmetric Beta variance αβ/((α+β)²(α+β+1)) at α = m+1, β = n+1."
+    "content": "variance_eq: E[X²] − E[X]² = (m+1)(n+1)/((m+n+2)²(m+n+3)). Rewriting by the two proven moments, the difference is (m+1)/(m+n+2)·[(m+2)/(m+n+3) − (m+1)/(m+n+2)]; the bracket numerator (m+2)(m+n+2) − (m+1)(m+n+3) collapses to exactly n+1 (field_simp, ring), giving the symmetric Beta variance αβ/((α+β)²(α+β+1)) at α = m+1, β = n+1.",
+    "mathContext": "$\\operatorname{Var}(X)=\\dfrac{(m+1)(n+1)}{(m+n+2)^2(m+n+3)}=\\dfrac{\\alpha\\beta}{(\\alpha+\\beta)^2(\\alpha+\\beta+1)}$; the key cancellation is $(m+2)(m+n+2)-(m+1)(m+n+3)=n+1$.",
+    "significance": "critical",
+    "relatedConcepts": ["variance", "E[X²] − E[X]²", "algebraic cancellation", "symmetry in (m,n)"],
+    "prerequisites": ["the mean and second-moment theorems", "field_simp / ring"]
   }
 ]

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/index.ts
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BetaIntegralRecurrenceOQ01OQ03OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const betaIntegralRecurrenceOq01Oq03Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const betaIntegralRecurrenceOq01Oq03Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const betaIntegralRecurrenceOq01Oq03Oq01Oq02Data: ProofData = {
+  proof: betaIntegralRecurrenceOq01Oq03Oq01Oq02Proof,
+  annotations: betaIntegralRecurrenceOq01Oq03Oq01Oq02Annotations,
+}

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02/meta.json
@@ -97,6 +97,43 @@
       "Does the variance formula (m+1)(n+1)/((m+n+2)²(m+n+3)) reproduce, after the substitution m ↦ a-1, n ↦ b-1, Mathlib's real Beta-distribution variance for integer a, b, and can the equality be stated against a Mathlib pdf if one is added?"
     ]
   },
+  "sections": [
+    {
+      "id": "module-docstring-and-setup",
+      "title": "Module docstring, imports, and the B abbreviation",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "The module docstring frames the goal — derive the mean, second moment, and variance of the integer Beta(m+1,n+1) distribution from the single parent identity ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!. Imports the parent leaf `Proofs.BetaIntegralRecurrenceOQ01OQ03OQ01` and `Mathlib.Tactic`, opens `intervalIntegral`/`MeasureTheory`, enters the namespace, and introduces a shorthand `B` for the parent's off-diagonal integer Beta integral."
+    },
+    {
+      "id": "normalising-pos",
+      "title": "normalising_pos: the Beta value is positive",
+      "startLine": 44,
+      "endLine": 56,
+      "summary": "Proves 0 < ∫₀¹ xᵐ(1-x)ⁿ by rewriting to the closed form m!·n!/(m+n+1)! (parent's integral_offdiag_eq_factorial) and applying Nat.factorial_pos. This guarantees the moment ratios below divide by a nonzero quantity."
+    },
+    {
+      "id": "mean-eq",
+      "title": "mean_eq: E[X] = (m+1)/(m+n+2)",
+      "startLine": 57,
+      "endLine": 82,
+      "summary": "The parent's second open question. The weighted numerator x·xᵐ(1-x)ⁿ = xᵐ⁺¹(1-x)ⁿ (integral_congr + ring) shifts the index m ↦ m+1, so the parent closed form applies to both numerator and denominator; Nat.factorial_succ peels the factorials and field_simp yields (m+1)/(m+n+2)."
+    },
+    {
+      "id": "second-moment-eq",
+      "title": "second_moment_eq: E[X²] = (m+1)(m+2)/((m+n+2)(m+n+3))",
+      "startLine": 83,
+      "endLine": 108,
+      "summary": "The weight x² shifts m ↦ m+2; two applications of Nat.factorial_succ peel (m+2)! and (m+n+3)!, and field_simp produces the ascending-factor ratio α(α+1)/((α+β)(α+β+1)) at α=m+1, β=n+1."
+    },
+    {
+      "id": "variance-eq",
+      "title": "variance_eq: Var(X) = (m+1)(n+1)/((m+n+2)²(m+n+3))",
+      "startLine": 109,
+      "endLine": 122,
+      "summary": "Rewrites Var = E[X²] − E[X]² by the two proven moments; the bracketed numerator (m+2)(m+n+2) − (m+1)(m+n+3) collapses to n+1 (field_simp, ring), giving the symmetric Beta variance αβ/((α+β)²(α+β+1))."
+    }
+  ],
   "references": [
     {
       "authors": "Johnson, N. L.; Kotz, S.; Balakrishnan, N.",


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-03-oq-01-oq-02` (quality 58, 0 prior passes).

## What changed
- **Added missing `index.ts`** — without it the proof renders 'proof not found' on the live site (highest-impact gap; meta/overview/conclusion/references were already rich).
- **Added `sections`** — meta.json had no sections; added a 5-section breakdown covering the full 122-line Lean file (docstring+setup / normalising_pos / mean_eq / second_moment_eq / variance_eq).
- **Enriched all 5 annotations** with `significance`, `relatedConcepts`, `prerequisites`, and LaTeX `mathContext`.

## Integrity
No mathematical claims altered. meta keeps `status: verified`, `badge: original`, `axiomCount: 0` — consistent with the Lean file (4 theorems, 0 sorries, 0 axioms, no native_decide; #print axioms reports only propext/Classical.choice/Quot.sound).

JSON validated; `pnpm build` skipped (no node_modules in worktree).