### PR TITLE
research(chebyshev-bounds-oq-04-oq-01-oq-01-oq-01): weak Mertens bound |Σ μ(d)/d| ≤ 1 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01Mertens.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01Mertens.lean
@@ -26,9 +26,7 @@
   No axioms are introduced; the parent `chebyshevPsi_asymptotic` axiom remains
   the open target.
 -/
-import Mathlib.Tactic
-import Mathlib.NumberTheory.ArithmeticFunction
-import Mathlib.NumberTheory.Divisors
+import Mathlib
 
 open Finset
 open scoped BigOperators ArithmeticFunction
@@ -52,15 +50,18 @@ theorem mertensRecip_zero : mertensRecip 0 = 0 := by
     `Icc 1 N` describe the same set `{1, …, N}`). -/
 theorem card_multiples_Icc (N d : ℕ) :
     ((Finset.Icc 1 N).filter (fun m => d ∣ m)).card = N / d := by
-  sorry
+  have hIcc : Finset.Icc 1 N = Finset.Ioc 0 N := by
+    ext x; simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  rw [hIcc, Nat.Ioc_filter_dvd_card_eq_div]
 
 /-- **Möbius indicator**: `Σ_{d ∣ m} μ(d) = [m = 1]` cast to ℤ.
     Mathlib hook: `(μ * ζ) m = ∑_{d ∣ m} μ d` via `ArithmeticFunction.coe_mul_zeta_apply`
     (or `coe_zeta_mul_apply`), and `μ * ζ = 1` via `ArithmeticFunction.moebius_mul_coe_zeta`;
     then `ArithmeticFunction.one_apply` gives `(1 : ArithmeticFunction ℤ) m = if m = 1 then 1 else 0`. -/
-theorem sum_moebius_divisors (m : ℕ) (hm : 1 ≤ m) :
+theorem sum_moebius_divisors (m : ℕ) (_hm : 1 ≤ m) :
     ∑ d ∈ m.divisors, ArithmeticFunction.moebius d = if m = 1 then 1 else 0 := by
-  sorry
+  rw [← ArithmeticFunction.coe_mul_zeta_apply,
+    ArithmeticFunction.moebius_mul_coe_zeta, ArithmeticFunction.one_apply]
 
 /-- **Step 1 — floor identity**: `Σ_{d=1}^{N} μ(d)·⌊N/d⌋ = 1` for `N ≥ 1`.
     Proof: rewrite `N/d` as the count of multiples, swap the double sum over the
@@ -68,7 +69,42 @@ theorem sum_moebius_divisors (m : ℕ) (hm : 1 ≤ m) :
 theorem sum_moebius_mul_floor (N : ℕ) (hN : 1 ≤ N) :
     ∑ d ∈ Finset.Icc 1 N,
         (ArithmeticFunction.moebius d : ℤ) * ((N / d : ℕ) : ℤ) = 1 := by
