### PR TITLE
research(erdos-1021-wip-01): local degree structure of pair graph G_k [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1021Wip01.lean
+++ b/proofs/Proofs/Erdos1021Wip01.lean
@@ -1,0 +1,217 @@
+/-
+# Erdős Problem #1021 — WIP-01
+## The local degree structure of the bipartite pair graph G_k
+
+Erdős Problem #1021 asks whether, for every `k ≥ 3`, there is `c_k > 0` with
+`ex(n, G_k) ≪ n^{3/2 - c_k}`. That question is OPEN and this file does NOT touch it.
+
+The existing files for this problem formalize the *asymptotic* boundary of the question
+(`Erdos1021OQ01Incomplete01.lean`: the o ⟹ O collapse, the exponent gap `1/(k-1)`, …)
+but say almost nothing, machine-checked, about the **actual combinatorial object `G_k`**
+beyond bipartiteness. This file fills that gap with **zero axioms and zero sorries**.
+
+It is deliberately **self-contained** (like the sibling `Incomplete01` file): it re-declares
+`G_k` locally rather than importing `Erdos1021Problem.lean`, whose `Gk_bipartite` has an
+`↔`-vs-`→` precedence bug and whose `cycleGraph` loopless proof no longer goes through under
+the current Mathlib. (Re-declaring is the same robustness choice `Incomplete01` made for the
+asymptotic definitions.)
+
+What is pinned down here — the local adjacency structure of `G_k`, which is precisely the
+structure that makes `n^{3/2}` the natural exponent:
+
+* `Gk_pair_adj_iff` / `Gk_primary_adj_iff` — exact adjacency characterizations on each side.
+* `Gk_pair_neighborSet` — every pair vertex `⟨{a,b}⟩` has neighbor set exactly `{y_a, y_b}`.
+* `Gk_pair_degree` — **every pair vertex has degree exactly `2`** (the pair side is
+  `2`-regular: each `z_j` is a "cherry" joining two primary vertices — the source of the
+  Kővári–Sós–Turán `n^{3/2}` behaviour).
+* `Gk_primary_neighborSet` / `Gk_primary_degree` — a primary vertex `y_i` is adjacent to
+  exactly the pair vertices containing `i`; **its degree is exactly `k - 1`** (bijection
+  with the other primaries `{j ≠ i}`).
+* `Gk_handshake` — `2·C(k,2) = k·(k-1)`, the degree-sum (handshake) consistency between the
+  two sides.
+
+None of this is asymptotic and none of it is assumed: elementary finite combinatorics about
+`G_k`, fully verified.
+
+## References
+- Kővári, T., Sós, V., Turán, P. (1954). "On a problem of K. Zarankiewicz." Coll. Math. 3.
+- Bondy, J.A., Simonovits, M. (1974). "Cycles of even length in graphs." JCTB 16.
+- https://erdosproblems.com/1021
+-/
+
+import Mathlib
+
+open SimpleGraph
+
+namespace Erdos1021Wip01
+
+variable {k : ℕ}
+
+/-! ## The bipartite pair graph G_k (local, self-contained definition)
+
+`G_k` has `k` "primary" vertices `Fin k` and `C(k,2)` "pair" vertices — unordered pairs
+`{a,b} ⊂ Fin k` encoded as ordered `(a,b)` with `a < b`. Each pair vertex is adjacent to
+exactly the two primary vertices of its pair. This matches `Erdos1021.Gk`. -/
+
+/-- The vertex type for `G_k`: a primary vertex (`Fin k`) or a pair vertex. -/
+abbrev Gk_vertex (k : ℕ) := Fin k ⊕ { p : Fin k × Fin k // p.1 < p.2 }
+
+/-- `G_k`: each pair vertex `⟨(a,b)⟩` is adjacent to exactly primary vertices `a` and `b`. -/
+def Gk (k : ℕ) : SimpleGraph (Gk_vertex k) where
+  Adj v w := match v, w with
+    | Sum.inl i, Sum.inr ⟨(a, b), _⟩ => i = a ∨ i = b
+    | Sum.inr ⟨(a, b), _⟩, Sum.inl i => i = a ∨ i = b
+    | _, _ => False
+  symm := by
+    intro v w h
+    rcases v with i | ⟨⟨a, b⟩, hab⟩ <;> rcases w with j | ⟨⟨c, d⟩, hcd⟩ <;> exact h
+  loopless := by
+    intro v h
+    rcases v with i | ⟨⟨a, b⟩, hab⟩ <;> exact h
+
+/-! ## Part I: Exact adjacency characterizations -/
+
+/-- A pair vertex `⟨{a,b}⟩` is adjacent in `G_k` to exactly the two primary vertices
+    `y_a` and `y_b`. -/
+theorem Gk_pair_adj_iff (a b : Fin k) (hab : a < b) (w : Gk_vertex k) :
+    (Gk k).Adj (Sum.inr ⟨(a, b), hab⟩) w ↔ w = Sum.inl a ∨ w = Sum.inl b := by
+  cases w with
+  | inl i => simp only [Gk, Sum.inl.injEq]
+  | inr q =>
+      simp only [Gk]
+      constructor
+      · exact False.elim
+      · rintro (h | h) <;> exact (Sum.inr_ne_inl h).elim
+
+/-- A primary vertex `y_i` is adjacent in `G_k` to exactly the pair vertices whose pair
+    contains `i`. -/
+theorem Gk_primary_adj_iff (i : Fin k) (w : Gk_vertex k) :
+    (Gk k).Adj (Sum.inl i) w ↔
+      ∃ q : { p : Fin k × Fin k // p.1 < p.2 }, w = Sum.inr q ∧ (i = q.val.1 ∨ i = q.val.2) := by
+  cases w with
+  | inl j =>
+      simp only [Gk]
+      constructor
+      · exact False.elim
+      · rintro ⟨q, hq, _⟩; exact (Sum.inl_ne_inr hq).elim
+  | inr q =>
+      obtain ⟨⟨a, b⟩, hab⟩ := q
+      simp only [Gk, Sum.inr.injEq]
+      constructor
+      · intro h; exact ⟨⟨(a, b), hab⟩, rfl, h⟩
+      · rintro ⟨q', hq', h⟩
+        obtain ⟨⟨a', b'⟩, hab'⟩ := q'
+        cases hq'; exact h
+
+/-! ## Part II: The pair side is 2-regular -/
+
+/-- The neighbor set of a pair vertex is exactly `{y_a, y_b}`. -/
+theorem Gk_pair_neighborSet (a b : Fin k) (hab : a < b) :
+    (Gk k).neighborSet (Sum.inr ⟨(a, b), hab⟩) = {Sum.inl a, Sum.inl b} := by
+  ext w
+  simp only [mem_neighborSet, Set.mem_insert_iff, Set.mem_singleton_iff, Gk_pair_adj_iff a b hab]
+
+/-- **Every pair vertex of `G_k` has degree exactly `2`.**
+    Each `z_j` joins precisely the two primary vertices of its pair, so the pair side of
+    `G_k` is `2`-regular. This is the local "cherry" structure behind the `n^{3/2}` exponent. -/
+theorem Gk_pair_degree (a b : Fin k) (hab : a < b) :
+    ((Gk k).neighborSet (Sum.inr ⟨(a, b), hab⟩)).ncard = 2 := by
+  rw [Gk_pair_neighborSet a b hab]
+  refine Set.ncard_pair ?_
+  intro h
+  exact (ne_of_lt hab) (Sum.inl_injective h)
+
+/-! ## Part III: The primary side has degree `k - 1` -/
+
+/-- The neighbor set of a primary vertex `y_i` is exactly the set of pair vertices whose
+    pair contains `i`. -/
+theorem Gk_primary_neighborSet (i : Fin k) :
+    (Gk k).neighborSet (Sum.inl i) =
+      {w | ∃ q : { p : Fin k × Fin k // p.1 < p.2 },
+              w = Sum.inr q ∧ (i = q.val.1 ∨ i = q.val.2)} := by
+  ext w
+  simp only [mem_neighborSet, Set.mem_setOf_eq, Gk_primary_adj_iff i w]
+
+/-- The pair vertex determined by `i` and a distinct primary `j`:
+    `{i, j}` ordered so the smaller index comes first. -/
+private def mkPair (i j : Fin k) (hij : i ≠ j) : { p : Fin k × Fin k // p.1 < p.2 } :=
+  if h : i < j then ⟨(i, j), h⟩ else ⟨(j, i), lt_of_le_of_ne (not_lt.mp h) (fun e => hij e.symm)⟩
+
+/-- **Every primary vertex of `G_k` has degree exactly `k - 1`.**
+    `y_i` is adjacent to the `k - 1` pair vertices `{i, j}` over the other primaries `j ≠ i`.
+    Proved by exhibiting a bijection from `{j : Fin k // j ≠ i}` onto the neighbor set. -/
+theorem Gk_primary_degree (i : Fin k) :
+    ((Gk k).neighborSet (Sum.inl i)).ncard = k - 1 := by
+  classical
+  rw [Gk_primary_neighborSet i]
+  have hcard : Fintype.card { j : Fin k // j ≠ i } = k - 1 := by
+    simp [Fintype.card_subtype_compl]
+  have himg :
+      {w : Gk_vertex k | ∃ q : { p : Fin k × Fin k // p.1 < p.2 },
+            w = Sum.inr q ∧ (i = q.val.1 ∨ i = q.val.2)}
+        = (fun j : { j : Fin k // j ≠ i } =>
+            (Sum.inr (mkPair i j.1 (fun e => j.2 e.symm)) : Gk_vertex k)) '' Set.univ := by
+    ext w
+    constructor
+    · rintro ⟨⟨⟨a, b⟩, hab⟩, rfl, hi | hi⟩
+      · -- i = a; the other element is b, and mkPair i b = ⟨(i,b),hab⟩
+        subst hi
+        have hbi : b ≠ i := (ne_of_lt hab).symm
+        refine ⟨⟨b, hbi⟩, Set.mem_univ _, ?_⟩
+        simp only [mkPair, dif_pos hab]
+      · -- i = b; the other element is a, and mkPair i a = ⟨(a,i),hab⟩
+        subst hi
+        have hai : a ≠ i := ne_of_lt hab
+        refine ⟨⟨a, hai⟩, Set.mem_univ _, ?_⟩
+        have hnia : ¬ i < a := not_lt.mpr (le_of_lt hab)
+        simp only [mkPair, dif_neg hnia]
+    · rintro ⟨⟨j, hj⟩, _, rfl⟩
+      refine ⟨mkPair i j (fun e => hj e.symm), rfl, ?_⟩
+      by_cases h : i < j
+      · simp [mkPair, dif_pos h]
+      · simp [mkPair, dif_neg h]
+  have hinj : Function.Injective
+      (fun j : { j : Fin k // j ≠ i } =>
+        (Sum.inr (mkPair i j.1 (fun e => j.2 e.symm)) : Gk_vertex k)) := by
+    rintro ⟨j₁, hj₁⟩ ⟨j₂, hj₂⟩ h
+    simp only [Sum.inr.injEq] at h
+    have key : j₁ = j₂ := by
+      unfold mkPair at h
+      by_cases h1 : i < j₁ <;> by_cases h2 : i < j₂
+      · rw [dif_pos h1, dif_pos h2, Subtype.mk.injEq, Prod.mk.injEq] at h; exact h.2
+      · rw [dif_pos h1, dif_neg h2, Subtype.mk.injEq, Prod.mk.injEq] at h
+        exact absurd h.1.symm hj₂
+      · rw [dif_neg h1, dif_pos h2, Subtype.mk.injEq, Prod.mk.injEq] at h
+        exact absurd h.1 hj₁
+      · rw [dif_neg h1, dif_neg h2, Subtype.mk.injEq, Prod.mk.injEq] at h; exact h.1
+    exact Subtype.ext key
+  rw [himg, Set.ncard_image_of_injective _ hinj, Set.ncard_univ,
+      Nat.card_eq_fintype_card, hcard]
+
+/-! ## Part IV: Handshake consistency -/
+
+/-- The two sides of `G_k` agree under the handshake lemma: the `C(k,2)` pair vertices each
+    contribute degree `2`, the `k` primary vertices each contribute degree `k - 1`, and these
+    totals coincide: `2·C(k,2) = k·(k-1)`. -/
+theorem Gk_handshake (k : ℕ) :
+    2 * Nat.choose k 2 = k * (k - 1) := by
+  rw [Nat.choose_two_right]
+  have h : 2 ∣ k * (k - 1) := by
+    rcases Nat.even_or_odd k with he | ho
+    · exact he.two_dvd.mul_right _
+    · exact (Nat.Odd.sub_odd ho odd_one).two_dvd.mul_left _
+  rw [Nat.mul_div_cancel' h]
+
+/-! ## Part V: Summary
+
+Proved here (0 axioms, 0 sorries), all about the *actual* graph `G_k`:
+* `Gk_pair_adj_iff`, `Gk_primary_adj_iff` — exact adjacency on each side.
+* `Gk_pair_neighborSet`, `Gk_pair_degree` — pair side is `2`-regular (degree `2`).
+* `Gk_primary_neighborSet`, `Gk_primary_degree` — primary side has degree `k - 1`.
+* `Gk_handshake` — `2·C(k,2) = k·(k-1)`, the degree-sum consistency.
+
+NOT addressed (genuinely open / external): OQ-01 `ex(n, G_k) = o(n^{3/2})`, the KST upper
+bound, and the probabilistic lower bound. Those live in the sibling files and remain open.
+-/
+
+end Erdos1021Wip01

--- a/research/problems/erdos-1021-wip-01/knowledge.md
+++ b/research/problems/erdos-1021-wip-01/knowledge.md
@@ -1,0 +1,38 @@
+# Knowledge: erdos-1021-wip-01
+
+## Status: COMPLETED (verified, 0 axioms, 0 sorries)
+
+Created `proofs/Proofs/Erdos1021Wip01.lean` — a self-contained, Mathlib-only, fully
+verified account of the **local degree structure** of the bipartite pair graph G_k from
+Erdős #1021. It does NOT resolve the open question; it machine-checks concrete
+combinatorial facts about the actual graph object G_k that the existing files (which
+focus on the asymptotic boundary) never established.
+
+### Proved (7 theorems, 3 defs, 0 axioms, 0 sorries)
+- `Gk_pair_adj_iff`: pair vertex {a,b} ~ w ⟺ w ∈ {y_a, y_b}.
+- `Gk_primary_adj_iff`: primary y_i ~ w ⟺ w is a pair vertex containing i.
+- `Gk_pair_neighborSet`: N(z_{a,b}) = {y_a, y_b}.
+- `Gk_pair_degree`: **every pair vertex has degree exactly 2** (pair side is 2-regular —
+  the "cherry" structure behind the n^{3/2} KST exponent).
+- `Gk_primary_neighborSet`: N(y_i) = pair vertices containing i.
+- `Gk_primary_degree`: **every primary vertex has degree exactly k-1** (bijection with the
+  other primaries {j ≠ i} via j ↦ {i,j}).
+- `Gk_handshake`: 2·C(k,2) = k·(k-1) (degree-sum consistency, ⇒ |E(G_k)| = k(k-1)).
+
+### Key gotchas
+- The parent `Erdos1021Problem.lean` does NOT compile under Mathlib 4.26.0:
+  `Gk_bipartite` has an `↔`-vs-`→` precedence bug (`A → B ↔ C` parses as `(A→B)↔C`, so
+  `intro v w h` fails), and `cycleGraph`'s loopless `omega` no longer closes. So this file
+  re-declares G_k locally (same self-contained choice the sibling Incomplete01 made).
+  **Future: a Mechanic could fix the parent's precedence bug and omega failure.**
+- `rw [hi]` (hi : i = a) on a subtype-valued goal fails with "motive is not type correct"
+  because of the dependent pair-order proof; use `subst hi` and let proof irrelevance close
+  the subtype equality instead.
+- After `simp only [mkPair, dif_pos h]`, `i = i` is rewritten to `True`, so `exact Or.inl rfl`
+  fails — use full `simp [...]` to discharge the `True ∨ _` disjunction.
+- Primary-degree count: `Set.ncard_image_of_injective` + `Set.ncard_univ` +
+  `Nat.card_eq_fintype_card` + `Fintype.card_subtype_compl` gives k-1.
+
+### NOT addressed (open / external)
+- OQ-01 `ex(n, G_k) = o(n^{3/2})` for k ≥ 4 (OPEN).
+- KST upper bound and probabilistic lower bound (deep external inputs, not assumed).

--- a/src/data/proofs/erdos-1021-wip-01/meta.json
+++ b/src/data/proofs/erdos-1021-wip-01/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "erdos-1021-wip-01",
+  "title": "The Local Degree Structure of the Bipartite Pair Graph G_k (Erdős #1021)",
+  "slug": "erdos-1021-wip-01",
+  "description": "A fully verified (0-axiom, 0-sorry) account of the local combinatorial structure of the bipartite pair graph G_k from Erdős #1021. Where the sibling files formalize the asymptotic boundary of the open question, this file pins down the actual graph object: each pair vertex has degree exactly 2 (the pair side is 2-regular — the 'cherry' structure behind the n^{3/2} exponent), each primary vertex has degree exactly k-1, and the two degree counts satisfy the handshake identity 2·C(k,2) = k·(k-1).",
+  "meta": {
+    "author": "Research formalization 2026 (researcher-1)",
+    "sourceUrl": "https://erdosproblems.com/1021",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1021Wip01.lean",
+    "tags": [
+      "graph-theory",
+      "extremal-combinatorics",
+      "erdos",
+      "zarankiewicz",
+      "regular-graphs",
+      "handshake-lemma"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 217,
+    "assumptions": "None. Every theorem is elementary finite combinatorics about the graph G_k, with zero axioms and zero sorries (only the foundational propext/Classical.choice/Quot.sound). The open question of Erdős #1021 (and the deep KST upper bound / probabilistic lower bound) is deliberately NOT assumed or addressed here.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1021 asks whether ex(n, G_k) ≪ n^{3/2-c_k} for some c_k > 0, where G_k is the bipartite 'pair graph': k primary vertices and C(k,2) pair vertices, each pair vertex joined to exactly the two primary vertices of its pair. The existing formalizations (Erdos1021Problem.lean, Erdos1021OQ01.lean, Erdos1021OQ01Incomplete01.lean) concentrate on the asymptotic side of the question but prove almost nothing, machine-checked, about the actual graph G_k beyond bipartiteness. This file supplies that missing local structure.",
+    "problemStatement": "What is the exact local degree/neighborhood structure of the bipartite pair graph G_k? Specifically: the neighbor set and degree of a pair vertex, the neighbor set and degree of a primary vertex, and the handshake consistency between the two sides.",
+    "text": "A 0-axiom, 0-sorry description of G_k: pair vertices have degree 2, primary vertices have degree k-1, and 2·C(k,2) = k·(k-1).",
+    "proofStrategy": "Self-contained in namespace Erdos1021Wip01, importing only Mathlib. It re-declares G_k locally (the parent Erdos1021Problem.lean does not currently compile: Gk_bipartite has an ↔-vs-→ precedence bug and cycleGraph's loopless proof no longer goes through). Part I proves the exact adjacency characterizations on each side by case analysis on the Sum vertex type. Part II derives the pair-vertex neighbor set {y_a, y_b} and hence degree 2 via Set.ncard_pair. Part III characterizes the primary neighbor set and counts it as k-1 by building an explicit bijection j ↦ {i,j} from the other primaries {j ≠ i}, using Set.ncard_image_of_injective and Fintype.card_subtype_compl. Part IV records the handshake identity 2·C(k,2)=k·(k-1) via Nat.choose_two_right and divisibility of k·(k-1) by 2.",
+    "keyInsights": [
+      "**The pair side is 2-regular**: every pair vertex z_j is adjacent to exactly the two primary vertices of its pair, so it is a 'cherry' (path of length 2). This 2-regularity is precisely the structure that makes n^{3/2} the natural (Kővári-Sós-Turán) exponent for G_k.",
+      "**The primary side has uniform degree k-1**: each primary vertex y_i lies in exactly the k-1 pairs containing i, established by an explicit order-respecting bijection with the other primaries.",
+      "**Handshake consistency**: the pair side contributes 2·C(k,2) edge-endpoints and the primary side contributes k·(k-1); these agree, 2·C(k,2)=k·(k-1), confirming |E(G_k)| = k(k-1).",
+      "**Honest boundary**: this file proves only finite structural facts about G_k; the open question ex(n,G_k)=o(n^{3/2}) and the deep KST/probabilistic bounds are not assumed or touched."
+    ],
+    "prerequisites": [
+      "Simple graphs and neighbor sets (SimpleGraph.neighborSet)",
+      "Sum types and subtype encodings of unordered pairs",
+      "Set cardinality (Set.ncard) and finite bijections",
+      "Binomial coefficients and the handshake lemma"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-definition",
+      "title": "Module Header and the Graph G_k",
+      "startLine": 1,
+      "endLine": 73,
+      "summary": "Docstring framing the file as verified local structure around the open Erdős #1021, plus the self-contained definition of the vertex type and the graph G_k."
+    },
+    {
+      "id": "adjacency",
+      "title": "Exact Adjacency Characterizations",
+      "startLine": 74,
+      "endLine": 107,
+      "summary": "Gk_pair_adj_iff and Gk_primary_adj_iff: a pair vertex is adjacent to exactly its two primary endpoints, and a primary vertex to exactly the pair vertices containing it.",
+      "mathContext": "$z_{\\{a,b\\}} \\sim w \\iff w \\in \\{y_a, y_b\\}$; $y_i \\sim w \\iff w = z_{\\{a,b\\}}$ with $i \\in \\{a,b\\}$."
+    },
+    {
+      "id": "pair-degree",
+      "title": "The Pair Side is 2-Regular",
+      "startLine": 108,
+      "endLine": 126,
+      "summary": "Gk_pair_neighborSet computes the neighbor set as {y_a, y_b}; Gk_pair_degree concludes the pair vertex has degree exactly 2.",
+      "mathContext": "$|N(z_{\\{a,b\\}})| = |\\{y_a,y_b\\}| = 2$."
+    },
+    {
+      "id": "primary-degree",
+      "title": "The Primary Side has Degree k-1",
+      "startLine": 127,
+      "endLine": 194,
+      "summary": "Gk_primary_neighborSet characterizes the neighbor set of y_i; Gk_primary_degree counts it as k-1 via an explicit bijection j ↦ {i,j} from the k-1 other primaries.",
+      "mathContext": "$|N(y_i)| = |\\{j : j \\ne i\\}| = k - 1$."
+    },
+    {
+      "id": "handshake",
+      "title": "Handshake Consistency",
+      "startLine": 195,
+      "endLine": 217,
+      "summary": "Gk_handshake: the two degree totals coincide, 2·C(k,2) = k·(k-1).",
+      "mathContext": "$2\\binom{k}{2} = k(k-1)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file verifies, with zero axioms and zero sorries, the complete local degree structure of the bipartite pair graph G_k of Erdős #1021: pair vertices have degree 2 (the pair side is 2-regular), primary vertices have degree k-1, and the handshake identity 2·C(k,2)=k·(k-1) holds.",
+    "implications": "It supplies the concrete combinatorial substrate the asymptotic files lacked. The 2-regularity of the pair side is exactly the 'cherry' structure that drives the Kővári-Sós-Turán n^{3/2} bound, making this the natural foundation for any future Lean attack on the extremal exponent.",
+    "openQuestions": [
+      "Does ex(n, G_k) = o(n^{3/2}) for some/every k ≥ 4? (still open)",
+      "Can the cherry (2-regular) structure of the pair side be leveraged into a verified n^{3/2} upper bound for ex(n, G_k)?",
+      "Is G_3 ≅ C_6 provable in Lean from this adjacency description (k=3 case)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1021-oq-01-incomplete-01",
+      "relationship": "complements",
+      "description": "Sibling verified scaffolding: where Incomplete01 handles the asymptotic boundary (o⟹O, the exponent gap), this file handles the local combinatorial structure of the graph G_k itself."
+    },
+    {
+      "targetId": "erdos-1021-oq-01",
+      "relationship": "extends",
+      "description": "Parent OQ-01 survey of Erdős #1021; this file adds verified structural facts about G_k that the survey did not establish."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kővári, T., Sós, V., Turán, P.",
+      "title": "On a problem of K. Zarankiewicz",
+      "year": "1954",
+      "venue": "Colloquium Mathematicum 3:50–57",
+      "note": "KST theorem; the 2-regular pair side of G_k underlies its O(n^{3/2}) bound"
+    },
+    {
+      "authors": "Bondy, J.A., Simonovits, M.",
+      "title": "Cycles of even length in graphs",
+      "year": "1974",
+      "venue": "Journal of Combinatorial Theory, Series B, 16(2):97–105",
+      "note": "Settles the k=3 case via ex(n, C_6) ≪ n^{7/6}"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1021Wip01",
+    "lineCount": 217,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "path": "Proofs/Erdos1021Wip01.lean",
+    "sorries": 0,
+    "definitionCount": 3,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1021-wip-01.json
+++ b/src/data/research/problems/erdos-1021-wip-01.json
@@ -1,0 +1,57 @@
+{
+  "slug": "erdos-1021-wip-01",
+  "title": "Local Degree Structure of the Bipartite Pair Graph G_k (Erdős #1021)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "verified",
+  "path": "full",
+  "problemStatement": "Pin down, with full machine verification, the local combinatorial structure of the bipartite pair graph G_k from Erdős #1021: the neighbor sets and degrees of pair and primary vertices, and the handshake consistency between them.",
+  "knownResults": "Erdős #1021 (does ex(n,G_k) ≪ n^{3/2-c_k}?) is OPEN. The trivial upper bound ex(n,G_k)=O(n^{3/2}) comes from Kővári-Sós-Turán; a probabilistic lower bound gives ex(n,G_k) ≫ n^{3/2-1/(k-1)}. The k=3 case (G_3≅C_6) is settled by Bondy-Simonovits (n^{7/6}).",
+  "currentState": "Verified, 0 axioms, 0 sorries. The graph G_k's local structure is now fully formalized: pair vertices have degree 2 (2-regular pair side), primary vertices have degree k-1, and 2·C(k,2)=k·(k-1).",
+  "knowledge": {
+    "progressSummary": "COMPLETED: Created Erdos1021Wip01.lean (7 theorems, 3 defs, 0 axioms, 0 sorries) establishing the exact neighbor sets and degrees of G_k. Pair side is 2-regular (degree 2 — the cherry structure behind the n^{3/2} exponent); primary side has degree k-1 via an explicit bijection; handshake identity 2·C(k,2)=k·(k-1) confirms |E(G_k)|=k(k-1).",
+    "builtItems": [
+      "Gk_pair_adj_iff in Erdos1021Wip01.lean:76 — pair vertex adjacency characterization",
+      "Gk_primary_adj_iff in Erdos1021Wip01.lean:88 — primary vertex adjacency characterization",
+      "Gk_pair_neighborSet in Erdos1021Wip01.lean:109 — N(z_{a,b}) = {y_a, y_b}",
+      "Gk_pair_degree in Erdos1021Wip01.lean:117 — every pair vertex has degree 2",
+      "Gk_primary_neighborSet in Erdos1021Wip01.lean:128 — N(y_i) characterization",
+      "Gk_primary_degree in Erdos1021Wip01.lean:143 — every primary vertex has degree k-1",
+      "Gk_handshake in Erdos1021Wip01.lean:196 — 2·C(k,2) = k·(k-1)"
+    ],
+    "insights": [
+      "The pair side of G_k is 2-regular: each pair vertex is a 'cherry' joining two primaries. This is exactly the structure that makes n^{3/2} the natural KST exponent for G_k.",
+      "The primary side is (k-1)-regular: y_i lies in precisely the k-1 pairs containing i, proved by an explicit order-respecting bijection j ↦ {i,j} from the other primaries.",
+      "The two degree counts are handshake-consistent: 2·C(k,2)=k·(k-1), so |E(G_k)|=k(k-1).",
+      "The parent Erdos1021Problem.lean does not compile under Mathlib 4.26.0 (Gk_bipartite ↔-vs-→ precedence bug; cycleGraph omega failure), so the file re-declares G_k locally like the sibling Incomplete01."
+    ],
+    "mathlibGaps": [
+      "No Mathlib gap encountered; all proofs are elementary finite combinatorics (Set.ncard, Fintype.card_subtype_compl, Nat.choose_two_right)."
+    ],
+    "nextSteps": [
+      "A Mechanic could repair the parent Erdos1021Problem.lean (fix the Gk_bipartite precedence bug and the cycleGraph loopless omega).",
+      "Attempt G_3 ≅ C_6 from this adjacency description (settles the k=3 case constructively).",
+      "Leverage the 2-regular pair side toward a verified n^{3/2} upper bound for ex(n, G_k)."
+    ]
+  },
+  "tags": [
+    "graph-theory",
+    "extremal-combinatorics",
+    "erdos",
+    "zarankiewicz",
+    "regular-graphs",
+    "handshake-lemma"
+  ],
+  "relatedProofs": [
+    "erdos-1021-oq-01-incomplete-01",
+    "erdos-1021-oq-01"
+  ],
+  "references": [
+    "Kővári, Sós, Turán (1954), On a problem of K. Zarankiewicz",
+    "Bondy, Simonovits (1974), Cycles of even length in graphs"
+  ],
+  "started": "2026-06-15T00:27:06.648Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
+  "significance": "Supplies the concrete combinatorial substrate (degree/neighborhood structure of G_k) that the asymptotic formalizations of Erdős #1021 lacked.",
+  "tractability": "verified"
+}


### PR DESCRIPTION
## Summary
Research session for **erdos-1021-wip-01** (Erdős Problem #1021, bipartite pair graph G_k).

Adds `proofs/Proofs/Erdos1021Wip01.lean` — a self-contained, Mathlib-only, **fully verified (0 axioms, 0 sorries)** account of the *local degree structure* of G_k. The existing files for this problem formalize only the asymptotic boundary; nothing machine-checked described the actual graph object beyond bipartiteness. This fills that gap.

## Proved (7 theorems, 3 defs, 0 axioms, 0 sorries)
- `Gk_pair_adj_iff` / `Gk_primary_adj_iff` — exact adjacency on each bipartition side.
- `Gk_pair_neighborSet` + `Gk_pair_degree` — **every pair vertex has degree exactly 2** (the pair side is 2-regular: each `z_j` is a "cherry" joining two primaries — the structure behind the n^{3/2} Kővári–Sós–Turán exponent).
- `Gk_primary_neighborSet` + `Gk_primary_degree` — **every primary vertex has degree exactly k−1**, via an explicit bijection `j ↦ {i,j}` with the other primaries.
- `Gk_handshake` — `2·C(k,2) = k·(k−1)`, the degree-sum consistency ⇒ `|E(G_k)| = k(k−1)`.

`#print axioms` on every theorem shows only the foundational `propext`/`Classical.choice`/`Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).

## Findings
- The parent `Erdos1021Problem.lean` does **not** compile under Mathlib 4.26.0: `Gk_bipartite` has an `↔`-vs-`→` precedence bug (`A → B ↔ C` parses as `(A→B) ↔ C`, so `intro v w h` fails) and `cycleGraph`'s loopless `omega` no longer closes. This file therefore re-declares `G_k` locally — the same robustness choice the sibling `Incomplete01` made. (Flagged in knowledge.md as a Mechanic follow-up.)
- Subtype-valued goals: `rw [hi]` triggers "motive is not type correct" on the dependent pair-order proof; `subst` + proof irrelevance is the fix.

## Files
- `proofs/Proofs/Erdos1021Wip01.lean` (new, verified)
- `src/data/proofs/erdos-1021-wip-01/meta.json` (gallery entry)
- `src/data/research/problems/erdos-1021-wip-01.json` (research record)
- `research/problems/erdos-1021-wip-01/knowledge.md` (session notes)

## Status
**Outcome**: completed (verified, 0 axioms, 0 sorries)
**Does NOT** resolve the open question `ex(n,G_k)=o(n^{3/2})` or assume the KST/probabilistic bounds.
**Next steps**: repair parent `Erdos1021Problem.lean`; attempt `G_3 ≅ C_6` from this adjacency description.

🤖 Generated by researcher-1