### PR TITLE
Enrich Nine-Point Circle (abstract inner product space): populate empty annotations.json

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04-oq-03/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-overview",
+    "proofId": "feuerbachs-theorem-defs-oq-04-oq-03",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "context",
+    "title": "Coordinate-Free Nine-Point Circle: the Open Question and Strategy",
+    "content": "Euler (1765) observed that nine special points of a triangle are concyclic — the three side midpoints, the three feet of the altitudes, and the three midpoints of the vertex-to-orthocenter segments; Feuerbach (1822) added the tangency to the incircle and excircles. The gallery already formalises the nine concyclic points in a fixed coordinate model (Point = ℝ × ℝ) and bridges one coordinate triangle to Mathlib's Metric.sphere. This file takes the open-question step OQ-04 → OQ-03: discard coordinates and prove the theorem for an arbitrary triangle in ANY real inner product space V, with the circumcenter O supplied as a hypothesis (dist O A = dist O B = dist O C = R). The result is genuinely more general than the gallery in three ways: no coordinates (V is any InnerProductSpace ℝ V — EuclideanSpace ℝ (Fin 2), ℝ³, an abstract Hilbert space), no nondegeneracy needed for six of the nine points (the midpoint-type points lie on the circle even for collinear A B C), and a free choice of circumcenter. Since Mathlib has no nine-point/Feuerbach circle, this is new, upstream-ready infrastructure (headline ninePoints_mem_sphere). The proof normalises O to the origin and reduces everything to vector identities in a = A−O, b = B−O, c = C−O with ‖a‖=‖b‖=‖c‖=R.",
+    "mathContext": "All nine points lie on $\\mathrm{sphere}(N, R/2)$, $N = (A+B+C-O)/2$, given $\\mathrm{dist}\\,O\\,A = \\mathrm{dist}\\,O\\,B = \\mathrm{dist}\\,O\\,C = R$ in any real inner product space.",
+    "significance": "context",
+    "relatedConcepts": ["nine-point circle", "Feuerbach's theorem", "Euler line", "InnerProductSpace ℝ V", "coordinate-free geometry", "Metric.sphere"],
+    "prerequisites": ["the classical nine-point circle (background)", "real inner product spaces", "circumcenter / orthocenter of a triangle"]
+  },
+  {
+    "id": "ann-constructions",
+    "proofId": "feuerbachs-theorem-defs-oq-04-oq-03",
+    "range": { "startLine": 64, "endLine": 83 },
+    "type": "definition",
+    "title": "Coordinate-Free Constructions (orthocenter, ninePointCenter, ninePointRadius, foot)",
+    "content": "Four definitions build the configuration as plain vector terms valid in any InnerProductSpace ℝ V — not the gallery's ℝ × ℝ coordinate formulas. orthocenter A B C O = A + B + C − 2•O is the standard relation H = A+B+C−2O when O is the circumcenter. ninePointCenter A B C O = (1/2)•(A+B+C−O) is the midpoint of O and H. ninePointRadius A B C O = dist O A / 2 is half the circumradius. foot P Q S = Q + (⟪P−Q,S−Q⟫/⟪S−Q,S−Q⟫)•(S−Q) is the orthogonal projection of P onto the line through Q and S — the standard inner-product formula for the perpendicular foot. ninePointCenter_rotate proves the centre is symmetric under cyclic vertex permutation (ninePointCenter B C A O = ninePointCenter A B C O), closed by the `module` tactic; this symmetry later lets all three altitude feet be derived from a single core lemma.",
+    "mathContext": "$H = A+B+C-2O$; $N = \\tfrac12(A+B+C-O)$; $\\mathrm{foot}(P,Q,S) = Q + \\frac{\\langle P-Q, S-Q\\rangle}{\\langle S-Q, S-Q\\rangle}(S-Q)$.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal projection onto a line", "orthocenter as A+B+C−2O", "nine-point centre", "vertex-permutation symmetry", "the module tactic"],
+    "prerequisites": ["vector arithmetic in an inner product space", "the orthogonal-projection formula", "midpoints as (1/2)•(·)"]
+  },
+  {
+    "id": "ann-foot-core",
+    "proofId": "feuerbachs-theorem-defs-oq-04-oq-03",
+    "range": { "startLine": 85, "endLine": 120 },
+    "type": "theorem",
+    "title": "The Analytic Heart: Altitude Foot at the Origin (foot_core)",
+    "content": "foot_core is the only place the inner-product structure is genuinely used. With the circumcenter normalised to the origin (‖a‖=‖b‖=‖c‖=R, b ≠ c), it proves the foot of the altitude from a onto line bc lies at distance R/2 from N = (a+b+c)/2. The proof: substitute the radius identities ⟪x,x⟫ = R² (real_inner_self_eq_norm_sq), record the denominator value ⟪c−b,c−b⟫ = 2R² − 2⟪b,c⟫ and that it is nonzero (so R² − ⟪b,c⟫ ≠ 0), rewrite the difference N − F into (1/2)•(a−b+c) − t•(c−b) via `module`, reduce dist = R/2 to ‖·‖² = (R/2)² through Real.sqrt_sq, expand ‖·‖² = ⟪·,·⟫_ℝ with full bilinearity + symmetry (inner_sub/add_left/right, real_inner_smul, real_inner_comm), substitute the three ⟪x,x⟫ = R² values, and finally clear the single division with field_simp [hden2] and close by ring. Substituting the denominator's value BEFORE expanding is what turns the geometry into a polynomial identity that ring discharges.",
+    "mathContext": "$\\|N-F\\|^2 = R^2/4$ with $F = b + t(c-b)$, $t = \\frac{\\langle a-b,c-b\\rangle}{\\langle c-b,c-b\\rangle}$, after $\\langle c-b,c-b\\rangle = 2R^2 - 2\\langle b,c\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": ["altitude foot distance", "real_inner_self_eq_norm_sq", "bilinearity + symmetry of the real inner product", "field_simp + ring", "Real.sqrt_sq"],
+    "prerequisites": ["expanding ‖·‖² via the inner product", "inner_sub_left/right and real_inner_comm", "clearing a division before ring"]
+  },
+  {
+    "id": "ann-midpoints",
+    "proofId": "feuerbachs-theorem-defs-oq-04-oq-03",
+    "range": { "startLine": 122, "endLine": 169 },
+    "type": "theorem",
+    "title": "The Six Midpoint-Type Memberships (dist_eq_of_diff + corollaries)",
+    "content": "The three side midpoints and three vertex-orthocenter midpoints need no inner-product computation at all. The private helper dist_eq_of_diff says: if N − P = (1/2)•Y with ‖Y‖ = dist O A, then dist N P = ninePointRadius (= dist O A / 2) — proved by norm_smul. Six one-line corollaries then instantiate it: each difference N − P equals ±(1/2)•(X − O) for X ∈ {A,B,C} (or O − X), verified by the `module` tactic, with ‖X − O‖ = R supplied by the relevant circumradius equality (and dist_eq_norm/norm_sub_rev to orient it). Notably dist_midpoint_BC and dist_midpoint_AH need NO circumradius hypothesis — the side-BC and A-to-orthocenter midpoints lie on the circle for any A B C, hence even for collinear (degenerate) triangles; only the other four pull in a circumradius equality, and only the altitude feet require a genuine line.",
+    "mathContext": "$N - \\mathrm{mid}(B,C) = \\tfrac12(A-O)$, $N - \\mathrm{mid}(A,H) = \\tfrac12(O-A)$, etc., each of norm $R/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["midpoint memberships", "norm_smul", "the module tactic for vector identities", "degenerate (collinear) triangles", "hypothesis-free concyclicity"],
+    "prerequisites": ["the definitions of ninePointCenter / ninePointRadius / orthocenter", "norm of a scalar multiple", "dist_eq_norm and norm_sub_rev"]
+  },
+  {
+    "id": "ann-feet",
+    "proofId": "feuerbachs-theorem-defs-oq-04-oq-03",
+    "range": { "startLine": 171, "endLine": 207 },
+    "type": "theorem",
+    "title": "The Three Altitude Feet via Translation + Rotation (dist_foot, dist_foot_A/B/C)",
+    "content": "dist_foot lifts foot_core from the origin to an arbitrary circumcenter O. The altitude-foot parameter t = ⟪A−B,C−B⟫/⟪C−B,C−B⟫ is translation-invariant (the O's cancel in the differences), so applying foot_core to a = A−O, b = B−O, c = C−O and then rewriting (1/2)•(a+b+c) = N − O and foot's expansion = foot A B C − O (both by `module`) reduces the general distance to the origin case via dist_sub_right (dist is translation-invariant). dist_foot_A is just dist_foot; dist_foot_B and dist_foot_C cover the other two altitudes by rotating the vertices and using ninePointCenter_rotate to keep the centre fixed — so all three altitude feet follow from the single core lemma. Only these three statements require their side to be a genuine line (B ≠ C etc.), the sole nondegeneracy hypotheses in the file.",
+    "mathContext": "$\\mathrm{dist}(N, \\mathrm{foot}(A,B,C)) = R/2$ from `foot_core` by `dist_sub_right`; the other altitudes by cyclic rotation + `ninePointCenter_rotate`.",
+    "significance": "supporting",
+    "relatedConcepts": ["translation invariance of distance (dist_sub_right)", "translation-invariant projection parameter", "vertex rotation symmetry", "lifting a normalised lemma", "nondegeneracy B ≠ C"],
+    "prerequisites": ["the core lemma foot_core", "dist_sub_right", "ninePointCenter_rotate and module rewrites"]
+  },
+  {
+    "id": "ann-headline",
+    "proofId": "feuerbachs-theorem-defs-oq-04-oq-03",
+    "range": { "startLine": 209, "endLine": 239 },
+    "type": "theorem",
+    "title": "Headline: All Nine Points on One Metric.sphere (ninePoints_mem_sphere)",
+    "content": "ninePoints_mem_sphere is the full coordinate-free nine-point circle theorem: for a triangle A B C in any real inner product space with common circumcenter O (dist O A = dist O B = dist O C = R) and distinct vertices, all nine special points — the three side midpoints, the three vertex-orthocenter midpoints, and the three altitude feet — lie on the single Metric.sphere about the nine-point centre with radius R/2. The proof derives the two circumradius equalities and ninePointRadius = R/2, then splits the nine-fold conjunction (refine ⟨…⟩ <;> rw [Metric.mem_sphere, dist_comm]) and discharges each conjunct with the matching distance lemma (six midpoint lemmas and the three dist_foot_A/B/C). Phrasing membership through Metric.sphere — rather than a bespoke predicate — keeps the statement directly compatible with Mathlib's metric/EuclideanGeometry library, which is the point of the OQ-03 generalisation.",
+    "mathContext": "$\\{$6 midpoints$\\} \\cup \\{$3 altitude feet$\\} \\subseteq \\mathrm{Metric.sphere}(N, R/2)$ for any non-degenerate triangle.",
+    "significance": "key",
+    "relatedConcepts": ["nine-point circle theorem", "Metric.sphere / Metric.mem_sphere", "dist_comm", "Mathlib-ready geometry", "assembling a conjunction"],
+    "prerequisites": ["all six midpoint and three foot distance lemmas", "Metric.mem_sphere unfolding", "the common-circumradius hypothesis"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-04-oq-03` (quality 33, passes 0).

## Gap
Complete meta.json (5 sections, 5 keyInsights, structured conclusion, `originalContributions`) but the `annotations.json` was **empty (`[]`)** — no inline annotations on the proof page.

## Change
Populated `annotations.json` with **6 annotations covering the full 243-line Lean file**, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:
1. **overview** (1–50) — the OQ-04→OQ-03 coordinate-free generalisation and the translate-to-origin strategy.
2. **constructions** (64–83) — `orthocenter`, `ninePointCenter`, `ninePointRadius`, `foot`, and the vertex symmetry.
3. **foot_core** (85–120) — the analytic heart: `‖N−F‖² = R²/4` via inner-product expansion closed by `field_simp; ring`.
4. **midpoints** (122–169) — the six hypothesis-light midpoint memberships via `dist_eq_of_diff` (two need no circumradius hypothesis).
5. **feet** (171–207) — the three altitude feet via translation (`dist_sub_right`) + rotation.
6. **ninePoints_mem_sphere** (209–239) — the headline nine-fold `Metric.sphere` membership.

## Notes
- Pure data; no TypeScript touched. `annotations:build` exits clean with **no warnings for this proof**.
- `status: verified` / `badge: original` / `axiomCount: 0` / 0 sorries / no `native_decide` confirmed against the Lean source.
- Dedicated branch, independent of sibling enrichment PRs.