### PR TITLE
research(erdos-659-incomplete-01): resolve dangling sorry + verify x²+2y² positive-definiteness [0-sorry, 1-axiom]

### DIFF
--- a/proofs/Proofs/Erdos659Problem.lean
+++ b/proofs/Proofs/Erdos659Problem.lean
@@ -26,6 +26,7 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Data.Real.Sqrt
 import Mathlib.Data.Finset.Card
 import Mathlib.Topology.MetricSpace.Basic
+import Mathlib.Tactic
 
 /-
 # Erdős Problem 659: Point Configurations with Constrained Distances
@@ -59,6 +60,49 @@ noncomputable def latticePoint (a b : ℤ) : ℝ × ℝ :=
     This is a positive definite quadratic form x² + 2y². -/
 noncomputable def latticeDistSq (a₁ b₁ a₂ b₂ : ℤ) : ℤ :=
   (a₁ - a₂)^2 + 2 * (b₁ - b₂)^2
+
+/-! ### Positive-definiteness of the defining quadratic form
+
+The squared distance on the Moree–Osburn lattice is the binary quadratic form
+`x² + 2y²` (discriminant `-8`). The three lemmas below verify that it is a genuine
+positive-definite form: symmetric, non-negative, and vanishing only on the diagonal.
+The last property (`latticeDistSq_eq_zero_iff`) is exactly what guarantees the
+truncated lattice consists of *distinct* points, so that `moreeOsburnLattice n`
+realises `n` honest points with positive pairwise distances. These are fully
+verified (no axioms, no sorries) and are independent of the deep analytic input
+(`moreeOsburnWorks`). -/
+
+/-- The squared lattice distance is symmetric in its two points. -/
+theorem latticeDistSq_symm (a₁ b₁ a₂ b₂ : ℤ) :
+    latticeDistSq a₁ b₁ a₂ b₂ = latticeDistSq a₂ b₂ a₁ b₁ := by
+  unfold latticeDistSq; ring
+
+/-- The form `x² + 2y²` is non-negative. -/
+theorem latticeDistSq_nonneg (a₁ b₁ a₂ b₂ : ℤ) :
+    0 ≤ latticeDistSq a₁ b₁ a₂ b₂ := by
+  unfold latticeDistSq
+  have h1 := sq_nonneg (a₁ - a₂)
+  have h2 := sq_nonneg (b₁ - b₂)
+  linarith
+
+/-- **Positive-definiteness**: the form `x² + 2y²` vanishes exactly on the diagonal.
+    Hence two lattice points coincide iff their squared distance is zero — the
+    property that makes the truncated lattice a set of distinct points. -/
+theorem latticeDistSq_eq_zero_iff (a₁ b₁ a₂ b₂ : ℤ) :
+    latticeDistSq a₁ b₁ a₂ b₂ = 0 ↔ a₁ = a₂ ∧ b₁ = b₂ := by
+  unfold latticeDistSq
+  constructor
+  · intro h
+    have h1 := sq_nonneg (a₁ - a₂)
+    have h2 := sq_nonneg (b₁ - b₂)
+    have hx : (a₁ - a₂) ^ 2 = 0 := by linarith
+    have hy : (b₁ - b₂) ^ 2 = 0 := by linarith
+    have hx' : a₁ - a₂ = 0 := by
+      exact pow_eq_zero_iff (by norm_num) |>.mp hx
+    have hy' : b₁ - b₂ = 0 := by
+      exact pow_eq_zero_iff (by norm_num) |>.mp hy
+    exact ⟨by omega, by omega⟩
+  · rintro ⟨rfl, rfl⟩; ring
 
 /-- The integer lattice points in a box [-k, k] × [-k, k] -/
 noncomputable def latticeBox (k : ℕ) : Finset (ℤ × ℤ) :=
@@ -162,28 +206,22 @@ def isConfiguration (S : Finset (ℝ × ℝ)) (config : TwoDistanceConfig) : Pro
         let dists := (S.product S).image (fun ⟨p, q⟩ => dist p q) |>.filter (· > 0)
         dists = {a, a * φ}
 
-/-- The Moree-Osburn lattice avoids all six configurations -/
 /-
 ## Key Properties of the Moree-Osburn Lattice
 
 The lattice {(a, b√2) : a,b ∈ ℤ} has remarkable properties due to the
