### PR TITLE
research(stars-and-bars-weak-compositions-oq-03): weak↔positive composition ±1 bijection [verified, 0 axiom]

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ03.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ03.lean
@@ -1,0 +1,124 @@
+import Mathlib.Data.Sym.Card
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositions
+
+/-
+# Stars-and-Bars Duality: weak ↔ positive compositions via an explicit `±1` bijection
+
+## What This Proves
+
+A *weak composition* of `m` into `k` parts is a function `f : Fin k → ℕ` with
+`∑ i, f i = m` (zero parts allowed). A *positive* (or *strict*) composition of `n`
+into `k` parts is a function `g : Fin k → ℕ` with every `g i ≥ 1` and `∑ i, g i = n`.
+
+The classical duality between the two is the per-coordinate shift `g i = f i + 1`:
+adding `1` to each of the `k` parts of a weak composition of `m` turns it into a
+positive composition of `m + k`, and this is a bijection. Equivalently, subtracting
+`1` from each part of a positive composition of `n` (legal because every part is
+`≥ 1`) gives a weak composition of `n - k`.
+
+This file records that bijection explicitly,
+
+  `positiveCompositionEquivWeak : {g // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n}`
+                                   `≃ {f : Fin k → ℕ // ∑ i, f i = n - k}`  (for `k ≤ n`),
+
+and reads off the resulting count of positive compositions through the parent
+stars-and-bars theorem `card_weakComposition`:
+
+  number of positive compositions of `n` into `k` parts `= C(n - 1, k - 1)`   (`0 < k ≤ n`).
+
+## What this adds over the parent
+
+The parent `StarsAndBarsWeakCompositions` counts *weak* compositions
+(`C(n + k - 1, n)`). The standard "compositions of `n` into exactly `k` positive
+parts" count `C(n - 1, k - 1)` is the dual statement; the bridge is precisely the
+`±1` bijection. Mathlib has neither the positive-composition tuple count nor this
+explicit shift equivalence, so both are supplied here. Everything is fully
+machine-checked with no axioms.
+-/
+
+open Finset
+
+namespace StarsAndBars
+
+variable {k n : ℕ}
+
+/-- Subtracting `1` from each part of a positive composition of `n` lands in a weak
+composition of `n - k`: with every part `≥ 1`, the truncated subtraction is exact and
+`∑ i, (g i - 1) = (∑ i, g i) - k = n - k`. -/
+private theorem sum_sub_one (g : Fin k → ℕ) (h1 : ∀ i, 1 ≤ g i) :
+    (∑ i, (g i - 1)) = (∑ i, g i) - k := by
+  have key : (∑ i, (g i - 1)) + k = ∑ i, g i := by
+    have : (∑ i, (g i - 1)) + ∑ _i : Fin k, 1 = ∑ i, ((g i - 1) + 1) := by
+      rw [← Finset.sum_add_distrib]
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul, mul_one] at this
+    rw [this]
+    refine Finset.sum_congr rfl ?_
+    intro i _
+    rw [Nat.sub_add_cancel (h1 i)]
+  omega
+
+/-- **The `±1` duality, as an explicit bijection.** For `k ≤ n`, positive
+compositions of `n` into `k` parts biject with weak compositions of `n - k` into `k`
+parts. The map subtracts `1` from each part; its inverse adds `1` back. -/
+def positiveCompositionEquivWeak (k n : ℕ) (hkn : k ≤ n) :
+    {g : Fin k → ℕ // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n} ≃
+      {f : Fin k → ℕ // ∑ i, f i = n - k} where
+  toFun g := ⟨fun i => g.1 i - 1, by
+    rw [sum_sub_one g.1 g.2.1, g.2.2]⟩
+  invFun f := ⟨fun i => f.1 i + 1, by
+    refine ⟨fun i => Nat.le_add_left 1 (f.1 i), ?_⟩
+    rw [Finset.sum_add_distrib, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+      smul_eq_mul, mul_one, f.2]
+    omega⟩
+  left_inv := by
+    rintro ⟨g, hg1, -⟩
+    apply Subtype.ext
+    funext i
+    show g i - 1 + 1 = g i
+    exact Nat.sub_add_cancel (hg1 i)
+  right_inv := by
+    rintro ⟨f, -⟩
+    apply Subtype.ext
+    funext i
+    show f i + 1 - 1 = f i
+    omega
+
+/-- The positive-composition subtype is finite. -/
+instance instFintypePositiveComposition (k n : ℕ) :
+    Fintype {g : Fin k → ℕ // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n} :=
+  if hkn : k ≤ n then
+    Fintype.ofEquiv _ (positiveCompositionEquivWeak k n hkn).symm
+  else by
+    -- when `k > n` there are no positive compositions: the subtype is empty
+    have hnk : n < k := lt_of_not_ge hkn
+    have : IsEmpty {g : Fin k → ℕ // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n} := by
+      refine ⟨fun g => ?_⟩
+      have hlt : n < ∑ i, g.1 i := by
+        calc n < k := hnk
+          _ = ∑ _i : Fin k, 1 := by
+                rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul, mul_one]
+          _ ≤ ∑ i, g.1 i := Finset.sum_le_sum (fun i _ => g.2.1 i)
+      exact absurd g.2.2 (by omega)
+    exact Fintype.ofIsEmpty
+
+/-- **Count of positive compositions, raw form.** For `k ≤ n`, the number of positive
+compositions of `n` into `k` parts equals the number of weak compositions of `n - k`,
+namely `C((n - k) + k - 1, n - k)`. -/
+theorem card_positiveComposition_eq_weak (k n : ℕ) (hkn : k ≤ n) :
+    Fintype.card {g : Fin k → ℕ // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n} =
+      ((n - k) + k - 1).choose (n - k) := by
+  rw [Fintype.card_congr (positiveCompositionEquivWeak k n hkn), card_weakComposition]
+
+/-- **Count of positive compositions, classical form.** For `0 < k ≤ n`, the number of
+positive compositions of `n` into `k` parts is `C(n - 1, k - 1)`. -/
+theorem card_positiveComposition (k n : ℕ) (hk : 0 < k) (hkn : k ≤ n) :
+    Fintype.card {g : Fin k → ℕ // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n} =
+      (n - 1).choose (k - 1) := by
+  rw [card_positiveComposition_eq_weak k n hkn]
+  have hn : 1 ≤ n := le_trans hk hkn
+  -- `(n - k) + k - 1 = n - 1` and `C(n-1, n-k) = C(n-1, (n-1)-(n-k)) = C(n-1, k-1)`.
+  have e1 : (n - k) + k - 1 = n - 1 := by omega
+  rw [e1, show k - 1 = (n - 1) - (n - k) by omega, Nat.choose_symm (by omega : n - k ≤ n - 1)]
+
+end StarsAndBars

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-03/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-03/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions-oq-03",
+    "range": {
+      "startLine": 4,
+      "endLine": 38
+    },
+    "type": "context",
+    "title": "The duality and what it adds over the parent",
+    "content": "The header fixes the two objects — weak compositions f : Fin k → ℕ with ∑ f = m (zero parts allowed) and positive compositions g with every g(i) ≥ 1 and ∑ g = n — and states the duality between them as the per-coordinate shift g(i) = f(i) + 1. Adding 1 to each of the k parts of a weak composition of m gives a positive composition of m + k; subtracting 1 (legal because parts are ≥ 1) inverts it. The parent stars-and-bars-weak-compositions counts the weak side as C(n+k−1, n) and explicitly poses this duality as an open question; this entry resolves it with the explicit bijection positiveCompositionEquivWeak and reads off the positive-parts count C(n−1, k−1). Mathlib has neither the positive tuple count nor the shift equivalence.",
+    "mathContext": "$\\{g \\mid (\\forall i,\\,g(i)\\ge1)\\wedge\\sum_i g(i)=n\\} \\simeq \\{f \\mid \\sum_i f(i)=n-k\\}$ via $g(i)\\mapsto g(i)-1$, for $k \\le n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "weak composition",
+      "positive composition",
+      "stars and bars",
+      "bijective proof"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "truncated natural subtraction"
+    ]
+  },
+  {
+    "id": "ann-shift-arithmetic",
+    "proofId": "stars-and-bars-weak-compositions-oq-03",
+    "range": {
+      "startLine": 44,
+      "endLine": 62
+    },
+    "type": "technique",
+    "title": "Exactness of the per-part shift",
+    "content": "sum_sub_one is the arithmetic core: when every part satisfies g(i) ≥ 1, subtracting 1 from each of the k parts lowers the total by exactly k, so ∑ᵢ (g(i) − 1) = (∑ᵢ g(i)) − k. The proof avoids reasoning directly about truncated subtraction inside a sum: it proves the additive form ∑ᵢ (g(i) − 1) + k = ∑ᵢ g(i) instead. Here k is rewritten as ∑ᵢ 1 over Fin k (Finset.sum_const + Fintype.card_fin), the two sums merge under Finset.sum_add_distrib into ∑ᵢ ((g(i) − 1) + 1), and Nat.sub_add_cancel applied with the part bound collapses each summand back to g(i); omega then discharges the subtraction. This 'clear the truncated subtraction additively' move is the standard way to keep ℕ-subtraction honest.",
+    "mathContext": "$\\sum_i (g(i)-1) + k = \\sum_i g(i)$, hence $\\sum_i (g(i)-1) = \\left(\\sum_i g(i)\\right) - k$ when $\\forall i,\\ g(i)\\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "truncated subtraction",
+      "Finset.sum_add_distrib",
+      "Nat.sub_add_cancel"
+    ],
+    "prerequisites": [
+      "Finset sums over a Fintype",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-the-bijection",
+    "proofId": "stars-and-bars-weak-compositions-oq-03",
+    "range": {
+      "startLine": 64,
+      "endLine": 86
+    },
+    "type": "technique",
+    "title": "The ±1 bijection, built by hand",
+    "content": "positiveCompositionEquivWeak is the explicit Equiv. Forward: g ↦ (i ↦ g(i) − 1), which sums to n − k by sum_sub_one together with ∑ g = n. Inverse: f ↦ (i ↦ f(i) + 1), positive by Nat.le_add_left and summing to (n − k) + k = n via Finset.sum_add_distrib and the hypothesis k ≤ n (this is precisely where k ≤ n is needed — it makes the truncated (n − k) + k equal n on the nose). The two round-trips are pointwise identities: (g(i) − 1) + 1 = g(i) by Nat.sub_add_cancel using the part bound, and (f(i) + 1) − 1 = f(i) by omega. Each is preceded by a `show` that beta-reduces the subtype coercions so the bare arithmetic lemma unifies with the goal — without it the goal is stuck on an unreduced `↑(toFun (invFun …))` redex.",
+    "mathContext": "$\\mathrm{toFun}\\,g = (i\\mapsto g(i)-1)$, $\\mathrm{invFun}\\,f = (i\\mapsto f(i)+1)$, mutually inverse on the subtypes.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Equiv",
+      "Subtype.ext",
+      "beta reduction of coercions"
+    ],
+    "prerequisites": [
+      "building an Equiv by hand",
+      "funext"
+    ]
+  },
+  {
+    "id": "ann-fintype-instance",
+    "proofId": "stars-and-bars-weak-compositions-oq-03",
+    "range": {
+      "startLine": 88,
+      "endLine": 106
+    },
+    "type": "technique",
+    "title": "A total finiteness instance by dependent case split",
+    "content": "instFintypePositiveComposition makes the positive-composition subtype finite for every k, n via a dependent `if hkn : k ≤ n`. When k ≤ n the bijection supplies Fintype.ofEquiv from the manifestly finite weak side. When k > n the subtype is empty — a positive composition would force ∑ᵢ g(i) ≥ ∑ᵢ 1 = k > n (Finset.sum_le_sum against the constant 1), contradicting ∑ = n — so an IsEmpty witness gives Fintype.ofIsEmpty. A dependent `if` (dite, which eliminates via Decidable into Type) is essential: a plain `rcases`/`cases` on the Prop-valued `k ≤ n ∨ n < k` cannot eliminate into the Type-valued Fintype goal.",
+    "mathContext": "Total $\\mathrm{Fintype}$ on $\\{g \\mid (\\forall i,\\,g(i)\\ge1)\\wedge\\sum_i g(i)=n\\}$: bijection when $k\\le n$, $\\mathrm{IsEmpty}$ when $k>n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fintype.ofEquiv",
+      "Fintype.ofIsEmpty",
+      "dite / Decidable elimination into Type"
+    ],
+    "prerequisites": [
+      "Fintype instances",
+      "IsEmpty"
+    ]
+  },
+  {
+    "id": "ann-the-count",
+    "proofId": "stars-and-bars-weak-compositions-oq-03",
+    "range": {
+      "startLine": 108,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "The count C(n−1, k−1), obtained by transport",
+    "content": "The positive-parts count is not reproved from scratch but transported. card_positiveComposition_eq_weak carries the cardinality along the bijection (Fintype.card_congr) into the parent's card_weakComposition, giving the raw C((n−k)+k−1, n−k). card_positiveComposition then specialises for 0 < k ≤ n: (n−k)+k−1 = n−1 by omega, and Nat.choose_symm rewrites the lower index n−k as (n−1) − (n−k) = k−1, delivering the classical C(n−1, k−1). The 0 < k hypothesis is what keeps the truncated index arithmetic honest (at n = 0 the form would misfire). This is the reuse the parent's open question intended — the same C(n−1,k−1) the sibling composition-parts-choose-oq-01 proves from Mathlib's Composition n, here gotten by the shift.",
+    "mathContext": "$\\#\\{g \\mid (\\forall i,\\,g(i)\\ge1)\\wedge\\sum_i g(i)=n\\} = \\binom{(n-k)+k-1}{n-k} = \\binom{n-1}{k-1}$ for $0<k\\le n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fintype.card_congr",
+      "Nat.choose_symm",
+      "transport of a count"
+    ],
+    "prerequisites": [
+      "binomial symmetry",
+      "the parent weak-composition count"
+    ]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-03/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-03/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-03",
+  "title": "Stars-and-Bars Duality: Weak ↔ Positive Compositions via an Explicit ±1 Bijection",
+  "slug": "stars-and-bars-weak-compositions-oq-03",
+  "description": "A weak composition of m into k parts is a function f : Fin k → ℕ with ∑ᵢ f(i) = m (zero parts allowed); a positive composition of n into k parts is a function g : Fin k → ℕ with every g(i) ≥ 1 and ∑ᵢ g(i) = n. The classical duality between the two is the per-coordinate shift g(i) = f(i) + 1: adding 1 to each of the k parts of a weak composition of m turns it into a positive composition of m + k, and this is a bijection. This entry formalises that bijection explicitly as positiveCompositionEquivWeak (k n : ℕ) (hkn : k ≤ n) : {g : Fin k → ℕ // (∀ i, 1 ≤ g i) ∧ ∑ i, g i = n} ≃ {f : Fin k → ℕ // ∑ i, f i = n − k}, whose forward map subtracts 1 from each part and whose inverse adds 1 back. The truncated ℕ-subtraction is exact because every part is ≥ 1, giving ∑ᵢ (g(i) − 1) = (∑ᵢ g(i)) − k = n − k (sum_sub_one). Reading the count through the parent stars-and-bars theorem card_weakComposition gives the number of positive compositions of n into k parts as C((n−k) + k − 1, n − k) (raw form, card_positiveComposition_eq_weak) and, after Nat.choose_symm, the classical C(n − 1, k − 1) for 0 < k ≤ n (card_positiveComposition). The entry answers the parent's open question 'establish the duality with the positive-parts count C(n−1, k−1) as an explicit bijection (add 1 to each part)'. Mathlib has neither the positive-composition tuple count on Fin k → ℕ nor this explicit shift equivalence; both are supplied here, fully machine-checked and axiom-free.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Sym.Card",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositions"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "StarsAndBars",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "stars-and-bars",
+      "weak-compositions",
+      "positive-compositions",
+      "counting",
+      "binomial-coefficients",
+      "bijective-proof"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Direct parent. The parent counts WEAK compositions of n into k parts as C(n+k−1, n) via a bijection to size-n multisets Sym (Fin k) n, and explicitly lists this duality as an open question: 'establish the symmetry with the positive-parts count C(n−1,k−1) as an explicit bijection (add 1 to each part)'. This entry supplies exactly that bijection, positiveCompositionEquivWeak, and reuses the parent's card_weakComposition to read off the positive-parts count."
+      },
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Sibling positive-parts count from a different model. That entry proves the number of compositions of n into k POSITIVE parts is C(n−1, k−1) using Mathlib's Composition n type and a cuts-in-gaps bijection. This entry obtains the same C(n−1, k−1) for the Fin k → ℕ tuple model, but derives it from the WEAK-composition count by the explicit ±1 shift, exhibiting the two stars-and-bars variants (bars among stars vs bars in gaps) as transports of one another."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 124,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All named declarations (sum_sub_one, positiveCompositionEquivWeak, instFintypePositiveComposition, card_positiveComposition_eq_weak, card_positiveComposition) were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The bijection positiveCompositionEquivWeak requires k ≤ n (otherwise the n − k target uses truncated subtraction and the positive side is empty); the closed-form count card_positiveComposition additionally requires 0 < k so that C(n − 1, k − 1) is the correct value (at n = 0 the truncated n − 1 would otherwise misfire). The Fintype instance on the positive-composition subtype is total: it uses the bijection when k ≤ n and an IsEmpty witness when k > n (a positive composition would force ∑ ≥ k > n). The C(n−1, k−1) form follows from the raw C((n−k)+k−1, n−k) by Nat.choose_symm on the index k−1 = (n−1) − (n−k).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Compositions come in two flavours that stars and bars counts in parallel. A weak composition of n into k parts allows zero parts and is counted by C(n+k−1, n) — bars placed among the stars; a (strict) composition into k positive parts forbids zero parts and is counted by C(n−1, k−1) — bars placed in the k−1 internal gaps between n stars. The two pictures are not independent: subtracting one star from each of the k groups (equivalently, sliding each internal bar to absorb one star) turns a positive composition of n into a weak composition of n−k, and adding one star back inverts it. This add-1-to-each-part dictionary is the standard textbook reduction of 'positive solutions of x₁+⋯+x_k = n' to 'nonnegative solutions of y₁+⋯+y_k = n−k', and it is exactly the bijection formalised here.",
+    "problemStatement": "Exhibit the duality between weak and positive compositions as an explicit bijection and read off the positive-parts count. Concretely, for k ≤ n construct an equivalence\n\n$$\\{g : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid (\\forall i,\\ g(i) \\ge 1)\\ \\wedge\\ \\textstyle\\sum_i g(i) = n\\}\\ \\simeq\\ \\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\textstyle\\sum_i f(i) = n - k\\}$$\n\nvia $g \\mapsto (i \\mapsto g(i) - 1)$ with inverse $f \\mapsto (i \\mapsto f(i) + 1)$, and deduce that the number of positive compositions of $n$ into $k$ parts is $\\binom{n-1}{k-1}$ for $0 < k \\le n$.",
+    "text": "The parent entry stars-and-bars-weak-compositions counts weak compositions of n into k parts as C(n+k−1, n) via the bijection weakCompositionEquivSym to size-n multisets, and explicitly poses this duality as an open question. This entry resolves it. The bridge is the per-coordinate shift: a positive composition g (every part ≥ 1) maps to the weak composition i ↦ g(i) − 1 of n − k, and a weak composition f of n − k maps back to the positive composition i ↦ f(i) + 1 of n. Composing with the parent's count turns the positive-parts count into a weak-parts count and hence into a binomial coefficient.",
+    "proofStrategy": "The arithmetic core is sum_sub_one: if every g(i) ≥ 1 then ∑ᵢ (g(i) − 1) = (∑ᵢ g(i)) − k. It is proved by showing ∑ᵢ (g(i) − 1) + k = ∑ᵢ g(i): the constant k is ∑ᵢ 1 over Fin k (Finset.sum_const, Fintype.card_fin), distributing the sum (Finset.sum_add_distrib) gives ∑ᵢ ((g(i) − 1) + 1), and Nat.sub_add_cancel (g(i) ≥ 1) collapses each summand to g(i); omega finishes. The equivalence positiveCompositionEquivWeak uses this for the forward well-formedness (∑ᵢ (g(i) − 1) = n − k) and, for the inverse, ∑ᵢ (f(i) + 1) = (n − k) + k = n via Finset.sum_add_distrib and k ≤ n. The two round-trips are pointwise: (g(i) − 1) + 1 = g(i) by Nat.sub_add_cancel (part ≥ 1) and (f(i) + 1) − 1 = f(i) by omega, each after a show that beta-reduces the subtype projections. A total Fintype instance is supplied by dependent case split: for k ≤ n through the bijection (Fintype.ofEquiv), for k > n by an IsEmpty witness since a positive composition would force ∑ᵢ g(i) ≥ ∑ᵢ 1 = k > n, contradicting ∑ = n. The raw count card_positiveComposition_eq_weak transports cardinality along the bijection (Fintype.card_congr) into the parent's card_weakComposition, giving C((n−k)+k−1, n−k). The classical form card_positiveComposition rewrites (n−k)+k−1 = n−1 (omega) and applies Nat.choose_symm to convert the lower index n−k into (n−1) − (n−k) = k−1.",
+    "keyInsights": [
+      "**Positive ↔ weak is literally 'subtract one star from each group'**: the map g ↦ (i ↦ g(i) − 1) is a bijection because every part being ≥ 1 makes the truncated ℕ-subtraction exact and pointwise invertible by +1. The whole reduction of positive to nonnegative solutions is this single per-coordinate shift, packaged as an Equiv rather than just a counting argument.",
+      "**The hypothesis k ≤ n is exactly the legality of the shift**: it is what makes (n − k) + k = n hold on the nose in ℕ, so the inverse lands back at sum n; for k > n there are no positive compositions at all, handled separately by an IsEmpty witness to keep the Fintype instance total.",
+      "**The count is obtained, not reproved**: rather than recounting positive compositions from scratch, the entry transports the parent's weak-composition count C(n+k−1, n) through the bijection, turning it into C((n−k)+k−1, n−k); Nat.choose_symm then exposes the classical C(n−1, k−1). This is the reuse the open question intended.",
+      "**Two stars-and-bars variants as one transport**: combined with the sibling composition-parts-choose-oq-01 (same C(n−1,k−1) from Mathlib's Composition n), this shows the 'bars in gaps' and 'bars among stars' pictures are not two theorems but two readings of a single bijection."
+    ],
+    "prerequisites": [
+      "Truncated natural-number subtraction and its exactness under a lower bound (Nat.sub_add_cancel, Nat.add_sub_cancel), with omega for the linear arithmetic",
+      "Finset sums over a Fintype: Finset.sum_add_distrib, Finset.sum_const, Finset.card_univ, Fintype.card_fin, and Finset.sum_le_sum",
+      "Building an Equiv by hand (toFun / invFun / left_inv / right_inv) on subtypes, with Subtype.ext and funext, and transporting finiteness/cardinality (Fintype.ofEquiv, Fintype.card_congr, Fintype.ofIsEmpty)",
+      "The parent stars-and-bars count card_weakComposition and binomial symmetry Nat.choose_symm"
+    ]
+  },
+  "sections": [
+    {
+      "id": "the-shift-arithmetic",
+      "title": "The Arithmetic of the Per-Part Shift",
+      "startLine": 49,
+      "endLine": 62,
+      "mathContext": "$\\sum_i (g(i) - 1) = \\left(\\sum_i g(i)\\right) - k$ whenever every $g(i) \\ge 1$.",
+      "summary": "sum_sub_one is the arithmetic heart: with every part ≥ 1, subtracting 1 from each of the k parts lowers the total by exactly k. The proof shows ∑ᵢ (g(i) − 1) + k = ∑ᵢ g(i) by writing k = ∑ᵢ 1 over Fin k (Finset.sum_const, Fintype.card_fin), merging with Finset.sum_add_distrib into ∑ᵢ ((g(i) − 1) + 1), collapsing each summand via Nat.sub_add_cancel (g(i) ≥ 1), and closing with omega — the lower bound is what makes the truncated subtraction exact."
+    },
+    {
+      "id": "the-bijection",
+      "title": "The ±1 Bijection Between Positive and Weak Compositions",
+      "startLine": 64,
+      "endLine": 86,
+      "mathContext": "$\\{g : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid (\\forall i,\\,g(i)\\ge 1)\\wedge \\sum_i g(i)=n\\} \\simeq \\{f : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid \\sum_i f(i)=n-k\\}$, for $k \\le n$.",
+      "summary": "positiveCompositionEquivWeak is the explicit equivalence. Forward: g ↦ (i ↦ g(i) − 1), which sums to n − k by sum_sub_one and ∑ g = n. Inverse: f ↦ (i ↦ f(i) + 1), positive by Nat.le_add_left and summing to (n−k) + k = n via Finset.sum_add_distrib and k ≤ n. The round-trips are pointwise — (g(i) − 1) + 1 = g(i) by Nat.sub_add_cancel using the part bound, and (f(i) + 1) − 1 = f(i) by omega — each preceded by a show that beta-reduces the subtype coercions so the arithmetic lemma applies."
+    },
+    {
+      "id": "fintype-instance",
+      "title": "A Total Finiteness Instance by Case Split",
+      "startLine": 88,
+      "endLine": 106,
+      "mathContext": "$\\mathrm{Fintype}\\,\\{g : \\mathrm{Fin}\\,k \\to \\mathbb{N} \\mid (\\forall i,\\,g(i)\\ge1)\\wedge\\sum_i g(i)=n\\}$ for all $k, n$.",
+      "summary": "instFintypePositiveComposition makes the subtype finite for every k, n via a dependent if on k ≤ n. When k ≤ n the bijection gives Fintype.ofEquiv from the manifestly finite weak side. When k > n the subtype is empty: a positive composition would force ∑ᵢ g(i) ≥ ∑ᵢ 1 = k > n (Finset.sum_le_sum against the constant 1), contradicting ∑ = n, so an IsEmpty witness yields Fintype.ofIsEmpty. The dependent if (not a Prop-valued case split) is required because the goal Fintype … lives in Type."
+    },
+    {
+      "id": "the-count",
+      "title": "The Positive-Parts Count C(n−1, k−1)",
+      "startLine": 108,
+      "endLine": 124,
+      "mathContext": "$\\#\\{g \\mid (\\forall i,\\,g(i)\\ge1)\\wedge\\sum_i g(i)=n\\} = \\binom{n-1}{k-1}$ for $0 < k \\le n$.",
+      "summary": "card_positiveComposition_eq_weak transports the cardinality along the bijection (Fintype.card_congr) into the parent's card_weakComposition, giving the raw C((n−k)+k−1, n−k). card_positiveComposition then specialises: (n−k)+k−1 = n−1 by omega, and Nat.choose_symm rewrites the lower index n−k as (n−1) − (n−k) = k−1, delivering the classical C(n−1, k−1). The hypotheses 0 < k ≤ n are exactly what make both index simplifications valid in truncated ℕ-arithmetic."
+    }
+  ],
+  "conclusion": {
+    "summary": "The weak–positive duality of stars and bars is formalised as an explicit, axiom-free bijection. positiveCompositionEquivWeak realises the textbook 'add 1 to each part' dictionary as an Equiv between positive compositions of n and weak compositions of n − k into the same k parts, valid for k ≤ n. Transporting the parent's weak count C(n+k−1, n) through it yields the positive-parts count, raw as C((n−k)+k−1, n−k) and classical as C(n−1, k−1) for 0 < k ≤ n. The entry answers the parent's own open question and complements the sibling composition-parts-choose-oq-01, which proves the same C(n−1, k−1) from Mathlib's Composition n type — here it is obtained instead by transport from the weak count.",
+    "implications": "Delivered as an Equiv rather than a bare count, the bijection is reusable: any statement about positive compositions on Fin k → ℕ can be rewritten as one about weak compositions of n − k (and vice versa), and the total Fintype instance unlocks Finset.sum / Fintype.card reasoning over the positive-composition subtype. Together with the parent and the Composition-based sibling, the gallery now records both stars-and-bars variants and the explicit transport identifying them, a clean candidate for upstreaming alongside the tuple form of the weak count.",
+    "openQuestions": [
+      "Promote the bijection to a generating-function identity: the positive count C(n−1,k−1) is the coefficient of xⁿ in (x/(1−x))ᵏ, the k-fold shift of the weak series 1/(1−x)ᵏ by exactly the +k the ±1 map performs.",
+      "Refine to bounded positive parts: count positive compositions of n into k parts each at most m by composing this ±1 shift with the inclusion–exclusion bounded-weak count, the strict analogue of the parent's bounded-parts open question."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions",
+    "composition-parts-choose-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the **open question posed by the parent** `stars-and-bars-weak-compositions`: *"establish the duality with the positive-parts count C(n−1, k−1) as an explicit bijection (add 1 to each part)."*

A **weak** composition of `m` into `k` parts is `f : Fin k → ℕ` with `∑ f = m` (zero parts allowed); a **positive** composition of `n` is `g : Fin k → ℕ` with every `g i ≥ 1` and `∑ g = n`. The classical duality is the per-coordinate shift `g i = f i + 1`. This PR formalises it as an explicit `Equiv` and reads off the positive-parts count.

## Contents (`Proofs/StarsAndBarsWeakCompositionsOQ03.lean`, 124 lines)

- `sum_sub_one` — `∑ᵢ (g i − 1) = (∑ᵢ g i) − k` when all parts `≥ 1` (proved additively to keep truncated ℕ-subtraction honest).
- `positiveCompositionEquivWeak (k ≤ n)` — the explicit bijection `{g // (∀ i, 1 ≤ g i) ∧ ∑ g = n} ≃ {f // ∑ f = n − k}`; forward subtracts 1 from each part, inverse adds 1 back, round-trips pointwise.
- `instFintypePositiveComposition` — total `Fintype` instance (dependent `if`: bijection when `k ≤ n`, `IsEmpty` when `k > n`).
- `card_positiveComposition_eq_weak` — raw count `C((n−k)+k−1, n−k)` by transporting the parent's `card_weakComposition`.
- `card_positiveComposition` — classical `C(n−1, k−1)` for `0 < k ≤ n` via `Nat.choose_symm`.

## Verification

- `#print axioms` on every declaration: only `propext` / `Classical.choice` / `Quot.sound`.
- **0 axioms, 0 sorries, no `native_decide`.** Status: `verified`, badge `original`.
- Builds against Mathlib `v4.26.0` (typechecked offline via `lake env lean`; Docker was unavailable this session).

## Gallery

Adds `src/data/proofs/stars-and-bars-weak-compositions-oq-03/` (meta.json + annotations.json), cross-referencing the parent and the sibling `composition-parts-choose-oq-01` (same `C(n−1,k−1)` from Mathlib's `Composition n` — here obtained instead by transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)