### PR TITLE
research(erdos-1204): define A(k) and pin the trivial regime (A(2)=2)

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -184,6 +184,94 @@ theorem exists_admissible_card (k : ℕ) :
     rw [hp0, mul_zero]
     exact zero_ne_one
 
+/- ## The extremal quantity `A(k)`
+
+The headline question of Problem #1204 concerns `A(k) = min a_k`, the minimal possible
+*largest element* of an admissible `k`-set. We now make this object precise. Because
+admissible `k`-sets exist for every `k` (`exists_admissible_card`), the set of achievable
+maxima is nonempty, so its infimum (`A k`) is attained. We bracket it between the trivial
+packing bound `k - 1` and the primorial bound, and compute the first values exactly. The
+exact value `A(2) = 2 > 1 = k - 1` is the first place where admissibility is *binding*:
+the densest 2-set `{0,1}` is inadmissible, forcing the max strictly above the packing bound. -/
+
+/-- The largest element (`a.sup id`) of any `k`-element finset of `ℕ` is at least `k - 1`:
+the `k` distinct elements all lie in `{0, 1, …, a.sup id}`, which has `a.sup id + 1`
+members. -/
+theorem card_le_sup_succ (a : Finset ℕ) : a.card ≤ a.sup id + 1 := by
+  have hsub : a ⊆ Finset.range (a.sup id + 1) := by
+    intro x hx
+    rw [Finset.mem_range]
+    have : x ≤ a.sup id := Finset.le_sup (f := id) hx
+    omega
+  calc a.card ≤ (Finset.range (a.sup id + 1)).card := Finset.card_le_card hsub
+    _ = a.sup id + 1 := Finset.card_range _
+
+/-- **`A(k)`**, the minimal largest element over admissible `k`-element sets. We use
+`a.sup id` (the maximum, with the empty set giving `0`) so that `A` is total; for `k ≥ 1`
+this is exactly `min a_k`. The minimization is over a nonempty family
+(`exists_admissible_card`), so the infimum is attained (`A_mem`). -/
+noncomputable def A (k : ℕ) : ℕ :=
+  sInf { m | ∃ a : Finset ℕ, a.card = k ∧ Admissible a ∧ a.sup id = m }
+
+/-- The family of achievable maxima is nonempty (an admissible `k`-set always exists). -/
+theorem A_set_nonempty (k : ℕ) :
+    { m | ∃ a : Finset ℕ, a.card = k ∧ Admissible a ∧ a.sup id = m }.Nonempty := by
+  obtain ⟨a, hcard, ha⟩ := exists_admissible_card k
+  exact ⟨a.sup id, a, hcard, ha, rfl⟩
+
+/-- The infimum defining `A(k)` is **attained**: there is an admissible `k`-set whose
+largest element equals `A(k)`. -/
+theorem A_mem (k : ℕ) :
+    ∃ a : Finset ℕ, a.card = k ∧ Admissible a ∧ a.sup id = A k :=
+  Nat.sInf_mem (A_set_nonempty k)
+
+/-- `A(k)` is a lower bound: any admissible `k`-set has largest element at least `A(k)`. -/
+theorem A_le {k : ℕ} {a : Finset ℕ} (hcard : a.card = k) (ha : Admissible a) :
+    A k ≤ a.sup id :=
+  Nat.sInf_le ⟨a, hcard, ha, rfl⟩
+
+/-- **Trivial lower bound.** `A(k) ≥ k - 1`, since any `k` distinct naturals have maximum
+at least `k - 1`. -/
+theorem sub_one_le_A (k : ℕ) : k - 1 ≤ A k := by
+  obtain ⟨a, hcard, _, hsup⟩ := A_mem k
+  have := card_le_sup_succ a
+  rw [hcard, hsup] at this
+  omega
+
+/-- `A(0) = 0` (the only admissible `0`-set is `∅`). -/
+theorem A_zero : A 0 = 0 :=
+  Nat.le_zero.mp (by simpa using A_le (a := (∅ : Finset ℕ)) Finset.card_empty admissible_empty)
+
+/-- `A(1) = 0` (the singleton `{0}` is admissible with maximum `0`). -/
+theorem A_one : A 1 = 0 := by
+  refine Nat.le_zero.mp ?_
+  simpa using A_le (a := ({0} : Finset ℕ)) (by simp) (admissible_singleton 0)
+
+/-- **`A(2) = 2`.** The upper bound comes from the admissible set `{0, 2}`. The lower
+bound `A(2) ≥ 2` is where admissibility first bites: the only `2`-set with maximum `1` is
+`{0, 1}`, which is *not* admissible, so the minimal maximum jumps from the packing value
+`k - 1 = 1` to `2`. -/
+theorem A_two : A 2 = 2 := by
+  apply le_antisymm
+  · have h := A_le (k := 2) (a := ({0, 2} : Finset ℕ)) (by decide) admissible_zero_two
+    have hs : ({0, 2} : Finset ℕ).sup id = 2 := by decide
+    rwa [hs] at h
+  · by_contra hlt
+    push_neg at hlt
+    have hlb := sub_one_le_A 2
+    have hA1 : A 2 = 1 := by omega
+    obtain ⟨a, hcard, ha, hsup⟩ := A_mem 2
+    have hsub : a ⊆ ({0, 1} : Finset ℕ) := by
+      intro x hx
+      have hle : x ≤ a.sup id := Finset.le_sup (f := id) hx
+      rw [hsup, hA1] at hle
+      simp only [Finset.mem_insert, Finset.mem_singleton]
+      omega
+    have heq : a = ({0, 1} : Finset ℕ) :=
+      Finset.eq_of_subset_of_card_le hsub (by rw [hcard]; decide)
+    rw [heq] at ha
+    exact not_admissible_zero_one ha
+
 /- ## Open Problems
 
 The asymptotic behaviour of the extremal quantities is OPEN:

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -57,3 +57,24 @@ A(k)∼k log k and B(k) estimate remain OPEN (need sieve theory).
 
 Gotcha: `(N:ZMod p)=0` from `p∣N` via `CharP.cast_eq_zero_iff (ZMod p) p N` (no NeZero needed,
 unlike `ZMod.natCast_zmod_eq_zero_iff_dvd`); `push_cast` then `rw [hp0, mul_zero]; exact zero_ne_one`.
