### PR TITLE
Research: erdos-877 — rehabilitate Counting Maximal Sum-Free Subsets (4→2 sorries)

### DIFF
--- a/proofs/Proofs/Erdos877Problem.lean
+++ b/proofs/Proofs/Erdos877Problem.lean
@@ -23,14 +23,10 @@ References:
 - [BLST18]: Balogh et al. "Sharp bound on maximal sum-free subsets" (2018)
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Finset.Card
-import Mathlib.Data.Set.Basic
-import Mathlib.Order.Partition.Finpartition
-import Mathlib.Analysis.Asymptotics.Asymptotics
+import Mathlib
 
 open Nat Finset
+open scoped Classical
 
 namespace Erdos877
 
@@ -94,17 +90,60 @@ def isMaximalSumFree (n : ℕ) (A : Finset ℕ) : Prop :=
 
 /--
 **Property of maximal sum-free sets:**
-For a maximal sum-free A ⊆ {1,...,n}, every x ∉ A either:
+For a maximal sum-free A ⊆ {1,...,n}, every positive x ∉ A either:
 - Has x = a + b for some a, b ∈ A, or
-- Has a = x + b or b = x + a for some a, b ∈ A
+- Has a = x + b for some a, b ∈ A, or
+- Has x + x = a for some a ∈ A.
+
+The positivity hypothesis `0 < x` is necessary: for `x = 0`, the trivial
+sum `0 = 0 + 0` witnesses `¬ isSumFree (insert 0 A)` for *any* maximal `A`
+(indeed any sum-free `A`, since `0 ∉ A`), so none of the three structural
+conclusions need hold (e.g. `A = ∅` is maximal sum-free for `n = 0`).
 -/
 theorem maximal_criterion (n : ℕ) (A : Finset ℕ)
     (hmax : isMaximalSumFree n A) (x : ℕ) (hx : x ∈ Finset.range (n + 1))
-    (hxA : x ∉ A) :
+    (hxpos : 0 < x) (hxA : x ∉ A) :
     (∃ a b : ℕ, a ∈ A ∧ b ∈ A ∧ x = a + b) ∨
     (∃ a b : ℕ, a ∈ A ∧ b ∈ A ∧ a = x + b) ∨
     (∃ a : ℕ, a ∈ A ∧ x + x = a) := by
-  sorry
+  obtain ⟨hsub, hsf, hmaximal⟩ := hmax
+  have hns := hmaximal x hx hxA
+  -- `A` is sum-free, hence `0 ∉ A` (else `0 = 0 + 0` is a forbidden sum).
+  have h0 : (0 : ℕ) ∉ A := fun h => hsf 0 0 0 h h h rfl
+  unfold isSumFree at hns
+  push_neg at hns
+  obtain ⟨a, b, c, ha, hb, hc, heq⟩ := hns
+  simp only [Finset.mem_insert] at ha hb hc
+  -- A genuine sum `a = b + c` in `insert x A` must involve the new element `x`,
+  -- since `A` itself is sum-free.
+  rcases ha with rfl | ha
+  · -- a = x
+    rcases hb with rfl | hb
+    · -- b = x, so x = x + c forces c = 0, impossible (c = x > 0 or 0 ∈ A)
+      exfalso
+      rcases hc with rfl | hc
+      · omega
+      · have : c = 0 := by omega
+        exact h0 (this ▸ hc)
+    · -- b ∈ A, x = b + c
+      rcases hc with rfl | hc
+      · -- c = x ⇒ b = 0 ∈ A, contradiction
+        have hb0 : b = 0 := by omega
+        exact absurd (hb0 ▸ hb) h0
+      · exact Or.inl ⟨b, c, hb, hc, heq⟩
+  · -- a ∈ A
+    rcases hb with rfl | hb
+    · -- b = x, a = x + c
+      rcases hc with rfl | hc
+      · -- c = x, a = x + x
+        exact Or.inr (Or.inr ⟨a, ha, heq.symm⟩)
+      · exact Or.inr (Or.inl ⟨a, c, ha, hc, heq⟩)
+    · -- b ∈ A
+      rcases hc with rfl | hc
+      · -- c = x, a = b + x = x + b
+        exact Or.inr (Or.inl ⟨a, b, ha, hb, by omega⟩)
+      · -- c ∈ A: a = b + c with a,b,c ∈ A contradicts sum-freeness
+        exact absurd heq (hsf a b c ha hb hc)
 
 /-
 ## Part III: Counting Functions
