### PR TITLE
research(factorial-telescoping-sum-oq-01): ∑ k·k! = (n+1)!−1 [verified, 5 thm, 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/FactorialTelescopingSumOQ01.lean
+++ b/proofs/Proofs/FactorialTelescopingSumOQ01.lean
@@ -24,9 +24,11 @@
     term vanishes, so the `range (n+1)` and `Icc 1 n` sums agree).
 -/
 
-import Mathlib
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
 
-open Finset
+open Finset Nat
 
 namespace FactorialTelescopingSum
 
@@ -41,12 +43,12 @@ theorem sum_mul_factorial_add_one (n : ℕ) :
   induction n with
   | zero => simp
   | succ n ih =>
-      rw [Finset.sum_range_succ]
-      -- Regroup so the inductive hypothesis `(∑) + 1 = (n+1)!` applies.
-      have key : (∑ k ∈ range (n + 1), k * k !) + (n + 1) * (n + 1)! + 1
-          = ((∑ k ∈ range (n + 1), k * k !) + 1) + (n + 1) * (n + 1)! := by ring
-      rw [key, ih, Nat.factorial_succ (n + 1)]
-      ring
+      rw [Finset.sum_range_succ, Nat.factorial_succ (n + 1)]
+      -- Expand `(n+2)·(n+1)!` so the goal becomes linear in the atoms
+      -- `∑`, `(n+1)!`, and `(n+1)·(n+1)!`; then `omega` closes it using `ih`.
+      have hexp : (n + 1 + 1) * (n + 1)! = (n + 1)! + (n + 1) * (n + 1)! := by ring
+      rw [hexp]
+      omega
 
 /-- **Headline identity (ℕ-subtraction form).**  `∑_{k=0}^{n} k·k! = (n+1)! − 1`.
 
@@ -75,8 +77,7 @@ theorem sum_Icc_mul_factorial (n : ℕ) :
 
 /-- Pointwise telescoping identity behind the proof: `k·k! = (k+1)! − k!`. -/
 theorem mul_factorial_eq (k : ℕ) : k * k ! = (k + 1)! - k ! := by
-  rw [Nat.factorial_succ]
-  have : k ! ≤ (k + 1) * k ! := Nat.le_mul_of_pos_left _ (by omega)
+  rw [Nat.factorial_succ, add_one_mul]
   omega
 
 -- Sanity checks (small concrete values).

