### PR TITLE
Enrich Cramer's Rule OQ-04-OQ-01-OQ-01: The Explicit Cramer Solution

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/annotations.json
@@ -3,12 +3,16 @@
     "id": "ann-algebraic-core",
     "proofId": "cramers-rule-oq-04-oq-01-oq-01",
     "range": {
-      "startLine": 54,
-      "endLine": 64
+      "startLine": 46,
+      "endLine": 57
     },
     "type": "insight",
     "title": "Cramer's Rule Before Division: A Commutative-Ring Identity",
-    "content": "det_smul_solution_eq_cramer is the algebraic heart, and it needs NO invertibility and NO field: over any commutative ring, A *ᵥ x = b implies (det A) • x = cramer A b. The proof rewrites cramer A b = adjugate A *ᵥ b (Mathlib's cramer_eq_adjugate_mulVec), substitutes b = A *ᵥ x, and collapses adjugate A *ᵥ (A *ᵥ x) = (adjugate A * A) *ᵥ x = ((det A)•1) *ᵥ x = (det A)•x using mulVec_mulVec, adjugate_mul, smul_mulVec, one_mulVec. Componentwise, with cramer_apply, this is (det A)·xᵢ = det(Aᵢ) — the column-replaced determinant. Division by det A is deferred entirely to the field step."
+    "content": "det_smul_solution_eq_cramer is the algebraic heart, and it needs NO invertibility and NO field: over any commutative ring, A *ᵥ x = b implies (det A) • x = cramer A b. The proof rewrites cramer A b = adjugate A *ᵥ b (Mathlib's cramer_eq_adjugate_mulVec), substitutes b = A *ᵥ x, and collapses adjugate A *ᵥ (A *ᵥ x) = (adjugate A * A) *ᵥ x = ((det A)•1) *ᵥ x = (det A)•x using mulVec_mulVec, adjugate_mul, smul_mulVec, one_mulVec. Division by det A is deferred entirely to the field step.",
+    "mathContext": "$(\\det A)\\,x = \\mathrm{cramer}\\,A\\,b$ over any commutative ring, from $\\mathrm{adj}(A)\\,A = (\\det A)\\,I$.",
+    "significance": "key",
+    "relatedConcepts": ["adjugate identity adj(A)·A = det(A)·I", "cramer_eq_adjugate_mulVec", "commutative ring (no division)", "deferring invertibility"],
+    "prerequisites": ["matrix adjugate", "matrix-vector multiplication", "the determinant"]
   },
   {
     "id": "ann-cramer-apply-bridge",
@@ -19,28 +23,55 @@
     },
     "type": "concept",
     "title": "cramer_apply: From the Abstract Adjugate to det(Aᵢ)",
