### PR TITLE
Enrich Norm-Rigidity / Polarization (cauchy-schwarz-oq-08): index.ts + annotation depth

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-08/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08/annotations.json
@@ -4,43 +4,59 @@
     "proofId": "cauchy-schwarz-oq-08",
     "range": {
       "startLine": 1,
-      "endLine": 39
+      "endLine": 35
     },
     "type": "concept",
     "title": "Module Header and Problem Setup",
-    "content": "The open question asks for the polarization identity $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ in a real inner-product space. The bare identity already appears in cauchy-schwarz-oq-07; this entry pushes it to its structural payoff — the inner product is uniquely determined by the norm, so any map preserving the norm must preserve the inner product. Two real inner-product spaces $F, F'$ are fixed via `[NormedAddCommGroup F] [InnerProductSpace ℝ F]`."
+    "content": "The open question asks for the polarization identity $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ in a real inner-product space. The bare identity already appears in cauchy-schwarz-oq-07; this entry pushes it to its structural payoff — the inner product is uniquely determined by the norm, so any map preserving the norm must preserve the inner product. Two real inner-product spaces $F, F'$ are fixed via `[NormedAddCommGroup F] [InnerProductSpace ℝ F]`.",
+    "mathContext": "Polarization $\\langle x,y\\rangle=\\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2)$ exhibits $\\langle\\cdot,\\cdot\\rangle$ as a function of $\\|\\cdot\\|$ alone — the source of all rigidity results in the file.",
+    "significance": "context",
+    "relatedConcepts": ["polarization identity", "norm rigidity", "real inner-product space", "isometries"],
+    "prerequisites": ["inner-product spaces", "norms"]
   },
   {
     "id": "csoq08-polarization",
     "proofId": "cauchy-schwarz-oq-08",
     "range": {
-      "startLine": 41,
-      "endLine": 50
+      "startLine": 37,
+      "endLine": 43
     },
     "type": "theorem",
     "title": "The Polarization Identity",
-    "content": "`polarization` proves $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ self-contained: expanding $\\|x+y\\|^2 = \\|x\\|^2 + 2\\langle x,y\\rangle + \\|y\\|^2$ and $\\|x-y\\|^2 = \\|x\\|^2 - 2\\langle x,y\\rangle + \\|y\\|^2$ (via `norm_add_sq_real`/`norm_sub_sq_real`), the difference is $4\\langle x,y\\rangle$. This recovers the inner product from the norm and serves as the engine for the rigidity results below."
+    "content": "`polarization` proves $\\langle x,y\\rangle = (\\|x+y\\|^2 - \\|x-y\\|^2)/4$ self-contained: expanding $\\|x+y\\|^2 = \\|x\\|^2 + 2\\langle x,y\\rangle + \\|y\\|^2$ and $\\|x-y\\|^2 = \\|x\\|^2 - 2\\langle x,y\\rangle + \\|y\\|^2$ (via `norm_add_sq_real`/`norm_sub_sq_real`), the difference is $4\\langle x,y\\rangle$. This recovers the inner product from the norm and serves as the engine for the rigidity results below.",
+    "mathContext": "$\\|x+y\\|^2-\\|x-y\\|^2=(\\dots+2\\langle x,y\\rangle+\\dots)-(\\dots-2\\langle x,y\\rangle+\\dots)=4\\langle x,y\\rangle$, closed by `ring`.",
+    "significance": "key",
+    "relatedConcepts": ["polarization identity", "cross-term cancellation", "norm_add_sq_real / norm_sub_sq_real", "inner product from norm"],
+    "prerequisites": ["real inner-product space", "the ring tactic"]
   },
   {
     "id": "csoq08-rigidity",
     "proofId": "cauchy-schwarz-oq-08",
     "range": {
-      "startLine": 52,
-      "endLine": 71
+      "startLine": 45,
+      "endLine": 68
     },
     "type": "theorem",
     "title": "Norm-Rigidity of the Inner Product",
-    "content": "`inner_map_eq` is the headline result: a norm-preserving **additive** map $f : F \\to_+ F'$ satisfies $\\langle f x, f y\\rangle = \\langle x,y\\rangle$. Rewriting both sides by polarization, additivity gives $f x \\pm f y = f(x \\pm y)$ and the hypothesis $\\|f z\\| = \\|z\\|$ equates the norms — so the inner products coincide. Crucially only additivity is used, not $\\mathbb{R}$-linearity. `inner_map_eq_zero_iff` derives preservation of orthogonality, and `injective_of_norm_preserving` shows such maps are injective (a vector of norm $0$ is $0$)."
+    "content": "`inner_map_eq` is the headline result: a norm-preserving **additive** map $f : F \\to_+ F'$ satisfies $\\langle f x, f y\\rangle = \\langle x,y\\rangle$. Rewriting both sides by polarization, additivity gives $f x \\pm f y = f(x \\pm y)$ and the hypothesis $\\|f z\\| = \\|z\\|$ equates the norms — so the inner products coincide. Crucially only additivity is used, not $\\mathbb{R}$-linearity. `inner_map_eq_zero_iff` derives preservation of orthogonality, and `injective_of_norm_preserving` shows such maps are injective (a vector of norm $0$ is $0$).",
+    "mathContext": "$\\langle fx,fy\\rangle=\\tfrac14(\\|fx+fy\\|^2-\\|fx-fy\\|^2)=\\tfrac14(\\|f(x+y)\\|^2-\\|f(x-y)\\|^2)=\\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2)=\\langle x,y\\rangle$, using only $f(x\\pm y)=fx\\pm fy$ and $\\|f z\\|=\\|z\\|$.",
+    "significance": "key",
+    "relatedConcepts": ["norm rigidity", "additive map (AddMonoidHom)", "orthogonality preservation", "injectivity from norm preservation"],
+    "prerequisites": ["polarization", "map_add / map_sub", "injective_iff_map_eq_zero"]
   },
   {
     "id": "csoq08-isometry",
     "proofId": "cauchy-schwarz-oq-08",
     "range": {
-      "startLine": 73,
+      "startLine": 70,
       "endLine": 83
     },
     "type": "theorem",
     "title": "Linear and Bundled-Isometry Corollaries",
-    "content": "`inner_linearMap_eq` specializes the rigidity theorem to an $\\mathbb{R}$-linear map by forgetting linearity down to its additive structure, recovering the defining property of a linear isometry. `inner_linearIsometry_eq` applies this to a bundled `LinearIsometry` through its `norm_map` field — obtaining $\\langle f x, f y\\rangle = \\langle x,y\\rangle$ without invoking Mathlib's bundled `LinearIsometry.inner_map_map`. This is the elementary reason isometries of Hilbert spaces are unitary."
+    "content": "`inner_linearMap_eq` specializes the rigidity theorem to an $\\mathbb{R}$-linear map by forgetting linearity down to its additive structure, recovering the defining property of a linear isometry. `inner_linearIsometry_eq` applies this to a bundled `LinearIsometry` through its `norm_map` field — obtaining $\\langle f x, f y\\rangle = \\langle x,y\\rangle$ without invoking Mathlib's bundled `LinearIsometry.inner_map_map`. This is the elementary reason isometries of Hilbert spaces are unitary.",
+    "mathContext": "A linear isometry is in particular a norm-preserving additive map, so `inner_map_eq` applies via `f.toAddMonoidHom` / `f.toLinearMap` and the `norm_map` field; hence $\\langle fx,fy\\rangle=\\langle x,y\\rangle$ — the inner-product-preserving (unitary) property.",
+    "significance": "supporting",
+    "relatedConcepts": ["linear isometry", "LinearIsometry (bundled)", "unitary maps", "Hilbert space isometries"],
+    "prerequisites": ["inner_map_eq", "LinearMap.toAddMonoidHom", "LinearIsometry.norm_map"]
   }
 ]