--- a/proofs/Proofs/FactorialTelescopingSumOQ01.lean
+++ b/proofs/Proofs/FactorialTelescopingSumOQ01.lean
@@ -1,0 +1,86 @@
+/-
+  Factorial Telescoping Sum:  ∑_{k=1}^{n} k · k! = (n+1)! − 1
+
+  Source / context: classical factorial identity (Gauss-style telescoping).
+  Status: VERIFIED (0 sorries, 0 axioms, no native_decide).
+
+  Statement:
+    For every natural number n,
+        ∑_{k=1}^{n} k · k!  =  (n+1)! − 1.
+
+  The Key Insight (telescoping):
+    Each summand collapses a factorial difference,
+        k · k!  =  (k+1)! − k!,
+    so the sum telescopes:
+        ∑_{k=1}^{n} k · k!  =  ∑_{k=1}^{n} ((k+1)! − k!)  =  (n+1)! − 1! = (n+1)! − 1.
+
+  Lean strategy:
+    Over ℕ, truncated subtraction makes the telescoped form awkward to manipulate,
+    so the engine is the *additive* (subtraction-free) reformulation
+        (∑_{k=0}^{n} k · k!) + 1 = (n+1)!,
+    proved by a one-line induction (`Finset.sum_range_succ` + `Nat.factorial_succ`).
+    The headline subtraction form and the literal `∑_{k=1}^{n}` (over `Finset.Icc 1 n`)
+    are then derived from it (`omega` discharges the ℕ-subtraction step; the `k = 0`
+    term vanishes, so the `range (n+1)` and `Icc 1 n` sums agree).
+-/
+
+import Mathlib
+
+open Finset
+
+namespace FactorialTelescopingSum
+
+/-- **Additive (subtraction-free) form.**  `(∑_{k=0}^{n} k·k!) + 1 = (n+1)!`.
+
+    The `k = 0` term is `0·0! = 0`, so the left sum equals `∑_{k=1}^{n} k·k!`.
+    This is the genuine content of the identity: it is proved directly by induction,
+    using the telescoping step `(n+1)·(n+1)! + (n+1)! = (n+2)!`, and avoids ℕ
+    truncated subtraction entirely. -/
+theorem sum_mul_factorial_add_one (n : ℕ) :
+    (∑ k ∈ range (n + 1), k * k !) + 1 = (n + 1)! := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_range_succ]
+      -- Regroup so the inductive hypothesis `(∑) + 1 = (n+1)!` applies.
+      have key : (∑ k ∈ range (n + 1), k * k !) + (n + 1) * (n + 1)! + 1
+          = ((∑ k ∈ range (n + 1), k * k !) + 1) + (n + 1) * (n + 1)! := by ring
+      rw [key, ih, Nat.factorial_succ (n + 1)]
+      ring
+
+/-- **Headline identity (ℕ-subtraction form).**  `∑_{k=0}^{n} k·k! = (n+1)! − 1`.
+
+    Since the `k = 0` summand vanishes this is exactly `∑_{k=1}^{n} k·k! = (n+1)! − 1`.
+    Derived from `sum_mul_factorial_add_one`; `omega` handles the truncated subtraction
+    (valid because `(n+1)! ≥ 1`). -/
+theorem sum_mul_factorial (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * k ! = (n + 1)! - 1 := by
+  have h := sum_mul_factorial_add_one n
+  omega
+
+/-- The `range (n+1)` sum equals the literal `∑_{k=1}^{n}` over `Finset.Icc 1 n`:
+    the only extra index is `k = 0`, whose summand `0·0!` is zero. -/
+theorem sum_Icc_eq_sum_range (n : ℕ) :
+    ∑ k ∈ Finset.Icc 1 n, k * k ! = ∑ k ∈ range (n + 1), k * k ! := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ n + 1), Finset.sum_range_succ, ih]
+
+/-- **Literal `∑_{k=1}^{n}` form.**  `∑_{k=1}^{n} k·k! = (n+1)! − 1`,
+    stated over `Finset.Icc 1 n` to match the usual lower limit `k = 1`. -/
+theorem sum_Icc_mul_factorial (n : ℕ) :
+    ∑ k ∈ Finset.Icc 1 n, k * k ! = (n + 1)! - 1 := by
+  rw [sum_Icc_eq_sum_range, sum_mul_factorial]
+
+/-- Pointwise telescoping identity behind the proof: `k·k! = (k+1)! − k!`. -/
+theorem mul_factorial_eq (k : ℕ) : k * k ! = (k + 1)! - k ! := by
+  rw [Nat.factorial_succ]
+  have : k ! ≤ (k + 1) * k ! := Nat.le_mul_of_pos_left _ (by omega)
+  omega
+
+-- Sanity checks (small concrete values).
+example : ∑ k ∈ range 4, k * k ! = 23 := by decide   -- 0+1+4+18 = 23 = 4! − 1
+example : ∑ k ∈ Finset.Icc 1 5, k * k ! = 719 := by decide  -- 6! − 1 = 719
+
+end FactorialTelescopingSum