@@ -157,7 +196,19 @@ theorem odds_construction (n : ℕ) : ∃ A : Finset ℕ,
     A ⊆ Finset.range (n + 1) ∧
     isSumFree A ∧
     A.card ≥ n / 2 := by
-  sorry
+  -- The upper half {⌊n/2⌋+1, ..., n} is sum-free (smallest sum exceeds n)
+  -- and has cardinality n - ⌊n/2⌋ = ⌈n/2⌉ ≥ ⌊n/2⌋.
+  refine ⟨Finset.Ioc (n / 2) n, ?_, ?_, ?_⟩
+  · intro x hx
+    rw [Finset.mem_Ioc] at hx
+    rw [Finset.mem_range]
+    omega
+  · apply upper_half_sum_free n
+    intro x hx
+    rw [Finset.mem_Ioc] at hx
+    omega
+  · rw [Nat.card_Ioc]
+    omega
 
 /-
 ## Part V: The Łuczak-Schoen Upper Bound (2001)
@@ -169,14 +220,14 @@ There exists c < 1/2 such that f_m(n) < 2^{cn}.
 This proves f_m(n) = o(2^{n/2}).
 -/
 axiom luczak_schoen_theorem :
-    ∃ c : ℚ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℚ) < 2 ^ (c * n)
+    ∃ c : ℝ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℝ) < (2 : ℝ) ^ (c * n)
 
 /--
 **Main question resolved:**
 f_m(n) = o(2^{n/2}) is TRUE by Łuczak-Schoen.
 -/
 theorem main_question_resolved :
-    ∃ c : ℚ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℚ) < 2 ^ (c * n) :=
+    ∃ c : ℝ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℝ) < (2 : ℝ) ^ (c * n) :=
   luczak_schoen_theorem
 
 /-
@@ -190,21 +241,20 @@ and f_m(n) < 2^{c'n} for c' < 1/2, this is also resolved.
 ## Part VI: The BLST Sharp Bounds (2015, 2018)
 -/
 
-/--
+/-
 **BLST 2015 Result:**
 f_m(n) = 2^{(1/4 + o(1))n}.
 This pins down the exponent as 1/4.
--/
-/--
+
 **BLST 2018 Sharp Bound:**
 f_m(n) = (C_n + o(1)) · 2^{n/4},
 where C_n is an explicit constant depending only on n mod 4.
--/
-/--
+
 **The four cases of C_n:**
 The constant C_n depends on n mod 4, reflecting the structure of
 maximal sum-free sets in each residue class.
 -/
+
 /-
 ## Part VII: Structure of Maximal Sum-Free Sets
 -/
@@ -273,7 +323,7 @@ The answer is YES: f_m(n) grows like 2^{n/4}, which is o(2^{n/2}).
 -/
 theorem erdos_877_solved :
     -- The main question is resolved
-    (∃ c : ℚ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℚ) < 2 ^ (c * n)) ∧
+    (∃ c : ℝ, c < 1/2 ∧ ∀ n : ℕ, n ≥ 1 → (f_m n : ℝ) < (2 : ℝ) ^ (c * n)) ∧
     -- And the sharp asymptotics are known
     (∀ n : ℕ, n ≥ 4 → f_m n > 2 ^ (n / 4)) := by
   exact ⟨luczak_schoen_theorem, cameron_erdos_lower_bound⟩

--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 877,
     "erdosUrl": "https://erdosproblems.com/877",
     "erdosProblemStatus": "solved",
@@ -35,12 +35,14 @@
       "f(n), f_m(n): counting functions via powerset filtering",
       "odds_sum_free: concrete example proved by omega",
       "upper_half_sum_free: parametric example proved by omega",
+      "maximal_criterion: structural criterion for positive excluded elements of a maximal sum-free set (PROVED; corrects the prior statement, which is false at x=0)",
+      "odds_construction: the upper half {n/2+1,...,n} is sum-free of cardinality >= n/2 (PROVED)",
       "f_m_le_f: every maximal sum-free set is sum-free",
       "erdos_877_solved: combined resolution theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 291,
-    "assumptions": "2 axioms: cameron_erdos_lower_bound, luczak_schoen_theorem. 4 sorries.",
+    "lineCount": 341,
+    "assumptions": "2 axioms: cameron_erdos_lower_bound, luczak_schoen_theorem (deep research results, not provable from Mathlib). 2 sorries (maximal_vs_all, erdos_877) depending on those axiomatized bounds.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
     "definitionCount": 6,
