### PR TITLE
research(basel-problem-oq-11-oq-01): exponent-generic Dirichlet eta/zeta relation η(2m)=(1−2^{1−2m})ζ(2m), η(4)=7π⁴/720 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BaselProblemOQ11OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ11OQ01.lean
@@ -1,0 +1,155 @@
+/-
+  # The Dirichlet eta / zeta relation at even integers
+  # η(2m) = (1 − 2^{1−2m}) ζ(2m)   (basel-problem-oq-11-oq-01)
+
+  ## The open question
+
+  The parent entry `basel-problem-oq-11` proves the single value
+  η(2) = ∑ (-1)^(n+1)/n² = π²/12 via the parity split η(2) = (1/2) ζ(2).
+  This file *generalizes* that argument once and for all: for **every** exponent
+  `e ≥ 1`, knowing the zeta-type sum `∑ 1/n^e = Z` already determines the
+  alternating ("eta") sum,
+
+      ∑ (-1)^(n+1)/n^e  =  (1 − 2^{1−e}) · Z.
+
+  Specializing `e = 2m` to an even argument and plugging Mathlib's evaluations of
+  ζ(2) and ζ(4) then yields, with **no new analytic input**,
+
+      η(2) = (1 − 1/2)·ζ(2) = (1/2)(π²/6)  = π²/12,
+      η(4) = (1 − 1/8)·ζ(4) = (7/8)(π⁴/90) = 7π⁴/720.
+
+  ## The argument (one parity split, exponent-generic)
+
+  Write `Z = ∑_{n≥1} 1/n^e`. Splitting by parity with `HasSum.even_add_odd`:
+
+    * **even part** `∑_k 1/(2k)^e = (1/2^e) Z`, since 1/(2k)^e = (1/2^e)(1/k^e);
+    * **odd part**  `∑_k 1/(2k+1)^e = (1 − 1/2^e) Z`, recovered as `Z` minus the
+      even part by uniqueness of sums (`HasSum.unique`).
+
+  For the alternating series the even-indexed terms carry sign (-1)^(2k+1) = -1
+  and the odd-indexed terms (-1)^(2k+2) = +1, so
+
+      η = −(1/2^e) Z + (1 − 1/2^e) Z = (1 − 2/2^e) Z = (1 − 2^{1−e}) Z.
+
+  Everything is `npow` in a fixed natural exponent `e`, so no `rpow` or analytic
+  continuation is needed — only the convergent series identity at the integer point.
+
+  ## Axiom count: 0
+-/
+
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Tactic
+
+open Real
+
+namespace BaselEtaEven
+
+/-- The alternating ("eta") summand at exponent `e`: `(-1)^(n+1) / n^e`.
+    (At `n = 0` this is `±1/0 = 0` in ℝ, so the series effectively starts at n = 1.) -/
+noncomputable def etaSummand (e n : ℕ) : ℝ := (-1) ^ (n + 1) / (n : ℝ) ^ e
+
+/-- **Even-indexed zeta subseries, generic exponent.** From `∑ 1/n^e = Z` the
+    even-indexed terms `1/(2k)^e` form a `(1/2^e)`-scaled copy, summing to `(1/2^e)·Z`. -/
+theorem hasSum_even_of_hasSum_zeta {e : ℕ} {Z : ℝ}
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ e) Z) :
+    HasSum (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ e) ((1 / 2 ^ e) * Z) := by
+  have hscaled := hZ.mul_left (1 / 2 ^ e : ℝ)
+  have hfe : (fun k : ℕ => 1 / ((2 * k : ℕ) : ℝ) ^ e)
+      = (fun k : ℕ => (1 / 2 ^ e : ℝ) * (1 / (k : ℝ) ^ e)) := by
+    funext k
+    have h2k : ((2 * k : ℕ) : ℝ) ^ e = 2 ^ e * (k : ℝ) ^ e := by
+      push_cast; rw [mul_pow]
+    rw [h2k]
+    simp only [one_div, mul_inv]
+  rw [hfe]; exact hscaled
+
+/-- **Odd-indexed zeta subseries, generic exponent.** From `∑ 1/n^e = Z` the
+    odd-indexed terms sum to `(1 − 1/2^e)·Z`, obtained as `Z` minus the even part
+    via `HasSum.even_add_odd` and uniqueness of sums. -/
+theorem hasSum_odd_of_hasSum_zeta {e : ℕ} {Z : ℝ}
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ e) Z) :
+    HasSum (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e) ((1 - 1 / 2 ^ e) * Z) := by
+  have hodd_summable : Summable (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e) :=
+    hZ.summable.comp_injective (fun a b h => by omega)
+  have heven := hasSum_even_of_hasSum_zeta hZ
+  have hkey : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ e)
+      ((1 / 2 ^ e) * Z + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e) :=
+    HasSum.even_add_odd heven hodd_summable.hasSum
+  have hsum_eq : (1 / 2 ^ e) * Z + ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e = Z :=
+    hkey.unique hZ
+  have hval : ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e = (1 - 1 / 2 ^ e) * Z := by
+    have hstep : ∑' k : ℕ, 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e = Z - (1 / 2 ^ e) * Z := by linarith
+    rw [hstep]; ring
+  rw [← hval]; exact hodd_summable.hasSum
+
+/-- **The Dirichlet eta / zeta relation at a natural exponent `e`.**
+    From `∑ 1/n^e = Z` we get `∑ (-1)^(n+1)/n^e = (1 − 2/2^e)·Z`, i.e.
+    `η(e) = (1 − 2^{1−e}) ζ(e)`. -/
+theorem hasSum_eta_of_hasSum_zeta {e : ℕ} {Z : ℝ}
+    (hZ : HasSum (fun n : ℕ => 1 / (n : ℝ) ^ e) Z) :
+    HasSum (etaSummand e) ((1 - 2 / 2 ^ e) * Z) := by
+  -- Even-indexed alternating terms: (-1)^(2k+1)/(2k)^e = -1/(2k)^e, summing to -(1/2^e)Z.
+  have ha_even : HasSum (fun k : ℕ => etaSummand e (2 * k)) (-((1 / 2 ^ e) * Z)) := by
+    have hfe : (fun k : ℕ => etaSummand e (2 * k))
+        = (fun k : ℕ => -(1 / ((2 * k : ℕ) : ℝ) ^ e)) := by
+      funext k
+      simp only [etaSummand]
+      rw [Odd.neg_one_pow (⟨k, by ring⟩ : Odd (2 * k + 1))]
+      ring
+    rw [hfe]; exact (hasSum_even_of_hasSum_zeta hZ).neg
+  -- Odd-indexed alternating terms: (-1)^(2k+2)/(2k+1)^e = 1/(2k+1)^e, summing to (1-1/2^e)Z.
+  have ha_odd : HasSum (fun k : ℕ => etaSummand e (2 * k + 1)) ((1 - 1 / 2 ^ e) * Z) := by
+    have hfo : (fun k : ℕ => etaSummand e (2 * k + 1))
+        = (fun k : ℕ => 1 / ((2 * k + 1 : ℕ) : ℝ) ^ e) := by
+      funext k
+      simp only [etaSummand]
+      rw [Even.neg_one_pow (⟨k + 1, by ring⟩ : Even (2 * k + 1 + 1))]
+    rw [hfo]; exact hasSum_odd_of_hasSum_zeta hZ
+  have ha : HasSum (etaSummand e) (-((1 / 2 ^ e) * Z) + (1 - 1 / 2 ^ e) * Z) :=
+    HasSum.even_add_odd ha_even ha_odd
+  have hval : -((1 / 2 ^ e) * Z) + (1 - 1 / 2 ^ e) * Z = (1 - 2 / 2 ^ e) * Z := by ring
+  rwa [hval] at ha
+
+/-- **η(2) = π²/12**, recovered from the generic relation at `e = 2` and Mathlib's ζ(2). -/
+theorem hasSum_eta_two : HasSum (etaSummand 2) (π ^ 2 / 12) := by
+  have h := hasSum_eta_of_hasSum_zeta hasSum_zeta_two
+  have hval : (1 - 2 / (2 : ℝ) ^ 2) * (π ^ 2 / 6) = π ^ 2 / 12 := by ring
+  rwa [hval] at h
+
+/-- **η(4) = 7π⁴/720**, the new value: the generic relation at `e = 4` applied to
+    Mathlib's `hasSum_zeta_four` (ζ(4) = π⁴/90), with no new analytic input. -/
+theorem hasSum_eta_four : HasSum (etaSummand 4) (7 * π ^ 4 / 720) := by
+  have h := hasSum_eta_of_hasSum_zeta hasSum_zeta_four
+  have hval : (1 - 2 / (2 : ℝ) ^ 4) * (π ^ 4 / 90) = 7 * π ^ 4 / 720 := by ring
+  rwa [hval] at h
+
+/-- **η(2)** in `tsum` form: `∑' n, (-1)^(n+1)/n² = π²/12`. -/
+theorem tsum_eta_two : ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 2 = π ^ 2 / 12 := by
+  simpa [etaSummand] using hasSum_eta_two.tsum_eq
+
+/-- **η(4)** in `tsum` form: `∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720`. -/
+theorem tsum_eta_four : ∑' n : ℕ, (-1 : ℝ) ^ (n + 1) / (n : ℝ) ^ 4 = 7 * π ^ 4 / 720 := by
+  simpa [etaSummand] using hasSum_eta_four.tsum_eq
+
+end BaselEtaEven
+
+/-
+  ## Summary
+
+  | Result | Statement |
+  |--------|-----------|
+  | `hasSum_even_of_hasSum_zeta` | ∑_k 1/(2k)^e = (1/2^e)·Z from ζ(e)=Z |
+  | `hasSum_odd_of_hasSum_zeta`  | ∑_k 1/(2k+1)^e = (1−1/2^e)·Z from ζ(e)=Z |
+  | `hasSum_eta_of_hasSum_zeta`  | ∑ (-1)^(n+1)/n^e = (1−2^{1−e})·Z  (η(e) = (1−2^{1−e})ζ(e)) |
+  | `hasSum_eta_two`  | η(2) = π²/12  (e = 2) |
+  | `hasSum_eta_four` | η(4) = 7π⁴/720  (e = 4, the new value) |
+  | `tsum_eta_two` / `tsum_eta_four` | tsum forms of the two values |
+
+  The parent `basel-problem-oq-11` proved only the `e = 2` instance by hand; here the
+  even/odd parity split is carried out once at a generic exponent `e`, so each new
+  even value of η is a one-line specialization of `hasSum_eta_of_hasSum_zeta` against
+  the corresponding Mathlib ζ evaluation.
+
+  **Sorries**: 0
+  **Axioms**: 0
+-/

