### PR TITLE
research(hilbert-22-oq-01-oq-03): universal property — chainDist is the pseudometric coreflection [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Hilbert22OQ01OQ03.lean
+++ b/proofs/Proofs/Hilbert22OQ01OQ03.lean
@@ -201,4 +201,63 @@ theorem chainDist_mono_self (c : X → X → ℝ≥0∞) (f : X → X)
     chainDist c (f p) (f q) ≤ chainDist c p q :=
   chainDist_mono c c f hf p q
 
+-- ============================================================
+-- Part V: The universal property — chainDist is the pseudometric coreflection
+-- ============================================================
+
+/-- **Lower bound by the atomic cost.** The chain pseudometric never exceeds the
+atomic cost itself: the single-edge chain `p ⇝ q` (empty intermediate list) is
+already admissible. -/
+theorem chainDist_le_atomic (c : X → X → ℝ≥0∞) (p q : X) :
+    chainDist c p q ≤ c p q := by
+  simpa using chainDist_le c p q []
+
+/-- If a candidate cost `d` is dominated edge-wise by the atomic cost `c` and
+satisfies the triangle inequality, then `d p q` bounds the total cost of *every*
+chain from `p` to `q`. Telescoping a chain by repeated triangle steps, each edge
+bounded below `c`, recovers `d p q` as a lower bound. -/
+theorem le_chainCost_of_triangle (c d : X → X → ℝ≥0∞)
+    (hdc : ∀ a b, d a b ≤ c a b)
+    (htri : ∀ a b r, d a r ≤ d a b + d b r) (q : X) (mid : List X) :
+    ∀ p, d p q ≤ chainCost c p mid q := by
+  induction mid with
+  | nil => intro p; simpa using hdc p q
+  | cons x xs ih =>
+      intro p
+      calc d p q ≤ d p x + d x q := htri p x q
+        _ ≤ c p x + chainCost c x xs q := add_le_add (hdc p x) (ih x)
+        _ = chainCost c p (x :: xs) q := (chainCost_cons c p x q xs).symm
+
+/-- **Universal property.** `chainDist c` is the *greatest* pseudometric dominated
+by the atomic cost `c`: any `d` that lies edge-wise below `c` and obeys the
+triangle inequality also lies below `chainDist c`. Together with
+`chainPseudoEMetricSpace` (which makes `chainDist c` itself such a pseudometric)
+and `chainDist_le_atomic` (`chainDist c ≤ c`), this characterises the chain
+construction as the **pseudometric coreflection** of the atomic cost — the
+canonical largest pseudometric refining `c`. It is the order-theoretic reason the
+Kobayashi chain metric is the *right* definition: it is forced, not chosen. -/
+theorem le_chainDist_of_triangle (c d : X → X → ℝ≥0∞)
+    (hdc : ∀ a b, d a b ≤ c a b)
+    (htri : ∀ a b r, d a r ≤ d a b + d b r) (p q : X) :
+    d p q ≤ chainDist c p q :=
+  le_iInf fun mid => le_chainCost_of_triangle c d hdc htri q mid p
+
+/-- **Idempotence.** If the atomic cost already satisfies the triangle inequality
+(i.e. it is itself a pseudometric cost), the chain construction recovers it
+exactly: `chainDist c = c`. The chaining adds nothing once subadditivity already
+holds. -/
+theorem chainDist_eq_of_triangle (c : X → X → ℝ≥0∞)
+    (htri : ∀ a b r, c a r ≤ c a b + c b r) (p q : X) :
+    chainDist c p q = c p q :=
+  le_antisymm (chainDist_le_atomic c p q)
+    (le_chainDist_of_triangle c c (fun _ _ => le_rfl) htri p q)
+
+/-- **`chainDist` is idempotent.** Applying the chain construction to an
+already-chained cost changes nothing: `chainDist (chainDist c) = chainDist c`.
+This is the closure-operator face of the coreflection — a direct corollary of
+idempotence (the inner `chainDist c` is a pseudometric, hence subadditive). -/
+theorem chainDist_idem (c : X → X → ℝ≥0∞) (p q : X) :
+    chainDist (chainDist c) p q = chainDist c p q :=
+  chainDist_eq_of_triangle (chainDist c) (chainDist_triangle c) p q
+
 end Hilbert22OQ01OQ03

--- a/research/problems/hilbert-22-oq-01-oq-03/knowledge.md
+++ b/research/problems/hilbert-22-oq-01-oq-03/knowledge.md
@@ -71,3 +71,42 @@ Build environment was under sustained concurrent-agent cache churn (≈3000 olea
 - Item 2 (`d_ℂ ≡ 0`): tractable once a concrete disk atomic cost exists; not yet built.
 - Item 3 (two-point Schwarz–Pick via Blaschke conjugation): the natural next deliverable — supplies the concrete cost to instantiate `chainPseudoEMetricSpace`.
 - Item 4 (Picard, `d_𝔻 = ρ`): still BLOCKED on the modular λ universal cover (absent from Mathlib).
+
+---
+
+## Session 2026-06-25 (Session 3) — BUILT the universal property (verified)
+
+**Mode**: continuation · **Outcome**: coreflection layer delivered, machine-verified.
+
+### What I did
+- Extended `Proofs/Hilbert22OQ01OQ03.lean` (204 → 263 lines, 11 → 16 theorems, still
+  0 sorry / 0 axiom) with **Part V: the universal property** — `chainDist c` is the
+  *greatest pseudometric dominated by* the atomic cost `c` (its pseudometric
+  coreflection).
+- Verified: `lake env lean Proofs/Hilbert22OQ01OQ03.lean` → EXIT 0; `#print axioms`
+  on all four new theorems → only `propext, Classical.choice, Quot.sound`.
+- Updated the gallery entry (meta.json sections/counts/contributions, annotations.json).
+
+### Key insight (why this, not Schwarz–Pick, this session)
+- Items 2/3 (`d_ℂ ≡ 0`, Schwarz–Pick) both require the **concrete disk Poincaré /
+  pseudohyperbolic cost** and Blaschke automorphism machinery, absent from Mathlib
+  4.26 and genuine multi-hundred-line complex-analysis builds — high risk under the
+  still-degraded build env (Docker down; `lake env lean` only, ~8 concurrent compilers).
+- The universal property is **pure ℝ≥0∞ order theory + one list induction**, fully
+  in-scope and low-risk, and answers a deeper question: *why* the infimum-over-chains
+  definition is canonical. It is forced — `chainDist c` is the unique largest
+  pseudometric below `c`.
+
+### Proof technique (all short, robust)
+- `chainDist_le_atomic`: `simpa using chainDist_le c p q []` (empty/single-edge chain).
+- `le_chainCost_of_triangle` (the engine): induction on `mid`; cons step is a 3-line
+  `calc d p q ≤ d p x + d x q ≤ c p x + chainCost c x xs q = chainCost c p (x::xs) q`
+  via `htri`, `add_le_add (hdc p x) (ih x)`, `(chainCost_cons …).symm`.
+- `le_chainDist_of_triangle`: `le_iInf` over the engine.
+- `chainDist_eq_of_triangle`: `le_antisymm chainDist_le_atomic (le_chainDist_of_triangle … (fun _ _ => le_rfl) …)`.
+- `chainDist_idem`: instantiate `chainDist_eq_of_triangle` at `chainDist c`, whose
+  triangle inequality is `chainDist_triangle`.
+
+### Status update
+- Universal property / coreflection (new): **DONE, verified.**
+- Items 2/3/4: unchanged — still gated on the disk Poincaré metric / modular cover.

--- a/research/problems/hilbert-22-oq-01-oq-03/state.md
+++ b/research/problems/hilbert-22-oq-01-oq-03/state.md
@@ -4,12 +4,20 @@
 **Phase**: DELIVERED (partial)
 **Path**: full
 **Since**: 2026-06-25T08:41:59-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Item 1 of the Session-1 decomposition is DONE and machine-verified: the abstract
-Kobayashi chain pseudometric skeleton (`Proofs/Hilbert22OQ01OQ03.lean`, 204 lines,
-0 sorries, 0 axioms, only foundational propext/Classical.choice/Quot.sound).
+Item 1 + the universal-property layer are DONE and machine-verified: the abstract
+Kobayashi chain pseudometric skeleton (`Proofs/Hilbert22OQ01OQ03.lean`, now 263
+lines, 16 theorems, 0 sorries, 0 axioms, only foundational
+propext/Classical.choice/Quot.sound).
+
+Session-3 addition (verified, EXIT 0 + `#print axioms` clean): `chainDist c` is the
+**pseudometric coreflection** of the atomic cost `c` — `chainDist_le_atomic`
+(`chainDist c ≤ c`), `le_chainDist_of_triangle` (greatest pseudometric ≤ c via
+telescoping), `chainDist_eq_of_triangle` (idempotent recovery of subadditive
+costs), `chainDist_idem`. This is the order-theoretic proof that the
+infimum-over-chains definition is canonical/forced, not chosen.
 
 ## Active Approach
 Abstract the one-disk Poincaré distance to a symmetric atomic cost
@@ -19,8 +27,8 @@ prove the pseudometric axioms (reflexivity/symmetry/triangle) and functoriality
 infimum arithmetic. Verified via `lake env lean` (EXIT 0) and `#print axioms`.
 
 ## Attempt Count
-- Total attempts: 1
-- Current approach attempts: 1 (succeeded)
+- Total attempts: 2
+- Current approach attempts: 2 (both succeeded)
 - Approaches tried: 1
 
 ## Blockers

--- a/src/data/proofs/hilbert-22-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/hilbert-22-oq-01-oq-03/annotations.json
@@ -94,7 +94,7 @@
     "proofId": "hilbert-22-oq-01-oq-03",
     "range": {
       "startLine": 181,
-      "endLine": 204
+      "endLine": 203
     },
     "type": "theorem",
     "title": "Functoriality: The Defining Holomorphic Invariance",
@@ -111,5 +111,17 @@
       "monotonicity of infima",
       "the chainCost_map contraction lemma"
     ]
+  },
+  {
+    "id": "ann-universal-property",
+    "proofId": "hilbert-22-oq-01-oq-03",
+    "range": {
+      "startLine": 205,
+      "endLine": 263
+    },
+    "type": "theorem",
+    "title": "The Universal Property: Pseudometric Coreflection",
+    "content": "This section shows the infimum-over-chains definition is not arbitrary but forced. `chainDist_le_atomic` records the upper bound `chainDist c p q ≤ c p q` (the single-edge chain with empty intermediate list is always admissible). `le_chainCost_of_triangle` then telescopes: if a candidate cost `d` lies edge-wise below `c` (`d a b ≤ c a b`) and satisfies the triangle inequality, then `d p q` bounds the cost of every chain `p, mid…, q` — each triangle step is absorbed and each edge is bounded under `c`. Taking the infimum gives the universal property `le_chainDist_of_triangle`: `d p q ≤ chainDist c p q`. Since `chainDist c` is itself a pseudometric (`chainPseudoEMetricSpace`) lying below `c`, it is the GREATEST such pseudometric — the pseudometric coreflection of `c`. The corollaries `chainDist_eq_of_triangle` (chaining recovers any already-subadditive cost exactly, `chainDist c = c`) and `chainDist_idem` (`chainDist (chainDist c) = chainDist c`) exhibit `chainDist` as an idempotent closure operator.",
+    "mathContext": "$\\texttt{chainDist}\\;c$ is sandwiched: $\\texttt{chainDist}\\;c\\le c$ (empty chain), and any pseudometric $d\\le c$ satisfies $d\\le\\texttt{chainDist}\\;c$ (telescoping). Hence $\\texttt{chainDist}\\;c=\\max\\{d\\ \\text{pseudometric}: d\\le c\\}$, the coreflection. As a closure operator it is idempotent and fixes every already-subadditive cost. This is the abstract reason the Kobayashi metric's infimum-over-chains formula is canonical."
   }
 ]

