### PR TITLE
research: similarity ⟺ K[X]-module isomorphism — structural heart of RCF (cayley-hamilton-minpoly-oq-02-oq-02-oq-01)

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ01.lean
@@ -1,0 +1,166 @@
+/-
+Similarity is K[X]-Module Isomorphism: the Structural Heart of Rational Canonical Form
+(cayley-hamilton-minpoly-oq-02-oq-02-oq-01)
+
+Open question from cayley-hamilton-minpoly-oq-02-oq-02:
+"The minimal and characteristic polynomials do not determine the similarity
+class; the complete invariant is the list of invariant factors (the rational
+canonical form, RCF). Can the classification A ∼ B ⟺ RCF(A) = RCF(B) be
+formalized?"
+
+## What this file contributes
+
+The sibling file `CayleyHamiltonMinpolyOQ02OQ02.lean` gave a concrete 4×4
+counterexample showing minpoly + charpoly are *not* a complete invariant, and
+`...OQ02OQ02OQ02.lean` built the single Jordan block `J_n(μ)` (one elementary
+divisor `(X - μ)ⁿ`). The remaining gap is the *organizing principle* behind
+RCF: why invariant factors are a **complete** invariant at all.
+
+That principle is a reduction, not a computation:
+
+    two operators are similar  ⟺  their associated K[X]-modules are isomorphic.
+
+Recall the K[X]-module attached to an endomorphism `φ : M →ₗ[K] M`: it is `M`
+itself, with the indeterminate `X` acting as `φ` (Mathlib's `Module.AEval' φ`,
+where `X • m = φ m`). This file proves the bridge
+
+  `conj_iff_nonempty_aeval_linearEquiv`:
+      (∃ e : M ≃ₗ[K] M, e ∘ₗ φ = ψ ∘ₗ e)  ↔  Nonempty (AEval' φ ≃ₗ[K[X]] AEval' ψ)
+
+i.e. `φ` and `ψ` are conjugate (similar) **iff** the K[X]-modules `AEval' φ`
+and `AEval' ψ` are isomorphic. We also give the matrix-level corollary via
+`Matrix.toLin'`.
+
+## Why this is the right reduction
+
+Combined with Mathlib's structure theorem for finitely generated modules over a
+PID (`Module.equiv_directSum_of_isTorsion` in `Mathlib/Algebra/Module/PID.lean`),
+which classifies a finitely generated torsion `K[X]`-module up to isomorphism by
+its sequence of invariant factors, this bridge turns the geometric statement
+"`A ∼ B ⟺ RCF(A) = RCF(B)`" into the algebraic statement "isomorphic modules
+have the same invariant factors". One structural reduction replaces an
+open-ended case analysis over canonical forms.
+
+The forward direction repackages the construction Mathlib uses internally in
+`LinearEquiv.isSemisimple_iff` (`Mathlib/LinearAlgebra/Semisimple.lean`) as a
+standalone, reusable equivalence; the converse (module iso ⟹ conjugacy) does
+not appear in Mathlib and is the new content here.
+
+## What is proved (0 axioms, 0 sorries)
+
+  * `aeval_linearEquiv_of_conj`     : intertwiner  ⟹  K[X]-module iso  (forward)
+  * `conj_of_aeval_linearEquiv`     : K[X]-module iso  ⟹  intertwiner  (converse)
+  * `conj_iff_nonempty_aeval_linearEquiv` : the full ⟺ at operator level
+  * `aeval_isTorsion`               : for finite-dimensional `M`, `AEval' φ` is a
+                                      torsion `K[X]`-module (the hypothesis of the
+                                      PID structure theorem)
+  * `matrix_conj_iff_nonempty_aeval_linearEquiv` : matrix-level ⟺ via `toLin'`
+
+References:
+- Hoffman & Kunze, "Linear Algebra" (1971), Chapter 7 (§7.1–7.3: the K[x]-module
+  picture and the rational form).
+- Dummit & Foote, "Abstract Algebra" (2004), §12.2 (rational canonical form as
+  the invariant-factor decomposition of the F[x]-module).
+- Mathlib: `Module.AEval'`, `LinearEquiv.ofAEval`, `Module.equiv_directSum_of_isTorsion`.
+-/
+
+import Mathlib.Algebra.Polynomial.Module.AEval
+import Mathlib.Algebra.Module.PID
+import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.LinearAlgebra.Charpoly.Basic
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+set_option maxHeartbeats 800000
+
+open Polynomial Module Matrix
+
+namespace RCFSimilarityBridge
+
+variable {K : Type*} [Field K]
+variable {M : Type*} [AddCommGroup M] [Module K M]
+
+/-- **Forward direction.** An intertwiner `e ∘ φ = ψ ∘ e` (a `K`-linear
+isomorphism conjugating `φ` to `ψ`) induces a `K[X]`-linear isomorphism of the
+associated polynomial modules `AEval' φ ≃ₗ[K[X]] AEval' ψ`.
+
+This is the construction Mathlib performs inside `LinearEquiv.isSemisimple_iff`,
+extracted as a reusable equivalence. The underlying `K`-linear map is just `e`;
+the point is that the intertwining hypothesis makes it commute with the
+`X`-action (which is `φ` on the source and `ψ` on the target). -/
+noncomputable def aeval_linearEquiv_of_conj
+    (φ ψ : Module.End K M) (e : M ≃ₗ[K] M)
+    (he : e.toLinearMap ∘ₗ φ = ψ ∘ₗ e.toLinearMap) :
+    AEval' φ ≃ₗ[K[X]] AEval' ψ :=
+  LinearEquiv.ofAEval _ (e.trans (AEval'.of ψ)) fun x ↦ by
+    simpa [AEval'.X_smul_of] using LinearMap.congr_fun he x
+
+/-- **Converse direction.** A `K[X]`-linear isomorphism `AEval' φ ≃ₗ[K[X]] AEval' ψ`
+yields a `K`-linear isomorphism `e : M ≃ₗ[K] M` intertwining `φ` and `ψ`.
+
+The map is `e = (of ψ)⁻¹ ∘ E ∘ (of φ)`, `K`-linear because `E` is in particular
+`K`-linear. The intertwining identity is exactly the statement that `E` respects
+the `X`-action: `X` acts as `φ` on the source and as `ψ` on the target. -/
+theorem conj_of_aeval_linearEquiv
+    (φ ψ : Module.End K M) (E : AEval' φ ≃ₗ[K[X]] AEval' ψ) :
+    ∃ e : M ≃ₗ[K] M, e.toLinearMap ∘ₗ φ = ψ ∘ₗ e.toLinearMap := by
+  -- `e` is `E` sandwiched between the canonical `K`-linear identifications `of`.
+  refine ⟨((AEval'.of φ).trans (E.restrictScalars K)).trans (AEval'.of ψ).symm, ?_⟩
+  ext m
+  -- Unfold to a pointwise statement about `m : M`.
+  show (AEval'.of ψ).symm (E (AEval'.of φ (φ m))) = ψ ((AEval'.of ψ).symm (E (AEval'.of φ m)))
+  -- `of φ (φ m) = X • of φ m`, so we can pull `X` through the `K[X]`-linear `E`.
+  have hX : AEval'.of φ (φ m) = (X : K[X]) • AEval'.of φ m := (AEval'.X_smul_of φ m).symm
+  rw [hX, map_smul, AEval'.of_symm_X_smul]
+
+/-- **The structural reduction.** Two endomorphisms `φ, ψ : M →ₗ[K] M` are
+similar (conjugate by a `K`-linear automorphism) **iff** the `K[X]`-modules they
+induce — `M` with `X` acting as `φ`, resp. as `ψ` — are isomorphic.
+
+This is the algebraic heart of the rational canonical form: similarity *is*
+isomorphism of `K[X]`-modules. Together with the PID structure theorem (which
+classifies finitely generated torsion `K[X]`-modules by their invariant
+factors), it explains why the invariant factors are a *complete* similarity
+invariant, whereas the minimal polynomial alone (the largest invariant factor)
+is not. -/
+theorem conj_iff_nonempty_aeval_linearEquiv (φ ψ : Module.End K M) :
+    (∃ e : M ≃ₗ[K] M, e.toLinearMap ∘ₗ φ = ψ ∘ₗ e.toLinearMap) ↔
+      Nonempty (AEval' φ ≃ₗ[K[X]] AEval' ψ) :=
+  ⟨fun ⟨e, he⟩ ↦ ⟨aeval_linearEquiv_of_conj φ ψ e he⟩,
+   fun ⟨E⟩ ↦ conj_of_aeval_linearEquiv φ ψ E⟩
+
+/-- For a finite-dimensional space `M`, the polynomial module `AEval' φ` is a
+torsion `K[X]`-module: every element is killed by a nonzero polynomial, namely
+the (monic, hence nonzero) characteristic polynomial of `φ`, which annihilates
+the whole module by Cayley–Hamilton.
+
+This is precisely the hypothesis `Module.IsTorsion` required by the PID
+structure theorem `Module.equiv_directSum_of_isTorsion`, so it is the missing
+link that lets one apply that classification to `AEval' φ`. -/
+theorem aeval_isTorsion [FiniteDimensional K M] (φ : Module.End K M) :
+    Module.IsTorsion K[X] (AEval' φ) := by
+  intro x
+  -- Transport `x` back to `M` along the canonical identification `of`.
+  obtain ⟨m, rfl⟩ := (AEval'.of φ).surjective x
+  -- The characteristic polynomial is monic, hence a nonzero divisor in `K[X]`.
+  refine ⟨⟨φ.charpoly, mem_nonZeroDivisors_of_ne_zero φ.charpoly_monic.ne_zero⟩, ?_⟩
+  -- `charpoly • x = aeval φ charpoly • x = 0` by Cayley–Hamilton.
+  have hCH : (aeval φ) φ.charpoly = 0 := φ.aeval_self_charpoly
+  show (φ.charpoly : K[X]) • (AEval'.of φ) m = 0
+  rw [← AEval.of_aeval_smul, hCH]
+  simp
+
+/-- **Matrix-level corollary.** Two square matrices over `K` are similar — there
+is an invertible `P` with `e = toLin' P` conjugating one to the other — iff the
+`K[X]`-modules attached to the linear maps `Matrix.toLin' A` and `Matrix.toLin' B`
+are isomorphic. This is the rational-canonical-form reduction in its classical
+matrix phrasing. -/
+theorem matrix_conj_iff_nonempty_aeval_linearEquiv
+    {n : Type*} [Fintype n] [DecidableEq n] (A B : Matrix n n K) :
+    (∃ e : (n → K) ≃ₗ[K] (n → K),
+        e.toLinearMap ∘ₗ Matrix.toLin' A = (Matrix.toLin' B) ∘ₗ e.toLinearMap) ↔
+      Nonempty (AEval' (Matrix.toLin' A) ≃ₗ[K[X]] AEval' (Matrix.toLin' B)) :=
+  conj_iff_nonempty_aeval_linearEquiv (Matrix.toLin' A) (Matrix.toLin' B)
+
+end RCFSimilarityBridge

--- a/proofs/Proofs/Erdos1023OQ01.lean
+++ b/proofs/Proofs/Erdos1023OQ01.lean
@@ -24,8 +24,11 @@ import Mathlib.Tactic
 import Mathlib.Data.Nat.Choose.Central
 import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Order.ConditionallyCompleteLattice.Basic
+import Mathlib
 
 open Finset
+open Filter Asymptotics
+open scoped Topology Real Nat
 
 namespace Erdos1023OQ01
 
@@ -366,10 +369,206 @@ axiom problem_447_solution :
   ∀ n : ℕ, sSup { m : ℕ | ∃ F : SetFamily n, isTwoUnionFree F ∧ F.card = m } =
     Nat.choose n (n / 2)
 
-/-- Stirling's approximation for central binomials (deep result). -/
-axiom stirling_central_approx :
-  ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,
-    |(Nat.choose n (n / 2) : ℝ) / (stirlingConstant * 2^n / Real.sqrt n) - 1| < ε
+-- ----------------------------------------------------------------------------
+-- Stirling's approximation for central binomials, **proved** (no longer an axiom)
+-- from Mathlib's Stirling equivalence via
+-- `BetaDiagAsymptotic.centralBinom_isEquivalent` (`C(2n, n) ~ 4ⁿ / √(πn)`).
+-- ----------------------------------------------------------------------------
+
+/-- `C(2n,n) = (2n)! / (n!·n!)` as a real quotient. -/
+private lemma centralBinom_cast (n : ℕ) :
+    (Nat.centralBinom n : ℝ)
+      = (Nat.factorial (2 * n) : ℝ) / ((Nat.factorial n : ℝ) * (Nat.factorial n : ℝ)) := by
+  have hfac : Nat.centralBinom n * (Nat.factorial n * Nat.factorial n)
+      = Nat.factorial (2 * n) := by
+    have h := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+    rw [show 2 * n - n = n by omega] at h
+    rw [Nat.centralBinom_eq_two_mul_choose, ← mul_assoc]
+    exact h
+  rw [eq_div_iff (by positivity)]
+  exact_mod_cast hfac
+
+/-- **Wallis ratio identity.** The ratio of Stirling expressions for `(2k)!` and
+    `(k!)²` collapses to `4ᵏ / √(πm)` (the `4ᵏ` is `(2m/e)^{2k}/(m/e)^{2k}`). -/
+private lemma stirling_ratio_identity {m e : ℝ} (hm : 0 < m) (he : 0 < e) (k : ℕ) :
+    Real.sqrt (2 * (2 * m) * Real.pi) * ((2 * m) / e) ^ (2 * k) /
+        (Real.sqrt (2 * m * Real.pi) * (m / e) ^ k
+          * (Real.sqrt (2 * m * Real.pi) * (m / e) ^ k))
+      = 4 ^ k / Real.sqrt (Real.pi * m) := by
+  have hpi : 0 < Real.pi := Real.pi_pos
+  have hA : Real.sqrt (2 * (2 * m) * Real.pi) = 2 * Real.sqrt (Real.pi * m) := by
+    rw [show 2 * (2 * m) * Real.pi = (2 : ℝ) ^ 2 * (Real.pi * m) by ring,
+      Real.sqrt_mul (by positivity), Real.sqrt_sq (by norm_num)]
+  have hC : ((2 * m) / e) ^ (2 * k) = 4 ^ k * ((m / e) ^ k) ^ 2 := by
+    have h2 : (2 : ℝ) ^ (2 * k) = 4 ^ k := by rw [pow_mul]; norm_num
+    rw [show (2 * m) / e = 2 * (m / e) by rw [mul_div_assoc], mul_pow, h2, ← pow_mul,
+      Nat.mul_comm k 2]
+  have hrsq : Real.sqrt (Real.pi * m) * Real.sqrt (Real.pi * m) = Real.pi * m :=
+    Real.mul_self_sqrt (by positivity)
+  have hsq2 : Real.sqrt (2 * m * Real.pi) * Real.sqrt (2 * m * Real.pi) = 2 * m * Real.pi :=
+    Real.mul_self_sqrt (by positivity)
+  have hr0 : Real.sqrt (Real.pi * m) ≠ 0 := (Real.sqrt_pos.2 (by positivity)).ne'
+  rw [hA, hC, div_eq_div_iff (by positivity) hr0]
+  linear_combination (2 * 4 ^ k * ((m / e) ^ k) ^ 2) * hrsq - (4 ^ k * ((m / e) ^ k) ^ 2) * hsq2
+
+/-- **Central binomial asymptotic.** `C(2n, n) ~ 4ⁿ / √(πn)`, from Mathlib's
+    `Stirling.factorial_isEquivalent_stirling`. -/
+private lemma centralBinom_isEquivalent :
+    (fun n : ℕ => (Nat.centralBinom n : ℝ)) ~[atTop]
+      (fun n : ℕ => (4 : ℝ) ^ n / Real.sqrt (Real.pi * n)) := by
+  have hstir := Stirling.factorial_isEquivalent_stirling
+  have hk : Tendsto (fun n : ℕ => 2 * n) atTop atTop :=
+    tendsto_atTop_atTop.2 (fun b => ⟨b, fun a ha => by omega⟩)
+  have h2n := hstir.comp_tendsto hk
+  have hmul := hstir.mul hstir
+  have hdiv := h2n.div hmul
+  have hcb : (fun n : ℕ => (Nat.centralBinom n : ℝ)) ~[atTop]
+      (fun n : ℕ => (Nat.factorial (2 * n) : ℝ) /
+        ((Nat.factorial n : ℝ) * (Nat.factorial n : ℝ))) :=
+    Filter.EventuallyEq.isEquivalent (Filter.Eventually.of_forall centralBinom_cast)
+  refine (hcb.trans hdiv).trans (Filter.EventuallyEq.isEquivalent ?_)
+  filter_upwards [eventually_ge_atTop 1] with n hn
+  have hm : (0 : ℝ) < (n : ℝ) := Nat.cast_pos.mpr (by omega)
+  simp only [Pi.div_apply, Function.comp_apply]
+  rw [show ((2 * n : ℕ) : ℝ) = 2 * (n : ℝ) by push_cast; ring]
+  exact stirling_ratio_identity hm (Real.exp_pos 1) n
+
+/-- Key identity `√(2/π) · √(π·x) = √(2·x)`. -/
+private lemma stirlingConstant_sqrt (x : ℝ) :
+    stirlingConstant * Real.sqrt (Real.pi * x) = Real.sqrt (2 * x) := by
+  have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+  rw [stirlingConstant, ← Real.sqrt_mul (by positivity) (Real.pi * x)]
+  congr 1
+  rw [div_mul_eq_mul_div, mul_comm Real.pi x, ← mul_assoc, mul_div_assoc, div_self hpi, mul_one]
+
+/-- The normalized central binomial ratio `C(2n, n) / (4ⁿ/√(πn))` tends to `1`. -/
+private lemma centralBinom_ratio_tendsto :
+    Tendsto (fun n : ℕ => (Nat.centralBinom n : ℝ) / ((4 : ℝ) ^ n / Real.sqrt (Real.pi * n)))
+      atTop (𝓝 1) := by
+  have hz : ∀ᶠ n : ℕ in atTop, (4 : ℝ) ^ n / Real.sqrt (Real.pi * n) ≠ 0 := by
+    filter_upwards [eventually_ge_atTop 1] with n hn
+    have hn' : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+    refine ne_of_gt (div_pos (by positivity) ?_)
+    rw [Real.sqrt_pos]; positivity
+  exact (isEquivalent_iff_tendsto_one hz).mp centralBinom_isEquivalent
+
+/-- Even subsequence: at `n = 2m` the target ratio equals the central-binomial
+    ratio exactly (because `√(2m)/√(πm) = √(2/π)`), hence tends to `1`. -/
+private lemma even_ratio_tendsto :
+    Tendsto (fun m : ℕ => (Nat.choose (2 * m) ((2 * m) / 2) : ℝ)
+        / (stirlingConstant * (2 : ℝ) ^ (2 * m) / Real.sqrt ((2 * m : ℕ) : ℝ)))
+      atTop (𝓝 1) := by
+  refine Tendsto.congr' ?_ centralBinom_ratio_tendsto
+  filter_upwards [eventually_ge_atTop 1] with m _
+  have hch : Nat.choose (2 * m) ((2 * m) / 2) = Nat.centralBinom m := by
+    rw [show (2 * m) / 2 = m from by omega, Nat.centralBinom_eq_two_mul_choose]
+  have e1 : ((2 * m : ℕ) : ℝ) = 2 * (m : ℝ) := by push_cast; ring
+  have e2 : (2 : ℝ) ^ (2 * m) = (4 : ℝ) ^ m := by rw [pow_mul]; norm_num
+  rw [hch, e1, e2, ← stirlingConstant_sqrt (m : ℝ),
+      mul_div_mul_left _ _ (ne_of_gt stirlingConstant_pos)]
+
+/-- `C(2m+1, m) = ½·C(2m+2, m+1)` (Pascal + symmetry of the two central terms). -/
+private lemma odd_choose_eq (m : ℕ) :
+    2 * Nat.choose (2 * m + 1) m = Nat.centralBinom (m + 1) := by
+  rw [Nat.centralBinom_eq_two_mul_choose, show 2 * (m + 1) = (2 * m + 1) + 1 from by ring,
+      Nat.choose_succ_succ' (2 * m + 1) m, Nat.choose_symm_half]
+  ring
+
+/-- Odd subsequence: at `n = 2m+1`, `C(2m+1, m) = ½·centralBinom (m+1)` and the
+    target ratio is the central-binomial ratio times a correction
+    `√((2m+1)/(2m+2)) → 1`, hence tends to `1`. -/
+private lemma odd_ratio_tendsto :
+    Tendsto (fun m : ℕ => (Nat.choose (2 * m + 1) ((2 * m + 1) / 2) : ℝ)
+        / (stirlingConstant * (2 : ℝ) ^ (2 * m + 1) / Real.sqrt ((2 * m + 1 : ℕ) : ℝ)))
+      atTop (𝓝 1) := by
+  have hcbr1 : Tendsto (fun m : ℕ => (Nat.centralBinom (m + 1) : ℝ)
+      / ((4 : ℝ) ^ (m + 1) / Real.sqrt (Real.pi * ((m + 1 : ℕ) : ℝ)))) atTop (𝓝 1) :=
+    centralBinom_ratio_tendsto.comp (tendsto_add_atTop_nat 1)
+  have hrat : Tendsto (fun m : ℕ => (2 * (m : ℝ) + 1) / (2 * (m : ℝ) + 2)) atTop (𝓝 1) := by
+    have hden : Tendsto (fun m : ℕ => 2 * (m : ℝ) + 2) atTop atTop := by
+      refine tendsto_atTop_mono (fun m => ?_) tendsto_natCast_atTop_atTop
+      have : (0 : ℝ) ≤ (m : ℝ) := Nat.cast_nonneg m
+      linarith
+    have hinv : Tendsto (fun m : ℕ => (2 * (m : ℝ) + 2)⁻¹) atTop (𝓝 0) := hden.inv_tendsto_atTop
+    have hsub : Tendsto (fun m : ℕ => 1 - (2 * (m : ℝ) + 2)⁻¹) atTop (𝓝 (1 - 0)) :=
+      tendsto_const_nhds.sub hinv
+    rw [sub_zero] at hsub
+    refine hsub.congr' ?_
+    filter_upwards [eventually_ge_atTop 0] with m _
+    have h2 : (2 * (m : ℝ) + 2) ≠ 0 := by positivity
+    field_simp
+    ring
+  have hsqrt1 : Tendsto (fun m : ℕ => Real.sqrt ((2 * (m : ℝ) + 1) / (2 * (m : ℝ) + 2)))
+      atTop (𝓝 1) := by
+    have hc := (Real.continuous_sqrt.tendsto 1).comp hrat
+    simpa using hc
+  have hprod : Tendsto (fun m : ℕ => (Nat.centralBinom (m + 1) : ℝ)
+        / ((4 : ℝ) ^ (m + 1) / Real.sqrt (Real.pi * ((m + 1 : ℕ) : ℝ)))
+      * Real.sqrt ((2 * (m : ℝ) + 1) / (2 * (m : ℝ) + 2))) atTop (𝓝 (1 * 1)) :=
+    hcbr1.mul hsqrt1
+  rw [one_mul] at hprod
+  refine Tendsto.congr' ?_ hprod
+  filter_upwards [eventually_ge_atTop 0] with m _
+  rw [eq_comm]
+  -- Pointwise: the target ratio equals `centralBinom-ratio · √((2m+1)/(2m+2))`.
+  set A := (Nat.choose (2 * m + 1) ((2 * m + 1) / 2) : ℝ)
+      / (stirlingConstant * (2 : ℝ) ^ (2 * m + 1) / Real.sqrt ((2 * m + 1 : ℕ) : ℝ)) with hAdef
+  set B := (Nat.centralBinom (m + 1) : ℝ)
+        / ((4 : ℝ) ^ (m + 1) / Real.sqrt (Real.pi * ((m + 1 : ℕ) : ℝ)))
+      * Real.sqrt ((2 * (m : ℝ) + 1) / (2 * (m : ℝ) + 2)) with hBdef
+  have hcast : (Nat.choose (2 * m + 1) m : ℝ) = (Nat.centralBinom (m + 1) : ℝ) / 2 := by
+    have h := odd_choose_eq m
+    have h' : (2 : ℝ) * (Nat.choose (2 * m + 1) m : ℝ) = (Nat.centralBinom (m + 1) : ℝ) := by
+      exact_mod_cast h
+    linarith
+  have hA0 : 0 ≤ A := by
+    rw [hAdef]
+    refine div_nonneg (by positivity) (div_nonneg ?_ (Real.sqrt_nonneg _))
+    exact mul_nonneg stirlingConstant_pos.le (by positivity)
+  have hB0 : 0 ≤ B := by rw [hBdef]; positivity
+  have hsq : A ^ 2 = B ^ 2 := by
+    rw [hAdef, hBdef, show (2 * m + 1) / 2 = m from by omega, hcast,
+        show (2 : ℝ) ^ (2 * m + 1) = 2 * (4 : ℝ) ^ m from by rw [pow_succ, pow_mul]; ring,
+        show (4 : ℝ) ^ (m + 1) = 4 * (4 : ℝ) ^ m from by rw [pow_succ]; ring]
+    simp only [div_pow, mul_pow]
+    rw [Real.sq_sqrt (show (0 : ℝ) ≤ ((2 * m + 1 : ℕ) : ℝ) from by positivity),
+        Real.sq_sqrt (show (0 : ℝ) ≤ Real.pi * ((m + 1 : ℕ) : ℝ) from by positivity),
+        Real.sq_sqrt (show (0 : ℝ) ≤ (2 * (m : ℝ) + 1) / (2 * (m : ℝ) + 2) from by positivity),
+        stirlingConstant_sq]
+    have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+    have h4 : (4 : ℝ) ^ m ≠ 0 := by positivity
+    have h2m2 : (2 * (m : ℝ) + 2) ≠ 0 := by positivity
+    push_cast
+    field_simp
+    ring
+  exact (Real.sqrt_sq hA0).symm.trans ((congrArg Real.sqrt hsq).trans (Real.sqrt_sq hB0))
+
+/-- **Stirling's approximation for central binomials.**
+    `C(n, ⌊n/2⌋) / (√(2/π) · 2ⁿ/√n) → 1`. Proved from Mathlib's Stirling
+    equivalence; the even and odd subsequences are handled separately. -/
+theorem stirling_central_approx :
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,
+      |(Nat.choose n (n / 2) : ℝ) / (stirlingConstant * 2^n / Real.sqrt n) - 1| < ε := by
+  have hmain : Tendsto (fun n : ℕ => (Nat.choose n (n / 2) : ℝ)
+      / (stirlingConstant * (2 : ℝ) ^ n / Real.sqrt (n : ℝ))) atTop (𝓝 1) := by
+    rw [Metric.tendsto_atTop]
+    intro ε hε
+    obtain ⟨Na, hNa⟩ := Metric.tendsto_atTop.mp even_ratio_tendsto ε hε
+    obtain ⟨Nb, hNb⟩ := Metric.tendsto_atTop.mp odd_ratio_tendsto ε hε
+    refine ⟨2 * max Na Nb + 1, fun n hn => ?_⟩
+    have hNa' : Na ≤ max Na Nb := le_max_left _ _
+    have hNb' : Nb ≤ max Na Nb := le_max_right _ _
+    rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+    · have hm : Na ≤ m := by omega
+      have hd := hNa m hm
+      rwa [show m + m = 2 * m from (two_mul m).symm]
+    · have hm : Nb ≤ m := by omega
+      exact hNb m hm
+  intro ε hε
+  obtain ⟨N, hN⟩ := Metric.tendsto_atTop.mp hmain ε hε
+  refine ⟨N, fun n hn => ?_⟩
+  have hd := hN n hn
+  rwa [Real.dist_eq] at hd
 
 /-- F(n) = C(n, n/2) exactly (Erdős-Kleitman + Hunter).
     This follows from Problem 447 and the observation that
@@ -444,15 +643,18 @@ theorem erdos_1023_asymptotic :
 
 5. **Computational Verification**: Middle layer sizes for n = 0, 2, 4, 6.
 
-### Axioms Used (2 deep results)
+### Axioms Used (1 deep result)
 - `problem_447_solution`: 2-union-free max = C(n, n/2)
-- `stirling_central_approx`: Stirling approximation for central binomials
 
 ### Axioms Eliminated (vs main file's 5 axioms)
 - `asymptoticConstant` → concrete `stirlingConstant = √(2/π)`
 - `asymptoticConstant_pos` → proved `stirlingConstant_pos`
 - `unionFreeMax_asymptotic` → proved `erdos_1023_asymptotic`
   (from `unionFreeMax_eq_middle` + `stirling_central_approx`)
+- `stirling_central_approx` → **proved** from Mathlib's
+  `Stirling.factorial_isEquivalent_stirling` via the central-binomial
+  asymptotic `C(2n, n) ~ 4ⁿ/√(πn)` (even/odd subsequence split).
+  `#print axioms` ⇒ `[propext, Classical.choice, Quot.sound]`.
 -/
 
 end Erdos1023OQ01

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,109 @@
+[
+  {
+    "id": "ann-forward",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Forward: Intertwiner Induces a K[X]-Module Isomorphism",
+    "content": "`aeval_linearEquiv_of_conj` takes a $K$-linear automorphism $e$ with $e \\circ \\varphi = \\psi \\circ e$ and produces a $K[X]$-linear isomorphism $\\mathrm{AEval}'\\,\\varphi \\simeq \\mathrm{AEval}'\\,\\psi$. The underlying map is just $e$; the intertwining hypothesis is exactly what makes $e$ commute with the $X$-action ($X$ acts as $\\varphi$ on the source, $\\psi$ on the target), so `LinearEquiv.ofAEval` upgrades it to a $K[X]$-linear equivalence. This repackages the construction Mathlib uses internally in `LinearEquiv.isSemisimple_iff`.",
+    "mathContext": "If $e\\varphi = \\psi e$ then on $\\mathrm{AEval}'$ modules $e(X \\cdot m) = X \\cdot e(m)$, so $e$ is $K[X]$-linear.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polynomial module (Module.AEval')",
+      "intertwining operator",
+      "LinearEquiv.ofAEval"
+    ],
+    "prerequisites": [
+      "K[X]-module from an endomorphism",
+      "linear equivalence"
+    ]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 125
+    },
+    "type": "theorem",
+    "title": "Converse: Module Isomorphism Recovers an Intertwiner",
+    "content": "`conj_of_aeval_linearEquiv` is the new content not present in Mathlib. Given a $K[X]$-linear isomorphism $E : \\mathrm{AEval}'\\,\\varphi \\simeq \\mathrm{AEval}'\\,\\psi$, it builds $e = (\\mathrm{of}\\,\\psi)^{-1} \\circ E \\circ (\\mathrm{of}\\,\\varphi) : M \\simeq_K M$ and proves the intertwining identity $e \\circ \\varphi = \\psi \\circ e$. The proof pulls $X$ through $E$: using $\\mathrm{of}\\,\\varphi(\\varphi m) = X \\cdot \\mathrm{of}\\,\\varphi(m)$, the $K[X]$-linearity of $E$, and $(\\mathrm{of}\\,\\psi)^{-1}(X \\cdot w) = \\psi((\\mathrm{of}\\,\\psi)^{-1} w)$.",
+    "mathContext": "$e(\\varphi m) = (\\mathrm{of}\\,\\psi)^{-1}(E(X \\cdot \\mathrm{of}\\,\\varphi\\, m)) = (\\mathrm{of}\\,\\psi)^{-1}(X \\cdot E(\\mathrm{of}\\,\\varphi\\, m)) = \\psi(e\\, m)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "restriction of scalars",
+      "of_symm_X_smul",
+      "module isomorphism"
+    ],
+    "prerequisites": [
+      "K[X]-linear maps are K-linear",
+      "the X-action encodes the operator"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 139
+    },
+    "type": "theorem",
+    "title": "The Bridge: Similarity is Module Isomorphism",
+    "content": "`conj_iff_nonempty_aeval_linearEquiv` combines the two directions: operators $\\varphi, \\psi$ are similar (there exists an intertwining automorphism) **if and only if** the $K[X]$-modules $\\mathrm{AEval}'\\,\\varphi$ and $\\mathrm{AEval}'\\,\\psi$ are isomorphic. This is the structural reduction at the heart of the rational canonical form — the statement that turns a classification of operators up to similarity into a classification of modules up to isomorphism.",
+    "mathContext": "$\\varphi \\sim \\psi \\iff \\mathrm{AEval}'\\,\\varphi \\cong \\mathrm{AEval}'\\,\\psi$ as $K[X]$-modules.",
+    "significance": "key",
+    "relatedConcepts": [
+      "matrix similarity",
+      "rational canonical form",
+      "invariant factors"
+    ],
+    "prerequisites": [
+      "the two directions above"
+    ]
+  },
+  {
+    "id": "ann-torsion",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+    "range": {
+      "startLine": 141,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "Torsion: Activating the PID Structure Theorem",
+    "content": "`aeval_isTorsion` shows that for finite-dimensional $M$, the module $\\mathrm{AEval}'\\,\\varphi$ is a torsion $K[X]$-module. The torsion witness is the characteristic polynomial of $\\varphi$: it is monic (hence a nonzero divisor in the domain $K[X]$) and annihilates the whole module by the Cayley-Hamilton theorem. This is precisely the hypothesis `Module.IsTorsion` required by `Module.equiv_directSum_of_isTorsion`, the PID structure theorem that produces the invariant-factor decomposition.",
+    "mathContext": "$\\chi_\\varphi$ is monic, so $\\chi_\\varphi \\in K[X]^{\\times 0}$, and $\\mathrm{aeval}\\,\\varphi\\,\\chi_\\varphi = 0$ kills every element.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cayley-Hamilton theorem",
+      "torsion module",
+      "PID structure theorem"
+    ],
+    "prerequisites": [
+      "characteristic polynomial is monic",
+      "nonzero divisors in K[X]"
+    ]
+  },
+  {
+    "id": "ann-matrix-corollary",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+    "range": {
+      "startLine": 159,
+      "endLine": 166
+    },
+    "type": "theorem",
+    "title": "Matrix-Level Corollary via toLin'",
+    "content": "`matrix_conj_iff_nonempty_aeval_linearEquiv` specializes the bridge to square matrices $A, B$ over $K$ through `Matrix.toLin'`, giving the classical statement: $A$ and $B$ are similar if and only if the $K[X]$-modules attached to $\\mathrm{toLin}'\\,A$ and $\\mathrm{toLin}'\\,B$ are isomorphic.",
+    "mathContext": "For $A, B \\in M_n(K)$: $A \\sim B \\iff \\mathrm{AEval}'(\\mathrm{toLin}'\\,A) \\cong \\mathrm{AEval}'(\\mathrm{toLin}'\\,B)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matrix.toLin'",
+      "matrix similarity"
+    ],
+    "prerequisites": [
+      "matrices as linear maps"
+    ]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,200 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+  "title": "Similarity is K[X]-Module Isomorphism (Heart of Rational Canonical Form)",
+  "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+  "description": "The structural reduction underlying the rational canonical form: two linear operators are similar if and only if their associated K[X]-modules (M with X acting as the operator) are isomorphic. Combined with the PID structure theorem, this is why invariant factors are a complete similarity invariant while the minimal polynomial alone is not. Includes the matrix-level corollary and the torsion property that lets the structure theorem apply.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Rational_canonical_form",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "module-theory",
+      "similarity",
+      "rational-canonical-form",
+      "invariant-factors",
+      "polynomial-module",
+      "PID-structure-theorem",
+      "AEval",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Module.AEval'",
+        "description": "The K[X]-module structure on M induced by an endomorphism, with X acting as the endomorphism",
+        "module": "Mathlib.Algebra.Polynomial.Module.AEval"
+      },
+      {
+        "theorem": "LinearEquiv.ofAEval",
+        "description": "Builds a K[X]-linear equivalence out of AEval R M a from a K-linear map commuting with the X-action",
+        "module": "Mathlib.Algebra.Polynomial.Module.AEval"
+      },
+      {
+        "theorem": "Module.AEval'.of_symm_X_smul",
+        "description": "Transports the X-action through the canonical identification: (of φ).symm (X • m) = φ ((of φ).symm m)",
+        "module": "Mathlib.Algebra.Polynomial.Module.AEval"
+      },
+      {
+        "theorem": "LinearMap.aeval_self_charpoly",
+        "description": "Cayley-Hamilton: the characteristic polynomial annihilates the endomorphism",
+        "module": "Mathlib.LinearAlgebra.Charpoly.Basic"
+      },
+      {
+        "theorem": "Module.equiv_directSum_of_isTorsion",
+        "description": "PID structure theorem: a finitely generated torsion module over a PID decomposes by invariant factors (the downstream classification this bridge reduces to)",
+        "module": "Mathlib.Algebra.Module.PID"
+      }
+    ],
+    "originalContributions": [
+      "Standalone equivalence aeval_linearEquiv_of_conj: an intertwiner e∘φ = ψ∘e induces a K[X]-module isomorphism AEval' φ ≃ AEval' ψ (repackaging Mathlib's internal construction in LinearEquiv.isSemisimple_iff)",
+      "New converse conj_of_aeval_linearEquiv: a K[X]-module isomorphism AEval' φ ≃ AEval' ψ recovers a K-linear intertwiner conjugating φ to ψ (not present in Mathlib)",
+      "The full bridge conj_iff_nonempty_aeval_linearEquiv: similarity of operators ⟺ isomorphism of associated K[X]-modules",
+      "aeval_isTorsion: for finite-dimensional M, AEval' φ is a torsion K[X]-module (via Cayley-Hamilton), supplying the exact hypothesis of the PID structure theorem",
+      "Matrix-level corollary matrix_conj_iff_nonempty_aeval_linearEquiv via Matrix.toLin'"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 166,
+    "assumptions": "None beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). All five declarations verified axiom-free in that sense; 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Frobenius (1878) and Weierstrass established the rational canonical form: over any field, the similarity class of a matrix is completely determined by its sequence of invariant factors. The modern viewpoint, due to the structure theory of modules over a principal ideal domain (PID), recasts this as follows. A matrix A over a field K turns the vector space K^n into a module over the polynomial ring K[x], with x acting as A. Two matrices are similar precisely when these K[x]-modules are isomorphic, and the classification of finitely generated torsion K[x]-modules (every such module is a direct sum of cyclic modules K[x]/(f_i) with f_1 | f_2 | ... ) yields the invariant factors. This is the conceptual reason the minimal polynomial alone (the largest invariant factor) cannot determine similarity.",
+    "problemStatement": "**Open Question** (from cayley-hamilton-minpoly-oq-02-oq-02): the minimal and characteristic polynomials are not a complete similarity invariant; the invariant factors / rational canonical form are. Can the organizing principle A ∼ B ⟺ RCF(A) = RCF(B) be formalized?\n\nThis entry formalizes the structural core: **similarity of operators is exactly isomorphism of the associated K[X]-modules**, the reduction that makes invariant factors a complete invariant.",
+    "text": "Two linear operators φ, ψ on a K-vector space are similar (conjugate by an automorphism) if and only if the K[X]-modules they induce — the space with X acting as φ, resp. as ψ — are isomorphic. This is the module-theoretic heart of the rational canonical form.",
+    "proofStrategy": "Use Mathlib's Module.AEval' φ, the type synonym of M on which a polynomial f acts by aeval φ f and in particular X acts as φ. Forward: an intertwiner e∘φ = ψ∘e makes the underlying K-linear equivalence e commute with the X-action, so LinearEquiv.ofAEval upgrades it to a K[X]-linear isomorphism. Converse: given a K[X]-linear isomorphism E, sandwich it between the canonical K-linear identifications of φ and of ψ to get e : M ≃ₗ[K] M; K[X]-linearity of E at X (of_symm_X_smul) is exactly the intertwining identity e∘φ = ψ∘e. The torsion property follows from Cayley-Hamilton: the monic characteristic polynomial is a nonzero divisor annihilating the whole module.",
+    "keyInsights": [
+      "Similarity is not merely detected by module isomorphism — it IS module isomorphism; the two notions coincide on the nose",
+      "The X-action encodes the operator: X • m = φ m, so a K[X]-linear map is precisely a K-linear map intertwining the operators",
+      "LinearEquiv.ofAEval converts 'K-linear and commutes with X' into 'K[X]-linear', making the forward direction a one-liner",
+      "The converse direction (module iso ⟹ similarity) is the new content; Mathlib only had the forward construction internally",
+      "Cayley-Hamilton gives the torsion hypothesis: the characteristic polynomial is a nonzero-divisor annihilator, so the PID structure theorem applies to AEval' φ"
+    ],
+    "prerequisites": [
+      "Matrix/operator similarity (conjugation by an automorphism)",
+      "The polynomial ring K[X] as a PID",
+      "Modules over a PID and the structure theorem (invariant factors)",
+      "The K[X]-module attached to an endomorphism (Module.AEval')",
+      "Cayley-Hamilton theorem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header: Similarity as Module Isomorphism",
+      "startLine": 1,
+      "endLine": 79,
+      "summary": "Documentation header explaining the reduction at the heart of the rational canonical form: similarity of operators equals isomorphism of the associated K[X]-modules. States how this combines with Mathlib's PID structure theorem to make invariant factors a complete invariant, and lists the five results proved. Imports the AEval polynomial-module API, the PID structure theorem, matrix-to-linear-map machinery, and Cayley-Hamilton.",
+      "mathContext": "For φ : M →ₗ[K] M the module AEval' φ is M with X • m = φ m. Goal: φ ∼ ψ ⟺ AEval' φ ≅ AEval' ψ as K[X]-modules."
+    },
+    {
+      "id": "forward",
+      "title": "Forward: Intertwiner ⟹ Module Isomorphism",
+      "startLine": 82,
+      "endLine": 103,
+      "summary": "aeval_linearEquiv_of_conj: from a K-linear automorphism e with e∘φ = ψ∘e, builds the K[X]-linear isomorphism AEval' φ ≃ₗ[K[X]] AEval' ψ via LinearEquiv.ofAEval, using that the intertwining hypothesis makes e commute with the X-action.",
+      "mathContext": "If e φ = ψ e then e : M ≃ₗ[K] M satisfies e(X • m) = X • e(m) on AEval' modules, hence is K[X]-linear."
+    },
+    {
+      "id": "converse",
+      "title": "Converse: Module Isomorphism ⟹ Intertwiner",
+      "startLine": 105,
+      "endLine": 125,
+      "summary": "conj_of_aeval_linearEquiv: from a K[X]-linear isomorphism E : AEval' φ ≃ AEval' ψ, recovers e = (of ψ)⁻¹ ∘ E ∘ (of φ) : M ≃ₗ[K] M and proves e∘φ = ψ∘e by pulling X through E (of_symm_X_smul). This direction is new content not in Mathlib.",
+      "mathContext": "E(X • x) = X • E(x); with of φ (φ m) = X • of φ m and (of ψ).symm (X • w) = ψ ((of ψ).symm w), this gives e(φ m) = ψ(e m)."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge: Similarity ⟺ K[X]-Module Isomorphism",
+      "startLine": 127,
+      "endLine": 139,
+      "summary": "conj_iff_nonempty_aeval_linearEquiv combines the two directions into the equivalence (∃ intertwiner) ↔ Nonempty (AEval' φ ≃ₗ[K[X]] AEval' ψ): the structural reduction underlying the rational canonical form.",
+      "mathContext": "φ ∼ ψ ⟺ AEval' φ ≅ AEval' ψ as K[X]-modules."
+    },
+    {
+      "id": "torsion",
+      "title": "Torsion: Enabling the PID Structure Theorem",
+      "startLine": 141,
+      "endLine": 157,
+      "summary": "aeval_isTorsion: for finite-dimensional M, AEval' φ is a torsion K[X]-module. The witness is the monic (hence nonzero-divisor) characteristic polynomial, which annihilates the module by Cayley-Hamilton. This is exactly the hypothesis required by Module.equiv_directSum_of_isTorsion.",
+      "mathContext": "charpoly(φ) is a nonzero divisor with aeval φ charpoly = 0, so every element of AEval' φ is torsion."
+    },
+    {
+      "id": "matrix-corollary",
+      "title": "Matrix-Level Corollary",
+      "startLine": 159,
+      "endLine": 166,
+      "summary": "matrix_conj_iff_nonempty_aeval_linearEquiv specializes the bridge to matrices A, B via Matrix.toLin', giving the classical phrasing: A and B are similar iff the K[X]-modules of toLin' A and toLin' B are isomorphic.",
+      "mathContext": "For A, B : Matrix n n K, A ∼ B ⟺ AEval' (toLin' A) ≅ AEval' (toLin' B)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Similarity of linear operators is precisely isomorphism of their associated K[X]-modules. This single reduction — proved in both directions, with the torsion property that activates the PID structure theorem — is the conceptual engine of the rational canonical form and explains why the full invariant-factor sequence, not just the minimal polynomial, determines the similarity class.",
+    "implications": "1. **Complete invariant via modules**: Composing this bridge with Module.equiv_directSum_of_isTorsion reduces 'A ∼ B ⟺ RCF(A) = RCF(B)' to 'isomorphic torsion K[X]-modules have the same invariant factors'.\n\n2. **Why minpoly is insufficient**: The minimal polynomial is only the largest invariant factor (the K[X]-module's exponent), so it cannot distinguish modules with the same exponent but different decompositions — exactly the sibling counterexample.\n\n3. **Reusable converse**: Mathlib previously had only the forward construction (inside LinearEquiv.isSemisimple_iff). The packaged equivalence and the converse make the operator/module dictionary directly usable.",
+    "openQuestions": [
+      "Assemble the full classification A ∼ B ⟺ equal invariant factors by combining this bridge with Module.equiv_directSum_of_isTorsion and a uniqueness statement for invariant factors.",
+      "Formalize that the minimal polynomial equals the largest invariant factor (the module's exponent / annihilator generator), pinning down precisely the information minpoly loses."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Polynomial.Module.AEval",
+      "Mathlib.Algebra.Module.PID",
+      "Mathlib.LinearAlgebra.Matrix.ToLin",
+      "Mathlib.LinearAlgebra.Charpoly.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Polynomial",
+      "Module",
+      "Matrix"
+    ],
+    "namespace": "RCFSimilarityBridge",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent gave a concrete counterexample showing minpoly + charpoly are not a complete invariant. This entry supplies the positive structural reason — similarity is K[X]-module isomorphism — that makes invariant factors the complete invariant."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Sibling built the single Jordan block J_n(μ) (one elementary divisor). This entry provides the framework into which such blocks assemble: each block is a cyclic summand of the K[X]-module."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-02",
+      "relationship": "related",
+      "description": "Grandparent proved similar matrices share a minimal polynomial (forward invariance). The module bridge here both refines that (similarity is module iso) and explains its converse failure."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd edition",
+      "note": "Section 12.2: the rational canonical form as the invariant-factor decomposition of the F[x]-module K^n, with x acting as the matrix."
+    },
+    {
+      "authors": "Hoffman, Kenneth; Kunze, Ray",
+      "title": "Linear Algebra",
+      "year": "1971",
+      "venue": "Prentice-Hall, 2nd edition",
+      "note": "Chapter 7: the K[x]-module attached to an operator and the rational canonical form as the complete similarity invariant."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/erdos-1023-oq-01/meta.json
+++ b/src/data/proofs/erdos-1023-oq-01/meta.json
@@ -63,9 +63,9 @@
   },
   "leanFile": {
     "namespace": "Erdos1023OQ01",
-    "lineCount": 458,
-    "axiomCount": 2,
-    "theoremCount": 36,
+    "lineCount": 660,
+    "axiomCount": 1,
+    "theoremCount": 45,
     "definitionCount": 20,
     "path": "Proofs/Erdos1023OQ01.lean",
     "sorries": 0

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
   "title": "Rational Canonical Form Determines Similarity Class",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,28 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE: Formalized the structural reduction similarity <=> K[X]-module isomorphism (AEval), the heart of RCF, plus the torsion property enabling the PID structure theorem. 4 thm + 1 def, 0 axioms, 0 sorries.",
+    "builtItems": [
+      "aeval_linearEquiv_of_conj (CayleyHamiltonMinpolyOQ02OQ02OQ01.lean:92): intertwiner => AEval' phi iso AEval' psi over K[X]",
+      "conj_of_aeval_linearEquiv (:105): K[X]-module iso => intertwiner (new, not in Mathlib)",
+      "conj_iff_nonempty_aeval_linearEquiv (:127): full bridge phi~psi iff Nonempty (AEval' phi iso AEval' psi)",
+      "aeval_isTorsion (:141): AEval' phi is a torsion K[X]-module for finite-dim M",
+      "matrix_conj_iff_nonempty_aeval_linearEquiv (:159): matrix-level corollary via Matrix.toLin'"
+    ],
+    "insights": [
+      "Mathlib already builds the forward AEval-module iso from an intertwiner internally inside LinearEquiv.isSemisimple_iff (Semisimple.lean:125), but exposes no standalone bridge; the converse (module iso => similarity) was absent.",
+      "Module.AEval' phi makes X act as phi, so a K[X]-linear map between AEval' phi and AEval' psi is exactly a K-linear intertwiner -- similarity literally equals module isomorphism, not merely is detected by it.",
+      "of_symm_X_smul gives (of psi).symm (X*w) = psi((of psi).symm w), the one rewrite needed for the converse direction.",
+      "Cayley-Hamilton (LinearMap.aeval_self_charpoly) + monic=>nonzero-divisor gives AEval' phi torsion for finite-dim M, the exact hypothesis of Module.equiv_directSum_of_isTorsion (PID structure theorem)."
+    ],
+    "mathlibGaps": [
+      "No packaged similarity<=>AEval-module-iso bridge in Mathlib; only the forward half exists, buried inside LinearEquiv.isSemisimple_iff.",
+      "Remaining for full RCF classification: combine this bridge with Module.equiv_directSum_of_isTorsion plus a uniqueness statement for invariant factors (Mathlib lacks a clean invariant-factor uniqueness API for K[X]-modules)."
+    ],
+    "nextSteps": [
+      "Assemble A~B iff equal invariant factors by composing conj_iff_nonempty_aeval_linearEquiv with the PID structure theorem and an invariant-factor uniqueness lemma.",
+      "Prove minpoly phi generates the annihilator of AEval' phi (= largest invariant factor), pinning down what information the minimal polynomial loses."
+    ],
     "markdown": "# Knowledge Base: cayley-hamilton-minpoly-oq-02-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\nThe Rational Canonical Form (RCF) theorem states that two n×n matrices over a field F are similar if and only if they have identical invariant factor sequences. This is strictly stronger than sharing the same minimal polynomial (two matrices can share a minimal polynomial but have different invariant factor sequences and thus not be similar).\n\nKey example: The 3×3 matrices with characteristic polynomial (x-1)³ and minimal polynomial (x-1)² — one might have invariant factors [(x-1), (x-1)²] and another [(x-1)³], which are different despite potentially sharing the minimal polynomial.\n\nThe proof strategy is via the Structure Theorem for finitely generated modules over the PID F[x].\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],


### PR DESCRIPTION
## Summary

Formalizes the **structural reduction underlying the rational canonical form** (problem `cayley-hamilton-minpoly-oq-02-oq-02-oq-01`):

> Two linear operators are **similar** if and only if their associated **K[X]-modules are isomorphic**.

The K[X]-module attached to an endomorphism `φ : M →ₗ[K] M` is `M` with the indeterminate `X` acting as `φ` (Mathlib's `Module.AEval' φ`). This bridge is *why* the invariant factors (rational canonical form) are a **complete** similarity invariant, whereas the minimal polynomial alone — the largest invariant factor — is not (the sibling counterexample `…-oq-02-oq-02`).

## Results (0 axioms, 0 sorries)

| Declaration | Statement |
|---|---|
| `aeval_linearEquiv_of_conj` | intertwiner `e∘φ = ψ∘e` ⟹ `AEval' φ ≃ₗ[K[X]] AEval' ψ` (repackages Mathlib's internal construction in `LinearEquiv.isSemisimple_iff`) |
| `conj_of_aeval_linearEquiv` | K[X]-module iso ⟹ intertwiner — **new content, not in Mathlib** |
| `conj_iff_nonempty_aeval_linearEquiv` | the full bridge: `(∃ intertwiner) ↔ Nonempty (AEval' φ ≃ₗ[K[X]] AEval' ψ)` |
| `aeval_isTorsion` | for finite-dimensional `M`, `AEval' φ` is a torsion K[X]-module (via Cayley–Hamilton) — the exact hypothesis of the PID structure theorem `Module.equiv_directSum_of_isTorsion` |
| `matrix_conj_iff_nonempty_aeval_linearEquiv` | matrix-level corollary via `Matrix.toLin'` |

## Why this matters

Composing this bridge with Mathlib's PID structure theorem reduces the full classification `A ∼ B ⟺ RCF(A) = RCF(B)` to "isomorphic torsion K[X]-modules have the same invariant factors" — one structural reduction in place of an open-ended case analysis over canonical forms. Mathlib previously had only the *forward* half of the dictionary, buried inside `LinearEquiv.isSemisimple_iff`; the converse and the packaged equivalence are the new content.

## Verification

- 4 theorems + 1 def, 166 lines, 0 sorries.
- Verified offline (`lake env lean`); `#print axioms` on all five declarations reports only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no custom axioms, no `Lean.ofReduceBool`).
- Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)