### PR TITLE
Enrich Nullstellensatz-fails-over-ℤ (UFD obstruction): add annotations + section ranges

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "context",
+    "title": "The Open Question and the Two Obstructions",
+    "content": "The docstring frames the entry as the answer to open question #2 of the parent (ℤ[X,Y] is a UFD): can the Nullstellensatz be formalized in the multivariate UFD context? The honest answer is no. Hilbert's Nullstellensatz requires an algebraically closed FIELD of coefficients, and a UFD — even ℤ, the most arithmetically perfect UFD — is not a field. The docstring carefully separates two distinct obstructions: the not-algebraically-closed obstruction (X²+1 over ℝ has no real root, a degree-2 failure handled in the sibling FactorRemainderNullstellensatzOQ01OQ02) and the not-a-field obstruction studied here, which is already visible at degree 0 — the prime constant 2 ∈ ℤ is a nonzero non-unit, so (2) is a proper ideal that nonetheless vanishes nowhere. The same prime 2 witnesses (2,X) being non-principal in the PIR sibling, tying both failures to a single arithmetic fact. It also notes that Mathlib's zeroLocus/vanishingIdeal are field-only, so the entry must first re-develop those notions over a general ring.",
+    "mathContext": "Over an algebraically closed field $k$, $\\sqrt{I} = I(V(I))$ and every proper $I \\subseteq k[X_1,\\dots,X_n]$ has a common zero. Over $\\mathbb{Z}$, $(2)$ is proper yet $V(2) = \\varnothing$.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's Nullstellensatz", "algebraically closed field", "unique factorization domain", "field vs UFD"],
+    "prerequisites": ["the statement of the weak and strong Nullstellensatz", "polynomial rings over a coefficient ring"]
+  },
+  {
+    "id": "ann-ring-level-defs",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 75 },
+    "type": "definition",
+    "title": "Ring-level zeroSet and vanishingId (over any commutative ring)",
+    "content": "Mathlib's MvPolynomial.zeroLocus and vanishingIdeal are defined only with [Field k], so the question cannot even be stated over ℤ with the library primitives — re-developing the basic objects is itself part of the answer. zeroSet I = {x : σ → R | ∀ p ∈ I, eval x p = 0} is the common zero locus of an ideal under MvPolynomial.eval, which is a ring hom over any commutative ring. vanishingId V is dual: the set {p | ∀ x ∈ V, eval x p = 0}, packaged as an Ideal — zero_mem' from map_zero, add_mem' from map_add, smul_mem' from map_mul, each reducing the membership condition through the ring-hom structure of evaluation. The accompanying mem_zeroSet and mem_vanishingId are definitional (Iff.rfl) simp lemmas that unfold membership to the evaluation condition.",
+    "mathContext": "$\\mathrm{zeroSet}(I) = \\{x : \\sigma \\to R \\mid \\forall p \\in I,\\ \\mathrm{eval}_x\\,p = 0\\}$, $\\mathrm{vanishingId}(V) = \\{p \\mid \\forall x \\in V,\\ \\mathrm{eval}_x\\,p = 0\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["MvPolynomial.eval as a ring hom", "zero locus V(I)", "vanishing ideal I(V)", "Galois connection of algebraic geometry"],
+    "prerequisites": ["ideals and submodule closure conditions", "evaluation homomorphism of polynomial rings"]
+  },
+  {
+    "id": "ann-vanishingid-empty",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 77, "endLine": 82 },
+    "type": "technique",
+    "title": "The Vanishing Ideal of the Empty Set is Everything",
+    "content": "vanishingId_empty proves vanishingId (∅ : Set (σ → R)) = ⊤. The membership condition ∀ x ∈ ∅, eval x p = 0 is vacuously true for every polynomial p, so the vanishing ideal of the empty point set is the whole ring. This is the pivot that turns 'the zero locus is empty' into 'the vanishing ideal is ⊤', and it is exactly what makes the strong Nullstellensatz collapse: I(V(2)) = I(∅) = ⊤ while √(2) is still proper.",
+    "mathContext": "$I(\\varnothing) = \\top$: the condition $\\forall x \\in \\varnothing,\\ \\mathrm{eval}_x\\,p = 0$ holds vacuously for all $p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["vacuous truth", "empty zero locus", "the I–V Galois connection at its extremes"],
+    "prerequisites": ["Set.notMem_empty", "ideal extensionality"]
+  },
+  {
+    "id": "ann-general-obstruction",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 107 },
+    "type": "theorem",
+    "title": "The Field-Agnostic Core (weakNSS_fails_of_nonunit)",
+    "content": "weakNSS_fails_of_nonunit isolates the abstract reason the weak Nullstellensatz fails: any nonzero non-unit constant C p produces a counterexample. Properness — (C p) ≠ ⊤ — comes from Ideal.span_singleton_eq_top (span {a} = ⊤ ↔ IsUnit a): if the ideal were everything, C p would be a unit, contradicting the hypothesis. Emptiness of the zero locus — zeroSet (C p) = ∅ — comes from eval_C: at any point x, eval x (C p) = p, which is nonzero, so x is never a common zero. The weak Nullstellensatz claims a proper ideal must have a common zero; over a field there are no nonzero non-units, so the hypothesis can never be met, but over any ring that has one (like ℤ) the claim breaks at the level of constants. This lemma carries all the mathematical content; the ℤ-specific theorems are mere instantiations.",
+    "mathContext": "For $p \\neq 0$ with $C p$ a non-unit: $(C p) \\neq \\top$ and $\\mathrm{zeroSet}(C p) = \\varnothing$, since $\\mathrm{eval}_x(C p) = p \\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Ideal.span_singleton_eq_top", "units of a ring", "eval_C", "constant polynomials"],
+    "prerequisites": ["the unit criterion for principal ideals", "evaluation of constant polynomials"]
+  },
+  {
+    "id": "ann-not-unit-c-two",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 113, "endLine": 121 },
+    "type": "technique",
+    "title": "The Arithmetic Witness: C 2 is Not a Unit (not_isUnit_C_two)",
+    "content": "not_isUnit_C_two supplies the single arithmetic fact that drives everything: C 2 is not a unit in ℤ[X,…]. The trick is to push the supposed unit through the ring homomorphism constantCoeff : MvPolynomial σ ℤ →+* ℤ. A unit maps to a unit (IsUnit.map), and constantCoeff_C sends C 2 ↦ 2, so 2 would be a unit in ℤ; but Int.isUnit_iff forces a unit to be ±1, and norm_num rules out 2 = ±1. This is the same nonzero non-unit 2 ∈ ℤ that witnesses the non-principality of (2,X) in the sibling — one prime, two structural failures.",
+    "mathContext": "$\\neg\\,\\mathrm{IsUnit}(C\\,2)$: $\\mathrm{constantCoeff}(C\\,2) = 2$, and $\\mathrm{IsUnit}(n)$ in $\\mathbb{Z}$ iff $n = \\pm 1$.",
+    "significance": "key",
+    "relatedConcepts": ["constantCoeff ring hom", "IsUnit.map", "Int.isUnit_iff", "units of ℤ"],
+    "prerequisites": ["ring homomorphisms preserve units", "the unit group of ℤ"]
+  },
+  {
+    "id": "ann-failures",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 150 },
+    "type": "insight",
+    "title": "The Named Failures: Weak over ℤ, over ℤ[X,Y], and Strong over ℤ",
+    "content": "Three headline corollaries instantiate the machinery. weak_nullstellensatz_fails_over_int applies weakNSS_fails_of_nonunit at p = 2 for any index set σ, giving a proper (2) with empty zero locus. weak_nullstellensatz_fails_over_ZXY specializes to σ = Fin 2 — the very ring ℤ[X,Y] that the parent proves is a UFD, underscoring that UFD-ness does not rescue the Nullstellensatz. strong_nullstellensatz_fails_over_int closes the strong form: from the empty zero locus, vanishingId_empty gives I(V(2)) = ⊤; meanwhile Ideal.radical_eq_top (radical I = ⊤ ↔ I = ⊤) plus (2) ≠ ⊤ gives √(2) ≠ ⊤. So I(V(2)) = ⊤ ≠ √(2): the correspondence breaks maximally, the right side proper while the left is the whole ring.",
+    "mathContext": "$I(V(2)) = \\top \\neq \\sqrt{(2)}$ over $\\mathbb{Z}$, since $V(2) = \\varnothing$ and $\\sqrt{(2)} = (2) \\neq \\top$.",
+    "significance": "key",
+    "relatedConcepts": ["Ideal.radical_eq_top", "strong vs weak Nullstellensatz", "ℤ[X,Y] as a UFD", "radical of a prime-generated ideal"],
+    "prerequisites": ["radical of an ideal", "the I–V correspondence in the Nullstellensatz"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -76,20 +76,32 @@
   },
   "sections": [
     {
+      "id": "module-header",
       "title": "Module Header, Imports, and Namespace",
-      "description": "Imports Mathlib; opens MvPolynomial and Ideal; works in a noncomputable section over a commutative ring R and index set σ."
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "The docstring states the open question (can the Nullstellensatz be formalized over the multivariate UFD ℤ[X,Y]?), the honest negative answer, and why: Hilbert's Nullstellensatz needs an algebraically closed field, and ℤ — though a UFD — is not a field. It contrasts this not-a-field obstruction with the not-algebraically-closed obstruction (X²+1 over ℝ) and flags that Mathlib's zeroLocus/vanishingIdeal are field-only. Imports Mathlib; opens MvPolynomial and Ideal; works in a noncomputable section over a commutative ring R and index set σ."
     },
     {
-      "title": "Ring-level zero locus and vanishing ideal",
-      "description": "Defines zeroSet I and vanishingId V over any commutative ring (Mathlib's versions require a field), with membership simp lemmas and vanishingId_empty (= ⊤)."
+      "id": "ring-level-defs",
+      "title": "Ring-level Zero Locus and Vanishing Ideal",
+      "startLine": 52,
+      "endLine": 82,
+      "summary": "Defines zeroSet I = {x | ∀ p ∈ I, eval x p = 0} and vanishingId V over any commutative ring (Mathlib's MvPolynomial.zeroLocus / vanishingIdeal require [Field k]), the vanishingId carrier closed under +/• by evaluation being a ring hom. Adds the membership simp lemmas mem_zeroSet / mem_vanishingId and the vacuous fact vanishingId ∅ = ⊤ (every polynomial vanishes on the empty set)."
     },
     {
-      "title": "The general arithmetic obstruction",
-      "description": "weakNSS_fails_of_nonunit: a nonzero non-unit constant C p gives a proper ideal (C p) with empty zero locus."
+      "id": "general-obstruction",
+      "title": "The General Arithmetic Obstruction",
+      "startLine": 84,
+      "endLine": 107,
+      "summary": "weakNSS_fails_of_nonunit: for a nonzero non-unit constant C p, the ideal (C p) is proper (span {C p} = ⊤ ↔ IsUnit (C p), contradicted by the hypothesis) and its zero locus is empty (eval x (C p) = p ≠ 0 for every point x). This is the field-agnostic core: any commutative ring carrying a nonzero non-unit already breaks the weak Nullstellensatz; over a field there are no such elements."
     },
     {
-      "title": "The UFD case — failure over ℤ and ℤ[X,Y]",
-      "description": "not_isUnit_C_two via constantCoeff and Int.isUnit_iff; weak_nullstellensatz_fails_over_int, weak_nullstellensatz_fails_over_ZXY, and strong_nullstellensatz_fails_over_int."
+      "id": "ufd-case",
+      "title": "The UFD Case — Failure over ℤ and ℤ[X,Y]",
+      "startLine": 109,
+      "endLine": 150,
+      "summary": "not_isUnit_C_two pushes C 2 through the ring hom constantCoeff to 2 ∈ ℤ and applies Int.isUnit_iff. Instantiating the general obstruction at p = 2 gives weak_nullstellensatz_fails_over_int (any σ) and the headline weak_nullstellensatz_fails_over_ZXY (σ = Fin 2). strong_nullstellensatz_fails_over_int then derives I(V(2)) = vanishingId ∅ = ⊤ while √(2) ≠ ⊤ (radical_eq_top), so the strong correspondence breaks."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02` ("The Nullstellensatz Fails Over ℤ: the UFD Arithmetic Obstruction").

This is a fresh research entry whose gallery data had two structural gaps:

- **`annotations.json` was missing entirely.** Added 6 annotations — each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` — covering: the docstring framing (two obstructions: not-a-field vs not-algebraically-closed), the ring-level `zeroSet`/`vanishingId` definitions (necessary because Mathlib's are `[Field k]`-only), `vanishingId_empty`, the field-agnostic core `weakNSS_fails_of_nonunit`, the arithmetic witness `not_isUnit_C_two` (via `constantCoeff` + `Int.isUnit_iff`), and the three named failure theorems.
- **`sections` did not match the `ProofSection` schema** — entries had only `title`/`description` and lacked `id`/`startLine`/`endLine`/`summary`. Rewrote them to the schema with line ranges spanning all of lines 1–150.

No mathematical claims changed; `status: verified`, `axiomCount: 0` remain accurate (`#print axioms` reports only propext / Classical.choice / Quot.sound). JSON validates, `pnpm annotations:build` reports no warnings for this entry, and `tsc -b` passes.