### PR TITLE
Enrich Neumann Series (geometric-series-oq-02-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 39, "endLine": 62 },
     "type": "concept",
     "title": "The Neumann Series Identity",
-    "content": "neumann_series is the operator-theoretic geometric series: in a normed ring with summable geometric series (any Banach algebra), ‖t‖ < 1 gives (1 − t)⁻¹ = ∑' n, tⁿ. It is Mathlib's geom_series_eq_inverse read in the natural direction. hasSum_neumann_series records the same fact as a HasSum (the partial sums converge to the inverse), and summable_neumann_series notes the series converges because ‖tⁿ‖ ≤ ‖t‖ⁿ is geometrically dominated."
+    "content": "neumann_series is the operator-theoretic geometric series: in a normed ring with summable geometric series (any Banach algebra), ‖t‖ < 1 gives (1 − t)⁻¹ = ∑' n, tⁿ. It is Mathlib's geom_series_eq_inverse read in the natural direction. hasSum_neumann_series records the same fact as a HasSum (the partial sums converge to the inverse), and summable_neumann_series notes the series converges because ‖tⁿ‖ ≤ ‖t‖ⁿ is geometrically dominated.",
+    "mathContext": "$\\|t\\| < 1 \\;\\Rightarrow\\; (1-t)^{-1} = \\sum_{n=0}^{\\infty} t^n$, generalizing $\\frac{1}{1-r} = \\sum_n r^n$ to a Banach algebra.",
+    "significance": "critical",
+    "relatedConcepts": ["Neumann series", "geometric series", "Banach algebra", "tsum / HasSum", "geometric domination"],
+    "prerequisites": ["normed rings", "summability in complete spaces", "geometric series"]
   },
   {
     "id": "ann-gs0201-invertibility",
@@ -13,7 +17,11 @@
     "range": { "startLine": 63, "endLine": 86 },
     "type": "technique",
     "title": "Invertibility and the Two-Sided Inverse",
-    "content": "isUnit_one_sub captures the qualitative heart: a perturbation of the identity by anything of norm < 1 stays invertible — the reason the unit group of a Banach algebra is open. neumann_mul_left and neumann_mul_right then verify the series really is a two-sided inverse of 1 − t: each rewrites ∑' n, tⁿ back to Ring.inverse (1 − t) and applies Ring.inverse_mul_cancel / mul_inverse_cancel with the unit witness from isUnit_one_sub."
+    "content": "isUnit_one_sub captures the qualitative heart: a perturbation of the identity by anything of norm < 1 stays invertible — the reason the unit group of a Banach algebra is open. neumann_mul_left and neumann_mul_right then verify the series really is a two-sided inverse of 1 − t: each rewrites ∑' n, tⁿ back to Ring.inverse (1 − t) and applies Ring.inverse_mul_cancel / mul_inverse_cancel with the unit witness from isUnit_one_sub.",
+    "mathContext": "$1-t \\in R^{\\times}$ when $\\|t\\|<1$; $\\;(1-t)\\sum_n t^n = \\sum_n t^n\\,(1-t) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["unit group", "open set of invertibles", "two-sided inverse", "Ring.inverse", "perturbation of the identity"],
+    "prerequisites": ["units in a ring", "Ring.inverse API"]
   },
   {
     "id": "ann-gs0201-truncation",
@@ -21,7 +29,11 @@
     "range": { "startLine": 87, "endLine": 104 },
     "type": "technique",
     "title": "Finite Truncation with Explicit Remainder",
-    "content": "neumann_partial_remainder (Mathlib's inverse_one_sub_nth_order') gives (1 − t)⁻¹ = (∑_{i<N} tⁱ) + tᴺ·(1 − t)⁻¹. The remainder term tᴺ·(1 − t)⁻¹ has norm at most ‖t‖ᴺ·‖(1 − t)⁻¹‖, which decays geometrically, so truncating after N terms yields an inverse to any prescribed accuracy. This is exactly the convergence mechanism of stationary iterative solvers and of successive approximation for integral equations."
+    "content": "neumann_partial_remainder (Mathlib's inverse_one_sub_nth_order') gives (1 − t)⁻¹ = (∑_{i<N} tⁱ) + tᴺ·(1 − t)⁻¹. The remainder term tᴺ·(1 − t)⁻¹ has norm at most ‖t‖ᴺ·‖(1 − t)⁻¹‖, which decays geometrically, so truncating after N terms yields an inverse to any prescribed accuracy. This is exactly the convergence mechanism of stationary iterative solvers and of successive approximation for integral equations.",
+    "mathContext": "$(1-t)^{-1} = \\sum_{i<N} t^i + t^N (1-t)^{-1}, \\quad \\|t^N(1-t)^{-1}\\| \\le \\|t\\|^N \\,\\|(1-t)^{-1}\\| \\to 0.$",
+    "significance": "key",
+    "relatedConcepts": ["truncation error", "geometric convergence", "iterative inversion", "stationary iterative methods", "successive approximation"],
+    "prerequisites": ["partial sums", "operator norm estimates"]
   },
   {
     "id": "ann-gs0201-summary",
@@ -29,6 +41,10 @@
     "range": { "startLine": 105, "endLine": 129 },
     "type": "concept",
     "title": "Summary: From Scalars to Operators",
-    "content": "The closing table pairs each result with its Mathlib backing. The scalar geometric series 1/(1 − r) = ∑ rⁿ is the R = ℝ case; abstracting to a normed ring makes the one identity cover scalars, matrices, and bounded operators at once. Downstream it yields the openness of the unit group, the analyticity of inversion and of the resolvent (λ − T)⁻¹, and the spectral theory built on them."
+    "content": "The closing table pairs each result with its Mathlib backing. The scalar geometric series 1/(1 − r) = ∑ rⁿ is the R = ℝ case; abstracting to a normed ring makes the one identity cover scalars, matrices, and bounded operators at once. Downstream it yields the openness of the unit group, the analyticity of inversion and of the resolvent (λ − T)⁻¹, and the spectral theory built on them.",
+    "mathContext": "$R = \\mathbb{R}$ recovers $\\tfrac{1}{1-r}=\\sum_n r^n$; general $R$ covers matrices and bounded operators, underpinning the resolvent $(\\lambda - T)^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["spectral theory", "resolvent", "holomorphic functional calculus", "operator algebras", "abstraction over normed rings"],
+    "prerequisites": ["functional analysis", "spectral theory basics"]
   }
 ]

--- a/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/index.ts
+++ b/src/data/proofs/geometric-series-oq-02-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ02OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOq02Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOq02Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOq02Oq03Oq01Data: ProofData = {
+  proof: geometricSeriesOq02Oq03Oq01Proof,
+  annotations: geometricSeriesOq02Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-02-oq-03-oq-01`.

## Quality improvements
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site.
- **Structured annotation fields** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 annotations (previously none had them).

meta.json was already complete (overview, conclusion, crossReferences, sections) and left intact. Content verified against the Lean source (Neumann series, two-sided inverse, truncation remainder). 0 axioms, 0 sorries unchanged.