### PR TITLE
Enrich Parallelogram Law (cauchy-schwarz-oq-07): annotation enrichment fields

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-07/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "Module Header and Problem Setup",
-    "content": "The open question asks for the parallelogram law $\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$ in a real or complex inner-product space, proved by expanding both squares via the inner-product self-identity and cancelling the cross terms. The law is the algebraic signature of inner-product geometry: by the Jordan–von Neumann theorem (1935) a norm is induced by an inner product if and only if it satisfies this identity."
+    "content": "The open question asks for the parallelogram law $\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$ in a real or complex inner-product space, proved by expanding both squares via the inner-product self-identity and cancelling the cross terms. The law is the algebraic signature of inner-product geometry: by the Jordan–von Neumann theorem (1935) a norm is induced by an inner product if and only if it satisfies this identity.",
+    "mathContext": "$\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$ — sum of squared diagonals = sum of squared sides.",
+    "significance": "context",
+    "relatedConcepts": ["inner-product space", "parallelogram law", "Jordan–von Neumann theorem", "norm induced by an inner product"],
+    "prerequisites": ["inner-product spaces", "norms", "the inner-product self-identity ‖x‖² = ⟪x,x⟫"]
   },
   {
     "id": "csoq07-rclike",
@@ -19,28 +23,40 @@
     },
     "type": "theorem",
     "title": "Parallelogram Law over an RCLike Field",
