### PR TITLE
research(erdos-798): prove t(n)=o(n) + repair non-compiling base file [axiomatized, offline-verified]

### DIFF
--- a/proofs/Proofs/Erdos798Problem.lean
+++ b/proofs/Proofs/Erdos798Problem.lean
@@ -30,8 +30,9 @@ import Mathlib.Data.Set.Card
 import Mathlib.Data.Finset.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics
 
-open Set Real Finset
+open Set Real Finset Filter Asymptotics
 
 namespace Erdos798
 
@@ -197,16 +198,49 @@ theorem t_is_o_n :
     ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n ≥ N, (t n : ℝ) < ε * n := by
   intro ε hε
   obtain ⟨C, hC, hbound⟩ := alon_upper_bound
-  -- For large n, C · n^{2/3} · log n < ε · n
-  -- Equivalent to C · log n < ε · n^{1/3}
-  -- This holds for large enough n
-  sorry
+  -- The upper-bound majorant `C · x^{2/3} · log x` is `o(x)`, because
+  -- `log x = o(x^{1/3})`, hence `x^{2/3} · log x = o(x^{2/3} · x^{1/3}) = o(x)`.
+  have hlog : Real.log =o[atTop] fun x : ℝ => x ^ (1 / 3 : ℝ) :=
+    isLittleO_log_rpow_atTop (by norm_num)
+  have hmul : (fun x : ℝ => x ^ (2 / 3 : ℝ) * Real.log x) =o[atTop]
+      fun x : ℝ => x ^ (2 / 3 : ℝ) * x ^ (1 / 3 : ℝ) :=
+    (isBigO_refl (fun x : ℝ => x ^ (2 / 3 : ℝ)) atTop).mul_isLittleO hlog
+  have hEq : (fun x : ℝ => x ^ (2 / 3 : ℝ) * x ^ (1 / 3 : ℝ)) =ᶠ[atTop] fun x : ℝ => x := by
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with x hx
+    have hsum : (2 / 3 : ℝ) + 1 / 3 = 1 := by norm_num
+    rw [← Real.rpow_add hx, hsum, Real.rpow_one]
+  have hmul' : (fun x : ℝ => x ^ (2 / 3 : ℝ) * Real.log x) =o[atTop] fun x : ℝ => x :=
+    hmul.congr' (EventuallyEq.refl _ _) hEq
+  -- Scale by the constant `C`.
+  have key : (fun x : ℝ => C * x ^ (2 / 3 : ℝ) * Real.log x) =o[atTop] fun x : ℝ => x := by
+    refine (hmul'.const_mul_left C).congr' ?_ (EventuallyEq.refl _ _)
+    filter_upwards with x using by ring
+  -- Turn the `o(x)` bound into a pointwise estimate `≤ (ε/2)·x` eventually.
+  have hReal : ∀ᶠ x : ℝ in atTop, C * x ^ (2 / 3 : ℝ) * Real.log x ≤ ε / 2 * x := by
+    filter_upwards [key.def (half_pos hε), eventually_gt_atTop (0 : ℝ)] with x hxb hx0
+    calc C * x ^ (2 / 3 : ℝ) * Real.log x
+        ≤ ‖C * x ^ (2 / 3 : ℝ) * Real.log x‖ := le_abs_self _
+      _ ≤ ε / 2 * ‖x‖ := hxb
+      _ = ε / 2 * x := by rw [Real.norm_eq_abs, abs_of_pos hx0]
+  -- Transfer the eventual bound from `ℝ` to `ℕ`.
+  have hNat : ∀ᶠ n : ℕ in atTop, C * (n : ℝ) ^ (2 / 3 : ℝ) * Real.log n ≤ ε / 2 * n :=
+    tendsto_natCast_atTop_atTop.eventually hReal
+  rw [Filter.eventually_atTop] at hNat
+  obtain ⟨N₀, hN₀⟩ := hNat
+  refine ⟨max N₀ 2, fun n hn => ?_⟩
+  have hn0 : N₀ ≤ n := le_trans (le_max_left _ _) hn
+  have hn2 : 2 ≤ n := le_trans (le_max_right _ _) hn
+  have hnpos : (0 : ℝ) < n := by exact_mod_cast lt_of_lt_of_le (by norm_num : 0 < 2) hn2
+  calc (t n : ℝ)
+      ≤ C * (n : ℝ) ^ (2 / 3 : ℝ) * Real.log n := hbound n hn2
+    _ ≤ ε / 2 * n := hN₀ n hn0
+    _ < ε * n := by nlinarith [mul_pos hε hnpos]
 
 /-
 ## Part VI: Examples and Explicit Bounds
 -/
 
-/--
+/-
 **Example: Small n**
 For small n, we can compute or bound t(n) explicitly.
 -/
@@ -230,7 +264,7 @@ theorem t_3_bound : t 3 ≤ 4 := by
 t(n) ≥ ceiling(n^{2/3})
 -/
 theorem explicit_lower (n : ℕ) (hn : n ≥ 1) :
-    t n ≥ Nat.ceil (n ^ (2/3 : ℝ)) := by
+    t n ≥ Nat.ceil ((n : ℝ) ^ (2/3 : ℝ)) := by
   sorry
 
 /-

--- a/src/data/proofs/erdos-798/annotations.json
+++ b/src/data/proofs/erdos-798/annotations.json
@@ -203,12 +203,12 @@
     "id": "ann-e798-o-n",
     "proofId": "erdos-798",
     "range": {
-      "startLine": 190,
-      "endLine": 203
+      "startLine": 191,
+      "endLine": 237
     },
     "type": "concept",
     "title": "t(n) = o(n)",
-    "content": "**t_is_o_n:**\n\nThe answer to Erdos's question is YES.\n\n**Proof outline:**\nt(n) <= C * n^{2/3} * log n\n\nFor any epsilon > 0, eventually:\nC * n^{2/3} * log n < epsilon * n\n\nThis holds because n^{2/3} * log n = o(n) (since 2/3 < 1).",
+    "content": "**t_is_o_n:**\n\nThe answer to Erdos's question is YES — now fully proven (no `sorry`) from the Alon upper-bound axiom.\n\n**Proof:**\nt(n) <= C * n^{2/3} * log n, and the majorant C * x^{2/3} * log x = o(x):\nsince log x = o(x^{1/3}) (`isLittleO_log_rpow_atTop`), multiplying by x^{2/3} gives\nx^{2/3} * log x = o(x^{2/3} * x^{1/3}) = o(x). Hence for every epsilon > 0, eventually\nC * n^{2/3} * log n < epsilon * n, so t(n) < epsilon * n. The o(x) estimate is\ntransferred from the real variable to the naturals via tendsto_natCast_atTop_atTop.\nDepends only on the Alon upper-bound axiom (no sorry).",
     "significance": "key",
     "mathContext": "See annotation content for formal details of t(n) = o(n)",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 6,
     "erdosNumber": 798,
     "erdosUrl": "https://erdosproblems.com/798",
     "erdosProblemStatus": "solved",
@@ -44,6 +44,11 @@
         "theorem": "Real.rpow",
         "description": "Real exponentiation",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.isLittleO_log_rpow_atTop",
+        "description": "log x = o(x^r) for r>0, the key asymptotic for t(n)=o(n)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
       }
     ],
     "originalContributions": [
@@ -61,8 +66,8 @@
       "Explicit bounds for small n: t(2), t(3)"
     ],
     "axiomCount": 3,
