### PR TITLE
Enrich Reducing the General Cubic to Depressed Form (Tschirnhaus Shift)

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-soc-oq01-params",
+    "proofId": "solution-of-cubic-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "The Depressed Parameters p and q",
+    "content": "depressedP and depressedQ are the linear and constant coefficients of the depressed cubic produced by the shift x = t - b/(3a). They are noncomputable because division in ℂ is noncomputable. For a monic input (a = 1) they collapse to the familiar p = c - b²/3 and q = 2b³/27 - bc/3 + d, verified in the Part 5 sanity examples. These are the inputs handed to the parent's depressedCubic and cardano_formula.",
+    "mathContext": "$p = \\dfrac{3ac - b^2}{3a^2}, \\qquad q = \\dfrac{2b^3 - 9abc + 27a^2 d}{27a^3}$",
+    "significance": "supporting",
+    "relatedConcepts": ["depressed cubic", "Tschirnhaus transformation", "monic normalization", "noncomputable division in ℂ"],
+    "prerequisites": ["field arithmetic over ℂ", "polynomial coefficients"]
+  },
+  {
     "id": "ann-soc-oq01-shift",
     "proofId": "solution-of-cubic-oq-01",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "The Tschirnhaus Shift Kills the Quadratic Term",
-    "content": "cubic_depress is the heart of the file: substituting x = t - b/(3a) into a·x³ + b·x² + c·x + d gives a·(t³ + p·t + q). The coefficient of t² after substitution is exactly b - 3a·(b/3a) = 0 — this single cancellation is the entire content of 'depressing' the cubic and is why the translation is by precisely b/(3a). Proof is one field_simp (clearing denominators using a ≠ 0) followed by ring. The parent file only asserts this formula in its docstring; here it is machine-checked."
+    "content": "cubic_depress is the heart of the file: substituting x = t - b/(3a) into a·x³ + b·x² + c·x + d gives a·(t³ + p·t + q). The coefficient of t² after substitution is exactly b - 3a·(b/3a) = 0 — this single cancellation is the entire content of 'depressing' the cubic and is why the translation is by precisely b/(3a). Proof is one field_simp (clearing denominators using a ≠ 0) followed by ring. The parent file only asserts this formula in its docstring; here it is machine-checked.",
+    "mathContext": "$a\\Big(t-\\tfrac{b}{3a}\\Big)^3 + b\\Big(t-\\tfrac{b}{3a}\\Big)^2 + c\\Big(t-\\tfrac{b}{3a}\\Big) + d = a\\,(t^3 + p\\,t + q)$; the $t^2$ coefficient is $b - 3a\\cdot\\tfrac{b}{3a} = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["completing the cube", "Tschirnhaus transformation", "inflection point translation", "field_simp + ring"],
+    "prerequisites": ["polynomial expansion", "field arithmetic", "the substitution x = t - b/(3a)"]
   },
   {
     "id": "ann-soc-oq01-bijection",
@@ -19,7 +38,11 @@
     },
     "type": "insight",
     "title": "Roots Transfer Both Ways Because a ≠ 0",
