### PR TITLE
Enrich Parallelogram Law (cauchy-schwarz-oq-07): index.ts + annotation depth

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-07/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq07Data: ProofData = {
+  proof: cauchySchwarzOq07Proof,
+  annotations: cauchySchwarzOq07Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-07/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07/meta.json
@@ -60,7 +60,9 @@
     "keyInsights": [
       "**Cross terms cancel on addition, survive on subtraction.** The single expansion ‖x±y‖² = ‖x‖² ± 2⟪x,y⟩ + ‖y‖² yields both the parallelogram law (sum, cross terms cancel) and the polarization identity (difference, cross terms double). They are two faces of the same computation.",
       "**Parallelogram law characterizes inner-product norms.** By Jordan–von Neumann, a norm comes from an inner product iff it satisfies this identity — so the law is not just a consequence of having an inner product but is equivalent to it.",
-      "**Field-agnostic packaging.** Stating `parallelogram_norm_sq` with the scalar field `𝕜` explicit lets the same lemma serve real and complex inner-product spaces, recovering both classical forms from one statement."
+      "**Field-agnostic packaging.** Stating `parallelogram_norm_sq` with the scalar field `𝕜` explicit lets the same lemma serve real and complex inner-product spaces, recovering both classical forms from one statement.",
+      "**The norm is the only data needed.** Both diagonals ‖x+y‖ and ‖x−y‖ and the sides ‖x‖, ‖y‖ are pure norm quantities — the parallelogram law is an identity *within the normed structure*, which is exactly why it can serve as the criterion (Jordan–von Neumann) for an inner product to exist at all, without presupposing one.",
+      "**Squared vs. unsquared form is not cosmetic.** Mathlib states the law with `*self`; the open question (and most analysis texts) want the `^2` form. Bridging them needs `pow_two` plus `linarith`, a reminder that `a^2` and `a*a` are definitionally distinct in Lean and downstream lemmas must match the chosen form."
     ],
     "prerequisites": [
       "Inner product spaces (InnerProductSpace 𝕜 E in Mathlib, 𝕜 = ℝ or ℂ)",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-07` (the parallelogram law / polarization identity).

## Changes
- **Created missing `index.ts`** — without it the proof page rendered "proof not found" on the live site (the entry had meta.json + annotations.json but no index.ts).
- **Enriched all 4 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — they previously had `content` only. Also corrected their `range` startLines to land on the actual `theorem` declarations (the annotation validator requires this).
- **Expanded `overview.keyInsights` from 3 to 5** (the norm carries all the data; the squared-vs-unsquared form distinction in Lean).

## Verification
- JSON parses; `pnpm annotations:build` reports no errors for this entry; `tsc -b` clean; `vite build` succeeds.
- Axiom integrity unchanged: `status: verified`, `badge: original`, 0 axioms, 0 sorries.

(Note: the repo-wide `pnpm build` currently crashes in the `research:enrich` step on a pre-existing dangling reference to `proofs/Proofs/SylowTheoremsOQ05.lean`, unrelated to this entry; validated via the gallery/tsc/vite steps directly.)