### PR TITLE
Enrich Cantor Diagonalization OQ-07: The Continuum Is Multiplicatively Idempotent (#(ℝ×ℝ)=#ℝ)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-07/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-07/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "Module Header and Problem Setup",
-    "content": "The open question asks for $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$, equivalently $\\mathfrak{c} \\cdot \\mathfrak{c} = \\mathfrak{c}$. Where Cantor's 1874 diagonal argument (cantor-diagonalization-oq-06) shows ℝ is *strictly* larger than ℕ, his surprising 1878 result shows the continuum is *stable* under products: the line and the plane are in bijection, so dimension does not change cardinality."
+    "content": "The open question asks for $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$, equivalently $\\mathfrak{c} \\cdot \\mathfrak{c} = \\mathfrak{c}$. Where Cantor's 1874 diagonal argument (cantor-diagonalization-oq-06) shows ℝ is *strictly* larger than ℕ, his surprising 1878 result shows the continuum is *stable* under products: the line and the plane are in bijection, so dimension does not change cardinality.",
+    "mathContext": "$\\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R}$, i.e. $\\mathfrak{c}\\cdot\\mathfrak{c} = \\mathfrak{c}$ where $\\mathfrak{c} = 2^{\\aleph_0} = \\#\\mathbb{R}$.",
+    "significance": "context",
+    "relatedConcepts": ["cardinality of the continuum 𝔠", "Cantor 1878 line≅plane", "cardinal arithmetic", "dimension vs cardinality"],
+    "prerequisites": ["cardinal numbers", "the diagonal argument (#ℕ < #ℝ)"]
   },
   {
     "id": "cantoroq07-engine",
@@ -19,7 +23,11 @@
     },
     "type": "theorem",
     "title": "The Absorption Law 𝔠 · 𝔠 = 𝔠",
-    "content": "`continuum_sq` re-exports Mathlib's `Cardinal.continuum_mul_self`, which is the case $c = \\mathfrak{c}$ of `Cardinal.mul_eq_self` ($\\aleph_0 \\le c \\Rightarrow c \\cdot c = c$). This absorption law — every infinite cardinal is multiplicatively idempotent — is the only nontrivial ingredient, and is itself equivalent to the axiom of choice (Tarski). Every result below is a one-line specialization of it at the continuum."
+    "content": "`continuum_sq` re-exports Mathlib's `Cardinal.continuum_mul_self`, which is the case $c = \\mathfrak{c}$ of `Cardinal.mul_eq_self` ($\\aleph_0 \\le c \\Rightarrow c \\cdot c = c$). This absorption law — every infinite cardinal is multiplicatively idempotent — is the only nontrivial ingredient, and is itself equivalent to the axiom of choice (Tarski). Every result below is a one-line specialization of it at the continuum.",
+    "mathContext": "$\\mathfrak{c}\\cdot\\mathfrak{c} = \\mathfrak{c}$, the case $c = \\mathfrak{c}$ of $\\aleph_0 \\le c \\Rightarrow c\\cdot c = c$. Tarski: this idempotence for all infinite $c$ is equivalent to AC.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.mul_eq_self", "infinite cardinal idempotence", "axiom of choice (Tarski's theorem)", "aleph_0 ≤ 𝔠"],
+    "prerequisites": ["infinite cardinal multiplication", "the axiom of choice"]
   },
   {
     "id": "cantoroq07-plane",
@@ -30,17 +38,40 @@
     },
     "type": "theorem",
     "title": "The Plane Equals the Line",
