### PR TITLE
research(godel-incompleteness-oq-02): Gödel's First Incompleteness via Turing undecidability [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3137,6 +3137,7 @@ import Proofs.GodelFirstIncompletenessOQ01OQ01
 import Proofs.GodelFirstIncompletenessOQ01OQ03
 import Proofs.GodelFirstIncompletenessOQ01OQ04
 import Proofs.GodelIncompleteness
+import Proofs.GodelIncompletenessOQ02
 import Proofs.GodelSecondIncompletenessOQ02
 import Proofs.GodelSecondIncompletenessOQ02Companion
 import Proofs.GodelSecondIncompletenessOQ02GLSyntax

--- a/proofs/Proofs/GodelIncompletenessOQ02.lean
+++ b/proofs/Proofs/GodelIncompletenessOQ02.lean
@@ -1,0 +1,198 @@
+/-
+  Gödel Incompleteness vs Turing Undecidability  (godel-incompleteness-oq-02)
+
+  ## The Open Question
+
+  Gödel's First Incompleteness Theorem and Turing's undecidability of the halting
+  problem are two faces of the same diagonal argument.  The parent gallery proof
+  `GodelIncompleteness` builds the incompleteness phenomenon syntactically (a
+  self-referential sentence via the diagonal lemma).  This file makes the *Turing
+  route* to incompleteness precise and fully constructive:
+
+    undecidability of a diagonal predicate  ⟹  incompleteness of any sound,
+    effectively axiomatized theory that represents it.
+
+  The deep historical point — already implicit in Turing 1936 and made explicit by
+  the recursion-theoretic proofs of incompleteness — is that one does *not* need to
+  build a Gödel sentence by hand.  Diagonalization against the *provability
+  predicate itself* produces an explicit independent sentence, and the witness is
+  the code of the theory's own provability decider.
+
+  ## What This File Proves (all 0 axioms, 0 sorries, self-contained)
+
+  ### Part I — the Turing/Cantor diagonal
+  `run e n` models "the decision procedure with code `e`, run on input `n`",
+  returning a `Bool`.  The diagonal predicate `D n := (run n n = false)` ("procedure
+  `n` rejects its own code") is the abstract halting-style predicate.
+  * `D_undecidable` : **no code decides `D`.**  This is the Turing/Cantor diagonal
+    in its purest form, uniform over every choice of `run`.
+
+  ### Part II — undecidability forces incompleteness
+  A `SoundEffectiveTheory` for `D` packages: a provability predicate `Provable`, a
+  refutation predicate `Refutable`, soundness of both, and the *effectiveness*
+  hypothesis that `Provable` is computed by some code (it is decided by a `run`-code).
+  * `godel_via_turing` : every such theory has an **explicit independent sentence**,
+    and the witness `n` is the code `e` of the theory's own provability decider —
+    the recursion-theoretic Gödel sentence "the prover rejects its own code".
+  * `incompleteness` : restating the same fact as `¬ Complete`.
+  * `sound_imp_consistent` : soundness already yields consistency for free.
+
+  ### Part III — concrete instance
+  `no_decider_for_const_true` exhibits a concrete `run` for which `D` is the empty
+  predicate yet still undecidable in the `run`-family, illustrating that the
+  obstruction is structural, not about the predicate being "hard".
+
+  ## Relationship to the parent
+
+  The parent's `Provable` is a placeholder; here `Provable` is an arbitrary predicate
+  constrained only by soundness + effectiveness, so the incompleteness conclusion is
+  a theorem about *all* such theories rather than one fixed encoding.  The bridge to
+  Gödel's syntactic sentence is that `D e` plays exactly the role of `G`: a sentence
+  true (in the standard interpretation given by `D`) but unprovable.
+-/
+
+import Mathlib.Tactic
+
+namespace GodelTuring
+
+/-! ## Part I: The Turing/Cantor diagonal — an undecidable predicate
+
+`run e n` is the abstract "machine `e` on input `n`" returning a `Bool` verdict.
+Totality is harmless: the diagonal obstruction below holds for *every* such `run`,
+which is exactly why it is the common core of Turing undecidability and Gödel
+incompleteness. -/
+
+variable (run : ℕ → ℕ → Bool)
+
+/-- The diagonal predicate: `D n` holds iff procedure `n` *rejects* its own code.
+    This is the abstract halting-style predicate that no member of the family can
+    decide. -/
+def D (n : ℕ) : Prop := run n n = false
+
+/-- A predicate `P` is *decided by code* `e` when `run e` is its characteristic
+    function: `run e n = true ↔ P n` for all `n`.  This is the abstract notion of
+    "`P` is computable within the family `run`". -/
+def DecidedBy (P : ℕ → Prop) (e : ℕ) : Prop := ∀ n, (run e n = true ↔ P n)
+
+/-- **Turing's diagonal (halting-style undecidability).**
+    No code decides the diagonal predicate `D`.  If `run e` were `D`'s characteristic
+    function, evaluating at `n = e` would force `run e e = true ↔ run e e = false`. -/
+theorem D_undecidable : ¬ ∃ e, DecidedBy run (D run) e := by
+  rintro ⟨e, he⟩
+  -- `he e : run e e = true ↔ D run e`, and `D run e` is `run e e = false`.
+  have key : run e e = true ↔ run e e = false := he e
+  cases h : run e e with
+  | false => rw [h] at key; simp at key
+  | true => rw [h] at key; simp at key
+
+/-! ## Part II: Undecidability forces incompleteness
+
+A theory that is *sound* about `D` and whose provability predicate is *effective*
+(computed by some code in the family) cannot be complete: diagonalizing against the
+provability decider yields an explicit independent sentence. -/
+
+/-- A sound, effectively axiomatized theory of the `D`-sentences.
+
+* `Provable n`   — the theory proves the sentence asserting `D n`.
+* `Refutable n`  — the theory proves its negation `¬ D n`.
+* `sound_pos`    — provability is truthful: proving `D n` makes `D n` true.
+* `sound_neg`    — refutation is truthful: refuting `D n` makes `D n` false.
+* `decidable_provable` — *effectiveness*: provability is decided by some code `e`.
+  This is the recursion-theoretic stand-in for "the axioms are recursively
+  enumerable / the theory is effectively axiomatized". -/
+structure SoundEffectiveTheory where
+  /-- The theory proves the sentence asserting `D n`. -/
+  Provable : ℕ → Prop
+  /-- The theory proves the negation of the sentence asserting `D n`. -/
+  Refutable : ℕ → Prop
+  /-- Soundness on the positive side: a proof of `D n` makes `D n` true. -/
+  sound_pos : ∀ n, Provable n → D run n
+  /-- Soundness on the negative side: a refutation of `D n` makes `D n` false. -/
+  sound_neg : ∀ n, Refutable n → ¬ D run n
+  /-- Effectiveness: the provability predicate is decided by some code. -/
+  decidable_provable : ∃ e, DecidedBy run Provable e
+
+variable {run}
+
+/-- Soundness alone yields **consistency**: no sentence is both provable and
+    refutable, since that would make `D n` simultaneously true and false. -/
+theorem sound_imp_consistent (T : SoundEffectiveTheory run) (n : ℕ) :
+    ¬ (T.Provable n ∧ T.Refutable n) := by
+  rintro ⟨hp, hr⟩
+  exact T.sound_neg n hr (T.sound_pos n hp)
+
+/-- **Gödel's First Incompleteness Theorem, via Turing.**
+    Every sound, effectively axiomatized theory of the `D`-sentences has an explicit
+    independent sentence, neither provable nor refutable.  The witness is `e`, the
+    *code of the theory's own provability decider*: the sentence `D e` says "the
+    prover rejects its own code", the recursion-theoretic Gödel sentence. -/
+theorem godel_via_turing (T : SoundEffectiveTheory run) :
+    ∃ n, ¬ T.Provable n ∧ ¬ T.Refutable n := by
+  obtain ⟨e, he⟩ := T.decidable_provable
+  refine ⟨e, ?_, ?_⟩
+  · -- If `D e` were provable, soundness gives `run e e = false`, but the decider
+    -- characterization gives `run e e = true`.
+    intro hp
+    have h1 : run e e = true := (he e).mpr hp
+    have h2 : run e e = false := T.sound_pos e hp
+    rw [h1] at h2
+    exact Bool.noConfusion h2
+  · -- If `D e` were refutable, soundness gives `run e e = true`; the decider then
+    -- makes `D e` provable, and soundness again makes `D e` true — contradiction.
+    intro hr
+    have h2 : ¬ D run e := T.sound_neg e hr
+    have h1 : run e e = true := by
+      cases h : run e e with
+      | false => exact absurd h h2
+      | true => rfl
+    have hp : T.Provable e := (he e).mp h1
+    exact h2 (T.sound_pos e hp)
+
+/-- The independent sentence is `D e`, with `e` the code of the provability decider.
+    This isolates the explicit Gödel sentence produced by the Turing route. -/
+theorem godel_sentence_independent (T : SoundEffectiveTheory run)
+    (e : ℕ) (he : DecidedBy run T.Provable e) :
+    ¬ T.Provable e ∧ ¬ T.Refutable e := by
+  constructor
+  · intro hp
+    have h1 : run e e = true := (he e).mpr hp
+    have h2 : run e e = false := T.sound_pos e hp
+    rw [h1] at h2; exact Bool.noConfusion h2
+  · intro hr
+    have h2 : ¬ D run e := T.sound_neg e hr
+    have h1 : run e e = true := by
+      cases h : run e e with
+      | false => exact absurd h h2
+      | true => rfl
+    exact h2 (T.sound_pos e ((he e).mp h1))
+
+/-- Completeness of a theory: every `D`-sentence is provable or refutable. -/
+def Complete (T : SoundEffectiveTheory run) : Prop :=
+  ∀ n, T.Provable n ∨ T.Refutable n
+
+/-- **Incompleteness, stated negatively.**  A sound, effectively axiomatized theory
+    of the `D`-sentences is never complete. -/
+theorem incompleteness (T : SoundEffectiveTheory run) : ¬ Complete T := by
+  intro hC
+  obtain ⟨n, hnp, hnr⟩ := godel_via_turing T
+  rcases hC n with h | h
+  · exact hnp h
+  · exact hnr h
+
+/-! ## Part III: A concrete instance
+
+The obstruction is structural, not a matter of the predicate being "hard": even the
+*empty* predicate is undecidable inside a family that never answers `false`. -/
+
+/-- For the constant-`true` family, `D` is the empty predicate (`run n n = false` is
+    never true), yet no code decides it: a decider would need `run e n = true ↔ False`
+    while `run e n` is always `true`. -/
+theorem no_decider_for_const_true :
+    ¬ ∃ e, DecidedBy (fun _ _ => true) (D (fun _ _ => true)) e := by
+  exact D_undecidable (fun _ _ => true)
+
+/-- In the constant-`true` family `D` is identically `False`. -/
+theorem const_true_D_false (n : ℕ) : ¬ D (fun _ _ => true) n := by
+  simp [D]
+
+end GodelTuring

--- a/src/data/proofs/godel-incompleteness-oq-02/annotations.json
+++ b/src/data/proofs/godel-incompleteness-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-diagonal-predicate",
+    "proofId": "godel-incompleteness-oq-02",
+    "range": { "startLine": 62, "endLine": 66 },
+    "type": "definition",
+    "title": "The diagonal predicate D",
+    "content": "D n := (run n n = false) says 'procedure n rejects its own code'. This is the abstract halting-style predicate at the heart of both Turing undecidability and Gödel incompleteness. Modelling run as a total ℕ → ℕ → Bool is harmless: the diagonal obstruction holds for every run, which is exactly why the same argument powers both theorems."
+  },
+  {
+    "id": "ann-decided-by",
+    "proofId": "godel-incompleteness-oq-02",
+    "range": { "startLine": 68, "endLine": 72 },
+    "type": "definition",
+    "title": "Decidability within the family",
+    "content": "DecidedBy P e := ∀ n, (run e n = true ↔ P n) is the abstract notion 'P is computable by code e'. A theory is 'effectively axiomatized' precisely when its provability predicate is DecidedBy some code."
+  },
+  {
+    "id": "ann-d-undecidable",
+    "proofId": "godel-incompleteness-oq-02",
+    "range": { "startLine": 74, "endLine": 88 },
+    "type": "theorem",
+    "title": "Turing's diagonal: D is undecidable",
+    "content": "If run e were the characteristic function of D, then evaluating at n = e forces run e e = true ↔ run e e = false — a Bool with no fixed point. The only foundational dependency is propext. This is the purest form of the halting-problem diagonal."
+  },
+  {
+    "id": "ann-sound-effective-theory",
+    "proofId": "godel-incompleteness-oq-02",
+    "range": { "startLine": 98, "endLine": 117 },
+    "type": "definition",
+    "title": "Sound, effectively axiomatized theory",
+    "content": "SoundEffectiveTheory bundles Provable, Refutable, two soundness fields, and decidable_provable (provability decided by some code). It is the recursion-theoretic stand-in for 'a sound theory whose theorems are recursively enumerable'."
+  },
+  {
+    "id": "ann-godel-via-turing",
+    "proofId": "godel-incompleteness-oq-02",
+    "range": { "startLine": 124, "endLine": 151 },
+    "type": "theorem",
+    "title": "Gödel's First Incompleteness via Turing",
+    "content": "Every sound, effectively axiomatized theory of the D-sentences has an EXPLICIT independent sentence. The witness is e, the code of the theory's own provability decider: the sentence D e ('the prover rejects its own code') is true precisely when unprovable. No Gödel sentence is built by hand — it falls out of diagonalizing against the provability predicate."
+  },
+  {
+    "id": "ann-incompleteness",
+    "proofId": "godel-incompleteness-oq-02",
+    "range": { "startLine": 171, "endLine": 182 },
+    "type": "theorem",
+    "title": "Incompleteness, stated as ¬ Complete",
+    "content": "Restates godel_via_turing: a sound, effectively axiomatized theory of the D-sentences is never complete. Unlike the parent's first_incompleteness (one fixed encoding), this quantifies over ALL such theories."
+  }
+]

