### PR TITLE
research(erdos-771): quantitative Erdős–Graham bound via Bertrand — m-avoiding set of size ≥ ⌊n/(2m)⌋ [verified, 6 thm, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos771Construction.lean
+++ b/proofs/Proofs/Erdos771Construction.lean
@@ -97,12 +97,44 @@ theorem exists_avoiding_multiples (m n : ℕ) (hm : 1 ≤ m) :
   obtain ⟨p, hp, hpm⟩ := exists_prime_not_dvd m hm
   exact ⟨p, hp, Finset.filter_subset _ _, prime_multiples_avoid p m n hp hpm⟩
 
+/-! ## Quantitative existence via Bertrand's postulate
+
+The bare existence above uses *some* prime `> m`, which may be far larger than `m`
+(so `⌊n/p⌋` could be tiny — for instance the smallest prime not dividing `m = lcm{2,…,t}`
+grows with `t`). Bertrand's postulate supplies a prime `p` with `m < p ≤ 2m`, pinning the
+size of the construction from below: `⌊n/(2m)⌋ ≤ |S|`. -/
+
+/-- A prime `p` strictly larger than a positive `m` cannot divide `m`
+    (otherwise `p ≤ m`). -/
+theorem prime_gt_not_dvd {p m : ℕ} (hm : 1 ≤ m) (hmp : m < p) : ¬ p ∣ m := by
+  intro hdvd
+  have := Nat.le_of_dvd hm hdvd
+  omega
+
+/-- **Quantitative Erdős–Graham construction.** For every `m ≥ 1` and `n`, Bertrand's
+    postulate yields a prime with `m < p ≤ 2m`; the multiples of `p` in `{1,…,n}` then form an
+    `m`-avoiding subset of size `⌊n/p⌋ ≥ ⌊n/(2m)⌋`. This strengthens `exists_avoiding_multiples`
+    from bare existence to an explicit lower bound on the avoiding-set size (with the prime
+    controlled to within a factor of two of `m`). -/
+theorem exists_avoiding_multiples_quantitative (m n : ℕ) (hm : 1 ≤ m) :
+    ∃ p, Nat.Prime p ∧ m < p ∧ p ≤ 2 * m ∧
+      primeMultiples p n ⊆ Icc_n n ∧
+      AvoidSum (primeMultiples p n) m ∧
+      n / (2 * m) ≤ (primeMultiples p n).card := by
+  obtain ⟨p, hp, hmp, hp2m⟩ := Nat.exists_prime_lt_and_le_two_mul m (by omega)
+  refine ⟨p, hp, hmp, hp2m, Finset.filter_subset _ _,
+    prime_multiples_avoid p m n hp (prime_gt_not_dvd hm hmp), ?_⟩
+  rw [prime_multiples_size]
+  exact Nat.div_le_div_left hp2m hp.pos
+
 /-! ## Summary
 
 Verified here (0 axioms, 0 sorries): the elementary Erdős–Graham construction behind the
 lower bound for `f(n)` — the multiples of a prime `p` in `{1,…,n}` have size `⌊n/p⌋`, avoid
-any `m` with `p ∤ m`, and such a prime exists for every `m ≥ 1`. The deep asymptotics
-(the matching `(1/2 + o(1)) n / log n` lower and upper bounds) are not addressed here.
+any `m` with `p ∤ m`, and such a prime exists for every `m ≥ 1`; and, via Bertrand's
+postulate, an `m`-avoiding subset of size `≥ ⌊n/(2m)⌋` exists for every `m ≥ 1`. The deep
+asymptotics (the matching `(1/2 + o(1)) n / log n` lower and upper bounds) are not addressed
+here.
 -/
 
 end Erdos771Construction

--- a/research/problems/erdos-771/knowledge.md
+++ b/research/problems/erdos-771/knowledge.md
@@ -27,3 +27,30 @@ sorries. Breakages found (Mechanic follow-up):
 ### Open (not addressed)
 The deep asymptotics f(n) = (1/2 + o(1))·n/log n (axiomatized in the companion file) remain
 external; this session only verifies the elementary construction.
+
+## Session 2026-06-25 (researcher-9) — quantitative bound via Bertrand
+
+Extended `Erdos771Construction.lean` (now 6 thm/4 def, 0 axioms, 0 sorries, VERIFIED) with a
+quantitative strengthening of `exists_avoiding_multiples`:
+- `prime_gt_not_dvd`: a prime `p > m ≥ 1` cannot divide `m` (else `p ≤ m` by `Nat.le_of_dvd`).
+- `exists_avoiding_multiples_quantitative`: via Bertrand's postulate
+  (`Nat.exists_prime_lt_and_le_two_mul`), for every `m ≥ 1` there is a prime `m < p ≤ 2m`,
+  giving an `m`-avoiding subset of `{1,…,n}` of size `⌊n/p⌋ ≥ ⌊n/(2m)⌋`. Size bound via
+  `Nat.div_le_div_left hp2m hp.pos` (Nat division is antitone in the denominator).
+
+### Why this matters
+The bare existence used *some* prime `> m`, possibly enormous (least prime ∤ `m = lcm{2,…,t}`
+grows with `t`), so `⌊n/p⌋` could be tiny. Bertrand pins the prime to within a factor of two
+of `m`, turning existence into an explicit size lower bound.
+
+### Still open
+The per-m bound `⌊n/(2m)⌋` weakens as `m` grows; the n/log n lower bound needs a
+uniform-over-all-m argument (primes near log n) not formalized here. Asymptotics remain external.
+
+### Gotchas
+- Docker down → offline typecheck with `LAKE_UNSAFE=1 elan run leanprover/lean4:v4.26.0 lake env
+  lean Proofs/Erdos771Construction.lean`. Main repo's shared `.lake` had a CORRUPT
+  `Mathlib/Data/Nat/Bits.olean.private` (invalid header) → typechecked in a sibling worktree
+  (`r8-picard`) with an intact Mathlib build instead.
+- `Nat.div_le_div_left (h : a ≤ b) (hpos : 0 < a) : k / b ≤ k / a` — args are the *smaller*
+  denominator's `≤` and positivity.

--- a/src/data/proofs/erdos-771-construction/annotations.json
+++ b/src/data/proofs/erdos-771-construction/annotations.json
@@ -58,5 +58,17 @@
     "significance": "supporting",
     "relatedConcepts": ["infinitude of primes (Nat.exists_infinite_primes)", "Nat.le_of_dvd", "Finset.filter_subset", "existence of an avoiding set"],
     "prerequisites": ["there are arbitrarily large primes", "a divisor of a positive number is ≤ it", "the omega tactic", "the avoidance lemma"]
+  },
+  {
+    "id": "ann-quantitative",
+    "proofId": "erdos-771-construction",
+    "range": { "startLine": 100, "endLine": 140 },
+    "type": "theorem",
+    "title": "Quantitative Existence via Bertrand's Postulate (exists_avoiding_multiples_quantitative)",
+    "content": "The bare existence above is unsatisfying for sizing the construction: exists_prime_not_dvd produces *some* prime p > m, but p can be enormous (e.g. for m = lcm{2,…,t} the least prime not dividing m is the next prime after t), making ⌊n/p⌋ tiny. exists_avoiding_multiples_quantitative fixes this with Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul), which guarantees a prime in the window m < p ≤ 2m. The helper prime_gt_not_dvd notes that any prime strictly above a positive m cannot divide m (else Nat.le_of_dvd forces p ≤ m). Combining: p ∤ m gives avoidance (prime_multiples_avoid), and p ≤ 2m gives, after rewriting the cardinality with prime_multiples_size, the size bound ⌊n/(2m)⌋ ≤ ⌊n/p⌋ = |S| via Nat.div_le_div_left (dividing by a smaller denominator only increases the quotient). So for every m ≥ 1 there is an m-avoiding subset of {1,…,n} of size at least ⌊n/(2m)⌋ — the construction's size is now controlled to within a factor of two of n/m. This is still a per-m bound (it weakens as m grows); the uniform-over-all-m argument behind the n/log n lower bound is not formalized here.",
+    "mathContext": "Bertrand: $\\exists p$ prime, $m < p \\le 2m$. Then $p \\nmid m$ and $|S| = \\lfloor n/p \\rfloor \\ge \\lfloor n/(2m) \\rfloor$ (Nat.div_le_div_left).",
+    "significance": "key",
+    "relatedConcepts": ["Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul)", "Nat.div_le_div_left", "quantitative lower bound on avoiding-set size", "controlling the prime to within a factor of two"],
+    "prerequisites": ["Bertrand's postulate (a prime in (m, 2m])", "monotonicity of Nat division in the denominator", "the size and avoidance lemmas"]
   }
 ]

