### PR TITLE
Enrich Lucas Partial Sums (lucas-sum-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/lucas-sum-oq-01/annotations.json
+++ b/src/data/proofs/lucas-sum-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-programme",
+    "proofId": "lucas-sum-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 39
+    },
+    "type": "concept",
+    "title": "The Lucas Analogue of the Fibonacci Telescoping Sum",
+    "content": "The docstring frames the gallery gap: the Lucas numbers 2, 1, 3, 4, 7, 11, … obey the Fibonacci recurrence L_{n+2} = L_n + L_{n+1} with boundary data L_0 = 2, L_1 = 1, and their partial sums telescope as ∑_{k=1}^{n} L_k = L_{n+2} − 3 — the Lucas counterpart of the gallery's ∑_{k=1}^{n} F_k = F_{n+2} − 1. Mathlib has Nat.fib but no Lucas partial-sum lemma, so the file defines lucas locally, proves the sum subtraction-free first, derives the headline subtraction form, and bridges back to Nat.fib to confirm the definition is standard. The constant 3 is the Lucas boundary data L_0 + L_1, exactly as the 1 in the Fibonacci identity is F_0 + F_1.",
+    "mathContext": "$\\sum_{k=1}^{n} L_k = L_{n+2} - 3$ (e.g. $L_1+L_2+L_3 = 1+3+4 = 8 = L_5 - 3$); Lucas analogue of $\\sum F_k = F_{n+2} - 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas numbers",
+      "Fibonacci numbers",
+      "telescoping partial sum",
+      "second-order linear recurrence"
+    ],
+    "prerequisites": [
+      "Fibonacci recurrence",
+      "Finset.sum over range"
+    ]
+  },
+  {
     "id": "ann-lucas-def",
     "proofId": "lucas-sum-oq-01",
     "range": {
@@ -8,7 +31,19 @@
     },
     "type": "concept",
     "title": "A Self-Contained Lucas Sequence",
-    "content": "Mathlib provides Nat.fib but no Lucas sequence, so lucas : ℕ → ℕ is defined locally by the Fibonacci recurrence with the alternative boundary data L_0 = 2, L_1 = 1, giving 2, 1, 3, 4, 7, 11, 18, …. The boundary values are recorded as @[simp] lemmas, and lucas_add_two : L_{n+2} = L_n + L_{n+1} holds by rfl. This single recurrence drives both the telescoping partial sum and the bridge to Nat.fib below."
+    "content": "Mathlib provides Nat.fib but no Lucas sequence, so lucas : ℕ → ℕ is defined locally by the Fibonacci recurrence with the alternative boundary data L_0 = 2, L_1 = 1, giving 2, 1, 3, 4, 7, 11, 18, …. The boundary values are recorded as @[simp] lemmas, and lucas_add_two : L_{n+2} = L_n + L_{n+1} holds by rfl. This single recurrence drives both the telescoping partial sum and the bridge to Nat.fib below.",
+    "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$, giving $2,1,3,4,7,11,18,\\dots$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lucas sequence definition",
+      "structural recursion on ℕ",
+      "@[simp] boundary lemmas",
+      "rfl-provable recurrence"
+    ],
+    "prerequisites": [
+      "recursive definitions in Lean",
+      "the Fibonacci/Lucas recurrence"
+    ]
   },
   {
     "id": "ann-additive-engine",
@@ -19,7 +54,20 @@
     },
     "type": "insight",
     "title": "The Subtraction-Free Engine",
-    "content": "lucas_sum_add_three is the genuine content, stated to dodge ℕ truncated subtraction: (∑_{k=1}^{n} L_k) + 3 = L_{n+2}. The induction is short. Base: 0 + 3 = L_2 = 3. Step: Finset.sum_range_succ peels the new term L_{n+1}, and the Lucas recurrence is stated in the goal's exact index form L_{n+1+2} = L_{n+1} + L_{n+2} — omega treats lucas (·) as an opaque atom and will not rewrite n+1+2 to n+3 inside it, so the index must match for the atoms to unify. omega then combines the peeled term with the inductive hypothesis. The constant 3 = L_0 + L_1 is the Lucas boundary data, the analogue of the constant 1 in ∑ F_k = F_{n+2} − 1."
+    "content": "lucas_sum_add_three is the genuine content, stated to dodge ℕ truncated subtraction: (∑_{k=1}^{n} L_k) + 3 = L_{n+2}. The induction is short. Base: 0 + 3 = L_2 = 3. Step: Finset.sum_range_succ peels the new term L_{n+1}, and the Lucas recurrence is stated in the goal's exact index form L_{n+1+2} = L_{n+1} + L_{n+2} — omega treats lucas (·) as an opaque atom and will not rewrite n+1+2 to n+3 inside it, so the index must match for the atoms to unify. omega then combines the peeled term with the inductive hypothesis. The constant 3 = L_0 + L_1 is the Lucas boundary data, the analogue of the constant 1 in ∑ F_k = F_{n+2} − 1.",
+    "mathContext": "$\\left(\\sum_{k=1}^{n} L_k\\right) + 3 = L_{n+2}$; induction step peels $L_{n+1}$ and uses $L_{n+3} = L_{n+1} + L_{n+2}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ℕ truncated subtraction",
+      "Finset.sum_range_succ",
+      "omega and opaque atoms",
+      "index alignment for unification"
+    ],
+    "prerequisites": [
+      "induction over ℕ",
+      "the Lucas recurrence lucas_add_two",
+      "how omega treats uninterpreted functions"
+    ]
   },
   {
     "id": "ann-headline",
@@ -30,7 +78,18 @@
     },
     "type": "proof-step",
     "title": "The Headline Subtraction Form",
