### PR TITLE
Enrich Erdős #1013: The Asymptotic Constant Subsumes Ratio Convergence

### DIFF
--- a/src/data/proofs/erdos-1013-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1013-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 36 },
     "type": "concept",
     "title": "Two open questions, and how they relate",
-    "content": "Erdős #1013 asks for the asymptotics of h₃(k) — the least number of vertices in a triangle-free graph of chromatic number k — and, separately, whether h₃(k+1)/h₃(k) → 1. The known bounds (log k/log log k)·k² ≪ h₃(k) ≪ (log k)·k² pin the order of growth and conjecturally h₃(k) ~ c·k²·log k with c ∈ [1/2,1], but the exact constant c is unknown. This file does not determine c. It proves a structural fact valid for every c: existence of the asymptotic constant implies ratio convergence, and the constant is unique. The results are stated for an arbitrary candidate h : ℕ → ℝ, so they apply verbatim to the genuine h₃ once its asymptotic is established — and they avoid the parent entry's Mycielski finiteness axiom entirely."
+    "content": "Erdős #1013 asks for the asymptotics of h₃(k) — the least number of vertices in a triangle-free graph of chromatic number k — and, separately, whether h₃(k+1)/h₃(k) → 1. The known bounds (log k/log log k)·k² ≪ h₃(k) ≪ (log k)·k² pin the order of growth and conjecturally h₃(k) ~ c·k²·log k with c ∈ [1/2,1], but the exact constant c is unknown. This file does not determine c. It proves a structural fact valid for every c: existence of the asymptotic constant implies ratio convergence, and the constant is unique. The results are stated for an arbitrary candidate h : ℕ → ℝ, so they apply verbatim to the genuine h₃ once its asymptotic is established — and they avoid the parent entry's Mycielski finiteness axiom entirely.",
+    "mathContext": "$\\frac{\\log k}{\\log\\log k}\\,k^2 \\ll h_3(k) \\ll (\\log k)\\,k^2$, conjecturally $h_3(k)\\sim c\\,k^2\\log k$ with $c\\in[\\tfrac12,1]$.",
+    "significance": "context",
+    "relatedConcepts": ["chromatic number", "triangle-free graphs", "Ramsey numbers", "asymptotic equivalence"],
+    "prerequisites": ["extremal graph theory", "asymptotic notation"]
   },
   {
     "id": "e1013-scale-def",
@@ -13,15 +17,23 @@
     "range": { "startLine": 37, "endLine": 48 },
     "type": "definition",
     "title": "The growth scale and the asymptotic-constant predicate",
-    "content": "`scale k = k²·log k` is the conjectured order of growth of h₃. `HasAsymptoticConstant h c` packages the statement h(k)/(k²·log k) → c as a Filter.Tendsto to the neighbourhood filter 𝓝 c. Phrasing the hypothesis this way lets the reduction theorem consume exactly the asymptotic conjecture and nothing more."
+    "content": "`scale k = k²·log k` is the conjectured order of growth of h₃. `HasAsymptoticConstant h c` packages the statement h(k)/(k²·log k) → c as a Filter.Tendsto to the neighbourhood filter 𝓝 c. Phrasing the hypothesis this way lets the reduction theorem consume exactly the asymptotic conjecture and nothing more. Both definitions are noncomputable because Real.log is.",
+    "mathContext": "$g(k) = k^2\\log k$; $\\;\\textsf{HasAsymptoticConstant}\\,h\\,c \\iff \\dfrac{h(k)}{k^2\\log k}\\xrightarrow[k\\to\\infty]{} c$.",
+    "significance": "supporting",
+    "relatedConcepts": ["filter convergence", "neighbourhood filter", "asymptotic equivalence"],
+    "prerequisites": ["filters", "Filter.Tendsto", "real logarithm"]
   },
   {
     "id": "e1013-unique",
     "proofId": "erdos-1013-oq-01",
-    "range": { "startLine": 46, "endLine": 49 },
+    "range": { "startLine": 44, "endLine": 49 },
     "type": "technique",
     "title": "Uniqueness of the constant",
-    "content": "If h admits asymptotic constants c and d, then c = d. This is a one-liner: limits in ℝ (a Hausdorff space) are unique, so tendsto_nhds_unique applied to the two Tendsto witnesses forces equality. So although the value of c is open, the framework guarantees there is at most one."
+    "content": "If h admits asymptotic constants c and d, then c = d. This is a one-liner: limits in ℝ (a Hausdorff space) are unique, so tendsto_nhds_unique applied to the two Tendsto witnesses forces equality. So although the value of c is open, the framework guarantees there is at most one.",
+    "mathContext": "$\\dfrac{h(k)}{g(k)}\\to c \\,\\wedge\\, \\dfrac{h(k)}{g(k)}\\to d \\;\\Rightarrow\\; c=d$ (uniqueness of limits in a Hausdorff space).",
+    "significance": "supporting",
+    "relatedConcepts": ["uniqueness of limits", "Hausdorff space", "T2 separation"],
+    "prerequisites": ["topology of ℝ", "Filter.Tendsto"]
   },
   {
     "id": "e1013-scale-ratio",
@@ -29,7 +41,11 @@
     "range": { "startLine": 50, "endLine": 112 },
     "type": "key-step",
     "title": "Analytic core: ((k+1)²·log(k+1))/(k²·log k) → 1",
-    "content": "The heart of the file. Factor the scale ratio as ((k+1)/k)²·(log(k+1)/log k). The linear factor → 1 because (k+1)/k = 1 + 1/k and 1/k → 0 (squaring is continuous). The logarithmic factor → 1 because log(k+1) = log k + log(1+1/k): the increment log(1+1/k) → log 1 = 0 (continuity of log at 1), while log k → ∞, so their quotient → 0 by Tendsto.div_atTop, and 1 + (that) → 1. Each step is proved as an eventual identity (k ≥ 2, where log k ≠ 0) and transported along the limit with Tendsto.congr'."
+    "content": "The heart of the file. Factor the scale ratio as ((k+1)/k)²·(log(k+1)/log k). The linear factor → 1 because (k+1)/k = 1 + 1/k and 1/k → 0 (squaring is continuous). The logarithmic factor → 1 because log(k+1) = log k + log(1+1/k): the increment log(1+1/k) → log 1 = 0 (continuity of log at 1), while log k → ∞, so their quotient → 0 by Tendsto.div_atTop, and 1 + (that) → 1. Each step is proved as an eventual identity (k ≥ 2, where log k ≠ 0) and transported along the limit with Tendsto.congr'.",
+    "mathContext": "$\\dfrac{(k+1)^2\\log(k+1)}{k^2\\log k} = \\left(\\dfrac{k+1}{k}\\right)^2\\cdot\\dfrac{\\log(k+1)}{\\log k},\\quad \\dfrac{\\log(k+1)}{\\log k}=1+\\dfrac{\\log(1+1/k)}{\\log k}\\to 1+\\dfrac{0}{\\infty}=1.$",
+    "significance": "key",
+    "relatedConcepts": ["logarithmic asymptotics", "L'Hôpital-free limit", "Tendsto.div_atTop", "eventual equality"],
+    "prerequisites": ["limit arithmetic", "continuity of log", "filter_upwards / Tendsto.congr'"]
   },
   {
     "id": "e1013-reduction",
@@ -37,7 +53,11 @@
     "range": { "startLine": 113, "endLine": 149 },
     "type": "key-step",
     "title": "The reduction: asymptotic constant ⇒ ratio → 1",
-    "content": "Given h(k)/scale(k) → c with c > 0, factor h(k+1)/h(k) = (h(k+1)/scale(k+1)) · (scale(k+1)/scale(k)) / (h(k)/scale(k)). The first factor → c (the asymptotic, shifted by one via tendsto_add_atTop_nat), the middle → 1 (the analytic core), and the denominator → c, so the whole quotient → c·1/c = 1 (using c ≠ 0). The pointwise factorisation is only valid where scale(k) ≠ 0 (k ≥ 2) and is handled with a case split on whether h(k) = 0, then field_simp; the limit is then obtained by Tendsto.congr'."
+    "content": "Given h(k)/scale(k) → c with c > 0, factor h(k+1)/h(k) = (h(k+1)/scale(k+1)) · (scale(k+1)/scale(k)) / (h(k)/scale(k)). The first factor → c (the asymptotic, shifted by one via tendsto_add_atTop_nat), the middle → 1 (the analytic core), and the denominator → c, so the whole quotient → c·1/c = 1 (using c ≠ 0). The pointwise factorisation is only valid where scale(k) ≠ 0 (k ≥ 2) and is handled with a case split on whether h(k) = 0, then field_simp; the limit is then obtained by Tendsto.congr'.",
+    "mathContext": "$\\dfrac{h(k+1)}{h(k)} = \\dfrac{h(k+1)/g(k+1)}{h(k)/g(k)}\\cdot\\dfrac{g(k+1)}{g(k)} \\xrightarrow{\\;} \\dfrac{c}{c}\\cdot 1 = 1,\\quad c>0.$",
+    "significance": "key",
+    "relatedConcepts": ["limit of a quotient", "index shift (tendsto_add_atTop_nat)", "eventual equality", "non-vanishing denominator"],
+    "prerequisites": ["limit arithmetic", "Filter.Tendsto.div", "case analysis"]
   },
   {
     "id": "e1013-applied",
@@ -45,6 +65,10 @@
     "range": { "startLine": 150, "endLine": 162 },
     "type": "concept",
     "title": "Statement for the genuine threshold",
-    "content": "asymptotic_subsumes_ratio restates the reduction directly for the threshold h₃: if h₃(k)/(k²·log k) → c with c > 0, then h₃(k+1)/h₃(k) → 1. This is exactly the claim that the asymptotic-constant question of #1013 subsumes its ratio-convergence question, with the proof a one-line application of ratio_tendsto_one."
+    "content": "asymptotic_subsumes_ratio restates the reduction directly for the threshold h₃: if h₃(k)/(k²·log k) → c with c > 0, then h₃(k+1)/h₃(k) → 1. This is exactly the claim that the asymptotic-constant question of #1013 subsumes its ratio-convergence question, with the proof a one-line application of ratio_tendsto_one.",
+    "mathContext": "$\\dfrac{h_3(k)}{k^2\\log k}\\to c,\\ c>0 \\;\\Longrightarrow\\; \\dfrac{h_3(k+1)}{h_3(k)}\\to 1.$",
+    "significance": "key",
+    "relatedConcepts": ["specialization of a general lemma", "chromatic threshold", "structural reduction"],
+    "prerequisites": ["Filter.Tendsto"]
   }
 ]

