### PR TITLE
research(odd-squares-sum-oq-01): ∑(2k−1)²=n(2n−1)(2n+1)/3 [verified, 2 thm, 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/OddSquaresSum.lean
+++ b/proofs/Proofs/OddSquaresSum.lean
@@ -1,0 +1,74 @@
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-
+# Sum of Squares of the First n Odd Numbers
+
+## Open Question (odd-squares-sum-oq-01)
+
+"The sum of the squares of the first n odd numbers has the closed form
+`n(2n−1)(2n+1)/3`."  Writing the k-th odd number as `2k+1` for `k = 0,…,n−1`,
+
+    ∑_{k<n} (2k+1)² = 1² + 3² + 5² + ⋯ + (2n−1)² = n(2n−1)(2n+1)/3.
+
+This is the odd-indexed companion of the square-pyramidal identity
+`∑_{k≤n} k² = n(n+1)(2n+1)/6`.
+
+## Result
+
+A fully machine-checked, self-contained proof by induction.
+
+* `three_mul_sum_odd_squares` is the division-free integer form
+  `3·∑_{k<n} (2k+1)² + n = 4n³`.  Phrased additively it contains **no truncated
+  subtraction**, so the inductive step closes by `ring` alone.
+* `sum_odd_squares_rat` is the classical closed form over `ℚ`,
+  `∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3`, proved directly by induction.
+
+## Novelty
+
+Mathlib has the square-pyramidal sum-of-squares identity but *not* this
+odd-indexed variant.  This file supplies both an exact ℕ form and the rational
+closed form.
+
+0 sorries, 0 axioms.
+-/
+
+namespace OddSquaresSum
+
+open Finset
+
+/-- **Division-free integer form.**  Three times the sum of the squares of the
+first `n` odd numbers, plus `n`, equals `4n³`:
+
+`3·∑_{k<n} (2k+1)² + n = 4n³`.
+
+Stated additively there is no subtraction, so the inductive step is pure `ring`. -/
+theorem three_mul_sum_odd_squares (n : ℕ) :
+    3 * (∑ k ∈ range n, (2 * k + 1) ^ 2) + n = 4 * n ^ 3 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, Nat.mul_add]
+    -- Reassociate so the inductive hypothesis `3·∑ + m = 4m³` appears verbatim.
+    have key :
+        3 * (∑ k ∈ range m, (2 * k + 1) ^ 2) + 3 * (2 * m + 1) ^ 2 + (m + 1)
+          = (3 * (∑ k ∈ range m, (2 * k + 1) ^ 2) + m) + (3 * (2 * m + 1) ^ 2 + 1) := by
+      ring
+    rw [key, ih]
+    ring
+
+/-- **Closed form over `ℚ`.**  The sum of the squares of the first `n` odd
+numbers equals `n(2n−1)(2n+1)/3`:
+
+`∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3`. -/
+theorem sum_odd_squares_rat (n : ℕ) :
+    ∑ k ∈ range n, (2 * (k : ℚ) + 1) ^ 2
+      = (n : ℚ) * (2 * n - 1) * (2 * n + 1) / 3 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, ih]
+    push_cast
+    ring
+
+end OddSquaresSum

