### PR TITLE
research(lucas-sum-oq-01): ∑ Lₖ = L_{n+2}−3 [verified, 0 sorry, 0 axiom]

### DIFF
--- a/proofs/Proofs/LucasSumOQ01.lean
+++ b/proofs/Proofs/LucasSumOQ01.lean
@@ -1,0 +1,114 @@
+import Mathlib
+
+/-
+# Partial Sums of the Lucas Numbers: `∑_{k=1}^{n} L_k = L_{n+2} − 3`
+
+## Open Question OQ-01 (gallery gap)
+
+The Lucas numbers `2, 1, 3, 4, 7, 11, 18, …` obey the same second-order recurrence as
+the Fibonacci numbers, `L_{n+2} = L_n + L_{n+1}`, with the alternative initial data
+`L_0 = 2`, `L_1 = 1`.  Their partial sums satisfy the telescoping identity
+
+  ∑_{k=1}^{n} L_k = L_{n+2} − 3 .
+
+For example `L_1 + L_2 + L_3 = 1 + 3 + 4 = 8 = L_5 − 3 = 11 − 3`.
+
+This is the Lucas analogue of the Fibonacci telescoping sum `∑_{k=1}^{n} F_k = F_{n+2} − 1`
+already in the gallery.  Mathlib provides `Nat.fib` but no packaged Lucas-number
+partial-sum lemma, so this is a clean, self-contained gallery gap.
+
+## What is proved here
+
+1. `lucas_sum_add_three` — the subtraction-free form
+        (∑_{k<n} L_{k+1}) + 3 = L_{n+2},
+   proved by induction on `n` directly from the recurrence; this is the exact statement
+   the telescoping argument produces and avoids all `ℕ`-subtraction edge cases.
+
+2. `lucas_sum` — the headline identity `∑_{k=1}^{n} L_k = L_{n+2} − 3` in `ℕ`,
+   read off from (1) (legitimate because `L_{n+2} ≥ 3`).
+
+3. `lucas_succ_eq_fib_add_fib` — the bridge `L_{n+1} = F_n + F_{n+2}` to Mathlib's
+   `Nat.fib`, validating that this self-contained `lucas` agrees with the standard
+   Fibonacci-based Lucas numbers.  (Same two-step induction used in
+   `FibonacciIdentitiesOQ03OQ03`.)
+
+The 1-indexed sum `∑_{k=1}^{n} L_k` is encoded as `∑ k ∈ Finset.range n, lucas (k+1)`,
+so the summand runs over `L_1, …, L_n`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace LucasSumOQ01
+
+open Finset
+
+/-- The Lucas numbers `2, 1, 3, 4, 7, 11, …` — the Fibonacci recurrence with the
+alternative initial data `L_0 = 2`, `L_1 = 1`. -/
+def lucas : ℕ → ℕ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => lucas n + lucas (n + 1)
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining Lucas recurrence `L_{n+2} = L_n + L_{n+1}`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-- **Telescoping partial sum (subtraction-free).**
+`(∑_{k=1}^{n} L_k) + 3 = L_{n+2}`.
+
+Proof by induction on `n`.  The base case is `0 + 3 = L_2 = 3`.  In the step,
+`Finset.sum_range_succ` peels off the new term `L_{n+1}`, and the Lucas recurrence
+`L_{n+3} = L_{n+1} + L_{n+2}` lets `omega` combine the new term with the inductive
+hypothesis. -/
+theorem lucas_sum_add_three (n : ℕ) :
+    (∑ k ∈ Finset.range n, lucas (k + 1)) + 3 = lucas (n + 2) := by
+  induction n with
+  | zero => decide
+  | succ n ih =>
+    rw [Finset.sum_range_succ]
+    -- The goal's RHS is `lucas (n + 1 + 2)`; state the recurrence in that exact index
+    -- form so `omega` shares the `lucas (·)` atoms (it will not rewrite `n+1+2 ↦ n+3`).
+    have hrec : lucas (n + 1 + 2) = lucas (n + 1) + lucas (n + 2) := lucas_add_two (n + 1)
+    omega
+
+/-- **Lucas partial-sum identity** `∑_{k=1}^{n} L_k = L_{n+2} − 3`.
+Obtained from `lucas_sum_add_three` by transposing the `+ 3`; the `ℕ`-subtraction is
+exact because `L_{n+2} ≥ 3`. -/
+theorem lucas_sum (n : ℕ) :
+    (∑ k ∈ Finset.range n, lucas (k + 1)) = lucas (n + 2) - 3 := by
+  have h := lucas_sum_add_three n
+  omega
+
+/-- **Lucas via Fibonacci.** `L_{n+1} = F_n + F_{n+2}`, equivalently `L_m = F_{m−1} + F_{m+1}`.
+Two-step induction: both sides obey `x_{n+2} = x_n + x_{n+1}` and agree at the two base
+indices, so the closed Fibonacci combination satisfies the Lucas recurrence.  This pins the
+self-contained `lucas` above to Mathlib's standard `Nat.fib`. -/
+theorem lucas_succ_eq_fib_add_fib (n : ℕ) :
+    lucas (n + 1) = Nat.fib n + Nat.fib (n + 2) := by
+  induction n using Nat.twoStepInduction with
+  | zero => decide
+  | one => decide
+  | more n h0 h1 =>
+    -- IHs at `n` and `n+1`, restated in canonical index form.
+    have h0' : lucas (n + 1) = Nat.fib n + Nat.fib (n + 2) := h0
+    have h1' : lucas (n + 2) = Nat.fib (n + 1) + Nat.fib (n + 3) := h1
+    show lucas (n + 3) = Nat.fib (n + 2) + Nat.fib (n + 4)
+    -- Lucas recurrence, then eliminate every `lucas` so only aligned `fib` atoms remain
+    -- (`omega` does not normalise `n+1+2` vs `n+3` inside an opaque `lucas (·)`).
+    have el : lucas (n + 3) = lucas (n + 1) + lucas (n + 2) := lucas_add_two (n + 1)
+    have f1 : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+    have f2 : Nat.fib (n + 4) = Nat.fib (n + 2) + Nat.fib (n + 3) := Nat.fib_add_two
+    rw [el, h0', h1']
+    omega
+
+/-- Sanity check: `L_1 + L_2 + L_3 = 1 + 3 + 4 = 8 = L_5 − 3 = 11 − 3`. -/
+example : (∑ k ∈ Finset.range 3, lucas (k + 1)) = 8 := by decide
+
+/-- Sanity check of the headline identity at `n = 4`:
+`1 + 3 + 4 + 7 = 15 = L_6 − 3 = 18 − 3`. -/
+example : (∑ k ∈ Finset.range 4, lucas (k + 1)) = lucas 6 - 3 := by decide
+
+end LucasSumOQ01

