### PR TITLE
research(erdos-501): refute false outer-measure Fubini route for Erdős–Hajnal finite independence

### DIFF
--- a/proofs/Proofs/Erdos501Problem.lean
+++ b/proofs/Proofs/Erdos501Problem.lean
@@ -89,7 +89,18 @@ def HasInfiniteIndependent (A : SetFamily) : Prop :=
     1-dimensional outer measure < 1. Hence μ(C_{ij}) < L^{n-1}.
     By subadditivity: μ(⋃_{i≠j} C_{ij}) < n(n-1) · L^{n-1} < L^n.
     So conflict-free tuples exist. The non-injective tuples form a
-    measure-zero subset, so conflict-free *injective* tuples exist. -/
+    measure-zero subset, so conflict-free *injective* tuples exist.
+
+    ⚠️ **CAUTION (researcher-7, 2026-06-25): the "Fubini section bound" step
+    above is NOT valid as stated for non-measurable families.** For Lebesgue
+    *outer* measure, `λ*_n(E) ≤ ∫ λ*_1(E_t)` (product ≤ integral of section
+    outer measures) is the FALSE direction; only `λ*_n(E) ≥ ∫_* λ*_1(E_t)`
+    holds. A Sierpiński set in [0,L]^2 has all sections null yet full planar
+    outer measure, so `μ(C_{ij})` can be as large as `L^n`. A correct proof
+    must pass to measurable hulls `H_t ⊇ A_t∩[0,L]` and apply *measurable*
+    Fubini, which requires joint measurability of `t ↦ H_t` — the genuine
+    crux. The same non-measurability is what makes the infinite case
+    CH-dependent (Hechler 1972). This sorry is HARD, not routine. -/
 lemma exists_independent_tuple (A : SetFamily) (hA : BoundedOuterMeasureFamily A)
     (n : ℕ) :
     ∃ f : Fin n → ℝ, Function.Injective f ∧

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "last_updated": "",
+  "last_updated": "2026-06-25",
   "description": "Cross-problem technique index tracking which proof techniques have been tried on which problems",
   "techniques": [
     {
@@ -37,6 +37,15 @@
       ],
       "outcome": "success",
       "date": "2026-06-20"
+    },
+    {
+      "name": "Outer-measure obstruction analysis",
+      "used_in_problems": [
+        "erdos-501-incomplete-01"
+      ],
+      "outcome": "blocked",
+      "date": "2026-06-25",
+      "description": "Established that the product-outer-measure Fubini section bound (lambda*_n(E) <= integral of section outer measures) is the FALSE direction for non-measurable families (Sierpinski counterexample), refuting the proposed OuterMeasure.le_prod_outer helper for Erdos-Hajnal finite independence. Real crux is joint measurability of a measurable-hull family."
     }
   ]
 }

--- a/research/problems/erdos-501-incomplete-01/state.md
+++ b/research/problems/erdos-501-incomplete-01/state.md
@@ -2,10 +2,53 @@
 
 **Phase**: ORIENT
 **Since**: 2026-03-28T20:57:10Z
-**Iteration**: 2 (S2 compile-repair, this PR)
-**Last Updated**: 2026-06-25 (researcher-3)
+**Iteration**: 3 (S3 obstruction analysis, this PR)
+**Last Updated**: 2026-06-25 (researcher-7)
 
 ## Current Focus
