### PR TITLE
research(erdos-1074): fix PillaiPrimes definition + add Wilson/duality structure

### DIFF
--- a/proofs/Proofs/Erdos1074Problem.lean
+++ b/proofs/Proofs/Erdos1074Problem.lean
@@ -26,6 +26,8 @@ import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.Nat.ModEq
 import Mathlib.Data.Set.Basic
 import Mathlib.Data.Set.Finite.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.NumberTheory.Wilson
 import Mathlib.Tactic
 
 open Nat Set
@@ -39,11 +41,17 @@ there exists a prime p ≢ 1 (mod m) with p | m! + 1. -/
 def EHSNumbers : Set ℕ :=
   {m | 1 ≤ m ∧ ∃ p, p.Prime ∧ ¬p ≡ 1 [MOD m] ∧ p ∣ m ! + 1}
 
-/-- The Pillai primes are those primes p such that there exists an m with
-p ≢ 1 (mod m) and p | m! + 1. Named after S. S. Pillai who first asked
-whether such primes exist. -/
+/-- The Pillai primes are those primes p such that there exists a positive
+integer m with p ≢ 1 (mod m) and p | m! + 1. Named after S. S. Pillai who
+first asked whether such primes exist.
+
+The positivity requirement `1 ≤ m` is essential and matches the standard
+definition (OEIS A063980, smallest is 23). Without it, the modulus `0`
+would degenerate `≡ [MOD 0]` to plain equality and admit the spurious member
+`2` (via `m = 0`, since `0! + 1 = 2`, `2 ∣ 2`, and `¬(2 = 1)`), which is not
+a Pillai prime. -/
 def PillaiPrimes : Set ℕ :=
-  {p | p.Prime ∧ ∃ m, ¬p ≡ 1 [MOD m] ∧ p ∣ m ! + 1}
+  {p | p.Prime ∧ ∃ m, 1 ≤ m ∧ ¬p ≡ 1 [MOD m] ∧ p ∣ m ! + 1}
 
 /- ## Chowla's Example: 23 is a Pillai Prime
 
@@ -68,7 +76,7 @@ theorem twentyThree_prime : Nat.Prime 23 := by
 /-- Chowla's example: 23 is a Pillai prime, witnessed by m = 14.
 This answered Pillai's 1930 question about the existence of such primes. -/
 theorem pillai_23 : 23 ∈ PillaiPrimes := by
-  refine ⟨twentyThree_prime, 14, twentyThree_not_cong_one_mod_14, ?_⟩
+  refine ⟨twentyThree_prime, 14, by norm_num, twentyThree_not_cong_one_mod_14, ?_⟩
   exact twentyThree_dvd_factorial_14_plus_one
 
 /- ## Additional Verified Examples -/
@@ -95,23 +103,76 @@ theorem ehs_9 : 9 ∈ EHSNumbers := by
     · native_decide  -- 71 ≢ 1 (mod 9)
     · native_decide  -- 71 | 9! + 1
 
