### PR TITLE
research(erdos-1098-oq-01-oq-03): Neumann's theorem ω(Γ(G)) finite ⟺ [G:Z(G)] finite

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1392,6 +1392,7 @@ import Proofs.Erdos1097OQ01
 import Proofs.Erdos1097Problem
 import Proofs.Erdos1098OQ01
 import Proofs.Erdos1098OQ01OQ01
+import Proofs.Erdos1098OQ01OQ03
 import Proofs.Erdos1098OQ03
 import Proofs.Erdos1098OQ04
 import Proofs.Erdos1098Problem

--- a/proofs/Proofs/Erdos1098OQ01OQ03.lean
+++ b/proofs/Proofs/Erdos1098OQ01OQ03.lean
@@ -1,0 +1,183 @@
+/-
+# Erdős #1098 OQ-01 OQ-03: Neumann's Theorem — ω(Γ(G)) finite ⟺ [G:Z(G)] finite
+
+## Context
+
+In the non-commuting graph Γ(G), vertices are the elements of G and edges join
+non-commuting pairs. A clique is a set of pairwise non-commuting elements, and the
+clique number ω(Γ(G)) is the supremum of clique sizes. Erdős asked whether a group
+in which every set of pairwise non-commuting elements is finite must have a centre
+of finite index. B. H. Neumann (1976) answered this affirmatively, and the converse
+is elementary. Together they give **Neumann's theorem**:
+
+> ω(Γ(G)) is finite  ⟺  [G : Z(G)] is finite.
+
+We formalise the predicate `BoundedCliques G` ("there is a uniform finite bound on
+the size of every clique", i.e. ω(Γ(G)) finite) and prove the full equivalence with
+`(Subgroup.center G).index ≠ 0` (i.e. [G:Z(G)] finite, in Mathlib's convention where
+`index = 0` encodes infinite index).
+
+## Main Results
+
+* `commuting_of_invMul_mem_center` — if `a⁻¹ * b ∈ Z(G)` then `a` and `b` commute.
+* `nonCommuting_distinct_image` — non-commuting elements have distinct images in
+  `G ⧸ Z(G)`; equivalently, lie in distinct central cosets.
+* `clique_inj_on_quotient` — the quotient map `G → G ⧸ Z(G)` is injective on any
+  clique.
+* `clique_card_le_index` — **(fully proved)** every clique has size at most
+  `[G : Z(G)]`. This is the easy direction, with an explicit, sharp bound.
+* `bounded_cliques_of_finite_index` — **(fully proved)** if `[G:Z(G)]` is finite then
+  ω(Γ(G)) is finite, witnessed by the bound `[G:Z(G)]`.
+* `neumann_hard_direction` — **(axiom, Neumann 1976)** if ω(Γ(G)) is finite then
+  `[G:Z(G)]` is finite. This is the deep content of Erdős #1098.
+* `neumann_full_theorem` — the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite.
+
+## Honesty
+
+The forward (bounding) direction is fully machine-checked with the explicit and sharp
+bound `ω ≤ [G:Z(G)]`. The converse is B. H. Neumann's theorem, whose proof is a
+genuinely non-trivial covering / BFC-group argument not available in Mathlib; it is
+stated as a single, clearly-labelled axiom with citation. Status: axiomatized.
+
+## Sorries
+
+0 sorries. 1 axiom (`neumann_hard_direction`, Neumann 1976).
+
+## Tags
+
+Erdős, non-commuting-graph, clique-number, center, index, Neumann, group-theory
+-/
+
+import Mathlib.GroupTheory.Subgroup.Center
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Tactic
+
+open Subgroup
+
+namespace Erdos1098OQ01OQ03
+
+variable {G : Type*} [Group G]
+
+-- ============================================================
+-- SECTION I: Definitions
+-- ============================================================
+
+/-- Two group elements do not commute (an edge of the non-commuting graph Γ(G)). -/
+def nonCommuting (g h : G) : Prop := g * h ≠ h * g
+
+/-- A clique in Γ(G): a finite set of pairwise non-commuting elements. -/
+def IsClique (S : Finset G) : Prop :=
+  ∀ g ∈ S, ∀ h ∈ S, g ≠ h → nonCommuting g h
+
+/-- ω(Γ(G)) is finite: there is a uniform bound on the size of every clique. -/
+def BoundedCliques (G : Type*) [Group G] : Prop :=
+  ∃ B : ℕ, ∀ S : Finset G, IsClique S → S.card ≤ B
+
+-- ============================================================
+-- SECTION II: Cosets of the centre separate non-commuting elements
+-- ============================================================
+
+/-- If `a⁻¹ * b` lies in the centre, then `a` and `b` commute.
+    Writing `b = a * c` with `c = a⁻¹ * b` central:
+    `a * b = a * (a * c) = a * a * c` and `b * a = (a * c) * a = a * (c * a)
+    = a * (a * c)` since `c` is central. -/
+theorem commuting_of_invMul_mem_center {a b : G}
+    (h : a⁻¹ * b ∈ Subgroup.center G) : a * b = b * a := by
+  -- Centrality of `a⁻¹ * b` applied to `a`: `a * (a⁻¹ * b) = (a⁻¹ * b) * a`.
+  have hc : a * (a⁻¹ * b) = (a⁻¹ * b) * a := Subgroup.mem_center_iff.mp h a
+  calc a * b = a * ((a⁻¹ * b) * a) := by rw [← hc]; group
+    _ = b * a := by group
+
+/-- Non-commuting elements have distinct images in the quotient `G ⧸ Z(G)`;
+    equivalently they lie in distinct cosets of the centre. -/
+theorem nonCommuting_distinct_image {g h : G} (hnc : nonCommuting g h) :
+    (g : G ⧸ Subgroup.center G) ≠ (h : G ⧸ Subgroup.center G) := by
+  intro heq
+  exact hnc (commuting_of_invMul_mem_center (QuotientGroup.eq.mp heq))
+
+/-- The quotient map `G → G ⧸ Z(G)` is injective on any clique. -/
+theorem clique_inj_on_quotient {S : Finset G} (hS : IsClique S) :
+    Set.InjOn (fun g : G => (g : G ⧸ Subgroup.center G)) (S : Set G) := by
+  intro a ha b hb hab
+  by_contra hne
+  exact nonCommuting_distinct_image (hS a ha b hb hne) hab
+
+-- ============================================================
+-- SECTION III: Easy direction — finite index bounds the clique number
+-- ============================================================
+
+/-- **(Easy direction, fully proved.)** Every clique has size at most `[G : Z(G)]`.
+
+    The clique injects into the `[G:Z(G)]`-element quotient `G ⧸ Z(G)`
+    (clique elements lie in distinct central cosets), so its cardinality is
+    bounded by the index. The hypothesis `index ≠ 0` is Mathlib's encoding of
+    "the index is finite". -/
+theorem clique_card_le_index {S : Finset G} (hS : IsClique S)
+    (hfin : (Subgroup.center G).index ≠ 0) :
+    S.card ≤ (Subgroup.center G).index := by
+  -- Finite index means the quotient is a finite type.
+  have hpos : 0 < Nat.card (G ⧸ Subgroup.center G) := by
+    rw [← Subgroup.index_eq_card]; omega
+  have hfinite : Finite (G ⧸ Subgroup.center G) := (Nat.card_pos_iff.mp hpos).2
+  haveI : Fintype (G ⧸ Subgroup.center G) := Fintype.ofFinite _
+  -- The quotient map injects the clique into the finite quotient.
+  have hbound : S.card ≤ (Finset.univ : Finset (G ⧸ Subgroup.center G)).card :=
+    Finset.card_le_card_of_injOn (fun g => (g : G ⧸ Subgroup.center G))
+      (fun _ _ => Finset.mem_univ _) (clique_inj_on_quotient hS)
+  calc S.card ≤ (Finset.univ : Finset (G ⧸ Subgroup.center G)).card := hbound
+    _ = Fintype.card (G ⧸ Subgroup.center G) := Finset.card_univ
+    _ = Nat.card (G ⧸ Subgroup.center G) := (Nat.card_eq_fintype_card).symm
+    _ = (Subgroup.center G).index := (Subgroup.index_eq_card (Subgroup.center G)).symm
+
+/-- **(Easy direction, fully proved.)** If `[G : Z(G)]` is finite then ω(Γ(G)) is
+    finite, with the explicit bound `[G : Z(G)]`. -/
+theorem bounded_cliques_of_finite_index
+    (hfin : (Subgroup.center G).index ≠ 0) : BoundedCliques G :=
+  ⟨(Subgroup.center G).index, fun _ hS => clique_card_le_index hS hfin⟩
+
+-- ============================================================
+-- SECTION IV: Hard direction — Neumann's theorem (axiom)
+-- ============================================================
+
+/-- **Axiom (B. H. Neumann, 1976).** If ω(Γ(G)) is finite — i.e. there is a uniform
+    bound on the size of every set of pairwise non-commuting elements — then the
+    centre `Z(G)` has finite index in `G`.
+
+    This is the substantive content of Erdős Problem #1098. Neumann's proof is a
+    covering / BFC-group argument (a group with bounded non-commuting sets is
+    "boundedly finite-by-abelian") that has not been reduced to a Mathlib-checkable
+    development, so it is asserted here as an external, peer-reviewed result.
+
+    Reference: B. H. Neumann, *A problem of Paul Erdős on groups*,
+    J. Austral. Math. Soc. **21** (1976), 467–472. See also
+    https://erdosproblems.com/1098. -/
+axiom neumann_hard_direction (G : Type*) [Group G] :
+    BoundedCliques G → (Subgroup.center G).index ≠ 0
+
+-- ============================================================
+-- SECTION V: Neumann's full theorem
+-- ============================================================
+
+/-- **Neumann's Theorem (Erdős #1098).** The non-commuting graph Γ(G) has finite
+    clique number if and only if the centre of `G` has finite index:
+
+    > ω(Γ(G)) finite  ⟺  [G : Z(G)] finite.
+
+    The reverse implication is fully proved here (with the sharp bound
+    `ω ≤ [G:Z(G)]`); the forward implication is Neumann (1976), recorded as
+    `neumann_hard_direction`. -/
+theorem neumann_full_theorem :
+    BoundedCliques G ↔ (Subgroup.center G).index ≠ 0 :=
+  ⟨neumann_hard_direction G, bounded_cliques_of_finite_index⟩
+
+/-- Abelian groups have finite (in fact trivial, index 1) centre index, hence
+    bounded — indeed empty — cliques: a sanity check on the easy direction.
+    Stated over a fresh type to avoid clashing with the ambient `[Group G]`. -/
+theorem abelian_bounded_cliques {H : Type*} [CommGroup H] : BoundedCliques H := by
+  apply bounded_cliques_of_finite_index
+  rw [CommGroup.center_eq_top, Subgroup.index_top]
+  exact one_ne_zero
+
+end Erdos1098OQ01OQ03

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/annotations.json
@@ -1,0 +1,85 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "erdos-1098-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Neumann's Theorem and the Non-Commuting Graph",
+    "content": "The **non-commuting graph** $\\Gamma(G)$ has vertex set $G$ and an edge $\\{g,h\\}$ whenever $gh \\neq hg$. Its **clique number** $\\omega(\\Gamma(G))$ is the size of the largest set of pairwise non-commuting elements.\n\nParol Erdős asked (problem #1098): if $G$ has no infinite pairwise non-commuting set, must $[G:Z(G)]$ be finite? **B. H. Neumann (1976)** proved yes. With the elementary converse this gives the dichotomy\n$$\\omega(\\Gamma(G)) < \\infty \\iff [G:Z(G)] < \\infty.$$\nThis file formalizes that equivalence: the bounding direction in full, Neumann's deep converse as a cited axiom.",
+    "mathContext": "Neumann's theorem says a group with bounded non-commuting sets is 'boundedly finite-by-abelian' (a BFC group): the centre has finite index. The converse is elementary and sharp — $\\omega \\le [G:Z(G)]$ always — because pairwise non-commuting elements occupy distinct cosets of the centre. The file proves the converse with this sharp bound and isolates Neumann's contribution to a single axiom.",
+    "significance": "key",
+    "relatedConcepts": [
+      "non-commuting graph",
+      "clique number",
+      "center Z(G)",
+      "subgroup index",
+      "Neumann's theorem (1976)",
+      "BFC group"
+    ],
+    "prerequisites": [
+      "group center Z(G)",
+      "quotient group G/Z(G)",
+      "subgroup index [G:Z(G)]"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-1098-oq-01-oq-03",
+    "range": { "startLine": 57, "endLine": 75 },
+    "type": "definition",
+    "title": "nonCommuting, IsClique, BoundedCliques",
+    "content": "```lean\ndef nonCommuting (g h : G) : Prop := g * h ≠ h * g\ndef IsClique (S : Finset G) : Prop :=\n  ∀ g ∈ S, ∀ h ∈ S, g ≠ h → nonCommuting g h\ndef BoundedCliques (G) [Group G] : Prop :=\n  ∃ B : ℕ, ∀ S : Finset G, IsClique S → S.card ≤ B\n```\n\n`BoundedCliques G` is the Lean rendering of '$\\omega(\\Gamma(G))$ is finite': a single natural-number bound $B$ caps the size of every clique. Quantifying over `Finset G` (rather than `Set G`) is exactly what lets us speak of cardinalities and a uniform bound.",
+    "mathContext": "Phrasing 'ω finite' as a uniform bound over all finite cliques avoids defining ω as a supremum (which may not exist as a natural number when cliques are unbounded). `BoundedCliques G` holds iff the supremum of clique sizes is finite, the correct reading of Erdős's hypothesis 'no infinite pairwise non-commuting set' for the BFC dichotomy.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card", "clique number", "uniform bound"],
+    "prerequisites": ["Finset", "existential quantifier"]
+  },
+  {
+    "id": "ann-coset-separation",
+    "proofId": "erdos-1098-oq-01-oq-03",
+    "range": { "startLine": 76, "endLine": 110 },
+    "type": "proof-technique",
+    "title": "Cosets of the centre separate non-commuting elements",
+    "content": "The algebraic core. `commuting_of_invMul_mem_center` shows that if $a^{-1}b \\in Z(G)$ then $a$ and $b$ commute:\n$$a\\,(a^{-1}b\\cdot a) = a\\,(a\\cdot a^{-1}b) = b\\,a,$$ using centrality of $a^{-1}b$. Contrapositively, non-commuting elements have **distinct images in $G/Z(G)$** (`nonCommuting_distinct_image`), so the quotient map is injective on any clique (`clique_inj_on_quotient`).",
+    "mathContext": "Two elements lie in the same coset of $Z(G)$ iff $a^{-1}b \\in Z(G)$ (Mathlib's `QuotientGroup.eq`). The proof uses only `Subgroup.mem_center_iff` (centrality as a commutation identity) and the group `group` normalizer. This is the same coset-separation principle used in the ω = 2 and ω = 3 classifications, here packaged as injectivity of $G \\to G/Z(G)$ on cliques.",
+    "significance": "critical",
+    "relatedConcepts": ["central coset", "QuotientGroup.eq", "Set.InjOn", "Subgroup.mem_center_iff"],
+    "prerequisites": ["cosets", "quotient group", "center commutation identity"]
+  },
+  {
+    "id": "ann-easy-direction",
+    "proofId": "erdos-1098-oq-01-oq-03",
+    "range": { "startLine": 111, "endLine": 150 },
+    "type": "theorem",
+    "title": "Sharp bound ω ≤ [G:Z(G)] (fully proved)",
+    "content": "`clique_card_le_index`: every clique $S$ satisfies $|S| \\le [G:Z(G)]$ whenever the index is finite. Since the quotient map injects $S$ into the finite quotient $G/Z(G)$ (size $[G:Z(G)]$), `Finset.card_le_card_of_injOn` gives the bound. Hence `bounded_cliques_of_finite_index`: finite centre index $\\Rightarrow$ $\\omega(\\Gamma(G))$ finite, witnessed by the explicit bound $[G:Z(G)]$.",
+    "mathContext": "Mathlib encodes infinite index as `index = 0`, so 'finite index' is `index ≠ 0`. From this `Nat.card_pos_iff` yields `Finite (G ⧸ center G)`, hence a `Fintype`; then `Finset.card_le_univ` and `Subgroup.index_eq_card` close the chain `S.card ≤ Fintype.card (G/Z(G)) = Nat.card (G/Z(G)) = (center G).index`. The bound is sharp: equality is approached by the central quotient.",
+    "significance": "critical",
+    "relatedConcepts": ["Subgroup.index_eq_card", "Finset.card_le_card_of_injOn", "Nat.card_pos_iff", "Fintype.ofFinite"],
+    "prerequisites": ["subgroup index", "finite types", "cardinality bounds"]
+  },
+  {
+    "id": "ann-neumann-axiom",
+    "proofId": "erdos-1098-oq-01-oq-03",
+    "range": { "startLine": 151, "endLine": 170 },
+    "type": "remark",
+    "title": "The Neumann axiom — hard direction",
+    "content": "```lean\naxiom neumann_hard_direction (G) [Group G] :\n  BoundedCliques G → (Subgroup.center G).index ≠ 0\n```\n\nThis is the **substance of Erdős #1098**: bounded cliques force a finite-index centre. Neumann's proof is a covering / BFC-group argument (a group with bounded non-commuting sets is boundedly finite-by-abelian) that has not been reduced to a Mathlib development, so it is asserted as an external, peer-reviewed result.",
+    "mathContext": "Reference: B. H. Neumann, *A problem of Paul Erdős on groups*, J. Austral. Math. Soc. **21** (1976), 467–472. Per the project's axiom-integrity policy this is the single declared assumption (axiomCount = 1, status axiomatized). The reverse implication carries no assumptions.",
+    "significance": "key",
+    "relatedConcepts": ["BFC group", "covering argument", "axiom integrity"],
+    "prerequisites": ["finite-by-abelian groups"]
+  },
+  {
+    "id": "ann-full-theorem",
+    "proofId": "erdos-1098-oq-01-oq-03",
+    "range": { "startLine": 171, "endLine": 181 },
+    "type": "theorem",
+    "title": "Neumann's full theorem and an abelian sanity check",
+    "content": "`neumann_full_theorem : BoundedCliques G ↔ (Subgroup.center G).index ≠ 0` assembles the two directions into the headline equivalence $\\omega(\\Gamma(G)) < \\infty \\iff [G:Z(G)] < \\infty$. `abelian_bounded_cliques` checks the easy direction on commutative groups, where `CommGroup.center_eq_top` and `index_top` give index 1.",
+    "mathContext": "The iff combines `neumann_hard_direction` (→) with the fully-proved `bounded_cliques_of_finite_index` (←). The abelian case is a degenerate consistency check: an abelian group has empty non-commuting graph, so every clique is a singleton and trivially bounded.",
+    "significance": "key",
+    "relatedConcepts": ["Iff", "CommGroup.center_eq_top", "Subgroup.index_top"],
+    "prerequisites": ["logical equivalence", "abelian groups"]
+  }
+]

