### PR TITLE
research(erdos-395-oq-02): higher-dim reverse Littlewood–Offord — orthogonality obstruction [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1980,6 +1980,7 @@ import Proofs.Erdos393Problem
 import Proofs.Erdos394Problem
 import Proofs.Erdos395OQ01
 import Proofs.Erdos395OQ01Incomplete01
+import Proofs.Erdos395OQ02
 import Proofs.Erdos395Problem
 import Proofs.Erdos396OQ04
 import Proofs.Erdos396OQ04OQ01

--- a/proofs/Proofs/Erdos395OQ02.lean
+++ b/proofs/Proofs/Erdos395OQ02.lean
@@ -1,0 +1,240 @@
+/-
+Erdős Problem #395 — Open Question oq-02:
+  "Does a similar result hold for higher-dimensional vectors?"
+
+Source: https://erdosproblems.com/395  (open questions, follow-up #2)
+Parent: Erdős #395 — Reverse Littlewood–Offord, SOLVED by
+        He–Juškevičius–Narayanan–Spiro (HJNS 2024).
+
+## The parent result (HJNS 2024)
+
+For unit *complex* vectors z₁, …, zₙ (|zᵢ| = 1 in ℂ ≅ ℝ²) and random signs
+εᵢ ∈ {±1}, the probability that |ε₁z₁ + … + εₙzₙ| ≤ √2 is at least c/n for an
+absolute constant c > 0.  Here ℂ = ℝ² is the **2-dimensional** real inner
+product space.
+
+## The open question
+
+Does the same phenomenon — a c/n lower bound on the probability that a random
+sign sum lands within a *fixed* distance of the origin — persist for unit
+vectors in higher-dimensional real inner product spaces ℝ^d (d ≥ 3)?
+
+This file does **not** resolve the open question for fixed dimension d (that
+remains open).  What it does, axiom-free, is isolate the *correct shape* of any
+higher-dimensional statement by proving a clean obstruction:
+
+  **If the dimension is allowed to grow with n, the naive "dimension-free,
+  fixed-threshold" analogue of HJNS is FALSE.**
+
+The mechanism is the orthogonality identity.  If z₁, …, zₙ are *orthonormal*
+unit vectors (which exist precisely when the ambient dimension d ≥ n — e.g. the
+standard basis of ℝⁿ), then for **every** sign choice ε ∈ {±1}ⁿ,
+
+  ‖ε₁z₁ + … + εₙzₙ‖² = Σ εᵢ² ‖zᵢ‖² = n   (the cross terms ⟨zᵢ,zⱼ⟩ vanish),
+
+so the sign sum sits at distance exactly √n from the origin — *deterministically*.
+Hence for any fixed threshold C, once n > C² no sign choice lands within C: the
+favourable event is empty and its probability is 0, not ≥ c/n.
+
+**Conclusion / contribution.** Any correct higher-dimensional reverse
+Littlewood–Offord statement must keep the dimension d bounded (independent of n),
+or let the threshold grow with the dimension.  The orthonormal configuration is
+the obstruction, and the proof here is fully machine-checked with 0 axioms.
+
+References:
+- [HJNS24] He, Juškevičius, Narayanan, Spiro, "The Reverse Littlewood–Offord
+           problem of Erdős", arXiv:2408.11034 (2024).
+- Parent formalization: Proofs/Erdos395Problem.lean.
+-/
+import Mathlib
+
+open scoped RealInnerProductSpace BigOperators
+
+namespace Erdos395OQ02
+
+/-!
+## Part I: Sign vectors and signed sums in a real inner product space
+
+We work over an arbitrary real inner product space `E`, so the statements cover
+ℝ^d for every dimension d uniformly (the complex case ℂ = ℝ² of the parent
+problem included).
+-/
+
+variable {n : ℕ} {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- A sign vector: each component is `+1` or `-1`. -/
+def IsSign (ε : Fin n → ℝ) : Prop := ∀ i, ε i = 1 ∨ ε i = -1
+
+/-- The signed sum `ε₁ z₁ + … + εₙ zₙ`. -/
+def signedSum (z : Fin n → E) (ε : Fin n → ℝ) : E := ∑ i, ε i • z i
+
+/-- A sign squares to one. -/
+lemma sign_mul_self {ε : Fin n → ℝ} (hε : IsSign ε) (i : Fin n) : ε i * ε i = 1 := by
+  rcases hε i with h | h <;> rw [h] <;> ring
+
+/-!
+## Part II: The orthogonality identity
+
+For an orthonormal family the squared norm of *every* sign sum equals `n`,
+independently of the signs.  This is the engine of the obstruction.
+-/
+
+/-- **Orthogonality identity.** If `z` is orthonormal and `ε` is a sign vector,
+then `‖ε₁z₁ + … + εₙzₙ‖² = n` for every choice of signs. -/
+theorem signedSum_norm_sq_of_orthonormal (z : Fin n → E) (hz : Orthonormal ℝ z)
+    (ε : Fin n → ℝ) (hε : IsSign ε) :
+    ‖signedSum z ε‖ ^ 2 = (n : ℝ) := by
+  rw [← real_inner_self_eq_norm_sq, signedSum, sum_inner]
+  simp_rw [inner_sum, real_inner_smul_left, real_inner_smul_right,
+    orthonormal_iff_ite.mp hz]
+  simp only [mul_ite, mul_one, mul_zero, Finset.sum_ite_eq, Finset.mem_univ, if_true]
+  simp only [sign_mul_self hε, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+    nsmul_eq_mul, mul_one]
+
+/-- Consequence: the sign sum of an orthonormal family has norm exactly `√n`. -/
+theorem signedSum_norm_of_orthonormal (z : Fin n → E) (hz : Orthonormal ℝ z)
+    (ε : Fin n → ℝ) (hε : IsSign ε) :
+    ‖signedSum z ε‖ = Real.sqrt n := by
+  have h := signedSum_norm_sq_of_orthonormal z hz ε hε
+  have : ‖signedSum z ε‖ = Real.sqrt (‖signedSum z ε‖ ^ 2) :=
+    (Real.sqrt_sq (norm_nonneg _)).symm
+  rw [this, h]
+
+/-!
+## Part III: The obstruction
+
+For a fixed threshold `C` with `C² < n`, *no* sign choice of an orthonormal
+family lands within distance `C` of the origin.  The favourable set is empty.
+-/
+
+/-- **Obstruction (set form).** For an orthonormal family and a threshold `C`
+with `C² < n`, the set of sign vectors whose signed sum has norm `≤ C` is
+empty. -/
+theorem orthonormal_smallSum_eq_empty (z : Fin n → E) (hz : Orthonormal ℝ z)
+    (C : ℝ) (hC : C ^ 2 < (n : ℝ)) :
+    {ε : Fin n → ℝ | IsSign ε ∧ ‖signedSum z ε‖ ≤ C} = ∅ := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  rintro ε ⟨hε, hle⟩
+  have h0 : (0 : ℝ) ≤ ‖signedSum z ε‖ := norm_nonneg _
+  have hsq : ‖signedSum z ε‖ ^ 2 ≤ C ^ 2 := by nlinarith [h0, hle]
+  rw [signedSum_norm_sq_of_orthonormal z hz ε hε] at hsq
+  linarith
+
+/-!
+## Part IV: Probability formulation and falsity of the dimension-free analogue
+
+We now phrase the counting/probability version in `EuclideanSpace ℝ (Fin d)`,
+matching the parent problem's `probSmallSum`, and prove that the
+"dimension-free, fixed-threshold" reverse Littlewood–Offord statement fails.
+
+Sign vectors are indexed by `Fin n → Bool` (`true ↦ +1`, `false ↦ -1`), giving a
+finite sample space of size `2ⁿ`.
+-/
+
+/-- Boolean encoding of a sign. -/
+def toSign (b : Bool) : ℝ := if b then 1 else -1
+
+/-- The sign vector induced by a Boolean vector. -/
+def signOf (s : Fin n → Bool) : Fin n → ℝ := fun i => toSign (s i)
+
+lemma isSign_signOf (s : Fin n → Bool) : IsSign (signOf s) := by
+  intro i; unfold signOf toSign; cases s i <;> simp
+
+variable {d : ℕ}
+
+/-- Number of sign choices `ε ∈ {±1}ⁿ` with `‖ε₁z₁ + … + εₙzₙ‖ ≤ C`. -/
+noncomputable def smallSumCount (z : Fin n → EuclideanSpace ℝ (Fin d)) (C : ℝ) : ℕ :=
+  (Finset.univ.filter (fun s : Fin n → Bool => ‖signedSum z (signOf s)‖ ≤ C)).card
+
+/-- Probability that a uniform random sign choice gives `‖sum‖ ≤ C`. -/
+noncomputable def smallSumProb (z : Fin n → EuclideanSpace ℝ (Fin d)) (C : ℝ) : ℝ :=
+  (smallSumCount z C : ℝ) / (2 : ℝ) ^ n
+
+/-- For an orthonormal family with `C² < n`, *no* sign choice is favourable. -/
+theorem orthonormal_smallSumCount_eq_zero (z : Fin n → EuclideanSpace ℝ (Fin d))
+    (hz : Orthonormal ℝ z) (C : ℝ) (hC : C ^ 2 < (n : ℝ)) :
+    smallSumCount z C = 0 := by
+  rw [smallSumCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  intro s _ hle
+  have h0 : (0 : ℝ) ≤ ‖signedSum z (signOf s)‖ := norm_nonneg _
+  have hsq : ‖signedSum z (signOf s)‖ ^ 2 ≤ C ^ 2 := by nlinarith [h0, hle]
+  rw [signedSum_norm_sq_of_orthonormal z hz (signOf s) (isSign_signOf s)] at hsq
+  linarith
+
+/-- Hence the probability is exactly `0`. -/
+theorem orthonormal_smallSumProb_eq_zero (z : Fin n → EuclideanSpace ℝ (Fin d))
+    (hz : Orthonormal ℝ z) (C : ℝ) (hC : C ^ 2 < (n : ℝ)) :
+    smallSumProb z C = 0 := by
+  rw [smallSumProb, orthonormal_smallSumCount_eq_zero z hz C hC]; simp
+
+/-- The standard basis of `EuclideanSpace ℝ (Fin n)` is orthonormal; it realizes
+the obstruction in ambient dimension `d = n`. -/
+theorem basisFun_orthonormal :
+    Orthonormal ℝ (⇑(EuclideanSpace.basisFun (Fin n) ℝ)) :=
+  (EuclideanSpace.basisFun (Fin n) ℝ).orthonormal
+
+/-- **Headline.** The dimension-free, fixed-threshold analogue of HJNS is FALSE:
+there is no single threshold `C` and constant `c > 0` such that, for all `n` and
+all orthonormal unit configurations in `EuclideanSpace ℝ (Fin n)` (dimension
+growing with `n`), the probability that `‖ε₁z₁ + … + εₙzₙ‖ ≤ C` is at least
+`c / n`.
+
+The witness is the standard orthonormal basis in dimension `d = n`: for `n > C²`
+the favourable event is empty (probability `0`), while `c / n > 0`. -/
+theorem dimensionFree_reverseLO_false :
+    ¬ ∃ C c : ℝ, 0 < c ∧
+        ∀ m : ℕ, 0 < m → ∀ z : Fin m → EuclideanSpace ℝ (Fin m),
+          Orthonormal ℝ z → c / (m : ℝ) ≤ smallSumProb z C := by
+  rintro ⟨C, c, hc, h⟩
+  -- Pick `m` with `C² < m` (so the obstruction fires) and `m > 0`.
+  obtain ⟨m, hm⟩ := exists_nat_gt (C ^ 2)
+  have hCsq : (0 : ℝ) ≤ C ^ 2 := sq_nonneg C
+  have hm0 : 0 < m := by
+    have : (0 : ℝ) < (m : ℝ) := lt_of_le_of_lt hCsq hm
+    exact_mod_cast this
+  -- The standard basis in dimension `m` gives probability 0.
+  have hprob :=
+    orthonormal_smallSumProb_eq_zero (d := m) (⇑(EuclideanSpace.basisFun (Fin m) ℝ))
+      basisFun_orthonormal C (by exact_mod_cast hm)
+  have hge := h m hm0 (⇑(EuclideanSpace.basisFun (Fin m) ℝ)) basisFun_orthonormal
+  rw [hprob] at hge
+  -- `c / m ≤ 0` but `c / m > 0`.
+  have : 0 < c / (m : ℝ) := div_pos hc (by exact_mod_cast hm0)
+  linarith
+
+/-!
+## Part V: The genuine open question (left unproven)
+
+The *fixed-dimension* form of the question is what remains genuinely open.  For
+each fixed `d`, does there exist a threshold `C_d` and constant `c_d > 0` such
+that for all `n` and all unit vectors `z₁, …, zₙ ∈ ℝ^d`, the probability that
+`‖ε₁z₁ + … + εₙzₙ‖ ≤ C_d` is at least `c_d / n`?
+
+We record the statement as a `Prop`; it is **not** a theorem here.
+-/
+
+/-- The fixed-dimension higher-dimensional reverse Littlewood–Offord question for
+ambient dimension `d`.  This proposition is the open problem and is deliberately
+left unproven. -/
+def ReverseLO_fixedDim (d : ℕ) : Prop :=
+  ∃ C c : ℝ, 0 < c ∧
+    ∀ m : ℕ, 0 < m → ∀ z : Fin m → EuclideanSpace ℝ (Fin d),
+      (∀ i, ‖z i‖ = 1) → c / (m : ℝ) ≤ smallSumProb z C
+
+/-!
+## Part VI: Summary
+
+**Erdős #395 oq-02 — Higher-dimensional reverse Littlewood–Offord.**
+
+- Parent (HJNS 2024): in dimension 2 (ℂ), `P(‖Σεᵢzᵢ‖ ≤ √2) ≥ c/n`.
+- This file (0 axioms): proves the **orthogonality identity**
+  `‖Σεᵢzᵢ‖² = n` for orthonormal families, hence the favourable event is empty
+  once the threshold satisfies `C² < n`.  Therefore the **dimension-free**
+  fixed-threshold analogue is FALSE (`dimensionFree_reverseLO_false`): any
+  correct higher-dimensional statement must bound the dimension `d`
+  independently of `n` (or grow the threshold with `d`).
+- The **fixed-dimension** question `ReverseLO_fixedDim d` (d ≥ 3) is recorded as
+  an open `Prop` and remains unresolved.
+-/
+
+end Erdos395OQ02

--- a/research/problems/erdos-395-oq-02/state.md
+++ b/research/problems/erdos-395-oq-02/state.md
@@ -1,0 +1,54 @@
+# Current State
+
+**Phase**: FORMALIZED (obstruction proved; fixed-dimension question remains open)
+**Since**: 2026-06-25
+**Iteration**: 1
+
+## Current Focus
+
+Formalized the orthogonality obstruction to a higher-dimensional reverse
+Littlewood–Offord theorem: `proofs/Proofs/Erdos395OQ02.lean` (240 lines,
+9 theorems, 7 defs, 0 sorries, 0 axioms; #print axioms reports only
+propext / Classical.choice / Quot.sound — no native_decide).
+
+## Active Approach
+
+Single deterministic identity drives everything:
+
+1. **Orthogonality identity** (`signedSum_norm_sq_of_orthonormal`) — for an
+   orthonormal family z₁,…,zₙ in any real inner product space and any sign
+   vector ε ∈ {±1}ⁿ, `‖Σ εᵢzᵢ‖² = n` exactly, independent of the signs. The
+   cross terms ⟨zᵢ,zⱼ⟩ vanish; εᵢ² = 1 collapses the diagonal to n.
+
+2. **Obstruction** (`orthonormal_smallSum_eq_empty`,
+   `orthonormal_smallSumProb_eq_zero`) — comparing squared norms, the event
+   `‖S‖ ≤ C` forces `n ≤ C²`, so for any fixed threshold C with `C² < n` the
+   favourable set is empty and its probability is 0.
+
+3. **Headline** (`dimensionFree_reverseLO_false`) — the dimension-free,
+   fixed-threshold analogue of HJNS 2024 is FALSE: the standard orthonormal
+   basis of ℝⁿ (dimension d = n) gives probability 0 for every n > C², while
+   any claimed bound demands c/n > 0.
+
+## Blockers
+
+The genuine open question — the **fixed-dimension** reverse Littlewood–Offord
+problem (`ReverseLO_fixedDim d` for d ≥ 3: does a c_d/n lower bound hold for
+unit vectors in ℝ^d?) — is **not** resolved. It is recorded as an unproven
+Prop. The obstruction shows the dimension must be bounded independently of n
+(or the threshold must scale with d), but the fixed-d case is open.
+
+## Next Action
+
+Two natural directions:
+- Determine the optimal threshold growth C(d): the identity ‖Σεᵢzᵢ‖² = n
+  suggests C(d) ~ √d on orthonormal configurations; pin the dependence across
+  all unit configurations.
+- Attempt the fixed-d lower bound via a Paley–Zygmund / Fourier route using
+  ‖Σεᵢzᵢ‖² = n as the second-moment input, paralleling HJNS.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/erdos-395-oq-02/annotations.json
+++ b/src/data/proofs/erdos-395-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-erdos395oq02-header",
+    "proofId": "erdos-395-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "The higher-dimensional question — and the honest boundary",
+    "content": "Erdős #395 (HJNS 2024) proves that for unit complex vectors z₁,…,zₙ — exactly the 2-dimensional case, ℂ ≅ ℝ² — the probability that |Σεᵢzᵢ| ≤ √2 is ≥ c/n. Open question oq-02 asks whether a similar c/n lower bound holds for unit vectors in higher dimensions ℝ^d. The header states plainly that this file does NOT resolve the fixed-dimension question; instead it proves an obstruction showing the naive dimension-free version is false, and isolates the correct hypotheses.",
+    "mathContext": "Parent (HJNS 2024): unit $z_i \\in \\mathbb{C}$, $\\mathbb{P}(|\\sum \\varepsilon_i z_i| \\le \\sqrt 2) \\ge c/n$. Here we vary the ambient real inner product space $\\mathbb{R}^d$.",
+    "significance": "context",
+    "relatedConcepts": ["reverse Littlewood–Offord", "anti-concentration", "random signs", "Rademacher sums"],
+    "prerequisites": ["probability", "inner product spaces"]
+  },
+  {
+    "id": "ann-erdos395oq02-definitions",
+    "proofId": "erdos-395-oq-02",
+    "range": { "startLine": 55, "endLine": 72 },
+    "type": "definition",
+    "title": "Sign vectors and signed sums in a general inner product space",
+    "content": "IsSign ε requires each component εᵢ ∈ {+1,−1}. signedSum z ε := Σᵢ εᵢ•zᵢ is defined over an arbitrary real inner product space E, so a single statement covers ℝ^d for every dimension d (and the complex case ℂ ≅ ℝ² of the parent). sign_mul_self records εᵢ·εᵢ = 1, the only arithmetic fact about signs the argument needs.",
+    "mathContext": "$S = \\sum_i \\varepsilon_i z_i \\in E$, $\\varepsilon_i = \\pm 1$, $\\varepsilon_i^2 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sign vector", "signed sum", "real inner product space"],
+    "prerequisites": ["finite sums", "scalar multiplication"]
+  },
+  {
+    "id": "ann-erdos395oq02-orthogonality",
+    "proofId": "erdos-395-oq-02",
+    "range": { "startLine": 75, "endLine": 101 },
+    "type": "key-step",
+    "title": "The orthogonality identity ‖Σεᵢzᵢ‖² = n",
+    "content": "signedSum_norm_sq_of_orthonormal is the engine. Writing ‖S‖² = ⟪S,S⟫ and expanding with sum_inner/inner_sum and the bilinearity real_inner_smul_left/right gives ΣᵢΣⱼ εᵢεⱼ⟪zᵢ,zⱼ⟫. For an orthonormal family orthonormal_iff_ite rewrites ⟪zᵢ,zⱼ⟫ = [i=j], collapsing the double sum (Finset.sum_ite_eq) to Σᵢ εᵢ² = Σᵢ 1 = n. So every sign sum sits on the sphere of radius √n (signedSum_norm_of_orthonormal): the randomness is irrelevant.",
+    "mathContext": "$\\|\\sum_i \\varepsilon_i z_i\\|^2 = \\sum_{i,j}\\varepsilon_i\\varepsilon_j\\langle z_i,z_j\\rangle = \\sum_i \\varepsilon_i^2 = n$ when $\\langle z_i,z_j\\rangle = \\delta_{ij}$.",
+    "significance": "central",
+    "relatedConcepts": ["orthonormal basis", "Parseval", "second moment", "bilinearity"],
+    "prerequisites": ["inner product expansion", "Kronecker delta"]
+  },
+  {
+    "id": "ann-erdos395oq02-obstruction",
+    "proofId": "erdos-395-oq-02",
+    "range": { "startLine": 103, "endLine": 121 },
+    "type": "key-step",
+    "title": "The small-sum set is empty when C² < n",
+    "content": "orthonormal_smallSum_eq_empty turns the deterministic identity into the obstruction without any square roots. If some sign vector gave ‖S‖ ≤ C, then 0 ≤ ‖S‖ ≤ C forces ‖S‖² ≤ C² (nlinarith); but ‖S‖² = n by the orthogonality identity, so n ≤ C², contradicting the hypothesis C² < n. Hence no sign choice lands within C of the origin — the favourable set is ∅.",
+    "mathContext": "$\\|S\\| \\le C \\Rightarrow \\|S\\|^2 \\le C^2$, yet $\\|S\\|^2 = n > C^2$: contradiction. The event $\\{\\|S\\| \\le C\\}$ is empty.",
+    "significance": "central",
+    "relatedConcepts": ["anti-concentration failure", "squared-norm comparison", "empty event"],
+    "prerequisites": ["monotonicity of squaring on nonnegatives"]
+  },
+  {
+    "id": "ann-erdos395oq02-headline",
+    "proofId": "erdos-395-oq-02",
+    "range": { "startLine": 123, "endLine": 203 },
+    "type": "key-step",
+    "title": "The dimension-free analogue is false",
+    "content": "The probability layer: sign vectors are encoded by Fin n → Bool (toSign/signOf), giving a uniform 2ⁿ-point sample space; smallSumProb z C := smallSumCount z C / 2ⁿ. orthonormal_smallSumProb_eq_zero says the probability is exactly 0 when C² < n. The headline dimensionFree_reverseLO_false then refutes any dimension-free, fixed-threshold bound: given a hypothetical (C, c) with c>0, pick n > C² (exists_nat_gt), take the standard orthonormal basis of EuclideanSpace ℝ (Fin n) (basisFun_orthonormal) — the probability is 0, but c/n > 0, contradiction.",
+    "mathContext": "For any $(C,c)$ with $c>0$, choose $n > C^2$ and the standard basis of $\\mathbb{R}^n$: $\\mathbb{P} = 0 < c/n$. So no dimension-free $c/n$ bound exists.",
+    "significance": "central",
+    "relatedConcepts": ["counterexample", "standard basis", "uniform sign space", "Archimedean property"],
+    "prerequisites": ["finite probability", "EuclideanSpace"]
+  },
+  {
+    "id": "ann-erdos395oq02-open-question",
+    "proofId": "erdos-395-oq-02",
+    "range": { "startLine": 205, "endLine": 222 },
+    "type": "context",
+    "title": "The genuine open question, recorded but unproven",
+    "content": "ReverseLO_fixedDim d states the fixed-dimension reverse Littlewood–Offord question: for each fixed d, is there a threshold C_d and constant c_d>0 with P(‖Σεᵢzᵢ‖ ≤ C_d) ≥ c_d/n for all n and all unit vectors in ℝ^d? It is recorded as a Prop and deliberately NOT proved. The obstruction above shows why the dimension must be fixed (or bounded) — but for fixed d ≥ 3 the question remains open.",
+    "mathContext": "Open: $\\exists C_d, c_d>0$ s.t. $\\forall n$, unit $z_i \\in \\mathbb{R}^d$, $\\mathbb{P}(\\|\\sum \\varepsilon_i z_i\\| \\le C_d) \\ge c_d/n$.",
+    "significance": "context",
+    "relatedConcepts": ["open problem", "fixed dimension", "honest scope"],
+    "prerequisites": ["quantifier structure"]
+  }
+]

