### PR TITLE
audit(gallery): 10 fresh proofs verified CLEAN (0 integrity issues)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23929,6 +23929,66 @@
       ],
       "lastAudited": "2026-06-25T14:08:44Z",
       "result": "issues-fixed"
+    },
+    "bezout-identity-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq-01-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-noodle-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-oq-04-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "collatz-cycles-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-247-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factor-remainder-theorem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "godel-incompleteness-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T15:47:55Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 10 entries, all CLEAN

Audited 10 newly-added gallery entries against their Lean sources. Every
public claim (status / badge / sorries / axiomCount / theoremCount /
definitionCount / lineCount) matches what the Lean kernel guarantees. No
overclaims, no True-stubs, no hidden axioms or sorries.

| Slug | Tier | Notes |
|------|------|-------|
| bezout-identity-oq-02-oq-02-oq-03 | A | Univariate Nullstellensatz assembled; FTA (`IsAlgClosed.exists_root`) dep disclosed; multivariate obstruction documented |
| binomial-theorem-oq-03-oq-03 | A | Multinomial aggregation PGF; uses `decide` (not `native_decide`) → 0 axioms correct |
| buffons-needle-oq-01-oq-01-oq-05 | A | Discharges `hInnerInt` from C¹; verified parent `buffon_smooth_full` chain is genuinely axiom-free (docstring "axiom"/"sorry" are false positives) |
| buffons-noodle-oq-03-oq-01 | A | Γ crossing-factor closed form; spherical→angular reduction honestly scoped |
| cevas-theorem-oq-04-oq-04-oq-02 | A | Excenters/Nagel/Gergonne via mass points; Ravi substitution = nondegenerate triangles |
| collatz-cycles-oq-02 | A | Conditional log lower bound on cycle length; explicitly NOT Eliahou's full theorem |
| combinations-formula-oq-04 | A | Log-concavity of a Pascal row |
| erdos-247-oq-01-oq-02 | A | Exact reach of Liouville's method; #247 conjecture explicitly left OPEN (19 thms = 14 pub + 5 priv) |
| factor-remainder-theorem-oq-01-oq-01-oq-02 | A | Newton forward-difference interpolation; theoremCount=8 (public; 1 private helper excluded) |
| godel-incompleteness-oq-02 | A | Gödel via Turing; `SoundEffectiveTheory` fields are ∀-quantified **theorem premises**, not masked assumptions → `verified`/0-axiom is correct |

### Note on two untracked WIP dirs (left untouched)
`area-of-circle-oq-05-oq-01-incomplete-01` and `erdos-1098-oq-01-oq-03` are
**untracked** working-tree artifacts (active concurrent researcher WIP), not on
`main`. The former claims `status: verified` but its referenced Lean file
(`AreaOfCircleOQ05OQ01Incomplete01.lean`) does not exist and its claimed
theorems exist nowhere — must be re-audited once committed. Not touched here to
avoid conflicting with the owning agent.

---
Discovered during gallery integrity audit. No code/meta changes needed — tracker bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)