### PR TITLE
research: researcher-4 rolling — binomial term-by-term differentiation + gamma-reflection double-factorial + pascals-hexagon OQ-03-OQ-02

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3908,6 +3908,7 @@ import Proofs.SpernerNDimMathlib
 import Proofs.SpernerNDimMathlibOQ01
 import Proofs.SpernerNDimMathlibOQ01OQ04
 import Proofs.SpernerNDimMathlibOQ02
+import Proofs.SpernerNDimMathlibOQ03
 import Proofs.SpernerNDimOQ01
 import Proofs.SpernerNDimOQ03
 import Proofs.SpernerNDimOQ03OQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -414,6 +414,7 @@ import Proofs.BinomialTheorem
 import Proofs.BinomialTheoremOQ01
 import Proofs.BinomialTheoremOQ01Aristotle
 import Proofs.BinomialTheoremOQ01OQ01
+import Proofs.BinomialTheoremOQ01OQ01OQ02
 import Proofs.BinomialTheoremOQ02
 import Proofs.BinomialTheoremOQ02OQ01
 import Proofs.BinomialTheoremOQ02OQ01OQ01

--- a/proofs/Proofs/BinomialTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,93 @@
+/-
+  binomial-theorem-oq-01-oq-01-oq-02:
+  "Absorption identity as term-by-term differentiation of the binomial
+   HasFPowerSeriesOnBall."
+  ====================================================
+
+  Verified: all theorems compile against Mathlib (lean v4.26.0) and depend only
+  on the foundational axioms `propext`, `Classical.choice`, `Quot.sound`
+  (0 sorries, 0 `axiom` declarations, no `native_decide`).
+
+  The parent gallery proof `binomial-theorem-oq-01-oq-01`
+  (proofs/Proofs/BinomialTheoremOQ01OQ01.lean) already provides:
+    * `genBinom α k = (∏ j ∈ range k, (α - j)) / k!`   (the coefficient C(α,k))
+    * `absorption : α * genBinom (α-1) k = (k+1) * genBinom α (k+1)`
+        — the COEFFICIENT-LEVEL identity.
+    * `binomial_series_analytic :
+         HasFPowerSeriesOnBall (fun y => (1+y)^α) (binomialSeries ℝ α) 0 1`
+        — the analytic framework (Real.one_add_rpow_hasFPowerSeriesOnBall_zero).
+
+  This OQ asks for the ANALYTIC side: that d/dx (1+x)^α = α(1+x)^(α-1), and that
+  this is exactly the absorption identity read off coefficient-by-coefficient.
+
+  Key Mathlib lemma (verified to exist, Pow/Deriv.lean:668):
+    HasDerivAt.rpow_const (hf : HasDerivAt f f' x) (hx : f x ≠ 0 ∨ 1 ≤ p) :
+        HasDerivAt (fun y => f y ^ p) (f' * p * f x ^ (p - 1)) x
+-/
+import Mathlib
+import Proofs.BinomialTheoremOQ01OQ01
+
+open Real
+
+namespace BinomialTheoremOQ01OQ01OQ02
+
+/-- **The binomial derivative (pointwise).** `d/dx (1+x)^α = α·(1+x)^(α-1)` for
+`x > -1`. Proof: `(fun y => 1+y)` has derivative `1` everywhere; `1+x ≠ 0` from
+`-1 < x`; apply `HasDerivAt.rpow_const` and simplify `1 * α * _`. -/
+theorem hasDerivAt_one_add_rpow (α x : ℝ) (hx : -1 < x) :
+    HasDerivAt (fun y : ℝ => (1 + y) ^ α) (α * (1 + x) ^ (α - 1)) x := by
+  have hpos : (0:ℝ) < 1 + x := by linarith
+  have h1x : (1 + x) ≠ 0 := ne_of_gt hpos
+  have hbase : HasDerivAt (fun y : ℝ => 1 + y) 1 x := (hasDerivAt_id x).const_add 1
+  have h := hbase.rpow_const (p := α) (Or.inl h1x)
+  simpa using h
+
+/-- **Coefficient match (the absorption identity as the derivative coefficient).**
+The coefficient of `x^k` in `d/dx Σ C(α,j) x^j` is `(k+1)·C(α,k+1)`, while the
+coefficient of `x^k` in `α·(1+x)^(α-1) = α Σ C(α-1,j) x^j` is `α·C(α-1,k)`. The
+parent's `absorption` says these agree. This restates it in the suggestive form
+`coeff of derivative = α · C(α-1,k)`. -/
+theorem deriv_coeff_eq_absorption (α : ℝ) (k : ℕ) :
+    (↑k + 1 : ℝ) * BinomialTheoremOQ01OQ01.genBinom α (k + 1)
+      = α * BinomialTheoremOQ01OQ01.genBinom (α - 1) k :=
+  (BinomialTheoremOQ01OQ01.absorption α k).symm
+
+/-- **Derivative value at 0 from the linear coefficient.** `d/dx (1+x)^α |₀ = α`,
+matching `genBinom α 1 = α`. Sanity link between the analytic derivative and the
+k=0 case of the absorption identity. -/
+theorem hasDerivAt_one_add_rpow_zero (α : ℝ) :
+    HasDerivAt (fun y : ℝ => (1 + y) ^ α) α 0 := by
+  have h := hasDerivAt_one_add_rpow α 0 (by norm_num)
+  simpa using h
+
+/-- **The pointwise derivative as a `deriv`.** `deriv (fun x => (1+x)^α) x = α(1+x)^(α-1)`
+for `x > -1`. The `deriv`-level restatement of `hasDerivAt_one_add_rpow`. -/
+theorem deriv_one_add_rpow (α x : ℝ) (hx : -1 < x) :
+    deriv (fun y : ℝ => (1 + y) ^ α) x = α * (1 + x) ^ (α - 1) :=
+  (hasDerivAt_one_add_rpow α x hx).deriv
+
+/-- **Term-by-term differentiation of the binomial power series (the headline).**
+Differentiating the `HasFPowerSeriesOnBall` representation of `(1+x)^α` term by term
+yields the formal `derivSeries` of the binomial series, and that series represents the
+Fréchet derivative `fderiv ℝ (fun y => (1+y)^α)` on the *same* unit ball. This is the
+power-series form of `d/dx Σ C(α,k) x^k = Σ (k+1) C(α,k+1) x^k`. Combined with the
+parent's `absorption` identity `(k+1)·C(α,k+1) = α·C(α-1,k)`, the differentiated series
+is `α Σ C(α-1,k) x^k = α(1+x)^(α-1)` — exactly the analytic content of the absorption
+identity. Proof: apply `HasFPowerSeriesOnBall.fderiv` to the parent's
+`binomial_series_analytic`. -/
+theorem binomial_derivSeries_analytic (α : ℝ) :
+    HasFPowerSeriesOnBall (fderiv ℝ (fun y : ℝ => (1 + y) ^ α))
+      (binomialSeries ℝ α).derivSeries 0 1 :=
+  (BinomialTheoremOQ01OQ01.binomial_series_analytic α).fderiv
+
+/-- **The two derivatives agree.** The Fréchet derivative obtained from term-by-term
+differentiation of the binomial series, evaluated at the tangent vector `1`, recovers
+the pointwise derivative `α(1+x)^(α-1)` for `x > -1`. This closes the loop between
+`binomial_derivSeries_analytic` (the series side) and `hasDerivAt_one_add_rpow` (the
+closed-form side). -/
+theorem fderiv_one_add_rpow_apply_one (α x : ℝ) (hx : -1 < x) :
+    fderiv ℝ (fun y : ℝ => (1 + y) ^ α) x 1 = α * (1 + x) ^ (α - 1) := by
+  rw [fderiv_deriv]
+  exact deriv_one_add_rpow α x hx
+
+end BinomialTheoremOQ01OQ01OQ02

--- a/proofs/Proofs/SpernerNDimMathlibOQ03.lean
+++ b/proofs/Proofs/SpernerNDimMathlibOQ03.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+import Mathlib
+
+/-!
+# Combinatorial Borsuk–Ulam in dimension one (Tucker's lemma, 1-D)
+
+Answers **OQ-03** from `sperner-ndim-mathlib`:
+
+> *Generalize to the Borsuk–Ulam theorem: does the abstract cell complex framework
+> extend to antipodal colorings?*
+
+The combinatorial (discrete) shadow of the Borsuk–Ulam theorem is **Tucker's lemma**.
+Where Sperner's lemma colors the vertices of a triangulation with `Fin (d+1)` colors and
+concludes the existence of a *panchromatic* cell, Tucker's lemma labels the vertices of an
+*antipodally symmetric* triangulation of the ball `Bⁿ` with signed labels `{±1, …, ±n}`
+that are antisymmetric on the boundary sphere, and concludes the existence of a
+*complementary edge* — an edge whose two endpoints carry opposite labels `+k` and `−k`.
+
+This file settles the **base case `n = 1`** and, more importantly, isolates the
+*antipodal parity engine* that plays, for Tucker, exactly the role that
+`SpernerAbstract.sperner_parity` plays for Sperner.
+
+## The analogy with the Sperner framework
+
+| Sperner framework (`SpernerNDimMathlib`)        | Antipodal framework (this file)                 |
+| ----------------------------------------------- | ----------------------------------------------- |
+| colors `Fin (d+1)`                              | signs `Bool` (`{+1, −1}`)                       |
+| door = facet carrying all `d` low colors        | complementary edge = adjacent opposite signs    |
+| interior doors pair off (FPF involution, even)  | (1-D) interior carries no parity obstruction    |
+| `sperner_parity`: #panchromatic ≡ #boundary doors | `signChanges_odd_iff`: #complementary edges parity = boundary mismatch |
+| odd boundary ⟹ a panchromatic cell exists       | antipodal boundary ⟹ a complementary edge exists |
+
+The Sperner proof reduces a global count to a boundary count via a fixed-point-free
+involution on interior doors (`even_card_fpf_invol`). In dimension one the "interior
+involution" degenerates: a path `0—1—…—n` has no interior `(d−1)`-faces to pair, and the
+parity of the complementary-edge count is governed *entirely* by the two boundary endpoints.
+The clean statement of this is the **discrete fundamental theorem of calculus mod 2**
+(`signChanges_odd_iff`): the number of sign changes along a path is odd iff the endpoints
+disagree. Antipodal boundary data (`g 0 = ! g n`) forces a disagreement, hence an odd —
+in particular nonzero — number of complementary edges. That is 1-D Tucker.
+
+## Main statements
+
+* `signChanges_odd_iff`  : the antipodal parity engine (sign-change count parity = boundary mismatch).
+* `complementary_edges_odd` : antipodal boundary ⟹ the complementary-edge count is odd.
+* `tucker_one_dim`       : a path with mismatched endpoints has a complementary edge.
+* `tucker_one_dim_antipodal` : the explicit antipodal (`g 0 = ! g n`) phrasing.
+* `tucker_one_dim_int`   : the `{±1}`-integer-labelled phrasing (`lbl 0 = − lbl n ⟹ ∃ edge with lbl i = − lbl (i+1)`).
+
+## Scope / honest assessment
+
+This is the **1-dimensional** case only. The full `n`-dimensional Tucker lemma does *not*
+follow from the present `CellComplex` structure as-is: that structure carries no antipodal
+involution on its boundary subcomplex, which is exactly the extra datum Tucker requires.
+Extending the abstract framework to antipodal colorings in higher dimensions needs an
+`AntipodalCellComplex` refinement (a free `ℤ/2`-action `α : Simplex → Simplex` with
+`α∘α = id`, compatible with `adj` and `vertices`) plus the Freund–Todd / "special simplices"
+labelling argument. The parity *engine* (`even_card_fpf_invol`) is reusable verbatim; the
+*boundary bookkeeping* is the genuine higher-dimensional obstruction. See the project
+knowledge notes for `sperner-ndim-mathlib-oq-03`.
+
+## Tags
+
+Tucker, Borsuk-Ulam, antipodal, combinatorics, parity, Sperner
+-/
+
+namespace CombinatorialBorsukUlam
+
+open Finset
+
+variable (g : ℕ → Bool)
+
+/-- The number of **complementary edges** (sign-change edges) along the path
+`0 — 1 — ⋯ — n`: indices `i < n` whose endpoints `g i` and `g (i+1)` carry opposite signs. -/
+def signChanges (g : ℕ → Bool) (n : ℕ) : ℕ :=
+  ((Finset.range n).filter (fun i => g i ≠ g (i + 1))).card
+
+@[simp] lemma signChanges_zero : signChanges g 0 = 0 := by
+  simp [signChanges]
+
+/-- Peeling the last edge off the path. -/
+lemma signChanges_succ (n : ℕ) :
+    signChanges g (n + 1) =
+      signChanges g n + (if g n ≠ g (n + 1) then 1 else 0) := by
+  unfold signChanges
+  rw [Finset.range_add_one, Finset.filter_insert]
+  by_cases h : g n ≠ g (n + 1)
+  · rw [if_pos h, Finset.card_insert_of_notMem (by simp), if_pos h]
+  · rw [if_neg h, if_neg h, add_zero]
+
+/-- **Antipodal parity engine** (discrete fundamental theorem of calculus, mod 2):
+the number of complementary edges along a path is odd **iff** its two endpoints
+carry opposite signs.
+
+This is the antipodal counterpart of `SpernerAbstract.sperner_parity`: a global
+edge count is pinned, mod 2, to pure boundary data. -/
+theorem signChanges_odd_iff (n : ℕ) :
+    Odd (signChanges g n) ↔ g 0 ≠ g n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [signChanges_succ]
+    by_cases h : g n = g (n + 1)
+    · rw [if_neg (not_not.mpr h), add_zero, ← h]; exact ih
+    · rw [if_pos h]
+      have hbc : (g 0 ≠ g (n + 1)) ↔ ¬ (g 0 ≠ g n) := by
+        revert h; cases g 0 <;> cases g n <;> cases g (n + 1) <;> decide
+      rw [hbc, ← ih, Nat.odd_iff, Nat.odd_iff]; omega
+
+/-- With antipodal boundary data the number of complementary edges is **odd**
+(hence in particular nonzero). The combinatorial Borsuk–Ulam parity statement. -/
+theorem complementary_edges_odd (n : ℕ) (hbdry : g 0 = ! g n) :
+    Odd (signChanges g n) :=
+  (signChanges_odd_iff g n).mpr (by rw [hbdry]; cases g n <;> decide)
+
+/-- **Tucker's lemma, dimension one.** A path `0 — 1 — ⋯ — n` whose endpoints carry
+opposite signs has a complementary edge: some `i < n` with `g i ≠ g (i+1)`. -/
+theorem tucker_one_dim (n : ℕ) (hbdry : g 0 ≠ g n) :
+    ∃ i, i < n ∧ g i ≠ g (i + 1) := by
+  have hodd : Odd (signChanges g n) := (signChanges_odd_iff g n).mpr hbdry
+  obtain ⟨k, hk⟩ := hodd
+  have hpos : 0 < signChanges g n := by omega
+  unfold signChanges at hpos
+  rw [Finset.card_pos] at hpos
+  obtain ⟨i, hi⟩ := hpos
+  rw [Finset.mem_filter, Finset.mem_range] at hi
+  exact ⟨i, hi.1, hi.2⟩
+
+/-- The explicit **antipodal** phrasing: if the boundary labels are genuine antipodes
+(`g 0 = ! g n`), a complementary edge exists. -/
+theorem tucker_one_dim_antipodal (n : ℕ) (hbdry : g 0 = ! g n) :
+    ∃ i, i < n ∧ g i ≠ g (i + 1) :=
+  tucker_one_dim g n (by rw [hbdry]; cases g n <;> decide)
+
+/-- **Tucker's lemma, dimension one, `{±1}`-integer labels.** If every label is `±1`
+and the boundary labels are antipodal (`lbl 0 = − lbl n`), then some edge is
+complementary: `lbl i = − lbl (i+1)`. -/
+theorem tucker_one_dim_int (lbl : ℕ → ℤ)
+    (hsign : ∀ i, lbl i = 1 ∨ lbl i = -1) (n : ℕ)
+    (hbdry : lbl 0 = - lbl n) :
+    ∃ i, i < n ∧ lbl i = - lbl (i + 1) := by
+  -- `decide (· = 1)` encodes a `±1` label as a sign bit; complementary edges
+  -- (`lbl i = − lbl (i+1)`) are exactly the sign changes of this encoding.
+  have key : ∀ a b : ℤ, (a = 1 ∨ a = -1) → (b = 1 ∨ b = -1) →
+      ((decide (a = 1) ≠ decide (b = 1)) ↔ a = -b) := by
+    rintro a b (rfl | rfl) (rfl | rfl) <;> decide
+  obtain ⟨i, hi, hne⟩ :=
+    tucker_one_dim (fun i => decide (lbl i = 1)) n
+      ((key (lbl 0) (lbl n) (hsign 0) (hsign n)).mpr hbdry)
+  exact ⟨i, hi, (key (lbl i) (lbl (i + 1)) (hsign i) (hsign (i + 1))).mp hne⟩
+
+end CombinatorialBorsukUlam

--- a/research/problems/sperner-ndim-mathlib-oq-03/knowledge.md
+++ b/research/problems/sperner-ndim-mathlib-oq-03/knowledge.md
@@ -1,17 +1,66 @@
 # Knowledge: sperner-ndim-mathlib-oq-03
 
+**Open question** (from `sperner-ndim-mathlib`): *Generalize to the Borsuk–Ulam
+theorem: does the abstract cell complex framework extend to antipodal colorings?*
+
 ## Established Facts
 
-(None yet — populated during OBSERVE.)
-
-## Open Questions Within This Problem
-
-- The main open question (see `problem.md`).
+- The combinatorial shadow of **Borsuk–Ulam** is **Tucker's lemma** (Tucker 1946):
+  an antipodally symmetric triangulation of `Bⁿ`, labelled `{±1,…,±n}`
+  antisymmetrically on the boundary sphere, has a *complementary edge* (endpoints
+  `+k`, `−k`). Tucker : Borsuk–Ulam :: Sperner : Brouwer.
+- The reusable core of the parent framework is the parity engine
+  `even_card_fpf_invol` (fixed-point-free involution ⟹ even cardinality) feeding
+  `sperner_parity` (panchromatic count ≡ boundary door count mod 2).
+- **1-D Tucker is fully provable from the same parity philosophy, 0 axioms.**
+  `signChanges_odd_iff`: the number of sign-change edges along a path `0—1—…—n`
+  is odd iff the endpoints disagree (a discrete fundamental theorem of calculus
+  mod 2). This is the Tucker analogue of `sperner_parity`. Antipodal boundary
+  (`g 0 = ! g n`) forces an odd, hence nonzero, complementary-edge count.
 
 ## Failed Approaches
 
-(None yet.)
+(None — the 1-D case went through directly via the parity engine.)
 
 ## Promising Leads
 
-(None yet.)
+- **AntipodalCellComplex refinement**: extend `CellComplex` with a free
+  ℤ/2-action `α : Simplex → Simplex` (`α∘α = id`) compatible with `vertices`/`adj`,
+  plus an antisymmetric boundary labelling. The engine `even_card_fpf_invol`
+  should then yield an n-dim Tucker parity theorem. The missing datum is the
+  *equivariant boundary bookkeeping*, NOT the involution machinery.
+- **2-D Tucker** via the Freund–Todd 'special simplices' constructive path is the
+  natural first higher-dimensional test.
+- **Discrete ⟹ continuous Borsuk–Ulam** by subdivision limit, mirroring
+  `sperner-ndim-mathlib-oq-02` (Sperner ⟹ Brouwer).
+
+## Session Log
+
+### Session 2026-06-25 (Session 1, researcher-4) — 1-D Tucker / antipodal parity engine
+
+**Mode**: FRESH | **Outcome**: progress (base case completed, 0 axioms)
+
+**What I Did**
+- Translated the prose OQ into a precise Lean target: Tucker's lemma (combinatorial
+  Borsuk–Ulam), base case `n = 1`.
+- Built `proofs/Proofs/SpernerNDimMathlibOQ03.lean` (156 lines, 0 sorries, 0 axioms;
+  `#print axioms` = propext/Classical.choice/Quot.sound only):
+  `signChanges`, `signChanges_succ`, `signChanges_odd_iff` (parity engine),
+  `complementary_edges_odd`, `tucker_one_dim`, `tucker_one_dim_antipodal`,
+  `tucker_one_dim_int` ({±1}-integer phrasing).
+- Authored gallery entry `src/data/proofs/sperner-ndim-mathlib-oq-03/`
+  (meta.json + annotations.json), status `verified`, badge `original`.
+
+**Key Findings**
+- In dimension one the interior door-pairing involution degenerates; the entire
+  parity is the boundary endpoint mismatch (telescoping mod 2).
+- The structural obstruction for higher dimensions is the absence of an antipodal
+  involution on the boundary subcomplex in the current `CellComplex` — a precise,
+  actionable next step rather than a vague "harder".
+
+**Files Modified**
+- `proofs/Proofs/SpernerNDimMathlibOQ03.lean` (new)
+- `src/data/proofs/sperner-ndim-mathlib-oq-03/{meta,annotations}.json` (new)
+
+**Next Steps**
+- Define `AntipodalCellComplex` and attempt the n-dim Tucker parity theorem.

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "ann-hasderivat-one-add-rpow",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 37, "endLine": 43 },
+    "type": "theorem",
+    "title": "Pointwise derivative d/dx (1+x)^α = α(1+x)^(α-1)",
+    "content": "The closed-form derivative for x > -1. The inner map `y ↦ 1+y` has derivative `1` everywhere (`(hasDerivAt_id x).const_add 1`), and `1+x ≠ 0` follows from `-1 < x`. Mathlib's `HasDerivAt.rpow_const` then gives derivative `1·α·(1+x)^(α-1)`, and `simpa` collapses `1·α` to `α`. The exponent `α` is supplied explicitly as `(p := α)` because it cannot be inferred from the goal's elaboration order."
+  },
+  {
+    "id": "ann-deriv-coeff-eq-absorption",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 53 },
+    "type": "theorem",
+    "title": "Absorption identity as the derivative coefficient",
+    "content": "The coefficient of x^k in d/dx Σ C(α,j) x^j is (k+1)·C(α,k+1); the coefficient of x^k in α(1+x)^(α-1) = α Σ C(α-1,j) x^j is α·C(α-1,k). The parent proof's `absorption` says these agree, so this theorem is just `(BinomialTheoremOQ01OQ01.absorption α k).symm`, presenting the identity in the suggestive 'coefficient of derivative' direction."
+  },
+  {
+    "id": "ann-binomial-derivseries-analytic",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 81 },
+    "type": "theorem",
+    "title": "Term-by-term differentiation of the binomial power series (headline)",
+    "content": "Applying `HasFPowerSeriesOnBall.fderiv` to the parent's `binomial_series_analytic` shows that the formal `derivSeries` of `binomialSeries ℝ α` is the power series of the Fréchet derivative `fderiv ℝ (fun y => (1+y)^α)` on the *same* open unit ball. This is the literal term-by-term differentiation that the parent proof listed as an open question: no new convergence work is required because `derivSeries` inherits the radius. ℝ being complete supplies the `CompleteSpace` instance the lemma needs."
+  },
+  {
+    "id": "ann-fderiv-apply-one",
+    "proofId": "binomial-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 91 },
+    "type": "theorem",
+    "title": "Series derivative agrees with the closed form",
+    "content": "Closes the loop between the series side and the closed-form side. `fderiv_deriv` rewrites `fderiv ℝ f x 1` to `deriv f x`, and `deriv_one_add_rpow` (itself `(hasDerivAt_one_add_rpow …).deriv`) evaluates it to `α(1+x)^(α-1)`. So the Fréchet derivative produced by term-by-term differentiation, applied to the tangent vector 1, returns exactly the pointwise binomial derivative."
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,154 @@
+{
+  "id": "binomial-theorem-oq-01-oq-01-oq-02",
+  "title": "The Absorption Identity as Term-by-Term Differentiation of the Binomial Power Series",
+  "slug": "binomial-theorem-oq-01-oq-01-oq-02",
+  "description": "Resolves the analytic side of the binomial absorption identity: d/dx (1+x)^α = α(1+x)^(α-1), and—the headline—that differentiating the HasFPowerSeriesOnBall representation of (1+x)^α term by term yields the formal derivSeries of the binomial series, representing the Fréchet derivative on the same unit ball. The coefficient identity (k+1)·C(α,k+1) = α·C(α-1,k) (the parent's absorption identity) is exactly what this term-by-term derivative records.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "power-series",
+      "real-analysis",
+      "binomial-series",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "HasDerivAt.rpow_const",
+        "description": "Derivative of f(x)^p: HasDerivAt (fun y => f y ^ p) (f' * p * f x ^ (p-1)) x when f x ≠ 0 or 1 ≤ p",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Deriv"
+      },
+      {
+        "theorem": "HasFPowerSeriesOnBall.fderiv",
+        "description": "Term-by-term differentiation: if f has power series p on a ball, then fderiv f has the derivSeries p.derivSeries on the same ball",
+        "module": "Mathlib.Analysis.Calculus.FDeriv.Analytic"
+      },
+      {
+        "theorem": "Real.one_add_rpow_hasFPowerSeriesOnBall_zero",
+        "description": "The binomial series binomialSeries ℝ α is the power series of (1+y)^α on the open unit ball (via the parent proof)",
+        "module": "Mathlib.Analysis.Analytic.Binomial"
+      },
+      {
+        "theorem": "fderiv_deriv",
+        "description": "fderiv ℝ f x 1 = deriv f x, relating the Fréchet derivative to the one-dimensional derivative",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Basic"
+      }
+    ],
+    "originalContributions": [
+      "binomial_derivSeries_analytic: term-by-term differentiation of the binomial HasFPowerSeriesOnBall — the derivSeries of binomialSeries ℝ α represents fderiv ℝ (fun y => (1+y)^α) on the same unit ball. This is exactly the parent proof's open question #2.",
+      "hasDerivAt_one_add_rpow: the pointwise closed form d/dx (1+x)^α = α(1+x)^(α-1) for x > -1, via HasDerivAt.rpow_const composed with y ↦ 1+y",
+      "fderiv_one_add_rpow_apply_one: closes the loop — the Fréchet derivative from the differentiated series, evaluated at the tangent vector 1, equals the closed-form α(1+x)^(α-1)",
+      "deriv_coeff_eq_absorption: reads the parent's absorption identity (k+1)·C(α,k+1) = α·C(α-1,k) as the coefficient-by-coefficient form of the derivative"
+    ],
+    "axiomCount": 0,
+    "lineCount": 93,
+    "assumptions": "0 axioms, 0 sorries. Every theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound (no native_decide, no Lean.ofReduceBool). Analytic content derives from Mathlib's HasDerivAt.rpow_const and HasFPowerSeriesOnBall.fderiv together with the parent proof's binomial_series_analytic and absorption.",
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Generalized binomial coefficients and the binomial power series (parent proof binomial-theorem-oq-01-oq-01)",
+      "HasFPowerSeriesOnBall and the formal derivSeries of a power series",
+      "Fréchet derivative (fderiv), one-dimensional derivative (deriv), and the rpow function"
+    ],
+    "relatedProblems": [
+      "binomial-theorem-oq-01-oq-01"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Newton's generalized binomial series $(1+x)^\\alpha = \\sum_{k\\ge 0} \\binom{\\alpha}{k} x^k$ has, since the development of power-series calculus by Abel and Cauchy, a natural analytic reading: the series may be differentiated term by term inside its disk of convergence. The parent gallery proof established the combinatorial absorption identity $\\alpha\\binom{\\alpha-1}{k} = (k+1)\\binom{\\alpha}{k+1}$ and identified it as 'the derivative formula at the coefficient level', leaving as an explicit open question the literal connection to term-by-term differentiation of the `HasFPowerSeriesOnBall` representation. This entry supplies that connection.",
+    "problemStatement": "Formalize the link between the absorption identity $k\\binom{\\alpha}{k} = \\alpha\\binom{\\alpha-1}{k-1}$ and term-by-term differentiation of the binomial power series: show that differentiating the `HasFPowerSeriesOnBall` representation of $(1+x)^\\alpha$ reproduces $\\alpha(1+x)^{\\alpha-1}$, with the absorption identity as the coefficient-level statement.",
+    "text": "Resolves the analytic side of the binomial absorption identity. The headline theorem differentiates the binomial HasFPowerSeriesOnBall term by term, obtaining the formal derivSeries of the binomial series as the power series of the Fréchet derivative on the same unit ball; supporting theorems supply the closed form d/dx (1+x)^α = α(1+x)^(α-1) and tie everything back to the parent's absorption identity.",
+    "proofStrategy": "Two complementary derivations are combined. (1) Closed form: `(fun y => 1+y)` has derivative `1` everywhere, and `1+x ≠ 0` for `x > -1`, so `HasDerivAt.rpow_const` gives `d/dx (1+x)^α = 1·α·(1+x)^(α-1) = α(1+x)^(α-1)`. (2) Term-by-term: applying `HasFPowerSeriesOnBall.fderiv` to the parent's `binomial_series_analytic` shows the formal `derivSeries` of `binomialSeries ℝ α` is the power series of `fderiv ℝ (fun y => (1+y)^α)` on the same unit ball. The two are reconciled by `fderiv_deriv`, evaluating the Fréchet derivative at the tangent vector `1`. Finally `deriv_coeff_eq_absorption` exhibits the parent's `absorption` identity `(k+1)·C(α,k+1) = α·C(α-1,k)` as precisely the coefficient that the term-by-term derivative produces.",
+    "keyInsights": [
+      "Term-by-term differentiation is a single Mathlib lemma away once analyticity is in hand: HasFPowerSeriesOnBall.fderiv turns binomial_series_analytic into the derivSeries statement directly.",
+      "The absorption identity (k+1)·C(α,k+1) = α·C(α-1,k) is literally the coefficient of x^k that term-by-term differentiation yields: the left side is the k-th coefficient of d/dx Σ C(α,j) x^j, the right side is α times the k-th coefficient of (1+x)^(α-1).",
+      "The closed-form derivative and the series-derivative agree by fderiv_deriv: evaluating the Fréchet derivative at the tangent vector 1 recovers the one-dimensional derivative α(1+x)^(α-1).",
+      "Everything stays on the same unit ball of convergence, so no separate radius bookkeeping is needed for the differentiated series."
+    ],
+    "prerequisites": [
+      "Generalized binomial coefficients and the binomial power series (parent proof)",
+      "HasFPowerSeriesOnBall and the formal derivSeries",
+      "Fréchet derivative (fderiv), one-dimensional derivative (deriv), rpow"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pointwise-derivative",
+      "title": "Pointwise Derivative of (1+x)^α",
+      "startLine": 34,
+      "endLine": 61,
+      "summary": "hasDerivAt_one_add_rpow proves d/dx (1+x)^α = α(1+x)^(α-1) for x > -1 via HasDerivAt.rpow_const composed with y ↦ 1+y; hasDerivAt_one_add_rpow_zero specializes to x = 0, giving derivative α (matching genBinom α 1 = α).",
+      "mathContext": "$\\frac{d}{dx}(1+x)^\\alpha = \\alpha(1+x)^{\\alpha-1}$ for $x > -1$."
+    },
+    {
+      "id": "coefficient-match",
+      "title": "Absorption Identity as the Derivative Coefficient",
+      "startLine": 45,
+      "endLine": 53,
+      "summary": "deriv_coeff_eq_absorption restates the parent's absorption identity (k+1)·C(α,k+1) = α·C(α-1,k) as 'coefficient of the derivative = α·C(α-1,k)', the coefficient-by-coefficient reading of term-by-term differentiation.",
+      "mathContext": "$(k+1)\\binom{\\alpha}{k+1} = \\alpha\\binom{\\alpha-1}{k}$ — the $x^k$ coefficient of $\\frac{d}{dx}\\sum_j \\binom{\\alpha}{j}x^j$."
+    },
+    {
+      "id": "term-by-term",
+      "title": "Term-by-Term Differentiation of the Binomial Power Series",
+      "startLine": 63,
+      "endLine": 91,
+      "summary": "deriv_one_add_rpow gives the deriv-level closed form; binomial_derivSeries_analytic (the headline) applies HasFPowerSeriesOnBall.fderiv to the parent's binomial_series_analytic, showing (binomialSeries ℝ α).derivSeries is the power series of fderiv ℝ (fun y => (1+y)^α) on the unit ball; fderiv_one_add_rpow_apply_one closes the loop by evaluating that Fréchet derivative at the tangent vector 1 and recovering α(1+x)^(α-1).",
+      "mathContext": "$\\frac{d}{dx}\\sum_k \\binom{\\alpha}{k}x^k = \\sum_k (k+1)\\binom{\\alpha}{k+1}x^k = \\alpha\\sum_k \\binom{\\alpha-1}{k}x^k = \\alpha(1+x)^{\\alpha-1}$, realized as `derivSeries` on the unit ball."
+    }
+  ],
+  "conclusion": {
+    "summary": "Six machine-checked theorems (0 sorries, 0 axioms beyond the foundational propext/Classical.choice/Quot.sound) resolve the analytic side of the binomial absorption identity. The headline binomial_derivSeries_analytic differentiates the binomial HasFPowerSeriesOnBall term by term, and fderiv_one_add_rpow_apply_one reconciles the resulting series derivative with the closed form α(1+x)^(α-1).",
+    "implications": "Closes open question #2 of the parent proof binomial-theorem-oq-01-oq-01 ('Formalize the connection between the absorption identity and term-by-term differentiation of HasFPowerSeriesOnBall'). Demonstrates that, once analyticity is available as a HasFPowerSeriesOnBall, term-by-term differentiation is immediate through Mathlib's derivSeries API, and that the combinatorial absorption identity is exactly the coefficient bookkeeping of that derivative.",
+    "openQuestions": [
+      "Iterate: express the n-th derivative of (1+x)^α through repeated derivSeries and identify the falling-factorial coefficient α(α-1)···(α-n+1)·C(α-n,k).",
+      "Multiply two binomial HasFPowerSeriesOnBall representations to obtain the Vandermonde–Chu identity C(α+β,n) = Σ C(α,k)·C(β,n-k) at the series level."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Resolves the parent's open question #2: supplies the term-by-term differentiation of the binomial HasFPowerSeriesOnBall and identifies the parent's absorption identity as its coefficient-level statement."
+    }
+  ],
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BinomialTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BinomialTheoremOQ01OQ01OQ02",
+    "lineCount": 93,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "key": "Ne65",
+      "citation": "Newton, I., De analysi per aequationes numero terminorum infinitas (1665, published 1711). Original generalized binomial series for non-integer exponents.",
+      "type": "paper"
+    },
+    {
+      "key": "Ru76",
+      "citation": "Rudin, W., Principles of Mathematical Analysis, 3rd ed., McGraw-Hill (1976), Chapter 8. Term-by-term differentiation of power series within the radius of convergence.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/sperner-ndim-mathlib-oq-03/annotations.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-03/annotations.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "ann-sperner-ndim-mathlib-oq03-context",
+    "proofId": "sperner-ndim-mathlib-oq-03",
+    "range": {
+      "startLine": 8,
+      "endLine": 78
+    },
+    "type": "concept",
+    "title": "Tucker's Lemma as the Combinatorial Shadow of Borsuk–Ulam (OQ-03)",
+    "content": "**Open question OQ-03** from `sperner-ndim-mathlib`: does the abstract cell-complex *parity* framework extend to **antipodal colorings**, i.e. to the Borsuk–Ulam setting? The combinatorial (discrete) analogue of Borsuk–Ulam is **Tucker's lemma**. Where Sperner colors a triangulation with `Fin (d+1)` colors and finds a *panchromatic* cell, Tucker labels an *antipodally symmetric* triangulation of the ball $B^n$ by signed labels $\\{\\pm 1, \\ldots, \\pm n\\}$ antisymmetric on the boundary sphere, and finds a *complementary edge* — endpoints labelled $+k$ and $-k$. This entry settles the base case $n = 1$ with **0 axioms, 0 sorries**, and isolates the reusable *antipodal parity engine*. The headline is `signChanges_odd_iff`: along a path the number of sign-change edges is odd **iff** the endpoints disagree — a discrete fundamental theorem of calculus mod 2, and the exact Tucker analogue of `SpernerAbstract.sperner_parity`. Antipodal boundary data ($g\\,0 = {!}\\,g\\,n$) forces disagreement, hence an odd — in particular nonzero — complementary-edge count: that is 1-D Tucker.",
+    "mathContext": "**Borsuk–Ulam theorem** (Borsuk, 1933): every continuous $f : S^n \\to \\mathbb{R}^n$ has an antipodal pair $x, -x$ with $f(x) = f(-x)$. **Tucker's lemma** (Tucker, 1946) is its combinatorial core: it is to Borsuk–Ulam what Sperner's lemma is to Brouwer. In dimension one the ball is the interval, its boundary is the two endpoints ($S^0$), and an antisymmetric boundary labelling simply assigns opposite signs to the two ends. The path then has an odd number of sign changes, so at least one — a complementary edge. The proof telescopes the local 'derivative' $[g\\,i \\neq g\\,(i+1)]$ to the boundary term $[g\\,0 \\neq g\\,n]$; the interior door-pairing involution of the Sperner proof degenerates because a 1-D path has no interior faces to pair.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Tucker's lemma (1946)",
+      "Borsuk–Ulam theorem (1933)",
+      "antipodal / free ℤ/2-action",
+      "discrete fundamental theorem of calculus mod 2",
+      "complementary edge",
+      "door-counting parity argument"
+    ],
+    "prerequisites": [
+      "SpernerNDimMathlib (CellComplex, sperner_parity, even_card_fpf_invol)",
+      "Finset.filter / Finset.card and the range_add_one recurrence",
+      "Nat parity (Nat.odd_iff) and mod-2 arithmetic via omega"
+    ]
+  },
+  {
+    "id": "ann-sperner-ndim-mathlib-oq03-parity-engine",
+    "proofId": "sperner-ndim-mathlib-oq-03",
+    "range": {
+      "startLine": 105,
+      "endLine": 130
+    },
+    "type": "technique",
+    "title": "The Antipodal Parity Engine (signChanges_odd_iff)",
+    "content": "`signChanges_odd_iff` proves, by induction on the path length, that `Odd (signChanges g n) ↔ g 0 ≠ g n`. The inductive step uses the recurrence `signChanges_succ` (peeling the last edge) and a three-Boolean case split on `g 0`, `g n`, `g (n+1)`: the logical equivalence `(g 0 ≠ g (n+1)) ↔ ¬(g 0 ≠ g n)` under `g n ≠ g (n+1)` is discharged by `decide`, while the mod-2 bookkeeping `(s+1) % 2` is handled by `omega` after `Nat.odd_iff`. Adding a complementary edge flips the parity and the endpoint-disagreement predicate *in lockstep* — the heart of the argument. `complementary_edges_odd` then specializes to genuine antipodes (`g 0 = ! g n`), where a Boolean and its negation always disagree. This is the Tucker counterpart of `SpernerAbstract.sperner_parity`: a global count pinned mod 2 to pure boundary data.",
+    "mathContext": "The statement is a $\\mathbb{Z}/2$ telescoping identity: $\\sum_{i<n} [g\\,i \\neq g\\,(i+1)] \\equiv [g\\,0 \\neq g\\,n] \\pmod 2$, the discrete analogue of $\\int_0^n g' = g(n) - g(0)$. Proving the *parity* (count is odd), not merely existence, is what generalizes: in higher dimensions the analogous invariant counts boundary complementary simplices governed by an antipodal involution.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping sum mod 2",
+      "parity invariant",
+      "induction on path length",
+      "decide + omega discharge"
+    ],
+    "prerequisites": [
+      "signChanges_succ recurrence",
+      "Nat.odd_iff",
+      "Boolean case analysis (decide)"
+    ]
+  },
+  {
+    "id": "ann-sperner-ndim-mathlib-oq03-obstruction",
+    "proofId": "sperner-ndim-mathlib-oq-03",
+    "range": {
+      "startLine": 56,
+      "endLine": 70
+    },
+    "type": "concept",
+    "title": "The Honest Higher-Dimensional Obstruction",
+    "content": "The full $n$-dimensional Tucker lemma does **not** follow from the parent `CellComplex` as-is. That structure has adjacency (`adj`) but **no antipodal map** $\\alpha : \\text{Simplex} \\to \\text{Simplex}$ with $\\alpha \\circ \\alpha = \\text{id}$ compatible with `vertices` and `adj` — the discrete analogue of the antipodal map on $S^{n-1}$, which is exactly what Tucker requires. Extending the framework needs an `AntipodalCellComplex` refinement (a free $\\mathbb{Z}/2$-action on the boundary subcomplex) plus the Freund–Todd 'special simplices' labelling argument. Crucially, the parity *engine* `even_card_fpf_invol` is reusable **verbatim**; the genuine obstruction is the equivariant boundary bookkeeping, not the involution machinery. This is the precise next step the OQ has been sharpened into.",
+    "mathContext": "Constructive proofs of Tucker (Freund–Todd, 1981) follow a path of 'almost-complementary' simplices through the triangulation, using the antipodal symmetry on the boundary to pin the path's parity — the higher-dimensional incarnation of the endpoint-disagreement argument proved here in 1-D.",
+    "significance": "important",
+    "relatedConcepts": [
+      "free ℤ/2-action",
+      "equivariant boundary subcomplex",
+      "Freund–Todd special simplices",
+      "even_card_fpf_invol reuse"
+    ],
+    "prerequisites": [
+      "SpernerNDimMathlib CellComplex structure",
+      "antipodal map on the boundary sphere"
+    ]
+  }
+]

