### PR TITLE
research(erdos-748-incomplete-01): max sum-free subset size = ⌈n/2⌉ [verified, +3 thm/0 axiom]

### DIFF
--- a/proofs/Proofs/Erdos748Aristotle.lean
+++ b/proofs/Proofs/Erdos748Aristotle.lean
@@ -30,20 +30,20 @@ open Erdos748
 /-- f(1) = 2: The sum-free subsets of {1} are {} and {1}.
     Strategy: decide (or native_decide) — finite computation. -/
 theorem f_1 : f 1 = 2 := by
-  sorry
+  native_decide
 
 /-- f(2) = 3: The sum-free subsets of {1,2} are {}, {1}, {2}.
     (Note: {1,2} is not sum-free since 1+1=2, but {1,2} requires 1+1=2 with repeated use;
     IsSumFree allows repetition, so {2} is fine but {1,2}: 1 ∈ A ∧ 1 ∈ A ∧ 2 ∈ A ∧ 1+1=2 fails.)
     Strategy: decide (or native_decide) — finite computation. -/
 theorem f_2 : f 2 = 3 := by
-  sorry
+  native_decide
 
 /-- f(3) = 6: The sum-free subsets of {1,2,3} are {}, {1}, {2}, {3}, {1,3}, {2,3}.
     ({1,3} is not sum-free: 1+3=4 ∉ {1,3}, 1+1=2 ∉ {1,3}, 3+3=6 ∉ {1,3} — wait, it IS sum-free.
      {1,2}: 1+1=2 ∈ {1,2} — not sum-free. {1,2,3}: 1+2=3 ∈ set — not sum-free.)
     Strategy: decide (or native_decide) — finite computation. -/
 theorem f_3 : f 3 = 6 := by
-  sorry
+  native_decide
 
 end Erdos748Aristotle

--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -151,6 +151,107 @@ theorem trivial_lower_bound (n : ℕ) (hn : n ≥ 2) :
     _ ≤ f n := hcard
 
 /-
