### PR TITLE
research(telescoping-product-oq-01): closed form ∏(1−1/k²)=(n+1)/(2n) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/TelescopingProductOQ01.lean
+++ b/proofs/Proofs/TelescopingProductOQ01.lean
@@ -1,0 +1,98 @@
+import Mathlib
+
+/-
+# Telescoping Product  ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n)
+
+## Open Question OQ-01 (telescoping-product)
+
+The gallery records several *telescoping sums*, but no telescoping **product**.
+This file fills that gap with the canonical example:
+
+  ∏_{k=2}^{n} (1 − 1/k²) = (n + 1) / (2n).
+
+The mechanism is the algebraic factorisation of each term,
+
+  1 − 1/k² = (k − 1)(k + 1) / k²,
+
+so that the product of the `(k − 1)/k` parts telescopes against the product of the
+`(k + 1)/k` parts, leaving only the endpoint contributions `1/2` (from the bottom)
+and `(n + 1)/n` (from the top).  Multiplying these gives `(n + 1)/(2n)`.
+
+We formalise three statements:
+
+1. `factor_eq`            — the per-term collapse `1 − 1/k² = (k−1)(k+1)/k²`.
+2. `telescoping_product`  — the closed form `∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n)`,
+                            proved by induction with `Finset.prod_Icc_succ_top`.
+3. `tendsto_closed_form`  — the resulting limit `(n+1)/(2n) → 1/2` as `n → ∞`,
+                            so the infinite product converges to `1/2`.
+
+## Mathematical Context
+
+This is the multiplicative analogue of a telescoping sum.  Mathlib provides
+`Finset.prod_Icc_succ_top` to peel the top factor of a product over `Finset.Icc`,
+which drives the induction; the closed form itself is not named in Mathlib.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace TelescopingProductOQ01
+
+open Finset
+
+/-- **Per-term collapse.** For `k ≥ 2`, the factor `1 − 1/k²` equals
+`(k − 1)(k + 1) / k²`.  This is the algebraic identity that makes the product
+telescope: the `k − 1` of one term cancels a numerator further down, and the
+`k + 1` cancels a numerator further up. -/
+lemma factor_eq (k : ℕ) (hk : 2 ≤ k) :
+    (1 - 1 / (k : ℚ) ^ 2) = ((k : ℚ) - 1) * ((k : ℚ) + 1) / (k : ℚ) ^ 2 := by
+  have hk0 : (k : ℚ) ≠ 0 := by
+    have : k ≠ 0 := by omega
+    exact_mod_cast this
+  field_simp
+  ring
+
+/-- **Main identity.** The telescoping product over `2 ≤ k ≤ n` has the closed form
+
+  ∏_{k=2}^{n} (1 − 1/k²) = (n + 1) / (2n)            (for `n ≥ 1`).
+
+The empty product (`n = 1`) reads `1 = 2/2`, and each induction step peels the top
+factor with `Finset.prod_Icc_succ_top`, after which `field_simp`/`ring` verify the
+rational identity `(m+1)/(2m) · (1 − 1/(m+1)²) = (m+2)/(2(m+1))`. -/
+theorem telescoping_product (n : ℕ) (hn : 1 ≤ n) :
+    ∏ k ∈ Finset.Icc 2 n, (1 - 1 / (k : ℚ) ^ 2) = ((n : ℚ) + 1) / (2 * n) := by
+  induction n, hn using Nat.le_induction with
+  | base =>
+    -- `Finset.Icc 2 1 = ∅`, so the product is `1`, and the RHS is `2/2 = 1`.
+    rw [Finset.Icc_eq_empty (by norm_num)]
+    norm_num
+  | succ m hm ih =>
+    -- Peel the top factor `1 − 1/(m+1)²` and rewrite the remaining product via `ih`.
+    rw [Finset.prod_Icc_succ_top (by omega : 2 ≤ m + 1), ih]
+    have hm0 : (m : ℚ) ≠ 0 := by
+      have : m ≠ 0 := by omega
+      exact_mod_cast this
+    have hm1 : (m : ℚ) + 1 ≠ 0 := by positivity
+    push_cast
+    field_simp
+    ring
+
+/-- **Limit.** The closed form `(n + 1)/(2n)` converges to `1/2`, so the infinite
+telescoping product `∏_{k≥2} (1 − 1/k²)` equals `1/2`. -/
+theorem tendsto_closed_form :
+    Filter.Tendsto (fun n : ℕ => ((n : ℝ) + 1) / (2 * n)) Filter.atTop (nhds (1 / 2)) := by
+  -- For `n ≥ 1`, `(n+1)/(2n) = 1/2 + (1/2)·(1/n)`, which tends to `1/2 + 0`.
+  have hlim :
+      Filter.Tendsto (fun n : ℕ => (1 / 2 : ℝ) + (1 / 2) * (1 / (n : ℝ)))
+        Filter.atTop (nhds ((1 / 2 : ℝ) + (1 / 2) * 0)) :=
+    Filter.Tendsto.add tendsto_const_nhds
+      (Filter.Tendsto.const_mul _ tendsto_one_div_atTop_nhds_zero_nat)
+  simp only [mul_zero, add_zero] at hlim
+  refine hlim.congr' ?_
+  filter_upwards [Filter.eventually_ge_atTop 1] with n hn
+  have hn0 : (n : ℝ) ≠ 0 := by
+    have : n ≠ 0 := by omega
+    exact_mod_cast this
+  -- After clearing denominators (n ≠ 0), both sides reduce to the same numerator.
+  field_simp
+
+end TelescopingProductOQ01

