### PR TITLE
audit(gallery): konigsberg-oq-03-oq-01 CLEAN (Euler-path infinite-graph instances)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24408,6 +24408,12 @@
       "lastAudited": "2026-06-25T20:20:19Z",
       "result": "clean",
       "issues": []
+    },
+    "konigsberg-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T20:50:12Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — konigsberg-oq-03-oq-01

Audited the lone fresh proof in the queue not already covered by open PR #30234.

**Result: CLEAN** ✓

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | verified | — | ✓ |
| badge | original | — | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (`grep '^axiom '`) | ✓ |
| theoremCount | 11 | 11 | ✓ |
| native_decide | — | none | ✓ |

### Substance check
`Proofs/KonigsbergOQ03OQ01.lean` builds genuine `InfiniteGraph` / infinite-Euler-walk
infrastructure and proves Euler paths for two canonical instances (ray graph on ℕ,
line graph on ℤ). No `True`-stubs, no Mathlib wrapper standing in for the core result.

### Narrative honesty
The `assumptions` field correctly scopes the claim: the **general**
Erdős–Grünwald–Weiszfeld theorem for arbitrary locally-finite even-degree graphs is
**not** proven and deliberately **not** axiomatized — only the two concrete instances
are verified. No famous-name overclaim (Tier A for what it actually proves).

The remaining 7 unaudited proofs (erdos-395-oq-02, feuerbach nine-point, lucas-sum,
odd-cubes-sum, odd-squares-sum, quadratic-gauss-sum, twin-primes-special) were each
independently re-verified CLEAN this iteration and are already covered by the pending
audit PR #30234, so they are not re-filed here.

---
Discovered during gallery integrity audit. Tracker drains to 3932/3939.