### PR TITLE
Research: erdos-1204 — admissible k-tuples exist (A(k) well defined, A(k) ≤ (k-1)·k!)

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -120,6 +120,82 @@ theorem not_admissible_zero_one : ¬ Admissible ({0, 1} : Finset ℕ) := by
   · exact (hr 0 (by decide)) (by decide)
   · exact (hr 1 (by decide)) (by decide)
 
+/- ## Structural properties -/
+
+/-- **Downward closed.** Any subset of an admissible set is admissible: if `b`
+misses a residue class modulo `p`, the smaller set `a ⊆ b` misses the same class. -/
+theorem Admissible.subset {a b : Finset ℕ} (hab : a ⊆ b) (hb : Admissible b) :
+    Admissible a := by
+  intro p hp
+  obtain ⟨r, hr⟩ := hb p hp
+  exact ⟨r, fun x hx => hr x (hab hx)⟩
+
+/-- **Translation invariance.** Shifting every element by a constant `c` preserves
+admissibility: a missed class `r` modulo `p` for `a` becomes the missed class
+`r + c` for the shifted set, and conversely. Hence admissibility depends only on
+the differences of the elements, which is exactly why the extremal quantity `A(k)`
+may be normalised to sequences starting at `0`. -/
+theorem admissible_image_add (a : Finset ℕ) (c : ℕ) :
+    Admissible (a.image (· + c)) ↔ Admissible a := by
+  constructor
+  · intro h p hp
+    obtain ⟨r, hr⟩ := h p hp
+    refine ⟨r - (c : ZMod p), fun x hx => ?_⟩
+    have hmem : x + c ∈ a.image (· + c) := Finset.mem_image.mpr ⟨x, hx, rfl⟩
+    have hne := hr (x + c) hmem
+    intro hxr
+    apply hne
+    push_cast
+    rw [hxr]; ring
+  · intro h p hp
+    obtain ⟨r, hr⟩ := h p hp
+    refine ⟨r + (c : ZMod p), fun y hy => ?_⟩
+    obtain ⟨x, hx, rfl⟩ := Finset.mem_image.mp hy
+    show ((x + c : ℕ) : ZMod p) ≠ r + (c : ZMod p)
+    push_cast
+    intro hcon
+    exact hr x hx (add_right_cancel hcon)
+
+/- ## Existence and an explicit upper bound for A(k) -/
+
+/-- **Admissible `k`-tuples exist, so `A(k)` is well defined.** The arithmetic
+progression `{0, k!, 2·k!, …, (k-1)·k!}` has exactly `k` elements and is admissible:
+modulo every prime `p ≤ k` all of its elements are `≡ 0` (since `p ∣ k!`), so the
+class `1` is missed; modulo every prime `p > k` the size bound
+`missing_class_of_card_lt` applies. Its largest element is `(k-1)·k!`, giving the
+(very weak) explicit upper bound `A(k) ≤ (k-1)·k!`. The conjectured truth
+`A(k) ∼ k log k` is far sharper and remains OPEN. -/
+theorem exists_admissible_card (k : ℕ) :
+    ∃ a : Finset ℕ, a.card = k ∧ Admissible a ∧ ∀ x ∈ a, x ≤ (k - 1) * k.factorial := by
+  have hinj : Function.Injective (fun i : ℕ => i * k.factorial) := fun i j hij =>
+    Nat.eq_of_mul_eq_mul_right k.factorial_pos hij
+  refine ⟨(Finset.range k).image (fun i => i * k.factorial), ?_, ?_, ?_⟩
+  · rw [Finset.card_image_of_injective _ hinj, Finset.card_range]
+  · intro p hp
+    rcases le_or_gt p k with hpk | hpk
+    · -- `p ≤ k`: every element is `≡ 0 (mod p)`, so the class `1` is missed.
+      haveI : Fact (1 < p) := ⟨hp.one_lt⟩
+      haveI : NeZero p := ⟨hp.pos.ne'⟩
+      refine ⟨1, fun x hx => ?_⟩
+      obtain ⟨i, _, rfl⟩ := Finset.mem_image.mp hx
+      show ((i * k.factorial : ℕ) : ZMod p) ≠ 1
+      have hz : ((i * k.factorial : ℕ) : ZMod p) = 0 := by
+        have hfac : ((k.factorial : ℕ) : ZMod p) = 0 :=
+          (ZMod.natCast_eq_zero_iff _ _).mpr (Nat.dvd_factorial hp.pos hpk)
+        push_cast
+        rw [hfac, mul_zero]
+      rw [hz]; exact zero_ne_one
+    · -- `p > k = card`: the elements cannot cover all `p` residue classes.
+      haveI : NeZero p := ⟨hp.pos.ne'⟩
+      apply missing_class_of_card_lt
+      rw [Finset.card_image_of_injective _ hinj, Finset.card_range]; exact hpk
+  · intro x hx
+    obtain ⟨i, hi, rfl⟩ := Finset.mem_image.mp hx
+    rw [Finset.mem_range] at hi
+    show i * k.factorial ≤ (k - 1) * k.factorial
+    gcongr
+    omega
+
 /- ## Open Problems
 
 The asymptotic behaviour of the extremal quantities is OPEN:

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -45,6 +45,21 @@
         "theorem": "Nat.Prime",
         "description": "Prime number predicate",
         "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_factorial",
