### PR TITLE
research(buffons-needle-oq-01-oq-01-oq-05): eliminate the integrability hypothesis from Buffon–Barbier via C¹ continuity [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -549,6 +549,7 @@ import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01Beta
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02
+import Proofs.BuffonsNeedleOQ01OQ01OQ05
 import Proofs.BuffonsNeedleOQ01OQ02
 import Proofs.BuffonsNeedleOQ01OQ02OQ01
 import Proofs.BuffonsNeedleOQ01OQ04

--- a/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ05.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ05.lean
@@ -1,0 +1,114 @@
+import Mathlib
+import Proofs.BuffonsNeedleOQ01OQ01
+
+/-!
+# Buffon–Barbier: Discharging the Integrability Hypothesis from C¹ Smoothness
+
+`BuffonsNeedleOQ01OQ01.lean` proves the Buffon–Barbier smooth-curve formula
+
+  `concreteSmoothExpectedCrossings γ a b d = 2 · planarArcLength γ a b / (π·d)`
+
+but leaves the analytic regularity packaged as **hypotheses** of
+`buffon_smooth_full`:
+
+* `hdx`, `hdy` — differentiability of the two coordinate functions (the C¹ assumption);
+* `hInnerInt` — *interval-integrability* of the inner angular integral
+  `t ↦ ∫₀^π |γ'₁(t)·sin θ + γ'₂(t)·cos θ| dθ` as a function of `t`.
+
+The fifth open question of the parent entry asks to *"prove the co-area formula
+in Mathlib to eliminate the Fubini hypothesis"*. The full co-area formula remains
+open in Mathlib. This file resolves the **concrete, Buffon-specific residue** of
+that question: it discharges `hInnerInt` directly from continuity of the velocity
+field, with **no integrability assumption left**.
+
+## The mathematical content
+
+The map `t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ` is **continuous** whenever `A`, `B`
+are continuous, because the integrand `(t, θ) ↦ |A(t)·sin θ + B(t)·cos θ|` is jointly
+continuous and the integration interval `[0, π]` is fixed and compact (Mathlib's
+`continuous_parametric_intervalIntegral_of_continuous'`). Continuity on the compact
+interval `[a, b]` upgrades to interval-integrability. No closed form, dominated
+convergence bookkeeping, or co-area machinery is required.
+
+Feeding this into `buffon_smooth_full` yields `buffon_smooth_C1`: the Buffon–Barbier
+identity for an arbitrary C¹ planar curve whose velocity is continuous, with the
+integrability hypothesis fully removed.
+
+## Honest scope
+
+This is **not** the general co-area / Cauchy–Crofton formula. It eliminates exactly
+one of the two analytic side conditions (`hInnerInt`) of the parent theorem, leaving
+only the differentiability hypotheses `hdx`/`hdy`, which *are* the bare C¹ assumption.
+The general co-area formula in arbitrary dimension remains an open Mathlib target.
+-/
+
+open Real intervalIntegral MeasureTheory
+
+namespace BuffonsNeedleOQ01OQ01OQ05
+
+/-- The **inner angular integral** as a function of the coefficient functions:
+`t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ`. This is precisely the integrand of the
+outer integral in `concreteSmoothExpectedCrossings`, with `A = γ'₁`, `B = γ'₂`. -/
+noncomputable def innerAngular (A B : ℝ → ℝ) (t : ℝ) : ℝ :=
+  ∫ θ in (0 : ℝ)..π, |A t * sin θ + B t * cos θ|
+
+/-- **Continuity of the inner angular integral.**
+If the coefficient functions `A` and `B` are continuous, then the inner angular
+integral `t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ` is continuous.
+
+The integrand `(t, θ) ↦ |A(t)·sin θ + B(t)·cos θ|` is jointly continuous, and the
+interval of integration `[0, π]` is fixed; continuity of the parametric interval
+integral is then `continuous_parametric_intervalIntegral_of_continuous'`. -/
+theorem innerAngular_continuous (A B : ℝ → ℝ) (hA : Continuous A) (hB : Continuous B) :
+    Continuous (innerAngular A B) := by
+  unfold innerAngular
+  apply intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
+  have : Continuous (Function.uncurry fun t θ => |A t * sin θ + B t * cos θ|) := by
+    unfold Function.uncurry
+    fun_prop
+  exact this
+
+/-- **Interval-integrability of the inner angular integral.**
+Continuity (`innerAngular_continuous`) on the compact interval `[a, b]` gives
+interval-integrability — exactly the shape of the `hInnerInt` hypothesis required by
+`BuffonsNeedleOQ01OQ01.buffon_smooth_full`. -/
+theorem innerAngular_intervalIntegrable (A B : ℝ → ℝ)
+    (hA : Continuous A) (hB : Continuous B) (a b : ℝ) :
+    IntervalIntegrable
+      (fun t => ∫ θ in (0 : ℝ)..π, |A t * sin θ + B t * cos θ|) volume a b :=
+  (innerAngular_continuous A B hA hB).intervalIntegrable a b
+
+/-- Specialisation to a curve `γ`: the integrability hypothesis `hInnerInt` of
+`buffon_smooth_full`, obtained from continuity of the two velocity components
+`γ'₁ = deriv (Prod.fst ∘ γ)` and `γ'₂ = deriv (Prod.snd ∘ γ)`. -/
+theorem hInnerInt_of_continuous_deriv (γ : ℝ → ℝ × ℝ) (a b : ℝ)
+    (hA : Continuous (deriv (Prod.fst ∘ γ)))
+    (hB : Continuous (deriv (Prod.snd ∘ γ))) :
+    IntervalIntegrable
+      (fun t => ∫ θ in (0 : ℝ)..π, |(deriv (Prod.fst ∘ γ) t) * sin θ +
+                                      (deriv (Prod.snd ∘ γ) t) * cos θ|) volume a b :=
+  innerAngular_intervalIntegrable _ _ hA hB a b
+
+/-- **Buffon–Barbier for a C¹ curve, with the integrability hypothesis removed.**
+
+The expected number of crossings of a smooth curve with a unit grid equals
+`2·length / (π·d)`, assuming only that
+
+* each coordinate is differentiable on `[a, b]` (`hdx`, `hdy` — the C¹ assumption), and
+* each velocity component is continuous (`hA`, `hB`).
+
+Compared with `BuffonsNeedleOQ01OQ01.buffon_smooth_full`, the explicit
+integrability hypothesis `hInnerInt` is gone: it is now *derived* from continuity
+of the velocity via `hInnerInt_of_continuous_deriv`. -/
+theorem buffon_smooth_C1
+    (γ : ℝ → ℝ × ℝ) (a b d : ℝ) (hd : 0 < d) (hab : a ≤ b)
+    (hdx : ∀ t ∈ Set.uIcc a b, HasDerivAt (Prod.fst ∘ γ) (deriv (Prod.fst ∘ γ) t) t)
+    (hdy : ∀ t ∈ Set.uIcc a b, HasDerivAt (Prod.snd ∘ γ) (deriv (Prod.snd ∘ γ) t) t)
+    (hA : Continuous (deriv (Prod.fst ∘ γ)))
+    (hB : Continuous (deriv (Prod.snd ∘ γ))) :
+    BuffonsNeedleOQ01OQ01.concreteSmoothExpectedCrossings γ a b d
+      = 2 * BuffonsNeedleOQ01OQ01.planarArcLength γ a b / (π * d) :=
+  BuffonsNeedleOQ01OQ01.buffon_smooth_full γ a b d hd hab hdx hdy
+    (hInnerInt_of_continuous_deriv γ a b hA hB)
+
+end BuffonsNeedleOQ01OQ01OQ05

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "buffons-needle-oq-01-oq-01-oq-05",
+  "title": "Buffon–Barbier: Discharging the Integrability Hypothesis from C¹ Smoothness",
+  "slug": "buffons-needle-oq-01-oq-01-oq-05",
+  "description": "Removes the explicit integrability side condition (hInnerInt) from the Buffon–Barbier smooth-curve theorem. The inner angular integral t ↦ ∫₀^π |γ'₁(t)·sin θ + γ'₂(t)·cos θ| dθ is shown continuous in t whenever the velocity is continuous — via Mathlib's parametric interval-integral continuity theorem — hence interval-integrable on the compact parameter interval. Feeding this into the parent's buffon_smooth_full yields the Buffon–Barbier identity for an arbitrary C¹ planar curve with no integrability hypothesis left.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "proofs/Proofs/BuffonsNeedleOQ01OQ01OQ05.lean",
+    "tags": [
+      "integral-geometry",
+      "buffon-barbier",
+      "measure-theory",
+      "parametric-integral",
+      "continuity",
+      "integrability",
+      "interval-integral"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Mathlib.MeasureTheory.Integral.DominatedConvergence (continuous_parametric_intervalIntegral_of_continuous')",
+      "Mathlib.MeasureTheory.Integral.IntervalIntegral (Continuous.intervalIntegrable)"
+    ],
+    "originalContributions": [
+      "innerAngular: the inner angular integral t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ as a function of the coefficient functions",
+      "innerAngular_continuous: continuity of the inner angular integral in t from continuity of A, B (joint continuity of the integrand over the fixed compact interval [0, π])",
+      "innerAngular_intervalIntegrable: interval-integrability on [a, b] via continuity",
+      "hInnerInt_of_continuous_deriv: specialisation supplying the parent's exact hInnerInt hypothesis from continuity of the two velocity components",
+      "buffon_smooth_C1: Buffon–Barbier for an arbitrary C¹ curve with the integrability hypothesis eliminated"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 114,
+    "mathlib_version": "v4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parent entry buffons-needle-oq-01-oq-01 proves the Buffon–Barbier smooth-curve formula E[crossings] = 2L/(πd) from the angular-average identity, but packages the analytic regularity as hypotheses of buffon_smooth_full: differentiability of the coordinate functions (hdx, hdy) and interval-integrability of the inner angular integral (hInnerInt). Its fifth open question asks to 'prove the co-area formula in Mathlib to eliminate the Fubini hypothesis'.\n\nThe general co-area formula is not in Mathlib, and remains an open target. This entry resolves the concrete, Buffon-specific residue of that question: it discharges the integrability hypothesis hInnerInt directly from continuity of the velocity field, leaving only the bare C¹ differentiability assumptions.",
+    "problemStatement": "**Open question (buffons-needle-oq-01-oq-01, #2 and #5):** prove the integrability hypothesis hInnerInt from smoothness of γ, eliminating the analytic side condition on the inner angular integral t ↦ ∫₀^π |γ'₁(t)·sin θ + γ'₂(t)·cos θ| dθ.",
+    "keyInsight": "The integrand (t, θ) ↦ |A(t)·sin θ + B(t)·cos θ| is jointly continuous when A and B are continuous, and the interval of integration [0, π] is fixed and compact. Mathlib's continuous_parametric_intervalIntegral_of_continuous' then gives continuity of t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ, and continuity on the compact parameter interval [a, b] upgrades to interval-integrability. No closed form, dominated-convergence bookkeeping, or co-area machinery is required."
+  },
+  "sections": [
+    {
+      "id": "inner-angular",
+      "title": "The Inner Angular Integral",
+      "startLine": 48,
+      "endLine": 52,
+      "summary": "innerAngular A B t := ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ — the integrand of the outer integral in concreteSmoothExpectedCrossings, with A = γ'₁, B = γ'₂."
+    },
+    {
+      "id": "continuity",
+      "title": "Continuity of the Parametric Integral",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "innerAngular_continuous: from continuity of A, B and joint continuity of (t, θ) ↦ |A(t)·sin θ + B(t)·cos θ|, continuous_parametric_intervalIntegral_of_continuous' gives continuity of the inner angular integral in t."
+    },
+    {
+      "id": "integrability",
+      "title": "Interval-Integrability",
+      "startLine": 75,
+      "endLine": 95,
+      "summary": "innerAngular_intervalIntegrable and hInnerInt_of_continuous_deriv: continuity on the compact interval [a, b] yields interval-integrability — exactly the hInnerInt hypothesis required by the parent's buffon_smooth_full."
+    },
+    {
+      "id": "capstone",
+      "title": "Buffon–Barbier with the Integrability Hypothesis Removed",
+      "startLine": 97,
+      "endLine": 114,
+      "summary": "buffon_smooth_C1: applies buffon_smooth_full with hInnerInt derived from continuity of the velocity, giving the Buffon–Barbier identity for an arbitrary C¹ curve with no integrability assumption."
+    }
+  ],
+  "conclusion": {
+    "summary": "The integrability side condition hInnerInt of the Buffon–Barbier smooth-curve theorem is discharged from continuity of the velocity field. The capstone buffon_smooth_C1 states the Buffon–Barbier identity for an arbitrary C¹ planar curve with only differentiability hypotheses remaining and no integrability assumption.",
+    "implications": "**1. One analytic hypothesis eliminated.** The parent's buffon_smooth_full carried two analytic side conditions beyond differentiability: a Fubini swap (already discharged inside the parent via the angular average) and the integrability of the inner integral. This entry removes the latter, leaving only the bare C¹ assumption.\n\n**2. Continuity, not the closed form.** The argument does not use the closed form 2‖γ'(t)‖ of the inner integral; it uses only joint continuity of the integrand and the fixed compact integration interval. This keeps the result robust and self-contained on Mathlib's parametric-integral API.\n\n**3. Honest scope.** This is not the general co-area / Cauchy–Crofton formula, which remains absent from Mathlib. It resolves exactly the integrability residue of the parent's fifth open question.",
+    "openQuestions": [
+      "Discharge the differentiability hypotheses hdx/hdy from a single ContDiff/C¹ assumption on γ, giving a Buffon–Barbier statement with one clean smoothness hypothesis.",
+      "Weaken Continuous to ContinuousOn (Set.uIcc a b) for the velocity, matching the natural C¹-on-[a,b] hypothesis.",
+      "Formalize the general 1-dimensional co-area (Banach indicatrix) formula in Mathlib.",
+      "Higher-dimensional co-area / Cauchy–Crofton for hyperplane arrangements."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Discharges the hInnerInt integrability hypothesis of buffon_smooth_full and supplies the capstone buffon_smooth_C1; addresses open questions #2 and #5 of the parent entry."
+    },
+    {
+      "targetId": "buffons-needle-oq-01",
+      "relationship": "extends",
+      "description": "Continues the program of replacing the axiomatic smooth Buffon–Barbier case by a concrete verified theorem with minimal hypotheses."
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "extends",
+      "description": "Part of the Buffon's needle / noodle integral-geometry family."
+    }
+  ],
+  "references": [
+    {
+      "title": "Note sur un problème de calcul des probabilités",
+      "author": "Barbier, É.",
+      "year": "1860",
+      "description": "Original generalization of Buffon's needle to arbitrary smooth curves: E[crossings] = 2L/(πd)."
+    },
+    {
+      "title": "mathlib4: MeasureTheory.Integral.DominatedConvergence",
+      "author": "The Mathlib Community",
+      "year": "2024",
+      "description": "Source of continuous_parametric_intervalIntegral_of_continuous', the parametric interval-integral continuity theorem used here."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BuffonsNeedleOQ01OQ01"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "BuffonsNeedleOQ01OQ01OQ05",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/BuffonsNeedleOQ01OQ01OQ05.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

The parent entry **buffons-needle-oq-01-oq-01** (Buffon–Barbier, `E[crossings] = 2L/(πd)`) is fully verified but leaves two analytic side conditions as **hypotheses** of `buffon_smooth_full`:

- `hdx`, `hdy` — differentiability of the coordinate functions (the bare C¹ assumption);
- `hInnerInt` — interval-integrability of the inner angular integral `t ↦ ∫₀^π |γ'₁(t)·sin θ + γ'₂(t)·cos θ| dθ`.

Its open questions #2 ("prove the integrability hypothesis hInnerInt from smoothness of γ") and #5 ("prove the co-area formula … to eliminate the Fubini hypothesis") ask to remove these.

This PR **discharges `hInnerInt`** directly from continuity of the velocity field.

## The argument

The integrand `(t, θ) ↦ |A(t)·sin θ + B(t)·cos θ|` is jointly continuous whenever `A, B` are continuous, and the integration interval `[0, π]` is **fixed and compact**. Mathlib's `continuous_parametric_intervalIntegral_of_continuous'` then gives continuity of `t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ`, and continuity on the compact parameter interval `[a, b]` upgrades to interval-integrability. No closed form, dominated-convergence bookkeeping, or co-area machinery is needed.

Feeding this into the parent's `buffon_smooth_full` gives the capstone **`buffon_smooth_C1`**: Buffon–Barbier for an arbitrary C¹ planar curve with **no integrability hypothesis remaining**.

## Contributions (`proofs/Proofs/BuffonsNeedleOQ01OQ01OQ05.lean`, 114 lines)

- `innerAngular` — the inner angular integral as a function of the coefficient functions
- `innerAngular_continuous` — continuity in `t` from continuity of `A, B`
- `innerAngular_intervalIntegrable` — interval-integrability on `[a, b]`
- `hInnerInt_of_continuous_deriv` — supplies the parent's exact `hInnerInt` hypothesis
- `buffon_smooth_C1` — Buffon–Barbier with the integrability hypothesis eliminated

## Honest scope

This is **not** the general co-area / Cauchy–Crofton formula, which remains absent from Mathlib. It removes exactly the integrability residue of the parent's fifth open question, leaving only the differentiability hypotheses (which are the bare C¹ assumption).

## Verification

- **0 sorries, 0 axioms, 0 `native_decide`** — status `verified`, badge `original`.
- The Mathlib-only core (`innerAngular*`, `hInnerInt_of_continuous_deriv`) compiled clean via `lake env lean` (exit 0).
- The one-line capstone `buffon_smooth_C1` was type-checked against the parent's **verbatim** signatures for `concreteSmoothExpectedCrossings`, `planarArcLength`, and `buffon_smooth_full` (exit 0); the worktree parent file is byte-identical to the verified gallery version.
- Docker was unavailable this session, so the full-aggregate `docker-build.sh` was not run; the deployer build will confirm the composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)