### PR TITLE
Enrich Every Prime Power is Deficient (perfect-numbers-oq-05)

### DIFF
--- a/src/data/proofs/perfect-numbers-oq-05/annotations.json
+++ b/src/data/proofs/perfect-numbers-oq-05/annotations.json
@@ -8,7 +8,11 @@
       "endLine": 47
     },
     "title": "Module Header: Prime Powers and the Deficiency Classification",
-    "content": "A positive integer $n$ is **deficient** when $\\sigma(n) < 2n$, equivalently when its proper divisors sum to strictly less than $n$. This classification (deficient / perfect / abundant) goes back to Nicomachus of Gerasa (c. 100 AD).\n\nPrime powers are the simplest infinite family of deficient numbers. The divisors of $p^k$ are exactly $1, p, p^2, \\dots, p^k$, so\n$$\\sigma(p^k) = 1 + p + \\cdots + p^k = \\frac{p^{k+1}-1}{p-1},$$\nwhich is always *just short* of $2p^k$. The deficiency is the elementary geometric fact that the lower tail $1 + p + \\cdots + p^{k-1}$ is strictly smaller than the single top term $p^k$ (for $p \\ge 2$):\n$$\\sigma(p^k) = \\underbrace{(1 + p + \\cdots + p^{k-1})}_{< \\,p^k} + p^k < p^k + p^k = 2p^k.$$\n\n**What was missing.** The existing gallery family had only the $k=1$ case (`prime_is_deficient`), the closed-form sum (`sigma_prime_pow`), and a few *specific* deficient numbers proved by `native_decide` (which trusts the compiler, `Lean.ofReduceBool`). This file supplies the **general, all-$k$ theorem** with a uniform geometric-series proof, fully kernel-checked with **0 axioms**."
+    "content": "A positive integer $n$ is **deficient** when $\\sigma(n) < 2n$, equivalently when its proper divisors sum to strictly less than $n$. This classification (deficient / perfect / abundant) goes back to Nicomachus of Gerasa (c. 100 AD).\n\nPrime powers are the simplest infinite family of deficient numbers. The divisors of $p^k$ are exactly $1, p, p^2, \\dots, p^k$, so\n$$\\sigma(p^k) = 1 + p + \\cdots + p^k = \\frac{p^{k+1}-1}{p-1},$$\nwhich is always *just short* of $2p^k$. The deficiency is the elementary geometric fact that the lower tail $1 + p + \\cdots + p^{k-1}$ is strictly smaller than the single top term $p^k$ (for $p \\ge 2$):\n$$\\sigma(p^k) = \\underbrace{(1 + p + \\cdots + p^{k-1})}_{< \\,p^k} + p^k < p^k + p^k = 2p^k.$$\n\n**What was missing.** The existing gallery family had only the $k=1$ case (`prime_is_deficient`), the closed-form sum (`sigma_prime_pow`), and a few *specific* deficient numbers proved by `native_decide` (which trusts the compiler, `Lean.ofReduceBool`). This file supplies the **general, all-$k$ theorem** with a uniform geometric-series proof, fully kernel-checked with **0 axioms**.",
+    "mathContext": "$\\sigma(p^k) = \\dfrac{p^{k+1}-1}{p-1} < 2p^k$ for every prime $p$ and every $k \\ge 0$",
+    "significance": "context",
+    "relatedConcepts": ["deficient number", "sum-of-divisors function σ", "prime power", "Nicomachus classification"],
+    "prerequisites": ["divisor function", "geometric series", "number theory"]
   },
   {
     "id": "perfect-numbers-oq-05-geomsum",
@@ -19,7 +23,11 @@
       "endLine": 63
     },
     "title": "The Geometric Heart: Lower Tail Below the Top Term",