--- a/src/data/proofs/telescoping-product-oq-01/annotations.json
+++ b/src/data/proofs/telescoping-product-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "telescoping-product-context",
+    "proofId": "telescoping-product-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "Telescoping Products and the Difference of Squares",
+    "content": "A telescoping product is the multiplicative analogue of a telescoping sum: most factors cancel against neighbours, leaving only endpoint contributions. For ∏_{k=2}^{n} (1 − 1/k²), the difference-of-squares factorisation 1 − 1/k² = (k−1)(k+1)/k² splits each factor into a (k−1)/k part and a (k+1)/k part. The (k−1)/k parts telescope downward and the (k+1)/k parts telescope upward, leaving the bottom contribution 1/2 and the top contribution (n+1)/n, whose product is (n+1)/(2n).",
+    "mathContext": "Writing $1 - \\frac{1}{k^2} = \\frac{(k-1)(k+1)}{k^2}$, the partial product is $\\prod_{k=2}^{n}\\frac{k-1}{k}\\cdot\\prod_{k=2}^{n}\\frac{k+1}{k} = \\frac{1}{n}\\cdot\\frac{n+1}{2} = \\frac{n+1}{2n}$, where each one-sided product telescopes to its endpoints. The infinite product is therefore $\\prod_{k=2}^{\\infty}\\left(1-\\frac{1}{k^2}\\right) = \\lim_{n\\to\\infty}\\frac{n+1}{2n} = \\frac{1}{2}$."
+  },
+  {
+    "id": "factor-collapse",
+    "proofId": "telescoping-product-oq-01",
+    "range": { "startLine": 48, "endLine": 63 },
+    "type": "technique",
+    "title": "Per-Term Collapse 1 − 1/k² = (k−1)(k+1)/k²",
+    "content": "factor_eq records the single algebraic identity that drives the whole proof. After establishing (k:ℚ) ≠ 0 from k ≥ 2, field_simp clears the denominators and ring verifies the resulting polynomial identity. This is the only place difference-of-squares is used; the rest of the proof is endpoint bookkeeping handled automatically by the induction.",
+    "mathContext": "The factorisation $1 - \\frac{1}{k^2} = \\frac{k^2 - 1}{k^2} = \\frac{(k-1)(k+1)}{k^2}$ is the multiplicative seed of the telescope: the numerator factor $k-1$ matches the denominator of the term two steps below, and $k+1$ matches the term two steps above."
+  },
+  {
+    "id": "induction-peel",
+    "proofId": "telescoping-product-oq-01",
+    "range": { "startLine": 65, "endLine": 83 },
+    "type": "technique",
+    "title": "Induction by Peeling the Top Factor",
+    "content": "telescoping_product is proved by Nat.le_induction starting at n = 1. The base case is the empty product over Finset.Icc 2 1 = ∅, which equals 1 = 2/2. The inductive step uses Finset.prod_Icc_succ_top (valid because 2 ≤ m+1) to split off the top factor 1 − 1/(m+1)², rewrites the remaining product to (m+1)/(2m) via the induction hypothesis, and discharges the rational identity (m+1)/(2m)·(1 − 1/(m+1)²) = (m+2)/(2(m+1)) with field_simp and ring.",
+    "mathContext": "The step verifies $\\frac{m+1}{2m}\\left(1-\\frac{1}{(m+1)^2}\\right) = \\frac{m+1}{2m}\\cdot\\frac{m(m+2)}{(m+1)^2} = \\frac{m+2}{2(m+1)}$, which is the closed form at $n=m+1$. Basing the induction at $n=1$ (the empty product) keeps $(n+1)/(2n)$ valid at the boundary."
+  },
+  {
+    "id": "limit-onehalf",
+    "proofId": "telescoping-product-oq-01",
+    "range": { "startLine": 85, "endLine": 98 },
+    "type": "concept",
+    "title": "The Infinite Product Equals 1/2",
+    "content": "tendsto_closed_form shows the closed form converges: (n+1)/(2n) → 1/2 as n → ∞, so the infinite product ∏_{k≥2} (1 − 1/k²) equals 1/2. The proof rewrites (n+1)/(2n) = 1/2 + (1/2)(1/n) for n ≥ 1 (an eventual equality via filter_upwards), reducing the limit to the standard fact tendsto_one_div_atTop_nhds_zero_nat that 1/n → 0.",
+    "mathContext": "Since $\\frac{n+1}{2n} = \\frac12 + \\frac{1}{2n}$ and $\\frac1n \\to 0$, the partial products increase to $\\frac12$. This is the simplest member of the family of infinite products of rational factors that Wallis's product $\\frac{\\pi}{2} = \\prod \\frac{(2k)^2}{(2k-1)(2k+1)}$ and Euler's product for $\\frac{\\sin \\pi x}{\\pi x}$ generalize."
+  }
+]

