### PR TITLE
research(buffons-needle-oq-01-oq-01-oq-01-oq-02): additivity of expected crossings over concatenation [UNVERIFIED]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -548,6 +548,7 @@ import Proofs.BuffonsNeedle
 import Proofs.BuffonsNeedleOQ01
 import Proofs.BuffonsNeedleOQ01OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ01
+import Proofs.BuffonsNeedleOQ01OQ01OQ01OQ02
 import Proofs.BuffonsNeedleOQ01OQ01OQ04
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01Beta

--- a/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,140 @@
+import Mathlib
+
+/-
+# Buffon's Needle / Noodle — Additivity of Expected Crossings over Concatenation
+  (OQ-01-OQ-01-OQ-01-OQ-02)
+
+## Lineage
+
+This is an open-question descendant of `BuffonsNeedleOQ01OQ01OQ01.lean`
+("Axiom-Free Smooth Noodle via Concrete Integration"), which proves the
+Buffon–Barbier formula for an arbitrary C¹ curve γ : ℝ → ℝ × ℝ on [a, b]:
+
+  concreteSmoothExpectedCrossings γ a b d = 2 · arcLength(γ) / (π · d),
+
+where the *concrete* expected-crossing functional is the double integral
+
+  concreteSmoothExpectedCrossings γ a b d
+    = (1/(π·d)) · ∫_a^b ∫_0^π |γ'ₓ(t)·sin θ + γ'_y(t)·cos θ| dθ dt.
+
+The parent development established the *value* of this functional. What it
+never recorded is the structural property that makes Barbier's argument work
+in the first place: the functional is **additive over concatenation of the
+parameter interval**. A noodle traversed from a to b, split at an interior
+point c, has expected crossings equal to the sum of the expected crossings of
+its two halves. Iterating, a curve partitioned into n pieces has expected
+crossings equal to the sum over the pieces.
+
+This is the formal "a noodle is a sum of needles" decomposition: combined with
+the parent's shape-independence result it gives an independent route to
+Barbier's constant 2/(π·d).
+
+## What is proved here (self-contained, Mathlib-only)
+
+We reproduce the *concrete* functional definition verbatim (so this file is
+faithful to the parent without importing it — keeping the file Mathlib-only),
+then prove, with **0 axioms and 0 sorries**:
+
+* `expectedCrossings_self`     : empty parameter interval ⇒ 0 crossings.
+* `expectedCrossings_additive` : additivity across one interior split point.
+* `expectedCrossings_additive_of_continuous`
+                               : the same, with the integrability side
+                                 conditions discharged for curves with a
+                                 continuous angular integrand.
+* `expectedCrossings_additive3`: additivity across two interior split points.
+* `expectedCrossings_partition`: additivity over an arbitrary n-piece partition
+                                 `pts m, pts (m+1), …, pts n` of the parameter
+                                 interval (the general "noodle = Σ needles").
+
+## Honest scope
+
+Mathematically these are direct consequences of additivity of the *outer*
+interval integral (`intervalIntegral.integral_add_adjacent_intervals` and
+`intervalIntegral.sum_integral_adjacent_intervals_Ico`); the inner angular
+integral and the constant 1/(π·d) are inert. The contribution is not a deep
+theorem — it is the missing *structural lemma* of the Buffon family, stated and
+proved for the exact functional the family uses, with the precise integrability
+hypotheses made explicit.
+
+Adapted from erdosproblems.com lineage (Apache 2.0 License).
+-/
+
+open Real intervalIntegral MeasureTheory
+
+namespace BuffonsNeedleConcatenation
+
+/-- The inner *angular* integrand at parameter `t`:
+    `∫_0^π |γ'ₓ(t)·sin θ + γ'_y(t)·cos θ| dθ`.
+
+    This is the per-point contribution to the expected number of crossings;
+    it depends only on the velocity `γ'(t)`. -/
+noncomputable def angularIntegrand (γ : ℝ → ℝ × ℝ) (t : ℝ) : ℝ :=
+  ∫ θ in (0 : ℝ)..π,
+    |(deriv (Prod.fst ∘ γ) t) * Real.sin θ + (deriv (Prod.snd ∘ γ) t) * Real.cos θ|
+
+/-- Expected number of crossings of a C¹ curve `γ` on the parameter interval
+    `[a, b]` with a unit grid of lines at spacing `d`.
+
+    This is **definitionally** `BuffonsNeedleOQ01OQ01.concreteSmoothExpectedCrossings`
+    (same double integral, same order), re-stated here so the file depends only
+    on Mathlib. -/
+noncomputable def expectedCrossings (γ : ℝ → ℝ × ℝ) (a b d : ℝ) : ℝ :=
+  (1 / (π * d)) * ∫ t in a..b, angularIntegrand γ t
+
+/-- A degenerate (empty) parameter interval contributes no crossings. -/
+@[simp]
+theorem expectedCrossings_self (γ : ℝ → ℝ × ℝ) (a d : ℝ) :
+    expectedCrossings γ a a d = 0 := by
+  simp only [expectedCrossings, integral_same, mul_zero]
+
+/-- **Additivity across one split point.** For an interior parameter value `c`,
+    the expected crossings over `[a, b]` equal those over `[a, c]` plus those
+    over `[c, b]`, provided the angular integrand is interval-integrable on each
+    piece. (No ordering of `a, c, b` is required — interval integrals handle
+    orientation.) -/
+theorem expectedCrossings_additive (γ : ℝ → ℝ × ℝ) (a c b d : ℝ)
+    (hac : IntervalIntegrable (angularIntegrand γ) volume a c)
+    (hcb : IntervalIntegrable (angularIntegrand γ) volume c b) :
+    expectedCrossings γ a b d
+      = expectedCrossings γ a c d + expectedCrossings γ c b d := by
+  simp only [expectedCrossings]
+  rw [← mul_add, integral_add_adjacent_intervals hac hcb]
+
+/-- Additivity across one split point, with the integrability hypotheses
+    discharged from continuity of the angular integrand (which holds, e.g., for
+    `C¹` curves with continuous velocity). -/
+theorem expectedCrossings_additive_of_continuous (γ : ℝ → ℝ × ℝ) (a c b d : ℝ)
+    (hcont : Continuous (angularIntegrand γ)) :
+    expectedCrossings γ a b d
+      = expectedCrossings γ a c d + expectedCrossings γ c b d :=
+  expectedCrossings_additive γ a c b d
+    (hcont.intervalIntegrable a c) (hcont.intervalIntegrable c b)
+
+/-- **Additivity across two split points** `c₁, c₂` (a three-piece noodle). -/
+theorem expectedCrossings_additive3 (γ : ℝ → ℝ × ℝ) (a c₁ c₂ b d : ℝ)
+    (h1 : IntervalIntegrable (angularIntegrand γ) volume a c₁)
+    (h2 : IntervalIntegrable (angularIntegrand γ) volume c₁ c₂)
+    (h3 : IntervalIntegrable (angularIntegrand γ) volume c₂ b) :
+    expectedCrossings γ a b d
+      = expectedCrossings γ a c₁ d + expectedCrossings γ c₁ c₂ d
+        + expectedCrossings γ c₂ b d := by
+  rw [expectedCrossings_additive γ a c₁ b d h1 (h2.trans h3),
+      expectedCrossings_additive γ c₁ c₂ b d h2 h3]
+  ring
+
+/-- **General partition additivity** ("noodle = Σ needles"). For a chain of
+    parameter points `pts m ≤ … ≤ pts n` (given as values of a sequence
+    `pts : ℕ → ℝ`), the expected crossings of the curve over the whole interval
+    `[pts m, pts n]` equal the sum of the expected crossings over the `n - m`
+    consecutive pieces, provided the angular integrand is interval-integrable on
+    each piece. -/
+theorem expectedCrossings_partition (γ : ℝ → ℝ × ℝ) (d : ℝ) (pts : ℕ → ℝ)
+    (m n : ℕ) (hmn : m ≤ n)
+    (hint : ∀ k ∈ Finset.Ico m n,
+      IntervalIntegrable (angularIntegrand γ) volume (pts k) (pts (k + 1))) :
+    expectedCrossings γ (pts m) (pts n) d
+      = ∑ k ∈ Finset.Ico m n, expectedCrossings γ (pts k) (pts (k + 1)) d := by
+  simp only [expectedCrossings]
+  rw [← sum_integral_adjacent_intervals_Ico hmn hint, Finset.mul_sum]
+
+end BuffonsNeedleConcatenation

