### PR TITLE
research(frobenius-number-oq-02-oq-01): Apéry sets + Kunz symmetry criterion (forward) [verified, 0 axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3063,6 +3063,7 @@ import Proofs.FrobeniusNumberOQ01
 import Proofs.FrobeniusNumberOQ01OQ03OQ01
 import Proofs.FrobeniusNumberOQ01OQ04
 import Proofs.FrobeniusNumberOQ02
+import Proofs.FrobeniusNumberOQ02OQ01
 import Proofs.FrobeniusNumberOQ03
 import Proofs.FrobeniusNumberOQ04
 import Proofs.FundamentalArithmetic

--- a/proofs/Proofs/FrobeniusNumberOQ02OQ01.lean
+++ b/proofs/Proofs/FrobeniusNumberOQ02OQ01.lean
@@ -1,0 +1,179 @@
+import Mathlib
+import Proofs.FrobeniusNumber
+import Proofs.FrobeniusNumberOQ01OQ03
+import Proofs.FrobeniusNumberOQ01OQ03OQ01
+
+/-
+# Apéry sets and the Kunz symmetry criterion for numerical semigroups
+
+`frobenius-number-oq-02-oq-01`. Building on the generator-agnostic numerical
+semigroup infrastructure of `FrobeniusNumberOQ01OQ03OQ01`
+(`IsNumericalSemigroup`, `IsFrobeniusNumber`, `IsSymmetric`), this file
+introduces the **Apéry set** and proves two foundational, fully machine-checked
+results about it.
+
+For a numerical semigroup `S` and a nonzero `m ∈ S`, the Apéry set is
+  `Ap(S, m) = { s ∈ S : s − m ∉ S }`
+(with `s − m` read over `ℤ`, so `0 ∈ Ap(S, m)` always). It selects, in each
+residue class mod `m`, the *smallest* element of `S` — a finite certificate of
+the whole semigroup, central to Kunz's (1970) coordinate description.
+
+## Results
+
+* `InApery` — the Apéry-set membership predicate, with the `ℤ`-subtraction
+  encoded faithfully in `ℕ` as `s < m ∨ s − m ∉ S`.
+* `mem_iff_exists_apery` — **the Apéry covering theorem**: `n ∈ S` iff `n = w + j·m`
+  for some Apéry element `w` and some `j : ℕ`. The forward direction selects the
+  minimal element of `S` in `n`'s residue class via `Nat.find`; the converse is
+  closure under adding `m`. This is the structural backbone of Apéry theory.
+* `frobenius_add_m_inApery` — the Frobenius number's mirror `g + m` is the
+  largest Apéry element.
+* `inApery_le_frobenius_add_m` — every Apéry element is `≤ g + m`.
+* `apery_mirror_of_isSymmetric` — **one direction of Kunz's symmetry criterion**:
+  if `S` is symmetric then its Apéry set is closed under the involution
+  `w ↦ (g + m) − w`. Concretely, `S` symmetric ⟹ `Ap(S, m)` is symmetric about
+  its top element `g + m`.
+
+## Scope (honest statement)
+
+The *converse* of Kunz's criterion — Apéry-mirror-symmetry ⟹ `S` symmetric, and
+the explicit ≥ 3-generator Kunz-coordinate characterization sought by the parent
+problem — is **not** proved here; it requires relating an arbitrary `k ≤ g` to
+the Apéry decomposition of its class and remains open. What is established is the
+Apéry set itself, its covering theorem, and the forward symmetry implication —
+genuine, reusable Apéry/Kunz infrastructure that the gallery did not previously
+have.
+-/
+
+namespace FrobeniusNumberOQ02OQ01
+
+open FrobeniusNumberOQ01OQ03OQ01
+
+open scoped Classical
+
+variable {S : Set ℕ} {m g w : ℕ}
+
+/-- **Apéry-set membership.** `s` lies in the Apéry set `Ap(S, m)` when `s ∈ S`
+and `s − m ∉ S`, where the difference is taken over `ℤ`: in `ℕ` this is `s < m`
+(so `s − m < 0 ∉ S`) or `s − m ∉ S`. In particular `0 ∈ Ap(S, m)` whenever
+`0 < m`. -/
+def InApery (S : Set ℕ) (m s : ℕ) : Prop :=
+  s ∈ S ∧ (s < m ∨ s - m ∉ S)
+
+/-- `0` is always an Apéry element (for `m > 0`). -/
+theorem zero_inApery (h0 : 0 ∈ S) (hm : 0 < m) : InApery S m 0 :=
+  ⟨h0, Or.inl hm⟩
+
+/-- Adding any multiple of `m ∈ S` to a semigroup element stays in `S`. -/
+theorem add_mul_mem (hadd : ∀ x ∈ S, ∀ y ∈ S, x + y ∈ S) (hm : m ∈ S)
+    (hw : w ∈ S) (j : ℕ) : w + j * m ∈ S := by
+  induction j with
+  | zero => simpa using hw
+  | succ k ih =>
+    have : w + (k + 1) * m = (w + k * m) + m := by ring
+    rw [this]
+    exact hadd _ ih _ hm
+
+/-- **Apéry covering theorem.** `n ∈ S` if and only if `n = w + j·m` for some
+Apéry element `w ∈ Ap(S, m)` and some `j : ℕ`. The forward direction takes `w`
+to be the least element of `S` in `n`'s residue class mod `m` (via `Nat.find`),
+which is automatically an Apéry element; the converse is closure under adding
+`m`. This expresses every semigroup element through the finite Apéry data. -/
+theorem mem_iff_exists_apery (hS : IsNumericalSemigroup S) (hm : m ∈ S)
+    (hmpos : 0 < m) (n : ℕ) :
+    n ∈ S ↔ ∃ w, InApery S m w ∧ ∃ j, n = w + j * m := by
+  constructor
+  · intro hn
+    have hP : ∃ s, s ∈ S ∧ s % m = n % m := ⟨n, hn, rfl⟩
+    obtain ⟨hwS, hwmod⟩ := Nat.find_spec hP
+    set w := Nat.find hP with hwdef
+    have hwle : w ≤ n := Nat.find_le ⟨hn, rfl⟩
+    -- `w` is an Apéry element: if `w - m ∈ S` (with `m ≤ w`) it would be a
+    -- strictly smaller element of `S` in the same class, contradicting minimality.
+    have hap : InApery S m w := by
+      refine ⟨hwS, ?_⟩
+      by_cases hlt : w < m
+      · exact Or.inl hlt
+      · right
+        intro hcontra
+        have hmw : m ≤ w := not_lt.mp hlt
+        have hmod : (w - m) % m = n % m := by
+          calc (w - m) % m = ((w - m) + m) % m := (Nat.add_mod_right (w - m) m).symm
+            _ = w % m := by rw [Nat.sub_add_cancel hmw]
+            _ = n % m := hwmod
+        exact Nat.find_min hP (show w - m < w by omega) ⟨hcontra, hmod⟩
+    -- `w ≤ n` with `w ≡ n (mod m)` gives `m ∣ n - w`, hence `n = w + j·m`.
+    have hdvd : m ∣ n - w := (Nat.modEq_iff_dvd' hwle).mp hwmod
+    obtain ⟨j, hj⟩ := hdvd
+    exact ⟨w, hap, j, by rw [Nat.mul_comm]; omega⟩
+  · rintro ⟨w, ⟨hwS, _⟩, j, rfl⟩
+    exact add_mul_mem hS.2.1 hm hwS j
+
+/-- The mirror `g + m` of the Frobenius number is an Apéry element: it lies in
+`S` (being `> g`) while `(g + m) − m = g ∉ S`. It is the *largest* Apéry
+element, the top of the Apéry set's symmetry. -/
+theorem frobenius_add_m_inApery (hg : IsFrobeniusNumber S g) (hmpos : 0 < m) :
+    InApery S m (g + m) := by
+  refine ⟨hg.2 (g + m) (by omega), Or.inr ?_⟩
+  rw [Nat.add_sub_cancel]
+  exact hg.1
+
+/-- Every Apéry element is `≤ g + m`: its predecessor `w - m` is a gap, hence
+`≤ g`. So `g + m` indeed bounds the Apéry set. -/
+theorem inApery_le_frobenius_add_m (hg : IsFrobeniusNumber S g)
+    (h : InApery S m w) : w ≤ g + m := by
+  obtain ⟨_, hcond⟩ := h
+  by_cases hmw : m ≤ w
+  · -- `w - m ∉ S` (since `m ≤ w` rules out `w < m`), so `w - m ≤ g`.
+    have hsub : w - m ∉ S := by
+      rcases hcond with h1 | h2
+      · exact absurd h1 (not_lt.mpr hmw)
+      · exact h2
+    have : w - m ≤ g := by
+      by_contra hgt
+      exact hsub (hg.2 (w - m) (by omega))
+    omega
+  · omega
+
+/-- **Kunz symmetry criterion (forward direction).** If `S` is symmetric with
+Frobenius number `g`, then its Apéry set `Ap(S, m)` is closed under the
+involution `w ↦ (g + m) − w`. Equivalently, the Apéry set is symmetric about its
+top element `g + m`. This is the elementary, generator-agnostic half of Kunz's
+characterization of symmetric numerical semigroups via Apéry sets. -/
+theorem apery_mirror_of_isSymmetric (hg : IsFrobeniusNumber S g)
+    (hsym : IsSymmetric S g) (_hmpos : 0 < m) (h : InApery S m w) :
+    InApery S m (g + m - w) := by
+  have hwle : w ≤ g + m := inApery_le_frobenius_add_m hg h
+  obtain ⟨hwS, hcond⟩ := h
+  refine ⟨?_, ?_⟩
+  · -- `(g + m) - w ∈ S`.
+    by_cases hwm : w < m
+    · -- Then `(g + m) - w > g`, so it is in `S`.
+      exact hg.2 _ (by omega)
+    · -- `m ≤ w`: the gap `w - m ≤ g` mirrors under symmetry to `g + m - w ∈ S`.
+      have hmw : m ≤ w := not_lt.mp hwm
+      have hsub : w - m ∉ S := by
+        rcases hcond with h1 | h2
+        · exact absurd h1 (not_lt.mpr hmw)
+        · exact h2
+      have hsuble : w - m ≤ g := by
+        by_contra hgt
+        exact hsub (hg.2 (w - m) (by omega))
+      have hsymwm := hsym (w - m) hsuble
+      have hin : g - (w - m) ∈ S := by
+        by_contra hc
+        exact hsub (hsymwm.mpr hc)
+      have heq : g - (w - m) = g + m - w := by omega
+      rwa [heq] at hin
+  · -- Apéry condition for `(g + m) - w`.
+    by_cases hwg : w ≤ g
+    · -- `(g + m - w) - m = g - w`, and `w ∈ S` with `w ≤ g` forces `g - w ∉ S`.
+      right
+      have heq : (g + m - w) - m = g - w := by omega
+      rw [heq]
+      exact (hsym w hwg).mp hwS
+    · -- `w > g` gives `(g + m) - w < m`.
+      left
+      omega
+
+end FrobeniusNumberOQ02OQ01

--- a/src/data/proofs/frobenius-number-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/frobenius-number-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-apery-def",
+    "proofId": "frobenius-number-oq-02-oq-01",
+    "range": { "startLine": 60, "endLine": 66 },
+    "type": "definition",
+    "title": "The Apéry set Ap(S,m)",
+    "content": "`InApery S m s := s ∈ S ∧ (s < m ∨ s − m ∉ S)` encodes the classical Apéry set $\\mathrm{Ap}(S,m) = \\{s \\in S : s - m \\notin S\\}$, where the difference is over $\\mathbb{Z}$. Since $\\mathbb{N}$-subtraction truncates, the integer condition $s - m \\notin S$ is written as the disjunction $s < m$ (so $s - m < 0$, never in $S$) or $s - m \\notin S$. This makes $0 \\in \\mathrm{Ap}(S,m)$ for every $m > 0$ (lemma `zero_inApery`). The Apéry set picks out the smallest element of $S$ in each residue class mod $m$.",
+    "mathContext": "$\\mathrm{Ap}(S,m) = \\{\\,s \\in S : s - m \\notin S\\,\\}$; $0 \\in \\mathrm{Ap}(S,m)$ when $m > 0$.",
+    "significance": "critical",
+    "prerequisites": ["Numerical semigroups", "truncated natural subtraction"],
+    "relatedConcepts": ["Apéry set", "residue classes", "Kunz coordinates"]
+  },
+  {
+    "id": "ann-closure",
+    "proofId": "frobenius-number-oq-02-oq-01",
+    "range": { "startLine": 68, "endLine": 80 },
+    "type": "theorem",
+    "title": "Closure under adding multiples of m",
+    "content": "`add_mul_mem`: if $m \\in S$ and $w \\in S$ then $w + j m \\in S$ for every $j$, by induction on $j$ using the semigroup's additive closure ($w + (k+1)m = (w + km) + m$). This is the easy converse engine of the covering theorem: any $w + jm$ built from an Apéry element is automatically in $S$.",
+    "mathContext": "$m \\in S,\\ w \\in S \\implies w + jm \\in S$ for all $j \\in \\mathbb{N}$.",
+    "significance": "supporting",
+    "prerequisites": ["Induction", "semigroup closure"],
+    "relatedConcepts": ["additive closure", "Apéry covering"]
+  },
+  {
+    "id": "ann-covering",
+    "proofId": "frobenius-number-oq-02-oq-01",
+    "range": { "startLine": 82, "endLine": 113 },
+    "type": "theorem",
+    "title": "Apéry covering theorem: n ∈ S ⟺ n = w + j·m",
+    "content": "`mem_iff_exists_apery`: $n \\in S$ iff $n = w + jm$ for some Apéry element $w$ and some $j$. Forward — apply `Nat.find` to the predicate $s \\in S \\wedge s \\equiv n \\pmod m$; the least such $w$ satisfies $w \\le n$ and $w \\equiv n \\pmod m$. Minimality (`Nat.find_min`) forces $w - m \\notin S$ whenever $m \\le w$ (else $w - m$ would be a smaller element of $S$ in the same class), so $w$ is Apéry. Then $w \\le n$ with $w \\equiv n \\pmod m$ gives $m \\mid n - w$ (via `Nat.modEq_iff_dvd'`), so $n = w + jm$. Converse — `add_mul_mem`. This expresses the whole semigroup through its finite Apéry data.",
+    "mathContext": "$n \\in S \\iff \\exists\\, w \\in \\mathrm{Ap}(S,m),\\ \\exists\\, j,\\ n = w + jm$.",
+    "significance": "critical",
+    "prerequisites": ["Nat.find minimal-witness selection", "Nat.modEq_iff_dvd'", "Nat.add_mod_right"],
+    "relatedConcepts": ["Apéry set", "residue-class minima", "structure of numerical semigroups"]
+  },
+  {
+    "id": "ann-top-element",
+    "proofId": "frobenius-number-oq-02-oq-01",
+    "range": { "startLine": 115, "endLine": 141 },
+    "type": "theorem",
+    "title": "g + m is the largest Apéry element",
+    "content": "`frobenius_add_m_inApery`: $g + m \\in \\mathrm{Ap}(S,m)$ — it exceeds $g$ so lies in $S$, while $(g+m) - m = g \\notin S$. `inApery_le_frobenius_add_m`: every Apéry element $w$ satisfies $w \\le g + m$, because its predecessor $w - m$ is a gap and gaps are $\\le g$. Hence $g + m$ is the top of the Apéry set, and the involution $w \\mapsto (g+m) - w$ is well-defined on it.",
+    "mathContext": "$g + m \\in \\mathrm{Ap}(S,m)$ and $w \\le g + m$ for all $w \\in \\mathrm{Ap}(S,m)$.",
+    "significance": "supporting",
+    "prerequisites": ["IsFrobeniusNumber", "gaps are ≤ g"],
+    "relatedConcepts": ["maximal Apéry element", "Frobenius mirror"]
+  },
+  {
+    "id": "ann-kunz-forward",
+    "proofId": "frobenius-number-oq-02-oq-01",
+    "range": { "startLine": 143, "endLine": 177 },
+    "type": "theorem",
+    "title": "Kunz symmetry criterion (forward): symmetric ⟹ Apéry mirror-closed",
+    "content": "`apery_mirror_of_isSymmetric`: if $S$ is symmetric ($k \\in S \\iff g - k \\notin S$ for $k \\le g$), then $\\mathrm{Ap}(S,m)$ is closed under $w \\mapsto (g+m) - w$. Membership $(g+m)-w \\in S$: when $w < m$ the mirror exceeds $g$, hence is in $S$; when $m \\le w$, the gap $w - m \\le g$ maps under symmetry to $g - (w-m) = (g+m)-w \\in S$. The Apéry condition of the mirror reduces (for $w \\le g$) to $g - w \\notin S$, which is exactly symmetry applied to $w \\in S$; for $w > g$ the mirror is $< m$. This is the elementary, generator-agnostic forward half of Kunz's characterization.",
+    "mathContext": "$S$ symmetric $\\implies\\ \\big(w \\in \\mathrm{Ap}(S,m) \\implies (g+m)-w \\in \\mathrm{Ap}(S,m)\\big)$.",
+    "significance": "critical",
+    "prerequisites": ["IsSymmetric", "inApery_le_frobenius_add_m", "case analysis on truncated subtraction"],
+    "relatedConcepts": ["Kunz criterion", "symmetric numerical semigroup", "involution on the Apéry set"]
+  }
+]

