### PR TITLE
research(collatz-structured-oq-02-oq-03): Tao 2019 almost-all bound — statement + axiom-free core [+7 thm/1 deep axiom]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -1,0 +1,145 @@
+/-
+# OQ-02 OQ-03: Tao's 2019 Almost-All Bound — A Feasibility Anchor
+
+Open question OQ-03 of `collatz-structured-oq-02` (Collatz Cycles):
+
+  "Can Tao's 2019 almost-all result (logarithmic density 1) be formalized in Lean
+   using Mathlib's measure theory and ergodic theory libraries?"
+
+Tao (2019, *Forum Math. Pi*, "Almost all orbits of the Collatz map attain almost
+bounded values") proved: for every `f : ℕ → ℝ` with `f n → ∞`, the set of starting
+values `n` whose orbit minimum `Col_min(n)` drops below `f n` has **logarithmic
+density 1**.  This subsumes the classical Terras/Korec "almost all have finite
+stopping time" statements and pushes the bound from "below `n`" down to "below any
+slowly growing `f`".
+
+## What resists formalization (honest assessment)
+
+Tao's proof is genuinely analytic and is **out of reach of a direct Lean proof
+today** (BLOCKED, >> 1000 lines):
+
+  * It runs the Collatz/Syracuse dynamics against a carefully chosen family of
+    measures on the 3-adics / on residue classes, and controls the evolution of
+    those measures (a transport/coupling argument), establishing that the pushed
+    forward measures concentrate.
+  * The quantitative heart is a **stable point estimate** obtained from a
+    `3`-adic large-deviation / entropy bound, combined with a Fourier-analytic
+    input.  Mathlib currently has the general measure-theory and `Tendsto`
+    plumbing used below, but not the specialised concentration/transport
+    estimates Tao needs; building those is the real cost.
+
+So, mirroring the sibling files `CollatzStructuredOQ02OQ01.lean` (which axiomatized
+the Eliahou bound) and `CollatzStructuredOQ02OQ02.lean` (which proved Eliahou's
+algebraic core and isolated the finite-check residue), this file:
+
+  * gives a **precise, machine-checkable statement** of Tao's theorem
+    (`tao_2019`) so the open question is no longer informal, and the
+    "logarithmic density 1" target is pinned down as `HasLogDensityOne`;
+  * proves, **unconditionally and axiom-free**, that two large explicit families
+    of starting values already satisfy the "drops below itself" conclusion — the
+    even numbers and the powers of two — so the elementary part of the
+    almost-all picture is real Lean content, not scaffolding on the axiom.
+
+References:
+- Tao, T. (2019). "Almost all orbits of the Collatz map attain almost bounded
+  values." *Forum Math. Pi* 8, e9.
+- Terras, R. (1976). "A stopping time problem on the positive integers."
+- Korec, I. (1994). "A density estimate for the 3x+1 problem."
+-/
+import Mathlib
+
+namespace CollatzStructuredOQ02OQ03
+
+open Filter
+
+/-! ## Part I: The Collatz map (self-contained) -/
+
+/-- The Collatz function: `n ↦ n/2` if even, `n ↦ 3n+1` if odd. -/
+def collatz (n : ℕ) : ℕ :=
+  if n % 2 = 0 then n / 2 else 3 * n + 1
+
+theorem collatz_even {n : ℕ} (h : n % 2 = 0) : collatz n = n / 2 := by
+  simp [collatz, h]
+
+theorem collatz_two_mul (n : ℕ) : collatz (2 * n) = n := by
+  simp [collatz, Nat.mul_mod_right]
+
+/-! ## Part II: Two explicit families that drop below their start
+
+These are the unconditional, axiom-free part of the almost-all picture: whatever
+Tao's analytic argument gives for *almost all* `n`, the even numbers and the
+powers of two are handled by elementary one-line dynamics. -/
+
+/-- `n` *attains a value below itself*: some positive number of Collatz steps
+takes `n` to a strictly smaller value.  This is the "finite stopping time"
+event whose almost-all behaviour Tao controls. -/
+def AttainsBelow (n : ℕ) : Prop := ∃ k, 0 < k ∧ collatz^[k] n < n
+
+/-- Every positive **even** number drops below itself in a single step. -/
+theorem even_attainsBelow {n : ℕ} (hn : 1 ≤ n) (he : n % 2 = 0) : AttainsBelow n :=
+  ⟨1, one_pos, by
+    rw [Function.iterate_one, collatz_even he]
+    exact Nat.div_lt_self hn (by norm_num)⟩
+
+/-- A power of two collapses to `1` after exactly that many steps:
+`collatz^[k] (2^k) = 1`. -/
+theorem pow_two_reaches_one (k : ℕ) : collatz^[k] (2 ^ k) = 1 := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply]
+    have hstep : collatz (2 ^ (k + 1)) = 2 ^ k := by
+      rw [pow_succ']
+      exact collatz_two_mul (2 ^ k)
+    rw [hstep, ih]
+
+/-- Every power of two `2^k` with `k ≥ 1` drops below itself (all the way to 1). -/
+theorem pow_two_attainsBelow {k : ℕ} (hk : 1 ≤ k) : AttainsBelow (2 ^ k) := by
+  refine ⟨k, hk, ?_⟩
+  rw [pow_two_reaches_one]
+  have h2 : (2 : ℕ) ≤ 2 ^ k := by
+    simpa using Nat.pow_le_pow_right (by norm_num : 1 ≤ 2) hk
+  omega
+
+/-! ## Part III: The orbit minimum and logarithmic density -/
+
+/-- The **orbit minimum** of `n`: the infimum of the values visited by the
+Collatz orbit of `n` (including `n` itself).  `Col_min` in Tao's notation. -/
+noncomputable def colMin (n : ℕ) : ℕ := sInf {m | ∃ k, collatz^[k] n = m}
+
+/-- The orbit minimum never exceeds the starting value (`k = 0` visits `n`). -/
+theorem colMin_le_self (n : ℕ) : colMin n ≤ n :=
+  Nat.sInf_le ⟨0, Function.iterate_zero_apply collatz n⟩
+
+/-- The orbit of a power of two reaches `1`, so its orbit minimum is `≤ 1`. -/
+theorem colMin_pow_two_le_one (k : ℕ) : colMin (2 ^ k) ≤ 1 :=
+  Nat.sInf_le ⟨k, pow_two_reaches_one k⟩
+
+/-- The logarithmic-density partial average of a set `S` up to `N`:
+`(∑_{n≤N, n∈S} 1/n) / (∑_{n≤N} 1/n)`. -/
+noncomputable def logDensity (S : Set ℕ) (N : ℕ) : ℝ :=
+  (∑ n ∈ Finset.Icc 1 N, S.indicator (fun m => (1 : ℝ) / m) n)
+    / (∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / n)
+
+/-- `S` has **logarithmic density one** if its partial averages tend to `1`. -/
+def HasLogDensityOne (S : Set ℕ) : Prop :=
+  Tendsto (logDensity S) atTop (nhds 1)
+
+/-! ## Part IV: Tao's theorem (axiomatized, deep)
+
+The precise statement of Tao (2019).  This is the result whose formalization the
+open question asks about; we record it as a single axiom and document above why a
+direct Lean proof is currently out of reach.  No theorem in this file is derived
+from it — the content of Parts II–III stands on its own. -/
+
+/--
+**Tao (2019):** for every `f : ℕ → ℝ` tending to infinity, the set of positive
+starting values whose orbit minimum is eventually below `f n` has logarithmic
+density one.  Taking `f n = n` recovers "almost all `n` have finite stopping
+time"; the strength of the theorem is that `f` may grow arbitrarily slowly.
+-/
+axiom tao_2019 :
+    ∀ f : ℕ → ℝ, Tendsto f atTop atTop →
+      HasLogDensityOne {n : ℕ | 0 < n ∧ (colMin n : ℝ) < f n}
+
+end CollatzStructuredOQ02OQ03

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -6,16 +6,45 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+OQ-03 asks whether Tao's 2019 almost-all result (logarithmic density 1) can be
+formalized in Lean with Mathlib. Tao (2019, *Forum Math. Pi*): for every
+`f : ℕ → ℝ` with `f n → ∞`, the set `{n : Col_min(n) < f n}` has **logarithmic
+density 1**. This subsumes Terras (1976) / Korec (1994) (almost all n have finite
+stopping time, in natural density).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Statement formalizes cleanly.** "Logarithmic density 1" becomes the predicate
+  `HasLogDensityOne S := Tendsto (fun N => (∑_{n≤N,n∈S} 1/n)/(∑_{n≤N} 1/n)) atTop (𝓝 1)`.
+  `Set.indicator` (classical, no `DecidablePred` needed) handles the filtered sum.
+  Tao's theorem is then a single clean `axiom tao_2019` quantified over all `f → ∞`.
+- **The elementary half is axiom-free.** Even numbers drop in one step
+  (`collatz n = n/2 < n`), and powers of two collapse to 1
+  (`collatz^[k] (2^k) = 1`, induction via `collatz (2·m) = m` + `pow_succ'` +
+  `Function.iterate_succ_apply`). These give explicit large families in the
+  almost-all set without any analysis.
+- **Orbit minimum** `colMin n := sInf {m | ∃ k, collatz^[k] n = m}`; `colMin_le_self`
+  is just `Nat.sInf_le ⟨0, Function.iterate_zero_apply ..⟩`.
 
 ---
 
-## Dead Ends
+## Dead Ends / Blockers
 
-[Approaches known not to work will be documented here]
+- **Full proof of Tao (2019) is BLOCKED.** The proof evolves tuned measures on the
+  3-adics and controls their concentration (a transport estimate) plus a
+  Fourier-analytic input — none present in Mathlib. A direct formalization is a
+  multi-thousand-line project, not a near-term target. So the file states the
+  theorem as an axiom and proves only the independent elementary content.
+- Suggested intermediate milestone: formalize the Terras/Korec *natural*-density
+  stopping-time result first (easier than the logarithmic-density sharpening).
+
+---
+
+## Deliverable
+
+`proofs/Proofs/CollatzStructuredOQ02OQ03.lean` (0 sorries, 1 deep axiom, 7
+axiom-free theorems, 5 defs). Gallery entry under
+`src/data/proofs/collatz-structured-oq-02-oq-03/`. Build offline (Docker down):
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean <abs path>` → EXIT 0.

--- a/research/problems/collatz-structured-oq-02-oq-03/state.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/state.md
@@ -1,25 +1,32 @@
 # Research State: collatz-structured-oq-02-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-03-30T11:35:21-07:00
-**Iteration**: 1
+**Since**: 2026-06-25
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Pinned the open question with a precise Lean statement of Tao (2019) and proved
+the elementary, axiom-free part of the almost-all picture.
 
 ## Active Approach
-None yet.
+Sibling pattern (cf. CollatzStructuredOQ02OQ02): state the deep result as a single
+documented axiom, prove the elementary core independently.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Approaches tried: 1 (statement + explicit families)
 
 ## Blockers
-None.
+Full proof of Tao (2019) is BLOCKED: requires 3-adic transport/concentration
+estimates + Fourier input absent from Mathlib (>> 1000 lines).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Possible future milestone: formalize the Terras/Korec natural-density stopping-time
+result as an intermediate step toward Tao's logarithmic-density bound.
+
+## Deliverable (this session)
+`proofs/Proofs/CollatzStructuredOQ02OQ03.lean` — 0 sorries, 1 deep axiom (tao_2019),
+7 axiom-free theorems (even numbers + powers of two drop below themselves; orbit
+minimum bounds). Gallery: `src/data/proofs/collatz-structured-oq-02-oq-03/`.

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/annotations.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "collatz-two-mul",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": {
+      "startLine": 68,
+      "endLine": 70
+    },
+    "type": "insight",
+    "title": "The Single Dynamical Fact: collatz(2m) = m",
+    "content": "Because 2m is even, one Collatz step halves it: collatz (2*m) = (2*m)/2 = m. This one identity is the engine behind the dyadic collapse. Iterating it, a power of two is peeled one factor of 2 at a time until nothing but 1 remains, which is why collatz^[k] (2^k) = 1 falls out of a clean induction.",
+    "mathContext": "$$\\mathrm{collatz}(2m) = m.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Collatz map",
+      "even step",
+      "Nat.mul_mod_right"
+    ],
+    "prerequisites": [
+      "n / 2 for even n",
+      "Nat.mul_div_cancel_left"
+    ]
+  },
+  {
+    "id": "even-attains-below",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": {
+      "startLine": 82,
+      "endLine": 86
+    },
+    "type": "insight",
+    "title": "Half of All Starting Values Drop Immediately",
+    "content": "For any positive even n, a single Collatz step sends n to n/2 < n. So the entire arithmetic progression of even numbers — natural density 1/2 — satisfies the 'attains a value below itself' conclusion with no analysis whatsoever. The almost-all phenomenon is only interesting on the odd numbers; the even half is elementary.",
+    "mathContext": "$$n \\text{ even}, n \\ge 1 \\;\\Rightarrow\\; \\mathrm{collatz}(n) = n/2 < n.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "stopping time",
+      "Nat.div_lt_self",
+      "natural density"
+    ],
+    "prerequisites": [
+      "Collatz map on even inputs"
+    ]
+  },
+  {
+    "id": "pow-two-collapse",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": {
+      "startLine": 90,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Powers of Two Collapse All the Way to 1",
+    "content": "collatz^[k] (2^k) = 1, by induction on k: the successor step writes 2^(k+1) = 2·2^k, applies collatz(2·m) = m to reach 2^k, and finishes by the inductive hypothesis. Hence every dyadic starting value not only drops below itself but reaches the global minimum 1 — a concrete witness that colMin(2^k) ≤ 1.",
+    "mathContext": "$$\\mathrm{collatz}^{[k]}(2^k) = 1.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Function.iterate_succ_apply",
+      "pow_succ'",
+      "orbit minimum"
+    ],
+    "prerequisites": [
+      "Function iteration",
+      "induction on ℕ"
+    ]
+  },
+  {
+    "id": "tao-statement",
+    "proofId": "collatz-structured-oq-02-oq-03",
+    "range": {
+      "startLine": 138,
+      "endLine": 145
+    },
+    "type": "caveat",
+    "title": "Tao's Theorem Is Stated, Not Proved (and Why)",
+    "content": "tao_2019 records Tao's 2019 result precisely: for every f → ∞, the orbit-minimum sublevel set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. It is an axiom, not a theorem, because the proof is genuinely analytic — Tao evolves tuned measures on the 3-adics and controls their concentration (a transport estimate) together with a Fourier-analytic input, machinery Mathlib does not yet have. So the answer to OQ-03 is: the STATEMENT formalizes cleanly as a Tendsto predicate, but the PROOF is BLOCKED (>> 1000 lines). Crucially, no other theorem in this file depends on this axiom.",
+    "mathContext": "$$\\forall f \\to \\infty:\\quad \\mathrm{logdens}\\{n : \\mathrm{Col\\_min}(n) < f(n)\\} = 1.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "logarithmic density",
+      "3-adic measures",
+      "concentration of measure",
+      "Tendsto"
+    ],
+    "prerequisites": [
+      "Filters and Tendsto",
+      "logarithmic vs natural density"
+    ]
+  }
+]

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "collatz-structured-oq-02-oq-03",
+  "title": "Tao's 2019 Almost-All Collatz Bound — A Feasibility Anchor",
+  "slug": "collatz-structured-oq-02-oq-03",
+  "description": "Addresses OQ-03 of the Collatz cycle non-existence problem: can Tao's 2019 almost-all result (logarithmic density 1) be formalized in Lean using Mathlib's measure/ergodic theory? Tao's analytic proof (3-adic transport/concentration estimates) is out of reach today, so — mirroring the sibling OQ-02 entry — this file pins down the open question with a precise machine-checkable statement of Tao's theorem (logarithmic density of {n : Col_min(n) < f n} is 1 for every f → ∞) and proves, axiom-free, that two large explicit families already satisfy the elementary 'drops below itself' conclusion: every positive even number (one step) and every power of two (collapses to 1). Single deep axiom (tao_2019); the proven content does not depend on it.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://terrytao.wordpress.com/2019/09/10/almost-all-collatz-orbits-attain-almost-bounded-values/",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/CollatzStructuredOQ02OQ03.lean",
+    "tags": [
+      "number-theory",
+      "collatz",
+      "dynamics",
+      "logarithmic-density",
+      "almost-all",
+      "open-question"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 145,
+    "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "The Collatz conjecture asserts every positive integer's orbit reaches 1. Short of the full conjecture, 'almost all' results bound the orbit for density-one sets of starting values. Terras (1976) and Korec (1994) showed almost all n (in natural density) have finite stopping time — their orbit drops below the starting value. Tao (2019, Forum Math. Pi) gave a dramatically stronger statement: for any f → ∞, almost all n (in the finer logarithmic density) have orbit minimum below f(n), i.e. orbits attain almost bounded values. OQ-03 asks whether this analytic landmark can be formalized in Lean.",
+    "problemStatement": "**OQ-03**: Can Tao's 2019 almost-all result (logarithmic density 1) be formalized in Lean using Mathlib's measure theory and ergodic theory libraries?",
+    "text": "We give a precise Lean statement of Tao's theorem (tao_2019) — pinning the informal 'logarithmic density 1' target to the explicit predicate HasLogDensityOne on the orbit-minimum sublevel sets {n : Col_min(n) < f n} — and we prove, axiom-free, the elementary part of the almost-all picture: the even numbers and the powers of two already drop below themselves by one-line dynamics. The verdict on OQ-03 is recorded honestly: the statement formalizes cleanly; the proof is BLOCKED on concentration/transport estimates Mathlib does not yet have.",
+    "proofStrategy": "Self-contained Collatz map collatz n = if n even then n/2 else 3n+1. (II) even_attainsBelow: for even n ≥ 1, collatz n = n/2 < n (Nat.div_lt_self), so n drops in one step. pow_two_reaches_one: collatz^[k] (2^k) = 1 by induction, using collatz (2·m) = m at each step (2^(k+1) = 2·2^k). pow_two_attainsBelow: 2^k → 1 < 2^k for k ≥ 1. (III) colMin n = sInf of the orbit value set; colMin_le_self (k=0 visits n) and colMin_pow_two_le_one (orbit reaches 1). (IV) HasLogDensityOne S = Tendsto of (∑_{n≤N,n∈S} 1/n)/(∑_{n≤N} 1/n) to 1; tao_2019 states this holds for {n : Col_min(n) < f n} whenever f → ∞.",
+    "keyInsights": [
+      "The open question is upgraded from informal prose to a precise, machine-checkable statement: 'logarithmic density 1' is the predicate HasLogDensityOne, and Tao's theorem is the single axiom tao_2019 quantified over all f → ∞.",
+      "The elementary half of the almost-all phenomenon needs no analysis: every positive even number drops below itself in one Collatz step (n/2 < n), and every power of two collapses to 1 — both proved axiom-free.",
+      "collatz (2·m) = m makes the dyadic collapse collatz^[k] (2^k) = 1 a clean induction, witnessing colMin(2^k) ≤ 1.",
+      "What resists formalization is exactly the analytic core: Tao runs the Syracuse dynamics against tuned measures on the 3-adics and controls their concentration — machinery not present in Mathlib, so a direct proof is BLOCKED (>> 1000 lines)."
+    ],
+    "prerequisites": [
+      "The Collatz / Syracuse map",
+      "Logarithmic vs. natural density of subsets of ℕ",
+      "Filters and Tendsto (for the density-one statement)",
+      "Nat.sInf and infima over orbit value sets"
+    ]
+  },
+  "sections": [
+    {
+      "id": "collatz-map",
+      "title": "The Collatz Map (Self-Contained)",
+      "startLine": 60,
+      "endLine": 73,
+      "summary": "Defines collatz n = if n % 2 = 0 then n / 2 else 3n + 1 and the helper lemmas collatz_even and collatz (2·n) = n.",
+      "mathContext": "$\\mathrm{collatz}(2m) = m$ is the single dynamical fact powering the dyadic collapse."
+    },
+    {
+      "id": "explicit-families",
+      "title": "Two Explicit Families That Drop Below Their Start",
+      "startLine": 75,
+      "endLine": 109,
+      "summary": "AttainsBelow n := ∃ k>0, collatz^[k] n < n. Proves even_attainsBelow (even n ≥ 1 drops in one step), pow_two_reaches_one (collatz^[k] (2^k) = 1), and pow_two_attainsBelow (2^k drops to 1 for k ≥ 1). All axiom-free.",
+      "mathContext": "$\\mathrm{collatz}^{[k]}(2^k) = 1 < 2^k$, so every dyadic starting value attains a value below itself."
+    },
+    {
+      "id": "orbit-min-density",
+      "title": "Orbit Minimum and Logarithmic Density",
+      "startLine": 111,
+      "endLine": 137,
+      "summary": "colMin n = sInf {m : ∃ k, collatz^[k] n = m}; colMin_le_self (visit at k=0) and colMin_pow_two_le_one. logDensity and HasLogDensityOne formalize the 'logarithmic density 1' target via Tendsto.",
+      "mathContext": "$\\mathrm{logDensity}(S,N) = \\left(\\sum_{n\\le N,\\,n\\in S} \\tfrac1n\\right)\\big/\\left(\\sum_{n\\le N}\\tfrac1n\\right)$."
+    },
+    {
+      "id": "tao-axiom",
+      "title": "Tao's Theorem (Axiomatized, Deep)",
+      "startLine": 138,
+      "endLine": 145,
+      "summary": "tao_2019: for every f : ℕ → ℝ with f → ∞, {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. Recorded as an axiom; no file theorem depends on it. The answer to OQ-03: statement formalizes cleanly, proof is BLOCKED on Mathlib-absent concentration estimates.",
+      "mathContext": "Taking $f(n) = n$ recovers 'almost all $n$ have finite stopping time'; arbitrary slow $f$ is the strength."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-03 is given a concrete answer. Tao's 2019 theorem is stated precisely in Lean (tao_2019) so the open question is no longer informal, and the elementary part of the almost-all picture — that the even numbers and the powers of two already drop below themselves — is proved unconditionally and axiom-free. The single axiom isolates exactly the deep analytic content.",
+    "implications": "The 'logarithmic density 1' phrasing formalizes cleanly as a Tendsto statement, and Mathlib's filter/measure plumbing is adequate for the STATEMENT. The PROOF, however, is BLOCKED: Tao's argument controls the evolution of tuned measures on the 3-adics (a transport/concentration estimate) plus a Fourier-analytic input, none of which Mathlib currently provides. Formalizing it is a multi-thousand-line undertaking, not a near-term target.",
+    "openQuestions": [
+      "Can the 3-adic transport/concentration estimate at the heart of Tao's proof be built on top of Mathlib's measure theory?",
+      "Does Mathlib's ergodic-theory library suffice to formalize the Syracuse-dynamics-against-a-measure step, or is new infrastructure required?",
+      "Can the elementary density-one stopping-time result (Terras/Korec) be formalized first as an intermediate milestone toward Tao's stronger bound?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "collatz-structured-oq-02-oq-02",
+      "relationship": "related",
+      "description": "Sibling OQ-02: de-axiomatizes the algebraic core of Eliahou's cycle bound; this entry (OQ-03) anchors the analytic almost-all bound instead"
+    },
+    {
+      "targetId": "collatz-structured-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling OQ-01: extends k-cycle exclusion via case analysis (axiomatizes Eliahou)"
+    },
+    {
+      "targetId": "collatz-structured-oq-02",
+      "relationship": "extends",
+      "description": "Parent: Collatz Cycles — Non-Existence of Small Cycles (CollatzCycles.lean)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Tao, T.",
+      "title": "Almost all orbits of the Collatz map attain almost bounded values",
+      "year": "2019",
+      "venue": "Forum of Mathematics, Pi 8, e9",
+      "note": "Proves that for any f → ∞, the set of n with orbit minimum below f(n) has logarithmic density one"
+    },
+    {
+      "authors": "Terras, R.",
+      "title": "A stopping time problem on the positive integers",
+      "year": "1976",
+      "venue": "Acta Arithmetica 30(3):241–252",
+      "note": "Almost all n (natural density) have finite stopping time — orbit drops below the starting value"
+    },
+    {
+      "authors": "Korec, I.",
+      "title": "A density estimate for the 3x+1 problem",
+      "year": "1994",
+      "venue": "Mathematica Slovaca 44(1):85–89",
+      "note": "Density estimate sharpening the almost-all stopping-time result"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "CollatzStructuredOQ02OQ03",
+    "lineCount": 145,
+    "axiomCount": 1,
+    "theoremCount": 7,
+    "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 5
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-03** of the Collatz cycle problem — *"Can Tao's 2019 almost-all result (logarithmic density 1) be formalized in Lean using Mathlib?"* — with a concrete verdict: the **statement** formalizes cleanly, the **proof** is BLOCKED on analytic machinery Mathlib lacks.

New file `proofs/Proofs/CollatzStructuredOQ02OQ03.lean` (0 sorries, 1 deep axiom), following the accepted sibling pattern of `CollatzStructuredOQ02OQ02.lean` (prove the elementary core, isolate and document the deep part).

### Precise statement of Tao (2019) — `axiom tao_2019`
For every `f : ℕ → ℝ` with `f n → ∞`, the set `{n : 0 < n ∧ Col_min(n) < f n}` has **logarithmic density one** (`HasLogDensityOne`, a `Tendsto` predicate on the partial averages `(∑_{n≤N,n∈S} 1/n)/(∑_{n≤N} 1/n)`). Taking `f n = n` recovers "almost all n have finite stopping time"; arbitrary slow `f` is the strength. **No theorem in the file depends on this axiom.**

### Axiom-free elementary core (the real Lean content)
- `even_attainsBelow` — every positive **even** n drops below itself in one step (`collatz n = n/2 < n`).
- `pow_two_reaches_one` — `collatz^[k] (2^k) = 1`, by induction via `collatz (2·m) = m`.
- `pow_two_attainsBelow`, `colMin_le_self`, `colMin_pow_two_le_one`.

So two large explicit families (the even numbers, the powers of two) are shown unconditionally to satisfy the almost-all conclusion.

## Why the proof is BLOCKED (honest assessment)
Tao's argument evolves tuned measures on the 3-adics and controls their concentration (a transport estimate) plus a Fourier-analytic input — none present in Mathlib. A direct formalization is a multi-thousand-line undertaking. This entry pins the open question down precisely rather than claiming the result.

## Verification
- `lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → exit 0, no errors.
- `#print axioms` on all 7 theorems: only `propext` / `Classical.choice` / `Quot.sound`. The sole declared axiom is `tao_2019`.
- Status `axiomatized`, badge `axiom` (1 deep axiom) — consistent with the Axiom Integrity Policy.

## Files
- `proofs/Proofs/CollatzStructuredOQ02OQ03.lean` (new)
- `src/data/proofs/collatz-structured-oq-02-oq-03/{meta,annotations}.json` (new gallery entry)
- `research/problems/collatz-structured-oq-02-oq-03/{knowledge,state}.md` (refreshed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)