--- a/research/problems/lucas-sum-oq-01/knowledge.md
+++ b/research/problems/lucas-sum-oq-01/knowledge.md
@@ -1,0 +1,47 @@
+# Knowledge Base: lucas-sum-oq-01
+
+Partial sums of the Lucas numbers: ∑_{k=1}^{n} L_k = L_{n+2} − 3.
+
+---
+
+## Problem Understanding
+
+Lucas numbers L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1} (2, 1, 3, 4, 7, 11, 18, …).
+The partial-sum identity is the Lucas analogue of ∑ F_k = F_{n+2} − 1; the additive
+constant is 3 = L_0 + L_1 instead of 1. Mathlib has Nat.fib but no Lucas sequence and
+no packaged Lucas partial-sum lemma.
+
+---
+
+## Insights
+
+- **Subtraction-free engine.** Over ℕ, prove (∑_{k=1}^{n} L_k) + 3 = L_{n+2} first by
+  induction; the headline subtraction form follows by omega since L_{n+2} ≥ 3. Same ℕ
+  trick as factorial-telescoping-sum-oq-01.
+- **omega + opaque atoms.** omega does NOT normalize indices inside an opaque function
+  application: in the inductive step the goal's RHS is `lucas (n+1+2)`, so the recurrence
+  must be stated as `lucas (n+1+2) = lucas (n+1) + lucas (n+2)` (via `lucas_add_two (n+1)`)
+  for the atoms to unify. Stating it as `lucas (n+3) = …` leaves omega with two distinct
+  atoms and it fails. In the fib bridge, eliminate every `lucas` by `rw` so only aligned
+  `fib` atoms remain before calling omega.
+- **Bridge to Nat.fib.** L_{n+1} = F_n + F_{n+2} by Nat.twoStepInduction; keeps the entry
+  self-contained while anchoring the local Lucas definition to Mathlib (reuses the pattern
+  from FibonacciIdentitiesOQ03OQ03).
+
+---
+
+## Dead Ends
+
+- Stating the recurrence as `lucas (n+3) = …` and calling `omega` in the inductive step
+  fails: omega sees `lucas (n+1+2)` (goal) and `lucas (n+3)` (hypothesis) as distinct
+  atoms. Use the goal's exact index form.
+
+---
+
+## Outcome
+
+**SOLVED (verified, 0 sorry, 0 axiom).** `proofs/Proofs/LucasSumOQ01.lean` — 114 lines,
+6 theorems, 1 definition. `#print axioms` reports only [propext, Classical.choice,
+Quot.sound] for the sum theorems (no sorryAx, no native_decide). Gallery entry at
+`src/data/proofs/lucas-sum-oq-01/`. Compiled offline with `lake env lean` against
+Mathlib v4.26.0 (Docker unavailable this session).

