### PR TITLE
research(erdos-1204): sharpen A(k) ≥ 2(k−1) via parity constraint [4 thm, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1204Problem.lean
+++ b/proofs/Proofs/Erdos1204Problem.lean
@@ -184,6 +184,61 @@ theorem exists_admissible_card (k : ℕ) :
     rw [hp0, mul_zero]
     exact zero_ne_one
 
+/- ## The parity constraint and a sharper diameter bound
+
+The trivial packing bound says `k` distinct naturals span at least `k - 1`. The smallest
+prime already doubles this: modulo `2` an admissible set misses a residue class, and `ZMod 2`
+has only two classes, so **every element shares the same parity**. Distinct same-parity
+naturals differ by at least `2`, so an admissible `k`-set has diameter `≥ 2(k-1)`. This is the
+leading term of the sieve heuristic behind the conjecture `A(k) ∼ k log k`. -/
+
+/-- **All elements of an admissible set share parity.** Modulo the prime `2` the set misses a
+residue class, and `ZMod 2` has only two classes, so the remaining class holds every element. -/
+theorem admissible_same_parity {a : Finset ℕ} (ha : Admissible a) {x y : ℕ}
+    (hx : x ∈ a) (hy : y ∈ a) : (x : ZMod 2) = (y : ZMod 2) := by
+  obtain ⟨r, hr⟩ := ha 2 (by norm_num)
+  -- in `ZMod 2`, two elements both `≠ r` must be equal (only two classes)
+  have key : ∀ (s z w : ZMod 2), z ≠ s → w ≠ s → z = w := by decide
+  exact key r _ _ (hr x hx) (hr y hy)
+
+/-- **Parity lower bound on the diameter.** Any nonempty admissible set has diameter
+`max - min ≥ 2(card - 1)`: its elements share parity (`admissible_same_parity`), so the
+map `x ↦ (x - min)/2` injects `a` into `{0, 1, …, (max-min)/2}`, forcing
+`card ≤ (max-min)/2 + 1`. This doubles the trivial packing bound `card - 1`. -/
+theorem admissible_diam_ge {a : Finset ℕ} (ha : Admissible a) (hne : a.Nonempty) :
+    2 * (a.card - 1) ≤ a.max' hne - a.min' hne := by
+  classical
+  -- every element is `≥ min`, `≤ max`, and `≡ min (mod 2)`, hence `2 ∣ x - min`
+  have hdvd : ∀ x ∈ a, 2 ∣ (x - a.min' hne) := by
+    intro x hx
+    have hmx : a.min' hne ≤ x := a.min'_le x hx
+    have hpar : ((a.min' hne : ℕ) : ZMod 2) = (x : ZMod 2) :=
+      admissible_same_parity ha (a.min'_mem hne) hx
+    rw [ZMod.natCast_eq_natCast_iff] at hpar
+    exact (Nat.modEq_iff_dvd' hmx).mp hpar
+  -- `x ↦ (x - min)/2` maps `a` into `range ((max-min)/2 + 1)` ...
+  have hmono : ∀ x ∈ a, (x - a.min' hne) / 2 ∈ Finset.range ((a.max' hne - a.min' hne)/2 + 1) := by
+    intro x hx
+    rw [Finset.mem_range]
+    have hxM : x ≤ a.max' hne := a.le_max' x hx
+    have hmx : a.min' hne ≤ x := a.min'_le x hx
+    omega
+  -- ... and it is injective (distinct same-parity values give distinct halves)
+  have hinj : Set.InjOn (fun x => (x - a.min' hne) / 2) a := by
+    intro x hx y hy hxy
+    simp only at hxy
+    have hmx : a.min' hne ≤ x := a.min'_le x hx
+    have hmy : a.min' hne ≤ y := a.min'_le y hy
+    obtain ⟨u, hu⟩ := hdvd x hx
+    obtain ⟨v, hv⟩ := hdvd y hy
+    omega
+  have hcard : a.card ≤ (a.max' hne - a.min' hne)/2 + 1 := by
+    have h := Finset.card_le_card_of_injOn
+      (f := fun x => (x - a.min' hne) / 2)
+      (t := Finset.range ((a.max' hne - a.min' hne)/2 + 1)) hmono hinj
+    simpa using h
+  omega
+
 /- ## The extremal quantity `A(k)`
 
 The headline question of Problem #1204 concerns `A(k) = min a_k`, the minimal possible
@@ -237,6 +292,27 @@ theorem sub_one_le_A (k : ℕ) : k - 1 ≤ A k := by
   have := card_le_sup_succ a
   rw [hcard, hsup] at this
   omega
+
+/-- **Sharpened lower bound (parity).** Any admissible `k`-set has largest element
+`a.sup id ≥ 2(k-1)`: its diameter is `≥ 2(k-1)` (`admissible_diam_ge`) and its least element
+is `≥ 0`, so the maximum (which is `≤ a.sup id`) is at least `2(k-1)`. -/
+theorem admissible_two_mul_card_sub_one_le_sup {a : Finset ℕ} (ha : Admissible a) :
+    2 * (a.card - 1) ≤ a.sup id := by
+  rcases a.eq_empty_or_nonempty with rfl | hne
+  · simp
+  · have hdiam := admissible_diam_ge ha hne
+    have hmax_le_sup : a.max' hne ≤ a.sup id := Finset.le_sup (f := id) (a.max'_mem hne)
+    omega
+
+/-- **Sharpened lower bound on `A(k)`: `A(k) ≥ 2(k-1)`,** twice the trivial packing bound
+`sub_one_le_A`. The prime `2` forces every admissible set to be single-parity, so its `k`
+distinct elements span at least `2(k-1)`. This is sharp at `k = 2` (`A 2 = 2`) and is the
+leading prime-`2` contribution toward the conjectured `A(k) ∼ k log k`. -/
+theorem two_mul_sub_one_le_A (k : ℕ) : 2 * (k - 1) ≤ A k := by
+  obtain ⟨a, hcard, ha, hsup⟩ := A_mem k
+  have h := admissible_two_mul_card_sub_one_le_sup ha
+  rw [hcard, hsup] at h
+  exact h
 
 /-- `A(0) = 0` (the only admissible `0`-set is `∅`). -/
 theorem A_zero : A 0 = 0 :=

--- a/research/problems/erdos-1204/knowledge.md
+++ b/research/problems/erdos-1204/knowledge.md
@@ -104,3 +104,31 @@ Gotchas: parity extracted via `ZMod.natCast_eq_zero_iff x 2` ((x:ZMod 2)=0 ↔ 2
 `ZMod.natCast_zmod_eq_zero_iff_dvd` is now DEPRECATED. `∀ y:ZMod 2, y=0∨y=1` by `decide`
 splits the ≠1 case to get evenness. `omega` closes membership in {0,2,4}/{1,3,5} from
 `x ≤ 5` + a divisibility fact. Pin the 3-set with `Finset.eq_of_subset_of_card_le`.
+
+## Session 2026-06-25 (researcher-5b) — parity sharpens A(k) ≥ 2(k−1) for ALL k
+
+Added 4 verified theorems (now 27 thm / 2 def total, 0 axioms, 0 sorries), STRENGTHENING the
+existing trivial bound `sub_one_le_A : k−1 ≤ A k` to `two_mul_sub_one_le_A : 2(k−1) ≤ A k`:
+- `admissible_same_parity` — the prime p=2 forces ALL elements of an admissible set to share
+  parity: ZMod 2 has only two classes, one is missed, so every element lies in the other
+  (`∀ s z w : ZMod 2, z ≠ s → w ≠ s → z = w` by `decide`).
+- `admissible_diam_ge` — any nonempty admissible set has `max' − min' ≥ 2(card − 1)`. Same
+  parity ⇒ `2 ∣ x − min'`; the map `x ↦ (x − min')/2` injects `a` into `range((max'−min')/2+1)`,
+  so `card ≤ (max'−min')/2 + 1`.
+- `admissible_two_mul_card_sub_one_le_sup` — for admissible `a`, `2(card−1) ≤ a.sup id`
+  (diameter bound + `min' ≥ 0` + `max' ≤ sup id`).
+- `two_mul_sub_one_le_A` — **A(k) ≥ 2(k−1)**, twice the packing bound, sharp at k=2 (A 2 = 2 ✓).
+
+Insight: this is the leading prime-2 term of the sieve heuristic predicting A(k) ∼ k log k.
+Each further prime p contributes a factor p/(p−1) (elements occupy ≤ p−1 of p classes); the
+log k comes from summing/CRT over small primes — that combination needs analytic sieve
+machinery and stays OPEN.
+
+Gotchas: `Finset.card_le_card_of_injOn` wants `Set.MapsTo f ↑s ↑t`, not `∀ x ∈ s, f x ∈ t` —
+pass `(t := …)` explicitly so the target Finset is inferred. `2 ∣ x − min` from
+`(min : ZMod 2) = (x : ZMod 2)` via `ZMod.natCast_eq_natCast_iff` then `Nat.modEq_iff_dvd'`
+(needs `min ≤ x`). `omega` discharges all the /2 division reasoning (injectivity, range bound,
+diameter→sup chain). This bound is the general-k counterpart of the per-value A(3)=6 lower
+bound above (which used the same parity-pins-the-set idea for k=3). NOTE: always rebase onto
+current `origin/main` before editing — the A(k) section grew from 201→289→404→480 lines across
+concurrent sessions; a stale worktree branch can hold an old copy.

--- a/research/problems/erdos-1204/state.md
+++ b/research/problems/erdos-1204/state.md
@@ -1,27 +1,32 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-16T17:08:10.942Z
-**Iteration**: 1
+**Phase**: ACTIVE
+**Since**: 2026-06-25
+**Iteration**: 4
 
 ## Current Focus
 
-Initial exploration of the problem.
+Verified lower bounds on the extremal quantity A(k) (minimal largest element of an
+admissible k-tuple).
 
 ## Active Approach
 
-None yet.
+Sieve-style lower bounds from individual small primes. The prime 2 gives the parity
+constraint ⇒ A(k) ≥ 2(k−1) (verified this session, doubling the trivial k−1 and sharp
+at k=2). Next candidate: combine primes 2 and 3 (elements occupy ≤ 1 class mod 2 and
+≤ 2 mod 3) for a sharper interval-counting bound toward the k log k heuristic.
 
 ## Blockers
 
-None.
+Combining constraints across multiple primes rigorously needs CRT / sieve counting that
+is not yet formalized. The headline A(k) ∼ k log k and the B(k) estimate remain OPEN.
 
 ## Next Action
 
-Begin problem exploration.
+Explore a mod-2-and-mod-3 combined lower bound (factor 3 over trivial).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 4
+- Current approach attempts: 1
+- Approaches tried: 2

--- a/src/data/proofs/erdos-1204/meta.json
+++ b/src/data/proofs/erdos-1204/meta.json
@@ -57,12 +57,15 @@
       "A_mem / A_le: the infimum defining A(k) is attained (nonempty family via exists_admissible_card) and is a genuine lower bound",
       "card_le_sup_succ + sub_one_le_A: trivial packing lower bound A(k) ≥ k-1",
       "A_zero=0, A_one=0, and A_two=2 computed exactly; A(2)=2 > 1=k-1 is the first place admissibility is binding ({0,1} inadmissible forces the max above the packing bound)",
-      "A_three: the exact value A(3)=6 (= Hardy–Littlewood minimal diameter H(3)). Upper bound from the admissible witness {0,2,6}; lower bound via a finite argument — any admissible 3-set with max ≤ 5 must (mod 2) be single-parity, pinning it to {0,2,4} or {1,3,5}, both of which cover all classes mod 3 and so are inadmissible (admissible_three_sup_ge + not_admissible_zero_two_four / not_admissible_one_three_five)"
+      "A_three: the exact value A(3)=6 (= Hardy–Littlewood minimal diameter H(3)). Upper bound from the admissible witness {0,2,6}; lower bound via a finite argument — any admissible 3-set with max ≤ 5 must (mod 2) be single-parity, pinning it to {0,2,4} or {1,3,5}, both of which cover all classes mod 3 and so are inadmissible (admissible_three_sup_ge + not_admissible_zero_two_four / not_admissible_one_three_five)",
+      "admissible_same_parity: the prime 2 forces ALL elements of an admissible set to share parity (ZMod 2 has only two classes, one is missed)",
+      "admissible_diam_ge: a VERIFIED nontrivial bound — any nonempty admissible set has diameter max − min ≥ 2(card − 1), via the injection x ↦ (x−min)/2 of a into {0,…,(max−min)/2}",
+      "two_mul_sub_one_le_A: SHARPENED general lower bound A(k) ≥ 2(k−1), DOUBLING the trivial packing bound sub_one_le_A for every k and sharp at k=2 (A 2 = 2); the parity (prime-2) contribution toward the conjectured A(k) ∼ k log k, and the general-k counterpart of the per-value A(3)=6 argument"
     ],
     "axiomCount": 0,
-    "lineCount": 404,
-    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), two-sided bounds k-1 ≤ A(k) ≤ (k-1)·primorial, and the exact values A(0)=A(1)=0, A(2)=2, A(3)=6.",
-    "theoremCount": 23,
+    "lineCount": 480,
+    "assumptions": "0 axiom declarations and 0 sorries; every stated lemma is fully proved. Proofs use only kernel `decide` (no `native_decide`) and `Nat.sInf`; #print axioms (incl. admissible_same_parity, admissible_diam_ge, two_mul_sub_one_le_A) shows only propext/Classical.choice/Quot.sound — no Lean.ofReduceBool, no sorryAx. Status is 'axiomatized' because the headline asymptotic questions of Problem #1204 — whether A(k) ∼ k log k and the estimate for B(k) — remain OPEN and are documented but not formalized as theorems. Formalized here: the admissibility framework, the reduction to small primes, existence/well-definedness of A(k), the parity-sharpened two-sided bounds 2(k-1) ≤ A(k) ≤ (k-1)·primorial (doubling the trivial k-1 lower bound for all k), and the exact values A(0)=A(1)=0, A(2)=2, A(3)=6.",
+    "theoremCount": 27,
     "definitionCount": 2
   },
   "overview": {
@@ -86,7 +89,7 @@
   },
   "sections": [],
   "conclusion": {
-    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the standard reduction showing only primes p ≤ k impose constraints, and small worked examples. The asymptotic questions themselves remain open and are not asserted.",
+    "summary": "Erdős Problem #1204 asks for the asymptotics of the minimal diameter A(k) and minimal average B(k) of admissible k-tuples, conjecturally A(k) ∼ k log k. This entry formalizes the admissibility framework: the definition, the reduction showing only primes p ≤ k impose constraints, the extremal quantity A(k) itself (as an attained infimum), exact values A(0)=A(1)=0 and A(2)=2, and a verified parity-sharpened lower bound A(k) ≥ 2(k−1) — the prime 2 forces all elements to share parity, doubling the trivial packing bound k−1 (sharp at k=2). The full asymptotic questions remain open and are not asserted.",
     "openQuestions": [
       "Is A(k) ∼ k log k?",
       "What is the correct order of B(k) = min (a₁+⋯+a_k)/k?"
@@ -130,9 +133,9 @@
       "Finset"
     ],
     "namespace": "Erdos1204",
-    "lineCount": 404,
+    "lineCount": 480,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 27,
     "definitionCount": 2,
     "path": "Proofs/Erdos1204Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Erdős Problem #1204 — a verified general lower bound on A(k)

The headline questions of [Erdős #1204](https://erdosproblems.com/1204) (is `A(k) ∼ k log k`? estimate `B(k)`) remain **OPEN**. This PR adds a **verified, general-k lower bound** on the extremal quantity `A(k)` (the minimal largest element of an admissible k-tuple) that the gallery file already defines.

### Result: `A(k) ≥ 2(k−1)`

Modulo the prime `2` an admissible set misses a residue class, and `ZMod 2` has only two classes, so **every element shares the same parity**. Distinct same-parity naturals differ by at least `2`, so an admissible `k`-set spans at least `2(k−1)`. This **doubles** the file's existing trivial packing bound `sub_one_le_A : k−1 ≤ A k`, is **sharp at `k=2`** (`A 2 = 2`), and is the leading prime-`2` term of the sieve heuristic predicting `A(k) ∼ k log k`.

It is the general-`k` counterpart of the per-value `A(3) = 6` argument already in the file (both use *parity pins the set*).

### New theorems (4) — 0 axioms, 0 sorries
- `admissible_same_parity` — all elements of an admissible set share parity (from the missed class mod 2).
- `admissible_diam_ge` — any nonempty admissible set has `max − min ≥ 2(card − 1)`, via the injection `x ↦ (x−min)/2` of `a` into `{0,…,(max−min)/2}`.
- `admissible_two_mul_card_sub_one_le_sup` — `2(card − 1) ≤ a.sup id` for admissible `a`.
- `two_mul_sub_one_le_A` — **`A(k) ≥ 2(k−1)`**.

### Verification
- Typechecked offline with `lake env lean` (mathlib 4.26.0); file is now 27 theorems / 2 defs, 480 lines.
- `#print axioms` on the new theorems shows only `propext` / `Classical.choice` / `Quot.sound` — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.
- Status remains `axiomatized`: the asymptotic questions `A(k) ∼ k log k` and `B(k)` are documented but not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)