### PR TITLE
Enrich Stars and Bars (weak compositions): annotations + structured conclusion

### DIFF
--- a/src/data/proofs/stars-and-bars-weak-compositions/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions/annotations.json
@@ -1,35 +1,62 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions",
+    "range": { "startLine": 4, "endLine": 39 },
+    "type": "context",
+    "title": "The bijective idea and the Mathlib gap",
+    "content": "The header states the theorem and the strategy. A weak composition f : Fin k → ℕ summing to n carries exactly the same information as a size-n multiset over the k indices — the multiset containing index i with multiplicity f(i) — so the two are in bijection with Sym (Fin k) n. Mathlib already proves the multiset form of stars and bars (Sym.card_sym_eq_choose) but never records the equivalent, more familiar tuple/function form C(n+k−1, n); supplying that form and the bijection that bridges to it is the original content of this entry. The 'stars and bars' mnemonic — n stars split into k groups by k−1 bars, choosing n of n+(k−1) positions — names the count.",
+    "mathContext": "$\\#\\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum_i f(i) = n\\} = \\binom{n+k-1}{n}$; the count of nonnegative solutions of $x_1+\\cdots+x_k = n$.",
+    "significance": "context",
+    "relatedConcepts": ["stars and bars", "weak composition", "multichoose", "symmetric power Sym"],
+    "prerequisites": ["binomial coefficients", "multisets"]
+  },
+  {
     "id": "ann-multiset-of-a-weak-composition",
     "proofId": "stars-and-bars-weak-compositions",
-    "range": {
-      "startLine": 49,
-      "endLine": 65
-    },
+    "range": { "startLine": 47, "endLine": 65 },
     "type": "definition",
     "title": "The Multiset Attached to a Weak Composition (toMultiset, count_toMultiset, card_toMultiset)",
-    "content": "toMultiset f = ∑ i, Multiset.replicate (f i) i packages a weak composition f : Fin k → ℕ as the multiset over the index set Fin k in which index i appears with multiplicity f(i). This is the concrete realisation of the slogan 'a weak composition is a multiset of indices'. Two bookkeeping lemmas pin the construction down. count_toMultiset proves Multiset.count j (toMultiset f) = f j: Multiset.count_sum' distributes the count over the Finset sum, Multiset.count_replicate turns each summand into the indicator (if i = j then f i else 0), and Fintype.sum_ite_eq' collapses the sum over Fin k to the single surviving term f j. card_toMultiset proves Multiset.card (toMultiset f) = ∑ i, f i: Multiset.card_sum distributes the cardinality over the Finset sum and Multiset.card_replicate evaluates card (replicate (f i) i) = f i. Together these are the two facts that make toMultiset both injective-recoverable and size-correct."
+    "content": "toMultiset f = ∑ i, Multiset.replicate (f i) i packages a weak composition f : Fin k → ℕ as the multiset over the index set Fin k in which index i appears with multiplicity f(i). This is the concrete realisation of the slogan 'a weak composition is a multiset of indices'. Two bookkeeping lemmas pin the construction down. count_toMultiset proves Multiset.count j (toMultiset f) = f j: Multiset.count_sum' distributes the count over the Finset sum, Multiset.count_replicate turns each summand into the indicator (if i = j then f i else 0), and Fintype.sum_ite_eq' collapses the sum over Fin k to the single surviving term f j. card_toMultiset proves Multiset.card (toMultiset f) = ∑ i, f i: Multiset.card_sum distributes the cardinality over the Finset sum and Multiset.card_replicate evaluates card (replicate (f i) i) = f i. Together these are the two facts that make toMultiset both injective-recoverable and size-correct.",
+    "mathContext": "$\\mathrm{toMultiset}\\,f = \\sum_i \\mathrm{replicate}\\,(f(i))\\,i$, with $\\mathrm{count}_j = f(j)$ and $\\#(\\mathrm{toMultiset}\\,f) = \\sum_i f(i)$.",
+    "significance": "key",
+    "relatedConcepts": ["multiset multiplicity", "Multiset.replicate", "indicator collapse", "Fintype.sum_ite_eq'"],
+    "prerequisites": ["Multiset.count / replicate calculus", "finite sums over Fin k"]
   },
   {
     "id": "ann-the-bijection",
     "proofId": "stars-and-bars-weak-compositions",
-    "range": {
-      "startLine": 67,
-      "endLine": 97
-    },
-    "type": "theorem",
-    "title": "The Bijection to Size-n Multisets (weakCompositionEquivSym, instFintypeWeakComposition)",
-    "content": "weakCompositionEquivSym k n is the explicit equivalence {f : Fin k → ℕ // ∑ i, f i = n} ≃ Sym (Fin k) n. The forward map sends f to toMultiset f, which lands in Sym (Fin k) n because card_toMultiset gives card (toMultiset f) = ∑ i, f i = n. The inverse sends a multiset s to the multiplicity function i ↦ Multiset.count i s, whose values sum to n because Multiset.sum_count_eq_card gives ∑ i, count i s = card s = n over the Fintype index Fin k. left_inv is count_toMultiset applied pointwise (count j (toMultiset f) = f j). right_inv is the identity ∑ i, replicate (count i s) i = s: rewrite each replicate (count i s) i as count i s • {i} (Multiset.nsmul_singleton), shrink the sum over all of Fin k to the sum over the support s.toFinset — the dropped indices have count 0, so their terms vanish (Finset.sum_subset with Multiset.count_eq_zero_of_notMem) — and close with Multiset.toFinset_sum_count_nsmul_eq, the standard fact that a multiset is the support-sum of count-many copies of each element. The companion instance instFintypeWeakComposition builds Fintype {f : Fin k → ℕ // ∑ i, f i = n} by Fintype.ofEquiv through this bijection; the instance is genuinely needed because Lean cannot synthesise a Fintype for a subtype of Fin k → ℕ directly (the codomain ℕ is infinite), even though the summing subtype is finite."
+    "range": { "startLine": 65, "endLine": 90 },
+    "type": "technique",
+    "title": "The Bijection to Size-n Multisets (weakCompositionEquivSym)",
+    "content": "weakCompositionEquivSym k n is the explicit equivalence {f : Fin k → ℕ // ∑ i, f i = n} ≃ Sym (Fin k) n. The forward map sends f to toMultiset f, which lands in Sym (Fin k) n because card_toMultiset gives card (toMultiset f) = ∑ i, f i = n. The inverse sends a multiset s to the multiplicity function i ↦ Multiset.count i s, whose values sum to n because Multiset.sum_count_eq_card gives ∑ i, count i s = card s = n over the Fintype index Fin k. left_inv is count_toMultiset applied pointwise (count j (toMultiset f) = f j). right_inv is the identity ∑ i, replicate (count i s) i = s: rewrite each replicate (count i s) i as count i s • {i} (Multiset.nsmul_singleton), shrink the sum over all of Fin k to the sum over the support s.toFinset — the dropped indices have count 0, so their terms vanish (Finset.sum_subset with Multiset.count_eq_zero_of_notMem) — and close with Multiset.toFinset_sum_count_nsmul_eq, the standard fact that a multiset is the support-sum of count-many copies of each element.",
+    "mathContext": "$\\mathrm{weakCompositionEquivSym} : \\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum_i f(i)=n\\} \\simeq \\mathrm{Sym}\\,(\\mathrm{Fin}\\,k)\\,n$.",
+    "significance": "key",
+    "relatedConcepts": ["explicit equivalence", "mutual inverses", "support sum", "toFinset_sum_count_nsmul_eq"],
+    "prerequisites": ["Equiv construction (toFun/invFun/left_inv/right_inv)", "Sym α n", "count_toMultiset"]
+  },
+  {
+    "id": "ann-fintype-instance",
+    "proofId": "stars-and-bars-weak-compositions",
+    "range": { "startLine": 91, "endLine": 95 },
+    "type": "technique",
+    "title": "The Fintype instance transported across the bijection",
+    "content": "instFintypeWeakComposition builds Fintype {f : Fin k → ℕ // ∑ i, f i = n} by Fintype.ofEquiv through weakCompositionEquivSym (Sym (Fin k) n is finite). This instance is genuinely necessary, not bookkeeping: Lean cannot synthesise a Fintype for a subtype of Fin k → ℕ directly because the codomain ℕ is infinite, even though the summing subtype is in fact finite. Establishing finiteness via the bijection is what makes the subsequent Fintype.card statement well-posed.",
+    "mathContext": "$\\mathrm{Fintype}\\,\\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum_i f(i)=n\\}$ via $\\mathrm{Fintype.ofEquiv}\\,(\\mathrm{Sym}\\,(\\mathrm{Fin}\\,k)\\,n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fintype.ofEquiv", "finiteness from a bijection", "infinite codomain subtype"],
+    "prerequisites": ["typeclass instance synthesis", "weakCompositionEquivSym"]
   },
   {
     "id": "ann-the-count",
     "proofId": "stars-and-bars-weak-compositions",
-    "range": {
-      "startLine": 99,
-      "endLine": 104
-    },
-    "type": "theorem",
+    "range": { "startLine": 97, "endLine": 104 },
+    "type": "insight",
     "title": "The Count C(n+k−1, n) (card_weakComposition)",
-    "content": "card_weakComposition k n is the headline stars-and-bars count: Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} = (n + k − 1).choose n. Fintype.card_congr transports the cardinality along weakCompositionEquivSym to card (Sym (Fin k) n), Sym.card_sym_eq_choose evaluates this to (card (Fin k) + n − 1).choose n, and a final simp with Fintype.card_fin and Nat.add_comm rewrites card (Fin k) = k and reorders the addition to the stated (n + k − 1).choose n. This is the function/tuple form of stars and bars that Mathlib leaves unstated — Mathlib records only the multiset form Sym.card_sym_eq_choose."
+    "content": "card_weakComposition k n is the headline stars-and-bars count: Fintype.card {f : Fin k → ℕ // ∑ i, f i = n} = (n + k − 1).choose n. Fintype.card_congr transports the cardinality along weakCompositionEquivSym to card (Sym (Fin k) n), Sym.card_sym_eq_choose evaluates this to (card (Fin k) + n − 1).choose n, and a final simp with Fintype.card_fin and Nat.add_comm rewrites card (Fin k) = k and reorders the addition to the stated (n + k − 1).choose n. This is the function/tuple form of stars and bars that Mathlib leaves unstated — Mathlib records only the multiset form Sym.card_sym_eq_choose.",
+    "mathContext": "$\\mathrm{Fintype.card}\\,\\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum_i f(i)=n\\} = \\binom{n+k-1}{n}$.",
+    "significance": "key",
+    "relatedConcepts": ["Fintype.card_congr", "Sym.card_sym_eq_choose", "cardinality transport", "binomial coefficient"],
+    "prerequisites": ["the bijection weakCompositionEquivSym", "Sym.card_sym_eq_choose"]
   }
 ]

