### PR TITLE
research(erdos-748-incomplete-01): f is monotone + subset-step [verified, +2 thm/0 axiom]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -150,6 +150,30 @@ theorem trivial_lower_bound (n : ℕ) (hn : n ≥ 2) :
   calc 2 ^ (n / 2) ≤ 2 ^ U.card := Nat.pow_le_pow_right (by norm_num) hexp
     _ ≤ f n := hcard
 
+/--
+**Monotonicity, ground step:**
+Every sum-free subset of {1,...,n} is also a sum-free subset of {1,...,n+1}.
+Sum-freeness is a property of the set itself (no `a = b + c` among its own
+elements), so enlarging the ambient range cannot break it; the only change is
+that the subset is now allowed to live in the larger box.
+-/
+theorem sumFreeSubsets_subset_succ (n : ℕ) :
+    sumFreeSubsets n ⊆ sumFreeSubsets (n + 1) := by
+  intro A hA
+  rw [sumFreeSubsets, Finset.mem_filter, Finset.mem_powerset] at hA ⊢
+  exact ⟨hA.1.trans (Finset.Icc_subset_Icc (le_refl 1) (Nat.le_succ n)), hA.2⟩
+
+/--
+**The counting function `f` is monotone.**
+Since the family of sum-free subsets only grows as the ambient range grows
+(`sumFreeSubsets_subset_succ`), its cardinality `f n` is non-decreasing in `n`.
+This is the structural fact underlying the trivial lower bound: the supply of
+sum-free sets never shrinks.
+-/
+theorem f_monotone : Monotone f :=
+  monotone_nat_of_le_succ fun n =>
+    Finset.card_le_card (sumFreeSubsets_subset_succ n)
+
 /-
 ## Part IV: The Cameron-Erdős Conjecture
 -/

--- a/research/problems/erdos-748-incomplete-01/knowledge.md
+++ b/research/problems/erdos-748-incomplete-01/knowledge.md
@@ -2,13 +2,41 @@
 
 ## Research Notes
 
-*No research conducted yet. See problem.md for context.*
+### Current state (2026-06-25, researcher-2)
+
+`proofs/Proofs/Erdos748Problem.lean` is in good shape: **0 sorries, 2 axioms**.
+The formalization of the Cameron–Erdős conjecture is essentially complete at the
+*achievable* level. The two remaining axioms are genuinely deep literature results:
+
+- `green_upper_bound` — Green (2004), `f(n) ≪ 2^{n/2}`. Fourier-analytic /
+  structure-theorem proof; formalizing it is a >1000-line undertaking (BLOCKED).
+- `precise_asymptotic` — Green/Sapozhenko (2003/2004), `f(n) ~ c_n·2^{n/2}`
+  with parity-dependent constants. Same blocker.
+
+The trivial lower bound `f(n) ≥ 2^{⌊n/2⌋}` is **fully proved** (formerly an axiom)
+via the powerset of the upper half `{⌊n/2⌋+1,…,n}` embedding into the sum-free
+subsets.
+
+This session added two new 0-axiom structural theorems:
+- `sumFreeSubsets_subset_succ : sumFreeSubsets n ⊆ sumFreeSubsets (n+1)` —
+  sum-freeness is intrinsic to a set, so enlarging the ambient range `{1,…,n}`
+  cannot break it.
+- `f_monotone : Monotone f` — the counting function never decreases. Proved by
+  `monotone_nat_of_le_succ` from the subset-step + `Finset.card_le_card`.
+
+### Follow-up status
+
+The natural follow-up "largest sum-free subset of {1,…,n} has size ⌈n/2⌉" is
+owned by **open PR #30202** (do not duplicate).
 
 ## Known Facts
 
-- Lean file: `proofs/Proofs/`
-- Sorries: see problem.md
+- Lean file: `proofs/Proofs/Erdos748Problem.lean` (0 sorries, 2 deep axioms)
+- Companion: `proofs/Proofs/Erdos748Aristotle.lean`
+- `f n := (Finset.Icc 1 n).powerset.filter IsSumFree |>.card`
+- Both remaining axioms are deep (Green 2004 / Sapozhenko 2003), not routine.
 
 ## Approaches Tried
 
