### PR TITLE
Enrich Brahmagupta–Fibonacci Two-Squares Identity (pythagorean-triples-oq-05)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-05/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-05/annotations.json
@@ -8,39 +8,70 @@
     },
     "type": "concept",
     "title": "Module Header and Problem Setup",
-    "content": "The open question asks for the two-squares identity $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$ over a commutative ring, and the derivation that being a sum of two squares is closed under multiplication. The identity is exactly the multiplicativity of the Gaussian-integer norm $N(a+bi) = a^2+b^2$, and is the algebraic heart of the classification of integers that are sums of two squares."
+    "content": "The open question asks for the two-squares identity $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$ over a commutative ring, and the derivation that being a sum of two squares is closed under multiplication. The identity is exactly the multiplicativity of the Gaussian-integer norm $N(a+bi) = a^2+b^2$, and is the algebraic heart of the classification of integers that are sums of two squares. The development is parameterized over `variable {R : Type*} [CommRing R]`, so every result holds uniformly over $\\mathbb{Z}$, $\\mathbb{R}$, $\\mathbb{C}$, polynomial rings, and finite rings.",
+    "mathContext": "$N : \\mathbb{Z}[i] \\to \\mathbb{Z},\\ N(a+bi) = a^2+b^2 = (a+bi)(a-bi)$; the identity is the statement $N(zw) = N(z)\\,N(w)$.",
+    "significance": "context",
+    "relatedConcepts": ["Gaussian integers", "multiplicative norm", "commutative ring", "sum of two squares"],
+    "prerequisites": ["commutative rings", "complex numbers", "the ring norm concept"]
   },
   {
     "id": "pythoq05-identity",
     "proofId": "pythagorean-triples-oq-05",
     "range": {
       "startLine": 25,
-      "endLine": 40
+      "endLine": 38
     },
     "type": "theorem",
     "title": "The Brahmagupta–Fibonacci Identity",
-    "content": "`sq_add_sq_mul_sq_add_sq` states $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$, a polynomial identity over any `CommRing`, closed by `ring`. The conjugate form `sq_add_sq_mul_sq_add_sq'` gives $(ac+bd)^2 + (ad-bc)^2$, corresponding to multiplying by the conjugate $\\overline{c+di}$. The two witnesses $(ac-bd,\\ ad+bc)$ are the real and imaginary parts of $(a+bi)(c+di)$."
+    "content": "`sq_add_sq_mul_sq_add_sq` states $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$, a polynomial identity over any `CommRing`, closed in a single line by `ring`. The conjugate form `sq_add_sq_mul_sq_add_sq'` gives $(ac+bd)^2 + (ad-bc)^2$, corresponding to multiplying by the conjugate $\\overline{c+di}$ instead of $c+di$. The two witnesses $(ac-bd,\\ ad+bc)$ are precisely the real and imaginary parts of the Gaussian product $(a+bi)(c+di) = (ac-bd) + (ad+bc)i$; the conjugate witnesses come from $(a+bi)(c-di)$. That a single `ring` call discharges both reflects that the identity is purely formal — it lives in the polynomial ring $\\mathbb{Z}[a,b,c,d]$ and specializes to every commutative ring.",
+    "mathContext": "$(a+bi)(c+di) = (ac-bd) + (ad+bc)i \\implies |(a+bi)(c+di)|^2 = (ac-bd)^2 + (ad+bc)^2$; conjugate form from $(a+bi)\\overline{(c+di)}$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial identity", "complex multiplication", "the `ring` tactic", "norm multiplicativity"],
+    "prerequisites": ["the `ring` tactic", "complex multiplication", "conjugation in ℂ"]
+  },
+  {
+    "id": "pythoq05-predicate",
+    "proofId": "pythagorean-triples-oq-05",
+    "range": {
+      "startLine": 40,
+      "endLine": 41
+    },
+    "type": "definition",
+    "title": "The IsSumOfTwoSquares Predicate",
+    "content": "`IsSumOfTwoSquares x := ∃ a b : R, x = a^2 + b^2` packages the property as an existential predicate over the ring $R$. Encoding membership as a `Prop` rather than a subtype lets the closure lemmas read as ordinary implications (`hx → hy → IsSumOfTwoSquares (x*y)`) and lets the witnesses be extracted by `obtain ⟨a, b, rfl⟩`. The predicate carves out a multiplicatively closed subset of $R$ that contains $0 = 0^2+0^2$ and $1 = 1^2+0^2$ — a submonoid under multiplication, as the next lemmas establish.",
+    "mathContext": "$S = \\{x \\in R : \\exists a\\,b,\\ x = a^2+b^2\\}$; $1 \\in S$ and $x,y \\in S \\implies xy \\in S$, so $S$ is a submonoid of $(R,\\times)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["existential predicate", "multiplicative submonoid", "subtype vs Prop"],
+    "prerequisites": ["existential quantifiers in Lean", "Prop vs Type"]
   },
   {
     "id": "pythoq05-closure",
     "proofId": "pythagorean-triples-oq-05",
     "range": {
       "startLine": 42,
-      "endLine": 70
+      "endLine": 64
     },
     "type": "theorem",
-    "title": "Closure of Sums of Two Squares",
-    "content": "`IsSumOfTwoSquares x := ∃ a b, x = a²+b²`. `IsSumOfTwoSquares.mul` proves the set is closed under multiplication by supplying the explicit witness from the identity; `IsSumOfTwoSquares.sq` notes every square qualifies; `IsSumOfTwoSquares.listProd` extends closure to finite products by list induction (empty product $1 = 1^2+0^2$, cons step via binary closure). This multiplicative closure is what reduces the two-squares theorem to prime factors."
+    "title": "Closure Under Multiplication and Finite Products",
+    "content": "`IsSumOfTwoSquares.mul` proves the set is closed under multiplication: it destructures the two witnesses with `obtain ⟨a, b, rfl⟩` / `⟨c, d, rfl⟩` and supplies the explicit product witness $(ac-bd,\\ ad+bc)$ straight from the identity. `IsSumOfTwoSquares.sq` notes every square $a^2 = a^2 + 0^2$ qualifies. `IsSumOfTwoSquares.listProd` extends closure to finite products by list induction: the empty product gives $1 = 1^2 + 0^2$ (via `List.prod_nil`), and the cons step rewrites with `List.prod_cons` and applies binary closure `.mul`. This multiplicative closure is exactly what reduces the two-squares theorem to prime factors: once you know the property is preserved by products, deciding which integers are sums of two squares collapses to deciding it for primes — which is Fermat's $p = a^2+b^2 \\iff p = 2 \\text{ or } p \\equiv 1 \\pmod 4$.",
+    "mathContext": "$x = a^2+b^2,\\ y = c^2+d^2 \\implies xy = (ac-bd)^2 + (ad+bc)^2$; by induction $\\prod_{i} x_i \\in S$ whenever each $x_i \\in S$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative closure", "list induction", "two-squares theorem", "Fermat's theorem on sums of two squares", "prime factorization"],
+    "prerequisites": ["existential witnesses in Lean", "list induction", "Fermat's two-square theorem"]
   },
   {
     "id": "pythoq05-example",
     "proofId": "pythagorean-triples-oq-05",
     "range": {
-      "startLine": 72,
+      "startLine": 68,
       "endLine": 75
     },
     "type": "example",
     "title": "Concrete Witness over ℤ",
-    "content": "A worked instance over ℤ: $(1^2+2^2)(1^2+1^2) = 5 \\cdot 2 = 10 = 1^2 + 3^2$, exhibiting 10 as a sum of two squares directly through the identity with $(a,b,c,d) = (1,2,1,1)$."
+    "content": "A worked instance over $\\mathbb{Z}$: $(1^2+2^2)(1^2+1^2) = 5 \\cdot 2 = 10 = 1^2 + 3^2$, exhibiting $10$ as a sum of two squares directly through the identity with $(a,b,c,d) = (1,2,1,1)$. Computing the witnesses: $ac-bd = 1\\cdot1 - 2\\cdot1 = -1$ and $ad+bc = 1\\cdot1 + 2\\cdot1 = 3$, giving $(-1)^2 + 3^2 = 1 + 9 = 10$. The proof rewrites with the general identity and closes by `norm_num`, demonstrating that the abstract `CommRing` lemma specializes correctly to a concrete numerical fact.",
+    "mathContext": "$(1^2+2^2)(1^2+1^2) = (1\\cdot1-2\\cdot1)^2 + (1\\cdot1+2\\cdot1)^2 = (-1)^2 + 3^2 = 10$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "norm_num", "specialization to ℤ"],
+    "prerequisites": ["integer arithmetic", "the norm_num tactic"]
   }
 ]

