### PR TITLE
research(angle-trisection-oq-02-oq-02-oq-03): complex constructibility extension of Gauss–Wantzel [axiomatized, 2-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -143,6 +143,7 @@ import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01
 import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle
 import Proofs.AngleTrisectionOQ02OQ02
 import Proofs.AngleTrisectionOQ02OQ02OQ02
+import Proofs.AngleTrisectionOQ02OQ02OQ03
 import Proofs.AngleTrisectionOQ02OQ03
 import Proofs.AngleTrisectionOQ02OQ03Ext
 import Proofs.AngleTrisectionOQ02OQ03ExtOQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -628,6 +628,7 @@ import Proofs.CantorsTheoremOQ01OQ01
 import Proofs.CantorsTheoremOQ01OQ02
 import Proofs.CantorsTheoremOQ01OQ03
 import Proofs.CantorsTheoremOQ01OQ03OQ04
+import Proofs.CantorsTheoremOQ01OQ04
 import Proofs.CantorsTheoremOQ02
 import Proofs.CantorsTheoremOQ03
 import Proofs.CantorsTheoremOQ03OQ02

--- a/proofs/Proofs/AngleTrisectionOQ02OQ02OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ02OQ03.lean
@@ -1,0 +1,274 @@
+/-
+# Angle Trisection OQ-02-OQ-02-OQ-03: Complex Constructibility Extension of Gauss–Wantzel
+
+## Open Question
+
+The parent entry `angle-trisection-oq-02-oq-02` states the Gauss–Wantzel theorem for the
+*real* coordinate `cos(2π/n)`: a regular `n`-gon is constructible iff `φ(n)` is a power of
+two.  Geometrically the `n`-gon lives in the plane `ℂ`, with vertices the `n`-th roots of
+unity `ζₙᵏ = exp(2πik/n)`.  This entry lifts constructibility from `ℝ` to `ℂ`:
+
+> Call `z ∈ ℂ` **constructible** when both `Re z` and `Im z` are constructible reals.
+> Then the vertex `ζₙ = exp(2πi/n)` of the regular `n`-gon is (complex-)constructible
+> **iff** `φ(n)` is a power of two — the genuinely planar form of Gauss–Wantzel.
+
+## Answer: YES
+
+We define `IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im`
+on top of the parent's real predicate `GaussWantzel.IsConstructibleFromQ`, and prove the
+structural backbone of the complex constructible numbers that requires **no field-compositum
+machinery**:
+
+* `ℚ ⊆` constructibles: every rational, in particular `0` and `1`, is constructible
+  (witnessed by the bottom field `⊥`, `[⊥:ℚ] = 1 = 2⁰`).
+* Closure under **negation** and **complex conjugation** (an intermediate field is closed
+  under negation — no degree growth).
+* The imaginary unit `i`, every Gaussian rational `a + b·i` (`a,b ∈ ℚ`), and the
+  real/imaginary embeddings are constructible; multiplication by `i` preserves
+  constructibility.
+
+The **headline** is the planar Gauss–Wantzel equivalence
+
+  `IsConstructibleℂ (exp(2πi/n)) ↔ ∃ k, φ(n) = 2ᵏ`,
+
+obtained by splitting `exp(iθ) = cos θ + i·sin θ` into real and imaginary parts
+(`Complex.exp_ofReal_mul_I_re/_im`) and feeding the real coordinate to the parent's
+Gauss–Wantzel bridge.  Concrete corollaries: the vertices of the 3-, 4-, 5-, 15-, 17-gon
+are constructible, while those of the 7- and 9-gon are not.
+
+## Assumptions
+
+* `GaussWantzel.gauss_wantzel_theorem` — the parent's *geometric* bridge (`cos(2π/n)`
+  constructible ↔ `φ(n)` a power of two), itself axiomatized.
+* `sin_constructible_of_cos` (new) — the single *analytic* fact that the constructible reals
+  are closed under the passage `cos(2π/n) ↦ sin(2π/n) = √(1 − cos²(2π/n))` (a non-negative
+  square root for `n ≥ 3`).  This is the only addition over the parent and isolates exactly
+  the imaginary-axis content of the lift.
+
+All remaining results below are fully proved (no further axioms, no sorries).
+
+## Tags
+
+angle-trisection, gauss-wantzel, complex-constructibility, roots-of-unity, fermat-primes
+-/
+
+import Mathlib
+import Proofs.AngleTrisectionOQ02OQ02
+
+open GaussWantzel
+
+namespace ComplexGaussWantzel
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I:  RATIONALS AND NEGATION ARE CONSTRUCTIBLE (no compositum needed)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Every rational number is a constructible real: it lies in the bottom field `⊥`,
+    whose degree over `ℚ` is `1 = 2⁰`. -/
+theorem isConstructibleFromQ_rat (q : ℚ) : IsConstructibleFromQ (q : ℝ) := by
+  refine ⟨(⊥ : IntermediateField ℚ ℝ), inferInstance, ⟨0, ?_⟩, ?_⟩
+  · simp [IntermediateField.finrank_bot]
+  · exact (⊥ : IntermediateField ℚ ℝ).algebraMap_mem q
+
+/-- `0` is a constructible real. -/
+theorem isConstructibleFromQ_zero : IsConstructibleFromQ (0 : ℝ) := by
+  simpa using isConstructibleFromQ_rat 0
+
+/-- `1` is a constructible real. -/
+theorem isConstructibleFromQ_one : IsConstructibleFromQ (1 : ℝ) := by
+  simpa using isConstructibleFromQ_rat 1
+
+/-- The constructible reals are closed under negation: the *same* field `K` works, since an
+    intermediate field is closed under negation (no degree growth). -/
+theorem isConstructibleFromQ_neg {x : ℝ} (hx : IsConstructibleFromQ x) :
+    IsConstructibleFromQ (-x) := by
+  obtain ⟨K, hfd, hpow, hmem⟩ := hx
+  exact ⟨K, hfd, hpow, K.neg_mem hmem⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II:  COMPLEX CONSTRUCTIBILITY
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- A complex number is **constructible** when both its real and imaginary parts are
+    constructible reals — the planar lift of the parent's real predicate. -/
+def IsConstructibleℂ (z : ℂ) : Prop :=
+  IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im
+
+/-- `0` is constructible. -/
+theorem isConstructibleℂ_zero : IsConstructibleℂ 0 :=
+  ⟨by simpa using isConstructibleFromQ_zero, by simpa using isConstructibleFromQ_zero⟩
+
+/-- `1` is constructible. -/
+theorem isConstructibleℂ_one : IsConstructibleℂ 1 :=
+  ⟨by simpa using isConstructibleFromQ_one, by simpa using isConstructibleFromQ_zero⟩
+
+/-- The imaginary unit `i` is constructible (`Re i = 0`, `Im i = 1`). -/
+theorem isConstructibleℂ_I : IsConstructibleℂ Complex.I :=
+  ⟨by simpa using isConstructibleFromQ_zero, by simpa using isConstructibleFromQ_one⟩
+
+/-- A real number is a constructible real iff it is constructible as a complex number. -/
+theorem isConstructibleℂ_ofReal_iff (x : ℝ) :
+    IsConstructibleℂ (x : ℂ) ↔ IsConstructibleFromQ x := by
+  unfold IsConstructibleℂ
+  simp only [Complex.ofReal_re, Complex.ofReal_im]
+  exact ⟨fun h => h.1, fun h => ⟨h, isConstructibleFromQ_zero⟩⟩
+
+/-- Every Gaussian rational `a + b·i` with `a, b ∈ ℚ` is constructible. -/
+theorem isConstructibleℂ_ratGaussian (a b : ℚ) :
+    IsConstructibleℂ ((a : ℂ) + (b : ℂ) * Complex.I) := by
+  constructor
+  · have : ((a : ℂ) + (b : ℂ) * Complex.I).re = (a : ℝ) := by simp
+    rw [this]; exact isConstructibleFromQ_rat a
+  · have : ((a : ℂ) + (b : ℂ) * Complex.I).im = (b : ℝ) := by simp
+    rw [this]; exact isConstructibleFromQ_rat b
+
+/-- Closure under complex conjugation: `Re(z̄) = Re z` and `Im(z̄) = -Im z`, and the
+    constructible reals are closed under negation. -/
+theorem IsConstructibleℂ.conj {z : ℂ} (hz : IsConstructibleℂ z) :
+    IsConstructibleℂ (starRingEnd ℂ z) := by
+  obtain ⟨hre, him⟩ := hz
+  refine ⟨?_, ?_⟩
+  · simpa using hre
+  · simpa using isConstructibleFromQ_neg him
+
+/-- Conjugation does not change constructibility (the converse via `conj ∘ conj = id`). -/
+theorem isConstructibleℂ_conj_iff (z : ℂ) :
+    IsConstructibleℂ (starRingEnd ℂ z) ↔ IsConstructibleℂ z := by
+  refine ⟨fun h => ?_, fun h => h.conj⟩
+  simpa using h.conj
+
+/-- Multiplication by `i` preserves constructibility: `Re(i·z) = -Im z`, `Im(i·z) = Re z`. -/
+theorem IsConstructibleℂ.mul_I {z : ℂ} (hz : IsConstructibleℂ z) :
+    IsConstructibleℂ (Complex.I * z) := by
+  obtain ⟨hre, him⟩ := hz
+  refine ⟨?_, ?_⟩
+  · have : (Complex.I * z).re = -z.im := by simp
+    rw [this]; exact isConstructibleFromQ_neg him
+  · have : (Complex.I * z).im = z.re := by simp
+    rw [this]; exact hre
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III:  THE ANALYTIC BRIDGE (sin from cos)
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Analytic bridge.**  The constructible reals are closed under the passage
+    `cos(2π/n) ↦ sin(2π/n)`.  For `n ≥ 3` we have `2π/n ∈ (0, π)`, so
+    `sin(2π/n) = √(1 − cos²(2π/n)) ≥ 0`; constructibility of this non-negative square root
+    follows from the constructible reals forming a field closed under square roots.  This is
+    the only new assumption of the entry, isolating exactly the imaginary-axis content. -/
+axiom sin_constructible_of_cos {n : ℕ} (hn : 3 ≤ n) :
+    IsConstructibleFromQ (Real.cos (2 * Real.pi / (n : ℝ))) →
+    IsConstructibleFromQ (Real.sin (2 * Real.pi / (n : ℝ)))
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV:  THE HEADLINE — PLANAR GAUSS–WANTZEL
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The `n`-th root of unity `ζₙ = exp(2πi/n)` is (complex-)constructible **iff** its real
+    coordinate `cos(2π/n)` is a constructible real.  The forward direction is immediate
+    (the real part); the converse supplies the imaginary part via `sin_constructible_of_cos`. -/
+theorem rootOfUnity_isConstructibleℂ_iff_cos {n : ℕ} (hn : 3 ≤ n) :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (n : ℝ) : ℝ) : ℂ) * Complex.I))
+      ↔ IsConstructibleFromQ (Real.cos (2 * Real.pi / (n : ℝ))) := by
+  unfold IsConstructibleℂ
+  rw [Complex.exp_ofReal_mul_I_re, Complex.exp_ofReal_mul_I_im]
+  exact ⟨fun h => h.1, fun h => ⟨h, sin_constructible_of_cos hn h⟩⟩
+
+/-- **Planar Gauss–Wantzel.**  The vertex `exp(2πi/n)` of the regular `n`-gon is
+    (complex-)constructible **iff** `φ(n)` is a power of two.  This is the genuinely
+    two-dimensional form of the theorem: the entire polygon vertex, not just its abscissa. -/
+theorem ngon_vertex_isConstructibleℂ_iff {n : ℕ} (hn : 3 ≤ n) :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (n : ℝ) : ℝ) : ℂ) * Complex.I))
+      ↔ ∃ k : ℕ, Nat.totient n = 2 ^ k := by
+  rw [rootOfUnity_isConstructibleℂ_iff_cos hn, gauss_wantzel_theorem n hn]
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART V:  CONCRETE CONSTRUCTIBLE VERTICES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The equilateral triangle vertex `exp(2πi/3)` is constructible: `φ(3) = 2 = 2¹`. -/
+theorem vertex3_constructibleℂ :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (3 : ℝ) : ℝ) : ℂ) * Complex.I)) :=
+  (ngon_vertex_isConstructibleℂ_iff (by norm_num)).mpr ⟨1, by decide⟩
+
+/-- The square vertex `exp(2πi/4) = i` is constructible: `φ(4) = 2 = 2¹`. -/
+theorem vertex4_constructibleℂ :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (4 : ℝ) : ℝ) : ℂ) * Complex.I)) :=
+  (ngon_vertex_isConstructibleℂ_iff (by norm_num)).mpr ⟨1, by decide⟩
+
+/-- The regular pentagon vertex `exp(2πi/5)` is constructible: `φ(5) = 4 = 2²`. -/
+theorem vertex5_constructibleℂ :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (5 : ℝ) : ℝ) : ℂ) * Complex.I)) :=
+  (ngon_vertex_isConstructibleℂ_iff (by norm_num)).mpr ⟨2, by decide⟩
+
+/-- The 15-gon vertex `exp(2πi/15)` is constructible: `15 = 3·5` (distinct Fermat primes),
+    `φ(15) = 8 = 2³`. -/
+theorem vertex15_constructibleℂ :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (15 : ℝ) : ℝ) : ℂ) * Complex.I)) :=
+  (ngon_vertex_isConstructibleℂ_iff (by norm_num)).mpr ⟨3, by decide⟩
+
+/-- Gauss's heptadecagon vertex `exp(2πi/17)` is constructible: `φ(17) = 16 = 2⁴`. -/
+theorem vertex17_constructibleℂ :
+    IsConstructibleℂ (Complex.exp (((2 * Real.pi / (17 : ℝ) : ℝ) : ℂ) * Complex.I)) :=
+  (ngon_vertex_isConstructibleℂ_iff (by norm_num)).mpr ⟨4, by decide⟩
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART VI:  NON-CONSTRUCTIBLE VERTICES
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The heptagon vertex `exp(2πi/7)` is **not** constructible: `φ(7) = 6` is not a power of
+    two. -/
+theorem vertex7_not_constructibleℂ :
+    ¬ IsConstructibleℂ (Complex.exp (((2 * Real.pi / (7 : ℝ) : ℝ) : ℂ) * Complex.I)) := by
+  intro hcon
+  obtain ⟨k, hk⟩ := (ngon_vertex_isConstructibleℂ_iff (n := 7) (by norm_num)).mp hcon
+  have h6 : Nat.totient 7 = 6 := by decide
+  rw [h6] at hk
+  have hk3 : k ≤ 3 := by
+    by_contra h
+    push_neg at h
+    have : 2 ^ 4 ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) h
+    omega
+  interval_cases k <;> norm_num at hk
+
+/-- The nonagon vertex `exp(2πi/9)` is **not** constructible: `φ(9) = 6` is not a power of
+    two (`9 = 3²`, a repeated Fermat prime). -/
+theorem vertex9_not_constructibleℂ :
+    ¬ IsConstructibleℂ (Complex.exp (((2 * Real.pi / (9 : ℝ) : ℝ) : ℂ) * Complex.I)) := by
+  intro hcon
+  obtain ⟨k, hk⟩ := (ngon_vertex_isConstructibleℂ_iff (n := 9) (by norm_num)).mp hcon
+  have h6 : Nat.totient 9 = 6 := by decide
+  rw [h6] at hk
+  have hk3 : k ≤ 3 := by
+    by_contra h
+    push_neg at h
+    have : 2 ^ 4 ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) h
+    omega
+  interval_cases k <;> norm_num at hk
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+VERIFICATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+#check @isConstructibleFromQ_rat
+#check @isConstructibleFromQ_neg
+#check @IsConstructibleℂ
+#check @isConstructibleℂ_I
+#check @isConstructibleℂ_ofReal_iff
+#check @isConstructibleℂ_ratGaussian
+#check @IsConstructibleℂ.conj
+#check @isConstructibleℂ_conj_iff
+#check @IsConstructibleℂ.mul_I
+#check @rootOfUnity_isConstructibleℂ_iff_cos
+#check @ngon_vertex_isConstructibleℂ_iff
+#check @vertex17_constructibleℂ
+#check @vertex7_not_constructibleℂ
+
+end ComplexGaussWantzel

