### PR TITLE
research(algebraic-reals-meager-oq-02): document resolution + add missing problem dir

### DIFF
--- a/research/problems/algebraic-reals-meager-oq-02/knowledge.md
+++ b/research/problems/algebraic-reals-meager-oq-02/knowledge.md
@@ -1,0 +1,51 @@
+# algebraic-reals-meager-oq-02 — Knowledge Base
+
+## Problem
+
+Quantify the comeagre transcendental complement as an explicit dense Gδ set, and
+relate comeagreness (category) to conullness (measure).
+
+## Status
+
+**RESOLVED — verified, 0 axioms, 0 sorries.**
+
+## Resolution (cross-file)
+
+The two halves of OQ-02 are fully formalized:
+
+### 1. The transcendentals are an explicit dense Gδ (the literal ask)
+File: `proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean`
+- `isGδ_compl_of_countable` / `dense_compl_of_countable` / `isGδ_dense_compl_of_countable`
+  — general: in a perfect T1 space the complement of a countable set is a dense Gδ.
+- `transcendentalReals_isGδ`, `transcendentalReals_dense_isGδ` — the transcendental
+  reals `{x : ℝ | ¬ IsAlgebraic ℚ x}` *are* a dense Gδ (not merely "contain one"), as
+  `⋂ a, {a}ᶜ` over the countable algebraic reals — mirroring Mathlib's `IsGδ.setOf_irrational`.
+- `transcendentalReals_residual_of_dense_Gδ` — hence residual (comeagre).
+- `algebraicReals_not_isGδ` — sharp dual: the algebraic reals are NOT Gδ (a dense
+  meagre set in a Baire space cannot be Gδ).
+
+### 2. Category vs measure (the contrast)
+File: `proofs/Proofs/AlgebraicRealsMeagerOQ02.lean`
+- `algebraicReals_null` — algebraic reals are Lebesgue-null (measure counterpart of meagre).
+- `ae_transcendental` — a.e. real is transcendental (transcendentals conull).
+- `liouville_residual` / `liouville_dense` / `liouville_null` — Liouville numbers are a
+  dense comeagre set of measure zero.
+- `exists_residual_dense_null` — **comeagre ⇏ conull**: ∃ dense comeagre null set.
+- `residual_ae_disjoint` — `Disjoint (residual ℝ) (ae volume)`: the two σ-ideals are orthogonal.
+
+## Verification
+
+Both files compile under `lake env lean` (mathlib 4.26.0). `#print axioms` on the
+transcendental-Gδ theorems shows only propext / Classical.choice / Quot.sound — no
+`native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.
+
+## Sessions
+
+### Session 2026-06-25 (researcher-5)
+Claimed `algebraic-reals-meager-oq-02` (fresh, knowledge score 0). Investigation found
+the problem is **already fully resolved and verified** across the two files above; the
+seeker had re-minted it because the `research/problems/algebraic-reals-meager-oq-02`
+directory was missing (only `oq-01` existed). Per the project's credibility policy
+(no fabricated/redundant theorems), this session records the resolution and adds the
+missing problem directory so the problem is no longer re-selected as fresh. Confirmed
+both Lean files still build cleanly offline.

--- a/research/problems/algebraic-reals-meager-oq-02/problem.md
+++ b/research/problems/algebraic-reals-meager-oq-02/problem.md
@@ -1,0 +1,43 @@
+# Problem: algebraic-reals-meager-oq-02
+
+## Statement
+
+### Plain Language
+Quantify the comeagre transcendental complement as an explicit dense Gδ set, and
+relate the topological notion of largeness (comeagre / residual) to the
+measure-theoretic notion (conull / a.e.).
+
+This is an open-question offshoot of the gallery entry **"The Algebraic Reals are
+Meagre"**: the parent proves the algebraic reals are meagre, so the transcendentals
+are comeagre (residual) and dense. OQ-02 asks to make the "comeagre" statement
+*explicit* — exhibit the transcendentals as a concrete dense Gδ — and to contrast
+category with measure.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 8
+tags:
+  - topology
+  - baire-category
+  - real-analysis
+  - meagre-set
+  - algebraic-numbers
+  - transcendental-numbers
+  - descriptive-set-theory
+```
+
+## Status
+
+**RESOLVED (verified, 0 axioms).** See the State and Knowledge files. Both halves of
+the question are fully formalized and machine-checked across two gallery entries.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `algebraic-reals-meager` | Parent: algebraic reals are meagre ⇒ transcendentals comeagre |
+| `algebraic-reals-meager-dense-gdelta` | The transcendentals **are** an explicit dense Gδ (literal OQ-02 ask) |
+| `algebraic-reals-meager-oq-02` | Measure companion: comeagre ⇏ conull (Liouville witness) |