+
+## Session 2026-06-25 (researcher-8) — defined A(k) + trivial regime exact values
+
+Added 8 verified theorems + 1 def (now 18 thm / 2 def, 0 axioms, 0 sorries):
+- `A (k : ℕ) : ℕ := sInf {a.sup id | a admissible, a.card = k}` — **the central object A(k)
+  is now actually defined in Lean** (previously only `Admissible` + existence existed). This
+  makes the headline question "A(k) ∼ k log k?" expressible. Uses `a.sup id` (max, ∅↦0) for totality.
+- `A_set_nonempty`, `A_mem` — the family is nonempty (via `exists_admissible_card`), so the
+  infimum is **attained**: ∃ admissible k-set with max exactly A(k).
+- `A_le` — A(k) is a genuine lower bound on the max of any admissible k-set (`Nat.sInf_le`).
+- `card_le_sup_succ` (a.card ≤ a.sup id + 1) ⇒ `sub_one_le_A`: **A(k) ≥ k-1** (packing bound).
+- `A_zero = 0`, `A_one = 0`, `A_two = 2` exact. **A(2)=2 > 1=k-1** is the first place
+  admissibility is *binding*: the densest 2-set {0,1} is inadmissible, forcing the max above
+  the packing bound. (Lower bound: a 2-set with max 1 must be {0,1} = not admissible.)
+
+Still OPEN: the asymptotics A(k)∼k log k and B(k) (need sieve theory). The new content brackets
+A(k) between k-1 and (k-1)·primorial and nails the trivial small-k regime.
+
+Gotchas: `A_le` k is implicit — `(by decide)` for `card {0,2} = k` fails with "Expected type must
+not contain metavariables"; pass `(k := 2)` explicitly. `a.sup id ≥ k-1` via `a ⊆ range (sup+1)`
++ `Finset.le_sup (f := id)`. `Nat.sInf_mem`/`Nat.sInf_le` give attainment + lower bound directly.

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -52,13 +52,17 @@
       "missing_class_of_card_lt: a set of size < p always misses a class mod p (image into ZMod p cannot be surjective)",
       "admissible_iff_card: KEY REDUCTION — admissibility ⟺ missing a class modulo every prime p ≤ |a|; all larger primes are automatic",
       "Worked examples: ∅, {0}, and {0,2} are admissible; {0,1} is NOT (it covers both classes mod 2)",
