### PR TITLE
Enrich Hilbert 14 OQ-02: Sₙ degree bounds (hilbert-14-oq-02)

### DIFF
--- a/src/data/proofs/hilbert-14-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-14-oq-02/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-scope",
+    "proofId": "hilbert-14-oq-02",
+    "range": {
+      "startLine": 6,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "The Model Case for Hilbert 14's Degree-Bound Question",
+    "content": "The parent's OQ-02 asks for optimal degree bounds for general reductive groups — subtle and partly open. This entry resolves it completely for the symmetric group Sₙ, the textbook reductive (finite) group: the answer β(Sₙ) = n is exact, sharp in both the number of generators and their degrees. It is the natural anchor case from which Noether's bound β(G) ≤ |G| for general finite groups, and the harder reductive constants, generalize.",
+    "mathContext": "$R[x_1,\\dots,x_n]^{S_n} = R[e_1,\\dots,e_n]$ with $\\beta(S_n) = n$; Noether: $\\beta(G) \\le |G|$ for finite $G$.",
+    "significance": "supporting",
+    "relatedConcepts": ["invariant theory", "Hilbert's 14th problem", "reductive groups", "Noether bound", "degree bound β(G)"],
+    "prerequisites": ["group actions on polynomial rings", "invariant rings"]
+  },
+  {
     "id": "ann-generation",
     "proofId": "hilbert-14-oq-02",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "The Fundamental Theorem as the Optimal-Generation Statement",
-    "content": "symmetric_eq_aeval_esymm is the invariant-theory reading of Mathlib's esymmAlgHom_surjective: every Sₙ-invariant (symmetric polynomial) is a polynomial expression in the n elementary symmetric polynomials e₁,…,eₙ. The proof lifts a symmetric p into symmetricSubalgebra, pulls it back through the surjective esymmAlgHom, and unfolds esymmAlgHom_apply to recover p = aeval (e₁,…,eₙ) q. symmetric_algEquiv_polynomial then records that for |σ| = n the invariant ring is a free polynomial ring on these n generators — the Fundamental Theorem of Symmetric Polynomials."
+    "content": "symmetric_eq_aeval_esymm is the invariant-theory reading of Mathlib's esymmAlgHom_surjective: every Sₙ-invariant (symmetric polynomial) is a polynomial expression in the n elementary symmetric polynomials e₁,…,eₙ. The proof lifts a symmetric p into symmetricSubalgebra, pulls it back through the surjective esymmAlgHom, and unfolds esymmAlgHom_apply to recover p = aeval (e₁,…,eₙ) q. symmetric_algEquiv_polynomial then records that for |σ| = n the invariant ring is a free polynomial ring on these n generators — the Fundamental Theorem of Symmetric Polynomials.",
+    "mathContext": "$p \\text{ symmetric} \\;\\Rightarrow\\; p = q(e_1,\\dots,e_n)$ for a unique $q$; $\\;R[x_\\sigma]^{S_n} \\cong R[y_1,\\dots,y_n]$ (free).",
+    "significance": "critical",
+    "relatedConcepts": ["Fundamental Theorem of Symmetric Polynomials", "elementary symmetric polynomials", "surjective algebra homomorphism", "aeval", "subalgebra"],
+    "prerequisites": ["symmetric polynomials", "algebra homomorphisms", "polynomial rings"]
   },
   {
     "id": "ann-optimal-number",
@@ -19,7 +38,11 @@
     },
     "type": "insight",
     "title": "Exactly n Generators — Algebraic Independence",
-    "content": "esymm_algebraicIndependent shows the bound is sharp in the number of generators: e₁,…,eₙ are algebraically independent over R. The key is that aeval (e₁,…,eₙ) factors as the subalgebra inclusion (Subtype.val, injective) composed with esymmAlgHom, which is injective by the Fundamental Theorem; a composition of injections is injective, and algebraicIndependent_iff_injective_aeval converts that to algebraic independence. So no eₖ is a polynomial in the others — the generating set cannot be shrunk."
+    "content": "esymm_algebraicIndependent shows the bound is sharp in the number of generators: e₁,…,eₙ are algebraically independent over R. The key is that aeval (e₁,…,eₙ) factors as the subalgebra inclusion (Subtype.val, injective) composed with esymmAlgHom, which is injective by the Fundamental Theorem; a composition of injections is injective, and algebraicIndependent_iff_injective_aeval converts that to algebraic independence. So no eₖ is a polynomial in the others — the generating set cannot be shrunk.",
+    "mathContext": "$e_1,\\dots,e_n$ algebraically independent $\\iff$ $\\mathrm{aeval}(e_1,\\dots,e_n)$ injective; injectivity inherited from $\\mathrm{esymmAlgHom}$ via the subalgebra inclusion.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic independence", "injective composition", "esymmAlgHom_injective", "minimal generating set"],
+    "prerequisites": ["algebraic independence", "injective maps", "algebra isomorphisms"]
   },
   {
     "id": "ann-degrees",
@@ -30,17 +53,10 @@
     },
     "type": "concept",
     "title": "Why eₖ Has Degree k: a Combinatorial Multidegree",