-    "content": "`mk_prod_real_eq_continuum` computes $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\mathfrak{c}$: `Cardinal.mk_prod` expands the product to $\\#\\mathbb{R} \\cdot \\#\\mathbb{R}$ (the universe lifts vanish by `Cardinal.lift_id`), `Cardinal.mk_real` rewrites each factor to $\\mathfrak{c}$, and `continuum_sq` collapses $\\mathfrak{c} \\cdot \\mathfrak{c}$ to $\\mathfrak{c}$. The main result `mk_prod_real` then reads off $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$ since both sides equal $\\mathfrak{c}$."
+    "content": "`mk_prod_real_eq_continuum` computes $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\mathfrak{c}$: `Cardinal.mk_prod` expands the product to $\\#\\mathbb{R} \\cdot \\#\\mathbb{R}$ (the universe lifts vanish by `Cardinal.lift_id`), `Cardinal.mk_real` rewrites each factor to $\\mathfrak{c}$, and `continuum_sq` collapses $\\mathfrak{c} \\cdot \\mathfrak{c}$ to $\\mathfrak{c}$. The main result `mk_prod_real` then reads off $\\#(\\mathbb{R} \\times \\mathbb{R}) = \\#\\mathbb{R}$ since both sides equal $\\mathfrak{c}$.",
+    "mathContext": "$\\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R}\\cdot\\#\\mathbb{R} = \\mathfrak{c}\\cdot\\mathfrak{c} = \\mathfrak{c} = \\#\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.mk_prod", "universe lift (lift_id)", "Cardinal.mk_real", "equinumerosity of ℝ and ℝ²"],
+    "prerequisites": ["the absorption law above", "cardinality of a product type"]
   },
   {
     "id": "cantoroq07-bijection",
     "proofId": "cantor-diagonalization-oq-07",
     "range": {
       "startLine": 47,
-      "endLine": 60
+      "endLine": 52
     },
     "type": "theorem",
-    "title": "Bijection and Complex Corollary",
-    "content": "`nonempty_equiv_prod_real` applies `Cardinal.eq` ($\\#\\alpha = \\#\\beta \\leftrightarrow \\mathrm{Nonempty}\\,(\\alpha \\simeq \\beta)$) to turn the cardinal equality into an honest bijection $\\mathbb{R} \\times \\mathbb{R} \\simeq \\mathbb{R}$ — Cantor's 1878 'line ≅ plane' map, recovered from the cardinal computation. `mk_complex_eq_mk_real` records the corollary $\\#\\mathbb{C} = \\#\\mathbb{R}$, immediate from $\\mathbb{C} \\simeq \\mathbb{R} \\times \\mathbb{R}$ (`Complex.equivRealProd`) or from `Cardinal.mk_complex`."
+    "title": "From Cardinal Equality to an Honest Bijection",
+    "content": "`nonempty_equiv_prod_real` applies `Cardinal.eq` ($\\#\\alpha = \\#\\beta \\leftrightarrow \\mathrm{Nonempty}\\,(\\alpha \\simeq \\beta)$) to turn the cardinal equality $\\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R}$ into an honest bijection $\\mathbb{R} \\times \\mathbb{R} \\simeq \\mathbb{R}$ — Cantor's 1878 'line ≅ plane' map, recovered from the cardinal computation. The witness is non-constructive: it comes from the cardinal-arithmetic proof, not an explicit interleaving-of-digits pairing.",
+    "mathContext": "$\\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R} \\;\\Longleftrightarrow\\; \\mathrm{Nonempty}\\,(\\mathbb{R}\\times\\mathbb{R} \\simeq \\mathbb{R})$, via `Cardinal.eq`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cardinal.eq", "Nonempty (α ≃ β)", "non-constructive bijection", "Schröder–Bernstein"],
+    "prerequisites": ["the equinumerosity result above", "the definition of cardinal equality"]
+  },
+  {
+    "id": "cantoroq07-complex",
+    "proofId": "cantor-diagonalization-oq-07",
+    "range": {
+      "startLine": 54,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "Corollary: the Complex Plane Has Cardinality #ℝ",
+    "content": "`mk_complex_eq_mk_real` records the corollary $\\#\\mathbb{C} = \\#\\mathbb{R}$, immediate from $\\mathbb{C} \\simeq \\mathbb{R} \\times \\mathbb{R}$ (`Complex.equivRealProd`) together with the plane–line equality, or directly from `Cardinal.mk_complex : \\#\\mathbb{C} = \\mathfrak{c}` and `Cardinal.mk_real : \\#\\mathbb{R} = \\mathfrak{c}`. So ℂ — a 2-dimensional real space — is equinumerous with the line.",
+    "mathContext": "$\\#\\mathbb{C} = \\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R} = \\mathfrak{c}$, since $\\mathbb{C} \\simeq \\mathbb{R}\\times\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex.equivRealProd", "Cardinal.mk_complex", "real vector spaces and cardinality", "dimension does not affect cardinality"],
+    "prerequisites": ["the plane–line equality", "ℂ ≅ ℝ × ℝ"]
   }
 ]

--- a/src/data/proofs/cantor-diagonalization-oq-07/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CantorDiagonalizationOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cantorDiagonalizationOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOq07Data: ProofData = {
+  proof: cantorDiagonalizationOq07Proof,
+  annotations: cantorDiagonalizationOq07Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-07`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- **Annotation coverage**: split the bijection annotation into the bijection (`nonempty_equiv_prod_real`) and the ℂ corollary (`mk_complex_eq_mk_real`) — 4 → 5 annotations spanning all five theorems.

Axiom integrity unchanged: meta reports `verified`/`mathlib`, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)