### PR TITLE
research(erdos-308-oq-03): constructive harmonic bound f(N) ≤ ⌊H_N⌋+1

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1835,6 +1835,7 @@ import Proofs.Erdos306Problem
 import Proofs.Erdos307Aristotle
 import Proofs.Erdos307OQ02
 import Proofs.Erdos307Problem
+import Proofs.Erdos308OQ03
 import Proofs.Erdos308Problem
 import Proofs.Erdos309Aristotle
 import Proofs.Erdos309Problem

--- a/proofs/Proofs/Erdos308OQ03.lean
+++ b/proofs/Proofs/Erdos308OQ03.lean
@@ -1,0 +1,208 @@
+/-
+  Erdős Problem #308 — Open Question 03
+  A constructive finiteness argument for f(N) with an explicit harmonic bound
+
+  Parent: Erdos308Problem.lean (Erdős #308: smallest integer f(N) not representable
+  as a sum of distinct unit fractions with denominators in {1,…,N}).
+
+  Open Question (erdos-308-oq-03):
+  "Can the `sorry` in the existence proof of `f` (the finiteness argument that some
+   integer is not representable) be replaced by a constructive bound?"
+
+  Answer (this file): yes, and with an explicit *harmonic* bound. Every representable
+  integer k satisfies k ≤ H_N (the N-th harmonic number), because a sum of distinct
+  unit fractions with denominators in {1,…,N} is at most the sum of *all* of them.
+  Hence ⌊H_N⌋ + 1 is never representable, so the least non-representable integer
+  satisfies the explicit, fully constructive bound
+
+      f(N) ≤ ⌊H_N⌋ + 1.
+
+  This sharpens the bare existence witness `N + 1` used in the parent (any unit-fraction
+  sum is ≤ N, so N+1 is non-representable) to the much smaller ⌊H_N⌋ + 1, since
+  H_N ≤ N gives ⌊H_N⌋ + 1 ≤ N + 1.
+
+  This file is self-contained over Mathlib (it re-states the definitions with current
+  import paths; the parent file's `import Mathlib.Data.Rat.Basic` is stale on the
+  pinned Mathlib). Status: 0 axioms, 0 sorries — fully machine-checked.
+
+  References:
+  - Croot (1999): "On some questions of Erdős and Graham about Egyptian fractions"
+  - Erdős–Graham (1980), Problem #308
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Data.Rat.Floor
+import Mathlib.Data.Nat.Find
+
+open Finset BigOperators
+open Classical
+
+namespace Erdos308OQ03
+
+-- ============================================================
+-- Part I: Definitions (unit fractions, harmonic number, representability)
+-- ============================================================
+
+/-- Sum of unit fractions over a finite set of denominators: `∑_{n ∈ S} 1/n`. -/
+def sumUnitFracs (S : Finset ℕ) : ℚ := ∑ n ∈ S, (1 : ℚ) / n
+
+/-- The `N`-th harmonic number `H_N = ∑_{n=1}^{N} 1/n`, written over `range N`. -/
+def H (N : ℕ) : ℚ := ∑ n ∈ Finset.range N, (1 : ℚ) / (n + 1)
+
+/-- The shift embedding `n ↦ n + 1`, sending `range N = {0,…,N-1}` to `{1,…,N}`. -/
+def succEmb : ℕ ↪ ℕ := ⟨(· + 1), fun _ _ h => Nat.succ_injective h⟩
+
+/-- `k` is representable using denominators from `{1,…,N}`: there is a subset of
+    `range N` whose shifted denominators give unit fractions summing to `k`. -/
+def Representable (N k : ℕ) : Prop :=
+  ∃ S : Finset ℕ, S ⊆ Finset.range N ∧ sumUnitFracs (S.map succEmb) = k
+
+-- ============================================================
+-- Part II: Harmonic bounds
+-- ============================================================
+
+/-- The harmonic number is nonnegative. -/
+theorem H_nonneg (N : ℕ) : 0 ≤ H N := by
+  unfold H
+  apply Finset.sum_nonneg
+  intro i _
+  positivity
+
+/-- Crude bound: `H_N ≤ N` (each of the `N` terms is at most `1`). -/
+theorem H_le_N (N : ℕ) : H N ≤ (N : ℚ) := by
+  unfold H
+  calc ∑ n ∈ Finset.range N, (1 : ℚ) / (n + 1)
+      ≤ ∑ _n ∈ Finset.range N, (1 : ℚ) := by
+        apply Finset.sum_le_sum
+        intro i _
+        rw [div_le_one (by positivity)]
+        have : (0 : ℚ) ≤ i := by positivity
+        linarith
+    _ = (N : ℚ) := by rw [Finset.sum_const, Finset.card_range]; simp
+
+-- ============================================================
+-- Part III: Every representable integer is ≤ H_N
+-- ============================================================
+
+/-- **Key bound.** A sum of distinct unit fractions with denominators in `{1,…,N}`
+    is at most the sum of *all* of them, namely `H_N`. Hence any representable
+    integer `k` satisfies `(k : ℚ) ≤ H_N`. -/
+theorem representable_le_H {N k : ℕ} (h : Representable N k) : (k : ℚ) ≤ H N := by
+  obtain ⟨S, hSsub, hsum⟩ := h
+  rw [← hsum]
+  have hHmap : H N = ∑ n ∈ (Finset.range N).map succEmb, (1 : ℚ) / n := by
+    unfold H
+    rw [Finset.sum_map]
+    refine Finset.sum_congr rfl (fun x _ => ?_)
+    simp only [succEmb, Function.Embedding.coeFn_mk]
+    push_cast
+    ring
+  rw [hHmap]
+  unfold sumUnitFracs
+  apply Finset.sum_le_sum_of_subset_of_nonneg (Finset.map_subset_map.mpr hSsub)
+  intro i _ _
+  positivity
+
+/-- `⌊H_N⌋ + 1` is **not** representable: it exceeds every representable integer. -/
+theorem not_representable_floor_succ (N : ℕ) : ¬ Representable N (⌊H N⌋₊ + 1) := by
+  intro h
+  have h1 : ((⌊H N⌋₊ + 1 : ℕ) : ℚ) ≤ H N := representable_le_H h
+  have h2 : H N < (⌊H N⌋₊ : ℚ) + 1 := Nat.lt_floor_add_one (H N)
+  push_cast at h1
+  linarith
+
+/-- The parent's witness, re-derived: `N + 1` is not representable (the unit-fraction
+    sum is at most `H_N ≤ N`). -/
+theorem not_representable_succ (N : ℕ) : ¬ Representable N (N + 1) := by
+  intro h
+  have h1 : ((N + 1 : ℕ) : ℚ) ≤ H N := representable_le_H h
+  have h2 : H N ≤ (N : ℚ) := H_le_N N
+  have h3 : ((N + 1 : ℕ) : ℚ) ≤ (N : ℚ) := h1.trans h2
+  push_cast at h3
+  linarith
+
+-- ============================================================
+-- Part IV: The smallest non-representable integer f(N), constructively bounded
+-- ============================================================
+
+/-- The finiteness fact powering `f`: there exists a non-representable integer.
+    Constructive witness: `⌊H_N⌋ + 1`. -/
+theorem exists_not_representable (N : ℕ) : ∃ k, ¬ Representable N k :=
+  ⟨⌊H N⌋₊ + 1, not_representable_floor_succ N⟩
+
+/-- `f(N)` = the smallest integer not representable with denominators from `{1,…,N}`. -/
+noncomputable def f (N : ℕ) : ℕ := Nat.find (exists_not_representable N)
+
+/-- **The explicit constructive bound (answer to OQ-03):** `f(N) ≤ ⌊H_N⌋ + 1`. -/
+theorem f_le_floor_succ (N : ℕ) : f N ≤ ⌊H N⌋₊ + 1 := by
+  unfold f
+  exact Nat.find_le (not_representable_floor_succ N)
+
+/-- The coarser parent bound, recovered: `f(N) ≤ N + 1`. -/
+theorem f_le_succ (N : ℕ) : f N ≤ N + 1 := by
+  unfold f
+  exact Nat.find_le (not_representable_succ N)
+
+/-- The harmonic bound is at least as sharp as `N + 1`: `⌊H_N⌋ + 1 ≤ N + 1`. -/
+theorem floor_H_succ_le_succ (N : ℕ) : ⌊H N⌋₊ + 1 ≤ N + 1 := by
+  have : ⌊H N⌋₊ ≤ N := by
+    calc ⌊H N⌋₊ ≤ ⌊(N : ℚ)⌋₊ := Nat.floor_le_floor (H_le_N N)
+      _ = N := Nat.floor_natCast N
+  omega
+
+/-- Every integer below `f(N)` *is* representable — i.e. `f(N)` is genuinely the
+    least non-representable integer. -/
+theorem representable_of_lt_f {N k : ℕ} (h : k < f N) : Representable N k := by
+  unfold f at h
+  have := Nat.find_min (exists_not_representable N) h
+  exact not_not.mp this
+
+-- ============================================================
+-- Part V: Concrete positive cases
+-- ============================================================
+
+/-- `0` is always representable (empty sum). -/
+theorem representable_zero (N : ℕ) : Representable N 0 := by
+  refine ⟨∅, Finset.empty_subset _, ?_⟩
+  simp [sumUnitFracs]
+
+/-- `1` is representable for `N ≥ 1` (the single denominator `1`). -/
+theorem representable_one : Representable 1 1 := by
+  refine ⟨{0}, ?_, ?_⟩
+  · decide
+  · simp [sumUnitFracs, succEmb]
+
+/-- `H_1 = 1`, so the bound gives `f(1) ≤ 2`. -/
+theorem f_one_le_two : f 1 ≤ 2 := by
+  have hH : H 1 = 1 := by simp [H]
+  have := f_le_floor_succ 1
+  rw [hH] at this
+  simpa using this
+
+/-
+  Summary
+
+  Erdős #308 asks for f(N), the smallest integer not representable as a sum of
+  distinct unit fractions with denominators in {1,…,N}. OQ-03 asked whether the
+  finiteness argument behind f could be made constructive. This file answers yes,
+  with the explicit harmonic bound
+
+      f(N) ≤ ⌊H_N⌋ + 1                                  (f_le_floor_succ)
+
+  obtained from the elementary fact that every representable integer is ≤ H_N
+  (representable_le_H), since a sub-sum of the unit fractions {1/1, …, 1/N} cannot
+  exceed their total H_N. The witness ⌊H_N⌋ + 1 is sharper than the parent's N + 1
+  (floor_H_succ_le_succ: ⌊H_N⌋ + 1 ≤ N + 1, from H_N ≤ N).
+
+  We also record that f is the genuine minimum (representable_of_lt_f) and verify
+  concrete representable cases (representable_zero, representable_one), giving
+  f(1) ≤ 2.
+
+  13 theorems, 5 definitions, 0 axioms, 0 sorries — fully machine-checked.
+  (Croot's deep asymptotic bounds f(N) = ⌊H_N⌋ - Θ((log log N)²/log N) remain
+  axiomatized in the parent; this file provides the elementary, verified upper half.)
+-/
+
+end Erdos308OQ03