--- a/proofs/Proofs/CantorsTheoremOQ01OQ04.lean
+++ b/proofs/Proofs/CantorsTheoremOQ01OQ04.lean
@@ -1,0 +1,102 @@
+/-
+# |𝒫(𝒫(ℝ))| = ℶ₃: The Third Beth Number via Iterated Power Sets
+
+## Open Question: cantors-theorem-oq-01-oq-04
+
+This entry resolves open question #4 of `cantors-theorem-oq-01` ("The Cardinality
+of 𝒫(ℝ)"), which proved `|𝒫(ℝ)| = ℶ₂`.  The follow-up asks for the next rung of
+the beth tower:
+
+  **Is `|𝒫(𝒫(ℝ))| = ℶ₃`?  (Yes — provable in ZFC, the same pattern as ℶ₂.)**
+
+The answer is yes, and the proof is a clean application of Cantor's power-set
+cardinality law twice:
+
+  |𝒫(𝒫(ℝ))| = 2^|𝒫(ℝ)| = 2^(2^|ℝ|) = 2^(2^(2^ℵ₀)) = ℶ₃.
+
+The beth tower is `ℶ₀ = ℵ₀`, `ℶ₁ = 2^ℵ₀ = 𝔠 = |ℝ|`, `ℶ₂ = 2^𝔠 = |𝒫(ℝ)|`,
+`ℶ₃ = 2^ℶ₂ = |𝒫(𝒫(ℝ))|`, each level the power set of the previous one.
+
+Unlike the *aleph*-index of these cardinals (which is independent of ZFC — the
+content of the parent's open question), the *beth*-index is pinned down outright:
+every iterated power set of ℝ lands exactly on a beth number, by definition of the
+beth function as `ℶ_{α+1} = 2^{ℶ_α}`.
+
+## What is proved
+
+* `card_powerSet_powerSet_real_eq_beth_three` — `|𝒫(𝒫(ℝ))| = ℶ₃` (main result).
+* `beth_two_eq`, `beth_three_eq` — the successor unfoldings `ℶ₂ = 2^ℶ₁`, `ℶ₃ = 2^ℶ₂`.
+* `card_real_eq_beth_one`, `card_powerSet_real_eq_beth_two` — the lower rungs,
+  re-derived here so the file is self-contained.
+* `card_real_lt_powerSet`, `card_powerSet_real_lt_powerSet_powerSet` — Cantor's
+  strict inequalities `|ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))|`.
+* `beth_tower_strictMono` — `ℶ₁ < ℶ₂ < ℶ₃`, the strictly increasing tower.
+
+No axioms beyond Lean/Mathlib's foundations; 0 sorries.
+-/
+import Mathlib
+
+namespace CantorsTheoremOQ01OQ04
+
+open Cardinal
+
+/-- `ℶ₂ = 2^ℶ₁` (the beth successor unfolding at 2). -/
+theorem beth_two_eq : (beth 2 : Cardinal.{0}) = 2 ^ beth 1 := by
+  have o2 : (2 : Ordinal) = Order.succ (1 : Ordinal) := by
+    rw [Order.succ_eq_add_one]; norm_num
+  rw [o2, beth_succ]
+
+/-- `ℶ₃ = 2^ℶ₂` (the beth successor unfolding at 3). -/
+theorem beth_three_eq : (beth 3 : Cardinal.{0}) = 2 ^ beth 2 := by
+  have o3 : (3 : Ordinal) = Order.succ (2 : Ordinal) := by
+    rw [Order.succ_eq_add_one]; norm_num
+  rw [o3, beth_succ]
+
+/-- `|ℝ| = ℶ₁`: the cardinality of the reals is the first beth number
+(`Cardinal.mk_real` says `#ℝ = 𝔠`, and `Cardinal.beth_one` says `ℶ₁ = 𝔠`). -/
+theorem card_real_eq_beth_one : (#ℝ : Cardinal.{0}) = beth 1 := by
+  rw [mk_real, beth_one]
+
+/-- `|𝒫(ℝ)| = ℶ₂`: re-derivation of the parent result `cantors-theorem-oq-01`,
+`#(Set ℝ) = 2^#ℝ = 2^ℶ₁ = ℶ₂`. -/
+theorem card_powerSet_real_eq_beth_two : (#(Set ℝ) : Cardinal.{0}) = beth 2 := by
+  rw [mk_set, card_real_eq_beth_one, beth_two_eq]
+
+/-- **Main result: `|𝒫(𝒫(ℝ))| = ℶ₃`.**
+
+`#(Set (Set ℝ)) = 2^#(Set ℝ) = 2^ℶ₂ = ℶ₃`, applying the power-set cardinality
+law `Cardinal.mk_set` to the second power set and unfolding the beth successor. -/
+theorem card_powerSet_powerSet_real_eq_beth_three :
+    (#(Set (Set ℝ)) : Cardinal.{0}) = beth 3 := by
+  rw [mk_set, card_powerSet_real_eq_beth_two, beth_three_eq]
+
+/-- Cantor's theorem for ℝ: `|ℝ| < |𝒫(ℝ)|`. -/
+theorem card_real_lt_powerSet : (#ℝ : Cardinal.{0}) < #(Set ℝ) := by
+  rw [mk_set]; exact cantor _
+
+/-- Cantor's theorem one level up: `|𝒫(ℝ)| < |𝒫(𝒫(ℝ))|`. -/
+theorem card_powerSet_real_lt_powerSet_powerSet :
+    (#(Set ℝ) : Cardinal.{0}) < #(Set (Set ℝ)) := by
+  have h : (#(Set (Set ℝ)) : Cardinal.{0}) = 2 ^ #(Set ℝ) := mk_set
+  rw [h]; exact cantor _
+
+/-- The beth tower is strictly increasing through the third level: `ℶ₁ < ℶ₂ < ℶ₃`. -/
+theorem beth_tower_strictMono :
+    (beth 1 : Cardinal.{0}) < beth 2 ∧ (beth 2 : Cardinal.{0}) < beth 3 :=
+  ⟨beth_strictMono (by exact_mod_cast (show (1 : ℕ) < 2 by norm_num)),
+   beth_strictMono (by exact_mod_cast (show (2 : ℕ) < 3 by norm_num))⟩
+
+/-- **Summary of the ZFC-provable facts about `|𝒫(𝒫(ℝ))|`.**
+
+1. `|𝒫(𝒫(ℝ))| = ℶ₃` (the third beth number);
+2. the Cantor tower `|ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))|`;
+3. the beth tower `ℶ₁ < ℶ₂ < ℶ₃`. -/
+theorem cantors_theorem_oq01oq04_summary :
+    ((#(Set (Set ℝ)) : Cardinal.{0}) = beth 3) ∧
+    ((#ℝ : Cardinal.{0}) < #(Set ℝ) ∧ (#(Set ℝ) : Cardinal.{0}) < #(Set (Set ℝ))) ∧
+    ((beth 1 : Cardinal.{0}) < beth 2 ∧ (beth 2 : Cardinal.{0}) < beth 3) :=
+  ⟨card_powerSet_powerSet_real_eq_beth_three,
+   ⟨card_real_lt_powerSet, card_powerSet_real_lt_powerSet_powerSet⟩,
+   beth_tower_strictMono⟩
+
+end CantorsTheoremOQ01OQ04

--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-oq02oq02oq03-overview",
+    "proofId": "angle-trisection-oq-02-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "concept",
+    "title": "From a real coordinate to the complex plane: the planar Gauss–Wantzel theorem",
+    "content": "The regular n-gon classically lives in the Euclidean plane, identified with ℂ, and its vertices are the n-th roots of unity ζₙᵏ = exp(2πik/n). The parent entry formalizes Gauss–Wantzel through the single real coordinate cos(2π/n). This file restores the genuinely two-dimensional picture: a complex number z is declared CONSTRUCTIBLE when both Re z and Im z are constructible reals, and the headline shows the full vertex ζₙ is constructible iff φ(n) is a power of two. The lift costs exactly one extra analytic input — the imaginary coordinate sin(2π/n), recovered from cos(2π/n) by a single non-negative square root.",
+    "mathContext": "$z\\in\\mathbb{C}$ constructible $:\\iff$ $\\operatorname{Re}z$ and $\\operatorname{Im}z$ constructible; $\\zeta_n=\\cos(2\\pi/n)+i\\sin(2\\pi/n)$.",
+    "significance": "key",
+    "relatedConcepts": ["roots of unity", "Gauss–Wantzel theorem", "compass-and-straightedge constructibility", "Fermat primes"],
+    "prerequisites": ["the parent real predicate IsConstructibleFromQ", "complex exponential exp(iθ)=cos θ + i sin θ"]
+  },
+  {
+    "id": "ann-oq02oq02oq03-rationals",
+    "proofId": "angle-trisection-oq-02-oq-02-oq-03",
+    "range": { "startLine": 64, "endLine": 89 },
+    "type": "lemma",
+    "title": "Rationals and negation: the compositum-free part of constructibility",
+    "content": "Two facts about the real predicate need NO field-compositum machinery. (1) Every rational q is a constructible real: it lies in the bottom intermediate field ⊥, whose degree over ℚ is 1 = 2⁰. (2) The constructible reals are closed under negation, witnessed by the SAME field K — because an intermediate field is closed under negation, the degree never grows. These are the seeds from which all the complex structural closure properties are built.",
+    "mathContext": "$q\\in\\bot$, $[\\bot:\\mathbb{Q}]=1=2^0$; and $\\alpha\\in K\\Rightarrow-\\alpha\\in K$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IntermediateField.finrank_bot", "IntermediateField.neg_mem"],
+    "prerequisites": ["intermediate fields", "finrank of the bottom field"]
+  },
+  {
+    "id": "ann-oq02oq02oq03-complex-structure",
+    "proofId": "angle-trisection-oq-02-oq-02-oq-03",
+    "range": { "startLine": 91, "endLine": 152 },
+    "type": "theorem",
+    "title": "Structural backbone of the complex constructible numbers",
+    "content": "Defining IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im, the file proves the closure properties that follow purely from real-part/imaginary-part identities plus negation closure — deliberately avoiding any field-degree arithmetic. It establishes that 0, 1, and the imaginary unit i are constructible; that a real number is a constructible real iff it is constructible as a complex number; that every Gaussian rational a + b·i is constructible; that conjugation preserves constructibility (Im(z̄) = −Im z, using negation closure); and that multiplication by i preserves it (Re(i·z) = −Im z, Im(i·z) = Re z).",
+    "mathContext": "Closure under conjugation and multiplication by $i$ reduces to negating one real coordinate; no compositum of fields is required.",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian rationals", "complex conjugation", "imaginary unit"],
+    "prerequisites": ["complex re/im algebra", "negation closure of constructible reals"]
+  },
+  {
+    "id": "ann-oq02oq02oq03-sin-bridge",
+    "proofId": "angle-trisection-oq-02-oq-02-oq-03",
+    "range": { "startLine": 154, "endLine": 166 },
+    "type": "insight",
+    "title": "The one analytic assumption: sin from cos",
+    "content": "The entire imaginary-axis content of the real→complex lift is isolated into a single axiom: for n ≥ 3, if cos(2π/n) is a constructible real then so is sin(2π/n). This is justified by sin(2π/n) = √(1 − cos²(2π/n)) ≥ 0 (since 2π/n ∈ (0,π) for n ≥ 3) together with the fact that the constructible reals form a field closed under non-negative square roots. It is the only new assumption beyond the parent's geometric axiom; discharging it requires the full field-closure of the constructible reals (compositum degree a power of two), which is left as future work.",
+    "mathContext": "$\\sin(2\\pi/n)=\\sqrt{1-\\cos^2(2\\pi/n)}\\ge0$ for $n\\ge3$.",
+    "significance": "critical",
+    "relatedConcepts": ["closure under square roots", "constructible reals as a field", "Pythagorean identity"],
+    "prerequisites": ["sin/cos on (0,π)", "square-root closure of constructible numbers"]
+  },
+  {
+    "id": "ann-oq02oq02oq03-headline",
+    "proofId": "angle-trisection-oq-02-oq-02-oq-03",
+    "range": { "startLine": 168, "endLine": 189 },
+    "type": "theorem",
+    "title": "Planar Gauss–Wantzel: ζₙ constructible ⟺ φ(n) a power of two",
+    "content": "Splitting exp(iθ) = cos θ + i·sin θ via Complex.exp_ofReal_mul_I_re/_im, the file first proves rootOfUnity_isConstructibleℂ_iff_cos: the vertex exp(2πi/n) is complex-constructible iff its real coordinate cos(2π/n) is a constructible real (the forward direction is immediate from the real part; the converse supplies the imaginary part via the sin-from-cos axiom). Chaining this with the parent's geometric bridge gauss_wantzel_theorem yields the headline ngon_vertex_isConstructibleℂ_iff: the regular n-gon vertex is constructible iff φ(n) is a power of two — the entire vertex, not merely its abscissa.",
+    "mathContext": "$\\exp(2\\pi i/n)$ constructible $\\iff\\cos(2\\pi/n)$ constructible $\\iff\\varphi(n)=2^k$.",
+    "significance": "critical",
+    "relatedConcepts": ["complex exponential", "Euler totient", "Gauss–Wantzel equivalence"],
+    "prerequisites": ["Complex.exp_ofReal_mul_I_re/_im", "the parent gauss_wantzel_theorem axiom"]
+  },
+  {
+    "id": "ann-oq02oq02oq03-instances",
+    "proofId": "angle-trisection-oq-02-oq-02-oq-03",
+    "range": { "startLine": 191, "endLine": 274 },
+    "type": "lemma",
+    "title": "Constructible and non-constructible vertices in the plane",
+    "content": "The headline equivalence is instantiated at concrete polygons, evaluating the relevant totients by kernel `decide` (no native_decide, hence no Lean.ofReduceBool dependency). Constructible vertices: 3-gon (φ=2), 4-gon (φ=2, the vertex i itself), 5-gon (φ=4), 15-gon (φ=8, with 15 = 3·5 distinct Fermat primes), 17-gon (φ=16, Gauss's 1796 polygon). Non-constructible vertices: 7-gon and 9-gon, both with φ = 6, which is not a power of two (9 = 3² exhibits a repeated Fermat prime).",
+    "mathContext": "$\\varphi(3,4,5,15,17)=2,2,4,8,16$ (powers of two); $\\varphi(7)=\\varphi(9)=6$ (not).",
+    "significance": "supporting",
+    "relatedConcepts": ["heptadecagon", "Fermat primes", "Euler totient values"],
+    "prerequisites": ["the headline equivalence", "evaluating φ by decide"]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "angle-trisection-oq-02-oq-02-oq-03",
+  "slug": "angle-trisection-oq-02-oq-02-oq-03",
+  "title": "Complex Constructibility Extension of Gauss–Wantzel: ζₙ constructible ⟺ φ(n) a power of two",
+  "description": "Lifts the Gauss–Wantzel constructibility theorem from the real coordinate cos(2π/n) to the plane ℂ, where the regular n-gon actually lives. A complex number z is declared constructible when both Re z and Im z are constructible reals (building on the parent's real predicate IsConstructibleFromQ). The entry proves the structural backbone of the complex constructible numbers that needs no field-compositum machinery — ℚ ⊆ constructibles (via the bottom field ⊥, [⊥:ℚ]=1=2⁰), closure under negation and complex conjugation, the constructibility of the imaginary unit i, of every Gaussian rational a+b·i, and of the real/imaginary embeddings, and closure under multiplication by i. The headline is the genuinely planar Gauss–Wantzel equivalence: the n-gon vertex exp(2πi/n) is complex-constructible iff φ(n) is a power of two, obtained by splitting exp(iθ)=cos θ + i·sin θ into real/imaginary parts and feeding the real coordinate to the parent's Gauss–Wantzel bridge. Concrete corollaries: the 3-, 4-, 5-, 15-, 17-gon vertices are constructible; the 7- and 9-gon vertices are not.",
+  "meta": {
+    "author": "Lean Genius Researcher-8",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ02OQ03.lean",
+    "tags": [
+      "angle-trisection",
+      "gauss-wantzel",
+      "complex-constructibility",
+      "roots-of-unity",
+      "constructibility",
+      "fermat-primes",
+      "field-theory",
+      "totient"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 2,
+    "lineCount": 274,
+    "theoremCount": 21,
+    "definitionCount": 1,
+    "assumptions": "Two axioms. (1) Inherited from the parent angle-trisection-oq-02-oq-02: GaussWantzel.gauss_wantzel_theorem, the geometric bridge that cos(2π/n) is constructible ⟺ φ(n) is a power of two. (2) New here: sin_constructible_of_cos — the single analytic fact that the constructible reals are closed under cos(2π/n) ↦ sin(2π/n) = √(1 − cos²(2π/n)) (a non-negative square root for n ≥ 3). This isolates exactly the imaginary-axis content of the real→complex lift. All 21 theorems are otherwise fully proved (0 sorries); the finite arithmetic facts (φ(3),φ(4),φ(5),φ(15),φ(17),φ(7),φ(9)) use kernel `decide`, not native_decide, so no Lean.ofReduceBool dependency. leanFile.axiomCount = 1 counts only the literal `axiom` declaration in this file; meta.axiomCount = 2 includes the inherited parent axiom that the headline equivalence rests on.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.exp_ofReal_mul_I_re",
+        "description": "Re(exp(↑x·i)) = cos x for real x",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Complex.exp_ofReal_mul_I_im",
+        "description": "Im(exp(↑x·i)) = sin x for real x",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "IntermediateField.finrank_bot",
+        "description": "[⊥:F] = 1, witnessing that rationals are constructible (degree 2⁰)",
+        "module": "Mathlib.FieldTheory.IntermediateField.Adjoin.Basic"
+      },
+      {
+        "theorem": "IntermediateField.neg_mem",
+        "description": "An intermediate field is closed under negation (no degree growth) — basis of negation/conjugation closure",
+        "module": "Mathlib.FieldTheory.IntermediateField.Basic"
+      },
+      {
+        "theorem": "IntermediateField.algebraMap_mem",
+        "description": "The image of the base field lies in every intermediate field",
+        "module": "Mathlib.FieldTheory.IntermediateField.Basic"
+      },
+      {
+        "theorem": "Nat.totient",
+        "description": "Euler's totient, evaluated by kernel decide on the worked instances",
+        "module": "Mathlib.Data.Nat.Totient"
+      }
+    ],
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AngleTrisectionOQ02OQ02"
+    ],
+    "opens": [
+      "GaussWantzel"
+    ],
+    "namespace": "ComplexGaussWantzel",
+    "lineCount": 274,
+    "axiomCount": 1,
+    "theoremCount": 21,
+    "definitionCount": 1,
+    "path": "Proofs/AngleTrisectionOQ02OQ02OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "ngon_vertex_isConstructibleℂ_iff",
+      "type": "headline",
+      "statement": "3 ≤ n → (IsConstructibleℂ (exp(2πi/n)) ↔ ∃ k, φ(n) = 2^k)",
+      "description": "Planar Gauss–Wantzel: the regular n-gon vertex exp(2πi/n) ∈ ℂ is complex-constructible iff φ(n) is a power of two — the genuinely two-dimensional form of the theorem (the entire vertex, not just its abscissa cos(2π/n)).",
+      "significance": "Lifts the parent's real characterization to the plane where the polygon lives, via exp(iθ)=cos θ+i sin θ and the analytic sin-from-cos bridge."
+    },
+    {
+      "name": "rootOfUnity_isConstructibleℂ_iff_cos",
+      "type": "core",
+      "statement": "3 ≤ n → (IsConstructibleℂ (exp(2πi/n)) ↔ IsConstructibleFromQ (cos(2π/n)))",
+      "description": "The vertex exp(2πi/n) is complex-constructible iff its real coordinate cos(2π/n) is a constructible real. Forward is immediate (real part); the converse supplies the imaginary part via sin_constructible_of_cos.",
+      "significance": "The bridge that reduces complex constructibility of roots of unity to the parent's real predicate."
+    },
+    {
+      "name": "IsConstructibleℂ.conj",
+      "type": "structural",
+      "statement": "IsConstructibleℂ z → IsConstructibleℂ (conj z)",
+      "description": "Closure under complex conjugation: Re(z̄)=Re z and Im(z̄)=−Im z, with the constructible reals closed under negation (an intermediate field is closed under negation, so no degree growth).",
+      "significance": "One of the compositum-free structural closure properties of the complex constructible numbers."
+    },
+    {
+      "name": "isConstructibleℂ_ratGaussian",
+      "type": "structural",
+      "statement": "∀ a b : ℚ, IsConstructibleℂ (a + b·i)",
+      "description": "Every Gaussian rational is constructible, witnessed by the bottom field ⊥ for each rational coordinate.",
+      "significance": "Identifies ℚ(i) ∩ Gaussian rationals inside the complex constructibles without any field-degree computation."
+    },
+    {
+      "name": "vertex7_not_constructibleℂ",
+      "type": "corollary",
+      "statement": "¬ IsConstructibleℂ (exp(2πi/7))",
+      "description": "The heptagon vertex is not constructible because φ(7)=6 is not a power of two — a planar instance of non-constructibility.",
+      "significance": "Demonstrates the negative direction of the planar characterization."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Gauss showed in 1796 that the regular 17-gon is constructible and stated in Disquisitiones Arithmeticae (1801) that a regular n-gon is constructible iff n = 2^a · (product of distinct Fermat primes); Wantzel proved necessity in 1837. Classically the polygon is drawn in the Euclidean plane, identified with ℂ, and its vertices are the n-th roots of unity ζₙᵏ = exp(2πik/n). The parent entry formalizes the theorem through the single real coordinate cos(2π/n); this entry restores the planar (complex) picture by working with the full vertex ζₙ.",
+    "keyInsight": "A point z ∈ ℂ is constructible exactly when its two real coordinates Re z and Im z are constructible reals. For a root of unity ζₙ = cos(2π/n) + i·sin(2π/n), constructibility of the real part is the parent's whole story, and the imaginary part sin(2π/n) = √(1 − cos²(2π/n)) is determined by it via a single non-negative square root. Hence the planar characterization collapses onto the real one, and the φ(n)-power-of-two criterion governs both.",
+    "approach": "Define IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im. Prove the compositum-free structural facts (rationals/0/1, negation, conjugation, i, Gaussian rationals, real embedding, multiplication by i). Split exp(iθ) into re=cos, im=sin via Complex.exp_ofReal_mul_I_re/_im; combine the parent's geometric axiom with the analytic sin-from-cos axiom to obtain the headline equivalence; instantiate it at 3,4,5,15,17 (constructible) and 7,9 (not)."
+  },
+  "sections": [
+    {
+      "id": "rationals-negation",
+      "title": "Part I: Rationals and negation are constructible",
+      "summary": "isConstructibleFromQ_rat: every rational is a constructible real (witnessed by ⊥, degree 1=2⁰). isConstructibleFromQ_zero/one. isConstructibleFromQ_neg: the constructible reals are closed under negation, reusing the same field K (an intermediate field is closed under negation).",
+      "mathContext": "$q\\in\\mathbb{Q}$ lies in $\\bot$ with $[\\bot:\\mathbb{Q}]=1=2^0$; closure under negation needs no compositum since $\\alpha\\in K\\Rightarrow-\\alpha\\in K$."
+    },
+    {
+      "id": "complex-constructibility",
+      "title": "Part II: Complex constructibility",
+      "summary": "IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im. Proves 0, 1, i constructible; the real/imaginary embedding iff; Gaussian rationals; conjugation closure and its iff; closure under multiplication by i (Re(i·z)=−Im z, Im(i·z)=Re z).",
+      "mathContext": "The structural backbone of the complex constructibles obtainable purely from real-part/imaginary-part identities plus negation closure — no field-degree arithmetic."
+    },
+    {
+      "id": "analytic-bridge",
+      "title": "Part III: The analytic bridge (sin from cos)",
+      "summary": "axiom sin_constructible_of_cos: for n ≥ 3, IsConstructibleFromQ (cos(2π/n)) → IsConstructibleFromQ (sin(2π/n)). The only new assumption, capturing closure of the constructible reals under the non-negative square root sin(2π/n)=√(1−cos²(2π/n)).",
+      "mathContext": "For $n\\ge3$, $2\\pi/n\\in(0,\\pi)$ so $\\sin(2\\pi/n)\\ge0$; the constructible reals form a field closed under square roots, which supplies the imaginary coordinate."
+    },
+    {
+      "id": "headline",
+      "title": "Part IV: The headline — planar Gauss–Wantzel",
+      "summary": "rootOfUnity_isConstructibleℂ_iff_cos: vertex constructible ↔ cos(2π/n) constructible. ngon_vertex_isConstructibleℂ_iff: vertex constructible ↔ φ(n) a power of two (combining the cos bridge with the parent's gauss_wantzel_theorem).",
+      "mathContext": "$\\exp(2\\pi i/n)=\\cos(2\\pi/n)+i\\sin(2\\pi/n)$; constructibility of the complex vertex is equivalent to that of its real coordinate, hence to $\\varphi(n)=2^k$."
+    },
+    {
+      "id": "instances",
+      "title": "Parts V–VI: Constructible and non-constructible vertices",
+      "summary": "Constructible: 3-, 4-, 5-, 15-, 17-gon vertices (φ = 2,2,4,8,16). Not constructible: 7- and 9-gon vertices (φ(7)=φ(9)=6, not a power of two). All via kernel decide on the totients.",
+      "mathContext": "Worked planar instances derived from the headline equivalence."
+    }
+  ],
+  "conclusion": {
+    "summary": "Gauss–Wantzel is recast in its native planar setting: the vertex exp(2πi/n) of the regular n-gon in ℂ is constructible exactly when φ(n) is a power of two. The complex constructibility predicate is built on the parent's real predicate, with its compositum-free structural closure properties (rationals, negation, conjugation, i, Gaussian rationals, multiplication by i) proved outright, and the real→complex lift isolated into a single analytic axiom (sin from cos) on top of the parent's geometric axiom.",
+    "significance": "Restores the two-dimensional geometric content of Gauss–Wantzel that a single real coordinate hides, and exposes exactly what extra analytic input (one non-negative square root) the imaginary axis costs.",
+    "futureDirections": "Prove the full field-closure of the constructible reals (compositum degree = power of two) to discharge sin_constructible_of_cos and upgrade the entry to 0 new axioms; characterize the constructible complex numbers as the largest subfield of ℂ obtained by iterated quadratic extensions of ℚ(i)."
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "The parent states Gauss–Wantzel for the real coordinate cos(2π/n) with the geometric bridge axiomatized; this child lifts the predicate and the characterization to the complex plane, reusing that bridge."
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-02-oq-02",
+      "relationship": "sibling",
+      "description": "The sibling proves the purely number-theoretic core (φ(n) a power of two ⟺ squarefree odd part of distinct Fermat primes) with 0 axioms; together they cover the arithmetic and the planar-geometric faces of the same theorem."
+    },
+    {
+      "targetId": "angle-trisection-oq-02",
+      "relationship": "ancestor",
+      "description": "The grandparent characterizes constructible algebraic numbers via 2-group Galois groups; complex constructibility here is the concrete planar manifestation for roots of unity."
+    }
+  ],
+  "references": [
+    {
+      "title": "Disquisitiones Arithmeticae",
+      "author": "C. F. Gauss",
+      "year": 1801,
+      "note": "Section VII; constructibility of regular polygons and Fermat primes."
+    },
+    {
+      "title": "Recherches sur les moyens de reconnaître si un problème de Géométrie peut se résoudre avec la règle et le compas",
+      "author": "P. Wantzel",
+      "year": 1837,
+      "note": "Necessity of the φ(n)-power-of-two condition."
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/proofs/cantors-theorem-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-cantorsoq0104-setup",
+    "proofId": "cantors-theorem-oq-01-oq-04",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "Setup: Extending the Beth Tower over ℝ to ℶ₃",
+    "content": "This file resolves open question #4 of cantors-theorem-oq-01, which had established |𝒫(ℝ)| = ℶ₂: the follow-up asks whether the next iterated power set lands on the next beth number, |𝒫(𝒫(ℝ))| = ℶ₃. It does, and provably in ZFC. The conceptual payoff is the contrast drawn in the docstring: the BETH-index of an iterated power set of ℝ is fixed by definition (the beth function is ℶ_{α+1} = 2^{ℶ_α}, exactly the power-set operation), whereas the ALEPH-index of the same cardinal is independent of ZFC (Easton's theorem). Mathlib has all the cardinal-arithmetic pieces but not this identity."
+  },
+  {
+    "id": "ann-cantorsoq0104-beth-successors",
+    "proofId": "cantors-theorem-oq-01-oq-04",
+    "range": { "startLine": 43, "endLine": 55 },
+    "type": "lemma",
+    "title": "§1 — Beth Successor Unfoldings ℶ₂ = 2^ℶ₁, ℶ₃ = 2^ℶ₂",
+    "content": "beth_two_eq and beth_three_eq unfold the beth function at the concrete indices 2 and 3. The only nontrivial step is recognizing the numeral as an ordinal successor — (2 : Ordinal) = Order.succ 1 and (3 : Ordinal) = Order.succ 2, each discharged by Order.succ_eq_add_one + norm_num — after which Cardinal.beth_succ (ℶ_(succ o) = 2^ℶ_o) gives the doubling. These are the two rungs of the climb |𝒫(𝒫(ℝ))| → 2^|𝒫(ℝ)| → 2^(2^|ℝ|)."
+  },
+  {
+    "id": "ann-cantorsoq0104-lower-rungs",
+    "proofId": "cantors-theorem-oq-01-oq-04",
+    "range": { "startLine": 56, "endLine": 67 },
+    "type": "lemma",
+    "title": "§2 — Lower Rungs: |ℝ| = ℶ₁ and |𝒫(ℝ)| = ℶ₂",
+    "content": "card_real_eq_beth_one chains Cardinal.mk_real (#ℝ = 𝔠) with Cardinal.beth_one (ℶ₁ = 𝔠) to get #ℝ = ℶ₁. card_powerSet_real_eq_beth_two then re-derives the parent's headline result: Cardinal.mk_set gives #(Set ℝ) = 2^#ℝ, rewriting #ℝ = ℶ₁ and beth_two_eq (ℶ₂ = 2^ℶ₁) matches both sides. Re-deriving these here keeps the file self-contained (no import of the parent entry, whose olean would otherwise be a build dependency)."
+  },
+  {
+    "id": "ann-cantorsoq0104-main",
+    "proofId": "cantors-theorem-oq-01-oq-04",
+    "range": { "startLine": 68, "endLine": 72 },
+    "type": "theorem",
+    "title": "§3 — Main Result: |𝒫(𝒫(ℝ))| = ℶ₃",
+    "content": "card_powerSet_powerSet_real_eq_beth_three: a three-rewrite proof. Cardinal.mk_set applied to the outer power set gives #(Set (Set ℝ)) = 2^#(Set ℝ); card_powerSet_real_eq_beth_two (§2) rewrites #(Set ℝ) = ℶ₂ to reach 2^ℶ₂; beth_three_eq (§1) rewrites ℶ₃ = 2^ℶ₂, matching the two sides. Numerically this is |𝒫(𝒫(ℝ))| = 2^(2^(2^ℵ₀)) = ℶ₃."
+  },
+  {
+    "id": "ann-cantorsoq0104-towers",
+    "proofId": "cantors-theorem-oq-01-oq-04",
+    "range": { "startLine": 74, "endLine": 92 },
+    "type": "lemma",
+    "title": "§4 — Strict Cantor and Beth Towers",
+    "content": "card_real_lt_powerSet (|ℝ| < |𝒫(ℝ)|) and card_powerSet_real_lt_powerSet_powerSet (|𝒫(ℝ)| < |𝒫(𝒫(ℝ))|) are instances of Cardinal.cantor (κ < 2^κ): rewrite the appropriate power set with mk_set, then apply cantor. (For the second, the rewrite must target the right-hand #(Set (Set ℝ)), supplied via an explicit have, since mk_set would otherwise match the left side first.) beth_tower_strictMono gives ℶ₁ < ℶ₂ < ℶ₃ from Cardinal.beth_strictMono applied to the ordinal inequalities 1 < 2 and 2 < 3."
+  },
+  {
+    "id": "ann-cantorsoq0104-summary",
+    "proofId": "cantors-theorem-oq-01-oq-04",
+    "range": { "startLine": 93, "endLine": 102 },
+    "type": "theorem",
+    "title": "§5 — Summary",
+    "content": "cantors_theorem_oq01oq04_summary packages the three ZFC-provable facts as one conjunction: the main identity |𝒫(𝒫(ℝ))| = ℶ₃, the strict Cantor tower |ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))|, and the strict beth tower ℶ₁ < ℶ₂ < ℶ₃. #print axioms confirms only the foundational propext, Classical.choice, Quot.sound."
+  }
+]

--- a/src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-04/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "cantors-theorem-oq-01-oq-04",
+  "title": "|𝒫(𝒫(ℝ))| = ℶ₃: The Third Beth Number",
+  "slug": "cantors-theorem-oq-01-oq-04",
+  "description": "Open question #4 of cantors-theorem-oq-01 ('The Cardinality of 𝒫(ℝ)', which proved |𝒫(ℝ)| = ℶ₂) asks for the next rung of the beth tower: is |𝒫(𝒫(ℝ))| = ℶ₃? The answer is yes, provable outright in ZFC, and this entry gives a fully machine-checked Lean 4 proof. Applying Cantor's power-set cardinality law (Cardinal.mk_set : #(Set α) = 2^#α) twice gives |𝒫(𝒫(ℝ))| = 2^|𝒫(ℝ)| = 2^(2^|ℝ|) = 2^(2^(2^ℵ₀)), and unfolding the beth successor function (Cardinal.beth_succ : ℶ_(o+1) = 2^ℶ_o) twice from ℶ₁ = 𝔠 = |ℝ| identifies this with ℶ₃. The contrast with the parent's open question is the point: the ALEPH-index of these iterated power sets is independent of ZFC (Easton's theorem), but the BETH-index is pinned down by definition — every iterated power set of ℝ lands exactly on a beth number. The entry also records the strict Cantor tower |ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))| and the strictly increasing beth tower ℶ₁ < ℶ₂ < ℶ₃.",
+  "meta": {
+    "author": "Georg Cantor (1891); beth hierarchy: Felix Hausdorff (1908)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorsTheoremOQ01OQ04.lean",
+    "tags": [
+      "set-theory",
+      "cardinal-arithmetic",
+      "beth-numbers",
+      "power-set",
+      "cantor-theorem",
+      "continuum",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 102,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib 4.29 (single-file elaboration via `lake env lean Proofs/CantorsTheoremOQ01OQ04.lean`, exit 0; `#print axioms CantorsTheoremOQ01OQ04.card_powerSet_powerSet_real_eq_beth_three` and the summary theorem list only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). The proof is built entirely from standard Mathlib cardinal-arithmetic lemmas: Cardinal.mk_set (#(Set α) = 2^#α), Cardinal.mk_real (#ℝ = 𝔠), Cardinal.beth_one (ℶ₁ = 𝔠), Cardinal.beth_succ (ℶ_(succ o) = 2^ℶ_o), Cardinal.cantor (κ < 2^κ), and Cardinal.beth_strictMono. The result |𝒫(𝒫(ℝ))| = ℶ₃ is NOT in Mathlib and is assembled here; the file is self-contained (re-deriving the ℶ₁/ℶ₂ rungs) and does not import the parent entry.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.29",
+    "originalContributions": [
+      "A complete, axiom-free Lean 4 proof that |𝒫(𝒫(ℝ))| = ℶ₃, the third beth number — advancing the beth tower of cantors-theorem-oq-01 by one rung from |𝒫(ℝ)| = ℶ₂.",
+      "The explicit beth-successor unfoldings beth_two_eq (ℶ₂ = 2^ℶ₁) and beth_three_eq (ℶ₃ = 2^ℶ₂) at concrete ordinal indices, together with card_real_eq_beth_one (|ℝ| = ℶ₁), giving a self-contained derivation of the whole tower ℶ₁, ℶ₂, ℶ₃ as iterated power sets of ℝ.",
+      "The strict Cantor tower |ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))| (card_real_lt_powerSet, card_powerSet_real_lt_powerSet_powerSet) and the strictly increasing beth tower ℶ₁ < ℶ₂ < ℶ₃ (beth_tower_strictMono), packaged with the main identity in cantors_theorem_oq01oq04_summary."
+    ],
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cantor's theorem (1891) — that no set surjects onto its power set, hence κ < 2^κ for every cardinal κ — generates an unbounded tower of cardinalities by iteration. Hausdorff later organized these into the beth hierarchy ℶ₀ = ℵ₀, ℶ_{α+1} = 2^{ℶ_α} (with suprema at limits), the canonical 'powers of two' scale of infinity. The parent entry cantors-theorem-oq-01 established |𝒫(ℝ)| = ℶ₂ and highlighted that while the beth-index of 2^𝔠 is determined, its aleph-index is independent of ZFC (Gödel 1938, Cohen 1963, Easton 1970). This entry takes the next deterministic step: the second power set of ℝ is exactly ℶ₃.",
+    "problemStatement": "Show that the power set of the power set of the reals has cardinality the third beth number: $|\\mathcal{P}(\\mathcal{P}(\\mathbb{R}))| = \\beth_3 = 2^{2^{2^{\\aleph_0}}}$.",
+    "text": "The main theorem `card_powerSet_powerSet_real_eq_beth_three : #(Set (Set ℝ)) = beth 3`, supported by the beth-successor unfoldings and lower-rung identities, plus the strict Cantor and beth towers and a summary theorem `cantors_theorem_oq01oq04_summary`.",
+    "proofStrategy": "Two applications of the power-set law. Cardinal.mk_set gives #(Set (Set ℝ)) = 2^#(Set ℝ); the parent-style lemma card_powerSet_real_eq_beth_two (re-derived here as #(Set ℝ) = 2^#ℝ = 2^ℶ₁ = ℶ₂) gives #(Set ℝ) = ℶ₂; so #(Set (Set ℝ)) = 2^ℶ₂. Unfolding the beth tower. beth_three_eq rewrites ℶ₃ as 2^ℶ₂ by expressing the ordinal 3 as succ 2 and applying Cardinal.beth_succ; matching the two yields the identity. The lower rungs use Cardinal.mk_real (#ℝ = 𝔠) and Cardinal.beth_one (ℶ₁ = 𝔠) for #ℝ = ℶ₁, and beth_two_eq (3 ↦ succ, beth_succ) for ℶ₂ = 2^ℶ₁. Strict towers. The Cantor inequalities are direct instances of Cardinal.cantor (κ < 2^κ) after rewriting each power set by mk_set; the beth tower ℶ₁ < ℶ₂ < ℶ₃ follows from Cardinal.beth_strictMono applied to 1 < 2 and 2 < 3.",
+    "keyInsights": [
+      "Iterated power sets of ℝ march up the beth tower one rung at a time: |ℝ| = ℶ₁, |𝒫(ℝ)| = ℶ₂, |𝒫(𝒫(ℝ))| = ℶ₃, because each power set doubles the exponent and the beth function is defined by exactly that doubling, ℶ_{α+1} = 2^{ℶ_α}.",
+      "The beth-index is absolute where the aleph-index is not. Whether |𝒫(𝒫(ℝ))| equals ℵ₃ (or any particular aleph) is independent of ZFC, but that it equals ℶ₃ is a definitional certainty — this is the cleanest illustration of why set theorists use the beth scale to name 2^κ-style cardinals.",
+      "Pinning the beth successor to a concrete numeral requires only the tiny ordinal fact 3 = succ 2 (and 2 = succ 1); once Cardinal.beth_succ is applied the cardinal computation is purely formal.",
+      "Cantor's strict inequality κ < 2^κ, applied at κ = #ℝ and κ = #(Set ℝ), gives the strict containment chain |ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))| for free, matching the strict monotonicity of the beth function."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib: #, the cardinality of a type, and cardinal exponentiation 2^κ",
+      "The power-set cardinality law |𝒫(α)| = 2^|α| (Cardinal.mk_set)",
+      "The beth function ℶ on ordinals: ℶ₀ = ℵ₀, ℶ_{α+1} = 2^{ℶ_α}, and ℶ₁ = 𝔠 (Cardinal.beth_one)",
+      "Cantor's theorem κ < 2^κ (Cardinal.cantor) and strict monotonicity of beth (Cardinal.beth_strictMono)",
+      "The cardinality of the reals #ℝ = 𝔠 = 2^ℵ₀ (Cardinal.mk_real)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Statement and the Beth Tower",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring framing open question #4 of cantors-theorem-oq-01: extend |𝒫(ℝ)| = ℶ₂ to |𝒫(𝒫(ℝ))| = ℶ₃, noting that the beth-index is ZFC-determined whereas the aleph-index is independent. Imports Mathlib and opens Cardinal in namespace CantorsTheoremOQ01OQ04.",
+      "mathContext": "The beth tower ℶ₀ = ℵ₀, ℶ₁ = 𝔠 = |ℝ|, ℶ₂ = |𝒫(ℝ)|, ℶ₃ = |𝒫(𝒫(ℝ))|, each level the power set of the previous one."
+    },
+    {
+      "id": "beth-successors",
+      "title": "§1: Beth Successor Unfoldings",
+      "startLine": 43,
+      "endLine": 55,
+      "summary": "beth_two_eq (ℶ₂ = 2^ℶ₁) and beth_three_eq (ℶ₃ = 2^ℶ₂), each proved by writing the ordinal index as a successor (2 = succ 1, 3 = succ 2 via Order.succ_eq_add_one + norm_num) and applying Cardinal.beth_succ.",
+      "mathContext": "$\\beth_{o+1} = 2^{\\beth_o}$; specializing at $o = 1, 2$ gives the two doublings used to climb the tower."
+    },
+    {
+      "id": "lower-rungs",
+      "title": "§2: Lower Rungs |ℝ| = ℶ₁ and |𝒫(ℝ)| = ℶ₂",
+      "startLine": 56,
+      "endLine": 67,
+      "summary": "card_real_eq_beth_one (#ℝ = ℶ₁ via Cardinal.mk_real and Cardinal.beth_one) and card_powerSet_real_eq_beth_two (#(Set ℝ) = 2^#ℝ = 2^ℶ₁ = ℶ₂ via mk_set + beth_two_eq), re-deriving the parent result so the file stands alone.",
+      "mathContext": "$|\\mathbb{R}| = \\mathfrak{c} = \\beth_1$ and $|\\mathcal{P}(\\mathbb{R})| = 2^{\\beth_1} = \\beth_2$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "§3: Main Result |𝒫(𝒫(ℝ))| = ℶ₃",
+      "startLine": 68,
+      "endLine": 72,
+      "summary": "card_powerSet_powerSet_real_eq_beth_three: #(Set (Set ℝ)) = 2^#(Set ℝ) = 2^ℶ₂ = ℶ₃, applying Cardinal.mk_set to the second power set, then card_powerSet_real_eq_beth_two and beth_three_eq.",
+      "mathContext": "$|\\mathcal{P}(\\mathcal{P}(\\mathbb{R}))| = 2^{\\beth_2} = \\beth_3 = 2^{2^{2^{\\aleph_0}}}$."
+    },
+    {
+      "id": "cantor-tower",
+      "title": "§4: Strict Cantor and Beth Towers",
+      "startLine": 74,
+      "endLine": 92,
+      "summary": "card_real_lt_powerSet (|ℝ| < |𝒫(ℝ)|) and card_powerSet_real_lt_powerSet_powerSet (|𝒫(ℝ)| < |𝒫(𝒫(ℝ))|), each from Cardinal.cantor after rewriting the relevant power set by mk_set; beth_tower_strictMono (ℶ₁ < ℶ₂ < ℶ₃) from Cardinal.beth_strictMono on 1 < 2 and 2 < 3.",
+      "mathContext": "Cantor's $\\kappa < 2^\\kappa$ gives the strict chain $|\\mathbb{R}| < |\\mathcal{P}(\\mathbb{R})| < |\\mathcal{P}(\\mathcal{P}(\\mathbb{R}))|$, mirrored by the strict monotonicity $\\beth_1 < \\beth_2 < \\beth_3$."
+    },
+    {
+      "id": "summary",
+      "title": "§5: Summary",
+      "startLine": 93,
+      "endLine": 102,
+      "summary": "cantors_theorem_oq01oq04_summary bundles the three facts: |𝒫(𝒫(ℝ))| = ℶ₃, the Cantor tower |ℝ| < |𝒫(ℝ)| < |𝒫(𝒫(ℝ))|, and the beth tower ℶ₁ < ℶ₂ < ℶ₃.",
+      "mathContext": "A single conjunction recording the ZFC-provable structure of the second power set of ℝ."
+    }
+  ],
+  "conclusion": {
+    "summary": "|𝒫(𝒫(ℝ))| = ℶ₃ is established for the reals, fully machine-checked and axiom-free (only propext / Classical.choice / Quot.sound), advancing the parent entry's beth tower by one rung. The proof is two applications of |𝒫(α)| = 2^|α| matched against two unfoldings of the beth successor, and it records the accompanying strict Cantor and beth towers.",
+    "openQuestions": [
+      "Generalize to a single theorem |𝒫^{(n)}(ℝ)| = ℶ_{n+1} for all n by induction on n, formalizing the n-fold iterated power set (e.g. via a recursively defined type family) — turning the n = 1, 2 (parent) and n = 2 (this entry) cases into a uniform statement of the beth tower over ℝ.",
+      "The aleph-index of ℶ₃ (whether |𝒫(𝒫(ℝ))| = ℵ₃) is independent of ZFC, the higher-level analogue of the parent's open question; formalizing the Easton-theorem obstruction that prevents pinning it down would be a substantially deeper set-theoretic project."
+    ],
+    "implications": "Completes the third rung of the explicit beth tower over ℝ in the gallery (ℶ₁ = |ℝ|, ℶ₂ = |𝒫(ℝ)|, ℶ₃ = |𝒫(𝒫(ℝ))|), and supplies reusable concrete beth-successor unfoldings (beth_two_eq, beth_three_eq) and the cardinality identities for iterated power sets of ℝ. It sharpens the parent's central contrast — beth-index determined, aleph-index independent — by exhibiting the next deterministic level."
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantors-theorem-oq-01",
+      "relationship": "parent-problem",
+      "description": "Direct parent: proves |𝒫(ℝ)| = ℶ₂ and poses, as its open question #4, whether |𝒫(𝒫(ℝ))| = ℶ₃ (answered yes here). This entry re-derives the parent's ℶ₂ rung so as to stand alone."
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "ancestor",
+      "description": "Cantor's theorem κ < 2^κ is the engine generating the entire tower; each rung is one application of it, here instantiated twice for ℝ and 𝒫(ℝ)."
+    }
+  ],
+  "references": [
+    {
+      "author": "Cantor, G.",
+      "title": "Über eine elementare Frage der Mannigfaltigkeitslehre",
+      "year": 1891,
+      "note": "Cantor's theorem: no set surjects onto its power set, so κ < 2^κ"
+    },
+    {
+      "author": "Hausdorff, F.",
+      "title": "Grundzüge einer Theorie der geordneten Mengen",
+      "year": 1908,
+      "note": "Develops the beth/aleph cardinal hierarchies used to name 2^κ-style cardinals"
+    },
+    {
+      "author": "Jech, T.",
+      "title": "Set Theory, 3rd Millennium ed.",
+      "year": 2003,
+      "note": "Standard reference for the beth hierarchy, Cantor's theorem, and the ZFC-independence of the aleph-indices (Easton's theorem)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "CantorsTheoremOQ01OQ04",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CantorsTheoremOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Complex Constructibility Extension of Gauss–Wantzel

Problem: **angle-trisection-oq-02-oq-02-oq-03** (tier B, significance 7) — lift the Gauss–Wantzel constructibility theorem from the real coordinate `cos(2π/n)` to the plane `ℂ`, where the regular `n`-gon actually lives (vertices = `n`-th roots of unity `ζₙᵏ = exp(2πik/n)`).

### What is proved

Define complex constructibility on top of the parent's real predicate:
```
IsConstructibleℂ z := IsConstructibleFromQ z.re ∧ IsConstructibleFromQ z.im
```

**Structural backbone (no field-compositum machinery, fully proved, foundational axioms only):**
- every rational / `0` / `1` is a constructible real (via the bottom field `⊥`, `[⊥:ℚ]=1=2⁰`);
- the constructible reals are closed under **negation** (same field — an intermediate field is closed under negation);
- `0, 1, i` constructible; real ↔ complex embedding; every **Gaussian rational** `a+b·i` constructible;
- closure under **complex conjugation** and under **multiplication by `i`**.

**Headline — planar Gauss–Wantzel:**
```
ngon_vertex_isConstructibleℂ_iff :
  3 ≤ n → (IsConstructibleℂ (exp(2πi/n)) ↔ ∃ k, φ(n) = 2^k)
```
obtained by splitting `exp(iθ)=cos θ + i·sin θ` (`Complex.exp_ofReal_mul_I_re/_im`) and feeding the real coordinate to the parent's geometric bridge.

**Concrete vertices:** 3-, 4-, 5-, 15-, 17-gon constructible; 7-, 9-gon not (`decide`, no `native_decide`).

### Status: axiomatized (2 axioms)

`#print axioms` on the headline → `propext, Classical.choice, Quot.sound` (foundational, uncounted) plus:
1. `GaussWantzel.gauss_wantzel_theorem` — **inherited** from parent `angle-trisection-oq-02-oq-02` (geometric bridge `cos(2π/n)` constructible ⟺ `φ(n)=2^k`).
2. `sin_constructible_of_cos` — **new**, the single analytic fact that the constructible reals are closed under `cos(2π/n) ↦ sin(2π/n) = √(1−cos²(2π/n))` (`n ≥ 3`). Isolates exactly the imaginary-axis content of the lift.

No `Lean.ofReduceBool` (kernel `decide` only), no `sorryAx`. The pure structural results (e.g. `isConstructibleℂ_ratGaussian`) depend on the 3 foundational axioms only.

### Verification
- 274 lines, 21 theorems, 1 definition, 0 sorries; `leanFile.axiomCount=1` (literal `axiom`), `meta.axiomCount=2` (incl. inherited).
- Compiled offline against Mathlib v4.26.0 + parent olean (`lake env lean`, exit 0, no warnings).

### Files
- `proofs/Proofs/AngleTrisectionOQ02OQ02OQ03.lean`
- `proofs/Proofs.lean` (import)
- `src/data/proofs/angle-trisection-oq-02-oq-02-oq-03/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)