### PR TITLE
research(jacobi-symbol-oq-01-oq-01): quadratic reciprocity for the Jacobi symbol + explicit power-form supplementary laws [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3317,6 +3317,7 @@ import Proofs.IsoscelesTriangleOQ01
 import Proofs.IsoscelesTriangleOQ02
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
+import Proofs.JacobiSymbolOQ0101
 import Proofs.JacobiSymbolOQ0103
 import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01

--- a/proofs/Proofs/JacobiSymbolOQ0101.lean
+++ b/proofs/Proofs/JacobiSymbolOQ0101.lean
@@ -1,0 +1,132 @@
+/-
+  Quadratic Reciprocity for the Jacobi symbol, with explicit power-form
+  supplementary laws.
+
+  The **Jacobi symbol** `J(a | b)` (for odd `b`) obeys the *Law of Quadratic
+  Reciprocity* and two *supplementary laws*, exactly as the Legendre symbol
+  does — even though `b` need not be prime:
+
+    * **Reciprocity**: for odd `a, b`,
+        `J(a | b) = (-1)^((a-1)/2 · (b-1)/2) · J(b | a)`;
+      with the clean residue-class corollaries
+        `a ≡ 1 (mod 4)  ⟹  J(a|b) = J(b|a)`,
+        `a ≡ b ≡ 3 (mod 4)  ⟹  J(a|b) = -J(b|a)`.
+    * **First supplementary law**: `J(-1 | b) = (-1)^((b-1)/2)`.
+    * **Second supplementary law**: `J(2 | b) = (-1)^((b²-1)/8)`.
+
+  Mathlib provides the reciprocity law directly (`jacobiSym.quadratic_reciprocity`)
+  and the supplementary laws in *character* form — `J(-1|b) = χ₄ b` and
+  `J(2|b) = χ₈ b`, where `χ₄, χ₈` are the quadratic characters mod 4 and mod 8.
+  The mathematical content added here is the bridge to the **classical explicit
+  power forms**: we evaluate `χ₄ b` and `χ₈ b` as concrete powers of `-1`,
+  the form in which the supplementary laws are stated in every textbook. The
+  `χ₈ → (-1)^((b²-1)/8)` bridge is the substantive step: it is an elementary
+  but genuine residue computation on `b mod 8` (the parity of `(b²-1)/8` is
+  `b mod 8`–periodic), carried out below from first principles.
+
+  Together with a worked evaluation by *flipping*, this packages the full
+  reciprocity toolkit that makes the Jacobi symbol an efficient,
+  factorization-free residue calculator.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+namespace JacobiSymbolOQ0101
+
+/-! ### The Law of Quadratic Reciprocity -/
+
+/-- **Quadratic Reciprocity for the Jacobi symbol**: for odd `a, b`,
+`J(a | b) = (-1)^((a/2)·(b/2)) · J(b | a)`.  (For odd `n`, `n/2 = (n-1)/2`.) -/
+theorem jacobi_quadratic_reciprocity {a b : ℕ} (ha : Odd a) (hb : Odd b) :
+    jacobiSym a b = (-1) ^ (a / 2 * (b / 2)) * jacobiSym b a :=
+  jacobiSym.quadratic_reciprocity ha hb
+
+/-- If `a ≡ 1 (mod 4)` and `b` is odd, the symbols agree: `J(a|b) = J(b|a)`. -/
+theorem jacobi_reciprocity_one_mod_four {a b : ℕ} (ha : a % 4 = 1) (hb : Odd b) :
+    jacobiSym a b = jacobiSym b a :=
+  jacobiSym.quadratic_reciprocity_one_mod_four ha hb
+
+/-- If `a ≡ b ≡ 3 (mod 4)`, the symbols are opposite: `J(a|b) = -J(b|a)`. -/
+theorem jacobi_reciprocity_three_mod_four {a b : ℕ} (ha : a % 4 = 3) (hb : b % 4 = 3) :
+    jacobiSym a b = -jacobiSym b a :=
+  jacobiSym.quadratic_reciprocity_three_mod_four ha hb
+
+/-! ### First supplementary law: `J(-1 | b) = (-1)^((b-1)/2)` -/
+
+/-- **First supplementary law**, explicit power form: for odd `b`,
+`J(-1 | b) = (-1)^((b-1)/2)`.  Bridges Mathlib's character form `χ₄ b`. -/
+theorem jacobi_at_neg_one_pow {b : ℕ} (hb : Odd b) :
+    jacobiSym (-1) b = (-1) ^ ((b - 1) / 2) := by
+  have hodd : b % 2 = 1 := Nat.odd_iff.mp hb
+  rw [jacobiSym.at_neg_one hb, ZMod.χ₄_eq_neg_one_pow hodd]
+  congr 1
+  omega
+
+/-! ### Second supplementary law: `J(2 | b) = (-1)^((b²-1)/8)`
+
+This is the substantive bridge.  Mathlib gives `J(2|b) = χ₈ b`, where `χ₈ b`
+is `+1` for `b ≡ ±1 (mod 8)` and `-1` for `b ≡ ±3 (mod 8)`.  We must show this
+equals `(-1)^((b²-1)/8)`, i.e. that the parity of the exponent `(b²-1)/8` is
+`+` exactly for `b ≡ ±1 (mod 8)`.  Writing `b = 8q + r` with `r = b % 8 ∈
+{1,3,5,7}`, we have `b² - 1 = 8(8q² + 2qr) + (r²-1)` with `8 ∣ r²-1`, so the
+parity of `(b²-1)/8` is the parity of `(r²-1)/8`, which is even iff `r ∈ {1,7}`.
+The four residue cases are discharged below by `omega` (treating `q*q` as an
+opaque atom) plus `pow_mul`/`pow_succ`. -/
+
+/-- **Second supplementary law**, explicit power form: for odd `b`,
+`J(2 | b) = (-1)^((b²-1)/8)`. -/
+theorem jacobi_at_two_pow {b : ℕ} (hb : Odd b) :
+    jacobiSym 2 b = (-1) ^ ((b ^ 2 - 1) / 8) := by
+  have hodd : b % 2 = 1 := Nat.odd_iff.mp hb
+  rw [jacobiSym.at_two hb, ZMod.χ₈_nat_eq_if_mod_eight]
+  rw [if_neg (by omega : ¬ b % 2 = 0)]
+  set q := b / 8 with hq
+  rcases (by omega : b % 8 = 1 ∨ b % 8 = 3 ∨ b % 8 = 5 ∨ b % 8 = 7) with h | h | h | h
+  · -- b ≡ 1 (mod 8): exponent even
+    rw [if_pos (Or.inl h)]
+    have hb1 : b = 8 * q + 1 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 16 * q + 1 := by rw [hb1]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + q) := by omega
+    rw [hexp, pow_mul]; norm_num
+  · -- b ≡ 3 (mod 8): exponent odd
+    rw [if_neg (by omega)]
+    have hb3 : b = 8 * q + 3 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 48 * q + 9 := by rw [hb3]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + 3 * q) + 1 := by omega
+    rw [hexp, pow_succ, pow_mul]; norm_num
+  · -- b ≡ 5 (mod 8): exponent odd
+    rw [if_neg (by omega)]
+    have hb5 : b = 8 * q + 5 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 80 * q + 25 := by rw [hb5]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + 5 * q + 1) + 1 := by omega
+    rw [hexp, pow_succ, pow_mul]; norm_num
+  · -- b ≡ 7 (mod 8): exponent even
+    rw [if_pos (Or.inr h)]
+    have hb7 : b = 8 * q + 7 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 112 * q + 49 := by rw [hb7]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + 7 * q + 3) := by omega
+    rw [hexp, pow_mul]; norm_num
+
+/-! ### A worked evaluation by reciprocity (no factorization)
+
+The payoff of Jacobi reciprocity: `J(a|b)` can be evaluated by repeatedly
+*flipping* the arguments and reducing the (now larger) numerator modulo the
+(smaller) denominator — never factoring `b`.  We illustrate one flip step.
+`norm_num`'s Jacobi-symbol extension automates the whole chain; the explicit
+flip below exhibits the single reciprocity step it performs internally. -/
+
+/-- Worked evaluation: `J(5 | 21) = 1`, obtained by flipping (`5 ≡ 1 mod 4`,
+so `J(5|21) = J(21|5)`) and then reducing — *without* factoring `21 = 3·7`. -/
+theorem jacobi_five_twentyone_by_reciprocity : jacobiSym 5 21 = 1 := by
+  have flip : jacobiSym 5 21 = jacobiSym 21 5 :=
+    jacobiSym.quadratic_reciprocity_one_mod_four (by norm_num) (by norm_num)
+  rw [flip]
+  -- `J(21|5)`: numerator reduces `21 ≡ 1 (mod 5)`, giving `J(1|5) = 1`.
+  norm_num
+
+/-- Sanity cross-check: the same value computed directly (definitionally,
+via the prime factorization of `21`). Both routes agree. -/
+theorem jacobi_five_twentyone_direct : jacobiSym 5 21 = 1 := by norm_num
+
+end JacobiSymbolOQ0101

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-module-header",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 38 },
+    "title": "Module Header: Reciprocity and the Supplementary Laws",
+    "content": "The **Jacobi symbol** $J(a \\mid b)$ (with $b$ odd) obeys **quadratic reciprocity** $J(a\\mid b) = (-1)^{\\frac{a-1}{2}\\frac{b-1}{2}} J(b\\mid a)$ and the two **supplementary laws** for $-1$ and $2$, exactly as the Legendre symbol does — even though $b$ need not be prime. Mathlib provides reciprocity directly and the supplementary laws in *character* form ($J(-1\\mid b) = \\chi_4(b)$, $J(2\\mid b) = \\chi_8(b)$). This entry derives the classical **explicit power forms** $J(-1\\mid b) = (-1)^{(b-1)/2}$ and $J(2\\mid b) = (-1)^{(b^2-1)/8}$; the second is a genuine residue computation on $b \\bmod 8$.",
+    "mathContext": "$J(a\\mid b)=(-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}J(b\\mid a)$, $J(-1\\mid b)=(-1)^{\\frac{b-1}{2}}$, $J(2\\mid b)=(-1)^{\\frac{b^2-1}{8}}$.",
+    "significance": "context",
+    "relatedConcepts": ["quadratic reciprocity", "supplementary laws", "Legendre symbol", "quadratic characters χ₄, χ₈"],
+    "prerequisites": ["Jacobi symbol", "Gauss reciprocity for primes", "odd moduli"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-reciprocity",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 40, "endLine": 53 },
+    "title": "The Law of Quadratic Reciprocity",
+    "content": "`jacobi_quadratic_reciprocity`: for odd $a, b$, $J(a\\mid b) = (-1)^{(a/2)(b/2)} J(b\\mid a)$ (for odd $n$, $n/2 = (n-1)/2$). The residue-class corollaries `jacobi_reciprocity_one_mod_four` ($a \\equiv 1 \\bmod 4 \\Rightarrow J(a\\mid b) = J(b\\mid a)$) and `jacobi_reciprocity_three_mod_four` ($a \\equiv b \\equiv 3 \\bmod 4 \\Rightarrow J(a\\mid b) = -J(b\\mid a)$) record the two sign regimes. These are restatements of Mathlib's `jacobiSym.quadratic_reciprocity` and its mod-4 specializations.",
+    "mathContext": "The flip sign $(-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}$ is itself bimultiplicative, which is why reciprocity survives composite $b$.",
+    "significance": "core",
+    "relatedConcepts": ["quadratic reciprocity", "qrSign", "residue classes mod 4"],
+    "prerequisites": ["Legendre reciprocity", "bimultiplicativity of the Jacobi symbol"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-supp1",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 55, "endLine": 66 },
+    "title": "First Supplementary Law: J(−1|b) = (−1)^((b−1)/2)",
+    "content": "`jacobi_at_neg_one_pow`: for odd $b$, $J(-1\\mid b) = (-1)^{(b-1)/2}$ — so $J(-1\\mid b) = 1$ iff $b \\equiv 1 \\pmod 4$. The proof rewrites $J(-1\\mid b) = \\chi_4(b)$ (`jacobiSym.at_neg_one`), then $\\chi_4(b) = (-1)^{b/2}$ (`ZMod.χ₄_eq_neg_one_pow`), and closes with $b/2 = (b-1)/2$ for odd $b$ (`omega`).",
+    "mathContext": "$J(-1\\mid b)=\\chi_4(b)=(-1)^{(b-1)/2}$.",
+    "significance": "core",
+    "relatedConcepts": ["first supplementary law", "character χ₄", "residue mod 4"],
+    "prerequisites": ["jacobiSym.at_neg_one", "ZMod.χ₄_eq_neg_one_pow"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-supp2",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 68, "endLine": 117 },
+    "title": "Second Supplementary Law: J(2|b) = (−1)^((b²−1)/8)",
+    "content": "`jacobi_at_two_pow` (the substantive result): for odd $b$, $J(2\\mid b) = (-1)^{(b^2-1)/8}$ — so $J(2\\mid b) = 1$ iff $b \\equiv \\pm 1 \\pmod 8$. Mathlib gives only the character form $J(2\\mid b) = \\chi_8(b)$; the bridge is proved here from scratch. Writing $b = 8q + r$ with $r = b \\bmod 8 \\in \\{1,3,5,7\\}$, one has $b^2 - 1 = 8(8q^2 + 2qr) + (r^2-1)$ with $8 \\mid (r^2-1)$, so the parity of the exponent $(b^2-1)/8$ equals that of $(r^2-1)/8$ — even for $r \\in \\{1,7\\}$, odd for $r \\in \\{3,5\\}$. Each of the four cases is discharged by `omega` (abstracting $q\\cdot q$ as an opaque atom so division by 8 stays linear) together with `pow_mul`/`pow_succ`.",
+    "mathContext": "Exponent parity is $b\\bmod 8$–periodic: $(b^2-1)/8 \\equiv (r^2-1)/8 \\pmod 2$ for $r = b \\bmod 8$.",
+    "significance": "core",
+    "relatedConcepts": ["second supplementary law", "character χ₈", "residue mod 8", "parity of (b²−1)/8"],
+    "prerequisites": ["jacobiSym.at_two", "ZMod.χ₈_nat_eq_if_mod_eight", "omega over Nat division"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-worked",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 119, "endLine": 132 },
+    "title": "A Worked Evaluation by Reciprocity",
+    "content": "`jacobi_five_twentyone_by_reciprocity`: $J(5\\mid 21) = 1$, obtained by *flipping* — since $5 \\equiv 1 \\pmod 4$, $J(5\\mid 21) = J(21\\mid 5)$ — and then reducing $21 \\equiv 1 \\pmod 5$, never factoring $21 = 3\\cdot 7$. This is the algorithmic payoff of reciprocity. `jacobi_five_twentyone_direct` cross-checks the value $1$ via the prime factorization. `norm_num`'s Jacobi-symbol extension automates the whole descent; the explicit flip exhibits the single reciprocity step it performs.",
+    "mathContext": "$J(5\\mid21) = J(21\\mid5) = J(1\\mid5) = 1$ — factorization-free.",
+    "significance": "illustration",
+    "relatedConcepts": ["reciprocity descent", "Solovay–Strassen primality test", "factorization-free evaluation"],
+    "prerequisites": ["jacobi_reciprocity_one_mod_four", "norm_num Jacobi extension"]
+  }
+]

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-01/meta.json
@@ -1,0 +1,225 @@
+{
+  "id": "jacobi-symbol-oq-01-oq-01",
+  "title": "Quadratic Reciprocity for the Jacobi Symbol, with Explicit Power-Form Supplementary Laws",
+  "slug": "jacobi-symbol-oq-01-oq-01",
+  "description": "The Jacobi symbol J(a|b) (b odd) obeys quadratic reciprocity and two supplementary laws exactly as the Legendre symbol does, even for composite b. This entry packages the reciprocity law J(a|b) = (−1)^((a−1)/2·(b−1)/2)·J(b|a) with its residue-class corollaries, and derives the classical EXPLICIT power forms of both supplementary laws: J(−1|b) = (−1)^((b−1)/2) and J(2|b) = (−1)^((b²−1)/8). Mathlib provides reciprocity directly and the supplementary laws in character form (χ₄ b, χ₈ b); the mathematical content added here is the elementary bridge to the textbook power forms — in particular the χ₈ → (−1)^((b²−1)/8) step, a genuine residue computation on b mod 8. A worked flip evaluates J(5|21) without factoring. 7 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
+    "date": "Carl Gustav Jacob Jacobi, 1837",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "supplementary-laws",
+      "modular-arithmetic",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/JacobiSymbolOQ0101.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 7 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, confirmed by #print axioms, which do not count). The concrete value J(5|21) = 1 is proved by the norm_num Legendre-symbol extension (a kernel-checked proof) — no native_decide, so no Lean.ofReduceBool.",
+    "originalContributions": [
+      "jacobi_at_two_pow (the substantive result): the SECOND supplementary law in explicit power form, J(2|b) = (−1)^((b²−1)/8) for odd b. Mathlib only provides J(2|b) = χ₈ b (character form). The bridge χ₈ b = (−1)^((b²−1)/8) is proved here from first principles: writing b = 8q + r with r = b mod 8, one shows b² − 1 = 8(8q² + 2qr) + (r² − 1) with 8 ∣ (r² − 1), so the parity of the exponent (b²−1)/8 equals that of (r²−1)/8 — even iff r ∈ {1,7}. The four residue cases are discharged by omega (abstracting q*q as an opaque atom so division-by-8 stays linear) and pow_mul/pow_succ. This is the genuinely original, non-wrapping content.",
+      "jacobi_at_neg_one_pow: the FIRST supplementary law in explicit power form, J(−1|b) = (−1)^((b−1)/2) for odd b, bridged from Mathlib's character form J(−1|b) = χ₄ b via ZMod.χ₄_eq_neg_one_pow and the identity b/2 = (b−1)/2 for odd b.",
+      "jacobi_quadratic_reciprocity, jacobi_reciprocity_one_mod_four, jacobi_reciprocity_three_mod_four: the reciprocity law and its clean residue-class corollaries — one-line re-exports of Mathlib's jacobiSym.quadratic_reciprocity and its mod-4 specializations; packaging, not independent proof.",
+      "jacobi_five_twentyone_by_reciprocity: a worked evaluation exhibiting the reciprocity FLIP (5 ≡ 1 mod 4 ⟹ J(5|21) = J(21|5)) that lets the symbol be computed without factoring 21 = 3·7; cross-checked against the direct value (jacobi_five_twentyone_direct).",
+      "Resolves the first open question posed by jacobi-symbol-oq-01: 'Formalize quadratic reciprocity for the Jacobi symbol itself and the supplementary laws for −1 and 2.'"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "jacobiSym.quadratic_reciprocity",
+        "description": "For odd a, b: J(a|b) = (−1)^((a/2)·(b/2))·J(b|a). jacobi_quadratic_reciprocity is this lemma.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.quadratic_reciprocity_one_mod_four / quadratic_reciprocity_three_mod_four",
+        "description": "Residue-class corollaries: a ≡ 1 (mod 4) ⟹ J(a|b) = J(b|a); a ≡ b ≡ 3 (mod 4) ⟹ J(a|b) = −J(b|a).",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.at_neg_one",
+        "description": "J(−1|b) = χ₄ b for odd b (character form of the first supplementary law). Bridged to (−1)^((b−1)/2) in jacobi_at_neg_one_pow.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.at_two",
+        "description": "J(2|b) = χ₈ b for odd b (character form of the second supplementary law). Bridged to (−1)^((b²−1)/8) in jacobi_at_two_pow.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "ZMod.χ₄_eq_neg_one_pow / ZMod.χ₈_nat_eq_if_mod_eight",
+        "description": "Explicit evaluations of the quadratic characters: χ₄ n = (−1)^(n/2) for odd n; χ₈ n = +1 for n ≡ ±1 (mod 8) and −1 for n ≡ ±3 (mod 8). The raw material for the power-form bridges.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.ZModChar"
+      }
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 132,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Gauss's law of quadratic reciprocity, together with the two supplementary laws for −1 and 2, is the cornerstone of elementary number theory. Jacobi's 1837 extension of the Legendre symbol to composite odd moduli is what makes reciprocity ALGORITHMIC: because J(a|b) obeys the same reciprocity and supplementary laws — yet requires no factorization of b — one can evaluate a Legendre symbol by repeatedly flipping arguments and reducing modulo, the recursion underlying the Solovay–Strassen primality test and fast Legendre-symbol computation.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01, from jacobi-symbol-oq-01)**: Formalize quadratic reciprocity for the Jacobi symbol itself and the supplementary laws for −1 and 2.\n\n**Formalized**: the reciprocity law J(a|b) = (−1)^((a−1)/2·(b−1)/2)·J(b|a) with its mod-4 corollaries; both supplementary laws in explicit power form, J(−1|b) = (−1)^((b−1)/2) and J(2|b) = (−1)^((b²−1)/8); and a worked reciprocity flip computing J(5|21) = 1 without factoring 21.",
+    "text": "A 132-line formalization built on Mathlib's jacobiSym and the quadratic characters χ₄, χ₈. The reciprocity theorems are clean restatements of Mathlib's jacobiSym.quadratic_reciprocity and its residue-class specializations. The two supplementary laws are the focus: Mathlib supplies them only in character form (J(−1|b) = χ₄ b, J(2|b) = χ₈ b), and this entry derives the classical EXPLICIT power forms. The first, J(−1|b) = (−1)^((b−1)/2), follows from ZMod.χ₄_eq_neg_one_pow. The second, J(2|b) = (−1)^((b²−1)/8), is the substantive step: an elementary residue computation showing the exponent's parity is b mod 8–periodic, carried out from scratch over the four odd residues. All 7 theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**Reciprocity**: jacobi_quadratic_reciprocity / jacobi_reciprocity_one_mod_four / jacobi_reciprocity_three_mod_four are restatements of jacobiSym.quadratic_reciprocity and its mod-4 corollaries.\n\n**First supplementary law**: jacobi_at_neg_one_pow rewrites J(−1|b) = χ₄ b (jacobiSym.at_neg_one), then χ₄ b = (−1)^(b/2) (ZMod.χ₄_eq_neg_one_pow), then b/2 = (b−1)/2 for odd b (omega).\n\n**Second supplementary law** (the substantive bridge): jacobi_at_two_pow rewrites J(2|b) = χ₈ b (jacobiSym.at_two) and expands χ₈ b by residue mod 8 (ZMod.χ₈_nat_eq_if_mod_eight). Setting q = b/8 and casing on b mod 8 ∈ {1,3,5,7}, it establishes b² as 64q² + (linear in q) + r² and then, treating q*q as an opaque atom so that division by 8 stays within linear arithmetic, derives (b²−1)/8 = 2·(…) [+1] by omega — even exponent for r ∈ {1,7}, odd for r ∈ {3,5} — and finishes each case with pow_mul/pow_succ and norm_num.\n\n**Worked flip**: jacobi_five_twentyone_by_reciprocity applies the 1-mod-4 corollary to turn J(5|21) into J(21|5), evaluated by norm_num after reducing 21 ≡ 1 (mod 5) — no factorization of 21; jacobi_five_twentyone_direct cross-checks the value.",
+    "keyInsights": [
+      "**Reciprocity survives the loss of primality**: even though b need not be prime, J(a|b) flips against J(b|a) with the very same (−1)^((a−1)/2·(b−1)/2) sign as the Legendre symbol — because the sign is itself bimultiplicative (Mathlib's qrSign).",
+      "**The second supplementary law is the interesting one**: J(2|b) = (−1)^((b²−1)/8). The exponent (b²−1)/8 is always an integer for odd b, and its PARITY depends only on b mod 8: even for b ≡ ±1, odd for b ≡ ±3. The clean way to see this is b² − 1 = 8(8q² + 2qr) + (r²−1) with 8 ∣ (r²−1), so the parity reduces to that of (r²−1)/8 over r = b mod 8 ∈ {1,3,5,7}.",
+      "**Bridging characters to powers of −1 is real work**: Mathlib deliberately states the supplementary laws via the quadratic characters χ₄, χ₈ (which generalize cleanly), not via (−1)-powers. Recovering the textbook power forms is the formalization content here, not a re-export.",
+      "**omega + opaque nonlinear atoms**: the residue computation never needs nonlinear reasoning — once b² is expanded against a fixed residue and q*q is abstracted as a single variable, the exponent identity (including division by 8) is purely linear and omega closes it.",
+      "**Why this matters computationally**: with reciprocity plus the two supplementary laws (handling the factors of 2 and the sign), a Jacobi symbol is evaluated by a Euclidean-style descent on the arguments — no factorization — which is exactly what jacobi_five_twentyone_by_reciprocity illustrates and what powers Solovay–Strassen."
+    ],
+    "prerequisites": [
+      "The Legendre symbol (a|p) and Gauss's quadratic reciprocity for primes",
+      "The Jacobi symbol jacobiSym a b = ∏_{p∣b} (a|p) over the prime factors of odd b (Mathlib jacobiSym), and its bimultiplicativity (see jacobi-symbol-oq-01)",
+      "The quadratic characters χ₄ : (ZMod 4)ˣ → ℤ and χ₈ : (ZMod 8)ˣ → ℤ and their explicit values",
+      "jacobiSym.quadratic_reciprocity, jacobiSym.at_neg_one, jacobiSym.at_two; ZMod.χ₄_eq_neg_one_pow, ZMod.χ₈_nat_eq_if_mod_eight",
+      "Nat division/modulus arithmetic and the omega decision procedure"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Docstring stating the reciprocity law and the two supplementary laws in both character form (Mathlib's χ₄ b, χ₈ b) and the classical explicit power forms derived here, and explaining that the χ₈ → (−1)^((b²−1)/8) bridge is the substantive content. Fully verified (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "$J(a\\mid b)=(-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}J(b\\mid a)$, $J(-1\\mid b)=(-1)^{\\frac{b-1}{2}}$, $J(2\\mid b)=(-1)^{\\frac{b^2-1}{8}}$."
+    },
+    {
+      "id": "sec-reciprocity",
+      "title": "The Law of Quadratic Reciprocity",
+      "startLine": 40,
+      "endLine": 53,
+      "summary": "jacobi_quadratic_reciprocity (the (−1)-power form) and the residue-class corollaries jacobi_reciprocity_one_mod_four (a ≡ 1 mod 4 ⟹ symbols agree) and jacobi_reciprocity_three_mod_four (a ≡ b ≡ 3 mod 4 ⟹ symbols opposite). Restatements of Mathlib's jacobiSym reciprocity API.",
+      "mathContext": "$a\\equiv1\\!\\pmod 4\\Rightarrow J(a\\mid b)=J(b\\mid a)$; $a\\equiv b\\equiv3\\!\\pmod4\\Rightarrow J(a\\mid b)=-J(b\\mid a)$."
+    },
+    {
+      "id": "sec-supp1",
+      "title": "First Supplementary Law: J(−1|b)",
+      "startLine": 55,
+      "endLine": 66,
+      "summary": "jacobi_at_neg_one_pow: J(−1|b) = (−1)^((b−1)/2) for odd b, bridged from Mathlib's character form J(−1|b) = χ₄ b via ZMod.χ₄_eq_neg_one_pow and the odd-b identity b/2 = (b−1)/2.",
+      "mathContext": "$J(-1\\mid b)=\\chi_4(b)=(-1)^{(b-1)/2}$."
+    },
+    {
+      "id": "sec-supp2",
+      "title": "Second Supplementary Law: J(2|b) (the substantive bridge)",
+      "startLine": 68,
+      "endLine": 117,
+      "summary": "jacobi_at_two_pow: J(2|b) = (−1)^((b²−1)/8) for odd b. Starting from J(2|b) = χ₈ b, the proof expands χ₈ b by b mod 8 and, casing on the four odd residues, derives the parity of (b²−1)/8 from first principles — b² − 1 = 8(8q²+2qr) + (r²−1) with 8 ∣ (r²−1) — using omega (with q*q abstracted) and pow_mul/pow_succ.",
+      "mathContext": "$J(2\\mid b)=\\chi_8(b)=(-1)^{(b^2-1)/8}$; exponent parity is $b\\bmod 8$–periodic."
+    },
+    {
+      "id": "sec-worked",
+      "title": "A Worked Evaluation by Reciprocity",
+      "startLine": 119,
+      "endLine": 132,
+      "summary": "jacobi_five_twentyone_by_reciprocity flips J(5|21) to J(21|5) (since 5 ≡ 1 mod 4) and evaluates after reducing 21 ≡ 1 (mod 5) — computing the symbol without factoring 21 = 3·7. jacobi_five_twentyone_direct cross-checks the value 1.",
+      "mathContext": "$J(5\\mid21)=J(21\\mid5)=J(1\\mid5)=1$, no factorization of $21$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "jacobi-symbol-oq-01",
+      "relationship": "extends",
+      "description": "jacobi-symbol-oq-01 assembles the Jacobi symbol's bimultiplicativity, trichotomy, and one-sided non-residue obstruction, and explicitly poses as its first open question the formalization of quadratic reciprocity and the supplementary laws for −1 and 2. This entry resolves that question."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "builds-on",
+      "description": "The Legendre-symbol reciprocity and supplementary laws (over a prime) underlie the Jacobi-symbol versions here, which are obtained by multiplying over the prime factorization of the odd modulus."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "JacobiSymbolOQ0101",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/JacobiSymbolOQ0101.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "jacobi_at_two_pow",
+      "type": "core",
+      "statement": "$b \\text{ odd} \\Rightarrow J(2 \\mid b) = (-1)^{(b^2-1)/8}$",
+      "significance": "The second supplementary law in classical explicit power form, and the substantive original content: Mathlib provides only the character form J(2|b) = χ₈ b, and the bridge χ₈ b = (−1)^((b²−1)/8) is proved here from first principles via an elementary parity computation on b mod 8.",
+      "description": "Second supplementary law, explicit power form."
+    },
+    {
+      "name": "jacobi_at_neg_one_pow",
+      "type": "core",
+      "statement": "$b \\text{ odd} \\Rightarrow J(-1 \\mid b) = (-1)^{(b-1)/2}$",
+      "significance": "The first supplementary law in explicit power form, bridged from Mathlib's character form J(−1|b) = χ₄ b.",
+      "description": "First supplementary law, explicit power form."
+    },
+    {
+      "name": "jacobi_quadratic_reciprocity",
+      "type": "core",
+      "statement": "$a, b \\text{ odd} \\Rightarrow J(a \\mid b) = (-1)^{(a/2)(b/2)} J(b \\mid a)$",
+      "significance": "The headline reciprocity law for the Jacobi symbol — the same flip sign as the Legendre symbol, valid for all odd moduli.",
+      "description": "Quadratic reciprocity for the Jacobi symbol."
+    },
+    {
+      "name": "jacobi_reciprocity_one_mod_four",
+      "type": "supporting",
+      "statement": "$a \\equiv 1 \\pmod 4,\\ b \\text{ odd} \\Rightarrow J(a \\mid b) = J(b \\mid a)$",
+      "significance": "The clean residue-class corollary: when a ≡ 1 (mod 4) the flip sign is +1 and the symbols agree.",
+      "description": "Reciprocity corollary for a ≡ 1 (mod 4)."
+    },
+    {
+      "name": "jacobi_reciprocity_three_mod_four",
+      "type": "supporting",
+      "statement": "$a \\equiv b \\equiv 3 \\pmod 4 \\Rightarrow J(a \\mid b) = -J(b \\mid a)$",
+      "significance": "The other residue-class corollary: two arguments ≡ 3 (mod 4) flip with a sign change.",
+      "description": "Reciprocity corollary for a ≡ b ≡ 3 (mod 4)."
+    },
+    {
+      "name": "jacobi_five_twentyone_by_reciprocity",
+      "type": "supporting",
+      "statement": "$J(5 \\mid 21) = 1$ via the flip $J(5\\mid21) = J(21\\mid5)$",
+      "significance": "Illustrates the algorithmic payoff: reciprocity evaluates the symbol by flipping and reducing, never factoring the modulus 21 = 3·7.",
+      "description": "Worked evaluation by reciprocity."
+    },
+    {
+      "name": "jacobi_five_twentyone_direct",
+      "type": "supporting",
+      "statement": "$J(5 \\mid 21) = 1$",
+      "significance": "Cross-check of the worked evaluation against the direct value (via the prime factorization of 21).",
+      "description": "Direct cross-check of J(5|21)."
+    }
+  ],
+  "references": [
+    {
+      "text": "Jacobi, C. G. J. (1837). Über die Kreisteilung und ihre Anwendung auf die Zahlentheorie. Introduction of the Jacobi symbol.",
+      "url": "https://en.wikipedia.org/wiki/Jacobi_symbol"
+    },
+    {
+      "text": "Ireland, K. & Rosen, M. A Classical Introduction to Modern Number Theory. Quadratic reciprocity and the supplementary laws for the Jacobi symbol.",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity"
+    },
+    {
+      "text": "Mathlib4: jacobiSym.quadratic_reciprocity, jacobiSym.at_neg_one, jacobiSym.at_two (NumberTheory/LegendreSymbol/JacobiSymbol.lean); ZMod.χ₄_eq_neg_one_pow, ZMod.χ₈_nat_eq_if_mod_eight (NumberTheory/LegendreSymbol/ZModChar.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Resolves the first open question of jacobi-symbol-oq-01 by formalizing quadratic reciprocity for the Jacobi symbol and both supplementary laws. The reciprocity theorems are restatements of Mathlib's jacobiSym API; the original content is the bridge from Mathlib's character forms to the classical explicit power forms J(−1|b) = (−1)^((b−1)/2) and — the substantive step — J(2|b) = (−1)^((b²−1)/8), the latter proved by an elementary parity computation on b mod 8. A worked flip evaluates J(5|21) without factoring. All 7 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Reciprocity plus the two supplementary laws turn Jacobi-symbol evaluation into a factorization-free Euclidean descent — the engine behind the Solovay–Strassen primality test and fast Legendre-symbol computation. The explicit power forms are the shape in which the supplementary laws are applied in such algorithms and in hand computation.",
+    "openQuestions": [
+      "Formalize the Solovay–Strassen Euler-witness predicate a^((b−1)/2) ≡ J(a|b) (mod b) and quantify its failure rate for composite b.",
+      "Prove the b mod 4a periodicity of J(a|b) (Mathlib's jacobiSym.mod_right') as a standalone reciprocity corollary and use it to bound the descent length of the evaluation algorithm."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **first open question** posed by `jacobi-symbol-oq-01`: *formalize quadratic reciprocity for the Jacobi symbol itself and the supplementary laws for −1 and 2.*

For odd `b`, the Jacobi symbol `J(a|b)` obeys quadratic reciprocity and the two supplementary laws exactly as the Legendre symbol does — even though `b` need not be prime. Mathlib provides reciprocity directly and the supplementary laws in **character form** (`J(-1|b) = χ₄ b`, `J(2|b) = χ₈ b`). This entry derives the classical **explicit power forms**.

## Theorems (7, file `Proofs/JacobiSymbolOQ0101.lean`, 132 lines)

- `jacobi_quadratic_reciprocity` + `jacobi_reciprocity_one_mod_four` / `_three_mod_four` — reciprocity law and its mod-4 corollaries (restate Mathlib)
- `jacobi_at_neg_one_pow`: `J(-1|b) = (-1)^((b-1)/2)`, bridged from `χ₄`
- **`jacobi_at_two_pow` (the substantive result)**: `J(2|b) = (-1)^((b²-1)/8)`. Mathlib gives only `J(2|b) = χ₈ b`; the bridge `χ₈ b = (-1)^((b²-1)/8)` is proved from first principles. Writing `b = 8q + r`, `r = b mod 8`, one has `b² - 1 = 8(8q² + 2qr) + (r²-1)` with `8 ∣ (r²-1)`, so the exponent parity is `b mod 8`-periodic (even iff `r ∈ {1,7}`). The four residue cases close by `omega` (with `q*q` abstracted as an opaque atom, keeping division-by-8 linear) plus `pow_mul`/`pow_succ`.
- `jacobi_five_twentyone_by_reciprocity`: a worked **flip** evaluating `J(5|21) = 1` without factoring `21 = 3·7`; cross-checked by `jacobi_five_twentyone_direct`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` (foundational, do not count); no `sorryAx`, no `Lean.ofReduceBool`.
- **No `native_decide`.** The concrete value uses `norm_num`'s kernel-checked Jacobi extension.
- Verified with `lake env lean Proofs/JacobiSymbolOQ0101.lean` (exit 0) off the main `.lake` (Docker build host down this session).

## Honesty note

The reciprocity theorems are one-line re-exports of Mathlib's `jacobiSym.quadratic_reciprocity` API — packaging, not independent proof. The genuinely original content is the power-form bridges, especially the elementary `χ₈ → (-1)^((b²-1)/8)` parity computation, which Mathlib does not provide. Distinct from existing `jacobi-symbol-oq-01` (multiplicativity/residue detection) and `-oq-01-oq-03` (count representation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)