### PR TITLE
Enrich Sign-Free Quadratic Reciprocity: add sections + missing annotations.json

### DIFF
--- a/src/data/proofs/quadratic-gauss-sum-square-oq-03/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "quadratic-gauss-sum-square-oq-03",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "Why p* Makes Reciprocity Sign-Free",
+    "content": "The docstring states the programme: take the parent's identity g² = (−1)^((p−1)/2)·p, name the right-hand side p*, and combine it with a Gauss-sum proof of quadratic reciprocity to reach a self-contained, *sign-free* statement of the law. The classical reciprocity law (q/p) = (−1)^((p−1)(q−1)/4)·(p/q) carries an awkward parity sign; phrased through the starred prime p* = (−1)^((p−1)/2)·p, that sign is absorbed once and for all and the law becomes the perfectly symmetric (p*/q) = (q/p) for all odd primes p, q. This is exactly the form Gauss's own favourite proof — through the quadratic Gauss sum g — produces, and p* is not cosmetic: it is the fundamental discriminant of the quadratic field ℚ(√p*) = ℚ(g) inside the p-th cyclotomic field. The file makes three points: the bridge g² = p*, the congruence p* ≡ 1 (mod 4), and the sign-free law with its symmetric companion and square-test corollary.",
+    "mathContext": "$(q/p) = (-1)^{(p-1)(q-1)/4}(p/q)$ becomes $\\left(\\tfrac{p^*}{q}\\right) = \\left(\\tfrac{q}{p}\\right)$ with $p^* = (-1)^{(p-1)/2}p$.",
+    "significance": "context",
+    "relatedConcepts": ["quadratic reciprocity", "quadratic Gauss sum", "starred prime / fundamental discriminant", "cyclotomic fields", "Legendre symbol"],
+    "prerequisites": ["the Legendre symbol and quadratic residues", "the classical reciprocity law and its sign", "Gauss sums (background)"]
+  },
+  {
+    "id": "ann-pstar-def",
+    "proofId": "quadratic-gauss-sum-square-oq-03",
+    "range": { "startLine": 52, "endLine": 55 },
+    "type": "definition",
+    "title": "The Starred Prime (pStar)",
+    "content": "pStar p = (−1)^((p−1)/2)·(p : ℤ) is the central object: an integer equal to +p when p ≡ 1 (mod 4) and −p when p ≡ 3 (mod 4). It is precisely the value of the square of the quadratic Gauss sum (established by gaussSquare_eq_pStar below), and it is the fundamental discriminant of the quadratic subfield ℚ(√p*) = ℚ(g) of the p-th cyclotomic field. Defining it once lets every later statement carry the reciprocity sign implicitly, which is the whole point of the file.",
+    "mathContext": "$p^* = (-1)^{(p-1)/2}\\,p \\in \\mathbb{Z}$; $p^* = +p$ if $p \\equiv 1\\,(4)$, $p^* = -p$ if $p \\equiv 3\\,(4)$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental discriminant", "quadratic field ℚ(√p*)", "the sign (−1)^((p−1)/2)", "integer normalisation"],
+    "prerequisites": ["modular arithmetic mod 4", "the exponent (p−1)/2 for odd p"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "quadratic-gauss-sum-square-oq-03",
+    "range": { "startLine": 57, "endLine": 107 },
+    "type": "theorem",
+    "title": "The Bridge g² = p* from Mathlib's Generic Gauss-Sum Square",
+    "content": "The Bridge section makes the file self-contained by re-deriving the parent's headline from Mathlib's generic gaussSum_sq. chiC p is the ℂ-valued quadratic character (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ); the helper lemmas establish it is quadratic (chiC_isQuadratic), non-trivial for p ≠ 2 (chiC_ne_one), and evaluate the first supplement chiC p (−1) = (−1)^((p−1)/2) (chiC_neg_one, via quadraticChar_neg_one and ZMod.χ₄_eq_neg_one_pow, with the index shift p/2 = (p−1)/2 for odd p). The headline gaussSquare_eq_pStar then computes, for any primitive additive character ψ: gaussSum(chiC, ψ)² = chiC(−1)·#(ZMod p) (this is exactly gaussSum_sq) = (−1)^((p−1)/2)·p = (p* : ℂ). So g² = p* is recovered without importing the parent, anchoring the p* normalisation in the Gauss sum itself.",
+    "mathContext": "$g^2 = \\chi(-1)\\cdot\\#(\\mathbb{Z}/p\\mathbb{Z}) = (-1)^{(p-1)/2}\\cdot p = (p^* : \\mathbb{C})$, from `gaussSum_sq`.",
+    "significance": "key",
+    "relatedConcepts": ["gaussSum_sq", "quadraticChar / MulChar.ringHomComp", "first supplement χ(−1) = (−1)^((p−1)/2)", "primitive additive character", "ZMod.χ₄_eq_neg_one_pow"],
+    "prerequisites": ["quadratic characters on ZMod p", "Mathlib's generic Gauss-sum square identity", "transporting a character along a ring hom"]
+  },
+  {
+    "id": "ann-mod-four",
+    "proofId": "quadratic-gauss-sum-square-oq-03",
+    "range": { "startLine": 109, "endLine": 135 },
+    "type": "theorem",
+    "title": "p* ≡ 1 (mod 4) (pStar_mod_four)",
+    "content": "pStar_mod_four proves p* ≡ 1 (mod 4) for every odd prime p — the arithmetic reason p* (not ±p) is the natural normalisation, since a fundamental discriminant must be ≡ 0 or 1 (mod 4). Writing p = 2m+1, the exponent (p−1)/2 = m, and the proof splits on the parity of m. If m is even, (−1)^m = 1 so p* = p, and p ≡ 1 (mod 4) (p = 4j+1); if m is odd, (−1)^m = −1 so p* = −p, and p ≡ 3 (mod 4) gives −p ≡ 1 (mod 4). Each branch is discharged by exhibiting the explicit divisor via Int.modEq_iff_dvd and closing with ring. The same sign (−1)^((p−1)/2) that defines p* is what forces the congruence — it flips exactly when p switches residue class mod 4.",
+    "mathContext": "$m = (p-1)/2$: $m$ even $\\Rightarrow p^* = p \\equiv 1\\,(4)$; $m$ odd $\\Rightarrow p^* = -p$ with $p \\equiv 3\\,(4)$, so $p^* \\equiv 1\\,(4)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental discriminant ≡ 1 (mod 4)", "Int.modEq_iff_dvd", "parity of (p−1)/2", "Even/Odd.neg_one_pow"],
+    "prerequisites": ["integer congruences [ZMOD 4]", "case split on parity", "the omega and ring tactics"]
+  },
+  {
+    "id": "ann-reciprocity",
+    "proofId": "quadratic-gauss-sum-square-oq-03",
+    "range": { "startLine": 137, "endLine": 181 },
+    "type": "theorem",
+    "title": "Sign-Free Reciprocity (pStar_reciprocity, pStar_reciprocity_symm)",
+    "content": "pStar_reciprocity is the heart: (p*/q) = (q/p) for odd primes p, q. Expanding the Legendre symbol over p* = (−1)^((p−1)/2)·p multiplicatively (legendreSym.mul) and evaluating the first supplement legendreSym q (−1) = (−1)^(q/2) gives the key identity (p*/q) = (−1)^(q/2·p/2)·(q/p) (after the index shift (p−1)/2 = p/2). Substituting Mathlib's classical legendreSym.quadratic_reciprocity' rewrites (q/p) and introduces a second sign (−1)^(p/2·q/2); the two signs are equal powers of −1, so their product is (−1)^(2·(p/2·q/2)) = 1 (Even.neg_one_pow), leaving (p*/q) = (q/p). The cancellation 'two equal signs multiply to 1' IS the entire content of the sign-free law — the parity bookkeeping of the classical statement is absorbed into p*. pStar_reciprocity_symm is literally pStar_reciprocity with p and q exchanged, displaying the genuine symmetry (q*/p) = (p/q).",
+    "mathContext": "$\\left(\\tfrac{p^*}{q}\\right) = (-1)^{\\frac{q}{2}\\frac{p}{2}}\\left(\\tfrac{q}{p}\\right)$ and $\\left(\\tfrac{q}{p}\\right) = (-1)^{\\frac{p}{2}\\frac{q}{2}}\\left(\\tfrac{p}{q}\\right)^{-1}$ combine via $(-1)^{2a}=1$.",
+    "significance": "key",
+    "relatedConcepts": ["legendreSym.quadratic_reciprocity'", "legendreSym.mul / at_neg_one", "Even.neg_one_pow", "sign cancellation", "symmetry of reciprocity"],
+    "prerequisites": ["multiplicativity of the Legendre symbol", "Mathlib's classical quadratic reciprocity", "the first supplement (−1/q)"]
+  },
+  {
+    "id": "ann-square-test",
+    "proofId": "quadratic-gauss-sum-square-oq-03",
+    "range": { "startLine": 183, "endLine": 207 },
+    "type": "theorem",
+    "title": "Square-Solvability Form (pStar_isSquare_iff)",
+    "content": "pStar_isSquare_iff packages the sign-free law as an equivalence of concrete congruence solvability: for distinct odd primes, IsSquare ((p* : ℤ) : ZMod q) ↔ IsSquare ((q : ℤ) : ZMod p), i.e. x² ≡ p* (mod q) is solvable iff x² ≡ q (mod p) is. The proof first records that distinct primes do not divide each other (q ∤ p and p ∤ q, via Nat.prime_dvd_prime_iff_eq), which makes both residues units: (p* : ZMod q) ≠ 0 (checked on each sign branch of p*) and (q : ZMod p) ≠ 0. It then rewrites each IsSquare through legendreSym.eq_one_iff (Legendre symbol 1 ⟺ a nonzero square) and applies pStar_reciprocity. The hypothesis p ≠ q is exactly what guarantees the unit condition that eq_one_iff needs; without it a residue could be 0 and the equivalence would fail.",
+    "mathContext": "$x^2 \\equiv p^* \\pmod q \\iff x^2 \\equiv q \\pmod p$, via $\\left(\\tfrac{a}{p}\\right) = 1 \\iff a$ a nonzero square (`legendreSym.eq_one_iff`) and the sign-free law.",
+    "significance": "supporting",
+    "relatedConcepts": ["legendreSym.eq_one_iff", "IsSquare in ZMod", "Nat.prime_dvd_prime_iff_eq", "units mod a prime", "ZMod.intCast_zmod_eq_zero_iff_dvd"],
+    "prerequisites": ["the sign-free reciprocity law", "Legendre symbol = 1 iff nonzero square", "distinct primes are coprime"]
+  }
+]

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-03/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-03/meta.json
@@ -51,6 +51,48 @@
       "The square-solvability form $x^2 \\equiv p^* \\pmod q \\iff x^2 \\equiv q \\pmod p$ is the sign-free law read through `eq_one_iff`; the only side condition is that $p \\ne q$, which guarantees both residues are units."
     ]
   },