-    "content": "`geomSum_prime_pow_lt`: for a prime $p$ and any $k$, $\\sum_{j < k} p^j < p^k$.\n\nThis is the engine of every deficiency statement in the file. It is a one-line instance of Mathlib's **`Nat.geomSum_lt`**:\n$$2 \\le m \\;\\land\\; (\\forall j \\in s,\\ j < n) \\;\\Rightarrow\\; \\sum_{j \\in s} m^j < m^n.$$\nHere $m = p$ (with $p \\ge 2$ from `hp.two_le`), $s = \\mathrm{range}\\,k$, and $n = k$; every index $j \\in \\mathrm{range}\\,k$ satisfies $j < k$ by `Finset.mem_range`. Internally `Nat.geomSum_lt` routes through the closed form $(p^k-1)/(p-1)$ and the bound $(p^k-1)/(p-1) \\le p^k - 1 < p^k$.\n\nThe inequality is strict and uniform in $k$ — no case analysis, no computation."
+    "content": "`geomSum_prime_pow_lt`: for a prime $p$ and any $k$, $\\sum_{j < k} p^j < p^k$.\n\nThis is the engine of every deficiency statement in the file. It is a one-line instance of Mathlib's **`Nat.geomSum_lt`**:\n$$2 \\le m \\;\\land\\; (\\forall j \\in s,\\ j < n) \\;\\Rightarrow\\; \\sum_{j \\in s} m^j < m^n.$$\nHere $m = p$ (with $p \\ge 2$ from `hp.two_le`), $s = \\mathrm{range}\\,k$, and $n = k$; every index $j \\in \\mathrm{range}\\,k$ satisfies $j < k$ by `Finset.mem_range`. Internally `Nat.geomSum_lt` routes through the closed form $(p^k-1)/(p-1)$ and the bound $(p^k-1)/(p-1) \\le p^k - 1 < p^k$.\n\nThe inequality is strict and uniform in $k$ — no case analysis, no computation.",
+    "mathContext": "$\\sum_{j=0}^{k-1} p^j < p^k \\quad (p \\ge 2)$",
+    "significance": "key",
+    "relatedConcepts": ["geometric series bound", "Nat.geomSum_lt", "strict inequality", "doubling"],
+    "prerequisites": ["finite geometric sum", "Finset.range"]
   },
   {
     "id": "perfect-numbers-oq-05-sigma-form",
@@ -30,7 +38,11 @@
       "endLine": 78
     },
     "title": "Sum-of-Divisors Form: σ(pᵏ) < 2·pᵏ",
-    "content": "`sigma_one_prime_pow_lt`: $\\sigma(p^k) < 2p^k$ for prime $p$ and any $k$.\n\n**Proof.** Rewrite $\\sigma(p^k)$ with Mathlib's `sigma_one_apply_prime_pow` to $\\sum_{j \\in \\mathrm{range}(k+1)} p^j$, then peel the top term $p^k$ with `Finset.sum_range_succ`, leaving the lower tail $\\sum_{j \\in \\mathrm{range}\\,k} p^j$. The geometric heart bounds that tail by $p^k$, and `omega` closes\n$$(\\text{lower tail}) + p^k < 2p^k \\quad\\text{from}\\quad (\\text{lower tail}) < p^k.$$\nNo `native_decide`: the bound is derived, so the result is kernel-checked with 0 axioms."
+    "content": "`sigma_one_prime_pow_lt`: $\\sigma(p^k) < 2p^k$ for prime $p$ and any $k$.\n\n**Proof.** Rewrite $\\sigma(p^k)$ with Mathlib's `sigma_one_apply_prime_pow` to $\\sum_{j \\in \\mathrm{range}(k+1)} p^j$, then peel the top term $p^k$ with `Finset.sum_range_succ`, leaving the lower tail $\\sum_{j \\in \\mathrm{range}\\,k} p^j$. The geometric heart bounds that tail by $p^k$, and `omega` closes\n$$(\\text{lower tail}) + p^k < 2p^k \\quad\\text{from}\\quad (\\text{lower tail}) < p^k.$$\nNo `native_decide`: the bound is derived, so the result is kernel-checked with 0 axioms.",
+    "mathContext": "$\\sigma(p^k) = \\Big(\\sum_{j<k} p^j\\Big) + p^k < p^k + p^k = 2p^k$",
+    "significance": "key",
+    "relatedConcepts": ["sigma_one_apply_prime_pow", "Finset.sum_range_succ", "top-term peeling", "omega"],
+    "prerequisites": ["σ on prime powers", "the geometric heart"]
   },
   {
     "id": "perfect-numbers-oq-05-proper-divisors",
@@ -41,7 +53,11 @@
       "endLine": 88
     },
     "title": "Proper-Divisor Form: The Parts Are Smaller Than the Whole",
