### PR TITLE
Research: erdos-335-oq-01 — repair broken build vs pinned Mathlib + singleton-translate lemmas

### DIFF
--- a/proofs/Proofs/Erdos335Problem.lean
+++ b/proofs/Proofs/Erdos335Problem.lean
@@ -180,7 +180,7 @@ theorem density_additive_comm (A B : Set ℕ) (h : DensityAdditive A B) :
 /-- Density additivity with the Plünnecke–Ruzsa bound: additive pairs are
     extremal (they achieve the minimum possible sumset density). -/
 theorem additive_achieves_lower_bound (A B : Set ℕ)
-    (hA : DensityExists A) (hB : DensityExists B) (h : DensityAdditive A B) :
+    (_hA : DensityExists A) (_hB : DensityExists B) (h : DensityAdditive A B) :
     asympDensity (Sumset A B) ≥ min (asympDensity A + asympDensity B) 1 := by
   rw [additive_implies_tight A B h]
 
@@ -324,16 +324,16 @@ theorem density_double_sumset (A : Set ℕ) (h : DensityAdditive A A) :
 /-- Counting function for the whole set ℕ equals N. -/
 private lemma countingFn_univ_eq (N : ℕ) : countingFn Set.univ N = N := by
   unfold countingFn
-  rw [Set.univ_inter, Set.ncard_Icc]
+  rw [Set.univ_inter, ← Finset.coe_Icc, Set.ncard_coe_finset, Nat.card_Icc]
   omega
 
 /-- The whole set ℕ has asymptotic density 1:
     every element of {1,...,N} is in ℕ, so the ratio is N/N = 1. -/
 theorem density_univ_one : DensityExists Set.univ ∧ asympDensity Set.univ = 1 := by
-  have htend : Filter.Tendsto (fun N => (countingFn Set.univ N : ℝ) / N) atTop (nhds 1) :=
-    Filter.Tendsto.congr' tendsto_const_nhds
-      (by filter_upwards [Filter.eventually_ne_atTop 0] with N hN
-          rw [countingFn_univ_eq, div_self (Nat.cast_ne_zero.mpr hN)])
+  have htend : Filter.Tendsto (fun N => (countingFn Set.univ N : ℝ) / N) atTop (nhds 1) := by
+    refine Filter.Tendsto.congr' ?_ tendsto_const_nhds
+    filter_upwards [Filter.eventually_ne_atTop 0] with N hN
+    rw [countingFn_univ_eq, div_self (Nat.cast_ne_zero.mpr hN)]
   exact ⟨⟨1, htend⟩, htend.limUnder_eq⟩
 
 /-- The counting function for a finite set A is bounded by its cardinality. -/
@@ -358,6 +358,57 @@ theorem density_finite_zero (A : Set ℕ) (hA : A.Finite) :
         by exact_mod_cast Nat.lt_of_succ_le hN
       linarith [Nat.le_ceil ((Set.ncard A : ℝ) / ε)]
     calc (countingFn A N : ℝ) / N
-        ≤ (Set.ncard A : ℝ) / N := (div_le_div_right hN_pos).mpr hNA
-      _ < ε := by rwa [div_lt_iff hN_pos, mul_comm, ← div_lt_iff hε]
+        ≤ (Set.ncard A : ℝ) / N := (div_le_div_iff_of_pos_right hN_pos).mpr hNA
+      _ < ε := by rwa [div_lt_iff₀ hN_pos, mul_comm, ← div_lt_iff₀ hε]
   exact ⟨⟨0, htend⟩, htend.limUnder_eq⟩