+  "sections": [
+    {
+      "id": "starred-prime",
+      "title": "The Starred Prime p*",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Docstring framing the goal — absorb the (−1)^((p−1)(q−1)/4) sign of reciprocity into a normalisation — and the definition pStar p = (−1)^((p−1)/2)·p, the value of g² and the fundamental discriminant of the quadratic subfield of the p-th cyclotomic field.",
+      "mathContext": "$p^* := (-1)^{(p-1)/2}\\,p$, the value of $g^2$."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge g² = p* for the Complex Gauss Sum",
+      "startLine": 57,
+      "endLine": 107,
+      "summary": "The ℂ-valued quadratic character chiC (transported from quadraticChar (ZMod p) along ℤ → ℂ), its quadratic/non-trivial/first-supplement lemmas, and gaussSquare_eq_pStar: for a primitive additive character ψ, gaussSum(chiC, ψ)² = (p* : ℂ), re-derived from Mathlib's generic gaussSum_sq so the file is self-contained.",
+      "mathContext": "$\\left(\\sum_n \\chi(n)\\psi(n)\\right)^2 = \\chi(-1)\\cdot\\#(\\mathbb{Z}/p) = (-1)^{(p-1)/2}p = p^*$."
+    },
+    {
+      "id": "mod-four",
+      "title": "p* ≡ 1 (mod 4)",
+      "startLine": 109,
+      "endLine": 135,
+      "summary": "pStar_mod_four: for every odd prime p, p* ≡ 1 (mod 4). The proof splits on the parity of (p−1)/2 — p ≡ 1 (mod 4) keeps p* = p ≡ 1, p ≡ 3 (mod 4) flips to p* = −p ≡ 1 — each case closed by Int.modEq_iff_dvd and ring. This is why p*, not ±p, is the fundamental discriminant.",
+      "mathContext": "$p \\equiv 1\\,(4) \\Rightarrow p^* = p \\equiv 1$; $p \\equiv 3\\,(4) \\Rightarrow p^* = -p \\equiv 1\\,(4)$."
+    },
+    {
+      "id": "reciprocity",
+      "title": "Sign-Free Reciprocity (p*/q) = (q/p)",
+      "startLine": 137,
+      "endLine": 181,
+      "summary": "pStar_reciprocity expands (p*/q) multiplicatively, evaluates the (−1)^((p−1)/2) factor via the first supplement, substitutes Mathlib's classical legendreSym.quadratic_reciprocity', and collapses the doubled sign (−1)^(q/2·p/2)·(−1)^(p/2·q/2) = 1 via Even.neg_one_pow. pStar_reciprocity_symm is the same with p, q swapped, exhibiting the symmetry.",
+      "mathContext": "$\\left(\\tfrac{p^*}{q}\\right) = \\left(\\tfrac{q}{p}\\right)$; the sign cancels as $(-1)^{a}(-1)^{a} = 1$."
+    },
+    {
+      "id": "square-test",
+      "title": "Square-Solvability Form",
+      "startLine": 183,
+      "endLine": 207,
+      "summary": "pStar_isSquare_iff: for distinct odd primes, p* is a square mod q iff q is a square mod p, obtained by reading the sign-free law through legendreSym.eq_one_iff. The side condition p ≠ q guarantees both residues are units (distinct primes do not divide each other).",
+      "mathContext": "$x^2 \\equiv p^* \\pmod q \\iff x^2 \\equiv q \\pmod p$ for distinct odd primes $p \\ne q$."
+    }
+  ],
   "conclusion": {
     "summary": "For all odd primes $p, q$ the entry machine-verifies the sign-free reciprocity law $\\left(\\frac{p^*}{q}\\right) = \\left(\\frac{q}{p}\\right)$ with $p^* = (-1)^{(p-1)/2} p$, the value of the square of the quadratic Gauss sum, together with $p^* \\equiv 1 \\pmod 4$ and the equivalence of $x^2 \\equiv p^* \\pmod q$ and $x^2 \\equiv q \\pmod p$. The Gauss-sum square $g^2 = p^*$ is re-derived from Mathlib so the development is self-contained, with no axioms and no sorries.",
     "implications": "The sign-free form is the practically useful one: it makes reciprocity a symmetric relation between $p^*$ and $q$, eliminates parity bookkeeping in Legendre-symbol computations, and exposes $p^*$ as the discriminant governing the quadratic subfield of the cyclotomic field. It packages the parent's algebraic square identity and Mathlib's classical reciprocity into a single clean statement, completing the 'combine $g^2 = p^*$ with reciprocity' programme posed by the parent entry.",


### PR DESCRIPTION
Enrichment pass for `quadratic-gauss-sum-square-oq-03` (quality 33, passes 0).

## Gaps
Strong overview/conclusion, but **0 sections** and **no `annotations.json`** — the proof page had neither a section outline nor inline annotations.

## Change
- **5 sections** covering the full 209-line Lean file, each with `mathContext`: the starred prime `p*`, the bridge `g² = p*`, `p* ≡ 1 (mod 4)`, sign-free reciprocity, and the square-test form.
- **6 annotations** with full fields (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  1. **overview** (1–45) — why `p*` makes reciprocity sign-free (the parity sign is absorbed into the normalisation).
  2. **pStar** (52–55) — the starred prime definition / fundamental discriminant.
  3. **bridge** (57–107) — `gaussSquare_eq_pStar` re-derived from Mathlib's `gaussSum_sq`.
  4. **pStar_mod_four** (109–135) — `p* ≡ 1 (mod 4)` by parity split.
  5. **pStar_reciprocity** (137–181) — the sign cancellation `(-1)^a(-1)^a = 1` IS the law; plus the symmetric companion.
  6. **pStar_isSquare_iff** (183–207) — square-solvability form via `legendreSym.eq_one_iff`.

## Notes
- Pure data; no TypeScript touched. `annotations:build` exits clean with **no warnings for this proof**.
- `status: verified` / `axiomCount: 0` / 0 sorries confirmed against the Lean source.
- Dedicated branch to stay independent of sibling enrichment PRs.