### PR TITLE
research(hilbert-22-oq-01-oq-03): universal property + vanishing criterion for the Kobayashi chain pseudometric

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3283,6 +3283,7 @@ import Proofs.Hilbert20OQ01OQ03Aristotle
 import Proofs.Hilbert21RiemannHilbert
 import Proofs.Hilbert22OQ01
 import Proofs.Hilbert22OQ01OQ03
+import Proofs.Hilbert22OQ01OQ03Universal
 import Proofs.Hilbert22Uniformization
 import Proofs.Hilbert23CalculusVariations
 import Proofs.Hilbert23CalculusVariationsOQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3284,6 +3284,7 @@ import Proofs.Hilbert21RiemannHilbert
 import Proofs.Hilbert22OQ01
 import Proofs.Hilbert22OQ01OQ03
 import Proofs.Hilbert22OQ01OQ03Universal
+import Proofs.Hilbert22OQ01OQ03Pseudohyperbolic
 import Proofs.Hilbert22Uniformization
 import Proofs.Hilbert23CalculusVariations
 import Proofs.Hilbert23CalculusVariationsOQ01

--- a/proofs/Proofs/Hilbert22OQ01OQ03Pseudohyperbolic.lean
+++ b/proofs/Proofs/Hilbert22OQ01OQ03Pseudohyperbolic.lean
@@ -1,0 +1,157 @@
+/-
+# Hilbert 22 (OQ-01-OQ-03) — Blaschke automorphisms and the pseudohyperbolic gauge
+
+The algebraic backbone of the Schwarz–Pick / Kobayashi program on the unit disk
+(Item 3 of the `hilbert-22-oq-01-oq-03` decomposition).
+
+This file is deliberately **elementary**: it works with raw complex numbers under
+the hypothesis `‖·‖ < 1` and uses only field algebra over `ℂ` (no holomorphy, no
+special functions such as `arctanh`).  Mathlib provides the unit-disc *type*
+(`Complex.UnitDisc`) but no Blaschke automorphism, no pseudohyperbolic distance,
+and no Schwarz–Pick lemma — this file supplies the foundational identities that
+those results are built from.
+
+Main results:
+
+* `blaschke a z = (z - a) / (1 - conj a * z)` — the disk automorphism sending `a ↦ 0`.
+* `normSq_oneSubConjMul_sub_normSq_sub` — the Pythagorean identity
+  `|1 - ā z|² - |z - a|² = (1 - |a|²)(1 - |z|²)`, the engine of the whole theory.
+* `normSq_blaschke_lt_one` / `psh_lt_one` — Blaschke factors map the disk into itself.
+* `blaschke_eq_zero_iff`, `psh_self`, `psh_eq_zero_iff`, `psh_comm` — the
+  pseudohyperbolic gauge `psh z w = ‖blaschke w z‖` is a symmetric, nonnegative
+  separating gauge taking values in `[0, 1)`.  (It is *not* a metric — the genuine
+  Poincaré metric is `arctanh ∘ psh`; that requires `arctanh`, absent from Mathlib.)
+* `psh_schwarzPick_center` — the center-fixing case of Schwarz–Pick, obtained by
+  specialising Mathlib's center-fixing Schwarz lemma; the general two-point form
+  reduces to this by Blaschke conjugation, whose algebraic core is the identities above.
+
+These connect to the abstract Kobayashi chain pseudometric of `Hilbert22OQ01OQ03.lean`:
+`psh` (after `arctanh`) is the atomic cost whose chain infimum is the Kobayashi metric.
+-/
+import Mathlib
+
+open Complex Metric Set
+open scoped ComplexConjugate
+
+namespace Hilbert22OQ01OQ03
+
+/-- The **Blaschke automorphism** of the unit disk that sends `a` to `0`:
+`φ_a(z) = (z - a) / (1 - ā z)`. -/
+noncomputable def blaschke (a z : ℂ) : ℂ := (z - a) / (1 - conj a * z)
+
+/-- On the unit disk the Blaschke denominator is nonzero:
+`1 - ā z ≠ 0` whenever `‖a‖ < 1` and `‖z‖ < 1`. -/
+lemma oneSubConjMul_ne_zero {a z : ℂ} (ha : ‖a‖ < 1) (hz : ‖z‖ < 1) :
+    1 - conj a * z ≠ 0 := by
+  have hw : ‖conj a * z‖ < 1 := by
+    rw [norm_mul, Complex.norm_conj]
+    calc ‖a‖ * ‖z‖ ≤ 1 * ‖z‖ := mul_le_mul_of_nonneg_right ha.le (norm_nonneg z)
+      _ = ‖z‖ := one_mul _
+      _ < 1 := hz
+  intro hcontra
+  have h1 : (1 : ℂ) = conj a * z := sub_eq_zero.mp hcontra
+  rw [← h1, norm_one] at hw
+  exact lt_irrefl 1 hw
+
+/-- **Pythagorean (Schwarz–Pick) identity.** The numerator gap controlling
+`1 - |φ_a(z)|²`:
+`|1 - ā z|² - |z - a|² = (1 - |a|²)(1 - |z|²)`.
+Pure real-polynomial algebra in the real and imaginary parts. -/
+lemma normSq_oneSubConjMul_sub_normSq_sub (a z : ℂ) :
+    normSq (1 - conj a * z) - normSq (z - a)
+      = (1 - normSq a) * (1 - normSq z) := by
+  simp only [normSq_apply, Complex.sub_re, Complex.sub_im, Complex.mul_re,
+    Complex.mul_im, Complex.conj_re, Complex.conj_im, Complex.one_re, Complex.one_im]
+  ring
+
+/-- `|1 - w̄ z|² = |1 - z̄ w|²`: the Blaschke denominator is norm-symmetric. -/
+lemma normSq_oneSubConjMul_comm (z w : ℂ) :
+    normSq (1 - conj w * z) = normSq (1 - conj z * w) := by
+  simp only [normSq_apply, Complex.sub_re, Complex.sub_im, Complex.mul_re,
+    Complex.mul_im, Complex.conj_re, Complex.conj_im, Complex.one_re, Complex.one_im]
+  ring
+
+/-- A Blaschke factor maps the open unit disk into itself: `|φ_a(z)|² < 1`. -/
+lemma normSq_blaschke_lt_one {a z : ℂ} (ha : ‖a‖ < 1) (hz : ‖z‖ < 1) :
+    normSq (blaschke a z) < 1 := by
+  have hden : (1 - conj a * z) ≠ 0 := oneSubConjMul_ne_zero ha hz
+  have hdenpos : 0 < normSq (1 - conj a * z) := normSq_pos.mpr hden
+  have hNa : normSq a < 1 := by
+    have h : ‖a‖ ^ 2 < 1 := by nlinarith [norm_nonneg a]
+    rwa [Complex.sq_norm] at h
+  have hNz : normSq z < 1 := by
+    have h : ‖z‖ ^ 2 < 1 := by nlinarith [norm_nonneg z]
+    rwa [Complex.sq_norm] at h
+  have key := normSq_oneSubConjMul_sub_normSq_sub a z
+  have hpos : 0 < (1 - normSq a) * (1 - normSq z) := mul_pos (by linarith) (by linarith)
+  have hlt : normSq (z - a) < normSq (1 - conj a * z) := by linarith
+  rw [blaschke, map_div₀, div_lt_one hdenpos]
+  exact hlt
+
+/-- A Blaschke factor vanishes exactly at its center: `φ_a(z) = 0 ↔ z = a`. -/
+lemma blaschke_eq_zero_iff {a z : ℂ} (ha : ‖a‖ < 1) (hz : ‖z‖ < 1) :
+    blaschke a z = 0 ↔ z = a := by
+  have hden : (1 - conj a * z) ≠ 0 := oneSubConjMul_ne_zero ha hz
+  rw [blaschke, div_eq_zero_iff]
+  constructor
+  · rintro (h | h)
+    · exact sub_eq_zero.mp h
+    · exact absurd h hden
+  · intro h; left; rw [h, sub_self]
+
+/-- `φ_a(a) = 0`. -/
+@[simp] lemma blaschke_self (a : ℂ) : blaschke a a = 0 := by
+  simp [blaschke]
+
+/-- `φ_0 = id`. -/
+@[simp] lemma blaschke_zero_left (z : ℂ) : blaschke 0 z = z := by
+  simp [blaschke]
+
+/-- The **pseudohyperbolic gauge** on the unit disk:
+`psh z w = |φ_w(z)| = |(z - w) / (1 - w̄ z)|`. -/
+noncomputable def psh (z w : ℂ) : ℝ := ‖blaschke w z‖
+
+lemma psh_nonneg (z w : ℂ) : 0 ≤ psh z w := norm_nonneg _
+
+@[simp] lemma psh_self (z : ℂ) : psh z z = 0 := by
+  simp [psh]
+
+/-- `psh z 0 = ‖z‖`: at the center the gauge is the Euclidean norm. -/
+@[simp] lemma psh_zero_right (z : ℂ) : psh z 0 = ‖z‖ := by
+  simp [psh]
+
+/-- The pseudohyperbolic gauge takes values strictly below `1` on the disk. -/
+lemma psh_lt_one {z w : ℂ} (hz : ‖z‖ < 1) (hw : ‖w‖ < 1) : psh z w < 1 := by
+  rw [psh]
+  have h := normSq_blaschke_lt_one hw hz
+  have h2 : ‖blaschke w z‖ ^ 2 < 1 := by rwa [Complex.sq_norm]
+  nlinarith [norm_nonneg (blaschke w z)]
+
+/-- The gauge separates points: `psh z w = 0 ↔ z = w`. -/
+lemma psh_eq_zero_iff {z w : ℂ} (hz : ‖z‖ < 1) (hw : ‖w‖ < 1) :
+    psh z w = 0 ↔ z = w := by
+  rw [psh, norm_eq_zero, blaschke_eq_zero_iff hw hz]
+
+/-- The gauge is symmetric: `psh z w = psh w z`. -/
+lemma psh_comm (z w : ℂ) : psh z w = psh w z := by
+  rw [psh, psh, blaschke, blaschke, norm_div, norm_div, norm_sub_rev,
+    Complex.norm_def (1 - conj w * z), Complex.norm_def (1 - conj z * w),
+    normSq_oneSubConjMul_comm]
+
+/-- **Schwarz–Pick, center case.** A holomorphic self-map of the unit disk fixing
+`0` is a pseudohyperbolic contraction toward the center:
+`psh (f z) 0 ≤ psh z 0`.
+
+This specialises Mathlib's center-fixing Schwarz lemma
+(`Complex.norm_le_norm_of_mapsTo_ball_self`).  The *general* two-point Schwarz–Pick
+`psh (f z) (f w) ≤ psh z w` reduces to this case by pre/post-composing with the
+Blaschke automorphisms `blaschke w` and `blaschke (f w)`, whose disk-preserving
+algebra is exactly `normSq_blaschke_lt_one` and `blaschke_eq_zero_iff` above. -/
+lemma psh_schwarzPick_center {f : ℂ → ℂ}
+    (hd : DifferentiableOn ℂ f (ball 0 1))
+    (hmaps : MapsTo f (ball 0 1) (ball 0 1)) (hf0 : f 0 = 0)
+    {z : ℂ} (hz : ‖z‖ < 1) : psh (f z) 0 ≤ psh z 0 := by
+  rw [psh_zero_right, psh_zero_right]
+  exact Complex.norm_le_norm_of_mapsTo_ball_self hd hmaps hf0 hz
+
+end Hilbert22OQ01OQ03