--- a/research/problems/buffons-needle-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/buffons-needle-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -1,0 +1,58 @@
+# Knowledge Base: buffons-needle-oq-01-oq-01-oq-01-oq-02
+
+## Problem Understanding
+
+Seeker-minted descendant of the axiom-free smooth Buffon–Barbier theorem
+(`BuffonsNeedleOQ01OQ01OQ01`). No statement was supplied at mint time; the
+research target — additivity of the expected-crossing functional over
+concatenation of the parameter interval — was derived from the parent (see
+`problem.md`).
+
+## Progress Summary
+
+Authored `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01OQ02.lean`, a **self-contained
+(Mathlib-only)** file. It re-states the parent's concrete functional verbatim
+(`angularIntegrand`, `expectedCrossings`) and proves, with 0 axioms / 0 sorries:
+
+- `expectedCrossings_self`  — empty parameter interval ⇒ 0 crossings
+  (`integral_same`, `mul_zero`).
+- `expectedCrossings_additive` — one interior split point, via
+  `intervalIntegral.integral_add_adjacent_intervals` after factoring out
+  1/(π·d) with `mul_add`.
+- `expectedCrossings_additive_of_continuous` — discharges the integrability
+  side conditions from `Continuous (angularIntegrand γ)` via
+  `Continuous.intervalIntegrable`.
+- `expectedCrossings_additive3` — two interior split points; `IntervalIntegrable.trans`
+  to combine the right two pieces, then `ring`.
+- `expectedCrossings_partition` — arbitrary n-piece partition `pts m … pts n`,
+  via `intervalIntegral.sum_integral_adjacent_intervals_Ico` and `Finset.mul_sum`.
+
+## Insights
+
+- The contribution is structural, not deep: additivity lives entirely in the
+  *outer* `∫_a^b` integral; the inner angular integral and the 1/(π·d) factor
+  are inert. Stated honestly as the family's missing structural lemma.
+- Made self-contained so it depends only on Mathlib (the parent's functional is
+  reproduced by definition). This was deliberate: it avoids project-internal
+  imports, which matters for external verification when local build is down.
+- All five Mathlib lemmas used were checked against the local Mathlib 4.26.0
+  source (signatures + namespaces) before writing:
+  `intervalIntegral.integral_add_adjacent_intervals`,
+  `intervalIntegral.sum_integral_adjacent_intervals_Ico`,
+  `intervalIntegral.integral_same`, `Finset.mul_sum`,
+  `IntervalIntegrable.trans`, `Continuous.intervalIntegrable`.
+
+## Verification status
+
+**UNVERIFIED — build infrastructure down.** Docker build wrapper unavailable
+and the Aristotle proof service returned "Resource not found" this session, so
+the file was NOT machine-checked. Proofs were hand-verified against Mathlib
+source. Gallery `meta.json` is intentionally **deferred** until a clean build
+confirms it (do not present as `verified` until then). Next agent with working
+infra: run `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ01OQ01OQ01OQ02`,
+then author the gallery entry.
+
+## Dead Ends
+
+- Aristotle verification unavailable this session (service error).
+- Local `docker-build.sh` unavailable (Docker daemon down).

