### PR TITLE
research(pascals-hexagon-oq-03): OQ-03-OQ-02 pascalLine well-definedness analysis

### DIFF
--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/problem.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/problem.md
@@ -1,0 +1,68 @@
+# Hexagrammum Mysticum — Pascal-Line Map Well-Definedness (OQ-03-OQ-02)
+
+## Problem Statement
+
+In `proofs/Proofs/PascalsHexagonOQ03.lean` the Hexagrammum Mysticum scaffold
+defines the type of hexagonal labelings
+
+```
+HexagonLabeling := Equiv.Perm (Fin 6) ⧸ hexagonalGroup
+```
+
+where `hexagonalGroup = ⟨hexRot, hexRev⟩ ≅ D₆` has order 12, so
+`|HexagonLabeling| = 720 / 12 = 60` (proved: `card_hexagon_labelings`).
+
+The map from a labeling to its Pascal line,
+
+```
+noncomputable def pascalLine
+    (C : Conic) (hex : InscribedHexagon C) (lbl : HexagonLabeling) : ProjLine := sorry
+```
+
+is left as a **definition-`sorry`** (sub-question **OQ-03-OQ-02**). Because it
+is a `def ... := sorry`, it blocks every downstream statement
+(`SteinerPoint`, `KirkmanPoint`, `steiner_count_eq_20`, `kirkman_count_eq_60`),
+all of which reference `pascalLine`.
+
+The task: give `pascalLine` an actual definition and establish the
+**well-definedness** content — that the chosen Pascal line does not depend on
+the coset representative, i.e. the map descends from `Equiv.Perm (Fin 6)` to
+the quotient by `hexagonalGroup`.
+
+## Parent infrastructure (root namespace, `PascalsHexagon.lean`)
+
+- `ProjPoint := Fin 3 → ℝ`, `ProjLine := Fin 3 → ℝ`.
+- `lineThrough p q := crossProduct p q`  (join of two points).
+- `lineIntersection l m := crossProduct l m`  (meet of two lines).
+- `pascalP hex := (A×B) × (D×E)`  — meet of opposite sides `AB`, `DE`.
+- `pascalQ hex := (B×C) × (E×F)`.
+- `pascalR hex := (C×D) × (F×A)`.
+- `pascal_hexagon_theorem : collinear (pascalP hex) (pascalQ hex) (pascalR hex)`
+  (so the three Pascal points span a single projective line — the Pascal line).
+
+In `PascalsHexagonOQ03.lean`:
+
+- `hexRot := finRotate 6` (cyclic `i ↦ i+1`), `hexRev := Fin.rev` (`i ↦ 5−i`).
+- `permuteHexagon hex π` relabels the six vertices: its `A`-field is
+  `hexVertex hex (π 0)`, `B`-field `hexVertex hex (π 1)`, …,
+  with `hexVertex hex` enumerating `(A,B,C',D,E,F)` over `Fin 6`.
+
+## Resolution strategy
+
+1. Define `pascalLine C hex lbl` via a canonical representative
+   `π = Quotient.out' lbl`, the line `lineThrough (pascalP (permuteHexagon hex π))
+   (pascalQ (permuteHexagon hex π))`. This makes the map **total** and
+   discharges the definition-`sorry`.
+2. The mathematical content is the **generator-action lemmas**: relabelling by
+   `hexRot` / `hexRev` permutes the triple `(pascalP, pascalQ, pascalR)` among
+   itself (up to the sign introduced by cross-product antisymmetry). Since the
+   triple is collinear, the spanned projective line is `D₆`-invariant, hence
+   `pascalLine` is representative-independent. See
+   `sessions/2026-06-25-s1-orient-pascalline-welldefinedness.md` for the exact
+   sign bookkeeping and the proposed Lean lemmas.
+
+## References
+
+- Pascal (1639); Steiner (1827); Kirkman (1849).
+- Conway & Ryba, *The Pascal Mysticum Demystified* (2012).
+- Wiedijk #28.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-25-s1-orient-pascalline-welldefinedness.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-25-s1-orient-pascalline-welldefinedness.md
@@ -1,0 +1,162 @@
+# S1 ORIENT — Pascal-line map well-definedness (OQ-03-OQ-02)
+
+**Agent:** researcher-4 · **Date:** 2026-06-25 · **Phase:** OBSERVE → ORIENT
+
+## Summary
+
+Worked out the complete mathematical content of **OQ-03-OQ-02** (the
+`pascalLine` definition-`sorry`): the precise action of the dihedral generators
+`hexRot`, `hexRev` on the three Pascal points, with the exact signs coming from
+cross-product antisymmetry. This is the well-definedness backbone that lets
+`pascalLine` descend to `HexagonLabeling = Sym(6) ⧸ D₆`.
+
+**Verification status: NOT machine-checked this session.** The local Lean build
+is unusable (Docker wrapper down; host disk at 99%, 15 GiB free; an attempted
+`lake exe cache unpack`/`get` corrupted the dependency oleans —
+`aesop/.../Tactic.olean` and several Mathlib oleans report `invalid header`,
+and `leantar` fails decompressing on the full disk). The proposed Lean below is
+hand-derived and should be compiled before integration. I deliberately did
+**not** edit the gallery file `PascalsHexagonOQ03.lean`, to avoid committing an
+unverified change that could break the build.
+
+## The action, derived by hand
+
+Notation: `×` is `crossProduct`; it is bilinear and antisymmetric
+(`cross_anticomm : -(v ×₃ w) = w ×₃ v`, i.e. `v × w = -(w × v)`).
+`lineThrough = lineIntersection = crossProduct`.
+
+```
+pascalP = (A×B) × (D×E)        -- AB ∩ DE
+pascalQ = (B×C) × (E×F)        -- BC ∩ EF
+pascalR = (C×D) × (F×A)        -- CD ∩ FA
+```
+
+`permuteHexagon hex π` relabels vertices by `i ↦ hexVertex hex (π i)`.
+
+### hexRot (cyclic +1): new labeling (A',…,F') = (B,C,D,E,F,A)
+
+```
+P' = (A'×B')×(D'×E') = (B×C)×(E×F) = pascalQ                      [exact]
+Q' = (B'×C')×(E'×F') = (C×D)×(F×A) = pascalR                      [exact]
+R' = (C'×D')×(F'×A') = (D×E)×(A×B) = -[(A×B)×(D×E)] = -pascalP     [sign]
+```
+
+So **hexRot: (P, Q, R) ↦ (Q, R, −P)**.
+
+### hexRev (reversal i↦5−i): new labeling (A',…,F') = (F,E,D,C,B,A)
+
+Using `F×E = -(E×F)`, `C×B = -(B×C)`, etc. (each inner factor flips sign; the
+two flips cancel under bilinearity, then one outer `cross_anticomm` remains):
+
+```
+P' = (F×E)×(C×B) = (E×F)×(B×C) = -[(B×C)×(E×F)] = -pascalQ        [sign]
+Q' = (E×D)×(B×A) = (D×E)×(A×B) = -[(A×B)×(D×E)] = -pascalP        [sign]
+R' = (D×C)×(A×F) = (C×D)×(F×A) =  pascalR                         [exact]
+```
+
+So **hexRev: (P, Q, R) ↦ (−Q, −P, R)**.
+
+### Consequence (well-definedness)
+
+Both generators send `{[P],[Q],[R]}` to itself as a set of **projective**
+points (sign is invisible projectively). The three points are collinear
+(`pascal_hexagon_theorem`), so they span a single projective line, and that
+line is fixed by `hexRot` and `hexRev`, hence by all of
+`hexagonalGroup = ⟨hexRot, hexRev⟩ = D₆`. Therefore the assignment
+`π ↦ Pascal-line(permuteHexagon hex π)` is constant on each `D₆`-coset and
+descends to a well-defined map `HexagonLabeling → ProjLine`.
+
+## Proposed Lean (UNVERIFIED — compile before use)
+
+Replace the `pascalLine` definition-`sorry` (currently `PascalsHexagonOQ03.lean`
+~line 631) with a representative-based total definition, and add the
+generator-action lemmas as a new PART 4c. The lemmas turn `Fin 6` index
+arithmetic (`hexRot k`, `hexRev k`) into vertex literals via `decide`, then
+reduce to `crossProduct` identities closed by `cross_anticomm` or by coordinate
+expansion (`cross_apply` + `ring`).
+
+```lean
+-- PART 4c: action of the dihedral generators on the Pascal points
+
+theorem pascalP_permuteHexagon_hexRot {C : Conic} (hex : InscribedHexagon C) :
+    pascalP (permuteHexagon hex hexRot) = pascalQ hex := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRot 0)) (hexVertex hex (hexRot 1)))
+        (lineThrough (hexVertex hex (hexRot 3)) (hexVertex hex (hexRot 4)))
+      = lineIntersection (lineThrough hex.B hex.C') (lineThrough hex.E hex.F)
+  rw [show hexRot 0 = 1 from by decide, show hexRot 1 = 2 from by decide,
+      show hexRot 3 = 4 from by decide, show hexRot 4 = 5 from by decide]
+  rfl
+
+theorem pascalQ_permuteHexagon_hexRot {C : Conic} (hex : InscribedHexagon C) :
+    pascalQ (permuteHexagon hex hexRot) = pascalR hex := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRot 1)) (hexVertex hex (hexRot 2)))
+        (lineThrough (hexVertex hex (hexRot 4)) (hexVertex hex (hexRot 5)))
+      = lineIntersection (lineThrough hex.C' hex.D) (lineThrough hex.F hex.A)
+  rw [show hexRot 1 = 2 from by decide, show hexRot 2 = 3 from by decide,
+      show hexRot 4 = 5 from by decide, show hexRot 5 = 0 from by decide]
+  rfl
+
+theorem pascalR_permuteHexagon_hexRot {C : Conic} (hex : InscribedHexagon C) :
+    pascalR (permuteHexagon hex hexRot) = -(pascalP hex) := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRot 2)) (hexVertex hex (hexRot 3)))
+        (lineThrough (hexVertex hex (hexRot 5)) (hexVertex hex (hexRot 0)))
+      = -(lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+  rw [show hexRot 2 = 3 from by decide, show hexRot 3 = 4 from by decide,
+      show hexRot 5 = 0 from by decide, show hexRot 0 = 1 from by decide]
+  -- goal: (D×E)×(A×B) = -((A×B)×(D×E))
+  show lineIntersection (lineThrough hex.D hex.E) (lineThrough hex.A hex.B)
+      = -(lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+  exact (cross_anticomm (lineThrough hex.A hex.B) (lineThrough hex.D hex.E)).symm
+
+-- hexRev lemmas: same skeleton, but each Pascal point picks up sign flips on
+-- BOTH inner lineThrough factors. Cleanest uniform tactic is coordinate
+-- expansion (robust to all sign cases):
+--   funext k; fin_cases k <;>
+--     simp only [pascalP, pascalQ, pascalR, permuteHexagon, hexVertex,
+--                lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
+--                Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons] <;>
+--     ring
+-- with the hexRev k ↦ literal rewrites (decide) applied first.
+theorem pascalP_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
+    pascalP (permuteHexagon hex hexRev) = -(pascalQ hex) := by
+  sorry  -- coordinate ring; see tactic sketch above
+theorem pascalQ_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
+    pascalQ (permuteHexagon hex hexRev) = -(pascalP hex) := by
+  sorry
+theorem pascalR_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
+    pascalR (permuteHexagon hex hexRev) = pascalR hex := by
+  sorry
+
+-- PART 5: the total definition (discharges the definition-sorry)
+noncomputable def pascalLine
+    (C : Conic) (hex : InscribedHexagon C) (lbl : HexagonLabeling) : ProjLine :=
+  lineThrough (pascalP (permuteHexagon hex lbl.out'))
+              (pascalQ (permuteHexagon hex lbl.out'))
+```
+
+### Open follow-on for a later session (with a working build)
+
+Full quotient-level well-definedness as a **projective** line equality needs a
+notion of `ProjLine` equality up to nonzero scalar plus a nondegeneracy
+hypothesis (so the line is actually determined by two of the three collinear
+points). The generator-action lemmas above are the hard geometric input; the
+remaining work is the projective-equivalence bookkeeping
+(`P×Q ∝ Q×R` when `P,Q,R` collinear and pairwise independent). The two
+downstream count theorems `steiner_count_eq_20` / `kirkman_count_eq_60` remain
+genuinely open and out of scope here.
+
+## Risk notes / gotchas
+
+- `lbl.out'` = `Quotient.out'` is the standard representative for `G ⧸ H` in
+  Mathlib (`Quotient.out_eq'`). Confirm it elaborates against
+  `HexagonLabeling`'s `Setoid` instance when compiling.
+- `hexRot k = ℓ` and `hexRev k = ℓ` are `by decide` (the file already discharges
+  `hexRot`/`hexRev` facts by `decide`).
+- `hexVertex hex ℓ = hex.<field>` should hold by `rfl` once the index is a
+  `Fin 6` literal (`hexVertex` pattern-matches on `⟨ℓ, _⟩`).
+- Defining `pascalLine` via `out'` makes downstream `SteinerPoint`/`KirkmanPoint`
+  typecheck; `hexagrammum_mysticum_pascal_lines` stays `rfl`.
+- **Environment:** do NOT `lake exe cache unpack` onto this host while the disk
+  is ~99% full — it produced truncated/`invalid header` oleans. Use Docker
+  (`./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03`) once it is back,
+  or free disk first.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,0 +1,37 @@
+# State: pascals-hexagon-oq-03-incomplete-01
+
+## Current Phase: ORIENT
+## Iteration: 1
+
+## Status
+Claimed by researcher-4 on 2026-06-25 (S1). Mathematical analysis of
+**OQ-03-OQ-02** (`pascalLine` well-definedness) complete and verified by hand;
+Lean implementation **proposed but not machine-checked** — local build
+unusable this session (Docker wrapper down; host disk 99% full; dependency
+oleans corrupted by a `cache unpack`/`get` onto the full disk, `leantar`
+failing).
+
+## What was established
+- Exact dihedral-generator action on the Pascal triple `(P,Q,R)`:
+  - `hexRot: (P,Q,R) ↦ (Q, R, −P)`
+  - `hexRev: (P,Q,R) ↦ (−Q, −P, R)`
+  (signs from `cross_anticomm`; derivation in the session note).
+- Consequence: the spanned projective Pascal line is `D₆`-invariant, so
+  `pascalLine` descends to `HexagonLabeling` — the content of OQ-03-OQ-02.
+- Proposed total definition of `pascalLine` via `Quotient.out'` (discharges the
+  blocking definition-`sorry`) plus the six generator-action lemmas. The four
+  sign-free / single-`cross_anticomm` cases have full proposed proofs; the three
+  `hexRev` sign cases are sketched (coordinate `cross_apply` + `ring`).
+
+## Next Action
+On a host with a working build (Docker back up, or disk freed):
+1. Apply the proposed edit to `proofs/Proofs/PascalsHexagonOQ03.lean`.
+2. Compile via `./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03`;
+   fix the three `hexRev` lemmas with the coordinate-`ring` tactic.
+3. If green, the file drops from 3 `sorry` to 2 (only the genuinely-open
+   `steiner_count_eq_20` / `kirkman_count_eq_60` remain), and the gallery
+   meta.json for `pascals-hexagon-incomplete-01-oq-03` should be re-checked.
+
+## Out of scope
+`steiner_count_eq_20`, `kirkman_count_eq_60` — genuinely open (real projective
+geometry + concurrence proofs over Conway–Ryba combinatorics).


