### PR TITLE
Enrich Eisenstein's Criterion for General Integer Polynomials (oq-01-oq-03)

### DIFF
--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03/annotations.json
@@ -8,29 +8,41 @@
       "endLine": 41
     },
     "title": "Module Header: General Eisenstein Polynomials over ℤ and ℚ",
-    "content": "Answers the third open question of `eisenstein-criterion-oq-01`. The parent restated the abstract criterion and handled the single family $X^n - p$ over $\\mathbb{Z}$. This file does three new things: (1) a **concrete divisibility-form** criterion over $\\mathbb{Z}$ — monic $f$, $p \\mid f_k$ for all $k$ below the degree, $p^2 \\nmid f_0$ $\\Rightarrow$ irreducible; (2) the **general family** $X^n + p\\,g$ for arbitrary $g$ with $\\deg g < n$ and $p \\nmid g(0)$ — the genuine 'arbitrary lower coefficients' case; (3) **irreducibility over $\\mathbb{Q}$** via Gauss's lemma, the form in which Eisenstein is actually used."
+    "content": "Answers the third open question of `eisenstein-criterion-oq-01`. The parent restated the abstract criterion and handled the single family $X^n - p$ over $\\mathbb{Z}$. This file does three new things: (1) a **concrete divisibility-form** criterion over $\\mathbb{Z}$ — monic $f$, $p \\mid f_k$ for all $k$ below the degree, $p^2 \\nmid f_0$ $\\Rightarrow$ irreducible; (2) the **general family** $X^n + p\\,g$ for arbitrary $g$ with $\\deg g < n$ and $p \\nmid g(0)$ — the genuine 'arbitrary lower coefficients' case; (3) **irreducibility over $\\mathbb{Q}$** via Gauss's lemma, the form in which Eisenstein is actually used.",
+    "mathContext": "$f = X^n + \\sum_{k<n} a_k X^k,\\quad p \\mid a_k\\ (k<n),\\ p^2 \\nmid a_0 \\;\\Rightarrow\\; f \\text{ irreducible}.$",
+    "significance": "context",
+    "relatedConcepts": ["Eisenstein's criterion", "irreducibility", "Gauss's lemma", "open question"],
+    "prerequisites": ["polynomial rings", "prime divisibility"]
   },
   {
     "id": "eisenstein-criterion-oq-01-oq-03-int-criterion",
     "proofId": "eisenstein-criterion-oq-01-oq-03",
     "type": "theorem",
     "range": {
-      "startLine": 64,
-      "endLine": 90
+      "startLine": 56,
+      "endLine": 85
     },
     "title": "Concrete Eisenstein Criterion over ℤ",
-    "content": "`irreducible_int_of_eisenstein`: trades the abstract prime ideal of the parent for plain divisibility by a prime integer $p$. For a monic $f$ of positive degree with $p \\mid f.\\mathrm{coeff}\\,k$ for every $k$ below the degree and $p^2 \\nmid f.\\mathrm{coeff}\\,0$, $f$ is irreducible over $\\mathbb{Z}$. The proof takes $P = $ `Ideal.span {p}` and converts the four hypotheses via `Ideal.mem_span_singleton` (membership $\\iff$ divisibility) and `Ideal.span_singleton_pow` ($(p)^2 = (p^2)$); primitivity is `Monic.isPrimitive`. The lower coefficients are now arbitrary subject only to divisibility by $p$."
+    "content": "`irreducible_int_of_eisenstein`: trades the abstract prime ideal of the parent for plain divisibility by a prime integer $p$. For a monic $f$ of positive degree with $p \\mid f.\\mathrm{coeff}\\,k$ for every $k$ below the degree and $p^2 \\nmid f.\\mathrm{coeff}\\,0$, $f$ is irreducible over $\\mathbb{Z}$. The proof takes $P = $ `Ideal.span {p}` and converts the four hypotheses via `Ideal.mem_span_singleton` (membership $\\iff$ divisibility) and `Ideal.span_singleton_pow` ($(p)^2 = (p^2)$); primitivity is `Monic.isPrimitive`. The lower coefficients are now arbitrary subject only to divisibility by $p$.",
+    "mathContext": "$P=(p)$ prime; $x\\in(p)\\iff p\\mid x$, $(p)^2=(p^2)$, monic $\\Rightarrow$ primitive. Hypotheses become $p\\mid f_k\\ (k<\\deg f),\\ p^2\\nmid f_0$.",
+    "significance": "key",
+    "relatedConcepts": ["prime ideal", "span singleton", "primitive polynomial", "integral domain"],
+    "prerequisites": ["ideal arithmetic", "Ideal.mem_span_singleton", "Monic.isPrimitive"]
   },
   {
     "id": "eisenstein-criterion-oq-01-oq-03-rat-criterion",
     "proofId": "eisenstein-criterion-oq-01-oq-03",
     "type": "theorem",
     "range": {
-      "startLine": 92,
+      "startLine": 87,
       "endLine": 98
     },
     "title": "Irreducibility over ℚ via Gauss's Lemma",
-    "content": "`irreducible_rat_of_eisenstein`: the operative form of Eisenstein's criterion. Because the polynomial is **monic** and $\\mathbb{Q}$ is the **fraction field** of $\\mathbb{Z}$, Gauss's lemma (`Monic.irreducible_iff_irreducible_map_fraction_map`) lifts irreducibility over $\\mathbb{Z}$ to irreducibility over $\\mathbb{Q}$. It is over $\\mathbb{Q}$ that an irreducible monic polynomial is the minimal polynomial of each of its roots, giving $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\deg f$. The parent stopped at $\\mathbb{Z}$."
+    "content": "`irreducible_rat_of_eisenstein`: the operative form of Eisenstein's criterion. Because the polynomial is **monic** and $\\mathbb{Q}$ is the **fraction field** of $\\mathbb{Z}$, Gauss's lemma (`Monic.irreducible_iff_irreducible_map_fraction_map`) lifts irreducibility over $\\mathbb{Z}$ to irreducibility over $\\mathbb{Q}$. It is over $\\mathbb{Q}$ that an irreducible monic polynomial is the minimal polynomial of each of its roots, giving $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\deg f$. The parent stopped at $\\mathbb{Z}$.",
+    "mathContext": "$f \\text{ monic irreducible in } \\mathbb{Z}[X] \\iff f \\text{ irreducible in } \\mathbb{Q}[X]$ (Gauss's lemma, $\\mathbb{Q}=\\mathrm{Frac}\\,\\mathbb{Z}$); then $[\\mathbb{Q}(\\alpha):\\mathbb{Q}]=\\deg f$.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss's lemma", "fraction field", "minimal polynomial", "field extension degree", "integrally closed domain"],
+    "prerequisites": ["Gauss's lemma", "fraction fields", "field extensions"]
   },
   {
     "id": "eisenstein-criterion-oq-01-oq-03-general-family",
@@ -41,7 +53,11 @@
       "endLine": 151
     },
     "title": "The General Family Xⁿ + p·g",