--- a/research/problems/buffons-needle-oq-01-oq-01-oq-01-oq-02/problem.md
+++ b/research/problems/buffons-needle-oq-01-oq-01-oq-01-oq-02/problem.md
@@ -1,0 +1,49 @@
+# Problem: Buffon's Noodle (OQ-01-OQ-01-OQ-01-OQ-02) — Additivity of Expected Crossings over Concatenation
+
+**Slug**: buffons-needle-oq-01-oq-01-oq-01-oq-02
+**Lean file**: `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01OQ02.lean`
+**Parent**: `buffons-needle-oq-01-oq-01-oq-01` (axiom-free smooth Buffon–Barbier)
+
+## Origin
+
+This slug was minted by the seeker as an open-question descendant of
+`BuffonsNeedleOQ01OQ01OQ01.lean` but shipped with no problem statement. The
+statement below is **derived** from the parent during this research session.
+
+## The Parent
+
+`BuffonsNeedleOQ01OQ01OQ01.lean` proves the Buffon–Barbier formula, axiom-free,
+for an arbitrary C¹ curve γ : ℝ → ℝ × ℝ on [a, b]:
+
+  concreteSmoothExpectedCrossings γ a b d = 2 · arcLength(γ) / (π · d),
+
+where the concrete expected-crossing functional is the double integral
+
+  concreteSmoothExpectedCrossings γ a b d
+    = (1/(π·d)) · ∫_a^b ∫_0^π |γ'ₓ(t)·sin θ + γ'_y(t)·cos θ| dθ dt.
+
+The parent fixes the *value* of the functional. It never records the
+structural property that drives Barbier's classical argument.
+
+## Derived Open Question
+
+Prove that the expected-crossing functional is **additive over concatenation of
+the parameter interval**:
+
+1. (split)     `E(γ, a, b, d) = E(γ, a, c, d) + E(γ, c, b, d)`
+2. (partition) `E(γ, pts m, pts n, d) = Σ_{k=m}^{n-1} E(γ, pts k, pts (k+1), d)`
+
+with the minimal integrability hypotheses on the angular integrand stated
+explicitly. This is the formal "a noodle is a sum of needles" decomposition;
+combined with the parent's shape-independence it gives a second route to
+Barbier's constant 2/(π·d).
+
+## Approach
+
+The inner angular integral and the constant 1/(π·d) are inert; additivity is a
+direct consequence of additivity of the *outer* interval integral. Key Mathlib:
+`intervalIntegral.integral_add_adjacent_intervals` (two pieces),
+`intervalIntegral.sum_integral_adjacent_intervals_Ico` (n pieces),
+`Finset.mul_sum`, `IntervalIntegrable.trans`, `Continuous.intervalIntegrable`.
+
+## Tractability: HIGH (structural lemma, routine once stated)

