### PR TITLE
research(cauchy-schwarz-oq-07-oq-01): Jordan–von Neumann converse — parallelogram law ⇔ inner product, with sharp ℓ^∞ counterexample [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -699,6 +699,7 @@ import Proofs.CauchySchwarzOQ05
 import Proofs.CauchySchwarzOQ06
 import Proofs.CauchySchwarzOQ06OQ01
 import Proofs.CauchySchwarzOQ07
+import Proofs.CauchySchwarzOQ07OQ01
 import Proofs.CauchySchwarzOQ08
 import Proofs.CayleyHamilton
 import Proofs.CayleyHamiltonCyclicVectorAllFields

--- a/proofs/Proofs/CauchySchwarzOQ07OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ07OQ01.lean
@@ -1,0 +1,107 @@
+/-
+  The Jordan–von Neumann converse (cauchy-schwarz-oq-07-oq-01).
+
+  Open question (the converse direction of the parent cauchy-schwarz-oq-07): if a norm
+  `‖·‖` on a real or complex normed space satisfies the parallelogram law
+      ‖x + y‖² + ‖x − y‖² = 2‖x‖² + 2‖y‖²,
+  then it is induced by an inner product, recovered from the norm via the polarization
+  identity.
+
+  The parent proved the FORWARD direction — every inner-product norm satisfies the
+  parallelogram law.  This file packages the full **Jordan–von Neumann (1935)
+  characterization** as a biconditional:
+
+      a compatible inner product exists  ⇔  the parallelogram law holds.
+
+  The hard converse (⇐) is Mathlib's `InnerProductSpace.ofNorm` (the
+  Fréchet–von Neumann–Jordan theorem): it constructs the inner product by polarization and
+  verifies bilinearity and norm-compatibility.  We expose it in both the `*self` form Mathlib
+  uses and the squared `^2` form of the parent, and add a `recovers the norm` corollary
+  making `‖x‖² = re⟪x,x⟫` explicit for the recovered inner product.
+
+  To show the criterion is SHARP (not vacuously always satisfiable), we exhibit a concrete
+  counterexample: the supremum norm on `ℝ × ℝ` violates the parallelogram law at
+  `x = (1,0), y = (0,1)` (the diagonals (1,1) and (1,-1) both have sup-norm 1, giving
+  LHS = 2 ≠ 4 = RHS), and therefore — by the characterization — admits NO compatible inner
+  product.  So the sup-normed plane is a genuine non-Hilbert Banach space.
+
+  Sorry-free and axiom-free.
+-/
+import Mathlib
+
+open RCLike
+open scoped InnerProductSpace
+
+namespace CauchySchwarzOQ07OQ01
+
+section Characterization
+
+variable {𝕜 : Type*} [RCLike 𝕜] {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+/-- **Jordan–von Neumann characterization (`*self` form).**  A real-or-complex normed space
+`E` carries a compatible inner product if and only if its norm satisfies the parallelogram
+identity `‖x+y‖·‖x+y‖ + ‖x−y‖·‖x−y‖ = 2(‖x‖·‖x‖ + ‖y‖·‖y‖)`.
+
+The forward direction is Mathlib's `parallelogram_law_with_norm`; the converse is the
+Fréchet–von Neumann–Jordan construction `InnerProductSpace.ofNorm`, which builds the inner
+product by polarization.  `Nonempty (InnerProductSpace 𝕜 E)` is the precise statement that
+*some* inner product compatible with the existing norm exists. -/
+theorem nonempty_innerProductSpace_iff_parallelogram :
+    Nonempty (InnerProductSpace 𝕜 E) ↔
+      ∀ x y : E, ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖) := by
+  constructor
+  · rintro ⟨i⟩ x y
+    letI := i
+    exact parallelogram_law_with_norm 𝕜 x y
+  · intro h
+    exact ⟨InnerProductSpace.ofNorm 𝕜 h⟩
+
+/-- **Jordan–von Neumann characterization (squared `^2` form).**  The same biconditional in
+the squared form used by the parent entry: a compatible inner product exists iff
+`‖x+y‖² + ‖x−y‖² = 2‖x‖² + 2‖y‖²`. -/
+theorem nonempty_innerProductSpace_iff_parallelogram_sq :
+    Nonempty (InnerProductSpace 𝕜 E) ↔
+      ∀ x y : E, ‖x + y‖ ^ 2 + ‖x - y‖ ^ 2 = 2 * ‖x‖ ^ 2 + 2 * ‖y‖ ^ 2 := by
+  rw [nonempty_innerProductSpace_iff_parallelogram (𝕜 := 𝕜)]
+  refine ⟨fun h x y => ?_, fun h x y => ?_⟩ <;>
+    · have := h x y; simp only [pow_two] at *; linarith
+
+/-- **The recovered inner product reproduces the norm.**  Given the parallelogram law, the
+inner product produced by `InnerProductSpace.ofNorm` satisfies `‖x‖² = re⟪x,x⟫`, i.e. the
+polarization-defined inner product is genuinely compatible with the original norm. -/
+theorem ofNorm_norm_sq_eq_re_inner
+    (h : ∀ x y : E, ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖))
+    (x : E) :
+    letI := InnerProductSpace.ofNorm 𝕜 h
+    ‖x‖ ^ 2 = RCLike.re (inner 𝕜 x x) := by
+  letI := InnerProductSpace.ofNorm 𝕜 h
+  exact norm_sq_eq_re_inner (𝕜 := 𝕜) x
+
+end Characterization
+
+section Counterexample
+
+/-- **Sharpness: the supremum norm on `ℝ × ℝ` violates the parallelogram law.**  Tested at
+`x = (1,0)`, `y = (0,1)`: both diagonals `x+y = (1,1)` and `x−y = (1,−1)` have sup-norm `1`,
+so the left-hand side is `1 + 1 = 2`, while the right-hand side is `2(1 + 1) = 4`.  Hence the
+parallelogram law fails for the `ℓ^∞` norm. -/
+theorem supNorm_not_parallelogram :
+    ¬ ∀ x y : ℝ × ℝ,
+      ‖x + y‖ * ‖x + y‖ + ‖x - y‖ * ‖x - y‖ = 2 * (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖) := by
+  intro h
+  have key := h (1, 0) (0, 1)
+  norm_num [Prod.norm_def, Real.norm_eq_abs, Prod.fst_add, Prod.snd_add,
+    Prod.fst_sub, Prod.snd_sub] at key
+
+/-- **The sup-normed plane is not an inner-product space.**  Combining the characterization
+with the counterexample: since the `ℓ^∞` norm on `ℝ × ℝ` fails the parallelogram law, no
+inner product is compatible with it.  This exhibits a concrete finite-dimensional Banach
+space that is not a Hilbert space. -/
+theorem no_innerProductSpace_sup_norm :
+    ¬ Nonempty (InnerProductSpace ℝ (ℝ × ℝ)) := by
+  rw [nonempty_innerProductSpace_iff_parallelogram (𝕜 := ℝ)]
+  exact supNorm_not_parallelogram
+
+end Counterexample
+
+end CauchySchwarzOQ07OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "csoq0701-header",
+    "proofId": "cauchy-schwarz-oq-07-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 35
+    },
+    "type": "concept",
+    "title": "Module Header: the Converse Direction",
+    "content": "The parent entry (cauchy-schwarz-oq-07) proved that every inner-product norm satisfies the parallelogram law $\\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$. This file formalizes the harder **converse**: a norm satisfying the parallelogram law is itself induced by an inner product (Jordan–von Neumann, 1935), recovered from the norm via the polarization identity. The two directions together give the exact characterization of inner-product norms among all normed-space norms.",
+    "mathContext": "Hypothesis: the parallelogram law for $\\|\\cdot\\|$. Conclusion: existence of a compatible inner product with $\\|x\\|^2 = \\operatorname{re}\\langle x,x\\rangle$.",
+    "significance": "context",
+    "relatedConcepts": ["Jordan–von Neumann theorem", "polarization identity", "parallelogram law", "inner-product space", "Hilbert space"],
+    "prerequisites": ["normed spaces", "inner-product spaces", "the parallelogram law (parent entry)"]
+  },
+  {
+    "id": "csoq0701-biconditional",
+    "proofId": "cauchy-schwarz-oq-07-oq-01",
+    "range": {
+      "startLine": 41,
+      "endLine": 67
+    },
+    "type": "theorem",
+    "title": "The Jordan–von Neumann Biconditional",
+    "content": "`nonempty_innerProductSpace_iff_parallelogram` states that a real-or-complex normed space carries a compatible inner product — `Nonempty (InnerProductSpace 𝕜 E)` — **if and only if** its norm satisfies the parallelogram law. The forward direction unwraps a given `InnerProductSpace` instance and applies Mathlib's `parallelogram_law_with_norm`. The converse feeds the law to `InnerProductSpace.ofNorm 𝕜`, the Fréchet–von Neumann–Jordan construction that polarizes the norm into an inner product and discharges all the inner-product axioms. `nonempty_innerProductSpace_iff_parallelogram_sq` restates the same equivalence in the squared `^2` form used by the parent, bridging `a*a` and `a^2` with `pow_two` and `linarith`.",
+    "mathContext": "$\\exists\\ \\langle\\cdot,\\cdot\\rangle\\text{ compatible} \\iff \\forall x,y,\\ \\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2.$ Converse via $\\langle x,y\\rangle = \\tfrac14(\\|x+y\\|^2-\\|x-y\\|^2+\\cdots)$ (polarization).",
+    "significance": "critical",
+    "relatedConcepts": ["InnerProductSpace.ofNorm", "parallelogram_law_with_norm", "Nonempty existence", "polarization", "pow_two"],
+    "prerequisites": ["InnerProductSpace 𝕜 E", "NormedSpace 𝕜 E", "RCLike (ℝ or ℂ)"]
+  },
+  {
+    "id": "csoq0701-recovery",
+    "proofId": "cauchy-schwarz-oq-07-oq-01",
+    "range": {
+      "startLine": 69,
+      "endLine": 80
+    },
+    "type": "theorem",
+    "title": "The Recovered Inner Product Reproduces the Norm",
+    "content": "`ofNorm_norm_sq_eq_re_inner` makes the compatibility explicit: for the inner product produced by `InnerProductSpace.ofNorm` from the parallelogram law, one has $\\|x\\|^2 = \\operatorname{re}\\langle x,x\\rangle$. This is the precise sense in which the polarization-defined inner product is not just *some* inner product but one that *induces the original norm* — closing the loop with the forward direction.",
+    "mathContext": "$\\|x\\|^2 = \\operatorname{re}\\langle x,x\\rangle$ for the inner product recovered from $\\|\\cdot\\|$ — the norm-compatibility field `norm_sq_eq_re_inner` of the constructed `InnerProductSpace`.",
+    "significance": "key",
+    "relatedConcepts": ["norm_sq_eq_re_inner", "norm recovery", "compatibility", "polarization identity"],
+    "prerequisites": ["InnerProductSpace.ofNorm", "the field norm_sq_eq_re_inner"]
+  },
+  {
+    "id": "csoq0701-counterexample",
+    "proofId": "cauchy-schwarz-oq-07-oq-01",
+    "range": {
+      "startLine": 82,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "Sharpness: the Sup-Normed Plane Is Not a Hilbert Space",
+    "content": "A characterization is only meaningful if its hypothesis can fail. `supNorm_not_parallelogram` proves the supremum ($\\ell^\\infty$) norm on $\\mathbb{R}\\times\\mathbb{R}$ violates the parallelogram law, witnessed at $x=(1,0)$, $y=(0,1)$: the diagonals $x+y=(1,1)$ and $x-y=(1,-1)$ both have sup-norm $1$, so the left side is $1+1=2$ while the right side is $2(1+1)=4$. `no_innerProductSpace_sup_norm` then applies the biconditional to conclude $\\neg\\,\\mathrm{Nonempty}\\,(\\mathrm{InnerProductSpace}\\ \\mathbb{R}\\ (\\mathbb{R}\\times\\mathbb{R}))$ — the sup-normed plane admits no compatible inner product, a concrete finite-dimensional Banach space that is not a Hilbert space.",
+    "mathContext": "$x=(1,0),\\ y=(0,1)$: $\\|x\\pm y\\|_\\infty = 1$, so $\\|x+y\\|^2+\\|x-y\\|^2 = 2 \\ne 4 = 2\\|x\\|^2+2\\|y\\|^2$; hence no inner product induces $\\|\\cdot\\|_\\infty$ on $\\mathbb{R}^2$.",
+    "significance": "critical",
+    "relatedConcepts": ["supremum norm", "Prod.norm_def", "counterexample", "Banach vs Hilbert space", "sharpness"],
+    "prerequisites": ["the product (sup) norm", "the biconditional above"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-07-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-07-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "cauchy-schwarz-oq-07-oq-01",
+  "title": "The Jordan–von Neumann Converse",
+  "slug": "cauchy-schwarz-oq-07-oq-01",
+  "description": "The converse direction of the parallelogram law (cauchy-schwarz-oq-07): a norm on a real or complex space is induced by an inner product if and only if it satisfies the parallelogram law (Jordan–von Neumann, 1935). Packaged as a biconditional via Mathlib's polarization construction InnerProductSpace.ofNorm, with a sharp counterexample — the supremum norm on ℝ×ℝ fails the law and so admits no compatible inner product.",
+  "meta": {
+    "author": "Classical (Jordan–von Neumann 1935); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Parallelogram_law#Inner_product_spaces",
+    "date": "1935",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "inner-product-spaces",
+      "cauchy-schwarz",
+      "parallelogram-law",
+      "jordan-von-neumann",
+      "polarization-identity",
+      "counterexample",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ07OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "InnerProductSpace.ofNorm",
+        "description": "Fréchet–von Neumann–Jordan theorem: a normed space whose norm satisfies the parallelogram identity carries a compatible inner product, built by the polarization formula",
+        "module": "Mathlib.Analysis.InnerProductSpace.OfNorm"
+      },
+      {
+        "theorem": "parallelogram_law_with_norm",
+        "description": "Forward direction: every inner-product norm satisfies the parallelogram law (*self form)",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "norm_sq_eq_re_inner",
+        "description": "Compatibility of the recovered inner product with the norm: ‖x‖² = re⟪x,x⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "Prod.norm_def",
+        "description": "The product norm on E × F is the supremum max(‖x.1‖, ‖x.2‖) — used to evaluate the ℓ^∞ counterexample",
+        "module": "Mathlib.Analysis.Normed.Group.Constructions"
+      }
+    ],
+    "originalContributions": [
+      "nonempty_innerProductSpace_iff_parallelogram: packages the full Jordan–von Neumann characterization as a single biconditional — a compatible inner product exists (Nonempty (InnerProductSpace 𝕜 E)) iff the parallelogram law holds — combining Mathlib's forward parallelogram_law_with_norm with the converse construction InnerProductSpace.ofNorm",
+      "nonempty_innerProductSpace_iff_parallelogram_sq: the same biconditional restated in the squared (^2) form used by the parent entry",
+      "ofNorm_norm_sq_eq_re_inner: makes explicit that the polarization-recovered inner product reproduces the original norm, ‖x‖² = re⟪x,x⟫",
+      "supNorm_not_parallelogram: a concrete proof that the supremum (ℓ^∞) norm on ℝ×ℝ violates the parallelogram law, witnessed at x=(1,0), y=(0,1) where both diagonals have sup-norm 1 (LHS 2 ≠ 4 RHS)",
+      "no_innerProductSpace_sup_norm: the corollary that the sup-normed plane admits NO compatible inner product — a concrete finite-dimensional Banach space that is not a Hilbert space, proving the characterization is sharp rather than vacuous"
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 107,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The converse direction reuses Mathlib's verified InnerProductSpace.ofNorm; the counterexample and biconditional packaging are original.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry (cauchy-schwarz-oq-07) proved the *forward* direction of the Jordan–von Neumann theorem: every norm coming from an inner product satisfies the parallelogram law ‖x+y‖² + ‖x−y‖² = 2‖x‖² + 2‖y‖². The deep content of Jordan and von Neumann's 1935 paper is the **converse**: that the parallelogram law alone forces the existence of an inner product, recovered from the norm by the polarization formula. Together the two directions give the exact characterization of inner-product (pre-Hilbert) spaces among all normed spaces — the reason the parallelogram law is the decisive test for whether a Banach space is a Hilbert space. Mathlib formalizes the hard converse as `InnerProductSpace.ofNorm` (the Fréchet–von Neumann–Jordan theorem), constructing the inner product by polarization and discharging bilinearity and norm-compatibility.",
+    "problemStatement": "**Open Question (cauchy-schwarz-oq-07-oq-01)**: Prove the Jordan–von Neumann converse — if a norm on a real or complex vector space satisfies the parallelogram law, then it is induced by an inner product, recovered via the polarization identity, and that inner product recovers the norm.\n\n**Result**: Packaged as the biconditional `nonempty_innerProductSpace_iff_parallelogram` (a compatible inner product exists ⇔ the parallelogram law holds), in both the `*self` and squared `^2` forms, with `ofNorm_norm_sq_eq_re_inner` confirming norm recovery. To show the criterion is sharp, `supNorm_not_parallelogram` and `no_innerProductSpace_sup_norm` exhibit the supremum norm on ℝ×ℝ as a concrete normed space that fails the law and therefore admits no compatible inner product.",
+    "text": "The converse of the parallelogram law: a norm satisfying ‖x+y‖² + ‖x−y‖² = 2‖x‖² + 2‖y‖² is induced by an inner product (Jordan–von Neumann 1935). Stated as a biconditional via Mathlib's InnerProductSpace.ofNorm, with a sharp ℓ^∞ counterexample.",
+    "proofStrategy": "**Proof Strategy: biconditional packaging plus a sharp counterexample.**\n\n1. **Forward (⇒).** Given any compatible inner product (an element of `InnerProductSpace 𝕜 E`), Mathlib's `parallelogram_law_with_norm` yields the parallelogram law for the existing norm.\n2. **Converse (⇐).** Given the parallelogram law, feed it to `InnerProductSpace.ofNorm 𝕜`, which polarizes the norm into an inner product and verifies all inner-product-space axioms; this produces the required `InnerProductSpace 𝕜 E` instance.\n3. Restate the biconditional in the squared `^2` form by converting `a*a ↔ a^2` with `pow_two` and `linarith`.\n4. **Norm recovery.** The instance from `ofNorm` satisfies `norm_sq_eq_re_inner`, i.e. ‖x‖² = re⟪x,x⟫, so the polarization-recovered inner product genuinely reproduces the original norm.\n5. **Sharpness.** Evaluate the supremum norm on ℝ×ℝ at x=(1,0), y=(0,1): the diagonals (1,1) and (1,−1) both have sup-norm 1, giving LHS = 1+1 = 2 while RHS = 2(1+1) = 4. So the law fails, and by the biconditional the sup-normed plane has no compatible inner product.",
+    "keyInsights": [
+      "**The parallelogram law is exactly the obstruction.** The biconditional makes precise that the law is not merely necessary but sufficient: it is the *single* identity separating inner-product norms from all other norms. Nothing else about the norm need be checked.",
+      "**Polarization is the inverse of the parallelogram law.** The forward direction discards the inner product to a norm identity; `ofNorm` runs the computation backwards, reconstructing ⟪·,·⟫ from ‖·‖ alone — the two are information-equivalent.",
+      "**Existence is the right phrasing of the converse.** Because the recovered inner product is *defined by* the norm, the converse is naturally a statement about `Nonempty (InnerProductSpace 𝕜 E)` — the existence of some compatible inner-product structure — rather than about a pre-chosen one.",
+      "**Sharpness needs a witness, not a slogan.** A characterization theorem is only meaningful if its hypothesis can fail. The explicit ℓ^∞ counterexample on ℝ×ℝ turns 'the law characterizes inner-product norms' into a verified separation: a concrete finite-dimensional Banach space that is provably not a Hilbert space.",
+      "**The sup norm fails at the unit vectors.** The cleanest failure of the parallelogram law for ℓ^∞ is already visible on the standard basis: max-norm makes both diagonals length 1, collapsing the left side to 2 while the right side stays at 4."
+    ],
+    "prerequisites": [
+      "Inner product spaces and normed spaces (InnerProductSpace 𝕜 E, NormedSpace 𝕜 E in Mathlib, 𝕜 = ℝ or ℂ)",
+      "The parallelogram law (parent entry cauchy-schwarz-oq-07)",
+      "The polarization identity recovering ⟪·,·⟫ from ‖·‖",
+      "The product (supremum) norm on E × F"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring stating the converse open question, the role of Mathlib's InnerProductSpace.ofNorm, and the plan to add a sharp ℓ^∞ counterexample. Mathlib import and the CauchySchwarzOQ07OQ01 namespace.",
+      "mathContext": "Work over 𝕜 ∈ {ℝ, ℂ} with `[RCLike 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]`; the parallelogram law is the hypothesis, an inner product the conclusion."
+    },
+    {
+      "id": "characterization",
+      "title": "The Jordan–von Neumann Biconditional",
+      "startLine": 37,
+      "endLine": 80,
+      "summary": "nonempty_innerProductSpace_iff_parallelogram packages forward (parallelogram_law_with_norm) and converse (InnerProductSpace.ofNorm) into one biconditional; nonempty_innerProductSpace_iff_parallelogram_sq restates it in squared form; ofNorm_norm_sq_eq_re_inner confirms the recovered inner product reproduces the norm.",
+      "mathContext": "$\\exists$ compatible inner product $\\iff \\forall x,y,\\ \\|x+y\\|^2 + \\|x-y\\|^2 = 2\\|x\\|^2 + 2\\|y\\|^2$, with $\\|x\\|^2 = \\operatorname{re}\\langle x,x\\rangle$ for the recovered product."
+    },
+    {
+      "id": "counterexample",
+      "title": "Sharpness: the Sup-Normed Plane",
+      "startLine": 82,
+      "endLine": 105,
+      "summary": "supNorm_not_parallelogram proves the supremum norm on ℝ×ℝ violates the parallelogram law at (1,0),(0,1); no_innerProductSpace_sup_norm concludes via the biconditional that ℝ×ℝ with the ℓ^∞ norm admits no compatible inner product.",
+      "mathContext": "For $x=(1,0),\\,y=(0,1)$ with the sup norm: $\\|x\\pm y\\| = 1$, so LHS $= 2 \\ne 4 =$ RHS; hence no inner product induces the $\\ell^\\infty$ norm on $\\mathbb{R}^2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "cauchy-schwarz-oq-07",
+      "relationship": "extends",
+      "description": "The parent proves the forward direction (inner-product norm ⇒ parallelogram law); this entry adds the converse (parallelogram law ⇒ inner product), completing the Jordan–von Neumann characterization, and lists it as openQuestions[0]"
+    },
+    {
+      "proofId": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "Cauchy–Schwarz holds in any inner-product space; the converse here certifies exactly which normed spaces admit such an inner product in the first place"
+    },
+    {
+      "proofId": "triangle-inequality",
+      "relationship": "related",
+      "description": "Every normed space satisfies the triangle inequality; the parallelogram law is the further equality that singles out the inner-product (Hilbert) norms among them, as the ℓ^∞ counterexample shows"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the Jordan–von Neumann converse, packaged as the biconditional ‘a compatible inner product exists ⇔ the parallelogram law holds’ (both *self and squared forms), with the recovered inner product shown to reproduce the norm, and a sharp counterexample proving the supremum norm on ℝ×ℝ admits no compatible inner product.",
+    "implications": "Together with the parent's forward direction, this gives the full Jordan–von Neumann characterization of inner-product norms. The ℓ^∞ counterexample on ℝ×ℝ certifies the criterion is sharp: it exhibits a concrete finite-dimensional Banach space that is not a Hilbert space, so the parallelogram law is a genuine, decidable test for Hilbert-space structure.",
+    "openQuestions": [
+      "Extend the counterexample to ℓ^p on ℝ×ℝ for p ≠ 2, computing the parallelogram defect as a function of p and identifying p = 2 as the unique Hilbert case.",
+      "Formalize the quantitative (stability) version: bound how far a norm with small parallelogram defect is from an inner-product norm."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Jordan, Pascual; von Neumann, John",
+      "title": "On Inner Products in Linear, Metric Spaces",
+      "year": "1935",
+      "venue": "Annals of Mathematics, vol. 36, no. 3, pp. 719–723",
+      "note": "Proves the converse: a norm satisfying the parallelogram law is induced by an inner product, recovered by polarization"
+    },
+    {
+      "authors": "Conway, John B.",
+      "title": "A Course in Functional Analysis",
+      "year": "1990",
+      "venue": "Springer, Graduate Texts in Mathematics 96 (2nd edition)",
+      "note": "Chapter I: the parallelogram law, the polarization identity, and the characterization of inner-product spaces"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **cauchy-schwarz-oq-07-oq-01**, the converse direction of the parent parallelogram-law entry: the full **Jordan–von Neumann (1935) characterization** of inner-product norms, packaged as a biconditional.

> A real or complex normed space `E` carries a compatible inner product **iff** its norm satisfies the parallelogram law `‖x+y‖² + ‖x−y‖² = 2‖x‖² + 2‖y‖²`.

- **Forward (⇒):** Mathlib's `parallelogram_law_with_norm`.
- **Converse (⇐):** Mathlib's polarization construction `InnerProductSpace.ofNorm` (Fréchet–von Neumann–Jordan), which rebuilds `⟪·,·⟫` from `‖·‖` and discharges all inner-product axioms.

The biconditional is phrased as `Nonempty (InnerProductSpace 𝕜 E)` — the existence of *some* compatible inner product — which is the natural statement since the recovered product is *defined by* the norm.

## Theorems (5, 0 sorries, 0 axioms)

1. `nonempty_innerProductSpace_iff_parallelogram` — the biconditional (`*self` form)
2. `nonempty_innerProductSpace_iff_parallelogram_sq` — restated in the parent's squared `^2` form
3. `ofNorm_norm_sq_eq_re_inner` — the recovered inner product reproduces the norm (`‖x‖² = re⟪x,x⟫`)
4. `supNorm_not_parallelogram` — the sup norm on `ℝ×ℝ` fails the law at `(1,0),(0,1)` (LHS 2 ≠ 4 RHS)
5. `no_innerProductSpace_sup_norm` — hence the `ℓ^∞` plane admits **no** compatible inner product

Theorems 4–5 prove the characterization is **sharp**: a concrete finite-dimensional Banach space that is provably not a Hilbert space.

## Verification

Build infra (Docker) is down, so verified **offline**:
- `lake env lean Proofs/CauchySchwarzOQ07OQ01.lean` → exit 0, no errors/warnings.
- `#print axioms` on all 5 theorems → `[propext, Classical.choice, Quot.sound]` only. No `sorryAx`, no `Lean.ofReduceBool`. Genuinely **0-axiom**.

`status: verified`, `badge: mathlib`. Gallery entry (meta.json + annotations.json) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)