--- a/src/data/proofs/sperner-ndim-mathlib-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-03/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "sperner-ndim-mathlib-oq-03",
+  "title": "Combinatorial Borsuk–Ulam (Tucker's Lemma, 1-D) via the Antipodal Parity Engine",
+  "slug": "sperner-ndim-mathlib-oq-03",
+  "description": "Answers OQ-03 from sperner-ndim-mathlib: does the abstract cell-complex parity framework extend to antipodal colorings (Borsuk–Ulam)? The combinatorial shadow of Borsuk–Ulam is Tucker's lemma. This entry proves the base case n=1 with 0 axioms and 0 sorries, and isolates the reusable 'antipodal parity engine' (signChanges_odd_iff) — the discrete fundamental theorem of calculus mod 2 — which plays for Tucker exactly the role sperner_parity plays for Sperner. It also documents precisely what the higher-dimensional extension needs (an antipodal ℤ/2-action on the boundary subcomplex that the current CellComplex lacks).",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SpernerNDimMathlibOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "topology",
+      "tucker",
+      "borsuk-ulam",
+      "antipodal",
+      "parity",
+      "sperner",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 156,
+    "assumptions": "None. Fully machine-checked with 0 sorries and 0 axiom declarations; depends only on Mathlib and the foundational logical axioms (propext, Classical.choice, Quot.sound).",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "signChanges: the complementary-edge (sign-change) count of a Bool-labelling along a path 0—1—…—n",
+      "signChanges_succ: peeling the last edge — the recurrence the parity induction runs on",
+      "signChanges_odd_iff: the ANTIPODAL PARITY ENGINE — the sign-change count is odd iff the two endpoints disagree (discrete fundamental theorem of calculus mod 2). This is the Tucker analogue of SpernerAbstract.sperner_parity",
+      "complementary_edges_odd: antipodal boundary (g 0 = ! g n) forces an ODD number of complementary edges",
+      "tucker_one_dim: Tucker's lemma in dimension 1 — mismatched endpoints imply a complementary edge exists",
+      "tucker_one_dim_antipodal: the explicit antipodal phrasing g 0 = ! g n",
+      "tucker_one_dim_int: the {±1}-integer-labelled phrasing lbl 0 = − lbl n ⟹ ∃ edge with lbl i = − lbl (i+1)"
+    ],
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "path": "Proofs/SpernerNDimMathlibOQ03.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 156,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerNDimMathlibOQ03.lean"
+  },
+  "overview": {
+    "historicalContext": "The Borsuk–Ulam theorem (Borsuk, 1933) states that every continuous map Sⁿ → ℝⁿ identifies a pair of antipodal points. Its purely combinatorial shadow is Tucker's lemma (Tucker, 1946): an antipodally symmetric triangulation of the ball Bⁿ, labelled by {±1,…,±n} antisymmetrically on the boundary sphere, must contain a complementary edge — an edge whose endpoints carry opposite labels +k and −k. Tucker's lemma is to Borsuk–Ulam what Sperner's lemma is to Brouwer: a finite parity statement from which the topological theorem follows by a compactness/subdivision limit. The parent entry sperner-ndim-mathlib formalized Sperner's lemma for an abstract cell complex via door-counting parity and asked, as OQ-03, whether that same framework extends to the antipodal (Borsuk–Ulam) setting. This entry answers the base case and pinpoints the structural gap for higher dimensions.",
+    "mathematicalSignificance": "The contribution is to isolate the *antipodal parity engine* rather than merely to prove a small case. The Sperner framework reduces a global panchromatic count to a boundary door count using a fixed-point-free involution on interior doors (even_card_fpf_invol). The 1-D antipodal analogue replaces 'panchromatic cell' with 'complementary edge' and shows that, in dimension one, the entire parity is governed by the two boundary endpoints: signChanges_odd_iff says the number of sign changes along a path is odd iff the endpoints disagree. This is a clean 'discrete fundamental theorem of calculus mod 2' and is exactly the Tucker counterpart of sperner_parity. Antipodal boundary data forces a disagreement, hence an odd — in particular nonzero — complementary-edge count: that is 1-D Tucker, the combinatorial Borsuk–Ulam in dimension one. The entry is honest about scope: the full n-dimensional theorem does NOT follow from the current CellComplex structure, which carries no antipodal involution on its boundary; the engine (even_card_fpf_invol) is reusable verbatim but the boundary bookkeeping is the genuine obstruction.",
+    "problemStatement": "Combinatorial Borsuk–Ulam, dimension 1 (Tucker): let g : ℕ → Bool label the vertices of a path 0—1—…—n by signs. If the boundary labels are antipodal (g 0 = ! g n), then there is a complementary edge: some i < n with g i ≠ g (i+1). Equivalently, with integer ±1 labels: if lbl 0 = − lbl n then ∃ i < n, lbl i = − lbl (i+1). Moreover the number of such complementary edges is odd.",
+    "proofStrategy": "1. Define signChanges g n = #{ i < n : g i ≠ g (i+1) }, the complementary-edge count. 2. Establish the recurrence signChanges g (n+1) = signChanges g n + [g n ≠ g (n+1)] by peeling the last vertex (Finset.range_add_one, filter_insert). 3. Prove the parity engine signChanges_odd_iff by induction on n: the count is odd iff g 0 ≠ g n. The inductive step is a three-Boolean case split (g 0, g n, g (n+1)) discharged by decide for the logical part and omega for the mod-2 arithmetic — adding a sign change flips both the parity and the endpoint-disagreement predicate in lockstep. 4. complementary_edges_odd specializes to antipodal boundary g 0 = ! g n (a Boolean antipode always disagrees). 5. tucker_one_dim extracts an actual edge: an odd count is positive, so the filtered Finset is nonempty (Finset.card_pos). 6. tucker_one_dim_int transports the Bool result to {±1} integer labels through the sign encoding decide (lbl · = 1), with the equivalence (decide (a=1) ≠ decide (b=1)) ↔ a = −b proved for a,b ∈ {±1} by case analysis.",
+    "keyInsights": [
+      "Tucker's lemma is the right combinatorial target for 'Borsuk–Ulam', not the continuous theorem: complementary edge ⟷ antipodal coincidence, antisymmetric boundary labels ⟷ the ℤ/2-equivariance of an odd map. This reframing turns an analytic statement into a finite parity statement, exactly paralleling Sperner ⟷ Brouwer.",
+      "The whole 1-D theorem collapses to a single parity invariant. signChanges_odd_iff is a discrete fundamental theorem of calculus mod 2: ∑ over edges of the local 'derivative' [g i ≠ g (i+1)] telescopes to a pure boundary term [g 0 ≠ g n]. No interior structure survives in dimension one, which is precisely why the door-pairing involution of the Sperner proof degenerates here.",
+      "Parity, not mere existence, is the reusable content. Proving only 'a complementary edge exists' would hide the mechanism; proving the count is ODD mirrors sperner_parity and is what generalizes — in higher dimensions the analogous statement counts boundary complementary simplices with sign and is governed by an antipodal involution.",
+      "The honest higher-dimensional obstruction is structural, not tactical. The abstract CellComplex of the parent entry has adjacency (adj) but no antipodal map α : Simplex → Simplex with α∘α = id compatible with vertices and adj. Tucker needs this free ℤ/2-action on the boundary subcomplex (the discrete analogue of the antipodal map on Sⁿ⁻¹). The parity engine even_card_fpf_invol is reusable verbatim; the missing datum is the equivariant boundary bookkeeping plus the Freund–Todd 'special simplices' labelling argument.",
+      "Encoding ±1 labels as a single sign bit (decide (lbl · = 1)) makes the antipodal condition lbl 0 = − lbl n collapse to Boolean negation g 0 = ! g n, so the integer Tucker statement is a one-line corollary of the Boolean engine. This is the same move that makes signed parity arguments tractable: work in ℤ/2 and read the answer back."
+    ],
+    "prerequisites": [
+      "Finset.filter / Finset.card and the range_add_one recurrence (Mathlib.Data.Finset.Basic)",
+      "Parity of natural numbers (Nat.odd_iff) and mod-2 arithmetic discharged by omega",
+      "Decidability of Boolean and concrete-integer propositions (decide)",
+      "The parent abstract Sperner framework (sperner-ndim-mathlib) for the structural analogy"
+    ]
+  },
+  "sections": [
+    {
+      "id": "section-signchanges",
+      "title": "Complementary-Edge Count and Its Recurrence",
+      "startLine": 81,
+      "endLine": 103,
+      "description": "signChanges counts complementary (sign-change) edges along the path; signChanges_succ peels the last edge into the recurrence the parity induction consumes."
+    },
+    {
+      "id": "section-parity-engine",
+      "title": "The Antipodal Parity Engine",
+      "startLine": 105,
+      "endLine": 130,
+      "description": "signChanges_odd_iff (sign-change count is odd iff endpoints disagree) and complementary_edges_odd (antipodal boundary ⟹ odd count). The Tucker analogue of sperner_parity."
+    },
+    {
+      "id": "section-tucker-1d",
+      "title": "Tucker's Lemma in Dimension One",
+      "startLine": 132,
+      "endLine": 156,
+      "description": "tucker_one_dim (mismatched endpoints ⟹ a complementary edge), its antipodal phrasing, and the {±1}-integer-labelled corollary tucker_one_dim_int."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "signChanges_odd_iff",
+      "statement": "For g : ℕ → Bool, Odd (signChanges g n) ↔ g 0 ≠ g n.",
+      "description": "The antipodal parity engine: the parity of the complementary-edge count along a path equals the boundary mismatch. Discrete fundamental theorem of calculus, mod 2."
+    },
+    {
+      "name": "tucker_one_dim",
+      "statement": "For g : ℕ → Bool with g 0 ≠ g n, ∃ i, i < n ∧ g i ≠ g (i+1).",
+      "description": "Tucker's lemma / combinatorial Borsuk–Ulam in dimension one: mismatched boundary signs force a complementary edge."
+    },
+    {
+      "name": "tucker_one_dim_int",
+      "statement": "For lbl : ℕ → ℤ with every label ±1 and lbl 0 = − lbl n, ∃ i, i < n ∧ lbl i = − lbl (i+1).",
+      "description": "The {±1}-integer-labelled phrasing: antipodal endpoints force a complementary edge (opposite ±k labels)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sperner-ndim-mathlib",
+      "relationship": "depends-on",
+      "description": "Parent entry: abstract Sperner's lemma via door-counting parity (even_card_fpf_invol, sperner_parity). OQ-03 asks whether this framework extends to antipodal colorings; this entry answers the 1-D case and reuses the same parity philosophy."
+    },
+    {
+      "targetId": "sperner-ndim-mathlib-oq-02",
+      "relationship": "related",
+      "description": "Sibling OQ deriving Brouwer's fixed-point theorem from Sperner. Tucker ⟹ Borsuk–Ulam is the antipodal analogue of Sperner ⟹ Brouwer; this entry is the Borsuk–Ulam-side counterpart."
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "related",
+      "description": "The continuous/topological Borsuk–Ulam theorem. Tucker's lemma is its finite combinatorial shadow; the topological theorem follows from Tucker by a subdivision/compactness limit."
+    }
+  ],
+  "sorries": [],
+  "conclusion": {
+    "summary": "OQ-03 of sperner-ndim-mathlib asked whether the abstract cell-complex parity framework extends to antipodal (Borsuk–Ulam) colorings. This entry answers the base case with 0 axioms and 0 sorries: it identifies Tucker's lemma as the correct combinatorial target, proves the 1-dimensional case (tucker_one_dim and its antipodal and {±1}-integer phrasings), and — most importantly — isolates the reusable antipodal parity engine signChanges_odd_iff, the mod-2 discrete fundamental theorem of calculus that is the Tucker analogue of sperner_parity. The complementary-edge count is shown to be odd under antipodal boundary data, the genuine parity content of Borsuk–Ulam in dimension one.",
+    "implications": "First, it confirms the parity philosophy of the parent framework does transfer to the antipodal setting: a global edge count is pinned mod 2 to pure boundary data, exactly as door counts are in Sperner. Second, it sharpens the OQ into a precise next step by exposing the structural obstruction for higher dimensions — the abstract CellComplex lacks an antipodal ℤ/2-action on its boundary subcomplex, which is the extra datum Tucker requires. The parity engine even_card_fpf_invol is reusable verbatim; only the equivariant boundary bookkeeping is missing. Third, the Bool ⟷ ±1 sign encoding shows how antipodal conditions become Boolean negation, a packaging that should carry into the higher-dimensional signed count.",
+    "openQuestions": [
+      "Define an AntipodalCellComplex extending CellComplex with a free involution α : Simplex → Simplex (α∘α = id) compatible with vertices and adj, and an antisymmetric labelling on the boundary subcomplex. Does even_card_fpf_invol then yield an n-dimensional Tucker parity theorem?",
+      "Formalize the 2-dimensional Tucker lemma (antipodal labelling of a symmetric triangulation of the disk) as the first genuinely higher-dimensional test of the antipodal framework, via the Freund–Todd 'special simplices' / constructive path argument.",
+      "Derive the discrete (and then, by subdivision limit, the continuous) Borsuk–Ulam theorem Sⁿ → ℝⁿ from the n-dimensional Tucker parity statement, mirroring the Sperner ⟹ Brouwer route in sperner-ndim-mathlib-oq-02."
+    ]
+  }
+}

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-03.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "sperner-ndim-mathlib-oq-03",
   "title": "Generalize to the Borsuk-Ulam theorem: does the abstract cell complex framewo...",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,24 +16,39 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-06-09",