+
+/- ## Singleton Translates and a Concrete Density-Additive Witness -/
+
+/-- Adding a singleton `{k}` on the left translates `A` by `k`:
+    `{k} + A = (· + k) '' A`. This generalizes `Sumset_zero_left`
+    (the case `k = 0`) and makes the translation structure of singleton
+    sumsets explicit. -/
+theorem Sumset_singleton_left (k : ℕ) (A : Set ℕ) :
+    Sumset {k} A = (· + k) '' A := by
+  ext n
+  constructor
+  · rintro ⟨a, ha, b, hb, rfl⟩
+    rw [Set.mem_singleton_iff] at ha; subst ha
+    exact ⟨b, hb, by ring⟩
+  · rintro ⟨b, hb, rfl⟩
+    exact ⟨k, rfl, b, hb, by ring⟩
+
+/-- Adding a singleton `{k}` on the right translates `A` by `k`:
+    `A + {k} = (· + k) '' A`. -/
+theorem Sumset_singleton_right (A : Set ℕ) (k : ℕ) :
+    Sumset A {k} = (· + k) '' A := by
+  rw [Sumset_comm]; exact Sumset_singleton_left k A
+
+/-- The trivial pair `({0}, A)` is always density-additive whenever `A`
+    has a density: `d({0} + A) = d({0}) + d(A)` holds because `{0}` has
+    density `0` and `{0} + A = A`. This is the degenerate witness for the
+    density-additivity relation (it does not have positive density, so it
+    is not a witness for Erdős #335 proper, but it confirms the relation
+    is non-vacuous). -/
+theorem density_additive_zero_singleton (A : Set ℕ) (hA : DensityExists A) :
+    DensityAdditive {0} A := by
+  have hzero := density_finite_zero ({0} : Set ℕ) (Set.finite_singleton 0)
+  refine ⟨hzero.1, hA, ?_, ?_⟩
+  · rw [Sumset_zero_left]; exact hA
+  · rw [Sumset_zero_left, hzero.2, zero_add]
+
+/-- In a density-additive pair where `B` has positive density, the density
+    of `A` is strictly below `1`: from `d(A) + d(B) ≤ 1` and `d(B) > 0`. -/
+theorem density_additive_lt_one_left (A B : Set ℕ) (h : DensityAdditive A B)
+    (hB : HasPositiveDensity B) : asympDensity A < 1 := by
+  have hsum := additive_sum_le_one A B h
+  have hpos : 0 < asympDensity B := hB
+  linarith
+
+/-- Symmetric strict bound: in a density-additive pair where `A` has positive
+    density, the density of `B` is strictly below `1`. -/
+theorem density_additive_lt_one_right (A B : Set ℕ) (h : DensityAdditive A B)
+    (hA : HasPositiveDensity A) : asympDensity B < 1 := by
+  have hsum := additive_sum_le_one A B h
+  have hpos : 0 < asympDensity A := hA
+  linarith

--- a/research/problems/erdos-335/knowledge.md
+++ b/research/problems/erdos-335/knowledge.md
@@ -75,4 +75,32 @@ See: `sessions/2026-05-13-s06-prep-mathlib-bearer-audit-and-subgoal-roadmap.md`
 
 ---
 
+### S7 ACT — Build repair + singleton-translate lemmas + concrete witness (2026-06-25, researcher-4)
+
+ACT session at pinned Mathlib v4.26.0 (`2df2f01…`). Docker daemon down →
+verified single-file via unpacked mathlib cache + `lake env lean`.
+
+**Critical finding**: the `origin/main` file (363 LOC, gallery status
+`axiomatized`) **no longer compiled against its own pinned Mathlib v4.26.0** —
+8 elaboration errors from API drift (`Set.ncard_Icc`, `div_le_div_right`,
+`div_lt_iff` removed; `Filter.Tendsto.congr'` argument order changed). Repaired
+all four; also silenced 2 pre-existing `unused variable` warnings. File now
+compiles clean (0 errors / 0 warnings).
+
+**New verified theorems (5, all 0-axiom — `#print axioms` shows only
+`propext`/`Classical.choice`/`Quot.sound`, none of the 3 deep file axioms)**:
+- `Sumset_singleton_left`, `Sumset_singleton_right` — translate identity
+  `Sumset {k} A = (· + k) '' A` (S9 from roadmap; generalizes `Sumset_zero_left`).
+- `density_additive_zero_singleton` — `DensityAdditive {0} A` whenever
+  `DensityExists A` (S8 from roadmap; degenerate non-vacuity witness).
+- `density_additive_lt_one_left` / `_right` — strict complement bounds
+  `asympDensity A < 1` when the partner has positive density.
+
+**Lean snapshot**: 414 LOC, 40 theorems/lemmas, 8 defs, 0 sorries, 3 axioms
+(unchanged). The Schnirelmann↔asymptotic bridge sub-goal remains open.
+
+See: `sessions/2026-06-25-s07-act-build-repair-and-singleton-translate-lemmas.md`
+
+---
+
 *Generated from erdosproblems.com on 2026-01-13; sessions appended chronologically.*

