### PR TITLE
research(hermite-floor-identity): Hermite's floor identity ∑⌊x+k/n⌋=⌊nx⌋ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3207,6 +3207,7 @@ import Proofs.HarmonicDivergenceOQ04
 import Proofs.HarmonicDivergenceOQ05
 import Proofs.HarmonicDivergenceOQ05OQ01
 import Proofs.HarmonicDivergenceOQ05OQ02
+import Proofs.HermiteFloorIdentity
 import Proofs.HermiteLindemann
 import Proofs.HeronsFormula
 import Proofs.HeronsFormulaOQ01

--- a/proofs/Proofs/HermiteFloorIdentity.lean
+++ b/proofs/Proofs/HermiteFloorIdentity.lean
@@ -1,0 +1,100 @@
+/-
+# Hermite's Identity for the Floor Function
+
+For every real `x` and every integer `n ≥ 1`,
+$$\sum_{k=0}^{n-1} \left\lfloor x + \frac{k}{n} \right\rfloor = \lfloor n x \rfloor.$$
+
+This is the classical identity of Charles Hermite (1880s).  It is *not* the
+Hermite–Lindemann transcendence theorem (an unrelated result that already lives
+in the gallery as `HermiteLindemann.lean`), nor is it about Hermite polynomials
+or Hermite normal form.
+
+## Strategy
+
+The proof factors through two elementary steps:
+
+1. **Real → integer reduction.**  Using `Int.floor_div_natCast`
+   (`⌊a / n⌋ = ⌊a⌋ / n`, where the right-hand division is Euclidean division on
+   `ℤ`) together with `Int.floor_add_natCast`, each real floor collapses to an
+   integer Euclidean quotient:
+   `⌊x + k/n⌋ = (⌊n·x⌋ + k) / n`.
+
+2. **Integer Hermite sum.**  The remaining statement
+   `∑_{k=0}^{n-1} (a + k) / n = a` (for any `a : ℤ`, `n ≥ 1`) is proved by
+   integer induction on `a`.  Shifting `a ↦ a + 1` reindexes the sum and changes
+   it by exactly `1`, so the linear function `a ↦ a` is pinned down by its value
+   `0` at `a = 0`.
+
+Because Euclidean division `/` on `ℤ` has a nonnegative remainder, for a positive
+divisor it coincides with floor division, which is precisely what makes step (1)
+valid for negative arguments.
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.
+-/
+import Mathlib
+
+open Finset
+
+namespace HermiteFloorIdentity
+
+/-- **Integer Hermite sum.**  For `n ≥ 1` and any integer `a`,
+the Euclidean quotients `(a + k) / n` over `k = 0, …, n-1` sum to `a`. -/
+theorem int_hermite_sum (n : ℕ) (hn : 0 < n) (a : ℤ) :
+    ∑ k ∈ range n, (a + (k : ℤ)) / (n : ℤ) = a := by
+  have hn' : (n : ℤ) ≠ 0 := by exact_mod_cast hn.ne'
+  -- The shift recurrence: replacing `b` by `b + 1` increases the sum by `1`.
+  have step : ∀ b : ℤ,
+      (∑ k ∈ range n, (b + 1 + (k : ℤ)) / (n : ℤ))
+        = (∑ k ∈ range n, (b + (k : ℤ)) / (n : ℤ)) + 1 := by
+    intro b
+    -- Reindex `k ↦ k + 1`, matching the `g (k+1)` shape of `sum_range_succ'`.
+    have key : (∑ k ∈ range n, (b + 1 + (k : ℤ)) / (n : ℤ))
+        = (∑ k ∈ range n, (b + (((k + 1 : ℕ) : ℤ))) / (n : ℤ)) := by
+      refine Finset.sum_congr rfl ?_
+      intro k _; congr 1; push_cast; ring
+    rw [key]
+    -- `∑_{range(n+1)} g = (∑_{range n} g(·+1)) + g 0`  and  `= (∑_{range n} g) + g n`.
+    have h1 := Finset.sum_range_succ' (fun j : ℕ => (b + (j : ℤ)) / (n : ℤ)) n
+    have h2 := Finset.sum_range_succ (fun j : ℕ => (b + (j : ℤ)) / (n : ℤ)) n
+    simp only at h1 h2
+    -- Endpoint quotients: `g 0 = b/n` and `g n = b/n + 1`.
+    have hg0 : (b + (((0 : ℕ) : ℤ))) / (n : ℤ) = b / (n : ℤ) := by norm_num
+    have hgn : (b + ((n : ℤ))) / (n : ℤ) = b / (n : ℤ) + 1 := by
+      rw [show b + (n : ℤ) = b + 1 * (n : ℤ) by ring, Int.add_mul_ediv_right b 1 hn']
+    linarith [h1, h2, hg0, hgn]
+  -- Integer induction on `a`, using the shift recurrence both ways.
+  refine Int.induction_on a ?_ ?_ ?_
+  · refine Finset.sum_eq_zero ?_
+    intro x hx
+    rw [Finset.mem_range] at hx
+    rw [zero_add]
+    have hnabs : |(n : ℤ)| = (n : ℤ) := abs_of_pos (by exact_mod_cast hn)
+    refine Int.ediv_eq_zero_of_lt_abs (by positivity) ?_
+    rw [hnabs]; exact_mod_cast hx
+  · intro i ih
+    rw [step (i : ℤ), ih]
+  · intro i ih
+    have hs := step (-(i : ℤ) - 1)
+    have heq : (∑ k ∈ range n, (-(i : ℤ) - 1 + 1 + (k : ℤ)) / (n : ℤ))
+        = (∑ k ∈ range n, (-(i : ℤ) + (k : ℤ)) / (n : ℤ)) := by
+      refine Finset.sum_congr rfl ?_
+      intro k _; congr 1; ring
+    rw [heq, ih] at hs
+    linarith [hs]
+
+/-- **Hermite's identity.**  For every real `x` and every `n ≥ 1`,
+`∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋`. -/
+theorem hermite_floor_identity (x : ℝ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, ⌊x + (k : ℝ) / (n : ℝ)⌋ = ⌊(n : ℝ) * x⌋ := by
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  -- Step 1: collapse each real floor to an integer Euclidean quotient.
+  have hterm : ∀ k ∈ range n,
+      ⌊x + (k : ℝ) / (n : ℝ)⌋ = (⌊(n : ℝ) * x⌋ + (k : ℤ)) / (n : ℤ) := by
+    intro k _
+    have hx : x + (k : ℝ) / (n : ℝ) = ((n : ℝ) * x + (k : ℝ)) / (n : ℝ) := by
+      field_simp
+    rw [hx, Int.floor_div_natCast, Int.floor_add_natCast]
+  -- Step 2: apply the integer Hermite sum.
+  rw [Finset.sum_congr rfl hterm, int_hermite_sum n hn ⌊(n : ℝ) * x⌋]
+
+end HermiteFloorIdentity

--- a/src/data/proofs/hermite-floor-identity/annotations.json
+++ b/src/data/proofs/hermite-floor-identity/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-hermitefloor-setup",
+    "proofId": "hermite-floor-identity",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Setup: Hermite's Floor Identity and the Two-Step Plan",
+    "content": "The file proves Hermite's classical identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋ for real x and integer n ≥ 1. The docstring is careful to distinguish this from the unrelated `Hermite` objects in Mathlib — the Hermite–Lindemann transcendence theorem (already a gallery entry), Hermite polynomials, and Hermite normal form — none of which concern the floor identity. The strategy is announced up front: first reduce each real floor to an integer Euclidean quotient using Mathlib's division-floor law ⌊a/n⌋ = ⌊a⌋/n, then prove the remaining purely integer identity ∑_{k<n}(a+k)/n = a by induction on a. The single import of full Mathlib pulls in the `Int.floor`, Euclidean-division, and `Finset.range` summation APIs used below.",
+    "mathContext": "For real $x$ and $n \\ge 1$: $\\sum_{k=0}^{n-1}\\lfloor x + k/n\\rfloor = \\lfloor n x\\rfloor$. Sampling $\\lfloor\\cdot\\rfloor$ at the $n$ equally spaced shifts $x, x+\\tfrac1n, \\dots, x+\\tfrac{n-1}{n}$ recovers $\\lfloor n x\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.floor",
+      "Int.floor_div_natCast",
+      "Finset.range",
+      "Euclidean division on ℤ"
+    ],
+    "prerequisites": [
+      "the floor function on ℝ and ℤ",
+      "Euclidean (round-toward-−∞ for positive divisor) division on ℤ",
+      "finite sums over Finset.range"
+    ]
+  },
+  {
+    "id": "ann-hermitefloor-shift-recurrence",
+    "proofId": "hermite-floor-identity",
+    "range": {
+      "startLine": 40,
+      "endLine": 64
+    },
+    "type": "insight",
+    "title": "The Shift Recurrence: Bumping a by 1 Adds 1 to the Sum",
+    "content": "The heart of the integer lemma is the recurrence `step`: ∑_{k<n}((b+1)+k)/n = (∑_{k<n}(b+k)/n) + 1. It is proved by reindexing k ↦ k+1. With g(j) := (b+j)/n, the shifted summand (b+1+k)/n equals g(k+1) (lemma `key`, an honest cast manipulation: ↑(k+1) = ↑k+1). Then the SAME range-(n+1) sum ∑_{j<n+1} g(j) is expanded two ways — `Finset.sum_range_succ'` peels off the bottom term g(0) and reindexes the rest as ∑_{k<n} g(k+1), while `Finset.sum_range_succ` peels off the top term g(n). Equating the two expansions shows ∑_{k<n} g(k+1) and ∑_{k<n} g(k) differ by exactly g(n) − g(0). The endpoint quotients are computed explicitly: g(n) = (b+n)/n = b/n + 1 via `Int.add_mul_ediv_right` (since b+n = b + 1·n), and g(0) = (b+0)/n = b/n. So the difference is 1, and `linarith` assembles the recurrence.",
+    "mathContext": "Writing $g(j) = (b+j)/n$, $\\sum_{k<n} g(k+1) - \\sum_{k<n} g(k) = g(n) - g(0) = (b/n + 1) - b/n = 1$. The Euclidean quotient $(b+n)/n = b/n + 1$ because adding the divisor adds one to the quotient.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_succ'",
+      "Finset.sum_range_succ",
+      "Int.add_mul_ediv_right",
+      "telescoping / reindexing"
+    ],
+    "prerequisites": [
+      "reindexing a finite sum by shifting the index",
+      "Euclidean-division arithmetic (a + b·n)/n = a/n + b"
+    ]
+  },
+  {
+    "id": "ann-hermitefloor-integer-induction",
+    "proofId": "hermite-floor-identity",
+    "range": {
+      "startLine": 65,
+      "endLine": 83
+    },
+    "type": "insight",
+    "title": "Integer Induction: From the Recurrence to the Identity Function",
+    "content": "With the shift recurrence in hand, `Int.induction_on` proves ∑_{k<n}(a+k)/n = a for ALL integers a, including negatives. The base case a = 0 requires ∑_{k<n} k/n = 0; each summand (0+k)/n is an Euclidean quotient with 0 ≤ k < n, hence 0 by `Int.ediv_eq_zero_of_lt_abs` (using |n| = n for n > 0), so `Finset.sum_eq_zero` closes it. The forward arm (a = i → a = i+1) rewrites the goal's sum with `step i` and the inductive hypothesis: the sum at i+1 is (sum at i) + 1 = i + 1. The backward arm (a = −i → a = −i−1) applies `step` at b = −i−1: since (−i−1)+1 = −i, the recurrence reads (sum at −i) = (sum at −i−1) + 1, and the hypothesis (sum at −i) = −i gives (sum at −i−1) = −i−1. Both arms are linear bookkeeping closed by `linarith`. This two-sided induction is why the identity holds for negative a — essential because ⌊n·x⌋ can be negative.",
+    "mathContext": "A function $F : \\mathbb{Z} \\to \\mathbb{Z}$ with $F(0) = 0$ and $F(a+1) = F(a) + 1$ is the identity. Here $F(a) = \\sum_{k<n}(a+k)/n$; the recurrence and base case force $F(a) = a$ for every integer $a$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Int.induction_on",
+      "Int.ediv_eq_zero_of_lt_abs",
+      "Finset.sum_eq_zero"
+    ],
+    "prerequisites": [
+      "two-sided induction over ℤ",
+      "vanishing of small Euclidean quotients: 0 ≤ k < n ⟹ k/n = 0"
+    ]
+  },
+  {
+    "id": "ann-hermitefloor-real-reduction",
+    "proofId": "hermite-floor-identity",
+    "range": {
+      "startLine": 85,
+      "endLine": 100
+    },
+    "type": "insight",
+    "title": "Real → Integer Reduction and the Final Assembly",
+    "content": "The headline theorem `hermite_floor_identity` reduces the real statement to the integer lemma term by term. For each k, the field identity x + k/n = (n·x + k)/n (proved by `field_simp`, using n ≠ 0) rewrites the floor as ⌊(n·x + k)/n⌋. Mathlib's `Int.floor_div_natCast` (⌊a/n⌋ = ⌊a⌋/n, Euclidean division on ℤ) turns this into ⌊n·x + k⌋/n, and `Int.floor_add_natCast` (⌊a + k⌋ = ⌊a⌋ + k) gives the integer Euclidean quotient (⌊n·x⌋ + k)/n. Thus every real floor in the sum is replaced by an integer quotient with the SAME numerator pattern a + k where a = ⌊n·x⌋. A single `Finset.sum_congr` applies this term rewrite across the range, and `int_hermite_sum n hn ⌊n·x⌋` finishes: the sum equals ⌊n·x⌋. The reduction is valid even when ⌊n·x⌋ < 0 precisely because Euclidean and floor division coincide for the positive divisor n.",
+    "mathContext": "$\\lfloor x + k/n\\rfloor = \\lfloor (nx+k)/n\\rfloor = \\lfloor nx + k\\rfloor / n = (\\lfloor nx\\rfloor + k)/n$ (integer Euclidean division). Summed over $k < n$ this is $\\sum_{k<n}(a+k)/n = a = \\lfloor nx\\rfloor$ with $a = \\lfloor nx\\rfloor$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Int.floor_div_natCast",
+      "Int.floor_add_natCast",
+      "Finset.sum_congr",
+      "int_hermite_sum"
+    ],
+    "prerequisites": [
+      "the floor/division interchange ⌊a/n⌋ = ⌊a⌋/n",
+      "termwise rewriting of a finite sum"
+    ]
+  }
+]

