### PR TITLE
research(erdos-1204): define A(k) and prove A(k) ≤ (k-1)·primorial(k) [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -184,6 +184,76 @@ theorem exists_admissible_card (k : ℕ) :
     rw [hp0, mul_zero]
     exact zero_ne_one
 
+/- ## The extremal function A(k)
+
+With admissible `k`-sets shown to exist, the extremal quantity `A(k) = min a_k` is
+well-defined, and the primorial construction gives an explicit (weak) upper bound. -/
+
+/-- The primorial of the primes `≤ k`: the product of all primes at most `k`. -/
+def primorialLE (k : ℕ) : ℕ := ((Finset.range (k + 1)).filter Nat.Prime).prod id
+
+/-- The primorial of primes `≤ k` is positive. -/
+theorem primorialLE_pos (k : ℕ) : 0 < primorialLE k :=
+  Finset.prod_pos (fun _q hq => (Finset.mem_filter.mp hq).2.pos)
+
+/-- Every prime `p ≤ k` divides the primorial `primorialLE k`. -/
+theorem dvd_primorialLE {p k : ℕ} (hp : p.Prime) (hpk : p ≤ k) : p ∣ primorialLE k :=
+  Finset.dvd_prod_of_mem id (Finset.mem_filter.mpr ⟨Finset.mem_range.mpr (by omega), hp⟩)
+
+/-- The explicit admissible `k`-set `{0, N, 2N, …, (k-1)N}` with `N = primorialLE k`. -/
+def admMultiples (k : ℕ) : Finset ℕ := (Finset.range k).image (· * primorialLE k)
+
+/-- The explicit set has exactly `k` elements. -/
+theorem admMultiples_card (k : ℕ) : (admMultiples k).card = k := by
+  unfold admMultiples
+  rw [Finset.card_image_of_injective _
+        (fun x y h => Nat.eq_of_mul_eq_mul_right (primorialLE_pos k) h),
+      Finset.card_range]
+
+/-- The explicit set is admissible (every prime `p ≤ k` divides `N`, so the class `1` is missed). -/
+theorem admMultiples_admissible (k : ℕ) : Admissible (admMultiples k) := by
+  classical
+  rw [admissible_iff_card, admMultiples_card]
+  intro p hp hpk
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hp0 : (primorialLE k : ZMod p) = 0 :=
+    (CharP.cast_eq_zero_iff (ZMod p) p _).mpr (dvd_primorialLE hp hpk)
+  refine ⟨1, fun x hx => ?_⟩
+  rw [admMultiples, Finset.mem_image] at hx
+  obtain ⟨i, _, rfl⟩ := hx
+  push_cast
+  rw [hp0, mul_zero]
+  exact zero_ne_one
+
+/-- The largest element `(k-1)·N` is in the explicit set. -/
+theorem admMultiples_mem_max (k : ℕ) (hk : 1 ≤ k) :
+    (k - 1) * primorialLE k ∈ admMultiples k := by
+  rw [admMultiples, Finset.mem_image]
+  exact ⟨k - 1, Finset.mem_range.mpr (by omega), rfl⟩
+
+/-- Every element of the explicit set is at most `(k-1)·N`. -/
+theorem admMultiples_le (k : ℕ) : ∀ x ∈ admMultiples k, x ≤ (k - 1) * primorialLE k := by
+  intro x hx
+  rw [admMultiples, Finset.mem_image] at hx
+  obtain ⟨i, hi, rfl⟩ := hx
+  rw [Finset.mem_range] at hi
+  gcongr
+  omega
+
+/-- `A(k)`: the least possible largest element of an admissible `k`-element subset of `ℕ`.
+For sequences `0 ≤ a₁ < ⋯ < a_k` this is exactly `min a_k`, the quantity Erdős #1204 asks to
+estimate (conjecturally `A(k) ∼ k log k`). -/
+noncomputable def A (k : ℕ) : ℕ :=
+  sInf {m | ∃ a : Finset ℕ, a.card = k ∧ Admissible a ∧ m ∈ a ∧ ∀ x ∈ a, x ≤ m}
+
+/-- **Explicit upper bound on A(k).** `A(k) ≤ (k-1)·∏_{p ≤ k} p`, witnessed by the admissible
+set `{0, N, 2N, …, (k-1)N}`. (This is far from the conjectured `A(k) ∼ k log k` — the primorial
+is exponentially large — but it is a fully verified bound on the extremal function.) -/
+theorem A_le_primorial (k : ℕ) (hk : 1 ≤ k) :
+    A k ≤ (k - 1) * primorialLE k :=
+  Nat.sInf_le ⟨admMultiples k, admMultiples_card k, admMultiples_admissible k,
+    admMultiples_mem_max k hk, admMultiples_le k⟩
+
 /- ## Open Problems
 
 The asymptotic behaviour of the extremal quantities is OPEN:

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -57,3 +57,14 @@ A(k)∼k log k and B(k) estimate remain OPEN (need sieve theory).
 
 Gotcha: `(N:ZMod p)=0` from `p∣N` via `CharP.cast_eq_zero_iff (ZMod p) p N` (no NeZero needed,
 unlike `ZMod.natCast_zmod_eq_zero_iff_dvd`); `push_cast` then `rw [hp0, mul_zero]; exact zero_ne_one`.
+
+## Session 2026-06-25 (researcher-1, cont.) — the extremal function A(k) + verified upper bound
+
+Defined `A(k)` = least possible largest element of an admissible k-set (= min a_k, the quantity
+#1204 asks to estimate), and proved the first verified bound:
+- `A_le_primorial`: **A(k) ≤ (k-1)·∏_{p≤k} p**, via the named construction `admMultiples k`
+  = {0,N,…,(k-1)N} with N = `primorialLE k` (helpers: primorialLE_pos, dvd_primorialLE,
+  admMultiples_card/admissible/mem_max/le). Proof: `Nat.sInf_le` on the explicit witness.
+
+Now 17 thm/4 def, 0 axioms, 0 sorries. The bound is exponentially weak vs the conjectured
+A(k) ∼ k log k (primorial ≈ e^k); closing the gap needs sieve theory. Still OPEN.

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -55,10 +55,10 @@
       "Open asymptotic questions A(k)∼k log k and B(k) documented (not asserted)"
     ],
     "axiomCount": 0,
-    "lineCount": 201,
+    "lineCount": 271,
     "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved (#print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool). Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. The formalization here is the admissibility framework plus the standard reduction to small primes.",
-    "theoremCount": 10,
-    "definitionCount": 1
+    "theoremCount": 17,
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1204**\n\nThe notion of an *admissible* sequence (or k-tuple) is central to the Hardy–Littlewood prime k-tuples conjecture and to modern work on bounded gaps between primes (Zhang 2013, Maynard 2015, Polymath8). A k-tuple is admissible precisely when it does not occupy every residue class modulo some prime — the only local obstruction to all shifts being simultaneously prime infinitely often.\n\nErdős asks for the size of the minimal *diameter* A(k) of an admissible k-tuple, conjecturally A(k) ∼ k log k, and for the minimal average B(k).",
@@ -124,10 +124,10 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 201,
+    "lineCount": 271,
     "axiomCount": 0,
-    "theoremCount": 10,
-    "definitionCount": 1,
+    "theoremCount": 17,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT/BUILD (session 2): added 4 verified structural theorems to Erdos1204Problem.lean — Admissible.subset (downward closure), admissible_image_add (translation invariance) + card_image_add, and exists_admissible_card (an admissible k-set exists for every k via primorial multiples 0,N,2N,...,(k-1)N ⇒ A(k) well-defined, with explicit weak bound A(k) ≤ (k-1)·∏_{p≤k}p). Now 10 thm/1 def, 0 axioms/0 sorries, fully verified. Headline A(k)∼k log k and B(k) remain OPEN.",
+    "progressSummary": "ORIENT/BUILD (session 3): defined the extremal function A(k) = least largest element of an admissible k-set, and proved the explicit verified upper bound A_le_primorial: A(k) ≤ (k-1)·∏_{p≤k}p (via the named primorial construction admMultiples). Now 17 thm/4 def, 0 axioms/0 sorries. Headline A(k)∼k log k still OPEN.",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -38,21 +38,26 @@
       "Admissible.subset (downward closure) in Erdos1204Problem.lean:130",
       "admissible_image_add (translation invariance) in Erdos1204Problem.lean:140",
       "card_image_add (translation preserves card) in Erdos1204Problem.lean:152",
-      "exists_admissible_card (∃ admissible k-set ⇒ A(k) well-defined) in Erdos1204Problem.lean:165"
+      "exists_admissible_card (∃ admissible k-set ⇒ A(k) well-defined) in Erdos1204Problem.lean:165",
+      "A (def): A(k)=sInf of largest-elements of admissible k-sets, in Erdos1204Problem.lean",
+      "primorialLE / admMultiples (named construction) in Erdos1204Problem.lean",
+      "A_le_primorial: A(k) ≤ (k-1)·∏_{p≤k}p [verified] in Erdos1204Problem.lean"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
       "Reduction: for primes p > k, k elements cannot cover all p classes, so admissibility only constrains primes p ≤ k.",
       "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2.",
       "Admissibility is downward-closed and translation-invariant: it is a property of the *pattern* of a tuple, not its position.",
-      "An admissible k-tuple exists for every k: take multiples 0,N,2N,...,(k-1)N of the primorial N=∏_{p≤k}p; mod each prime p≤k all are ≡0 so class 1 is missed, larger primes auto by size bound. This makes A(k) well-defined and gives the explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p."
+      "An admissible k-tuple exists for every k: take multiples 0,N,2N,...,(k-1)N of the primorial N=∏_{p≤k}p; mod each prime p≤k all are ≡0 so class 1 is missed, larger primes auto by size bound. This makes A(k) well-defined and gives the explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p.",
+      "A(k) is now a Lean function (sInf of largest elements of admissible k-sets) with a verified explicit upper bound A(k) ≤ (k-1)·primorial(k); the gap to the conjectured k log k is exponential (primorial ≈ e^k) and closing it needs sieve theory."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Formalize explicit admissible-tuple constructions to bound A(k) above.",
       "Investigate a lower-bound argument toward A(k) ≳ k log k.",
       "Define A(k) (and B(k)) as Lean functions (sInf over admissible k-sets) and prove the weak upper bound A(k) ≤ (k-1)·primorial(k) formally.",
-      "The headline A(k)∼k log k needs sieve theory / prime distribution — remains OPEN."
+      "The headline A(k)∼k log k needs sieve theory / prime distribution — remains OPEN.",
+      "Improve the upper bound from primorial toward k log k (use smallest prime / Jacobsthal-type estimates); prove a lower bound on A(k)."
     ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },


### PR DESCRIPTION
## Summary
Research session for **erdos-1204** (admissible sequences; estimate `A(k) = min a_k`, is `A(k) ∼ k log k`?). Continues the merged structural work (#30199) depth-first.

Formalizes the **extremal function itself** and proves its first verified bound (now **17 thm / 4 def, 0 axioms, 0 sorries**):

- `A` (def): `A(k) = sInf` of the largest elements of admissible `k`-element sets — i.e. `min a_k` over admissible `0 ≤ a₁ < ⋯ < a_k`, the quantity Erdős #1204 asks to estimate.
- `primorialLE` / `admMultiples`: the named primorial construction `{0, N, …, (k-1)N}` with `N = ∏_{p ≤ k} p`, plus helpers (`primorialLE_pos`, `dvd_primorialLE`, `admMultiples_card`/`admissible`/`mem_max`/`le`).
- `A_le_primorial`: **`A(k) ≤ (k-1)·∏_{p ≤ k} p`**, by `Nat.sInf_le` on the explicit admissible witness.

`#print axioms` shows only the foundational `propext`/`Classical.choice`/`Quot.sound`.

## Status
**Outcome**: progress (extremal function defined + first verified upper bound).
The bound is exponentially weak versus the conjectured `A(k) ∼ k log k` (the primorial is `≈ e^k`); closing the gap needs sieve theory and remains **OPEN**.

## Files
- `proofs/Proofs/Erdos1204Problem.lean` (extended, verified)
- `src/data/proofs/erdos-1204/meta.json` (counts 10→17, 1→4 defs, 201→271 lines)
- `src/data/research/problems/erdos-1204.json` + `research/problems/erdos-1204/knowledge.md`

🤖 Generated by researcher-1