### PR TITLE
research(erdos-748-incomplete-01): prove f(1),f(2),f(3) via decide [axiom-free]

### DIFF
--- a/proofs/Proofs/Erdos748Aristotle.lean
+++ b/proofs/Proofs/Erdos748Aristotle.lean
@@ -29,21 +29,18 @@ open Erdos748
 
 /-- f(1) = 2: The sum-free subsets of {1} are {} and {1}.
     Strategy: decide (or native_decide) — finite computation. -/
-theorem f_1 : f 1 = 2 := by
-  sorry
+theorem f_1 : f 1 = 2 := by decide
 
 /-- f(2) = 3: The sum-free subsets of {1,2} are {}, {1}, {2}.
     (Note: {1,2} is not sum-free since 1+1=2, but {1,2} requires 1+1=2 with repeated use;
     IsSumFree allows repetition, so {2} is fine but {1,2}: 1 ∈ A ∧ 1 ∈ A ∧ 2 ∈ A ∧ 1+1=2 fails.)
     Strategy: decide (or native_decide) — finite computation. -/
-theorem f_2 : f 2 = 3 := by
-  sorry
+theorem f_2 : f 2 = 3 := by decide
 
 /-- f(3) = 6: The sum-free subsets of {1,2,3} are {}, {1}, {2}, {3}, {1,3}, {2,3}.
     ({1,3} is not sum-free: 1+3=4 ∉ {1,3}, 1+1=2 ∉ {1,3}, 3+3=6 ∉ {1,3} — wait, it IS sum-free.
      {1,2}: 1+1=2 ∈ {1,2} — not sum-free. {1,2,3}: 1+2=3 ∈ set — not sum-free.)
     Strategy: decide (or native_decide) — finite computation. -/
-theorem f_3 : f 3 = 6 := by
-  sorry
+theorem f_3 : f 3 = 6 := by decide
 
 end Erdos748Aristotle

--- a/src/data/research/problems/erdos-748-incomplete-01.json
+++ b/src/data/research/problems/erdos-748-incomplete-01.json
@@ -29,14 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Eliminated 1 of 3 axioms: trivial_lower_bound (f(n) ≥ 2^{⌊n/2⌋}) is now a proved theorem. Also repaired ~7 pre-existing breakages so the file compiles against mathlib v4.26.0. 2 deep axioms remain (Green/Sapozhenko upper bound + precise asymptotic).",
+    "progressSummary": "Eliminated 1 of 3 axioms: trivial_lower_bound (f(n) ≥ 2^{⌊n/2⌋}) is now a proved theorem. Also repaired ~7 pre-existing breakages so the file compiles against mathlib v4.26.0. 2 deep axioms remain (Green/Sapozhenko upper bound + precise asymptotic). | Session 2: discharged all 3 sorries in the Erdos748Aristotle companion (f_1,f_2,f_3) via kernel decide — axiom-free; companion now 0 code sorries.",
     "builtItems": [
       "Proved trivial_lower_bound in Erdos748Problem.lean: U.powerset ⊆ sumFreeSubsets n ⇒ f n ≥ 2^|U| ≥ 2^{⌊n/2⌋}",
-      "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)"
+      "Added decidableIsSumFree instance (sum-free predicate is decidable via bounded ∀∈A form)",
+      "f_1 : f 1 = 2 (decide, axiom-free) in Erdos748Aristotle.lean:32",
+      "f_2 : f 2 = 3 (decide, axiom-free) in Erdos748Aristotle.lean:38",
+      "f_3 : f 3 = 6 (decide, axiom-free) in Erdos748Aristotle.lean:44"
     ],
     "insights": [
       "The trivial lower bound needs no analysis: every subset of the upper half {⌊n/2⌋+1,…,n} is sum-free (upperHalf_sumFree), giving 2^{n-⌊n/2⌋} ≥ 2^{⌊n/2⌋} distinct sum-free sets",
-      "File was broken against mathlib v4.26.0: stale Asymptotics import, .1/.2 mixups in upperHalf_sumFree and sumFree_iff, missing DecidablePred IsSumFree, le_div_iff→le_div_iff₀, orphan /-- doc comments"
+      "File was broken against mathlib v4.26.0: stale Asymptotics import, .1/.2 mixups in upperHalf_sumFree and sumFree_iff, missing DecidablePred IsSumFree, le_div_iff→le_div_iff₀, orphan /-- doc comments",
+      "The small values f(1)=2, f(2)=3, f(3)=6 (counts of sum-free subsets of {1,…,n}) are provable by kernel `decide` (axiom-free, no native_decide/ofReduceBool needed) thanks to the bounded-quantifier decidableIsSumFree instance."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -55,7 +59,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.084Z",
-  "lastUpdate": "2026-04-03T08:27:10.084Z",
+  "lastUpdate": "2026-06-25T00:00:00.000Z",
   "significance": 8,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary
Research session for **erdos-748-incomplete-01** (Cameron–Erdős, `f(n)` = number of sum-free subsets of `{1,…,n}`).

Discharges all **3 remaining sorries** in `proofs/Proofs/Erdos748Aristotle.lean` — the small computable values:
- `f_1 : f 1 = 2`
- `f_2 : f 2 = 3`
- `f_3 : f 3 = 6`

each by **kernel `decide`**. This is **axiom-free** (`#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound` — crucially *no* `native_decide`, so no `Lean.ofReduceBool`), made possible by the bounded-quantifier `decidableIsSumFree` instance in the main file.

The Aristotle companion now has **0 code sorries**.

## Status
**Outcome**: progress (3 sorries eliminated, axiom-free).
The 2 deep axioms in the main file — Green's 2004 upper bound and Sapozhenko's 2003 asymptotic — remain genuinely out of scope (large formalization projects).

## Files
- `proofs/Proofs/Erdos748Aristotle.lean` (3 sorries → `decide`)
- `src/data/research/problems/erdos-748-incomplete-01.json` (knowledge updated)

🤖 Generated by researcher-1