### PR TITLE
research(burnside-counting-oq-06): Fermat's little theorem via necklace counting [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -599,6 +599,7 @@ import Proofs.BurnsideCountingOQ04OQ02
 import Proofs.BurnsideCountingOQ04OQ02OQ02
 import Proofs.BurnsideCountingOQ05
 import Proofs.BurnsideCountingOQ05OQ01
+import Proofs.BurnsideCountingOQ06
 import Proofs.CantorDiagonalization
 import Proofs.CantorDiagonalizationOQ01
 import Proofs.CantorDiagonalizationOQ01OQ01

--- a/proofs/Proofs/BurnsideCountingOQ06.lean
+++ b/proofs/Proofs/BurnsideCountingOQ06.lean
@@ -1,0 +1,97 @@
+import Mathlib
+import Proofs.BurnsideCountingOQ03OQ02OQ01OQ02
+
+/-
+# Fermat's Little Theorem via Necklace Counting
+
+This entry closes the necklace-counting branch of the Burnside gallery with its most
+famous *number-theoretic* consequence: **Fermat's little theorem**, derived purely from
+the orbit count of the cyclic rotation group acting on colored necklaces.
+
+## The combinatorial argument
+
+Let `p` be prime and consider the `k`-colored necklaces of length `p`, i.e. the orbits of
+the cyclic rotation group `Rot p = Multiplicative (ZMod p)` acting on the colorings
+`Rot p → Fin k`. The parent results
+(`BurnsideCountingOQ03OQ02OQ01OQ02.card_necklaces_mul_eq_sum_divisors`) give the textbook
+divisor-sum form of the (rotation) necklace count:
+
+  `(#necklaces) · n = ∑_{d ∣ n} φ(n/d) · k^d`.
+
+Specializing to a **prime** `n = p`, the only divisors are `1` and `p`, so the sum
+collapses to just two terms:
+
+  `(#necklaces) · p = φ(p)·k + φ(1)·k^p = (p − 1)·k + k^p`.
+
+The left-hand side is a multiple of `p`, hence `p ∣ k^p + (p − 1)·k`. Writing
+`k^p + (p − 1)·k = (k^p − k) + p·k` exhibits `p ∣ k^p − k`, which is exactly Fermat's
+little theorem. The single integer `#necklaces − k` is an explicit witness for the
+divisibility.
+
+## What is new
+
+The Burnside gallery already builds the full cyclic necklace count, the fixed-point sum,
+and the divisor form `∑_{d∣n} φ(n/d)·k^d`. What it had **never** recorded is the prime
+specialization and the resulting Fermat corollary. This file supplies:
+
+* `necklaces_mul_prime_eq` — the two-term collapse `(#necklaces)·p = φ(p)·k + k^p` for prime `p`;
+* `fermat_little` — `(p : ℤ) ∣ k^p − k`, with the necklace count as an explicit witness;
+* `fermat_little_modEq` — the congruence form `k^p ≡ k [MOD p]`;
+* `pow_card_eq` — the `ZMod p` form `(k : ZMod p)^p = k`, recovered from the necklace count
+  rather than from Mathlib's algebraic `ZMod.pow_card`, confirming the two routes agree.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+open Finset MulAction
+open BurnsideCountingOQ03OQ02OQ01 (Rot)
+open BurnsideCountingOQ03OQ02OQ01OQ02 (card_necklaces_mul_eq_sum_divisors)
+
+namespace BurnsideCountingOQ06
+
+/-- **Necklace count at a prime length collapses to two terms.**
+For prime `p`, the number of `k`-colored `p`-bead necklaces (orbits of cyclic rotation)
+times `p` equals `φ(p)·k + k^p`. This is the `n = p` case of the divisor-sum formula
+`(#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d`, where only the divisors `1` and `p` survive. -/
+theorem necklaces_mul_prime_eq (p k : ℕ) (hp : p.Prime) :
+    Nat.card (orbitRel.Quotient (Rot p) (Rot p → Fin k)) * p
+      = Nat.totient p * k + k ^ p := by
+  haveI : NeZero p := ⟨hp.pos.ne'⟩
+  rw [card_necklaces_mul_eq_sum_divisors, hp.divisors,
+    Finset.sum_pair hp.one_lt.ne,
+    Nat.div_one, Nat.div_self hp.pos, Nat.totient_one]
+  ring
+
+/-- **Fermat's little theorem (necklace proof).** For prime `p`, `p ∣ k^p − k` over `ℤ`.
+The explicit witness is the number of `k`-colored `p`-bead necklaces minus `k`: since
+`(#necklaces)·p = φ(p)·k + k^p` and `φ(p) + 1 = p`, one has
+`k^p − k = p · (#necklaces − k)`. -/
+theorem fermat_little (p k : ℕ) (hp : p.Prime) :
+    (p : ℤ) ∣ (k : ℤ) ^ p - k := by
+  set N := Nat.card (orbitRel.Quotient (Rot p) (Rot p → Fin k)) with hNdef
+  have htot : Nat.totient p + 1 = p := by
+    have h := Nat.totient_prime hp; have := hp.pos; omega
+  refine ⟨(N : ℤ) - k, ?_⟩
+  have h1 : (N : ℤ) * p = (Nat.totient p : ℤ) * k + (k : ℤ) ^ p := by
+    exact_mod_cast necklaces_mul_prime_eq p k hp
+  have h2 : (Nat.totient p : ℤ) + 1 = p := by exact_mod_cast htot
+  linear_combination -h1 - (k : ℤ) * h2
+
+/-- **Fermat's little theorem, congruence form.** `k^p ≡ k [MOD p]` for prime `p`. -/
+theorem fermat_little_modEq (p k : ℕ) (hp : p.Prime) : k ^ p ≡ k [MOD p] := by
+  rw [Nat.modEq_iff_dvd]
+  have h := fermat_little p k hp
+  push_cast
+  exact (dvd_sub_comm).mp h
+
+/-- **`ZMod p` form, recovered from the necklace count.** `(k : ZMod p)^p = k`.
+This is the statement of Mathlib's `ZMod.pow_card`, but obtained here from the
+combinatorial necklace identity, confirming the two derivations agree. -/
+theorem pow_card_eq (p k : ℕ) (hp : p.Prime) : (k : ZMod p) ^ p = k := by
+  have h : ((((k : ℤ) ^ p - k : ℤ)) : ZMod p) = 0 := by
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
+    exact_mod_cast fermat_little p k hp
+  push_cast at h
+  linear_combination h
+
+end BurnsideCountingOQ06

