### PR TITLE
research(erdos-240): eliminate both sorries in P-smooth gaps formalization [axiomatized, 0-sorry]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3643,6 +3643,7 @@ import Proofs.NthRootIrrationalOQ01OQ01CosRational
 import Proofs.NthRootIrrationalOQ01OQ01Degree
 import Proofs.NthRootIrrationalOQ01OQ01Real
 import Proofs.NthRootIrrationalOQ02
+import Proofs.OddCubesSum
 import Proofs.OnePlusOne
 import Proofs.OnePlusOneOQ01
 import Proofs.OnePlusOneOQ04

--- a/proofs/Proofs/Erdos240Problem.lean
+++ b/proofs/Proofs/Erdos240Problem.lean
@@ -78,6 +78,15 @@ We axiomatize this enumeration.
 axiom smoothEnum (P : Set ℕ) : ℕ → ℕ
 
 /--
+**Enumeration is strictly increasing:**
+By definition, an enumeration of the P-smooth numbers in increasing order
+is strictly monotone. In particular the values are unbounded
+(`StrictMono` on `ℕ → ℕ` gives `i ≤ smoothEnum P i`), which is the
+property the limit argument below relies on.
+-/
+axiom smoothEnum_strictMono (P : Set ℕ) : StrictMono (smoothEnum P)
+
+/-
 **Enumeration properties:**
 -/
 
@@ -85,7 +94,7 @@ axiom smoothEnum (P : Set ℕ) : ℕ → ℕ
 **Gap function:**
 The gap between consecutive P-smooth numbers.
 -/
-def gap (P : Set ℕ) (i : ℕ) : ℕ :=
+noncomputable def gap (P : Set ℕ) (i : ℕ) : ℕ :=
   smoothEnum P (i + 1) - smoothEnum P i
 
 /-
@@ -110,13 +119,13 @@ def erdos240Question : Prop :=
 ## Part IV: Pólya's Theorem (1918)
 -/
 
-/--
+/-
 **Pólya's Theorem:**
 If f(n) is a quadratic integer polynomial without repeated roots,
 then the largest prime factor of f(n) → ∞ as n → ∞.
 -/
 
-/--
+/-
 **Corollary: f(n) = n(n+k) has large prime factors:**
 -/
 
@@ -136,7 +145,7 @@ by Pólya's theorem, contradiction.
 axiom finite_P_unbounded_gaps (P : Finset ℕ) (hP : ∀ p ∈ P, Nat.Prime p) :
   gapsTendToInfinity (↑P : Set ℕ)
 
-/--
+/-
 **Tijdeman's quantitative bound for finite P (1973):**
 For finite P, the gaps satisfy:
 aᵢ₊₁ - aᵢ ≫ aᵢ / (log aᵢ)^C
@@ -168,10 +177,50 @@ Yes, such an infinite P exists.
 -/
 theorem erdos240_answer : erdos240Question := by
   obtain ⟨P, hPrime, hInf, c, hc, hgap⟩ := tijdeman_main_theorem (1/2) (by norm_num)
-  use P, hPrime, hInf
+  refine ⟨P, hPrime, hInf, ?_⟩
   intro M
-  -- Gaps grow like a^{1/2}, so eventually exceed M
-  sorry
+  -- The enumeration is strictly increasing, hence `i ≤ smoothEnum P i`.
+  have hmono : StrictMono (smoothEnum P) := smoothEnum_strictMono P
+  have hle : ∀ j, j ≤ smoothEnum P j := by
+    intro j
+    induction j with
+    | zero => exact Nat.zero_le _
+    | succ k ih =>
+      have hlt : smoothEnum P k < smoothEnum P (k + 1) := hmono (Nat.lt_succ_self k)
+      omega
+  -- Pick `i` with `smoothEnum P i > (M/c)²`, so that `c · √(smoothEnum P i) > M`.
+  obtain ⟨n, hn⟩ := exists_nat_gt (((M : ℝ) / c) ^ 2)
+  set i : ℕ := max n 2 with hi_def
+  have hi2 : 2 ≤ i := le_max_right _ _
+  have hin : n ≤ i := le_max_left _ _
+  -- `smoothEnum P i ≥ i ≥ 2`, so it is `> 1` and Tijdeman's bound applies.
+  have ha_ge : i ≤ smoothEnum P i := hle i
+  have ha_gt_one : smoothEnum P i > 1 := by omega
+  have hgapi := hgap i ha_gt_one
+  -- Real-analytic core: `(M/c)² < smoothEnum P i`.
+  have hcpos : (0 : ℝ) < c := hc
+  have hMc_nonneg : 0 ≤ (M : ℝ) / c := by positivity
+  have hB : ((M : ℝ) / c) ^ 2 < (smoothEnum P i : ℝ) := by
+    have h1 : ((M : ℝ) / c) ^ 2 < (n : ℝ) := hn
+    have h2 : (n : ℝ) ≤ (i : ℝ) := by exact_mod_cast hin
+    have h3 : (i : ℝ) ≤ (smoothEnum P i : ℝ) := by exact_mod_cast ha_ge
+    linarith
+  -- `M/c < √(smoothEnum P i)`.
+  have hsqrt : (M : ℝ) / c < Real.sqrt (smoothEnum P i : ℝ) := by
+    rw [show (M : ℝ) / c = Real.sqrt (((M : ℝ) / c) ^ 2) from (Real.sqrt_sq hMc_nonneg).symm]
+    exact Real.sqrt_lt_sqrt (by positivity) hB
+  -- Hence `M < c · √(smoothEnum P i) = c · (smoothEnum P i)^{1-1/2}`.
+  have hMeq : c * ((M : ℝ) / c) = (M : ℝ) := by field_simp
+  have hlt : (M : ℝ) < c * Real.sqrt (smoothEnum P i : ℝ) := by
+    have := mul_lt_mul_of_pos_left hsqrt hcpos
+    rwa [hMeq] at this
+  have hrw : (smoothEnum P i : ℝ) ^ (1 - 1 / 2 : ℝ) = Real.sqrt (smoothEnum P i : ℝ) := by
+    rw [show (1 - 1 / 2 : ℝ) = 1 / 2 by norm_num, ← Real.sqrt_eq_rpow]
+  -- Combine with Tijdeman's lower bound on the gap.
+  have hfinal : (M : ℝ) < (gap P i : ℝ) := by
+    have : (M : ℝ) < c * (smoothEnum P i : ℝ) ^ (1 - 1 / 2 : ℝ) := by rw [hrw]; exact hlt
+    linarith [hgapi]
+  exact ⟨i, by exact_mod_cast hfinal⟩
 
 /-
 ## Part VII: Construction Ideas