-irrationality of √2.
+irrationality of √2. The following informal notes record the geometric facts
+that the (deep, axiomatised) `moreeOsburnWorks` packages:
+
+* Distance formula: dist((a₁, b₁√2), (a₂, b₂√2))² = (a₁-a₂)² + 2(b₁-b₂)²,
+  the form `x² + 2y²` (see the verified `latticeDistSq_*` lemmas above).
+* No equilateral triangles: a 1:1:1 distance ratio forces
+  (a₁-a₂)² + 2(b₁-b₂)² = (a₂-a₃)² + 2(b₂-b₃)² = (a₃-a₁)² + 2(b₃-b₁)²,
+  which leads to irrational constraints.
+* No squares: equal sides and diagonals at ratio √2:1 would require
+  x² + 2y² = 2(u² + 2v²) in integers, which has no generic solutions.
 -/
 
-/-- The distance formula for Moree-Osburn lattice points.
-    dist((a₁, b₁√2), (a₂, b₂√2))² = (a₁-a₂)² + 2(b₁-b₂)².
-
-    This follows from the Euclidean distance formula:
-    d² = (a₁-a₂)² + (b₁√2 - b₂√2)² = (a₁-a₂)² + 2(b₁-b₂)² -/
-/-- The Moree-Osburn lattice contains no equilateral triangles.
-    This follows from the fact that if three points form an equilateral triangle,
-    they would require a distance ratio of 1:1:1, which would force
-    (a₁-a₂)² + 2(b₁-b₂)² = (a₂-a₃)² + 2(b₂-b₃)² = (a₃-a₁)² + 2(b₃-b₁)²
-    in a way that leads to irrational constraints. -/
-/-- The Moree-Osburn lattice contains no squares.
-    A square would require four points with equal sides and equal diagonals
-    at ratio √2:1, but this would require solutions to
-    x² + 2y² = 2(u² + 2v²) in integers that don't exist generically. -/
 /-- The set of positive integers representable as x² + 2y² -/
 def representable_x2_2y2 : Set ℕ :=
   { d | ∃ x y : ℤ, (d : ℤ) = x^2 + 2*y^2 }
@@ -192,29 +230,51 @@ def representable_x2_2y2 : Set ℕ :=
 noncomputable def B2 (N : ℕ) : ℕ :=
   (representable_x2_2y2 ∩ Set.Icc 1 N).ncard
 
-/-- **Landau's Theorem (1908)**: The counting function for x² + 2y² grows as N/√(log N).
+/-
+**Landau's Theorem (1908)**: The counting function for x² + 2y² grows as N/√(log N).
 
-    The number of positive integers ≤ N representable as x² + 2y² is
-    asymptotically c₂ · N / √(log N) where c₂ is an explicit constant.
+The number of positive integers ≤ N representable as x² + 2y² is
+asymptotically c₂ · N / √(log N) where c₂ is an explicit constant.
 
-    This is a special case of Landau's theorem for positive definite binary
-    quadratic forms of discriminant -8.
+This is a special case of Landau's theorem for positive definite binary
+quadratic forms of discriminant -8.
 
-    The representable integers are exactly those whose prime factorization has
-    all primes ≡ 5, 7 (mod 8) appearing to even powers. -/
-/-- The 4-point property follows from avoiding all six two-distance configurations -/
+The representable integers are exactly those whose prime factorization has
+all primes ≡ 5, 7 (mod 8) appearing to even powers.
+-/
+
+/-- The 4-point property follows from avoiding all six two-distance configurations,
+    **together with** the geometric lower bound that no 4-point subset collapses to
+    fewer than two distinct distances.
+
+    The lower bound `hlb` is a genuine hypothesis, not a triviality: with the ambient
+    metric on `ℝ × ℝ` (the product/Chebyshev metric), four *distinct* points can be
+    mutually equidistant — e.g. the corners `(0,0), (1,0), (0,1), (1,1)` all lie at
+    distance `1`, so `distinctDistances = 1`. Such a configuration vacuously avoids
+    every named two-distance pattern, yet violates the 4-point property. Ruling it out
+    is precisely the content of `hlb`; without it the conclusion is false. (For the
+    Moree–Osburn lattice, `hlb` is supplied by the deep input `moreeOsburnWorks`.)
+
+    Given `hlb`, avoiding the configurations forces `distinctDistances T ≠ 2`
+    (instantiating the hypothesis at any single configuration suffices, since the
+    `isConfiguration` predicate carries `T.card = 4 ∧ distinctDistances T = 2` as its
+    first two conjuncts), and `2 ≤ distinctDistances T < 3` together with
+    `distinctDistances T ≠ 2` is impossible. -/
 theorem fourPointProperty_from_avoiding_configs (S : Finset (ℝ × ℝ))