--- a/src/data/proofs/factorial-telescoping-sum-oq-01/annotations.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-additive-engine",
+    "proofId": "factorial-telescoping-sum-oq-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 51
+    },
+    "type": "insight",
+    "title": "The Subtraction-Free Engine",
+    "content": "sum_mul_factorial_add_one is the genuine content of the identity, stated to dodge ℕ truncated subtraction: (∑_{k=0}^{n} k·k!) + 1 = (n+1)!. The induction is short. Base: 0·0! + 1 = 1 = 1!. Step: Finset.sum_range_succ peels the top term (n+1)·(n+1)!, Nat.factorial_succ expands (n+2)! = (n+2)·(n+1)!, and after rewriting (n+2)·(n+1)! = (n+1)! + (n+1)·(n+1)! the goal is linear in the three atoms ∑, (n+1)!, and (n+1)·(n+1)!, so omega finishes it using the inductive hypothesis. This is the multiplicative-factorial analogue of arithmetic telescoping."
+  },
+  {
+    "id": "ann-headline",
+    "proofId": "factorial-telescoping-sum-oq-01",
+    "range": {
+      "startLine": 53,
+      "endLine": 61
+    },
+    "type": "concept",
+    "title": "The Headline Subtraction Form",
+    "content": "sum_mul_factorial is the identity as usually quoted: ∑_{k=0}^{n} k·k! = (n+1)! − 1 (and since the k=0 term vanishes, this is ∑_{k=1}^{n} k·k!). It is read straight off the engine: from (∑)+1 = (n+1)! with (n+1)! ≥ 1, omega discharges the ℕ truncated subtraction exactly. Proving the additive form first is the standard trick that keeps the subtraction honest."
+  },
+  {
+    "id": "ann-literal-form",
+    "proofId": "factorial-telescoping-sum-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 76
+    },
+    "type": "proof-step",
+    "title": "The Literal ∑_{k=1}^{n} Form",
+    "content": "sum_Icc_eq_sum_range proves that the literal lower-limit-1 sum over Finset.Icc 1 n equals the range (n+1) sum, by an induction whose step matches Finset.sum_Icc_succ_top against Finset.sum_range_succ term by term; the only extra index, k = 0, contributes 0·0! = 0. sum_Icc_mul_factorial then states the identity with the customary lower limit k = 1, showing that limit is purely cosmetic."
+  },
+  {
+    "id": "ann-pointwise",
+    "proofId": "factorial-telescoping-sum-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "Why It Telescopes: k·k! = (k+1)! − k!",
+    "content": "mul_factorial_eq isolates the per-term collapse that makes the whole sum telescope. From the factorial recurrence (k+1)! = (k+1)·k! = k·k! + k! (via add_one_mul), subtracting k! recovers k·k!; omega handles the ℕ subtraction. Summing this identity over k = 1..n gives a difference of consecutive factorials that collapses to (n+1)! − 1! = (n+1)! − 1 — the conceptual one-line proof behind the formal induction."
+  }
+]

