### PR TITLE
Enrich Order Distribution in (ℤ/pℤ)ˣ (Primitive Roots OQ-03): add sections + annotation fields

### DIFF
--- a/src/data/proofs/primitive-roots-oq-03/annotations.json
+++ b/src/data/proofs/primitive-roots-oq-03/annotations.json
@@ -3,55 +3,60 @@
     "id": "primitive-roots-oq-03-module-header",
     "proofId": "primitive-roots-oq-03",
     "type": "concept",
-    "range": {
-      "startLine": 1,
-      "endLine": 39
-    },
+    "range": { "startLine": 1, "endLine": 39 },
     "title": "Module Header: From Generators to the Full Order Distribution",
-    "content": "The base Primitive-Roots entry counts only the **generators** of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ — the elements of the single order $p-1$, of which there are $\\varphi(p-1)$.\n\nThis file gives the **full order distribution**: for *every* divisor $d$ of $p-1$,\n$$\\#\\{g \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times : \\mathrm{ord}(g) = d\\} = \\varphi(d).$$\n\nSumming over all divisors tiles the group, and since the orders partition the $p-1$ units, this recovers **Gauss's identity** $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ from the group-theoretic side. The engine is Mathlib's `IsCyclic.card_orderOf_eq_totient`, specialized to the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$."
+    "content": "The base Primitive-Roots entry counts only the **generators** of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ — the elements of the single order $p-1$, of which there are $\\varphi(p-1)$.\n\nThis file gives the **full order distribution**: for *every* divisor $d$ of $p-1$,\n$$\\#\\{g \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times : \\mathrm{ord}(g) = d\\} = \\varphi(d).$$\n\nSumming over all divisors tiles the group, and since the orders partition the $p-1$ units, this recovers **Gauss's identity** $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ from the group-theoretic side. The engine is Mathlib's `IsCyclic.card_orderOf_eq_totient`, specialized to the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$.",
+    "mathContext": "$\\#\\{g : \\mathrm{ord}(g) = d\\} = \\varphi(d)$ for each $d \\mid p-1$, and $\\sum_{d \\mid p-1}\\varphi(d) = p-1$.",
+    "significance": "context",
+    "relatedConcepts": ["primitive roots modulo p", "order distribution of a cyclic group", "Euler totient φ", "Gauss's divisor-sum identity", "IsCyclic.card_orderOf_eq_totient"],
+    "prerequisites": ["multiplicative order in a finite group", "(ℤ/pℤ)ˣ is cyclic of order p−1", "Euler's totient and divisor sums"]
   },
   {
     "id": "primitive-roots-oq-03-setup",
     "proofId": "primitive-roots-oq-03",
     "type": "theorem",
-    "range": {
-      "startLine": 47,
-      "endLine": 53
-    },
+    "range": { "startLine": 47, "endLine": 53 },
     "title": "Cyclicity and Order of the Unit Group",
-    "content": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is **cyclic** because any finite multiplicative subgroup of an integral domain is cyclic — and $\\mathbb{Z}/p\\mathbb{Z}$ is a field for prime $p$ (`isCyclic_of_subgroup_isDomain` with the injectivity `Units.coeHom_injective`).\n\n`card_units`: its order is $p-1$, via `ZMod.card_units_eq_totient` (giving $\\varphi(p)$) and `Nat.totient_prime` (giving $p-1$). This is the input that converts the hypothesis $d \\mid p-1$ into $d \\mid |\\text{group}|$ for the distribution theorem."
+    "content": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is **cyclic** because any finite multiplicative subgroup of an integral domain is cyclic — and $\\mathbb{Z}/p\\mathbb{Z}$ is a field for prime $p$ (`isCyclic_of_subgroup_isDomain` with the injectivity `Units.coeHom_injective`).\n\n`card_units`: its order is $p-1$, via `ZMod.card_units_eq_totient` (giving $\\varphi(p)$) and `Nat.totient_prime` (giving $p-1$). This is the input that converts the hypothesis $d \\mid p-1$ into $d \\mid |\\text{group}|$ for the distribution theorem.",
+    "mathContext": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ cyclic; $\\mathrm{Fintype.card}\\,(\\mathbb{Z}/p\\mathbb{Z})^\\times = \\varphi(p) = p-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["isCyclic_of_subgroup_isDomain", "finite subgroups of a field's units are cyclic", "ZMod.card_units_eq_totient", "Nat.totient_prime", "Units.coeHom_injective"],
+    "prerequisites": ["integral domains and their unit groups", "the totient at a prime φ(p) = p−1", "instance resolution for IsCyclic"]
   },
   {
     "id": "primitive-roots-oq-03-distribution",
     "proofId": "primitive-roots-oq-03",
     "type": "theorem",
-    "range": {
-      "startLine": 55,
-      "endLine": 69
-    },
+    "range": { "startLine": 55, "endLine": 69 },
     "title": "The Full Order Distribution",
-    "content": "`card_orderOf_eq_totient`: for every divisor $d$ of $p-1$, the unit group has exactly $\\varphi(d)$ elements of order $d$.\n\n**Proof.** Lift $d \\mid p-1$ to $d \\mid \\mathrm{Fintype.card}\\,(\\mathbb{Z}/p\\mathbb{Z})^\\times$ via `card_units`, then apply Mathlib's `IsCyclic.card_orderOf_eq_totient`, which gives $\\#\\{g \\mid \\mathrm{ord}(g) = d\\} = \\varphi(d)$ in any cyclic group. A `convert ... using 2` matches the set-builder count to the `Finset.filter` cardinality. This is the all-$d$ strengthening of the base entry's single $d = p-1$ count."
+    "content": "`card_orderOf_eq_totient`: for every divisor $d$ of $p-1$, the unit group has exactly $\\varphi(d)$ elements of order $d$.\n\n**Proof.** Lift $d \\mid p-1$ to $d \\mid \\mathrm{Fintype.card}\\,(\\mathbb{Z}/p\\mathbb{Z})^\\times$ via `card_units`, then apply Mathlib's `IsCyclic.card_orderOf_eq_totient`, which gives $\\#\\{g \\mid \\mathrm{ord}(g) = d\\} = \\varphi(d)$ in any cyclic group. A `convert ... using 2` matches the set-builder count to the `Finset.filter` cardinality. This is the all-$d$ strengthening of the base entry's single $d = p-1$ count.",
+    "mathContext": "$d \\mid p-1 \\Rightarrow \\#\\{g \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times : \\mathrm{ord}(g) = d\\} = \\varphi(d)$.",
+    "significance": "key",
+    "relatedConcepts": ["IsCyclic.card_orderOf_eq_totient", "order classes of a cyclic group", "Finset.filter cardinality", "lifting a divisibility hypothesis", "Z/(p−1)Z structure"],
+    "prerequisites": ["the count of order-d elements in a cyclic group", "card_units (group order = p−1)", "set-builder vs Finset.filter count"]
   },
   {
     "id": "primitive-roots-oq-03-existence",
     "proofId": "primitive-roots-oq-03",
     "type": "theorem",
-    "range": {
-      "startLine": 71,
-      "endLine": 89
-    },
+    "range": { "startLine": 71, "endLine": 89 },
     "title": "Existence of Each Order, and the Generator Count",
-    "content": "`exists_orderOf_eq`: for every $d \\mid p-1$ there exists a unit of order exactly $d$. Since $d$ is a positive divisor of $p-1 > 0$ we have $d \\ge 1$, so $\\varphi(d) > 0$ and the order-$d$ class is nonempty.\n\n`card_generators`: the $d = p-1$ case recovers the classical count $\\#\\text{generators} = \\varphi(p-1)$ — the base entry's `card_primitiveRoots`, now a one-line specialization of the general distribution."
+    "content": "`exists_orderOf_eq`: for every $d \\mid p-1$ there exists a unit of order exactly $d$. Since $d$ is a positive divisor of $p-1 > 0$ we have $d \\ge 1$, so $\\varphi(d) > 0$ and the order-$d$ class is nonempty.\n\n`card_generators`: the $d = p-1$ case recovers the classical count $\\#\\text{generators} = \\varphi(p-1)$ — the base entry's `card_primitiveRoots`, now a one-line specialization of the general distribution.",
+    "mathContext": "$d \\mid p-1 \\Rightarrow \\exists g,\\ \\mathrm{ord}(g) = d$ (as $\\varphi(d) > 0$); $\\#\\{g : \\mathrm{ord}(g) = p-1\\} = \\varphi(p-1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["existence from a positive count", "Nat.totient_pos", "primitive roots as generators", "specialization d = p−1", "Nat.pos_of_dvd_of_pos"],
+    "prerequisites": ["φ(d) > 0 for d ≥ 1", "Finset.card_pos and nonempty filters", "the distribution theorem card_orderOf_eq_totient"]
   },
   {
     "id": "primitive-roots-oq-03-tiling-gauss",
     "proofId": "primitive-roots-oq-03",
     "type": "theorem",
-    "range": {
-      "startLine": 91,
-      "endLine": 115
-    },
+    "range": { "startLine": 91, "endLine": 115 },
     "title": "Tiling and Gauss's Divisor Sum",
-    "content": "`sum_card_orderOf`: the order classes **tile** the group — summing $\\#\\{g \\mid \\mathrm{ord}(g) = d\\}$ over all $d \\mid p-1$ gives $p-1$. Each summand is $\\varphi(d)$ by `card_orderOf_eq_totient`, and the resulting $\\sum_{d \\mid p-1} \\varphi(d)$ equals $p-1$ by `Nat.sum_totient`.\n\n`gauss_divisor_sum`: Gauss's identity $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ stated in the primitive-root setting. The two readings — counting units by order vs. the number-theoretic divisor sum — are the same partition of the $p-1$ units, giving a group-theoretic proof of Gauss's classical identity."
+    "content": "`sum_card_orderOf`: the order classes **tile** the group — summing $\\#\\{g \\mid \\mathrm{ord}(g) = d\\}$ over all $d \\mid p-1$ gives $p-1$. Each summand is $\\varphi(d)$ by `card_orderOf_eq_totient`, and the resulting $\\sum_{d \\mid p-1} \\varphi(d)$ equals $p-1$ by `Nat.sum_totient`.\n\n`gauss_divisor_sum`: Gauss's identity $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ stated in the primitive-root setting. The two readings — counting units by order vs. the number-theoretic divisor sum — are the same partition of the $p-1$ units, giving a group-theoretic proof of Gauss's classical identity.",
+    "mathContext": "$\\sum_{d \\mid p-1}\\#\\{g : \\mathrm{ord}(g) = d\\} = \\sum_{d \\mid p-1}\\varphi(d) = p-1$ (`Nat.sum_totient`).",
+    "significance": "key",
+    "relatedConcepts": ["Gauss's divisor-sum identity", "order classes partition a cyclic group", "Nat.sum_totient", "Finset.sum_congr", "group-theoretic proof of a number-theoretic identity"],
+    "prerequisites": ["the order distribution card_orderOf_eq_totient", "∑_{d∣n} φ(d) = n (Nat.sum_totient)", "summing over Nat.divisors"]
   }
 ]

