### PR TITLE
Enrich Lagrange Interpolant Realizes the Unique Polynomial Interpolant (Vandermonde OQ-01-OQ-01)

### DIFF
--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "type": "concept",
     "range": { "startLine": 1, "endLine": 36 },
     "title": "Module Header: The Lagrange Interpolant as the Realizer",
-    "content": "The companion entry proves **uniqueness** of the degree-$<n$ interpolant through $n$ distinct nodes $v$. This file supplies the matching **existence** half: the explicit **Lagrange interpolant** $\\mathrm{interp}\\,v\\,r = \\sum_i r_i\\,\\ell_i$ (with $\\ell_i$ the $i$-th Lagrange basis polynomial, $\\ell_i(v_j) = \\delta_{ij}$) takes the value $r_j$ at each node and has degree $<n$, so the interpolation problem is **well-posed** — a unique solution exists, and it is exactly this formula. Mathlib's `Lagrange.*` API supplies the engine; the work is recasting it in the $\\mathrm{Fin}\\,n$ / `Polynomial.eval` / `natDegree` idiom and exposing existence-and-uniqueness as $\\exists!$."
+    "content": "The companion entry proves **uniqueness** of the degree-$<n$ interpolant through $n$ distinct nodes $v$. This file supplies the matching **existence** half: the explicit **Lagrange interpolant** $\\mathrm{interp}\\,v\\,r = \\sum_i r_i\\,\\ell_i$ (with $\\ell_i$ the $i$-th Lagrange basis polynomial, $\\ell_i(v_j) = \\delta_{ij}$) takes the value $r_j$ at each node and has degree $<n$, so the interpolation problem is **well-posed** — a unique solution exists, and it is exactly this formula. Mathlib's `Lagrange.*` API supplies the engine; the work is recasting it in the $\\mathrm{Fin}\\,n$ / `Polynomial.eval` / `natDegree` idiom and exposing existence-and-uniqueness as $\\exists!$.",
+    "mathContext": "$\\mathrm{interp}\\,v\\,r = \\sum_{i=0}^{n-1} r_i\\,\\ell_i(X)$, where $\\ell_i(X) = \\prod_{j\\ne i}\\dfrac{X - v_j}{v_i - v_j}$ and $\\ell_i(v_j) = \\delta_{ij}$.",
+    "significance": "context",
+    "relatedConcepts": ["Lagrange interpolation", "existence vs uniqueness", "Vandermonde determinant", "well-posed problem"],
+    "prerequisites": ["polynomials over a field", "the companion uniqueness proof"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-oq-01-interp-def",
@@ -13,7 +17,11 @@
     "type": "definition",
     "range": { "startLine": 53, "endLine": 54 },
     "title": "The Explicit Lagrange Interpolant",
-    "content": "`interp v r := Lagrange.interpolate univ v r`. Concretely $\\sum_{i} C(r_i)\\cdot \\mathrm{basis}\\,v\\,i$, the degree-$<n$ polynomial $\\sum_i r_i\\,\\ell_i$ whose value at $v_j$ is $r_j$. This is the explicit existence witness complementing the companion's abstract uniqueness."
+    "content": "`interp v r := Lagrange.interpolate univ v r`. Concretely $\\sum_{i} C(r_i)\\cdot \\mathrm{basis}\\,v\\,i$, the degree-$<n$ polynomial $\\sum_i r_i\\,\\ell_i$ whose value at $v_j$ is $r_j$. This is the explicit existence witness complementing the companion's abstract uniqueness.",
+    "mathContext": "$\\mathrm{interp}\\,v\\,r := \\mathrm{Lagrange.interpolate}\\;\\mathrm{univ}\\;v\\;r \\in F[X]$; noncomputable because field inverses are noncomputable.",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange basis polynomials", "Lagrange.interpolate", "existence witness"],
+    "prerequisites": ["the polynomial ring F[X]", "Lagrange basis"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-oq-01-eval",
@@ -21,7 +29,11 @@
     "type": "theorem",
     "range": { "startLine": 56, "endLine": 61 },
     "title": "Existence: the Interpolant Hits the Data",
-    "content": "`eval_interp`: $(\\mathrm{interp}\\,v\\,r)(v_j) = r_j$ for every node $j$. Immediate from Mathlib's `Lagrange.eval_interpolate_at_node` (using $v$ injective on `univ`, $j \\in$ `univ`). This is the existence half — the interpolation system is solvable, and the Lagrange formula is a solution."
+    "content": "`eval_interp`: $(\\mathrm{interp}\\,v\\,r)(v_j) = r_j$ for every node $j$. Immediate from Mathlib's `Lagrange.eval_interpolate_at_node` (using $v$ injective on `univ`, $j \\in$ `univ`). This is the existence half — the interpolation system is solvable, and the Lagrange formula is a solution.",
+    "mathContext": "$(\\mathrm{interp}\\,v\\,r)(v_j) = r_j$ for all $j \\in \\mathrm{Fin}\\,n$. Relies on $v$ being injective so the nodes are distinct.",
+    "significance": "key",
+    "relatedConcepts": ["interpolation conditions", "node injectivity", "Lagrange.eval_interpolate_at_node", "Kronecker delta property"],
+    "prerequisites": ["polynomial evaluation", "distinct interpolation nodes"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-oq-01-degree",
@@ -29,7 +41,11 @@
     "type": "theorem",
     "range": { "startLine": 63, "endLine": 87 },
     "title": "Degree Bound and the degree ↔ natDegree Bridge",
-    "content": "`degree_interp_lt`: $\\deg(\\mathrm{interp}\\,v\\,r) < n$, from `Lagrange.degree_interpolate_lt` with $\\#\\mathrm{univ} = n$. `natDegree_interp_lt` recasts this in the companion's $\\deg_{\\mathbb N} < n$ idiom for $n \\ge 1$: Mathlib's `degree < \\#s` form correctly includes the zero polynomial, so the bridge case-splits on $\\mathrm{interp} = 0$ (then $\\deg_{\\mathbb N} = 0 < n$ needs $0 < n$) versus nonzero (then `degree_eq_natDegree` + `Nat.cast_lt` transfer the bound)."
+    "content": "`degree_interp_lt`: $\\deg(\\mathrm{interp}\\,v\\,r) < n$, from `Lagrange.degree_interpolate_lt` with $\\#\\mathrm{univ} = n$. `natDegree_interp_lt` recasts this in the companion's $\\deg_{\\mathbb N} < n$ idiom for $n \\ge 1$: Mathlib's `degree < \\#s` form correctly includes the zero polynomial, so the bridge case-splits on $\\mathrm{interp} = 0$ (then $\\deg_{\\mathbb N} = 0 < n$ needs $0 < n$) versus nonzero (then `degree_eq_natDegree` + `Nat.cast_lt` transfer the bound).",
+    "mathContext": "$\\deg(\\mathrm{interp}\\,v\\,r) < n$ as a `WithBot ℕ` degree; for $n \\ge 1$, $\\mathrm{natDegree} < n$. The $\\deg < n$ form already covers $0$ (whose degree is $\\bot$), but $\\mathrm{natDegree}\\,0 = 0$ needs $n \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial degree", "natDegree", "WithBot ℕ", "zero polynomial edge case", "degree_eq_natDegree"],
+    "prerequisites": ["degree vs natDegree in Mathlib", "the dimension count of degree-<n polynomials"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-oq-01-eq-interp",
@@ -37,7 +53,11 @@
     "type": "theorem",
     "range": { "startLine": 89, "endLine": 97 },
     "title": "The Interpolant Is the Unique Answer",
-    "content": "`eq_interp_of_eval_eq`: any polynomial $p$ of degree $<n$ with $p(v_j) = r_j$ at every node **equals** $\\mathrm{interp}\\,v\\,r$ (via `Lagrange.eq_interpolate_of_eval_eq`). So the explicit Lagrange formula is not merely *a* solution but *the* solution — the realizer of the unique interpolant from the companion entry."
+    "content": "`eq_interp_of_eval_eq`: any polynomial $p$ of degree $<n$ with $p(v_j) = r_j$ at every node **equals** $\\mathrm{interp}\\,v\\,r$ (via `Lagrange.eq_interpolate_of_eval_eq`). So the explicit Lagrange formula is not merely *a* solution but *the* solution — the realizer of the unique interpolant from the companion entry.",
+    "mathContext": "$\\big(\\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j\\big) \\Rightarrow p = \\mathrm{interp}\\,v\\,r$ — the uniqueness clause, tying back to the Vandermonde nonvanishing of the companion.",
+    "significance": "key",
+    "relatedConcepts": ["uniqueness of interpolant", "Lagrange.eq_interpolate_of_eval_eq", "Vandermonde determinant nonvanishing"],
+    "prerequisites": ["existence of the interpolant", "a degree-<n polynomial is determined by n values"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-oq-01-existsunique",
@@ -45,14 +65,22 @@
     "type": "theorem",
     "range": { "startLine": 99, "endLine": 114 },
     "title": "Well-Posedness: ∃! Interpolant",
-    "content": "`existsUnique_interp`: $\\exists!\\,p,\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$. Existence from `eval_interp` + `degree_interp_lt`; uniqueness from `eq_interp_of_eval_eq`. `existsUnique_interp_natDegree` ($n \\ge 1$) gives the same in the companion's $\\deg_{\\mathbb N} < n$ framing via the degree↔natDegree bridge. This is the complete well-posedness statement: the interpolation problem has exactly one degree-$<n$ solution, and it is the Lagrange interpolant."
+    "content": "`existsUnique_interp`: $\\exists!\\,p,\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$. Existence from `eval_interp` + `degree_interp_lt`; uniqueness from `eq_interp_of_eval_eq`. `existsUnique_interp_natDegree` ($n \\ge 1$) gives the same in the companion's $\\deg_{\\mathbb N} < n$ framing via the degree↔natDegree bridge. This is the complete well-posedness statement: the interpolation problem has exactly one degree-$<n$ solution, and it is the Lagrange interpolant.",
+    "mathContext": "$\\exists!\\,p \\in F[X],\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$. Existence $\\wedge$ uniqueness packaged as $\\exists!$, the formal meaning of 'well-posed'.",
+    "significance": "key",
+    "relatedConcepts": ["ExistsUnique", "well-posedness (Hadamard)", "existence ∧ uniqueness", "linear system with nonsingular matrix"],
+    "prerequisites": ["the eval and degree lemmas", "the uniqueness lemma"]
   },
   {
     "id": "vandermonde-interpolation-oq-01-oq-01-reproduction-linearity",
     "proofId": "vandermonde-interpolation-oq-01-oq-01",
     "type": "theorem",
-    "range": { "startLine": 116, "endLine": 132 },
+    "range": { "startLine": 116, "endLine": 133 },
     "title": "Reproduction and Linearity",
-    "content": "`interp_eval_self`: interpolating the sampled values of a degree-$<n$ polynomial $f$ returns $f$ — Lagrange interpolation is a **left inverse to evaluation** on the degree-$<n$ subspace. `interp_add` / `interp_smul`: the data-to-interpolant map $r \\mapsto \\mathrm{interp}\\,v\\,r$ is $F$-**linear** (`map_add` / `map_smul` of Mathlib's `LinearMap` `interpolate`), the structural fact behind superposition and basis expansion in interpolation."
+    "content": "`interp_eval_self`: interpolating the sampled values of a degree-$<n$ polynomial $f$ returns $f$ — Lagrange interpolation is a **left inverse to evaluation** on the degree-$<n$ subspace. `interp_add` / `interp_smul`: the data-to-interpolant map $r \\mapsto \\mathrm{interp}\\,v\\,r$ is $F$-**linear** (`map_add` / `map_smul` of Mathlib's `LinearMap` `interpolate`), the structural fact behind superposition and basis expansion in interpolation.",
+    "mathContext": "Reproduction: $\\mathrm{interp}\\,v\\,(f(v_\\bullet)) = f$ when $\\deg f < n$. Linearity: $\\mathrm{interp}\\,v\\,(r + r') = \\mathrm{interp}\\,v\\,r + \\mathrm{interp}\\,v\\,r'$ and $\\mathrm{interp}\\,v\\,(c\\cdot r) = c\\cdot\\mathrm{interp}\\,v\\,r$.",
+    "significance": "supporting",
+    "relatedConcepts": ["left inverse to the evaluation map", "F-linear map", "superposition principle", "isomorphism of degree-<n polynomials with F^n"],
+    "prerequisites": ["linear maps", "the evaluation-at-nodes map", "uniqueness of the interpolant"]
   }
 ]

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/index.ts
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/VandermondeInterpolationOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const vandermondeInterpolationOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const vandermondeInterpolationOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const vandermondeInterpolationOq01Oq01Data: ProofData = {
+  proof: vandermondeInterpolationOq01Oq01Proof,
+  annotations: vandermondeInterpolationOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `vandermonde-interpolation-oq-01-oq-01`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 7 annotations (coverage of the file was already complete).

Axiom integrity unchanged: meta reports `verified`, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)