### PR TITLE
audit(gallery): 3 fresh proofs ALL CLEAN (descartes-exact-count, little-wedderburn-lattice, pythagorean-prime-location)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23877,6 +23877,24 @@
       "lastAudited": "2026-06-25T13:18:12Z",
       "result": "clean",
       "issues": []
+    },
+    "descartes-rule-of-signs-oq-01-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T13:46:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "little-wedderburn-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T13:46:56Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-06-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T13:46:56Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 3 fresh proofs, all CLEAN

Audited the 3 genuinely-new unaudited proofs. The other 8 unaudited targets are already cleared in open PRs #30017 / #30013 / #30023, so this PR covers only the remainder.

All three pass static integrity: **0 sorries, 0 `axiom` declarations, 0 `True` stubs, theorem/def counts match meta.json, registered in `Proofs.lean`.**

| Proof | Status/Badge | Lean | Verdict |
|-------|--------------|------|---------|
| descartes-rule-of-signs-oq-01-oq-04-oq-02 | verified/original | 3 thm, 0 ax | CLEAN |
| little-wedderburn-oq-02-oq-01 | verified/mathlib | 7 thm + 1 def, 0 ax | CLEAN |
| pythagorean-triples-oq-06-oq-01-oq-01-oq-01 | verified/original | 10 thm, 0 ax | CLEAN |

### Notes
- **descartes**: the `native_decide` grep hit is a **comment** (`-- ... no native_decide`), not real usage → `axiomCount: 0` correct. Mathlib's `roots_countP_pos_le_signVariations` supplies only the ≤ bound; the IVT-based existence half (the original contribution) is fully disclosed in `overview` and `mathlibDependencies`. Badge `original` justified.
- **little-wedderburn**: core `embeds_iff_dvd` derives from Mathlib's `nonempty_algHom_iff_finrank_dvd`; the docstring honestly credits Mathlib and scopes the new content to `card_subfieldFix` and the concrete GF(4)⊆GF(64) / GF(4)⊄GF(8) computations. Badge `mathlib` is the correct conservative choice.
- **pythagorean**: elementary `ZMod` prime-location arguments; counts match.

### Verification method
Docker is down and no mathlib oleans are cached, so a full unpack was uneconomic for three already-merged, research-verified proofs. This audit is a claims-vs-source static integrity check (the auditor mandate), not a recompile.

Only `src/data/proofs/audit-tracker.json` is modified (3 `clean` entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)