### PR TITLE
research(erdos-748): sharpen trivial lower bound to f(n) ≥ 2^⌈n/2⌉ [0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -151,6 +151,41 @@ theorem trivial_lower_bound (n : ℕ) (hn : n ≥ 2) :
     _ ≤ f n := hcard
 
 /--
+**Sharp Trivial Lower Bound:**
+`f(n) ≥ 2^{⌈n/2⌉}`.
+
+The upper half `U = {⌊n/2⌋+1, …, n}` has *exactly* `⌈n/2⌉ = n − ⌊n/2⌋` elements,
+and by `upperHalf_sumFree` **all** `2^{⌈n/2⌉}` of its subsets are sum-free. This
+sharpens `trivial_lower_bound`, which only extracted the weaker exponent `⌊n/2⌋`:
+for odd `n`, `⌈n/2⌉ = ⌊n/2⌋ + 1`, so the bound here is a full factor of `2`
+(i.e. `√2` per element) larger. It is the largest power of two the upper-half
+construction can yield. In `ℕ`, the ceiling `⌈n/2⌉` is written `(n + 1) / 2`.
+-/
+theorem sharp_lower_bound (n : ℕ) :
+    f n ≥ 2 ^ ((n + 1) / 2) := by
+  -- Same upper half U = {⌊n/2⌋+1, …, n}, but we keep its full cardinality.
+  set U : Finset ℕ := Finset.Icc (n / 2 + 1) n with hU
+  have hsub : U.powerset ⊆ sumFreeSubsets n := by
+    intro A hAmem
+    rw [Finset.mem_powerset] at hAmem
+    rw [sumFreeSubsets, Finset.mem_filter, Finset.mem_powerset]
+    refine ⟨hAmem.trans ?_, ?_⟩
+    · rw [hU]; exact Finset.Icc_subset_Icc (by omega) (le_refl n)
+    · apply upperHalf_sumFree n A
+      intro a ha
+      have haU : a ∈ U := hAmem ha
+      rw [hU, Finset.mem_Icc] at haU
+      exact haU
+  have hcard : 2 ^ U.card ≤ f n :=
+    calc 2 ^ U.card = U.powerset.card := (Finset.card_powerset U).symm
+      _ ≤ (sumFreeSubsets n).card := Finset.card_le_card hsub
+      _ = f n := rfl
+  -- |U| = n − ⌊n/2⌋ = ⌈n/2⌉ = (n+1)/2.
+  have hUcard : U.card = (n + 1) / 2 := by rw [hU, Nat.card_Icc]; omega
+  rw [hUcard] at hcard
+  exact hcard
+
+/--
 **Monotonicity, ground step:**
 Every sum-free subset of {1,...,n} is also a sum-free subset of {1,...,n+1}.
 Sum-freeness is a property of the set itself (no `a = b + c` among its own
@@ -365,14 +400,14 @@ More precisely:
 3. f(n) ~ c_n · 2^{n/2} with c_n depending on parity
 -/
 theorem erdos_748_summary :
-    -- Trivial lower bound
-    (∀ n ≥ 2, f n ≥ 2 ^ (n / 2)) ∧
+    -- Sharp trivial lower bound (uses the full ⌈n/2⌉ exponent)
+    (∀ n : ℕ, f n ≥ 2 ^ ((n + 1) / 2)) ∧
     -- Upper bound exists
     (∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (f n : ℝ) ≤ C * 2 ^ (n / 2)) ∧
     -- Precise asymptotic exists
     (∃ c_even c_odd : ℝ, c_even > 0 ∧ c_odd > 0) := by
   constructor
-  · exact trivial_lower_bound
+  · exact sharp_lower_bound
   constructor
   · exact green_upper_bound
   · obtain ⟨ce, co, hce, hco, _⟩ := precise_asymptotic

--- a/research/problems/erdos-748-incomplete-01/knowledge.md
+++ b/research/problems/erdos-748-incomplete-01/knowledge.md
@@ -2,6 +2,17 @@
 
 ## Research Notes
 
+### Sharper trivial lower bound (2026-06-25, researcher-9)
+
+Added `sharp_lower_bound : ∀ n, f n ≥ 2 ^ ((n+1)/2)` — i.e. `f(n) ≥ 2^⌈n/2⌉`,
+0 axioms. The previously-stated `trivial_lower_bound` only extracted the weaker
+exponent `⌊n/2⌋` despite the proof already establishing `2^|U| ≤ f n` for the
+upper half `U = {⌊n/2⌋+1,…,n}`, whose cardinality is `n − ⌊n/2⌋ = ⌈n/2⌉`. The
+sharp version simply keeps `|U|` instead of weakening it to `⌊n/2⌋`. For odd `n`
+this is a full factor of 2 (√2 per element) larger and is the best the upper-half
+construction yields. `erdos_748_summary` now cites the sharp bound (`∀ n`, no
+`n ≥ 2` hypothesis needed). Typechecked clean via `lake env lean` (Docker down).
+
 ### Current state (2026-06-25, researcher-2)
 
 `proofs/Proofs/Erdos748Problem.lean` is in good shape: **0 sorries, 2 axioms**.

--- a/research/problems/erdos-748-incomplete-01/state.md
+++ b/research/problems/erdos-748-incomplete-01/state.md
@@ -2,9 +2,16 @@
 
 **Phase**: ACT
 **Since**: 2026-06-25T00:00:00Z
-**Attempts**: 1
+**Attempts**: 2
 **Status**: in-progress
 
-Added `f_monotone` + `sumFreeSubsets_subset_succ` (0 axioms). File now 0 sorries,
-2 deep axioms (Green 2004, Sapozhenko 2003 — BLOCKED, >1000 lines each).
+Attempt 2 (researcher-9): added `sharp_lower_bound : f n ≥ 2^⌈n/2⌉` (0 axioms),
+sharpening `trivial_lower_bound` (which only used `2^⌊n/2⌋`). The upper half
+`{⌊n/2⌋+1,…,n}` has exactly `⌈n/2⌉ = n−⌊n/2⌋` elements, all of whose subsets are
+sum-free, so the full `2^⌈n/2⌉` is recoverable — for odd `n` a factor of √2 over
+the old bound. Re-pointed `erdos_748_summary`'s lower-bound conjunct to it.
+Typechecks clean (`lake env lean`, exit 0; Docker down).
+
+Attempt 1: added `f_monotone` + `sumFreeSubsets_subset_succ` (0 axioms). File now
+0 sorries, 2 deep axioms (Green 2004, Sapozhenko 2003 — BLOCKED, >1000 lines each).
 Follow-up "max sum-free size = ⌈n/2⌉" owned by open PR #30202.

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -48,6 +48,7 @@
       "f(n): counting function for sum-free subsets",
       "upperHalf_sumFree theorem: upper half is always sum-free",
       "trivial_lower_bound theorem (PROVED, formerly an axiom): f(n) ≥ 2^{⌊n/2⌋} via the powerset of the upper half embedding into the sum-free subsets",
+      "sharp_lower_bound theorem (PROVED, 0 axioms): f(n) ≥ 2^{⌈n/2⌉} — the upper half {⌊n/2⌋+1,…,n} has exactly ⌈n/2⌉ = n−⌊n/2⌋ elements whose subsets are all sum-free, so the full exponent is recoverable; for odd n this is a factor of √2 sharper than trivial_lower_bound",
       "cameronErdosConjecture definition: formal statement",
       "sumFreeSubsets_subset_succ theorem (PROVED, 0 axioms): sum-free subsets of {1,...,n} embed into those of {1,...,n+1} — sum-freeness is intrinsic, so enlarging the ambient range preserves it",
       "f_monotone theorem (PROVED, 0 axioms): the counting function f is monotone (Monotone f), the structural fact underlying the trivial lower bound",
@@ -57,9 +58,9 @@
       "erdos_748_summary: combining all results"
     ],
     "axiomCount": 2,
-    "lineCount": 386,
-    "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The trivial lower bound f(n) ≥ 2^{⌊n/2⌋} is now fully proved (no longer an axiom). See the Lean source for details.",
-    "theoremCount": 14,
+    "lineCount": 421,
+    "assumptions": "2 axiom(s): green_upper_bound (Green 2004), precise_asymptotic (Green/Sapozhenko). Both are deep results from the literature. The lower bound is fully proved (no longer an axiom), and sharpened to f(n) ≥ 2^{⌈n/2⌉} (sharp_lower_bound) — the best the upper-half construction yields. See the Lean source for details.",
+    "theoremCount": 15,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/Erdos748Aristotle.lean"
@@ -179,9 +180,9 @@
       "Finset"
     ],
     "namespace": "Erdos748",