--- a/src/data/proofs/erdos-395-oq-02/index.ts
+++ b/src/data/proofs/erdos-395-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos395OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos395OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos395OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos395OQ02Data: ProofData = {
+  proof: erdos395OQ02Proof,
+  annotations: erdos395OQ02Annotations,
+}

--- a/src/data/proofs/erdos-395-oq-02/meta.json
+++ b/src/data/proofs/erdos-395-oq-02/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "erdos-395-oq-02",
+  "slug": "erdos-395-oq-02",
+  "sorries": 0,
+  "title": "Higher-Dimensional Reverse Littlewood–Offord: The Orthogonality Obstruction",
+  "description": "Erdős #395 (solved by He–Juškevičius–Narayanan–Spiro 2024) asks, for unit complex vectors z₁,…,zₙ (|zᵢ|=1 in ℂ ≅ ℝ²) and random signs εᵢ∈{±1}, whether P(|ε₁z₁+…+εₙzₙ| ≤ √2) ≥ c/n; the answer is yes. Open question oq-02 asks whether the same phenomenon — a c/n lower bound on the probability of landing within a fixed distance of the origin — persists for unit vectors in higher dimensions ℝ^d. This entry does not resolve the fixed-dimension question (that remains open); instead it isolates the correct shape of any higher-dimensional statement by proving, axiom-free, a sharp obstruction. The engine is the orthogonality identity: for orthonormal unit vectors z₁,…,zₙ (which exist precisely when the ambient dimension d ≥ n, e.g. the standard basis of ℝⁿ), EVERY sign sum satisfies ‖ε₁z₁+…+εₙzₙ‖² = Σεᵢ²‖zᵢ‖² = n deterministically — the cross terms ⟨zᵢ,zⱼ⟩ all vanish. So the sum sits at distance exactly √n from the origin for all 2ⁿ sign choices. Consequently, for any fixed threshold C, once n > C² no sign choice lands within C: the favourable event is empty and its probability is 0, never ≥ c/n. The conclusion (dimensionFree_reverseLO_false) is that the naive dimension-free, fixed-threshold analogue of HJNS is FALSE: any correct higher-dimensional reverse Littlewood–Offord statement must keep the dimension d bounded independently of n (or grow the threshold with d). The genuinely open fixed-dimension form is recorded as an unproven Prop.",
+  "leanFile": {
+    "lineCount": 240,
+    "axiomCount": 0,
+    "path": "Proofs/Erdos395OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 7,
+    "theoremCount": 9
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (reverse Littlewood–Offord, higher-dimensional obstruction)",
+    "date": "2024",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos395OQ02.lean",
+    "tags": [
+      "probability",
+      "littlewood-offord",
+      "random-signs",
+      "inner-product-space",
+      "anti-concentration",
+      "combinatorics"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-25",
+    "lineCount": 240,
+    "originalContributions": [
+      "signedSum_norm_sq_of_orthonormal: the orthogonality identity — for an orthonormal family z₁,…,zₙ in any real inner product space and any sign vector ε∈{±1}ⁿ, ‖Σεᵢzᵢ‖² = n exactly, independently of the signs. Proved by expanding ⟪Σεᵢzᵢ, Σεⱼzⱼ⟫ with sum_inner/inner_sum and the bilinearity of the real inner product, collapsing the double sum via orthonormal_iff_ite and εᵢ²=1. This is the engine of the obstruction",
+      "signedSum_norm_of_orthonormal: consequently ‖Σεᵢzᵢ‖ = √n for every sign choice — the sign sum of an orthonormal family is pinned to the sphere of radius √n, deterministically",
+      "orthonormal_smallSum_eq_empty: the obstruction in set form — for a fixed threshold C with C² < n, the set { ε∈{±1}ⁿ : ‖Σεᵢzᵢ‖ ≤ C } of an orthonormal family is empty. No sign choice lands within C of the origin",
+      "orthonormal_smallSumProb_eq_zero: the probability formulation — over the uniform 2ⁿ-point sign space, P(‖Σεᵢzᵢ‖ ≤ C) = 0 exactly when C² < n, in ambient dimension d ≥ n",
+      "dimensionFree_reverseLO_false (headline): the dimension-free, fixed-threshold analogue of HJNS is FALSE — there is no single threshold C and constant c>0 with P(‖Σεᵢzᵢ‖ ≤ C) ≥ c/n holding for all n and all orthonormal configurations in EuclideanSpace ℝ (Fin n). The standard basis in dimension d=n witnesses the failure for every n > C²",
+      "basisFun_orthonormal: the standard basis of EuclideanSpace ℝ (Fin n) realizes the obstruction in ambient dimension d = n, so the orthonormal hypothesis is not vacuous",
+      "ReverseLO_fixedDim: a precise statement of the genuinely open fixed-dimension question (for each d, a threshold C_d and constant c_d>0 giving P(‖Σεᵢzᵢ‖ ≤ C_d) ≥ c_d/n for all unit configurations in ℝ^d), recorded as an unproven Prop to mark the honest boundary"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for the headline theorems (signedSum_norm_sq_of_orthonormal, orthonormal_smallSum_eq_empty, orthonormal_smallSumProb_eq_zero, dimensionFree_reverseLO_false). No native_decide is used (so no Lean.ofReduceBool). This entry does NOT resolve the open higher-dimensional reverse Littlewood–Offord question for fixed dimension d ≥ 3 (recorded as the unproven Prop ReverseLO_fixedDim); it proves the obstruction that any correct statement of that question must respect.",
+    "theoremCount": 9,
+    "definitionCount": 7
+  },
+  "overview": {
+    "historicalContext": "Erdős #395, the reverse Littlewood–Offord problem, asks for a LOWER bound on how often a random sign sum of unit vectors lands near the origin — the mirror image of the classical Littlewood–Offord upper bounds on concentration. Erdős first asked it with threshold 1; Carnielli–Carolino (2011) showed that fails, and the correct threshold is √2. He–Juškevičius–Narayanan–Spiro (arXiv:2408.11034, 2024) proved the √2 version: for unit complex vectors, P(|Σεᵢzᵢ| ≤ √2) ≥ c/n, with the 1/n rate optimal. Complex unit vectors are exactly the 2-dimensional case (ℂ ≅ ℝ²). The natural next question, listed among the problem's open follow-ups, is whether the same c/n concentration persists in higher dimensions ℝ^d.",
+    "problemStatement": "Does a reverse Littlewood–Offord lower bound hold for higher-dimensional unit vectors: is there, for unit vectors z₁,…,zₙ ∈ ℝ^d, a fixed threshold C and constant c>0 with P(‖ε₁z₁+…+εₙzₙ‖ ≤ C) ≥ c/n? This entry asks specifically what happens to the naive 'dimension-free' version in which d is allowed to grow with n.",
+    "proofStrategy": "The obstruction reduces to a single deterministic identity. Writing the squared norm of a sign sum as a real inner product, ‖Σεᵢzᵢ‖² = ⟪Σεᵢzᵢ, Σεⱼzⱼ⟫ = ΣᵢΣⱼ εᵢεⱼ⟪zᵢ,zⱼ⟫. For an orthonormal family ⟪zᵢ,zⱼ⟫ = [i=j], so the double sum collapses to Σᵢ εᵢ²·1 = n (using εᵢ²=1). Thus ‖Σεᵢzᵢ‖² = n for EVERY sign choice — the randomness is irrelevant. To get the obstruction without any square roots, observe that the favourable event ‖S‖ ≤ C (with C ≥ ‖S‖ ≥ 0) is equivalent to ‖S‖² ≤ C²; since ‖S‖² = n, this forces n ≤ C². Hence when C² < n the event is empty and its probability is 0. Picking n > C² with the standard orthonormal basis of ℝⁿ (which exists because the dimension equals n) yields, for any proposed (C,c), a configuration with probability 0 < c/n — refuting the dimension-free statement.",
+    "keyInsights": [
+      "Orthogonality kills the cross terms: for orthonormal unit vectors the squared sign sum is ‖Σεᵢzᵢ‖² = Σεᵢ²‖zᵢ‖² = n, a constant — the same value for all 2ⁿ sign choices. Anti-concentration near the origin becomes impossible because the sum never leaves the sphere of radius √n.",
+      "Dimension is the hidden parameter. Orthonormality of n vectors requires ambient dimension d ≥ n; the complex (2-dimensional) case of HJNS is far from this regime, which is exactly why a c/n bound is possible there but not when d grows with n.",
+      "The obstruction needs no square roots or probability machinery: comparing squared norms (‖S‖ ≤ C ⟺ ‖S‖² ≤ C² for nonnegative C) turns the whole argument into the integer/real inequality n ≤ C², making it elementary and fully constructive.",
+      "This sharpens the open problem rather than solving it: it shows any correct higher-dimensional reverse Littlewood–Offord statement must fix (or bound) the dimension d independently of n, or let the threshold C grow with d. The fixed-dimension question d ≥ 3 remains genuinely open.",
+      "The standard basis of ℝⁿ is the explicit extremal configuration — the cleanest possible witness — so the obstruction is not an abstract non-existence but a concrete family realizing probability exactly 0."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (240 lines, 9 theorems, 7 definitions) of the orthogonality obstruction to a dimension-free higher-dimensional reverse Littlewood–Offord theorem. For orthonormal unit vectors z₁,…,zₙ every sign sum has ‖Σεᵢzᵢ‖² = n exactly, so for any fixed threshold C the small-sum event is empty once n > C² and its probability is 0. Therefore the dimension-free, fixed-threshold analogue of HJNS 2024 is FALSE; the genuinely open fixed-dimension question is recorded as an unproven Prop.",
+    "implications": "The result delineates the correct hypotheses for any higher-dimensional reverse Littlewood–Offord statement: the dimension must be controlled relative to n, or the threshold must scale with the dimension. It explains structurally why the 2-dimensional (complex) case of HJNS is special — n unit vectors in a 2-dimensional space are forced into massive linear dependence, which is what permits concentration near zero, whereas orthogonal configurations in growing dimension forbid it. The orthogonality identity ‖Σεᵢzᵢ‖² = n is reusable as the second-moment scaffold for any anti-concentration analysis of Rademacher sums of unit vectors.",
+    "openQuestions": [
+      "The fixed-dimension reverse Littlewood–Offord question (ReverseLO_fixedDim d for d ≥ 3): for each fixed d, is there a threshold C_d and constant c_d > 0 such that for all n and all unit vectors z₁,…,zₙ ∈ ℝ^d, P(‖Σεᵢzᵢ‖ ≤ C_d) ≥ c_d/n? This is the genuine open problem and is left unproven.",
+      "How must the threshold C(d) grow with the dimension for a c/n bound to survive when d is allowed to scale with n? The identity ‖Σεᵢzᵢ‖² = n suggests C(d) ~ √d on orthonormal configurations, but the optimal dependence across all unit configurations is unknown.",
+      "Is there a Paley–Zygmund or Fourier-analytic route, paralleling HJNS, that yields the fixed-d lower bound directly, using ‖Σεᵢzᵢ‖² = n as the second-moment input?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Background: HJNS 2024 and the higher-dimensional question",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring framing the parent result (HJNS 2024, the 2-dimensional/complex case) and the open higher-dimensional follow-up. States plainly that the fixed-dimension question is NOT resolved; what is proved is the orthogonality obstruction showing the dimension-free analogue is false."
+    },
+    {
+      "id": "definitions",
+      "title": "§I Sign vectors and signed sums",
+      "startLine": 55,
+      "endLine": 72,
+      "summary": "IsSign ε (each component ±1), signedSum z ε := Σ εᵢ•zᵢ over an arbitrary real inner product space E (so ℝ^d for all d at once, complex case included), and sign_mul_self: εᵢ·εᵢ = 1."
+    },
+    {
+      "id": "orthogonality",
+      "title": "§II The orthogonality identity ‖Σεᵢzᵢ‖² = n",
+      "startLine": 75,
+      "endLine": 101,
+      "summary": "signedSum_norm_sq_of_orthonormal: for an orthonormal family, the squared norm of every sign sum equals n, independent of the signs — proved by expanding the real inner product and collapsing the double sum via orthonormal_iff_ite and εᵢ²=1. signedSum_norm_of_orthonormal: hence ‖Σεᵢzᵢ‖ = √n."
+    },
+    {
+      "id": "obstruction",
+      "title": "§III The obstruction: the small-sum set is empty",
+      "startLine": 103,
+      "endLine": 121,
+      "summary": "orthonormal_smallSum_eq_empty: for a threshold C with C² < n, the set of sign vectors whose orthonormal sign sum has norm ≤ C is empty. Proved by comparing squared norms — ‖S‖ ≤ C forces ‖S‖² ≤ C², but ‖S‖² = n > C², a contradiction (nlinarith)."
+    },
+    {
+      "id": "headline",
+      "title": "§IV Probability formulation and falsity of the dimension-free analogue",
+      "startLine": 123,
+      "endLine": 203,
+      "summary": "Boolean sign space {±1}ⁿ via toSign/signOf; smallSumCount and smallSumProb (= count / 2ⁿ) in EuclideanSpace ℝ (Fin d). orthonormal_smallSumCount_eq_zero / orthonormal_smallSumProb_eq_zero give probability 0 when C² < n. basisFun_orthonormal supplies the standard-basis witness, and dimensionFree_reverseLO_false (headline) refutes any dimension-free, fixed-threshold c/n bound."
+    },
+    {
+      "id": "open-question",
+      "title": "§V The genuine open question (left unproven)",
+      "startLine": 205,
+      "endLine": 222,
+      "summary": "ReverseLO_fixedDim d: the fixed-dimension reverse Littlewood–Offord question for ambient dimension d, recorded as a Prop and deliberately NOT proved — this is the honest boundary with the open problem."
+    },
+    {
+      "id": "summary",
+      "title": "§VI Summary",
+      "startLine": 224,
+      "endLine": 238,
+      "summary": "Recap: parent HJNS gives c/n in dimension 2; this file proves ‖Σεᵢzᵢ‖² = n for orthonormal families, hence the dimension-free analogue is false; the fixed-dimension question remains open."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-395",
+      "relationship": "extends",
+      "description": "Addresses the parent problem's open follow-up #2 ('Does a similar result hold for higher-dimensional vectors?'). The parent records HJNS 2024's c/n bound for unit complex (2-dimensional) vectors with threshold √2; this entry proves that the naive dimension-free generalization to ℝ^d is false, isolating the obstruction (orthonormal configurations force ‖Σεᵢzᵢ‖² = n) without resolving the fixed-dimension question."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "signedSum_norm_sq_of_orthonormal",
+      "type": "core",
+      "description": "The orthogonality identity: for an orthonormal family z₁,…,zₙ in any real inner product space and any sign vector ε∈{±1}ⁿ, ‖ε₁z₁+…+εₙzₙ‖² = n, independent of the signs. The engine of the obstruction.",
+      "leanType": "∀ {n : ℕ} {E : Type*} [inst : NormedAddCommGroup E] [inst : InnerProductSpace ℝ E] (z : Fin n → E), Orthonormal ℝ z → ∀ (ε : Fin n → ℝ), IsSign ε → ‖signedSum z ε‖ ^ 2 = ↑n"
+    },
+    {
+      "name": "dimensionFree_reverseLO_false",
+      "type": "headline",
+      "description": "The dimension-free, fixed-threshold analogue of HJNS is FALSE: no single threshold C and constant c>0 give P(‖ε₁z₁+…+εₙzₙ‖ ≤ C) ≥ c/n for all n and all orthonormal configurations in EuclideanSpace ℝ (Fin n). The standard basis in dimension d=n witnesses the failure for every n > C².",
+      "leanType": "¬ ∃ C c : ℝ, 0 < c ∧ ∀ m : ℕ, 0 < m → ∀ z : Fin m → EuclideanSpace ℝ (Fin m), Orthonormal ℝ z → c / ↑m ≤ smallSumProb z C"
+    },
+    {
+      "name": "orthonormal_smallSum_eq_empty",
+      "type": "core",
+      "description": "The obstruction in set form: for a threshold C with C² < n, the set of sign vectors whose orthonormal sign sum has norm ≤ C is empty — no sign choice lands within C of the origin.",
+      "leanType": "∀ {n : ℕ} {E : Type*} [inst : NormedAddCommGroup E] [inst : InnerProductSpace ℝ E] (z : Fin n → E), Orthonormal ℝ z → ∀ (C : ℝ), C ^ 2 < ↑n → {ε : Fin n → ℝ | IsSign ε ∧ ‖signedSum z ε‖ ≤ C} = ∅"
+    },
+    {
+      "name": "orthonormal_smallSumProb_eq_zero",
+      "type": "core",
+      "description": "The probability formulation: over the uniform 2ⁿ-point sign space, the probability that an orthonormal sign sum lands within C of the origin is exactly 0 whenever C² < n (ambient dimension d ≥ n).",
+      "leanType": "∀ {n d : ℕ} (z : Fin n → EuclideanSpace ℝ (Fin d)), Orthonormal ℝ z → ∀ (C : ℝ), C ^ 2 < ↑n → smallSumProb z C = 0"
+    },
+    {
+      "name": "ReverseLO_fixedDim",
+      "type": "supporting",
+      "description": "The genuinely open fixed-dimension reverse Littlewood–Offord question for ambient dimension d, recorded as an unproven Prop to mark the boundary with the open problem.",
+      "leanType": "ℕ → Prop"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Research session for **erdos-395-oq-02** — Erdős #395's open follow-up *"Does a similar result hold for higher-dimensional vectors?"*

Erdős #395 (reverse Littlewood–Offord) was solved by He–Juškevičius–Narayanan–Spiro (2024): for unit **complex** vectors z₁,…,zₙ (the 2-dimensional case, ℂ ≅ ℝ²) and random signs εᵢ∈{±1}, `P(|Σεᵢzᵢ| ≤ √2) ≥ c/n`. oq-02 asks whether the same c/n concentration persists in higher dimensions ℝ^d.

This PR does **not** resolve the fixed-dimension question (it remains open). It proves, axiom-free, the **orthogonality obstruction** that pins down the correct hypotheses.

## Progress — `proofs/Proofs/Erdos395OQ02.lean` (240 lines, 9 thms, 7 defs, 0 sorries, 0 axioms)

- **Orthogonality identity** (`signedSum_norm_sq_of_orthonormal`): for an orthonormal family in any real inner product space and any sign vector, `‖Σεᵢzᵢ‖² = n` **exactly**, independent of the signs — the cross terms ⟨zᵢ,zⱼ⟩ vanish and εᵢ²=1 collapses the diagonal. Hence `‖Σεᵢzᵢ‖ = √n` for all 2ⁿ sign choices.
- **Obstruction** (`orthonormal_smallSum_eq_empty`, `orthonormal_smallSumProb_eq_zero`): comparing squared norms, `‖S‖ ≤ C` forces `n ≤ C²`, so for any fixed threshold C with `C² < n` the favourable event is **empty** and its probability is exactly **0**.
- **Headline** (`dimensionFree_reverseLO_false`): the dimension-free, fixed-threshold analogue of HJNS is **FALSE** — the standard orthonormal basis of ℝⁿ (dimension d=n) gives probability 0 for every n > C², refuting any claimed c/n bound.

## Findings

- Orthogonality kills anti-concentration: n unit vectors in a 2-dimensional space (the HJNS regime) are forced into heavy linear dependence, which is exactly what permits concentration near zero; orthogonal configurations in growing dimension forbid it.
- Any correct higher-dimensional reverse Littlewood–Offord statement must **bound the dimension d independently of n**, or let the threshold grow with d.
- The argument needs no square roots or probability machinery — squared-norm comparison reduces it to `n ≤ C²`.

## Files

- `proofs/Proofs/Erdos395OQ02.lean`, `proofs/Proofs.lean` (import)
- `src/data/proofs/erdos-395-oq-02/{meta.json,annotations.json,index.ts}`
- `research/problems/erdos-395-oq-02/state.md`

## Verification

`#print axioms` on all headline theorems reports only `propext / Classical.choice / Quot.sound` (no `native_decide`, no `sorryAx`). Typechecked against Mathlib (lean v4.26.0) via `lake env lean`.

## Status

**Outcome**: progress (verified obstruction; fixed-dimension question recorded as the unproven Prop `ReverseLO_fixedDim` and remains open)
**Next Steps**: optimal threshold growth C(d) ~ √d; a Paley–Zygmund/Fourier attempt on the fixed-d lower bound using `‖Σεᵢzᵢ‖² = n` as second-moment input.

🤖 Generated by researcher-5