### PR TITLE
Enrich Sylow OQ-03: Schur–Zassenhaus splitting (annotation depth + coverage)

### DIFF
--- a/src/data/proofs/sylow-theorem-oq-03/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-03/annotations.json
@@ -1,46 +1,77 @@
 [
   {
-    "id": "ann-splitting",
+    "id": "ann-header",
     "proofId": "sylow-theorem-oq-03",
     "range": {
-      "startLine": 65,
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "context",
+    "title": "Schur–Zassenhaus as a Sylow Extension",
+    "content": "The docstring states the parent's open question: can Schur–Zassenhaus (if $\\gcd(|H|, [G:H]) = 1$ then $H$ is complemented in $G$) be formalized as an extension of Sylow theory? This file answers it. Mathlib supplies the existence half (`Subgroup.exists_right_complement'_of_coprime`); the contribution is to package it in gallery form and derive the Sylow corollary: a **normal** Sylow $p$-subgroup is always complemented, with complement a Hall $p'$-subgroup. This is the bridge between Sylow theory and the theory of group extensions — whenever a Sylow subgroup is normal, the group splits as an internal semidirect product $G = P \\rtimes K$.",
+    "mathContext": "$\\gcd(|N|, [G:N]) = 1 \\implies G = N \\rtimes K$; for a Sylow $p$-subgroup the coprimality is automatic (Hall property).",
+    "significance": "context",
+    "relatedConcepts": ["Schur–Zassenhaus theorem", "Sylow theory", "group extensions", "semidirect product", "Hall subgroups"],
+    "prerequisites": ["normal subgroups", "Sylow p-subgroups", "subgroup index"]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "sylow-theorem-oq-03",
+    "range": {
+      "startLine": 44,
+      "endLine": 60
+    },
+    "type": "theorem",
+    "title": "Existence of a Complement and Its Order",
+    "content": "`schurZassenhaus` restates Mathlib's existence theorem in gallery form: a normal subgroup $N$ with $\\gcd(|N|, [G:N]) = 1$ has a complement $K$, meaning the multiplication map $N \\times K \\to G$ is a bijection (`IsComplement' N K`). `isComplement'_card_eq_index` then pins down the complement's order: from $|N|\\cdot|K| = |G|$ (the complement identity) and $|N|\\cdot[G:N] = |G|$ (Lagrange), cancelling the positive factor $|N|$ via `Nat.eq_of_mul_eq_mul_left` gives $|K| = [G:N]$. The order fact uses no structure of $N$ or $K$ beyond finiteness — it is pure arithmetic.",
+    "mathContext": "$|N| \\cdot |K| = |G| = |N| \\cdot [G:N] \\implies |K| = [G:N]$.",
+    "significance": "key",
+    "relatedConcepts": ["IsComplement'", "Lagrange's theorem", "subgroup index", "cancellation"],
+    "prerequisites": ["complements of subgroups", "Lagrange's theorem", "Nat cancellation"]
+  },
+  {
+    "id": "ann-structure",
+    "proofId": "sylow-theorem-oq-03",
+    "range": {
+      "startLine": 62,
       "endLine": 79
     },
     "type": "insight",
-    "title": "Coprime Order Forces a Splitting",
-    "content": "schurZassenhaus_structure packages the full content of Schur–Zassenhaus for a normal subgroup N with gcd(|N|, [G:N]) = 1: there is a complement K with N ⊓ K = ⊥ and N ⊔ K = ⊤ — exactly an internal semidirect product G = N ⋊ K — and |K| = [G:N]. The order fact is pure Lagrange: from the complement identity |N|·|K| = |G| and |N|·[G:N] = |G|, cancelling |N| (positive since G is finite) gives |K| = [G:N]. No structure of N or K is used beyond finiteness; the splitting is a consequence of arithmetic coprimality alone."
+    "title": "Coprime Order Forces an Internal Semidirect Product",
+    "content": "`schurZassenhaus_structure` packages the full content for a normal subgroup $N$ with $\\gcd(|N|, [G:N]) = 1$: a complement $K$ with $N \\sqcap K = \\bot$ and $N \\sqcup K = \\top$ — exactly an internal semidirect product $G = N \\rtimes K$ — and $|K| = [G:N]$. `complement_of_coprime_orders` phrases it in the form most used in classification: if $|G| = m\\cdot n$ with $\\gcd(m,n) = 1$ and a normal subgroup of order $m$, then a complementary subgroup of order $n$ exists. In small-order classification (orders $pq$, $p^2q$, …) Sylow counting often forces a Sylow subgroup to be normal; this lemma then immediately supplies the complementary factor and reduces $G$ to a semidirect product $N \\rtimes K$.",
+    "mathContext": "$N \\sqcap K = \\bot,\\ N \\sqcup K = \\top,\\ |K| = [G:N]$; equivalently $G = N \\rtimes K$.",
+    "significance": "key",
+    "relatedConcepts": ["internal semidirect product", "disjoint subgroups", "group classification", "groups of order pq"],
+    "prerequisites": ["semidirect products", "lattice of subgroups (⊓, ⊔)", "coprime factorization of |G|"]
   },
   {
     "id": "ann-sylow-extension",
     "proofId": "sylow-theorem-oq-03",
     "range": {
-      "startLine": 87,
+      "startLine": 81,
       "endLine": 95
     },
     "type": "insight",
     "title": "Why Normal Sylow Subgroups Always Split: the Hall Property",
-    "content": "normalSylow_isComplemented is the Sylow extension the parent asked for, and its proof is a one-liner: schurZassenhaus P.card_coprime_index. The point is that the coprimality hypothesis of Schur–Zassenhaus is FREE for Sylow subgroups. A Sylow p-subgroup P has order a power of p, while its index [G:P] is coprime to p (Mathlib's Sylow.card_coprime_index — Sylow subgroups are Hall subgroups). So gcd(|P|, [G:P]) = 1 automatically, and the only extra hypothesis needed is normality of P. Whenever a Sylow subgroup is normal, the group splits as P ⋊ K."
+    "content": "`normalSylow_isComplemented` is the Sylow extension the parent asked for, and its proof is a one-liner: `schurZassenhaus P.card_coprime_index`. The key is that the coprimality hypothesis of Schur–Zassenhaus is FREE for Sylow subgroups. A Sylow $p$-subgroup $P$ has order a power of $p$, while its index $[G:P]$ is coprime to $p$ (Mathlib's `Sylow.card_coprime_index` — Sylow subgroups are Hall subgroups). So $\\gcd(|P|, [G:P]) = 1$ automatically, and the only extra hypothesis is normality of $P$. Whenever a Sylow subgroup is normal, the group splits as $P \\rtimes K$.",
+    "mathContext": "$|P| = p^a$ and $\\gcd(p, [G:P]) = 1 \\implies \\gcd(|P|, [G:P]) = 1$; normality of $P$ then gives $G = P \\rtimes K$.",
+    "significance": "key",
+    "relatedConcepts": ["Hall subgroups", "Sylow.card_coprime_index", "normal Sylow subgroup", "Hall property"],
+    "prerequisites": ["Sylow p-subgroups are Hall subgroups", "coprimality of order and index"]
   },
   {
     "id": "ann-hall-complement",
     "proofId": "sylow-theorem-oq-03",
     "range": {
-      "startLine": 103,
+      "startLine": 97,
       "endLine": 119
     },
     "type": "concept",
     "title": "The Complement Is a Hall p′-Subgroup",
-    "content": "normalSylow_complement_not_dvd shows p ∤ |K|: since |K| = [G:P] and p never divides the index of a Sylow p-subgroup (Sylow.not_dvd_index), the complement contains no p-torsion in its order — it is a p-complement, i.e. a Hall p′-subgroup. Together with normalSylow_complement_coprime (|P| coprime to |K|), this realises G as the product of two coprime Hall subgroups. This is the concrete bridge from Sylow theory to extension theory: a normal Sylow subgroup and its p′-complement carve the group into its p-part and p′-part."
-  },
-  {
-    "id": "ann-classification-use",
-    "proofId": "sylow-theorem-oq-03",
-    "range": {
-      "startLine": 72,
-      "endLine": 79
-    },
-    "type": "concept",
-    "title": "An Order-Factorization Tool for Group Classification",
-    "content": "complement_of_coprime_orders phrases the theorem in the form most used in classification: if |G| = m·n with gcd(m,n) = 1 and G has a normal subgroup N of order m, then G has a subgroup K of order n complementing it. In small-order classification (groups of order pq, p²q, …) Sylow counting frequently forces one Sylow subgroup to be normal; this lemma then immediately supplies the complementary factor and reduces the structure of G to a semidirect product N ⋊ K, the starting point for enumerating the possible actions."
+    "content": "`normalSylow_complement_card` records $|K| = [G:P]$, and `normalSylow_complement_not_dvd` shows $p \\nmid |K|$: since $|K| = [G:P]$ and $p$ never divides the index of a Sylow $p$-subgroup (`Sylow.not_dvd_index`), the complement contains no $p$-torsion in its order — it is a $p$-complement, i.e. a Hall $p'$-subgroup. Together with `normalSylow_complement_coprime` ($|P|$ coprime to $|K|$), this realizes $G$ as the product of two coprime Hall subgroups. This is the concrete bridge from Sylow theory to extension theory: a normal Sylow subgroup and its $p'$-complement carve the group into its $p$-part and $p'$-part.",
+    "mathContext": "$|K| = [G:P]$, $p \\nmid |K|$, $\\gcd(|P|, |K|) = 1$ — so $K$ is a Hall $p'$-subgroup and $G$ is the $p$-part $\\times$ $p'$-part.",
+    "significance": "supporting",
+    "relatedConcepts": ["Hall p′-subgroup", "p-complement", "Sylow.not_dvd_index", "p-part and p′-part"],
+    "prerequisites": ["divisibility of subgroup index", "Hall p′-subgroups"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sylow-theorem-oq-03` (The Schur–Zassenhaus splitting theorem and its Sylow corollary).

## annotations.json
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to **all** annotations (none had these before).
- Closed coverage gaps: added a header annotation (lines 1-37) and an existence-theorem annotation (lines 44-60, covering `schurZassenhaus` and `isComplement'_card_eq_index`), which were previously unannotated.
- Restructured 4 → 5 annotations spanning the full Lean file end to end.

## meta.json
No changes needed — already strong (5 keyInsights, 2 sections with mathContext, full conclusion, crossReferences, references).

## Axiom integrity
Verified: 0 axioms, 0 sorries, no structure-encoded assumptions. `status: verified` / `badge: original` accurate; the Schur–Zassenhaus existence half is honestly credited to Mathlib, with the Sylow extension (normal Sylow ⟹ complemented, complement is Hall '$) as the original packaging.

## Verification
JSON validated via both `json.load` and node `JSON.parse`.