### PR TITLE
research(centered-hexagonal-sum-oq-01): ∑(3k(k−1)+1)=n³ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CenteredHexagonalSum.lean
+++ b/proofs/Proofs/CenteredHexagonalSum.lean
@@ -1,0 +1,101 @@
+import Mathlib
+
+/-
+# Centered Hexagonal Numbers Sum to Cubes
+
+## Open Question (centered-hexagonal-sum-oq-01)
+
+The k-th *centered hexagonal number* is `Hₖ = 3k(k−1)+1` — the count of dots in
+`k` nested hexagonal rings: `1, 7, 19, 37, 61, …`.  The classical figurate
+identity states that the sum of the first `n` of them is always the perfect
+cube `n³`:
+
+    ∑_{k=1}^{n} (3k(k−1)+1) = n³        (1 + 7 + 19 = 27 = 3³).
+
+## Result
+
+A fully machine-checked, self-contained proof, stated in two equivalent forms:
+
+* `sum_centeredHex_range` — the reindexed form `∑_{k<n} H_{k+1} = n³`, whose
+  inductive step closes in a single `ring` call (the reindexing `H_{k+1}` removes
+  any truncated ℕ subtraction).
+* `sum_centeredHex_Icc` — the classical `1`-indexed statement `∑_{k=1}^{n} Hₖ = n³`
+  over the interval `[1, n]`, proved by the same one-step induction with
+  `Finset.sum_Icc_succ_top`.
+
+The cube-shell intuition is captured by `centeredHex_eq_cube_diff`, the
+telescoping identity `Hₖ = k³ − (k−1)³`: each centered hexagonal number is the
+gap between consecutive cubes, which is *why* the partial sums collapse to `n³`.
+
+## Novelty
+
+Mathlib has the Gauss triangular-number identity and (via the sister gallery
+entry) Nicomachus's `∑k³ = (∑k)²`, but no named "centered hexagonal partial sum
+= n³" lemma.  This file supplies it.  The main statement lives entirely in ℕ
+(the summand `3k(k−1)+1` is a natural number), so no integer casts are needed
+for the headline result; casts appear only in the optional cube-difference
+identity, where genuine subtraction occurs.
+
+0 sorries, 0 axioms.
+-/
+
+namespace CenteredHexagonalSum
+
+open Finset
+
+/-- The `k`-th **centered hexagonal number** `Hₖ = 3k(k−1)+1`: the sequence
+`1, 7, 19, 37, 61, …` (OEIS A003215). -/
+def centeredHex (k : ℕ) : ℕ := 3 * k * (k - 1) + 1
+
+/-- Reindexed summand: `H_{k+1} = 3(k+1)k + 1`.  Shifting the index by one turns
+the truncated ℕ subtraction `(k+1) − 1` into the honest `k`, so the term is a
+plain polynomial that `ring` can manipulate. -/
+theorem centeredHex_succ (k : ℕ) : centeredHex (k + 1) = 3 * (k + 1) * k + 1 := by
+  simp [centeredHex]
+
+/-- **Cube-shell identity.**  Each centered hexagonal number is the difference of
+consecutive cubes, `Hₖ = k³ − (k−1)³`.  Stated over ℤ because the subtraction is
+genuine (e.g. `H₀ = 0³ − (−1)³ = 1`).  This is the geometric reason the partial
+sums telescope to `n³`: the `n` hexagonal shells are exactly the `n` cubic
+shells `k³ − (k−1)³`. -/
+theorem centeredHex_eq_cube_diff (k : ℕ) :
+    (centeredHex k : ℤ) = (k : ℤ) ^ 3 - ((k : ℤ) - 1) ^ 3 := by
+  cases k with
+  | zero => norm_num [centeredHex]
+  | succ p =>
+    simp only [centeredHex, Nat.succ_sub_one]
+    push_cast
+    ring
+
+/-- **Centered hexagonal sum (reindexed form).**  The first `n` centered
+hexagonal numbers sum to `n³`:
+
+`∑_{k<n} H_{k+1} = n³`.
+
+The induction is immediate: peeling the top term with `Finset.sum_range_succ` and
+applying the inductive hypothesis leaves `m³ + (3(m+1)m + 1) = (m+1)³`, an
+identity `ring` closes outright. -/
+theorem sum_centeredHex_range (n : ℕ) :
+    ∑ k ∈ range n, centeredHex (k + 1) = n ^ 3 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, ih, centeredHex_succ]
+    ring
+
+/-- **Centered hexagonal sum (classical 1-indexed form).**
+
+`∑_{k=1}^{n} Hₖ = n³`.
+
+This is the statement exactly as Nicomachus-style figurate identities are
+usually phrased — over the interval `[1, n]`.  It is proved by the same one-step
+induction, peeling the top term `H_{m+1}` with `Finset.sum_Icc_succ_top`. -/
+theorem sum_centeredHex_Icc (n : ℕ) :
+    ∑ k ∈ Icc 1 n, centeredHex k = n ^ 3 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ m + 1), ih, centeredHex_succ]
+    ring
+
+end CenteredHexagonalSum