--- a/src/data/proofs/primitive-roots-oq-03/meta.json
+++ b/src/data/proofs/primitive-roots-oq-03/meta.json
@@ -54,6 +54,48 @@
       "Finset.filter cardinality and Finset.sum_congr"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header: From Generators to the Full Order Distribution",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Frames the file as the all-d strengthening of the base entry's generator (d = p−1) count: for every divisor d of p−1, (ℤ/pℤ)ˣ has exactly φ(d) elements of order d, and summing over divisors recovers Gauss's identity. The engine is Mathlib's IsCyclic.card_orderOf_eq_totient specialized to (ℤ/pℤ)ˣ.",
+      "mathContext": "$\\#\\{g : \\mathrm{ord}(g) = d\\} = \\varphi(d)$ for $d \\mid p-1$; $\\sum_{d \\mid p-1}\\varphi(d) = p-1$."
+    },
+    {
+      "id": "setup",
+      "title": "Cyclicity and Order of the Unit Group",
+      "startLine": 47,
+      "endLine": 53,
+      "summary": "The IsCyclic instance on (ℤ/pℤ)ˣ via isCyclic_of_subgroup_isDomain (a finite subgroup of a field's units is cyclic), and card_units: |(ℤ/pℤ)ˣ| = p−1 via ZMod.card_units_eq_totient + Nat.totient_prime.",
+      "mathContext": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ cyclic of order $\\varphi(p) = p-1$."
+    },
+    {
+      "id": "distribution",
+      "title": "The Full Order Distribution",
+      "startLine": 55,
+      "endLine": 69,
+      "summary": "card_orderOf_eq_totient: for d ∣ p−1, exactly φ(d) elements of order d, by lifting d ∣ p−1 to d ∣ |group| (card_units) and specializing IsCyclic.card_orderOf_eq_totient.",
+      "mathContext": "$d \\mid p-1 \\Rightarrow \\#\\{g : \\mathrm{ord}(g) = d\\} = \\varphi(d)$."
+    },
+    {
+      "id": "existence-generators",
+      "title": "Existence of Each Order and the Generator Count",
+      "startLine": 71,
+      "endLine": 89,
+      "summary": "exists_orderOf_eq: an element of each order d ∣ p−1 exists (φ(d) > 0 since d ≥ 1). card_generators: the d = p−1 case recovers #generators = φ(p−1), the base entry's primitive-root count.",
+      "mathContext": "$\\exists g,\\ \\mathrm{ord}(g) = d$ for $d \\mid p-1$; $\\#\\{g : \\mathrm{ord}(g) = p-1\\} = \\varphi(p-1)$."
+    },
+    {
+      "id": "tiling-gauss",
+      "title": "Tiling and Gauss's Divisor Sum",
+      "startLine": 91,
+      "endLine": 115,
+      "summary": "sum_card_orderOf: the order classes tile the group — summing the counts over d ∣ p−1 gives p−1 (each summand is φ(d) via card_orderOf_eq_totient, closed by Nat.sum_totient). gauss_divisor_sum: ∑_{d∣p−1} φ(d) = p−1 stated in the primitive-root setting.",
+      "mathContext": "$\\sum_{d \\mid p-1}\\#\\{g : \\mathrm{ord}(g) = d\\} = \\sum_{d \\mid p-1}\\varphi(d) = p-1$."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "primitive-roots",


### PR DESCRIPTION
Enrichment pass for `primitive-roots-oq-03` (quality 33, passes 0).

## Gaps
Rich `overview`/`conclusion`/`mainTheorems`, but **0 `sections`** and the 5 annotations were **missing `mathContext`, `significance`, `relatedConcepts`, `prerequisites`**.

## Change
- **5 sections** covering the full 117-line Lean file, each with `mathContext`: module header, cyclicity/order, the order distribution, existence + generator count, tiling + Gauss's divisor sum.
- Added the four enrichment fields to all **5 annotations** (their existing LaTeX-rich `content` is preserved).

## Notes
- Pure data; no TypeScript touched. `annotations:build` exits clean with **no warnings for this proof**.
- `status: verified` / `badge: original` / `axiomCount: 0` / 0 sorries confirmed against the Lean source. Per the entry's own note (and the auditor convention), this file uses **no `native_decide`** — unlike the base Primitive-Roots family which evaluates totient values by `native_decide` — so the 0-axiom claim is honest here.
- Dedicated branch, independent of sibling enrichment PRs.