--- a/proofs/Proofs/Hilbert22OQ01OQ03Universal.lean
+++ b/proofs/Proofs/Hilbert22OQ01OQ03Universal.lean
@@ -1,0 +1,150 @@
+import Mathlib
+import Proofs.Hilbert22OQ01OQ03
+
+/-
+# Hilbert 22 — OQ-01-OQ-03 (continued): Universal property and the vanishing criterion
+
+## Research Problem: hilbert-22-oq-01-oq-03
+
+The companion file `Hilbert22OQ01OQ03.lean` builds the abstract Kobayashi chain
+pseudometric `chainDist c` from a symmetric atomic cost `c : X → X → ℝ≥0∞`
+vanishing on the diagonal, and proves it is a `PseudoEMetricSpace` that is
+functorial (distance-non-increasing under cost-contracting maps).
+
+This file proves the two structural facts that *characterize* that construction and
+that drive every concrete computation of a Kobayashi-type pseudometric — still in
+pure `ℝ≥0∞` order theory, with no complex analysis:
+
+* **Universal property.** `chainDist c` is the *greatest* subadditive (triangle-law)
+  cost dominated by the atomic cost `c`:
+    - `chainDist_le_cost`  : `chainDist c ≤ c`  (a single-edge chain), and
+    - `le_chainDist`       : every triangle-law `d` with `d ≤ c` satisfies
+                              `d ≤ chainDist c`.
+  Together these say `chainDist c = ⨆ { d | d subadditive, d ≤ c }`. This is the
+  abstract reason the Kobayashi pseudometric is the largest pseudometric for which
+  all holomorphic disks are non-expanding.
+
+* **Vanishing criterion.** `chainDist c p q = 0` as soon as `p` and `q` are joined
+  by arbitrarily cheap chains (`chainDist_eq_zero_of_forall`), with the handy
+  special cases `c p q = 0` and a one-vertex bridge. This is the order-theoretic
+  core of *non-hyperbolicity*: e.g. on `ℂ` the affine maps `z ↦ p + (q-p)z/δ`
+  push the disk Poincaré cost to `0`, so `d_ℂ ≡ 0`. Once the disk atomic cost is
+  in place, "ℂ is not Kobayashi hyperbolic" reduces to exhibiting such cheap chains
+  and applying `chainDist_eq_zero_of_forall`.
+
+No sorries, no axioms beyond Mathlib's foundations.
+
+Tags: complex-geometry, kobayashi-metric, hyperbolic-manifolds, pseudometric,
+universal-property, hilbert-problems
+-/
+
+namespace Hilbert22OQ01OQ03
+
+open scoped ENNReal
+
+variable {X : Type*}
+
+-- ============================================================
+-- Part V: Monotonicity of the chain cost in the atomic cost
+-- ============================================================
+
+/-- The cost of a fixed chain is monotone in the atomic cost: a pointwise-smaller
+atomic cost gives a smaller chain cost. (This is `chainCost_map` specialised to the
+identity map, but stated directly for clarity.) -/
+theorem chainCost_mono_cost (c₁ c₂ : X → X → ℝ≥0∞) (h : ∀ a b, c₁ a b ≤ c₂ a b)
+    (q : X) (mid : List X) : ∀ p, chainCost c₁ p mid q ≤ chainCost c₂ p mid q := by
+  induction mid with
+  | nil => intro p; simpa using h p q
+  | cons x xs ih =>
+      intro p
+      simp only [chainCost_cons]
+      exact add_le_add (h p x) (ih x)
+
+-- ============================================================
+-- Part VI: The universal property
+-- ============================================================
+
+/-- The chain pseudometric never exceeds the atomic cost: the single-edge chain
+`p ⇝ q` already realises cost `c p q`. -/
+theorem chainDist_le_cost (c : X → X → ℝ≥0∞) (p q : X) : chainDist c p q ≤ c p q := by
+  simpa using chainDist_le c p q []
+
+/-- **Telescoping.** Any `d` satisfying the triangle law is bounded by the
+`d`-cost of every chain: summing the triangle inequalities along the chain. -/
+theorem le_chainCost_of_triangle (d : X → X → ℝ≥0∞)
+    (htri : ∀ a b e, d a b ≤ d a e + d e b) (q : X) (mid : List X) :
+    ∀ p, d p q ≤ chainCost d p mid q := by
+  induction mid with
+  | nil => intro p; simp
+  | cons x xs ih =>
+      intro p
+      calc d p q ≤ d p x + d x q := htri p q x
+        _ ≤ d p x + chainCost d x xs q := add_le_add (le_refl (d p x)) (ih x)
+        _ = chainCost d p (x :: xs) q := by rw [chainCost_cons]
+
+/-- **Universal property (maximality).** `chainDist c` is the *greatest* triangle-law
+cost dominated by `c`: any `d` that satisfies the triangle inequality and is
+pointwise ≤ `c` is pointwise ≤ `chainDist c`. With `chainDist_le_cost`, this says
+`chainDist c` is the largest pseudometric-like cost below `c`. -/
+theorem le_chainDist (c d : X → X → ℝ≥0∞)
+    (htri : ∀ a b e, d a b ≤ d a e + d e b)
+    (hdom : ∀ a b, d a b ≤ c a b) (p q : X) :
+    d p q ≤ chainDist c p q := by
+  refine le_iInf fun mid => ?_
+  calc d p q ≤ chainCost d p mid q := le_chainCost_of_triangle d htri q mid p
+    _ ≤ chainCost c p mid q := chainCost_mono_cost d c hdom q mid p
+
+-- ============================================================
+-- Part VII: The vanishing criterion (abstract non-hyperbolicity)
+-- ============================================================
+
+/-- **Vanishing criterion.** If `p` and `q` can be joined by chains of arbitrarily
+small total cost, then the chain pseudometric between them is `0`. This is the
+order-theoretic core of non-hyperbolicity (e.g. `d_ℂ ≡ 0` via affine maps). -/
+theorem chainDist_eq_zero_of_forall (c : X → X → ℝ≥0∞) (p q : X)
+    (h : ∀ ε : ℝ≥0∞, 0 < ε → ∃ mid : List X, chainCost c p mid q ≤ ε) :
+    chainDist c p q = 0 := by
+  refine le_antisymm ?_ (zero_le _)
+  refine ENNReal.le_of_forall_pos_le_add fun ε hε _ => ?_
+  obtain ⟨mid, hmid⟩ := h (ε : ℝ≥0∞) (by exact_mod_cast hε)
+  calc chainDist c p q ≤ chainCost c p mid q := chainDist_le c p q mid
+    _ ≤ (ε : ℝ≥0∞) := hmid
+    _ = 0 + (ε : ℝ≥0∞) := (zero_add _).symm
+
+/-- If the atomic cost between `p` and `q` is already `0`, so is the chain
+pseudometric. -/
+theorem chainDist_eq_zero_of_cost_zero (c : X → X → ℝ≥0∞) (p q : X) (h : c p q = 0) :
+    chainDist c p q = 0 :=
+  le_antisymm (by simpa [h] using chainDist_le_cost c p q) (zero_le _)
+
+/-- A one-vertex bridge of zero cost forces the chain pseudometric to vanish:
+if `c p r = 0` and `c r q = 0`, then `chainDist c p q = 0`. -/
+theorem chainDist_eq_zero_of_bridge (c : X → X → ℝ≥0∞) (p r q : X)
+    (h1 : c p r = 0) (h2 : c r q = 0) : chainDist c p q = 0 := by
+  refine le_antisymm ?_ (zero_le _)
+  calc chainDist c p q ≤ chainCost c p [r] q := chainDist_le c p q [r]
+    _ = c p r + c r q := by simp [chainCost]
+    _ = 0 := by simp [h1, h2]
+
+/-
+## Summary
+
+Building on the abstract Kobayashi chain pseudometric of `Hilbert22OQ01OQ03.lean`,
+this file adds, in pure `ℝ≥0∞` order theory (0 axioms, 0 sorries):
+
+* `chainCost_mono_cost`  — the chain cost is monotone in the atomic cost.
+* `chainDist_le_cost`    — `chainDist c ≤ c`.
+* `le_chainCost_of_triangle`, `le_chainDist` — the **universal property**:
+  `chainDist c` is the greatest triangle-law cost dominated by `c`.
+* `chainDist_eq_zero_of_forall` and corollaries — the **vanishing criterion**, the
+  abstract heart of non-hyperbolicity (`d_ℂ ≡ 0`).
+
+Together with the parent file this completes the order-theoretic specification of
+the Kobayashi pseudometric: it is a functorial `PseudoEMetricSpace`, it is the
+largest pseudometric below the atomic cost, and it collapses precisely when cheap
+chains exist. The remaining ingredients (the unit-disk Poincaré metric, Schwarz–Pick,
+`d_𝔻 = ρ`, and Picard via the modular λ cover) are the genuinely analytic part and
+stay open, absent from Mathlib.
+-/
+
+end Hilbert22OQ01OQ03


