### PR TITLE
Enrich Erdős Divisibility Pigeonhole chain refinement (oq-03)

### DIFF
--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-03/annotations.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-hasdivchain3-def",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 49, "endLine": 52 },
+    "type": "definition",
+    "title": "The 3-term chain predicate",
+    "content": "`HasDivChain3 S` asserts that `S` contains three elements `a, b, c` with `a ∣ b ∣ c` and `a ≠ b`, `b ≠ c`. For positive elements the two distinctness clauses upgrade the divisor relations to strict inequalities `a < b < c`, so the predicate captures a genuine length-3 chain in the divisibility poset (not a degenerate one collapsed by repeats). Isolating 'length ≥ 3' as a reusable Finset predicate is what lets the refinement state its conclusion crisply: the forced structure stops *below* this threshold.",
+    "mathContext": "$\\exists\\, a,b,c \\in S:\\; a \\mid b,\\; b \\mid c,\\; a \\neq b,\\; b \\neq c$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility poset", "chain (order theory)", "antichain", "transitivity of divisibility"],
+    "prerequisites": ["partial orders", "divisibility", "Finset"]
+  },
+  {
+    "id": "ann-block-no-chain3",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 54, "endLine": 83 },
+    "type": "technique",
+    "title": "Doubling argument: no 3-term chain in [n, 2n]",
+    "content": "The heart of the refinement. Within the block `Icc n (2n)` a *proper* divisor relation `a ∣ b` with `a ≠ b` forces the quotient `d = b/a` to satisfy `d ≥ 2`, hence `b ≥ 2a`. Since `a ≥ n`, this gives `b ≥ 2n`, pinning `b = 2n` and `a = n`. Stacking a second relation `b ∣ c` would demand `c ≥ 2b = 4n > 2n`, impossible inside the block. The `rcases d with _ | _ | d` case split rules out `d = 0` and `d = 1` so that `2 ≤ d`, and `omega` closes the final arithmetic contradiction `2n ≤ 2a ≤ b` versus `2b ≤ c ≤ 2n`.",
+    "mathContext": "$a \\mid b,\\ a \\neq b,\\ a,b \\in [n,2n] \\Rightarrow b \\ge 2a \\ge 2n \\Rightarrow a=n,\\ b=2n;$ then $c \\ge 2b = 4n > 2n.$",
+    "significance": "key",
+    "relatedConcepts": ["doubling argument", "ratio bound", "extremal set", "antichain plus one"],
+    "prerequisites": ["Nat.le_of_dvd", "divisibility quotients", "omega arithmetic"]
+  },
+  {
+    "id": "ann-block-has-pair",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 85, "endLine": 92 },
+    "type": "concept",
+    "title": "The witness block does contain a pair",
+    "content": "The block `Icc n (2n)` is not a full antichain: adjoining the smallest element `n` to the maximal antichain `{n+1, …, 2n}` creates exactly one divisibility relation, `n ∣ 2n` (witnessed by quotient 2). This is the minimal possible amount of forced structure — one pair — and `block_no_chain3` shows it is also the maximal: the single relation never extends to a chain. Together they make `Icc n (2n)` a tight 'antichain-plus-one' configuration.",
+    "mathContext": "$n \\mid 2n,\\quad n \\neq 2n,\\quad n,\\,2n \\in \\mathrm{Icc}\\,n\\,(2n)$",
+    "significance": "supporting",
+    "relatedConcepts": ["maximal antichain", "divisibility pair", "tight extremal example"],
+    "prerequisites": ["Finset.Icc", "divisibility"]
+  },
+  {
+    "id": "ann-threshold-pair-forced",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 94, "endLine": 100 },
+    "type": "context",
+    "title": "The pair is unavoidable (parent pigeonhole)",
+    "content": "This wrapper re-exports the parent theorem `erdos_divisibility_pigeonhole`: *every* `(n+1)`-subset of `{1,…,2n}` already contains a divisibility pair. It frames the contribution precisely — the refinement is not that *a* pair exists (that is forced for all such subsets) but that nothing *beyond* a pair is forced, since the explicit witness block realizes the lower bound exactly. The proof reuses the verified parent result rather than reproving the pigeonhole.",
+    "mathContext": "$T \\subseteq \\{1,\\dots,2n\\},\\ |T| \\ge n+1 \\Rightarrow \\exists\\, a,b \\in T:\\ a \\neq b,\\ a \\mid b$",
+    "significance": "supporting",
+    "relatedConcepts": ["pigeonhole principle", "forced substructure", "lower bound matching"],
+    "prerequisites": ["pigeonhole principle", "Erdős divisibility pigeonhole"]
+  },
+  {
+    "id": "ann-main-confined",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "insight",
+    "title": "Main theorem: forced collisions confine to pairs",
+    "content": "The headline result assembles the witness: `Icc n (2n)` is an `(n+1)`-element subset of `{1,…,2n}` (cardinality from `Nat.card_Icc`, giving `2n − n + 1 = n+1`) that contains a divisibility pair yet no 3-term chain. Therefore the longest divisibility chain forced at the pigeonhole threshold has length exactly 2 — the first horn of the parent's dichotomy ('chains of growing length are forced') fails. The proof is a clean refinement of an existence statement into an exact extremal value.",
+    "mathContext": "$\\exists\\, T \\subseteq \\{1,\\dots,2n\\}:\\ |T| = n+1,\\ (\\exists\\,\\text{pair}) \\wedge \\neg\\,\\mathrm{HasDivChain3}(T)$",
+    "significance": "key",
+    "relatedConcepts": ["extremal combinatorics", "tight bound", "divisibility chain length"],
+    "prerequisites": ["Nat.card_Icc", "Finset cardinality", "the witness block"]
+  },
+  {
+    "id": "ann-ambient-long-chain",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 114, "endLine": 144 },
+    "type": "technique",
+    "title": "The other horn: powers of two as a long ambient chain",
+    "content": "To show the dichotomy is genuine and not vacuous, the interval `{1,…,2n}` is exhibited holding chains of growing length. The powers `{2^0, 2^1, …, 2^k}` (valid while `2^k ≤ 2n`) form such a chain: injectivity of `i ↦ 2^i` (`Nat.pow_right_injective`) gives cardinality `k+1` via `card_image_of_injective`, and `pow_dvd_pow` makes them totally ordered by divisibility since `i ≤ j ⟹ 2^i ∣ 2^j`. So the *poset* on `{1,…,2n}` is deep (depth `~log₂(2n)`) even though the *forced* structure among threshold subsets is shallow.",
+    "mathContext": "$2^k \\le 2n \\Rightarrow \\{2^0,\\dots,2^k\\} \\subseteq \\{1,\\dots,2n\\},\\ \\ 2^i \\mid 2^j \\iff i \\le j$",
+    "significance": "key",
+    "relatedConcepts": ["geometric chain", "powers of two", "poset depth", "image cardinality"],
+    "prerequisites": ["Nat.pow_right_injective", "pow_dvd_pow", "Finset.image"]
+  },
+  {
+    "id": "ann-ambient-unbounded",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 146, "endLine": 156 },
+    "type": "insight",
+    "title": "Ambient chain length is unbounded",
+    "content": "Quantifying the contrast: for any target length `k`, choosing `n = 2^k` makes `{1,…,2n}` contain a divisibility chain of length ≥ `k`. Set against `collisions_confined_to_pairs`, this is the precise statement of the dichotomy — the interval's chains grow like `log n`, but the structure *forced* among `(n+1)`-subsets never exceeds a pair. The two theorems read off complementary facets: poset depth versus forced-collision size.",
+    "mathContext": "$\\forall k\\, \\exists n\\ (= 2^k):\\ \\{1,\\dots,2n\\}\\ \\text{has a }\\mid\\text{-chain of length} \\ge k$",
+    "significance": "supporting",
+    "relatedConcepts": ["unbounded growth", "logarithmic chain length", "separation of parameters"],
+    "prerequisites": ["ambient_has_long_chain", "monotone selection of n"]
+  },
+  {
+    "id": "ann-axiom-audit",
+    "proofId": "erdos-divisibility-pigeonhole-oq-03",
+    "range": { "startLine": 158, "endLine": 162 },
+    "type": "context",
+    "title": "In-file axiom audit",
+    "content": "`#print axioms` on both headline theorems confirms dependence only on the standard foundational axioms `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool` (the proof uses no `native_decide`) and no `sorryAx`. This substantiates the `verified` / `original` badge: the result is fully machine-checked with zero added assumptions, built on the parent's verified pigeonhole theorem.",
+    "mathContext": "axioms $\\subseteq \\{\\texttt{propext},\\ \\texttt{Classical.choice},\\ \\texttt{Quot.sound}\\}$",
+    "significance": "technical",
+    "relatedConcepts": ["axiom auditing", "trusted kernel", "verified status"],
+    "prerequisites": ["Lean axioms", "#print axioms"]
+  }
+]

