### PR TITLE
research(erdos-1204): structural properties + well-definedness of A(k) [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -120,6 +120,70 @@ theorem not_admissible_zero_one : ¬ Admissible ({0, 1} : Finset ℕ) := by
   · exact (hr 0 (by decide)) (by decide)
   · exact (hr 1 (by decide)) (by decide)
 
+/- ## Structural properties
+
+Admissibility is closed downward and is invariant under translation, and admissible
+`k`-tuples exist for every `k` — so the extremal quantity `A(k)` is well-defined. -/
+
+/-- **Downward closure.** Any subset of an admissible set is admissible: a residue class
+missed by `a` mod `p` is still missed by any subset of `a`. -/
+theorem Admissible.subset {a b : Finset ℕ} (ha : Admissible a) (hba : b ⊆ a) :
+    Admissible b := by
+  intro p hp
+  obtain ⟨r, hr⟩ := ha p hp
+  exact ⟨r, fun x hx => hr x (hba hx)⟩
+
+/-- **Translation invariance.** Translating every element by a fixed `t` preserves
+admissibility: if `a` misses class `r` modulo `p`, then `a + t` misses class `r + t`.
+Admissibility depends only on the *pattern* of a tuple, not its position. -/
+theorem admissible_image_add {a : Finset ℕ} (t : ℕ) (ha : Admissible a) :
+    Admissible (a.image (· + t)) := by
+  intro p hp
+  obtain ⟨r, hr⟩ := ha p hp
+  refine ⟨r + (t : ZMod p), fun y hy => ?_⟩
+  obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp hy
+  have hx' := hr x hx
+  push_cast
+  exact fun h => hx' (add_right_cancel h)
+
+/-- Translation by a fixed `t` is injective, so it preserves cardinality: it sends
+admissible `k`-tuples to admissible `k`-tuples. -/
+theorem card_image_add (a : Finset ℕ) (t : ℕ) :
+    (a.image (· + t)).card = a.card :=
+  Finset.card_image_of_injective _ (add_left_injective t)
+
+/-- **Existence / well-definedness of `A(k)`.** For every `k` there is an admissible set of
+size exactly `k`, so the extremal value `A(k) = min a_k` is taken over a nonempty family.
+
+Construction: the multiples `0, N, 2N, …, (k-1)N` of the primorial
+`N = ∏_{p ≤ k, p prime} p`. Modulo each prime `p ≤ k` every element is `≡ 0` (since `p ∣ N`),
+so the class `1` is missed; primes `p > k = card` are automatic by `missing_class_of_card_lt`.
+This also gives the explicit (weak) upper bound `A(k) ≤ (k-1)·∏_{p ≤ k} p`. -/
+theorem exists_admissible_card (k : ℕ) :
+    ∃ a : Finset ℕ, a.card = k ∧ Admissible a := by
+  classical
+  -- An `N > 0` divisible by every prime `p ≤ k` (the primorial works).
+  obtain ⟨N, hNpos, hNdvd⟩ : ∃ N : ℕ, 0 < N ∧ ∀ p, p.Prime → p ≤ k → p ∣ N := by
+    refine ⟨((Finset.range (k + 1)).filter Nat.Prime).prod id, ?_, ?_⟩
+    · exact Finset.prod_pos (fun q hq => (Finset.mem_filter.mp hq).2.pos)
+    · intro p hp hpk
+      exact Finset.dvd_prod_of_mem id
+        (Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), hp⟩)
+  have hinj : Function.Injective (fun x : ℕ => x * N) :=
+    fun x y h => Nat.eq_of_mul_eq_mul_right hNpos h
+  refine ⟨(Finset.range k).image (fun x => x * N), ?_, ?_⟩
+  · rw [Finset.card_image_of_injective _ hinj, Finset.card_range]
+  · rw [admissible_iff_card, Finset.card_image_of_injective _ hinj, Finset.card_range]
+    intro p hp hpk
+    haveI : Fact p.Prime := ⟨hp⟩
+    have hp0 : (N : ZMod p) = 0 :=
+      (CharP.cast_eq_zero_iff (ZMod p) p N).mpr (hNdvd p hp hpk)
+    refine ⟨1, fun x hx => ?_⟩
+    obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hx
+    push_cast
+    rw [hp0, mul_zero]
+    exact zero_ne_one
+
 /- ## Open Problems
 
 The asymptotic behaviour of the extremal quantities is OPEN:

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -41,3 +41,19 @@ We call a sequence of integers $0\leq a_1<\cdots <a_k$ admissible if it is missi
 ---
 
 *Generated from erdosproblems.com on 2026-04-16*
+
+## Session 2026-06-25 (researcher-1) — structural properties + well-definedness of A(k)
+
+Added 4 verified theorems (now 10 thm/1 def, 0 axioms, 0 sorries):
+- `Admissible.subset` — downward closure (subset of admissible is admissible).
+- `admissible_image_add` — translation invariance (a ↦ a+t preserves admissibility);
+  `card_image_add` — translation preserves cardinality.
+- `exists_admissible_card` — **an admissible k-set exists for every k** (multiples
+  0,N,2N,…,(k-1)N of the primorial N=∏_{p≤k}p), so **A(k) is well-defined**, with the
+  explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p.
+
+Insight: admissibility is a property of the *pattern*, not the position. The headline
+A(k)∼k log k and B(k) estimate remain OPEN (need sieve theory).
+
+Gotcha: `(N:ZMod p)=0` from `p∣N` via `CharP.cast_eq_zero_iff (ZMod p) p N` (no NeZero needed,
+unlike `ZMod.natCast_zmod_eq_zero_iff_dvd`); `push_cast` then `rw [hp0, mul_zero]; exact zero_ne_one`.

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -55,9 +55,9 @@
       "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)"
     ],
     "axiomCount": 0,
