### PR TITLE
research(burnside-counting-oq-03-oq-02-oq-02): dihedral reflection cycle counts ⇒ k^{cyc} fixed colorings [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ03OQ02OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ03OQ02OQ02.lean
@@ -1,0 +1,171 @@
+/-
+# Dihedral Reflection Cycle Counts: cyc(reflection) = (n+|Fix|)/2 and k^{cyc} Fixed Colorings
+## (burnside-counting-oq-03-oq-02-oq-02)
+
+**Open question** (from `burnside-counting-oq-03-oq-02`): the parent proves the
+group-agnostic master formula `#(colorings fixed by g) = k ^ cyc g`, where
+`cyc g = Nat.card (orbitRel.Quotient ⟨g⟩ X)` is the number of `⟨g⟩`-cycles on the
+positions. The sibling `...-oq-01` specialised this to **rotations** (`cyc = gcd(n,r)`).
+This leaf specialises it to **reflections**, recovering the classical dihedral reflection
+counts `k^{(n+1)/2}` (odd `n`) and `k^{n/2+1}`, `k^{n/2}` (even `n`) as instances of
+`k^{cyc g}`, now for *every* number of colours `k`.
+
+A reflection acts on the `n` positions `ZMod n` by the involution `p ↦ -i - p`, realised as
+the permutation `reflPerm i := Equiv.subLeft (-i) : Equiv.Perm (ZMod n)`.  Its cycle count is
+computed by reading the parent's `k = 2` coloring count two ways:
+
+* the parent's master formula gives `#(2-colorings fixed by reflPerm i) = 2 ^ cyc (reflPerm i)`;
+* the sibling `BurnsideCountingOQ04OQ02OQ02.card_invariant_colorings_involutive` gives the
+  same count as `2 ^ ((n + reflFix i)/2)`, because the orbits of an involution are fixed points
+  (singletons) and transposed pairs, so there are `(|positions| + |fixed points|)/2` of them.
+
+Injectivity of `2 ^ ·` yields the **cycle count**
+
+  `cyc (reflPerm i) = (n + reflFix i) / 2`                          (`cyc_reflPerm`)
+
+and hence, via the parent's *general-`k`* master formula,
+
+  `#(k-colorings fixed by reflPerm i) = k ^ ((n + reflFix i) / 2)` (`card_fixedColorings_reflPerm`).
+
+Specialising the fixed-point count `reflFix i` by parity (`reflFix_odd` / `reflFix_even`, reused
+from the sibling) recovers the textbook dihedral reflection contributions for **all** `k`:
+
+  odd  `n` :  `cyc = (n+1)/2`,  count `k^{(n+1)/2}`              (`cyc_reflPerm_odd`)
+  even `n` :  `cyc ∈ {n/2+1, n/2}`,  count `k^{n/2+1}` or `k^{n/2}` (`cyc_reflPerm_even`)
+
+This completes the general-`k` reflection half of the master formula, the dual of the sibling's
+rotation half `cyc = gcd(n,r)`.
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+import Mathlib
+import Proofs.BurnsideCountingOQ03OQ02
+import Proofs.BurnsideCountingOQ04OQ02OQ02
+
+open MulAction Finset
+
+namespace BurnsideCountingOQ03OQ02OQ02
+
+open BurnsideCountingOQ03OQ02 (cyc card_fixedBy_eq_pow_cyc coloring_smul_apply)
+open BurnsideCountingOQ04OQ02OQ02 (refl refl_involutive reflFix reflFix_odd reflFix_even
+  card_invariant_colorings_involutive)
+
+variable {n : ℕ}
+
+/-! ## Section I: The reflection permutation
+
+The reflection through the axis indexed by `i` sends position `p` to `-i - p`.  This is the
+involution `Equiv.subLeft (-i)`, viewed as an element of `Equiv.Perm (ZMod n)` so the parent's
+`cyc`/Burnside machinery (stated for an arbitrary group element) applies directly. -/
+
+/-- The reflection permutation of the `n` positions: `p ↦ -i - p`. -/
+def reflPerm (i : ZMod n) : Equiv.Perm (ZMod n) := Equiv.subLeft (-i)
+
+@[simp] lemma reflPerm_apply (i : ZMod n) (p : ZMod n) : reflPerm i p = -i - p :=
+  Equiv.subLeft_apply _ _
+
+/-- `reflPerm i` agrees with the sibling's position involution `refl i = (-i - ·)`. -/
+lemma reflPerm_eq_refl (i : ZMod n) (p : ZMod n) : reflPerm i p = refl i p := by
+  rw [reflPerm_apply]; rfl
+
+/-- `reflPerm i` squares to the identity. -/
+lemma reflPerm_mul_self (i : ZMod n) : reflPerm i * reflPerm i = 1 := by
+  ext p
+  simp only [Equiv.Perm.mul_apply, reflPerm_apply, Equiv.Perm.one_apply]
+  ring
+
+/-- `reflPerm i` is its own inverse (an involution). -/
+@[simp] lemma reflPerm_inv (i : ZMod n) : (reflPerm i)⁻¹ = reflPerm i :=
+  inv_eq_of_mul_eq_one_right (reflPerm_mul_self i)
+
+/-- Acting by `(reflPerm i)⁻¹` on a position is the involution `refl i`. -/
+lemma reflPerm_inv_smul (i : ZMod n) (p : ZMod n) : (reflPerm i)⁻¹ • p = refl i p := by
+  rw [reflPerm_inv, Equiv.Perm.smul_def, reflPerm_eq_refl]
+
+/-! ## Section II: Fixed colorings of `reflPerm i` are the `refl i`-symmetric colorings -/
+
+/-- A `k`-coloring is fixed by `reflPerm i` (under the parent's coloring action) exactly when it
+is constant on the `refl i`-orbits, i.e. symmetric about the reflection axis. -/
+lemma fixedBy_reflPerm_iff {k : ℕ} (i : ZMod n) (c : ZMod n → Fin k) :
+    reflPerm i • c = c ↔ ∀ p, c (refl i p) = c p := by
+  constructor
+  · intro h p
+    have hp := congrFun h p
+    rw [coloring_smul_apply, reflPerm_inv_smul] at hp
+    exact hp
+  · intro h
+    funext p
+    rw [coloring_smul_apply, reflPerm_inv_smul]
+    exact h p
+
+/-! ## Section III: The `k = 2` count, via the involution-orbit count -/
+
+/-- **`k = 2` reflection count.**  The number of `2`-colorings fixed by `reflPerm i` is
+`2 ^ ((n + reflFix i)/2)` — the sibling's involution-invariant count for `σ = refl i`. -/
+lemma card_fixed_two_colorings [NeZero n] (i : ZMod n) :
+    Nat.card (fixedBy (ZMod n → Fin 2) (reflPerm i)) = 2 ^ ((n + reflFix i) / 2) := by
+  rw [Nat.card_eq_fintype_card]
+  have e : (fixedBy (ZMod n → Fin 2) (reflPerm i))
+      ≃ {c : ZMod n → Fin 2 // ∀ p, c (refl i p) = c p} :=
+    Equiv.subtypeEquivRight (fun c => by rw [mem_fixedBy]; exact fixedBy_reflPerm_iff i c)
+  rw [Fintype.card_congr e, card_invariant_colorings_involutive (refl i) (refl_involutive i),
+    ZMod.card]
+  rfl
+
+/-! ## Section IV: The cycle count and the general-`k` reflection count -/
+
+/-- **Reflection cycle count.**  The number of `⟨reflPerm i⟩`-orbits on the `n` positions is
+`(n + reflFix i)/2`: an involution's orbits are its fixed points (singletons) and its transposed
+pairs.  Obtained by injectivity of `2 ^ ·` from the two readings of the `k = 2` count. -/
+theorem cyc_reflPerm [NeZero n] (i : ZMod n) :
+    cyc (X := ZMod n) (reflPerm i) = (n + reflFix i) / 2 := by
+  have h : (2 : ℕ) ^ cyc (X := ZMod n) (reflPerm i) = 2 ^ ((n + reflFix i) / 2) := by
+    rw [← card_fixedBy_eq_pow_cyc (X := ZMod n) (k := 2) (reflPerm i), card_fixed_two_colorings]
+  exact Nat.pow_right_injective (le_refl 2) h
+
+/-- **General-`k` reflection count.**  The number of `k`-colorings fixed by the reflection
+`reflPerm i` is `k ^ ((n + reflFix i)/2) = k ^ cyc (reflPerm i)`. -/
+theorem card_fixedColorings_reflPerm [NeZero n] (i : ZMod n) (k : ℕ) :
+    Nat.card (fixedBy (ZMod n → Fin k) (reflPerm i)) = k ^ ((n + reflFix i) / 2) := by
+  rw [card_fixedBy_eq_pow_cyc (X := ZMod n) (k := k) (reflPerm i), cyc_reflPerm i]
+
+/-! ## Section V: Parity specialisation — the textbook reflection counts -/
+
+/-- **Odd `n`.**  Every reflection has `(n+1)/2` cycles (one fixed point plus `(n-1)/2` pairs). -/
+theorem cyc_reflPerm_odd [NeZero n] (hn : Odd n) (i : ZMod n) :
+    cyc (X := ZMod n) (reflPerm i) = (n + 1) / 2 := by
+  rw [cyc_reflPerm i, reflFix_odd hn i]
+
+/-- **Odd `n`, count.**  Every reflection fixes `k ^ ((n+1)/2)` colorings, for every `k`. -/
+theorem card_fixedColorings_reflPerm_odd [NeZero n] (hn : Odd n) (i : ZMod n) (k : ℕ) :
+    Nat.card (fixedBy (ZMod n → Fin k) (reflPerm i)) = k ^ ((n + 1) / 2) := by
+  rw [card_fixedColorings_reflPerm i k, reflFix_odd hn i]
+
+/-- **Even `n`.**  A reflection has either `n/2 + 1` cycles (axis through two vertices,
+`reflFix = 2`) or `n/2` cycles (axis through two edge-midpoints, `reflFix = 0`). -/
+theorem cyc_reflPerm_even [NeZero n] (hn : Even n) (i : ZMod n) :
+    cyc (X := ZMod n) (reflPerm i) = n / 2 + 1 ∨ cyc (X := ZMod n) (reflPerm i) = n / 2 := by
+  rw [cyc_reflPerm i]
+  rcases reflFix_even hn i with h | h <;> rw [h] <;> omega
+
+/-- **Even `n`, count.**  A reflection fixes either `k ^ (n/2+1)` or `k ^ (n/2)` colorings. -/
+theorem card_fixedColorings_reflPerm_even [NeZero n] (hn : Even n) (i : ZMod n) (k : ℕ) :
+    Nat.card (fixedBy (ZMod n → Fin k) (reflPerm i)) = k ^ (n / 2 + 1) ∨
+      Nat.card (fixedBy (ZMod n → Fin k) (reflPerm i)) = k ^ (n / 2) := by
+  rw [card_fixedColorings_reflPerm i k]
+  rcases reflFix_even hn i with h | h
+  · right; rw [h, Nat.add_zero]
+  · left; rw [h]; congr 1; omega
+
+#check @cyc_reflPerm
+#check @card_fixedColorings_reflPerm
+#check @cyc_reflPerm_odd
+#check @cyc_reflPerm_even
+
+end BurnsideCountingOQ03OQ02OQ02
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms BurnsideCountingOQ03OQ02OQ02.cyc_reflPerm
+#print axioms BurnsideCountingOQ03OQ02OQ02.card_fixedColorings_reflPerm

--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-02/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "burnside-counting-oq-03-oq-02-oq-02",
+  "title": "Dihedral Reflection Cycle Counts: cyc(reflection) = (n + |Fix|)/2 and k^{cyc} Fixed Colorings",
+  "slug": "burnside-counting-oq-03-oq-02-oq-02",
+  "leanFile": {
+    "lineCount": 171,
+    "path": "Proofs/BurnsideCountingOQ03OQ02OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 13
+  },
+  "description": "Specializes the parent's group-agnostic Burnside master formula |Fix(g)| = k^{cyc(g)} to the dihedral reflection action on the n positions ZMod n, recovering the classical reflection cycle counts (n+1)/2 (odd n) and n/2+1, n/2 (even n) as instances of cyc(g) — now for EVERY number of colours k, not just k=2. A reflection acts on positions by the involution p ↦ -i - p, realized as reflPerm i := Equiv.subLeft (-i) ∈ Equiv.Perm (ZMod n). The headline cyc(reflPerm i) = (n + reflFix i)/2 is computed by reading the parent's k=2 coloring count two ways: the parent's master formula gives #(2-colorings fixed by reflPerm i) = 2^{cyc(reflPerm i)}, while the sibling BurnsideCountingOQ04OQ02OQ02.card_invariant_colorings_involutive gives the same count as 2^{(n + reflFix i)/2} (an involution's orbits are fixed points and transposed pairs, so there are (|positions| + |fixed points|)/2 of them). Injectivity of 2^· yields the cycle count, and the parent's general-k card_fixedBy_eq_pow_cyc then gives #(k-colorings fixed by reflPerm i) = k^{(n + reflFix i)/2}. Specializing reflFix i by parity (reflFix_odd: =1; reflFix_even: ∈{0,2}, reused from the sibling) recovers the textbook reflection contributions k^{(n+1)/2}, k^{n/2+1}, k^{n/2} for all k. This is the general-k reflection half of the master formula, dual to the sibling's rotation half cyc = gcd(n,r).",
+  "meta": {
+    "author": "Cauchy–Frobenius–Burnside (dihedral reflection counts); formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Necklace_(combinatorics)",
+    "date": "1887",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ03OQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-theory",
+      "bracelets",
+      "burnside",
+      "orbit-counting",
+      "group-action",
+      "dihedral-group",
+      "reflection",
+      "involution",
+      "cycle-count",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 sorries, 0 literal `axiom` declarations, 0 structure-encoded assumptions. Fully machine-checked: the headline theorems (cyc_reflPerm, card_fixedColorings_reflPerm, and the parity specializations) depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide, no Lean.ofReduceBool, no sorryAx.",
+    "dateAdded": "2026-06-25",
+    "lineCount": 171,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.subLeft",
+        "description": "The equivalence x ↦ a - x; reflPerm i := Equiv.subLeft (-i) realizes the reflection p ↦ -i - p as an element of Equiv.Perm (ZMod n), so the parent's cyc machinery (stated for an arbitrary group element) applies directly",
+        "module": "Mathlib.Logic.Equiv.Defs"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For 2 ≤ a, the map m ↦ a^m is injective; applied with a = 2 to extract the exponent cyc(reflPerm i) = (n + reflFix i)/2 from the equality 2^{cyc} = 2^{(n+reflFix)/2} of the two readings of the k=2 count",
+        "module": "Mathlib.Data.Nat.Basic"
+      },
+      {
+        "theorem": "MulAction.mem_fixedBy",
+        "description": "a ∈ fixedBy α m ↔ m • a = a; turns the fixed-coloring set into the subtype {c // reflPerm i • c = c}, bridged to the involution-invariant colorings via fixedBy_reflPerm_iff",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      },
+      {
+        "theorem": "Equiv.Perm.smul_def",
+        "description": "σ • a = σ a for the apply-action of a permutation; identifies (reflPerm i)⁻¹ • p with the involution refl i p after reflPerm_inv",
+        "module": "Mathlib.GroupTheory.GroupAction.Defs"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "description": "Transports the fixed-coloring count along the equivalence to the involution-invariant subtype on which the sibling's card_invariant_colorings_involutive applies",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "originalContributions": [
+      "reflPerm i := Equiv.subLeft (-i): the dihedral reflection through axis i, realized as a permutation of ZMod n; reflPerm_mul_self / reflPerm_inv establish it is an involution and reflPerm_inv_smul identifies its action with the sibling's position involution refl i",
+      "fixedBy_reflPerm_iff: a k-coloring is fixed by reflPerm i (under the parent's coloring action with the g⁻¹ twist) iff it is symmetric about the axis, ∀ p, c(refl i p) = c p — the bridge between the abstract fixedBy set and the sibling's involution-invariant colorings",
+      "card_fixed_two_colorings: #(2-colorings fixed by reflPerm i) = 2^{(n + reflFix i)/2}, obtained by transporting along fixedBy_reflPerm_iff to the sibling's card_invariant_colorings_involutive",
+      "cyc_reflPerm (headline): cyc(reflPerm i) = (n + reflFix i)/2 — the reflection cycle count, extracted by injectivity of 2^· from the parent's 2^{cyc} reading versus the involution-orbit 2^{(n+reflFix)/2} reading; no Burnside-over-subgroup machinery needed",
+      "card_fixedColorings_reflPerm: #(k-colorings fixed by reflPerm i) = k^{(n + reflFix i)/2} for every k, via the parent's general-k card_fixedBy_eq_pow_cyc",
+      "Parity specializations cyc_reflPerm_odd (=(n+1)/2), cyc_reflPerm_even (∈{n/2+1, n/2}) and their colored counterparts, recovering the textbook dihedral reflection contributions k^{(n+1)/2}, k^{n/2+1}, k^{n/2} for all k by reusing the sibling's reflFix_odd / reflFix_even"
+    ]
+  },
+  "overview": {
+    "what": "For the dihedral reflection p ↦ -i - p acting on the n positions ZMod n, the number of ⟨reflection⟩-orbits (cycles) is cyc = (n + |fixed points|)/2, and hence the number of k-colorings fixed by the reflection is k^{(n + |fixed points|)/2}. By parity this is k^{(n+1)/2} for odd n and k^{n/2+1} or k^{n/2} for even n — the classical dihedral reflection counts, now established for every number of colours k as instances of the parent's master formula |Fix(g)| = k^{cyc(g)}.",
+    "how": "Read the parent's k=2 coloring count two ways. The parent's master formula gives #(2-colorings fixed by the reflection) = 2^{cyc}. The sibling's card_invariant_colorings_involutive gives the same count as 2^{(n+|Fix|)/2}, since an involution's orbits are its fixed points (singletons) and its transposed pairs. Injectivity of 2^· forces cyc = (n+|Fix|)/2, and the parent's general-k count then upgrades to k^{(n+|Fix|)/2}.",
+    "historicalContext": "Counting k-colored bracelets of n beads up to rotation AND reflection is the second textbook application of Burnside's lemma, after the rotation-only necklace count. The reflection contribution depends on parity: for odd n each of the n reflection axes passes through one vertex and the opposite edge-midpoint, fixing k^{(n+1)/2} colorings; for even n half the axes pass through two opposite vertices (fixing k^{n/2+1}) and half through two opposite edge-midpoints (fixing k^{n/2}). The parent gallery entry burnside-counting-oq-03-oq-02 proved the group-agnostic master formula |Fix(g)| = k^{cyc(g)} for an arbitrary finite group, with cyc(g) the number of ⟨g⟩-orbits, and its rotation specialization (oq-01) explicitly asked to recover these dihedral reflection counts as instances of cyc(g). This entry supplies that bridge: it pins the abstract reflection orbit count to the parity formula (n+|Fix|)/2 and re-derives the textbook reflection contributions for all k, not just the binary k=2 case of the parallel BurnsideCountingOQ04 dihedral branch.",
+    "problemStatement": "Realize a dihedral reflection through axis i as the involution reflPerm i = Equiv.subLeft (-i) ∈ Equiv.Perm (ZMod n) acting on the n positions, and prove (A) cyc(reflPerm i) = (n + reflFix i)/2 where cyc is the parent's count of ⟨reflPerm i⟩-orbits and reflFix i = #{p : -i - p = p} is the number of fixed positions; (B) the number of k-colorings fixed by reflPerm i is k^{(n + reflFix i)/2}; and (C) specialize by parity: odd n gives cyc = (n+1)/2 and count k^{(n+1)/2}; even n gives cyc ∈ {n/2+1, n/2} and count k^{n/2+1} or k^{n/2}.",
+    "proofStrategy": "**Setup.** Realize the reflection as reflPerm i := Equiv.subLeft (-i) : Equiv.Perm (ZMod n), so it acts on positions p by p ↦ -i - p. reflPerm_mul_self shows it squares to 1 (an involution) and reflPerm_inv gives (reflPerm i)⁻¹ = reflPerm i; reflPerm_inv_smul identifies its action with the sibling's position involution refl i.\n\n**The two readings of the k=2 count.** A k-coloring c is fixed by reflPerm i under the parent's coloring action ((g•c) x = c (g⁻¹•x)) iff ∀ p, c(refl i p) = c p (fixedBy_reflPerm_iff), using reflPerm_inv to cancel the inverse twist. Transporting along this equivalence (Equiv.subtypeEquivRight, Fintype.card_congr) and the sibling's card_invariant_colorings_involutive — which counts involution-invariant 2-colorings as 2^{(|positions| + |fixed points|)/2} — gives card_fixed_two_colorings: #(2-colorings fixed by reflPerm i) = 2^{(n + reflFix i)/2}. Separately, the parent's card_fixedBy_eq_pow_cyc at k=2 gives the same count as 2^{cyc(reflPerm i)}.\n\n**(A) The cycle count.** Equating 2^{cyc(reflPerm i)} = 2^{(n + reflFix i)/2} and applying Nat.pow_right_injective (2 ≤ 2) extracts cyc(reflPerm i) = (n + reflFix i)/2. No Burnside-over-subgroup argument or explicit orbit-representative bijection is needed: the cycle count falls out of the two colour-count readings.\n\n**(B) General k.** The parent's card_fixedBy_eq_pow_cyc at arbitrary k gives #(k-colorings fixed) = k^{cyc(reflPerm i)} = k^{(n + reflFix i)/2}.\n\n**(C) Parity.** The sibling's reflFix_odd (=1 for odd n, since 2 is a unit so -i = 2p has a unique solution) and reflFix_even (∈{0,2} for even n) substitute into (A)/(B): odd n ⟹ cyc = (n+1)/2, count k^{(n+1)/2}; even n ⟹ cyc = n/2+1 (vertex axis, reflFix=2) or n/2 (edge axis, reflFix=0), count k^{n/2+1} or k^{n/2}.",
+    "keyInsights": [
+      "**The cycle count is read off the colour count, not computed directly.** Rather than build the ⟨reflection⟩-orbit quotient and count it (or run Burnside over the 2-element subgroup), the abstract cyc is recovered by writing the k=2 fixed-coloring count two independent ways — 2^{cyc} (parent) and 2^{(n+|Fix|)/2} (involution orbits) — and cancelling the base 2 by injectivity of 2^·.",
+      "**An involution's orbits are exactly fixed points plus transposed pairs.** |positions| = |fixed points| + 2·(#pairs), so the number of orbits is (|positions| + |fixed points|)/2. This single combinatorial identity, supplied by the sibling's card_invariant_colorings_involutive, IS the reflection cycle count.",
+      "**General k for free.** Because cyc is colour-independent, computing it once (via the convenient k=2 count) upgrades immediately to k^{cyc} for every k through the parent's master formula — generalizing the parallel BurnsideCountingOQ04 dihedral branch, which established only the binary k=2 reflection counts.",
+      "**Parity lives entirely in |Fix|.** All n-dependence of the cycle count is funneled through reflFix i, the solution count of 2p = -i in ZMod n: a unit doubling (odd n) forces exactly one fixed point, while a two-element doubling kernel (even n) forces zero or two, giving the three textbook reflection cases."
+    ],
+    "prerequisites": [
+      "The parent entry's master formula |Fix(g)| = k^{cyc(g)} (burnside-counting-oq-03-oq-02, card_fixedBy_eq_pow_cyc)",
+      "The sibling involution count card_invariant_colorings_involutive and the parity facts reflFix_odd / reflFix_even (burnside-counting-oq-04-oq-02-oq-02)",
+      "Equiv.subLeft and the apply-action of Equiv.Perm on ZMod n",
+      "Injectivity of m ↦ a^m for 2 ≤ a (Nat.pow_right_injective)"
+    ],
+    "significance": "Closes the dihedral half of the parent's program, flagged verbatim in the rotation sibling's openQuestions[0]: it derives the textbook reflection cycle counts (n+1)/2, n/2+1, n/2 from the abstract group-agnostic cyc, so the classical dihedral reflection contributions k^{(n+1)/2}, k^{n/2+1}, k^{n/2} become specializations of one master theorem rather than a separate computation. Crucially it does so for every number of colours k, generalizing the binary k=2 dihedral reflection counts of the parallel BurnsideCountingOQ04 branch, and it demonstrates a reusable technique — recovering an abstract orbit invariant by reading a convenient colour count two ways and cancelling the base — that sidesteps direct orbit-quotient bookkeeping."
+  },
+  "conclusion": {
+    "summary": "Specializes the parent's group-agnostic Burnside formula |Fix(g)| = k^{cyc(g)} to the dihedral reflection action, proving (A) cyc(reflPerm i) = (n + reflFix i)/2 by reading the k=2 coloring count two ways (parent's 2^{cyc} versus the sibling's involution-orbit 2^{(n+|Fix|)/2}) and cancelling the base by injectivity of 2^·; (B) k^{(n+reflFix i)/2} fixed colorings for every k via the parent's general-k count; and (C) the parity specializations cyc = (n+1)/2 (odd) and cyc ∈ {n/2+1, n/2} (even), recovering the textbook reflection counts k^{(n+1)/2}, k^{n/2+1}, k^{n/2}. Fully verified with 0 sorries and 0 axioms.",
+    "implications": "Answers the rotation sibling's openQuestions[0] verbatim — recovering the dihedral reflection counts as instances of k^{cyc(g)} by computing each reflection's cycle count — and upgrades the binary k=2 dihedral reflection counts of the BurnsideCountingOQ04 branch to all k. Together with the rotation half (cyc = gcd(n,r), oq-01), it supplies both halves of the dihedral Burnside sum at the level of the abstract cyc invariant.",
+    "openQuestions": [
+      "Assemble the full general-k dihedral bracelet count b(n,k) = (1/2n)(∑_{r∈ZMod n} k^{gcd(n,r)} + ∑_{reflections} k^{cyc}) by combining the rotation half (oq-01) with this reflection half, obtaining the closed two-sided count of k-colored bracelets up to the dihedral symmetry for all k.",
+      "Package the reflection sum ∑_{reflections} k^{cyc} in parity-closed form (n·k^{(n+1)/2} for odd n; (n/2)(k^{n/2+1}+k^{n/2}) for even n), the general-k analogue of the sibling's reflection-half evaluations."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-burnside-oq0302-parent",
+      "targetId": "burnside-counting-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Answers the parent's program for the dihedral group: recover the reflection cycle counts as instances of cyc(g) and derive k^{cyc} from the parent's master formula |Fix(g)| = k^{cyc(g)}. Reuses the parent's cyc and card_fixedBy_eq_pow_cyc directly."
+    },
+    {
+      "id": "xref-burnside-oq030201-sibling-rotation",
+      "targetId": "burnside-counting-oq-03-oq-02-oq-01",
+      "relationship": "complements",
+      "description": "Answers this rotation sibling's openQuestions[0] verbatim. The sibling computed the rotation cycle count cyc(rotation r) = gcd(n,r); this entry computes the dual reflection cycle count cyc(reflection) = (n+|Fix|)/2, supplying the second half of the dihedral Burnside sum at the abstract cyc level."
+    },
+    {
+      "id": "xref-burnside-oq04020202-binary-reflection",
+      "targetId": "burnside-counting-oq-04-oq-02-oq-02",
+      "relationship": "generalizes",
+      "description": "Reuses this entry's card_invariant_colorings_involutive and parity facts reflFix_odd / reflFix_even, which established the binary k=2 dihedral reflection counts 2^{(n+1)/2}, 2^{n/2+1}, 2^{n/2}. The present entry lifts those to k^{cyc} for every number of colours k via the parent's general-k master formula."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Results",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring: recovering the dihedral reflection counts k^{(n+1)/2}, k^{n/2+1}, k^{n/2} as instances of k^{cyc(g)} by computing each reflection's cycle count, via reading the parent's k=2 coloring count two ways.",
+      "mathContext": "$\\mathrm{cyc}(\\text{reflection}) = (n + |\\mathrm{Fix}|)/2,\\ |\\mathrm{Fix}| = k^{(n+|\\mathrm{Fix}|)/2}$"
+    },
+    {
+      "id": "reflection-permutation",
+      "title": "Section I: The Reflection Permutation",
+      "startLine": 56,
+      "endLine": 85,
+      "summary": "reflPerm i := Equiv.subLeft (-i) realizes the reflection p ↦ -i - p as a permutation of ZMod n. reflPerm_mul_self and reflPerm_inv establish it is an involution; reflPerm_inv_smul identifies its action with the sibling's position involution refl i.",
+      "mathContext": "$\\mathrm{reflPerm}\\,i = (p \\mapsto -i - p),\\ (\\mathrm{reflPerm}\\,i)^{-1} = \\mathrm{reflPerm}\\,i$"
+    },
+    {
+      "id": "fixed-colorings-symm",
+      "title": "Section II: Fixed Colorings are Axis-Symmetric",
+      "startLine": 86,
+      "endLine": 101,
+      "summary": "fixedBy_reflPerm_iff: a coloring is fixed by reflPerm i under the parent's coloring action iff it is symmetric about the axis, ∀ p, c(refl i p) = c p — cancelling the g⁻¹ twist via reflPerm_inv.",
+      "mathContext": "$\\mathrm{reflPerm}\\,i \\cdot c = c \\iff \\forall p,\\ c(-i-p) = c(p)$"
+    },
+    {
+      "id": "k2-count",
+      "title": "Section III: The k = 2 Count via Involution Orbits",
+      "startLine": 102,
+      "endLine": 115,
+      "summary": "card_fixed_two_colorings: transporting along fixedBy_reflPerm_iff to the sibling's card_invariant_colorings_involutive gives #(2-colorings fixed by reflPerm i) = 2^{(n + reflFix i)/2}.",
+      "mathContext": "$\\#\\{c \\mid \\mathrm{reflPerm}\\,i \\cdot c = c\\} = 2^{(n + \\mathrm{reflFix}\\,i)/2}$"
+    },
+    {
+      "id": "cycle-count-general-k",
+      "title": "Section IV: The Cycle Count and General-k Count",
+      "startLine": 116,
+      "endLine": 132,
+      "summary": "cyc_reflPerm: equating the parent's 2^{cyc} with 2^{(n+reflFix)/2} and applying Nat.pow_right_injective gives cyc(reflPerm i) = (n + reflFix i)/2. card_fixedColorings_reflPerm: the parent's general-k count then gives k^{(n + reflFix i)/2}.",
+      "mathContext": "$\\mathrm{cyc}(\\mathrm{reflPerm}\\,i) = (n + \\mathrm{reflFix}\\,i)/2,\\ |\\mathrm{Fix}| = k^{(n+\\mathrm{reflFix}\\,i)/2}$"
+    },
+    {
+      "id": "parity-specialization",
+      "title": "Section V: Parity Specialization",
+      "startLine": 133,
+      "endLine": 165,
+      "summary": "Substituting the sibling's reflFix_odd (=1) and reflFix_even (∈{0,2}): odd n gives cyc = (n+1)/2 and count k^{(n+1)/2}; even n gives cyc ∈ {n/2+1, n/2} and count k^{n/2+1} or k^{n/2} — the textbook dihedral reflection contributions for all k.",
+      "mathContext": "$\\text{odd } n:\\ k^{(n+1)/2};\\quad \\text{even } n:\\ k^{n/2+1}\\text{ or }k^{n/2}$"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Specializes the parent's group-agnostic Burnside master formula `|Fix(g)| = k^{cyc(g)}` (`burnside-counting-oq-03-oq-02`) to the **dihedral reflection** action on the `n` positions `ZMod n`, recovering the classical reflection cycle counts as instances of `cyc(g)` — **for every number of colours `k`**, not just the binary `k=2` case of the parallel `BurnsideCountingOQ04` dihedral branch.

A reflection acts on positions by the involution `p ↦ -i - p`, realized as `reflPerm i := Equiv.subLeft (-i) ∈ Equiv.Perm (ZMod n)`.

### Headline results
- **`cyc_reflPerm`**: `cyc(reflPerm i) = (n + reflFix i)/2` — the reflection cycle count.
- **`card_fixedColorings_reflPerm`**: `#(k-colorings fixed by reflPerm i) = k^{(n + reflFix i)/2}` for all `k`.
- **Parity** (`cyc_reflPerm_odd`/`_even` + colored counterparts): odd `n` ⟹ `cyc=(n+1)/2`, count `k^{(n+1)/2}`; even `n` ⟹ `cyc ∈ {n/2+1, n/2}`, count `k^{n/2+1}` or `k^{n/2}`.

This answers `burnside-counting-oq-03-oq-02-oq-01`'s `openQuestions[0]` verbatim, supplying the **reflection half** of the dihedral Burnside sum (dual to the sibling's rotation half `cyc = gcd(n,r)`).

## Technique

Read the parent's `k=2` coloring count two independent ways and cancel the base:
- parent's master formula ⟹ `#(2-colorings fixed) = 2^{cyc}`;
- the sibling's `card_invariant_colorings_involutive` ⟹ same count `= 2^{(n+|Fix|)/2}` (an involution's orbits are fixed points + transposed pairs);
- `Nat.pow_right_injective` extracts `cyc = (n+|Fix|)/2`.

No Burnside-over-subgroup machinery or explicit orbit-quotient bijection needed; `cyc` is colour-independent so the parent's general-`k` formula upgrades it to `k^{cyc}` for free.

## Verification
- **0 sorries, 0 axioms.** `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.
- 6 theorems / 7 lemmas / 1 def, 171 lines.
- Typechecked against Mathlib v4.26.0 (`lake env lean`).

## Files
- `proofs/Proofs/BurnsideCountingOQ03OQ02OQ02.lean`
- `src/data/proofs/burnside-counting-oq-03-oq-02-oq-02/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)