--- a/src/data/proofs/erdos-308-oq-03/annotations.json
+++ b/src/data/proofs/erdos-308-oq-03/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "oq03-header",
+    "proofId": "erdos-308-oq-03",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Making f(N) well-defined, constructively",
+    "content": "Erdős #308 defines f(N) as the smallest integer not representable as a sum of distinct unit fractions with denominators in {1,…,N}. For f(N) to be well-defined one needs *some* non-representable integer. OQ-03 asks for this finiteness fact to be constructive. The answer here is sharp: a sum of distinct unit fractions with denominators in {1,…,N} is at most their total H_N, so any integer above H_N is non-representable, giving f(N) ≤ ⌊H_N⌋ + 1. The file is self-contained because the parent's `import Mathlib.Data.Rat.Basic` no longer exists on the pinned Mathlib.",
+    "mathContext": "$f(N) \\le \\lfloor H_N\\rfloor + 1$, where $H_N = \\sum_{k=1}^N 1/k$.",
+    "significance": "context",
+    "relatedConcepts": ["Egyptian fractions", "harmonic number", "Nat.find", "constructive existence"]
+  },
+  {
+    "id": "representable-le-H",
+    "proofId": "erdos-308-oq-03",
+    "range": { "startLine": 92, "endLine": 107 },
+    "type": "technique",
+    "title": "Representability bounded by the harmonic number",
+    "content": "The crux. A representable k equals ∑_{n∈S} 1/(n+1) with S ⊆ range N. Rewriting H_N = ∑_{n∈range N} 1/(n+1) as a sum over the *mapped* denominator set (Finset.sum_map along n ↦ n+1), the representing denominators S.map succEmb are a subset of (range N).map succEmb. Since every reciprocal is nonnegative, Finset.sum_le_sum_of_subset_of_nonneg gives k ≤ H_N. One inequality does all the work.",
+    "mathContext": "$k = \\sum_{n\\in S}\\frac{1}{n+1} \\le \\sum_{n\\in\\mathrm{range}\\,N}\\frac{1}{n+1} = H_N.$",
+    "significance": "key-technique",
+    "relatedConcepts": ["sum_le_sum_of_subset_of_nonneg", "Finset.sum_map", "monotonicity of partial sums"]
+  },
+  {
+    "id": "floor-witness",
+    "proofId": "erdos-308-oq-03",
+    "range": { "startLine": 109, "endLine": 124 },
+    "type": "insight",
+    "title": "The floor converts the real bound into an integer witness",
+    "content": "Representable values are integers ≤ H_N, hence ≤ ⌊H_N⌋. The next integer ⌊H_N⌋ + 1 strictly exceeds H_N (Nat.lt_floor_add_one), so it cannot be representable — a clean, explicit non-representable witness. The same argument with the cruder H_N ≤ N reproduces the parent's N+1 witness.",
+    "mathContext": "$H_N < \\lfloor H_N\\rfloor + 1 \\implies \\lfloor H_N\\rfloor + 1 \\notin \\mathrm{Rep}(N).$",
+    "significance": "insight",
+    "relatedConcepts": ["Nat.floor", "Nat.lt_floor_add_one"]
+  },
+  {
+    "id": "f-bound",
+    "proofId": "erdos-308-oq-03",
+    "range": { "startLine": 132, "endLine": 160 },
+    "type": "insight",
+    "title": "From witness to bound, and minimality",
+    "content": "Defining f(N) = Nat.find (exists_not_representable N), the explicit bound f(N) ≤ ⌊H_N⌋ + 1 is immediate from Nat.find_le applied to the witness. floor_H_succ_le_succ shows ⌊H_N⌋ + 1 ≤ N + 1 (via H_N ≤ N), so the harmonic bound dominates the naive one. representable_of_lt_f uses Nat.find_min to certify that every integer below f(N) is representable, so f(N) really is the least non-representable integer.",
+    "mathContext": "$f(N) \\le \\lfloor H_N\\rfloor + 1 \\le N+1$, and $k < f(N) \\Rightarrow k \\in \\mathrm{Rep}(N).$",
+    "significance": "key-result",
+    "relatedConcepts": ["Nat.find_le", "Nat.find_min", "least element of a predicate"]
+  },
+  {
+    "id": "concrete",
+    "proofId": "erdos-308-oq-03",
+    "range": { "startLine": 162, "endLine": 208 },
+    "type": "context",
+    "title": "Concrete cases and the elementary half of Croot",
+    "content": "representable_zero (empty sum) and representable_one (denominator 1) confirm the definition is satisfiable; with H_1 = 1 they give f(1) ≤ 2. The summary notes that f(N) ≤ ⌊H_N⌋ + 1 is exactly the easy upper half of Croot's f(N) = ⌊H_N⌋ - Θ((log log N)²/log N); the deep second-order terms remain axiomatized in the parent.",
+    "mathContext": "$f(1) \\le 2$ from $H_1 = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Croot's theorem", "second-order asymptotics", "concrete verification"]
+  }
+]

