### PR TITLE
Enrich Hilbert's 3rd Problem: Tensor-Product Dehn Invariant Group

### DIFF
--- a/src/data/proofs/hilbert-3-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-3-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "hilbert-3-oq-02",
+    "range": { "startLine": 7, "endLine": 50 },
+    "type": "context",
+    "title": "Scope: the honest tensor-product Dehn group, not Sydler",
+    "content": "The header frames the entry against the parent's open question OQ-02. The parent modelled the Dehn invariant with a crude list-of-pairs surrogate and left the structural lemmas as ':= trivial'. This file replaces that with the genuine target group D = ℝ ⊗_ℤ (ℝ/πℚ) built from Mathlib's TensorProduct, and proves the two facts that carry Dehn's obstruction — rational angles vanish, and supplementary angles cancel. It is explicit and honest that the full Sydler completeness theorem (which needs transcendence theory and a hard surjectivity direction) is out of scope and NOT claimed.",
+    "mathContext": "Dehn invariant lives in $D = \\mathbb{R} \\otimes_{\\mathbb{Z}} (\\mathbb{R}/\\pi\\mathbb{Q})$, summing $\\text{length} \\otimes \\text{(dihedral angle)}$ over edges.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's Third Problem", "Dehn invariant", "scissors congruence", "Sydler's theorem"],
+    "prerequisites": ["tensor products of abelian groups", "quotient groups"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "hilbert-3-oq-02",
+    "range": { "startLine": 52, "endLine": 87 },
+    "type": "definition",
+    "title": "Building the Dehn target group D = ℝ ⊗_ℤ (ℝ/πℚ)",
+    "content": "The construction proceeds in layers. piRatHom : ℚ →+ ℝ, q ↦ q·π, has range piRat = πℚ, the subgroup of rational multiples of π. The angle group is the quotient AngleGroup = ℝ ⧸ πℚ, in which dihedral angles are measured mod rational multiples of π. The Dehn group is the genuine tensor product DehnGroup = ℝ ⊗[ℤ] AngleGroup. angleClass θ is the quotient map (taken as QuotientAddGroup.mk' so it inherits map_add), a single edge contributes dehnTerm l θ = l ⊗ₜ angleClass θ, and the whole polyhedron's invariant is dehnSum, the Finset.sum of edge terms. This is the structure Sydler's theorem is actually a statement about.",
+    "mathContext": "$A = \\mathbb{R}/\\pi\\mathbb{Q}$, $D = \\mathbb{R}\\otimes_{\\mathbb{Z}} A$, $\\mathrm{dehnTerm}\\,l\\,\\theta = l \\otimes_t [\\theta]$.",
+    "significance": "key",
+    "relatedConcepts": ["quotient by a subgroup", "range of a homomorphism", "simple tensor", "QuotientAddGroup.mk'"],
+    "prerequisites": ["AddSubgroup.range", "TensorProduct over ℤ"]
+  },
+  {
+    "id": "ann-angle-group",
+    "proofId": "hilbert-3-oq-02",
+    "range": { "startLine": 89, "endLine": 106 },
+    "type": "technique",
+    "title": "Rational multiples of π vanish in the angle group",
+    "content": "The quotient computations that make rational dihedral angles trivial. angleClass_eq_zero_of_ratPi proves q·π is 0 in ℝ/πℚ: by QuotientAddGroup.eq_zero_iff this reduces to membership of q·π in piRatHom.range, witnessed by q. angleClass_pi is the special case π = 1·π. angleClass_add records additivity of the class map (inherited from map_add of the quotient homomorphism), needed for the supplementary-angle identity.",
+    "mathContext": "$[q\\pi] = 0$ in $\\mathbb{R}/\\pi\\mathbb{Q}$ via $\\mathrm{eq\\_zero\\_iff}$ and $q\\pi \\in \\mathrm{range}(\\mathrm{piRatHom})$; $[\\theta_1+\\theta_2] = [\\theta_1]+[\\theta_2]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["QuotientAddGroup.eq_zero_iff", "membership in a range", "additive quotient map"],
+    "prerequisites": ["quotient group arithmetic"]
+  },
+  {
+    "id": "ann-dehn-term",
+    "proofId": "hilbert-3-oq-02",
+    "range": { "startLine": 108, "endLine": 140 },
+    "type": "insight",
+    "title": "The two key facts: rational-angle vanishing and supplementary cancellation",
+    "content": "The algebraic heart of the entry. dehnTerm_eq_zero_of_ratPi: a length at a rational-multiple-of-π angle contributes 0, because the angle class is 0 and TensorProduct.tmul_zero finishes — this is the mechanism behind D(cube)=0. Additivity in length (add_tmul) and angle (tmul_add) give the Dehn term its bilinear structure. dehnTerm_supplementary: l ⊗ θ + l ⊗ (π−θ) = 0, proved by combining the two terms with tmul_add into l ⊗ (θ+(π−θ)) = l ⊗ π and then angleClass_pi + tmul_zero. This single identity is exactly why a planar cut (which replaces a dihedral angle θ by θ and π−θ on the two new pieces) preserves the Dehn invariant — the statement the parent could only assert as ':= trivial'.",
+    "mathContext": "$l \\otimes (q\\pi) = 0$; and $l\\otimes\\theta + l\\otimes(\\pi-\\theta) = l\\otimes\\pi = 0$ since $\\theta+(\\pi-\\theta)=\\pi\\equiv0$.",
+    "significance": "key",
+    "relatedConcepts": ["bilinearity", "tmul_zero", "tmul_add", "cutting invariance"],
+    "prerequisites": ["TensorProduct bilinearity lemmas", "angleClass_pi"]
+  },
+  {
+    "id": "ann-polyhedron",
+    "proofId": "hilbert-3-oq-02",
+    "range": { "startLine": 142, "endLine": 165 },
+    "type": "concept",
+    "title": "Whole-polyhedron consequences: the cube is Dehn-trivial",
+    "content": "The single-edge facts lift to entire polyhedra. dehnSum_eq_zero_of_ratPi: if every dihedral angle is a rational multiple of π, the whole Dehn invariant vanishes, by Finset.sum_eq_zero applied to dehnTerm_eq_zero_of_ratPi edge-by-edge. cube_dehnSum_zero specializes to all angles π/2 = (1/2)·π, recovering Dehn's original computation that the cube has Dehn invariant 0 — now inside the genuine real tensor-product group rather than the parent's surrogate. (The contrast — the regular tetrahedron's NONvanishing, which needs Niven's transcendence theorem — is left as an open question.)",
+    "mathContext": "All angles $\\in \\pi\\mathbb{Q} \\Rightarrow \\mathrm{dehnSum} = 0$; cube: every angle $= \\tfrac12\\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_eq_zero", "cube vs tetrahedron", "Bolyai–Gerwien (rational-angle world)", "Niven's theorem"],
+    "prerequisites": ["finite sums vanishing termwise", "dehnTerm_eq_zero_of_ratPi"]
+  }
+]


