### PR TITLE
audit: 5 fresh proofs (4 clean) + cantors-oq0104 theoremCount 8→9

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24127,6 +24127,36 @@
       "lastAudited": "2026-06-25T16:58:19Z",
       "result": "clean",
       "issues": []
+    },
+    "brianchon-theorem-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-07-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gram-linear-independence-iff-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "partition-theorem-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:20:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantors-theorem-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:20:00Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json
@@ -29,7 +29,7 @@
       "The explicit beth-successor unfoldings beth_two_eq (ℶ₂ = 2^ℶ₁) and beth_three_eq (ℶ₃ = 2^ℶ₂) at concrete ordinal indices, together with card_real_eq_beth_one (|ℝ| = ℶ₁), giving a self-contained derivation of the whole tower ℶ₁, ℶ₂, ℶ₃ as iterated power sets of ℝ.",
       "The strict Cantor tower |ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))| (card_real_lt_powerSet, card_powerSet_real_lt_powerSet_powerSet) and the strictly increasing beth tower ℶ₁ < ℶ₂ < ℶ₃ (beth_tower_strictMono), packaged with the main identity in cantors_theorem_oq01oq04_summary."
     ],
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "overview": {
@@ -148,7 +148,7 @@
     "namespace": "CantorsTheoremOQ01OQ04",
     "lineCount": 102,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CantorsTheoremOQ01OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery integrity audit — fresh never-audited queue

Audited the 5 fresh never-audited proofs surfaced by \`find-targets.ts\`.

| Proof | Status/Badge | Result | Notes |
|-------|--------------|--------|-------|
| brianchon-theorem-oq-01-oq-02 | verified/original | ✅ CLEAN | 13 thm / 0 axiom / 0 sorry. Self-contained det-identity converse (det(diag)=(detC)⁴·det(pascal)); uses Mathlib det lemmas as tools, **not** a Brianchon/Pascal wrapper → `original` justified. |
| cantor-diagonalization-oq-07-oq-01 | verified/original | ✅ CLEAN | 8 thm / 0 axiom / 0 sorry. |
| gram-linear-independence-iff-oq-01-oq-01-oq-02 | verified/original | ✅ CLEAN | 7 thm (incl. `@[simp] col_apply`) / 0 axiom / 0 sorry. |
| partition-theorem-oq-03-oq-03 | verified/original | ✅ CLEAN | 5 thm / 0 axiom / 0 sorry. |
| cantors-theorem-oq-01-oq-04 | verified/verified | 🔧 FIXED | `theoremCount` 8→9: file has 9 theorems (incl. `cantors_theorem_oq01oq04_summary`). Corrected both `meta.theoremCount` and `leanFile.theoremCount`. 0 axiom / 0 sorry confirmed. |

### Not audited
- **borsuk-ulam-oq-03-oq-02**: untracked researcher WIP — neither its `meta.json` nor `Proofs/BorsukUlamOQ03OQ02.lean` is on `main`, and there is no open PR. It only surfaces because the files sit in the shared working tree. Not part of the published gallery, so deliberately left unaudited (not blessed).

### Changes
- `src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json` — theoremCount 8→9 (2 fields)
- `src/data/proofs/audit-tracker.json` — record 5 audit results

🤖 Generated with [Claude Code](https://claude.com/claude-code)