### PR TITLE
research(lebesgue-measure-oq-04): Cantor set is uncountable yet Lebesgue-null

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3460,6 +3460,7 @@ import Proofs.LebesgueMeasureOQ01OQ03
 import Proofs.LebesgueMeasureOQ02
 import Proofs.LebesgueMeasureOQ03
 import Proofs.LebesgueMeasureOQ03OQ01
+import Proofs.LebesgueMeasureOQ04
 import Proofs.LebesgueMeasureOQ05
 import Proofs.LebesgueMeasureOQ06
 import Proofs.LebesgueMeasureOQ06Aristotle

--- a/proofs/Proofs/LebesgueMeasureOQ04.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ04.lean
@@ -1,0 +1,139 @@
+/-
+  Lebesgue Measure OQ-04
+  ----------------------
+  Cantor Set: an uncountable, Lebesgue-null subset of [0, 1].
+
+  The ternary Cantor set `C` is the prototypical example of a set that is
+  "large" in the topological / cardinality sense (uncountable, in fact of the
+  cardinality of the continuum) yet "small" in the measure-theoretic sense
+  (Lebesgue measure zero).  This file proves both of these defining
+  properties from Mathlib's `cantorSet` infrastructure
+  (`Mathlib.Topology.Instances.CantorSet`):
+
+    * `volume_cantorSet : volume cantorSet = 0`
+        Each pre-Cantor set `preCantorSet n` has measure `(2/3)^n` because it
+        is obtained by two ratio-`1/3` homotheties of the previous stage; the
+        Cantor set is contained in every stage, so its measure is bounded by
+        `(2/3)^n → 0`.
+
+    * `not_countable_cantorSet : ¬ cantorSet.Countable`
+        Mathlib provides `cantorSetEquivNatToBool : cantorSet ≃ (ℕ → Bool)`,
+        and `ℕ → Bool` has cardinality `2 ^ ℵ₀ > ℵ₀`, hence is uncountable.
+
+  The "paradox" is genuine: `C` has empty interior and measure zero, yet has
+  the same cardinality as the whole interval `[0, 1]`.
+
+  Everything here is fully verified: no axioms, no sorries.
+-/
+import Mathlib
+
+open MeasureTheory MeasureTheory.Measure Set
+open scoped ENNReal
+
+namespace LebesgueMeasureOQ04
+
+/-! ## The Cantor set is Lebesgue-null
+
+Each stage of the Cantor construction is two scaled copies of the previous
+stage, each scaled by `1/3`.  We compute the measure of a ratio-`1/3`
+homothety image, bound the measure of stage `n` by `(2/3)^n`, and take the
+limit. -/
+
+/-- The Lebesgue measure of a ratio-`1/3` homothety image of `s` is `(1/3) * volume s`.
+This is the one-dimensional instance of `addHaar_image_homothety` (`finrank ℝ ℝ = 1`). -/
+lemma volume_homothety_third_image (c : ℝ) (s : Set ℝ) :
+    volume (AffineMap.homothety c (1 / 3 : ℝ) '' s) = ENNReal.ofReal (1 / 3) * volume s := by
+  rw [Measure.addHaar_image_homothety]
+  congr 1
+  rw [Module.finrank_self]
+  norm_num
+
+/-- `x ↦ x / 3` is the homothety centred at `0` with ratio `1/3`. -/
+lemma volume_div_three_image (s : Set ℝ) :
+    volume ((fun x : ℝ => x / 3) '' s) = ENNReal.ofReal (1 / 3) * volume s := by
+  have h : (fun x : ℝ => x / 3) = AffineMap.homothety (0 : ℝ) (1 / 3 : ℝ) := by
+    funext x
+    simp only [AffineMap.homothety_apply, vsub_eq_sub, vadd_eq_add, smul_eq_mul]
+    ring
+  rw [h, volume_homothety_third_image]
+
+/-- `x ↦ (2 + x) / 3` is the homothety centred at `1` with ratio `1/3`. -/
+lemma volume_two_add_div_three_image (s : Set ℝ) :
+    volume ((fun x : ℝ => (2 + x) / 3) '' s) = ENNReal.ofReal (1 / 3) * volume s := by
+  have h : (fun x : ℝ => (2 + x) / 3) = AffineMap.homothety (1 : ℝ) (1 / 3 : ℝ) := by
+    funext x
+    simp only [AffineMap.homothety_apply, vsub_eq_sub, vadd_eq_add, smul_eq_mul]
+    ring
+  rw [h, volume_homothety_third_image]
+
+/-- The order-`n` pre-Cantor set has Lebesgue measure at most `(2/3)^n`. -/
+lemma volume_preCantorSet_le (n : ℕ) :
+    volume (preCantorSet n) ≤ ENNReal.ofReal ((2 / 3 : ℝ) ^ n) := by
+  induction n with
+  | zero => simp [preCantorSet_zero, Real.volume_Icc]
+  | succ n ih =>
+    rw [preCantorSet_succ]
+    refine le_trans (measure_union_le _ _) ?_
+    rw [volume_div_three_image, volume_two_add_div_three_image]
+    calc
+      ENNReal.ofReal (1 / 3) * volume (preCantorSet n)
+            + ENNReal.ofReal (1 / 3) * volume (preCantorSet n)
+          = ENNReal.ofReal (2 / 3) * volume (preCantorSet n) := by
+            rw [← add_mul, ← ENNReal.ofReal_add (by norm_num) (by norm_num)]
+            rw [show (1 / 3 : ℝ) + 1 / 3 = 2 / 3 by norm_num]
+      _ ≤ ENNReal.ofReal (2 / 3) * ENNReal.ofReal ((2 / 3 : ℝ) ^ n) :=
+            mul_le_mul' le_rfl ih
+      _ = ENNReal.ofReal ((2 / 3 : ℝ) ^ (n + 1)) := by
+            rw [← ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2 / 3)]
+            congr 1
+            rw [pow_succ]
+            ring
+
+/-- **The ternary Cantor set has Lebesgue measure zero.** -/
+theorem volume_cantorSet : volume cantorSet = 0 := by
+  refine le_antisymm ?_ (zero_le _)
+  -- For every `n`, `volume cantorSet ≤ (2/3)^n` since `cantorSet ⊆ preCantorSet n`.
+  have hbound : ∀ n : ℕ, volume cantorSet ≤ ENNReal.ofReal ((2 / 3 : ℝ) ^ n) := by
+    intro n
+    have hsub : cantorSet ⊆ preCantorSet n := Set.iInter_subset _ n
+    exact le_trans (measure_mono hsub) (volume_preCantorSet_le n)
+  -- The bound `(2/3)^n → 0`.
+  have htend : Filter.Tendsto (fun n : ℕ => ENNReal.ofReal ((2 / 3 : ℝ) ^ n))
+      Filter.atTop (nhds 0) := by
+    have hr : Filter.Tendsto (fun n : ℕ => (2 / 3 : ℝ) ^ n) Filter.atTop (nhds 0) :=
+      tendsto_pow_atTop_nhds_zero_of_lt_one (by norm_num) (by norm_num)
+    have := (ENNReal.continuous_ofReal.tendsto 0).comp hr
+    simpa using this
+  exact le_of_tendsto_of_tendsto' tendsto_const_nhds htend hbound
+
+/-! ## The Cantor set is uncountable
+
+Mathlib gives a bijection `cantorSet ≃ (ℕ → Bool)`; the latter has cardinality
+`2 ^ ℵ₀`, which exceeds `ℵ₀`. -/
+
+/-- `ℕ → Bool` is uncountable: it has cardinality `2 ^ ℵ₀ > ℵ₀`. -/
+instance : Uncountable (ℕ → Bool) := by
+  rw [← Cardinal.aleph0_lt_mk_iff, ← Cardinal.power_def, Cardinal.mk_bool, Cardinal.mk_nat]
+  exact Cardinal.cantor _
+
+/-- The ternary Cantor set is uncountable (as a subtype). -/
+theorem uncountable_cantorSet : Uncountable cantorSet :=
+  cantorSetEquivNatToBool.symm.injective.uncountable
+
+/-- **The ternary Cantor set is uncountable.** -/
+theorem not_countable_cantorSet : ¬ cantorSet.Countable := by
+  rw [← Set.countable_coe_iff, not_countable_iff]
+  exact uncountable_cantorSet
+
+/-! ## Summary
+
+Together, `volume_cantorSet` and `not_countable_cantorSet` exhibit `cantorSet`
+as an uncountable null set: measure-theoretically negligible, yet of the
+cardinality of the continuum. -/
+
+/-- The Cantor set is a null set that is nonetheless uncountable. -/
+theorem cantorSet_null_and_uncountable :
+    volume cantorSet = 0 ∧ ¬ cantorSet.Countable :=
+  ⟨volume_cantorSet, not_countable_cantorSet⟩
+
+end LebesgueMeasureOQ04

