### PR TITLE
audit: 10 fresh proofs clean + erdos-490 meta-block stale counts

### DIFF
--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -68,9 +68,9 @@
       "bound_is_optimal: matching lower bound (partially proved)"
     ],
     "axiomCount": 2,
-    "lineCount": 330,
-    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details.",
-    "theoremCount": 12,
+    "lineCount": 282,
+    "assumptions": "2 axiom(s) and 6 sorry(s). See the Lean source for details.",
+    "theoremCount": 10,
     "definitionCount": 15,
     "additionalFiles": [
       "Proofs/Erdos490ProblemAristotle.lean",


### PR DESCRIPTION
## Gallery Integrity Audit

### 10 fresh proofs audited — all CLEAN
Counts, sorries, axioms, and badges verified against the Lean source on `main`:

| Proof | badge | thm | sorries | axioms |
|-------|-------|-----|---------|--------|
| ballot-problem-oq-02-oq-04 | original | 9 ✓ | 0 ✓ | 0 ✓ |
| basel-problem-oq-11-oq-01 | mathlib | 7 ✓ | 0 ✓ | 0 ✓ |
| cassini-identity-oq-01 | original | 3 ✓ | 0 ✓ | 0 ✓ |
| cauchy-schwarz-oq-01-oq-02-oq-01 | verified | 10 ✓ | 0 ✓ | 0 ✓ |
| cauchy-schwarz-oq-01-oq-05-oq-01 | original | 8 ✓ | 0 ✓ | 0 ✓ |
| cayley-hamilton-oq-04-oq-02 | verified | 4 ✓ | 0 ✓ | 0 ✓ |
| chinese-remainder-non-coprime-oq-03-oq-03 | original | 4 ✓ | 0 ✓ | 0 ✓ |
| eisenstein-criterion-oq-01-oq-01 | mathlib | 5 ✓ | 0 ✓ | 0 ✓ |
| fatou-lemma-oq-01-oq-02-oq-01 | original | 2 ✓ | 0 ✓ | 0 ✓ |
| nicomachus-sum-of-cubes-oq-01 | original | 4 ✓ | 0 ✓ | 0 ✓ |

Spot-checked the `original`-badged headline theorems (Nicomachus, Cassini) — genuine independent proofs (inductive / matrix-power), not thin Mathlib wrappers. No True stubs, no `native_decide`, no hidden axioms.

### erdos-490 meta-block stale-count fix
`#30160` fixed the `leanFile` block but missed the sibling `meta` block, which still showed pre-edit values. Corrected to match the actual `Erdos490Problem.lean` (282 lines, 10 theorems, 6 sorries, 2 axioms):
- `meta.lineCount` 330 → 282
- `meta.theoremCount` 12 → 10
- `meta.assumptions` "2 axiom(s) and 3 sorry(s)" → "2 axiom(s) and 6 sorry(s)"

### Skipped
`factorial-telescoping-sum-oq-01` — directory has no committed `meta.json` on `main` (untracked WIP); left unaudited.

---
Discovered during autonomous gallery integrity audit.