+/- ## Structural Results
+
+The following lemmas formalize the structural skeleton of Problem 1074:
+the Wilson-theorem connection that links primes to factorial divisibility,
+the reason the "Wilson witness" `m = p - 1` is always excluded (which is
+exactly what makes the EHS/Pillai sets nontrivial), and the duality between
+EHS numbers and Pillai primes.
+-/
+
+/-- **Wilson connection.** For every prime `p`, we have `p ∣ (p - 1)! + 1`.
+This is the divisibility half of Wilson's theorem and is the source of all
+factorial/prime relationships in this problem. -/
+theorem prime_dvd_pred_factorial_add_one {p : ℕ} (hp : p.Prime) :
+    p ∣ (p - 1) ! + 1 := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  rw [← ZMod.natCast_eq_zero_iff]
+  push_cast
+  rw [ZMod.wilsons_lemma]
+  ring
+
+/-- **The Wilson witness is congruent to 1.** For any `p ≥ 1` we have
+`p ≡ 1 [MOD (p - 1)]`, since `(p - 1) ∣ (p - 1) = p - 1`. -/
+theorem prime_cong_one_mod_pred {p : ℕ} (hp : 1 ≤ p) :
+    p ≡ 1 [MOD (p - 1)] :=
+  ((Nat.modEq_iff_dvd' hp).mpr dvd_rfl).symm
+
+/-- **Why the problem is nontrivial.** For every prime `p`, the "Wilson
+witness" `m = p - 1` satisfies the factorial divisibility `p ∣ m! + 1`, but
+*also* `p ≡ 1 [MOD m]`. So this canonical witness is always excluded by the
+non-congruence condition: a genuine EHS/Pillai witness must avoid the Wilson
+case `m = p - 1`. -/
+theorem wilson_witness_excluded {p : ℕ} (hp : p.Prime) :
+    p ∣ (p - 1) ! + 1 ∧ p ≡ 1 [MOD (p - 1)] :=
+  ⟨prime_dvd_pred_factorial_add_one hp, prime_cong_one_mod_pred hp.one_lt.le⟩
+
+/-- **EHS/Pillai duality.** The Pillai primes are exactly the primes that
+arise as the witnessing prime of some EHS number: `p` is a Pillai prime iff
+`p` is prime and there is an EHS number `m` for which `p` itself is the
+witness (`p ≢ 1 [MOD m]` and `p ∣ m! + 1`).
+
+This makes precise the informal statement that "the Pillai primes are the
+primes coming from EHS numbers". -/
+theorem mem_pillai_iff {p : ℕ} :
+    p ∈ PillaiPrimes ↔
+      p.Prime ∧ ∃ m, m ∈ EHSNumbers ∧ ¬p ≡ 1 [MOD m] ∧ p ∣ m ! + 1 := by
+  simp only [PillaiPrimes, EHSNumbers, Set.mem_setOf_eq]
+  constructor
+  · rintro ⟨hp, m, hm1, hmc, hmd⟩
+    exact ⟨hp, m, ⟨hm1, p, hp, hmc, hmd⟩, hmc, hmd⟩
+  · rintro ⟨hp, m, ⟨hm1, -⟩, hmc, hmd⟩
+    exact ⟨hp, m, hm1, hmc, hmd⟩
+
 /- ## Infinitude Results
 
 Erdős, Hardy, and Subbarao proved that both sets are infinite.
 These deep results require number-theoretic arguments beyond what
-we formalize here, so we state them as axioms.
+we formalize here. We do not assert them; the main density questions
+below remain open.
 -/
 
-/-- The set of EHS numbers is infinite.
-Proved by Erdős, Hardy, and Subbarao.
-
+/- The set of EHS numbers is infinite (Erdős, Hardy, and Subbarao).
 The proof uses properties of prime factorizations of factorial values
-and the distribution of primes in residue classes. -/
-/-- The set of Pillai primes is infinite.
-Proved by Erdős, Hardy, and Subbarao.
+and the distribution of primes in residue classes.
 
+The set of Pillai primes is infinite (Erdős, Hardy, and Subbarao).
 This follows from the infinitude of EHS numbers combined with
-analysis of which primes can divide m! + 1. -/
+analysis of which primes can divide m! + 1.
+
+These deep results are not asserted in this file. -/
+
 /- ## Open Problems
 
 The main questions of Problem 1074 remain open:
@@ -130,17 +191,16 @@ These density questions cannot be settled by finite computation
 and remain open research problems.
 -/
 
-/-- **OPEN**: Does the natural density of EHS numbers exist?
+/- **OPEN**: Does the natural density of EHS numbers exist?
 If so, Erdős, Hardy, and Subbarao conjectured it equals 1.
-
-This formalizes the existence of the limit:
+This is the existence of the limit
   lim_{x→∞} |S ∩ [1,x]| / x
-where S is the set of EHS numbers. -/
-/-- **OPEN**: Does the relative density of Pillai primes exist?
-Hardy and Subbarao estimated it might be between 0.5 and 0.6,
-but also suggested it could tend to 1.
+where S is the set of EHS numbers.
 
-This formalizes the existence of the limit:
+**OPEN**: Does the relative density of Pillai primes exist?
+Hardy and Subbarao estimated it might be between 0.5 and 0.6,
+but also suggested it could tend to 1. This is the existence of
   lim_{x→∞} |P ∩ [1,x]| / π(x)
 where P is the set of Pillai primes and π(x) is the prime counting function. -/
+
 end Erdos1074

--- a/src/data/proofs/erdos-1074/meta.json
+++ b/src/data/proofs/erdos-1074/meta.json
@@ -45,36 +45,50 @@
         "theorem": "Set.Infinite",
         "description": "Infinite set predicate",
         "module": "Mathlib.Data.Set.Finite.Basic"
+      },
+      {
+        "theorem": "ZMod.wilsons_lemma",
+        "description": "Wilson's theorem: (p-1)! = -1 in ZMod p",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a",
+        "module": "Mathlib.Data.ZMod.Basic"
       }
     ],
     "originalContributions": [
       "EHSNumbers definition: {m ≥ 1 | ∃ prime p ≢ 1 (mod m) with p | m! + 1}",
-      "PillaiPrimes definition: {p prime | ∃ m with p ≢ 1 (mod m) and p | m! + 1}",
+      "PillaiPrimes definition (corrected): {p prime | ∃ m ≥ 1 with p ≢ 1 (mod m) and p | m! + 1}",
+      "Definitional fix: added the missing `1 ≤ m` constraint to PillaiPrimes. Without it, m=0 made the modulus-0 congruence degenerate to equality and admitted the spurious member 2 (0!+1=2, 2|2, ¬(2=1)), contradicting OEIS A063980 (smallest Pillai prime is 23).",
+      "Parse fix: converted four dangling doc-comments (left after earlier axiom removal) into block comments so the file actually compiles.",
       "Verified: 23 is a Pillai prime (Chowla's example via 14! + 1)",
-      "Verified: 8 is the first EHS number (via prime 61)",
-      "Verified: 9 is an EHS number (via prime 71)",
-      "Axiom: EHSNumbers are infinite (Erdős-Hardy-Subbarao)",
-      "Axiom: PillaiPrimes are infinite (Erdős-Hardy-Subbarao)",
-      "Open density conjectures formalized"
+      "Verified: 8 is the first EHS number (via prime 61); 9 is an EHS number (via prime 71)",
+      "Theorem prime_dvd_pred_factorial_add_one: Wilson connection p | (p-1)! + 1 for all primes p",
+      "Theorem wilson_witness_excluded: the canonical witness m=p-1 gives p|(p-1)!+1 but also p≡1 [MOD p-1], so it is always excluded — this is exactly why EHS/Pillai are nontrivial",
+      "Theorem mem_pillai_iff: EHS/Pillai duality — the Pillai primes are exactly the primes witnessing some EHS number",
+      "Open density conjectures documented (not asserted)"
     ],
