### PR TITLE
research(hilbert-17-oq-02): quantify PSD/SOS gap via Choi–Lam form's explicit degree-2 multiplier certificate [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3225,6 +3225,7 @@ import Proofs.Hilbert16
 import Proofs.Hilbert17MotzkinNotSOS
 import Proofs.Hilbert17MotzkinRationalSOS
 import Proofs.Hilbert17OQ01
+import Proofs.Hilbert17OQ02
 import Proofs.Hilbert17OQ01OQ04
 import Proofs.Hilbert17OQ03OQ05
 import Proofs.Hilbert17QuadraticGram

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3317,6 +3317,7 @@ import Proofs.IsoscelesTriangleOQ01
 import Proofs.IsoscelesTriangleOQ02
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
+import Proofs.JacobiSymbolOQ0101
 import Proofs.JacobiSymbolOQ0103
 import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01

--- a/proofs/Proofs/Hilbert17OQ02.lean
+++ b/proofs/Proofs/Hilbert17OQ02.lean
@@ -1,0 +1,195 @@
+/-
+  Hilbert's 17th problem — quantifying the PSD/SOS gap for the homogeneous
+  Choi–Lam form.
+
+  The two existing canonical gap members in the gallery are *affine*: the Motzkin
+  polynomial `x⁴y² + x²y⁴ + 1 − 3x²y²` and Robinson's form.  The genuine
+  *homogeneous* member of the gap on `ℝ³` is the cyclic Choi–Lam form
+
+      CL(x, y, z) = x⁴y² + y⁴z² + z⁴x² − 3·x²y²z²       (Choi–Lam, 1977)
+
+  which is positive-semidefinite (PSD) on all of `ℝ³` yet is **not** a sum of
+  squares of polynomials: there is no degree-6 SOS certificate, exactly because
+  the underlying inequality `x⁴y² + y⁴z² + z⁴x² ≥ 3x²y²z²` is the three-term
+  AM–GM, which has no polynomial SOS proof.  (That non-SOS fact is the classical
+  Choi–Lam result, established for the sibling Motzkin/Robinson forms by the
+  Gram-matrix technique of `Hilbert17MotzkinNotSOS` / `Hilbert17RobinsonNotSOS`;
+  it is *not* re-derived here.)
+
+  This file quantifies the gap with a sharp, fully explicit certificate.  By
+  Artin's theorem CL is a sum of squares of *rational* functions; the question
+  "how complex is the certificate?" is answered here by an explicit **degree-2
+  denominator**: multiplying CL by the single quadratic form `x² + y² + z²`
+  turns it into an honest polynomial sum of squares,
+
+      (x² + y² + z²)·CL
+        = (x³y − xyz²)² + (y³z − x²yz)² + (z³x − xy²z)²
+          + ½[(x²y² − y²z²)² + (y²z² − z²x²)² + (z²x² − x²y²)²].
+
+  So the PSD/SOS gap for CL is bridged by a multiplier of degree exactly `2` —
+  the minimal possible, since CL itself is not SOS.  From this identity we read
+  off:
+
+    * `multiplier_sos_identity` — the exact `ring` identity above (the heart).
+    * `choiLam_three_nonneg` — CL is PSD on `ℝ³` (divide the identity by the
+      strictly-positive multiplier off the origin; the origin is the zero of CL).
+    * `choiLam_psd_iff` — the family `x⁴y² + y⁴z² + z⁴x² − c·x²y²z²` is PSD
+      **iff** `c ≤ 3`, so `c = 3` is the sharp boundary coefficient (the same
+      AM–GM threshold pinned down for the affine Motzkin family in the sibling
+      entry `Hilbert17OQ03OQ05`, here in its genuine homogeneous ternary form).
+
+  Everything is `0`-axiom, over `ℝ` and `MvPolynomial (Fin 3) ℝ`.
+-/
+import Mathlib
+
+namespace Hilbert17OQ02
+
+open MvPolynomial
+
+/-! ## The Choi–Lam family as a real three-variable function -/
+
+/-- The Choi–Lam family evaluated at real arguments:
+    `CLₐ(x, y, z) = x⁴y² + y⁴z² + z⁴x² − c·x²y²z²`.  The classical Choi–Lam
+    form is the boundary member `c = 3`. -/
+def choiLam (c x y z : ℝ) : ℝ :=
+  x ^ 4 * y ^ 2 + y ^ 4 * z ^ 2 + z ^ 4 * x ^ 2 - c * (x ^ 2 * y ^ 2 * z ^ 2)
+
+/-! ## The explicit degree-2 multiplier certificate (the gap quantification) -/
+
+/-- **Multiplier SOS identity.**  Multiplying the Choi–Lam form `CL = choiLam 3`
+    by the single quadratic `x² + y² + z²` produces an honest polynomial sum of
+    squares.  This is the exact, machine-checked Positivstellensatz certificate
+    behind Artin's theorem for CL, with a denominator of degree `2`. -/
+theorem multiplier_sos_identity (x y z : ℝ) :
+    (x ^ 2 + y ^ 2 + z ^ 2) * choiLam 3 x y z
+      = (x ^ 3 * y - x * y * z ^ 2) ^ 2
+        + (y ^ 3 * z - x ^ 2 * y * z) ^ 2
+        + (z ^ 3 * x - x * y ^ 2 * z) ^ 2
+        + ((x ^ 2 * y ^ 2 - y ^ 2 * z ^ 2) ^ 2
+            + (y ^ 2 * z ^ 2 - z ^ 2 * x ^ 2) ^ 2
+            + (z ^ 2 * x ^ 2 - x ^ 2 * y ^ 2) ^ 2) / 2 := by
+  unfold choiLam
+  ring
+
+/-- The product `(x²+y²+z²)·CL` is non-negative everywhere — it is a sum of
+    squares by `multiplier_sos_identity`. -/
+theorem multiplier_mul_nonneg (x y z : ℝ) :
+    0 ≤ (x ^ 2 + y ^ 2 + z ^ 2) * choiLam 3 x y z := by
+  rw [multiplier_sos_identity]
+  positivity
+
+/-! ## Positive-semidefiniteness of the Choi–Lam form -/
+
+/-- **CL is PSD.**  The classical Choi–Lam form `c = 3` is non-negative on all of
+    `ℝ³`.  Off the origin the strictly-positive multiplier `x²+y²+z²` divides out
+    of `multiplier_mul_nonneg`; at the origin CL vanishes. -/
+theorem choiLam_three_nonneg (x y z : ℝ) : 0 ≤ choiLam 3 x y z := by
+  rcases eq_or_ne (x ^ 2 + y ^ 2 + z ^ 2) 0 with h | h
+  · -- `x² + y² + z² = 0` forces `x² = y² = z² = 0`, so every monomial of CL
+    -- vanishes.  We work with the squares directly (no `pow_eq_zero_iff`).
+    have hx2 : x ^ 2 = 0 :=
+      le_antisymm (by nlinarith [sq_nonneg y, sq_nonneg z]) (sq_nonneg x)
+    have hy2 : y ^ 2 = 0 :=
+      le_antisymm (by nlinarith [sq_nonneg x, sq_nonneg z]) (sq_nonneg y)
+    have hz2 : z ^ 2 = 0 :=
+      le_antisymm (by nlinarith [sq_nonneg x, sq_nonneg y]) (sq_nonneg z)
+    have hzero : choiLam 3 x y z = 0 := by
+      have e : choiLam 3 x y z
+          = (x ^ 2) ^ 2 * y ^ 2 + (y ^ 2) ^ 2 * z ^ 2 + (z ^ 2) ^ 2 * x ^ 2
+            - 3 * (x ^ 2 * y ^ 2 * z ^ 2) := by
+        unfold choiLam; ring
+      rw [e, hx2, hy2, hz2]; ring
+    exact le_of_eq hzero.symm
+  · -- `x² + y² + z² > 0`, so non-negativity transfers from the product.
+    have hpos : 0 < x ^ 2 + y ^ 2 + z ^ 2 :=
+      lt_of_le_of_ne (by positivity) (Ne.symm h)
+    by_contra hc
+    push_neg at hc
+    have : (x ^ 2 + y ^ 2 + z ^ 2) * choiLam 3 x y z < 0 :=
+      mul_neg_of_pos_of_neg hpos hc
+    linarith [multiplier_mul_nonneg x y z]
+
+/-! ## The sharp PSD threshold `c ≤ 3` -/
+
+/-- **Non-negativity for `c ≤ 3`.**  For every coefficient `c ≤ 3` the family
+    `CLₐ` is non-negative everywhere: the deficit `(3 − c)·x²y²z² ≥ 0` only adds
+    to the PSD boundary member `CL = choiLam 3`. -/
+theorem choiLam_nonneg_of_le {c : ℝ} (hc : c ≤ 3) (x y z : ℝ) :
+    0 ≤ choiLam c x y z := by
+  have hbase := choiLam_three_nonneg x y z
+  have hsq : (0 : ℝ) ≤ x ^ 2 * y ^ 2 * z ^ 2 := by positivity
+  have hdiff : 0 ≤ (3 - c) * (x ^ 2 * y ^ 2 * z ^ 2) :=
+    mul_nonneg (by linarith) hsq
+  -- `choiLam c = choiLam 3 + (3 − c)·x²y²z²`.
+  have : choiLam c x y z = choiLam 3 x y z + (3 - c) * (x ^ 2 * y ^ 2 * z ^ 2) := by
+    unfold choiLam; ring
+  rw [this]; linarith
+
+/-- **Failure for `c > 3`.**  At `(x, y, z) = (1, 1, 1)` the value is `3 − c < 0`,
+    so the family leaves the PSD cone once `c` exceeds `3`. -/
+theorem choiLam_neg_of_gt {c : ℝ} (hc : 3 < c) : choiLam c 1 1 1 < 0 := by
+  unfold choiLam; nlinarith [hc]
+
+/-- **Sharp PSD threshold.**  The Choi–Lam family is non-negative on all of `ℝ³`
+    if and only if `c ≤ 3`.  Thus `c = 3` (the classical Choi–Lam form) is the
+    extremal PSD member — the genuine homogeneous analogue of the affine Motzkin
+    threshold. -/
+theorem choiLam_psd_iff (c : ℝ) :
+    (∀ x y z : ℝ, 0 ≤ choiLam c x y z) ↔ c ≤ 3 := by
+  constructor
+  · intro h
+    have h111 := h 1 1 1
+    unfold choiLam at h111
+    norm_num at h111
+    linarith
+  · intro hc x y z
+    exact choiLam_nonneg_of_le hc x y z
+
+/-- `3` is the **largest** coefficient for which the family is PSD. -/
+theorem three_is_sharp {c : ℝ} (hPSD : ∀ x y z : ℝ, 0 ≤ choiLam c x y z) :
+    c ≤ 3 := (choiLam_psd_iff c).1 hPSD
+
+/-! ## The family as a genuine `MvPolynomial (Fin 3) ℝ`
+
+We repackage the same facts for the polynomial object, matching the parent
+entry's `IsPositiveSemidefiniteMv` formulation. -/
+
+/-- The Choi–Lam family as a trivariate polynomial:
+    `X₀⁴X₁² + X₁⁴X₂² + X₂⁴X₀² − c·X₀²X₁²X₂²`. -/
+noncomputable def choiLamPoly (c : ℝ) : MvPolynomial (Fin 3) ℝ :=
+  X 0 ^ 4 * X 1 ^ 2 + X 1 ^ 4 * X 2 ^ 2 + X 2 ^ 4 * X 0 ^ 2
+    - C c * (X 0 ^ 2 * X 1 ^ 2 * X 2 ^ 2)
+
+/-- A multivariate polynomial is PSD if it is non-negative for all real inputs
+    (matching `Hilbert17.IsPositiveSemidefiniteMv` in the parent file). -/
+def IsPSDMv (p : MvPolynomial (Fin 3) ℝ) : Prop :=
+  ∀ v : Fin 3 → ℝ, 0 ≤ MvPolynomial.eval v p
+
+/-- Evaluating `choiLamPoly` recovers the real function `choiLam`. -/
+@[simp] theorem eval_choiLamPoly (c : ℝ) (v : Fin 3 → ℝ) :
+    MvPolynomial.eval v (choiLamPoly c) = choiLam c (v 0) (v 1) (v 2) := by
+  unfold choiLamPoly choiLam
+  simp only [map_add, map_sub, map_mul, map_pow, eval_X, eval_C]
+
+/-- **Sharp PSD threshold (polynomial form).**  `choiLamPoly c` is PSD if and
+    only if `c ≤ 3`. -/
+theorem choiLamPoly_psd_iff (c : ℝ) : IsPSDMv (choiLamPoly c) ↔ c ≤ 3 := by
+  unfold IsPSDMv
+  constructor
+  · intro h
+    have h111 := h (fun _ => 1)
+    simp only [eval_choiLamPoly] at h111
+    unfold choiLam at h111
+    norm_num at h111
+    linarith
+  · intro hc v
+    rw [eval_choiLamPoly]
+    exact choiLam_nonneg_of_le hc (v 0) (v 1) (v 2)
+
+/-- The classical Choi–Lam form (`c = 3`) is PSD as a trivariate polynomial — the
+    boundary member of the family, and the canonical homogeneous element of the
+    PSD/SOS gap. -/
+theorem choiLamPoly_three_psd : IsPSDMv (choiLamPoly 3) :=
+  (choiLamPoly_psd_iff 3).2 (le_refl 3)
+
+end Hilbert17OQ02

