### PR TITLE
research(divisibility-by-3-oq-01-oq-02): S2 — math-verify merged osculators, scope duality follow-up

### DIFF
--- a/research/problems/divisibility-by-3-oq-01-oq-02/knowledge.md
+++ b/research/problems/divisibility-by-3-oq-01-oq-02/knowledge.md
@@ -70,3 +70,55 @@ prime is purely a matter of supplying its osculator constant — **no new machin
 - After Docker is restored: `./proofs/scripts/docker-build.sh Proofs.DivisibilityTruncationGeneral`.
   If green, flip candidate status available → completed and (optionally) generate a
   follow-up OQ on whether `c` can be produced uniformly via a decidable osculator function.
+
+### Session 2026-06-25 (S2) — VERIFY (math) + follow-up scoped
+
+**Mode**: REVISIT (S1 work already merged via PR #23115)
+**Outcome**: no new code (verification blackout); independent math check + ready-to-formalize follow-up
+
+**What I did**
+- Confirmed S1's additions are present and merged on `main`
+  (`fortyone_dvd_trunc`, `fortythree_dvd_trunc`, `extended_truncation_coverage`;
+  file is 284 lines, 18 theorems, **0 axioms, 0 sorries**).
+- **Independently re-checked the two new osculators by hand:**
+  - 41 (negative): `10·4 + 1 = 41 = 41·1` ✓ → `41 ∣ n ↔ 41 ∣ (n/10 − 4·(n%10))`.
+  - 43 (positive): `10·13 − 1 = 129 = 43·3` ✓ → `43 ∣ n ↔ 43 ∣ (n/10 + 13·(n%10))`.
+  Both are correct; the new theorems are structurally identical to the merged
+  23/29/31/37 instances. The OQ ("extend coverage to 23,29,31,37,41,43") is
+  **mathematically solved**; only the canonical Docker build remains to bless it.
+
+**Build status**
+- Still NOT verifiable locally this session: Docker daemon down, no local Mathlib
+  oleans, host disk at 99% (≈13Gi free — fetching the olean cache is unsafe), and
+  the Aristotle MCP endpoint returned `Resource not found` (service unavailable).
+  Deliberately did **not** append unverified Lean to the already-merged working
+  file: a single typo would fail the whole-project build and could jeopardize S1's
+  merged content with no way to check. Left for the deployer's Docker build.
+
+**Follow-up worked out (ready to formalize next session, needs no new machinery):**
+*Osculator duality* — the positive and negative truncation rules are NOT independent.
+If `c` is a positive osculator for `d` (`d ∣ 10c − 1`), then `d − c` is a negative
+osculator (`d ∣ 10(d−c) + 1`), and conversely. Proof is pure `dvd` arithmetic:
+`10(d−c) + 1 = 10d − (10c − 1)`, and `d ∣ 10d` with `d ∣ (10c − 1)` give the result
+via `dvd_sub`. Consequence: `truncation_neg` is derivable from `truncation_pos`
+(and vice versa), so the framework needs only one general theorem. Candidate
+statements (verify once a build path returns):
+```lean
+theorem neg_osculator_of_pos (d : ℕ) (c : ℤ) (hc : (d:ℤ) ∣ 10*c - 1) :
+    (d:ℤ) ∣ 10*((d:ℤ) - c) + 1 := by
+  have hkey : (10:ℤ)*((d:ℤ) - c) + 1 = 10*(d:ℤ) - (10*c - 1) := by ring
+  rw [hkey]; exact Int.dvd_sub (dvd_mul_left (d:ℤ) 10) hc
+theorem pos_osculator_of_neg (d : ℕ) (c : ℤ) (hc : (d:ℤ) ∣ 10*c + 1) :
+    (d:ℤ) ∣ 10*((d:ℤ) - c) - 1 := by
+  have hkey : (10:ℤ)*((d:ℤ) - c) - 1 = 10*(d:ℤ) - (10*c + 1) := by ring
+  rw [hkey]; exact Int.dvd_sub (dvd_mul_left (d:ℤ) 10) hc
+```
+This is theory-level (a structural duality between the two rule forms), not a
+shallow per-prime extension, so it is a legitimate follow-up rather than a cosmetic
+variant. Adding *more primes* (47, 49, …) is explicitly NOT worth doing — pure
+repetition of the existing pattern.
+
+**Next steps (unchanged + refined)**
+- When any build path returns (Docker up, or Aristotle MCP reachable, or local
+  cache safe to fetch): build the merged file to bless this OQ, then add the two
+  duality theorems above and re-verify.


### PR DESCRIPTION
## Summary

The OQ *"extend truncation coverage beyond 19 (23, 29, 31, 37, 41, 43)"* is **already solved and merged** (PR #23115): `extended_truncation_coverage` in `DivisibilityTruncationGeneral.lean` bundles all six primes. This session independently verifies that result and scopes a theory-level follow-up.

## What this PR does (knowledge-only)
- **Independent hand-check of the two new osculators** added in S1:
  - 41 (negative, c=4): `10·4 + 1 = 41 = 41·1` ✓
  - 43 (positive, c=13): `10·13 − 1 = 129 = 43·3` ✓
  - Both correct; theorems are structurally identical to the merged 23/29/31/37 instances. File is 284 lines, 18 theorems, **0 axioms / 0 sorries**.
- **Documents a worked-out follow-up** — *osculator duality*: if `c` is a positive osculator for `d` (`d ∣ 10c−1`) then `d−c` is a negative osculator (`d ∣ 10(d−c)+1`), and conversely. This makes `truncation_neg` derivable from `truncation_pos`; ready-to-build statements included in `knowledge.md`. It is theory-level (a structural duality), not a shallow per-prime extension.

## Why no new Lean code
Verification blackout this session: Docker daemon down, no local Mathlib oleans, host disk at 99%% (cache fetch unsafe), and the Aristotle MCP endpoint returned `Resource not found`. Per project policy I did **not** append unverified Lean to the already-merged working file — a single typo would fail the whole-project build. The merged S1 code still awaits the deployer's canonical Docker build to be blessed `completed`.

## Files
- `research/problems/divisibility-by-3-oq-01-oq-02/knowledge.md` — S2 session log

🤖 Generated with [Claude Code](https://claude.com/claude-code)