### PR TITLE
research(jensen-inequality-oq-01-oq-02): weighted power-mean monotonicity M_p ≤ M_q for 0<p≤q [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3351,6 +3351,7 @@ import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01
 import Proofs.JensenInequalityOQ01OQ01OQ01OQ01
 import Proofs.JensenInequalityOQ01OQ01OQ01OQ03
+import Proofs.JensenInequalityOQ01OQ02
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeithNumberOQ01OQ02

--- a/proofs/Proofs/JensenInequalityOQ01OQ02.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ02.lean
@@ -1,0 +1,87 @@
+/-
+# Weighted Power-Mean Monotonicity in the Exponent
+
+For nonnegative data `z : ι → ℝ` with nonnegative weights `w` summing to `1`, the
+**weighted power mean**
+
+    M_r(z; w) = (∑ᵢ wᵢ · zᵢ^r) ^ (1/r)
+
+is monotone *nondecreasing in the exponent* `r`: if `0 < p ≤ q` then `M_p ≤ M_q`.
+
+This is the classical generalized-mean (Hölder/power-mean) inequality. Mathlib provides the
+convexity engine for power maps — `Real.rpow_arith_mean_le_arith_mean_rpow`, the finite weighted
+Jensen inequality `(∑ wᵢ zᵢ)^t ≤ ∑ wᵢ zᵢ^t` for `t ≥ 1` — but it does **not** package the
+monotonicity of `M_r` in `r`. That derivation is the content of this file.
+
+## The argument
+
+Write `A = ∑ wᵢ zᵢ^p` and `B = ∑ wᵢ zᵢ^q`. Put `t = q/p ≥ 1`. Applying Jensen with exponent `t`
+to the data `yᵢ = zᵢ^p`:
+
+    A^t = (∑ wᵢ zᵢ^p)^t ≤ ∑ wᵢ (zᵢ^p)^t = ∑ wᵢ zᵢ^{p·t} = ∑ wᵢ zᵢ^q = B,
+
+using `(zᵢ^p)^t = zᵢ^{p·t}` and `p·t = q`. Raising the monotone inequality `A^t ≤ B` to the power
+`1/q ≥ 0` and simplifying `(A^t)^{1/q} = A^{t/q} = A^{1/p}` gives `M_p = A^{1/p} ≤ B^{1/q} = M_q`.
+
+## Main results
+
+* `powerMean_le_powerMean` — weighted power-mean monotonicity for `0 < p ≤ q`.
+* `weighted_am_le_qm` — the arithmetic mean ≤ quadratic mean specialization (`p = 1`, `q = 2`).
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+
+open Finset Real
+
+variable {ι : Type*} {s : Finset ι} {w z : ι → ℝ}
+
+/-- **Weighted power-mean monotonicity** (positive exponents).
+For nonnegative data `z` with nonnegative weights `w` summing to `1`, and `0 < p ≤ q`, the
+weighted power mean is monotone nondecreasing in the exponent:
+`(∑ᵢ wᵢ · zᵢ^p)^(1/p) ≤ (∑ᵢ wᵢ · zᵢ^q)^(1/q)`. -/
+theorem powerMean_le_powerMean
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i)
+    {p q : ℝ} (hp : 0 < p) (hpq : p ≤ q) :
+    (∑ i ∈ s, w i * z i ^ p) ^ (1 / p) ≤ (∑ i ∈ s, w i * z i ^ q) ^ (1 / q) := by
+  have hq : 0 < q := lt_of_lt_of_le hp hpq
+  have hp' : p ≠ 0 := hp.ne'
+  have hq' : q ≠ 0 := hq.ne'
+  -- the exponent ratio `t = q / p ≥ 1`
+  set t : ℝ := q / p with ht
+  have ht1 : 1 ≤ t := by rw [ht, le_div_iff₀ hp]; linarith
+  -- nonnegativity facts
+  have hzp : ∀ i ∈ s, 0 ≤ z i ^ p := fun i hi => rpow_nonneg (hz i hi) p
+  have hA : 0 ≤ ∑ i ∈ s, w i * z i ^ p :=
+    sum_nonneg fun i hi => mul_nonneg (hw i hi) (hzp i hi)
+  -- `p · t = q`, so `(zᵢ^p)^t = zᵢ^q`
+  have hpt : p * t = q := by
+    rw [ht]; field_simp
+  have hrw : ∀ i ∈ s, w i * (z i ^ p) ^ t = w i * z i ^ q := by
+    intro i hi
+    rw [← Real.rpow_mul (hz i hi) p t, hpt]
+  -- Jensen with exponent `t` applied to `yᵢ = zᵢ^p`
+  have key : (∑ i ∈ s, w i * z i ^ p) ^ t ≤ ∑ i ∈ s, w i * z i ^ q := by
+    calc (∑ i ∈ s, w i * z i ^ p) ^ t
+        ≤ ∑ i ∈ s, w i * (z i ^ p) ^ t :=
+          Real.rpow_arith_mean_le_arith_mean_rpow s w (fun i => z i ^ p) hw hw' hzp ht1
+      _ = ∑ i ∈ s, w i * z i ^ q := sum_congr rfl hrw
+  -- raise `A^t ≤ B` to the power `1/q`, then rewrite `(A^t)^{1/q} = A^{1/p}`
+  have hexp : t * (1 / q) = 1 / p := by
+    rw [ht]; field_simp
+  calc (∑ i ∈ s, w i * z i ^ p) ^ (1 / p)
+      = ((∑ i ∈ s, w i * z i ^ p) ^ t) ^ (1 / q) := by
+        rw [← Real.rpow_mul hA, hexp]
+    _ ≤ (∑ i ∈ s, w i * z i ^ q) ^ (1 / q) :=
+        Real.rpow_le_rpow (by positivity) key (by positivity)
+
+/-- **Arithmetic mean ≤ quadratic mean** (weighted), the `p = 1, q = 2` specialization of
+power-mean monotonicity:
+`∑ᵢ wᵢ zᵢ ≤ (∑ᵢ wᵢ zᵢ²)^(1/2)`. -/
+theorem weighted_am_le_qm
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∑ i ∈ s, w i * z i ≤ (∑ i ∈ s, w i * z i ^ (2 : ℝ)) ^ (1 / 2 : ℝ) := by
+  have h := powerMean_le_powerMean hw hw' hz (p := 1) (q := 2) one_pos (by norm_num)
+  -- normalize the `M_1` side: `(∑ wᵢ zᵢ^(1:ℝ))^(1/1) = ∑ wᵢ zᵢ`
+  simpa using h