### PR DESCRIPTION
## Summary

Continuation of the **abstract Kobayashi chain pseudometric** entry (Item 1, merged in #30079). Adds `Proofs/Hilbert22OQ01OQ03Universal.lean` — **7 theorems, 0 axioms, 0 sorries**, pure `ℝ≥0∞` order theory, no complex analysis — proving the two facts that *characterize* the construction.

### Universal property
`chainDist c` is the **greatest** triangle-law cost dominated by the atomic cost `c`:
- `chainDist_le_cost` : `chainDist c ≤ c` (single-edge chain);
- `le_chainCost_of_triangle` : a subadditive `d` is ≤ its `d`-cost on every chain (telescoping);
- `chainCost_mono_cost` : chain cost is monotone in the atomic cost;
- `le_chainDist` : any subadditive `d ≤ c` satisfies `d ≤ chainDist c`.

Together: `chainDist c = sup { d | d subadditive, d ≤ c }` — the abstract reason the Kobayashi pseudometric is the largest pseudometric for which every holomorphic disk is non-expanding.

### Vanishing criterion
`chainDist_eq_zero_of_forall` : if `p,q` are joined by arbitrarily cheap chains then `chainDist c p q = 0` (via `ENNReal.le_of_forall_pos_le_add`), with corollaries `chainDist_eq_zero_of_cost_zero` and `chainDist_eq_zero_of_bridge`. This is the **order-theoretic core of non-hyperbolicity** ($d_\mathbb{C} \equiv 0$): on ℂ the affine maps $z \mapsto p + (q-p)z/\delta$ make disk chains arbitrarily cheap.

## Decomposition progress

This delivers the **abstract core of Item 2** from the problem's research plan: the concrete $d_\mathbb{C} \equiv 0$ now reduces to defining the disk atomic cost and exhibiting cheap chains, then applying `chainDist_eq_zero_of_forall`. Item 3 (Schwarz–Pick via Blaschke) and Item 4 (Picard, modular λ) remain open as before. See the updated `research/problems/hilbert-22-oq-01-oq-03/knowledge.md` (Session 3).

## Verification

- **Compiles `EXIT 0`** (local `lake env lean` against Mathlib oleans).
- `#print axioms` on `le_chainDist`, `chainDist_eq_zero_of_forall`, `chainDist_le_cost` reports only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`**.
- Imports the merged Item-1 file; registered in `Proofs.lean`. Gallery entry updated with a companion section and refreshed conclusion/open-questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)