-    "content": "The statement of Cramer's rule mentions det(Aᵢ), the determinant of A with column i replaced by b. What connects this concrete quantity to the adjugate machinery is Mathlib's cramer_apply: cramer A b i = det(A.updateCol i b), true by definition of Matrix.cramer (a cofactor expansion along column i). det_mul_solution_eq_det_updateCol simply reads off the i-th component of the core identity and applies cramer_apply, yielding (det A)·xᵢ = det(Aᵢ). Without this dictionary, the 'det(Aᵢ)' in the classical formula would be disconnected from the adjugate identity that proves it."
+    "content": "The classical formula mentions det(Aᵢ), the determinant of A with column i replaced by b. Mathlib's cramer_apply connects this concrete quantity to the adjugate machinery: cramer A b i = det(A.updateCol i b), true by definition of Matrix.cramer (cofactor expansion along column i). det_mul_solution_eq_det_updateCol reads off the i-th component of the core identity and applies cramer_apply, yielding (det A)·xᵢ = det(Aᵢ). Without this dictionary the 'det(Aᵢ)' in the formula would be disconnected from the adjugate identity that proves it.",
+    "mathContext": "$\\mathrm{cramer}\\,A\\,b\\,(i) = \\det(A.\\mathrm{updateCol}\\,i\\,b) = \\det(A_i)$, hence $(\\det A)\\,x_i = \\det(A_i)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Matrix.cramer / cramer_apply", "column-replaced determinant det(Aᵢ)", "cofactor expansion", "updateCol"],
+    "prerequisites": ["the algebraic core", "determinant cofactor expansion"]
   },
   {
     "id": "ann-explicit-formula",
     "proofId": "cramers-rule-oq-04-oq-01-oq-01",
     "range": {
-      "startLine": 75,
-      "endLine": 92
+      "startLine": 72,
+      "endLine": 85
     },
     "type": "insight",
-    "title": "The Classical Formula and Why It Is the Only Solution",
-    "content": "cramer_solution is the OQ's literal target: over a field with det A ≠ 0, xᵢ = det(Aᵢ)/det A. eq_div_iff hdet turns this goal into (det A)·xᵢ = det(Aᵢ) (after mul_comm), which is exactly the algebraic core proved above — so the only field-specific ingredient is the cancellation of a nonzero scalar. cramer_solution_eq packages all coordinates into the closed-form vector. cramer_solution_unique then needs nothing new: every solution of A x = b equals that same closed form, so any two solutions coincide. Over a field, det A ≠ 0 is exactly invertibility of A, so this is the sharp hypothesis."
+    "title": "The Classical Formula xᵢ = det(Aᵢ)/det A",
+    "content": "cramer_solution is the OQ's literal target: over a field with det A ≠ 0, xᵢ = det(Aᵢ)/det A. eq_div_iff hdet turns this goal into (det A)·xᵢ = det(Aᵢ) (after mul_comm), which is exactly the commutative-ring core proved above — so the only field-specific ingredient is the cancellation of a nonzero scalar. cramer_solution_eq packages all coordinates into the closed-form vector x = fun i => det(Aᵢ)/det A. Over a field, det A ≠ 0 is exactly invertibility of A, so this is the sharp hypothesis.",
+    "mathContext": "$x_i = \\dfrac{\\det(A_i)}{\\det A}$ over a field with $\\det A \\ne 0$; the field only contributes dividing by the nonzero scalar $\\det A$.",
+    "significance": "key",
+    "relatedConcepts": ["Cramer's rule (classical form)", "eq_div_iff", "det A ≠ 0 ⟺ invertibility", "closed-form solution vector"],
+    "prerequisites": ["the scalar core identity", "field division"]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "cramers-rule-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "Uniqueness: the Cramer Vector Is the Solution",
+    "content": "cramer_solution_unique needs nothing new: every solution of A x = b equals the same closed form det(Aᵢ)/det A, so any two solutions coincide (rewrite both via cramer_solution_eq). This upgrades the formula from 'a solution satisfies this' to 'this is the unique solution', the uniqueness half of well-posedness for an invertible square system.",
+    "mathContext": "$A x = b \\wedge A y = b \\wedge \\det A \\ne 0 \\Rightarrow x = y$ — both equal $\\big(\\det(A_i)/\\det A\\big)_i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["uniqueness of the solution", "invertible square system", "well-posedness"],
+    "prerequisites": ["the closed-form solution", "transitivity of equality"]
   },
   {
     "id": "ann-existence",
     "proofId": "cramers-rule-oq-04-oq-01-oq-01",
     "range": {
-      "startLine": 98,
+      "startLine": 94,
       "endLine": 105
     },
     "type": "insight",
     "title": "Existence: The Formula Actually Solves the System",
-    "content": "cramer_formula_isSolution closes the loop: A *ᵥ (fun i => det(Aᵢ)/det A) = b. The key rewrite expresses the closed-form vector as A.det⁻¹ • cramer A b (since det(Aᵢ)/det A = (det A)⁻¹ · det(Aᵢ) = (det A)⁻¹ · (cramer A b)ᵢ). Then mulVec_cramer (A *ᵥ cramer A b = (det A)•b) and inv_mul_cancel₀ hdet collapse A.det⁻¹ • (det A) • b to b. Combined with uniqueness, the system A x = b has EXACTLY ONE solution when det A ≠ 0, and it is given explicitly by the ratio of determinants."
+    "content": "cramer_formula_isSolution closes the loop: A *ᵥ (fun i => det(Aᵢ)/det A) = b. The key rewrite expresses the closed-form vector as A.det⁻¹ • cramer A b (since det(Aᵢ)/det A = (det A)⁻¹ · (cramer A b)ᵢ). Then mulVec_cramer (A *ᵥ cramer A b = (det A)•b) and inv_mul_cancel₀ hdet collapse A.det⁻¹ • (det A) • b to b. Combined with uniqueness, the system A x = b has EXACTLY ONE solution when det A ≠ 0, given explicitly by the ratio of determinants.",
+    "mathContext": "$A\\big(\\det(A_i)/\\det A\\big)_i = b$, via $A\\,\\mathrm{cramer}(A,b) = (\\det A)\\,b$ and $(\\det A)^{-1}(\\det A) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["mulVec_cramer", "inv_mul_cancel₀", "existence ∧ uniqueness", "explicit inverse via adjugate"],
+    "prerequisites": ["the cramer vector identity", "field inverse cancellation"]
   }
 ]

--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CramersRuleOQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cramersRuleOq04Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cramersRuleOq04Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cramersRuleOq04Oq01Oq01Data: ProofData = {
+  proof: cramersRuleOq04Oq01Oq01Proof,
+  annotations: cramersRuleOq04Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-04-oq-01-oq-01`.

## Changes
- **Created missing `index.ts`** — without it the proof page shows 'proof not found' on the live site.
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- **Annotation coverage**: restructured into 5 clean non-overlapping annotations (ring core, `cramer_apply` bridge, the classical formula, uniqueness, existence) covering all 6 theorems.

Axiom integrity unchanged: meta reports `verified`/`mathlib`, 0 axioms, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)