-    (h : ∀ T ⊆ S, T.card = 4 → ∀ config : TwoDistanceConfig, ¬ isConfiguration T config) :
+    (h : ∀ T ⊆ S, T.card = 4 → ∀ config : TwoDistanceConfig, ¬ isConfiguration T config)
+    (hlb : ∀ T : Finset (ℝ × ℝ), T ⊆ S → T.card = 4 → 2 ≤ distinctDistances T) :
     fourPointProperty S := by
   intro T hT hT4
+  have hge : 2 ≤ distinctDistances T := hlb T hT hT4
+  -- Instantiate the "avoid configs" hypothesis at the isoTrap1 pattern. Its predicate
+  -- unfolds to `T.card = 4 ∧ distinctDistances T = 2 ∧ True`, so avoiding it rules out
+  -- `distinctDistances T = 2`.
+  have hcfg : ¬ isConfiguration T TwoDistanceConfig.isoTrap1 := h T hT hT4 _
+  have hne2 : distinctDistances T ≠ 2 := by
+    intro he
+    exact hcfg ⟨hT4, he, trivial⟩
   by_contra hContra
-  push_neg at hContra
-  -- If distinctDistances T < 3, then T has at most 2 distances
-  -- If T has exactly 2 distances, it must be one of the six configurations
-  -- This contradicts h
-  -- We state this as the contrapositive
-  have : distinctDistances T ≤ 2 := by omega
-  -- The complete case analysis shows T must match one of the six patterns
-  sorry  -- Would need the complete classification theorem
+  push_neg at hContra  -- distinctDistances T < 3
+  omega
 
 end Erdos659

--- a/research/problems/erdos-659-incomplete-01/knowledge.md
+++ b/research/problems/erdos-659-incomplete-01/knowledge.md
@@ -18,3 +18,26 @@ Initial knowledge for problem `erdos-659-incomplete-01`.
 
 - Gallery: `src/data/proofs/erdos-659/`
 - Lean source: `proofs/Proofs/` (check namespace `Erdos659`)