--- a/research/problems/odd-squares-sum-oq-01/knowledge.md
+++ b/research/problems/odd-squares-sum-oq-01/knowledge.md
@@ -1,0 +1,46 @@
+# odd-squares-sum-oq-01 — Sum of Squares of the First n Odd Numbers
+
+**Statement:** ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3  (i.e. 1² + 3² + ⋯ + (2n−1)²).
+
+**Status:** COMPLETED (verified, 0 axioms, 0 sorries).
+
+## Summary
+
+Odd-indexed companion of the square-pyramidal identity ∑k² = n(n+1)(2n+1)/6.
+Mathlib has the square-pyramidal form but not this odd variant. Proved twice:
+the division-free exact ℕ identity `3·∑(2k+1)² + n = 4n³` (additive, so the
+inductive step is a single `ring`), and the classical rational closed form
+over ℚ.
+
+## Session 2026-06-25 (Session 1) — FRESH
+
+**Mode:** FRESH
+**Outcome:** completed
+
+### What I Did
+- Verified the formula numerically (n=0..7): ∑ matches n(2n−1)(2n+1)/3 and 3·∑+n = 4n³.
+- Wrote `proofs/Proofs/OddSquaresSum.lean` with two theorems.
+- `three_mul_sum_odd_squares`: `3·∑(2k+1)² + n = 4n³` by induction; step closes
+  by reassociating to expose the hypothesis cluster `3·∑+m` then `ring`.
+- `sum_odd_squares_rat`: `∑(2k+1)² = n(2n−1)(2n+1)/3` over ℚ; step is
+  `sum_range_succ; push_cast; ring`.
+- Compiled offline via `lake env lean` (Docker daemon down): exit 0.
+- `#print axioms` for both: only propext / Classical.choice / Quot.sound → axiom-free.
+- Added gallery data (meta.json, annotations.json); `pnpm annotations:validate`
+  reports no errors for this proof.
+
+### Key Findings
+- "Clear the denominator additively": rewriting f(n)/c as c·∑ + (linear) =
+  (polynomial) removes both division and truncated ℕ subtraction, collapsing the
+  inductive step to one `ring` call.
+- The ℚ form is cleanest for the headline division statement; `push_cast`
+  handles the ↑(m+1) cast automatically.
+
+### Files Modified
+- proofs/Proofs/OddSquaresSum.lean (new, 74 lines)
+- src/data/proofs/odd-squares-sum-oq-01/{meta,annotations}.json (new)
+- src/data/research/problems/odd-squares-sum-oq-01.json (new)
+
+### Next Steps
+- Same pattern for ∑(2k+1)³ = n²(2n²−1) (odd-cubes-sum-oq-01, ℕ-integral RHS).
+- Derive as ∑_{j<2n} j² − 4∑_{k<n} k² from Mathlib's square-pyramidal identity.

--- a/src/data/proofs/odd-squares-sum-oq-01/annotations.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/annotations.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "ann-integer-form",
+    "proofId": "odd-squares-sum-oq-01",
+    "range": { "startLine": 46, "endLine": 62 },
+    "type": "theorem",
+    "title": "Division-free integer form: 3·∑(2k+1)² + n = 4n³",
+    "content": "The exact identity over $\\mathbb{N}$. Clearing the denominator in $\\sum (2k+1)^2 = (4n^3-n)/3$ and moving the linear term left gives $3\\sum(2k+1)^2 + n = 4n^3$ — additive, with no subtraction, so `ring` never meets a truncated $\\mathbb{N}$ difference. The base case is `simp` (empty sum). In the step, `sum_range_succ` peels off $(2m+1)^2$; a single `have key` reassociates the goal so the inductive hypothesis $3\\sum + m = 4m^3$ appears verbatim, after which `rw [key, ih]; ring` verifies $4m^3 + 3(2m+1)^2 + 1 = 4(m+1)^3$.",
+    "mathContext": "$3\\sum_{k<n}(2k+1)^2 + n = 4n^3$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
+    "relatedConcepts": ["Power sums", "Truncated natural subtraction", "ring tactic", "Denominator clearing"]
+  },
+  {
+    "id": "ann-reassociation",
+    "proofId": "odd-squares-sum-oq-01",
+    "range": { "startLine": 53, "endLine": 61 },
+    "type": "insight",
+    "title": "Reassociating so the hypothesis appears verbatim",
+    "content": "After `sum_range_succ` the goal is $3(\\sum_{k<m} + (2m+1)^2) + (m+1) = 4(m+1)^3$. The inductive hypothesis is about the *clustered* term $3\\sum_{k<m} + m$, which is not yet syntactically present. The `key` step regroups the left side by `ring` into $(3\\sum_{k<m} + m) + (3(2m+1)^2 + 1)$, exposing the hypothesis cluster exactly; rewriting by `ih` replaces it with $4m^3$ and a final `ring` finishes. This 'shape the goal to fit the hypothesis' move is what keeps the proof to two `ring` calls.",
+    "mathContext": "$3\\sum_{k<m+1}(2k+1)^2 + (m+1) = (3\\sum_{k<m}(2k+1)^2 + m) + (3(2m+1)^2 + 1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Inductive hypothesis matching", "Associativity", "ring tactic"]
+  },
+  {
+    "id": "ann-rational-form",
+    "proofId": "odd-squares-sum-oq-01",
+    "range": { "startLine": 64, "endLine": 72 },
+    "type": "theorem",
+    "title": "Rational closed form: ∑(2k+1)² = n(2n−1)(2n+1)/3",
+    "content": "The classical closed form, stated over $\\mathbb{Q}$ where division by $3$ is genuine. The base case is `simp`. The inductive step peels the top term with `sum_range_succ`, rewrites the sum by the hypothesis, and then `push_cast` normalizes the cast $\\uparrow(m+1) = \\uparrow m + 1$ while `ring` verifies the field identity $\\frac{m(2m-1)(2m+1)}{3} + (2m+1)^2 = \\frac{(m+1)(2m+1)(2m+3)}{3}$. Proving it directly over $\\mathbb{Q}$ avoids any natural-number division artifact.",
+    "mathContext": "$\\sum_{k<n}(2k+1)^2 = \\frac{n(2n-1)(2n+1)}{3}$ over $\\mathbb{Q}$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Field arithmetic over ℚ", "push_cast"],
+    "relatedConcepts": ["Closed-form power sums", "Square-pyramidal number", "ℕ→ℚ casting"]
+  }
+]

