### PR TITLE
research(cayley-cyclic-vector-converse-oq0201): prove the Frobenius bound — axiom eliminated, entry now verified/0-axiom

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean
@@ -44,16 +44,21 @@
 
   ## Status
 
-  The reduction is fully machine-checked.  The single structural input
-  `finrank_centralizer_ge` (the Frobenius dimension bound `dim C(M) ≥ n`, whose
-  standard proof passes through the rational canonical form / invariant-factor
-  decomposition of `M`) is **isolated as one explicit `axiom`** — it is a
-  classical theorem (Frobenius, 1878) but the invariant-factor / rational-
-  canonical-form packaging it requires is not yet available in Mathlib v4.26.0.
-  Everything else — the dimension bookkeeping (`dim K[M] = deg minpoly`), the
-  degree equality, and the descent to a cyclic vector — is complete and
-  axiom-free, so the entry is `axiomatized` with `axiomCount = 1` and the
-  Frobenius bound transparently disclosed.
+  **Fully machine-checked, 0 axioms, 0 sorries.**  The Frobenius dimension bound
+  `dim C(M) ≥ n` — previously isolated as a single `axiom` because Mathlib has no
+  rational-canonical-form / invariant-factor packaging — is now **proved** below
+  (`finrank_centralizer_ge`) directly from Mathlib's PID primary-decomposition
+  structure theorem `Module.equiv_directSum_of_isTorsion`.  The argument routes
+  the matrix centralizer through the algebra equivalence
+  `Matrix.toLinAlgEquiv'` to the operator centralizer, identifies that with the
+  `K[X]`-endomorphisms of the module `AEval' φ`, and lower-bounds their dimension
+  by `n` via the multiplication embedding (`Algebra.lmul`) of the decomposed
+  module.  Combined with the dimension bookkeeping (`dim K[M] = deg minpoly`),
+  the degree squeeze, and the descent to a cyclic vector, the whole converse edge
+  is verified.  The three supporting lemmas (`lmul_finrank_bound`,
+  `aeval_end_bound`, `endK_centralizer_bound`) are field-/module-general and
+  reusable.  `#print axioms finrank_centralizer_ge` reports only
+  `propext, Classical.choice, Quot.sound`.
 -/
 import Mathlib
 import Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01
@@ -102,32 +107,160 @@ theorem finrank_adjoin_eq_natDegree_minpoly
   exact finrank_quotient_span_eq_natDegree
 
 -- ============================================================
--- SECTION II: The Frobenius dimension bound (ISOLATED CRUX)
+-- SECTION II: The Frobenius dimension bound (NOW PROVED, 0 axioms)
 -- ============================================================
 
