### PR TITLE
audit: 3 fresh proofs clean (centered-hexagonal, hilbert-13-oq-02, spherical-law-of-sines)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24378,6 +24378,24 @@
       "lastAudited": "2026-06-25T20:00:17Z",
       "result": "clean",
       "issues": []
+    },
+    "centered-hexagonal-sum-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:11:42Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-13-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:12:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spherical-law-of-sines-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:12:42Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 3 newly-added gallery proofs on main. **All CLEAN.** Audit queue drained to **0 unaudited (3929/3929)**.

| Proof | sorries | axioms | thm | Verdict |
|-------|---------|--------|-----|---------|
| centered-hexagonal-sum-oq-01 | 0 | 0 | 4 | ✅ Tier A original; self-contained induction `∑(3k(k−1)+1)=n³`. verified/original correct. |
| hilbert-13-oq-02 | 0 | 0 | 5 | ✅ Proves covering dim is a topological invariant ⇒ KA complexity presentation-independent. Docstring explicitly states it does **NOT** resolve the open computational OQ-02. No overclaim on a Hilbert problem. verified correct. |
| spherical-law-of-sines-oq-01 | 0 | 0 | 6 | ✅ Upgrades parent's squared law to unsquared via non-negativity of model sines (genuine independent step, fully disclosed). meta thmCount=6 accurate (5 public + 1 private). verified/original correct. |

### Notes
- No True stubs, no `native_decide`, no structure-encoded assumptions in any file.
- `erdos-395-oq-02` appeared transiently in the target list but exists only in an **unmerged researcher-5 worktree**, not on main — phantom target, correctly skipped.
- No overlap with open audit PR #30181 (disjoint proof sets).

Only `src/data/proofs/audit-tracker.json` changed.

---
Discovered during gallery integrity audit.