-    "content": "esymm_isHomogeneous proves eₖ is homogeneous of degree k. Writing eₖ = ∑_{|t|=k} ∏_{i∈t} xᵢ (esymm_eq_sum_monomial), each summand is a monomial whose multidegree is the indicator finsupp ∑_{i∈t} single i 1. Because Finsupp.degree is an additive monoid hom, map_sum and degree_single compute its degree as ∑_{i∈t} 1 = |t| = k. So every monomial — and hence eₖ — is homogeneous of degree k (isHomogeneous_monomial + IsHomogeneous.sum). Thus the generators have degrees 1,…,n, esymm_totalDegree_le gives degree ≤ n, and the optimal bound is β(Sₙ) = n, attained by eₙ = x₁⋯xₙ."
-  },
-  {
-    "id": "ann-scope",
-    "proofId": "hilbert-14-oq-02",
-    "range": {
-      "startLine": 6,
-      "endLine": 38
-    },
-    "type": "concept",
-    "title": "The Model Case for Hilbert 14's Degree-Bound Question",
-    "content": "The parent's OQ-02 asks for optimal degree bounds for general reductive groups — subtle and partly open. This entry resolves it completely for the symmetric group Sₙ, the textbook reductive (finite) group: the answer β(Sₙ) = n is exact, sharp in both the number of generators and their degrees. It is the natural anchor case from which Noether's bound β(G) ≤ |G| for general finite groups, and the harder reductive constants, generalize."
+    "content": "esymm_isHomogeneous proves eₖ is homogeneous of degree k. Writing eₖ = ∑_{|t|=k} ∏_{i∈t} xᵢ (esymm_eq_sum_monomial), each summand is a monomial whose multidegree is the indicator finsupp ∑_{i∈t} single i 1. Because Finsupp.degree is an additive monoid hom, map_sum and degree_single compute its degree as ∑_{i∈t} 1 = |t| = k. So every monomial — and hence eₖ — is homogeneous of degree k (isHomogeneous_monomial + IsHomogeneous.sum). Thus the generators have degrees 1,…,n, esymm_totalDegree_le gives degree ≤ n, and the optimal bound is β(Sₙ) = n, attained by eₙ = x₁⋯xₙ.",
+    "mathContext": "$e_k = \\sum_{|t|=k}\\prod_{i\\in t} x_i$ is homogeneous of degree $k$; $\\deg(\\sum_{i\\in t}\\mathbf{1}_i) = |t| = k$, so $\\beta(S_n) = n$ via $e_n = x_1\\cdots x_n$.",
+    "significance": "key",
+    "relatedConcepts": ["homogeneous polynomial", "multidegree", "Finsupp.degree", "squarefree monomial", "total degree"],
+    "prerequisites": ["graded polynomial rings", "Finsupp", "monomial degrees"]
   }
 ]

--- a/src/data/proofs/hilbert-14-oq-02/index.ts
+++ b/src/data/proofs/hilbert-14-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert14OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert14Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert14Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert14Oq02Data: ProofData = {
+  proof: hilbert14Oq02Proof,
+  annotations: hilbert14Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `hilbert-14-oq-02`.

## Quality improvements
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site.
- **Structured annotation fields** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 annotations (previously none had them).
- **Reordered annotations** into source-line order (scope annotation, lines 6–38, now first).

meta.json was already complete (overview, conclusion, crossReferences, sections, references) and left intact. Content verified against the Lean source (Fundamental Theorem of Symmetric Polynomials, algebraic independence, eₖ homogeneity). 0 axioms, 0 sorries unchanged.