--- a/src/data/proofs/pythagorean-triples-oq-05/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-05/meta.json
@@ -51,7 +51,9 @@
     "keyInsights": [
       "**The identity IS norm multiplicativity.** N(z)N(w) = N(zw) for the Gaussian-integer norm N(a+bi) = a²+b²; the explicit witnesses (ac−bd, ad+bc) are the real and imaginary parts of the product (a+bi)(c+di).",
       "**Closure reduces the two-squares theorem to primes.** Because sums of two squares form a multiplicatively closed set, deciding which integers are sums of two squares reduces to the prime factors — the structural reason Fermat's theorem on primes ≡ 1 mod 4 suffices.",
-      "**Ring-level generality.** Stated over an arbitrary CommRing, the identity applies uniformly to ℤ, ℝ, ℂ, polynomial rings, and finite rings — wherever a 'sum of two squares' makes sense."
+      "**Ring-level generality.** Stated over an arbitrary CommRing, the identity applies uniformly to ℤ, ℝ, ℂ, polynomial rings, and finite rings — wherever a 'sum of two squares' makes sense.",
+      "**A purely formal identity.** Both forms are dispatched by a single `ring` call because the equality holds in the polynomial ring ℤ[a,b,c,d] and then specializes to every commutative ring by the universal property of polynomial rings; there is no number-theoretic content in the identity itself — that content appears only when it is combined with Fermat's prime theorem.",
+      "**The two conjugate forms encode the two factorizations.** The witnesses (ac−bd, ad+bc) come from the product (a+bi)(c+di), while (ac+bd, ad−bc) come from (a+bi)(c−di); when a number has several representations as a sum of two squares, these distinct witness pairs are the algebraic shadow of distinct Gaussian-integer factorizations, the mechanism behind non-unique representations like 50 = 1²+7² = 5²+5²."
     ],
     "prerequisites": [
       "Commutative rings and the `ring` tactic",


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-05`. (Re-opened on a dedicated branch — the original PR #30035 was inadvertently overwritten by a second target's force-push and merged with the wrong content; this restores the pythagorean enrichment, which never landed.)

## Annotation depth
- Added `mathContext`, `significance`, `relatedConcepts`, `prerequisites` to **all** annotations (previously none had these).
- Split 4 → 5 annotations, breaking out the `IsSumOfTwoSquares` predicate; tightened line ranges to the Lean source.
- Added explicit Gaussian-product witness derivation and the reduction-to-primes argument.

## meta.json
- Added 2 `keyInsights` (3 → 5): the identity as a purely formal polynomial identity, and the two conjugate forms as distinct Gaussian factorizations / non-unique representations.

## Axiom integrity
0 axioms, 0 sorries, no structure-encoded assumptions; `status: verified` / `badge: original` accurate (5 theorems, 1 definition).

## Verification
JSON validated via `json.load`. Full `pnpm build` not completed here (`node_modules` absent; annotation build step halts on a pre-existing malformed `meta.json` in unrelated `little-wedderburn-oq-01-oq-02`).