### PR TITLE
Add missing index.ts for sylow-theorems-oq-01-oq-02-oq-01

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/sylow-theorems-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SylowTheoremOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sylowTheoremsOq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sylowTheoremsOq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sylowTheoremsOq01Oq02Oq01Data: ProofData = {
+  proof: sylowTheoremsOq01Oq02Oq01Proof,
+  annotations: sylowTheoremsOq01Oq02Oq01Annotations,
+}


### PR DESCRIPTION
A concurrent enrichment (PR #30002) merged `annotations.json` plus the `overview.proofStrategy`/`implications` fields to `main` for this entry — but **without** an `index.ts`. Without it, Vite's `import.meta.glob` cannot discover the proof and the page renders "proof not found" on the live site.

This PR is reduced to **only the missing `index.ts`** (+36 lines), leaving the peer's richer annotations and meta untouched. Verified with `tsc -b` (clean) and `vite build` (succeeds).