### PR TITLE
Enrich Bounded Prime Gaps: The Gap-Sieve Axiom Is Redundant (OQ-01-OQ-01)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "The Gap-Sieve Axioms Are Redundant",
     "content": "The BoundedPrimeGaps formalization encodes the Maynard-Tao machinery as three axioms: a density axiom (maynard_tao_m_tuples) and two gap-sieve axioms (maynard_tao_sieve for k >= 50, maynard_tao_sieve_eh for k >= 5 under Elliott-Halberstam). This file shows the two gap-sieve axioms are not independent: their conclusion - infinitely many consecutive prime gaps <= D - follows by a purely elementary argument from the density statement alone. No sieve weights, no Bombieri-Vinogradov, and not even admissibility are needed; the analytic content lives entirely in producing the density witness.",
-    "mathContext": "The eliminated axiom asserts: for an admissible tuple $H$ with $|H| \\geq 50$ and $\\forall h \\in H,\\ h \\leq D$, there are infinitely many indices $n$ with $p_{n+1} - p_n \\leq D$. We prove this conclusion from $\\mathrm{MaynardTaoDensity}\\ H\\ 2$, i.e. that infinitely many shifts $n$ have at least two primes among $\\{n + h : h \\in H\\}$."
+    "mathContext": "The eliminated axiom asserts: for an admissible tuple $H$ with $|H| \\geq 50$ and $\\forall h \\in H,\\ h \\leq D$, there are infinitely many indices $n$ with $p_{n+1} - p_n \\leq D$. We prove this conclusion from $\\mathrm{MaynardTaoDensity}\\ H\\ 2$, i.e. that infinitely many shifts $n$ have at least two primes among $\\{n + h : h \\in H\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["axiom elimination", "Maynard–Tao sieve", "Elliott–Halberstam conjecture", "logical redundancy of assumptions"],
+    "prerequisites": ["bounded prime gaps program", "sieve theory at a high level", "the parent's axiom encoding"]
   },
   {
     "id": "definitions-mirror",
@@ -15,7 +18,10 @@
     "type": "definition",
     "title": "Definitions mirrored from the parent file",
     "content": "IsAdmissible, nthPrime, primeGap, and MaynardTaoDensity are reproduced verbatim from Proofs.BoundedPrimeGaps. Keeping the file dependent only on Mathlib lets it verify without rebuilding the native_decide-heavy parent, while the verbatim definitions make the redundancy claim literal: the theorems below discharge the exact conclusion shape of the parent's axioms.",
-    "mathContext": "$\\mathrm{primeGap}(n) = p_{n+1} - p_n$ where $p_k = \\mathrm{nthPrime}(k) = $ Nat.nth Nat.Prime $k$. $\\mathrm{MaynardTaoDensity}\\ H\\ m := \\forall N,\\ \\exists n \\geq N,\\ m \\leq |\\{h \\in H : n + h \\text{ prime}\\}|$."
+    "mathContext": "$\\mathrm{primeGap}(n) = p_{n+1} - p_n$ where $p_k = \\mathrm{nthPrime}(k) = $ Nat.nth Nat.Prime $k$. $\\mathrm{MaynardTaoDensity}\\ H\\ m := \\forall N,\\ \\exists n \\geq N,\\ m \\leq |\\{h \\in H : n + h \\text{ prime}\\}|$.",
+    "significance": "technical",
+    "relatedConcepts": ["Nat.nth", "prime-counting function", "import-light formalization", "verbatim definitional correspondence"],
+    "prerequisites": ["Nat.nth / Nat.count", "Finset filtering", "the parent's definitions"]
   },
   {
     "id": "arithmetic-core",
@@ -24,7 +30,10 @@
     "type": "theorem",
     "title": "gap_from_two_primes: two nearby primes give a bounded consecutive gap",
     "content": "The workhorse. Given two primes p = n+x < q = n+y with y <= D, set k = pi(p) = count Nat.Prime p. The next prime nthPrime(k+1) is the least prime strictly above p; since q is itself a prime above p, monotonicity of Nat.nth forces nthPrime(k+1) <= q, so primeGap k = nthPrime(k+1) - p <= q - p = (y - x) <= D. The index satisfies k >= N because the shift n >= nthPrime N makes p >= nthPrime N, and count is monotone with count(nthPrime N) = N.",
-    "mathContext": "Two primes within distance $D$ bracket a consecutive prime gap $\\leq D$: if $p < q$ are prime and $q \\leq p + D$, the immediate successor prime $p'$ of $p$ satisfies $p' \\leq q \\leq p + D$, hence $p' - p \\leq D$. The index identity $\\pi(p_k) = k$ (Nat.nth_count / Nat.count_nth_of_infinite) and monotonicity of $\\pi$ and of $p_\\bullet$ translate this into the $\\mathrm{primeGap}$ index language."
+    "mathContext": "Two primes within distance $D$ bracket a consecutive prime gap $\\leq D$: if $p < q$ are prime and $q \\leq p + D$, the immediate successor prime $p'$ of $p$ satisfies $p' \\leq q \\leq p + D$, hence $p' - p \\leq D$. The index identity $\\pi(p_k) = k$ (Nat.nth_count / Nat.count_nth_of_infinite) and monotonicity of $\\pi$ and of $p_\\bullet$ translate this into the $\\mathrm{primeGap}$ index language.",
+    "significance": "key",
+    "relatedConcepts": ["consecutive prime gap", "successor prime", "monotonicity of Nat.nth", "prime-counting index π(p) = k"],
+    "prerequisites": ["Nat.nth / Nat.count inverse and monotonicity lemmas", "infinitude of primes"]
   },
   {
     "id": "main-reduction",
@@ -33,7 +42,10 @@
     "type": "theorem",
     "title": "density_two_implies_bounded_gaps: the eliminated axiom, proved",
     "content": "The headline result. Applying the density predicate at threshold nthPrime N yields a shift n >= nthPrime N with at least two primes among {n + h : h in H}; Finset.one_lt_card extracts two distinct shifts a != b, ordered by a single case split, and gap_from_two_primes finishes. sieve_conclusion_from_density and sieve_eh_conclusion_from_density restate this in the literal signatures of maynard_tao_sieve (k >= 50) and maynard_tao_sieve_eh (k >= 5), with the admissibility and cardinality hypotheses present but provably unused - underscoring that the reduction needs only the diameter bound.",
-    "mathContext": "Conclusion shape matched exactly: $\\forall N,\\ \\exists n \\geq N,\\ \\mathrm{primeGap}(n) \\leq D$. The redundancy is logical: $\\text{density} \\wedge (\\forall h \\in H,\\ h \\leq D) \\Rightarrow \\text{gap-sieve conclusion}$, so the gap-sieve axioms add no assumptions beyond the density axiom."
+    "mathContext": "Conclusion shape matched exactly: $\\forall N,\\ \\exists n \\geq N,\\ \\mathrm{primeGap}(n) \\leq D$. The redundancy is logical: $\\text{density} \\wedge (\\forall h \\in H,\\ h \\leq D) \\Rightarrow \\text{gap-sieve conclusion}$, so the gap-sieve axioms add no assumptions beyond the density axiom.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.one_lt_card", "liminf of prime gaps", "unused hypotheses", "signature-matching reduction"],
+    "prerequisites": ["the arithmetic core above", "extracting elements from a Finset by cardinality", "the density predicate"]
   },
   {
     "id": "pair-instance",
@@ -42,6 +54,9 @@
     "type": "theorem",
     "title": "pair_density_implies_bounded_gaps: the {0, d} reading",
     "content": "Specialising H = {0, d} (diameter d) gives: a density of two primes among {n, n+d} infinitely often implies infinitely many consecutive prime gaps <= d. At d = 2 this is the elementary statement that the twin-prime density hypothesis already entails infinitely many gaps <= 2 - the last step needs no sieve axiom.",
-    "mathContext": "With $H = \\{0, d\\}$, $\\mathrm{MaynardTaoDensity}\\ \\{0,d\\}\\ 2$ means both $n$ and $n + d$ are prime for infinitely many $n$ (a prime pair at distance $d$); the corollary turns each such pair into a certificate of a consecutive gap $\\leq d$."
+    "mathContext": "With $H = \\{0, d\\}$, $\\mathrm{MaynardTaoDensity}\\ \\{0,d\\}\\ 2$ means both $n$ and $n + d$ are prime for infinitely many $n$ (a prime pair at distance $d$); the corollary turns each such pair into a certificate of a consecutive gap $\\leq d$.",
+    "significance": "supporting",
+    "relatedConcepts": ["twin primes (d = 2)", "prime pairs at distance d", "specialisation of a general theorem", "Polignac's conjecture"],
+    "prerequisites": ["the headline reduction", "the tuple H = {0, d}"]
   }
 ]

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/index.ts
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BoundedPrimeGapsOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const boundedPrimeGapsOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const boundedPrimeGapsOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const boundedPrimeGapsOq01Oq01Data: ProofData = {
+  proof: boundedPrimeGapsOq01Oq01Proof,
+  annotations: boundedPrimeGapsOq01Oq01Annotations,
+}

