### PR TITLE
audit(gallery): 2 fresh proofs CLEAN, queue re-drained 3931/3931

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24396,6 +24396,18 @@
       "lastAudited": "2026-06-25T20:12:42Z",
       "result": "clean",
       "issues": []
+    },
+    "chebyshev-bounds-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:19:27Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-771-construction": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:20:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the two never-audited gallery entries. **Both CLEAN.** Queue re-drained to 3931/3931 audited, 0 unaudited, 0 issues.

### chebyshev-bounds-oq-04-oq-01-oq-01-oq-01 — Weak Mertens bound |Σμ(d)/d| ≤ 1
- **209 lines, 0 sorries, 0 axioms, 7 theorems, 1 def** — all match meta.json.
- `status: verified`, `badge: original` justified (Tier A). Main theorem `mertensRecip_abs_le_one` is derived from the file's own hyperbola-method Möbius–floor identity (`sum_moebius_mul_floor`), not a thin Mathlib wrapper.
- `import Mathlib` only; assumptions field honest (foundational axioms only).

### erdos-771-construction — Erdős–Graham sum-avoiding construction (Erdős #771)
- **108 lines, 0 real sorries, 0 axioms, 4 theorems, 4 defs** — all match meta.json.
- The lone `sorry` grep hit is a **docstring** reference to the companion file `Erdos771Problem.lean`, not code.
- Honestly scoped: title, docstring, summary, and `assumptions` all explicitly disclaim the deep `(1/2 + o(1))·n/log n` asymptotics — only the elementary construction (multiples of a prime avoid any `m` not divisible by `p`) is verified. No Erdős-problem overclaim.

Not a duplicate of open PR #30181 (which covers a different set of slugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)