-      "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)"
+      "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)",
+      "A(k) defined in Lean for the first time: A k = sInf of the largest elements (a.sup id) over admissible k-sets — makes the headline question A(k)∼k log k expressible",
+      "A_mem / A_le: the infimum defining A(k) is attained (nonempty family via exists_admissible_card) and is a genuine lower bound",
+      "card_le_sup_succ + sub_one_le_A: trivial packing lower bound A(k) ≥ k-1",
+      "A_zero=0, A_one=0, and A_two=2 computed exactly; A(2)=2 > 1=k-1 is the first place admissibility is binding ({0,1} inadmissible forces the max above the packing bound)"
     ],
     "axiomCount": 0,
-    "lineCount": 201,
-    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved (#print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool). Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. The formalization here is the admissibility framework plus the standard reduction to small primes.",
-    "theoremCount": 10,
-    "definitionCount": 1
+    "lineCount": 289,
+    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), two-sided bounds k-1 ≤ A(k) ≤ (k-1)·primorial, and the exact values A(0)=A(1)=0, A(2)=2.",
+    "theoremCount": 18,
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1204**\n\nThe notion of an *admissible* sequence (or k-tuple) is central to the Hardy–Littlewood prime k-tuples conjecture and to modern work on bounded gaps between primes (Zhang 2013, Maynard 2015, Polymath8). A k-tuple is admissible precisely when it does not occupy every residue class modulo some prime — the only local obstruction to all shifts being simultaneously prime infinitely often.\n\nErdős asks for the size of the minimal *diameter* A(k) of an admissible k-tuple, conjecturally A(k) ∼ k log k, and for the minimal average B(k).",
@@ -69,7 +73,8 @@
       "**Local obstructions only:** admissibility is a purely local (mod-p) condition; a tuple fails iff some prime sees every residue.",
       "**Only small primes matter:** for p > k there are more classes than elements, so a class is always free — admissibility reduces to primes p ≤ k.",
       "**Minimal example:** {0,2} is admissible but {0,1} is not, because {0,1} hits both classes mod 2 (this is why twin-prime-like patterns must avoid such coverage).",
-      "**Connection:** this is exactly the admissible-tuple notion underlying bounded gaps between primes (Zhang, Maynard)."
+      "**Connection:** this is exactly the admissible-tuple notion underlying bounded gaps between primes (Zhang, Maynard).",
+      "**A(k) is now defined and pinned in the trivial regime:** k-1 ≤ A(k), with A(0)=A(1)=0 and A(2)=2 — the value A(2)=2>1 shows admissibility first becomes binding at k=2."
     ],
     "prerequisites": [
       "Number theory",
@@ -124,10 +129,10 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 201,
+    "lineCount": 289,
     "axiomCount": 0,
-    "theoremCount": 10,
-    "definitionCount": 1,
+    "theoremCount": 18,
+    "definitionCount": 2,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT/BUILD (session 2): added 4 verified structural theorems to Erdos1204Problem.lean — Admissible.subset (downward closure), admissible_image_add (translation invariance) + card_image_add, and exists_admissible_card (an admissible k-set exists for every k via primorial multiples 0,N,2N,...,(k-1)N ⇒ A(k) well-defined, with explicit weak bound A(k) ≤ (k-1)·∏_{p≤k}p). Now 10 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) remain OPEN.",
+    "progressSummary": "PROGRESS: A(k) now defined in Lean and pinned in the trivial regime (A(0)=A(1)=0, A(2)=2; bounds k-1 ≤ A(k) ≤ (k-1)·primorial). Headline asymptotics A(k)∼k log k and B(k) remain OPEN (sieve theory).",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -38,14 +38,16 @@
       "Admissible.subset (downward closure) in Erdos1204Problem.lean:130",
       "admissible_image_add (translation invariance) in Erdos1204Problem.lean:140",
       "card_image_add (translation preserves card) in Erdos1204Problem.lean:152",