-    "lineCount": 137,
+    "lineCount": 201,
     "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved (#print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool). Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. The formalization here is the admissibility framework plus the standard reduction to small primes.",
-    "theoremCount": 6,
+    "theoremCount": 10,
     "definitionCount": 1
   },
   "overview": {
@@ -124,9 +124,9 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 137,
+    "lineCount": 201,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,22 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY/BUILD: defined Admissible (Finset ℕ misses a residue class mod every prime); proved missing_class_of_card_lt and the key reduction admissible_iff_card (only primes p ≤ |a| matter); verified examples ∅,{0},{0,2} admissible and {0,1} not. 6 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) estimates remain OPEN.",
+    "progressSummary": "ORIENT/BUILD (session 2): added 4 verified structural theorems to Erdos1204Problem.lean — Admissible.subset (downward closure), admissible_image_add (translation invariance) + card_image_add, and exists_admissible_card (an admissible k-set exists for every k via primorial multiples 0,N,2N,...,(k-1)N ⇒ A(k) well-defined, with explicit weak bound A(k) ≤ (k-1)·∏_{p≤k}p). Now 10 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) remain OPEN.",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
       "Erdos1204.admissible_iff_card (key reduction)",
-      "Erdos1204.admissible_zero_two / not_admissible_zero_one (examples)"
+      "Erdos1204.admissible_zero_two / not_admissible_zero_one (examples)",
+      "Admissible.subset (downward closure) in Erdos1204Problem.lean:130",
+      "admissible_image_add (translation invariance) in Erdos1204Problem.lean:140",
+      "card_image_add (translation preserves card) in Erdos1204Problem.lean:152",
+      "exists_admissible_card (∃ admissible k-set ⇒ A(k) well-defined) in Erdos1204Problem.lean:165"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
       "Reduction: for primes p > k, k elements cannot cover all p classes, so admissibility only constrains primes p ≤ k.",
-      "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2."
+      "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2.",
+      "Admissibility is downward-closed and translation-invariant: it is a property of the *pattern* of a tuple, not its position.",
+      "An admissible k-tuple exists for every k: take multiples 0,N,2N,...,(k-1)N of the primorial N=∏_{p≤k}p; mod each prime p≤k all are ≡0 so class 1 is missed, larger primes auto by size bound. This makes A(k) well-defined and gives the explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Formalize explicit admissible-tuple constructions to bound A(k) above.",
-      "Investigate a lower-bound argument toward A(k) ≳ k log k."
+      "Investigate a lower-bound argument toward A(k) ≳ k log k.",
+      "Define A(k) (and B(k)) as Lean functions (sInf over admissible k-sets) and prove the weak upper bound A(k) ≤ (k-1)·primorial(k) formally.",
+      "The headline A(k)∼k log k needs sieve theory / prime distribution — remains OPEN."
     ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-1204** (admissible sequences; estimate A(k), is A(k)∼k log k?). Builds depth-first on the prior verified formalization.

Adds **4 verified theorems** to `proofs/Proofs/Erdos1204Problem.lean` (now **10 thm / 1 def, 0 axioms, 0 sorries**), establishing the basic structure theory the file was missing:

- `Admissible.subset` — **downward closure**: any subset of an admissible set is admissible.
- `admissible_image_add` — **translation invariance**: `a ↦ a + t` preserves admissibility (admissibility is a property of the *pattern*, not the position).
- `card_image_add` — translation preserves cardinality (sends admissible k-tuples to admissible k-tuples).
- `exists_admissible_card` — **an admissible k-set exists for every k**, so **A(k) is well-defined**. Construction: the multiples `0, N, 2N, …, (k-1)N` of the primorial `N = ∏_{p ≤ k} p`; modulo each prime `p ≤ k` every element is `≡ 0`, missing class `1`, and larger primes are automatic by the size bound. This also yields the explicit (weak) upper bound `A(k) ≤ (k-1)·∏_{p ≤ k} p`.

`#print axioms` shows only the foundational `propext`/`Classical.choice`/`Quot.sound`.

## Status
**Outcome**: progress (verified, 0 axioms, 0 sorries; 4 new theorems on the critical path to A(k)).
The headline `A(k) ∼ k log k` and the `B(k)` estimate remain **OPEN** (require sieve methods / prime distribution) and are not asserted.

## Files
- `proofs/Proofs/Erdos1204Problem.lean` (extended)
- `src/data/proofs/erdos-1204/meta.json` (counts 6→10, 137→201)
- `src/data/research/problems/erdos-1204.json` (knowledge updated)
- `research/problems/erdos-1204/knowledge.md` (session 2 notes)

🤖 Generated by researcher-1