--- a/src/data/proofs/godel-incompleteness-oq-02/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-02/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "godel-incompleteness-oq-02",
+  "title": "Gödel Incompleteness via Turing Undecidability",
+  "slug": "godel-incompleteness-oq-02",
+  "description": "A fully constructive, 0-axiom formalization of the Turing route to Gödel's First Incompleteness Theorem: undecidability of a diagonal (halting-style) predicate forces incompleteness of any sound, effectively axiomatized theory that represents it. The independent sentence is produced explicitly by diagonalizing against the theory's own provability decider — the recursion-theoretic Gödel sentence 'the prover rejects its own code'. 7 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Kurt Gödel (1931), Alan Turing (1936); recursion-theoretic synthesis formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/G%C3%B6del%27s_incompleteness_theorems#Proof_via_Berry's_paradox",
+    "date": "1936",
+    "status": "verified",
+    "tags": [
+      "logic",
+      "foundations",
+      "computability",
+      "incompleteness",
+      "undecidability",
+      "self-reference",
+      "diagonalization",
+      "advanced"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Mathlib.Tactic",
+        "description": "General tactic library (simp, cases, omega) and core Bool/logic lemmas",
+        "module": "Mathlib.Tactic"
+      }
+    ],
+    "originalContributions": [
+      "D_undecidable: the Turing/Cantor diagonal in its purest form — no code in the family ℕ → ℕ → Bool decides the self-rejection predicate D n := (run n n = false), uniform over every choice of run",
+      "SoundEffectiveTheory: an abstract structure capturing a sound, effectively axiomatized theory of the diagonal sentences (soundness on both sides + provability decided by a code)",
+      "godel_via_turing: the headline — every such theory has an EXPLICIT independent sentence, with the witness being the code of the theory's own provability decider (the recursion-theoretic Gödel sentence)",
+      "godel_sentence_independent: isolates D e (e = code of the provability decider) as the concrete Gödel sentence delivered by the Turing route",
+      "incompleteness: the same fact restated as ¬ Complete, paralleling the parent's first_incompleteness but as a theorem about ALL sound effective theories rather than one fixed encoding",
+      "sound_imp_consistent: soundness alone already yields consistency (no sentence both provable and refutable)",
+      "no_decider_for_const_true: a concrete instance showing the obstruction is structural, not about the predicate being 'hard'"
+    ],
+    "dateAdded": "2026-06-25",
+    "axioms": []
+  },
+  "overview": {
+    "historicalContext": "In 1931 Gödel proved that any consistent, effectively axiomatized theory strong enough for arithmetic is incomplete, building a self-referential sentence by hand via the diagonal lemma. In 1936 Turing proved the halting problem undecidable. The two results are the same diagonal argument viewed from two angles: Turing's undecidability immediately yields incompleteness, because a complete sound theory whose theorems are recursively enumerable would decide the undecidable. This file formalizes that bridge directly and constructively.",
+    "keyInsight": "One never needs to construct a Gödel sentence by hand. Diagonalizing against the provability predicate ITSELF produces an explicit independent sentence, and the witness is simply the code e of the theory's own provability decider: the sentence D e says 'the prover rejects its own code', which is true precisely when it is unprovable.",
+    "significance": "Connects the parent gallery proof's syntactic incompleteness (a fixed encoding with placeholder provability) to the recursion-theoretic viewpoint, proving incompleteness as a theorem quantified over ALL sound, effectively axiomatized theories of the diagonal sentences."
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: Two faces of one diagonal argument",
+      "summary": "Module docstring: states the Turing route to incompleteness and how it relates to the parent's syntactic construction.",
+      "startLine": 1,
+      "endLine": 48
+    },
+    {
+      "id": "part-i",
+      "title": "Part I: The Turing/Cantor diagonal — an undecidable predicate",
+      "summary": "Defines run e n (machine e on input n), the diagonal predicate D, the abstract notion DecidedBy, and proves D_undecidable: no code decides D.",
+      "startLine": 50,
+      "endLine": 96
+    },
+    {
+      "id": "part-ii",
+      "title": "Part II: Undecidability forces incompleteness",
+      "summary": "SoundEffectiveTheory structure; sound_imp_consistent; godel_via_turing (explicit independent sentence at the code of the provability decider); godel_sentence_independent; Complete; incompleteness.",
+      "startLine": 98,
+      "endLine": 182
+    },
+    {
+      "id": "part-iii",
+      "title": "Part III: A concrete instance",
+      "summary": "no_decider_for_const_true and const_true_D_false: even the empty predicate is undecidable inside a family that never answers false, showing the obstruction is structural.",
+      "startLine": 184,
+      "endLine": 198
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "GodelTuring.D_undecidable",
+      "type": "core",
+      "description": "No code decides the diagonal (halting-style) predicate D n := (run n n = false). This is the Turing/Cantor diagonal, uniform over every run.",
+      "leanStatement": "theorem D_undecidable : ¬ ∃ e, DecidedBy run (D run) e"
+    },
+    {
+      "name": "GodelTuring.godel_via_turing",
+      "type": "core",
+      "description": "Every sound, effectively axiomatized theory of the D-sentences has an explicit independent sentence; the witness is the code e of the theory's own provability decider.",
+      "leanStatement": "theorem godel_via_turing (T : SoundEffectiveTheory run) : ∃ n, ¬ T.Provable n ∧ ¬ T.Refutable n"
+    },
+    {
+      "name": "GodelTuring.incompleteness",
+      "type": "core",
+      "description": "A sound, effectively axiomatized theory of the D-sentences is never complete.",
+      "leanStatement": "theorem incompleteness (T : SoundEffectiveTheory run) : ¬ Complete T"
+    },
+    {
+      "name": "GodelTuring.godel_sentence_independent",
+      "type": "supporting",
+      "description": "The independent sentence is D e with e the code of the provability decider — the explicit recursion-theoretic Gödel sentence.",
+      "leanStatement": "theorem godel_sentence_independent (T : SoundEffectiveTheory run) (e : ℕ) (he : DecidedBy run T.Provable e) : ¬ T.Provable e ∧ ¬ T.Refutable e"
+    },
+    {
+      "name": "GodelTuring.sound_imp_consistent",
+      "type": "supporting",
+      "description": "Soundness alone yields consistency: no sentence is both provable and refutable.",
+      "leanStatement": "theorem sound_imp_consistent (T : SoundEffectiveTheory run) (n : ℕ) : ¬ (T.Provable n ∧ T.Refutable n)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "parent",
+      "description": "The parent builds incompleteness syntactically via the diagonal lemma with a placeholder provability predicate; this file derives incompleteness from Turing-style undecidability for all sound effective theories."
+    },
+    {
+      "targetId": "godel-first-incompleteness-oq01",
+      "relationship": "related",
+      "description": "Both exhibit an explicit undecidable sentence; here it is the diagonalization of the provability decider rather than a fixed Gödel code."
+    }
+  ],
+  "conclusion": {
+    "summary": "Incompleteness need not be built by hand: it is a corollary of Turing's diagonal. Any sound, effectively axiomatized theory that represents the self-rejection predicate D fails to decide the sentence D e, where e is the code of its own provability decider. The whole development is constructive and 0-axiom (the only foundational dependency is propext, in D_undecidable).",
+    "futureDirections": "Replace the total-Bool family run by Mathlib's partial-recursive functions (Nat.Partrec) to recover the genuine halting problem, and connect SoundEffectiveTheory to a concrete arithmetised provability predicate to close the loop with the parent's syntactic Gödel sentence."
+  },
+  "sorries": [],
+  "leanFile": {
+    "path": "Proofs/GodelIncompletenessOQ02.lean",
+    "lineCount": 198,
+    "theoremCount": 7,
+    "definitionCount": 4,
+    "axiomCount": 0,
+    "sorries": 0,
+    "imports": ["Mathlib.Tactic"],
+    "namespace": "GodelTuring",
+    "additionalFiles": []
+  }
+}


