### PR TITLE
Enrich Erdős #771 construction: add missing annotations.json (5 annotations)

### DIFF
--- a/src/data/proofs/erdos-771-construction/annotations.json
+++ b/src/data/proofs/erdos-771-construction/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "erdos-771-construction",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "context",
+    "title": "Erdős #771 and the Scope of This File",
+    "content": "Erdős #771 asks for f(n), the largest k such that for every target m ≥ 1 there exists an m-avoiding set S ⊆ {1,…,n} with |S| = k (no nonempty subset of S sums to m). The full answer f(n) = (1/2 + o(1))·n/log n is known and deep: the Erdős–Graham lower bound and the matching Alon–Freiman upper bound (an LCM argument). This file deliberately does NOT touch the asymptotics. It isolates and fully verifies (0 axioms, 0 sorries) the elementary *construction* underlying the lower bound: take S = the multiples of a prime p in {1,…,n}; every subset sum of S is a multiple of p, so if p ∤ m then m cannot be a subset sum and S avoids m. The four verified results are the construction's size (⌊n/p⌋), its avoidance property, the existence of a suitable prime for every m, and the combined existence of an m-avoiding set. The companion Erdos771Problem.lean left these as sorries and no longer compiles under Mathlib 4.26.0 (stale import path, DecidablePred gaps, dangling doc-comments).",
+    "mathContext": "$f(n) = (\\tfrac12 + o(1))\\,n/\\log n$; this file verifies the construction $S = \\{k \\le n : p \\mid k\\}$ with $p \\nmid m$, the engine of the Erdős–Graham *lower* bound only.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problem 771", "subset-sum-avoiding sets", "Erdős–Graham lower bound", "Alon–Freiman upper bound", "additive combinatorics"],
+    "prerequisites": ["subset sums of a finite set of integers", "divisibility", "the statement of the asymptotic f(n) (background)"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-771-construction",
+    "range": { "startLine": 37, "endLine": 52 },
+    "type": "definition",
+    "title": "Self-Contained Definitions (Icc_n, subsetSums, AvoidSum, primeMultiples)",
+    "content": "Four definitions set up the problem without depending on the broken companion file. Icc_n n = Finset.Icc 1 n is the ground set {1,…,n}. subsetSums S = (S.powerset.image (∑ a ∈ A, a)).filter (· > 0) is the set of *positive* subset sums of S — the powerset is imaged under summation and the zero sum (from the empty set) is filtered out, matching the 'no nonempty subset sums to m' formulation. AvoidSum S m := m ∉ subsetSums S says S avoids m. primeMultiples p n = (Icc_n n).filter (p ∣ ·) is the construction itself: the multiples of p inside {1,…,n}. Keeping subsetSums noncomputable and filtering on > 0 are the two design choices that make the avoidance statement clean.",
+    "mathContext": "$\\mathrm{subsetSums}(S) = \\{\\sum_{a \\in A} a : A \\subseteq S\\} \\cap \\mathbb{Z}_{>0}$; $\\mathrm{primeMultiples}(p,n) = \\{k \\in \\{1,\\dots,n\\} : p \\mid k\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.powerset", "Finset.image and Finset.filter", "positive subset sums", "the construction set", "noncomputable definitions"],
+    "prerequisites": ["Finset operations (Icc, powerset, image, filter)", "summation over a Finset", "divisibility filter"]
+  },
+  {
+    "id": "ann-size",
+    "proofId": "erdos-771-construction",
+    "range": { "startLine": 54, "endLine": 63 },
+    "type": "theorem",
+    "title": "Size of the Construction (prime_multiples_size)",
+    "content": "prime_multiples_size proves (primeMultiples p n).card = n / p — the multiples of p in {1,…,n} number exactly ⌊n/p⌋ (Nat division). The proof first rewrites the ground set: Icc_n n = Finset.Ioc 0 n (the half-open interval (0, n], proved by ext + omega), which matches the form of the counting lemma. It then unfolds primeMultiples and applies Nat.Ioc_filter_dvd_card_eq_div n p, Mathlib's exact count of the multiples of p in (0, n]. This is the cardinality that, summed with the (1/2+o(1)) density of suitable primes, drives the n/log n leading order of the lower bound — but here only the exact finite count is claimed.",
+    "mathContext": "$|\\{k \\le n : p \\mid k\\}| = \\lfloor n/p \\rfloor$, via $\\{1,\\dots,n\\} = (0, n]$ and `Nat.Ioc_filter_dvd_card_eq_div`.",
+    "significance": "key",
+    "relatedConcepts": ["counting multiples in an interval", "Nat.Ioc_filter_dvd_card_eq_div", "floor division ⌊n/p⌋", "Finset.Icc vs Finset.Ioc"],
+    "prerequisites": ["Nat division / floor", "rewriting Icc as Ioc", "the omega tactic"]
+  },
+  {
+    "id": "ann-avoidance",
+    "proofId": "erdos-771-construction",
+    "range": { "startLine": 65, "endLine": 81 },
+    "type": "theorem",
+    "title": "The Avoidance Property — the Engine (prime_multiples_avoid)",
+    "content": "prime_multiples_avoid is the heart of the construction: if p ∤ m then primeMultiples p n avoids m. The proof is a clean contradiction. Suppose m ∈ subsetSums (primeMultiples p n); unfolding gives a subset A ⊆ primeMultiples p n with ∑ a ∈ A, a = m. Every element a ∈ A is a multiple of p (it passed the p ∣ · filter), so by Finset.dvd_sum the whole sum is divisible by p — i.e. p ∣ m after rewriting with hAsum. That contradicts the hypothesis p ∤ m. Notice the primality hypothesis _hp is never actually used (underscored): avoidance holds for the multiples of *any* p with p ∤ m. Primality is retained only to align with the construction and to guarantee, via the next lemma, that a suitable p exists densely enough for the asymptotic count.",
+    "mathContext": "$p \\nmid m \\Rightarrow m \\notin \\mathrm{subsetSums}(S)$: every subset sum is $\\equiv 0 \\pmod p$ (Finset.dvd_sum), but $m \\not\\equiv 0$.",
+    "significance": "key",
+    "relatedConcepts": ["divisibility of a sum (Finset.dvd_sum)", "subset-sum avoidance", "proof by contradiction", "unused primality hypothesis"],
+    "prerequisites": ["Finset.dvd_sum and membership in powerset/image/filter", "the AvoidSum / subsetSums definitions", "basic modular reasoning"]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "erdos-771-construction",
+    "range": { "startLine": 83, "endLine": 98 },
+    "type": "theorem",
+    "title": "The Construction Always Applies (exists_prime_not_dvd, exists_avoiding_multiples)",
+    "content": "Two lemmas close the existence half. exists_prime_not_dvd shows that for every m ≥ 1 there is a prime p ∤ m: take any prime p > m (Nat.exists_infinite_primes (m+1)); if p ∣ m then Nat.le_of_dvd would force p ≤ m, contradicting p > m (closed by omega). exists_avoiding_multiples then assembles the full statement: for every m ≥ 1 there is a prime p such that primeMultiples p n ⊆ Icc_n n (immediate, Finset.filter_subset) and AvoidSum (primeMultiples p n) m (from prime_multiples_avoid). This is the existence statement the lower bound rests on — an m-avoiding subset of {1,…,n} always exists — even though the *optimal* size driving the (1/2)·n/log n constant (smallest suitable prime) is left external.",
+    "mathContext": "$\\forall m \\ge 1,\\ \\exists p\\ \\text{prime},\\ p \\nmid m$ (take $p > m$); hence an $m$-avoiding $S = \\mathrm{primeMultiples}(p,n) \\subseteq \\{1,\\dots,n\\}$ exists.",
+    "significance": "supporting",
+    "relatedConcepts": ["infinitude of primes (Nat.exists_infinite_primes)", "Nat.le_of_dvd", "Finset.filter_subset", "existence of an avoiding set"],
+    "prerequisites": ["there are arbitrarily large primes", "a divisor of a positive number is ≤ it", "the omega tactic", "the avoidance lemma"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-771-construction` (quality 41, passes 0).

## Gap
Complete `meta.json` (structured conclusion, 4 keyInsights, 4 sections, references) but **no `annotations.json`** — proof page had no inline annotations.

## Change
Authored `annotations.json` with **5 annotations covering the full 108-line Lean file**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. **overview** (1–29) — Erdős #771, the known `f(n) = (½+o(1))n/log n` asymptotics, and this file's scope (the elementary lower-bound construction only).
2. **definitions** (37–52) — `Icc_n`, `subsetSums` (positive subset sums), `AvoidSum`, `primeMultiples`.
3. **prime_multiples_size** (54–63) — `|S| = ⌊n/p⌋` via `Nat.Ioc_filter_dvd_card_eq_div`.
4. **prime_multiples_avoid** (65–81) — the avoidance engine (`Finset.dvd_sum`); notes that the primality hypothesis is underscored/unused — avoidance holds for the multiples of any `p ∤ m`.
5. **existence** (83–98) — a prime `> m` cannot divide `m`, so an `m`-avoiding set always exists.

## Notes
- Pure data addition; no TypeScript touched. `annotations:build` exits clean with **no warnings for this proof**.
- `status: verified` / `axiomCount: 0` / 0 sorries confirmed against the Lean source; annotations are explicit that only the construction (not the `(½+o(1))n/log n` asymptotics) is verified.
- On a dedicated branch to keep it independent of sibling enrichment PRs.