### PR TITLE
Enrich Erdős #247 ratio-growth delineation (oq-01-oq-02)

### DIFF
--- a/src/data/proofs/erdos-247-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-247-oq-01-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 49 },
     "type": "concept",
     "title": "How far does Liouville's method reach?",
-    "content": "Erdős #247 asks whether the lacunary binary sum Σ 1/2^{n_k} is transcendental when limsup n_k/k = ∞. Erdős (1975) proved it under super-polynomial growth; the parent entry states that result as an axiom and removes it only for n_k = k! (where the sum is liouvilleNumber 2 − 1/2). This file answers the natural follow-up — which sequences can the elementary Liouville argument actually handle axiom-free? — by isolating the exact 'ratio-growth' subclass. It is honest about scope: the general conjecture and the axiom for sequences like 2^k stay open."
+    "content": "Erdős #247 asks whether the lacunary binary sum Σ 1/2^{n_k} is transcendental when limsup n_k/k = ∞. Erdős (1975) proved it under super-polynomial growth; the parent entry states that result as an axiom and removes it only for n_k = k! (where the sum is liouvilleNumber 2 − 1/2). This file answers the natural follow-up — which sequences can the elementary Liouville argument actually handle axiom-free? — by isolating the exact 'ratio-growth' subclass. It is honest about scope: the general conjecture and the axiom for sequences like 2^k stay open.",
+    "mathContext": "$\\displaystyle\\sum_{k}\\frac{1}{2^{n_k}}$ with $\\limsup_k \\frac{n_k}{k} = \\infty$ (Erdős #247); this file handles the subclass with $\\limsup_k \\frac{n_{k+1}}{n_k} = \\infty$.",
+    "significance": "context",
+    "relatedConcepts": ["transcendental number", "Liouville number", "lacunary series", "Erdős problem 247"],
+    "prerequisites": ["transcendence theory", "infinite series"]
   },
   {
     "id": "e247rg-selfcontained",
@@ -13,7 +17,11 @@
     "range": { "startLine": 52, "endLine": 65 },
     "type": "definition",
     "title": "Self-contained restatement of the parent infrastructure",
-    "content": "lacunarySum n = Σ' k, 1/2^{n_k} and transcendental_int_to_rat (Transcendental ℤ x → Transcendental ℚ x, by clearing denominators via IsFractionRing.isAlgebraic_iff) duplicate the parent's definitions so this file depends only on Mathlib. The parent module is linked in the gallery build through Proofs.lean."
+    "content": "lacunarySum n = Σ' k, 1/2^{n_k} and transcendental_int_to_rat (Transcendental ℤ x → Transcendental ℚ x, by clearing denominators via IsFractionRing.isAlgebraic_iff) duplicate the parent's definitions so this file depends only on Mathlib. The parent module is linked in the gallery build through Proofs.lean.",
+    "mathContext": "$\\mathrm{lacunarySum}\\,n = \\sum_k' \\frac{1}{2^{n_k}};\\quad \\text{Transcendental}_{\\mathbb{Z}}\\,x \\Rightarrow \\text{Transcendental}_{\\mathbb{Q}}\\,x$",
+    "significance": "supporting",
+    "relatedConcepts": ["tsum (unconditional sum)", "fraction field", "IsFractionRing", "algebraic independence of scalars"],
+    "prerequisites": ["Mathlib tsum", "field of fractions"]
   },
   {
     "id": "e247rg-ratiogrowth",
@@ -21,7 +29,11 @@
     "range": { "startLine": 68, "endLine": 76 },
     "type": "definition",
     "title": "The ratio-growth condition",
-    "content": "HasRatioGrowth n := ∀ m, ∃ N, n_N ≥ 1 ∧ n_{N+1} > m·n_N + 1. This is the predicate limsup n_{k+1}/n_k = ∞ phrased so it feeds directly into Liouville's inequality: the index N chosen for parameter m is exactly the approximation point. The n_N ≥ 1 clause guarantees the Liouville denominator 2^{n_N} exceeds 1."
+    "content": "HasRatioGrowth n := ∀ m, ∃ N, n_N ≥ 1 ∧ n_{N+1} > m·n_N + 1. This is the predicate limsup n_{k+1}/n_k = ∞ phrased so it feeds directly into Liouville's inequality: the index N chosen for parameter m is exactly the approximation point. The n_N ≥ 1 clause guarantees the Liouville denominator 2^{n_N} exceeds 1.",
+    "mathContext": "$\\mathrm{HasRatioGrowth}(n) \\iff \\forall m\\, \\exists N:\\ n_N \\ge 1 \\ \\wedge\\ n_{N+1} > m\\,n_N + 1$",
+    "significance": "key",
+    "relatedConcepts": ["limit superior", "consecutive ratio", "approximation exponent", "lacunary growth"],
+    "prerequisites": ["limsup", "quantifier reasoning"]
   },
   {
     "id": "e247rg-infra",
@@ -29,7 +41,11 @@
     "range": { "startLine": 77, "endLine": 125 },
     "type": "technique",
     "title": "Generic Liouville infrastructure",
-    "content": "Reusable estimates for any strictly increasing exponent sequence: self_le (k ≤ n_k), shift_le (n_{N+1}+j ≤ n_{j+(N+1)}), and summability of both the full series and its tail by comparison with the geometric series Σ (1/2)^k. These replace the parent's factorial-specific lemmas with versions valid for an arbitrary StrictMono n."
+    "content": "Reusable estimates for any strictly increasing exponent sequence: self_le (k ≤ n_k), shift_le (n_{N+1}+j ≤ n_{j+(N+1)}), and summability of both the full series and its tail by comparison with the geometric series Σ (1/2)^k. These replace the parent's factorial-specific lemmas with versions valid for an arbitrary StrictMono n.",
+    "mathContext": "$\\text{StrictMono } n \\Rightarrow k \\le n_k;\\quad n_{N+1}+j \\le n_{j+(N+1)};\\quad \\sum_k \\tfrac{1}{2^{n_k}} \\le \\sum_k (\\tfrac12)^k = 2$",
+    "significance": "supporting",
+    "relatedConcepts": ["StrictMono", "geometric series comparison", "summability", "monotone exponent bound"],
+    "prerequisites": ["strictly monotone sequences", "comparison test"]
   },
   {
     "id": "e247rg-split",
@@ -37,7 +53,11 @@
     "range": { "startLine": 127, "endLine": 153 },
     "type": "key-step",
     "title": "Head/tail split and the dyadic head identity",
-    "content": "lacunarySum_split decomposes the sum into the finite head over range(N+1) plus the tail, via Summable.sum_add_tsum_nat_add. partialSum_eq_div proves by induction that the head equals an integer a over 2^{n_N}: at each step a/2^{n_N} + 1/2^{n_{N+1}} = (a·2^d + 1)/2^{n_{N+1}} with d = n_{N+1} − n_N. This rational a/2^{n_N} is the Liouville approximant."
+    "content": "lacunarySum_split decomposes the sum into the finite head over range(N+1) plus the tail, via Summable.sum_add_tsum_nat_add. partialSum_eq_div proves by induction that the head equals an integer a over 2^{n_N}: at each step a/2^{n_N} + 1/2^{n_{N+1}} = (a·2^d + 1)/2^{n_{N+1}} with d = n_{N+1} − n_N. This rational a/2^{n_N} is the Liouville approximant.",
+    "mathContext": "$\\sum_k \\tfrac{1}{2^{n_k}} = \\underbrace{\\sum_{k=0}^{N}\\tfrac{1}{2^{n_k}}}_{= a/2^{n_N}} + \\sum_{j} \\tfrac{1}{2^{n_{j+N+1}}}$",
+    "significance": "key",
+    "relatedConcepts": ["rational approximation", "dyadic rational", "telescoping induction", "partial sums"],
+    "prerequisites": ["finite/infinite sum splitting", "induction"]
   },
   {
     "id": "e247rg-tailbound",
@@ -45,7 +65,11 @@
     "range": { "startLine": 155, "endLine": 181 },
     "type": "key-step",
     "title": "Tail positivity and the geometric tail bound",
-    "content": "tail_pos shows the tail is strictly positive (so the sum is never exactly the approximant — Liouville's strict inequality). tail_le bounds it: each term 1/2^{n_{j+(N+1)}} ≤ (1/2^{n_{N+1}})·(1/2)^j by the shift estimate, and summing the geometric series gives tail ≤ 2/2^{n_{N+1}}. This single bound is what ratio growth must beat."
+    "content": "tail_pos shows the tail is strictly positive (so the sum is never exactly the approximant — Liouville's strict inequality). tail_le bounds it: each term 1/2^{n_{j+(N+1)}} ≤ (1/2^{n_{N+1}})·(1/2)^j by the shift estimate, and summing the geometric series gives tail ≤ 2/2^{n_{N+1}}. This single bound is what ratio growth must beat.",
+    "mathContext": "$0 < \\sum_j \\tfrac{1}{2^{n_{j+N+1}}} \\le \\tfrac{1}{2^{n_{N+1}}}\\sum_j (\\tfrac12)^j = \\tfrac{2}{2^{n_{N+1}}}$",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "tail estimate", "strict positivity", "Liouville inequality"],
+    "prerequisites": ["geometric series sum", "term-by-term bounds"]
   },
   {
     "id": "e247rg-liouville",
@@ -53,7 +77,11 @@
     "range": { "startLine": 183, "endLine": 220 },
     "type": "key-step",
     "title": "Main theorem: ratio growth ⇒ Liouville number",
-    "content": "lacunarySum_liouville: for each m, ratio growth supplies N with n_{N+1} > m·n_N + 1. With denominator b = 2^{n_N} > 1 and numerator a from the head, the error equals the tail, which satisfies 2/2^{n_{N+1}} < 1/(2^{n_N})^m exactly because the cross-multiplied inequality 2·2^{m·n_N} = 2^{m·n_N+1} < 2^{n_{N+1}} reduces to m·n_N + 1 < n_{N+1}. This is the heart of the proof — and shows precisely why ratio growth is the right hypothesis."
+    "content": "lacunarySum_liouville: for each m, ratio growth supplies N with n_{N+1} > m·n_N + 1. With denominator b = 2^{n_N} > 1 and numerator a from the head, the error equals the tail, which satisfies 2/2^{n_{N+1}} < 1/(2^{n_N})^m exactly because the cross-multiplied inequality 2·2^{m·n_N} = 2^{m·n_N+1} < 2^{n_{N+1}} reduces to m·n_N + 1 < n_{N+1}. This is the heart of the proof — and shows precisely why ratio growth is the right hypothesis.",
+    "mathContext": "$0 < \\left| x - \\tfrac{a}{2^{n_N}}\\right| \\le \\tfrac{2}{2^{n_{N+1}}} < \\tfrac{1}{(2^{n_N})^m} \\iff m\\,n_N + 1 < n_{N+1}$",
+    "significance": "key",
+    "relatedConcepts": ["Liouville's theorem", "irrationality measure", "rational approximation order", "cross-multiplication"],
+    "prerequisites": ["Liouville numbers", "exponent inequalities"]
   },
   {
     "id": "e247rg-transc",
@@ -61,7 +89,11 @@
     "range": { "startLine": 222, "endLine": 224 },
     "type": "technique",
     "title": "Transcendence over ℚ",
-    "content": "lacunarySum_transcendental chains Liouville.transcendental (Liouville ⇒ Transcendental ℤ) with transcendental_int_to_rat (ℤ ⇒ ℚ), all axiom-free. #print axioms reports only propext / Classical.choice / Quot.sound."
+    "content": "lacunarySum_transcendental chains Liouville.transcendental (Liouville ⇒ Transcendental ℤ) with transcendental_int_to_rat (ℤ ⇒ ℚ), all axiom-free. #print axioms reports only propext / Classical.choice / Quot.sound.",
+    "mathContext": "$\\text{Liouville}(x) \\Rightarrow \\text{Transcendental}_{\\mathbb{Z}}(x) \\Rightarrow \\text{Transcendental}_{\\mathbb{Q}}(x)$",
+    "significance": "supporting",
+    "relatedConcepts": ["transcendence", "Liouville implies transcendental", "scalar tower"],
+    "prerequisites": ["transcendence over a field", "Liouville.transcendental"]
   },
   {
     "id": "e247rg-factorial",
@@ -69,7 +101,11 @@
     "range": { "startLine": 226, "endLine": 250 },
     "type": "example",
     "title": "Factorial is the special case N = m+1",
-    "content": "factorial_hasRatioGrowth shows n_k = (k+1)! satisfies ratio growth with witness N = m+1: there n_N = (m+2)! and n_{N+1} = (m+3)! = (m+3)·(m+2)! > m·(m+2)! + 1. So factorial_sum_transcendental_via_ratio re-derives the parent's axiom-free factorial transcendence as one instance of the general theorem — the parent's single computation was not special."
+    "content": "factorial_hasRatioGrowth shows n_k = (k+1)! satisfies ratio growth with witness N = m+1: there n_N = (m+2)! and n_{N+1} = (m+3)! = (m+3)·(m+2)! > m·(m+2)! + 1. So factorial_sum_transcendental_via_ratio re-derives the parent's axiom-free factorial transcendence as one instance of the general theorem — the parent's single computation was not special.",
+    "mathContext": "$n_k = (k+1)!:\\ \\ n_{N+1}/n_N = m+3 > m \\ \\text{(at } N=m+1),\\ \\text{so ratio growth holds}$",
+    "significance": "supporting",
+    "relatedConcepts": ["factorial growth", "Liouville's constant", "instantiation of a general theorem"],
+    "prerequisites": ["factorial", "the ratio-growth condition"]
   },
   {
     "id": "e247rg-pow2",
@@ -77,7 +113,11 @@
     "range": { "startLine": 251, "endLine": 300 },
     "type": "key-step",
     "title": "2^k escapes the method: strong growth ≠ ratio growth",
-    "content": "pow2_not_hasRatioGrowth: n_k = 2^k has constant consecutive ratio 2, so n_{N+1} = 2·n_N can never exceed 2·n_N + 1 — ratio growth fails. Yet pow2_strong_growth shows 2^k satisfies the parent's super-polynomial strong-growth condition. Hence strongGrowth_not_implies_ratioGrowth: the Liouville-reachable class is a PROPER subclass of the strong-growth class. This proves the erdos_transcendence_strong axiom is genuinely required for sequences like 2^k — Liouville's inequality alone cannot remove it."
+    "content": "pow2_not_hasRatioGrowth: n_k = 2^k has constant consecutive ratio 2, so n_{N+1} = 2·n_N can never exceed 2·n_N + 1 — ratio growth fails. Yet pow2_strong_growth shows 2^k satisfies the parent's super-polynomial strong-growth condition. Hence strongGrowth_not_implies_ratioGrowth: the Liouville-reachable class is a PROPER subclass of the strong-growth class. This proves the erdos_transcendence_strong axiom is genuinely required for sequences like 2^k — Liouville's inequality alone cannot remove it.",
+    "mathContext": "$n_k = 2^k:\\ \\ n_{N+1} = 2 n_N \\not> 2 n_N + 1,\\ \\text{so ratio growth fails, yet } \\limsup \\tfrac{n_k}{k} = \\infty$",
+    "significance": "key",
+    "relatedConcepts": ["proper subclass", "super-polynomial growth", "limits of elementary methods", "necessity of an axiom"],
+    "prerequisites": ["powers of two", "ratio-growth vs strong-growth conditions"]
   },
   {
     "id": "e247rg-summary",
@@ -85,6 +125,10 @@
     "range": { "startLine": 302, "endLine": 316 },
     "type": "concept",
     "title": "Summary of the delineation",
-    "content": "ratio_growth_summary bundles the three facts: (1) ratio growth ⇒ transcendence (the reachable subclass), (2) factorial is in it, (3) 2^k is not, yet has strong growth (the subclass is proper). Together they map the exact boundary of the axiom-free Liouville approach to Erdős #247."
+    "content": "ratio_growth_summary bundles the three facts: (1) ratio growth ⇒ transcendence (the reachable subclass), (2) factorial is in it, (3) 2^k is not, yet has strong growth (the subclass is proper). Together they map the exact boundary of the axiom-free Liouville approach to Erdős #247.",
+    "mathContext": "$\\{\\text{ratio growth}\\} \\subsetneq \\{\\text{strong growth}\\};\\ \\ (k+1)! \\in \\text{former},\\ \\ 2^k \\in \\text{latter} \\setminus \\text{former}$",
+    "significance": "context",
+    "relatedConcepts": ["boundary of a method", "classification", "Erdős #247 landscape"],
+    "prerequisites": ["the main theorem", "the factorial and powers-of-two cases"]
   }
 ]

