### PR TITLE
research(burnside-oq040202oq02): reflection half of the bracelet Burnside sum, both parities [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -574,6 +574,7 @@ import Proofs.BurnsideCountingOQ04
 import Proofs.BurnsideCountingOQ04OQ01
 import Proofs.BurnsideCountingOQ04OQ01OQ01OQ01
 import Proofs.BurnsideCountingOQ04OQ02
+import Proofs.BurnsideCountingOQ04OQ02OQ02
 import Proofs.BurnsideCountingOQ05
 import Proofs.BurnsideCountingOQ05OQ01
 import Proofs.CantorDiagonalization

--- a/proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean
@@ -1,0 +1,270 @@
+import Mathlib.Tactic
+import Proofs.BurnsideCountingOQ04OQ02
+
+/-
+# Burnside Counting, OQ-04 → OQ-02 → OQ-02: the reflection half (odd `n`)
+
+The parent file `BurnsideCountingOQ04OQ02OQ01` evaluated the **rotation half** of the dihedral
+Burnside sum as the gcd-cycle sum `∑_i 2^{gcd(n,i)}`.  This file evaluates the **reflection
+half**
+
+      ∑_{i ∈ ZMod n} |Fix(sr i)|
+
+for **odd** `n`, completing the closed form `b(n) = (rotations + reflections)/(2n)` in that case.
+
+## The reflection involution
+
+A reflection `sr i` acts on positions by `p ↦ -i - p` (the parent's `posPerm_sr = subLeft (-i)`),
+which is the **involution** `refl i`.  A colouring is fixed by `sr i` exactly when it is constant
+on the `refl i`-orbits.  Counting the invariant `2`-colourings of *any* involution `σ` gives
+
+      |{c : α → Fin 2 // c ∘ σ = c}|  =  2 ^ ((|α| + |Fix σ|) / 2)
+
+(`card_invariant_colorings_involutive`): the orbits are fixed points (singletons) and transposed
+pairs, so `|α| = |Fix σ| + 2·(pairs)` and the number of orbits is `(|α| + |Fix σ|)/2`.
+
+## Odd `n`
+
+The fixed points of `refl i` are the solutions of `2p = -i`.  For odd `n`, `2` is a unit in
+`ZMod n`, so there is exactly **one** fixed point for every `i` (`reflFix_odd`); hence every
+reflection fixes `2^{(n+1)/2}` colourings and
+
+      ∑_{i ∈ ZMod n} |Fix(sr i)|  =  n · 2^{(n+1)/2}            (`reflection_sum_odd`).
+
+The even-`n` count (`2^{n/2+1}` and `2^{n/2}` over the two reflection classes) is the documented
+follow-up; the general per-reflection count `card_fixedBy_reflection` below applies uniformly and
+is the single ingredient that remains to be specialised by parity.
+
+`#print axioms` on the headlines confirms only `propext, Classical.choice, Quot.sound`.
+-/
+
+namespace BurnsideCountingOQ04OQ02OQ02
+
+open Finset MulAction BurnsideCountingOQ04OQ02
+
+variable {n : ℕ}
+
+/-! ### Unfolding the reflection action -/
+
+/-- The reflection `sr i` acts on a colouring by `(sr i • c) p = c (-i - p)`.  Reads off the
+parent's `smul_apply` at `g = sr i`, where `ρ (sr i) = Equiv.subLeft (-i)`, an involution. -/
+theorem reflection_smul_apply (i : ZMod n) (c : Coloring n) (p : ZMod n) :
+    ((DihedralGroup.sr i : DihedralGroup n) • c) p = c (-i - p) := by
+  rw [smul_apply]
+  congr 1
+  have hρ : (ρ (DihedralGroup.sr i) : Equiv.Perm (Pos n)) = Equiv.subLeft (-i) := rfl
+  rw [hρ, Equiv.symm_apply_eq]
+  show p = -i - (-i - p)
+  ring
+
+/-- A colouring is fixed by the reflection `sr i` iff it is symmetric about the axis:
+`c (-i - p) = c p`. -/
+theorem fixed_iff_symm (i : ZMod n) (c : Coloring n) :
+    (DihedralGroup.sr i : DihedralGroup n) • c = c ↔ ∀ p, c (-i - p) = c p := by
+  constructor
+  · intro h p
+    have := congrFun h p
+    rwa [reflection_smul_apply] at this
+  · intro h
+    funext p
+    rw [reflection_smul_apply]
+    exact h p
+
+/-! ### The reflection involution on positions -/
+
+/-- The position involution induced by the reflection `sr i`: `refl i p = -i - p`. -/
+def refl (i : ZMod n) : ZMod n → ZMod n := fun p => -i - p
+
+/-- `refl i` is an involution: `-i - (-i - p) = p`. -/
+theorem refl_involutive (i : ZMod n) : Function.Involutive (refl i) := by
+  intro p
+  show -i - (-i - p) = p
+  ring
+
+/-! ### Counting invariant 2-colourings of an arbitrary involution
+
+The orbits of an involution `σ` are singletons (fixed points) and transposed pairs.  We index
+`α` by `ℕ` and pick the smaller-indexed element of each orbit as its representative; an invariant
+colouring is freely determined by its values on the representatives.  The representatives are
+`{a : f a ≤ f (σ a)}`, whose size is `(|α| + |Fix σ|)/2` because the non-fixed points split
+evenly (via `σ`) between `f a < f (σ a)` and `f (σ a) < f a`. -/
+
+/-- **Invariant `2`-colourings of an involution.**  For an involution `σ` on a finite type,
+the number of `2`-colourings constant on `σ`-orbits is `2^{(|α| + |Fix σ|)/2}`. -/
+theorem card_invariant_colorings_involutive {α : Type*} [Fintype α] [DecidableEq α]
+    (σ : α → α) (hσ : Function.Involutive σ) :
+    Fintype.card {c : α → Fin 2 // ∀ a, c (σ a) = c a}
+      = 2 ^ ((Fintype.card α + (univ.filter (fun a => σ a = a)).card) / 2) := by
+  classical
+  -- injective index function to ℕ
+  let f : α → ℕ := fun a => (Fintype.equivFin α a).val
+  have hf_inj : Function.Injective f := fun a b h => (Fintype.equivFin α).injective (Fin.ext h)
+  -- the representative of each orbit (smaller index)
+  let rep : α → α := fun a => if f a ≤ f (σ a) then a else σ a
+  have hrep_def : ∀ a, rep a = if f a ≤ f (σ a) then a else σ a := fun _ => rfl
+  set R : Finset α := univ.filter (fun a => f a ≤ f (σ a)) with hR
+  have hrepR : ∀ a, rep a ∈ R := by
+    intro a
+    rw [hR, mem_filter]
+    refine ⟨mem_univ _, ?_⟩
+    simp only [hrep_def]
+    by_cases h : f a ≤ f (σ a)
+    · rw [if_pos h]; exact h
+    · rw [if_neg h, hσ a]; omega
+  have hrep_symm : ∀ a, rep (σ a) = rep a := by
+    intro a
+    simp only [hrep_def, hσ a]
+    rcases lt_trichotomy (f a) (f (σ a)) with h | h | h
+    · rw [if_neg (show ¬ f (σ a) ≤ f a by omega), if_pos h.le]
+    · have heq : a = σ a := hf_inj h
+      rw [if_pos (le_of_eq h.symm), if_pos (le_of_eq h)]; exact heq.symm
+    · rw [if_pos h.le, if_neg (show ¬ f a ≤ f (σ a) by omega)]
+  have hrep_mem : ∀ a, a ∈ R → rep a = a := by
+    intro a ha
+    rw [hR, mem_filter] at ha
+    rw [hrep_def, if_pos ha.2]
+  have hrep_color : ∀ (c : {c : α → Fin 2 // ∀ a, c (σ a) = c a}) a, c.1 (rep a) = c.1 a := by
+    intro c a
+    rw [hrep_def]
+    by_cases h : f a ≤ f (σ a)
+    · rw [if_pos h]
+    · rw [if_neg h]; exact c.2 a
+  -- the bijection: invariant colourings ≃ functions on representatives
+  have ecard : Fintype.card {c : α → Fin 2 // ∀ a, c (σ a) = c a}
+      = Fintype.card (R → Fin 2) := by
+    apply Fintype.card_congr
+    refine
+    { toFun := fun c r => c.1 r.1
+      invFun := fun g => ⟨fun a => g ⟨rep a, hrepR a⟩, ?_⟩
+      left_inv := ?_
+      right_inv := ?_ }
+    · intro a
+      show g ⟨rep (σ a), hrepR (σ a)⟩ = g ⟨rep a, hrepR a⟩
+      congr 1
+      exact Subtype.ext (hrep_symm a)
+    · intro c
+      apply Subtype.ext
+      funext a
+      exact hrep_color c a
+    · intro g
+      funext r
+      show g ⟨rep r.1, hrepR r.1⟩ = g r
+      congr 1
+      exact Subtype.ext (hrep_mem r.1 r.2)
+  rw [ecard, Fintype.card_fun, Fintype.card_fin, Fintype.card_coe]
+  congr 1
+  -- count the representatives
+  set Fix : Finset α := univ.filter (fun a => σ a = a) with hFix
+  set L : Finset α := univ.filter (fun a => f a < f (σ a)) with hL
+  set G : Finset α := univ.filter (fun a => f (σ a) < f a) with hG
+  -- R = L ∪ Fix (disjoint)
+  have hRLF : R.card = L.card + Fix.card := by
+    have hdisj : Disjoint L Fix := by
+      rw [hL, hFix, Finset.disjoint_filter]
+      intro a _ h1 h2
+      rw [h2] at h1
+      exact absurd h1 (lt_irrefl _)
+    have hpred : R = L ∪ Fix := by
+      rw [hR, hL, hFix, ← Finset.filter_or]
+      apply Finset.filter_congr
+      intro a _
+      constructor
+      · intro h
+        rcases lt_or_eq_of_le h with h' | h'
+        · exact Or.inl h'
+        · exact Or.inr (hf_inj h').symm
+      · rintro (h | h)
+        · exact h.le
+        · exact le_of_eq (congrArg f h).symm
+    rw [hpred, Finset.card_union_of_disjoint hdisj]
+  -- |R| + |G| = |α|
+  have hRG : R.card + G.card = Fintype.card α := by
+    have hGeq : G = univ.filter (fun a => ¬ f a ≤ f (σ a)) := by
+      rw [hG]
+      apply Finset.filter_congr
+      intro a _
+      exact not_le.symm
+    rw [hR, hGeq, filter_card_add_filter_neg_card_eq_card, Finset.card_univ]
+  -- |L| = |G| via σ
+  have hLG : L.card = G.card := by
+    rw [hL, hG]
+    apply Finset.card_nbij' σ σ
+    · intro a ha
+      simp only [Finset.mem_coe, mem_filter, mem_univ, true_and] at ha ⊢
+      rw [hσ a]; exact ha
+    · intro a ha
+      simp only [Finset.mem_coe, mem_filter, mem_univ, true_and] at ha ⊢
+      rw [hσ a]; exact ha
+    · intro a _; exact hσ a
+    · intro a _; exact hσ a
+  omega
+
+/-! ### The per-reflection fixed-colouring count -/
+
+/-- The number of positions fixed by `refl i`, i.e. solutions of `2p = -i`. -/
+def reflFix [NeZero n] (i : ZMod n) : ℕ := (univ.filter (fun p : ZMod n => refl i p = p)).card
+
+/-- **Per-reflection count.**  The number of colourings fixed by `sr i` is `2^{(n + reflFix i)/2}`:
+they are the `2`-colourings invariant under the involution `refl i`. -/
+theorem card_fixedBy_reflection [NeZero n] (i : ZMod n) :
+    Fintype.card (fixedBy (Coloring n) (DihedralGroup.sr i))
+      = 2 ^ ((n + reflFix i) / 2) := by
+  classical
+  have e : ↥(fixedBy (Coloring n) (DihedralGroup.sr i))
+      ≃ {c : Coloring n // ∀ p, c (refl i p) = c p} :=
+    Equiv.subtypeEquivRight (fun c => by rw [mem_fixedBy]; exact fixed_iff_symm i c)
+  rw [Fintype.card_congr e, card_invariant_colorings_involutive (refl i) (refl_involutive i),
+    ZMod.card]
+  rfl
+
+/-! ### Odd `n`: every reflection fixes `2^{(n+1)/2}` colourings -/
+
+/-- For odd `n`, the involution `refl i` has a **unique** fixed point (`2` is a unit in `ZMod n`),
+so `reflFix i = 1`. -/
+theorem reflFix_odd [NeZero n] (hn : Odd n) (i : ZMod n) : reflFix i = 1 := by
+  -- `2` is a unit in `ZMod n` for odd `n`
+  have h2unit : IsUnit (2 : ZMod n) := by
+    have h2 : (2 : ZMod n) = ((2 : ℕ) : ZMod n) := by norm_cast
+    rw [h2, ZMod.isUnit_iff_coprime]
+    exact Nat.coprime_two_left.mpr hn
+  obtain ⟨u, hu⟩ := h2unit
+  -- multiplication by the unit `2` is a bijection, so `2p = -i` has a unique solution
+  have hbij : Function.Bijective (fun p : ZMod n => (2 : ZMod n) * p) := by
+    have hb := Units.mulLeft_bijective u
+    rwa [hu] at hb
+  obtain ⟨p₀, hp₀, huniq⟩ := hbij.existsUnique (-i)
+  -- `refl i p = p` is exactly `2p = -i`
+  have hcond : ∀ p : ZMod n, refl i p = p ↔ (2 : ZMod n) * p = -i := by
+    intro p
+    simp only [refl]
+    constructor
+    · intro h; linear_combination -h
+    · intro h; linear_combination -h
+  rw [reflFix, Finset.card_eq_one]
+  refine ⟨p₀, ?_⟩
+  ext p
+  simp only [mem_filter, mem_univ, true_and, mem_singleton, hcond]
+  constructor
+  · intro h; exact huniq p h
+  · intro h; subst h; exact hp₀
+
+/-- **The reflection half for odd `n`.**
+
+      ∑_{i ∈ ZMod n} |Fix(sr i)|  =  n · 2^{(n+1)/2}. -/
+theorem reflection_sum_odd [NeZero n] (hn : Odd n) :
+    ∑ i : ZMod n, Fintype.card (fixedBy (Coloring n) (DihedralGroup.sr i))
+      = n * 2 ^ ((n + 1) / 2) := by
+  have h1 : ∀ i : ZMod n,
+      Fintype.card (fixedBy (Coloring n) (DihedralGroup.sr i)) = 2 ^ ((n + 1) / 2) := by
+    intro i
+    rw [card_fixedBy_reflection, reflFix_odd hn i]
+  rw [Finset.sum_congr rfl (fun i _ => h1 i), Finset.sum_const, Finset.card_univ, ZMod.card,
+    smul_eq_mul]
+
+end BurnsideCountingOQ04OQ02OQ02
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms BurnsideCountingOQ04OQ02OQ02.card_invariant_colorings_involutive
+#print axioms BurnsideCountingOQ04OQ02OQ02.card_fixedBy_reflection
+#print axioms BurnsideCountingOQ04OQ02OQ02.reflection_sum_odd

--- a/proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean
@@ -10,7 +10,7 @@ half**
 
       ∑_{i ∈ ZMod n} |Fix(sr i)|
 
-for **odd** `n`, completing the closed form `b(n) = (rotations + reflections)/(2n)` in that case.
+for **both parities** of `n`, completing the closed form `b(n) = (rotations + reflections)/(2n)`.
 
 ## The reflection involution
 
@@ -31,9 +31,14 @@ reflection fixes `2^{(n+1)/2}` colourings and
 
       ∑_{i ∈ ZMod n} |Fix(sr i)|  =  n · 2^{(n+1)/2}            (`reflection_sum_odd`).
 
-The even-`n` count (`2^{n/2+1}` and `2^{n/2}` over the two reflection classes) is the documented
-follow-up; the general per-reflection count `card_fixedBy_reflection` below applies uniformly and
-is the single ingredient that remains to be specialised by parity.
+For **even** `n`, doubling has the two-element kernel `{0, n/2}`, so `reflFix i ∈ {0, 2}`; since
+`∑_i reflFix i = n` (each position is the unique fixed point of one axis), exactly `n/2` of the
+reflections carry a fixed pair, giving
+
+      ∑_{i ∈ ZMod n} |Fix(sr i)|  =  3 · (n/2) · 2^{n/2}            (`reflection_sum_even`).
+
+The general per-reflection count `card_fixedBy_reflection` below applies uniformly and is the
+single ingredient specialised by parity (`reflFix_odd` / `reflFix_even`).
 
 `#print axioms` on the headlines confirms only `propext, Classical.choice, Quot.sound`.
 -/
@@ -261,6 +266,166 @@ theorem reflection_sum_odd [NeZero n] (hn : Odd n) :
   rw [Finset.sum_congr rfl (fun i _ => h1 i), Finset.sum_const, Finset.card_univ, ZMod.card,
     smul_eq_mul]
 
+/-! ### Even `n`: reflections split by parity
+
+For even `n = 2m` (`m := n/2`), doubling `p ↦ 2p` on `ZMod n` has the two-element kernel
+`{0, m}`, so `2p = -i` has either `0` or exactly `2` solutions: `reflFix i ∈ {0, 2}`.  The
+*total* `∑_i reflFix i = n` (each position `p` is the unique fixed point of exactly one axis
+`i = -2p`), which forces exactly `n/2` of the reflections to be the "even" ones with
+`reflFix = 2`.  Hence
+
+      ∑_{i} |Fix(sr i)|  =  (n/2)·2^{n/2+1} + (n/2)·2^{n/2}  =  3·(n/2)·2^{n/2}.
+-/
+
+/-- For even `n = 2m`, doubling on `ZMod n` has kernel exactly `{0, (m : ZMod n)}`. -/
+theorem two_mul_eq_zero_iff [NeZero n] (hn : Even n) (p : ZMod n) :
+    (2 : ZMod n) * p = 0 ↔ p = 0 ∨ p = ((n / 2 : ℕ) : ZMod n) := by
+  obtain ⟨m, hm⟩ := hn                       -- n = m + m
+  have hn2 : n = 2 * m := by omega
+  have hmpos : 0 < m := by
+    have := NeZero.pos n; omega
+  have hhalf : n / 2 = m := by omega
+  constructor
+  · intro h
+    -- 2 * p = 0  ⇒  n ∣ 2 * p.val  ⇒  m ∣ p.val  ⇒  p.val ∈ {0, m}
+    have hp : ((2 * p.val : ℕ) : ZMod n) = 0 := by
+      push_cast
+      rw [ZMod.natCast_rightInverse p]; exact h
+    rw [ZMod.natCast_eq_zero_iff] at hp
+    have hdvd : m ∣ p.val := by
+      -- `n = 2m` and `n ∣ 2·p.val` give `2·p.val = 2·(m·c)`, so `p.val = m·c`.
+      obtain ⟨c, hc⟩ := hp
+      refine ⟨c, ?_⟩
+      have h2 : 2 * p.val = 2 * (m * c) := by rw [hc, hn2]; ring
+      omega
+    have hlt : p.val < n := ZMod.val_lt p
+    obtain ⟨k, hk⟩ := hdvd
+    have hk2 : k < 2 := by
+      rw [hk, hn2] at hlt
+      by_contra hcon
+      push_neg at hcon
+      have : 2 * m ≤ m * k := by nlinarith
+      omega
+    have hinv := ZMod.natCast_rightInverse (n := n) p   -- ↑(p.val) = p
+    interval_cases k
+    · left
+      have h0 : p.val = 0 := by omega
+      rw [← hinv, h0, Nat.cast_zero]
+    · right
+      have h1 : p.val = m := by omega
+      rw [← hinv, h1, hhalf]
+  · rintro (h | h)
+    · rw [h, mul_zero]
+    · rw [h, hhalf]
+      have : (2 : ZMod n) * (m : ZMod n) = ((2 * m : ℕ) : ZMod n) := by push_cast; ring
+      rw [this, ← hn2, ZMod.natCast_self]
+
+/-- For even `n`, the involution `refl i` has either `0` or exactly `2` fixed points: the
+solution set of `2p = -i` is empty or a coset of the kernel `{0, n/2}`. -/
+theorem reflFix_even [NeZero n] (hn : Even n) (i : ZMod n) :
+    reflFix i = 0 ∨ reflFix i = 2 := by
+  classical
+  rw [reflFix]
+  by_cases hne : (univ.filter (fun p : ZMod n => refl i p = p)).Nonempty
+  · right
+    obtain ⟨p₀, hp₀⟩ := hne
+    rw [mem_filter] at hp₀
+    have hp₀eq : (2 : ZMod n) * p₀ = -i := by
+      have h := hp₀.2; simp only [refl] at h; linear_combination -h
+    have hmne : ((n / 2 : ℕ) : ZMod n) ≠ 0 := by
+      rw [Ne, ZMod.natCast_eq_zero_iff]
+      intro hdvd
+      have hpos := NeZero.pos n
+      obtain ⟨k, hk⟩ := hn
+      have h1 : 0 < n / 2 := by omega
+      have h2 : n / 2 < n := by omega
+      exact absurd (Nat.le_of_dvd h1 hdvd) (by omega)
+    have hm2 : (2 : ZMod n) * ((n / 2 : ℕ) : ZMod n) = 0 :=
+      (two_mul_eq_zero_iff hn _).2 (Or.inr rfl)
+    have hset : (univ.filter (fun p : ZMod n => refl i p = p))
+        = {p₀, p₀ + ((n / 2 : ℕ) : ZMod n)} := by
+      ext p
+      simp only [mem_filter, mem_univ, true_and, mem_insert, mem_singleton, refl]
+      constructor
+      · intro hp
+        have h2p : (2 : ZMod n) * (p - p₀) = 0 := by linear_combination -hp - hp₀eq
+        rcases (two_mul_eq_zero_iff hn _).1 h2p with h | h
+        · left; linear_combination h
+        · right; linear_combination h
+      · rintro (h | h)
+        · subst h; linear_combination -hp₀eq
+        · subst h; linear_combination -hp₀eq - hm2
+    rw [hset, Finset.card_insert_of_notMem (by
+          simp only [mem_singleton]
+          intro hc
+          exact hmne (by linear_combination -hc)), Finset.card_singleton]
+  · left
+    rw [Finset.not_nonempty_iff_eq_empty.1 hne, Finset.card_empty]
+
+/-- The total of all fixed-point counts is `n`: each position `p` is the unique fixed point of
+the single reflection axis `i = -2p`.  (Holds for every `n`; we use it for even `n`.) -/
+theorem reflFix_sum [NeZero n] : ∑ i : ZMod n, reflFix i = n := by
+  classical
+  have hcard : ∑ i : ZMod n, reflFix i
+      = ∑ i : ZMod n, ∑ p : ZMod n, (if refl i p = p then (1 : ℕ) else 0) := by
+    simp only [reflFix, Finset.card_filter]
+  rw [hcard, Finset.sum_comm]
+  have hp : ∀ p : ZMod n, ∑ i : ZMod n, (if refl i p = p then (1 : ℕ) else 0) = 1 := by
+    intro p
+    have hset : (univ.filter (fun i : ZMod n => refl i p = p)) = {-(2 * p)} := by
+      ext i
+      simp only [mem_filter, mem_univ, true_and, mem_singleton, refl]
+      constructor
+      · intro h; linear_combination -h
+      · intro h; rw [h]; ring
+    rw [← Finset.card_filter, hset, Finset.card_singleton]
+  rw [Finset.sum_congr rfl (fun p _ => hp p), Finset.sum_const, Finset.card_univ, ZMod.card,
+    smul_eq_mul, mul_one]
+
+/-- For even `n`, exactly `n/2` of the reflections have a (doubled) fixed pair, because
+`∑_i reflFix i = n` and every `reflFix i ∈ {0, 2}`. -/
+theorem card_even_reflections [NeZero n] (hn : Even n) :
+    (univ.filter (fun i : ZMod n => reflFix i = 2)).card = n / 2 := by
+  classical
+  have heq : ∑ i : ZMod n, reflFix i
+      = ∑ i : ZMod n, (if reflFix i = 2 then (2 : ℕ) else 0) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rcases reflFix_even hn i with h | h <;> simp [h]
+  have h2 : ∑ i : ZMod n, (if reflFix i = 2 then (2 : ℕ) else 0)
+      = 2 * (univ.filter (fun i : ZMod n => reflFix i = 2)).card := by
+    rw [← Finset.sum_filter, Finset.sum_const, smul_eq_mul, mul_comm]
+  have hkey : 2 * (univ.filter (fun i : ZMod n => reflFix i = 2)).card = n := by
+    rw [← h2, ← heq, reflFix_sum]
+  omega
+
+/-- **The reflection half for even `n`.**
+
+      ∑_{i ∈ ZMod n} |Fix(sr i)|  =  3 · (n/2) · 2^{n/2}. -/
+theorem reflection_sum_even [NeZero n] (hn : Even n) :
+    ∑ i : ZMod n, Fintype.card (fixedBy (Coloring n) (DihedralGroup.sr i))
+      = 3 * (n / 2) * 2 ^ (n / 2) := by
+  classical
+  -- Write each term additively so only the *positive* filter `{i : reflFix i = 2}` appears.
+  have hterm : ∀ i : ZMod n, Fintype.card (fixedBy (Coloring n) (DihedralGroup.sr i))
+      = 2 ^ (n / 2) + (if reflFix i = 2 then 2 ^ (n / 2) else 0) := by
+    intro i
+    rw [card_fixedBy_reflection]
+    rcases reflFix_even hn i with h | h
+    · rw [h, if_neg (by norm_num)]
+      simp                                             -- 2^((n+0)/2) = 2^(n/2) + 0
+    · rw [h, if_pos rfl, show (n + 2) / 2 = n / 2 + 1 by omega, pow_succ]
+      ring                                             -- 2^(n/2)*2 = 2^(n/2) + 2^(n/2)
+  rw [Finset.sum_congr rfl (fun i _ => hterm i), Finset.sum_add_distrib, Finset.sum_const,
+    ← Finset.sum_filter, Finset.sum_const, Finset.card_univ, ZMod.card,
+    card_even_reflections hn, smul_eq_mul, smul_eq_mul]
+  -- goal: n * 2^(n/2) + (n/2) * 2^(n/2) = 3 * (n/2) * 2^(n/2)
+  obtain ⟨k, hk⟩ := hn
+  have hsum : n + n / 2 = 3 * (n / 2) := by omega
+  calc n * 2 ^ (n / 2) + n / 2 * 2 ^ (n / 2)
+      = (n + n / 2) * 2 ^ (n / 2) := by ring
+    _ = 3 * (n / 2) * 2 ^ (n / 2) := by rw [hsum]
+
 end BurnsideCountingOQ04OQ02OQ02
 
 -- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
@@ -268,3 +433,4 @@ end BurnsideCountingOQ04OQ02OQ02
 #print axioms BurnsideCountingOQ04OQ02OQ02.card_invariant_colorings_involutive
 #print axioms BurnsideCountingOQ04OQ02OQ02.card_fixedBy_reflection
 #print axioms BurnsideCountingOQ04OQ02OQ02.reflection_sum_odd
+#print axioms BurnsideCountingOQ04OQ02OQ02.reflection_sum_even

--- a/research/problems/burnside-counting-oq-04-oq-02-oq-02/knowledge.md
+++ b/research/problems/burnside-counting-oq-04-oq-02-oq-02/knowledge.md
@@ -1,0 +1,60 @@
+# burnside-counting-oq-04-oq-02-oq-02 — Reflection half of the dihedral bracelet count
+
+## Goal
+Evaluate Σᵢ |Fix(sr i)| (reflection contribution to the dihedral Burnside sum) by parity of n,
+completing the closed form b(n) = (rotationSum + reflectionSum)/(2n) built in parent OQ-04-OQ-02-OQ-01.
+
+## Worked-out mathematics (complete)
+Reflection `sr i` acts on positions by the involution σ_i(p) = -i - p (from posPerm_sr = subLeft(-i)).
+A colouring is fixed by sr i ⟺ constant on σ_i-orbits.
+#σ_i-orbits = (n + f_i)/2 where f_i = #{p : 2p = -i} (fixed points of σ_i).
+So |Fix(sr i)| = 2^((n+f_i)/2).
+
+f_i by parity of n:
+- n odd: 2 is a unit ⟹ f_i = 1 for all i ⟹ |Fix| = 2^((n+1)/2).
+  Σ = n·2^((n+1)/2).
+- n even: f_i = 2 if i has even val (i in image of doubling), else 0; n/2 of each.
+  even-val i: 2^(n/2+1); odd-val i: 2^(n/2).
+  Σ = (n/2)·2^(n/2+1) + (n/2)·2^(n/2) = (3n/2)·2^(n/2).
+
+## Linchpin lemma (proved, elementary)
+`card_invariant_colorings_involutive`: for an involution σ on a Fintype α,
+|{c : α → Fin 2 // ∀a, c(σ a)=c a}| = 2^((|α| + |Fix σ|)/2).
+Proof avoids group actions / Burnside / orbit-quotient Fintype instances entirely:
+- index α by ℕ via Fintype.equivFin (f a = (equivFin a).val), injective;
+- representative rep a = the smaller-f element of {a, σ a}; reps = R = filter (f a ≤ f(σ a));
+- invariant colourings ≃ (R → Fin 2)  [explicit Equiv: restrict to reps / pull back via rep];
+- |R| = (|α|+|Fix|)/2 from: R = L ∪ Fix (L = filter f a<f(σa)); R.card+G.card=|α|
+  (G = filter f(σa)<fa = complement of R); |L|=|G| via the σ-bijection (Finset.card_nbij'); omega.
+Key API: Fintype.card_fun, Fintype.card_coe, filter_card_add_filter_neg_card_eq_card,
+Finset.card_nbij', Finset.filter_or, Finset.card_union_of_disjoint, lt_trichotomy.
+
+## Session 1 (FRESH) — 2026-06-25
+- Read parent (rotation half = Σ 2^gcd(n,i)) and grandparent (dihedral action; bracelet_burnside).
+- Wrote proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean: structural lemmas
+  (reflection_smul_apply, fixed_iff_symm, refl, refl_involutive), the linchpin
+  card_invariant_colorings_involutive, the per-reflection count card_fixedBy_reflection
+  (= 2^((n+reflFix i)/2)), reflFix_odd (= 1 via (2:ZMod n) unit / Units.mulLeft_bijective /
+  Bijective.existsUnique), and reflection_sum_odd (= n·2^((n+1)/2)).
+- reflFix_odd API: ZMod.isUnit_iff_coprime, Nat.coprime_two_left.mpr, Units.mulLeft_bijective,
+  Bijective.existsUnique, Finset.card_eq_one, linear_combination for refl i p = p ↔ 2p = -i.
+
+## !! BLOCKER — UNVERIFIED !!
+Docker Desktop daemon was DOWN host-wide this entire session ("ERROR: Docker daemon is not
+running"); the whole researcher fleet's builds were gridlocked (docker info → 0 containers,
+docker version server unreachable). `./proofs/scripts/docker-build.sh` could not run.
+The file is written and carefully reviewed but HAS NOT BEEN BUILT/VERIFIED.
+Do NOT open a PR or claim "verified" until a build passes and `#print axioms` shows only
+propext/Classical.choice/Quot.sound. Aristotle MCP was also down ("Resource not found").
+
+## Next steps (for a session with Docker up)
+1. Build proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean; fix any errors (likely spots:
+   Equiv.subtypeEquivRight defeq for refl vs -i-p; the `show` lines in the Equiv; card_nbij'
+   MapsTo simp set; linear_combination signs in hcond).
+2. Add the EVEN-n case: reflFix_even (0 or 2 by parity of i.val), count #{i : even val}=n/2,
+   reflection_sum_even = (3n/2)·2^(n/2). Even count needs the doubling-map kernel {0,n/2}.
+3. Combine with parent rotation sum for the full b(n) closed form (optional follow-up).
+4. Gallery entry src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/ + meta.json, then PR.
+
+## Branch
+WIP committed to branch `research/burnside-reflection-half-oq04020202` (NO PR — unverified).

--- a/research/problems/burnside-counting-oq-04-oq-02-oq-02/knowledge.md
+++ b/research/problems/burnside-counting-oq-04-oq-02-oq-02/knowledge.md
@@ -39,22 +39,37 @@ Finset.card_nbij', Finset.filter_or, Finset.card_union_of_disjoint, lt_trichotom
 - reflFix_odd API: ZMod.isUnit_iff_coprime, Nat.coprime_two_left.mpr, Units.mulLeft_bijective,
   Bijective.existsUnique, Finset.card_eq_one, linear_combination for refl i p = p ↔ 2p = -i.
 
-## !! BLOCKER — UNVERIFIED !!
-Docker Desktop daemon was DOWN host-wide this entire session ("ERROR: Docker daemon is not
-running"); the whole researcher fleet's builds were gridlocked (docker info → 0 containers,
-docker version server unreachable). `./proofs/scripts/docker-build.sh` could not run.
-The file is written and carefully reviewed but HAS NOT BEEN BUILT/VERIFIED.
-Do NOT open a PR or claim "verified" until a build passes and `#print axioms` shows only
-propext/Classical.choice/Quot.sound. Aristotle MCP was also down ("Resource not found").
+## Session 2 — 2026-06-25 — COMPLETE & VERIFIED (both parities)
+- Odd case built clean as written (no errors). Added the EVEN-n case:
+  - two_mul_eq_zero_iff: doubling kernel on ZMod (2m) is exactly {0, m}.
+  - reflFix_even: reflFix i ∈ {0, 2} (solution set of 2p=-i is empty or a {0,n/2}-coset).
+  - reflFix_sum: Σ_i reflFix i = n for every n, by a fiberwise Finset.sum_comm count
+    (each bead is the unique fixed point of one axis i=-2p).
+  - card_even_reflections: #{i : reflFix i = 2} = n/2 (omega from 2·#=n and each term∈{0,2}).
+  - reflection_sum_even: Σ_i |Fix(sr i)| = 3·(n/2)·2^(n/2), via an ADDITIVE split of the term
+    (2^(n/2) + if reflFix i=2 then 2^(n/2) else 0) that uses only the positive filter and
+    dodges the un-beta-reduced negated filter from Finset.sum_ite.
+- n=6 sanity: 3·3·8 = 72 (parent `decide`: Dihedral 6 total = 156).
 
-## Next steps (for a session with Docker up)
-1. Build proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean; fix any errors (likely spots:
-   Equiv.subtypeEquivRight defeq for refl vs -i-p; the `show` lines in the Equiv; card_nbij'
-   MapsTo simp set; linear_combination signs in hcond).
-2. Add the EVEN-n case: reflFix_even (0 or 2 by parity of i.val), count #{i : even val}=n/2,
-   reflection_sum_even = (3n/2)·2^(n/2). Even count needs the doubling-map kernel {0,n/2}.
-3. Combine with parent rotation sum for the full b(n) closed form (optional follow-up).
-4. Gallery entry src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/ + meta.json, then PR.
+## VERIFICATION (Docker down → single-file lake env)
+Docker Desktop VM was hung host-wide again (`docker info` HANGS; whole fleet piled up zombie
+docker info; `open -a Docker` did not revive in time). Verified anyway WITHOUT docker-build:
+  cd /Users/rwalters/GitHub/lean-genius/proofs && lake env lean <worktree-abs-path>
+`lake env` is an explicit SAFE pass-through in proofs/bin/lake (only `lake build` is blocked);
+it elaborates ONE file against main's prebuilt .lake oleans (parent + Mathlib), bounded memory,
+and runs the `#print axioms` lines. RESULT: all four headlines
+(card_invariant_colorings_involutive, card_fixedBy_reflection, reflection_sum_odd,
+reflection_sum_even) depend only on [propext, Classical.choice, Quot.sound] — no sorryAx, no
+Lean.ofReduceBool. 0 axioms, 0 sorries, 12 thm / 2 def / 436 lines.
+
+Lean fixes: `rw [hn2] at hp` (hp:n∣2*p.val) fails motive (p.val type depends on n) → obtain
+the witness and finish with omega; `congr 1; omega` → "No goals" (congr already closed defeq)
+→ `simp`; deprecations natCast_zmod_eq_zero_iff_dvd→natCast_eq_zero_iff,
+card_insert_of_not_mem→card_insert_of_notMem.
+
+## Status: registered in Proofs.lean; gallery entry
+src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/ (meta.json + annotations.json) created;
+status verified / badge original / axiomCount 0. PR opened.
 
 ## Branch
-WIP committed to branch `research/burnside-reflection-half-oq04020202` (NO PR — unverified).
+`research/burnside-reflection-half-oq04020202`.

--- a/src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "burnside-oq040202-ann-symm",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-02",
+    "range": { "startLine": 52, "endLine": 88 },
+    "type": "technique",
+    "title": "Fixed-by-reflection is a symmetry condition",
+    "content": "reflection_smul_apply unfolds the parent's dihedral colouring action at a reflection: since the position permutation ρ(sr i) = Equiv.subLeft (-i) is the involution p ↦ -i - p, the action reads (sr i • c) p = c (-i - p). fixed_iff_symm then recasts the fixed-point equation sr i • c = c as the symmetry ∀ p, c (-i - p) = c p. This is the bridge that turns a question about a group action into an involution-orbit count: a fixed colouring is one that is constant on the orbits of refl i : p ↦ -i - p (recorded as the involution refl_involutive).",
+    "mathContext": "$(sr_i \\bullet c)(p) = c(-i - p)$, so $sr_i \\bullet c = c \\iff \\forall p,\\; c(-i-p) = c(p)$, i.e. $c$ is constant on the orbits of the involution $p \\mapsto -i-p$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed points of a group action", "Equiv.subLeft", "involution", "reflection symmetry"],
+    "prerequisites": ["group actions", "permutations of ZMod n"]
+  },
+  {
+    "id": "burnside-oq040202-ann-involution-count",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-02",
+    "range": { "startLine": 89, "endLine": 206 },
+    "type": "insight",
+    "title": "Counting invariant 2-colourings of any involution, elementarily",
+    "content": "card_invariant_colorings_involutive is the structural heart: for ANY involution σ on a finite type α, the 2-colourings constant on σ-orbits number 2^{(|α| + |Fix σ|)/2}. The proof deliberately avoids group actions, Burnside, and orbit-quotient Fintype instances. Instead it indexes α through ℕ by f a = (Fintype.equivFin α a).val (injective), and chooses for each orbit {a, σ a} the smaller-indexed element as representative, rep a = if f a ≤ f (σ a) then a else σ a. Invariant colourings biject with arbitrary functions on the representative set R = {a : f a ≤ f (σ a)} (forward: restrict; backward: pull back along rep, well-defined because rep is σ-invariant and constant on R). The count |R| = (|α| + |Fix σ|)/2 follows by pure finite arithmetic: R = L ∪ Fix is disjoint (L = {f a < f (σ a)}), R.card + G.card = |α| (G = {f (σ a) < f a} is the complement of R), and |L| = |G| because σ is a bijection swapping L and G; omega closes it.",
+    "mathContext": "An involution's orbits are fixed points (singletons) and transposed pairs, so the number of orbits is $(|\\alpha| + |\\mathrm{Fix}\\,\\sigma|)/2$ and the invariant 2-colourings number $2^{(|\\alpha| + |\\mathrm{Fix}\\,\\sigma|)/2}$.",
+    "significance": "central",
+    "relatedConcepts": ["involution orbit structure", "Fintype.equivFin", "orbit representatives", "Finset.card_nbij'", "double counting"],
+    "prerequisites": ["finite cardinality arithmetic", "explicit bijections between Fintypes"]
+  },
+  {
+    "id": "burnside-oq040202-ann-perreflection",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-02",
+    "range": { "startLine": 207, "endLine": 224 },
+    "type": "technique",
+    "title": "The per-reflection count reduces to a doubling-map fiber",
+    "content": "card_fixedBy_reflection specialises the involution count to refl i, giving |Fix(sr i)| = 2^{(n + reflFix i)/2}, where reflFix i = #{p : refl i p = p} = #{p : 2p = -i} is the number of fixed beads. The reduction is an Equiv.subtypeEquivRight from the fixed set of sr i to the invariant colourings of refl i (via fixed_iff_symm), followed by card_invariant_colorings_involutive and ZMod.card. Everything about the parity of n is now isolated in the single arithmetic quantity reflFix i — the size of the fiber of the doubling map p ↦ 2p over -i.",
+    "mathContext": "$|\\mathrm{Fix}(sr_i)| = 2^{(n + f_i)/2}$ with $f_i = \\#\\{p : 2p = -i\\}$, the fiber of doubling over $-i$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv.subtypeEquivRight", "fibers of the doubling map", "ZMod.card"],
+    "prerequisites": ["the involution count", "ZMod n arithmetic"]
+  },
+  {
+    "id": "burnside-oq040202-ann-parity",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-02",
+    "range": { "startLine": 225, "endLine": 366 },
+    "type": "insight",
+    "title": "Parity of n controls the fixed-bead count",
+    "content": "The fiber count reflFix i = #{p : 2p = -i} depends entirely on the doubling map p ↦ 2p on ZMod n. For ODD n, 2 is a unit (ZMod.isUnit_iff_coprime with Nat.coprime_two_left), so doubling is a bijection (Units.mulLeft_bijective) and 2p = -i has a unique solution: reflFix_odd gives reflFix i = 1 for every axis. For EVEN n = 2m, two_mul_eq_zero_iff pins the doubling kernel to exactly {0, m}, so the solution set of 2p = -i is empty or a coset of {0, n/2}: reflFix_even gives reflFix i ∈ {0, 2}. The even case never needs to identify which axes have a fixed pair pointwise — it only needs the count.",
+    "mathContext": "Odd $n$: $2 \\in (\\mathbb{Z}/n)^\\times$, so $f_i = 1$. Even $n = 2m$: $\\ker(\\cdot 2) = \\{0, m\\}$, so $f_i \\in \\{0, 2\\}$.",
+    "significance": "central",
+    "relatedConcepts": ["units in ZMod n", "doubling kernel", "coset of a kernel", "coprimality with 2"],
+    "prerequisites": ["units and bijections", "ZMod.natCast_eq_zero_iff"]
+  },
+  {
+    "id": "burnside-oq040202-ann-doublecount",
+    "proofId": "burnside-counting-oq-04-oq-02-oq-02",
+    "range": { "startLine": 367, "endLine": 428 },
+    "type": "technique",
+    "title": "A fiberwise double-count fixes the even-n split",
+    "content": "The even reflection sum needs to know how many of the n reflections have a fixed pair. reflFix_sum proves Σ_{i∈ZMod n} reflFix i = n for EVERY n by a fiberwise double-count: writing reflFix i = Σ_p [refl i p = p] and swapping sums (Finset.sum_comm) gives Σ_p Σ_i [2p = -i] = Σ_p 1 = n, because for each bead p exactly one axis i = -2p has it as fixed point. With reflFix i ∈ {0, 2} (reflFix_even) this forces exactly n/2 reflections with reflFix i = 2 (card_even_reflections, by omega from 2·#{i} = n). reflection_sum_even then writes each term additively as 2^{n/2} + (if reflFix i = 2 then 2^{n/2} else 0) — using only the positive filter, avoiding the negated filter from Finset.sum_ite — and sums to 3·(n/2)·2^{n/2}.",
+    "mathContext": "$\\sum_i f_i = \\#\\{(i,p) : 2p = -i\\} = \\sum_p 1 = n$, and $f_i \\in \\{0,2\\}$ force $\\#\\{i : f_i = 2\\} = n/2$, giving $\\sum_i 2^{(n+f_i)/2} = 3\\,(n/2)\\,2^{n/2}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_comm", "fiberwise counting", "Finset.sum_filter", "omega"],
+    "prerequisites": ["double counting over a Finset", "filter cardinalities"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "burnside-counting-oq-04-oq-02-oq-02",
+  "title": "The Reflection Half of the Bracelet Burnside Sum, Both Parities",
+  "slug": "burnside-counting-oq-04-oq-02-oq-02",
+  "description": "Discharges the second open question of the parent burnside-counting-oq-04-oq-02 (and the open question left by the sibling rotation half burnside-counting-oq-04-oq-02-oq-01): the closed evaluation of the reflection contribution Σ_{i∈ZMod n} |Fix(sr i)| to the n-uniform Burnside bracelet identity Σ_{g∈Dₙ} |Fix(g)| = b(n)·(2n), for BOTH parities of n. A reflection sr i acts on the n positions by the involution refl i : p ↦ -i - p (the parent's posPerm_sr = Equiv.subLeft (-i)); a colouring is fixed exactly when it is constant on the refl i-orbits. The structural heart is an elementary involution-counting lemma, card_invariant_colorings_involutive: for ANY involution σ on a finite type α, the 2-colourings constant on σ-orbits number 2^{(|α| + |Fix σ|)/2} — proved with no group actions, Burnside, or orbit-quotient Fintype instances, by indexing α through ℕ (Fintype.equivFin), choosing the smaller-indexed element of each orbit {a, σ a} as representative, biject­ing invariant colourings with functions on the representatives R, and counting |R| = (|α| + |Fix σ|)/2 from R = L ∪ Fix and |L| = |G| via the σ-bijection. Specialised to refl i this gives the per-reflection count |Fix(sr i)| = 2^{(n + f_i)/2} with f_i = #{p : 2p = -i} (card_fixedBy_reflection). The fixed-point count f_i then splits by parity: for ODD n, 2 is a unit in ZMod n so 2p = -i has a unique solution, f_i = 1 (reflFix_odd), giving Σ_i |Fix(sr i)| = n·2^{(n+1)/2} (reflection_sum_odd); for EVEN n, doubling has the two-element kernel {0, n/2}, so f_i ∈ {0, 2} (reflFix_even), and since Σ_i f_i = n (each position is the unique fixed point of exactly one axis, reflFix_sum) exactly n/2 of the reflections carry a fixed pair (card_even_reflections), giving Σ_i |Fix(sr i)| = 3·(n/2)·2^{n/2} (reflection_sum_even). #print axioms on all four headline declarations confirms only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool (no native_decide) and no sorryAx.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius (researcher-3)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04OQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "bracelets",
+      "necklaces",
+      "orbit-counting",
+      "reflections",
+      "involutions",
+      "parity",
+      "number-theory",
+      "native-decide-free"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.equivFin",
+        "description": "An equivalence α ≃ Fin (card α); supplies the injective index function f : α → ℕ used to pick a canonical (smaller-indexed) representative of each involution orbit {a, σ a}, with no choice of orbit-quotient Fintype instance.",
+        "module": "Mathlib.Logic.Equiv.Fin"
+      },
+      {
+        "theorem": "Finset.card_nbij'",
+        "description": "Cardinality equality from an explicit bijection with a two-sided inverse; used with σ itself to prove |L| = |G| (the two halves of the non-fixed points split evenly by the involution).",
+        "module": "Mathlib.Combinatorics.Enumerative.DoubleCounting"
+      },
+      {
+        "theorem": "Finset.filter_card_add_filter_neg_card_eq_card",
+        "description": "|s.filter p| + |s.filter ¬p| = |s|; gives R.card + G.card = |α| in the representative count and the complementary reflection count in the even case.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "ZMod.isUnit_iff_coprime",
+        "description": "(a : ZMod n) is a unit ⟺ gcd(a, n) = 1; with Nat.coprime_two_left it makes 2 a unit in ZMod n for odd n, so doubling is a bijection and 2p = -i has a unique solution.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Units.mulLeft_bijective / Function.Bijective.existsUnique",
+        "description": "Left multiplication by a unit is a bijection, hence 2p = -i has a unique solution for odd n — the source of reflFix_odd = 1.",
+        "module": "Mathlib.Algebra.Group.Units.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod n) = 0 ⟺ n ∣ a; identifies the doubling kernel {0, n/2} for even n (two_mul_eq_zero_iff) and shows (n/2 : ZMod n) ≠ 0.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of a double sum; turns Σ_i f_i = Σ_i #{p : 2p = -i} into a fiberwise count Σ_p #{i : 2p = -i} = Σ_p 1 = n (reflFix_sum).",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "MulAction.fixedBy / mem_fixedBy",
+        "description": "The fixed-point set of a group element under the parent's dihedral colouring action; reflection_smul_apply unfolds it at a reflection to the symmetry condition c (-i - p) = c p.",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      }
+    ],
+    "originalContributions": [
+      "card_invariant_colorings_involutive: for any involution σ on a finite type α, the 2-colourings constant on σ-orbits number 2^{(|α| + |Fix σ|)/2}. An elementary, fully self-contained count that avoids group actions, Burnside, and orbit-quotient Fintype instances entirely: index α by ℕ via Fintype.equivFin, take the smaller-indexed element of each orbit {a, σ a} as its representative, biject invariant colourings with functions on the representative set R, and compute |R| = (|α| + |Fix σ|)/2 from R = L ∪ Fix (disjoint) together with R.card + G.card = |α| and |L| = |G| (the σ-bijection on non-fixed points). This is the single ingredient that the rest of the file specialises.",
+      "card_fixedBy_reflection: |Fix(sr i)| = 2^{(n + reflFix i)/2}, the per-reflection fixed-colouring count, obtained by recognising the reflection action as the involution refl i : p ↦ -i - p and applying the involution count with |Fix(refl i)| = reflFix i = #{p : 2p = -i}.",
+      "reflFix_odd: for odd n the involution refl i has a unique fixed point (2 is a unit in ZMod n), so reflFix i = 1 for every axis i; hence reflection_sum_odd: Σ_{i∈ZMod n} |Fix(sr i)| = n·2^{(n+1)/2}.",
+      "two_mul_eq_zero_iff and reflFix_even: for even n = 2m the doubling map p ↦ 2p on ZMod n has the exact two-element kernel {0, m}, so 2p = -i has 0 or exactly 2 solutions and reflFix i ∈ {0, 2}.",
+      "reflFix_sum: Σ_{i∈ZMod n} reflFix i = n for every n — a clean fiberwise double-count (each position p is the unique fixed point of the single axis i = -2p), proved by Finset.sum_comm with no parity hypothesis.",
+      "card_even_reflections and reflection_sum_even: combining reflFix_even (each term ∈ {0,2}) with reflFix_sum (the terms total n) forces exactly n/2 of the reflections to carry a fixed pair, giving the even-n reflection half Σ_{i∈ZMod n} |Fix(sr i)| = 3·(n/2)·2^{n/2}."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, and no native_decide: all four headlines (card_invariant_colorings_involutive, card_fixedBy_reflection, reflection_sum_odd, reflection_sum_even) depend only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms — in particular no Lean.ofReduceBool and no sorryAx). The hypothesis NeZero n (i.e. n > 0) is required only where the Fintype/cardinality layer is used; the involution count card_invariant_colorings_involutive is stated for an arbitrary finite type with no positivity hypothesis. The parity hypotheses Odd n / Even n select which fixed-point count applies.",
+    "lineCount": 436,
+    "theoremCount": 12,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Burnside's lemma counts the orbits of a finite group action as the average number of fixed points. For the dihedral group D_n acting on the beads of an n-cycle this yields the bracelet numbers (OEIS A000029). Closing the bracelet count requires evaluating the fixed-point total Σ_{g∈Dₙ} |Fix(g)| in closed form, split into a rotation half (the gcd-cycle sum, done by the sibling oq-04-oq-02-oq-01) and a reflection half. A reflection of an n-gon is an involution on the beads; classically its cycle structure depends on the parity of n — for odd n every reflection axis passes through one vertex and the opposite edge midpoint (one fixed bead), while for even n half the axes pass through two opposite vertices (two fixed beads) and half through two opposite edge midpoints (none). This entry formalises that parity dichotomy and reads off the reflection contribution to the bracelet Burnside sum.",
+    "problemStatement": "Evaluate the reflection contribution Σ_{i∈ZMod n} |Fix(sr i)| to the n-uniform Burnside bracelet identity in closed form, for both parities of n, by counting the 2-colourings invariant under each reflection involution refl i : p ↦ -i - p.",
+    "text": "A binary colouring is fixed by the reflection sr i iff it is symmetric about the axis, c (-i - p) = c p, i.e. constant on the orbits of the involution refl i. The number of such colourings is 2^{(number of refl i-orbits)} = 2^{(n + f_i)/2}, where f_i = #{p : 2p = -i} counts the fixed beads. For odd n, 2 is a unit in ZMod n so f_i = 1 always and Σ_i |Fix(sr i)| = n·2^{(n+1)/2}. For even n, doubling has kernel {0, n/2} so f_i ∈ {0, 2}; since Σ_i f_i = n exactly n/2 reflections have f_i = 2, giving Σ_i |Fix(sr i)| = 3·(n/2)·2^{n/2}.",
+    "proofStrategy": "reflection_smul_apply unfolds the parent action at a reflection: (sr i • c) p = c (-i - p), since ρ (sr i) = Equiv.subLeft (-i). fixed_iff_symm recasts sr i • c = c as the symmetry ∀ p, c (-i - p) = c p, i.e. c is constant on the orbits of the involution refl i : p ↦ -i - p. The linchpin card_invariant_colorings_involutive counts the invariant 2-colourings of an arbitrary involution σ as 2^{(|α| + |Fix σ|)/2}: it indexes α by ℕ (Fintype.equivFin), uses the smaller-indexed element of {a, σ a} as a representative, bijects invariant colourings with functions on the representative set R, and computes |R| = (|α| + |Fix σ|)/2 from R = L ∪ Fix, R.card + G.card = |α|, and |L| = |G| (the σ-bijection). card_fixedBy_reflection specialises this to refl i, with reflFix i = #{p : refl i p = p} = #{p : 2p = -i}. The parity split then evaluates reflFix i: reflFix_odd = 1 via ZMod.isUnit_iff_coprime + Units.mulLeft_bijective + Bijective.existsUnique; two_mul_eq_zero_iff pins the even doubling kernel to {0, n/2}; reflFix_even reads reflFix i ∈ {0, 2}; reflFix_sum = n is a fiberwise Finset.sum_comm count; card_even_reflections = n/2 follows by omega from Σ reflFix = n and each term ∈ {0,2}; reflection_sum_odd and reflection_sum_even sum the per-reflection counts.",
+    "keyInsights": [
+      "Fixed-by-reflection is a symmetry condition: sr i • c = c unfolds to c (-i - p) = c p, i.e. c is constant on the orbits of the involution refl i : p ↦ -i - p — the bridge from the group action to an involution-orbit count",
+      "The orbit count of any involution is uniform: an involution σ on α has orbits that are singletons (fixed points) and transposed pairs, so the number of orbits is exactly (|α| + |Fix σ|)/2 and the invariant 2-colourings number 2^{(|α| + |Fix σ|)/2} — proved elementarily without group actions or quotient Fintype instances",
+      "The fixed-bead count of a reflection is governed by the doubling map on ZMod n: f_i = #{p : 2p = -i} is the fiber of p ↦ 2p over -i, so parity of n (whether 2 is a unit or has kernel {0, n/2}) controls whether f_i is 1, or alternates between 0 and 2",
+      "A global double-count fixes the even-n split without case analysis on i: Σ_i f_i = n (each bead is the unique fixed point of one axis i = -2p, by Finset.sum_comm), so with f_i ∈ {0,2} exactly n/2 reflections have a fixed pair — no need to identify which axes are vertex-axes",
+      "Together with the rotation half (the gcd-cycle sum Σ_i 2^{gcd(n,i)}) this completes both halves of the bracelet Burnside sum: b(n) = (Σ_i 2^{gcd(n,i)} + reflection-total)/(2n), with reflection-total = n·2^{(n+1)/2} (odd) or 3·(n/2)·2^{n/2} (even)"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, fixed-point sets, and the orbit-counting (Burnside) lemma",
+      "Involutions and their orbit structure (fixed points and transposed pairs)",
+      "Units and the doubling map in ZMod n: 2 is a unit for odd n, with kernel {0, n/2} for even n",
+      "Finite-set double counting: Finset.sum_comm, filter cardinalities, and explicit bijections (Finset.card_nbij')"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; the dihedral cycle index whose reflection terms differ by the parity of n"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-04-oq-02",
+      "relationship": "extends",
+      "description": "Answers the parent's second open question by evaluating the reflection half Σ_i |Fix(sr i)| of its bracelet_burnside identity in closed form for both parities of n."
+    },
+    {
+      "targetId": "burnside-counting-oq-04-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Supplies the reflection half complementary to the sibling's rotation half (the gcd-cycle sum Σ_i 2^{gcd(n,i)}); together the two halves give the full bracelet Burnside total Σ_{g∈Dₙ} |Fix(g)|, and answers the sibling's stated open question on the reflection contribution by parity."
+    }
+  ],
+  "conclusion": {
+    "summary": "A binary colouring is fixed by the reflection sr i exactly when it is constant on the orbits of the involution refl i : p ↦ -i - p, so the count is 2^{(n + f_i)/2} with f_i = #{p : 2p = -i} the number of fixed beads. The parity of n controls f_i: for odd n, 2 is a unit in ZMod n so f_i = 1 and Σ_i |Fix(sr i)| = n·2^{(n+1)/2}; for even n, doubling has kernel {0, n/2} so f_i ∈ {0,2}, and since Σ_i f_i = n exactly n/2 reflections fix a pair, giving Σ_i |Fix(sr i)| = 3·(n/2)·2^{n/2}. Verified, 0 axioms, no native_decide.",
+    "implications": "Completes the reflection contribution to the closed-form bracelet number b(n) = (rotation-total(n) + reflection-total(n))/(2n). With the sibling rotation half (Σ_i 2^{gcd(n,i)}) both halves of the dihedral Burnside sum are now evaluated in closed form, with the only per-n input being the parity of n.",
+    "openQuestions": [
+      "Assemble the two halves into the single closed form b(n) = (Σ_{i∈ZMod n} 2^{gcd(n,i)} + reflectionTotal(n)) / (2n), with reflectionTotal(n) = n·2^{(n+1)/2} for odd n and 3·(n/2)·2^{n/2} for even n, directly from the parent's bracelet_burnside identity.",
+      "Identify the even-n reflection classes geometrically (the n/2 vertex-axes vs n/2 edge-axes) rather than only counting them via Σ f_i = n, to match the classical dihedral cycle index term by term."
+    ]
+  },
+  "sections": [
+    {
+      "title": "Module header and scope",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "States the goal — the closed evaluation of the reflection half of the parent's bracelet_burnside identity for both parities — and the structural plan: a reflection acts by the involution refl i : p ↦ -i - p, fixed colourings are constant on its orbits, the orbit count of any involution is (|α| + |Fix|)/2, and f_i = #{p : 2p = -i} splits by parity. Records the axiom-hygiene claim (only propext/Classical.choice/Quot.sound)."
+    },
+    {
+      "title": "Unfolding the reflection action",
+      "startLine": 52,
+      "endLine": 77,
+      "summary": "reflection_smul_apply: (sr i • c) p = c (-i - p), reading off the parent's smul_apply with ρ (sr i) = Equiv.subLeft (-i). fixed_iff_symm: sr i • c = c ↔ ∀ p, c (-i - p) = c p — the symmetry condition that makes a fixed colouring constant on refl i-orbits."
+    },
+    {
+      "title": "The reflection involution on positions",
+      "startLine": 78,
+      "endLine": 88,
+      "summary": "refl i : p ↦ -i - p and refl_involutive: refl i is an involution (-i - (-i - p) = p). This is the involution whose invariant 2-colourings are exactly the colourings fixed by sr i."
+    },
+    {
+      "title": "Counting invariant 2-colourings of an arbitrary involution",
+      "startLine": 89,
+      "endLine": 206,
+      "summary": "card_invariant_colorings_involutive: for any involution σ on a finite type α, |{c : α → Fin 2 // ∀ a, c (σ a) = c a}| = 2^{(|α| + |Fix σ|)/2}. Elementary proof: index α by ℕ (Fintype.equivFin), representative = smaller-indexed element of {a, σ a}, invariant colourings ≃ (R → Fin 2), and |R| = (|α| + |Fix σ|)/2 from R = L ∪ Fix (disjoint), R.card + G.card = |α|, and |L| = |G| (Finset.card_nbij' with σ). No group actions, Burnside, or orbit-quotient Fintype instances."
+    },
+    {
+      "title": "The per-reflection fixed-colouring count",
+      "startLine": 207,
+      "endLine": 224,
+      "summary": "reflFix i = #{p : refl i p = p} = #{p : 2p = -i} (the fixed-bead count), and card_fixedBy_reflection: |Fix(sr i)| = 2^{(n + reflFix i)/2} via Equiv.subtypeEquivRight to the invariant colourings of refl i and the involution count."
+    },
+    {
+      "title": "Odd n: every reflection fixes one bead",
+      "startLine": 225,
+      "endLine": 268,
+      "summary": "reflFix_odd: for odd n, 2 is a unit in ZMod n (ZMod.isUnit_iff_coprime + Nat.coprime_two_left), so 2p = -i has a unique solution (Units.mulLeft_bijective + Bijective.existsUnique + Finset.card_eq_one) and reflFix i = 1. reflection_sum_odd: Σ_{i∈ZMod n} |Fix(sr i)| = n·2^{(n+1)/2}."
+    },
+    {
+      "title": "Even n: reflections split by parity",
+      "startLine": 269,
+      "endLine": 428,
+      "summary": "two_mul_eq_zero_iff: for even n = 2m the doubling kernel is exactly {0, m}. reflFix_even: reflFix i ∈ {0, 2} (the solution set of 2p = -i is empty or a coset of {0, n/2}). reflFix_sum: Σ_i reflFix i = n for every n, a fiberwise Finset.sum_comm count (each bead is the unique fixed point of one axis). card_even_reflections: exactly n/2 reflections have reflFix i = 2 (omega from Σ reflFix = n and each term ∈ {0,2}). reflection_sum_even: Σ_{i∈ZMod n} |Fix(sr i)| = 3·(n/2)·2^{n/2}, via an additive split of each term that uses only the positive filter. Axiom audit confirms only the foundational axioms."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.BurnsideCountingOQ04OQ02"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction",
+      "BurnsideCountingOQ04OQ02"
+    ],
+    "namespace": "BurnsideCountingOQ04OQ02OQ02",
+    "lineCount": 436,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/BurnsideCountingOQ04OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closed-form evaluation of the **reflection contribution** `Σ_{i∈ZMod n} |Fix(sr i)|` to the dihedral bracelet Burnside sum `Σ_{g∈Dₙ} |Fix(g)| = b(n)·(2n)`, for **both parities** of `n`. This discharges the parent `burnside-counting-oq-04-oq-02`'s second open question and complements the sibling **rotation half** `burnside-counting-oq-04-oq-02-oq-01` (the gcd-cycle sum).

A reflection `sr i` acts on the `n` beads by the involution `refl i : p ↦ -i - p`; a colouring is fixed exactly when it is constant on the `refl i`-orbits.

## Results (all verified, 0 axioms)

| theorem | statement |
|---|---|
| `card_invariant_colorings_involutive` | for **any** involution `σ`, invariant 2-colourings `= 2^{(|α| + |Fix σ|)/2}` |
| `card_fixedBy_reflection` | `|Fix(sr i)| = 2^{(n + f_i)/2}`, `f_i = #{p : 2p = -i}` |
| `reflection_sum_odd` | odd `n`: `Σ_i |Fix(sr i)| = n · 2^{(n+1)/2}` |
| `reflection_sum_even` | even `n`: `Σ_i |Fix(sr i)| = 3 · (n/2) · 2^{n/2}` |

**Linchpin.** `card_invariant_colorings_involutive` counts the invariant 2-colourings of an arbitrary involution **elementarily** — no group actions, Burnside, or orbit-quotient `Fintype` instances: index `α` by `ℕ` (`Fintype.equivFin`), take the smaller-indexed element of each orbit `{a, σ a}` as representative, biject invariant colourings with functions on the representatives, and count `|R| = (|α| + |Fix σ|)/2`.

**Parity split.** For odd `n`, `2` is a unit in `ZMod n` so `f_i = 1`. For even `n = 2m`, doubling has kernel `{0, m}` so `f_i ∈ {0, 2}`; since `Σ_i f_i = n` (each bead is the unique fixed point of one axis, by `Finset.sum_comm`) exactly `n/2` reflections fix a pair.

## Verification

`#print axioms` on all four headlines → only `propext, Classical.choice, Quot.sound` (no `native_decide`/`Lean.ofReduceBool`, no `sorryAx`). 12 theorems / 2 defs / 436 lines, 0 sorries.

Because the Docker daemon was down host-wide, the file was verified by single-file elaboration: `lake env lean` (an explicit safe pass-through in `proofs/bin/lake`) against main's prebuilt `.lake` oleans — one file, bounded memory, **not** `lake build`. `n=6` sanity: reflection total `3·3·8 = 72` (parent `decide`: `Dihedral 6` total `= 156`).

## Files
- `proofs/Proofs/BurnsideCountingOQ04OQ02OQ02.lean` (+ registered in `proofs/Proofs.lean`)
- `src/data/proofs/burnside-counting-oq-04-oq-02-oq-02/` — `meta.json` + `annotations.json`
- `research/problems/burnside-counting-oq-04-oq-02-oq-02/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)