--- a/research/problems/lucas-sum-oq-01/literature/README.md
+++ b/research/problems/lucas-sum-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for lucas-sum-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/lucas-sum-oq-01/problem.md
+++ b/research/problems/lucas-sum-oq-01/problem.md
@@ -1,0 +1,118 @@
+# Problem: Partial sums of Lucas numbers
+
+**Slug**: lucas-sum-oq-01
+**Created**: 2026-06-25
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\sum_{k=1}^{n} L_k = L_{n+2} - 3
+$$
+
+where $L_1 = 1,\ L_2 = 3,\ L_{k+2} = L_{k+1} + L_k$ are the Lucas numbers.
+
+### Plain Language
+
+Adding up the first n Lucas numbers (1, 3, 4, 7, 11, …) gives the Lucas number two
+places further along, minus 3. For example 1+3+4 = 8 = L₅ − 3 = 11 − 3.
+
+### Why This Matters
+
+This is the Lucas analogue of the well-known Fibonacci telescoping sum
+∑F_k = F_{n+2} − 1, which already appears in the gallery. Mathlib provides
+`Nat.fib` but no packaged Lucas-number partial-sum lemma, so this is a clean gallery
+gap that exercises a second-order linear recurrence by induction.
+
+## Known Results
+
+### What's Already Proven
+
+- ∑_{k=1}^n F_k = F_{n+2} − 1 — Fibonacci telescoping sum (gallery + Mathlib `Nat.fib` lemmas).
+- Lucas/Fibonacci relations such as L_n = F_{n−1} + F_{n+1} — standard identities.
+
+### What's Still Open
+
+- A named Lucas partial-sum lemma in Mathlib.
+- A self-contained Lucas definition (since Mathlib centers on `Nat.fib`).
+
+### Our Goal
+
+Prove ∑_{k=1}^{n} L_k = L_{n+2} − 3 in Lean 4, axiom-free, either with a
+self-contained Lucas recurrence or via the identity L_n = F_{n−1} + F_{n+1} over `Nat.fib`.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| fibonacci-identities | Direct Fibonacci analogue ∑F_k = F_{n+2}−1 | induction, recurrence |
+| lucas-cassini (combinations-formula) | Same Lucas-number objects | recurrence, induction |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Self-contained Lucas recurrence**: define `L : ℕ → ℕ` with L 0 = 2, L 1 = 1,
+   L (n+2) = L (n+1) + L n; induct using the recurrence so the telescoping is exact.
+   - Why it might work: the recurrence makes the inductive step L_{n+2} appear directly.
+   - Risk: aligning the 1-indexed sum with a 0-indexed definition; constant offset (2 vs 3).
+
+2. **Via Nat.fib using L_n = F_{n−1} + F_{n+1}**: reuse the Fibonacci sum lemma.
+   - Why it might work: leans on existing Mathlib fib machinery.
+   - Risk: index shifting and proving the L-to-F bridge first.
+
+### Key Difficulties
+
+- Index alignment between the 1-based sum and 0-based recurrence.
+- Choosing initial conditions (L₀=2, L₁=1) consistently with the offset −3.
+
+### What Would a Proof Need?
+
+- Key lemma 1: the Lucas recurrence (own definition) or L_n = F_{n−1} + F_{n+1}.
+- Key lemma 2: Finset.sum_range_succ for the inductive unfolding.
+- Technical requirements: induction, omega/ring for the arithmetic offset.
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- A standard telescoping induction over a second-order linear recurrence.
+- The Fibonacci analogue is already formalized; structure carries over.
+- Mathlib `Nat.fib` provides a fallback route if a self-contained Lucas def is preferred.
+
+**Estimated Effort**:
+- Exploration: under 1 hour
+- If tractable: a few hours
+- If hard: not expected
+
+## References
+
+### Papers
+- Folklore Lucas-number identity; no paper required.
+
+### Online Resources
+- OEIS A000032 (Lucas numbers) and partial-sum relation L_{n+2} − 3.
+
+### Mathlib
+- Mathlib.Algebra.BigOperators.Basic — Finset.sum_range_succ.
+- Mathlib.Data.Nat.Fib.Basic — `Nat.fib` (for the bridge route).
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - lucas-numbers
+  - recurrence
+  - telescoping
+related_proofs:
+  - fibonacci-identities
+  - lucas-cassini
+difficulty: low
+source: gallery-gap
+created: 2026-06-25
+```

--- a/research/problems/lucas-sum-oq-01/state.md
+++ b/research/problems/lucas-sum-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: lucas-sum-oq-01
+
+## Current State
+**Phase**: COMPLETED
+**Path**: full
+**Since**: 2026-06-25T13:18:39-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/proofs/lucas-sum-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sum-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-lucas-def",
+    "proofId": "lucas-sum-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 57
+    },
+    "type": "concept",
+    "title": "A Self-Contained Lucas Sequence",
+    "content": "Mathlib provides Nat.fib but no Lucas sequence, so lucas : ℕ → ℕ is defined locally by the Fibonacci recurrence with the alternative boundary data L_0 = 2, L_1 = 1, giving 2, 1, 3, 4, 7, 11, 18, …. The boundary values are recorded as @[simp] lemmas, and lucas_add_two : L_{n+2} = L_n + L_{n+1} holds by rfl. This single recurrence drives both the telescoping partial sum and the bridge to Nat.fib below."
+  },
+  {
+    "id": "ann-additive-engine",
+    "proofId": "lucas-sum-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 75
+    },
+    "type": "insight",
+    "title": "The Subtraction-Free Engine",
+    "content": "lucas_sum_add_three is the genuine content, stated to dodge ℕ truncated subtraction: (∑_{k=1}^{n} L_k) + 3 = L_{n+2}. The induction is short. Base: 0 + 3 = L_2 = 3. Step: Finset.sum_range_succ peels the new term L_{n+1}, and the Lucas recurrence is stated in the goal's exact index form L_{n+1+2} = L_{n+1} + L_{n+2} — omega treats lucas (·) as an opaque atom and will not rewrite n+1+2 to n+3 inside it, so the index must match for the atoms to unify. omega then combines the peeled term with the inductive hypothesis. The constant 3 = L_0 + L_1 is the Lucas boundary data, the analogue of the constant 1 in ∑ F_k = F_{n+2} − 1."
+  },
+  {
+    "id": "ann-headline",
+    "proofId": "lucas-sum-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 83
+    },
+    "type": "proof-step",
+    "title": "The Headline Subtraction Form",
+    "content": "lucas_sum is the identity as usually quoted: ∑_{k=1}^{n} L_k = L_{n+2} − 3. It is read straight off the engine: from (∑)+3 = L_{n+2} with L_{n+2} ≥ 3, omega discharges the ℕ truncated subtraction exactly. Proving the additive form first is the standard ℕ trick that keeps the subtraction honest, avoiding any case split on whether the sum exceeds the boundary."
+  },
+  {
+    "id": "ann-fib-bridge",
+    "proofId": "lucas-sum-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 106
+    },
+    "type": "insight",
+    "title": "Pinning the Definition to Nat.fib",
+    "content": "lucas_succ_eq_fib_add_fib proves the classical bridge L_{n+1} = F_n + F_{n+2} (equivalently L_m = F_{m−1} + F_{m+1}), confirming the locally defined lucas agrees with the standard Fibonacci-based Lucas numbers. The proof is a two-step induction (Nat.twoStepInduction): both base indices agree, and in the step every lucas is rewritten away via the recurrence and the two inductive hypotheses so that only fib atoms with aligned indices remain, after which Nat.fib_add_two facts let omega finish. This keeps the entry self-contained while anchoring it to Mathlib."
+  }
+]

--- a/src/data/proofs/lucas-sum-oq-01/meta.json
+++ b/src/data/proofs/lucas-sum-oq-01/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "lucas-sum-oq-01",
+  "slug": "lucas-sum-oq-01",
+  "title": "Partial Sums of the Lucas Numbers: ∑_{k=1}^{n} L_k = L_{n+2} − 3",
+  "status": "verified",
+  "badge": "original",
+  "description": "The Lucas analogue of the Fibonacci telescoping sum: ∑_{k=1}^{n} L_k = L_{n+2} − 3, where L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}. Formalized in Lean 4 from a self-contained Lucas recurrence. Because ℕ has truncated subtraction, the engine is the subtraction-free form (∑_{k=1}^{n} L_k) + 3 = L_{n+2}, proved by a short induction (Finset.sum_range_succ + the Lucas recurrence); the headline subtraction form is then read off by omega. A two-step induction proves the bridge L_{n+1} = F_n + F_{n+2} to Mathlib's Nat.fib, pinning the local definition to the standard Lucas numbers. Fully verified: 6 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "overview": {
+    "historicalContext": "The Lucas numbers 2, 1, 3, 4, 7, 11, 18, … (OEIS A000032) share the Fibonacci recurrence but start from L_0 = 2, L_1 = 1. Their partial-sum identity ∑_{k=1}^{n} L_k = L_{n+2} − 3 is the exact analogue of the classical Fibonacci telescoping sum ∑_{k=1}^{n} F_k = F_{n+2} − 1, with the additive constant 1 replaced by 3 because the two sequences carry different boundary data. Both are textbook consequences of a second-order linear recurrence and are standard exercises in any treatment of the Fibonacci–Lucas family.",
+    "problemStatement": "Prove, for every natural number n, that ∑_{k=1}^{n} L_k = L_{n+2} − 3 over ℕ (so truncated subtraction is handled honestly), with L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}. Mathlib provides Nat.fib but no packaged Lucas partial-sum lemma, so the Lucas sequence is defined locally; the file also relates that definition to Nat.fib.",
+    "proofStrategy": "Avoid ℕ truncated subtraction by proving the additive form (∑_{k=1}^{n} L_k) + 3 = L_{n+2} first, by induction on n. The base case is 0 + 3 = L_2 = 3. In the step, Finset.sum_range_succ peels the new term L_{n+1}, and the Lucas recurrence stated in the goal's index form L_{n+1+2} = L_{n+1} + L_{n+2} lets omega combine the new term with the inductive hypothesis (it does not normalize n+1+2 to n+3 inside an opaque lucas application). The headline ∑_{k=1}^{n} L_k = L_{n+2} − 3 follows by omega, valid since L_{n+2} ≥ 3. Finally a two-step induction (Nat.twoStepInduction) proves the bridge L_{n+1} = F_n + F_{n+2}: the goal is reduced to fib atoms by eliminating every lucas via rewriting, then omega closes it from Nat.fib_add_two.",
+    "keyInsights": [
+      "The telescoping is exactly the Fibonacci pattern with a different constant: ∑ L_k collapses to L_{n+2} minus the boundary term 3 = L_0 + L_1, rather than 1.",
+      "Over ℕ the clean statement uses truncated subtraction; proving the subtraction-free form (∑)+3 = L_{n+2} first makes the induction a one-liner and lets omega discharge the subtraction.",
+      "omega treats lucas (·) and fib (·) as opaque atoms and does not rewrite their arguments, so the recurrence must be stated in the goal's exact index form (here L_{n+1+2}) for the atoms to match.",
+      "The locally defined Lucas sequence agrees with the standard Fibonacci-based one: L_{n+1} = F_n + F_{n+2}, proved by two-step induction, which keeps the entry self-contained while anchoring it to Mathlib's Nat.fib."
+    ],
+    "prerequisites": [
+      "Second-order linear recurrences and the Lucas/Fibonacci initial data",
+      "Finite sums over Finset.range with Finset.sum_range_succ",
+      "ℕ truncated subtraction and the omega decision procedure over opaque atoms",
+      "Nat.fib and its recurrence Nat.fib_add_two; Nat.twoStepInduction"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lucas-def",
+      "title": "Section I: The Lucas Numbers and Their Recurrence",
+      "startLine": 45,
+      "endLine": 57,
+      "summary": "lucas: ℕ → ℕ with L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}, plus the boundary simp lemmas and the recurrence lucas_add_two.",
+      "mathContext": "A self-contained definition (Mathlib centers on Nat.fib and has no Lucas sequence); lucas_add_two : L_{n+2} = L_n + L_{n+1} is the rfl-recurrence that drives both the telescoping sum and the Fibonacci bridge."
+    },
+    {
+      "id": "additive-engine",
+      "title": "Section II: The Subtraction-Free Engine",
+      "startLine": 59,
+      "endLine": 75,
+      "summary": "lucas_sum_add_three: (∑_{k=1}^{n} L_k) + 3 = L_{n+2}, proved by induction — the genuine content, free of ℕ truncated subtraction.",
+      "mathContext": "Induction with Finset.sum_range_succ; the recurrence is stated as L_{n+1+2} = L_{n+1} + L_{n+2} to match the goal's index form, after which omega combines the peeled term L_{n+1} with the inductive hypothesis."
+    },
+    {
+      "id": "headline",
+      "title": "Section III: The Headline Subtraction Form",
+      "startLine": 77,
+      "endLine": 83,
+      "summary": "lucas_sum: ∑_{k=1}^{n} L_k = L_{n+2} − 3, the headline identity in ℕ-subtraction form, derived from the additive engine by omega.",
+      "mathContext": "From (∑)+3 = L_{n+2} and L_{n+2} ≥ 3, the truncated subtraction ∑ = L_{n+2} − 3 is exact; omega handles ℕ subtraction directly."
+    },
+    {
+      "id": "fib-bridge",
+      "title": "Section IV: The Bridge to Nat.fib",
+      "startLine": 85,
+      "endLine": 106,
+      "summary": "lucas_succ_eq_fib_add_fib: L_{n+1} = F_n + F_{n+2}, pinning the local Lucas definition to Mathlib's standard Fibonacci-based one.",
+      "mathContext": "Two-step induction (Nat.twoStepInduction): both bases agree, and in the step every lucas is rewritten away so only aligned fib atoms remain, which omega closes using Nat.fib_add_two."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 114 lines, 6 theorems and 1 definition establishing the Lucas partial-sum identity ∑_{k=1}^{n} L_k = L_{n+2} − 3. The subtraction-free additive form (∑)+3 = L_{n+2} is the inductive engine; the headline ℕ-subtraction form is derived, and the bridge L_{n+1} = F_n + F_{n+2} ties the self-contained Lucas definition to Mathlib's Nat.fib. #print axioms reports only [propext, Classical.choice, Quot.sound] for the sum theorems.",
+    "implications": "An elementary but cleanly formalized gallery entry filling a genuine Mathlib gap (no packaged Lucas partial-sum lemma). Its value is a tidy, axiom-free analogue of the Fibonacci telescoping sum together with a reusable self-contained Lucas definition and its bridge to Nat.fib; the result is routine in difficulty rather than a new mathematical contribution.",
+    "openQuestions": [
+      "Prove the alternating Lucas partial sum and the even/odd-indexed Lucas sums (e.g. ∑ L_{2k}, ∑ L_{2k-1}) by the same subtraction-free engine.",
+      "Derive a Lucas analogue of ∑ k·F_k or ∑ F_k² and relate it to the Fibonacci versions through the bridge L_{n+1} = F_n + F_{n+2}."
+    ]
+  },
+  "references": [
+    {
+      "key": "OEIS_A000032",
+      "citation": "OEIS Foundation, The On-Line Encyclopedia of Integer Sequences, sequence A000032 (Lucas numbers) and its partial-sum relation ∑_{k=1}^{n} L_k = L_{n+2} − 3.",
+      "type": "web"
+    },
+    {
+      "key": "Koshy",
+      "citation": "Koshy, T., Fibonacci and Lucas Numbers with Applications, Wiley (2001), Ch. on Lucas-number summation identities.",
+      "type": "book"
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "factorial-telescoping-sum-oq-01",
+      "relation": "Shares the ℕ subtraction-free telescoping technique (prove (∑)+c = boundary first)."
+    },
+    {
+      "proofId": "fibonacci-identities",
+      "relation": "Fibonacci analogue ∑_{k=1}^{n} F_k = F_{n+2} − 1; the bridge L_{n+1} = F_n + F_{n+2} connects the two."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "LucasSumOQ01",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/LucasSumOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://oeis.org/A000032",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasSumOQ01.lean",
+    "tags": [
+      "number-theory",
+      "lucas-numbers",
+      "fibonacci",
+      "recurrence",
+      "telescoping",
+      "induction",
+      "finite-sums",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{k ∈ range (n+1)} f k = (∑_{k ∈ range n} f k) + f n — peels the new term L_{n+1} in the induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n+2) = fib n + fib (n+1) — the Fibonacci recurrence used to close the bridge L_{n+1} = F_n + F_{n+2}",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "Two-step (second-order) induction principle matching the Lucas/Fibonacci recurrence",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "lucas_sum_add_three: the subtraction-free engine (∑_{k=1}^{n} L_k) + 3 = L_{n+2} by induction, the ℕ-clean heart of the proof",
+      "lucas_sum: the headline ∑_{k=1}^{n} L_k = L_{n+2} − 3 in ℕ-subtraction form",
+      "lucas: a self-contained Lucas-number definition (L_0=2, L_1=1) with recurrence lucas_add_two, filling the Mathlib gap",
+      "lucas_succ_eq_fib_add_fib: the bridge L_{n+1} = F_n + F_{n+2} relating the local Lucas definition to Mathlib's Nat.fib"
+    ],
+    "axiomCount": 0,
+    "lineCount": 114,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. #print axioms reports only [propext, Classical.choice, Quot.sound] for lucas_sum_add_three and lucas_sum, and [propext, Quot.sound] for lucas_succ_eq_fib_add_fib. The two `example` sanity checks (∑_{k<3} L_{k+1} = 8 and ∑_{k<4} L_{k+1} = L_6 − 3) use kernel `decide`, not `native_decide`. Compiled against Mathlib v4.26.0. The identity is elementary/classical; Mathlib has no packaged Lucas partial-sum lemma, so the Lucas sequence is defined locally and bridged to Nat.fib.",
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "prerequisites": [
+      "Second-order linear recurrences and Lucas/Fibonacci initial data",
+      "Finite sums over Finset.range with Finset.sum_range_succ",
+      "ℕ truncated subtraction and omega over opaque atoms",
+      "Nat.fib, Nat.fib_add_two, and Nat.twoStepInduction"
+    ],
+    "relatedProblems": [
+      "factorial-telescoping-sum-oq-01",
+      "fibonacci-identities"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **Lucas partial-sum identity** ∑_{k=1}^{n} L_k = L_{n+2} − 3 — the Lucas analogue of the Fibonacci telescoping sum ∑ F_k = F_{n+2} − 1 (the constant is 3 = L_0 + L_1 rather than 1). Mathlib provides `Nat.fib` but **no Lucas sequence and no packaged Lucas partial-sum lemma**, so the Lucas numbers are defined locally and bridged to `Nat.fib`.

Problem: `lucas-sum-oq-01` (gallery-gap, seeker-minted).

## What's proved (`proofs/Proofs/LucasSumOQ01.lean`)

- `lucas` — self-contained Lucas sequence `L_0=2, L_1=1, L_{n+2}=L_n+L_{n+1}` with recurrence `lucas_add_two`.
- `lucas_sum_add_three` — subtraction-free engine `(∑_{k=1}^{n} L_k) + 3 = L_{n+2}` by induction (the genuine content; dodges ℕ truncated subtraction).
- `lucas_sum` — headline `∑_{k=1}^{n} L_k = L_{n+2} − 3` in ℕ-subtraction form, read off by `omega`.
- `lucas_succ_eq_fib_add_fib` — bridge `L_{n+1} = F_n + F_{n+2}` (two-step induction) pinning the local definition to Mathlib's `Nat.fib`.

## Verification

- **6 theorems, 1 definition, 0 sorries, 0 axioms, no `native_decide`.**
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for the sum theorems (and `[propext, Quot.sound]` for the bridge).
- Compiled offline with `lake env lean` against Mathlib v4.26.0 (Docker unavailable this session).

## Note for `omega` users

In the inductive step the goal's RHS is `lucas (n+1+2)`; `omega` treats `lucas (·)` as an opaque atom and will **not** rewrite `n+1+2 ↦ n+3` inside it, so the recurrence must be stated in the goal's exact index form for the atoms to unify. Documented in `research/problems/lucas-sum-oq-01/knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)