### PR TITLE
Enrich Erdős #634 Medial Reptiling (erdos-634-medial-congruence)

### DIFF
--- a/src/data/proofs/erdos-634-medial-congruence/annotations.json
+++ b/src/data/proofs/erdos-634-medial-congruence/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "The Medial Reptiling and Erdős #634",
     "content": "Erdős Problem #634 asks to understand all triples (T, R, N) such that triangle T can be tiled by N congruent copies of triangle R. The constructive backbone is the square reptiling: subdividing each side of a triangle into k equal parts cuts it into k^2 congruent triangles, each a 1/k-scale copy. This entry formalizes the base case k = 2 — the medial subdivision — proving the four pieces are mutually congruent. We capture the congruence of the pieces (the combinatorial heart), not the covering/disjointness (the analytic part of #634).",
-    "mathContext": "The medial points are $m_{AB} = \\tfrac{A+B}{2}$, $m_{BC} = \\tfrac{B+C}{2}$, $m_{CA} = \\tfrac{C+A}{2}$. The four medial triangles are the three corner triangles and the central one; all four are congruent and similar to $ABC$ at ratio $\\tfrac12$."
+    "mathContext": "The medial points are $m_{AB} = \\tfrac{A+B}{2}$, $m_{BC} = \\tfrac{B+C}{2}$, $m_{CA} = \\tfrac{C+A}{2}$. The four medial triangles are the three corner triangles and the central one; all four are congruent and similar to $ABC$ at ratio $\\tfrac12$.",
+    "significance": "context",
+    "relatedConcepts": ["reptile", "rep-tile dissection", "self-similar tiling", "medial triangle", "Erdős problems"],
+    "prerequisites": ["Euclidean geometry", "tilings and dissections"]
   },
   {
     "id": "tri-congruent",
@@ -15,7 +18,10 @@
     "type": "definition",
     "title": "TriCongruent: isometry-congruence of triangles",
     "content": "Two ordered triangles are congruent if some isometry of the ambient space carries the first vertex triple onto the second, vertex by vertex. This is the gold-standard notion of congruence. It is proved to be an equivalence relation (refl/symm/trans), and congruent triangles are shown to have equal corresponding side lengths (the SSS direction), since isometries preserve distance.",
-    "mathContext": "$\\mathrm{TriCongruent}\\ t\\ s := \\exists f : V \\simeq_i V,\\ f(t_1)=s_1 \\wedge f(t_2)=s_2 \\wedge f(t_3)=s_3$. Working over a general real normed space $V$ keeps the result coordinate-free and applicable to the Euclidean plane."
+    "mathContext": "$\\mathrm{TriCongruent}\\ t\\ s := \\exists f : V \\simeq_i V,\\ f(t_1)=s_1 \\wedge f(t_2)=s_2 \\wedge f(t_3)=s_3$. Working over a general real normed space $V$ keeps the result coordinate-free and applicable to the Euclidean plane.",
+    "significance": "key",
+    "relatedConcepts": ["isometry", "congruence as an equivalence relation", "distance preservation", "ordered triangle", "SSS criterion"],
+    "prerequisites": ["metric spaces", "isometry groups", "equivalence relations"]
   },
   {
     "id": "explicit-isometries",
@@ -24,7 +30,10 @@
     "type": "definition",
     "title": "The explicit isometries: translation and point reflection",
     "content": "Two isometry families witness the congruences. Translation x ↦ v + x (IsometryEquiv.constVAdd) handles the three corner triangles. The central triangle needs a 180° rotation, realized as the point reflection x ↦ w - x and built as negation (LinearIsometryEquiv.neg ℝ) followed by a translation — an isometry in any normed space.",
-    "mathContext": "Point reflection through $P$ is $x \\mapsto 2P - x$; writing $w = 2P$, it is $x \\mapsto w - x$. Translations and point reflections are isometries in every normed space (no inner product needed)."
+    "mathContext": "Point reflection through $P$ is $x \\mapsto 2P - x$; writing $w = 2P$, it is $x \\mapsto w - x$. Translations and point reflections are isometries in every normed space (no inner product needed).",
+    "significance": "supporting",
+    "relatedConcepts": ["translation", "point reflection", "180-degree rotation", "linear isometry", "normed space isometries"],
+    "prerequisites": ["normed vector spaces", "linear isometries"]
   },
   {
     "id": "main-congruence",
@@ -33,7 +42,10 @@
     "type": "theorem",
     "title": "medial_four_congruent: the four pieces are pairwise congruent",
     "content": "The main theorem. The three corner triangles are translates of the reference T1 (by (B-A)/2 and (C-A)/2); the central triangle is the image of T1 under the point reflection x ↦ (A + mBC) - x. Each isometry's three vertex images reduce to ℝ-linear vector identities discharged by the `module` tactic. Since TriCongruent is an equivalence relation, the three congruences relative to T1 yield all six pairwise congruences.",
-    "mathContext": "Reference $T_1 = (A, m_{AB}, m_{CA})$. The point reflection $g(x) = (A + m_{BC}) - x$ satisfies $g(A) = m_{BC}$, $g(m_{AB}) = m_{CA}$, $g(m_{CA}) = m_{AB}$, mapping $T_1$ onto the central triangle $T_4 = (m_{BC}, m_{CA}, m_{AB})$."
+    "mathContext": "Reference $T_1 = (A, m_{AB}, m_{CA})$. The point reflection $g(x) = (A + m_{BC}) - x$ satisfies $g(A) = m_{BC}$, $g(m_{AB}) = m_{CA}$, $g(m_{CA}) = m_{AB}$, mapping $T_1$ onto the central triangle $T_4 = (m_{BC}, m_{CA}, m_{AB})$.",
+    "significance": "key",
+    "relatedConcepts": ["transitivity of congruence", "translation orbit", "central inversion", "module tactic", "vector identities"],
+    "prerequisites": ["affine combinations", "equivalence-relation reasoning"]
   },
   {
     "id": "sides-halved",
@@ -42,6 +54,9 @@
     "type": "theorem",
     "title": "medial_sides_halved: 4 = 2² congruent half-copies",
     "content": "Each medial triangle has side lengths exactly dist A B / 2, dist B C / 2, dist C A / 2. The vertex-to-midpoint sides use dist_left_midpoint / dist_midpoint_right; the midpoint-to-midpoint side (shared vertex A) uses midpoint_vsub_midpoint_same_left, giving the difference (1/2)(B - C). This exhibits the medial subdivision as the k = 2 square reptiling: four congruent copies at half scale.",
-    "mathContext": "$\\mathrm{dist}(m_{AB}, m_{CA}) = \\tfrac12\\,\\mathrm{dist}(B,C)$ because $m_{AB} - m_{CA} = \\tfrac12(B - C)$ (shared vertex $A$). Halving all sides scales area by $\\tfrac14$, so four pieces tile the original by area — the $2^2$ reptiling."
+    "mathContext": "$\\mathrm{dist}(m_{AB}, m_{CA}) = \\tfrac12\\,\\mathrm{dist}(B,C)$ because $m_{AB} - m_{CA} = \\tfrac12(B - C)$ (shared vertex $A$). Halving all sides scales area by $\\tfrac14$, so four pieces tile the original by area — the $2^2$ reptiling.",
+    "significance": "key",
+    "relatedConcepts": ["midpoint", "similarity ratio", "area scaling", "half-scale copy", "k-squared reptiling"],
+    "prerequisites": ["distance in normed spaces", "midpoint identities"]
   }
 ]

