### PR TITLE
research(lagrange-four-squares-oq-03): Waring g(4)≤53 via Liouville identity + Lagrange [verified, 0 axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3411,6 +3411,7 @@ import Proofs.LagrangeFourSquares
 import Proofs.LagrangeFourSquaresOQ01
 import Proofs.LagrangeFourSquaresOQ01OQ01
 import Proofs.LagrangeFourSquaresOQ02
+import Proofs.LagrangeFourSquaresOQ03
 import Proofs.LagrangeFourSquaresOQ04
 import Proofs.LagrangeFourSquaresWaringG2
 import Proofs.LagrangeFourSquaresWaringG2OQ01

--- a/proofs/Proofs/LagrangeFourSquaresOQ03.lean
+++ b/proofs/Proofs/LagrangeFourSquaresOQ03.lean
@@ -1,0 +1,156 @@
+import Mathlib
+
+/-
+# Waring's problem for fourth powers via a Lagrange-type argument: `g(4) ≤ 53`
+
+This file gives a **sorry-free, axiom-free** proof that every natural number is a
+sum of at most `53` fourth powers, i.e. an explicit finite upper bound for the
+Waring constant `g(4)`.  The whole argument is "Lagrange-type": it rests entirely
+on Lagrange's four-square theorem (`Nat.sum_four_squares`) together with the
+classical **Liouville identity**
+
+  `6 (a² + b² + c² + d²)² = Σ_{i<j} ((xᵢ + xⱼ)⁴ + (xᵢ − xⱼ)⁴)`        (★)
+
+over the four variables `a, b, c, d`.  The right-hand side is a sum of `12`
+fourth powers, so (★) says that `6 m²` is a sum of `12` fourth powers whenever
+`m` is itself a sum of four squares — which, by Lagrange, is *every* `m`.
+
+## Context in the gallery
+
+The existing `lagrange-four-squares-waring-g2-*` entries establish the **lower**
+bound `g(4) ≥ 19` (via a counting / `omega` infeasibility argument).  This file
+supplies the complementary **upper** bound `g(4) ≤ 53` and, in particular, the
+*finiteness* of `g(4)` — the qualitative heart of Waring's problem for fourth
+powers — by the elementary Liouville route rather than by the analytic
+circle-method machinery.  The constant `53` is the classical Liouville bound; it
+is not optimal (the true value is `g(4) = 19`), but it is obtained here by a
+completely self-contained finite argument.
+
+## Proof outline
+
+1. `liouville_identity` — the polynomial identity (★) over `ℤ`, closed by `ring`.
+2. `IsSumOfFourthPowers` — `n` is a sum of `k` fourth powers (zero summands are
+   allowed, so this really means "at most `k`").  It is closed under
+   concatenation (`append`) and padding by zeros (`zeros`, `succ`).
+3. `sixMulSq_isSum` — `6 m²` is a sum of `12` fourth powers, by feeding the four
+   squares from Lagrange into (★).  The `12` summands are `a ± b`, `a ± c`, …,
+   realised as natural numbers via `Int.natAbs`.
+4. `sixMul_isSum` — `6 Q` is a sum of `48` fourth powers, writing
+   `Q = m₁² + m₂² + m₃² + m₄²` (Lagrange again) and applying step 3 four times.
+5. `waring_four` — `N = 6 (N / 6) + N % 6` with `N % 6 ≤ 5`; the quotient block
+   is `48` fourth powers and the residue is at most `5` copies of `1⁴`, giving
+   `53` in total.
+-/
+
+namespace LagrangeFourSquaresOQ03
+
+/-- **Liouville's identity** over `ℤ`: six times the square of a sum of four
+squares equals a sum of twelve fourth powers, namely `(xᵢ ± xⱼ)⁴` over the six
+unordered pairs `{i, j} ⊆ {a, b, c, d}`. -/
+theorem liouville_identity (a b c d : ℤ) :
+    6 * (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2) ^ 2 =
+      (a + b) ^ 4 + (a - b) ^ 4 + (a + c) ^ 4 + (a - c) ^ 4 + (a + d) ^ 4 + (a - d) ^ 4
+        + (b + c) ^ 4 + (b - c) ^ 4 + (b + d) ^ 4 + (b - d) ^ 4 + (c + d) ^ 4 + (c - d) ^ 4 := by
+  ring
+
+/-- For an integer `z`, the fourth power of its natural absolute value (viewed
+back in `ℤ`) is `z ⁴`.  This lets us realise the difference summands `(xᵢ − xⱼ)⁴`
+of Liouville's identity as fourth powers of *natural* numbers. -/
+theorem cast_natAbs_pow4 (z : ℤ) : ((z.natAbs : ℤ)) ^ 4 = z ^ 4 := by
+  rw [← Int.abs_eq_natAbs, ← abs_pow]
+  exact abs_of_nonneg (by positivity)
+
+/-- `n` is a sum of `k` fourth powers.  Because `0 ⁴ = 0`, allowing zero
+summands means this is really "`n` is a sum of *at most* `k` fourth powers". -/
+def IsSumOfFourthPowers (k n : ℕ) : Prop :=
+  ∃ l : List ℕ, l.length = k ∧ (l.map (· ^ 4)).sum = n
+
+namespace IsSumOfFourthPowers
+
+/-- The empty sum: `0` is a sum of `0` fourth powers. -/
+theorem zero : IsSumOfFourthPowers 0 0 := ⟨[], rfl, rfl⟩
+
+/-- A single fourth power. -/
+theorem single (a : ℕ) : IsSumOfFourthPowers 1 (a ^ 4) := ⟨[a], rfl, by simp⟩
+
+/-- Concatenating representations: a sum of `k₁` fourth powers plus a sum of
+`k₂` fourth powers is a sum of `k₁ + k₂` fourth powers. -/
+theorem append {k₁ k₂ x y : ℕ} (hx : IsSumOfFourthPowers k₁ x)
+    (hy : IsSumOfFourthPowers k₂ y) : IsSumOfFourthPowers (k₁ + k₂) (x + y) := by
+  obtain ⟨l, hl, hls⟩ := hx
+  obtain ⟨m, hm, hms⟩ := hy
+  exact ⟨l ++ m, by rw [List.length_append, hl, hm],
+    by rw [List.map_append, List.sum_append, hls, hms]⟩
+
+/-- `0` is a sum of any number `k` of fourth powers (all summands zero). -/
+theorem zeros (k : ℕ) : IsSumOfFourthPowers k 0 := by
+  refine ⟨List.replicate k 0, by simp, ?_⟩
+  rw [List.map_replicate]
+  simp
+
+/-- Padding by one zero summand: monotonicity in the number of summands. -/
+theorem succ {k n : ℕ} (h : IsSumOfFourthPowers k n) : IsSumOfFourthPowers (k + 1) n := by
+  have := (zeros 1).append h
+  simpa [Nat.add_comm] using this
+
+end IsSumOfFourthPowers
+
+open IsSumOfFourthPowers
+
+/-- **Liouville step.** For any naturals `a, b, c, d`, the number
+`6 (a² + b² + c² + d²)²` is a sum of `12` fourth powers.  The twelve summands
+are `a + b`, `|a − b|`, …, `c + d`, `|c − d|`, and the identity is verified by
+casting to `ℤ` and applying `liouville_identity`. -/
+theorem sixMulSq_isSum (a b c d : ℕ) :
+    IsSumOfFourthPowers 12 (6 * (a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2) ^ 2) := by
+  refine ⟨[a + b, ((a : ℤ) - b).natAbs, a + c, ((a : ℤ) - c).natAbs,
+           a + d, ((a : ℤ) - d).natAbs, b + c, ((b : ℤ) - c).natAbs,
+           b + d, ((b : ℤ) - d).natAbs, c + d, ((c : ℤ) - d).natAbs], rfl, ?_⟩
+  simp only [List.map_cons, List.map_nil, List.sum_cons, List.sum_nil, add_zero]
+  rw [← @Nat.cast_inj ℤ]
+  simp only [Nat.cast_add, Nat.cast_pow, Nat.cast_mul, Nat.cast_ofNat, cast_natAbs_pow4]
+  linear_combination liouville_identity (a : ℤ) (b : ℤ) (c : ℤ) (d : ℤ)
+
+/-- `6 m²` is a sum of `12` fourth powers, for every natural `m`: apply
+Lagrange's four-square theorem to `m` and feed the result into the Liouville
+step. -/
+theorem sixMulSq (m : ℕ) : IsSumOfFourthPowers 12 (6 * m ^ 2) := by
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares m
+  have := sixMulSq_isSum a b c d
+  rwa [h] at this
+
+/-- `6 Q` is a sum of `48` fourth powers, for every natural `Q`: write
+`Q = m₁² + m₂² + m₃² + m₄²` (Lagrange), so `6 Q = 6 m₁² + 6 m₂² + 6 m₃² + 6 m₄²`,
+and apply the previous step to each block. -/
+theorem sixMul (Q : ℕ) : IsSumOfFourthPowers 48 (6 * Q) := by
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares Q
+  have e : 6 * Q = 6 * a ^ 2 + 6 * b ^ 2 + (6 * c ^ 2 + 6 * d ^ 2) := by rw [← h]; ring
+  rw [e]
+  have h1 := ((sixMulSq a).append (sixMulSq b)).append ((sixMulSq c).append (sixMulSq d))
+  -- `h1 : IsSumOfFourthPowers ((12+12)+(12+12)) ((6a²+6b²)+(6c²+6d²))`
+  rw [show (6 * a ^ 2 + 6 * b ^ 2 + (6 * c ^ 2 + 6 * d ^ 2))
+        = (6 * a ^ 2 + 6 * b ^ 2) + (6 * c ^ 2 + 6 * d ^ 2) by ring]
+  exact h1
+
+/-- **Waring's problem for fourth powers, upper bound.**  Every natural number
+`N` is a sum of at most `53` fourth powers.  Hence the Waring constant `g(4)` is
+finite, with `g(4) ≤ 53`.  The proof is purely a Lagrange-type argument: it uses
+only Lagrange's four-square theorem and Liouville's identity. -/
+theorem waring_four (N : ℕ) : IsSumOfFourthPowers 53 N := by
+  -- residue part: `N % 6 ≤ 5` copies of `1⁴ = 1`, padded to `5` summands
+  have hr : N % 6 ≤ 5 := by omega
+  have hres : IsSumOfFourthPowers 5 (N % 6) := by
+    -- `N % 6` copies of `1` realise `N % 6`; pad with `5 - N % 6` zeros
+    have hones : IsSumOfFourthPowers (N % 6) (N % 6) := by
+      refine ⟨List.replicate (N % 6) 1, by simp, ?_⟩
+      rw [List.map_replicate]
+      simp
+    have := hones.append (zeros (5 - N % 6))
+    rwa [Nat.add_sub_cancel' hr, add_zero] at this
+  -- quotient part: `48` fourth powers for `6 * (N / 6)`
+  have hquot : IsSumOfFourthPowers 48 (6 * (N / 6)) := sixMul (N / 6)
+  -- combine: `48 + 5 = 53` summands for `6 * (N / 6) + N % 6 = N`
+  have := hquot.append hres
+  rwa [Nat.div_add_mod N 6] at this
+
+end LagrangeFourSquaresOQ03

--- a/src/data/proofs/lagrange-four-squares-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-liouville-identity",
+    "proofId": "lagrange-four-squares-oq-03",
+    "range": { "startLine": 50, "endLine": 57 },
+    "type": "theorem",
+    "title": "Liouville's identity: 6(a²+b²+c²+d²)² as twelve fourth powers",
+    "content": "The classical Liouville identity $6(a^2+b^2+c^2+d^2)^2 = \\sum_{1\\le i<j\\le 4}\\big((x_i+x_j)^4+(x_i-x_j)^4\\big)$, stated over $\\mathbb{Z}$ and closed by a single `ring`. The right-hand side runs over the six unordered pairs from $\\{a,b,c,d\\}$, giving twelve fourth powers. The reason it holds: $(u+v)^4+(u-v)^4 = 2u^4+12u^2v^2+2v^4$, so summing over all six pairs yields $6\\sum_i x_i^4 + 12\\sum_{i<j}x_i^2x_j^2$, which is exactly $6(\\sum_i x_i^2)^2$ since $(\\sum_i x_i^2)^2 = \\sum_i x_i^4 + 2\\sum_{i<j}x_i^2x_j^2$.",
+    "mathContext": "$6(a^2+b^2+c^2+d^2)^2 = (a+b)^4+(a-b)^4+\\cdots+(c+d)^4+(c-d)^4$.",
+    "significance": "critical",
+    "prerequisites": ["Polynomial identities over ℤ", "the `ring` tactic"],
+    "relatedConcepts": ["Waring's problem", "Liouville identity", "sums of fourth powers"]
+  },
+  {
+    "id": "ann-natabs-bridge",
+    "proofId": "lagrange-four-squares-oq-03",
+    "range": { "startLine": 59, "endLine": 62 },
+    "type": "insight",
+    "title": "Realising differences (xᵢ−xⱼ)⁴ as natural fourth powers",
+    "content": "Liouville's identity contains difference terms $(x_i-x_j)^4$, but subtraction truncates in $\\mathbb{N}$. The fix is to witness each difference by its natural absolute value $|x_i-x_j| = $ `Int.natAbs ((xᵢ:ℤ) - xⱼ)` and observe $(\\uparrow z.\\mathrm{natAbs})^4 = z^4$: indeed $\\uparrow z.\\mathrm{natAbs} = |z|$ (`Int.abs_eq_natAbs`), and $|z|^4 = |z^4| = z^4$ because $z^4 \\ge 0$ (`abs_pow` then `abs_of_nonneg`). This keeps the headline statement about sums of fourth powers of *natural* numbers while the algebra runs in $\\mathbb{Z}$.",
+    "mathContext": "$(\\uparrow z.\\mathrm{natAbs})^4 = z^4$ in $\\mathbb{Z}$; the difference summand is realised by $|x_i-x_j| \\in \\mathbb{N}$.",
+    "significance": "supporting",
+    "prerequisites": ["Integer absolute value", "ℕ↔ℤ casting"],
+    "relatedConcepts": ["Int.natAbs", "truncated natural subtraction", "even powers"]
+  },
+  {
+    "id": "ann-issumoffourthpowers",
+    "proofId": "lagrange-four-squares-oq-03",
+    "range": { "startLine": 65, "endLine": 100 },
+    "type": "definition",
+    "title": "The 'sum of k fourth powers' predicate and its closure lemmas",
+    "content": "`IsSumOfFourthPowers k n` says there is a length-$k$ list of naturals whose fourth powers sum to $n$. Because $0^4 = 0$, allowing zero summands makes this 'sum of *at most* $k$ fourth powers'. The closure lemmas turn all later counting into one-liners: `zero` (empty sum gives $0$), `single` (one fourth power $a^4$), `append` (a sum of $k_1$ plus a sum of $k_2$ is a sum of $k_1+k_2$, via list concatenation and `List.sum_append`), `zeros` (all-zero list realises $0$ with any count), and `succ` (pad by one zero summand). With these, the bound arithmetic $12+12+(12+12)=48$ and $48+5=53$ holds definitionally on the Nat indices.",
+    "mathContext": "$\\mathrm{IsSumOfFourthPowers}\\,k\\,n \\iff \\exists\\,\\ell : \\mathrm{List}\\,\\mathbb{N},\\ |\\ell|=k \\wedge \\sum_{x\\in\\ell} x^4 = n$.",
+    "significance": "supporting",
+    "prerequisites": ["Lists and list sums", "List.length_append, List.sum_append"],
+    "relatedConcepts": ["additive bookkeeping", "monotonicity in the number of summands"]
+  },
+  {
+    "id": "ann-six-msq",
+    "proofId": "lagrange-four-squares-oq-03",
+    "range": { "startLine": 104, "endLine": 123 },
+    "type": "theorem",
+    "title": "6m² is a sum of twelve fourth powers",
+    "content": "`sixMulSq_isSum` provides the explicit twelve-element list $[a+b,\\,|a-b|,\\,a+c,\\,|a-c|,\\,\\dots,\\,c+d,\\,|c-d|]$ and proves its fourth-power sum equals $6(a^2+b^2+c^2+d^2)^2$. The proof expands the list sum, casts the ℕ equation into $\\mathbb{Z}$ via `Nat.cast_inj`, rewrites the natAbs terms with `cast_natAbs_pow4`, and closes with `linear_combination liouville_identity a b c d`. Then `sixMulSq` applies Lagrange's four-square theorem to $m$ (so $a^2+b^2+c^2+d^2 = m$) to conclude $6m^2$ is a sum of $12$ fourth powers for *every* $m$.",
+    "mathContext": "$\\forall m,\\ \\exists\\,12\\text{ fourth powers summing to } 6m^2$ (via $m = a^2+b^2+c^2+d^2$).",
+    "significance": "critical",
+    "prerequisites": ["Liouville's identity", "Nat.sum_four_squares", "ℕ→ℤ casting"],
+    "relatedConcepts": ["Lagrange four-square theorem", "linear_combination"]
+  },
+  {
+    "id": "ann-six-Q",
+    "proofId": "lagrange-four-squares-oq-03",
+    "range": { "startLine": 125, "endLine": 137 },
+    "type": "theorem",
+    "title": "6Q is a sum of forty-eight fourth powers",
+    "content": "`sixMul` uses Lagrange a second time: write $Q = m_1^2+m_2^2+m_3^2+m_4^2$, so $6Q = 6m_1^2+6m_2^2+6m_3^2+6m_4^2$. Each $6m_i^2$ is a sum of $12$ fourth powers (`sixMulSq`), and concatenating the four blocks with `append` gives $12\\cdot 4 = 48$ summands for $6Q$. The reassociation of the value is a `ring` rewrite; the count $((12+12)+(12+12)) = 48$ is definitional.",
+    "mathContext": "$\\forall Q,\\ 6Q$ is a sum of $48$ fourth powers.",
+    "significance": "supporting",
+    "prerequisites": ["sixMulSq", "Nat.sum_four_squares", "IsSumOfFourthPowers.append"],
+    "relatedConcepts": ["block concatenation", "double use of Lagrange"]
+  },
+  {
+    "id": "ann-waring-four",
+    "proofId": "lagrange-four-squares-oq-03",
+    "range": { "startLine": 139, "endLine": 154 },
+    "type": "theorem",
+    "title": "Main theorem: every N is a sum of at most 53 fourth powers (g(4) ≤ 53)",
+    "content": "`waring_four` assembles the bound. Euclidean division gives $N = 6\\lfloor N/6\\rfloor + (N\\bmod 6)$ with $N\\bmod 6 \\le 5$ (`Nat.div_add_mod`, `omega`). The residue $N\\bmod 6$ is realised as $N\\bmod 6$ copies of $1^4=1$ (a `List.replicate`), padded with zeros to exactly $5$ summands. The quotient block $6\\lfloor N/6\\rfloor$ is $48$ fourth powers (`sixMul`). Concatenating, $N$ is a sum of $48+5 = 53$ fourth powers — a finite, explicit upper bound for the Waring constant $g(4)$, proved with no axioms and no sorries.",
+    "mathContext": "$\\forall N,\\ N$ is a sum of at most $53$ fourth powers; hence $g(4) \\le 53$.",
+    "significance": "critical",
+    "prerequisites": ["sixMul", "Nat.div_add_mod", "IsSumOfFourthPowers.append and zeros"],
+    "relatedConcepts": ["Waring's problem", "g(4)", "Euclidean division"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-oq-03/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-03/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "lagrange-four-squares-oq-03",
+  "title": "Waring's Problem for Fourth Powers via Lagrange: g(4) ≤ 53",
+  "slug": "lagrange-four-squares-oq-03",
+  "description": "A fully machine-checked, axiom-free proof that every natural number is a sum of at most 53 fourth powers — an explicit finite upper bound for the Waring constant g(4). The argument is entirely 'Lagrange-type': it combines Lagrange's four-square theorem (Nat.sum_four_squares) with the classical Liouville identity 6(a²+b²+c²+d²)² = Σ_{i<j}((xᵢ+xⱼ)⁴+(xᵢ−xⱼ)⁴), which exhibits 6m² as a sum of 12 fourth powers whenever m is a sum of four squares (i.e. always). Writing N = 6·(N/6) + N%6 then yields 48 + 5 = 53 fourth powers. This complements the gallery's lagrange-four-squares-waring-g2 entries, which establish the lower bound g(4) ≥ 19; together they bracket g(4) by a self-contained elementary route, with no analytic circle-method machinery.",
+  "meta": {
+    "author": "Liouville (identity, 1859); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Waring%27s_problem",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "additive-combinatorics",
+      "waring-problem",
+      "four-squares",
+      "lagrange",
+      "fourth-powers",
+      "liouville-identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/LagrangeFourSquaresOQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_four_squares",
+        "description": "Lagrange's four-square theorem: every n : ℕ is a sum of four squares, ∃ a b c d, a²+b²+c²+d² = n. Used twice — once to convert 6·(sum of squares)² into 6m², and once to split 6Q into four 6mᵢ² blocks.",
+        "module": "Mathlib.NumberTheory.SumFourSquares"
+      },
+      {
+        "theorem": "Int.abs_eq_natAbs",
+        "description": "|z| = ↑z.natAbs for z : ℤ. The bridge that realises the difference summands (xᵢ−xⱼ)⁴ of Liouville's identity as fourth powers of natural numbers.",
+        "module": "Mathlib.Data.Int.Order"
+      }
+    ],
+    "originalContributions": [
+      "A machine-checked, axiom-free proof of g(4) ≤ 53: every natural number is a sum of at most 53 fourth powers (Mathlib has Lagrange's four-square theorem but not the fourth-power Waring upper bound)",
+      "A formalization of the Liouville identity 6(a²+b²+c²+d²)² = Σ_{i<j}((xᵢ+xⱼ)⁴+(xᵢ−xⱼ)⁴) over ℤ, closed by a single `ring` call",
+      "The lemma that 6m² is a sum of exactly 12 fourth powers for every m : ℕ, obtained by feeding Lagrange's four squares into the Liouville identity and realising the differences via Int.natAbs",
+      "A reusable List-based 'sum of k fourth powers' predicate (IsSumOfFourthPowers) closed under concatenation and zero-padding, making the additive bookkeeping (12 → 48 → 53) a few one-line lemmas",
+      "The complementary upper bound to the gallery's g(4) ≥ 19 lower-bound entries, bracketing the Waring constant g(4) entirely by elementary means"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 156,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on waring_four and sixMulSq_isSum reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide (so no Lean.ofReduceBool), no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "namespace": "LagrangeFourSquaresOQ03",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 1,
+    "path": "Proofs/LagrangeFourSquaresOQ03.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "liouville-identity",
+      "title": "Liouville's identity over ℤ",
+      "startLine": 48,
+      "endLine": 57,
+      "summary": "The polynomial identity 6(a²+b²+c²+d²)² = (a+b)⁴+(a−b)⁴+…+(c+d)⁴+(c−d)⁴, a sum over the six unordered pairs of variables of (xᵢ+xⱼ)⁴+(xᵢ−xⱼ)⁴. Closed by a single `ring`. This is the algebraic heart of the Lagrange-type argument."
+    },
+    {
+      "id": "natabs-bridge",
+      "title": "Realising differences as natural fourth powers",
+      "startLine": 58,
+      "endLine": 62,
+      "summary": "cast_natAbs_pow4: (↑z.natAbs)⁴ = z⁴ in ℤ, since |z|⁴ = |z⁴| = z⁴ for the nonnegative z⁴. This lets the difference summands (xᵢ−xⱼ)⁴ — which would be truncated in ℕ — be witnessed by the natural numbers |xᵢ−xⱼ|."
+    },
+    {
+      "id": "issumoffourthpowers",
+      "title": "The 'sum of k fourth powers' predicate and its closure lemmas",
+      "startLine": 63,
+      "endLine": 100,
+      "summary": "IsSumOfFourthPowers k n: there is a length-k list of naturals whose fourth powers sum to n (zeros allowed, so really 'at most k'). Closure: empty sum (zero), single fourth power (single), concatenation (append), all-zeros (zeros), and zero-padding (succ). These make the count bookkeeping mechanical."
+    },
+    {
+      "id": "six-msq-twelve",
+      "title": "6m² is a sum of twelve fourth powers",
+      "startLine": 101,
+      "endLine": 123,
+      "summary": "sixMulSq_isSum exhibits the twelve summands a±b, a±c, …, c±d for 6(a²+b²+c²+d²)², proving the sum equals 6(a²+b²+c²+d²)² by casting to ℤ and applying liouville_identity. sixMulSq then specialises via Lagrange (Nat.sum_four_squares m) to give 6m² as a sum of 12 fourth powers for every m."
+    },
+    {
+      "id": "six-Q-fortyeight",
+      "title": "6Q is a sum of forty-eight fourth powers",
+      "startLine": 124,
+      "endLine": 137,
+      "summary": "sixMul writes Q = m₁²+m₂²+m₃²+m₄² (Lagrange again), so 6Q = 6m₁²+6m₂²+6m₃²+6m₄², and concatenates four 12-term blocks (12·4 = 48) using append."
+    },
+    {
+      "id": "waring-four",
+      "title": "Main theorem: g(4) ≤ 53",
+      "startLine": 138,
+      "endLine": 154,
+      "summary": "waring_four: every N is a sum of at most 53 fourth powers. Write N = 6·(N/6) + N%6 with N%6 ≤ 5; the quotient block is 48 fourth powers (sixMul) and the residue is N%6 copies of 1⁴ padded to 5 summands, giving 48 + 5 = 53 in total via append and Nat.div_add_mod."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Waring's problem.** In 1770 Edward Waring asserted that for every exponent $k$ there is a number $g(k)$ such that every positive integer is a sum of at most $g(k)$ non-negative $k$-th powers. The case $k=2$ is Lagrange's four-square theorem ($g(2)=4$, proved that same year). Finiteness of $g(k)$ for all $k$ was first established by Hilbert in 1909. For fourth powers, Liouville gave in 1859 a beautifully elementary proof of finiteness using his identity\n$$6(a^2+b^2+c^2+d^2)^2 = \\sum_{1\\le i<j\\le 4}\\big((x_i+x_j)^4+(x_i-x_j)^4\\big),$$\nwhich expresses $6m^2$ as a sum of $12$ fourth powers whenever $m$ is a sum of four squares — and by Lagrange, every $m$ is. The true value is $g(4)=19$ (the lower bound $g(4)\\ge 19$ comes from $n=31\\cdot 16=479$ and similar 'bad' numbers; the matching upper bound was completed by Balasubramanian, Deshouillers and Dress in 1986). Liouville's argument does not reach $19$, but it gives a clean, completely finite bound — classically $g(4)\\le 53$ — with no analysis whatsoever.",
+    "problemStatement": "**Finite Waring bound for fourth powers.** Prove, by an elementary Lagrange-type argument, that there is an explicit constant $C$ such that every natural number $N$ is a sum of at most $C$ fourth powers. Here $C = 53$ is obtained, machine-checked with no axioms and no sorries.",
+    "proofStrategy": "**Liouville identity + Lagrange, twice.** (1) The identity $6(a^2+b^2+c^2+d^2)^2 = \\sum_{i<j}((x_i+x_j)^4+(x_i-x_j)^4)$ is a `ring` fact over $\\mathbb{Z}$; its right side is $12$ fourth powers. (2) By Lagrange any $m = a^2+b^2+c^2+d^2$, so $6m^2$ is a sum of $12$ fourth powers. (3) By Lagrange again any $Q = m_1^2+\\cdots+m_4^2$, so $6Q = \\sum 6m_i^2$ is a sum of $48$ fourth powers. (4) Finally $N = 6\\lfloor N/6\\rfloor + (N\\bmod 6)$ with $N\\bmod 6 \\le 5$, and the residue is at most $5$ copies of $1^4$; so $N$ is a sum of $48+5 = 53$ fourth powers.",
+    "keyInsights": [
+      "**Liouville's identity is the whole game.** A single `ring` call verifies $6(\\sum x_i^2)^2 = \\sum_{i<j}((x_i\\pm x_j)^4)$. Expanding $(u+v)^4+(u-v)^4 = 2u^4+12u^2v^2+2v^4$ and summing over the six pairs gives $6\\sum x_i^4 + 12\\sum_{i<j}x_i^2x_j^2 = 6(\\sum x_i^2)^2$.",
+      "**Differences need ℤ, but the summands are natural.** The terms $(x_i-x_j)^4$ involve subtraction, which truncates in $\\mathbb{N}$. Working in $\\mathbb{Z}$ and witnessing each difference by $|x_i-x_j| = \\,$`Int.natAbs` keeps the final statement about sums of fourth powers of *natural* numbers, with $(\\uparrow|z|)^4 = z^4$ supplied by `cast_natAbs_pow4`.",
+      "**Counting is bookkeeping once the predicate is right.** Encoding 'sum of $k$ fourth powers' as a length-$k$ list closed under concatenation turns $12 \\to 48 \\to 53$ into three short `append`/zero-pad lemmas — the Nat indices $12+12+(12+12)=48$ and $48+5=53$ hold definitionally.",
+      "**Lagrange is used at two different scales.** Once on $m$ (to feed the identity) and once on the quotient $Q=\\lfloor N/6\\rfloor$ (to split $6Q$ into four blocks). This double use is exactly what makes the bound 'Lagrange-type'.",
+      "**Upper bound complements the gallery's lower bound.** The sibling `lagrange-four-squares-waring-g2` entries prove $g(4)\\ge 19$ by a counting/`omega` infeasibility argument; this entry supplies $g(4)\\le 53$, so the two together establish $19 \\le g(4) \\le 53$ by entirely finite means."
+    ],
+    "prerequisites": [
+      "Lagrange's four-square theorem (Nat.sum_four_squares)",
+      "Polynomial identities over ℤ (the `ring` tactic)",
+      "Natural absolute value and ℕ↔ℤ casting",
+      "Finite sums over lists; Euclidean division N = 6·(N/6) + N%6"
+    ]
+  },
+  "conclusion": {
+    "summary": "Every natural number is a sum of at most 53 fourth powers, hence the Waring constant g(4) is finite with g(4) ≤ 53. The proof is purely a Lagrange-type argument: Liouville's identity 6(a²+b²+c²+d²)² = Σ_{i<j}((xᵢ+xⱼ)⁴+(xᵢ−xⱼ)⁴) makes 6m² a sum of 12 fourth powers, Lagrange's four-square theorem supplies the required sums of squares (used twice), and Euclidean division by 6 assembles 48 + 5 = 53 summands. 11 theorems, 1 definition, 156 lines, 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the elementary fourth-power Waring upper bound that Mathlib's number-theory library does not provide, complementing Lagrange's four-square theorem.",
+      "Brackets the Waring constant: together with the gallery's g(4) ≥ 19 lower-bound entries, this gives 19 ≤ g(4) ≤ 53 by self-contained finite arguments.",
+      "Packages a reusable Liouville identity and a 'sum of k fourth powers' combinator that downstream work on Waring-type bounds can build on."
+    ],
+    "openQuestions": [
+      "Sharpen the constant: a more careful residue analysis (and using that small numbers need few fourth powers) brings Liouville's bound down toward the classical g(4) ≤ 53 → 50 → … range; how low can a purely elementary, machine-checked argument push it?",
+      "Formalize the true value g(4) = 19 by combining this finiteness route with the Balasubramanian–Deshouillers–Dress upper bound and the n = 31·16ᵏ lower-bound family.",
+      "Generalize the Liouville-style identity to give elementary finite bounds for g(8) (eighth powers, where an analogous identity expresses a constant times a square of a four-square form as a sum of eighth powers) and other even exponents."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A fully machine-checked, **axiom-free** proof that **every natural number is a sum of at most 53 fourth powers** — an explicit finite upper bound for the Waring constant `g(4)`. The whole argument is *Lagrange-type*: no analysis, just Lagrange's four-square theorem and Liouville's identity.

```
6 (a²+b²+c²+d²)² = Σ_{1≤i<j≤4} ((xᵢ+xⱼ)⁴ + (xᵢ−xⱼ)⁴)        (Liouville)
```

The right side is 12 fourth powers, so `6m²` is a sum of 12 fourth powers whenever `m` is a sum of four squares — and by Lagrange, every `m` is. Writing `N = 6·(N/6) + N%6` (with `N%6 ≤ 5`) assembles **48 + 5 = 53** summands.

## Gallery context

The existing `lagrange-four-squares-waring-g2-*` entries prove the **lower** bound `g(4) ≥ 19` (counting / `omega` infeasibility). This PR supplies the complementary **upper** bound `g(4) ≤ 53`, so together they bracket `19 ≤ g(4) ≤ 53` by entirely elementary, self-contained means.

## Contents
- `proofs/Proofs/LagrangeFourSquaresOQ03.lean` — 11 theorems, 1 definition, 156 lines, **0 sorry, 0 axiom**
  - `liouville_identity` (ring identity over ℤ)
  - `cast_natAbs_pow4` (realises difference summands as natural fourth powers)
  - `IsSumOfFourthPowers` + closure lemmas (List-based 'sum of k fourth powers')
  - `sixMulSq_isSum` / `sixMulSq` (6m² = sum of 12 fourth powers)
  - `sixMul` (6Q = sum of 48 fourth powers)
  - `waring_four` (**g(4) ≤ 53**)
- Gallery entry `src/data/proofs/lagrange-four-squares-oq-03/` (meta + annotations)

## Verification
- `lake env lean Proofs/LagrangeFourSquaresOQ03.lean` compiles cleanly (Mathlib 4.26.0).
- `#print axioms waring_four` → only `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`). Status: **verified**.
- `pnpm build` succeeds with the new gallery entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)