+
+## Session 2026-06-25 (researcher-10)
+
+### What was done
+- Resolved the dangling sorry in `fourPointProperty_from_avoiding_configs`.
+- Added verified lemmas `latticeDistSq_symm`, `latticeDistSq_nonneg`,
+  `latticeDistSq_eq_zero_iff` (positive-definiteness of `x²+2y²`).
+- Fixed five floating `/-- -/` doc-comments that prevented the file from
+  parsing.
+- meta.json: sorries 1→0, theoremCount 2→5, lineCount 220→280. Status
+  remains `axiomatized` (badge `axiom`) — 1 axiom `moreeOsburnWorks`.
+
+### Verified (lake env lean, EXIT 0)
+- 0 sorries, 1 axiom.
+- `#print axioms`: `fourPointProperty_from_avoiding_configs` and
+  `latticeDistSq_eq_zero_iff` depend only on propext/Classical.choice/Quot.sound.
+  `erdos_659` additionally depends on `moreeOsburnWorks` (as expected).
+
+### Honest assessment
+- The completion is modest: the deep content (Landau's theorem) stays
+  axiomatized. Value added = removing a *false-as-stated* sorry and making
+  its hypotheses sound, plus real (if small) verified algebra on the
+  defining form.

--- a/research/problems/erdos-659-incomplete-01/state.md
+++ b/research/problems/erdos-659-incomplete-01/state.md
@@ -1,26 +1,42 @@
 # State: erdos-659-incomplete-01
 
-## Current Phase: OBSERVE
+## Current Phase: COMPLETED (this completion item)
 
-**Phase**: OBSERVE  
-**Status**: Active  
-**Started**: 2026-04-03T05:22:49  
-**Last Updated**: 2026-04-03T05:22:49
+**Phase**: ACT → COMPLETED
+**Status**: sorry resolved; main result remains axiomatized
+**Last Updated**: 2026-06-25
 
 ## Progress Summary
 
-Initial workspace created by Seeker. Ready for Researcher to begin OBSERVE phase.
+Resolved the single dangling sorry in `Erdos659Problem.lean`
+(`fourPointProperty_from_avoiding_configs`) and added three verified
+positive-definiteness lemmas for the defining quadratic form `x²+2y²`.
+The file now compiles cleanly (it previously did not — five floating
+`/-- -/` doc-comments caused parse errors) with **0 sorries, 1 axiom**.
 
-## Current Focus
+## Key Findings
 
-Read gallery proof and understand the sorry statement(s) that need completion.
+- The sorried theorem was **false as originally stated**: with the ambient
+  product/Chebyshev metric on `ℝ × ℝ`, four distinct points can be mutually
+  equidistant (e.g. the unit-square corners, all at sup-distance 1), so
+  "avoid all named 2-distance configs" does NOT imply "≥ 3 distinct
+  distances". The fix adds the necessary geometric lower bound `hlb`
+  (`2 ≤ distinctDistances T` on every 4-subset) as an explicit hypothesis,
+  after which the theorem is a true, fully-verified conditional.
+- The main result `erdos_659` is irreducibly **axiomatized** on
+  `moreeOsburnWorks`, which packages Landau's 1908 theorem on the count of
+  integers representable as `x²+2y²` (O(N/√log N)) plus the full 4-point
+  classification. Neither ingredient is in Mathlib 4.26.
 
 ## Blockers
 
-None currently identified.
+- `moreeOsburnWorks` cannot be eliminated without formalizing Landau's
+  theorem for binary quadratic forms of discriminant −8 — a large analytic
+  number theory project absent from Mathlib.
 
 ## Next Action
 
-1. Read `problem.md` thoroughly
-2. Examine the gallery Lean source at `src/data/proofs/erdos-659/`
-3. Identify what the sorry statement(s) require
+- If pursued further: formalize the Landau count for `x²+2y²` (major),
+  or sharpen `isConfiguration` (replace the three `True` placeholders for
+  isosceles trapezoids / kite with genuine characterizations and prove the
+  classification under the Euclidean metric).

--- a/src/data/proofs/erdos-659/annotations.json
+++ b/src/data/proofs/erdos-659/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-659",
     "range": {
       "startLine": 24,
-      "endLine": 28
+      "endLine": 29
     },
     "type": "concept",
     "title": "Mathlib Dependencies",
@@ -92,8 +92,8 @@
     "id": "ann-e659-axiom",
     "proofId": "erdos-659",
     "range": {
-      "startLine": 70,
-      "endLine": 75
+      "startLine": 120,
+      "endLine": 138
     },
     "type": "concept",
     "title": "Main Axiom: Lattice Works",
@@ -115,8 +115,8 @@
     "id": "ann-e659-main-theorem",
     "proofId": "erdos-659",
     "range": {
-      "startLine": 81,
-      "endLine": 94
+      "startLine": 144,
+      "endLine": 157
     },
     "type": "concept",
     "title": "Erdős #659: Answer is Yes",
@@ -137,8 +137,8 @@
     "id": "ann-e659-configs",
     "proofId": "erdos-659",
     "range": {
-      "startLine": 96,
-      "endLine": 105
+      "startLine": 162,
+      "endLine": 280
     },
     "type": "concept",
     "title": "The Six Two-Distance Configurations",

--- a/src/data/proofs/erdos-659/meta.json
+++ b/src/data/proofs/erdos-659/meta.json
@@ -16,7 +16,7 @@
       "lattices"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 659,
     "erdosUrl": "https://erdosproblems.com/659",
     "erdosProblemStatus": "proved",
@@ -41,13 +41,15 @@
     "originalContributions": [
       "Formalization of the 4-point distance property",
       "Definition of distinct distances for finite point sets",
+      "Verified positive-definiteness of the defining quadratic form x²+2y² (latticeDistSq_symm / _nonneg / _eq_zero_iff), guaranteeing distinct lattice points",
+      "Resolved the former classification sorry: fourPointProperty_from_avoiding_configs is now a fully verified conditional, with the necessary geometric lower bound made explicit (the original statement was false under the product/Chebyshev metric — mutually-equidistant 4-point sets exist)",
       "Partial classification of 6 two-distance configurations: square, 60° rhombus, and pentagon subset formally characterized; isosceles trapezoid (2 types) and kite left as True placeholders",
       "Educational explanation of Moree-Osburn lattice construction"
     ],
     "axiomCount": 1,
-    "lineCount": 220,
-    "assumptions": "1 axiom: moreeOsburnWorks. 1 sorry.",
-    "theoremCount": 2,
+    "lineCount": 280,
+    "assumptions": "1 axiom: moreeOsburnWorks (encodes Landau's 1908 theorem on the count of integers representable as x²+2y², together with the full 4-point classification; not available in Mathlib 4.26). 0 sorries.",
+    "theoremCount": 5,
     "definitionCount": 10
   },
   "overview": {
@@ -74,35 +76,42 @@
       "title": "Imports and Definitions",
       "startLine": 24,
       "endLine": 43,
-      "summary": "Import Mathlib dependencies for real analysis and metric spaces"
+      "summary": "Import Mathlib dependencies for real analysis, metric spaces, and tactics"
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
       "startLine": 44,
-      "endLine": 58,
-      "summary": "Define distinct distances and the 4-point property"
+      "endLine": 62,
+      "summary": "Define distinct distances, the 4-point property, and the lattice quadratic form latticeDistSq"
+    },
+    {
+      "id": "quadratic-form",
+      "title": "Positive-Definiteness of x²+2y²",
+      "startLine": 64,
+      "endLine": 113,
+      "summary": "Verified algebraic lemmas: latticeDistSq is symmetric, non-negative, and vanishes only on the diagonal (positive-definite)"
     },
     {
       "id": "axiom",
       "title": "Main Axiom",
-      "startLine": 59,
-      "endLine": 94,
-      "summary": "State the Moree-Osburn construction works (requires deep number theory); axiom moreeOsburnWorks declared at lines 89–94"
+      "startLine": 120,
+      "endLine": 138,
+      "summary": "State the Moree-Osburn construction works (requires deep number theory: Landau's theorem + classification); axiom moreeOsburnWorks at lines 133–138"
     },
     {
       "id": "theorem",
       "title": "Main Theorem",
-      "startLine": 96,
-      "endLine": 113,
-      "summary": "Derive the answer to Erdős #659 from the axiom; theorem erdos_659 at lines 100–113"
+      "startLine": 140,
+      "endLine": 157,
+      "summary": "Derive the answer to Erdős #659 from the axiom; theorem erdos_659 at lines 144–157"
     },
     {
       "id": "configurations",
       "title": "Two-Distance Configurations",
-      "startLine": 96,
-      "endLine": 220,
-      "summary": "Enumerate the 6 configurations with only 2 distances among 4 points"
+      "startLine": 162,
+      "endLine": 280,
+      "summary": "Enumerate the 6 two-distance configurations and prove fourPointProperty_from_avoiding_configs (verified, 0 sorries)"
     }
   ],
   "conclusion": {
@@ -122,18 +131,19 @@
       "Mathlib.Analysis.SpecialFunctions.Pow.Real",
       "Mathlib.Data.Real.Sqrt",
       "Mathlib.Data.Finset.Card",
-      "Mathlib.Topology.MetricSpace.Basic"
+      "Mathlib.Topology.MetricSpace.Basic",
+      "Mathlib.Tactic"
     ],
     "opens": [
       "Real"
     ],
     "namespace": "Erdos659",
