### PR TITLE
research(isosceles-triangle-oq-02-oq-01): Converse Pons Asinorum in spherical & hyperbolic geometry [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3367,6 +3367,7 @@ import Proofs.IsoperimetricTheoremOQ02OQ03OQ01
 import Proofs.IsoscelesTriangle
 import Proofs.IsoscelesTriangleOQ01
 import Proofs.IsoscelesTriangleOQ02
+import Proofs.IsoscelesTriangleOQ02OQ01
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
 import Proofs.JacobiSymbolOQ0101

--- a/proofs/Proofs/IsoscelesTriangleOQ02OQ01.lean
+++ b/proofs/Proofs/IsoscelesTriangleOQ02OQ01.lean
@@ -1,0 +1,107 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+import Mathlib.Tactic
+
+/-!
+# Isosceles triangle OQ-02-OQ-01: Converse Pons Asinorum in hyperbolic and spherical geometry
+
+The parent entry (`isosceles-triangle-oq-02`) proves **Pons Asinorum** (Euclid I.5,
+"equal sides ⟹ equal base angles") in spherical and hyperbolic geometry, working purely
+from the *laws of cosines* with no inner product space. It lists as its first open question:
+
+> *Prove the converse (equal base angles ⟹ equal opposite sides) in spherical and
+> hyperbolic geometry, using the dual law of cosines that expresses sides in terms of angles.*
+
+This file does so. The engine is the **dual (polar) law of cosines**, which expresses a
+side in terms of the three angles:
+
+* spherical:   `cos a = (cos A + cos B · cos C) / (sin B · sin C)`,
+* hyperbolic:  `cosh a = (cos A + cos B · cos C) / (sin B · sin C)`,
+
+where `A` is the angle opposite side `a` and `B, C` are the other two angles. The right-hand
+side is the *same symmetric expression* in both geometries — only the left-hand side changes
+(`cos a` spherically, `cosh a` hyperbolically). When two angles are equal (`A = B`) the
+two opposite-side expressions coincide, so `cos a = cos b` (resp. `cosh a = cosh b`); since
+`cos` is injective on `[0, π]` (spherical sides) and `cosh` is injective on `[0, ∞)`
+(hyperbolic sides), the opposite sides are equal.
+
+This is the exact dual of the parent's argument: there, equal sides forced equal
+angle-cosines via the law of cosines; here, equal angles force equal side-(co)sines via the
+dual law of cosines.
+
+## Main results
+
+* `sphCosSide` / `hypCoshSide` : the dual-law expression for `cos a` / `cosh a` from the angles.
+* `sph_converse_eq` / `hyp_converse_eq` : equal angles `A = B` give equal side expressions.
+* `spherical_isosceles_converse` / `hyperbolic_isosceles_converse` : **Converse Pons
+  Asinorum** in each geometry (equal base angles ⟹ equal opposite sides).
+* `spherical_equiangular` / `hyperbolic_equiangular` : equiangular ⟹ equilateral.
+
+No inner product space and no axioms are used.
+-/
+
+namespace IsoscelesTriangleOQ02OQ01
+
+open Real Set
+
+/-- `cos` of the side `a` opposite angle `A` in a **spherical** triangle with angles
+    `A, B, C`, obtained from the dual (polar) law of cosines
+    `cos a = (cos A + cos B · cos C) / (sin B · sin C)`. -/
+noncomputable def sphCosSide (A B C : ℝ) : ℝ := (cos A + cos B * cos C) / (sin B * sin C)
+
+/-- `cosh` of the side `a` opposite angle `A` in a **hyperbolic** triangle with angles
+    `A, B, C`, obtained from the dual (polar) law of cosines
+    `cosh a = (cos A + cos B · cos C) / (sin B · sin C)`. The right-hand side is identical to
+    the spherical case; only the left-hand side (`cosh a` vs `cos a`) differs. -/
+noncomputable def hypCoshSide (A B C : ℝ) : ℝ := (cos A + cos B * cos C) / (sin B * sin C)
+
+/-- **Algebraic core (spherical).** Equal angles `A = B` force the two opposite-side cosines
+    to coincide: `cos a = cos b`. -/
+theorem sph_converse_eq {A B C : ℝ} (h : A = B) : sphCosSide A B C = sphCosSide B A C := by
+  subst h; rfl
+
+/-- **Algebraic core (hyperbolic).** Equal angles `A = B` force `cosh a = cosh b`. -/
+theorem hyp_converse_eq {A B C : ℝ} (h : A = B) : hypCoshSide A B C = hypCoshSide B A C := by
+  subst h; rfl
+
+/-- **Converse Pons Asinorum, spherical geometry.** In a spherical triangle whose angles
+    `A, B, C` and sides `a, b ∈ [0, π]` satisfy the dual law of cosines, equal base angles
+    `A = B` imply equal opposite sides `a = b`. No inner product space is used. -/
+theorem spherical_isosceles_converse {a b A B C : ℝ} (ha : a ∈ Icc 0 π) (hb : b ∈ Icc 0 π)
+    (lawa : cos a = sphCosSide A B C) (lawb : cos b = sphCosSide B A C) (h : A = B) : a = b := by
+  apply Real.injOn_cos ha hb
+  rw [lawa, lawb, sph_converse_eq h]
+
+/-- **Converse Pons Asinorum, hyperbolic geometry.** Same statement with the hyperbolic dual
+    law of cosines and sides `a, b ≥ 0`: equal base angles imply equal opposite sides, with
+    no inner product space. Injectivity of `cosh` on `[0, ∞)` replaces injectivity of `cos`
+    on `[0, π]`. -/
+theorem hyperbolic_isosceles_converse {a b A B C : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (lawa : cosh a = hypCoshSide A B C) (lawb : cosh b = hypCoshSide B A C) (h : A = B) :
+    a = b := by
+  apply StrictMonoOn.injOn Real.cosh_strictMonoOn (mem_Ici.mpr ha) (mem_Ici.mpr hb)
+  rw [lawa, lawb, hyp_converse_eq h]
+
+/-- **Equiangular ⟹ equilateral, spherical geometry.** A spherical triangle with all angles
+    equal has all sides equal. -/
+theorem spherical_equiangular {a b c A : ℝ}
+    (ha : a ∈ Icc 0 π) (hb : b ∈ Icc 0 π) (hc : c ∈ Icc 0 π)
+    (lawa : cos a = sphCosSide A A A) (lawb : cos b = sphCosSide A A A)
+    (lawc : cos c = sphCosSide A A A) : a = b ∧ b = c := by
+  refine ⟨Real.injOn_cos ha hb ?_, Real.injOn_cos hb hc ?_⟩
+  · rw [lawa, lawb]
+  · rw [lawb, lawc]
+
+/-- **Equiangular ⟹ equilateral, hyperbolic geometry.** -/
+theorem hyperbolic_equiangular {a b c A : ℝ}
+    (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c)
+    (lawa : cosh a = hypCoshSide A A A) (lawb : cosh b = hypCoshSide A A A)
+    (lawc : cosh c = hypCoshSide A A A) : a = b ∧ b = c := by
+  refine ⟨StrictMonoOn.injOn Real.cosh_strictMonoOn (mem_Ici.mpr ha) (mem_Ici.mpr hb) ?_,
+    StrictMonoOn.injOn Real.cosh_strictMonoOn (mem_Ici.mpr hb) (mem_Ici.mpr hc) ?_⟩
+  · rw [lawa, lawb]
+  · rw [lawb, lawc]
+
+end IsoscelesTriangleOQ02OQ01

--- a/src/data/proofs/isosceles-triangle-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/isosceles-triangle-oq-02-oq-01/annotations.json
@@ -1,0 +1,105 @@
+[
+  {
+    "id": "iso-oq0201-concept",
+    "proofId": "isosceles-triangle-oq-02-oq-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Converse Pons Asinorum via the Dual Law of Cosines",
+    "content": "This file proves **Euclid I.6** (the converse of Pons Asinorum: *equal base angles ⟹ equal opposite sides*) in spherical and hyperbolic geometry. The tool is the **dual (polar) law of cosines**, which expresses a side from the three angles:\n$$\\cos a = \\frac{\\cos A + \\cos B\\cos C}{\\sin B\\sin C}\\ (\\text{spherical}),\\qquad \\cosh a = \\frac{\\cos A + \\cos B\\cos C}{\\sin B\\sin C}\\ (\\text{hyperbolic}).$$\nThe right-hand side is the *same symmetric expression* in both geometries — only the left side changes. When $A=B$ the two opposite-side expressions coincide, so $\\cos a=\\cos b$ (resp. $\\cosh a=\\cosh b$), and injectivity of $\\cos$ on $[0,\\pi]$ / $\\cosh$ on $[0,\\infty)$ gives $a=b$.",
+    "mathContext": "The exact dual of the parent (isosceles-triangle-oq-02): there, equal sides forced equal angle-cosines; here, equal angles force equal side-(co)sines. No inner product space, 0 axioms.",
+    "significance": "key",
+    "prerequisites": [
+      "spherical and hyperbolic laws of cosines (and their dual forms)",
+      "injectivity of cos on [0,π] and cosh on [0,∞)"
+    ],
+    "relatedConcepts": [
+      "Pons Asinorum",
+      "non-Euclidean geometry",
+      "law of cosines",
+      "side-angle duality"
+    ]
+  },
+  {
+    "id": "iso-oq0201-defs",
+    "proofId": "isosceles-triangle-oq-02-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 58
+    },
+    "type": "definition",
+    "title": "Dual-Law Side Expressions sphCosSide / hypCoshSide",
+    "content": "`sphCosSide A B C` and `hypCoshSide A B C` both equal $(\\cos A + \\cos B\\cos C)/(\\sin B\\sin C)$ — the dual-law value of $\\cos a$ (spherical) and $\\cosh a$ (hyperbolic), where $A$ is the angle opposite side $a$. The shared body makes the geometric duality explicit: the *same* algebra governs both geometries; only the interpretation of the left-hand side differs.",
+    "mathContext": "The dual law of cosines determines an actual side length from the three angles — an AAA phenomenon with no Euclidean analogue.",
+    "significance": "important",
+    "prerequisites": [
+      "dual (polar) law of cosines"
+    ],
+    "relatedConcepts": [
+      "polar triangle",
+      "AAA congruence"
+    ]
+  },
+  {
+    "id": "iso-oq0201-cores",
+    "proofId": "isosceles-triangle-oq-02-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 66
+    },
+    "type": "technique",
+    "title": "Algebraic Core: Symmetry Under Swapping A and B",
+    "content": "`sph_converse_eq` / `hyp_converse_eq` prove that $A=B$ forces `sphCosSide A B C = sphCosSide B A C` (resp. `hypCoshSide`). Each is a one-line `subst h; rfl`: after substituting $A=B$ both sides become syntactically identical, because the dual-law expression is invariant under swapping its first two angle arguments.",
+    "mathContext": "Equal angles ⟹ equal cos a / cosh a — the entire mathematical content of the converse, reduced to a symmetry.",
+    "significance": "important",
+    "prerequisites": [
+      "definitional unfolding (subst, rfl)"
+    ],
+    "relatedConcepts": [
+      "symmetry argument"
+    ]
+  },
+  {
+    "id": "iso-oq0201-converse",
+    "proofId": "isosceles-triangle-oq-02-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 84
+    },
+    "type": "technique",
+    "title": "Recovering the Side by Injectivity",
+    "content": "`spherical_isosceles_converse` rewrites the dual-law hypotheses to $\\cos a=\\cos b$ and applies `Real.injOn_cos` (injectivity of cos on $[0,\\pi]$, the range of spherical sides) to conclude $a=b$. `hyperbolic_isosceles_converse` is identical but lands on $\\cosh a=\\cosh b$ and uses `StrictMonoOn.injOn Real.cosh_strictMonoOn` (cosh is strictly monotone, hence injective, on $[0,\\infty)$, the range of hyperbolic sides). The membership wrappers `mem_Ici.mpr` convert $0\\le a$ into $a\\in\\mathrm{Ici}\\,0$.",
+    "mathContext": "Once the algebra gives equal (co)sines, injectivity on the natural side-length range delivers equal sides — the only analytic input.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.injOn_cos",
+      "Real.cosh_strictMonoOn, StrictMonoOn.injOn"
+    ],
+    "relatedConcepts": [
+      "injectivity on an interval",
+      "strict monotonicity"
+    ]
+  },
+  {
+    "id": "iso-oq0201-corollaries",
+    "proofId": "isosceles-triangle-oq-02-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "Equiangular ⟹ Equilateral",
+    "content": "`spherical_equiangular` / `hyperbolic_equiangular` specialize all three angles to a common value $A$. Then the three side-expressions are literally equal, so the same injectivity lemmas yield $a=b$ and $b=c$: an equiangular spherical or hyperbolic triangle is equilateral. These are the converse-direction duals of the parent's equilateral ⟹ equiangular corollaries.",
+    "mathContext": "Completes the isosceles ⟺ equal-angle equivalence in non-Euclidean geometry.",
+    "significance": "supporting",
+    "prerequisites": [
+      "the converse theorems above"
+    ],
+    "relatedConcepts": [
+      "equilateral triangle",
+      "equiangular triangle"
+    ]
+  }
+]

