### PR TITLE
Enrich Frobenius generates Galois group (frobenius-endomorphism-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/annotations.json
@@ -8,7 +8,11 @@
       "endLine": 36
     },
     "title": "Module Header: Frobenius Generates the Galois Group",
-    "content": "For the canonical finite field $\\mathbb{F}_{p^n} = \\mathrm{GaloisField}\\,p\\,n$ over its prime field $\\mathbb{F}_p = \\mathbb{Z}/p$, the **Frobenius automorphism** $\\mathrm{frob} : x \\mapsto x^p$ is the canonical generator of the Galois group $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$. This file answers the parent's first open question: $\\mathrm{frob}$ has order **exactly** $n$ ($\\mathrm{frob}^n = 1$ but $\\mathrm{frob}^k \\neq 1$ for $0 < k < n$), **generates** the whole group ($\\langle\\mathrm{frob}\\rangle = \\top$, every $\\sigma$ a power of $\\mathrm{frob}$), and the group is cyclic of order $n$. The core machinery is Mathlib's `frobeniusAlgEquivOfAlgebraic`; the contribution is the specialisation to $\\mathbb{F}_{p^n}/\\mathbb{F}_p$ where the degree is literally $n$."
+    "content": "For the canonical finite field $\\mathbb{F}_{p^n} = \\mathrm{GaloisField}\\,p\\,n$ over its prime field $\\mathbb{F}_p = \\mathbb{Z}/p$, the **Frobenius automorphism** $\\mathrm{frob} : x \\mapsto x^p$ is the canonical generator of the Galois group $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$. This file answers the parent's first open question: $\\mathrm{frob}$ has order **exactly** $n$ ($\\mathrm{frob}^n = 1$ but $\\mathrm{frob}^k \\neq 1$ for $0 < k < n$), **generates** the whole group ($\\langle\\mathrm{frob}\\rangle = \\top$, every $\\sigma$ a power of $\\mathrm{frob}$), and the group is cyclic of order $n$. The core machinery is Mathlib's `frobeniusAlgEquivOfAlgebraic`; the contribution is the specialisation to $\\mathbb{F}_{p^n}/\\mathbb{F}_p$ where the degree is literally $n$.",
+    "mathContext": "$\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p) = \\langle \\mathrm{frob}\\rangle \\cong \\mathbb{Z}/n\\mathbb{Z},\\quad \\mathrm{frob}(x) = x^p$",
+    "significance": "context",
+    "relatedConcepts": ["Galois group", "finite field", "Frobenius automorphism", "cyclic group"],
+    "prerequisites": ["Galois theory", "finite fields", "group theory"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-01-def",
@@ -19,7 +23,11 @@
       "endLine": 65
     },
     "title": "The Frobenius Automorphism and its Powers",
-    "content": "`frob` is `frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n)`, the Frobenius as an element of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$. Because $|\\mathbb{Z}/p| = p$, `frob_apply` gives $\\mathrm{frob}\\,x = x^p$ (the absolute Frobenius of the parent entry), and `frob_pow_apply` gives the iterated Frobenius $\\mathrm{frob}^k x = x^{p^k}$ — the $q$-power iterates of the parent, now realised as powers of a single group element."
+    "content": "`frob` is `frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n)`, the Frobenius as an element of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$. Because $|\\mathbb{Z}/p| = p$, `frob_apply` gives $\\mathrm{frob}\\,x = x^p$ (the absolute Frobenius of the parent entry), and `frob_pow_apply` gives the iterated Frobenius $\\mathrm{frob}^k x = x^{p^k}$ — the $q$-power iterates of the parent, now realised as powers of a single group element.",
+    "mathContext": "$\\mathrm{frob}(x) = x^p,\\qquad \\mathrm{frob}^k(x) = x^{p^k}$",
+    "significance": "supporting",
+    "relatedConcepts": ["AlgEquiv", "field automorphism", "iterated Frobenius", "prime field ZMod p"],
+    "prerequisites": ["ring homomorphism", "GaloisField", "algebraic extension"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-01-order",
@@ -30,7 +38,11 @@
       "endLine": 88
     },
     "title": "Order Exactly n, with Sharpness",
