### PR TITLE
research(hilbert-22-oq-01-oq-03): verified abstract Kobayashi chain pseudometric

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3255,6 +3255,7 @@ import Proofs.Hilbert20OQ01OQ03
 import Proofs.Hilbert20OQ01OQ03Aristotle
 import Proofs.Hilbert21RiemannHilbert
 import Proofs.Hilbert22OQ01
+import Proofs.Hilbert22OQ01OQ03
 import Proofs.Hilbert22Uniformization
 import Proofs.Hilbert23CalculusVariations
 import Proofs.Hilbert23CalculusVariationsOQ01

--- a/proofs/Proofs/Hilbert22OQ01OQ03.lean
+++ b/proofs/Proofs/Hilbert22OQ01OQ03.lean
@@ -1,0 +1,204 @@
+import Mathlib
+
+/-
+# Hilbert 22 — OQ-01-OQ-03: The Abstract Kobayashi Chain Pseudometric
+
+## Research Problem: hilbert-22-oq-01-oq-03
+
+The Kobayashi pseudometric on a complex manifold `M` is the infimum, over all
+*holomorphic chains* of disks connecting two points, of the total Poincaré
+length of the chain:
+
+  d_M(p, q) = inf { Σ ρ(aᵢ, bᵢ) | chain of holomorphic maps 𝔻 → M from p to q }.
+
+The defining structural features of this construction are entirely *order-theoretic*
+and *combinatorial*: they do not depend on complex analysis at all. They are:
+
+  1. it is a pseudometric  (reflexivity, symmetry, triangle inequality), and
+  2. it is *functorial* — distance-non-increasing under maps that contract the
+     underlying atomic cost (the abstract shadow of "holomorphic maps are
+     distance-non-increasing", which is what makes the Kobayashi metric an
+     invariant of the complex structure).
+
+This file isolates and *fully verifies* that order-theoretic skeleton, with **no
+sorries and no axioms beyond Mathlib's foundations**. We work over an arbitrary
+type `X` with a symmetric "atomic cost" `c : X → X → ℝ≥0∞` vanishing on the
+diagonal — the abstract stand-in for the one-step Poincaré distance ρ of a single
+disk in a chain — and build
+
+  chainDist c p q = ⨅ over finite chains p ⇝ q of the total cost,
+
+valued in `ℝ≥0∞` (so infima are junk-free: an empty chain set gives `⊤`, never a
+spurious `0`). We prove:
+
+* `chainDist_self`     :  d(p, p) = 0
+* `chainDist_comm`     :  d(p, q) = d(q, p)
+* `chainDist_triangle` :  d(p, r) ≤ d(p, q) + d(q, r)
+* `chainPseudoEMetricSpace` : these package into a genuine `PseudoEMetricSpace`
+* `chainDist_mono`     :  functoriality — a cost-contracting map is
+                          distance-non-increasing for `chainDist`.
+
+This is exactly properties (1)–(2) of the Kobayashi pseudometric listed in the
+`hilbert-22-oq-01` gallery entry, which were previously stated only informally.
+The genuinely analytic ingredients (the unit-disk Poincaré metric, Schwarz–Pick
+contraction, the identification `d_𝔻 = ρ`, and Picard's theorem via the modular
+λ universal cover) are **not** in Mathlib and remain open; this file deliberately
+does not assume them.
+
+## Design notes
+
+A chain from `p` to `q` is encoded by its list of *intermediate* points
+`mid : List X`; the full vertex sequence is `p, mid…, q`. The cost is summed from
+the front by `chainCost`, which never needs `List.head!`/`getLast!` and so keeps
+every lemma free of nonemptiness side-conditions. Concatenation of chains becomes
+`List.append` with a shared joining vertex, and reversal becomes `List.reverse`;
+the three pseudometric axioms are then short inductions plus the standard
+`ENNReal` infimum-arithmetic lemmas `ENNReal.iInf_add` / `ENNReal.add_iInf`.
+
+Tags: complex-geometry, kobayashi-metric, hyperbolic-manifolds, pseudometric,
+hilbert-problems
+-/
+
+namespace Hilbert22OQ01OQ03
+
+open scoped ENNReal
+
+variable {X Y : Type*}
+
+-- ============================================================
+-- Part I: Cost of a single chain
+-- ============================================================
+
+/-- `chainCost c p mid q` is the total atomic cost of the chain whose vertex
+sequence is `p`, then the intermediate points `mid`, then `q`. The sum is
+accumulated from the front, so no list-head/last partial functions appear. -/
+noncomputable def chainCost (c : X → X → ℝ≥0∞) : X → List X → X → ℝ≥0∞
+  | p, [],      q => c p q
+  | p, x :: xs, q => c p x + chainCost c x xs q
+
+@[simp] theorem chainCost_nil (c : X → X → ℝ≥0∞) (p q : X) :
+    chainCost c p [] q = c p q := rfl
+
+@[simp] theorem chainCost_cons (c : X → X → ℝ≥0∞) (p x q : X) (xs : List X) :
+    chainCost c p (x :: xs) q = c p x + chainCost c x xs q := rfl
+
+/-- **Chain concatenation.** Splicing a chain `p ⇝ q` (intermediates `m₁`) to a
+chain `q ⇝ r` (intermediates `m₂`) at the shared vertex `q` adds their costs.
+This is the combinatorial heart of the triangle inequality. -/
+theorem chainCost_concat (c : X → X → ℝ≥0∞) (q r : X) (m₁ m₂ : List X) :
+    ∀ p, chainCost c p (m₁ ++ q :: m₂) r
+        = chainCost c p m₁ q + chainCost c q m₂ r := by
+  induction m₁ with
+  | nil => intro p; simp
+  | cons x xs ih => intro p; simp [ih, add_assoc]
+
+/-- **Chain reversal.** When the atomic cost is symmetric, reversing a chain
+preserves its total cost. This is the combinatorial heart of symmetry. -/
+theorem chainCost_reverse (c : X → X → ℝ≥0∞) (hc : ∀ a b, c a b = c b a) (q : X)
+    (mid : List X) : ∀ p, chainCost c p mid q = chainCost c q mid.reverse p := by
+  induction mid with
+  | nil => intro p; simp [hc p q]
+  | cons x xs ih =>
+      intro p
+      rw [chainCost_cons, ih x, List.reverse_cons, chainCost_concat]
+      simp [hc p x, add_comm]
+
+/-- **Functoriality at the chain level.** A map `f : X → Y` that contracts the
+atomic cost (`c_Y (f a) (f b) ≤ c_X a b`) contracts the cost of every chain after
+pushing the chain forward by `f`. -/
+theorem chainCost_map (cX : X → X → ℝ≥0∞) (cY : Y → Y → ℝ≥0∞) (f : X → Y)
+    (hf : ∀ a b, cY (f a) (f b) ≤ cX a b) (q : X) (mid : List X) :
+    ∀ p, chainCost cY (f p) (mid.map f) (f q) ≤ chainCost cX p mid q := by
+  induction mid with
+  | nil => intro p; simpa using hf p q
+  | cons x xs ih =>
+      intro p
+      simp only [List.map_cons, chainCost_cons]
+      exact add_le_add (hf p x) (ih x)
+
+-- ============================================================
+-- Part II: The chain pseudometric  d(p,q) = ⨅ chains, cost
+-- ============================================================
+
+/-- The **abstract Kobayashi chain pseudometric**: the infimum of the cost over
+all finite chains from `p` to `q`, indexed by the list of intermediate vertices.
+Valued in `ℝ≥0∞`, so the infimum is always well-defined and junk-free. -/
+noncomputable def chainDist (c : X → X → ℝ≥0∞) (p q : X) : ℝ≥0∞ :=
+  ⨅ mid : List X, chainCost c p mid q
+
+/-- `chainDist` is bounded above by the cost of any particular chain. -/
+theorem chainDist_le (c : X → X → ℝ≥0∞) (p q : X) (mid : List X) :
+    chainDist c p q ≤ chainCost c p mid q :=
+  iInf_le _ mid
+
+/-- **Reflexivity.** If the atomic cost vanishes on the diagonal, so does the
+chain pseudometric: the empty chain `p ⇝ p` already has cost `0`. -/
+theorem chainDist_self (c : X → X → ℝ≥0∞) (hself : ∀ a, c a a = 0) (p : X) :
+    chainDist c p p = 0 :=
+  le_antisymm (by simpa [hself p] using chainDist_le c p p []) (zero_le _)
+
+/-- **Symmetry.** A symmetric atomic cost yields a symmetric chain pseudometric:
+reverse every chain. -/
+theorem chainDist_comm (c : X → X → ℝ≥0∞) (hsymm : ∀ a b, c a b = c b a) (p q : X) :
+    chainDist c p q = chainDist c q p := by
+  have key : ∀ a b, chainDist c a b ≤ chainDist c b a := by
+    intro a b
+    refine le_iInf fun mid => ?_
+    rw [chainCost_reverse c hsymm a mid b]
+    exact chainDist_le c a b mid.reverse
+  exact le_antisymm (key p q) (key q p)
+
+/-- **Triangle inequality.** Concatenating chains at `q` realises a chain from
+`p` to `r`, so `chainDist` is subadditive. Uses the `ENNReal` infimum-arithmetic
+lemmas to push the two infima together. -/
+theorem chainDist_triangle (c : X → X → ℝ≥0∞) (p q r : X) :
+    chainDist c p r ≤ chainDist c p q + chainDist c q r := by
+  unfold chainDist
+  rw [ENNReal.iInf_add]
+  refine le_iInf fun m₁ => ?_
+  rw [ENNReal.add_iInf]
+  refine le_iInf fun m₂ => ?_
+  rw [← chainCost_concat]
+  exact iInf_le _ (m₁ ++ q :: m₂)
+
+-- ============================================================
+-- Part III: Packaging as a pseudo-extended-metric space
+-- ============================================================
+
+/-- The chain construction equips `X` with a genuine `PseudoEMetricSpace`,
+provided the atomic cost is symmetric and vanishes on the diagonal. This is the
+abstract Kobayashi pseudometric as a first-class Mathlib structure (properties
+(1)–(2) of the gallery entry). -/
+noncomputable def chainPseudoEMetricSpace (c : X → X → ℝ≥0∞)
+    (hsymm : ∀ a b, c a b = c b a) (hself : ∀ a, c a a = 0) :
+    PseudoEMetricSpace X where
+  edist := chainDist c
+  edist_self := chainDist_self c hself
+  edist_comm := chainDist_comm c hsymm
+  edist_triangle := chainDist_triangle c
+
+-- ============================================================
+-- Part IV: Functoriality — the defining invariance property
+-- ============================================================
+
+/-- **Functoriality / distance non-increase.** If `f : X → Y` contracts the
+atomic cost, then it is distance-non-increasing for the chain pseudometric:
+`d_Y (f p) (f q) ≤ d_X p q`. This is the order-theoretic shadow of the
+fundamental fact that holomorphic maps are non-expanding for the Kobayashi
+metric — the property that makes it a holomorphic invariant. -/
+theorem chainDist_mono (cX : X → X → ℝ≥0∞) (cY : Y → Y → ℝ≥0∞) (f : X → Y)
+    (hf : ∀ a b, cY (f a) (f b) ≤ cX a b) (p q : X) :
+    chainDist cY (f p) (f q) ≤ chainDist cX p q := by
+  refine le_iInf fun mid => ?_
+  calc chainDist cY (f p) (f q)
+      ≤ chainCost cY (f p) (mid.map f) (f q) := chainDist_le cY (f p) (f q) _
+    _ ≤ chainCost cX p mid q := chainCost_map cX cY f hf q mid p
+
+/-- A self-map version: an atomic-cost-contracting endomorphism is
+`chainDist`-non-increasing. -/
+theorem chainDist_mono_self (c : X → X → ℝ≥0∞) (f : X → X)
+    (hf : ∀ a b, c (f a) (f b) ≤ c a b) (p q : X) :
+    chainDist c (f p) (f q) ≤ chainDist c p q :=
+  chainDist_mono c c f hf p q
+
+end Hilbert22OQ01OQ03

