### PR TITLE
Enrich Newton Forward-Difference Interpolation (factor-remainder-theorem-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "context",
+    "title": "Two Coordinate Systems on the Shifted Line",
+    "content": "The module docstring frames the open question: a degree-$N$ polynomial $p$ sampled along the line $a + r$ carries two natural coordinate systems. The **Taylor (monomial) coefficients** $t_j = (\\text{taylor } a\\, p).\\text{coeff } j$ are the coordinates of $p(a+r)$ in the basis $\\{r^j\\}$; the **Newton (forward-difference) coefficients** $c_m = \\Delta^m[r \\mapsto p(a+r)](0)$ are the coordinates in the binomial basis $\\{\\binom{r}{m}\\}$, equivalently the iterated finite differences of the samples $p(a), p(a+1), p(a+2), \\ldots$. The bridge is the finite-difference-of-monomials kernel $K(j,m) = \\Delta^m(r \\mapsto r^j)(0) = m! \\cdot S(j,m)$, where $S(j,m)$ is the Stirling number of the second kind. The imports pull in Mathlib's forward-difference operator, Taylor expansion, and binomial-ring machinery; everything is over $\\mathbb{Q}$, with 0 axioms.",
+    "mathContext": "Taylor: $p(a+r) = \\sum_j t_j r^j$. Newton: $p(a+r) = \\sum_m c_m \\binom{r}{m}$. Change of basis: $c_m = \\sum_j t_j K(j,m)$, $K(j,m) = m! \\, S(j,m)$.",
+    "significance": "context",
+    "relatedConcepts": ["finite differences", "Newton interpolation", "Taylor expansion", "Stirling numbers of the second kind", "binomial basis"],
+    "prerequisites": ["polynomial Taylor coefficients", "the forward difference operator", "change of basis"]
+  },
+  {
     "id": "ann-kernel",
     "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-02",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "The Kernel That Translates Taylor Coordinates into Newton Coordinates",
-    "content": "Everything hinges on one family of numbers: K(j,m) = Δᵐ(r ↦ rʲ)(0), the m-th forward difference of the j-th power, evaluated at 0. fwdDiff_pow_lt shows K(j,m) = 0 whenever j < m (Mathlib's fwdDiff_iter_pow_eq_zero_of_lt), and fwdDiff_pow_self shows K(m,m) = m! (Mathlib's fwdDiff_iter_eq_factorial). Combinatorially K(j,m) = m!·S(j,m), where S(j,m) is the Stirling number of the second kind — the number of ways to partition a j-set into m nonempty blocks. The triangularity (zero below the diagonal) is exactly what makes the m-th finite difference of a polynomial depend only on its coefficients of degree ≥ m, and the diagonal value m! is the discrete analogue of differentiating xᵐ down to the constant m!."
+    "content": "Everything hinges on one family of numbers: K(j,m) = Δᵐ(r ↦ rʲ)(0), the m-th forward difference of the j-th power, evaluated at 0. fwdDiff_pow_lt shows K(j,m) = 0 whenever j < m (Mathlib's fwdDiff_iter_pow_eq_zero_of_lt), and fwdDiff_pow_self shows K(m,m) = m! (Mathlib's fwdDiff_iter_eq_factorial). Combinatorially K(j,m) = m!·S(j,m), where S(j,m) is the Stirling number of the second kind — the number of ways to partition a j-set into m nonempty blocks. The triangularity (zero below the diagonal) is exactly what makes the m-th finite difference of a polynomial depend only on its coefficients of degree ≥ m, and the diagonal value m! is the discrete analogue of differentiating xᵐ down to the constant m!.",
+    "mathContext": "$K(j,m) = \\Delta^m(r \\mapsto r^j)(0) = m! \\, S(j,m)$; $K(j,m) = 0$ for $j < m$ and $K(m,m) = m!$.",
+    "significance": "key",
+    "relatedConcepts": ["Stirling numbers of the second kind", "triangular change of basis", "discrete derivative", "monomial basis"],
+    "prerequisites": ["iterated forward differences", "Stirling numbers", "factorials"]
   },
   {
     "id": "ann-change-of-basis",
@@ -19,17 +38,40 @@
     },
     "type": "insight",
     "title": "Taylor ↔ Newton: the Change-of-Basis Dictionary and the Leading Coefficient",
