### PR TITLE
research(erdos-1204): exact value A(3)=6 [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -272,6 +272,121 @@ theorem A_two : A 2 = 2 := by
     rw [heq] at ha
     exact not_admissible_zero_one ha
 
+/- ## The exact value `A(3) = 6`
+
+The next value after `A(2) = 2` is `A(3) = 6`. This is the first place where the
+gap between `A(k)` and the trivial packing bound `k - 1` opens up appreciably
+(`6` versus `2`), and `6` is exactly the Hardy–Littlewood minimal diameter
+`H(3)` of an admissible `3`-tuple.
+
+*Upper bound* `A(3) ≤ 6`: the set `{0, 2, 6}` is admissible (mod `2` all even, so
+the odd class is missed; mod `3` the residues are `{0, 2, 0}`, so class `1` is
+missed) and has largest element `6`.
+
+*Lower bound* `A(3) ≥ 6`: any admissible `3`-set with largest element `≤ 5` lies
+in `{0, …, 5}`. Modulo `2` it must miss a class, hence all three elements share a
+parity, forcing the set to be `{0, 2, 4}` or `{1, 3, 5}`. But each of those covers
+**all** residue classes modulo `3` (`{0,2,4} ≡ {0,2,1}`, `{1,3,5} ≡ {1,0,2}`), so
+neither is admissible — a contradiction. Hence no admissible `3`-set fits below `6`. -/
+
+/-- `{0, 2, 6}` is admissible: even mod `2` (misses the odd class) and `≡ {0,2,0}`
+mod `3` (misses class `1`); larger primes are automatic by the size bound. -/
+theorem admissible_zero_two_six : Admissible ({0, 2, 6} : Finset ℕ) := by
+  rw [admissible_iff_card]
+  intro p hp hcard
+  have hc : ({0, 2, 6} : Finset ℕ).card = 3 := by decide
+  rw [hc] at hcard
+  interval_cases p
+  · exact absurd hp (by decide)   -- p = 0
+  · exact absurd hp (by decide)   -- p = 1
+  · exact ⟨1, by intro x hx; fin_cases hx <;> decide⟩   -- p = 2: miss class 1
+  · exact ⟨1, by intro x hx; fin_cases hx <;> decide⟩   -- p = 3: miss class 1
+
+/-- `{0, 2, 4}` is **not** admissible: modulo `3` the residues `{0, 2, 1}` cover all
+three classes, so no class is missed. -/
+theorem not_admissible_zero_two_four : ¬ Admissible ({0, 2, 4} : Finset ℕ) := by
+  intro h
+  obtain ⟨r, hr⟩ := h 3 (by decide)
+  fin_cases r
+  · exact hr 0 (by decide) (by decide)   -- class 0 occupied by 0
+  · exact hr 4 (by decide) (by decide)   -- class 1 occupied by 4
+  · exact hr 2 (by decide) (by decide)   -- class 2 occupied by 2
+
+/-- `{1, 3, 5}` is **not** admissible: modulo `3` the residues `{1, 0, 2}` cover all
+three classes, so no class is missed. -/
+theorem not_admissible_one_three_five : ¬ Admissible ({1, 3, 5} : Finset ℕ) := by
+  intro h
+  obtain ⟨r, hr⟩ := h 3 (by decide)
+  fin_cases r
+  · exact hr 3 (by decide) (by decide)   -- class 0 occupied by 3
+  · exact hr 1 (by decide) (by decide)   -- class 1 occupied by 1
+  · exact hr 5 (by decide) (by decide)   -- class 2 occupied by 5
+
+/-- **Lower-bound core.** Every admissible `3`-set has largest element at least `6`.
+If the maximum were `≤ 5`, the set would sit in `{0, …, 5}`; missing a class mod `2`
+forces a single parity, pinning the set to `{0,2,4}` or `{1,3,5}`, both inadmissible
+mod `3`. -/
+theorem admissible_three_sup_ge {a : Finset ℕ} (hcard : a.card = 3)
+    (ha : Admissible a) : 6 ≤ a.sup id := by
+  by_contra hlt
+  push_neg at hlt
+  -- every element is ≤ 5
+  have hbound : ∀ x ∈ a, x ≤ 5 := by
+    intro x hx
+    have h1 : id x ≤ a.sup id := Finset.le_sup hx
+    simp only [id_eq] at h1
+    omega
+  -- in ZMod 2 every value is 0 or 1
+  have hy : ∀ y : ZMod 2, y = 0 ∨ y = 1 := by decide
+  -- 2 ∣ x ↔ (x : ZMod 2) = 0
+  have hdvd : ∀ x : ℕ, (x : ZMod 2) = 0 ↔ 2 ∣ x := fun x =>
+    ZMod.natCast_eq_zero_iff x 2
+  -- mod 2 the set misses a class, so all elements share a parity
+  obtain ⟨r2, hr2⟩ := ha 2 (by decide)
+  fin_cases r2
+  · -- misses class 0 ⇒ all elements odd ⇒ a = {1,3,5}
+    have hsub : a ⊆ ({1, 3, 5} : Finset ℕ) := by
+      intro x hx
+      have hx5 := hbound x hx
+      have hne : (x : ZMod 2) ≠ 0 := hr2 x hx
+      have hodd : ¬ 2 ∣ x := fun hd => hne ((hdvd x).mpr hd)
+      simp only [Finset.mem_insert, Finset.mem_singleton]
+      omega
+    have : a = ({1, 3, 5} : Finset ℕ) :=
+      Finset.eq_of_subset_of_card_le hsub (by rw [hcard]; decide)
+    rw [this] at ha
+    exact not_admissible_one_three_five ha
+  · -- misses class 1 ⇒ all elements even ⇒ a = {0,2,4}
+    have hsub : a ⊆ ({0, 2, 4} : Finset ℕ) := by
+      intro x hx
+      have hx5 := hbound x hx
+      have hne : (x : ZMod 2) ≠ 1 := hr2 x hx
+      have heven : 2 ∣ x := by
+        rcases hy (x : ZMod 2) with h0 | h1
+        · exact (hdvd x).mp h0
+        · exact absurd h1 hne
+      simp only [Finset.mem_insert, Finset.mem_singleton]
+      omega
+    have : a = ({0, 2, 4} : Finset ℕ) :=
+      Finset.eq_of_subset_of_card_le hsub (by rw [hcard]; decide)
+    rw [this] at ha
+    exact not_admissible_zero_two_four ha
+
+/-- **`A(3) = 6`.** The minimal largest element of an admissible `3`-set is `6`,
+attained by `{0, 2, 6}` (equivalently `{0, 4, 6}`). This matches the
+Hardy–Littlewood minimal diameter `H(3) = 6`. -/
+theorem A_three : A 3 = 6 := by
+  apply le_antisymm
+  · -- upper bound from the witness {0,2,6}
+    have h := A_le (k := 3) (a := ({0, 2, 6} : Finset ℕ)) (by decide)
+      admissible_zero_two_six
+    have hs : ({0, 2, 6} : Finset ℕ).sup id = 6 := by decide
+    rwa [hs] at h
+  · -- lower bound: the attained minimizer also has sup ≥ 6
+    obtain ⟨a, hcard, ha, hsup⟩ := A_mem 3
+    have hge := admissible_three_sup_ge hcard ha
+    omega
+
 /- ## Open Problems
 
 The asymptotic behaviour of the extremal quantities is OPEN:

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -78,3 +78,29 @@ A(k) between k-1 and (k-1)·primorial and nails the trivial small-k regime.
 Gotchas: `A_le` k is implicit — `(by decide)` for `card {0,2} = k` fails with "Expected type must
 not contain metavariables"; pass `(k := 2)` explicitly. `a.sup id ≥ k-1` via `a ⊆ range (sup+1)`
 + `Finset.le_sup (f := id)`. `Nat.sInf_mem`/`Nat.sInf_le` give attainment + lower bound directly.
+
+## Session 2026-06-25 (researcher-5) — exact value A(3)=6
+
+Added 5 verified theorems (now 23 thm / 2 def, 0 axioms, 0 sorries; #print axioms A_three =
+propext/Classical.choice/Quot.sound only — no native_decide, no sorryAx):
+- `A_three : A 3 = 6` — **the next exact value after A(2)=2**, and the first appreciable gap
+  over the packing bound (6 vs k-1=2). 6 = Hardy–Littlewood minimal diameter H(3).
+- `admissible_zero_two_six : Admissible {0,2,6}` — the witness giving A(3) ≤ 6 (all even ⇒
+  miss odd class mod 2; residues {0,2,0} mod 3 ⇒ miss class 1).
+- `admissible_three_sup_ge : a.card=3 → Admissible a → 6 ≤ a.sup id` — the lower bound core.
+- `not_admissible_zero_two_four`, `not_admissible_one_three_five` — both 3-sets cover ALL
+  classes mod 3, so are inadmissible.
+
+**Lower-bound argument (A(3) ≥ 6).** Any admissible 3-set with max ≤ 5 lies in {0,..,5}.
+Missing a class mod 2 forces all three elements to share a parity ⇒ the set is exactly
+{0,2,4} or {1,3,5} (the only single-parity triples in {0,..,5}). Both cover every residue
+class mod 3 ({0,2,1} and {1,0,2} resp.), so neither is admissible — contradiction.
+
+**Key realization.** A(k) = the Hardy–Littlewood minimal diameter H(k) (translation invariance
+makes min a_k = min diameter). So the exact-value frontier is just computing successive H(k):
+H(3)=6, H(4)=8, H(5)=12, …. Next: A(4)=8 (witness {0,2,6,8}).
+
+Gotchas: parity extracted via `ZMod.natCast_eq_zero_iff x 2` ((x:ZMod 2)=0 ↔ 2∣x) — note
+`ZMod.natCast_zmod_eq_zero_iff_dvd` is now DEPRECATED. `∀ y:ZMod 2, y=0∨y=1` by `decide`
+splits the ≠1 case to get evenness. `omega` closes membership in {0,2,4}/{1,3,5} from
+`x ≤ 5` + a divisibility fact. Pin the 3-set with `Finset.eq_of_subset_of_card_le`.

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -56,12 +56,13 @@
       "A(k) defined in Lean for the first time: A k = sInf of the largest elements (a.sup id) over admissible k-sets — makes the headline question A(k)∼k log k expressible",
       "A_mem / A_le: the infimum defining A(k) is attained (nonempty family via exists_admissible_card) and is a genuine lower bound",
       "card_le_sup_succ + sub_one_le_A: trivial packing lower bound A(k) ≥ k-1",
-      "A_zero=0, A_one=0, and A_two=2 computed exactly; A(2)=2 > 1=k-1 is the first place admissibility is binding ({0,1} inadmissible forces the max above the packing bound)"
+      "A_zero=0, A_one=0, and A_two=2 computed exactly; A(2)=2 > 1=k-1 is the first place admissibility is binding ({0,1} inadmissible forces the max above the packing bound)",
+      "A_three: the exact value A(3)=6 (= Hardy–Littlewood minimal diameter H(3)). Upper bound from the admissible witness {0,2,6}; lower bound via a finite argument — any admissible 3-set with max ≤ 5 must (mod 2) be single-parity, pinning it to {0,2,4} or {1,3,5}, both of which cover all classes mod 3 and so are inadmissible (admissible_three_sup_ge + not_admissible_zero_two_four / not_admissible_one_three_five)"
     ],
     "axiomCount": 0,