+
+Iteration 3 (2026-06-25, researcher-7, this PR): **ORIENT — correcting the
+Lever A proof strategy. The product-outer-measure section bound it relies on
+is the WRONG DIRECTION and cannot be formalized as stated.**
+
+> ⚠️ **CRITICAL CORRECTION to Lever A below.** Every prior sketch (the file
+> docstring and the Lever A section of this document) asserts that the conflict
+> set `C_{ij} = {f ∈ [0,L]^n : f(i) ∈ A(f(j))}` has product measure
+> `≤ L^(n-1)` because each `A_t` has outer measure `< 1`, and proposes a
+> Mathlib helper `OuterMeasure.le_prod_outer` (outer-measure sub-Fubini). **This
+> helper is mathematically FALSE.** For Lebesgue *outer* measure the inequality
+> `λ*_n(E) ≤ ∫ λ*_1(E_t)` (product outer measure bounded by the integral of
+> section outer measures) does **not** hold; only the reverse
+> `λ*_n(E) ≥ ∫_* λ*_1(E_t)` is valid. **Counterexample:** under CH a Sierpiński
+> set in `[0,L]^2` has every vertical section countable (hence null) yet full
+> planar outer measure `L^2`. So "all sections have outer measure < 1" does NOT
+> bound the product outer measure of `C_{ij}`, and `C_{ij}` can have outer
+> measure `L^n`. The union-bound therefore collapses.
+>
+> **Why this matters:** the *same* non-measurability/Sierpiński phenomenon is
+> what makes the infinite case CH-dependent (Hechler 1972). The finite
+> Erdős–Hajnal result is still a ZFC theorem, but its genuine proof must avoid
+> the product-outer-measure route entirely.
+>
+> **What an honest Lever A would require:** replace each `A_t ∩ [0,L]` by a
+> measurable hull `H_t ⊇ A_t∩[0,L]` with `λ(H_t) = λ*(A_t∩[0,L]) < 1`, then
+> apply *measurable* Fubini (`MeasureTheory.lintegral_prod`). The remaining gap
+> is **joint measurability of the hull family `t ↦ H_t`**, which is NOT
+> automatic for an arbitrary family. This (not a sub-Fubini outer-measure
+> inequality) is the true crux. `n = 2` is already non-trivial for the same
+> reason — there is no elementary shortcut.
+>
+> **Stale-record fix:** `Erdos501Aristotle.lean` now has **0 sorries**
+> (`exists_not_mem_of_outerMeasure_lt_Icc` and `measure_compl_Icc_pos` are both
+> fully proved). The snapshot table below (written at Iteration 1) listing 1
+> sorry in the Aristotle file is outdated. Current aggregate: the only open
+> sorries are the 3 in `Erdos501Problem.lean`.
+>
+> Aristotle async submission of `exists_independent_tuple` was attempted this
+> session but the MCP endpoint returned "Resource not found"; retry when
+> reachable.
+
+### (Historical) Iteration 2 focus follows
 
 Iteration 2 (2026-06-25, researcher-3, this PR): **compile-repair — the three
 erdos-501 Lean files do not build under the pinned Mathlib (v4.26.0)**.

--- a/src/data/research/problems/erdos-501-incomplete-01.json
+++ b/src/data/research/problems/erdos-501-incomplete-01.json
@@ -19,17 +19,17 @@
     "phase": "ORIENT",
     "since": "2026-03-28T20:57:10.258Z",
     "iteration": 6,
-    "focus": "CH-def bug fixed in Provable file. 3 deep sorries remain across both files (Erdos-Hajnal n>=2, Hechler under CH, NPS closed).",
+    "focus": "Identified that the product-outer-measure Fubini section bound (basis of all prior exists_independent_tuple sketches) is the wrong direction for non-measurable A_y; real crux is joint measurability of measurable hulls. Companion file verified complete (0 sorries).",
     "blockers": [],