-      "exists_admissible_card (∃ admissible k-set ⇒ A(k) well-defined) in Erdos1204Problem.lean:165"
+      "exists_admissible_card (∃ admissible k-set ⇒ A(k) well-defined) in Erdos1204Problem.lean:165",
+      "Erdos1204Problem.lean: def A + A_mem/A_le/sub_one_le_A/A_zero/A_one/A_two/card_le_sup_succ/A_set_nonempty (8 thm + 1 def)"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
       "Reduction: for primes p > k, k elements cannot cover all p classes, so admissibility only constrains primes p ≤ k.",
       "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2.",
       "Admissibility is downward-closed and translation-invariant: it is a property of the *pattern* of a tuple, not its position.",
-      "An admissible k-tuple exists for every k: take multiples 0,N,2N,...,(k-1)N of the primorial N=∏_{p≤k}p; mod each prime p≤k all are ≡0 so class 1 is missed, larger primes auto by size bound. This makes A(k) well-defined and gives the explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p."
+      "An admissible k-tuple exists for every k: take multiples 0,N,2N,...,(k-1)N of the primorial N=∏_{p≤k}p; mod each prime p≤k all are ≡0 so class 1 is missed, larger primes auto by size bound. This makes A(k) well-defined and gives the explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p.",
+      "A(k) defined as sInf of max over admissible k-sets; infimum attained (nonempty family); k-1 ≤ A(k) ≤ (k-1)·primorial; A(0)=A(1)=0, A(2)=2 (admissibility first binding at k=2)."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for **Erdős Problem #1204** (admissible sequences). The headline question asks for the asymptotics of A(k) = min a_k over admissible k-tuples (is A(k) ∼ k log k?). Until now the Lean file had the `Admissible` predicate, the small-prime reduction, and existence of admissible k-sets — but **A(k) itself was never defined**. This session defines it and pins down the trivial regime.

## Progress (8 new theorems + 1 def; 18 thm / 2 def total, 0 axioms, 0 sorries)
- `A k := sInf {a.sup id | a admissible, a.card = k}` — the central extremal quantity, **defined in Lean for the first time**, making the headline question A(k)∼k log k expressible.
- `A_set_nonempty`, `A_mem` — the minimization family is nonempty (`exists_admissible_card`), so the infimum is **attained**: there is an admissible k-set whose max equals A(k).
- `A_le` — A(k) is a genuine lower bound on the largest element of any admissible k-set (`Nat.sInf_le`).
- `card_le_sup_succ` ⇒ `sub_one_le_A` — packing lower bound **A(k) ≥ k−1**.
- `A_zero = 0`, `A_one = 0`, `A_two = 2` — exact small values. **A(2) = 2 > 1 = k−1** is the first place admissibility is *binding*: the densest 2-set `{0,1}` is inadmissible, forcing the max strictly above the packing bound.

## Files modified
- `proofs/Proofs/Erdos1204Problem.lean` (201 → 289 lines)
- `src/data/proofs/erdos-1204/meta.json` (counts, contributions, assumptions)
- `research/problems/erdos-1204/knowledge.md`, `src/data/research/problems/erdos-1204.json`

## Verification
- Offline `lake env lean` type-check clean (Docker was down).
- `#print axioms A_two` / `exists_admissible_card` → `[propext, Classical.choice, Quot.sound]` only — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`. Genuinely 0-axiom.

## Status
**Outcome**: progress (formalization advance) — A(k) now defined and bracketed `k−1 ≤ A(k) ≤ (k−1)·primorial`, trivial regime nailed.
**Open**: A(k) ∼ k log k and the estimate for B(k) remain OPEN (need sieve theory). Status stays `axiomatized` per policy.
**Next steps**: B(k) could be defined analogously; the k−1 lower bound could be sharpened for larger k.

🤖 Generated by researcher-8