### PR TITLE
Enrich Equality Condition for Strong Subadditivity (Markov Chain Characterization)

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 126, "endLine": 137 },
     "type": "definition",
     "title": "cmiSum: conditional mutual information as a relative entropy",
-    "content": "cmiSum encodes I(X;Z|Y) = Σ_{x,y,z} p(x,y,z)·log( p(x,y,z)·p_Y(y) / (p_{XY}(x,y)·p_{YZ}(y,z)) ), with the convention that zero-probability terms contribute 0. This is exactly the relative entropy D(p ‖ q) against the conditional-independence distribution q(x,y,z) = p_{XY}(x,y)·p_{YZ}(y,z)/p_Y(y), written in a division-free numerator so the summand is well-defined even when a slice has probability zero."
+    "content": "cmiSum encodes I(X;Z|Y) = Σ_{x,y,z} p(x,y,z)·log( p(x,y,z)·p_Y(y) / (p_{XY}(x,y)·p_{YZ}(y,z)) ), with the convention that zero-probability terms contribute 0. This is exactly the relative entropy D(p ‖ q) against the conditional-independence distribution q(x,y,z) = p_{XY}(x,y)·p_{YZ}(y,z)/p_Y(y), written in a division-free numerator so the summand is well-defined even when a slice has probability zero.",
+    "mathContext": "$$I(X;Z\\mid Y) = \\sum_{x,y,z} p(x,y,z)\\,\\log\\frac{p(x,y,z)\\,p_Y(y)}{p_{XY}(x,y)\\,p_{YZ}(y,z)} = D\\!\\left(p \\,\\Vert\\, q\\right),\\qquad q(x,y,z)=\\frac{p_{XY}(x,y)\\,p_{YZ}(y,z)}{p_Y(y)}.$$",
+    "significance": "key",
+    "relatedConcepts": ["conditional mutual information", "relative entropy", "Kullback–Leibler divergence", "conditional independence"],
+    "prerequisites": ["Shannon entropy", "joint and marginal distributions", "logarithm conventions (0 log 0 = 0)"]
   },
   {
     "id": "ann-kl-strict",
@@ -13,7 +17,11 @@
     "range": { "startLine": 109, "endLine": 122 },
     "type": "lemma",
     "title": "kl_lb_strict: the strict pointwise KL bound",
-    "content": "For p, q > 0 with p ≠ q, the relative-entropy term is strictly bounded: p·log(p/q) > p − q. This strictness is the engine of the equality characterization — it is what forces p = q at every support point once the total deficit is known to vanish. It refines the non-strict bound kl_lb (p·log(p/q) ≥ p − q) used to prove SSA itself."
+    "content": "For p, q > 0 with p ≠ q, the relative-entropy term is strictly bounded: p·log(p/q) > p − q. This strictness is the engine of the equality characterization — it is what forces p = q at every support point once the total deficit is known to vanish. It refines the non-strict bound kl_lb (p·log(p/q) ≥ p − q) used to prove SSA itself, and follows from the strict logarithm inequality log y < y − 1 for y ≠ 1 applied to y = q/p.",
+    "mathContext": "$$p\\log\\tfrac{p}{q} > p - q \\quad (p,q>0,\\ p\\neq q),\\qquad\\text{from}\\qquad \\log y < y-1 \\ \\ (y\\neq 1),\\ \\ y=\\tfrac{q}{p}.$$",
+    "significance": "key",
+    "relatedConcepts": ["Gibbs' inequality", "strict convexity of x log x", "logarithm inequality log y ≤ y − 1", "equality case of KL divergence"],
+    "prerequisites": ["real logarithm", "convexity / tangent-line bounds", "strict inequalities"]
   },
   {
     "id": "ann-deficit-eq-cmi",
@@ -21,7 +29,11 @@
     "range": { "startLine": 140, "endLine": 251 },
     "type": "theorem",
     "title": "ssa_deficit_eq_cmi: the SSA deficit IS the conditional mutual information",
-    "content": "The slack H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y) equals cmiSum exactly. The proof expands each entropy as a nested sum over (x,y,z), applies the marginal-telescoping identity to rewrite the marginal entropies, and splits log p(x,y,z) into the conditional-MI term plus the three marginal log terms; the marginal pieces cancel and the deficit collapses to the single relative-entropy sum. This is the precise (equality) form of the algebra that underlies the SSA inequality."
+    "content": "The slack H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y) equals cmiSum exactly. The proof expands each entropy as a nested sum over (x,y,z), applies the marginal-telescoping identity to rewrite the marginal entropies, and splits log p(x,y,z) into the conditional-MI term plus the three marginal log terms; the marginal pieces cancel and the deficit collapses to the single relative-entropy sum. This is the precise (equality) form of the algebra that underlies the SSA inequality.",
+    "mathContext": "$$H(X,Y)+H(Y,Z)-H(X,Y,Z)-H(Y) \\;=\\; \\sum_{x,y,z} p(x,y,z)\\,\\log\\frac{p(x,y,z)\\,p_Y(y)}{p_{XY}(x,y)\\,p_{YZ}(y,z)} \\;=\\; I(X;Z\\mid Y).$$",
+    "significance": "key",
+    "relatedConcepts": ["entropy chain rule", "telescoping sums", "conditional mutual information identity", "strong subadditivity"],
+    "prerequisites": ["Shannon entropy expansion", "Finset sum manipulation", "marginalization"]
   },
   {
     "id": "ann-cmi-zero-iff",
@@ -29,7 +41,11 @@
     "range": { "startLine": 254, "endLine": 431 },
     "type": "theorem",
     "title": "ssa_cmi_eq_zero_iff: vanishing CMI ⟺ Markov factorization",
-    "content": "cmiSum = 0 iff p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z) for all x,y,z. Forward: each summand p·log(p/q) dominates p − q, and Σ(p − q) = 0, so the deficit vanishes only if every summand equals p − q; the strict KL bound then forces p = q everywhere, i.e. the factorization (handled uniformly across zero-probability slices). Backward: substituting the factorization makes every log(p/q) = log 1 = 0."
+    "content": "cmiSum = 0 iff p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z) for all x,y,z. Forward: each summand p·log(p/q) dominates p − q, and Σ(p − q) = 0, so the deficit vanishes only if every summand equals p − q; the strict KL bound then forces p = q everywhere, i.e. the factorization (handled uniformly across zero-probability slices). Backward: substituting the factorization makes every log(p/q) = log 1 = 0.",
+    "mathContext": "$$\\sum_{x,y,z} p\\log\\tfrac{p}{q} = 0 \\;\\Longleftrightarrow\\; \\forall x,y,z:\\ p(x,y,z)\\,p_Y(y) = p_{XY}(x,y)\\,p_{YZ}(y,z),\\qquad \\sum(p-q)=1-1=0.$$",
+    "significance": "key",
+    "relatedConcepts": ["equality case of Gibbs' inequality", "conditional independence", "Markov chain factorization", "support of a distribution"],
+    "prerequisites": ["KL divergence non-negativity", "sum of nonnegative terms vanishing", "case analysis on zero probabilities"]
   },
   {
     "id": "ann-ssa-eq-iff",
@@ -37,6 +53,10 @@
     "range": { "startLine": 433, "endLine": 446 },
     "type": "theorem",
     "title": "strong_subadditivity_eq_iff: SSA equality ⟺ Markov chain X–Y–Z",
-    "content": "Combining the two reductions: H(X,Y,Z)+H(Y) = H(X,Y)+H(Y,Z) holds if and only if X and Z are conditionally independent given Y, i.e. X–Y–Z is a Markov chain. This is the sharp boundary of the deepest classical entropy inequality — the classical special case of the quantum SSA equality theorem of Hayden–Jozsa–Petz–Winter."
+    "content": "Combining the two reductions: H(X,Y,Z)+H(Y) = H(X,Y)+H(Y,Z) holds if and only if X and Z are conditionally independent given Y, i.e. X–Y–Z is a Markov chain. This is the sharp boundary of the deepest classical entropy inequality — the classical special case of the quantum SSA equality theorem of Hayden–Jozsa–Petz–Winter.",
+    "mathContext": "$$H(X,Y,Z)+H(Y) = H(X,Y)+H(Y,Z) \\;\\Longleftrightarrow\\; X\\!-\\!Y\\!-\\!Z\\ \\text{Markov} \\;\\Longleftrightarrow\\; I(X;Z\\mid Y)=0.$$",
+    "significance": "key",
+    "relatedConcepts": ["strong subadditivity equality case", "Markov chain", "conditional independence", "quantum Markov states / Petz recovery"],
+    "prerequisites": ["strong subadditivity of entropy", "conditional mutual information", "Markov chains in information theory"]
   }
 ]

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/index.ts
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ShannonEntropySSAEq.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const shannonEntropyOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const shannonEntropyOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const shannonEntropyOq03Oq01Data: ProofData = {
+  proof: shannonEntropyOq03Oq01Proof,
+  annotations: shannonEntropyOq03Oq01Annotations,
+}

