### PR TITLE
Enrich Multinomial Aggregation (binomial-theorem-oq-03-oq-03): add annotations

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-03/meta.json
@@ -76,12 +76,12 @@
   },
   "crossReferences": [
     {
-      "targetId": "binomial-theorem-oq-03",
+      "proofId": "binomial-theorem-oq-03",
       "relationship": "extends",
       "description": "parent: builds the binomial distribution and its properties directly from the binomial theorem; this entry carries the same program to the multinomial distribution, focusing on category aggregation."
     },
     {
-      "targetId": "binomial-theorem-oq-02-oq-01-oq-02",
+      "proofId": "binomial-theorem-oq-02-oq-01-oq-02",
       "relationship": "extends",
       "description": "sibling: proves single-coordinate marginals of the multinomial are binomial via the PGF; this entry generalizes that to arbitrary unions of categories (the lumping property), recovering the single-coordinate case as A = {i₀}."
     }


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-03-oq-03` (quality 41, pass 0).

The meta.json was already strong (overview object, 4 sections, conclusion with
implications + 3 open questions, 4 keyInsights). The gap was the entirely
**missing `annotations.json`**.

## Changes
- **Created `annotations.json`.** 7 annotations covering the full 246-line Lean
  file, each with `mathContext`, `significance`, `relatedConcepts`,
  `prerequisites`:
  module header · the multinomial PMF (`multinomialProb`) · the generating
  identity + normalization (`multinomial_mgf_real`, `multinomialProb_sum_one`) ·
  the aggregation PGF main theorem (`multinomial_aggregate_pgf`) · the
  binomial-PMF identification (`..._eq_binomial`) · the marginal/complement/total
  corollaries · the `Fin 3` worked example (`aggregate_fin3_example`).
- **Normalized `crossReferences`** `targetId` → `proofId` (preferred field name).

## Verification
- `tsc -b` clean; `annotations:build` reports no warnings for this entry (all
  ranges land on real Lean constructs); `vite build` succeeds.
- Cross-reference targets `binomial-theorem-oq-03` and
  `binomial-theorem-oq-02-oq-01-oq-02` exist.

## Axiom integrity
No status change. `status: verified` / `badge: original`, `axiomCount: 0` — the
Lean file has 0 sorries, 0 `axiom` declarations, no structure-encoded
assumptions, and no `native_decide` (the `Fin 3` example uses `decide` only for a
`≠` side-condition, which does not introduce `Lean.ofReduceBool`). Accurate as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)