--- a/src/data/proofs/factorial-telescoping-sum-oq-01/meta.json
+++ b/src/data/proofs/factorial-telescoping-sum-oq-01/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "factorial-telescoping-sum-oq-01",
+  "slug": "factorial-telescoping-sum-oq-01",
+  "title": "Factorial Telescoping Sum: ∑ k·k! = (n+1)! − 1",
+  "status": "verified",
+  "badge": "original",
+  "description": "The classical factorial telescoping identity ∑_{k=1}^{n} k·k! = (n+1)! − 1, formalized in Lean 4 from primitives. Each summand collapses a factorial difference, k·k! = (k+1)! − k!, so the sum telescopes to (n+1)! − 1! = (n+1)! − 1. Because ℕ has truncated subtraction, the proof engine is the subtraction-free reformulation (∑_{k=0}^{n} k·k!) + 1 = (n+1)!, proved by a short induction (Finset.sum_range_succ + Nat.factorial_succ); the headline subtraction form and the literal lower-limit-1 form over Finset.Icc 1 n are then derived. Fully verified: 5 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The identity ∑_{k=1}^{n} k·k! = (n+1)! − 1 is a staple of introductory combinatorics and a textbook example of telescoping: the per-term identity k·k! = (k+1)! − k! turns the sum into a difference of consecutive factorials that collapses to a single boundary term. It is the multiplicative-factorial analogue of the arithmetic telescoping ∑ (a_{k+1} − a_k) = a_{n+1} − a_1, and underlies the factorial number system (factoradic), where it expresses that the digits 0..k in position k! exactly fill the range up to (n+1)! − 1.",
+    "problemStatement": "Prove, for every natural number n, that ∑_{k=1}^{n} k·k! = (n+1)! − 1, working over ℕ (so that truncated subtraction is handled honestly), and provide both the standard range form and the literal ∑_{k=1}^{n} form over Finset.Icc 1 n.",
+    "proofStrategy": "Avoid ℕ truncated subtraction by proving the additive form (∑_{k=0}^{n} k·k!) + 1 = (n+1)! first, by induction on n. The base case is 0·0! + 1 = 1 = 1!. In the step, Finset.sum_range_succ peels the top term (n+1)·(n+1)!, Nat.factorial_succ expands (n+2)! = (n+2)·(n+1)!, and after regrouping the goal is linear in the atoms ∑, (n+1)!, and (n+1)·(n+1)!, so omega closes it using the inductive hypothesis. The headline ∑_{k=0}^{n} k·k! = (n+1)! − 1 follows by omega (valid since (n+1)! ≥ 1). A separate induction shows the Finset.Icc 1 n sum equals the range (n+1) sum (the only extra index k = 0 contributes 0·0! = 0), giving the literal ∑_{k=1}^{n} form.",
+    "keyInsights": [
+      "The summand telescopes: k·k! = (k+1)! − k!, so ∑_{k=1}^{n} k·k! = (n+1)! − 1! = (n+1)! − 1.",
+      "Over ℕ the clean statement uses truncated subtraction; proving the subtraction-free form (∑)+1 = (n+1)! first makes the induction a one-liner and lets omega discharge the subtraction step.",
+      "The inductive step reduces to a linear fact in three opaque atoms (∑, (n+1)!, (n+1)·(n+1)!) once (n+2)! is expanded, so omega — not nonlinear reasoning — finishes it.",
+      "The lower limit k = 1 is cosmetic: the k = 0 term 0·0! vanishes, so the range (n+1) sum and the Finset.Icc 1 n sum coincide."
+    ],
+    "prerequisites": [
+      "The factorial Nat.factorial and its recurrence (n+1)! = (n+1)·n!",
+      "Finite sums over Finset.range and Finset.Icc, with sum_range_succ and sum_Icc_succ_top",
+      "ℕ truncated subtraction and the omega decision procedure for linear arithmetic over atoms"
+    ]
+  },
+  "sections": [
+    {
+      "id": "additive-engine",
+      "title": "Section I: The Subtraction-Free Engine",
+      "startLine": 35,
+      "endLine": 51,
+      "summary": "sum_mul_factorial_add_one: (∑_{k=0}^{n} k·k!) + 1 = (n+1)!, proved by induction — the genuine content, free of ℕ truncated subtraction.",
+      "mathContext": "Induction with Finset.sum_range_succ and Nat.factorial_succ; the step (n+1)·(n+1)! + (n+1)! = (n+2)! is the telescoping collapse, closed by omega over the atoms after expanding (n+2)!."
+    },
+    {
+      "id": "headline",
+      "title": "Section II: The Headline Subtraction Form",
+      "startLine": 53,
+      "endLine": 61,
+      "summary": "sum_mul_factorial: ∑_{k=0}^{n} k·k! = (n+1)! − 1, the headline identity in ℕ-subtraction form, derived from the additive engine by omega.",
+      "mathContext": "From (∑)+1 = (n+1)! and (n+1)! ≥ 1, the truncated subtraction ∑ = (n+1)! − 1 is exact; omega handles ℕ subtraction directly."
+    },
+    {
+      "id": "literal-form",
+      "title": "Section III: The Literal ∑_{k=1}^{n} Form",
+      "startLine": 63,
+      "endLine": 76,
+      "summary": "sum_Icc_eq_sum_range bridges Finset.Icc 1 n to range (n+1) (the k=0 term vanishes), and sum_Icc_mul_factorial states the identity with the usual lower limit k = 1.",
+      "mathContext": "Induction via Finset.sum_Icc_succ_top matches Finset.sum_range_succ term by term; the extra index 0 contributes 0·0! = 0."
+    },
+    {
+      "id": "pointwise",
+      "title": "Section IV: The Pointwise Telescoping Identity",
+      "startLine": 78,
+      "endLine": 82,
+      "summary": "mul_factorial_eq: k·k! = (k+1)! − k!, the per-term collapse that makes the sum telescope.",
+      "mathContext": "From (k+1)! = (k+1)·k! = k·k! + k!, subtracting k! recovers k·k!; add_one_mul + omega."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 87 lines and 5 theorems establishing the factorial telescoping identity ∑_{k=1}^{n} k·k! = (n+1)! − 1. The subtraction-free additive form (∑)+1 = (n+1)! is the inductive engine; the headline ℕ-subtraction form, the literal ∑_{k=1}^{n} form over Finset.Icc 1 n, and the pointwise collapse k·k! = (k+1)! − k! are derived. #print axioms reports only [propext, Classical.choice, Quot.sound] for the sum theorems.",
+    "implications": "An elementary but cleanly formalized identity: it demonstrates the standard ℕ workaround of proving an additive form before a subtractive one, and provides a reusable telescoping lemma (mul_factorial_eq) and the boundary identity behind the factorial number system. The result is routine in difficulty; its value is a tidy, axiom-free gallery entry rather than a new mathematical contribution.",
+    "openQuestions": [
+      "Generalize the telescoping engine to ∑_{k} (a_{k+1} − a_k) = a_{n+1} − a_1 over a commutative monoid and recover this identity as the factorial instance a_k = k!.",
+      "Formalize the related rising/falling-factorial telescoping sums (e.g. ∑ k·(k+1)! patterns) and the factoradic representation that ∑_{k=1}^{n} k·k! = (n+1)! − 1 underlies."
+    ]
+  },
+  "references": [
+    {
+      "key": "ConcreteMath",
+      "citation": "Graham, R.L., Knuth, D.E., Patashnik, O., Concrete Mathematics, 2nd ed., Addison-Wesley (1994), Ch. 2 (sums and telescoping; factorial identities).",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Algebra.BigOperators.Intervals",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "FactorialTelescopingSum",
+    "lineCount": 87,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/FactorialTelescopingSumOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Factorial_number_system",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorialTelescopingSumOQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "factorial",
+      "telescoping",
+      "induction",
+      "finite-sums",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n! — the factorial recurrence driving the telescoping collapse",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k ∈ range (n+1)} f k = (∑_{k ∈ range n} f k) + f n — peels the top term in the induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "a ≤ b+1 → ∑_{k ∈ Icc a (b+1)} f k = (∑_{k ∈ Icc a b} f k) + f (b+1) — bridges the Icc form to the range form",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      }
+    ],
+    "originalContributions": [
+      "sum_mul_factorial_add_one: the subtraction-free engine (∑_{k=0}^{n} k·k!) + 1 = (n+1)! by induction, the ℕ-clean heart of the proof",
+      "sum_mul_factorial: the headline ∑_{k=0}^{n} k·k! = (n+1)! − 1 in ℕ-subtraction form",
+      "sum_Icc_mul_factorial with sum_Icc_eq_sum_range: the literal ∑_{k=1}^{n} k·k! = (n+1)! − 1 over Finset.Icc 1 n, proving the lower limit k = 1 is cosmetic",
+      "mul_factorial_eq: the reusable pointwise telescoping identity k·k! = (k+1)! − k!"
+    ],
+    "axiomCount": 0,
+    "lineCount": 87,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for sum_mul_factorial_add_one, sum_mul_factorial, and sum_Icc_mul_factorial (mul_factorial_eq uses only [propext, Quot.sound]). The two `example` sanity checks (∑_{k<4} = 23, ∑_{Icc 1 5} = 719) use kernel `decide`, not `native_decide`. Compiled against Mathlib v4.26.0. The identity is elementary/classical; the formalization is built from primitives (sum_range_succ, factorial_succ) rather than wrapping a single named Mathlib lemma.",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "prerequisites": [
+      "The factorial and its recurrence (n+1)! = (n+1)·n!",
+      "Finite sums over Finset.range and Finset.Icc",
+      "ℕ truncated subtraction and omega for linear arithmetic over atoms"
+    ],
+    "relatedProblems": []
+  }
+}

