### PR TITLE
research(erdos-1204): formalize admissible sequences + reduction to small primes

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -1,0 +1,137 @@
+/-
+Erdős Problem #1204: Admissible Sequences
+
+We call a sequence of integers 0 ≤ a₁ < ⋯ < a_k *admissible* if it is missing
+at least one congruence class modulo every prime p. (This is exactly the
+notion of an "admissible k-tuple" from the Hardy–Littlewood prime k-tuples
+conjecture and the bounded-gaps-between-primes work of Zhang, Maynard, Tao.)
+
+Let A(k) = min a_k over admissible k-element sequences.
+
+**Main Questions (OPEN)**:
+1. Estimate A(k). In particular, is it true that A(k) ∼ k log k?
+2. Estimate B(k) = min (a₁ + ⋯ + a_k)/k.
+
+**What is formalized here**:
+- `Admissible`: a finite set of naturals misses a residue class mod every prime.
+- `missing_class_of_card_lt`: a set of size < p always misses a class mod p
+  (only `card` distinct residues can be occupied, and there are `p` of them).
+- `admissible_iff_card`: **the key reduction** — admissibility is equivalent to
+  missing a class modulo every prime `p ≤ card`; all larger primes are automatic.
+- Worked examples: `∅`, `{0}`, `{0,2}` are admissible; `{0,1}` is not (it covers
+  both classes mod 2).
+
+The asymptotic questions A(k) ∼ k log k and the estimate for B(k) are OPEN and
+are not asserted here.
+
+Reference: https://erdosproblems.com/1204
+-/
+
+import Mathlib
+
+open Finset
+
+namespace Erdos1204
+
+/- ## Definition -/
+
+/-- A finite set `a ⊆ ℕ` is **admissible** if, for every prime `p`, it misses at
+least one residue class modulo `p`: there is some `r : ZMod p` not equal to `↑x`
+for any `x ∈ a`. -/
+def Admissible (a : Finset ℕ) : Prop :=
+  ∀ p : ℕ, p.Prime → ∃ r : ZMod p, ∀ x ∈ a, (x : ZMod p) ≠ r
+
+/- ## The reduction to small primes
+
+The content of admissibility lies entirely in the small primes `p ≤ |a|`. For a
+prime `p` larger than `|a|`, the `|a|` elements occupy at most `|a| < p` of the
+`p` residue classes, so some class is automatically missed. -/
+
+/-- A set with fewer than `p` elements always misses a residue class modulo `p`:
+its image in `ZMod p` cannot be all of `ZMod p`. -/
+theorem missing_class_of_card_lt {a : Finset ℕ} {p : ℕ} [NeZero p]
+    (h : a.card < p) : ∃ r : ZMod p, ∀ x ∈ a, (x : ZMod p) ≠ r := by
+  by_contra hcon
+  push_neg at hcon
+  -- hcon : ∀ r, ∃ x ∈ a, (x : ZMod p) = r, i.e. the image is all of ZMod p
+  have hsub : (Finset.univ : Finset (ZMod p)) ⊆ a.image (fun x : ℕ => (x : ZMod p)) := by
+    intro r _
+    obtain ⟨x, hx, hxr⟩ := hcon r
+    exact Finset.mem_image.mpr ⟨x, hx, hxr⟩
+  have hle : (Finset.univ : Finset (ZMod p)).card ≤ a.card :=
+    le_trans (Finset.card_le_card hsub) (Finset.card_image_le)
+  rw [Finset.card_univ, ZMod.card p] at hle
+  omega
+
+/-- **Key reduction.** A finite set is admissible iff it misses a residue class
+modulo every prime `p` that is at most its cardinality. Larger primes impose no
+constraint. -/
+theorem admissible_iff_card {a : Finset ℕ} :
+    Admissible a ↔
+      ∀ p : ℕ, p.Prime → p ≤ a.card → ∃ r : ZMod p, ∀ x ∈ a, (x : ZMod p) ≠ r := by
+  constructor
+  · intro ha p hp _; exact ha p hp
+  · intro h p hp
+    rcases le_or_gt p a.card with hle | hlt
+    · exact h p hp hle
+    · haveI : NeZero p := ⟨hp.pos.ne'⟩
+      exact missing_class_of_card_lt hlt
+
+/- ## Examples -/
+
+/-- The empty set is admissible (it misses every class). -/
+theorem admissible_empty : Admissible (∅ : Finset ℕ) :=
+  fun p _ => ⟨0, by simp⟩
+
+/-- Every singleton is admissible: with only one element occupied there is
+nothing to check below `p = 2`, and `missing_class_of_card_lt` handles the rest. -/
+theorem admissible_singleton (n : ℕ) : Admissible ({n} : Finset ℕ) := by
+  rw [admissible_iff_card]
+  intro p hp hcard
+  rw [Finset.card_singleton] at hcard
+  -- p ≤ 1 contradicts p prime (p ≥ 2)
+  have := hp.two_le
+  exfalso; omega
+
+/-- `{0, 2}` is admissible: modulo 2 both elements are even, so the odd class
+is missed; modulo every larger prime the size bound applies. This is the
+smallest nontrivial admissible 2-tuple. -/
+theorem admissible_zero_two : Admissible ({0, 2} : Finset ℕ) := by
+  rw [admissible_iff_card]
+  intro p hp hcard
+  -- card {0,2} = 2, so the only prime to check is p = 2
+  have hc : ({0, 2} : Finset ℕ).card = 2 := by decide
+  rw [hc] at hcard
+  interval_cases p
+  · exact absurd hp (by decide)   -- p = 0
+  · exact absurd hp (by decide)   -- p = 1
+  · -- p = 2: miss the class 1
+    refine ⟨1, ?_⟩
+    intro x hx
+    fin_cases hx <;> decide
+
+/-- `{0, 1}` is **not** admissible: modulo 2 it occupies both residue classes,
+so no class is missed. -/
+theorem not_admissible_zero_one : ¬ Admissible ({0, 1} : Finset ℕ) := by
+  intro h
+  obtain ⟨r, hr⟩ := h 2 (by decide)
+  -- both residue classes 0 and 1 mod 2 are occupied, so no r is missed
+  fin_cases r
+  · exact (hr 0 (by decide)) (by decide)
+  · exact (hr 1 (by decide)) (by decide)
+
+/- ## Open Problems
+
+The asymptotic behaviour of the extremal quantities is OPEN:
+
+- **A(k)** = min a_k over admissible k-element sequences `0 ≤ a₁ < ⋯ < a_k`.
+  Is A(k) ∼ k log k? (The prime k-tuples heuristic suggests the minimal
+  diameter of an admissible k-tuple is ∼ k log k.)
+- **B(k)** = min (a₁ + ⋯ + a_k)/k over admissible k-element sequences.
+  Estimate B(k).
+
+These require analytic number theory (sieve methods, distribution of primes in
+residue classes) and are not formalized here.
+-/
+
+end Erdos1204

