### PR TITLE
research: second Bonferroni inequality in union form, with a sharp tightness criterion (inclusion-exclusion-oq-01-oq-01-oq-02)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3233,6 +3233,7 @@ import Proofs.InclusionExclusionGeneral
 import Proofs.InclusionExclusionOQ01
 import Proofs.InclusionExclusionOQ01OQ03
 import Proofs.InclusionExclusionOQ03
+import Proofs.InclusionExclusionSecondBonferroni
 import Proofs.InclusionExclusionSieve
 import Proofs.InclusionExclusionSieveDerangements
 import Proofs.InclusionExclusionSieveDerangementsBonferroni

--- a/proofs/Proofs/InclusionExclusionSecondBonferroni.lean
+++ b/proofs/Proofs/InclusionExclusionSecondBonferroni.lean
@@ -1,0 +1,328 @@
+import Mathlib
+import Proofs.InclusionExclusionBonferroniGeneral
+
+/-
+# The Second Bonferroni Inequality in Union Form, with a Sharp Tightness Criterion
+
+## What This Proves
+Let `A : ι → Finset α` be a finite family of finite sets. Write
+
+    U   = ⋃_i A i                         (the union),
+    S₁  = Σ_i |A i|                        (sum of sizes),
+    S₂  = Σ_{i<j} |A i ∩ A j|              (sum of pairwise intersection sizes).
+
+The **second Bonferroni inequality** is the lower bound
+
+    |U|  ≥  S₁ − S₂.                                            (`second_bonferroni`)
+
+This is the `m = 2` truncation of inclusion–exclusion, dual to the first Bonferroni
+inequality `|U| ≤ S₁` proved in the parent gallery file. We go further and pin down the
+**exact defect** of the bound by a single non-negative sum over the union:
+
+    |U| − (S₁ − S₂)  =  Σ_{x ∈ U}  C(deg x − 1, 2),            (`union_card_sub_eq_gap`)
+
+where `deg x = #{i : x ∈ A i}` is the number of sets containing `x`. Since each term is a
+binomial coefficient, the inequality is immediate, and equality is characterised sharply:
+
+    |U| = S₁ − S₂   ⟺   every element lies in at most two sets  (∀ x, deg x ≤ 2)
+                    ⟺   all triple intersections are empty.     (`second_bonferroni_eq_iff`,
+                                                                  `deg_le_two_iff_no_triple`)
+
+## A correction to the folklore tightness claim
+The bound is *often* stated to be tight exactly for **disjoint** families. That is wrong: it
+is only a *sufficient* condition. The truncated sieve already collapses as soon as no point is
+covered three or more times — pairwise overlaps are harmless. We prove disjointness is
+sufficient (`disjoint_imp_tight`) and exhibit a concrete family with a non-empty pairwise
+intersection for which the second Bonferroni bound is nonetheless *exact*
+(`exFam`, over `Fin 3`: `{0,1}` and `{1,2}` overlap in `1`, yet `|U| = 3 = S₁ − S₂`). The
+genuinely sharp criterion is "no triple overlaps", which is strictly weaker than disjointness.
+
+## Proof Strategy
+Everything is reduced to the per-element reindexing already established in the gallery file
+`InclusionExclusionBonferroniGeneral`. That file proves
+`bonf A m = Σ_x altPartial (deg A x) m` and `bonf A m − noneCard A = Σ_x term`, where `bonf A 2`
+is the `m = 2` truncated sieve and `noneCard A` counts points in no set. We
+
+1. evaluate `bonf A 2 = |α| − S₁ + S₂` (the three layers `S₀ = |α|`, `S₁`, `S₂`);
+2. note `|U| = |α| − noneCard A` (a point is in the union iff its degree is positive);
+3. evaluate each per-element error term at `m = 2` to `C(deg x − 1, 2)`;
+
+and combine. The whole development is `sorry`-free and `axiom`-free (the worked numerical
+witnesses use `decide`, not `native_decide`).
+
+## Relationship to the Gallery
+Parent `inclusion-exclusion-oq-01-oq-01` (`InclusionExclusionGeneral`) proves the *first*
+Bonferroni inequality `|U| ≤ S₁` and lists "prove the second Bonferroni inequality and
+characterise tightness" as an explicit open question; this file answers it, and corrects the
+"disjoint families" guess to the sharp "no triple overlaps" criterion. The truncated-sieve
+machinery is reused from sibling `InclusionExclusionBonferroniGeneral`.
+-/
+
+namespace InclusionExclusionSecondBonferroni
+
+open Finset InclusionExclusionBonferroniGeneral
+
+variable {α ι : Type*} [Fintype α] [DecidableEq α] [Fintype ι] [DecidableEq ι]
+
+/-
+## Part I: The union and the two sieve sums in readable form
+-/
+
+/-- The union `⋃_i A i`, described as the set of elements of positive degree. -/
+def unionSet (A : ι → Finset α) : Finset α := (univ : Finset α).filter (fun x => 0 < deg A x)
+
+/-- `unionSet` really is the indexed union `⋃_i A i`. -/
+theorem unionSet_eq_biUnion (A : ι → Finset α) :
+    unionSet A = (univ : Finset ι).biUnion A := by
+  ext x
+  simp only [unionSet, mem_filter, mem_univ, true_and, mem_biUnion, deg, Finset.card_pos,
+    Finset.filter_nonempty_iff]
+
+/-- `S₁ = Σ_i |A i|`, the sum of the set sizes (the first Bonferroni term). -/
+def S1 (A : ι → Finset α) : ℤ := ∑ i : ι, ((A i).card : ℤ)
+
+/-- `S₂ = Σ_{|J| = 2} |⋂_{i ∈ J} A i|`, the sum of pairwise intersection sizes
+(the second Bonferroni term). This is exactly the `k = 2` inclusion–exclusion layer. -/
+def S2 (A : ι → Finset α) : ℤ := sieveLayer A 2
+
+/-- **Transparency for `S₂`.** Each size-two layer term is the cardinality of an honest
+pairwise intersection: for `i ≠ j`, `|⋂_{l ∈ {i,j}} A l| = |A i ∩ A j|`. -/
+theorem interCard_pair (A : ι → Finset α) {i j : ι} (hij : i ≠ j) :
+    interCard A {i, j} = (A i ∩ A j).card := by
+  unfold interCard
+  congr 1
+  ext x
+  simp only [mem_filter, mem_univ, true_and, mem_inter, Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · intro h; exact ⟨h i (Or.inl rfl), h j (Or.inr rfl)⟩
+  · rintro ⟨hi, hj⟩ l (rfl | rfl)
+    · exact hi
+    · exact hj
+
+/-
+## Part II: The two layers in terms of degrees
+-/
+
+/-- An element of degree `0` is one lying in no set. -/
+theorem deg_eq_zero_iff (A : ι → Finset α) (x : α) : deg A x = 0 ↔ ∀ i, x ∉ A i := by
+  rw [deg, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  exact ⟨fun h i => h (mem_univ i), fun h i _ => h i⟩
+
+/-- Double counting: `Σ_i |A i| = Σ_x deg x`. -/
+theorem sum_card_eq_sum_deg (A : ι → Finset α) :
+    ∑ i : ι, ((A i).card : ℤ) = ∑ x : α, (deg A x : ℤ) := by
+  have hA : ∀ i, ((A i).card : ℤ) = ∑ x : α, (if x ∈ A i then (1 : ℤ) else 0) := by
+    intro i
+    rw [Finset.sum_boole, Finset.filter_mem_eq_inter, Finset.univ_inter]
+  have hd : ∀ x, (deg A x : ℤ) = ∑ i : ι, (if x ∈ A i then (1 : ℤ) else 0) := by
+    intro x
+    rw [Finset.sum_boole, deg]
+  simp_rw [hA, hd]
+  rw [Finset.sum_comm]
+
+/-- `S₁` is the first inclusion–exclusion layer. -/
+theorem S1_eq_sieveLayer (A : ι → Finset α) : S1 A = sieveLayer A 1 := by
+  rw [S1, sum_card_eq_sum_deg, sieveLayer_eq_sum_choose]
+  simp [Nat.choose_one_right]
+
+/-- The zeroth layer is the size of the whole universe. -/
+theorem sieveLayer_zero (A : ι → Finset α) : sieveLayer A 0 = (Fintype.card α : ℤ) := by
+  rw [sieveLayer_eq_sum_choose]
+  simp only [Nat.choose_zero_right, Nat.cast_one]
+  rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
+
+/-- The second truncated sieve equals `|α| − S₁ + S₂`. -/
+theorem bonf_two_eq (A : ι → Finset α) :
+    bonf A 2 = (Fintype.card α : ℤ) - S1 A + S2 A := by
+  have h : bonf A 2 = sieveLayer A 0 - sieveLayer A 1 + sieveLayer A 2 := by
+    rw [bonf, Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_one]
+    ring
+  rw [h, sieveLayer_zero, ← S1_eq_sieveLayer, S2]
+
+/-- The union and the no-set elements partition the universe. -/
+theorem unionSet_card_add_noneCard (A : ι → Finset α) :
+    (unionSet A).card + noneCard A = Fintype.card α := by
+  have hnone : noneCard A = (univ.filter (fun x => ¬ (0 < deg A x))).card := by
+    unfold noneCard
+    congr 1
+    apply Finset.filter_congr
+    intro x _
+    constructor
+    · intro h
+      simp only [not_lt, Nat.le_zero]
+      exact (deg_eq_zero_iff A x).mpr h
+    · intro h
+      rw [not_lt, Nat.le_zero] at h
+      exact (deg_eq_zero_iff A x).mp h
+  rw [hnone, unionSet, Finset.filter_card_add_filter_neg_card_eq_card, Finset.card_univ]
+
+/-
+## Part III: The exact Bonferroni defect
+-/
+
+/-- The per-element truncation error at `m = 2`. An element in no set contributes `0`; an
+element of degree `f+1 ≥ 1` contributes `C(f, 2) = C(deg − 1, 2)`. -/
+theorem term_two (A : ι → Finset α) (x : α) :
+    altPartial (deg A x) 2 - (if deg A x = 0 then (1 : ℤ) else 0)
+      = (if deg A x = 0 then (0 : ℤ) else ((deg A x - 1).choose 2 : ℤ)) := by
+  rcases Nat.eq_zero_or_pos (deg A x) with h0 | hpos
+  · rw [h0, altPartial_zero]; simp
+  · obtain ⟨f, hf⟩ := Nat.exists_eq_succ_of_ne_zero hpos.ne'
+    rw [hf, altPartial_succ, if_neg (Nat.succ_ne_zero f), if_neg (Nat.succ_ne_zero f), sub_zero]
+    have hfeq : f + 1 - 1 = f := by omega
+    rw [hfeq]
+    norm_num
+
+/-- **The exact second-Bonferroni defect.** The slack in `|U| ≥ S₁ − S₂` is a single
+non-negative sum over the union:
+
+    |U| − (S₁ − S₂)  =  Σ_{x ∈ U} C(deg x − 1, 2).
+
+An element covered `d` times contributes `C(d−1, 2)`, which vanishes precisely when `d ≤ 2`. -/
+theorem union_card_sub_eq_gap (A : ι → Finset α) :
+    ((unionSet A).card : ℤ) - (S1 A - S2 A)
+      = ∑ x ∈ unionSet A, ((deg A x - 1).choose 2 : ℤ) := by
+  have hbsn := bonf_sub_noneCard A 2
+  rw [Finset.sum_congr rfl (fun x (_ : x ∈ (univ : Finset α)) => term_two A x)] at hbsn
+  have hsum : (∑ x : α, (if deg A x = 0 then (0 : ℤ) else ((deg A x - 1).choose 2 : ℤ)))
+      = ∑ x ∈ unionSet A, ((deg A x - 1).choose 2 : ℤ) := by
+    rw [unionSet, Finset.sum_filter]
+    apply Finset.sum_congr rfl
+    intro x _
+    by_cases h : deg A x = 0
+    · simp [h]
+    · have hpos : 0 < deg A x := Nat.pos_of_ne_zero h
+      simp [h, hpos]
+  rw [hsum] at hbsn
+  rw [bonf_two_eq] at hbsn
+  have hcard : ((unionSet A).card : ℤ) + (noneCard A : ℤ) = (Fintype.card α : ℤ) := by
+    have h := unionSet_card_add_noneCard A
+    exact_mod_cast h
+  linarith [hbsn, hcard]
+
+/-
+## Part IV: The inequality and its sharp tightness criterion
+-/
+
+/-- **The second Bonferroni inequality (union form).** `S₁ − S₂ ≤ |U|`, i.e.
+
+    |⋃_i A i|  ≥  Σ_i |A i|  −  Σ_{i<j} |A i ∩ A j|. -/
+theorem second_bonferroni (A : ι → Finset α) :
+    S1 A - S2 A ≤ ((unionSet A).card : ℤ) := by
+  have h := union_card_sub_eq_gap A
+  have hnn : 0 ≤ ∑ x ∈ unionSet A, ((deg A x - 1).choose 2 : ℤ) :=
+    Finset.sum_nonneg (fun x _ => by positivity)
+  linarith [h, hnn]
+
+/-- **Sharp tightness.** The second Bonferroni bound is exact iff every element lies in at
+most two of the sets (equivalently, no element is triple-covered). -/
+theorem second_bonferroni_eq_iff (A : ι → Finset α) :
+    ((unionSet A).card : ℤ) = S1 A - S2 A ↔ ∀ x, deg A x ≤ 2 := by
+  rw [← sub_eq_zero, union_card_sub_eq_gap A,
+    Finset.sum_eq_zero_iff_of_nonneg (fun x _ => by positivity)]
+  constructor
+  · intro h x
+    by_cases hx : x ∈ unionSet A
+    · have hxz : (deg A x - 1).choose 2 = 0 := by exact_mod_cast h x hx
+      rw [Nat.choose_eq_zero_iff] at hxz
+      omega
+    · simp only [unionSet, mem_filter, mem_univ, true_and, not_lt, Nat.le_zero] at hx
+      omega
+  · intro h x _
+    have hxle : deg A x ≤ 2 := h x
+    have : (deg A x - 1).choose 2 = 0 := by rw [Nat.choose_eq_zero_iff]; omega
+    exact_mod_cast this
+
+/-- The sharp criterion restated geometrically: **all triple intersections are empty.** -/
+theorem deg_le_two_iff_no_triple (A : ι → Finset α) :
+    (∀ x, deg A x ≤ 2) ↔
+      ∀ i j k : ι, i ≠ j → i ≠ k → j ≠ k → A i ∩ A j ∩ A k = ∅ := by
+  constructor
+  · intro h i j k hij hik hjk
+    rw [← Finset.not_nonempty_iff_eq_empty]
+    rintro ⟨x, hx⟩
+    rw [Finset.mem_inter, Finset.mem_inter] at hx
+    obtain ⟨⟨hi, hj⟩, hk⟩ := hx
+    have hsub : ({i, j, k} : Finset ι) ⊆ univ.filter (fun l => x ∈ A l) := by
+      intro l hl
+      simp only [mem_filter, mem_univ, true_and]
+      rcases Finset.mem_insert.mp hl with rfl | hl
+      · exact hi
+      rcases Finset.mem_insert.mp hl with rfl | hl
+      · exact hj
+      · rw [Finset.mem_singleton] at hl; subst hl; exact hk
+    have hcard3 : ({i, j, k} : Finset ι).card = 3 :=
+      Finset.card_eq_three.mpr ⟨i, j, k, hij, hik, hjk, rfl⟩
+    have h3 : 3 ≤ deg A x := by
+      rw [deg, ← hcard3]; exact Finset.card_le_card hsub
+    have := h x; omega
+  · intro h x
+    by_contra hgt
+    push_neg at hgt
+    rw [deg] at hgt
+    obtain ⟨i, j, k, hi, hj, hk, hij, hik, hjk⟩ := Finset.two_lt_card_iff.mp hgt
+    rw [mem_filter] at hi hj hk
+    have hempty : A i ∩ A j ∩ A k = ∅ := h i j k hij hik hjk
+    have hx : x ∈ A i ∩ A j ∩ A k := by
+      rw [Finset.mem_inter, Finset.mem_inter]; exact ⟨⟨hi.2, hj.2⟩, hk.2⟩
+    rw [hempty] at hx
+    exact absurd hx (Finset.not_mem_empty x)
+
+/-- The same criterion as the vanishing of the third inclusion–exclusion layer. -/
+theorem deg_le_two_iff_sieveLayer_three (A : ι → Finset α) :
+    (∀ x, deg A x ≤ 2) ↔ sieveLayer A 3 = 0 := by
+  rw [sieveLayer_eq_sum_choose, Finset.sum_eq_zero_iff_of_nonneg (fun x _ => by positivity)]
+  constructor
+  · intro h x _
+    have : (deg A x).choose 3 = 0 := by rw [Nat.choose_eq_zero_iff]; have := h x; omega
+    exact_mod_cast this
+  · intro h x
+    have hx : (deg A x).choose 3 = 0 := by exact_mod_cast h x (mem_univ x)
+    rw [Nat.choose_eq_zero_iff] at hx
+    omega
+
+/-
+## Part V: Disjointness is sufficient but not necessary
+-/
+
+/-- **Disjointness is sufficient.** A pairwise-disjoint family makes the second Bonferroni
+bound exact (then `S₂ = 0` and `|U| = S₁`). -/
+theorem disjoint_imp_tight (A : ι → Finset α)
+    (h : ∀ i j, i ≠ j → Disjoint (A i) (A j)) :
+    ((unionSet A).card : ℤ) = S1 A - S2 A := by
+  rw [second_bonferroni_eq_iff]
+  intro x
+  by_contra hgt
+  push_neg at hgt
+  rw [deg] at hgt
+  obtain ⟨i, j, _, hi, hj, _, hij, _, _⟩ := Finset.two_lt_card_iff.mp hgt
+  rw [mem_filter] at hi hj
+  exact (Finset.disjoint_left.mp (h i j hij) hi.2) hj.2
+
+/-
+## Part VI: A concrete witness that disjointness is *not* necessary
+
+The family `A 0 = {0,1}`, `A 1 = {1,2}` over `Fin 3` overlaps in the point `1`, so it is not
+disjoint; yet every point has degree ≤ 2, so the second Bonferroni bound is exact:
+`|U| = 3`, `S₁ = 4`, `S₂ = 1`, and `3 = 4 − 1`. All checked by `decide` (axiom-free).
+-/
+
+/-- The overlapping example family `A 0 = {0,1}`, `A 1 = {1,2}` over `Fin 3`. -/
+def exFam : Fin 2 → Finset (Fin 3) := fun i => if i = 0 then {0, 1} else {1, 2}
+
+/-- The two sets are **not** disjoint — they share the point `1`. -/
+example : ¬ Disjoint (exFam 0) (exFam 1) := by decide
+
+/-- The shared point has degree `2`. -/
+example : deg exFam (1 : Fin 3) = 2 := by decide
+
+/-- Despite the overlap, the second Bonferroni bound is **exact**: `|U| = S₁ − S₂` (`3 = 4 − 1`). -/
+example : ((unionSet exFam).card : ℤ) = S1 exFam - S2 exFam := by decide
+
+#check @second_bonferroni
+#check @union_card_sub_eq_gap
+#check @second_bonferroni_eq_iff
+#check @deg_le_two_iff_no_triple
+#check @disjoint_imp_tight
+
+end InclusionExclusionSecondBonferroni

--- a/src/data/proofs/inclusion-exclusion-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "inclusion-exclusion-oq-01-oq-01-oq-02",
+  "title": "The Second Bonferroni Inequality, Sharply",
+  "slug": "inclusion-exclusion-oq-01-oq-01-oq-02",
+  "description": "Proves the second Bonferroni inequality in union form, |⋃ᵢ Aᵢ| ≥ Σ|Aᵢ| - Σ|Aᵢ∩Aⱼ|, for an arbitrary finite family of finite sets, and pins down its exact defect as a single non-negative sum over the union: |U| - (S₁ - S₂) = Σ_{x∈U} C(deg x - 1, 2). This yields a sharp tightness criterion — equality holds iff every element lies in at most two sets, equivalently iff all triple intersections are empty — which corrects the folklore 'disjoint families' claim (sufficient but not necessary). A concrete overlapping family on Fin 3 witnesses exactness without disjointness. Built on the gallery's general truncated-sieve machinery. 15 theorems, 4 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InclusionExclusionSecondBonferroni.lean",
+    "tags": [
+      "combinatorics",
+      "inclusion-exclusion",
+      "bonferroni-inequalities",
+      "finset",
+      "counting",
+      "double-counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified. The numerical witnesses use `decide` (not `native_decide`), so the file depends on no extra axioms beyond Lean/Mathlib's foundations.",
+    "lineCount": 328,
+    "theoremCount": 15,
+    "definitionCount": 4,
+    "originalContributions": [
+      "second_bonferroni: the second Bonferroni inequality in union form, S₁ - S₂ ≤ |⋃ᵢ Aᵢ|, for an arbitrary finite family",
+      "union_card_sub_eq_gap: the exact defect formula |U| - (S₁ - S₂) = Σ_{x∈U} C(deg x - 1, 2), making the inequality immediate and the tightness criterion transparent",
+      "second_bonferroni_eq_iff: sharp tightness — equality holds iff ∀ x, deg x ≤ 2 (every element is covered at most twice)",
+      "deg_le_two_iff_no_triple: the geometric restatement — the bound is exact iff every triple intersection Aᵢ ∩ Aⱼ ∩ Aₖ (distinct i,j,k) is empty",
+      "deg_le_two_iff_sieveLayer_three: equivalent algebraic form — tightness iff the third inclusion–exclusion layer S₃ vanishes",
+      "disjoint_imp_tight: pairwise-disjoint families are tight (the classical sufficient condition), shown to be a special case",
+      "exFam: a Fin-3 counterexample (sets {0,1} and {1,2} overlapping in 1) proving disjointness is NOT necessary for tightness — equality holds with a non-empty pairwise intersection",
+      "interCard_pair: transparency lemma that each size-2 sieve layer term |⋂_{l∈{i,j}} Aₗ| equals the honest pairwise intersection |Aᵢ ∩ Aⱼ|"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Bonferroni inequalities (Carlo Emilio Bonferroni, 1936) bound the size of a union — or, dually, the probability of a union of events — by truncating the inclusion–exclusion alternating sum after a fixed number of layers. Truncating after an even layer over-estimates the count of elements in no set (yielding the upper bounds), after an odd layer under-estimates it. The first Bonferroni inequality is Boole's union bound |⋃Aᵢ| ≤ Σᵢ|Aᵢ|; the second adds the pairwise-intersection correction to give the lower bound |⋃Aᵢ| ≥ Σ|Aᵢ| - Σ_{i<j}|Aᵢ∩Aⱼ|. These one-sided bounds are workhorses of probabilistic combinatorics and the probabilistic method, where the full inclusion–exclusion sum is intractable but a two-term truncation already suffices.",
+    "problemStatement": "Prove the second Bonferroni inequality |⋃ᵢ Aᵢ| ≥ Σᵢ|Aᵢ| - Σ_{i<j}|Aᵢ∩Aⱼ| for an arbitrary finite family A : ι → Finset α, and characterise exactly when the bound is tight. (Posed as an open question in the parent file inclusion-exclusion-oq-01-oq-01, which conjectured tightness for 'disjoint families'.)",
+    "text": "The file works in six parts. Part I defines the union as the set of positive-degree elements (proved equal to the indexed biUnion) and the two Bonferroni terms S₁ = Σᵢ|Aᵢ| and S₂ = Σ_{|J|=2}|⋂_{i∈J}Aᵢ|, with a transparency lemma showing each size-2 layer term is a genuine pairwise intersection. Part II expresses both layers through element degrees by double counting. Part III is the heart: evaluating the truncated sieve bonf A 2 = |α| - S₁ + S₂ and the per-element truncation error at m = 2, it derives the exact defect |U| - (S₁ - S₂) = Σ_{x∈U} C(deg x - 1, 2). Part IV reads off the inequality (the defect is a sum of binomial coefficients, hence ≥ 0) and the sharp tightness criterion (the defect is 0 iff every degree is ≤ 2). Part V proves disjointness is sufficient, and Part VI exhibits an overlapping family that is nonetheless tight, refuting the necessity of disjointness.",
+    "proofStrategy": "Everything reduces to the per-element reindexing established in the sibling file InclusionExclusionBonferroniGeneral, which proves bonf A m = Σ_x altPartial(deg x) m and isolates the per-element truncation error. For m = 2 the error term is altPartial(deg x) 2 - [deg x = 0], which evaluates to C(deg x - 1, 2) for deg x ≥ 1 and to 0 for deg x = 0 (Pascal telescoping). Summing and converting between the 'no-set' count noneCard A and the union size via the partition |U| + noneCard = |α| gives the closed-form defect. Non-negativity of binomial coefficients gives the inequality; Finset.sum_eq_zero_iff_of_nonneg together with Nat.choose_eq_zero_iff (C(d-1,2)=0 ⟺ d ≤ 2) gives the tightness characterisation. The triple-intersection form uses Finset.two_lt_card_iff to extract three distinct covering indices from a degree-≥3 point.",
+    "keyInsights": [
+      "The exact defect Σ_{x∈U} C(deg x - 1, 2) is the right object: it makes the inequality a one-line consequence of binomial non-negativity AND simultaneously delivers the sharp equality criterion, since each term vanishes precisely when that point's degree drops to ≤ 2.",
+      "The folklore 'tight iff disjoint' is a genuine error. Disjointness forces every degree to ≤ 1, which is overkill: degree ≤ 2 already kills every C(deg-1,2) term. Pairwise overlaps are completely harmless to the second Bonferroni bound — only triple coverage matters.",
+      "The sharp criterion has three faces: combinatorial (every element in ≤ 2 sets), geometric (all triple intersections empty), and algebraic (the third sieve layer S₃ vanishes). All three are proved equivalent.",
+      "Reusing the general truncated-sieve file avoids re-deriving the hard reindexing: the second Bonferroni inequality is literally the m = 2 instance, and the only genuinely new work is the union-vs-complement bookkeeping and the exact C(deg-1,2) defect.",
+      "Working with the integer-valued sieve sidesteps natural-number subtraction entirely, so the defect identity and the partition |U| + noneCard = |α| combine by linarith without case splits."
+    ],
+    "prerequisites": [
+      "InclusionExclusionBonferroniGeneral (sibling: truncated sieve bonf, per-element reindexing, Pascal telescoping)",
+      "Finset.sum_eq_zero_iff_of_nonneg (a non-negative sum vanishes iff every term does)",
+      "Nat.choose_eq_zero_iff (C(n,k) = 0 ⟺ n < k)",
+      "Finset.two_lt_card_iff (a set of size > 2 contains three distinct elements)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Machine-verified second Bonferroni inequality |⋃ᵢ Aᵢ| ≥ Σ|Aᵢ| - Σ|Aᵢ∩Aⱼ| for an arbitrary finite family, with the exact defect Σ_{x∈U} C(deg x - 1, 2) and a sharp tightness criterion: equality holds iff every element lies in at most two sets, equivalently iff all triple intersections are empty. Disjointness is shown sufficient but not necessary, with an explicit overlapping witness. 15 theorems, 4 definitions, 0 axioms, 328 lines.",
+    "implications": "This closes the parent file's open question and corrects its conjectured 'disjoint families' tightness condition. The exact-defect identity turns a one-sided inequality into an equality with an explicit error term, the pattern needed for quantitative sieve estimates. The combinatorial/geometric/algebraic trichotomy of the tightness criterion provides three reusable characterisations of 'no triple overlaps' for a finite set family.",
+    "openQuestions": [
+      "Generalise the exact-defect identity to the m-th Bonferroni truncation: |U| - bonf-style m-truncation = ±Σ_{x∈U} C(deg x - 1, m), and read off the sharp tightness criterion 'every element in ≤ m sets' / 'all (m+1)-fold intersections empty' uniformly in m.",
+      "Transport the union-form second Bonferroni inequality and its sharp tightness criterion to the probabilistic setting (measures / probabilities of events) via the indicator-function bridge, recovering the classical probabilistic Bonferroni lower bound P(⋃ Eᵢ) ≥ ΣP(Eᵢ) - Σ P(Eᵢ∩Eⱼ)."
+    ]
+  },
+  "leanFile": {
+    "namespace": "InclusionExclusionSecondBonferroni",
+    "lineCount": 328,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 4,
+    "path": "Proofs/InclusionExclusionSecondBonferroni.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "parent: proves the first Bonferroni inequality (union bound |U| ≤ S₁) and poses the second Bonferroni inequality with its tightness characterisation as an open question; this file answers it and corrects the conjectured 'disjoint families' condition"
+    },
+    {
+      "targetId": "inclusion-exclusion-oq-04-oq-03",
+      "relationship": "uses",
+      "description": "sibling: the general truncated-sieve machinery (bonf, per-element reindexing, Pascal telescoping) is reused; the second Bonferroni inequality is the m = 2 instance, recast in union form with an exact defect"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-2bonf-header",
+      "title": "Header and Imports",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Imports Mathlib and the sibling InclusionExclusionBonferroniGeneral. Documents the union-form statement |U| ≥ S₁ - S₂, the exact defect Σ C(deg-1,2), the sharp tightness criterion, and the correction to the 'disjoint families' folklore."
+    },
+    {
+      "id": "sec-2bonf-union-sums",
+      "title": "Part I: Union and the Two Sieve Sums",
+      "startLine": 61,
+      "endLine": 102,
+      "summary": "Defines unionSet (positive-degree elements, proved equal to the indexed biUnion), S1 = Σᵢ|Aᵢ|, S2 = Σ_{|J|=2}|⋂Aᵢ|, plus interCard_pair showing each size-2 layer term is a genuine pairwise intersection |Aᵢ∩Aⱼ|."
+    },
+    {
+      "id": "sec-2bonf-degrees",
+      "title": "Part II: Layers via Degrees",
+      "startLine": 103,
+      "endLine": 159,
+      "summary": "Proves deg_eq_zero_iff, the double-counting identity Σᵢ|Aᵢ| = Σ_x deg x, S1 = sieveLayer 1, sieveLayer 0 = |α|, the second sieve bonf A 2 = |α| - S₁ + S₂, and the universe partition |U| + noneCard = |α|."
+    },
+    {
+      "id": "sec-2bonf-defect",
+      "title": "Part III: The Exact Bonferroni Defect",
+      "startLine": 160,
+      "endLine": 203,
+      "summary": "Evaluates the per-element truncation error at m = 2 to C(deg-1,2) via Pascal telescoping, then assembles the exact defect identity |U| - (S₁ - S₂) = Σ_{x∈U} C(deg x - 1, 2)."
+    },
+    {
+      "id": "sec-2bonf-inequality",
+      "title": "Part IV: Inequality and Sharp Tightness",
+      "startLine": 204,
+      "endLine": 284,
+      "summary": "Reads off second_bonferroni (S₁ - S₂ ≤ |U|), the sharp tightness criterion second_bonferroni_eq_iff (∀ x, deg x ≤ 2), and the equivalent geometric (all triple intersections empty) and algebraic (S₃ = 0) forms."
+    },
+    {
+      "id": "sec-2bonf-disjoint",
+      "title": "Parts V–VI: Disjointness Sufficient, Not Necessary",
+      "startLine": 285,
+      "endLine": 328,
+      "summary": "Proves disjoint_imp_tight (pairwise-disjoint families are tight) and exhibits exFam over Fin 3 — sets {0,1} and {1,2} overlapping in 1 — which is tight despite the non-empty pairwise intersection, all verified by decide."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question posed in the parent gallery file **inclusion-exclusion-oq-01-oq-01**: prove the **second Bonferroni inequality** in union form and characterise its tightness.

For an arbitrary finite family `A : ι → Finset α`, with `U = ⋃ᵢ Aᵢ`, `S₁ = Σᵢ|Aᵢ|`, `S₂ = Σ_{i<j}|Aᵢ∩Aⱼ|`:

```
|U| ≥ S₁ − S₂            (second_bonferroni)
```

and, going further, the **exact defect**

```
|U| − (S₁ − S₂) = Σ_{x∈U} C(deg x − 1, 2)   (union_card_sub_eq_gap)
```

where `deg x = #{i : x ∈ Aᵢ}`. Since each term is a binomial coefficient the inequality is immediate, and equality is characterised sharply:

```
|U| = S₁ − S₂  ⟺  ∀ x, deg x ≤ 2  ⟺  all triple intersections empty  (⟺ S₃ = 0)
```

## A correction to the folklore claim

The bound is often stated to be tight exactly for **disjoint** families. That is only *sufficient*: pairwise overlaps are harmless to the truncated sieve — only triple coverage matters. We prove `disjoint_imp_tight`, then exhibit `exFam` over `Fin 3` (`{0,1}` and `{1,2}`, overlapping in `1`) where the bound is nonetheless exact (`|U| = 3 = 4 − 1`).

## Verification

- Host `lake env lean` against the repo's pinned toolchain (`leanprover/lean4:v4.26.0`) + pinned Mathlib (Docker daemon was down).
- **0 sorries.** All six key theorems depend only on `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool` (numerical witnesses use `decide`, not `native_decide`).
- 15 theorems, 4 definitions, 328 lines. Registered in `Proofs.lean`.

Reuses the general truncated-sieve machinery from sibling **inclusion-exclusion-oq-04-oq-03** (`InclusionExclusionBonferroniGeneral`); the second Bonferroni inequality is its `m = 2` instance, recast in union form with an exact defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)