--- a/src/data/research/problems/factorial-telescoping-sum-oq-01.json
+++ b/src/data/research/problems/factorial-telescoping-sum-oq-01.json
@@ -1,0 +1,28 @@
+{
+  "id": "factorial-telescoping-sum-oq-01",
+  "name": "Factorial Telescoping Sum: ∑ k·k! = (n+1)! − 1",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "insights": [
+      "The summand telescopes pointwise: k·k! = (k+1)! − k!, so ∑_{k=1}^{n} k·k! collapses to (n+1)! − 1! = (n+1)! − 1.",
+      "Over ℕ the clean statement uses truncated subtraction; proving the subtraction-free form (∑_{k=0}^{n} k·k!) + 1 = (n+1)! first makes the induction trivial and lets omega discharge the subtraction step exactly (valid since (n+1)! ≥ 1).",
+      "After expanding (n+2)! = (n+2)·(n+1)! and rewriting (n+2)·(n+1)! = (n+1)! + (n+1)·(n+1)!, the inductive step is linear in the three opaque atoms ∑, (n+1)!, (n+1)·(n+1)! — omega closes it; no nonlinear reasoning needed.",
+      "The lower limit k = 1 is cosmetic: the k = 0 term 0·0! = 0, so the Finset.Icc 1 n sum equals the Finset.range (n+1) sum, proved by an induction matching sum_Icc_succ_top against sum_range_succ.",
+      "Mathlib has the factorial recurrence and the Finset sum lemmas but not this specific telescoping identity as a named result; it is built here from primitives."
+    ],
+    "builtItems": [
+      "FactorialTelescopingSum.sum_mul_factorial_add_one (Proofs/FactorialTelescopingSumOQ01.lean:41) — (∑_{k=0}^{n} k·k!) + 1 = (n+1)!, the subtraction-free engine",
+      "FactorialTelescopingSum.sum_mul_factorial (:58) — ∑_{k=0}^{n} k·k! = (n+1)! − 1, headline form",
+      "FactorialTelescopingSum.sum_Icc_eq_sum_range (:65) — bridges Finset.Icc 1 n to Finset.range (n+1)",
+      "FactorialTelescopingSum.sum_Icc_mul_factorial (:74) — ∑_{k=1}^{n} k·k! = (n+1)! − 1, literal lower-limit-1 form",
+      "FactorialTelescopingSum.mul_factorial_eq (:79) — k·k! = (k+1)! − k!, the pointwise telescoping identity"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Generalize the engine to ∑_{k} (a_{k+1} − a_k) = a_{n+1} − a_1 over a commutative monoid and recover this identity as the factorial instance a_k = k!.",
+      "Formalize the factoradic (factorial number system) representation that ∑_{k=1}^{n} k·k! = (n+1)! − 1 underlies, and related rising/falling-factorial telescoping sums."
+    ],
+    "progressSummary": "COMPLETE: ∑_{k=1}^{n} k·k! = (n+1)! − 1 formalized and verified — 5 theorems, 0 sorries, 0 axioms, no native_decide (#print axioms = [propext, Classical.choice, Quot.sound]). Compiled against Mathlib v4.26.0. Elementary/classical identity; routine difficulty. PR opened."
+  }
+}


