### PR TITLE
Enrich Ceva non-Euclidean flat limit (cevas-theorem-non-euclidean-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-01-oq-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "ann-programme",
+    "proofId": "cevas-theorem-non-euclidean-oq-01-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 40
+    },
+    "type": "concept",
+    "title": "The Flat Limit That Closes the Parent's Open Question",
+    "content": "The docstring states the single analytic fact the parent entry left open: that the curvature sine sin_κ(x) — equal to sin(√κ·x)/√κ for κ > 0, x for κ = 0, and sinh(√(−κ)·x)/√(−κ) for κ < 0 — converges to x as κ → 0. Proving this two-sidedly shows the curved Ceva theorem degenerates *continuously* to the Euclidean one. The strategy is to recognise each branch as a difference quotient (a slope at 0) of t ↦ sin(x·t) or t ↦ sinh(x·t), whose derivatives at 0 are both x (since cos 0 = cosh 0 = 1), then change variables √κ → 0⁺ and glue the one-sided limits with the exact value at κ = 0.",
+    "mathContext": "$\\sin_\\kappa(x) \\to x$ as $\\kappa \\to 0$; branches $\\frac{\\sin(\\sqrt\\kappa\\,x)}{\\sqrt\\kappa}$ ($\\kappa>0$), $x$ ($\\kappa=0$), $\\frac{\\sinh(\\sqrt{-\\kappa}\\,x)}{\\sqrt{-\\kappa}}$ ($\\kappa<0$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "curvature sine sin_κ",
+      "non-Euclidean Ceva theorem",
+      "continuous deformation of geometry",
+      "spherical vs hyperbolic branch"
+    ],
+    "prerequisites": [
+      "filters and Tendsto",
+      "derivative as a limit of slopes",
+      "parent entry cevas-theorem-non-euclidean-oq-01"
+    ]
+  },
+  {
     "id": "ann-slope-kernel",
     "proofId": "cevas-theorem-non-euclidean-oq-01-oq-01",
     "range": {
@@ -8,7 +32,20 @@
     },
     "type": "insight",
     "title": "The Flat Limit Is a Derivative in Disguise",
-    "content": "On the spherical branch sin_κ(x) = sin(√κ·x)/√κ. Substituting s = √κ, this is exactly the difference quotient (sin(s·x) − sin(0))/(s − 0) of the map t ↦ sin(x·t) at the point 0 — i.e. its slope at 0. By hasDerivAt_iff_tendsto_slope, the limit of that slope is the derivative, which is x·cos 0 = x. So the flat limit is not a delicate ε–δ estimate: it is the value of a derivative. tendsto_sin_mul_div and tendsto_sinh_mul_div package this for sin and sinh. Phrasing the kernel as the slope of t ↦ sin(x·t) — rather than as x·(sin u / u) — makes the argument uniform in x, with no special case at x = 0."
+    "content": "On the spherical branch sin_κ(x) = sin(√κ·x)/√κ. Substituting s = √κ, this is exactly the difference quotient (sin(s·x) − sin(0))/(s − 0) of the map t ↦ sin(x·t) at the point 0 — i.e. its slope at 0. By hasDerivAt_iff_tendsto_slope, the limit of that slope is the derivative, which is x·cos 0 = x. So the flat limit is not a delicate ε–δ estimate: it is the value of a derivative. tendsto_sin_mul_div and tendsto_sinh_mul_div package this for sin and sinh. Phrasing the kernel as the slope of t ↦ sin(x·t) — rather than as x·(sin u / u) — makes the argument uniform in x, with no special case at x = 0.",
+    "mathContext": "$\\frac{\\sin(x t)}{t} = \\mathrm{slope}_0(t \\mapsto \\sin(x t)) \\to \\frac{d}{dt}\\sin(x t)\\big|_0 = x\\cos 0 = x$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "difference quotient / slope",
+      "hasDerivAt_iff_tendsto_slope",
+      "derivative of sin and sinh at 0",
+      "uniformity in x"
+    ],
+    "prerequisites": [
+      "HasDerivAt and the chain rule",
+      "slope_fun_def_field",
+      "punctured neighbourhood filter 𝓝[≠] 0"
+    ]
   },
   {
     "id": "ann-sqrt-cov",
@@ -19,7 +56,20 @@
     },
     "type": "technique",
     "title": "κ → 0 Becomes √κ → 0, the Slope Increment",
-    "content": "The √κ normalization that makes sin_κ a genuine geometric interpolant is precisely what turns the curvature limit into a difference-quotient limit. sqrt_tendsto_nhdsGT shows √κ → 0⁺ as κ → 0⁺ (continuity of √ plus √κ > 0), and sqrt_neg_tendsto_nhdsLT shows √(−κ) → 0⁺ as κ → 0⁻. Composing these with the kernels transports the limit in the slope increment t to a limit in the curvature κ. The right-punctured filter feeds the kernel's punctured-neighbourhood hypothesis via nhdsGT_le_nhdsNE."
+    "content": "The √κ normalization that makes sin_κ a genuine geometric interpolant is precisely what turns the curvature limit into a difference-quotient limit. sqrt_tendsto_nhdsGT shows √κ → 0⁺ as κ → 0⁺ (continuity of √ plus √κ > 0), and sqrt_neg_tendsto_nhdsLT shows √(−κ) → 0⁺ as κ → 0⁻. Composing these with the kernels transports the limit in the slope increment t to a limit in the curvature κ. The right-punctured filter feeds the kernel's punctured-neighbourhood hypothesis via nhdsGT_le_nhdsNE.",
+    "mathContext": "$\\sqrt{\\cdot} : \\mathcal{N}[>]0 \\to \\mathcal{N}[>]0$ and $\\kappa \\mapsto \\sqrt{-\\kappa} : \\mathcal{N}[<]0 \\to \\mathcal{N}[>]0$; compose with the kernel.",
+    "significance": "key",
+    "relatedConcepts": [
+      "change of variables in a limit",
+      "one-sided neighbourhood filters 𝓝[>]/𝓝[<]",
+      "continuity of Real.sqrt",
+      "Tendsto.comp"
+    ],
+    "prerequisites": [
+      "nhdsWithin and tendsto_nhdsWithin_iff",
+      "filter_upwards / self_mem_nhdsWithin",
+      "Real.sqrt_pos"
+    ]
   },
   {
     "id": "ann-gluing",
@@ -30,7 +80,20 @@
     },
     "type": "insight",
     "title": "Two Geometries Meet at κ = 0 from Opposite Sides",