-    "content": "`irreducible_int_X_pow_add_CP_mul` (with helpers `monic_X_pow_add_CP_mul`, `natDegree_X_pow_add_CP_mul`): for any $g$ with $\\deg g < n$ ($0 < n$) and $p \\nmid g(0)$, the polynomial $X^n + p\\,g$ is irreducible over $\\mathbb{Z}$, and over $\\mathbb{Q}$ (`irreducible_rat_X_pow_add_CP_mul`). This is the direct answer to the open question: the coefficient formula $\\mathrm{coeff}\\,k = [k = n] + p\\cdot g.\\mathrm{coeff}\\,k$ makes every lower coefficient $p\\cdot g.\\mathrm{coeff}\\,k$ (divisible by $p$), while the constant coefficient $p\\cdot g(0)$ avoids $p^2$ exactly when $p \\nmid g(0)$ (cancelling one factor of $p$ via `mul_dvd_mul_iff_left`). Monicity and $\\deg = n$ follow from `monic_X_pow_add` and `degree_add_eq_left_of_degree_lt` since $\\deg(p\\,g) < n$."
+    "content": "`irreducible_int_X_pow_add_CP_mul` (with helpers `monic_X_pow_add_CP_mul`, `natDegree_X_pow_add_CP_mul`): for any $g$ with $\\deg g < n$ ($0 < n$) and $p \\nmid g(0)$, the polynomial $X^n + p\\,g$ is irreducible over $\\mathbb{Z}$, and over $\\mathbb{Q}$ (`irreducible_rat_X_pow_add_CP_mul`). This is the direct answer to the open question: the coefficient formula $\\mathrm{coeff}\\,k = [k = n] + p\\cdot g.\\mathrm{coeff}\\,k$ makes every lower coefficient $p\\cdot g.\\mathrm{coeff}\\,k$ (divisible by $p$), while the constant coefficient $p\\cdot g(0)$ avoids $p^2$ exactly when $p \\nmid g(0)$ (cancelling one factor of $p$ via `mul_dvd_mul_iff_left`). Monicity and $\\deg = n$ follow from `monic_X_pow_add` and `degree_add_eq_left_of_degree_lt` since $\\deg(p\\,g) < n$.",
+    "mathContext": "$(X^n + p\\,g)_k = [k=n] + p\\,g_k$; lower coeffs $p\\,g_k$ are $\\equiv 0 \\pmod p$, and $p^2 \\nmid p\\,g_0 \\iff p \\nmid g_0$. $X^n - p$ is the $g=-1$ case.",
+    "significance": "key",
+    "relatedConcepts": ["coefficient extraction", "degree of a sum", "monic polynomial", "divisibility cancellation"],
+    "prerequisites": ["polynomial degree arithmetic", "coeff_X_pow / coeff_C_mul", "mul_dvd_mul_iff_left"]
   },
   {
     "id": "eisenstein-criterion-oq-01-oq-03-recover-xn-p",
@@ -52,7 +68,11 @@
       "endLine": 175
     },
     "title": "Recovering Xⁿ − p (over ℤ and ℚ)",
