### PR TITLE
research(abel-ruffini-oq-03): cyclotomic realization of the abelian inverse Galois problem over ℚ [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -17,6 +17,7 @@ import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4Aristotle
 import Proofs.AbelRuffiniGaloisExtensionsOQ07
 import Proofs.AbelRuffiniGaloisExtensionsOQ11
+import Proofs.AbelRuffiniOQ03
 import Proofs.AbelRuffiniOQ04
 import Proofs.AbelRuffiniOQ04OQ01
 import Proofs.AbelRuffiniOQ04OQ01OQ01

--- a/proofs/Proofs/AbelRuffiniOQ03.lean
+++ b/proofs/Proofs/AbelRuffiniOQ03.lean
@@ -1,0 +1,131 @@
+import Mathlib
+
+/-
+# The abelian Inverse Galois Problem over ℚ: the cyclotomic realization
+
+## Open Question (abel-ruffini-oq-03)
+
+The **Inverse Galois Problem** asks which finite groups `G` arise as `Gal(L/ℚ)`
+for some finite Galois extension `L/ℚ`. The general problem is open; for finite
+*solvable* groups it is Shafarevich's theorem (recorded as an axiom in the sibling
+entry `abel-ruffini-galois-extensions-oq-05`, since its proof needs class field
+theory). For finite *abelian* groups it is a **theorem**, traditionally derived
+from the Kronecker–Weber theorem together with Dirichlet's theorem on primes in
+arithmetic progressions: every finite abelian group `A` is a quotient of
+`(ZMod n)ˣ` for a suitable `n` and is realized inside the `n`-th cyclotomic field.
+
+This file isolates and **proves, with zero axioms**, the load-bearing arithmetic
+core of that argument, the part that `Mathlib` already supports in full:
+
+> For every `n ≥ 1`, the `n`-th cyclotomic field `ℚ(ζₙ)` is an **abelian Galois
+> extension of `ℚ`** whose Galois group is `(ZMod n)ˣ`.
+
+Consequently every group of the form `(ZMod n)ˣ` is realized as a Galois group over
+`ℚ` by an explicit abelian extension. This is exactly the family of groups out of
+which the Kronecker–Weber realization builds an *arbitrary* finite abelian group:
+the only remaining ingredients are Dirichlet's theorem (to find `n` with `A` a
+quotient of `(ZMod n)ˣ`) and the Galois correspondence (to descend to the fixed
+field). Those steps are flagged in `kroneckerWeber_realization_target` below but
+are **not** part of the verified content here.
+
+## What is proved (all 0-sorry, 0-axiom)
+
+- `cyclotomicField_isGalois`      : `ℚ(ζₙ) / ℚ` is Galois.
+- `autEquivUnitsZMod`             : `Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ` (Mathlib's `autEquivPow`,
+                                    specialized to `ℚ` via `cyclotomic.irreducible_rat`).
+- `galois_mul_comm`               : the Galois group is **abelian** — `ℚ(ζₙ)/ℚ` is an
+                                    abelian extension.
+- `galois_finite`                 : the Galois group is finite.
+- `RealizationOverRat`            : a bundle "the finite group `G` is `Gal(L/ℚ)` for a
+                                    Galois extension `L/ℚ`".
+- `unitsZMod_realizableOverRat`   : `(ZMod n)ˣ` is realizable over `ℚ` (the cyclotomic
+                                    field is the witness).
+
+`#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` for each
+result above.
+-/
+
+namespace AbelRuffiniOQ03
+
+open Polynomial IsCyclotomicExtension
+
+/-- The `n`-th cyclotomic field over `ℚ` is a Galois extension of `ℚ`. -/
+theorem cyclotomicField_isGalois (n : ℕ) [NeZero n] :
+    IsGalois ℚ (CyclotomicField n ℚ) :=
+  IsCyclotomicExtension.isGalois (S := {n}) (K := ℚ) (L := CyclotomicField n ℚ)
+
+/-- **Cyclotomic Galois group.** The Galois group of `ℚ(ζₙ)/ℚ` is `(ZMod n)ˣ`.
+This is `Mathlib`'s `IsCyclotomicExtension.autEquivPow`, specialized to the base
+field `ℚ` where the `n`-th cyclotomic polynomial is irreducible. -/
+noncomputable def autEquivUnitsZMod (n : ℕ) [NeZero n] :
+    (CyclotomicField n ℚ ≃ₐ[ℚ] CyclotomicField n ℚ) ≃* (ZMod n)ˣ :=
+  IsCyclotomicExtension.autEquivPow (CyclotomicField n ℚ)
+    (cyclotomic.irreducible_rat (NeZero.pos n))
+
+/-- **The cyclotomic extension is abelian.** Any two automorphisms of `ℚ(ζₙ)/ℚ`
+commute, because the Galois group is isomorphic to the commutative group
+`(ZMod n)ˣ`. -/
+theorem galois_mul_comm (n : ℕ) [NeZero n]
+    (σ τ : CyclotomicField n ℚ ≃ₐ[ℚ] CyclotomicField n ℚ) :
+    σ * τ = τ * σ := by
+  have e := autEquivUnitsZMod n
+  apply e.injective
+  rw [map_mul, map_mul, mul_comm]
+
+/-- The Galois group `Gal(ℚ(ζₙ)/ℚ)` is finite. -/
+theorem galois_finite (n : ℕ) [NeZero n] :
+    Finite (CyclotomicField n ℚ ≃ₐ[ℚ] CyclotomicField n ℚ) :=
+  Finite.of_equiv _ (autEquivUnitsZMod n).symm.toEquiv
+
+/-- A bundle witnessing that the finite group `G` is the Galois group of a Galois
+extension of `ℚ`. The carrier field and its `ℚ`-algebra structure are packaged as
+instance fields so that `Carrier ≃ₐ[ℚ] Carrier` is well-typed. -/
+structure RealizationOverRat (G : Type*) [Group G] where
+  /-- The realizing field `L`. -/
+  Carrier : Type
+  [field : Field Carrier]
+  [algebra : Algebra ℚ Carrier]
+  /-- `L/ℚ` is a Galois extension. -/
+  isGalois : IsGalois ℚ Carrier
+  /-- An isomorphism `Gal(L/ℚ) ≃* G`. -/
+  equiv : (Carrier ≃ₐ[ℚ] Carrier) ≃* G
+
+attribute [instance] RealizationOverRat.field RealizationOverRat.algebra
+
+/-- **Cyclotomic realization.** For every `n ≥ 1`, the group `(ZMod n)ˣ` is the
+Galois group over `ℚ` of the `n`-th cyclotomic field. -/
+noncomputable def unitsZModRealization (n : ℕ) [NeZero n] :
+    RealizationOverRat (ZMod n)ˣ where
+  Carrier := CyclotomicField n ℚ
+  isGalois := cyclotomicField_isGalois n
+  equiv := autEquivUnitsZMod n
+
+/-- **`(ZMod n)ˣ` is realizable over `ℚ`** by an explicit abelian Galois extension. -/
+theorem unitsZMod_realizableOverRat (n : ℕ) [NeZero n] :
+    Nonempty (RealizationOverRat (ZMod n)ˣ) :=
+  ⟨unitsZModRealization n⟩
+
+/-!
+## The full Kronecker–Weber realization (not verified here)
+
+The complete abelian Inverse Galois statement — *every* finite abelian group `A`
+is `Gal(L/ℚ)` for some `L` — follows from the verified core above together with two
+classical inputs that are out of scope for this file:
+
+1. **Dirichlet's theorem on primes in arithmetic progressions**, used to choose `n`
+   so that `A` is a quotient of `(ZMod n)ˣ` (e.g. take distinct primes
+   `p ≡ 1 (mod mᵢ)` for the invariant factors `mᵢ` of `A`).
+2. **The Galois correspondence for abelian extensions**: a quotient `G/N` of an
+   abelian Galois group is realized by the fixed field `L^N`, which is itself
+   Galois over `ℚ` with group `G/N`.
+
+The statement of that target theorem is recorded below for reference; we do not
+assert it.
+
+```
+theorem kroneckerWeber_realization_target :
+    ∀ (A : Type) [AddCommGroup A] [Finite A], Nonempty (RealizationOverRat (Multiplicative A))
+```
+-/
+
+end AbelRuffiniOQ03

