### PR TITLE
research(erdos-4): rehabilitate file — fix 3 parse errors + prove improved_stronger [verified]

### DIFF
--- a/proofs/Proofs/Erdos4Problem.lean
+++ b/proofs/Proofs/Erdos4Problem.lean
@@ -81,7 +81,7 @@ def erdos_4_conjecture : Prop :=
 
 /- ## Historical Results -/
 
-/--
+/-
 **Rankin's Theorem** (1938):
 There exists C > 0 such that for infinitely many n,
   p_{n+1} - p_n > C · erdosFunction(n).
@@ -103,7 +103,7 @@ This proves Erdős Problem 4 in the affirmative.
 -/
 axiom maynard_theorem : erdos_4_conjecture
 
-/--
+/-
 **Ford-Green-Konyagin-Tao Theorem** (2016):
 Independent proof of the same result as Maynard.
 -/
@@ -125,7 +125,7 @@ noncomputable def improvedErdosFunction (n : ℕ) : ℝ :=
 
 /- ## Upper Bounds -/
 
-/--
+/-
 **Baker-Harman-Pintz Theorem** (2001):
 For all sufficiently large n,
   p_{n+1} - p_n ≤ n^{0.525}.
@@ -162,9 +162,57 @@ noncomputable def cramer_granville_constant : ℝ := 2 * Real.exp (-0.5772156649
 /-- The improved bound is stronger (larger). -/
 theorem improved_stronger (n : ℕ) (hn : n ≥ 100) :
     erdosFunction n ≤ improvedErdosFunction n := by
-  unfold erdosFunction improvedErdosFunction
-  -- The improved has lg3 n in denominator vs (lg3 n)^2
-  sorry -- Technical inequality
+  -- Write both bounds in terms of nested `Real.log`s.
+  simp only [erdosFunction, improvedErdosFunction, lg, lg2, lg3, lg4]
+  -- Numeric anchor: for n ≥ 100 we have log n > 3 (> e), hence the iterated
+  -- logs are well-behaved: log(log n) > 1 and log(log(log n)) > 0.
+  have hn' : (100 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have he3 : Real.exp 3 < 100 := by
+    have he : Real.exp 1 < 2.7182818286 := Real.exp_one_lt_d9
+    have h3 : Real.exp 3 = Real.exp 1 ^ 3 := by
+      rw [← Real.exp_nat_mul]; norm_num
+    have hb : Real.exp 1 ^ 3 ≤ (2.7182818286 : ℝ) ^ 3 := by gcongr
+    have hc100 : (2.7182818286 : ℝ) ^ 3 < 100 := by norm_num
+    rw [h3]; linarith
+  have hc3 : (3 : ℝ) < Real.log (n : ℝ) := by
+    have h100 : (3 : ℝ) < Real.log (100 : ℝ) := by
+      have := Real.log_lt_log (Real.exp_pos 3) he3
+      rwa [Real.log_exp] at this
+    have hmono : Real.log (100 : ℝ) ≤ Real.log (n : ℝ) :=
+      Real.log_le_log (by norm_num) hn'
+    linarith
+  have hc : (0 : ℝ) < Real.log (n : ℝ) := by linarith
+  have ha : (1 : ℝ) < Real.log (Real.log (n : ℝ)) := by
+    have hexp1n : Real.exp 1 < Real.log (n : ℝ) := by
+      have := Real.exp_one_lt_d9; linarith
+    have := Real.log_lt_log (Real.exp_pos 1) hexp1n
+    rwa [Real.log_exp] at this
+  have hr : (0 : ℝ) < Real.log (Real.log (Real.log (n : ℝ))) := Real.log_pos ha
+  -- Abbreviate the four iterated logarithms.
+  set L1 := Real.log (n : ℝ) with hL1def
+  set L2 := Real.log L1 with hL2def
+  set L3 := Real.log L2 with hL3def
+  set L4 := Real.log L3 with hL4def
+  have hL1pos : 0 < L1 := hc
+  have hL2pos : 0 < L2 := by linarith
+  have hL3pos : 0 < L3 := hr
+  -- Core sign fact: L4 · (1 - L3) ≤ 0, since log L3 and (L3 - 1) share a sign.
+  have key : L4 * (1 - L3) ≤ 0 := by
+    rw [hL4def]
+    rcases le_total L3 1 with h | h
+    · have hlog : Real.log L3 ≤ 0 := Real.log_nonpos hL3pos.le h
+      nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - L3)
+        (by linarith : (0 : ℝ) ≤ -Real.log L3)]
+    · have hlog : 0 ≤ Real.log L3 := Real.log_nonneg h
+      nlinarith [mul_nonneg hlog (by linarith : (0 : ℝ) ≤ L3 - 1)]
+  -- The two bounds differ only by a factor 1/L3 vs 1/L3², so the claim reduces
+  -- to (L2·L1·L3) · (-(L4·(1-L3))) ≥ 0.
+  have hL3sq : (0 : ℝ) < L3 ^ 2 := by positivity
+  rw [div_mul_eq_mul_div, div_mul_eq_mul_div, div_le_div_iff₀ hL3sq hL3pos]
+  have hfac : 0 ≤ (L2 * L1 * L3) * (-(L4 * (1 - L3))) :=
+    mul_nonneg (mul_nonneg (mul_nonneg hL2pos.le hL1pos.le) hL3pos.le)
+      (neg_nonneg.mpr key)
+  nlinarith [hfac]
 
 /- ## Related Conjectures -/
 