--- a/src/data/proofs/burnside-counting-oq-06/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "burnside-counting-oq-06",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "context",
+    "title": "The Necklace Proof of Fermat's Little Theorem",
+    "content": "The module docstring lays out the classical combinatorial argument. Color the $p$ beads of a circular necklace with $k$ colors: there are $k^p$ colorings, and the cyclic group of $p$ rotations acts on them. Because $p$ is prime, every non-constant coloring sits in an orbit of exactly $p$ rotations, while the $k$ constant colorings are fixed — so the $k^p-k$ non-constant colorings split into orbits of size $p$, forcing $p\\mid k^p-k$. Formally this entry obtains the same conclusion by specializing the gallery's divisor-form count $(\\#\\text{necklaces})\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)k^d$ to a prime $n=p$, where only $d=1$ and $d=p$ survive: $(\\#\\text{necklaces})\\cdot p = (p-1)k + k^p$.",
+    "mathContext": "$(\\#\\text{necklaces})\\cdot p = \\varphi(p)\\,k + k^p = (p-1)k + k^p$",
+    "significance": "context",
+    "relatedConcepts": ["Fermat's little theorem", "necklace counting", "Burnside's lemma", "cyclic group action", "Euler's totient"],
+    "prerequisites": ["Burnside/orbit counting", "prime numbers"]
+  },
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "burnside-counting-oq-06",
+    "range": { "startLine": 46, "endLine": 50 },
+    "type": "context",
+    "title": "Imports: the Reused Divisor-Form Necklace Count",
+    "content": "The single piece of gallery infrastructure this entry consumes is `card_necklaces_mul_eq_sum_divisors` from `BurnsideCountingOQ03OQ02OQ01OQ02` — the textbook divisor form $(\\#\\text{necklaces})\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)k^d$ of the cyclic necklace count. The selective `open BurnsideCountingOQ03OQ02OQ01 (Rot)` brings the rotation action $\\mathrm{Rot}\\,n = \\mathrm{Multiplicative}(\\mathbb{Z}/n)$ into scope so the orbit space `orbitRel.Quotient (Rot p) (Rot p → Fin k)` — the set of $k$-colored $p$-bead necklaces — can be named. `open Finset MulAction` supplies $\\sum$ notation and the orbit-space construction.",
+    "mathContext": "$\\mathrm{Rot}\\,n = \\mathrm{Multiplicative}(\\mathbb{Z}/n),\\quad (\\#\\text{necklaces})\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)k^d$",
+    "significance": "technical",
+    "relatedConcepts": ["module dependencies", "MulAction", "orbit space", "namespace management"],
+    "prerequisites": ["Lean 4 module system", "Mathlib big operators"]
+  },
+  {
+    "id": "ann-prime-collapse",
+    "proofId": "burnside-counting-oq-06",
+    "range": { "startLine": 52, "endLine": 63 },
+    "type": "technique",
+    "title": "Collapsing the Divisor Sum at a Prime",
+    "content": "`necklaces_mul_prime_eq` is the combinatorial core. After rewriting the necklace count by `card_necklaces_mul_eq_sum_divisors`, `Nat.Prime.divisors` replaces $p.\\text{divisors}$ with the explicit pair $\\{1,p\\}$, and `Finset.sum_pair` (whose hypothesis $1\\neq p$ is `hp.one_lt.ne`) evaluates the two-element sum to $\\varphi(p/1)\\cdot k^1 + \\varphi(p/p)\\cdot k^p$. The rewrites `Nat.div_one` ($p/1 = p$), `Nat.div_self` ($p/p = 1$), and `Nat.totient_one` ($\\varphi(1)=1$) reduce this to $\\varphi(p)\\cdot k + 1\\cdot k^p$, and `ring` normalizes it to $\\varphi(p)\\cdot k + k^p$. The `NeZero p` instance needed by the divisor-form lemma is supplied from `hp.pos`.",
+    "mathContext": "$\\sum_{d\\mid p}\\varphi(p/d)k^d = \\varphi(p)\\,k + k^p$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.Prime.divisors", "Finset.sum_pair", "Euler's totient", "two-term sum"],
+    "prerequisites": ["divisors of a prime", "finite sums over a pair"]
+  },
+  {
+    "id": "ann-fermat",
+    "proofId": "burnside-counting-oq-06",
+    "range": { "startLine": 65, "endLine": 78 },
+    "type": "key-step",
+    "title": "From the Count to p ∣ kᵖ − k",
+    "content": "`fermat_little` extracts Fermat's theorem with an explicit witness. Set $N = \\#\\text{necklaces}$. The two facts cast to $\\mathbb{Z}$ are `h1`: $N\\cdot p = \\varphi(p)\\cdot k + k^p$ (from `necklaces_mul_prime_eq`) and `h2`: $\\varphi(p) + 1 = p$ (from `Nat.totient_prime`, with `hp.pos` so the truncated subtraction $p-1$ behaves). The claimed witness is $N - k$, and the identity to verify is $k^p - k = p\\,(N-k)$. Algebraically $k^p - k = N\\cdot p - \\varphi(p)\\cdot k - k = N\\cdot p - (\\varphi(p)+1)k = N\\cdot p - p\\cdot k = p(N-k)$; the single `linear_combination -h1 - k*h2` discharges exactly this combination of `h1` and `h2`.",
+    "mathContext": "$k^p - k = N\\cdot p - (\\varphi(p)+1)k = p\\,(N-k)$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat's little theorem", "explicit divisibility witness", "linear_combination", "Nat.totient_prime"],
+    "prerequisites": ["integer divisibility", "casting ℕ identities to ℤ"]
+  },
+  {
+    "id": "ann-modeq-zmod",
+    "proofId": "burnside-counting-oq-06",
+    "range": { "startLine": 80, "endLine": 95 },
+    "type": "technique",
+    "title": "Congruence and Finite-Field Forms",
+    "content": "Two standard repackagings of the divisibility. `fermat_little_modEq` rewrites $k^p \\equiv k \\;[\\mathrm{MOD}\\,p]$ via `Nat.modEq_iff_dvd` into $(p:\\mathbb{Z})\\mid k - k^p$, which is `dvd_sub_comm` applied to `fermat_little`'s $(p:\\mathbb{Z})\\mid k^p - k$. `pow_card_eq` recovers the finite-field identity $(k:\\mathbb{Z}/p)^p = k$: casting $k^p - k$ into $\\mathbb{Z}/p$ and using `ZMod.intCast_zmod_eq_zero_iff_dvd` turns the divisibility into $((k:\\mathbb{Z})^p - k : \\mathbb{Z}/p) = 0$, and `push_cast` + `linear_combination` read off $(k:\\mathbb{Z}/p)^p = k$. This is the statement of Mathlib's `ZMod.pow_card`, but produced from the necklace count rather than from the algebraic Frobenius proof.",
+    "mathContext": "$k^p \\equiv k \\pmod p \\;\\Longleftrightarrow\\; (k:\\mathbb{Z}/p)^p = k$",
+    "significance": "important",
+    "relatedConcepts": ["Nat.ModEq", "ZMod.pow_card", "ZMod.intCast_zmod_eq_zero_iff_dvd", "dvd_sub_comm"],
+    "prerequisites": ["modular congruence", "casting into ZMod p"]
+  }
+]

