### PR TITLE
Enrich The Flat Limit of sin_κ (cevas-theorem-non-euclidean-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CevasTheoremNonEuclideanOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cevasTheoremNonEuclideanOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cevasTheoremNonEuclideanOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cevasTheoremNonEuclideanOq01Oq01Data: ProofData = {
+  proof: cevasTheoremNonEuclideanOq01Oq01Proof,
+  annotations: cevasTheoremNonEuclideanOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cevas-theorem-non-euclidean-oq-01-oq-01`.

## Quality improvements
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing.
- **Structured annotation fields** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation (previously none had them).
- **Better coverage** — added a geometric overview annotation for the header/docstring, and split the single dense gluing annotation into a one-sided-limits annotation plus the filter-gluing annotation. Annotation count 4 → 6.

Content is mathematically accurate to the Lean source (curvature sine flat limit via difference quotients, √κ change of variables, filter gluing, Ceva-ratio degeneration). meta.json was already rich and left intact.