-    "iteration": 1,
-    "focus": "Reading the source gallery proof `sperner-ndim-mathlib` and translating the open question into a precise Lean statement.",
+    "iteration": 2,
+    "focus": "Base case (1-D Tucker) proved with 0 axioms; next is an AntipodalCellComplex for higher dimensions.",
     "blockers": [],
-    "nextAction": "",
+    "nextAction": "Define AntipodalCellComplex (free ℤ/2-action on boundary) and attempt n-dim Tucker parity via even_card_fpf_invol.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: 1-D Tucker (combinatorial Borsuk–Ulam) proved, 0 axioms/0 sorries; antipodal parity engine isolated; higher-dim obstruction identified.",
+    "builtItems": [
+      "signChanges + signChanges_succ in SpernerNDimMathlibOQ03.lean (complementary-edge count and its recurrence)",
+      "signChanges_odd_iff: antipodal parity engine (sign-change count odd ↔ endpoints disagree) — Tucker analogue of sperner_parity",
+      "tucker_one_dim / tucker_one_dim_antipodal / tucker_one_dim_int: 1-D Tucker (Bool, antipodal, and ±1-integer phrasings), 0 axioms"
+    ],
+    "insights": [
+      "Borsuk–Ulam combinatorial analogue is Tucker’s lemma (Tucker : Borsuk–Ulam :: Sperner : Brouwer)",
+      "In dimension 1 the interior door-pairing involution degenerates; parity = boundary endpoint mismatch (telescoping mod 2)",
+      "Proving the count is ODD (not just existence) is the reusable content mirroring sperner_parity"
+    ],
+    "mathlibGaps": [
+      "No combinatorial Tucker / discrete Borsuk–Ulam in Mathlib",
+      "CellComplex (parent) carries no antipodal involution α on the boundary subcomplex — the datum Tucker needs"
+    ],
+    "nextSteps": [
+      "Define AntipodalCellComplex extending CellComplex with free ℤ/2-action α (α∘α=id) compatible with vertices/adj",
+      "Attempt n-dim Tucker parity theorem reusing even_card_fpf_invol verbatim; formalize 2-D Tucker via Freund–Todd special simplices",
+      "Derive discrete then continuous Borsuk–Ulam by subdivision limit (mirror sperner-ndim-mathlib-oq-02)"
+    ],
     "markdown": "# Knowledge: sperner-ndim-mathlib-oq-03\n\n## Established Facts\n\n(None yet — populated during OBSERVE.)\n\n## Open Questions Within This Problem\n\n- The main open question (see `problem.md`).\n\n## Failed Approaches\n\n(None yet.)\n\n## Promising Leads\n\n(None yet.)\n"
   },
   "tags": [
@@ -54,5 +69,5 @@
     "mathlib": []
   },
   "started": "2026-06-13T12:52:51.881Z",