--- a/src/data/proofs/erdos-771-construction/meta.json
+++ b/src/data/proofs/erdos-771-construction/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-771-construction",
   "title": "The Erdős–Graham Construction for Sum-Avoiding Sets, Verified (Erdős #771)",
   "slug": "erdos-771-construction",
-  "description": "A fully verified (0-axiom, 0-sorry) formalization of the elementary construction at the heart of the Erdős–Graham lower bound for Erdős #771 (max size of a subset of {1,…,n} avoiding a target subset sum m). The construction takes S = multiples of a prime p in {1,…,n}: every subset sum is divisible by p, so if p ∤ m then S avoids m. The file proves the size of the construction (⌊n/p⌋), the avoidance property, and that a suitable prime exists for every m ≥ 1 — so an m-avoiding set always exists. The companion Erdos771Problem.lean left these as sorries and no longer compiles under Mathlib 4.26.0.",
+  "description": "A fully verified (0-axiom, 0-sorry) formalization of the elementary construction at the heart of the Erdős–Graham lower bound for Erdős #771 (max size of a subset of {1,…,n} avoiding a target subset sum m). The construction takes S = multiples of a prime p in {1,…,n}: every subset sum is divisible by p, so if p ∤ m then S avoids m. The file proves the size of the construction (⌊n/p⌋), the avoidance property, that a suitable prime exists for every m ≥ 1 — so an m-avoiding set always exists — and, via Bertrand's postulate, a quantitative version: a prime m < p ≤ 2m can always be chosen, yielding an m-avoiding subset of size ⌊n/p⌋ ≥ ⌊n/(2m)⌋. The companion Erdos771Problem.lean left these as sorries and no longer compiles under Mathlib 4.26.0.",
   "meta": {
     "author": "Research formalization 2026 (researcher-1)",
     "sourceUrl": "https://erdosproblems.com/771",
@@ -19,11 +19,11 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 108,
-    "assumptions": "None. Every theorem is elementary number theory / finite combinatorics with zero axioms and zero sorries (only the foundational propext/Classical.choice/Quot.sound). The deep asymptotic bounds of Erdős #771 (the matching (1/2+o(1))·n/log n lower and upper bounds) are NOT proved or assumed here.",
+    "lineCount": 140,
+    "assumptions": "None. Every theorem is elementary number theory / finite combinatorics with zero axioms and zero sorries (only the foundational propext/Classical.choice/Quot.sound; the quantitative theorem additionally uses Mathlib's verified Bertrand's postulate, itself 0-axiom). The deep asymptotic bounds of Erdős #771 (the matching (1/2+o(1))·n/log n lower and upper bounds) are NOT proved or assumed here.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 6,
     "definitionCount": 4,
     "additionalFiles": []
   },
