### PR TITLE
research: Irreducibility of Φ_p via Eisenstein at X+1 (eisenstein-criterion-oq-01-oq-01) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/EisensteinCriterionOQ01OQ01.lean
+++ b/proofs/Proofs/EisensteinCriterionOQ01OQ01.lean
@@ -1,0 +1,152 @@
+/-
+  Irreducibility of the p-th cyclotomic polynomial Φ_p via Eisenstein at X + 1.
+
+  This is a child of `EisensteinCriterionOQ01`, which packages Eisenstein's
+  irreducibility criterion (`irreducible_of_eisenstein`) and the `Xⁿ − p`
+  family.  Here we carry out the *classical* derivation of the irreducibility
+  of the p-th cyclotomic polynomial
+
+      Φ_p(X) = 1 + X + X² + … + X^{p−1}        (p prime)
+
+  by applying that criterion to the SHIFTED polynomial Φ_p(X + 1).
+
+  **The mechanism.**  From the geometric-sum identity `Φ_p · (X − 1) = X^p − 1`
+  one gets, after substituting `X ↦ X + 1`,
+
+      Φ_p(X + 1) · X = (X + 1)^p − 1.
+
+  Reading off coefficients (`coeff_mul_X`, `coeff_X_add_one_pow`) gives the
+  exact shape
+
+      Φ_p(X + 1) = ∑_{j=0}^{p−1} C(p, j+1) · X^j,        i.e.  coeff j = C(p, j+1).
+
+  The Eisenstein hypotheses at the prime `p` then read off the binomial
+  coefficients:
+
+    * leading coefficient `C(p, p) = 1 ∉ (p)`             (Φ_p(X+1) is monic),
+    * every lower coefficient `C(p, k)` with `1 ≤ k ≤ p−1` lies in `(p)`
+      (`Nat.Prime.dvd_choose_self`),
+    * the constant term `C(p, 1) = p ∉ (p²)`              (else `p ∣ 1`).
+
+  Eisenstein gives irreducibility of `Φ_p(X + 1)`, and since `X ↦ X + 1` is a
+  ring automorphism of `ℤ[X]` (`Polynomial.algEquivAevalXAddC`), irreducibility
+  transfers back to `Φ_p` itself.
+
+  Note: Mathlib already proves `Polynomial.cyclotomic.irreducible` for *all* `n`,
+  but by an entirely different route (the minimal polynomial of a primitive root
+  / Galois theory).  The elementary Eisenstein argument formalized here for the
+  prime case is the textbook proof and is independent of that machinery.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+import Proofs.EisensteinCriterionOQ01
+
+open Polynomial
+
+namespace EisensteinCriterionOQ01OQ01
+
+variable {p : ℕ}
+
+/-! ### The shifted cyclotomic polynomial `Φ_p(X + 1)` -/
+
+/-- **Substitution identity.** `Φ_p(X + 1) · X = (X + 1)^p − 1`.
+
+This is the geometric-sum identity `Φ_p · (X − 1) = X^p − 1` pushed through the
+ring homomorphism `f ↦ f.comp (X + 1)`, noting `(X − 1)(X + 1) ↦ X`. -/
+theorem cyclotomic_comp_X_add_one_mul_X (hp : p.Prime) :
+    (cyclotomic p ℤ).comp (X + C 1) * X = (X + C 1) ^ p - 1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have h := cyclotomic_prime_mul_X_sub_one ℤ p
+  have hc := congrArg (fun q : ℤ[X] => q.comp (X + C 1)) h
+  simp only [mul_comp, sub_comp, pow_comp, X_comp, one_comp] at hc
+  -- `(X - 1).comp (X + C 1) = X`, `(X^p - 1).comp (X + C 1) = (X + C 1)^p - 1`
+  simpa [C_1, add_sub_cancel_right] using hc
+
+/-- **Coefficient formula.** The `j`-th coefficient of `Φ_p(X + 1)` is the
+binomial coefficient `C(p, j + 1)`. -/
+theorem coeff_cyclotomic_comp_X_add_one (hp : p.Prime) (j : ℕ) :
+    ((cyclotomic p ℤ).comp (X + C 1)).coeff j = (p.choose (j + 1) : ℤ) := by
+  have hX := cyclotomic_comp_X_add_one_mul_X hp
+  have h2 := congrArg (fun q : ℤ[X] => q.coeff (j + 1)) hX
+  simp only [coeff_mul_X] at h2
+  rw [h2, coeff_sub, C_1, coeff_X_add_one_pow]
+  simp [coeff_one]
+
+/-! ### Irreducibility of `Φ_p` over `ℤ` -/
+
+/-- **Irreducibility of the p-th cyclotomic polynomial over `ℤ`**, proved by
+applying Eisenstein's criterion (from the parent file) to `Φ_p(X + 1)`. -/
+theorem irreducible_cyclotomic_prime (hp : p.Prime) :
+    Irreducible (cyclotomic p ℤ) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hpZ : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp hp
+  set g : ℤ[X] := (cyclotomic p ℤ).comp (X + C 1) with hg
+  -- `g` is monic of degree `p − 1`.
+  have hmonic : g.Monic := (cyclotomic.monic p ℤ).comp_X_add_C 1
+  have hndeg : g.natDegree = p - 1 := by
+    rw [hg, natDegree_comp, natDegree_X_add_C, mul_one, natDegree_cyclotomic,
+      Nat.totient_prime hp]
+  have hdeg_val : g.degree = (p - 1 : ℕ) := by
+    rw [degree_eq_natDegree hmonic.ne_zero, hndeg]
+  -- The Eisenstein ideal `P = (p)`.
+  set P : Ideal ℤ := Ideal.span {(p : ℤ)} with hP_def
+  have hPprime : P.IsPrime := (Ideal.span_singleton_prime hpZ.ne_zero).mpr hpZ
+  -- Leading coefficient `1 ∉ (p)`.
+  have hlead : g.leadingCoeff ∉ P := by
+    rw [hmonic.leadingCoeff, hP_def, Ideal.mem_span_singleton]
+    intro hdvd
+    exact hp.one_lt.ne' (by exact_mod_cast Int.eq_one_of_dvd_one (by positivity) hdvd)
+  -- All lower coefficients lie in `(p)`.
+  have hlow : ∀ k : ℕ, (k : WithBot ℕ) < g.degree → g.coeff k ∈ P := by
+    intro k hk
+    rw [hdeg_val] at hk
+    have hk' : k < p - 1 := by exact_mod_cast hk
+    rw [coeff_cyclotomic_comp_X_add_one hp, hP_def, Ideal.mem_span_singleton]
+    have hkp : k + 1 < p := by omega
+    have hdvd : (p : ℕ) ∣ p.choose (k + 1) := hp.dvd_choose_self (Nat.succ_ne_zero k) hkp
+    exact_mod_cast hdvd
+  -- Degree is positive.
+  have hdeg : 0 < g.degree := by
+    rw [← natDegree_pos_iff_degree_pos, hndeg]
+    have := hp.two_le; omega
+  -- Constant term `C(p,1) = p ∉ (p²)`.
+  have hconst : g.coeff 0 ∉ P ^ 2 := by
+    have hc0 : g.coeff 0 = (p : ℤ) := by
+      rw [coeff_cyclotomic_comp_X_add_one hp]; simp [Nat.choose_one_right]
+    rw [hc0, hP_def, Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+    intro hdvd
+    -- `p² ∣ p` would force `p² ≤ p`, impossible for `p > 1`.
+    have hp2 : (0 : ℤ) < p := by exact_mod_cast hp.pos
+    have hle := Int.le_of_dvd hp2 hdvd
+    nlinarith [hle, (by exact_mod_cast hp.one_lt : (1 : ℤ) < p)]
+  -- Eisenstein gives irreducibility of `g = Φ_p(X + 1)`.
+  have hg_irred : Irreducible g :=
+    EisensteinCriterionOQ01.irreducible_of_eisenstein hPprime hlead hlow hdeg hconst
+      hmonic.isPrimitive
+  -- Transfer back along the automorphism `X ↦ X + 1`.
+  have hgeq : (algEquivAevalXAddC (1 : ℤ)) (cyclotomic p ℤ) = g := by
+    rw [hg, algEquivAevalXAddC_apply, ← comp_eq_aeval]
+  rw [← hgeq] at hg_irred
+  exact (MulEquiv.irreducible_iff
+    (f := (algEquivAevalXAddC (1 : ℤ)).toMulEquiv)).mp hg_irred
+
+/-! ### Corollaries -/
+
+/-- The degree of `Φ_p` is `p − 1`. -/
+theorem natDegree_cyclotomic_prime (hp : p.Prime) :
+    (cyclotomic p ℤ).natDegree = p - 1 := by
+  rw [natDegree_cyclotomic, Nat.totient_prime hp]
+
+/-- **Irreducibility over `ℚ`.** Since `Φ_p` is monic (hence primitive) over `ℤ`,
+Gauss's lemma upgrades irreducibility over `ℤ` to irreducibility over `ℚ`. -/
+theorem irreducible_cyclotomic_prime_rat (hp : p.Prime) :
+    Irreducible (cyclotomic p ℚ) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hmap : (cyclotomic p ℤ).map (Int.castRingHom ℚ) = cyclotomic p ℚ :=
+    map_cyclotomic_int p ℚ
+  rw [← hmap]
+  exact (IsPrimitive.Int.irreducible_iff_irreducible_map_cast
+    (cyclotomic.isPrimitive p ℤ)).mp (irreducible_cyclotomic_prime hp)
+
+end EisensteinCriterionOQ01OQ01

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-01/annotations.json
@@ -1,0 +1,77 @@
+[
+  {
+    "id": "eisenstein-criterion-oq-01-oq-01-module-header",
+    "proofId": "eisenstein-criterion-oq-01-oq-01",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 50
+    },
+    "title": "Module Header: Φ_p Irreducible via Eisenstein at X + 1",
+    "content": "Realizes the classical Gauss/Eisenstein proof that the $p$-th cyclotomic polynomial $\\Phi_p = 1 + X + \\cdots + X^{p-1}$ is irreducible. The plan, stated in the docstring: from the geometric-sum identity $\\Phi_p\\cdot(X-1) = X^p-1$, the substitution $X \\mapsto X+1$ yields $\\Phi_p(X+1)\\cdot X = (X+1)^p-1$, so the coefficients of $\\Phi_p(X+1)$ are the binomials $\\binom{p}{j+1}$ — an Eisenstein polynomial at $p$. Imports `Mathlib` and the parent `EisensteinCriterionOQ01` (whose `irreducible_of_eisenstein` is the engine).",
+    "mathContext": "$\\Phi_p(X+1) = \\sum_{j=0}^{p-1} \\binom{p}{j+1} X^j;\\quad \\binom{p}{p}=1,\\ p \\mid \\binom{p}{k}\\ (0<k<p),\\ \\binom{p}{1}=p.$",
+    "significance": "context",
+    "relatedConcepts": ["cyclotomic polynomial", "Eisenstein's criterion", "irreducibility", "open question"],
+    "prerequisites": ["polynomial rings", "binomial coefficients", "prime divisibility"]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-01-substitution-identity",
+    "proofId": "eisenstein-criterion-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 51,
+      "endLine": 64
+    },
+    "title": "Substitution Identity Φ_p(X+1)·X = (X+1)^p − 1",
+    "content": "`cyclotomic_comp_X_add_one_mul_X`: applies `congrArg (·.comp (X + C 1))` to Mathlib's `cyclotomic_prime_mul_X_sub_one` (the identity $\\Phi_p\\cdot(X-1) = X^p-1$). Polynomial composition is a ring homomorphism, so the product and difference distribute; the key simplifications are $(X-1).\\mathrm{comp}(X+1) = X$ and $(X^p).\\mathrm{comp}(X+1) = (X+1)^p$ (via `mul_comp`, `sub_comp`, `pow_comp`, `X_comp`, `one_comp`, `C_1`, `add_sub_cancel_right`).",
+    "mathContext": "$(\\Phi_p\\cdot(X-1)).\\mathrm{comp}(X+1) = \\Phi_p(X+1)\\cdot X;\\quad (X^p-1).\\mathrm{comp}(X+1) = (X+1)^p-1.$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial composition", "ring homomorphism", "geometric sum", "change of variable"],
+    "prerequisites": ["Polynomial.comp", "cyclotomic_prime_mul_X_sub_one"]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-01-coefficient-formula",
+    "proofId": "eisenstein-criterion-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 66,
+      "endLine": 74
+    },
+    "title": "Coefficient Formula: coeff_j Φ_p(X+1) = C(p, j+1)",
+    "content": "`coeff_cyclotomic_comp_X_add_one`: takes the $(j+1)$-st coefficient of the substitution identity. `coeff_mul_X` collapses $((\\Phi_p(X+1))\\cdot X).\\mathrm{coeff}(j+1)$ to $(\\Phi_p(X+1)).\\mathrm{coeff}\\,j$, and `coeff_sub` together with `coeff_X_add_one_pow` ($((X+1)^p).\\mathrm{coeff}\\,k = \\binom{p}{k}$) turns the right side into $\\binom{p}{j+1}$ — the constant $1$ contributes $0$ at the positive index $j+1$. This exhibits $\\Phi_p(X+1)$ as an Eisenstein polynomial at $p$ and is the structural heart of the proof.",
+    "mathContext": "$(\\Phi_p(X+1)).\\mathrm{coeff}\\,j = ((X+1)^p-1).\\mathrm{coeff}(j+1) = \\binom{p}{j+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["binomial coefficients", "coeff_mul_X", "coeff_X_add_one_pow"],
+    "prerequisites": ["polynomial coefficients", "binomial theorem for (X+1)^n"]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-01-irreducibility-Z",
+    "proofId": "eisenstein-criterion-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 76,
+      "endLine": 132
+    },
+    "title": "Irreducibility of Φ_p over ℤ via Eisenstein",
+    "content": "`irreducible_cyclotomic_prime`: sets $g = \\Phi_p(X+1)$ — monic (`Monic.comp_X_add_C`) of natDegree $p-1$ (`natDegree_comp`, `natDegree_cyclotomic`, `Nat.totient_prime`) — and $P = $ `Ideal.span {p}`. The four Eisenstein hypotheses reduce to binomial arithmetic via the coefficient formula and `Ideal.mem_span_singleton` / `Ideal.span_singleton_pow`: the leader $\\binom{p}{p}=1 \\notin (p)$ (else $p \\mid 1$); each lower coefficient $\\binom{p}{k} \\in (p)$ by `Nat.Prime.dvd_choose_self` for $1 \\le k < p$; the constant $\\binom{p}{1}=p \\notin (p^2)$ since $p^2 \\nmid p$ (`Int.le_of_dvd`). The parent's `irreducible_of_eisenstein` gives `Irreducible g`, and since $X \\mapsto X+1$ is a ring automorphism (`algEquivAevalXAddC 1`, irreducibility-preserving by `MulEquiv.irreducible_iff`) the result transfers back to $\\Phi_p$.",
+    "mathContext": "Eisenstein at $p$: $\\mathrm{lead}=1\\notin(p)$, $\\binom{p}{k}\\in(p)$ for $1\\le k\\le p-1$, $\\binom{p}{1}=p\\notin(p^2)$; automorphism transfer $\\mathrm{Irreducible}\\,g \\iff \\mathrm{Irreducible}\\,\\Phi_p$.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein's criterion", "prime ideal", "ring automorphism", "dvd_choose_self"],
+    "prerequisites": ["irreducible_of_eisenstein", "Ideal.mem_span_singleton", "algEquivAevalXAddC", "MulEquiv.irreducible_iff"]
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-01-corollaries",
+    "proofId": "eisenstein-criterion-oq-01-oq-01",
+    "type": "theorem",
+    "range": {
+      "startLine": 134,
+      "endLine": 150
+    },
+    "title": "Degree p − 1 and Irreducibility over ℚ",
+    "content": "`natDegree_cyclotomic_prime`: $\\deg \\Phi_p = p-1$, the totient of a prime (`natDegree_cyclotomic`, `Nat.totient_prime`). `irreducible_cyclotomic_prime_rat`: rewrites $\\Phi_{p,\\mathbb{Q}}$ as the $\\mathbb{Z}\\to\\mathbb{Q}$ map of $\\Phi_{p,\\mathbb{Z}}$ (`map_cyclotomic_int`) and applies Gauss's lemma (`IsPrimitive.Int.irreducible_iff_irreducible_map_cast`, with $\\Phi_p$ primitive because monic) to upgrade irreducibility from $\\mathbb{Z}$ to $\\mathbb{Q}$ — the form underlying $[\\mathbb{Q}(\\zeta_p):\\mathbb{Q}] = p-1$.",
+    "mathContext": "$\\deg\\Phi_p = \\varphi(p) = p-1;\\quad \\Phi_p\\text{ irreducible over }\\mathbb{Z} \\Rightarrow \\text{irreducible over }\\mathbb{Q}\\ (\\text{Gauss}).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gauss's lemma", "Euler totient", "cyclotomic field", "minimal polynomial"],
+    "prerequisites": ["map_cyclotomic_int", "IsPrimitive.Int.irreducible_iff_irreducible_map_cast", "Nat.totient_prime"]
+  }
+]

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-01/index.ts
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EisensteinCriterionOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eisensteinCriterionOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eisensteinCriterionOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eisensteinCriterionOq01Oq01Data: ProofData = {
+  proof: eisensteinCriterionOq01Oq01Proof,
+  annotations: eisensteinCriterionOq01Oq01Annotations,
+}

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-01/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-01/meta.json
@@ -1,0 +1,218 @@
+{
+  "id": "eisenstein-criterion-oq-01-oq-01",
+  "title": "Irreducibility of the p-th Cyclotomic Polynomial via Eisenstein at X + 1",
+  "slug": "eisenstein-criterion-oq-01-oq-01",
+  "description": "Answers the first open question of eisenstein-criterion-oq-01 (and the open question recorded in sibling oq-01-oq-03): establish irreducibility of the p-th cyclotomic polynomial Φ_p, for p prime, by applying the parent's Eisenstein criterion to the shifted polynomial Φ_p(X + 1). The mechanism: from the geometric-sum identity Φ_p·(X−1) = X^p−1, substituting X ↦ X+1 gives Φ_p(X+1)·X = (X+1)^p−1, so the coefficients of Φ_p(X+1) read off as C(p, j+1). The binomial coefficients C(p,1),…,C(p,p−1) are all divisible by p (prime), C(p,p)=1 is the monic leader, and C(p,1)=p is not divisible by p² — exactly Eisenstein at p. Irreducibility transfers back to Φ_p via the ring automorphism X ↦ X+1, and Gauss's lemma lifts it to ℚ. Notably Mathlib's own cyclotomic.irreducible uses the entirely different minimal-polynomial / Galois route, so this elementary textbook proof for the prime case is independent of that machinery. 5 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cyclotomic_polynomial",
+    "date": "Gauss, 1801 (Disquisitiones Arithmeticae); Eisenstein, 1850",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "number-theory",
+      "cyclotomic-polynomial",
+      "eisenstein-criterion",
+      "irreducibility",
+      "ring-theory",
+      "gauss-lemma",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/EisensteinCriterionOQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.cyclotomic_prime_mul_X_sub_one",
+        "description": "The geometric-sum identity cyclotomic p R · (X − 1) = X^p − 1 for prime p. Substituting X ↦ X+1 turns this into Φ_p(X+1)·X = (X+1)^p−1, the source of the binomial coefficients.",
+        "module": "Mathlib.RingTheory.Polynomial.Cyclotomic.Basic"
+      },
+      {
+        "theorem": "Polynomial.coeff_X_add_one_pow",
+        "description": "((X + 1)^n).coeff k = n.choose k. Combined with coeff_mul_X it gives the exact coefficient formula coeff (Φ_p(X+1)) j = C(p, j+1).",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_choose_self",
+        "description": "For prime p and 0 < k < p, p ∣ C(p, k). Supplies the Eisenstein lower-coefficient divisibility for C(p,1),…,C(p,p−1).",
+        "module": "Mathlib.Data.Nat.Choose.Dvd"
+      },
+      {
+        "theorem": "Polynomial.algEquivAevalXAddC",
+        "description": "The algebra automorphism f ↦ f.comp(X + t) of R[X], with inverse f ↦ f.comp(X − t). As a ring isomorphism it preserves irreducibility (MulEquiv.irreducible_iff), transferring Eisenstein irreducibility of Φ_p(X+1) back to Φ_p.",
+        "module": "Mathlib.Algebra.Polynomial.AlgebraMap"
+      },
+      {
+        "theorem": "Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss's lemma: a primitive integer polynomial is irreducible over ℤ iff its image over ℚ is. Lifts irreducibility of Φ_p from ℤ to ℚ.",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "Ideal.span_singleton_prime / Ideal.mem_span_singleton / Ideal.span_singleton_pow",
+        "description": "Primality of (p), membership x ∈ (p) ↔ p ∣ x, and (p)² = (p²); convert the abstract Eisenstein ideal hypotheses into concrete divisibility by p and p².",
+        "module": "Mathlib.RingTheory.Ideal.Operations"
+      }
+    ],
+    "assumptions": "None. All 5 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere. The Eisenstein engine is imported from the parent entry EisensteinCriterionOQ01 (irreducible_of_eisenstein), itself 0-axiom.",
+    "originalContributions": [
+      "cyclotomic_comp_X_add_one_mul_X: the substitution identity Φ_p(X+1)·X = (X+1)^p − 1, obtained by pushing the geometric-sum identity Φ_p·(X−1) = X^p−1 through the ring homomorphism f ↦ f.comp(X+1), under which (X−1) ↦ X.",
+      "coeff_cyclotomic_comp_X_add_one: the exact coefficient formula coeff(Φ_p(X+1)) j = C(p, j+1), read off from the substitution identity via coeff_mul_X and coeff_X_add_one_pow. This is the structural heart — it exhibits Φ_p(X+1) as an Eisenstein polynomial at p.",
+      "irreducible_cyclotomic_prime: irreducibility of Φ_p over ℤ by applying the parent's Eisenstein criterion to Φ_p(X+1) (leader C(p,p)=1 ∉ (p); lower coefficients C(p,k) ∈ (p) for 1≤k≤p−1; constant C(p,1)=p ∉ (p²)), then transferring back along the automorphism X ↦ X+1.",
+      "irreducible_cyclotomic_prime_rat: irreducibility of Φ_p over ℚ via Gauss's lemma — the form underlying [ℚ(ζ_p):ℚ] = p−1 and the Galois group (ℤ/p)ˣ.",
+      "natDegree_cyclotomic_prime: deg Φ_p = p − 1 (totient of a prime), the degree appearing as the field extension degree."
+    ],
+    "dateAdded": "2026-06-25",
+    "lineCount": 152,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "That the p-th cyclotomic polynomial Φ_p = 1 + X + ⋯ + X^{p−1} is irreducible over ℚ is a theorem of Gauss (Disquisitiones Arithmeticae, 1801); the now-standard proof substitutes X ↦ X+1 and invokes Eisenstein's criterion (Eisenstein 1850, Schönemann 1846). The parent entry eisenstein-criterion-oq-01 packaged the abstract criterion and the Xⁿ − p family; its sibling oq-01-oq-03 reached irreducibility over ℚ and explicitly listed Φ_p as the remaining classical application. This entry carries out that application.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01)**: Apply the parent's Eisenstein criterion to a shifted polynomial to obtain a new irreducibility result. Concretely: prove the p-th cyclotomic polynomial Φ_p (p prime) irreducible by applying Eisenstein at p to Φ_p(X + 1), whose coefficients are the binomial coefficients C(p, k).\n\n**Formalized**: the substitution identity Φ_p(X+1)·X = (X+1)^p−1; the coefficient formula coeff(Φ_p(X+1)) j = C(p, j+1); irreducibility of Φ_p over ℤ via Eisenstein; the transfer to ℚ via Gauss's lemma; and the degree deg Φ_p = p−1.",
+    "text": "A 152-line formalization in 5 theorems. The geometric-sum identity Φ_p·(X−1) = X^p−1 (Mathlib's cyclotomic_prime_mul_X_sub_one) is pushed through the ring homomorphism f ↦ f.comp(X+1); since (X−1) ↦ X this yields Φ_p(X+1)·X = (X+1)^p−1. Dividing by X at the level of coefficients (coeff_mul_X) and expanding (X+1)^p (coeff_X_add_one_pow) gives the clean formula coeff(Φ_p(X+1)) j = C(p, j+1). The Eisenstein hypotheses at p are then pure binomial arithmetic: the leader C(p,p)=1 escapes (p), every lower coefficient C(p,k) with 1≤k≤p−1 lies in (p) by Nat.Prime.dvd_choose_self, and the constant C(p,1)=p escapes (p²) because p² ∤ p. The parent's irreducible_of_eisenstein gives irreducibility of Φ_p(X+1), and because X ↦ X+1 is a ring automorphism of ℤ[X] (algEquivAevalXAddC, irreducibility-preserving by MulEquiv.irreducible_iff) the result transfers back to Φ_p. Gauss's lemma lifts it to ℚ. All 5 theorems compile with 0 sorries and 0 axioms, no native_decide.",
+    "proofStrategy": "**Substitution identity (cyclotomic_comp_X_add_one_mul_X)**: apply congrArg (·.comp (X + C 1)) to cyclotomic_prime_mul_X_sub_one and simplify with mul_comp/sub_comp/pow_comp/X_comp/one_comp, using (X − 1).comp(X+1) = X.\n\n**Coefficient formula (coeff_cyclotomic_comp_X_add_one)**: take the (j+1)-st coefficient of the identity; coeff_mul_X turns the left side into coeff(Φ_p(X+1)) j, and coeff_sub + coeff_X_add_one_pow turns the right side into C(p, j+1) (the constant 1 contributes 0 at index j+1≥1).\n\n**Irreducibility over ℤ (irreducible_cyclotomic_prime)**: set g = Φ_p(X+1) and P = Ideal.span {p}. g is monic (Monic.comp_X_add_C) of natDegree p−1 (natDegree_comp, natDegree_cyclotomic, totient_prime). Discharge the four Eisenstein hypotheses via the coefficient formula and Ideal.mem_span_singleton / Ideal.span_singleton_pow: leader 1 ∉ (p) (else p ∣ 1); lower coefficients C(p,k) ∈ (p) by dvd_choose_self for 1≤k<p; constant p ∉ (p²) because p² ∤ p (Int.le_of_dvd). irreducible_of_eisenstein gives Irreducible g; transfer to Φ_p via (algEquivAevalXAddC 1) and MulEquiv.irreducible_iff.\n\n**Over ℚ (irreducible_cyclotomic_prime_rat)**: rewrite cyclotomic p ℚ = (cyclotomic p ℤ).map (Int.castRingHom ℚ) (map_cyclotomic_int) and apply IsPrimitive.Int.irreducible_iff_irreducible_map_cast (Gauss's lemma).",
+    "keyInsights": [
+      "**The shift turns Φ_p into a binomial polynomial**: Φ_p(X+1) has coefficients exactly C(p, j+1). The whole proof reduces to three facts about binomial coefficients of a prime: C(p,p)=1, p ∣ C(p,k) for 0<k<p, and C(p,1)=p.",
+      "**One ring homomorphism does the coefficient bookkeeping**: pushing the geometric-sum identity through f ↦ f.comp(X+1) and reading the (j+1)-st coefficient (coeff_mul_X) avoids any direct binomial expansion of Φ_p itself.",
+      "**Irreducibility is automorphism-invariant**: X ↦ X+1 is a ring automorphism of ℤ[X] (algEquivAevalXAddC), so Eisenstein irreducibility of the shifted polynomial transfers verbatim to the original via MulEquiv.irreducible_iff — no separate descent argument.",
+      "**Independent of Mathlib's cyclotomic.irreducible**: Mathlib proves Φ_n irreducible for all n by the minimal-polynomial / Galois route. The elementary Eisenstein proof formalized here for the prime case uses none of that — only the geometric-sum form of Φ_p and binomial divisibility.",
+      "**0-axiom, no native_decide**: all 5 theorems are kernel-checked, depending only on propext / Classical.choice / Quot.sound, which do not count as assumptions."
+    ],
+    "prerequisites": [
+      "Cyclotomic polynomials: the prime case Φ_p = 1 + X + ⋯ + X^{p−1} and the identity Φ_p·(X−1) = X^p−1 (Mathlib Cyclotomic)",
+      "Polynomial composition f.comp q as a ring homomorphism; coefficients of f·X and of (X+1)^n",
+      "Eisenstein's criterion over an integral domain with a prime ideal P (imported from the parent entry)",
+      "Prime ideals and ideal powers: Ideal.span {p}, x ∈ (p) ↔ p ∣ x, (p)² = (p²)",
+      "Binomial divisibility for primes (Nat.Prime.dvd_choose_self) and Gauss's lemma over ℚ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module header and open question",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Docstring framing the parent entry's open question — apply Eisenstein to a shifted polynomial — and stating the plan: from Φ_p·(X−1) = X^p−1, the substitution X ↦ X+1 gives Φ_p(X+1)·X = (X+1)^p−1, whose coefficients are binomials C(p, j+1), Eisenstein at p. Imports Mathlib and the parent EisensteinCriterionOQ01, opens the Polynomial namespace."
+    },
+    {
+      "id": "substitution-identity",
+      "title": "The substitution identity Φ_p(X+1)·X = (X+1)^p − 1",
+      "startLine": 51,
+      "endLine": 64,
+      "summary": "cyclotomic_comp_X_add_one_mul_X: pushes the geometric-sum identity cyclotomic_prime_mul_X_sub_one through f ↦ f.comp(X + C 1). Composition is a ring homomorphism, and (X − 1).comp(X + C 1) = X, so the left side becomes Φ_p(X+1)·X while the right side (X^p − 1).comp(X + C 1) becomes (X+1)^p − 1."
+    },
+    {
+      "id": "coefficient-formula",
+      "title": "Coefficient formula: coeff(Φ_p(X+1)) j = C(p, j+1)",
+      "startLine": 66,
+      "endLine": 74,
+      "summary": "coeff_cyclotomic_comp_X_add_one: takes the (j+1)-st coefficient of the substitution identity. coeff_mul_X collapses the left side to coeff(Φ_p(X+1)) j, and coeff_sub with coeff_X_add_one_pow turns the right side into C(p, j+1) (the constant 1 contributes 0 at a positive index). This exhibits Φ_p(X+1) as an Eisenstein polynomial at p."
+    },
+    {
+      "id": "irreducibility-Z",
+      "title": "Irreducibility of Φ_p over ℤ via Eisenstein",
+      "startLine": 76,
+      "endLine": 132,
+      "summary": "irreducible_cyclotomic_prime: sets g = Φ_p(X+1) (monic of natDegree p−1) and P = Ideal.span {p}. The four Eisenstein hypotheses become binomial arithmetic via the coefficient formula and Ideal.mem_span_singleton / Ideal.span_singleton_pow: leader 1 ∉ (p), lower coefficients C(p,k) ∈ (p) by Nat.Prime.dvd_choose_self, constant p ∉ (p²) since p² ∤ p. The parent's irreducible_of_eisenstein gives Irreducible g, transferred back to Φ_p via the automorphism algEquivAevalXAddC 1 and MulEquiv.irreducible_iff."
+    },
+    {
+      "id": "corollaries",
+      "title": "Degree and irreducibility over ℚ",
+      "startLine": 134,
+      "endLine": 150,
+      "summary": "natDegree_cyclotomic_prime: deg Φ_p = p − 1 (totient of a prime). irreducible_cyclotomic_prime_rat: rewrites cyclotomic p ℚ as the ℤ-to-ℚ map of cyclotomic p ℤ (map_cyclotomic_int) and applies Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) to upgrade irreducibility from ℤ to ℚ — the form underlying [ℚ(ζ_p):ℚ] = p − 1."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "eisenstein-criterion-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. It states the abstract Eisenstein criterion (irreducible_of_eisenstein, imported and used here) and proves Xⁿ − p irreducible. This entry answers its open question of applying the criterion to a shifted polynomial: Φ_p(X+1) is Eisenstein at p, giving irreducibility of the p-th cyclotomic polynomial."
+    },
+    {
+      "proofId": "eisenstein-criterion-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry that reached irreducibility over ℚ via Gauss's lemma and explicitly listed 'irreducibility of Φ_p by applying Eisenstein to Φ_p(X+1)' as an open question. This entry realizes that step, reusing the same ℤ-to-ℚ upgrade."
+    },
+    {
+      "proofId": "cyclotomic-polynomials-oq-01",
+      "relationship": "related",
+      "description": "Companion cyclotomic-polynomial entry. The prime-case irreducibility proved here is the foundational fact behind the structure of cyclotomic extensions (degree p−1, Galois group (ℤ/p)ˣ)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.EisensteinCriterionOQ01"
+    ],
+    "namespace": "EisensteinCriterionOQ01OQ01",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/EisensteinCriterionOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "irreducible_cyclotomic_prime",
+      "type": "core",
+      "statement": "$p$ prime $\\Rightarrow$ $\\Phi_p$ is irreducible over $\\mathbb{Z}$",
+      "significance": "The headline result: the p-th cyclotomic polynomial is irreducible over ℤ, proved by the classical Eisenstein-at-(X+1) argument and the parent's criterion — independent of Mathlib's Galois-theoretic cyclotomic.irreducible.",
+      "description": "Φ_p is irreducible over ℤ for prime p."
+    },
+    {
+      "name": "irreducible_cyclotomic_prime_rat",
+      "type": "core",
+      "statement": "$p$ prime $\\Rightarrow$ $\\Phi_p$ is irreducible over $\\mathbb{Q}$",
+      "significance": "The operative form: via Gauss's lemma, Φ_p is the minimal polynomial of a primitive p-th root of unity, giving [ℚ(ζ_p):ℚ] = p − 1 and Galois group (ℤ/p)ˣ.",
+      "description": "Φ_p is irreducible over ℚ for prime p."
+    },
+    {
+      "name": "coeff_cyclotomic_comp_X_add_one",
+      "type": "core",
+      "statement": "$\\operatorname{coeff}_j \\Phi_p(X+1) = \\binom{p}{j+1}$",
+      "significance": "The structural heart: the shifted cyclotomic polynomial has binomial coefficients, exhibiting it as an Eisenstein polynomial at p. All the Eisenstein hypotheses reduce to facts about C(p, k).",
+      "description": "The j-th coefficient of Φ_p(X+1) is the binomial coefficient C(p, j+1)."
+    },
+    {
+      "name": "cyclotomic_comp_X_add_one_mul_X",
+      "type": "supporting",
+      "statement": "$\\Phi_p(X+1)\\cdot X = (X+1)^p - 1$",
+      "significance": "The substitution identity obtained by pushing Φ_p·(X−1) = X^p−1 through the homomorphism f ↦ f.comp(X+1); the source of the binomial coefficients.",
+      "description": "Φ_p(X+1)·X = (X+1)^p − 1."
+    },
+    {
+      "name": "natDegree_cyclotomic_prime",
+      "type": "supporting",
+      "statement": "$\\deg \\Phi_p = p - 1$",
+      "significance": "The degree of Φ_p is the totient of a prime, p − 1 — the field extension degree [ℚ(ζ_p):ℚ].",
+      "description": "deg Φ_p = p − 1."
+    }
+  ],
+  "references": [
+    {
+      "text": "Gauss, C. F. (1801). Disquisitiones Arithmeticae, art. 341 — irreducibility of the cyclotomic equation of prime order.",
+      "url": "https://en.wikipedia.org/wiki/Cyclotomic_polynomial"
+    },
+    {
+      "text": "Eisenstein, G. (1850). Über die Irreductibilität... (Schönemann, 1846). The criterion applied to Φ_p(X+1).",
+      "url": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion"
+    },
+    {
+      "text": "Mathlib4: Polynomial.cyclotomic_prime_mul_X_sub_one, Polynomial.coeff_X_add_one_pow, Nat.Prime.dvd_choose_self, Polynomial.algEquivAevalXAddC, Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Realizes the classical Gauss/Eisenstein proof that the p-th cyclotomic polynomial Φ_p is irreducible. The substitution X ↦ X+1, applied to the geometric-sum identity Φ_p·(X−1) = X^p−1, exhibits Φ_p(X+1) with coefficients C(p, j+1) — an Eisenstein polynomial at p (leader 1, lower coefficients divisible by p, constant p not divisible by p²). The parent's Eisenstein criterion gives irreducibility of Φ_p(X+1), the automorphism X ↦ X+1 transfers it to Φ_p, and Gauss's lemma lifts it to ℚ. All 5 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Irreducibility of Φ_p over ℚ is the foundation of the theory of cyclotomic fields: Φ_p is the minimal polynomial of a primitive p-th root of unity ζ_p, so [ℚ(ζ_p):ℚ] = p − 1 and Gal(ℚ(ζ_p)/ℚ) ≅ (ℤ/p)ˣ. The proof is also a model application of Eisenstein's criterion to a non-obvious polynomial via a change of variable, independent of Mathlib's Galois-theoretic route.",
+    "openQuestions": [
+      "Extend the Eisenstein-at-(X+1) argument to prime-power cyclotomic polynomials Φ_{p^k}, whose shift Φ_{p^k}(X+1) is again Eisenstein at p.",
+      "Derive the field extension degree [ℚ(ζ_p):ℚ] = p − 1 and the cyclotomic Galois group (ℤ/p)ˣ as consequences of the irreducibility established here."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **classical Gauss/Eisenstein proof** that the p-th cyclotomic polynomial `Φ_p` (p prime) is irreducible, by applying the parent entry's Eisenstein criterion to the **shifted** polynomial `Φ_p(X + 1)`. This answers the open question recorded in the parent `eisenstein-criterion-oq-01` and its sibling `oq-01-oq-03` (which explicitly listed "irreducibility of Φ_p via Φ_p(X+1)" as an open question).

## Mechanism

Pushing the geometric-sum identity `Φ_p·(X−1) = X^p−1` through the ring homomorphism `f ↦ f.comp(X+1)` gives

```
Φ_p(X+1) · X = (X+1)^p − 1
```

so reading off the (j+1)-st coefficient yields the exact formula

```
coeff_j Φ_p(X+1) = C(p, j+1).
```

The Eisenstein hypotheses at `p` are then pure binomial arithmetic:
- leader `C(p,p) = 1 ∉ (p)`,
- lower coefficients `C(p,k) ∈ (p)` for `1 ≤ k ≤ p−1` (`Nat.Prime.dvd_choose_self`),
- constant `C(p,1) = p ∉ (p²)`.

Irreducibility of `Φ_p(X+1)` (parent's `irreducible_of_eisenstein`) transfers back to `Φ_p` via the ring automorphism `X ↦ X+1` (`Polynomial.algEquivAevalXAddC` + `MulEquiv.irreducible_iff`), and Gauss's lemma lifts it to `ℚ`.

## Why it's new

Mathlib already has `Polynomial.cyclotomic.irreducible` for all `n`, but proved by the **minimal-polynomial / Galois** route. The elementary textbook Eisenstein argument formalized here (prime case) is independent of that machinery and exhibits the structural fact that `Φ_p(X+1)` is an Eisenstein polynomial.

## Theorems (5)

- `cyclotomic_comp_X_add_one_mul_X` — substitution identity `Φ_p(X+1)·X = (X+1)^p − 1`
- `coeff_cyclotomic_comp_X_add_one` — `coeff_j Φ_p(X+1) = C(p, j+1)` (structural heart)
- `irreducible_cyclotomic_prime` — `Φ_p` irreducible over `ℤ`
- `irreducible_cyclotomic_prime_rat` — `Φ_p` irreducible over `ℚ` (Gauss's lemma)
- `natDegree_cyclotomic_prime` — `deg Φ_p = p − 1`

## Verification

- **0 sorries, 0 axioms** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`.
- **No `native_decide`.**
- Imports the parent `Proofs.EisensteinCriterionOQ01` (itself 0-axiom) for the Eisenstein engine.
- Built offline with `lake env lean` (Docker unavailable this session).

## Files

- `proofs/Proofs/EisensteinCriterionOQ01OQ01.lean` (152 lines)
- `src/data/proofs/eisenstein-criterion-oq-01-oq-01/{meta.json, annotations.json, index.ts}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)