--- a/src/data/proofs/stars-and-bars-weak-compositions/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions/meta.json
@@ -100,7 +100,15 @@
       "summary": "card_weakComposition is the headline result. Fintype.card_congr transports the cardinality along weakCompositionEquivSym to card (Sym (Fin k) n), which Sym.card_sym_eq_choose evaluates to C(card (Fin k) + n − 1, n); with Fintype.card_fin and commutativity of addition this is C(n + k − 1, n)."
     }
   ],
-  "conclusion": "The function/tuple form of stars and bars — weak compositions of n into k parts number C(n + k − 1, n) — is formalised sorry-free and axiom-free. The mathematical content beyond Mathlib is the explicit bijection weakCompositionEquivSym between the summing subtype {f : Fin k → ℕ // ∑ i, f i = n} and the symmetric power Sym (Fin k) n, identifying a weak composition with the multiset of its indices counted with multiplicity. Mathlib records only the multiset form Sym.card_sym_eq_choose; this entry supplies the equivalent and more familiar tuple count, together with the Fintype instance on the summing subtype that the bijection makes available. It is the weak (empty-parts-allowed) sibling of the positive-parts composition count C(n−1, k−1).",
+  "conclusion": {
+    "summary": "The function/tuple form of stars and bars — weak compositions of n into k parts number C(n + k − 1, n) — is formalised sorry-free and axiom-free. The mathematical content beyond Mathlib is the explicit bijection weakCompositionEquivSym between the summing subtype {f : Fin k → ℕ // ∑ i, f i = n} and the symmetric power Sym (Fin k) n, identifying a weak composition with the multiset of its indices counted with multiplicity. Mathlib records only the multiset form Sym.card_sym_eq_choose; this entry supplies the equivalent and more familiar tuple count, together with the Fintype instance on the summing subtype that the bijection makes available. It is the weak (empty-parts-allowed) sibling of the positive-parts composition count C(n−1, k−1).",
+    "implications": "Because the result is delivered as an explicit Equiv (not merely a cardinality equation), it is reusable: any downstream count phrased as 'ℕ-valued tuples on k indices summing to n' can now be rewritten as a multiset count over Fin k, and the Fintype instance on the summing subtype unlocks Finset.sum / Fintype.card reasoning over weak compositions elsewhere. The bijective, axiom-free style also makes the entry a candidate for upstreaming the tuple form to Mathlib, which currently stops at Sym.card_sym_eq_choose.",
+    "openQuestions": [
+      "Formalize the generating-function view: ∑ₙ (#weak compositions of n into k parts) xⁿ = 1/(1−x)ᵏ, recovering C(n+k−1,n) as the coefficient and connecting to the negative-binomial series.",
+      "Prove the bounded-parts refinement — weak compositions of n into k parts each at most m — counted by inclusion–exclusion ∑ⱼ (−1)ʲ C(k,j) C(n−j(m+1)+k−1, k−1), of which the unbounded count here is the m→∞ case.",
+      "Establish the symmetry/duality with the positive-parts count C(n−1,k−1) as an explicit bijection (add 1 to each part), unifying the two stars-and-bars variants formalized across the sibling entries."
+    ]
+  },
   "crossReferences": [
     "composition-parts-choose-oq-01",
     "composition-card-2pow-oq-01"


### PR DESCRIPTION
## Enrichment: `stars-and-bars-weak-compositions`

Quality 39, 0 passes. This entry had an excellent `meta.json` overview but two concrete gaps:

### annotations.json — 3 → 5, all fields added
- The existing 3 annotations were detailed in `content` but carried **no** `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. Added all four to each.
- Added a **header** annotation (the bijective idea + the Mathlib gap) and a dedicated annotation for the **`Fintype` instance** — necessary precisely because Lean cannot synthesize `Fintype` on a subtype of `Fin k → ℕ` (infinite codomain), so finiteness is imported through the bijection.
- Tightened the existing line ranges to anchor on their constructs.

### meta.json — `conclusion` string → object
The `conclusion` was a bare string. Upgraded to `{summary, implications, openQuestions}`:
- `implications`: the result is an explicit `Equiv`, hence reusable, and a Mathlib-upstreaming candidate.
- 3 `openQuestions`: generating-function view (1/(1−x)ᵏ); bounded-parts inclusion–exclusion refinement; explicit duality bijection with the positive-parts count C(n−1,k−1).

### Verification
Both JSON files parse cleanly; all 5 annotations carry `mathContext`/`significance`/`relatedConcepts`; cross-reference targets (`composition-parts-choose-oq-01`, `composition-card-2pow-oq-01`) exist. `axiomCount: 0` / `status: verified` confirmed accurate (no `native_decide`, `#print axioms` clean per the entry's own assumptions field).