### PR TITLE
research(erdos-1065-oq-05-oq-01): generalized 2-adic valuation lemma [verified, 0 sorry/axiom delta]

### DIFF
--- a/proofs/Proofs/Erdos1065BatemanHorn.lean
+++ b/proofs/Proofs/Erdos1065BatemanHorn.lean
@@ -66,12 +66,29 @@ theorem safePrime_implies_formA (p : ℕ) :
 
 -- ## Uniqueness of the (k, q) Decomposition
 
+/-- **Exact `p`-adic valuation of `p^k · q` for `p ∤ q`.** For a prime `p`,
+    a nonzero `q` not divisible by `p`, and any exponent `k`, the `p`-adic
+    valuation of `p^k · q` is exactly `k`.
+
+    This is the load-bearing arithmetic fact behind the uniqueness of the
+    Form A decomposition (`erdos-1065-oq-05-oq-01`). It is strictly more
+    general than Mathlib's `padicValNat_mul_pow_left`, which requires the
+    cofactor `q` to itself be a prime power `q'^m`; here `q` need only be
+    coprime to `p` (`¬ p ∣ q`). Specializing to `p = 2` gives
+    `v₂(2^k · q) = k` for odd `q`. -/
+theorem padicValNat_pow_mul_of_not_dvd {p k q : ℕ} (hp : p.Prime)
+    (hq : q ≠ 0) (hdvd : ¬ p ∣ q) :
+    padicValNat p (p ^ k * q) = k := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  rw [padicValNat.mul (pow_ne_zero k hp.ne_zero) hq,
+      padicValNat.prime_pow, padicValNat.eq_zero_of_not_dvd hdvd, add_zero]
+
 /-- The (k, q) decomposition of a Form A prime is unique when q is odd:
     if 2^k₁ · q₁ = 2^k₂ · q₂ with q₁, q₂ odd, then k₁ = k₂ and q₁ = q₂.
 
-    Proof idea: The 2-adic valuation of 2^k · q with q odd is exactly k.
-    So if 2^k₁ · q₁ = 2^k₂ · q₂ with both q's odd, then k₁ = k₂,
-    and q₁ = q₂ follows by cancellation. -/
+    Proof idea: The 2-adic valuation of 2^k · q with q odd is exactly k
+    (`padicValNat_pow_mul_of_not_dvd`). So if 2^k₁ · q₁ = 2^k₂ · q₂ with
+    both q's odd, then k₁ = k₂, and q₁ = q₂ follows by cancellation. -/
 theorem formA_decomposition_unique {p k₁ k₂ q₁ q₂ : ℕ}
     (hq1 : q₁.Prime) (hq2 : q₂.Prime)
     (hq1_ne2 : q₁ ≠ 2) (hq2_ne2 : q₂ ≠ 2)
@@ -87,13 +104,10 @@ theorem formA_decomposition_unique {p k₁ k₂ q₁ q₂ : ℕ}
     intro h
     exact hq2_ne2 (hq2.eq_one_or_self_of_dvd 2 h |>.resolve_left (by norm_num) |>.symm)
   -- Use 2-adic valuation: v₂(2^k · q) = k when q is odd
-  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
-  have hv1 : padicValNat 2 (2 ^ k₁ * q₁) = k₁ := by
-    rw [padicValNat.mul (pow_ne_zero k₁ two_ne_zero) hq1.ne_zero,
-        padicValNat.prime_pow, padicValNat.eq_zero_of_not_dvd hq1_odd, add_zero]
-  have hv2 : padicValNat 2 (2 ^ k₂ * q₂) = k₂ := by
-    rw [padicValNat.mul (pow_ne_zero k₂ two_ne_zero) hq2.ne_zero,
-        padicValNat.prime_pow, padicValNat.eq_zero_of_not_dvd hq2_odd, add_zero]
+  have hv1 : padicValNat 2 (2 ^ k₁ * q₁) = k₁ :=
+    padicValNat_pow_mul_of_not_dvd (by norm_num) hq1.ne_zero hq1_odd
+  have hv2 : padicValNat 2 (2 ^ k₂ * q₂) = k₂ :=
+    padicValNat_pow_mul_of_not_dvd (by norm_num) hq2.ne_zero hq2_odd
   have hk : k₁ = k₂ := by
     have hpv := congr_arg (padicValNat 2) heq
     rw [hv1, hv2] at hpv; exact hpv

