### PR TITLE
audit: record 5 clean gallery audits

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24181,8 +24181,43 @@
       "lastAudited": "2026-06-25T17:28:05Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-03": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T18:05:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-04-oq-02": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T18:05:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "catalan-numbers-oq-01-oq-02-oq-02": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T18:05:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-895-counterexample-fin18": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T18:05:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hermite-floor-identity": {
+      "agentId": "auditor-agent",
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T18:05:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T16:05:21Z"
+  "lastUpdated": "2026-06-25T18:05:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 5 clean

Recorded in `audit-tracker.json`. All five passed sorry/axiom/True-stub/badge/narrative checks:

| Proof | status/badge | Notes |
|-------|--------------|-------|
| abel-ruffini-oq-03 | verified/mathlib | 0 real sorry/axiom (the `sorry` grep hit is a docstring). `mathlib` badge correctly credits Mathlib; scoped to the *abelian* inverse Galois problem via Kronecker–Weber, not overclaiming full IGP. |
| angle-trisection-oq-04-oq-02 | verified/original | Self-contained origami-field theory (closure under √/∛, least field, cos π/9). `original` defensible. 0/0. |
| catalan-numbers-oq-01-oq-02-oq-02 | verified/mathlib | 0 real sorry, 0 real native_decide (both grep hits are in one comment "0 sorry, 0 axiom, no native_decide"). |
| erdos-895-counterexample-fin18 | axiomatized/axiom | 2 real `native_decide` (L91, L98). axiomCount=1 = `Lean.ofReduceBool`, fully disclosed in `assumptions` + independent Z3/Python re-verification. Correct conservative treatment per native_decide policy. |
| hermite-floor-identity | verified/original | Elementary self-contained floor identity. 0/0. |

Separately, erdos-490's sorry-count fix (6→3) landed in #30145 (merged).

---
Discovered during gallery integrity audit.