### PR TITLE
Enrich Hausdorff's Free Subgroup of SO(3): populate annotations

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-06-oq-01/annotations.json
@@ -1,1 +1,184 @@
-[]
+[
+  {
+    "id": "lm-oq0601-ann-goal",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 47
+    },
+    "type": "insight",
+    "title": "The Upgrade: From Underlying Linear Maps to an Honest Subgroup of SO(3)",
+    "content": "The module docstring fixes the gap this file closes. The parent's `hausdorff_free_subgroup` proves rank-2 freeness but states injectivity for the *underlying linear equivalences* φ.toLinearEquiv (objects in ℝ³ ≃ₗ ℝ³), forgetting that φ, ψ are isometries. That is a real loss of information: 'SO(3) contains F₂' is a statement about the isometry group, not about GL(ℝ³). The file restores it in five steps — a forgetful bridge, freeness internal to the isometry group, an injective hom out of FreeGroup Bool, a literal isomorphic subgroup, and a concrete non-commuting pair — without reproving any geometry. The hard content (the ℤ[√2]-residue orbit argument that no reduced word fixes a test vector) stays in the parent; here everything is pure group-theoretic packaging.",
+    "mathContext": "Parent: $\\mathrm{Injective}(\\mathrm{lift}\\,(b\\mapsto \\varphi.\\mathrm{toLinearEquiv}/\\psi.\\mathrm{toLinearEquiv}))$ in $\\mathbb{R}^3\\simeq_\\ell\\mathbb{R}^3$. Here: the same in $\\mathbb{R}^3\\simeq_{\\ell i}\\mathbb{R}^3 = O(3)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hausdorff paradox",
+      "free group of rank 2",
+      "rotation group SO(3)",
+      "Banach–Tarski paradox"
+    ],
+    "prerequisites": [
+      "free groups and FreeGroup.lift",
+      "linear isometry equivalences"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-abbrevs",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 55,
+      "endLine": 60
+    },
+    "type": "definition",
+    "title": "Rot3 and Lin3: The Two Worlds the Bridge Connects",
+    "content": "`Rot3 = EuclideanSpace ℝ (Fin 3) ≃ₗᵢ[ℝ] EuclideanSpace ℝ (Fin 3)` is the group of linear isometric self-equivalences of ℝ³ — the orthogonal group O(3), with SO(3) the determinant-+1 component where the rotation generators live. `Lin3` is the larger group ℝ³ ≃ₗ ℝ³ of all linear self-equivalences (essentially GL₃(ℝ)). The parent proves freeness in Lin3; this file's job is to pull it back into Rot3. Both are groups under composition with the Mathlib convention a * b = b.trans a (apply b first), which matters in the next step.",
+    "mathContext": "$\\mathrm{Rot3} = \\mathbb{R}^3\\simeq_{\\ell i}\\mathbb{R}^3 = O(3) \\le \\mathrm{Lin3} = \\mathbb{R}^3\\simeq_{\\ell}\\mathbb{R}^3 \\cong \\mathrm{GL}_3(\\mathbb{R})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "orthogonal group O(3)",
+      "general linear group",
+      "EuclideanSpace"
+    ],
+    "prerequisites": [
+      "linear isometry equivalence (≃ₗᵢ)",
+      "linear equivalence (≃ₗ)"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-bridge",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 77
+    },
+    "type": "definition",
+    "title": "The Forgetful Bridge toLinearEquivHom : O(3) →* GL",
+    "content": "`toLinearEquivHom` bundles 'an isometry is in particular a linear equivalence', e ↦ e.toLinearEquiv, as a *monoid homomorphism* Rot3 →* Lin3. The entire content is multiplicativity: `MonoidHom.mk'` needs only map_mul (map_one is derived for groups). The proof rewrites (a*b).toLinearEquiv using `LinearEquiv.mul_eq_trans` (to expose the trans composition on the target) and closes with `LinearIsometryEquiv.toLinearEquiv_trans`, which says forgetting commutes with composition. Matching the two groups' composition conventions (both a*b = b.trans a) is what makes the forgetful map a homomorphism rather than an anti-homomorphism — this convention-matching is the whole subtlety.",
+    "mathContext": "$\\Phi(e)=e_{\\text{lin}}$, and $\\Phi(ab)=\\Phi(a)\\Phi(b)$ because $(b\\circ a)_{\\text{lin}} = b_{\\text{lin}}\\circ a_{\\text{lin}}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "forgetful functor",
+      "monoid homomorphism",
+      "MonoidHom.mk'",
+      "composition convention"
+    ],
+    "prerequisites": [
+      "LinearIsometryEquiv.toLinearEquiv_trans",
+      "LinearEquiv.mul_eq_trans"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-internal",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 106
+    },
+    "type": "theorem",
+    "title": "Hausdorff Freeness, Transferred into the Isometry Group",
+    "content": "`hausdorff_free_subgroup_isometry` is the key transfer. It extracts φ, ψ and the parent's injectivity hinj (for the lift into Lin3), then proves the lift into Rot3 is injective. The mechanism is a factorisation: the parent's lift equals toLinearEquivHom ∘ (our lift into Rot3), established by `FreeGroup.ext_hom` (two homs out of a free group agreeing on generators are equal — here both send each generator to φ or ψ). Given the factorisation, injectivity transfers trivially: if our lift sends x, y to the same isometry, apply toLinearEquivHom to get equal linear equivalences, then hinj forces x = y. No orbit/ℤ[√2] argument is reproved — freeness is *forgetful-stable*: injectivity of a hom out of F₂ survives post-composition with any further hom.",
+    "mathContext": "$\\mathrm{lift}_{\\mathrm{Lin}} = \\Phi\\circ\\mathrm{lift}_{\\mathrm{Rot}}$, and $\\mathrm{Injective}(\\Phi\\circ\\mathrm{lift}_{\\mathrm{Rot}})\\Rightarrow\\mathrm{Injective}(\\mathrm{lift}_{\\mathrm{Rot}})$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "free group universal property",
+      "injectivity transfer",
+      "FreeGroup.ext_hom",
+      "forgetful-stability of freeness"
+    ],
+    "prerequisites": [
+      "FreeGroup.lift and FreeGroup.ext_hom",
+      "hausdorff_free_subgroup (parent)"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-contains",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 112
+    },
+    "type": "theorem",
+    "title": "O(3) Contains F₂ as an Injective Homomorphism",
+    "content": "`isometryGroup_contains_freeGroup` restates the previous result in the cleanest group-theoretic form: there exists an injective monoid homomorphism FreeGroup Bool →* Rot3. The witness is literally `FreeGroup.lift (b ↦ if b then φ else ψ)`, which is a homomorphism by the universal property of the free group, and its injectivity is exactly hausdorff_free_subgroup_isometry. This is the statement 'the rank-2 free group embeds in the 3D isometry group', the precise object the Banach–Tarski construction consumes.",
+    "mathContext": "$\\exists\\, f:\\mathrm{FreeGroup}\\,\\mathrm{Bool}\\to^* O(3),\\ \\mathrm{Injective}(f)$ — i.e. $F_2\\hookrightarrow O(3)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "group embedding",
+      "free group of rank 2",
+      "Banach–Tarski paradox"
+    ],
+    "prerequisites": [
+      "injective group homomorphism",
+      "FreeGroup.lift"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-subgroup",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 114,
+      "endLine": 122
+    },
+    "type": "theorem",
+    "title": "A Literal Isomorphic Copy of F₂ inside SO(3)",
+    "content": "`exists_freeGroup_mulEquiv_rotationSubgroup` produces an actual subgroup S ≤ Rot3 together with a group isomorphism FreeGroup Bool ≃* S. The construction is one application of `MonoidHom.ofInjective` to the injective hom f from the previous theorem: an injective homomorphism is the same data as an isomorphism onto its range, so S = f.range and the iso is FreeGroup Bool ≃* f.range. This is the strongest packaging — 'SO(3) contains a copy of F₂' is now a literal Lean ∃-statement about subgroups, not merely an embedding map.",
+    "mathContext": "$\\exists\\, S\\le O(3),\\ \\mathrm{FreeGroup}\\,\\mathrm{Bool}\\cong S$, via $S=\\mathrm{range}(f)$ and $\\mathrm{ofInjective}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "subgroup",
+      "MulEquiv (group isomorphism)",
+      "MonoidHom.ofInjective",
+      "range of a homomorphism"
+    ],
+    "prerequisites": [
+      "image/range of a group hom",
+      "isomorphism onto range"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-noncomm-gens",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 124,
+      "endLine": 140
+    },
+    "type": "technique",
+    "title": "Free Generators Don't Commute, Detected in S₃",
+    "content": "`freeGroup_of_true_false_ne` proves a·b ≠ b·a for the two generators of FreeGroup Bool. Directly comparing reduced words is awkward, so the proof uses a homomorphic image with a *decidable* equality: map into S₃ = Perm (Fin 3), sending a ↦ swap 0 1 and b ↦ swap 1 2, two transpositions that famously fail to commute (their products are the two 3-cycles). If a·b = b·a held, applying the lift (via congrArg) would force swap(0 1)·swap(1 2) = swap(1 2)·swap(0 1) in S₃, refuted by `decide` on the finite group. This is the standard trick for proving non-relations in a free group: exhibit a quotient where the relation visibly fails.",
+    "mathContext": "$a\\cdot b\\ne b\\cdot a$ in $F_2$ because $(0\\,1)(1\\,2)=(0\\,1\\,2)\\ne(0\\,2\\,1)=(1\\,2)(0\\,1)$ in $S_3$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric group S₃",
+      "transpositions",
+      "decidability (decide)",
+      "non-relations via quotient"
+    ],
+    "prerequisites": [
+      "Equiv.Perm and Equiv.swap",
+      "FreeGroup.lift homomorphism property"
+    ]
+  },
+  {
+    "id": "lm-oq0601-ann-noncomm-rot",
+    "proofId": "lebesgue-measure-oq-06-oq-01",
+    "range": {
+      "startLine": 142,
+      "endLine": 157
+    },
+    "type": "theorem",
+    "title": "Concrete Non-Commuting Rotations: SO(3) Is Non-Abelian",
+    "content": "`exists_noncommuting_rotations` transports non-commutativity of the free generators along the injective embedding to produce honest rotations φ, ψ ∈ Rot3 with φ·ψ ≠ ψ·φ. The argument is by contradiction: if φ·ψ = ψ·φ, then since the lift is a homomorphism, lift(a·b) = φ·ψ = ψ·φ = lift(b·a); injectivity (hinj) forces a·b = b·a in FreeGroup Bool, contradicting freeGroup_of_true_false_ne. This is the geometric punchline — the abstract algebra delivers a concrete witness that SO(3) is non-abelian. It also marks exactly where the planar case fails: SO(2) is abelian (hence amenable), which is why no Banach–Tarski paradox exists in two dimensions.",
+    "mathContext": "$\\exists\\,\\varphi,\\psi\\in SO(3),\\ \\varphi\\psi\\ne\\psi\\varphi$; contrast $SO(2)$ abelian $\\Rightarrow$ no paradox.",
+    "significance": "key",
+    "relatedConcepts": [
+      "non-abelian group",
+      "amenability",
+      "SO(2) vs SO(3)",
+      "injectivity reflects relations"
+    ],
+    "prerequisites": [
+      "proof by contradiction",
+      "homomorphism preserves products"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `lebesgue-measure-oq-06-oq-01` (quality 43, 0 prior passes).

## Gap addressed
The meta.json (overview, sections, conclusion, crossReferences, references, mathlibDependencies, originalContributions) was already rich, but **annotations.json was an empty array** — the sole quality gap. Populated it with 8 substantive annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the full 157-line file:

1. The upgrade goal (from underlying linear maps to an honest SO(3) subgroup)
2. `Rot3`/`Lin3` abbreviations (O(3) vs GL)
3. The forgetful bridge `toLinearEquivHom : O(3) →* GL`
4. `hausdorff_free_subgroup_isometry` — freeness transferred into the isometry group via a factorisation through the bridge
5. `isometryGroup_contains_freeGroup` — the injective F₂ embedding
6. `exists_freeGroup_mulEquiv_rotationSubgroup` — the literal isomorphic subgroup via `MonoidHom.ofInjective`
7. `freeGroup_of_true_false_ne` — non-commuting generators detected in S₃ by `decide`
8. `exists_noncommuting_rotations` — concrete non-abelian witness, contrasted with SO(2)

## Verification
- JSON validates (8 annotations).
- `pnpm build` data-generation processes the entry cleanly; the gallery-wide validation error count is unchanged from baseline (pre-existing, not introduced here).

Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean source and its `#print axioms` audit (results depend only on the parent's fully-proved `hausdorff_free_subgroup`, not on `banach_tarski`).