### PR TITLE
audit: correct theoremCount 9→8 (binomial-oq0303, factor-remainder-oq010102)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-03/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified against Lean v4.26.0 + Mathlib. Every theorem depends only on [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool (no native_decide; the Fin 3 example uses `decide` for ≠).",
     "lineCount": 246,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "originalContributions": [
       "multinomial_aggregate_pgf: the aggregation/lumping property — for any block A ⊆ s, E[t^{X_A}] = Σ_k P(X=k)·t^{Σ_{i∈A} k(i)} = (p_A·t + (1−p_A))^n, the Binomial(n, p_A) generating function. This is the multinomial family's defining closure property and the genuine generalization of the single-coordinate marginal.",
@@ -69,7 +69,7 @@
     "namespace": "BinomialTheoremOQ03OQ03",
     "lineCount": 246,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 1,
     "path": "Proofs/BinomialTheoremOQ03OQ03.lean",
     "sorries": 0

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01-oq-02/meta.json
@@ -75,7 +75,7 @@
     "axiomCount": 0,
     "lineCount": 205,
     "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide). The base ring is ℚ throughout, used so that the generalized binomial coefficient Ring.choose and the division by m! in the Newton basis are available; #print axioms reports only [propext, Classical.choice, Quot.sound]. The Taylor → Newton change of basis and the diagonal leading-coefficient corollary do not use division and would generalize to any commutative ring, but are stated over ℚ for uniformity with the interpolation theorems.",
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 0,
     "prerequisites": [
       "The forward difference operator Δ and its iterates (Mathlib.Algebra.Group.ForwardDiff)",
@@ -164,7 +164,7 @@
     "namespace": "FactorRemainderTheoremOQ01OQ01OQ02",
     "lineCount": 205,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/FactorRemainderTheoremOQ01OQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

Two gallery entries overstate `theoremCount` by 1. In each, a **docstring word-wrap line** that begins with the word `theorem ` (the continuation of a `/-- ... -/` doc comment) was miscounted as a theorem declaration when the metadata was generated.

| slug | claimed | actual | spurious line |
|------|---------|--------|---------------|
| `binomial-theorem-oq-03-oq-03` | 9 | **8** | L82 `theorem with \`f(i) = p(i)·g(i)\`...` (doc continuation) |
| `factor-remainder-theorem-oq-01-oq-01-oq-02` | 9 | **8** | doc-comment continuation |

Each file has exactly 8 top-level `theorem` declarations (verified against `origin/main` source).

## Fix

Corrected both `meta.theoremCount` and `leanFile.theoremCount` from 9 → 8 in each meta.json. Two-line-per-file change; JSON re-validated; no unicode churn (`ensure_ascii=False`).

## Not changed (verified accurate)

`status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0` are all correct for both entries — these are genuine, fully-machine-checked, 0-axiom proofs. Only the descriptive theorem count was off.

---
Discovered during gallery integrity audit. Severity: LOW (descriptive count, not a verification claim).
🤖 Generated with [Claude Code](https://claude.com/claude-code)