--- a/research/problems/hilbert-22-oq-01-oq-03/knowledge.md
+++ b/research/problems/hilbert-22-oq-01-oq-03/knowledge.md
@@ -45,3 +45,29 @@ Build item 1 (standalone, fully tractable, no complex analysis) as the first ver
 
 ### Why no Lean this session
 Build environment was under sustained concurrent-agent cache churn (≈3000 oleans/min rewritten; Docker down). Each `lake env lean` compile cost ~30 min and frequently crashed on mmap'd-olean races (SIGBUS/SIGSEGV). Attempting a new nontrivial complex-analysis proof under these conditions risked an unverified/overclaimed result; deferred Lean to a calm window.
+
+---
+
+## Session 2026-06-25 (Session 2) — BUILT Item 1 (verified)
+
+**Mode**: continuation of Session-1 decomposition · **Outcome**: Item 1 delivered, machine-verified.
+
+### What I did
+- Implemented `proofs/Proofs/Hilbert22OQ01OQ03.lean` (204 lines): the abstract Kobayashi chain pseudometric skeleton (Item 1 of the Session-1 plan), exactly as scoped — pure ℝ≥0∞ order theory + list combinatorics, no complex analysis.
+- Verified with `lake env lean Proofs/Hilbert22OQ01OQ03.lean` → EXIT 0 (Docker still down; single-file `lake env lean` against the symlinked prebuilt Mathlib oleans is the safe route and worked despite ~96 concurrent lean procs).
+- Confirmed axiom profile with `#print axioms`: only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Genuinely `verified` / 0-axiom.
+- Authored the gallery entry (`src/data/proofs/hilbert-22-oq-01-oq-03/{meta.json,annotations.json}`).
+
+### Key implementation insights
+- **Chain encoding**: represent a chain p⇝q by its *intermediate* vertices `mid : List X`; sum cost from the front via `chainCost c p mid q` (`c p q` for `[]`, `c p x + chainCost c x xs q` for `x::xs`). This avoids `List.head!`/`getLast!` entirely, so **every lemma is free of nonemptiness side-conditions** — the single biggest simplification.
+- **Triangle = concatenation** (`chainCost_concat`, 2-case induction), **symmetry = reversal** (`chainCost_reverse`, uses concat with empty tail to peel the last edge), **reflexivity = empty chain**.
+- `chainCost` MUST be marked `noncomputable` (ENNReal `+`/CommSemiring has no executable code → IR compile error otherwise). Only fix needed after the first compile.
+- The two ENNReal lemmas that close the triangle inequality cleanly: `ENNReal.iInf_add : iInf f + a = ⨅ i, f i + a` and `ENNReal.add_iInf : a + iInf f = ⨅ b, a + f b` (both in `Mathlib/Data/ENNReal/Operations.lean`, namespace `ENNReal`).
+- **Functoriality** (`chainDist_mono`): a cost-contracting map is distance-non-increasing — the order-theoretic shadow of the Kobayashi non-expansion theorem; this is the exact interface where Schwarz–Pick would plug in.
+- `PseudoEMetricSpace` can be built from just `edist` + the 3 axioms (`toUniformSpace`/`uniformity_edist` have autoParam defaults).
+
+### Status of the decomposition
+- Item 1 (abstract pseudometric + functoriality): **DONE, verified.**
+- Item 2 (`d_ℂ ≡ 0`): tractable once a concrete disk atomic cost exists; not yet built.
+- Item 3 (two-point Schwarz–Pick via Blaschke conjugation): the natural next deliverable — supplies the concrete cost to instantiate `chainPseudoEMetricSpace`.
+- Item 4 (Picard, `d_𝔻 = ρ`): still BLOCKED on the modular λ universal cover (absent from Mathlib).