-    "lineCount": 386,
+    "lineCount": 421,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 15,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds `sharp_lower_bound : ∀ n, f n ≥ 2 ^ ((n+1)/2)` to `Erdos748Problem.lean` — i.e. **f(n) ≥ 2^⌈n/2⌉** for the Cameron–Erdős sum-free counting function, with **0 axioms**.

## Why this is a real improvement

The existing `trivial_lower_bound` proves only `f(n) ≥ 2^⌊n/2⌋`. But its own proof already establishes `2^|U| ≤ f n` for the upper half `U = {⌊n/2⌋+1,…,n}`, whose cardinality is `|U| = n − ⌊n/2⌋ = ⌈n/2⌉` — by `upperHalf_sumFree`, **every** one of `U`'s `2^⌈n/2⌉` subsets is sum-free. `trivial_lower_bound` then needlessly weakened the exponent to `⌊n/2⌋`. `sharp_lower_bound` keeps the full `|U|`:

- For **odd n**, `⌈n/2⌉ = ⌊n/2⌋ + 1`, so this is a full factor of **2** (√2 per element) larger.
- It is the **best** bound the upper-half construction can yield.
- It needs **no** `n ≥ 2` hypothesis (holds for all n).

`erdos_748_summary` now cites the sharp bound.

## Verification

- Typechecked clean via `lake env lean Proofs/Erdos748Problem.lean` (exit 0; Docker unavailable this session).
- Reuses only axiom-free Mathlib (`upperHalf_sumFree`, `Finset.card_powerset`, `Finset.card_le_card`, `Nat.card_Icc`, `omega`). **0 new axioms.**
- The two deep literature axioms (`green_upper_bound` — Green 2004; `precise_asymptotic` — Green/Sapozhenko 2003/2004) are unchanged. Entry remains `axiomatized` (2 axioms).
- meta.json: theoremCount 14→15, lineCount 386→421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)