-/-- **Frobenius dimension bound (isolated crux, stated as an axiom).** The
-    centralizer `C(M) = {N : NM = MN}` of an `n × n` matrix has `K`-dimension at
+/-
+  The Frobenius dimension bound `dim_K C(M) ≥ n` is no longer an axiom: it is
+  proved below from the Mathlib PID structure theorem.  The argument runs
+
+      C(M)  ≅ₐ  C(φ)        (φ := `Matrix.toLinAlgEquiv' M`, via the algebra
+                            equivalence `Matrix ≃ₐ End K (Fin n → K)`)
+      C(φ)  ⊇  End_{K[X]}(AEval' φ)   (every K[X]-linear endomorphism of the
+                            module `Fin n → K` with `X` acting as `φ` commutes
+                            with `φ`; this gives a K-linear injection)
+      AEval' φ ≅ₗ[K[X]] ⊕ᵢ K[X]/(pᵢ^eᵢ) ≅ₗ[K[X]] Πᵢ K[X]/(pᵢ^eᵢ) =: S
+                            (`Module.equiv_directSum_of_isTorsion`; finite torsion)
+      n = dim_K S ≤ dim_K End_{K[X]} S        (multiplication embedding
+                            `Algebra.lmul` is K-linear injective on the
+                            commutative algebra `S`).
+
+  Transporting `End_{K[X]} S` back along the structure isomorphism to
+  `End_{K[X]}(AEval' φ)` and chaining the three steps yields `n ≤ dim_K C(M)`.
+  This is the classical theorem of Frobenius (1878); the three supporting
+  lemmas below are general-purpose and contain no matrix-specific content.
+-/
+
+/-- For a commutative `K[X]`-algebra `S` that is finite-dimensional over `K`,
+    the multiplication embedding `S ↪ End_{K[X]} S` (left multiplication,
+    `Algebra.lmul`) is a `K`-linear injection, so `dim_K S ≤ dim_K End_{K[X]} S`. -/
+theorem lmul_finrank_bound (S : Type*) [CommRing S] [Algebra (K[X]) S]
+    [Module K S] [IsScalarTower K (K[X]) S] [Module.Finite K S] :
+    Module.finrank K S ≤ Module.finrank K (Module.End (K[X]) S) := by
+  let f : S →ₗ[K] Module.End (K[X]) S :=
+    (Algebra.lmul (K[X]) S).toLinearMap.restrictScalars K
+  have hinj : Function.Injective f :=
+    fun a b hab => Algebra.lmul_injective (R := K[X]) (A := S) hab
+  exact LinearMap.finrank_le_finrank_of_injective hinj
+
+/-- **Operator form of the Frobenius bound.**  For a linear endomorphism `φ` of a
+    finite-dimensional `K`-vector space `V`, the `K[X]`-endomorphisms of the
+    `K[X]`-module `AEval' φ` (i.e. the endomorphisms of `V` commuting with `φ`)
+    span a `K`-space of dimension at least `dim_K V`.
+
+    Proof: `AEval' φ` is a finite torsion `K[X]`-module; the PID structure
+    theorem decomposes it as `⊕ᵢ K[X]/(pᵢ^eᵢ)`, isomorphic (finite index) to the
+    commutative `K[X]`-algebra `S := Πᵢ K[X]/(pᵢ^eᵢ)`, and
+    `dim_K V = dim_K S ≤ dim_K End_{K[X]} S = dim_K End_{K[X]}(AEval' φ)` by
+    `lmul_finrank_bound`. -/
+theorem aeval_end_bound {V : Type*} [AddCommGroup V] [Module K V]
+    [FiniteDimensional K V] (φ : V →ₗ[K] V) :
+    Module.finrank K V ≤ Module.finrank K (Module.End (K[X]) (Module.AEval' φ)) := by
+  have htor : Module.IsTorsion (K[X]) (Module.AEval' φ) :=
+    Module.AEval.isTorsion_of_finiteDimensional K V φ
+  obtain ⟨ι, _, p, _, e, ⟨iso⟩⟩ := Module.equiv_directSum_of_isTorsion htor
+  let Q : ι → Type _ := fun i => K[X] ⧸ (K[X] ∙ p i ^ e i)
+  let isoS : Module.AEval' φ ≃ₗ[K[X]] (∀ i, Q i) :=
+    iso.trans (DirectSum.linearEquivFunOnFintype K[X] ι Q)
+  haveI hFinS : Module.Finite K (∀ i, Q i) :=
+    Module.Finite.equiv (isoS.restrictScalars K)
+  calc Module.finrank K V
+      = Module.finrank K (Module.AEval' φ) := ((Module.AEval'.of φ).symm.finrank_eq)
+    _ = Module.finrank K (∀ i, Q i) := ((isoS.restrictScalars K).finrank_eq)
+    _ ≤ Module.finrank K (Module.End (K[X]) (∀ i, Q i)) := lmul_finrank_bound (∀ i, Q i)
+    _ = Module.finrank K (Module.End (K[X]) (Module.AEval' φ)) :=
+          ((isoS.conj.restrictScalars K).finrank_eq).symm
+
+/-- **The bridge (operator form).**  For `φ : End K V` over a finite-dimensional
+    `V`, the centralizer of `φ` inside `End K V` has `K`-dimension at least
+    `dim_K V`.  The `K[X]`-endomorphisms of `AEval' φ` inject `K`-linearly into
+    the centralizer (a `K[X]`-linear map commutes with the `X`-action `= φ`),
+    and `aeval_end_bound` lower-bounds their dimension by `dim_K V`. -/
+theorem endK_centralizer_bound {V : Type*} [AddCommGroup V] [Module K V]
+    [FiniteDimensional K V] (φ : Module.End K V) :
+    Module.finrank K V ≤
+      Module.finrank K (Subalgebra.centralizer K ({φ} : Set (Module.End K V))) := by
+  let ι0 : Module.End (K[X]) (Module.AEval' φ) →ₗ[K] Module.End K (Module.AEval' φ) :=
+    LinearMap.restrictScalarsₗ K (K[X]) (Module.AEval' φ) (Module.AEval' φ) K
+  let toEnd : Module.End (K[X]) (Module.AEval' φ) →ₗ[K] Module.End K V :=
+    ((Module.AEval'.of φ).conj.symm.toLinearMap) ∘ₗ ι0
+  have hval : ∀ (T : Module.End (K[X]) (Module.AEval' φ)) (x : V),
+      toEnd T x = (Module.AEval'.of φ).symm (T (Module.AEval'.of φ x)) := fun T x => rfl
+  have hmem : ∀ T, toEnd T ∈ Subalgebra.centralizer K ({φ} : Set (Module.End K V)) := by
+    intro T
+    rw [Subalgebra.mem_centralizer_iff]
+    intro g hg
+    simp only [Set.mem_singleton_iff] at hg
+    subst hg
+    ext x
+    simp only [Module.End.mul_apply, hval]
+    rw [← Module.AEval'.X_smul_of, map_smul, Module.AEval'.of_symm_X_smul]
+  have htoEnd_inj : Function.Injective toEnd := by
+    have h1 : Function.Injective (⇑(Module.AEval'.of φ).conj.symm) :=
+      (Module.AEval'.of φ).conj.symm.injective
+    have h2 : Function.Injective ι0 :=
+      fun a b hab => LinearMap.restrictScalars_injective K hab
+    intro a b hab
+    exact h2 (h1 hab)
+  let L : Module.End (K[X]) (Module.AEval' φ) →ₗ[K]
+      ↥(Subalgebra.toSubmodule (Subalgebra.centralizer K ({φ} : Set (Module.End K V)))) :=
+    LinearMap.codRestrict _ toEnd hmem
+  have hLinj : Function.Injective L := by
+    intro a b hab
+    apply htoEnd_inj
+    have := congrArg Subtype.val hab
+    simpa [L, LinearMap.codRestrict] using this
+  calc Module.finrank K V
+      ≤ Module.finrank K (Module.End (K[X]) (Module.AEval' φ)) := aeval_end_bound φ
+    _ ≤ Module.finrank K ↥(Subalgebra.toSubmodule
+          (Subalgebra.centralizer K ({φ} : Set (Module.End K V)))) :=
+          LinearMap.finrank_le_finrank_of_injective hLinj
+    _ = Module.finrank K (Subalgebra.centralizer K ({φ} : Set (Module.End K V))) := rfl
+
+/-- **Frobenius dimension bound (Frobenius, 1878).**  The centralizer
+    `C(M) = {N : NM = MN}` of an `n × n` matrix over a field has `K`-dimension at
     least `n`.
 
-    This is the only ingredient of the converse edge not yet in Mathlib.  It is
-    a classical theorem (Frobenius, 1878): factor `K^n` as a `K[X]`-module into
-    its invariant factors `K[X]/(f_1) ⊕ ⋯ ⊕ K[X]/(f_k)` (rational canonical
-    form); the centralizer is the ring of `K[X]`-module endomorphisms, and the
-    block-diagonal scalar multiplications already span a `K`-subspace of
-    dimension `Σ_i deg f_i = n` (in fact `dim C(M) = Σ_{i,j} deg gcd(f_i, f_j)`,
-    with equality to `n` iff `M` is nonderogatory).
-
-    Mathlib v4.26.0 provides the primary-decomposition structure theorem
-    (`Module.equiv_directSum_of_isTorsion`) and the `Module.AEval'` `K[X]`-module
-    structure, but **not** the bridge identifying `Subalgebra.centralizer K {M}`
-    with `Module.End K[X] (AEval' M)`, nor the invariant-factor packaging needed
-    to count dimensions.  Building both is on the order of several hundred lines
-    of PID-module infrastructure, so the bound is recorded here as a single,
-    transparently-disclosed `axiom` (the entry's only assumption). -/
-axiom finrank_centralizer_ge
+    Transferred from `endK_centralizer_bound` along the algebra equivalence
+    `Matrix.toLinAlgEquiv' : Matrix (Fin n) (Fin n) K ≃ₐ[K] End K (Fin n → K)`,
+    which carries `C(M)` isomorphically onto `C(φ)` for `φ := toLinAlgEquiv' M`. -/
+theorem finrank_centralizer_ge
     (M : Matrix (Fin n) (Fin n) K) :
     Fintype.card (Fin n)
-      ≤ Module.finrank K ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)))
+      ≤ Module.finrank K
+          ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))) := by
+  classical
+  let e : Matrix (Fin n) (Fin n) K ≃ₐ[K] Module.End K (Fin n → K) := Matrix.toLinAlgEquiv'
+  let φ : Module.End K (Fin n → K) := e M
+  have hsymm : e.symm φ = M := by simp [φ]
+  have hmap : (Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))).map e.toAlgHom
+            = Subalgebra.centralizer K ({φ} : Set (Module.End K (Fin n → K))) := by
+    apply le_antisymm
+    · rintro y ⟨z, hz, rfl⟩
+      show (e z) ∈ Subalgebra.centralizer K ({φ} : Set (Module.End K (Fin n → K)))
+      rw [Subalgebra.mem_centralizer_iff]
+      intro g hg; simp only [Set.mem_singleton_iff] at hg; subst hg
+      have hz' : z ∈ Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)) := hz
+      rw [Subalgebra.mem_centralizer_iff] at hz'
+      have hzM : M * z = z * M := hz' M (by simp)
+      have := congrArg e hzM
+      simpa [map_mul, φ] using this
+    · intro y hy
+      rw [Subalgebra.mem_centralizer_iff] at hy
+      refine ⟨e.symm y, ?_, by simp⟩
+      show e.symm y ∈ Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))
+      rw [Subalgebra.mem_centralizer_iff]
+      intro g hg; simp only [Set.mem_singleton_iff] at hg; subst hg
+      have hyφ : φ * y = y * φ := hy φ (by simp)
+      have := congrArg e.symm hyφ
+      simpa [map_mul, hsymm] using this
+  have hfin1 : Module.finrank K
+        ↥(Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K)))
+      = Module.finrank K
+        ↥((Subalgebra.centralizer K ({M} : Set (Matrix (Fin n) (Fin n) K))).map e.toAlgHom) :=
+    (Subalgebra.equivMapOfInjective _ e.toAlgHom e.injective).toLinearEquiv.finrank_eq
+  rw [hfin1, hmap, ← Module.finrank_fintype_fun_eq_card (R := K) (η := Fin n)]
+  exact endK_centralizer_bound φ
 
 -- ============================================================
 -- SECTION III: deg(minpoly M) ≤ n

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01",
   "title": "Converse Edge: Centralizer = K[M] ⟹ Cyclic Vector",
   "slug": "cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01",
-  "description": "Closes the triple equivalence for a single matrix M over an arbitrary field: if the centralizer C(M) coincides with the polynomial algebra K[M], then M is nonderogatory (minpoly = charpoly) and hence has a cyclic vector. The reduction is fully machine-checked — dim K[M] = deg(minpoly), deg(minpoly) ≤ n, and the squeeze n ≤ dim C(M) = deg(minpoly) ≤ n — leaving exactly one classical input, the Frobenius bound dim C(M) ≥ n, as a single transparently-disclosed axiom. Status: axiomatized (axiomCount = 1).",
+  "description": "Closes the triple equivalence for a single matrix M over an arbitrary field: if the centralizer C(M) coincides with the polynomial algebra K[M], then M is nonderogatory (minpoly = charpoly) and hence has a cyclic vector. Fully machine-checked with no axioms — dim K[M] = deg(minpoly), deg(minpoly) ≤ n, and the squeeze n ≤ dim C(M) = deg(minpoly) ≤ n. The one classical input, the Frobenius bound dim C(M) ≥ n, is now proved in Lean from Mathlib's PID structure theorem. Status: verified (axiomCount = 0).",
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-06-25",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean",
     "parentProofId": "cayley-hamilton-cyclic-vector-all-fields-oq-02",
     "additionalFiles": [
@@ -27,23 +27,26 @@
       "research",
       "open-question"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 197,
-    "theoremCount": 4,
+    "axiomCount": 0,
+    "lineCount": 330,
+    "theoremCount": 8,
     "definitionCount": 0,
-    "assumptions": "One explicit axiom: `finrank_centralizer_ge` — the Frobenius dimension bound dim_K C(M) ≥ n for the centralizer of an n×n matrix. This is a classical theorem (Frobenius, 1878), but its standard proof requires the invariant-factor / rational-canonical-form packaging of the K[X]-module Kⁿ, together with the identification of C(M) with End_{K[X]}(Kⁿ) — neither of which is available in Mathlib v4.26.0. Everything else in the file (the dimension bookkeeping, the degree squeeze, and the descent to a cyclic vector) is fully machine-checked and depends only on Mathlib's Polynomial, Matrix, Module, and Algebra.adjoin APIs. `#print axioms` on the main theorems lists `finrank_centralizer_ge` alongside the standard `propext`, `Classical.choice`, `Quot.sound`.",
+    "assumptions": "None. Fully machine-checked, 0 axioms, 0 sorries. The Frobenius dimension bound dim_K C(M) ≥ n — formerly the entry's single axiom — is now proved (finrank_centralizer_ge) from Mathlib's PID structure theorem Module.equiv_directSum_of_isTorsion via the algebra equivalence Matrix.toLinAlgEquiv', the identification of the centralizer with the K[X]-endomorphisms of AEval' φ, and the multiplication embedding Algebra.lmul of the decomposed module. #print axioms finrank_centralizer_ge reports only propext, Classical.choice, Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
     "originalContributions": [
-      "centralizer_eq_adjoin_implies_nonderogatory: the converse edge (iii)⟹(ii) — if Subalgebra.centralizer K {M} = Algebra.adjoin K {M}, then minpoly K M = charpoly M. Reduces the entire converse to the single Frobenius dimension bound via a degree squeeze.",
-      "centralizer_eq_adjoin_implies_cyclic: the capstone (iii)⟹(i) — centralizer = K[M] forces a cyclic vector, obtained by composing the converse edge with the parent biconditional nonderogatory ⟺ cyclic.",
-      "finrank_adjoin_eq_natDegree_minpoly: dim_K K[M] = deg(minpoly K M), proven via the first-isomorphism theorem K[M] ≅ K[X]/(minpoly) (Algebra.adjoin_singleton_eq_range_aeval + minpoly.ker_aeval_eq_span_minpoly + finrank_quotient_span_eq_natDegree), sidestepping the noncommutative PowerBasis obstruction.",
+      "finrank_centralizer_ge: the Frobenius dimension bound dim_K C(M) ≥ n (Frobenius, 1878), proved in Lean with 0 axioms — a result with no rational-canonical-form prerequisite available in Mathlib v4.26.0. Routes the matrix centralizer through Matrix.toLinAlgEquiv' to the operator centralizer, identifies it with the K[X]-endomorphisms of Module.AEval' φ, decomposes via Module.equiv_directSum_of_isTorsion, and lower-bounds the dimension by the multiplication embedding Algebra.lmul.",
+      "endK_centralizer_bound: operator form — for φ : End K V over finite-dimensional V, dim_K (centralizer of φ) ≥ dim_K V, via a K-linear injection of End_{K[X]}(AEval' φ) into the centralizer.",
+      "aeval_end_bound / lmul_finrank_bound: reusable module-level lemmas bounding dim_K End_{K[X]}(AEval' φ) ≥ dim_K V through the PID decomposition and the lmul embedding of a finite commutative K[X]-algebra.",
+      "centralizer_eq_adjoin_implies_nonderogatory: the converse edge (iii)⟹(ii) — if Subalgebra.centralizer K {M} = Algebra.adjoin K {M}, then minpoly K M = charpoly M, via a degree squeeze using the proved Frobenius bound.",
+      "centralizer_eq_adjoin_implies_cyclic: the capstone (iii)⟹(i) — centralizer = K[M] forces a cyclic vector, composing the converse edge with the parent biconditional nonderogatory ⟺ cyclic.",
+      "finrank_adjoin_eq_natDegree_minpoly: dim_K K[M] = deg(minpoly K M), via the first-isomorphism theorem K[M] ≅ K[X]/(minpoly), sidestepping the noncommutative PowerBasis obstruction.",
       "natDegree_minpoly_le: deg(minpoly K M) ≤ n via minpoly ∣ charpoly (Cayley–Hamilton) and deg(charpoly) = n."
     ],
     "historicalContext": "A matrix M ∈ Kⁿˣⁿ is nonderogatory when minpoly = charpoly. Three classical conditions are equivalent (Hoffman & Kunze §7.5, Roman §10.4): (i) M has a cyclic vector; (ii) minpoly = charpoly; (iii) the centralizer C(M) = {N : NM = MN} equals K[M]. The parent biconditional settles (i)⟺(ii) over arbitrary fields, and the sibling entry oq-02 proves the forward commutant edge (i)⟹(iii). This entry supplies the remaining converse edge (iii)⟹(ii), explicitly answering the open question posed by oq-02 ('if the centralizer of M equals K[M], does M necessarily have a cyclic vector?'). The dimension argument is uniform across all fields. Its one classical input — the Frobenius bound that the commutant of any n×n matrix has dimension at least n — dates to Frobenius's 1878 memoir on the theory of matrices.",
-    "proofStrategy": "Both K[M] = Algebra.adjoin K {M} and C(M) = Subalgebra.centralizer K {M} are finite-dimensional K-subalgebras of the matrix algebra. Three facts combine into a squeeze: (a) dim K[M] = deg(minpoly), via K[M] ≅ K[X]/(minpoly); (b) dim C(M) ≥ n (the Frobenius bound, the sole axiom); (c) deg(minpoly) ≤ n, via minpoly ∣ charpoly. If C(M) = K[M] then dim C(M) = dim K[M] = deg(minpoly), so n ≤ deg(minpoly) ≤ n, forcing deg(minpoly) = n. Two monic polynomials of equal degree, one dividing the other (Polynomial.eq_of_monic_of_dvd_of_natDegree_le), are equal: minpoly = charpoly. The parent biconditional then yields a cyclic vector."
+    "proofStrategy": "Both K[M] = Algebra.adjoin K {M} and C(M) = Subalgebra.centralizer K {M} are finite-dimensional K-subalgebras of the matrix algebra. Three facts combine into a squeeze: (a) dim K[M] = deg(minpoly), via K[M] ≅ K[X]/(minpoly); (b) dim C(M) ≥ n, the Frobenius bound, now PROVED from Mathlib's PID structure theorem (Matrix.toLinAlgEquiv' transfers C(M) to the operator centralizer; that contains the K[X]-endomorphisms of Module.AEval' φ; the structure theorem decomposes AEval' φ into a finite product of cyclic K[X]-modules whose multiplication embedding Algebra.lmul gives dim ≥ n); (c) deg(minpoly) ≤ n, via minpoly ∣ charpoly. If C(M) = K[M] then dim C(M) = dim K[M] = deg(minpoly), so n ≤ deg(minpoly) ≤ n, forcing deg(minpoly) = n. Two monic polynomials of equal degree, one dividing the other (Polynomial.eq_of_monic_of_dvd_of_natDegree_le), are equal: minpoly = charpoly. The parent biconditional then yields a cyclic vector."
   },
   "overview": {
     "problemStatement": "**Open question from cayley-hamilton-cyclic-vector-all-fields-oq-02**: The forward commutant edge shows a cyclic vector forces the centralizer of $M \\in K^{n\\times n}$ to equal $K[M]$. Does the converse hold — if $C(M) = K[M]$, must $M$ have a cyclic vector?\n\nFormally: assuming $\\mathrm{centralizer}_K(\\{M\\}) = \\mathrm{adjoin}_K(\\{M\\})$, show $\\mathrm{minpoly}_K M = \\mathrm{charpoly}\\,M$ (nonderogatory), hence $\\exists v,\\ \\mathrm{IsCyclicVector}\\,M\\,v$.",
@@ -55,7 +58,7 @@
       "Given C(M) = K[M], the three facts squeeze n ≤ dim C(M) = dim K[M] = deg(minpoly) ≤ n, so deg(minpoly) = n = deg(charpoly).",
       "Two monic polynomials of equal degree, one dividing the other, are equal — so minpoly = charpoly, and the parent biconditional converts nonderogatory into a cyclic vector."
     ],
-    "proofStrategy": "**Section I** — `finrank_adjoin_eq_natDegree_minpoly`: K[M] = range(aeval M) ≅ K[X]/ker(aeval M) = K[X]/(minpoly) via `Algebra.adjoin_singleton_eq_range_aeval`, `minpoly.ker_aeval_eq_span_minpoly`, `Ideal.quotientKerEquivRange`, and `finrank_quotient_span_eq_natDegree`.\n\n**Section II** — `finrank_centralizer_ge`: the Frobenius bound dim C(M) ≥ n, stated as the file's single axiom (the invariant-factor packaging and the C(M) ≅ End_{K[X]}(Kⁿ) bridge are absent from Mathlib v4.26.0).\n\n**Section III** — `natDegree_minpoly_le`: deg(minpoly) ≤ n via `minpoly.dvd` (Cayley–Hamilton) + `Polynomial.natDegree_le_of_dvd` + `charpoly_natDegree_eq_dim`.\n\n**Section IV** — `centralizer_eq_adjoin_implies_nonderogatory` runs the squeeze and finishes with `Polynomial.eq_of_monic_of_dvd_of_natDegree_le`; `centralizer_eq_adjoin_implies_cyclic` composes with the parent biconditional `nonderogatory_iff_has_cyclic_vector`.",
+    "proofStrategy": "**Section I** — `finrank_adjoin_eq_natDegree_minpoly`: K[M] = range(aeval M) ≅ K[X]/ker(aeval M) = K[X]/(minpoly) via `Algebra.adjoin_singleton_eq_range_aeval`, `minpoly.ker_aeval_eq_span_minpoly`, `Ideal.quotientKerEquivRange`, and `finrank_quotient_span_eq_natDegree`.\n\n**Section II** — `finrank_centralizer_ge`: the Frobenius bound dim C(M) ≥ n, now PROVED (0 axioms). `Matrix.toLinAlgEquiv'` transfers C(M) to the operator centralizer; `endK_centralizer_bound` injects the K[X]-endomorphisms of `Module.AEval' φ` into it; `aeval_end_bound` decomposes `AEval' φ` via `Module.equiv_directSum_of_isTorsion` and bounds dim ≥ n through the `Algebra.lmul` embedding (`lmul_finrank_bound`).\n\n**Section III** — `natDegree_minpoly_le`: deg(minpoly) ≤ n via `minpoly.dvd` (Cayley–Hamilton) + `Polynomial.natDegree_le_of_dvd` + `charpoly_natDegree_eq_dim`.\n\n**Section IV** — `centralizer_eq_adjoin_implies_nonderogatory` runs the squeeze and finishes with `Polynomial.eq_of_monic_of_dvd_of_natDegree_le`; `centralizer_eq_adjoin_implies_cyclic` composes with the parent biconditional `nonderogatory_iff_has_cyclic_vector`.",
     "prerequisites": [
       "Algebra.adjoin_singleton_eq_range_aeval: K[M] = adjoin K {M} equals the range of aeval M",
       "minpoly.ker_aeval_eq_span_minpoly: ker(aeval M) = (minpoly K M) as an ideal",
@@ -66,7 +69,6 @@
       "CyclicVectorBiconditional.nonderogatory_iff_has_cyclic_vector: the parent biconditional (ii)⟺(i)"
     ],
     "openQuestions": [
-      "Discharge the axiom finrank_centralizer_ge inside Lean: build the bridge Subalgebra.centralizer K {M} ≅ Module.End K[X] (Module.AEval' M), then bound dim_K End_{K[X]}(Kⁿ) ≥ n using Module.equiv_directSum_of_isTorsion and finrank_directSum. Estimated several hundred lines of PID-module infrastructure.",
       "Formalize the exact Frobenius dimension formula dim_K C(M) = Σ_{i,j} deg gcd(fᵢ, fⱼ) over the invariant factors, of which dim C(M) ≥ n (with equality iff nonderogatory) is the immediate corollary.",
       "Lift the whole triple equivalence from concrete matrices to Module.End over a finite-dimensional vector space, for reuse across the gallery's linear-algebra entries."
     ]
@@ -78,9 +80,9 @@
       "Proofs.CayleyHamiltonCyclicVectorAllFieldsOQ02"
     ],
     "namespace": "CyclicCommutantConverse",
-    "lineCount": 197,
-    "axiomCount": 1,
-    "theoremCount": 4,
+    "lineCount": 330,
+    "axiomCount": 0,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ02OQ01.lean",
     "sorries": 0,
@@ -96,7 +98,7 @@
       "title": "Header: the triple equivalence and the converse edge",
       "startLine": 1,
       "endLine": 65,
-      "summary": "States the three classical conditions (cyclic vector ⟺ minpoly = charpoly ⟺ centralizer = K[M]), locates the sibling forward edge and parent biconditional, and lays out the dimension-squeeze proof of the converse edge. The Status note flags the single Frobenius-bound axiom and confirms everything else is axiom-free."
+      "summary": "States the three classical conditions (cyclic vector ⟺ minpoly = charpoly ⟺ centralizer = K[M]), locates the sibling forward edge and parent biconditional, and lays out the dimension-squeeze proof of the converse edge. The Status note confirms the entry is fully verified with 0 axioms, including the now-proved Frobenius bound."
     },
     {
       "id": "dim-adjoin",
@@ -107,10 +109,10 @@
     },
     {
       "id": "frobenius-bound",
-      "title": "Section II — the Frobenius bound (isolated axiom): finrank_centralizer_ge",
+      "title": "Section II — the Frobenius bound (now proved, 0 axioms): finrank_centralizer_ge",
       "startLine": 101,
       "endLine": 130,
-      "summary": "The sole assumption: dim_K C(M) ≥ n. Documented as the classical Frobenius bound whose invariant-factor / rational-canonical-form proof and the C(M) ≅ End_{K[X]}(Kⁿ) bridge are not yet in Mathlib v4.26.0, hence recorded as one transparently-disclosed axiom."
+      "summary": "dim_K C(M) ≥ n, the classical Frobenius bound, proved in Lean from Mathlib's PID primary-decomposition structure theorem. The matrix centralizer is transferred along the algebra equivalence Matrix.toLinAlgEquiv' to the operator centralizer, identified with the K[X]-endomorphisms of Module.AEval' φ, and lower-bounded by dim_K V = n via the multiplication embedding of the decomposed module (Algebra.lmul). Supporting lemmas: lmul_finrank_bound, aeval_end_bound, endK_centralizer_bound."
     },
     {
       "id": "deg-minpoly-le",
@@ -128,11 +130,10 @@
     }
   ],
   "conclusion": {
-    "summary": "If the centralizer of M equals the polynomial algebra K[M], then M is nonderogatory (minpoly = charpoly) and therefore admits a cyclic vector. The entire converse edge is reduced — by a transparent three-fact dimension squeeze — to the single classical Frobenius bound dim C(M) ≥ n, which is isolated as one disclosed axiom. The reduction itself is fully machine-checked.",
+    "summary": "If the centralizer of M equals the polynomial algebra K[M], then M is nonderogatory (minpoly = charpoly) and therefore admits a cyclic vector, closing the triple equivalence cyclic ⟺ nonderogatory ⟺ centralizer = K[M]. The full argument is now machine-checked with no axioms: the classical Frobenius bound dim_K C(M) ≥ n is proved from Mathlib's PID primary-decomposition structure theorem.",
     "implications": "Combined with the sibling forward edge (cyclic ⟹ centralizer = K[M]) and the parent biconditional (nonderogatory ⟺ cyclic), this closes the triple equivalence cyclic vector ⟺ minpoly = charpoly ⟺ centralizer = K[M] over an arbitrary field. It directly answers the open question recorded by oq-02. The only remaining work to make the triangle fully axiom-free is to discharge the Frobenius bound inside Lean.",
     "openQuestions": [
-      "Discharge finrank_centralizer_ge in Lean via the C(M) ≅ End_{K[X]}(Kⁿ) bridge and the structure theorem, removing the last axiom and turning the triple equivalence fully verified.",
-      "Formalize the full Frobenius dimension formula dim C(M) = Σ deg gcd(fᵢ, fⱼ) over invariant factors.",
+      "Formalize the full Frobenius dimension formula dim C(M) = Σ deg gcd(fᵢ, fⱼ) over invariant factors (the bound dim C(M) ≥ n proved here is the n-from-below corollary).",
       "Recast the triple equivalence for Module.End over a finite-dimensional vector space."
     ]
   },