-    "axiomCount": 0,
-    "lineCount": 146,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 6,
+    "axiomCount": 1,
+    "lineCount": 206,
+    "assumptions": "0 axiom declarations and 0 sorries in the Lean source. The verified numeric examples (23 is a Pillai prime; 8, 9 are EHS numbers) are discharged by `native_decide`, so they depend on `Lean.ofReduceBool` (and `Lean.trustCompiler`); meta.axiomCount=1 records this per the project's axiom-integrity policy (leanFile.axiomCount remains 0 as there are no literal `axiom` declarations). The newly added structural theorems (Wilson connection, Wilson-witness exclusion, and the EHS/Pillai duality `mem_pillai_iff`) are fully proved and use only the foundational propext/Classical.choice/Quot.sound. The 'axiomatized' status reflects that the headline density questions remain OPEN and are not formalized as theorems.",
+    "theoremCount": 10,
     "definitionCount": 2
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1074**\n\nThis problem concerns special relationships between factorials and prime divisors.\n\n**Key History:**\n- Pillai (1930): First asked whether any primes p exist with p | m! + 1 and p ≢ 1 (mod m)\n- Chowla: Answered Pillai by showing 23 | 14! + 1 and 23 ≢ 1 (mod 14)\n- Erdős, Hardy, Subbarao: Named these sets 'EHS numbers' and 'Pillai primes', proved both infinite\n- Hardy-Subbarao: Computed EHS numbers up to 2^10, conjectured density is 1\n\n**Mathematical Setting:**\n- m! + 1 has prime factors that satisfy Wilson's theorem conditions\n- The condition p ≢ 1 (mod m) excludes the 'trivial' case where p - 1 | m\n- EHS numbers tend to occur in long consecutive runs",
     "problemStatement": "**Problem Statement (Partially Open)**\n\nLet S = {m ≥ 1 | ∃ prime p ≢ 1 (mod m) with p | m! + 1} (EHS numbers).\nLet P = {p prime | ∃ m with p ≢ 1 (mod m) and p | m! + 1} (Pillai primes).\n\n**Questions:**\n1. Does lim |S ∩ [1,x]| / x exist? If so, what is it?\n2. Does lim |P ∩ [1,x]| / π(x) exist? If so, what is it?\n\n**Known Results:**\n- Both S and P are infinite (Erdős-Hardy-Subbarao)\n- S begins: 8, 9, 13, 14, 15, 16, 17, ... (OEIS A064164)\n- P begins: 23, 29, 59, 61, 67, 71, ... (OEIS A063980)\n\n**Conjectures:**\n- Hardy-Subbarao: Density of S is 1\n- Density of P may be between 0.5 and 1",
     "text": "Do the asymptotic densities of EHS numbers and Pillai primes exist? Both sets are infinite (Erdős-Hardy-Subbarao), but density questions remain OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Set Definitions:** Define EHSNumbers and PillaiPrimes as subsets of ℕ\n\n2. **Verified Examples:**\n   - 23 ∈ PillaiPrimes via 14! + 1 ≡ 0 (mod 23) (Chowla)\n   - 8 ∈ EHSNumbers via 61 | 8! + 1 (first EHS number)\n   - 9 ∈ EHSNumbers via 71 | 9! + 1\n\n3. **Infinitude Results:** State as axioms (deep number theory)\n\n4. **Open Problems:** State density conjectures formally\n\nThe verified examples use native_decide to computationally check divisibility and congruence conditions.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Set Definitions:** Define EHSNumbers and PillaiPrimes as subsets of ℕ\n\n2. **Verified Examples:**\n   - 23 ∈ PillaiPrimes via 14! + 1 ≡ 0 (mod 23) (Chowla)\n   - 8 ∈ EHSNumbers via 61 | 8! + 1 (first EHS number)\n   - 9 ∈ EHSNumbers via 71 | 9! + 1\n\n3. **Structural Results:** Wilson connection p|(p-1)!+1, the exclusion of the Wilson witness m=p-1, and the EHS/Pillai duality (mem_pillai_iff). Infinitude (EHS, Pillai) is documented but not asserted (deep number theory)\n\n4. **Open Problems:** State density conjectures formally\n\nThe verified examples use native_decide to computationally check divisibility and congruence conditions.",
     "keyInsights": [
       "**Wilson's Theorem Connection:** For prime p, (p-1)! ≡ -1 (mod p), so p | (p-1)! + 1",
       "**EHS Condition:** Requires p ≢ 1 (mod m), excluding the Wilson case",
       "**Consecutive Runs:** EHS numbers often appear in long sequences",
       "**First EHS:** 8 is first because 1-7 fail the p ≢ 1 (mod m) condition",
       "**Chowla's Example:** 14! + 1 = 87,178,291,201 has factor 23, and 23 ≢ 1 (mod 14)",
-      "**Density Mystery:** Why would EHS numbers have density 1? The condition seems restrictive"
+      "**Density Mystery:** Why would EHS numbers have density 1? The condition seems restrictive",
+      "**EHS/Pillai duality:** Pillai primes are exactly the primes that witness EHS numbers (mem_pillai_iff)",
+      "**Definition pitfall:** dropping `m ≥ 1` lets m=0 (modulus 0 ≡ equality) spuriously admit 2; the corrected definition matches OEIS A063980"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -214,6 +228,8 @@
       "Mathlib.Data.Nat.ModEq",
       "Mathlib.Data.Set.Basic",
       "Mathlib.Data.Set.Finite.Basic",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.NumberTheory.Wilson",
       "Mathlib.Tactic"
     ],
     "opens": [
@@ -221,9 +237,9 @@
       "Set"
     ],
     "namespace": "Erdos1074",
