### PR TITLE
audit(erdos-490): correct sorry count 6→3 (gallery integrity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7494,9 +7494,9 @@
     },
     "erdos-490": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-27T07:15:29Z",
-      "result": "clean",
+      "auditCount": 6,
+      "lastAudited": "2026-06-25T17:47:24Z",
+      "result": "issues-fixed",
       "issues": [
         "phantom sidon_bound axiom + van_doorn_observation + their-equivalence narrative; section line drift (issue #14335)"
       ]

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -68,9 +68,9 @@
       "bound_is_optimal: matching lower bound (partially proved)"
     ],
     "axiomCount": 2,
-    "lineCount": 282,
-    "assumptions": "2 axiom(s) and 6 sorry(s). See the Lean source for details.",
-    "theoremCount": 10,
+    "lineCount": 330,
+    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details.",
+    "theoremCount": 12,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -202,12 +202,12 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 282,
+    "lineCount": 330,
     "axiomCount": 2,
-    "theoremCount": 10,
+    "theoremCount": 12,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 6,
+    "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
       "Proofs/Erdos490Aristotle.lean"
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory, solved"
     }
   ],
-  "sorries": 6
+  "sorries": 3
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-490 (Erdős Problem #490: Distinct Products of Two Sets)
**Issue**: meta.json overstated the sorry count and carried stale line/theorem counts. Flagged by the auditor on every cycle (5+ times, since 2026-05-27).

## Evidence

`proofs/Proofs/Erdos490Problem.lean` (330 lines) contains exactly **3** `sorry`s:
- L216 `optimal_has_distinct_products` (distinct-products lemma)
- L241 `distinct_minimal_energy`
- L328 `bound_is_optimal` lower bound (PNT-level estimate)

Companion files `Erdos490ProblemAristotle.lean` / `Erdos490Aristotle.lean` have **0** sorries. Chain total = 3.

**meta claimed**: 6 sorries (in `.sorries`, `.meta.sorries`, `.leanFile.sorries`, and the `assumptions` string)
**actual**: 3

Also refreshed metadata stale relative to the current file:
- `lineCount` 282 → 330
- `theoremCount` 10 → 12 (theorem+lemma decls)

## Not changed (verified correct)

- `status: axiomatized` / `badge: axiom` — the headline results `erdos_490_answer` / `erdos_490` reduce to the in-file `axiom szemeredi_theorem`. Honestly attributed to "Szemerédi 1976" in the description. No overclaiming.
- `axiomCount: 2` — 1 in-file declaration + 1 inherited; conservative, not flagged.

---
Discovered during gallery integrity audit.