### PR TITLE
Enrich The Algebraic Core of [ℚ(cos 2π/n):ℚ] = φ(n)/2 (Angle Trisection OQ-02)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02/annotations.json
@@ -1,5 +1,35 @@
 [
   {
+    "id": "ann-scope",
+    "proofId": "angle-trisection-cos-20-gal-oq-02",
+    "range": {
+      "startLine": 6,
+      "endLine": 37
+    },
+    "type": "context",
+    "title": "Honest Scope: Algebraic Core, Not the Field Degree",
+    "content": "This entry deliberately proves the algebraic ingredients of [ℚ(cos 2π/n):ℚ] = φ(n)/2 — the index-2 quadratic and the Chebyshev root — over ℂ and ℝ, where they are elementary and 0-axiom. It does NOT prove the field-degree equality itself: that needs [ℚ(ζ_n):ℚ(cos 2π/n)] = 2 (complex conjugation as the order-2 automorphism with the real subfield as fixed field) and, for a uniform classification, Kronecker–Weber — neither of which is in Mathlib 4.26. Isolating the provable core both advances the OQ and makes the precise remaining gap explicit.",
+    "mathContext": "Target: $[\\mathbb{Q}(\\cos 2\\pi/n):\\mathbb{Q}] = \\varphi(n)/2$. Provable now: the $\\le 2$ index relation and the Chebyshev witness; blocked: the field-degree equality (needs the maximal-real-subfield degree + Kronecker–Weber).",
+    "significance": "context",
+    "relatedConcepts": ["maximal real subfield ℚ(ζ_n)⁺", "Kronecker–Weber theorem", "scope of a formalization", "Mathlib coverage gaps"],
+    "prerequisites": ["cyclotomic fields", "Galois theory of abelian extensions"]
+  },
+  {
+    "id": "ann-two-cos-bridge",
+    "proofId": "angle-trisection-cos-20-gal-oq-02",
+    "range": {
+      "startLine": 43,
+      "endLine": 48
+    },
+    "type": "technique",
+    "title": "The Bridge: 2cos x = e^{ix} + e^{−ix}",
+    "content": "two_cos_eq_exp_add_inv restates Mathlib's Complex.two_cos: the cosine is the average of the two conjugate exponentials. This is the small but essential bridge that turns a trigonometric quantity (cos x) into an algebraic relation among roots of unity (ζ = e^{ix} and ζ⁻¹ = e^{-ix}), which is what lets the rest of the file talk about field degrees rather than analysis.",
+    "mathContext": "$2\\cos x = e^{ix} + e^{-ix}$; with $\\zeta = e^{ix}$ this reads $2\\cos x = \\zeta + \\zeta^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler's formula", "Complex.two_cos", "roots of unity", "ζ + ζ⁻¹"],
+    "prerequisites": ["complex exponential", "trigonometric identities over ℂ"]
+  },
+  {
     "id": "ann-index-two",
     "proofId": "angle-trisection-cos-20-gal-oq-02",
     "range": {
@@ -8,18 +38,26 @@
     },
     "type": "insight",
     "title": "Where the ÷2 in φ(n)/2 Comes From",
-    "content": "zeta_quadratic is the heart of the matter. Writing ζ = e^{ix}, the identity 2cos x = ζ + ζ⁻¹ (Complex.two_cos) rearranges to ζ² − (2cos x)·ζ + 1 = 0 once you use ζ·ζ⁻¹ = e^{ix}·e^{-ix} = e^0 = 1. So ζ is a root of the real quadratic X² − (2cos x)X + 1 ∈ ℝ(cos x)[X]: the cyclotomic field ℚ(ζ_n) is at most a degree-2 extension of the real subfield ℚ(cos 2π/n). Against the cyclotomic degree [ℚ(ζ_n):ℚ] = φ(n) (already in Mathlib), this degree-2 step is exactly the source of the halving to φ(n)/2. The whole proof is a single linear_combination once ζ·ζ⁻¹ = 1 is in hand."
+    "content": "zeta_quadratic is the heart of the matter. Writing ζ = e^{ix}, the identity 2cos x = ζ + ζ⁻¹ (Complex.two_cos) rearranges to ζ² − (2cos x)·ζ + 1 = 0 once you use ζ·ζ⁻¹ = e^{ix}·e^{-ix} = e^0 = 1. So ζ is a root of the real quadratic X² − (2cos x)X + 1 ∈ ℝ(cos x)[X]: the cyclotomic field ℚ(ζ_n) is at most a degree-2 extension of the real subfield ℚ(cos 2π/n). Against the cyclotomic degree [ℚ(ζ_n):ℚ] = φ(n) (already in Mathlib), this degree-2 step is exactly the source of the halving to φ(n)/2. The whole proof is a single linear_combination once ζ·ζ⁻¹ = 1 is in hand. zeta_quadratic_real rephrases it over a real angle via Complex.ofReal_cos.",
+    "mathContext": "$\\zeta^2 - (2\\cos x)\\,\\zeta + 1 = 0$, so $\\zeta$ is a root of $X^2 - (2\\cos x)X + 1 \\in \\mathbb{R}(\\cos x)[X]$ and $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}(\\cos 2\\pi/n)] \\le 2$. With $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ this gives the $\\varphi(n)/2$.",
+    "significance": "key",
+    "relatedConcepts": ["index-2 subfield", "ζ + ζ⁻¹ generates the real subfield", "cyclotomic degree φ(n)", "linear_combination tactic"],
+    "prerequisites": ["the 2cos bridge above", "tower law for field extensions", "cyclotomic degree"]
   },
   {
     "id": "ann-chebyshev",
     "proofId": "angle-trisection-cos-20-gal-oq-02",
     "range": {
-      "startLine": 75,
+      "startLine": 69,
       "endLine": 83
     },
     "type": "concept",
     "title": "An Explicit Polynomial Vanishing at cos 2π/n",
-    "content": "cos_two_pi_div_chebyshev_root exhibits cos 2π/n as a concrete algebraic number: by Polynomial.Chebyshev.T_real_cos, Tₙ(cos θ) = cos(nθ), and at θ = 2π/n the multiple angle n·(2π/n) = 2π gives cos(2π) = 1. Hence Tₙ(cos 2π/n) = 1, i.e. cos 2π/n is a root of the integer polynomial Tₙ − 1 (degree n). The minimal polynomial of cos 2π/n — degree φ(n)/2 — is the relevant irreducible factor of Tₙ − 1, the bridge between the trigonometric value and the field degree the OQ asks about."
+    "content": "cos_two_pi_div_chebyshev_root exhibits cos 2π/n as a concrete algebraic number: by Polynomial.Chebyshev.T_real_cos (cos_chebyshev_eval), Tₙ(cos θ) = cos(nθ), and at θ = 2π/n the multiple angle n·(2π/n) = 2π gives cos(2π) = 1. Hence Tₙ(cos 2π/n) = 1, i.e. cos 2π/n is a root of the integer polynomial Tₙ − 1 (degree n). The minimal polynomial of cos 2π/n — degree φ(n)/2 — is the relevant irreducible factor of Tₙ − 1, the bridge between the trigonometric value and the field degree the OQ asks about.",
+    "mathContext": "$T_n(\\cos 2\\pi/n) = \\cos(2\\pi) = 1$, so $\\cos 2\\pi/n$ is a root of $T_n - 1 \\in \\mathbb{Z}[X]$; its degree-$\\varphi(n)/2$ irreducible factor is the minimal polynomial.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials of the first kind", "T_n(cos θ) = cos(nθ)", "minimal polynomial", "algebraic numbers"],
+    "prerequisites": ["Chebyshev polynomials", "polynomial evaluation", "cos(2π) = 1"]
   },
   {
     "id": "ann-consistency",
@@ -30,17 +68,10 @@
     },
     "type": "concept",
     "title": "φ(n)/2 Reproduces the Gallery's Computed Degrees",