-    "nextAction": "Either eliminate file duplication (provable now mirrors main exactly), or break Mathlib gap with outer-measure Fubini lemma.",
+    "nextAction": "Pursue joint-measurability hull route or locate original Erdos-Hajnal 1960 argument; submit to Aristotle when endpoint reachable.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 0,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed CH definition bug in Erdos501ProblemProvable.lean — old def `∀ S ⊆ ℝ uncountable, ∃ surjection ℝ → S` is trivially provable in ZFC (carries no content). Replaced with `Cardinal.aleph 1 = Cardinal.continuum` matching main file. 0 axioms, 3 sorries remain (exists_independent_tuple n>=2, hechler_under_CH, nps_closed_infinite).",
+    "progressSummary": "BLOCKED (sharpened): 3 sorries remain in Erdos501Problem.lean. Key finding (researcher-7 2026-06-25): the naive product-outer-measure Fubini section bound used in all prior attempt sketches is the FALSE direction for non-measurable families (Sierpinski counterexample), so exists_independent_tuple cannot be proved that way; the real obstruction is joint measurability of a hull family. Companion file confirmed 0 sorries (prior record stale).",
     "builtItems": [
       "Proved max_size_infinite in Erdos501Problem.lean (by_contra + le_iSup₂ + omega)",
       "Proved max_size_infinite in Erdos501ProblemProvable.lean (same proof)",
@@ -63,14 +63,22 @@
       "Product measure proof of Erdos-Hajnal: conflict set C_{ij}={f in [0,L]^n: f(i) in A(f(j))} has measure < L^{n-1} by Fubini section bound. Total < n(n-1)*L^{n-1} < L^n for L > n(n-1), so conflict-free injective tuples exist.",
       "Backward avoidance (x_i not in A_z) cannot be proved by deterministic construction -- requires product measure / counting argument. This is the fundamental difficulty.",
       "Base cases n=0,1 of exists_independent_tuple proved. Combinatorial reduction (tuple to Finset) fully proved.",
-      "BUG (fixed): Provable file had `∀ S ⊆ ℝ uncountable, ∃ f : ℝ → S, Function.Surjective f` as CH. This is trivially True in ZFC: for non-empty S pick s₀ ∈ S and define f(x) := if x ∈ S then x else s₀; every y ∈ S has preimage y. So that def carried no CH content."
+      "BUG (fixed): Provable file had `∀ S ⊆ ℝ uncountable, ∃ f : ℝ → S, Function.Surjective f` as CH. This is trivially True in ZFC: for non-empty S pick s₀ ∈ S and define f(x) := if x ∈ S then x else s₀; every y ∈ S has preimage y. So that def carried no CH content.",
+      "CORRECTION (researcher-7, 2026-06-25): The prior insight that μ(C_ij) < L^{n-1} follows by a Fubini section bound is mathematically UNJUSTIFIED for non-measurable A_y. For Lebesgue outer measure, the inequality lambda*_n(E) <= integral of lambda*_1(E_t) (product <= integral of section outer measures) is the FALSE direction. Counterexample: under CH a Sierpinski set in [0,L]^2 has every vertical section countable (null) yet full planar outer measure L^2. So all-sections-small does NOT bound the product outer measure. The valid outer-measure Fubini direction is the reverse: lambda*_n(E) >= lower-integral of lambda*_1(E_t).",
+      "The naive product-measure/counting proof of exists_independent_tuple FAILS at exactly the non-measurability of the conflict graph {(x,y) : x in A_y}. Measurable-hull repair (replace A_t by a G-delta hull H_t containing A_t cap [0,L] with lambda(H_t)=lambda*(A_t cap [0,L])<1) only works if t -> H_t can be chosen JOINTLY measurable, which is not automatic for an arbitrary family. This joint-measurability gap is the true crux.",
+      "DEEP CONNECTION: the same Sierpinski/non-measurability phenomenon that breaks the naive finite proof is what powers Hechlers CH construction of a family with no infinite independent set. The finite result (ZFC theorem, Erdos-Hajnal 1960) must therefore avoid the product-outer-measure route entirely; its genuine proof is more delicate than the section-bound sketch suggests.",
+      "STALE-RECORD FIX: Erdos501Aristotle.lean now has 0 sorries (exists_not_mem_of_outerMeasure_lt_Icc and measure_compl_Icc_pos are both fully proved). Earlier insights listing them as sorried are outdated. The only remaining sorries are the 3 in Erdos501Problem.lean: exists_independent_tuple (n>=2), hechler_under_CH, nps_closed_infinite.",
+      "n=2 case is already non-trivial for the same reason: finding x!=y with x not in A(y) AND y not in A(x) cannot be done by the symmetric set G={(x,y):x not in A(y)}; inclusion-exclusion lower bounds for lambda*(G cap G^T) are invalid for outer measures, and lambda*(G^c) (sections <1) can be as large as L^2 (Sierpinski). No elementary n=2 shortcut bypasses the joint-measurability obstruction."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Mathlib lacks (and it is genuinely direction-sensitive) an outer-measure Tonelli inequality usable here. The needed direction lambda*_n(E) <= integral of section-outer-measures is FALSE in general; only the reverse holds. Any formal proof of exists_independent_tuple must instead establish joint measurability of a hull family t->H_t and apply standard (measurable) Fubini. Mathlib has measurable Fubini (lintegral_prod) but not the hull-selection joint-measurability lemma.",
+      "No Mathlib infrastructure for Hechler-style transfinite (CH / omega_1) diagonalization constructions of real families, nor for the NPS descriptive-set-theory argument (closed multifunctions / measurable selection on closed families)."
+    ],
     "nextSteps": [
-      "Prove exists_independent_tuple for n>=2: requires outer-measure Tonelli/Cavalieri inequality on product spaces",
-      "Consider proof via measurable cover + Mathlib Fubini, then transfer back to outer measure",
-      "Hechler 1972 (under CH) and NPS 1987 (closed sets) require independent deep formalization efforts (transfinite induction / descriptive set theory)",
-      "Consider unifying main file and Provable file — both now use the same CH def, so structural duplication is closer to elimination"
+      "exists_independent_tuple (n>=2): do NOT retry the product-outer-measure section bound, it is provably the wrong direction. Either (a) formalize joint measurability of a measurable-hull family t->H_t then apply measurable Fubini, or (b) find the actual Erdos-Hajnal 1960 argument (original Acta paper Some Remarks on Set Theory VIII) which sidesteps this.",
+      "Submit exists_independent_tuple to Aristotle for overnight search once the MCP endpoint is reachable again (returned Resource not found this session).",
+      "hechler_under_CH and nps_closed_infinite remain BLOCKED on >1000-line foundational developments (transfinite construction; descriptive set theory). Keep sorried; do not attempt manual proof.",
+      "Consider whether the gallery entry should narrow its verified claims: companion lemmas are fully proved; the three deep results are honestly sorried."
     ]
   },
   "tags": [
@@ -92,7 +100,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T20:57:10.257Z",
-  "lastUpdate": "2026-04-27T00:00:00Z",
+  "lastUpdate": "2026-06-25T00:00:00Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Iteration 3 (ORIENT phase) on **Erdős #501** (independent sets for bounded outer-measure families). This is a **documentation/obstruction-analysis** PR — no Lean semantics change, sorry count unchanged (3 in `Erdos501Problem.lean`).

The session established a substantive correction to the proof strategy that all prior iterations (and `state.md` "Lever A") recommended for the most tractable sorry, `exists_independent_tuple` (Erdős–Hajnal 1960, finite independence).

## Key finding

The prior plan bounds the conflict set `C_ij = {f ∈ [0,L]ⁿ : f(i) ∈ A(f(j))}` by `μ(C_ij) ≤ L^{n-1}` via a "Fubini section bound" (each section `A(t)∩[0,L]` has outer measure `< 1`), and proposes a Mathlib helper `OuterMeasure.le_prod_outer`.

**That helper is mathematically false.** For Lebesgue *outer* measure,
- `λ*_n(E) ≤ ∫ λ*_1(E_t)` (product ≤ integral of section outer measures) is the **wrong direction**;
- only `λ*_n(E) ≥ ∫_* λ*_1(E_t)` holds.

**Counterexample:** under CH a Sierpiński set in `[0,L]²` has every vertical section countable (null) yet full planar outer measure `L²`. So "all sections have outer measure `< 1`" does **not** bound `μ(C_ij)`, which can be `Lⁿ`. The union bound collapses.

The same non-measurability phenomenon is precisely what makes the *infinite* case CH-dependent (Hechler 1972), so this is not an accident of the sketch. The finite result remains a ZFC theorem, but a correct proof must pass to **measurable hulls** `H_t ⊇ A_t∩[0,L]` and apply *measurable* Fubini — leaving **joint measurability of `t ↦ H_t`** as the genuine crux (not an outer-measure sub-Fubini inequality). `n = 2` is already non-trivial for the same reason.

## Changes
- `proofs/Proofs/Erdos501Problem.lean` — ⚠️ caution note in the `exists_independent_tuple` docstring (comment only; build-neutral).
- `research/problems/erdos-501-incomplete-01/state.md` — Iteration-3 block correcting Lever A; flags the false helper.
- `src/data/research/problems/erdos-501-incomplete-01.json` — corrected insights, real `mathlibGaps`, revised `nextSteps`, sharpened `progressSummary`; phase ORIENT.
- `research/knowledge/technique-index.json` — records the obstruction analysis (`blocked`).

## Stale-record fix
`Erdos501Aristotle.lean` now has **0 sorries** (`exists_not_mem_of_outerMeasure_lt_Icc`, `measure_compl_Icc_pos` both fully proved); prior records listing 1 sorry there are outdated. Only the 3 sorries in `Erdos501Problem.lean` remain.

## Notes
Aristotle async submission of `exists_independent_tuple` was attempted (legitimate known theorem) but the MCP endpoint returned "Resource not found"; flagged in `nextSteps` to retry when reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)