--- a/proofs/Proofs/JacobiSymbolOQ0101.lean
+++ b/proofs/Proofs/JacobiSymbolOQ0101.lean
@@ -1,0 +1,132 @@
+/-
+  Quadratic Reciprocity for the Jacobi symbol, with explicit power-form
+  supplementary laws.
+
+  The **Jacobi symbol** `J(a | b)` (for odd `b`) obeys the *Law of Quadratic
+  Reciprocity* and two *supplementary laws*, exactly as the Legendre symbol
+  does — even though `b` need not be prime:
+
+    * **Reciprocity**: for odd `a, b`,
+        `J(a | b) = (-1)^((a-1)/2 · (b-1)/2) · J(b | a)`;
+      with the clean residue-class corollaries
+        `a ≡ 1 (mod 4)  ⟹  J(a|b) = J(b|a)`,
+        `a ≡ b ≡ 3 (mod 4)  ⟹  J(a|b) = -J(b|a)`.
+    * **First supplementary law**: `J(-1 | b) = (-1)^((b-1)/2)`.
+    * **Second supplementary law**: `J(2 | b) = (-1)^((b²-1)/8)`.
+
+  Mathlib provides the reciprocity law directly (`jacobiSym.quadratic_reciprocity`)
+  and the supplementary laws in *character* form — `J(-1|b) = χ₄ b` and
+  `J(2|b) = χ₈ b`, where `χ₄, χ₈` are the quadratic characters mod 4 and mod 8.
+  The mathematical content added here is the bridge to the **classical explicit
+  power forms**: we evaluate `χ₄ b` and `χ₈ b` as concrete powers of `-1`,
+  the form in which the supplementary laws are stated in every textbook. The
+  `χ₈ → (-1)^((b²-1)/8)` bridge is the substantive step: it is an elementary
+  but genuine residue computation on `b mod 8` (the parity of `(b²-1)/8` is
+  `b mod 8`–periodic), carried out below from first principles.
+
+  Together with a worked evaluation by *flipping*, this packages the full
+  reciprocity toolkit that makes the Jacobi symbol an efficient,
+  factorization-free residue calculator.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+namespace JacobiSymbolOQ0101
+
+/-! ### The Law of Quadratic Reciprocity -/
+
+/-- **Quadratic Reciprocity for the Jacobi symbol**: for odd `a, b`,
+`J(a | b) = (-1)^((a/2)·(b/2)) · J(b | a)`.  (For odd `n`, `n/2 = (n-1)/2`.) -/
+theorem jacobi_quadratic_reciprocity {a b : ℕ} (ha : Odd a) (hb : Odd b) :
+    jacobiSym a b = (-1) ^ (a / 2 * (b / 2)) * jacobiSym b a :=
+  jacobiSym.quadratic_reciprocity ha hb
+
+/-- If `a ≡ 1 (mod 4)` and `b` is odd, the symbols agree: `J(a|b) = J(b|a)`. -/
+theorem jacobi_reciprocity_one_mod_four {a b : ℕ} (ha : a % 4 = 1) (hb : Odd b) :
+    jacobiSym a b = jacobiSym b a :=
+  jacobiSym.quadratic_reciprocity_one_mod_four ha hb
+
+/-- If `a ≡ b ≡ 3 (mod 4)`, the symbols are opposite: `J(a|b) = -J(b|a)`. -/
+theorem jacobi_reciprocity_three_mod_four {a b : ℕ} (ha : a % 4 = 3) (hb : b % 4 = 3) :
+    jacobiSym a b = -jacobiSym b a :=
+  jacobiSym.quadratic_reciprocity_three_mod_four ha hb
+
+/-! ### First supplementary law: `J(-1 | b) = (-1)^((b-1)/2)` -/
+
+/-- **First supplementary law**, explicit power form: for odd `b`,
+`J(-1 | b) = (-1)^((b-1)/2)`.  Bridges Mathlib's character form `χ₄ b`. -/
+theorem jacobi_at_neg_one_pow {b : ℕ} (hb : Odd b) :
+    jacobiSym (-1) b = (-1) ^ ((b - 1) / 2) := by
+  have hodd : b % 2 = 1 := Nat.odd_iff.mp hb
+  rw [jacobiSym.at_neg_one hb, ZMod.χ₄_eq_neg_one_pow hodd]
+  congr 1
+  omega
+
+/-! ### Second supplementary law: `J(2 | b) = (-1)^((b²-1)/8)`
+
+This is the substantive bridge.  Mathlib gives `J(2|b) = χ₈ b`, where `χ₈ b`
+is `+1` for `b ≡ ±1 (mod 8)` and `-1` for `b ≡ ±3 (mod 8)`.  We must show this
+equals `(-1)^((b²-1)/8)`, i.e. that the parity of the exponent `(b²-1)/8` is
+`+` exactly for `b ≡ ±1 (mod 8)`.  Writing `b = 8q + r` with `r = b % 8 ∈
+{1,3,5,7}`, we have `b² - 1 = 8(8q² + 2qr) + (r²-1)` with `8 ∣ r²-1`, so the
+parity of `(b²-1)/8` is the parity of `(r²-1)/8`, which is even iff `r ∈ {1,7}`.
+The four residue cases are discharged below by `omega` (treating `q*q` as an
+opaque atom) plus `pow_mul`/`pow_succ`. -/
+
+/-- **Second supplementary law**, explicit power form: for odd `b`,
+`J(2 | b) = (-1)^((b²-1)/8)`. -/
+theorem jacobi_at_two_pow {b : ℕ} (hb : Odd b) :
+    jacobiSym 2 b = (-1) ^ ((b ^ 2 - 1) / 8) := by
+  have hodd : b % 2 = 1 := Nat.odd_iff.mp hb
+  rw [jacobiSym.at_two hb, ZMod.χ₈_nat_eq_if_mod_eight]
+  rw [if_neg (by omega : ¬ b % 2 = 0)]
+  set q := b / 8 with hq
+  rcases (by omega : b % 8 = 1 ∨ b % 8 = 3 ∨ b % 8 = 5 ∨ b % 8 = 7) with h | h | h | h
+  · -- b ≡ 1 (mod 8): exponent even
+    rw [if_pos (Or.inl h)]
+    have hb1 : b = 8 * q + 1 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 16 * q + 1 := by rw [hb1]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + q) := by omega
+    rw [hexp, pow_mul]; norm_num
+  · -- b ≡ 3 (mod 8): exponent odd
+    rw [if_neg (by omega)]
+    have hb3 : b = 8 * q + 3 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 48 * q + 9 := by rw [hb3]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + 3 * q) + 1 := by omega
+    rw [hexp, pow_succ, pow_mul]; norm_num
+  · -- b ≡ 5 (mod 8): exponent odd
+    rw [if_neg (by omega)]
+    have hb5 : b = 8 * q + 5 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 80 * q + 25 := by rw [hb5]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + 5 * q + 1) + 1 := by omega
+    rw [hexp, pow_succ, pow_mul]; norm_num
+  · -- b ≡ 7 (mod 8): exponent even
+    rw [if_pos (Or.inr h)]
+    have hb7 : b = 8 * q + 7 := by omega
+    have hsq : b ^ 2 = 64 * (q * q) + 112 * q + 49 := by rw [hb7]; ring
+    have hexp : (b ^ 2 - 1) / 8 = 2 * (4 * (q * q) + 7 * q + 3) := by omega
+    rw [hexp, pow_mul]; norm_num
+
+/-! ### A worked evaluation by reciprocity (no factorization)
+
+The payoff of Jacobi reciprocity: `J(a|b)` can be evaluated by repeatedly
+*flipping* the arguments and reducing the (now larger) numerator modulo the
+(smaller) denominator — never factoring `b`.  We illustrate one flip step.
+`norm_num`'s Jacobi-symbol extension automates the whole chain; the explicit
+flip below exhibits the single reciprocity step it performs internally. -/
+
+/-- Worked evaluation: `J(5 | 21) = 1`, obtained by flipping (`5 ≡ 1 mod 4`,
+so `J(5|21) = J(21|5)`) and then reducing — *without* factoring `21 = 3·7`. -/
+theorem jacobi_five_twentyone_by_reciprocity : jacobiSym 5 21 = 1 := by
+  have flip : jacobiSym 5 21 = jacobiSym 21 5 :=
+    jacobiSym.quadratic_reciprocity_one_mod_four (by norm_num) (by norm_num)
+  rw [flip]
+  -- `J(21|5)`: numerator reduces `21 ≡ 1 (mod 5)`, giving `J(1|5) = 1`.
+  norm_num
+
+/-- Sanity cross-check: the same value computed directly (definitionally,
+via the prime factorization of `21`). Both routes agree. -/
+theorem jacobi_five_twentyone_direct : jacobiSym 5 21 = 1 := by norm_num
+
+end JacobiSymbolOQ0101

