### PR TITLE
research(catalan-numbers-oq-01-oq-02-oq-02): density & exact count ⌊log₂N⌋+1 of odd Catalan numbers

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -642,6 +642,7 @@ import Proofs.CatalanNumbersOQ01OQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ01OQ02OQ03
 import Proofs.CatalanNumbersOQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ02OQ01
+import Proofs.CatalanNumbersOQ01OQ02OQ02
 import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01OQ01

--- a/proofs/Proofs/CatalanNumbersOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/CatalanNumbersOQ01OQ02OQ02.lean
@@ -1,0 +1,126 @@
+import Mathlib
+import Proofs.CatalanNumbersOQ01OQ02
+
+/-!
+# Catalan OQ-01-OQ-02-OQ-02: Density and gap structure of the odd Catalan indices
+
+The parent entry `Proofs.CatalanNumbersOQ01OQ02` establishes the arithmetic of the
+2-adic valuation of the Catalan numbers:
+
+* `v₂(Cₙ) = s₂(n+1) − 1`, and
+* `Cₙ` is **odd** ⟺ `n + 1` is a power of two.
+
+This file answers the natural follow-up open question on the **distribution** of the
+odd Catalan numbers: where do they sit, how fast do the gaps grow, and how many are
+there below a given bound?
+
+The odd Catalan numbers occur exactly at the indices
+`n = 2ᵏ − 1`, i.e. `0, 1, 3, 7, 15, 31, …`.  We prove:
+
+* `odd_catalan_iff_eq`        : `Cₙ` odd ⟺ `∃ k, n = 2ᵏ − 1`
+* `oddIndices_eq_range`       : `{n | Cₙ odd} = {2ᵏ − 1 : k ∈ ℕ}` (set equality)
+* `oddIndex_strictMono`       : `k ↦ 2ᵏ − 1` is strictly monotone
+* `oddIndex_gap`              : consecutive odd indices satisfy `a_{k+1} − a_k = 2ᵏ`
+                               (the gaps grow geometrically, so the odd indices are sparse)
+* `card_odd_catalan_below`    : `#{ n < N : Cₙ odd } = Nat.log 2 N + 1`  (for `N ≥ 1`)
+* `card_odd_catalan_below_pow`: `#{ n < 2^K : Cₙ odd } = K + 1`  (the special case `N = 2^K`)
+
+The exact count `⌊log₂ N⌋ + 1` makes the *density* statement precise: the proportion of
+odd Catalan numbers among the first `N` is `(log₂ N)/N → 0`.
+
+Everything is derived from the parent's `odd_catalan_iff`; the only new ingredients are
+elementary facts about powers of two.  All results are fully machine-checked:
+`0` `sorry`, `0` `axiom`, no `native_decide`.
+-/
+
+open Nat Finset
+
+namespace CatalanTwoAdic
+
+/-! ### The odd-index set is exactly `{2ᵏ − 1}` -/
+
+/-- `Cₙ` is odd precisely when `n = 2ᵏ − 1` for some `k` (the indices `0, 1, 3, 7, …`).
+This is the `n = 2ᵏ − 1` reformulation of the parent's `odd_catalan_iff`. -/
+theorem odd_catalan_iff_eq (n : ℕ) : Odd (catalan n) ↔ ∃ k, n = 2 ^ k - 1 := by
+  rw [odd_catalan_iff]
+  constructor
+  · rintro ⟨k, hk⟩
+    exact ⟨k, by omega⟩
+  · rintro ⟨k, hk⟩
+    have h1 : 1 ≤ 2 ^ k := Nat.one_le_pow k 2 (by norm_num)
+    exact ⟨k, by omega⟩
+
+/-- The set of indices at which the Catalan number is odd equals the range of
+`k ↦ 2ᵏ − 1`. -/
+theorem oddIndices_eq_range :
+    {n : ℕ | Odd (catalan n)} = Set.range (fun k => 2 ^ k - 1) := by
+  ext n
+  rw [Set.mem_setOf_eq, Set.mem_range, odd_catalan_iff_eq]
+  exact ⟨fun ⟨k, hk⟩ => ⟨k, hk.symm⟩, fun ⟨k, hk⟩ => ⟨k, hk.symm⟩⟩
+
+/-! ### Gap structure: the odd indices are geometrically sparse -/
+
+/-- The enumerating map `k ↦ 2ᵏ − 1` of the odd Catalan indices is strictly
+monotone, so the indices `0, 1, 3, 7, 15, …` are listed in increasing order without
+repetition. -/
+theorem oddIndex_strictMono : StrictMono (fun k => 2 ^ k - 1) := by
+  intro i j hij
+  have h1 : 1 ≤ 2 ^ i := Nat.one_le_pow i 2 (by norm_num)
+  have h2 : 2 ^ i < 2 ^ j := Nat.pow_lt_pow_right (by norm_num) hij
+  simp only
+  omega
+
+/-- The gap between consecutive odd Catalan indices is `2ᵏ`:
+`(2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ`.  Since `2ᵏ` is strictly increasing, the gaps grow
+geometrically and the odd Catalan numbers thin out. -/
+theorem oddIndex_gap (k : ℕ) :
+    (2 ^ (k + 1) - 1) - (2 ^ k - 1) = 2 ^ k := by
+  have h1 : 1 ≤ 2 ^ k := Nat.one_le_pow k 2 (by norm_num)
+  have h2 : 2 ^ (k + 1) = 2 * 2 ^ k := by rw [pow_succ]; ring
+  omega
+
+/-! ### Counting: the exact count below an arbitrary threshold -/
+
+/-- **Counting function.** For any threshold `N ≥ 1`, the number of odd Catalan numbers
+below `N` is exactly `⌊log₂ N⌋ + 1`, namely the ones at indices
+`2⁰ − 1, 2¹ − 1, …, 2^{⌊log₂ N⌋} − 1`.  In particular the count grows only
+*logarithmically* in the threshold, so the odd Catalan numbers have density `0`. -/
+theorem card_odd_catalan_below (N : ℕ) (hN : 1 ≤ N) :
+    ((Finset.range N).filter (fun n => Odd (catalan n))).card = Nat.log 2 N + 1 := by
+  have hset : (Finset.range N).filter (fun n => Odd (catalan n))
+      = (Finset.range (Nat.log 2 N + 1)).image (fun k => 2 ^ k - 1) := by
+    ext n
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_image, odd_catalan_iff_eq]
+    constructor
+    · rintro ⟨hn, k, rfl⟩
+      refine ⟨k, ?_, rfl⟩
+      have h1 : 1 ≤ 2 ^ k := Nat.one_le_pow k 2 (by norm_num)
+      have hle : 2 ^ k ≤ N := by omega
+      have := (Nat.le_log_iff_pow_le (by norm_num : 1 < 2) (by omega)).mpr hle
+      omega
+    · rintro ⟨k, hk, rfl⟩
+      have h1 : 1 ≤ 2 ^ k := Nat.one_le_pow k 2 (by norm_num)
+      have hle : 2 ^ k ≤ N :=
+        (Nat.le_log_iff_pow_le (by norm_num : 1 < 2) (by omega)).mp (by omega)
+      exact ⟨by omega, k, rfl⟩
+  rw [hset, Finset.card_image_of_injective _ oddIndex_strictMono.injective,
+    Finset.card_range]
+
+/-- The special case `N = 2^K`: there are exactly `K + 1` odd Catalan numbers below `2^K`,
+at indices `2⁰ − 1, …, 2^K − 1`. -/
+theorem card_odd_catalan_below_pow (K : ℕ) :
+    ((Finset.range (2 ^ K)).filter (fun n => Odd (catalan n))).card = K + 1 := by
+  rw [card_odd_catalan_below _ (Nat.one_le_pow K 2 (by norm_num)), Nat.log_pow (by norm_num)]
+
+/-! ### Sanity checks
+
+The four odd Catalan numbers below `8` are `C₀, C₁, C₃, C₇` (indices `2ᵏ − 1`); below `16`
+a fifth appears at index `15 = 2⁴ − 1`. -/
+
+example : ((Finset.range (2 ^ 3)).filter (fun n => Odd (catalan n))).card = 4 :=
+  card_odd_catalan_below_pow 3
+example : ((Finset.range (2 ^ 4)).filter (fun n => Odd (catalan n))).card = 5 :=
+  card_odd_catalan_below_pow 4
+example (n : ℕ) : Odd (catalan n) ↔ ∃ k, n = 2 ^ k - 1 := odd_catalan_iff_eq n
+
+end CatalanTwoAdic

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "context",
+    "title": "From Parity to Distribution",
+    "content": "The parent entry (catalan-numbers-oq-01-oq-02) proves the classical parity fact that Cₙ is odd exactly when n+1 is a power of two. This file, imported on top of it, answers the parent's open question 2: where do the odd Catalan numbers sit, and how many are there? Since the odd indices are precisely the shifted powers of two n = 2ᵏ − 1 (0,1,3,7,15,…), the answers are crisp — the gaps double and the count below N is the binary length ⌊log₂ N⌋ + 1, so the odd Catalan numbers have density 0."
+  },
+  {
+    "id": "ann-odd-index-set",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-02",
+    "range": { "startLine": 40, "endLine": 60 },
+    "type": "key-step",
+    "title": "The Odd Indices Are Exactly {2ᵏ − 1}",
+    "content": "odd_catalan_iff_eq rewrites the parent's odd_catalan_iff (n+1 = 2ᵏ) into the canonical form n = 2ᵏ − 1 — valid because 1 ≤ 2ᵏ, so adding/subtracting 1 is reversible (discharged by omega with that bound). oddIndices_eq_range then packages the set {n | Cₙ odd} as the explicit range of k ↦ 2ᵏ − 1, the indices 0,1,3,7,15,…."
+  },
+  {
+    "id": "ann-gap-structure",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-02",
+    "range": { "startLine": 61, "endLine": 81 },
+    "type": "key-step",
+    "title": "Geometric Gaps ⟹ Sparsity",
+    "content": "oddIndex_strictMono shows the enumerating map k ↦ 2ᵏ − 1 is strictly monotone: from 2ⁱ < 2ʲ (Nat.pow_lt_pow_right) and 1 ≤ 2ⁱ, omega gives 2ⁱ − 1 < 2ʲ − 1. This yields injectivity, used in the counting argument. oddIndex_gap computes the exact gap (2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ (from 2^{k+1} = 2·2ᵏ by omega); since 2ᵏ grows without bound, the odd Catalan numbers thin out geometrically."
+  },
+  {
+    "id": "ann-counting",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-02",
+    "range": { "startLine": 82, "endLine": 114 },
+    "type": "key-step",
+    "title": "The Exact Count ⌊log₂ N⌋ + 1",
+    "content": "card_odd_catalan_below is the centrepiece: for N ≥ 1, #{ n < N : Cₙ odd } = ⌊log₂ N⌋ + 1. The proof identifies the filtered Finset with (range (⌊log₂ N⌋ + 1)).image (k ↦ 2ᵏ − 1). The membership equivalence reduces to 2ᵏ − 1 < N ⟺ k ≤ ⌊log₂ N⌋: since 1 ≤ 2ᵏ, the inequality 2ᵏ − 1 < N is equivalent to 2ᵏ ≤ N, which Nat.le_log_iff_pow_le converts to k ≤ ⌊log₂ N⌋. As k ↦ 2ᵏ − 1 is injective, the image has cardinality card (range (⌊log₂ N⌋ + 1)) = ⌊log₂ N⌋ + 1. card_odd_catalan_below_pow specialises this to N = 2^K via Nat.log_pow, giving K + 1."
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-02",
+    "range": { "startLine": 115, "endLine": 126 },
+    "type": "observation",
+    "title": "Concrete Counts, Axiom-Free",
+    "content": "The examples instantiate card_odd_catalan_below_pow: 4 odd Catalan numbers below 8 = 2³ (C₀,C₁,C₃,C₇) and 5 below 16 = 2⁴ (adding C₁₅). They are direct theorem applications rather than kernel computations on catalan (which does not reduce by decide), so the file stays free of native_decide and of any extra axioms — every theorem depends only on propext, Classical.choice, Quot.sound."
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,186 @@
+{
+  "id": "catalan-numbers-oq-01-oq-02-oq-02",
+  "title": "Odd Catalan Numbers: density, geometric gaps, and the exact count ⌊log₂ N⌋ + 1 below N",
+  "slug": "catalan-numbers-oq-01-oq-02-oq-02",
+  "description": "A precise description of the distribution of the odd Catalan numbers, answering open question 2 of the parent 2-adic-valuation entry. Building on Cₙ odd ⟺ n+1 a power of two (odd_catalan_iff), the odd Catalan numbers occur exactly at the indices n = 2ᵏ − 1 (0,1,3,7,15,…). The entry proves: (i) the reformulation Cₙ odd ⟺ ∃k, n = 2ᵏ − 1 and the set equality {n | Cₙ odd} = {2ᵏ − 1 : k ∈ ℕ}; (ii) the gap structure — the enumerating map k ↦ 2ᵏ − 1 is strictly monotone and consecutive odd indices differ by 2ᵏ, so the gaps grow geometrically and the odd indices are sparse; (iii) the counting function: for every threshold N ≥ 1 there are exactly ⌊log₂ N⌋ + 1 odd Catalan numbers below N (specialising to K + 1 below 2^K). The exact ⌊log₂ N⌋ + 1 count makes the density statement precise — the proportion of odd Catalan numbers among the first N is (log₂ N)/N → 0. Everything is derived from the parent's odd_catalan_iff together with elementary facts about powers of two and Nat.log; the counting proof identifies the filtered Finset with the injective image of range(⌊log₂ N⌋ + 1) under k ↦ 2ᵏ − 1. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (parity/density of Catalan numbers); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CatalanNumbersOQ01OQ02OQ02.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "catalan-numbers",
+      "p-adic-valuation",
+      "binary-digit-sum",
+      "counting",
+      "density",
+      "powers-of-two",
+      "parity",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.le_log_iff_pow_le",
+        "description": "For 1 < b and y ≠ 0: x ≤ log b y ↔ b^x ≤ y. The bridge between the threshold inequality 2ᵏ ≤ N and k ≤ ⌊log₂ N⌋, giving the exact counting bound on the odd indices.",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Nat.log_pow",
+        "description": "For 1 < b: log b (bˣ) = x. Specialises the general count ⌊log₂ N⌋ + 1 to the clean K + 1 at the power-of-two threshold N = 2^K.",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "(s.image f).card = s.card for injective f. Combined with injectivity of k ↦ 2ᵏ − 1 (from strict monotonicity), it turns the image representation of the odd-index Finset into the count card (range (⌊log₂ N⌋ + 1)).",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.pow_lt_pow_right",
+        "description": "For 1 < b and m < n: bᵐ < bⁿ. The strict monotonicity of 2ᵏ underlying both the geometric gap growth and the injectivity of the index-enumerating map.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.one_le_pow",
+        "description": "0 < m → 1 ≤ mⁿ. Supplies 1 ≤ 2ᵏ, the positivity needed to convert between 2ᵏ − 1 < N and 2ᵏ ≤ N in the omega steps.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "odd_catalan_iff_eq: Odd (catalan n) ↔ ∃ k, n = 2ᵏ − 1. The 'n = 2ᵏ − 1' reformulation of the parent's odd_catalan_iff (which is stated as n+1 = 2ᵏ), giving the odd indices in their canonical Mersenne-shifted form 0,1,3,7,15,….",
+      "oddIndices_eq_range: {n | Odd (catalan n)} = Set.range (fun k => 2ᵏ − 1). The odd-index set as an explicit range.",
+      "oddIndex_strictMono: the enumerating map k ↦ 2ᵏ − 1 is strictly monotone — the odd indices are listed in increasing order without repetition, and the map is injective.",
+      "oddIndex_gap: (2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ. Consecutive odd Catalan indices differ by 2ᵏ, so the gaps grow geometrically and the odd Catalan numbers are sparse.",
+      "card_odd_catalan_below: for N ≥ 1, #{ n < N : Cₙ odd } = ⌊log₂ N⌋ + 1. The exact counting function, proved by identifying the filtered Finset with the injective image of range(⌊log₂ N⌋ + 1) under k ↦ 2ᵏ − 1.",
+      "card_odd_catalan_below_pow: #{ n < 2^K : Cₙ odd } = K + 1. The clean power-of-two special case (via Nat.log_pow).",
+      "Concrete witnesses: exactly 4 odd Catalan numbers below 2³ = 8 (C₀,C₁,C₃,C₇) and 5 below 2⁴ = 16 (adding C₁₅), as direct applications of the counting theorem."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms on every theorem). Builds on the parent entry catalan-numbers-oq-01-oq-02 (imported as Proofs.CatalanNumbersOQ01OQ02), itself 0-axiom.",
+    "lineCount": 126,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the Catalan numbers Cₙ are odd exactly at n = 2ᵏ − 1 (indices 0,1,3,7,15,…) is classical, a consequence of the 2-adic valuation v₂(Cₙ) = s₂(n+1) − 1 established in the parent entry. A natural quantitative follow-up — and the parent's open question 2 — asks how these odd indices are distributed: how fast do the gaps grow, and how many odd Catalan numbers lie below a given bound? Because the odd indices are precisely the shifted powers of two, both questions have crisp answers: the gaps double, and the count below N is the binary length ⌊log₂ N⌋ + 1.",
+    "problemStatement": "Given that catalan n is odd ⟺ n + 1 is a power of two (parent entry), determine the distribution of the odd Catalan indices {n : Cₙ odd}: their explicit form, the gap structure, and the exact count below an arbitrary threshold N.\n\n**Answer:** the odd indices are exactly {2ᵏ − 1 : k ∈ ℕ}; consecutive ones differ by 2ᵏ (geometric gaps); and for N ≥ 1 there are exactly ⌊log₂ N⌋ + 1 of them below N, so they have density 0.",
+    "text": "From the parent's parity characterisation, the odd-index set is identified with the range of k ↦ 2ᵏ − 1, its gaps are computed, and its counting function is pinned to ⌊log₂ N⌋ + 1 by exhibiting the filtered Finset as the injective image of an initial segment — all with 0 axioms.",
+    "proofStrategy": "1. odd_catalan_iff_eq: rewrite the parent's odd_catalan_iff (n+1 = 2ᵏ) into n = 2ᵏ − 1, using 1 ≤ 2ᵏ so n+1 = 2ᵏ ⟺ n = 2ᵏ − 1.\n2. oddIndices_eq_range: extensionally, membership in {n | Cₙ odd} unfolds via step 1 to ∃k, n = 2ᵏ − 1, i.e. membership in Set.range (k ↦ 2ᵏ − 1).\n3. oddIndex_strictMono: i < j ⟹ 2ⁱ < 2ʲ (Nat.pow_lt_pow_right) and 1 ≤ 2ⁱ, so 2ⁱ − 1 < 2ʲ − 1 by omega; injectivity follows.\n4. oddIndex_gap: with 2^{k+1} = 2·2ᵏ and 1 ≤ 2ᵏ, omega gives (2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ.\n5. card_odd_catalan_below: show (range N).filter (Odd ∘ catalan) = (range (⌊log₂ N⌋ + 1)).image (k ↦ 2ᵏ − 1). The key equivalence 2ᵏ − 1 < N ⟺ k ≤ ⌊log₂ N⌋ comes from 2ᵏ − 1 < N ⟺ 2ᵏ ≤ N (since 1 ≤ 2ᵏ) and Nat.le_log_iff_pow_le. Then card of an injective image is card (range (⌊log₂ N⌋ + 1)) = ⌊log₂ N⌋ + 1.\n6. card_odd_catalan_below_pow: instantiate step 5 at N = 2^K and simplify ⌊log₂ 2^K⌋ = K via Nat.log_pow.",
+    "keyInsights": [
+      "**The odd indices are shifted powers of two.** Cₙ odd ⟺ n + 1 = 2ᵏ ⟺ n = 2ᵏ − 1, so the odd-index set is exactly {0,1,3,7,15,…} — one odd Catalan number in each dyadic block [2ᵏ−1, 2^{k+1}−1).",
+      "**Geometric gaps ⟹ density zero.** Consecutive odd indices differ by 2ᵏ, which grows without bound; the count below N is only ⌊log₂ N⌋ + 1, so the fraction of odd Catalan numbers among the first N tends to 0.",
+      "**Counting via an injective image.** The exact count is obtained not by induction but by identifying the filtered Finset with the image of an initial segment of ℕ under the injective map k ↦ 2ᵏ − 1; the cardinality is then read off from card_range.",
+      "**Built on the parent, not re-derived.** The parity characterisation is imported from catalan-numbers-oq-01-oq-02; the new content is purely the structural/quantitative description (range form, gaps, counting function) of the odd-index set."
+    ],
+    "exampleSections": [
+      {
+        "title": "Counting odd Catalan numbers below a threshold",
+        "mathContext": "Below 8 = 2³ the odd Catalan numbers are C₀=1, C₁=1, C₃=5, C₇=429 — exactly 4 = ⌊log₂ 8⌋ + 1 = 3 + 1, at indices 2⁰−1,…,2³−1. Below 16 = 2⁴ a fifth appears at index 15 = 2⁴ − 1, giving ⌊log₂ 16⌋ + 1 = 5. For a general N ≥ 1 the count is ⌊log₂ N⌋ + 1: e.g. below N = 100, ⌊log₂ 100⌋ = 6, so there are 7 odd Catalan numbers (at indices 0,1,3,7,15,31,63)."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Deutsch, Emeric; Sagan, Bruce E.",
+      "title": "Congruences for Catalan and Motzkin numbers and related sequences",
+      "year": "2006",
+      "note": "J. Number Theory 117 — the 2-adic valuation of the Catalan numbers and the oddness ⟺ n = 2ᵏ−1 characterisation underlying the distribution results here."
+    },
+    {
+      "authors": "Alter, Ronald; Kubota, K. K.",
+      "title": "Prime and prime power divisibility of Catalan numbers",
+      "year": "1973",
+      "note": "J. Combinatorial Theory A 15 — divisibility structure of Catalan numbers, including the sparse occurrence of the odd ones at shifted powers of two."
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "Sequence A000108 (Catalan numbers) and A083058 (odd-Catalan indices 2ᵏ−1)",
+      "year": "2024",
+      "note": "Catalogues the Catalan numbers and the indices at which they are odd, matching the {2ᵏ − 1} characterisation."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "catalan-numbers-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: establishes v₂(Cₙ) = s₂(n+1) − 1 and the parity characterisation Cₙ odd ⟺ n+1 a power of two (odd_catalan_iff), which this entry imports and turns into the distribution/counting of the odd Catalan indices. Answers its open question 2."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling extension of the same parent 2-adic-valuation entry."
+    },
+    {
+      "proofId": "catalan-numbers-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Related Catalan entry on the central-binomial reflection form, also built on succ_mul_catalan_eq_centralBinom."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: Distribution of the Odd Catalan Numbers",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Imports Mathlib and the parent entry Proofs.CatalanNumbersOQ01OQ02, opens Nat and Finset, and opens namespace CatalanTwoAdic. The docstring states the program: from Cₙ odd ⟺ n+1 a power of two, locate the odd indices (2ᵏ − 1), measure their gaps (geometric), and count them below N (exactly ⌊log₂ N⌋ + 1)."
+    },
+    {
+      "id": "odd-index-set",
+      "title": "The Odd-Index Set is Exactly {2ᵏ − 1}",
+      "startLine": 40,
+      "endLine": 60,
+      "summary": "odd_catalan_iff_eq: Odd (catalan n) ↔ ∃ k, n = 2ᵏ − 1, the canonical reformulation of the parent's odd_catalan_iff. oddIndices_eq_range: {n | Odd (catalan n)} = Set.range (k ↦ 2ᵏ − 1), the odd-index set as an explicit range."
+    },
+    {
+      "id": "gap-structure",
+      "title": "Gap Structure: Geometric Sparsity",
+      "startLine": 61,
+      "endLine": 81,
+      "summary": "oddIndex_strictMono: k ↦ 2ᵏ − 1 is strictly monotone (hence injective), so the odd indices are enumerated in increasing order. oddIndex_gap: consecutive odd indices satisfy (2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ, so the gaps grow geometrically and the odd Catalan numbers thin out."
+    },
+    {
+      "id": "counting",
+      "title": "Counting: Exactly ⌊log₂ N⌋ + 1 Below N",
+      "startLine": 82,
+      "endLine": 114,
+      "summary": "card_odd_catalan_below: for N ≥ 1, #{ n < N : Cₙ odd } = ⌊log₂ N⌋ + 1, proved by identifying the filtered Finset with the injective image of range(⌊log₂ N⌋ + 1) under k ↦ 2ᵏ − 1 (using Nat.le_log_iff_pow_le for the threshold 2ᵏ ≤ N). card_odd_catalan_below_pow: the special case #{ n < 2^K : Cₙ odd } = K + 1 via Nat.log_pow."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Counts",
+      "startLine": 115,
+      "endLine": 126,
+      "summary": "Exactly 4 odd Catalan numbers below 2³ = 8 (C₀,C₁,C₃,C₇) and 5 below 2⁴ = 16 (adding C₁₅), as direct applications of card_odd_catalan_below_pow, plus the odd-index characterisation restated — no native_decide, preserving the axiom-free claim."
+    }
+  ],
+  "conclusion": {
+    "summary": "The odd Catalan numbers occur exactly at the indices n = 2ᵏ − 1 (oddIndices_eq_range); consecutive odd indices differ by 2ᵏ, so the gaps grow geometrically (oddIndex_gap, oddIndex_strictMono); and for every threshold N ≥ 1 there are exactly ⌊log₂ N⌋ + 1 odd Catalan numbers below N (card_odd_catalan_below), specialising to K + 1 below 2^K (card_odd_catalan_below_pow). The odd Catalan numbers therefore have density 0. All results are verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Completes the quantitative side of the gallery's Catalan 2-adic-valuation program: having pinned down which Catalan numbers are odd (parent), this entry pins down how many and how spread out they are, with an exact logarithmic counting function obtained by an image/cardinality argument rather than induction.",
+    "openQuestions": [
+      "Generalise the counting function to fixed valuation v: count n < N with v₂(catalan n) = v, i.e. n+1 with binary digit sum s₂(n+1) = v + 1, via the distribution of digit sums (a Stern–Brocot / Trollope–Delange style estimate).",
+      "Carry out the same density analysis for an odd prime p: characterise and count the indices with p ∤ catalan n in terms of base-p digit conditions on n+1."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CatalanNumbersOQ01OQ02"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "CatalanTwoAdic",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CatalanNumbersOQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 2** of the parent entry `catalan-numbers-oq-01-oq-02`
(*v₂(Cₙ) = s₂(n+1) − 1; Cₙ odd ⟺ n+1 a power of two*): the **distribution** of the
odd Catalan numbers.

The odd Catalan numbers occur exactly at the indices `n = 2ᵏ − 1` (0,1,3,7,15,…).
Building on the parent's `odd_catalan_iff` (imported, not re-derived), this entry proves:

| Theorem | Statement |
|---|---|
| `odd_catalan_iff_eq` | `Cₙ` odd ⟺ `∃ k, n = 2ᵏ − 1` |
| `oddIndices_eq_range` | `{n \| Cₙ odd} = {2ᵏ − 1 : k ∈ ℕ}` |
| `oddIndex_strictMono` | `k ↦ 2ᵏ − 1` strictly monotone (injective) |
| `oddIndex_gap` | `(2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ` — geometric gaps |
| `card_odd_catalan_below` | `N ≥ 1 ⟹ #{ n < N : Cₙ odd } = ⌊log₂ N⌋ + 1` |
| `card_odd_catalan_below_pow` | `#{ n < 2^K : Cₙ odd } = K + 1` |

The exact `⌊log₂ N⌋ + 1` count makes the **density 0** statement precise. The counting
proof identifies the filtered `Finset` with the injective image of `range(⌊log₂ N⌋ + 1)`
under `k ↦ 2ᵏ − 1` (via `Nat.le_log_iff_pow_le`) — a cardinality argument, no induction.

## Verification

- `lake env lean Proofs/CatalanNumbersOQ01OQ02OQ02.lean` → **EXIT 0** (offline, full Mathlib + parent olean)
- `#print axioms` on all 6 theorems → only `propext, Classical.choice, Quot.sound`
- **0 axioms, 0 sorries, no `native_decide`** (`catalan` doesn't kernel-reduce, so the
  concrete-count examples are theorem applications, not `by decide`)

## Files

- `proofs/Proofs/CatalanNumbersOQ01OQ02OQ02.lean` (new, 126 lines, 6 theorems)
- `proofs/Proofs.lean` (one import line)
- `src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)