### PR TITLE
Enrich Erdős #247 (oq-01-oq-02): add missing index.ts

### DIFF
--- a/src/data/proofs/erdos-247-oq-01-oq-02/index.ts
+++ b/src/data/proofs/erdos-247-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos247RatioGrowth.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos247Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos247Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos247Oq01Oq02Data: ProofData = {
+  proof: erdos247Oq01Oq02Proof,
+  annotations: erdos247Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-247-oq-01-oq-02`.

This entry was already in good shape — full `sections` array (11 sections covering the entire 317-line Lean file) and 11 annotations each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`. The one genuine gap was a **missing `index.ts`**: without the Vite entry point the proof page renders "proof not found" on the live site even though it appears in the gallery listing.

- **Created `index.ts`** wiring `Erdos247RatioGrowth.lean` as source via the standard template.

No metadata, status, or axiom changes. Build passes (`pnpm build`).