### PR TITLE
Enrich Jacobi Symbol Parity Characterization (oq-01-oq-03)

### DIFF
--- a/src/data/proofs/jacobi-symbol-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-03/annotations.json
@@ -5,10 +5,14 @@
     "type": "concept",
     "range": {
       "startLine": 1,
-      "endLine": 29
+      "endLine": 34
     },
     "title": "Module Header: J(a|n) = 1 as a Parity Count",
-    "content": "Answers the parent entry's open question: characterize exactly when $J(a\\mid n) = 1$ even though $a$ is a non-residue. For coprime $a, n$ the Jacobi symbol is a pure sign $(-1)^k$, where $k = \\#\\{p \\mid n : (a\\mid p) = -1\\}$ counts the prime factors of $n$ **with multiplicity** at which $a$ is a non-residue. So $J(a\\mid n) = 1 \\iff k$ is even — the $-1$'s cancel in pairs. The parent's puzzle $J(2\\mid 15) = 1$ is the case $k = 2$ (both $3$ and $5$ are non-residue witnesses); $J(2\\mid 45) = -1$ is the case $k = 3$ (the list $[3,3,5]$), showing multiplicity is essential."
+    "content": "Answers the parent entry's open question: characterize exactly when $J(a\\mid n) = 1$ even though $a$ is a non-residue. For coprime $a, n$ the Jacobi symbol is a pure sign $(-1)^k$, where $k = \\#\\{p \\mid n : (a\\mid p) = -1\\}$ counts the prime factors of $n$ **with multiplicity** at which $a$ is a non-residue. So $J(a\\mid n) = 1 \\iff k$ is even — the $-1$'s cancel in pairs. The parent's puzzle $J(2\\mid 15) = 1$ is the case $k = 2$ (both $3$ and $5$ are non-residue witnesses); $J(2\\mid 45) = -1$ is the case $k = 3$ (the list $[3,3,5]$), showing multiplicity is essential.",
+    "mathContext": "$J(a\\mid n) = \\prod_{p\\mid n}(a\\mid p) = (-1)^k,\\quad k = \\#\\{p\\mid n\\text{ (with mult.)} : (a\\mid p) = -1\\};\\quad J(a\\mid n)=1 \\iff k \\text{ even}.$",
+    "significance": "context",
+    "relatedConcepts": ["Jacobi symbol", "Legendre symbol", "quadratic residue", "Solovay–Strassen test", "false witness"],
+    "prerequisites": ["quadratic reciprocity", "prime factorization with multiplicity"]
   },
   {
     "id": "jacobi-symbol-oq-01-oq-03-legvals",
@@ -19,7 +23,11 @@
       "endLine": 47
     },
     "title": "The Legendre-Symbol List",
-    "content": "`legVals a n` is the list of Legendre symbols $(a\\mid p)$ as $p$ ranges over `n.primeFactorsList` — the prime factorization of $n$ **as a list, carrying multiplicity**. By the very definition of Mathlib's `jacobiSym`, the Jacobi symbol is the product of this list (`jacobiSym_eq_legVals_prod`, proved by `rfl`). This is the definitional bridge that turns the Jacobi symbol into a counting problem over its prime-factor signs."
+    "content": "`legVals a n` is the list of Legendre symbols $(a\\mid p)$ as $p$ ranges over `n.primeFactorsList` — the prime factorization of $n$ **as a list, carrying multiplicity**. By the very definition of Mathlib's `jacobiSym`, the Jacobi symbol is the product of this list (`jacobiSym_eq_legVals_prod`, proved by `rfl`). This is the definitional bridge that turns the Jacobi symbol into a counting problem over its prime-factor signs.",
+    "mathContext": "$\\textsf{legVals}\\,a\\,n = [\\,(a\\mid p) : p \\in \\textsf{primeFactorsList}\\,n\\,],\\quad J(a\\mid n) = \\prod \\textsf{legVals}\\,a\\,n$ (by $\\textsf{rfl}$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.primeFactorsList", "List.pmap", "multiplicity", "product over prime factors"],
+    "prerequisites": ["Legendre symbol", "lists in Lean", "Mathlib jacobiSym definition"]
   },
   {
     "id": "jacobi-symbol-oq-01-oq-03-each-sign",
@@ -30,29 +38,41 @@
       "endLine": 71
     },
     "title": "Coprimality Makes Each Factor a Genuine Sign",