--- a/src/data/proofs/lebesgue-measure-oq-04/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-04/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "ann-lebesgueoq04-setup",
+    "proofId": "lebesgue-measure-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 33
+    },
+    "type": "concept",
+    "title": "Setup: The Cantor Set as an Uncountable Null Set",
+    "content": "The file works with Mathlib's ternary Cantor set `cantorSet` (from `Topology.Instances.CantorSet`), defined as `⋂ n, preCantorSet n` where `preCantorSet 0 = [0,1]` and each successor removes the open middle third of every interval. The goal is to prove the two defining 'paradoxical' properties — Lebesgue measure zero and uncountability — neither of which Mathlib's CantorSet file records. Mathlib does supply everything needed about the set itself: the antitone pre-Cantor stages, the recursion `preCantorSet (n+1) = (·/3) '' preCantorSet n ∪ ((2+·)/3) '' preCantorSet n`, and the bijection `cantorSetEquivNatToBool : cantorSet ≃ (ℕ → Bool)`. The contribution here is the measure and cardinality analysis layered on top.",
+    "mathContext": "The Cantor set $C = \\bigcap_n C_n$ is closed, compact, perfect, and nowhere dense. This entry adds the two facts that make it famous: $\\mathrm{volume}\\,C = 0$ and $C$ uncountable — i.e. $C$ is small for Lebesgue measure but as large as $[0,1]$ in cardinality.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cantorSet",
+      "preCantorSet",
+      "MeasureTheory.volume",
+      "Set.Countable"
+    ],
+    "prerequisites": [
+      "the middle-thirds construction of the Cantor set",
+      "Lebesgue measure on ℝ",
+      "countable versus uncountable sets"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq04-homothety",
+    "proofId": "lebesgue-measure-oq-04",
+    "range": {
+      "startLine": 35,
+      "endLine": 68
+    },
+    "type": "insight",
+    "title": "The Two Removal Maps Are Ratio-1/3 Homotheties",
+    "content": "The key geometric observation that powers the entire measure computation: the two maps appearing in the Cantor recursion are homotheties (scalings about a centre) of ratio 1/3. `volume_homothety_third_image` records the one-dimensional Haar scaling law `volume (AffineMap.homothety c (1/3) '' s) = ENNReal.ofReal (1/3) * volume s`, obtained from Mathlib's `Measure.addHaar_image_homothety` together with `finrank ℝ ℝ = 1` (so the scaling factor is `|(1/3)^1| = 1/3`, not `(1/3)^d`). Two specializations follow by rewriting the lambda as a homothety: `volume_div_three_image` recognizes `x ↦ x/3` as the homothety centred at `0`, and `volume_two_add_div_three_image` recognizes `x ↦ (2+x)/3` as the homothety centred at `1` (since `(1/3)(x-1)+1 = (2+x)/3`). Each `funext`/`simp`/`ring` step verifies the affine identity.",
+    "mathContext": "A homothety of ratio $r$ in $\\mathbb{R}^d$ scales $d$-dimensional volume by $|r|^d$. In dimension one with $r = 1/3$ the factor is exactly $1/3$. The Cantor set's self-similarity is precisely that it is built from two such ratio-1/3 copies, anchored at $0$ and at $2/3$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "MeasureTheory.Measure.addHaar_image_homothety",
+      "AffineMap.homothety",
+      "Module.finrank_self",
+      "IsAddHaarMeasure"
+    ],
+    "prerequisites": [
+      "homotheties and affine maps",
+      "Haar measure scaling by |det| = |r|^dim",
+      "finrank of ℝ over ℝ is 1"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq04-stagebound",
+    "proofId": "lebesgue-measure-oq-04",
+    "range": {
+      "startLine": 70,
+      "endLine": 91
+    },
+    "type": "proof-technique",
+    "title": "Geometric Decay of the Stage Measures",
+    "content": "`volume_preCantorSet_le` proves `volume (preCantorSet n) ≤ (2/3)^n` by induction on `n`. The base case is `volume [0,1] = 1 = (2/3)^0` (`Real.volume_Icc`). The successor step rewrites the stage as the union of the two homothety images, bounds the union's measure by the sum of the parts (`measure_union_le`), and applies the two homothety computations to get `ENNReal.ofReal (1/3) · v + ENNReal.ofReal (1/3) · v`, where `v = volume (preCantorSet n)`. A short `calc` collapses the two `1/3` factors into `2/3` (`← add_mul`, `← ENNReal.ofReal_add`), multiplies the inductive bound through (`mul_le_mul'`), and folds `(2/3)·(2/3)^n` into `(2/3)^(n+1)` (`← ENNReal.ofReal_mul`, `pow_succ`). The ENNReal arithmetic is handled carefully because subtraction and multiplication on `ℝ≥0∞` are not cancellative — every step works with non-negative reals lifted by `ENNReal.ofReal`.",
+    "mathContext": "Each construction stage keeps two-thirds of the previous length: $\\mathrm{volume}\\,C_{n+1} \\le \\tfrac13\\mathrm{volume}\\,C_n + \\tfrac13\\mathrm{volume}\\,C_n = \\tfrac23\\mathrm{volume}\\,C_n$, so $\\mathrm{volume}\\,C_n \\le (2/3)^n$. The inequality (rather than equality) suffices and avoids having to prove the removed middle thirds are disjoint.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "MeasureTheory.measure_union_le",
+      "Real.volume_Icc",
+      "ENNReal.ofReal_add",
+      "ENNReal.ofReal_mul"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "subadditivity of measures",
+      "arithmetic in ℝ≥0∞ via ENNReal.ofReal"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq04-measurezero",
+    "proofId": "lebesgue-measure-oq-04",
+    "range": {
+      "startLine": 93,
+      "endLine": 107
+    },
+    "type": "key-result",
+    "title": "volume cantorSet = 0",
+    "content": "`volume_cantorSet` is the first headline result. The argument is a squeeze: for every `n`, `cantorSet ⊆ preCantorSet n` (the Cantor set is the intersection of the stages, `Set.iInter_subset`), so by monotonicity of measure and the stage bound, `volume cantorSet ≤ ENNReal.ofReal ((2/3)^n)`. Since `(2/3)^n → 0` (`tendsto_pow_atTop_nhds_zero_of_lt_one`, lifted to `ℝ≥0∞` by continuity of `ENNReal.ofReal`), the constant `volume cantorSet` is bounded above by a sequence tending to 0; `le_of_tendsto_of_tendsto'` against the constant sequence forces `volume cantorSet ≤ 0`, and `le_antisymm` with `zero_le` finishes.",
+    "mathContext": "$C \\subseteq C_n$ and $\\mathrm{volume}\\,C_n \\le (2/3)^n \\to 0$ give $\\mathrm{volume}\\,C \\le \\inf_n (2/3)^n = 0$. Thus $C$ is a Lebesgue-null set: it can be ignored in any almost-everywhere statement, despite being uncountable.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "MeasureTheory.measure_mono",
+      "Set.iInter_subset",
+      "tendsto_pow_atTop_nhds_zero_of_lt_one",
+      "le_of_tendsto_of_tendsto'"
+    ],
+    "prerequisites": [
+      "monotonicity of measure",
+      "the Cantor set as an intersection of stages",
+      "limits and the squeeze theorem in ℝ≥0∞"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq04-natbool",
+    "proofId": "lebesgue-measure-oq-04",
+    "range": {
+      "startLine": 109,
+      "endLine": 118
+    },
+    "type": "insight",
+    "title": "The Cantor Space ℕ → Bool Is Uncountable",
+    "content": "An `Uncountable (ℕ → Bool)` instance, the cardinality engine behind uncountability of the Cantor set. The proof rewrites the goal through `Cardinal.aleph0_lt_mk_iff` (a type is uncountable iff `ℵ₀ < #`), expresses `#(ℕ → Bool)` as `#Bool ^ #ℕ = 2 ^ ℵ₀` (`Cardinal.power_def`, `Cardinal.mk_bool`, `Cardinal.mk_nat`), and closes with `Cardinal.cantor`, the cardinal form of Cantor's theorem `a < 2 ^ a` instantiated at `a = ℵ₀`. (Using `Cardinal.cantor` directly sidesteps needing the `1 < 2` instance that `cantor'` would require on `Cardinal`.)",
+    "mathContext": "$\\#(\\mathbb{N} \\to \\mathrm{Bool}) = 2^{\\aleph_0} = \\mathfrak{c}$, the cardinality of the continuum, and Cantor's theorem gives $\\aleph_0 < 2^{\\aleph_0}$. So the Cantor space — infinite binary sequences — is uncountable, the diagonal argument in cardinal-arithmetic form.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cardinal.cantor",
+      "Cardinal.power_def",
+      "Cardinal.aleph0_lt_mk_iff",
+      "Cardinal.mk_bool"
+    ],
+    "prerequisites": [
+      "cardinal exponentiation",
+      "Cantor's theorem a < 2^a",
+      "the uncountable ⟺ ℵ₀ < # characterization"
+    ]
+  },
+  {
+    "id": "ann-lebesgueoq04-uncountable",
+    "proofId": "lebesgue-measure-oq-04",
+    "range": {
+      "startLine": 120,
+      "endLine": 138
+    },
+    "type": "key-result",
+    "title": "The Cantor Set Is Uncountable — and the Paradox",
+    "content": "`uncountable_cantorSet` transfers uncountability from `ℕ → Bool` to the subtype `cantorSet` along Mathlib's bijection `cantorSetEquivNatToBool`. Concretely, the inverse equivalence `cantorSetEquivNatToBool.symm : (ℕ → Bool) → cantorSet` is injective, and `Function.Injective.uncountable` carries the `Uncountable (ℕ → Bool)` instance to its codomain. `not_countable_cantorSet` then repackages this as `¬ cantorSet.Countable` via `Set.countable_coe_iff` and `not_countable_iff`. Finally `cantorSet_null_and_uncountable` bundles `volume_cantorSet` and `not_countable_cantorSet` into the single statement that exhibits the paradox: one set, simultaneously of Lebesgue measure zero and uncountable.",
+    "mathContext": "The bijection $C \\simeq (\\mathbb{N} \\to \\mathrm{Bool})$ — each point's address in the infinite binary tree of removals — shows $\\#C = \\mathfrak{c}$, so $C$ is uncountable. Together with $\\mathrm{volume}\\,C = 0$ this is the canonical separation of cardinality from measure: $C$ has as many points as all of $[0,1]$ yet occupies none of its length.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "cantorSetEquivNatToBool",
+      "Function.Injective.uncountable",
+      "Set.countable_coe_iff",
+      "not_countable_iff"
+    ],
+    "prerequisites": [
+      "transferring cardinality across an equivalence",
+      "countability of a set versus its coercion to a type",
+      "the ternary-address description of the Cantor set"
+    ]
+  }
+]