-*None yet.*
+- Axiom hunt: only `trivial_lower_bound` was routine; already eliminated upstream.
+- Structural additions (monotonicity of `f`) — done this session, 0 new axioms.

--- a/research/problems/erdos-748-incomplete-01/state.md
+++ b/research/problems/erdos-748-incomplete-01/state.md
@@ -1,6 +1,10 @@
 # State: erdos-748-incomplete-01
 
-**Phase**: OBSERVE
-**Since**: 2026-04-03T08:28:28Z
-**Attempts**: 0
-**Status**: available
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Attempts**: 1
+**Status**: in-progress
+
+Added `f_monotone` + `sumFreeSubsets_subset_succ` (0 axioms). File now 0 sorries,
+2 deep axioms (Green 2004, Sapozhenko 2003 — BLOCKED, >1000 lines each).
+Follow-up "max sum-free size = ⌈n/2⌉" owned by open PR #30202.

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -49,15 +49,17 @@
       "upperHalf_sumFree theorem: upper half is always sum-free",
       "trivial_lower_bound theorem (PROVED, formerly an axiom): f(n) ≥ 2^{⌊n/2⌋} via the powerset of the upper half embedding into the sum-free subsets",
       "cameronErdosConjecture definition: formal statement",
+      "sumFreeSubsets_subset_succ theorem (PROVED, 0 axioms): sum-free subsets of {1,...,n} embed into those of {1,...,n+1} — sum-freeness is intrinsic, so enlarging the ambient range preserves it",
+      "f_monotone theorem (PROVED, 0 axioms): the counting function f is monotone (Monotone f), the structural fact underlying the trivial lower bound",
       "green_upper_bound axiom: f(n) ≪ 2^{n/2}",
       "precise_asymptotic axiom: f(n) ~ c_n · 2^{n/2}",
       "oddNumbers_sumFree theorem: odds form sum-free set",
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 362,
+    "lineCount": 386,
     "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The trivial lower bound f(n) ≥ 2^{⌊n/2⌋} is now fully proved (no longer an axiom). See the Lean source for details.",
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/Erdos748Aristotle.lean"
@@ -177,9 +179,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 362,
+    "lineCount": 386,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Two new **0-axiom** structural theorems for the Cameron–Erdős sum-free counting formalization (`Erdos748Problem.lean`), where `f n` counts the sum-free subsets of `{1,…,n}`.

- `sumFreeSubsets_subset_succ : sumFreeSubsets n ⊆ sumFreeSubsets (n+1)` — sum-freeness is intrinsic to a set (no `a = b + c` among its own elements), so enlarging the ambient range cannot break it. The family of sum-free subsets only grows.
- `f_monotone : Monotone f` — the counting function is non-decreasing, via `monotone_nat_of_le_succ` and `Finset.card_le_card`. This is the structural fact underlying the trivial lower bound (the supply of sum-free sets never shrinks).

## Verification

- `lake env lean Proofs/Erdos748Problem.lean` typechecks (exit 0, no errors).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only — no substantive axioms.

## Status unchanged

The file remains `status: axiomatized` (badge `axiom`): the two remaining axioms `green_upper_bound` (Green 2004) and `precise_asymptotic` (Green/Sapozhenko 2003) are deep literature results (>1000-line formalizations, BLOCKED) and are intentionally left axiomatized. This PR adds no new axioms.

## Notes

- The natural follow-up "largest sum-free subset of `{1,…,n}` has size `⌈n/2⌉`" is owned by open PR #30202 and is **not** duplicated here.
- Refreshes the stale `knowledge.md`/`state.md` (previously "no research conducted yet") to reflect the real state; bumps meta `theoremCount` 12→14, `lineCount` 362→386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)