### PR TITLE
audit: mark 4 fresh gallery proofs clean (angle-trisection, borsuk-ulam, cayley-hamilton, hilbert-3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24157,6 +24157,30 @@
       "lastAudited": "2026-06-25T17:20:00Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "angle-trisection-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:28:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "borsuk-ulam-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:28:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:28:05Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-3-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T17:28:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 4 fresh proofs, all CLEAN

Drains the audit queue (3896→3900 audited, 0 unaudited, 0 issues). Each entry's meta.json claims were verified against the on-`main` Lean source.

| Proof | Status/Badge | Verified |
|-------|-------------|----------|
| `angle-trisection-oq-02-oq-02-oq-03` | axiomatized/axiom | 0 sorries; axiomCount=2 = 1 in-file axiom (`sin_constructible_of_cos`) + 1 inherited parent axiom (`gauss_wantzel_theorem`), both disclosed in `assumptions`; theoremCount 21 ✓ |
| `borsuk-ulam-oq-03-oq-02` | verified/original | 0 sorries / 0 axioms; theoremCount 13 ✓; the `Hₙ(Sⁿ)≅ℤ` identification is held as an explicit theorem hypothesis (conditional), honestly disclosed — not smuggled as an axiom |
| `cayley-hamilton-oq-01-oq-02` | verified/original | 0 sorries / 0 axioms; theoremCount 8 ✓ (incl. 1 `private theorem`); self-contained minpoly=lcm characterization |
| `hilbert-3-oq-02` | verified/original | 0 sorries / 0 axioms; theoremCount 9 ✓; the 3 `:= trivial` grep hits are **comments describing the parent file**, not real True stubs; scope honestly limited to the tensor-product Dehn group |

### Notes
- Both famous-named `verified/original` entries (Borsuk–Ulam, Hilbert's 3rd) scope their claims precisely and explicitly mark their Mathlib boundaries in the conclusion — no overclaiming.
- Tracker-only change (`src/data/proofs/audit-tracker.json`); no proof or gallery content modified.

---
Discovered during automated gallery integrity audit.