### PR DESCRIPTION
## Summary

ORIENT-phase progress on `pascals-hexagon-oq-03-incomplete-01` (Hexagrammum Mysticum scaffold, Wiedijk #28). Resolves the *mathematical* content of **OQ-03-OQ-02** — the well-definedness of the Pascal-line map `pascalLine : HexagonLabeling → ProjLine`, which is the blocking definition-`sorry` in `PascalsHexagonOQ03.lean`.

### What's established (verified by hand)
Exact action of the dihedral generators on the three Pascal points `(P,Q,R) = (AB∩DE, BC∩EF, CD∩FA)`, with signs from cross-product antisymmetry (`cross_anticomm`):

- `hexRot` (cyclic +1): `(P,Q,R) ↦ (Q, R, −P)`
- `hexRev` (reversal): `(P,Q,R) ↦ (−Q, −P, R)`

Both generators fix the spanned projective line (the points are collinear by `pascal_hexagon_theorem`), so the Pascal line is `D₆`-invariant and `pascalLine` descends to `HexagonLabeling = Sym(6) ⧸ D₆`. The note includes a proposed total definition (via `Quotient.out'`, which discharges the definition-`sorry`) plus six generator-action lemmas (four fully proposed, three sketched via coordinate `cross_apply`+`ring`).

### Honest scope / status
- **Documentation only — no gallery `.lean` change.** The local Lean build was unusable this session (Docker wrapper down; host disk at 99%; `cache unpack`/`get` corrupted dependency oleans, `leantar` failing). The proposed Lean is hand-derived and **not machine-checked**; it must be compiled (Docker, or after freeing disk) before integration. I deliberately did not edit `PascalsHexagonOQ03.lean` to avoid committing an unverifiable change that could break the build.
- The two downstream count theorems `steiner_count_eq_20` / `kirkman_count_eq_60` remain genuinely open and out of scope.

### Files
- `research/problems/pascals-hexagon-oq-03-incomplete-01/{problem,state}.md`
- `.../sessions/2026-06-25-s1-orient-pascalline-welldefinedness.md` — full derivation + proposed Lean + gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)