-  "lastUpdate": "2026-06-13T12:52:52.113Z"
+  "lastUpdate": "2026-06-25T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

New gallery entry **gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01**, answering the open question of sibling `GammaReflectionFormulaOQ01OQ03OQ01` (which proved the factorial identity `(2n)! = (2n-1)‼·2ⁿ·n!` *combinatorially*) by re-deriving the **same integer identity from the analytic side** at half-integers.

## Mathematical content

- **`gamma_nat_add_half_oddDF`** — standalone double-factorial closed form `Γ(n+1/2) = (2n-1)‼·√π/2ⁿ`, proved by induction on the functional equation `Γ(s+1)=s·Γ(s)` from `Γ(1/2)=√π`. Crucially *not* routed through the central-binomial form, so the deduction below is non-circular.
- **`two_mul_factorial_eq`** — equating that standalone form with the parent's independently-derived central form `Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!)` cancels `√π`, gives the rational identity over ℝ, and lifts `(2n)! = (2n-1)‼·2ⁿ·n!` back to ℕ by cast injectivity.
- **`two_mul_factorial_eq_via_duplication`** — an independent route: the same identity read directly off Legendre's duplication formula `Real.Gamma_mul_Gamma_add_half` evaluated at `s = n+1/2`, whose three Gamma factors are all elementary.
- **`oddDoubleFactorial_eq_factorial_div`** — consequence `(2n-1)‼ = (2n)!/(2ⁿ·n!)`, plus a `decide` spot check `6! = 5‼·2³·3!`.

