### PR TITLE
research(arithmetic-series-oq-02-oq-02-oq-01-oq-03): generating-function proof of the k-dimensional hockey stick

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -230,6 +230,7 @@ import Proofs.ArithmeticSeriesOQ02OQ01
 import Proofs.ArithmeticSeriesOQ02OQ01OQ01
 import Proofs.ArithmeticSeriesOQ02OQ02
 import Proofs.ArithmeticSeriesOQ02OQ02OQ01
+import Proofs.ArithmeticSeriesOQ02OQ02OQ01OQ03
 import Proofs.ArithmeticSeriesOQ02OQ02OQ02
 import Proofs.ArithmeticSeriesOQ02OQ02OQ03
 import Proofs.ArithmeticSeriesOQ02OQ02OQ03OQ01

--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean
@@ -1,0 +1,268 @@
+/-
+  Multivariate Generating-Function Proof of the k-Dimensional Hockey Stick
+
+  Open Question (arithmetic-series-oq-02-oq-02-oq-01-oq-03):
+  "Prove the multivariate generating function identity
+
+      ∑_{i ≥ 0} ∏_j C(i_j + a_j, a_j) · z^{∑ i_j} = 1 / (1 - z)^{∑ a_j + k}
+
+   This gives an alternative proof of the k-dimensional hockey stick via
+   generating functions rather than convolution induction."
+
+  Parent: ArithmeticSeriesOQ02OQ02OQ01.lean (k-dimensional hockey stick by
+  induction on dimension, 0 axioms, 0 sorries). The parent proves the
+  *coefficient-level* identity over the simplex {∑ i_j ≤ n} by repeated
+  application of the 2-variable parallel Vandermonde convolution.
+
+  Here we give the *generating-function* proof. The key observation is that the
+  one-dimensional factor
+
+      G_a(z) = ∑_{i ≥ 0} C(a + i, a) · z^i  =  1 / (1 - z)^{a+1}
+
+  is exactly Mathlib's `PowerSeries.invOneSubPow S (a+1)` (the multiplicative
+  inverse of `(1 - X)^(a+1)` in `S⟦X⟧ˣ`). The whole identity then collapses to
+  the *multiplicativity of `invOneSubPow` in its exponent*:
+
+      ∏_j 1/(1-z)^{a_j+1}  =  1 / (1 - z)^{∑(a_j+1)}  =  1 / (1 - z)^{∑ a_j + k}.
+
+  No induction on a numerical bound is needed: the dimension count k is the
+  *length* of the parameter list, the offset ∑ a_j is its *sum*, and the proof
+  is a one-line list induction whose engine is `invOneSubPow_add`.
+
+  Status (0 axioms, 0 sorries)
+  - [x] 1-D generating function G_a = invOneSubPow S (a+1), coefficient formula
+  - [x] Multivariate GF identity at the unit level (∏ = invOneSubPow of total)
+  - [x] Multivariate GF identity at the series level + "× (1-X)^m = 1" form
+  - [x] Closed form of the GF coefficients (diagonal simplicial numbers)
+  - [x] k=2 Cauchy product → parallel Vandermonde, via GF (over any CommRing, and ℕ)
+  - [x] Special cases (1-D, 2-D, 3-D)
+
+  References:
+  - Graham, Knuth, Patashnik (1994): "Concrete Mathematics", Ch. 5 & 7
+    (generating functions for binomial sums; 1/(1-z)^{k+1} = ∑ C(n+k,k) z^n)
+  - Mathlib: `Mathlib.RingTheory.PowerSeries.WellKnown` (`invOneSubPow`)
+-/
+
+import Mathlib.RingTheory.PowerSeries.WellKnown
+
+namespace ArithmeticSeriesOQ02OQ02OQ01OQ03
+
+open PowerSeries Finset
+open scoped PowerSeries BigOperators
+
+variable (S : Type*) [CommRing S]
+
+-- ============================================================
+-- Part I: The one-dimensional generating function
+-- ============================================================
+
+/-- The one-dimensional generating function of the simplicial numbers:
+
+      `geomGF S a = ∑_{i ≥ 0} C(a + i, a) · X^i = 1 / (1 - X)^(a+1)`.
+
+    This is exactly the value of Mathlib's `invOneSubPow S (a+1)`, the
+    multiplicative inverse of `(1 - X)^(a+1)` in `S⟦X⟧ˣ`. -/
+noncomputable def geomGF (a : ℕ) : S⟦X⟧ := (invOneSubPow S (a + 1)).val
+
+theorem geomGF_def (a : ℕ) : geomGF S a = (invOneSubPow S (a + 1)).val := rfl
+
+/-- The `n`-th coefficient of the 1-D generating function is the simplicial
+    number `C(a + n, a)`. -/
+@[simp] theorem geomGF_coeff (a n : ℕ) :
+    (coeff (R := S) n) (geomGF S a) = (Nat.choose (a + n) a : S) := by
+  rw [geomGF_def, invOneSubPow_val_succ_eq_mk_add_choose, coeff_mk]
+
+-- ============================================================
+-- Part II: The multivariate identity at the unit level
+-- ============================================================
+
+/-- **Unit-level multivariate generating-function identity.**
+
+    The product of the one-dimensional generating units over a list of
+    parameters `as = [a₁, …, aₖ]` equals a single inverse power:
+
+      `∏_j invOneSubPow S (a_j + 1) = invOneSubPow S (∑ a_j + k)`
+
+    where `k = as.length` and `∑ a_j = as.sum`. The proof is a list induction
+    whose step is a single application of `invOneSubPow_add`. -/
+theorem multiGFUnit_eq (as : List ℕ) :
+    (as.map (fun a => invOneSubPow S (a + 1))).prod
+      = invOneSubPow S (as.sum + as.length) := by
+  induction as with
+  | nil => simp [invOneSubPow_zero]
+  | cons a as ih =>
+    have harg : (a + 1) + (as.sum + as.length)
+        = (a :: as).sum + (a :: as).length := by
+      simp only [List.sum_cons, List.length_cons]; omega
+    rw [List.map_cons, List.prod_cons, ih, ← invOneSubPow_add, harg]
+
+-- ============================================================
+-- Part III: The multivariate identity at the series level
+-- ============================================================
+
+/-- **The multivariate generating-function identity.**
+
+      `∏_j G_{a_j}(z) = 1 / (1 - z)^{∑ a_j + k}`
+
+    stated in `S⟦X⟧` as `(as.map geomGF).prod = (invOneSubPow S (∑ + k)).val`.
+
+    This is the open question: the left-hand side is the product of the
+    one-variable generating functions `∑_i C(a_j+i, a_j) z^i`, whose product
+    expands to `∑_{i₁,…,iₖ} ∏_j C(i_j+a_j, a_j) z^{∑ i_j}`; the right-hand side
+    is `1/(1-z)^{∑ a_j + k}`. -/
+theorem multiGF_eq (as : List ℕ) :
+    (as.map (geomGF S)).prod = (invOneSubPow S (as.sum + as.length)).val := by
+  induction as with
+  | nil => simp [invOneSubPow_zero]
+  | cons a as ih =>
+    have harg : (a + 1) + (as.sum + as.length)
+        = (a :: as).sum + (a :: as).length := by
+      simp only [List.sum_cons, List.length_cons]; omega
+    rw [List.map_cons, List.prod_cons, ih, geomGF_def, ← Units.val_mul,
+      ← invOneSubPow_add, harg]
+
+/-- The same identity in the cleared-denominator form that avoids division:
+
+      `(∏_j G_{a_j}(z)) · (1 - z)^{∑ a_j + k} = 1`.
+
+    This is the most elementary statement of the open question — it certifies
+    that the product of generating functions really is the multiplicative
+    inverse of `(1 - z)^{∑ a_j + k}` in the power series ring. -/
+theorem multiGF_mul_one_sub_pow (as : List ℕ) :
+    (as.map (geomGF S)).prod * (1 - X) ^ (as.sum + as.length) = 1 := by
+  rw [multiGF_eq, ← invOneSubPow_inv_eq_one_sub_pow]
+  exact (invOneSubPow S (as.sum + as.length)).val_inv
+
+/-- **Closed form of the multivariate GF coefficients.** When the total exponent
+    `m = ∑ a_j + k` is positive, the `n`-th coefficient of the product is the
+    diagonal simplicial number `C(m - 1 + n, m - 1)`.
+
+    Combined with the Cauchy-product expansion (Part IV), this *is* the
+    k-dimensional hockey stick over the boundary simplex `{∑ i_j = n}`:
+    `∑_{i₁+…+iₖ = n} ∏_j C(i_j+a_j, a_j) = C(n + ∑a_j + k - 1, ∑a_j + k - 1)`. -/
+theorem multiGF_coeff (as : List ℕ) (h : 0 < as.sum + as.length) (n : ℕ) :
+    (coeff (R := S) n) ((as.map (geomGF S)).prod)
+      = (Nat.choose (as.sum + as.length - 1 + n) (as.sum + as.length - 1) : S) := by
+  rw [multiGF_eq, invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos S _ h, coeff_mk]
+
+-- ============================================================
+-- Part IV: k = 2 — Cauchy product recovers parallel Vandermonde
+-- ============================================================
+
+/-- The 2-factor product `[a, b]` collapses to `geomGF a * geomGF b`. -/
+theorem twoDim_multiGF (a b : ℕ) :
+    ([a, b].map (geomGF S)).prod = geomGF S a * geomGF S b := by
+  simp [List.map_cons, List.prod_cons]
+
+/-- Extracting the `n`-th coefficient of `geomGF a * geomGF b` via the Cauchy
+    product (coefficientwise multiplication of power series) yields exactly the
+    parallel-Vandermonde convolution sum. -/
+theorem twoDim_cauchy (a b n : ℕ) :
+    (coeff (R := S) n) (geomGF S a * geomGF S b)
+      = ∑ p ∈ Finset.antidiagonal n,
+          (Nat.choose (a + p.1) a : S) * (Nat.choose (b + p.2) b : S) := by
+  rw [coeff_mul]
+  apply Finset.sum_congr rfl
+  intro p _
+  rw [geomGF_coeff, geomGF_coeff]
+
+/-- The same coefficient in closed form, read off from the GF identity:
+    `geomGF a * geomGF b = invOneSubPow S (a+b+2)`, whose `n`-th coefficient is
+    `C(a + b + 1 + n, a + b + 1)`. -/
+theorem twoDim_closed (a b n : ℕ) :
+    (coeff (R := S) n) (geomGF S a * geomGF S b)
+      = (Nat.choose (a + b + 1 + n) (a + b + 1) : S) := by
+  have hprod : geomGF S a * geomGF S b = (invOneSubPow S (a + b + 2)).val := by
+    have harg : (a + 1) + (b + 1) = a + b + 2 := by omega
+    rw [geomGF_def, geomGF_def, ← Units.val_mul, ← invOneSubPow_add, harg]
+  have hsub : a + b + 2 - 1 = a + b + 1 := by omega
+  rw [hprod, invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos S _ (by omega),
+    coeff_mk, hsub]
+
+/-- **Parallel Vandermonde via generating functions (over any `CommRing`).**
+    Equating the two coefficient computations of Part IV gives the convolution
+    identity that the parent file proves by Pascal-recurrence induction:
+
+      `∑_{p+q = n} C(a+p, a) · C(b+q, b) = C(a + b + 1 + n, a + b + 1)`.
+
+    Here it is a one-line consequence of `invOneSubPow_add`. -/
+theorem parallel_vandermonde_gf (a b n : ℕ) :
+    ∑ p ∈ Finset.antidiagonal n,
+        (Nat.choose (a + p.1) a : S) * (Nat.choose (b + p.2) b : S)
+      = (Nat.choose (a + b + 1 + n) (a + b + 1) : S) := by
+  rw [← twoDim_cauchy, twoDim_closed]
+
+/-- The `ℕ`-valued parallel Vandermonde convolution, obtained from the
+    `CommRing` version over `ℤ` by injectivity of the cast `ℕ → ℤ`. This matches
+    the parent's `parallel_vandermonde` (modulo `simplicial k n = C(n+k, k)` and
+    the `range`↔`antidiagonal` reindexing), now proved by generating functions
+    instead of double induction. -/
+theorem parallel_vandermonde_nat (a b n : ℕ) :
+    ∑ p ∈ Finset.antidiagonal n, Nat.choose (a + p.1) a * Nat.choose (b + p.2) b
+      = Nat.choose (a + b + 1 + n) (a + b + 1) := by
+  have h := parallel_vandermonde_gf (S := ℤ) a b n
+  exact_mod_cast h
+
+-- ============================================================
+-- Part V: Special cases (dimensions 1 and 3)
+-- ============================================================
+
+/-- 1-D case: the single-parameter product is just the 1-D generating function,
+    whose coefficients are the simplicial numbers `C(a + n, a)`. -/
+theorem oneDim_multiGF (a : ℕ) :
+    ([a].map (geomGF S)).prod = geomGF S a := by
+  simp [List.map_cons, List.prod_cons]
+
+/-- 3-D case: the product over `[a, b, c]` is `1/(1-z)^{a+b+c+3}`, the generating
+    function of the simplicial numbers `C(n + a+b+c+2, a+b+c+2)` over a
+    tetrahedron. -/
+theorem threeDim_multiGF (a b c : ℕ) :
+    ([a, b, c].map (geomGF S)).prod = (invOneSubPow S (a + b + c + 3)).val := by
+  have harg : ([a, b, c] : List ℕ).sum + ([a, b, c] : List ℕ).length
+      = a + b + c + 3 := by
+    simp only [List.sum_cons, List.sum_nil, List.length_cons, List.length_nil]
+    omega
+  rw [multiGF_eq, harg]
+
+/-
+  Summary
+
+  This file gives the generating-function proof of the k-dimensional hockey
+  stick identity (the open question arithmetic-series-oq-02-oq-02-oq-01-oq-03),
+  with 0 sorries and 0 axioms. It is self-contained over `Mathlib`'s
+  `PowerSeries.invOneSubPow` API and does not import the parent's combinatorial
+  development; the connection is established by the parallel-Vandermonde
+  corollary `parallel_vandermonde_nat`.
+
+  Part I — One-dimensional generating function:
+    geomGF S a := invOneSubPow S (a+1)   -- = ∑_i C(a+i,a) X^i = 1/(1-X)^{a+1}
+    geomGF_coeff: coeff n (geomGF S a) = C(a+n, a)
+
+  Part II — Unit-level multivariate identity:
+    multiGFUnit_eq: ∏_j invOneSubPow S (a_j+1) = invOneSubPow S (∑a_j + k)
+
+  Part III — Series-level multivariate identity (the open question):
+    multiGF_eq:              ∏_j geomGF a_j = (invOneSubPow S (∑a_j + k)).val
+    multiGF_mul_one_sub_pow: (∏_j geomGF a_j) · (1-X)^{∑a_j+k} = 1
+    multiGF_coeff:           coeff n (∏) = C(n + ∑a_j + k - 1, ∑a_j + k - 1)
+
+  Part IV — k=2 recovers parallel Vandermonde, via generating functions:
+    twoDim_cauchy / twoDim_closed: the two coefficient computations
+    parallel_vandermonde_gf:  ∑_{p+q=n} C(a+p,a)C(b+q,b) = C(a+b+1+n, a+b+1)  (CommRing)
+    parallel_vandermonde_nat: the same over ℕ
+
+  Part V — Special cases:
+    oneDim_multiGF, threeDim_multiGF
+
+  Key Insight:
+    The parent proves the k-dimensional hockey stick by peeling off one
+    dimension at a time and folding it back with parallel Vandermonde — an
+    induction on a numerical bound. The generating-function proof replaces that
+    entire induction by the single algebraic fact that `invOneSubPow` is
+    *additive in its exponent* (`invOneSubPow_add`): the dimension k is the list
+    length, the offset ∑a_j is the list sum, and convolution of the simplex sums
+    is just multiplication of power series. The combinatorial induction becomes
+    a one-line monoid-homomorphism computation.
+-/
+
+end ArithmeticSeriesOQ02OQ02OQ01OQ03

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "gf-overview-header",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Convolution induction vs. generating functions",
+    "content": "The parent file proves the k-dimensional hockey stick by induction on dimension, folding one variable at a time with the parallel Vandermonde convolution. This file gives the generating-function proof requested by the parent's third open question. The pivot is that the one-variable factor 1/(1-z)^{a+1} is already in Mathlib as `PowerSeries.invOneSubPow S (a+1)` — the unit of S⟦X⟧ˣ whose value has coefficients C(a+n, a). Because invOneSubPow is additive in its exponent (invOneSubPow_add), the multivariate identity is a one-line list induction with no induction on a numerical bound.",
+    "mathContext": "$\\prod_{j=1}^{k} \\Big(\\sum_{i\\ge 0}\\binom{a_j+i}{a_j} z^i\\Big) = \\prod_j \\frac{1}{(1-z)^{a_j+1}} = \\frac{1}{(1-z)^{\\sum a_j + k}}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "formal power series",
+      "generating functions",
+      "hockey stick identity",
+      "invOneSubPow"
+    ]
+  },
+  {
+    "id": "geomgf-def",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+    "range": { "startLine": 65, "endLine": 73 },
+    "type": "definition",
+    "title": "The one-dimensional generating function as invOneSubPow",
+    "content": "geomGF S a is defined as (invOneSubPow S (a+1)).val rather than built from scratch. This single design choice is what makes the rest of the file short: invOneSubPow already packages the closed-form coefficients (invOneSubPow_val_succ_eq_mk_add_choose gives coeff n = C(a+n,a)), the inverse (1-X)^{a+1}, and — crucially — the exponent-additivity law. geomGF_coeff is then a two-rewrite proof.",
+    "mathContext": "$G_a(z) = \\sum_{i\\ge 0}\\binom{a+i}{a} z^i = (1-z)^{-(a+1)}$, with $[z^n]\\,G_a = \\binom{a+n}{a} = \\text{simplicial}\\,a\\,n$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "negative binomial series",
+      "simplicial numbers",
+      "coefficient extraction"
+    ]
+  },
+  {
+    "id": "multigf-induction",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 128 },
+    "type": "technique",
+    "title": "List induction whose engine is exponent additivity",
+    "content": "multiGFUnit_eq and multiGF_eq both run the same one-step induction on the parameter list. The cons step rewrites the head factor invOneSubPow S (a+1) and the tail product, fuses them with `← invOneSubPow_add` into invOneSubPow S ((a+1)+(as.sum+as.length)), and closes by an `omega`-proved arithmetic equality identifying the exponent with (a::as).sum+(a::as).length. There is no induction on a numerical bound n anywhere — the dimension is the list length and the offset is the list sum.",
+    "mathContext": "$\\prod_j \\text{invOneSubPow}(a_j+1) = \\text{invOneSubPow}\\Big(\\sum_j a_j + k\\Big)$, with $(a+1) + \\big(\\textstyle\\sum_{\\text{tail}} a_j + (k-1)\\big) = \\sum_j a_j + k$.",
+    "significance": "key-technique",
+    "relatedConcepts": [
+      "list induction",
+      "monoid homomorphism",
+      "Units.val_mul",
+      "invOneSubPow_add"
+    ]
+  },
+  {
+    "id": "cleared-denominator",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+    "range": { "startLine": 131, "endLine": 146 },
+    "type": "insight",
+    "title": "The division-free statement of the open question",
+    "content": "multiGF_mul_one_sub_pow states (∏_j geomGF a_j)·(1-X)^{∑a_j+k} = 1, which is the open question with the denominator cleared: it certifies that the product of generating functions is genuinely the multiplicative inverse of (1-z)^{∑a_j+k} in the power series ring. The proof is a one-liner: rewrite the product as a unit value, turn (1-X)^{m} into that unit's inverse via invOneSubPow_inv_eq_one_sub_pow, and apply val_inv. multiGF_coeff then reads off the diagonal simplicial coefficients.",
+    "mathContext": "$\\Big(\\prod_j G_{a_j}(z)\\Big)\\,(1-z)^{\\sum a_j + k} = 1$, hence $[z^n]\\prod_j G_{a_j} = \\binom{n + \\sum a_j + k - 1}{\\sum a_j + k - 1}$.",
+    "significance": "insight",
+    "relatedConcepts": [
+      "units of a power series ring",
+      "multiplicative inverse",
+      "diagonal simplicial numbers"
+    ]
+  },
+  {
+    "id": "k2-vandermonde",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+    "range": { "startLine": 153, "endLine": 204 },
+    "type": "insight",
+    "title": "k=2 recovers parallel Vandermonde with zero induction",
+    "content": "Extracting the n-th coefficient of geomGF a * geomGF b two different ways proves a parent theorem for free. The Cauchy product (coeff_mul over Finset.antidiagonal) gives the convolution ∑_{p+q=n} C(a+p,a)C(b+q,b) (twoDim_cauchy); the closed form from multiGF_coeff gives C(a+b+1+n, a+b+1) (twoDim_closed). Equating them is parallel_vandermonde_gf over any CommRing, and casting through ℤ with exact_mod_cast gives parallel_vandermonde_nat over ℕ — the same statement the parent proves by double induction.",
+    "mathContext": "$\\sum_{p+q=n}\\binom{a+p}{a}\\binom{b+q}{b} = \\binom{a+b+1+n}{a+b+1}$, i.e. $[z^n]\\big(G_a G_b\\big) = [z^n]\\,G_{a+b+1}$.",
+    "significance": "key-result",
+    "relatedConcepts": [
+      "Cauchy product",
+      "Vandermonde convolution",
+      "antidiagonal",
+      "norm_cast"
+    ]
+  },
+  {
+    "id": "special-cases-summary",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+    "range": { "startLine": 206, "endLine": 268 },
+    "type": "context",
+    "title": "Uniform specializations and the take-away",
+    "content": "Because multiGF_eq is quantified over an arbitrary list, the 1-D and 3-D cases are one-line specializations (oneDim_multiGF, threeDim_multiGF) rather than separate proofs. The closing summary records the file's organizing principle: the right algebraic abstraction — the group of units of S⟦X⟧ together with the additivity of invOneSubPow — compresses the parent's combinatorial induction into a homomorphism computation.",
+    "mathContext": "3-D: $\\prod\\limits_{j\\in\\{a,b,c\\}} G_j(z) = (1-z)^{-(a+b+c+3)}$, with coefficients $\\binom{n+a+b+c+2}{a+b+c+2}$ counting weighted lattice points in a tetrahedron.",
+    "significance": "context",
+    "relatedConcepts": [
+      "specialization",
+      "lattice point counting",
+      "tetrahedron"
+    ]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const arithmeticSeriesOq02Oq02Oq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const arithmeticSeriesOq02Oq02Oq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const arithmeticSeriesOq02Oq02Oq01Oq03Data: ProofData = {
+  proof: arithmeticSeriesOq02Oq02Oq01Oq03Proof,
+  annotations: arithmeticSeriesOq02Oq02Oq01Oq03Annotations,
+}

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+  "title": "Multivariate Generating-Function Proof of the k-Dimensional Hockey Stick",
+  "slug": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+  "description": "Proves the multivariate generating-function identity ∏_j (∑_i C(a_j+i,a_j) z^i) = 1/(1-z)^{∑a_j+k} in Lean's PowerSeries ring, giving an alternative proof of the k-dimensional hockey stick via generating functions rather than convolution induction. The one-variable factor 1/(1-z)^{a+1} is identified with Mathlib's invOneSubPow S (a+1), and the entire identity collapses to the additivity of invOneSubPow in its exponent (invOneSubPow_add). The k=2 Cauchy product recovers the parent's parallel Vandermonde convolution as a one-line corollary, over any commutative ring and over ℕ. 13 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hockey-stick_identity",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "hockey-stick",
+      "generating functions",
+      "formal power series",
+      "Vandermonde",
+      "Cauchy product"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib's foundational axioms. `#print axioms` on the headline results (`multiGF_eq`, `multiGF_mul_one_sub_pow`, `parallel_vandermonde_nat`) reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. No `native_decide`, no literal `axiom` declarations, 0 sorries. Fully machine-checked. Self-contained over `Mathlib.RingTheory.PowerSeries.WellKnown` (the `invOneSubPow` API); does not import the parent combinatorial file.",
+    "lineCount": 268,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "originalContributions": [
+      "geomGF: the one-variable generating function ∑_i C(a+i,a) X^i identified with invOneSubPow S (a+1), with its coefficient formula geomGF_coeff",
+      "multiGFUnit_eq / multiGF_eq: the multivariate generating-function identity ∏_j geomGF a_j = invOneSubPow S (∑a_j + k), proved by one-line list induction whose engine is invOneSubPow_add — replacing the parent's induction on a numerical bound",
+      "multiGF_mul_one_sub_pow: the cleared-denominator form (∏_j geomGF a_j) · (1-X)^{∑a_j+k} = 1, certifying the product is exactly 1/(1-z)^{∑a_j+k}",
+      "multiGF_coeff: closed form of the GF coefficients as diagonal simplicial numbers C(n+∑a_j+k-1, ∑a_j+k-1)",
+      "parallel_vandermonde_gf / parallel_vandermonde_nat: the k=2 Cauchy product recovers the parent's parallel Vandermonde convolution ∑_{p+q=n} C(a+p,a)C(b+q,b) = C(a+b+1+n, a+b+1) via generating functions, over any CommRing and over ℕ"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The hockey stick identity $\\sum_{j=0}^n \\binom{j+k}{k} = \\binom{n+k+1}{k+1}$ and its higher-dimensional generalizations admit two classical proof styles. The **combinatorial / inductive** style (used by the parent file) folds dimensions one at a time using a convolution identity (parallel Vandermonde). The **generating-function** style, championed in Graham–Knuth–Patashnik's *Concrete Mathematics* (1994, Chapters 5 and 7), encodes each one-dimensional sequence as a power series and replaces convolution by multiplication.\n\nThe cornerstone is the formal power series identity $\\sum_{n \\geq 0} \\binom{n+k}{k} z^n = \\dfrac{1}{(1-z)^{k+1}}$. In Mathlib this is precisely `PowerSeries.invOneSubPow S (k+1)`: the chosen unit of `S⟦X⟧ˣ` whose value is `mk (fun n => Nat.choose (k+n) k)` and whose inverse is `(1 - X)^{k+1}` (file `Mathlib.RingTheory.PowerSeries.WellKnown`).\n\nOnce one-dimensional sequences become inverse powers of $(1-z)$, the multivariate hockey stick is a statement about a **product of power series**: $\\prod_{j=1}^k \\dfrac{1}{(1-z)^{a_j+1}} = \\dfrac{1}{(1-z)^{\\sum a_j + k}}$. This is exactly the open question arithmetic-series-oq-02-oq-02-oq-01-oq-03, the third open question raised by the parent k-dimensional hockey stick entry, which asked for the generating-function proof as an alternative to convolution induction.",
+    "problemStatement": "Prove, in Lean's formal power series ring $S\\llbracket X \\rrbracket$ over a commutative ring $S$, the multivariate generating-function identity\n$$\\prod_{j=1}^{k} \\left( \\sum_{i \\geq 0} \\binom{a_j + i}{a_j} z^{i} \\right) \\;=\\; \\frac{1}{(1-z)^{\\sum_j a_j + k}},$$\nwhose left-hand side expands to $\\sum_{i_1,\\dots,i_k \\geq 0} \\prod_j \\binom{i_j + a_j}{a_j}\\, z^{\\sum_j i_j}$. Derive from it the k-dimensional hockey stick (the coefficient identity) and, in the case $k=2$, recover the parent's parallel Vandermonde convolution.",
+    "proofStrategy": "Encode the dimension $k$ as the **length** of a parameter list `as = [a₁,…,aₖ]` and the offset $\\sum a_j$ as its **sum**.\n\n**Step 1 — one-dimensional factor.** Define `geomGF S a := (invOneSubPow S (a+1)).val`. By `invOneSubPow_val_succ_eq_mk_add_choose`, its $n$-th coefficient is $\\binom{a+n}{a}$ (lemma `geomGF_coeff`).\n\n**Step 2 — list induction.** `multiGFUnit_eq` proves $\\prod_j \\text{invOneSubPow}(a_j+1) = \\text{invOneSubPow}(\\sum a_j + k)$ by induction on the list. The base case is `invOneSubPow_zero`; the inductive step is a **single** application of `invOneSubPow_add` (additivity of the exponent) plus an `omega` bookkeeping step matching $(a+1) + (\\text{as.sum}+\\text{as.length}) = (a::as).\\text{sum} + (a::as).\\text{length}$.\n\n**Step 3 — series and coefficient forms.** Taking `.val` gives `multiGF_eq`; multiplying by `(1-X)^{…}` and using `val_inv` gives the division-free `multiGF_mul_one_sub_pow`; reading off coefficients via `invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos` gives `multiGF_coeff`.\n\n**Step 4 — k=2 Cauchy product.** `coeff_mul` (the power-series Cauchy product over `Finset.antidiagonal`) turns the $n$-th coefficient of `geomGF a * geomGF b` into the convolution $\\sum_{p+q=n} \\binom{a+p}{a}\\binom{b+q}{b}$ (`twoDim_cauchy`); the closed form $\\binom{a+b+1+n}{a+b+1}$ comes from `multiGF_coeff` specialized to $[a,b]$ (`twoDim_closed`). Equating them yields parallel Vandermonde over any `CommRing` (`parallel_vandermonde_gf`); casting through `ℤ` and `exact_mod_cast` gives the `ℕ` form (`parallel_vandermonde_nat`).",
+    "keyInsights": [
+      "**Convolution becomes multiplication.** The parent proves the k-dimensional hockey stick by an induction whose every step invokes the parallel Vandermonde convolution. In the generating-function world that convolution *is* the product of two power series, so the entire induction is replaced by the single algebraic fact that `invOneSubPow` is additive in its exponent: `invOneSubPow_add : invOneSubPow S (d+e) = invOneSubPow S d * invOneSubPow S e`.",
+      "**The list encodes geometry.** The dimension $k$ is `as.length`, the weight offset $\\sum a_j$ is `as.sum`, and the total inverse power is `as.sum + as.length`. Peeling one element `a` off the list bumps the exponent by exactly $a+1$, which is precisely the exponent of that element's generating factor — so the induction step is pure bookkeeping (`omega`).",
+      "**invOneSubPow is the right Mathlib abstraction.** Rather than build `1/(1-z)^m` by hand, the proof reuses Mathlib's unit `invOneSubPow S m ∈ S⟦X⟧ˣ`. Its `.val` is the power series with coefficients $\\binom{m-1+n}{m-1}$ and its `.inv` is `(1-X)^m`; the unit structure makes `multiGF_mul_one_sub_pow` a one-liner via `val_inv`.",
+      "**One generating-function identity contains all dimensions and all parameters.** `multiGF_eq` is quantified over an arbitrary list `as`, so 1-D, 2-D, 3-D, … are uniform specializations (`oneDim_multiGF`, `twoDim_multiGF`, `threeDim_multiGF`) rather than separate proofs.",
+      "**Same theorem, two proofs.** `parallel_vandermonde_nat` reproves the parent's `parallel_vandermonde` (modulo `simplicial k n = C(n+k,k)` and the `range`↔`antidiagonal` reindexing) with no induction at all — a concrete demonstration that the generating-function method is genuinely an *alternative* proof, not a repackaging of the convolution argument."
+    ],
+    "prerequisites": [
+      "Mathlib.RingTheory.PowerSeries.WellKnown: invOneSubPow, invOneSubPow_add, invOneSubPow_zero, invOneSubPow_val_succ_eq_mk_add_choose, invOneSubPow_val_eq_mk_sub_one_add_choose_of_pos, invOneSubPow_inv_eq_one_sub_pow",
+      "PowerSeries.coeff_mk and PowerSeries.coeff_mul (Cauchy product over Finset.antidiagonal)",
+      "Units API: Units.val_mul and (u).val_inv for the group of units of S⟦X⟧",
+      "List operations: List.sum_cons, List.length_cons, List.map_cons, List.prod_cons",
+      "norm_cast / exact_mod_cast for transferring the ring identity over ℤ down to ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble-imports",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring framing the open question (the multivariate generating-function identity) and the key observation that the one-variable factor 1/(1-z)^{a+1} is Mathlib's invOneSubPow S (a+1). Imports only Mathlib.RingTheory.PowerSeries.WellKnown; opens PowerSeries, Finset, and the PowerSeries / BigOperators scopes; fixes a commutative ring S.",
+      "mathContext": "The file is self-contained over Mathlib and deliberately does not import the parent combinatorial development — the link to parallel Vandermonde is re-derived in Part IV, demonstrating independence of the two proofs."
+    },
+    {
+      "id": "one-dim-gf",
+      "title": "Part I — The One-Dimensional Generating Function",
+      "startLine": 55,
+      "endLine": 73,
+      "summary": "Defines geomGF S a := (invOneSubPow S (a+1)).val, the generating function ∑_i C(a+i,a) X^i = 1/(1-X)^{a+1}. geomGF_def exposes the definition for rewriting; geomGF_coeff proves coeff n (geomGF S a) = C(a+n, a) via invOneSubPow_val_succ_eq_mk_add_choose and coeff_mk.",
+      "mathContext": "$G_a(z) = \\sum_{i \\geq 0} \\binom{a+i}{a} z^i = (1-z)^{-(a+1)}$. The coefficient $\\binom{a+n}{a}$ is the simplicial number $\\text{simplicial}\\,a\\,n$ of the parent file (there written $\\binom{n+a}{a}$; equal by commutativity of $+$ inside the binomial)."
+    },
+    {
+      "id": "unit-level-identity",
+      "title": "Part II — The Multivariate Identity at the Unit Level",
+      "startLine": 75,
+      "endLine": 97,
+      "summary": "multiGFUnit_eq: ∏_j invOneSubPow S (a_j+1) = invOneSubPow S (as.sum + as.length), by list induction. Base case via invOneSubPow_zero (empty product = 1); inductive step via invOneSubPow_add and an omega step matching (a+1)+(as.sum+as.length) with (a::as).sum+(a::as).length.",
+      "mathContext": "Working in the group of units S⟦X⟧ˣ lets the proof use the exponent-additivity law `invOneSubPow_add` directly, before taking values. The product of units is a single unit invOneSubPow S (∑a_j + k)."
+    },
+    {
+      "id": "series-level-identity",
+      "title": "Part III — The Multivariate Identity at the Series Level",
+      "startLine": 99,
+      "endLine": 146,
+      "summary": "multiGF_eq: ∏_j geomGF a_j = (invOneSubPow S (∑a_j+k)).val — the open question. multiGF_mul_one_sub_pow: (∏_j geomGF a_j)·(1-X)^{∑a_j+k} = 1, the division-free form, proved with invOneSubPow_inv_eq_one_sub_pow and val_inv. multiGF_coeff: coeff n (∏) = C(n+∑a_j+k-1, ∑a_j+k-1) when the total exponent is positive.",
+      "mathContext": "The series-level statement is the literal open question: the left side is the product of the one-variable generating functions, the right side is $1/(1-z)^{\\sum a_j + k}$. The coefficient form is the k-dimensional hockey stick over the *boundary* simplex $\\{\\sum i_j = n\\}$: $\\sum_{i_1+\\dots+i_k=n} \\prod_j \\binom{i_j+a_j}{a_j} = \\binom{n + \\sum a_j + k - 1}{\\sum a_j + k - 1}$."
+    },
+    {
+      "id": "k2-parallel-vandermonde",
+      "title": "Part IV — k=2 Recovers Parallel Vandermonde",
+      "startLine": 148,
+      "endLine": 204,
+      "summary": "twoDim_multiGF collapses the list [a,b] to geomGF a * geomGF b. twoDim_cauchy expands coeff n (geomGF a * geomGF b) via coeff_mul into the convolution ∑_{p+q=n} C(a+p,a)C(b+q,b). twoDim_closed gives the same coefficient as C(a+b+1+n, a+b+1). parallel_vandermonde_gf equates them over any CommRing; parallel_vandermonde_nat transfers to ℕ via ℤ and exact_mod_cast.",
+      "mathContext": "$\\sum_{p+q=n} \\binom{a+p}{a}\\binom{b+q}{b} = \\binom{a+b+1+n}{a+b+1}$. This is the parent's parallel_vandermonde (with simplicial $a\\,i = \\binom{i+a}{a}$ and Finset.antidiagonal in place of range), now obtained with zero induction — the Cauchy product of two geometric factors equals a single one."
+    },
+    {
+      "id": "special-cases",
+      "title": "Part V — Special Cases and Summary",
+      "startLine": 206,
+      "endLine": 268,
+      "summary": "oneDim_multiGF: the single-parameter product is geomGF a itself. threeDim_multiGF: the product over [a,b,c] is invOneSubPow S (a+b+c+3), the generating function over a tetrahedron. Closing summary recaps the five parts and the key insight that exponent-additivity of invOneSubPow replaces the parent's convolution induction.",
+      "mathContext": "1-D recovers the classical hockey stick generating function; 3-D gives $1/(1-z)^{a+b+c+3}$, whose coefficients $\\binom{n+a+b+c+2}{a+b+c+2}$ count weighted lattice points in a tetrahedron."
+    }
+  ],
+  "conclusion": {
+    "summary": "The multivariate generating-function identity ∏_j (∑_i C(a_j+i,a_j) z^i) = 1/(1-z)^{∑a_j+k} is proved in Lean's PowerSeries ring, answering the parent's third open question. The one-variable factor is Mathlib's invOneSubPow S (a+1); the whole identity is a one-line list induction whose engine is the exponent-additivity law invOneSubPow_add. The k=2 Cauchy product recovers the parent's parallel Vandermonde convolution with no induction. 13 theorems, 1 definition, 0 axioms, 0 sorries, fully machine-checked (only propext / Classical.choice / Quot.sound).",
+    "implications": "The entry makes precise the textbook slogan that 'convolution of sequences is multiplication of generating functions.' Where the parent file performs a dimension-by-dimension induction driven by parallel Vandermonde, this file performs no numerical induction at all: the dimension count is a list length, the weight offset is a list sum, and folding the simplex is multiplication of inverse powers of (1-z). Reusing Mathlib's invOneSubPow unit means the proof's mathematical content reduces to a single additivity lemma, illustrating how the right algebraic abstraction (the group of units of a power series ring) can compress a combinatorial induction into a homomorphism computation.",
+    "openQuestions": [
+      "Lift the boundary-simplex coefficient identity to the parent's full ≤-simplex statement inside the power series ring directly, by multiplying by the extra factor 1/(1-z) (which performs the partial-sum / prefix-sum operation on coefficients) and comparing with multiHockeySum.",
+      "Formalize the k-fold Cauchy product explicitly: prove coeff n ((as.map geomGF).prod) = ∑ over compositions i₁+…+iₖ=n of ∏_j C(i_j+a_j, a_j), generalizing twoDim_cauchy from k=2 to arbitrary k via List/Finset.antidiagonal.",
+      "Replace the single variable z by k independent variables z₁,…,z_k (MvPowerSeries) to obtain the genuinely multivariate generating function ∏_j 1/(1-z_j)^{a_j+1}, recovering the diagonal specialization z_j = z used here.",
+      "Generalize the base 1/(1-z) to other rational generating functions (e.g. cube faces 1/(1-z^{m+1})) and identify which polytope identities still reduce to exponent arithmetic in a unit group."
+    ]
+  },
+  "leanFile": {
+    "namespace": "ArithmeticSeriesOQ02OQ02OQ01OQ03",
+    "lineCount": 268,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.RingTheory.PowerSeries.WellKnown"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-02-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the k-dimensional hockey stick proved by induction on dimension. This file answers its third open question by giving the generating-function proof and recovering its parallel Vandermonde step (k=2) as a corollary."
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Grandparent entry providing the original parallel Vandermonde convolution and simplicial numbers, reproved here via the Cauchy product of generating functions."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent k-dimensional hockey stick entry (`arithmetic-series-oq-02-oq-02-oq-01`): prove the multivariate **generating-function** identity

$$\prod_{j=1}^{k}\Big(\sum_{i\ge 0}\binom{a_j+i}{a_j}z^i\Big)=\frac{1}{(1-z)^{\sum_j a_j + k}}$$

in Lean's formal power series ring `S⟦X⟧`, as an *alternative* proof of the k-dimensional hockey stick — generating functions instead of convolution induction.

## Key idea

The one-variable factor $1/(1-z)^{a+1}$ is exactly Mathlib's `PowerSeries.invOneSubPow S (a+1)` (coefficients $\binom{a+n}{a}$, inverse $(1-X)^{a+1}$). The entire multivariate identity then collapses to the **additivity of `invOneSubPow` in its exponent** (`invOneSubPow_add`), proved by a one-line list induction in which the dimension $k$ is the list **length** and the offset $\sum a_j$ is the list **sum**. No induction on a numerical bound anywhere.

The $k=2$ Cauchy product (`PowerSeries.coeff_mul` over `Finset.antidiagonal`) recovers the parent's **parallel Vandermonde** convolution

$$\sum_{p+q=n}\binom{a+p}{a}\binom{b+q}{b}=\binom{a+b+1+n}{a+b+1}$$

with *zero* induction, over any `CommRing` and (via a cast through `ℤ`) over `ℕ` — a concrete demonstration that the GF method is genuinely a different proof.

## Contents (`Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean`)

- `geomGF` + `geomGF_coeff` — the 1-D generating function and its coefficients
- `multiGFUnit_eq` / `multiGF_eq` — the multivariate identity (unit- and series-level)
- `multiGF_mul_one_sub_pow` — the division-free form $(\prod_j G_{a_j})\,(1-X)^{\sum a_j+k}=1$
- `multiGF_coeff` — closed-form coefficients (diagonal simplicial numbers)
- `twoDim_cauchy` / `twoDim_closed` / `parallel_vandermonde_gf` / `parallel_vandermonde_nat` — k=2 ⇒ parallel Vandermonde
- `oneDim_multiGF` / `threeDim_multiGF` — special cases

## Verification

- **Compiles `EXIT 0`** (local `lake env lean`, against Mathlib oleans).
- `#print axioms` on `multiGF_eq`, `multiGF_mul_one_sub_pow`, `parallel_vandermonde_nat` reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`**.
- **13 theorems, 1 definition, 0 axioms, 0 sorries.** `status=verified`, `badge=original`.
- Self-contained over `Mathlib.RingTheory.PowerSeries.WellKnown`; does **not** import the parent combinatorial file (the parallel-Vandermonde link is re-derived).

Includes the full gallery entry (`meta.json`, `annotations.json`, `index.ts`) and the `Proofs.lean` import registration. `listings.json` / `data-manifest.json` are intentionally left to `pnpm build` regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)