-    "lineCount": 311,
-    "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
+    "lineCount": 345,
+    "assumptions": "3 axiom(s) and 6 sorry(s). See the Lean source for details.",
     "theoremCount": 11,
     "definitionCount": 7,
     "additionalFiles": [
@@ -170,19 +175,22 @@
       "Mathlib.Data.Set.Card",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-      "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Asymptotics"
     ],
     "opens": [
       "Set",
       "Real",
-      "Finset"
+      "Finset",
+      "Filter",
+      "Asymptotics"
     ],
     "namespace": "Erdos798",
-    "lineCount": 311,
+    "lineCount": 345,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 7,
-    "sorries": 7,
+    "sorries": 6,
     "path": "Proofs/Erdos798Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos798Aristotle.lean",
@@ -206,5 +214,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, geometry, solved"
     }
   ],
-  "sorries": 7
+  "sorries": 6
 }


### PR DESCRIPTION
## Erdős Problem #798 — covering lattice points with lines

`t(n)` = minimum points in {1,…,n}² whose determined lines cover the whole grid. Erdős asked: is `t(n) = o(n)`? **Yes** — Alon (1991) proved `t(n) = Θ(n^{2/3} log n)`.

This PR does two things to the existing gallery entry `erdos-798`.

### 1. The base Lean file did not compile on `main`
`proofs/Proofs/Erdos798Problem.lean` had two pre-existing errors (verified by running `lake env lean` on the pristine `main` copy):
- a dangling `/-- … -/` docstring with no attached declaration → `unexpected token '/--'; expected 'lemma'`;
- `Nat.ceil (n ^ (2/3 : ℝ))` with `n : ℕ` → `failed to synthesize HPow ℕ ℝ`.

Fixed by turning the section docstring into a `/- -/` block comment and casting `(n : ℝ)` in `explicit_lower`. The file now typechecks.

### 2. Proved the central result `t_is_o_n` (was `sorry`)
The literal "answer is YES" — `t(n) = o(n)` — is now derived from the `alon_upper_bound` axiom:

- `log x = o(x^{1/3})` via `isLittleO_log_rpow_atTop`;
- multiply by `x^{2/3}`: `x^{2/3}·log x = o(x^{2/3}·x^{1/3}) = o(x)`;
- scale by the constant `C`, extract the eventual bound `C·x^{2/3}·log x ≤ (ε/2)·x`;
- transfer from `ℝ` to `ℕ` with `tendsto_natCast_atTop_atTop`, combine with `t n ≤ C·n^{2/3}·log n`.

This also makes `erdos_798` and `erdos_798_answer` genuine (they reference `t_is_o_n`).

```
#print axioms Erdos798.t_is_o_n
  → [propext, Classical.choice, Erdos798.alon_upper_bound, Quot.sound]   -- no sorryAx
```

### Status
- **Sorries 7 → 6**; file now compiles (offline `lake env lean`, Mathlib v4.26.0).
- Remaining 3 axioms (Erdős–Purdy lower bound, Alon upper bound, Alon construction) and 6 sorries are genuine deep results / constructions — **status stays `axiomatized`**.
- `meta.json` / `annotations.json` updated: sorry count, line count, imports/opens, and the `t_is_o_n` annotation (now fully proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)