### PR TITLE
research(gelfond-schneider-oq04): logarithm dichotomy + transcendence of log₂3 [axiomatized, 1 GS axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3054,6 +3054,7 @@ import Proofs.GcdAlgorithmOQ02
 import Proofs.GcdAlgorithmOQ04
 import Proofs.GcdAlgorithmOQ04OQ01
 import Proofs.GelfondSchneider
+import Proofs.GelfondSchneiderOQ04
 import Proofs.GeneralQuartic
 import Proofs.GeneralQuarticAxiomsDischarge
 import Proofs.GeometricSeries

--- a/proofs/Proofs/GelfondSchneiderOQ04.lean
+++ b/proofs/Proofs/GelfondSchneiderOQ04.lean
@@ -1,0 +1,187 @@
+import Mathlib
+
+/-
+# Gelfond–Schneider — OQ-04: The Logarithm Dichotomy and the Transcendence of log₂ 3
+
+## Research Problem: gelfond-schneider-oq-04
+
+The gallery parent (`gelfond-schneider`) records the Gelfond–Schneider theorem (Hilbert's 7th
+problem) as a stated assumption and derives the classic transcendental *constants* `2^√2`,
+`e^π`, `√2^√2`, `2^∛2`, together with the fact that `log a` is transcendental for algebraic
+`a ∉ {0, 1}`.
+
+This file proves the other principal number-theoretic consequence of Gelfond–Schneider — the
+one about *logarithms of one algebraic number to another algebraic base* — which the parent
+does not contain.
+
+## Main result — the logarithm dichotomy
+
+For positive algebraic reals `a, b` with `a ≠ 1`, the base-`a` logarithm of `b`,
+
+      log_a b  =  log b / log a,
+
+is **either rational or transcendental — never an irrational algebraic number.**
+
+Proof.  Suppose `β := log b / log a` were algebraic *and* irrational.  Since `a > 0`,
+
+      a ^ β  =  exp(β · log a)  =  exp(log b)  =  b      (using log a ≠ 0 and b > 0),
+
+so `a ^ β = b`.  But Gelfond–Schneider says `a ^ β` is transcendental (algebraic base
+`a ≠ 0, 1`, irrational algebraic exponent `β`), contradicting that `b` is algebraic.  Hence
+`β` cannot be both algebraic and irrational: it is rational or transcendental.  ∎
+
+## A concrete instance — log₂ 3 is transcendental
+
+The dichotomy upgrades *irrationality* of a logarithm to *transcendence* for free.  We supply
+the irrationality input in the cleanest classical case:
+
+* `irrational_log_three_div_log_two` — `log 3 / log 2 ∉ ℚ`.  A rational value `p/d` would give
+  `2^p = 3^d` for positive integers `p, d` (exponentiate `p · log 2 = d · log 3`), impossible
+  by parity: the left side is even and the right side is odd.
+* `transcendental_log_three_div_log_two` — feeding this into the dichotomy at the algebraic
+  bases `2, 3`, the non-rational ratio `log₂ 3` must be transcendental.
+
+## Assumption
+
+`gelfond_schneider_real` is re-declared here as an `axiom`, exactly as in the parent entry — the
+full Gelfond–Schneider proof (Siegel's lemma, auxiliary functions, zero estimates) is not
+formalized.  Every theorem below is otherwise fully machine-checked; `#print axioms` shows the
+only non-foundational dependency is this single Gelfond–Schneider assumption.
+
+Tags: transcendental-number-theory, gelfond-schneider, hilbert-7, logarithm, irrationality
+-/
+
+namespace GelfondSchneiderOQ04
+
+open Real
+
+/-- **Gelfond–Schneider theorem** (real form, Hilbert's 7th problem), stated as an assumption
+    exactly as in the gallery parent `gelfond-schneider`.  If `a` is a positive algebraic real
+    with `a ≠ 1`, and `b` is an irrational algebraic real, then `a ^ b` is transcendental
+    (not algebraic over `ℚ`). -/
+axiom gelfond_schneider_real (a b : ℝ) (ha_pos : 0 < a) (ha_ne_one : a ≠ 1)
+    (ha_alg : IsAlgebraic ℚ a) (hb_alg : IsAlgebraic ℚ b) (hb_irr : Irrational b) :
+    ¬ IsAlgebraic ℚ (a ^ b)
+
+/-- `log a ≠ 0` for a positive `a ≠ 1`. -/
+private lemma log_ne_zero_of_pos_ne_one {a : ℝ} (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) :
+    Real.log a ≠ 0 := by
+  rw [ne_eq, Real.log_eq_zero]
+  push_neg
+  exact ⟨ne_of_gt ha_pos, ha_ne_one, by linarith⟩
+
+/-- `a ^ (log b / log a) = b` for positive `a ≠ 1` and positive `b` — the identity that turns a
+    logarithm into an exponent for the dichotomy. -/
+private lemma rpow_logb_eq {a b : ℝ} (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) (hb_pos : 0 < b) :
+    a ^ (Real.log b / Real.log a) = b := by
+  have hla : Real.log a ≠ 0 := log_ne_zero_of_pos_ne_one ha_pos ha_ne_one
+  rw [Real.rpow_def_of_pos ha_pos]
+  have : Real.log a * (Real.log b / Real.log a) = Real.log b := by field_simp
+  rw [this, Real.exp_log hb_pos]
+
+/-- **The Gelfond–Schneider logarithm dichotomy.**
+
+    For positive algebraic reals `a, b` with `a ≠ 1`, the ratio `log b / log a` (the base-`a`
+    logarithm of `b`) is *either rational or transcendental* — it is never an irrational
+    algebraic number.
+
+    If it were algebraic and irrational, then `a ^ (log b / log a) = b` would be transcendental
+    by Gelfond–Schneider, contradicting that `b` is algebraic. -/
+theorem gelfond_schneider_logb_dichotomy
+    (a b : ℝ) (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) (hb_pos : 0 < b)
+    (ha_alg : IsAlgebraic ℚ a) (hb_alg : IsAlgebraic ℚ b) :
+    (∃ q : ℚ, (q : ℝ) = Real.log b / Real.log a) ∨
+      ¬ IsAlgebraic ℚ (Real.log b / Real.log a) := by
+  by_cases hrat : ∃ q : ℚ, (q : ℝ) = Real.log b / Real.log a
+  · exact Or.inl hrat
+  · right
+    intro hβ_alg
+    have hβ_irr : Irrational (Real.log b / Real.log a) := hrat
+    have hab : a ^ (Real.log b / Real.log a) = b := rpow_logb_eq ha_pos ha_ne_one hb_pos
+    have htr := gelfond_schneider_real a (Real.log b / Real.log a) ha_pos ha_ne_one ha_alg
+      hβ_alg hβ_irr
+    rw [hab] at htr
+    exact htr hb_alg
+
+/-- **`log 3 / log 2` is irrational.**  A rational value would force `2^p = 3^d` for positive
+    integers `p, d`, impossible by parity (an even number equal to an odd number). -/
+theorem irrational_log_three_div_log_two : Irrational (Real.log 3 / Real.log 2) := by
+  rw [Irrational]
+  rintro ⟨q, hq⟩
+  have hl2 : (0 : ℝ) < Real.log 2 := Real.log_pos (by norm_num)
+  have hl3 : (0 : ℝ) < Real.log 3 := Real.log_pos (by norm_num)
+  have hqpos : (0 : ℝ) < (q : ℝ) := by rw [hq]; positivity
+  have hqnum_pos : 0 < q.num := by
+    rwa [Rat.num_pos, ← Rat.cast_pos (K := ℝ)]
+  have hden : (0 : ℝ) < (q.den : ℝ) := by exact_mod_cast q.pos
+  -- cross-multiplied real relation:  q.num · log 2 = q.den · log 3
+  have hcross : (q.num : ℝ) * Real.log 2 = (q.den : ℝ) * Real.log 3 := by
+    have hqeq : (q : ℝ) = (q.num : ℝ) / (q.den : ℝ) := by exact_mod_cast (Rat.num_div_den q).symm
+    rw [hqeq] at hq
+    field_simp at hq
+    nlinarith [hq, hl2, hl3]
+  -- pass to natural-number exponents
+  set N : ℕ := q.num.toNat with hN
+  have hNcast : (N : ℝ) = (q.num : ℝ) := by
+    rw [hN]; exact_mod_cast Int.toNat_of_nonneg (le_of_lt hqnum_pos)
+  have hNpos : 0 < N := by rw [hN]; omega
+  have hlog : Real.log ((2 : ℝ) ^ N) = Real.log ((3 : ℝ) ^ q.den) := by
+    rw [Real.log_pow, Real.log_pow]
+    rw [hNcast]
+    linarith [hcross]
+  have hpow : (2 : ℝ) ^ N = (3 : ℝ) ^ q.den := by
+    have h2 : (0 : ℝ) < (2 : ℝ) ^ N := by positivity
+    have h3 : (0 : ℝ) < (3 : ℝ) ^ q.den := by positivity
+    have := congrArg Real.exp hlog
+    rwa [Real.exp_log h2, Real.exp_log h3] at this
+  have hnat : (2 : ℕ) ^ N = (3 : ℕ) ^ q.den := by
+    have : ((2 ^ N : ℕ) : ℝ) = ((3 ^ q.den : ℕ) : ℝ) := by push_cast; exact hpow
+    exact_mod_cast this
+  -- parity contradiction:  2 ∣ 2^N = 3^d  ⟹  2 ∣ 3
+  have hdvd : (2 : ℕ) ∣ 3 ^ q.den := by
+    rw [← hnat]; exact dvd_pow_self 2 hNpos.ne'
+  have : (2 : ℕ) ∣ 3 := Nat.Prime.dvd_of_dvd_pow Nat.prime_two hdvd
+  norm_num at this
+
+/-- **`log₂ 3` is transcendental.**  Combining the irrationality of `log 3 / log 2` with the
+    Gelfond–Schneider logarithm dichotomy (applied to the algebraic bases `2, 3`): since the
+    ratio is not rational, it must be transcendental. -/
+theorem transcendental_log_three_div_log_two :
+    ¬ IsAlgebraic ℚ (Real.log 3 / Real.log 2) := by
+  have halg2 : IsAlgebraic ℚ (2 : ℝ) := by
+    have := isAlgebraic_int (R := ℚ) (A := ℝ) 2; simpa using this
+  have halg3 : IsAlgebraic ℚ (3 : ℝ) := by
+    have := isAlgebraic_int (R := ℚ) (A := ℝ) 3; simpa using this
+  rcases gelfond_schneider_logb_dichotomy 2 3 (by norm_num) (by norm_num) (by norm_num)
+      halg2 halg3 with hrat | htr
+  · exfalso
+    obtain ⟨q, hq⟩ := hrat
+    exact irrational_log_three_div_log_two ⟨q, hq⟩
+  · exact htr
+
+#check @gelfond_schneider_logb_dichotomy
+#check @irrational_log_three_div_log_two
+#check @transcendental_log_three_div_log_two
+
+/-
+## Summary
+
+Proved (0 sorries; the single non-foundational assumption is the Gelfond–Schneider theorem
+`gelfond_schneider_real`, re-declared as an axiom exactly as in the parent entry; imports only
+Mathlib):
+
+* `gelfond_schneider_logb_dichotomy` — for positive algebraic `a, b` with `a ≠ 1`, the ratio
+  `log b / log a` is rational or transcendental, never an irrational algebraic number.
+* `irrational_log_three_div_log_two` — `log 3 / log 2 ∉ ℚ` (parity of `2^p = 3^d`).
+* `transcendental_log_three_div_log_two` — hence `log₂ 3` is transcendental.
+
+The dichotomy is the structural heart: Gelfond–Schneider, usually invoked to produce
+transcendental *constants*, here forbids an *irrational algebraic logarithm*, converting any
+irrationality fact about `log_a b` (for algebraic `a, b`) into transcendence.  `log₂ 3` is the
+cleanest concrete witness.
+-/
+
+end GelfondSchneiderOQ04
+
+#print axioms GelfondSchneiderOQ04.gelfond_schneider_logb_dichotomy
+#print axioms GelfondSchneiderOQ04.transcendental_log_three_div_log_two

--- a/src/data/proofs/gelfond-schneider-oq-04/annotations.json
+++ b/src/data/proofs/gelfond-schneider-oq-04/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "gelfond-schneider-oq-04",
+    "range": { "startLine": 3, "endLine": 54 },
+    "type": "context",
+    "title": "Gelfond-Schneider as a Constraint on Logarithms",
+    "content": "The parent entry uses Gelfond-Schneider to produce transcendental constants (2^√2, e^π, ...). Its other principal consequence concerns logarithms: log_a b cannot be an irrational algebraic number when a, b are algebraic. This file proves that dichotomy and applies it to log₂ 3. Gelfond-Schneider itself is re-declared as an axiom, exactly as in the parent — the entry's value is the new logarithm reasoning built on top of it.",
+    "mathContext": "$\\log_a b=\\dfrac{\\log b}{\\log a}\\in\\mathbb{Q}\\ \\text{or transcendental, never irrational algebraic}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gelfond-Schneider theorem",
+      "Hilbert's 7th problem",
+      "transcendence",
+      "logarithm"
+    ],
+    "prerequisites": [
+      "algebraic and transcendental numbers",
+      "real logarithm"
+    ]
+  },
+  {
+    "id": "ann-identity",
+    "proofId": "gelfond-schneider-oq-04",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "lemma",
+    "title": "Turning the Logarithm Back into an Exponent",
+    "content": "rpow_logb_eq proves a^(log b/log a) = b for positive a ≠ 1 and positive b. Using Real.rpow_def_of_pos, a^x = exp(x · log a); with x = log b/log a and log a ≠ 0, the exponent simplifies to log b, and Real.exp_log gives b. This identity is what lets Gelfond-Schneider — a statement about a^b — speak about the logarithm log b/log a.",
+    "mathContext": "$a^{\\log b/\\log a}=\\exp\\!\\big(\\tfrac{\\log b}{\\log a}\\cdot\\log a\\big)=\\exp(\\log b)=b$",
+    "significance": "high",
+    "relatedConcepts": [
+      "real power",
+      "exponential-logarithm inverse"
+    ],
+    "prerequisites": [
+      "Real.rpow_def_of_pos",
+      "Real.exp_log"
+    ]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "gelfond-schneider-oq-04",
+    "range": { "startLine": 84, "endLine": 106 },
+    "type": "theorem",
+    "title": "The Logarithm Dichotomy",
+    "content": "gelfond_schneider_logb_dichotomy: for positive algebraic a, b with a ≠ 1, log b/log a is rational or transcendental. The proof splits on whether the ratio is rational; if not, it is irrational, and were it also algebraic, then a^(log b/log a) = b would be transcendental by Gelfond-Schneider — contradicting that b is algebraic. So an irrational algebraic logarithm is impossible.",
+    "mathContext": "$\\beta=\\tfrac{\\log b}{\\log a}\\ \\text{algebraic}\\wedge\\text{irrational}\\Rightarrow a^\\beta=b\\ \\text{transcendental},\\ \\text{contra } b\\ \\text{algebraic}$",
+    "significance": "high",
+    "relatedConcepts": [
+      "Gelfond-Schneider theorem",
+      "dichotomy",
+      "proof by contradiction"
+    ],
+    "prerequisites": [
+      "Gelfond-Schneider theorem",
+      "rationality case split"
+    ]
+  },
+  {
+    "id": "ann-irrational",
+    "proofId": "gelfond-schneider-oq-04",
+    "range": { "startLine": 108, "endLine": 147 },
+    "type": "theorem",
+    "title": "log 3 / log 2 is Irrational (Unconditional)",
+    "content": "irrational_log_three_div_log_two needs NO Gelfond-Schneider assumption. A rational value p/d (positive, in lowest terms) cross-multiplies to N · log 2 = d · log 3, i.e. log(2^N) = log(3^d), hence 2^N = 3^d as naturals (N ≥ 1). But 2 divides 2^N = 3^d forces 2 ∣ 3 by Nat.Prime.dvd_of_dvd_pow — false. Parity (even = odd) kills it.",
+    "mathContext": "$\\tfrac{\\log 3}{\\log 2}=\\tfrac{N}{d}\\Rightarrow 2^N=3^d,\\ N,d\\ge 1\\Rightarrow 2\\mid 3^d\\Rightarrow 2\\mid 3,\\ \\bot$",
+    "significance": "high",
+    "relatedConcepts": [
+      "irrationality",
+      "unique factorization",
+      "parity argument"
+    ],
+    "prerequisites": [
+      "Real.log_pow",
+      "Nat.Prime.dvd_of_dvd_pow"
+    ]
+  },
+  {
+    "id": "ann-transcendental",
+    "proofId": "gelfond-schneider-oq-04",
+    "range": { "startLine": 149, "endLine": 160 },
+    "type": "theorem",
+    "title": "log₂ 3 is Transcendental",
+    "content": "transcendental_log_three_div_log_two applies the dichotomy at the algebraic bases 2 and 3: log 3/log 2 is rational or transcendental, and since it is not rational (the previous theorem), it is transcendental. The dichotomy upgrades irrationality to transcendence at no extra cost.",
+    "mathContext": "$\\log_2 3\\notin\\mathbb{Q}\\ \\wedge\\ (\\log_2 3\\in\\mathbb{Q}\\vee\\log_2 3\\ \\text{transc.})\\Rightarrow\\log_2 3\\ \\text{transcendental}$",
+    "significance": "high",
+    "relatedConcepts": [
+      "transcendence",
+      "logarithm dichotomy"
+    ],
+    "prerequisites": [
+      "the logarithm dichotomy",
+      "irrationality of log₂ 3"
+    ]
+  }
+]