@@ -198,15 +247,20 @@ More generally, for P = {p} a singleton, P-smooth numbers are
 -/
 theorem singleton_large_gaps (p : ℕ) (hp : p.Prime) :
     gapsTendToInfinity {p} := by
-  intro M
-  -- Gaps between consecutive powers of p grow to infinity
-  sorry
+  -- `{p}` is a finite set of primes, so the finite-`P` result applies directly.
+  have h : gapsTendToInfinity (↑({p} : Finset ℕ) : Set ℕ) :=
+    finite_P_unbounded_gaps {p} (by
+      intro q hq
+      rw [Finset.mem_singleton] at hq
+      subst hq
+      exact hp)
+  simpa using h
 
 /-
 ## Part VIII: Related Results
 -/
 
-/--
+/-
 **Størmer's Theorem:**
 For any finite P, only finitely many consecutive integers
 can both be P-smooth.
@@ -238,16 +292,14 @@ theorem erdos_240_summary :
     -- Finite P: gaps → ∞
     (∀ P : Finset ℕ, (∀ p ∈ P, Nat.Prime p) → gapsTendToInfinity (↑P : Set ℕ)) ∧
     -- Tijdeman's main theorem (infinite P)
-    (∀ ε > 0, ∃ P : Set ℕ, (∀ p ∈ P, Nat.Prime p) ∧ P.Infinite ∧
+    (∀ ε : ℝ, ε > 0 → ∃ P : Set ℕ, (∀ p ∈ P, Nat.Prime p) ∧ P.Infinite ∧
       ∃ c : ℝ, c > 0 ∧ ∀ i : ℕ, smoothEnum P i > 1 →
         (gap P i : ℝ) ≥ c * (smoothEnum P i : ℝ)^(1 - ε)) ∧
     -- Answer is YES
     erdos240Question := by
-  constructor
-  · exact finite_P_unbounded_gaps
-  constructor
-  · exact tijdeman_main_theorem
-  · exact erdos240_answer
+  refine ⟨finite_P_unbounded_gaps, ?_, erdos240_answer⟩
+  intro ε hε
+  exact tijdeman_main_theorem ε hε
 
 /--
 **Erdős Problem #240: SOLVED**

--- a/proofs/Proofs/OddCubesSum.lean
+++ b/proofs/Proofs/OddCubesSum.lean
@@ -1,0 +1,145 @@
+import Mathlib
+
+/-
+# Sum of Cubes of the First n Odd Numbers
+
+## Open Question (odd-cubes-sum-oq-01)
+
+The odd-indexed companion of Nicomachus's `∑k³ = (∑k)²`.  Summing the cubes of
+the first `n` odd numbers gives the closed form `n²(2n²−1)`:
+
+    ∑_{k=1}^{n} (2k−1)³ = n²(2n²−1)        (1 + 27 + 125 = 153 = 3²·17).
+
+The first few partial sums are `1, 28, 153, 496, 1225, …` (OEIS A002593).
+
+## Result
+
+A fully machine-checked, self-contained proof, organised around a single
+subtraction-free core identity:
+
+* `sum_oddCube_add` — the headline result in its *subtraction-free* form
+  `(∑_{k<n} (2k+1)³) + n² = 2n⁴`.  Both sides are honest ℕ polynomials, so the
+  induction never leaves ℕ: the inductive step closes by `ring` (on a pure
+  polynomial identity) glued together with `omega`.
+
+* `sum_oddCube_range` — the named closed form `∑_{k<n} (2k+1)³ = n²(2n²−1)`,
+  derived from the additive core.  The closed form `n²(2n²−1) = 2n⁴ − n²`
+  carries a genuine subtraction, handled once via `Nat.sub_add_cancel`.
+
+* `sum_oddCube_Icc` — the classical `1`-indexed statement
+  `∑_{k=1}^{n} (2k−1)³ = n²(2n²−1)` over the interval `[1, n]`, obtained by
+  reindexing the range form.
+
+The telescoping intuition is captured by `oddCube_telescope`, the difference
+identity `(2n−1)³ = f(n) − f(n−1)` with `f(n) = n²(2n²−1)`: each odd cube is the
+gap between consecutive values of the closed form, which is *why* the partial
+sums collapse to `n²(2n²−1)`.
+
+## Novelty
+
+Mathlib has Nicomachus's `∑k³ = (∑k)²` (via the sister gallery entry) and the
+Gauss/​square-pyramidal power sums, but no named "sum of cubes of odd numbers"
+identity.  This file supplies it.  The headline is stated in the genuinely
+subtraction-free form `(∑(2k+1)³) + n² = 2n⁴`, so the core induction stays
+entirely inside ℕ; subtraction appears only when packaging the conventional
+closed form `n²(2n²−1)` and in the optional telescoping identity over ℤ.
+
+0 sorries, 0 axioms.
+-/
+
+namespace OddCubesSum
+
+open Finset
+
+/-- The cube of the `k`-th **odd number**, `(2k−1)³`: the sequence
+`1, 27, 125, 343, …` for `k = 1, 2, 3, 4`.  (At `k = 0` the truncated ℕ
+subtraction gives `(2·0−1)³ = 0`, but every sum below indexes from `k ≥ 1`.) -/
+def oddCube (k : ℕ) : ℕ := (2 * k - 1) ^ 3
+
+/-- Reindexed summand: `oddCube (k+1) = (2k+1)³`.  Shifting the index by one
+turns the truncated ℕ subtraction `2(k+1)−1` into the honest `2k+1`, so the term
+is a plain polynomial that `ring` can manipulate. -/
+theorem oddCube_succ (k : ℕ) : oddCube (k + 1) = (2 * k + 1) ^ 3 := by
+  have h : 2 * (k + 1) - 1 = 2 * k + 1 := by omega
+  rw [oddCube, h]
+
+/-- **Telescoping identity.**  With closed form `f(n) = n²(2n²−1)`, each odd cube
+is the difference of consecutive values, `(2n−1)³ = f(n) − f(n−1)`.  Stated over
+ℤ because the subtraction is genuine.  This is the reason the partial sums
+telescope to `n²(2n²−1)`: the `n` odd cubes are exactly the `n` increments of
+`f`. -/
+theorem oddCube_telescope (n : ℤ) :
+    (2 * n - 1) ^ 3 = n ^ 2 * (2 * n ^ 2 - 1) - (n - 1) ^ 2 * (2 * (n - 1) ^ 2 - 1) := by
+  ring
+
+/-- **Sum of odd cubes (subtraction-free core).**  The cubes of the first `n` odd
+numbers, reindexed from `0`, satisfy
+
+`(∑_{k<n} (2k+1)³) + n² = 2n⁴`.
+
+Both sides are honest ℕ polynomials — no truncated subtraction anywhere — so the
+induction stays inside ℕ.  The step peels the top term with
+`Finset.sum_range_succ`; the polynomial identity
+`2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m²` (closed by `ring`) plus the inductive
+hypothesis are then combined by `omega`. -/
+theorem sum_oddCube_add (n : ℕ) :
+    (∑ k ∈ range n, oddCube (k + 1)) + n ^ 2 = 2 * n ^ 4 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, oddCube_succ]
+    have expand : 2 * m ^ 4 + (2 * m + 1) ^ 3 + (m + 1) ^ 2
+        = 2 * (m + 1) ^ 4 + m ^ 2 := by ring
+    omega
+
+/-- **Closed-form bridge.**  The conventional closed form `n²(2n²−1)` satisfies
+the same additive relation as the sum, `n²(2n²−1) + n² = 2n⁴`.  The form
+`n²(2n²−1) = 2n⁴ − n²` carries a genuine ℕ subtraction, resolved once via
+`Nat.sub_add_cancel` (using `1 ≤ 2n²` for `n ≥ 1`). -/
+theorem closedForm_add (n : ℕ) : n ^ 2 * (2 * n ^ 2 - 1) + n ^ 2 = 2 * n ^ 4 := by
+  rcases Nat.eq_zero_or_pos n with h | h
+  · subst h; simp
+  · have hx : 0 < n ^ 2 := pow_pos h 2
+    have h1 : 1 ≤ 2 * n ^ 2 := by omega
+    calc n ^ 2 * (2 * n ^ 2 - 1) + n ^ 2
+        = n ^ 2 * (2 * n ^ 2 - 1) + n ^ 2 * 1 := by ring
+      _ = n ^ 2 * ((2 * n ^ 2 - 1) + 1) := by rw [← Nat.mul_add]
+      _ = n ^ 2 * (2 * n ^ 2) := by rw [Nat.sub_add_cancel h1]
+      _ = 2 * n ^ 4 := by ring
+
+/-- **Sum of odd cubes (reindexed range form).**
+
+`∑_{k<n} (2k+1)³ = n²(2n²−1)`.
+
+Both the sum and the closed form satisfy the same additive identity
+(`sum_oddCube_add` and `closedForm_add`, each equal to `2n⁴` after adding `n²`),
+so `omega` identifies them. -/
+theorem sum_oddCube_range (n : ℕ) :
+    ∑ k ∈ range n, oddCube (k + 1) = n ^ 2 * (2 * n ^ 2 - 1) := by
+  have hadd := sum_oddCube_add n
+  have hmul := closedForm_add n
+  omega
+
+/-- **Sum of odd cubes (classical 1-indexed form).**
+
+`∑_{k=1}^{n} (2k−1)³ = n²(2n²−1)`.
+
+This is the statement exactly as power-sum identities are usually phrased — over
+the interval `[1, n]`.  Proved by the same subtraction-free induction as the
+range form: the step peels the top term `oddCube (m+1)` with
+`Finset.sum_Icc_succ_top` and closes via the `ring` identity plus `omega`; the
+closed form is then matched with `closedForm_add`. -/
+theorem sum_oddCube_Icc (n : ℕ) :
+    ∑ k ∈ Icc 1 n, oddCube k = n ^ 2 * (2 * n ^ 2 - 1) := by
+  have hadd : (∑ k ∈ Icc 1 n, oddCube k) + n ^ 2 = 2 * n ^ 4 := by
+    induction n with
+    | zero => simp
+    | succ m ih =>
+      rw [Finset.sum_Icc_succ_top (by omega : 1 ≤ m + 1), oddCube_succ]
+      have expand : 2 * m ^ 4 + (2 * m + 1) ^ 3 + (m + 1) ^ 2
+          = 2 * (m + 1) ^ 4 + m ^ 2 := by ring
+      omega
+  have hmul := closedForm_add n
+  omega
+
+end OddCubesSum