--- a/src/data/proofs/erdos-1013-oq-01/index.ts
+++ b/src/data/proofs/erdos-1013-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1013ConstantRatio.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1013Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1013Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1013Oq01Data: ProofData = {
+  proof: erdos1013Oq01Proof,
+  annotations: erdos1013Oq01Annotations,
+}

--- a/src/data/proofs/erdos-1013-oq-01/meta.json
+++ b/src/data/proofs/erdos-1013-oq-01/meta.json
@@ -61,6 +61,50 @@
       "Mathlib's Filter.Tendsto API"
     ]
   },
+  "sections": [
+    {
+      "id": "header-and-imports",
+      "title": "Problem statement and setup",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring framing Erdős #1013's two open questions — the asymptotic constant c in h₃(k) ~ c·k²·log k (known only to lie in [1/2, 1]) and the ratio convergence h₃(k+1)/h₃(k) → 1 — and stating this file's contribution: a structural reduction proving the second follows from the first, for an arbitrary candidate h : ℕ → ℝ. Imports Real-log asymptotics and the tactic library; opens the Filter and Topology namespaces."
+    },
+    {
+      "id": "scale-and-predicate",
+      "title": "Growth scale and asymptotic-constant predicate",
+      "startLine": 37,
+      "endLine": 42,
+      "summary": "Defines scale k = k²·log k (the conjectured order of growth, noncomputable because Real.log is) and HasAsymptoticConstant h c := Tendsto (fun k => h k / scale k) atTop (𝓝 c), which packages the asymptotic conjecture as a single filter limit so the reduction theorem consumes exactly that hypothesis."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of the constant",
+      "startLine": 44,
+      "endLine": 48,
+      "summary": "constant_unique: if h has asymptotic constants c and d then c = d, a one-line consequence of tendsto_nhds_unique (limits in the Hausdorff space ℝ are unique). Guarantees there is at most one constant even though its value is open."
+    },
+    {
+      "id": "scale-ratio",
+      "title": "Analytic core: the scale ratio tends to 1",
+      "startLine": 50,
+      "endLine": 111,
+      "summary": "scale_ratio_tendsto_one proves ((k+1)²·log(k+1))/(k²·log k) → 1 by factoring the ratio into ((k+1)/k)² → 1 (squaring the limit 1 + 1/k → 1) and log(k+1)/log k → 1. The logarithmic factor uses log(k+1) = log k + log(1+1/k), with the increment → 0 (continuity of log at 1) divided by log k → ∞ via Tendsto.div_atTop. Pointwise identities are transported along the filter with Tendsto.congr' and discharged by field_simp on the eventual region k ≥ 2."
+    },
+    {
+      "id": "main-reduction",
+      "title": "Main reduction: asymptotic constant ⇒ ratio → 1",
+      "startLine": 113,
+      "endLine": 148,
+      "summary": "ratio_tendsto_one: given h(k)/scale(k) → c with c > 0, factor h(k+1)/h(k) = (h(k+1)/scale(k+1))·(scale(k+1)/scale(k))/(h(k)/scale(k)). The shifted asymptotic (via tendsto_add_atTop_nat) gives the first factor → c, the analytic core gives the middle → 1, and the denominator → c, so the quotient → c·1/c = 1 (needing c ≠ 0). The factorisation is valid only where scale(k) ≠ 0 (k ≥ 2), handled by a case split on h(k) = 0 followed by field_simp."
+    },
+    {
+      "id": "threshold-statement",
+      "title": "Statement for the genuine threshold",
+      "startLine": 150,
+      "endLine": 162,
+      "summary": "asymptotic_subsumes_ratio restates ratio_tendsto_one directly for the triangle-free chromatic threshold h₃: if h₃(k)/(k²·log k) → c with c > 0 then h₃(k+1)/h₃(k) → 1. This is the headline claim that #1013's asymptotic-constant question subsumes its ratio-convergence question; the proof is a one-line application of the reduction."
+    }
+  ],
   "conclusion": {
     "summary": "For the triangle-free chromatic threshold h₃(k) of Erdős #1013, the existence of the asymptotic constant c in h₃(k) ~ c·k²·log k (for any c > 0) implies the separately-posed ratio convergence h₃(k+1)/h₃(k) → 1, and the constant is unique. The result is proved abstractly for any h : ℕ → ℝ, is 0-axiom and 0-sorry, and rests on the verified analytic fact that the growth scale k²·log k has consecutive ratio tending to 1.",
     "implications": "This sharpens the structure of Problem #1013: it shows the ratio-convergence question is strictly subordinate to the asymptotic-constant question, so any future proof that the constant exists (even without pinning down its value in [1/2, 1]) would immediately settle ratio convergence. It cleanly separates the genuinely hard part (existence and value of c, an extremal/probabilistic question) from the soft analytic part (smoothness of the scale).",


### PR DESCRIPTION
Enrichment pass for `erdos-1013-oq-01`.

## Quality improvements
- **Created missing `index.ts`** — the proof had no Vite entry point, so it would render "proof not found" on the live site. Added the standard template wiring `Erdos1013ConstantRatio.lean` as source.
- **Added `sections` array** (6 sections) covering the full 162-line Lean file: setup, scale/predicate definitions, uniqueness, analytic core, main reduction, and the threshold statement.
- **Enriched all 6 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` — previously each had only `title`/`content`.

## Axiom integrity
No status/badge/axiom changes. Confirmed the file is genuinely 0-axiom / 0-sorry: all four theorems are proved unconditionally for an arbitrary `h : ℕ → ℝ`, with the asymptotic constant entering only as a hypothesis. `status: verified`, `badge: original`, `axiomCount: 0` remain accurate.

Build passes (`pnpm build`).