--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-03/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-03/meta.json
@@ -64,6 +64,91 @@
  },
  "overview": {
   "historicalContext": "The Erdős divisibility pigeonhole — popularized by Paul Erdős, who reportedly posed it to the young Lajos Pósa — guarantees a divisible pair among any n+1 elements of {1,…,2n}. A natural follow-up, recorded as the parent's open question, asks how much *more* structure is forced: a single pair, or an ever-longer divisibility chain? The answer is that only a pair is forced. The block {n,…,2n} adds the smallest element n to the maximal antichain {n+1,…,2n}, creating exactly one divisibility relation (n ∣ 2n) and no chain of length 3. Meanwhile the interval {1,…,2n} as a whole contains the powers-of-two chain 1,2,4,…, whose length ~log₂(2n) grows without bound — so the divisibility poset is deep, but its forced collisions among threshold subsets are shallow.",
-  "significance": "Separates two distinct combinatorial quantities for the divisibility poset on {1,…,2n}: the size of the largest forced collision (a pair, length 2) versus the depth of the poset (chains of length ~log n). It makes precise the intuition that the pigeonhole gem is a statement about pairs, not chains, and exhibits an explicit (n+1)-element 'pair-only' witness alongside an explicit family of long ambient chains."
- }
+  "significance": "Separates two distinct combinatorial quantities for the divisibility poset on {1,…,2n}: the size of the largest forced collision (a pair, length 2) versus the depth of the poset (chains of length ~log n). It makes precise the intuition that the pigeonhole gem is a statement about pairs, not chains, and exhibits an explicit (n+1)-element 'pair-only' witness alongside an explicit family of long ambient chains.",
+  "proofStrategy": "Two contrasting constructions answer the dichotomy. (1) Confinement: the witness block T = Icc n (2n) is shown to contain no 3-term chain via a doubling argument — any proper divisor relation a ∣ b inside [n,2n] forces b ≥ 2a ≥ 2n, pinning a=n, b=2n, after which a third element c ≥ 2b = 4n exceeds the block. Combined with the explicit pair n ∣ 2n and the cardinality |Icc n (2n)| = n+1, this realizes a threshold subset whose forced structure is exactly a pair. (2) Contrast: the powers of two {2^0,…,2^k} are exhibited as a totally ∣-ordered subset of {1,…,2n} of size k+1 (injectivity of i ↦ 2^i for cardinality, pow_dvd_pow for the chain), so ambient chain length grows like log₂(2n). The parent pigeonhole is reused verbatim to certify the pair is unavoidable.",
+  "keyInsights": [
+   "The pigeonhole gem is fundamentally a statement about *pairs*, not chains: the threshold n+1 forces one divisibility relation but never a longer chain among (n+1)-subsets.",
+   "Adjoining the single smallest element n to the maximal antichain {n+1,…,2n} produces an 'antichain-plus-one' set whose only relation is n ∣ 2n — minimal *and* maximal forced structure simultaneously.",
+   "The doubling bound b ≥ 2a is the entire engine: in [n,2n] a divisor must at least double its divisor, so two stacked relations would need a factor of 4 and overflow the block.",
+   "Poset depth and forced-collision size are genuinely different parameters: {1,…,2n} has chains of length ~log₂(2n) (the powers of two) even though nothing past a pair is forced at the threshold.",
+   "Resolving an open question by extremal example: the witness block converts the parent's existence statement (some pair exists) into an exact value (longest forced chain = 2)."
+  ]
+ },
+ "sections": [
+  {
+   "id": "chain-predicate",
+   "title": "The 3-term chain predicate",
+   "startLine": 49,
+   "endLine": 52,
+   "summary": "Defines HasDivChain3 S — three elements a ∣ b ∣ c with a ≠ b, b ≠ c — the reusable 'length ≥ 3' obstruction that the refinement rules out."
+  },
+  {
+   "id": "no-chain3",
+   "title": "No 3-term chain in the witness block",
+   "startLine": 54,
+   "endLine": 83,
+   "summary": "block_no_chain3: the doubling argument b ≥ 2a forces a=n, b=2n, after which b ∣ c with c ≤ 2n is impossible, so Icc n (2n) holds no length-3 chain."
+  },
+  {
+   "id": "block-pair",
+   "title": "The witness block has a pair",
+   "startLine": 85,
+   "endLine": 92,
+   "summary": "block_has_pair: exhibits n ∣ 2n with n ≠ 2n, both in Icc n (2n) — the single divisibility relation created by adjoining n to the antichain."
+  },
+  {
+   "id": "pair-forced",
+   "title": "The pair is unavoidable",
+   "startLine": 94,
+   "endLine": 100,
+   "summary": "every_threshold_set_has_pair re-exports the parent pigeonhole: every (n+1)-subset of {1,…,2n} contains a pair, fixing the lower bound the witness matches."
+  },
+  {
+   "id": "main-confinement",
+   "title": "Collisions confined to pairs",
+   "startLine": 102,
+   "endLine": 112,
+   "summary": "collisions_confined_to_pairs: the headline theorem assembling the (n+1)-element witness with a pair but no 3-term chain — longest forced chain has length exactly 2."
+  },
+  {
+   "id": "ambient-chain",
+   "title": "Powers of two as a long ambient chain",
+   "startLine": 114,
+   "endLine": 144,
+   "summary": "ambient_has_long_chain: whenever 2^k ≤ 2n, the powers {2^0,…,2^k} form a size-(k+1) subset of {1,…,2n} totally ordered by divisibility."
+  },
+  {
+   "id": "ambient-unbounded",
+   "title": "Ambient chain length is unbounded",
+   "startLine": 146,
+   "endLine": 156,
+   "summary": "ambient_chain_length_unbounded: for any k, taking n = 2^k yields a chain of length ≥ k in {1,…,2n} — the second horn making the dichotomy real."
+  },
+  {
+   "id": "axiom-audit",
+   "title": "Axiom audit",
+   "startLine": 158,
+   "endLine": 162,
+   "summary": "#print axioms confirms both headline theorems depend only on propext, Classical.choice, Quot.sound — no native_decide, no sorry."
+  }
+ ],
+ "conclusion": {
+  "summary": "For n ≥ 1 the explicit (n+1)-element block {n,…,2n} contains a divisibility pair (forced, by the parent pigeonhole) but no 3-term divisibility chain, so the longest divisibility chain that the threshold n+1 can force among subsets of {1,…,2n} has length exactly 2. The contrasting construction — the powers of two inside {1,…,2n} — shows chain lengths in the interval itself grow like log₂(2n), so the parent's chain-versus-pair dichotomy is genuine: forced collisions are shallow even though the divisibility poset is deep.",
+  "implications": "The result cleanly separates two combinatorial quantities that the original pigeonhole statement conflates: the size of the largest *forced* collision (a pair) and the depth of the divisibility poset (logarithmic). It certifies that the Erdős gem is intrinsically a theorem about pairs, and supplies a tight extremal witness — the antichain-plus-one block — that any sharper quantitative refinement must respect. Methodologically it illustrates resolving an open question by exhibiting a matching extremal example rather than strengthening the existence proof.",
+  "openQuestions": [
+   "If one forbids the extremal block {n,…,2n} (or more generally bounds how close a subset may sit to the top of the interval), is a 3-term chain then forced, and at what cardinality threshold?",
+   "Over {1,…,kn} with an (n+1)-element subset, how does the longest forced divisibility chain grow with the multiplier k — does relaxing the 2n ceiling reintroduce forced chains?",
+   "What is the extremal count of (n+1)-subsets that achieve the 'pair-only' bound, and is {n,…,2n} the unique such witness up to obvious symmetries?"
+  ]
+ },
+ "crossReferences": [
+  {
+   "proofId": "erdos-divisibility-pigeonhole",
+   "relationship": "Parent. Supplies the verified pigeonhole theorem this entry reuses (every_threshold_set_has_pair) and poses the chain-refinement open question answered here."
+  },
+  {
+   "proofId": "erdos-divisibility-pigeonhole-oq-01",
+   "relationship": "Sibling extremal form. Where oq-01 measures the largest divisibility antichain (max size n), this entry measures the longest forced chain (length 2) — complementary facets of the same divisibility poset on {1,…,2n}."
+  }
+ ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-divisibility-pigeonhole-oq-03`.

This entry previously had only `meta.json` (with `overview`) and no `annotations.json`, `sections`, or `conclusion`.

## Changes
- **annotations.json (new)**: 8 substantive annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the full Lean file — the `HasDivChain3` predicate, the doubling argument in `block_no_chain3`, the witness pair, the parent-pigeonhole wrapper, the main confinement theorem, the powers-of-two ambient chain, the unbounded-length contrast, and the in-file axiom audit.
- **meta.json**: added `overview.proofStrategy` and 5 `keyInsights`; added `sections` (7 theorem/definition blocks + axiom audit, covering all 164 lines); added `conclusion` with summary, implications, and 3 open questions; added `crossReferences` to the parent and the oq-01 sibling.

Mathematical content preserved and accurate; `status: verified` / `badge: original` / `axiomCount: 0` confirmed consistent with the in-file `#print axioms` audit (only propext/Classical.choice/Quot.sound). `pnpm build` passes.