-    "content": "`parallelogram_norm_sq` states $\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$ over any inner-product space whose scalar field is `RCLike` (i.e. $\\mathbb{R}$ or $\\mathbb{C}$). Mathlib provides this identity only in the un-squared `*self` form `parallelogram_law_with_norm`; here it is repackaged into the squared `^2` form via `pow_two` and linear arithmetic, with the scalar field 𝕜 left explicit so the lemma can be specialized to either field."
+    "content": "`parallelogram_norm_sq` states $\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$ over any inner-product space whose scalar field is `RCLike` (i.e. $\\mathbb{R}$ or $\\mathbb{C}$). Mathlib provides this identity only in the un-squared `*self` form `parallelogram_law_with_norm`; here it is repackaged into the squared `^2` form via `pow_two` and linear arithmetic, with the scalar field 𝕜 left explicit so the lemma can be specialized to either field.",
+    "mathContext": "$\\|x+y\\|\\cdot\\|x+y\\| + \\|x-y\\|\\cdot\\|x-y\\| = 2(\\|x\\|\\cdot\\|x\\| + \\|y\\|\\cdot\\|y\\|) \\;\\xrightarrow{\\ \\mathrm{pow\\_two}\\ }\\; \\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2.$",
+    "significance": "key",
+    "relatedConcepts": ["RCLike scalar field", "parallelogram_law_with_norm", "pow_two", "explicit scalar field argument"],
+    "prerequisites": ["RCLike (ℝ or ℂ)", "InnerProductSpace 𝕜 E", "linarith"]
   },
   {
     "id": "csoq07-real",
     "proofId": "cauchy-schwarz-oq-07",
     "range": {
       "startLine": 55,
-      "endLine": 82
+      "endLine": 71
     },
     "type": "theorem",
     "title": "Real Case by Cross-Term Cancellation, and Polarization",
-    "content": "`parallelogram_norm_sq_real` proves the law over a real inner-product space by exactly the method named in the open question: expand $\\|x+y\\|^2 = \\|x\\|^2 + 2\\langle x,y\\rangle + \\|y\\|^2$ and $\\|x-y\\|^2 = \\|x\\|^2 - 2\\langle x,y\\rangle + \\|y\\|^2$, then add — the cross terms $\\pm 2\\langle x,y\\rangle$ cancel. Subtracting instead doubles the cross term, giving the dual **polarization identity** $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ (`real_inner_eq_norm_sq_diff_div_four`), which recovers the inner product from the norm alone. `norm_add_sq_eq_real` records the rearranged law."
+    "content": "`parallelogram_norm_sq_real` proves the law over a real inner-product space by exactly the method named in the open question: expand $\\|x+y\\|^2 = \\|x\\|^2 + 2\\langle x,y\\rangle + \\|y\\|^2$ and $\\|x-y\\|^2 = \\|x\\|^2 - 2\\langle x,y\\rangle + \\|y\\|^2$ (`norm_add_sq_real`, `norm_sub_sq_real`), then add — the cross terms $\\pm 2\\langle x,y\\rangle$ cancel and `ring` closes. Subtracting instead doubles the cross term, giving the dual **polarization identity** $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ (`real_inner_eq_norm_sq_diff_div_four`), which recovers the inner product from the norm alone. `norm_add_sq_eq_real` records the rearranged law.",
+    "mathContext": "$\\|x\\pm y\\|^2 = \\|x\\|^2 \\pm 2\\langle x,y\\rangle + \\|y\\|^2;\\quad \\text{add} \\Rightarrow \\text{parallelogram law},\\ \\text{subtract} \\Rightarrow \\langle x,y\\rangle = \\tfrac{\\|x+y\\|^2 - \\|x-y\\|^2}{4}.$",
+    "significance": "critical",
+    "relatedConcepts": ["polarization identity", "norm_add_sq_real", "norm_sub_sq_real", "cross-term cancellation", "recovering the inner product"],
+    "prerequisites": ["real inner-product spaces", "bilinearity of ⟪·,·⟫", "the ring tactic"]
   },
   {
     "id": "csoq07-complex",
     "proofId": "cauchy-schwarz-oq-07",
     "range": {
-      "startLine": 84,
-      "endLine": 85
+      "startLine": 77,
+      "endLine": 83
     },
     "type": "theorem",
     "title": "Complex Case",
-    "content": "`parallelogram_norm_sq_complex` is the $\\mathbb{C}$ instance of `parallelogram_norm_sq`, confirming the identity holds verbatim over a complex inner-product space."
+    "content": "`parallelogram_norm_sq_complex` is the $\\mathbb{C}$ instance of `parallelogram_norm_sq`, confirming the identity holds verbatim over a complex inner-product space. Unlike the polarization identity (which acquires an imaginary part over $\\mathbb{C}$), the parallelogram law itself is field-agnostic: only real squared norms appear, so the `RCLike` proof specializes directly with no extra work.",
+    "mathContext": "$\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$ over a complex inner-product space ($\\mathbb{C}$ instance of `parallelogram_norm_sq`).",
+    "significance": "supporting",
+    "relatedConcepts": ["complex inner-product space", "sesquilinear inner product", "field specialization"],
+    "prerequisites": ["complex inner-product spaces", "parallelogram_norm_sq"]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-oq-07/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07/meta.json
@@ -104,22 +104,22 @@
   ],
   "crossReferences": [
     {
-      "targetId": "cauchy-schwarz",
+      "proofId": "cauchy-schwarz",
       "relationship": "extends",
       "description": "Both are foundational inner-product-space identities; the parallelogram law and Cauchy-Schwarz together underpin Hilbert-space geometry"
     },
     {
-      "targetId": "cauchy-schwarz-oq-04",
+      "proofId": "cauchy-schwarz-oq-04",
       "relationship": "related",
       "description": "OQ-04 uses the Pythagorean norm decomposition (orthogonality); the parallelogram law here is the polarization-dual companion identity in the same inner-product-space family"
     },
     {
-      "targetId": "pythagorean-theorem",
+      "proofId": "pythagorean-theorem",
       "relationship": "foundational",
       "description": "The parallelogram law specializes to the Pythagorean theorem when ⟪x,y⟩ = 0: then ‖x+y‖² = ‖x‖² + ‖y‖² and ‖x−y‖² = ‖x‖² + ‖y‖², averaging to the parallelogram identity"
     },
     {
-      "targetId": "triangle-inequality",
+      "proofId": "triangle-inequality",
       "relationship": "related",
       "description": "Another norm identity/inequality in normed spaces; the parallelogram law is the equality that singles out inner-product norms among those satisfying the triangle inequality"
     }


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-07` (quality 59, pass 0).

The meta.json was already strong (complete overview, 4 sections, conclusion with
implications). The gap: the 4 annotations had good `content` but **none carried
the enrichment fields** (`mathContext`, `significance`, `relatedConcepts`,
`prerequisites`).

## Changes
- **Added `mathContext`, `significance`, `relatedConcepts`, `prerequisites`** to
  all 4 annotations (module header, RCLike-field case, real case + polarization,
  complex case).
- **Expanded the complex-case annotation** to cover its full section and noted
  that the parallelogram law is field-agnostic (only real squared norms appear),
  in contrast to the polarization identity which gains an imaginary part over ℂ.
- **Normalized `crossReferences`** `targetId` → `proofId` (preferred field name).

## Verification
- `tsc -b` clean; `annotations:build` reports no warnings for this entry (all
  ranges land on real Lean constructs); `vite build` succeeds.
- Cross-reference targets `cauchy-schwarz`, `cauchy-schwarz-oq-04`,
  `pythagorean-theorem`, `triangle-inequality` all exist.

## Axiom integrity
No status change. `status: verified` / `badge: original`, `axiomCount: 0` — the
Lean file is sorry-free and axiom-free, with no structure-encoded assumptions
and no `native_decide`. Accurate as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)