+## Part III-B: Maximum Size of a Sum-Free Subset (the Schur connection)
+
+The Cameron–Erdős counting bounds concern *how many* sum-free subsets exist.
+A complementary, fully elementary question is *how large* a single sum-free
+subset of `{1,…,n}` can be. The classical answer is `⌈n/2⌉ = (n+1)/2`, and —
+unlike the asymptotic counting result — it admits a short, axiom-free proof.
+
+The structure section of this entry previously stated this maximum only as
+commentary; the theorems below make it rigorous (both directions, no axioms).
+-/
+
+/--
+**Upper bound on the size of a sum-free set (the hard direction):**
+Any sum-free subset `A ⊆ {1,…,n}` satisfies `|A| ≤ (n+1)/2 = ⌈n/2⌉`.
+
+*Proof (Erdős's reflection/difference argument).* Assume `A` is nonempty and let
+`m = max A`. The "reflection" map `x ↦ m - x` is injective on `A` (every element
+is `≤ m`), so its image `B := {m - x : x ∈ A}` has `|B| = |A|`. If some `z` lay in
+both `A` and `B`, say `z = m - x` with `x ∈ A`, then `m = x + z` with
+`m, x, z ∈ A`, contradicting sum-freeness; hence `A` and `B` are disjoint. Both
+`A` and `B` sit inside `{0,1,…,n}` (which has `n+1` elements), so
+`2|A| = |A| + |B| = |A ∪ B| ≤ n+1`, giving `|A| ≤ (n+1)/2`.
+-/
+theorem sumFree_card_le {n : ℕ} {A : Finset ℕ}
+    (hsf : IsSumFree A) (hA : A ⊆ Finset.Icc 1 n) :
+    A.card ≤ (n + 1) / 2 := by
+  rcases A.eq_empty_or_nonempty with rfl | hne
+  · simp
+  -- `m` is the largest element of `A`; every element of `A` is `≤ m`.
+  set m := A.max' hne with hm
+  have hmA : m ∈ A := A.max'_mem hne
+  have hle : ∀ x ∈ A, x ≤ m := fun x hx => A.le_max' x hx
+  -- The reflection image `B = {m - x : x ∈ A}`.
+  set B := A.image (fun x => m - x) with hB
+  -- Injectivity of `x ↦ m - x` on `A` (all elements bounded by `m`).
+  have hinj : Set.InjOn (fun x => m - x) (A : Set ℕ) := by
+    intro x hx y hy h
+    simp only [Finset.mem_coe] at hx hy
+    simp only at h
+    have hx' := hle x hx
+    have hy' := hle y hy
+    omega
+  have hcardB : B.card = A.card := by
+    rw [hB, Finset.card_image_of_injOn hinj]
+  -- `A` and `B` are disjoint: a common element would force `m = x + z` in `A`.
+  have hdisj : Disjoint A B := by
+    rw [Finset.disjoint_left]
+    intro z hzA hzB
+    rw [hB, Finset.mem_image] at hzB
+    obtain ⟨x, hxA, hxz⟩ := hzB
+    have hx' := hle x hxA
+    have hmxz : m = x + z := by omega
+    exact hsf m x z hmA hxA hzA hmxz
+  -- `m ≤ n`, hence both `A` and `B` lie in `{0,…,n}`.
+  have hmn : m ≤ n := by
+    have := hA hmA; rw [Finset.mem_Icc] at this; exact this.2
+  have hAsub : A ⊆ Finset.Icc 0 n := by
+    intro a ha
+    have := hA ha; rw [Finset.mem_Icc] at this ⊢; omega
+  have hBsub : B ⊆ Finset.Icc 0 n := by
+    intro b hb
+    rw [hB, Finset.mem_image] at hb
+    obtain ⟨x, hxA, hxb⟩ := hb
+    rw [Finset.mem_Icc]
+    have hx' := hle x hxA
+    omega
+  have hunion : A ∪ B ⊆ Finset.Icc 0 n := Finset.union_subset hAsub hBsub
+  -- `|A| + |B| = |A ∪ B| ≤ |{0,…,n}| = n+1`, and `|B| = |A|`.
+  have hcard : A.card + B.card ≤ (Finset.Icc 0 n).card := by
+    rw [← Finset.card_union_of_disjoint hdisj]
+    exact Finset.card_le_card hunion
+  rw [hcardB, Nat.card_Icc] at hcard
+  omega
+
+/--
+**The upper half achieves the bound (the easy direction):**
+The set `{⌊n/2⌋+1, …, n}` has exactly `(n+1)/2 = ⌈n/2⌉` elements.
+-/
+theorem upperHalf_card_eq (n : ℕ) :
+    (Finset.Icc (n / 2 + 1) n).card = (n + 1) / 2 := by
+  rw [Nat.card_Icc]; omega
+
+/--
+**Maximum size of a sum-free subset of `{1,…,n}` is exactly `⌈n/2⌉`.**
+
+This packages both directions:
+1. every sum-free `A ⊆ {1,…,n}` has `|A| ≤ (n+1)/2`, and
+2. the upper half `{⌊n/2⌋+1,…,n}` is sum-free with `|A| = (n+1)/2`.
+
+So `max { |A| : A ⊆ {1,…,n} sum-free } = (n+1)/2 = ⌈n/2⌉`, the rigorous form of
+the "Schur connection" noted in the structure commentary. No axioms are used.
+-/
+theorem max_sumFree_card (n : ℕ) :
+    (∀ A : Finset ℕ, IsSumFree A → A ⊆ Finset.Icc 1 n → A.card ≤ (n + 1) / 2) ∧
+      (∃ A : Finset ℕ, IsSumFree A ∧ A ⊆ Finset.Icc 1 n ∧ A.card = (n + 1) / 2) := by
+  refine ⟨fun A hsf hA => sumFree_card_le hsf hA, ?_⟩
+  refine ⟨Finset.Icc (n / 2 + 1) n, ?_, ?_, upperHalf_card_eq n⟩
+  · exact upperHalf_sumFree n _ (fun a ha => by rw [Finset.mem_Icc] at ha; exact ha)
+  · exact Finset.Icc_subset_Icc (by omega) le_rfl
+
+/-
 ## Part IV: The Cameron-Erdős Conjecture
 -/
 

--- a/research/problems/erdos-748-incomplete-01/knowledge.md
+++ b/research/problems/erdos-748-incomplete-01/knowledge.md
@@ -2,13 +2,46 @@
 
 ## Research Notes
 
-*No research conducted yet. See problem.md for context.*
+### Session 2026-06-25 (researcher-9)
+
+File `Erdos748Problem.lean` was already 0-sorry / 2-axiom on arrival (prior
+session eliminated `trivial_lower_bound` and fixed mathlib v4.26 breakages).
+The two remaining axioms — `green_upper_bound` (Green 2004) and
+`precise_asymptotic` (Green/Sapozhenko) — are genuinely deep results; full
+formalization is a large project, not a single session.
+
+**Contribution this session:** proved the *maximum size* of a single sum-free
+subset of `{1,…,n}` is exactly `⌈n/2⌉ = (n+1)/2` — the rigorous "Schur
+connection" that the structure section previously stated only as commentary.
+All new theorems are axiom-free (`#print axioms` → only propext/Choice/Quot).
+
+New theorems (Part III-B):
+- `sumFree_card_le` : sum-free `A ⊆ Icc 1 n` ⇒ `A.card ≤ (n+1)/2`
+- `upperHalf_card_eq` : `(Icc (n/2+1) n).card = (n+1)/2`
+- `max_sumFree_card` : both directions packaged (max = ⌈n/2⌉)
+
+Also filled the 3 trivial `native_decide` sorries in `Erdos748Aristotle.lean`
+(they duplicate `f_1/f_2/f_3`, already proved in the main file).
 
 ## Known Facts
 
-- Lean file: `proofs/Proofs/`
-- Sorries: see problem.md
+- Lean file: `proofs/Proofs/Erdos748Problem.lean` (0 sorries, 2 deep axioms)
+- 15 theorems, 5 defs, lineCount 463
 
 ## Approaches Tried
 
-*None yet.*
+- **Erdős reflection/difference argument** (WORKED, axiom-free) for the max
+  sum-free set size. Key: with `m = max A`, the map `x ↦ m - x` is injective on
+  `A` (all elements `≤ m`) and its image is disjoint from `A` (a common element
+  forces `m = x + z` in `A`, violating sum-freeness). Both `A` and image lie in
+  `Icc 0 n`, so `2|A| ≤ n+1`.
+  - Lean gotchas: after `Finset.mem_image`, the membership equation
+    `(fun x => m - x) x = z` is already beta-reduced by the elaborator, so a
+    follow-up `simp only at h` errors "made no progress" — just feed it to
+    `omega` directly. `Nat.card_Icc` gives `(Icc a b).card = b + 1 - a`;
+    `omega` then discharges `n + 1 - (n/2 + 1) = (n+1)/2`.
+
+## Still Open
+
+- `green_upper_bound`, `precise_asymptotic`: deep (Green 2004, Sapozhenko 2003).
+- Structure/classification of the sum-free sets attaining the max size ⌈n/2⌉.

--- a/research/problems/erdos-748-incomplete-01/state.md
+++ b/research/problems/erdos-748-incomplete-01/state.md
@@ -1,6 +1,9 @@
 # State: erdos-748-incomplete-01
 
-**Phase**: OBSERVE
-**Since**: 2026-04-03T08:28:28Z
-**Attempts**: 0
+**Phase**: ACT
+**Since**: 2026-06-25
+**Attempts**: 1
 **Status**: available
+
+Proved max sum-free subset size = ⌈n/2⌉ (axiom-free, 3 new theorems). 2 deep
+axioms remain (Green/Sapozhenko), unchanged — out of scope for a single session.

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -52,12 +52,15 @@
       "green_upper_bound axiom: f(n) ≪ 2^{n/2}",
       "precise_asymptotic axiom: f(n) ~ c_n · 2^{n/2}",
       "oddNumbers_sumFree theorem: odds form sum-free set",
+      "sumFree_card_le theorem (PROVED, axiom-free): every sum-free A ⊆ {1,…,n} has |A| ≤ (n+1)/2 = ⌈n/2⌉, via Erdős's reflection map x ↦ max(A) − x onto a disjoint copy inside {0,…,n}",
+      "upperHalf_card_eq theorem (PROVED): the upper half {⌊n/2⌋+1,…,n} has exactly ⌈n/2⌉ elements, achieving the bound",
+      "max_sumFree_card theorem (PROVED, axiom-free): the maximum size of a sum-free subset of {1,…,n} is exactly ⌈n/2⌉ (both directions; the rigorous Schur connection)",
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 362,
-    "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The trivial lower bound f(n) ≥ 2^{⌊n/2⌋} is now fully proved (no longer an axiom). See the Lean source for details.",
-    "theoremCount": 12,
+    "lineCount": 463,
+    "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The trivial lower bound f(n) ≥ 2^{⌊n/2⌋} and the maximum sum-free subset size = ⌈n/2⌉ (max_sumFree_card) are both fully proved (no axioms). See the Lean source for details.",
+    "theoremCount": 15,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/Erdos748Aristotle.lean"
@@ -70,6 +73,7 @@
     "proofStrategy": "**Formalization Approach**\n\n1. **Sum-Free Sets:** Define IsSumFree predicate and counting function f(n).\n\n2. **Lower Bound:** Prove upperHalf_sumFree showing any subset of [n/2+1, n] is sum-free, giving f(n) ≥ 2^{n/2}.\n\n3. **Upper Bound:** Axiomatize Green's theorem f(n) ≤ C · 2^{n/2}.\n\n4. **Examples:** Prove empty set, singletons, and odd numbers are sum-free.\n\n5. **The Conjecture:** Define cameronErdosConjecture formally and show it holds.",
     "keyInsights": [
       "**Trivial Lower Bound:** Any subset of [n/2+1, n] is sum-free because any sum exceeds n",
+      "**Maximum Single Set (proved, axiom-free):** the largest sum-free subset of [1,n] has exactly ⌈n/2⌉ elements — Erdős's reflection map x ↦ max(A)−x sends A to a disjoint copy in {0,…,n}, forcing 2|A| ≤ n+1; the upper half attains it",
       "**Upper Bound is Tight:** Green/Sapozhenko showed f(n) ≤ C · 2^{n/2}",
       "**Parity Dependence:** The constant c_n in f(n) ~ c_n · 2^{n/2} depends on whether n is even or odd",
       "**Structure Theorem:** Most sum-free sets are subsets of [n/2, n] or odd numbers",
@@ -107,51 +111,59 @@
       "mathContext": "Proves `upperHalf_sumFree`: subsets of $\\{\\lfloor n/2 \\rfloor + 1, \\ldots, n\\}$ are sum-free (sums exceed $n$). Axiomatizes $f(n) \\ge $$2^{{n/2}$}$$."
     },
     {
+      "id": "max-size",
+      "title": "Maximum Size of a Sum-Free Subset",
+      "summary": "Proves the rigorous Schur bound. `sumFree_card_le`: every sum-free $A \\subseteq \\{1,\\ldots,n\\}$ has $|A| \\le \\lceil n/2 \\rceil = (n+1)/2$, via Erdős's reflection map $x \\mapsto \\max(A) - x$ sending $A$ to a disjoint copy in $\\{0,\\ldots,n\\}$. `upperHalf_card_eq`: the upper half attains it. `max_sumFree_card`: the maximum is exactly $\\lceil n/2 \\rceil$. Fully proved, no axioms.",
+      "startLine": 153,
+      "endLine": 253,
+      "mathContext": "Verified, axiom-free: The maximum size of a sum-free subset of $\\{1,\\ldots,n\\}$ is exactly $\\lceil n/2 \\rceil$. Hard direction (`sumFree_card_le`): if $A$ is sum-free with $m = \\max A$, the reflection $x \\mapsto m - x$ is injective on $A$ and its image is disjoint from $A$ (a common element would give $m = x + z$ in $A$); both sit in $\\{0,\\ldots,n\\}$, so $2|A| \\le n+1$. Easy direction (`upperHalf_card_eq`): the upper half $\\{\\lfloor n/2 \\rfloor + 1,\\ldots,n\\}$ has $\\lceil n/2 \\rceil$ elements and is sum-free."
+    },
+    {
       "id": "conjecture",
       "title": "The Cameron-Erdős Conjecture",
       "summary": "Defines `cameronErdosConjecture`: $\\forall \\varepsilon > 0,\\; \\exists N,\\; \\forall n \\ge N$, $(1-\\varepsilon)n/2 \\le \\log_2 f(n) \\le (1+\\varepsilon)n/2$.",
-      "startLine": 116,
-      "endLine": 130,
+      "startLine": 255,
+      "endLine": 269,
       "mathContext": "Formal definition: Defines `cameronErdosConjecture`: $\\forall \\varepsilon > 0,\\; \\exists N,\\; \\forall n \\ge N$, $(1-\\varepsilon)n/2 \\le \\log_2 f(n) \\le (1+\\varepsilon)n/2$."
     },
     {
       "id": "solution",
       "title": "The Solution",
       "summary": "Axiomatizes Green's $f(n) \\le C \\cdot 2^{n/2}$, Sapozhenko's independent result, and the precise $f(n) \\sim c_n \\cdot 2^{n/2}$ with parity-dependent constants. Proves `cameron_erdos_proved`.",
-      "startLine": 132,
-      "endLine": 217,
+      "startLine": 271,
+      "endLine": 356,
       "mathContext": "Axiomatizes Green's $f(n) \\le C \\cdot $$2^{{n/2}$}$$, Sapozhenko's independent result, and the precise $f(n) \\sim c_n \\cdot $$2^{{n/2}$}$$ with parity-dependent constants. Proves `cameron_erdos_proved`."
     },
     {
       "id": "examples",
       "title": "Examples",
       "summary": "Proves `empty_sumFree` (vacuous), `singleton_sumFree` ($x \\ne 2x$ for $x > 0$), and `oddNumbers_sumFree` (odd + odd = even $\\ne$ odd).",
-      "startLine": 219,
-      "endLine": 254,
+      "startLine": 358,
+      "endLine": 393,
       "mathContext": "Verified: Proves `empty_sumFree` (vacuous), `singleton_sumFree` ($x \\ne 2x$ for $x > 0$), and `oddNumbers_sumFree` (odd + odd = even $\\ne$ odd)."
     },
     {
       "id": "structure",
       "title": "Structure of Sum-Free Sets",
-      "summary": "Informal docstring commentary on the two dominant types of sum-free sets (subsets of $[n/2+1, n]$ and subsets of odd numbers) and the Schur connection (maximum sum-free subset of $[1,n]$ has size $\\lceil n/2 \\rceil$). No axioms or theorems are declared in this section.",
-      "startLine": 256,
-      "endLine": 272,
-      "mathContext": "Commentary only: Two dominant types of sum-free sets — subsets of the upper half $[n/2+1, n]$ (type 1) and subsets of odd numbers (type 2) — account for essentially all sum-free sets. Schur connection: maximum size of a sum-free subset of $[1,n]$ is $\\lceil n/2 \\rceil$."
+      "summary": "Informal docstring commentary on the two dominant types of sum-free sets (subsets of $[n/2+1, n]$ and subsets of odd numbers). The Schur connection (maximum sum-free subset of $[1,n]$ has size $\\lceil n/2 \\rceil$) is now proved rigorously in the Maximum Size section above. No axioms or theorems are declared in this section.",
+      "startLine": 395,
+      "endLine": 410,
+      "mathContext": "Commentary only: Two dominant types of sum-free sets — subsets of the upper half $[n/2+1, n]$ (type 1) and subsets of odd numbers (type 2) — account for essentially all sum-free sets. The Schur connection (max sum-free subset of $[1,n]$ has size $\\lceil n/2 \\rceil$) is proved in `max_sumFree_card`."
     },
     {
       "id": "oeis",
       "title": "OEIS A007865",
       "summary": "Proves $f(1) = 2$, $f(2) = 3$, $f(3) = 6$ by `native_decide`, matching OEIS A007865. These are fully machine-checked results, not axioms.",
-      "startLine": 274,
-      "endLine": 289,
+      "startLine": 412,
+      "endLine": 427,
       "mathContext": "Verified by `native_decide`: $f(1) = 2$, $f(2) = 3$, $f(3) = 6$. Matches OEIS A007865. The counting function $f(n) = |\\text{sumFreeSubsets}(n)|$ is evaluated computably for small $n$."
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "Combines all results into `erdos_748_summary`: the conjecture $f(n) = 2^{(1+o(1))n/2}$ is TRUE (Green 2004, Sapozhenko 2003). The main theorem `erdos_748` packages the lower bound, upper bound, and precise asymptotic $f(n) \\sim c_n \\cdot 2^{n/2}$.",
-      "startLine": 291,
-      "endLine": 325,
+      "startLine": 429,
+      "endLine": 463,
       "mathContext": "Combines all results into `erdos_748_summary`: the conjecture $f(n) = 2^{(1+o(1))n/2}$ is TRUE (Green 2004, Sapozhenko 2003). The main theorem `erdos_748` packages the lower bound, upper bound, and precise asymptotic $f(n) \\sim c_n \\cdot 2^{n/2}$."
     }
   ],
