### PR TITLE
research(cauchy-schwarz-oq-01-oq-02-oq-01): one Gram-Schmidt step is an orthogonal projector [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ02OQ01.lean
@@ -1,0 +1,152 @@
+/-
+# Gram-Schmidt via Cauchy-Schwarz — OQ-01: one step is an orthogonal projector
+
+Open Question (cauchy-schwarz-oq-01-oq-02-oq-01), a follow-up to
+`CauchySchwarzOQ01OQ02.lean` (Gram-Schmidt via Cauchy-Schwarz).
+
+The parent file showed the Gram-Schmidt projection `orthProj v u = (⟪v,u⟫/⟪v,v⟫)•v`
+is **bounded** (`‖orthProj v u‖ ≤ ‖u‖`), produces an **orthogonal residual**
+(`⟪gsStep v u, v⟫ = 0`), and satisfies **Pythagoras**. It did NOT establish that
+`u ↦ orthProj v u` is an *orthogonal projector* in the operator sense.
+
+This file proves exactly that, with **zero axioms and zero sorries**:
+
+* **Idempotency** `orthProj v (orthProj v u) = orthProj v u` (`P² = P`).
+* **Kernel** `orthProj v (gsStep v u) = 0`: the projector annihilates the residual.
+* **Residual idempotency** `gsStep v (gsStep v u) = gsStep v u` (`(1−P)² = 1−P`).
+* **Reconstruction** `orthProj v u + gsStep v u = u` (`P + (1−P) = id`).
+* **Exact norm** `‖orthProj v u‖ = ‖⟪v,u⟫‖ / ‖v‖` (the Cauchy-Schwarz bound is the
+  *value*, not merely an upper bound).
+
+Together these are the projector axioms for the rank-one orthogonal projection onto
+`span{v}`, completing the operator-theoretic picture of one Gram-Schmidt step.
+
+The definitions `orthProj`, `projCoeff`, `gsStep` mirror the verified parent file; this
+file is kept self-contained (Mathlib-only). The scalar field `𝕜` is taken as an explicit
+argument of each definition so the projector identities (whose statements do not otherwise
+mention `𝕜`) are unambiguous.
+-/
+
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+
+open scoped InnerProductSpace
+
+namespace CauchySchwarzOQ01OQ02OQ01
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-! ## Definitions (mirroring the verified parent; `𝕜` explicit) -/
+
+/-- Orthogonal projection of `u` onto `v`: `proj_v(u) = (⟪v,u⟫/⟪v,v⟫) • v`. -/
+noncomputable def orthProj (v u : E) : E :=
+  ((⟪v, u⟫_𝕜 / ⟪v, v⟫_𝕜 : 𝕜)) • v
+
+/-- The projection coefficient `c = ⟪v,u⟫/⟪v,v⟫`. -/
+noncomputable def projCoeff (v u : E) : 𝕜 :=
+  ⟪v, u⟫_𝕜 / ⟪v, v⟫_𝕜
+
+/-- One Gram-Schmidt step: `gsStep v u = u − proj_v(u)`. -/
+noncomputable def gsStep (v u : E) : E :=
+  u - orthProj 𝕜 v u
+
+/-- The residual is orthogonal to the direction vector (right argument). -/
+theorem residual_orthogonal' (u v : E) (hv : v ≠ 0) :
+    ⟪v, u - orthProj 𝕜 v u⟫_𝕜 = 0 := by
+  rw [inner_eq_zero_symm]
+  unfold orthProj
+  simp only [inner_sub_left, inner_smul_left, map_div₀, inner_conj_symm]
+  have hvv : ⟪v, v⟫_𝕜 ≠ 0 := inner_self_ne_zero.mpr hv
+  field_simp
+  ring
+
+/-! ## Part I: The projection is a projector (P² = P) -/
+
+/-- Projecting a multiple of `v` onto `v` returns it unchanged: `orthProj v (c•v) = c•v`.
+    This is the eigenvalue-1 (range) behaviour of the projector. -/
+theorem orthProj_smul_self (v : E) (c : 𝕜) (hv : v ≠ 0) :
+    orthProj 𝕜 v (c • v) = c • v := by
+  unfold orthProj
+  have hvv : ⟪v, v⟫_𝕜 ≠ 0 := inner_self_ne_zero.mpr hv
+  rw [inner_smul_right, mul_div_assoc, div_self hvv, mul_one]
+
+/-- `orthProj v u` lies in `span{v}`, so re-projecting it does nothing:
+    **idempotency** `P² = P`. -/
+theorem orthProj_idempotent (u v : E) (hv : v ≠ 0) :
+    orthProj 𝕜 v (orthProj 𝕜 v u) = orthProj 𝕜 v u := by
+  have h1 : orthProj 𝕜 v u = projCoeff 𝕜 v u • v := rfl
+  rw [h1, orthProj_smul_self 𝕜 v (projCoeff 𝕜 v u) hv]
+
+/-! ## Part II: The projector annihilates the residual -/
+
+/-- The direction vector is orthogonal to the residual (left argument). -/
+theorem inner_left_gsStep (u v : E) (hv : v ≠ 0) :
+    ⟪v, gsStep 𝕜 v u⟫_𝕜 = 0 := by
+  unfold gsStep
+  exact residual_orthogonal' 𝕜 u v hv
+
+/-- The projector kills the residual: `orthProj v (gsStep v u) = 0`.
+    The residual lies in the kernel `(span{v})^⊥`. -/
+theorem orthProj_gsStep_eq_zero (u v : E) (hv : v ≠ 0) :
+    orthProj 𝕜 v (gsStep 𝕜 v u) = 0 := by
+  unfold orthProj
+  rw [inner_left_gsStep 𝕜 u v hv, zero_div, zero_smul]
+
+/-- The residual map `1 − P` is idempotent: `gsStep v (gsStep v u) = gsStep v u`. -/
+theorem gsStep_idempotent (u v : E) (hv : v ≠ 0) :
+    gsStep 𝕜 v (gsStep 𝕜 v u) = gsStep 𝕜 v u := by
+  have h : gsStep 𝕜 v (gsStep 𝕜 v u) = gsStep 𝕜 v u - orthProj 𝕜 v (gsStep 𝕜 v u) := rfl
+  rw [h, orthProj_gsStep_eq_zero 𝕜 u v hv, sub_zero]
+
+/-! ## Part III: Reconstruction `P + (1 − P) = id` -/
+
+/-- The projection and residual reconstruct the input: `orthProj v u + gsStep v u = u`. -/
+theorem orthProj_add_gsStep (u v : E) :
+    orthProj 𝕜 v u + gsStep 𝕜 v u = u := by
+  unfold gsStep
+  abel
+
+/-! ## Part IV: The exact projection norm (Cauchy-Schwarz as an equality) -/
+
+/-- The projection norm equals `‖⟪v,u⟫‖ / ‖v‖` exactly. The parent's CS bound
+    `‖orthProj v u‖ ≤ ‖u‖` is the inequality `‖⟪v,u⟫‖/‖v‖ ≤ ‖u‖` in disguise. -/
+theorem orthProj_norm_eq (u v : E) (hv : v ≠ 0) :
+    ‖orthProj 𝕜 v u‖ = ‖⟪v, u⟫_𝕜‖ / ‖v‖ := by
+  unfold orthProj
+  rw [norm_smul, norm_div]
+  have hvv : ‖⟪v, v⟫_𝕜‖ = ‖v‖ ^ 2 := by
+    rw [inner_self_eq_norm_sq_to_K]
+    simp
+  have hv_ne : ‖v‖ ≠ 0 := by simpa using norm_pos_iff.mpr hv
+  rw [hvv]
+  field_simp
+
+/-- The exact norm recovers the parent's Cauchy-Schwarz upper bound `‖orthProj v u‖ ≤ ‖u‖`. -/
+theorem orthProj_norm_le (u v : E) (hv : v ≠ 0) :
+    ‖orthProj 𝕜 v u‖ ≤ ‖u‖ := by
+  rw [orthProj_norm_eq 𝕜 u v hv]
+  have hv_pos : (0 : ℝ) < ‖v‖ := norm_pos_iff.mpr hv
+  rw [div_le_iff₀ hv_pos]
+  calc ‖⟪v, u⟫_𝕜‖ ≤ ‖v‖ * ‖u‖ := norm_inner_le_norm v u
+    _ = ‖u‖ * ‖v‖ := by ring
+
+/-! ## Part V: Capstone — one Gram-Schmidt step is an orthogonal projector -/
+
+/-- **Summary.** For `v ≠ 0`, `P := orthProj v` is the orthogonal projector onto
+    `span{v}`: it is idempotent, its complement `1 − P = gsStep v` is idempotent,
+    they sum to the identity, and `P` annihilates the residual. -/
+theorem gsStep_is_orthogonal_projector (v : E) (hv : v ≠ 0) :
+    (∀ u : E, orthProj 𝕜 v (orthProj 𝕜 v u) = orthProj 𝕜 v u) ∧
+    (∀ u : E, gsStep 𝕜 v (gsStep 𝕜 v u) = gsStep 𝕜 v u) ∧
+    (∀ u : E, orthProj 𝕜 v u + gsStep 𝕜 v u = u) ∧
+    (∀ u : E, orthProj 𝕜 v (gsStep 𝕜 v u) = 0) :=
+  ⟨fun u => orthProj_idempotent 𝕜 u v hv,
+   fun u => gsStep_idempotent 𝕜 u v hv,
+   fun u => orthProj_add_gsStep 𝕜 u v,
+   fun u => orthProj_gsStep_eq_zero 𝕜 u v hv⟩
+
+end CauchySchwarzOQ01OQ02OQ01

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,105 @@
+[
+  {
+    "id": "ann-overview",
+    "title": "From Bounds to a Projector",
+    "type": "concept",
+    "startLine": 1,
+    "endLine": 38,
+    "mathContext": "The parent (cauchy-schwarz-oq-01-oq-02) proved the Gram-Schmidt projection orthProj v u = (⟪v,u⟫/⟪v,v⟫)•v is bounded, has an orthogonal residual, and obeys Pythagoras. It did not establish that u ↦ orthProj v u is an orthogonal projector. This file supplies the projector axioms: idempotency, complementary idempotency, identity reconstruction, kernel annihilation, and the exact projection norm.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonal projection",
+      "idempotent operator",
+      "Gram-Schmidt",
+      "Cauchy-Schwarz"
+    ],
+    "prerequisites": [
+      "inner product spaces over an RCLike field",
+      "projection onto a line"
+    ],
+    "content": "The single Gram-Schmidt step is exactly the rank-one orthogonal projector onto span{v}; this file proves the operator identities that justify calling it a projector.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 38 }
+  },
+  {
+    "id": "ann-field-explicit",
+    "title": "Why 𝕜 is an Explicit Argument",
+    "type": "proof_technique",
+    "startLine": 40,
+    "endLine": 56,
+    "mathContext": "InnerProductSpace 𝕜 E does not have 𝕜 as an outParam, so a term like orthProj v u : E cannot determine 𝕜 from E alone. The projector statements (orthProj v (orthProj v u) = orthProj v u, etc.) do not mention 𝕜, so leaving it implicit makes typeclass resolution stuck. Making 𝕜 an explicit argument of orthProj/projCoeff/gsStep keeps every statement unambiguous.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "typeclass resolution",
+      "outParam",
+      "definitional API design"
+    ],
+    "prerequisites": [
+      "Lean elaboration and implicit arguments"
+    ],
+    "content": "A small but essential design choice: the scalar field is threaded explicitly so that field-free operator identities elaborate without ambiguity.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+    "range": { "startLine": 40, "endLine": 56 }
+  },
+  {
+    "id": "ann-idempotency",
+    "title": "Idempotency P² = P",
+    "type": "proof_technique",
+    "startLine": 71,
+    "endLine": 85,
+    "mathContext": "orthProj_smul_self: orthProj v (c•v) = c•v, because ⟪v, c•v⟫/⟪v,v⟫ = c·⟪v,v⟫/⟪v,v⟫ = c (inner_smul_right, div_self). Since orthProj v u = projCoeff v u • v lies in span{v}, orthProj v (orthProj v u) = orthProj v u.",
+    "significance": "key",
+    "relatedConcepts": [
+      "idempotent operator",
+      "range of a projector",
+      "inner_smul_right"
+    ],
+    "prerequisites": [
+      "scalar multiplication in inner product spaces"
+    ],
+    "content": "The projector fixes its own range: projecting twice equals projecting once.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 85 }
+  },
+  {
+    "id": "ann-kernel",
+    "title": "Kernel: the projector kills the residual",
+    "type": "proof_technique",
+    "startLine": 86,
+    "endLine": 106,
+    "mathContext": "Since ⟪v, gsStep v u⟫ = 0 (residual orthogonality), orthProj v (gsStep v u) = (0/⟪v,v⟫)•v = 0. Hence the complement gsStep v = 1 − P satisfies gsStep v (gsStep v u) = gsStep v u − 0 = gsStep v u: (1−P)² = 1−P.",
+    "significance": "key",
+    "relatedConcepts": [
+      "kernel of a projector",
+      "orthogonal complement",
+      "complementary idempotents"
+    ],
+    "prerequisites": [
+      "orthogonality of the Gram-Schmidt residual"
+    ],
+    "content": "The residual lives in (span{v})^⊥, the kernel of P; equivalently 1−P is also a projector.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+    "range": { "startLine": 86, "endLine": 106 }
+  },
+  {
+    "id": "ann-exact-norm",
+    "title": "Cauchy-Schwarz as an Equality",
+    "type": "proof_technique",
+    "startLine": 117,
+    "endLine": 140,
+    "mathContext": "orthProj_norm_eq: ‖orthProj v u‖ = ‖⟪v,u⟫/⟪v,v⟫‖·‖v‖ = (‖⟪v,u⟫‖/‖v‖²)·‖v‖ = ‖⟪v,u⟫‖/‖v‖ (norm_smul, norm_div, inner_self_eq_norm_sq_to_K). The parent's bound ‖orthProj v u‖ ≤ ‖u‖ is then exactly ‖⟪v,u⟫‖/‖v‖ ≤ ‖u‖, i.e. norm_inner_le_norm.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy-Schwarz inequality",
+      "projection norm",
+      "norm_smul"
+    ],
+    "prerequisites": [
+      "norm of a scalar multiple",
+      "inner_self_eq_norm_sq_to_K"
+    ],
+    "content": "The exact projection norm shows the Cauchy-Schwarz inequality is the upper bound ‖⟪v,u⟫‖/‖v‖ ≤ ‖u‖ on this quantity.",
+    "proofId": "cauchy-schwarz-oq-01-oq-02-oq-01",
+    "range": { "startLine": 117, "endLine": 140 }
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-02-oq-01",
+  "title": "One Gram-Schmidt Step is an Orthogonal Projector",
+  "slug": "cauchy-schwarz-oq-01-oq-02-oq-01",
+  "description": "A verified (0-axiom, 0-sorry) follow-up to the Gram-Schmidt via Cauchy-Schwarz formalization. The parent established that the projection orthProj v u = (⟪v,u⟫/⟪v,v⟫)•v is bounded, produces an orthogonal residual, and obeys Pythagoras. This file proves the missing operator-theoretic fact: u ↦ orthProj v u is an orthogonal projector onto span{v} — idempotent (P²=P), its complement gsStep is idempotent ((1-P)²=1-P), they reconstruct the identity (P+(1-P)=id), P annihilates the residual, and the projection norm equals ‖⟪v,u⟫‖/‖v‖ exactly (the Cauchy-Schwarz bound as an equality).",
+  "meta": {
+    "author": "Research formalization 2026 (researcher-4)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ02OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-spaces",
+      "gram-schmidt",
+      "orthogonal-projection",
+      "cauchy-schwarz"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 152,
+    "assumptions": "None. Every theorem is verified over an arbitrary RCLike field 𝕜 and inner product space E with zero axioms and zero sorries (only foundational propext/Classical.choice/Quot.sound).",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 3,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "The Gram-Schmidt process orthogonalizes a list of vectors by repeatedly subtracting orthogonal projections. The parent entry (cauchy-schwarz-oq-01-oq-02) formalized one step via Cauchy-Schwarz: the projection coefficient ⟪v,u⟫/⟪v,v⟫ is bounded by ‖u‖/‖v‖, the residual u − proj_v(u) is orthogonal to v, and Pythagoras holds. What it left implicit is the operator-theoretic identity of the step: that orthProj v is a genuine orthogonal projector (P²=P) onto the line span{v}. This follow-up supplies precisely those projector axioms.",
+    "problemStatement": "Is the single Gram-Schmidt step u ↦ orthProj v u an orthogonal projector onto span{v} in the operator sense (idempotent, complementary residual, identity reconstruction, exact norm)?",
+    "text": "Verified projector identities for one Gram-Schmidt step over an arbitrary RCLike inner product space.",
+    "proofStrategy": "Self-contained in namespace CauchySchwarzOQ01OQ02OQ01 (Mathlib-only). The definitions orthProj, projCoeff, gsStep mirror the verified parent, with the scalar field 𝕜 made an explicit argument so the projector identities (whose statements do not otherwise mention 𝕜) are unambiguous. Key steps: orthProj_smul_self (orthProj v (c•v)=c•v via inner_smul_right + div_self) gives idempotency; residual orthogonality (⟪v, u−proj⟫=0) gives that the projector annihilates the residual, hence gsStep idempotency; subtraction unfolds to reconstruction by abel; and orthProj_norm_eq computes ‖orthProj v u‖ = ‖⟪v,u⟫‖/‖v‖ from norm_smul + inner_self_eq_norm_sq_to_K, recovering the parent's CS upper bound as a corollary.",
+    "keyInsights": [
+      "**P² = P**: orthProj v u lies in span{v}, and projecting a multiple of v onto v is the identity (orthProj v (c•v) = c•v), so re-projecting does nothing.",
+      "**The residual is in the kernel**: orthProj v (gsStep v u) = 0 because gsStep v u ⊥ v; equivalently gsStep = 1 − P is itself idempotent.",
+      "**Reconstruction**: orthProj v u + gsStep v u = u is the projector decomposition P + (1−P) = id, proved by simple cancellation.",
+      "**Cauchy-Schwarz as an equality**: ‖orthProj v u‖ = ‖⟪v,u⟫‖/‖v‖ exactly; the parent's bound ‖orthProj v u‖ ≤ ‖u‖ is then just ‖⟪v,u⟫‖/‖v‖ ≤ ‖u‖, i.e. Cauchy-Schwarz.",
+      "**Field-explicit definitions**: making 𝕜 an explicit argument keeps the 𝕜-free projector statements (P²=P etc.) unambiguous, since InnerProductSpace's field is not an outParam."
+    ],
+    "prerequisites": [
+      "Inner product spaces over an RCLike field",
+      "Orthogonal projection onto a line",
+      "Idempotent operators and the projector decomposition id = P + (1−P)",
+      "Cauchy-Schwarz inequality (norm_inner_le_norm)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 42,
+      "endLine": 64,
+      "summary": "orthProj, projCoeff, gsStep (mirroring the verified parent, 𝕜 explicit) and the residual-orthogonality lemma.",
+      "mathContext": "$\\mathrm{orthProj}_v u = \\tfrac{\\langle v,u\\rangle}{\\langle v,v\\rangle} v$, $\\mathrm{gsStep}_v u = u - \\mathrm{orthProj}_v u$, with $\\langle v, u - \\mathrm{orthProj}_v u\\rangle = 0$."
+    },
+    {
+      "id": "idempotency",
+      "title": "Idempotency (P² = P)",
+      "startLine": 66,
+      "endLine": 85,
+      "summary": "orthProj v (c•v) = c•v and hence orthProj v (orthProj v u) = orthProj v u.",
+      "mathContext": "$P^2 = P$ on $\\mathrm{span}\\{v\\}$."
+    },
+    {
+      "id": "kernel",
+      "title": "The projector annihilates the residual",
+      "startLine": 86,
+      "endLine": 106,
+      "summary": "orthProj v (gsStep v u) = 0 and gsStep idempotency (1−P)²=1−P.",
+      "mathContext": "$P(1-P) = 0$, so $(1-P)^2 = 1-P$."
+    },
+    {
+      "id": "reconstruction-norm",
+      "title": "Reconstruction and exact norm",
+      "startLine": 107,
+      "endLine": 140,
+      "summary": "orthProj v u + gsStep v u = u, and ‖orthProj v u‖ = ‖⟪v,u⟫‖/‖v‖ (recovering the parent's CS bound).",
+      "mathContext": "$P + (1-P) = \\mathrm{id}$ and $\\|P u\\| = |\\langle v,u\\rangle|/\\|v\\|$."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone: orthogonal projector",
+      "startLine": 141,
+      "endLine": 152,
+      "summary": "Bundles idempotency, complement idempotency, reconstruction, and kernel into the projector axioms.",
+      "mathContext": "$P$ is the orthogonal projector onto $\\mathrm{span}\\{v\\}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file verifies, with zero axioms and zero sorries, that one Gram-Schmidt step is the orthogonal projector onto span{v}: idempotent, with idempotent complement, summing to the identity, annihilating the residual, and with projection norm equal to ‖⟪v,u⟫‖/‖v‖ exactly.",
+    "implications": "It completes the operator-theoretic picture of Gram-Schmidt left open by the parent, and exhibits the Cauchy-Schwarz inequality as the equality case of the projection norm. These projector identities are the algebraic backbone for an eventual QR-decomposition formalization.",
+    "openQuestions": [
+      "Can pairwise orthogonality of the full gramSchmidtList output be proved by induction over the foldl?",
+      "Can the rank-one projectors be assembled into a QR decomposition?",
+      "Does the projector identity extend to projection onto a finite-dimensional subspace (sum of rank-one projectors over an orthogonal basis)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent: Gram-Schmidt via Cauchy-Schwarz. This file adds the projector identities (P²=P, reconstruction, exact norm) the parent left implicit."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gram, J.P.",
+      "title": "Über die Entwicklung reeller Funktionen in Reihen mittelst der Methode der kleinsten Quadrate",
+      "year": "1883",
+      "venue": "Journal für die reine und angewandte Mathematik 94",
+      "note": "Original Gram-Schmidt orthogonalization"
+    },
+    {
+      "authors": "Schmidt, E.",
+      "title": "Zur Theorie der linearen und nichtlinearen Integralgleichungen",
+      "year": "1907",
+      "venue": "Mathematische Annalen 63",
+      "note": "Schmidt's formulation of the orthogonalization process"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.RCLike.Basic",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "CauchySchwarzOQ01OQ02OQ01",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "path": "Proofs/CauchySchwarzOQ01OQ02OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 3,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Verified (**0-axiom, 0-sorry**) follow-up to `cauchy-schwarz-oq-01-oq-02` (Gram-Schmidt via Cauchy-Schwarz).

The parent established that the projection `orthProj v u = (⟪v,u⟫/⟪v,v⟫)•v` is **bounded** (`‖orthProj v u‖ ≤ ‖u‖`), produces an **orthogonal residual**, and obeys **Pythagoras** — but never showed `u ↦ orthProj v u` is an *orthogonal projector* in the operator sense. This PR proves exactly that.

## What is proved (`Proofs/CauchySchwarzOQ01OQ02OQ01.lean`, Mathlib-only)

- **Idempotency** `orthProj v (orthProj v u) = orthProj v u` (`P² = P`), via `orthProj_smul_self` (`orthProj v (c•v) = c•v`).
- **Kernel** `orthProj v (gsStep v u) = 0`: the projector annihilates the residual; hence **complement idempotency** `gsStep v (gsStep v u) = gsStep v u` (`(1−P)² = 1−P`).
- **Reconstruction** `orthProj v u + gsStep v u = u` (`P + (1−P) = id`).
- **Exact norm** `‖orthProj v u‖ = ‖⟪v,u⟫‖ / ‖v‖` — Cauchy-Schwarz as an *equality*; `orthProj_norm_le` then recovers the parent's `‖orthProj v u‖ ≤ ‖u‖` as a one-line corollary.
- **Capstone** `gsStep_is_orthogonal_projector`: bundles the projector axioms.

## Verification

10 theorems, 3 defs, **0 axioms, 0 sorries**. Typechecked offline via `lake env lean`; `#print axioms` reports only `propext / Classical.choice / Quot.sound` on every theorem (no `sorryAx`, no `Lean.ofReduceBool`).

Note: the definitions take the scalar field `𝕜` as an **explicit** argument, since `InnerProductSpace`'s field is not an `outParam` and the projector statements (`P²=P`, etc.) do not otherwise mention `𝕜`.

## Status

**Outcome**: completed (verified). `status: verified`, `badge: verified`, `axiomCount: 0`.

## Files

- `proofs/Proofs/CauchySchwarzOQ01OQ02OQ01.lean` (new, 152 LOC)
- `src/data/proofs/cauchy-schwarz-oq-01-oq-02-oq-01/{meta.json,annotations.json}` (new gallery entry)

🤖 Generated by researcher-4