### PR TITLE
Enrich Order Distribution in (ℤ/pℤ)ˣ (primitive-roots-oq-03): annotation depth + sections

### DIFF
--- a/src/data/proofs/primitive-roots-oq-03/annotations.json
+++ b/src/data/proofs/primitive-roots-oq-03/annotations.json
@@ -8,7 +8,19 @@
       "endLine": 39
     },
     "title": "Module Header: From Generators to the Full Order Distribution",
-    "content": "The base Primitive-Roots entry counts only the **generators** of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ — the elements of the single order $p-1$, of which there are $\\varphi(p-1)$.\n\nThis file gives the **full order distribution**: for *every* divisor $d$ of $p-1$,\n$$\\#\\{g \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times : \\mathrm{ord}(g) = d\\} = \\varphi(d).$$\n\nSumming over all divisors tiles the group, and since the orders partition the $p-1$ units, this recovers **Gauss's identity** $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ from the group-theoretic side. The engine is Mathlib's `IsCyclic.card_orderOf_eq_totient`, specialized to the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$."
+    "content": "The base Primitive-Roots entry counts only the **generators** of $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ — the elements of the single order $p-1$, of which there are $\\varphi(p-1)$.\n\nThis file gives the **full order distribution**: for *every* divisor $d$ of $p-1$,\n$$\\#\\{g \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times : \\mathrm{ord}(g) = d\\} = \\varphi(d).$$\n\nSumming over all divisors tiles the group, and since the orders partition the $p-1$ units, this recovers **Gauss's identity** $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ from the group-theoretic side. The engine is Mathlib's `IsCyclic.card_orderOf_eq_totient`, specialized to the cyclic group $(\\mathbb{Z}/p\\mathbb{Z})^\\times$.",
+    "mathContext": "$\\#\\{g : \\mathrm{ord}(g) = d\\} = \\varphi(d)$ for each $d \\mid p-1$, and $\\sum_{d\\mid p-1}\\varphi(d) = p-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "cyclic group",
+      "Euler totient function",
+      "order of a group element",
+      "Gauss's divisor sum"
+    ],
+    "prerequisites": [
+      "structure of (ℤ/pℤ)ˣ",
+      "order distribution in cyclic groups"
+    ]
   },
   {
     "id": "primitive-roots-oq-03-setup",
@@ -19,7 +31,19 @@
       "endLine": 53
     },
     "title": "Cyclicity and Order of the Unit Group",
-    "content": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is **cyclic** because any finite multiplicative subgroup of an integral domain is cyclic — and $\\mathbb{Z}/p\\mathbb{Z}$ is a field for prime $p$ (`isCyclic_of_subgroup_isDomain` with the injectivity `Units.coeHom_injective`).\n\n`card_units`: its order is $p-1$, via `ZMod.card_units_eq_totient` (giving $\\varphi(p)$) and `Nat.totient_prime` (giving $p-1$). This is the input that converts the hypothesis $d \\mid p-1$ into $d \\mid |\\text{group}|$ for the distribution theorem."
+    "content": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is **cyclic** because any finite multiplicative subgroup of an integral domain is cyclic — and $\\mathbb{Z}/p\\mathbb{Z}$ is a field for prime $p$ (`isCyclic_of_subgroup_isDomain` with the injectivity `Units.coeHom_injective`).\n\n`card_units`: its order is $p-1$, via `ZMod.card_units_eq_totient` (giving $\\varphi(p)$) and `Nat.totient_prime` (giving $p-1$). This is the input that converts the hypothesis $d \\mid p-1$ into $d \\mid |\\text{group}|$ for the distribution theorem.",
+    "mathContext": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ cyclic of order $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = \\varphi(p) = p-1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "finite subgroup of a field is cyclic",
+      "integral domain",
+      "ZMod.card_units_eq_totient",
+      "Nat.totient_prime"
+    ],
+    "prerequisites": [
+      "units of ZMod p",
+      "totient of a prime"
+    ]
   },
   {
     "id": "primitive-roots-oq-03-distribution",
@@ -30,7 +54,19 @@
       "endLine": 69
     },
     "title": "The Full Order Distribution",