--- a/src/data/proofs/hermite-floor-identity/meta.json
+++ b/src/data/proofs/hermite-floor-identity/meta.json
@@ -1,0 +1,119 @@
+{
+  "id": "hermite-floor-identity",
+  "title": "Hermite's Identity for the Floor Function",
+  "slug": "hermite-floor-identity",
+  "description": "Hermite's classical identity (Charles Hermite, 1880s) states that for every real x and every integer n ≥ 1, ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋: summing the floor of x shifted by the n equally spaced amounts 0, 1/n, …, (n-1)/n reconstructs the floor of n·x exactly. This is the floor-function identity, not the unrelated Hermite–Lindemann transcendence theorem (gallery entry HermiteLindemann.lean), nor Hermite polynomials or normal form; Mathlib's only `Hermite` references are those unrelated objects, so the floor identity is a fresh contribution. The proof factors into two elementary steps. (1) Real → integer reduction: writing x + k/n = (n·x + k)/n and applying Mathlib's `Int.floor_div_natCast` (⌊a/n⌋ = ⌊a⌋/n, Euclidean division on ℤ) with `Int.floor_add_natCast`, each real floor collapses to an integer Euclidean quotient ⌊x + k/n⌋ = (⌊n·x⌋ + k)/n. (2) Integer Hermite sum: the residual statement ∑_{k=0}^{n-1} (a + k)/n = a (any a : ℤ, n ≥ 1) is proved by integer induction on a — shifting a ↦ a+1 reindexes the range-n sum (via sum_range_succ' / sum_range_succ) and changes it by exactly 1, while the value at a = 0 is 0 because each summand k/n with 0 ≤ k < n vanishes. Euclidean division's nonnegative remainder makes the reduction valid for negative arguments, where Euclidean and floor division agree for a positive divisor.",
+  "meta": {
+    "author": "Charles Hermite (1880s)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HermiteFloorIdentity.lean",
+    "tags": [
+      "number-theory",
+      "floor-function",
+      "real-analysis",
+      "euclidean-division",
+      "classic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 100,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lake env lean Proofs/HermiteFloorIdentity.lean`, exit 0; `#print axioms hermite_floor_identity` and `#print axioms int_hermite_sum` list only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). Mathlib supplies all the floor/division infrastructure used (`Int.floor_div_natCast`, `Int.floor_add_natCast`, `Int.add_mul_ediv_right`, `Int.ediv_eq_zero_of_lt_abs`, `Finset.sum_range_succ'`, `Finset.sum_range_succ`, `Int.induction_on`) but does NOT contain Hermite's floor identity itself, nor the integer Euclidean-quotient sum ∑_{k<n}(a+k)/n = a; both are proved here.",
+    "dateAdded": "2026-06-25",
+    "originalContributions": [
+      "Hermite's floor identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋ over ℝ for every n ≥ 1, a result absent from Mathlib (whose `Hermite` namespace covers only Hermite polynomials, Hermite normal form, and the Hermite–Lindemann theorem).",
+      "The integer Euclidean-quotient lemma int_hermite_sum: ∑_{k=0}^{n-1} (a + k)/n = a for every a : ℤ and n ≥ 1, proved by two-sided integer induction on a via a shift recurrence rather than a remainder case-split.",
+      "A clean real→integer reduction: each real floor ⌊x + k/n⌋ is rewritten as the integer Euclidean quotient (⌊n·x⌋ + k)/n using Int.floor_div_natCast, dispatching the (potentially negative, irrational) real case to a purely integer computation."
+    ],
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Charles Hermite recorded this floor-summation identity in the 1880s; it is a staple of elementary number theory and analysis courses, often used to evaluate sums of floor functions and to relate ⌊n·x⌋ to a uniform sampling of ⌊·⌋. It generalizes the obvious n = 2 case ⌊x⌋ + ⌊x + 1/2⌋ = ⌊2x⌋ and is the additive companion to the Gauss/Legendre formulas for the exponent of a prime in n!. Mathlib formalizes a great deal of floor-function theory (`Int.floor`, `Int.fract`, division-floor interchange) but does not record Hermite's identity; this entry adds it.",
+    "problemStatement": "Prove that for every real number $x$ and every integer $n \\ge 1$, $$\\sum_{k=0}^{n-1} \\left\\lfloor x + \\frac{k}{n} \\right\\rfloor = \\lfloor n x \\rfloor.$$",
+    "text": "The headline theorem `hermite_floor_identity (x : ℝ) (n : ℕ) (hn : 0 < n) : ∑ k ∈ range n, ⌊x + k/n⌋ = ⌊n·x⌋`, supported by the integer lemma `int_hermite_sum (n) (hn) (a : ℤ) : ∑ k ∈ range n, (a + k)/n = a` (Euclidean division on ℤ).",
+    "proofStrategy": "Two steps. (1) Real → integer reduction. For each k, x + k/n = (n·x + k)/n, so `Int.floor_div_natCast` (⌊a/n⌋ = ⌊a⌋/n) followed by `Int.floor_add_natCast` (⌊a + k⌋ = ⌊a⌋ + k) gives ⌊x + k/n⌋ = (⌊n·x⌋ + k)/n as an integer Euclidean quotient. The whole sum thus equals ∑_{k<n}(⌊n·x⌋ + k)/n. (2) Integer Hermite sum. Setting a = ⌊n·x⌋, prove ∑_{k<n}(a + k)/n = a by integer induction on a (`Int.induction_on`). The shift recurrence ∑_{k<n}((b+1)+k)/n = (∑_{k<n}(b+k)/n) + 1 follows by reindexing k ↦ k+1: `Finset.sum_range_succ'` and `Finset.sum_range_succ` express the same range-(n+1) sum two ways, and the endpoint quotients satisfy (b+n)/n = b/n + 1 (via `Int.add_mul_ediv_right`) while (b+0)/n = b/n, so the difference is exactly 1. The base case a = 0 is ∑_{k<n} k/n = 0 because each Euclidean quotient k/n with 0 ≤ k < n is 0 (`Int.ediv_eq_zero_of_lt_abs`). Two-sided induction (the negative arm uses the same recurrence at b = -i-1) pins the linear function a ↦ a.",
+    "keyInsights": [
+      "The real, possibly irrational argument is a red herring: x + k/n = (n·x + k)/n, and Mathlib's floor/division law ⌊a/n⌋ = ⌊a⌋/n collapses every real floor to an integer Euclidean quotient, so the entire identity is equivalent to a statement about integers and integer division.",
+      "Once integerized, the identity ∑_{k<n}(a+k)/n = a is most cleanly proved not by splitting a into quotient and remainder but by an additive recurrence: shifting a by 1 shifts the whole sum by exactly 1, and the value at 0 is 0, so the sum is the identity function on ℤ.",
+      "The shift recurrence is a reindexing trick: ∑_{k<n} f(k+1) and ∑_{k<n} f(k) differ only at the endpoints f(0) and f(n) (both equal the same range-(n+1) sum minus one boundary term), and for f(k) = (b+k)/n those endpoints differ by 1.",
+      "Euclidean division (Mathlib's `/` on ℤ) keeps a nonnegative remainder, so for a positive divisor it agrees with floor division; this is exactly what makes ⌊a/n⌋ = ⌊a⌋/n hold for negative a and lets the reduction handle negative ⌊n·x⌋."
+    ],
+    "prerequisites": [
+      "The floor function ⌊·⌋ on ℝ and on ℤ (Int.floor)",
+      "Euclidean division on ℤ and the law ⌊a/n⌋ = ⌊a⌋/n",
+      "Finite sums over Finset.range and reindexing (sum_range_succ / sum_range_succ')",
+      "Integer induction (Int.induction_on)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring stating Hermite's identity, distinguishing it from the unrelated Hermite–Lindemann theorem / Hermite polynomials, outlining the two-step strategy (real→integer reduction, then integer induction), imports (full Mathlib for the floor/division and Finset APIs), and the namespace.",
+      "mathContext": "Targets $\\sum_{k=0}^{n-1}\\lfloor x + k/n\\rfloor = \\lfloor n x\\rfloor$ for real $x$ and $n \\ge 1$."
+    },
+    {
+      "id": "int-hermite-sum",
+      "title": "The Integer Hermite Sum",
+      "startLine": 40,
+      "endLine": 83,
+      "summary": "int_hermite_sum: ∑_{k<n}(a + k)/n = a for any a : ℤ, n ≥ 1 (Euclidean division). The core is the shift recurrence `step`, proved by reindexing k ↦ k+1 with Finset.sum_range_succ' and Finset.sum_range_succ and computing the endpoint quotients (b+n)/n = b/n+1 (Int.add_mul_ediv_right) and (b+0)/n = b/n. Integer induction (Int.induction_on) then runs the recurrence both ways from the base value 0, whose summands k/n vanish for 0 ≤ k < n (Int.ediv_eq_zero_of_lt_abs).",
+      "mathContext": "$\\sum_{k=0}^{n-1}\\lfloor (a+k)/n\\rfloor = a$: shifting $a \\mapsto a+1$ adds exactly $1$ to the sum, and the sum is $0$ at $a = 0$, so it equals $a$."
+    },
+    {
+      "id": "real-identity",
+      "title": "Hermite's Identity over the Reals",
+      "startLine": 85,
+      "endLine": 100,
+      "summary": "hermite_floor_identity: rewrites each term via x + k/n = (n·x + k)/n and Int.floor_div_natCast / Int.floor_add_natCast to the integer Euclidean quotient (⌊n·x⌋ + k)/n, then applies int_hermite_sum with a = ⌊n·x⌋ to conclude the sum equals ⌊n·x⌋.",
+      "mathContext": "Each $\\lfloor x + k/n\\rfloor = (\\lfloor n x\\rfloor + k)/n$ (integer division), so the sum reduces to the integer Hermite sum at $a = \\lfloor n x\\rfloor$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Hermite's floor identity ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊n·x⌋ is proved for every real x and every n ≥ 1, with 0 axioms and 0 sorries. The real argument is reduced term-by-term to integer Euclidean quotients via Mathlib's ⌊a/n⌋ = ⌊a⌋/n, and the resulting integer identity ∑_{k<n}(a+k)/n = a is established by a shift-recurrence integer induction. Neither the real identity nor the integer quotient-sum lemma is present in Mathlib.",
+    "openQuestions": [
+      "Prove the two-variable generalization (the 'Hermite identity for ⌊mx⌋'): relate ∑_{k=0}^{n-1} ⌊x + k/n⌋ and partial sums sampling at rationals with a different denominator, or the Bernoulli-polynomial refinement ∑_{k=0}^{n-1} ⌊x + k/n⌋ = ⌊nx⌋ together with the companion sawtooth/fractional-part identity ∑_{k=0}^{n-1} {x + k/n} = {nx} + (n-1)/2.",
+      "Derive Legendre's formula for v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋ as a consequence, exhibiting Hermite's identity as the additive backbone of the prime-exponent count in factorials."
+    ],
+    "implications": "Hermite's identity is the standard tool for collapsing uniformly sampled floor sums and underlies several closed-form floor evaluations and the additive structure behind Legendre/Gauss prime-power counts. Recording it gives the gallery a reusable floor-summation lemma and a self-contained integer Euclidean-quotient sum (int_hermite_sum) usable elsewhere."
+  },
+  "crossReferences": [
+    {
+      "targetId": "hermite-lindemann",
+      "relationship": "related",
+      "description": "Shares only the name 'Hermite': HermiteLindemann is the transcendence theorem (e and π transcendental), an entirely different result. This entry is the elementary floor-function identity; the cross-reference exists to disambiguate the two."
+    }
+  ],
+  "references": [
+    {
+      "author": "Hermite, C.",
+      "title": "Sur quelques conséquences arithmétiques des formules de la théorie des fonctions elliptiques",
+      "year": 1884,
+      "note": "Period in which Hermite recorded the floor-summation identity"
+    },
+    {
+      "author": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "note": "Chapter 3 (Integer Functions) treats Hermite's identity and floor-sum manipulations"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "HermiteFloorIdentity",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/HermiteFloorIdentity.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **Hermite's classical floor identity** for every real `x` and integer `n ≥ 1`:
$$\sum_{k=0}^{n-1} \left\lfloor x + \tfrac{k}{n} \right\rfloor = \lfloor n x \rfloor.$$

**0 sorries, 0 axioms** (kernel check lists only `propext`/`Classical.choice`/`Quot.sound`). This is the floor-function identity — **not** the unrelated Hermite–Lindemann transcendence theorem, Hermite polynomials, or Hermite normal form. Mathlib's only `Hermite` references are those other objects, so the floor identity (and the supporting integer Euclidean-quotient sum) are fresh contributions.

## Proof strategy

1. **Real → integer reduction.** For each `k`, `x + k/n = (n·x + k)/n`, so `Int.floor_div_natCast` (`⌊a/n⌋ = ⌊a⌋/n`, Euclidean division on ℤ) and `Int.floor_add_natCast` collapse the real floor to the integer Euclidean quotient `⌊x + k/n⌋ = (⌊n·x⌋ + k)/n`.
2. **Integer Hermite sum.** `int_hermite_sum : ∑_{k<n} (a + k)/n = a` for any `a : ℤ`, proved by **two-sided integer induction** on `a`. A shift recurrence (`Finset.sum_range_succ'`/`sum_range_succ`) shows bumping `a` by 1 bumps the sum by exactly 1; the base value at `a = 0` is 0 because each quotient `k/n` with `0 ≤ k < n` vanishes. Negative arguments are handled because Euclidean and floor division agree for a positive divisor — essential since `⌊n·x⌋` may be negative.

## Verification

- `lake env lean Proofs/HermiteFloorIdentity.lean` → exit 0 (single-file elaboration).
- `#print axioms hermite_floor_identity` / `#print axioms int_hermite_sum` → only `propext, Classical.choice, Quot.sound`.
- 2 theorems, 0 definitions, 100 lines.

## Files

- `proofs/Proofs/HermiteFloorIdentity.lean` (new, 100 lines)
- `proofs/Proofs.lean` (registers module)
- `src/data/proofs/hermite-floor-identity/` (meta.json + annotations.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)