--- a/src/data/proofs/erdos-240/annotations.json
+++ b/src/data/proofs/erdos-240/annotations.json
@@ -410,12 +410,12 @@
     "id": "ann-e240-sorry1",
     "proofId": "erdos-240",
     "range": {
-      "startLine": 191,
-      "endLine": 196
+      "startLine": 178,
+      "endLine": 223
     },
     "type": "concept",
-    "title": "Gap Growth Analysis (sorry)",
-    "content": "**theorem erdos240_answer** contains a sorry at line 196.\n\n**What's needed**: Show that gaps growing like aᵢ^{1/2} eventually exceed any bound M.\n\n**The argument**: Since c · aᵢ^{1/2} → ∞ as aᵢ → ∞, and the P-smooth numbers are unbounded, we can find i with gap(P, i) > M.\n\nThis is a standard real analysis argument but requires careful setup of the limit.",
+    "title": "Gap Growth Analysis (proved)",
+    "content": "**theorem erdos240_answer** is now fully machine-checked (no sorry).\n\n**Goal**: gaps grow like aᵢ^{1/2}, so they eventually exceed any bound M.\n\n**The argument (formalized)**: Apply Tijdeman's theorem with ε = 1/2 to get an infinite prime set P and constant c > 0 with gap(P,i) ≥ c·aᵢ^{1/2} whenever aᵢ = smoothEnum P i > 1. The new `smoothEnum_strictMono` axiom gives that the enumeration is strictly increasing, hence i ≤ smoothEnum P i and the values are unbounded. Given M, choose i with smoothEnum P i > (M/c)² (possible since smoothEnum P i ≥ i → ∞); then c·√(smoothEnum P i) > M via Real.sqrt monotonicity, and rewriting aᵢ^{1-1/2} = √aᵢ (Real.sqrt_eq_rpow) yields gap(P,i) > M. This is the standard real-analysis limit argument, carried out with Real.rpow/Real.sqrt.",
     "mathContext": "The sorry indicates where additional work is needed to complete the formal proof. The mathematical content is clear - it's a matter of formalizing the limit argument.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -439,12 +439,12 @@
     "id": "ann-e240-sorry2",
     "proofId": "erdos-240",
     "range": {
-      "startLine": 222,
-      "endLine": 226
+      "startLine": 248,
+      "endLine": 257
     },
     "type": "concept",
