### PR TITLE
Enrich Cantor Diagonalization OQ-07-OQ-01: Continuum Powers #(ℝⁿ)=#ℝ and #(ℕ→ℝ)=𝔠

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-07-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "cantoroq0701-header",
+    "proofId": "cantor-diagonalization-oq-07-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "context",
+    "title": "Module Header: n-Fold and Countable Continuum Powers",
+    "content": "The parent (cantor-diagonalization-oq-07) proves #(ℝ × ℝ) = #ℝ, i.e. the n = 2 case of the continuum's stability under powers. This file generalises in two directions: to every finite dimension (#(ℝⁿ) = #ℝ for n ≥ 1) and to countably-infinite dimension (#(ℕ → ℝ) = 𝔠, the space of real sequences). Both are absorption laws for infinite cardinals — 𝔠 ^ n = 𝔠 and 𝔠 ^ ℵ₀ = 𝔠 — and each unpacks, via Cardinal.eq, to an honest (non-constructive) bijection with the line.",
+    "mathContext": "$\\#(\\mathbb{R}^n) = \\#\\mathbb{R}$ for $n \\ge 1$, and $\\#(\\mathbb{N}\\to\\mathbb{R}) = \\mathfrak{c}$. Cantor 1878: finite dimension does not change cardinality.",
+    "significance": "context",
+    "relatedConcepts": ["cardinality of the continuum 𝔠", "cardinal exponentiation", "absorption laws", "Cantor 1878 dimension result"],
+    "prerequisites": ["cardinal arithmetic", "the parent #(ℝ×ℝ)=#ℝ"]
+  },
+  {
+    "id": "cantoroq0701-finite-engine",
+    "proofId": "cantor-diagonalization-oq-07-oq-01",
+    "range": { "startLine": 36, "endLine": 47 },
+    "type": "theorem",
+    "title": "Finite-Power Absorption: 𝔠 ^ n = 𝔠 and #(ℝⁿ) = 𝔠",
+    "content": "continuum_pow_eq is the engine: Cardinal.power_nat_eq (ℵ₀ ≤ c ∧ 1 ≤ n ⟹ c ^ n = c) at c = 𝔠 gives 𝔠 ^ n = 𝔠 for n ≥ 1. mk_pi_real_eq_continuum then computes #(Fin n → ℝ) = 𝔠: Cardinal.mk_arrow rewrites the function-type cardinal to #ℝ ^ #(Fin n) (lifts vanish by lift_id in one universe), mk_real and mk_fin turn it into 𝔠 ^ (n : ℕ) (bridging cardinal and monoid powers via power_natCast), and continuum_pow_eq collapses it.",
+    "mathContext": "$\\mathfrak{c}^n = \\mathfrak{c}$ ($n \\ge 1$); hence $\\#(\\mathbb{R}^n) = \\#\\mathbb{R}^{\\#\\mathrm{Fin}\\,n} = \\mathfrak{c}^n = \\mathfrak{c}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.power_nat_eq", "Cardinal.mk_arrow", "power_natCast (cardinal vs monoid power)", "ℝⁿ as Fin n → ℝ"],
+    "prerequisites": ["infinite-cardinal power laws", "cardinality of a function type", "ℵ₀ ≤ 𝔠"]
+  },
+  {
+    "id": "cantoroq0701-finite-main",
+    "proofId": "cantor-diagonalization-oq-07-oq-01",
+    "range": { "startLine": 49, "endLine": 58 },
+    "type": "theorem",
+    "title": "n-Space Equals the Line, With a Bijection",
+    "content": "mk_pi_real reads off #(ℝⁿ) = #ℝ since both sides equal 𝔠 — Euclidean n-space is equinumerous with the line for every n ≥ 1, the finite-dimensional companion to the parent's #(ℝ × ℝ) = #ℝ. nonempty_equiv_pi_real then applies Cardinal.eq to turn the equality into the existence of a bijection ℝⁿ ≃ ℝ. The witness is classical, coming from the cardinal-arithmetic proof rather than an explicit coordinate-interleaving formula.",
+    "mathContext": "$\\#(\\mathbb{R}^n) = \\#\\mathbb{R}$ and $\\mathrm{Nonempty}((\\mathrm{Fin}\\,n \\to \\mathbb{R}) \\simeq \\mathbb{R})$ for $n \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.eq", "non-constructive bijection", "equinumerosity ℝⁿ ≃ ℝ", "dimension vs cardinality"],
+    "prerequisites": ["the finite-power absorption above", "cardinal equality ⟺ bijection"]
+  },
+  {
+    "id": "cantoroq0701-countable",
+    "proofId": "cantor-diagonalization-oq-07-oq-01",
+    "range": { "startLine": 60, "endLine": 76 },
+    "type": "theorem",
+    "title": "Countable Power: Real Sequences Stay at the Continuum",
+    "content": "mk_nat_arrow_real_eq_continuum computes #(ℕ → ℝ) = 𝔠: Cardinal.mk_arrow gives #ℝ ^ #ℕ = 𝔠 ^ ℵ₀ (via mk_real, mk_nat), and Cardinal.continuum_power_aleph0 (𝔠 ^ ℵ₀ = 𝔠, itself from 2^ℵ₀ = 𝔠 and ℵ₀·ℵ₀ = ℵ₀) collapses it. So even countably-infinite-dimensional real space is no larger than the line. mk_nat_arrow_real records #(ℕ → ℝ) = #ℝ, and nonempty_equiv_nat_arrow_real unpacks it to a bijection (ℕ → ℝ) ≃ ℝ.",
+    "mathContext": "$\\#(\\mathbb{N}\\to\\mathbb{R}) = \\mathfrak{c}^{\\aleph_0} = \\mathfrak{c} = \\#\\mathbb{R}$; the countable power is the last exponent the continuum absorbs.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.continuum_power_aleph0", "𝔠 ^ ℵ₀ = 𝔠", "sequence space ℕ → ℝ", "boundary of stability (𝔠^𝔠 > 𝔠)"],
+    "prerequisites": ["countable cardinal power", "2^ℵ₀ = 𝔠", "cardinality of a function type"]
+  },
+  {
+    "id": "cantoroq0701-sanity",
+    "proofId": "cantor-diagonalization-oq-07-oq-01",
+    "range": { "startLine": 78, "endLine": 81 },
+    "type": "concept",
+    "title": "Sanity Check: n = 2 Recovers the Parent",
+    "content": "mk_pi_two_real instantiates mk_pi_real at n = 2, giving #(Fin 2 → ℝ) = #ℝ — the Fin-indexed form of the parent's #(ℝ × ℝ) = #ℝ. This confirms the general result specialises correctly to the case already in the gallery, closing the loop with cantor-diagonalization-oq-07.",
+    "mathContext": "$\\#(\\mathrm{Fin}\\,2 \\to \\mathbb{R}) = \\#\\mathbb{R}$, the $n = 2$ instance recovering $\\#(\\mathbb{R}\\times\\mathbb{R}) = \\#\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialisation at n = 2", "Fin 2 → ℝ vs ℝ × ℝ", "regression against the parent"],
+    "prerequisites": ["the general mk_pi_real", "Fin 2 → ℝ ≅ ℝ × ℝ"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-07-oq-01/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-07-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CantorDiagonalizationOQ07OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cantorDiagonalizationOq07Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cantorDiagonalizationOq07Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cantorDiagonalizationOq07Oq01Data: ProofData = {
+  proof: cantorDiagonalizationOq07Oq01Proof,
+  annotations: cantorDiagonalizationOq07Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-07-oq-01`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Authored `annotations.json` from scratch** — the entry had no annotations file at all. Added 5 annotations (with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the header, finite-power absorption, n-space equinumerosity + bijection, the countable power, and the n=2 sanity check.

Axiom integrity unchanged: meta reports `verified`/`original`, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)