-    "lineCount": 289,
-    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), two-sided bounds k-1 ≤ A(k) ≤ (k-1)·primorial, and the exact values A(0)=A(1)=0, A(2)=2.",
-    "theoremCount": 18,
+    "lineCount": 404,
+    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), two-sided bounds k-1 ≤ A(k) ≤ (k-1)·primorial, and the exact values A(0)=A(1)=0, A(2)=2, A(3)=6.",
+    "theoremCount": 23,
     "definitionCount": 2
   },
   "overview": {
@@ -74,7 +75,7 @@
       "**Only small primes matter:** for p > k there are more classes than elements, so a class is always free — admissibility reduces to primes p ≤ k.",
       "**Minimal example:** {0,2} is admissible but {0,1} is not, because {0,1} hits both classes mod 2 (this is why twin-prime-like patterns must avoid such coverage).",
       "**Connection:** this is exactly the admissible-tuple notion underlying bounded gaps between primes (Zhang, Maynard).",
-      "**A(k) is now defined and pinned in the trivial regime:** k-1 ≤ A(k), with A(0)=A(1)=0 and A(2)=2 — the value A(2)=2>1 shows admissibility first becomes binding at k=2."
+      "**A(k) is now defined and computed for small k:** k-1 ≤ A(k), with A(0)=A(1)=0, A(2)=2, and A(3)=6 — the latter equals the Hardy–Littlewood minimal diameter H(3) and is proved by a finite parity-then-mod-3 argument (no admissible 3-set fits below 6)."
     ],
     "prerequisites": [
       "Number theory",
@@ -129,9 +130,9 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 289,
+    "lineCount": 404,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 23,
     "definitionCount": 2,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1204.json
+++ b/src/data/research/problems/erdos-1204.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: A(k) now defined in Lean and pinned in the trivial regime (A(0)=A(1)=0, A(2)=2; bounds k-1 ≤ A(k) ≤ (k-1)·primorial). Headline asymptotics A(k)∼k log k and B(k) remain OPEN (sieve theory).",
+    "progressSummary": "PROGRESS: A(k) defined in Lean; exact small values A(0)=A(1)=0, A(2)=2, A(3)=6 (=Hardy–Littlewood minimal diameter H(3)). Two-sided bounds k-1 ≤ A(k) ≤ (k-1)·primorial. Headline asymptotics A(k)∼k log k and B(k) remain OPEN (sieve theory).",
     "builtItems": [
       "Erdos1204.Admissible (def) in Proofs/Erdos1204Problem.lean",
       "Erdos1204.missing_class_of_card_lt",
@@ -39,7 +39,10 @@
       "admissible_image_add (translation invariance) in Erdos1204Problem.lean:140",
       "card_image_add (translation preserves card) in Erdos1204Problem.lean:152",
       "exists_admissible_card (∃ admissible k-set ⇒ A(k) well-defined) in Erdos1204Problem.lean:165",
-      "Erdos1204Problem.lean: def A + A_mem/A_le/sub_one_le_A/A_zero/A_one/A_two/card_le_sup_succ/A_set_nonempty (8 thm + 1 def)"
+      "Erdos1204Problem.lean: def A + A_mem/A_le/sub_one_le_A/A_zero/A_one/A_two/card_le_sup_succ/A_set_nonempty (8 thm + 1 def)",
+      "A_three: A(3)=6 proved exactly (Erdos1204Problem.lean), with witness {0,2,6} and finite lower-bound argument",
+      "admissible_three_sup_ge: every admissible 3-set has max ≥ 6 (parity forces {0,2,4} or {1,3,5}, both inadmissible mod 3)",
+      "not_admissible_zero_two_four / not_admissible_one_three_five / admissible_zero_two_six: supporting examples for A(3)"
     ],
     "insights": [
       "Admissibility is purely local: only the residue pattern mod each prime matters.",
@@ -47,14 +50,18 @@
       "{0,2} is the minimal nontrivial admissible 2-tuple; {0,1} fails because it covers both classes mod 2.",
       "Admissibility is downward-closed and translation-invariant: it is a property of the *pattern* of a tuple, not its position.",
       "An admissible k-tuple exists for every k: take multiples 0,N,2N,...,(k-1)N of the primorial N=∏_{p≤k}p; mod each prime p≤k all are ≡0 so class 1 is missed, larger primes auto by size bound. This makes A(k) well-defined and gives the explicit weak upper bound A(k) ≤ (k-1)·∏_{p≤k}p.",
-      "A(k) defined as sInf of max over admissible k-sets; infimum attained (nonempty family); k-1 ≤ A(k) ≤ (k-1)·primorial; A(0)=A(1)=0, A(2)=2 (admissibility first binding at k=2)."
+      "A(k) defined as sInf of max over admissible k-sets; infimum attained (nonempty family); k-1 ≤ A(k) ≤ (k-1)·primorial; A(0)=A(1)=0, A(2)=2 (admissibility first binding at k=2).",
+      "A(k) equals the Hardy–Littlewood minimal diameter H(k) (by translation invariance min a_k = min diameter); so A(3)=H(3)=6, A(4)=H(4)=8, etc. — the exact-value frontier is computing successive H(k).",
+      "Lower bound for A(3): the mod-2 admissibility constraint forces all three elements to share a parity, so within {0,..,5} the only candidates are {0,2,4} and {1,3,5}, both of which cover every class mod 3. This parity-then-residue pruning is the model for larger exact values."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Formalize explicit admissible-tuple constructions to bound A(k) above.",
       "Investigate a lower-bound argument toward A(k) ≳ k log k.",
       "Define A(k) (and B(k)) as Lean functions (sInf over admissible k-sets) and prove the weak upper bound A(k) ≤ (k-1)·primorial(k) formally.",
-      "The headline A(k)∼k log k needs sieve theory / prime distribution — remains OPEN."
+      "The headline A(k)∼k log k needs sieve theory / prime distribution — remains OPEN.",
+      "Prove A(4)=8 (witness {0,2,6,8}; lower bound needs mod-2 and mod-3 pruning over {0,..,7}).",
+      "Generalize the lower-bound pruning into a reusable lemma: an admissible k-set within {0,..,N} must avoid a class mod each prime ≤ k, enabling a decision procedure for A(k) at small k."
     ],
     "markdown": "# Erdős #1204 - Knowledge Base\n\n## Problem Statement\n\nWe call a sequence of integers $0\\leq a_1<\\cdots <a_k$ admissible if it is missing at least one congruence class modulo every prime $p$. Let $A(k)=\\min a_k$. Estimate $A(k)$ - in particular, is it true that\\[A(k)\\sim k\\log k?\\]Estimate\\[B(k)=\\min \\frac{a_1+\\cdots+a_k}{k}.\\]\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #2\n- Problem #855\n- Problem #1203\n- Problem #1205\n- Problem #39\n- Problem #1\n\n## References\n\n- Er80\n- HeRi73\n- Po14c\n- El65\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-04-16*\n"
   },