@@ -31,18 +31,20 @@
     "historicalContext": "Erdős #771 asks for the maximal f(n) such that for every m ≥ 1 there is a set S ⊆ {1,…,n} with |S| = f(n) and no nonempty subset of S summing to m. Erdős–Graham proved the lower bound f(n) ≥ (1/2+o(1))·n/log n via prime multiples, and Alon–Freiman the matching upper bound via an LCM argument, settling f(n) = (1/2+o(1))·n/log n. The companion formalization Erdos771Problem.lean sets up the definitions but leaves the construction lemmas as sorries and, under Mathlib 4.26.0, no longer compiles (a stale module import path, DecidablePred synthesis gaps, and dangling doc-comments).",
     "problemStatement": "Verify the elementary construction underlying the Erdős–Graham lower bound: the multiples of a prime p in {1,…,n} form a set whose subset sums are all divisible by p, hence avoid any m with p ∤ m; and such a prime exists for every m ≥ 1.",
     "text": "A 0-axiom, 0-sorry proof that multiples of a prime p in {1,…,n} have size ⌊n/p⌋, avoid any m not divisible by p, and that such a prime exists for every m ≥ 1.",
-    "proofStrategy": "Self-contained in namespace Erdos771Construction, importing Mathlib. It re-declares the minimal objects (Icc_n, subsetSums, AvoidSum, primeMultiples). prime_multiples_size rewrites {1,…,n} as Ioc 0 n and applies Nat.Ioc_filter_dvd_card_eq_div to get ⌊n/p⌋. prime_multiples_avoid shows every subset sum is divisible by p via Finset.dvd_sum (each element is a multiple of p), so equality to m would force p ∣ m — contradicting the hypothesis. exists_prime_not_dvd takes a prime above m (Nat.exists_infinite_primes) which cannot divide a positive m. exists_avoiding_multiples combines these to produce, for every m ≥ 1, an m-avoiding subset of {1,…,n}.",
+    "proofStrategy": "Self-contained in namespace Erdos771Construction, importing Mathlib. It re-declares the minimal objects (Icc_n, subsetSums, AvoidSum, primeMultiples). prime_multiples_size rewrites {1,…,n} as Ioc 0 n and applies Nat.Ioc_filter_dvd_card_eq_div to get ⌊n/p⌋. prime_multiples_avoid shows every subset sum is divisible by p via Finset.dvd_sum (each element is a multiple of p), so equality to m would force p ∣ m — contradicting the hypothesis. exists_prime_not_dvd takes a prime above m (Nat.exists_infinite_primes) which cannot divide a positive m. exists_avoiding_multiples combines these to produce, for every m ≥ 1, an m-avoiding subset of {1,…,n}. Finally, exists_avoiding_multiples_quantitative upgrades existence to a quantitative bound: Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul) supplies a prime m < p ≤ 2m, which cannot divide m (helper prime_gt_not_dvd), so the size ⌊n/p⌋ of the construction is at least ⌊n/(2m)⌋ via Nat.div_le_div_left.",
     "keyInsights": [
       "**Divisibility blocks subset sums**: if every element of S is a multiple of p, so is every subset sum; therefore S avoids any target m with p ∤ m. This single observation is the engine of the Erdős–Graham lower bound.",
       "**Primality is not even needed for avoidance**: the avoidance property holds for the multiples of any p ∤ m; primality is retained only to match the construction (and to guarantee a suitable p exists densely).",
       "**Existence is free**: for every m ≥ 1 a prime above m fails to divide m, so the construction always applies — an m-avoiding set always exists.",
+      "**Bertrand makes it quantitative**: the bare existence uses *some* prime > m, possibly enormous (the least prime not dividing m = lcm{2,…,t} grows with t), so ⌊n/p⌋ could be tiny. Bertrand's postulate pins the prime to m < p ≤ 2m, giving the explicit size bound ⌊n/p⌋ ≥ ⌊n/(2m)⌋ — the construction's size is controlled to within a factor of two of n/m.",
       "**Honest boundary**: only the construction (and its size ⌊n/p⌋) is verified; the deep (1/2+o(1))·n/log n asymptotics remain external and are not assumed."
     ],
     "prerequisites": [
       "Finite sets and subset sums (Finset.powerset, Finset.sum)",
       "Divisibility of sums (Finset.dvd_sum)",
       "Counting multiples in an interval (Nat.Ioc_filter_dvd_card_eq_div)",
-      "Infinitude of primes (Nat.exists_infinite_primes)"
+      "Infinitude of primes (Nat.exists_infinite_primes)",
+      "Bertrand's postulate (Nat.exists_prime_lt_and_le_two_mul)"
     ]
   },
   "sections": [
@@ -73,17 +75,26 @@
     {
       "id": "existence",
       "title": "Existence: the Construction Always Applies",
-      "startLine": 93,
-      "endLine": 108,
+      "startLine": 83,
+      "endLine": 98,
       "summary": "exists_prime_not_dvd (a prime above m misses m) and exists_avoiding_multiples (hence an m-avoiding subset of {1,…,n} exists for every m ≥ 1).",
       "mathContext": "$\\forall m \\ge 1,\\ \\exists p\\ \\text{prime},\\ p \\nmid m$, giving an $m$-avoiding $S \\subseteq \\{1,\\dots,n\\}$."
+    },
+    {
+      "id": "quantitative",
+      "title": "Quantitative Existence via Bertrand's Postulate",
+      "startLine": 100,
+      "endLine": 140,
+      "summary": "prime_gt_not_dvd (a prime > m ≥ 1 cannot divide m) and exists_avoiding_multiples_quantitative: Bertrand gives a prime m < p ≤ 2m, so an m-avoiding subset of size ⌊n/p⌋ ≥ ⌊n/(2m)⌋ exists for every m ≥ 1.",
+      "mathContext": "$\\forall m \\ge 1,\\ \\exists p\\ \\text{prime},\\ m < p \\le 2m$ and $|S| = \\lfloor n/p \\rfloor \\ge \\lfloor n/(2m) \\rfloor$."
     }
   ],
   "conclusion": {
-    "summary": "This file verifies, with zero axioms and zero sorries, the elementary Erdős–Graham construction underlying the lower bound for Erdős #771: the multiples of a prime p in {1,…,n} have size ⌊n/p⌋, avoid any m not divisible by p, and such a prime exists for every m ≥ 1.",
-    "implications": "It turns the previously-sorried (and no-longer-compiling) construction lemmas of the companion file into machine-checked theorems, supplying the verified combinatorial core of the f(n) ≥ (1/2+o(1))·n/log n lower bound.",
+    "summary": "This file verifies, with zero axioms and zero sorries, the elementary Erdős–Graham construction underlying the lower bound for Erdős #771: the multiples of a prime p in {1,…,n} have size ⌊n/p⌋, avoid any m not divisible by p, such a prime exists for every m ≥ 1, and — via Bertrand's postulate — one can be chosen with m < p ≤ 2m, giving an m-avoiding subset of size ⌊n/p⌋ ≥ ⌊n/(2m)⌋.",
+    "implications": "It turns the previously-sorried (and no-longer-compiling) construction lemmas of the companion file into machine-checked theorems, supplying the verified combinatorial core of the f(n) ≥ (1/2+o(1))·n/log n lower bound, now with an explicit (factor-of-two) handle on the prime and hence on the avoiding-set size.",
     "openQuestions": [
       "The matching asymptotics f(n) = (1/2+o(1))·n/log n (Erdős–Graham lower + Alon–Freiman upper) remain unformalized here.",
+      "The per-m bound ⌊n/(2m)⌋ degrades as m grows; the n/log n lower bound requires a uniform-over-all-m argument (choosing primes near log n) that is not yet formalized.",
       "Can the optimal prime (smallest p ∤ m) be used to derive the (1/2)·n/log n leading constant in Lean?"
     ]
   },
