### PR TITLE
Enrich Hilbert 17 Motzkin rational SOS (hilbert-17-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/hilbert-17-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-01/annotations.json
@@ -10,7 +10,9 @@
     "title": "The Motzkin polynomial and the SOS multiplier",
     "content": "motzkin is defined exactly as in the parent entry Hilbert17SumOfSquares.lean: M = x⁴y² + x²y⁴ − 3x²y² + 1, the canonical polynomial that is nonnegative on ℝ² yet not a sum of squares of polynomials. The multiplier 4 + 4x² + 4y² is the key auxiliary: it is strictly positive, it is itself a sum of squares (2² + (2x)² + (2y)²), and multiplying M by it lands the product inside the polynomial SOS cone.",
     "mathContext": "$M(x,y) = x^4y^2 + x^2y^4 - 3x^2y^2 + 1,\\qquad D(x,y) = 4 + 4x^2 + 4y^2 = 2^2 + (2x)^2 + (2y)^2.$",
-    "significance": "context"
+    "significance": "supporting",
+    "relatedConcepts": ["Motzkin polynomial", "nonnegative polynomial", "SOS cone", "AM-GM inequality", "positive multiplier"],
+    "prerequisites": ["multivariate polynomials", "sum of squares", "real nonnegativity"]
   },
   {
     "id": "ann-h17-oq0301-certificate",
@@ -23,7 +25,9 @@
     "title": "The SOS Positivstellensatz certificate",
     "content": "The mathematical heart of the entry. A single polynomial identity, with all integer coefficients, certifies that D·M is a sum of squares: (4+4x²+4y²)·M = (2xy−x³y−xy³)² (three copies) + (x³y−xy³)² + (2x−2xy²)² + (2y−2x²y)² + (2−2x²y²)². Because every coefficient is an integer, Lean's ring tactic closes it outright. The five generators and the multiplier were found by solving the associated semidefinite Gram-matrix feasibility problem: Motzkin lies on the boundary of the SOS cone, and the rational boundary Gram matrix factors into exactly these squares.",
     "mathContext": "$(4+4x^2+4y^2)\\,M = 3(2xy-x^3y-xy^3)^2 + (x^3y-xy^3)^2 + (2x-2xy^2)^2 + (2y-2x^2y)^2 + (2-2x^2y^2)^2.$",
-    "significance": "key"
+    "significance": "critical",
+    "relatedConcepts": ["Positivstellensatz", "SOS certificate", "semidefinite programming", "Gram matrix", "ring tactic"],
+    "prerequisites": ["polynomial identities", "semidefinite programming basics"]
   },
   {
     "id": "ann-h17-oq0301-multiplier-sos",
@@ -36,7 +40,9 @@
     "title": "The multiplier is a sum of squares",
     "content": "4 + 4x² + 4y² = 2² + (2x)² + (2y)². This is what lets the polynomial certificate become a rational-function certificate: dividing M = (D·M)/D by an SOS denominator D and using that the product of two sums of squares is again a sum of squares ((∑aᵢ²)(∑bⱼ²) = ∑ᵢⱼ(aᵢbⱼ)²) keeps the result a sum of squares, now of rational functions.",
     "mathContext": "$D = 2^2 + (2x)^2 + (2y)^2,\\qquad M = \\frac{D\\cdot M}{D} = \\frac{(\\sum q_i^2)(\\sum d_j^2)}{D^2} = \\sum_{i,j}\\Big(\\frac{q_i d_j}{D}\\Big)^2.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["Brahmagupta–Fibonacci / Lagrange identity", "product of sums of squares", "rational functions", "SOS denominator"],
+    "prerequisites": ["sum-of-squares identities", "field of fractions"]
   },
   {
     "id": "ann-h17-oq0301-ratfunc",
@@ -49,6 +55,8 @@
     "title": "Hilbert's 17th, constructively, for Motzkin",
     "content": "motzkin_isSOS_ratFunc concludes M is a sum of squares of rational functions in ℝ(x,y) = FractionRing ℝ[x,y]. The proof lifts the 21-term polynomial identity Σ_{i<7,j<3}(qᵢdⱼ)² = (D·M)·D through the embedding ℝ[x,y] ↪ ℝ(x,y), divides by D² (legitimate since D ≠ 0, its constant term being 4), and reindexes Fin 7 × Fin 3 ≃ Fin 21. The result is the explicit, 0-axiom witness for the canonical example underlying the parent's axiomatized general Artin theorem artin_hilbert17: where the parent only asserts existence, here a certificate is exhibited and machine-checked.",
     "mathContext": "$M = \\sum_{i=1}^{7}\\sum_{j=1}^{3}\\Big(\\frac{q_i\\,d_j}{4+4x^2+4y^2}\\Big)^2 \\in \\Sigma\\,\\mathbb{R}(x,y)^2.$",
-    "significance": "key"
+    "significance": "key",
+    "relatedConcepts": ["Artin's theorem", "Hilbert's 17th problem", "fraction ring", "constructive existence witness", "reindexing a finite sum"],
+    "prerequisites": ["FractionRing / field of fractions", "finite sums over product types", "Artin's theorem statement"]
   }
 ]

--- a/src/data/proofs/hilbert-17-oq-03-oq-01/index.ts
+++ b/src/data/proofs/hilbert-17-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert17MotzkinRationalSOS.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert17Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert17Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert17Oq03Oq01Data: ProofData = {
+  proof: hilbert17Oq03Oq01Proof,
+  annotations: hilbert17Oq03Oq01Annotations,
+}

--- a/src/data/proofs/hilbert-17-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-03-oq-01/meta.json
@@ -166,7 +166,18 @@
       "url": "https://link.springer.com/article/10.1007/BF02952513"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-17",
+      "relationship": "extends",
+      "description": "Parent: states Artin's theorem (every nonnegative real polynomial is a sum of squares of rational functions) but must axiomatize it, and axiomatizes that Motzkin is not a polynomial SOS. This entry replaces the existence axiom artin_hilbert17 with an explicit, machine-checked rational SOS certificate for the canonical example M."
+    },
+    {
+      "targetId": "hilbert-17-oq-03-oq-02",
+      "relationship": "complements",
+      "description": "Companion proving Motzkin is NOT a sum of squares of polynomials. Together the two entries exhibit the full Hilbert-17 picture for M: polynomial SOS fails (oq-03-oq-02), yet rational-function SOS succeeds (this entry), so rational functions are genuinely necessary."
+    }
+  ],
   "sections": [
     {
       "id": "definitions",


### PR DESCRIPTION
Enrichment pass for `hilbert-17-oq-03-oq-01`.

## Quality improvements
- **Created missing `index.ts`** — without it the proof page renders "proof not found" on the live site.
- **Populated empty `crossReferences`** — to the parent `hilbert-17` (axiomatized Artin theorem this entry makes constructive) and the complement `hilbert-17-oq-03-oq-02` (Motzkin is *not* a polynomial SOS), which together show rational functions are necessary.
- **Annotation fields** — added `relatedConcepts` and `prerequisites` to all 4 annotations; fixed invalid `significance: "context"` -> `"supporting"` (only critical/key/supporting are valid).

meta.json overview/conclusion/sections/references already present and left intact. Content verified against the Lean source. 0 axioms, 0 sorries unchanged.