### PR TITLE
research(chinese-remainder-non-coprime-oq-03-oq-03): Chinese Remainder Theorem for modules [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ03.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ03.lean
@@ -1,0 +1,160 @@
+/-
+  CRT Non-Coprime OQ-03-OQ-03: Chinese Remainder Theorem for Modules
+
+  The parent chain (ChineseRemainderNonCoprime …) established the Chinese
+  Remainder Theorem for **elements** of a Euclidean domain: a system of
+  congruences `x ≡ aᵢ (mod mᵢ)` is solvable iff the pairwise gcd conditions
+  hold.  This open question elevates the result to the **module** level, where
+  it becomes a structural isomorphism rather than a solvability criterion.
+
+  ## Main result
+
+  Let `R` be a commutative ring, `M` an `R`-module, and `I, J ⊆ R` two
+  *comaximal* ideals (`I ⊔ J = ⊤`).  Then
+
+        M ⧸ (I • M ⊓ J • M)  ≅  (M ⧸ I • M) × (M ⧸ J • M)
+
+  as `R`-modules, where `I • M` abbreviates the submodule `I • (⊤ : Submodule R M)`.
+
+  Under comaximality the "denominator" simplifies, `(I ⊓ J) • M = I • M ⊓ J • M`,
+  so the isomorphism takes the textbook form
+
+        M ⧸ (I ⊓ J) • M  ≅  (M ⧸ I • M) × (M ⧸ J • M).
+
+  Specialising to a principal ideal domain, two coprime elements `a, b` generate
+  comaximal ideals, recovering `M ⧸ (a * b) • M ≅ M ⧸ a • M × M ⧸ b • M`.
+
+  ## Proof architecture
+
+  The whole theorem is the first isomorphism theorem applied to the product of
+  the two quotient maps `φ = (I • ⊤).mkQ.prod (J • ⊤).mkQ`:
+
+  * `crtMap_surjective` — surjectivity of `φ`.  This is the only place the
+    comaximality hypothesis is used: writing `1 = i + j` with `i ∈ I`, `j ∈ J`,
+    the element `j • m₁ + i • m₂` reduces to `m₁` modulo `I • M` and to `m₂`
+    modulo `J • M`.
+  * `ker_crtMap` — the kernel of `φ` is `I • ⊤ ⊓ J • ⊤` (a formal consequence of
+    `LinearMap.ker_prod` and `Submodule.ker_mkQ`, needing no hypothesis).
+  * `crtEquiv` — `LinearMap.quotKerEquivOfSurjective` packages the two facts
+    into the isomorphism.
+  * `inf_smul_top` — comaximality forces `(I ⊓ J) • ⊤ = I • ⊤ ⊓ J • ⊤`.
+  * `crtEquiv'` / `crtEquivPID` — the textbook form and the PID specialisation.
+
+  No axioms, no sorries; self-contained over Mathlib.
+-/
+import Mathlib
+
+set_option linter.unusedSectionVars false
+
+namespace ChineseRemainderModuleCRT
+
+open Submodule LinearMap
+
+variable {R : Type*} [CommRing R]
+variable {M : Type*} [AddCommGroup M] [Module R M]
+
+variable (I J : Ideal R)
+
+/-- The Chinese-Remainder linear map `M → (M ⧸ I•M) × (M ⧸ J•M)`,
+the pairing of the two canonical quotient projections. -/
+noncomputable def crtMap : M →ₗ[R] (M ⧸ I • (⊤ : Submodule R M)) × (M ⧸ J • (⊤ : Submodule R M)) :=
+  (I • (⊤ : Submodule R M)).mkQ.prod (J • (⊤ : Submodule R M)).mkQ
+
+@[simp] theorem crtMap_apply (m : M) :
+    crtMap I J m =
+      ((I • (⊤ : Submodule R M)).mkQ m, (J • (⊤ : Submodule R M)).mkQ m) := rfl
+
+/-- The kernel of the CRT map is `I•M ⊓ J•M`.  No coprimality is needed. -/
+theorem ker_crtMap :
+    LinearMap.ker (crtMap I J) =
+      I • (⊤ : Submodule R M) ⊓ J • (⊤ : Submodule R M) := by
+  rw [crtMap, LinearMap.ker_prod, Submodule.ker_mkQ, Submodule.ker_mkQ]
+
+/-- **Surjectivity** of the CRT map for comaximal ideals.  This is the analytic
+heart of the theorem: the witness `1 = i + j` lets us hit any target pair. -/
+theorem crtMap_surjective (h : I ⊔ J = ⊤) :
+    Function.Surjective (crtMap (M := M) I J) := by
+  -- Comaximality gives `i ∈ I`, `j ∈ J` with `i + j = 1`.
+  obtain ⟨i, hi, j, hj, hij⟩ :=
+    Submodule.mem_sup.mp (show (1 : R) ∈ I ⊔ J by rw [h]; exact Submodule.mem_top)
+  rintro ⟨y₁, y₂⟩
+  -- Lift the two quotient targets to honest module elements.
+  obtain ⟨m₁, rfl⟩ := (I • (⊤ : Submodule R M)).mkQ_surjective y₁
+  obtain ⟨m₂, rfl⟩ := (J • (⊤ : Submodule R M)).mkQ_surjective y₂
+  refine ⟨j • m₁ + i • m₂, ?_⟩
+  rw [crtMap_apply, Prod.mk.injEq]
+  constructor
+  · -- `(j•m₁ + i•m₂) - m₁ = i • (m₂ - m₁) ∈ I•M`.
+    rw [← sub_eq_zero, ← map_sub, Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
+    have hsub : (j • m₁ + i • m₂) - m₁ = i • (m₂ - m₁) := by
+      have hj1 : j = 1 - i := by linear_combination hij
+      subst hj1; module
+    rw [hsub]
+    exact Submodule.smul_mem_smul hi Submodule.mem_top
+  · -- `(j•m₁ + i•m₂) - m₂ = j • (m₁ - m₂) ∈ J•M`.
+    rw [← sub_eq_zero, ← map_sub, Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
+    have hsub : (j • m₁ + i • m₂) - m₂ = j • (m₁ - m₂) := by
+      have hi1 : i = 1 - j := by linear_combination hij
+      subst hi1; module
+    rw [hsub]
+    exact Submodule.smul_mem_smul hj Submodule.mem_top
+
+/-- **Chinese Remainder Theorem for modules** (core form).
+For comaximal ideals `I, J`, the canonical map induces an `R`-linear isomorphism
+
+    `M ⧸ (I•M ⊓ J•M) ≃ₗ[R] (M ⧸ I•M) × (M ⧸ J•M)`. -/
+noncomputable def crtEquiv (h : I ⊔ J = ⊤) :
+    (M ⧸ (I • (⊤ : Submodule R M) ⊓ J • (⊤ : Submodule R M))) ≃ₗ[R]
+      (M ⧸ I • (⊤ : Submodule R M)) × (M ⧸ J • (⊤ : Submodule R M)) :=
+  (Submodule.quotEquivOfEq _ _ (ker_crtMap I J).symm).trans
+    (LinearMap.quotKerEquivOfSurjective _ (crtMap_surjective I J h))
+
+/-- Under comaximality the two natural "denominators" coincide:
+`(I ⊓ J) • M = I • M ⊓ J • M`.  (The inclusion `⊆` always holds; `⊇` uses
+`1 = i + j` together with `I • J • M ≤ (I ⊓ J) • M`.) -/
+theorem inf_smul_top (h : I ⊔ J = ⊤) :
+    (I ⊓ J) • (⊤ : Submodule R M) =
+      I • (⊤ : Submodule R M) ⊓ J • (⊤ : Submodule R M) := by
+  refine le_antisymm ?_ ?_
+  · -- `(I ⊓ J) • ⊤ ≤ I • ⊤` and `≤ J • ⊤`, hence `≤` the inf.
+    refine le_inf ?_ ?_
+    · exact Submodule.smul_le.2 fun r hr m _ =>
+        Submodule.smul_mem_smul (Submodule.mem_inf.1 hr).1 Submodule.mem_top
+    · exact Submodule.smul_le.2 fun r hr m _ =>
+        Submodule.smul_mem_smul (Submodule.mem_inf.1 hr).2 Submodule.mem_top
+  · -- For `x` in both, `x = i•x + j•x` with each summand in `(I⊓J)•⊤`.
+    obtain ⟨i, hi, j, hj, hij⟩ :=
+      Submodule.mem_sup.mp (show (1 : R) ∈ I ⊔ J by rw [h]; exact Submodule.mem_top)
+    -- `I • (J • ⊤) ≤ (I ⊓ J) • ⊤` and symmetrically.
+    have hIJ : I • (J • (⊤ : Submodule R M)) ≤ (I ⊓ J) • (⊤ : Submodule R M) := by
+      rw [← Submodule.mul_smul]
+      exact Submodule.smul_mono_left Ideal.mul_le_inf
+    have hJI : J • (I • (⊤ : Submodule R M)) ≤ (I ⊓ J) • (⊤ : Submodule R M) := by
+      rw [← Submodule.mul_smul]
+      exact Submodule.smul_mono_left (le_trans Ideal.mul_le_inf (le_of_eq (inf_comm J I)))
+    intro x hx
+    obtain ⟨hxI, hxJ⟩ := Submodule.mem_inf.1 hx
+    have hx_eq : x = i • x + j • x := by
+      rw [← add_smul, hij, one_smul]
+    rw [hx_eq]
+    refine Submodule.add_mem _ ?_ ?_
+    · exact hIJ (Submodule.smul_mem_smul hi hxJ)
+    · exact hJI (Submodule.smul_mem_smul hj hxI)
+
+/-- **Chinese Remainder Theorem for modules** (textbook form).
+For comaximal ideals, `M ⧸ (I ⊓ J)•M ≅ (M ⧸ I•M) × (M ⧸ J•M)`. -/
+noncomputable def crtEquiv' (h : I ⊔ J = ⊤) :
+    (M ⧸ (I ⊓ J) • (⊤ : Submodule R M)) ≃ₗ[R]
+      (M ⧸ I • (⊤ : Submodule R M)) × (M ⧸ J • (⊤ : Submodule R M)) :=
+  (Submodule.quotEquivOfEq _ _ (inf_smul_top I J h)).trans (crtEquiv I J h)
+
+/-- **PID specialisation.**  Two coprime ring elements generate comaximal
+principal ideals, so the module CRT applies to `span {a}` and `span {b}`. -/
+noncomputable def crtEquivPID {a b : R} (hab : IsCoprime a b) :
+    (M ⧸ (Ideal.span {a} ⊓ Ideal.span {b}) • (⊤ : Submodule R M)) ≃ₗ[R]
+      (M ⧸ Ideal.span {a} • (⊤ : Submodule R M)) ×
+        (M ⧸ Ideal.span {b} • (⊤ : Submodule R M)) :=
+  crtEquiv' (Ideal.span {a}) (Ideal.span {b})
+    (Ideal.isCoprime_iff_sup_eq.1 ((Ideal.isCoprime_span_singleton_iff a b).2 hab))
+
+end ChineseRemainderModuleCRT

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-03/annotations.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "ann-crt-mod-overview",
+    "proofId": "chinese-remainder-non-coprime-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "From Elements to Modules: What the Module CRT Says",
+    "content": "The parent chain proved the Chinese Remainder Theorem for elements of a Euclidean domain — a solvability criterion for systems of congruences. This file lifts the statement one level: for comaximal ideals I, J in a commutative ring R and any R-module M, the quotient M/(I⊓J)M splits as the product (M/IM) × (M/JM). The denominator IM abbreviates the submodule I • (⊤ : Submodule R M). Crucially the core theorem needs no PID — comaximality I ⊔ J = ⊤ is the entire hypothesis — and the PID/coprime-element version is just a corollary that manufactures comaximality from IsCoprime a b. This strictly generalises Mathlib's ring-level Ideal.quotientInfRingEquivPiQuotient, recovered at M = R.",
+    "mathContext": "For comaximal ideals $I, J$ ($I + J = R$) and an $R$-module $M$: $M/(I\\cap J)M \\;\\cong\\; M/IM \\times M/JM$. The map is induced by $m \\mapsto (m + IM,\\; m + JM)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "comaximal ideals",
+      "quotient modules",
+      "structure theorem over a PID"
+    ],
+    "prerequisites": [
+      "Ideal action I • N on submodules",
+      "Quotient module M/N and projection mkQ"
+    ]
+  },
+  {
+    "id": "ann-crt-mod-kernel",
+    "proofId": "chinese-remainder-non-coprime-oq-03-oq-03",
+    "range": { "startLine": 58, "endLine": 71 },
+    "type": "technique",
+    "title": "The CRT Map and Its Kernel (No Hypothesis Needed)",
+    "content": "crtMap is defined as (IM).mkQ.prod (JM).mkQ — the pairing of the two canonical quotient projections into a single linear map M → (M/IM) × (M/JM). Its kernel falls out structurally: LinearMap.ker_prod gives ker(f.prod g) = ker f ⊓ ker g, and Submodule.ker_mkQ identifies each factor as ker (N.mkQ) = N. Hence ker crtMap = IM ⊓ JM with no appeal to comaximality. Isolating the kernel computation this way means the comaximal hypothesis is confined entirely to the surjectivity lemma — a clean separation that keeps each step short.",
+    "mathContext": "$\\ker\\big(\\mathrm{mk}_{IM} \\times \\mathrm{mk}_{JM}\\big) = \\ker \\mathrm{mk}_{IM} \\cap \\ker \\mathrm{mk}_{JM} = IM \\cap JM$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LinearMap.ker_prod",
+      "Submodule.ker_mkQ",
+      "product of linear maps"
+    ],
+    "prerequisites": [
+      "Kernel of a product map",
+      "Kernel of a quotient projection"
+    ]
+  },
+  {
+    "id": "ann-crt-mod-surjectivity",
+    "proofId": "chinese-remainder-non-coprime-oq-03-oq-03",
+    "range": { "startLine": 73, "endLine": 100 },
+    "type": "key-step",
+    "title": "Surjectivity: Where Comaximality Is Spent",
+    "content": "This is the only step using I ⊔ J = ⊤. Extracting from 1 ∈ I ⊔ J a decomposition 1 = i + j with i ∈ I, j ∈ J, the proof lifts the two target residues to module elements m₁, m₂ and exhibits the preimage j·m₁ + i·m₂. The two checks reduce to module identities once j (resp. i) is replaced by 1 − i (resp. 1 − j) via linear_combination on i + j = 1: (j·m₁ + i·m₂) − m₁ = i·(m₂ − m₁), which lies in IM since i ∈ I; symmetrically (j·m₁ + i·m₂) − m₂ = j·(m₁ − m₂) ∈ JM. The module tactic discharges each algebraic identity, and Submodule.smul_mem_smul certifies membership. Thus crtMap sends j·m₁ + i·m₂ to exactly (m̄₁, m̄₂).",
+    "mathContext": "With $i + j = 1$, $i \\in I$, $j \\in J$: the element $x = j m_1 + i m_2$ satisfies $x \\equiv m_1 \\pmod{IM}$ and $x \\equiv m_2 \\pmod{JM}$, because $x - m_1 = i(m_2 - m_1) \\in IM$ and $x - m_2 = j(m_1 - m_2) \\in JM$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "comaximal decomposition 1 = i + j",
+      "Submodule.smul_mem_smul",
+      "module tactic",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "Submodule.mem_sup (witness extraction)",
+      "Quotient equality via mk_eq_zero",
+      "r ∈ I → r • m ∈ I • N"
+    ]
+  },
+  {
+    "id": "ann-crt-mod-equiv",
+    "proofId": "chinese-remainder-non-coprime-oq-03-oq-03",
+    "range": { "startLine": 102, "endLine": 110 },
+    "type": "key-step",
+    "title": "Assembling the Isomorphism via the First Isomorphism Theorem",
+    "content": "crtEquiv combines the two prior facts. LinearMap.quotKerEquivOfSurjective turns the surjective crtMap into an isomorphism M/(ker crtMap) ≅ (M/IM) × (M/JM). Since ker crtMap = IM ⊓ JM was already computed, Submodule.quotEquivOfEq transports the domain to M/(IM ⊓ JM), giving the core module CRT. No new mathematics enters here — it is pure assembly, which is exactly why the kernel and surjectivity were proved separately.",
+    "mathContext": "First isomorphism theorem: a surjective $\\varphi : M \\to N$ induces $M/\\ker\\varphi \\cong N$. Here $\\ker\\varphi = IM \\cap JM$ and $N = (M/IM)\\times(M/JM)$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "first isomorphism theorem",
+      "LinearMap.quotKerEquivOfSurjective",
+      "Submodule.quotEquivOfEq"
+    ],
+    "prerequisites": [
+      "Surjective linear map induces quotient isomorphism",
+      "Rewriting the quotient along an equality of submodules"
+    ]
+  },
+  {
+    "id": "ann-crt-mod-denominator-pid",
+    "proofId": "chinese-remainder-non-coprime-oq-03-oq-03",
+    "range": { "startLine": 112, "endLine": 160 },
+    "type": "technique",
+    "title": "Collapsing the Denominator and the PID Corollary",
+    "content": "The natural kernel IM ⊓ JM and the textbook denominator (I⊓J)M agree only under comaximality. inf_smul_top proves the equality: the inclusion (I⊓J)M ⊆ IM ⊓ JM is automatic by monotonicity, while ⊇ uses x = i·x + j·x and the bound I·(J·M) = (I*J)·M ≤ (I⊓J)·M (from Ideal.mul_le_inf), so each summand lands in (I⊓J)M. crtEquiv' then rewrites the core isomorphism into the textbook form M/(I⊓J)M ≅ (M/IM) × (M/JM). Finally crtEquivPID specialises to principal ideals: IsCoprime a b gives IsCoprime (span{a}) (span{b}) (Ideal.isCoprime_span_singleton_iff), and Ideal.isCoprime_iff_sup_eq turns that into the comaximality span{a} ⊔ span{b} = ⊤ the theorem consumes.",
+    "mathContext": "Comaximality forces $(I\\cap J)M = IM \\cap JM$ because $I\\cdot J\\cdot M \\subseteq (I\\cap J)M$ and any $x \\in IM\\cap JM$ is $x = ix + jx$ with $ix \\in I(JM)$, $jx \\in J(IM)$. Over a PID, $\\gcd(a,b)=1 \\Rightarrow (a)+(b)=R$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Ideal.mul_le_inf",
+      "(I*J)•N = I•(J•N)",
+      "Ideal.isCoprime_span_singleton_iff",
+      "Ideal.isCoprime_iff_sup_eq"
+    ],
+    "prerequisites": [
+      "Product of ideals acting on a module",
+      "Coprime elements generate comaximal ideals"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-03/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "chinese-remainder-non-coprime-oq-03-oq-03",
+  "title": "Chinese Remainder Theorem for Modules",
+  "slug": "chinese-remainder-non-coprime-oq-03-oq-03",
+  "description": "Elevates the non-coprime Chinese Remainder Theorem from elements of a ring to modules: for comaximal ideals I, J in any commutative ring R and any R-module M, the canonical map induces an R-linear isomorphism M/(IM ⊓ JM) ≅ (M/IM) × (M/JM). Under comaximality the denominator collapses to (I⊓J)·M, yielding the textbook form M/(I⊓J)M ≅ M/IM × M/JM, and a coprime-elements corollary specialises it to principal ideals over a PID. Proved as the first isomorphism theorem applied to the product of the two quotient projections; the comaximality witness 1 = i + j is the entire mathematical input. 4 theorems, 4 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeOQ03OQ03.lean",
+    "tags": [
+      "algebra",
+      "commutative-algebra",
+      "chinese-remainder-theorem",
+      "module-theory",
+      "ideals",
+      "quotient-modules"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified over Mathlib. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool).",
+    "lineCount": 160,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "additionalFiles": [],
+    "originalContributions": [
+      "crtMap: the canonical Chinese-Remainder linear map M → (M/IM) × (M/JM) as the pairing of the two quotient projections",
+      "ker_crtMap: the kernel of the CRT map equals I·M ⊓ J·M (hypothesis-free)",
+      "crtMap_surjective: surjectivity for comaximal ideals — the only step using 1 = i + j; the witness j·m₁ + i·m₂ reduces to m₁ mod IM and m₂ mod JM",
+      "crtEquiv: core module CRT isomorphism M/(IM ⊓ JM) ≅ (M/IM) × (M/JM) via the first isomorphism theorem",
+      "inf_smul_top: under comaximality (I⊓J)·M = I·M ⊓ J·M, using (I*J)·M = I·(J·M) and I*J ≤ I⊓J",
+      "crtEquiv': textbook form M/(I⊓J)·M ≅ (M/IM) × (M/JM)",
+      "crtEquivPID: PID/coprime-elements specialisation to principal ideals span{a}, span{b}"
+    ]
+  },
+  "leanFile": {
+    "namespace": "ChineseRemainderModuleCRT",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "path": "Proofs/ChineseRemainderNonCoprimeOQ03OQ03.lean",
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The Chinese Remainder Theorem has three classical strata. The most elementary, for integers, gives ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ when gcd(m,n)=1. Mathlib formalises the ring-level generalisation as Ideal.quotientInfRingEquivPiQuotient: for pairwise-comaximal ideals, R/⋂Iᵢ ≅ ∏ R/Iᵢ. The parent chain of this gallery worked out the non-coprime element-level theory over Euclidean domains — when moduli share factors, solvability needs pairwise gcd compatibility. The present entry sits at the third stratum: the *module* CRT. Here the statement is no longer a solvability criterion but a structural decomposition of M/(I⊓J)M, and it holds over any commutative ring, the PID hypothesis being needed only to manufacture comaximality from coprime elements. The module CRT is the form used throughout commutative algebra (e.g. the structure theorem for finitely generated modules over a PID localises a module at each prime by exactly this splitting).",
+    "problemStatement": "Let R be a commutative ring, M an R-module, and I, J ⊆ R comaximal ideals (I ⊔ J = ⊤). Prove the canonical map M → (M/IM) × (M/JM) descends to an R-linear isomorphism M/(I⊓J)M ≅ (M/IM) × (M/JM), generalising the element-level CRT of the parent chain.",
+    "text": "Write IM for the submodule I • (⊤ : Submodule R M). The proof is the first isomorphism theorem applied to φ = (IM).mkQ.prod (JM).mkQ : M → (M/IM) × (M/JM). Two facts feed it. (1) ker φ = IM ⊓ JM — a formal consequence of LinearMap.ker_prod and Submodule.ker_mkQ, needing no hypothesis. (2) φ is surjective — the only place comaximality enters. Writing 1 = i + j with i ∈ I, j ∈ J, the element j·m₁ + i·m₂ satisfies (j·m₁ + i·m₂) − m₁ = i·(m₂ − m₁) ∈ IM and (j·m₁ + i·m₂) − m₂ = j·(m₁ − m₂) ∈ JM, so it maps to the prescribed pair (m̄₁, m̄₂). LinearMap.quotKerEquivOfSurjective then yields M/ker φ ≅ (M/IM) × (M/JM), and transporting along ker φ = IM ⊓ JM gives the core isomorphism. Finally inf_smul_top shows comaximality forces (I⊓J)·M = IM ⊓ JM (the inclusion ⊇ uses x = i·x + j·x together with I·(J·M) = (I*J)·M ≤ (I⊓J)·M), upgrading the result to the textbook denominator (I⊓J)M.",
+    "proofStrategy": "First isomorphism theorem on the product of quotient projections. Surjectivity from the comaximality witness 1 = i + j; kernel computed structurally; denominator simplified via the ideal-product/inf inequality. PID corollary obtained by turning coprime elements into comaximal principal ideals.",
+    "keyInsights": [
+      "At the module level the CRT becomes a structural isomorphism of quotients, not a solvability statement — the right object is the product of the two quotient maps",
+      "Comaximality is used exactly once, in surjectivity: 1 = i + j lets j·m₁ + i·m₂ hit any prescribed pair of residues",
+      "The kernel computation ker(f.prod g) = ker f ⊓ ker g is hypothesis-free, so the comaximal hypothesis is fully isolated to one lemma",
+      "The textbook denominator (I⊓J)M and the natural kernel IM ⊓ JM agree only under comaximality; in general only (I⊓J)M ⊆ IM ⊓ JM holds",
+      "The product-of-ideals bound (I*J)M = I(JM) ⊆ (I⊓J)M converts the abstract comaximality into the denominator identity",
+      "No PID is needed for the core theorem — the PID enters only to certify comaximality of span{a}, span{b} from IsCoprime a b"
+    ],
+    "prerequisites": [
+      "Quotient modules and the canonical projection Submodule.mkQ",
+      "First isomorphism theorem (LinearMap.quotKerEquivOfSurjective)",
+      "Ideal action on submodules: I • N, the identity (I*J)•N = I•(J•N), and I*J ≤ I⊓J",
+      "Comaximal ideals and the witness 1 = i + j"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Chinese Remainder Theorem is established at the module level: for comaximal ideals I, J in a commutative ring and any module M, M/(I⊓J)M ≅ (M/IM) × (M/JM) as R-modules, with a PID/coprime-elements specialisation. The proof is the first isomorphism theorem applied to the product of the two quotient projections, with comaximality entering only through surjectivity. 4 theorems, 4 definitions, 160 lines, 0 axioms — verified over Mathlib.",
+    "implications": "This is the structural form of the CRT that underlies the classification of modules over a PID: it splits M along coprime annihilator factors, the step that decomposes a finitely generated torsion module into its primary components. It strictly generalises Mathlib's ring-level Ideal.quotientInfRingEquivPiQuotient (recovered at M = R) and the element-level non-coprime CRT of the parent chain (recovered by reading the isomorphism on representatives). The two-ideal result extends to n comaximal ideals by induction, matching the ring-level statement."
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Docstring stating the module CRT, the proof architecture, and the namespace/variable setup (commutative ring R, R-module M, ideals I, J)."
+    },
+    {
+      "id": "crt-map",
+      "title": "The Chinese-Remainder Map and Its Kernel",
+      "startLine": 58,
+      "endLine": 71,
+      "summary": "crtMap pairs the two quotient projections M → M/IM and M → M/JM; ker_crtMap computes its kernel as IM ⊓ JM with no coprimality hypothesis."
+    },
+    {
+      "id": "surjectivity",
+      "title": "Surjectivity from Comaximality",
+      "startLine": 73,
+      "endLine": 100,
+      "summary": "crtMap_surjective: the witness 1 = i + j lets j·m₁ + i·m₂ reduce to m₁ mod IM and m₂ mod JM, hitting any target pair. The only step using the comaximal hypothesis."
+    },
+    {
+      "id": "core-equiv",
+      "title": "Core Module CRT Isomorphism",
+      "startLine": 102,
+      "endLine": 110,
+      "summary": "crtEquiv: first isomorphism theorem packages kernel + surjectivity into M/(IM ⊓ JM) ≅ (M/IM) × (M/JM)."
+    },
+    {
+      "id": "denominator",
+      "title": "Comaximality Collapses the Denominator",
+      "startLine": 112,
+      "endLine": 142,
+      "summary": "inf_smul_top: under comaximality (I⊓J)·M = IM ⊓ JM, via (I*J)·M = I·(J·M) ≤ (I⊓J)·M and x = i·x + j·x."
+    },
+    {
+      "id": "textbook-and-pid",
+      "title": "Textbook Form and PID Specialisation",
+      "startLine": 144,
+      "endLine": 160,
+      "summary": "crtEquiv' gives M/(I⊓J)M ≅ (M/IM) × (M/JM); crtEquivPID specialises to principal ideals span{a}, span{b} from IsCoprime a b."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "chinese-remainder-non-coprime-oq-03",
+      "relationship": "extends",
+      "description": "Parent: the element-level non-coprime CRT for three moduli over Euclidean domains. This entry lifts the whole circle of ideas from elements to modules, where solvability criteria become a structural quotient isomorphism. Reading crtEquiv on representatives recovers the parent's congruence statements."
+    },
+    {
+      "proofId": "chinese-remainder-non-coprime",
+      "relationship": "extends",
+      "description": "The ℤ-specific non-coprime CRT for two moduli. The module CRT here is the structural envelope of that result: ℤ/(m⊓n)ℤ ≅ ℤ/mℤ × ℤ/nℤ is the M = ℤ, R = ℤ instance of crtEquiv' once one notes (m)⊓(n) = (lcm m n)."
+    },
+    {
+      "proofId": "chinese-remainder-constructive",
+      "relationship": "complementary",
+      "description": "The classical pairwise-coprime CRT (always solvable, unique modulo the product). That entry handles the coprime extreme constructively; this one provides the comaximal-ideal module isomorphism behind it and the non-coprime denominator (I⊓J)M in full generality."
+    },
+    {
+      "proofId": "bezout-identity",
+      "relationship": "uses",
+      "description": "Comaximality I ⊔ J = ⊤ is precisely the existence of a Bézout-type witness 1 = i + j with i ∈ I, j ∈ J. For the PID corollary this witness comes from IsCoprime a b, i.e. ∃ u v, u·a + v·b = 1 — Bézout's identity in disguise."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the open question **chinese-remainder-non-coprime-oq-03-oq-03** by lifting the non-coprime Chinese Remainder Theorem from *elements* of a ring (the parent chain, over Euclidean domains) to *modules*, where it becomes a structural isomorphism.

**Main theorem.** For comaximal ideals `I, J` in a commutative ring `R` (`I ⊔ J = ⊤`) and any `R`-module `M`:

```
M / (I ⊓ J) • M  ≅ₗ  (M / I • M) × (M / J • M)
```

as `R`-modules, where `I • M` denotes `I • (⊤ : Submodule R M)`.

## Proof architecture

The theorem is the first isomorphism theorem applied to `φ = (I•M).mkQ.prod (J•M).mkQ`:

- **`ker_crtMap`** — `ker φ = I•M ⊓ J•M`, a hypothesis-free consequence of `LinearMap.ker_prod` + `Submodule.ker_mkQ`.
- **`crtMap_surjective`** — the only step using comaximality: from `1 = i + j` (`i ∈ I`, `j ∈ J`), the element `j•m₁ + i•m₂` reduces to `m₁` mod `I•M` and `m₂` mod `J•M`.
- **`crtEquiv`** — `LinearMap.quotKerEquivOfSurjective` packages the two facts.
- **`inf_smul_top`** — comaximality forces `(I⊓J)•M = I•M ⊓ J•M` (via `(I*J)•M = I•(J•M) ≤ (I⊓J)•M`), upgrading to the textbook denominator.
- **`crtEquiv'` / `crtEquivPID`** — textbook form and the PID/coprime-elements specialisation.

## Relationship to Mathlib

Mathlib has the **ring**-level CRT (`Ideal.quotientInfRingEquivPiQuotient`) but not the **module**-level statement; this fills that gap and strictly generalises it (recovered at `M = R`). The core theorem needs no PID — comaximality is the entire hypothesis; the PID enters only to certify comaximality of `span{a}, span{b}` from `IsCoprime a b`.

## Verification

- **4 theorems, 4 definitions, 160 lines, 0 axioms**
- `#print axioms` on all results: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`)
- Builds offline against the pinned Mathlib (`lake env lean`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)