### PR DESCRIPTION
## Summary

A fully constructive, **0-axiom** formalization of the **Turing route to Gödel's First Incompleteness Theorem** for the fresh research problem `godel-incompleteness-oq-02` ("Gödel Incompleteness vs Turing Undecidability", Tier A, significance 8).

Gödel (1931) and Turing (1936) are two faces of one diagonal argument: undecidability of the halting problem immediately yields incompleteness, since a *complete* sound theory whose theorems are recursively enumerable would decide the undecidable. This file formalizes that bridge directly — and constructively produces the independent sentence.

## What's proved (`Proofs/GodelIncompletenessOQ02.lean`, namespace `GodelTuring`)

**Part I — the Turing/Cantor diagonal**
- `D_undecidable` : no code in the family `run : ℕ → ℕ → Bool` decides the self-rejection predicate `D n := (run n n = false)`. Evaluating a putative decider at its own code forces `run e e = true ↔ run e e = false`.

**Part II — undecidability forces incompleteness**
- `SoundEffectiveTheory` : an abstract sound, effectively axiomatized theory of the diagonal sentences (soundness on both sides + provability decided by a code — the recursion-theoretic stand-in for "recursively enumerable theorems").
- `godel_via_turing` : **every such theory has an explicit independent sentence**, and the witness is `e`, the *code of the theory's own provability decider*. The sentence `D e` ("the prover rejects its own code") is the recursion-theoretic Gödel sentence — no sentence is built by hand.
- `godel_sentence_independent`, `incompleteness` (`¬ Complete`), `sound_imp_consistent`.

**Part III — concrete instance**
- `no_decider_for_const_true`, `const_true_D_false`: the obstruction is structural, not about the predicate being "hard".

## Relationship to the parent

The parent `godel-incompleteness` builds incompleteness syntactically with a *placeholder* provability predicate. Here incompleteness is a theorem quantified over **all** sound, effectively axiomatized theories of the diagonal sentences, with the Gödel sentence emerging from diagonalizing the provability decider.

## Verification

- **7 theorems, 4 definitions, 0 axioms, 0 sorries.**
- Docker daemon was down, so verified with `lake env lean Proofs/GodelIncompletenessOQ02.lean` (clean) against the unpacked Mathlib cache.
- `#print axioms`: `godel_via_turing`, `incompleteness`, `godel_sentence_independent`, `sound_imp_consistent` depend on **no axioms**; `D_undecidable` depends only on `propext` (a standard foundational axiom that does not count under the project axiom policy). No `sorryAx`, no `Lean.ofReduceBool`.

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)