### PR TITLE
Enrich Buffon–Barbier C¹ (buffons-needle-oq-01-oq-01-oq-05): fix overview, add annotations

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "buffons-needle-oq-01-oq-01-oq-05-header",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-05",
+    "type": "concept",
+    "range": { "startLine": 4, "endLine": 43 },
+    "title": "Discharging the integrability hypothesis",
+    "content": "The parent entry proves the Buffon–Barbier smooth-curve formula $E[\\text{crossings}] = 2L/(\\pi d)$ but packages the analytic regularity as hypotheses of `buffon_smooth_full`: differentiability of the coordinates (`hdx`, `hdy`) and interval-integrability of the inner angular integral (`hInnerInt`). The parent's fifth open question asks to prove the co-area formula to remove the Fubini hypothesis — which remains open in Mathlib. This file resolves the concrete Buffon-specific residue: it derives `hInnerInt` directly from continuity of the velocity field, leaving only the bare C¹ assumption.",
+    "mathContext": "$E[\\text{crossings}] = \\dfrac{2L}{\\pi d}$ for a C¹ planar curve, with the integrability side condition removed.",
+    "significance": "context",
+    "relatedConcepts": ["Buffon–Barbier formula", "integral geometry", "co-area formula", "parametric integral"],
+    "prerequisites": ["interval integrals", "continuity", "Buffon's needle problem"]
+  },
+  {
+    "id": "buffons-needle-oq-01-oq-01-oq-05-def",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-05",
+    "type": "definition",
+    "range": { "startLine": 49, "endLine": 53 },
+    "title": "The inner angular integral",
+    "content": "`innerAngular A B t` $= \\int_0^\\pi |A(t)\\sin\\theta + B(t)\\cos\\theta|\\,d\\theta$, abstracted in two coefficient functions $A, B$. This is exactly the integrand of the outer integral in the parent's `concreteSmoothExpectedCrossings`, with $A = \\gamma'_1$, $B = \\gamma'_2$. Abstracting away from the specific velocity components keeps the continuity/integrability proofs free of curve-specific plumbing.",
+    "mathContext": "$\\mathrm{innerAngular}(A,B)(t) = \\displaystyle\\int_0^\\pi |A(t)\\sin\\theta + B(t)\\cos\\theta|\\,d\\theta.$",
+    "significance": "supporting",
+    "relatedConcepts": ["interval integral", "angular average", "absolute value integrand"],
+    "prerequisites": ["interval integrals", "trigonometric functions"]
+  },
+  {
+    "id": "buffons-needle-oq-01-oq-01-oq-05-continuity",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-05",
+    "type": "theorem",
+    "range": { "startLine": 55, "endLine": 69 },
+    "title": "Continuity of the parametric integral",
+    "content": "`innerAngular_continuous`: if $A$ and $B$ are continuous, so is $t \\mapsto \\mathrm{innerAngular}(A,B)(t)$. The proof unfolds the definition and applies Mathlib's `continuous_parametric_intervalIntegral_of_continuous'`, whose sole hypothesis is joint continuity of the (uncurried) integrand $(t,\\theta) \\mapsto |A(t)\\sin\\theta + B(t)\\cos\\theta|$ — discharged by `fun_prop`. The fixed compact interval $[0,\\pi]$ is what makes the parametric integral continuous in $t$ with no dominated-convergence argument.",
+    "mathContext": "$A, B \\text{ continuous} \\Rightarrow t \\mapsto \\int_0^\\pi |A(t)\\sin\\theta + B(t)\\cos\\theta|\\,d\\theta \\text{ continuous}.$",
+    "significance": "critical",
+    "relatedConcepts": ["continuous_parametric_intervalIntegral_of_continuous'", "joint continuity", "fun_prop", "parametric integral"],
+    "prerequisites": ["continuity of functions", "Function.uncurry", "parametric interval-integral continuity"]
+  },
+  {
+    "id": "buffons-needle-oq-01-oq-01-oq-05-integrability",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-05",
+    "type": "theorem",
+    "range": { "startLine": 71, "endLine": 90 },
+    "title": "From continuity to interval-integrability",
+    "content": "`innerAngular_intervalIntegrable`: continuity on the compact interval $[a,b]$ upgrades to interval-integrability, via `Continuous.intervalIntegrable`. `hInnerInt_of_continuous_deriv` then specialises this to a curve $\\gamma$, taking $A = \\mathrm{deriv}(\\mathrm{fst}\\circ\\gamma)$ and $B = \\mathrm{deriv}(\\mathrm{snd}\\circ\\gamma)$ — producing exactly the `hInnerInt` hypothesis shape that the parent's `buffon_smooth_full` requires, but now as a consequence of continuity of the two velocity components.",
+    "mathContext": "$f \\text{ continuous} \\Rightarrow \\mathrm{IntervalIntegrable}\\,f\\,\\mathrm{volume}\\,a\\,b.$",
+    "significance": "key",
+    "relatedConcepts": ["Continuous.intervalIntegrable", "interval-integrability", "velocity components", "deriv"],
+    "prerequisites": ["interval-integrability", "continuity on compact intervals", "derivatives of composite functions"]
+  },
+  {
+    "id": "buffons-needle-oq-01-oq-01-oq-05-capstone",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-05",
+    "type": "theorem",
+    "range": { "startLine": 92, "endLine": 114 },
+    "title": "Buffon–Barbier with the integrability hypothesis removed",
+    "content": "`buffon_smooth_C1`: the Buffon–Barbier identity $\\mathrm{concreteSmoothExpectedCrossings}\\,\\gamma\\,a\\,b\\,d = 2\\,\\mathrm{planarArcLength}\\,\\gamma\\,a\\,b / (\\pi d)$ for an arbitrary C¹ planar curve, assuming only differentiability of each coordinate on $[a,b]$ (`hdx`, `hdy`) and continuity of each velocity component (`hA`, `hB`). The proof applies the parent's `buffon_smooth_full` with the integrability argument supplied by `hInnerInt_of_continuous_deriv` — so the explicit `hInnerInt` hypothesis is gone, derived rather than assumed.",
+    "mathContext": "$\\mathrm{concreteSmoothExpectedCrossings}\\,\\gamma\\,a\\,b\\,d = \\dfrac{2\\,\\mathrm{planarArcLength}\\,\\gamma\\,a\\,b}{\\pi d}.$",
+    "significance": "critical",
+    "relatedConcepts": ["buffon_smooth_full", "C¹ curve", "arc length", "expected crossings", "HasDerivAt"],
+    "prerequisites": ["the parent buffon_smooth_full", "differentiability on an interval", "continuity of the velocity"]
+  }
+]

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-05/meta.json
@@ -41,7 +41,13 @@
   "overview": {
     "historicalContext": "The parent entry buffons-needle-oq-01-oq-01 proves the Buffon–Barbier smooth-curve formula E[crossings] = 2L/(πd) from the angular-average identity, but packages the analytic regularity as hypotheses of buffon_smooth_full: differentiability of the coordinate functions (hdx, hdy) and interval-integrability of the inner angular integral (hInnerInt). Its fifth open question asks to 'prove the co-area formula in Mathlib to eliminate the Fubini hypothesis'.\n\nThe general co-area formula is not in Mathlib, and remains an open target. This entry resolves the concrete, Buffon-specific residue of that question: it discharges the integrability hypothesis hInnerInt directly from continuity of the velocity field, leaving only the bare C¹ differentiability assumptions.",
     "problemStatement": "**Open question (buffons-needle-oq-01-oq-01, #2 and #5):** prove the integrability hypothesis hInnerInt from smoothness of γ, eliminating the analytic side condition on the inner angular integral t ↦ ∫₀^π |γ'₁(t)·sin θ + γ'₂(t)·cos θ| dθ.",
-    "keyInsight": "The integrand (t, θ) ↦ |A(t)·sin θ + B(t)·cos θ| is jointly continuous when A and B are continuous, and the interval of integration [0, π] is fixed and compact. Mathlib's continuous_parametric_intervalIntegral_of_continuous' then gives continuity of t ↦ ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ, and continuity on the compact parameter interval [a, b] upgrades to interval-integrability. No closed form, dominated-convergence bookkeeping, or co-area machinery is required."
+    "proofStrategy": "Abstract the inner integral as innerAngular A B t = ∫₀^π |A(t)·sin θ + B(t)·cos θ| dθ in two coefficient functions A, B. (1) The integrand (t, θ) ↦ |A(t)·sin θ + B(t)·cos θ| is jointly continuous when A, B are continuous (fun_prop, after uncurrying); since the integration interval [0, π] is fixed and compact, Mathlib's continuous_parametric_intervalIntegral_of_continuous' yields continuity of t ↦ innerAngular A B t (innerAngular_continuous). (2) Continuity on the compact parameter interval [a, b] upgrades to interval-integrability via Continuous.intervalIntegrable (innerAngular_intervalIntegrable). (3) Specialising A = γ'₁, B = γ'₂ produces exactly the hInnerInt hypothesis shape (hInnerInt_of_continuous_deriv). (4) Feeding this into the parent's buffon_smooth_full discharges the integrability side condition, leaving the capstone buffon_smooth_C1 with only the C¹ differentiability hypotheses hdx, hdy and continuity of the velocity.",
+    "keyInsights": [
+      "The integrand (t, θ) ↦ |A(t)·sin θ + B(t)·cos θ| is jointly continuous when A and B are continuous, and the interval of integration [0, π] is fixed and compact — so continuous_parametric_intervalIntegral_of_continuous' applies directly with no dominated-convergence bookkeeping.",
+      "Continuity is enough: the proof never uses the closed form 2‖γ'(t)‖ of the inner integral, only joint continuity of the integrand and the fixed compact interval. This keeps the result robust and self-contained on Mathlib's parametric-integral API.",
+      "Continuity on a compact parameter interval [a, b] immediately gives interval-integrability (Continuous.intervalIntegrable), turning the analytic side condition into a one-line consequence of regularity.",
+      "Honest scope: this discharges exactly the Buffon-specific integrability residue (hInnerInt), not the general co-area / Cauchy–Crofton formula, which remains absent from Mathlib."
+    ]
   },
   "sections": [
     {
@@ -85,17 +91,17 @@
   },
   "crossReferences": [
     {
-      "targetId": "buffons-needle-oq-01-oq-01",
+      "proofId": "buffons-needle-oq-01-oq-01",
       "relationship": "extends",
       "description": "Discharges the hInnerInt integrability hypothesis of buffon_smooth_full and supplies the capstone buffon_smooth_C1; addresses open questions #2 and #5 of the parent entry."
     },
     {
-      "targetId": "buffons-needle-oq-01",
+      "proofId": "buffons-needle-oq-01",
       "relationship": "extends",
       "description": "Continues the program of replacing the axiomatic smooth Buffon–Barbier case by a concrete verified theorem with minimal hypotheses."
     },
     {
-      "targetId": "buffons-needle",
+      "proofId": "buffons-needle",
       "relationship": "extends",
       "description": "Part of the Buffon's needle / noodle integral-geometry family."
     }


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-01-oq-01-oq-05` (quality 33, pass 0).

## Changes
- **Fixed a malformed `overview`.** It had `keyInsight` (singular string) instead
  of the schema-required `keyInsights: string[]`, and was **missing
  `proofStrategy`** entirely — both required by the `ProofOverview` type, so the
  page rendered an incomplete overview. Added a 4-step `proofStrategy` and 4
  `keyInsights`.
- **Created `annotations.json`** (was missing). 5 annotations covering the full
  114-line Lean file — module header, the `innerAngular` definition,
  parametric-integral continuity (`innerAngular_continuous`), interval-integrability
  / `hInnerInt` (`innerAngular_intervalIntegrable`, `hInnerInt_of_continuous_deriv`),
  and the `buffon_smooth_C1` capstone — each with `mathContext`, `significance`,
  `relatedConcepts`, `prerequisites`.
- **Normalized `crossReferences`** `targetId` → `proofId` (preferred field name).

## Verification
- `tsc -b` clean; `annotations:build` reports no warnings for this entry (all
  ranges land on real Lean constructs); `vite build` succeeds.
- Cross-reference targets `buffons-needle-oq-01-oq-01`, `buffons-needle-oq-01`,
  and `buffons-needle` all exist.

## Axiom integrity
No status change. `status: verified` / `badge: original`, `axiomCount: 0` — the
Lean file has 0 sorries, 0 `axiom` declarations, no structure-encoded
assumptions, and no `native_decide`. Reliance on Mathlib's parametric-integral
API is ordinary library use. Accurate as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)