### PR TITLE
Enrich Multinomial Aggregation (binomial-theorem-oq-03-oq-03): index.ts + annotations

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-pmf-mgf",
+    "proofId": "binomial-theorem-oq-03-oq-03",
+    "range": { "startLine": 76, "endLine": 95 },
+    "type": "definition",
+    "title": "Multinomial PMF and the generating identity",
+    "content": "multinomialProb defines P(X = k) = multinomial(s, k)·∏_{i∈s} p(i)^{k(i)}. multinomial_mgf_real is the workhorse: for any weight g, (Σᵢ p(i)·g(i))^n = Σ_k P(X=k)·∏ᵢ g(i)^{k(i)} — the multinomial theorem applied to f(i) = p(i)·g(i), with the p- and g-powers split apart via mul_pow + prod_mul_distrib. Every distributional result in the file is obtained by choosing g.",
+    "mathContext": "$P(X=k)=\\binom{n}{k}_{\\!*}\\prod_{i\\in s}p_i^{k_i}$ where $\\binom{n}{k}_{\\!*}$ is the multinomial coefficient. Generating identity: $\\left(\\sum_{i\\in s}p_i g_i\\right)^n=\\sum_{k:\\,\\sum k_i=n}P(X=k)\\prod_{i\\in s}g_i^{k_i}$, i.e. the multinomial theorem with $f_i=p_i g_i$.",
+    "significance": "key",
+    "relatedConcepts": ["multinomial distribution", "multinomial theorem", "moment generating function", "Finset.sum_pow_eq_sum_piAntidiag"],
+    "prerequisites": ["Nat.multinomial", "piAntidiag (compositions of n)", "mul_pow / prod_mul_distrib"]
+  },
+  {
+    "id": "ann-normalization",
+    "proofId": "binomial-theorem-oq-03-oq-03",
+    "range": { "startLine": 97, "endLine": 104 },
+    "type": "lemma",
+    "title": "Normalization of the multinomial PMF",
+    "content": "multinomialProb_sum_one: when Σᵢ p(i) = 1, the PMF sums to 1 over all compositions k with Σk = n. Immediate from the generating identity with g ≡ 1, since (Σ p)^n = 1^n = 1. This is literally the multinomial theorem certifying that multinomialProb is a genuine probability distribution.",
+    "mathContext": "$\\sum_{k:\\,\\sum k_i=n}P(X=k)=\\left(\\sum_{i\\in s}p_i\\right)^n=1^n=1$ when $\\sum_i p_i=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["probability normalization", "multinomial theorem", "total probability"],
+    "prerequisites": ["multinomial_mgf_real (g ≡ 1)"]
+  },
+  {
+    "id": "ann-main-aggregate",
+    "proofId": "binomial-theorem-oq-03-oq-03",
+    "range": { "startLine": 108, "endLine": 145 },
+    "type": "theorem",
+    "title": "multinomial_aggregate_pgf — the lumping property",
+    "content": "The centerpiece: for any block A ⊆ s, the PGF of the aggregated count X_A = Σ_{i∈A} X_i is E[t^{X_A}] = (p_A·t + (1−p_A))^n — exactly the Binomial(n, p_A) generating function, so the lumped count is binomial. The proof feeds the block indicator g(i) = if i∈A then t else 1 into multinomial_mgf_real: the product collapses to t^{Σ_{i∈A} k(i)} (Finset.prod_ite_mem, inter_eq_right for A⊆s, prod_pow_eq_pow_sum), and the n-th-power base simplifies to p_A·t + (1−p_A) by splitting off the (t−1)-weighted block sum (sum_ite_mem) and using Σ_s p = 1.",
+    "mathContext": "$E[t^{X_A}]=\\sum_k P(X=k)\\,t^{\\sum_{i\\in A}k_i}=(p_A t+(1-p_A))^n$ with $p_A=\\sum_{i\\in A}p_i$. Two distributions on $\\{0,\\dots,n\\}$ with equal PGF coincide, so $X_A\\sim\\mathrm{Binomial}(n,p_A)$.",
+    "significance": "key",
+    "relatedConcepts": ["probability generating function", "category aggregation / lumping", "closure of the multinomial family", "block indicator"],
+    "prerequisites": ["multinomial_mgf_real", "Finset.prod_ite_mem / sum_ite_mem", "Finset.prod_pow_eq_pow_sum", "Finset.inter_eq_right"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "binomial-theorem-oq-03-oq-03",
+    "range": { "startLine": 149, "endLine": 199 },
+    "type": "theorem",
+    "title": "Corollaries: binomial PMF, marginal, complement, total",
+    "content": "Four immediate consequences of the aggregation PGF. multinomial_aggregate_pgf_eq_binomial expands (p_A·t + (1−p_A))^n via add_pow (binomial theorem) to read off the coefficients Σ_j C(n,j)·p_A^j·(1−p_A)^{n−j}·t^j — the Binomial(n, p_A) PMF. multinomial_marginal_pgf_of_aggregate is the singleton case A = {i₀}, recovering the classical single-coordinate marginal. multinomial_aggregate_compl_pgf handles the complement s\\A (p_{s\\A} = 1 − p_A via Finset.sum_sdiff), giving Binomial(n, 1−p_A). multinomial_aggregate_univ takes A = s: with p_s = 1 the PGF collapses to t^n, the deterministic total X_s = n.",
+    "mathContext": "PMF: $\\sum_{j=0}^n\\binom{n}{j}p_A^{\\,j}(1-p_A)^{n-j}t^j$. Marginal: $A=\\{i_0\\}\\Rightarrow X_{i_0}\\sim\\mathrm{Binomial}(n,p_{i_0})$. Complement: $X_{s\\setminus A}\\sim\\mathrm{Binomial}(n,1-p_A)$. Total: $A=s\\Rightarrow p_s=1\\Rightarrow E[t^{X_s}]=t^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial PMF", "single-coordinate marginal", "complementary block", "deterministic total", "add_pow"],
+    "prerequisites": ["multinomial_aggregate_pgf", "add_pow", "Finset.sum_sdiff", "Finset.singleton_subset_iff"]
+  },
+  {
+    "id": "ann-fin3-example",
+    "proofId": "binomial-theorem-oq-03-oq-03",
+    "range": { "startLine": 203, "endLine": 226 },
+    "type": "context",
+    "title": "Worked example: a three-category multinomial on Fin 3",
+    "content": "aggregate_fin3_example instantiates the lumping property concretely: a Multinomial(n, p) on s = {0,1,2} ⊆ Fin 3 with categories {0,1} merged gives a Binomial(n, p₀+p₁) count, PGF ((p₀+p₁)·t + p₂)^n. Uses Fin.sum_univ_three for Σp = 1, Finset.sum_pair (with decide for 0 ≠ 1) to evaluate the block sums, and aligns the exponent Σ_{i∈{0,1}}k(i) = k 0 + k 1.",
+    "mathContext": "$s=\\{0,1,2\\}$, lump $A=\\{0,1\\}$: $X_0+X_1\\sim\\mathrm{Binomial}(n,p_0+p_1)$, PGF $((p_0+p_1)t+p_2)^n$, with $p_2=1-(p_0+p_1)$.",
+    "significance": "context",
+    "relatedConcepts": ["concrete instantiation", "Fin.sum_univ_three", "Finset.sum_pair", "two-outcome lumping"],
+    "prerequisites": ["multinomial_aggregate_pgf", "the decide tactic"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-03-oq-03/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ03OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const binomialTheoremOq03Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const binomialTheoremOq03Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const binomialTheoremOq03Oq03Data: ProofData = {
+  proof: binomialTheoremOq03Oq03Proof,
+  annotations: binomialTheoremOq03Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-03-oq-03` (the aggregation/lumping property of the multinomial distribution).

## Changes
- **Created missing `index.ts`** — without it the proof page rendered "proof not found" on the live site (entry had meta.json but no annotations or index.ts).
- **Created `annotations.json` from scratch** — 5 annotations covering the multinomial PMF + generating identity (`multinomialProb`, `multinomial_mgf_real`), normalization, the main lumping PGF theorem (`multinomial_aggregate_pgf`), the four corollaries (binomial-PMF identification, single-coordinate marginal, complement block, deterministic total), and the `aggregate_fin3_example`. Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, with startLines landing on the actual `def`/`theorem` constructs.

## Verification
- JSON parses; `pnpm annotations:build` reports no errors for this entry; `tsc -b` clean; `vite build` succeeds.
- Axiom integrity consistent with the Lean source: `status: verified`, `badge: original`, 0 axioms, 0 sorries, no `native_decide`.