--- a/src/data/proofs/erdos-308-oq-03/index.ts
+++ b/src/data/proofs/erdos-308-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos308OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos308Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos308Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos308Oq03Data: ProofData = {
+  proof: erdos308Oq03Proof,
+  annotations: erdos308Oq03Annotations,
+}

--- a/src/data/proofs/erdos-308-oq-03/meta.json
+++ b/src/data/proofs/erdos-308-oq-03/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "erdos-308-oq-03",
+  "title": "Erdős #308 OQ-03: A Constructive Harmonic Bound for f(N)",
+  "slug": "erdos-308-oq-03",
+  "description": "Answers the parent Erdős #308 entry's third open question: replace the existence argument behind f(N) (the smallest integer not representable as a sum of distinct unit fractions with denominators in {1,…,N}) with a constructive bound. Proves that every representable integer is ≤ H_N (the N-th harmonic number), hence ⌊H_N⌋ + 1 is never representable, giving the explicit constructive bound f(N) ≤ ⌊H_N⌋ + 1 — sharper than the parent's N+1 witness since H_N ≤ N. Self-contained over Mathlib with corrected imports (the parent's Mathlib.Data.Rat.Basic import is stale). 13 theorems, 5 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://erdosproblems.com/308",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos308OQ03.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "unit-fractions",
+      "egyptian-fractions",
+      "harmonic",
+      "constructive"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib's foundational axioms. `#print axioms` on the headline results (`f_le_floor_succ`, `representable_le_H`, `representable_of_lt_f`) reports only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`, no literal `axiom` declarations, 0 sorries. Fully machine-checked. Self-contained over Mathlib (Finset, BigOperators, Rat.Floor, Nat.Find); does not import the parent file, whose `import Mathlib.Data.Rat.Basic` is stale on the pinned Mathlib. `open Classical` supplies the `DecidablePred` instance used by `Nat.find` in the definition of `f`. Croot's deep asymptotic bounds remain axiomatized in the parent — this file provides only the elementary, verified upper half.",
+    "lineCount": 208,
+    "theoremCount": 13,
+    "definitionCount": 5,
+    "originalContributions": [
+      "representable_le_H: every representable integer k satisfies (k : ℚ) ≤ H_N, because a sub-sum of the unit fractions {1/1,…,1/N} cannot exceed their total H_N (Finset.sum_le_sum_of_subset_of_nonneg after rewriting H_N as a sum over the shifted index set)",
+      "not_representable_floor_succ: ⌊H_N⌋ + 1 is not representable (it exceeds every representable integer, via Nat.lt_floor_add_one)",
+      "f_le_floor_succ: the explicit constructive bound f(N) ≤ ⌊H_N⌋ + 1, answering OQ-03",
+      "floor_H_succ_le_succ: ⌊H_N⌋ + 1 ≤ N + 1, showing the harmonic bound is sharper than the parent's N+1 witness (H_N ≤ N)",
+      "representable_of_lt_f: every integer below f(N) is representable, so f(N) is genuinely the least non-representable integer (Nat.find_min); concrete positive cases representable_zero, representable_one ⇒ f(1) ≤ 2"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #308 (Erdős–Graham 1980) asks about the structure of the integers representable as sums of distinct unit fractions $1/n$ with denominators $n \\in \\{1,\\dots,N\\}$. Writing $f(N)$ for the smallest non-representable integer, Croot (1999) determined $f(N)$ up to second-order terms: $f(N) = \\lfloor H_N\\rfloor - \\Theta\\big((\\log\\log N)^2/\\log N\\big)$, where $H_N = \\sum_{k=1}^N 1/k$ is the harmonic number. Croot also resolved the companion question that the representable set is contiguous (an initial segment $\\{0,1,\\dots,m\\}$) for large $N$.\n\nThe parent gallery entry formalizes the statement and axiomatizes Croot's deep asymptotic bounds. Its third open question (OQ-03) isolates a much more elementary loose end: the *existence* of a non-representable integer — the fact that makes $f(N)$ well-defined via `Nat.find` — should be given by a constructive bound rather than an opaque existence proof. This entry supplies that bound, and a sharp one: the harmonic number itself.",
+    "problemStatement": "Give a constructive, fully verified proof that some integer is not representable with denominators in $\\{1,\\dots,N\\}$, together with an explicit upper bound on the smallest such integer $f(N)$. Concretely, prove $f(N) \\le \\lfloor H_N\\rfloor + 1$.",
+    "proofStrategy": "The engine is a single monotonicity inequality. A representable integer $k$ equals $\\sum_{n \\in S} 1/(n+1)$ for some $S \\subseteq \\{0,\\dots,N-1\\}$, i.e. a sub-sum of the unit fractions with denominators in $\\{1,\\dots,N\\}$. Rewriting $H_N = \\sum_{n=0}^{N-1} 1/(n+1)$ as a sum over the shifted index set $\\{1,\\dots,N\\}$ (`Finset.sum_map` along the embedding $n \\mapsto n+1$), the representing set's denominators form a *subset*, so by `Finset.sum_le_sum_of_subset_of_nonneg` (all terms nonnegative) we get $k \\le H_N$ (`representable_le_H`).\n\nConsequently any integer exceeding $H_N$ is non-representable. In particular $\\lfloor H_N\\rfloor + 1 > H_N$ (`Nat.lt_floor_add_one`), so $\\lfloor H_N\\rfloor + 1$ is non-representable (`not_representable_floor_succ`). Feeding this witness to `Nat.find_le` bounds the minimum: $f(N) \\le \\lfloor H_N\\rfloor + 1$ (`f_le_floor_succ`). The coarse bound $H_N \\le N$ then yields $\\lfloor H_N\\rfloor + 1 \\le N + 1$, recovering and sharpening the parent's witness.",
+    "keyInsights": [
+      "**Representability is bounded by the harmonic number.** The entire finiteness argument rests on the trivial-but-decisive observation that a sum of *some* of the unit fractions $1/1,\\dots,1/N$ is at most their total $H_N$. This converts an existence question into an explicit inequality.",
+      "**The floor turns the real bound into an integer witness.** Since representable values are integers $\\le H_N$, they are $\\le \\lfloor H_N\\rfloor$; the very next integer $\\lfloor H_N\\rfloor + 1$ is forced to be non-representable. `Nat.lt_floor_add_one` makes this a one-line consequence.",
+      "**`Nat.find` packages the minimum, `Nat.find_le` reads the bound.** Defining $f(N)$ as `Nat.find` of the (now constructive) existence proof, the explicit bound is immediate from `Nat.find_le` applied to the witness $\\lfloor H_N\\rfloor + 1$, and `Nat.find_min` shows everything below $f(N)$ is representable.",
+      "**The harmonic bound dominates the naive one.** The parent's witness $N+1$ comes from the weaker estimate (sum $\\le |S| \\le N$). Because $H_N \\le N$, the harmonic witness $\\lfloor H_N\\rfloor + 1$ is always at least as good — and asymptotically far better, since $H_N \\sim \\ln N \\ll N$."
+    ],
+    "prerequisites": [
+      "Finset.sum_le_sum_of_subset_of_nonneg: monotonicity of sums of nonnegative terms under subset inclusion",
+      "Finset.sum_map and Finset.map_subset_map: transporting sums and subsets along the embedding n ↦ n+1",
+      "Nat.lt_floor_add_one and Nat.floor_le_floor / Nat.floor_natCast: floor arithmetic over ℚ",
+      "Nat.find, Nat.find_le, Nat.find_min: the least element of a decidable predicate and its bounds",
+      "open Classical for the DecidablePred instance backing Nat.find on the representability predicate"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-header",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Docstring framing OQ-03 (make the finiteness argument behind f(N) constructive) and the harmonic-bound answer f(N) ≤ ⌊H_N⌋ + 1. Imports Finset, ordered BigOperators, Rat.Floor, and Nat.Find with current Mathlib paths (the parent's Mathlib.Data.Rat.Basic is stale); opens Classical for Nat.find's decidability instance.",
+      "mathContext": "Self-contained restatement: the file does not import the parent, so it is unaffected by the parent's broken import and carries none of its axioms."
+    },
+    {
+      "id": "definitions",
+      "title": "Part I — Definitions",
+      "startLine": 44,
+      "endLine": 60,
+      "summary": "sumUnitFracs S = ∑_{n∈S} 1/n; the harmonic number H N = ∑_{n∈range N} 1/(n+1); the shift embedding succEmb : n ↦ n+1; and Representable N k = ∃ S ⊆ range N, sumUnitFracs (S.map succEmb) = k.",
+      "mathContext": "succEmb sends range N = {0,…,N-1} bijectively onto the denominator set {1,…,N}, so a representation of k is a choice of distinct denominators in {1,…,N} whose reciprocals sum to k."
+    },
+    {
+      "id": "harmonic-bounds",
+      "title": "Part II — Harmonic Bounds",
+      "startLine": 62,
+      "endLine": 84,
+      "summary": "H_nonneg: 0 ≤ H_N. H_le_N: H_N ≤ N, since each of the N terms 1/(n+1) is at most 1.",
+      "mathContext": "H_N ≤ N is the crude bound underlying the parent's N+1 witness; the file later shows the harmonic witness is sharper."
+    },
+    {
+      "id": "representable-le-H",
+      "title": "Part III — Every Representable Integer is ≤ H_N",
+      "startLine": 85,
+      "endLine": 125,
+      "summary": "representable_le_H: (k:ℚ) ≤ H_N for representable k, by rewriting H_N as a sum over the mapped index set and applying Finset.sum_le_sum_of_subset_of_nonneg. not_representable_floor_succ: ⌊H_N⌋+1 is non-representable (Nat.lt_floor_add_one). not_representable_succ: N+1 is non-representable (via H_N ≤ N).",
+      "mathContext": "k = ∑_{n∈S} 1/(n+1) ≤ ∑_{n∈range N} 1/(n+1) = H_N because the representing denominators form a subset of {1,…,N} and all reciprocals are nonnegative."
+    },
+    {
+      "id": "f-bound",
+      "title": "Part IV — f(N) and Its Constructive Bound",
+      "startLine": 126,
+      "endLine": 160,
+      "summary": "exists_not_representable: constructive witness ⌊H_N⌋+1. f N = Nat.find (…). f_le_floor_succ: f(N) ≤ ⌊H_N⌋+1 (the OQ-03 answer). f_le_succ: f(N) ≤ N+1. floor_H_succ_le_succ: ⌊H_N⌋+1 ≤ N+1. representable_of_lt_f: every integer below f(N) is representable.",
+      "mathContext": "Nat.find_le turns the explicit non-representable witness into an upper bound on the minimum; Nat.find_min certifies f(N) is the least non-representable integer."
+    },
+    {
+      "id": "concrete-cases",
+      "title": "Part V — Concrete Positive Cases",
+      "startLine": 162,
+      "endLine": 208,
+      "summary": "representable_zero: 0 is representable (empty sum). representable_one: 1 is representable for N=1 (denominator 1). f_one_le_two: since H_1 = 1, the bound gives f(1) ≤ 2.",
+      "mathContext": "These witnesses confirm the definition is satisfiable and instantiate the general bound at N=1."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #308 OQ-03 asked for a constructive replacement of the existence argument behind f(N). This entry proves the explicit harmonic bound f(N) ≤ ⌊H_N⌋ + 1, derived from the elementary fact representable_le_H that every representable integer is ≤ H_N (a sub-sum of {1/1,…,1/N} cannot exceed their total). The witness ⌊H_N⌋ + 1 is sharper than the parent's N+1 (floor_H_succ_le_succ). The file also shows f(N) is the genuine minimum and verifies concrete representable cases. 13 theorems, 5 definitions, 0 axioms, 0 sorries — fully machine-checked, self-contained over Mathlib.",
+    "implications": "The contribution is the verified elementary upper half of Croot's theorem: f(N) ≤ ⌊H_N⌋ + 1 is exactly the easy direction of f(N) = ⌊H_N⌋ - Θ((log log N)²/log N). It also fixes a practical gap — the parent file's stale Mathlib import — by re-deriving the development self-containedly, so the constructive bound stands independently of the axiomatized asymptotics.",
+    "openQuestions": [
+      "Prove the matching lower bound's elementary part: exhibit explicit representations showing every integer up to some f₀(N) (e.g. ⌊H_N⌋ - O(1) in concrete ranges) IS representable, narrowing the gap between ⌊H_N⌋ and f(N) without invoking Croot's asymptotics.",
+      "Formalize H_N ≥ log N (e.g. via integral comparison or the dyadic 1+1/2+(1/3+1/4)+… ≥ 1 + k/2 bound) to turn f(N) ≤ ⌊H_N⌋ + 1 into an explicit growth statement f(N) = O(log N) is false / f(N) ≳ log N companion.",
+      "Decide Representable N k for fixed small N,k (a finite search over subsets of range N) to compute exact values of f(N) for small N and confirm tightness of the ⌊H_N⌋ + 1 bound.",
+      "Repair and re-import the parent Erdos308Problem.lean (replace Mathlib.Data.Rat.Basic with Mathlib.Data.Rat.Defs) so this OQ-03 development can reference the parent's f directly instead of restating it."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Erdos308OQ03",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos308OQ03.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset",
+      "Mathlib.Data.Rat.Floor",
+      "Mathlib.Data.Nat.Find"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-308",
+      "relationship": "extends",
+      "description": "Parent entry (Erdős #308, Croot 1999). This file answers its third open question with a constructive harmonic bound f(N) ≤ ⌊H_N⌋ + 1 and re-derives the development self-containedly (the parent's Mathlib.Data.Rat.Basic import is stale)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the Erdős #308 entry (`erdos-308`): replace the existence argument behind **f(N)** — the smallest integer not representable as a sum of distinct unit fractions with denominators in $\{1,\dots,N\}$ — with a *constructive* bound.

## Result

$$f(N) \le \lfloor H_N\rfloor + 1, \qquad H_N = \sum_{k=1}^{N}\tfrac1k.$$

**Key lemma** (`representable_le_H`): every representable integer is $\le H_N$, because a sum of *some* of the unit fractions $\{1/1,\dots,1/N\}$ cannot exceed their total. Rewriting $H_N$ as a sum over the shifted denominator set and applying `Finset.sum_le_sum_of_subset_of_nonneg` does it in one inequality. Hence $\lfloor H_N\rfloor + 1 > H_N$ is non-representable (`not_representable_floor_succ`, via `Nat.lt_floor_add_one`), and `Nat.find_le` gives the bound (`f_le_floor_succ`).

The harmonic witness is **sharper** than the parent's $N+1$: `floor_H_succ_le_succ` proves $\lfloor H_N\rfloor + 1 \le N+1$ from $H_N \le N$. We also show $f$ is the genuine minimum (`representable_of_lt_f` via `Nat.find_min`) and verify concrete cases (`representable_zero`, `representable_one` ⇒ `f(1) ≤ 2`).

This is exactly the **elementary upper half** of Croot's theorem $f(N) = \lfloor H_N\rfloor - \Theta((\log\log N)^2/\log N)$; the deep second-order terms remain axiomatized in the parent.

## Note on the parent

`Erdos308Problem.lean` currently has a **stale import** (`import Mathlib.Data.Rat.Basic`, removed from the pinned Mathlib) and does not compile. This OQ-03 file is therefore **self-contained**: it re-states the definitions with correct imports (`Mathlib.Data.Rat.Floor` etc.) and does not depend on the parent. (A follow-up to repair the parent's import is listed in `openQuestions`.)

## Verification

- **Compiles `EXIT 0`** (local `lake env lean` against Mathlib oleans).
- `#print axioms` on `f_le_floor_succ`, `representable_le_H`, `representable_of_lt_f` reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`**.
- **13 theorems, 5 definitions, 0 axioms, 0 sorries.** `status=verified`, `badge=original`.

Includes the gallery entry (`meta.json`, `annotations.json`, `index.ts`) and `Proofs.lean` registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)