### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01): matching lower bound + two-sided sandwich for the p-series tail [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -168,6 +168,7 @@ import Proofs.AngleTrisectionOQ05OQ03
 import Proofs.AngleTrisectionOQ05OQ04
 import Proofs.AntitoneIntegralSumComparisonOQ01OQ01
 import Proofs.AntitoneIntegralSumComparisonOQ01OQ01OQ02
+import Proofs.AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01
 import Proofs.AntitoneIntegralSumComparisonOQ01OQ02
 import Proofs.ArchimedesMethodOfExhaustion
 import Proofs.AreaFromCircumferenceIntegral

--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,194 @@
+import Mathlib
+import Proofs.AntitoneIntegralSumComparisonOQ01OQ01OQ02
+
+/-
+# Matching lower bound and two-sided sandwich for the p-series tail
+
+The parent file `AntitoneIntegralSumComparisonOQ01OQ01OQ02` proved the **upper**
+remainder bound for the p-series via the antitone integral test: for `p > 1` and `N ≥ 1`,
+
+  ∑_{n > N} 1/nᵖ  ≤  ∫_N^∞ x^{−p} dx  =  N^{1−p}/(p−1).
+
+That file's own open question asks for the **matching lower bound**, obtained from the
+*left* Riemann sum instead of the right one.  A decreasing function over-estimates its
+integral when sampled at left endpoints, so
+
+  ∑_{n > N} 1/nᵖ  ≥  ∫_{N+1}^∞ x^{−p} dx  =  (N+1)^{1−p}/(p−1).
+
+This file proves that lower bound and assembles the two-sided **sandwich**
+
+  (N+1)^{1−p}/(p−1)  ≤  ∑_{n > N} 1/nᵖ  ≤  N^{1−p}/(p−1),
+
+pinning the remainder between two consecutive values of the same primitive
+`x ↦ x^{1−p}/(p−1)` and confirming its leading order is exactly `N^{1−p}`.
+
+For the Basel exponent `p = 2` the sandwich collapses to the textbook estimate
+
+  1/(N+1)  ≤  ∑_{n > N} 1/n²  ≤  1/N.
+
+Results (all fully machine-verified, 0 sorries, 0 axioms):
+
+* `pseries_tail_partial_ge`  — every finite tail partial sum dominates the integral
+  `∫_{N+1}^{N+1+m} x^{−p} dx`, i.e. `((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1) ≤ ∑_{i<m} 1/(N+1+i)ᵖ`.
+* `pseries_tail_tsum_ge`  — passing to the limit, `(N+1)^{1−p}/(p−1) ≤ ∑'_i 1/(N+1+i)ᵖ`.
+* `pseries_tail_ge_explicit`  — the textbook form `1/((p−1)·(N+1)^{p−1}) ≤ tail`.
+* `pseries_tail_sandwich`  — the two-sided bound, combining the new lower bound with the
+  parent's upper bound.
+-/
+
+namespace AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01
+
+open scoped BigOperators
+open Finset intervalIntegral Filter Topology
+
+/-! ## The tail partial-sum lower bound -/
+
+/-- **Tail partial-sum lower bound.**  For `p > 1` and `N ≥ 1`, every finite tail
+`∑_{i<m} 1/(N+1+i)ᵖ` dominates the integral `∫_{N+1}^{N+1+m} x^{−p} dx`, whose value is
+`((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1)`.  This is the antitone integral test applied to
+`1/xᵖ` on `[N+1, N+1+m]` in its *left*-Riemann form (`AntitoneOn.integral_le_sum`): a
+decreasing function over-estimates its integral on left endpoints. -/
+theorem pseries_tail_partial_ge (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) (m : ℕ) :
+    (((N : ℝ) + 1) ^ (1 - p) - (((N : ℝ) + 1) + (m : ℝ)) ^ (1 - p)) / (p - 1)
+      ≤ ∑ i ∈ Finset.range m, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by
+  have hp0 : (0 : ℝ) < p := by linarith
+  have hN1pos : (0 : ℝ) < (N : ℝ) + 1 := by positivity
+  -- `1/xᵖ` is antitone on `[N+1, N+1+m]`.
+  have hanti : AntitoneOn (fun x : ℝ => 1 / x ^ p)
+      (Set.Icc ((N : ℝ) + 1) (((N : ℝ) + 1) + (m : ℝ))) := by
+    intro x hx y _ hxy
+    have hx0 : (0 : ℝ) < x := lt_of_lt_of_le hN1pos hx.1
+    exact one_div_le_one_div_of_le (Real.rpow_pos_of_pos hx0 p)
+      (Real.rpow_le_rpow hx0.le hxy hp0.le)
+  -- Rewrite `1/xᵖ` as `x^{−p}` on the interval, to use `integral_rpow`.
+  have hcongr : (∫ x in ((N : ℝ) + 1)..((N : ℝ) + 1) + (m : ℝ), 1 / x ^ p)
+      = ∫ x in ((N : ℝ) + 1)..((N : ℝ) + 1) + (m : ℝ), x ^ (-p) := by
+    refine intervalIntegral.integral_congr (fun x hx => ?_)
+    rw [Set.uIcc_of_le (le_add_of_nonneg_right (by positivity))] at hx
+    have hx0 : (0 : ℝ) < x := lt_of_lt_of_le hN1pos hx.1
+    rw [Real.rpow_neg hx0.le, one_div]
+  -- Evaluate the integral.
+  have hint : (∫ x in ((N : ℝ) + 1)..((N : ℝ) + 1) + (m : ℝ), 1 / x ^ p)
+      = ((((N : ℝ) + 1) + (m : ℝ)) ^ (-p + 1) - ((N : ℝ) + 1) ^ (-p + 1)) / (-p + 1) := by
+    rw [hcongr, integral_rpow (Or.inr ⟨ne_of_lt (by linarith),
+      Set.notMem_uIcc_of_lt hN1pos
+        (lt_of_lt_of_le hN1pos (le_add_of_nonneg_right (by positivity)))⟩)]
+  -- The integral test (left Riemann sum): the integral underestimates the sum.
+  have key := hanti.integral_le_sum
+  -- Reconcile the summation index `(N+1) + i` with `i + (N+1)`.
+  have hsum_eq : (∑ i ∈ Finset.range m, 1 / (((N : ℝ) + 1) + (i : ℝ)) ^ p)
+      = ∑ i ∈ Finset.range m, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [show (((N : ℝ) + 1) + (i : ℝ)) = (((i + (N + 1) : ℕ)) : ℝ) by push_cast; ring]
+  rw [hint, hsum_eq] at key
+  -- `key : (integral value) ≤ ∑_{i<m} 1/(i+(N+1))ᵖ`.  Now match the LHS.
+  refine le_trans ?_ key
+  rw [show (-p + 1) = (1 - p) by ring]
+  have hp1ne : (1 : ℝ) - p ≠ 0 := by linarith
+  have hpm_ne : (p : ℝ) - 1 ≠ 0 := by linarith
+  have hval : (((N : ℝ) + 1) ^ (1 - p) - (((N : ℝ) + 1) + (m : ℝ)) ^ (1 - p)) / (p - 1)
+      = ((((N : ℝ) + 1) + (m : ℝ)) ^ (1 - p) - ((N : ℝ) + 1) ^ (1 - p)) / (1 - p) := by
+    field_simp
+    ring
+  rw [hval]
+
+/-! ## The tail lower bound (full tsum) -/
+
+set_option maxHeartbeats 800000 in
+/-- **Tail lower bound for the p-series.**  For `p > 1` and `N ≥ 1`, the full tail
+`∑'_{i} 1/(N+1+i)ᵖ` is bounded below by `(N+1)^{1−p}/(p−1)`, the value of the improper
+integral `∫_{N+1}^∞ x^{−p} dx`.  The uniform partial-sum lower bound
+`((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1)` converges up to `(N+1)^{1−p}/(p−1)` as `m → ∞`
+(the subtracted term `(N+1+m)^{1−p} → 0` since `1 − p < 0`), and each partial sum is `≤`
+the tsum, so the limit is `≤` the tsum. -/
+theorem pseries_tail_tsum_ge (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) :
+    ((N : ℝ) + 1) ^ (1 - p) / (p - 1) ≤ ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by
+  have hsummable : Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) :=
+    Real.summable_one_div_nat_rpow.mpr hp
+  have hsummable_tail : Summable (fun i : ℕ => 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p) :=
+    (summable_nat_add_iff (N + 1)).mpr hsummable
+  -- The uniform lower bound `u m ≤ tsum` for every `m`.
+  have hle : ∀ m : ℕ,
+      (((N : ℝ) + 1) ^ (1 - p) - (((N : ℝ) + 1) + (m : ℝ)) ^ (1 - p)) / (p - 1)
+        ≤ ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by
+    intro m
+    refine le_trans (pseries_tail_partial_ge p hp N hN m) ?_
+    exact Summable.sum_le_tsum (Finset.range m) (fun i _ => by positivity) hsummable_tail
+  -- `u m → (N+1)^{1−p}/(p−1)` as `m → ∞`.
+  have hbase : Tendsto (fun m : ℕ => ((N : ℝ) + 1) + (m : ℝ)) atTop atTop :=
+    tendsto_atTop_add_const_left atTop ((N : ℝ) + 1) tendsto_natCast_atTop_atTop
+  have hneg : Tendsto (fun x : ℝ => x ^ (1 - p)) atTop (𝓝 0) := by
+    rw [show (1 - p) = -(p - 1) by ring]
+    exact tendsto_rpow_neg_atTop (by linarith)
+  have h1 : Tendsto (fun m : ℕ => (((N : ℝ) + 1) + (m : ℝ)) ^ (1 - p)) atTop (𝓝 0) := by
+    simpa [Function.comp_def] using hneg.comp hbase
+  have h2 : Tendsto
+      (fun m : ℕ => ((N : ℝ) + 1) ^ (1 - p) - (((N : ℝ) + 1) + (m : ℝ)) ^ (1 - p))
+      atTop (𝓝 (((N : ℝ) + 1) ^ (1 - p) - 0)) :=
+    Filter.Tendsto.sub tendsto_const_nhds h1
+  have h3 := h2.div_const (p - 1)
+  rw [sub_zero] at h3
+  exact le_of_tendsto' h3 hle
+
+/-! ## The explicit `1/((p−1)·(N+1)^{p−1})` form -/
+
+/-- **Explicit lower bound, textbook form.**  Rewriting `(N+1)^{1−p}/(p−1)` as
+`1/((p−1)·(N+1)^{p−1})` exhibits the `O(N^{1−p})` order of the p-series tail from below. -/
+theorem pseries_tail_ge_explicit (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) :
+    1 / ((p - 1) * ((N : ℝ) + 1) ^ (p - 1)) ≤ ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by
+  have h := pseries_tail_tsum_ge p hp N hN
+  have hN1pos : (0 : ℝ) < (N : ℝ) + 1 := by positivity
+  have hpm_ne : (p : ℝ) - 1 ≠ 0 := by linarith
+  have hNp : (0 : ℝ) < ((N : ℝ) + 1) ^ (p - 1) := Real.rpow_pos_of_pos hN1pos _
+  have heq : ((N : ℝ) + 1) ^ (1 - p) / (p - 1) = 1 / ((p - 1) * ((N : ℝ) + 1) ^ (p - 1)) := by
+    rw [show (1 - p) = -(p - 1) by ring, Real.rpow_neg hN1pos.le]
+    field_simp
+  rwa [heq] at h
+
+/-! ## The two-sided sandwich -/
+
+/-- **Two-sided remainder sandwich.**  For `p > 1` and `N ≥ 1`, the p-series tail is
+pinned between two consecutive values of the primitive `x ↦ x^{1−p}/(p−1)`:
+
+  `(N+1)^{1−p}/(p−1) ≤ ∑'_{i} 1/(N+1+i)ᵖ ≤ N^{1−p}/(p−1)`.
+
+The lower bound is the new `pseries_tail_tsum_ge` (left Riemann sum / `∫_{N+1}^∞`); the
+upper bound is the parent's `pseries_tail_tsum_le` (right Riemann sum / `∫_N^∞`).  Both
+flanks have leading order `N^{1−p}`, so the remainder's order is exactly `N^{1−p}`. -/
+theorem pseries_tail_sandwich (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) :
+    ((N : ℝ) + 1) ^ (1 - p) / (p - 1) ≤ ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p ∧
+      (∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p) ≤ (N : ℝ) ^ (1 - p) / (p - 1) :=
+  ⟨pseries_tail_tsum_ge p hp N hN,
+   AntitoneIntegralSumComparisonOQ01OQ01OQ02.pseries_tail_tsum_le p hp N hN⟩
+
+/-! ## Worked witnesses -/
+
+/-- **Basel-exponent sandwich.**  For `p = 2`, the two-sided bound is the clean estimate
+`1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N`. -/
+example (N : ℕ) (hN : 1 ≤ N) :
+    1 / ((N : ℝ) + 1) ≤ ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ (2 : ℝ) ∧
+      (∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ (2 : ℝ)) ≤ 1 / (N : ℝ) := by
+  obtain ⟨hlo, hhi⟩ := pseries_tail_sandwich 2 (by norm_num) N hN
+  have hN1pos : (0 : ℝ) < (N : ℝ) + 1 := by positivity
+  refine ⟨?_, ?_⟩
+  · have hleq : ((N : ℝ) + 1) ^ ((1 : ℝ) - 2) / ((2 : ℝ) - 1) = 1 / ((N : ℝ) + 1) := by
+      rw [show ((1 : ℝ) - 2) = -(1 : ℝ) by norm_num, Real.rpow_neg hN1pos.le, Real.rpow_one]
+      norm_num
+    rwa [hleq] at hlo
+  · have hheq : (N : ℝ) ^ ((1 : ℝ) - 2) / ((2 : ℝ) - 1) = 1 / (N : ℝ) := by
+      have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+      rw [show ((1 : ℝ) - 2) = -(1 : ℝ) by norm_num, Real.rpow_neg hNpos.le, Real.rpow_one]
+      norm_num
+    rwa [hheq] at hhi
+
+/-- The lower bound is a genuine quantitative floor on the truncation error of `∑ 1/n²`:
+`1/11 ≤ ∑_{n>10} 1/n²` (the explicit textbook form at `p = 2`, `N = 10`). -/
+example : 1 / ((11 : ℝ)) ≤ ∑' i : ℕ, 1 / (((i + (10 + 1) : ℕ)) : ℝ) ^ (2 : ℝ) := by
+  have h := pseries_tail_ge_explicit 2 (by norm_num) 10 (by norm_num)
+  have heq : 1 / (((2 : ℝ) - 1) * (((10 : ℕ) : ℝ) + 1) ^ ((2 : ℝ) - 1)) = 1 / (11 : ℝ) := by
+    rw [show ((2 : ℝ) - 1) = (1 : ℝ) by norm_num, Real.rpow_one]
+    norm_num
+  rwa [heq] at h
+
+end AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-isc-oq01010201-partial-ge",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 51, "endLine": 94 },
+    "type": "theorem",
+    "title": "Tail Partial-Sum Lower Bound via the Left Riemann Sum",
+    "content": "pseries_tail_partial_ge is the left-endpoint dual of the parent's tail bound. Since 1/xᵖ is antitone on [N+1, N+1+m], AntitoneOn.integral_le_sum gives ∫_{N+1}^{N+1+m} x^{−p} dx ≤ ∑_{i<m} 1/(N+1+i)ᵖ: a decreasing function over-estimates its integral when sampled at left endpoints, so the integral underestimates the sum. The integral is evaluated by integral_rpow (after rewriting 1/xᵖ = x^{−p}) and matched, via field_simp; ring, to ((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1).",
+    "mathContext": "\\frac{(N+1)^{1-p} - (N+1+m)^{1-p}}{p-1} \\;=\\; \\int_{N+1}^{N+1+m} x^{-p}\\,dx \\;\\le\\; \\sum_{i<m} \\frac{1}{(N+1+i)^p}",
+    "significance": "key",
+    "relatedConcepts": ["integral test", "left Riemann sums", "antitone functions", "AntitoneOn.integral_le_sum", "integral_rpow"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq01010201-tsum-ge",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 105, "endLine": 131 },
+    "type": "theorem",
+    "title": "The Tail Floor in the Limit",
+    "content": "pseries_tail_tsum_ge passes the uniform partial-sum lower bound to the limit. Each lower bound u m = ((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1) is ≤ the partial tail (previous theorem) and hence ≤ the full tsum (Summable.sum_le_tsum, with summability of the shifted series from summable_nat_add_iff). As m → ∞ the subtracted term (N+1+m)^{1−p} → 0 because 1−p < 0 (tendsto_rpow_neg_atTop composed with N+1+m → ∞), so u m → (N+1)^{1−p}/(p−1). Since every u m ≤ tsum, le_of_tendsto' forces the limit (N+1)^{1−p}/(p−1) ≤ tsum.",
+    "mathContext": "\\frac{(N+1)^{1-p}}{p-1} \\;\\le\\; \\sum_{i=0}^{\\infty} \\frac{1}{(N+1+i)^p}",
+    "significance": "key",
+    "relatedConcepts": ["tsum", "le_of_tendsto'", "tendsto_rpow_neg_atTop", "monotone convergence", "lower bound"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq01010201-explicit",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 138, "endLine": 149 },
+    "type": "theorem",
+    "title": "Explicit Lower Bound, Textbook Form",
+    "content": "pseries_tail_ge_explicit rewrites the floor (N+1)^{1−p}/(p−1) as 1/((p−1)·(N+1)^{p−1}) using Real.rpow_neg ((N+1)^{1−p} = 1/(N+1)^{p−1}) and field_simp, exhibiting the matching O(N^{1−p}) order from below.",
+    "mathContext": "\\frac{1}{(p-1)\\,(N+1)^{p-1}} \\;\\le\\; \\sum_{i=0}^{\\infty} \\frac{1}{(N+1+i)^p}",
+    "significance": "standard",
+    "relatedConcepts": ["rate of convergence", "Real.rpow_neg", "asymptotic order"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq01010201-sandwich",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 159, "endLine": 165 },
+    "type": "theorem",
+    "title": "The Two-Sided Remainder Sandwich",
+    "content": "pseries_tail_sandwich pairs the new lower bound (pseries_tail_tsum_ge, ∫_{N+1}^∞) with the parent's upper bound (pseries_tail_tsum_le, ∫_N^∞), pinning the tail between two consecutive values of the primitive x ↦ x^{1−p}/(p−1): (N+1)^{1−p}/(p−1) ≤ ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1). Both flanks have leading order N^{1−p}, so the remainder's asymptotic order is exactly N^{1−p}.",
+    "mathContext": "\\frac{(N+1)^{1-p}}{p-1} \\;\\le\\; \\sum_{n>N} \\frac{1}{n^p} \\;\\le\\; \\frac{N^{1-p}}{p-1}",
+    "significance": "key",
+    "relatedConcepts": ["two-sided bound", "remainder estimate", "asymptotic order", "integral test"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq01010201-basel",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 169, "endLine": 185 },
+    "type": "example",
+    "title": "Basel-Exponent Sandwich",
+    "content": "For p = 2 the sandwich collapses to the textbook estimate 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N: both (N+1)^{1−2}/(2−1) and N^{1−2}/(2−1) simplify to 1/(N+1) and 1/N via Real.rpow_neg and Real.rpow_one.",
+    "mathContext": "\\frac{1}{N+1} \\;\\le\\; \\sum_{n>N} \\frac{1}{n^2} \\;\\le\\; \\frac{1}{N}",
+    "significance": "standard",
+    "relatedConcepts": ["Basel problem", "worked example", "rate of convergence"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,76 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+  "title": "Two-Sided Sandwich for the p-Series Tail",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01",
+  "description": "Answers the parent's open question by proving the matching LOWER bound for the p-series tail and assembling the two-sided sandwich. Where the parent bounded the remainder from above via the right Riemann sum (∑_{n>N} 1/nᵖ ≤ ∫_N^∞ x^{−p} dx = N^{1−p}/(p−1)), this entry runs the antitone integral test in its LEFT-Riemann form (AntitoneOn.integral_le_sum): a decreasing function over-estimates its integral on left endpoints, so ∑_{n>N} 1/nᵖ ≥ ∫_{N+1}^∞ x^{−p} dx = (N+1)^{1−p}/(p−1). Passing the uniform partial-sum lower bound to the limit (le_of_tendsto', with the subtracted endpoint term (N+1+m)^{1−p} → 0 by tendsto_rpow_neg_atTop) gives the tail floor, and combining with the parent's ceiling yields (N+1)^{1−p}/(p−1) ≤ ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1). Both flanks have leading order N^{1−p}, pinning the remainder's exact asymptotic order. For the Basel exponent p=2 the sandwich is 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N. 4 theorems, 2 worked witnesses, 0 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Integral_test_for_convergence",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "p-series",
+      "remainder-bound",
+      "rate-of-convergence",
+      "tail-estimate",
+      "sandwich",
+      "tsum",
+      "convergence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the foundational propext / Classical.choice / Quot.sound).",
+    "lineCount": 194,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "pseries_tail_partial_ge: every finite tail ∑_{i<m} 1/(N+1+i)ᵖ dominates the integral ∫_{N+1}^{N+1+m} x^{−p} dx = ((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1) — the antitone integral test in its LEFT-Riemann form (AntitoneOn.integral_le_sum) applied to 1/xᵖ on [N+1, N+1+m], with the integral computed by integral_rpow",
+      "pseries_tail_tsum_ge: passing the uniform partial-sum lower bound to the limit via le_of_tendsto' gives (N+1)^{1−p}/(p−1) ≤ ∑'_{i} 1/(N+1+i)ᵖ; the subtracted endpoint term (N+1+m)^{1−p} → 0 because 1−p < 0 (tendsto_rpow_neg_atTop), and each partial sum is ≤ the tsum (Summable.sum_le_tsum)",
+      "pseries_tail_ge_explicit: rewrites the floor in the textbook form 1/((p−1)·(N+1)^{p−1}), exhibiting the matching O(N^{1−p}) order from below",
+      "pseries_tail_sandwich: the two-sided bound (N+1)^{1−p}/(p−1) ≤ ∑'_{i} 1/(N+1+i)ᵖ ≤ N^{1−p}/(p−1), combining the new lower bound with the parent's pseries_tail_tsum_le — the remainder is pinned between two consecutive values of the same primitive x ↦ x^{1−p}/(p−1)",
+      "Worked witnesses: the Basel-exponent sandwich 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N for all N ≥ 1, and the concrete floor 1/11 ≤ ∑_{n>10} 1/n²"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral test pins a tail between two integrals of the same monotone integrand. The parent entry used only the upper half — the right Riemann sum under-estimates the integral, giving ∑_{n>N} 1/nᵖ ≤ ∫_N^∞ x^{−p} = N^{1−p}/(p−1). The classical 'integral remainder' estimate is genuinely TWO-sided: the left Riemann sum over-estimates the integral, so the same tail is bounded BELOW by ∫_{N+1}^∞ x^{−p} = (N+1)^{1−p}/(p−1). The two bounds straddle the tail with the same leading order N^{1−p}, which is what certifies that N^{1−p}/(p−1) is the true asymptotic size of the remainder, not merely an upper estimate. This sandwich is the standard tool for both truncating ζ(p) = ∑ 1/nᵖ to N terms AND certifying the truncation is not wasteful.",
+    "problemStatement": "Derive the matching lower bound for the p-series tail and assemble the two-sided sandwich: for p > 1 and N ≥ 1, (N+1)^{1−p}/(p−1) ≤ ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1).",
+    "text": "Apply the antitone integral test to f(x) = 1/xᵖ on [N+1, N+1+m], but now in its left-Riemann form: AntitoneOn.integral_le_sum says ∫_{N+1}^{N+1+m} x^{−p} dx ≤ ∑_{i<m} 1/(N+1+i)ᵖ (left endpoints of a decreasing function over-estimate the integral). The integral equals ((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1). As m → ∞ the subtracted term (N+1+m)^{1−p} → 0 (since 1−p < 0), so the partial-sum lower bounds increase up to (N+1)^{1−p}/(p−1); since each partial sum is ≤ the full tail tsum, the limit (N+1)^{1−p}/(p−1) is ≤ the tail. Pairing this floor with the parent's ceiling N^{1−p}/(p−1) gives the sandwich. The textbook form 1/((p−1)·(N+1)^{p−1}) follows from (N+1)^{1−p} = 1/(N+1)^{p−1}.",
+    "proofStrategy": "pseries_tail_partial_ge mirrors the parent's pseries_tail_partial_le but starts the comparison at base N+1 and uses AntitoneOn.integral_le_sum (left Riemann sum) instead of AntitoneOn.sum_le_integral: 1/xᵖ is antitone on [N+1, N+1+m] (one_div_le_one_div_of_le with Real.rpow_le_rpow), the integral is evaluated by integral_rpow after rewriting 1/xᵖ = x^{−p} (intervalIntegral.integral_congr), and the value is matched to ((N+1)^{1−p} − (N+1+m)^{1−p})/(p−1) (field_simp; ring). pseries_tail_tsum_ge defines u m = that integral value and shows (i) u m ≤ tsum for all m, via the partial bound followed by Summable.sum_le_tsum (summability of the shifted series from summable_nat_add_iff applied to Real.summable_one_div_nat_rpow), and (ii) u m → (N+1)^{1−p}/(p−1), via tendsto_rpow_neg_atTop composed with the divergence of N+1+m and Tendsto.sub / Tendsto.div_const; le_of_tendsto' then gives the floor. pseries_tail_ge_explicit rewrites (N+1)^{1−p}/(p−1) = 1/((p−1)·(N+1)^{p−1}) via Real.rpow_neg and field_simp. pseries_tail_sandwich pairs the floor with the parent's pseries_tail_tsum_le. Two example witnesses specialize to p=2.",
+    "keyInsights": [
+      "Symmetry of the integral test: the SAME antitone integrand gives an upper bound from the right Riemann sum (base N) and a lower bound from the left Riemann sum (base N+1)",
+      "AntitoneOn.integral_le_sum is the missing left-endpoint half: a decreasing function over-estimates its integral when sampled at left endpoints, so the integral underestimates the tail partial sum",
+      "Passing a one-sided LOWER bound to the limit needs le_of_tendsto' (each partial sum ≤ tsum, and the lower bounds converge UP to the floor) — the dual of the parent's Real.tsum_le_of_sum_range_le",
+      "The subtracted far-endpoint term (N+1+m)^{1−p} vanishes precisely because p > 1 makes the exponent 1−p negative (tendsto_rpow_neg_atTop), the same hypothesis that makes the series converge",
+      "Both flanks of the sandwich are consecutive values N^{1−p}/(p−1) and (N+1)^{1−p}/(p−1) of one primitive, so the remainder's leading order is exactly N^{1−p} — pinned, not merely bounded",
+      "For p = 2 the sandwich collapses to 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N, the textbook two-sided rate for truncating the Basel series"
+    ],
+    "prerequisites": [
+      "The antitone integral-test sandwich (AntitoneOn.integral_le_sum and AntitoneOn.sum_le_integral) from the parent entries",
+      "Interval integrals of real powers (integral_rpow) and real powers (rpow, Real.rpow_neg)",
+      "Limits at infinity of negative powers (tendsto_rpow_neg_atTop) and passing inequalities through limits (le_of_tendsto')",
+      "Partial sums bounded by the tsum (Summable.sum_le_tsum) and the shifted p-series summability criterion (summable_nat_add_iff, Real.summable_one_div_nat_rpow)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The p-series tail is sandwiched: for p > 1 and N ≥ 1, (N+1)^{1−p}/(p−1) ≤ ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1). The lower bound is the antitone integral test in left-Riemann form (∫_{N+1}^∞) passed to the limit; the upper bound is the parent's right-Riemann estimate (∫_N^∞). The Basel exponent gives 1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N. 4 theorems, 2 witnesses, 0 definitions, 194 lines, 0 sorries, 0 axioms.",
+    "implications": "Upgrades the parent's one-sided remainder bound to a two-sided estimate, certifying that N^{1−p}/(p−1) is the exact leading order of the truncation error of ζ(p), not just an upper bound. The base-shift technique (run the left-Riemann comparison from x = N+1) produces matching lower bounds for any antitone summand whose integral can be evaluated.",
+    "openQuestions": [
+      "Refine the sandwich to a leading-order asymptotic ∑_{n>N} 1/nᵖ = N^{1−p}/(p−1) + O(N^{−p}) by also estimating the gap between the two integrals (an Euler–Maclaurin first-order correction)",
+      "Specialize at integer p to explicit rational two-sided error bounds for ζ(2), ζ(4), … and compare against the exact values π²/6, π⁴/90"
+    ]
+  },
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01",
+    "lineCount": 194,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's (`antitone-integral-sum-comparison-oq-01-oq-01-oq-02`) open question by proving the **matching lower bound** for the p-series tail and assembling the **two-sided sandwich**.

The parent bounded the remainder only from *above* via the right Riemann sum:
∑_{n>N} 1/nᵖ ≤ ∫_N^∞ x⁻ᵖ dx = N^{1−p}/(p−1).

This entry runs the antitone integral test in its **left**-Riemann form (`AntitoneOn.integral_le_sum`) — a decreasing function over-estimates its integral on left endpoints — giving the matching floor:
∑_{n>N} 1/nᵖ ≥ ∫_{N+1}^∞ x⁻ᵖ dx = (N+1)^{1−p}/(p−1).

Combining the two yields the sandwich

> (N+1)^{1−p}/(p−1)  ≤  ∑_{n>N} 1/nᵖ  ≤  N^{1−p}/(p−1).

Both flanks are consecutive values of the same primitive `x ↦ x^{1−p}/(p−1)`, so they share leading order `N^{1−p}` — the remainder's asymptotic order is **pinned**, not merely bounded. Basel exponent p=2: `1/(N+1) ≤ ∑_{n>N} 1/n² ≤ 1/N`.

## Theorems (4 + 2 witnesses)

- `pseries_tail_partial_ge` — finite tail dominates `∫_{N+1}^{N+1+m} x⁻ᵖ` (left Riemann sum).
- `pseries_tail_tsum_ge` — the floor `(N+1)^{1−p}/(p−1) ≤ tail`, via `le_of_tendsto'` (the subtracted endpoint `(N+1+m)^{1−p} → 0` by `tendsto_rpow_neg_atTop`).
- `pseries_tail_ge_explicit` — textbook form `1/((p−1)·(N+1)^{p−1}) ≤ tail`.
- `pseries_tail_sandwich` — the two-sided bound (new floor + parent's ceiling).

## Verification

- 0 sorries, 0 `axiom` declarations.
- `#print axioms` on all 4 theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- Built offline with `lake env lean` (Docker daemon was unavailable in this environment). Imports the parent module `Proofs.AntitoneIntegralSumComparisonOQ01OQ01OQ02` for the upper-bound half of the sandwich.

## Files

- `proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02OQ01.lean` (194 lines)
- `proofs/Proofs.lean` — aggregator import
- `src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)