-    "content": "fwdDiff_iter_eval_eq_sum_taylor is the open question's target. The Newton coefficient c_m = Δᵐ[r ↦ p(a+r)](0) is the m-th entry of the difference table of p sampled along a + ℤ. Writing p(a+r) = (taylor a p).eval r = Σ_{j ≤ N} t_j·rʲ (via taylor_eval and eval_eq_sum_range) and pushing the LINEAR operator Δᵐ through the sum yields c_m = Σ_{j ≤ N} t_j·K(j,m): the Newton coordinates are the kernel-image of the Taylor coordinates. On the diagonal m = N the triangular kernel kills every term but j = N, so fwdDiff_iter_natDegree_eval gives c_N = t_N·N!, and leadingCoeff_taylor rewrites the top Taylor coefficient as leadingCoeff p — the divided-difference reading of the leading coefficient, c_N = leadingCoeff p · N!. This is the discrete counterpart of '(d/dx)ᴺ of a degree-N polynomial is N!·(leading coefficient)'."
+    "content": "fwdDiff_iter_eval_eq_sum_taylor is the open question's target. The Newton coefficient c_m = Δᵐ[r ↦ p(a+r)](0) is the m-th entry of the difference table of p sampled along a + ℤ. Writing p(a+r) = (taylor a p).eval r = Σ_{j ≤ N} t_j·rʲ (via taylor_eval and eval_eq_sum_range) and pushing the LINEAR operator Δᵐ through the sum yields c_m = Σ_{j ≤ N} t_j·K(j,m): the Newton coordinates are the kernel-image of the Taylor coordinates. On the diagonal m = N the triangular kernel kills every term but j = N, so fwdDiff_iter_natDegree_eval gives c_N = t_N·N!, and leadingCoeff_taylor rewrites the top Taylor coefficient as leadingCoeff p — the divided-difference reading of the leading coefficient, c_N = leadingCoeff p · N!. This is the discrete counterpart of '(d/dx)ᴺ of a degree-N polynomial is N!·(leading coefficient)'.",
+    "mathContext": "$c_m = \\sum_{j \\le N} t_j K(j,m)$; diagonal: $c_N = t_N \\cdot N! = \\text{leadingCoeff}(p) \\cdot N!$.",
+    "significance": "key",
+    "relatedConcepts": ["linearity of the difference operator", "leading coefficient", "divided differences", "change of basis"],
+    "prerequisites": ["linearity of Δ", "Taylor evaluation taylor_eval", "leadingCoeff_taylor"]
   },
   {
-    "id": "ann-interpolation",
+    "id": "ann-interpolation-integer",
     "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-02",
     "range": {
       "startLine": 119,
+      "endLine": 162
+    },
+    "type": "insight",
+    "title": "Newton Interpolation at Integer Nodes",
+    "content": "The forward-difference coefficients c_0,…,c_N reconstruct p at every integer node. fwdDiff_iter_eval_eq_zero first shows the table terminates: c_m = 0 for m > deg p, since r ↦ p(a+r) is itself a polynomial of degree deg p. The key operator identity is shift = 1 + Δ, hence shiftⁿ = (1+Δ)ⁿ = Σ C(n,m) Δᵐ (Mathlib's shift_eq_sum_fwdDiff_iter): evaluating at integer nodes gives p(a+n) = Σ_{m ≤ n} c_m·(n choose m) with no analysis, purely from commuting operators. eval_add_natCast_eq_sum_fwdDiff_choose normalizes the index set to range (N+1) — terms with m > n vanish because (n choose m) = 0, and terms with m > N vanish because the difference table terminates at the degree.",
+    "mathContext": "$\\text{shift} = 1 + \\Delta \\implies \\text{shift}^n = \\sum_m \\binom{n}{m}\\Delta^m$; so $p(a+n) = \\sum_{m \\le N} c_m \\binom{n}{m}$ for $n \\in \\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["shift operator", "operator binomial theorem", "Newton interpolation", "vanishing binomial coefficients"],
+    "prerequisites": ["the shift operator", "shift_eq_sum_fwdDiff_iter", "finite-sum index manipulation"]
+  },
+  {
+    "id": "ann-interpolation-poly",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 164,
       "endLine": 205
     },
     "type": "insight",
