### PR TITLE
research(binomial-theorem-oq-02-oq-02-oq-02-oq-03): figurate r-simplex tower [verified, 8 thm, 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean
@@ -1,0 +1,124 @@
+/-
+  Figurate (r-simplex) numbers and the general hockey-stick tower
+  Open Question: binomial-theorem-oq-02-oq-02-oq-02-oq-03
+
+  The parent BinomialTheoremOQ02OQ02OQ02.lean proves the hockey-stick (Zhu Shijie)
+  identity ∑_{m} C(m,r) = C(n+1,r+1) and reads off two *specific* figurate
+  consequences: the triangular numbers (r = 2) and the tetrahedral numbers (r = 3).
+
+  Its open question asks for the **figurate generalization to arbitrary r**: read
+  the hockey-stick identity as a statement about the whole tower of r-simplex
+  (figurate) numbers, of which the line / triangular / tetrahedral numbers are the
+  r = 1, 2, 3 floors.
+
+  This file does that. We define the (0-indexed) r-simplex number
+
+      figurate r n := C(n + r, r)
+
+  and prove, with 0 axioms / 0 sorries:
+
+    • figurate_zero/one/two/three : the bottom floors are 1, n+1, the triangular
+        numbers (n+1)(n+2)/2, and the tetrahedral numbers (n+1)(n+2)(n+3).
+    • figurate_succ_eq_sum  : the **tower** — every (r+1)-simplex number is the
+        running total of the r-simplex numbers below it,
+            figurate (r+1) n = ∑_{i=0}^{n} figurate r i.
+        This is the hockey-stick identity at *arbitrary* r, the generalization the
+        parent's two special cases instantiate.
+    • figurate_pascal       : the Pascal-style recurrence between adjacent floors,
+            figurate (r+1) (n+1) = figurate r (n+1) + figurate (r+1) n.
+    • factorial_mul_figurate: the general closed form, r! · figurate r n equals the
+        rising factorial (n+1)(n+2)···(n+r).
+    • figurate_eq_multichoose: figurate r n = multichoose (n+1) r, identifying the
+        figurate numbers with Mathlib's multiset ("stars and bars") count.
+
+  References:
+    https://en.wikipedia.org/wiki/Figurate_number
+    https://en.wikipedia.org/wiki/Hockey-stick_identity
+-/
+
+import Mathlib
+
+namespace BinomialFigurateSimplex
+
+open Finset
+
+/-- **r-simplex (figurate) number**, 0-indexed.
+
+    `figurate r n = C(n + r, r)` counts the points of a discrete r-dimensional
+    simplex with `n + 1` points along each edge. The floors of the tower are:
+    `r = 0` the constant `1`, `r = 1` the natural numbers, `r = 2` the triangular
+    numbers, `r = 3` the tetrahedral numbers, and so on. -/
+def figurate (r n : ℕ) : ℕ := (n + r).choose r
+
+/- ## The bottom floors of the tower -/
+
+/-- The 0-simplex numbers are constantly `1` (a single point). -/
+@[simp] theorem figurate_zero (n : ℕ) : figurate 0 n = 1 := by
+  simp [figurate]
+
+/-- The 1-simplex numbers are the naturals `n + 1` (points on a segment). -/
+@[simp] theorem figurate_one (n : ℕ) : figurate 1 n = n + 1 := by
+  simp [figurate, Nat.choose_one_right]
+
+/-- The 2-simplex numbers are the triangular numbers `(n+1)(n+2)/2`. -/
+theorem figurate_two (n : ℕ) : figurate 2 n = (n + 1) * (n + 2) / 2 := by
+  rw [figurate, Nat.choose_two_right]
+  rw [show n + 2 - 1 = n + 1 from by omega, Nat.mul_comm]
+
+/-- The 3-simplex numbers are the tetrahedral numbers: `6 · figurate 3 n` is the
+    product of three consecutive integers `(n+1)(n+2)(n+3)`. -/
+theorem figurate_three (n : ℕ) :
+    6 * figurate 3 n = (n + 1) * (n + 2) * (n + 3) := by
+  have h : (n + 1).ascFactorial 3 = Nat.factorial 3 * figurate 3 n := by
+    rw [figurate, Nat.ascFactorial_eq_factorial_mul_choose]
+  have e : (n + 1).ascFactorial 3 = (n + 1) * (n + 2) * (n + 3) := by
+    simp only [show (3 : ℕ) = 2 + 1 from rfl, Nat.ascFactorial_succ,
+      show (2 : ℕ) = 1 + 1 from rfl, Nat.ascFactorial_succ, Nat.ascFactorial_zero]
+    ring
+  rw [e, show Nat.factorial 3 = 6 from rfl] at h
+  exact h.symm
+
+/- ## The figurate tower: hockey-stick at arbitrary r -/
+
+/-- **The figurate tower.** Each `(r+1)`-simplex number is the running total of
+    the `r`-simplex numbers below it:
+    `figurate (r+1) n = ∑_{i=0}^{n} figurate r i`.
+
+    This is the hockey-stick (Zhu Shijie) identity stated for *every* `r` at once;
+    the triangular (`r = 1`) and tetrahedral (`r = 2`) accumulations the parent file
+    derives are the bottom two instances. -/
+theorem figurate_succ_eq_sum (r n : ℕ) :
+    figurate (r + 1) n = ∑ i ∈ range (n + 1), figurate r i := by
+  simp only [figurate]
+  rw [Nat.sum_range_add_choose n r, show n + (r + 1) = n + r + 1 from by omega]
+
+/-- **Pascal recurrence between floors.** A figurate number equals the one directly
+    below it on the same floor plus the one on the floor beneath:
+    `figurate (r+1) (n+1) = figurate r (n+1) + figurate (r+1) n`. -/
+theorem figurate_pascal (r n : ℕ) :
+    figurate (r + 1) (n + 1) = figurate r (n + 1) + figurate (r + 1) n := by
+  simp only [figurate]
+  rw [show n + 1 + (r + 1) = (n + r + 1) + 1 from by omega,
+      show n + 1 + r = n + r + 1 from by omega,
+      show n + (r + 1) = n + r + 1 from by omega,
+      Nat.choose_succ_succ (n + r + 1) r]
+
+/- ## Closed forms -/
+
+/-- **General closed form.** `r! · figurate r n` is the rising factorial
+    `(n+1)(n+2)···(n+r)`. Dividing by `r!` recovers `figurate r n = C(n+r, r)`,
+    and the `r = 2, 3` cases give the triangular and tetrahedral formulas above. -/
+theorem factorial_mul_figurate (r n : ℕ) :
+    Nat.factorial r * figurate r n = (n + 1).ascFactorial r := by
+  rw [figurate, Nat.ascFactorial_eq_factorial_mul_choose]
+
+/-- **Multiset interpretation.** The `r`-simplex numbers are exactly Mathlib's
+    `multichoose (n+1) r`: the number of size-`r` multisets drawn from `n+1`
+    symbols (the "stars and bars" count). -/
+theorem figurate_eq_multichoose (r n : ℕ) :
+    figurate r n = Nat.multichoose (n + 1) r := by
+  rw [figurate, Nat.multichoose_eq]
+  congr 1
+  omega
+
+end BinomialFigurateSimplex

--- a/research/problems/binomial-theorem-oq-02-oq-02-oq-02-oq-03/knowledge.md
+++ b/research/problems/binomial-theorem-oq-02-oq-02-oq-02-oq-03/knowledge.md
@@ -1,0 +1,55 @@
+# binomial-theorem-oq-02-oq-02-oq-02-oq-03 — Figurate (r-Simplex) Numbers and the General Hockey-Stick Tower
+
+**Status**: COMPLETED (verified, 0 axioms / 0 sorries)
+**Lean file**: `proofs/Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean`
+**Gallery**: `src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02-oq-03/`
+
+## Problem
+
+Parent OQ#3: generalize the figurate-number consequences of the hockey-stick
+identity to arbitrary `r`. The parent (`BinomialTheoremOQ02OQ02OQ02`) only derives
+the `r = 1` (Gauss's sum) and `r = 2` (tetrahedral) floors as separate special cases.
+
+## Session 2026-06-25 (Session 1) — FRESH
+
+**Mode**: FRESH · **Outcome**: completed
+
+### What I Did
+- Defined `figurate r n := (n + r).choose r`, the 0-indexed r-simplex number.
+- Proved the **figurate tower** `figurate (r+1) n = ∑_{i=0}^{n} figurate r i` for all `r`
+  (the headline generalization), `figurate_succ_eq_sum`.
+- Proved the Pascal recurrence between floors `figurate_pascal`.
+- Proved the general rising-factorial closed form `factorial_mul_figurate`:
+  `r! · figurate r n = (n+1).ascFactorial r = (n+1)(n+2)···(n+r)`.
+- Identified figurate numbers with `Nat.multichoose (n+1) r` (`figurate_eq_multichoose`).
+- Bottom floors: `figurate_zero/one/two/three` (1, n+1, triangular, tetrahedral).
+- 8 theorems + 1 def, 0 sorry, axioms = {propext, Classical.choice, Quot.sound} only.
+
+### Key Findings / Insights
+- The headline is just Mathlib's range-form hockey-stick `Nat.sum_range_add_choose`
+  after the index normalization `n + (r+1) → n + r + 1` (definitional but not syntactic;
+  must be rewritten explicitly with `show … from by omega` before/after the `rw`).
+- The product closed form comes free from `Nat.ascFactorial_eq_factorial_mul_choose`
+  `(n+1).ascFactorial k = k! · (n+k).choose k` — avoids any ℕ-subtraction.
+- For the tetrahedral cubic, state it as `6 * figurate 3 n = (n+1)(n+2)(n+3)`
+  (multiplied form) to dodge ℕ division; expand `ascFactorial 3` with two
+  `Nat.ascFactorial_succ` rewrites + `ring`.
+- Mathlib's `Nat.multichoose_eq` gives the multiset / stars-and-bars reading directly.
+
+### Gotchas
+- Factorial postfix `n !`: `(3 : ℕ)!` fails to parse after a paren, and `r ! *` misparses
+  before `*`. Use `Nat.factorial r` explicitly in term position.
+- Build env: Docker daemon was down; used offline `LAKE_UNSAFE=1 lake env lean File.lean`
+  to typecheck against prebuilt Mathlib oleans (no full `lake build`). `#print axioms`
+  via a temp olean copied onto `LEAN_PATH`.
+- Gallery data must be written to the **worktree** `src/data/proofs/…`, not the absolute
+  main-repo path (Write to `/Users/.../lean-genius/src/...` lands in main, off-branch).
+
+### Files Modified
+- `proofs/Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean` (new)
+- `src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02-oq-03/{meta,annotations}.json` (new)
+
+### Next Steps (follow-up open questions)
+- Iterated-sum form: `figurate r n` as an r-fold nested partial sum of the constant
+  sequence 1, exhibiting the full tower telescoping.
+- (Parent siblings) q-Vandermonde and Stirling asymptotic of C(2n,n) remain open.

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02-oq-03/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Figurate Numbers at Arbitrary r (OQ#3)",
+    "content": "The parent derives the r=1 (Gauss's sum) and r=2 (tetrahedral) figurate consequences of the hockey-stick identity. Its third open question asks for the generalization to arbitrary r. This file defines the r-simplex number figurate r n = C(n+r, r) and treats the whole tower uniformly — the figurate tower, the Pascal recurrence, the rising-factorial closed form, and the multiset interpretation — all 0 axioms / 0 sorries.",
+    "mathContext": "The line, triangular, and tetrahedral numbers are the bottom floors of one r-indexed simplex-number family.",
+    "significance": "key",
+    "relatedConcepts": [
+      "figurate numbers",
+      "simplex numbers",
+      "hockey-stick identity"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Pascal's rule"
+    ]
+  },
+  {
+    "id": "ann-figurate-def",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+    "range": {
+      "startLine": 45,
+      "endLine": 51
+    },
+    "type": "definition",
+    "title": "The r-Simplex (Figurate) Number",
+    "content": "figurate r n = C(n+r, r), the 0-indexed r-dimensional figurate number counting the points of a discrete simplex with n+1 points per edge. r=0 is the constant 1, r=1 the naturals, r=2 the triangular numbers, r=3 the tetrahedral numbers.",
+    "mathContext": "A single family indexed by dimension r and position n.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "simplex numbers",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-bottom-floors",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+    "range": {
+      "startLine": 56,
+      "endLine": 79
+    },
+    "type": "theorem",
+    "title": "Bottom Floors: 1, n+1, Triangular, Tetrahedral",
+    "content": "figurate 0 n = 1, figurate 1 n = n+1 (naturals), figurate 2 n = (n+1)(n+2)/2 (triangular numbers, via Nat.choose_two_right), and 6·figurate 3 n = (n+1)(n+2)(n+3) (tetrahedral numbers, via the rising-factorial closed form). These recover the classical figurate sequences as the low-dimensional floors of the tower.",
+    "mathContext": "The r=0,1,2,3 instances of figurate r n = C(n+r, r).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangular numbers",
+      "tetrahedral numbers",
+      "figurate numbers"
+    ]
+  },
+  {
+    "id": "ann-figurate-tower",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+    "range": {
+      "startLine": 81,
+      "endLine": 96
+    },
+    "type": "theorem",
+    "title": "The Figurate Tower: figurate (r+1) n = ∑ figurate r i",
+    "content": "The central result: every (r+1)-simplex number is the running total of the r-simplex numbers below it, figurate (r+1) n = ∑_{i=0}^{n} figurate r i. This is Mathlib's range-form hockey-stick Nat.sum_range_add_choose stated for arbitrary r, generalizing the parent's Gauss (r=1) and tetrahedral (r=2) accumulations into one theorem.",
+    "mathContext": "The hockey-stick identity read uniformly across all dimensions: each floor is the partial-sum sequence of the floor below.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "partial sums",
+      "Pascal's triangle"
+    ]
+  },
+  {
+    "id": "ann-figurate-pascal",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+    "range": {
+      "startLine": 98,
+      "endLine": 104
+    },
+    "type": "theorem",
+    "title": "Pascal Recurrence Between Floors",
+    "content": "figurate (r+1) (n+1) = figurate r (n+1) + figurate (r+1) n, a single application of Pascal's rule Nat.choose_succ_succ with index bookkeeping discharged by omega. It places the figurate tower directly on the additive structure of Pascal's triangle.",
+    "mathContext": "Pascal's rule transcribed into figurate-number coordinates.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pascal's rule",
+      "recurrence"
+    ]
+  },
+  {
+    "id": "ann-closed-forms",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+    "range": {
+      "startLine": 106,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "Closed Forms: Rising Factorial and Multichoose",
+    "content": "The general product closed form r!·figurate r n = (n+1).ascFactorial r = (n+1)(n+2)···(n+r) (via Nat.ascFactorial_eq_factorial_mul_choose), instantiating to the triangular and tetrahedral products; and the identification figurate r n = multichoose (n+1) r (via Nat.multichoose_eq), grounding the figurate numbers in the multiset / stars-and-bars count.",
+    "mathContext": "Rising-factorial product form and the multiset interpretation of the simplex numbers.",
+    "significance": "key",
+    "relatedConcepts": [
+      "rising factorial",
+      "multichoose",
+      "stars and bars"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02-oq-03/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+  "title": "Figurate (r-Simplex) Numbers and the General Hockey-Stick Tower",
+  "slug": "binomial-theorem-oq-02-oq-02-oq-02-oq-03",
+  "description": "Answers the parent's third open question: generalize the figurate-number consequences of the hockey-stick identity to arbitrary r. Defines the r-simplex (figurate) number figurate r n = C(n+r, r) and proves, for every r at once, the figurate tower figurate (r+1) n = ∑_{i=0}^{n} figurate r i — the hockey-stick identity read as 'each floor is the running total of the floor below'. Also gives the Pascal recurrence between floors, the general closed form r!·figurate r n = (n+1)(n+2)···(n+r), the identification with Mathlib's multichoose (stars and bars), and the bottom floors 1, n+1, triangular (n+1)(n+2)/2, tetrahedral (n+1)(n+2)(n+3). 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Zhu Shijie (1303)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Figurate_number",
+    "date": "1303",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "hockey-stick",
+      "figurate-numbers",
+      "simplex-numbers",
+      "multichoose",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_range_add_choose",
+        "description": "Range form of the hockey-stick identity: ∑_{i<n+1} C(i+r,r) = C(n+r+1,r+1); the engine for the figurate tower at arbitrary r",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1); gives the recurrence between adjacent figurate floors",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.ascFactorial_eq_factorial_mul_choose",
+        "description": "(n+1).ascFactorial k = k! · C(n+k,k); yields the general product closed form for figurate numbers",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.multichoose_eq",
+        "description": "multichoose n k = C(n+k-1,k); identifies the figurate numbers with the multiset / stars-and-bars count",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "C(m,2) = m(m-1)/2; gives the triangular closed form for the r=2 floor",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Defined the r-simplex (figurate) number figurate r n = C(n+r, r) as a single family indexed by dimension r and position n",
+      "Proved the figurate tower figurate (r+1) n = ∑_{i=0}^{n} figurate r i for ALL r — the hockey-stick identity at arbitrary r, generalizing the parent's r=1 (Gauss) and r=2 (tetrahedral) special cases into one theorem",
+      "Proved the Pascal-style recurrence between floors figurate (r+1) (n+1) = figurate r (n+1) + figurate (r+1) n",
+      "Proved the general product closed form r!·figurate r n = (n+1)(n+2)···(n+r) (rising factorial), instantiating to triangular (n+1)(n+2)/2 and tetrahedral (n+1)(n+2)(n+3)",
+      "Identified the figurate numbers with Mathlib's multichoose (n+1) r, grounding them in the multiset / stars-and-bars interpretation"
+    ],
+    "axiomCount": 0,
+    "lineCount": 124,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The q-analogue (q-Vandermonde) and the Stirling asymptotic of C(2n,n) remain the parent's other open questions and are out of scope.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Figurate numbers — counts of points arranged in regular geometric shapes — are among the oldest objects in mathematics: the line (n), the triangular numbers, the tetrahedral numbers, and their higher-dimensional simplex generalizations. They form a tower in which each sequence is the running total of the one below, a fact equivalent to the hockey-stick identity of Zhu Shijie's 1303 Jade Mirror of the Four Unknowns. The parent file derives the r=1 (Gauss's sum) and r=2 (tetrahedral) floors as special cases; this entry treats the entire tower uniformly.",
+    "problemStatement": "Generalize the figurate consequences of the hockey-stick identity to arbitrary r: define the r-simplex numbers and show ∑_{m} C(m,r) = C(n+1,r+1) expresses each figurate sequence as the partial sums of the previous one.",
+    "text": "A uniform treatment of the r-simplex (figurate) number tower built on the hockey-stick identity at arbitrary r.",
+    "proofStrategy": "Define figurate r n = C(n+r, r). The central theorem figurate (r+1) n = ∑_{i=0}^{n} figurate r i is Mathlib's range-form hockey-stick Nat.sum_range_add_choose after an index normalization. The Pascal recurrence between floors is a single application of Nat.choose_succ_succ with index bookkeeping discharged by omega. The general closed form r!·figurate r n = (n+1).ascFactorial r is Nat.ascFactorial_eq_factorial_mul_choose; expanding the rising factorial gives the tetrahedral product, and Nat.choose_two_right gives the triangular form. The multiset identification is Nat.multichoose_eq.",
+    "keyInsights": [
+      "All figurate numbers are one family figurate r n = C(n+r, r) indexed by dimension r and position n; the line, triangular, and tetrahedral sequences are the r=1,2,3 floors",
+      "The figurate tower 'each floor is the running total of the floor below' is exactly the hockey-stick identity stated for every r simultaneously",
+      "The Pascal recurrence figurate (r+1)(n+1) = figurate r (n+1) + figurate (r+1) n places the figurate tower directly on Pascal's triangle",
+      "The general closed form is the rising factorial: r!·figurate r n = (n+1)(n+2)···(n+r), with the triangular and tetrahedral formulas as r=2,3 instances",
+      "Figurate numbers count multisets: figurate r n = multichoose (n+1) r, the stars-and-bars count of size-r multisets over n+1 symbols",
+      "Index normalization (n+(r+1) vs n+r+1, definitional but not syntactic) must be made explicit before the Mathlib lemmas fire"
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Pascal's rule",
+      "The hockey-stick identity (parent entry)",
+      "Finite sums",
+      "Figurate / simplex numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bottom-floors",
+      "title": "The Bottom Floors of the Tower",
+      "startLine": 1,
+      "endLine": 79,
+      "summary": "Module docstring framing OQ#3, the definition figurate r n = C(n+r, r), and the identifications of the bottom floors: figurate 0 = 1, figurate 1 = n+1, figurate 2 = (n+1)(n+2)/2 (triangular), and 6·figurate 3 = (n+1)(n+2)(n+3) (tetrahedral).",
+      "mathContext": "The constant, line, triangular, and tetrahedral sequences are the r=0,1,2,3 floors of the simplex tower."
+    },
+    {
+      "id": "figurate-tower",
+      "title": "The Figurate Tower: Hockey-Stick at Arbitrary r",
+      "startLine": 81,
+      "endLine": 104,
+      "summary": "The central result figurate (r+1) n = ∑_{i=0}^{n} figurate r i (every floor is the running total of the floor below, via Nat.sum_range_add_choose), plus the Pascal recurrence figurate (r+1)(n+1) = figurate r (n+1) + figurate (r+1) n.",
+      "mathContext": "The hockey-stick identity, read uniformly across all dimensions r."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Closed Forms",
+      "startLine": 106,
+      "endLine": 124,
+      "summary": "The general product closed form r!·figurate r n = (n+1).ascFactorial r = (n+1)(n+2)···(n+r), and the identification figurate r n = multichoose (n+1) r with Mathlib's multiset count.",
+      "mathContext": "Rising-factorial product form and the stars-and-bars multiset interpretation."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) uniform treatment of the r-simplex (figurate) number tower, answering the parent's third open question. The single theorem figurate (r+1) n = ∑ figurate r i generalizes the parent's r=1 (Gauss) and r=2 (tetrahedral) accumulations to every dimension at once.",
+    "implications": "Reading the hockey-stick identity at arbitrary r exhibits the entire figurate-number tower — line, triangular, tetrahedral, and beyond — as iterated partial sums sitting on the diagonals of Pascal's triangle, with a single rising-factorial closed form and a multiset (stars-and-bars) interpretation.",
+    "openQuestions": [
+      "Formalize the q-Vandermonde identity via Mathlib's Gaussian binomial coefficients (parent OQ#1).",
+      "Formalize the Stirling asymptotic C(2n,n) ~ 4^n/√(πn) (parent OQ#3).",
+      "Prove the iterated-sum form: figurate r n as an r-fold nested partial sum of the constant sequence 1, exhibiting the full tower telescoping."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "Parent proving the hockey-stick identity and its r=1 (Gauss) and r=2 (tetrahedral) figurate cases; this entry answers its third open question by generalizing to arbitrary r"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "BinomialFigurateSimplex",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `binomial-theorem-oq-02-oq-02-oq-02` (The Hockey-Stick Identity and Figurate Numbers): *generalize the figurate consequences to arbitrary r.*

The parent derives only the `r = 1` (Gauss's sum) and `r = 2` (tetrahedral) floors as separate special cases. This entry defines the **r-simplex (figurate) number** `figurate r n = C(n+r, r)` and treats the whole tower uniformly.

## Results (`proofs/Proofs/BinomialTheoremOQ02OQ02OQ02OQ03.lean`)

| Theorem | Statement |
|---|---|
| `figurate_succ_eq_sum` | **The figurate tower:** `figurate (r+1) n = ∑_{i=0}^{n} figurate r i` — hockey-stick at arbitrary `r` |
| `figurate_pascal` | Pascal recurrence: `figurate (r+1) (n+1) = figurate r (n+1) + figurate (r+1) n` |
| `factorial_mul_figurate` | General closed form: `r! · figurate r n = (n+1)(n+2)···(n+r)` (rising factorial) |
| `figurate_eq_multichoose` | `figurate r n = multichoose (n+1) r` (multiset / stars-and-bars count) |
| `figurate_zero/one/two/three` | Bottom floors: `1`, `n+1`, triangular `(n+1)(n+2)/2`, tetrahedral `(n+1)(n+2)(n+3)` |

The parent's Gauss (`r=1`) and tetrahedral (`r=2`) accumulations are now single instances of `figurate_succ_eq_sum`.

## Verification

- **8 theorems + 1 definition, 0 sorries, 0 axioms.**
- `#print axioms` lists only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Status: **verified**.
- Built offline against Mathlib 4.26.0 (`lake env lean`); annotations validated against the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)