### PR TITLE
Research: CRT for 3 non-coprime moduli in PIDs via lattice distributivity (chinese-remainder-non-coprime-oq-02-oq-01)

### DIFF
--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean
@@ -1,0 +1,272 @@
+/-
+# CRT for 3 Non-Coprime Moduli in PIDs (OQ-02-OQ-01)
+
+The classical Chinese Remainder Theorem covers coprime moduli.  The parent entry
+`chinese-remainder-non-coprime-oq-02` settled the **two-modulus** non-coprime case
+in PIDs / Euclidean domains: the system
+
+  x ≡ a (mod m),   x ≡ b (mod n)
+
+is solvable iff `gcd m n ∣ a - b`, and solutions are unique mod `lcm m n`.
+
+For **three or more** moduli the natural conjecture is *pairwise compatibility*:
+
+  x ≡ aᵢ (mod mᵢ),  i = 1, 2, 3      solvable  ⟺  gcd mᵢ mⱼ ∣ aᵢ - aⱼ for all i,j.
+
+The forward (necessity) direction holds in any commutative ring.  The converse
+(pairwise compatibility ⟹ a global solution) is the subtle part: it is **false**
+in a general commutative ring and becomes true exactly when the lattice of ideals
+is distributive.  In a PID / Bézout domain that distributivity is automatic, and
+this file makes the whole argument precise.
+
+## The mathematical heart: distributivity of the divisibility lattice
+
+The reduction of three moduli to two needs the identity
+
+  gcd (lcm m₁ m₂) m₃  ∣  lcm (gcd m₁ m₃) (gcd m₂ m₃).            (★)
+
+Translated to ideals this is the *distributive* inequality
+
+  (I₁ ⊔ I₃) ⊓ (I₂ ⊔ I₃)  ≤  (I₁ ⊓ I₂) ⊔ I₃,
+
+whose reverse holds in every lattice; the displayed direction is what
+distinguishes the divisibility lattice of a UFD/Bézout domain.  We prove (★) by
+transporting the goal through `Associates.factors` to the genuinely distributive
+lattice `FactorSet R` (a `WithTop (Multiset _)`), where it is `inf_sup_right`.
+
+With (★) in hand the three-modulus CRT follows by solving `m₁, m₂` first and then
+combining with `m₃` over the modulus `lcm m₁ m₂`.
+
+## Main results
+
+* `gcd_lcm_distrib`        — the distributive law (★) for a UFD / GCD domain.
+* `crt2_iff`              — two-modulus CRT: solvable ↔ `gcd m n ∣ a - b`.
+* `crt3_necessary`        — pairwise gcd conditions are necessary.
+* `crt3_sufficient`       — pairwise compatibility ⟹ a global solution (uses ★).
+* `crt3_iff`             — the full characterization for three moduli.
+* `crt3_unique`           — solutions are unique mod `lcm (lcm m₁ m₂) m₃`.
+* `crt3_solution_set`     — combined existence + uniqueness statement.
+
+All results are stated for a commutative domain that is simultaneously a Bézout
+ring and a UFD — i.e. a PID such as `ℤ`, `k[X]`, or `ℤ[i]` (see the closing
+`example`s instantiating `ℤ`).
+
+The sibling gallery entry `chinese-remainder-non-coprime-oq-03-oq-01` proves the
+same distributive law (★) by an elementary coprime-cofactor argument over Euclidean
+domains; the factorization-model proof given here (`gcd_lcm_distrib`) is shorter and
+holds in any UFD.
+
+References:
+- Hungerford (1974), *Algebra*, Ch. III (CRT and ideal arithmetic).
+- Cohn (1968), *Bezout rings and their subrings* (distributivity of f.g. ideals).
+-/
+import Mathlib
+
+set_option linter.unusedSectionVars false
+
+namespace ChineseRemainderNonCoprimeOQ02OQ01
+
+open Associates
+
+/-
+## Part I: Distributivity of the divisibility lattice
+
+We work in a UFD; the divisibility order on `Associates R` is then a lattice, and
+we transport distributivity from the `FactorSet` (multiset) model.
+-/
+
+section Distrib
+
+variable {R : Type*} [CancelCommMonoidWithZero R] [UniqueFactorizationMonoid R]
+
+/-- The lattice `Associates R` of a UFD is distributive (the nontrivial direction
+`(A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C)`).  Proved by pushing the inequality through the
+order isomorphism `Associates.factors` onto the distributive lattice `FactorSet R`. -/
+theorem associates_inf_sup_le [Nontrivial R] (A B C : Associates R) :
+    (A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C) := by
+  classical
+  have hsup : ∀ x y : Associates R, (x ⊔ y).factors = x.factors ⊔ y.factors := by
+    intro x y
+    show ((x.factors ⊔ y.factors).prod).factors = _
+    rw [prod_factors]
+  have hinf : ∀ x y : Associates R, (x ⊓ y).factors = x.factors ⊓ y.factors := by
+    intro x y
+    show ((x.factors ⊓ y.factors).prod).factors = _
+    rw [prod_factors]
+  rw [← Associates.factors_le, hinf, hsup, hsup, hinf, hinf]
+  exact (inf_sup_right _ _ _).le
+
+variable [GCDMonoid R]
+
+/-- `mk (gcd a b)` is the lattice meet of `mk a` and `mk b` in `Associates R`. -/
+theorem mk_gcd_eq_inf (a b : R) :
+    Associates.mk (gcd a b) = Associates.mk a ⊓ Associates.mk b := by
+  refine le_antisymm (le_inf (mk_le_mk_of_dvd (gcd_dvd_left a b))
+    (mk_le_mk_of_dvd (gcd_dvd_right a b))) ?_
+  obtain ⟨e, he⟩ := Associates.mk_surjective (Associates.mk a ⊓ Associates.mk b)
+  rw [← he]
+  exact mk_le_mk_of_dvd (dvd_gcd (dvd_of_mk_le_mk (he ▸ inf_le_left))
+    (dvd_of_mk_le_mk (he ▸ inf_le_right)))
+
+/-- `mk (lcm a b)` is the lattice join of `mk a` and `mk b` in `Associates R`. -/
+theorem mk_lcm_eq_sup (a b : R) :
+    Associates.mk (lcm a b) = Associates.mk a ⊔ Associates.mk b := by
+  refine le_antisymm ?_ (sup_le (mk_le_mk_of_dvd (dvd_lcm_left a b))
+    (mk_le_mk_of_dvd (dvd_lcm_right a b)))
+  obtain ⟨e, he⟩ := Associates.mk_surjective (Associates.mk a ⊔ Associates.mk b)
+  rw [← he]
+  exact mk_le_mk_of_dvd (lcm_dvd (dvd_of_mk_le_mk (he ▸ le_sup_left))
+    (dvd_of_mk_le_mk (he ▸ le_sup_right)))
+
+/-- **Distributive law of divisibility (★).** In a UFD / GCD domain,
+`gcd (lcm a b) c ∣ lcm (gcd a c) (gcd b c)`.
+
+The reverse divisibility `lcm (gcd a c) (gcd b c) ∣ gcd (lcm a b) c` holds in any
+GCD monoid; this direction is the distributive one and is the engine of the
+three-modulus CRT. -/
+theorem gcd_lcm_distrib [Nontrivial R] (a b c : R) :
+    gcd (lcm a b) c ∣ lcm (gcd a c) (gcd b c) := by
+  rw [← Associates.mk_dvd_mk, mk_gcd_eq_inf, mk_lcm_eq_sup, mk_lcm_eq_sup,
+    mk_gcd_eq_inf, mk_gcd_eq_inf]
+  exact associates_inf_sup_le _ _ _
+
+/-- The easy (always-true) reverse direction, recorded for contrast with (★). -/
+theorem lcm_gcd_dvd (a b c : R) :
+    lcm (gcd a c) (gcd b c) ∣ gcd (lcm a b) c := by
+  refine lcm_dvd (dvd_gcd ?_ (gcd_dvd_right a c)) (dvd_gcd ?_ (gcd_dvd_right b c))
+  · exact (gcd_dvd_left a c).trans (dvd_lcm_left a b)
+  · exact (gcd_dvd_left b c).trans (dvd_lcm_right a b)
+
+end Distrib
+
+/-
+## Part II: Two-modulus CRT in a Bézout domain
+
+`gcd m n ∣ a - b` is necessary and sufficient; this is the parent result, reproved
+here through Bézout's identity (`gcd_dvd_iff_exists`) so the file is self-contained.
+-/
+
+section CRT
+
+variable {R : Type*} [CommRing R] [IsDomain R] [IsBezout R] [GCDMonoid R]
+  [UniqueFactorizationMonoid R]
+
+/-- Necessity for two moduli: a common solution forces `gcd m n ∣ a - b`. -/
+theorem crt2_necessary {m n a b : R} (h : ∃ x : R, m ∣ (x - a) ∧ n ∣ (x - b)) :
+    gcd m n ∣ a - b := by
+  obtain ⟨x, hm, hn⟩ := h
+  have := dvd_sub ((gcd_dvd_right m n).trans hn) ((gcd_dvd_left m n).trans hm)
+  rwa [show (x - b) - (x - a) = a - b by ring] at this
+
+/-- Sufficiency for two moduli, via Bézout: if `gcd m n ∣ a - b` then the system
+`x ≡ a (mod m)`, `x ≡ b (mod n)` has a solution. -/
+theorem crt2_sufficient {m n a b : R} (h : gcd m n ∣ a - b) :
+    ∃ x : R, m ∣ (x - a) ∧ n ∣ (x - b) := by
+  obtain ⟨s, t, hst⟩ := (gcd_dvd_iff_exists m n).mp h
+  exact ⟨a - m * s, ⟨-s, by ring⟩, ⟨t, by linear_combination hst⟩⟩
+
+/-- **Two-modulus non-coprime CRT.** -/
+theorem crt2_iff {m n a b : R} :
+    (∃ x : R, m ∣ (x - a) ∧ n ∣ (x - b)) ↔ gcd m n ∣ a - b :=
+  ⟨crt2_necessary, crt2_sufficient⟩
+
+/-- Two-modulus uniqueness: any two solutions agree mod `lcm m n`. -/
+theorem crt2_unique {m n a b x y : R}
+    (hx : m ∣ (x - a) ∧ n ∣ (x - b)) (hy : m ∣ (y - a) ∧ n ∣ (y - b)) :
+    lcm m n ∣ x - y := by
+  refine lcm_dvd ?_ ?_
+  · have := dvd_sub hx.1 hy.1; rwa [show (x - a) - (y - a) = x - y by ring] at this
+  · have := dvd_sub hx.2 hy.2; rwa [show (x - b) - (y - b) = x - y by ring] at this
+
+/-
+## Part III: Three-modulus CRT
+-/
+
+/-- **Necessity** for three moduli: pairwise gcd-compatibility of the residues. -/
+theorem crt3_necessary {m₁ m₂ m₃ a₁ a₂ a₃ : R}
+    (h : ∃ x : R, m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃)) :
+    gcd m₁ m₂ ∣ a₁ - a₂ ∧ gcd m₁ m₃ ∣ a₁ - a₃ ∧ gcd m₂ m₃ ∣ a₂ - a₃ := by
+  obtain ⟨x, h1, h2, h3⟩ := h
+  exact ⟨crt2_necessary ⟨x, h1, h2⟩, crt2_necessary ⟨x, h1, h3⟩, crt2_necessary ⟨x, h2, h3⟩⟩
+
+/-- **Sufficiency** for three moduli: pairwise compatibility yields a global
+solution.  This is the main new result; the distributive law `gcd_lcm_distrib` (★)
+is exactly what lets us combine the solution of the first two congruences with the
+third over the modulus `lcm m₁ m₂`. -/
+theorem crt3_sufficient {m₁ m₂ m₃ a₁ a₂ a₃ : R}
+    (h12 : gcd m₁ m₂ ∣ a₁ - a₂)
+    (h13 : gcd m₁ m₃ ∣ a₁ - a₃)
+    (h23 : gcd m₂ m₃ ∣ a₂ - a₃) :
+    ∃ x : R, m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃) := by
+  -- Solve the first two congruences.
+  obtain ⟨y, hy1, hy2⟩ := crt2_sufficient h12
+  -- The combined residue `y` is compatible with `a₃` modulo each of `m₁`, `m₂`.
+  have hd1 : gcd m₁ m₃ ∣ y - a₃ := by
+    have h := dvd_add ((gcd_dvd_left m₁ m₃).trans hy1) h13
+    rwa [show (y - a₁) + (a₁ - a₃) = y - a₃ by ring] at h
+  have hd2 : gcd m₂ m₃ ∣ y - a₃ := by
+    have h := dvd_add ((gcd_dvd_left m₂ m₃).trans hy2) h23
+    rwa [show (y - a₂) + (a₂ - a₃) = y - a₃ by ring] at h
+  -- Distributivity (★): `gcd (lcm m₁ m₂) m₃` divides `y - a₃`.
+  have hkey : gcd (lcm m₁ m₂) m₃ ∣ y - a₃ :=
+    (gcd_lcm_distrib m₁ m₂ m₃).trans (lcm_dvd hd1 hd2)
+  -- Solve `lcm m₁ m₂` and `m₃` with targets `y` and `a₃`.
+  obtain ⟨x, hx1, hx2⟩ := crt2_sufficient hkey
+  refine ⟨x, ?_, ?_, hx2⟩
+  · have h := dvd_add ((dvd_lcm_left m₁ m₂).trans hx1) hy1
+    rwa [show (x - y) + (y - a₁) = x - a₁ by ring] at h
+  · have h := dvd_add ((dvd_lcm_right m₁ m₂).trans hx1) hy2
+    rwa [show (x - y) + (y - a₂) = x - a₂ by ring] at h
+
+/-- **Three-modulus non-coprime CRT.**  The system is solvable iff the residues are
+pairwise compatible. -/
+theorem crt3_iff {m₁ m₂ m₃ a₁ a₂ a₃ : R} :
+    (∃ x : R, m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃)) ↔
+      (gcd m₁ m₂ ∣ a₁ - a₂ ∧ gcd m₁ m₃ ∣ a₁ - a₃ ∧ gcd m₂ m₃ ∣ a₂ - a₃) :=
+  ⟨crt3_necessary, fun ⟨h12, h13, h23⟩ => crt3_sufficient h12 h13 h23⟩
+
+/-- **Uniqueness** for three moduli: solutions agree mod `lcm (lcm m₁ m₂) m₃`,
+the lcm of the three moduli (the generator of `⟨m₁⟩ ∩ ⟨m₂⟩ ∩ ⟨m₃⟩`). -/
+theorem crt3_unique {m₁ m₂ m₃ a₁ a₂ a₃ x y : R}
+    (hx : m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃))
+    (hy : m₁ ∣ (y - a₁) ∧ m₂ ∣ (y - a₂) ∧ m₃ ∣ (y - a₃)) :
+    lcm (lcm m₁ m₂) m₃ ∣ x - y := by
+  refine lcm_dvd (lcm_dvd ?_ ?_) ?_
+  · have := dvd_sub hx.1 hy.1; rwa [show (x - a₁) - (y - a₁) = x - y by ring] at this
+  · have := dvd_sub hx.2.1 hy.2.1; rwa [show (x - a₂) - (y - a₂) = x - y by ring] at this
+  · have := dvd_sub hx.2.2 hy.2.2; rwa [show (x - a₃) - (y - a₃) = x - y by ring] at this
+
+/-- Combined existence-and-uniqueness statement for three pairwise-compatible
+moduli: a solution exists and is unique modulo `lcm (lcm m₁ m₂) m₃`. -/
+theorem crt3_solution_set {m₁ m₂ m₃ a₁ a₂ a₃ : R}
+    (h12 : gcd m₁ m₂ ∣ a₁ - a₂) (h13 : gcd m₁ m₃ ∣ a₁ - a₃)
+    (h23 : gcd m₂ m₃ ∣ a₂ - a₃) :
+    (∃ x : R, m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃)) ∧
+      (∀ x y : R, (m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃)) →
+        (m₁ ∣ (y - a₁) ∧ m₂ ∣ (y - a₂) ∧ m₃ ∣ (y - a₃)) →
+        lcm (lcm m₁ m₂) m₃ ∣ x - y) :=
+  ⟨crt3_sufficient h12 h13 h23, fun _ _ hx hy => crt3_unique hx hy⟩
+
+end CRT
+
+/-
+## Part IV: Concrete instantiations
+
+`ℤ` is a PID, hence simultaneously Bézout and a UFD, so every result above applies.
+-/
+
+section Examples
+
+/-- The distributive law (★) holds in `ℤ`. -/
+example (a b c : ℤ) : gcd (lcm a b) c ∣ lcm (gcd a c) (gcd b c) :=
+  gcd_lcm_distrib a b c
+
+/-- Three-modulus solvability in `ℤ` is exactly pairwise compatibility. -/
+example {m₁ m₂ m₃ a₁ a₂ a₃ : ℤ} :
+    (∃ x : ℤ, m₁ ∣ (x - a₁) ∧ m₂ ∣ (x - a₂) ∧ m₃ ∣ (x - a₃)) ↔
+      (gcd m₁ m₂ ∣ a₁ - a₂ ∧ gcd m₁ m₃ ∣ a₁ - a₃ ∧ gcd m₂ m₃ ∣ a₂ - a₃) :=
+  crt3_iff
+
+end Examples
+
+end ChineseRemainderNonCoprimeOQ02OQ01

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/annotations.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "ann-module-overview",
+    "proofId": "chinese-remainder-non-coprime-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 61
+    },
+    "type": "context",
+    "title": "Three non-coprime moduli: where distributivity enters",
+    "content": "The module extends the parent's two-modulus non-coprime CRT to three moduli over a PID. The headline crt3_iff says x ≡ aᵢ (mod mᵢ), i=1,2,3, is solvable iff the residues are pairwise compatible (gcd mᵢ mⱼ ∣ aᵢ − aⱼ), and crt3_unique gives uniqueness modulo lcm(m₁,m₂,m₃). The novelty over two moduli is that SUFFICIENCY no longer follows formally: necessity and uniqueness hold in any commutative ring, but 'pairwise compatible ⟹ globally solvable' requires the divisibility lattice to be distributive — true in PIDs/Bézout domains, false in general.",
+    "mathContext": "$\\{x \\equiv a_i \\pmod{m_i}\\}_{i=1}^3 \\text{ solvable} \\iff \\forall i,j:\\ \\gcd(m_i,m_j) \\mid (a_i - a_j)$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "non-coprime moduli",
+      "distributive lattice",
+      "PID"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "GCD and LCM",
+      "ideal theory"
+    ]
+  },
+  {
+    "id": "ann-associates-distrib",
+    "proofId": "chinese-remainder-non-coprime-oq-02-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 100
+    },
+    "type": "concept",
+    "title": "Distributivity of the Associates lattice via the factorization model",
+    "content": "associates_inf_sup_le proves (A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C) in Associates R for a UFD. Rather than fight gcd/lcm algebra, the proof transports the inequality through Associates.factors — an order isomorphism onto FactorSet R = WithTop (Multiset _), the genuinely distributive multiset lattice — where the goal is exactly inf_sup_right. The two helper facts hsup/hinf say factors of a join/meet are the join/meet of factors (immediate from the definition of ⊔/⊓ on Associates plus prod_factors).",
+    "mathContext": "$(A \\sqcup B) \\sqcap C \\le (A \\sqcap C) \\sqcup (B \\sqcap C)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Associates",
+      "FactorSet",
+      "multiset lattice",
+      "distributive lattice",
+      "order isomorphism"
+    ],
+    "prerequisites": [
+      "unique factorization",
+      "lattice distributivity",
+      "Associates.factors"
+    ]
+  },
+  {
+    "id": "ann-mk-bridges",
+    "proofId": "chinese-remainder-non-coprime-oq-02-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 124
+    },
+    "type": "technique",
+    "title": "Bridging gcd/lcm to lattice meet/join",
+    "content": "mk_gcd_eq_inf and mk_lcm_eq_sup identify Associates.mk(gcd a b) with mk a ⊓ mk b and Associates.mk(lcm a b) with mk a ⊔ mk b. Each is an antisymmetry argument: one direction from the universal divisibility properties of gcd/lcm, the other by writing the lattice meet/join as mk e (via mk_surjective) and reflecting divisibility back through dvd_of_mk_le_mk. These bridges let the divisibility statement be read off the lattice statement.",
+    "mathContext": "$\\mathrm{mk}(\\gcd\\,a\\,b) = \\mathrm{mk}\\,a \\sqcap \\mathrm{mk}\\,b, \\qquad \\mathrm{mk}(\\mathrm{lcm}\\,a\\,b) = \\mathrm{mk}\\,a \\sqcup \\mathrm{mk}\\,b$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Associates.mk",
+      "gcd",
+      "lcm",
+      "antisymmetry"
+    ],
+    "prerequisites": [
+      "GCD monoid",
+      "Associates order"
+    ]
+  },
+  {
+    "id": "ann-gcd-lcm-distrib",
+    "proofId": "chinese-remainder-non-coprime-oq-02-oq-01",
+    "range": {
+      "startLine": 127,
+      "endLine": 141
+    },
+    "type": "concept",
+    "title": "The distributive law of divisibility (★)",
+    "content": "gcd_lcm_distrib is the crux: gcd(lcm a b, c) ∣ lcm(gcd a c, gcd b c). After the bridges it is literally associates_inf_sup_le applied to mk a, mk b, mk c. The companion lcm_gcd_dvd records the reverse divisibility lcm(gcd a c, gcd b c) ∣ gcd(lcm a b, c), which holds in ANY GCD monoid — so the content is entirely in direction (★). The sibling entry oq-03-oq-01 proves the same law by a long elementary coprime-cofactor argument over Euclidean domains; the factorization route here is shorter and holds in any UFD.",
+    "mathContext": "$\\gcd(\\mathrm{lcm}(a,b),c) \\mid \\mathrm{lcm}(\\gcd(a,c),\\gcd(b,c))$",
+    "significance": "key",
+    "relatedConcepts": [
+      "distributive lattice",
+      "Birkhoff",
+      "divisibility lattice",
+      "gcd",
+      "lcm"
+    ],
+    "prerequisites": [
+      "Associates lattice distributivity",
+      "gcd/lcm bridges"
+    ]
+  },
+  {
+    "id": "ann-crt2-bezout",
+    "proofId": "chinese-remainder-non-coprime-oq-02-oq-01",
+    "range": {
+      "startLine": 155,
+      "endLine": 183
+    },
+    "type": "technique",
+    "title": "Two-modulus base case via Bézout",
+    "content": "crt2_sufficient is the merge step reused twice in the three-modulus proof. From gcd m n ∣ a − b, Bézout's identity (gcd_dvd_iff_exists) gives a − b = m·s + n·t, and x = a − m·s solves both congruences: x − a = −m·s is divisible by m, while x − b = (a−b) − m·s = n·t is divisible by n. crt2_necessary and crt2_unique complete the binary characterization.",
+    "mathContext": "$x = a - m s,\\quad a - b = m s + n t \\ \\Rightarrow\\ m \\mid x - a,\\ n \\mid x - b$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "binary CRT",
+      "explicit construction"
+    ],
+    "prerequisites": [
+      "Bézout domain",
+      "gcd"
+    ]
+  },
+  {
+    "id": "ann-crt3-sufficient",
+    "proofId": "chinese-remainder-non-coprime-oq-02-oq-01",
+    "range": {
+      "startLine": 196,
+      "endLine": 221
+    },
+    "type": "technique",
+    "title": "Reducing three moduli to two with the distributive law",
+    "content": "crt3_sufficient is the main result. First solve m₁, m₂ to obtain y. Since gcd m₁ m₃ ∣ m₁ ∣ y − a₁ and gcd m₁ m₃ ∣ a₁ − a₃, we get gcd m₁ m₃ ∣ y − a₃ (similarly for m₂), hence lcm(gcd m₁ m₃, gcd m₂ m₃) ∣ y − a₃. The distributive law (★) then yields gcd(lcm m₁ m₂, m₃) ∣ y − a₃ — exactly the compatibility needed to merge y with a₃ over the modulus lcm m₁ m₂. A final binary solve produces x, and x ≡ aᵢ mod mᵢ follows because mᵢ ∣ lcm m₁ m₂ ∣ x − y and mᵢ ∣ y − aᵢ.",
+    "mathContext": "$\\gcd(\\mathrm{lcm}(m_1,m_2),m_3) \\mid y - a_3 \\ \\Leftarrow\\ \\mathrm{lcm}(\\gcd(m_1,m_3),\\gcd(m_2,m_3)) \\mid y - a_3$",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction step",
+      "distributive law",
+      "lcm modulus",
+      "CRT"
+    ],
+    "prerequisites": [
+      "gcd_lcm_distrib",
+      "two-modulus CRT"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/meta.json
@@ -1,0 +1,70 @@
+{
+  "id": "chinese-remainder-non-coprime-oq-02-oq-01",
+  "title": "CRT for 3 Non-Coprime Moduli in PIDs via Lattice Distributivity",
+  "slug": "chinese-remainder-non-coprime-oq-02-oq-01",
+  "description": "Extends the non-coprime Chinese Remainder Theorem to THREE moduli in a PID/Bézout domain: the system x ≡ aᵢ (mod mᵢ) is solvable iff the residues are pairwise compatible (gcd mᵢ mⱼ ∣ aᵢ - aⱼ), with the solution unique modulo lcm(m₁,m₂,m₃). Unlike necessity (true in any ring) and uniqueness, the converse — pairwise compatibility ⟹ a global solution — is FALSE in general commutative rings and holds exactly when the divisibility lattice is distributive. The engine is a self-contained proof of the distributive law gcd(lcm a b, c) ∣ lcm(gcd a c, gcd b c), obtained by transporting the goal through Associates.factors to the genuinely distributive multiset lattice FactorSet R. 14 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "chinese-remainder-theorem",
+      "ring-theory",
+      "pid",
+      "ideal-theory",
+      "gcd-monoid",
+      "lattice-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib foundations (propext, Classical.choice, Quot.sound). No axiom declarations, no structure-encoded assumptions, no native_decide. The results are stated for a commutative domain that is simultaneously a Bézout ring and a UFD — i.e. a PID such as ℤ, k[X], or ℤ[i] — and instantiated for ℤ in the closing examples.",
+    "lineCount": 272,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "originalContributions": [
+      "gcd_lcm_distrib: the distributive law of divisibility gcd(lcm a b, c) ∣ lcm(gcd a c, gcd b c) in a UFD/GCD domain — the nontrivial direction, proved by transporting through Associates.factors to the distributive multiset lattice (this fact is not in Mathlib as a named lemma)",
+      "associates_inf_sup_le: distributivity (A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C) of the Associates lattice of a UFD, via the order isomorphism onto FactorSet",
+      "mk_gcd_eq_inf / mk_lcm_eq_sup: the bridge identifying Associates.mk(gcd a b) with the lattice meet and Associates.mk(lcm a b) with the lattice join",
+      "crt3_sufficient: pairwise compatibility (gcd mᵢ mⱼ ∣ aᵢ - aⱼ) implies a global solution exists — the main new result, reducing three moduli to two via the distributive law",
+      "crt3_necessary: pairwise gcd-compatibility is necessary for solvability",
+      "crt3_iff: full solvability characterization for three non-coprime moduli",
+      "crt3_unique: solutions are unique modulo lcm(lcm m₁ m₂, m₃), the generator of ⟨m₁⟩ ∩ ⟨m₂⟩ ∩ ⟨m₃⟩",
+      "crt3_solution_set: combined existence + uniqueness for three pairwise-compatible moduli",
+      "crt2_iff / crt2_unique: the two-modulus base case reproved self-contained via Bézout (gcd_dvd_iff_exists)",
+      "lcm_gcd_dvd: the always-true reverse divisibility, recorded to contrast with the distributive direction"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Chinese Remainder Theorem for coprime moduli is classical (Sunzi, 5th century). The non-coprime two-modulus case over ℤ — solvable iff gcd(m,n) ∣ (a-b) — follows from Bézout's identity. For three or more moduli the natural guess is pairwise compatibility, and indeed Noether-era commutative algebra recognized the correct general statement as a condition on ideal sums and intersections. The subtle point, emphasized by P. M. Cohn in his work on Bézout rings (1968) and by lattice theorists, is that 'pairwise compatible ⟹ globally solvable' for three or more congruences requires the lattice of ideals to be DISTRIBUTIVE. This fails for general commutative rings but holds for Bézout domains and PIDs, where finitely generated ideals form a distributive lattice — equivalently, where the divisibility relation satisfies gcd(lcm a b, c) = lcm(gcd a c, gcd b c).",
+    "problemStatement": "Extend the non-coprime CRT (parent: 2 moduli in PIDs) to 3 moduli: characterize solvability of x ≡ aᵢ (mod mᵢ), i=1,2,3, by pairwise compatibility, and describe the solution set's uniqueness modulus.",
+    "text": "Part I isolates the mathematical heart: distributivity of the divisibility lattice. Working in a UFD, the divisibility order on Associates R is a lattice, and we push the distributive inequality (A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C) through the order isomorphism Associates.factors onto FactorSet R = WithTop (Multiset _), where it is simply inf_sup_right. Bridges identify mk(gcd) with meet and mk(lcm) with join, yielding gcd(lcm a b, c) ∣ lcm(gcd a c, gcd b c). Part II reproves the two-modulus CRT via Bézout. Part III combines: solve the first two congruences to get y, observe gcd mᵢ m₃ ∣ y - a₃ for i=1,2, hence lcm(gcd m₁ m₃, gcd m₂ m₃) ∣ y - a₃, and apply the distributive law to conclude gcd(lcm m₁ m₂, m₃) ∣ y - a₃ — exactly the compatibility needed to merge with the third congruence over the modulus lcm m₁ m₂. Part IV instantiates ℤ.",
+    "proofStrategy": "Reduce three moduli to two using the distributive law of the divisibility lattice as the linchpin. Prove that law not by elementary gcd manipulation (which fails — the relevant direction is genuinely the distributive one) but by transporting to the factorization model, where the lattice is a multiset lattice and distributivity is automatic.",
+    "keyInsights": [
+      "Necessity and uniqueness for 3 moduli hold in any commutative ring / GCD monoid; only SUFFICIENCY needs distributivity, which is why 3-modulus CRT is strictly subtler than 2-modulus CRT",
+      "The obstruction is precisely (I₁ ⊔ I₃) ⊓ (I₂ ⊔ I₃) ≤ (I₁ ⊓ I₂) ⊔ I₃; the reverse holds in every lattice, the displayed direction characterizes distributive lattices",
+      "gcd(lcm a b, c) ∣ lcm(gcd a c, gcd b c) is the divisibility incarnation of that inequality; the easy direction lcm(gcd a c, gcd b c) ∣ gcd(lcm a b, c) holds in any GCD monoid",
+      "The factorization model FactorSet R is a multiset lattice (min/max of prime multiplicities) and is therefore distributive — transporting through Associates.factors is the cleanest route, avoiding ad hoc gcd/lcm cancellation",
+      "Solving the first two congruences and re-expressing compatibility with the third over lcm(m₁,m₂) is what turns the distributive law into a working induction step"
+    ],
+    "prerequisites": [
+      "GCD monoids: gcd, lcm, and their universal divisibility properties",
+      "Bézout domains: gcd a b = a·x + b·y (gcd_dvd_iff_exists)",
+      "Unique factorization: the Associates lattice and the FactorSet (multiset) model",
+      "Lattice theory: distributive law inf_sup_right and the distributivity of multiset lattices"
+    ]
+  },
+  "conclusion": {
+    "summary": "The three-modulus non-coprime CRT is fully verified for PIDs: solvable iff pairwise compatible (crt3_iff), with solutions unique mod lcm(m₁,m₂,m₃) (crt3_unique). The proof identifies and supplies the precise missing ingredient over the 2-modulus parent — the distributive law of the divisibility lattice gcd(lcm a b, c) ∣ lcm(gcd a c, gcd b c) — proved via the factorization model. 14 theorems, 272 lines, 0 axioms.",
+    "implications": "Pins down exactly why CRT for ≥3 non-coprime moduli works in PIDs but not in arbitrary commutative rings: distributivity of the ideal lattice. The standalone lemma gcd_lcm_distrib is reusable wherever the divisibility lattice's distributivity is needed and is currently absent from Mathlib as a named result. The argument generalizes verbatim to any finite number of moduli by iterating the two-into-one merge.",
+    "openQuestions": [
+      "Generalize from 3 to n moduli by induction, with uniqueness modulo the lcm of all moduli (the same distributive law suffices at each step)",
+      "State the result purely ideal-theoretically and identify the exact class of rings (distributive ideal lattice / arithmetical rings) for which pairwise-compatible CRT holds without the domain hypothesis",
+      "Add gcd_lcm_distrib and the Associates DistribLattice instance to Mathlib (the divisibility lattice of a UFD is distributive)",
+      "Quantify the solution: an explicit representative modulo lcm(m₁,m₂,m₃) via iterated Bézout, with complexity bounds"
+    ]
+  }
+}

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-02-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "chinese-remainder-non-coprime-oq-02-oq-01",
   "title": "CRT for 3 Non-Coprime Moduli in PIDs via IsBezout",
-  "phase": "OBSERVE",
+  "phase": "VERIFIED",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,24 +16,39 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-21T22:19:23+02:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "VERIFIED",
+    "since": "2026-06-25",
+    "iteration": 2,
+    "focus": "Solved: 3-modulus non-coprime CRT in PIDs via divisibility-lattice distributivity.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Entry complete; optional n-modulus generalization and Mathlib upstreaming.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED. Three-modulus non-coprime CRT in a PID/Bézout domain: crt3_iff shows x ≡ aᵢ (mod mᵢ), i=1,2,3, is solvable iff pairwise compatible (gcd mᵢ mⱼ ∣ aᵢ−aⱼ); crt3_unique gives uniqueness mod lcm(m₁,m₂,m₃). The engine is gcd_lcm_distrib — the distributive law gcd(lcm a b,c) ∣ lcm(gcd a c,gcd b c) — proved by transporting the inequality (A⊔B)⊓C ≤ (A⊓C)⊔(B⊓C) through Associates.factors to the distributive multiset lattice FactorSet R. 14 thm, 0 def, 0 axioms, 0 sorries; instantiated for ℤ. File Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean.",
+    "builtItems": [
+      "gcd_lcm_distrib: gcd(lcm a b,c) ∣ lcm(gcd a c,gcd b c) in a UFD/GCD domain (distributive direction)",
+      "associates_inf_sup_le: distributivity of the Associates lattice via the FactorSet model",
+      "mk_gcd_eq_inf / mk_lcm_eq_sup: gcd/lcm ↔ lattice meet/join bridges on Associates",
+      "crt2_iff / crt2_unique: two-modulus base case via Bézout (gcd_dvd_iff_exists)",
+      "crt3_necessary / crt3_sufficient / crt3_iff: three-modulus characterization",
+      "crt3_unique / crt3_solution_set: uniqueness mod lcm(m₁,m₂,m₃) + combined statement"
+    ],
+    "insights": [
+      "Necessity and uniqueness for 3 moduli hold in any commutative ring; only sufficiency needs the ideal lattice to be distributive.",
+      "The precise obstruction is (I₁⊔I₃)⊓(I₂⊔I₃) ≤ (I₁⊓I₂)⊔I₃; its divisibility form is gcd(lcm a b,c) ∣ lcm(gcd a c,gcd b c).",
+      "The factorization model FactorSet R is a multiset lattice, hence distributive — transporting through Associates.factors avoids ad hoc gcd/lcm cancellation.",
+      "The sibling oq-03-oq-01 proves the same distributive law by a long elementary coprime-cofactor argument; the factorization route here is shorter and holds in any UFD."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Generalize 3 → n moduli by iterating the two-into-one merge (uniqueness mod lcm of all moduli).",
+      "Upstream gcd_lcm_distrib / Associates DistribLattice to Mathlib."
+    ],
     "markdown": "# Knowledge Base: chinese-remainder-non-coprime-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -50,9 +65,11 @@
     "chinese-remainder-non-coprime-oq-01",
     "chinese-remainder-non-coprime-oq-01-oq-01",
     "chinese-remainder-non-coprime-oq-02",
+    "chinese-remainder-non-coprime-oq-02-oq-01",
     "chinese-remainder-non-coprime-oq-03",
     "chinese-remainder-non-coprime-oq-03-oq-01",
     "chinese-remainder-non-coprime-oq-03-oq-02",
+    "chinese-remainder-non-coprime-oq-03-oq-03",
     "chinese-remainder-non-coprime-oq-04"
   ],
   "references": {
@@ -120,6 +137,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ02.lean"
     },
     {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ02OQ01.lean",
+      "lineCount": 273,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/ChineseRemainderNonCoprimeOQ03.lean",
       "filename": "ChineseRemainderNonCoprimeOQ03.lean",
       "lineCount": 392,
@@ -162,6 +190,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ03OQ03.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ03OQ03.lean",
+      "lineCount": 161,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ03.lean"
     },
     {
       "path": "Proofs/ChineseRemainderNonCoprimeOQ04.lean",


### PR DESCRIPTION
## Summary

Solves `chinese-remainder-non-coprime-oq-02-oq-01`: the three-modulus non-coprime Chinese Remainder Theorem in a PID / Bézout domain.

- **`crt3_iff`** — the system `x ≡ aᵢ (mod mᵢ)`, i=1,2,3, is solvable **iff** the residues are pairwise compatible: `gcd mᵢ mⱼ ∣ aᵢ − aⱼ` for all pairs.
- **`crt3_unique`** — solutions are unique modulo `lcm(m₁,m₂,m₃)` (the generator of `⟨m₁⟩ ∩ ⟨m₂⟩ ∩ ⟨m₃⟩`).

## Why it is not routine

For **two** moduli, sufficiency is a one-line Bézout argument. For **three**, necessity and uniqueness still hold in any commutative ring, but *pairwise compatibility ⟹ a global solution* is **false in general** — it holds exactly when the lattice of ideals is **distributive**. PIDs/Bézout domains supply that distributivity.

The engine is a self-contained proof of the distributive law of divisibility

```
gcd_lcm_distrib :  gcd (lcm a b) c  ∣  lcm (gcd a c) (gcd b c)
```

(the reverse divisibility holds in any GCD monoid; this is the hard/distributive direction). It is obtained by transporting the inequality `(A ⊔ B) ⊓ C ≤ (A ⊓ C) ⊔ (B ⊓ C)` through the order isomorphism `Associates.factors` onto the genuinely distributive multiset lattice `FactorSet R`, where it is just `inf_sup_right`.

The reduction then solves `m₁, m₂` first, re-expresses compatibility with the third modulus over `lcm m₁ m₂`, and applies the distributive law.

## Verification

- 14 theorems, 0 definitions, **0 sorries, 0 axiom declarations**, 272 lines.
- `#print axioms` for `gcd_lcm_distrib`, `crt3_sufficient`, `crt3_iff`: only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`).
- Built offline with `lake env lean` against Mathlib v4.26.0 (Docker unavailable this session). Instantiated for `ℤ` in closing examples.

## Relation to existing entries

The sibling `chinese-remainder-non-coprime-oq-03-oq-01` (a different node, on the oq-03 branch) proves the same distributive law by a longer elementary coprime-cofactor argument over Euclidean domains. This entry gives the explicit 3-modulus characterization for the oq-02 branch, with a shorter factorization-model proof valid in any UFD. The cross-reference is noted in the file docstring, `meta.json`, and annotations.

## Files

- `proofs/Proofs/ChineseRemainderNonCoprimeOQ02OQ01.lean`
- `src/data/proofs/chinese-remainder-non-coprime-oq-02-oq-01/{meta.json,annotations.json}`
- `src/data/research/problems/chinese-remainder-non-coprime-oq-02-oq-01.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)