### PR TITLE
Fix hilbert-4 annotation: 6→5 axioms to match Lean source

### DIFF
--- a/src/data/proofs/hilbert-4/annotations.json
+++ b/src/data/proofs/hilbert-4/annotations.json
@@ -225,7 +225,7 @@
     "title": "Problem Status: SOLVED",
     "content": "**Hilbert's 4th Problem is SOLVED**:\n\n**Timeline**:\n- 1900: Hilbert poses the problem\n- 1903: Hamel solves 2D case\n- 1955: Busemann gives complete classification\n- 2000s: Finsler perspective refined\n\n**The Answer**: Straight-line geodesic metrics are exactly:\n- Minkowski (translation-invariant)\n- Hilbert (projective invariant)\n- Funk-type (asymmetric)\n\nFoundation for modern Finsler geometry and convex analysis.",
     "significance": "supporting",
-    "mathContext": "Hilbert's 4th Problem has the unusual status of being 'solved' but still generating active research. Busemann's 1955 classification settled the metrizable case, but extensions to non-metrizable geometries and connections to symplectic geometry (via Álvarez Paiva) remain active areas. The formalization captures the key definitions and classification statement with 0 sorries, 6 axioms.",
+    "mathContext": "Hilbert's 4th Problem has the unusual status of being 'solved' but still generating active research. Busemann's 1955 classification settled the metrizable case, but extensions to non-metrizable geometries and connections to symplectic geometry (via Álvarez Paiva) remain active areas. The formalization captures the key definitions and classification statement with 0 sorries, 5 axioms.",
     "relatedConcepts": [
       "solved problems",
       "Hilbert problems",


### PR DESCRIPTION
## Fix

Correct a stale axiom count in the hilbert-4 `ann-summary` annotation.

## Evidence

**Before**: `annotations.json` ann-summary mathContext: "...with 0 sorries, **6 axioms**."
**After**: "...with 0 sorries, **5 axioms**."

The Lean source `proofs/Proofs/Hilbert4Geodesics.lean` has exactly **5** axiom declarations:
- `minkowski_geodesics_are_straight`
- `minkowski_straight_line_shortest`
- `busemann_classification`
- `hamel_theorem_2d`
- `funk_geodesics_straight`

`grep -c "^axiom "` = 5. This matches `meta.json` `leanFile.axiomCount = 5` and the `assumptions` field ("5 axiom declarations"). The annotation's "6 axioms" was stale prose from when the source carried 6 axioms (the peer-review of 2026-03-24 referenced 6; one was since removed/consolidated and meta.json updated, but the annotation was missed).

No structure-encoded assumptions beyond the 5 axioms (ProjectiveFinsler `: True` fields carry no assumption). Metadata-only, single-file diff. JSON validated.

---
Automated fix by lean-mechanic agent.