-    "content": "`legVals_mem_eq_one_or_neg_one`: when $\\gcd(a,n) = 1$, every entry $(a\\mid p)$ of the list is $\\pm 1$, never $0$. A Legendre symbol $(a\\mid p)$ vanishes iff $p \\mid a$ (`ZMod.intCast_zmod_eq_zero_iff_dvd`); but $p$ is a prime factor of $n$, so $p \\mid a$ would give $p \\mid \\gcd(a,n) = 1$, impossible. This is the hypothesis that lets the product-of-signs argument run."
+    "content": "`legVals_mem_eq_one_or_neg_one`: when $\\gcd(a,n) = 1$, every entry $(a\\mid p)$ of the list is $\\pm 1$, never $0$. A Legendre symbol $(a\\mid p)$ vanishes iff $p \\mid a$ (`ZMod.intCast_zmod_eq_zero_iff_dvd`); but $p$ is a prime factor of $n$, so $p \\mid a$ would give $p \\mid \\gcd(a,n) = 1$, impossible. This is the hypothesis that lets the product-of-signs argument run.",
+    "mathContext": "$\\gcd(a,n)=1,\\ p\\mid n \\;\\Rightarrow\\; (a\\mid p)\\neq 0,$ since $(a\\mid p)=0 \\iff p\\mid a$, which would force $p\\mid\\gcd(a,n)=1$.",
+    "significance": "key",
+    "relatedConcepts": ["coprimality", "vanishing Legendre symbol", "gcd divisibility", "ZMod"],
+    "prerequisites": ["Nat.dvd_gcd", "intCast_zmod_eq_zero_iff_dvd", "legendreSym.eq_one_or_neg_one"]
   },
   {
     "id": "jacobi-symbol-oq-01-oq-03-product-sign",
     "proofId": "jacobi-symbol-oq-01-oq-03",
     "type": "theorem",
     "range": {
-      "startLine": 75,
+      "startLine": 73,
       "endLine": 90
     },
     "title": "Product of ±1's is (-1) to the Count of -1's",
-    "content": "`prod_eq_neg_one_pow_count`: the elementary engine. For any list $L$ of integers each equal to $1$ or $-1$, $\\prod L = (-1)^{\\#\\{x \\in L : x = -1\\}}$. A one-line induction: a head $+1$ leaves both product and count unchanged (`List.count_cons_of_ne`), while a head $-1$ multiplies the product by $-1$ and increments the count by one (`List.count_cons_self`), matching `pow_succ`. Reusable sign-counting infrastructure, independent of number theory."
+    "content": "`prod_eq_neg_one_pow_count`: the elementary engine. For any list $L$ of integers each equal to $1$ or $-1$, $\\prod L = (-1)^{\\#\\{x \\in L : x = -1\\}}$. A one-line induction: a head $+1$ leaves both product and count unchanged (`List.count_cons_of_ne`), while a head $-1$ multiplies the product by $-1$ and increments the count by one (`List.count_cons_self`), matching `pow_succ`. Reusable sign-counting infrastructure, independent of number theory.",
+    "mathContext": "$\\forall x\\in L,\\ x=\\pm 1 \\;\\Rightarrow\\; \\prod L = (-1)^{L.\\mathrm{count}(-1)}$ (induction on $L$).",
+    "significance": "supporting",
+    "relatedConcepts": ["list induction", "List.count", "sign product", "pow_succ"],
+    "prerequisites": ["List.prod", "List.count_cons lemmas", "induction in Lean"]
   },
   {
     "id": "jacobi-symbol-oq-01-oq-03-sign-formula",
     "proofId": "jacobi-symbol-oq-01-oq-03",
     "type": "theorem",
     "range": {
-      "startLine": 94,
+      "startLine": 92,
       "endLine": 103
     },
     "title": "The Sign Formula J(a|n) = (-1)^k",
-    "content": "`numNonResidueFactors a n` is $k = \\#\\{p \\mid n \\text{ (with multiplicity)} : (a\\mid p) = -1\\}$, the count of $-1$ entries in `legVals a n`. Combining the two preceding lemmas, `jacobiSym_eq_neg_one_pow` gives $J(a\\mid n) = (-1)^k$ for coprime $a, n$: the Jacobi symbol is determined entirely by how many prime factors of $n$ (with multiplicity) see $a$ as a non-residue."
+    "content": "`numNonResidueFactors a n` is $k = \\#\\{p \\mid n \\text{ (with multiplicity)} : (a\\mid p) = -1\\}$, the count of $-1$ entries in `legVals a n`. Combining the two preceding lemmas, `jacobiSym_eq_neg_one_pow` gives $J(a\\mid n) = (-1)^k$ for coprime $a, n$: the Jacobi symbol is determined entirely by how many prime factors of $n$ (with multiplicity) see $a$ as a non-residue.",
+    "mathContext": "$k := \\textsf{numNonResidueFactors}\\,a\\,n = (\\textsf{legVals}\\,a\\,n).\\mathrm{count}(-1);\\quad \\gcd(a,n)=1 \\Rightarrow J(a\\mid n)=(-1)^k.$",
+    "significance": "key",
+    "relatedConcepts": ["counting non-residues", "sign formula", "composition of lemmas"],
+    "prerequisites": ["the Legendre-symbol list", "product-of-signs lemma"]
   },
   {
     "id": "jacobi-symbol-oq-01-oq-03-parity",
@@ -63,7 +83,11 @@
       "endLine": 124
     },
     "title": "The Parity Characterization (Main Result)",