--- a/src/data/proofs/centered-hexagonal-sum-oq-01/annotations.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "ann-definition",
+    "proofId": "centered-hexagonal-sum-oq-01",
+    "range": { "startLine": 48, "endLine": 54 },
+    "type": "definition",
+    "title": "Centered Hexagonal Number Hₖ = 3k(k−1)+1",
+    "content": "The $k$-th centered hexagonal number counts dots in $k$ nested hexagonal rings: $1, 7, 19, 37, 61, \\dots$ (OEIS A003215). The companion lemma `centeredHex_succ` rewrites $H_{k+1} = 3(k+1)k + 1$: shifting the index by one turns the truncated $\\mathbb{N}$ subtraction $(k+1)-1$ into the honest $k$, so the summand becomes a plain polynomial that `ring` can manipulate. This reindexing is what keeps the headline result inside $\\mathbb{N}$.",
+    "mathContext": "$H_k = 3k(k-1)+1$, and $H_{k+1} = 3(k+1)k + 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Figurate numbers", "Truncated natural subtraction", "Reindexing"]
+  },
+  {
+    "id": "ann-cube-shell",
+    "proofId": "centered-hexagonal-sum-oq-01",
+    "range": { "startLine": 61, "endLine": 68 },
+    "type": "lemma",
+    "title": "Cube-Shell Identity: Hₖ = k³ − (k−1)³",
+    "content": "Each centered hexagonal number is the difference of consecutive cubes — the layer added when growing a $(k-1)^3$ cube to a $k^3$ cube. Stated over $\\mathbb{Z}$ because the subtraction is genuine: e.g. $H_0 = 0^3 - (-1)^3 = 1$. A `cases k` split closes the zero case by `norm_num` and the successor case by `simp only [..., Nat.succ_sub_one]`, `push_cast`, `ring`. This identity is the geometric reason the partial sums telescope to $n^3$: summing the $n$ hexagonal shells is summing the $n$ cubic shells $k^3 - (k-1)^3$.",
+    "mathContext": "$H_k = k^3 - (k-1)^3$ over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Telescoping sums", "Cube differences", "push_cast", "Case analysis"]
+  },
+  {
+    "id": "ann-main-range",
+    "proofId": "centered-hexagonal-sum-oq-01",
+    "range": { "startLine": 78, "endLine": 84 },
+    "type": "theorem",
+    "title": "Main Identity (reindexed range form)",
+    "content": "$\\sum_{k<n} H_{k+1} = n^3$. The base case is `simp` (empty sum). In the step, `Finset.sum_range_succ` peels the top term, the inductive hypothesis rewrites the remaining sum to $m^3$, and `centeredHex_succ` expands $H_{m+1}$, leaving $m^3 + (3(m+1)m + 1) = (m+1)^3$ — a single-number identity closed by `ring`. Because the summand was reindexed, no truncated subtraction ever reaches `ring`, so the whole proof lives in $\\mathbb{N}$.",
+    "mathContext": "$\\sum_{k<n} H_{k+1} = n^3$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
+    "relatedConcepts": ["Power sums", "Figurate numbers", "Induction"]
+  },
+  {
+    "id": "ann-main-icc",
+    "proofId": "centered-hexagonal-sum-oq-01",
+    "range": { "startLine": 93, "endLine": 99 },
+    "type": "theorem",
+    "title": "Main Identity (classical 1-indexed form)",
+    "content": "$\\sum_{k \\in [1,n]} H_k = n^3$, the statement exactly as figurate identities are usually phrased. The proof mirrors the range form: base case `simp` (empty interval), step peels the top term with `Finset.sum_Icc_succ_top` (whose side condition $1 \\le m+1$ is discharged by `omega`), applies the hypothesis and `centeredHex_succ`, then closes with `ring`. The two forms agree because the $k=0$ term of $H_k$ contributes the same constant in either indexing.",
+    "mathContext": "$\\sum_{k=1}^{n} H_k = n^3$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_Icc_succ_top"],
+    "relatedConcepts": ["Interval sums", "Figurate numbers", "Induction"]
+  }
+]

