### PR TITLE
research(cauchy-schwarz-oq-01-oq-05-oq-01): defect as squared norm of the orthogonal residual

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -686,6 +686,7 @@ import Proofs.CauchySchwarzOQ01OQ02
 import Proofs.CauchySchwarzOQ01OQ03
 import Proofs.CauchySchwarzOQ01OQ04
 import Proofs.CauchySchwarzOQ01OQ04OQ04
+import Proofs.CauchySchwarzOQ01OQ05OQ01
 import Proofs.CauchySchwarzOQ02
 import Proofs.CauchySchwarzOQ02OQ01
 import Proofs.CauchySchwarzOQ02OQ02

--- a/proofs/Proofs/CauchySchwarzOQ01OQ05OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ05OQ01.lean
@@ -1,0 +1,193 @@
+/-
+The Cauchy-Schwarz defect as the squared norm of the orthogonal residual,
+connecting the algebraic Lagrange identity to Mathlib's `starProjection`
+(orthogonal projection) onto a single vector.
+
+Open Question (cauchy-schwarz-oq-01-oq-05-oq-01):
+"Can the Lagrange identity for the Cauchy-Schwarz defect be packaged as the
+squared norm of an *explicit orthogonal residual*, to connect with Mathlib's
+`orthogonalProjection`/`starProjection`?"
+
+Answer: YES. Let `P x y := (𝕜 ∙ x).starProjection y` be the orthogonal
+projection of `y` onto the line `𝕜 ∙ x`, and let the residual be
+
+    r := y − P x y                    (the component of y perpendicular to x).
+
+The parent problem (cauchy-schwarz-oq-01-oq-05) proves the *division-free*
+Gram identity for the scaled Gram vector `w := ⟪x,x⟫ • y − ⟪x,y⟫ • x`:
+
+    ‖w‖² = ‖x‖² · ( ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² ).                       (★)
+
+Here we show that this scaled Gram vector is exactly `⟪x,x⟫` times the
+residual,
+
+    w = ⟪x,x⟫ • r,                                                 (bridge)
+
+because Mathlib's `starProjection_singleton` gives `P x y = (⟪x,y⟫/‖x‖²) • x`,
+so `⟪x,x⟫ • P x y = ⟪x,y⟫ • x`. Substituting (bridge) into (★) and cancelling
+`‖x‖²` (for `x ≠ 0`) yields the clean residual form of the Cauchy-Schwarz
+defect:
+
+    ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖² · ‖r‖²       (defect = ‖x‖²·‖residual‖²).
+
+From this the inequality is immediate (`‖r‖² ≥ 0`), and equality holds iff the
+residual vanishes, i.e. iff `y` already lies on the line `𝕜 ∙ x`
+(`P x y = y`).
+
+This file formalizes:
+1. The residual `r = y − P x y` is orthogonal to `x`            (Mathlib API)
+2. The bridge identity `⟪x,x⟫ • y − ⟪x,y⟫ • x = ⟪x,x⟫ • r`
+3. The defect-as-residual identity `defect = ‖x‖²·‖r‖²`          (x ≠ 0)
+4. Cauchy-Schwarz recovered from nonnegativity of `‖r‖²`
+5. Equality characterization `‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ P x y = y`
+6. Specializations to ℝ and ℂ
+
+References:
+- Mathlib: starProjection_singleton, sub_starProjection_mem_orthogonal,
+  mem_orthogonal_singleton_iff_inner_right, inner_self_eq_norm_sq_to_K
+- Parent entry CauchySchwarzOQ01OQ05 (the division-free Lagrange identity ★)
+-/
+
+import Proofs.CauchySchwarzOQ01OQ05
+import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped InnerProductSpace
+open RCLike
+
+namespace CauchySchwarzOQ01OQ05OQ01
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-- The orthogonal projection of `y` onto the line `𝕜 ∙ x`. -/
+noncomputable def proj (x y : E) : E := (𝕜 ∙ x).starProjection y
+
+/-- The orthogonal residual: the component of `y` perpendicular to `x`. -/
+noncomputable def residual (x y : E) : E := y - proj (𝕜 := 𝕜) x y
+
+-- ============================================================
+-- PART I: The residual is orthogonal to x
+-- ============================================================
+
+/-- **Residual ⟂ x.** The residual `r = y − P x y` is orthogonal to `x`:
+`⟪x, r⟫ = 0`. This is the defining property of the orthogonal projection,
+specialised to the line `𝕜 ∙ x`. -/
+theorem inner_residual_right (x y : E) :
+    ⟪x, residual (𝕜 := 𝕜) x y⟫_𝕜 = 0 := by
+  have hr : residual (𝕜 := 𝕜) x y ∈ (𝕜 ∙ x)ᗮ :=
+    Submodule.sub_starProjection_mem_orthogonal (K := 𝕜 ∙ x) y
+  exact (Submodule.mem_orthogonal_singleton_iff_inner_right).mp hr
+
+/-- The explicit Mathlib formula for the projection onto a single vector. -/
+theorem proj_eq (x y : E) :
+    proj (𝕜 := 𝕜) x y = (⟪x, y⟫_𝕜 / ((‖x‖ ^ 2 : ℝ) : 𝕜)) • x :=
+  Submodule.starProjection_singleton 𝕜 y
+
+-- ============================================================
+-- PART II: The bridge — scaled Gram vector = ⟪x,x⟫ • residual
+-- ============================================================
+
+/-- **Bridge identity.** The scaled Gram vector of the parent problem is
+exactly `⟪x,x⟫` times the orthogonal residual:
+`⟪x,x⟫ • y − ⟪x,y⟫ • x = ⟪x,x⟫ • (y − P x y)`.
+
+This is what links the parent's *division-free* algebraic Lagrange identity to
+Mathlib's orthogonal-projection machinery: the only content is that
+`⟪x,x⟫ • P x y = ⟪x,y⟫ • x`, which holds because `P x y = (⟪x,y⟫/‖x‖²) • x`
+and `⟪x,x⟫ = (‖x‖² : 𝕜)`. Valid for all `x` (at `x = 0` both sides vanish). -/
+theorem gram_vector_eq_smul_residual (x y : E) :
+    ⟪x, x⟫_𝕜 • y - ⟪x, y⟫_𝕜 • x = ⟪x, x⟫_𝕜 • residual (𝕜 := 𝕜) x y := by
+  rw [residual, smul_sub, proj_eq, smul_smul, inner_self_eq_norm_sq_to_K]
+  rcases eq_or_ne x 0 with hx | hx
+  · subst hx; simp
+  · have hxn : ‖x‖ ≠ 0 := norm_ne_zero_iff.mpr hx
+    have hxK : ((‖x‖ ^ 2 : ℝ) : 𝕜) ≠ 0 := by
+      rw [Ne, RCLike.ofReal_eq_zero]; exact pow_ne_zero 2 hxn
+    rw [show ((‖x‖ : 𝕜) ^ 2) = ((‖x‖ ^ 2 : ℝ) : 𝕜) by push_cast; ring,
+        mul_div_cancel₀ _ hxK]
+
+-- ============================================================
+-- PART III: The defect as the squared norm of the residual
+-- ============================================================
+
+/-- **Defect = ‖x‖² · ‖residual‖².** The Cauchy-Schwarz defect equals `‖x‖²`
+times the squared norm of the orthogonal residual:
+`‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖² · ‖y − P x y‖²`.
+
+Proof: substitute the bridge identity into the parent's Lagrange identity (★),
+`‖w‖² = ‖x‖²·defect`, where `w = ⟪x,x⟫ • r`. Then
+`‖w‖² = ‖⟪x,x⟫‖²·‖r‖² = ‖x‖⁴·‖r‖²`, so `‖x‖²·defect = ‖x‖⁴·‖r‖²`; cancelling the
+positive factor `‖x‖²` (using `x ≠ 0`) gives the result. -/
+theorem defect_eq_norm_sq_residual (x y : E) (hx : x ≠ 0) :
+    ‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_𝕜‖ ^ 2
+      = ‖x‖ ^ 2 * ‖residual (𝕜 := 𝕜) x y‖ ^ 2 := by
+  have hlag := CauchySchwarzOQ01OQ05.gram_norm_sq (𝕜 := 𝕜) x y
+  rw [gram_vector_eq_smul_residual, norm_smul, mul_pow,
+      inner_self_eq_norm_sq_to_K, norm_pow, RCLike.norm_ofReal,
+      abs_of_nonneg (norm_nonneg x)] at hlag
+  -- hlag : (‖x‖^2)^2 * ‖r‖^2 = ‖x‖^2 * (‖x‖^2*‖y‖^2 - ‖⟪x,y⟫‖^2)
+  have hxpos : 0 < ‖x‖ ^ 2 := by
+    have : 0 < ‖x‖ := norm_pos_iff.mpr hx
+    positivity
+  nlinarith [hlag, hxpos]
+
+-- ============================================================
+-- PART IV: Cauchy-Schwarz and equality, from the residual
+-- ============================================================
+
+/-- **Cauchy-Schwarz from the residual.** Since `‖r‖² ≥ 0`, the residual form
+of the defect gives `‖⟪x,y⟫‖² ≤ ‖x‖²·‖y‖²` directly. -/
+theorem cauchy_schwarz_sq (x y : E) :
+    ‖⟪x, y⟫_𝕜‖ ^ 2 ≤ ‖x‖ ^ 2 * ‖y‖ ^ 2 := by
+  rcases eq_or_ne x 0 with hx | hx
+  · subst hx; simp
+  · have h := defect_eq_norm_sq_residual (𝕜 := 𝕜) x y hx
+    nlinarith [h, sq_nonneg ‖residual (𝕜 := 𝕜) x y‖, norm_nonneg x]
+
+/-- **Equality iff the residual vanishes.** For `x ≠ 0`, equality
+`‖⟪x,y⟫‖ = ‖x‖·‖y‖` holds **iff** the orthogonal projection recovers `y`,
+i.e. the residual is zero (`P x y = y`), i.e. `y ∈ 𝕜 ∙ x`. -/
+theorem eq_iff_proj_eq (x y : E) (hx : x ≠ 0) :
+    ‖⟪x, y⟫_𝕜‖ = ‖x‖ * ‖y‖ ↔ proj (𝕜 := 𝕜) x y = y := by
+  have hxpos : 0 < ‖x‖ ^ 2 := by
+    have : 0 < ‖x‖ := norm_pos_iff.mpr hx
+    positivity
+  have hdef := defect_eq_norm_sq_residual (𝕜 := 𝕜) x y hx
+  constructor
+  · intro h
+    have hsq : ‖⟪x, y⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2 * ‖y‖ ^ 2 := by rw [h, mul_pow]
+    have hr0 : ‖residual (𝕜 := 𝕜) x y‖ ^ 2 = 0 := by nlinarith [hdef, hsq, hxpos]
+    have : residual (𝕜 := 𝕜) x y = 0 := by
+      have := pow_eq_zero_iff (n := 2) (by norm_num) |>.mp hr0
+      exact norm_eq_zero.mp this
+    rw [residual, sub_eq_zero] at this
+    exact this.symm
+  · intro h
+    have hr0 : residual (𝕜 := 𝕜) x y = 0 := by rw [residual, h, sub_self]
+    rw [hr0, norm_zero] at hdef
+    have hsq : ‖⟪x, y⟫_𝕜‖ ^ 2 = (‖x‖ * ‖y‖) ^ 2 := by rw [mul_pow]; nlinarith [hdef]
+    have hb : (0 : ℝ) ≤ ‖x‖ * ‖y‖ := by positivity
+    nlinarith [hsq, norm_nonneg (⟪x, y⟫_𝕜), hb]
+
+-- ============================================================
+-- PART V: Specializations
+-- ============================================================
+
+/-- The defect-as-residual identity over a **real** inner product space. -/
+theorem defect_eq_norm_sq_residual_real
+    {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] (x y : F) (hx : x ≠ 0) :
+    ‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_ℝ‖ ^ 2
+      = ‖x‖ ^ 2 * ‖residual (𝕜 := ℝ) x y‖ ^ 2 :=
+  defect_eq_norm_sq_residual (𝕜 := ℝ) x y hx
+
+/-- The defect-as-residual identity over a **complex** inner product space. -/
+theorem defect_eq_norm_sq_residual_complex
+    {H : Type*} [NormedAddCommGroup H] [InnerProductSpace ℂ H] (x y : H) (hx : x ≠ 0) :
+    ‖x‖ ^ 2 * ‖y‖ ^ 2 - ‖⟪x, y⟫_ℂ‖ ^ 2
+      = ‖x‖ ^ 2 * ‖residual (𝕜 := ℂ) x y‖ ^ 2 :=
+  defect_eq_norm_sq_residual (𝕜 := ℂ) x y hx
+
+end CauchySchwarzOQ01OQ05OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-05-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-residual-orthogonal",
+    "proofId": "cauchy-schwarz-oq-01-oq-05-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 87
+    },
+    "type": "concept",
+    "title": "The Residual is Orthogonal to x",
+    "content": "The residual $r = y - P\\,x\\,y$ is defined via Mathlib's `starProjection` onto the line $\\mathbb{k}\\!\\cdot\\!x$. By `sub_starProjection_mem_orthogonal`, $r$ lies in the orthogonal complement $(\\mathbb{k}\\!\\cdot\\!x)^\\perp$; specialising the membership test `mem_orthogonal_singleton_iff_inner_right` then gives $\\langle x, r\\rangle = 0$. The companion lemma `proj_eq` records the explicit Mathlib formula $P\\,x\\,y = (\\langle x,y\\rangle/\\|x\\|^2)\\,x$ from `starProjection_singleton`.",
+    "mathContext": "$\\langle x,\\ y - P\\,x\\,y\\rangle = 0, \\qquad P\\,x\\,y = \\tfrac{\\langle x,y\\rangle}{\\|x\\|^2}\\,x$",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "orthogonal projection",
+      "orthogonal complement",
+      "starProjection_singleton"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "orthogonal projection onto a subspace"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "cauchy-schwarz-oq-01-oq-05-oq-01",
+    "range": {
+      "startLine": 101,
+      "endLine": 110
+    },
+    "type": "insight",
+    "title": "The Bridge: Scaled Gram Vector = ⟪x,x⟫ • Residual",
+    "content": "This is the heart of the entry and the explicit answer to the parent's open question. The scaled Gram vector $w = \\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x$ from the parent problem equals $\\langle x,x\\rangle$ times Mathlib's orthogonal residual: $w = \\langle x,x\\rangle\\,(y - P\\,x\\,y)$. After expanding with `smul_sub` and the projection formula, the only nontrivial fact is $\\langle x,x\\rangle\\,P\\,x\\,y = \\langle x,y\\rangle\\,x$, which holds because $\\langle x,x\\rangle = (\\|x\\|^2 : \\mathbb{k})$ (`inner_self_eq_norm_sq_to_K`) cancels the denominator via `mul_div_cancel₀`. The $x = 0$ case is closed by `simp` (both sides vanish), so the identity is valid for all $x$.",
+    "mathContext": "$\\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x = \\langle x,x\\rangle\\,(y - P\\,x\\,y)$",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "Gram vector",
+      "orthogonal projection",
+      "smul cancellation"
+    ],
+    "prerequisites": [
+      "scalar multiplication",
+      "field division"
+    ]
+  },
+  {
+    "id": "ann-defect-residual",
+    "proofId": "cauchy-schwarz-oq-01-oq-05-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 135
+    },
+    "type": "insight",
+    "title": "The Defect as the Squared Norm of the Residual",
+    "content": "Substituting the bridge identity into the parent's Lagrange identity (★) $\\|w\\|^2 = \\|x\\|^2 \\cdot \\text{defect}$ does the work. Since $w = \\langle x,x\\rangle\\,r$ and $\\|\\langle x,x\\rangle\\| = \\|x\\|^2$ (via `norm_smul`, `inner_self_eq_norm_sq_to_K`, `RCLike.norm_ofReal`), the left side becomes $\\|x\\|^4\\,\\|r\\|^2$. Thus $\\|x\\|^2\\cdot\\text{defect} = \\|x\\|^4\\|r\\|^2$, and cancelling the positive factor $\\|x\\|^2$ (for $x \\ne 0$, via `nlinarith`) yields $\\text{defect} = \\|x\\|^2\\|r\\|^2$. No fresh inner-product expansion is needed — the parent's verified identity is reused wholesale.",
+    "mathContext": "$\\|x\\|^2\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2 = \\|x\\|^2\\,\\|y - P\\,x\\,y\\|^2 \\quad (x \\ne 0)$",
+    "significance": "major",
+    "relatedConcepts": [
+      "Cauchy-Schwarz defect",
+      "orthogonal residual",
+      "Lagrange identity"
+    ],
+    "prerequisites": [
+      "norm of a scalar multiple",
+      "cancellation in ordered fields"
+    ]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "cauchy-schwarz-oq-01-oq-05-oq-01",
+    "range": {
+      "startLine": 143,
+      "endLine": 173
+    },
+    "type": "concept",
+    "title": "Cauchy-Schwarz and Equality, from the Residual",
+    "content": "The residual form makes both classical consequences immediate. Nonnegativity of $\\|r\\|^2$ gives $\\|\\langle x,y\\rangle\\|^2 \\le \\|x\\|^2\\|y\\|^2$ (the $x = 0$ case by `simp`). For equality, $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\|$ forces $\\|r\\|^2 = 0$, hence $r = 0$, i.e. $P\\,x\\,y = y$; conversely $P\\,x\\,y = y$ makes the defect vanish. Phrasing the equality case as 'the projection recovers $y$' ties the sharpness of Cauchy-Schwarz to the projection operator itself.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff P\\,x\\,y = y$",
+    "significance": "major",
+    "relatedConcepts": [
+      "Cauchy-Schwarz inequality",
+      "equality conditions",
+      "orthogonal projection"
+    ],
+    "prerequisites": [
+      "nonnegativity of squares",
+      "norm positive-definiteness"
+    ]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "cauchy-schwarz-oq-01-oq-05-oq-01",
+    "range": {
+      "startLine": 186,
+      "endLine": 191
+    },
+    "type": "concept",
+    "title": "Real and Complex Specializations",
+    "content": "Instantiating the RCLike field at $\\mathbb{k} = \\mathbb{R}$ and $\\mathbb{k} = \\mathbb{C}$ recovers the classical real and complex residual decompositions of the Cauchy-Schwarz defect as direct corollaries of the single uniform development.",
+    "mathContext": "$\\mathbb{k} \\in \\{\\mathbb{R}, \\mathbb{C}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "RCLike abstraction",
+      "real vs complex inner products"
+    ],
+    "prerequisites": [
+      "type class instantiation"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-05-oq-01/meta.json
@@ -1,0 +1,370 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-05-oq-01",
+  "title": "The Cauchy-Schwarz Defect as the Squared Norm of the Orthogonal Residual",
+  "slug": "cauchy-schwarz-oq-01-oq-05-oq-01",
+  "description": "Packages the parent's division-free Lagrange defect identity as the squared norm of an explicit orthogonal residual, connecting it to Mathlib's starProjection (orthogonal projection onto a line). The scaled Gram vector ⟪x,x⟫•y − ⟪x,y⟫•x equals ⟪x,x⟫ times the residual y − P x y, yielding the clean form ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖² (for x ≠ 0).",
+  "meta": {
+    "author": "Schwarz (1885); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality",
+    "date": "1885",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "linear-algebra",
+      "inner-product-spaces",
+      "orthogonal-projection",
+      "functional-analysis",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ05OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.starProjection_singleton",
+        "description": "Orthogonal projection onto a single vector: (𝕜 ∙ v).starProjection w = (⟪v,w⟫/‖v‖²) • v",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection.Basic"
+      },
+      {
+        "theorem": "Submodule.sub_starProjection_mem_orthogonal",
+        "description": "The residual v − P v lies in the orthogonal complement Kᗮ",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection.Basic"
+      },
+      {
+        "theorem": "Submodule.mem_orthogonal_singleton_iff_inner_right",
+        "description": "v ∈ (𝕜 ∙ u)ᗮ ↔ ⟪u,v⟫ = 0, the orthogonality test against a line",
+        "module": "Mathlib.Analysis.InnerProductSpace.Orthogonal"
+      },
+      {
+        "theorem": "inner_self_eq_norm_sq_to_K",
+        "description": "Self-inner product as a field element: ⟪x,x⟫_𝕜 = (‖x‖:𝕜)²",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "RCLike.norm_ofReal",
+        "description": "Norm of a real coercion: ‖(r:𝕜)‖ = |r|",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Bridge identity ⟪x,x⟫•y − ⟪x,y⟫•x = ⟪x,x⟫ • (y − P x y): the parent's scaled Gram vector IS ⟪x,x⟫ times Mathlib's orthogonal residual, valid for all x including x = 0",
+      "Defect-as-residual identity ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖² (x ≠ 0), obtained by substituting the bridge into the parent's Lagrange identity (★) and cancelling ‖x‖²",
+      "Cauchy-Schwarz recovered directly from nonnegativity of ‖residual‖²",
+      "Equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ P x y = y (the projection recovers y, i.e. y lies on the line 𝕜 ∙ x)",
+      "Residual orthogonality ⟪x, y − P x y⟫ = 0 via Mathlib's projection API specialised to a singleton span",
+      "ℝ and ℂ specializations of the defect-as-residual identity"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 193,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound. The orthogonal-projection step uses the canonical HasOrthogonalProjection instance for the (finite-dimensional, hence complete) singleton span 𝕜 ∙ x.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Schwarz's Orthogonal Residual, Made Division-Free**\n\nH. A. Schwarz's 1885 proof of the inner-product inequality is geometric: decompose $y$ into its component along $x$ and a perpendicular remainder. The remainder — the *orthogonal residual* $r = y - \\operatorname{proj}_x y$ — has nonnegative squared length, and that single fact yields $|\\langle x,y\\rangle| \\le \\|x\\|\\,\\|y\\|$. The classical projection $\\operatorname{proj}_x y = \\frac{\\langle x,y\\rangle}{\\langle x,x\\rangle}\\,x$ requires dividing by $\\langle x,x\\rangle$, hence $x \\ne 0$.\n\nThe parent entry (cauchy-schwarz-oq-01-oq-05) avoided that division by scaling rather than dividing, working with the Gram vector $w = \\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x$. This entry closes the loop: it shows the scaled Gram vector is *literally* $\\langle x,x\\rangle$ times Schwarz's orthogonal residual, $w = \\langle x,x\\rangle\\,r$, where $r = y - P\\,x\\,y$ is computed by Mathlib's `starProjection` onto the line $\\mathbb{k}\\!\\cdot\\!x$. Substituting this into the parent's identity (★) gives the textbook residual form of the defect.",
+    "problemStatement": "**Defect as Squared Residual (Complex / RCLike)**\n\nLet $P\\,x\\,y$ be the orthogonal projection of $y$ onto the line $\\mathbb{k} \\cdot x$, with residual $r = y - P\\,x\\,y$. For $x \\ne 0$:\n$$\\|x\\|^2\\,\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2 = \\|x\\|^2\\,\\|y - P\\,x\\,y\\|^2.$$\nThe Cauchy-Schwarz defect equals $\\|x\\|^2$ times the squared norm of the orthogonal residual; equality holds iff $P\\,x\\,y = y$, i.e. iff $y$ lies on the line $\\mathbb{k} \\cdot x$.",
+    "text": "Connects the division-free Lagrange defect identity to Mathlib's orthogonal projection by exhibiting the Cauchy-Schwarz defect as ‖x‖² times the squared norm of the orthogonal residual y − P x y.",
+    "proofStrategy": "**Bridge, Substitute, Cancel**\n\n1. **Compute the projection** $P\\,x\\,y = (\\langle x,y\\rangle / \\|x\\|^2)\\,x$ from Mathlib's `starProjection_singleton`, and confirm the residual $r = y - P\\,x\\,y$ is orthogonal to $x$ (it lies in $(\\mathbb{k}\\!\\cdot\\!x)^\\perp$).\n2. **Bridge**: show $\\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x = \\langle x,x\\rangle\\,r$. The only content is $\\langle x,x\\rangle\\,P\\,x\\,y = \\langle x,y\\rangle\\,x$, which follows from $\\langle x,x\\rangle = (\\|x\\|^2 : \\mathbb{k})$ and the cancellation $\\langle x,x\\rangle \\cdot (\\langle x,y\\rangle/\\|x\\|^2) = \\langle x,y\\rangle$.\n3. **Substitute** the bridge into the parent's Lagrange identity $\\|w\\|^2 = \\|x\\|^2 \\cdot \\text{defect}$. Since $w = \\langle x,x\\rangle\\,r$, we get $\\|w\\|^2 = \\|x\\|^4\\,\\|r\\|^2$ (using $\\|\\langle x,x\\rangle\\| = \\|x\\|^2$).\n4. **Cancel** the positive factor $\\|x\\|^2$ (for $x \\ne 0$): $\\text{defect} = \\|x\\|^2\\,\\|r\\|^2$.\n5. **Consequences**: nonnegativity of $\\|r\\|^2$ gives Cauchy-Schwarz; $\\|r\\|^2 = 0 \\iff r = 0 \\iff P\\,x\\,y = y$ gives the equality characterization.",
+    "keyInsights": [
+      "**The scaled Gram vector is the residual, scaled**: $w = \\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x = \\langle x,x\\rangle\\,(y - P\\,x\\,y)$ identifies the parent's purely algebraic object with Mathlib's geometric orthogonal projection — the explicit link the open question asked for.",
+      "**Defect is ‖x‖² times a squared residual**: the Cauchy-Schwarz gap is exhibited as $\\|x\\|^2\\|r\\|^2$, the textbook 'length of the perpendicular component' picture, now machine-checked over an arbitrary RCLike field.",
+      "**Equality is residual vanishing**: $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff P\\,x\\,y = y$, a crisp restatement of 'y lies on the line through x' in terms of the projection operator itself.",
+      "**Reuse over re-proof**: rather than re-deriving the algebra, the bridge plugs straight into the parent's identity (★); the new mathematical content is exactly the one smul-cancellation lemma.",
+      "**Singleton span needs no completeness hypothesis on E**: the line $\\mathbb{k}\\!\\cdot\\!x$ is finite-dimensional, so Mathlib's `HasOrthogonalProjection` instance is available with no assumption on the ambient space."
+    ],
+    "prerequisites": [
+      "Mathematical analysis",
+      "Linear algebra",
+      "Inner product spaces and orthogonal projection"
+    ]
+  },
+  "sections": [
+    {
+      "id": "residual-orthogonal",
+      "title": "The Residual is Orthogonal to x",
+      "summary": "⟪x, y − P x y⟫ = 0, from sub_starProjection_mem_orthogonal and mem_orthogonal_singleton_iff_inner_right; plus the explicit projection formula P x y = (⟪x,y⟫/‖x‖²)•x.",
+      "startLine": 78,
+      "endLine": 87,
+      "mathContext": "The defining property of the orthogonal projection onto the line $\\mathbb{k}\\!\\cdot\\!x$: the residual lands in the orthogonal complement $(\\mathbb{k}\\!\\cdot\\!x)^\\perp$, so it is perpendicular to $x$."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge: Scaled Gram Vector = ⟪x,x⟫ • Residual",
+      "summary": "⟪x,x⟫•y − ⟪x,y⟫•x = ⟪x,x⟫ • (y − P x y), valid for all x. The only content is ⟪x,x⟫ • P x y = ⟪x,y⟫•x via inner_self_eq_norm_sq_to_K and a smul-cancellation.",
+      "startLine": 101,
+      "endLine": 110,
+      "mathContext": "Identifies the parent's algebraic Gram vector with Mathlib's geometric orthogonal residual, scaled by $\\langle x,x\\rangle$. This is the explicit connection the open question requested."
+    },
+    {
+      "id": "defect-residual",
+      "title": "The Defect as the Squared Norm of the Residual",
+      "summary": "‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖² for x ≠ 0, by substituting the bridge into the parent's Lagrange identity (★) and cancelling ‖x‖².",
+      "startLine": 124,
+      "endLine": 135,
+      "mathContext": "The central result: Schwarz's residual form of the Cauchy-Schwarz defect, derived by reusing the parent's division-free identity rather than re-expanding inner products."
+    },
+    {
+      "id": "consequences",
+      "title": "Cauchy-Schwarz and Equality, from the Residual",
+      "summary": "Squared Cauchy-Schwarz from nonnegativity of ‖residual‖², and the equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ P x y = y.",
+      "startLine": 143,
+      "endLine": 173,
+      "mathContext": "Nonnegativity of the squared residual gives the inequality; the residual vanishing iff the projection recovers $y$ gives the equality case as a statement about the projection operator."
+    },
+    {
+      "id": "specializations",
+      "title": "Specializations to ℝ and ℂ",
+      "summary": "The defect-as-residual identity over real and complex inner product spaces, as direct instantiations of the RCLike result.",
+      "startLine": 180,
+      "endLine": 191,
+      "mathContext": "Instantiating $\\mathbb{k} = \\mathbb{R}$ and $\\mathbb{k} = \\mathbb{C}$ recovers the classical real and complex residual decompositions."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question is answered affirmatively: the division-free Lagrange defect identity packages exactly as the squared norm of Mathlib's explicit orthogonal residual y − starProjection (𝕜 ∙ x) y. The scaled Gram vector equals ⟪x,x⟫ times that residual, giving the defect form ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖². All 8 theorems verified with 0 sorries and 0 axioms.",
+    "implications": "**Theoretical Significance**\n\n1. **Algebra meets geometry**: The bridge identity shows the parent's abstract Gram vector and Mathlib's concrete orthogonal projection are the same object up to the scalar ⟪x,x⟫ — making the 'defect = length of perpendicular component' picture literal and machine-checked.\n2. **Reuse of a verified identity**: The defect form is obtained by substitution into the parent's (★), not by a fresh inner-product expansion, illustrating composable formalization.\n3. **Operator-level equality condition**: Phrasing equality as P x y = y connects the sharpness of Cauchy-Schwarz directly to the orthogonal-projection operator, the form most useful in least-squares and approximation theory.",
+    "openQuestions": [
+      "Does the bridge generalize to projection onto a finite-dimensional subspace, giving the Gram-determinant defect as ‖x‖²ⁿ times the squared distance to the span?",
+      "Can the residual form be used to derive a quantitative stability estimate for the least-squares solution when x is nearly parallel to y?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CauchySchwarzOQ01OQ05",
+      "Mathlib.Analysis.InnerProductSpace.Projection.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "RCLike"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ05OQ01",
+    "lineCount": 193,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CauchySchwarzOQ01OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "H. A. Schwarz",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem",
+      "year": "1885",
+      "venue": "Acta Societatis Scientiarum Fennicae",
+      "note": "Inner-product formulation via the orthogonal residual"
+    },
+    {
+      "authors": "J.-L. Lagrange",
+      "title": "Solutions analytiques de quelques problèmes sur les pyramides triangulaires",
+      "year": "1773",
+      "venue": "Nouveaux mémoires de l'Académie de Berlin",
+      "note": "Original algebraic identity underlying the defect"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-05",
+      "relationship": "extends",
+      "description": "Parent problem (division-free Lagrange defect identity); this entry packages that identity as the squared norm of an explicit orthogonal residual and links it to Mathlib's starProjection"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling equality characterization via the projection coefficient and Pythagoras; this entry phrases equality directly as the projection recovering y (P x y = y)"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The defect-as-residual identity is the orthogonal-decomposition Pythagoras relation ‖y‖² = ‖P x y‖² + ‖residual‖², scaled by ‖x‖²"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "cauchy-schwarz-oq-01-oq-05-oq-01",
+  "title": "The Cauchy-Schwarz Defect as the Squared Norm of the Orthogonal Residual",
+  "slug": "cauchy-schwarz-oq-01-oq-05-oq-01",
+  "description": "Packages the parent's division-free Lagrange defect identity as the squared norm of an explicit orthogonal residual, connecting it to Mathlib's starProjection (orthogonal projection onto a line). The scaled Gram vector ⟪x,x⟫•y − ⟪x,y⟫•x equals ⟪x,x⟫ times the residual y − P x y, yielding the clean form ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖² (for x ≠ 0).",
+  "meta": {
+    "author": "Schwarz (1885); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cauchy%E2%80%93Schwarz_inequality",
+    "date": "1885",
+    "status": "verified",
+    "tags": [
+      "analysis",
+      "linear-algebra",
+      "inner-product-spaces",
+      "orthogonal-projection",
+      "functional-analysis",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ05OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.starProjection_singleton",
+        "description": "Orthogonal projection onto a single vector: (𝕜 ∙ v).starProjection w = (⟪v,w⟫/‖v‖²) • v",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection.Basic"
+      },
+      {
+        "theorem": "Submodule.sub_starProjection_mem_orthogonal",
+        "description": "The residual v − P v lies in the orthogonal complement Kᗮ",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection.Basic"
+      },
+      {
+        "theorem": "Submodule.mem_orthogonal_singleton_iff_inner_right",
+        "description": "v ∈ (𝕜 ∙ u)ᗮ ↔ ⟪u,v⟫ = 0, the orthogonality test against a line",
+        "module": "Mathlib.Analysis.InnerProductSpace.Orthogonal"
+      },
+      {
+        "theorem": "inner_self_eq_norm_sq_to_K",
+        "description": "Self-inner product as a field element: ⟪x,x⟫_𝕜 = (‖x‖:𝕜)²",
+        "module": "Mathlib.Analysis.InnerProductSpace.Basic"
+      },
+      {
+        "theorem": "RCLike.norm_ofReal",
+        "description": "Norm of a real coercion: ‖(r:𝕜)‖ = |r|",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Bridge identity ⟪x,x⟫•y − ⟪x,y⟫•x = ⟪x,x⟫ • (y − P x y): the parent's scaled Gram vector IS ⟪x,x⟫ times Mathlib's orthogonal residual, valid for all x including x = 0",
+      "Defect-as-residual identity ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖² (x ≠ 0), obtained by substituting the bridge into the parent's Lagrange identity (★) and cancelling ‖x‖²",
+      "Cauchy-Schwarz recovered directly from nonnegativity of ‖residual‖²",
+      "Equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ P x y = y (the projection recovers y, i.e. y lies on the line 𝕜 ∙ x)",
+      "Residual orthogonality ⟪x, y − P x y⟫ = 0 via Mathlib's projection API specialised to a singleton span",
+      "ℝ and ℂ specializations of the defect-as-residual identity"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 193,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound. The orthogonal-projection step uses the canonical HasOrthogonalProjection instance for the (finite-dimensional, hence complete) singleton span 𝕜 ∙ x.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "**Schwarz's Orthogonal Residual, Made Division-Free**\n\nH. A. Schwarz's 1885 proof of the inner-product inequality is geometric: decompose $y$ into its component along $x$ and a perpendicular remainder. The remainder — the *orthogonal residual* $r = y - \\operatorname{proj}_x y$ — has nonnegative squared length, and that single fact yields $|\\langle x,y\\rangle| \\le \\|x\\|\\,\\|y\\|$. The classical projection $\\operatorname{proj}_x y = \\frac{\\langle x,y\\rangle}{\\langle x,x\\rangle}\\,x$ requires dividing by $\\langle x,x\\rangle$, hence $x \\ne 0$.\n\nThe parent entry (cauchy-schwarz-oq-01-oq-05) avoided that division by scaling rather than dividing, working with the Gram vector $w = \\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x$. This entry closes the loop: it shows the scaled Gram vector is *literally* $\\langle x,x\\rangle$ times Schwarz's orthogonal residual, $w = \\langle x,x\\rangle\\,r$, where $r = y - P\\,x\\,y$ is computed by Mathlib's `starProjection` onto the line $\\mathbb{k}\\!\\cdot\\!x$. Substituting this into the parent's identity (★) gives the textbook residual form of the defect.",
+    "problemStatement": "**Defect as Squared Residual (Complex / RCLike)**\n\nLet $P\\,x\\,y$ be the orthogonal projection of $y$ onto the line $\\mathbb{k} \\cdot x$, with residual $r = y - P\\,x\\,y$. For $x \\ne 0$:\n$$\\|x\\|^2\\,\\|y\\|^2 - \\|\\langle x,y\\rangle\\|^2 = \\|x\\|^2\\,\\|y - P\\,x\\,y\\|^2.$$\nThe Cauchy-Schwarz defect equals $\\|x\\|^2$ times the squared norm of the orthogonal residual; equality holds iff $P\\,x\\,y = y$, i.e. iff $y$ lies on the line $\\mathbb{k} \\cdot x$.",
+    "text": "Connects the division-free Lagrange defect identity to Mathlib's orthogonal projection by exhibiting the Cauchy-Schwarz defect as ‖x‖² times the squared norm of the orthogonal residual y − P x y.",
+    "proofStrategy": "**Bridge, Substitute, Cancel**\n\n1. **Compute the projection** $P\\,x\\,y = (\\langle x,y\\rangle / \\|x\\|^2)\\,x$ from Mathlib's `starProjection_singleton`, and confirm the residual $r = y - P\\,x\\,y$ is orthogonal to $x$ (it lies in $(\\mathbb{k}\\!\\cdot\\!x)^\\perp$).\n2. **Bridge**: show $\\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x = \\langle x,x\\rangle\\,r$. The only content is $\\langle x,x\\rangle\\,P\\,x\\,y = \\langle x,y\\rangle\\,x$, which follows from $\\langle x,x\\rangle = (\\|x\\|^2 : \\mathbb{k})$ and the cancellation $\\langle x,x\\rangle \\cdot (\\langle x,y\\rangle/\\|x\\|^2) = \\langle x,y\\rangle$.\n3. **Substitute** the bridge into the parent's Lagrange identity $\\|w\\|^2 = \\|x\\|^2 \\cdot \\text{defect}$. Since $w = \\langle x,x\\rangle\\,r$, we get $\\|w\\|^2 = \\|x\\|^4\\,\\|r\\|^2$ (using $\\|\\langle x,x\\rangle\\| = \\|x\\|^2$).\n4. **Cancel** the positive factor $\\|x\\|^2$ (for $x \\ne 0$): $\\text{defect} = \\|x\\|^2\\,\\|r\\|^2$.\n5. **Consequences**: nonnegativity of $\\|r\\|^2$ gives Cauchy-Schwarz; $\\|r\\|^2 = 0 \\iff r = 0 \\iff P\\,x\\,y = y$ gives the equality characterization.",
+    "keyInsights": [
+      "**The scaled Gram vector is the residual, scaled**: $w = \\langle x,x\\rangle\\,y - \\langle x,y\\rangle\\,x = \\langle x,x\\rangle\\,(y - P\\,x\\,y)$ identifies the parent's purely algebraic object with Mathlib's geometric orthogonal projection — the explicit link the open question asked for.",
+      "**Defect is ‖x‖² times a squared residual**: the Cauchy-Schwarz gap is exhibited as $\\|x\\|^2\\|r\\|^2$, the textbook 'length of the perpendicular component' picture, now machine-checked over an arbitrary RCLike field.",
+      "**Equality is residual vanishing**: $\\|\\langle x,y\\rangle\\| = \\|x\\|\\|y\\| \\iff P\\,x\\,y = y$, a crisp restatement of 'y lies on the line through x' in terms of the projection operator itself.",
+      "**Reuse over re-proof**: rather than re-deriving the algebra, the bridge plugs straight into the parent's identity (★); the new mathematical content is exactly the one smul-cancellation lemma.",
+      "**Singleton span needs no completeness hypothesis on E**: the line $\\mathbb{k}\\!\\cdot\\!x$ is finite-dimensional, so Mathlib's `HasOrthogonalProjection` instance is available with no assumption on the ambient space."
+    ],
+    "prerequisites": [
+      "Mathematical analysis",
+      "Linear algebra",
+      "Inner product spaces and orthogonal projection"
+    ]
+  },
+  "sections": [
+    {
+      "id": "residual-orthogonal",
+      "title": "The Residual is Orthogonal to x",
+      "summary": "⟪x, y − P x y⟫ = 0, from sub_starProjection_mem_orthogonal and mem_orthogonal_singleton_iff_inner_right; plus the explicit projection formula P x y = (⟪x,y⟫/‖x‖²)•x.",
+      "startLine": 78,
+      "endLine": 87,
+      "mathContext": "The defining property of the orthogonal projection onto the line $\\mathbb{k}\\!\\cdot\\!x$: the residual lands in the orthogonal complement $(\\mathbb{k}\\!\\cdot\\!x)^\\perp$, so it is perpendicular to $x$."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge: Scaled Gram Vector = ⟪x,x⟫ • Residual",
+      "summary": "⟪x,x⟫•y − ⟪x,y⟫•x = ⟪x,x⟫ • (y − P x y), valid for all x. The only content is ⟪x,x⟫ • P x y = ⟪x,y⟫•x via inner_self_eq_norm_sq_to_K and a smul-cancellation.",
+      "startLine": 101,
+      "endLine": 110,
+      "mathContext": "Identifies the parent's algebraic Gram vector with Mathlib's geometric orthogonal residual, scaled by $\\langle x,x\\rangle$. This is the explicit connection the open question requested."
+    },
+    {
+      "id": "defect-residual",
+      "title": "The Defect as the Squared Norm of the Residual",
+      "summary": "‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖² for x ≠ 0, by substituting the bridge into the parent's Lagrange identity (★) and cancelling ‖x‖².",
+      "startLine": 124,
+      "endLine": 135,
+      "mathContext": "The central result: Schwarz's residual form of the Cauchy-Schwarz defect, derived by reusing the parent's division-free identity rather than re-expanding inner products."
+    },
+    {
+      "id": "consequences",
+      "title": "Cauchy-Schwarz and Equality, from the Residual",
+      "summary": "Squared Cauchy-Schwarz from nonnegativity of ‖residual‖², and the equality characterization ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ P x y = y.",
+      "startLine": 143,
+      "endLine": 173,
+      "mathContext": "Nonnegativity of the squared residual gives the inequality; the residual vanishing iff the projection recovers $y$ gives the equality case as a statement about the projection operator."
+    },
+    {
+      "id": "specializations",
+      "title": "Specializations to ℝ and ℂ",
+      "summary": "The defect-as-residual identity over real and complex inner product spaces, as direct instantiations of the RCLike result.",
+      "startLine": 180,
+      "endLine": 191,
+      "mathContext": "Instantiating $\\mathbb{k} = \\mathbb{R}$ and $\\mathbb{k} = \\mathbb{C}$ recovers the classical real and complex residual decompositions."
+    }
+  ],
+  "conclusion": {
+    "summary": "The open question is answered affirmatively: the division-free Lagrange defect identity packages exactly as the squared norm of Mathlib's explicit orthogonal residual y − starProjection (𝕜 ∙ x) y. The scaled Gram vector equals ⟪x,x⟫ times that residual, giving the defect form ‖x‖²·‖y‖² − ‖⟪x,y⟫‖² = ‖x‖²·‖y − P x y‖². All 8 theorems verified with 0 sorries and 0 axioms.",
+    "implications": "**Theoretical Significance**\n\n1. **Algebra meets geometry**: The bridge identity shows the parent's abstract Gram vector and Mathlib's concrete orthogonal projection are the same object up to the scalar ⟪x,x⟫ — making the 'defect = length of perpendicular component' picture literal and machine-checked.\n2. **Reuse of a verified identity**: The defect form is obtained by substitution into the parent's (★), not by a fresh inner-product expansion, illustrating composable formalization.\n3. **Operator-level equality condition**: Phrasing equality as P x y = y connects the sharpness of Cauchy-Schwarz directly to the orthogonal-projection operator, the form most useful in least-squares and approximation theory.",
+    "openQuestions": [
+      "Does the bridge generalize to projection onto a finite-dimensional subspace, giving the Gram-determinant defect as ‖x‖²ⁿ times the squared distance to the span?",
+      "Can the residual form be used to derive a quantitative stability estimate for the least-squares solution when x is nearly parallel to y?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CauchySchwarzOQ01OQ05",
+      "Mathlib.Analysis.InnerProductSpace.Projection.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "RCLike"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ05OQ01",
+    "lineCount": 193,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CauchySchwarzOQ01OQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "H. A. Schwarz",
+      "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem",
+      "year": "1885",
+      "venue": "Acta Societatis Scientiarum Fennicae",
+      "note": "Inner-product formulation via the orthogonal residual"
+    },
+    {
+      "authors": "J.-L. Lagrange",
+      "title": "Solutions analytiques de quelques problèmes sur les pyramides triangulaires",
+      "year": "1773",
+      "venue": "Nouveaux mémoires de l'Académie de Berlin",
+      "note": "Original algebraic identity underlying the defect"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-05",
+      "relationship": "extends",
+      "description": "Parent problem (division-free Lagrange defect identity); this entry packages that identity as the squared norm of an explicit orthogonal residual and links it to Mathlib's starProjection"
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling equality characterization via the projection coefficient and Pythagoras; this entry phrases equality directly as the projection recovering y (P x y = y)"
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "related",
+      "description": "The defect-as-residual identity is the orthogonal-decomposition Pythagoras relation ‖y‖² = ‖P x y‖² + ‖residual‖², scaled by ‖x‖²"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question **cauchy-schwarz-oq-01-oq-05 OQ-01**:

> *Can the Lagrange identity for the Cauchy-Schwarz defect be packaged as the squared norm of an explicit orthogonal residual, to connect with Mathlib's `orthogonalProjection`?*

**Yes.** Let `P x y := (𝕜 ∙ x).starProjection y` be Mathlib's orthogonal projection of `y` onto the line `𝕜 ∙ x`, with residual `r = y − P x y`. The key new result is the **bridge identity**

```
⟪x,x⟫ • y − ⟪x,y⟫ • x  =  ⟪x,x⟫ • (y − P x y)
```

i.e. the parent's *scaled Gram vector* is exactly `⟪x,x⟫` times Mathlib's orthogonal residual. Substituting this into the parent's verified Lagrange identity `‖w‖² = ‖x‖²·defect` and cancelling `‖x‖²` (for `x ≠ 0`) gives the textbook residual form of the Cauchy-Schwarz defect:

```
‖x‖²·‖y‖² − ‖⟪x,y⟫‖²  =  ‖x‖²·‖y − P x y‖²
```

From this:
- **Cauchy-Schwarz** follows immediately from `‖residual‖² ≥ 0`;
- **equality** `‖⟪x,y⟫‖ = ‖x‖·‖y‖` holds **iff** `P x y = y` (the projection recovers `y`, i.e. `y` lies on the line `𝕜 ∙ x`).

## Contents

- `proofs/Proofs/CauchySchwarzOQ01OQ05OQ01.lean` — 193 lines, **8 theorems, 2 defs, 0 sorries, 0 axioms**
- Gallery entry `src/data/proofs/cauchy-schwarz-oq-01-oq-05-oq-01/` (meta.json + annotations.json)
- 1 import line added to `proofs/Proofs.lean`

## Verification

Built offline with `lake env lean` (Docker build infra unavailable): both the parent olean and this file compile **EXIT 0** with no warnings. `#print axioms` on the main theorems reports only `propext`, `Classical.choice`, `Quot.sound` — status `verified`, `axiomCount: 0`.

## Notes

- Reuses the parent's identity wholesale — the only genuinely new mathematical content is one `smul`-cancellation lemma; the rest is substitution.
- Mathlib API note: the `orthogonalProjection`-on-a-singleton lemmas were renamed to the `starProjection` family (deprecated aliases since 2025-07-07); this entry uses the current names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)