### PR TITLE
audit: 2 sylow gallery proofs verified CLEAN (0 issues)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23823,6 +23823,18 @@
       "lastAudited": "2026-06-25T12:54:11Z",
       "result": "clean",
       "issues": []
+    },
+    "sylow-theorems-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T13:18:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorems-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T13:18:12Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 2 fresh unaudited proofs, both CLEAN

Audited the two remaining unaudited gallery proofs not covered by #30000.

### sylow-theorems-oq-01-oq-02-oq-01 — *Groups of Order pq: the Cyclic Case when q ∤ (p−1)*
- `proofs/Proofs/SylowTheoremOQ01OQ02OQ01.lean`: 0 sorry, 0 axiom, 0 `native_decide`, 0 True-stubs.
- `card_sylow_eq_one_of_card_pq` proved by hand (Sylow counting arithmetic); cyclic deduction via Mathlib Z-group + nilpotency TFAE.
- Title honestly qualified to the single direction; "Honest scope" section discloses the open `q ∣ (p−1)` case.
- status `verified`/`original`, sorries 0, axioms 0 — **matches source**. Tier A/B original work on Mathlib infrastructure.

### sylow-theorems-oq-05 — *The Transfer Homomorphism G → P/[P,P]*
- `proofs/Proofs/SylowTheoremsOQ05.lean`: 0 sorry, 0 axiom, 0 `native_decide`, 0 True-stubs.
- The grep hits for `sorry`/`native_decide` are in the docstring prose ("no sorry, and no native_decide"), not code.
- Proves genuinely new results (transfer naturality `transfer_comp`, universal object `transferAb`, universal property, kernel minimality) on top of Mathlib's `transfer`; honestly framed ("what Mathlib does not record is…"). Assumptions field discloses Mathlib reliance.
- status `verified`/`original`, sorries 0, axioms 0 — **matches source**.

### Result
Both marked `clean` in `audit-tracker.json`. No integrity issues.

---
Discovered during gallery integrity audit (auditor agent).