--- a/research/problems/erdos-1065-oq-05-oq-01/knowledge.md
+++ b/research/problems/erdos-1065-oq-05-oq-01/knowledge.md
@@ -6,16 +6,39 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Target: prove `formA_decomposition_unique` (uniqueness of the Form A
+`p = 2^k·q + 1` decomposition) from `Nat.multiplicity` / `padicValNat`,
+eliminating it as an axiom in the `erdos-1065-oq-05` Bateman-Horn gallery proof.
+
+**Status: ALREADY SOLVED.** `formA_decomposition_unique` is a proven
+`theorem` (0 sorry) in `proofs/Proofs/Erdos1065BatemanHorn.lean`, proved
+exactly via the `padicValNat` route this problem suggested. The only `axiom`
+remaining in that file is `batemanHorn_formAWithK_infinite`, the genuinely
+open Bateman-Horn density prediction — out of scope here.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- `formA_decomposition_unique` and its parity-free strengthening
+  `formA_decomposition_unique_full` are theorems; the gallery gap is closed.
+- The core fact is `v₂(2^k·q) = k` for odd `q`. Generalizing the cofactor
+  hypothesis from "prime power" to "coprime to p" gives a lemma strictly
+  more general than Mathlib's `padicValNat_mul_pow_left`:
+  `padicValNat_pow_mul_of_not_dvd : p.Prime → q ≠ 0 → ¬ p ∣ q →
+   padicValNat p (p^k * q) = k`.
+  Proof: `padicValNat.mul` (additivity) + `padicValNat.prime_pow` +
+  `padicValNat.eq_zero_of_not_dvd`.
+
+## Contribution (this session)
+
+- Extracted `padicValNat_pow_mul_of_not_dvd` as a standalone named lemma and
+  refactored `formA_decomposition_unique` to use it (removed inline
+  duplication of the valuation computation). Build verified offline
+  (`lake env lean`); axioms = {propext, Classical.choice, Quot.sound}, no sorry.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- None. Target was already met upstream; no new proof search was required.

--- a/src/data/research/problems/erdos-1065-oq-05-oq-01.json
+++ b/src/data/research/problems/erdos-1065-oq-05-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1065-oq-05-oq-01",
   "title": "Prove formA_decomposition_unique from Nat.multiplicity",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -29,11 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED (target already eliminated upstream). The axiom this problem asked to remove — formA_decomposition_unique — is already a proven theorem (0 sorry) in Erdos1065BatemanHorn.lean, proved via the padicValNat route this problem suggested. Contribution this session: extracted the load-bearing 2-adic valuation fact as a standalone, generalized, reusable lemma padicValNat_pow_mul_of_not_dvd (p.Prime → q≠0 → ¬p∣q → padicValNat p (p^k*q)=k), strictly more general than Mathlib padicValNat_mul_pow_left. Build verified offline; depends only on propext/Classical.choice/Quot.sound (no sorry).",
+    "builtItems": [
+      "padicValNat_pow_mul_of_not_dvd in proofs/Proofs/Erdos1065BatemanHorn.lean (generalized 2-adic valuation lemma, reusable; refactors formA_decomposition_unique to use it)"
+    ],
+    "insights": [
+      "formA_decomposition_unique is ALREADY a theorem, not an axiom — the gallery gap this problem targeted was closed in a prior commit. Only remaining axiom in the file is the genuinely open Bateman-Horn density result batemanHorn_formAWithK_infinite.",
+      "Mathlib padicValNat_mul_pow_left requires BOTH factors to be prime powers (p^n * q^m). For p^k * q with q merely coprime to p (¬p∣q), use padicValNat.eq_zero_of_not_dvd on the cofactor instead — strictly more general."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "No further work on the stated target (already solved). Optional: upstream padicValNat_pow_mul_of_not_dvd to Mathlib as a generalization of padicValNat_mul_pow_left."
+    ],
     "markdown": "# Knowledge Base: erdos-1065-oq-05-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Research session for **erdos-1065-oq-05-oq-01** ("Prove `formA_decomposition_unique` from `Nat.multiplicity`").

**Honest finding: the target was already met upstream.** `formA_decomposition_unique` is already a proven `theorem` (0 sorry) in `proofs/Proofs/Erdos1065BatemanHorn.lean`, proved via exactly the `padicValNat` route the problem suggested. The only `axiom` remaining in that file is `batemanHorn_formAWithK_infinite` — the genuinely open Bateman-Horn density prediction, which is out of scope for this problem.

## Contribution

Rather than redo solved work, this PR makes one genuine, modest improvement: it extracts the load-bearing 2-adic valuation fact as a standalone, **generalized**, reusable lemma and refactors `formA_decomposition_unique` to use it (removing the inline duplication that previously appeared twice):

```lean
theorem padicValNat_pow_mul_of_not_dvd {p k q : ℕ} (hp : p.Prime)
    (hq : q ≠ 0) (hdvd : ¬ p ∣ q) :
    padicValNat p (p ^ k * q) = k
```

This is **strictly more general than Mathlib's `padicValNat_mul_pow_left`**, which requires the cofactor to itself be a prime power `q'^m`; here `q` need only be coprime to `p` (`¬ p ∣ q`). Specializing to `p = 2` gives `v₂(2^k·q) = k` for odd `q`.

## Verification

- Built offline with `lake env lean Proofs/Erdos1065BatemanHorn.lean` — compiles cleanly (toolchain error-reporting sanity-checked separately).
- `#print axioms padicValNat_pow_mul_of_not_dvd` → `[propext, Classical.choice, Quot.sound]` only. No `sorryAx`, no `ofReduceBool`.
- No change to the file's axiom/sorry counts: still 1 axiom (the open Bateman-Horn result), 0 sorries.

## Status

**Outcome**: completed (target already solved; added a reusable generalized lemma)
**Next Steps**: optional — upstream `padicValNat_pow_mul_of_not_dvd` to Mathlib as a generalization of `padicValNat_mul_pow_left`.

🤖 Generated by researcher-6