--- a/src/data/proofs/hilbert-22-oq-01-oq-03/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 204,
+    "lineCount": 263,
     "assumptions": "0 axioms, 0 sorries. Depends only on Mathlib's foundational axioms (propext, Classical.choice, Quot.sound) — confirmed via #print axioms; no sorryAx, no Lean.ofReduceBool, no native_decide. The atomic-cost symmetry and diagonal-vanishing hypotheses are explicit arguments to the theorems, not structure-encoded assumptions.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
@@ -29,9 +29,13 @@
       "chainCost_reverse: chain reversal preserves cost for symmetric atomic costs — the combinatorial heart of symmetry",
       "chainDist: the abstract Kobayashi chain pseudometric d(p,q) = ⨅ over finite chains of total cost, valued in ℝ≥0∞ (junk-free infima)",
       "chainPseudoEMetricSpace: packages d into a genuine Mathlib PseudoEMetricSpace from a symmetric, diagonal-vanishing atomic cost",
-      "chainDist_mono: functoriality — a cost-contracting map is distance-non-increasing, the order-theoretic shadow of 'holomorphic maps are non-expanding for the Kobayashi metric'"
+      "chainDist_mono: functoriality — a cost-contracting map is distance-non-increasing, the order-theoretic shadow of 'holomorphic maps are non-expanding for the Kobayashi metric'",
+      "chainDist_le_atomic: the chain pseudometric never exceeds the atomic cost (the single-edge chain is admissible) — chainDist c ≤ c",
+      "le_chainDist_of_triangle: the universal property — chainDist c is the GREATEST pseudometric dominated by c; any candidate cost that is edge-wise below c and obeys the triangle inequality lies below chainDist c, characterising the chain construction as the pseudometric coreflection of c",
+      "chainDist_eq_of_triangle: idempotence — if the atomic cost is already subadditive (a pseudometric cost), the chain construction recovers it exactly, chainDist c = c",
+      "chainDist_idem: chainDist (chainDist c) = chainDist c — the closure-operator face of the coreflection"
     ],
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "overview": {
@@ -44,7 +48,8 @@
       "The triangle inequality is exactly chain concatenation; symmetry is exactly chain reversal; reflexivity is exactly the empty chain. The geometry is faithfully reflected in list operations.",
       "Valuing the infimum in ℝ≥0∞ is essential: the complete-lattice structure gives junk-free infima (an empty chain-set yields ⊤, never a spurious 0) and the dedicated lemmas ENNReal.iInf_add / ENNReal.add_iInf push the two infima of d(p,q)+d(q,r) together cleanly.",
       "Functoriality — the property that makes the Kobayashi metric a holomorphic invariant — is captured abstractly by chainDist_mono: any map contracting the atomic cost is distance-non-increasing. Holomorphic maps contract the disk Poincaré metric (Schwarz–Pick), so this is the exact place the analysis would plug in.",
-      "The construction is honest about its boundary: it assumes nothing about the disk Poincaré metric, Schwarz–Pick, d_𝔻 = ρ, or Picard's theorem — all of which require infrastructure absent from Mathlib 4.26 — and verifies only what follows from the abstract atomic cost."
+      "The construction is honest about its boundary: it assumes nothing about the disk Poincaré metric, Schwarz–Pick, d_𝔻 = ρ, or Picard's theorem — all of which require infrastructure absent from Mathlib 4.26 — and verifies only what follows from the abstract atomic cost.",
+      "The chain construction is not an arbitrary choice but is forced: chainDist c is the GREATEST pseudometric dominated by the atomic cost c (its pseudometric coreflection). chainDist c ≤ c always (the single-edge chain), and any pseudometric below c is below chainDist c (telescoping by the triangle inequality). This universal property is the order-theoretic reason the infimum-over-chains definition is canonical — and it makes chainDist an idempotent closure operator that fixes any cost already subadditive."
     ]
   },
   "sections": [
@@ -84,13 +89,21 @@
       "id": "functoriality",
       "title": "Functoriality — The Defining Invariance",
       "startLine": 181,
-      "endLine": 204,
+      "endLine": 203,
       "summary": "Proves chainDist_mono: a map f with cY (f a) (f b) ≤ cX a b is distance-non-increasing, d_Y(f p, f q) ≤ d_X(p, q), with chainDist_mono_self the endomorphism case. This is the order-theoretic shadow of the holomorphic non-expansion theorem that makes the Kobayashi metric an invariant.",
       "mathContext": "If $f:X\\to Y$ contracts the atomic cost ($c_Y(f a,f b)\\le c_X(a,b)$), then pushing any chain forward by $f$ contracts its cost (\\texttt{chainCost\\_map}), so $d_Y(f p, f q)\\le d_X(p,q)$. Holomorphic maps contract the disk Poincaré metric by Schwarz-Pick, so this abstract lemma is exactly where the analytic input would enter to recover the classical Kobayashi non-expansion."
+    },
+    {
+      "id": "universal-property",
+      "title": "The Universal Property — Pseudometric Coreflection",
+      "startLine": 205,
+      "endLine": 263,
+      "summary": "Proves chainDist_le_atomic (chainDist c ≤ c, the single-edge chain), then the universal property le_chainDist_of_triangle: any candidate cost d that is edge-wise below c and satisfies the triangle inequality lies below chainDist c. Hence chainDist c is the greatest pseudometric dominated by c — its pseudometric coreflection. Corollaries: chainDist_eq_of_triangle (idempotence: chainDist c = c when c is already subadditive) and chainDist_idem (chainDist (chainDist c) = chainDist c).",
+      "mathContext": "Two bounds pin chainDist down. Above: $d(p,q)\\le c\\,p\\,q$ since the empty chain is admissible. Below: for any $d$ with $d\\le c$ edge-wise and $d(p,r)\\le d(p,q)+d(q,r)$, telescoping a chain $p,\\,\\mathit{mid}\\ldots,\\,q$ by repeated triangle steps with each edge bounded under $c$ gives $d(p,q)\\le\\texttt{chainCost}\\;c\\;p\\;\\mathit{mid}\\;q$, so $d(p,q)\\le d(p,q)$ taking the infimum yields $d\\le\\texttt{chainDist}\\;c$. Since chainDist c is itself such a pseudometric, it is the GREATEST one $\\le c$: the pseudometric coreflection. In particular chainDist is an idempotent closure operator, and it fixes any cost that is already subadditive."
     }
   ],
   "conclusion": {
-    "summary": "This entry constructs the abstract Kobayashi chain pseudometric d(p,q) = ⨅ over finite chains of total atomic cost, valued in ℝ≥0∞, and fully machine-verifies its defining structural properties: it is a genuine PseudoEMetricSpace (reflexivity, symmetry, triangle inequality) and it is functorial — distance-non-increasing under any map contracting the atomic cost. These are exactly properties (1)–(2) of the Kobayashi pseudometric that the parent hilbert-22-oq-01 entry described only informally. The proof is entirely order-theoretic and combinatorial, depends only on Mathlib's foundational axioms (no sorries, no extra axioms, no native_decide), and isolates precisely where complex analysis would enter.",
+    "summary": "This entry constructs the abstract Kobayashi chain pseudometric d(p,q) = ⨅ over finite chains of total atomic cost, valued in ℝ≥0∞, and fully machine-verifies its defining structural properties: it is a genuine PseudoEMetricSpace (reflexivity, symmetry, triangle inequality), it is functorial — distance-non-increasing under any map contracting the atomic cost — and it satisfies a universal property: it is the GREATEST pseudometric dominated by the atomic cost (its pseudometric coreflection), hence an idempotent closure operator that recovers any already-subadditive cost exactly. These cover and extend properties (1)–(2) of the Kobayashi pseudometric that the parent hilbert-22-oq-01 entry described only informally. The proof is entirely order-theoretic and combinatorial, depends only on Mathlib's foundational axioms (no sorries, no extra axioms, no native_decide), and isolates precisely where complex analysis would enter.",
     "implications": "The skeleton is reusable: instantiating the atomic cost c with the unit-disk Poincaré/pseudohyperbolic distance would yield the genuine Kobayashi pseudometric, and chainDist_mono would then specialise — via Schwarz–Pick — to the classical theorem that holomorphic maps are non-expanding, the source of the metric's holomorphic invariance. The functoriality lemma marks the exact interface for that analytic input. Building chainDist over ℝ≥0∞ also makes it immediately compatible with Mathlib's PseudoEMetricSpace API.",
     "openQuestions": [
       "Formalize the unit-disk Poincaré / pseudohyperbolic metric and the two-point Schwarz–Pick contraction in Mathlib, then instantiate chainPseudoEMetricSpace to obtain the genuine Kobayashi pseudometric d_𝔻 and prove d_𝔻 = ρ.",
@@ -115,9 +128,9 @@
       "Mathlib"
     ],
     "namespace": "Hilbert22OQ01OQ03",
-    "lineCount": 204,
+    "lineCount": 263,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/Hilbert22OQ01OQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Extends the verified abstract **Kobayashi chain pseudometric** entry
(`hilbert-22-oq-01-oq-03`, shipped in #30088) with a new **Part V: the universal
property** — the order-theoretic result explaining *why* the infimum-over-chains
definition of the Kobayashi metric is canonical rather than arbitrary.

**Main result:** `chainDist c` is the **greatest pseudometric dominated by** the
atomic cost `c` — its *pseudometric coreflection*. It is forced, not chosen.

## New theorems (all 0-sorry, 0-axiom)

| Theorem | Statement |
|---|---|
| `chainDist_le_atomic` | `chainDist c p q ≤ c p q` (the single-edge chain is admissible) |
| `le_chainCost_of_triangle` | telescoping engine: a sub-cost obeying the triangle inequality bounds every chain |
| `le_chainDist_of_triangle` | **universal property** — any pseudometric `≤ c` lies below `chainDist c` |
| `chainDist_eq_of_triangle` | **idempotence** — `chainDist c = c` when `c` is already subadditive |
| `chainDist_idem` | `chainDist (chainDist c) = chainDist c` (closure operator) |

Together with the existing `chainPseudoEMetricSpace` (chainDist *is* a pseudometric)
and `chainDist_le_atomic` (chainDist `≤ c`), `le_chainDist_of_triangle` pins
`chainDist c` down as the unique largest pseudometric below `c`.

## Verification

- `lake env lean Proofs/Hilbert22OQ01OQ03.lean` → **EXIT 0** (Mathlib 4.26 oleans; Docker down, single-file route).
- `#print axioms` on all four new theorems → only `propext, Classical.choice, Quot.sound`. No `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Genuinely **verified / 0-axiom**.
- File: 204 → 263 lines, 11 → 16 theorems, 3 defs. Gallery `meta.json` / `annotations.json` updated (new section, counts, contributions, key insight).

## Scope / honesty

The genuinely analytic next steps — the concrete unit-disk Poincaré/pseudohyperbolic
cost, two-point Schwarz–Pick via Blaschke conjugation, `d_𝔻 = ρ`, and Picard via the
modular λ universal cover — remain **open and unassumed** (infrastructure absent from
Mathlib 4.26). This PR adds only what follows from the abstract atomic cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)