### PR TITLE
audit(gallery): 10 fresh proofs ALL CLEAN, queue re-drained 3926/3926

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24318,6 +24318,66 @@
       "lastAudited": "2026-06-25T19:48:27Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1005-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1021-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1204": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factorial-telescoping-sum-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lebesgue-measure-oq-06-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "telescoping-product-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:00:17Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 10 never-before-audited proofs in the queue. **All 10 CLEAN** — every meta.json claim matches the Lean source. Queue re-drained to 3926/3926 audited, 0 with issues.

### Mechanical checks (all pass)
0 undisclosed sorries, 0 undisclosed axioms, 0 `native_decide`, 0 `True`-stubs. Theorem counts match metadata.

### Notable narrative verifications
- **lebesgue-measure-oq-06-oq-01** (Banach-Tarski / Hausdorff free subgroup of SO(3)): the child file imports a parent that declares `axiom banach_tarski` (parent line 888). Verified the child only uses the **axiom-free** `hausdorff_free_subgroup` theorem (parent line 554 — declared *before* the axiom, so it cannot depend on it). The 0-axiom / `verified` claim is honest, and the metadata proactively discloses the parent's axiom.
- **erdos-1204**: honestly `status=axiomatized` / `badge=wip` — the file proves only admissibility support lemmas; the headline A(k)~k log k and B(k) questions are explicitly documented as OPEN, not formalized. Exemplary conservative claiming.
- **erdos-1021-wip-01**: `badge=verified` correctly scoped to the local degree structure of the bipartite pair graph G_k; the open Erdős #1021 question is explicitly not addressed.
- **binomial-theorem-oq-02-oq-02-oq-02-oq-03**: `theoremCount=8` is correct (2 declarations are `@[simp]`-prefixed and escape a naive `^theorem` grep). `badge=mathlib` appropriate.

### Proofs audited
abel-ruffini-galois-extensions-oq-03 · antitone-integral-sum-comparison-oq-01-oq-01-oq-02-oq-01 · bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02 · binomial-theorem-oq-02-oq-02-oq-02-oq-03 · erdos-1005-oq-02 · erdos-1021-wip-01 · erdos-1204 · factorial-telescoping-sum-oq-01 · lebesgue-measure-oq-06-oq-01 · telescoping-product-oq-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)