@@ -160,7 +172,7 @@
     "implications": "**Theoretical Significance**: **Combinatorial Implications**\n\n1. **Structure Theorem:** Sum-free sets are essentially subsets of [n/2, n] or odd numbers\n\n2. **Additive Combinatorics:** Foundational result for counting sets avoiding arithmetic patterns\n\n**3. Schur Numbers:** Connection to coloring problems and Ramsey theory\n\n4. **Asymptotic Counting:** Model example of precise asymptotic enumeration\n\n5. **OEIS A007865:** Explicit sequence with known asymptotics.",
     "openQuestions": [
       "What are the exact values of c_even and c_odd?",
-      "What is the structure of sum-free sets achieving the maximum size?",
+      "The maximum size of a sum-free subset of [1,n] is now proved to be exactly ⌈n/2⌉ (max_sumFree_card); what is the full structure/classification of the sets achieving it?",
       "Analogous questions for sum-free subsets of other groups?",
       "Connection to Schur numbers and Ramsey theory?",
       "Higher-order analogues (a = b₁ + ... + b_k)?"
@@ -177,9 +189,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 362,
+    "lineCount": 463,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-748-incomplete-01.json
+++ b/src/data/research/problems/erdos-748-incomplete-01.json
@@ -17,30 +17,35 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-03T08:27:10.084Z",
-    "iteration": 2,
-    "focus": "",
+    "since": "2026-06-25T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Maximum size of a sum-free subset of {1,…,n} = ⌈n/2⌉ (proved this session)",
     "blockers": [],
-    "nextAction": "",
+    "nextAction": "Optional: classify the extremal sum-free sets attaining the max size",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Eliminated 1 of 3 axioms: trivial_lower_bound (f(n) ≥ 2^{⌊n/2⌋}) is now a proved theorem. Also repaired ~7 pre-existing breakages so the file compiles against mathlib v4.26.0. 2 deep axioms remain (Green/Sapozhenko upper bound + precise asymptotic).",
+    "progressSummary": "Session 2026-06-25: proved the maximum size of a single sum-free subset of {1,…,n} is exactly ⌈n/2⌉ = (n+1)/2 — the rigorous Schur connection, previously stated only as structure commentary. 3 new axiom-free theorems (sumFree_card_le, upperHalf_card_eq, max_sumFree_card). Prior session had eliminated 1 of 3 axioms (trivial_lower_bound) and fixed mathlib v4.26 breakages. 2 deep axioms remain unchanged (Green/Sapozhenko upper bound + precise asymptotic); formalizing them is a large project, not a single session.",
     "builtItems": [
-      "Proved trivial_lower_bound in Erdos748Problem.lean: U.powerset ⊆ sumFreeSubsets n ⇒ f n ≥ 2^|U| ≥ 2^{⌊n/2⌋}",
-      "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)"
+      "Proved sumFree_card_le (axiom-free): every sum-free A ⊆ Icc 1 n has |A| ≤ (n+1)/2, via Erdős reflection x ↦ max(A)−x onto a disjoint copy in Icc 0 n",
+      "Proved upperHalf_card_eq: (Icc (n/2+1) n).card = (n+1)/2 (upper half attains the bound)",
+      "Proved max_sumFree_card (axiom-free): max sum-free subset size of {1,…,n} = ⌈n/2⌉, both directions",
+      "Filled 3 trivial native_decide sorries in Erdos748Aristotle.lean (f_1/f_2/f_3 duplicates)",
+      "Prior session: trivial_lower_bound + decidableIsSumFree instance"
     ],
     "insights": [
-      "The trivial lower bound needs no analysis: every subset of the upper half {⌊n/2⌋+1,…,n} is sum-free (upperHalf_sumFree), giving 2^{n-⌊n/2⌋} ≥ 2^{⌊n/2⌋} distinct sum-free sets",
-      "File was broken against mathlib v4.26.0: stale Asymptotics import, .1/.2 mixups in upperHalf_sumFree and sumFree_iff, missing DecidablePred IsSumFree, le_div_iff→le_div_iff₀, orphan /-- doc comments"
+      "Erdős reflection argument: with m = max A, x ↦ m − x is injective on A (all ≤ m) and its image is disjoint from A (a shared element gives m = x + z in A, violating sum-freeness); both sit in Icc 0 n, so 2|A| ≤ n+1, i.e. |A| ≤ ⌈n/2⌉",
+      "The trivial lower bound needs no analysis: every subset of the upper half {⌊n/2⌋+1,…,n} is sum-free (upperHalf_sumFree)",
+      "Lean: after Finset.mem_image the equation (fun x => m-x) x = z is already beta-reduced; a follow-up `simp only at h` errors 'made no progress' — feed it to omega directly. Nat.card_Icc + omega handle n+1−(n/2+1) = (n+1)/2"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "green_upper_bound and precise_asymptotic are deep results (Green 2004, Sapozhenko 2003); formalizing them is a large project, not a single session"
+      "green_upper_bound and precise_asymptotic are deep results (Green 2004, Sapozhenko 2003); formalizing them is a large project, not a single session",
+      "Possible follow-up: classify the sum-free subsets of {1,…,n} attaining the maximum size ⌈n/2⌉ (structure, not just size)"
     ]
   },
   "tags": [],