--- a/src/data/proofs/erdos-4/meta.json
+++ b/src/data/proofs/erdos-4/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-4",
   "title": "Erdős Problem #4: Large Prime Gaps",
   "slug": "erdos-4",
-  "description": "Erdős Problem #4: For any $C > 0$, are there infinitely many $n$ with $p_{n+1} - p_n > C \\cdot \\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n / (\\log\\log\\log n)^2$? SOLVED (YES) by Maynard (2016) and Ford-Green-Konyagin-Tao (2016) independently, with the combined FGKMT (2018) establishing the stronger result. This 219-line formalization axiomatizes Maynard's (2016) resolution as a single axiom (`maynard_theorem`); the Rankin/FGKT/FGKMT/BHP results are documented in the module narrative. It defines `primeGap` and `erdosFunction` with iterated logarithms, and states the conjecture's resolution. 1 sorry remains. Erdős's $10,000 prize for gaps exceeding $(\\log n)^{1+c}$ remains open.",
+  "description": "Erdős Problem #4: For any $C > 0$, are there infinitely many $n$ with $p_{n+1} - p_n > C \\cdot \\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n / (\\log\\log\\log n)^2$? SOLVED (YES) by Maynard (2016) and Ford-Green-Konyagin-Tao (2016) independently, with the combined FGKMT (2018) establishing the stronger result. This 267-line formalization axiomatizes Maynard's (2016) resolution as a single axiom (`maynard_theorem`); the Rankin/FGKT/FGKMT/BHP results are documented in the module narrative. It defines `primeGap` and `erdosFunction` with iterated logarithms, and states the conjecture's resolution. The file is now sorry-free: the `improved_stronger` comparison lemma is fully proved for $n \\geq 100$. Erdős's $10,000 prize for gaps exceeding $(\\log n)^{1+c}$ remains open.",
   "meta": {
     "author": "Ford-Green-Konyagin-Maynard-Tao",
     "erdosNumber": 4,
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosUrl": "https://erdosproblems.com/4",
     "sourceUrl": "https://erdosproblems.com/4",
     "erdosProblemStatus": "solved",
@@ -73,7 +73,7 @@
       "Probabilistic methods in combinatorics and number theory",
       "Filter-based asymptotics in Lean (Filter.atTop, Filter.Tendsto)"
     ],