-    "content": "Spherical geometry approaches κ = 0 from 𝓝[>] 0 and hyperbolic from 𝓝[<] 0. The standard filter identity 𝓝[<] 0 ⊔ 𝓝[>] 0 = 𝓝[≠] 0 (nhdsLT_sup_nhdsGT) glues the two one-sided flat limits into a punctured two-sided limit (tendsto_sinKappa_punctured). Adjoining the exact value sin_0(x) = x via 𝓝[≠] 0 ⊔ pure 0 = 𝓝 0 (nhdsNE_sup_pure) upgrades it to the full continuous limit tendsto_sinKappa_flat — the formal answer to the parent's OQ-01."
+    "content": "Spherical geometry approaches κ = 0 from 𝓝[>] 0 and hyperbolic from 𝓝[<] 0. The standard filter identity 𝓝[<] 0 ⊔ 𝓝[>] 0 = 𝓝[≠] 0 (nhdsLT_sup_nhdsGT) glues the two one-sided flat limits into a punctured two-sided limit (tendsto_sinKappa_punctured). Adjoining the exact value sin_0(x) = x via 𝓝[≠] 0 ⊔ pure 0 = 𝓝 0 (nhdsNE_sup_pure) upgrades it to the full continuous limit tendsto_sinKappa_flat — the formal answer to the parent's OQ-01.",
+    "mathContext": "$\\mathcal{N}[<]0 \\sqcup \\mathcal{N}[>]0 = \\mathcal{N}[\\ne]0$, then $\\mathcal{N}[\\ne]0 \\sqcup \\mathrm{pure}\\,0 = \\mathcal{N}\\,0$, with $\\sin_0(x)=x$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "gluing one-sided limits",
+      "nhdsLT_sup_nhdsGT",
+      "nhdsNE_sup_pure",
+      "tendsto_sup"
+    ],
+    "prerequisites": [
+      "supremum of filters and Tendsto",
+      "pure filter and tendsto_pure_nhds",
+      "sinKappa_zero"
+    ]
   },
   {
     "id": "ann-ceva-degeneration",
@@ -41,6 +104,18 @@
     },
     "type": "insight",
     "title": "The Curved Ceva Condition Deforms to the Flat One",
-    "content": "Because sin_κ is continuous at κ = 0 with limit the identity, each curvature-κ Ceva ratio sin_κ(p)/sin_κ(q) tends to the Euclidean ratio p/q as κ → 0 (sinKappa_ceva_ratio_tendsto). Taking the product over the six sub-segments, the curvature-κ concurrency criterion limits to the Euclidean one: the curved Ceva theorem is a genuine deformation of the flat theorem, not an unrelated statement."
+    "content": "Because sin_κ is continuous at κ = 0 with limit the identity, each curvature-κ Ceva ratio sin_κ(p)/sin_κ(q) tends to the Euclidean ratio p/q as κ → 0 (sinKappa_ceva_ratio_tendsto). Taking the product over the six sub-segments, the curvature-κ concurrency criterion limits to the Euclidean one: the curved Ceva theorem is a genuine deformation of the flat theorem, not an unrelated statement.",
+    "mathContext": "$\\frac{\\sin_\\kappa(p)}{\\sin_\\kappa(q)} \\to \\frac{p}{q}$ as $\\kappa \\to 0$ (for $q \\ne 0$), via Tendsto.div.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ceva's theorem concurrency criterion",
+      "deformation of a theorem",
+      "Tendsto.div",
+      "Euclidean limit of curved geometry"
+    ],
+    "prerequisites": [
+      "the full flat limit tendsto_sinKappa_flat",
+      "limit of a quotient with nonzero denominator"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cevas-theorem-non-euclidean-oq-01-oq-01` (quality 61, 0 prior passes; verified under-enriched on latest main — no prior Enrich commit).

## Gap addressed
meta.json (overview, 3 sections, conclusion) was already rich. The gap was **annotation depth**: the 4 existing annotations carried only `title` + `content`.

Changes to annotations.json:
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 existing annotations.
- Added a 5th annotation covering the module docstring/programme (lines 5-40), previously uncovered.

Now 5 annotations, every one with full metadata.

## Verification
- JSON validates (5 annotations, all four metadata fields present).
- Annotation ranges validate against the Lean source: no 'No Lean construct found' warnings for this entry in the annotations build.

Axiom integrity unchanged: status `verified`, axiomCount 0 (0 sorries, 0 axioms).