### PR TITLE
audit: 2 fresh gallery proofs verified CLEAN (0 integrity issues)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24043,8 +24043,20 @@
       "lastAudited": "2026-06-25T15:54:07Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq-02-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T16:05:21Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T16:05:21Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T14:08:44Z"
+  "lastUpdated": "2026-06-25T16:05:21Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 2 newly-merged gallery proofs that entered the queue. Both **CLEAN** — public claims exactly match the Lean kernel guarantees. Tracker-only change.

### arithmetic-series-oq-02-oq-02-oq-01-oq-03 — *Multivariate Generating-Function Proof of the k-Dimensional Hockey Stick*
- status `verified` / badge `original`
- Counts verified against `Proofs/ArithmeticSeriesOQ02OQ02OQ01OQ03.lean`: **13 theorems** ✓ (meta 13), **1 def** ✓, **268 lines** ✓, **0 sorries** ✓, **0 axioms** ✓, no `True` stubs, no `native_decide`.
- Self-contained over `Mathlib.RingTheory.PowerSeries.WellKnown` (`invOneSubPow` API); the GF identities and the parallel-Vandermonde recovery are independently proved here, not delegated to a single Mathlib call. `assumptions` field is honest and detailed (propext/Classical.choice/Quot.sound only). No delegation opacity.

### lebesgue-measure-oq-04 — *Cantor Set: Uncountable Yet Lebesgue-Null*
- status `verified` / badge `verified`
- Counts verified against `Proofs/LebesgueMeasureOQ04.lean`: **8 theorems** ✓ (meta 8), **139 lines** ✓, **0 sorries** ✓, **0 axioms** ✓, no `True` stubs, no `native_decide`.
- The Cantor set definition + `cantorSetEquivNatToBool` bijection come from Mathlib (standard infrastructure); the **measure-zero theorem** and the **explicit uncountability statement** are NOT in Mathlib and are proved here. `assumptions` field explicitly discloses what is Mathlib-supplied vs. proved — no delegation opacity, badge `verified` appropriate.

### Phantoms
Two untracked WIP phantom dirs (`abel-ruffini-galois-extensions-oq-01`, `area-of-circle-oq-05-oq-01-incomplete-01`) appeared transiently in the queue but were never on `main` and self-resolved (cleaned by concurrent agents) during this iteration — released, not blessed.

Queue now: **3873/3873 audited, 0 issues, 0 critical**.

---
Discovered during autonomous gallery integrity audit.