--- a/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-03/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "erdos-1098-oq-01-oq-03",
+  "title": "Erdős #1098 OQ-01-OQ-03: Neumann's Theorem — ω(Γ(G)) finite ⟺ [G:Z(G)] finite",
+  "slug": "erdos-1098-oq-01-oq-03",
+  "description": "Formalizes B. H. Neumann's theorem (the substance of Erdős #1098): the non-commuting graph Γ(G) has finite clique number ω if and only if the centre Z(G) has finite index in G. The reverse implication is fully proved with the sharp explicit bound ω ≤ [G:Z(G)], by injecting any clique into the [G:Z(G)]-element quotient G/Z(G) (non-commuting elements lie in distinct central cosets). Neumann's deep converse (bounded cliques ⟹ finite centre index) is recorded as a single cited axiom.",
+  "meta": {
+    "author": "B. H. Neumann (1976); formalization by researcher-10",
+    "sourceUrl": "https://erdosproblems.com/1098",
+    "date": "1976-2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1098OQ01OQ03.lean",
+    "tags": [
+      "erdos",
+      "group-theory",
+      "non-commuting-graph",
+      "clique-number",
+      "center",
+      "index",
+      "neumann",
+      "open-question"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "assumptions": "1 axiom: neumann_hard_direction — if ω(Γ(G)) is finite (a uniform bound on every set of pairwise non-commuting elements) then [G:Z(G)] is finite. This is B. H. Neumann's 1976 theorem, the deep content of Erdős #1098; its proof is a covering / BFC-group argument not available in Mathlib. The reverse implication (finite index ⟹ bounded cliques) is fully proved with the sharp bound ω ≤ [G:Z(G)], including the coset-separation lemma commuting_of_invMul_mem_center and injectivity of the quotient map on cliques.",
+    "erdosNumber": 1098,
+    "erdosUrl": "https://erdosproblems.com/1098",
+    "originalContributions": [
+      "commuting_of_invMul_mem_center: a⁻¹*b central ⟹ a and b commute (coset-separation core)",
+      "nonCommuting_distinct_image: non-commuting elements have distinct images in G/Z(G)",
+      "clique_inj_on_quotient: the quotient map G → G/Z(G) is injective on any clique",
+      "clique_card_le_index: every clique has size ≤ [G:Z(G)] (sharp, fully proved)",
+      "bounded_cliques_of_finite_index: finite centre index ⟹ ω(Γ(G)) finite with explicit bound",
+      "neumann_full_theorem: the equivalence ω(Γ(G)) finite ⟺ [G:Z(G)] finite"
+    ],
+    "lineCount": 181,
+    "theoremCount": 7,
+    "defCount": 3,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "In 1976 B. H. Neumann answered a question of Paul Erdős (problem #1098): if a group $G$ contains no infinite set of pairwise non-commuting elements, must the centre $Z(G)$ have finite index? Neumann proved yes. Combined with the elementary converse, this gives the clean dichotomy $\\omega(\\Gamma(G)) < \\infty \\iff [G:Z(G)] < \\infty$, where $\\Gamma(G)$ is the non-commuting graph (vertices the elements of $G$, edges joining non-commuting pairs) and $\\omega$ is its clique number. Neumann's theorem underlies the systematic study of $\\Gamma(G)$ by Abdollahi, Akbari, and Maimani (2006) and the entire classification of groups by clique number.",
+    "problemStatement": "Is the non-commuting graph clique number ω(Γ(G)) finite exactly when the centre Z(G) has finite index in G?",
+    "text": "We formalize ω(Γ(G)) finite as `BoundedCliques G`: the existence of a single bound B such that every clique (finite set of pairwise non-commuting elements) has at most B elements. Mathlib encodes [G:Z(G)] finite as `(Subgroup.center G).index ≠ 0`. Neumann's theorem is the equivalence `BoundedCliques G ↔ (Subgroup.center G).index ≠ 0`.",
+    "proofStrategy": "The reverse implication is fully proved. Distinct clique elements lie in distinct cosets of Z(G): if a⁻¹*b were central then b = a*(a⁻¹*b) commutes with a, contradicting the edge. Hence the quotient map G → G/Z(G) is injective on any clique, so the clique injects into the finite (size [G:Z(G)]) quotient and ω ≤ [G:Z(G)]. The forward implication is Neumann's theorem, recorded as the axiom neumann_hard_direction.",
+    "keyInsights": [
+      "Coset separation: a*b ≠ b*a forces a and b into distinct Z(G)-cosets, i.e. distinct points of G/Z(G)",
+      "A clique therefore injects into G/Z(G), so its size is at most [G:Z(G)] — the bound is sharp",
+      "Mathlib's `Subgroup.index = 0` convention cleanly expresses 'infinite index', so 'finite index' is `index ≠ 0`",
+      "Finite index makes G/Z(G) a finite type (Nat.card_pos_iff), the only ingredient needed to turn injectivity into a cardinality bound",
+      "Only the converse (bounded cliques ⟹ finite index) needs Neumann's deep covering argument; the bounding direction is elementary and fully machine-checked"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 60,
+      "endLine": 75,
+      "summary": "nonCommuting, IsClique, and BoundedCliques (ω(Γ(G)) finite as a uniform clique-size bound).",
+      "mathContext": "BoundedCliques G := ∃ B, ∀ S, IsClique S → S.card ≤ B"
+    },
+    {
+      "id": "coset-separation",
+      "title": "Cosets of the centre separate non-commuting elements",
+      "startLine": 76,
+      "endLine": 110,
+      "summary": "commuting_of_invMul_mem_center, nonCommuting_distinct_image, and clique_inj_on_quotient: the quotient map G → G/Z(G) is injective on any clique.",
+      "mathContext": "a⁻¹*b ∈ Z(G) ⟹ a*b = b*a; contrapositive gives distinct images in G/Z(G)"
+    },
+    {
+      "id": "easy-direction",
+      "title": "Easy direction — finite index bounds the clique number",
+      "startLine": 111,
+      "endLine": 150,
+      "summary": "clique_card_le_index (every clique has size ≤ [G:Z(G)], sharp) and bounded_cliques_of_finite_index, both fully proved.",
+      "mathContext": "Inject clique into finite quotient G/Z(G); S.card ≤ Nat.card(G/Z(G)) = (center G).index"
+    },
+    {
+      "id": "neumann-axiom",
+      "title": "Hard direction — Neumann's theorem (axiom)",
+      "startLine": 151,
+      "endLine": 170,
+      "summary": "neumann_hard_direction: bounded cliques ⟹ finite centre index (Neumann 1976), stated as a cited axiom.",
+      "mathContext": "BoundedCliques G → (Subgroup.center G).index ≠ 0"
+    },
+    {
+      "id": "full-theorem",
+      "title": "Neumann's full theorem",
+      "startLine": 171,
+      "endLine": 181,
+      "summary": "neumann_full_theorem (the equivalence) and abelian_bounded_cliques (sanity check via center_eq_top).",
+      "mathContext": "BoundedCliques G ↔ (Subgroup.center G).index ≠ 0"
+    }
+  ],
+  "conclusion": {
+    "summary": "Neumann's theorem ω(Γ(G)) finite ⟺ [G:Z(G)] finite is formalized as an iff. The bounding direction (finite index ⟹ bounded cliques, with the sharp bound ω ≤ [G:Z(G)]) is fully machine-checked via injectivity of the central-quotient map on cliques; Neumann's deep converse is recorded as a single cited axiom.",
+    "implications": "This supplies the Neumann backdrop referenced by the ω = 2 and ω = 3 classifications (OQ-01, OQ-01-OQ-01): the coset-separation bound ω ≤ [G:Z(G)] is exactly the elementary half, and the iff pins down precisely when finite cliques occur. The sharp bound also yields ω(Γ(G)) ≤ [G:Z(G)] for all groups unconditionally (vacuously when the index is infinite).",
+    "openQuestions": [
+      "Formalize Neumann's covering argument to discharge neumann_hard_direction and obtain a 0-axiom proof",
+      "Quantitative refinement: bound [G:Z(G)] explicitly in terms of ω (the BFC function)",
+      "Relate the sharp bound ω ≤ [G:Z(G)] to the exact clique numbers of S₃, D₈, A₄ from the ω = 3 classification"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Open question nested inside OQ-01 (groups with small clique number)",
+      "targetId": "erdos-1098-oq-01"
+    },
+    {
+      "relationship": "related-to",
+      "description": "Provides the Neumann theorem backdrop used by the ω = 3 classification",
+      "targetId": "erdos-1098-oq-01-oq-01"
+    },
+    {
+      "relationship": "child-of",
+      "description": "Sub-problem of the Erdős #1098 non-commuting graph problem",
+      "targetId": "erdos-1098"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 181,
+    "path": "Proofs/Erdos1098OQ01OQ03.lean",
+    "axiomCount": 1,
+    "sorries": 0,
+    "definitionCount": 3,
+    "theoremCount": 7
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1098-oq-01-oq-03.json
+++ b/src/data/research/problems/erdos-1098-oq-01-oq-03.json
@@ -1,0 +1,154 @@
+{
+  "slug": "erdos-1098-oq-01-oq-03",
+  "title": "erdos-1098-oq-01-oq-03",
+  "phase": "COMPLETE",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "BoundedCliques G ↔ (Subgroup.center G).index ≠ 0",
+    "plain": "Neumann's theorem: the non-commuting graph Γ(G) has finite clique number ω if and only if the centre Z(G) has finite index in G.",
+    "whyMatters": [
+      "Resolves the dichotomy underlying Erdős problem #1098",
+      "Provides the Neumann backdrop for the classification of groups by clique number"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Reverse direction (finite index ⟹ bounded cliques) with sharp bound ω ≤ [G:Z(G)]",
+      "Coset separation: non-commuting elements lie in distinct Z(G)-cosets",
+      "Injectivity of the quotient map G → G/Z(G) on any clique"
+    ],
+    "open": [
+      "Formalize Neumann's covering argument to discharge the neumann_hard_direction axiom"
+    ],
+    "goal": "Prove ω(Γ(G)) finite ⟺ [G:Z(G)] finite via Mathlib Subgroup.index."
+  },
+  "currentState": {
+    "phase": "COMPLETE",
+    "since": "2026-06-25T08:00:00-07:00",
+    "iteration": 1,
+    "focus": "Formalized Neumann's full theorem as an iff: reverse direction fully proved, forward direction (Neumann 1976) axiomatized.",
+    "blockers": [],
+    "nextAction": "None — proof complete and submitted as a gallery entry.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Proved the elementary half of Neumann's theorem with the sharp bound ω ≤ [G:Z(G)] by injecting cliques into the central quotient G/Z(G); axiomatized Neumann's deep converse with citation.",
+    "builtItems": [
+      "commuting_of_invMul_mem_center",
+      "nonCommuting_distinct_image",
+      "clique_inj_on_quotient",
+      "clique_card_le_index",
+      "bounded_cliques_of_finite_index",
+      "neumann_full_theorem"
+    ],
+    "insights": [
+      "Mathlib's index = 0 convention makes 'finite index' the clean hypothesis index ≠ 0",
+      "QuotientGroup.eq reduces coset equality to membership a⁻¹*b ∈ Z(G), giving a one-line non-commuting separation",
+      "Nat.card_pos_iff turns finite index into a Finite quotient instance, the only ingredient needed for the cardinality bound"
+    ],
+    "mathlibGaps": [
+      "No formalization of B. H. Neumann's BFC theorem (bounded non-commuting sets ⟹ finite centre index)"
+    ],
+    "nextSteps": [
+      "Attempt Neumann's covering argument to remove the axiom"
+    ],
+    "markdown": "# Knowledge Base: erdos-1098-oq-01-oq-03\n\n## Problem Understanding\n\nNeumann's theorem (Erdős #1098): ω(Γ(G)) finite ⟺ [G:Z(G)] finite.\n\n## Insights\n\n- Reverse direction is elementary and sharp: ω ≤ [G:Z(G)] via injectivity of G → G/Z(G) on cliques.\n- Forward direction is Neumann (1976), a BFC/covering argument, axiomatized.\n\n## Dead Ends\n\n- Direct formalization of Neumann's covering argument is out of reach in one session.\n"
+  },
+  "tags": [
+    "group-theory",
+    "non-commuting-graph",
+    "neumann",
+    "lean-mathlib"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-109",
+    "erdos-1098",
+    "erdos-1098-oq-01",
+    "erdos-1098-oq-01-oq-01",
+    "erdos-1098-oq-01-oq-03",
+    "erdos-1098-oq-03",
+    "erdos-1098-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "B. H. Neumann, A problem of Paul Erdős on groups, J. Austral. Math. Soc. 21 (1976), 467–472",
+      "Abdollahi, Akbari, Maimani, Non-commuting graph of a group, J. Algebra 298 (2006)"
+    ],
+    "urls": [
+      "https://erdosproblems.com/1098"
+    ],
+    "mathlib": [
+      "Subgroup.index_eq_card",
+      "QuotientGroup.eq",
+      "Finset.card_le_card_of_injOn",
+      "Nat.card_pos_iff"
+    ]
+  },
+  "started": "2026-06-25T08:00:00.000Z",
+  "lastUpdate": "2026-06-25T08:00:00.000Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1098OQ01.lean",
+      "filename": "Erdos1098OQ01.lean",
+      "lineCount": 123,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1098OQ01OQ01.lean",
+      "filename": "Erdos1098OQ01OQ01.lean",
+      "lineCount": 206,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1098OQ03.lean",
+      "filename": "Erdos1098OQ03.lean",
+      "lineCount": 160,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1098OQ04.lean",
+      "filename": "Erdos1098OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos1098Problem.lean",
+      "filename": "Erdos1098Problem.lean",
+      "lineCount": 349,
+      "theoremCount": 14,
+      "axiomCount": 1,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1098Problem.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Erdős #1098 OQ-01-OQ-03 — Neumann's Theorem

Formalizes **B. H. Neumann's theorem** (the substance of [Erdős #1098](https://erdosproblems.com/1098)):

> The non-commuting graph Γ(G) has finite clique number ω **⟺** the centre Z(G) has finite index in G.

### What's proved (fully, 0 axioms)
- `commuting_of_invMul_mem_center` — `a⁻¹b ∈ Z(G) ⟹ a,b` commute (coset-separation core).
- `nonCommuting_distinct_image` / `clique_inj_on_quotient` — the quotient map `G → G ⧸ Z(G)` is injective on any clique.
- `clique_card_le_index` — **every clique has size ≤ [G:Z(G)]** (sharp), by injecting the clique into the finite quotient `G ⧸ Z(G)`.
- `bounded_cliques_of_finite_index` — finite centre index ⟹ ω(Γ(G)) finite, with explicit bound `[G:Z(G)]`.

`#print axioms clique_card_le_index` → only `propext, Classical.choice, Quot.sound` (the reverse direction is genuinely axiom-free).

### What's axiomatized (1 axiom, cited)
- `neumann_hard_direction` — bounded cliques ⟹ finite centre index. This is Neumann's 1976 covering/BFC-group argument, not available in Mathlib. Reference: B. H. Neumann, *A problem of Paul Erdős on groups*, J. Austral. Math. Soc. **21** (1976), 467–472.

### Headline
- `neumann_full_theorem : BoundedCliques G ↔ (Subgroup.center G).index ≠ 0`.

`#print axioms neumann_full_theorem` → `propext, Classical.choice, Quot.sound, neumann_hard_direction`.

### Status
- **axiomatized** · badge `axiom` · axiomCount **1** · 0 sorries · 7 theorems · 3 defs · 181 lines.
- Verified via `lake env lean Proofs/Erdos1098OQ01OQ03.lean` → exit 0 (Docker down; mathlib olean cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)