### PR TITLE
research(chebyshev-bounds-oq-06): two-sided central binomial bound 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ [verified, 5 thm/0 axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -846,6 +846,7 @@ import Proofs.ChebyshevBoundsOQ04Aristotle
 import Proofs.ChebyshevBoundsOQ04OQ01
 import Proofs.ChebyshevBoundsOQ04OQ01Mertens
 import Proofs.ChebyshevBoundsOQ04OQ01OQ01WeakMertensStatementOnly
+import Proofs.ChebyshevBoundsOQ06
 import Proofs.ChebyshevPNTBridge
 import Proofs.ChebyshevPNTBridgeOQ01
 import Proofs.ChebyshevPNTBridgeOQ01Aristotle

--- a/proofs/Proofs/ChebyshevBoundsOQ06.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ06.lean
@@ -1,0 +1,87 @@
+import Mathlib
+
+/-
+# Two-sided central binomial coefficient bound
+
+The central binomial coefficient `C(2n, n) = Nat.centralBinom n` satisfies the
+elementary sandwich
+$$ \frac{4^n}{2n+1} \;\le\; \binom{2n}{n} \;\le\; 4^n. $$
+
+This is the workhorse estimate behind Chebyshev-type prime-counting bounds: the
+upper bound feeds the bound on `θ(n)`, and the lower bound forces enough prime
+factors into `C(2n, n)` to drive the lower estimate on `π(n)`.
+
+This is a **routine assembly** of existing Mathlib primitives into a single named
+two-sided estimate (with quotient and real-valued forms), to serve as an axiom-free
+building block for the axiomatized parent `chebyshev-bounds`. Neither bound is new:
+
+* **Lower bound** `4 ^ n ≤ (2n + 1) · centralBinom n`: this *is* Mathlib's
+  `Nat.four_pow_le_two_mul_add_one_mul_central_binom` (proved there from
+  `(1+1)^(2n) = Σ C(2n, m)` with the middle term largest); we just record it in
+  `centralBinom` notation.
+
+* **Upper bound** `centralBinom n ≤ 4 ^ n`: a one-line corollary of
+  `Nat.choose_le_two_pow` (`C(m, k) ≤ 2 ^ m`) at row `m = 2n`, giving
+  `C(2n, n) ≤ 2 ^ (2n) = 4 ^ n`. (Mathlib records the analogous `choose_middle_le_pow`
+  for the *odd* row `C(2n+1, n) ≤ 4 ^ n`, but not this even-row form.)
+
+The packaging value is the unified `centralBinom_sandwich`, the literal quotient form
+`4 ^ n / (2n + 1) ≤ C(2n, n)` (truncated `ℕ`-division), and the real-valued sandwich.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace ChebyshevBoundsOQ06
+
+open Nat
+
+/-- **Upper bound.** The central binomial coefficient is at most `4 ^ n`.
+`C(2n, n) ≤ 2 ^ (2n) = 4 ^ n`, since any entry of row `2n` of Pascal's triangle
+is bounded by the row sum `2 ^ (2n)`. -/
+theorem centralBinom_le_four_pow (n : ℕ) : centralBinom n ≤ 4 ^ n := by
+  have h : (2 * n).choose n ≤ 2 ^ (2 * n) := Nat.choose_le_two_pow (2 * n) n
+  calc centralBinom n = (2 * n).choose n := Nat.centralBinom_eq_two_mul_choose n
+    _ ≤ 2 ^ (2 * n) := h
+    _ = 4 ^ n := by rw [pow_mul]; norm_num
+
+/-- **Lower bound (product form).** `4 ^ n ≤ (2n + 1) · C(2n, n)` for every `n`.
+This is Mathlib's `Nat.four_pow_le_two_mul_add_one_mul_central_binom`, restated with
+`centralBinom n` in place of `(2 * n).choose n` (the two are definitionally equal).
+Stated multiplicatively to avoid truncated division. -/
+theorem four_pow_le_succ_two_mul_mul_centralBinom (n : ℕ) :
+    4 ^ n ≤ (2 * n + 1) * centralBinom n := by
+  rw [Nat.centralBinom_eq_two_mul_choose]
+  exact Nat.four_pow_le_two_mul_add_one_mul_central_binom n
+
+/-- **Lower bound (quotient form).** The literal statement `4 ^ n / (2n + 1) ≤ C(2n, n)`,
+with truncated natural-number division. Immediate from the product form. -/
+theorem four_pow_div_succ_two_mul_le_centralBinom (n : ℕ) :
+    4 ^ n / (2 * n + 1) ≤ centralBinom n := by
+  apply Nat.div_le_of_le_mul
+  exact four_pow_le_succ_two_mul_mul_centralBinom n
+
+/-- **The two-sided sandwich, product form.** Combines both bounds into the single
+statement `4 ^ n ≤ (2n + 1) · C(2n, n)` and `C(2n, n) ≤ 4 ^ n`. -/
+theorem centralBinom_sandwich (n : ℕ) :
+    4 ^ n ≤ (2 * n + 1) * centralBinom n ∧ centralBinom n ≤ 4 ^ n :=
+  ⟨four_pow_le_succ_two_mul_mul_centralBinom n, centralBinom_le_four_pow n⟩
+
+/-- **The two-sided sandwich, real-valued quotient form.**
+`(4 ^ n) / (2n + 1) ≤ C(2n, n) ≤ 4 ^ n` as an inequality of real numbers, so the
+division is the genuine quotient rather than its `ℕ`-truncation. -/
+theorem centralBinom_real_sandwich (n : ℕ) :
+    (4 : ℝ) ^ n / (2 * n + 1) ≤ (centralBinom n : ℝ) ∧
+      (centralBinom n : ℝ) ≤ (4 : ℝ) ^ n := by
+  refine ⟨?_, ?_⟩
+  · rw [div_le_iff₀ (by positivity)]
+    have h := four_pow_le_succ_two_mul_mul_centralBinom n
+    have hcast : ((4 ^ n : ℕ) : ℝ) ≤ (((2 * n + 1) * centralBinom n : ℕ) : ℝ) :=
+      Nat.cast_le.mpr h
+    push_cast at hcast
+    linarith
+  · have h := centralBinom_le_four_pow n
+    have hcast : ((centralBinom n : ℕ) : ℝ) ≤ ((4 ^ n : ℕ) : ℝ) := Nat.cast_le.mpr h
+    push_cast at hcast
+    linarith
+
+end ChebyshevBoundsOQ06

--- a/src/data/proofs/chebyshev-bounds-oq-06/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-upper-bound",
+    "proofId": "chebyshev-bounds-oq-06",
+    "range": { "startLine": 38, "endLine": 45 },
+    "type": "theorem",
+    "title": "Upper bound: C(2n,n) ≤ 4ⁿ",
+    "content": "`centralBinom_le_four_pow`. The central binomial coefficient is one term of the row sum $\\sum_k \\binom{2n}{k} = 2^{2n}$, so it cannot exceed it. Formally, `Nat.choose_le_two_pow (2n) n` gives $\\binom{2n}{n} \\le 2^{2n}$; then `centralBinom n = (2n).choose n` (via `Nat.centralBinom_eq_two_mul_choose`) and $2^{2n} = (2^2)^n = 4^n$ by `pow_mul` and `norm_num`. Mathlib records the analogous bound for the odd row, `choose_middle_le_pow : (2n+1).choose n ≤ 4ⁿ`, but not this even-row statement.",
+    "mathContext": "$\\binom{2n}{n} \\le 2^{2n} = 4^n$.",
+    "significance": "critical",
+    "prerequisites": ["Binomial coefficients", "Nat.choose_le_two_pow"],
+    "relatedConcepts": ["Central binomial coefficient", "Row sums of Pascal's triangle", "Pochhammer/binomial bounds"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "chebyshev-bounds-oq-06",
+    "range": { "startLine": 47, "endLine": 54 },
+    "type": "theorem",
+    "title": "Lower bound: 4ⁿ ≤ (2n+1)·C(2n,n)",
+    "content": "`four_pow_le_succ_two_mul_mul_centralBinom`. This is exactly Mathlib's `Nat.four_pow_le_two_mul_add_one_mul_central_binom`, restated with `centralBinom n` in place of `(2n).choose n` (the two are definitionally equal, bridged by `Nat.centralBinom_eq_two_mul_choose`). Mathlib's proof writes $4^n = (1+1)^{2n} = \\sum_{m} \\binom{2n}{m}$ and bounds each of the $2n+1$ terms by the central, maximal one $\\binom{2n}{n}$. Stated multiplicatively to keep everything inside ℕ with no truncated division.",
+    "mathContext": "$4^n \\le (2n+1)\\binom{2n}{n}$.",
+    "significance": "critical",
+    "prerequisites": ["Binomial theorem", "Nat.four_pow_le_two_mul_add_one_mul_central_binom"],
+    "relatedConcepts": ["Central term is largest", "Pigeonhole on row entries", "Erdős prime-counting estimates"]
+  },
+  {
+    "id": "ann-quotient-form",
+    "proofId": "chebyshev-bounds-oq-06",
+    "range": { "startLine": 56, "endLine": 61 },
+    "type": "theorem",
+    "title": "Quotient form: 4ⁿ/(2n+1) ≤ C(2n,n) over ℕ",
+    "content": "`four_pow_div_succ_two_mul_le_centralBinom`. The literal textbook statement with truncated natural-number division. Immediate from the multiplicative lower bound via `Nat.div_le_of_le_mul`, whose goal `4ⁿ ≤ (2n+1)·centralBinom n` matches `four_pow_le_succ_two_mul_mul_centralBinom` verbatim (the divisor `2n+1` is the left factor).",
+    "mathContext": "$\\lfloor 4^n/(2n+1)\\rfloor \\le \\binom{2n}{n}$.",
+    "significance": "supporting",
+    "prerequisites": ["Truncated ℕ-division", "Nat.div_le_of_le_mul"],
+    "relatedConcepts": ["Floor division", "Multiplicative vs quotient phrasing"]
+  },
+  {
+    "id": "ann-real-sandwich",
+    "proofId": "chebyshev-bounds-oq-06",
+    "range": { "startLine": 69, "endLine": 87 },
+    "type": "theorem",
+    "title": "Real-valued sandwich with genuine division",
+    "content": "`centralBinom_real_sandwich`. Lifts both bounds to $\\mathbb{R}$ so the division $4^n/(2n+1)$ is the true quotient, not its ℕ-truncation. For the lower half, `div_le_iff₀` (with positivity of $2n+1$) reduces to $4^n \\le (2n+1)\\binom{2n}{n}$, which is the cast of the ℕ inequality (`Nat.cast_le` then `push_cast`; `linarith` finishes). The upper half is the cast of `centralBinom_le_four_pow`. `centralBinom_sandwich` (lines 63–67) packages the two ℕ bounds together.",
+    "mathContext": "$\\dfrac{4^n}{2n+1} \\le \\binom{2n}{n} \\le 4^n$ in $\\mathbb{R}$.",
+    "significance": "supporting",
+    "prerequisites": ["ℕ→ℝ casting", "div_le_iff₀", "push_cast / linarith"],
+    "relatedConcepts": ["Genuine vs truncated division", "Cast monotonicity", "Reusable packaging"]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-06/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-06/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "chebyshev-bounds-oq-06",
+  "title": "Two-Sided Central Binomial Bound: 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ",
+  "slug": "chebyshev-bounds-oq-06",
+  "description": "A fully machine-checked, axiom-free packaging of the elementary two-sided estimate for the central binomial coefficient C(2n,n) = Nat.centralBinom n: 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ. This is the combinatorial workhorse behind Chebyshev-type prime-counting bounds. The entry is an honest assembly of existing Mathlib primitives rather than a new result: the lower bound IS Mathlib's Nat.four_pow_le_two_mul_add_one_mul_central_binom, and the upper bound is a one-line corollary of Nat.choose_le_two_pow. The packaging value is the unified sandwich plus the literal ℕ-quotient form and a real-valued (genuine-division) sandwich, suitable as an axiom-free building block for the axiomatized parent chebyshev-bounds.",
+  "meta": {
+    "author": "Classical (bounds due to Chebyshev/Erdős); assembled in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Central_binomial_coefficient",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "central-binomial-coefficient",
+      "chebyshev-bounds",
+      "prime-counting",
+      "binomial-coefficients",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ06.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.four_pow_le_two_mul_add_one_mul_central_binom",
+        "description": "4ⁿ ≤ (2n+1)·C(2n,n). This IS the lower bound; proved in Mathlib from (1+1)^(2n) = Σ_m C(2n,m) with the central term largest. We only restate it in centralBinom notation.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.choose_le_two_pow",
+        "description": "C(m,k) ≤ 2^m for every row m. At m = 2n this gives C(2n,n) ≤ 2^(2n) = 4ⁿ, the upper bound.",
+        "module": "Mathlib.Data.Nat.Choose.Bounds"
+      },
+      {
+        "theorem": "Nat.centralBinom_eq_two_mul_choose",
+        "description": "centralBinom n = (2n).choose n, used to move between the centralBinom notation and the raw binomial coefficient.",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.div_le_of_le_mul",
+        "description": "From 4ⁿ ≤ (2n+1)·C(2n,n) deduce the truncated-division form 4ⁿ/(2n+1) ≤ C(2n,n).",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "centralBinom_le_four_pow: the EVEN-row upper bound C(2n,n) ≤ 4ⁿ, packaged as a named lemma (Mathlib records the analogous choose_middle_le_pow only for the odd row C(2n+1,n) ≤ 4ⁿ, not this even-row form) — a one-line corollary of Nat.choose_le_two_pow at row 2n",
+      "centralBinom_sandwich: the unified two-sided statement 4ⁿ ≤ (2n+1)·C(2n,n) ∧ C(2n,n) ≤ 4ⁿ as a single reusable lemma",
+      "four_pow_div_succ_two_mul_le_centralBinom: the literal quotient form 4ⁿ/(2n+1) ≤ C(2n,n) with truncated ℕ-division, matching the textbook statement",
+      "centralBinom_real_sandwich: a real-valued sandwich (4:ℝ)ⁿ/(2n+1) ≤ C(2n,n) ≤ (4:ℝ)ⁿ where the division is genuine rather than ℕ-truncated, via Nat.cast_le + push_cast"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 87,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for all five theorems (none of which count as assumptions). No native_decide (hence no Lean.ofReduceBool), no structure-encoded hypotheses. Honest framing: the two bounds are not new — both are already essentially in Mathlib; this entry is a routine assembly into a single named sandwich with quotient and real-valued forms.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "upper-bound",
+      "title": "Upper bound C(2n,n) ≤ 4ⁿ",
+      "startLine": 38,
+      "endLine": 45,
+      "summary": "centralBinom_le_four_pow. Every entry of row 2n of Pascal's triangle is bounded by the row sum 2^(2n) (Nat.choose_le_two_pow), so C(2n,n) ≤ 2^(2n), and 2^(2n) = 4ⁿ by pow_mul + norm_num. Mathlib has the odd-row analogue choose_middle_le_pow but not this even-row statement."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Lower bound 4ⁿ ≤ (2n+1)·C(2n,n)",
+      "startLine": 47,
+      "endLine": 54,
+      "summary": "four_pow_le_succ_two_mul_mul_centralBinom. This is Mathlib's Nat.four_pow_le_two_mul_add_one_mul_central_binom restated with centralBinom n in place of (2n).choose n (definitionally equal). Mathlib proves it from (1+1)^(2n) = Σ_m C(2n,m), bounding every term by the central one."
+    },
+    {
+      "id": "quotient-and-sandwich",
+      "title": "Quotient form and unified sandwiches",
+      "startLine": 56,
+      "endLine": 87,
+      "summary": "four_pow_div_succ_two_mul_le_centralBinom gives the textbook 4ⁿ/(2n+1) ≤ C(2n,n) over ℕ via Nat.div_le_of_le_mul. centralBinom_sandwich bundles both bounds. centralBinom_real_sandwich lifts to ℝ so the division is genuine: cast both ℕ-inequalities with Nat.cast_le, push_cast, and close by linarith / div_le_iff₀."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**The central binomial coefficient and Chebyshev's bounds**\n\nThe central binomial coefficient $\\binom{2n}{n}$ is the largest entry of the $2n$-th row of Pascal's triangle, and the row sums to $2^{2n}=4^n$. Two elementary facts pin it down to within a polynomial factor:\n$$\\frac{4^n}{2n+1}\\;\\le\\;\\binom{2n}{n}\\;\\le\\;4^n.$$\nThe upper bound is immediate (it is one term of a sum equal to $4^n$); the lower bound says the central term carries at least a $1/(2n+1)$ share of the total. Chebyshev (1852) and later Erdős built their elementary prime-counting estimates on exactly this kind of bound: $\\binom{2n}{n}$ is divisible by every prime in $(n,2n]$, so squeezing it between powers of $4$ controls $\\theta$ and $\\pi$.",
+    "problemStatement": "**Two-sided central binomial bound**\n\nFor every natural number $n$,\n$$\\frac{4^n}{2n+1}\\;\\le\\;\\binom{2n}{n}\\;\\le\\;4^n.$$\nThe goal is a fully machine-checked, axiom-free statement of this sandwich (in multiplicative, ℕ-quotient, and real-valued forms) for reuse as a building block by the axiomatized Chebyshev prime-counting entries.",
+    "proofStrategy": "**Routine assembly of Mathlib primitives.**\n\n*Upper bound.* $\\binom{2n}{n}\\le 2^{2n}=4^n$ from `Nat.choose_le_two_pow` (any binomial coefficient on row $m$ is at most $2^m$), specialised to $m=2n$.\n\n*Lower bound.* $4^n\\le(2n+1)\\binom{2n}{n}$ is Mathlib's `Nat.four_pow_le_two_mul_add_one_mul_central_binom`, which expands $4^n=(1+1)^{2n}=\\sum_m\\binom{2n}{m}$ and bounds every term by the central (largest) one.\n\n*Forms.* The truncated-division statement $4^n/(2n+1)\\le\\binom{2n}{n}$ follows by `Nat.div_le_of_le_mul`; the real-valued sandwich casts both ℕ-inequalities to $\\mathbb{R}$ (`Nat.cast_le`, `push_cast`, `linarith`) so the division is genuine.",
+    "keyInsights": [
+      "**The upper bound is free.** $\\binom{2n}{n}$ is a single term of $\\sum_k\\binom{2n}{k}=4^n$, so it cannot exceed $4^n$ — formalised here as the row bound $\\binom{2n}{n}\\le 2^{2n}$.",
+      "**The lower bound is the central-term-is-largest principle.** Among the $2n+1$ entries of row $2n$, the central one is maximal, so it is at least the average $4^n/(2n+1)$ — exactly Mathlib's `four_pow_le_two_mul_add_one_mul_central_binom`.",
+      "**Multiplicative phrasing avoids ℕ-division artifacts.** Stating the lower bound as $4^n\\le(2n+1)\\binom{2n}{n}$ keeps the development inside ℕ with no truncation; the quotient and real forms are derived on top.",
+      "**Honest provenance.** Neither inequality is new to Mathlib; the contribution is the even-row upper bound as a named lemma plus the unified sandwich and real-valued form for downstream reuse."
+    ],
+    "prerequisites": [
+      "Binomial coefficients and the central binomial coefficient",
+      "The binomial theorem / row sums of Pascal's triangle",
+      "Mathlib: Nat.centralBinom, Nat.choose_le_two_pow, Nat.four_pow_le_two_mul_add_one_mul_central_binom"
+    ]
+  },
+  "conclusion": {
+    "summary": "The central binomial coefficient satisfies $4^n/(2n+1)\\le\\binom{2n}{n}\\le 4^n$. This entry assembles the two halves from Mathlib — the lower bound is `Nat.four_pow_le_two_mul_add_one_mul_central_binom`, the upper bound a one-line corollary of `Nat.choose_le_two_pow` — into a single named sandwich, together with the textbook ℕ-quotient form and a real-valued (genuine-division) sandwich. 5 theorems, 0 sorries, 0 axioms.",
+    "implications": [
+      "Supplies an axiom-free building block for the axiomatized parent chebyshev-bounds, where $\\binom{2n}{n}\\le 4^n$ controls $\\theta(2n)-\\theta(n)$ and $4^n/(2n+1)\\le\\binom{2n}{n}$ forces enough primes into $(n,2n]$ for the lower estimate on $\\pi$.",
+      "Packages the EVEN-row upper bound $\\binom{2n}{n}\\le 4^n$ as a named lemma, complementing Mathlib's odd-row `choose_middle_le_pow`.",
+      "Provides both ℕ-truncated and real-valued quotient forms, so downstream entries can use whichever division semantics they need."
+    ],
+    "openQuestions": [
+      "Can the upper bound be sharpened to the standard $\\binom{2n}{n}\\le 4^n/\\sqrt{\\pi n}$ (Stirling) within Mathlib, giving the matching asymptotic $\\binom{2n}{n}\\sim 4^n/\\sqrt{\\pi n}$?",
+      "Does the central-binomial sandwich let the parent chebyshev-bounds discharge its remaining axiomatized $\\theta(n)\\le n\\log 4$ upper bound directly?"
+    ]
+  }
+}

--- a/src/data/research/problems/chebyshev-bounds-oq-06.json
+++ b/src/data/research/problems/chebyshev-bounds-oq-06.json
@@ -1,0 +1,31 @@
+{
+  "id": "chebyshev-bounds-oq-06",
+  "name": "Two-Sided Central Binomial Bound: 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "insights": [
+      "The central binomial coefficient C(2n,n) = Nat.centralBinom n is the largest entry of row 2n of Pascal's triangle, which sums to 2^(2n) = 4ⁿ.",
+      "Upper bound C(2n,n) ≤ 4ⁿ is a one-line corollary of Nat.choose_le_two_pow (C(m,k) ≤ 2^m) at row m = 2n, since 2^(2n) = 4ⁿ.",
+      "Lower bound 4ⁿ ≤ (2n+1)·C(2n,n) IS Mathlib's Nat.four_pow_le_two_mul_add_one_mul_central_binom (expand 4ⁿ = Σ_m C(2n,m), bound each of the 2n+1 terms by the central one). My lemma just restates it in centralBinom notation (definitionally equal via centralBinom_eq_two_mul_choose).",
+      "Mathlib has choose_middle_le_pow for the ODD row C(2n+1,n) ≤ 4ⁿ but not the even-row C(2n,n) ≤ 4ⁿ; that even-row lemma is the only genuinely new packaging here.",
+      "The ℕ-quotient form 4ⁿ/(2n+1) ≤ C(2n,n) follows from the multiplicative bound via Nat.div_le_of_le_mul (divisor is the left factor, so the goal matches the lemma verbatim).",
+      "The real-valued sandwich (cast via Nat.cast_le + push_cast, closed by linarith/div_le_iff₀) gives genuine division rather than ℕ-truncation."
+    ],
+    "builtItems": [
+      "ChebyshevBoundsOQ06.centralBinom_le_four_pow (Proofs/ChebyshevBoundsOQ06.lean:41) — C(2n,n) ≤ 4ⁿ (even-row upper bound, new named lemma)",
+      "ChebyshevBoundsOQ06.four_pow_le_succ_two_mul_mul_centralBinom (:51) — 4ⁿ ≤ (2n+1)·C(2n,n) (restatement of Mathlib lemma)",
+      "ChebyshevBoundsOQ06.four_pow_div_succ_two_mul_le_centralBinom (:58) — 4ⁿ/(2n+1) ≤ C(2n,n) over ℕ",
+      "ChebyshevBoundsOQ06.centralBinom_sandwich (:65) — unified two-sided ℕ statement",
+      "ChebyshevBoundsOQ06.centralBinom_real_sandwich (:72) — real-valued sandwich with genuine division"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the odd-row upper bound choose_middle_le_pow (C(2n+1,n) ≤ 4ⁿ) and the lower bound four_pow_le_two_mul_add_one_mul_central_binom, but no named even-row upper bound C(2n,n) ≤ 4ⁿ and no unified two-sided central-binomial sandwich lemma."
+    ],
+    "nextSteps": [
+      "Sharpen the upper bound to the Stirling form C(2n,n) ≤ 4ⁿ/√(πn) for the matching asymptotic C(2n,n) ~ 4ⁿ/√(πn).",
+      "Use this sandwich to discharge the axiomatized θ(n) ≤ n·log 4 upper bound in the parent chebyshev-bounds."
+    ],
+    "progressSummary": "COMPLETE (honest low-novelty assembly): the two-sided central binomial bound 4ⁿ/(2n+1) ≤ C(2n,n) ≤ 4ⁿ packaged from Mathlib primitives — 5 theorems, 0 sorries, 0 axioms, no native_decide (#print axioms = [propext, Classical.choice, Quot.sound]). Compiled against Mathlib v4.26.0. Neither bound is new (lower = Nat.four_pow_le_two_mul_add_one_mul_central_binom; upper = corollary of Nat.choose_le_two_pow); contribution is the even-row upper bound as a named lemma plus the unified sandwich and real-valued/quotient forms as an axiom-free building block for the axiomatized parent chebyshev-bounds. PR opened."
+  }
+}