-    "lineCount": 219,
+    "lineCount": 267,
     "relatedProblems": [
       {
         "id": "erdos-1",
@@ -179,7 +179,7 @@
     {
       "id": "comparison",
       "title": "Comparison of Bounds",
-      "summary": "**erdos_function_growth**: $f(n) < (\\log n)^{1+\\varepsilon}$ eventually. **improved_stronger**: the FGKMT function dominates the original (sorry for technical inequality).",
+      "summary": "**erdos_function_growth**: $f(n) < (\\log n)^{1+\\varepsilon}$ eventually. **improved_stronger**: the FGKMT function dominates the original, $f(n) \\leq f'(n)$ for $n \\geq 100$ — fully proved by case-splitting on whether $\\log\\log\\log n \\lessgtr 1$.",
       "mathContext": "$f(n) < (\\log n)^{1+\\varepsilon}$ eventually for any $\\varepsilon > 0$. The FGKMT improved function $f'(n)$ satisfies $f'(n) / f(n) \\to \\infty$.",
       "startLine": 180,
       "endLine": 192
@@ -204,15 +204,15 @@
   "overview": {
     "historicalContext": "Erdős Problem #4 is one of the most celebrated problems in prime number theory, rooted in a question that goes back to Euclid: how are the primes distributed among the integers? The Prime Number Theorem (Hadamard, de la Vallée Poussin, 1896) gives the average gap between consecutive primes near $n$ as $\\sim \\log n$, but individual gaps can be much larger — and quantifying *how much* larger is a central problem in analytic number theory.\n\nThe first systematic study of large prime gaps was by Backlund (1929), who showed gaps exceeding $2\\log n$ exist infinitely often. Westzynthius (1931) improved this to $\\omega(\\log n)$ using the Brun sieve, and Erdős (1935) achieved $c \\cdot \\log n \\cdot \\log\\log n / (\\log\\log\\log n)^2$ using covering congruences — already revealing the iterated-log structure that characterizes the problem.\n\nRobert Rankin (1938) made the decisive advance, proving infinitely many gaps exceed $C \\cdot (\\log n)(\\log\\log n)(\\log\\log\\log\\log n)/(\\log\\log\\log n)^2$ for $C = e^\\gamma/3 \\approx 0.593$, where $\\gamma$ is the Euler-Mascheroni constant. His method — constructing large prime-free intervals via optimized sieve parameters and the Chinese Remainder Theorem — established the template for all subsequent work. Remarkably, Rankin's constant $e^\\gamma/3$ was not improved for over 75 years, despite incremental progress by Maier-Pomerance (1990) and Pintz (1997) on the lower-order terms. Erdős famously offered a $\\$10{,}000$ prize (his largest for any prime gap problem) for proving that gaps exceed $(\\log n)^{1+c}$ for some $c > 0$ — a question that remains open today.\n\nThe breakthrough came in 2014-2016 with two independent solutions. James Maynard adapted his revolutionary multidimensional sieve method — the same technique that proved bounded gaps between primes ($\\liminf g_n \\leq 246$) — to show the constant $C$ could be made arbitrarily large, resolving the problem for ALL $C > 0$. Simultaneously, Kevin Ford, Ben Green, Sergei Konyagin, and Terence Tao achieved the same result using an entirely different approach based on probabilistic number theory and hypergraph covering lemmas from additive combinatorics. In 2018, all five authors combined their techniques for a stronger bound, replacing the $(\\log\\log\\log n)^2$ denominator with $\\log\\log\\log n$.\n\nThe problem sits at the intersection of two complementary strands: the study of small gaps (Zhang 2013, Maynard-Polymath 2014: $\\liminf g_n \\leq 246$) and large gaps (Erdős #4: $\\limsup g_n / f(n) = \\infty$). Together they reveal that prime gaps are simultaneously infinitely small and infinitely large relative to their expected size. Cramér's conjecture ($\\sim (\\log p_n)^2$) and Granville's refinement ($\\sim 2e^{-\\gamma}(\\log p_n)^2$) predict the true maximum gap size, but proving any bound stronger than the current iterated-log results seems far beyond present methods.",
     "problemStatement": "Is it true that for any $C > 0$, there are infinitely many $n$ such that $p_{n+1} - p_n > C \\cdot \\frac{\\log\\log n \\cdot \\log\\log\\log\\log n}{(\\log\\log\\log n)^2} \\cdot \\log n$?",
-    "text": "A 219-line formalization of one of Erdős's most celebrated problems on prime gaps. The problem asks whether for any constant $C > 0$, there exist infinitely many consecutive primes $p_n, p_{n+1}$ with gap exceeding $C$ times Rankin's function $R(n) = \\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n / (\\log\\log\\log n)^2$. Posed by Erdős in the 1930s, it stood for 75 years — with Rankin (1938) establishing the first lower bound on large gaps using sieve methods, then Maier-Pomerance (1990) and Pintz (1997) making incremental progress — until simultaneous solutions by Maynard (2016) and Ford-Green-Konyagin-Tao (2016), with their combined FGKMT (2018) paper establishing the strongest result. The formalization defines `nthPrime` via `Nat.nth Nat.Prime`, `primeGap n = nthPrime (n+1) - nthPrime n`, and `erdosFunction`/`rankinFunction` with iterated real logarithms. A single axiom (`maynard_theorem`) captures Maynard's 2016 resolution; the Rankin/FGKT/FGKMT/BHP results are documented in the module narrative, with 1 sorry remaining on a log-comparison lemma. Erdős offered \\$10,000 — his largest prize — for proving gaps exceed $(\\log n)^{1+c}$; this remains open and is the most tantalizing prize in prime number theory.",
-    "proofStrategy": "The formalization defines the $n$-th prime via `Nat.nth`, iterated logarithms, and the Erdős function. The conjecture is stated as a universally quantified proposition over $C > 0$. Maynard's theorem ($\\forall C$) is axiomatized as the single axiom `maynard_theorem`; Rankin's theorem ($\\exists C$) and the FGKT theorem (independent $\\forall C$) are documented in the module narrative. The FGKMT improved bound, Baker-Harman-Pintz upper bound, Cramér's conjecture, and Firoozbakht's conjecture provide context. One sorry remains in the comparison theorem `improved_stronger`.",
+    "text": "A 267-line formalization of one of Erdős's most celebrated problems on prime gaps. The problem asks whether for any constant $C > 0$, there exist infinitely many consecutive primes $p_n, p_{n+1}$ with gap exceeding $C$ times Rankin's function $R(n) = \\log n \\cdot \\log\\log n \\cdot \\log\\log\\log\\log n / (\\log\\log\\log n)^2$. Posed by Erdős in the 1930s, it stood for 75 years — with Rankin (1938) establishing the first lower bound on large gaps using sieve methods, then Maier-Pomerance (1990) and Pintz (1997) making incremental progress — until simultaneous solutions by Maynard (2016) and Ford-Green-Konyagin-Tao (2016), with their combined FGKMT (2018) paper establishing the strongest result. The formalization defines `nthPrime` via `Nat.nth Nat.Prime`, `primeGap n = nthPrime (n+1) - nthPrime n`, and `erdosFunction`/`rankinFunction` with iterated real logarithms. A single axiom (`maynard_theorem`) captures Maynard's 2016 resolution; the Rankin/FGKT/FGKMT/BHP results are documented in the module narrative, and the file is sorry-free, with the log-comparison lemma `improved_stronger` fully proved. Erdős offered \\$10,000 — his largest prize — for proving gaps exceed $(\\log n)^{1+c}$; this remains open and is the most tantalizing prize in prime number theory.",
+    "proofStrategy": "The formalization defines the $n$-th prime via `Nat.nth`, iterated logarithms, and the Erdős function. The conjecture is stated as a universally quantified proposition over $C > 0$. Maynard's theorem ($\\forall C$) is axiomatized as the single axiom `maynard_theorem`; Rankin's theorem ($\\exists C$) and the FGKT theorem (independent $\\forall C$) are documented in the module narrative. The FGKMT improved bound, Baker-Harman-Pintz upper bound, Cramér's conjecture, and Firoozbakht's conjecture provide context. The comparison theorem `improved_stronger` is fully proved: for $n \\geq 100$ one anchors $\\log n > 3 > e$ (so $\\log\\log n > 1$, $\\log\\log\\log n > 0$), then case-splits on $\\log\\log\\log n \\lessgtr 1$. The shared sign of $\\log(\\log\\log\\log n)$ and $(\\log\\log\\log n - 1)$ forces $\\text{lg4}\\cdot(1-\\text{lg3}) \\leq 0$, which yields the inequality after clearing the $1/\\text{lg3}^2$ vs $1/\\text{lg3}$ denominators.",
     "keyInsights": [
       "**75 years stuck**: Rankin's constant $C = e^\\gamma/3$ from 1938 was not improved until 2016 — the longest-standing result in prime gap theory",
       "**Two independent proofs**: Maynard (multidimensional sieve) and FGKT (probabilistic + additive combinatorics) solved it simultaneously, suggesting the problem was 'ripe'",
       "**Sieve revolution**: Maynard's approach uses the same multidimensional sieve that proved bounded gaps ($\\liminf g_n \\leq 246$), applied in reverse to prove unbounded gaps",
       "**Upper-lower gap**: Current bounds span from $\\omega(\\log n \\cdot \\log\\log n / \\log\\log\\log n)$ (lower) to $O(n^{0.525})$ (upper) — an enormous range reflecting our ignorance about prime distribution",
       "**$10,000 still open**: Erdős's stronger conjecture ($g_n > (\\log n)^{1+c}$) remains unresolved and would require fundamentally new ideas beyond current sieve methods",
-      "**Potential bound error**: The `improved_stronger` theorem (the file's only sorry) claims $f(n) \\leq f'(n)$ for $n \\geq 100$, but $\\log\\log\\log 100 \\approx 0.83 < 1$, so the inequality may fail at the stated threshold — the correct bound is $n \\geq e^{e^e} \\approx 3{,}814{,}279$. This is a candidate for correction and Aristotle proof search"
+      "**Sign-flip rescues the threshold**: The `improved_stronger` theorem claims $f(n) \\leq f'(n)$ for $n \\geq 100$. A naive reading worries that $\\log\\log\\log 100 \\approx 0.83 < 1$ should break it (since $1/\\text{lg3}^2 > 1/\\text{lg3}$ there). But in that regime $\\text{lg4} = \\log(\\log\\log\\log n) < 0$, so the numerator $\\text{lg2}\\cdot\\text{lg4}$ is *negative* and both $f(n), f'(n)$ are negative — dividing the more-negative numerator by the smaller $\\text{lg3}^2$ makes $f(n)$ smaller, so $f(n) \\leq f'(n)$ still holds. The proof case-splits on $\\text{lg3} \\lessgtr 1$ and is sorry-free for all $n \\geq 100$"
     ],
     "prerequisites": [
       "Analytic number theory: the Prime Number Theorem and its consequences",
@@ -223,7 +223,7 @@
     ]
   },
   "conclusion": {
-    "summary": "This 219-line formalization captures the SOLVED Erdős Problem #4: for any $C > 0$, infinitely many prime gaps satisfy $g_n > C \\cdot \\frac{\\log p_n \\cdot \\log\\log p_n \\cdot \\log\\log\\log\\log p_n}{(\\log\\log\\log p_n)^2}$, proved independently by Maynard and Ford-Green-Konyagin-Tao (2016). The formalization axiomatizes Maynard's (2016) resolution as a single axiom (`maynard_theorem`); the prime gap function and the Cramér and Erdős conjectures are defined as `def`s, and the FGKT resolution and the related $\\$10{,}000$ Erdős prize conjecture ($g_n > (\\log n)^{1+c}$, still OPEN) are documented in the module narrative. The key structural insight: the solution required combining sieve methods (Maynard-Tao multidimensional sieve producing bounded prime gaps) with Green-Tao-type machinery for long arithmetic progressions in primes — neither technique alone suffices, and the synthesis resolved a 75-year-old question about the growth rate of maximal prime gaps.",
+    "summary": "This 267-line formalization captures the SOLVED Erdős Problem #4: for any $C > 0$, infinitely many prime gaps satisfy $g_n > C \\cdot \\frac{\\log p_n \\cdot \\log\\log p_n \\cdot \\log\\log\\log\\log p_n}{(\\log\\log\\log p_n)^2}$, proved independently by Maynard and Ford-Green-Konyagin-Tao (2016). The formalization axiomatizes Maynard's (2016) resolution as a single axiom (`maynard_theorem`); the prime gap function and the Cramér and Erdős conjectures are defined as `def`s, and the FGKT resolution and the related $\\$10{,}000$ Erdős prize conjecture ($g_n > (\\log n)^{1+c}$, still OPEN) are documented in the module narrative. The key structural insight: the solution required combining sieve methods (Maynard-Tao multidimensional sieve producing bounded prime gaps) with Green-Tao-type machinery for long arithmetic progressions in primes — neither technique alone suffices, and the synthesis resolved a 75-year-old question about the growth rate of maximal prime gaps.",
     "implications": "Prime gaps can far exceed the average gap of log n, with Rankin's amplification factor growing without bound — answering a question open since the 1930s. Maynard's multidimensional sieve techniques became fundamental tools in analytic number theory, leading to his Fields Medal-winning work on bounded gaps (p_{n+1} - p_n ≤ 246 infinitely often). The FGKT probabilistic hypergraph covering approach bridges combinatorics and analytic number theory, with applications to additive combinatorics and Ramsey theory. Under the Riemann Hypothesis, the maximum gap below x is O(√x log x), far below the unconditional (log x)² prediction — the gap between conditional and unconditional results remains a central mystery. The $10,000 prize for gaps exceeding (log n)^{1+c} remains open and would require fundamentally new ideas beyond current sieve methods.",
     "openQuestions": [
       "Erdős's $10,000 conjecture: Does p_{n+1} - p_n > (log n)^{1+c} hold for some c > 0 and infinitely many n?",
@@ -286,7 +286,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 219,
+    "lineCount": 267,
     "structureCount": 0,
     "axiomCount": 1,
     "theoremCount": 2,
@@ -301,7 +301,7 @@
     ],
     "namespace": "Erdos4",
     "path": "Proofs/Erdos4Problem.lean",
-    "sorries": 1,
+    "sorries": 0,
     "definitionCount": 16
   },
   "references": [
@@ -348,5 +348,5 @@
       "note": "Conjectured g_n = O((log p_n)²) based on a probabilistic model of primes"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Rehabilitates `Proofs/Erdos4Problem.lean` (Erdős Problem #4, large prime gaps).

**The file did not compile on `main`.** Three descriptive comment blocks — *Rankin's Theorem*, *Ford-Green-Konyagin-Tao Theorem*, *Baker-Harman-Pintz Theorem* — were written as `/-- … -/` **declaration docstrings with no following declaration**, which Lean rejects (`unexpected token '/--'; expected declaration`). Converted those three to ordinary `/- … -/` block comments.

**Proved the lone `sorry`** in `improved_stronger`: `erdosFunction n ≤ improvedErdosFunction n` for `n ≥ 100`.

### The "potential bound error" was a false alarm
A prior `keyInsight` worried the inequality fails at `n ≥ 100` because `log log log 100 ≈ 0.83 < 1`. It does **not** fail: in that regime `lg4 = log(log log log n) < 0`, so the numerator `lg2·lg4` is *negative* and **both** functions are negative. Dividing the more-negative numerator by the smaller `lg3²` makes `erdosFunction` *smaller*, so `≤` holds. The proof anchors `log n > 3 > e` for `n ≥ 100`, then case-splits on `lg3 ≷ 1`; the shared sign of `log(lg3)` and `(lg3 − 1)` forces `lg4·(1 − lg3) ≤ 0`, closing the goal after clearing `1/lg3²` vs `1/lg3` via `div_le_div_iff₀`.

## Verification

`lake env lean Proofs/Erdos4Problem.lean` → exit 0, no errors, **no sorry warnings**.

```
'Erdos4.improved_stronger' depends on axioms: [propext, Classical.choice, Quot.sound]
'Erdos4.erdos_4_solved'   depends on axioms: [propext, Classical.choice, Erdos4.maynard_theorem, Quot.sound]
```

- `improved_stronger`: fully proved, **0 axioms** beyond foundational.
- File: **0 sorries**, **1 axiom** (`maynard_theorem`) — Erdős #4 is a deep solved result, so status remains `axiomatized`.
- `meta.json` updated: `sorries` 1→0, `lineCount` 219→267, corrected `keyInsight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)