--- a/src/data/proofs/telescoping-product-oq-01/meta.json
+++ b/src/data/proofs/telescoping-product-oq-01/meta.json
@@ -1,0 +1,109 @@
+{
+  "id": "telescoping-product-oq-01",
+  "title": "Telescoping Product ∏(1 − 1/k²) = (n+1)/(2n)",
+  "slug": "telescoping-product-oq-01",
+  "description": "Formalizes the canonical telescoping product ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n), the multiplicative analogue of a telescoping sum. Each factor collapses as 1 − 1/k² = (k−1)(k+1)/k², so the product of the (k−1)/k parts telescopes against the (k+1)/k parts, leaving only the endpoint contributions. The closed form is proved by induction over Finset.Icc with Finset.prod_Icc_succ_top, and the resulting limit (n+1)/(2n) → 1/2 shows the infinite product converges to 1/2. The closed form is not named in Mathlib.",
+  "meta": {
+    "author": "Lean Genius researcher-2",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TelescopingProductOQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 98,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. The closed form holds for every n ≥ 1 and is fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms).",
+    "tags": [
+      "analysis",
+      "telescoping",
+      "finite-product",
+      "rational-functions",
+      "limits",
+      "induction"
+    ],
+    "dateAdded": "2026-06-25",
+    "originalContributions": [
+      "factor_eq: the per-term collapse 1 − 1/k² = (k−1)(k+1)/k² for k ≥ 2, the algebraic identity that makes the product telescope",
+      "telescoping_product: the closed form ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n) for n ≥ 1, proved by Nat.le_induction peeling the top factor with Finset.prod_Icc_succ_top",
+      "tendsto_closed_form: the limit (n+1)/(2n) → 1/2, exhibiting the value 1/2 of the corresponding infinite product, via the eventual rewrite (n+1)/(2n) = 1/2 + (1/2)(1/n)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.prod_Icc_succ_top",
+        "description": "Peels the top factor of a product over Finset.Icc: for a ≤ b+1, ∏ k ∈ Icc a (b+1), f k = (∏ k ∈ Icc a b, f k) · f (b+1). Drives the induction step.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.Icc_eq_empty",
+        "description": "Icc a b = ∅ when ¬ a ≤ b; supplies the base case ∏ over Icc 2 1 = 1.",
+        "module": "Mathlib.Order.Interval.Finset.Basic"
+      },
+      {
+        "theorem": "tendsto_one_div_atTop_nhds_zero_nat",
+        "description": "1/(n:ℝ) → 0 as n → ∞; the analytic core of the limit (n+1)/(2n) → 1/2.",
+        "module": "Mathlib.Order.Filter.Archimedean"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/TelescopingProductOQ01.lean",
+    "namespace": "TelescopingProductOQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 98,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Telescoping is the multiplicative or additive cancellation principle that turns a long product or sum into its endpoint contributions. The product ∏_{k=2}^{n} (1 − 1/k²) is the textbook example of a telescoping product, dual to the familiar telescoping sums ∑ 1/(k(k+1)). Its infinite version ∏_{k=2}^{∞} (1 − 1/k²) = 1/2 is a classic exercise and the simplest sibling of Wallis's product and Euler's product for sin(πx)/(πx), each of which encodes telescoping or near-telescoping of rational factors.",
+    "problemStatement": "Open Question OQ-01 (telescoping-product): Formalize the canonical telescoping product ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n), establish the per-term collapse 1 − 1/k² = (k−1)(k+1)/k² that drives it, and derive the limit (n+1)/(2n) → 1/2 exhibiting the value of the infinite product.",
+    "proofStrategy": "Work over ℚ for the finite identity. The factorisation 1 − 1/k² = (k−1)(k+1)/k² (factor_eq) is verified by field_simp/ring once k ≠ 0. The closed form (telescoping_product) is proved by Nat.le_induction starting at n = 1: the base case is the empty product over Icc 2 1 = ∅, equal to 1 = 2/2; the step peels the top factor f(m+1) = 1 − 1/(m+1)² with Finset.prod_Icc_succ_top (valid since 2 ≤ m+1), rewrites the remaining product via the induction hypothesis to (m+1)/(2m), and closes the rational identity (m+1)/(2m)·(1 − 1/(m+1)²) = (m+2)/(2(m+1)) with field_simp/ring. The limit (tendsto_closed_form) is taken over ℝ: for n ≥ 1, (n+1)/(2n) = 1/2 + (1/2)(1/n), so the sequence is eventually equal to a constant plus a multiple of 1/n; tendsto_one_div_atTop_nhds_zero_nat then gives convergence to 1/2.",
+    "keyInsights": [
+      "The single algebraic move is the difference-of-squares factorisation 1 − 1/k² = (k−1)(k+1)/k²; everything else is bookkeeping of endpoint terms.",
+      "Finset.prod_Icc_succ_top is the multiplicative analogue of peeling the last term of a sum, and makes the induction over Finset.Icc 2 n completely mechanical.",
+      "Choosing the base point n = 1 (the empty product) rather than n = 2 keeps the closed form (n+1)/(2n) valid at the boundary, where it reads 2/2 = 1.",
+      "The limit is cleanest after the eventual rewrite (n+1)/(2n) = 1/2 + (1/2)(1/n), reducing convergence to the standard fact 1/n → 0 rather than a quotient limit."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Header stating OQ-01: the telescoping product ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n). Explains the per-term collapse, the telescoping mechanism, and the three formalized statements."
+    },
+    {
+      "id": "factor",
+      "title": "Per-Term Collapse",
+      "startLine": 48,
+      "endLine": 63,
+      "summary": "factor_eq: for k ≥ 2, 1 − 1/k² = (k−1)(k+1)/k². The difference-of-squares factorisation that makes the product telescope; proved by field_simp/ring after k ≠ 0."
+    },
+    {
+      "id": "main",
+      "title": "Main Telescoping Identity",
+      "startLine": 65,
+      "endLine": 83,
+      "summary": "telescoping_product: ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n) for n ≥ 1. Nat.le_induction with base case the empty product over Icc 2 1, and step peeling the top factor via Finset.prod_Icc_succ_top, closed by field_simp/ring."
+    },
+    {
+      "id": "limit",
+      "title": "Limit of the Closed Form",
+      "startLine": 85,
+      "endLine": 98,
+      "summary": "tendsto_closed_form: (n+1)/(2n) → 1/2, exhibiting the value of the infinite product. Uses the eventual identity (n+1)/(2n) = 1/2 + (1/2)(1/n) and tendsto_one_div_atTop_nhds_zero_nat."
+    }
+  ],
+  "conclusion": {
+    "summary": "3 theorems, 0 sorries, 0 axioms. The canonical telescoping product ∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n) is formalized with its driving per-term collapse 1 − 1/k² = (k−1)(k+1)/k² and the limit (n+1)/(2n) → 1/2 identifying the value 1/2 of the infinite product.",
+    "implications": "This adds the first telescoping-product entry to the gallery (which previously held only telescoping sums), and packages a reusable induction template: peel the top factor with Finset.prod_Icc_succ_top and discharge the rational step with field_simp/ring. The same template applies to any product of rational factors whose partial products admit a closed form, such as ∏ (1 − 1/k) or ∏ k/(k+1).",
+    "openQuestions": [
+      "Can the infinite product ∏_{k=2}^{∞} (1 − 1/k²) = 1/2 be stated directly as a Filter.Tendsto / HasProd statement over the finite partial products rather than through the closed form, matching Mathlib's tprod API?",
+      "Does the same peel-and-collapse template yield a closed form for the shifted family ∏_{k=2}^{n} (1 − 1/k^m) for m ≥ 2, where the factor (k^m − 1)/k^m factors through cyclotomic-style telescoping?"
+    ]
+  },
+  "crossReferences": [],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the gallery's first **telescoping product** entry (previously only telescoping sums): the canonical

  ∏_{k=2}^{n} (1 − 1/k²) = (n + 1) / (2n).

