### PR TITLE
Enrich Erdős #220 extremal residue structure (erdos-220-incomplete-01): annotation depth

### DIFF
--- a/src/data/proofs/erdos-220-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-220-incomplete-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-def-reduced-residues",
+    "proofId": "erdos-220-incomplete-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 41
+    },
+    "type": "definition",
+    "title": "Reduced Residues as a Filtered Finset",
+    "content": "reducedResidues n is defined as the m in [0, n) (Finset.range n) filtered by 1 ≤ m ∧ Nat.Coprime m n — the φ(n) units mod n listed as natural numbers in [1, n). The companion membership lemma mem_reducedResidues unfolds this to m < n ∧ 1 ≤ m ∧ Coprime m n, the workhorse used by every later theorem. Keeping the set as an explicit Finset of ℕ (rather than (ZMod n)ˣ) is what lets the gaps a_{k+1} − a_k be computed by `decide` on concrete sorted lists, matching the companion entry erdos-220-oq-01's convention.",
+    "mathContext": "$\\mathrm{reducedResidues}(n) = \\{m : 1 \\le m < n,\\ \\gcd(m,n)=1\\}$, of size $\\varphi(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "reduced residue system",
+      "Finset.filter",
+      "Euler totient",
+      "units mod n"
+    ],
+    "prerequisites": [
+      "Nat.Coprime",
+      "Finset.range and filter"
+    ]
+  },
+  {
     "id": "ann-prime-block",
     "proofId": "erdos-220-incomplete-01",
     "range": {
@@ -8,7 +31,20 @@
     },
     "type": "insight",
     "title": "For a Prime, Coprimality Is Free",
-    "content": "reducedResidues_prime proves the reduced residues mod a prime p are exactly the contiguous block {1, 2, …, p−1}. The point is that the coprimality filter does nothing: any m with 1 ≤ m < p is automatically coprime to p, since p ∣ m would force p ≤ m (Nat.le_of_dvd), contradicting m < p. So the residues are consecutive integers — and consecutive integers have all gaps equal to 1."
+    "content": "reducedResidues_prime proves the reduced residues mod a prime p are exactly the contiguous block {1, 2, …, p−1}. The point is that the coprimality filter does nothing: any m with 1 ≤ m < p is automatically coprime to p, since p ∣ m would force p ≤ m (Nat.le_of_dvd), contradicting m < p. So the residues are consecutive integers — and consecutive integers have all gaps equal to 1.",
+    "mathContext": "$\\{m \\in [1,p) : \\gcd(m,p)=1\\} = \\{1,2,\\dots,p-1\\}$ since $p \\mid m \\Rightarrow p \\le m$ contradicts $m < p$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reduced residue system",
+      "coprimality to a prime",
+      "contiguous integer block",
+      "Nat.le_of_dvd"
+    ],
+    "prerequisites": [
+      "Euler totient φ(p) = p−1",
+      "divisibility and coprimality",
+      "Finset.Icc"
+    ]
   },
   {
     "id": "ann-tight",
@@ -19,7 +55,20 @@
     },
     "type": "concept",
     "title": "The Prime Is the Tight Case",
-    "content": "reducedResidues_prime_consecutive records that the prime residues run 1, …, p−1 with no holes, so every gap is 1 and ∑gaps² = p − 2. The companion entry's Cauchy–Schwarz lower bound is (n−2)² ≤ (φ(n)−1)·∑gaps², i.e. ∑gaps² ≥ (p−2)²/(p−2) = p − 2. For the prime this is an EQUALITY — Cauchy–Schwarz is tight exactly when all the gaps are equal, which is precisely the contiguous-block structure. The prime therefore realizes the n²/φ(n) order on the nose."
+    "content": "reducedResidues_prime_consecutive records that the prime residues run 1, …, p−1 with no holes, so every gap is 1 and ∑gaps² = p − 2. The companion entry's Cauchy–Schwarz lower bound is (n−2)² ≤ (φ(n)−1)·∑gaps², i.e. ∑gaps² ≥ (p−2)²/(p−2) = p − 2. For the prime this is an EQUALITY — Cauchy–Schwarz is tight exactly when all the gaps are equal, which is precisely the contiguous-block structure. The prime therefore realizes the n²/φ(n) order on the nose.",
+    "mathContext": "Equality in $(n-2)^2 \\le (\\varphi(n)-1)\\sum g_k^2$: $\\sum g_k^2 = \\frac{(p-2)^2}{p-2} = p-2$ when all $g_k = 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cauchy–Schwarz equality condition",
+      "squared gap sum",
+      "Montgomery–Vaughan bound",
+      "extremal configuration"
+    ],
+    "prerequisites": [
+      "Cauchy–Schwarz inequality",
+      "telescoping gap sum",
+      "companion entry erdos-220-oq-01"
+    ]
   },
   {
     "id": "ann-two-pow",
@@ -30,7 +79,20 @@
     },
     "type": "concept",
     "title": "Powers of Two: the Odd Numbers",