-    "content": "`orderOf_frob`: $\\mathrm{ord}(\\mathrm{frob}) = n$, the heart of the open question. Mathlib's `orderOf_frobeniusAlgEquivOfAlgebraic` gives $\\mathrm{ord} = \\mathrm{finrank}$, and `GaloisField.finrank` $= n$ supplies the exact value. The bound `frob_pow_card` ($\\mathrm{frob}^n = 1$) is `pow_orderOf_eq_one`; sharpness `frob_pow_ne_one` ($\\mathrm{frob}^k \\neq 1$ for $0 < k < n$) follows since $\\mathrm{frob}^k = 1 \\Rightarrow n \\mid k$, impossible for $0 < k < n$. Mathematically this says $\\mathbb{F}_{p^n} \\not\\subseteq \\mathbb{F}_{p^k}$ for $k < n$."
+    "content": "`orderOf_frob`: $\\mathrm{ord}(\\mathrm{frob}) = n$, the heart of the open question. Mathlib's `orderOf_frobeniusAlgEquivOfAlgebraic` gives $\\mathrm{ord} = \\mathrm{finrank}$, and `GaloisField.finrank` $= n$ supplies the exact value. The bound `frob_pow_card` ($\\mathrm{frob}^n = 1$) is `pow_orderOf_eq_one`; sharpness `frob_pow_ne_one` ($\\mathrm{frob}^k \\neq 1$ for $0 < k < n$) follows since $\\mathrm{frob}^k = 1 \\Rightarrow n \\mid k$, impossible for $0 < k < n$. Mathematically this says $\\mathbb{F}_{p^n} \\not\\subseteq \\mathbb{F}_{p^k}$ for $k < n$.",
+    "mathContext": "$\\mathrm{ord}(\\mathrm{frob}) = [\\mathbb{F}_{p^n}:\\mathbb{F}_p] = n;\\quad \\mathrm{frob}^k = 1 \\iff n \\mid k$",
+    "significance": "key",
+    "relatedConcepts": ["order of a group element", "field degree (finrank)", "subfield lattice", "minimal period"],
+    "prerequisites": ["orderOf", "extension degree", "divisibility"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-01-generates",
@@ -41,7 +53,11 @@
       "endLine": 113
     },
     "title": "The Frobenius Generates the Galois Group",
-    "content": "`frob_generates`: every automorphism $\\sigma \\in \\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$ is a power of $\\mathrm{frob}$ — the surjectivity of $k \\mapsto \\mathrm{frob}^k$ from Mathlib's `bijective_frobeniusAlgEquivOfAlgebraic_pow`. `zpowers_frob_eq_top`: the cyclic subgroup $\\langle\\mathrm{frob}\\rangle$ is the whole group. Together with order $n$, this exhibits $\\mathrm{frob}$ as a genuine generator."
+    "content": "`frob_generates`: every automorphism $\\sigma \\in \\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$ is a power of $\\mathrm{frob}$ — the surjectivity of $k \\mapsto \\mathrm{frob}^k$ from Mathlib's `bijective_frobeniusAlgEquivOfAlgebraic_pow`. `zpowers_frob_eq_top`: the cyclic subgroup $\\langle\\mathrm{frob}\\rangle$ is the whole group. Together with order $n$, this exhibits $\\mathrm{frob}$ as a genuine generator.",
+    "mathContext": "$\\forall \\sigma\\, \\exists k:\\ \\sigma = \\mathrm{frob}^k;\\qquad \\langle \\mathrm{frob}\\rangle = \\top$",
+    "significance": "key",
+    "relatedConcepts": ["group generator", "zpowers (cyclic subgroup)", "surjectivity", "top subgroup"],
+    "prerequisites": ["subgroup generated by an element", "cyclic groups"]
   },
   {
     "id": "frobenius-endomorphism-oq-01-oq-01-cyclic",
@@ -52,6 +68,10 @@
       "endLine": 127
     },
     "title": "Cardinality, Cyclicity, and a Concrete Instance",
