### PR TITLE
research(combinations-oq04): log-concavity of a Pascal row [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -880,6 +880,7 @@ import Proofs.CombinationsFormulaOQ02Aristotle
 import Proofs.CombinationsFormulaOQ02OQ01
 import Proofs.CombinationsFormulaOQ03
 import Proofs.CombinationsFormulaOQ03OQ06
+import Proofs.CombinationsFormulaOQ04
 import Proofs.CombinationsFormulaOQ05
 import Proofs.CombinationsFormulaOQ05OQ01
 import Proofs.CombinationsFormulaOQ05OQ01OQ01

--- a/proofs/Proofs/CombinationsFormulaOQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ04.lean
@@ -1,0 +1,135 @@
+import Mathlib
+
+/-
+# Combinations Formula — OQ-04: Log-Concavity of a Pascal Row
+
+## Research Problem: combinations-formula-oq-04
+
+The parent (`combinations-formula`) is the basic count `C(n,k) = n!/(k!(n-k)!)`, and the large
+sibling family develops binomial *identities* — Vandermonde, hockey-stick, Catalan numbers,
+sums of squares, weighted moments, alternating sums, q-analogs.  Every one of them is an
+*equality*.
+
+This file proves the row's fundamental *inequality*: **each Pascal row `k ↦ C(n,k)` is
+log-concave**,
+
+      C(n,k) · C(n,k+2)  ≤  C(n,k+1)²        for all n, k,
+
+with **strict** inequality throughout the interior (`k + 2 ≤ n`).  This is the binomial case of
+Newton's inequalities and the structural reason the row is unimodal (Mathlib already has the
+unimodal maximum `Nat.choose_le_middle`, but not the log-concavity that underlies it).  Mathlib
+has the ratio relation `Nat.choose_succ_right_eq` but no log-concavity statement.
+
+## The mechanism
+
+Write `a = C(n,k)`, `b = C(n,k+1)`, `c = C(n,k+2)`.  Mathlib's `choose_succ_right_eq` gives the
+two adjacent-ratio relations (after substituting `n = k + 2 + t`, eliminating all truncated
+subtraction):
+
+      a · (t+2) = b · (k+1),        c · (k+2) = b · (t+1).
+
+Multiplying,
+
+      a · c · (t+2)(k+2)  =  b² · (k+1)(t+1).
+
+Since `(k+1)(t+1) < (t+2)(k+2)` — their difference is `t + k + 3 > 0` — and `(t+2)(k+2) > 0`,
+cancelling the common positive factor yields `a · c ≤ b²` (strictly when `b > 0`, i.e. in the
+interior).  Outside the row (`n < k+2`) the coefficient `c` vanishes and the bound is trivial.
+
+## What is proved
+
+* `choose_mul_choose_le_sq` — `C(n,k) · C(n,k+2) ≤ C(n,k+1)²` for all `n, k`.
+* `choose_mul_choose_lt_sq` — the strict form for `k + 2 ≤ n`.
+* `choose_mul_choose_le_sq'` — the centered restatement `C(n,j−1) · C(n,j+1) ≤ C(n,j)²`.
+
+Tags: combinatorics, binomial-coefficients, pascals-triangle, log-concavity, newton-inequality
+-/
+
+namespace CombinationsFormulaOQ04
+
+open Nat
+
+/-- **Log-concavity of a Pascal row.**  Along any fixed row `n`, consecutive binomial
+    coefficients satisfy `C(n,k) · C(n,k+2) ≤ C(n,k+1)²`.  Outside the row the right factor
+    vanishes and the bound is trivial; inside, it is the cancelled form of the two
+    adjacent-ratio relations from `choose_succ_right_eq`. -/
+theorem choose_mul_choose_le_sq (n k : ℕ) :
+    n.choose k * n.choose (k + 2) ≤ (n.choose (k + 1)) ^ 2 := by
+  rcases lt_or_ge n (k + 2) with h | h
+  · rw [Nat.choose_eq_zero_of_lt h]; simp
+  · obtain ⟨t, rfl⟩ : ∃ t, n = k + 2 + t := ⟨n - (k + 2), by omega⟩
+    have R1 : (k + 2 + t).choose (k + 1) * (k + 1) = (k + 2 + t).choose k * (t + 2) := by
+      have := Nat.choose_succ_right_eq (k + 2 + t) k
+      simpa [show (k + 2 + t) - k = t + 2 by omega] using this
+    have R2 : (k + 2 + t).choose (k + 2) * (k + 2) = (k + 2 + t).choose (k + 1) * (t + 1) := by
+      have := Nat.choose_succ_right_eq (k + 2 + t) (k + 1)
+      simpa [show (k + 2 + t) - (k + 1) = t + 1 by omega] using this
+    set a := (k + 2 + t).choose k
+    set b := (k + 2 + t).choose (k + 1)
+    set c := (k + 2 + t).choose (k + 2)
+    have e1 : a * (t + 2) = b * (k + 1) := R1.symm
+    have e2 : c * (k + 2) = b * (t + 1) := R2
+    have hmul : a * c * ((t + 2) * (k + 2)) = b ^ 2 * ((k + 1) * (t + 1)) := by
+      have step : a * c * ((t + 2) * (k + 2)) = (a * (t + 2)) * (c * (k + 2)) := by ring
+      rw [step, e1, e2]; ring
+    have hle : (k + 1) * (t + 1) ≤ (t + 2) * (k + 2) := by nlinarith
+    have hpos : 0 < (t + 2) * (k + 2) := by positivity
+    have hfinal : a * c * ((t + 2) * (k + 2)) ≤ b ^ 2 * ((t + 2) * (k + 2)) := by
+      rw [hmul]; exact Nat.mul_le_mul (le_refl (b ^ 2)) hle
+    exact Nat.le_of_mul_le_mul_right hfinal hpos
+
+/-- **Strict log-concavity in the interior of the row.**  For `k + 2 ≤ n`, the inequality is
+    strict: `C(n,k) · C(n,k+2) < C(n,k+1)²`.  This is the binomial case of Newton's
+    inequalities. -/
+theorem choose_mul_choose_lt_sq (n k : ℕ) (h : k + 2 ≤ n) :
+    n.choose k * n.choose (k + 2) < (n.choose (k + 1)) ^ 2 := by
+  obtain ⟨t, rfl⟩ : ∃ t, n = k + 2 + t := ⟨n - (k + 2), by omega⟩
+  have R1 : (k + 2 + t).choose (k + 1) * (k + 1) = (k + 2 + t).choose k * (t + 2) := by
+    have := Nat.choose_succ_right_eq (k + 2 + t) k
+    simpa [show (k + 2 + t) - k = t + 2 by omega] using this
+  have R2 : (k + 2 + t).choose (k + 2) * (k + 2) = (k + 2 + t).choose (k + 1) * (t + 1) := by
+    have := Nat.choose_succ_right_eq (k + 2 + t) (k + 1)
+    simpa [show (k + 2 + t) - (k + 1) = t + 1 by omega] using this
+  set a := (k + 2 + t).choose k
+  set b := (k + 2 + t).choose (k + 1) with hb
+  set c := (k + 2 + t).choose (k + 2)
+  have e1 : a * (t + 2) = b * (k + 1) := R1.symm
+  have e2 : c * (k + 2) = b * (t + 1) := R2
+  have hmul : a * c * ((t + 2) * (k + 2)) = b ^ 2 * ((k + 1) * (t + 1)) := by
+    have step : a * c * ((t + 2) * (k + 2)) = (a * (t + 2)) * (c * (k + 2)) := by ring
+    rw [step, e1, e2]; ring
+  have hbpos : 0 < b := by rw [hb]; exact Nat.choose_pos (by omega)
+  have hlt : (k + 1) * (t + 1) < (t + 2) * (k + 2) := by nlinarith
+  have hfinal : a * c * ((t + 2) * (k + 2)) < b ^ 2 * ((t + 2) * (k + 2)) := by
+    rw [hmul]; gcongr
+  exact Nat.lt_of_mul_lt_mul_right hfinal
+
+/-- **Centered restatement.**  Rewriting `k = j − 1`, for `1 ≤ j` the row is log-concave at the
+    interior index `j`: `C(n,j−1) · C(n,j+1) ≤ C(n,j)²`. -/
+theorem choose_mul_choose_le_sq' (n j : ℕ) (hj : 1 ≤ j) :
+    n.choose (j - 1) * n.choose (j + 1) ≤ (n.choose j) ^ 2 := by
+  obtain ⟨k, rfl⟩ : ∃ k, j = k + 1 := ⟨j - 1, by omega⟩
+  simpa using choose_mul_choose_le_sq n k
+
+#check @choose_mul_choose_le_sq
+#check @choose_mul_choose_lt_sq
+#check @choose_mul_choose_le_sq'
+
+/-
+## Summary
+
+Proved (0 sorries, 0 axioms; imports only Mathlib):
+
+* `choose_mul_choose_le_sq` — every Pascal row is log-concave:
+  `C(n,k) · C(n,k+2) ≤ C(n,k+1)²` for all `n, k`.
+* `choose_mul_choose_lt_sq` — strict in the interior `k + 2 ≤ n` (Newton's inequality).
+* `choose_mul_choose_le_sq'` — the centered form `C(n,j−1) · C(n,j+1) ≤ C(n,j)²`.
+
+Where the sibling family records binomial *identities*, this entry supplies the row's basic
+*inequality*: log-concavity, the structural fact underlying unimodality
+(`Nat.choose_le_middle`).  The proof clears denominators with Mathlib's adjacent-ratio relation
+`choose_succ_right_eq` and reduces to `(k+1)(t+1) < (t+2)(k+2)`, whose difference `t + k + 3`
+is manifestly positive.
+-/
+
+end CombinationsFormulaOQ04

--- a/src/data/proofs/combinations-formula-oq-04/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-04/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "combinations-formula-oq-04",
+    "range": { "startLine": 3, "endLine": 49 },
+    "type": "context",
+    "title": "The Row's Inequality, Not Another Identity",
+    "content": "The combinations-formula family develops binomial identities exhaustively (Vandermonde, hockey-stick, Catalan, sums of squares, moments, alternating sums, q-analogs), all equalities. This entry proves the row's basic inequality: log-concavity C(n,k)·C(n,k+2) ≤ C(n,k+1)². It is the binomial case of Newton's inequalities and the structural reason the row is unimodal — Mathlib has the unimodal maximum Nat.choose_le_middle but not the log-concavity underlying it.",
+    "mathContext": "$C(n,k)\\,C(n,k+2)\\le C(n,k+1)^2,\\quad\\text{strict for } k+2\\le n$",
+    "significance": "context",
+    "relatedConcepts": [
+      "log-concavity",
+      "Newton's inequalities",
+      "unimodality",
+      "Pascal's triangle"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Nat.choose"
+    ]
+  },
+  {
+    "id": "ann-log-concave",
+    "proofId": "combinations-formula-oq-04",
+    "range": { "startLine": 51, "endLine": 81 },
+    "type": "theorem",
+    "title": "Log-Concavity of the Row",
+    "content": "choose_mul_choose_le_sq: C(n,k)·C(n,k+2) ≤ C(n,k+1)². Out of range (n < k+2) the right factor is 0 and the bound is trivial. In range, substituting n = k+2+t removes truncated subtraction; choose_succ_right_eq at k and at k+1 give a·(t+2)=b·(k+1) and c·(k+2)=b·(t+1). Multiplying yields a·c·(t+2)(k+2) = b²·(k+1)(t+1), and cancelling the positive factor (t+2)(k+2) finishes, since (k+1)(t+1) ≤ (t+2)(k+2).",
+    "mathContext": "$a c\\,(t{+}2)(k{+}2)=(a(t{+}2))(c(k{+}2))=(b(k{+}1))(b(t{+}1))=b^2(k{+}1)(t{+}1)$",
+    "significance": "high",
+    "relatedConcepts": [
+      "adjacent-ratio relation",
+      "denominator clearing",
+      "factor cancellation"
+    ],
+    "prerequisites": [
+      "Nat.choose_succ_right_eq",
+      "Nat.le_of_mul_le_mul_right"
+    ]
+  },
+  {
+    "id": "ann-strict",
+    "proofId": "combinations-formula-oq-04",
+    "range": { "startLine": 83, "endLine": 107 },
+    "type": "theorem",
+    "title": "Strict in the Interior (Newton's Inequality)",
+    "content": "choose_mul_choose_lt_sq: for k+2 ≤ n the inequality is strict. Here b = C(n,k+1) > 0 by Nat.choose_pos, and the gap (t+2)(k+2) − (k+1)(t+1) = t+k+3 is strictly positive, so b²·(k+1)(t+1) < b²·(t+2)(k+2). This is exactly the binomial case of Newton's inequalities on the elementary symmetric functions.",
+    "mathContext": "$(t{+}2)(k{+}2)-(k{+}1)(t{+}1)=t+k+3>0$",
+    "significance": "high",
+    "relatedConcepts": [
+      "Newton's inequalities",
+      "strict log-concavity"
+    ],
+    "prerequisites": [
+      "Nat.choose_pos",
+      "gcongr"
+    ]
+  },
+  {
+    "id": "ann-centered",
+    "proofId": "combinations-formula-oq-04",
+    "range": { "startLine": 109, "endLine": 114 },
+    "type": "theorem",
+    "title": "Centered Restatement",
+    "content": "choose_mul_choose_le_sq': rewriting k = j−1 gives the symmetric textbook form C(n,j−1)·C(n,j+1) ≤ C(n,j)² for 1 ≤ j, obtained from the main theorem by a reindexing.",
+    "mathContext": "$C(n,j-1)\\,C(n,j+1)\\le C(n,j)^2$",
+    "significance": "medium",
+    "relatedConcepts": [
+      "reindexing",
+      "log-concavity"
+    ],
+    "prerequisites": [
+      "the main log-concavity theorem"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-04/index.ts
+++ b/src/data/proofs/combinations-formula-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOq04Data: ProofData = {
+  proof: combinationsFormulaOq04Proof,
+  annotations: combinationsFormulaOq04Annotations,
+}

--- a/src/data/proofs/combinations-formula-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-04/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "combinations-formula-oq-04",
+  "title": "Log-Concavity of a Pascal Row",
+  "slug": "combinations-formula-oq-04",
+  "description": "Every row of Pascal's triangle is log-concave: C(n,k)·C(n,k+2) ≤ C(n,k+1)², with strict inequality throughout the interior (k+2 ≤ n). This is the binomial case of Newton's inequalities and the structural fact underlying the unimodality of the row. Where the sibling family records binomial identities, this entry supplies the row's basic inequality. Formalized in Lean 4 over Mathlib's Nat.choose.",
+  "meta": {
+    "author": "Lean Genius research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ04.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "pascals-triangle",
+      "log-concavity",
+      "newton-inequality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "assumptions": "None. Fully machine-verified: `lake env lean` builds Proofs/CombinationsFormulaOQ04.lean to exit 0 against the pinned Mathlib (v4.26.0), and #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no Lean.ofReduceBool, no sorryAx) for choose_mul_choose_le_sq. The file imports only Mathlib and is self-contained, building on Mathlib's Nat.choose_succ_right_eq adjacent-ratio relation.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "C(n,k+1)·(k+1) = C(n,k)·(n−k), the adjacent-coefficient ratio relation. Applied at k and k+1 (after substituting n = k+2+t to clear truncated subtraction) it gives the two relations a·(t+2)=b·(k+1) and c·(k+2)=b·(t+1) that multiply to the log-concavity bound.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_eq_zero_of_lt",
+        "description": "C(n,k) = 0 for n < k — discharges the trivial out-of-row case where the right factor vanishes.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.le_of_mul_le_mul_right",
+        "description": "cancels the common positive factor (t+2)(k+2) to pass from a·c·(t+2)(k+2) ≤ b²·(t+2)(k+2) down to a·c ≤ b².",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.choose_pos",
+        "description": "C(n,k) > 0 for k ≤ n — supplies b > 0 in the interior, giving the strict inequality.",
+        "module": "Mathlib.Combinatorics.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "choose_mul_choose_le_sq: every Pascal row is log-concave, C(n,k)·C(n,k+2) ≤ C(n,k+1)² for all n, k — the row's basic inequality, which the entire sibling identity family does not contain and which Mathlib does not state (Mathlib has only the unimodal maximum Nat.choose_le_middle, not the log-concavity underlying it)",
+      "choose_mul_choose_lt_sq: the strict form C(n,k)·C(n,k+2) < C(n,k+1)² for k+2 ≤ n — the binomial case of Newton's inequalities",
+      "choose_mul_choose_le_sq': the centered restatement C(n,j−1)·C(n,j+1) ≤ C(n,j)²",
+      "Proof technique: substitute n = k+2+t to eliminate ℕ truncated subtraction, clear denominators via the adjacent-ratio relation choose_succ_right_eq, and reduce to the manifestly positive gap (t+2)(k+2) − (k+1)(t+1) = t+k+3"
+    ],
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Log-concavity of the binomial coefficients — C(n,k)² ≥ C(n,k−1)·C(n,k+1) — is the prototypical example of a log-concave combinatorial sequence and the binomial instance of Newton's inequalities on the elementary symmetric functions. It is the structural reason each Pascal row first increases then decreases (unimodality). The gallery's large combinations-formula family develops binomial identities exhaustively but contains no inequality; Mathlib provides the unimodal maximum Nat.choose_le_middle but not the log-concavity that underlies it.",
+    "problemStatement": "Show that each row of Pascal's triangle is log-concave: for all n and k, C(n,k)·C(n,k+2) ≤ C(n,k+1)², strictly in the interior of the row.",
+    "text": "Writing a = C(n,k), b = C(n,k+1), c = C(n,k+2) and substituting n = k+2+t to remove truncated subtraction, Mathlib's adjacent-ratio relation choose_succ_right_eq gives a·(t+2) = b·(k+1) and c·(k+2) = b·(t+1). Multiplying, a·c·(t+2)(k+2) = b²·(k+1)(t+1). Since (k+1)(t+1) < (t+2)(k+2) — their difference is t+k+3 > 0 — cancelling the positive factor (t+2)(k+2) yields a·c ≤ b², strictly when b > 0 (i.e. k+2 ≤ n). Outside the row C(n,k+2) = 0 and the bound is immediate."
+  },
+  "sections": [
+    {
+      "id": "log-concave",
+      "title": "Log-Concavity of the Row",
+      "summary": "choose_mul_choose_le_sq: C(n,k)·C(n,k+2) ≤ C(n,k+1)² for all n, k. Splits on whether k+2 ≤ n; in range, substitutes n = k+2+t, applies choose_succ_right_eq twice, multiplies the two ratio relations, and cancels the common positive factor.",
+      "startLine": 51,
+      "endLine": 81
+    },
+    {
+      "id": "strict",
+      "title": "Strict Inequality in the Interior",
+      "summary": "choose_mul_choose_lt_sq: the strict form for k+2 ≤ n, where b = C(n,k+1) > 0 and the gap (t+2)(k+2) − (k+1)(t+1) = t+k+3 is strictly positive. The binomial case of Newton's inequalities.",
+      "startLine": 83,
+      "endLine": 107
+    },
+    {
+      "id": "centered",
+      "title": "Centered Restatement",
+      "summary": "choose_mul_choose_le_sq': rewriting k = j−1 gives the symmetric form C(n,j−1)·C(n,j+1) ≤ C(n,j)² for 1 ≤ j.",
+      "startLine": 109,
+      "endLine": 114
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalized in Lean 4 (0 axioms, 0 sorries; imports only Mathlib): every Pascal row is log-concave, C(n,k)·C(n,k+2) ≤ C(n,k+1)², strictly in the interior. Proof by clearing denominators with Mathlib's adjacent-ratio relation and cancelling a manifestly positive factor.",
+    "implications": "Supplies the row's fundamental inequality, complementing the sibling family's identities and Mathlib's unimodal-maximum lemma. Log-concavity implies unimodality and no internal zeros, and is the entry point to deeper properties (real-rootedness of the row polynomial, the binomial case of Newton's inequalities, and ultra-log-concavity).",
+    "openQuestions": [
+      "Strengthen to ultra-log-concavity: C(n,k)²/(C(n,k)+...) normalisations, or the normalized form (C(n,k)/binom-sum) being log-concave.",
+      "Derive unimodality of the row directly from log-concavity and compare with Mathlib's Nat.choose_le_middle.",
+      "Prove the real-rootedness of the row generating polynomial ∑ C(n,k) x^k = (1+x)^n implies log-concavity via Newton's inequalities, giving an alternative proof."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula",
+      "relationship": "parent-problem",
+      "description": "Parent: the basic combinations count C(n,k) = n!/(k!(n−k)!). This entry proves the row's fundamental inequality (log-concavity) rather than an identity."
+    },
+    {
+      "targetId": "combinations-formula-oq-05",
+      "relationship": "related",
+      "description": "Sibling on the alternating row sum and the even/odd split of a Pascal row — another structural property of the row, complementary to log-concavity."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Richard P. Stanley"
+      ],
+      "title": "Log-concave and unimodal sequences in algebra, combinatorics, and geometry",
+      "year": "1989",
+      "venue": "Annals of the New York Academy of Sciences 576, 500-535",
+      "note": "Survey of log-concavity, with the binomial row as the prototypical example"
+    },
+    {
+      "authors": [
+        "G. H. Hardy",
+        "J. E. Littlewood",
+        "G. Pólya"
+      ],
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Newton's inequalities on elementary symmetric functions, of which binomial log-concavity is the model case"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "CombinationsFormulaOQ04",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/CombinationsFormulaOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Problem

`combinations-formula-oq-04` — the `combinations-formula` family develops binomial **identities** exhaustively (Vandermonde, hockey-stick, Catalan, sums of squares, weighted moments, alternating sums, q-analogs), every one an *equality*. This PR supplies the row's basic **inequality**.

## Result

Every row of Pascal's triangle is **log-concave**:

```
C(n,k) · C(n,k+2)  ≤  C(n,k+1)²        for all n, k,
```

with **strict** inequality throughout the interior (`k + 2 ≤ n`). This is the binomial case of Newton's inequalities and the structural reason each row is unimodal. Mathlib has the unimodal maximum `Nat.choose_le_middle` but **not** the log-concavity underlying it.

## Proof

With `a = C(n,k)`, `b = C(n,k+1)`, `c = C(n,k+2)`, substitute `n = k+2+t` to remove ℕ truncated subtraction. Mathlib's adjacent-ratio relation `choose_succ_right_eq` gives

```
a · (t+2) = b · (k+1),     c · (k+2) = b · (t+1).
```

Multiplying: `a · c · (t+2)(k+2) = b² · (k+1)(t+1)`. Since `(t+2)(k+2) − (k+1)(t+1) = t + k + 3 > 0`, cancelling the common positive factor gives `a·c ≤ b²` (strict when `b > 0`, i.e. in the interior).

## Theorems (`proofs/Proofs/CombinationsFormulaOQ04.lean`)

- `choose_mul_choose_le_sq` — `C(n,k)·C(n,k+2) ≤ C(n,k+1)²` for all `n, k`.
- `choose_mul_choose_lt_sq` — strict for `k + 2 ≤ n` (Newton's inequality).
- `choose_mul_choose_le_sq'` — centered form `C(n,j−1)·C(n,j+1) ≤ C(n,j)²`.

## Verification

- `lake env lean` exits **0** against pinned Mathlib **v4.26.0** (imports only `Mathlib`).
- `#print axioms` reports only `propext / Classical.choice / Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**.
- `status: verified`, `badge: original`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)