--- a/src/data/proofs/basel-problem-oq-11-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-11-oq-01/annotations.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "eta-summand-generic",
+    "proofId": "basel-problem-oq-11-oq-01",
+    "range": { "startLine": 49, "endLine": 49 },
+    "type": "definition",
+    "title": "The Generic Eta Summand (-1)^(n+1)/nᵉ",
+    "content": "etaSummand e n = (-1)^(n+1)/nᵉ is the alternating eta term at an arbitrary natural exponent e. Carrying e as a parameter (rather than fixing e = 2 as the parent does) is what lets the whole parity split be proved once and reused for every even value. As usual the n = 0 term is harmless: ±1/0ᵉ = 0 in ℝ by Lean's junk-value convention, so the series effectively starts at n = 1.",
+    "mathContext": "$\\eta\\text{-summand}(e,n) = \\dfrac{(-1)^{n+1}}{n^{e}}$, giving $\\eta(e) = 1 - \\tfrac1{2^{e}} + \\tfrac1{3^{e}} - \\cdots$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Dirichlet eta function",
+      "alternating series",
+      "junk-value convention"
+    ],
+    "prerequisites": ["alternating series", "Lean definitions"]
+  },
+  {
+    "id": "even-generic",
+    "proofId": "basel-problem-oq-11-oq-01",
+    "range": { "startLine": 53, "endLine": 67 },
+    "type": "theorem",
+    "title": "Even subseries: ∑ 1/(2k)ᵉ = (1/2ᵉ)·Z",
+    "content": "Given ζ(e) = Z as a HasSum, the even-indexed terms 1/(2k)ᵉ are a (1/2ᵉ)-scaled copy of ζ(e): since (2k)ᵉ = 2ᵉ·kᵉ (a push_cast + mul_pow rewrite), 1/(2k)ᵉ = (1/2ᵉ)(1/kᵉ), and scaling the sum by 1/2ᵉ (HasSum.mul_left) gives (1/2ᵉ)Z. The rewrite is valid even at k = 0, where both sides are 0 in ℝ (because eᵉ ≥ 1 forces 0ᵉ = 0).",
+    "mathContext": "$\\sum_{k} \\dfrac{1}{(2k)^{e}} = \\dfrac{1}{2^{e}}\\,\\zeta(e)$",
+    "significance": "important",
+    "relatedConcepts": ["reindexing", "HasSum.mul_left", "geometric scaling"],
+    "prerequisites": ["HasSum API", "mul_pow"]
+  },
+  {
+    "id": "odd-generic",
+    "proofId": "basel-problem-oq-11-oq-01",
+    "range": { "startLine": 69, "endLine": 86 },
+    "type": "theorem",
+    "title": "Odd subseries: ∑ 1/(2k+1)ᵉ = (1 − 1/2ᵉ)·Z",
+    "content": "The odd-indexed subseries is summable (Summable.comp_injective along k ↦ 2k+1, injectivity by omega). Reassembling ζ(e) from its even and odd halves with HasSum.even_add_odd and applying HasSum.unique against the hypothesis ζ(e) = Z forces the odd sum to be Z − (1/2ᵉ)Z = (1 − 1/2ᵉ)Z. This is the exponent-generic version of the parent's ∑ 1/(2k+1)² = π²/8 step.",
+    "mathContext": "$\\sum_{k} \\dfrac{1}{(2k+1)^{e}} = \\left(1 - \\dfrac{1}{2^{e}}\\right)\\zeta(e)$",
+    "significance": "important",
+    "relatedConcepts": ["HasSum.even_add_odd", "HasSum.unique", "Summable.comp_injective"],
+    "prerequisites": ["even/odd splitting", "uniqueness of sums"]
+  },
+  {
+    "id": "eta-relation",
+    "proofId": "basel-problem-oq-11-oq-01",
+    "range": { "startLine": 88, "endLine": 112 },
+    "type": "theorem",
+    "title": "The Dirichlet relation η(e) = (1 − 2^{1−e})ζ(e)",
+    "content": "For the alternating summand the even-indexed terms carry sign (-1)^(2k+1) = -1 (Odd.neg_one_pow), summing to −(1/2ᵉ)Z, and the odd-indexed terms (-1)^(2k+2) = +1 (Even.neg_one_pow), summing to (1 − 1/2ᵉ)Z. HasSum.even_add_odd combines them to (−(1/2ᵉ) + (1 − 1/2ᵉ))Z = (1 − 2/2ᵉ)Z, which is exactly (1 − 2^{1−e})ζ(e). The factor of the Dirichlet eta/zeta functional relation thus emerges directly from the parity bookkeeping, with no analytic continuation.",
+    "mathContext": "$\\eta(e) = \\sum_n \\dfrac{(-1)^{n+1}}{n^{e}} = \\bigl(1 - 2^{1-e}\\bigr)\\zeta(e)$",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet eta function", "functional equation", "Odd.neg_one_pow", "Even.neg_one_pow"],
+    "prerequisites": ["even/odd splitting", "parity of signs"]
+  },
+  {
+    "id": "eta-values",
+    "proofId": "basel-problem-oq-11-oq-01",
+    "range": { "startLine": 114, "endLine": 133 },
+    "type": "theorem",
+    "title": "η(2) = π²/12 and η(4) = 7π⁴/720",
+    "content": "Specializing the generic relation: at e = 2 the factor is 1 − 2/2² = 1/2, so η(2) = (1/2)(π²/6) = π²/12 (reproducing the parent value from hasSum_zeta_two); at e = 4 the factor is 1 − 2/2⁴ = 7/8, so η(4) = (7/8)(π⁴/90) = 7π⁴/720 (the new value, from Mathlib's hasSum_zeta_four). Each numeric coefficient is closed by `ring`, and tsum corollaries restate the values in ∑' form.",
+    "mathContext": "$\\eta(2)=\\dfrac{\\pi^2}{12},\\qquad \\eta(4)=\\dfrac{7\\pi^4}{720}$",
+    "significance": "key",
+    "relatedConcepts": ["Basel problem", "ζ(4) = π⁴/90", "specialization"],
+    "prerequisites": ["hasSum_zeta_two", "hasSum_zeta_four"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-11-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-11-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "basel-problem-oq-11-oq-01",
+  "title": "Dirichlet eta at even integers: η(2m) = (1 − 2^{1−2m})ζ(2m), η(4) = 7π⁴/720",
+  "slug": "basel-problem-oq-11-oq-01",
+  "description": "Generalizes the parent entry's single value η(2) = π²/12 into an exponent-generic parity-split lemma: for every natural exponent e, knowing the zeta-type sum ∑ 1/nᵉ = Z determines the alternating eta sum ∑ (-1)^(n+1)/nᵉ = (1 − 2/2ᵉ)·Z, i.e. the Dirichlet relation η(e) = (1 − 2^{1−e})ζ(e). Splitting by parity with HasSum.even_add_odd, the even-indexed terms 1/(2k)ᵉ form a (1/2ᵉ)-scaled copy of ζ(e) and the odd-indexed terms are recovered as Z minus the even part by uniqueness of sums; the alternating signs (-1)^(2k+1) = -1 and (-1)^(2k+2) = +1 then assemble the eta value. Specializing e = 2 reproduces η(2) = π²/12 and e = 4 yields the new value η(4) = (7/8)ζ(4) = (7/8)(π⁴/90) = 7π⁴/720, both drawn from Mathlib's hasSum_zeta_two and hasSum_zeta_four with no new analytic input. Verified with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ11OQ01.lean",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "series",
+      "zeta-function",
+      "dirichlet-eta",
+      "basel-problem",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 155,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-25",
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "The Basel sum: HasSum (fun n => 1/n²) (π²/6)",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_four",
+        "description": "ζ(4): HasSum (fun n => 1/n⁴) (π⁴/90), the input for the new η(4) value",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Combine even- and odd-indexed subseries into the full sum",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "HasSum.unique",
+        "description": "Uniqueness of sums, used to pin the odd subseries to (1 − 1/2ᵉ)Z",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "Summability of the odd-indexed subseries from summability of ζ(e)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Odd.neg_one_pow / Even.neg_one_pow",
+        "description": "(-1)^n = -1 for n odd and 1 for n even, fixing the alternating signs",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_even_of_hasSum_zeta: exponent-generic even subseries ∑_k 1/(2k)ᵉ = (1/2ᵉ)·Z from ζ(e) = Z (a (1/2ᵉ)-scaled copy via (2k)ᵉ = 2ᵉ·kᵉ)",
+      "hasSum_odd_of_hasSum_zeta: exponent-generic odd subseries ∑_k 1/(2k+1)ᵉ = (1 − 1/2ᵉ)·Z, recovered as Z minus the even part by HasSum.even_add_odd + HasSum.unique",
+      "hasSum_eta_of_hasSum_zeta: the Dirichlet relation η(e) = (1 − 2^{1−e})ζ(e) as a single reusable HasSum lemma over an arbitrary natural exponent e",
+      "hasSum_eta_two / tsum_eta_two: η(2) = π²/12 as a one-line specialization (e = 2) of the generic relation",
+      "hasSum_eta_four / tsum_eta_four: η(4) = 7π⁴/720 (e = 4), the new even eta value, obtained from Mathlib's ζ(4) = π⁴/90 with no new analysis"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6 and ζ(4) = π⁴/90 (Mathlib hasSum_zeta_two, hasSum_zeta_four)",
+      "Even/odd splitting of an infinite sum (HasSum.even_add_odd)",
+      "Uniqueness of sums (HasSum.unique)",
+      "Dirichlet eta function and the relation η(s) = (1 − 2^(1-s))ζ(s)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real"],
+    "namespace": "BaselEtaEven",
+    "path": "Proofs/BaselProblemOQ11OQ01.lean",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The Dirichlet eta function η(s) = ∑ (-1)^(n+1)/n^s is the alternating companion of the Riemann zeta function, tied to it by η(s) = (1 − 2^(1-s))ζ(s) — the identity that analytically continues ζ across the line Re s = 1. At even integers s = 2m, Euler's evaluations ζ(2) = π²/6, ζ(4) = π⁴/90, … turn this into closed forms η(2) = π²/12, η(4) = 7π⁴/720, …. The parent entry basel-problem-oq-11 formalized only the s = 2 value by an explicit parity split; this entry carries that split out once at a generic exponent so that every even eta value becomes a one-line corollary of the corresponding Mathlib ζ evaluation.",
+    "problemStatement": "Generalize the even/odd parity split of basel-problem-oq-11 into a reusable lemma\n\n$$\\eta(e) = \\sum_{n=1}^{\\infty}\\frac{(-1)^{n+1}}{n^{e}} = \\bigl(1 - 2^{1-e}\\bigr)\\,\\zeta(e),$$\n\nfor an arbitrary natural exponent e, and derive η(4) = 7π⁴/720 from Mathlib's `hasSum_zeta_four` (ζ(4) = π⁴/90) with no new analytic input. Verified with 0 sorries and 0 axioms.",
+    "text": "An exponent-generic Dirichlet eta/zeta relation η(e) = (1 − 2^{1−e})ζ(e), proved once by a parity split and specialized to η(2) = π²/12 and the new value η(4) = 7π⁴/720.",
+    "proofStrategy": "Three generic HasSum lemmas parameterized by a natural exponent e, then two specializations. (1) hasSum_even_of_hasSum_zeta: since (2k)ᵉ = 2ᵉ·kᵉ, the even-indexed terms 1/(2k)ᵉ equal (1/2ᵉ)(1/kᵉ), so scaling ζ(e) = Z by 1/2ᵉ gives the even sum (1/2ᵉ)Z (valid even at k = 0 where both sides are 0 in ℝ). (2) hasSum_odd_of_hasSum_zeta: the odd subseries is summable (Summable.comp_injective with k ↦ 2k+1); reassembling ζ(e) = even + odd via HasSum.even_add_odd and applying HasSum.unique forces the odd sum to Z − (1/2ᵉ)Z = (1 − 1/2ᵉ)Z. (3) hasSum_eta_of_hasSum_zeta: for the alternating summand the even-indexed terms carry sign (-1)^(2k+1) = -1 (Odd.neg_one_pow) summing to −(1/2ᵉ)Z, the odd-indexed terms (-1)^(2k+2) = +1 (Even.neg_one_pow) summing to (1 − 1/2ᵉ)Z; HasSum.even_add_odd combines them to (1 − 2/2ᵉ)Z = (1 − 2^{1−e})Z. Finally hasSum_eta_two plugs in hasSum_zeta_two (e = 2 ⟹ factor 1/2, value π²/12) and hasSum_eta_four plugs in hasSum_zeta_four (e = 4 ⟹ factor 7/8, value 7π⁴/720).",
+    "keyInsights": [
+      "**One parity split serves all even eta values.** The parent proved η(2) by hand; here the same even/odd decomposition is performed at a symbolic exponent e, so η(2), η(4), η(6), … are each a single application of hasSum_eta_of_hasSum_zeta against the matching Mathlib ζ value — the analytic content is reused, not re-derived.",
+      "**The factor 1 − 2^{1−e} appears constructively as −(1/2ᵉ) + (1 − 1/2ᵉ).** The even-indexed alternating terms contribute −(1/2ᵉ)Z and the odd-indexed ones (1 − 1/2ᵉ)Z; their sum (1 − 2/2ᵉ)Z is exactly (1 − 2^{1−e})ζ(e), so the Dirichlet relation is literally the parity bookkeeping.",
+      "**Everything stays in `npow` — no `rpow`, no analytic continuation.** Working with a fixed natural exponent e keeps the even-part identity (2k)ᵉ = 2ᵉkᵉ a `mul_pow` rewrite and avoids real powers entirely; the relation η = (1 − 2^{1−e})ζ is obtained purely at the convergent integer point.",
+      "**The odd subseries is free.** Rather than summing ∑ 1/(2k+1)ᵉ directly, it is recovered as ζ(e) minus its even half by uniqueness of sums — the same trick the parent used for ∑ 1/(2k+1)² = π²/8, now exponent-generic.",
+      "**Signs are pinned by parity, not case analysis.** Odd.neg_one_pow and Even.neg_one_pow convert the alternating numerators into two fixed-sign subseries with no per-term split, exactly as in the parent."
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6 and ζ(4) = π⁴/90",
+      "Dirichlet eta function and η(s) = (1 − 2^(1-s))ζ(s)",
+      "Even/odd decomposition of infinite sums (HasSum.even_add_odd)",
+      "HasSum / tsum API and uniqueness of sums in Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header, Imports, and the Generic Eta Summand",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Documents the exponent-generic parity split η(e) = (1 − 2^{1−e})ζ(e); imports Mathlib's ZetaValues (for hasSum_zeta_two and hasSum_zeta_four); defines etaSummand e n = (-1)^(n+1)/nᵉ over an arbitrary exponent e.",
+      "mathContext": "η(e) is the value at e of the Dirichlet eta function, the alternating companion of ζ."
+    },
+    {
+      "id": "even-generic",
+      "title": "hasSum_even_of_hasSum_zeta — ∑ 1/(2k)ᵉ = (1/2ᵉ)·Z",
+      "startLine": 51,
+      "endLine": 67,
+      "summary": "Rewrites (2k)ᵉ = 2ᵉ·kᵉ and scales ζ(e) = Z by 1/2ᵉ to get the even subseries (1/2ᵉ)Z.",
+      "mathContext": "The even-indexed terms form a (1/2ᵉ)-scaled copy of ζ(e)."
+    },
+    {
+      "id": "odd-generic",
+      "title": "hasSum_odd_of_hasSum_zeta — ∑ 1/(2k+1)ᵉ = (1 − 1/2ᵉ)·Z",
+      "startLine": 68,
+      "endLine": 86,
+      "summary": "Odd subseries summable via comp_injective; reassemble ζ(e) = even + odd and use HasSum.unique to pin the odd sum to (1 − 1/2ᵉ)Z.",
+      "mathContext": "The odd-indexed zeta subseries, recovered as ζ(e) minus its even part."
+    },
+    {
+      "id": "eta-relation",
+      "title": "hasSum_eta_of_hasSum_zeta — η(e) = (1 − 2^{1−e})ζ(e)",
+      "startLine": 87,
+      "endLine": 112,
+      "summary": "Even-indexed alternating terms sum to −(1/2ᵉ)Z (Odd.neg_one_pow), odd-indexed to (1 − 1/2ᵉ)Z (Even.neg_one_pow); HasSum.even_add_odd combines them to (1 − 2/2ᵉ)Z.",
+      "mathContext": "The Dirichlet eta/zeta relation as a single reusable lemma."
+    },
+    {
+      "id": "values",
+      "title": "η(2) = π²/12 and η(4) = 7π⁴/720",
+      "startLine": 113,
+      "endLine": 133,
+      "summary": "Specializes the generic relation to e = 2 (factor 1/2, π²/12) and e = 4 (factor 7/8, 7π⁴/720) using hasSum_zeta_two and hasSum_zeta_four, with tsum corollaries.",
+      "mathContext": "The first two even eta values as one-line corollaries of the generic relation."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Dirichlet eta/zeta relation η(e) = (1 − 2^{1−e})ζ(e) is formalized once at an arbitrary natural exponent e, with 0 axioms and 0 sorries, by the even/odd parity split. Specializing to Mathlib's ζ(2) = π²/6 and ζ(4) = π⁴/90 yields η(2) = π²/12 (matching the parent) and the new value η(4) = 7π⁴/720, each as a single line.",
+    "implications": "Turns the parent's bespoke η(2) computation into reusable infrastructure: any further even eta value η(2m) is now a one-line corollary of the corresponding Mathlib ζ(2m) evaluation. The generic lemma also isolates the constructive content of the functional equation η(s) = (1 − 2^(1-s))ζ(s) at integer points, separated from analytic continuation.",
+    "openQuestions": [
+      {
+        "id": "basel-problem-oq-11-oq-01-oq-01",
+        "question": "Package the generic relation against Mathlib's hasSum_zeta_nat to obtain η(2m) = (1 − 2^{1−2m})·(−1)^{m+1} B_{2m} (2π)^{2m} / (2·(2m)!) as a closed form in the Bernoulli numbers for all m ≥ 1.",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-11",
+      "relationship": "extends",
+      "description": "Parent entry η(2) = π²/12 by an explicit s = 2 parity split; this generalizes the split to all even arguments and adds η(4) = 7π⁴/720."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "Root Basel entry ζ(2) = π²/6; the eta values are the alternating companions of the zeta values."
+    }
+  ],
+  "references": [
+    {
+      "title": "Riemann's Zeta Function",
+      "author": "Harold M. Edwards",
+      "year": "1974",
+      "venue": "Academic Press",
+      "description": "Develops the Dirichlet eta function η(s) = (1 − 2^(1-s))ζ(s) as the alternating series continuing ζ past Re s = 1."
+    },
+    {
+      "title": "Introductio in analysin infinitorum",
+      "author": "Leonhard Euler",
+      "year": "1748",
+      "description": "Euler's evaluation of ζ(2m); the even eta values follow from the same zeta machinery."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "basel-problem-oq-11-oq-01-oq-01",
+      "question": "Use the generic relation with Mathlib's hasSum_zeta_nat to give a Bernoulli-number closed form for η(2m) for all m ≥ 1.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the open question **basel-problem-oq-11-oq-01**: generalize the parent entry's single value η(2) = π²/12 into a reusable parity-split lemma and derive η(4) = 7π⁴/720 from Mathlib's `hasSum_zeta_four` with **no new analytic input**.

The parent `basel-problem-oq-11` proved η(2) = π²/12 by an explicit even/odd split at the fixed exponent 2. This entry carries that split out **once at an arbitrary natural exponent `e`**, giving the Dirichlet eta/zeta relation as a single reusable theorem:

> `hasSum_eta_of_hasSum_zeta`: if `∑ 1/nᵉ = Z` then `∑ (-1)^(n+1)/nᵉ = (1 − 2/2ᵉ)·Z`, i.e. **η(e) = (1 − 2^{1−e}) ζ(e)**.

Every even eta value is then a one-line specialization against the matching Mathlib ζ evaluation:

| value | exponent | factor | result |
|-------|----------|--------|--------|
| `hasSum_eta_two`  | e = 2 | 1 − 2/2² = 1/2 | η(2) = (1/2)(π²/6) = **π²/12** |
| `hasSum_eta_four` | e = 4 | 1 − 2/2⁴ = 7/8 | η(4) = (7/8)(π⁴/90) = **7π⁴/720** *(new)* |

## Proof structure (155 lines, 7 theorems, 1 def)

1. `hasSum_even_of_hasSum_zeta` — `∑ 1/(2k)ᵉ = (1/2ᵉ)Z` via `(2k)ᵉ = 2ᵉkᵉ` + `HasSum.mul_left`.
2. `hasSum_odd_of_hasSum_zeta` — `∑ 1/(2k+1)ᵉ = (1 − 1/2ᵉ)Z` as `Z` minus the even part (`HasSum.even_add_odd` + `HasSum.unique`).
3. `hasSum_eta_of_hasSum_zeta` — alternating signs `(-1)^(2k+1) = -1`, `(-1)^(2k+2) = +1` (`Odd/Even.neg_one_pow`) combine the two subseries to `(1 − 2/2ᵉ)Z`.
4. `hasSum_eta_two` / `hasSum_eta_four` (+ `tsum_*` corollaries) — specializations at e = 2, 4.

Everything stays in `npow` at a fixed natural exponent — no `rpow`, no analytic continuation; the functional-equation factor `1 − 2^{1−e}` emerges purely from parity bookkeeping.

## Verification

- **0 sorries**, compiles against Mathlib (`lake env lean`).
- `#print axioms` on all eta theorems: only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. **axiomCount = 0**, status `verified`.

## Relation to Mathlib

Mathlib provides ζ(2) and ζ(4) (`hasSum_zeta_two`, `hasSum_zeta_four`) but not the Dirichlet eta values or the eta/zeta relation at integer points; this packages that relation as reusable infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)