-    "content": "`card_aut`: $|\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)| = n$ via `IsGalois.card_aut_eq_finrank` and `GaloisField.finrank`. `galois_group_cyclic`: the group is cyclic (Mathlib's `IsCyclic Gal(L/K)` instance for finite fields). `frob_fixed_iff` records that a Frobenius fixed point is a Fermat fixed point $x^p = x$, and `orderOf_frob_two_three` is the concrete instance: the Frobenius $x \\mapsto x^2$ of $\\mathbb{F}_8 = \\mathbb{F}_{2^3}$ has order exactly $3$."
+    "content": "`card_aut`: $|\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)| = n$ via `IsGalois.card_aut_eq_finrank` and `GaloisField.finrank`. `galois_group_cyclic`: the group is cyclic (Mathlib's `IsCyclic Gal(L/K)` instance for finite fields). `frob_fixed_iff` records that a Frobenius fixed point is a Fermat fixed point $x^p = x$, and `orderOf_frob_two_three` is the concrete instance: the Frobenius $x \\mapsto x^2$ of $\\mathbb{F}_8 = \\mathbb{F}_{2^3}$ has order exactly $3$.",
+    "mathContext": "$|\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)| = n;\\quad \\mathrm{frob}(x)=x \\iff x^p = x;\\quad \\mathrm{ord}(\\mathrm{frob}_{\\mathbb{F}_8}) = 3$",
+    "significance": "supporting",
+    "relatedConcepts": ["IsGalois", "cardinality of automorphism group", "fixed field", "Fermat's little theorem"],
+    "prerequisites": ["IsGalois.card_aut_eq_finrank", "IsCyclic", "fixed points"]
   }
 ]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-01/meta.json
@@ -90,6 +90,43 @@
       "GaloisField.finrank (ZMod p) (GaloisField p n) = n for n ≠ 0, and ZMod.card (|ZMod p| = p)"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Frobenius generates the Galois group",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Docstring framing the parent's first open question: for 𝔽_{pⁿ}/𝔽_p the Frobenius x ↦ x^p has order exactly n, generates Gal, and the group is cyclic of order n. The contribution is specializing Mathlib's frobeniusAlgEquivOfAlgebraic to the canonical degree-n model."
+    },
+    {
+      "id": "frob-definition",
+      "title": "The Frobenius automorphism and its powers",
+      "startLine": 48,
+      "endLine": 65,
+      "summary": "Defines frob = frobeniusAlgEquivOfAlgebraic (ZMod p) (GaloisField p n); frob_apply gives frob x = x^p (since |ZMod p| = p) and frob_pow_apply gives frob^k x = x^{p^k}."
+    },
+    {
+      "id": "order-exactly-n",
+      "title": "Order exactly n, with sharpness",
+      "startLine": 70,
+      "endLine": 88,
+      "summary": "orderOf_frob: ord(frob) = n via orderOf_frobeniusAlgEquivOfAlgebraic and GaloisField.finrank = n. frob_pow_card gives frob^n = 1; frob_pow_ne_one gives sharpness for 0 < k < n (since frob^k = 1 ⟹ n ∣ k), i.e. 𝔽_{pⁿ} ⊄ 𝔽_{p^k}."
+    },
+    {
+      "id": "frob-generates",
+      "title": "The Frobenius generates the Galois group",
+      "startLine": 90,
+      "endLine": 113,
+      "summary": "frob_generates: every σ is a power of frob (surjectivity from bijective_frobeniusAlgEquivOfAlgebraic_pow); zpowers_frob_eq_top: ⟨frob⟩ = ⊤. Together with order n this exhibits frob as a genuine generator."
+    },
+    {
+      "id": "cardinality-cyclicity",
+      "title": "Cardinality, cyclicity, and a concrete instance",
+      "startLine": 114,
+      "endLine": 127,
+      "summary": "card_aut: |Gal| = n via IsGalois.card_aut_eq_finrank; galois_group_cyclic: the group is cyclic; frob_fixed_iff: a Frobenius fixed point is a Fermat fixed point x^p = x; orderOf_frob_two_three: the Frobenius of 𝔽_8 = 𝔽_{2³} has order exactly 3."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "frobenius-endomorphism-oq-01",


### PR DESCRIPTION
Enrichment pass for `frobenius-endomorphism-oq-01-oq-01`.

The entry had a complete `overview`/`conclusion` but its 5 annotations carried only `content`, and `sections` was empty.

## Changes
- **annotations.json**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations — the Frobenius definition and its powers, order exactly n with sharpness, generation of Gal, and cardinality/cyclicity plus the 𝔽_8 instance.
- **meta.json**: added a `sections` array (5 entries) covering the full 128-line Lean file.

Existing content preserved; status/badge/axiomCount unchanged. `pnpm build` passes.