-    "content": "`card_orderOf_eq_totient`: for every divisor $d$ of $p-1$, the unit group has exactly $\\varphi(d)$ elements of order $d$.\n\n**Proof.** Lift $d \\mid p-1$ to $d \\mid \\mathrm{Fintype.card}\\,(\\mathbb{Z}/p\\mathbb{Z})^\\times$ via `card_units`, then apply Mathlib's `IsCyclic.card_orderOf_eq_totient`, which gives $\\#\\{g \\mid \\mathrm{ord}(g) = d\\} = \\varphi(d)$ in any cyclic group. A `convert ... using 2` matches the set-builder count to the `Finset.filter` cardinality. This is the all-$d$ strengthening of the base entry's single $d = p-1$ count."
+    "content": "`card_orderOf_eq_totient`: for every divisor $d$ of $p-1$, the unit group has exactly $\\varphi(d)$ elements of order $d$.\n\n**Proof.** Lift $d \\mid p-1$ to $d \\mid \\mathrm{Fintype.card}\\,(\\mathbb{Z}/p\\mathbb{Z})^\\times$ via `card_units`, then apply Mathlib's `IsCyclic.card_orderOf_eq_totient`, which gives $\\#\\{g \\mid \\mathrm{ord}(g) = d\\} = \\varphi(d)$ in any cyclic group. A `convert ... using 2` matches the set-builder count to the `Finset.filter` cardinality. This is the all-$d$ strengthening of the base entry's single $d = p-1$ count.",
+    "mathContext": "$\\#\\{g \\in (\\mathbb{Z}/p\\mathbb{Z})^\\times : \\mathrm{ord}(g)=d\\} = \\varphi(d)$ for $d \\mid p-1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "IsCyclic.card_orderOf_eq_totient",
+      "order classes",
+      "Finset.filter cardinality",
+      "generalization from generators"
+    ],
+    "prerequisites": [
+      "cyclic group order distribution",
+      "divisibility lifting via card_units"
+    ]
   },
   {
     "id": "primitive-roots-oq-03-existence",
@@ -41,7 +77,19 @@
       "endLine": 89
     },
     "title": "Existence of Each Order, and the Generator Count",
-    "content": "`exists_orderOf_eq`: for every $d \\mid p-1$ there exists a unit of order exactly $d$. Since $d$ is a positive divisor of $p-1 > 0$ we have $d \\ge 1$, so $\\varphi(d) > 0$ and the order-$d$ class is nonempty.\n\n`card_generators`: the $d = p-1$ case recovers the classical count $\\#\\text{generators} = \\varphi(p-1)$ — the base entry's `card_primitiveRoots`, now a one-line specialization of the general distribution."
+    "content": "`exists_orderOf_eq`: for every $d \\mid p-1$ there exists a unit of order exactly $d$. Since $d$ is a positive divisor of $p-1 > 0$ we have $d \\ge 1$, so $\\varphi(d) > 0$ and the order-$d$ class is nonempty.\n\n`card_generators`: the $d = p-1$ case recovers the classical count $\\#\\text{generators} = \\varphi(p-1)$ — the base entry's `card_primitiveRoots`, now a one-line specialization of the general distribution.",
+    "mathContext": "$\\varphi(d) > 0 \\Rightarrow \\exists g,\\ \\mathrm{ord}(g) = d$; the $d = p-1$ case gives $\\#\\text{generators} = \\varphi(p-1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "primitive roots",
+      "nonempty from positive cardinality",
+      "Nat.totient_pos",
+      "specialization to d = p−1"
+    ],
+    "prerequisites": [
+      "Finset.card_pos",
+      "positive divisor of a positive number"
+    ]
   },
   {
     "id": "primitive-roots-oq-03-tiling-gauss",
@@ -52,6 +100,18 @@
       "endLine": 115
     },
     "title": "Tiling and Gauss's Divisor Sum",
-    "content": "`sum_card_orderOf`: the order classes **tile** the group — summing $\\#\\{g \\mid \\mathrm{ord}(g) = d\\}$ over all $d \\mid p-1$ gives $p-1$. Each summand is $\\varphi(d)$ by `card_orderOf_eq_totient`, and the resulting $\\sum_{d \\mid p-1} \\varphi(d)$ equals $p-1$ by `Nat.sum_totient`.\n\n`gauss_divisor_sum`: Gauss's identity $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ stated in the primitive-root setting. The two readings — counting units by order vs. the number-theoretic divisor sum — are the same partition of the $p-1$ units, giving a group-theoretic proof of Gauss's classical identity."
+    "content": "`sum_card_orderOf`: the order classes **tile** the group — summing $\\#\\{g \\mid \\mathrm{ord}(g) = d\\}$ over all $d \\mid p-1$ gives $p-1$. Each summand is $\\varphi(d)$ by `card_orderOf_eq_totient`, and the resulting $\\sum_{d \\mid p-1} \\varphi(d)$ equals $p-1$ by `Nat.sum_totient`.\n\n`gauss_divisor_sum`: Gauss's identity $\\sum_{d \\mid p-1} \\varphi(d) = p-1$ stated in the primitive-root setting. The two readings — counting units by order vs. the number-theoretic divisor sum — are the same partition of the $p-1$ units, giving a group-theoretic proof of Gauss's classical identity.",
+    "mathContext": "$\\sum_{d\\mid p-1}\\#\\{g:\\mathrm{ord}(g)=d\\} = \\sum_{d\\mid p-1}\\varphi(d) = p-1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Gauss's divisor sum identity",
+      "partition by order",
+      "Nat.sum_totient",
+      "group-theoretic vs number-theoretic proof"
+    ],
+    "prerequisites": [
+      "divisors of a natural number",
+      "Finset.sum_congr"
+    ]
   }
 ]