--- a/src/data/proofs/cauchy-schwarz-oq-08/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-08/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ08.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOq08Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOq08Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOq08Data: ProofData = {
+  proof: cauchySchwarzOq08Proof,
+  annotations: cauchySchwarzOq08Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-08/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-08/meta.json
@@ -67,7 +67,9 @@
     "keyInsights": [
       "**Polarization is a rigidity statement in disguise.** The bare identity recovers the inner product from the norm within one space; reading it across two spaces shows that fixing the norm forces fixing the inner product. The structural theorem `inner_map_eq` is the real content the identity is for.",
       "**Additivity suffices — linearity is not needed.** Polarization only references f(x+y) and f(x−y), so the inner-product-preservation theorem holds for any norm-preserving AddMonoidHom; ℝ-linear isometries are merely a special case. This is sharper than the usual textbook statement for linear isometries.",
-      "**Why isometries are unitary, elementarily.** The chain norm-preserving ⟹ inner-product-preserving ⟹ orthogonality-preserving + injective is exactly the reason Hilbert-space isometries are unitary, derived here without the bundled `LinearIsometry.inner_map_map` machinery."
+      "**Why isometries are unitary, elementarily.** The chain norm-preserving ⟹ inner-product-preserving ⟹ orthogonality-preserving + injective is exactly the reason Hilbert-space isometries are unitary, derived here without the bundled `LinearIsometry.inner_map_map` machinery.",
+      "**The proof of `inner_map_eq` is a four-rewrite chain.** Apply polarization to both sides, then `← map_add` and `← map_sub` turn fx±fy into f(x±y), and two applications of the norm hypothesis h collapse the norms — no induction, no case analysis, the whole rigidity theorem is `rw [polarization, polarization, ← map_add, ← map_sub, h, h]`.",
+      "**Rigidity is specific to the real case as stated.** Over ℂ the real-part polarization recovers only Re⟪x,y⟫, so a norm-preserving additive map fixes the real inner product; pinning the full Hermitian product needs the four-term complex polarization. The file works over ℝ, where the single identity already determines the inner product completely."
     ],
     "prerequisites": [
       "Inner product spaces (InnerProductSpace ℝ F in Mathlib)",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-08` (norm-rigidity of the real inner product via polarization).

## Changes
- **Created missing `index.ts`** — without it the proof page rendered "proof not found" on the live site.
- **Enriched all 4 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — previously `content`-only.
- **Expanded `overview.keyInsights` from 3 to 5** (the four-rewrite proof structure of `inner_map_eq`; why the rigidity is specific to the real case — ℂ recovers only Re⟪x,y⟫).

## Verification
- JSON parses; `pnpm annotations:build` reports no errors for this entry; `tsc -b` clean; `vite build` succeeds.
- Axiom integrity unchanged: `status: verified`, 0 axioms, 0 sorries.