@@ -55,7 +60,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.084Z",
-  "lastUpdate": "2026-04-03T08:27:10.084Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
   "significance": 8,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Erdős Problem #748 (Cameron–Erdős conjecture). The Lean file was already
0-sorry / 2-axiom; the two remaining axioms (`green_upper_bound`,
`precise_asymptotic`) are genuinely deep results (Green 2004, Sapozhenko 2003),
out of scope for a single session.

This session proves a **complementary, fully elementary, axiom-free** result the
entry was missing: the **maximum size of a single sum-free subset of {1,…,n} is
exactly ⌈n/2⌉ = (n+1)/2**. The structure section previously stated this "Schur
connection" only as commentary; it is now a theorem (both directions).

## New theorems (Part III-B)

- `sumFree_card_le` — every sum-free `A ⊆ Icc 1 n` has `|A| ≤ (n+1)/2`, via
  Erdős's reflection map `x ↦ max(A) − x`: it is injective on `A` and its image
  is disjoint from `A` (a shared element would force `m = x + z` in `A`,
  violating sum-freeness), and both sit in `Icc 0 n`, so `2|A| ≤ n+1`.
- `upperHalf_card_eq` — the upper half `{⌊n/2⌋+1,…,n}` has exactly `⌈n/2⌉`
  elements, attaining the bound.
- `max_sumFree_card` — packages both directions: the maximum is exactly `⌈n/2⌉`.

`#print axioms` on all three reports only `propext / Classical.choice /
Quot.sound` — independent of the two deep Green/Sapozhenko axioms.

## Also

- Filled the 3 trivial `native_decide` sorries in `Erdos748Aristotle.lean`
  (duplicates of `f_1/f_2/f_3`, already proved in the main file).
- Gallery `meta.json`: `theoremCount` 12→15, `lineCount` 362→463, new
  "Maximum Size" section, corrected downstream section line ranges, refined the
  open question (size now settled; structure of extremal sets remains open).

## Verification

- `lake env lean Proofs/Erdos748Problem.lean` → exit 0 (offline; Docker down)
- `lake env lean Proofs/Erdos748Aristotle.lean` → exit 0
- meta.json / research json validated with `json.load`

axiomCount unchanged at 2 (both deep, disclosed). status remains `axiomatized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)