-    "content": "mem_reducedResidues_two_pow shows the reduced residues mod 2^k are exactly the odd numbers in [1, 2^k): coprimality to 2^k reduces to coprimality to 2 (Nat.coprime_pow_right_iff) and then to oddness (Nat.coprime_two_left). These form an arithmetic progression of common difference 2, so every gap is 2 — the second perfectly-regular family."
+    "content": "mem_reducedResidues_two_pow shows the reduced residues mod 2^k are exactly the odd numbers in [1, 2^k): coprimality to 2^k reduces to coprimality to 2 (Nat.coprime_pow_right_iff) and then to oddness (Nat.coprime_two_left). These form an arithmetic progression of common difference 2, so every gap is 2 — the second perfectly-regular family.",
+    "mathContext": "$\\gcd(m, 2^k) = 1 \\iff \\gcd(m,2) = 1 \\iff m$ odd; residues $= \\{1,3,5,\\dots,2^k-1\\}$, all gaps $= 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime power modulus",
+      "arithmetic progression of residues",
+      "Nat.coprime_pow_right_iff",
+      "oddness as coprimality to 2"
+    ],
+    "prerequisites": [
+      "coprimality to a prime power",
+      "φ(2^k) = 2^{k-1}",
+      "arithmetic progressions"
+    ]
   },
   {
     "id": "ann-concrete",
@@ -41,6 +103,19 @@
     },
     "type": "insight",
     "title": "Concrete Gaps: Regular vs Irregular",
-    "content": "For p = 7 the residues {1,2,3,4,5,6} have all five gaps equal to 1, so ∑gaps² = 5 = p − 2 (the tight prime case). For n = 8 the residues {1,3,5,7} have gaps all 2, ∑gaps² = 12 (order n²/φ(n) = 16). For the composite n = 12 the residues {1,5,7,11} have IRREGULAR gaps 4, 2, 4 — exactly the behaviour that makes the general Montgomery–Vaughan bound nontrivial. Every check is kernel decide, so no native_decide and no Lean.ofReduceBool enters."
+    "content": "For p = 7 the residues {1,2,3,4,5,6} have all five gaps equal to 1, so ∑gaps² = 5 = p − 2 (the tight prime case). For n = 8 the residues {1,3,5,7} have gaps all 2, ∑gaps² = 12 (order n²/φ(n) = 16). For the composite n = 12 the residues {1,5,7,11} have IRREGULAR gaps 4, 2, 4 — exactly the behaviour that makes the general Montgomery–Vaughan bound nontrivial. Every check is kernel decide, so no native_decide and no Lean.ofReduceBool enters.",
+    "mathContext": "$p=7$: gaps $1^5$, $\\sum g^2 = 5 = p-2$; $n=8$: gaps $2^3$, $\\sum g^2 = 12$; $n=12$: gaps $4,2,4$ (irregular).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked examples",
+      "kernel decide (no native_decide)",
+      "irregular gaps in composites",
+      "Montgomery–Vaughan tightness"
+    ],
+    "prerequisites": [
+      "explicit Finset/List computation",
+      "decide tactic and axiom hygiene",
+      "squared gap sum"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-220-incomplete-01` (quality 61, 0 prior passes; verified genuinely under-enriched on latest main — no prior Enrich commit).

## Gap addressed
meta.json (1096-char historicalContext, 5 keyInsights, 3 sections, 3 openQuestions) was already rich. The gap was **annotation depth**: the 4 existing annotations carried only `title` + `content`.

Changes to annotations.json:
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 existing annotations.
- Added a 5th annotation for the `reducedResidues` definition (lines 35-41), previously uncovered.

Now 5 annotations, every one with full metadata.

## Verification
- JSON validates (5 annotations, all four metadata fields present).
- Annotation ranges validate against the Lean source: `erdos-220-incomplete-01` produces **no** 'No Lean construct found' warnings in the annotations build.

Axiom integrity unchanged: status `verified`, badge `verified`, axiomCount 0 — consistent with the Lean source (0 sorries, 0 axioms, kernel `decide` only, no `native_decide`).