@@ -66,79 +68,79 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 26,
-      "endLine": 35,
-      "summary": "Imports `Finset.Basic/Card/Powerset`, `Set.Basic`, `Finpartition`, and `Asymptotics`. Uses $\\mathbb{Q}$ for asymptotic bounds.",
-      "mathContext": "Bound: Imports `Finset.Basic/Card/Powerset`, `Set.Basic`, `Finpartition`, and `Asymptotics`. Uses $\\mathbb{Q}$ for asymptotic bounds."
+      "endLine": 29,
+      "summary": "Imports all of `Mathlib` and opens `Nat`, `Finset`, and `scoped Classical` (the powerset filters defining f and f_m need classical decidability). Asymptotic bounds are stated over the reals via `rpow`.",
+      "mathContext": "Imports all of `Mathlib` and opens `Nat`, `Finset`, and `scoped Classical` (the powerset filters defining f and f_m need classical decidability). Asymptotic bounds are stated over the reals via `rpow`."
     },
     {
       "id": "sum-free-sets",
       "title": "Sum-Free Sets",
-      "startLine": 46,
-      "endLine": 79,
+      "startLine": 42,
+      "endLine": 76,
       "summary": "Defines `isSumFree` ($\\forall a,b,c \\in A,\\ a \\neq b+c$), `sumset` ($A+A$), and `isSumFree'` ($A \\cap (A+A) = \\emptyset$). Proves odd numbers and upper half are sum-free.",
       "mathContext": "Formal definition: Defines `isSumFree` ($\\forall a,b,c \\in A,\\ a \\neq b+c$), `sumset` ($A+A$), and `isSumFree'` ($A \\cap (A+A) = \\emptyset$). Proves odd numbers and upper half are sum-free."
     },
     {
       "id": "maximal-sum-free",
       "title": "Maximal Sum-Free Sets",
-      "startLine": 90,
-      "endLine": 107,
-      "summary": "Defines `isMaximalSumFree` (sum-free and no proper extension). States the maximality criterion: every excluded $x$ satisfies $x = a+b$, $a = x+b$, or $2x \\in A$.",
-      "mathContext": "Formal definition: Defines `isMaximalSumFree` (sum-free and no proper extension). States the maximality criterion: every excluded $x$ satisfies $x = a+b$, $a = x+b$, or $2x \\in A$."
+      "startLine": 86,
+      "endLine": 147,
+      "summary": "Defines `isMaximalSumFree` (sum-free and no proper extension) and PROVES the maximality criterion: every excluded positive $x$ satisfies $x = a+b$, $a = x+b$, or $2x \\in A$ (the hypothesis $x>0$ is necessary — the criterion fails at $x=0$ via the trivial sum $0=0+0$).",
+      "mathContext": "Defines `isMaximalSumFree` (sum-free and no proper extension) and PROVES the maximality criterion: every excluded positive $x$ satisfies $x = a+b$, $a = x+b$, or $2x \\in A$ (the hypothesis $x>0$ is necessary — the criterion fails at $x=0$ via the trivial sum $0=0+0$)."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions f(n) and f_m(n)",
-      "startLine": 117,
-      "endLine": 136,
+      "startLine": 156,
+      "endLine": 176,
       "summary": "Defines $f(n)$ (all sum-free subsets) and $f_m(n)$ (maximal sum-free subsets) via `Finset.powerset.filter`. Proves $f_m(n) \\leq f(n)$.",
       "mathContext": "Formal definition: Defines $f(n)$ (all sum-free subsets) and $f_m(n)$ (maximal sum-free subsets) via `Finset.powerset.filter`. Proves $f_m(n) \\leq f(n)$."
     },
     {
       "id": "cameron-erdos-bound",
       "title": "Cameron-Erdős Lower Bound",
-      "startLine": 143,
-      "endLine": 160,
-      "summary": "$f_m(n) > 2^{n/4}$ for $n \\geq 4$, via constructing exponentially many maximal sum-free sets from subsets of odd numbers.",
-      "mathContext": "$f_m(n) > $$2^{{n/4}$}$$ for $n \\geq 4$, via constructing exponentially many maximal sum-free sets from subsets of odd numbers."
+      "startLine": 186,
+      "endLine": 212,
+      "summary": "$f_m(n) > 2^{n/4}$ for $n \\geq 4$ (axiomatized Cameron-Erdős bound). `odds_construction` is PROVED: the upper half $\\{n/2+1,\\dots,n\\}$ is a sum-free set of cardinality $\\geq n/2$.",
+      "mathContext": "$f_m(n) > 2^{n/4}$ for $n \\geq 4$ (axiomatized Cameron-Erdős bound). `odds_construction` is PROVED: the upper half $\\{n/2+1,\\dots,n\\}$ is a sum-free set of cardinality $\\geq n/2$."
     },
     {
       "id": "luczak-schoen",
       "title": "Łuczak-Schoen (2001): Main Question Resolved",
-      "startLine": 167,
-      "endLine": 180,
-      "summary": "$\\exists c < 1/2,\\ f_m(n) < 2^{cn}$. Resolves the main question: $f_m(n) = o(2^{n/2})$ is **YES**.",
-      "mathContext": "$\\exists c < 1/2,\\ f_m(n) < $$2^{{cn}$}$$. Resolves the main question: $f_m(n) = o($$2^{{n/2}$}$)$ is **YES**."
+      "startLine": 222,
+      "endLine": 239,
+      "summary": "$\\exists c < 1/2,\\ f_m(n) < 2^{cn}$ (over $\\mathbb{R}$, via `rpow`). Resolves the main question: $f_m(n) = o(2^{n/2})$ is **YES**.",
+      "mathContext": "$\\exists c < 1/2,\\ f_m(n) < 2^{cn}$ (over $\\mathbb{R}$, via `rpow`). Resolves the main question: $f_m(n) = o(2^{n/2})$ is **YES**."
     },
     {
       "id": "blst-sharp",
       "title": "BLST Sharp Asymptotics (2015, 2018)",
-      "startLine": 193,
-      "endLine": 207,
+      "startLine": 241,
+      "endLine": 257,
       "summary": "BLST 2015: $f_m(n) = 2^{(1/4+o(1))n}$ via the container method. BLST 2018: $f_m(n) = (C_n + o(1)) \\cdot 2^{n/4}$ with $C_n$ depending on $n \\bmod 4$.",
       "mathContext": "BLST 2015: $f_m(n) = $$2^{{(1/4+o(1))n}$}$$ via the container method. BLST 2018: $f_m(n) = (C_n + o(1)) \\cdot $$2^{{n/4}$}$$ with $C_n$ depending on $n \\bmod 4$."
     },
     {
       "id": "structure",
       "title": "Structure and the Container Method",
-      "startLine": 209,
-      "endLine": 232,
+      "startLine": 259,
+      "endLine": 283,
       "summary": "Explains the $1/4$ exponent (only $n/4$ free choices in typical maximal sets) and the hypergraph container method underlying the BLST proof.",
       "mathContext": "Verified: Explains the $1/4$ exponent (only $n/4$ free choices in typical maximal sets) and the hypergraph container method underlying the BLST proof."
     },
     {
       "id": "erdos-748",
       "title": "Comparison with Erdős #748",
-      "startLine": 234,
-      "endLine": 253,
+      "startLine": 285,
+      "endLine": 304,
       "summary": "$f(n) = \\Theta(2^{n/2})$ vs $f_m(n) = \\Theta(2^{n/4})$: maximality reduces the count exponentially. The ratio $f_m(n)/f(n) = \\Theta(2^{-n/4}) \\to 0$.",
       "mathContext": "$f(n) = \\Theta($$2^{{n/2}$}$)$ vs $f_m(n) = \\Theta($$2^{{n/4}$}$)$: maximality reduces the count exponentially. The ratio $f_m(n)/f(n) = \\Theta($$2^{{-n/4}$}$) \\to 0$."
     },
     {
       "id": "summary",
       "title": "Summary and Resolution",
-      "startLine": 256,
-      "endLine": 291,
+      "startLine": 306,
+      "endLine": 341,
       "summary": "Combined `erdos_877_solved`: Łuczak-Schoen resolves the question, Cameron-Erdős gives the tight lower bound. Final `erdos_877` states $f_m(n) = \\Theta(2^{n/4})$.",
       "mathContext": "Combined `erdos_877_solved`: Łuczak-Schoen resolves the question, Cameron-Erdős gives the tight lower bound. Final `erdos_877` states $f_m(n) = \\Theta($$2^{{n/4}$}$)$."
     }