--- a/src/data/proofs/abel-ruffini-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-03/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "arar-oq03-ann-header",
+    "proofId": "abel-ruffini-oq-03",
+    "range": {
+      "startLine": 3,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "The abelian case is a theorem — this verifies its arithmetic core",
+    "content": "The inverse Galois problem (which finite groups are Gal(L/ℚ)?) is open in general and is Shafarevich's theorem for solvable groups (axiomatized in the sibling abel-ruffini-galois-extensions-oq-05). For ABELIAN groups it is a theorem, classically derived from Kronecker–Weber plus Dirichlet's theorem on primes in arithmetic progressions. This file isolates the part Mathlib supports in full and proves it with zero axioms: for every n ≥ 1 the n-th cyclotomic field ℚ(ζₙ) is an abelian Galois extension of ℚ with Galois group (ZMod n)ˣ. That family of groups is precisely the building block of the Kronecker–Weber realization of an arbitrary finite abelian group; the two remaining classical reductions are named in the closing docstring but not asserted."
+  },
+  {
+    "id": "arar-oq03-ann-galois-group",
+    "proofId": "abel-ruffini-oq-03",
+    "range": {
+      "startLine": 52,
+      "endLine": 66
+    },
+    "type": "key-step",
+    "title": "Gal(ℚ(ζₙ)/ℚ) ≅ (ZMod n)ˣ for all n",
+    "content": "cyclotomicField_isGalois packages IsCyclotomicExtension.isGalois: ℚ(ζₙ)/ℚ is a Galois extension. autEquivUnitsZMod is the arithmetic heart: Mathlib's IsCyclotomicExtension.autEquivPow produces Gal(L/K) ≃* (ZMod n)ˣ whenever the n-th cyclotomic polynomial is irreducible over the base field K. Over K = ℚ that irreducibility is cyclotomic.irreducible_rat, which holds for EVERY n ≥ 1 — so the isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ is unconditional. This is the single deep fact behind the abelian inverse Galois problem; everything else is transport of structure."
+  },
+  {
+    "id": "arar-oq03-ann-abelian",
+    "proofId": "abel-ruffini-oq-03",
+    "range": {
+      "startLine": 67,
+      "endLine": 80
+    },
+    "type": "key-step",
+    "title": "The extension is abelian (and finite) by transport",
+    "content": "galois_mul_comm proves ℚ(ζₙ)/ℚ is an ABELIAN extension without any hand computation on automorphisms: apply the isomorphism e = autEquivUnitsZMod to σ·τ and τ·σ, use map_mul and mul_comm on the commutative unit group (ZMod n)ˣ, and conclude σ·τ = τ·σ by injectivity of e. galois_finite likewise transports finiteness of (ZMod n)ˣ across e.symm. Both are clean instances of the principle that a group isomorphism carries group-theoretic properties (commutativity, finiteness) between its two sides."
+  },
+  {
+    "id": "arar-oq03-ann-realization",
+    "proofId": "abel-ruffini-oq-03",
+    "range": {
+      "startLine": 81,
+      "endLine": 110
+    },
+    "type": "key-step",
+    "title": "Realizability bundle: (ZMod n)ˣ is Gal(L/ℚ)",
+    "content": "RealizationOverRat G bundles the data witnessing that a finite group G is a Galois group over ℚ: a carrier field L (with its Field and Algebra ℚ instances packaged as instance fields so that L ≃ₐ[ℚ] L type-checks), a proof IsGalois ℚ L, and an isomorphism (L ≃ₐ[ℚ] L) ≃* G. unitsZModRealization instantiates the bundle with L = CyclotomicField n ℚ, and unitsZMod_realizableOverRat states the existence form: Nonempty (RealizationOverRat (ZMod n)ˣ). This is exactly the inverse-Galois shape 'G = Gal(L/ℚ)', proved for the cyclotomic family over the fixed arithmetic base ℚ."
+  },
+  {
+    "id": "arar-oq03-ann-target",
+    "proofId": "abel-ruffini-oq-03",
+    "range": {
+      "startLine": 111,
+      "endLine": 131
+    },
+    "type": "context",
+    "title": "What is left to reach an arbitrary abelian group",
+    "content": "The closing docstring records the full Kronecker–Weber realization target — every finite abelian group A is Gal(L/ℚ) — and names the two classical inputs that bridge from the verified family (ZMod n)ˣ: (1) Dirichlet's theorem on primes in arithmetic progressions, used to choose n so that A is a quotient of (ZMod n)ˣ (e.g. distinct primes pᵢ ≡ 1 mod the invariant factors mᵢ of A); and (2) the Galois correspondence for abelian extensions, by which a quotient G/N of an abelian Galois group is realized by the fixed field L^N, itself Galois over ℚ with group G/N. These are provable but out of scope here, and are deliberately NOT introduced as axioms."
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-03/knowledge.md
+++ b/src/data/proofs/abel-ruffini-oq-03/knowledge.md
@@ -1,0 +1,62 @@
+# The Abelian Inverse Galois Problem over ℚ — Cyclotomic Realization
+
+## Result
+
+For every `n ≥ 1`, the `n`-th cyclotomic field `ℚ(ζₙ)` is an **abelian Galois
+extension of `ℚ`** whose Galois group is `(ZMod n)ˣ`. Consequently every group of
+the form `(ZMod n)ˣ` is a Galois group over `ℚ`. Verified with **0 added axioms**
+(`#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`).
+
+## Why this matters
+
+The inverse Galois problem is open in general; for finite **solvable** groups it is
+Shafarevich's theorem (class field theory), axiomatized in the sibling entry
+`abel-ruffini-galois-extensions-oq-05`. For finite **abelian** groups it is a
+*theorem*. The classical proof:
+
+1. Write the target finite abelian group `A` as a product of cyclic groups
+   `∏ ℤ/mᵢℤ`.
+2. By **Dirichlet's theorem**, pick distinct primes `pᵢ ≡ 1 (mod mᵢ)`. Then
+   `Gal(ℚ(ζ_{pᵢ})/ℚ) ≅ (ZMod pᵢ)ˣ` is cyclic of order `pᵢ − 1`, which surjects onto
+   `ℤ/mᵢℤ`.
+3. Pass to the fixed field of the relevant subgroup (Galois correspondence), and
+   take the compositum, to realize `A` as `Gal(L/ℚ)`.
+
+The single arithmetic engine of this argument is the structure of the cyclotomic
+Galois group, `Gal(ℚ(ζₙ)/ℚ) ≅ (ZMod n)ˣ`. **That is exactly what this entry
+verifies**, leaving Dirichlet and the Galois descent as named, out-of-scope inputs.
+
+## Lean / Mathlib specifics
+
+- The cyclotomic field is `CyclotomicField n ℚ` with the instance
+  `IsCyclotomicExtension {n} ℚ (CyclotomicField n ℚ)` (needs `[NeZero n]`).
+- `IsCyclotomicExtension.isGalois` gives `IsGalois ℚ (CyclotomicField n ℚ)`. It is a
+  **theorem, not an instance** — must be applied explicitly with named arguments
+  `(S := {n}) (K := ℚ) (L := …)`.
+- `IsCyclotomicExtension.autEquivPow L h : Gal(L/K) ≃* (ZMod n)ˣ` requires
+  `h : Irreducible (cyclotomic n K)`. Over `ℚ` use
+  `Polynomial.cyclotomic.irreducible_rat (hpos : 0 < n)`
+  (`Mathlib/RingTheory/Polynomial/Cyclotomic/Roots.lean`); supply `hpos` as
+  `NeZero.pos n`.
+- `Gal(E/F)` is notation for `E ≃ₐ[F] E`.
+- Abelianness is obtained by **transport**: `(ZMod n)ˣ` is a `CommGroup`, so
+  `e.injective` together with `map_mul`/`mul_comm` (where `e := autEquivPow …`)
+  proves any two automorphisms commute. Finiteness transports the same way via
+  `Finite.of_equiv _ e.symm.toEquiv`.
+
+## Gotcha: bundling realizability
+
+To state "`G` is `Gal(L/ℚ)` for some Galois `L/ℚ`" as a reusable object, the carrier
+field's `Field` and `Algebra ℚ` instances must be available when forming the
+Galois-group type `L ≃ₐ[ℚ] L`. A plain existential `∃ (_ : Field L) (_ : Algebra ℚ L), …`
+does **not** register those binders as instances, so `L ≃ₐ[ℚ] L` fails to elaborate.
+The fix used here is a `structure RealizationOverRat` with the `Field`/`Algebra`
+fields declared as **instance-implicit** (`[field : …]`, `[algebra : …]`), which Lean
+makes available for instance resolution in the later field types
+(`attribute [instance]` is also added for downstream use).
+
+## Verification
+
+Docker build infra was down; verified offline from the main `proofs/` checkout with
+`LAKE_UNSAFE=1 lake env lean Proofs/AbelRuffiniOQ03.lean` (exit 0, no errors), and
+axioms confirmed via inline `#print axioms` on all five public results.

--- a/src/data/proofs/abel-ruffini-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-03/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "abel-ruffini-oq-03",
+  "title": "The Abelian Inverse Galois Problem over ℚ: the Cyclotomic Realization",
+  "slug": "abel-ruffini-oq-03",
+  "description": "Verifies, with zero added axioms, the arithmetic core of the abelian case of the inverse Galois problem over ℚ. While the general inverse Galois problem is open and the solvable case is Shafarevich's theorem (axiomatized in the sibling entry abel-ruffini-galois-extensions-oq-05), the ABELIAN case is a theorem, classically derived from Kronecker–Weber plus Dirichlet's theorem. This entry isolates the part Mathlib supports in full: for every n ≥ 1 the n-th cyclotomic field ℚ(ζₙ) is an ABELIAN Galois extension of ℚ with Galois group (ZMod n)ˣ. cyclotomicField_isGalois packages IsCyclotomicExtension.isGalois; autEquivUnitsZMod specializes Mathlib's IsCyclotomicExtension.autEquivPow to the base field ℚ (where cyclotomic.irreducible_rat applies) to give the explicit isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ; galois_mul_comm transports commutativity of (ZMod n)ˣ across that isomorphism to prove the extension is abelian; galois_finite records finiteness. The RealizationOverRat bundle packages 'the finite group G is Gal(L/ℚ) for a Galois L/ℚ', and unitsZMod_realizableOverRat exhibits (ZMod n)ˣ as realizable over ℚ with the cyclotomic field as witness — exactly the family of groups out of which the Kronecker–Weber argument builds an arbitrary finite abelian group. The two remaining classical inputs (Dirichlet, and the Galois correspondence for descending to a quotient) are flagged in the docstring as out of scope, not asserted. All results are 0-axiom (only propext, Classical.choice, Quot.sound).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ03.lean",
+    "tags": [
+      "galois-theory",
+      "number-theory",
+      "inverse-galois-problem",
+      "cyclotomic-fields",
+      "kronecker-weber",
+      "abelian-extensions",
+      "abel-ruffini"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None added. #print axioms reports only propext, Classical.choice, Quot.sound for cyclotomicField_isGalois, autEquivUnitsZMod, galois_mul_comm, galois_finite, and unitsZMod_realizableOverRat. NOTE on scope: the entry verifies the cyclotomic realization — that every group (ZMod n)ˣ is the Galois group of an abelian extension of ℚ. The full abelian inverse Galois statement (every finite abelian group is Gal(L/ℚ)) additionally requires (1) Dirichlet's theorem on primes in arithmetic progressions, to choose n so that the target abelian group is a quotient of (ZMod n)ˣ, and (2) the Galois correspondence for abelian extensions, to descend to the fixed field of the relevant subgroup. Both are classical and provable but are NOT formalized here; they are stated for reference in the kroneckerWeber_realization_target docstring and are not asserted as axioms.",
+    "lineCount": 131,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "originalContributions": [
+      "autEquivUnitsZMod: the explicit isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ, obtained by specializing Mathlib's IsCyclotomicExtension.autEquivPow to the base field ℚ via cyclotomic.irreducible_rat — the load-bearing arithmetic fact of the abelian inverse Galois problem.",
+      "galois_mul_comm: a machine-checked proof that the cyclotomic extension ℚ(ζₙ)/ℚ is ABELIAN, by transporting mul_comm on (ZMod n)ˣ across the Galois-group isomorphism and using injectivity of the MulEquiv.",
+      "RealizationOverRat + unitsZMod_realizableOverRat: a reusable bundle 'the finite group G is the Galois group of a Galois extension L/ℚ', with the carrier field and ℚ-algebra structure packaged as instance fields, instantiated to exhibit (ZMod n)ˣ as realizable over ℚ by the explicit cyclotomic field.",
+      "cyclotomicField_isGalois + galois_finite: the supporting structural facts that ℚ(ζₙ)/ℚ is Galois (IsCyclotomicExtension.isGalois) and that its Galois group is finite (transported from finiteness of (ZMod n)ˣ)."
+    ]
+  },
+  "leanFile": {
+    "namespace": "AbelRuffiniOQ03",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 3,
+    "path": "Proofs/AbelRuffiniOQ03.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The inverse Galois problem asks which finite groups arise as Gal(L/ℚ). It splits by the structure of the group. For finite ABELIAN groups the answer is YES and classical: every finite abelian group is realized over ℚ. The standard proof combines the Kronecker–Weber theorem (every abelian extension of ℚ lies in a cyclotomic field, so abelian realizations are exactly the subfields of cyclotomic fields) with Dirichlet's theorem on primes in arithmetic progressions (to manufacture cyclic factors of any order via Gal(ℚ(ζ_p)/ℚ) ≅ (ZMod p)ˣ, cyclic of order p−1). For finite SOLVABLE groups it is Shafarevich's theorem (1954, class field theory), recorded as an axiom in the sibling entry abel-ruffini-galois-extensions-oq-05; the general case remains open. This entry isolates the arithmetic engine of the abelian case — the cyclotomic Galois group — which Mathlib develops in full via IsCyclotomicExtension.autEquivPow.",
+    "problemStatement": "Verify, axiom-free, the realizable core of the abelian inverse Galois problem over ℚ: for every n ≥ 1, exhibit the n-th cyclotomic field ℚ(ζₙ) as an abelian Galois extension of ℚ whose Galois group is (ZMod n)ˣ, and package this as a realizability statement for the family of groups (ZMod n)ˣ. Flag the remaining classical inputs (Dirichlet, Galois descent to quotients) needed to reach an arbitrary finite abelian group without asserting them.",
+    "text": "The file specializes Mathlib's cyclotomic Galois theory to the base field ℚ. cyclotomicField_isGalois invokes IsCyclotomicExtension.isGalois to show ℚ(ζₙ)/ℚ is Galois. autEquivUnitsZMod is the heart: IsCyclotomicExtension.autEquivPow gives Gal(L/K) ≃* (ZMod n)ˣ whenever the n-th cyclotomic polynomial is irreducible over K, and over K = ℚ this irreducibility is cyclotomic.irreducible_rat (valid for all n ≥ 1), so Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ unconditionally. galois_mul_comm then proves the extension is abelian: applying the (injective) isomorphism to σ·τ and τ·σ and using commutativity of the unit group (ZMod n)ˣ forces σ·τ = τ·σ. galois_finite transports finiteness across the same isomorphism. The structure RealizationOverRat bundles a carrier field with its ℚ-algebra and Galois structure plus an isomorphism Gal(L/ℚ) ≃* G; unitsZModRealization instantiates it with the cyclotomic field, and unitsZMod_realizableOverRat states (ZMod n)ˣ is realizable over ℚ. A closing docstring records the full Kronecker–Weber realization target and names the two classical steps left out of the verified content.",
+    "proofStrategy": "Take the deep arithmetic input (the structure of the cyclotomic Galois group) from Mathlib, where IsCyclotomicExtension.autEquivPow is fully proved, and specialize it to ℚ using cyclotomic.irreducible_rat. Derive the abelian property and finiteness by transport of structure across the resulting MulEquiv (commutativity and finiteness are properties of (ZMod n)ˣ, pulled back to the Galois group). Package realizability as a bundle whose field/algebra data are instance fields so the Galois-group type is well-formed, and instantiate it at the cyclotomic field. Keep Dirichlet and the quotient/fixed-field descent in the docstring, since formalizing them is a separate substantial effort.",
+    "keyInsights": [
+      "The abelian inverse Galois problem over ℚ is a theorem (unlike the open general case), and its arithmetic engine is the single fact Gal(ℚ(ζₙ)/ℚ) ≅ (ZMod n)ˣ — which Mathlib already proves via autEquivPow once irreducibility of the cyclotomic polynomial over the base field is supplied.",
+      "Over ℚ the irreducibility hypothesis of autEquivPow is discharged for ALL n ≥ 1 by cyclotomic.irreducible_rat, so the isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ holds with no extra hypotheses on n.",
+      "Abelianness of the extension is not proved by hand on automorphisms; it is transported: (ZMod n)ˣ is commutative as the unit group of a commutative ring, and a group isomorphism carries commutativity back to Gal(ℚ(ζₙ)/ℚ).",
+      "(ZMod n)ˣ is exactly the family of groups Kronecker–Weber uses: every finite abelian group is a quotient of some (ZMod n)ˣ (via Dirichlet), and quotients of abelian Galois groups are realized by fixed fields — so this verified family is the genuine building block of the full theorem."
+    ],
+    "prerequisites": [
+      "Cyclotomic fields: CyclotomicField n K and the class IsCyclotomicExtension {n} K L (Mathlib NumberTheory.Cyclotomic.Basic).",
+      "The cyclotomic Galois group: IsCyclotomicExtension.autEquivPow : Gal(L/K) ≃* (ZMod n)ˣ given irreducibility of cyclotomic n K (Mathlib NumberTheory.Cyclotomic.Gal).",
+      "Irreducibility of the cyclotomic polynomial over ℚ: Polynomial.cyclotomic.irreducible_rat (Mathlib RingTheory.Polynomial.Cyclotomic.Roots).",
+      "Galois extensions IsGalois and the Galois group L ≃ₐ[K] L; group isomorphisms MulEquiv and transport of structure (commutativity, finiteness).",
+      "The unit group (ZMod n)ˣ of ℤ/nℤ as a finite commutative group."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every n ≥ 1 the n-th cyclotomic field ℚ(ζₙ) is an abelian Galois extension of ℚ with Galois group (ZMod n)ˣ: cyclotomicField_isGalois (Galois), autEquivUnitsZMod (Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ), galois_mul_comm (abelian), galois_finite (finite). Bundled as RealizationOverRat and stated as unitsZMod_realizableOverRat: (ZMod n)ˣ is realizable as a Galois group over ℚ by the explicit cyclotomic field. All results are 0-axiom (propext, Classical.choice, Quot.sound only). 4 theorems, 3 definitions, 131 lines.",
+    "implications": "This verifies the arithmetic core of the abelian inverse Galois problem over ℚ and supplies the building-block family (ZMod n)ˣ used by the Kronecker–Weber realization of arbitrary finite abelian groups. Together with the sibling Artin entry (oq-05-oq-02, realizability over an auxiliary base field) and the parent Shafarevich axiom (oq-05, solvable groups over ℚ), it sharpens the picture of the inverse Galois problem: abelian over ℚ is fully provable (this entry's family plus two classical reductions), solvable over ℚ is Shafarevich, and the general case is open. The RealizationOverRat bundle is reusable for any concrete realization over ℚ.",
+    "openQuestions": [
+      "Discharge the full Kronecker–Weber realization (kroneckerWeber_realization_target): every finite abelian group A is Gal(L/ℚ). This needs Dirichlet's theorem to choose n with A a quotient of (ZMod n)ˣ, and the Galois correspondence to descend to the fixed field of the corresponding subgroup.",
+      "Formalize the cyclic case explicitly: for each m ≥ 1, ℤ/mℤ is Gal(L/ℚ), by taking a prime p ≡ 1 (mod m) (Dirichlet), using Gal(ℚ(ζ_p)/ℚ) ≅ (ZMod p)ˣ cyclic of order p−1, and passing to the fixed field of the index-m subgroup.",
+      "Prove the descent lemma in this setting: for an abelian Galois extension L/ℚ with group G and subgroup H, the fixed field L^H is Galois over ℚ with Gal(L^H/ℚ) ≅ G/H — the second classical input named in the docstring."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and imports",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring framing the entry as the verified arithmetic core of the abelian inverse Galois problem over ℚ: the cyclotomic Galois group, the abelian property, and the realizability of (ZMod n)ˣ, with Dirichlet and the Galois descent flagged as out-of-scope classical inputs. Imports Mathlib; opens Polynomial and IsCyclotomicExtension."
+    },
+    {
+      "id": "galois-and-group",
+      "title": "Section I — ℚ(ζₙ)/ℚ is Galois with group (ZMod n)ˣ",
+      "startLine": 52,
+      "endLine": 66,
+      "summary": "cyclotomicField_isGalois: ℚ(ζₙ)/ℚ is Galois (IsCyclotomicExtension.isGalois). autEquivUnitsZMod: the explicit isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ, specializing IsCyclotomicExtension.autEquivPow to ℚ via cyclotomic.irreducible_rat (valid for all n ≥ 1)."
+    },
+    {
+      "id": "abelian-and-finite",
+      "title": "Section II — the extension is abelian and finite",
+      "startLine": 67,
+      "endLine": 80,
+      "summary": "galois_mul_comm: any two automorphisms of ℚ(ζₙ)/ℚ commute, proved by transporting mul_comm on (ZMod n)ˣ across the injective MulEquiv — i.e. ℚ(ζₙ)/ℚ is an abelian extension. galois_finite: the Galois group is finite, transported from finiteness of (ZMod n)ˣ."
+    },
+    {
+      "id": "realization",
+      "title": "Section III — realizability bundle for (ZMod n)ˣ",
+      "startLine": 81,
+      "endLine": 110,
+      "summary": "RealizationOverRat: a bundle (carrier field + ℚ-algebra + Galois + isomorphism Gal(L/ℚ) ≃* G) witnessing that G is a Galois group over ℚ. unitsZModRealization instantiates it with the cyclotomic field; unitsZMod_realizableOverRat states (ZMod n)ˣ is realizable over ℚ."
+    },
+    {
+      "id": "target",
+      "title": "Section IV — the full Kronecker–Weber target (not verified)",
+      "startLine": 111,
+      "endLine": 131,
+      "summary": "A docstring recording the full abelian realization target and the two classical inputs (Dirichlet's theorem; the Galois correspondence descent to a quotient) needed to upgrade the verified family (ZMod n)ˣ to an arbitrary finite abelian group. Not asserted."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-05-oq-02",
+      "relationship": "related",
+      "description": "Sibling: the Artin realizability direction, which realizes any finite group as a Galois group over an AUXILIARY base field (the fixed field F^G), axiom-free. This entry is the complementary axiom-free result that realizes the abelian family (ZMod n)ˣ over the FIXED arithmetic base ℚ via cyclotomic fields — progress on exactly the ℚ-difficulty the Artin entry isolates."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-05",
+      "relationship": "related",
+      "description": "Parent of the Artin sibling: records Shafarevich's theorem (every finite solvable group is Gal(L/ℚ)) as an axiom. The abelian case proved-of here is a special case of Shafarevich's solvable case, but verified directly via cyclotomic fields rather than assumed."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "extends",
+      "description": "Root entry: the Abel–Ruffini theorem and the solvability of S_n. This entry continues the Galois-theoretic thread by addressing which groups are realized over ℚ, for the abelian case."
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Verifies, with **zero added axioms**, the arithmetic core of the **abelian case of the inverse Galois problem over ℚ**. The general inverse Galois problem is open and the solvable case is Shafarevich's theorem (axiomatized in the sibling `abel-ruffini-galois-extensions-oq-05`); the abelian case is a *theorem*, classically derived from Kronecker–Weber + Dirichlet. This entry isolates the part Mathlib supports in full:

> For every `n ≥ 1`, the `n`-th cyclotomic field `ℚ(ζₙ)` is an **abelian Galois extension of ℚ** with Galois group `(ZMod n)ˣ`.

## Results (`Proofs/AbelRuffiniOQ03.lean`)

| Name | Statement |
|------|-----------|
| `cyclotomicField_isGalois` | `ℚ(ζₙ)/ℚ` is Galois (`IsCyclotomicExtension.isGalois`) |
| `autEquivUnitsZMod` | `Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ`, specializing Mathlib's `IsCyclotomicExtension.autEquivPow` to `ℚ` via `cyclotomic.irreducible_rat` (holds for all `n ≥ 1`) |
| `galois_mul_comm` | the extension is **abelian** (transport of `mul_comm` across the iso) |
| `galois_finite` | the Galois group is finite |
| `RealizationOverRat` / `unitsZMod_realizableOverRat` | `(ZMod n)ˣ` is realizable as `Gal(L/ℚ)`, with the cyclotomic field as explicit witness |

`(ZMod n)ˣ` is exactly the building-block family of the Kronecker–Weber realization of an arbitrary finite abelian group. The two remaining classical inputs (**Dirichlet's theorem**; **Galois descent to a quotient**) are flagged in the closing docstring as out of scope — **not asserted as axioms**.

## Verification

Docker build infra was down; verified offline from the main `proofs/` checkout:
- `LAKE_UNSAFE=1 lake env lean Proofs/AbelRuffiniOQ03.lean` → exit 0, no errors/warnings.
- `#print axioms` on all five public results → only `propext`, `Classical.choice`, `Quot.sound` (0 added axioms).

**Status:** `verified` · 0 sorries · 0 axioms · 4 theorems · 3 definitions · 131 lines.

Gallery entry added at `src/data/proofs/abel-ruffini-oq-03/` (meta.json, annotations.json, knowledge.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)