### PR TITLE
research(erdos-1059-oq-01-oq-01): discharge both interval-decomposition sorries — file now sorry-free

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01OQ01.lean
@@ -41,6 +41,7 @@ import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Tactic
 import Proofs.Erdos1059OQ01
 import Proofs.Erdos1059OQ02
@@ -368,25 +369,67 @@ This decomposition holds because:
 2. Every prime ≤ n! belongs to exactly one I(l) for l < n
 3. Finset.card distributes over the disjoint union
 
-The decomposition requires substantial Finset partition machinery. We state it
-as a theorem and leave the proof as sorry (a candidate for future work).
+This decomposition is now **proved** (previously a sorry): the generic
+`count_decomp` below establishes it for any predicate excluding 0 and 1, by a
+clean one-step induction on `n` (peel off the top interval), avoiding any heavy
+partition machinery.
 -/
+
+/-- **Generic interval decomposition.**  For any (decidable) predicate `P` that
+    excludes `0` and `1`, the count of `P`-elements up to `n!` decomposes as the
+    sum over primorial levels `l < n` of the level-wise `P`-counts.
+
+    Proof by induction on `n`: the single split
+    `range (n!·(n+1)+1) = range (n!+1) ∪ Ioc (n!) ((n+1)!)` peels off exactly the
+    `n`-th interval at each step (the two pieces are disjoint and their union is
+    `range ((n+1)!+1)` since `(n+1)! ≥ n!`). -/
+theorem count_decomp (P : ℕ → Prop) [DecidablePred P]
+    (hP : ∀ x, x < 2 → ¬ P x) (n : ℕ) :
+    ((Finset.range (Nat.factorial n + 1)).filter P).card
+      = ∑ l ∈ Finset.range n,
+          ((Finset.Ioc (Nat.factorial l) (Nat.factorial (l + 1))).filter P).card := by
+  induction n with
+  | zero => simpa using hP
+  | succ m ih =>
+    have hmono : Nat.factorial m ≤ Nat.factorial (m + 1) := Nat.factorial_le (by omega)
+    have hsplit : Finset.range (Nat.factorial (m + 1) + 1)
+        = Finset.range (Nat.factorial m + 1)
+            ∪ Finset.Ioc (Nat.factorial m) (Nat.factorial (m + 1)) := by
+      ext x
+      simp only [Finset.mem_range, Finset.mem_union, Finset.mem_Ioc, Nat.lt_succ_iff]
+      omega
+    have hdisj : Disjoint (Finset.range (Nat.factorial m + 1))
+        (Finset.Ioc (Nat.factorial m) (Nat.factorial (m + 1))) := by
+      rw [Finset.disjoint_left]
+      intro x hx hx'
+      simp only [Finset.mem_range, Finset.mem_Ioc, Nat.lt_succ_iff] at hx hx'
+      omega
+    rw [Finset.sum_range_succ, ← ih, hsplit, Finset.filter_union,
+      Finset.card_union_of_disjoint
+        (hdisj.mono (Finset.filter_subset _ _) (Finset.filter_subset _ _))]
 
 /-- **Interval decomposition for prime count** (cumulative → level sum):
     π(n!) = Σ_{l=0}^{n-1} primesInLevel l.
 
-    Every prime p with 2 ≤ p ≤ n! lies in exactly one primorial interval I(l)
-    for some l with 0 ≤ l < n. The intervals are disjoint (proved in OQ-02)
-    and their union covers {2, ..., n!}. -/
+    Every prime `p` with `2 ≤ p ≤ n!` lies in exactly one primorial interval
+    `I(l)` for some `l < n`; the intervals partition `{2, …, n!}`.  Immediate from
+    `count_decomp` with `P = Prime` (no prime is `< 2`). -/
 theorem primeCount_decomposition (n : ℕ) (hn : n ≥ 1) :
     Erdos1059OQ01.primeCount (Nat.factorial n) =
-    (Finset.range n).sum primesInLevel := by sorry
+    (Finset.range n).sum primesInLevel := by
+  unfold Erdos1059OQ01.primeCount primesInLevel Erdos1059OQ02.PrimorialInterval
+  exact count_decomp (fun m => m.Prime)
+    (fun x hx => by interval_cases x <;> simp [Nat.not_prime_zero, Nat.not_prime_one]) n
 
 /-- **Interval decomposition for qualifying prime count**:
-    C(n!) = Σ_{l=0}^{n-1} qualifyingInLevel l. -/
+    C(n!) = Σ_{l=0}^{n-1} qualifyingInLevel l.  Immediate from `count_decomp`
+    with `P = Prime ∧ AFSC` (a qualifying number is prime, hence `≥ 2`). -/
 theorem qualifyingCount_decomposition (n : ℕ) (hn : n ≥ 1) :
     Erdos1059OQ01.qualifyingPrimeCount (Nat.factorial n) =
-    (Finset.range n).sum qualifyingInLevel := by sorry
+    (Finset.range n).sum qualifyingInLevel := by
+  unfold Erdos1059OQ01.qualifyingPrimeCount qualifyingInLevel Erdos1059OQ02.PrimorialInterval
+  exact count_decomp (fun m => m.Prime ∧ Erdos1059OQ01.AllFactorialSubtractionsComposite m)
+    (fun x hx => by interval_cases x <;> simp [Nat.not_prime_zero, Nat.not_prime_one]) n
 
 /-- **Density one at factorial points**: For every k, there exists N such that
     for all n ≥ N, C(n!) · (k+1) ≥ π(n!) · k.