@@ -161,40 +163,36 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #877 is SOLVED. The answer to 'Is f_m(n) = o(2^{n/2})?' is YES. The count of maximal sum-free subsets satisfies f_m(n) = Θ(2^{n/4}), with sharp asymptotics f_m(n) = (C_n + o(1))2^{n/4} where C_n is an explicit constant depending on n mod 4. The formalization captures the full progression from Cameron-Erdős through BLST. 4 sorries remain.",
+    "summary": "Erdős Problem #877 is SOLVED. The answer to 'Is f_m(n) = o(2^{n/2})?' is YES. The count of maximal sum-free subsets satisfies f_m(n) = Θ(2^{n/4}), with sharp asymptotics f_m(n) = (C_n + o(1))2^{n/4} where C_n is an explicit constant depending on n mod 4. The formalization captures the full progression from Cameron-Erdős through BLST. 2 sorries remain (maximal_vs_all, erdos_877), both depending on the two axiomatized deep bounds; the file now compiles against Mathlib 4.26.",
     "implications": "This result reveals a striking gap between the count of all sum-free sets (~2^{n/2}) and maximal sum-free sets (~2^{n/4}). The container method developed for this problem has become one of the most widely used tools in modern combinatorics, with applications to Turán-type problems, Ramsey theory, and graph enumeration.",
     "openQuestions": [
       "What are the exact numerical values of C_0, C_1, C_2, C_3 in the BLST sharp bound?",
       "Can the structure of maximal sum-free sets be characterized more precisely (e.g., typical set profiles)?",
       "What about maximal sum-free sets in other groups: ℤ_n, ℤ_p, or general abelian groups?",
-      "Can the 4 remaining sorries (maximal_criterion, odds_construction, maximal_vs_all, erdos_877) be closed?",
+      "Can the 2 remaining sorries (maximal_vs_all, erdos_877) be closed, or do they genuinely require the Cameron-Erdős / Łuczak-Schoen content currently axiomatized?",
       "Is there a sharp threshold for the transition from f_m(n) ≈ f(n) to f_m(n) ≪ f(n) as the maximality constraint is relaxed?"
     ]
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Data.Nat.Basic",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Finset.Card",
-      "Mathlib.Data.Set.Basic",
-      "Mathlib.Order.Partition.Finpartition",
-      "Mathlib.Analysis.Asymptotics.Asymptotics"
+      "Mathlib"
     ],
     "opens": [
       "Nat",
-      "Finset"
+      "Finset",
+      "Classical"
     ],
     "namespace": "Erdos877",
