### PR TITLE
Enrich ζ(8)=π⁸/9450 (basel-problem-oq-08-oq-02-oq-01): index.ts + annotation depth

### DIFF
--- a/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "Module Header and Problem Setup",
-    "content": "The open question, posed by the parent $\\zeta(6)$ entry, asks for $\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$, the degree-8 even-zeta value, plus the π-free ratio $\\zeta(8)/\\zeta(2)^4$. Euler's 1740 formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=4$ using $B_8 = -1/30$. Mathlib formalizes the underlying Hurwitz-zeta computation as `hasSum_zeta_nat`, but stops its packaged Bernoulli evaluations at $B_4$ — so the entry must first compute $B_6$ and then $B_8$, the recurrence for $B_8$ consuming $B_6$ as a summand."
+    "content": "The open question, posed by the parent $\\zeta(6)$ entry, asks for $\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$, the degree-8 even-zeta value, plus the π-free ratio $\\zeta(8)/\\zeta(2)^4$. Euler's 1740 formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=4$ using $B_8 = -1/30$. Mathlib formalizes the underlying Hurwitz-zeta computation as `hasSum_zeta_nat`, but stops its packaged Bernoulli evaluations at $B_4$ — so the entry must first compute $B_6$ and then $B_8$, the recurrence for $B_8$ consuming $B_6$ as a summand.",
+    "mathContext": "$\\zeta(2k) = (-1)^{k+1}\\dfrac{B_{2k}(2\\pi)^{2k}}{2(2k)!}$; at $k=4$, $\\zeta(8) = \\pi^8/9450$.",
+    "significance": "key",
+    "relatedConcepts": ["Riemann zeta function", "even-argument zeta values", "Bernoulli numbers", "Basel problem", "hasSum_zeta_nat"],
+    "prerequisites": ["infinite series / tsum", "the zeta function", "ζ(6) = π⁶/945 (parent)"]
   },
   {
     "id": "baseloq08oq02oq01-bernoulli-numbers",
@@ -19,7 +23,11 @@
     },
     "type": "theorem",
     "title": "The Bernoulli Numbers B₆ = 1/42 and B₈ = −1/30",
-    "content": "`bernoulli_six` recomputes $B_6 = 1/42$ (reused here because it is a summand of the $B_8$ recurrence). `bernoulli_eight` then proves $B_8 = -1/30$ by expanding the defining recurrence $B_n = 1 - \\sum_{k<n}\\binom{n}{k}B_k/(n+1-k)$ over $k = 0,\\dots,7$: the odd terms $B_5 = B_7 = 0$ come from `bernoulli'_eq_zero_of_odd`, $B_6 = 1/42$ is bridged in via `bernoulli_eq_bernoulli'_of_ne_one`, the lower $B_0,\\dots,B_4$ are resolved by their `@[simp]` lemmas, and the binomials $\\binom{8}{1},\\dots,\\binom{8}{7} = 8,28,56,70,56,28,8$ are supplied to `norm_num`. Remarkably $B_8 = B_4 = -1/30$."
+    "content": "`bernoulli_six` recomputes $B_6 = 1/42$ (reused here because it is a summand of the $B_8$ recurrence). `bernoulli_eight` then proves $B_8 = -1/30$ by expanding the defining recurrence $B_n = 1 - \\sum_{k<n}\\binom{n}{k}B_k/(n+1-k)$ over $k = 0,\\dots,7$: the odd terms $B_5 = B_7 = 0$ come from `bernoulli'_eq_zero_of_odd`, $B_6 = 1/42$ is bridged in via `bernoulli_eq_bernoulli'_of_ne_one`, the lower $B_0,\\dots,B_4$ are resolved by their `@[simp]` lemmas, and the binomials $\\binom{8}{1},\\dots,\\binom{8}{7} = 8,28,56,70,56,28,8$ are supplied to `norm_num`. Remarkably $B_8 = B_4 = -1/30$.",
+    "mathContext": "$B_6 = 1/42$, $B_8 = -1/30$ (coincidentally $= B_4$), from $B_n = 1 - \\sum_{k<n}\\binom{n}{k}\\dfrac{B_k}{n+1-k}$ with $B_5 = B_7 = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Bernoulli numbers", "recurrence relations", "bernoulli_eq_bernoulli'_of_ne_one", "binomial coefficients", "chained computation"],
+    "prerequisites": ["the Bernoulli recurrence", "B₆ = 1/42", "vanishing of odd Bernoulli numbers"]
   },
   {
     "id": "baseloq08oq02oq01-zeta-eight",
@@ -30,7 +38,11 @@
     },
     "type": "theorem",
     "title": "The Value ζ(8) = π⁸/9450",
