### PR TITLE
research(gamma-reflection-oq-01-oq-03-oq-01-oq-01): analytic reproof of (2n)!=(2n-1)‼·2ⁿ·n! [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3061,6 +3061,7 @@ import Proofs.GammaReflectionFormulaOQ01OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ01OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ03
 import Proofs.GammaReflectionFormulaOQ01OQ03OQ01
+import Proofs.GammaReflectionFormulaOQ01OQ03OQ01OQ01
 import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussLemmaPrimitiveOQ01OQ02
 import Proofs.GaussWilsonNonCyclic

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean
@@ -1,0 +1,194 @@
+/-
+# Gamma Reflection OQ-01-OQ-03-OQ-01-OQ-01: An *analytic* reproof of `(2n)! = (2n-1)‼·2ⁿ·n!`
+
+**Open question (sibling `GammaReflectionFormulaOQ01OQ03OQ01`).** The sibling file proves
+the factorial identity
+
+> `(2n)! = (2n-1)‼ · 2ⁿ · n!`
+
+by a purely **combinatorial** route — the factorial split `(2n)! = (2n)‼·(2n-1)‼`
+together with `(2n)‼ = 2ⁿ·n!` (`Nat.doubleFactorial_two_mul`) — and uses it to convert the
+central form of the half-integer Gamma value into the odd-double-factorial form.
+
+This file does the **reverse**: it reproves the *same* arithmetic identity from the
+**analytic** side, "from the Legendre/half-integer Gamma value", with no appeal to the
+combinatorial bridge. The two pieces are:
+
+* a *fresh* induction giving the double-factorial closed form
+  `Γ(n+1/2) = (2n-1)‼·√π / 2ⁿ` directly from the functional equation
+  `Γ(s+1) = s·Γ(s)` and `Γ(1/2) = √π` — **not** routed through the central form; and
+* the parent's independently-derived central form
+  `Γ(n+1/2) = (2n)!·√π / (4ⁿ·n!)` (`GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half`).
+
+Equating the two closed forms cancels `√π` and yields the rational identity
+`(2n-1)‼ / 2ⁿ = (2n)! / (4ⁿ·n!)`; clearing denominators and casting back to `ℕ` gives
+`(2n)! = (2n-1)‼·2ⁿ·n!`. Because the two Gamma forms are each obtained by an *independent*
+telescoping of the half-integer recursion, the deduction is genuinely non-circular: the
+combinatorial identity is recovered as the statement that the two telescopings agree.
+
+## What is new
+
+The double-factorial half-integer form is here proved standalone (the sibling instead
+derived it *from* the central form *using* the very identity we now reprove). The
+analytic → arithmetic lift `(2n)! = (2n-1)‼·2ⁿ·n!` obtained by equating two Gamma closed
+forms is the new content; neither it nor the standalone induction is in Mathlib.
+
+## Method
+
+Induction for `gamma_nat_add_half_oddDF`: base `Γ(1/2)=√π`; step uses
+`Γ((k+1)+1/2) = (k+1/2)·Γ(k+1/2)` and the odd-double-factorial recursion
+`(2(k+1)-1)‼ = (2k+1)·(2k-1)‼` (`oddDoubleFactorial_succ`). Equating with the parent's
+central form and clearing denominators over `ℝ` recovers the real identity
+`((2n-1)‼ : ℝ)·2ⁿ·n! = (2n)!`; `Nat.cast_injective` lifts it to `ℕ`.
+
+## References
+
+* Mathlib: `Mathlib/Data/Nat/Factorial/DoubleFactorial.lean`,
+  `Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean`.
+* Whittaker & Watson, *A Course of Modern Analysis*, §12.14 (half-integer values of `Γ`).
+-/
+import Mathlib
+import Proofs.GammaReflectionFormulaOQ01OQ03
+
+namespace GammaReflectionFormulaOQ01OQ03OQ01OQ01
+
+open scoped Real Nat
+
+/-! ## The odd double-factorial recursion -/
+
+/-- **Odd double-factorial successor step.**
+`(2(k+1)-1)‼ = (2k+1)·(2k-1)‼` for every `k : ℕ`. After rewriting `2(k+1)-1 = 2k+1` this
+is exactly `Nat.doubleFactorial_add_one : (m+1)‼ = (m+1)·(m-1)‼` at `m = 2k`. -/
+theorem oddDoubleFactorial_succ (k : ℕ) :
+    (2 * (k + 1) - 1)‼ = (2 * k + 1) * (2 * k - 1)‼ := by
+  have e1 : 2 * (k + 1) - 1 = 2 * k + 1 := by omega
+  rw [e1, Nat.doubleFactorial_add_one]
+
+/-! ## The standalone double-factorial half-integer Gamma value -/
+
+/-- **Double-factorial closed form of `Γ` at half-integers, proved standalone.**
+`Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ` for every `n : ℕ`. Unlike the sibling
+`GammaReflectionFormulaOQ01OQ03OQ01.gamma_nat_add_half_doubleFactorial`, this is obtained
+*directly* by induction on the functional equation `Γ(s+1) = s·Γ(s)`, with no use of the
+factorial identity `(2n)! = (2n-1)‼·2ⁿ·n!`. -/
+theorem gamma_nat_add_half_oddDF (n : ℕ) :
+    Real.Gamma (n + 1 / 2) = ((2 * n - 1)‼ : ℝ) * Real.sqrt π / 2 ^ n := by
+  induction n with
+  | zero =>
+    -- `(2·0-1)‼ = 0‼ = 1`, `2⁰ = 1`: reduces to `Γ(1/2) = √π`.
+    have h0 : (2 * 0 - 1)‼ = 1 := rfl
+    simp only [Nat.cast_zero, zero_add, h0, Nat.cast_one, pow_zero, one_mul, div_one]
+    exact Real.Gamma_one_half_eq
+  | succ k ih =>
+    have hs : ((k : ℝ) + 1 / 2) ≠ 0 := by positivity
+    have h2 : (2 : ℝ) ^ k ≠ 0 := by positivity
+    -- Step `Γ((k+1)+1/2) = (k+1/2)·Γ(k+1/2)`, substitute the IH.
+    have harg : ((k + 1 : ℕ) : ℝ) + 1 / 2 = ((k : ℝ) + 1 / 2) + 1 := by push_cast; ring
+    -- Odd double-factorial recursion, transported to `ℝ`.
+    have hdf : (((2 * (k + 1) - 1)‼ : ℕ) : ℝ)
+        = (2 * (k : ℝ) + 1) * (((2 * k - 1)‼ : ℕ) : ℝ) := by
+      rw [oddDoubleFactorial_succ]; push_cast; ring
+    rw [harg, Real.Gamma_add_one hs, ih, hdf, pow_succ]
+    field_simp
+
+/-! ## The analytic reproof of the factorial identity -/
+
+/-- **Double-factorial form divided by `Γ(1/2) = √π`.**
+`Γ(n+1/2)/√π = (2n-1)‼/2ⁿ`: the half-integer Gamma quotient as the odd double factorial
+scaled by `2⁻ⁿ`. The `√π`-free shadow of `gamma_nat_add_half_oddDF`. -/
+theorem gamma_nat_add_half_oddDF_div_sqrt_pi (n : ℕ) :
+    Real.Gamma (n + 1 / 2) / Real.sqrt π = ((2 * n - 1)‼ : ℝ) / 2 ^ n := by
+  rw [gamma_nat_add_half_oddDF]
+  have hπ : Real.sqrt π ≠ 0 := by positivity
+  field_simp
+
+/-- **The factorial identity, recovered analytically over `ℝ`.**
+Both `(2n-1)‼/2ⁿ` and `(2n)!/(4ⁿ·n!)` equal the `√π`-free quotient `Γ(n+1/2)/√π`, so they
+are equal; cross-multiplying gives `((2n-1)‼ : ℝ)·2ⁿ·n! = (2n)!`. No appeal to the
+combinatorial split. -/
+theorem two_mul_factorial_eq_real (n : ℕ) :
+    (((2 * n - 1)‼ : ℕ) : ℝ) * 2 ^ n * (n.factorial : ℝ) = ((2 * n).factorial : ℝ) := by
+  -- The two rational quotients agree (both are `Γ(n+1/2)/√π`).
+  have hrat : ((2 * n - 1)‼ : ℝ) / 2 ^ n
+      = ((2 * n).factorial : ℝ) / (4 ^ n * (n.factorial : ℝ)) :=
+    (gamma_nat_add_half_oddDF_div_sqrt_pi n).symm.trans
+      (GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half_div_sqrt_pi n)
+  have h2 : (2 : ℝ) ^ n ≠ 0 := by positivity
+  have hfac : (n.factorial : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+  have hden : (4 : ℝ) ^ n * (n.factorial : ℝ) ≠ 0 := by positivity
+  have h4 : (4 : ℝ) ^ n = 2 ^ n * 2 ^ n := by
+    rw [show (4 : ℝ) = 2 * 2 by norm_num, mul_pow]
+  -- Cross-multiply, expand `4ⁿ = 2ⁿ·2ⁿ`, then cancel one `2ⁿ`.
+  rw [div_eq_div_iff h2 hden, h4] at hrat
+  have key : ((((2 * n - 1)‼ : ℕ) : ℝ) * 2 ^ n * (n.factorial : ℝ)) * 2 ^ n
+      = ((2 * n).factorial : ℝ) * 2 ^ n := by
+    linear_combination hrat
+  exact mul_right_cancel₀ h2 key
+
+/-- **The factorial identity `(2n)! = (2n-1)‼·2ⁿ·n!`, proved analytically.**
+The same statement as the sibling's combinatorial `two_mul_factorial_eq`, but obtained by
+lifting the real identity `two_mul_factorial_eq_real` back to `ℕ` via injectivity of the
+cast — an analytic proof of a combinatorial fact. -/
+theorem two_mul_factorial_eq (n : ℕ) :
+    (2 * n)! = (2 * n - 1)‼ * 2 ^ n * n ! := by
+  have h := two_mul_factorial_eq_real n
+  have hcast : (((2 * n - 1)‼ * 2 ^ n * n ! : ℕ) : ℝ) = ((2 * n)! : ℝ) := by
+    push_cast; linarith [h]
+  exact_mod_cast hcast.symm
+
+/-! ## The Legendre-duplication route (the open question, verbatim)
+
+The deduction above equated two closed forms of `Γ(n+1/2)`. The open question asks instead
+for the route through **Legendre's duplication formula**
+`Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π` (`Real.Gamma_mul_Gamma_add_half`). Evaluated at
+`s = n+1/2` its three Gamma factors are all elementary —
+`Γ(n+1/2) = (2n-1)‼·√π/2ⁿ` (the standalone form above), `Γ((n+1/2)+1/2) = Γ(n+1) = n!`,
+and `Γ(2(n+1/2)) = Γ(2n+1) = (2n)!` — while `2^(1-2(n+1/2)) = 2^(-2n)`. Substituting and
+cancelling the common `√π` recovers the *same* identity `(2n)! = (2n-1)‼·2ⁿ·n!`, now read
+off the duplication formula directly. -/
+
+/-- **The factorial identity, from the duplication formula at `s = n+1/2`.**
+`((2n-1)‼ : ℝ)·2ⁿ·n! = (2n)!`, obtained by substituting the three elementary Gamma values
+into `Real.Gamma_mul_Gamma_add_half (n+1/2)` and cancelling `√π`. Independent of the
+two-closed-forms argument (`two_mul_factorial_eq_real`): here a *single* analytic identity,
+Legendre duplication, carries the whole deduction. -/
+theorem two_mul_factorial_eq_via_duplication (n : ℕ) :
+    (((2 * n - 1)‼ : ℕ) : ℝ) * 2 ^ n * (n.factorial : ℝ) = ((2 * n).factorial : ℝ) := by
+  have hπ : (0 : ℝ) < Real.sqrt π := Real.sqrt_pos.mpr Real.pi_pos
+  have h2 : (2 : ℝ) ^ n ≠ 0 := by positivity
+  have hdup := Real.Gamma_mul_Gamma_add_half ((n : ℝ) + 1 / 2)
+  rw [gamma_nat_add_half_oddDF n,
+      show (1 : ℝ) - 2 * ((n : ℝ) + 1 / 2) = -((2 * n : ℕ) : ℝ) by push_cast; ring,
+      show ((n : ℝ) + 1 / 2) + 1 / 2 = ((n : ℝ) + 1) by ring,
+      show 2 * ((n : ℝ) + 1 / 2) = ((2 * n : ℕ) : ℝ) + 1 by push_cast; ring,
+      Real.rpow_neg (by norm_num : (0 : ℝ) ≤ 2), Real.rpow_natCast,
+      Real.Gamma_nat_eq_factorial, Real.Gamma_nat_eq_factorial] at hdup
+  -- `hdup : (2n-1)‼·√π/2ⁿ · n! = (2n)! · (2^(2n))⁻¹ · √π`.
+  have h22 : (2 : ℝ) ^ (2 * n) = 2 ^ n * 2 ^ n := by rw [two_mul, pow_add]
+  rw [h22] at hdup
+  -- Collect both sides as `(…)·√π` and cancel `√π`.
+  have hcollect : (((2 * n - 1)‼ : ℝ) * (n.factorial : ℝ) / 2 ^ n) * Real.sqrt π
+      = (((2 * n).factorial : ℝ) / (2 ^ n * 2 ^ n)) * Real.sqrt π := by
+    rw [div_eq_mul_inv ((2 * n).factorial : ℝ)]; linear_combination hdup
+  have hcancel := mul_right_cancel₀ (ne_of_gt hπ) hcollect
+  rw [div_eq_div_iff h2 (by positivity)] at hcancel
+  -- `hcancel : (2n-1)‼·n!·(2ⁿ·2ⁿ) = (2n)!·2ⁿ`; cancel one `2ⁿ`.
+  have key : (((2 * n - 1)‼ : ℝ) * 2 ^ n * (n.factorial : ℝ)) * 2 ^ n
+      = ((2 * n).factorial : ℝ) * 2 ^ n := by linear_combination hcancel
+  exact mul_right_cancel₀ h2 key
+
+/-! ## Consequences -/
+
+/-- **The odd double factorial as a factorial quotient.**
+`(2n-1)‼ = (2n)! / (2ⁿ·n!)`, the immediate divisibility consequence of the identity. -/
+theorem oddDoubleFactorial_eq_factorial_div (n : ℕ) :
+    (2 * n - 1)‼ = (2 * n)! / (2 ^ n * n !) := by
+  have h := two_mul_factorial_eq n
+  have hpos : 0 < 2 ^ n * n ! := Nat.mul_pos (pow_pos (by norm_num) n) (Nat.factorial_pos n)
+  have h' : (2 * n)! = (2 * n - 1)‼ * (2 ^ n * n !) := by rw [h]; ring
+  exact (Nat.div_eq_of_eq_mul_left hpos h').symm
+
+/-- **Spot check `n = 3`.** `6! = 720 = 5‼ · 2³ · 3! = 15 · 8 · 6`. -/
+theorem two_mul_factorial_eq_three : (6)! = (5)‼ * 2 ^ 3 * (3)! := by decide
+
+end GammaReflectionFormulaOQ01OQ03OQ01OQ01

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "Running the Derivation in Reverse: an Analytic Proof of a Combinatorial Fact",
+    "content": "The sibling GammaReflectionFormulaOQ01OQ03OQ01 proves the integer identity (2n)! = (2n-1)‼·2ⁿ·n! combinatorially and uses it to convert the central Gamma form into the double-factorial form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ. This file runs the deduction in reverse: it proves the double-factorial Gamma form standalone (a fresh induction on Γ(s+1) = s·Γ(s), not routed through the central form) and then recovers the integer identity from the analytic side — once by equating two independent telescopings of Γ(n+1/2), and once directly from Legendre's duplication formula. Because the double-factorial form is established without the identity it goes on to prove, the argument is genuinely non-circular.",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$ recovers $(2n)! = (2n-1)!!\\cdot 2^{n}\\cdot n!$.",
+    "significance": "context",
+    "relatedConcepts": ["Gamma function", "double factorial", "Legendre duplication formula", "half-integer Gamma values"]
+  },
+  {
+    "id": "ann-odd-recursion",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "technique",
+    "title": "The Odd Double-Factorial Recursion",
+    "content": "oddDoubleFactorial_succ establishes (2(k+1)-1)‼ = (2k+1)·(2k-1)‼. Over ℕ the argument 2(k+1)-1 must first be rewritten to 2k+1 (truncated subtraction), after which the claim is exactly Nat.doubleFactorial_add_one : (m+1)‼ = (m+1)·(m-1)‼ at m = 2k. This recursion is the engine of the standalone Gamma induction in the next section.",
+    "mathContext": "$(2k+1)!! = (2k+1)\\,(2k-1)!!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["double factorial", "natural-number subtraction", "recursion"]
+  },
+  {
+    "id": "ann-standalone-gamma",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 92 },
+    "type": "key-step",
+    "title": "The Standalone Double-Factorial Half-Integer Gamma Value",
+    "content": "gamma_nat_add_half_oddDF proves Γ(n+1/2) = (2n-1)‼·√π/2ⁿ directly by induction on n. The base case n = 0 reduces to Γ(1/2) = √π (Real.Gamma_one_half_eq). The step uses Γ((k+1)+1/2) = (k+1/2)·Γ(k+1/2) (Real.Gamma_add_one), substitutes the induction hypothesis, applies the odd-double-factorial recursion transported to ℝ, and closes with field_simp. Crucially this never touches the central binomial form or the factorial identity, which is what makes the later recovery of that identity non-circular.",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$, proved by induction on $\\Gamma(s+1)=s\\,\\Gamma(s)$.",
+    "significance": "critical",
+    "relatedConcepts": ["Gamma functional equation", "mathematical induction", "double factorial"]
+  },
+  {
+    "id": "ann-two-closed-forms",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 94, "endLine": 137 },
+    "type": "key-step",
+    "title": "The Analytic Reproof via Two Closed Forms",
+    "content": "gamma_nat_add_half_oddDF_div_sqrt_pi divides the standalone form by √π to give the rational quotient (2n-1)‼/2ⁿ. two_mul_factorial_eq_real equates this with the parent's central quotient (2n)!/(4ⁿ·n!) (GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half_div_sqrt_pi), cross-multiplies via div_eq_div_iff, expands 4ⁿ = 2ⁿ·2ⁿ, and cancels one 2ⁿ with mul_right_cancel₀ to obtain ((2n-1)‼ : ℝ)·2ⁿ·n! = (2n)!. two_mul_factorial_eq then lifts this real identity back to ℕ via Nat.cast injectivity — an analytic proof of a purely combinatorial fact.",
+    "mathContext": "$\\dfrac{(2n-1)!!}{2^{n}} = \\dfrac{(2n)!}{4^{n} n!} \\implies (2n)! = (2n-1)!!\\cdot 2^{n}\\cdot n!$.",
+    "significance": "critical",
+    "relatedConcepts": ["cast injectivity", "field manipulation", "combinatorial identity"]
+  },
+  {
+    "id": "ann-duplication-route",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 139, "endLine": 178 },
+    "type": "key-step",
+    "title": "The Legendre-Duplication Route (the Open Question, Verbatim)",
+    "content": "two_mul_factorial_eq_via_duplication recovers the same integer identity directly from Legendre's duplication formula Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π (Real.Gamma_mul_Gamma_add_half) at s = n+1/2. The three Gamma factors are all elementary: Γ(n+1/2) = (2n-1)‼·√π/2ⁿ (the standalone form), Γ((n+1/2)+1/2) = Γ(n+1) = n!, and Γ(2(n+1/2)) = Γ(2n+1) = (2n)! (Real.Gamma_nat_eq_factorial), while the power collapses to 2^(-2n). After expanding 2^(2n) = 2ⁿ·2ⁿ, both sides are collected as (…)·√π, √π is cancelled (mul_right_cancel₀), and one 2ⁿ is cancelled — a single analytic identity carrying the whole deduction, exactly as the open question requested.",
+    "mathContext": "$\\Gamma(s)\\,\\Gamma\\!\\left(s+\\tfrac12\\right) = 2^{1-2s}\\sqrt{\\pi}\\,\\Gamma(2s)$ at $s = n+\\tfrac12$.",
+    "significance": "critical",
+    "relatedConcepts": ["Legendre duplication formula", "half-integer Gamma values", "real power (rpow)"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 180, "endLine": 194 },
+    "type": "context",
+    "title": "Consequences and Spot Check",
+    "content": "oddDoubleFactorial_eq_factorial_div reads the identity as an exact natural-number quotient (2n-1)‼ = (2n)!/(2ⁿ·n!) via Nat.div_eq_of_eq_mul_left, certifying the divisibility 2ⁿ·n! ∣ (2n)!. two_mul_factorial_eq_three confirms the closed form numerically at n = 3: 6! = 720 = 5‼·2³·3! = 15·8·6, by decide.",
+    "mathContext": "$(2n-1)!! = \\dfrac{(2n)!}{2^{n} n!}$; $6! = 5!!\\cdot 2^{3}\\cdot 3! = 720$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility", "natural-number division", "decidability"]
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/index.ts
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gammaReflectionFormulaOq01Oq03Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gammaReflectionFormulaOq01Oq03Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gammaReflectionFormulaOq01Oq03Oq01Oq01Data: ProofData = {
+  proof: gammaReflectionFormulaOq01Oq03Oq01Oq01Proof,
+  annotations: gammaReflectionFormulaOq01Oq03Oq01Oq01Annotations,
+}

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+  "slug": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GammaReflectionFormulaOQ01OQ03"
+    ],
+    "opens": [
+      "scoped Real Nat"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ03OQ01OQ01",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "An Analytic Reproof of (2n)! = (2n-1)‼·2ⁿ·n! from the Legendre Duplication Formula",
+  "description": "Answers the sibling's open question: rather than proving the integer identity (2n)! = (2n-1)‼·2ⁿ·n! combinatorially (the factorial split (2n)! = (2n)‼·(2n-1)‼ with (2n)‼ = 2ⁿ·n!) and using it to convert the central Gamma form into the double-factorial form, this entry runs the deduction in reverse — recovering the combinatorial identity from the analytic side, with no appeal to the combinatorial bridge. First, the double-factorial closed form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ is proved standalone by a fresh induction on the functional equation Γ(s+1) = s·Γ(s) and Γ(1/2) = √π, routed through the odd-double-factorial recursion (2(k+1)-1)‼ = (2k+1)·(2k-1)‼ rather than the central binomial form. Equating this with the parent's independently-derived central form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) cancels √π and yields the rational identity (2n-1)‼/2ⁿ = (2n)!/(4ⁿ·n!); clearing denominators and casting back to ℕ via injectivity gives (2n)! = (2n-1)‼·2ⁿ·n!. The same identity is then obtained a second, fully independent way directly from Legendre's duplication formula Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π (Real.Gamma_mul_Gamma_add_half) evaluated at s = n+1/2, where all three Gamma factors are elementary half-integer values. 194 lines, 8 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "factorial",
+      "double-factorial",
+      "duplication-formula",
+      "combinatorial-identity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 194,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "gamma_nat_add_half_oddDF: the double-factorial half-integer Gamma form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ proved standalone by induction on the functional equation Γ(s+1) = s·Γ(s), with no use of the factorial identity (2n)! = (2n-1)‼·2ⁿ·n! — unlike the sibling, which derived this form from the central form using the very identity reproved here. This makes the subsequent deduction genuinely non-circular.",
+      "two_mul_factorial_eq_real / two_mul_factorial_eq: an analytic reproof of the integer identity (2n)! = (2n-1)‼·2ⁿ·n!, obtained by equating two independently-telescoped closed forms of Γ(n+1/2) (the standalone double-factorial form and the parent's central form), cancelling √π, clearing denominators over ℝ, and lifting back to ℕ via Nat.cast injectivity — an analytic proof of a combinatorial fact.",
+      "two_mul_factorial_eq_via_duplication: the same integer identity obtained a second, independent way directly from Legendre's duplication formula Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π (Real.Gamma_mul_Gamma_add_half) at s = n+1/2, substituting the three elementary half-integer Gamma values and cancelling the common √π — the route requested verbatim by the open question.",
+      "oddDoubleFactorial_succ: the odd-double-factorial recursion (2(k+1)-1)‼ = (2k+1)·(2k-1)‼, the engine of the standalone induction, obtained from Nat.doubleFactorial_add_one after rewriting 2(k+1)-1 = 2k+1 over ℕ.",
+      "oddDoubleFactorial_eq_factorial_div: the divisibility consequence (2n-1)‼ = (2n)!/(2ⁿ·n!), reading the integer identity as an exact natural-number quotient via Nat.div_eq_of_eq_mul_left."
+    ],
+    "prerequisites": [
+      "The parent's central half-integer closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) and its √π-free ratio (GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half, gamma_nat_add_half_div_sqrt_pi)",
+      "The Gamma functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) and Γ(1/2) = √π (Real.Gamma_one_half_eq)",
+      "Legendre's duplication formula Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π (Real.Gamma_mul_Gamma_add_half) and Γ(n+1) = n! (Real.Gamma_nat_eq_factorial)",
+      "Nat.doubleFactorial with notation n‼ and its recursion (m+1)‼ = (m+1)·(m-1)‼ (Nat.doubleFactorial_add_one)",
+      "Real-field manipulation (field_simp / linear_combination / mul_right_cancel₀) and Nat.cast injectivity to lift the real identity to ℕ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_mul_Gamma_add_half",
+        "description": "Legendre's duplication formula Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π — the single analytic identity carrying the duplication-route derivation.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "The Gamma functional equation Γ(s+1) = s·Γ(s) for s ≠ 0 — the engine of the standalone induction for the double-factorial form.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_nat_eq_factorial",
+        "description": "Γ(n+1) = n! — collapses the two elementary Gamma factors Γ(n+1) and Γ(2n+1) in the duplication route to n! and (2n)!.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Nat.doubleFactorial_add_one",
+        "description": "(m+1)‼ = (m+1)·(m-1)‼ — at m = 2k yields the odd-double-factorial recursion (2k+1)‼ = (2k+1)·(2k-1)‼ used in the standalone induction.",
+        "module": "Mathlib.Data.Nat.Factorial.DoubleFactorial"
+      },
+      {
+        "theorem": "GammaReflectionFormulaOQ01OQ03.gamma_nat_add_half_div_sqrt_pi",
+        "description": "The parent's √π-free central ratio Γ(n+1/2)/√π = (2n)!/(4ⁿ·n!), equated with the standalone double-factorial ratio to recover the integer identity analytically.",
+        "module": "Proofs.GammaReflectionFormulaOQ01OQ03"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01-oq-01",
+      "question": "Use the standalone double-factorial form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ to evaluate the half-line Gaussian moments ∫₀^∞ x^(2n) e^(-x²) dx = (2n-1)‼·√π/2^(n+1) via the substitution u = x², closing the loop between the analytic Gamma value and its integral representation.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "The sibling proves the same integer identity (2n)! = (2n-1)‼·2ⁿ·n! combinatorially and uses it to reach the double-factorial Gamma form; this entry inverts the logic, proving the double-factorial form standalone and recovering the integer identity analytically (and again from Legendre duplication), answering the sibling's stated open question."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "The grandparent proves the central-binomial closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!); its √π-free ratio is equated here with the standalone double-factorial ratio to recover the integer identity without the combinatorial bridge."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "extends",
+      "description": "The root entry establishes Euler's reflection formula and Γ(1/2) = √π, the base case of the standalone induction for the double-factorial Gamma form."
+    }
+  ],
+  "references": [
+    {
+      "title": "A Course of Modern Analysis",
+      "author": "E. T. Whittaker and G. N. Watson",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "description": "Classical reference for half-integer values of the Gamma function, Legendre duplication, and the double-factorial bookkeeping (§12.14, §12.15)."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_mul_Gamma_add_half (Legendre duplication), Real.Gamma_add_one, and Real.Gamma_nat_eq_factorial used in both analytic routes."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The half-integer values Γ(n+1/2) = (2n-1)‼·√π/2ⁿ are usually derived combinatorially: one proves the integer identity (2n)! = (2n-1)‼·2ⁿ·n! (the even/odd double-factorial split (2n)! = (2n)‼·(2n-1)‼ composed with (2n)‼ = 2ⁿ·n!) and substitutes it into the central-binomial Gamma form. The sibling entry takes exactly this route. This entry asks the converse question: can the same combinatorial identity be read off the analytic theory of Γ itself? The answer is yes, in two independent ways — by equating two telescopings of Γ(n+1/2), and directly from Legendre's duplication formula — turning a combinatorial fact into a corollary of special-function analysis.",
+    "problemStatement": "Reprove the integer identity (2n)! = (2n-1)‼·2ⁿ·n! from the analytic side, in particular from the Legendre duplication formula Γ(s)·Γ(s+1/2) = Γ(2s)·2^(1-2s)·√π at half-integer argument, without appeal to the combinatorial even/odd double-factorial split.",
+    "proofStrategy": "Step 1: prove the double-factorial Gamma form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ standalone, by induction on n — base Γ(1/2) = √π, step Γ((k+1)+1/2) = (k+1/2)·Γ(k+1/2) combined with the odd-double-factorial recursion (2k+1)‼ = (2k+1)·(2k-1)‼ and field_simp. This avoids the central form entirely. Step 2 (two-closed-forms route): equate the √π-free ratio of this form with the parent's central ratio Γ(n+1/2)/√π = (2n)!/(4ⁿ·n!), cross-multiply, expand 4ⁿ = 2ⁿ·2ⁿ, cancel one 2ⁿ, and lift the resulting real identity to ℕ via Nat.cast injectivity. Step 3 (duplication route): substitute the three elementary values Γ(n+1/2) = (2n-1)‼·√π/2ⁿ, Γ((n+1/2)+1/2) = Γ(n+1) = n!, Γ(2(n+1/2)) = Γ(2n+1) = (2n)! and 2^(1-2(n+1/2)) = 2^(-2n) into Real.Gamma_mul_Gamma_add_half (n+1/2), collect both sides as (…)·√π, cancel √π, and cancel one 2ⁿ to recover the same integer identity.",
+    "keyInsights": [
+      "The standalone double-factorial induction is the crux: deriving Γ(n+1/2) = (2n-1)‼·√π/2ⁿ directly from Γ(s+1) = s·Γ(s) — rather than from the central form — is what makes the subsequent recovery of (2n)! = (2n-1)‼·2ⁿ·n! non-circular.",
+      "The integer identity is the statement that two independent telescopings of the half-integer Gamma recursion agree: the central form telescopes (2n)!/(4ⁿ·n!), the double-factorial form telescopes (2n-1)‼/2ⁿ, and their equality is exactly the bridge.",
+      "Legendre duplication carries the whole deduction in a single analytic identity: at s = n+1/2 its three Gamma factors are all elementary half-integer or integer values, so substituting and cancelling √π gives the combinatorial identity with no induction beyond the standalone Gamma form.",
+      "Over ℝ the only non-formal step is 4ⁿ = 2ⁿ·2ⁿ (equivalently 2^(2n) = 2ⁿ·2ⁿ): ring treats the powers as independent atoms, so the factorisation must be supplied explicitly before cancelling.",
+      "The badge is original: neither the standalone odd-double-factorial Gamma induction nor the analytic/duplication lift of (2n)! = (2n-1)‼·2ⁿ·n! is in Mathlib, which records only the combinatorial double-factorial facts."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: An Analytic Reproof",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Contrasts the sibling's combinatorial route with this file's reverse, analytic route: prove the double-factorial Gamma form standalone, then recover (2n)! = (2n-1)‼·2ⁿ·n! by equating two closed forms and, independently, from Legendre duplication. Explains why the deduction is non-circular.",
+      "mathContext": "$\\Gamma(n+\\tfrac12) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$ recovers $(2n)! = (2n-1)!!\\cdot 2^{n}\\cdot n!$."
+    },
+    {
+      "id": "odd-recursion",
+      "title": "The Odd Double-Factorial Recursion",
+      "startLine": 57,
+      "endLine": 66,
+      "summary": "oddDoubleFactorial_succ proves (2(k+1)-1)‼ = (2k+1)·(2k-1)‼ from Nat.doubleFactorial_add_one after rewriting 2(k+1)-1 = 2k+1 — the recursion driving the standalone Gamma induction.",
+      "mathContext": "$(2k+1)!! = (2k+1)\\,(2k-1)!!$."
+    },
+    {
+      "id": "standalone-gamma",
+      "title": "The Standalone Double-Factorial Half-Integer Gamma Value",
+      "startLine": 67,
+      "endLine": 92,
+      "summary": "gamma_nat_add_half_oddDF proves Γ(n+1/2) = (2n-1)‼·√π/2ⁿ directly by induction on the functional equation Γ(s+1) = s·Γ(s) — base Γ(1/2) = √π, step via the odd-double-factorial recursion and field_simp — with no use of the central form or the factorial identity.",
+      "mathContext": "$\\Gamma(n+\\tfrac12) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$, by induction on $\\Gamma(s+1)=s\\,\\Gamma(s)$."
+    },
+    {
+      "id": "two-closed-forms",
+      "title": "The Analytic Reproof via Two Closed Forms",
+      "startLine": 94,
+      "endLine": 137,
+      "summary": "gamma_nat_add_half_oddDF_div_sqrt_pi gives the √π-free ratio (2n-1)‼/2ⁿ. two_mul_factorial_eq_real equates it with the parent's central ratio (2n)!/(4ⁿ·n!), cross-multiplies, and cancels one 2ⁿ; two_mul_factorial_eq lifts the real identity to ℕ via Nat.cast injectivity.",
+      "mathContext": "$\\dfrac{(2n-1)!!}{2^{n}} = \\dfrac{(2n)!}{4^{n} n!} \\implies (2n)! = (2n-1)!!\\cdot 2^{n}\\cdot n!$."
+    },
+    {
+      "id": "duplication-route",
+      "title": "The Legendre-Duplication Route",
+      "startLine": 139,
+      "endLine": 178,
+      "summary": "two_mul_factorial_eq_via_duplication recovers the same integer identity directly from Real.Gamma_mul_Gamma_add_half (n+1/2): substitute the three elementary Gamma values, expand 2^(2n) = 2ⁿ·2ⁿ, collect both sides as (…)·√π, cancel √π, and cancel one 2ⁿ. A single analytic identity carries the whole deduction.",
+      "mathContext": "$\\Gamma(s)\\Gamma(s+\\tfrac12) = 2^{1-2s}\\sqrt{\\pi}\\,\\Gamma(2s)$ at $s = n+\\tfrac12$."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences and Spot Check",
+      "startLine": 180,
+      "endLine": 194,
+      "summary": "oddDoubleFactorial_eq_factorial_div reads the identity as the exact natural-number quotient (2n-1)‼ = (2n)!/(2ⁿ·n!); two_mul_factorial_eq_three verifies 6! = 5‼·2³·3! = 720 by decide.",
+      "mathContext": "$(2n-1)!! = \\dfrac{(2n)!}{2^{n} n!}$; $6! = 5!!\\cdot 2^{3}\\cdot 3! = 720$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The integer identity (2n)! = (2n-1)‼·2ⁿ·n! is reproved from the analytic theory of Γ in two independent ways: by equating the standalone double-factorial Gamma form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ (proved here by a fresh induction on Γ(s+1) = s·Γ(s)) with the parent's central form and cancelling √π, and directly from Legendre's duplication formula at s = n+1/2. The divisibility consequence (2n-1)‼ = (2n)!/(2ⁿ·n!) and the spot check 6! = 5‼·2³·3! follow. 194 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Mathlib records the combinatorial double-factorial facts but neither the standalone odd-double-factorial Gamma induction nor the analytic/duplication recovery of (2n)! = (2n-1)‼·2ⁿ·n! — hence the original badge. The result demonstrates that a combinatorial identity can be obtained as a corollary of special-function analysis, the converse of the usual derivation.",
+    "openQuestions": [
+      "Use the standalone double-factorial form to evaluate the half-line Gaussian moments ∫₀^∞ x^(2n) e^(-x²) dx = (2n-1)‼·√π/2^(n+1) via u = x²."
+    ]
+  }
+}

--- a/src/data/research/problems/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01.json
@@ -1,0 +1,88 @@
+{
+  "slug": "gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01",
+  "title": "Double Factorial Identity from Legendre Duplication",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "(2n)! = (2n-1)!! \\cdot 2^n \\cdot n! \\quad \\text{for all } n \\in \\mathbb{N},",
+    "plain": "Reprove the elementary identity (2n)! = (2n-1)!! · 2^n · n! as a consequence of the Legendre duplication formula for the Gamma function evaluated at half-integers, deriving a combinatorial fact from the analytic duplication identity.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T05:03:08-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: (2n)! = (2n-1)‼·2ⁿ·n! reproved analytically two ways — equating the standalone double-factorial Gamma form with the parent central form, and directly from Legendre duplication. 0-axiom, original. Gallery-integrated.",
+    "builtItems": [
+      "gamma_nat_add_half_oddDF: standalone induction for Γ(n+1/2)=(2n-1)‼·√π/2ⁿ (GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean:74)",
+      "two_mul_factorial_eq / two_mul_factorial_eq_real: analytic reproof of (2n)!=(2n-1)‼·2ⁿ·n! via two closed forms (lines 109,132)",
+      "two_mul_factorial_eq_via_duplication: the same identity from Legendre duplication, the open question verbatim (line 155)",
+      "oddDoubleFactorial_succ (line 62), oddDoubleFactorial_eq_factorial_div (line 184)"
+    ],
+    "insights": [
+      "The standalone double-factorial Gamma form Γ(n+1/2)=(2n-1)‼·√π/2ⁿ can be proved by direct induction on Γ(s+1)=s·Γ(s) without routing through the central form, making the recovery of (2n)!=(2n-1)‼·2ⁿ·n! genuinely non-circular.",
+      "The integer identity is exactly the statement that two independent telescopings of the half-integer Gamma recursion (central (2n)!/(4ⁿn!) vs double-factorial (2n-1)‼/2ⁿ) agree.",
+      "Legendre duplication Real.Gamma_mul_Gamma_add_half at s=n+1/2 carries the whole deduction in one analytic identity since all three Gamma factors are elementary half-integer/integer values.",
+      "Over ℝ the only non-formal step is 4ⁿ=2ⁿ·2ⁿ (2^(2n)=2ⁿ·2ⁿ): ring treats the powers as independent atoms so the factorisation must be supplied explicitly before cancelling."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Half-line Gaussian moments ∫₀^∞ x^(2n)e^(-x²)dx = (2n-1)‼·√π/2^(n+1) via u=x² (new follow-up oq-...-oq-01)."
+    ],
+    "markdown": "# Knowledge Base: gamma-reflection-formula-oq-01-oq-03-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "special-functions",
+    "gamma-function",
+    "double-factorial",
+    "duplication-formula",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "gamma-reflection-formula-oq-01",
+    "gamma-reflection-formula-oq-01-oq-01",
+    "gamma-reflection-formula-oq-01-oq-01-oq-01",
+    "gamma-reflection-formula-oq-01-oq-03",
+    "gamma-reflection-formula-oq-01-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T12:08:08.371Z",
+  "lastUpdate": "2026-06-25T12:08:08.409Z",
+  "significance": 5,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean",
+      "filename": "GammaReflectionFormulaOQ01OQ03OQ01OQ01.lean",
+      "lineCount": 194,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question stated by the sibling entry `gamma-reflection-formula-oq-01-oq-03-oq-01`: recover the integer identity **(2n)! = (2n-1)‼·2ⁿ·n!** from the *analytic* theory of Γ, rather than the usual combinatorial even/odd double-factorial split — and in particular from **Legendre's duplication formula**.

## What's new (8 theorems, 194 lines, 0 axioms, 0 sorries)

- **`gamma_nat_add_half_oddDF`** — the double-factorial half-integer form `Γ(n+1/2) = (2n-1)‼·√π/2ⁿ` proved *standalone* by induction on the functional equation `Γ(s+1) = s·Γ(s)` with `Γ(1/2)=√π`, routed through the odd-double-factorial recursion — **no** use of the factorial identity, making the recovery non-circular.
- **`two_mul_factorial_eq{,_real}`** — equate this standalone form with the parent's central form `Γ(n+1/2)=(2n)!·√π/(4ⁿ·n!)`, cancel `√π`, clear denominators over ℝ, and lift to ℕ via `Nat.cast` injectivity. An analytic proof of a combinatorial fact.
- **`two_mul_factorial_eq_via_duplication`** — the same identity a second, fully independent way directly from `Real.Gamma_mul_Gamma_add_half` at `s = n+1/2` (the route requested verbatim by the open question).
- **`oddDoubleFactorial_eq_factorial_div`** — the divisibility consequence `(2n-1)‼ = (2n)!/(2ⁿ·n!)`.

## Verification

Docker was down, so verified with `lake env lean` on the shared Mathlib olean cache:
- **0 errors, 0 warnings** (clean exit).
- `#print axioms` on the main theorems lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom → `status: verified`, `badge: original`.

Gallery integration (`meta.json`, `annotations.json`, `index.ts`) and the research problem record are included; the import is registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)