--- a/research/problems/erdos-335/sessions/2026-06-25-s07-act-build-repair-and-singleton-translate-lemmas.md
+++ b/research/problems/erdos-335/sessions/2026-06-25-s07-act-build-repair-and-singleton-translate-lemmas.md
@@ -1,0 +1,57 @@
+# S7 ACT — Build repair + singleton-translate lemmas + concrete density-additive witness (2026-06-25, researcher-4)
+
+ACT session at lake-pinned Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0).
+
+## Critical finding: baseline was broken against its own pinned Mathlib
+
+The `origin/main` copy of `proofs/Proofs/Erdos335Problem.lean` (363 LOC, gallery
+status `axiomatized`/`axiom`) **failed to compile** against the project's *own*
+pinned Mathlib v4.26.0. Verified with `lake env lean` against the unpacked
+mathlib cache (Docker daemon was down). Eight elaboration errors, all from
+API drift — lemmas that were renamed/deprecated out of v4.26.0:
+
+| Broken identifier | Location | v4.26.0 replacement |
+|-------------------|----------|---------------------|
+| `Set.ncard_Icc` | `countingFn_univ_eq` | `← Finset.coe_Icc, Set.ncard_coe_finset, Nat.card_Icc` |
+| `div_le_div_right` (iff) | `density_finite_zero` | `div_le_div_iff_of_pos_right` |
+| `div_lt_iff` | `density_finite_zero` | `div_lt_iff₀` |
+| `Filter.Tendsto.congr'` arg order | `density_univ_one` | EventuallyEq first, then `Tendsto` (was swapped) |
+
+Also silenced two pre-existing `unused variable` warnings in
+`additive_achieves_lower_bound` (`hA`/`hB` → `_hA`/`_hB`).
+
+After repair: **0 errors, 0 warnings, 0 sorries** against pinned Mathlib.
+
+## New verified theorems (5, all 0-axiom)
+
+`#print axioms` confirms each depends only on `propext` / `Classical.choice` /
+`Quot.sound` — **none** of the file's 3 deep axioms.
+
+1. `Sumset_singleton_left (k) (A) : Sumset {k} A = (· + k) '' A` — S9 from the
+   S6 roadmap. The translate identity; generalizes `Sumset_zero_left` (k = 0).
+2. `Sumset_singleton_right (A) (k) : Sumset A {k} = (· + k) '' A` — right form.
+3. `density_additive_zero_singleton (A) (hA : DensityExists A) : DensityAdditive {0} A`
+   — S8 from the roadmap. The degenerate witness: `{0}` has density 0 and
+   `{0} + A = A`, so the relation `DensityAdditive` is non-vacuous. (Not a
+   witness for #335 proper — `{0}` lacks positive density.)
+4. `density_additive_lt_one_left (h : DensityAdditive A B) (hB : HasPositiveDensity B) : asympDensity A < 1`
+   — strict complement bound from `d(A) + d(B) ≤ 1` and `d(B) > 0`.
+5. `density_additive_lt_one_right` — symmetric.
+
+## Lean snapshot after this session
+
+- `proofs/Proofs/Erdos335Problem.lean`: **414 LOC**, **40 theorems/lemmas**,
+  8 defs, **0 sorries**, **3 axioms** (unchanged: `weyl_equidistribution`,
+  `fractional_part_density_additive`, `erdos_335_conjecture`).
+
+## Remaining sub-goal
+
+S7 (Schnirelmann↔asymptotic density bridge) from the S6 roadmap is still open;
+it requires `import Mathlib.Combinatorics.Schnirelmann` and ~40–80 LOC and was
+not attempted this session.
+
+## Non-goals respected
+
+- Did not touch the 3 deep axioms (they are mathematically necessary / are the
+  open problem itself).
+- Did not re-add the removed `plunnecke_ruzsa_lower` axiom.

--- a/research/problems/erdos-335/state.md
+++ b/research/problems/erdos-335/state.md
@@ -1,16 +1,16 @@
 # Current State
 
-**Phase**: PREP (Mathlib bearer audit + sub-goal roadmap)
-**Since**: 2026-05-13T11:00:00Z (S6 PREP shipped 2026-05-13; baseline iteration tracking carried over from S1 OBSERVE on 2026-01-13)
-**Iteration**: 6
+**Phase**: ACT (build repair + S8/S9 lemmas landed)
+**Since**: 2026-06-25T13:30:00Z (S7 ACT shipped 2026-06-25; baseline iteration tracking carried over from S1 OBSERVE on 2026-01-13)
+**Iteration**: 7
 
 ## Current Focus
 
-S6 PREP (doc-only) ships a Mathlib bearer audit at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` and pins three forward sub-goals for the next researcher: (S7) Schnirelmann↔asymptotic density bridge lemma, (S8) `DensityAdditive {0} A` concrete witness, (S9) `Sumset_singleton_left` translate identity.
+S7 ACT (researcher-4) **repaired a broken build**: the `origin/main` file no longer compiled against its *own* pinned Mathlib v4.26.0 due to API drift (`Set.ncard_Icc`, `div_le_div_right`, `div_lt_iff` removed; `Tendsto.congr'` arg order changed). Fixed all four and landed S8 (`density_additive_zero_singleton`) + S9 (`Sumset_singleton_left`/`_right`) from the S6 roadmap, plus two strict-bound corollaries. Remaining roadmap item — the Schnirelmann↔asymptotic bridge — is still open.
 
-## Lean File Snapshot (HEAD = main 5fec075d743)
+## Lean File Snapshot (HEAD = research/erdos-335-oq-01-build-repair)
 
-- `proofs/Proofs/Erdos335Problem.lean`: 363 LOC, **32 theorems/lemmas**, 8 defs, **0 sorries**, **3 axioms**.
+- `proofs/Proofs/Erdos335Problem.lean`: 414 LOC, **40 theorems/lemmas**, 8 defs, **0 sorries**, **3 axioms**. Compiles clean (0 errors / 0 warnings) against pinned Mathlib v4.26.0 via `lake env lean`.
 - Axioms (all deep / mathematically necessary):
   1. `weyl_equidistribution` — Weyl's equidistribution theorem (ABSENT from Mathlib at pinned SHA).
   2. `fractional_part_density_additive` — measure-theoretic transfer (ABSENT from Mathlib).

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -83,9 +83,9 @@
       "density_finite_zero: d(A) = 0 for any finite A ⊆ ℕ"
     ],
     "axiomCount": 3,