-    "content": "The general cubic equals a times the parent's depressedCubic evaluated at t (generalCubicEval_shift). Since a ≠ 0, a·w = 0 ⟺ w = 0, so the shift t ↦ t - b/(3a) is a bijection between the root set of the depressed cubic and that of the general cubic, with explicit inverse x ↦ x + b/(3a). Cardano's three depressed roots therefore yield all three roots of the general cubic."
+    "content": "The general cubic equals a times the parent's depressedCubic evaluated at t (generalCubicEval_shift). Since a ≠ 0, a·w = 0 ⟺ w = 0, so the shift t ↦ t - b/(3a) is a bijection between the root set of the depressed cubic and that of the general cubic, with explicit inverse x ↦ x + b/(3a). Cardano's three depressed roots therefore yield all three roots of the general cubic. The lifting direction (depressed_root_of_general_root) uses add_sub_cancel_right to undo the shift and mul_eq_zero with a ≠ 0 to strip the leading factor.",
+    "mathContext": "$\\text{general}(t - \\tfrac{b}{3a}) = a\\cdot\\text{depressed}(t)$, and $a \\neq 0 \\Rightarrow (a w = 0 \\iff w = 0)$. Inverse map: $x \\mapsto x + \\tfrac{b}{3a}$.",
+    "significance": "key",
+    "relatedConcepts": ["root-set bijection", "mul_eq_zero", "integral domain (no zero divisors)", "affine change of variable"],
+    "prerequisites": ["roots of polynomials", "ℂ has no zero divisors", "inverse functions"]
   },
   {
     "id": "ann-soc-oq01-cardano",
@@ -30,6 +53,25 @@
     },
     "type": "insight",
     "title": "Closing the Loop: a Radical Root of the General Cubic",
-    "content": "general_cubic_cardano_root composes the shift with the parent's cardano_formula: given u, v with u³ + v³ = -q and u·v = -p/3 for the depressed parameters p, q, the value (u+v) - b/(3a) is a root of a·x³ + b·x² + c·x + d = 0. This supplies the missing first half of Cardano's classical method, so the gallery now contains a complete machine-checked path from an arbitrary cubic to a radical solution."
+    "content": "general_cubic_cardano_root composes the shift with the parent's cardano_formula: given u, v with u³ + v³ = -q and u·v = -p/3 for the depressed parameters p, q, the value (u+v) - b/(3a) is a root of a·x³ + b·x² + c·x + d = 0. This supplies the missing first half of Cardano's classical method, so the gallery now contains a complete machine-checked path from an arbitrary cubic to a radical solution.",
+    "mathContext": "Cardano conditions $u^3 + v^3 = -q,\\; uv = -\\tfrac{p}{3}$ give the depressed root $u+v$; the shift then yields the general root $x = (u+v) - \\tfrac{b}{3a}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardano's formula", "resolvent substitution", "radical solvability", "proof composition / bridging lemmas"],
+    "prerequisites": ["Cardano's formula for the depressed cubic (parent proof)", "the root bijection above"]
+  },
+  {
+    "id": "ann-soc-oq01-sanity",
+    "proofId": "solution-of-cubic-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 152
+    },
+    "type": "context",
+    "title": "Sanity Checks: Monic Specialization and a Worked Root",
+    "content": "Four examples confirm the abstract reduction matches familiar cases: depressedP/depressedQ at a = 1 give the textbook monic formulas p = c - b²/3 and q = 2b³/27 - bc/3 + d; the shift kills the quadratic term of x³ - 3x² + ... (here x = t + 1); and generalCubicEval 1 0 (-6) (-40) 4 = 0 recovers the parent's x³ - 6x - 40 example with root x = 4. These ground the general identity in concrete arithmetic discharged by ring and norm_num.",
+    "mathContext": "Monic case: $p = c - \\tfrac{b^2}{3},\\; q = \\tfrac{2b^3}{27} - \\tfrac{bc}{3} + d$. Worked example: $x^3 - 6x - 40 = 0$ has root $x = 4$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "monic normalization", "norm_num / ring decision procedures", "regression checks against the parent"],
+    "prerequisites": ["substitution arithmetic", "evaluating polynomials at integers"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01/index.ts
+++ b/src/data/proofs/solution-of-cubic-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SolutionOfCubicOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const solutionOfCubicOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const solutionOfCubicOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const solutionOfCubicOq01Data: ProofData = {
+  proof: solutionOfCubicOq01Proof,
+  annotations: solutionOfCubicOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- **Annotation coverage**: added 2 annotations — the depressed parameters (Part 1) and the sanity checks (Part 5) — so all five parts of the file are now covered (3 → 5 annotations).

Axiom integrity unchanged: meta correctly reports `verified`, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)