### PR TITLE
research(spherical-law-of-sines-oq-01): unsquared spherical law of sines — the true proportion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3956,6 +3956,7 @@ import Proofs.SphericalLawOfCosinesOQ03OQ01
 import Proofs.SphericalLawOfCosinesOQ03Primal
 import Proofs.SphericalLawOfCosinesOQ05
 import Proofs.SphericalLawOfSines
+import Proofs.SphericalLawOfSinesOQ01
 import Proofs.SphericalLawOfSinesOQ03
 import Proofs.Sqrt2
 import Proofs.Sqrt2FromAxiomsOQ01

--- a/proofs/Proofs/SphericalLawOfSinesOQ01.lean
+++ b/proofs/Proofs/SphericalLawOfSinesOQ01.lean
@@ -1,0 +1,119 @@
+import Mathlib
+import Proofs.SphericalLawOfSines
+
+/-
+# Unsquared spherical law of sines: the true proportion of sines
+
+The parent file `SphericalLawOfSines` proves the spherical law of sines in **squared**
+ratio form (`spherical_law_of_sines_all_sq`):
+
+  sin²(a)/sin²(α) = sin²(b)/sin²(β) = sin²(c)/sin²(γ),
+
+where `a, b, c` are the side arc-lengths and `α, β, γ` the opposite dihedral (interior)
+angles of a spherical triangle with unit-vector vertices `A, B, C`.
+
+This is one square-root short of the textbook statement.  The squared form alone does not
+give the genuine proportion `sin(a)/sin(α) = sin(b)/sin(β)`: in principle an equality of
+squares `x² = y²` only yields `x = ±y`.  Here the sign ambiguity is killed by a geometric
+fact: **every side arc-length and every dihedral angle of the vector model lies in
+`[0, π]`, so all of `sin(a), sin(α), …` are non-negative.**  Indeed `arcLen u v` is an
+`arccos` (range `[0, π]`) and `dihedralAngle A B C` is either `0` or an `arccos`; in both
+cases `sin (arccos t) = √(1 − t²) ≥ 0`.  Taking square roots of non-negative quantities is
+unambiguous, so the squared law upgrades to the honest proportion.
+
+This file proves:
+
+* `sin_arcLen_nonneg`, `sin_dihedralAngle_nonneg` — the sines of the model's arc-lengths and
+  dihedral angles are non-negative.
+* `spherical_law_of_sines` — the full unsquared law of sines (all three ratios equal):
+  `sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ)`.
+* `spherical_law_of_sines_two` — the two-ratio convenience form.
+
+All results are fully machine-verified: 0 sorries, 0 axioms.
+-/
+
+namespace SphericalLawOfSinesOQ01
+
+open SphericalLawOfSines
+
+/-! ## Non-negativity of the model's sines -/
+
+/-- The sine of any side arc-length is non-negative: `arcLen u v = arccos (u·v) ∈ [0, π]`,
+and `sin (arccos t) = √(1 − t²) ≥ 0`. -/
+theorem sin_arcLen_nonneg (u v : Fin 3 → ℝ) : 0 ≤ Real.sin (arcLen u v) := by
+  simp only [arcLen, Real.sin_arccos]
+  exact Real.sqrt_nonneg _
+
+/-- The sine of any dihedral angle is non-negative.  `dihedralAngle A B C` is either `0`
+(degenerate branch, `sin 0 = 0`) or an `arccos` (`sin (arccos t) = √(1 − t²) ≥ 0`). -/
+theorem sin_dihedralAngle_nonneg (A B C : Fin 3 → ℝ) :
+    0 ≤ Real.sin (dihedralAngle A B C) := by
+  simp only [dihedralAngle]
+  split_ifs with h
+  · rw [Real.sin_zero]
+  · rw [Real.sin_arccos]; exact Real.sqrt_nonneg _
+
+/-! ## The unsquared law of sines -/
+
+/-- Take the square root of an equality of squared non-negative ratios.  If
+`x² / p² = y² / q²` with `x, p, y, q ≥ 0`, then `x / p = y / q`. -/
+private theorem ratio_of_sq_ratio {x p y q : ℝ}
+    (hx : 0 ≤ x) (hp : 0 ≤ p) (hy : 0 ≤ y) (hq : 0 ≤ q)
+    (h : x ^ 2 / p ^ 2 = y ^ 2 / q ^ 2) : x / p = y / q := by
+  have hsq : (x / p) ^ 2 = (y / q) ^ 2 := by rw [div_pow, div_pow]; exact h
+  calc x / p = Real.sqrt ((x / p) ^ 2) := (Real.sqrt_sq (div_nonneg hx hp)).symm
+    _ = Real.sqrt ((y / q) ^ 2) := by rw [hsq]
+    _ = y / q := Real.sqrt_sq (div_nonneg hy hq)
+
+/-- **Spherical Law of Sines** (unsquared, all three ratios equal).
+
+  sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ),
+
+the honest proportion behind the parent's squared form.  Obtained by taking square roots,
+which is unambiguous because every `sin` appearing is non-negative
+(`sin_arcLen_nonneg`, `sin_dihedralAngle_nonneg`). -/
+theorem spherical_law_of_sines (A B C : Fin 3 → ℝ)
+    (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
+    (hpBA : normSq (projPerp B A) ≠ 0) (hpCA : normSq (projPerp C A) ≠ 0)
+    (hpAB : normSq (projPerp A B) ≠ 0) (hpCB : normSq (projPerp C B) ≠ 0)
+    (hpAC : normSq (projPerp A C) ≠ 0) (hpBC : normSq (projPerp B C) ≠ 0)
+    (hT : tripleProduct A B C ≠ 0) :
+    Real.sin (arcLen B C) / Real.sin (dihedralAngle A B C) =
+      Real.sin (arcLen A C) / Real.sin (dihedralAngle B A C) ∧
+    Real.sin (arcLen A C) / Real.sin (dihedralAngle B A C) =
+      Real.sin (arcLen A B) / Real.sin (dihedralAngle C A B) := by
+  obtain ⟨h1, h2⟩ := spherical_law_of_sines_all_sq A B C hA hB hC
+    hpBA hpCA hpAB hpCB hpAC hpBC hT
+  refine ⟨?_, ?_⟩
+  · exact ratio_of_sq_ratio (sin_arcLen_nonneg B C) (sin_dihedralAngle_nonneg A B C)
+      (sin_arcLen_nonneg A C) (sin_dihedralAngle_nonneg B A C) h1
+  · exact ratio_of_sq_ratio (sin_arcLen_nonneg A C) (sin_dihedralAngle_nonneg B A C)
+      (sin_arcLen_nonneg A B) (sin_dihedralAngle_nonneg C A B) h2
+
+/-- **Spherical Law of Sines** (unsquared, two-ratio form):
+`sin(a)/sin(α) = sin(b)/sin(β)`. -/
+theorem spherical_law_of_sines_two (A B C : Fin 3 → ℝ)
+    (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
+    (hpBA : normSq (projPerp B A) ≠ 0) (hpCA : normSq (projPerp C A) ≠ 0)
+    (hpAB : normSq (projPerp A B) ≠ 0) (hpCB : normSq (projPerp C B) ≠ 0)
+    (hpAC : normSq (projPerp A C) ≠ 0) (hpBC : normSq (projPerp B C) ≠ 0)
+    (hT : tripleProduct A B C ≠ 0) :
+    Real.sin (arcLen B C) / Real.sin (dihedralAngle A B C) =
+      Real.sin (arcLen A C) / Real.sin (dihedralAngle B A C) :=
+  (spherical_law_of_sines A B C hA hB hC hpBA hpCA hpAB hpCB hpAC hpBC hT).1
+
+/-- Transitively, the first and third ratios agree as well:
+`sin(a)/sin(α) = sin(c)/sin(γ)`. -/
+theorem spherical_law_of_sines_ac (A B C : Fin 3 → ℝ)
+    (hA : IsUnit3 A) (hB : IsUnit3 B) (hC : IsUnit3 C)
+    (hpBA : normSq (projPerp B A) ≠ 0) (hpCA : normSq (projPerp C A) ≠ 0)
+    (hpAB : normSq (projPerp A B) ≠ 0) (hpCB : normSq (projPerp C B) ≠ 0)
+    (hpAC : normSq (projPerp A C) ≠ 0) (hpBC : normSq (projPerp B C) ≠ 0)
+    (hT : tripleProduct A B C ≠ 0) :
+    Real.sin (arcLen B C) / Real.sin (dihedralAngle A B C) =
+      Real.sin (arcLen A B) / Real.sin (dihedralAngle C A B) := by
+  obtain ⟨h1, h2⟩ := spherical_law_of_sines A B C hA hB hC
+    hpBA hpCA hpAB hpCB hpAC hpBC hT
+  rw [h1, h2]
+
+end SphericalLawOfSinesOQ01

--- a/src/data/proofs/spherical-law-of-sines-oq-01/annotations.json
+++ b/src/data/proofs/spherical-law-of-sines-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sls-oq01-sin-arclen-nonneg",
+    "proofId": "spherical-law-of-sines-oq-01",
+    "range": { "startLine": 43, "endLine": 46 },
+    "type": "theorem",
+    "title": "Sines of Side Arc-Lengths are Non-Negative",
+    "content": "sin_arcLen_nonneg supplies half of the sign information needed to remove the squares. Since arcLen u v = arccos(u·v) lies in [0,π], Real.sin_arccos rewrites sin(arcLen u v) = √(1 − (u·v)²), which is non-negative by Real.sqrt_nonneg.",
+    "mathContext": "\\sin(\\operatorname{arcLen}(u,v)) = \\sqrt{1-(u\\cdot v)^2} \\ge 0",
+    "significance": "key",
+    "relatedConcepts": ["arccos", "Real.sin_arccos", "non-negativity"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-sls-oq01-sin-dihedral-nonneg",
+    "proofId": "spherical-law-of-sines-oq-01",
+    "range": { "startLine": 49, "endLine": 55 },
+    "type": "theorem",
+    "title": "Sines of Dihedral Angles are Non-Negative",
+    "content": "sin_dihedralAngle_nonneg handles the other family of sines. The model's dihedralAngle is defined by cases: it is 0 in the degenerate branch (sin 0 = 0) and arccos(·) otherwise (sin(arccos t) = √(1−t²) ≥ 0). split_ifs discharges both branches, so every dihedral-angle sine is ≥ 0.",
+    "mathContext": "\\sin(\\operatorname{dihedralAngle}(A,B,C)) \\ge 0",
+    "significance": "key",
+    "relatedConcepts": ["dihedral angle", "case split", "arccos", "non-negativity"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-sls-oq01-ratio-step",
+    "proofId": "spherical-law-of-sines-oq-01",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "theorem",
+    "title": "The Square-Root Step",
+    "content": "ratio_of_sq_ratio is the engine that removes the squares. Given non-negative x,p,y,q with x²/p² = y²/q², it rewrites the hypothesis as (x/p)² = (y/q)² (div_pow) and applies Real.sqrt_sq to each non-negative ratio: x/p = √((x/p)²) = √((y/q)²) = y/q. Division-by-zero is harmless because both √ and / are total.",
+    "mathContext": "\\frac{x^2}{p^2}=\\frac{y^2}{q^2},\\ x,p,y,q\\ge 0 \\;\\Longrightarrow\\; \\frac{x}{p}=\\frac{y}{q}",
+    "significance": "key",
+    "relatedConcepts": ["Real.sqrt_sq", "div_pow", "non-negative ratios"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-sls-oq01-law",
+    "proofId": "spherical-law-of-sines-oq-01",
+    "range": { "startLine": 75, "endLine": 93 },
+    "type": "theorem",
+    "title": "The Unsquared Spherical Law of Sines",
+    "content": "spherical_law_of_sines is the headline result. It destructures the parent's spherical_law_of_sines_all_sq into the two squared-ratio equalities and feeds each — paired with sin_arcLen_nonneg and sin_dihedralAngle_nonneg for the four sines involved — to ratio_of_sq_ratio, yielding sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ) under exactly the parent's non-degeneracy hypotheses.",
+    "mathContext": "\\frac{\\sin a}{\\sin\\alpha}=\\frac{\\sin b}{\\sin\\beta}=\\frac{\\sin c}{\\sin\\gamma}",
+    "significance": "key",
+    "relatedConcepts": ["spherical law of sines", "proportion", "spherical trigonometry"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-sls-oq01-corollaries",
+    "proofId": "spherical-law-of-sines-oq-01",
+    "range": { "startLine": 95, "endLine": 118 },
+    "type": "theorem",
+    "title": "Two-Ratio and First-vs-Third Forms",
+    "content": "spherical_law_of_sines_two projects out the single equality sin(a)/sin(α) = sin(b)/sin(β); spherical_law_of_sines_ac chains the two equalities transitively to give sin(a)/sin(α) = sin(c)/sin(γ). These are the convenience forms one actually reaches for in computations.",
+    "mathContext": "\\frac{\\sin a}{\\sin\\alpha}=\\frac{\\sin b}{\\sin\\beta},\\qquad \\frac{\\sin a}{\\sin\\alpha}=\\frac{\\sin c}{\\sin\\gamma}",
+    "significance": "standard",
+    "relatedConcepts": ["corollary", "transitivity"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/spherical-law-of-sines-oq-01/meta.json
+++ b/src/data/proofs/spherical-law-of-sines-oq-01/meta.json
@@ -1,0 +1,72 @@
+{
+  "id": "spherical-law-of-sines-oq-01",
+  "title": "Unsquared Spherical Law of Sines: the True Proportion",
+  "slug": "spherical-law-of-sines-oq-01",
+  "description": "Upgrades the parent's SQUARED spherical law of sines (sin²a/sin²α = sin²b/sin²β = sin²c/sin²γ) to the honest textbook proportion sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ). The squared form is one square-root short: an equality of squares x²=y² only forces x=±y. The sign ambiguity is eliminated by a geometric fact about the vector model — every side arc-length is an arccos and every dihedral angle is either 0 or an arccos, so all lie in [0,π] and every sine appearing is non-negative (sin(arccos t) = √(1−t²) ≥ 0). Taking square roots of non-negative quantities is unambiguous, so the squared law upgrades to the genuine proportion. 6 theorems (incl. the non-negativity lemmas sin_arcLen_nonneg, sin_dihedralAngle_nonneg), 0 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Spherical_law_of_sines",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SphericalLawOfSinesOQ01.lean",
+    "tags": [
+      "geometry",
+      "spherical-geometry",
+      "trigonometry",
+      "law-of-sines",
+      "non-euclidean-geometry",
+      "arccos",
+      "square-root"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the foundational propext / Classical.choice / Quot.sound). The non-degeneracy hypotheses (sides and triple product nonzero) are the standard genuine-triangle assumptions inherited from the parent's squared law.",
+    "lineCount": 119,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "sin_arcLen_nonneg: the sine of any side arc-length is non-negative, since arcLen u v = arccos(u·v) ∈ [0,π] and sin(arccos t) = √(1−t²) ≥ 0",
+      "sin_dihedralAngle_nonneg: the sine of any dihedral angle is non-negative, splitting on the model's degenerate branch (sin 0 = 0) and the generic arccos branch (√(1−t²) ≥ 0)",
+      "ratio_of_sq_ratio: the square-root step — for non-negative x,p,y,q, x²/p² = y²/q² implies x/p = y/q (via Real.sqrt_sq on each non-negative ratio)",
+      "spherical_law_of_sines: the full unsquared law of sines, sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ), obtained by applying the square-root step to the parent's spherical_law_of_sines_all_sq with the non-negativity lemmas",
+      "spherical_law_of_sines_two and spherical_law_of_sines_ac: the two-ratio and first-vs-third convenience forms"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The spherical law of sines is classically stated as a proportion of plain sines, sin(a)/sin(A) = sin(b)/sin(B) = sin(c)/sin(C), the spherical analogue of the planar law of sines and a workhorse of celestial navigation and geodesy. A determinant/cross-product derivation in ℝ³ (as in the parent file) most naturally produces the SQUARED identity, because the quantities that appear are squared norms of projections and a squared triple product. Recovering the textbook proportion from the squared identity is exactly the step where one must know the signs: in the standard convention a spherical triangle's sides and angles all lie strictly between 0 and π, so their sines are positive and the proportion is unambiguous. This entry makes that final, often-glossed square-root step explicit and rigorous.",
+    "problemStatement": "From the parent's squared spherical law of sines, derive the genuine (unsquared) proportion sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ).",
+    "text": "The parent proves sin²(a)/sin²(α) = sin²(b)/sin²(β) = sin²(c)/sin²(γ) for unit-vector vertices A,B,C, with a = arcLen B C the side opposite A and α = dihedralAngle A B C the interior angle at A. To remove the squares, observe each sine is non-negative: arcLen u v = arccos(u·v) has range [0,π], and dihedralAngle A B C is by definition either 0 (degenerate) or arccos(·); since sin(arccos t) = √(1−t²) ≥ 0 and sin 0 = 0, all of sin(a), sin(α), … are ≥ 0. For non-negative x,p,y,q, the equality x²/p² = y²/q² rewrites as (x/p)² = (y/q)² (div_pow), and applying Real.sqrt_sq to each non-negative ratio gives x/p = √((x/p)²) = √((y/q)²) = y/q. Applying this to each pair of squared ratios yields the unsquared law of sines.",
+    "proofStrategy": "sin_arcLen_nonneg unfolds arcLen to arccos, rewrites sin(arccos) = √(1−·²) (Real.sin_arccos), and concludes by Real.sqrt_nonneg. sin_dihedralAngle_nonneg unfolds dihedralAngle and split_ifs: the degenerate branch is sin 0 = 0; the generic branch is again sin(arccos) ≥ 0. ratio_of_sq_ratio packages the square-root step using div_pow and Real.sqrt_sq (which needs the non-negativity of each ratio, supplied by div_nonneg). spherical_law_of_sines destructures the parent's spherical_law_of_sines_all_sq into its two squared-ratio equalities and feeds each, together with the matching non-negativity facts, to ratio_of_sq_ratio. The two-ratio and first-vs-third corollaries follow by projection and transitivity.",
+    "keyInsights": [
+      "The square-root step is where a clean determinant derivation meets the textbook statement: the squared law is sign-blind, the unsquared law is not",
+      "Non-negativity of every sine is forced purely by the model's definitions — arcLen and dihedralAngle are arccos-valued (or 0), hence valued in [0,π]",
+      "sin(arccos t) = √(1 − t²) ≥ 0 is the single identity that supplies all the non-negativity; no case analysis on the geometry is needed",
+      "For non-negative ratios, x²/p² = y²/q² ⇒ x/p = y/q is just Real.sqrt_sq applied twice — division-by-zero degeneracies are harmless because √ and / are total in Lean",
+      "Removing the squares loses no hypotheses: the proportion holds under exactly the parent's non-degeneracy assumptions (nonzero sides and triple product)"
+    ],
+    "prerequisites": [
+      "The parent's squared spherical law of sines (spherical_law_of_sines_all_sq) and its vector model (arcLen, dihedralAngle, projPerp, tripleProduct)",
+      "sin(arccos t) = √(1 − t²) (Real.sin_arccos) and non-negativity of the square root",
+      "√(x²) = x for x ≥ 0 (Real.sqrt_sq) and (a/b)² = a²/b² (div_pow)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The spherical law of sines holds in its true unsquared form sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ), recovered from the parent's squared identity by taking square roots — unambiguous because every sine in the vector model is non-negative (arcLen and dihedralAngle are arccos-valued, hence in [0,π]). 6 theorems, 0 definitions, 119 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the spherical law of sines to its standard textbook statement, making it directly usable for spherical-trigonometry computations (navigation, geodesy) without carrying squares. The same square-root-of-non-negative-sines pattern upgrades any squared spherical identity derived in the vector model.",
+    "openQuestions": [
+      "Express the common ratio explicitly as |det[A,B,C]| / (sin(a)·sin(b)·sin(c)), tying the proportion to the volume of the parallelepiped on the three vertices",
+      "Combine with the dual spherical law of cosines to derive the four-parts (cotangent) formula in the same vector framework"
+    ]
+  },
+  "leanFile": {
+    "namespace": "SphericalLawOfSinesOQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/SphericalLawOfSinesOQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Upgrades the parent (`spherical-law-of-sines`) **squared** law of sines
`sin²a/sin²α = sin²b/sin²β = sin²c/sin²γ` to the genuine textbook proportion

> sin(a)/sin(α) = sin(b)/sin(β) = sin(c)/sin(γ).

A determinant/cross-product derivation naturally yields the *squared* identity. Recovering the textbook statement is exactly the square-root step — and `x² = y²` only forces `x = ±y`. The sign ambiguity is removed by a fact of the vector model: `arcLen u v = arccos(u·v)` and `dihedralAngle A B C` is either `0` or an `arccos`, so **every sine is non-negative** (`sin(arccos t) = √(1−t²) ≥ 0`). Square-rooting non-negative quantities is unambiguous.

## Theorems (6)

- `sin_arcLen_nonneg`, `sin_dihedralAngle_nonneg` — the sign lemmas (the dihedral case splits on the model's degenerate branch).
- `ratio_of_sq_ratio` — for non-negative `x,p,y,q`, `x²/p² = y²/q² ⇒ x/p = y/q` (two `Real.sqrt_sq` applications).
- `spherical_law_of_sines` — the headline all-three-ratios proportion.
- `spherical_law_of_sines_two`, `spherical_law_of_sines_ac` — two-ratio and first-vs-third corollaries.

Holds under exactly the parent's non-degeneracy hypotheses (no hypotheses lost in removing the squares).

## Verification

- 0 sorries, 0 `axiom` declarations.
- `#print axioms` on the headline theorems: only `propext`, `Classical.choice`, `Quot.sound`.
- Built offline with `lake env lean` (Docker daemon unavailable in this environment). Imports parent module `Proofs.SphericalLawOfSines`.

## Files

- `proofs/Proofs/SphericalLawOfSinesOQ01.lean` (119 lines)
- `proofs/Proofs.lean` — aggregator import
- `src/data/proofs/spherical-law-of-sines-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)