--- a/research/problems/hilbert-22-oq-01-oq-03/state.md
+++ b/research/problems/hilbert-22-oq-01-oq-03/state.md
@@ -1,25 +1,35 @@
 # Research State: hilbert-22-oq-01-oq-03
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: DELIVERED (partial)
 **Path**: full
 **Since**: 2026-06-25T08:41:59-07:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Item 1 of the Session-1 decomposition is DONE and machine-verified: the abstract
+Kobayashi chain pseudometric skeleton (`Proofs/Hilbert22OQ01OQ03.lean`, 204 lines,
+0 sorries, 0 axioms, only foundational propext/Classical.choice/Quot.sound).
 
 ## Active Approach
-None yet.
+Abstract the one-disk Poincaré distance to a symmetric atomic cost
+`c : X → X → ℝ≥0∞` with `c x x = 0`; define `chainDist c p q = ⨅ chains, cost`;
+prove the pseudometric axioms (reflexivity/symmetry/triangle) and functoriality
+(distance non-increase under cost-contracting maps) by list induction + ENNReal
+infimum arithmetic. Verified via `lake env lean` (EXIT 0) and `#print axioms`.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1 (succeeded)
+- Approaches tried: 1
 
 ## Blockers
-None.
+None for items 1–3 of the decomposition. Item 4 (Picard's little theorem and
+`d_𝔻 = ρ`) remains BLOCKED on the modular λ universal cover 𝔻 → ℂ∖{0,1}, which
+is absent from Mathlib 4.26.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Next session: Item 3 — two-point Schwarz–Pick contraction on 𝔻 by conjugating
+Mathlib's center-fixing Schwarz lemma with Blaschke automorphisms — which would
+supply the concrete atomic cost to instantiate `chainPseudoEMetricSpace`, then
+Item 2 (`d_ℂ ≡ 0`). Item 4 stays deferred until the modular cover lands.

