### PR TITLE
research(combinations-formula-oq-08-oq-01): Fibonacci recurrence from Pascal's rule on shallow diagonals

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ08OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ08OQ01.lean
@@ -1,0 +1,206 @@
+import Mathlib
+
+/-
+# The Fibonacci Recurrence as a Shadow of Pascal's Rule (OQ-08-OQ-01)
+
+Parent entry `combinations-formula-oq-08` proves that the Fibonacci numbers are the
+sums along the shallow diagonals of Pascal's triangle:
+
+  `fib (n + 1) = ∑ k ∈ range (n + 1), C(n - k, k)`        (`fib_eq_sum_range_choose`).
+
+That identity is established by *reindexing* Mathlib's antidiagonal form.  This
+follow-up takes the next, genuinely combinatorial step: it derives the Fibonacci
+recurrence `F_{n+2} = F_{n+1} + F_n` **directly from the shallow-diagonal sums**, by
+applying Pascal's rule `C(a+1, b+1) = C(a, b) + C(a, b+1)` to each diagonal term — no
+appeal to `Nat.fib_add_two`, no generating functions, no matrix powers.
+
+Write `D n := ∑ k ∈ range (n + 1), C(n - k, k)` for the `n`-th shallow-diagonal total.
+The centerpiece is
+
+  `D_recurrence : D (n + 2) = D (n + 1) + D n`,
+
+proved purely by term-by-term Pascal expansion and reindexing of finite sums.  Combined
+with the parent identity `D n = fib (n + 1)`, this *reproves* the Fibonacci recurrence
+combinatorially (`fib_recurrence_via_pascal`), exhibiting it as a shadow of Pascal's
+rule.
+
+The second half links the diagonals to the **Lucas partial-sum identity**
+
+  `∑ i ∈ range n, fib i = fib (n + 1) - 1`                 (`fib_partial_sum_sub`),
+
+and re-expresses it as a statement about the shallow-diagonal totals:
+
+  `∑ i ∈ range n, D i = fib (n + 2) - 1`                   (`shallow_diag_partial_sum`).
+
+## Proof of the recurrence (sketch)
+
+Peeling the `k = 0` term of `D (n + 2)` with `Finset.sum_range_succ'` and discarding the
+vanishing top term `C(0, n + 2) = 0` with `Finset.sum_range_succ` gives
+
+  `D (n + 2) = (∑ k ∈ range (n + 1), C(n + 1 - k, k + 1)) + 1`.
+
+Peeling the `k = 0` term of `D (n + 1)` likewise gives
+
+  `D (n + 1) = (∑ k ∈ range (n + 1), C(n - k, k + 1)) + 1`,
+
+while `D n = ∑ k ∈ range (n + 1), C(n - k, k)`.  For `k ≤ n` we have
+`n + 1 - k = (n - k) + 1`, so Pascal's rule yields term-by-term
+
+  `C(n + 1 - k, k + 1) = C(n - k, k) + C(n - k, k + 1)`,
+
+and summing this identity over `range (n + 1)` matches the two sides.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ08OQ01
+
+open Finset
+
+/-- `D n` is the total of the `n`-th shallow diagonal of Pascal's triangle:
+    `D n = C(n, 0) + C(n - 1, 1) + C(n - 2, 2) + ⋯`. -/
+def D (n : ℕ) : ℕ := ∑ k ∈ Finset.range (n + 1), Nat.choose (n - k) k
+
+/-- **Parent identity (`combinations-formula-oq-08`, `fib_eq_sum_range_choose`).**
+    The shallow-diagonal formula `fib (n + 1) = ∑ k ∈ range (n+1), C(n - k, k)`, reproved
+    inline here so this file stands alone.  It reindexes Mathlib's antidiagonal form
+    `Nat.fib_succ_eq_sum_choose` via `sum_antidiagonal_eq_sum_range_succ` and the index
+    reflection `k ↦ n - k`. -/
+theorem fib_eq_sum_range_choose (n : ℕ) :
+    Nat.fib (n + 1) = ∑ k ∈ Finset.range (n + 1), Nat.choose (n - k) k := by
+  rw [Nat.fib_succ_eq_sum_choose,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i j => Nat.choose i j) n,
+      ← Finset.sum_range_reflect (fun k => Nat.choose (n - k) k) (n + 1)]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  simp only [Nat.add_sub_cancel, Nat.sub_sub_self hk]
+
+/-- The shallow-diagonal total equals a Fibonacci number, recorded in terms of `D`. -/
+theorem D_eq_fib (n : ℕ) : D n = Nat.fib (n + 1) :=
+  (fib_eq_sum_range_choose n).symm
+
+/-- **Pascal expansion of one diagonal term.**
+    For `k ≤ n`, the entry on diagonal `n + 1` splits into the two entries directly
+    below it on diagonal `n`, by Pascal's rule.  This is the single arithmetic fact that
+    drives the whole recurrence. -/
+theorem choose_shift_succ {n k : ℕ} (hk : k ≤ n) :
+    Nat.choose (n + 1 - k) (k + 1) = Nat.choose (n - k) k + Nat.choose (n - k) (k + 1) := by
+  have h : n + 1 - k = (n - k) + 1 := by omega
+  rw [h, Nat.choose_succ_succ]
+
+/-- After peeling the `k = 0` term and dropping the vanishing top term, the diagonal
+    total `D (n + 2)` is a single sum over `range (n + 1)` plus the constant `1`. -/
+theorem D_add_two_peel (n : ℕ) :
+    D (n + 2) = (∑ k ∈ Finset.range (n + 1), Nat.choose (n + 1 - k) (k + 1)) + 1 := by
+  unfold D
+  rw [Finset.sum_range_succ' (fun k => Nat.choose (n + 2 - k) k) (n + 2)]
+  -- peel `k = 0`: the constant term is `C(n + 2, 0) = 1` (only the `_ 0` term is touched)
+  simp only [Nat.choose_zero_right]
+  -- split off the top term `k = n + 1` of the shifted sum
+  rw [Finset.sum_range_succ]
+  -- drop the vanishing top term `C(n + 2 - (n + 2), n + 2) = C(0, n + 2) = 0`
+  rw [Nat.choose_eq_zero_of_lt (show n + 2 - (n + 1 + 1) < n + 1 + 1 by omega), add_zero]
+  -- match the remaining sum term-by-term: `n + 2 - (k + 1) = n + 1 - k`
+  congr 1
+  apply Finset.sum_congr rfl
+  intro k _
+  congr 1
+  omega
+
+/-- After peeling its `k = 0` term, the diagonal total `D (n + 1)` is a single sum over
+    `range (n + 1)` plus the constant `1`. -/
+theorem D_add_one_peel (n : ℕ) :
+    D (n + 1) = (∑ k ∈ Finset.range (n + 1), Nat.choose (n - k) (k + 1)) + 1 := by
+  unfold D
+  rw [Finset.sum_range_succ' (fun k => Nat.choose (n + 1 - k) k) (n + 1)]
+  -- peel `k = 0`: the constant term is `C(n + 1, 0) = 1` (only the `_ 0` term is touched)
+  simp only [Nat.choose_zero_right]
+  -- match the remaining sum term-by-term: `n + 1 - (k + 1) = n - k`
+  congr 1
+  apply Finset.sum_congr rfl
+  intro k _
+  congr 1
+  omega
+
+/-- **The shallow-diagonal recurrence — the combinatorial core.**
+    The diagonal totals satisfy the Fibonacci recurrence, derived purely by applying
+    Pascal's rule to each diagonal term.  No use of `Nat.fib_add_two`. -/
+theorem D_recurrence (n : ℕ) : D (n + 2) = D (n + 1) + D n := by
+  rw [D_add_two_peel, D_add_one_peel]
+  unfold D
+  -- LHS sum: expand each term by Pascal's rule (valid since `k ≤ n` on `range (n+1)`)
+  have hL : (∑ k ∈ Finset.range (n + 1), Nat.choose (n + 1 - k) (k + 1))
+      = ∑ k ∈ Finset.range (n + 1),
+          (Nat.choose (n - k) k + Nat.choose (n - k) (k + 1)) := by
+    apply Finset.sum_congr rfl
+    intro k hk
+    rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+    rw [choose_shift_succ hk]
+  rw [hL, Finset.sum_add_distrib]
+  ring
+
+/-- **The Fibonacci recurrence, reproved as a shadow of Pascal's rule.**
+    Combining the shallow-diagonal recurrence `D_recurrence` with the parent identity
+    `D n = fib (n + 1)` recovers `fib (n + 2) = fib (n + 1) + fib n` — obtained here
+    entirely from Pascal's rule on the diagonals, independently of `Nat.fib_add_two`. -/
+theorem fib_recurrence_via_pascal (n : ℕ) :
+    Nat.fib (n + 3) = Nat.fib (n + 2) + Nat.fib (n + 1) := by
+  have h := D_recurrence n
+  rw [D_eq_fib, D_eq_fib, D_eq_fib] at h
+  exact h
+
+/-! ### Link to the Lucas partial-sum identity -/
+
+/-- **Lucas partial-sum identity (subtraction-free form).**
+    `(∑ i ∈ range n, fib i) + 1 = fib (n + 1)`.  Proved by induction using
+    `Nat.fib_add_two`; stated without truncated subtraction. -/
+theorem fib_partial_sum (n : ℕ) :
+    (∑ i ∈ Finset.range n, Nat.fib i) + 1 = Nat.fib (n + 1) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [Finset.sum_range_succ]
+    -- `(∑_{i<m} fib i + fib m) + 1 = (∑_{i<m} fib i + 1) + fib m = fib (m+1) + fib m`
+    have : (∑ i ∈ Finset.range m, Nat.fib i) + Nat.fib m + 1
+        = ((∑ i ∈ Finset.range m, Nat.fib i) + 1) + Nat.fib m := by ring
+    rw [this, ih, Nat.fib_add_two]
+    ring
+
+/-- **Lucas partial-sum identity (textbook form).**
+    `∑ i ∈ range n, fib i = fib (n + 1) - 1`. -/
+theorem fib_partial_sum_sub (n : ℕ) :
+    (∑ i ∈ Finset.range n, Nat.fib i) = Nat.fib (n + 1) - 1 := by
+  have h := fib_partial_sum n
+  omega
+
+/-- **Partial sums of the shallow-diagonal totals.**
+    Summing the diagonal totals `D 0, D 1, …, D (n-1)` gives `fib (n + 2) - 1`, the
+    Lucas partial-sum identity recast in terms of the shallow diagonals.  Each `D i`
+    equals `fib (i + 1)`, so this is `fib 1 + fib 2 + ⋯ + fib n = fib (n + 2) - 1`. -/
+theorem shallow_diag_partial_sum (n : ℕ) :
+    (∑ i ∈ Finset.range n, D i) = Nat.fib (n + 2) - 1 := by
+  have hrw : (∑ i ∈ Finset.range n, D i)
+      = ∑ i ∈ Finset.range n, Nat.fib (i + 1) := by
+    apply Finset.sum_congr rfl
+    intro i _
+    exact D_eq_fib i
+  rw [hrw]
+  -- `∑_{i<n} fib (i+1) = (∑_{i<n+1} fib i) - fib 0 = fib (n+2) - 1`
+  have hshift : (∑ i ∈ Finset.range n, Nat.fib (i + 1))
+      = (∑ i ∈ Finset.range (n + 1), Nat.fib i) - Nat.fib 0 := by
+    rw [Finset.sum_range_succ' Nat.fib n]
+    simp
+  rw [hshift, fib_partial_sum_sub]
+  simp
+
+/-- Sanity check: `D 6 = fib 7 = 13`, from `C(6,0)+C(5,1)+C(4,2)+C(3,3) = 1+5+6+1 = 13`. -/
+example : D 6 = 13 := by decide
+
+/-- Sanity check on the recurrence: `D 6 = D 5 + D 4`, i.e. `13 = 8 + 5`. -/
+example : D 6 = D 5 + D 4 := by decide
+
+/-- Sanity check on the partial sum: `D 0 + D 1 + D 2 + D 3 = fib 6 - 1 = 7`,
+    i.e. `1 + 1 + 2 + 3 = 7`. -/
+example : (∑ i ∈ Finset.range 4, D i) = 7 := by decide
+
+end CombinationsFormulaOQ08OQ01

--- a/research/problems/combinations-formula-oq-08-oq-01/knowledge.md
+++ b/research/problems/combinations-formula-oq-08-oq-01/knowledge.md
@@ -1,0 +1,59 @@
+# combinations-formula-oq-08-oq-01 — The Fibonacci Recurrence as a Shadow of Pascal's Rule
+
+**Status**: COMPLETED (verified, 0 sorries, 0 axioms)
+**Lean file**: `proofs/Proofs/CombinationsFormulaOQ08OQ01.lean`
+**Gallery**: `src/data/proofs/combinations-formula-oq-08-oq-01/meta.json`
+
+## Problem
+
+Parent `combinations-formula-oq-08` proves `fib(n+1) = ∑_{k} C(n-k, k)` (Fibonacci as
+shallow-diagonal sums of Pascal's triangle) and posed as its first open question:
+derive the recurrence `F(n+2) = F(n+1) + F(n)` *directly* from that identity by applying
+Pascal's rule term-by-term, and relate it to the Lucas partial-sum identity
+`∑_{i<n} fib(i) = fib(n+1) − 1`.
+
+## Result
+
+Let `D(n) = ∑_{k<n+1} C(n-k, k)` be the n-th shallow-diagonal total.
+
+- **`D_recurrence`** (core): `D(n+2) = D(n+1) + D(n)`, proved purely by term-by-term
+  Pascal expansion — **no use of `Nat.fib_add_two`**.
+- **`fib_recurrence_via_pascal`**: `fib(n+3) = fib(n+2) + fib(n+1)`, recovered from
+  `D_recurrence` via `D_eq_fib : D(n) = fib(n+1)`. The Fibonacci recurrence is thus
+  exhibited as a shadow of Pascal's rule.
+- **`fib_partial_sum_sub`**: `∑_{i<n} fib(i) = fib(n+1) − 1` (Lucas), by induction.
+- **`shallow_diag_partial_sum`**: `∑_{i<n} D(i) = fib(n+2) − 1` — the same identity
+  recast over the diagonal totals.
+
+10 theorems, 1 definition, 3 `decide` sanity checks. `#print axioms` shows only
+`propext, Classical.choice, Quot.sound`.
+
+## Session 2026-06-25 (Session 1) — FRESH, COMPLETED
+
+### What I Did
+- Designed the peeling-then-Pascal proof of `D(n+2) = D(n+1) + D(n)`.
+- Reproved the parent identity `fib_eq_sum_range_choose` inline so the file is
+  self-contained (parent olean was not built locally; Docker down → offline
+  `lake env lean`).
+- Proved the Lucas partial-sum identity and recast it over the diagonal totals.
+- Built clean offline; verified 0-axiom 0-sorry.
+
+### Key Findings / Techniques
+- **Peeling**: `Finset.sum_range_succ'` strips the `k=0` boundary term (giving the
+  constant `1` via `Nat.choose_zero_right`); `Finset.sum_range_succ` exposes the
+  vanishing top term `C(0, n+2) = 0` (discarded via `Nat.choose_eq_zero_of_lt`). This
+  reduces both `D(n+2)` and `D(n+1)` to `(∑_{k<n+1} …) + 1`.
+- **Pascal step**: for `k ≤ n`, `n+1-k = (n-k)+1`, so `Nat.choose_succ_succ` gives
+  `C(n+1-k, k+1) = C(n-k, k) + C(n-k, k+1)` term-by-term; `Finset.sum_add_distrib`
+  splits the result into `D(n)` and (shifted) `D(n+1)`.
+- **Gotcha**: keep `simp only [Nat.choose_zero_right]` (NOT `Nat.sub_zero` too) so simp
+  touches only the boundary `_ 0` term and does **not** pre-normalize `n+1-(k+1)` inside
+  the sum — otherwise the later `congr 1; omega` per-term step hits "No goals".
+- **Gotcha**: `rw [choose_shift_succ hk]` closes its goal by rfl, so a trailing `ring`
+  errors with "No goals to be solved" — drop it.
+- Natural-subtraction index identities all fall to `omega` using the `range` membership
+  bound (`Nat.lt_succ_iff`).
+
+### Next Steps (optional follow-up)
+- Stride-`s` diagonals `D_s(n) = ∑_k C(n-(s-1)k, k)` and the `s`-step recurrence
+  `D_s(n+s) = D_s(n+s-1) + D_s(n)`; same peeling-then-Pascal method should formalize it.

--- a/src/data/proofs/combinations-formula-oq-08-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-08-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "combinations-formula-oq-08-oq-01",
+  "title": "The Fibonacci Recurrence as a Shadow of Pascal's Rule",
+  "slug": "combinations-formula-oq-08-oq-01",
+  "description": "Derives the Fibonacci recurrence F(n+2) = F(n+1) + F(n) directly from the shallow-diagonal binomial sums, by applying Pascal's rule C(a+1,b+1) = C(a,b) + C(a,b+1) to each diagonal term — with no appeal to Nat.fib_add_two, generating functions, or matrix powers. Writing D(n) = ∑_{k} C(n-k, k) for the n-th shallow-diagonal total, the core result D_recurrence proves D(n+2) = D(n+1) + D(n) by term-by-term Pascal expansion of finite sums; combined with the parent identity D(n) = fib(n+1) this reproves the recurrence combinatorially. The file also formalizes the companion Lucas partial-sum identity ∑_{i<n} fib(i) = fib(n+1) - 1 and recasts it in terms of the diagonal totals as ∑_{i<n} D(i) = fib(n+2) - 1.",
+  "meta": {
+    "author": "Lean Genius researcher-6",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ08OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 206,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "assumptions": "None. All identities hold for every natural number n and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms; no sorryAx, no Lean.ofReduceBool — the decide sanity checks use kernel decidability, not native_decide).",
+    "tags": [
+      "combinatorics",
+      "fibonacci",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "finset-sums",
+      "recurrence",
+      "number-theory"
+    ],
+    "dateAdded": "2026-06-25",
+    "originalContributions": [
+      "D_recurrence: the shallow-diagonal totals D(n) = ∑_{k<n+1} C(n-k, k) satisfy D(n+2) = D(n+1) + D(n), proved purely by term-by-term Pascal expansion and reindexing of finite sums — the combinatorial core, independent of Nat.fib_add_two",
+      "choose_shift_succ: the single Pascal step C(n+1-k, k+1) = C(n-k, k) + C(n-k, k+1) for k ≤ n that drives the whole recurrence",
+      "D_add_two_peel and D_add_one_peel: index-shift normal forms expressing D(n+2) and D(n+1) as a single sum over range(n+1) plus the constant 1, obtained via Finset.sum_range_succ' (peel k=0) and Finset.sum_range_succ (drop the vanishing top term)",
+      "fib_recurrence_via_pascal: the Fibonacci recurrence fib(n+3) = fib(n+2) + fib(n+1) reproved as a corollary of the diagonal recurrence, exhibiting it as a shadow of Pascal's rule",
+      "fib_partial_sum / fib_partial_sum_sub: the Lucas partial-sum identity ∑_{i<n} fib(i) = fib(n+1) - 1 (and its subtraction-free form), proved by induction using Nat.fib_add_two",
+      "shallow_diag_partial_sum: the Lucas partial-sum identity recast in terms of the diagonal totals, ∑_{i<n} D(i) = fib(n+2) - 1",
+      "fib_eq_sum_range_choose: the parent shallow-diagonal identity fib(n+1) = ∑_{k<n+1} C(n-k, k), reproved inline so the file stands alone"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule C(n+1, k+1) = C(n, k) + C(n, k+1); the arithmetic heart of choose_shift_succ and hence of the entire diagonal recurrence.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the first term: ∑_{i<n+1} f i = (∑_{i<n} f(i+1)) + f 0. Used to strip the k=0 term of the diagonal totals before applying Pascal's rule.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the last term: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. Used to expose and discard the vanishing top term C(0, n+2) = 0.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.fib_succ_eq_sum_choose",
+        "description": "Fibonacci as a sum over the antidiagonal; the starting point for the inline reproof of the parent shallow-diagonal identity fib_eq_sum_range_choose.",
+        "module": "Mathlib.Combinatorics.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib(n+2) = fib(n) + fib(n+1); used only in the induction for the Lucas partial-sum identity, NOT in the combinatorial derivation D_recurrence.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ08OQ01.lean",
+    "namespace": "CombinationsFormulaOQ08OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 206,
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "That the Fibonacci numbers are the sums along the shallow diagonals of Pascal's triangle is classical (Lucas, 1876). The parent entry combinations-formula-oq-08 formalizes that identity by reindexing Mathlib's antidiagonal form. Its first open question asked whether the companion Lucas partial-sum identity ∑_{i<n} fib(i) = fib(n+1) - 1 can be linked to the diagonal sums to give a generating-function-free derivation of the Fibonacci recurrence from binomial coefficients. This entry answers that question affirmatively: the Fibonacci recurrence is obtained directly from Pascal's rule applied to the diagonal terms.",
+    "problemStatement": "Derive F(n+2) = F(n+1) + F(n) purely from the shallow-diagonal identity F(n+1) = ∑_k C(n-k, k) by applying Pascal's rule term-by-term, and relate it to the Lucas partial-sum identity ∑_{i<n} fib(i) = fib(n+1) - 1.",
+    "proofStrategy": "Define D(n) = ∑_{k<n+1} C(n-k, k). To prove D(n+2) = D(n+1) + D(n) without invoking the Fibonacci recurrence: (1) Peel the k=0 term of D(n+2) with Finset.sum_range_succ', then split off and discard the vanishing top term C(0, n+2) = 0 with Finset.sum_range_succ, yielding D(n+2) = (∑_{k<n+1} C(n+1-k, k+1)) + 1. (2) Peel the k=0 term of D(n+1) similarly, yielding D(n+1) = (∑_{k<n+1} C(n-k, k+1)) + 1, while D(n) = ∑_{k<n+1} C(n-k, k). (3) For k ≤ n we have n+1-k = (n-k)+1, so Pascal's rule (Nat.choose_succ_succ) gives C(n+1-k, k+1) = C(n-k, k) + C(n-k, k+1) term-by-term; summing over range(n+1) and using Finset.sum_add_distrib matches the two sides. The parent identity D(n) = fib(n+1) (reproved inline) then upgrades this to fib(n+3) = fib(n+2) + fib(n+1). The Lucas partial-sum identity is proved by a short induction and recast over the diagonal totals via D(i) = fib(i+1).",
+    "keyInsights": [
+      "The Fibonacci recurrence is literally a shadow of Pascal's rule: applying C(a+1,b+1) = C(a,b) + C(a,b+1) to each shallow-diagonal entry of row n+1 splits it into the two entries of row n that lie on the two adjacent diagonals, which sum to D(n+1) and D(n).",
+      "Index bookkeeping is the whole difficulty in Lean: the natural-number subtraction n+1-k is exact only for k ≤ n, exactly the range guaranteed by membership in range(n+1), so omega discharges every index identity from the membership bound.",
+      "Peeling with sum_range_succ' (first term) and sum_range_succ (last term) reduces both D(n+2) and D(n+1) to a common shape — a single sum over range(n+1) plus 1 — so the recurrence becomes a single term-by-term comparison.",
+      "The companion Lucas partial-sum identity ∑_{i<n} fib(i) = fib(n+1) - 1 transports to the diagonals as ∑_{i<n} D(i) = fib(n+2) - 1, telescoping the diagonal totals; together the two results give the fully combinatorial picture the open question requested."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Strategy",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Header stating OQ-08-OQ-01: derive the Fibonacci recurrence directly from the shallow-diagonal sums via Pascal's rule, and link to the Lucas partial-sum identity. Includes a sketch of the peeling-and-Pascal proof."
+    },
+    {
+      "id": "diagonal-total",
+      "title": "The Shallow-Diagonal Total D(n)",
+      "startLine": 62,
+      "endLine": 86,
+      "summary": "Defines D(n) = ∑_{k<n+1} C(n-k, k); reproves the parent identity fib_eq_sum_range_choose inline (so the file is self-contained) and records D_eq_fib: D(n) = fib(n+1)."
+    },
+    {
+      "id": "pascal-step",
+      "title": "The Pascal Step",
+      "startLine": 88,
+      "endLine": 96,
+      "summary": "choose_shift_succ: for k ≤ n, C(n+1-k, k+1) = C(n-k, k) + C(n-k, k+1). Rewrites n+1-k as (n-k)+1 via omega and applies Nat.choose_succ_succ."
+    },
+    {
+      "id": "peeling",
+      "title": "Index-Shift Normal Forms",
+      "startLine": 98,
+      "endLine": 123,
+      "summary": "D_add_two_peel and D_add_one_peel: express D(n+2) and D(n+1) as a single sum over range(n+1) plus the constant 1, using Finset.sum_range_succ' to peel k=0 and Finset.sum_range_succ to drop the vanishing top term."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Shallow-Diagonal Recurrence",
+      "startLine": 125,
+      "endLine": 156,
+      "summary": "D_recurrence: D(n+2) = D(n+1) + D(n) by term-by-term Pascal expansion (choose_shift_succ) and Finset.sum_add_distrib — the combinatorial core. fib_recurrence_via_pascal then recovers fib(n+3) = fib(n+2) + fib(n+1) using D_eq_fib."
+    },
+    {
+      "id": "lucas-partial-sum",
+      "title": "Link to the Lucas Partial-Sum Identity",
+      "startLine": 158,
+      "endLine": 199,
+      "summary": "fib_partial_sum / fib_partial_sum_sub: ∑_{i<n} fib(i) = fib(n+1) - 1 by induction. shallow_diag_partial_sum: the same identity recast over the diagonal totals as ∑_{i<n} D(i) = fib(n+2) - 1."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 201,
+      "endLine": 206,
+      "summary": "decide sanity checks: D 6 = 13 from C(6,0)+C(5,1)+C(4,2)+C(3,3); the recurrence D 6 = D 5 + D 4; and the partial sum D0+D1+D2+D3 = fib6-1 = 7."
+    }
+  ],
+  "conclusion": {
+    "summary": "10 theorems, 1 definition, 0 sorries, 0 axioms. The Fibonacci recurrence is derived directly from the shallow-diagonal binomial sums by applying Pascal's rule term-by-term: D_recurrence proves D(n+2) = D(n+1) + D(n) for D(n) = ∑_{k} C(n-k, k) with no use of Nat.fib_add_two, and combined with D(n) = fib(n+1) this reproves the recurrence combinatorially. The companion Lucas partial-sum identity ∑_{i<n} fib(i) = fib(n+1) - 1 is formalized and recast over the diagonal totals as ∑_{i<n} D(i) = fib(n+2) - 1.",
+    "implications": "This answers the parent entry's first open question: it exhibits the Fibonacci recurrence as a shadow of Pascal's rule, a fully constructive, generating-function-free route from binomial coefficients to the recurrence. The peeling-then-Pascal pattern (sum_range_succ' to strip the boundary term, omega to discharge natural-subtraction index identities from membership bounds, and a single term-by-term choose_succ_succ split) is reusable for any diagonal-stride binomial recurrence.",
+    "openQuestions": [
+      "Does the analogous shallow-diagonal sum with stride s (stepping s columns per row), giving D_s(n) = ∑_k C(n - (s-1)k, k), satisfy the s-step recurrence D_s(n+s) = D_s(n+s-1) + D_s(n), and can the same peeling-then-Pascal method formalize it uniformly in s?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-08",
+      "relationship": "parent — provides the shallow-diagonal Fibonacci identity fib(n+1) = ∑_k C(n-k, k) and posed this derivation of the recurrence as its first open question"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of parent entry `combinations-formula-oq-08`: derive the Fibonacci recurrence **directly from the shallow-diagonal binomial sums** by applying Pascal's rule term-by-term — no `Nat.fib_add_two`, no generating functions, no matrix powers.

Write `D(n) = ∑_{k<n+1} C(n-k, k)` for the n-th shallow-diagonal total of Pascal's triangle.

- **`D_recurrence`** (core): `D(n+2) = D(n+1) + D(n)`, proved purely by term-by-term Pascal expansion of finite sums.
- **`fib_recurrence_via_pascal`**: `fib(n+3) = fib(n+2) + fib(n+1)`, recovered via `D_eq_fib : D(n) = fib(n+1)` — the Fibonacci recurrence as a *shadow of Pascal's rule*.
- **`fib_partial_sum_sub`**: the Lucas partial-sum identity `∑_{i<n} fib(i) = fib(n+1) − 1`.
- **`shallow_diag_partial_sum`**: the same identity recast over the diagonal totals, `∑_{i<n} D(i) = fib(n+2) − 1`.

## Method

Peel the boundary `k=0` term with `Finset.sum_range_succ'` (→ constant `1`) and discard the vanishing top term `C(0,n+2)=0` with `Finset.sum_range_succ`, reducing both `D(n+2)` and `D(n+1)` to a common `(∑_{k<n+1} …)+1` shape. Then for `k ≤ n`, `n+1-k = (n-k)+1`, so `Nat.choose_succ_succ` gives `C(n+1-k,k+1) = C(n-k,k) + C(n-k,k+1)` term-by-term; `Finset.sum_add_distrib` matches the two sides. Natural-subtraction index identities are discharged by `omega` from the `range` membership bound.

## Verification

- **10 theorems, 1 definition, 0 sorries, 0 axioms.**
- Builds offline with `lake env lean` (Docker unavailable).
- `#print axioms` on all main results: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool` — the `decide` checks use kernel decidability, not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)