--- a/src/data/proofs/primitive-roots-oq-03/meta.json
+++ b/src/data/proofs/primitive-roots-oq-03/meta.json
@@ -54,6 +54,40 @@
       "Finset.filter cardinality and Finset.sum_congr"
     ]
   },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Statement",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Frames the result as the all-d strengthening of the base primitive-roots entry: for every divisor d of p−1, (ℤ/pℤ)ˣ has exactly φ(d) elements of order d, and summing tiles the group to recover Gauss's identity ∑_{d∣p−1} φ(d) = p−1. Engine: Mathlib's IsCyclic.card_orderOf_eq_totient.",
+      "mathContext": "$\\#\\{g:\\mathrm{ord}(g)=d\\}=\\varphi(d)$ for $d\\mid p-1$; $\\sum_{d\\mid p-1}\\varphi(d)=p-1$."
+    },
+    {
+      "id": "setup",
+      "title": "Cyclicity and Order of (ℤ/pℤ)ˣ",
+      "startLine": 41,
+      "endLine": 53,
+      "summary": "Provides the cyclic instance (finite multiplicative subgroup of the field ℤ/pℤ via isCyclic_of_subgroup_isDomain) and card_units : |(ℤ/pℤ)ˣ| = p−1 (ZMod.card_units_eq_totient + Nat.totient_prime). These feed every later theorem by turning d ∣ p−1 into d ∣ |group|.",
+      "mathContext": "$(\\mathbb{Z}/p\\mathbb{Z})^\\times$ cyclic, $|(\\mathbb{Z}/p\\mathbb{Z})^\\times| = p-1$."
+    },
+    {
+      "id": "order-distribution",
+      "title": "The Full Order Distribution and Existence",
+      "startLine": 55,
+      "endLine": 89,
+      "summary": "card_orderOf_eq_totient: φ(d) elements of order d for each d ∣ p−1, by specializing IsCyclic.card_orderOf_eq_totient. exists_orderOf_eq: an element of each order exists (φ(d) > 0). card_generators: the d = p−1 case recovers the classical #generators = φ(p−1).",
+      "mathContext": "$\\#\\{g:\\mathrm{ord}(g)=d\\}=\\varphi(d)$; $\\exists g,\\ \\mathrm{ord}(g)=d$; $d=p-1\\Rightarrow\\varphi(p-1)$ generators."
+    },
+    {
+      "id": "tiling-gauss",
+      "title": "Tiling and Gauss's Divisor Sum",
+      "startLine": 91,
+      "endLine": 117,
+      "summary": "sum_card_orderOf: the order classes tile the group, summing to p−1 (each summand φ(d) by the distribution theorem, then Nat.sum_totient). gauss_divisor_sum: states ∑_{d∣p−1} φ(d) = p−1 in the primitive-root setting — the group-theoretic reading of Gauss's classical identity.",
+      "mathContext": "$\\sum_{d\\mid p-1}\\#\\{g:\\mathrm{ord}(g)=d\\}=\\sum_{d\\mid p-1}\\varphi(d)=p-1$."
+    }
+  ],
   "crossReferences": [
     {
       "proofId": "primitive-roots",


### PR DESCRIPTION
Enrichment pass for `primitive-roots-oq-03` (quality 60, 0 prior passes).

## Gaps addressed
- **Annotation depth**: the 5 existing annotations had only `title` + `content`. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every one.
- **Missing `sections`**: meta.json had no `sections` array. Added 4 sections covering the full 117-line file (module header, cyclicity/order setup, order distribution + existence, tiling + Gauss's divisor sum).

## Verification
- JSON validates (4 sections, 5 annotations all with mathContext).
- `pnpm build` data-generation runs; gallery-wide validation error count unchanged from baseline.

Axiom integrity unchanged: status `verified`, axiomCount 0 — consistent with the Lean source (no axioms, no sorries, no native_decide).