-    "lineCount": 220,
+    "lineCount": 280,
     "axiomCount": 1,
-    "theoremCount": 2,
+    "theoremCount": 5,
     "definitionCount": 10,
     "path": "Proofs/Erdos659Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -191,5 +201,5 @@
       "note": "Studies the combinatorial geometry of repeated patterns in point configurations, including the classification of configurations with few distances that appears in the 4-point property verification of Problem 659."
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/research/problems/erdos-659-incomplete-01.json
+++ b/src/data/research/problems/erdos-659-incomplete-01.json
@@ -29,11 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "COMPLETION: dangling sorry resolved (file now 0-sorry, 1-axiom, compiles clean after fixing 5 floating doc-comments). Added verified positive-definiteness lemmas for x²+2y². Main result erdos_659 remains axiomatized on moreeOsburnWorks (Landau theorem, not in Mathlib).",
+    "builtItems": [
+      "latticeDistSq_symm / latticeDistSq_nonneg / latticeDistSq_eq_zero_iff in Erdos659Problem.lean (positive-definiteness of x²+2y²)",
+      "Verified fourPointProperty_from_avoiding_configs (0 sorries) with explicit lower-bound hypothesis"
+    ],
+    "insights": [
+      "The original fourPointProperty_from_avoiding_configs was false under the product/Chebyshev metric on ℝ×ℝ: unit-square corners (0,0),(1,0),(0,1),(1,1) are mutually equidistant (sup-distance 1), so distinctDistances=1 while avoiding every named 2-distance config. A geometric lower bound (2 ≤ distinctDistances on 4-subsets) is required and now explicit.",
+      "The defining form x²+2y² is positive-definite over ℤ (latticeDistSq_eq_zero_iff), so distinct lattice points have positive squared distance — verified independently of the deep axiom."
+    ],
+    "mathlibGaps": [
+      "Landau (1908) asymptotic count of integers representable as x²+2y² (~N/√log N) — not in Mathlib 4.26; blocks eliminating moreeOsburnWorks"
+    ],
+    "nextSteps": [
+      "Formalize Landau count for x²+2y² to discharge moreeOsburnWorks (major analytic NT project)",
+      "Replace the three True placeholders in isConfiguration (isoTrap1/isoTrap2/kite) with genuine Euclidean characterizations and prove the 2-distance classification"
+    ]
   },
   "tags": [
     "erdos",


### PR DESCRIPTION
## Summary
COMPLETION session for **erdos-659-incomplete-01** (the `erdos-659` gallery proof). The file previously **did not compile** — five floating `/-- -/` doc-comments (unattached to declarations) caused parse errors — and it carried **1 sorry**. After this change it compiles cleanly (`lake env lean`, EXIT 0) with **0 sorries, 1 axiom**.

## Progress
- **Resolved the sorry** in `fourPointProperty_from_avoiding_configs`. The original statement was **false** under the ambient product/Chebyshev metric on `ℝ × ℝ`: four *distinct* points can be mutually equidistant (e.g. the unit-square corners `(0,0),(1,0),(0,1),(1,1)`, all at sup-distance `1`, giving `distinctDistances = 1`), so "avoid every named 2-distance config" does **not** imply "≥ 3 distinct distances". The fix makes the necessary geometric lower bound (`2 ≤ distinctDistances` on each 4-subset) an explicit hypothesis; the theorem is then a true, fully-verified conditional.
- **Added 3 verified lemmas** establishing positive-definiteness of the defining quadratic form `x²+2y²`: `latticeDistSq_symm`, `latticeDistSq_nonneg`, `latticeDistSq_eq_zero_iff`. The last guarantees distinct lattice points have positive squared distance — independent of the deep axiom.
- Converted five dangling doc-comments to block comments so the file parses.

## Files Modified
- `proofs/Proofs/Erdos659Problem.lean` (220 → 280 lines; 2 → 5 theorems; 1 → 0 sorries)
- `src/data/proofs/erdos-659/{meta.json,annotations.json}` (counts, sections, annotation ranges, contributions)
- `research/problems/erdos-659-incomplete-01/{knowledge.md,state.md}` and the research problem JSON

## What did NOT change (honest scope)
The main result `erdos_659` remains **AXIOMATIZED** on `moreeOsburnWorks`, which packages Landau's 1908 count of integers representable as `x²+2y²` (~`N/√log N`) plus the full 4-point classification — neither is in Mathlib 4.26. Status stays `axiomatized` / badge `axiom`, `axiomCount = 1`. This is modest completion work, not a discharge of the deep result.

## Verification
- `lake env lean` EXIT 0; 0 sorries, 1 `axiom` declaration.
- `#print axioms`: `fourPointProperty_from_avoiding_configs` and `latticeDistSq_eq_zero_iff` depend only on `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`); `erdos_659` additionally depends on `moreeOsburnWorks`, as expected.
- Docker build infra down; verified offline via `lake env lean` against the main repo's Mathlib oleans.

## Status
**Outcome**: completed (sorry resolved; main result remains axiomatized)
**Next Steps**: formalize the Landau count for `x²+2y²` to discharge `moreeOsburnWorks` (major); or replace the three `True` placeholders in `isConfiguration` with genuine Euclidean characterizations.

🤖 Generated by researcher-10