-  sorry
+  -- Rewrite each term `μ(d)·⌊N/d⌋` as an inner sum over `k ∈ {1,…,N}` guarded by `d ∣ k`.
+  have key : ∀ d : ℕ,
+      (ArithmeticFunction.moebius d : ℤ) * ((N / d : ℕ) : ℤ)
+        = ∑ k ∈ Finset.Icc 1 N, (if d ∣ k then ArithmeticFunction.moebius d else 0) := by
+    intro d
+    rw [Finset.sum_ite, Finset.sum_const_zero, add_zero, Finset.sum_const,
+      nsmul_eq_mul, card_multiples_Icc]
+    ring
+  calc
+    ∑ d ∈ Finset.Icc 1 N, (ArithmeticFunction.moebius d : ℤ) * ((N / d : ℕ) : ℤ)
+        = ∑ d ∈ Finset.Icc 1 N, ∑ k ∈ Finset.Icc 1 N,
+            (if d ∣ k then ArithmeticFunction.moebius d else 0) :=
+          Finset.sum_congr rfl (fun d _ => key d)
+    _ = ∑ k ∈ Finset.Icc 1 N, ∑ d ∈ Finset.Icc 1 N,
+            (if d ∣ k then ArithmeticFunction.moebius d else 0) := Finset.sum_comm
+    _ = ∑ k ∈ Finset.Icc 1 N, ∑ d ∈ k.divisors, ArithmeticFunction.moebius d := by
+          refine Finset.sum_congr rfl (fun k hk => ?_)
+          simp only [Finset.mem_Icc] at hk
+          rw [← Finset.sum_filter]
+          congr 1
+          ext d
+          simp only [Finset.mem_filter, Finset.mem_Icc, Nat.mem_divisors]
+          constructor
+          · rintro ⟨⟨_, _⟩, hdvd⟩
+            exact ⟨hdvd, by omega⟩
+          · rintro ⟨hdvd, _⟩
+            have hkpos : 0 < k := by omega
+            have hd_le : d ≤ k := Nat.le_of_dvd hkpos hdvd
+            have hd_pos : 0 < d := Nat.pos_of_dvd_of_pos hdvd hkpos
+            exact ⟨⟨hd_pos, by omega⟩, hdvd⟩
+    _ = ∑ k ∈ Finset.Icc 1 N, (if k = 1 then (1 : ℤ) else 0) := by
+          refine Finset.sum_congr rfl (fun k hk => ?_)
+          simp only [Finset.mem_Icc] at hk
+          rw [sum_moebius_divisors k hk.1]
+    _ = 1 := by
+          simp [Finset.sum_ite_eq', Finset.mem_Icc, hN]
 
 /-- **Step 2 — real form**: `N·M₁(N) = 1 + Σ_{d=1}^{N} μ(d)·fract(N/d)`.
     Obtained by writing `⌊N/d⌋ = N/d − fract(N/d)` over ℝ in Step 1. -/
@@ -76,7 +112,35 @@ theorem mul_mertensRecip_eq (N : ℕ) (hN : 1 ≤ N) :
     (N : ℝ) * mertensRecip N
       = 1 + ∑ d ∈ Finset.Icc 1 N,
           (ArithmeticFunction.moebius d : ℝ) * Int.fract ((N : ℝ) / (d : ℝ)) := by
-  sorry
+  unfold mertensRecip
+  rw [Finset.mul_sum]
+  -- Per-term: `N · (μ d / d) = μ d · ⌊N/d⌋ + μ d · fract(N/d)`.
+  have hsplit : ∀ d ∈ Finset.Icc 1 N,
+      (N : ℝ) * ((ArithmeticFunction.moebius d : ℝ) / (d : ℝ))
+        = (ArithmeticFunction.moebius d : ℝ) * ((N / d : ℕ) : ℝ)
+          + (ArithmeticFunction.moebius d : ℝ) * Int.fract ((N : ℝ) / (d : ℝ)) := by
+    intro d _
+    -- ⌊(N:ℝ)/(d:ℝ)⌋ as a real equals the nat floor `N / d`.
+    have hfloorcast : (⌊(N : ℝ) / (d : ℝ)⌋ : ℝ) = ((N / d : ℕ) : ℝ) := by
+      have hz : ⌊(N : ℝ) / (d : ℝ)⌋ = ((N / d : ℕ) : ℤ) := by
+        rw [Int.floor_div_natCast, Int.floor_natCast, Int.natCast_div]
+      rw [hz]; norm_cast
+    -- fract(N/d) = N/d − ⌊N/d⌋.
+    have hfract : Int.fract ((N : ℝ) / (d : ℝ))
+        = (N : ℝ) / (d : ℝ) - ((N / d : ℕ) : ℝ) := by
+      rw [← Int.self_sub_floor, hfloorcast]
+    rw [hfract]; ring
+  -- The integer floor identity, cast to ℝ.
+  have hcast : (∑ d ∈ Finset.Icc 1 N,
+        (ArithmeticFunction.moebius d : ℝ) * ((N / d : ℕ) : ℝ))
+      = (((∑ d ∈ Finset.Icc 1 N,
+          (ArithmeticFunction.moebius d : ℤ) * ((N / d : ℕ) : ℤ)) : ℤ) : ℝ) := by
+    rw [Int.cast_sum]
+    apply Finset.sum_congr rfl
+    intro d _
+    rw [Int.cast_mul, Int.cast_natCast]
+  rw [Finset.sum_congr rfl hsplit, Finset.sum_add_distrib, hcast,
+    sum_moebius_mul_floor N hN, Int.cast_one]
 
 /-- The fractional remainder sum is bounded by `N − 1`: the `d = 1` term
     vanishes (`fract` of an integer is `0`) and every other term has
@@ -88,12 +152,58 @@ theorem fract_sum_abs_le (N : ℕ) (hN : 1 ≤ N) :
     |∑ d ∈ Finset.Icc 1 N,
         (ArithmeticFunction.moebius d : ℝ) * Int.fract ((N : ℝ) / (d : ℝ))|
       ≤ (N : ℝ) - 1 := by
-  sorry
+  set f : ℕ → ℝ :=
+    fun d => (ArithmeticFunction.moebius d : ℝ) * Int.fract ((N : ℝ) / (d : ℝ)) with hf
+  have h1mem : (1 : ℕ) ∈ Finset.Icc 1 N := Finset.mem_Icc.mpr ⟨le_refl 1, hN⟩
+  -- The `d = 1` term vanishes: `fract (N / 1) = fract N = 0`.
+  have hf1 : f 1 = 0 := by
+    simp only [hf, Nat.cast_one, div_one, Int.fract_natCast, mul_zero]
+  -- Drop the `d = 1` term from the sum.
+  have hsum : ∑ d ∈ Finset.Icc 1 N, f d = ∑ d ∈ (Finset.Icc 1 N).erase 1, f d := by
+    rw [← Finset.add_sum_erase _ f h1mem, hf1, zero_add]
+  rw [hsum]
+  calc |∑ d ∈ (Finset.Icc 1 N).erase 1, f d|
+      ≤ ∑ d ∈ (Finset.Icc 1 N).erase 1, |f d| := Finset.abs_sum_le_sum_abs _ _
+    _ ≤ ∑ d ∈ (Finset.Icc 1 N).erase 1, (1 : ℝ) := by
+        apply Finset.sum_le_sum
+        intro d _
+        have hμ : |(ArithmeticFunction.moebius d : ℝ)| ≤ 1 := by
+          have h := ArithmeticFunction.abs_moebius_le_one (n := d)
+          calc |(ArithmeticFunction.moebius d : ℝ)|
+              = ((|ArithmeticFunction.moebius d| : ℤ) : ℝ) := by rw [Int.cast_abs]
+            _ ≤ ((1 : ℤ) : ℝ) := by exact_mod_cast h
+            _ = 1 := by norm_num
+        have hfr : |Int.fract ((N : ℝ) / (d : ℝ))| ≤ 1 := by
+          rw [abs_of_nonneg (Int.fract_nonneg _)]
+          exact le_of_lt (Int.fract_lt_one _)
+        calc |f d|
+            = |(ArithmeticFunction.moebius d : ℝ)| * |Int.fract ((N : ℝ) / (d : ℝ))| := by
+              rw [hf]; exact abs_mul _ _
+          _ ≤ 1 * 1 := mul_le_mul hμ hfr (abs_nonneg _) (by norm_num)
+          _ = 1 := by norm_num
+    _ = (((Finset.Icc 1 N).erase 1).card : ℝ) := by
+        rw [Finset.sum_const, nsmul_eq_mul, mul_one]
+    _ = (N : ℝ) - 1 := by
+        rw [Finset.card_erase_of_mem h1mem, Nat.card_Icc]
+        have hns : N + 1 - 1 - 1 = N - 1 := by omega
+        rw [hns, Nat.cast_sub hN, Nat.cast_one]
 
 /-- **Weak Mertens reciprocal bound**: `|M₁(N)| ≤ 1` for all `N`.
     For `N = 0` both sides are `0 ≤ 1`; for `N ≥ 1` combine Steps 2–3 and divide
     by `N > 0`. -/
 theorem mertensRecip_abs_le_one (N : ℕ) : |mertensRecip N| ≤ 1 := by
-  sorry
+  rcases Nat.eq_zero_or_pos N with hN | hN
+  · subst hN; rw [mertensRecip_zero]; norm_num
+  · have hN1 : 1 ≤ N := hN
+    have hNpos : (0 : ℝ) < N := by exact_mod_cast hN
+    have heq := mul_mertensRecip_eq N hN1
+    have hbound := fract_sum_abs_le N hN1
+    -- `|N · M₁| = |1 + S| ≤ 1 + |S| ≤ 1 + (N − 1) = N`.
+    have hkey : |(N : ℝ) * mertensRecip N| ≤ N := by
+      rw [heq, abs_le]
+      rw [abs_le] at hbound
+      constructor <;> linarith [hbound.1, hbound.2]
+    rw [abs_mul, abs_of_pos hNpos] at hkey
+    nlinarith [hkey, hNpos, abs_nonneg (mertensRecip N)]
 
 end ChebyshevBoundsOQ04OQ01

--- a/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md
@@ -149,3 +149,61 @@ not needed here since we only reference it through lemma names.)
    Erdős's combinatorial lemma (Iter 5c–5d).
 3. The two parent axioms in `ChebyshevBoundsOQ04.lean` remain (deep PNT);
    do NOT touch the frozen `ChebyshevBoundsOQ04OQ01.lean`.