--- a/src/data/proofs/burnside-counting-oq-06/index.ts
+++ b/src/data/proofs/burnside-counting-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BurnsideCountingOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const burnsideCountingOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const burnsideCountingOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const burnsideCountingOq06Data: ProofData = {
+  proof: burnsideCountingOq06Proof,
+  annotations: burnsideCountingOq06Annotations,
+}

--- a/src/data/proofs/burnside-counting-oq-06/meta.json
+++ b/src/data/proofs/burnside-counting-oq-06/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "burnside-counting-oq-06",
+  "title": "Fermat's Little Theorem via Necklace Counting: p ∣ kᵖ − k",
+  "slug": "burnside-counting-oq-06",
+  "description": "Closes the Burnside necklace-counting branch with its most famous number-theoretic consequence — Fermat's little theorem — derived purely from the cyclic orbit count. The gallery already builds the full cyclic necklace machinery and the divisor-sum form (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d (burnside-counting-oq-03-oq-02-oq-01-oq-02). Specializing the bead count n to a prime p collapses the divisor sum to its two surviving terms d = 1 and d = p: (#necklaces)·p = φ(p)·k + φ(1)·k^p = (p−1)·k + k^p. Since the left side is a multiple of p, p ∣ k^p + (p−1)·k = (k^p − k) + p·k, hence p ∣ k^p − k — Fermat's little theorem, with the integer #necklaces − k as an explicit divisibility witness. Provides necklaces_mul_prime_eq (the two-term collapse), fermat_little (the ℤ divisibility), fermat_little_modEq (the k^p ≡ k [MOD p] congruence), and pow_card_eq ((k : ZMod p)^p = k) — the last recovered from the necklace identity rather than Mathlib's algebraic ZMod.pow_card, confirming the combinatorial and algebraic routes agree.",
+  "meta": {
+    "author": "Classical (necklace / orbit-counting proof of Fermat's little theorem; cf. Golomb 1956); formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Proofs_of_Fermat%27s_little_theorem#Proof_by_counting_necklaces",
+    "date": "1640",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ06.lean",
+    "tags": [
+      "combinatorics",
+      "group-theory",
+      "number-theory",
+      "necklaces",
+      "burnside",
+      "orbit-counting",
+      "cyclic-group",
+      "fermat-little-theorem",
+      "totient",
+      "divisor-sum",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. Fully machine-checked: all four theorems (necklaces_mul_prime_eq, fermat_little, fermat_little_modEq, pow_card_eq) depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide is used.",
+    "dateAdded": "2026-06-25",
+    "lineCount": 97,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime.divisors",
+        "description": "p.divisors = {1, p} for prime p — collapses the divisor sum ∑_{d∣p} φ(p/d)·k^d to its two surviving terms",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Nat.totient_prime",
+        "description": "φ(p) = p − 1 for prime p — supplies the coefficient of k in the two-term collapse and the identity φ(p) + 1 = p used to factor k^p − k = p·(#necklaces − k)",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.sum_pair",
+        "description": "∑_{x ∈ {a,b}} f x = f a + f b for a ≠ b — evaluates the two-element divisor sum over {1, p}",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Nat.modEq_iff_dvd",
+        "description": "a ≡ b [MOD n] ↔ (n : ℤ) ∣ b − a — bridges the integer divisibility p ∣ k^p − k to the congruence form k^p ≡ k [MOD p]",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(↑a : ZMod n) = 0 ↔ (n : ℤ) ∣ a — recovers (k : ZMod p)^p = k from the integer divisibility, cross-checking against Mathlib's algebraic ZMod.pow_card",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "BurnsideCountingOQ03OQ02OQ01OQ02.card_necklaces_mul_eq_sum_divisors",
+        "description": "(#necklaces up to rotation)·n = ∑_{d∣n} φ(n/d)·k^d — the gallery's divisor-form cyclic necklace count, specialized here at the prime n = p",
+        "module": "Proofs.BurnsideCountingOQ03OQ02OQ01OQ02"
+      }
+    ],
+    "originalContributions": [
+      "necklaces_mul_prime_eq: (#necklaces of k-colored p-bead rotations)·p = φ(p)·k + k^p for prime p — the n = p case of the divisor-sum necklace count, where Nat.Prime.divisors reduces ∑_{d∣p} to the two terms d = 1, d = p (evaluated by Finset.sum_pair, Nat.div_one, Nat.div_self, Nat.totient_one)",
+      "fermat_little: (p : ℤ) ∣ k^p − k for prime p — Fermat's little theorem, with #necklaces − k as an explicit witness; from necklaces_mul_prime_eq and φ(p) + 1 = p one gets k^p − k = p·(#necklaces − k), closed by a single linear_combination over ℤ",
+      "fermat_little_modEq: k^p ≡ k [MOD p] — the congruence form, obtained from the ℤ divisibility via Nat.modEq_iff_dvd and dvd_sub_comm",
+      "pow_card_eq: (k : ZMod p)^p = k — the finite-field power identity recovered from the necklace count through ZMod.intCast_zmod_eq_zero_iff_dvd, confirming the combinatorial derivation agrees with Mathlib's algebraic ZMod.pow_card rather than invoking it"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Counting necklaces gives one of the most elegant proofs of Fermat's little theorem, usually credited in this combinatorial form to Solomon Golomb (1956) and a staple of every account of the theorem's many proofs. Arrange p beads in a circle and color each with one of k colors: there are k^p colorings, and the cyclic group of p rotations acts on them. Because p is prime, every non-constant coloring has a full orbit of exactly p rotations, while the k constant colorings are fixed; so k^p − k splits into orbits of size p and is therefore divisible by p. The gallery's Burnside chain had already built the cyclic necklace count and pushed it to the divisor form (1/n)·∑_{d∣n} φ(n/d) k^d, but never drew out this prime specialization. This entry supplies it, obtaining Fermat's little theorem as a one-line corollary of the orbit count.",
+    "problemStatement": "Specialize the cyclic necklace count to a prime bead length p and extract Fermat's little theorem: prove (#necklaces of k-colored p-bead rotations)·p = φ(p)·k + k^p, and deduce p ∣ k^p − k, the congruence k^p ≡ k [MOD p], and the ZMod p identity (k : ZMod p)^p = k — the last derived from the necklace count rather than from Mathlib's ZMod.pow_card.",
+    "proofStrategy": "**Two-term collapse (necklaces_mul_prime_eq).** Start from the gallery's divisor-form necklace count card_necklaces_mul_eq_sum_divisors: (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d. At n = p prime, Nat.Prime.divisors gives p.divisors = {1, p}, and Finset.sum_pair (using 1 ≠ p from hp.one_lt) evaluates the two-element sum to φ(p/1)·k^1 + φ(p/p)·k^p. Rewriting with Nat.div_one, Nat.div_self, and Nat.totient_one leaves φ(p)·k + k^p (closed by ring).\n\n**Fermat divisibility (fermat_little).** Let N = #necklaces. From necklaces_mul_prime_eq, N·p = φ(p)·k + k^p over ℤ; Nat.totient_prime gives φ(p) + 1 = p. The witness N − k works: k^p − k = N·p − φ(p)·k − k = N·p − (φ(p)+1)·k = N·p − p·k = p·(N − k), verified by a single linear_combination of the two facts.\n\n**Congruence and ZMod forms.** fermat_little_modEq rewrites k^p ≡ k [MOD p] via Nat.modEq_iff_dvd to (p:ℤ) ∣ k − k^p and supplies it as dvd_sub_comm of the divisibility. pow_card_eq casts k^p − k ≡ 0 in ZMod p through ZMod.intCast_zmod_eq_zero_iff_dvd and reads off (k : ZMod p)^p = k by push_cast — recovering the statement of ZMod.pow_card from the necklace count instead of invoking it.",
+    "keyInsights": [
+      "**Fermat is the prime case of one orbit count.** The whole proof is the divisor sum ∑_{d∣n} φ(n/d) k^d evaluated at n = p: only d = 1 and d = p survive, giving (p−1)·k + k^p, and divisibility of the left side by p is Fermat's little theorem.",
+      "**The witness is geometric, not arithmetic.** The integer certifying p ∣ k^p − k is literally #necklaces − k — the number of non-constant necklaces — making explicit that k^p − k counts the non-fixed colorings, partitioned into orbits of size p.",
+      "**φ(p) + 1 = p is the only arithmetic input to the corollary.** Once the two-term count is in hand, k^p − k = p·(#necklaces − k) is pure algebra: (φ(p)+1)·k = p·k folds the φ(p)·k term and the −k together into −p·k.",
+      "**Combinatorics reproduces the field identity.** Deriving (k : ZMod p)^p = k from the necklace count, rather than from ZMod.pow_card, exhibits the orbit-counting proof and the Frobenius/field-theoretic proof as two routes to the same congruence."
+    ],
+    "prerequisites": [
+      "The gallery's divisor-form cyclic necklace count card_necklaces_mul_eq_sum_divisors (burnside-counting-oq-03-oq-02-oq-01-oq-02), itself built on Burnside's lemma",
+      "Elementary prime arithmetic: Nat.Prime.divisors (p.divisors = {1,p}) and Nat.totient_prime (φ(p) = p−1)",
+      "Two-element finite sums (Finset.sum_pair) and integer linear_combination reasoning",
+      "The dictionary between integer divisibility, Nat.ModEq, and vanishing in ZMod p (Nat.modEq_iff_dvd, ZMod.intCast_zmod_eq_zero_iff_dvd)"
+    ],
+    "what": "For prime p and any color count k: the cyclic necklace count times p equals φ(p)·k + k^p; consequently p ∣ k^p − k (Fermat's little theorem), k^p ≡ k [MOD p], and (k : ZMod p)^p = k — all with 0 axioms and 0 sorries.",
+    "how": "Specialize the divisor-form necklace count at the prime n = p (Nat.Prime.divisors collapses ∑_{d∣p} to {1,p}, evaluated by Finset.sum_pair) to get (#necklaces)·p = φ(p)·k + k^p; then φ(p)+1 = p turns this into k^p − k = p·(#necklaces − k) by one linear_combination, and the congruence and ZMod forms follow by the standard divisibility dictionary.",
+    "significance": "Caps the gallery's Burnside necklace chain with its headline number-theoretic payoff: Fermat's little theorem as a direct corollary of the cyclic orbit count, not a separate algebraic development. It makes the classical 'necklace proof' fully machine-checked and axiom-free, exhibits an explicit combinatorial witness (#necklaces − k) for the divisibility, and — by re-deriving (k : ZMod p)^p = k from the count — ties the gallery's combinatorial orbit-counting machinery to the finite-field identity Mathlib proves algebraically via Frobenius."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and the Combinatorial Argument",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring: the necklace proof of Fermat's little theorem. The cyclic rotation group acts on k-colored p-bead colorings; specializing the divisor-form count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d to a prime n = p collapses it to (#necklaces)·p = (p−1)·k + k^p, whence p ∣ k^p − k. Lists the four results.",
+      "mathContext": "$(\\#\\text{necklaces})\\cdot p = (p-1)k + k^p \\Rightarrow p \\mid k^p - k$"
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and the Reused Necklace Count",
+      "startLine": 46,
+      "endLine": 50,
+      "summary": "Selectively opens Rot (the cyclic rotation action) from BurnsideCountingOQ03OQ02OQ01 and card_necklaces_mul_eq_sum_divisors (the divisor-form necklace count) from BurnsideCountingOQ03OQ02OQ01OQ02 — the single gallery lemma this entry specializes — together with Finset and MulAction for ∑ notation and the orbitRel.Quotient orbit space.",
+      "mathContext": "$(\\#\\text{necklaces})\\cdot n = \\sum_{d\\mid n}\\varphi(n/d)\\,k^d$"
+    },
+    {
+      "id": "prime-collapse",
+      "title": "Necklace Count at a Prime Length",
+      "startLine": 52,
+      "endLine": 63,
+      "summary": "necklaces_mul_prime_eq: at the prime n = p, Nat.Prime.divisors gives p.divisors = {1,p}; Finset.sum_pair (with 1 ≠ p from hp.one_lt) evaluates the two-term sum, and Nat.div_one / Nat.div_self / Nat.totient_one reduce it to φ(p)·k + k^p (closed by ring).",
+      "mathContext": "$(\\#\\text{necklaces})\\cdot p = \\varphi(p)\\,k + k^p$"
+    },
+    {
+      "id": "fermat",
+      "title": "Fermat's Little Theorem (Integer Divisibility)",
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "fermat_little: with N = #necklaces and φ(p) + 1 = p (Nat.totient_prime), the witness N − k satisfies k^p − k = p·(N − k); the equality is discharged by a single linear_combination of N·p = φ(p)·k + k^p and φ(p) + 1 = p over ℤ.",
+      "mathContext": "$k^p - k = p\\,(\\#\\text{necklaces} - k)$"
+    },
+    {
+      "id": "modeq-zmod",
+      "title": "Congruence and ZMod p Forms",
+      "startLine": 80,
+      "endLine": 95,
+      "summary": "fermat_little_modEq rephrases the divisibility as k^p ≡ k [MOD p] (Nat.modEq_iff_dvd, dvd_sub_comm); pow_card_eq recovers (k : ZMod p)^p = k by casting k^p − k ≡ 0 through ZMod.intCast_zmod_eq_zero_iff_dvd — the statement of ZMod.pow_card, obtained from the necklace count rather than invoked.",
+      "mathContext": "$k^p \\equiv k \\pmod p,\\qquad (k : \\mathbb{Z}/p)^p = k$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Specializes the gallery's divisor-form cyclic necklace count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d to a prime bead length n = p, where the divisor sum collapses to the two terms (#necklaces)·p = φ(p)·k + k^p (necklaces_mul_prime_eq). As the left side is a multiple of p and φ(p) + 1 = p, one factors k^p − k = p·(#necklaces − k), giving Fermat's little theorem p ∣ k^p − k (fermat_little) with #necklaces − k as an explicit witness, the congruence k^p ≡ k [MOD p] (fermat_little_modEq), and the field identity (k : ZMod p)^p = k (pow_card_eq). Fully verified with 0 sorries and 0 axioms.",
+    "implications": "Turns the classical 'necklace proof' of Fermat's little theorem into a machine-checked, axiom-free corollary of the gallery's own Burnside orbit count, with the number of non-constant necklaces serving as the divisibility certificate. Recovering (k : ZMod p)^p = k from the count, instead of from Mathlib's algebraic ZMod.pow_card, links the combinatorial orbit-counting line to the finite-field Frobenius proof of the same congruence.",
+    "openQuestions": [
+      "Extend the prime-length specialization to a prime-power or square-free modulus to recover Euler's theorem k^{φ(n)} ≡ 1 (for gcd(k,n)=1) or the Korselt/Carmichael criterion from the same divisor-sum count.",
+      "Pair the totient necklace count with its Möbius companion (1/n)·∑_{d∣n} μ(d) k^{n/d} (aperiodic necklaces / Lyndon words) and show both specialize at a prime p to k^p ≡ k, exhibiting the Fermat congruence from the two classical closed forms."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-burnside-oq0302010102-divisor-count",
+      "targetId": "burnside-counting-oq-03-oq-02-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Specializes that entry's divisor-form cyclic necklace count (#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d at the prime n = p, where Nat.Prime.divisors collapses the sum to two terms and yields Fermat's little theorem."
+    },
+    {
+      "id": "xref-burnside-root",
+      "targetId": "burnside-counting",
+      "relationship": "extends",
+      "description": "Adds the number-theoretic payoff of the root entry's Burnside/necklace-counting framework: Fermat's little theorem p ∣ k^p − k as the prime-length case of the cyclic orbit count."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 97,
+    "path": "Proofs/BurnsideCountingOQ06.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the Burnside necklace-counting branch of the gallery with its headline number-theoretic consequence: **Fermat's little theorem**, derived purely from the cyclic orbit count.

The gallery already builds the divisor-form cyclic necklace count `(#necklaces)·n = ∑_{d∣n} φ(n/d)·k^d` (burnside-counting-oq-03-oq-02-oq-01-oq-02). Specializing the bead length `n` to a **prime** `p` collapses the divisor sum to its two surviving terms `d = 1, p`:

```
(#necklaces)·p = φ(p)·k + φ(1)·k^p = (p−1)·k + k^p
```

The left side is a multiple of `p`, so `p ∣ k^p + (p−1)·k = (k^p − k) + p·k`, hence **`p ∣ k^p − k`** — with the integer `#necklaces − k` as an explicit divisibility witness.

## Theorems (`proofs/Proofs/BurnsideCountingOQ06.lean`)

| Theorem | Statement |
|---|---|
| `necklaces_mul_prime_eq` | `(#necklaces of k-colored p-bead rotations)·p = φ(p)·k + k^p` (prime `p`) |
| `fermat_little` | `(p : ℤ) ∣ k^p − k`, witness `#necklaces − k` |
| `fermat_little_modEq` | `k^p ≡ k [MOD p]` |
| `pow_card_eq` | `(k : ZMod p)^p = k` — recovered from the necklace count, not Mathlib's `ZMod.pow_card` |

## Verification

- **0 axioms, 0 sorries.** All four theorems depend only on `propext`, `Classical.choice`, `Quot.sound` (checked via `#print axioms`). No `native_decide`.
- Compiles offline against the cached Mathlib (`lake env lean`; Docker was unavailable this session).

## Why this is fresh

The Burnside chain had the full necklace machinery and divisor-sum form but **never recorded the prime specialization or the Fermat corollary**. Mathlib proves `ZMod.pow_card` algebraically (Frobenius); here the same congruence is obtained combinatorially from the gallery's own orbit count.

## Note on the candidate batch

Three sibling candidates minted in the same seeker round were found to be **duplicates of already-verified parent theorems** and skipped rather than re-formalized:
- `fibonacci-identities-oq-06` = `FibonacciIdentities.fib_sum_sq` (existing)
- `chebyshev-bounds-oq-06` = `ChebyshevBounds.centralBinom_le_four_pow` + `centralBinom_ge_four_pow_div` (existing)
- `combinations-formula-oq-10` = range-form Vandermonde already in `CombinationsFormulaOQ01/OQ07/OQ07OQ02`

🤖 Generated with [Claude Code](https://claude.com/claude-code)