### PR DESCRIPTION
## Enrichment: `hilbert-3-oq-02`

Quality 45, 0 passes. The `meta.json` was already complete (overview with `problemStatement`/`proofStrategy`/`keyInsights`, structured `conclusion`, `mainTheorems`, `sections`, `references`); the sole gap was the **missing `annotations.json`**.

### annotations.json (new) — 5 annotations
Covers the whole file:
- **Honest scope** — the genuine ℝ ⊗_ℤ (ℝ/πℚ) group replacing the parent's list surrogate; full Sydler explicitly out of scope.
- **The construction** — `piRatHom`/`piRat` → `AngleGroup = ℝ⧸πℚ` → `DehnGroup = ℝ ⊗[ℤ] A`, `angleClass`, `dehnTerm`, `dehnSum`.
- **Angle-group vanishing** — q·π = 0 via `QuotientAddGroup.eq_zero_iff`.
- **The two key facts** — rational-angle vanishing (`tmul_zero`) and supplementary cancellation `l⊗θ + l⊗(π−θ)=0` (the cutting-invariance core the parent left as `:= trivial`).
- **Whole-polyhedron** — the cube is Dehn-trivial via `Finset.sum_eq_zero`.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

### Axiom integrity
`axiomCount: 0` / `status: verified` / `badge: original` confirmed accurate (Mathlib-only, 0 sorries, `#print axioms` clean per the assumptions field). Scope is honestly bounded — Sydler completeness and the tetrahedron's nonvanishing remain listed as open questions, not claimed.

### Verification
`annotations.json` parses cleanly; all 5 annotations carry the four enrichment fields; cross-reference target `hilbert-3` exists.