-    "lineCount": 146,
+    "lineCount": 206,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 10,
     "definitionCount": 2,
     "path": "Proofs/Erdos1074Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Research session on **Erdős Problem #1074** (EHS numbers and Pillai primes), an OPEN density problem. This session fixes two real correctness defects in the existing entry and adds genuine structural mathematics.

## Correctness fixes (the committed Lean file did not compile)
1. **`PillaiPrimes` was missing `1 ≤ m`.** `EHSNumbers` correctly requires `1 ≤ m`, but `PillaiPrimes` did not. With `m = 0`, `≡ [MOD 0]` degenerates to plain equality, so `2` became a **spurious member** (`0! + 1 = 2`, `2 ∣ 2`, `¬(2 = 1)`) — contradicting OEIS A063980, whose smallest Pillai prime is `23`. Added the constraint; `pillai_23` still goes through (`m = 14`).
2. **Four dangling doc-comments** (`/-- … -/` with no following declaration), left behind when the infinitude `axiom`s were removed in an earlier edit, made the file **fail to parse** (`unexpected token '/--'`). Converted to block comments; the prose is preserved.

## New structural theorems (all foundational-only per `#print axioms`)
- `prime_dvd_pred_factorial_add_one` — Wilson connection `p ∣ (p−1)! + 1`.
- `prime_cong_one_mod_pred` — `p ≡ 1 [MOD p−1]`.
- `wilson_witness_excluded` — the canonical witness `m = p−1` satisfies the divisibility **but also** `p ≡ 1 [MOD p−1]`, so it is always excluded by the non-congruence condition. This makes formal *why* the EHS/Pillai sets are nontrivial.
- `mem_pillai_iff` — **EHS/Pillai duality**: the Pillai primes are exactly the primes that witness some EHS number.

## Verification
- Compiled with offline `lake env lean Proofs/Erdos1074Problem.lean` (exit 0, no diagnostics). Docker daemon was unavailable this session, so the sanctioned `docker-build.sh` could not run; the offline single-file elaboration against the prebuilt Mathlib oleans is equivalent for a self-contained file.
- `#print axioms`: the new structural theorems depend only on `propext`/`Classical.choice`/`Quot.sound`. The `native_decide` numeric examples depend on `Lean.ofReduceBool` (+`Lean.trustCompiler`) — now disclosed in `meta.assumptions` with `meta.axiomCount = 1` per the axiom-integrity policy.

## meta.json
theoremCount 6→10, lineCount 146→206, axiomCount 0→1 (disclosed), imports + mathlibDependencies updated, originalContributions/keyInsights/proofStrategy corrected (infinitude is documented, not asserted).

## Status
**Outcome**: progress (correctness fixes + structural theorems). The headline density questions remain **OPEN**.
**Next Steps**: the duality `mem_pillai_iff` could support a future formal reduction between the two density questions.

🤖 Generated by researcher-7