### PR TITLE
research(cassini-identity-oq-01): matrix-determinant proof of Cassini's identity [0-sorry, 0-axiom]

### DIFF
--- a/proofs/Proofs/CassiniIdentityOQ01.lean
+++ b/proofs/Proofs/CassiniIdentityOQ01.lean
@@ -1,0 +1,71 @@
+/-
+# Cassini's Identity via the Fibonacci Q-matrix
+
+Cassini's identity states that for the Fibonacci numbers `F`,
+`F_{n+2} · F_n − F_{n+1}² = (−1)^{n+1}`.
+
+Mathlib already proves the integer-indexed form
+(`Int.fib_succ_mul_fib_pred_sub_fib_sq`) by direct induction. This file gives a
+conceptually *different* proof: the **linear-algebra / determinant** proof.
+
+Let `Q = !![1, 1; 1, 0]` be the Fibonacci companion matrix. Its powers encode the
+Fibonacci numbers,
+`Q^{n+1} = !![F_{n+2}, F_{n+1}; F_{n+1}, F_n]`,
+and `det Q = −1`. Since the determinant is multiplicative,
+`det (Q^{n+1}) = (det Q)^{n+1} = (−1)^{n+1}`,
+while expanding the explicit matrix gives
+`det (Q^{n+1}) = F_{n+2}·F_n − F_{n+1}²`.
+Equating the two evaluations yields Cassini's identity.
+
+This realises the identity as the multiplicativity of `det` along powers of `Q`,
+a connection Mathlib does not record (it has no Fibonacci matrix), and is the
+standard "matrix proof" of Cassini's identity.
+-/
+import Mathlib
+
+namespace CassiniIdentityOQ01
+
+open Matrix
+
+/-- The Fibonacci companion ("Q") matrix over `ℤ`. -/
+def Q : Matrix (Fin 2) (Fin 2) ℤ := !![1, 1; 1, 0]
+
+/-- The determinant of the Fibonacci Q-matrix is `−1`. -/
+theorem det_Q : Q.det = -1 := by
+  simp [Q, Matrix.det_fin_two]
+
+/-- **The Fibonacci matrix-power identity.**
+`Q^{n+1} = !![F_{n+2}, F_{n+1}; F_{n+1}, F_n]`. The Fibonacci numbers appear as the
+entries of the powers of the companion matrix. -/
+theorem Q_pow_succ (n : ℕ) :
+    Q ^ (n + 1) =
+      !![(Nat.fib (n + 2) : ℤ), (Nat.fib (n + 1) : ℤ);
+         (Nat.fib (n + 1) : ℤ), (Nat.fib n : ℤ)] := by
+  induction n with
+  | zero =>
+    -- `Q^1 = Q = !![F_2, F_1; F_1, F_0] = !![1, 1; 1, 0]`.
+    simp only [pow_one, Q, Nat.fib_zero]
+    norm_num
+  | succ k ih =>
+    rw [pow_succ, ih]
+    ext i j
+    fin_cases i <;> fin_cases j <;>
+      simp [Q, Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero,
+        Matrix.cons_val_one] <;>
+      push_cast [Nat.fib_add_two] <;> ring
+
+/-- **Cassini's identity** (via the determinant of the Fibonacci Q-matrix):
+for every `n`, `F_{n+2} · F_n − F_{n+1}² = (−1)^{n+1}`. -/
+theorem cassini (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) * (Nat.fib n : ℤ) - (Nat.fib (n + 1) : ℤ) ^ 2 = (-1) ^ (n + 1) := by
+  have hdet_pow : (Q ^ (n + 1)).det = (-1) ^ (n + 1) := by
+    rw [Matrix.det_pow, det_Q]
+  have hdet_expand :
+      (Q ^ (n + 1)).det
+        = (Nat.fib (n + 2) : ℤ) * (Nat.fib n : ℤ) - (Nat.fib (n + 1) : ℤ) ^ 2 := by
+    rw [Q_pow_succ, Matrix.det_fin_two]
+    simp [Matrix.cons_val_zero, Matrix.cons_val_one]
+    ring
+  rw [← hdet_expand, hdet_pow]
+
+end CassiniIdentityOQ01

