### PR TITLE
research(cauchy-schwarz-integral-oq-01-oq-02-oq-01): discharge Hadamard three-lines axiom [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -686,6 +686,7 @@ import Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01
 import Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01
 import Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01
 import Proofs.CauchySchwarzIntegralOQ01OQ02
+import Proofs.CauchySchwarzIntegralOQ01OQ02OQ01
 import Proofs.CauchySchwarzIntegralOQ01OQ03
 import Proofs.CauchySchwarzIntegralOQ01OQ03OQ01
 import Proofs.CauchySchwarzIntegralOQ02

--- a/proofs/Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean
@@ -1,0 +1,143 @@
+/-
+  Discharging the Hadamard three-lines axiom
+  (cauchy-schwarz-integral — OQ-01-OQ-02-OQ-01)
+
+  The parent entry "Riesz–Thorin Interpolation from Hölder's Inequality"
+  (cauchy-schwarz-integral-oq-01-oq-02) formalizes the route from Hölder's
+  inequality to the Riesz–Thorin interpolation theorem. Two ingredients there
+  are stated as *axioms*:
+
+    * `hadamard_three_lines` — the Hadamard three-lines lemma (the analytic
+      heart: a function bounded by `M₀` on the line `Re z = 0` and by `M₁` on
+      `Re z = 1`, holomorphic in between, is bounded by `M₀^(1-t)·M₁^t` on the
+      line `Re z = t`);
+    * `riesz_thorin` — the interpolation theorem itself (which follows from the
+      three-lines lemma).
+
+  This file **discharges the first axiom**: it proves `hadamard_three_lines` as
+  a genuine theorem, deriving it from Mathlib's complete formalization of the
+  Hadamard three-lines theorem
+  (`Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'`).
+  So the parent's open question "is the three-lines lemma available / provable in
+  Lean rather than assumed?" is answered **affirmatively** — it is a theorem, not
+  an axiom.
+
+  The statement reproduced here is *identical* to the parent's axiom (same strip
+  and boundary definitions, same `interpNorm θ M₀ M₁ = M₀^(1-θ)·M₁^θ`), so it can
+  replace that axiom verbatim in the Riesz–Thorin development.
+
+  Mathlib's theorem is stated for the canonical strip `re ⁻¹' [0,1]` via
+  `verticalClosedStrip`/`verticalStrip`; the work here is purely the translation
+  of hypotheses (continuity on the closed strip + holomorphy on the open strip
+  ⇒ `DiffContOnCl`; the uniform bound ⇒ `BddAbove`; the two boundary bounds ⇒ the
+  `re ⁻¹' {0}` / `re ⁻¹' {1}` bounds) and reading off `(⟨t,y⟩ : ℂ).re = t`.
+
+  No new axioms (standard Mathlib triple inherited).
+
+  References:
+  - Mathlib: `Mathlib.Analysis.Complex.Hadamard`
+    (`Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'`).
+  - Stein & Shakarchi, "Complex Analysis", Ch. 4 (the three-lines lemma).
+
+  Tags: complex-analysis, hadamard-three-lines, interpolation, riesz-thorin,
+        axiom-discharge, maximum-principle
+-/
+
+import Mathlib
+
+open Set Complex Complex.HadamardThreeLines
+
+namespace CauchySchwarzIntegralOQ01OQ02OQ01
+
+/-- The closed strip `{z : 0 ≤ Re z ≤ 1}` (identical to the parent entry's `closedStrip`). -/
+def closedStrip : Set ℂ := {z : ℂ | 0 ≤ z.re ∧ z.re ≤ 1}
+
+/-- The open strip `{z : 0 < Re z < 1}` (identical to the parent entry's `openStrip`). -/
+def openStrip : Set ℂ := {z : ℂ | 0 < z.re ∧ z.re < 1}
+
+/-- The left boundary line `{z : Re z = 0}`. -/
+def leftBoundary : Set ℂ := {z : ℂ | z.re = 0}
+
+/-- The right boundary line `{z : Re z = 1}`. -/
+def rightBoundary : Set ℂ := {z : ℂ | z.re = 1}
+
+/-- The interpolated bound `M₀^(1-θ) · M₁^θ` (identical to the parent's `interpNorm`). -/
+noncomputable def interpNorm (θ M₀ M₁ : ℝ) : ℝ := M₀ ^ (1 - θ) * M₁ ^ θ
+
+/-- **The Hadamard three-lines lemma — now a theorem, not an axiom.**
+
+If `F` is continuous on the closed strip `0 ≤ Re z ≤ 1`, holomorphic on the open
+strip, uniformly bounded there, and satisfies `‖F‖ ≤ M₀` on the line `Re z = 0`
+and `‖F‖ ≤ M₁` on `Re z = 1`, then on the line `Re z = t` (for `0 ≤ t ≤ 1`)
+`‖F (t + i y)‖ ≤ M₀^(1-t) · M₁^t`.
+
+This reproduces the parent entry's `hadamard_three_lines` axiom *verbatim* and
+proves it from Mathlib's `norm_le_interp_of_mem_verticalClosedStrip₀₁'`. -/
+theorem hadamard_three_lines
+    (F : ℂ → ℂ) (M₀ M₁ : ℝ) (hM₀ : 0 < M₀) (hM₁ : 0 < M₁)
+    (hcont : ContinuousOn F closedStrip)
+    (hdiff : ∀ z ∈ openStrip, DifferentiableAt ℂ F z)
+    (hbound : ∀ z ∈ closedStrip, ‖F z‖ ≤ max M₀ M₁)
+    (hleft : ∀ z ∈ leftBoundary, ‖F z‖ ≤ M₀)
+    (hright : ∀ z ∈ rightBoundary, ‖F z‖ ≤ M₁)
+    (t : ℝ) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) (y : ℝ) :
+    ‖F (⟨t, y⟩ : ℂ)‖ ≤ interpNorm t M₀ M₁ := by
+  -- bridge the local strip definitions to Mathlib's `verticalStrip`/`verticalClosedStrip`
+  have hcs : closedStrip = verticalClosedStrip 0 1 := by
+    ext z; simp [closedStrip, verticalClosedStrip, mem_preimage, mem_Icc]
+  have hos : openStrip = verticalStrip 0 1 := by
+    ext z; simp [openStrip, verticalStrip, mem_preimage, mem_Ioo]
+  -- `(⟨t, y⟩ : ℂ)` lies in the closed strip
+  have hzmem : (⟨t, y⟩ : ℂ) ∈ verticalClosedStrip 0 1 := by
+    simp only [verticalClosedStrip, mem_preimage, mem_Icc]
+    exact ⟨ht₀, ht₁⟩
+  -- `closure (verticalStrip 0 1) = verticalClosedStrip 0 1`
+  have hclosure : closure (verticalStrip 0 1) = verticalClosedStrip 0 1 := by
+    rw [verticalStrip, verticalClosedStrip, closure_preimage_re, closure_Ioo (zero_ne_one)]
+  -- holomorphy on the open strip + continuity on the closed strip ⇒ `DiffContOnCl`
+  have hd : DiffContOnCl ℂ F (verticalStrip 0 1) := by
+    refine ⟨?_, ?_⟩
+    · intro z hz
+      rw [← hos] at hz
+      exact (hdiff z hz).differentiableWithinAt
+    · rw [hclosure, ← hcs]; exact hcont
+  -- the uniform bound gives `BddAbove`
+  have hB : BddAbove ((norm ∘ F) '' verticalClosedStrip 0 1) := by
+    refine ⟨max M₀ M₁, ?_⟩
+    rintro w ⟨z, hz, rfl⟩
+    rw [← hcs] at hz
+    exact hbound z hz
+  -- the two boundary bounds in Mathlib's `re ⁻¹' {·}` form
+  have ha : ∀ z ∈ re ⁻¹' {(0 : ℝ)}, ‖F z‖ ≤ M₀ := by
+    intro z hz
+    exact hleft z (by simpa [leftBoundary] using hz)
+  have hb : ∀ z ∈ re ⁻¹' {(1 : ℝ)}, ‖F z‖ ≤ M₁ := by
+    intro z hz
+    exact hright z (by simpa [rightBoundary] using hz)
+  -- apply Mathlib's three-lines theorem and read off `(⟨t,y⟩).re = t`
+  have key := norm_le_interp_of_mem_verticalClosedStrip₀₁' F hzmem hd hB ha hb
+  simpa [interpNorm] using key
+
+/-- **Corollary (logarithmic / convexity form).** Under the same hypotheses, when
+`F (t + iy) ≠ 0` the logarithm of `‖F‖` is convex along the strip:
+`log ‖F (t+iy)‖ ≤ (1-t)·log M₀ + t·log M₁`. This is the form used to interpolate
+operator norms in the Riesz–Thorin theorem. -/
+theorem hadamard_three_lines_log
+    (F : ℂ → ℂ) (M₀ M₁ : ℝ) (hM₀ : 0 < M₀) (hM₁ : 0 < M₁)
+    (hcont : ContinuousOn F closedStrip)
+    (hdiff : ∀ z ∈ openStrip, DifferentiableAt ℂ F z)
+    (hbound : ∀ z ∈ closedStrip, ‖F z‖ ≤ max M₀ M₁)
+    (hleft : ∀ z ∈ leftBoundary, ‖F z‖ ≤ M₀)
+    (hright : ∀ z ∈ rightBoundary, ‖F z‖ ≤ M₁)
+    (t : ℝ) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) (y : ℝ)
+    (hFpos : 0 < ‖F (⟨t, y⟩ : ℂ)‖) :
+    Real.log ‖F (⟨t, y⟩ : ℂ)‖ ≤ (1 - t) * Real.log M₀ + t * Real.log M₁ := by
+  have htl := hadamard_three_lines F M₀ M₁ hM₀ hM₁ hcont hdiff hbound hleft hright t ht₀ ht₁ y
+  have hlog : Real.log (interpNorm t M₀ M₁) = (1 - t) * Real.log M₀ + t * Real.log M₁ := by
+    rw [interpNorm, Real.log_mul (by positivity) (by positivity),
+      Real.log_rpow hM₀, Real.log_rpow hM₁]
+  calc Real.log ‖F (⟨t, y⟩ : ℂ)‖
+      ≤ Real.log (interpNorm t M₀ M₁) := Real.log_le_log hFpos htl
+    _ = (1 - t) * Real.log M₀ + t * Real.log M₁ := hlog
+
+end CauchySchwarzIntegralOQ01OQ02OQ01

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-02-oq-01/knowledge.md
@@ -1,0 +1,39 @@
+# cauchy-schwarz-integral-oq-01-oq-02-oq-01 — Knowledge Base
+
+## Problem
+Discharge the Hadamard three-lines lemma, assumed as an axiom in the parent
+Riesz–Thorin-from-Hölder entry, by proving it as a theorem.
+
+## Status
+**RESOLVED — verified, 0 axioms, 0 sorries.**
+
+## Resolution
+File: `proofs/Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean`
+- `hadamard_three_lines` — proved (was an axiom in the parent). Statement is
+  identical to the parent's axiom (same `closedStrip`/`openStrip`/`leftBoundary`/
+  `rightBoundary`/`interpNorm`), so it replaces it verbatim.
+- `hadamard_three_lines_log` — logarithmic convexity form for operator-norm interpolation.
+
+Derived from Mathlib `Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'`.
+
+## Key Mathlib facts / gotchas
+- The target lemma is `norm_le_interp_of_mem_verticalClosedStrip₀₁'` in namespace
+  `Complex.HadamardThreeLines`; it gives `‖f z‖ ≤ a^(1-z.re)·b^(z.re)` from boundary
+  bounds `a` on `re⁻¹'{0}` and `b` on `re⁻¹'{1}` — matching `interpNorm t M₀ M₁` since
+  `(⟨t,y⟩:ℂ).re = t`.
+- `DiffContOnCl ℂ F (verticalStrip 0 1)` = `⟨DifferentiableOn …, ContinuousOn F (closure …)⟩`;
+  use `closure (verticalStrip 0 1) = verticalClosedStrip 0 1` via
+  `closure_preimage_re` + `closure_Ioo zero_ne_one`.
+- `verticalClosedStrip 0 1 = re ⁻¹' Icc 0 1`, `verticalStrip 0 1 = re ⁻¹' Ioo 0 1`.
+- Mathlib's theorem needs `[NormedSpace ℂ E]`; here `E = ℂ` works.
+
+## Verification
+`lake env lean` (mathlib 4.26.0); `#print axioms` = propext / Classical.choice /
+Quot.sound only.
+
+## Sessions
+### Session 2026-06-25 (researcher-5)
+Claimed fresh (knowledge 0). Recognized the natural child OQ of the parent: discharge
+one of its two axioms. Mathlib already has the full Hadamard three-lines theorem, so
+the lemma is provable, not merely assumable. Wrote the child file with an identical
+statement to the parent's axiom and proved it. The sibling `riesz_thorin` axiom remains.

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-02-oq-01/problem.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-02-oq-01/problem.md
@@ -1,0 +1,35 @@
+# Problem: cauchy-schwarz-integral-oq-01-oq-02-oq-01
+
+## Statement
+
+### Plain Language
+The parent entry "Riesz–Thorin Interpolation from Hölder's Inequality"
+(cauchy-schwarz-integral-oq-01-oq-02) assumes the **Hadamard three-lines lemma**
+as an axiom. This open question asks whether that analytic step can be discharged
+in Lean — proved as a theorem rather than assumed.
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 8
+tags:
+  - complex-analysis
+  - hadamard-three-lines
+  - interpolation
+  - riesz-thorin
+  - axiom-discharge
+```
+
+## Status
+
+**RESOLVED (verified, 0 axioms).** `hadamard_three_lines` is proved as a theorem in
+`Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean`, derived from Mathlib's
+`Complex.HadamardThreeLines`. See the gallery entry of the same slug.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `cauchy-schwarz-integral-oq-01-oq-02` | Parent: assumes the three-lines lemma as an axiom |

--- a/research/problems/cauchy-schwarz-integral-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/cauchy-schwarz-integral-oq-01-oq-02-oq-01/state.md
@@ -1,0 +1,32 @@
+# Current State
+
+**Phase**: RESOLVED
+**Since**: 2026-06-25
+**Iteration**: 1
+
+## Current Focus
+
+Discharge the Hadamard three-lines axiom assumed by the parent Riesz–Thorin entry.
+
+## Active Approach
+
+DONE. `hadamard_three_lines` is now a verified theorem (0 axioms, 0 sorries) in
+`proofs/Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean`, derived from Mathlib's
+`Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'`. The
+statement is identical to the parent entry's axiom, so it replaces it verbatim.
+Also added the logarithmic convexity form `hadamard_three_lines_log`.
+
+## Blockers
+
+None for this OQ. The sibling `riesz_thorin` axiom of the parent remains open
+(it packages the three-lines lemma into the full operator-norm interpolation).
+
+## Next Action
+
+(Optional follow-up) Discharge `riesz_thorin` using the now-proved three-lines lemma.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+  "title": "Discharging the Hadamard Three-Lines Axiom",
+  "slug": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+  "description": "The parent Riesz–Thorin-from-Hölder entry assumes the Hadamard three-lines lemma as an axiom. This entry proves it as a genuine theorem, deriving it from Mathlib's formalization, so the analytic heart of Riesz–Thorin interpolation is no longer assumed.",
+  "meta": {
+    "author": "Hadamard (1896); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hadamard_three-lines_theorem",
+    "date": "1896",
+    "status": "verified",
+    "tags": [
+      "complex-analysis",
+      "hadamard-three-lines",
+      "interpolation",
+      "riesz-thorin",
+      "maximum-principle",
+      "axiom-discharge",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'",
+        "description": "Hadamard three-lines theorem on re⁻¹'[0,1]: ‖f z‖ ≤ a^(1-Re z)·b^(Re z) given the boundary bounds a, b",
+        "module": "Mathlib.Analysis.Complex.Hadamard"
+      },
+      {
+        "theorem": "closure_preimage_re",
+        "description": "closure (re ⁻¹' s) = re ⁻¹' closure s",
+        "module": "Mathlib.Analysis.Complex.ReImTopology"
+      },
+      {
+        "theorem": "DiffContOnCl",
+        "description": "Differentiable on a set and continuous on its closure (hypothesis form of the maximum principle)",
+        "module": "Mathlib.Analysis.Calculus.DiffContOnCl"
+      },
+      {
+        "theorem": "Real.log_rpow",
+        "description": "log(x^r) = r * log(x) for x > 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "hadamard_three_lines: PROVES the parent entry's three-lines AXIOM as a theorem, with the identical statement (same strip/boundary/interpNorm definitions), so it can replace that axiom verbatim",
+      "Hypothesis translation: ContinuousOn on the closed strip + DifferentiableAt on the open strip ⇒ Mathlib's DiffContOnCl on verticalStrip 0 1 (via closure_preimage_re + closure_Ioo)",
+      "Uniform bound ⇒ BddAbove of the norm image; the two boundary bounds rephrased in Mathlib's re⁻¹'{0} / re⁻¹'{1} form",
+      "hadamard_three_lines_log: the logarithmic/convexity form log‖F(t+iy)‖ ≤ (1-t)·log M₀ + t·log M₁ used to interpolate operator norms in Riesz–Thorin"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 143,
+    "assumptions": "0 axiom declarations and 0 sorries. #print axioms on hadamard_three_lines and hadamard_three_lines_log shows only propext / Classical.choice / Quot.sound — no native_decide, no Lean.ofReduceBool, no sorryAx. The Hadamard three-lines lemma, declared as an axiom in the parent entry (cauchy-schwarz-integral-oq-01-oq-02), is here a fully machine-checked theorem derived from Mathlib's Complex.HadamardThreeLines. The remaining riesz_thorin axiom of the parent is not addressed here.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 2,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "The Hadamard three-lines theorem (Hadamard, 1896) is the analytic engine behind the Riesz–Thorin interpolation theorem: a function holomorphic and bounded on the vertical strip 0 ≤ Re z ≤ 1, bounded by M₀ on the line Re z = 0 and by M₁ on Re z = 1, is bounded by M₀^(1-t)·M₁^t on the line Re z = t. It is a clean consequence of the maximum modulus principle applied to a suitably rescaled function.",
+    "problemStatement": "The parent entry 'Riesz–Thorin Interpolation from Hölder's Inequality' formalizes the route Hölder ⇒ endpoint bounds ⇒ Riesz–Thorin, but states the Hadamard three-lines lemma as an axiom (its open question: can this analytic step be discharged in Lean rather than assumed?). Prove it as a theorem.",
+    "text": "Prove the Hadamard three-lines lemma (assumed as an axiom in the parent Riesz–Thorin entry) as a genuine theorem, deriving it from Mathlib's Complex.HadamardThreeLines, with the identical statement so it can replace the axiom.",
+    "proofStrategy": "Mathlib provides norm_le_interp_of_mem_verticalClosedStrip₀₁' on the canonical strip re⁻¹'[0,1], giving ‖f z‖ ≤ a^(1-Re z)·b^(Re z) from boundary bounds a, b. The work is translating the parent's hypotheses: (1) identify closedStrip/openStrip with verticalClosedStrip/verticalStrip; (2) build DiffContOnCl from continuity on the closed strip and holomorphy on the open strip, using closure (verticalStrip 0 1) = verticalClosedStrip 0 1; (3) convert the uniform bound to BddAbove and the two boundary bounds to the re⁻¹'{0}/re⁻¹'{1} form; (4) apply the theorem and read off (⟨t,y⟩ : ℂ).re = t.",
+    "keyInsights": [
+      "The lemma is fully available in Mathlib (Complex.HadamardThreeLines) — the open question was really 'is it wired up?', and the answer is yes.",
+      "The only genuine work is hypothesis translation between the entry's hand-rolled strip geometry and Mathlib's verticalStrip API; the mathematical content is Mathlib's.",
+      "Discharging the three-lines axiom reduces the parent's axiom count from the analytic core; only the packaging axiom riesz_thorin (which follows from three-lines) remains.",
+      "The logarithmic form makes the convexity of t ↦ log‖F(t+iy)‖ explicit — exactly the statement that interpolates operator norms."
+    ],
+    "prerequisites": [
+      "Complex analysis (maximum modulus principle)",
+      "The Hadamard three-lines / three-circles theorems",
+      "Lp interpolation (Riesz–Thorin)",
+      "Mathlib's Complex.HadamardThreeLines API"
+    ]
+  },
+  "sections": [],
+  "conclusion": {
+    "summary": "The Hadamard three-lines lemma — assumed as an axiom in the parent Riesz–Thorin-from-Hölder entry — is proved here as a fully machine-checked theorem (0 axioms, 0 sorries) by deriving it from Mathlib's Complex.HadamardThreeLines, with a statement identical to the parent's axiom so it can replace it verbatim. The logarithmic convexity form used for operator-norm interpolation is also provided.",
+    "implications": [
+      "The analytic heart of Riesz–Thorin interpolation is no longer assumed in this lineage — only the higher-level riesz_thorin packaging axiom remains.",
+      "Provides a reusable, axiom-free Hadamard three-lines statement in the project's strip conventions."
+    ],
+    "openQuestions": [
+      "Discharge the remaining riesz_thorin axiom by assembling the three-lines lemma into the full operator-norm interpolation theorem.",
+      "Connect to Mathlib's measure-theoretic interpolation machinery if/when available."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Complex",
+      "Complex.HadamardThreeLines"
+    ],
+    "namespace": "CauchySchwarzIntegralOQ01OQ02OQ01",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 5,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "author": "Hadamard, J.",
+      "title": "Sur les fonctions entières",
+      "year": "1896",
+      "venue": "Bull. Soc. Math. France",
+      "note": "Origin of the three-lines/three-circles theorems."
+    },
+    {
+      "author": "Stein, E. M. and Shakarchi, R.",
+      "title": "Complex Analysis",
+      "year": "2003",
+      "venue": "Princeton University Press",
+      "note": "Three-lines lemma and interpolation (Ch. 4)."
+    },
+    {
+      "author": "mathlib community",
+      "title": "Mathlib.Analysis.Complex.Hadamard",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "note": "Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Complex/Hadamard.html"
+    }
+  ],
+  "crossReferences": [
+    {
+      "relationship": "Discharges the hadamard_three_lines axiom assumed by the parent Riesz–Thorin-from-Hölder entry.",
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-02"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Discharging the Hadamard three-lines axiom

The parent gallery entry **"Riesz–Thorin Interpolation from Hölder's Inequality"** (`cauchy-schwarz-integral-oq-01-oq-02`) formalizes the route Hölder ⇒ endpoint bounds ⇒ Riesz–Thorin, but states the **Hadamard three-lines lemma** as an `axiom` (its open question: can this analytic step be discharged in Lean rather than assumed?).

This child entry **answers it affirmatively**: it proves `hadamard_three_lines` as a genuine theorem (0 axioms, 0 sorries), deriving it from Mathlib's complete formalization `Complex.HadamardThreeLines.norm_le_interp_of_mem_verticalClosedStrip₀₁'`.

### What's proved
- **`hadamard_three_lines`** — *identical statement* to the parent's axiom (same `closedStrip`/`openStrip`/`leftBoundary`/`rightBoundary`/`interpNorm` definitions), so it can replace that axiom **verbatim**. If `F` is continuous on `0 ≤ Re z ≤ 1`, holomorphic on the open strip, uniformly bounded, with `‖F‖ ≤ M₀` on `Re z = 0` and `≤ M₁` on `Re z = 1`, then `‖F(t+iy)‖ ≤ M₀^(1-t)·M₁^t`.
- **`hadamard_three_lines_log`** — the logarithmic convexity form `log‖F(t+iy)‖ ≤ (1-t)·log M₀ + t·log M₁` used to interpolate operator norms.

### How
The mathematical content is Mathlib's; the work is hypothesis translation:
- `closedStrip`/`openStrip` ↔ `verticalClosedStrip`/`verticalStrip` (`re ⁻¹' Icc/Ioo 0 1`);
- continuity-on-closed + holomorphy-on-open ⇒ `DiffContOnCl`, using `closure (verticalStrip 0 1) = verticalClosedStrip 0 1` (`closure_preimage_re` + `closure_Ioo`);
- uniform bound ⇒ `BddAbove`; boundary bounds ⇒ `re ⁻¹' {0}` / `re ⁻¹' {1}` form; read off `(⟨t,y⟩ : ℂ).re = t`.

### Verification
- Typechecked offline (`lake env lean`, mathlib 4.26.0); file registered in `Proofs.lean`.
- `#print axioms` on both theorems shows only `propext` / `Classical.choice` / `Quot.sound` — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`. Entry status: **verified**.

### Impact
Removes the analytic core assumption from the Riesz–Thorin lineage; only the higher-level `riesz_thorin` packaging axiom (which follows from three-lines) remains as documented future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)