--- a/src/data/proofs/jensen-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-02/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "jensen-inequality-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "Goal: power-mean monotonicity in the exponent, a gap in Mathlib",
+    "content": "The weighted power mean M_r(z; w) = (∑ᵢ wᵢ·zᵢ^r)^(1/r) interpolates the harmonic (r = -1), geometric (r → 0), arithmetic (r = 1), and quadratic (r = 2) means. Its monotonicity in r — the generalized-mean / Hölder inequality — is classical, but Mathlib packages only the underlying convex-power Jensen inequality (Real.rpow_arith_mean_le_arith_mean_rpow), not the monotonicity of M_r. This file proves the positive-exponent case: 0 < p ≤ q ⟹ (∑ wᵢ zᵢ^p)^(1/p) ≤ (∑ wᵢ zᵢ^q)^(1/q), for nonnegative data and nonnegative weights summing to 1. The strategy is a change of variable: raise the data to the ratio exponent t = q/p ≥ 1 so a single Jensen application does the work."
+  },
+  {
+    "id": "ann-power-mean-monotone",
+    "proofId": "jensen-inequality-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 77 },
+    "type": "theorem",
+    "title": "Weighted power-mean monotonicity (0 < p ≤ q)",
+    "content": "powerMean_le_powerMean is the main result. Write A = ∑ wᵢ zᵢ^p, B = ∑ wᵢ zᵢ^q and set t = q/p ≥ 1 (from le_div_iff₀ hp and p ≤ q). Because t ≥ 1, Mathlib's Real.rpow_arith_mean_le_arith_mean_rpow applied to the data yᵢ = zᵢ^p (nonnegative via rpow_nonneg) gives A^t ≤ ∑ wᵢ (zᵢ^p)^t. The pointwise identity (zᵢ^p)^t = zᵢ^{p·t} (Real.rpow_mul, valid since zᵢ ≥ 0) together with p·t = q rewrites the right side to B, so A^t ≤ B. Both sums are nonnegative, so Real.rpow_le_rpow raises the bound to the power 1/q: (A^t)^{1/q} ≤ B^{1/q}. Finally (A^t)^{1/q} = A^{t·(1/q)} = A^{1/p}, using t·(1/q) = (q/p)·(1/q) = 1/p, which yields M_p = A^{1/p} ≤ B^{1/q} = M_q."
+  },
+  {
+    "id": "ann-am-le-qm",
+    "proofId": "jensen-inequality-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 87 },
+    "type": "theorem",
+    "title": "Arithmetic mean ≤ quadratic mean (specialization)",
+    "content": "weighted_am_le_qm instantiates the monotonicity theorem at (p, q) = (1, 2) to obtain the weighted arithmetic-mean ≤ quadratic-mean inequality ∑ wᵢ zᵢ ≤ (∑ wᵢ zᵢ²)^(1/2). The only work is normalizing the M₁ side: zᵢ^{(1:ℝ)} = zᵢ (Real.rpow_one) and the outer exponent 1/1 = 1 collapse the left power mean to the plain weighted average, discharged by simp. This shows how the single monotonicity theorem subsumes the named two-rung inequalities for free."
+  }
+]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "jensen-inequality-oq-01-oq-02",
+  "title": "Weighted Power-Mean Monotonicity in the Exponent (M_p ≤ M_q)",
+  "slug": "jensen-inequality-oq-01-oq-02",
+  "description": "Proves the weighted power-mean inequality for positive exponents: for nonnegative data zᵢ and weights wᵢ ≥ 0 summing to 1, the generalized power mean M_r = (∑ᵢ wᵢ·zᵢ^r)^(1/r) is monotone nondecreasing in the exponent r over the positive range — if 0 < p ≤ q then (∑ᵢ wᵢ·zᵢ^p)^(1/p) ≤ (∑ᵢ wᵢ·zᵢ^q)^(1/q). Mathlib supplies the convexity engine (Real.rpow_arith_mean_le_arith_mean_rpow, finite weighted Jensen for the convex map t ↦ t^s, s ≥ 1) but does not package monotonicity of M_r in the exponent; this entry derives it. The proof sets t = q/p ≥ 1 and applies Jensen with exponent t to the data yᵢ = zᵢ^p: (∑ wᵢ zᵢ^p)^t ≤ ∑ wᵢ (zᵢ^p)^t = ∑ wᵢ zᵢ^q, using (zᵢ^p)^t = zᵢ^{p·t} and p·t = q; raising the resulting bound A^t ≤ B to the power 1/q ≥ 0 and simplifying (A^t)^{1/q} = A^{1/p} gives M_p ≤ M_q. The arithmetic-mean ≤ quadratic-mean inequality is recovered as the (p,q) = (1,2) specialization. Directly answers the top open question recorded by the gallery sibling jensen-inequality-oq-01-oq-01-oq-01-oq-02 (full power-mean monotonicity for real exponents) over the positive range.",
+  "meta": {
+    "author": "Lean Genius (power-mean monotonicity via Jensen with exponent q/p); classical (generalized-mean / Hölder inequality)",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "power-means",
+      "inequalities",
+      "jensen",
+      "rpow",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-25",
+    "lineCount": 87,
+    "originalContributions": [
+      "powerMean_le_powerMean: weighted power-mean monotonicity for positive exponents — for nonnegative data and nonnegative weights summing to 1, 0 < p ≤ q implies (∑ᵢ wᵢ·zᵢ^p)^(1/p) ≤ (∑ᵢ wᵢ·zᵢ^q)^(1/q). Not packaged in Mathlib; derived from the rpow Jensen inequality by raising the data to the power-ratio exponent t = q/p ≥ 1.",
+      "weighted_am_le_qm: the weighted arithmetic-mean ≤ quadratic-mean inequality ∑ᵢ wᵢ·zᵢ ≤ (∑ᵢ wᵢ·zᵢ²)^(1/2), obtained as the (p,q) = (1,2) specialization of the monotonicity theorem."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. #print axioms reports only propext / Classical.choice / Quot.sound. Builds on the Mathlib rpow library (Real.rpow_arith_mean_le_arith_mean_rpow, Real.rpow_mul, Real.rpow_le_rpow).",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "That entry (weighted AM–HM, the M₋₁ ≤ M₁ rung) explicitly poses as its top open question the full weighted power-mean monotonicity M_r ≤ M_s for real exponents r ≤ s, via convexity of t ↦ t^{s/r} and Jensen. This entry answers it over the positive range 0 < p ≤ q with exactly that argument."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "extends",
+      "description": "Sits on the same weighted power-mean ladder as the parent Jensen/AM–GM chain, but proves monotonicity in the exponent rather than a fixed rung, using Mathlib's rpow Jensen inequality directly instead of the AM–GM specialization."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The power means M_r(z; w) = (∑ wᵢ zᵢ^r)^{1/r} interpolate between the harmonic (r = -1), geometric (r → 0), arithmetic (r = 1), and quadratic (r = 2) means, and their monotonicity in r is one of the classical inequalities of analysis (the generalized-mean or Hölder inequality). Mathlib formalizes the weighted Jensen inequality for convex power maps but does not record the monotonicity of M_r in the exponent; this entry supplies the positive-exponent case.",
+    "problemStatement": "Prove that for nonnegative data zᵢ and nonnegative weights wᵢ summing to 1, the weighted power mean M_r = (∑ wᵢ zᵢ^r)^{1/r} is monotone nondecreasing in r over r > 0: 0 < p ≤ q ⟹ (∑ wᵢ zᵢ^p)^{1/p} ≤ (∑ wᵢ zᵢ^q)^{1/q}.",
+    "proofStrategy": "Let A = ∑ wᵢ zᵢ^p, B = ∑ wᵢ zᵢ^q, and set t = q/p ≥ 1. The map t ≥ 1 makes y ↦ y^t convex, so Mathlib's Real.rpow_arith_mean_le_arith_mean_rpow applied to the data yᵢ = zᵢ^p gives A^t = (∑ wᵢ zᵢ^p)^t ≤ ∑ wᵢ (zᵢ^p)^t. Since (zᵢ^p)^t = zᵢ^{p·t} (Real.rpow_mul, valid as zᵢ ≥ 0) and p·t = q, the right side equals B, so A^t ≤ B. Both A, B ≥ 0, so raising to the power 1/q ≥ 0 preserves the inequality (Real.rpow_le_rpow): (A^t)^{1/q} ≤ B^{1/q}. Finally (A^t)^{1/q} = A^{t·(1/q)} = A^{1/p} because t·(1/q) = (q/p)·(1/q) = 1/p, giving M_p = A^{1/p} ≤ B^{1/q} = M_q.",
+    "keyInsights": [
+      "Monotonicity in the exponent is not a new convexity fact but a change of variable on the existing rpow Jensen inequality: raising the data to the ratio exponent t = q/p ≥ 1 turns 'M_p ≤ M_q' into a single application of the convex-power Jensen bound.",
+      "The exponent bookkeeping is the whole proof: p·t = q collapses ∑ wᵢ (zᵢ^p)^t to ∑ wᵢ zᵢ^q, and t·(1/q) = 1/p collapses (A^t)^{1/q} to A^{1/p}. Both are elementary rpow identities (Real.rpow_mul) valid because the base is nonnegative.",
+      "The argument needs only 0 < p ≤ q, not p ≥ 1 or any normalization of the data; the weight normalization ∑ wᵢ = 1 is the only structural hypothesis, inherited from the Jensen inequality.",
+      "Specializing to (p, q) = (1, 2) recovers the weighted arithmetic-mean ≤ quadratic-mean inequality with no extra work, illustrating how the single monotonicity theorem subsumes the named two-rung inequalities."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "States the goal — weighted power-mean monotonicity M_p ≤ M_q for 0 < p ≤ q, a gap in Mathlib — and outlines the change-of-variable strategy: apply the rpow Jensen inequality with exponent t = q/p ≥ 1, then raise to the power 1/q.",
+      "mathContext": "Power mean $M_r(z;w) = (\\sum_i w_i z_i^r)^{1/r}$; claim: $0 < p \\le q \\Rightarrow M_p \\le M_q$ for $z_i \\ge 0$, $w_i \\ge 0$, $\\sum_i w_i = 1$."
+    },
+    {
+      "id": "power-mean-monotone",
+      "title": "Weighted power-mean monotonicity",
+      "startLine": 40,
+      "endLine": 77,
+      "summary": "powerMean_le_powerMean: set t = q/p ≥ 1; Jensen (Real.rpow_arith_mean_le_arith_mean_rpow) on yᵢ = zᵢ^p gives A^t ≤ ∑ wᵢ zᵢ^q = B (via (zᵢ^p)^t = zᵢ^{p·t}, p·t = q); raise to 1/q (Real.rpow_le_rpow) and simplify (A^t)^{1/q} = A^{1/p} to conclude M_p ≤ M_q.",
+      "mathContext": "$A^{q/p} \\le B$ then $(A^{q/p})^{1/q} = A^{1/p} \\le B^{1/q}$, where $A = \\sum_i w_i z_i^p$, $B = \\sum_i w_i z_i^q$."
+    },
+    {
+      "id": "am-le-qm",
+      "title": "Arithmetic mean ≤ quadratic mean",
+      "startLine": 79,
+      "endLine": 87,
+      "summary": "weighted_am_le_qm: the (p,q) = (1,2) specialization, ∑ wᵢ zᵢ ≤ (∑ wᵢ zᵢ²)^{1/2}, obtained by instantiating powerMean_le_powerMean and normalizing the M₁ side (zᵢ^{(1:ℝ)} = zᵢ, exponent 1/1 = 1).",
+      "mathContext": "$\\sum_i w_i z_i \\le \\left(\\sum_i w_i z_i^2\\right)^{1/2}$, the weighted AM–QM inequality."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 87-line file (0 sorries, 0 axioms, no native_decide) proves weighted power-mean monotonicity over positive exponents — 0 < p ≤ q ⟹ M_p ≤ M_q — which Mathlib does not package, and recovers the weighted arithmetic-mean ≤ quadratic-mean inequality as a specialization. The proof is a single change of variable on Mathlib's rpow Jensen inequality.",
+    "implications": "This answers, over the positive range, the open question posed by the AM–HM sibling entry: the full power-mean ladder M_r is monotone in r. The same change-of-variable template would extend to negative exponents (with the inequality direction tracked through the sign of the ratio) and, in the limit, to the geometric-mean rung M_r → G as r → 0.",
+    "openQuestions": [
+      "Extend monotonicity to all real exponents, including p < 0 ≤ q and both-negative ranges, unifying the harmonic (r = -1) and geometric (r → 0) rungs with the positive-exponent case proved here.",
+      "Establish the equality case: M_p = M_q (for p < q) holds iff all the data zᵢ with positive weight are equal, via the strict convexity of t ↦ t^{q/p} and the strict Jensen inequality.",
+      "Prove the limiting identifications M_r → ∏ zᵢ^{wᵢ} as r → 0 and M_r → max zᵢ / min zᵢ as r → ±∞, connecting the discrete ladder to its endpoints."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 87,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 2,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **weighted power-mean monotonicity over positive exponents** — a gap in Mathlib. For nonnegative data `zᵢ` and weights `wᵢ ≥ 0` summing to `1`,

```
0 < p ≤ q  ⟹  (∑ᵢ wᵢ·zᵢ^p)^(1/p) ≤ (∑ᵢ wᵢ·zᵢ^q)^(1/q)
```

i.e. the generalized power mean `M_r = (∑ wᵢ zᵢ^r)^(1/r)` is monotone nondecreasing in the exponent `r` over `r > 0`.

Mathlib supplies the convex-power Jensen inequality (`Real.rpow_arith_mean_le_arith_mean_rpow`) but does **not** package monotonicity of `M_r` in the exponent.

## Proof

A change of variable on the existing rpow Jensen inequality. With `A = ∑ wᵢ zᵢ^p`, `B = ∑ wᵢ zᵢ^q`, set `t = q/p ≥ 1`. Jensen applied to the data `yᵢ = zᵢ^p` gives `A^t ≤ ∑ wᵢ (zᵢ^p)^t = ∑ wᵢ zᵢ^q = B` (using `(zᵢ^p)^t = zᵢ^{p·t}`, `p·t = q`). Raising `A^t ≤ B` to the power `1/q ≥ 0` and simplifying `(A^t)^{1/q} = A^{1/p}` yields `M_p ≤ M_q`.

## Results

- `powerMean_le_powerMean` — the main monotonicity theorem (0 < p ≤ q).
- `weighted_am_le_qm` — weighted arithmetic-mean ≤ quadratic-mean, the (p,q) = (1,2) specialization.

## Verification

Fully machine-checked: **0 sorries, 0 axioms, no `native_decide`**. `#print axioms` reports only `propext / Classical.choice / Quot.sound`. Typechecked locally with `lake env lean` (exit 0).

## Context

Directly answers the top open question recorded by the gallery sibling `jensen-inequality-oq-01-oq-01-oq-01-oq-02` (weighted AM–HM): *"Prove the full weighted power-mean monotonicity M_r ≤ M_s for real exponents r ≤ s, via convexity of t ↦ t^{s/r} and Jensen"* — delivered here over the positive range, by exactly that argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)