### PR DESCRIPTION
## Summary

Extends the **Erdős Problem #1204** (admissible sequences) gallery entry with the next exact value of `A(k)` after `A(2)=2`:

**`A_three : A 3 = 6`** — the minimal largest element of an admissible 3-set is 6, equal to the Hardy–Littlewood minimal diameter `H(3)`.

`A(k)` is the minimal `aₖ` over admissible `k`-tuples; by translation invariance this equals the minimal *diameter*, i.e. the Hardy–Littlewood quantity `H(k)`. So computing exact small values of `A(k)` is exactly computing `H(3)=6, H(4)=8, …`.

### Proof
- **Upper bound** `A(3) ≤ 6`: the witness `{0,2,6}` is admissible (all even ⇒ misses the odd class mod 2; residues `{0,2,0}` mod 3 ⇒ misses class 1).
- **Lower bound** `A(3) ≥ 6` (`admissible_three_sup_ge`): any admissible 3-set with max `≤ 5` lies in `{0,…,5}`. Missing a class mod 2 forces all three elements to share a parity, so the set is exactly `{0,2,4}` or `{1,3,5}` — the only single-parity triples in `{0,…,5}`. Both cover **every** residue class mod 3 (`{0,2,1}` and `{1,0,2}`), so neither is admissible. Contradiction.

### Changes
- `proofs/Proofs/Erdos1204Problem.lean`: +5 theorems (`admissible_zero_two_six`, `not_admissible_zero_two_four`, `not_admissible_one_three_five`, `admissible_three_sup_ge`, `A_three`). Now 23 thm / 2 def.
- Gallery `meta.json` + research `knowledge.md`/JSON updated.

### Verification
- Builds clean against Mathlib v4.26.0 (offline `lake env lean`, Docker unavailable), 0 errors/warnings.
- 0 sorries, 0 `axiom` declarations.
- `#print axioms A_three` → `propext, Classical.choice, Quot.sound` only — **no** `native_decide`/`Lean.ofReduceBool`, no `sorryAx`. Genuinely axiom-free.

The headline asymptotic questions (`A(k) ∼ k log k?` and `B(k)`) remain **OPEN** and are not asserted; entry status stays `axiomatized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)