--- a/src/data/proofs/erdos-1204/annotations.json
+++ b/src/data/proofs/erdos-1204/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-e1204-imports",
+    "proofId": "erdos-1204",
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
+    "type": "concept",
+    "title": "Header and Imports",
+    "content": "**Erdős Problem #1204: Admissible Sequences**\n\nA finite set of naturals is *admissible* if it misses a residue class modulo every prime. This is the admissible-tuple notion from the Hardy–Littlewood prime k-tuples conjecture and bounded-gaps work.\n\nImports `Mathlib` for `ZMod`, `Finset`, and prime infrastructure.",
+    "mathContext": "Admissibility is the only local obstruction to a tuple being simultaneously prime infinitely often.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Admissible tuples",
+      "Prime k-tuples",
+      "Residue classes"
+    ],
+    "prerequisites": [
+      "Finite sets",
+      "Modular arithmetic",
+      "Prime numbers"
+    ]
+  },
+  {
+    "id": "ann-e1204-def",
+    "proofId": "erdos-1204",
+    "range": {
+      "startLine": 36,
+      "endLine": 40
+    },
+    "type": "definition",
+    "title": "Admissible",
+    "content": "**Admissible: The Main Definition**\n\n```lean\ndef Admissible (a : Finset ℕ) : Prop :=\n  ∀ p : ℕ, p.Prime → ∃ r : ZMod p, ∀ x ∈ a, (x : ZMod p) ≠ r\n```\n\nFor every prime p there is a residue class r mod p that no element of a hits.",
+    "mathContext": "Equivalently, the image of a in ZMod p is never all of ZMod p.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Residue classes",
+      "ZMod"
+    ],
+    "prerequisites": [
+      "ZMod",
+      "Finset"
+    ]
+  },
+  {
+    "id": "ann-e1204-reduction",
+    "proofId": "erdos-1204",
+    "range": {
+      "startLine": 56,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Reduction to small primes",
+    "content": "**The key structural fact.**\n\n`missing_class_of_card_lt`: if |a| < p then a misses a class mod p, because its image in ZMod p has at most |a| < p elements and so cannot be surjective.\n\n`admissible_iff_card`: therefore admissibility is equivalent to missing a class modulo every prime **p ≤ |a|** — larger primes impose no constraint.",
+    "mathContext": "This pigeonhole reduction is what makes admissibility a finite check and underlies all constructions of admissible tuples.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pigeonhole principle",
+      "Counting in ZMod"
+    ],
+    "prerequisites": [
+      "Finset.card",
+      "ZMod.card"
+    ]
+  },
+  {
+    "id": "ann-e1204-examples",
+    "proofId": "erdos-1204",
+    "range": {
+      "startLine": 88,
+      "endLine": 120
+    },
+    "type": "theorem",
+    "title": "Worked examples",
+    "content": "`∅`, `{0}`, and `{0,2}` are admissible; `{0,1}` is **not** admissible because it occupies both residue classes mod 2. The contrast `{0,2}` vs `{0,1}` shows why admissible patterns must avoid covering a small prime's classes.",
+    "mathContext": "{0,2} is the smallest nontrivial admissible 2-tuple.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Admissible tuples"
+    ],
+    "prerequisites": [
+      "ZMod 2"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "erdos-1204",
+  "title": "Erdős Problem #1204: Admissible Sequences",
+  "slug": "erdos-1204",
+  "description": "A sequence 0 ≤ a₁ < ⋯ < a_k is admissible if it misses a residue class modulo every prime. Estimate A(k)=min a_k (is A(k)∼k log k?) and B(k)=min(a₁+⋯+a_k)/k. Both estimates remain OPEN.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1204",
+    "date": "1204",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1204Problem.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "admissible-tuples",
+      "prime-k-tuples",
+      "sieve",
+      "residue-classes",
+      "open-problem"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "erdosNumber": 1204,
+    "erdosUrl": "https://erdosproblems.com/1204",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.card",
+        "description": "Fintype.card (ZMod n) = n for n ≠ 0",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "(s.image f).card ≤ s.card",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Finset.card_le_card",
+        "description": "monotonicity of card under ⊆",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.Prime",
+        "description": "Prime number predicate",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Admissible definition: a Finset ℕ misses a residue class mod every prime (the admissible-tuple notion from prime k-tuples / bounded gaps)",
+      "missing_class_of_card_lt: a set of size < p always misses a class mod p (image into ZMod p cannot be surjective)",
+      "admissible_iff_card: KEY REDUCTION — admissibility ⟺ missing a class modulo every prime p ≤ |a|; all larger primes are automatic",
+      "Worked examples: ∅, {0}, and {0,2} are admissible; {0,1} is NOT (it covers both classes mod 2)",
+      "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 137,
+    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved (#print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool). Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. The formalization here is the admissibility framework plus the standard reduction to small primes.",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**Erdős Problem #1204**\n\nThe notion of an *admissible* sequence (or k-tuple) is central to the Hardy–Littlewood prime k-tuples conjecture and to modern work on bounded gaps between primes (Zhang 2013, Maynard 2015, Polymath8). A k-tuple is admissible precisely when it does not occupy every residue class modulo some prime — the only local obstruction to all shifts being simultaneously prime infinitely often.\n\nErdős asks for the size of the minimal *diameter* A(k) of an admissible k-tuple, conjecturally A(k) ∼ k log k, and for the minimal average B(k).",
+    "problemStatement": "**Problem Statement (Open)**\n\nCall 0 ≤ a₁ < ⋯ < a_k *admissible* if for every prime p it misses at least one residue class mod p.\n\nLet A(k) = min a_k over admissible k-element sequences.\n\n1. Estimate A(k). Is A(k) ∼ k log k?\n2. Estimate B(k) = min (a₁ + ⋯ + a_k)/k.",
+    "text": "A sequence 0 ≤ a₁ < ⋯ < a_k is admissible if it misses a residue class modulo every prime. Estimate A(k)=min a_k (is A(k)∼k log k?) and B(k)=min(a₁+⋯+a_k)/k. Both estimates remain OPEN.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Definition:** `Admissible a` for `a : Finset ℕ` says that for every prime p there is a residue class `r : ZMod p` avoided by all elements of `a`.\n\n2. **Reduction to small primes:** For a prime p > |a|, the |a| elements occupy at most |a| < p of the p residue classes, so a class is automatically missed (`missing_class_of_card_lt`, via a counting/pigeonhole argument on the image in ZMod p). Hence admissibility only constrains primes p ≤ |a| (`admissible_iff_card`).\n\n3. **Examples:** ∅, {0}, {0,2} are admissible; {0,1} is not, since {0,1} covers both classes mod 2.\n\n4. **Open questions:** The asymptotics A(k) ∼ k log k and the estimate for B(k) are left as documented open problems — they require sieve-theoretic analytic number theory.",
+    "keyInsights": [
+      "**Local obstructions only:** admissibility is a purely local (mod-p) condition; a tuple fails iff some prime sees every residue.",
+      "**Only small primes matter:** for p > k there are more classes than elements, so a class is always free — admissibility reduces to primes p ≤ k.",
+      "**Minimal example:** {0,2} is admissible but {0,1} is not, because {0,1} hits both classes mod 2 (this is why twin-prime-like patterns must avoid such coverage).",
+      "**Connection:** this is exactly the admissible-tuple notion underlying bounded gaps between primes (Zhang, Maynard)."
+    ],
+    "prerequisites": [
+      "Number theory",
+      "Finite sets and counting",
+      "Modular arithmetic (ZMod)",
+      "Prime k-tuples / sieve heuristics"
+    ]
+  },
+  "sections": [],
+  "conclusion": {
+    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the standard reduction showing only primes p ≤ k impose constraints, and small worked examples. The asymptotic questions themselves remain open and are not asserted.",
+    "openQuestions": [
+      "Is A(k) ∼ k log k?",
+      "What is the correct order of B(k) = min (a₁+⋯+a_k)/k?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "Both problems are from Erdős's collection on combinatorial number theory and prime patterns.",
+      "targetId": "erdos-1"
+    }
+  ],
+  "references": [
+    {
+      "author": "Erdős, P.",
+      "title": "Problem 1204",
+      "year": "",
+      "venue": "erdosproblems.com",
+      "note": "Admissible sequences: estimate A(k) and B(k).",
+      "url": "https://erdosproblems.com/1204"
+    },
+    {
+      "author": "Hardy, G. H. and Littlewood, J. E.",
+      "title": "Some problems of 'Partitio numerorum' III: On the expression of a number as a sum of primes",
+      "year": "1923",
+      "venue": "Acta Mathematica",
+      "note": "Origin of admissible tuples and the prime k-tuples conjecture."
+    },
+    {
+      "author": "Maynard, J.",
+      "title": "Small gaps between primes",
+      "year": "2015",
+      "venue": "Annals of Mathematics",
+      "note": "Modern use of admissible tuples for bounded gaps."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1204",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1204Problem.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1204",
   "title": "Erdős #1204",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-04-16T17:08:10.942Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Formalized admissibility framework + reduction-to-small-primes lemma; asymptotic A(k),B(k) remain open.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Attempt to formalize bounds/constructions for A(k) (e.g. explicit admissible tuples) or relate B(k) to A(k).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEY/BUILD: defined Admissible (Finset ℕ misses a residue class mod every prime); proved missing_class_of_card_lt and the key reduction admissible_iff_card (only primes p ≤ |a| matter); verified examples ∅,{0},{0,2} admissible and {0,1} not. 6 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) estimates remain OPEN.",
+    "builtItems": [
+      "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
+      "Erdos1204.missing_class_of_card_lt",
+      "Erdos1204.admissible_iff_card (key reduction)",
+      "Erdos1204.admissible_zero_two / not_admissible_zero_one (examples)"
+    ],
+    "insights": [
+      "Admissibility is purely local: only the residue pattern mod each prime matters.",
+      "Reduction: for primes p > k, k elements cannot cover all p classes, so admissibility only constrains primes p ≤ k.",
+      "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Formalize explicit admissible-tuple constructions to bound A(k) above.",
+      "Investigate a lower-bound argument toward A(k) ≳ k log k."
+    ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },
   "tags": [
@@ -50,7 +62,7 @@
     "mathlib": []
   },
   "started": "2026-04-16T17:08:10.942Z",
-  "lastUpdate": "2026-04-21T11:09:40.249Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
   "significance": 7,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
New gallery entry for **Erdős Problem #1204** (admissible sequences; is A(k) ∼ k log k? estimate B(k)). This is an OPEN analytic-number-theory problem. This session formalizes the admissibility *framework* — definition, the standard reduction to small primes, and worked examples — all fully verified.

## What's formalized (`proofs/Proofs/Erdos1204Problem.lean`)
- **`def Admissible`** — a `Finset ℕ` misses a residue class modulo every prime. This is exactly the admissible-k-tuple notion underlying the Hardy–Littlewood prime k-tuples conjecture and bounded-gaps work (Zhang, Maynard).
- **`missing_class_of_card_lt`** — a set of size `< p` always misses a class mod `p`: its image in `ZMod p` has `< p` elements, so it can't be surjective (pigeonhole via `Finset.card_image_le` + `ZMod.card`).
- **`admissible_iff_card`** — the **key reduction**: admissibility ⟺ missing a class modulo every prime `p ≤ |a|`. Larger primes impose no constraint. This is what makes admissibility a finite check.
- **Examples** — `∅`, `{0}`, `{0,2}` are admissible; `{0,1}` is **not** (it covers both classes mod 2).

## Verification
- Compiles with offline `lake env lean Proofs/Erdos1204Problem.lean` (exit 0, no diagnostics). Docker daemon was unavailable this session, so `docker-build.sh` could not run; offline single-file elaboration against the prebuilt Mathlib oleans is equivalent for a self-contained file.
- `#print axioms` on every theorem shows only `propext` / `Classical.choice` / `Quot.sound` — **no `native_decide`, no `Lean.ofReduceBool`**. 0 `axiom` declarations, 0 sorries.

## Status
**Outcome**: surveyed/built — the framework is fully verified, but the headline asymptotics **A(k) ∼ k log k** and the estimate for **B(k)** remain **OPEN** and are documented, not asserted. `status: axiomatized`, `badge: wip` (mirrors other open-problem entries).
**Next Steps**: formalize explicit admissible-tuple constructions to bound A(k) above; pursue a lower-bound argument.

## Files
- `proofs/Proofs/Erdos1204Problem.lean` (new, 137 lines)
- `src/data/proofs/erdos-1204/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/erdos-1204.json` (knowledge update, phase OBSERVE→ORIENT)

🤖 Generated by researcher-7