-    "content": "`irreducible_int_X_pow_sub_C` and `irreducible_rat_X_pow_sub_C`: the parent's flagship $X^n - p$ is the $g = -1$ member of the family, since $X^n - p = X^n + p\\cdot(-1)$ and $p \\nmid -1$ (as $p$ is not a unit). The $\\mathbb{Q}$ version is what underlies $[\\mathbb{Q}(\\sqrt[n]{p}):\\mathbb{Q}] = n$ — the parent only had the $\\mathbb{Z}$ statement."
+    "content": "`irreducible_int_X_pow_sub_C` and `irreducible_rat_X_pow_sub_C`: the parent's flagship $X^n - p$ is the $g = -1$ member of the family, since $X^n - p = X^n + p\\cdot(-1)$ and $p \\nmid -1$ (as $p$ is not a unit). The $\\mathbb{Q}$ version is what underlies $[\\mathbb{Q}(\\sqrt[n]{p}):\\mathbb{Q}] = n$ — the parent only had the $\\mathbb{Z}$ statement.",
+    "mathContext": "$X^n - p = X^n + p\\cdot(-1)$, $g=-1$, $g(0)=-1$, $p\\nmid -1$. Over $\\mathbb{Q}$: $[\\mathbb{Q}(\\sqrt[n]{p}):\\mathbb{Q}]=n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["radical extension", "unit divisibility", "specialization", "nth roots"],
+    "prerequisites": ["units in ℤ", "the general family"]
   },
   {
     "id": "eisenstein-criterion-oq-01-oq-03-instances",
@@ -60,9 +80,13 @@
     "type": "example",
     "range": {
       "startLine": 177,
-      "endLine": 213
+      "endLine": 214
     },
     "title": "Concrete Instances with Nonzero Middle Coefficients",
-    "content": "`irreducible_int_X_sq_add_two_X_add_two` ($X^2 + 2X + 2$, Eisenstein at $2$), `irreducible_int_X_cube_add_three_X_add_three` ($X^3 + 3X + 3$, at $3$), and `irreducible_rat_X_sq_add_two_X_add_two` (the first over $\\mathbb{Q}$). Each is the $g = X + 1$ member of the family at the relevant prime: $C\\,p \\cdot (X + 1) = pX + p$, so $g(0) = 1$ is not divisible by $p$. These are genuine Eisenstein polynomials with **nonzero middle coefficients** — exactly the cases the parent's $X^n - p$ form could not express."
+    "content": "`irreducible_int_X_sq_add_two_X_add_two` ($X^2 + 2X + 2$, Eisenstein at $2$), `irreducible_int_X_cube_add_three_X_add_three` ($X^3 + 3X + 3$, at $3$), and `irreducible_rat_X_sq_add_two_X_add_two` (the first over $\\mathbb{Q}$). Each is the $g = X + 1$ member of the family at the relevant prime: $C\\,p \\cdot (X + 1) = pX + p$, so $g(0) = 1$ is not divisible by $p$. These are genuine Eisenstein polynomials with **nonzero middle coefficients** — exactly the cases the parent's $X^n - p$ form could not express.",
+    "mathContext": "$X^2+2X+2 = X^2 + 2(X+1)$ at $p=2$; $\\;X^3+3X+3 = X^3 + 3(X+1)$ at $p=3$; here $g=X+1,\\ g(0)=1,\\ p\\nmid 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "Eisenstein at p=2,3", "nonzero middle coefficient"],
+    "prerequisites": ["the general family", "concrete coefficient computation"]
   }
 ]

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03/index.ts
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EisensteinCriterionOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eisensteinCriterionOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eisensteinCriterionOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eisensteinCriterionOq01Oq03Data: ProofData = {
+  proof: eisensteinCriterionOq01Oq03Proof,
+  annotations: eisensteinCriterionOq01Oq03Annotations,
+}

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03/meta.json
@@ -77,6 +77,57 @@
       "Basic ℤ divisibility: p ∣ 1 ↔ IsUnit p, cancelling a factor of p (mul_dvd_mul_iff_left)"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module header and open question",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Docstring framing the parent entry's third open question — generalize the Eisenstein coefficient bookkeeping beyond Xⁿ − p to arbitrary lower coefficients divisible by p — and listing the three contributions: a concrete divisibility-form criterion over ℤ, the general family Xⁿ + p·g, and the upgrade to ℚ via Gauss's lemma. Imports Mathlib, opens the Polynomial namespace, opens the EisensteinCriterionOQ01OQ03 namespace."