--- a/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01-oq-01/meta.json
@@ -114,5 +114,26 @@
       "endLine": 205,
       "summary": "pair_density_implies_bounded_gaps specialises to {0,d}: a density of two primes among {n, n+d} yields infinitely many consecutive gaps <= d, recovering the twin-style reading at d = 2."
     }
+  ],
+  "conclusion": {
+    "summary": "Five machine-checked theorems (0 sorries, 0 axioms beyond propext/Classical.choice/Quot.sound) show that the two gap-sieve axioms of the parent BoundedPrimeGaps formalization are logically redundant: their conclusion — infinitely many consecutive prime gaps ≤ D — is derived elementarily from the single Maynard–Tao density statement MaynardTaoDensity H 2 together with the diameter bound. The arithmetic core gap_from_two_primes turns any two primes within distance D into a bounded consecutive gap; density_two_implies_bounded_gaps lifts it to 'infinitely often'; and sieve_conclusion_from_density / sieve_eh_conclusion_from_density reproduce the eliminated axioms' exact signatures with the admissibility and cardinality hypotheses provably unused.",
+    "implications": "The result sharpens the formalization's axiomatic footprint: the irreducible analytic input of the bounded-prime-gaps program is one density statement, not three axioms. It also cleanly localises where the depth lives — admissibility and the sieve machinery serve only to make the density antecedent true; the passage from 'two nearby primes' to 'a bounded consecutive gap' is pure prime-counting arithmetic. This separation is a reusable pattern for auditing which assumptions in a formalization are genuinely primitive versus derivable.",
+    "openQuestions": [
+      "Can the remaining density axiom maynard_tao_m_tuples itself be reduced — e.g. derived from a Bombieri–Vinogradov-type equidistribution statement formalized in Mathlib — to shrink the axiomatic core to a single analytic input?",
+      "Does the density-to-gap reduction generalise from m = 2 (consecutive gaps) to m ≥ 3, certifying clusters of m primes within a bounded window and bounding p_{n+m-1} − p_n?",
+      "Is the diameter bound forall h in H, h <= D the minimal sufficient hypothesis, or can the same conclusion be extracted from a weaker average/quantile bound on the tuple H?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "extends",
+      "description": "Parent: the BoundedPrimeGaps formalization that encodes the Maynard–Tao machinery as three axioms (one density, two gap-sieve). This entry proves the two gap-sieve axioms redundant, reducing the irreducible analytic input to the single density axiom."
+    },
+    {
+      "targetId": "bounded-prime-gaps-oq-01",
+      "relationship": "related",
+      "description": "Sibling open-question branch of the bounded-prime-gaps family; this entry answers the OQ-01-OQ-01 sub-question on eliminating the gap-sieve axioms."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `bounded-prime-gaps-oq-01-oq-01`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Added a `conclusion`** (summary, implications, 3 open questions) — the entry had none.
- **Added `crossReferences`** to the parent `bounded-prime-gaps` and sibling `bounded-prime-gaps-oq-01`.
- **Annotation depth**: added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations (they already had `mathContext`).

Axiom integrity unchanged: meta reports `verified`/`original`, 0 axioms (only propext/Classical.choice/Quot.sound), 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)