### PR TITLE
audit: 2 fresh proofs clean (isoperimetric-fourier OQ0101, partition-theorem OQ02)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23811,6 +23811,18 @@
       "lastAudited": "2026-06-25T12:42:44Z",
       "result": "clean",
       "issues": []
+    },
+    "partition-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T12:53:36Z",
+      "result": "clean",
+      "issues": []
+    },
+    "isoperimetric-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T12:54:11Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the latest unaudited gallery proofs. Both **CLEAN** — no integrity issues.

### isoperimetric-theorem-oq-01-oq-01 — *The Fourier Method for the Isoperimetric Inequality (Hurwitz–Wirtinger)*
- Tier A for the algebraic core it claims. 7 theorems + 3 defs match meta; 0 sorry/axiom/native_decide/True-stubs.
- Genuine proofs (`ring`, `nlinarith`, `le_antisymm` chains) of the per-mode Hurwitz SOS identity, Wirtinger's inequality in coefficient form, the normalized isoperimetric inequality, and the equality (circle) characterization.
- **Honest framing**: title carries the `(Hurwitz–Wirtinger)` qualifier; `isoperimetric_fourier` carries the normalization hypotheses visibly in its statement; assumptions field explicitly discloses the Parseval bridge is documented (not re-derived). Badge `original` correct — Mathlib deps are just `Finset.sum` plumbing.

### partition-theorem-oq-02 — *Modulus-Monotonicity of Divisibility-Restricted Partition Counts*
- 5 theorems match meta (one docstring false-positive on `^theorem ` grep); 0 sorry/axiom/native_decide/True-stubs.
- The novel result `card_restricted_not_dvd_mono` (cross-modulus monotonicity `A_m(n) ≤ A_{m'}(n)` for `0 < m ≤ m'`) is **not** in Mathlib and is the file's own contribution.
- **No delegation opacity**: Glaisher (`card_restricted_eq_card_countRestricted`) and Euler (`card_odds_eq_card_distincts`) are used as imported lemmas and explicitly credited throughout docstring, description, and assumptions. Title names the new result, not a famous theorem. Badge `original`/status `verified` defensible.

Gallery audit-tracker updated: both marked `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)