--- a/src/data/proofs/odd-squares-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-squares-sum-oq-01/meta.json
@@ -1,0 +1,87 @@
+{
+  "id": "odd-squares-sum-oq-01",
+  "title": "Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3",
+  "slug": "odd-squares-sum-oq-01",
+  "description": "A fully machine-checked, self-contained proof that the sum of the squares of the first n odd numbers has the closed form n(2n−1)(2n+1)/3: ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3. The result is established both as a division-free exact identity over ℕ — 3·∑(2k+1)² + n = 4n³, phrased additively so the inductive step has no truncated subtraction and closes by `ring` alone — and as the classical rational closed form over ℚ. This is the odd-indexed companion of the square-pyramidal identity ∑k² = n(n+1)(2n+1)/6, which Mathlib has; this variant it does not.",
+  "meta": {
+    "author": "Classical; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Square_pyramidal_number",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "power-sums",
+      "odd-numbers",
+      "closed-form",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/OddSquaresSum.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. The engine of both inductive steps.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 for the sum of squares of the first n odd numbers, machine-checked over ℚ with 0 axioms and 0 sorries (Mathlib has the square-pyramidal ∑k² identity but not this odd-indexed companion)",
+      "The division-free exact ℕ identity 3·∑_{k<n} (2k+1)² + n = 4n³: stated additively it contains no truncated natural subtraction, so the entire inductive step is closed by a single `ring` after one reassociation — the whole development stays inside ℕ with no integer casts",
+      "A clean two-line rational proof: `sum_range_succ` peels the top odd square and `push_cast; ring` discharges the resulting polynomial identity over ℚ, with the ℕ→ℚ cast of n+1 normalized automatically"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 74,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "integer-form",
+      "title": "Division-free integer form (subtraction-free step)",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "The exact ℕ identity 3·∑_{k<n} (2k+1)² + n = 4n³, proved by induction. Phrased additively it contains no truncated subtraction. The step peels the top odd square with sum_range_succ, reassociates so the inductive hypothesis 3·∑ + m = 4m³ appears verbatim, and a single `ring` closes the branch. The whole proof lives in ℕ — no casts to ℤ or ℚ."
+    },
+    {
+      "id": "rational-closed-form",
+      "title": "Rational closed form n(2n−1)(2n+1)/3",
+      "startLine": 64,
+      "endLine": 72,
+      "summary": "The classical closed form ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 over ℚ. Base case is `simp` (empty sum). The inductive step peels the top term, rewrites by the hypothesis, and `push_cast; ring` discharges the polynomial identity — verifying (m(2m−1)(2m+1)/3) + (2m+1)² = (m+1)(2m+1)(2m+3)/3 in the field ℚ where division is genuine."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Odd-indexed power sums**\n\nThe squares of the odd numbers $1^2, 3^2, 5^2, \\dots$ sum to a strikingly clean closed form. Writing the $k$-th odd number as $2k+1$ for $k = 0, 1, \\dots, n-1$,\n$$1^2 + 3^2 + 5^2 + \\cdots + (2n-1)^2 = \\frac{n(2n-1)(2n+1)}{3}.$$\nThis is the odd-indexed sibling of the *square-pyramidal* identity $\\sum_{k\\le n} k^2 = \\tfrac{n(n+1)(2n+1)}{6}$. Indeed, summing all squares up to $2n-1$ and subtracting the even squares $\\sum (2k)^2 = 4\\sum k^2$ recovers exactly this formula. Mathlib provides the square-pyramidal identity but not this odd variant; this entry supplies it.",
+    "problemStatement": "**Sum of squares of the first $n$ odd numbers**\n\nFor every natural number $n$,\n$$\\sum_{k<n} (2k+1)^2 = \\frac{n(2n-1)(2n+1)}{3}.$$\nThe goal is a fully machine-checked proof with no axioms and no sorries, in a form that avoids artifacts of natural-number division.",
+    "proofStrategy": "**Two complementary statements**\n\nFirst the result is captured *exactly in $\\mathbb{N}$* by clearing the denominator and moving the linear term to the left:\n$$3\\sum_{k<n} (2k+1)^2 + n = 4n^3.$$\nAdditive and with no subtraction, this is ideal for `ring`: the inductive step peels the top term, and after one reassociation the hypothesis $3\\sum + m = 4m^3$ appears verbatim and `ring` finishes. Then the **rational closed form** $\\sum (2k+1)^2 = n(2n-1)(2n+1)/3$ is proved directly over $\\mathbb{Q}$, where the division is genuine and `push_cast; ring` discharges the step.",
+    "keyInsights": [
+      "**Clear the denominator additively.** Rewriting $\\sum = (4n^3 - n)/3$ as $3\\sum + n = 4n^3$ removes both the division *and* the subtraction, so the entire inductive step is a single `ring` call with no case split and no truncation hazard.",
+      "**The step is one cubic identity.** After substituting the hypothesis, the goal collapses to $4m^3 + 3(2m+1)^2 + 1 = 4(m+1)^3$ — a fact about the single number $m$, independent of the sum.",
+      "**Use ℚ for the headline form.** Division by $3$ is only honest in a field, so the classical $n(2n-1)(2n+1)/3$ form is stated and proved over $\\mathbb{Q}$, where `push_cast; ring` handles the casts and the cubic algebra in one stroke.",
+      "**Relation to the square-pyramidal sum.** The identity is exactly $\\sum_{j<2n} j^2 - 4\\sum_{k<n} k^2$, tying the odd-square sum to Mathlib's even-indexed power-sum machinery."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range`",
+      "Polynomial identities over ℚ"
+    ]
+  },
+  "conclusion": {
+    "summary": "The sum of the squares of the first $n$ odd numbers, $\\sum_{k<n}(2k+1)^2$, equals $n(2n-1)(2n+1)/3$. This is proved twice: as the division-free exact ℕ identity $3\\sum(2k+1)^2 + n = 4n^3$, whose additive phrasing lets the inductive step close by `ring` with no truncated subtraction, and as the classical rational closed form over $\\mathbb{Q}$. Both depend on the single Mathlib lemma `sum_range_succ`. 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the odd-indexed sum-of-squares closed form that Mathlib's power-sum library does not provide, complementing the square-pyramidal identity.",
+      "Demonstrates the 'clear the denominator additively' technique: replacing a closed form $f(n)/c$ by the subtraction-free $c\\cdot\\sum + (\\text{linear}) = (\\text{polynomial})$ keeps power-sum proofs entirely inside ℕ and reduces the inductive step to a single `ring`.",
+      "The rational form `sum_odd_squares_rat` packages the result for downstream reuse where genuine division is wanted."
+    ],
+    "openQuestions": [
+      "Does the same 'clear the denominator additively' pattern give equally clean ℕ proofs for the sum of cubes of odd numbers ∑(2k+1)³ = n²(2n²−1) and higher odd-power sums?",
+      "Can the odd-square sum be derived inside Lean as the explicit difference ∑_{j<2n} j² − 4∑_{k<n} k² from Mathlib's square-pyramidal identity, rather than re-proved by induction?"
+    ]
+  }
+}

--- a/src/data/research/problems/odd-squares-sum-oq-01.json
+++ b/src/data/research/problems/odd-squares-sum-oq-01.json
@@ -1,0 +1,27 @@
+{
+  "id": "odd-squares-sum-oq-01",
+  "name": "Sum of Squares of the First n Odd Numbers: ∑(2k−1)² = n(2n−1)(2n+1)/3",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "insights": [
+      "Writing the k-th odd number as 2k+1 (k = 0,…,n−1), ∑_{k<n} (2k+1)² = n(2n−1)(2n+1)/3 = (4n³ − n)/3.",
+      "Clearing the denominator and moving the linear term left gives the subtraction-free exact ℕ identity 3·∑(2k+1)² + n = 4n³; phrased additively the inductive step has no truncated ℕ subtraction and closes by a single `ring` after one reassociation.",
+      "After substituting the hypothesis 3·∑ + m = 4m³, the inductive step is the scalar cubic identity 4m³ + 3(2m+1)² + 1 = 4(m+1)³ — independent of the sum.",
+      "The headline division form n(2n−1)(2n+1)/3 is proved directly over ℚ (where division by 3 is genuine): sum_range_succ + push_cast + ring discharges it in two lines.",
+      "The identity equals ∑_{j<2n} j² − 4∑_{k<n} k² (all squares up to 2n−1 minus the even squares), tying it to Mathlib's square-pyramidal sum-of-squares identity."
+    ],
+    "builtItems": [
+      "OddSquaresSum.three_mul_sum_odd_squares (Proofs/OddSquaresSum.lean:46) — 3·∑_{k<n}(2k+1)² + n = 4n³, the division-free exact ℕ engine",
+      "OddSquaresSum.sum_odd_squares_rat (:64) — ∑_{k<n}(2k+1)² = n(2n−1)(2n+1)/3 over ℚ, the classical closed form"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the square-pyramidal ∑k² = n(n+1)(2n+1)/6 identity but no named odd-indexed power-sum closed forms (∑(2k+1)², ∑(2k+1)³)."
+    ],
+    "nextSteps": [
+      "Apply the same 'clear the denominator additively' pattern to the sum of cubes of odd numbers ∑(2k+1)³ = n²(2n²−1) (RHS already ℕ-integral, no division needed) and higher odd-power sums.",
+      "Derive the odd-square sum inside Lean as the explicit difference ∑_{j<2n} j² − 4∑_{k<n} k² from Mathlib's square-pyramidal identity, instead of re-proving by induction."
+    ],
+    "progressSummary": "COMPLETE: ∑_{k<n}(2k+1)² = n(2n−1)(2n+1)/3 formalized and verified — 2 theorems, 0 sorries, 0 axioms, no native_decide (#print axioms = [propext, Classical.choice, Quot.sound]). Compiled against Mathlib v4.26.0. Elementary/classical power-sum identity; routine difficulty. PR opened."
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the closed form for the **sum of squares of the first `n` odd numbers**:
$$\sum_{k<n} (2k+1)^2 = 1^2 + 3^2 + \cdots + (2n-1)^2 = \frac{n(2n-1)(2n+1)}{3}.$$

This is the odd-indexed companion of the square-pyramidal identity $\sum k^2 = n(n+1)(2n+1)/6$, which Mathlib provides; this odd variant it does not.

## Theorems (`proofs/Proofs/OddSquaresSum.lean`, 74 lines)

- **`three_mul_sum_odd_squares`** — division-free exact ℕ form `3·∑(2k+1)² + n = 4n³`. Phrased additively it has **no truncated ℕ subtraction**, so the inductive step closes by a single `ring` after one reassociation that exposes the hypothesis cluster `3·∑+m`.
- **`sum_odd_squares_rat`** — the classical closed form `n(2n−1)(2n+1)/3` over ℚ, where division by 3 is genuine; the step is `sum_range_succ; push_cast; ring`.

## Verification

- Compiled against **Mathlib v4.26.0** via offline `lake env lean` (Docker daemon was down); exit 0.
- `#print axioms` for both theorems reports only `propext`, `Classical.choice`, `Quot.sound` → **0 axioms, 0 sorries**, no `native_decide`.
- Gallery data added (meta.json, annotations.json); `pnpm annotations:validate` reports no errors for this proof.

## Key technique

"Clear the denominator additively": rewriting a closed form $f(n)/c$ as the subtraction-free $c\cdot\sum + (\text{linear}) = (\text{polynomial})$ removes both division and truncated ℕ subtraction, reducing the inductive step to one `ring` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)