### PR DESCRIPTION
## Summary

Axiom-free packaging of the elementary **two-sided central binomial bound**
$$\frac{4^n}{2n+1} \le \binom{2n}{n} \le 4^n,$$
the combinatorial workhorse behind Chebyshev-type prime-counting bounds. Built as an axiom-free building block for the axiomatized parent `chebyshev-bounds`.

## Honest framing (low novelty)

Neither bound is new to Mathlib — this is a **routine assembly**:

- **Lower bound** `4ⁿ ≤ (2n+1)·C(2n,n)` **IS** Mathlib's `Nat.four_pow_le_two_mul_add_one_mul_central_binom`, restated in `centralBinom` notation.
- **Upper bound** `C(2n,n) ≤ 4ⁿ` is a one-line corollary of `Nat.choose_le_two_pow` at row `2n` (`C(2n,n) ≤ 2^(2n) = 4ⁿ`).

What's packaged on top:
- `centralBinom_le_four_pow` — the **even-row** upper bound as a named lemma (Mathlib records only the odd-row `choose_middle_le_pow`).
- `centralBinom_sandwich` — the unified two-sided ℕ statement.
- `four_pow_div_succ_two_mul_le_centralBinom` — the literal ℕ-quotient form.
- `centralBinom_real_sandwich` — a real-valued sandwich with genuine (non-truncated) division.

## Verification

- **5 theorems, 0 sorries, 0 axioms**
- `#print axioms` for all five = `[propext, Classical.choice, Quot.sound]` (foundational only; none counted)
- No `native_decide` (no `Lean.ofReduceBool`); no structure-encoded assumptions
- Type-checked offline against **Mathlib v4.26.0** (`lake env lean`; Docker daemon was down)

## Note

Branch name is `research/fibonacci-identities-oq-06` for incidental reasons (the branch was created before re-targeting); the content is `chebyshev-bounds-oq-06`. The originally-claimed candidates `fibonacci-identities-oq-06` (∑fib(i)²) and `combinations-formula-oq-10` (Vandermonde) were released as **already present in the gallery** (`FibonacciIdentities.fib_sum_sq` and `CombinationsFormulaOQ01` respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)