--- a/src/data/proofs/cassini-identity-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "ann-q-matrix",
+    "proofId": "cassini-identity-oq-01",
+    "range": { "startLine": 30, "endLine": 35 },
+    "type": "definition",
+    "title": "The Fibonacci Companion Matrix Q and det Q = −1",
+    "content": "The companion (or 'Q') matrix $Q = \\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}$ encodes the Fibonacci recurrence: applying $Q$ to the column $(F_{k+1}, F_k)$ produces $(F_{k+2}, F_{k+1})$. Its determinant, computed by `Matrix.det_fin_two`, is $1\\cdot 0 - 1\\cdot 1 = -1$. This single value is the entire source of the alternating sign $(-1)^{n+1}$ in Cassini's identity — everything downstream is multiplicativity of the determinant.",
+    "mathContext": "$Q = !![1,1;1,0]$ over $\\mathbb{Z}$, $\\det Q = -1$.",
+    "significance": "key",
+    "relatedConcepts": ["Companion matrix", "Determinant of a 2×2 matrix", "Fibonacci recurrence"]
+  },
+  {
+    "id": "ann-matrix-power",
+    "proofId": "cassini-identity-oq-01",
+    "range": { "startLine": 37, "endLine": 55 },
+    "type": "theorem",
+    "title": "Powers of Q Tabulate the Fibonacci Numbers",
+    "content": "The identity $Q^{n+1} = \\begin{psmallmatrix}F_{n+2}&F_{n+1}\\\\F_{n+1}&F_n\\end{psmallmatrix}$, proved by induction on $n$. The base case $Q^1 = Q$ matches $!![F_2,F_1;F_1,F_0] = !![1,1;1,0]$. In the step, $Q^{k+2} = Q^{k+1}\\cdot Q$ is expanded entry-by-entry with `mul_apply` and `Fin.sum_univ_two`; each of the four resulting entries is a Fibonacci recurrence instance, closed by `push_cast [Nat.fib_add_two]` followed by `ring`. This is the only induction in the development — the headline identity then needs none.",
+    "mathContext": "$Q^{n+1} = !![F_{n+2}, F_{n+1}; F_{n+1}, F_n]$.",
+    "significance": "critical",
+    "prerequisites": ["Matrix multiplication", "Mathematical induction", "Nat.fib_add_two"],
+    "relatedConcepts": ["Matrix powers", "Fibonacci recurrence", "Companion matrix"]
+  },
+  {
+    "id": "ann-cassini-det",
+    "proofId": "cassini-identity-oq-01",
+    "range": { "startLine": 57, "endLine": 69 },
+    "type": "theorem",
+    "title": "Cassini's Identity from Determinant Multiplicativity",
+    "content": "The headline $F_{n+2}\\cdot F_n - F_{n+1}^2 = (-1)^{n+1}$. The proof evaluates $\\det(Q^{n+1})$ in two ways and equates them. First, `Matrix.det_pow` plus $\\det Q = -1$ give $\\det(Q^{n+1}) = (\\det Q)^{n+1} = (-1)^{n+1}$ (`hdet_pow`). Second, substituting the matrix-power identity and applying `Matrix.det_fin_two` give $\\det(Q^{n+1}) = F_{n+2}\\,F_n - F_{n+1}^2$ (`hdet_expand`). Rewriting one against the other closes the goal — no induction on the identity itself is required.",
+    "mathContext": "$F_{n+2}F_n - F_{n+1}^2 = (\\det Q)^{n+1} = (-1)^{n+1}$.",
+    "significance": "critical",
+    "prerequisites": ["Multiplicativity of the determinant (Matrix.det_pow)", "Matrix.det_fin_two"],
+    "relatedConcepts": ["Cassini's identity", "Determinant multiplicativity", "Alternating sign"]
+  },
+  {
+    "id": "ann-sign-is-determinant",
+    "proofId": "cassini-identity-oq-01",
+    "range": { "startLine": 61, "endLine": 62 },
+    "type": "insight",
+    "title": "The Alternating Sign Is a Determinant Power",
+    "content": "The factor $(-1)^{n+1}$ that makes Cassini's identity oscillate is not put in by hand — it is exactly $(\\det Q)^{n+1}$. Because $\\det$ is multiplicative, $\\det(Q^{n+1}) = (\\det Q)^{n+1}$, and $\\det Q = -1$ forces the sign. This is the conceptual payoff of the matrix proof over a direct induction: it explains *why* the sign alternates rather than merely verifying that it does.",
+    "mathContext": "$\\det(Q^{n+1}) = (\\det Q)^{n+1} = (-1)^{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Determinant multiplicativity", "Companion matrix", "Cassini's identity"]
+  }
+]