@@ -108,6 +119,13 @@
       "year": "1988",
       "venue": "Combinatorica 8",
       "note": "Matching upper bound (LCM argument)"
+    },
+    {
+      "authors": "Bertrand, J. (Chebyshev; Erdős)",
+      "title": "Bertrand's postulate: a prime lies in (m, 2m] for every m ≥ 1",
+      "year": "1845",
+      "venue": "Mathlib: Nat.exists_prime_lt_and_le_two_mul",
+      "note": "Used to choose a prime m < p ≤ 2m, making the avoiding-set size bound quantitative (⌊n/(2m)⌋)"
     }
   ],
   "leanFile": {
@@ -115,9 +133,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos771Construction",
-    "lineCount": 108,
+    "lineCount": 140,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 6,
     "path": "Proofs/Erdos771Construction.lean",
     "sorries": 0,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Strengthens the verified **Erdős–Graham construction** for Erdős #771 (`Erdos771Construction.lean`) from *bare existence* of an m-avoiding set to a **quantitative size bound**, using Mathlib's verified **Bertrand's postulate**.

Erdős #771: `f(n)` = largest `k` such that for every target `m ≥ 1` there is `S ⊆ {1,…,n}`, `|S| = k`, with no nonempty subset summing to `m`. The construction takes `S` = multiples of a prime `p` in `{1,…,n}`; every subset sum is divisible by `p`, so `p ∤ m` ⇒ `S` avoids `m`.

### New theorems (0 axioms, 0 sorries)
- `prime_gt_not_dvd`: a prime `p > m ≥ 1` cannot divide `m` (else `p ≤ m`).
- `exists_avoiding_multiples_quantitative`: via `Nat.exists_prime_lt_and_le_two_mul` (Bertrand), for every `m ≥ 1` there is a prime `m < p ≤ 2m`, giving an `m`-avoiding subset of `{1,…,n}` of size `⌊n/p⌋ ≥ ⌊n/(2m)⌋`. Size bound via `Nat.div_le_div_left` (Nat division is antitone in the denominator).

### Why it matters
The bare `exists_avoiding_multiples` used *some* prime `> m`, which can be enormous — the least prime not dividing `m = lcm{2,…,t}` grows with `t`, so `⌊n/p⌋` could be tiny. Bertrand pins the prime to within a factor of two of `m`, turning existence into an explicit lower bound on the avoiding-set size.

### Honest boundary
This is a **per-m** bound (it weakens as `m` grows). The uniform-over-all-`m` argument behind the deep `f(n) = (1/2+o(1))·n/log n` asymptotics (Erdős–Graham lower + Alon–Freiman upper) remains external and is not formalized here.

## Verification
- `lake env lean Proofs/Erdos771Construction.lean` — compiles clean (offline, Mathlib 4.26.0).
- `#print axioms` on both new theorems: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **verified / 0-axiom**.

## Gallery
`erdos-771-construction` meta + annotations updated: 4→6 theorems, 108→140 lines, new "Quantitative Existence via Bertrand's Postulate" section/annotation, Bertrand added to prerequisites/references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)