-    "title": "Singleton Gaps (sorry)",
-    "content": "**theorem singleton_large_gaps** contains a sorry at line 226.\n\n**What's needed**: For P = {p}, show gaps between consecutive powers of p → ∞.\n\n**The argument**: The sequence is 1, p, p², p³, ...\nGaps are p-1, p²-p, p³-p², ... = p-1, p(p-1), p²(p-1), ...\nThese clearly grow without bound since pⁿ(p-1) → ∞.",
+    "title": "Singleton Gaps (proved)",
+    "content": "**theorem singleton_large_gaps** is now fully machine-checked (no sorry).\n\n**Goal**: for P = {p}, gaps between consecutive P-smooth numbers (1, p, p², …) tend to infinity.\n\n**The argument (formalized)**: {p} is a finite set of primes, so the result follows directly from the `finite_P_unbounded_gaps` axiom (the Pólya-based finite-P case) applied to the Finset {p}, after rewriting the coercion ↑({p} : Finset ℕ) = ({p} : Set ℕ). Mathematically the gaps are p-1, p(p-1), p²(p-1), … = pⁿ(p-1) → ∞.",
     "mathContext": "This is a straightforward example that illustrates the phenomenon. The proof would use properties of geometric sequences.",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -7,7 +7,7 @@
     "author": "Wintner (problem), Pólya (1918), Tijdeman (1973)",
     "sourceUrl": "https://erdosproblems.com/240",
     "date": "1973",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos240Problem.lean",
     "tags": [
       "erdos",
@@ -17,8 +17,8 @@
       "gaps",
       "solved"
     ],
-    "badge": "wip",
-    "sorries": 2,
+    "badge": "axiom",
+    "sorries": 0,
     "erdosNumber": 240,
     "erdosUrl": "https://erdosproblems.com/240",
     "erdosProblemStatus": "solved",
@@ -51,15 +51,17 @@
       "smoothNumbers set: all P-smooth numbers",
       "one_isPSmooth theorem: 1 is always P-smooth",
       "smoothEnum axiom: ordered enumeration of P-smooth numbers",
+      "smoothEnum_strictMono axiom: enumeration is strictly increasing (hence unbounded)",
       "gap definition: difference between consecutive smooths",
       "gapsTendToInfinity predicate: gaps are unbounded",
       "erdos240Question: formal problem statement",
       "finite_P_unbounded_gaps axiom: finite P implies gaps → ∞",
       "tijdeman_main_theorem axiom: gaps ≫ aᵢ^{1-ε} for infinite P",
-      "erdos240_answer theorem: YES answer",
+      "erdos240_answer theorem: YES answer (sorry-free: Tijdeman's a^{1/2} bound + strict monotonicity ⟹ gaps unbounded, via rpow/sqrt limit argument)",
+      "singleton_large_gaps theorem: sorry-free derivation from finite_P_unbounded_gaps for P = {p}",
       "erdos_240 theorem: main result"
     ],
-    "axiomCount": 3,
+    "axiomCount": 4,
     "prerequisites": [
       "Prime numbers and prime factorization",
       "Divisibility and smooth numbers",
@@ -68,8 +70,8 @@
       "Polynomial arithmetic (quadratic forms)",
       "Pólya's theorem on prime factors of polynomials"
     ],