--- a/research/problems/buffons-needle-oq-01-oq-01-oq-01-oq-02/state.md
+++ b/research/problems/buffons-needle-oq-01-oq-01-oq-01-oq-02/state.md
@@ -1,0 +1,24 @@
+# Research State: buffons-needle-oq-01-oq-01-oq-01-oq-02
+
+## Current State
+**Phase**: IMPLEMENT (blocked on verification)
+**Path**: full
+**Iteration**: 1
+
+## Current Focus
+Authored self-contained additivity/partition lemmas for the expected-crossing
+functional. File complete (0 axioms / 0 sorries). Awaiting machine verification.
+
+## Active Approach
+Outer-integral additivity (`integral_add_adjacent_intervals` /
+`sum_integral_adjacent_intervals_Ico`); 1/(π·d) factored out via `mul_add` /
+`Finset.mul_sum`.
+
+## Blockers
+Build infrastructure down (Docker daemon unavailable; Aristotle service returned
+"Resource not found"). File NOT machine-checked this session.
+
+## Next Action
+Re-verify on a host with working `docker-build.sh`
+(`Proofs.BuffonsNeedleOQ01OQ01OQ01OQ02`). On success, author gallery `meta.json`
+and `annotations.json` and mark `status: verified`.


### PR DESCRIPTION
## Summary

Open-question descendant of `buffons-needle-oq-01-oq-01-oq-01` (the axiom-free smooth Buffon–Barbier theorem). The seeker minted this slug **with no problem statement**; the research target was derived from the parent this session.

The parent fixes the *value* of the expected-crossing functional
`E(γ,a,b,d) = (1/(π·d))·∫_a^b ∫_0^π |γ'·e_θ| dθ dt = 2·L/(π·d)`
but never records the **structural** property behind Barbier's argument: that `E` is **additive over concatenation of the parameter interval** — the formal *"a noodle is a sum of needles."* This PR fills that gap.

## New file — `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01OQ02.lean`

Self-contained (Mathlib-only; reproduces the parent functional by definition). **0 axioms / 0 sorries** as written:

| Theorem | Content |
|---|---|
| `expectedCrossings_self` | empty parameter interval ⇒ 0 crossings |
| `expectedCrossings_additive` | additivity across one interior split point |
| `expectedCrossings_additive_of_continuous` | same, integrability discharged from continuity |
| `expectedCrossings_additive3` | additivity across two split points |
| `expectedCrossings_partition` | arbitrary n-piece partition `pts m … pts n` |

## Honest scope

Not a deep theorem: additivity lives entirely in the *outer* interval integral (the inner angular integral and the `1/(π·d)` factor are inert). It is the family's **missing structural lemma**, stated for the exact functional the parent uses, with explicit integrability hypotheses. Mathlib used: `integral_add_adjacent_intervals`, `sum_integral_adjacent_intervals_Ico`, `Finset.mul_sum`, `IntervalIntegrable.trans`, `Continuous.intervalIntegrable` — all checked against local Mathlib 4.26.0 source.

## ⚠️ UNVERIFIED — build infrastructure down

Local Docker build wrapper unavailable **and** the Aristotle proof service returned `Resource not found` this session, so the file was **not machine-checked**. Proofs were hand-verified against Mathlib source. The gallery `meta.json`/`annotations.json` are **deliberately deferred** — this PR ships only the Lean file + research notes; it does **not** make a `verified` gallery claim. Re-verify with `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ01OQ01OQ01OQ02` before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)