--- a/src/data/proofs/erdos-634-medial-congruence/index.ts
+++ b/src/data/proofs/erdos-634-medial-congruence/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos634MedialCongruence.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos634MedialCongruenceProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos634MedialCongruenceAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos634MedialCongruenceData: ProofData = {
+  proof: erdos634MedialCongruenceProof,
+  annotations: erdos634MedialCongruenceAnnotations,
+}

--- a/src/data/proofs/erdos-634-medial-congruence/meta.json
+++ b/src/data/proofs/erdos-634-medial-congruence/meta.json
@@ -68,7 +68,8 @@
       "The four medial pieces are congruent via genuinely elementary isometries: three are translations and only one (the central piece) requires a non-translation — a 180° rotation realized as a point reflection.",
       "No inner-product or Euclidean-specific machinery is needed: translations and point reflections are isometries in ANY normed space, so the congruence holds in arbitrary real normed spaces and specialises to the plane.",
       "Side lengths halve exactly (midpoint_vsub_midpoint_same_left gives the shared-vertex midpoint difference (1/2)(b-c)), so the subdivision is the k = 2 square reptiling: 4 = 2^2 congruent half-copies.",
-      "The `module` tactic cleanly discharges every vertex-image identity once midpoints are written in smul form, keeping the geometric proof short and robust."
+      "The `module` tactic cleanly discharges every vertex-image identity once midpoints are written in smul form, keeping the geometric proof short and robust.",
+      "Defining congruence as an *equivalence relation* pays off combinatorially: only three congruences to the reference piece T1 need explicit isometries, and transitivity then delivers all six pairwise congruences for free."
     ],
     "prerequisites": [
       "Isometries of normed spaces (translations, negation, point reflections)",
@@ -104,6 +105,27 @@
       "startLine": 176,
       "endLine": 194,
       "summary": "medial_sides_halved: each medial triangle's side lengths are exactly half those of A B C, exhibiting the 4 = 2^2 square reptiling base case."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully machine-checked, axiom-free formalization (0 sorries; only propext/Classical.choice/Quot.sound) over an arbitrary real normed space that the medial subdivision of any triangle ABC into four pieces — three corner triangles and one central triangle — yields four mutually congruent triangles, each a half-scale copy of ABC. Congruence is the genuine isometry notion (an equivalence relation that preserves side lengths), witnessed by explicit isometries: three translations and one point reflection (a 180° rotation). The side-length computation exhibits the construction as the k = 2 base case of the k² square reptiling.",
+    "implications": "This is the geometric heart of the 'always achievable' tiling counts N = k² in Erdős #634: iterating the medial subdivision (or its k-fold generalization) realizes any perfect-square number of congruent sub-triangles. Because the argument uses only translations and point reflections — isometries available in any normed space — it is coordinate-free and avoids inner-product machinery, making it a reusable building block for further reptiling formalizations. The equivalence-relation packaging of congruence is what reduces the six pairwise congruences to three explicit isometries.",
+    "openQuestions": [
+      "Generalize from k = 2 to arbitrary k: subdividing each side into k equal parts produces k² congruent 1/k-scale copies. Formalizing this for all k would give the full square reptiling underlying #634.",
+      "Add the covering and interior-disjointness (measure/area) conditions to upgrade the congruence statement to a genuine tiling, completing the dissection claim rather than only the congruence of pieces.",
+      "Characterize, as Erdős #634 asks, exactly which counts N are achievable for tilings of a triangle T by congruent copies of a triangle R, beyond the square values N = k² supplied by reptiling."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-634",
+      "relationship": "relatedTo",
+      "description": "Companion entry modeling Erdős #634 dissection in an abstract side-length framework with an area-only Dissection condition. This geometric entry is independent and supplies genuine isometry-congruence of the medial pieces."
+    },
+    {
+      "targetId": "erdos-633",
+      "relationship": "relatedTo",
+      "description": "Closely related Erdős problem #633 on triangles admitting non-square tilings (into a non-square number of congruent triangles); the square reptiling formalized here is the complementary 'always achievable' N = k² construction."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-634-medial-congruence`.

## Quality improvements
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing.
- **Added `conclusion` block** — summary, mathematical implications, and 3 open questions (k-fold generalization, covering/disjointness for a genuine tiling, the full #634 achievable-counts question).
- **Added `crossReferences`** — to the companion `erdos-634` (abstract dissection framework) and the related `erdos-633` (non-square tilings).
- **Structured annotation fields** — added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations (they already had `mathContext`).
- **Added a 5th keyInsight** on how packaging congruence as an equivalence relation reduces six pairwise congruences to three explicit isometries.

Content verified against the Lean source (TriCongruent equivalence relation, translation + point-reflection witnesses, half-scale side lengths). 0 axioms, 0 sorries unchanged.