### PR TITLE
research(collatz-cycles-oq-02): general logarithmic lower bound on Collatz cycle length [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -864,6 +864,7 @@ import Proofs.CircumferenceViaDifferentiationOQ01
 import Proofs.CircumferenceViaDifferentiationOQ01OQ02
 import Proofs.CircumferenceViaDifferentiationOQ03
 import Proofs.CollatzCycles
+import Proofs.CollatzCyclesOQ02
 import Proofs.CollatzCyclesOQ03
 import Proofs.CollatzCyclesOQ04
 import Proofs.CollatzStructured

--- a/proofs/Proofs/CollatzCyclesOQ02.lean
+++ b/proofs/Proofs/CollatzCyclesOQ02.lean
@@ -1,0 +1,93 @@
+import Mathlib
+
+/-!
+# Collatz Cycles OQ-02: General Logarithmic Lower Bound on Cycle Length
+
+`CollatzCycles.lean` establishes, for a hypothetical non-trivial Collatz cycle with
+`J` odd (tripling) steps and `M` even (halving) steps, the **halving constraint**
+`3 ^ J < 2 ^ M` (generalised in `collatz-cycles-oq-04`), together with a *specific*
+ladder of minimal-halving bounds for small `J` (`min_halvings_one_odd` … four_odd:
+`J = 1 → M ≥ 2`, `J = 2 → M ≥ 4`, `J = 3 → M ≥ 5`, `J = 4 → M ≥ 7`).
+
+This file replaces that finite ladder by the **general** quantitative bound that holds
+for every `J`. From `3 ^ J < 2 ^ M`, taking base-2 logarithms gives the sharp growth
+rate
+
+  `M > J · log₂ 3`,
+
+hence (ceiling) `M ≥ ⌈J · log₂ 3⌉₊`, which reproduces every entry of the specific
+ladder as a special case, and the total cycle length `L = M + J` obeys
+
+  `L > J · log₂ 6 ≈ 2.585 · J`.
+
+## Honest scope
+
+This is the **elementary** logarithmic core of Eliahou's theorem, not the full result.
+Eliahou (1993) sharpens the constant via the continued-fraction expansion of `log₂ 3`
+to obtain the famous numerical bound (a non-trivial cycle has length ≥ 17,087,915);
+that refinement needs Diophantine-approximation machinery not formalised here. What is
+proved here is the clean linear-in-`J` lower bound implied directly by the halving
+constraint, valid for all `J ≥ 1`.
+-/
+
+open Real
+
+namespace CollatzCyclesOQ02
+
+/-- **General halving bound.** From the cycle halving constraint `3 ^ J < 2 ^ M`,
+the number of halvings exceeds `J · log₂ 3`. This is the exact growth rate
+(`log₂ 3 ≈ 1.585`), valid for every `J` — generalising the specific ladder
+`min_halvings_one_odd … four_odd` in `CollatzCycles.lean`. -/
+theorem halvings_gt_logb {M J : ℕ} (h : 3 ^ J < 2 ^ M) :
+    (J : ℝ) * Real.logb 2 3 < (M : ℝ) := by
+  have hcast : (3 : ℝ) ^ J < (2 : ℝ) ^ M := by
+    have := (Nat.cast_lt (α := ℝ)).mpr h
+    push_cast at this
+    exact this
+  have h3pos : (0 : ℝ) < (3 : ℝ) ^ J := by positivity
+  have hlt : Real.logb 2 ((3 : ℝ) ^ J) < Real.logb 2 ((2 : ℝ) ^ M) :=
+    Real.logb_lt_logb (by norm_num) h3pos hcast
+  rw [Real.logb_pow, Real.logb_pow, Real.logb_self_eq_one (by norm_num)] at hlt
+  simpa using hlt
+
+/-- **Integer halving bound.** `M ≥ ⌈J · log₂ 3⌉₊`. Evaluating the ceiling at small
+`J` recovers the specific ladder: `J = 1 → ⌈1.585⌉ = 2`, `J = 2 → ⌈3.170⌉ = 4`,
+`J = 3 → ⌈4.755⌉ = 5`, `J = 4 → ⌈6.340⌉ = 7`. -/
+theorem halvings_ge_ceil {M J : ℕ} (h : 3 ^ J < 2 ^ M) :
+    ⌈(J : ℝ) * Real.logb 2 3⌉₊ ≤ M :=
+  Nat.ceil_le.mpr (halvings_gt_logb h).le
+
+/-- **General cycle-length lower bound.** A non-trivial cycle with `J` odd steps and
+`M` even steps (so total length `L = M + J`) satisfies `L > J · log₂ 6`. Since
+`log₂ 6 = 1 + log₂ 3 ≈ 2.585`, the length grows at least linearly in the number of
+odd steps. -/
+theorem cycle_length_gt {M J : ℕ} (h : 3 ^ J < 2 ^ M) :
+    (J : ℝ) * Real.logb 2 6 < ((M + J : ℕ) : ℝ) := by
+  have hb := halvings_gt_logb h
+  have h6 : Real.logb 2 6 = Real.logb 2 3 + 1 := by
+    rw [show (6 : ℝ) = 3 * 2 by norm_num,
+        Real.logb_mul (by norm_num) (by norm_num),
+        Real.logb_self_eq_one (by norm_num)]
+  have hexp : (J : ℝ) * Real.logb 2 6 = (J : ℝ) * Real.logb 2 3 + (J : ℝ) := by
+    rw [h6]; ring
+  rw [hexp]
+  push_cast
+  linarith [hb]
+
+/-- **Elementary halving bound** (no logarithms): more halvings than triplings,
+`M > J`. Immediate from `2 ^ J ≤ 3 ^ J < 2 ^ M`. Weaker than `halvings_gt_logb`
+(which has the sharp constant `log₂ 3 > 1`) but fully elementary. -/
+theorem halvings_gt_odd_steps {M J : ℕ} (h : 3 ^ J < 2 ^ M) : J < M := by
+  have h2 : 2 ^ J ≤ 3 ^ J := Nat.pow_le_pow_left (by norm_num) J
+  have : 2 ^ J < 2 ^ M := lt_of_le_of_lt h2 h
+  exact (Nat.pow_lt_pow_iff_right (by norm_num)).mp this
+
+/-- **Elementary cycle-length bound**: `L = M + J ≥ 2J + 1`. A non-trivial cycle is
+more than twice as long as its number of odd steps. (The logarithmic bound
+`cycle_length_gt` improves the slope from `2` to `log₂ 6 ≈ 2.585`.) -/
+theorem cycle_length_ge_two_mul {M J : ℕ} (_hJ : 1 ≤ J) (h : 3 ^ J < 2 ^ M) :
+    2 * J + 1 ≤ M + J := by
+  have := halvings_gt_odd_steps h
+  omega
+
+end CollatzCyclesOQ02

--- a/src/data/proofs/collatz-cycles-oq-02/meta.json
+++ b/src/data/proofs/collatz-cycles-oq-02/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "collatz-cycles-oq-02",
+  "title": "Collatz Cycles OQ-02: General Logarithmic Lower Bound on Cycle Length",
+  "slug": "collatz-cycles-oq-02",
+  "description": "Generalizes the finite ladder of minimal-halving bounds in CollatzCycles.lean to a single quantitative result valid for every J. From the cycle halving constraint 3^J < 2^M (established in collatz-cycles-oq-04), taking base-2 logarithms gives the sharp growth rate M > J·log₂3, hence M ≥ ⌈J·log₂3⌉, and the total cycle length L = M + J satisfies L > J·log₂6 ≈ 2.585·J. This is the elementary logarithmic core of Eliahou's theorem; the full numerical bound (length ≥ 17,087,915) requires continued-fraction Diophantine machinery not formalized here.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "proofs/Proofs/CollatzCyclesOQ02.lean",
+    "tags": [
+      "number-theory",
+      "collatz",
+      "dynamical-systems",
+      "logarithm",
+      "diophantine",
+      "cycle-length",
+      "eliahou"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      "Mathlib.Analysis.SpecialFunctions.Log.Base (logb_lt_logb, logb_pow, logb_self_eq_one, logb_mul)",
+      "Mathlib.Algebra.Order.Floor (Nat.ceil_le)"
+    ],
+    "originalContributions": [
+      "halvings_gt_logb: from 3^J < 2^M, the sharp bound M > J·log₂3 for all J (generalizing the specific min_halvings ladder for J = 1..4)",
+      "halvings_ge_ceil: integer form M ≥ ⌈J·log₂3⌉₊, recovering each ladder entry as a special case",
+      "cycle_length_gt: total cycle length L = M + J satisfies L > J·log₂6 ≈ 2.585·J",
+      "halvings_gt_odd_steps: elementary (log-free) bound M > J from 2^J ≤ 3^J < 2^M",
+      "cycle_length_ge_two_mul: elementary cycle-length bound L ≥ 2J + 1"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 93,
+    "mathlib_version": "v4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Eliahou (1993) proved that any non-trivial cycle of the Collatz map has length at least 17,087,915, by analyzing the continued-fraction expansion of log₂3 to bound how closely 2^M can approximate 3^J. CollatzCycles.lean in this gallery establishes the underlying halving constraint 3^J < 2^M (generalized in collatz-cycles-oq-04) and a finite ladder of minimal-halving bounds for J = 1, 2, 3, 4. This entry supplies the general quantitative bound underlying that ladder.",
+    "problemStatement": "Establish, for every J, a lower bound on the number of halvings M (and hence on the total cycle length L = M + J) of a hypothetical non-trivial Collatz cycle with J odd steps, given the halving constraint 3^J < 2^M.",
+    "keyInsight": "Taking base-2 logarithms of the halving constraint 3^J < 2^M and using strict monotonicity of logb (base 2 > 1) gives J·log₂3 < M directly: logb 2 (3^J) = J·logb 2 3 and logb 2 (2^M) = M·logb 2 2 = M. The ceiling bound M ≥ ⌈J·log₂3⌉₊ follows from Nat.ceil_le, and L > J·log₂6 from log₂6 = 1 + log₂3."
+  },
+  "sections": [
+    {
+      "id": "log-bound",
+      "title": "The Sharp Logarithmic Halving Bound",
+      "startLine": 39,
+      "endLine": 52,
+      "summary": "halvings_gt_logb: M > J·log₂3, proved by casting 3^J < 2^M to ℝ and applying logb_lt_logb, logb_pow, and logb_self_eq_one."
+    },
+    {
+      "id": "ceiling",
+      "title": "Integer Halving Bound",
+      "startLine": 54,
+      "endLine": 60,
+      "summary": "halvings_ge_ceil: M ≥ ⌈J·log₂3⌉₊ via Nat.ceil_le, recovering the specific ladder values (J=1→2, J=2→4, J=3→5, J=4→7)."
+    },
+    {
+      "id": "length",
+      "title": "General Cycle-Length Bound",
+      "startLine": 62,
+      "endLine": 80,
+      "summary": "cycle_length_gt: L = M + J > J·log₂6 ≈ 2.585·J, using log₂6 = 1 + log₂3."
+    },
+    {
+      "id": "elementary",
+      "title": "Elementary Log-Free Corollaries",
+      "startLine": 82,
+      "endLine": 93,
+      "summary": "halvings_gt_odd_steps (M > J from 2^J ≤ 3^J < 2^M) and cycle_length_ge_two_mul (L ≥ 2J + 1) — weaker but fully elementary bounds."
+    }
+  ],
+  "conclusion": {
+    "summary": "A non-trivial Collatz cycle with J odd steps and M even steps has M > J·log₂3, M ≥ ⌈J·log₂3⌉₊, and total length L = M + J > J·log₂6 ≈ 2.585·J — a clean general bound that subsumes the specific minimal-halving ladder of CollatzCycles.lean.",
+    "implications": "**1. From a finite ladder to a uniform bound.** CollatzCycles.lean bounded halvings only for J = 1..4; this entry covers all J with the exact asymptotic constant log₂3.\n\n**2. Linear growth in odd steps.** The length grows at least like log₂6 · J, the elementary growth rate behind Eliahou's analysis.\n\n**3. Honest scope.** This is NOT Eliahou's full numerical bound (length ≥ 17,087,915), which sharpens the constant via the continued-fraction expansion of log₂3. That Diophantine-approximation step is not formalized here.",
+    "openQuestions": [
+      "Formalize the continued-fraction expansion of log₂3 to obtain Eliahou's sharp numerical constant.",
+      "Combine with a lower bound on the number of odd steps J in any non-trivial cycle to obtain an absolute length bound.",
+      "Connect to the 2-adic / Diophantine obstruction ruling out small cycles entirely."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "collatz-cycles",
+      "relationship": "extends",
+      "description": "Generalizes the specific min_halvings ladder (J = 1..4) of CollatzCycles.lean to all J."
+    },
+    {
+      "targetId": "collatz-cycles-oq-04",
+      "relationship": "depends-on",
+      "description": "Uses the general halving constraint 3^J < 2^M established in collatz-cycles-oq-04 as the hypothesis of the logarithmic bound."
+    }
+  ],
+  "references": [
+    {
+      "title": "The 3x+1 problem: new lower bounds on nontrivial cycle lengths",
+      "author": "Eliahou, S.",
+      "year": "1993",
+      "description": "Proves any non-trivial Collatz cycle has length ≥ 17,087,915 via the continued-fraction expansion of log₂3 (Discrete Mathematics 118)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CollatzCyclesOQ02",
+    "lineCount": 93,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CollatzCyclesOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

`CollatzCycles.lean` bounds the number of halvings `M` of a hypothetical non-trivial Collatz cycle only for small `J` (a finite ladder: `J=1→M≥2`, `J=2→M≥4`, `J=3→M≥5`, `J=4→M≥7`). This PR replaces that ladder with a **single uniform bound valid for every `J`**.

From the cycle halving constraint `3^J < 2^M` (established generally in **collatz-cycles-oq-04**), taking base-2 logarithms gives the sharp growth rate:

| theorem | bound |
|---|---|
| `halvings_gt_logb` | `M > J·log₂3` (exact constant `log₂3 ≈ 1.585`) |
| `halvings_ge_ceil` | `M ≥ ⌈J·log₂3⌉₊` (recovers each ladder entry as a special case) |
| `cycle_length_gt` | `L = M + J > J·log₂6 ≈ 2.585·J` |

Plus two elementary (log-free) corollaries: `halvings_gt_odd_steps` (`M > J`, from `2^J ≤ 3^J < 2^M`) and `cycle_length_ge_two_mul` (`L ≥ 2J + 1`).

## Proof idea

`logb 2 (3^J) = J·log₂3` and `logb 2 (2^M) = M·log₂2 = M`; strict monotonicity of `logb` (base `2 > 1`) applied to `3^J < 2^M` gives `J·log₂3 < M` directly. The ceiling bound follows from `Nat.ceil_le`, and the length bound from `log₂6 = 1 + log₂3`.

## Honest scope

This is the **elementary logarithmic core** of Eliahou's theorem, **not** the full numerical bound (a non-trivial cycle has length ≥ 17,087,915). Eliahou (1993) sharpens the constant via the continued-fraction expansion of `log₂3` — Diophantine-approximation machinery that is **not** formalized here. What is proved is the clean linear-in-`J` lower bound implied directly by the halving constraint.

## Verification

- **0 sorries, 0 axioms, 0 `native_decide`** — status `verified`, badge `original`.
- Compiled clean via `lake env lean Proofs/CollatzCyclesOQ02.lean` (exit 0). Docker was unavailable this session; the deployer build will confirm the aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)