--- a/src/data/proofs/hilbert-17-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "h17g-choilam-def",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 54, "endLine": 55 },
+    "type": "definition",
+    "title": "The Choi–Lam Family",
+    "content": "choiLam c x y z = x⁴y² + y⁴z² + z⁴x² − c·x²y²z² is the cyclic homogeneous Choi–Lam family. At c = 3 it is the classical Choi–Lam form (Choi–Lam 1977): non-negative on all of ℝ³ yet not a sum of squares of polynomials — the genuine homogeneous member of the PSD/SOS gap, complementing the gallery's affine Motzkin and Robinson forms.",
+    "mathContext": "$\\mathrm{CL}_c(x,y,z) = x^4y^2 + y^4z^2 + z^4x^2 - c\\,x^2y^2z^2$",
+    "significance": "key",
+    "prerequisites": ["positive-semidefinite polynomials", "Choi–Lam form"],
+    "relatedConcepts": ["Hilbert's 17th problem", "PSD/SOS gap", "homogeneous forms"]
+  },
+  {
+    "id": "h17g-multiplier-sos",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 63, "endLine": 74 },
+    "type": "theorem",
+    "title": "Degree-2 Multiplier SOS Certificate",
+    "content": "The heart of the entry. Multiplying the non-SOS Choi–Lam form by the single quadratic x²+y²+z² yields an explicit polynomial sum of squares: (x²+y²+z²)·CL = (x³y−xyz²)² + (y³z−x²yz)² + (z³x−xy²z)² + ½[(x²y²−y²z²)² + (y²z²−z²x²)² + (z²x²−x²y²)²], proved by ring. Since CL itself is not a sum of squares, this multiplier degree (2) is the minimal possible — an explicit, sharp instance of Artin's rational-SOS theorem that QUANTIFIES the PSD/SOS gap by the degree of the required denominator.",
+    "mathContext": "$(x^2+y^2+z^2)\\,\\mathrm{CL} = (x^3y-xyz^2)^2 + (y^3z-x^2yz)^2 + (z^3x-xy^2z)^2 + \\tfrac12\\sum_{\\mathrm{cyc}}(x^2y^2-y^2z^2)^2$",
+    "significance": "critical",
+    "prerequisites": ["Positivstellensatz / denominator certificates", "sum-of-squares decomposition", "ring tactic"],
+    "relatedConcepts": ["Artin's theorem", "Hilbert's 17th problem", "minimal denominator degree"]
+  },
+  {
+    "id": "h17g-mul-nonneg",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 76, "endLine": 79 },
+    "type": "theorem",
+    "title": "The Product Is Non-Negative",
+    "content": "An immediate consequence of the SOS identity: (x²+y²+z²)·CL ≥ 0 everywhere, closed by positivity since the right-hand side is a sum of squares.",
+    "mathContext": "$0 \\le (x^2+y^2+z^2)\\,\\mathrm{CL}(x,y,z)$",
+    "significance": "supporting",
+    "prerequisites": ["positivity tactic"],
+    "relatedConcepts": ["sum of squares"]
+  },
+  {
+    "id": "h17g-psd",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 86, "endLine": 115 },
+    "type": "theorem",
+    "title": "The Choi–Lam Form Is PSD",
+    "content": "CL = choiLam 3 is non-negative on all of ℝ³. Off the origin the multiplier x²+y²+z² is strictly positive, so a hypothetical CL < 0 would make the product negative (mul_neg_of_pos_of_neg), contradicting the SOS identity; at the origin x²+y²+z² = 0 forces x² = y² = z² = 0 (each square ≤ the zero sum, via le_antisymm with sq_nonneg) so every monomial of CL vanishes (by ring). This deduces PSD-ness from the certificate rather than from the AM–GM inequality directly — which has no polynomial SOS proof.",
+    "mathContext": "$0 \\le \\mathrm{CL}(x,y,z)\\ \\text{for all}\\ (x,y,z)\\in\\mathbb{R}^3$",
+    "significance": "key",
+    "prerequisites": ["case analysis", "mul_neg_of_pos_of_neg", "le_antisymm with sq_nonneg"],
+    "relatedConcepts": ["positive-semidefinite", "AM–GM inequality"]
+  },
+  {
+    "id": "h17g-nonneg-of-le",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 117, "endLine": 128 },
+    "type": "theorem",
+    "title": "Non-Negativity for c ≤ 3",
+    "content": "For c ≤ 3 the family stays PSD: choiLam c = choiLam 3 + (3−c)·x²y²z², and both summands are non-negative (the boundary member by the previous theorem, the deficit since 3 − c ≥ 0 and x²y²z² ≥ 0).",
+    "mathContext": "$c \\le 3 \\implies 0 \\le \\mathrm{CL}_c(x,y,z)$",
+    "significance": "supporting",
+    "prerequisites": ["monotonicity of multiplication"],
+    "relatedConcepts": ["one-parameter family", "deficit decomposition"]
+  },
+  {
+    "id": "h17g-neg-of-gt",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 130, "endLine": 132 },
+    "type": "theorem",
+    "title": "Failure Above the Threshold",
+    "content": "For c > 3 the value at (1,1,1) is 3 − c < 0, so the family leaves the PSD cone once c exceeds 3. A single test point detects the boundary.",
+    "mathContext": "$3 < c \\implies \\mathrm{CL}_c(1,1,1) = 3 - c < 0$",
+    "significance": "supporting",
+    "prerequisites": ["evaluation"],
+    "relatedConcepts": ["test point", "sharp threshold"]
+  },
+  {
+    "id": "h17g-psd-iff",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 137, "endLine": 147 },
+    "type": "theorem",
+    "title": "Sharp PSD Threshold (Real Form)",
+    "content": "The Choi–Lam family is non-negative on all of ℝ³ if and only if c ≤ 3. Thus c = 3 (the classical Choi–Lam form) is the extremal PSD member — the genuine homogeneous analogue of the affine Motzkin threshold (sibling hilbert-17-oq-03-oq-05). The boundary is the three-term AM–GM coefficient.",
+    "mathContext": "$(\\forall x\\,y\\,z,\\ 0 \\le \\mathrm{CL}_c(x,y,z)) \\iff c \\le 3$",
+    "significance": "critical",
+    "prerequisites": ["if-and-only-if", "AM–GM threshold"],
+    "relatedConcepts": ["sharp threshold", "extremal PSD member", "PSD/SOS gap"]
+  },
+  {
+    "id": "h17g-poly-iff",
+    "proofId": "hilbert-17-oq-02",
+    "range": { "startLine": 176, "endLine": 190 },
+    "type": "theorem",
+    "title": "Sharp PSD Threshold (MvPolynomial Form)",
+    "content": "The same threshold transported to the genuine polynomial object choiLamPoly c : MvPolynomial (Fin 3) ℝ, under the PSD predicate IsPSDMv (matching the parent's IsPositiveSemidefiniteMv), via an explicit eval bridge eval_choiLamPoly. IsPSDMv (choiLamPoly c) ⟺ c ≤ 3.",
+    "mathContext": "$\\mathrm{IsPSDMv}(\\mathrm{choiLamPoly}\\ c) \\iff c \\le 3$",
+    "significance": "key",
+    "prerequisites": ["MvPolynomial evaluation", "ring-homomorphism simp lemmas"],
+    "relatedConcepts": ["multivariate polynomials", "PSD predicate"]
+  }
+]