--- a/src/data/proofs/hilbert-22-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/hilbert-22-oq-01-oq-03/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "hilbert-22-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "Module Preamble: The Kobayashi Pseudometric and Its Analysis-Free Skeleton",
+    "content": "The file opens with `import Mathlib` and a long docblock that states the Kobayashi pseudometric d_M(p,q) = inf over holomorphic chains of disks of the total Poincaré length, explains why its three defining structural properties are independent of complex analysis, and is explicit about which analytic ingredients (unit-disk Poincaré metric, Schwarz–Pick, d_𝔻 = ρ, Picard via the modular λ cover) are deliberately left open and unassumed. The namespace `Hilbert22OQ01OQ03` is opened with two universe-polymorphic variables `X Y`, and `open scoped ENNReal` brings in the ℝ≥0∞ notation. The design choice to work in ℝ≥0∞ is what makes every infimum junk-free.",
+    "mathContext": "$d_M(p,q)=\\inf\\left\\{\\sum_{i=1}^n \\rho(a_i,b_i)\\right\\}$ over holomorphic chains $\\mathbb{D}\\to M$ joining $p$ to $q$. This entry abstracts the one-disk distance $\\rho$ to a symmetric atomic cost $c:X\\to X\\to\\mathbb{R}_{\\ge 0}^\\infty$ with $c\\,x\\,x=0$ and isolates the order-theoretic content of properties (1)-(2) listed informally in the parent gallery entry hilbert-22-oq-01.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Kobayashi pseudometric",
+      "hyperbolic complex geometry",
+      "Poincaré metric on the disk",
+      "extended non-negative reals ℝ≥0∞"
+    ],
+    "prerequisites": [
+      "infimum in a complete lattice",
+      "pseudometric spaces",
+      "basic list operations (append, reverse, map)"
+    ]
+  },
+  {
+    "id": "ann-chain-cost",
+    "proofId": "hilbert-22-oq-01-oq-03",
+    "range": {
+      "startLine": 69,
+      "endLine": 118
+    },
+    "type": "definition",
+    "title": "Cost of a Single Chain and Its Combinatorial Laws",
+    "content": "`chainCost c p mid q` is the total atomic cost of the chain whose vertices are `p`, then the intermediate points `mid`, then `q`, summed from the front: `chainCost c p [] q = c p q` and `chainCost c p (x :: xs) q = c p x + chainCost c x xs q`. Accumulating from the front is the key design move — it never invokes `List.head!` or `List.getLast!`, so no lemma carries a nonemptiness hypothesis. Three workhorse lemmas follow. `chainCost_concat` proves that splicing a chain p ⇝ q to a chain q ⇝ r at the shared vertex q adds their costs (a two-case list induction). `chainCost_reverse` proves that reversing a chain preserves its cost when c is symmetric (induction using the concat law with an empty tail to peel off the final edge). `chainCost_map` proves that a map f contracting the atomic cost contracts every pushed-forward chain's cost (induction with `add_le_add`).",
+    "mathContext": "Concatenation: $\\texttt{chainCost}\\,p\\,(m_1 +\\!\\!+ q::m_2)\\,r = \\texttt{chainCost}\\,p\\,m_1\\,q + \\texttt{chainCost}\\,q\\,m_2\\,r$. Reversal (for $c$ symmetric): $\\texttt{chainCost}\\,p\\,\\mathit{mid}\\,q = \\texttt{chainCost}\\,q\\,\\mathit{mid}.\\mathrm{reverse}\\,p$. Map contraction (for $c_Y(f a,f b)\\le c_X(a,b)$): $\\texttt{chainCost}\\,c_Y\\,(f p)\\,(\\mathit{mid}.\\mathrm{map}\\,f)\\,(f q)\\le \\texttt{chainCost}\\,c_X\\,p\\,\\mathit{mid}\\,q$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "list recursion",
+      "telescoping cost",
+      "monotonicity of addition in ℝ≥0∞"
+    ],
+    "prerequisites": [
+      "structural induction on lists",
+      "List.append and List.reverse identities"
+    ]
+  },
+  {
+    "id": "ann-chain-dist",
+    "proofId": "hilbert-22-oq-01-oq-03",
+    "range": {
+      "startLine": 120,
+      "endLine": 163
+    },
+    "type": "theorem",
+    "title": "The Chain Pseudometric and Its Three Axioms",
+    "content": "`chainDist c p q = ⨅ mid : List X, chainCost c p mid q` is the abstract Kobayashi pseudometric. `chainDist_le` records that it is bounded above by the cost of any particular chain (an `iInf_le`). The three pseudometric axioms then fall out: `chainDist_self` (reflexivity) uses the empty chain, whose cost `c p p = 0`; `chainDist_comm` (symmetry) reverses every chain via `chainCost_reverse`, packaged through a single `key : ∀ a b, chainDist c a b ≤ chainDist c b a`; and `chainDist_triangle` (subadditivity) concatenates a p ⇝ q chain with a q ⇝ r chain, then pushes the two infima of the right-hand side together using the ENNReal arithmetic identities `ENNReal.iInf_add` and `ENNReal.add_iInf`.",
+    "mathContext": "$d(p,q)=\\bigsqcap_{\\mathit{mid}}\\texttt{chainCost}\\,c\\,p\\,\\mathit{mid}\\,q$. The triangle proof rewrites $\\bigl(\\bigsqcap_{m_1} f\\,m_1\\bigr) + \\bigl(\\bigsqcap_{m_2} g\\,m_2\\bigr) = \\bigsqcap_{m_1}\\bigsqcap_{m_2}\\bigl(f\\,m_1 + g\\,m_2\\bigr)$ and bounds each summand below by $d(p,r)$ via the concatenated chain $m_1 +\\!\\!+ q::m_2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "infimum over chains",
+      "triangle inequality via concatenation",
+      "ENNReal.iInf_add / ENNReal.add_iInf"
+    ],
+    "prerequisites": [
+      "iInf and le_iInf in complete lattices",
+      "infimum arithmetic in ℝ≥0∞"
+    ]
+  },
+  {
+    "id": "ann-pseudo-emetric",
+    "proofId": "hilbert-22-oq-01-oq-03",
+    "range": {
+      "startLine": 165,
+      "endLine": 179
+    },
+    "type": "theorem",
+    "title": "Packaging into a Genuine PseudoEMetricSpace",
+    "content": "`chainPseudoEMetricSpace` assembles the three proved axioms into Mathlib's `PseudoEMetricSpace` structure: from any symmetric atomic cost vanishing on the diagonal, `X` is equipped with `edist := chainDist c` together with `edist_self`, `edist_comm`, and `edist_triangle`. The uniformity and its compatibility are supplied automatically by the structure's default fields. This realises properties (1)–(2) of the Kobayashi pseudometric — the parts the parent entry stated only informally — as a first-class, instance-grade Mathlib object. The symmetry and diagonal-vanishing conditions remain explicit hypotheses, not structure-encoded assumptions, so the construction carries no hidden axioms.",
+    "mathContext": "Mathlib's \\texttt{PseudoEMetricSpace} bundles $\\texttt{edist\\_self}:\\;d(x,x)=0$, $\\texttt{edist\\_comm}:\\;d(x,y)=d(y,x)$, and $\\texttt{edist\\_triangle}:\\;d(x,z)\\le d(x,y)+d(y,z)$, deriving the induced uniform structure from $d$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "PseudoEMetricSpace",
+      "extended-distance structures",
+      "uniformity from a pseudometric"
+    ],
+    "prerequisites": [
+      "Mathlib's metric-space hierarchy",
+      "structure construction with default fields"
+    ]
+  },
+  {
+    "id": "ann-functoriality",
+    "proofId": "hilbert-22-oq-01-oq-03",
+    "range": {
+      "startLine": 181,
+      "endLine": 204
+    },
+    "type": "theorem",
+    "title": "Functoriality: The Defining Holomorphic Invariance",
+    "content": "`chainDist_mono` proves that a map `f : X → Y` contracting the atomic cost (`cY (f a) (f b) ≤ cX a b`) is distance-non-increasing for the chain pseudometric: `chainDist cY (f p) (f q) ≤ chainDist cX p q`. The proof bounds `chainDist cY (f p) (f q)` by the cost of the pushed-forward chain (via `chainDist_le`) and then by the original chain's cost (via `chainCost_map`), for each chain `mid`. `chainDist_mono_self` is the endomorphism specialisation. This is the order-theoretic shadow of the theorem that makes the Kobayashi metric a holomorphic invariant: holomorphic maps contract the disk Poincaré metric (Schwarz–Pick), so plugging that in here recovers the classical non-expansion property.",
+    "mathContext": "If $f$ contracts atoms then $d_Y(f p, f q)\\le d_X(p,q)$. Classically, every holomorphic $f:M\\to N$ satisfies $d_N(f(p),f(q))\\le d_M(p,q)$ — the Kobayashi non-expansion theorem — and is the reason $d_M$ is an invariant of the complex structure; this lemma is exactly that statement at the level of the abstract atomic cost.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Kobayashi non-expansion theorem",
+      "Schwarz–Pick lemma",
+      "holomorphic invariance",
+      "functoriality of invariant metrics"
+    ],
+    "prerequisites": [
+      "monotonicity of infima",
+      "the chainCost_map contraction lemma"
+    ]
+  }
+]