--- a/src/data/proofs/frobenius-number-oq-02-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-02-oq-01/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "frobenius-number-oq-02-oq-01",
+  "title": "Apéry Sets and the Kunz Symmetry Criterion (forward direction)",
+  "slug": "frobenius-number-oq-02-oq-01",
+  "description": "Introduces the Apéry set Ap(S,m) = {s ∈ S : s−m ∉ S} for a numerical semigroup S and nonzero m ∈ S, and proves two foundational machine-checked results on the generator-agnostic infrastructure of frobenius-number-oq-01-oq-03-oq-01. (1) The Apéry covering theorem: n ∈ S ⟺ n = w + j·m for some Apéry element w and j : ℕ — the forward direction picks the least element of S in n's residue class via Nat.find, the converse is closure under adding m. (2) One direction of Kunz's symmetry criterion: if S is symmetric then its Apéry set is closed under the involution w ↦ (g+m)−w, i.e. Ap(S,m) is symmetric about its top element g+m (= the Frobenius mirror). The reverse direction and the explicit ≥3-generator Kunz-coordinate characterization remain open and are stated honestly as such.",
+  "meta": {
+    "author": "Kunz (1970, criterion); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Numerical_semigroup",
+    "date": "2026-06-25",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "numerical-semigroups",
+      "frobenius",
+      "apery-set",
+      "kunz",
+      "symmetric-semigroup",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusNumberOQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.find",
+        "description": "Least natural satisfying a decidable predicate, with Nat.find_spec / Nat.find_le / Nat.find_min. Used to select the minimal element of S in a residue class mod m — the Apéry element of that class.",
+        "module": "Mathlib.Data.Nat.Find"
+      },
+      {
+        "theorem": "Nat.modEq_iff_dvd'",
+        "description": "For a ≤ b, a ≡ b [MOD n] ↔ n ∣ b − a. Turns 'w ≤ n and w ≡ n (mod m)' into m ∣ n − w, yielding the multiple j with n = w + j·m in the covering theorem.",
+        "module": "Mathlib.Data.Nat.ModCast"
+      },
+      {
+        "theorem": "Nat.add_mod_right",
+        "description": "(a + n) % n = a % n. Used to show (w − m) % m = w % m for m ≤ w when verifying the selected element is Apéry.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "InApery: a faithful ℕ encoding of the Apéry set Ap(S,m) = {s ∈ S : s−m ∉ S}, with the ℤ-subtraction rendered as 's < m ∨ s − m ∉ S' so that 0 ∈ Ap(S,m) for m > 0",
+      "mem_iff_exists_apery: the Apéry covering theorem — n ∈ S ⟺ ∃ w ∈ Ap(S,m), ∃ j, n = w + j·m — proved by Nat.find minimal-element selection (forward) and additive closure (converse)",
+      "frobenius_add_m_inApery and inApery_le_frobenius_add_m: g + m is the largest Apéry element and bounds Ap(S,m)",
+      "apery_mirror_of_isSymmetric: the forward direction of Kunz's symmetry criterion — S symmetric ⟹ Ap(S,m) is closed under the involution w ↦ (g+m)−w (symmetric about its top g+m)",
+      "All of this is built on the existing generator-agnostic IsNumericalSemigroup / IsFrobeniusNumber / IsSymmetric framework, so it applies to semigroups with any number of generators"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 179,
+    "assumptions": "None beyond the foundational axioms. #print axioms on mem_iff_exists_apery and apery_mirror_of_isSymmetric reports only propext, Classical.choice, Quot.sound (none of which count as assumptions). `open scoped Classical` supplies decidability for Nat.find; no native_decide, no sorries, no structure-encoded hypotheses. The converse of Kunz's criterion is NOT claimed — see openQuestions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "namespace": "FrobeniusNumberOQ02OQ01",
+    "lineCount": 179,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/FrobeniusNumberOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "apery-def",
+      "title": "The Apéry set",
+      "startLine": 58,
+      "endLine": 66,
+      "summary": "InApery S m s := s ∈ S ∧ (s < m ∨ s − m ∉ S) — a ℕ encoding of Ap(S,m) = {s ∈ S : s − m ∉ S} over ℤ, so 0 is an Apéry element when m > 0 (zero_inApery)."
+    },
+    {
+      "id": "closure",
+      "title": "Additive closure by multiples of m",
+      "startLine": 67,
+      "endLine": 80,
+      "summary": "add_mul_mem: for m ∈ S and w ∈ S, w + j·m ∈ S for all j — the converse engine of the covering theorem, by induction on j using semigroup closure."
+    },
+    {
+      "id": "covering",
+      "title": "Apéry covering theorem",
+      "startLine": 81,
+      "endLine": 113,
+      "summary": "mem_iff_exists_apery: n ∈ S ⟺ ∃ Apéry w and j with n = w + j·m. Forward: Nat.find selects the least element w of S in n's residue class; minimality forces w − m ∉ S so w is Apéry, and w ≡ n (mod m) with w ≤ n gives m ∣ n − w. Converse: add_mul_mem."
+    },
+    {
+      "id": "top-element",
+      "title": "g + m is the top Apéry element",
+      "startLine": 114,
+      "endLine": 141,
+      "summary": "frobenius_add_m_inApery: g + m ∈ Ap(S,m) since g+m > g ∈ S and (g+m)−m = g ∉ S. inApery_le_frobenius_add_m: every Apéry element w ≤ g + m, because its predecessor w − m is a gap (≤ g)."
+    },
+    {
+      "id": "kunz-forward",
+      "title": "Kunz symmetry criterion (forward direction)",
+      "startLine": 142,
+      "endLine": 177,
+      "summary": "apery_mirror_of_isSymmetric: if S is symmetric then Ap(S,m) is closed under w ↦ (g+m)−w. The mirror image (g+m)−w lies in S (via symmetry applied to the gap w−m, or because it exceeds g when w < m), and its Apéry condition reduces to g−w ∉ S, which symmetry gives from w ∈ S, w ≤ g."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Apéry sets and symmetric numerical semigroups.** A numerical semigroup $S \\subseteq \\mathbb{N}$ is a cofinite, additively closed subset containing $0$; its largest gap is the Frobenius number $g = F(S)$. For any nonzero $m \\in S$, Apéry (1946) introduced the set $\\mathrm{Ap}(S,m) = \\{s \\in S : s - m \\notin S\\}$, which contains exactly the smallest element of $S$ in each residue class modulo $m$. The Apéry set is a finite certificate carrying the entire structure of $S$: Kunz (1970) recast it in terms of coordinates $(k_1,\\dots,k_{m-1})$ and used it to characterize the *symmetric* semigroups — those for which the gap set is the mirror image of $S$ across $g$ (equivalently, type one; equivalently, the associated monomial curve is Gorenstein). Kunz's criterion states that $S$ is symmetric iff its Apéry set is symmetric under the involution $w \\mapsto w_{\\max} - w$, where $w_{\\max} = g + m$ is the largest Apéry element.",
+    "problemStatement": "**Apéry/Kunz characterization of symmetry.** Define the Apéry set $\\mathrm{Ap}(S,m)$ for a numerical semigroup $S$ and nonzero $m \\in S$, establish the covering theorem expressing every $n \\in S$ through Apéry data, and prove Kunz's symmetry criterion relating symmetry of $S$ to the involution $w \\mapsto (g+m)-w$ on $\\mathrm{Ap}(S,m)$. The general (≥ 3-generator) Kunz-coordinate characterization is the long-term target.",
+    "proofStrategy": "**Minimal-element selection + symmetry transport.** The Apéry set is encoded over $\\mathbb{N}$ as $s \\in S \\wedge (s < m \\vee s - m \\notin S)$, matching the integer condition $s - m \\notin S$. The covering theorem selects, for each $n \\in S$, the least element $w$ of $S$ in $n$'s residue class mod $m$ via `Nat.find`; minimality forces $w - m \\notin S$ (else $w-m$ is a smaller element in the same class), so $w$ is Apéry, and $w \\le n$ with $w \\equiv n \\pmod m$ yields $n = w + j m$. For the forward symmetry direction, the mirror $(g+m)-w$ is shown to be in $S$ by applying the semigroup's symmetry $k \\in S \\iff g - k \\notin S$ to the gap $w - m$, and its Apéry condition reduces to $g - w \\notin S$, again supplied by symmetry from $w \\in S$, $w \\le g$.",
+    "keyInsights": [
+      "**The Apéry set is 'smallest element per residue class'.** This is exactly what `Nat.find` on the predicate $s \\in S \\wedge s \\equiv n \\pmod m$ computes; the minimality property `Nat.find_min` is precisely the Apéry condition $w - m \\notin S$.",
+      "**Encoding $\\mathbb{Z}$-subtraction in $\\mathbb{N}$.** The defining condition $s - m \\notin S$ is over $\\mathbb{Z}$; in $\\mathbb{N}$ it becomes $s < m \\vee s - m \\notin S$, so that $0 \\in \\mathrm{Ap}(S,m)$ (since $0 - m < 0 \\notin S$) for every $m > 0$.",
+      "**$g + m$ is the top of the Apéry set.** It is in $S$ (exceeds $g$) yet its predecessor is the Frobenius gap $g$, so it is Apéry; and every Apéry element's predecessor is a gap $\\le g$, bounding the whole set by $g + m$. The involution $w \\mapsto (g+m) - w$ is therefore well-defined on $\\mathrm{Ap}(S,m)$.",
+      "**Symmetry transports along the mirror.** For an Apéry $w$ with $m \\le w$, the gap $w - m \\le g$ maps under the semigroup symmetry $k \\in S \\iff g-k \\notin S$ to $g - (w-m) = (g+m)-w \\in S$; for $w < m$, the mirror simply exceeds $g$ and is in $S$. The Apéry condition of the mirror is $g - w \\notin S$, which is symmetry read off $w \\in S$.",
+      "**Generator-agnostic.** Everything is stated for an abstract `IsNumericalSemigroup S`, so it covers semigroups with any number of generators — the setting needed for the ≥ 3-generator question, even though the converse of Kunz's criterion is not yet closed here."
+    ],
+    "prerequisites": [
+      "Numerical semigroups: IsNumericalSemigroup, IsFrobeniusNumber, IsSymmetric (frobenius-number-oq-01-oq-03-oq-01)",
+      "Least-witness selection: Nat.find / Nat.find_spec / Nat.find_min",
+      "Modular arithmetic: Nat.ModEq, Nat.modEq_iff_dvd'",
+      "Truncated natural subtraction"
+    ]
+  },
+  "conclusion": {
+    "summary": "On the generator-agnostic numerical-semigroup framework, this entry defines the Apéry set Ap(S,m), proves the Apéry covering theorem (n ∈ S ⟺ n = w + j·m for an Apéry element w), identifies g + m as the largest Apéry element, and establishes the forward direction of Kunz's symmetry criterion: a symmetric semigroup has an Apéry set closed under the involution w ↦ (g+m)−w. 6 theorems, 1 definition, 179 lines, 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the gallery's first Apéry-set formalization and the covering theorem, a reusable backbone for further numerical-semigroup work (Kunz coordinates, type, genus).",
+      "Provides the elementary forward half of Kunz's symmetry criterion, connecting the existing symmetric ⟺ type-one equivalence to the Apéry-set involution.",
+      "Stays generator-agnostic, so it is directly usable in the ≥ 3-generator setting that the parent problem targets."
+    ],
+    "openQuestions": [
+      "Prove the CONVERSE of Kunz's criterion: if Ap(S,m) is closed under w ↦ (g+m)−w then S is symmetric. This requires relating an arbitrary k ≤ g to the Apéry decomposition of its residue class (via mem_iff_exists_apery) and is the substantive half of the theorem.",
+      "Formalize Kunz coordinates (k_1,…,k_{m-1}) explicitly and recast symmetry as the coordinate identity k_i + k_{m-i} relation, giving the ≥ 3-generator characterization sought by the parent problem.",
+      "Connect to the gallery's symmetric ⟺ type-one result: derive that the Apéry-set involution is equivalent to the pseudo-Frobenius set being the singleton {g}, completing a three-way equivalence (symmetric ⟺ type one ⟺ Apéry-mirror-symmetric)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "frobenius-number-oq-02",
+      "relationship": "parent",
+      "description": "The parent problem on symmetry of representable numbers for two generators; this child generalizes toward the Apéry/Kunz characterization for arbitrary generators."
+    },
+    {
+      "targetId": "frobenius-number-oq-01-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Supplies the generator-agnostic IsNumericalSemigroup / IsFrobeniusNumber / IsSymmetric definitions and the symmetric ⟺ type-one equivalence that this entry builds on."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Introduces the **Apéry set** to the gallery and proves two foundational, **axiom-free** results about it, building on the generator-agnostic numerical-semigroup framework of `frobenius-number-oq-01-oq-03-oq-01` (`IsNumericalSemigroup`, `IsFrobeniusNumber`, `IsSymmetric`).

For a numerical semigroup `S` and nonzero `m ∈ S`, the Apéry set is `Ap(S,m) = {s ∈ S : s − m ∉ S}` — the smallest element of `S` in each residue class mod `m`, the finite certificate central to Kunz's coordinate description.

### Results
- **`mem_iff_exists_apery` — the Apéry covering theorem**: `n ∈ S ⟺ n = w + j·m` for some Apéry element `w` and `j : ℕ`. Forward via `Nat.find` minimal-element selection (minimality *is* the Apéry condition); converse via additive closure.
- **`frobenius_add_m_inApery` / `inApery_le_frobenius_add_m`**: `g + m` is the largest Apéry element and bounds `Ap(S,m)`.
- **`apery_mirror_of_isSymmetric` — Kunz symmetry criterion, forward direction**: if `S` is symmetric then `Ap(S,m)` is closed under the involution `w ↦ (g+m) − w` (symmetric about its top element `g+m`).

### Honest scope
The **converse** of Kunz's criterion (Apéry-mirror-symmetry ⟹ `S` symmetric) and the explicit ≥3-generator Kunz-coordinate characterization are **not** claimed here — they are stated as open questions in the entry. What this PR delivers is the Apéry set itself, its covering theorem, and the forward symmetry implication: genuine, reusable Apéry/Kunz infrastructure the gallery lacked.

## Contents
- `proofs/Proofs/FrobeniusNumberOQ02OQ01.lean` — 6 theorems, 1 definition, 179 lines, **0 sorry, 0 axiom**
- Gallery entry `src/data/proofs/frobenius-number-oq-02-oq-01/` (meta + annotations)

## Verification
- `lake env lean Proofs/FrobeniusNumberOQ02OQ01.lean` compiles cleanly, no warnings (Mathlib 4.26.0).
- `#print axioms` on `mem_iff_exists_apery` and `apery_mirror_of_isSymmetric` → only `propext, Classical.choice, Quot.sound`. Status: **verified**.
- `pnpm build` succeeds with the new gallery entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)