-    "content": "`sum_properDivisors_pow_lt`: the proper divisors of $p^k$ — namely $1, p, \\dots, p^{k-1}$ — sum to strictly less than $p^k$.\n\nThis is the most concrete face of deficiency: a number exceeds the sum of its own proper divisors. The proof rewrites the proper-divisor sum with `Nat.sum_properDivisors_prime_pow` (which identifies $\\sum_{d \\mid p^k,\\, d < p^k} d = \\sum_{j \\in \\mathrm{range}\\,k} p^j$) and applies the geometric heart directly."
+    "content": "`sum_properDivisors_pow_lt`: the proper divisors of $p^k$ — namely $1, p, \\dots, p^{k-1}$ — sum to strictly less than $p^k$.\n\nThis is the most concrete face of deficiency: a number exceeds the sum of its own proper divisors. The proof rewrites the proper-divisor sum with `Nat.sum_properDivisors_prime_pow` (which identifies $\\sum_{d \\mid p^k,\\, d < p^k} d = \\sum_{j \\in \\mathrm{range}\\,k} p^j$) and applies the geometric heart directly.",
+    "mathContext": "$\\sum_{\\substack{d \\mid p^k \\\\ d < p^k}} d = \\sum_{j<k} p^j < p^k$",
+    "significance": "supporting",
+    "relatedConcepts": ["proper divisors", "Nat.sum_properDivisors_prime_pow", "aliquot sum", "deficiency"],
+    "prerequisites": ["proper-divisor sum", "the geometric heart"]
   },
   {
     "id": "perfect-numbers-oq-05-headline",
@@ -52,7 +68,11 @@
       "endLine": 108
     },
     "title": "Headline: Every Prime Power is Deficient",
-    "content": "`IsDeficient n := σ(n) < 2n` (identical to `SumOfDivisors.IsDeficient`, restated for self-containment).\n\n`prime_pow_is_deficient`: for every prime $p$ and every $k$, `IsDeficient (p^k)` — definitionally the $\\sigma$-form. This single statement captures the entire infinite family $\\{p^k\\}$ at once.\n\n`isDeficient_iff_sum_properDivisors_lt` bridges the two standard definitions of deficiency — $\\sigma(n) < 2n$ versus proper divisors summing below $n$ — via `Nat.sum_divisors_eq_sum_properDivisors_add_self` and `omega`, holding for all $n$ (including $n = 0$)."
+    "content": "`IsDeficient n := σ(n) < 2n` (identical to `SumOfDivisors.IsDeficient`, restated for self-containment).\n\n`prime_pow_is_deficient`: for every prime $p$ and every $k$, `IsDeficient (p^k)` — definitionally the $\\sigma$-form. This single statement captures the entire infinite family $\\{p^k\\}$ at once.\n\n`isDeficient_iff_sum_properDivisors_lt` bridges the two standard definitions of deficiency — $\\sigma(n) < 2n$ versus proper divisors summing below $n$ — via `Nat.sum_divisors_eq_sum_properDivisors_add_self` and `omega`, holding for all $n$ (including $n = 0$).",
+    "mathContext": "$\\forall\\, p\\ \\text{prime},\\ \\forall k:\\ \\mathrm{IsDeficient}(p^k);\\quad \\mathrm{IsDeficient}(n) \\iff \\sum_{d\\mid n, d<n} d < n$",
+    "significance": "key",
+    "relatedConcepts": ["IsDeficient predicate", "infinite family", "equivalent definitions", "Nat.sum_divisors_eq_sum_properDivisors_add_self"],
+    "prerequisites": ["deficiency definitions", "the σ-form and proper-divisor form"]
   },
   {
     "id": "perfect-numbers-oq-05-corollaries",
@@ -63,6 +83,10 @@
       "endLine": 142
     },
     "title": "Corollaries: k = 1 and Concrete Instances Without native_decide",