+        "description": "0 < m → m ≤ n → m ∣ n! ; shows every prime p ≤ k divides k!, so the AP elements vanish mod p",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod b) = 0 ↔ b ∣ a ; turns p ∣ k! into the AP elements being ≡ 0 mod p",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "card of an injective image equals the source card; gives card of the k!-spaced AP = k",
+        "module": "Mathlib.Data.Finset.Image"
       }
     ],
     "originalContributions": [
@@ -52,12 +67,15 @@
       "missing_class_of_card_lt: a set of size < p always misses a class mod p (image into ZMod p cannot be surjective)",
       "admissible_iff_card: KEY REDUCTION — admissibility ⟺ missing a class modulo every prime p ≤ |a|; all larger primes are automatic",
       "Worked examples: ∅, {0}, and {0,2} are admissible; {0,1} is NOT (it covers both classes mod 2)",
-      "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)"
+      "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)",
+      "Admissible.subset: admissibility is downward closed (any subset of an admissible set is admissible)",
+      "admissible_image_add: TRANSLATION INVARIANCE — shifting all elements by a constant preserves admissibility; justifies normalizing sequences to start at 0",
+      "exists_admissible_card: for every k the arithmetic progression {0, k!, 2·k!, …, (k-1)·k!} is an admissible k-tuple, so A(k) is WELL DEFINED and A(k) ≤ (k-1)·k! (an explicit, very weak, upper bound; the conjectured A(k)∼k log k is far sharper and remains OPEN)"
     ],
     "axiomCount": 0,