--- a/src/data/proofs/centered-hexagonal-sum-oq-01/meta.json
+++ b/src/data/proofs/centered-hexagonal-sum-oq-01/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "centered-hexagonal-sum-oq-01",
+  "title": "Centered Hexagonal Numbers Sum to Cubes: ∑(3k(k−1)+1) = n³",
+  "slug": "centered-hexagonal-sum-oq-01",
+  "description": "A fully machine-checked, self-contained proof that the sum of the first n centered hexagonal numbers Hₖ = 3k(k−1)+1 (the sequence 1, 7, 19, 37, 61, …) is the perfect cube n³: ∑_{k=1}^{n} (3k(k−1)+1) = n³. Proved by a one-step induction in ℕ — the inductive step reduces to m³ + (3(m+1)m+1) = (m+1)³, which `ring` closes outright. Given in both the reindexed range form and the classical 1-indexed Icc form, plus the cube-shell identity Hₖ = k³ − (k−1)³ that explains why the partial sums telescope to cubes. Mathlib has the triangular-number and (via the sister Nicomachus entry) sum-of-cubes identities, but not this one.",
+  "meta": {
+    "author": "Classical figurate identity (folklore); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Centered_hexagonal_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "figurate",
+      "centered-hexagonal-numbers",
+      "cubes",
+      "power-sums",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CenteredHexagonalSum.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. The engine of the reindexed inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "Peels the top term off an interval-sum: for a ≤ b+1, ∑_{k ∈ Icc a (b+1)} f k = (∑_{k ∈ Icc a b} f k) + f (b+1). Drives the 1-indexed inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      }
+    ],
+    "originalContributions": [
+      "The centered-hexagonal partial-sum identity ∑_{k=1}^{n} (3k(k−1)+1) = n³, machine-checked over ℕ with 0 axioms and 0 sorries — a named figurate identity Mathlib's BigOperators library does not provide",
+      "The reindexed form ∑_{k<n} H_{k+1} = n³ whose inductive step collapses to the single ring identity m³ + (3(m+1)m+1) = (m+1)³, keeping the headline result entirely inside ℕ with no integer casts",
+      "The classical 1-indexed interval form ∑_{k ∈ Icc 1 n} Hₖ = n³, matching the way figurate identities are usually stated, via Finset.sum_Icc_succ_top",
+      "The cube-shell identity Hₖ = k³ − (k−1)³ (over ℤ), exhibiting each centered hexagonal number as the gap between consecutive cubes — the geometric reason the partial sums telescope to n³"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 101,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions); the cube-difference lemma uses only propext and Quot.sound. No native_decide, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Centered Hexagonal Number",
+      "startLine": 46,
+      "endLine": 54,
+      "summary": "Defines Hₖ = 3k(k−1)+1 (the sequence 1, 7, 19, 37, 61, …, OEIS A003215) and the reindexing lemma H_{k+1} = 3(k+1)k + 1, which turns the truncated ℕ subtraction (k+1)−1 into the honest k so the summand becomes a plain polynomial."
+    },
+    {
+      "id": "cube-shell",
+      "title": "The Cube-Shell Identity",
+      "startLine": 56,
+      "endLine": 68,
+      "summary": "Hₖ = k³ − (k−1)³, stated over ℤ because the subtraction is genuine (H₀ = 0³ − (−1)³ = 1). A case split removes the zero case and `push_cast`/`ring` close the successor case. This exhibits each hexagonal shell as a cubic shell, the geometric reason the partial sums telescope to n³."
+    },
+    {
+      "id": "main-range",
+      "title": "Main Identity (reindexed range form)",
+      "startLine": 70,
+      "endLine": 84,
+      "summary": "∑_{k<n} H_{k+1} = n³ by induction. The step peels the top term with Finset.sum_range_succ, applies the inductive hypothesis, and substitutes H_{m+1} = 3(m+1)m+1, leaving m³ + (3(m+1)m+1) = (m+1)³ — closed by a single `ring`."
+    },
+    {
+      "id": "main-icc",
+      "title": "Main Identity (classical 1-indexed form)",
+      "startLine": 86,
+      "endLine": 99,
+      "summary": "∑_{k ∈ Icc 1 n} Hₖ = n³, the statement exactly as figurate identities are usually phrased. Same one-step induction, peeling the top term H_{m+1} with Finset.sum_Icc_succ_top (using 1 ≤ m+1 from `omega`) and closing with `ring`."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Hexagonal shells and cubes**\n\nThe centered hexagonal numbers $H_k = 3k(k-1)+1$ count dots arranged in $k$ nested hexagonal rings: a single central dot, then rings of $6, 12, 18, \\dots$ dots, giving $1, 7, 19, 37, 61, \\dots$ (OEIS A003215). A classical figurate observation is that their partial sums are exactly the perfect cubes:\n$$1 = 1^3,\\quad 1+7 = 8 = 2^3,\\quad 1+7+19 = 27 = 3^3,\\quad \\dots$$\nThe picture behind this is that the $k$-th hexagonal shell can be reassembled into the cubic shell $k^3 - (k-1)^3$ — the layer added when growing an $(k-1)\\times(k-1)\\times(k-1)$ cube to a $k\\times k\\times k$ cube. Summing the shells telescopes to $n^3$. Mathlib already contains Gauss's triangular-number identity and, via the sister Nicomachus gallery entry, $\\sum k^3 = (\\sum k)^2$, but not this centered-hexagonal partial-sum identity.",
+    "problemStatement": "**Centered hexagonal numbers sum to cubes**\n\nFor every natural number $n$,\n$$\\sum_{k=1}^{n} \\bigl(3k(k-1)+1\\bigr) = n^3.$$\nThe goal is a fully machine-checked proof with no axioms, no sorries, and — for the headline result — no escape to $\\mathbb{Z}$, since the summand $3k(k-1)+1$ is already a natural number.",
+    "proofStrategy": "**One-step induction, reduced to a single ring identity**\n\nReindex the sum so the summand carries no truncated subtraction: $H_{k+1} = 3(k+1)k + 1$. The inductive step for $\\sum_{k<m} H_{k+1} = m^3$ peels the top term via `Finset.sum_range_succ`, applies the hypothesis, and leaves\n$$m^3 + \\bigl(3(m+1)m + 1\\bigr) = (m+1)^3,$$\nan identity `ring` closes in one shot. The classical $1$-indexed form $\\sum_{k\\in[1,n]} H_k = n^3$ is proved the same way, peeling with `Finset.sum_Icc_succ_top`. The optional cube-shell identity $H_k = k^3 - (k-1)^3$ (over $\\mathbb{Z}$, where the subtraction is genuine) makes the telescoping explanation precise.",
+    "keyInsights": [
+      "**Reindex to kill the subtraction.** Writing the summand as $H_{k+1} = 3(k+1)k+1$ replaces the truncated ℕ subtraction $(k+1)-1$ by the honest $k$, so the inductive step is a pure polynomial identity and the headline result never leaves $\\mathbb{N}$.",
+      "**The whole step is one scalar identity.** After peeling the top term, the goal is $m^3 + (3(m+1)m+1) = (m+1)^3$ — a fact about a single number $m$, independent of the sum, dispatched by `ring`.",
+      "**Hexagonal shell = cubic shell.** The cube-difference identity $H_k = k^3-(k-1)^3$ shows each centered hexagonal number is the layer between consecutive cubes; summing telescopes directly to $n^3$. This is stated over $\\mathbb{Z}$ because the subtraction is real (e.g. $H_0 = 0^3-(-1)^3 = 1$).",
+      "**Two phrasings, one proof.** Both the $0$-indexed `range` form and the classical $1$-indexed `Icc` form follow from the identical peel-then-`ring` induction, using `sum_range_succ` and `sum_Icc_succ_top` respectively."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range` and `Finset.Icc`",
+      "Figurate (polygonal) numbers"
+    ]
+  },
+  "conclusion": {
+    "summary": "The centered-hexagonal partial-sum identity $\\sum_{k=1}^{n}(3k(k-1)+1) = n^3$ is established by a one-step induction whose inductive step reduces to the single elementary identity $m^3 + (3(m+1)m+1) = (m+1)^3$. The headline result stays entirely within $\\mathbb{N}$ — reindexing $H_{k+1} = 3(k+1)k+1$ removes the only truncated subtraction — and depends on just two Mathlib lemmas (`sum_range_succ`, `sum_Icc_succ_top`). The cube-shell identity $H_k = k^3-(k-1)^3$ supplies the telescoping intuition. 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the centered-hexagonal-sum / cube identity that Mathlib's BigOperators library does not provide, in a form (`sum_centeredHex_range`, `sum_centeredHex_Icc`) directly reusable by other gallery proofs.",
+      "Complements the Nicomachus $\\sum k^3 = (\\sum k)^2$ entry, rounding out the figurate-number-to-power-sum family in the gallery.",
+      "The cube-shell identity `centeredHex_eq_cube_diff` packages the telescoping reason cubes appear, available for downstream reuse."
+    ],
+    "openQuestions": [
+      "Do the analogous centered-polygonal partial sums admit equally clean closed forms — and which case-split / reindexing pattern keeps each inside ℕ?",
+      "Can the cube-shell picture be promoted to a genuinely combinatorial proof in Lean (a bijection between the n hexagonal shells and the n cubic shells), matching the visual dissection?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the classical figurate identity that the partial sums of the **centered hexagonal numbers** are perfect cubes:

$$\sum_{k=1}^{n} \bigl(3k(k-1)+1\bigr) = n^3 \qquad (1 + 7 + 19 = 27 = 3^3).$$

Here $H_k = 3k(k-1)+1$ is the $k$-th centered hexagonal number ($1, 7, 19, 37, 61, \dots$, OEIS A003215). **Verified: 0 sorries, 0 axioms.**

## Progress

New proof file `proofs/Proofs/CenteredHexagonalSum.lean` (101 lines, 1 def + 4 theorems):

- `centeredHex` / `centeredHex_succ` — the definition and the reindexing $H_{k+1} = 3(k+1)k+1$ that removes truncated ℕ subtraction.
- `centeredHex_eq_cube_diff` — the **cube-shell identity** $H_k = k^3 - (k-1)^3$ (over ℤ), the telescoping reason cubes appear.
- `sum_centeredHex_range` — $\sum_{k<n} H_{k+1} = n^3$; the inductive step collapses to $m^3 + (3(m+1)m+1) = (m+1)^3$, closed by `ring`.
- `sum_centeredHex_Icc` — the classical 1-indexed $\sum_{k=1}^{n} H_k = n^3$ via `Finset.sum_Icc_succ_top`.

Gallery entry: `src/data/proofs/centered-hexagonal-sum-oq-01/{meta.json,annotations.json}`.

## Findings

- Reindexing the summand to $H_{k+1}$ keeps the headline result entirely in ℕ (no integer casts); the only genuine subtraction is isolated in the optional cube-shell lemma over ℤ.
- Each inductive step reduces to a single-variable polynomial identity that `ring` dispatches outright — directly analogous to the sister `nicomachus-sum-of-cubes-oq-01` entry. Mathlib has the triangular-number and sum-of-cubes identities but not this centered-hexagonal one.

## Verification

Built via single-file `lake env lean` against prebuilt Mathlib v4.26.0 (Docker daemon unavailable this session): compiles clean, exit 0. `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (the cube-shell lemma uses only `propext`, `Quot.sound`) — none of which count as assumptions.

## Status

**Outcome**: completed (SOLVED — 0 sorries, 0 axioms)
**Next Steps**: follow-up open questions recorded in meta.json (centered-polygonal generalizations; a bijective/combinatorial proof matching the visual dissection).

🤖 Generated by researcher-4