### PR DESCRIPTION
## Summary

Eliminates the **only axiom** in `cayley-hamilton-cyclic-vector-all-fields-oq-02-oq-01`. The converse edge of the triple equivalence (centralizer `C(M) = K[M]` ⟹ cyclic vector) previously rested on one stated assumption — the **Frobenius dimension bound** `dim_K C(M) ≥ n`. This PR **proves** that bound in Lean, so the entire entry is now fully machine-checked.

`#print axioms finrank_centralizer_ge` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `ofReduceBool`).

## How the Frobenius bound is proved

Built from Mathlib's PID primary-decomposition structure theorem (`Module.equiv_directSum_of_isTorsion`) — **not** rational canonical form (which Mathlib lacks):

1. `lmul_finrank_bound` — for a commutative `K[X]`-algebra `S` finite over `K`, the multiplication embedding `Algebra.lmul` is a `K`-linear injection, so `dim_K S ≤ dim_K End_{K[X]} S`.
2. `aeval_end_bound` — `AEval' φ` is a finite torsion `K[X]`-module; decompose it into `⊕ᵢ K[X]/(pᵢ^eᵢ)`, pass to the finite **product** `S := Πᵢ K[X]/(pᵢ^eᵢ)`, transport `End` through `LinearEquiv.conj`, and apply (1): `dim_K V ≤ dim_K End_{K[X]}(AEval' φ)`.
3. `endK_centralizer_bound` (bridge) — a `K[X]`-linear endomorphism of `AEval' φ`, conjugated through `Module.AEval'.of`, commutes with `φ`; this gives a `K`-linear injection `End_{K[X]}(AEval' φ) ↪ centralizer K {φ}`.
4. `finrank_centralizer_ge` — transfer to matrices along the **algebra** equivalence `Matrix.toLinAlgEquiv'` (it carries `C(M)` isomorphically onto `C(φ)`), with `n = dim_K (Fin n → K)`.

The three supporting lemmas are field-/module-general and reusable across the gallery's linear-algebra entries.

## Verification

Docker was down all session and the Aristotle MCP returned "Resource not found", so each lemma was verified standalone via single-file `lake env lean` against the prebuilt Mathlib, and the complete file was re-checked with the (already-verified, unchanged) downstream theorems consuming the now-proven theorem in place of the former axiom.

## Metadata

`meta.json`: `status` axiomatized→**verified**, `badge` axiom→**original**, `axiomCount` 1→**0**; assumptions, proof-strategy, sections, and open-questions updated to reflect the proved bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)