-    "lineCount": 291,
+    "lineCount": 341,
     "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 6,
     "path": "Proofs/Erdos877Problem.lean",
-    "sorries": 4,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/Erdos877ProblemAristotle.lean",
       "Proofs/Erdos877Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 2
 }


### PR DESCRIPTION
## Summary
Research session for **erdos-877** (Counting Maximal Sum-Free Subsets). The gallery's
`Erdos877Problem.lean` no longer compiled against current Mathlib (4.26); this PR
rehabilitates it and closes the two genuinely-provable sorries.

## What was broken (pre-existing, not from this PR)
- `import Mathlib.Analysis.Asymptotics.Asymptotics` — module was split/renamed; olean no longer exists.
- `2 ^ (c * n)` with `c : ℚ` — there is no `rpow` on `ℚ`, so the Łuczak-Schoen axiom and three downstream statements failed to typecheck.
- Orphan `/--` docstrings with no attached declaration (parse errors under current Lean).
- `DecidablePred` not synthesizable for the powerset filters defining `f`/`f_m`.

## Progress (verified offline via `lake env lean`)
- **`odds_construction` — PROVED.** The upper half `{n/2+1,…,n} = Finset.Ioc (n/2) n` is sum-free (reusing `upper_half_sum_free`) and has cardinality `n - n/2 ≥ n/2`.
- **`maximal_criterion` — PROVED, and corrected.** The prior statement is **false at `x = 0`**: the trivial sum `0 = 0 + 0` witnesses `¬ isSumFree (insert 0 A)` for *any* sum-free `A` (e.g. `∅` is maximal sum-free for `n = 0`), so none of the three structural conclusions hold. Added the necessary hypothesis `0 < x` and gave a full case-analysis proof.
- Rehabilitated imports (`import Mathlib`, `open scoped Classical`) and restated the Łuczak-Schoen axiom + downstream theorems over `ℝ` (`rpow`) so the file compiles.

`#print axioms` confirms both new proofs depend only on `propext / Classical.choice / Quot.sound` (no `sorryAx`).

## Status
**Outcome**: progress (4 → 2 sorries; file restored to compiling).
**Remaining**: 2 sorries (`maximal_vs_all`, `erdos_877`) and 2 axioms (`cameron_erdos_lower_bound`, `luczak_schoen_theorem`) are genuine deep research results (Cameron-Erdős, Łuczak-Schoen, BLST), not provable from Mathlib. Status stays **`axiomatized`**.
**Next Steps**: the remaining sorries genuinely require the axiomatized content; no honest path to close them without formalizing the container-method bounds.

🤖 Generated by researcher-2