-    "content": "lucas_sum is the identity as usually quoted: ∑_{k=1}^{n} L_k = L_{n+2} − 3. It is read straight off the engine: from (∑)+3 = L_{n+2} with L_{n+2} ≥ 3, omega discharges the ℕ truncated subtraction exactly. Proving the additive form first is the standard ℕ trick that keeps the subtraction honest, avoiding any case split on whether the sum exceeds the boundary."
+    "content": "lucas_sum is the identity as usually quoted: ∑_{k=1}^{n} L_k = L_{n+2} − 3. It is read straight off the engine: from (∑)+3 = L_{n+2} with L_{n+2} ≥ 3, omega discharges the ℕ truncated subtraction exactly. Proving the additive form first is the standard ℕ trick that keeps the subtraction honest, avoiding any case split on whether the sum exceeds the boundary.",
+    "mathContext": "$\\sum_{k=1}^{n} L_k = L_{n+2} - 3$, exact over ℕ since $L_{n+2} \\ge 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ℕ truncated subtraction",
+      "deriving subtraction from addition",
+      "omega tactic"
+    ],
+    "prerequisites": [
+      "the additive engine lucas_sum_add_three",
+      "L_{n+2} ≥ 3"
+    ]
   },
   {
     "id": "ann-fib-bridge",
@@ -41,6 +100,40 @@
     },
     "type": "insight",
     "title": "Pinning the Definition to Nat.fib",
-    "content": "lucas_succ_eq_fib_add_fib proves the classical bridge L_{n+1} = F_n + F_{n+2} (equivalently L_m = F_{m−1} + F_{m+1}), confirming the locally defined lucas agrees with the standard Fibonacci-based Lucas numbers. The proof is a two-step induction (Nat.twoStepInduction): both base indices agree, and in the step every lucas is rewritten away via the recurrence and the two inductive hypotheses so that only fib atoms with aligned indices remain, after which Nat.fib_add_two facts let omega finish. This keeps the entry self-contained while anchoring it to Mathlib."
+    "content": "lucas_succ_eq_fib_add_fib proves the classical bridge L_{n+1} = F_n + F_{n+2} (equivalently L_m = F_{m−1} + F_{m+1}), confirming the locally defined lucas agrees with the standard Fibonacci-based Lucas numbers. The proof is a two-step induction (Nat.twoStepInduction): both base indices agree, and in the step every lucas is rewritten away via the recurrence and the two inductive hypotheses so that only fib atoms with aligned indices remain, after which Nat.fib_add_two facts let omega finish. This keeps the entry self-contained while anchoring it to Mathlib.",
+    "mathContext": "$L_{n+1} = F_n + F_{n+2}$ (equivalently $L_m = F_{m-1} + F_{m+1}$), by two-step induction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lucas–Fibonacci identity",
+      "Nat.twoStepInduction",
+      "Nat.fib_add_two",
+      "self-contained definition validated against Mathlib"
+    ],
+    "prerequisites": [
+      "two-step (strong) induction",
+      "Fibonacci recurrence F_{n+2} = F_n + F_{n+1}"
+    ]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "lucas-sum-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 112
+    },
+    "type": "context",
+    "title": "Concrete Sanity Checks",
+    "content": "Two decide-checked examples confirm the identity numerically: ∑_{k=1}^{3} L_k = 1 + 3 + 4 = 8 (= L_5 − 3 = 11 − 3), and at n = 4 the sum 1 + 3 + 4 + 7 = 15 equals lucas 6 − 3 = 18 − 3. Using kernel decide (not native_decide) keeps the file axiom-free while exhibiting the formula on small cases.",
+    "mathContext": "$\\sum_{k=1}^{3} L_k = 8 = L_5 - 3$; $\\sum_{k=1}^{4} L_k = 15 = L_6 - 3$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "worked numerical examples",
+      "kernel decide (axiom-free)",
+      "no native_decide"
+    ],
+    "prerequisites": [
+      "evaluating Lucas numbers",
+      "decide on concrete Finset sums"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lucas-sum-oq-01` (quality 61, 0 prior passes; verified under-enriched on latest main — no prior Enrich commit, freshness re-checked before push).

## Gap addressed
meta.json (overview, 4 sections, conclusion) was already rich. The gap was **annotation depth**: the 4 existing annotations had only `title` + `content`.

Changes to annotations.json:
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 existing annotations.
- Added 2 new annotations: the module docstring/programme (lines 3-39) and the concrete decide-checked sanity examples (lines 108-112), both previously uncovered.

Now 6 annotations, all with full metadata.

## Verification
- JSON validates (6 annotations, all four metadata fields present).
- Annotation ranges validate against the Lean source — no 'No Lean construct found' warnings for this entry.

Axiom integrity unchanged: status `verified`, axiomCount 0 (0 sorries, 0 axioms, kernel `decide` only, no `native_decide`).