--- a/src/data/proofs/gelfond-schneider-oq-04/index.ts
+++ b/src/data/proofs/gelfond-schneider-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GelfondSchneiderOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gelfondSchneiderOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gelfondSchneiderOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gelfondSchneiderOq04Data: ProofData = {
+  proof: gelfondSchneiderOq04Proof,
+  annotations: gelfondSchneiderOq04Annotations,
+}

--- a/src/data/proofs/gelfond-schneider-oq-04/meta.json
+++ b/src/data/proofs/gelfond-schneider-oq-04/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "gelfond-schneider-oq-04",
+  "title": "The Gelfond-Schneider Logarithm Dichotomy: log₂ 3 is Transcendental",
+  "slug": "gelfond-schneider-oq-04",
+  "description": "From the Gelfond-Schneider theorem, the base-a logarithm of an algebraic b (log b / log a, a and b positive algebraic, a ≠ 1) is either rational or transcendental — never an irrational algebraic number. As a concrete instance, log 3 / log 2 is proved irrational (a rational value forces 2^p = 3^d, impossible by parity), hence transcendental. Formalized in Lean 4 over Mathlib; the Gelfond-Schneider theorem itself is a stated assumption, as in the parent entry.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/GelfondSchneiderOQ04.lean",
+    "tags": [
+      "transcendental-number-theory",
+      "gelfond-schneider",
+      "hilbert-7",
+      "logarithm",
+      "irrationality",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 187,
+    "assumptions": "One stated assumption: gelfond_schneider_real, the real form of the Gelfond-Schneider theorem (positive algebraic base a ≠ 1, irrational algebraic exponent b ⟹ a^b transcendental), re-declared as an `axiom` exactly as in the gallery parent `gelfond-schneider` — the full Gelfond-Schneider proof (Siegel's lemma, auxiliary functions, zero estimates) is not formalized. Every theorem in this file is otherwise fully machine-checked: `lake env lean` builds Proofs/GelfondSchneiderOQ04.lean to exit 0 against the pinned Mathlib (v4.26.0), and #print axioms reports, beyond the foundational propext / Classical.choice / Quot.sound, only the single GelfondSchneiderOQ04.gelfond_schneider_real assumption (no sorryAx, no Lean.ofReduceBool). In particular irrational_log_three_div_log_two depends on NO Gelfond-Schneider assumption — it is unconditional. The file imports only Mathlib.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.rpow_def_of_pos",
+        "description": "a^x = exp(x · log a) for a > 0 — turns the logarithm log b / log a back into the exponent that makes a^(log b/log a) = b, the identity at the heart of the dichotomy.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.exp_log",
+        "description": "exp(log x) = x for x > 0 — closes a^(log b/log a) = b and recovers 2^N = 3^d from equality of logarithms.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_pow",
+        "description": "log(x^n) = n · log x — converts the cross-multiplied relation N · log 2 = d · log 3 into log(2^N) = log(3^d).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_of_dvd_pow",
+        "description": "a prime dividing a power divides the base — delivers the parity contradiction 2 ∣ 3^d ⟹ 2 ∣ 3.",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "isAlgebraic_int",
+        "description": "every integer is algebraic — supplies IsAlgebraic ℚ 2 and IsAlgebraic ℚ 3 for the concrete instance.",
+        "module": "Mathlib.RingTheory.Algebraic.Basic"
+      }
+    ],
+    "originalContributions": [
+      "gelfond_schneider_logb_dichotomy: for positive algebraic a, b with a ≠ 1, the ratio log b / log a is rational OR transcendental, never an irrational algebraic number — proved by observing a^(log b/log a) = b and applying Gelfond-Schneider to forbid an irrational algebraic exponent. This is the principal logarithm consequence of Gelfond-Schneider, absent from the parent entry which records only transcendental constants and the transcendence of log a.",
+      "irrational_log_three_div_log_two: log 3 / log 2 is irrational, proved unconditionally (no Gelfond-Schneider assumption) — a rational value p/d would give 2^p = 3^d for positive integers, impossible since 2^p is even and 3^d is odd.",
+      "transcendental_log_three_div_log_two: log₂ 3 is transcendental, obtained by feeding the irrationality into the dichotomy at the algebraic bases 2 and 3 — the dichotomy upgrades irrationality to transcendence for free."
+    ],
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Gelfond-Schneider theorem (1934, resolving Hilbert's 7th problem) is best known for producing transcendental constants such as 2^√2 and e^π. Equally important is its consequence for logarithms: it forbids log_a b (for algebraic a, b) from being an irrational algebraic number. The gallery parent `gelfond-schneider` develops the constants and the transcendence of log a, but not this logarithm dichotomy.",
+    "problemStatement": "What can be said about log_a b = log b / log a when a and b are algebraic? In particular, can a base-a logarithm of an algebraic number be an irrational algebraic number — and is log₂ 3 transcendental?",
+    "text": "If log b / log a were algebraic and irrational, then a^(log b/log a) = exp(log b) = b would be transcendental by Gelfond-Schneider, contradicting that b is algebraic. Hence log b / log a is rational or transcendental. Applied to a = 2, b = 3 and combined with the (unconditional) irrationality of log 3 / log 2 — which would otherwise force the impossible identity 2^p = 3^d between an even and an odd number — this yields the transcendence of log₂ 3."
+  },
+  "sections": [
+    {
+      "id": "assumption-and-identity",
+      "title": "The Assumption and the Logarithm-to-Exponent Identity",
+      "summary": "States the Gelfond-Schneider theorem as an axiom (as in the parent) and proves the supporting identity a^(log b/log a) = b for positive a ≠ 1 and positive b, via rpow_def_of_pos and exp_log.",
+      "startLine": 56,
+      "endLine": 82
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Logarithm Dichotomy",
+      "summary": "gelfond_schneider_logb_dichotomy: log b / log a is rational or transcendental. The proof splits on rationality; in the irrational case, an algebraic value would make a^(log b/log a) = b transcendental, contradicting that b is algebraic.",
+      "startLine": 84,
+      "endLine": 106
+    },
+    {
+      "id": "log-two-three",
+      "title": "log₂ 3: Irrational, hence Transcendental",
+      "summary": "irrational_log_three_div_log_two proves log 3 / log 2 ∉ ℚ unconditionally via the parity of 2^p = 3^d; transcendental_log_three_div_log_two feeds this into the dichotomy at bases 2 and 3.",
+      "startLine": 108,
+      "endLine": 160
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 sorries; the sole non-foundational assumption is the Gelfond-Schneider theorem, re-declared as an axiom as in the parent): the base-a logarithm of an algebraic b is rational or transcendental, never an irrational algebraic number, and log₂ 3 is transcendental. The irrationality of log 3 / log 2 is established unconditionally.",
+    "implications": "Recasts Gelfond-Schneider as a constraint on logarithms rather than a generator of constants: it forbids irrational algebraic logarithms of algebraic numbers, so any irrationality fact about log_a b (for algebraic a, b) automatically upgrades to transcendence. log₂ 3 is the cleanest concrete witness; the same template gives transcendence of log_a b for any algebraic a, b whose logarithm ratio is known irrational.",
+    "openQuestions": [
+      "Generalize the concrete instance to log_p q for distinct primes p, q, or to log_a b for any multiplicatively independent positive algebraic a, b.",
+      "Formalize the parent's Gelfond-Schneider axiom from Baker's theorem, which would discharge the assumption used here and make the dichotomy unconditional.",
+      "Establish a quantitative (effective) lower bound on |log b / log a − p/d| in the rational-approximation sense, as Baker's effective method provides."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "gelfond-schneider",
+      "relationship": "parent-problem",
+      "description": "Parent: the Gelfond-Schneider theorem (Hilbert's 7th) and its transcendental constants 2^√2, e^π, √2^√2, 2^∛2, plus transcendence of log a. This entry adds the logarithm dichotomy and the transcendence of log₂ 3, which the parent does not cover."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Aleksandr Gelfond"
+      ],
+      "title": "Sur le septième problème de Hilbert",
+      "year": "1934",
+      "venue": "Bulletin de l'Académie des Sciences de l'URSS",
+      "note": "Original resolution of Hilbert's 7th problem"
+    },
+    {
+      "authors": [
+        "Alan Baker"
+      ],
+      "title": "Transcendental Number Theory",
+      "year": "1975",
+      "venue": "Cambridge University Press",
+      "note": "Gelfond-Schneider, its logarithm consequences, and effective generalizations"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "GelfondSchneiderOQ04",
+    "lineCount": 187,
+    "axiomCount": 1,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/GelfondSchneiderOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Problem

`gelfond-schneider-oq-04` — develop the principal **logarithm** consequence of Gelfond–Schneider. The gallery parent (`gelfond-schneider`) records the theorem and its transcendental *constants* (`2^√2`, `e^π`, `√2^√2`, `2^∛2`) plus the transcendence of `log a`, but **not** the logarithm dichotomy.

## Main result

For positive algebraic reals `a, b` with `a ≠ 1`, the base-`a` logarithm

```
log_a b = log b / log a   is rational OR transcendental — never an irrational algebraic number.
```

**Proof.** If `β := log b / log a` were algebraic *and* irrational, then (since `a > 0`, `log a ≠ 0`, `b > 0`)

```
a ^ β = exp(β · log a) = exp(log b) = b,
```

so `a^β = b`. But Gelfond–Schneider says `a^β` is transcendental (algebraic base `a ≠ 0,1`, irrational algebraic exponent `β`), contradicting that `b` is algebraic. ∎

## Concrete instance — `log₂ 3` is transcendental

The dichotomy upgrades *irrationality* to *transcendence* for free:

- `irrational_log_three_div_log_two` — `log 3 / log 2 ∉ ℚ`, proved **unconditionally** (no GS assumption): a rational value `p/d` forces `2^p = 3^d` for positive integers, impossible by parity (`2^p` even, `3^d` odd).
- `transcendental_log_three_div_log_two` — feeding this into the dichotomy at bases `2, 3` makes `log₂ 3` transcendental.

## Theorems (`proofs/Proofs/GelfondSchneiderOQ04.lean`)

- `gelfond_schneider_logb_dichotomy` — the dichotomy.
- `irrational_log_three_div_log_two` — unconditional irrationality of `log₂ 3`.
- `transcendental_log_three_div_log_two` — transcendence of `log₂ 3`.

## Assumption & verification

- `gelfond_schneider_real` is re-declared as an `axiom` **exactly as in the parent** entry; the full Gelfond–Schneider proof (Siegel's lemma, auxiliary functions, zero estimates) is not formalized. → `status: axiomatized`, `badge: axiom`, `axiomCount: 1`.
- `lake env lean` exits **0** against pinned Mathlib **v4.26.0** (imports only `Mathlib`).
- `#print axioms` shows, beyond `propext / Classical.choice / Quot.sound`, only the single `gelfond_schneider_real` assumption — **no `sorryAx`, no `Lean.ofReduceBool`**. `irrational_log_three_div_log_two` depends on **no** GS assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)