@@ -417,13 +460,16 @@ theorem density_one_at_factorials (k : ℕ) : ∃ N : ℕ, ∀ n : ℕ, n ≥ N 
 5. levelwise_density_bound — l/(l+1) ≥ k/(k+1) for l ≥ k, applied to counts
 6. levelwise_strict_surplus — per-level surplus ≥ 1 for l ≥ max(3, k+2)
 7. density_at_levels — MAIN THEOREM: level-sum density bound, fully proved
+8. count_decomp — generic interval decomposition (induction; peel top interval)
+9. primeCount_decomposition — π(n!) = Σ primesInLevel  (now proved via count_decomp)
+10. qualifyingCount_decomposition — C(n!) = Σ qualifyingInLevel  (now proved)
+11. density_one_at_factorials — density at factorial points (now proved; combines
+    density_at_levels with the two decompositions)
 
-**Requires sorry** (Finset partition infrastructure):
-8. primeCount_decomposition — π(n!) = Σ primesInLevel
-9. qualifyingCount_decomposition — C(n!) = Σ qualifyingInLevel
-10. density_one_at_factorials — depends on 8, 9
+**This file is now sorry-free** — the previous two `sorry`s (the interval
+decompositions) are discharged by `count_decomp`.
 
-**Axioms** (2 new):
+**Axioms** (2, both disclosed sieve inputs):
 - strong_selberg_density: captures Selberg sieve's quantitative prediction
 - primes_growth_in_levels: weak PNT (p(l) ≥ l for l ≥ 3)
 

--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "selberg-sieve"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1059,
     "erdosUrl": "https://erdosproblems.com/1059",
     "erdosProblemStatus": "open",
@@ -69,7 +69,7 @@
       "Sieve theory: Selberg sieve, Brun-Titchmarsh inequality (motivational)",
       "Finset operations: filter, card, sum, sum splitting"
     ],
-    "lineCount": 434,
+    "lineCount": 480,
     "relatedProblems": [
       {
         "id": "erdos-1059-oq-01",
@@ -84,8 +84,8 @@
         "relationship": "Grandparent: main Erdős 1059 conjecture"
       }
     ],
-    "assumptions": "2 axioms: (1) strong_selberg_density — for l ≥ 3, qualifyingInLevel(l)·(l+1) ≥ primesInLevel(l)·l, capturing the Selberg sieve's prediction that the qualifying fraction approaches 1; (2) primes_growth_in_levels — for l ≥ 3, primesInLevel(l) ≥ l, an extremely weak consequence of PNT.",
-    "theoremCount": 10,
+    "assumptions": "Two explicit sieve axioms: strong_selberg_density (the Selberg sieve's quantitative prediction q(l)·(l+1) ≥ p(l)·l for l ≥ 3) and primes_growth_in_levels (weak PNT: p(l) ≥ l for l ≥ 3). The file is now SORRY-FREE: the two interval-decomposition lemmas (π(n!) and C(n!) as sums over primorial levels), previously sorry, are proved via the generic count_decomp by induction. Hence density_one_at_factorials is fully derived modulo the two disclosed axioms.",
+    "theoremCount": 11,
     "definitionCount": 3
   },
   "overview": {
@@ -190,14 +190,14 @@
     }
   ],
   "leanFile": {
-    "lineCount": 434,
+    "lineCount": 480,
     "namespace": "Erdos1059OQ01OQ01",
     "opens": [
       "Nat"
     ],
     "structureCount": 0,
     "axiomCount": 2,
-    "theoremCount": 10,
+    "theoremCount": 11,
     "substantiveTheoremCount": 7,
     "computationalVerifications": 0,
     "lemmaCount": 0,
@@ -211,7 +211,7 @@
       "Proofs.Erdos1059OQ02"
     ],
     "path": "Proofs/Erdos1059OQ01OQ01.lean",
-    "sorries": 2,
+    "sorries": 0,
     "definitionCount": 3
   },
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Eliminates the **two `sorry`s** in `Erdos1059OQ01OQ01.lean` (Erdős #1059, OQ-01-OQ-01 — density of factorial-avoiding primes). The file is now **sorry-free**; its two disclosed sieve axioms remain, so the gallery status stays `axiomatized`.

The sorries were the interval decompositions
- `π(n!) = Σ_{l<n} primesInLevel l`  (`primeCount_decomposition`)
- `C(n!) = Σ_{l<n} qualifyingInLevel l`  (`qualifyingCount_decomposition`)

previously deferred as "substantial Finset partition machinery".

## How

A new generic lemma `count_decomp` replaces the partition machinery with a clean **one-step induction on `n`**. The single set identity
```
range ((n+1)!+1) = range (n!+1) ∪ Ioc (n!) ((n+1)!)
```
(the two pieces are disjoint, and their union is `range ((n+1)!+1)` since `(n+1)! ≥ n!`) peels off exactly the `n`-th primorial interval at each step, so the count of any predicate `P` (excluding 0 and 1) adds level by level. The two decompositions are then `count_decomp` with `P = Prime` and `P = Prime ∧ AFSC`.

Consequently `density_one_at_factorials` — which already consumed the two lemmas — is now fully derived (modulo the two disclosed axioms).

## Verification

Docker was down and the Aristotle MCP unavailable this session, so `count_decomp` and both decomposition proofs were checked via single-file `lake env lean` under the file's exact imports, against faithful stubs of the parent definitions (`primeCount`, `qualifyingPrimeCount`, `AllFactorialSubtractionsComposite` + its `Decidable` instance, `PrimorialInterval`). Pre-existing theorems are untouched.

## Metadata

`meta.json`: `sorries` 2→0, `theoremCount` 10→11, `lineCount`→480. Status remains `axiomatized` (2 sieve axioms: `strong_selberg_density`, `primes_growth_in_levels`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)