### PR TITLE
Enrich Arcsine Distribution (Lévy's Arcsine Law core): full enrichment 0→100

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 3, "endLine": 58 },
+    "type": "context",
+    "title": "Lévy's Arcsine Law and the Scope of this Formalization",
+    "content": "The docstring states the research problem (the arcsine law 'via Brownian motion local times') and the honest scope. Lévy's Arcsine Law (1939) says three a priori different statistics of a standard Brownian motion on [0,1] — the occupation time of the positive half-line A⁺, the time of the maximum θ, and the time of the last zero L — all share the arcsine distribution with CDF F(x) = (2/π)·arcsin(√x) and density 1/(π√(x(1−x))). The 'via local times' derivation runs through the occupation density of W at level 0. Mathlib v4.26.0 has no Brownian motion, no stochastic local time, and no arcsine-distribution object, so that derivation cannot be carried out from primitives; the parent ballot-problem-oq-02 axiomatizes the Brownian facts. This entry instead proves, axiom-free, the verifiable real-analytic core — the CDF F and density f and their defining properties.",
+    "mathContext": "$F(x) = \\tfrac{2}{\\pi}\\arcsin\\sqrt{x}$, $f(x) = \\dfrac{1}{\\pi\\sqrt{x(1-x)}}$, $x \\in [0,1]$.",
+    "significance": "context",
+    "relatedConcepts": ["Lévy's arcsine law", "Brownian motion occupation time", "local time", "ballot problem", "fluctuation theory"],
+    "prerequisites": ["the statement of the arcsine law", "cumulative distribution functions"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 64, "endLine": 69 },
+    "type": "definition",
+    "title": "The Arcsine CDF and Density (arcsineCDF, arcsineDensity)",
+    "content": "arcsineCDF x = (2/π)·arcsin(√x) is the cumulative distribution function of the arcsine law on [0,1]; arcsineDensity x = 1/(π·√(x(1−x))) is its density on (0,1). Both are declared noncomputable because they are built from Real.arcsin and Real.sqrt. These two definitions are the only objects of study — every theorem in the file is a real-analytic property of one of them, so no measure-theoretic machinery is needed.",
+    "mathContext": "$\\mathrm{arcsineCDF}(x) = \\tfrac{2}{\\pi}\\arcsin\\sqrt{x}$, $\\mathrm{arcsineDensity}(x) = \\dfrac{1}{\\pi\\sqrt{x(1-x)}}$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.arcsin", "Real.sqrt", "probability density vs CDF", "noncomputable definitions"],
+    "prerequisites": ["the inverse sine function", "the relationship between a CDF and its density"]
+  },
+  {
+    "id": "ann-endpoints",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 71, "endLine": 80 },
+    "type": "theorem",
+    "title": "Endpoints and Total Mass (arcsineCDF_zero, arcsineCDF_one)",
+    "content": "arcsineCDF_zero proves F(0) = 0 by simp: √0 = 0 and arcsin 0 = 0. arcsineCDF_one proves F(1) = 1 by rewriting √1 = 1 (Real.sqrt_one) and arcsin 1 = π/2 (Real.arcsin_one), after which (2/π)·(π/2) = 1 by field_simp. These two facts certify that F maps the interval [0,1] onto [0,1] and that the distribution has total mass 1 — the minimal requirement to be a CDF.",
+    "mathContext": "$F(0) = \\tfrac{2}{\\pi}\\arcsin 0 = 0$, $F(1) = \\tfrac{2}{\\pi}\\arcsin 1 = \\tfrac{2}{\\pi}\\cdot\\tfrac{\\pi}{2} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.arcsin_one", "Real.sqrt_one", "total probability mass", "boundary conditions of a CDF"],
+    "prerequisites": ["values of arcsin at 0 and 1", "field_simp"]
+  },
+  {
+    "id": "ann-median",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 82, "endLine": 99 },
+    "type": "theorem",
+    "title": "The Median at the Centre (arcsin_sqrt_half, arcsineCDF_half)",
+    "content": "The helper arcsin_sqrt_half computes arcsin(√(1/2)) = π/4: it rewrites √(1/2) = √2/2 (via (√2/2)² = 1/2 and sqrt_sq), then recognizes √2/2 = sin(π/4) (Real.sin_pi_div_four) and inverts with Real.arcsin_sin, checking that π/4 lies in arcsin's principal range [−π/2, π/2]. arcsineCDF_half then gives F(1/2) = (2/π)·(π/4) = 1/2. Strikingly, the median of the arcsine law is the fair value 1/2 even though the density (below) takes its minimum exactly there — the distribution is balanced in the median sense while concentrating its mass at the extremes.",
+    "mathContext": "$\\arcsin\\sqrt{\\tfrac12} = \\arcsin\\tfrac{\\sqrt2}{2} = \\tfrac{\\pi}{4}$, so $F(\\tfrac12) = \\tfrac{2}{\\pi}\\cdot\\tfrac{\\pi}{4} = \\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.arcsin_sin", "Real.sin_pi_div_four", "principal range of arcsin", "median of a distribution"],
+    "prerequisites": ["sin(π/4) = √2/2", "inverting sin within its principal branch"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 101, "endLine": 108 },
+    "type": "theorem",
+    "title": "Monotonicity — F is a Genuine CDF (arcsineCDF_mono)",
+    "content": "arcsineCDF_mono shows that for 0 ≤ x ≤ y, F(x) ≤ F(y). The coefficient 2/π is nonnegative (positivity), so by mul_le_mul_of_nonneg_left it suffices that arcsin(√x) ≤ arcsin(√y); this is the composition of two monotone maps, Real.arcsin_le_arcsin applied to Real.sqrt_le_sqrt hxy. Monotonicity, with the endpoint values, is what makes F an honest cumulative distribution function rather than merely a function with the right boundary values.",
+    "mathContext": "$0 \\le x \\le y \\implies \\arcsin\\sqrt{x} \\le \\arcsin\\sqrt{y} \\implies F(x) \\le F(y)$, since $\\tfrac{2}{\\pi} \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.arcsin_le_arcsin", "Real.sqrt_le_sqrt", "monotone functions", "mul_le_mul_of_nonneg_left"],
+    "prerequisites": ["monotonicity of arcsin and sqrt", "scaling an inequality by a nonnegative constant"]
+  },
+  {
+    "id": "ann-reflection",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 110, "endLine": 135 },
+    "type": "insight",
+    "title": "Reflection Symmetry about 1/2 — the Arcsine Phenomenon (arcsineCDF_symm)",
+    "content": "The complementary-angle identity arcsin(√x) + arcsin(√(1−x)) = π/2 on [0,1] is the engine. It is proved by routing through arccos: since √x is nonnegative with (√x)² = x, Real.arccos_eq_arcsin gives arccos(√x) = arcsin(√(1−(√x)²)) = arcsin(√(1−x)), and Real.arccos_eq_pi_div_two_sub_arcsin gives arccos(√x) = π/2 − arcsin(√x); combining yields the identity (linarith). arcsineCDF_symm then proves F(x) + F(1−x) = 1: factor out 2/π, substitute the identity to get (2/π)·(π/2), and clear with field_simp/ring. This reflection symmetry is the formal statement of the arcsine law's signature feature — the occupation time is distributed symmetrically about 1/2, yet (by the U-shaped density) is least likely to be near 1/2.",
+    "mathContext": "$\\arcsin\\sqrt{x} + \\arcsin\\sqrt{1-x} = \\tfrac{\\pi}{2}$, hence $F(x) + F(1-x) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["complementary angles", "Real.arccos_eq_arcsin", "Real.arccos_eq_pi_div_two_sub_arcsin", "reflection symmetry of a distribution"],
+    "prerequisites": ["the arccos/arcsin relationship", "Pythagorean identity for sin and cos"]
+  },
+  {
+    "id": "ann-density",
+    "proofId": "ballot-problem-oq-02-oq-04",
+    "range": { "startLine": 137, "endLine": 151 },
+    "type": "theorem",
+    "title": "The U-shaped Density (arcsineDensity_symm, arcsineDensity_half)",
+    "content": "arcsineDensity_symm proves f(x) = f(1−x): after unfolding, the argument x(1−x) is symmetric under x ↦ 1−x, so ring_nf closes it. arcsineDensity_half proves f(1/2) = 2/π: rewrite (1/2)(1−1/2) = (1/2)² so √((1/2)²) = 1/2 (sqrt_sq), then field_simp. The value 2/π ≈ 0.637 is the bottom of the U — the density's global minimum — quantifying the paradox: the 'fair' split of spending half the time positive is the single least likely outcome, while f diverges at the extremes 0 and 1 where the path spends almost all its time on one side.",
+    "mathContext": "$f(x) = f(1-x)$ and $f(\\tfrac12) = \\dfrac{1}{\\pi\\sqrt{1/4}} = \\dfrac{2}{\\pi}$, the global minimum of the U-shaped density.",
+    "significance": "key",
+    "relatedConcepts": ["U-shaped / anti-concentrated density", "Real.sqrt_sq", "ring_nf", "global minimum of a density"],
+    "prerequisites": ["symmetry of x(1−x) about 1/2", "evaluating √ at a perfect square"]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-04/meta.json
@@ -24,7 +24,23 @@
     "scope": "Formalizes the arcsine DISTRIBUTION (the quantitative content of the law). The probabilistic statement 'the occupation time of the positive half-line is arcsine-distributed', derived via Brownian local times, is NOT proved here: Mathlib v4.26.0 contains no Brownian motion, no stochastic local time, and no arcsine-distribution object. The parent entry ballot-problem-oq-02 axiomatizes the Brownian facts; this entry instead proves the underlying real-analytic CDF axiom-free."
   },
   "overview": {
-    "text": "Lévy's Arcsine Law (1939) is the continuous-time culmination of the ballot problem. For a standard Brownian motion W on [0,1], three a priori different statistics — the occupation time of the positive half-line {t : W_t > 0}, the time of the maximum argmax_t W_t, and the time of the last zero sup{t : W_t = 0} — all share the same distribution on [0,1]: the arcsine law, with CDF F(x) = (2/π)·arcsin(√x) and density f(x) = 1/(π√(x(1-x))). The 'via local times' route obtains this through the occupation density (local time) of W at level 0. Because Mathlib has no local-time theory, this entry formalizes the verifiable heart of the law — the arcsine CDF F itself as a real-analytic object — proving its defining CDF properties and its signature reflection symmetry F(x)+F(1-x)=1, which is the formal expression of the counterintuitive 'arcsine' phenomenon: a Brownian path is least likely to spend half its time positive and most likely to spend nearly all or nearly none."
+    "text": "Lévy's Arcsine Law (1939) is the continuous-time culmination of the ballot problem. For a standard Brownian motion W on [0,1], three a priori different statistics — the occupation time of the positive half-line {t : W_t > 0}, the time of the maximum argmax_t W_t, and the time of the last zero sup{t : W_t = 0} — all share the same distribution on [0,1]: the arcsine law, with CDF F(x) = (2/π)·arcsin(√x) and density f(x) = 1/(π√(x(1-x))). The 'via local times' route obtains this through the occupation density (local time) of W at level 0. Because Mathlib has no local-time theory, this entry formalizes the verifiable heart of the law — the arcsine CDF F itself as a real-analytic object — proving its defining CDF properties and its signature reflection symmetry F(x)+F(1-x)=1, which is the formal expression of the counterintuitive 'arcsine' phenomenon: a Brownian path is least likely to spend half its time positive and most likely to spend nearly all or nearly none.",
+    "historicalContext": "The discrete ballot problem (Bertrand 1887, Whitworth) asks for the probability that one candidate stays strictly ahead throughout the count; its reflection-principle solution and the Catalan numbers are the combinatorial seed of fluctuation theory. Paul Lévy, in his 1939 memoir *Sur certains processus stochastiques homogènes* (Compositio Mathematica 7, 283–339), discovered the continuous-time limit: for Brownian motion on [0,1], the fraction of time spent above zero is NOT concentrated near 1/2 as naive fairness would suggest, but follows the arcsine law F(x) = (2/π)·arcsin(√x), whose density 1/(π√(x(1−x))) blows up at the endpoints. The same distribution simultaneously governs the time of the maximum and the time of the last zero — a triple coincidence later given canonical treatments by Karatzas–Shreve (1991, §6.3) and Mörters–Peres (2010, §5.2, Thm 5.28) via local times and the reflection principle. The law is the prototype of the 'unfair fairness' phenomena in random walks: in a long sequence of fair coin tosses, the lead is overwhelmingly likely to belong to one player for most of the game. The name 'arcsine' comes directly from the arcsin in the CDF.",
+    "problemStatement": "Lévy's Arcsine Law states that the occupation time $A^+ = |\\{t \\in [0,1] : W_t > 0\\}|$ of a standard Brownian motion (and equally its argmax time and last-zero time) has cumulative distribution $F(x) = \\tfrac{2}{\\pi}\\arcsin\\sqrt{x}$ on $[0,1]$. A from-primitives proof requires Brownian local times, absent from Mathlib v4.26.0. This entry isolates and proves the verifiable quantitative core: that $F$ is a genuine CDF on $[0,1]$ (endpoints $0,1$, median $1/2$, monotone) with the reflection symmetry $F(x) + F(1-x) = 1$, and that the density $f(x) = 1/(\\pi\\sqrt{x(1-x)})$ is symmetric about $1/2$ with global minimum $2/\\pi$ there.",
+    "proofStrategy": "Everything reduces to real-analytic facts about Real.arcsin and Real.sqrt. The endpoints use arcsin 0 = 0 and arcsin 1 = π/2; the median uses the helper arcsin_sqrt_half (arcsin(√(1/2)) = π/4), obtained by rewriting √(1/2) = √2/2 and inverting sin(π/4). Monotonicity is mul_le_mul_of_nonneg_left applied to Real.arcsin_le_arcsin ∘ Real.sqrt_le_sqrt with the nonnegative coefficient 2/π. The reflection symmetry rests on the complementary-angle identity arcsin(√x) + arcsin(√(1−x)) = π/2, proved by routing through arccos: arccos(√x) = arcsin(√(1−(√x)²)) = arcsin(√(1−x)) (Real.arccos_eq_arcsin) and arccos = π/2 − arcsin (Real.arccos_eq_pi_div_two_sub_arcsin); summing the two arcsin coefficients and clearing 2/π gives 1. The density symmetry is ring_nf on the manifestly symmetric x(1−x); its minimum value 2/π follows from √((1/2)²) = 1/2 and field_simp.",
+    "keyInsights": [
+      "**The arcsin in the name is literal**: the CDF is built directly from Real.arcsin(√x), so every property of the law is a property of a single elementary special function — the formalization needs no measure theory, only real analysis of arcsin and sqrt.",
+      "**Reflection symmetry F(x)+F(1−x)=1 is the heart of the matter**: it says the occupation time is distributed symmetrically about 1/2, yet — because the density is U-shaped — symmetry about 1/2 coexists with mass fleeing AWAY from 1/2. The symmetric median and the anti-concentrated density are not in tension; they are the whole surprise of the arcsine law.",
+      "**The complementary-angle identity arcsin(√x) + arcsin(√(1−x)) = π/2 is the engine**: it is the analytic shadow of the geometric fact that √x and √(1−x) are sine and cosine of complementary angles, and it is what forces the reflection symmetry. The proof routes through arccos to expose this.",
+      "**Honest scoping under a library gap**: Mathlib v4.26.0 has no Brownian motion, no stochastic local time, and no arcsine-distribution object, so the probabilistic 'via local times' derivation cannot be done from primitives. This entry proves exactly the part that IS formalizable — the CDF and density as real-analytic objects — and marks the local-time route as future work rather than axiomatizing it.",
+      "**The U-shaped density's minimum at 2/π quantifies the paradox**: the most 'fair' split (half the time positive) is the single least likely outcome, with density bottoming out at 2/π ≈ 0.637, while the density diverges at the extremes 0 and 1."
+    ],
+    "prerequisites": [
+      "Real.arcsin / Real.arccos and their identities (arcsin_one, arccos_eq_arcsin, arccos_eq_pi_div_two_sub_arcsin)",
+      "Real.sqrt and its monotonicity / square laws (sqrt_le_sqrt, sq_sqrt, sqrt_sq)",
+      "What a cumulative distribution function is (monotone, endpoints 0 and 1)",
+      "Background: Brownian motion, occupation/local time, and the statement of Lévy's arcsine law"
+    ]
   },
   "references": [
     {
@@ -46,6 +62,66 @@
       "note": "Local times and the arcsine law derivation."
     }
   ],
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation and Scope",
+      "startLine": 3,
+      "endLine": 58,
+      "summary": "States Lévy's Arcsine Law, the three statistics it governs (occupation time, argmax time, last-zero time), the CDF F(x)=(2/π)arcsin√x and density 1/(π√(x(1−x))), and the 'via local times' route. Honestly scopes the entry: Mathlib v4.26.0 has no Brownian motion / local time / arcsine-distribution object, so it formalizes the verifiable real-analytic core (the CDF and density) axiom-free and marks the probabilistic derivation as future work."
+    },
+    {
+      "id": "definitions",
+      "title": "The Arcsine CDF and Density",
+      "startLine": 60,
+      "endLine": 69,
+      "summary": "arcsineCDF x = (2/π)·arcsin(√x) and arcsineDensity x = 1/(π·√(x(1−x))), the two real-analytic objects the rest of the file analyzes. Both are noncomputable (they use Real.arcsin and Real.sqrt)."
+    },
+    {
+      "id": "endpoints",
+      "title": "Endpoints and Total Mass",
+      "startLine": 71,
+      "endLine": 80,
+      "summary": "arcsineCDF_zero: F(0) = 0 (no mass left of 0, via arcsin 0 = 0); arcsineCDF_one: F(1) = 1 (total mass 1, via √1 = 1 and arcsin 1 = π/2 cancelling 2/π). Together they certify F maps [0,1] onto [0,1]."
+    },
+    {
+      "id": "median",
+      "title": "The Median at the Centre",
+      "startLine": 82,
+      "endLine": 99,
+      "summary": "Helper arcsin_sqrt_half proves arcsin(√(1/2)) = π/4 by rewriting √(1/2) = √2/2 and inverting sin(π/4) within arcsin's principal range. arcsineCDF_half then gives F(1/2) = 1/2: the median is the fair value 1/2, even though the law concentrates mass away from it."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity — F is a Genuine CDF",
+      "startLine": 101,
+      "endLine": 108,
+      "summary": "arcsineCDF_mono: for 0 ≤ x ≤ y, F(x) ≤ F(y). Proved by mul_le_mul_of_nonneg_left with the nonnegative coefficient 2/π, reducing to Real.arcsin_le_arcsin (Real.sqrt_le_sqrt hxy) — arcsin and sqrt are both monotone."
+    },
+    {
+      "id": "reflection-symmetry",
+      "title": "Reflection Symmetry about 1/2 — the Arcsine Phenomenon",
+      "startLine": 110,
+      "endLine": 135,
+      "summary": "The complementary-angle identity arcsin(√x) + arcsin(√(1−x)) = π/2 (proved via arccos(√x) = arcsin(√(1−x)) and arccos = π/2 − arcsin) drives arcsineCDF_symm: F(x) + F(1−x) = 1 on [0,1]. This is the formal statement of the arcsine law's signature feature — symmetry about 1/2 alongside anti-concentration near it."
+    },
+    {
+      "id": "u-shaped-density",
+      "title": "The U-shaped Density",
+      "startLine": 137,
+      "endLine": 151,
+      "summary": "arcsineDensity_symm: f(x) = f(1−x), immediate from the symmetric x(1−x) (ring_nf). arcsineDensity_half: f(1/2) = 2/π, the bottom of the U and the density's global minimum — the quantitative form of 'the fair split is the least likely outcome', while f diverges at the endpoints."
+    }
+  ],
+  "conclusion": {
+    "summary": "An axiom-free, sorry-free formalization of the quantitative core of Lévy's Arcsine Law: the arcsine CDF F(x) = (2/π)·arcsin(√x) is shown to be a genuine cumulative distribution function on [0,1] — endpoints F(0)=0, F(1)=1, median F(1/2)=1/2, monotone — with the signature reflection symmetry F(x)+F(1−x)=1, and its density 1/(π√(x(1−x))) is symmetric about 1/2 with global minimum 2/π there. 9 theorems, 2 definitions, 0 axioms, depending only on real analysis of Real.arcsin and Real.sqrt.",
+    "implications": "Captures the counterintuitive heart of the arcsine law — symmetry about 1/2 coexisting with a density that flees 1/2 — as a fully checked real-analytic statement, independent of any probability theory. The CDF and density, together with the proven complementary-angle identity arcsin(√x)+arcsin(√(1−x))=π/2, are a reusable building block: once Mathlib gains Brownian motion and stochastic local times, the occupation-time random variable can be tied to this F to complete the probabilistic statement without re-deriving the analytic facts.",
+    "openQuestions": [
+      "Complete the probabilistic derivation 'via local times' once Mathlib has Brownian motion and stochastic local time: identify the occupation time A⁺ of the positive half-line as a random variable and prove ℙ(A⁺ ≤ x) = F(x).",
+      "Prove that the density f integrates to 1 and that F is its antiderivative (F'(x) = f(x) on (0,1)), tying the CDF and density together inside Mathlib's measure/integration framework.",
+      "Establish the joint arcsine law for the other two statistics (argmax time and last-zero time) and the equidistribution that makes all three share F."
+    ]
+  },
   "crossReferences": [
     "ballot-problem-oq-02"
   ],


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-02-oq-04` ("The Arcsine Distribution: verified core of Lévy's Arcsine Law").

This entry scored **quality 0**: no `annotations.json`, no `sections`, no `conclusion`, and `overview` had only a `text` field (no `historicalContext`/`keyInsights`). This pass brings it to **quality 100**:

- **Created `annotations.json`** — 7 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the docstring/scope, the `arcsineCDF`/`arcsineDensity` definitions, the endpoints, the median (`arcsin_sqrt_half` → `arcsineCDF_half`), monotonicity, the reflection symmetry `F(x)+F(1−x)=1` (via the complementary-angle identity), and the U-shaped density.
- **Extended `overview`** with `historicalContext` (ballot problem → Lévy 1939 → Karatzas–Shreve/Mörters–Peres), `problemStatement`, `proofStrategy`, and 5 `keyInsights`; preserved the existing `text`.
- **Added `sections`** (7, covering all of lines 3–151) and a **`conclusion`** object with summary, implications, and 3 open questions (notably completing the 'via local times' derivation once Mathlib has Brownian motion / stochastic local time).

No mathematical claims changed; `status: verified`, `axiomCount: 0` remain accurate (the entry honestly scopes the unprovable probabilistic part as future work rather than axiomatizing it). JSON validates, `pnpm annotations:build` reports no warnings for this entry, and `tsc -b` passes.