-    "content": "`tsum_one_div_nat_pow_eight` is the headline result $\\sum' n,\\ 1/n^8 = \\pi^8/9450$. It comes from `hasSum_one_div_nat_pow_eight`, the $k=4$ instance of `hasSum_zeta_nat`: substituting $B_8 = -1/30$ and $8! = 40320$ into $(-1)^5\\cdot 2^7\\cdot\\pi^8\\cdot B_8/8!$ gives $(-1)\\cdot 128\\cdot(-1/30)/40320 = 1/9450$. `riemannZeta_eight_eq` records the same value for the analytically continued zeta, $\\zeta(8) = \\pi^8/9450$ over $\\mathbb{C}$, via `riemannZeta_two_mul_nat`."
+    "content": "`tsum_one_div_nat_pow_eight` is the headline result $\\sum' n,\\ 1/n^8 = \\pi^8/9450$. It comes from `hasSum_one_div_nat_pow_eight`, the $k=4$ instance of `hasSum_zeta_nat`: substituting $B_8 = -1/30$ and $8! = 40320$ into $(-1)^5\\cdot 2^7\\cdot\\pi^8\\cdot B_8/8!$ gives $(-1)\\cdot 128\\cdot(-1/30)/40320 = 1/9450$. `riemannZeta_eight_eq` records the same value for the analytically continued zeta, $\\zeta(8) = \\pi^8/9450$ over $\\mathbb{C}$, via `riemannZeta_two_mul_nat`.",
+    "mathContext": "$\\sum_{n\\ge1} 1/n^8 = \\dfrac{2^7\\pi^8\\cdot(1/30)}{40320} = \\dfrac{\\pi^8}{9450}$; also $\\zeta(8) = \\pi^8/9450$ over $\\mathbb{C}$.",
+    "significance": "critical",
+    "relatedConcepts": ["ζ(8)", "even-zeta formula", "riemannZeta_two_mul_nat", "analytic continuation"],
+    "prerequisites": ["B₈ = −1/30", "the even-argument zeta formula"]
   },
   {
     "id": "baseloq08oq02oq01-ratio",
@@ -41,6 +53,10 @@
     },
     "type": "theorem",
     "title": "Euler's π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
-    "content": "`tsum_eight_div_tsum_two_pow_four` divides the even-zeta values: $\\zeta(8)/\\zeta(2)^4 = (\\pi^8/9450)/(\\pi^2/6)^4 = (\\pi^8/9450)/(\\pi^8/1296) = 1296/9450 = 24/175$. The $\\pi$ cancels entirely, leaving a rational determined only by the Bernoulli numbers $B_2 = 1/6$ and $B_8 = -1/30$. This continues the ratio chain $\\zeta(4)/\\zeta(2)^2 = 2/5$, $\\zeta(6)/\\zeta(2)^3 = 8/35$, $\\zeta(8)/\\zeta(2)^4 = 24/175$."
+    "content": "`tsum_eight_div_tsum_two_pow_four` divides the even-zeta values: $\\zeta(8)/\\zeta(2)^4 = (\\pi^8/9450)/(\\pi^2/6)^4 = (\\pi^8/9450)/(\\pi^8/1296) = 1296/9450 = 24/175$. The $\\pi$ cancels entirely, leaving a rational determined only by the Bernoulli numbers $B_2 = 1/6$ and $B_8 = -1/30$. This continues the ratio chain $\\zeta(4)/\\zeta(2)^2 = 2/5$, $\\zeta(6)/\\zeta(2)^3 = 8/35$, $\\zeta(8)/\\zeta(2)^4 = 24/175$.",
+    "mathContext": "$\\dfrac{\\zeta(8)}{\\zeta(2)^4} = \\dfrac{\\pi^8/9450}{\\pi^8/1296} = \\dfrac{1296}{9450} = \\dfrac{24}{175}$ — $\\pi$-independent.",
+    "significance": "key",
+    "relatedConcepts": ["dimensionless ratio", "cancellation of π", "ratio chain 2/5, 8/35, 24/175", "transcendence of π"],
+    "prerequisites": ["ζ(8) and ζ(2) values", "field_simp / ring"]
   }
 ]

--- a/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/index.ts
+++ b/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BaselProblemOQ08OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const baselProblemOq08Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const baselProblemOq08Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const baselProblemOq08Oq02Oq01Data: ProofData = {
+  proof: baselProblemOq08Oq02Oq01Proof,
+  annotations: baselProblemOq08Oq02Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-08-oq-02-oq-01` (quality 59, 0 prior passes).

## What changed
- **Added missing `index.ts`** — without it the proof renders 'proof not found' on the live site (highest-impact gap; meta/overview/sections/conclusion/references were already very complete).
- **Enriched all 4 annotations** with `significance`, `relatedConcepts`, `prerequisites`, and a dedicated LaTeX `mathContext` field.

## Integrity
No mathematical claims altered. meta keeps `status: verified`, `badge: mathlib`, `axiomCount: 0` — consistent with the Lean file (6 theorems, 0 sorries, 0 axioms; instantiates Mathlib's even-zeta formula, chaining B₆→B₈ from the recurrence).

JSON validated; `pnpm build` skipped (no node_modules in worktree).