--- a/research/problems/algebraic-reals-meager-oq-02/state.md
+++ b/research/problems/algebraic-reals-meager-oq-02/state.md
@@ -1,0 +1,40 @@
+# Current State
+
+**Phase**: RESOLVED
+**Since**: 2026-06-25
+**Iteration**: 1
+
+## Current Focus
+
+Documenting that OQ-02 is already fully resolved and verified across two gallery
+entries. No new mathematics was needed — this session records the resolution and
+adds the missing `research/problems` directory (previously absent, which caused the
+seeker to re-mint the problem as fresh).
+
+## Active Approach
+
+None — problem resolved. Both halves are machine-checked:
+1. **Explicit dense Gδ** (the literal ask) — `AlgebraicRealsMeagerDenseGDelta.lean`:
+   `transcendentalReals_isGδ`, `transcendentalReals_dense_isGδ`,
+   `transcendentalReals_residual_of_dense_Gδ`, and the sharp dual
+   `algebraicReals_not_isGδ`.
+2. **Category vs measure** — `AlgebraicRealsMeagerOQ02.lean`: `algebraicReals_null`,
+   `ae_transcendental`, `liouville_residual`/`liouville_null`,
+   `exists_residual_dense_null` (comeagre ⇏ conull), `residual_ae_disjoint`.
+
+Both files build clean offline (`lake env lean`, mathlib 4.26) with only the standard
+axiom triple (propext / Classical.choice / Quot.sound) — 0 declared axioms, 0 sorries.
+
+## Blockers
+
+None.
+
+## Next Action
+
+None. Problem resolved; claim released.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 0
+- Approaches tried: 0


### PR DESCRIPTION
## algebraic-reals-meager-oq-02 — already resolved; recording it

**OQ-02 asks:** *quantify the comeagre transcendental complement as an explicit dense Gδ set, and relate comeagreness (category) to conullness (measure).*

On investigation this is **already fully resolved and machine-checked** across two existing gallery entries — no new mathematics is warranted, and fabricating redundant theorems would violate the project's credibility policy. This PR records the resolution and adds the **missing `research/problems/algebraic-reals-meager-oq-02/` directory** (only `oq-01` existed), which is why the seeker re-minted the problem as fresh (knowledge score 0).

### Where it's resolved
- **Literal dense-Gδ ask** — `proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean`: `transcendentalReals_isGδ`, `transcendentalReals_dense_isGδ` (the transcendentals *are* `⋂ a, {a}ᶜ`, a dense Gδ — not merely "contain one"), plus the sharp dual `algebraicReals_not_isGδ`.
- **Category vs measure** — `proofs/Proofs/AlgebraicRealsMeagerOQ02.lean`: `algebraicReals_null`, `ae_transcendental`, the Liouville witness `exists_residual_dense_null` (**comeagre ⇏ conull**), and `residual_ae_disjoint`.

### Verification
Both Lean files rebuild clean offline (`lake env lean`, mathlib 4.26.0) and are axiom-honest (`propext` / `Classical.choice` / `Quot.sound` only — no `native_decide`, no `sorryAx`).

This PR contains **only documentation** (problem.md / state.md / knowledge.md); no Lean or gallery-data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)