--- a/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03-oq-01/meta.json
@@ -59,6 +59,57 @@
       "Can the quantum (von Neumann) equality case be formalized, characterizing saturation by short quantum Markov chains?"
     ]
   },
+  "sections": [
+    {
+      "id": "overview-docstring",
+      "title": "Statement of the equality condition",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring fixing the goal: SSA H(X,Y,Z)+H(Y) ≤ H(X,Y)+H(Y,Z) holds with equality iff X–Y–Z is a Markov chain, p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z). Outlines the two-step reduction (deficit = CMI, then CMI = 0 iff factorization) and notes the file is self-contained over Mathlib."
+    },
+    {
+      "id": "entropy-marginals",
+      "title": "Shannon entropy and three-variable marginals",
+      "startLine": 44,
+      "endLine": 70,
+      "summary": "Self-contained definitions: shannonEntropy' p = −Σ p log p with the 0·log 0 = 0 convention, and the three marginals marginalXY (sum over z), marginalYZ (sum over x), marginalY_3 (sum over x and z). These mirror the parent SSA formalization so the equality file stands alone."
+    },
+    {
+      "id": "telescope-kl-bounds",
+      "title": "Marginal telescoping and pointwise KL bounds",
+      "startLine": 72,
+      "endLine": 122,
+      "summary": "Helper lemmas: marginal_telescope (S log S = Σ_i a_i log S for S = Σ a_i, used to align marginal-entropy terms), rlog_lt_sub_one (log y < y − 1 strictly for y ≠ 1), the non-strict KL bound kl_lb (p log(p/q) ≥ p − q), and its strict refinement kl_lb_strict (p log(p/q) > p − q when p ≠ q) — the engine of the equality case."
+    },
+    {
+      "id": "cmisum-definition",
+      "title": "Conditional mutual information as a relative entropy",
+      "startLine": 124,
+      "endLine": 137,
+      "summary": "cmiSum pXYZ = Σ_{x,y,z} p(x,y,z)·log( p(x,y,z)·p_Y(y) / (p_{XY}(x,y)·p_{YZ}(y,z)) ), the relative entropy D(p ‖ q) against the conditional-independence law q = p_{XY}·p_{YZ}/p_Y, written division-free so zero-probability slices contribute 0."
+    },
+    {
+      "id": "deficit-equals-cmi",
+      "title": "ssa_deficit_eq_cmi: the SSA deficit is exactly I(X;Z|Y)",
+      "startLine": 139,
+      "endLine": 251,
+      "summary": "Entropy-algebra identity: H(X,Y)+H(Y,Z)−H(X,Y,Z)−H(Y) = cmiSum. Each entropy is expanded as a nested sum over (x,y,z); marginal_telescope rewrites the marginal entropies; log p(x,y,z) splits into the conditional-MI term plus three marginal logs that cancel, collapsing the deficit to the single relative-entropy sum."
+    },
+    {
+      "id": "cmi-zero-iff-markov",
+      "title": "ssa_cmi_eq_zero_iff: vanishing CMI ⟺ Markov factorization",
+      "startLine": 252,
+      "endLine": 428,
+      "summary": "cmiSum = 0 ↔ p(x,y,z)·p_Y(y) = p_{XY}(x,y)·p_{YZ}(y,z) for all x,y,z. Forward: every summand p·log(p/q) dominates p − q and Σ(p − q) = 0, so each must equal p − q; the strict KL bound then forces p = q everywhere. Backward: substituting the factorization makes each log(p/q) = log 1 = 0."
+    },
+    {
+      "id": "ssa-equality-iff",
+      "title": "strong_subadditivity_eq_iff: SSA equality ⟺ Markov chain",
+      "startLine": 429,
+      "endLine": 446,
+      "summary": "Combining the two reductions: H(X,Y,Z)+H(Y) = H(X,Y)+H(Y,Z) iff X and Z are conditionally independent given Y, i.e. X–Y–Z is a Markov chain — the sharp boundary of the deepest classical entropy inequality."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "shannon-entropy-oq-03",


### PR DESCRIPTION
Enrichment pass for `shannon-entropy-oq-03-oq-01`.

## Changes
- **Created missing `index.ts`** — the proof directory had only meta.json + annotations.json, so the page rendered "proof not found" on the live site. The new Vite entry point wires meta, annotations, and the raw Lean source.
- **Added 7 `sections`** (the array was absent) covering the full 446-line Lean file: overview docstring → entropy/marginal defs → telescoping + KL bounds → cmiSum definition → the three core theorems.
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

No mathematical claims altered; `status: verified`, `axiomCount: 0` left intact (self-contained over Mathlib, 0 sorries/0 axioms). Build passes (`pnpm build`).