### PR TITLE
research(erdos-1005-oq-02): § 5 — strict denominator growth + depth-two refinement [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -252,4 +252,66 @@ theorem mediant_is_min_denominator {a b c d : ℕ} (hb : 0 < b) (hd : 0 < d)
     have hpos : (0 : ℚ) < 1 / (d * (b + d) : ℚ) := by positivity
     linarith [hgap, hpos]
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 5: Strict denominator growth and depth-two refinement (toward counting)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The mediant denominator strictly exceeds the **left** endpoint denominator. -/
+theorem mediant_denom_gt_left {b d : ℕ} (hd : 0 < d) : b < b + d := by omega
+
+/-- The mediant denominator strictly exceeds the **right** endpoint denominator. -/
+theorem mediant_denom_gt_right {b d : ℕ} (hb : 0 < b) : d < b + d := by omega
+
+/-- **Strict growth of interior denominators.**  Every fraction strictly inside a
+unimodular gap has denominator strictly larger than *both* endpoint denominators:
+`q ≥ b + d > max b d`.  Refinement therefore strictly increases the smallest
+denominator present — the engine of any depth/counting argument. -/
+theorem interior_denom_gt_max {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q) (hhi : (p : ℚ) / q < (c : ℚ) / d) :
+    max b d < q := by
+  have hge := denom_ge_of_between hb hd hq h hlo hhi
+  omega
+
+/-- **Depth-two bound, left sub-gap.**  The left sub-gap `(a/b, (a+c)/(b+d))` is
+itself unimodular (`unimodular_left`), so any fraction strictly inside it has
+denominator `≥ b + (b+d) = 2b + d`. -/
+theorem denom_ge_left_subgap {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (↑(a + c) : ℚ) / ↑(b + d)) :
+    b + (b + d) ≤ q := by
+  have hbd : 0 < b + d := by omega
+  exact denom_ge_of_between hb hbd hq (unimodular_left h) hlo hhi
+
+/-- **Depth-two bound, right sub-gap.**  The right sub-gap `((a+c)/(b+d), c/d)` is
+itself unimodular (`unimodular_right`), so any fraction strictly inside it has
+denominator `≥ (b+d) + d = b + 2d`. -/
+theorem denom_ge_right_subgap {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (↑(a + c) : ℚ) / ↑(b + d) < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (c : ℚ) / d) :
+    (b + d) + d ≤ q := by
+  have hbd : 0 < b + d := by omega
+  exact denom_ge_of_between hbd hd hq (unimodular_right h) hlo hhi
+
+/-- **Second-smallest interior denominator.**  Every fraction strictly inside the
+gap *other than the mediant* falls in one of the two sub-gaps, so its denominator
+is `≥ (b+d) + min b d`.  Hence the mediant is the *unique* fraction of denominator
+`b+d` in the gap, and the next admissible denominator jumps by at least `min b d`.
+Iterating this strict growth is precisely the depth/counting route flagged as the
+next step toward the `1/12` run lower bound. -/
+theorem denom_ge_of_between_ne_mediant {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q) (hhi : (p : ℚ) / q < (c : ℚ) / d)
+    (hne : (p : ℚ) / q ≠ (↑(a + c) : ℚ) / ↑(b + d)) :
+    (b + d) + min b d ≤ q := by
+  rcases lt_or_gt_of_ne hne with hM | hM
+  · -- p/q lies strictly below the mediant ⇒ inside the left sub-gap
+    have hsub := denom_ge_left_subgap hb hd hq h hlo hM
+    omega
+  · -- p/q lies strictly above the mediant ⇒ inside the right sub-gap
+    have hsub := denom_ge_right_subgap hb hd hq h hM hhi
+    omega
+
 end Erdos1005OQ02

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -2,12 +2,12 @@
 
 **Phase**: FORMALIZED (verified infrastructure; open problem itself remains open)
 **Since**: 2026-06-25
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
 Formalized the exact arithmetic of mediant insertion on Farey gaps:
-`proofs/Proofs/Erdos1005ProblemOQ02.lean` (256 lines, 13 theorems, 1 def,
+`proofs/Proofs/Erdos1005ProblemOQ02.lean` (317 lines, 19 theorems, 1 def,
 0 sorries, 0 axioms; #print axioms reports only propext / Classical.choice /
 Quot.sound).
 
@@ -30,6 +30,18 @@ on the longest run of *similarly ordered* Farey fractions — is **not**
 addressed. That constant `c ∈ [1/12, 1/4]` remains open. This session
 formalizes the verified mediant calculus that such constructions rest on, not
 a resolution of the bound.
+
+## Iteration 3 addition (verified)
+
+Added **§5 (strict denominator growth + depth-two refinement)**, 0-sorry /
+0-axiom: `interior_denom_gt_max` (every in-gap fraction has denominator
+> max(b,d) — refinement strictly raises the smallest denominator);
+`denom_ge_left_subgap`/`denom_ge_right_subgap` (each sub-gap is again
+unimodular, giving depth-two bounds q ≥ 2b+d, q ≥ b+2d); and the headline
+`denom_ge_of_between_ne_mediant` — the mediant is the *unique* denominator-(b+d)
+point, and the next admissible denominator jumps by ≥ min(b,d). This is the
+strict-growth step the counting argument rests on; the 1/12 run constant itself
+remains open.
 
 ## Next Action
 

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 256,
+    "lineCount": 317,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 13
+    "theoremCount": 19
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -101,6 +101,13 @@
       "startLine": 152,
       "endLine": 254,
       "summary": "denom_identity (the ℤ kernel q = b·(cq−pd) + d·(pb−aq)); denom_ge_of_between (any in-gap fraction has q ≥ b+d); eq_mediant_of_denom_eq (equality forces p = a+c, the mediant); mediant_is_min_denominator (packaged: the mediant lies in the gap and minimises the denominator)."
+    },
+    {
+      "id": "denominator-growth",
+      "title": "§5 Strict denominator growth and depth-two refinement (toward counting)",
+      "startLine": 255,
+      "endLine": 316,
+      "summary": "mediant_denom_gt_left/_right (b < b+d, d < b+d); interior_denom_gt_max (every in-gap fraction has q > max b d, so refinement strictly raises the smallest denominator); denom_ge_left_subgap/denom_ge_right_subgap (the two sub-gaps are themselves unimodular, giving depth-two bounds q ≥ 2b+d and q ≥ b+2d); denom_ge_of_between_ne_mediant (every in-gap fraction other than the mediant has q ≥ (b+d)+min b d — the mediant is the unique denominator-(b+d) point, and the next admissible denominator jumps by at least min b d)."
     }
   ],
   "crossReferences": [
@@ -145,6 +152,12 @@
       "type": "supporting",
       "description": "The algebraic kernel over ℤ behind the denominator bound: q = b·(cq − pd) + d·(pb − aq), an unconditional identity once bc − ad = 1, verified by linear_combination.",
       "leanType": "∀ {a b c d p q : ℤ}, b * c = a * d + 1 → q = b * (c * q - p * d) + d * (p * b - a * q)"
+    },
+    {
+      "name": "denom_ge_of_between_ne_mediant",
+      "type": "headline",
+      "description": "Second-smallest interior denominator: every fraction p/q strictly inside a unimodular gap a/b < c/d that is NOT the mediant (a+c)/(b+d) lies in one of the two (again unimodular) sub-gaps, hence has q ≥ (b+d)+min b d. So the mediant is the unique fraction of denominator b+d in the gap, and the next admissible denominator is at least min b d larger — the strict-growth step underlying any depth/counting argument toward the 1/12 run bound.",
+      "leanType": "∀ {a b c d p q : ℕ}, 0 < b → 0 < d → 0 < q → Unimodular a b c d → (a:ℚ)/b < (p:ℚ)/q → (p:ℚ)/q < (c:ℚ)/d → (p:ℚ)/q ≠ (↑(a+c):ℚ)/↑(b+d) → (b+d)+min b d ≤ q"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Extends the merged mediant-gap calculus for Erdős #1005 (OQ-02) toward the **depth/counting argument** that the problem's `state.md` flagged as the next step toward the `f(n) ≥ (1/12 − o(1))n` run lower bound. Adds **§5** to `proofs/Proofs/Erdos1005ProblemOQ02.lean`: six new theorems, all **0-sorry / 0-axiom** (`#print axioms` reports only `propext / Classical.choice / Quot.sound`).

## New theorems (§5)

| Theorem | Statement |
|---|---|
| `mediant_denom_gt_left` / `_right` | `b < b+d`, `d < b+d` — the mediant denominator strictly exceeds each endpoint |
| `interior_denom_gt_max` | every fraction strictly inside a unimodular gap has denominator `> max b d` — refinement strictly raises the smallest denominator present |
| `denom_ge_left_subgap` / `denom_ge_right_subgap` | each sub-gap is itself unimodular (`unimodular_left/right`), giving depth-two bounds `q ≥ 2b+d` and `q ≥ b+2d` |
| `denom_ge_of_between_ne_mediant` (headline) | every in-gap fraction *other than the mediant* lies in one sub-gap, so `q ≥ (b+d) + min b d`: the mediant is the **unique** denominator-`(b+d)` point and the next admissible denominator jumps by `≥ min b d` |

These reuse the already-verified `denom_ge_of_between`, `unimodular_left`, `unimodular_right` from §3–§4 — the depth-two bounds are exactly "apply the minimal-denominator theorem to each sub-gap," and the headline is the trichotomy combining them.

## Scope / honesty

This does **not** resolve the open problem — the leading constant `c ∈ [1/12, 1/4]` for runs of *similarly ordered* Farey fractions remains open. §5 formalizes the strict-growth step that any depth/counting construction over consecutive mediant insertions rests on.

## Verification

- `lake env lean Proofs/Erdos1005ProblemOQ02.lean` → exit 0 (Docker wrapper unavailable; typechecked against the shared Mathlib oleans).
- `#print axioms` on all four headline theorems → `[propext, Classical.choice, Quot.sound]` only ⇒ `axiomCount = 0`, `status: verified`.
- `meta.json` updated: `theoremCount 13→19`, `lineCount 256→317`, new §5 section + `denom_ge_of_between_ne_mediant` mainTheorem. `state.md` → iteration 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)