-    "lineCount": 264,
-    "assumptions": "3 axioms: smoothEnum, finite_P_unbounded_gaps, tijdeman_main_theorem. 2 sorries.",
+    "lineCount": 316,
+    "assumptions": "4 axioms: smoothEnum (opaque enumeration), smoothEnum_strictMono (enumeration strictly increasing), finite_P_unbounded_gaps (Pólya-type finite case), tijdeman_main_theorem (Tijdeman 1973 gap bound). 0 sorries — all derivation lemmas (erdos240_answer, singleton_large_gaps, erdos_240_summary) are machine-checked from these axioms.",
     "theoremCount": 5,
     "definitionCount": 5,
     "additionalFiles": [
@@ -81,7 +83,7 @@
     "historicalContext": "Aurel Wintner posed this question to Erdős: given an infinite set P of primes, must the gaps between consecutive P-smooth numbers (integers whose prime factors all lie in P) tend to infinity? The finite case was already understood through Pólya's 1918 theorem, which showed that the largest prime factor of an irreducible quadratic polynomial f(n) grows without bound. Since consecutive P-smooth numbers n, n+k yield n(n+k) as P-smooth, and Pólya guarantees this product eventually has prime factors outside any finite P, gaps must grow for finite P. Størmer had shown in 1897 that for finite P, only finitely many consecutive integers can both be P-smooth, connecting to Pell equations. Tijdeman resolved the full question in his landmark 1973 paper 'On integers with many small prime factors': for any ε > 0, one can construct an infinite set of primes P such that gaps between consecutive P-smooth numbers grow at least as fast as $a_i^{1-\\varepsilon}$. The key insight is that if the primes in P grow sufficiently rapidly, then P-smooth numbers become sparse enough to force large gaps, even though P is infinite. This result connects to the ABC conjecture, which would give even stronger gap bounds, and to the broader theory of smooth numbers central to modern cryptography and factorization algorithms.",
     "problemStatement": "**Problem Statement (Solved)**\n\nIs there an infinite set of primes P such that if {a₁ < a₂ < ···} are the P-smooth numbers, then lim(aᵢ₊₁ - aᵢ) = ∞?\n\n**Answer: YES**\n\nTijdeman (1973) proved: For any ε > 0, there exists an infinite set of primes P such that gaps satisfy aᵢ₊₁ - aᵢ ≫ aᵢ^{1-ε}.\n\n**Key insight:** Making P 'sparse' (primes grow fast) makes P-smooth numbers sparse, hence large gaps.",
     "text": "Is there an infinite set of primes P such that gaps between consecutive P-smooth numbers → ∞? YES - Tijdeman (1973) proved for any ε > 0, exists infinite P with gaps ≫ aᵢ^{1-ε}.",
-    "proofStrategy": "The formalization builds up from definitions to the main result in layers. First, isPSmooth P n defines P-smoothness as positivity plus all prime factors lying in P, and smoothEnum axiomatizes the ordered enumeration of P-smooth numbers. The gap function measures consecutive differences. The main question erdos240Question asks for an infinite P with unbounded gaps. The proof chain proceeds: Pólya's theorem (prime factors of quadratics grow) implies finite_P_unbounded_gaps (finite P forces gap divergence), and then Tijdeman's main theorem constructs an infinite P achieving gaps $\\ge c \\cdot a_i^{1-\\varepsilon}$. The final theorem erdos240_answer applies Tijdeman with ε = 1/2 to yield a YES answer. Two sorries remain in the limit arguments converting the gap growth rate to the unboundedness predicate.",
+    "proofStrategy": "The formalization builds up from definitions to the main result in layers. First, isPSmooth P n defines P-smoothness as positivity plus all prime factors lying in P, and smoothEnum axiomatizes the ordered enumeration of P-smooth numbers. The gap function measures consecutive differences. The main question erdos240Question asks for an infinite P with unbounded gaps. The proof chain proceeds: Pólya's theorem (prime factors of quadratics grow) implies finite_P_unbounded_gaps (finite P forces gap divergence), and then Tijdeman's main theorem constructs an infinite P achieving gaps $\\ge c \\cdot a_i^{1-\\varepsilon}$. The final theorem erdos240_answer applies Tijdeman with ε = 1/2 to yield a YES answer. The two former sorries are now fully machine-checked: erdos240_answer converts the gap growth rate aᵢ^{1/2} into the unboundedness predicate via a real-analytic rpow/sqrt argument, using a new smoothEnum_strictMono axiom that records the enumeration is strictly increasing (so smoothEnum P i ≥ i → ∞); and singleton_large_gaps is derived directly from finite_P_unbounded_gaps since {p} is a finite prime set.",
     "keyInsights": [
       "Pólya's 1918 theorem on prime factors of quadratics is the foundation: n(n+k) eventually has prime factors outside any finite P, so consecutive P-smooth numbers n, n+k cannot persist",
       "The finite P case follows by contradiction: bounded gaps would force infinitely many consecutive P-smooth pairs, violating Pólya",
@@ -168,8 +170,8 @@
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_240_summary, erdos_240 main theorem",
-      "startLine": 255,
-      "endLine": 264,
+      "startLine": 284,
+      "endLine": 316,
       "mathContext": "Verified: erdos_240_summary, erdos_240 main theorem"
     }
   ],
@@ -261,16 +263,16 @@
       "Set"
     ],
     "namespace": "Erdos240",
-    "lineCount": 264,
-    "axiomCount": 3,
+    "lineCount": 316,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 5,
     "path": "Proofs/Erdos240Problem.lean",
-    "sorries": 2,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos240ProblemAristotle.lean",
       "Proofs/Erdos240Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }

--- a/src/data/proofs/odd-cubes-sum-oq-01/annotations.json
+++ b/src/data/proofs/odd-cubes-sum-oq-01/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-definition",
+    "proofId": "odd-cubes-sum-oq-01",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "definition",
+    "title": "Odd Cube oddCube k = (2k−1)³",
+    "content": "The cube of the $k$-th odd number: $1, 27, 125, 343, \\dots$ for $k = 1, 2, 3, 4$. The companion lemma `oddCube_succ` rewrites $\\text{oddCube}(k+1) = (2k+1)^3$: shifting the index by one turns the truncated $\\mathbb{N}$ subtraction $2(k+1)-1$ into the honest $2k+1$, so the summand becomes a plain polynomial that `ring` can manipulate. (At $k=0$ the truncated subtraction gives $0$, but every sum indexes from $k \\ge 1$.)",
+    "mathContext": "$\\text{oddCube}(k) = (2k-1)^3$, and $\\text{oddCube}(k+1) = (2k+1)^3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Odd numbers", "Truncated natural subtraction", "Reindexing"]
+  },
+  {
+    "id": "ann-telescope",
+    "proofId": "odd-cubes-sum-oq-01",
+    "range": { "startLine": 71, "endLine": 73 },
+    "type": "theorem",
+    "title": "Telescoping Identity: (2n−1)³ = f(n) − f(n−1)",
+    "content": "With closed form $f(n) = n^2(2n^2-1)$, each odd cube is the increment of $f$: $(2n-1)^3 = f(n) - f(n-1)$. Stated over $\\mathbb{Z}$ because the subtraction is genuine, and closed by a single `ring` call. This is the reason the partial sums telescope to $n^2(2n^2-1)$: summing the $n$ odd cubes is summing the $n$ increments of $f$, which collapses to $f(n) - f(0) = f(n)$.",
+    "mathContext": "$(2n-1)^3 = n^2(2n^2-1) - (n-1)^2(2(n-1)^2-1)$ over $\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["Telescoping sums", "Finite differences", "ring"]
+  },
+  {
+    "id": "ann-main-add",
+    "proofId": "odd-cubes-sum-oq-01",
+    "range": { "startLine": 85, "endLine": 93 },
+    "type": "theorem",
+    "title": "Subtraction-Free Core: (∑(2k+1)³) + n² = 2n⁴",
+    "content": "The headline in its subtraction-free form, with both sides honest $\\mathbb{N}$ polynomials. The base case is `simp` (empty sum). In the step, `Finset.sum_range_succ` peels the top term and `oddCube_succ` expands it to $(2m+1)^3$; the pure polynomial identity $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$ is closed by `ring`, and `omega` combines it with the inductive hypothesis. No truncated subtraction ever reaches `ring`, so the whole core lives in $\\mathbb{N}$.",
+    "mathContext": "$\\bigl(\\sum_{k<n} (2k+1)^3\\bigr) + n^2 = 2n^4$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
+    "relatedConcepts": ["Power sums", "Induction", "omega"]
+  },
+  {
+    "id": "ann-closed-form-bridge",
+    "proofId": "odd-cubes-sum-oq-01",
+    "range": { "startLine": 99, "endLine": 108 },
+    "type": "lemma",
+    "title": "Closed-Form Bridge: n²(2n²−1) + n² = 2n⁴",
+    "content": "Shows the conventional closed form satisfies the same additive relation as the sum. The genuine $\\mathbb{N}$ subtraction in $n^2(2n^2-1) = 2n^4 - n^2$ is the only one in the file's headline path, and is resolved once via `Nat.sub_add_cancel` (using $1 \\le 2n^2$ for $n \\ge 1$, with the $n=0$ case dispatched by `simp`). A `calc` chain distributes, cancels the subtraction, and finishes with `ring`.",
+    "mathContext": "$n^2(2n^2-1) + n^2 = 2n^4$, i.e. $n^2(2n^2-1) = 2n^4 - n^2$.",
+    "significance": "supporting",
+    "prerequisites": ["Truncated natural subtraction", "Nat.sub_add_cancel"],
+    "relatedConcepts": ["Distributivity", "Case analysis", "calc"]
+  },
+  {
+    "id": "ann-main-range",
+    "proofId": "odd-cubes-sum-oq-01",
+    "range": { "startLine": 117, "endLine": 121 },
+    "type": "theorem",
+    "title": "Main Identity (reindexed range form)",
+    "content": "$\\sum_{k<n} (2k+1)^3 = n^2(2n^2-1)$. Because both the sum (`sum_oddCube_add`) and the closed form (`closedForm_add`) equal $2n^4$ after adding $n^2$, `omega` identifies the two expressions for the sum directly — no further induction needed.",
+    "mathContext": "$\\sum_{k<n} (2k+1)^3 = n^2(2n^2-1)$.",
+    "significance": "critical",
+    "prerequisites": ["Subtraction-free core", "Closed-form bridge"],
+    "relatedConcepts": ["Power sums", "omega"]
+  },
+  {
+    "id": "ann-main-icc",
+    "proofId": "odd-cubes-sum-oq-01",
+    "range": { "startLine": 132, "endLine": 143 },
+    "type": "theorem",
+    "title": "Main Identity (classical 1-indexed form)",
+    "content": "$\\sum_{k \\in [1,n]} (2k-1)^3 = n^2(2n^2-1)$, the statement exactly as power-sum identities are usually phrased. An inner induction establishes the additive core over the interval — base case `simp` (empty interval), step peeling the top term with `Finset.sum_Icc_succ_top` (side condition $1 \\le m+1$ from `omega`), the same `ring` identity, and `omega` — after which `closedForm_add` matches the closed form via `omega`.",
+    "mathContext": "$\\sum_{k=1}^{n} (2k-1)^3 = n^2(2n^2-1)$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_Icc_succ_top"],
+    "relatedConcepts": ["Interval sums", "Induction", "omega"]
+  }
+]

