### PR TITLE
Enrich Hilbert #13 OQ-02: add missing annotations.json (6 annotations)

### DIFF
--- a/src/data/proofs/hilbert-13-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-13-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-framing",
+    "proofId": "hilbert-13-oq-02",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "What OQ-02 Asks and What This File Actually Proves",
+    "content": "The header draws the precise line between the open question and the provable kernel. Hilbert #13 / OQ-02 asks how hard it is to *compute* a Kolmogorov–Arnold (KA) superposition representation of a continuous function on a compactly-presented space; that computational question is genuinely open, because the classical existence proof (Kolmogorov–Arnold 1957, sharpened by Sternfeld 1985) is non-constructive (Baire category). This file deliberately does NOT resolve it. Instead it isolates the well-posedness kernel: Sternfeld's minimal superposition term count is 2·dim(X)+1 where dim is Lebesgue covering dimension, and covering dimension is a topological invariant. Therefore the 'complexity of the presented space' depends only on the homeomorphism type — not on which finite approximation, metric, or embedding presents it. Securing that invariance unconditionally (0 axioms, 0 sorries) is exactly what makes OQ-02 a meaningful question to ask.",
+    "mathContext": "Minimal KA superposition term count $= 2\\dim(X)+1$ (Sternfeld); the file proves $\\dim$ is a homeomorphism invariant, leaving the *computational* cost of producing a representation open.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's 13th problem", "Kolmogorov–Arnold superposition theorem", "Sternfeld's dimension bound", "well-posedness vs computability", "non-constructive existence"],
+    "prerequisites": ["the KA representation theorem (background)", "Lebesgue covering dimension", "the idea of a presentation-invariant of a space"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "hilbert-13-oq-02",
+    "range": { "startLine": 43, "endLine": 71 },
+    "type": "definition",
+    "title": "A Universe-Safe Covering Dimension via Finite Covers",
+    "content": "Four definitions build a clean, universe-monomorphic covering dimension. coverOrderAt sets x = {i | x ∈ sets i}.ncard is the order of a cover at a point — how many cover sets contain it — measured with Set.ncard, which needs no DecidablePred instance. coverOrderAtMost sets n means every point lies in at most n+1 sets. IsRefinement A B says every set of B sits inside some set of A. covDimLE X n is then 'dim X ≤ n': every finite open cover (indexed by Fin m) admits a finite open refinement (indexed by Fin p) of order ≤ n+1. Indexing covers by Fin m keeps every index type in Type 0, sidestepping both the universe-metavariable problems of a `∀ (ι : Type*)` definition and the decidability-synthesis failures that stop the companion Hilbert13GeneralSpaces.lean from compiling under Mathlib 4.26.0 — while still matching the standard fact that covering dimension is determined by finite open covers.",
+    "mathContext": "$\\dim X \\le n$ iff every finite open cover has a finite open refinement of order $\\le n+1$; order at $x$ is $\\#\\{i : x \\in U_i\\} = $ `Set.ncard`.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue covering dimension", "open cover refinement", "cover order", "Set.ncard", "universe monomorphism"],
+    "prerequisites": ["open covers and refinements", "Set.ncard and finiteness", "why Fin m indexing avoids universe/decidability issues"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "hilbert-13-oq-02",
+    "range": { "startLine": 73, "endLine": 79 },
+    "type": "theorem",
+    "title": "Monotonicity in the Bound (covDimLE_succ)",
+    "content": "covDimLE_succ proves dim X ≤ n ⟹ dim X ≤ n+1. The proof is immediate from the definition: given a finite open cover, the same refinement witnessing order ≤ n+1 also witnesses order ≤ (n+1)+1, because any value bounded by n+1 is bounded by n+2 (Nat.le_succ_of_le applied to the order bound hord x). Only the order component of the refinement witness changes; the refinement sets, openness, covering, and refinement properties are reused verbatim. This is the expected monotonicity of dimension in its upper bound.",
+    "mathContext": "$\\dim X \\le n \\Rightarrow \\dim X \\le n+1$, since order $\\le n+1 \\Rightarrow$ order $\\le (n+1)+1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotonicity of dimension", "Nat.le_succ_of_le", "reusing a refinement witness"],
+    "prerequisites": ["the covDimLE definition", "ℕ inequality basics"]
+  },
+  {
+    "id": "ann-base-case",
+    "proofId": "hilbert-13-oq-02",
+    "range": { "startLine": 81, "endLine": 105 },
+    "type": "theorem",
+    "title": "The 0-Dimensional Base Case (covDimLE_of_subsingleton)",
+    "content": "covDimLE_of_subsingleton proves a space with at most one point has covering dimension 0. The argument splits on emptiness. If X is empty, the empty refinement (indexed by Fin 0, via Fin.elim0) discharges every obligation vacuously — there are no refinement sets to be open and no points to cover or bound. If X has a single point x₀, take the cover set cover i₀ that already contains x₀ (from the covering hypothesis) as a one-element refinement Fin 1 → Set X. Covering holds because every x equals x₀ (Subsingleton.elim) so lies in that set; refinement is immediate; and the order at any x is bounded by ncard (Set.univ : Set (Fin 1)) = 1 = 0+1 via Set.ncard_le_ncard against the universal set. This is the dimension-theoretic fact that points (and the empty space) are 0-dimensional, here delivered without any metric or separation axiom.",
+    "mathContext": "$|X| \\le 1 \\Rightarrow \\dim X = 0$: empty space uses the empty refinement; a one-point space uses a single cover set with order $\\le \\#(\\mathrm{Fin}\\,1) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["subsingleton spaces", "0-dimensionality of points", "Fin.elim0 / vacuous obligations", "Set.ncard_le_ncard", "Subsingleton.elim"],
+    "prerequisites": ["case split on isEmpty_or_nonempty", "Set.ncard bounds via subset", "the covDimLE definition"]
+  },
+  {
+    "id": "ann-invariance",
+    "proofId": "hilbert-13-oq-02",
+    "range": { "startLine": 107, "endLine": 144 },
+    "type": "theorem",
+    "title": "Topological Invariance — the Headline (covDimLE_homeo_le, covDimLE_homeo)",
+    "content": "covDimLE_homeo_le is the main result: a homeomorphism e : X ≃ₜ Y transports the dimension bound, dim Y ≤ n ⟹ dim X ≤ n. Given a finite open cover of X, push it forward to Y along e.symm (coverY i = e.symm ⁻¹' cover i); preimages of opens are open (continuity of e.symm) and it still covers Y (any y has e.symm y in some cover set). Apply dim Y ≤ n to refine coverY in Y, then pull the refinement back along e (refine j = e ⁻¹' refineY j). Openness and covering survive by continuity of e; the refinement property survives because e x ∈ e.symm ⁻¹' cover i unfolds, via e.symm_apply_apply, to x's membership in cover i. Crucially the cover order is preserved *exactly*, not merely bounded: {j | x ∈ e ⁻¹' refineY j} = {j | e x ∈ refineY j} definitionally (x ∈ e ⁻¹' S ↔ e x ∈ S), so coverOrderAt (pullback) x = coverOrderAt refineY (e x) ≤ n+1. covDimLE_homeo then packages both directions (applying the lemma to e and to e.symm) into the iff dim X ≤ n ↔ dim Y ≤ n. No compactness, metric, or separation hypothesis is used — the invariance is pure point-set transport.",
+    "mathContext": "$X \\simeq_t Y \\Rightarrow (\\dim X \\le n \\iff \\dim Y \\le n)$. Order is preserved exactly because $x \\in e^{-1}(S) \\iff e(x) \\in S$.",
+    "significance": "key",
+    "relatedConcepts": ["topological invariant", "homeomorphism transport", "preimage of open is open", "exact order preservation", "Homeomorph.symm_apply_apply"],
+    "prerequisites": ["homeomorphisms and continuity", "preimages and the bijection x ∈ e⁻¹'S ↔ e x ∈ S", "the covDimLE definition"]
+  },
+  {
+    "id": "ann-ka-complexity",
+    "proofId": "hilbert-13-oq-02",
+    "range": { "startLine": 146, "endLine": 159 },
+    "type": "insight",
+    "title": "Presentation-Independence of KA Complexity (kaTermCount, kaTermCount_invariant)",
+    "content": "kaTermCount n = 2n+1 records the Kolmogorov–Arnold / Sternfeld term count for an n-dimensional space. kaTermCount_invariant draws the payoff: for a homeomorphism e : X ≃ₜ Y, the conjunction (dim X ≤ n ↔ dim Y ≤ n) ∧ kaTermCount n = 2n+1 holds — the first conjunct is covDimLE_homeo, the second is rfl. Because the minimal superposition complexity is 2·dim+1 and dim is a homeomorphism invariant, every homeomorphic presentation of a space — a different finite approximation, a different metric, a different embedding — yields the same n-dimensional superposition bound. This is precisely the statement that 'the complexity of the presented space' is well-defined as a function of the homeomorphism type, which is the most one can say unconditionally about OQ-02; the actual computational cost of producing a representation stays open.",
+    "mathContext": "$\\mathrm{kaTermCount}(n) = 2n+1$; with $\\dim$ invariant, homeomorphic presentations share the same $2n+1$ bound, so KA complexity is an invariant of the homeomorphism type.",
+    "significance": "key",
+    "relatedConcepts": ["Kolmogorov–Arnold superposition complexity", "Sternfeld 2n+1 bound", "presentation-independence", "invariant of homeomorphism type", "well-posedness of OQ-02"],
+    "prerequisites": ["the topological-invariance result covDimLE_homeo", "the Sternfeld term-count formula", "the distinction between well-posedness and computational cost"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `hilbert-13-oq-02` (quality 41, passes 0).

## Gap
The entry had a complete, high-quality `meta.json` (structured conclusion, 4 keyInsights, 4 sections, references) but **no `annotations.json` at all** — so the proof page rendered with zero inline annotations. Adding annotation coverage is the single highest-impact improvement here.

## Change
Authored `annotations.json` with **6 annotations covering the full 174-line Lean file**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
1. **framing** (1–35) — what OQ-02 actually asks (the *computational* cost, still open) vs. the provable well-posedness kernel this file secures.
2. **definitions** (43–71) — the universe-safe covering dimension via finite `Fin m` covers and `Set.ncard` order, and why that sidesteps the `DecidablePred`/universe issues that break the companion file.
3. **covDimLE_succ** (73–79) — monotonicity in the bound.
4. **covDimLE_of_subsingleton** (81–105) — the 0-dimensional base case (empty + one-point).
5. **covDimLE_homeo_le / covDimLE_homeo** (107–144) — topological invariance (headline); order preserved *exactly* via `x ∈ e⁻¹'S ↔ e x ∈ S`.
6. **kaTermCount_invariant** (146–159) — presentation-independence of the `2n+1` KA superposition complexity.

## Notes
- Pure data addition; no TypeScript touched. `annotations:build` and `research:build` both exit 0 with **no warnings for this proof** (all annotation ranges map to real Lean constructs).
- `status: verified` / `axiomCount: 0` / 0 sorries confirmed against the Lean source — no `native_decide`, no structure-encoded assumptions. The annotations are careful to state that only well-posedness is secured; the computational OQ-02 remains open.