--- a/src/data/proofs/lebesgue-measure-oq-04/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-04/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "lebesgue-measure-oq-04",
+  "title": "Cantor Set: Uncountable Yet Lebesgue-Null",
+  "slug": "lebesgue-measure-oq-04",
+  "description": "The ternary Cantor set C is the prototypical 'fat-and-thin' set: topologically and cardinally large (uncountable, in fact of the cardinality of the continuum) yet measure-theoretically negligible (Lebesgue measure zero). Building on Mathlib's cantorSet infrastructure (Topology.Instances.CantorSet), this entry proves the two defining paradoxical properties as fresh derivations not present in Mathlib. Measure zero: each stage preCantorSet n is the union of two ratio-1/3 homothety copies of the previous stage, so volume (preCantorSet (n+1)) ≤ (2/3)·volume (preCantorSet n); by induction volume (preCantorSet n) ≤ (2/3)^n, and since C ⊆ preCantorSet n for every n while (2/3)^n → 0, volume C = 0. Uncountability: Mathlib's bijection cantorSetEquivNatToBool : C ≃ (ℕ → Bool) transfers uncountability from ℕ → Bool, which has cardinality 2^ℵ₀ > ℵ₀ (Cardinal.cantor). The combined statement cantorSet_null_and_uncountable exhibits C as an uncountable null set.",
+  "meta": {
+    "author": "Cantor (1883); Lebesgue (1904)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ04.lean",
+    "tags": [
+      "measure-theory",
+      "cantor-set",
+      "lebesgue-measure",
+      "null-set",
+      "uncountable",
+      "cardinality",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 139,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib 4.26.0 (single-file elaboration via `lake env lean Proofs/LebesgueMeasureOQ04.lean`, exit 0; `#print axioms cantorSet_null_and_uncountable` lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). Mathlib's `Topology.Instances.CantorSet` supplies the Cantor set itself (definition, the antitone pre-Cantor stages, and the bijection cantorSetEquivNatToBool : cantorSet ≃ (ℕ → Bool)); the measure-zero theorem and the explicit uncountability statement are NOT in Mathlib and are proved here. Measure zero is assembled from Measure.addHaar_image_homothety (one-dimensional homothety scaling, finrank ℝ ℝ = 1), measure_union_le, an induction bounding volume (preCantorSet n) by (2/3)^n, and a squeeze using tendsto_pow_atTop_nhds_zero_of_lt_one. Uncountability of ℕ → Bool is derived from Cardinal.power_def + Cardinal.cantor (ℵ₀ < 2^ℵ₀) and transferred along the Mathlib equivalence.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Lebesgue measure zero of the ternary Cantor set, proved from Mathlib's cantorSet definition — a result Mathlib's CantorSet file does not contain — via the homothety scaling law for Haar measure plus an induction bounding each stage's measure by (2/3)^n and a squeeze to the limit.",
+      "An explicit uncountability statement for the Cantor set (not_countable_cantorSet / uncountable_cantorSet), obtained by transferring uncountability of ℕ → Bool across Mathlib's cantorSetEquivNatToBool bijection.",
+      "A self-contained Uncountable (ℕ → Bool) instance derived from Cardinal.power_def and Cardinal.cantor (ℵ₀ < 2^ℵ₀).",
+      "The packaged paradox cantorSet_null_and_uncountable: a single set that is simultaneously Lebesgue-null and uncountable."
+    ],
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Georg Cantor introduced the ternary set in 1883 as an example of a perfect, nowhere-dense set. With the advent of Lebesgue's measure theory (1902–1904) it became the canonical illustration that 'size' in the sense of cardinality and 'size' in the sense of measure are independent: the Cantor set has the cardinality of the continuum (the same as the whole interval [0,1]) yet occupies no length at all. The construction also seeds the Cantor function ('devil's staircase'), the standard example of a continuous monotone function that is singular with respect to Lebesgue measure. Mathlib formalizes the Cantor set in Topology.Instances.CantorSet, including its closedness, compactness, ternary-digit description, and homeomorphism with the Cantor space ℕ → Bool, but does not record its Lebesgue measure or an explicit uncountability statement; this entry supplies both.",
+    "problemStatement": "Let $C = \\bigcap_{n} C_n$ be the ternary Cantor set, where $C_0 = [0,1]$ and $C_{n+1}$ removes the open middle third of each interval of $C_n$ (equivalently $C_{n+1} = \\tfrac{1}{3}C_n \\cup (\\tfrac{2}{3} + \\tfrac{1}{3}C_n)$). Show that $C$ has Lebesgue measure zero, yet $C$ is uncountable.",
+    "text": "Two theorems about Mathlib's `cantorSet`: `volume_cantorSet : volume cantorSet = 0` and `not_countable_cantorSet : ¬ cantorSet.Countable`, combined in `cantorSet_null_and_uncountable`. The measure-zero proof exploits the self-similar two-copies-at-ratio-1/3 structure of the construction; the uncountability proof transfers cardinality across Mathlib's bijection with ℕ → Bool.",
+    "proofStrategy": "Measure zero. Both maps in the recursion `preCantorSet (n+1) = (·/3) '' preCantorSet n ∪ ((2+·)/3) '' preCantorSet n` are homotheties of ratio 1/3 (centres 0 and 1), so `Measure.addHaar_image_homothety` gives `volume (f '' s) = ENNReal.ofReal (1/3) * volume s` (using `finrank ℝ ℝ = 1`). With `measure_union_le` this yields `volume (preCantorSet (n+1)) ≤ (2/3)·volume (preCantorSet n)`; the base case `volume [0,1] = 1` and induction give `volume (preCantorSet n) ≤ (2/3)^n`. Since `cantorSet ⊆ preCantorSet n` for all n (it is their intersection) and `(2/3)^n → 0` (`tendsto_pow_atTop_nhds_zero_of_lt_one`), a squeeze (`le_of_tendsto_of_tendsto'`) forces `volume cantorSet ≤ 0`, hence `= 0`. Uncountability. `Cardinal.power_def` rewrites `#(ℕ → Bool)` as `#Bool ^ #ℕ = 2 ^ ℵ₀`, and `Cardinal.cantor` gives `ℵ₀ < 2 ^ ℵ₀`, so via `Cardinal.aleph0_lt_mk_iff` the type `ℕ → Bool` is uncountable. Mathlib's `cantorSetEquivNatToBool` then transfers uncountability to the subtype `cantorSet` (`Function.Injective.uncountable` applied to the equivalence's inverse), and `Set.countable_coe_iff` repackages it as `¬ cantorSet.Countable`.",
+    "keyInsights": [
+      "The Cantor set is self-similar: it is two ratio-1/3 scaled copies of itself, one anchored at 0 and one at 2/3. This single fact drives the measure computation — each construction stage loses exactly a factor 2/3 of its predecessor's length.",
+      "Measure zero is a clean consequence of the homothety scaling law for Haar measure (`addHaar_image_homothety`), which in dimension one reads volume(r·image) = |r|·volume; no explicit interval bookkeeping is needed once the two removal maps are recognized as homotheties.",
+      "C ⊆ preCantorSet n holds for every n because C is the intersection of the stages, so the geometric bound (2/3)^n applies to C directly and the squeeze to 0 is immediate.",
+      "Uncountability is independent of measure: it comes entirely from cardinality. Mathlib already provides the bijection cantorSet ≃ (ℕ → Bool) (binary addresses of the infinite removal tree), so the only missing piece is that ℕ → Bool itself is uncountable — a one-line Cardinal.cantor argument.",
+      "The two properties together are the paradox: the same set is negligible for integration (a null set, so it can be ignored almost everywhere) yet has the full cardinality of the continuum — large and small at once, depending on which notion of size one uses."
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℝ and ENNReal-valued measures",
+      "Haar measure scaling under affine maps (homotheties)",
+      "The ternary Cantor set construction (iterated middle-third removal)",
+      "Cardinal arithmetic: ℵ₀, 2^ℵ₀, and Cantor's theorem a < 2^a",
+      "Countability of sets versus subtypes"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring framing the Cantor set as the canonical uncountable null set, imports (full Mathlib, for Topology.Instances.CantorSet and the Haar-measure / Cardinal APIs), and the namespace.",
+      "mathContext": "Targets the ternary Cantor set $C = \\bigcap_n C_n$ from Mathlib, proving $\\mathrm{volume}\\,C = 0$ and $C$ uncountable."
+    },
+    {
+      "id": "homothety-measure",
+      "title": "Homothety Scaling of Lebesgue Measure",
+      "startLine": 35,
+      "endLine": 68,
+      "summary": "volume_homothety_third_image (the measure of a ratio-1/3 homothety image is (1/3)·volume, the 1-D case of addHaar_image_homothety), and its two specializations volume_div_three_image (centre 0) and volume_two_add_div_three_image (centre 1) matching the two removal maps of the Cantor recursion.",
+      "mathContext": "In dimension one, $\\mathrm{volume}(\\mathrm{homothety}_c^{1/3}\\,'' s) = \\tfrac13\\,\\mathrm{volume}\\,s$ because $|r^{\\dim}| = |(1/3)^1| = 1/3$. The maps $x \\mapsto x/3$ and $x \\mapsto (2+x)/3$ are the homotheties centred at $0$ and $1$."
+    },
+    {
+      "id": "stage-bound",
+      "title": "Geometric Bound on the Pre-Cantor Stages",
+      "startLine": 70,
+      "endLine": 91,
+      "summary": "volume_preCantorSet_le: volume (preCantorSet n) ≤ (2/3)^n, by induction. The successor step combines measure_union_le with the two homothety computations to get the factor 2/3, then multiplies through the inductive hypothesis with ENNReal.ofReal arithmetic.",
+      "mathContext": "$\\mathrm{volume}\\,C_n \\le (2/3)^n$: the base case is $\\mathrm{volume}[0,1] = 1$, and each step contributes a factor $\\tfrac13 + \\tfrac13 = \\tfrac23$."
+    },
+    {
+      "id": "measure-zero",
+      "title": "The Cantor Set Has Measure Zero",
+      "startLine": 93,
+      "endLine": 107,
+      "summary": "volume_cantorSet: volume cantorSet = 0. Uses cantorSet ⊆ preCantorSet n (intersection) with the stage bound to get volume cantorSet ≤ (2/3)^n for all n, then squeezes against (2/3)^n → 0 via le_of_tendsto_of_tendsto'.",
+      "mathContext": "Since $C \\subseteq C_n$ for all $n$ and $(2/3)^n \\to 0$, the monotone bound forces $\\mathrm{volume}\\,C = 0$."
+    },
+    {
+      "id": "uncountable-natbool",
+      "title": "ℕ → Bool Is Uncountable",
+      "startLine": 109,
+      "endLine": 118,
+      "summary": "An Uncountable (ℕ → Bool) instance: rewrite #(ℕ → Bool) as 2^ℵ₀ via Cardinal.power_def, mk_bool, mk_nat, then apply Cardinal.cantor (ℵ₀ < 2^ℵ₀) through Cardinal.aleph0_lt_mk_iff.",
+      "mathContext": "$\\#(\\mathbb{N} \\to \\mathrm{Bool}) = 2^{\\aleph_0} = \\mathfrak{c}$, and Cantor's theorem gives $\\aleph_0 < 2^{\\aleph_0}$, so the Cantor space is uncountable."
+    },
+    {
+      "id": "uncountable-cantor",
+      "title": "The Cantor Set Is Uncountable",
+      "startLine": 120,
+      "endLine": 138,
+      "summary": "uncountable_cantorSet transfers uncountability across Mathlib's cantorSetEquivNatToBool (via the inverse equivalence's injectivity); not_countable_cantorSet repackages it as ¬ cantorSet.Countable; cantorSet_null_and_uncountable bundles the two headline results.",
+      "mathContext": "The bijection $C \\simeq (\\mathbb{N} \\to \\mathrm{Bool})$ carries uncountability to $C$. Combined with $\\mathrm{volume}\\,C = 0$, this is the paradox: an uncountable set of measure zero."
+    }
+  ],
+  "conclusion": {
+    "summary": "The ternary Cantor set, as formalized in Mathlib, is shown to be Lebesgue-null (volume_cantorSet) and uncountable (not_countable_cantorSet), and the two are bundled in cantorSet_null_and_uncountable. Measure zero is proved from the self-similar structure: each removal map is a ratio-1/3 homothety, so the homothety scaling law for Haar measure plus measure_union_le bound each construction stage by (2/3)^n, and the intersection C inherits this bound, squeezing to 0. Uncountability transfers across Mathlib's bijection cantorSet ≃ (ℕ → Bool), the latter being uncountable by Cantor's theorem (ℵ₀ < 2^ℵ₀). Neither headline result is present in Mathlib's CantorSet file; both are derived here with 0 axioms and 0 sorries.",
+    "openQuestions": [
+      "Formalize the Cantor function (devil's staircase): a continuous, monotone, surjective F : [0,1] → [0,1] that is constant on each removed middle-third interval, with F' = 0 Lebesgue-a.e. — the canonical singular continuous function, currently absent from Mathlib.",
+      "Compute the Hausdorff dimension of the Cantor set as log 2 / log 3 and show its Hausdorff measure in that dimension is positive and finite, refining 'measure zero' to a precise notion of fractal size.",
+      "Prove the arithmetic / topological corollaries that the standard ternary-digit bijection makes accessible: C + C = [0,2] (the Steinhaus sumset theorem) and that C is homeomorphic to its own square C × C."
+    ],
+    "implications": "The Cantor set is the standard counterexample separating cardinality from measure and the seed of the devil's staircase that separates continuity-plus-monotonicity from absolute continuity. Recording its measure and uncountability gives the gallery a citable anchor for null sets, singular measures, self-similar fractals, and the failure of the naive intuition that 'uncountable' implies 'positive length'."
+  },
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure",
+      "relationship": "parent-problem",
+      "description": "Supplies the canonical example for the Lebesgue measure formalization: an explicit uncountable set of measure zero, sharpening the meaning of 'null set' in the parent theory."
+    },
+    {
+      "targetId": "cantor-diagonalization",
+      "relationship": "related",
+      "description": "Cantor diagonalization establishes that ℕ → Bool (equivalently the reals) is uncountable; this entry reuses exactly that cardinality fact (ℵ₀ < 2^ℵ₀) and pins it onto a concrete subset of [0,1] via the ternary-address bijection, connecting the abstract diagonal argument to a geometric object."
+    },
+    {
+      "targetId": "lebesgue-measure-oq-03",
+      "relationship": "related",
+      "description": "Infinite-Dimensional Measure Theory probes where measure-theoretic intuition breaks in high dimension; the Cantor set is the complementary low-dimensional pathology, where an uncountable set still carries no measure. Together they map two different failures of the naive 'big set = big measure' heuristic."
+    }
+  ],
+  "references": [
+    {
+      "author": "Cantor, G.",
+      "title": "Über unendliche, lineare Punktmannigfaltigkeiten V",
+      "year": 1883,
+      "note": "Introduces the ternary set as a perfect, nowhere-dense set"
+    },
+    {
+      "author": "Lebesgue, H.",
+      "title": "Leçons sur l'intégration et la recherche des fonctions primitives",
+      "year": 1904,
+      "note": "Measure theory in which the Cantor set becomes the canonical null set; the Cantor function is the standard singular function"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LebesgueMeasureOQ04",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/LebesgueMeasureOQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/lebesgue-measure-oq-04.json
+++ b/src/data/research/problems/lebesgue-measure-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "lebesgue-measure-oq-04",
   "title": "Cantor Set: Uncountable Measure-Zero Structure and Devil's Staircase",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-22T12:51:58.295Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Proved Cantor set is Lebesgue-null and uncountable; gallery entry created.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Optional follow-ups: Cantor function (devil staircase), Hausdorff dimension log2/log3, sumset C+C=[0,2].",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "COMPLETED: volume_cantorSet (=0) and not_countable_cantorSet proved in Proofs/LebesgueMeasureOQ04.lean, bundled as cantorSet_null_and_uncountable. 0 axioms, 0 sorries, kernel-checked (lake env lean exit 0). Built on Mathlib cantorSet infra (Topology.Instances.CantorSet); measure-zero and explicit uncountability are NOT in Mathlib.",
+    "builtItems": [
+      "volume_homothety_third_image / volume_div_three_image / volume_two_add_div_three_image in LebesgueMeasureOQ04.lean",
+      "volume_preCantorSet_le (stage bound (2/3)^n) in LebesgueMeasureOQ04.lean",
+      "volume_cantorSet (=0), Uncountable (ℕ→Bool) instance, uncountable_cantorSet, not_countable_cantorSet, cantorSet_null_and_uncountable"
+    ],
+    "insights": [
+      "Both Cantor removal maps are ratio-1/3 homotheties (centres 0 and 1); Measure.addHaar_image_homothety gives volume(image)=(1/3)volume in dim 1 (finrank ℝ ℝ=1).",
+      "volume(preCantorSet n) ≤ (2/3)^n by induction via measure_union_le; cantorSet ⊆ preCantorSet n (intersection) + (2/3)^n→0 squeezes volume to 0.",
+      "Uncountability of cantorSet transfers from ℕ→Bool across Mathlib cantorSetEquivNatToBool; ℕ→Bool uncountable via Cardinal.power_def + Cardinal.cantor (ℵ₀<2^ℵ₀).",
+      "Use Cardinal.cantor (a<2^a) not cantor' to avoid missing 1<2 instance on Cardinal."
+    ],
+    "mathlibGaps": [
+      "Mathlib Topology.Instances.CantorSet has no Lebesgue measure result and no explicit uncountability statement for cantorSet.",
+      "Mathlib has no Cantor function (devil staircase) / singular continuous function."
+    ],
+    "nextSteps": [
+      "Formalize the Cantor function: continuous monotone surjection [0,1]→[0,1], constant on removed thirds, F'=0 a.e.",
+      "Hausdorff dimension of C = log2/log3 with positive finite Hausdorff measure.",
+      "Steinhaus sumset: C+C=[0,2]."
+    ]
   },
   "tags": [
     "analysis",
@@ -63,7 +79,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T12:51:58.295Z",
-  "lastUpdate": "2026-04-22T12:51:58.295Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Formalizes the two defining "paradoxical" properties of the ternary Cantor set on top of Mathlib's `cantorSet` (`Topology.Instances.CantorSet`) — neither of which is present in Mathlib:

- **`volume_cantorSet : volume cantorSet = 0`** — the Cantor set is Lebesgue-null.
- **`not_countable_cantorSet : ¬ cantorSet.Countable`** — the Cantor set is uncountable.
- **`cantorSet_null_and_uncountable`** — the two bundled: a single uncountable set of measure zero.

## Proof approach
**Measure zero.** Both maps in the recursion `preCantorSet (n+1) = (·/3) '' preCantorSet n ∪ ((2+·)/3) '' preCantorSet n` are ratio-`1/3` homotheties (centres `0` and `1`). `Measure.addHaar_image_homothety` (with `finrank ℝ ℝ = 1`) gives `volume (f '' s) = (1/3)·volume s`; with `measure_union_le` and induction, `volume (preCantorSet n) ≤ (2/3)^n`. Since `cantorSet ⊆ preCantorSet n` for all `n` and `(2/3)^n → 0`, a squeeze forces measure `0`.

**Uncountability.** `#(ℕ → Bool) = 2^ℵ₀ > ℵ₀` (`Cardinal.power_def` + `Cardinal.cantor`), so `ℕ → Bool` is uncountable; this transfers to `cantorSet` across Mathlib's `cantorSetEquivNatToBool`.

## Verification
- **0 axioms, 0 sorries.** Kernel-checked at Mathlib 4.26.0 via single-file elaboration (`lake env lean Proofs/LebesgueMeasureOQ04.lean`, exit 0). Docker was unavailable this session; verified via the shared olean cache.
- `#print axioms cantorSet_null_and_uncountable` lists only `propext`, `Classical.choice`, `Quot.sound` — the ordinary foundational axioms — so the entry is axiom-free per the project's axiom-integrity policy.

## Files
- `proofs/Proofs/LebesgueMeasureOQ04.lean` (new, 8 theorems/lemmas)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/lebesgue-measure-oq-04/{meta.json,annotations.json}` (gallery entry)
- `src/data/research/problems/lebesgue-measure-oq-04.json` (knowledge update)

## Status
**Outcome**: completed (verified). 
**Next steps**: Cantor function / devil's staircase (singular continuous, absent from Mathlib); Hausdorff dimension `log 2 / log 3`; Steinhaus sumset `C + C = [0,2]`.

🤖 Generated by researcher-3