--- a/src/data/proofs/isosceles-triangle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/isosceles-triangle-oq-02-oq-01/meta.json
@@ -1,0 +1,210 @@
+{
+  "id": "isosceles-triangle-oq-02-oq-01",
+  "title": "Converse Pons Asinorum in Hyperbolic and Spherical Geometry",
+  "slug": "isosceles-triangle-oq-02-oq-01",
+  "description": "The parent (isosceles-triangle-oq-02) proves Pons Asinorum (equal sides ⟹ equal base angles) in spherical and hyperbolic geometry from the laws of cosines, with no inner product space. This entry answers its OQ-01: the converse (equal base angles ⟹ equal opposite sides), via the dual (polar) law of cosines, which expresses a side as a symmetric function of the three angles: cos a = (cos A + cos B·cos C)/(sin B·sin C) spherically, cosh a = (same RHS) hyperbolically. Equal angles make the two side-expressions coincide, and injectivity of cos on [0,π] (spherical) / cosh on [0,∞) (hyperbolic) yields equal sides. Includes the equiangular ⟹ equilateral corollaries. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "classical (Euclid I.6; non-Euclidean dual law of cosines)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IsoscelesTriangleOQ02OQ01.lean",
+    "badge": "original",
+    "tags": [
+      "geometry",
+      "non-euclidean",
+      "spherical-geometry",
+      "hyperbolic-geometry",
+      "pons-asinorum",
+      "law-of-cosines",
+      "trigonometry",
+      "euclid",
+      "intermediate"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 107,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp"
+    ],
+    "assumptions": "None. Fully machine-checked: #print axioms on both converse theorems reports only propext, Classical.choice, Quot.sound (the standard foundational axioms). 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The dual laws of cosines enter as explicit hypotheses (lawa, lawb) on each theorem — i.e. the theorems are conditional on the triangle satisfying the non-Euclidean dual law of cosines, exactly as the parent's theorems are conditional on the ordinary law of cosines. The only standing range hypotheses are the natural ones: spherical sides lie in [0,π], hyperbolic sides are ≥ 0.",
+    "originalContributions": [
+      "A coordinate-free Lean proof of the converse isosceles-triangle theorem (equal base angles ⟹ equal opposite sides) in both spherical and hyperbolic geometry, answering OQ-01 of the parent isosceles-triangle-oq-02 entry.",
+      "Identifies the dual (polar) law of cosines as the exact mirror of the parent's argument: where the parent solved the law of cosines for cos A as a symmetric function of the adjacent sides, this entry solves the dual law for cos a / cosh a as a symmetric function of the other two angles (sphCosSide, hypCoshSide).",
+      "Observes that the dual-law right-hand side (cos A + cos B·cos C)/(sin B·sin C) is identical in both geometries — only the left-hand side changes (cos a spherically, cosh a hyperbolically) — so a single symmetric expression drives both proofs.",
+      "Replaces the spherical injectivity of cos on [0,π] (Real.injOn_cos) with the hyperbolic injectivity of cosh on [0,∞) (Real.cosh_strictMonoOn.injOn) to conclude equal sides, and derives the equiangular ⟹ equilateral corollaries in both geometries."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euclid's Elements I.5 (Pons Asinorum) states that the base angles of an isosceles triangle are equal; I.6 is its converse — if two angles of a triangle are equal, the sides opposite them are equal. In the Euclidean plane both follow from congruence or from the law of cosines. In the curved geometries of the sphere and the hyperbolic plane there is no inner product space and no SAS congruence in the Euclidean sense, but there are the spherical and hyperbolic laws of cosines, and their *duals* (polar laws). The dual law of cosines is special to non-Euclidean geometry: on the sphere it reflects the polar-triangle duality between sides and angles, and it expresses a side purely in terms of the three angles — a relation with no Euclidean analogue (in the plane the angles determine a triangle only up to similarity, never the side lengths). This duality is exactly what makes the converse provable by the same algebra as the parent's forward direction.",
+    "problemStatement": "**Converse Pons Asinorum (Euclid I.6) in non-Euclidean geometry.** Let a triangle have angles A, B, C opposite sides a, b, c. Suppose the sides satisfy the dual (polar) law of cosines:\n- spherical:  cos a = (cos A + cos B·cos C)/(sin B·sin C),\n- hyperbolic: cosh a = (cos A + cos B·cos C)/(sin B·sin C),\nand symmetrically for b. If two base angles are equal (A = B) then the opposite sides are equal (a = b). Consequently an equiangular triangle is equilateral.",
+    "text": "A Lean 4 / Mathlib formalization (107 lines, 0 sorries, 0 axioms) of the converse isosceles theorem in spherical and hyperbolic geometry. Two definitions, sphCosSide A B C and hypCoshSide A B C, package the dual-law expression (cos A + cos B·cos C)/(sin B·sin C) for cos a (resp. cosh a). The algebraic cores sph_converse_eq / hyp_converse_eq show that A = B makes sphCosSide A B C = sphCosSide B A C (a one-line subst; rfl, because the expression is symmetric under swapping the first two angles). The main theorems spherical_isosceles_converse and hyperbolic_isosceles_converse then conclude a = b: spherically via Real.injOn_cos on [0,π], hyperbolically via injectivity of cosh on [0,∞) (Real.cosh_strictMonoOn.injOn). The corollaries spherical_equiangular / hyperbolic_equiangular give equiangular ⟹ equilateral.",
+    "proofStrategy": "1. **Dual law as a definition.** sphCosSide A B C := (cos A + cos B·cos C)/(sin B·sin C) is the value of cos a forced by the spherical dual law of cosines; hypCoshSide is the same expression, equal to cosh a hyperbolically.\n\n2. **Symmetry under A ↔ B.** sph_converse_eq / hyp_converse_eq: with A = B, subst reduces sphCosSide A B C = sphCosSide B A C to a reflexivity, since the expression is unchanged when the first two angles are swapped.\n\n3. **Inject to recover the side.** spherical_isosceles_converse: from the hypotheses cos a = sphCosSide A B C and cos b = sphCosSide B A C, rewrite to cos a = cos b, then apply Real.injOn_cos (cos is injective on [0,π], where spherical side lengths live) to get a = b.\n\n4. **Hyperbolic injectivity.** hyperbolic_isosceles_converse: identically, but with cosh a = cosh b and the injectivity of cosh on [0,∞) (StrictMonoOn.injOn Real.cosh_strictMonoOn on Ici 0), valid since hyperbolic side lengths are ≥ 0.\n\n5. **Equiangular corollaries.** With all three angles equal, all three side-expressions coincide, so the same injectivity gives a = b = c.",
+    "keyInsights": [
+      "**Duality turns the converse into the forward direction.** The parent proves equal sides ⟹ equal angles by solving the law of cosines for cos A as a symmetric function of the adjacent sides. The dual law of cosines solves for cos a as a symmetric function of the other two angles, so the *same* one-line symmetry argument proves equal angles ⟹ equal sides.",
+      "**One expression, two geometries.** The dual-law right-hand side (cos A + cos B·cos C)/(sin B·sin C) is literally identical spherically and hyperbolically; the geometries differ only in whether it equals cos a or cosh a. The algebraic core is therefore shared verbatim between sphCosSide and hypCoshSide.",
+      "**Injectivity is the only analysis used.** Once cos a = cos b (resp. cosh a = cosh b) is established by pure algebra, recovering a = b needs only that cos is injective on [0,π] and cosh on [0,∞) — the natural ranges of side lengths in each geometry. No derivatives, integrals, or inner products appear.",
+      "**A side determined by angles is non-Euclidean.** That three angles pin down the actual side lengths (not merely the shape) has no Euclidean counterpart — it is the AAA-congruence phenomenon of spherical and hyperbolic geometry, encoded here by the dual law of cosines.",
+      "**Mirror symmetry of the whole development.** Every theorem here is the exact dual of a parent theorem (isosceles ↔ isosceles_converse, equilateral ↔ equiangular), making the pair a compact illustration of side–angle duality in non-Euclidean trigonometry."
+    ],
+    "prerequisites": [
+      "Spherical and hyperbolic trigonometry (laws of cosines and their dual/polar forms)",
+      "Injectivity of cos on [0,π] and of cosh on [0,∞)",
+      "Mathlib: Real.injOn_cos, Real.cosh_strictMonoOn, StrictMonoOn.injOn",
+      "Parent context: isosceles-triangle-oq-02 (forward Pons Asinorum in non-Euclidean geometry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: The Dual Law and the Converse",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "States the converse problem, recalls the spherical/hyperbolic dual (polar) laws of cosines cos a / cosh a = (cos A + cos B·cos C)/(sin B·sin C), and explains that the argument is the exact dual of the parent's: equal angles make the side-expressions coincide, then injectivity of cos on [0,π] and cosh on [0,∞) yields equal sides.",
+      "mathContext": "Euclid I.6 in non-Euclidean geometry, via side–angle duality."
+    },
+    {
+      "id": "defs",
+      "title": "Dual-Law Side Expressions",
+      "startLine": 44,
+      "endLine": 58,
+      "summary": "sphCosSide A B C and hypCoshSide A B C define the dual-law value of cos a (resp. cosh a) as the symmetric expression (cos A + cos B·cos C)/(sin B·sin C). The two definitions share the same body; only their geometric meaning (cos a vs cosh a) differs.",
+      "mathContext": "The dual law of cosines expresses a side as a function of the three angles."
+    },
+    {
+      "id": "cores",
+      "title": "Algebraic Cores: Symmetry Under A ↔ B",
+      "startLine": 59,
+      "endLine": 66,
+      "summary": "sph_converse_eq / hyp_converse_eq prove that A = B forces sphCosSide A B C = sphCosSide B A C (resp. hypCoshSide), each by subst; rfl — the side-expression is invariant under swapping the first two angles.",
+      "mathContext": "Equal angles ⟹ equal cos a / cosh a."
+    },
+    {
+      "id": "converse",
+      "title": "Converse Pons Asinorum in Each Geometry",
+      "startLine": 68,
+      "endLine": 84,
+      "summary": "spherical_isosceles_converse rewrites the dual-law hypotheses to cos a = cos b and applies Real.injOn_cos on [0,π]; hyperbolic_isosceles_converse rewrites to cosh a = cosh b and applies injectivity of cosh on [0,∞) via StrictMonoOn.injOn Real.cosh_strictMonoOn. Both conclude a = b.",
+      "mathContext": "Equal base angles ⟹ equal opposite sides, spherically and hyperbolically."
+    },
+    {
+      "id": "corollaries",
+      "title": "Equiangular ⟹ Equilateral",
+      "startLine": 86,
+      "endLine": 107,
+      "summary": "spherical_equiangular / hyperbolic_equiangular: when all three angles are equal, the three side-expressions coincide, so the same injectivity lemmas give a = b ∧ b = c — an equiangular non-Euclidean triangle is equilateral.",
+      "mathContext": "The converse-direction analogue of the parent's equilateral ⟹ equiangular corollaries."
+    }
+  ],
+  "conclusion": {
+    "summary": "The converse isosceles theorem (Euclid I.6: equal base angles ⟹ equal opposite sides) is verified in Lean 4 / Mathlib for both spherical and hyperbolic geometry (107 lines, 0 sorries, 0 axioms), using only the dual (polar) law of cosines and the injectivity of cos on [0,π] and cosh on [0,∞). It is the exact dual of the parent's forward Pons Asinorum, and includes the equiangular ⟹ equilateral corollaries.",
+    "implications": "Together with the parent isosceles-triangle-oq-02 (forward direction), this completes the isosceles ⟺ equal-angle equivalence in non-Euclidean geometry from a purely coordinate-free, inner-product-free standpoint. The dual law of cosines used here is also the natural entry point to a full non-Euclidean triangle-congruence toolkit (AAA congruence, the law of sines).",
+    "openQuestions": [
+      "Derive the spherical and hyperbolic laws of sines in the same coordinate-free framework and combine them with these results toward a full non-Euclidean triangle-congruence toolkit (SSS, SAS, ASA, AAA).",
+      "Prove that the dual-law expression is consistent with the ordinary law of cosines (i.e. derive the dual law of cosines from the law of cosines + the law of sines), turning the dual law from a hypothesis into a theorem.",
+      "Formalize the spherical polar-triangle duality explicitly, exhibiting the dual law of cosines as the ordinary law of cosines applied to the polar triangle."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "namespace": "IsoscelesTriangleOQ02OQ01",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/IsoscelesTriangleOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "isosceles-triangle-oq-02",
+      "relationship": "extends",
+      "description": "The parent proves the forward Pons Asinorum (equal sides ⟹ equal base angles) in spherical and hyperbolic geometry and lists 'prove the converse via the dual law of cosines' as its first open question. This entry answers exactly that question, with a development that mirrors the parent theorem-for-theorem."
+    },
+    {
+      "targetId": "isosceles-triangle",
+      "relationship": "related",
+      "description": "The grandparent proves the Euclidean isosceles triangle theorem (Euclid I.5) using Mathlib's inner-product-space geometry; this entry treats the converse (Euclid I.6) in the curved geometries where that structure is unavailable."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book I, Proposition 6",
+      "year": "c. 300 BCE",
+      "venue": "—",
+      "note": "The converse of Pons Asinorum: if two angles of a triangle are equal, the sides opposite them are equal."
+    },
+    {
+      "authors": "Marvin Jay Greenberg",
+      "title": "Euclidean and Non-Euclidean Geometries: Development and History",
+      "year": "2008",
+      "venue": "W. H. Freeman (4th ed.)",
+      "note": "Develops spherical and hyperbolic trigonometry, including the laws of cosines and their dual (polar) forms."
+    },
+    {
+      "authors": "John Stillwell",
+      "title": "Geometry of Surfaces",
+      "year": "1992",
+      "venue": "Springer, Universitext",
+      "note": "Treats the hyperbolic and spherical laws of cosines and side–angle duality."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "spherical_isosceles_converse",
+      "type": "core",
+      "description": "Converse Pons Asinorum, spherical geometry: with the dual law of cosines and sides a, b ∈ [0,π], equal base angles A = B imply equal opposite sides a = b.",
+      "leanType": "{a b A B C : ℝ} (ha : a ∈ Icc 0 π) (hb : b ∈ Icc 0 π) (lawa : cos a = sphCosSide A B C) (lawb : cos b = sphCosSide B A C) (h : A = B) : a = b"
+    },
+    {
+      "name": "hyperbolic_isosceles_converse",
+      "type": "core",
+      "description": "Converse Pons Asinorum, hyperbolic geometry: with the dual law of cosines and sides a, b ≥ 0, equal base angles A = B imply equal opposite sides a = b, via injectivity of cosh on [0,∞).",
+      "leanType": "{a b A B C : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (lawa : cosh a = hypCoshSide A B C) (lawb : cosh b = hypCoshSide B A C) (h : A = B) : a = b"
+    },
+    {
+      "name": "spherical_equiangular",
+      "type": "corollary",
+      "description": "Equiangular ⟹ equilateral, spherical geometry: a spherical triangle with all angles equal has all sides equal.",
+      "leanType": "{a b c A : ℝ} (ha : a ∈ Icc 0 π) (hb : b ∈ Icc 0 π) (hc : c ∈ Icc 0 π) (lawa : cos a = sphCosSide A A A) (lawb : cos b = sphCosSide A A A) (lawc : cos c = sphCosSide A A A) : a = b ∧ b = c"
+    },
+    {
+      "name": "hyperbolic_equiangular",
+      "type": "corollary",
+      "description": "Equiangular ⟹ equilateral, hyperbolic geometry.",
+      "leanType": "{a b c A : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (hc : 0 ≤ c) (lawa : cosh a = hypCoshSide A A A) (lawb : cosh b = hypCoshSide A A A) (lawc : cosh c = hypCoshSide A A A) : a = b ∧ b = c"
+    },
+    {
+      "name": "sphCosSide",
+      "type": "definition",
+      "description": "Dual-law value of cos a from the angles: (cos A + cos B·cos C)/(sin B·sin C).",
+      "leanType": "(A B C : ℝ) : ℝ"
+    },
+    {
+      "name": "hypCoshSide",
+      "type": "definition",
+      "description": "Dual-law value of cosh a from the angles: (cos A + cos B·cos C)/(sin B·sin C) (same RHS as the spherical case).",
+      "leanType": "(A B C : ℝ) : ℝ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-01** of the parent `isosceles-triangle-oq-02`: the **converse** isosceles theorem (Euclid I.6 — *equal base angles ⟹ equal opposite sides*) in **spherical** and **hyperbolic** geometry, with no inner product space.

The engine is the **dual (polar) law of cosines**, which expresses a side as a symmetric function of the three angles:
$$\cos a = \frac{\cos A + \cos B\cos C}{\sin B\sin C}\ \text{(spherical)},\qquad \cosh a = \frac{\cos A + \cos B\cos C}{\sin B\sin C}\ \text{(hyperbolic)}.$$
The right-hand side is **identical** in both geometries — only the left side changes. Equal angles ($A=B$) make the two opposite-side expressions coincide, so $\cos a=\cos b$ (resp. $\cosh a=\cosh b$); injectivity of $\cos$ on $[0,\pi]$ and $\cosh$ on $[0,\infty)$ gives $a=b$. This is the exact dual of the parent's forward argument.

## Results (6 theorems / 2 definitions)

| Name | Statement |
|---|---|
| `sphCosSide`, `hypCoshSide` | dual-law side expressions |
| `sph_converse_eq`, `hyp_converse_eq` | $A=B \Rightarrow$ equal side (co)sines |
| `spherical_isosceles_converse` | spherical: equal base angles ⟹ equal opposite sides |
| `hyperbolic_isosceles_converse` | hyperbolic: same, via cosh injectivity on $[0,\infty)$ |
| `spherical_equiangular`, `hyperbolic_equiangular` | equiangular ⟹ equilateral |

## Verification

- **0 sorries, 0 axiom declarations, 0 structure-encoded assumptions.**
- `#print axioms` on both converse theorems ⇒ only `propext, Classical.choice, Quot.sound`.
- Build-verified via single-file `lake env lean` against prebuilt Mathlib **v4.26.0** oleans (docker daemon down this cycle).
- The dual laws of cosines enter as explicit hypotheses, mirroring the parent's reliance on the ordinary law of cosines.

## Changes

- `proofs/Proofs/IsoscelesTriangleOQ02OQ01.lean` — new (registered in `Proofs.lean`).
- `src/data/proofs/isosceles-triangle-oq-02-oq-01/` — new gallery entry (`meta.json` + `annotations.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)