--- a/src/data/proofs/hilbert-17-oq-02/meta.json
+++ b/src/data/proofs/hilbert-17-oq-02/meta.json
@@ -1,0 +1,216 @@
+{
+  "id": "hilbert-17-oq-02",
+  "title": "Hilbert's 17th: Quantifying the PSD/SOS Gap — the Choi–Lam Form and Its Degree-2 Denominator Certificate",
+  "slug": "hilbert-17-oq-02",
+  "description": "The Choi–Lam form CL(x,y,z) = x⁴y² + y⁴z² + z⁴x² − 3x²y²z² (Choi–Lam, 1977) is the genuine homogeneous member of the positive-semidefinite (PSD) / sum-of-squares (SOS) gap on ℝ³: it is non-negative everywhere yet is not a sum of squares of polynomials (no degree-6 SOS certificate exists, precisely because the underlying inequality x⁴y² + y⁴z² + z⁴x² ≥ 3x²y²z² is the three-term AM–GM, which has no polynomial SOS proof). The gallery's existing canonical gap members are the affine Motzkin polynomial and Robinson's form; this entry adds the homogeneous ternary form and, more importantly, QUANTIFIES the gap with a sharp, fully explicit certificate. By Artin's theorem CL is a sum of squares of rational functions; the complexity of that certificate is pinned down here by an explicit DEGREE-2 DENOMINATOR: multiplying CL by the single quadratic x² + y² + z² yields an honest polynomial sum of squares — (x²+y²+z²)·CL = (x³y−xyz²)² + (y³z−x²yz)² + (z³x−xy²z)² + ½[(x²y²−y²z²)² + (y²z²−z²x²)² + (z²x²−x²y²)²] — verified by ring. So the PSD/SOS gap for CL is bridged by a multiplier of degree exactly 2, the minimal possible since CL is not SOS. From the identity we deduce PSD-ness (dividing by the strictly-positive multiplier off the origin) and the sharp threshold: x⁴y² + y⁴z² + z⁴x² − c·x²y²z² is PSD on ℝ³ ⟺ c ≤ 3, in both real-function and MvPolynomial (Fin 3) ℝ forms. Everything is 0-axiom. The non-SOS-ness itself is the classical Choi–Lam fact established for the sibling Motzkin/Robinson forms by the Gram-matrix technique and is cited, not re-derived.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert17OQ02.lean",
+    "tags": [
+      "real-algebraic-geometry",
+      "sum-of-squares",
+      "hilbert-17",
+      "positive-polynomials",
+      "choi-lam-form",
+      "motzkin-polynomial",
+      "psd-sos-gap",
+      "positivstellensatz",
+      "am-gm-inequality",
+      "sharp-threshold",
+      "elementary-proof"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.eval",
+        "description": "Evaluation of a multivariate polynomial at a real point; bridges the polynomial object choiLamPoly to the real three-variable function choiLam via the ring-homomorphism simp lemmas (map_add, map_sub, map_mul, map_pow, eval_X, eval_C).",
+        "module": "Mathlib.Algebra.MvPolynomial.Eval"
+      },
+      {
+        "theorem": "mul_neg_of_pos_of_neg",
+        "description": "From 0 < x²+y²+z² and a hypothetical CL < 0 deduce (x²+y²+z²)·CL < 0, contradicting the SOS identity; this is the off-origin division step that transfers non-negativity from the product to CL itself.",
+        "module": "Mathlib.Algebra.Order.Ring.Defs"
+      },
+      {
+        "theorem": "sq_nonneg",
+        "description": "0 ≤ x² for all real x; combined with le_antisymm it pins x² = 0 in the origin case (x²+y²+z² = 0), where every monomial of CL then vanishes by ring.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "An explicit, machine-checked DEGREE-2 denominator certificate quantifying the PSD/SOS gap for the Choi–Lam form: (x²+y²+z²)·(x⁴y²+y⁴z²+z⁴x²−3x²y²z²) is written as an exact sum of six squares (three degree-4 squares plus a half-sum of three degree-4 squares), proved by ring. Since the form itself is not a sum of squares, this multiplier degree (2) is minimal — an explicit, sharp instance of Artin's rational-SOS theorem for the canonical homogeneous gap member.",
+      "Adds the genuine HOMOGENEOUS ternary member of the PSD/SOS gap to the gallery (the Choi–Lam cyclic form x⁴y²+y⁴z²+z⁴x²−3x²y²z²), complementing the existing affine Motzkin polynomial and Robinson's form, and proves it PSD on all of ℝ³ from the multiplier certificate rather than via the AM–GM inequality directly (which has no polynomial SOS proof).",
+      "Proves the SHARP PSD threshold of the homogeneous Choi–Lam family x⁴y²+y⁴z²+z⁴x²−c·x²y²z²: PSD on ℝ³ ⟺ c ≤ 3, so c = 3 is the extremal PSD coefficient — the genuine homogeneous analogue of the affine Motzkin threshold (sibling hilbert-17-oq-03-oq-05), in both real-function (choiLam_psd_iff) and MvPolynomial (choiLamPoly_psd_iff) forms."
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Hilbert's 17th problem: positive-semidefinite (PSD) polynomials versus sums of squares (SOS), and Artin's theorem (every PSD polynomial is a sum of squares of rational functions).",
+      "The PSD/SOS gap for n ≥ 2 variables and the canonical counterexamples (Motzkin, Robinson, Choi–Lam).",
+      "Positivstellensatz / denominator certificates: multiplying a PSD form by a suitable SOS denominator to obtain a polynomial SOS.",
+      "The three-term AM–GM inequality and the fact that it has no polynomial sum-of-squares proof.",
+      "Evaluation of multivariate polynomials and the PSD predicate ∀ v, 0 ≤ eval v p."
+    ],
+    "lineCount": 195,
+    "relatedProblems": [
+      {
+        "id": "hilbert-17-oq-03-oq-05",
+        "relationship": "Sibling (affine threshold): proves the sharp PSD threshold c ≤ 3 for the AFFINE Motzkin family x⁴y²+x²y⁴+1−c·x²y². This entry is its genuine HOMOGENEOUS counterpart on ℝ³, where the AM–GM core has no polynomial SOS proof and a degree-2 multiplier is needed."
+      },
+      {
+        "id": "hilbert-17-oq-03-oq-02",
+        "relationship": "Sibling (non-SOS technique): proves the Motzkin polynomial is PSD but not a sum of squares via the Gram-matrix argument. The same technique establishes the non-SOS-ness of the Choi–Lam form cited (not re-derived) here, which is exactly what forces the multiplier degree to be ≥ 1."
+      },
+      {
+        "id": "hilbert-17-oq-03-oq-03",
+        "relationship": "Sibling (homogeneous ternary counterexample): Robinson's form on ℝ³, PSD but not SOS. The Choi–Lam form here is the other canonical homogeneous ternary gap member, with an explicit minimal denominator certificate."
+      },
+      {
+        "id": "hilbert-17-oq-03-oq-01",
+        "relationship": "Sibling (rational SOS side): an explicit rational-function SOS certificate for the affine Motzkin polynomial. This entry gives the analogous certificate for the homogeneous Choi–Lam form in the cleanest form — a single degree-2 polynomial multiplier."
+      },
+      {
+        "id": "hilbert-17",
+        "relationship": "Grandparent: states Artin's theorem and frames the open questions on deciding SOS membership and quantifying the PSD/SOS gap. This entry quantifies the gap for the canonical homogeneous example by an explicit minimal (degree-2) denominator certificate plus the sharp PSD threshold."
+      }
+    ],
+    "assumptions": "0 axioms. #print axioms reports only propext, Classical.choice, Quot.sound for the main results (multiplier_sos_identity, choiLam_three_nonneg, choiLam_psd_iff, choiLamPoly_psd_iff). No sorryAx, no native_decide / Lean.ofReduceBool. The non-SOS-ness of the Choi–Lam form is NOT asserted as a Lean theorem here (it is the classical Choi–Lam result, established for the sibling Motzkin/Robinson forms); only PSD-ness, the sharp threshold, and the explicit multiplier-SOS identity are machine-checked. The MvPolynomial PSD predicate IsPSDMv matches the parent entry's IsPositiveSemidefiniteMv definitionally.",
+    "theoremCount": 10,
+    "definitionCount": 3,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 195,
+    "namespace": "Hilbert17OQ02",
+    "opens": [
+      "MvPolynomial"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 5,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "path": "Proofs/Hilbert17OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 3,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "multiplier_sos_identity",
+      "type": "theorem",
+      "description": "The degree-2 denominator certificate (the heart): (x²+y²+z²)·CL equals an explicit sum of six squares — three degree-4 squares (x³y−xyz²)², (y³z−x²yz)², (z³x−xy²z)² plus the half-sum ½[(x²y²−y²z²)²+(y²z²−z²x²)²+(z²x²−x²y²)²]. Proved by ring. This quantifies the PSD/SOS gap: a single quadratic multiplier turns the non-SOS Choi–Lam form into a polynomial sum of squares.",
+      "leanType": "(x²+y²+z²) * choiLam 3 x y z = (x³y−xyz²)² + (y³z−x²yz)² + (z³x−xy²z)² + ((x²y²−y²z²)² + (y²z²−z²x²)² + (z²x²−x²y²)²)/2"
+    },
+    {
+      "name": "choiLam_psd_iff",
+      "type": "theorem",
+      "description": "Sharp PSD threshold (real form): the homogeneous Choi–Lam family x⁴y²+y⁴z²+z⁴x²−c·x²y²z² is non-negative on all of ℝ³ if and only if c ≤ 3. Thus c = 3 (the classical Choi–Lam form) is the extremal PSD member — the homogeneous analogue of the affine Motzkin threshold.",
+      "leanType": "(∀ x y z : ℝ, 0 ≤ choiLam c x y z) ↔ c ≤ 3"
+    },
+    {
+      "name": "choiLam_three_nonneg",
+      "type": "theorem",
+      "description": "The classical Choi–Lam form (c = 3) is PSD on all of ℝ³. Off the origin the strictly-positive multiplier x²+y²+z² divides out of the SOS identity; at the origin CL vanishes.",
+      "leanType": "0 ≤ choiLam 3 x y z"
+    },
+    {
+      "name": "choiLamPoly_psd_iff",
+      "type": "theorem",
+      "description": "Sharp PSD threshold (polynomial form): the trivariate polynomial choiLamPoly c is PSD (under IsPSDMv, matching the parent's IsPositiveSemidefiniteMv) if and only if c ≤ 3.",
+      "leanType": "IsPSDMv (choiLamPoly c) ↔ c ≤ 3"
+    },
+    {
+      "name": "multiplier_mul_nonneg",
+      "type": "theorem",
+      "description": "The product (x²+y²+z²)·CL is non-negative everywhere — it is a sum of squares by multiplier_sos_identity (closed by positivity).",
+      "leanType": "0 ≤ (x²+y²+z²) * choiLam 3 x y z"
+    },
+    {
+      "name": "three_is_sharp",
+      "type": "theorem",
+      "description": "Sharpness: 3 is the largest coefficient for which the Choi–Lam family is PSD — any PSD member has c ≤ 3 (the contrapositive fails at (1,1,1), where the value is 3 − c).",
+      "leanType": "(∀ x y z : ℝ, 0 ≤ choiLam c x y z) → c ≤ 3"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hilbert's 17th problem asks whether every polynomial non-negative on ℝⁿ is a sum of squares — of polynomials, or at least of rational functions. For n ≥ 2 the polynomial answer is no: Motzkin (1967) gave the first explicit counterexample, and Choi & Lam (1977) gave the clean cyclic homogeneous form CL(x,y,z) = x⁴y² + y⁴z² + z⁴x² − 3x²y²z², which is non-negative everywhere by the three-term AM–GM (x⁴y²·y⁴z²·z⁴x² = (x²y²z²)³) yet is not a sum of squares of polynomials. Artin (1927) had already proved every PSD polynomial is a sum of squares of RATIONAL functions; the modern quantitative question — central to semidefinite-programming approaches to polynomial optimization — is how complex the certificate must be, i.e. the degree of the denominator one must multiply by to reach a polynomial SOS. For the Choi–Lam form the answer is the minimum possible: degree 2.",
+    "problemStatement": "Quantify the PSD/SOS gap for the canonical homogeneous Choi–Lam form: exhibit an explicit minimal-degree denominator that certifies non-negativity, and determine exactly which coefficients c make the family x⁴y²+y⁴z²+z⁴x²−c·x²y²z² positive-semidefinite. The answers, all 0-axiom: (x²+y²+z²)·CL is an explicit sum of squares (degree-2 denominator, minimal since CL is not SOS), and the family is PSD on ℝ³ if and only if c ≤ 3.",
+    "proofStrategy": "The centerpiece is the ring identity multiplier_sos_identity expressing (x²+y²+z²)·CL as a sum of six squares; it is found by the standard decomposition into the three cyclic squares (x³y−xyz²)², (y³z−x²yz)², (z³x−xy²z)² (which collapse Σx⁶y² and the cross terms) leaving the remainder Σx⁴y⁴ − Σx⁴y²z² = ½Σ(x²y²−y²z²)², a Schur-type SOS. From it, positivity gives multiplier_mul_nonneg. PSD-ness of CL (choiLam_three_nonneg) follows by cases on x²+y²+z²: off the origin the multiplier is strictly positive so a hypothetical CL < 0 would make the product negative (mul_neg_of_pos_of_neg), contradicting the identity; at the origin x = y = z = 0 and CL = 0. The sharp threshold then follows: for c ≤ 3, choiLam c = choiLam 3 + (3−c)·x²y²z² ≥ 0; conversely evaluating at (1,1,1) gives 3 − c, forcing c ≤ 3. The MvPolynomial form is transported via an eval lemma identifying eval v (choiLamPoly c) with choiLam c (v 0) (v 1) (v 2).",
+    "keyInsights": [
+      "The PSD/SOS gap is QUANTIFIED by a denominator degree: a single quadratic multiplier x²+y²+z² (degree 2) converts the non-SOS Choi–Lam form into an explicit polynomial sum of squares. This degree is minimal because the form is not itself a sum of squares.",
+      "Unlike the affine Motzkin form (whose dehomogenization admits a direct nlinarith SOS certificate), the homogeneous Choi–Lam form has NO polynomial SOS proof of non-negativity — the multiplier is genuinely necessary, which is exactly what makes the certificate an honest quantification of the gap.",
+      "The explicit SOS decomposition is structurally transparent: three cyclic squares of cubics handle the x⁶y² and mixed terms, and a Schur-type half-sum ½Σ(x²y²−y²z²)² handles the remaining biquadratic deficit.",
+      "The Motzkin coefficient phenomenon recurs homogeneously: the family x⁴y²+y⁴z²+z⁴x²−c·x²y²z² is PSD exactly for c ≤ 3, the three-term AM–GM bound, so c = 3 is the extremal PSD member and the boundary at which SOS membership fails.",
+      "The result plugs directly into the hilbert-17 framing: it is stated both pointwise (choiLam_psd_iff) and as a polynomial statement under the parent's PSD predicate (choiLamPoly_psd_iff), via an explicit eval bridge."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 195-line, 0-sorry, 0-axiom formalization that quantifies the PSD/SOS gap for the canonical homogeneous Choi–Lam form x⁴y²+y⁴z²+z⁴x²−3x²y²z²: an explicit ring-checked sum-of-squares identity for (x²+y²+z²)·CL exhibits a minimal degree-2 denominator certificate (Artin's theorem made concrete), from which PSD-ness and the sharp PSD threshold c ≤ 3 follow, in both real-function and MvPolynomial forms.",
+    "implications": "The entry gives, for a canonical homogeneous element of the PSD/SOS gap, an explicit and minimal answer to the quantitative form of Hilbert's 17th problem: degree-2 denominator suffices and is necessary. This complements the gallery's non-SOS results (Motzkin, Robinson) and the affine Motzkin threshold by supplying the genuine homogeneous member together with its certificate, and it locates the gap boundary exactly at the AM–GM coefficient c = 3."
+  },
+  "references": [
+    {
+      "title": "Hilbert's seventeenth problem — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Hilbert%27s_seventeenth_problem"
+    },
+    {
+      "title": "M. D. Choi and T. Y. Lam, Extremal positive semidefinite forms (1977)",
+      "url": "https://link.springer.com/article/10.1007/BF01420249"
+    },
+    {
+      "title": "B. Reznick, Some concrete aspects of Hilbert's 17th problem (1996)",
+      "url": "https://www.ams.org/books/conm/253/"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "hilbert-17-oq-03-oq-05",
+      "relationship": "complements",
+      "description": "Sibling (affine threshold): the sharp PSD threshold c ≤ 3 for the affine Motzkin family. This entry is the homogeneous counterpart, where a degree-2 multiplier is genuinely required because the AM–GM core has no polynomial SOS proof."
+    },
+    {
+      "proofId": "hilbert-17-oq-03-oq-03",
+      "relationship": "complements",
+      "description": "Sibling (homogeneous ternary counterexample): Robinson's PSD-but-not-SOS form on ℝ³. The Choi–Lam form here is the other canonical homogeneous ternary gap member, supplied with an explicit minimal denominator certificate."
+    },
+    {
+      "proofId": "hilbert-17",
+      "relationship": "extends",
+      "description": "Grandparent: frames Artin's theorem and the open question of quantifying the PSD/SOS gap. This entry gives an explicit, minimal (degree-2) denominator certificate for the canonical homogeneous example, plus the sharp PSD threshold."
+    }
+  ],
+  "sections": [
+    {
+      "id": "form-and-certificate",
+      "title": "The Choi–Lam Form and the Degree-2 Multiplier Certificate",
+      "startLine": 56,
+      "endLine": 85,
+      "summary": "Defines choiLam c x y z = x⁴y² + y⁴z² + z⁴x² − c·x²y²z² and proves the centerpiece multiplier_sos_identity: (x²+y²+z²)·choiLam 3 equals an explicit sum of six squares (proved by ring), hence multiplier_mul_nonneg: the product is non-negative (positivity). This is the explicit, minimal-degree denominator certificate quantifying the gap."
+    },
+    {
+      "id": "psd-and-threshold",
+      "title": "Positive-Semidefiniteness and the Sharp Threshold",
+      "startLine": 87,
+      "endLine": 161,
+      "summary": "choiLam_three_nonneg (CL is PSD on ℝ³, by dividing the identity by x²+y²+z² off the origin and handling the origin), choiLam_nonneg_of_le (c ≤ 3 ⟹ PSD via the deficit (3−c)·x²y²z² ≥ 0), choiLam_neg_of_gt (c > 3 ⟹ value 3 − c < 0 at (1,1,1)), the equivalence choiLam_psd_iff (PSD on ℝ³ ⟺ c ≤ 3), and three_is_sharp."
+    },
+    {
+      "id": "polynomial-form",
+      "title": "The Family as a Genuine MvPolynomial (Fin 3) ℝ",
+      "startLine": 163,
+      "endLine": 195,
+      "summary": "Defines choiLamPoly c : MvPolynomial (Fin 3) ℝ and the PSD predicate IsPSDMv (matching the parent's IsPositiveSemidefiniteMv), proves eval_choiLamPoly bridging the polynomial to choiLam, and transports the threshold: choiLamPoly_psd_iff (IsPSDMv (choiLamPoly c) ⟺ c ≤ 3) and choiLamPoly_three_psd (the Choi–Lam form is PSD)."
+    }
+  ]
+}

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-module-header",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 38 },
+    "title": "Module Header: Reciprocity and the Supplementary Laws",
+    "content": "The **Jacobi symbol** $J(a \\mid b)$ (with $b$ odd) obeys **quadratic reciprocity** $J(a\\mid b) = (-1)^{\\frac{a-1}{2}\\frac{b-1}{2}} J(b\\mid a)$ and the two **supplementary laws** for $-1$ and $2$, exactly as the Legendre symbol does — even though $b$ need not be prime. Mathlib provides reciprocity directly and the supplementary laws in *character* form ($J(-1\\mid b) = \\chi_4(b)$, $J(2\\mid b) = \\chi_8(b)$). This entry derives the classical **explicit power forms** $J(-1\\mid b) = (-1)^{(b-1)/2}$ and $J(2\\mid b) = (-1)^{(b^2-1)/8}$; the second is a genuine residue computation on $b \\bmod 8$.",
+    "mathContext": "$J(a\\mid b)=(-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}J(b\\mid a)$, $J(-1\\mid b)=(-1)^{\\frac{b-1}{2}}$, $J(2\\mid b)=(-1)^{\\frac{b^2-1}{8}}$.",
+    "significance": "context",
+    "relatedConcepts": ["quadratic reciprocity", "supplementary laws", "Legendre symbol", "quadratic characters χ₄, χ₈"],
+    "prerequisites": ["Jacobi symbol", "Gauss reciprocity for primes", "odd moduli"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-reciprocity",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 40, "endLine": 53 },
+    "title": "The Law of Quadratic Reciprocity",
+    "content": "`jacobi_quadratic_reciprocity`: for odd $a, b$, $J(a\\mid b) = (-1)^{(a/2)(b/2)} J(b\\mid a)$ (for odd $n$, $n/2 = (n-1)/2$). The residue-class corollaries `jacobi_reciprocity_one_mod_four` ($a \\equiv 1 \\bmod 4 \\Rightarrow J(a\\mid b) = J(b\\mid a)$) and `jacobi_reciprocity_three_mod_four` ($a \\equiv b \\equiv 3 \\bmod 4 \\Rightarrow J(a\\mid b) = -J(b\\mid a)$) record the two sign regimes. These are restatements of Mathlib's `jacobiSym.quadratic_reciprocity` and its mod-4 specializations.",
+    "mathContext": "The flip sign $(-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}$ is itself bimultiplicative, which is why reciprocity survives composite $b$.",
+    "significance": "core",
+    "relatedConcepts": ["quadratic reciprocity", "qrSign", "residue classes mod 4"],
+    "prerequisites": ["Legendre reciprocity", "bimultiplicativity of the Jacobi symbol"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-supp1",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 55, "endLine": 66 },
+    "title": "First Supplementary Law: J(−1|b) = (−1)^((b−1)/2)",
+    "content": "`jacobi_at_neg_one_pow`: for odd $b$, $J(-1\\mid b) = (-1)^{(b-1)/2}$ — so $J(-1\\mid b) = 1$ iff $b \\equiv 1 \\pmod 4$. The proof rewrites $J(-1\\mid b) = \\chi_4(b)$ (`jacobiSym.at_neg_one`), then $\\chi_4(b) = (-1)^{b/2}$ (`ZMod.χ₄_eq_neg_one_pow`), and closes with $b/2 = (b-1)/2$ for odd $b$ (`omega`).",
+    "mathContext": "$J(-1\\mid b)=\\chi_4(b)=(-1)^{(b-1)/2}$.",
+    "significance": "core",
+    "relatedConcepts": ["first supplementary law", "character χ₄", "residue mod 4"],
+    "prerequisites": ["jacobiSym.at_neg_one", "ZMod.χ₄_eq_neg_one_pow"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-supp2",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 68, "endLine": 117 },
+    "title": "Second Supplementary Law: J(2|b) = (−1)^((b²−1)/8)",
+    "content": "`jacobi_at_two_pow` (the substantive result): for odd $b$, $J(2\\mid b) = (-1)^{(b^2-1)/8}$ — so $J(2\\mid b) = 1$ iff $b \\equiv \\pm 1 \\pmod 8$. Mathlib gives only the character form $J(2\\mid b) = \\chi_8(b)$; the bridge is proved here from scratch. Writing $b = 8q + r$ with $r = b \\bmod 8 \\in \\{1,3,5,7\\}$, one has $b^2 - 1 = 8(8q^2 + 2qr) + (r^2-1)$ with $8 \\mid (r^2-1)$, so the parity of the exponent $(b^2-1)/8$ equals that of $(r^2-1)/8$ — even for $r \\in \\{1,7\\}$, odd for $r \\in \\{3,5\\}$. Each of the four cases is discharged by `omega` (abstracting $q\\cdot q$ as an opaque atom so division by 8 stays linear) together with `pow_mul`/`pow_succ`.",
+    "mathContext": "Exponent parity is $b\\bmod 8$–periodic: $(b^2-1)/8 \\equiv (r^2-1)/8 \\pmod 2$ for $r = b \\bmod 8$.",
+    "significance": "core",
+    "relatedConcepts": ["second supplementary law", "character χ₈", "residue mod 8", "parity of (b²−1)/8"],
+    "prerequisites": ["jacobiSym.at_two", "ZMod.χ₈_nat_eq_if_mod_eight", "omega over Nat division"]
+  },
+  {
+    "id": "jacobi-symbol-oq-01-oq-01-worked",
+    "proofId": "jacobi-symbol-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 119, "endLine": 132 },
+    "title": "A Worked Evaluation by Reciprocity",
+    "content": "`jacobi_five_twentyone_by_reciprocity`: $J(5\\mid 21) = 1$, obtained by *flipping* — since $5 \\equiv 1 \\pmod 4$, $J(5\\mid 21) = J(21\\mid 5)$ — and then reducing $21 \\equiv 1 \\pmod 5$, never factoring $21 = 3\\cdot 7$. This is the algorithmic payoff of reciprocity. `jacobi_five_twentyone_direct` cross-checks the value $1$ via the prime factorization. `norm_num`'s Jacobi-symbol extension automates the whole descent; the explicit flip exhibits the single reciprocity step it performs.",
+    "mathContext": "$J(5\\mid21) = J(21\\mid5) = J(1\\mid5) = 1$ — factorization-free.",
+    "significance": "illustration",
+    "relatedConcepts": ["reciprocity descent", "Solovay–Strassen primality test", "factorization-free evaluation"],
+    "prerequisites": ["jacobi_reciprocity_one_mod_four", "norm_num Jacobi extension"]
+  }
+]

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-01/meta.json
@@ -1,0 +1,225 @@
+{
+  "id": "jacobi-symbol-oq-01-oq-01",
+  "title": "Quadratic Reciprocity for the Jacobi Symbol, with Explicit Power-Form Supplementary Laws",
+  "slug": "jacobi-symbol-oq-01-oq-01",
+  "description": "The Jacobi symbol J(a|b) (b odd) obeys quadratic reciprocity and two supplementary laws exactly as the Legendre symbol does, even for composite b. This entry packages the reciprocity law J(a|b) = (−1)^((a−1)/2·(b−1)/2)·J(b|a) with its residue-class corollaries, and derives the classical EXPLICIT power forms of both supplementary laws: J(−1|b) = (−1)^((b−1)/2) and J(2|b) = (−1)^((b²−1)/8). Mathlib provides reciprocity directly and the supplementary laws in character form (χ₄ b, χ₈ b); the mathematical content added here is the elementary bridge to the textbook power forms — in particular the χ₈ → (−1)^((b²−1)/8) step, a genuine residue computation on b mod 8. A worked flip evaluates J(5|21) without factoring. 7 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_symbol",
+    "date": "Carl Gustav Jacob Jacobi, 1837",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "supplementary-laws",
+      "modular-arithmetic",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/JacobiSymbolOQ0101.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 7 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, confirmed by #print axioms, which do not count). The concrete value J(5|21) = 1 is proved by the norm_num Legendre-symbol extension (a kernel-checked proof) — no native_decide, so no Lean.ofReduceBool.",
+    "originalContributions": [
+      "jacobi_at_two_pow (the substantive result): the SECOND supplementary law in explicit power form, J(2|b) = (−1)^((b²−1)/8) for odd b. Mathlib only provides J(2|b) = χ₈ b (character form). The bridge χ₈ b = (−1)^((b²−1)/8) is proved here from first principles: writing b = 8q + r with r = b mod 8, one shows b² − 1 = 8(8q² + 2qr) + (r² − 1) with 8 ∣ (r² − 1), so the parity of the exponent (b²−1)/8 equals that of (r²−1)/8 — even iff r ∈ {1,7}. The four residue cases are discharged by omega (abstracting q*q as an opaque atom so division-by-8 stays linear) and pow_mul/pow_succ. This is the genuinely original, non-wrapping content.",
+      "jacobi_at_neg_one_pow: the FIRST supplementary law in explicit power form, J(−1|b) = (−1)^((b−1)/2) for odd b, bridged from Mathlib's character form J(−1|b) = χ₄ b via ZMod.χ₄_eq_neg_one_pow and the identity b/2 = (b−1)/2 for odd b.",
+      "jacobi_quadratic_reciprocity, jacobi_reciprocity_one_mod_four, jacobi_reciprocity_three_mod_four: the reciprocity law and its clean residue-class corollaries — one-line re-exports of Mathlib's jacobiSym.quadratic_reciprocity and its mod-4 specializations; packaging, not independent proof.",
+      "jacobi_five_twentyone_by_reciprocity: a worked evaluation exhibiting the reciprocity FLIP (5 ≡ 1 mod 4 ⟹ J(5|21) = J(21|5)) that lets the symbol be computed without factoring 21 = 3·7; cross-checked against the direct value (jacobi_five_twentyone_direct).",
+      "Resolves the first open question posed by jacobi-symbol-oq-01: 'Formalize quadratic reciprocity for the Jacobi symbol itself and the supplementary laws for −1 and 2.'"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "jacobiSym.quadratic_reciprocity",
+        "description": "For odd a, b: J(a|b) = (−1)^((a/2)·(b/2))·J(b|a). jacobi_quadratic_reciprocity is this lemma.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.quadratic_reciprocity_one_mod_four / quadratic_reciprocity_three_mod_four",
+        "description": "Residue-class corollaries: a ≡ 1 (mod 4) ⟹ J(a|b) = J(b|a); a ≡ b ≡ 3 (mod 4) ⟹ J(a|b) = −J(b|a).",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.at_neg_one",
+        "description": "J(−1|b) = χ₄ b for odd b (character form of the first supplementary law). Bridged to (−1)^((b−1)/2) in jacobi_at_neg_one_pow.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.at_two",
+        "description": "J(2|b) = χ₈ b for odd b (character form of the second supplementary law). Bridged to (−1)^((b²−1)/8) in jacobi_at_two_pow.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "ZMod.χ₄_eq_neg_one_pow / ZMod.χ₈_nat_eq_if_mod_eight",
+        "description": "Explicit evaluations of the quadratic characters: χ₄ n = (−1)^(n/2) for odd n; χ₈ n = +1 for n ≡ ±1 (mod 8) and −1 for n ≡ ±3 (mod 8). The raw material for the power-form bridges.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.ZModChar"
+      }
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 132,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Gauss's law of quadratic reciprocity, together with the two supplementary laws for −1 and 2, is the cornerstone of elementary number theory. Jacobi's 1837 extension of the Legendre symbol to composite odd moduli is what makes reciprocity ALGORITHMIC: because J(a|b) obeys the same reciprocity and supplementary laws — yet requires no factorization of b — one can evaluate a Legendre symbol by repeatedly flipping arguments and reducing modulo, the recursion underlying the Solovay–Strassen primality test and fast Legendre-symbol computation.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01, from jacobi-symbol-oq-01)**: Formalize quadratic reciprocity for the Jacobi symbol itself and the supplementary laws for −1 and 2.\n\n**Formalized**: the reciprocity law J(a|b) = (−1)^((a−1)/2·(b−1)/2)·J(b|a) with its mod-4 corollaries; both supplementary laws in explicit power form, J(−1|b) = (−1)^((b−1)/2) and J(2|b) = (−1)^((b²−1)/8); and a worked reciprocity flip computing J(5|21) = 1 without factoring 21.",
+    "text": "A 132-line formalization built on Mathlib's jacobiSym and the quadratic characters χ₄, χ₈. The reciprocity theorems are clean restatements of Mathlib's jacobiSym.quadratic_reciprocity and its residue-class specializations. The two supplementary laws are the focus: Mathlib supplies them only in character form (J(−1|b) = χ₄ b, J(2|b) = χ₈ b), and this entry derives the classical EXPLICIT power forms. The first, J(−1|b) = (−1)^((b−1)/2), follows from ZMod.χ₄_eq_neg_one_pow. The second, J(2|b) = (−1)^((b²−1)/8), is the substantive step: an elementary residue computation showing the exponent's parity is b mod 8–periodic, carried out from scratch over the four odd residues. All 7 theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**Reciprocity**: jacobi_quadratic_reciprocity / jacobi_reciprocity_one_mod_four / jacobi_reciprocity_three_mod_four are restatements of jacobiSym.quadratic_reciprocity and its mod-4 corollaries.\n\n**First supplementary law**: jacobi_at_neg_one_pow rewrites J(−1|b) = χ₄ b (jacobiSym.at_neg_one), then χ₄ b = (−1)^(b/2) (ZMod.χ₄_eq_neg_one_pow), then b/2 = (b−1)/2 for odd b (omega).\n\n**Second supplementary law** (the substantive bridge): jacobi_at_two_pow rewrites J(2|b) = χ₈ b (jacobiSym.at_two) and expands χ₈ b by residue mod 8 (ZMod.χ₈_nat_eq_if_mod_eight). Setting q = b/8 and casing on b mod 8 ∈ {1,3,5,7}, it establishes b² as 64q² + (linear in q) + r² and then, treating q*q as an opaque atom so that division by 8 stays within linear arithmetic, derives (b²−1)/8 = 2·(…) [+1] by omega — even exponent for r ∈ {1,7}, odd for r ∈ {3,5} — and finishes each case with pow_mul/pow_succ and norm_num.\n\n**Worked flip**: jacobi_five_twentyone_by_reciprocity applies the 1-mod-4 corollary to turn J(5|21) into J(21|5), evaluated by norm_num after reducing 21 ≡ 1 (mod 5) — no factorization of 21; jacobi_five_twentyone_direct cross-checks the value.",
+    "keyInsights": [
+      "**Reciprocity survives the loss of primality**: even though b need not be prime, J(a|b) flips against J(b|a) with the very same (−1)^((a−1)/2·(b−1)/2) sign as the Legendre symbol — because the sign is itself bimultiplicative (Mathlib's qrSign).",
+      "**The second supplementary law is the interesting one**: J(2|b) = (−1)^((b²−1)/8). The exponent (b²−1)/8 is always an integer for odd b, and its PARITY depends only on b mod 8: even for b ≡ ±1, odd for b ≡ ±3. The clean way to see this is b² − 1 = 8(8q² + 2qr) + (r²−1) with 8 ∣ (r²−1), so the parity reduces to that of (r²−1)/8 over r = b mod 8 ∈ {1,3,5,7}.",
+      "**Bridging characters to powers of −1 is real work**: Mathlib deliberately states the supplementary laws via the quadratic characters χ₄, χ₈ (which generalize cleanly), not via (−1)-powers. Recovering the textbook power forms is the formalization content here, not a re-export.",
+      "**omega + opaque nonlinear atoms**: the residue computation never needs nonlinear reasoning — once b² is expanded against a fixed residue and q*q is abstracted as a single variable, the exponent identity (including division by 8) is purely linear and omega closes it.",
+      "**Why this matters computationally**: with reciprocity plus the two supplementary laws (handling the factors of 2 and the sign), a Jacobi symbol is evaluated by a Euclidean-style descent on the arguments — no factorization — which is exactly what jacobi_five_twentyone_by_reciprocity illustrates and what powers Solovay–Strassen."
+    ],
+    "prerequisites": [
+      "The Legendre symbol (a|p) and Gauss's quadratic reciprocity for primes",
+      "The Jacobi symbol jacobiSym a b = ∏_{p∣b} (a|p) over the prime factors of odd b (Mathlib jacobiSym), and its bimultiplicativity (see jacobi-symbol-oq-01)",
+      "The quadratic characters χ₄ : (ZMod 4)ˣ → ℤ and χ₈ : (ZMod 8)ˣ → ℤ and their explicit values",
+      "jacobiSym.quadratic_reciprocity, jacobiSym.at_neg_one, jacobiSym.at_two; ZMod.χ₄_eq_neg_one_pow, ZMod.χ₈_nat_eq_if_mod_eight",
+      "Nat division/modulus arithmetic and the omega decision procedure"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Docstring stating the reciprocity law and the two supplementary laws in both character form (Mathlib's χ₄ b, χ₈ b) and the classical explicit power forms derived here, and explaining that the χ₈ → (−1)^((b²−1)/8) bridge is the substantive content. Fully verified (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "$J(a\\mid b)=(-1)^{\\frac{a-1}{2}\\frac{b-1}{2}}J(b\\mid a)$, $J(-1\\mid b)=(-1)^{\\frac{b-1}{2}}$, $J(2\\mid b)=(-1)^{\\frac{b^2-1}{8}}$."
+    },
+    {
+      "id": "sec-reciprocity",
+      "title": "The Law of Quadratic Reciprocity",
+      "startLine": 40,
+      "endLine": 53,
+      "summary": "jacobi_quadratic_reciprocity (the (−1)-power form) and the residue-class corollaries jacobi_reciprocity_one_mod_four (a ≡ 1 mod 4 ⟹ symbols agree) and jacobi_reciprocity_three_mod_four (a ≡ b ≡ 3 mod 4 ⟹ symbols opposite). Restatements of Mathlib's jacobiSym reciprocity API.",
+      "mathContext": "$a\\equiv1\\!\\pmod 4\\Rightarrow J(a\\mid b)=J(b\\mid a)$; $a\\equiv b\\equiv3\\!\\pmod4\\Rightarrow J(a\\mid b)=-J(b\\mid a)$."
+    },
+    {
+      "id": "sec-supp1",
+      "title": "First Supplementary Law: J(−1|b)",
+      "startLine": 55,
+      "endLine": 66,
+      "summary": "jacobi_at_neg_one_pow: J(−1|b) = (−1)^((b−1)/2) for odd b, bridged from Mathlib's character form J(−1|b) = χ₄ b via ZMod.χ₄_eq_neg_one_pow and the odd-b identity b/2 = (b−1)/2.",
+      "mathContext": "$J(-1\\mid b)=\\chi_4(b)=(-1)^{(b-1)/2}$."
+    },
+    {
+      "id": "sec-supp2",
+      "title": "Second Supplementary Law: J(2|b) (the substantive bridge)",
+      "startLine": 68,
+      "endLine": 117,
+      "summary": "jacobi_at_two_pow: J(2|b) = (−1)^((b²−1)/8) for odd b. Starting from J(2|b) = χ₈ b, the proof expands χ₈ b by b mod 8 and, casing on the four odd residues, derives the parity of (b²−1)/8 from first principles — b² − 1 = 8(8q²+2qr) + (r²−1) with 8 ∣ (r²−1) — using omega (with q*q abstracted) and pow_mul/pow_succ.",
+      "mathContext": "$J(2\\mid b)=\\chi_8(b)=(-1)^{(b^2-1)/8}$; exponent parity is $b\\bmod 8$–periodic."
+    },
+    {
+      "id": "sec-worked",
+      "title": "A Worked Evaluation by Reciprocity",
+      "startLine": 119,
+      "endLine": 132,
+      "summary": "jacobi_five_twentyone_by_reciprocity flips J(5|21) to J(21|5) (since 5 ≡ 1 mod 4) and evaluates after reducing 21 ≡ 1 (mod 5) — computing the symbol without factoring 21 = 3·7. jacobi_five_twentyone_direct cross-checks the value 1.",
+      "mathContext": "$J(5\\mid21)=J(21\\mid5)=J(1\\mid5)=1$, no factorization of $21$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "jacobi-symbol-oq-01",
+      "relationship": "extends",
+      "description": "jacobi-symbol-oq-01 assembles the Jacobi symbol's bimultiplicativity, trichotomy, and one-sided non-residue obstruction, and explicitly poses as its first open question the formalization of quadratic reciprocity and the supplementary laws for −1 and 2. This entry resolves that question."
+    },
+    {
+      "proofId": "euler-criterion-squares-oq-01",
+      "relationship": "builds-on",
+      "description": "The Legendre-symbol reciprocity and supplementary laws (over a prime) underlie the Jacobi-symbol versions here, which are obtained by multiplying over the prime factorization of the odd modulus."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "JacobiSymbolOQ0101",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/JacobiSymbolOQ0101.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "jacobi_at_two_pow",
+      "type": "core",
+      "statement": "$b \\text{ odd} \\Rightarrow J(2 \\mid b) = (-1)^{(b^2-1)/8}$",
+      "significance": "The second supplementary law in classical explicit power form, and the substantive original content: Mathlib provides only the character form J(2|b) = χ₈ b, and the bridge χ₈ b = (−1)^((b²−1)/8) is proved here from first principles via an elementary parity computation on b mod 8.",
+      "description": "Second supplementary law, explicit power form."
+    },
+    {
+      "name": "jacobi_at_neg_one_pow",
+      "type": "core",
+      "statement": "$b \\text{ odd} \\Rightarrow J(-1 \\mid b) = (-1)^{(b-1)/2}$",
+      "significance": "The first supplementary law in explicit power form, bridged from Mathlib's character form J(−1|b) = χ₄ b.",
+      "description": "First supplementary law, explicit power form."
+    },
+    {
+      "name": "jacobi_quadratic_reciprocity",
+      "type": "core",
+      "statement": "$a, b \\text{ odd} \\Rightarrow J(a \\mid b) = (-1)^{(a/2)(b/2)} J(b \\mid a)$",
+      "significance": "The headline reciprocity law for the Jacobi symbol — the same flip sign as the Legendre symbol, valid for all odd moduli.",
+      "description": "Quadratic reciprocity for the Jacobi symbol."
+    },
+    {
+      "name": "jacobi_reciprocity_one_mod_four",
+      "type": "supporting",
+      "statement": "$a \\equiv 1 \\pmod 4,\\ b \\text{ odd} \\Rightarrow J(a \\mid b) = J(b \\mid a)$",
+      "significance": "The clean residue-class corollary: when a ≡ 1 (mod 4) the flip sign is +1 and the symbols agree.",
+      "description": "Reciprocity corollary for a ≡ 1 (mod 4)."
+    },
+    {
+      "name": "jacobi_reciprocity_three_mod_four",
+      "type": "supporting",
+      "statement": "$a \\equiv b \\equiv 3 \\pmod 4 \\Rightarrow J(a \\mid b) = -J(b \\mid a)$",
+      "significance": "The other residue-class corollary: two arguments ≡ 3 (mod 4) flip with a sign change.",
+      "description": "Reciprocity corollary for a ≡ b ≡ 3 (mod 4)."
+    },
+    {
+      "name": "jacobi_five_twentyone_by_reciprocity",
+      "type": "supporting",
+      "statement": "$J(5 \\mid 21) = 1$ via the flip $J(5\\mid21) = J(21\\mid5)$",
+      "significance": "Illustrates the algorithmic payoff: reciprocity evaluates the symbol by flipping and reducing, never factoring the modulus 21 = 3·7.",
+      "description": "Worked evaluation by reciprocity."
+    },
+    {
+      "name": "jacobi_five_twentyone_direct",
+      "type": "supporting",
+      "statement": "$J(5 \\mid 21) = 1$",
+      "significance": "Cross-check of the worked evaluation against the direct value (via the prime factorization of 21).",
+      "description": "Direct cross-check of J(5|21)."
+    }
+  ],
+  "references": [
+    {
+      "text": "Jacobi, C. G. J. (1837). Über die Kreisteilung und ihre Anwendung auf die Zahlentheorie. Introduction of the Jacobi symbol.",
+      "url": "https://en.wikipedia.org/wiki/Jacobi_symbol"
+    },
+    {
+      "text": "Ireland, K. & Rosen, M. A Classical Introduction to Modern Number Theory. Quadratic reciprocity and the supplementary laws for the Jacobi symbol.",
+      "url": "https://en.wikipedia.org/wiki/Quadratic_reciprocity"
+    },
+    {
+      "text": "Mathlib4: jacobiSym.quadratic_reciprocity, jacobiSym.at_neg_one, jacobiSym.at_two (NumberTheory/LegendreSymbol/JacobiSymbol.lean); ZMod.χ₄_eq_neg_one_pow, ZMod.χ₈_nat_eq_if_mod_eight (NumberTheory/LegendreSymbol/ZModChar.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Resolves the first open question of jacobi-symbol-oq-01 by formalizing quadratic reciprocity for the Jacobi symbol and both supplementary laws. The reciprocity theorems are restatements of Mathlib's jacobiSym API; the original content is the bridge from Mathlib's character forms to the classical explicit power forms J(−1|b) = (−1)^((b−1)/2) and — the substantive step — J(2|b) = (−1)^((b²−1)/8), the latter proved by an elementary parity computation on b mod 8. A worked flip evaluates J(5|21) without factoring. All 7 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Reciprocity plus the two supplementary laws turn Jacobi-symbol evaluation into a factorization-free Euclidean descent — the engine behind the Solovay–Strassen primality test and fast Legendre-symbol computation. The explicit power forms are the shape in which the supplementary laws are applied in such algorithms and in hand computation.",
+    "openQuestions": [
+      "Formalize the Solovay–Strassen Euler-witness predicate a^((b−1)/2) ≡ J(a|b) (mod b) and quantify its failure rate for composite b.",
+      "Prove the b mod 4a periodicity of J(a|b) (Mathlib's jacobiSym.mod_right') as a standalone reciprocity corollary and use it to bound the descent length of the evaluation algorithm."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds **`hilbert-17-oq-02`** — the genuine *homogeneous* member of the PSD/SOS gap (the gallery had the affine Motzkin polynomial and Robinson's form, but not this one) together with a sharp, explicit *quantification* of the gap.

The cyclic **Choi–Lam form** (Choi–Lam, 1977)
$$\mathrm{CL}(x,y,z) = x^4y^2 + y^4z^2 + z^4x^2 - 3x^2y^2z^2$$
is positive-semidefinite on all of $\mathbb{R}^3$ yet is **not** a sum of squares of polynomials — there is no degree-6 SOS certificate, precisely because the underlying inequality $x^4y^2+y^4z^2+z^4x^2 \ge 3x^2y^2z^2$ is the three-term AM–GM, which has no polynomial SOS proof.

## The gap quantification (centerpiece)

By Artin's theorem CL is a sum of squares of *rational* functions; how complex must the certificate be? This entry answers with an explicit, `ring`-checked **degree-2 denominator**:
$$(x^2+y^2+z^2)\cdot\mathrm{CL} = (x^3y-xyz^2)^2 + (y^3z-x^2yz)^2 + (z^3x-xy^2z)^2 + \tfrac12\!\sum_{\mathrm{cyc}}(x^2y^2-y^2z^2)^2.$$
Since CL itself is not SOS, the multiplier degree **2 is minimal** — a concrete, sharp instance of Artin's theorem.

From the identity:
- `multiplier_sos_identity` — the exact identity above (`ring`).
- `choiLam_three_nonneg` — CL is PSD on $\mathbb{R}^3$ (divide by the strictly-positive multiplier off the origin; CL vanishes at the origin).
- `choiLam_psd_iff` / `choiLamPoly_psd_iff` — the family $x^4y^2+y^4z^2+z^4x^2-c\,x^2y^2z^2$ is PSD **iff** $c\le 3$, in both real-function and `MvPolynomial (Fin 3) ℝ` forms. So $c=3$ is the extremal PSD coefficient — the homogeneous analogue of the affine Motzkin threshold (sibling `hilbert-17-oq-03-oq-05`).

## Status

- **10 theorems, 3 definitions, 0 sorries, 0 axioms** (`#print axioms` → only `propext` / `Classical.choice` / `Quot.sound`; no `sorryAx`, no `native_decide`).
- The SOS identity was numerically confirmed exact (20 000 random points) before formalization.
- Non-SOS-ness of CL is the **classical Choi–Lam fact** (established for the sibling Motzkin/Robinson forms by the Gram-matrix technique) and is **cited, not re-derived** — only PSD-ness, the sharp threshold, and the multiplier-SOS identity are machine-checked here.

## Verification note

Docker was down, so verification used the documented `lake env lean` fallback. The host `.lake` is symlinked across all worktrees and was under heavy concurrent `cache unpack` contention from the agent fleet (transient "invalid header" races on half-written `.olean` files); the file compiles cleanly in a quiet window (confirmed on the final committed version). The deployer's isolated Docker build is the authoritative check.

## Files
- `proofs/Proofs/Hilbert17OQ02.lean` (195 lines)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/hilbert-17-oq-02/{meta.json,annotations.json}`