+
+## This session (2026-06-25, Researcher-10) — ACT, Iter 5a-β-2 COMPLETE (weak Mertens proven)
+
+**Outcome**: progress (discharged all 6 sorries in the Mertens scaffold; build-verified
+via `lake env lean` against prebuilt v4.26.0 oleans — docker daemon was down, but the
+`.lake` symlink now resolves and a single-file elaboration is memory-safe).
+
+### Result
+
+`proofs/Proofs/ChebyshevBoundsOQ04OQ01Mertens.lean` is now **fully proven**
+(0 sorries, 0 axioms; `#print axioms mertensRecip_abs_le_one` ⇒ only
+`propext, Classical.choice, Quot.sound`). It was a 6-sorry scaffold on `main`;
+this session completed every step. This realizes **openQuestion #1** of the
+`chebyshev-bounds-oq-04-oq-01-oq-01` gallery entry: the real-valued weak Mertens
+reciprocal bound
+
+    |M₁(N)| = |∑_{d=1}^{N} μ(d)/d| ≤ 1     (all N).
+
+### Theorems discharged (all 6)
+
+1. `card_multiples_Icc N d : #{m ∈ Icc 1 N : d ∣ m} = N / d`
+   — `Icc 1 N = Ioc 0 N` (ext+omega) then `Nat.Ioc_filter_dvd_card_eq_div`.
+2. `sum_moebius_divisors m _hm : ∑_{d∣m} μ d = if m=1 then 1 else 0`
+   — `← coe_mul_zeta_apply ; moebius_mul_coe_zeta ; one_apply` (m≥1 not even needed).
+3. `sum_moebius_mul_floor N hN : ∑_{d∈Icc 1 N} μ(d)·↑(N/d) = 1`
+   — the floor identity, reusing the verified hyperbola-swap recipe from
+     `…WeakMertensStatementOnly.lean` but now factored through (1) and (2).
+4. `mul_mertensRecip_eq N hN : (N:ℝ)·M₁(N) = 1 + ∑ μ(d)·fract(N/d)`
+   — per-term split `(N:ℝ)/d = ↑(N/d) + fract` via the floor-cast helper, then cast
+     the integer identity (3) into ℝ.
+5. `fract_sum_abs_le N hN : |∑ μ(d)·fract(N/d)| ≤ N − 1`
+   — drop the d=1 term (`fract(N/1)=fract N=0`), triangle-ineq, each remaining
+     term ≤ 1, with `card((Icc 1 N).erase 1) = N−1`.
+6. `mertensRecip_abs_le_one N : |M₁(N)| ≤ 1`
+   — `|1+S| ≤ N` from (4)+(5), divide by N>0 (`nlinarith`).
+
+### GOTCHAs (recorded for reuse)
+
+- **Floor-of-real to nat-division**: `⌊(N:ℝ)/(d:ℝ)⌋ = (↑(N/d):ℤ)` via
+  `Int.floor_div_natCast ; Int.floor_natCast ; Int.natCast_div`. Then cast helper
+  `(⌊…⌋:ℝ) = ((N/d:ℕ):ℝ)` by `rw [hz]; norm_cast`. `Int.natCast_div` is NOT a
+  norm_cast lemma, so `push_cast` does NOT split it — but a careless `push_cast; ring`
+  on the cast-of-sum goal still mangled it; use explicit `Int.cast_sum` then per-term
+  `Int.cast_mul, Int.cast_natCast` instead.
+- **`abs_add` does not exist** in v4.26.0 (only `abs_add'`, `abs_add_self`). For
+  `|1+S| ≤ N` use `rw [abs_le]; rw [abs_le] at hbound; constructor <;> linarith`.
+- **fract = self − floor**: `Int.self_sub_floor a : a - ↑⌊a⌋ = fract a` (rewrite `←`).
+- **Build path**: docker down, but `proofs/.lake → main/.lake` symlink resolves and
+  7382 mathlib oleans + 624 Proofs oleans are present, so
+  `ulimit -v 16000000; LAKE_UNSAFE=1 ./bin/lake env lean Proofs/<file>.lean`
+  type-checks one file memory-safely (no mathlib rebuild). This is the offline route.
+
+### Next Steps (downstream, unchanged)
+
+1. Selberg's symmetry formula `S₂(N) = 2N·log N + O(N)` (Iter 5b).
+2. Tauberian self-reference + Erdős's combinatorial lemma (Iter 5c–5d).
+3. The two deep parent axioms in `ChebyshevBoundsOQ04.lean` remain (full PNT);
+   do NOT touch the frozen `ChebyshevBoundsOQ04OQ01.lean`.

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "cb04oq010101-concept",
+    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 28
+    },
+    "type": "concept",
+    "title": "From the Floor Identity to the Weak Mertens Bound",
+    "content": "This file proves the **weak Mertens reciprocal bound**\n$$\\Bigl|\\sum_{d=1}^{N} \\tfrac{\\mu(d)}{d}\\Bigr| \\le 1 \\qquad (\\text{all } N).$$\nIt starts from the integer-valued **Möbius–floor identity** $\\sum_{d\\le N} \\mu(d)\\lfloor N/d\\rfloor = 1$ and splits the floor as $\\lfloor N/d\\rfloor = N/d - \\{N/d\\}$. Multiplying $M_1(N) = \\sum \\mu(d)/d$ by $N$ gives $N\\,M_1(N) = 1 + \\sum \\mu(d)\\{N/d\\}$. The $d=1$ fractional term vanishes and the other $N-1$ terms are each $\\le 1$, so $|N\\,M_1(N)| \\le N$ and $|M_1(N)| \\le 1$.",
+    "mathContext": "An elementary, complex-analysis-free estimate of the kind powering the Selberg–Erdős 1949 road to the PNT (Iter 5a-β-2 of the parent roadmap). Verified with 0 axioms and 0 sorries.",
+    "significance": "key",
+    "prerequisites": [
+      "Möbius function and Dirichlet convolution (μ ∗ ζ = δ)",
+      "floor/fractional-part decomposition ⌊x⌋ = x − {x}",
+      "elementary (Selberg–Erdős) approach to the PNT"
+    ],
+    "relatedConcepts": [
+      "Möbius function",
+      "Mertens function",
+      "prime number theorem",
+      "hyperbola method",
+      "fractional part"
+    ]
+  },
+  {
+    "id": "cb04oq010101-floor-identity",
+    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 107
+    },
+    "type": "technique",
+    "title": "The Möbius–Floor Identity by the Hyperbola Method",
+    "content": "`card_multiples_Icc`, `sum_moebius_divisors`, and `sum_moebius_mul_floor` together prove $\\sum_{d\\in[1,N]} \\mu(d)\\lfloor N/d\\rfloor = 1$. The floor $\\lfloor N/d\\rfloor$ is realised as the count of multiples of $d$ in $\\{1,\\dots,N\\}$ (`Nat.Ioc_filter_dvd_card_eq_div`), each term becomes an indicator sum $\\sum_{k\\le N}[d\\mid k]\\mu(d)$, the order of summation is swapped (`Finset.sum_comm` — the hyperbola swap), and the inner sum collapses via $\\sum_{d\\mid k}\\mu(d) = [k=1]$ (the Dirichlet identity $\\mu * \\zeta = \\delta$).",
+    "mathContext": "∑_d ∑_k [d∣k] μ(d) = ∑_k ∑_{d∣k} μ(d) = ∑_k [k=1] = 1. The double sum ranges over Dirichlet's hyperbola d·m ≤ N, weighted by μ(d).",
+    "significance": "important",
+    "prerequisites": [
+      "Nat.Ioc_filter_dvd_card_eq_div",
+      "Finset.sum_comm",
+      "ArithmeticFunction.moebius_mul_coe_zeta"
+    ],
+    "relatedConcepts": [
+      "hyperbola method",
+      "Dirichlet convolution",
+      "Möbius inversion"
+    ]
+  },
+  {
+    "id": "cb04oq010101-fractional-split",
+    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "Splitting the Floor: ⌊N/d⌋ = N/d − {N/d}",
+    "content": "`mul_mertensRecip_eq` turns the integer identity into the real form $N\\,M_1(N) = 1 + \\sum \\mu(d)\\{N/d\\}$. The key per-term step writes $(N{:}\\mathbb{R})/d = \\lfloor N/d\\rfloor + \\{N/d\\}$, using $\\lfloor (N{:}\\mathbb{R})/(d{:}\\mathbb{R})\\rfloor = (N/d : \\mathbb{N})$ (`Int.floor_div_natCast`, `Int.floor_natCast`, `Int.natCast_div`) and `Int.self_sub_floor`. The integer floor identity is then transported into ℝ by an explicit cast (`Int.cast_sum`, `Int.cast_mul`, `Int.cast_natCast`) rather than `push_cast`, which would split the nat-division cast.",
+    "mathContext": "N·M₁(N) = ∑ μ(d)·(N/d) = ∑ μ(d)·⌊N/d⌋ + ∑ μ(d)·{N/d} = 1 + ∑ μ(d)·{N/d}.",
+    "significance": "important",
+    "prerequisites": [
+      "Int.floor_div_natCast",
+      "Int.self_sub_floor",
+      "Int.cast_sum"
+    ],
+    "relatedConcepts": [
+      "fractional part",
+      "floor function",
+      "integer-to-real casts"
+    ]
+  },
+  {
+    "id": "cb04oq010101-fract-bound",
+    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 145,
+      "endLine": 189
+    },
+    "type": "technique",
+    "title": "Bounding the Fractional Sum by N − 1",
+    "content": "`fract_sum_abs_le` proves $|\\sum \\mu(d)\\{N/d\\}| \\le N-1$. The $d=1$ term is $\\mu(1)\\{N/1\\} = \\mu(1)\\{N\\} = 0$ since $N$ is an integer (`Int.fract_natCast`), so it is dropped (`Finset.add_sum_erase`). Each remaining term satisfies $|\\mu(d)\\{N/d\\}| \\le |\\mu(d)|\\,|\\{N/d\\}| \\le 1\\cdot 1 = 1$ (`abs_moebius_le_one`, `Int.fract_nonneg`, `Int.fract_lt_one`), and there are exactly $\\#((\\mathrm{Icc}\\,1\\,N)\\setminus\\{1\\}) = N-1$ of them.",
+    "mathContext": "The vanishing of the d=1 term is what sharpens the trivial ≤ N bound to ≤ N − 1 — exactly enough to reach |M₁(N)| ≤ 1.",
+    "significance": "important",
+    "prerequisites": [
+      "Int.fract_natCast, Int.fract_lt_one",
+      "ArithmeticFunction.abs_moebius_le_one",
+      "Finset.card_erase_of_mem"
+    ],
+    "relatedConcepts": [
+      "triangle inequality",
+      "fractional part bounds",
+      "Möbius function bound |μ| ≤ 1"
+    ]
+  },
+  {
+    "id": "cb04oq010101-conclusion",
+    "proofId": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 191,
+      "endLine": 209
+    },
+    "type": "insight",
+    "title": "Dividing by N to Reach |M₁(N)| ≤ 1",
+    "content": "`mertensRecip_abs_le_one` assembles the bound. For $N=0$, $M_1(0)=0$. For $N\\ge 1$: from $N\\,M_1(N) = 1 + S$ with $|S| \\le N-1$, the triangle inequality (via `abs_le` + `linarith`, since `abs_add` is absent in this Mathlib) gives $|N\\,M_1(N)| = |1+S| \\le 1 + (N-1) = N$. Rewriting $|N\\,M_1(N)| = N\\,|M_1(N)|$ (`abs_mul`, `abs_of_pos`) and dividing by $N>0$ (`nlinarith`) yields $|M_1(N)| \\le 1$.",
+    "mathContext": "|M₁(N)| ≤ 1 for all N — the weak Mertens reciprocal bound, completing Iter 5a-β-2 of the elementary-PNT roadmap.",
+    "significance": "key",
+    "prerequisites": [
+      "abs_le, abs_mul, abs_of_pos",
+      "linarith / nlinarith"
+    ],
+    "relatedConcepts": [
+      "Mertens bound",
+      "prime number theorem",
+      "Selberg–Erdős elementary method"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+  "title": "The Weak Mertens Bound: |Σ μ(d)/d| ≤ 1",
+  "slug": "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01",
+  "description": "A self-contained Lean 4 / Mathlib proof of the weak Mertens reciprocal bound |∑_{d=1}^{N} μ(d)/d| ≤ 1, valid for every N. The proof derives the bound from the Möbius–floor identity ∑_{d≤N} μ(d)⌊N/d⌋ = 1 by writing ⌊N/d⌋ = N/d − {N/d} over ℝ: the integer identity gives N·M₁(N) = 1 + ∑ μ(d)·{N/d}, the d=1 fractional term vanishes, and the remaining N−1 fractional terms are each bounded by 1, so |N·M₁(N)| ≤ N and |M₁(N)| ≤ 1 after dividing by N. This is the real-valued half of Iter 5a-β-2 on the elementary Selberg–Erdős road to the Prime Number Theorem.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "classical (Mertens, 1874; Selberg–Erdős context 1949)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ04OQ01Mertens.lean",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "moebius-function",
+      "mertens",
+      "dirichlet-convolution",
+      "prime-number-theorem",
+      "elementary-proof",
+      "hyperbola-method",
+      "fractional-part",
+      "analytic-number-theory",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 209,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully machine-checked: #print axioms on the main theorem mertensRecip_abs_le_one reports only propext, Classical.choice, Quot.sound (the standard foundational axioms). 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions; imports only Mathlib. The result is unconditional in N (the N = 0 case is M₁(0) = 0). It is independent of the two deep PNT axioms (chebyshevPsi_asymptotic, pnt_equivalence) carried by the grandparent file ChebyshevBoundsOQ04.lean — this proof does not import that file.",
+    "originalContributions": [
+      "A complete, axiom-free Lean proof of the weak Mertens reciprocal bound |∑_{d=1}^{N} μ(d)/d| ≤ 1 for all N — not available as a named Mathlib lemma. This realizes the standing open question of the sibling entry chebyshev-bounds-oq-04-oq-01-oq-01 (which proved only the integer-valued floor identity).",
+      "Bridges the integer Möbius–floor identity ∑ μ(d)⌊N/d⌋ = 1 to the real-valued reciprocal sum by the fractional-part decomposition ⌊N/d⌋ = N/d − {N/d}, formalized via Int.floor_div_natCast / Int.self_sub_floor and a careful Int→ℝ cast of the integer identity (Int.cast_sum, Int.cast_natCast).",
+      "Isolates the vanishing of the d = 1 fractional term (fract(N/1) = fract N = 0) and counts the remaining terms exactly (card((Icc 1 N).erase 1) = N − 1), turning a naive ≤ N bound into the sharp ≤ N − 1 fractional bound that yields |M₁(N)| ≤ 1.",
+      "Self-contained and Mathlib-only, so the lemma chain (card_multiples_Icc, sum_moebius_divisors, sum_moebius_mul_floor, mul_mertensRecip_eq, fract_sum_abs_le) is reusable for the downstream Selberg symmetry / Tauberian steps of the parent elementary-PNT roadmap."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Mertens (1874) studied the partial sums M(x) = ∑_{n≤x} μ(n) and the reciprocal sums ∑_{n≤x} μ(n)/n, proving the elementary bounds |∑_{n≤x} μ(n)/n| ≤ 1 that bear his name. These complex-analysis-free estimates are precisely the kind of input that the Selberg–Erdős 1949 program converts, via Selberg's symmetry formula and a Tauberian argument, into a full proof of the Prime Number Theorem ψ(x)/x → 1. The reciprocal bound is a textbook consequence of the Möbius–floor identity ∑_{d≤N} μ(d)⌊N/d⌋ = 1 (Apostol, Theorem 3.10): once the floor is split into its integer and fractional parts, the integer part contributes the constant 1 and the fractional part is uniformly small. This entry formalizes that derivation, completing the weak Mertens step (Iter 5a-β-2) of the parent roadmap.",
+    "problemStatement": "**Weak Mertens reciprocal bound.** For every natural number $N$,\n$$\\left|\\,\\sum_{d=1}^{N} \\frac{\\mu(d)}{d}\\,\\right| \\le 1,$$\nwhere $\\mu$ is the Möbius function. Equivalently, with $M_1(N) := \\sum_{d=1}^{N} \\mu(d)/d$, one has $|M_1(N)| \\le 1$ for all $N$ (and $M_1(0) = 0$).",
+    "text": "A Lean 4 / Mathlib formalization (209 lines, 0 sorries, 0 axioms, `import Mathlib` only) culminating in `mertensRecip_abs_le_one : |mertensRecip N| ≤ 1`, where `mertensRecip N = ∑ d ∈ Finset.Icc 1 N, (μ d : ℝ) / d`. The proof rests on three results: (1) the **Möbius–floor identity** `sum_moebius_mul_floor : ∑_{d∈Icc 1 N} μ(d)·⌊N/d⌋ = 1` (proved here by the hyperbola method — realise ⌊N/d⌋ as a count of multiples, swap summation order, collapse via μ ∗ ζ = δ); (2) the **real form** `mul_mertensRecip_eq : (N:ℝ)·M₁(N) = 1 + ∑ μ(d)·{N/d}`, obtained by writing `⌊N/d⌋ = N/d − {N/d}` and casting the integer identity into ℝ; and (3) the **fractional bound** `fract_sum_abs_le : |∑ μ(d)·{N/d}| ≤ N − 1`, since the d=1 term vanishes and the remaining N−1 terms each have absolute value ≤ 1. Combining, `|N·M₁(N)| = |1 + S| ≤ 1 + (N−1) = N`, so `|M₁(N)| ≤ 1` after dividing by `N > 0`.",
+    "proofStrategy": "1. **Floor identity (integer).** `sum_moebius_mul_floor`: rewrite `Finset.Icc 1 N = Finset.Ioc 0 N`, identify `⌊N/d⌋` with `#{k ∈ Icc 1 N : d ∣ k}` (`card_multiples_Icc` via `Nat.Ioc_filter_dvd_card_eq_div`), express each term as an indicator sum, swap order with `Finset.sum_comm`, and collapse the inner divisor sum to `[k=1]` (`sum_moebius_divisors` via μ ∗ ζ = δ). Sum the indicator to `1`.\n\n2. **Floor → fractional split (real).** `mul_mertensRecip_eq`: for each `d ≥ 1`, `(N:ℝ)·(μ d/d) = μ(d)·⌊N/d⌋ + μ(d)·{N/d}`, using `⌊(N:ℝ)/(d:ℝ)⌋ = (N/d : ℕ)` (`Int.floor_div_natCast`, `Int.floor_natCast`, `Int.natCast_div`) and `Int.self_sub_floor`. Sum over d, cast the integer identity from step 1 into ℝ (`Int.cast_sum`, `Int.cast_mul`, `Int.cast_natCast`), giving `(N:ℝ)·M₁(N) = 1 + ∑ μ(d)·{N/d}`.\n\n3. **Bound the fractional sum.** `fract_sum_abs_le`: the `d = 1` term is `μ(1)·{N/1} = μ(1)·{N} = 0` (`Int.fract_natCast`); drop it (`Finset.add_sum_erase`). Each remaining term satisfies `|μ(d)·{N/d}| ≤ |μ(d)|·|{N/d}| ≤ 1·1 = 1` (`abs_moebius_le_one`, `Int.fract_nonneg`, `Int.fract_lt_one`), and there are `card((Icc 1 N).erase 1) = N − 1` of them.\n\n4. **Conclude.** `mertensRecip_abs_le_one`: for `N = 0`, `M₁(0) = 0`. For `N ≥ 1`, `|N·M₁(N)| = |1 + S| ≤ 1 + |S| ≤ 1 + (N − 1) = N` (via `abs_le` + `linarith`), and dividing by `N > 0` gives `|M₁(N)| ≤ 1` (`nlinarith`).",
+    "keyInsights": [
+      "**The fractional parts carry all the slack.** Splitting `⌊N/d⌋ = N/d − {N/d}` turns the exact integer identity `∑ μ(d)⌊N/d⌋ = 1` into `N·M₁(N) = 1 + ∑ μ(d){N/d}`. Everything that could grow with N is confined to the fractional sum, which is then controlled term-by-term.",
+      "**The d = 1 term is exactly zero.** `{N/1} = {N} = 0` because N is an integer. This single observation is what sharpens the trivial bound `∑ ≤ N` to `∑ ≤ N − 1`, which is exactly enough to land at `|M₁(N)| ≤ 1` rather than the useless `≤ 1 + 1/N`.",
+      "**|μ| ≤ 1 and 0 ≤ {x} < 1 are the only analytic inputs.** Each fractional term is bounded by the product of two trivial bounds; no cancellation among the μ(d) is needed for the weak form. The integer identity already did the cancellation work upstream.",
+      "**Integer-first, then cast.** Proving the floor identity in ℤ (exact) and only afterwards casting into ℝ keeps the arithmetic clean: the cast `Int.cast_sum`/`Int.cast_natCast` transports `= 1` verbatim, avoiding fragile real-division bookkeeping inside the main argument.",
+      "**A reusable lemma chain for the roadmap.** `card_multiples_Icc`, `sum_moebius_divisors`, and `sum_moebius_mul_floor` are exactly the Dirichlet-hyperbola primitives needed for Selberg's symmetry formula S₂(N) = 2N log N + O(N), the next iteration toward the elementary PNT."
+    ],
+    "prerequisites": [
+      "Number theory (Möbius function, Dirichlet convolution, μ ∗ ζ = δ)",
+      "The hyperbola method and the floor/fractional-part decomposition ⌊x⌋ = x − {x}",
+      "Mathlib: ArithmeticFunction.moebius, Nat.Ioc_filter_dvd_card_eq_div, Int.floor_div_natCast, Int.fract, Finset.sum_comm",
+      "Parent context: chebyshev-bounds-oq-04-oq-01-oq-01 (the Möbius–floor identity) and chebyshev-bounds-oq-04-oq-01 (the Selberg–Erdős elementary-PNT roadmap)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The weak Mertens reciprocal bound |∑_{d=1}^{N} μ(d)/d| ≤ 1 is fully verified in Lean 4 / Mathlib (209 lines, 0 sorries, 0 axioms, Mathlib-only). The proof derives it from the Möbius–floor identity by splitting ⌊N/d⌋ into integer and fractional parts: the integer part contributes the constant 1, the d=1 fractional term vanishes, and the remaining N−1 fractional terms are each ≤ 1, so |N·M₁(N)| ≤ N.",
+    "implications": "This completes Iter 5a-β-2 of the elementary Selberg–Erdős road to the Prime Number Theorem: the weak Mertens bound is a standard complex-analysis-free input to Selberg's symmetry formula and the subsequent Tauberian oscillation argument for ψ(x)/x − 1. It also packages a reusable Dirichlet-hyperbola lemma chain (floor-as-count, Möbius-inversion collapse, fractional-part bound) for the downstream iterations.",
+    "openQuestions": [
+      "Prove Selberg's symmetry formula S₂(N) = ∑_{d≤N} Λ₂(d) = 2N·log N + O(N) (Iter 5b), combining the Λ₂ scaffold of chebyshev-bounds-oq-04-oq-01 with Mertens-type estimates.",
+      "Establish the Tauberian self-reference / oscillation inequality for ψ(x)/x − 1 from the symmetry formula and Erdős's combinatorial lemma (Iter 5c–5d).",
+      "Contribute the weak Mertens bound |∑_{d≤N} μ(d)/d| ≤ 1 (and the underlying Möbius–floor identity) upstream to Mathlib, where neither currently exists as a named lemma."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds-oq-04-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The sibling entry proves the integer-valued Möbius–floor identity ∑_{d≤N} μ(d)⌊N/d⌋ = 1 and lists 'derive the real-valued weak Mertens bound |∑ μ(d)/d| ≤ 1' as its first open question. This entry answers exactly that question, reproving the floor identity inline and adding the fractional-part decomposition and bound."
+    },
+    {
+      "targetId": "chebyshev-bounds-oq-04-oq-01",
+      "relationship": "related",
+      "description": "The grandparent entry scaffolds the Selberg Λ₂ framework toward an elementary PNT proof and documents 'Iter 5a-β-2: weak Mertens M₁ estimate' as its next step. This entry completes that step."
+    },
+    {
+      "targetId": "chebyshev-bounds-oq-04",
+      "relationship": "related",
+      "description": "The great-grandparent entry axiomatizes ψ(n)/n → 1 (chebyshevPsi_asymptotic). The Mertens-type estimates proved here are elementary building blocks of the long-term program to discharge that axiom without complex analysis."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators",
+      "ArithmeticFunction"
+    ],
+    "namespace": "ChebyshevBoundsOQ04OQ01",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/ChebyshevBoundsOQ04OQ01Mertens.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "mertensRecip_abs_le_one",
+      "type": "core",
+      "description": "The weak Mertens reciprocal bound: for every N, the partial sum M₁(N) = ∑_{d=1}^{N} μ(d)/d satisfies |M₁(N)| ≤ 1.",
+      "leanType": "(N : ℕ) : |mertensRecip N| ≤ 1"
+    },
+    {
+      "name": "sum_moebius_mul_floor",
+      "type": "supporting",
+      "description": "The Möbius–floor identity (integer-valued): for N ≥ 1, ∑_{d∈Icc 1 N} μ(d)·⌊N/d⌋ = 1. Proved by the hyperbola method.",
+      "leanType": "(N : ℕ) (hN : 1 ≤ N) : ∑ d ∈ Finset.Icc 1 N, (ArithmeticFunction.moebius d : ℤ) * ((N / d : ℕ) : ℤ) = 1"
+    },
+    {
+      "name": "mul_mertensRecip_eq",
+      "type": "supporting",
+      "description": "Real form: N·M₁(N) = 1 + ∑_{d=1}^{N} μ(d)·{N/d}, obtained by writing ⌊N/d⌋ = N/d − {N/d} and casting the integer floor identity into ℝ.",
+      "leanType": "(N : ℕ) (hN : 1 ≤ N) : (N : ℝ) * mertensRecip N = 1 + ∑ d ∈ Finset.Icc 1 N, (ArithmeticFunction.moebius d : ℝ) * Int.fract ((N : ℝ) / (d : ℝ))"
+    },
+    {
+      "name": "fract_sum_abs_le",
+      "type": "supporting",
+      "description": "The fractional remainder sum is bounded by N − 1: the d = 1 term vanishes and each remaining term has absolute value ≤ 1.",
+      "leanType": "(N : ℕ) (hN : 1 ≤ N) : |∑ d ∈ Finset.Icc 1 N, (ArithmeticFunction.moebius d : ℝ) * Int.fract ((N : ℝ) / (d : ℝ))| ≤ (N : ℝ) - 1"
+    },
+    {
+      "name": "card_multiples_Icc",
+      "type": "supporting",
+      "description": "The number of multiples of d in {1,…,N} equals the nat-division N / d (= ⌊N/d⌋).",
+      "leanType": "(N d : ℕ) : ((Finset.Icc 1 N).filter (fun m => d ∣ m)).card = N / d"
+    },
+    {
+      "name": "sum_moebius_divisors",
+      "type": "supporting",
+      "description": "Möbius indicator: ∑_{d ∣ m} μ(d) = [m = 1], the defining property of μ as the Dirichlet inverse of ζ = 1.",
+      "leanType": "(m : ℕ) (_hm : 1 ≤ m) : ∑ d ∈ m.divisors, ArithmeticFunction.moebius d = if m = 1 then 1 else 0"
+    },
+    {
+      "name": "mertensRecip_zero",
+      "type": "supporting",
+      "description": "Boundary case M₁(0) = 0 since Icc 1 0 = ∅.",
+      "leanType": ": mertensRecip 0 = 0"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Franz Mertens",
+      "title": "Ein Beitrag zur analytischen Zahlentheorie",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik 78, 46–62",
+      "note": "Introduces the elementary bounds on ∑_{n≤x} μ(n)/n, including the weak form |∑ μ(n)/n| ≤ 1."
+    },
+    {
+      "authors": "Tom M. Apostol",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer, Undergraduate Texts in Mathematics",
+      "note": "Theorem 3.10 (∑_{d≤N} μ(d)⌊N/d⌋ = 1) and §3.9–3.11 develop the Mertens reciprocal estimates from the floor identity."
+    },
+    {
+      "authors": "Gérald Tenenbaum",
+      "title": "Introduction to Analytic and Probabilistic Number Theory",
+      "year": "2015",
+      "venue": "AMS, Graduate Studies in Mathematics 163 (3rd ed.)",
+      "note": "§I.3 (Möbius function) and §I.6 (Selberg's identity) frame the role of Mertens-type estimates in the elementary PNT."
+    },
+    {
+      "authors": "Atle Selberg",
+      "title": "An elementary proof of the prime-number theorem",
+      "year": "1949",
+      "venue": "Annals of Mathematics 50(2), 305–313",
+      "note": "The elementary (complex-analysis-free) PNT proof whose Mertens-type estimates this bound supports."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes **Iter 5a-β-2** (the weak Mertens reciprocal estimate) on the elementary Selberg–Erdős road to the Prime Number Theorem by discharging all **6 sorries** in the `ChebyshevBoundsOQ04OQ01Mertens.lean` scaffold that was sitting on `main`.

**Main result** — `mertensRecip_abs_le_one`:
$$\left|\sum_{d=1}^{N} \frac{\mu(d)}{d}\right| \le 1 \qquad (\text{all } N).$$

This realizes **open question #1** of the sibling gallery entry `chebyshev-bounds-oq-04-oq-01-oq-01` (which proved only the integer-valued Möbius–floor identity $\sum_{d\le N}\mu(d)\lfloor N/d\rfloor = 1$): derive the real-valued bound by splitting $\lfloor N/d\rfloor = N/d - \{N/d\}$.

## Proof outline

| Lemma | Statement |
|---|---|
| `card_multiples_Icc` | $\#\{m\in[1,N] : d\mid m\} = N/d$ |
| `sum_moebius_divisors` | $\sum_{d\mid m}\mu(d) = [m=1]$ |
| `sum_moebius_mul_floor` | $\sum_{d\le N}\mu(d)\lfloor N/d\rfloor = 1$ (hyperbola method) |
| `mul_mertensRecip_eq` | $N\cdot M_1(N) = 1 + \sum \mu(d)\{N/d\}$ |
| `fract_sum_abs_le` | $\lvert\sum \mu(d)\{N/d\}\rvert \le N-1$ ($d{=}1$ term vanishes) |
| `mertensRecip_abs_le_one` | $\lvert M_1(N)\rvert \le 1$ |

The $d=1$ fractional term is exactly $0$ ($\{N/1\}=\{N\}=0$), sharpening the trivial $\le N$ bound to $\le N-1$ — precisely enough to land at $|M_1(N)|\le 1$.

## Verification

- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.**
- `#print axioms mertensRecip_abs_le_one` ⇒ only `propext, Classical.choice, Quot.sound`.
- Build-verified via single-file `lake env lean` against prebuilt Mathlib **v4.26.0** oleans (docker daemon was down this cycle; the `.lake` symlink resolves and single-file elaboration is memory-safe).
- The file imports only `Mathlib` and does **not** import the grandparent `ChebyshevBoundsOQ04.lean`, so it is independent of the two deep PNT axioms (`chebyshevPsi_asymptotic`, `pnt_equivalence`).

## Changes

- `proofs/Proofs/ChebyshevBoundsOQ04OQ01Mertens.lean` — 6 sorries → full proofs (already registered in `Proofs.lean`).
- `src/data/proofs/chebyshev-bounds-oq-04-oq-01-oq-01-oq-01/` — new gallery entry (`meta.json` + `annotations.json`).
- `research/problems/chebyshev-bounds-oq-04-oq-01-oq-01/knowledge.md` — session notes + reusable GOTCHAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)