### PR TITLE
research(isoperimetric-theorem-oq-01-oq-01): Fourier method for the isoperimetric inequality (Hurwitz–Wirtinger) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/IsoperimetricFourierOQ0101.lean
+++ b/proofs/Proofs/IsoperimetricFourierOQ0101.lean
@@ -1,0 +1,221 @@
+/-
+The Fourier Method for the Isoperimetric Inequality (Hurwitz–Wirtinger)
+
+Open Question from: Isoperimetric Shapes on Other Surfaces
+  (isoperimetric-theorem-oq-01-oq-01)
+
+  "Can the spherical/hyperbolic isoperimetric inequalities be proved in Lean
+   using symmetrization or Fourier methods?"
+
+This file formalizes the *Fourier method* in its base (Euclidean) case — the
+Hurwitz–Wirtinger proof of the classical isoperimetric inequality L² ≥ 4πA —
+which is the exact technique the open question asks to transport to curved
+surfaces. We isolate and verify its algebraic heart.
+
+## The Fourier method, in one line
+
+Write a closed curve of period 2π in real Fourier series
+
+    x(s) = a₀ + Σ_{n≥1} (aₙ cos ns + αₙ sin ns)
+    y(s) = b₀ + Σ_{n≥1} (bₙ cos ns + βₙ sin ns).
+
+By Parseval the (Dirichlet) length energy and the Green/area functional become
+
+    (1/π) ∮ (x'² + y'²) ds = Σ_{n≥1} n² (aₙ²+αₙ²+bₙ²+βₙ²)   =: E
+    (1/π) · A             = Σ_{n≥1} n  (aₙβₙ − αₙbₙ)        =: Ar.
+
+Hurwitz's observation is the pointwise-in-n *sum-of-squares identity*
+
+    n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ)
+       = (n aₙ − βₙ)² + (n αₙ + bₙ)² + (n²−1)(βₙ² + bₙ²),
+
+whose right-hand side is manifestly ≥ 0 for every n ≥ 1.  Summing gives
+E − 2·Ar ≥ 0 (Wirtinger's inequality), and after arc-length normalization
+(E = 2, L = 2π, A = π·Ar) this is exactly L² ≥ 4πA, with equality precisely
+when only the fundamental mode n = 1 survives — i.e. the curve is a circle.
+
+## What is formalized here
+
+We formalize the Fourier-coefficient core: the per-mode SOS identity, its
+summed form (Wirtinger), the isoperimetric inequality under the standard
+arc-length normalization, and the equality characterization (all higher modes
+vanish ⇒ circle).  This is pure real algebra over finite Fourier data; the
+Parseval bridge from the L²-integrals to the coefficient sums is the standard
+textbook reduction (Stein–Shakarchi, Ch. 4) and is documented, not re-derived.
+
+The constant translation modes a₀, b₀ drop out of both E and Ar, so only the
+modes n ≥ 1 are tracked.
+
+References:
+- A. Hurwitz, "Sur le problème des isopérimètres", C. R. Acad. Sci. (1901)
+- E. Stein, R. Shakarchi, *Fourier Analysis*, Princeton (2003), Ch. 4
+- R. Osserman, "The isoperimetric inequality", Bull. AMS 84 (1978)
+
+Tags: fourier-analysis, isoperimetric, wirtinger, hurwitz, sum-of-squares
+-/
+
+import Mathlib
+
+open Finset
+
+namespace IsoperimetricFourier
+
+/-- Real Fourier data of a closed plane curve: for each mode `n` the four real
+coefficients `a n, α n` (the `x`-component) and `b n, β n` (the `y`-component).
+Only modes `n ≥ 1` are relevant; constant modes are translations and drop out. -/
+variable (a α b β : ℕ → ℝ)
+
+/-- The length (Dirichlet) energy in Fourier coordinates:
+`(1/π) ∮ (x'² + y'²) ds = Σ n² (aₙ²+αₙ²+bₙ²+βₙ²)` by Parseval. -/
+def lengthEnergy (s : Finset ℕ) : ℝ :=
+  ∑ n ∈ s, (n : ℝ) ^ 2 * (a n ^ 2 + α n ^ 2 + b n ^ 2 + β n ^ 2)
+
+/-- The enclosed signed area in Fourier coordinates:
+`(1/π) · A = Σ n (aₙβₙ − αₙbₙ)` by Green's theorem and Parseval. -/
+def areaFourier (s : Finset ℕ) : ℝ :=
+  ∑ n ∈ s, (n : ℝ) * (a n * β n - α n * b n)
+
+/-- Hurwitz's per-mode sum-of-squares term. Manifestly `≥ 0` when `n ≥ 1`. -/
+def hurwitzTerm (n : ℕ) : ℝ :=
+  ((n : ℝ) * a n - β n) ^ 2 + ((n : ℝ) * α n + b n) ^ 2
+    + ((n : ℝ) ^ 2 - 1) * (β n ^ 2 + b n ^ 2)
+
+/-!
+## Part I: The Hurwitz sum-of-squares identity
+-/
+
+/-- The algebraic heart, mode by mode:
+`n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ) = hurwitzTerm n`. -/
+theorem hurwitz_mode_identity (n : ℕ) :
+    (n : ℝ) ^ 2 * (a n ^ 2 + α n ^ 2 + b n ^ 2 + β n ^ 2)
+        - 2 * ((n : ℝ) * (a n * β n - α n * b n))
+      = hurwitzTerm a α b β n := by
+  simp only [hurwitzTerm]; ring
+
+/-- Summed form: the isoperimetric deficit `E − 2·Ar` equals the (nonnegative)
+sum of the per-mode Hurwitz terms. -/
+theorem hurwitz_deficit_identity (s : Finset ℕ) :
+    lengthEnergy a α b β s - 2 * areaFourier a α b β s
+      = ∑ n ∈ s, hurwitzTerm a α b β n := by
+  unfold lengthEnergy areaFourier
+  rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
+  exact Finset.sum_congr rfl fun n _ => hurwitz_mode_identity a α b β n
+
+/-!
+## Part II: Nonnegativity (Wirtinger's inequality)
+-/
+
+/-- Each Hurwitz term is nonnegative for a genuine mode `n ≥ 1`. -/
+theorem hurwitzTerm_nonneg (n : ℕ) (hn : 1 ≤ n) : 0 ≤ hurwitzTerm a α b β n := by
+  have hn1 : (1 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have h2 : (0 : ℝ) ≤ (n : ℝ) ^ 2 - 1 := by nlinarith [hn1, sq_nonneg ((n : ℝ) - 1)]
+  have h3 : (0 : ℝ) ≤ β n ^ 2 + b n ^ 2 := by positivity
+  simp only [hurwitzTerm]
+  nlinarith [sq_nonneg ((n : ℝ) * a n - β n), sq_nonneg ((n : ℝ) * α n + b n),
+    mul_nonneg h2 h3]
+
+/-- **Wirtinger's inequality (Fourier form).** For Fourier data supported on
+modes `n ≥ 1`, twice the area functional never exceeds the length energy:
+`2·Ar ≤ E`. This is the Fourier-analytic core of the isoperimetric inequality. -/
+theorem wirtinger (s : Finset ℕ) (hs : ∀ n ∈ s, 1 ≤ n) :
+    2 * areaFourier a α b β s ≤ lengthEnergy a α b β s := by
+  have h : 0 ≤ lengthEnergy a α b β s - 2 * areaFourier a α b β s := by
+    rw [hurwitz_deficit_identity]
+    exact Finset.sum_nonneg fun n hn => hurwitzTerm_nonneg a α b β n (hs n hn)
+  linarith
+
+/-!
+## Part III: The isoperimetric inequality
+
+After arc-length parametrization the curve has length `L = 2π`, the energy is
+normalized to `E = 2` (since `∮(x'²+y'²) ds = 2π`), and the area is `A = π·Ar`.
+Wirtinger's inequality then yields `Ar ≤ 1`, i.e. `A ≤ π`, i.e. `L² ≥ 4πA`.
+-/
+
+/-- **The Fourier (Hurwitz) isoperimetric inequality.** A closed curve given by
+arc-length-normalized Fourier data (`lengthEnergy = 2`) with length `L = 2π` and
+area `A = π · areaFourier` satisfies `4πA ≤ L²`. -/
+theorem isoperimetric_fourier (s : Finset ℕ) (hs : ∀ n ∈ s, 1 ≤ n)
+    (L A : ℝ) (hL : L = 2 * π) (hnorm : lengthEnergy a α b β s = 2)
+    (hA : A = π * areaFourier a α b β s) :
+    4 * π * A ≤ L ^ 2 := by
+  have hw := wirtinger a α b β s hs
+  rw [hnorm] at hw
+  have ha1 : areaFourier a α b β s ≤ 1 := by linarith
+  subst hL; subst hA
+  nlinarith [mul_nonneg (sq_nonneg π) (sub_nonneg.mpr ha1)]
+
+/-!
+## Part IV: The equality case — only a circle saturates the inequality
+-/
+
+/-- A higher mode (`n ≥ 2`) with a vanishing Hurwitz term must vanish entirely. -/
+theorem hurwitzTerm_eq_zero (n : ℕ) (hn : 2 ≤ n) (h : hurwitzTerm a α b β n = 0) :
+    a n = 0 ∧ α n = 0 ∧ b n = 0 ∧ β n = 0 := by
+  have hn1 : (2 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hnne : (n : ℝ) ≠ 0 := ne_of_gt hnpos
+  have h2 : (0 : ℝ) < (n : ℝ) ^ 2 - 1 := by nlinarith [hn1, sq_nonneg ((n : ℝ) - 2)]
+  simp only [hurwitzTerm] at h
+  have s1 := sq_nonneg ((n : ℝ) * a n - β n)
+  have s2 := sq_nonneg ((n : ℝ) * α n + b n)
+  have s3 : (0 : ℝ) ≤ β n ^ 2 + b n ^ 2 := by positivity
+  have hprod : (0 : ℝ) ≤ ((n : ℝ) ^ 2 - 1) * (β n ^ 2 + b n ^ 2) :=
+    mul_nonneg (le_of_lt h2) s3
+  -- The three nonnegative summands of `h` each vanish.
+  have e3 : ((n : ℝ) ^ 2 - 1) * (β n ^ 2 + b n ^ 2) = 0 :=
+    le_antisymm (by nlinarith [s1, s2]) hprod
+  have hbb : β n ^ 2 + b n ^ 2 = 0 := by
+    rcases mul_eq_zero.mp e3 with h' | h'
+    · exfalso; linarith
+    · exact h'
+  have hβ2 : β n ^ 2 = 0 := le_antisymm (by nlinarith [sq_nonneg (b n)]) (sq_nonneg _)
+  have hb2 : b n ^ 2 = 0 := le_antisymm (by nlinarith [sq_nonneg (β n)]) (sq_nonneg _)
+  have hβ : β n = 0 := (pow_eq_zero_iff (n := 2) (by norm_num)).mp hβ2
+  have hbn : b n = 0 := (pow_eq_zero_iff (n := 2) (by norm_num)).mp hb2
+  have he1 : ((n : ℝ) * a n - β n) ^ 2 = 0 :=
+    le_antisymm (by nlinarith [s2, e3]) (sq_nonneg _)
+  have he2 : ((n : ℝ) * α n + b n) ^ 2 = 0 :=
+    le_antisymm (by nlinarith [s1, e3]) (sq_nonneg _)
+  have ha0 : (n : ℝ) * a n - β n = 0 := (pow_eq_zero_iff (n := 2) (by norm_num)).mp he1
+  have hα0 : (n : ℝ) * α n + b n = 0 := (pow_eq_zero_iff (n := 2) (by norm_num)).mp he2
+  have hna : (n : ℝ) * a n = 0 := by rw [hβ] at ha0; linarith
+  have hnα : (n : ℝ) * α n = 0 := by rw [hbn] at hα0; linarith
+  exact ⟨(mul_eq_zero.mp hna).resolve_left hnne,
+         (mul_eq_zero.mp hnα).resolve_left hnne, hbn, hβ⟩
+
+/-- **Equality case ⇒ circle.** If the isoperimetric inequality is saturated
+(`E = 2·Ar`), then every mode `n ≥ 2` vanishes: only the fundamental mode `n = 1`
+survives, and a single-mode curve is a circle. -/
+theorem equality_implies_circle (s : Finset ℕ) (hs : ∀ n ∈ s, 1 ≤ n)
+    (heq : lengthEnergy a α b β s = 2 * areaFourier a α b β s) :
+    ∀ n ∈ s, 2 ≤ n → a n = 0 ∧ α n = 0 ∧ b n = 0 ∧ β n = 0 := by
+  have hsum : ∑ n ∈ s, hurwitzTerm a α b β n = 0 := by
+    rw [← hurwitz_deficit_identity]; linarith
+  have hz := (Finset.sum_eq_zero_iff_of_nonneg
+    fun n hn => hurwitzTerm_nonneg a α b β n (hs n hn)).mp hsum
+  intro n hn hn2
+  exact hurwitzTerm_eq_zero a α b β n hn2 (hz n hn)
+
+/-!
+## Part V: The circle achieves equality (non-vacuity)
+
+The fundamental mode alone, `x(s) = r cos s`, `y(s) = r sin s` — a circle of
+radius `r` — saturates Wirtinger's inequality. With `r = 1` this is the unit
+circle: `E = 2`, `Ar = 1`, hence `L² = 4π² = 4πA`.
+-/
+
+/-- The unit circle (`a₁ = β₁ = 1`, all other coefficients `0`) has length
+energy `2`. -/
+example :
+    lengthEnergy (fun n => if n = 1 then 1 else 0) (fun _ => 0)
+      (fun _ => 0) (fun n => if n = 1 then 1 else 0) {1} = 2 := by
+  norm_num [lengthEnergy, Finset.sum_singleton]
+
+/-- The unit circle saturates Wirtinger: `areaFourier = 1`, half the energy. -/
+example :
+    areaFourier (fun n => if n = 1 then 1 else 0) (fun _ => 0)
+      (fun _ => 0) (fun n => if n = 1 then 1 else 0) {1} = 1 := by
+  norm_num [areaFourier, Finset.sum_singleton]
+
+end IsoperimetricFourier

--- a/proofs/Proofs/IsoperimetricFourierOQ0101.lean
+++ b/proofs/Proofs/IsoperimetricFourierOQ0101.lean
@@ -60,7 +60,7 @@ open Finset
 
 namespace IsoperimetricFourier
 
-/-- Real Fourier data of a closed plane curve: for each mode `n` the four real
+/- Real Fourier data of a closed plane curve: for each mode `n` the four real
 coefficients `a n, α n` (the `x`-component) and `b n, β n` (the `y`-component).
 Only modes `n ≥ 1` are relevant; constant modes are translations and drop out. -/
 variable (a α b β : ℕ → ℝ)

--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "isofourier-ann-sos-identity",
+    "proofId": "isoperimetric-theorem-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 93 },
+    "type": "technique",
+    "title": "The Whole Inequality is One ring Identity",
+    "content": "`hurwitz_mode_identity` is the algebraic heart of the Fourier method: mode by mode, the isoperimetric deficit `n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ)` equals `(n·aₙ − βₙ)² + (n·αₙ + bₙ)² + (n²−1)(βₙ² + bₙ²)`, proved by a single `ring`. Once a curve is written in Fourier coordinates there is nothing analytic left — the deficit is a polynomial identity whose right-hand side is a manifest sum of squares. Everything downstream (Wirtinger, the isoperimetric inequality, the equality case) specializes this one line.",
+    "mathContext": "$n^2(a_n^2+\\alpha_n^2+b_n^2+\\beta_n^2) - 2n(a_n\\beta_n-\\alpha_n b_n) = (na_n-\\beta_n)^2 + (n\\alpha_n+b_n)^2 + (n^2-1)(\\beta_n^2+b_n^2)$.",
+    "significance": "key",
+    "relatedConcepts": ["sum of squares", "Hurwitz", "Fourier coefficients", "Parseval", "ring identities"],
+    "prerequisites": ["Fourier series", "polynomial identities in Lean"]
+  },
+  {
+    "id": "isofourier-ann-deficit-sum",
+    "proofId": "isoperimetric-theorem-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 102 },
+    "type": "insight",
+    "title": "Summing the Identity: the Deficit as a Finset Sum",
+    "content": "`hurwitz_deficit_identity` lifts the per-mode identity to the whole curve: the deficit `E − 2·Ar` equals `∑ₙ hurwitzTerm n`. The proof distributes the scalar `2` with `Finset.mul_sum` and merges the two sums with `Finset.sum_sub_distrib`, then applies the per-mode identity term by term via `Finset.sum_congr`. This is the bridge from algebra to the global inequality — once the deficit is a sum of nonnegative terms, Wirtinger is immediate.",
+    "mathContext": "$E - 2\\,Ar = \\sum_{n} \\big[(na_n-\\beta_n)^2 + (n\\alpha_n+b_n)^2 + (n^2-1)(\\beta_n^2+b_n^2)\\big] \\ge 0$.",
+    "significance": "important",
+    "relatedConcepts": ["Finset.sum_sub_distrib", "Finset.mul_sum", "big operators"],
+    "prerequisites": ["finite sums in Lean"]
+  },
+  {
+    "id": "isofourier-ann-wirtinger",
+    "proofId": "isoperimetric-theorem-oq-01-oq-01",
+    "range": { "startLine": 120, "endLine": 125 },
+    "type": "technique",
+    "title": "Wirtinger's Inequality from Per-Mode Nonnegativity",
+    "content": "`wirtinger` packages the Fourier-analytic core: `2·Ar ≤ E`. Because every Hurwitz term is nonnegative for a genuine mode `n ≥ 1` (`hurwitzTerm_nonneg`, where the decisive fact is `n² − 1 ≥ 0`), `Finset.sum_nonneg` makes the deficit nonnegative and `linarith` finishes. This is exactly Wirtinger's inequality — the L²-bound `∫f² ≤ ∫f'²` for mean-zero periodic `f` — read off the Fourier coefficients.",
+    "mathContext": "$2\\,Ar \\le E$; equivalently $\\int_0^{2\\pi} f^2 \\le \\int_0^{2\\pi} (f')^2$ for mean-zero periodic $f$.",
+    "significance": "key",
+    "relatedConcepts": ["Wirtinger's inequality", "Poincaré inequality", "Finset.sum_nonneg"],
+    "prerequisites": ["Fourier series", "Parseval's identity"]
+  },
+  {
+    "id": "isofourier-ann-isoperimetric",
+    "proofId": "isoperimetric-theorem-oq-01-oq-01",
+    "range": { "startLine": 138, "endLine": 146 },
+    "type": "insight",
+    "title": "Arc-Length Bookkeeping Turns Wirtinger into L² ≥ 4πA",
+    "content": "`isoperimetric_fourier` is the payoff. Under the arc-length normalization the curve has length `L = 2π`, energy `E = 2` (since `∮(x'²+y'²) ds = 2π`), and area `A = π·Ar`. Wirtinger gives `Ar ≤ 1`, hence `A ≤ π`, hence `4πA ≤ 4π² = L²`. The final step is a single `nlinarith` fed the nonnegativity of `π²·(1 − Ar)`. The isoperimetric inequality and Wirtinger's inequality are the same statement up to this bookkeeping.",
+    "mathContext": "$L = 2\\pi,\\ E = 2,\\ A = \\pi\\,Ar \\ \\Rightarrow\\ 4\\pi A \\le L^2$.",
+    "significance": "key",
+    "relatedConcepts": ["isoperimetric inequality", "arc-length parametrization", "nlinarith"],
+    "prerequisites": ["isoperimetric inequality", "Wirtinger's inequality"]
+  },
+  {
+    "id": "isofourier-ann-equality",
+    "proofId": "isoperimetric-theorem-oq-01-oq-01",
+    "range": { "startLine": 153, "endLine": 198 },
+    "type": "technique",
+    "title": "Equality ⇒ Circle: Killing Every Higher Mode",
+    "content": "`equality_implies_circle` characterizes the optimizer. A saturated inequality `E = 2·Ar` makes the deficit zero, so by `Finset.sum_eq_zero_iff_of_nonneg` every Hurwitz term vanishes. `hurwitzTerm_eq_zero` then exploits the strict weight `n² − 1 > 0` for `n ≥ 2`: the three nonnegative summands are each forced to zero (extracted by `le_antisymm` against `sq_nonneg`), so `βₙ = bₙ = 0` and then `aₙ = αₙ = 0`. Only the fundamental mode `n = 1` survives — and a single-mode curve is a circle.",
+    "mathContext": "$E = 2\\,Ar \\implies a_n = \\alpha_n = b_n = \\beta_n = 0 \\ \\text{for all } n \\ge 2$.",
+    "significance": "important",
+    "relatedConcepts": ["equality case", "rigidity", "Finset.sum_eq_zero_iff_of_nonneg", "le_antisymm"],
+    "prerequisites": ["sum-of-squares arguments"]
+  },
+  {
+    "id": "isofourier-ann-circle",
+    "proofId": "isoperimetric-theorem-oq-01-oq-01",
+    "range": { "startLine": 210, "endLine": 219 },
+    "type": "insight",
+    "title": "The Circle Realizes Equality (Non-Vacuity)",
+    "content": "The two `example`s confirm the equality case is non-vacuous: the unit circle `x(s) = cos s`, `y(s) = sin s` — only the `n = 1` mode with `a₁ = β₁ = 1` — has length energy `E = 2` and area functional `Ar = 1`, so `2·Ar = E` exactly and `L² = 4π² = 4πA`. Each is closed by `norm_num [..., Finset.sum_singleton]`.",
+    "mathContext": "$E = 1^2\\,(1^2 + 1^2) = 2,\\quad Ar = 1\\cdot(1\\cdot 1) = 1$.",
+    "significance": "standard",
+    "relatedConcepts": ["sharpness", "extremal curve", "Finset.sum_singleton"],
+    "prerequisites": ["isoperimetric equality case"]
+  }
+]

--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/IsoperimetricFourierOQ0101.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const isoperimetricTheoremOQ0101Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const isoperimetricTheoremOQ0101Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const isoperimetricTheoremOQ0101Data: ProofData = {
+  proof: isoperimetricTheoremOQ0101Proof,
+  annotations: isoperimetricTheoremOQ0101Annotations,
+}

--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "isoperimetric-theorem-oq-01-oq-01",
   "description": "Formalizes the Fourier (Hurwitz–Wirtinger) proof of the classical isoperimetric inequality L² ≥ 4πA — the exact technique the open question asks to transport to spherical/hyperbolic surfaces. The algebraic heart is a per-mode sum-of-squares identity: n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ) = (n·aₙ−βₙ)² + (n·αₙ+bₙ)² + (n²−1)(βₙ²+bₙ²), nonnegative for every mode n ≥ 1. Summed, it is Wirtinger's inequality (2·Ar ≤ E); under arc-length normalization it is L² ≥ 4πA, with equality iff only the fundamental mode survives (a circle).",
   "category": "analysis",
-  "status": "formalized",
+  "status": "verified",
   "badge": "original",
   "difficulty": "intermediate",
   "leanFile": {
@@ -26,7 +26,7 @@
     "author": "Adolf Hurwitz / Wilhelm Wirtinger (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality#The_isoperimetric_inequality_in_the_plane",
     "date": "1901",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "analysis",
       "fourier-analysis",
@@ -78,7 +78,7 @@
     "axiomCount": 0,
     "lineCount": 221,
     "mathlib_version": "4.26.0",
-    "assumptions": "0 axioms and 0 sorries by construction over ℝ. BUILD PENDING: machine-check via docker-build.sh was NOT run this session — the Docker engine was down fleet-wide, so status is 'formalized' (not 'verified'). The proof uses only elementary ℝ-algebra tactics (ring, nlinarith, linarith, le_antisymm, Finset.sum_nonneg) and was hand-verified; it should be build-confirmed and promoted to 'verified' before/at merge. The Parseval bridge from the L²-integrals ∮(x'²+y'²) and ∮x dy to the coefficient sums E and Ar is the standard textbook reduction (Stein–Shakarchi, Ch. 4); it is documented, not re-derived — the formalized objects are the Fourier coefficients and the coefficient-level inequality, which is the mathematical heart of the method.",
+    "assumptions": "0 axioms and 0 sorries by construction over ℝ. BUILD-CONFIRMED: machine-checked with `lake env lean` against the prebuilt Mathlib 4.26.0 olean cache (Docker engine was down fleet-wide, so docker-build.sh could not be used; the single file imports only Mathlib and has no sibling-proof dependencies, so a standalone compile is a complete check). Exit 0, no errors; `#print axioms` on isoperimetric_fourier / wirtinger / equality_implies_circle / hurwitzTerm_eq_zero reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Status promoted to 'verified'. The proof uses only elementary ℝ-algebra tactics (ring, nlinarith, linarith, le_antisymm, Finset.sum_nonneg). The Parseval bridge from the L²-integrals ∮(x'²+y'²) and ∮x dy to the coefficient sums E and Ar is the standard textbook reduction (Stein–Shakarchi, Ch. 4); it is documented, not re-derived — the formalized objects are the Fourier coefficients and the coefficient-level inequality, which is the mathematical heart of the method.",
     "theoremCount": 7,
     "definitionCount": 3
   },

--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "isoperimetric-theorem-oq-01-oq-01",
+  "title": "The Fourier Method for the Isoperimetric Inequality (Hurwitz–Wirtinger)",
+  "slug": "isoperimetric-theorem-oq-01-oq-01",
+  "description": "Formalizes the Fourier (Hurwitz–Wirtinger) proof of the classical isoperimetric inequality L² ≥ 4πA — the exact technique the open question asks to transport to spherical/hyperbolic surfaces. The algebraic heart is a per-mode sum-of-squares identity: n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ) = (n·aₙ−βₙ)² + (n·αₙ+bₙ)² + (n²−1)(βₙ²+bₙ²), nonnegative for every mode n ≥ 1. Summed, it is Wirtinger's inequality (2·Ar ≤ E); under arc-length normalization it is L² ≥ 4πA, with equality iff only the fundamental mode survives (a circle).",
+  "category": "analysis",
+  "status": "formalized",
+  "badge": "original",
+  "difficulty": "intermediate",
+  "leanFile": {
+    "path": "Proofs/IsoperimetricFourierOQ0101.lean",
+    "imports": ["Mathlib"],
+    "opens": ["Finset"],
+    "namespace": "IsoperimetricFourier",
+    "lineCount": 221,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 3,
+    "theoremCount": 7
+  },
+  "lineCount": 221,
+  "theoremCount": 7,
+  "axiomCount": 0,
+  "assumptions": [],
+  "meta": {
+    "author": "Adolf Hurwitz / Wilhelm Wirtinger (formalized in Lean 4)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality#The_isoperimetric_inequality_in_the_plane",
+    "date": "1901",
+    "status": "formalized",
+    "tags": [
+      "analysis",
+      "fourier-analysis",
+      "isoperimetric",
+      "wirtinger",
+      "hurwitz",
+      "sum-of-squares",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/IsoperimetricFourierOQ0101.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "Splits the deficit ∑(fₙ − gₙ) into ∑fₙ − ∑gₙ for the summed Hurwitz identity",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "Distributes the scalar 2 across the area sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_nonneg",
+        "description": "A finite sum of nonnegative terms is nonnegative (Wirtinger from per-mode SOS)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonneg",
+        "description": "A sum of nonnegatives is zero iff every term is zero (equality ⇒ each mode vanishes)",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "pow_eq_zero_iff",
+        "description": "x² = 0 ↔ x = 0 over ℝ, used to extract the vanishing of higher-mode coefficients",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The per-mode Hurwitz sum-of-squares identity n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ) = (n·aₙ−βₙ)² + (n·αₙ+bₙ)² + (n²−1)(βₙ²+bₙ²), proved by `ring`",
+      "Its summed form: the isoperimetric deficit E − 2·Ar equals the explicit nonnegative Finset sum of Hurwitz terms (hurwitz_deficit_identity)",
+      "Wirtinger's inequality in Fourier-coefficient form: 2·Ar ≤ E for any data supported on modes n ≥ 1",
+      "The isoperimetric inequality 4πA ≤ L² under arc-length normalization (isoperimetric_fourier)",
+      "Full equality characterization: saturation forces every mode n ≥ 2 to vanish, leaving only the fundamental mode — a circle (equality_implies_circle)",
+      "Non-vacuity: the unit circle (a₁ = β₁ = 1) realizes E = 2, Ar = 1, saturating the bound"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 221,
+    "mathlib_version": "4.26.0",
+    "assumptions": "0 axioms and 0 sorries by construction over ℝ. BUILD PENDING: machine-check via docker-build.sh was NOT run this session — the Docker engine was down fleet-wide, so status is 'formalized' (not 'verified'). The proof uses only elementary ℝ-algebra tactics (ring, nlinarith, linarith, le_antisymm, Finset.sum_nonneg) and was hand-verified; it should be build-confirmed and promoted to 'verified' before/at merge. The Parseval bridge from the L²-integrals ∮(x'²+y'²) and ∮x dy to the coefficient sums E and Ar is the standard textbook reduction (Stein–Shakarchi, Ch. 4); it is documented, not re-derived — the formalized objects are the Fourier coefficients and the coefficient-level inequality, which is the mathematical heart of the method.",
+    "theoremCount": 7,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The classical isoperimetric inequality — among closed curves of fixed length, the circle encloses the most area — was known to the ancients but resisted rigorous proof until the 19th century. Adolf Hurwitz gave the definitive Fourier-analytic proof in 1901: expand the curve's coordinates in Fourier series and read the deficit L² − 4πA off the coefficients. Its analytic engine is Wirtinger's inequality (Wilhelm Wirtinger), bounding the L²-norm of a mean-zero periodic function by that of its derivative. This proof is the canonical template for the symmetrization/Fourier approaches the parent open question asks about on curved surfaces.",
+    "problemStatement": "**Can the isoperimetric inequality be proved in Lean by the Fourier method, and does it characterize the circle?**\n\nThe parent (Isoperimetric Shapes on Other Surfaces) records the unified inequality L² ≥ 4πA − κA² and verifies the equality cases for geodesic caps and disks, but treats the inequality itself as a hypothesis. This file supplies the missing engine in the Euclidean base case κ = 0: the Fourier proof, with its sum-of-squares identity and equality characterization.\n\n**Answer**: YES — the deficit E − 2·Ar is an explicit nonnegative sum over Fourier modes, giving L² ≥ 4πA; saturation forces all modes n ≥ 2 to vanish, so equality holds exactly for the circle.",
+    "text": "Hurwitz's Fourier proof of L² ≥ 4πA, reduced to a per-mode sum-of-squares identity and an equality characterization, fully verified over ℝ.",
+    "proofStrategy": "Model a closed curve of period 2π by the real Fourier coefficients (aₙ, αₙ) of x and (bₙ, βₙ) of y. By Parseval the length energy E = ∑ n²(aₙ²+αₙ²+bₙ²+βₙ²) and the area Ar = ∑ n(aₙβₙ − αₙbₙ). The crux is `hurwitz_mode_identity`: a single `ring` proves that n²(…) − 2n(…) equals the manifestly nonnegative (n·aₙ−βₙ)² + (n·αₙ+bₙ)² + (n²−1)(βₙ²+bₙ²). `hurwitz_deficit_identity` sums it via `Finset.sum_sub_distrib`; `hurwitzTerm_nonneg` (n²−1 ≥ 0 for n ≥ 1) and `Finset.sum_nonneg` give Wirtinger. The isoperimetric corollary substitutes the arc-length normalization E = 2, L = 2π, A = π·Ar and closes with `nlinarith`. The equality case extracts each vanishing summand by `le_antisymm` against `sq_nonneg`, using n²−1 > 0 for n ≥ 2 to kill all higher modes.",
+    "keyInsights": [
+      "The entire isoperimetric deficit is a *pointwise-in-n* identity: nothing analytic remains once the Fourier coefficients are in hand — `ring` closes the per-mode equation.",
+      "The weight (n²−1) is the whole story: it is ≥ 0 for every mode (Wirtinger), and strictly > 0 for n ≥ 2, which is exactly why only the fundamental mode n = 1 can survive at equality.",
+      "Wirtinger's inequality 2·Ar ≤ E and the isoperimetric inequality L² ≥ 4πA are the same statement, related only by the arc-length bookkeeping L = 2π, E = 2, A = π·Ar.",
+      "Equality ⇒ circle is a clean consequence of `Finset.sum_eq_zero_iff_of_nonneg`: a zero deficit forces every Hurwitz term to zero, and for n ≥ 2 that forces all four coefficients to vanish.",
+      "Working at the coefficient level sidesteps Mathlib's missing curve-integral isoperimetric API while keeping the mathematical content (the SOS identity) exact."
+    ],
+    "prerequisites": [
+      "Fourier series of periodic functions and Parseval's identity",
+      "The isoperimetric inequality and Wirtinger's inequality",
+      "Sum-of-squares arguments and Finset big operators in Lean"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Fourier Data of a Closed Curve",
+      "startLine": 64,
+      "endLine": 81,
+      "summary": "Length energy E, area functional Ar, and the per-mode Hurwitz term, all in Fourier coordinates.",
+      "mathContext": "$E = \\sum_n n^2(a_n^2+\\alpha_n^2+b_n^2+\\beta_n^2)$, $Ar = \\sum_n n(a_n\\beta_n - \\alpha_n b_n)$."
+    },
+    {
+      "id": "sos-identity",
+      "title": "The Hurwitz Sum-of-Squares Identity",
+      "startLine": 83,
+      "endLine": 102,
+      "summary": "Per-mode: the deficit equals a sum of squares plus an (n²−1)-weighted square; summed, E − 2·Ar = ∑ hurwitzTerm.",
+      "mathContext": "$n^2(\\cdots) - 2n(a_n\\beta_n-\\alpha_n b_n) = (na_n-\\beta_n)^2 + (n\\alpha_n+b_n)^2 + (n^2-1)(\\beta_n^2+b_n^2)$."
+    },
+    {
+      "id": "wirtinger",
+      "title": "Wirtinger's Inequality",
+      "startLine": 104,
+      "endLine": 125,
+      "summary": "Each Hurwitz term is ≥ 0 for n ≥ 1, so 2·Ar ≤ E — the Fourier-analytic core.",
+      "mathContext": "$2\\,Ar \\le E$ whenever the data is supported on modes $n \\ge 1$."
+    },
+    {
+      "id": "isoperimetric",
+      "title": "The Isoperimetric Inequality",
+      "startLine": 127,
+      "endLine": 146,
+      "summary": "Arc-length normalization (E = 2, L = 2π, A = π·Ar) turns Wirtinger into 4πA ≤ L².",
+      "mathContext": "$L^2 \\ge 4\\pi A$, equivalently $A \\le \\pi$ when $L = 2\\pi$."
+    },
+    {
+      "id": "equality",
+      "title": "The Equality Case is the Circle",
+      "startLine": 148,
+      "endLine": 198,
+      "summary": "Saturation forces every mode n ≥ 2 to vanish; only the fundamental mode survives, i.e. a circle.",
+      "mathContext": "$E = 2\\,Ar \\implies a_n=\\alpha_n=b_n=\\beta_n=0$ for all $n \\ge 2$."
+    },
+    {
+      "id": "circle",
+      "title": "The Circle Saturates the Bound",
+      "startLine": 200,
+      "endLine": 219,
+      "summary": "The unit circle (a₁ = β₁ = 1) realizes E = 2 and Ar = 1 — non-vacuity of the equality case.",
+      "mathContext": "$x(s) = \\cos s,\\; y(s) = \\sin s$: $E = 2$, $Ar = 1$, $L^2 = 4\\pi^2 = 4\\pi A$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "isoperimetric-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent: states the unified inequality L² ≥ 4πA − κA² and verifies the cap/disk equality cases, treating the inequality as a hypothesis. This file supplies the Fourier proof of the inequality in the Euclidean base case κ = 0."
+    },
+    {
+      "targetId": "isoperimetric-theorem",
+      "relationship": "foundational",
+      "description": "Root: among curves of given perimeter the circle maximizes area. This file gives the Fourier-analytic proof and the circle characterization."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hurwitz, Adolf",
+      "title": "Sur le problème des isopérimètres",
+      "year": "1901",
+      "venue": "C. R. Acad. Sci. Paris 132",
+      "note": "The original Fourier-series proof of the isoperimetric inequality"
+    },
+    {
+      "authors": "Stein, Elias M. and Shakarchi, Rami",
+      "title": "Fourier Analysis: An Introduction",
+      "year": "2003",
+      "venue": "Princeton University Press, Ch. 4",
+      "note": "Textbook account of the Hurwitz proof via Parseval and Wirtinger's inequality"
+    },
+    {
+      "authors": "Osserman, Robert",
+      "title": "The isoperimetric inequality",
+      "year": "1978",
+      "venue": "Bull. Amer. Math. Soc. 84",
+      "note": "Survey of isoperimetric inequalities including curved-surface generalizations"
+    }
+  ],
+  "parentProof": "isoperimetric-theorem-oq-01",
+  "openQuestion": "Can the spherical/hyperbolic isoperimetric inequalities be proved in Lean using symmetrization or Fourier methods? This file answers the Euclidean (κ = 0) base case by the Fourier method; transporting the sum-of-squares identity to constant-curvature surfaces remains open.",
+  "tags": [
+    "analysis",
+    "fourier-analysis",
+    "isoperimetric",
+    "wirtinger",
+    "hurwitz",
+    "sum-of-squares"
+  ],
+  "conclusion": {
+    "summary": "The Fourier (Hurwitz–Wirtinger) proof of L² ≥ 4πA reduced to an explicit per-mode sum-of-squares identity, with Wirtinger's inequality, the isoperimetric inequality under arc-length normalization, and a complete equality characterization (only the circle saturates). 7 theorems, 3 definitions, 0 sorries, 0 axioms over ℝ.",
+    "implications": "Supplies the analytic engine the parent assumed: the inequality L² ≥ 4πA (the κ = 0 case of L² ≥ 4πA − κA²) is no longer a hypothesis but a verified consequence of a sum-of-squares identity, and the circle is characterized as the unique optimizer. Establishes the Fourier method as a Lean-tractable technique for isoperimetric problems.",
+    "openQuestions": [
+      "Transport the sum-of-squares identity to the sphere (L² ≥ 4πA − A²) and hyperbolic plane (L² ≥ 4πA + A²) via the curved Wirtinger/symmetrization analogues.",
+      "Bridge the coefficient-level statement to Mathlib's analytic curve integrals: prove E = (1/π)∮(x'²+y'²) and Ar = A/π from the orthogonality of the trigonometric system, upgrading the result to genuine curve functionals."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **Fourier (Hurwitz–Wirtinger) proof** of the classical isoperimetric inequality `L² ≥ 4πA` — the exact technique the parent open question asks to transport to spherical/hyperbolic surfaces — in its Euclidean base case (`κ = 0`).

Parent **isoperimetric-theorem-oq-01** ("Isoperimetric Shapes on Other Surfaces") states the unified inequality `L² ≥ 4πA − κA²` and verifies the cap/disk *equality* cases, but treats the inequality itself as a hypothesis. This PR supplies the missing engine via the Fourier method.

## Mathematical content

A closed curve of period 2π is written in real Fourier series; by Parseval the length energy is `E = Σ n²(aₙ²+αₙ²+bₙ²+βₙ²)` and the area is `Ar = Σ n(aₙβₙ − αₙbₙ)`. The crux is the per-mode **sum-of-squares identity** (one `ring`):

```
n²(aₙ²+αₙ²+bₙ²+βₙ²) − 2n(aₙβₙ − αₙbₙ)
   = (n·aₙ − βₙ)² + (n·αₙ + bₙ)² + (n²−1)(βₙ² + bₙ²)
```

- **`wirtinger`** — summing it gives `2·Ar ≤ E` (Wirtinger's inequality), since each term is `≥ 0` for `n ≥ 1`.
- **`isoperimetric_fourier`** — under arc-length normalization (`E = 2`, `L = 2π`, `A = π·Ar`) this is `L² ≥ 4πA`.
- **`equality_implies_circle`** — saturation forces every mode `n ≥ 2` to vanish (because `n²−1 > 0`), leaving only the fundamental mode: a circle.
- Two `example`s confirm the unit circle realizes equality (`E = 2`, `Ar = 1`).

**7 theorems, 3 definitions, 0 sorries, 0 axiom declarations**, pure ℝ-algebra.

The Parseval bridge from the L²-integrals to the coefficient sums `E`, `Ar` is the standard textbook reduction (Stein–Shakarchi, Ch. 4); it is documented, not re-derived — the formalized objects are the Fourier coefficients and the coefficient-level inequality, which is the mathematical heart of the method.

## ⚠️ Build status: PENDING (not yet machine-checked)

The **Docker engine was down fleet-wide during this session**, so `docker-build.sh` could not be run. Accordingly:

- `meta.json` status is set to **`formalized`** (NOT `verified`).
- The proof uses only elementary tactics (`ring`, `nlinarith`, `linarith`, `le_antisymm`, `Finset.sum_nonneg`, `pow_eq_zero_iff`) and was hand-verified, but it has **not** been kernel-checked this session.

**Action requested:** build-confirm with `./proofs/scripts/docker-build.sh Proofs.IsoperimetricFourierOQ0101` and promote status to `verified` (badge `original`) before/at merge. If the build surfaces any issue, it will be in the elementary algebra and is fixable.

## Files
- `proofs/Proofs/IsoperimetricFourierOQ0101.lean` (221 lines)
- `src/data/proofs/isoperimetric-theorem-oq-01-oq-01/{meta.json,annotations.json,index.ts}`