--- a/src/data/proofs/erdos-247-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-247-oq-01-oq-02/meta.json
@@ -62,6 +62,85 @@
       "Mathlib's Filter / InfiniteSum APIs"
     ]
   },
+  "sections": [
+    {
+      "id": "scope-open-question",
+      "title": "Scope and the open question",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Header: Erdős #247 and the parent's strong-growth axiom; this file isolates the ratio-growth subclass that the elementary Liouville argument can handle axiom-free, staying honest about what remains open."
+    },
+    {
+      "id": "self-contained-infra",
+      "title": "Self-contained restatement",
+      "startLine": 52,
+      "endLine": 65,
+      "summary": "Duplicates the parent's lacunarySum definition and the transcendental_int_to_rat bridge (Transcendental ℤ → Transcendental ℚ) so the file depends only on Mathlib."
+    },
+    {
+      "id": "ratio-growth-condition",
+      "title": "The ratio-growth condition",
+      "startLine": 68,
+      "endLine": 76,
+      "summary": "Defines HasRatioGrowth n := ∀ m, ∃ N, n_N ≥ 1 ∧ n_{N+1} > m·n_N + 1 — the limsup n_{k+1}/n_k = ∞ predicate phrased to feed Liouville's inequality directly."
+    },
+    {
+      "id": "liouville-infrastructure",
+      "title": "Generic Liouville infrastructure",
+      "startLine": 77,
+      "endLine": 125,
+      "summary": "Reusable estimates for any StrictMono exponent sequence: k ≤ n_k, the shift bound n_{N+1}+j ≤ n_{j+N+1}, and summability of the series and its tail by geometric comparison."
+    },
+    {
+      "id": "head-tail-split",
+      "title": "Head/tail split and dyadic head identity",
+      "startLine": 127,
+      "endLine": 153,
+      "summary": "lacunarySum_split separates the finite head from the tail; partialSum_eq_div proves the head equals an integer a over 2^{n_N} — the Liouville approximant."
+    },
+    {
+      "id": "tail-bounds",
+      "title": "Tail positivity and geometric bound",
+      "startLine": 155,
+      "endLine": 181,
+      "summary": "tail_pos gives strict positivity (Liouville's strict inequality); tail_le bounds the tail by 2/2^{n_{N+1}} via the geometric series — the quantity ratio growth must beat."
+    },
+    {
+      "id": "main-liouville",
+      "title": "Main theorem: ratio growth ⇒ Liouville",
+      "startLine": 183,
+      "endLine": 220,
+      "summary": "lacunarySum_liouville: the cross-multiplied inequality 2^{m·n_N+1} < 2^{n_{N+1}} reduces to m·n_N + 1 < n_{N+1}, exactly the ratio-growth hypothesis — making the sum a Liouville number."
+    },
+    {
+      "id": "transcendence",
+      "title": "Transcendence over ℚ",
+      "startLine": 222,
+      "endLine": 224,
+      "summary": "lacunarySum_transcendental chains Liouville.transcendental with transcendental_int_to_rat to conclude transcendence over ℚ, axiom-free."
+    },
+    {
+      "id": "factorial-instance",
+      "title": "Factorial as the special case N = m+1",
+      "startLine": 226,
+      "endLine": 250,
+      "summary": "factorial_hasRatioGrowth and factorial_sum_transcendental_via_ratio recover the parent's axiom-free factorial transcendence as one instance of the general theorem."
+    },
+    {
+      "id": "pow2-escapes",
+      "title": "2^k escapes the method",
+      "startLine": 251,
+      "endLine": 300,
+      "summary": "pow2_not_hasRatioGrowth + pow2_strong_growth show 2^k has strong growth but not ratio growth, so the Liouville-reachable class is a proper subclass and the strong-growth axiom is genuinely needed for 2^k."
+    },
+    {
+      "id": "delineation-summary",
+      "title": "Summary of the delineation",
+      "startLine": 302,
+      "endLine": 316,
+      "summary": "ratio_growth_summary bundles the three facts (ratio growth ⇒ transcendence; factorial in the class; 2^k strong-growth but not in the class) mapping the exact boundary of the axiom-free approach."
+    }
+  ],
   "conclusion": {
     "summary": "For Erdős #247 lacunary binary sums, the elementary Liouville argument eliminates the erdos_transcendence_strong axiom exactly on the ratio-growth subclass (limsup n_{k+1}/n_k = ∞): every strictly increasing such sequence gives a Liouville number, hence a transcendental sum, proved with 0 axioms and 0 sorries. The factorial example is the instance N=m+1; the geometric sequence 2^k satisfies strong growth but not ratio growth, so the method provably cannot reach it. 19 theorems, 4 definitions, 317 lines.",
     "implications": "This pinpoints the boundary of the axiom-free approach to Erdős #247. It generalizes the parent entry's single factorial computation to an infinite family via one structural theorem, and — by exhibiting 2^k as strong-growth-but-not-ratio-growth — proves that Liouville's inequality alone cannot discharge the Erdős 1975 axiom in general. Pushing further (e.g. to 2^k) demands Mahler's method or transcendence machinery beyond Liouville's, clarifying exactly where the remaining difficulty lies.",


### PR DESCRIPTION
Enrichment pass for `erdos-247-oq-01-oq-02`.

The entry already had a strong `overview` and `conclusion`, but its 11 annotations carried only a `content` field and `sections` was empty.

## Changes
- **annotations.json**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 11 annotations — covering the ratio-growth condition, the generic Liouville infrastructure, the head/tail split and dyadic approximant, the tail bound, the main Liouville theorem, the factorial instance, and the powers-of-two non-example.
- **meta.json**: added a `sections` array (10 entries) spanning the full 317-line Lean file, from scope/open-question through the proper-subclass delineation summary.

Existing content preserved. `status`/`badge`/`axiomCount` unchanged and consistent with the file's #print axioms audit. `pnpm build` passes.