### PR TITLE
research(cantor-diagonalization-oq-07-oq-01): #(ℝⁿ)=#ℝ for n≥1 and #(ℕ→ℝ)=𝔠 [verified, 0-axiom]

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-07-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-07-oq-01.json
@@ -1,0 +1,31 @@
+{
+  "id": "cantor-diagonalization-oq-07-oq-01",
+  "name": "Cardinal Arithmetic of ℝⁿ and ℕ→ℝ: #(ℝⁿ) = #ℝ and #(ℕ → ℝ) = 𝔠",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "insights": [
+      "Modelling ℝⁿ as (Fin n → ℝ) turns the geometric 'dimension does not raise cardinality' into a single cardinal-power computation: #(Fin n → ℝ) = #ℝ ^ #(Fin n) = 𝔠 ^ n via Cardinal.mk_arrow + mk_fin.",
+      "The finite and countable cases use two distinct but parallel absorption lemmas, both descending from κ·κ=κ: Cardinal.power_nat_eq (ℵ₀ ≤ c, 1 ≤ n ⊢ c^n = c) for 𝔠^n = 𝔠, and Cardinal.continuum_power_aleph0 (𝔠 ^ ℵ₀ = 𝔠) for the sequence space.",
+      "Cardinal.mk_arrow returns lift #β ^ lift #α; in a single universe the two lifts must be cleared with lift_id (twice) before mk_real / mk_fin / mk_nat apply.",
+      "The cardinal exponent ↑n (Nat cast into Cardinal) must be bridged to the monoid power n via Cardinal.power_natCast before power_nat_eq fires.",
+      "n ≥ 1 is sharp: #(Fin 0 → ℝ) = 1 (the empty tuple), so the absorption law genuinely needs a positive exponent."
+    ],
+    "builtItems": [
+      "CantorDiagonalizationOQ07OQ01.continuum_pow_eq (Proofs/CantorDiagonalizationOQ07OQ01.lean:39) — 𝔠^n = 𝔠 for n ≥ 1",
+      "CantorDiagonalizationOQ07OQ01.mk_pi_real_eq_continuum (:45) — #(Fin n → ℝ) = 𝔠",
+      "CantorDiagonalizationOQ07OQ01.mk_pi_real (:52) — #(Fin n → ℝ) = #ℝ, main finite result",
+      "CantorDiagonalizationOQ07OQ01.nonempty_equiv_pi_real (:57) — bijection (Fin n → ℝ) ≃ ℝ",
+      "CantorDiagonalizationOQ07OQ01.mk_nat_arrow_real_eq_continuum (:64) — #(ℕ → ℝ) = 𝔠",
+      "CantorDiagonalizationOQ07OQ01.mk_nat_arrow_real (:69) — #(ℕ → ℝ) = #ℝ, main countable result",
+      "CantorDiagonalizationOQ07OQ01.nonempty_equiv_nat_arrow_real (:75) — bijection (ℕ → ℝ) ≃ ℝ",
+      "CantorDiagonalizationOQ07OQ01.mk_pi_two_real (:80) — #(Fin 2 → ℝ) = #ℝ, recovers the parent"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Formalize the uncountable power #(ℝ → ℝ) = 2^𝔠 — the first place dimension does raise cardinality, separating the 𝔠-sized spaces here from the function space on ℝ.",
+      "Exhibit a concrete digit-interleaving bijection (Fin n → ℝ) ≃ ℝ instead of routing through cardinal arithmetic."
+    ],
+    "progressSummary": "COMPLETE: #(Fin n → ℝ) = #ℝ for n ≥ 1 and #(ℕ → ℝ) = 𝔠 formalized verified, 0 sorries / 0 axioms (only propext/Classical.choice/Quot.sound). All cardinal-arithmetic levers present in Mathlib. PR opened."
+  }
+}


### PR DESCRIPTION
## Summary

Extends the parent **cantor-diagonalization-oq-07** (`#(ℝ × ℝ) = #ℝ`, i.e. `𝔠 · 𝔠 = 𝔠`) — this open question is listed verbatim as the parent's first `openQuestion` — to **all finite and countable dimensions**:

- `mk_pi_real`: `#(Fin n → ℝ) = #ℝ` for every `n ≥ 1` (Euclidean n-space is equinumerous with the line)
- `mk_nat_arrow_real`: `#(ℕ → ℝ) = #ℝ` and `mk_nat_arrow_real_eq_continuum`: `#(ℕ → ℝ) = 𝔠` (the space of real sequences still has cardinality the continuum)

Both follow from the infinite-cardinal absorption law `κ · κ = κ`, in two parallel regimes:

| Regime | Lever | Result |
|--------|-------|--------|
| Finite power | `Cardinal.power_nat_eq` (`ℵ₀ ≤ c, 1 ≤ n ⊢ c^n = c`) | `𝔠^n = 𝔠` → `#(ℝⁿ) = #ℝ` |
| Countable power | `Cardinal.continuum_power_aleph0` (`𝔠^ℵ₀ = 𝔠`) | `#(ℕ → ℝ) = 𝔠` |

Modelling `ℝⁿ` as `Fin n → ℝ` turns "dimension" into the cardinal exponent `#(Fin n) = n` via `Cardinal.mk_arrow`, so the whole geometric question becomes one cardinal-power computation. Each equality unpacks via `Cardinal.eq` to an explicit bijection, and `mk_pi_two_real` recovers the parent's `#(ℝ × ℝ) = #ℝ` as the `n = 2` case.

The boundary `n ≥ 1` is sharp: `#(Fin 0 → ℝ) = 1`.

## Verification

- **8 theorems, 0 definitions, 0 sorries, 0 axioms** (only the foundational `propext` / `Classical.choice` / `Quot.sound`, as for any Mathlib cardinal result)
- Verified offline with `lake env lean` (EXIT 0); `#print axioms` confirms no `sorryAx`/`ofReduceBool`
- Mathlib v4.26.0; new file `Proofs/CantorDiagonalizationOQ07OQ01.lean` (84 lines), imports only Mathlib

## Files

- `proofs/Proofs/CantorDiagonalizationOQ07OQ01.lean` (new)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/cantor-diagonalization-oq-07-oq-01/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/cantor-diagonalization-oq-07-oq-01.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)