-    "content": "The totient checks tie the general formula to the gallery's concrete results: φ(7)/2 = 3 and φ(9)/2 = 3 are the cubic minimal polynomials of cos 2π/7 and cos 40° (= cos 2π/9), exactly the degree-3 Galois groups the parent and sibling entries computed; φ(5)/2 = 2 is the quadratic of cos 36° (constructible pentagon); φ(15)/2 = 4 a non-prime quartic. The cubic for p = 7 (and the analogous one behind cos 40°) is what makes 120° = 3·40° impossible to trisect. totient_div_two_odd_prime records the prime pattern φ(p)/2 = (p−1)/2."
-  },
-  {
-    "id": "ann-scope",
-    "proofId": "angle-trisection-cos-20-gal-oq-02",
-    "range": {
-      "startLine": 6,
-      "endLine": 37
-    },
-    "type": "concept",
-    "title": "Honest Scope: Algebraic Core, Not the Field Degree",
-    "content": "This entry deliberately proves the algebraic ingredients of [ℚ(cos 2π/n):ℚ] = φ(n)/2 — the index-2 quadratic and the Chebyshev root — over ℂ and ℝ, where they are elementary and 0-axiom. It does NOT prove the field-degree equality itself: that needs [ℚ(ζ_n):ℚ(cos 2π/n)] = 2 (complex conjugation as the order-2 automorphism with the real subfield as fixed field) and, for a uniform classification, Kronecker–Weber — neither of which is in Mathlib 4.26. Isolating the provable core both advances the OQ and makes the precise remaining gap explicit."
+    "content": "The totient checks tie the general formula to the gallery's concrete results: φ(7)/2 = 3 and φ(9)/2 = 3 are the cubic minimal polynomials of cos 2π/7 and cos 40° (= cos 2π/9), exactly the degree-3 Galois groups the parent and sibling entries computed; φ(5)/2 = 2 is the quadratic of cos 36° (constructible pentagon); φ(15)/2 = 4 a non-prime quartic. The cubic for p = 7 (and the analogous one behind cos 40°) is what makes 120° = 3·40° impossible to trisect. totient_div_two_odd_prime records the prime pattern φ(p)/2 = (p−1)/2. These small totients are closed by kernel `decide` (not native_decide, so 0-axiom).",
+    "mathContext": "$\\varphi(5)/2 = 2,\\ \\varphi(7)/2 = 3,\\ \\varphi(9)/2 = 3,\\ \\varphi(15)/2 = 4$; odd prime $p$: $\\varphi(p)/2 = (p-1)/2$. Degree not a power of $2$ ⟹ the angle is not trisectable.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler totient φ(n)", "constructibility (power-of-2 degree)", "angle trisection impossibility", "kernel decide vs native_decide"],
+    "prerequisites": ["Euler's totient", "Gauss–Wantzel constructibility criterion", "the parent's degree computations"]
   }
 ]

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02/index.ts
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionCos20GalOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const angleTrisectionCos20GalOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionCos20GalOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionCos20GalOq02Data: ProofData = {
+  proof: angleTrisectionCos20GalOq02Proof,
+  annotations: angleTrisectionCos20GalOq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-02`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- **Annotation coverage**: added an annotation for the `2cos = e^{ix}+e^{-ix}` bridge theorem — 4 → 5 annotations spanning scope, bridge, index-2 quadratic, Chebyshev root, and totient checks.

Axiom integrity unchanged: meta reports `verified`/`original`, 0 axioms (kernel `decide`, not native_decide), 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)