### PR TITLE
research(cayley-hamilton-oq-04-oq-02): closed-form 2×2 matrix exponential exp(tA)=α·1+β·A [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/CayleyHamiltonOQ04OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonOQ04OQ02.lean
@@ -1,0 +1,232 @@
+import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+import Mathlib.Analysis.SpecialFunctions.Exponential
+import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.MeanValue
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Tactic
+
+/-
+# Closed-Form 2×2 Matrix Exponential from Cayley–Hamilton
+
+## What This Proves
+
+For a `2×2` real matrix `A` with `tr A = τ` and `det A = δ`, the explicit
+Cayley–Hamilton relation `A² = τ • A − δ • 1` collapses every power `Aᵏ` into the
+two-dimensional span `{1, A}`. This file pushes that collapse through the matrix
+exponential and proves the closed form
+
+  `exp(t • A) = α(t) • 1 + β(t) • A`,
+
+where the scalar coefficients `α, β : ℝ → ℝ` are *any* pair solving the Putzer ODE
+system
+
+  `α'(t) = −δ · β(t)`,  `β'(t) = α(t) + τ · β(t)`,  `α(0) = 1`,  `β(0) = 0`.
+
+The headline theorem `exp_eq_of_coeffs` proves this for an arbitrary such pair, by
+an integrating-factor / uniqueness argument: the matrix-valued function
+`φ(t) = exp(−t • A) · (α(t) • 1 + β(t) • A)` has identically-zero derivative, hence
+is the constant `φ(0) = 1`, which rearranges to the closed form.
+
+Two corollaries instantiate the classical explicit coefficients from the
+eigenvalues `λ₁, λ₂` (roots of `λ² − τλ + δ`):
+
+* `exp_two_two_distinct` (`λ₁ ≠ λ₂`):
+  `β(t) = (e^{λ₁t} − e^{λ₂t})/(λ₁ − λ₂)`, `α(t) = e^{λ₁t} − λ₁ β(t)`;
+* `exp_two_two_repeated` (`λ₁ = λ₂ = λ`):
+  `β(t) = t e^{λt}`, `α(t) = e^{λt} − λ t e^{λt}`.
+
+## Why This Is Not Just a Re-export
+
+Mathlib provides `Matrix.exp` and its derivative `hasDerivAt_exp_smul_const`, but no
+result reduces the 2×2 exponential to the finite span `{1, A}` with explicit scalar
+coefficients. The reduction here is genuinely new: it is the analytic completion of
+the algebraic parent `CayleyHamiltonOQ04` (`A² = τ•A − δ•1`), turning the infinite
+series `Σ tᵏAᵏ/k!` into a two-term closed form governed by the eigenvalue ODE. The
+uniqueness step is proved from scratch via `is_const_of_deriv_eq_zero`.
+
+## Mathematical Significance
+
+The 2×2 matrix exponential is the engine of planar linear ODE systems, rotation and
+shear flows, and the `SL₂`/`SU₂` Lie-group exponential maps. The closed form
+`exp(tA) = α(t)I + β(t)A` (no infinite series) is a reusable building block and a
+clean showcase of Cayley–Hamilton reducing an analytic matrix function to a scalar
+problem (E. J. Putzer, *Amer. Math. Monthly* 73 (1966)).
+
+## Extends
+- CayleyHamiltonOQ04.lean (open question OQ-04 of the Cayley–Hamilton entry)
+- CayleyHamilton.lean (Wiedijk #49)
+
+## Status
+- [x] Complete proof (no sorries). Inherits only the standard foundational axioms
+      used by `Matrix.exp` (`propext`, `Classical.choice`, `Quot.sound`).
+-/
+
+namespace CayleyHamiltonOQ04OQ02
+
+open Matrix NormedSpace
+
+attribute [local instance] Matrix.linftyOpNormedRing Matrix.linftyOpNormedAlgebra
+
+noncomputable section
+
+/-- **Explicit 2×2 Cayley–Hamilton** (`A * A = τ • A − δ • 1`), proved by direct
+entrywise expansion. This is the `A * A` form of the parent `sq_eq`. -/
+theorem mul_self_eq (A : Matrix (Fin 2) (Fin 2) ℝ) :
+    A * A = A.trace • A - A.det • 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.trace_fin_two, Matrix.det_fin_two,
+      Matrix.sub_apply, Matrix.smul_apply] <;> ring
+
+/-- **Headline closed form.** If the scalar coefficients `α, β` solve the Putzer ODE
+system `α' = −(det A)·β`, `β' = α + (tr A)·β` with `α(0) = 1`, `β(0) = 0`, then the
+matrix exponential is the two-term combination `exp(t • A) = α(t) • 1 + β(t) • A`.
+
+The proof is an integrating-factor uniqueness argument: `exp(−t•A) · (α•1 + β•A)` has
+zero derivative everywhere (using `A² = τ•A − δ•1` to cancel), hence equals its value
+`1` at `t = 0`. -/
+theorem exp_eq_of_coeffs (A : Matrix (Fin 2) (Fin 2) ℝ) (α β : ℝ → ℝ)
+    (hα : ∀ t, HasDerivAt α (-(A.det) * β t) t)
+    (hβ : ∀ t, HasDerivAt β (α t + A.trace * β t) t)
+    (h0 : α 0 = 1) (h0' : β 0 = 0) (t : ℝ) :
+    exp ℝ (t • A) = α t • 1 + β t • A := by
+  -- The algebraic cancellation underlying `φ' = 0`.
+  have key : ∀ s : ℝ, (-A) * (α s • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β s • A)
+      + ((-(A.det) * β s) • (1 : Matrix (Fin 2) (Fin 2) ℝ)
+          + (α s + A.trace * β s) • A) = 0 := by
+    intro s
+    have hexpand : (-A) * (α s • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β s • A)
+        = α s • (-A) + β s • (-(A * A)) := by
+      rw [mul_add, mul_smul_comm, mul_smul_comm, mul_one, neg_mul]
+    rw [hexpand, mul_self_eq]
+    module
+  -- `φ s = exp(−s•A) · (α s • 1 + β s • A)` has zero derivative at every `s`.
+  have hφderiv : ∀ s : ℝ, HasDerivAt
+      (fun x => exp ℝ (x • (-A)) * (α x • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β x • A)) 0 s := by
+    intro s
+    have hu : HasDerivAt (fun u : ℝ => exp ℝ (u • (-A))) (exp ℝ (s • (-A)) * (-A)) s :=
+      hasDerivAt_exp_smul_const (-A) s
+    have hMd : HasDerivAt (fun x => α x • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β x • A)
+        ((-(A.det) * β s) • (1 : Matrix (Fin 2) (Fin 2) ℝ)
+          + (α s + A.trace * β s) • A) s :=
+      ((hα s).smul_const _).add ((hβ s).smul_const _)
+    have hprod := hu.mul hMd
+    have hzero : exp ℝ (s • (-A)) * (-A) * (α s • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β s • A)
+        + exp ℝ (s • (-A)) * ((-(A.det) * β s) • (1 : Matrix (Fin 2) (Fin 2) ℝ)
+          + (α s + A.trace * β s) • A) = 0 := by
+      rw [mul_assoc, ← mul_add, key s, mul_zero]
+    rw [hzero] at hprod
+    exact hprod
+  -- Zero derivative everywhere ⇒ constant ⇒ equals its value `1` at `0`.
+  have hdiff : Differentiable ℝ
+      (fun x => exp ℝ (x • (-A)) * (α x • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β x • A)) :=
+    fun s => (hφderiv s).differentiableAt
+  have hderiv0 : ∀ s : ℝ,
+      deriv (fun x => exp ℝ (x • (-A)) * (α x • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β x • A)) s = 0 :=
+    fun s => (hφderiv s).deriv
+  have hφt : exp ℝ (t • (-A)) * (α t • (1 : Matrix (Fin 2) (Fin 2) ℝ) + β t • A) = 1 := by
+    have hconst := is_const_of_deriv_eq_zero hdiff hderiv0 t 0
+    simpa [h0, h0'] using hconst
+  -- Multiply by `exp(t•A)` on the left to extract the closed form.
+  have hcomm : Commute (t • A) (t • (-A)) := by
+    rw [smul_neg]; exact (Commute.refl (t • A)).neg_right
+  have hinv : exp ℝ (t • A) * exp ℝ (t • (-A)) = 1 := by
+    rw [← exp_add_of_commute ℝ _ _ hcomm, smul_neg, add_neg_cancel, exp_zero]
+  calc exp ℝ (t • A)
+      = exp ℝ (t • A) * 1 := (mul_one _).symm
+    _ = exp ℝ (t • A) * (exp ℝ (t • (-A)) * (α t • 1 + β t • A)) := by rw [hφt]
+    _ = (exp ℝ (t • A) * exp ℝ (t • (-A))) * (α t • 1 + β t • A) := by rw [mul_assoc]
+    _ = 1 * (α t • 1 + β t • A) := by rw [hinv]
+    _ = α t • 1 + β t • A := one_mul _
+
+/-- **Distinct-eigenvalue closed form.** If `tr A = λ₁ + λ₂` and `det A = λ₁ λ₂` with
+`λ₁ ≠ λ₂`, then
+`exp(t•A) = (e^{λ₁t} − λ₁ β(t)) • 1 + β(t) • A` where `β(t) = (e^{λ₁t} − e^{λ₂t})/(λ₁ − λ₂)`. -/
+theorem exp_two_two_distinct (A : Matrix (Fin 2) (Fin 2) ℝ) (lam1 lam2 : ℝ)
+    (hne : lam1 ≠ lam2) (hτ : A.trace = lam1 + lam2) (hδ : A.det = lam1 * lam2) (t : ℝ) :
+    exp ℝ (t • A)
+      = (Real.exp (lam1 * t)
+          - lam1 * ((Real.exp (lam1 * t) - Real.exp (lam2 * t)) / (lam1 - lam2))) • 1
+        + ((Real.exp (lam1 * t) - Real.exp (lam2 * t)) / (lam1 - lam2)) • A := by
+  have hd : lam1 - lam2 ≠ 0 := sub_ne_zero.mpr hne
+  refine exp_eq_of_coeffs A
+    (fun t => Real.exp (lam1 * t)
+        - lam1 * ((Real.exp (lam1 * t) - Real.exp (lam2 * t)) / (lam1 - lam2)))
+    (fun t => (Real.exp (lam1 * t) - Real.exp (lam2 * t)) / (lam1 - lam2))
+    ?_ ?_ ?_ ?_ t
+  · -- α' = −(det A)·β
+    intro s
+    have g1 : HasDerivAt (fun t : ℝ => lam1 * t) lam1 s := by
+      simpa using (hasDerivAt_id s).const_mul lam1
+    have g2 : HasDerivAt (fun t : ℝ => lam2 * t) lam2 s := by
+      simpa using (hasDerivAt_id s).const_mul lam2
+    have e1 : HasDerivAt (fun t : ℝ => Real.exp (lam1 * t)) (Real.exp (lam1 * s) * lam1) s := g1.exp
+    have e2 : HasDerivAt (fun t : ℝ => Real.exp (lam2 * t)) (Real.exp (lam2 * s) * lam2) s := g2.exp
+    have hβ' : HasDerivAt
+        (fun t => (Real.exp (lam1 * t) - Real.exp (lam2 * t)) / (lam1 - lam2))
+        ((Real.exp (lam1 * s) * lam1 - Real.exp (lam2 * s) * lam2) / (lam1 - lam2)) s :=
+      (e1.sub e2).div_const _
+    have hα' := e1.sub (hβ'.const_mul lam1)
+    convert hα' using 1
+    rw [hδ]
+    field_simp
+    ring
+  · -- β' = α + (tr A)·β
+    intro s
+    have g1 : HasDerivAt (fun t : ℝ => lam1 * t) lam1 s := by
+      simpa using (hasDerivAt_id s).const_mul lam1
+    have g2 : HasDerivAt (fun t : ℝ => lam2 * t) lam2 s := by
+      simpa using (hasDerivAt_id s).const_mul lam2
+    have e1 : HasDerivAt (fun t : ℝ => Real.exp (lam1 * t)) (Real.exp (lam1 * s) * lam1) s := g1.exp
+    have e2 : HasDerivAt (fun t : ℝ => Real.exp (lam2 * t)) (Real.exp (lam2 * s) * lam2) s := g2.exp
+    have hβ' : HasDerivAt
+        (fun t => (Real.exp (lam1 * t) - Real.exp (lam2 * t)) / (lam1 - lam2))
+        ((Real.exp (lam1 * s) * lam1 - Real.exp (lam2 * s) * lam2) / (lam1 - lam2)) s :=
+      (e1.sub e2).div_const _
+    convert hβ' using 1
+    rw [hτ]
+    field_simp
+    ring
+  · simp
+  · simp
+
+/-- **Repeated-eigenvalue closed form.** If `tr A = 2λ` and `det A = λ²`, then
+`exp(t•A) = (e^{λt} − λ t e^{λt}) • 1 + (t e^{λt}) • A`. -/
+theorem exp_two_two_repeated (A : Matrix (Fin 2) (Fin 2) ℝ) (lam : ℝ)
+    (hτ : A.trace = 2 * lam) (hδ : A.det = lam ^ 2) (t : ℝ) :
+    exp ℝ (t • A)
+      = (Real.exp (lam * t) - lam * (t * Real.exp (lam * t))) • 1
+        + (t * Real.exp (lam * t)) • A := by
+  refine exp_eq_of_coeffs A
+    (fun t => Real.exp (lam * t) - lam * (t * Real.exp (lam * t)))
+    (fun t => t * Real.exp (lam * t)) ?_ ?_ ?_ ?_ t
+  · -- α' = −(det A)·β
+    intro s
+    have g1 : HasDerivAt (fun t : ℝ => lam * t) lam s := by
+      simpa using (hasDerivAt_id s).const_mul lam
+    have e1 : HasDerivAt (fun t : ℝ => Real.exp (lam * t)) (Real.exp (lam * s) * lam) s := g1.exp
+    have hβ' : HasDerivAt (fun t => t * Real.exp (lam * t))
+        (1 * Real.exp (lam * s) + s * (Real.exp (lam * s) * lam)) s :=
+      (hasDerivAt_id s).mul e1
+    have hα' := e1.sub (hβ'.const_mul lam)
+    convert hα' using 1
+    rw [hδ]
+    ring
+  · -- β' = α + (tr A)·β
+    intro s
+    have g1 : HasDerivAt (fun t : ℝ => lam * t) lam s := by
+      simpa using (hasDerivAt_id s).const_mul lam
+    have e1 : HasDerivAt (fun t : ℝ => Real.exp (lam * t)) (Real.exp (lam * s) * lam) s := g1.exp
+    have hβ' : HasDerivAt (fun t => t * Real.exp (lam * t))
+        (1 * Real.exp (lam * s) + s * (Real.exp (lam * s) * lam)) s :=
+      (hasDerivAt_id s).mul e1
+    convert hβ' using 1
+    rw [hτ]
+    ring
+  · simp
+  · simp
+
+end
+
+end CayleyHamiltonOQ04OQ02

--- a/src/data/proofs/cayley-hamilton-oq-04-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-02/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "cayley-hamilton-oq-04-oq-02",
+  "title": "Closed-Form 2×2 Matrix Exponential from Cayley–Hamilton",
+  "slug": "cayley-hamilton-oq-04-oq-02",
+  "description": "Pushes the explicit 2×2 Cayley–Hamilton relation A² = (tr A)·A − (det A)·1 through the matrix exponential to prove the closed form exp(t·A) = α(t)·1 + β(t)·A. The headline theorem holds for ANY scalar coefficients α, β solving the Putzer ODE system α' = −(det A)·β, β' = α + (tr A)·β with α(0)=1, β(0)=0, proved by an integrating-factor uniqueness argument (the function exp(−t·A)·(α·1+β·A) has identically-zero derivative). Two corollaries supply the classical explicit coefficients from the eigenvalues: the distinct case β(t)=(e^{λ₁t}−e^{λ₂t})/(λ₁−λ₂) and the repeated case β(t)=t·e^{λt}. 4 theorems, 0 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonOQ04OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "matrix-exponential",
+      "cayley-hamilton",
+      "2x2-matrices",
+      "differential-equations",
+      "putzer"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound) — confirmed by #print axioms on all three headline theorems. Uses Mathlib's Matrix.exp (NormedSpace.exp) and its derivative hasDerivAt_exp_smul_const, both of which are themselves axiom-free; the explicit 2×2 Cayley–Hamilton relation A·A = (tr A)·A − (det A)·1 is re-proved from scratch by entrywise Fin 2 expansion.",
+    "lineCount": 232,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "exp_eq_of_coeffs: the closed form exp(t·A) = α(t)·1 + β(t)·A for any 2×2 real matrix, holding for ANY α, β solving the Putzer ODE system — proved by an integrating-factor / uniqueness argument (exp(−t·A)·(α·1+β·A) has zero derivative everywhere, hence is constant). No such reduction of Matrix.exp to the span {1, A} exists in Mathlib.",
+      "mul_self_eq: the A·A form of explicit 2×2 Cayley–Hamilton A·A = (tr A)·A − (det A)·1, proved entrywise (Mathlib provides only the abstract charpoly form).",
+      "exp_two_two_distinct: explicit distinct-eigenvalue closed form with β(t) = (e^{λ₁t} − e^{λ₂t})/(λ₁ − λ₂), the coefficient ODE verified by field_simp/ring.",
+      "exp_two_two_repeated: explicit repeated-eigenvalue closed form with β(t) = t·e^{λt}, the coefficient ODE verified by the product rule and ring."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The reduction of an analytic function of a 2×2 matrix to a two-term combination α·I + β·A is the Cayley–Hamilton / Lagrange–Sylvester functional calculus, made algorithmic for the exponential by E. J. Putzer ('Avoiding the Jordan canonical form in the discussion of linear systems with constant coefficients', Amer. Math. Monthly 73 (1966)). Putzer's method writes exp(tA) = α(t)I + β(t)A and reduces the problem to a scalar second-order linear ODE governed by the characteristic polynomial λ² − (tr A)λ + det A, exactly the form proved here. The 2×2 case is the workhorse of planar linear ODE systems, rotation and shear flows, and the SL₂/SU₂ Lie-group exponential maps.",
+    "problemStatement": "For a 2×2 real matrix A with tr A = τ and det A = δ, prove exp(t·A) = α(t)·1 + β(t)·A where the scalar coefficients α, β solve the Putzer ODE system α' = −δ·β, β' = α + τ·β with α(0)=1, β(0)=0; and instantiate the explicit closed forms in the distinct- and repeated-eigenvalue cases.",
+    "text": "Every power Aᵏ of a 2×2 matrix lives in the 2-dimensional span {1, A}, because A² = τ·A − δ·1 (Cayley–Hamilton). The matrix exponential exp(tA) = Σ tᵏAᵏ/k! therefore lies in that span too, with coefficients α(t), β(t) of 1 and A. Rather than manipulate the infinite series directly, the proof characterizes (α, β) by the first-order ODE system they must satisfy and uses uniqueness: form φ(t) = exp(−tA)·(α(t)·1 + β(t)·A); differentiating via the product rule and using A² = τ·A − δ·1 shows φ'(t) = exp(−tA)·[(−A)(α·1+β·A) + (α'·1 + β'·A)] = 0 precisely when α' = −δβ and β' = α + τβ. A matrix-valued function with identically-zero derivative on ℝ is constant, so φ(t) = φ(0) = 1, i.e. exp(−tA)·(α·1+β·A) = 1; left-multiplying by exp(tA) (which commutes with exp(−tA)) yields exp(tA) = α(t)·1 + β(t)·A. The eigenvalue closed forms then follow by exhibiting explicit α, β and checking the ODE with real-variable calculus.",
+    "proofStrategy": "The core theorem exp_eq_of_coeffs is parametric in α, β: it isolates the hard analytic uniqueness step once, so the explicit closed forms become corollaries that only require verifying the two ODEs. The cancellation (−A)(α·1+β·A) + (α'·1+β'·A) = 0 is reduced to the linear-algebra relation A·A = τ·A − δ·1 (mul_self_eq, proved entrywise) and closed with the `module` tactic. The exponential's derivative comes from Mathlib's `hasDerivAt_exp_smul_const`, the product rule from `HasDerivAt.mul`, and the constancy from `is_const_of_deriv_eq_zero`. Matrices over ℝ are given the l∞-operator NormedRing/NormedAlgebra instances (`Matrix.linftyOpNormedRing`/`linftyOpNormedAlgebra`) so that `NormedSpace.exp` applies. In the corollaries, scalar derivatives use `Real.HasDerivAt.exp`, `HasDerivAt.div_const`, and `HasDerivAt.const_mul`, and the resulting coefficient identities are discharged by `field_simp`/`ring`.",
+    "keyInsights": [
+      "Separating the uniqueness theorem (parametric in α, β) from the explicit eigenvalue formulas isolates the only genuinely analytic step and makes both closed forms one-line instantiations.",
+      "The integrating factor exp(−tA) converts the two competing ODEs (exp and the closed form both satisfy f' = f·A) into a single zero-derivative statement, avoiding any direct manipulation of the tsum defining Matrix.exp.",
+      "The cancellation that forces φ' = 0 is exactly the parent relation A² = (tr A)·A − (det A)·1; after substituting it, the `module` tactic closes the matrix identity since everything is ℝ-linear in the atoms 1 and A.",
+      "The same parametric theorem covers both eigenvalue branches uniformly: distinct eigenvalues give a divided-difference β, repeated eigenvalues give the t·e^{λt} term, with no separate limiting argument needed."
+    ],
+    "prerequisites": [
+      "2×2 Cayley–Hamilton: A² = (tr A)·A − (det A)·1 (parent OQ-04)",
+      "Mathlib's matrix exponential Matrix.exp / NormedSpace.exp and its derivative",
+      "First-order linear ODEs and uniqueness via zero-derivative-implies-constant",
+      "Putzer / Lagrange–Sylvester eigenvalue coefficient formulas"
+    ]
+  },
+  "conclusion": {
+    "summary": "4 theorems, 232 lines, 0 axioms. The analytic completion of the algebraic parent CayleyHamiltonOQ04: the closed form exp(t·A) = α(t)·1 + β(t)·A for any 2×2 real matrix, proved for arbitrary Putzer-ODE coefficients by an integrating-factor uniqueness argument, together with the explicit distinct- and repeated-eigenvalue formulas. Verified with no sorries and only the standard foundational axioms.",
+    "implications": "Provides a verified, series-free closed form for the 2×2 matrix exponential — the solution operator exp(tA) of the planar linear system x' = Ax — reusable for rotation/shear flows and the SL₂/SU₂ exponential maps. The parametric uniqueness theorem exp_eq_of_coeffs is a reusable bridge from the Putzer ODE system to the matrix exponential, independent of how the scalar coefficients are presented.",
+    "openQuestions": [
+      "Extend the same integrating-factor uniqueness method to the explicit 3×3 matrix exponential, where Cayley–Hamilton reduces exp(tA) to a combination of 1, A, A² with three Putzer coefficients.",
+      "Specialize to canonical 2×2 families: the rotation generator [[0,-θ],[θ,0]] (giving exp = rotation by θ) and the trace-zero/nilpotent cases, deriving the trigonometric and shear closed forms as named corollaries.",
+      "Connect exp_eq_of_coeffs to Mathlib's planar ODE solution theory to certify exp(tA) as the unique solution operator of x' = Ax."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CayleyHamiltonOQ04OQ02",
+    "lineCount": 232,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-oq-04",
+      "relationship": "extends",
+      "description": "Direct parent: OQ-04 proves the algebraic relation A² = (tr A)·A − (det A)·1; this entry pushes that relation through the matrix exponential to the closed form exp(tA) = α·1 + β·A, resolving OQ-04's open question on the explicit matrix exponential."
+    },
+    {
+      "targetId": "cayley-hamilton-oq-02",
+      "relationship": "related",
+      "description": "OQ-02 develops Putzer-style scalar recurrences for the powers Aᵏ; this entry carries the analogous coefficient ODE through to the exponential."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "The general Cayley–Hamilton theorem, of which the 2×2 span reduction used here is the smallest nontrivial case."
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Header stating the closed form exp(t·A) = α(t)·1 + β(t)·A, the parametric Putzer-ODE hypotheses, the integrating-factor uniqueness strategy, the two eigenvalue corollaries, and why this is the new analytic completion of the algebraic parent rather than a Mathlib re-export."
+    },
+    {
+      "id": "cayley-hamilton",
+      "title": "Explicit 2×2 Cayley–Hamilton (A·A form)",
+      "startLine": 70,
+      "endLine": 82,
+      "summary": "`mul_self_eq`: A·A = (tr A)·A − (det A)·1 proved by entrywise `fin_cases` over Fin 2 closed with `ring`, the form of the relation used to force φ' = 0."
+    },
+    {
+      "id": "headline",
+      "title": "Headline Closed Form",
+      "startLine": 83,
+      "endLine": 144,
+      "summary": "`exp_eq_of_coeffs`: for any α, β solving α' = −(det A)·β, β' = α + (tr A)·β with α(0)=1, β(0)=0, proves exp(t·A) = α(t)·1 + β(t)·A. The function exp(−t·A)·(α·1+β·A) is shown to have zero derivative everywhere (via `hasDerivAt_exp_smul_const`, `HasDerivAt.mul`, and the `module`-closed cancellation), hence is the constant 1, which rearranges to the closed form."
+    },
+    {
+      "id": "distinct",
+      "title": "Distinct-Eigenvalue Closed Form",
+      "startLine": 145,
+      "endLine": 194,
+      "summary": "`exp_two_two_distinct`: with tr A = λ₁+λ₂, det A = λ₁λ₂, λ₁ ≠ λ₂, instantiates β(t) = (e^{λ₁t} − e^{λ₂t})/(λ₁−λ₂), α(t) = e^{λ₁t} − λ₁β(t); the two ODEs are verified with `Real.HasDerivAt.exp`, `HasDerivAt.div_const`, and `field_simp`/`ring`."
+    },
+    {
+      "id": "repeated",
+      "title": "Repeated-Eigenvalue Closed Form",
+      "startLine": 195,
+      "endLine": 230,
+      "summary": "`exp_two_two_repeated`: with tr A = 2λ, det A = λ², instantiates β(t) = t·e^{λt}, α(t) = e^{λt} − λ·t·e^{λt}; the ODEs are verified with the product rule `HasDerivAt.mul` and `ring`."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the open question from the parent **cayley-hamilton-oq-04** entry: *derive the explicit 2×2 matrix exponential `exp(tA)` in closed form from `sq_eq` (`A² = (tr A)·A − (det A)·1`)*. This is the **analytic completion** of that purely algebraic parent.

New file `proofs/Proofs/CayleyHamiltonOQ04OQ02.lean` (4 theorems, 232 lines, **0 sorries, 0 axioms**).

## Results

- **`exp_eq_of_coeffs`** (headline): for a 2×2 real matrix `A`, `exp(t·A) = α(t)·1 + β(t)·A` for **any** scalar coefficients `α, β : ℝ → ℝ` solving the Putzer ODE system
  - `α'(t) = −(det A)·β(t)`,  `β'(t) = α(t) + (tr A)·β(t)`,  `α(0) = 1`,  `β(0) = 0`.

  Proved by an **integrating-factor uniqueness** argument: `φ(t) = exp(−t·A)·(α(t)·1 + β(t)·A)` has identically-zero derivative (the cancellation forcing `φ' = 0` is exactly `A² = (tr A)·A − (det A)·1`), hence is the constant `φ(0) = 1`, which rearranges to the closed form. No manipulation of the `tsum` defining `Matrix.exp` is needed.
- **`exp_two_two_distinct`** (`λ₁ ≠ λ₂`): `β(t) = (e^{λ₁t} − e^{λ₂t})/(λ₁ − λ₂)`, `α(t) = e^{λ₁t} − λ₁β(t)`.
- **`exp_two_two_repeated`** (`λ₁ = λ₂ = λ`): `β(t) = t·e^{λt}`, `α(t) = e^{λt} − λ·t·e^{λt}`.
- **`mul_self_eq`**: `A·A = (tr A)·A − (det A)·1`, re-proved entrywise (self-contained).

## Why this is new

Mathlib provides `Matrix.exp` and its derivative `hasDerivAt_exp_smul_const`, but **no** result reduces the 2×2 exponential to the finite span `{1, A}` with explicit scalar coefficients. The parametric uniqueness theorem isolates the single genuinely-analytic step, so both eigenvalue branches are one-line instantiations whose only obligation is verifying the coefficient ODEs (`field_simp`/`ring`).

## Verification

- Builds offline (`lake env lean Proofs/CayleyHamiltonOQ04OQ02.lean`), exit 0, no warnings.
- `#print axioms` on all three headline theorems: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. **Verified, 0 axioms.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)