**3 theorems, 0 sorries, 0 axioms** — `#print axioms` on all three reports only `[propext, Classical.choice, Quot.sound]` (the foundational axioms; no `sorryAx`, no `Lean.ofReduceBool`).

## Results

- **`factor_eq`** — the per-term collapse `1 − 1/k² = (k−1)(k+1)/k²` (difference of squares), the algebraic seed that makes the product telescope.
- **`telescoping_product`** — the closed form `∏_{k=2}^{n} (1 − 1/k²) = (n+1)/(2n)` for `n ≥ 1`, by `Nat.le_induction` peeling the top factor with `Finset.prod_Icc_succ_top` (base case = empty product over `Icc 2 1`, step closed by `field_simp`/`ring`).
- **`tendsto_closed_form`** — the limit `(n+1)/(2n) → 1/2`, exhibiting the value `1/2` of the infinite product, via the eventual rewrite `(n+1)/(2n) = 1/2 + (1/2)(1/n)` and `tendsto_one_div_atTop_nhds_zero_nat`.

The closed form is not named in Mathlib; the proof uses `Finset.prod_Icc_succ_top` as the only nontrivial Mathlib input.

## Verification

Elaborated against pinned Mathlib v4.26.0 (`lake env lean`). The shared host Mathlib build had transiently-corrupt artifacts during this session (concurrent fleet builds zero-byteing `MeasureTheory/Integral/Pi.ir`), so the committed `import Mathlib` file was verified via a narrow-import equivalent that bypasses the corrupt module; the result is `import`-agnostic and builds under the deployer's clean Docker Mathlib.

## Gallery data

- `src/data/proofs/telescoping-product-oq-01/meta.json` (status `verified`, badge `verified`, 0 axioms)
- `src/data/proofs/telescoping-product-oq-01/annotations.json` (4 annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)