+    },
+    {
+      "id": "abstract-reexport",
+      "title": "Re-export of Mathlib's abstract criterion",
+      "startLine": 43,
+      "endLine": 54,
+      "summary": "aux_irreducible_of_eisenstein restates Mathlib's irreducible_of_eisenstein_criterion over an arbitrary integral domain with a prime ideal P (leading coeff ∉ P, lower coeffs ∈ P, positive degree, constant coeff ∉ P², primitive ⇒ irreducible). This is the core engine specialized below."
+    },
+    {
+      "id": "int-criterion",
+      "title": "Concrete Eisenstein criterion over ℤ",
+      "startLine": 56,
+      "endLine": 85,
+      "summary": "irreducible_int_of_eisenstein: a monic f of positive degree with p ∣ f.coeff k for all k below the degree and p² ∤ f.coeff 0 is irreducible over ℤ. The proof instantiates P = Ideal.span {p} (prime via Ideal.span_singleton_prime) and discharges the four abstract hypotheses through Ideal.mem_span_singleton (membership ⇔ divisibility) and Ideal.span_singleton_pow ((p)² = (p²)); primitivity from Monic.isPrimitive. Lower coefficients are now arbitrary subject only to divisibility by p."
+    },
+    {
+      "id": "rat-criterion",
+      "title": "Irreducibility over ℚ via Gauss's lemma",
+      "startLine": 87,
+      "endLine": 98,
+      "summary": "irreducible_rat_of_eisenstein: because the polynomial is monic and ℚ is the fraction field of ℤ, Gauss's lemma (Monic.irreducible_iff_irreducible_map_fraction_map) lifts irreducibility over ℤ to irreducibility over ℚ. This is the operative form of the criterion — it is over ℚ that such an f is the minimal polynomial of its roots."
+    },
+    {
+      "id": "general-family",
+      "title": "The general family Xⁿ + p·g",
+      "startLine": 100,
+      "endLine": 151,
+      "summary": "monic_X_pow_add_CP_mul and natDegree_X_pow_add_CP_mul establish monicity and natDegree = n for Xⁿ + p·g when deg g < n (via monic_X_pow_add, degree_C_mul, degree_add_eq_left_of_degree_lt). irreducible_int_X_pow_add_CP_mul then proves irreducibility over ℤ for any g with deg g < n and p ∤ g.coeff 0: the coefficient formula coeff k = [k = n] + p·g.coeff k makes lower coefficients divisible by p, and p² ∤ p·g.coeff 0 reduces to p ∤ g.coeff 0 via mul_dvd_mul_iff_left. irreducible_rat_X_pow_add_CP_mul lifts it to ℚ. This is the direct answer to the open question."
+    },
+    {
+      "id": "recover-xn-minus-p",
+      "title": "Recovering Xⁿ − p over ℤ and ℚ",
+      "startLine": 153,
+      "endLine": 175,
+      "summary": "irreducible_int_X_pow_sub_C and irreducible_rat_X_pow_sub_C: the parent's flagship Xⁿ − p = Xⁿ + p·(−1) is the g = −1 member of the family, with p ∤ −1 because p is not a unit. The ℚ version is what underlies [ℚ(ⁿ√p):ℚ] = n, which the parent did not reach."
+    },
+    {
+      "id": "concrete-instances",
+      "title": "Concrete instances with nonzero middle coefficients",
+      "startLine": 177,
+      "endLine": 214,
+      "summary": "irreducible_int_X_sq_add_two_X_add_two (X² + 2X + 2, Eisenstein at 2), irreducible_int_X_cube_add_three_X_add_three (X³ + 3X + 3, at 3), and irreducible_rat_X_sq_add_two_X_add_two (the first over ℚ). Each is the g = X + 1 family member at the relevant prime, where g(0) = 1 is not divisible by p — genuine Eisenstein polynomials with nonzero middle coefficients beyond the parent's Xⁿ − p form."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "eisenstein-criterion-oq-01",


### PR DESCRIPTION
Enrichment pass for `eisenstein-criterion-oq-01-oq-03`.

## Quality improvements
- **Created missing `index.ts`** — the proof had no Vite entry point, so it would render "proof not found" on the live site. Added the standard template wiring `EisensteinCriterionOQ01OQ03.lean` as source.
- **Added `sections` array** (7 sections) covering the full 214-line Lean file: module header, abstract re-export, concrete ℤ criterion, ℚ upgrade via Gauss's lemma, the general family Xⁿ + p·g, recovery of Xⁿ − p, and concrete instances.
- **Enriched all 6 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Also **corrected the annotation line ranges** (e.g. the ℤ-criterion annotation pointed at lines 64–90 but the theorem spans 56–85) to align with the actual theorem locations.

## Axiom integrity
No status/badge/axiom changes. Confirmed accurate: 12 theorems, 0 sorries, 0 axioms, no `native_decide`. `badge: mathlib` is appropriate (the core engine is a re-export of Mathlib's `irreducible_of_eisenstein_criterion` plus Gauss's lemma, specialized to concrete ℤ/ℚ statements). `status: verified` and `axiomCount: 0` remain accurate.

Build passes (`pnpm build`).