-    "lineCount": 363,
+    "lineCount": 414,
     "assumptions": "3 axioms: weyl_equidistribution, fractional_part_density_additive, erdos_335_conjecture (OPEN). See Lean source for complete statements.",
-    "theoremCount": 35,
+    "theoremCount": 40,
     "definitionCount": 8
   },
   "sections": [
@@ -228,9 +228,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 363,
+    "lineCount": 414,
     "axiomCount": 3,
-    "theoremCount": 35,
+    "theoremCount": 40,
     "definitionCount": 8,
     "path": "Proofs/Erdos335Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős Problem #335 (density-additivity characterization), open-question child `erdos-335-oq-01`.

**Critical fix**: the on-`main` `proofs/Proofs/Erdos335Problem.lean` (gallery status `axiomatized`) **no longer compiled against its own pinned Mathlib v4.26.0**. Eight elaboration errors from upstream API drift:

| Removed/changed in v4.26.0 | Replacement applied |
|---|---|
| `Set.ncard_Icc` | `← Finset.coe_Icc, Set.ncard_coe_finset, Nat.card_Icc` |
| `div_le_div_right` (iff) | `div_le_div_iff_of_pos_right` |
| `div_lt_iff` | `div_lt_iff₀` |
| `Filter.Tendsto.congr'` arg order | EventuallyEq first, then `Tendsto` |

Also silenced two pre-existing `unused variable` warnings. The file now compiles **clean (0 errors / 0 warnings / 0 sorries)**, verified single-file via `lake env lean` against the unpacked mathlib cache (Docker daemon was down).

## New verified theorems (5, all 0-axiom)

`#print axioms` confirms each depends only on `propext` / `Classical.choice` / `Quot.sound` — **none** of the file's 3 deep axioms.

- `Sumset_singleton_left (k) (A) : Sumset {k} A = (· + k) '' A` — roadmap **S9** (generalizes `Sumset_zero_left`).
- `Sumset_singleton_right (A) (k) : Sumset A {k} = (· + k) '' A`.
- `density_additive_zero_singleton (A) (DensityExists A) : DensityAdditive {0} A` — roadmap **S8**; degenerate non-vacuity witness (`{0}` has density 0, `{0} + A = A`).
- `density_additive_lt_one_left` / `_right` — strict complement bounds (`asympDensity A < 1` when the partner has positive density).

## Verification

- `lake env lean proofs/Proofs/Erdos335Problem.lean` → RC=0, 0 errors, 0 warnings, against the project's pinned Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0).
- Axioms unchanged: still exactly 3 deep declarations (`weyl_equidistribution`, `fractional_part_density_additive`, `erdos_335_conjecture`). No assumptions added.

## Snapshot

363 → **414 LOC**, 35 → **40 theorems/lemmas**, 0 sorries, 3 axioms (gallery `meta.json` metrics updated; `status`/`axiomCount` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)