-    "content": "`jacobiSym_eq_one_iff_even`: reading the sign formula through `neg_one_pow_eq_one_iff_even`, $J(a\\mid n) = 1 \\iff k$ is even. This is the exact answer to the parent's open question — $J(a\\mid n) = 1$ while $a$ is a non-residue happens precisely when an EVEN (positive) number of prime factors are non-residue witnesses. Dually `jacobiSym_eq_neg_one_iff_odd`: $J(a\\mid n) = -1 \\iff k$ is odd, recovering the classical one-sided obstruction as the odd-parity case."
+    "content": "`jacobiSym_eq_one_iff_even`: reading the sign formula through `neg_one_pow_eq_one_iff_even`, $J(a\\mid n) = 1 \\iff k$ is even. This is the exact answer to the parent's open question — $J(a\\mid n) = 1$ while $a$ is a non-residue happens precisely when an EVEN (positive) number of prime factors are non-residue witnesses. Dually `jacobiSym_eq_neg_one_iff_odd`: $J(a\\mid n) = -1 \\iff k$ is odd, recovering the classical one-sided obstruction as the odd-parity case.",
+    "mathContext": "$J(a\\mid n)=1 \\iff k \\text{ even};\\qquad J(a\\mid n)=-1 \\iff k \\text{ odd}\\quad(\\gcd(a,n)=1).$",
+    "significance": "key",
+    "relatedConcepts": ["parity", "even/odd", "(-1)^k = 1 iff even", "non-residue cancellation"],
+    "prerequisites": ["the sign formula", "neg_one_pow_eq_one_iff_even"]
   },
   {
     "id": "jacobi-symbol-oq-01-oq-03-examples",
@@ -71,9 +95,13 @@
     "type": "theorem",
     "range": {
       "startLine": 126,
-      "endLine": 142
+      "endLine": 143
     },
     "title": "Worked Examples: Multiplicity Matters",
-    "content": "`even_numNonResidue_two_fifteen`: from $J(2\\mid 15) = 1$ the count is even ($k = 2$: both $3$ and $5$ are non-residue witnesses for $2$) — the parent's puzzle, explained. `odd_numNonResidue_two_fortyfive`: from $J(2\\mid 45) = -1$ the **multiplicity-aware** count is odd ($k = 3$, the list $[3,3,5]$), even though only two DISTINCT bad primes occur. The distinct-prime count $\\{3,5\\} = 2$ (even) would predict the wrong sign — so the characterization genuinely requires multiplicity. Both parities are read off the kernel-checked `norm_num` Jacobi values, so no `native_decide` enters."
+    "content": "`even_numNonResidue_two_fifteen`: from $J(2\\mid 15) = 1$ the count is even ($k = 2$: both $3$ and $5$ are non-residue witnesses for $2$) — the parent's puzzle, explained. `odd_numNonResidue_two_fortyfive`: from $J(2\\mid 45) = -1$ the **multiplicity-aware** count is odd ($k = 3$, the list $[3,3,5]$), even though only two DISTINCT bad primes occur. The distinct-prime count $\\{3,5\\} = 2$ (even) would predict the wrong sign — so the characterization genuinely requires multiplicity. Both parities are read off the kernel-checked `norm_num` Jacobi values, so no `native_decide` enters.",
+    "mathContext": "$J(2\\mid 15)=1\\Rightarrow k=2$ even; $\\;J(2\\mid 45)=-1\\Rightarrow k=3$ odd $([3,3,5])$, while distinct primes $\\{3,5\\}=2$ would mispredict.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "multiplicity vs distinctness", "norm_num evaluation", "n = 3²·5"],
+    "prerequisites": ["the parity characterization", "Jacobi symbol evaluation"]
   }
 ]

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-03/index.ts
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/JacobiSymbolOQ0103.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const jacobiSymbolOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const jacobiSymbolOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const jacobiSymbolOq01Oq03Data: ProofData = {
+  proof: jacobiSymbolOq01Oq03Proof,
+  annotations: jacobiSymbolOq01Oq03Annotations,
+}

