### PR TITLE
audit(gallery): 13 fresh proofs — 12 clean + area-of-circle-oq-05-oq-01-incomplete-01 theoremCount fix

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01-incomplete-01/meta.json
@@ -33,7 +33,7 @@
     ],
     "dateAdded": "2026-06-25",
     "lineCount": 203,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Gallery Integrity Audit — 13 fresh (never-audited) proofs

Audited the 13 unaudited gallery proofs at `fe95e94f468`. All real on `origin/main` (meta + Lean files verified via `git cat-file`). Source counts cross-checked against meta after stripping comments.

### Result: 12 clean, 1 fixed

**Fixed — `area-of-circle-oq-05-oq-01-incomplete-01`** (LOW severity, theoremCount off-by-one):
- meta claimed `theoremCount: 10`; the Lean file `AreaOfCircleOQ05OQ01Incomplete01.lean` has exactly **9** `theorem`/`lemma` decls (0 lemmas, 0 defs). Corrected 10 → 9.
- Note: prior audit PRs (#30094, #30112) recorded this fix, but the proof was an untracked phantom then; the researcher's real merge (#30081) landed `theoremCount: 10` on main, so the mismatch was genuinely present and is now fixed against the real file.

**Clean (12):** abel-ruffini-galois-extensions-oq-01, area-of-circle-oq-07-oq-05-oq-01-oq-01, beta-integral-recurrence-oq-01-oq-01-oq-01, binomial-theorem-oq-01-oq-01-oq-02, buffons-noodle-oq-01-oq-01, cauchy-schwarz-oq-07-oq-01, erdos-308-oq-03, gram-linear-independence-iff-oq-01-oq-01-oq-02, hilbert-22-oq-01-oq-03, lhopital-oq-05-oq-02, sperner-ndim-mathlib-oq-03, sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-03

Notes on the non-trivial ones:
- **buffons-noodle-oq-01-oq-01**: `axiomCount=2` correctly reflects 2 *inherited* kinematic-measure axioms from grandparent `BuffonsNoodle.lean` (Cauchy–Crofton infra not in Mathlib); file introduces 0 new axioms. `status=axiomatized`, fully disclosed. Correct.
- **abel-ruffini-galois-extensions-oq-01**: badge `original` — relies on Mathlib's `solvableByRad.isSolvable'` / S₅ non-solvability, but all 12 dependencies are fully disclosed in `mathlibDependencies`; the original contribution is the concrete realization of S₅ as the Galois group of X⁵−4X+2 (Eisenstein + IVT + Rolle bridge), not in Mathlib. Disclosure is thorough; not overclaiming.
- **sperner-ndim-mathlib-oq-03**: badge `original`, `mathlibDependencies: None`. Despite "mathlib" in the slug lineage, contributions are self-contained discrete sign-change/parity lemmas (1-dim Tucker). No heavy Mathlib core call. Correct.

Tracker (`audit-tracker.json`) updated: 12 `clean`, 1 `issues-fixed`.

---
Discovered during autonomous gallery integrity audit.