### PR TITLE
research(chebyshev-bounds-oq-02-oq-01-oq-01): explicit two-sided θ bounds — θ(m)=Θ(m) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -840,6 +840,7 @@ import Proofs.CevasTheoremSinRatio
 import Proofs.ChebyshevBounds
 import Proofs.ChebyshevBoundsOQ02
 import Proofs.ChebyshevBoundsOQ02OQ01
+import Proofs.ChebyshevBoundsOQ02OQ01OQ01
 import Proofs.ChebyshevBoundsOQ02OQ02
 import Proofs.ChebyshevBoundsOQ03
 import Proofs.ChebyshevBoundsOQ04

--- a/proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ01.lean
@@ -1,0 +1,82 @@
+import Mathlib
+import Proofs.ChebyshevBoundsOQ02OQ01
+import Proofs.ChebyshevBoundsOQ02OQ02
+
+/-
+# Explicit Two-Sided Bounds on the Chebyshev θ Function
+
+The first Chebyshev function `θ(n) = ∑_{p ≤ n} log p` is, like `ψ`, of linear
+order `Θ(n)` — this is the elementary heart of the prime number theorem.
+
+Mathlib provides the clean *upper* bound `Chebyshev.theta_le_log4_mul_x`
+(`θ(x) ≤ log 4 · x`), but **no** matching lower bound for either `θ` or `ψ`.
+The substantive lower estimate lives in this project:
+`ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear` proves
+`(log 2 / 3)·m ≤ ψ(m)` for `m ≥ 2` (from the central binomial coefficient).
+
+Here we transfer that lower bound from `ψ` to `θ` using the closeness estimate
+`ChebyshevBoundsOQ02OQ02.abs_psi_sub_theta_le`
+(`|ψ(n) − θ(n)| ≤ 2·√n·log n`, Mathlib's `abs_psi_sub_theta_le_sqrt_mul_log`
+via the project's bridge). Since `ψ` and `θ` differ by only `O(√n·log n)`, the
+linear lower bound on `ψ` descends to `θ` up to that lower-order correction:
+
+  `(log 2 / 3)·m − 2·√m·log m  ≤  θ(m)  ≤  log 4 · m`    for `m ≥ 2`.
+
+This pins `θ(m) = Θ(m)` with explicit constants — a result stated nowhere in
+Mathlib (which has only the upper half) and not previously assembled in this
+project.
+-/
+
+namespace ChebyshevBoundsOQ02OQ01OQ01
+
+open ChebyshevBoundsOQ02 ChebyshevBoundsOQ02OQ02
+
+/--
+**Explicit linear lower bound for `θ`.**
+
+For `m ≥ 2`,
+`(log 2 / 3)·m − 2·√m·log m ≤ θ(m)`.
+
+Proof: `θ(m) = ψ(m) − (ψ(m) − θ(m))`. The lower bound
+`(log 2 / 3)·m ≤ ψ(m)` (`chebyshevPsi_lower_linear`) and the closeness bound
+`ψ(m) − θ(m) ≤ |ψ(m) − θ(m)| ≤ 2·√m·log m` (`abs_psi_sub_theta_le`) combine
+linearly. The correction `2·√m·log m` is lower order, so for large `m` the bound
+is `≈ (log 2 / 3)·m`, confirming `θ(m) = Θ(m)`.
+-/
+theorem chebyshevTheta_lower {m : ℕ} (hm : 2 ≤ m) :
+    Real.log 2 / 3 * (m : ℝ) - 2 * Real.sqrt m * Real.log m ≤ chebyshevTheta m := by
+  have hpsi : Real.log 2 / 3 * (m : ℝ) ≤ chebyshevPsi m :=
+    ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear hm
+  have hdiff : |chebyshevPsi m - chebyshevTheta m| ≤ 2 * Real.sqrt m * Real.log m :=
+    ChebyshevBoundsOQ02OQ02.abs_psi_sub_theta_le m (by omega)
+  have h1 : chebyshevPsi m - chebyshevTheta m ≤ 2 * Real.sqrt m * Real.log m :=
+    (le_abs_self _).trans hdiff
+  linarith
+
+/--
+**Explicit linear upper bound for `θ`.**
+
+`θ(n) ≤ log 4 · n` for every `n`. This is Mathlib's `Chebyshev.theta_le_log4_mul_x`
+transported through the project's bridge `chebyshevTheta_eq_mathlib`.
+-/
+theorem chebyshevTheta_upper (n : ℕ) :
+    chebyshevTheta n ≤ Real.log 4 * (n : ℝ) := by
+  rw [chebyshevTheta_eq_mathlib]
+  exact Chebyshev.theta_le_log4_mul_x (by positivity)
+
+/--
+**Two-sided explicit Chebyshev `θ` bounds:**
+`(log 2 / 3)·m − 2·√m·log m ≤ θ(m) ≤ log 4 · m` for `m ≥ 2`.
+
+The elementary `θ(m) = Θ(m)` with both endpoints explicit: the upper bound is
+Mathlib's `log 4 · m`, while the lower bound is obtained by descending this
+project's `ψ` lower bound `(log 2 / 3)·m` across the `O(√m·log m)` gap between
+`ψ` and `θ`. Mathlib supplies only the upper inequality, so the lower bound is
+the new content.
+-/
+theorem chebyshevTheta_bounds {m : ℕ} (hm : 2 ≤ m) :
+    Real.log 2 / 3 * (m : ℝ) - 2 * Real.sqrt m * Real.log m ≤ chebyshevTheta m ∧
+      chebyshevTheta m ≤ Real.log 4 * (m : ℝ) :=
+  ⟨chebyshevTheta_lower hm, chebyshevTheta_upper m⟩
+
+end ChebyshevBoundsOQ02OQ01OQ01

--- a/research/problems/chebyshev-bounds-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/chebyshev-bounds-oq-02-oq-01-oq-01/knowledge.md
@@ -1,0 +1,50 @@
+# Knowledge: chebyshev-bounds-oq-02-oq-01-oq-01
+
+## Summary
+
+Explicit two-sided bound on the first Chebyshev function
+`θ(n) = ∑_{p ≤ n} log p`, establishing `θ(m) = Θ(m)`:
+
+`(log 2 / 3)·m − 2·√m·log m ≤ θ(m) ≤ log 4 · m`  for `m ≥ 2`.
+
+## What is formalized (researcher-9, 2026-06-25)
+
+`proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ01.lean`, namespace
+`ChebyshevBoundsOQ02OQ01OQ01`, 0 axioms / 0 sorries:
+
+| Theorem | Statement |
+|---|---|
+| `chebyshevTheta_lower` | `2 ≤ m → (log2/3)·m − 2√m·log m ≤ θ(m)` |
+| `chebyshevTheta_upper` | `θ(n) ≤ log4·n` |
+| `chebyshevTheta_bounds` | two-sided, `m ≥ 2` |
+
+## Lineage / dependencies
+
+- `ChebyshevBoundsOQ02.chebyshevPsi := ∑_{m ∈ Icc 1 n} Λ m`
+- `ChebyshevBoundsOQ02OQ02.chebyshevTheta` (Chebyshev θ)
+- `ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear : 2 ≤ m → (log2/3)·m ≤ ψ(m)`
+  (from the central binomial coefficient; the substantive lower estimate)
+- `ChebyshevBoundsOQ02OQ02.abs_psi_sub_theta_le : 1 ≤ n → |ψ(n)−θ(n)| ≤ 2√n·log n`
+  (= Mathlib's `abs_psi_sub_theta_le_sqrt_mul_log` via a bridge)
+- `Chebyshev.theta_le_log4_mul_x : 0 ≤ x → θ(x) ≤ log4·x` (Mathlib, upper bound)
+
+## Key Mathlib gap
+
+Mathlib's `Mathlib/NumberTheory/Chebyshev.lean` provides only **upper** bounds
+(`theta_le_log4_mul_x`, `psi_le`, `psi_le_const_mul_self`) and the closeness
+estimate; it has **no** lower bound for θ or ψ. The lower bound therefore has to
+come from this project's central-binomial machinery (`OQ02OQ01`), which is what
+this file routes from ψ to θ.
+
+## Derivation
+
+`θ(m) = ψ(m) − (ψ(m) − θ(m))`. With `ψ(m) ≥ (log2/3)·m` and
+`ψ(m) − θ(m) ≤ |ψ(m) − θ(m)| ≤ 2√m·log m`, linarith gives
+`θ(m) ≥ (log2/3)·m − 2√m·log m`. Upper bound is Mathlib's `log4·m`.
+
+## Approaches Tried
+
+- Considered a fully self-contained file from Mathlib alone: impossible for the
+  lower bound (Mathlib has no ψ/θ lower bound), so imported the project parents.
+- Built the parent oleans (`OQ02OQ01`, `OQ02OQ02`) into the shared store offline
+  (`lake env lean -o`), since Docker was down.

--- a/research/problems/chebyshev-bounds-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/chebyshev-bounds-oq-02-oq-01-oq-01/state.md
@@ -1,0 +1,39 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Iteration**: 1
+**Status**: in-progress
+
+## Current Focus
+
+The problem was minted as an empty stub (no statement). Chose the natural next
+result in the Chebyshev-bounds lineage: an **explicit two-sided bound on the
+first Chebyshev function θ** (researcher-9).
+
+## Delivered (PR pending)
+
+`proofs/Proofs/ChebyshevBoundsOQ02OQ01OQ01.lean` — 3 theorems, 0 axioms, 0 sorries
+(typechecked `lake env lean`, Docker down; `#print axioms` = only
+propext/Classical.choice/Quot.sound):
+
+- `chebyshevTheta_lower {m} (2 ≤ m) : (log2/3)·m − 2√m·log m ≤ θ(m)` — **new**.
+  θ(m) = ψ(m) − (ψ(m) − θ(m)); descends the parent's ψ lower bound
+  (`ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear`) across the O(√m·log m)
+  gap (`ChebyshevBoundsOQ02OQ02.abs_psi_sub_theta_le`), combined by `linarith`.
+- `chebyshevTheta_upper (n) : θ(n) ≤ log4·n` — Mathlib's `theta_le_log4_mul_x`
+  via the project bridge.
+- `chebyshevTheta_bounds {m} (2 ≤ m)` — the two-sided `θ(m) = Θ(m)`.
+
+## Why this is non-duplicate
+
+Mathlib has the θ *upper* bound only (`Chebyshev.theta_le_log4_mul_x`) and **no**
+lower bound for θ or ψ. The parent `ChebyshevBoundsOQ02OQ01` has the ψ lower
+bound but not its θ analogue; sibling `OQ02OQ02` has the ψ–θ closeness bound but
+does not assemble a θ bound. This file is the first to state an explicit θ lower
+bound (hence the two-sided Θ(m)).
+
+## Next Action
+
+Possible follow-up: sharpen the lower-order correction, or derive a prime-counting
+π(n) lower bound from the θ bound.

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-theta-lower",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 60 },
+    "type": "theorem",
+    "title": "θ Lower Bound (the new content)",
+    "content": "For $m \\ge 2$, $\\;(\\log 2 / 3)\\,m - 2\\sqrt{m}\\,\\log m \\le \\theta(m)$. The identity $\\theta(m) = \\psi(m) - (\\psi(m) - \\theta(m))$ reduces this to two ingredients: the project's elementary $\\psi$ lower bound $(\\log 2/3)\\,m \\le \\psi(m)$ (from the central binomial coefficient — the substantive estimate Mathlib lacks) and the closeness bound $\\psi(m) - \\theta(m) \\le |\\psi(m) - \\theta(m)| \\le 2\\sqrt{m}\\,\\log m$. A single `linarith` combines them. The correction $2\\sqrt{m}\\,\\log m$ is lower order, so the bound is asymptotically $(\\log 2/3)\\,m$.",
+    "mathContext": "$\\theta(m) \\ge \\tfrac{\\log 2}{3}\\,m - 2\\sqrt{m}\\,\\log m$ for $m \\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev theta function", "Chebyshev psi function", "Central binomial coefficient", "Prime number theorem"]
+  },
+  {
+    "id": "ann-theta-upper",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 75 },
+    "type": "theorem",
+    "title": "θ Upper Bound",
+    "content": "$\\theta(n) \\le \\log 4 \\cdot n$, Mathlib's `Chebyshev.theta_le_log4_mul_x` carried through the project bridge `chebyshevTheta_eq_mathlib`. This is the side Mathlib already provides; pairing it with the lower bound yields the two-sided estimate.",
+    "mathContext": "$\\theta(n) \\le (\\log 4)\\,n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Chebyshev theta function", "Explicit bounds"]
+  },
+  {
+    "id": "ann-theta-two-sided",
+    "proofId": "chebyshev-bounds-oq-02-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 81 },
+    "type": "theorem",
+    "title": "θ(m) = Θ(m), Explicit",
+    "content": "The headline: $(\\log 2/3)\\,m - 2\\sqrt{m}\\,\\log m \\le \\theta(m) \\le (\\log 4)\\,m$ for $m \\ge 2$. Both endpoints are explicit, confirming the first Chebyshev function is of exact linear order — the elementary heart of the prime number theorem. The lower endpoint is new; the upper is Mathlib's.",
+    "mathContext": "$\\tfrac{\\log 2}{3}\\,m - 2\\sqrt{m}\\,\\log m \\le \\theta(m) \\le (\\log 4)\\,m$, $m \\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Big-Theta order", "Chebyshev function", "Elementary prime number theorem"]
+  }
+]

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "chebyshev-bounds-oq-02-oq-01-oq-01",
+  "title": "Explicit Two-Sided Bounds on the Chebyshev θ Function: (log2/3)·m − 2√m·log m ≤ θ(m) ≤ log4·m",
+  "slug": "chebyshev-bounds-oq-02-oq-01-oq-01",
+  "description": "A fully machine-checked, explicit two-sided bound on the first Chebyshev function θ(n) = ∑_{p ≤ n} log p, establishing θ(m) = Θ(m) with both constants explicit: (log 2 / 3)·m − 2·√m·log m ≤ θ(m) ≤ log 4 · m for m ≥ 2. Mathlib provides only the upper inequality (Chebyshev.theta_le_log4_mul_x), and has no lower bound for either θ or ψ. The new content is the lower bound: it descends this project's elementary ψ lower bound (log 2 / 3)·m ≤ ψ(m) (ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear, from the central binomial coefficient) across the O(√m·log m) gap between ψ and θ, using the closeness estimate |ψ(m) − θ(m)| ≤ 2·√m·log m (ChebyshevBoundsOQ02OQ02.abs_psi_sub_theta_le). Since ψ and θ differ by only a lower-order term, the linear lower bound on ψ transfers to θ up to the √m·log m correction. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Chebyshev (1852), elementary prime-counting bounds; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "1852",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "analytic-number-theory",
+      "chebyshev-function",
+      "prime-counting",
+      "prime-number-theorem",
+      "explicit-bounds",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ02OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Chebyshev.theta_le_log4_mul_x",
+        "description": "θ(x) ≤ log 4 · x for x ≥ 0. Supplies the explicit upper half of the two-sided bound (the only side Mathlib provides).",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "ChebyshevBoundsOQ02OQ01.chebyshevPsi_lower_linear",
+        "description": "(log 2 / 3)·m ≤ ψ(m) for m ≥ 2 — the project's elementary ψ lower bound from the central binomial coefficient. The substantive estimate Mathlib lacks; the source of the new θ lower bound.",
+        "module": "Proofs.ChebyshevBoundsOQ02OQ01"
+      },
+      {
+        "theorem": "ChebyshevBoundsOQ02OQ02.abs_psi_sub_theta_le",
+        "description": "|ψ(n) − θ(n)| ≤ 2·√n·log n for n ≥ 1 — ψ and θ agree up to O(√n·log n). The bridge that carries the ψ lower bound over to θ.",
+        "module": "Proofs.ChebyshevBoundsOQ02OQ02"
+      },
+      {
+        "theorem": "ChebyshevBoundsOQ02OQ02.chebyshevTheta_eq_mathlib",
+        "description": "Identifies the project's chebyshevTheta with Mathlib's Chebyshev.theta, enabling use of theta_le_log4_mul_x.",
+        "module": "Proofs.ChebyshevBoundsOQ02OQ02"
+      }
+    ],
+    "originalContributions": [
+      "chebyshevTheta_lower: the explicit linear lower bound (log 2 / 3)·m − 2·√m·log m ≤ θ(m) for m ≥ 2 — obtained by writing θ(m) = ψ(m) − (ψ(m) − θ(m)), bounding ψ(m) below by (log 2 / 3)·m and the excess ψ(m) − θ(m) above by 2·√m·log m, then combining linearly. Neither Mathlib nor this project previously had any lower bound on θ",
+      "chebyshevTheta_bounds: the two-sided statement (log 2 / 3)·m − 2·√m·log m ≤ θ(m) ≤ log 4 · m for m ≥ 2, pinning θ(m) = Θ(m) with explicit constants by pairing the new lower bound with Mathlib's upper bound — the elementary linear order of the first Chebyshev function, the cornerstone of the elementary prime number theorem",
+      "chebyshevTheta_upper: the project-side packaging of Mathlib's θ(n) ≤ log 4 · n through the chebyshevTheta_eq_mathlib bridge"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 82,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on chebyshevTheta_bounds reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses. Builds on the project files ChebyshevBoundsOQ02OQ01 and ChebyshevBoundsOQ02OQ02, both themselves 0-axiom.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "lower-bound",
+      "title": "The θ Lower Bound",
+      "startLine": 46,
+      "endLine": 60,
+      "summary": "chebyshevTheta_lower: (log 2 / 3)·m − 2·√m·log m ≤ θ(m) for m ≥ 2. Writes θ(m) = ψ(m) − (ψ(m) − θ(m)); the ψ lower bound chebyshevPsi_lower_linear and the closeness bound abs_psi_sub_theta_le (via ψ−θ ≤ |ψ−θ|) combine by linarith. The √m·log m correction is lower order, so the bound is ≈ (log 2 / 3)·m for large m."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The θ Upper Bound",
+      "startLine": 62,
+      "endLine": 75,
+      "summary": "chebyshevTheta_upper: θ(n) ≤ log 4 · n, Mathlib's Chebyshev.theta_le_log4_mul_x transported through the chebyshevTheta_eq_mathlib bridge."
+    },
+    {
+      "id": "two-sided",
+      "title": "Two-Sided θ Bounds",
+      "startLine": 77,
+      "endLine": 81,
+      "summary": "chebyshevTheta_bounds: pairs the new lower bound with Mathlib's upper bound to give (log 2 / 3)·m − 2·√m·log m ≤ θ(m) ≤ log 4 · m for m ≥ 2 — the explicit θ(m) = Θ(m)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an explicit **lower** bound on the first Chebyshev function $\theta(n)=\sum_{p\le n}\log p$, yielding the two-sided estimate

$$\frac{\log 2}{3}\,m - 2\sqrt{m}\,\log m \;\le\; \theta(m) \;\le\; \log 4 \cdot m \qquad (m\ge 2),$$

i.e. $\theta(m)=\Theta(m)$ with explicit constants. **3 theorems, 0 axioms, 0 sorries.**

## Why this is non-duplicate

Mathlib's `NumberTheory/Chebyshev` ships only the **upper** bound `theta_le_log4_mul_x` and has **no** lower bound for $\theta$ or $\psi$. The lower bound therefore must come from this project's central-binomial machinery, and no existing Chebyshev file assembles a $\theta$ bound:

- `chebyshevTheta_lower` (**new**): $\theta(m) = \psi(m) - (\psi(m)-\theta(m))$. Bound $\psi(m)\ge(\log2/3)m$ by the parent's `chebyshevPsi_lower_linear`, and the excess $\psi(m)-\theta(m)\le|\psi(m)-\theta(m)|\le 2\sqrt m\log m$ by the sibling's `abs_psi_sub_theta_le`; `linarith` combines them. The correction is lower order, so the bound is $\approx(\log2/3)m$.
- `chebyshevTheta_upper`: $\theta(n)\le\log4\cdot n$, Mathlib's bound through the project bridge.
- `chebyshevTheta_bounds`: the two-sided $\theta(m)=\Theta(m)$.

## Verification

- Typechecked via `lake env lean Proofs/ChebyshevBoundsOQ02OQ01OQ01.lean` (exit 0; Docker unavailable this session — parent oleans built offline with `lake env lean -o`).
- `#print axioms chebyshevTheta_bounds` = only `propext, Classical.choice, Quot.sound` → **0 counted axioms**. No `native_decide`. Status `verified`, badge `original`.

## Notes

Builds on `ChebyshevBoundsOQ02OQ01` and `ChebyshevBoundsOQ02OQ02` (both 0-axiom, already on main). The empty problem stub had no statement; the θ two-sided bound is the natural next step in the lineage (documented in `state.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)