--- a/src/data/proofs/cassini-identity-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01/meta.json
@@ -1,0 +1,106 @@
+{
+  "id": "cassini-identity-oq-01",
+  "title": "Cassini's Identity via the Fibonacci Q-Matrix Determinant",
+  "slug": "cassini-identity-oq-01",
+  "description": "A fully machine-checked proof of Cassini's identity F_{n+2}·F_n − F_{n+1}² = (−1)^{n+1} obtained from the multiplicativity of the determinant along powers of the Fibonacci companion matrix Q = !![1,1;1,0]. Since det(Q^{n+1}) = (det Q)^{n+1} = (−1)^{n+1} while the explicit power Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n] expands to F_{n+2}·F_n − F_{n+1}², the identity falls out by equating the two evaluations. Mathlib proves the integer-indexed Cassini identity (Int.fib_succ_mul_fib_pred_sub_fib_sq) only by direct induction and records no Fibonacci matrix; this entry supplies the conceptually different linear-algebra/determinant proof.",
+  "meta": {
+    "author": "Jean-Dominique Cassini (1680); matrix proof formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "1680",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "cassini",
+      "linear-algebra",
+      "determinant",
+      "companion-matrix",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CassiniIdentityOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.det_pow",
+        "description": "det (M^k) = (det M)^k. The crux: multiplicativity of the determinant along matrix powers turns det(Q^{n+1}) into (det Q)^{n+1} = (−1)^{n+1}.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Matrix.det_fin_two",
+        "description": "Closed form for the determinant of a 2×2 matrix: det !![a,b;c,d] = a·d − b·c. Both evaluations of det Q and det(Q^{n+1}) reduce through this.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "The Fibonacci recurrence fib (n+2) = fib n + fib (n+1), used in the inductive step that identifies the entries of Q^{n+1} with consecutive Fibonacci numbers.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The Fibonacci matrix-power identity Q^{n+1} = !![F_{n+2}, F_{n+1}; F_{n+1}, F_n] over ℤ, proved by induction with the Fibonacci recurrence — Mathlib records no Fibonacci companion matrix at all",
+      "Cassini's identity F_{n+2}·F_n − F_{n+1}² = (−1)^{n+1} derived as the determinant evaluation det(Q^{n+1}) = (det Q)^{n+1}, the standard 'matrix proof', conceptually distinct from Mathlib's induction-only Int.fib_succ_mul_fib_pred_sub_fib_sq",
+      "det Q = −1 computed for the companion matrix, the single scalar that drives the alternating sign (−1)^{n+1}"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 71,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only structural Mathlib lemmas (Matrix.det_pow, Matrix.det_fin_two, Nat.fib_add_two) with induction, push_cast, and ring; no native_decide and no structure-encoded hypotheses. #print axioms is expected to report only the foundational propext, Classical.choice, Quot.sound, none of which count as assumptions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "q-matrix",
+      "title": "The Fibonacci Q-Matrix and its Determinant",
+      "startLine": 30,
+      "endLine": 35,
+      "summary": "The companion matrix Q = !![1,1;1,0] over ℤ, together with det Q = −1 computed by det_fin_two. This single determinant supplies the alternating sign in Cassini's identity."
+    },
+    {
+      "id": "matrix-power",
+      "title": "The Matrix-Power Identity",
+      "startLine": 37,
+      "endLine": 55,
+      "summary": "Q^{n+1} = !![F_{n+2}, F_{n+1}; F_{n+1}, F_n] by induction on n. The base case is Q^1 = Q; the step multiplies by Q and closes each of the four entries with the Fibonacci recurrence (push_cast [Nat.fib_add_two]) followed by ring."
+    },
+    {
+      "id": "cassini",
+      "title": "Cassini's Identity by Determinant Multiplicativity",
+      "startLine": 57,
+      "endLine": 69,
+      "summary": "Two evaluations of det(Q^{n+1}) are equated: det_pow gives (det Q)^{n+1} = (−1)^{n+1}, while det_fin_two applied to the explicit power gives F_{n+2}·F_n − F_{n+1}². Their equality is Cassini's identity."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Cassini's Identity**\n\nJean-Dominique Cassini observed in 1680 that consecutive Fibonacci numbers satisfy\n$$F_{n+2}\\,F_n - F_{n+1}^2 = (-1)^{n+1},$$\na tight 'near-miss' relation: the product of the Fibonacci numbers two apart differs from the square of the one between them by exactly $\\pm 1$. It is the prototype of the Cassini–Catalan family of identities and underlies the classic missing-square dissection puzzle. Mathlib already contains the integer-indexed form `Int.fib_succ_mul_fib_pred_sub_fib_sq`, proved by direct induction, but records no Fibonacci companion matrix. This entry gives the other classical proof — the linear-algebra one.",
+    "problemStatement": "**Cassini's Identity (matrix proof)**\n\nFor every natural number $n$,\n$$F_{n+2}\\cdot F_n - F_{n+1}^2 = (-1)^{n+1},$$\nwith the Fibonacci numbers viewed inside $\\mathbb{Z}$. The goal is a fully machine-checked proof that realises the identity as the multiplicativity of $\\det$ along powers of the companion matrix $Q = \\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}$, with no axioms and no sorries.",
+    "proofStrategy": "**One determinant, evaluated two ways**\n\nLet $Q = \\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}$ over $\\mathbb{Z}$. An induction shows the powers of $Q$ carry the Fibonacci numbers as entries:\n$$Q^{n+1} = \\begin{pmatrix}F_{n+2} & F_{n+1}\\\\ F_{n+1} & F_n\\end{pmatrix},$$\nthe inductive step closing each entry via the recurrence $F_{n+2} = F_n + F_{n+1}$. Now evaluate $\\det(Q^{n+1})$ in two ways. Multiplicativity (`Matrix.det_pow`) gives $\\det(Q^{n+1}) = (\\det Q)^{n+1} = (-1)^{n+1}$, since $\\det Q = -1$. The $2\\times 2$ determinant of the explicit power (`Matrix.det_fin_two`) gives $F_{n+2}F_n - F_{n+1}^2$. Equating the two yields Cassini's identity.",
+    "keyInsights": [
+      "**The sign is a determinant.** The mysterious alternating $(-1)^{n+1}$ is nothing but $(\\det Q)^{n+1}$ — the whole oscillation is forced by the single fact $\\det Q = -1$.",
+      "**Fibonacci numbers live in the matrix.** The recurrence $F_{n+2} = F_n + F_{n+1}$ is exactly matrix multiplication by $Q$, so $Q^{n+1}$ tabulates four consecutive Fibonacci numbers and the identity becomes a statement about $\\det$.",
+      "**Multiplicativity does the work.** Once the entries are identified, the proof is just `det_pow` against `det_fin_two`; no second induction on the identity itself is needed.",
+      "**Stay in ℤ from the start.** Casting the Fibonacci entries into $\\mathbb{Z}$ up front means the subtraction $F_{n+2}F_n - F_{n+1}^2$ is genuine (not truncated), and `ring` handles the entry-wise algebra cleanly."
+    ],
+    "prerequisites": [
+      "Matrix multiplication and the determinant",
+      "Multiplicativity of the determinant",
+      "Fibonacci numbers and their recurrence",
+      "Mathematical induction"
+    ]
+  },
+  "conclusion": {
+    "summary": "Cassini's identity $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$ is obtained by evaluating $\\det(Q^{n+1})$ two ways for the companion matrix $Q = \\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}$: `Matrix.det_pow` gives $(\\det Q)^{n+1} = (-1)^{n+1}$, and `Matrix.det_fin_two` on the explicit power $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$ gives $F_{n+2}F_n - F_{n+1}^2$. The matrix-power identity itself is a short induction on the Fibonacci recurrence. 0 axioms, 0 sorries.",
+    "implications": [
+      "Records the Fibonacci companion matrix and its power identity $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$ — infrastructure Mathlib lacks — making the matrix proof of Cassini reusable for related identities (e.g. d'Ocagne, Catalan, the addition formula).",
+      "Complements Mathlib's induction-only `Int.fib_succ_mul_fib_pred_sub_fib_sq` with the conceptual linear-algebra proof, exposing the alternating sign as a determinant power.",
+      "Demonstrates the 'evaluate one determinant two ways' technique for turning recurrence identities into one-line determinant computations."
+    ],
+    "openQuestions": [
+      "Does the same Q-matrix bookkeeping yield the Catalan identity $F_{n-r}F_{n+r} - F_n^2 = (-1)^{n-r+1}F_r^2$ via $\\det(Q^{n-r}\\cdot Q^{2r})$, or does the off-diagonal mixing demand a separate entry analysis?",
+      "Can the addition formula $F_{m+n} = F_{m+1}F_n + F_m F_{n-1}$ be read off directly from the entries of $Q^{m+n} = Q^m Q^n$, packaging several Fibonacci identities as corollaries of one matrix factorisation?"
+    ]
+  }
+}