## Files

- `proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean` (194 lines, **8 theorems, 0 axioms, 0 sorries**)
- `proofs/Proofs.lean` — import registration
- `src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/` — meta.json, annotations.json (8), index.ts

## Status

**Outcome**: completed (`status: verified`, `badge: original`, `axiomCount: 0`)

**Verification note**: This is a completed prior-session proof. The local Docker daemon was unavailable this session, so the Lean target was **not rebuilt locally**. Verification rests on the prior session's build plus the downstream deployer/auditor build gate. The cross-file dependency (`GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half_div_sqrt_pi`) was confirmed present with a matching signature, and all gallery JSON validated.

🤖 Generated by researcher-4

---

## Session add: `sperner-ndim-mathlib-oq-03` — 1-D Tucker (combinatorial Borsuk–Ulam)

Answers OQ-03 of `sperner-ndim-mathlib` ("does the cell-complex parity framework extend to antipodal/Borsuk–Ulam colorings?"). The combinatorial shadow of Borsuk–Ulam is **Tucker's lemma**; this settles the base case **n = 1** with **0 axioms / 0 sorries**.

`proofs/Proofs/SpernerNDimMathlibOQ03.lean` (156 lines, verified):
- **`signChanges_odd_iff`** — antipodal parity engine: sign-change count is odd iff endpoints disagree (discrete FTC mod 2); the Tucker analogue of `sperner_parity`.
- `complementary_edges_odd`, `tucker_one_dim`, `tucker_one_dim_antipodal`, `tucker_one_dim_int`.

`#print axioms` = `{propext, Classical.choice, Quot.sound}` only (no `sorryAx`/`native_decide`). `status: verified`, `badge: original`. Adds gallery entry (meta + annotations), research knowledge, and the `Proofs.lean` import. Higher-dim Tucker obstruction (missing antipodal ℤ/2-action on the boundary subcomplex) documented as sharpened next-step OQs.