### PR DESCRIPTION
## Summary

Fresh gallery entry for the open-question candidate **factorial-telescoping-sum-oq-01** (FRESH mode; pool score 0, tractability 8, no prior PR). Formalizes the classical factorial telescoping identity

$$\sum_{k=1}^{n} k\cdot k! = (n+1)! - 1$$

from primitives, **fully verified**: 5 theorems, 0 sorries, 0 axioms, no `native_decide`.

## Approach

ℕ has truncated subtraction, so the engine is the **subtraction-free** form proved by induction:

- `sum_mul_factorial_add_one` : `(∑_{k=0}^{n} k·k!) + 1 = (n+1)!`
  Step uses `Finset.sum_range_succ` + `Nat.factorial_succ`; after expanding `(n+2)! = (n+1)! + (n+1)·(n+1)!` the goal is linear in the atoms `∑`, `(n+1)!`, `(n+1)·(n+1)!`, so `omega` closes it.

Derived results:
- `sum_mul_factorial` : `∑_{k=0}^{n} k·k! = (n+1)! − 1` (headline; `omega` handles the ℕ subtraction).
- `sum_Icc_eq_sum_range` + `sum_Icc_mul_factorial` : the literal `∑_{k=1}^{n}` over `Finset.Icc 1 n` (the `k=0` term `0·0!` vanishes).
- `mul_factorial_eq` : the pointwise telescoping `k·k! = (k+1)! − k!`.

## Verification

- Compiled clean against **Mathlib v4.26.0** (`lake env lean`, exit 0, no errors/warnings).
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for the sum theorems (`mul_factorial_eq`: `[propext, Quot.sound]`). No `sorryAx`, no `Lean.ofReduceBool`.
- Two `example` sanity checks (`∑_{k<4} = 23 = 4!−1`, `∑_{Icc 1 5} = 719 = 6!−1`) via kernel `decide`.

## Honesty note

The identity is **elementary/classical** (routine difficulty); the value here is a tidy, axiom-free gallery entry plus a reusable telescoping lemma — not a new mathematical result. Status `verified`, badge `original` (built from primitives, not wrapping a single named Mathlib lemma).

## Files
- `proofs/Proofs/FactorialTelescopingSumOQ01.lean` (87 lines, 5 theorems)
- `src/data/proofs/factorial-telescoping-sum-oq-01/{meta.json,annotations.json}`
- `src/data/research/problems/factorial-telescoping-sum-oq-01.json` (knowledge, COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)