### PR TITLE
Enrich Closed-Form 2×2 Matrix Exponential (Cayley–Hamilton): add annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-04-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "cayley-hamilton-oq-04-oq-02",
+    "range": { "startLine": 9, "endLine": 63 },
+    "type": "context",
+    "title": "Closed Form, Putzer ODEs, and the Integrating-Factor Plan",
+    "content": "The docstring states the goal and the method. For a 2×2 real matrix A with tr A = τ and det A = δ, the explicit Cayley–Hamilton relation A² = τ•A − δ•1 collapses every power Aᵏ into the 2-dimensional span {1, A}; pushing this through the matrix exponential gives exp(t•A) = α(t)•1 + β(t)•A. The headline theorem holds for ANY scalar pair α, β solving the Putzer ODE system α' = −δ·β, β' = α + τ·β with α(0)=1, β(0)=0 — the only analytic input. The proof strategy is an integrating-factor uniqueness argument: φ(t) = exp(−t•A)·(α•1+β•A) has identically-zero derivative, hence equals φ(0)=1, which rearranges to the closed form. Mathlib has Matrix.exp and its derivative but no reduction of the 2×2 exponential to the finite span {1,A}; this is the new analytic completion of the algebraic parent CayleyHamiltonOQ04 (E. J. Putzer, Amer. Math. Monthly 73, 1966).",
+    "mathContext": "$\\exp(tA) = \\alpha(t)\\,\\mathbf{1} + \\beta(t)\\,A$ where $\\alpha' = -\\delta\\beta$, $\\beta' = \\alpha + \\tau\\beta$, $\\alpha(0)=1$, $\\beta(0)=0$, with $\\tau = \\operatorname{tr}A$, $\\delta = \\det A$.",
+    "significance": "context",
+    "relatedConcepts": ["Cayley–Hamilton theorem", "Putzer's method", "Lagrange–Sylvester functional calculus", "matrix exponential", "planar linear ODE systems"],
+    "prerequisites": ["the matrix exponential", "first-order linear ODE systems", "trace and determinant of a 2×2 matrix"]
+  },
+  {
+    "id": "ann-mul-self-eq",
+    "proofId": "cayley-hamilton-oq-04-oq-02",
+    "range": { "startLine": 73, "endLine": 80 },
+    "type": "definition",
+    "title": "Explicit 2×2 Cayley–Hamilton, A·A Form (mul_self_eq)",
+    "content": "mul_self_eq proves A * A = (tr A)•A − (det A)•1 for a 2×2 real matrix by brute entrywise expansion: ext i j then fin_cases over both Fin 2 indices, unfolding Matrix.mul_apply, Fin.sum_univ_two, trace_fin_two, and det_fin_two, with ring closing each of the four scalar identities. Mathlib provides Cayley–Hamilton only in the abstract charpoly form (aeval A (charpoly A) = 0); this re-proves the concrete A·A version that the headline proof actually needs to cancel the cross term. It is the algebraic engine: substituting it is exactly what forces the integrating-factor's derivative to vanish.",
+    "mathContext": "$A^2 = (\\operatorname{tr}A)\\,A - (\\det A)\\,\\mathbf{1}$ for $A \\in M_2(\\mathbb{R})$, verified entrywise over $\\mathrm{Fin}\\,2 \\times \\mathrm{Fin}\\,2$.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic polynomial λ² − τλ + δ", "trace_fin_two / det_fin_two", "fin_cases entrywise proof", "span {1, A}"],
+    "prerequisites": ["matrix multiplication over Fin 2", "trace and determinant formulas for 2×2 matrices"]
+  },
+  {
+    "id": "ann-exp-eq-of-coeffs",
+    "proofId": "cayley-hamilton-oq-04-oq-02",
+    "range": { "startLine": 82, "endLine": 141 },
+    "type": "theorem",
+    "title": "The Headline Closed Form via Integrating-Factor Uniqueness (exp_eq_of_coeffs)",
+    "content": "exp_eq_of_coeffs is the only genuinely analytic step, isolated once and parametric in α, β. The proof: (1) the algebraic key lemma shows (−A)(α•1+β•A) + ((−δβ)•1 + (α+τβ)•A) = 0 for every s, by expanding the product, rewriting A·A through mul_self_eq, and closing with the module tactic (everything is ℝ-linear in the atoms 1 and A). (2) hφderiv shows φ(x) = exp(x•(−A))·(α x•1 + β x•A) has derivative 0 everywhere: the exponential factor's derivative is hasDerivAt_exp_smul_const, the bracket's derivative comes from (hα).smul_const and (hβ).smul_const, the product rule HasDerivAt.mul combines them, and key collapses the sum to 0. (3) is_const_of_deriv_eq_zero turns zero derivative on ℝ into constancy, so φ(t) = φ(0) = 1 (using α(0)=1, β(0)=0). (4) Since exp(t•A) and exp(t•(−A)) commute (exp_add_of_commute) and multiply to 1, left-multiplying φ(t)=1 by exp(t•A) extracts exp(t•A) = α t•1 + β t•A. This avoids ever manipulating the tsum defining Matrix.exp.",
+    "mathContext": "$\\varphi(t) = \\exp(-tA)\\,(\\alpha(t)\\mathbf{1}+\\beta(t)A)$ has $\\varphi' \\equiv 0$, so $\\varphi(t) = \\varphi(0) = \\mathbf{1}$, giving $\\exp(tA) = \\alpha(t)\\mathbf{1} + \\beta(t)A$.",
+    "significance": "key",
+    "relatedConcepts": ["integrating factor", "is_const_of_deriv_eq_zero", "hasDerivAt_exp_smul_const", "HasDerivAt.mul (product rule)", "exp_add_of_commute", "the module tactic"],
+    "prerequisites": ["derivative of the matrix exponential", "the product rule for HasDerivAt", "zero-derivative-implies-constant on ℝ"]
+  },
+  {
+    "id": "ann-exp-two-two-distinct",
+    "proofId": "cayley-hamilton-oq-04-oq-02",
+    "range": { "startLine": 143, "endLine": 192 },
+    "type": "insight",
+    "title": "Distinct-Eigenvalue Closed Form (exp_two_two_distinct)",
+    "content": "exp_two_two_distinct instantiates the parametric theorem when A has distinct eigenvalues λ₁ ≠ λ₂ (so tr A = λ₁+λ₂, det A = λ₁λ₂). The divided-difference coefficient β(t) = (e^{λ₁t} − e^{λ₂t})/(λ₁−λ₂) and α(t) = e^{λ₁t} − λ₁β(t) are fed to exp_eq_of_coeffs, leaving only the two ODEs to verify. The scalar derivatives use Real.HasDerivAt.exp on the linear arguments λᵢt (built from (hasDerivAt_id).const_mul), HasDerivAt.div_const for the quotient, and HasDerivAt.const_mul / .sub for the combinations; the resulting coefficient identities are discharged by field_simp (clearing λ₁−λ₂ ≠ 0) and ring. This is the classical Lagrange–Sylvester formula, here certified rather than asserted.",
+    "mathContext": "$\\beta(t) = \\dfrac{e^{\\lambda_1 t} - e^{\\lambda_2 t}}{\\lambda_1 - \\lambda_2}$, $\\alpha(t) = e^{\\lambda_1 t} - \\lambda_1\\beta(t)$, valid for $\\lambda_1 \\neq \\lambda_2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divided differences", "Lagrange–Sylvester interpolation", "Real.HasDerivAt.exp", "field_simp / ring"],
+    "prerequisites": ["derivative of t ↦ e^{λt}", "eigenvalues as roots of the characteristic polynomial"]
+  },
+  {
+    "id": "ann-exp-two-two-repeated",
+    "proofId": "cayley-hamilton-oq-04-oq-02",
+    "range": { "startLine": 194, "endLine": 228 },
+    "type": "insight",
+    "title": "Repeated-Eigenvalue Closed Form (exp_two_two_repeated)",
+    "content": "exp_two_two_repeated handles the confluent case λ₁ = λ₂ = λ (so tr A = 2λ, det A = λ²), where the divided difference degenerates into a derivative: β(t) = t·e^{λt} and α(t) = e^{λt} − λ·t·e^{λt}. These are passed to the same parametric exp_eq_of_coeffs, so no separate limiting argument from the distinct case is needed — the uniqueness theorem covers both branches uniformly. The β derivative is the product rule (hasDerivAt_id).mul e1 giving 1·e^{λt} + s·(e^{λt}·λ), and the two ODE checks close with ring after rewriting tr A and det A. The t·e^{λt} term is the hallmark of a non-diagonalizable (defective) 2×2 matrix.",
+    "mathContext": "$\\beta(t) = t\\,e^{\\lambda t}$, $\\alpha(t) = e^{\\lambda t} - \\lambda t\\,e^{\\lambda t}$, for $\\lambda_1 = \\lambda_2 = \\lambda$.",
+    "significance": "supporting",
+    "relatedConcepts": ["confluent/defective eigenvalue", "generalized eigenvectors", "product rule HasDerivAt.mul", "Jordan block exponential"],
+    "prerequisites": ["the product rule for derivatives", "repeated roots of a quadratic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-04-oq-02` ("Closed-Form 2×2 Matrix Exponential from Cayley–Hamilton").

This fresh research entry had complete `sections`, `overview`, and `conclusion` but **no `annotations.json`**, so the proof page rendered no inline commentary.

- **Created `annotations.json`** with 5 annotations (each carrying `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  1. docstring framing — the closed form, the Putzer ODE system, and the integrating-factor uniqueness plan;
  2. `mul_self_eq` — the entrywise A·A form of 2×2 Cayley–Hamilton;
  3. `exp_eq_of_coeffs` — the headline: φ(t) = exp(−tA)·(α·1+β·A) has zero derivative (via `hasDerivAt_exp_smul_const`, the product rule, and the `module`-closed cancellation), hence is constant 1;
  4. `exp_two_two_distinct` — divided-difference β(t);
  5. `exp_two_two_repeated` — the confluent t·e^{λt} coefficient.

No mathematical claims changed; `status: verified`, `axiomCount: 0` remain accurate (`#print axioms` reports only propext / Classical.choice / Quot.sound). JSON validates, `pnpm annotations:build` reports no warnings for this entry, and `tsc -b` passes.