-    "title": "Reconstructing the Polynomial from Its Difference Table",
-    "content": "The forward-difference coefficients c_0,…,c_N are not just data — they rebuild p. The key is the operator identity shift = 1 + Δ, hence shiftⁿ = (1+Δ)ⁿ = Σ C(n,m) Δᵐ (Mathlib's shift_eq_sum_fwdDiff_iter): evaluating at integer nodes gives p(a+n) = Σ_{m ≤ n} c_m·(n choose m) with no analysis, purely from commuting operators. eval_add_natCast_eq_sum_fwdDiff_choose normalizes the index set to range (N+1) — terms with m > n vanish because (n choose m) = 0, and terms with m > N vanish because the difference table terminates at the degree (fwdDiff_iter_eval_eq_zero). Finally, realizing the Newton basis as the genuine polynomial (m!)⁻¹·descPochhammer ℚ m, whose evaluation is the generalized binomial coefficient Ring.choose x m (newtonPoly_eval), the reconstruction polynomial agrees with taylor a p at every natural argument — and a polynomial over the infinite field ℚ is determined by its values on ℕ. So eval_add_eq_sum_fwdDiff_choose promotes the integer-node formula to the polynomial identity p(a+x) = Σ_{m ≤ N} c_m·Ring.choose x m valid for every x : ℚ."
+    "title": "From Integer Nodes to a Polynomial Identity over ℚ",
+    "content": "The integer-node reconstruction is promoted to an identity valid at every x ∈ ℚ. The Newton basis is realized as a genuine polynomial: newtonPoly_eval shows (m!)⁻¹·descPochhammer ℚ m evaluates to the generalized binomial coefficient Ring.choose x m. The reconstruction polynomial Q = Σ_m C(c_m)·(m!)⁻¹·descPochhammer ℚ m then agrees with taylor a p at every natural argument (by the integer-node theorem), and since a polynomial over the infinite field ℚ is determined by its values on ℕ (Polynomial.eq_of_infinite_eval_eq), the two polynomials are equal. Evaluating that equality at x yields eval_add_eq_sum_fwdDiff_choose: p(a+x) = Σ_{m ≤ N} c_m·Ring.choose x m for all x : ℚ — the full Newton interpolation identity.",
+    "mathContext": "$\\binom{x}{m} = \\text{Ring.choose}\\ x\\ m = (m!)^{-1}\\,\\text{descPochhammer}_{\\mathbb{Q}}(m)(x)$; agreement on $\\mathbb{N} \\subset \\mathbb{Q}$ forces $p(a+x) = \\sum_{m \\le N} c_m \\binom{x}{m}$ for all $x$.",
+    "significance": "key",
+    "relatedConcepts": ["generalized binomial coefficient", "descending Pochhammer", "polynomial identity from infinite agreement", "density of ℕ in ℚ"],
+    "prerequisites": ["Ring.choose and binomial rings", "descPochhammer", "eq_of_infinite_eval_eq"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01-oq-01-oq-02`.

## annotations.json
- Added a **header annotation** (lines 1-56) — previously the docstring framing the two coordinate systems was uncovered.
- Split the large interpolation annotation into **integer-nodes** vs **polynomial-identity-over-ℚ** (3 → 5 annotations).
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to **all** annotations (none had these before).

## meta.json
No changes needed — already exemplary (5 keyInsights, 3 sections with mathContext, full conclusion with open questions, mathlibDependencies, references).

## Axiom integrity
Verified: 0 axioms, 0 sorries, no native_decide, no structure-encoded assumptions; `#print axioms` reports only propext/Classical.choice/Quot.sound. `status: verified` / `badge: original` accurate (9 theorems over ℚ).

## Verification
JSON validated via `json.load`. Full `pnpm build` not completed here (`node_modules` absent; annotation build step halts on a pre-existing malformed `meta.json` in unrelated `little-wedderburn-oq-01-oq-02`).