--- a/src/data/proofs/odd-cubes-sum-oq-01/meta.json
+++ b/src/data/proofs/odd-cubes-sum-oq-01/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "odd-cubes-sum-oq-01",
+  "title": "Sum of Cubes of the First n Odd Numbers: ∑(2k−1)³ = n²(2n²−1)",
+  "slug": "odd-cubes-sum-oq-01",
+  "description": "A fully machine-checked, self-contained proof that the sum of the cubes of the first n odd numbers is n²(2n²−1): ∑_{k=1}^{n} (2k−1)³ = n²(2n²−1) (1 + 27 + 125 = 153 = 3²·17; the partial sums are 1, 28, 153, 496, …, OEIS A002593). The headline is established in its subtraction-free form (∑_{k<n} (2k+1)³) + n² = 2n⁴, whose one-step induction stays entirely inside ℕ — the step reduces to the polynomial identity 2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m², closed by `ring` and glued with `omega`. The conventional closed form n²(2n²−1) and the classical 1-indexed Icc form follow, plus the telescoping identity (2n−1)³ = f(n) − f(n−1) with f(n) = n²(2n²−1). The odd-indexed companion of Nicomachus's ∑k³ = (∑k)², which Mathlib does not name.",
+  "meta": {
+    "author": "Classical power-sum identity (folklore); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://oeis.org/A002593",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "finite-sum",
+      "cubes",
+      "odd-numbers",
+      "power-sums",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/OddCubesSum.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. The engine of the reindexed inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Icc_succ_top",
+        "description": "Peels the top term off an interval-sum: for a ≤ b+1, ∑_{k ∈ Icc a (b+1)} f k = (∑_{k ∈ Icc a b} f k) + f (b+1). Drives the 1-indexed inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.sub_add_cancel",
+        "description": "For h : m ≤ n, (n - m) + m = n. Used once to resolve the genuine ℕ subtraction in the closed form n²(2n²−1) = 2n⁴ − n².",
+        "module": "Mathlib.Algebra.Order.Sub.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The sum-of-odd-cubes identity ∑_{k=1}^{n} (2k−1)³ = n²(2n²−1), machine-checked over ℕ with 0 axioms and 0 sorries — a named power-sum identity Mathlib's BigOperators library does not provide",
+      "The subtraction-free formulation (∑_{k<n} (2k+1)³) + n² = 2n⁴, which keeps the core induction entirely inside ℕ: the step is the pure polynomial identity 2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m² (closed by `ring`), with `omega` supplying the linear glue against the inductive hypothesis",
+      "The classical 1-indexed interval form ∑_{k ∈ Icc 1 n} (2k−1)³ = n²(2n²−1), matching the way power-sum identities are usually stated, via Finset.sum_Icc_succ_top",
+      "The telescoping identity (2n−1)³ = f(n) − f(n−1) with f(n) = n²(2n²−1) (over ℤ), exhibiting each odd cube as the increment of the closed form — the reason the partial sums collapse to n²(2n²−1)"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 145,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions); the telescoping and closed-form bridge lemmas use only propext and Quot.sound. No native_decide, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Odd Cube and Its Reindexing",
+      "startLine": 57,
+      "endLine": 64,
+      "summary": "Defines oddCube k = (2k−1)³ (the values 1, 27, 125, 343, … for k = 1, 2, 3, 4) and the reindexing lemma oddCube (k+1) = (2k+1)³, which turns the truncated ℕ subtraction 2(k+1)−1 into the honest 2k+1 so the summand becomes a plain polynomial."
+    },
+    {
+      "id": "telescope",
+      "title": "The Telescoping Identity",
+      "startLine": 66,
+      "endLine": 73,
+      "summary": "(2n−1)³ = f(n) − f(n−1) with f(n) = n²(2n²−1), stated over ℤ because the subtraction is genuine. A single `ring` call. This exhibits each odd cube as the increment of the closed form, the reason the partial sums telescope to n²(2n²−1)."
+    },
+    {
+      "id": "main-add",
+      "title": "Subtraction-Free Core",
+      "startLine": 75,
+      "endLine": 93,
+      "summary": "(∑_{k<n} (2k+1)³) + n² = 2n⁴ by induction, both sides honest ℕ polynomials. The step peels the top term with Finset.sum_range_succ, then the polynomial identity 2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m² (closed by `ring`) plus the inductive hypothesis are combined by `omega` — no truncated subtraction reaches `ring`."
+    },
+    {
+      "id": "closed-form-bridge",
+      "title": "The Closed-Form Bridge",
+      "startLine": 95,
+      "endLine": 108,
+      "summary": "n²(2n²−1) + n² = 2n⁴, showing the closed form satisfies the same additive relation as the sum. The genuine ℕ subtraction in n²(2n²−1) = 2n⁴ − n² is resolved once via Nat.sub_add_cancel (using 1 ≤ 2n² for n ≥ 1)."
+    },
+    {
+      "id": "main-range",
+      "title": "Main Identity (reindexed range form)",
+      "startLine": 110,
+      "endLine": 121,
+      "summary": "∑_{k<n} (2k+1)³ = n²(2n²−1). Since both the sum (sum_oddCube_add) and the closed form (closedForm_add) equal 2n⁴ after adding n², `omega` identifies the two expressions for the sum."
+    },
+    {
+      "id": "main-icc",
+      "title": "Main Identity (classical 1-indexed form)",
+      "startLine": 123,
+      "endLine": 143,
+      "summary": "∑_{k ∈ Icc 1 n} (2k−1)³ = n²(2n²−1), the statement exactly as power-sum identities are usually phrased. The same subtraction-free induction (peeling with Finset.sum_Icc_succ_top, the `ring` identity, `omega`) establishes the additive core, then closedForm_add matches the closed form."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Odd cubes and a clean square factor**\n\nNicomachus's theorem states that the sum of the first $n$ cubes is a perfect square, $\\sum_{k=1}^{n} k^3 = \\bigl(\\tfrac{n(n+1)}{2}\\bigr)^2$. Restricting to the *odd* cubes gives an equally clean closed form:\n$$\\sum_{k=1}^{n} (2k-1)^3 = n^2\\,(2n^2-1).$$\nThe partial sums are $1, 28, 153, 496, 1225, \\dots$ (OEIS A002593), and each is $n^2$ times the odd number $2n^2-1$. Equivalently $\\sum (2k-1)^3 = 2n^4 - n^2$. Mathlib already contains Gauss's triangular-number identity and, via the sister Nicomachus gallery entry, $\\sum k^3 = (\\sum k)^2$, but not this sum-of-odd-cubes identity.",
+    "problemStatement": "**Sum of cubes of odd numbers**\n\nFor every natural number $n$,\n$$\\sum_{k=1}^{n} (2k-1)^3 = n^2\\,(2n^2-1).$$\nThe goal is a fully machine-checked proof with no axioms and no sorries. Because the closed form $n^2(2n^2-1) = 2n^4 - n^2$ involves a subtraction, the headline is first stated in the genuinely subtraction-free form $\\bigl(\\sum_{k<n}(2k+1)^3\\bigr) + n^2 = 2n^4$, keeping the core induction entirely inside $\\mathbb{N}$.",
+    "proofStrategy": "**One subtraction-free induction, plus a closed-form bridge**\n\nReindex the sum so the summand carries no truncated subtraction: $\\text{oddCube}(k+1) = (2k+1)^3$. The inductive step for $\\bigl(\\sum_{k<m}(2k+1)^3\\bigr) + m^2 = 2m^4$ peels the top term via `Finset.sum_range_succ`; the pure polynomial identity\n$$2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$$\nis closed by `ring`, and `omega` combines it with the inductive hypothesis. The conventional closed form is reached through a bridge lemma $n^2(2n^2-1) + n^2 = 2n^4$ (the single genuine subtraction handled by `Nat.sub_add_cancel`), after which `omega` identifies the two. The $1$-indexed interval form is proved by the identical induction with `Finset.sum_Icc_succ_top`. The telescoping identity $(2n-1)^3 = f(n) - f(n-1)$ makes the collapse explicit.",
+    "keyInsights": [
+      "**Add instead of subtract.** The closed form $n^2(2n^2-1) = 2n^4 - n^2$ carries a subtraction, so the headline is recast as $\\bigl(\\sum(2k+1)^3\\bigr) + n^2 = 2n^4$ — a relation between honest ℕ polynomials, letting the entire core induction stay inside $\\mathbb{N}$.",
+      "**The step is one scalar identity.** After peeling the top term, the content is the polynomial identity $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$, a fact about the single number $m$ that `ring` closes; `omega` then supplies the purely linear bookkeeping against the hypothesis.",
+      "**Subtraction quarantined to one lemma.** The only genuine ℕ subtraction — turning $2n^4 - n^2$ back into the product $n^2(2n^2-1)$ — is isolated in the bridge lemma `closedForm_add` and dispatched once by `Nat.sub_add_cancel`.",
+      "**Two phrasings, one technique.** Both the $0$-indexed `range` form and the classical $1$-indexed `Icc` form follow from the identical peel-then-`ring`-then-`omega` induction, using `sum_range_succ` and `sum_Icc_succ_top` respectively."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range` and `Finset.Icc`",
+      "Truncated natural-number subtraction",
+      "Power sums of arithmetic progressions"
+    ]
+  },
+  "conclusion": {
+    "summary": "The sum-of-odd-cubes identity $\\sum_{k=1}^{n}(2k-1)^3 = n^2(2n^2-1)$ is established by a single subtraction-free induction whose inductive step reduces to the elementary polynomial identity $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$. The headline core stays entirely within $\\mathbb{N}$ — recasting the goal as $\\bigl(\\sum(2k+1)^3\\bigr) + n^2 = 2n^4$ removes every truncated subtraction — and the only genuine subtraction (recovering the product form $n^2(2n^2-1)$) is quarantined in one bridge lemma. The classical $1$-indexed form follows by the same induction, and the telescoping identity $(2n-1)^3 = f(n) - f(n-1)$ supplies the intuition. 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the sum-of-odd-cubes identity that Mathlib's BigOperators library does not provide, in forms (`sum_oddCube_range`, `sum_oddCube_Icc`) directly reusable by other gallery proofs.",
+      "Complements the Nicomachus $\\sum k^3 = (\\sum k)^2$ entry, extending the gallery's power-sum family to the odd-indexed case.",
+      "The subtraction-free recasting and the isolated `closedForm_add` bridge demonstrate a reusable pattern for keeping ℕ power-sum inductions free of truncated subtraction."
+    ],
+    "openQuestions": [
+      "Does the sum of fifth (or higher odd) powers of the first n odd numbers admit a comparably clean closed form, and does the same add-instead-of-subtract recasting keep its induction inside ℕ?",
+      "Is there a bijective or geometric proof — analogous to the cubic-shell dissection behind Nicomachus — that realizes ∑(2k−1)³ = n²(2n²−1) as an explicit decomposition rather than an induction?"
+    ]
+  }
+}


### PR DESCRIPTION
## Erdős Problem #240 — Gaps Between P-Smooth Numbers

Wintner's question (resolved by **Tijdeman 1973**): is there an infinite set of primes $P$ such that gaps between consecutive $P$-smooth numbers tend to infinity? **Yes** — for any $\varepsilon>0$ there is an infinite $P$ with gaps $\gg a_i^{1-\varepsilon}$.

This PR removes the **two remaining sorries**, so every derivation lemma is now machine-checked from the stated axioms (0 sorries).

### Proofs filled

- **`erdos240_answer`** — converts Tijdeman's bound $\mathrm{gap}(i) \ge c\,a_i^{1/2}$ into the unboundedness predicate `gapsTendToInfinity`. Given $M$, pick $i$ with $a_i > (M/c)^2$ (possible because the enumeration is unbounded), then $c\sqrt{a_i} > M$ by `Real.sqrt` monotonicity, rewriting $a_i^{1-1/2}=\sqrt{a_i}$ via `Real.sqrt_eq_rpow`.
- **`singleton_large_gaps`** — derived directly from the existing `finite_P_unbounded_gaps` axiom, since ${p}$ is a finite prime set (`Finset.coe_singleton` rewrite). No new axiom needed.

### New axiom
`smoothEnum_strictMono : StrictMono (smoothEnum P)` — records that the order-enumeration is strictly increasing (hence $a_i \ge i \to \infty$), the property the limit argument needs. This is a faithful, true property of any increasing enumeration.

### Pre-existing breakage repaired
The file did **not** compile before this PR. Fixed:
- several floating `/--` docstrings (no attached declaration) → `/-` block comments;
- `gap` marked `noncomputable` (it is built on the opaque `smoothEnum` axiom);
- `erdos_240_summary`'s `∀ ε > 0` annotated `: ℝ` — it had silently defaulted `ε : ℕ`, mismatching `tijdeman_main_theorem`.

### Axiom integrity
4 axioms: `smoothEnum`, `smoothEnum_strictMono`, `finite_P_unbounded_gaps`, `tijdeman_main_theorem`. `#print axioms` on the main results shows only these plus the standard `propext`/`Classical.choice`/`Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**.

meta.json updated: `status` formalized→**axiomatized**, `badge` wip→**axiom**, `sorries` 2→**0**, `axiomCount` 3→**4**; annotations for the two former sorries rewritten as proved.

### Build
`lake env lean Proofs/Erdos240Problem.lean` — clean, exit 0, 0 sorries (Docker down; built offline against the shared Mathlib cache).