-    "content": "`prime_is_deficient`: the classical $k=1$ case ($\\sigma(p) = p + 1 < 2p$), recovered as a one-line corollary (`simpa` with `pow_one`).\n\nThe concrete instances $8 = 2^3$, $16 = 2^4$, $9 = 3^2$, $81 = 3^4$, $2187 = 3^7$ are each a **substitution into the general theorem** — `prime_pow_is_deficient 2 3 (by norm_num)`, etc. The existing family proved analogous instances by `native_decide` (trusting the compiler via `Lean.ofReduceBool`); here the same numbers are certified by a uniform argument, so every named instance is kernel-checked with **0 axioms**."
+    "content": "`prime_is_deficient`: the classical $k=1$ case ($\\sigma(p) = p + 1 < 2p$), recovered as a one-line corollary (`simpa` with `pow_one`).\n\nThe concrete instances $8 = 2^3$, $16 = 2^4$, $9 = 3^2$, $81 = 3^4$, $2187 = 3^7$ are each a **substitution into the general theorem** — `prime_pow_is_deficient 2 3 (by norm_num)`, etc. The existing family proved analogous instances by `native_decide` (trusting the compiler via `Lean.ofReduceBool`); here the same numbers are certified by a uniform argument, so every named instance is kernel-checked with **0 axioms**.",
+    "mathContext": "$\\sigma(p) = p+1 < 2p;\\quad 8=2^3,\\ 16=2^4,\\ 9=3^2,\\ 81=3^4,\\ 2187=3^7\\ \\text{all deficient by substitution}$",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "kernel-checked vs native_decide", "Lean.ofReduceBool avoidance", "concrete instances"],
+    "prerequisites": ["the headline theorem", "pow_one"]
   }
 ]

--- a/src/data/proofs/perfect-numbers-oq-05/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-05/meta.json
@@ -56,6 +56,50 @@
       "Definition of deficiency IsDeficient n := σ₁(n) < 2n (matching SumOfDivisors.IsDeficient)"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Prime powers and the deficiency classification",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Docstring: deficient/perfect/abundant classification (Nicomachus), σ(pᵏ) = (p^{k+1}−1)/(p−1) < 2pᵏ, and what was missing — the general all-k theorem with a uniform geometric proof replacing per-instance native_decide."
+    },
+    {
+      "id": "geometric-heart",
+      "title": "The geometric heart: lower tail below the top term",
+      "startLine": 53,
+      "endLine": 63,
+      "summary": "geomSum_prime_pow_lt: Σ_{j<k} pʲ < pᵏ for prime p, a one-line instance of Mathlib's Nat.geomSum_lt — the engine of every deficiency statement, strict and uniform in k."
+    },
+    {
+      "id": "sigma-form",
+      "title": "Sum-of-divisors form: σ(pᵏ) < 2·pᵏ",
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "sigma_one_prime_pow_lt: rewrite σ(pᵏ) = Σ_{j∈range(k+1)} pʲ, peel the top term pᵏ via sum_range_succ, bound the tail by the geometric heart, and close with omega — kernel-checked, no native_decide."
+    },
+    {
+      "id": "proper-divisor-form",
+      "title": "Proper-divisor form: parts smaller than the whole",
+      "startLine": 80,
+      "endLine": 88,
+      "summary": "sum_properDivisors_pow_lt: the proper divisors 1, p, …, p^{k-1} of pᵏ sum to less than pᵏ, via Nat.sum_properDivisors_prime_pow plus the geometric heart — the most concrete face of deficiency."
+    },
+    {
+      "id": "headline",
+      "title": "Headline: every prime power is deficient",
+      "startLine": 90,
+      "endLine": 108,
+      "summary": "IsDeficient n := σ(n) < 2n; prime_pow_is_deficient captures the whole infinite family {pᵏ} at once; isDeficient_iff_sum_properDivisors_lt bridges the σ-form and proper-divisor definitions for all n."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: k = 1 and concrete instances",
+      "startLine": 110,
+      "endLine": 142,
+      "summary": "prime_is_deficient recovers the classical k=1 case; 8, 16, 9, 81, 2187 are each a substitution into the general theorem — the same numbers the existing family proved by native_decide, now certified with 0 axioms."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "perfect-numbers",


### PR DESCRIPTION
Enrichment pass for `perfect-numbers-oq-05`.

The entry had a complete `overview`/`conclusion` but its 6 annotations carried only `content`, and `sections` was empty.

## Changes
- **annotations.json**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all 6 annotations — the geometric heart (Σ_{j<k} pʲ < pᵏ), the σ-form, the proper-divisor form, the headline IsDeficient(pᵏ), and the k=1 / concrete-instance corollaries.
- **meta.json**: added a `sections` array (6 entries) covering the full 145-line Lean file.

Existing content preserved; status/badge/axiomCount unchanged. `pnpm build` passes.