### PR TITLE
audit(erdos-490): revert #30145 — restore correct sorry count (6, not 3)

### DIFF
--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -68,9 +68,9 @@
       "bound_is_optimal: matching lower bound (partially proved)"
     ],
     "axiomCount": 2,
-    "lineCount": 330,
-    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details.",
-    "theoremCount": 12,
+    "lineCount": 282,
+    "assumptions": "2 axiom(s) and 6 sorry(s). See the Lean source for details.",
+    "theoremCount": 10,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
@@ -202,12 +202,12 @@
       "Real"
     ],
     "namespace": "Erdos490",
-    "lineCount": 330,
+    "lineCount": 282,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 10,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 3,
+    "sorries": 6,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",
       "Proofs/Erdos490Aristotle.lean"
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory, solved"
     }
   ],
-  "sorries": 3
+  "sorries": 6
 }


### PR DESCRIPTION
## Self-correction: revert erroneous #30145

**My earlier PR #30145 (merged) was wrong.** It changed erdos-490's meta to `sorries: 3`, `lineCount: 330`, `theoremCount: 12`. Those values came from a **transient uncommitted working-tree read** — a concurrent researcher's in-progress 330-line/3-sorry edit that was present in the shared main checkout when I sampled the file, then reset away.

The **committed** `proofs/Proofs/Erdos490Problem.lean` on origin/main is and was:
- **282 lines**
- **6 `sorry`s** (lines 139, 174, 199, 275, 277, 280)
- **10 theorem/lemma** declarations

This matches the *original* meta. This PR restores:
- `sorries` 3 → **6** (×3 fields + assumptions string)
- `lineCount` 330 → **282** (×2)
- `theoremCount` 12 → **10** (×2)

Verified against `git show origin/main:` (immune to working-tree corruption), so this is the committed reality.

Lesson recorded: never audit count-claims from the shared main working tree during concurrent agent activity — verify via `git show origin/main:<path>`.

---
Gallery integrity audit self-correction.