--- a/src/data/proofs/hilbert-22-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01-oq-03/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "hilbert-22-oq-01-oq-03",
+  "title": "The Abstract Kobayashi Chain Pseudometric",
+  "slug": "hilbert-22-oq-01-oq-03",
+  "description": "Constructs and fully verifies the order-theoretic skeleton of the Kobayashi pseudometric in Lean 4: the infimum-over-chains distance d(p,q) = ⨅ chains Σ cost, proved to be a genuine PseudoEMetricSpace and functorial (distance-non-increasing) under cost-contracting maps.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert22OQ01OQ03.lean",
+    "tags": [
+      "complex-geometry",
+      "kobayashi-metric",
+      "hyperbolic-manifolds",
+      "pseudometric",
+      "hilbert-problems",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 204,
+    "assumptions": "0 axioms, 0 sorries. Depends only on Mathlib's foundational axioms (propext, Classical.choice, Quot.sound) — confirmed via #print axioms; no sorryAx, no Lean.ofReduceBool, no native_decide. The atomic-cost symmetry and diagonal-vanishing hypotheses are explicit arguments to the theorems, not structure-encoded assumptions.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "chainCost: front-accumulated cost of a chain p, mid…, q with no list-head/last partial functions, eliminating nonemptiness side-conditions throughout",
+      "chainCost_concat: chain splicing at a shared vertex is additive — the combinatorial heart of the triangle inequality",
+      "chainCost_reverse: chain reversal preserves cost for symmetric atomic costs — the combinatorial heart of symmetry",
+      "chainDist: the abstract Kobayashi chain pseudometric d(p,q) = ⨅ over finite chains of total cost, valued in ℝ≥0∞ (junk-free infima)",
+      "chainPseudoEMetricSpace: packages d into a genuine Mathlib PseudoEMetricSpace from a symmetric, diagonal-vanishing atomic cost",
+      "chainDist_mono: functoriality — a cost-contracting map is distance-non-increasing, the order-theoretic shadow of 'holomorphic maps are non-expanding for the Kobayashi metric'"
+    ],
+    "theoremCount": 11,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Shoshichi Kobayashi introduced his invariant pseudodistance in 1967 (\"Invariant distances on complex manifolds and holomorphic mappings\"). The Kobayashi pseudometric d_M(p,q) on a complex manifold M is the infimum, over all finite chains of holomorphic disks 𝔻 → M joining p to q, of the total Poincaré length of the chain. It is the central object of hyperbolic complex geometry: a manifold is Kobayashi hyperbolic exactly when d_M is a genuine metric, and the metric is a holomorphic invariant precisely because holomorphic maps are distance-non-increasing for it. The parent gallery entry hilbert-22-oq-01 defined IsKobayashiHyperbolic via Brody's criterion but stated the pseudometric's own properties (1)–(8) only informally. A Mathlib survey (recorded in the problem's knowledge base) confirmed Mathlib has the center-fixing Schwarz lemma, the upper-half-plane hyperbolic metric, and Nevanlinna theory, but lacks the unit-disk Poincaré/pseudohyperbolic metric, Schwarz–Pick, the Kobayashi pseudometric itself, and the modular λ universal cover needed for Picard. This entry isolates and machine-verifies the part of the construction that is genuinely independent of complex analysis — the order-theoretic and combinatorial skeleton — leaving the analytic ingredients open and honestly unassumed.",
+    "problemStatement": "Formally construct the Kobayashi pseudometric d_M(p,q) = inf over holomorphic chains of total Poincaré length, and prove its defining structural properties: that it is a pseudometric (reflexivity, symmetry, triangle inequality) and that holomorphic maps are distance-non-increasing (functoriality / holomorphic invariance).",
+    "proofStrategy": "Abstract away the only inputs the structural properties actually use: an arbitrary type X with a symmetric atomic cost c : X → X → ℝ≥0∞ vanishing on the diagonal (the abstract stand-in for the one-disk Poincaré distance ρ). A chain p ⇝ q is encoded by its list of intermediate vertices; chainCost sums c from the front, so no List.head!/getLast! ever appears and every lemma is free of nonemptiness side-conditions. Two combinatorial lemmas carry the analysis-free content: chainCost_concat (splicing chains at a shared vertex adds their costs) and chainCost_reverse (reversing a chain preserves cost when c is symmetric). The pseudometric d(p,q) = ⨅ mid, chainCost is then shown reflexive (empty chain has cost 0), symmetric (reverse every chain), and subadditive (concatenate chains, then push the two infima together with ENNReal.iInf_add / ENNReal.add_iInf). These package into a genuine PseudoEMetricSpace. Finally chainCost_map and chainDist_mono establish functoriality: a map contracting the atomic cost contracts the chain pseudometric — the order-theoretic shadow of the Kobayashi non-expansion theorem. Working in ℝ≥0∞ makes every infimum well-defined and junk-free.",
+    "keyInsights": [
+      "The three pseudometric axioms of the Kobayashi distance are purely order-theoretic and combinatorial: they need only that the atomic cost is symmetric and vanishes on the diagonal — no complex analysis, no manifold structure, no holomorphy.",
+      "Encoding a chain by its intermediate vertices and summing from the front (chainCost) removes all List.head!/getLast! partiality, so concatenation becomes List.append with a shared joining vertex and reversal becomes List.reverse — each axiom is then a one-screen induction.",
+      "The triangle inequality is exactly chain concatenation; symmetry is exactly chain reversal; reflexivity is exactly the empty chain. The geometry is faithfully reflected in list operations.",
+      "Valuing the infimum in ℝ≥0∞ is essential: the complete-lattice structure gives junk-free infima (an empty chain-set yields ⊤, never a spurious 0) and the dedicated lemmas ENNReal.iInf_add / ENNReal.add_iInf push the two infima of d(p,q)+d(q,r) together cleanly.",
+      "Functoriality — the property that makes the Kobayashi metric a holomorphic invariant — is captured abstractly by chainDist_mono: any map contracting the atomic cost is distance-non-increasing. Holomorphic maps contract the disk Poincaré metric (Schwarz–Pick), so this is the exact place the analysis would plug in.",
+      "The construction is honest about its boundary: it assumes nothing about the disk Poincaré metric, Schwarz–Pick, d_𝔻 = ρ, or Picard's theorem — all of which require infrastructure absent from Mathlib 4.26 — and verifies only what follows from the abstract atomic cost."
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Import, Docblock, and Namespace",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Imports Mathlib; an extensive docblock explains the Kobayashi pseudometric, why its structural skeleton is analysis-free, and exactly which analytic ingredients are left open and unassumed; opens the Hilbert22OQ01OQ03 namespace with variables X, Y.",
+      "mathContext": "The Kobayashi pseudometric is $d_M(p,q)=\\inf\\sum_i \\rho(a_i,b_i)$ over holomorphic chains $\\mathbb{D}\\to M$ joining $p$ to $q$, with $\\rho$ the Poincaré metric on the disk. This entry abstracts $\\rho$ to a symmetric atomic cost $c:X\\to X\\to\\mathbb{R}_{\\ge 0}^\\infty$ with $c\\,x\\,x=0$, isolating the order-theoretic content of properties (1)-(2) from the gallery's informal list."
+    },
+    {
+      "id": "chain-cost",
+      "title": "Cost of a Single Chain",
+      "startLine": 69,
+      "endLine": 118,
+      "summary": "Defines chainCost (front-accumulated cost of p, mid…, q) with definitional simp lemmas, then proves the three combinatorial workhorses: chainCost_concat (splicing at a shared vertex is additive), chainCost_reverse (reversal preserves cost for symmetric c), and chainCost_map (a cost-contracting map contracts every chain's cost).",
+      "mathContext": "\\texttt{chainCost}\\;c\\;p\\;[]\\;q = c\\,p\\,q$ and $\\texttt{chainCost}\\;c\\;p\\;(x::xs)\\;q = c\\,p\\,x + \\texttt{chainCost}\\;c\\;x\\;xs\\;q$. The concatenation law $\\texttt{chainCost}\\;p\\;(m_1 \\mathbin{+\\!\\!+} q::m_2)\\;r = \\texttt{chainCost}\\;p\\;m_1\\;q + \\texttt{chainCost}\\;q\\;m_2\\;r$ and the reversal law $\\texttt{chainCost}\\;p\\;\\mathit{mid}\\;q = \\texttt{chainCost}\\;q\\;\\mathit{mid}.\\mathrm{reverse}\\;p$ (for symmetric $c$) are the combinatorial hearts of the triangle inequality and symmetry."
+    },
+    {
+      "id": "chain-dist",
+      "title": "The Chain Pseudometric and Its Axioms",
+      "startLine": 120,
+      "endLine": 163,
+      "summary": "Defines chainDist c p q = ⨅ mid, chainCost c p mid q and proves chainDist_le (bounded by any chain), chainDist_self (reflexivity via the empty chain), chainDist_comm (symmetry via reversal), and chainDist_triangle (subadditivity via concatenation plus ENNReal.iInf_add / ENNReal.add_iInf).",
+      "mathContext": "$d(p,q)=\\bigsqcap_{\\mathit{mid}}\\texttt{chainCost}\\;c\\;p\\;\\mathit{mid}\\;q$ in $\\mathbb{R}_{\\ge 0}^\\infty$. Reflexivity: the empty chain gives $d(p,p)\\le c\\,p\\,p=0$. Symmetry: $d(p,q)=d(q,p)$ by reversing chains. Triangle: $d(p,r)\\le d(p,q)+d(q,r)$ because concatenating a $p\\rightsquigarrow q$ chain with a $q\\rightsquigarrow r$ chain yields a $p\\rightsquigarrow r$ chain whose cost is the sum; the two infima are merged with the ENNReal infimum-addition identities."
+    },
+    {
+      "id": "pseudo-emetric",
+      "title": "Packaging as a PseudoEMetricSpace",
+      "startLine": 165,
+      "endLine": 179,
+      "summary": "Bundles the three axioms into chainPseudoEMetricSpace: from any symmetric, diagonal-vanishing atomic cost, X carries a genuine Mathlib PseudoEMetricSpace whose edist is chainDist — the abstract Kobayashi pseudometric as a first-class structure.",
+      "mathContext": "The Mathlib class \\texttt{PseudoEMetricSpace} requires \\texttt{edist\\_self}, \\texttt{edist\\_comm}, \\texttt{edist\\_triangle} (with the uniformity derived automatically). Supplying \\texttt{chainDist}\\;c$ and the three proved axioms realises properties (1)-(2) of the Kobayashi pseudometric as an instance-grade structure."
+    },
+    {
+      "id": "functoriality",
+      "title": "Functoriality — The Defining Invariance",
+      "startLine": 181,
+      "endLine": 204,
+      "summary": "Proves chainDist_mono: a map f with cY (f a) (f b) ≤ cX a b is distance-non-increasing, d_Y(f p, f q) ≤ d_X(p, q), with chainDist_mono_self the endomorphism case. This is the order-theoretic shadow of the holomorphic non-expansion theorem that makes the Kobayashi metric an invariant.",
+      "mathContext": "If $f:X\\to Y$ contracts the atomic cost ($c_Y(f a,f b)\\le c_X(a,b)$), then pushing any chain forward by $f$ contracts its cost (\\texttt{chainCost\\_map}), so $d_Y(f p, f q)\\le d_X(p,q)$. Holomorphic maps contract the disk Poincaré metric by Schwarz-Pick, so this abstract lemma is exactly where the analytic input would enter to recover the classical Kobayashi non-expansion."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry constructs the abstract Kobayashi chain pseudometric d(p,q) = ⨅ over finite chains of total atomic cost, valued in ℝ≥0∞, and fully machine-verifies its defining structural properties: it is a genuine PseudoEMetricSpace (reflexivity, symmetry, triangle inequality) and it is functorial — distance-non-increasing under any map contracting the atomic cost. These are exactly properties (1)–(2) of the Kobayashi pseudometric that the parent hilbert-22-oq-01 entry described only informally. The proof is entirely order-theoretic and combinatorial, depends only on Mathlib's foundational axioms (no sorries, no extra axioms, no native_decide), and isolates precisely where complex analysis would enter.",
+    "implications": "The skeleton is reusable: instantiating the atomic cost c with the unit-disk Poincaré/pseudohyperbolic distance would yield the genuine Kobayashi pseudometric, and chainDist_mono would then specialise — via Schwarz–Pick — to the classical theorem that holomorphic maps are non-expanding, the source of the metric's holomorphic invariance. The functoriality lemma marks the exact interface for that analytic input. Building chainDist over ℝ≥0∞ also makes it immediately compatible with Mathlib's PseudoEMetricSpace API.",
+    "openQuestions": [
+      "Formalize the unit-disk Poincaré / pseudohyperbolic metric and the two-point Schwarz–Pick contraction in Mathlib, then instantiate chainPseudoEMetricSpace to obtain the genuine Kobayashi pseudometric d_𝔻 and prove d_𝔻 = ρ.",
+      "Prove that ℂ is not Kobayashi hyperbolic (d_ℂ ≡ 0) by exhibiting affine maps z ↦ p + (q−p)z/δ from the disk realising arbitrarily small chain cost — a tractable next step once the disk metric exists.",
+      "Picard's little theorem (an entire map omitting two values is constant) via the modular λ universal cover 𝔻 → ℂ∖{0,1}, currently blocked by the absence of that cover from Mathlib."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-22-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent: defines IsKobayashiHyperbolic via Brody's criterion and lists the Kobayashi pseudometric's properties (1)–(8) informally. This entry machine-verifies the order-theoretic skeleton behind properties (1)–(2)."
+    },
+    {
+      "targetId": "hilbert-22",
+      "relationship": "related",
+      "description": "The uniformization theorem supplies the Poincaré metric on the unit disk — the analytic atomic cost ρ that this abstract construction is built to receive."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Hilbert22OQ01OQ03",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/Hilbert22OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Builds **Item 1** of this problem's Session-1 decomposition: the order-theoretic
**skeleton of the Kobayashi pseudometric**, fully machine-verified, with **no
complex-analysis dependencies**.

The Kobayashi pseudometric is `d_M(p,q) = inf` over holomorphic chains of disks
`𝔻 → M` of the total Poincaré length. Its three defining structural properties
do not actually use complex analysis — only that the per-disk distance is a
symmetric cost vanishing on the diagonal. This PR isolates and proves exactly
that part.

Over an arbitrary type `X` with a symmetric atomic cost `c : X → X → ℝ≥0∞` with
`c x x = 0` (the abstract stand-in for the one-disk Poincaré distance ρ), it
defines `chainDist c p q = ⨅ over finite chains p ⇝ q of total cost` and proves:

| Result | Statement |
|---|---|
| `chainDist_self` | `d(p,p) = 0` (empty chain) |
| `chainDist_comm` | `d(p,q) = d(q,p)` (chain reversal) |
| `chainDist_triangle` | `d(p,r) ≤ d(p,q) + d(q,r)` (chain concatenation) |
| `chainPseudoEMetricSpace` | packages the above into a genuine `PseudoEMetricSpace` |
| `chainDist_mono` | functoriality: a cost-contracting map is distance-non-increasing |

`chainDist_mono` is the order-theoretic shadow of the theorem that makes the
Kobayashi metric a holomorphic invariant (holomorphic maps are non-expanding);
it marks the exact interface where Schwarz–Pick would later plug in.

These are precisely properties (1)–(2) of the Kobayashi pseudometric that the
parent entry `hilbert-22-oq-01` described only informally.

## Verification

- **204 lines, 0 sorries, 0 `axiom` declarations.**
- `#print axioms` on the headline results lists only `propext`,
  `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`, no
  `native_decide`**. Status: `verified`.
- Compiled with `lake env lean Proofs/Hilbert22OQ01OQ03.lean` → **EXIT 0**
  (Docker build wrapper currently down; single-file `lake env lean` against the
  prebuilt Mathlib oleans was used, as in recent auditor sessions).

## Scope / honesty

The genuinely analytic ingredients — the unit-disk Poincaré/pseudohyperbolic
metric, the two-point Schwarz–Pick contraction, the identification `d_𝔻 = ρ`,
and Picard's theorem via the modular λ universal cover `𝔻 → ℂ∖{0,1}` — are
**absent from Mathlib 4.26** and are deliberately **left open and unassumed**.
This PR claims only the abstract skeleton. Next steps (Item 3: Schwarz–Pick via
Blaschke conjugation → concrete atomic cost; Item 2: `d_ℂ ≡ 0`) are recorded in
`research/problems/hilbert-22-oq-01-oq-03/`.

## Files

- `proofs/Proofs/Hilbert22OQ01OQ03.lean` (new), registered in `proofs/Proofs.lean`
- `src/data/proofs/hilbert-22-oq-01-oq-03/{meta.json,annotations.json}` (gallery entry)
- `research/problems/hilbert-22-oq-01-oq-03/{state.md,knowledge.md}` (session log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)