--- a/src/data/proofs/jacobi-symbol-oq-01-oq-03/meta.json
+++ b/src/data/proofs/jacobi-symbol-oq-01-oq-03/meta.json
@@ -84,6 +84,57 @@
       "neg_one_pow_eq_one_iff_even and Even/Odd.neg_one_pow for reading (-1)^k by parity"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module header: J(a|n) = 1 as a parity count",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Docstring framing the parent's open question — when is J(a|n) = 1 even though a is a non-residue? — and the answer: J(a|n) = ∏_{p∣n} (a|p) with multiplicity, so for coprime a,n it is a sign (−1)^k where k counts non-residue prime factors with multiplicity; J(a|n) = 1 ⇔ k even. Notes the Solovay–Strassen 'false witness' connection and that multiplicity is essential (45 = 3²·5). Imports Mathlib, opens Nat and ZMod, opens the JacobiSymbolOQ0103 namespace."
+    },
+    {
+      "id": "legvals-def",
+      "title": "The Legendre-symbol list",
+      "startLine": 36,
+      "endLine": 47,
+      "summary": "legVals a n is the list of Legendre symbols (a|p) over n.primeFactorsList (the prime factorization as a list, carrying multiplicity). jacobiSym_eq_legVals_prod states jacobiSym a n = (legVals a n).prod, true by rfl from Mathlib's definition — the definitional bridge turning the Jacobi symbol into a counting problem."
+    },
+    {
+      "id": "each-sign",
+      "title": "Coprimality makes each factor a genuine sign",
+      "startLine": 49,
+      "endLine": 71,
+      "summary": "legVals_mem_eq_one_or_neg_one: when gcd(a,n) = 1, every entry (a|p) is ±1, never 0. A Legendre symbol vanishes iff p ∣ a (ZMod.intCast_zmod_eq_zero_iff_dvd); but p ∣ n, so p ∣ a would force p ∣ gcd(a,n) = 1, impossible. This is the hypothesis enabling the product-of-signs argument."
+    },
+    {
+      "id": "product-sign",
+      "title": "Product of ±1's is (−1) to the count of −1's",
+      "startLine": 73,
+      "endLine": 90,
+      "summary": "prod_eq_neg_one_pow_count: for any list of integers each ±1, ∏L = (−1)^(L.count (−1)). A one-line induction — a head +1 leaves product and count unchanged (List.count_cons_of_ne), a head −1 multiplies by −1 and increments the count (List.count_cons_self, pow_succ). Number-theory-independent, reusable sign-counting infrastructure."
+    },
+    {
+      "id": "sign-formula",
+      "title": "The sign formula J(a|n) = (−1)^k",
+      "startLine": 92,
+      "endLine": 103,
+      "summary": "numNonResidueFactors a n := (legVals a n).count (−1) = k, and jacobiSym_eq_neg_one_pow combines the two preceding lemmas to give J(a|n) = (−1)^k for coprime a,n: the Jacobi symbol is determined entirely by how many prime factors of n (with multiplicity) see a as a non-residue."
+    },
+    {
+      "id": "parity-main",
+      "title": "The parity characterization (main result)",
+      "startLine": 105,
+      "endLine": 124,
+      "summary": "jacobiSym_eq_one_iff_even: via neg_one_pow_eq_one_iff_even, J(a|n) = 1 ⇔ k is even — the exact answer to the parent's open question. Dually jacobiSym_eq_neg_one_iff_odd: J(a|n) = −1 ⇔ k is odd, recovering the classical one-sided obstruction as the odd-parity case."
+    },
+    {
+      "id": "worked-examples",
+      "title": "Worked examples: multiplicity matters",
+      "startLine": 126,
+      "endLine": 143,
+      "summary": "even_numNonResidue_two_fifteen: J(2|15) = 1 ⇒ k even (k = 2, primes 3 and 5) — the parent's puzzle explained. odd_numNonResidue_two_fortyfive: J(2|45) = −1 ⇒ the multiplicity-aware k = 3 (list [3,3,5]) is odd, whereas the distinct-prime count {3,5} = 2 (even) would predict the wrong sign. Both read off kernel-checked norm_num Jacobi values, so no native_decide."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "jacobi-symbol-oq-01",


### PR DESCRIPTION
Enrichment pass for `jacobi-symbol-oq-01-oq-03`.

## Quality improvements
- **Created missing `index.ts`** — no Vite entry point existed, so the page rendered "proof not found" on the live site. Added the standard template wiring `JacobiSymbolOQ0103.lean` as source.
- **Added `sections` array** (7 sections) covering the full 143-line Lean file: module header, the Legendre-symbol list, the coprimality sign lemma, the product-of-signs engine, the sign formula J(a|n) = (−1)^k, the parity characterization, and the worked examples.
- **Enriched all 7 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, and aligned their line ranges with the source.

## Axiom integrity
No status/badge/axiom changes. Confirmed: 8 theorems, 0 sorries, 0 axioms, no `native_decide` (examples use kernel-checked `norm_num`). `status: verified`, `badge: original`, `axiomCount: 0` remain accurate.

Build passes (`pnpm build`).