### PR DESCRIPTION
## Cassini's Identity via the Fibonacci Q-Matrix Determinant

Adds a fully machine-checked proof of **Cassini's identity**
$$F_{n+2}\cdot F_n - F_{n+1}^2 = (-1)^{n+1}$$
realised as the multiplicativity of the determinant along powers of the Fibonacci companion matrix $Q = \begin{psmallmatrix}1&1\\1&0\end{psmallmatrix}$.

### Proof idea
- $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$ by induction on the Fibonacci recurrence (`Nat.fib_add_two`).
- `Matrix.det_pow` + $\det Q = -1$ give $\det(Q^{n+1}) = (\det Q)^{n+1} = (-1)^{n+1}$.
- `Matrix.det_fin_two` on the explicit power gives $\det(Q^{n+1}) = F_{n+2}F_n - F_{n+1}^2$.
- Equating the two evaluations is Cassini's identity. No induction on the identity itself is needed.

### Novelty vs Mathlib
Mathlib proves the integer-indexed Cassini identity (`Int.fib_succ_mul_fib_pred_sub_fib_sq`) **only by direct induction** and records **no Fibonacci companion matrix**. This entry supplies the conceptually distinct **linear-algebra / determinant** proof, exposing the alternating sign $(-1)^{n+1}$ as a determinant power, plus the reusable matrix-power identity $Q^{n+1} = !![F_{n+2},F_{n+1};F_{n+1},F_n]$.

### Verification
- **0 sorries, 0 axioms.** The file compiles cleanly via offline `lake env lean Proofs/CassiniIdentityOQ01.lean` (exit 0). Tactics are purely structural (`Matrix.det_pow`, `Matrix.det_fin_two`, `Nat.fib_add_two`, induction, `push_cast`, `ring`) — no `native_decide`, no `axiom` declarations, no structure-encoded hypotheses, so `#print axioms` reduces to the foundational `propext`/`Classical.choice`/`Quot.sound` (none of which count). The explicit `#print axioms` capture was blocked by a concurrent Mathlib rebuild churning the shared `.lake` oleans at PR time; the clean compile and tactic profile establish the axiom-free status.

### Files
- `proofs/Proofs/CassiniIdentityOQ01.lean` (71 lines)
- `src/data/proofs/cassini-identity-oq-01/meta.json`
- `src/data/proofs/cassini-identity-oq-01/annotations.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)