-    "lineCount": 137,
-    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved (#print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool). Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. The formalization here is the admissibility framework plus the standard reduction to small primes.",
-    "theoremCount": 6,
+    "lineCount": 213,
+    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved (#print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool). Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. The formalization here is the admissibility framework, the reduction to small primes, translation invariance, and an explicit upper-bound construction giving A(k) ≤ (k-1)·k!.",
+    "theoremCount": 9,
     "definitionCount": 1
   },
   "overview": {
@@ -80,7 +98,7 @@
   },
   "sections": [],
   "conclusion": {
-    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the standard reduction showing only primes p ≤ k impose constraints, and small worked examples. The asymptotic questions themselves remain open and are not asserted.",
+    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the reduction showing only primes p ≤ k impose constraints, small worked examples, the structural facts that admissibility is downward closed and translation invariant, and an explicit construction proving admissible k-tuples exist for every k (hence A(k) is well defined, with the weak bound A(k) ≤ (k-1)·k!). The asymptotic questions themselves remain open and are not asserted.",
     "openQuestions": [
       "Is A(k) ∼ k log k?",
       "What is the correct order of B(k) = min (a₁+⋯+a_k)/k?"
@@ -124,9 +142,9 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 137,
+    "lineCount": 213,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,22 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY/BUILD: defined Admissible (Finset ℕ misses a residue class mod every prime); proved missing_class_of_card_lt and the key reduction admissible_iff_card (only primes p ≤ |a| matter); verified examples ∅,{0},{0,2} admissible and {0,1} not. 6 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) estimates remain OPEN.",
+    "progressSummary": "SURVEY/BUILD: framework (Admissible def; missing_class_of_card_lt; admissible_iff_card reduction to primes p≤|a|; examples) PLUS new structural results — Admissible.subset (downward closed), admissible_image_add (translation invariance), and exists_admissible_card: an explicit admissible k-tuple {0,k!,…,(k-1)k!} for every k, so A(k) is well defined with A(k) ≤ (k-1)·k!. 9 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) estimates remain OPEN.",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
       "Erdos1204.admissible_iff_card (key reduction)",
-      "Erdos1204.admissible_zero_two / not_admissible_zero_one (examples)"
+      "Erdos1204.admissible_zero_two / not_admissible_zero_one (examples)",
+      "Erdos1204.Admissible.subset (downward closure)",
+      "Erdos1204.admissible_image_add (translation invariance)",
+      "Erdos1204.exists_admissible_card (existence of admissible k-tuples + A(k) ≤ (k-1)·k!)"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
       "Reduction: for primes p > k, k elements cannot cover all p classes, so admissibility only constrains primes p ≤ k.",
-      "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2."
+      "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2.",
+      "Admissibility is downward closed (subset-stable) and translation invariant — so A(k) depends only on differences and can be normalized to a₁=0.",
+      "Existence: {0, k!, 2·k!, …, (k-1)·k!} is admissible for every k (all elements ≡0 mod each prime p≤k since p∣k!; size bound handles p>k), proving A(k) well defined with A(k) ≤ (k-1)·k!."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Formalize explicit admissible-tuple constructions to bound A(k) above.",
-      "Investigate a lower-bound argument toward A(k) ≳ k log k."
+      "Sharpen the upper bound: replace k! by the primorial ∏_{p≤k} p (much smaller) toward A(k) ≲ ... .",
+      "Investigate a lower-bound argument toward A(k) ≳ k log k (requires prime distribution in residue classes)."
     ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-1204** (admissible sequences; OPEN). Erdős asks for the asymptotics of `A(k) = min a_k` over admissible `k`-tuples (conjecturally `A(k) ∼ k log k`) and the average `B(k)`. The prior session formalized the admissibility framework (definition, `missing_class_of_card_lt`, the reduction `admissible_iff_card`, and small examples). This session adds the structural results the prior `nextSteps` called for.

## Progress
`proofs/Proofs/Erdos1204Problem.lean` (now 9 thm / 1 def, **0 sorry, 0 axiom**, verified offline via `lake env lean`):

- `Admissible.subset` — admissibility is **downward closed**: any subset of an admissible set is admissible.
- `admissible_image_add` — **translation invariance**: shifting every element by a constant preserves admissibility. This is exactly why `A(k)` depends only on the differences and may be normalized to sequences starting at `0`.
- `exists_admissible_card` — **existence + explicit upper bound**: the arithmetic progression `{0, k!, 2·k!, …, (k-1)·k!}` is an admissible `k`-tuple for every `k`. Modulo every prime `p ≤ k` all elements are `≡ 0` (since `p ∣ k!`), so the class `1` is missed; for `p > k` the size bound applies. Hence **`A(k)` is well defined** and `A(k) ≤ (k-1)·k!`.

## Findings
- `#print axioms exists_admissible_card` / `admissible_image_add` → `[propext, Classical.choice, Quot.sound]` only — genuinely axiom-free.
- The `(k-1)·k!` bound is exponentially weak vs. the conjectured `k log k`; sharpening it (e.g. via the primorial `∏_{p≤k} p`) and any matching lower bound require analytic number theory and remain OPEN.

## Status
**Outcome**: progress (structural lemmas + existence/upper bound; headline asymptotics stay OPEN — status remains `axiomatized`).
**Next Steps**: replace `k!` by the primorial for a sharper upper bound; pursue a lower bound toward `A(k) ≳ k log k`.

🤖 Generated by researcher-3