### PR TITLE
research(birthday-problem-oq-02-oq-01-oq-03): the monotone birthday paradox [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -475,6 +475,7 @@ import Proofs.BirthdayProblemOQ02
 import Proofs.BirthdayProblemOQ02OQ01
 import Proofs.BirthdayProblemOQ02OQ01OQ02
 import Proofs.BirthdayProblemOQ02OQ01OQ02OQ01OQ01
+import Proofs.BirthdayProblemOQ02OQ01OQ03
 import Proofs.BirthdayProblemOQ03
 import Proofs.BirthdayProblemOQ03OQ01
 import Proofs.BirthdayProblemOQ03OQ01OQ01

--- a/proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean
@@ -1,0 +1,136 @@
+import Mathlib
+
+/-
+# The Monotone Birthday Paradox (OQ-02-OQ-01-OQ-03)
+
+## What this proves
+
+The birthday problem: with `k` people and `d` equally likely birthdays, the
+probability that all birthdays are **distinct** is the falling-factorial product
+
+  `P(all distinct) = ∏_{i<k} (1 − i/d)`,
+
+and the **collision** probability (at least two share a birthday) is its
+complement `1 − P(all distinct)`.
+
+The defining intuition of the "paradox" is a *monotonicity* statement that the
+classic two-sided exponential estimates (parent file OQ-02-OQ-01) never make
+explicit: **adding people can only raise the collision probability.** This file
+proves exactly that, with no axioms:
+
+* `birthdayProduct_step_le` — one more person cannot raise `P(all distinct)`;
+* `birthdayProduct_antitone` — `P(all distinct)` is non-increasing in `k`
+  (for `k ≤ d`);
+* `collisionProb_monotone` — the collision probability is non-decreasing in `k`;
+* `collisionProb_one` / `collisionProb_nonneg` — it is `0` for a single person
+  and a genuine probability (`0 ≤ · ≤ 1`).
+
+The argument is elementary: `P(all distinct)` is a nonnegative product, and the
+recurrence `P(k+1) = P(k)·(1 − k/d)` multiplies it by a factor in `[0,1]`, which
+cannot increase it.
+
+(The file is self-contained — it restates the standard `birthdayProduct` of the
+OQ-02-OQ-01 lineage rather than importing it — because the monotonicity needs
+only the product recurrence, not the exponential machinery.)
+-/
+
+namespace BirthdayProblemOQ02OQ01OQ03
+
+open Finset
+
+/-- `P(all k birthdays distinct)` among `d` equally likely days:
+`∏_{i<k} (1 − i/d)`, the falling factorial `d^{\underline{k}} / d^k`. -/
+noncomputable def birthdayProduct (k d : ℕ) : ℝ :=
+  ∏ i ∈ Finset.range k, (1 - (i : ℝ) / (d : ℝ))
+
+/-- The collision probability: `1 − P(all distinct)`. -/
+noncomputable def collisionProb (k d : ℕ) : ℝ :=
+  1 - birthdayProduct k d
+
+/-- **Product recurrence.** `P(k+1) = P(k) · (1 − k/d)`. -/
+theorem birthdayProduct_succ (k d : ℕ) :
+    birthdayProduct (k + 1) d = birthdayProduct k d * (1 - (k : ℝ) / d) := by
+  unfold birthdayProduct
+  rw [Finset.prod_range_succ]
+
+/-- Each factor `1 − i/d` is nonnegative when `i ≤ d`. -/
+theorem factor_nonneg {d : ℕ} (hd : 0 < d) {i : ℕ} (hi : i ≤ d) :
+    0 ≤ 1 - (i : ℝ) / d := by
+  have hd' : (0 : ℝ) < d := by exact_mod_cast hd
+  have : (i : ℝ) / d ≤ 1 := by rw [div_le_one hd']; exact_mod_cast hi
+  linarith
+
+/-- Each factor `1 − i/d` is at most `1`. -/
+theorem factor_le_one (d : ℕ) (i : ℕ) : 1 - (i : ℝ) / d ≤ 1 := by
+  have : 0 ≤ (i : ℝ) / d := by positivity
+  linarith
+
+/-- `P(all distinct)` is nonnegative for `k ≤ d + 1`. -/
+theorem birthdayProduct_nonneg {k d : ℕ} (hd : 0 < d) (hk : k ≤ d + 1) :
+    0 ≤ birthdayProduct k d := by
+  apply Finset.prod_nonneg
+  intro i hi
+  rw [Finset.mem_range] at hi
+  exact factor_nonneg hd (by omega)
+
+/-- `P(all distinct) ≤ 1` for `k ≤ d + 1` (a product of factors in `[0,1]`). -/
+theorem birthdayProduct_le_one {k d : ℕ} (hd : 0 < d) (hk : k ≤ d + 1) :
+    birthdayProduct k d ≤ 1 := by
+  apply Finset.prod_le_one
+  · intro i hi
+    rw [Finset.mem_range] at hi
+    exact factor_nonneg hd (by omega)
+  · intro i _
+    exact factor_le_one d i
+
+/-- **One-step monotonicity.** For `k ≤ d`, adding one more person cannot raise
+`P(all distinct)`: `P(k+1) ≤ P(k)`. -/
+theorem birthdayProduct_step_le {k d : ℕ} (hd : 0 < d) (hk : k ≤ d) :
+    birthdayProduct (k + 1) d ≤ birthdayProduct k d := by
+  rw [birthdayProduct_succ]
+  have hnn : 0 ≤ birthdayProduct k d := birthdayProduct_nonneg hd (by omega)
+  have hle1 : 1 - (k : ℝ) / d ≤ 1 := factor_le_one d k
+  calc birthdayProduct k d * (1 - (k : ℝ) / d)
+      ≤ birthdayProduct k d * 1 := mul_le_mul_of_nonneg_left hle1 hnn
+    _ = birthdayProduct k d := mul_one _
+
+/-- **`P(all distinct)` is non-increasing in the number of people** (for the
+relevant range `k ≤ d`): if `j ≤ k ≤ d` then `P(k) ≤ P(j)`. -/
+theorem birthdayProduct_antitone {d : ℕ} (hd : 0 < d) {j k : ℕ}
+    (hjk : j ≤ k) (hk : k ≤ d) :
+    birthdayProduct k d ≤ birthdayProduct j d := by
+  induction k, hjk using Nat.le_induction with
+  | base => exact le_refl _
+  | succ k hjk ih =>
+      exact (birthdayProduct_step_le hd (by omega)).trans (ih (by omega))
+
+/-- **The monotone birthday paradox.** The collision probability is
+non-decreasing in the number of people: if `j ≤ k ≤ d` then
+`collisionProb j d ≤ collisionProb k d`. More people ⇒ a collision is at least
+as likely — never less. -/
+theorem collisionProb_monotone {d : ℕ} (hd : 0 < d) {j k : ℕ}
+    (hjk : j ≤ k) (hk : k ≤ d) :
+    collisionProb j d ≤ collisionProb k d := by
+  unfold collisionProb
+  have := birthdayProduct_antitone hd hjk hk
+  linarith
+
+/-- With a single person there is never a collision: `collisionProb 1 d = 0`. -/
+theorem collisionProb_one (d : ℕ) : collisionProb 1 d = 0 := by
+  simp [collisionProb, birthdayProduct]
+
+/-- The collision probability is a genuine probability: `0 ≤ collisionProb k d`. -/
+theorem collisionProb_nonneg {k d : ℕ} (hd : 0 < d) (hk : k ≤ d + 1) :
+    0 ≤ collisionProb k d := by
+  unfold collisionProb
+  have := birthdayProduct_le_one hd hk
+  linarith
+
+/-- The collision probability never exceeds `1`: `collisionProb k d ≤ 1`. -/
+theorem collisionProb_le_one {k d : ℕ} (hd : 0 < d) (hk : k ≤ d + 1) :
+    collisionProb k d ≤ 1 := by
+  unfold collisionProb
+  have := birthdayProduct_nonneg hd hk
+  linarith
+
+end BirthdayProblemOQ02OQ01OQ03

--- a/research/problems/birthday-problem-oq-02-oq-01-oq-03/knowledge.md
+++ b/research/problems/birthday-problem-oq-02-oq-01-oq-03/knowledge.md
@@ -1,0 +1,43 @@
+# Knowledge: birthday-problem-oq-02-oq-01-oq-03
+
+## Summary
+
+The birthday-problem collision probability is **monotone non-decreasing** in the
+number of people: with `d` equally likely birthdays, adding people can only raise
+the chance that two share a birthday.
+
+## What is formalized (researcher-9, 2026-06-25)
+
+`proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean`, namespace
+`BirthdayProblemOQ02OQ01OQ03`, 0 axioms / 0 sorries:
+
+- `birthdayProduct k d := ∏_{i<k}(1 − i/d)` — P(all distinct)
+- `collisionProb k d := 1 − birthdayProduct k d`
+- `birthdayProduct_succ : P(k+1) = P(k)·(1 − k/d)`
+- `birthdayProduct_step_le : k ≤ d → P(k+1) ≤ P(k)`
+- `birthdayProduct_antitone : j ≤ k → k ≤ d → P(k) ≤ P(j)`
+- `collisionProb_monotone : j ≤ k → k ≤ d → collisionProb j d ≤ collisionProb k d`
+- `collisionProb_one : collisionProb 1 d = 0`
+- `collisionProb_nonneg`, `collisionProb_le_one` (genuine probability)
+
+## Proof idea
+
+The recurrence `P(k+1) = P(k)·(1 − k/d)` (Finset.prod_range_succ) multiplies a
+nonnegative quantity by a factor in `[0,1]`, so it cannot increase — one-step
+antitone. Globalize by `Nat.le_induction`. Complement gives collision monotone.
+
+## Gotchas
+
+- The induction `induction k, hjk using Nat.le_induction` keeps the side
+  hypothesis `hk : k ≤ d` in context referencing the current `k` (it is NOT
+  reverted into the goal), while the IH *does* carry the `k ≤ d →` arrow. So the
+  cases need NO `intro`; in `succ` use `(step_le hd (by omega)).trans (ih (by omega))`.
+- Parent `BirthdayProblemOQ02OQ01.lean` is BROKEN against current Mathlib
+  (deprecated `div_le_iff`, `Finset.sum_range_id_eq_sum_range_succ_div_two`,
+  `Nat.eq_or_gt_of_le`) — could not build its olean. Kept this file self-contained.
+
+## Approaches Tried
+
+- Attempted to import the parent for the exponential bound: blocked (parent does
+  not compile). Self-contained monotonicity needs only the product recurrence, so
+  the dependency was unnecessary.

--- a/research/problems/birthday-problem-oq-02-oq-01-oq-03/state.md
+++ b/research/problems/birthday-problem-oq-02-oq-01-oq-03/state.md
@@ -1,0 +1,41 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Iteration**: 1
+**Status**: in-progress
+
+## Current Focus
+
+Empty stub (no statement). Chose the natural next result in the birthday-problem
+lineage: **monotonicity of the collision probability in group size** — the formal
+content of the paradox's defining intuition, which the lineage's exponential
+estimates never state (researcher-9).
+
+## Delivered (PR pending)
+
+`proofs/Proofs/BirthdayProblemOQ02OQ01OQ03.lean` — 9 theorems, 2 defs, 0 axioms,
+0 sorries (typechecked `lake env lean`, Docker down; `#print axioms` = only
+propext/Classical.choice/Quot.sound):
+
+- `collisionProb_monotone` — collision prob `1 − P(all distinct)` is
+  non-decreasing in `k` for `j ≤ k ≤ d` (the monotone birthday paradox).
+- `birthdayProduct_antitone` — `P(all distinct) = ∏_{i<k}(1 − i/d)` non-increasing
+  in `k ≤ d`, by `Nat.le_induction` from `birthdayProduct_step_le`.
+- `birthdayProduct_succ` — recurrence `P(k+1) = P(k)·(1 − k/d)`.
+- `collisionProb_one` (= 0), `collisionProb_nonneg`, `collisionProb_le_one` —
+  genuine probability.
+
+## Important note
+
+The lineage parent `BirthdayProblemOQ02OQ01.lean` (two-sided exp estimate) does
+NOT compile against the current store Mathlib (v4.26.0): it uses deprecated
+API (`div_le_iff`, `Finset.sum_range_id_eq_sum_range_succ_div_two`,
+`Nat.eq_or_gt_of_le`). So this file is deliberately **self-contained** (imports
+Mathlib only; restates the standard `birthdayProduct`), depending on no project
+file. Worth flagging the parent for a separate API-refresh repair.
+
+## Next Action
+
+Possible follow-up: strict monotonicity (collision prob strictly increases while
+`P(k) > 0`), or the half-probability threshold `k ≈ 1.177√d`.

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-recurrence",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 50, "endLine": 55 },
+    "type": "theorem",
+    "title": "Birthday Recurrence",
+    "content": "The product form $P(\\text{all distinct}) = \\prod_{i<k}\\bigl(1 - \\tfrac{i}{d}\\bigr)$ satisfies $P(k+1) = P(k)\\cdot\\bigl(1 - \\tfrac{k}{d}\\bigr)$, peeling the top factor with `Finset.prod_range_succ`. The new factor $1 - k/d$ is the conditional probability that the $(k{+}1)$-th person avoids the first $k$ birthdays. This single recurrence drives all the monotonicity below.",
+    "mathContext": "$P(k+1) = P(k)\\,(1 - k/d)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Falling factorial", "Conditional probability", "Telescoping product"]
+  },
+  {
+    "id": "ann-step",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 88, "endLine": 97 },
+    "type": "theorem",
+    "title": "One Person Can Only Lower P(all distinct)",
+    "content": "For $k \\le d$, $P(k+1) \\le P(k)$: the recurrence multiplies the nonnegative quantity $P(k)$ by the factor $1 - k/d \\in [0,1]$, which cannot increase it (`mul_le_mul_of_nonneg_left`). This is the inductive step behind the global monotonicity.",
+    "mathContext": "$P(k+1) \\le P(k)$ for $k \\le d$.",
+    "significance": "key",
+    "relatedConcepts": ["Monotonicity", "Nonnegative product"]
+  },
+  {
+    "id": "ann-monotone",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 111, "endLine": 117 },
+    "type": "theorem",
+    "title": "The Monotone Birthday Paradox",
+    "content": "The headline: the collision probability $1 - P(\\text{all distinct})$ is **non-decreasing** in the number of people (for $j \\le k \\le d$). Formally $\\text{collisionProb}(j,d) \\le \\text{collisionProb}(k,d)$. This is the precise content of the paradox's intuition — adding people can only make a shared birthday more likely, never less — a statement the classic two-sided exponential estimates (sibling OQ-02-OQ-01) leave implicit. It follows immediately from `birthdayProduct_antitone` (proved by `Nat.le_induction` from the one-step bound).",
+    "mathContext": "$j \\le k \\le d \\Rightarrow \\text{collisionProb}(j,d) \\le \\text{collisionProb}(k,d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Birthday paradox", "Monotonicity", "Antitone", "Mathematical induction"]
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,87 @@
+{
+  "id": "birthday-problem-oq-02-oq-01-oq-03",
+  "title": "The Monotone Birthday Paradox: Collision Probability is Non-Decreasing in Group Size",
+  "slug": "birthday-problem-oq-02-oq-01-oq-03",
+  "description": "A fully machine-checked proof that the birthday-problem collision probability is monotone in the number of people: with d equally likely birthdays, P(at least two share a birthday) never decreases as the group grows. The all-distinct probability P(all distinct) = ∏_{i<k}(1 − i/d) satisfies the recurrence P(k+1) = P(k)·(1 − k/d); since the new factor lies in [0,1] and P(k) ≥ 0, P(all distinct) is non-increasing in k for k ≤ d (birthdayProduct_antitone), so its complement collisionProb k d = 1 − P(all distinct) is non-decreasing (collisionProb_monotone). This is the formal content of the paradox's defining intuition — more people can only make a shared birthday more likely — which the classic two-sided exponential estimates (sibling OQ-02-OQ-01) never state. Also: collisionProb 1 d = 0 (no collision with one person) and 0 ≤ collisionProb ≤ 1 (a genuine probability). 0 axioms, 0 sorries, self-contained.",
+  "meta": {
+    "author": "Classical (birthday problem, von Mises 1939); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Birthday_problem",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "probability",
+      "combinatorics",
+      "birthday-problem",
+      "monotonicity",
+      "falling-factorial",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BirthdayProblemOQ02OQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.prod_range_succ",
+        "description": "Peels the top factor off a range-product: ∏_{i<k+1} f i = (∏_{i<k} f i)·f k. Gives the birthday recurrence P(k+1) = P(k)·(1 − k/d).",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.prod_nonneg",
+        "description": "A product of nonnegative terms is nonnegative. Establishes P(all distinct) ≥ 0.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring"
+      },
+      {
+        "theorem": "Finset.prod_le_one",
+        "description": "A product of terms in [0,1] is at most 1. Establishes P(all distinct) ≤ 1, hence collisionProb ≥ 0.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring"
+      },
+      {
+        "theorem": "mul_le_mul_of_nonneg_left",
+        "description": "From b ≤ c and 0 ≤ a, deduce a·b ≤ a·c. With c = 1 this is the one-step monotonicity P(k)·(1 − k/d) ≤ P(k).",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "collisionProb_monotone: the birthday collision probability 1 − ∏_{i<k}(1 − i/d) is non-decreasing in the number of people k (for j ≤ k ≤ d) — the formal statement of the paradox's core intuition that more people can only raise the chance of a shared birthday, never lower it; not stated by the lineage's exponential estimates",
+      "birthdayProduct_antitone: P(all distinct) = ∏_{i<k}(1 − i/d) is non-increasing in k for k ≤ d, proved by Nat.le_induction from the one-step bound birthdayProduct_step_le, which uses the recurrence P(k+1) = P(k)·(1 − k/d) and that the new factor lies in [0,1]",
+      "collisionProb_one / collisionProb_nonneg / collisionProb_le_one: collisionProb 1 d = 0 (one person, no collision) and 0 ≤ collisionProb k d ≤ 1, certifying it is a genuine probability"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 136,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on collisionProb_monotone and birthdayProduct_antitone reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses. Self-contained: imports only Mathlib and restates the standard birthdayProduct of the OQ-02-OQ-01 lineage (whose source predates current Mathlib API), so it does not depend on any other project file.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Birthday Product and Collision Probability",
+      "startLine": 41,
+      "endLine": 55,
+      "summary": "birthdayProduct k d = ∏_{i<k}(1 − i/d), the probability all k birthdays are distinct among d equally likely days (the falling factorial d^{underline k}/d^k); collisionProb k d = 1 − birthdayProduct k d."
+    },
+    {
+      "id": "recurrence-bounds",
+      "title": "Recurrence and Factor Bounds",
+      "startLine": 50,
+      "endLine": 86,
+      "summary": "birthdayProduct_succ: P(k+1) = P(k)·(1 − k/d) via Finset.prod_range_succ. factor_nonneg / factor_le_one: each factor 1 − i/d lies in [0,1] for i ≤ d. birthdayProduct_nonneg / birthdayProduct_le_one: P(all distinct) ∈ [0,1] for k ≤ d+1."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity of the Paradox",
+      "startLine": 88,
+      "endLine": 117,
+      "summary": "birthdayProduct_step_le: P(k+1) ≤ P(k) (multiply a nonneg quantity by a factor ≤ 1). birthdayProduct_antitone: P(k) ≤ P(j) for j ≤ k ≤ d by Nat.le_induction. collisionProb_monotone: hence 1 − P is non-decreasing — the monotone birthday paradox."
+    },
+    {
+      "id": "probability-facts",
+      "title": "Collision Probability is a Probability",
+      "startLine": 119,
+      "endLine": 134,
+      "summary": "collisionProb_one: collisionProb 1 d = 0 (no collision with a single person). collisionProb_nonneg / collisionProb_le_one: 0 ≤ collisionProb k d ≤ 1 for k ≤ d+1."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the birthday-problem **collision probability is non-decreasing in group size** — the formal content of the paradox's defining intuition (more people ⇒ a shared birthday is at least as likely, never less), which the lineage's two-sided exponential estimates (sibling OQ-02-OQ-01) never state. **9 theorems, 2 defs, 0 axioms, 0 sorries.**

With $d$ equally likely birthdays, $P(\text{all distinct}) = \prod_{i<k}(1 - i/d)$ and $\text{collisionProb}(k,d) = 1 - P(\text{all distinct})$.

- **`collisionProb_monotone`**: $j \le k \le d \Rightarrow \text{collisionProb}(j,d) \le \text{collisionProb}(k,d)$.
- **`birthdayProduct_antitone`**: $P(\text{all distinct})$ is non-increasing in $k \le d$, by `Nat.le_induction` from the one-step bound.
- **`birthdayProduct_step_le`**: the recurrence $P(k+1) = P(k)(1 - k/d)$ multiplies a nonnegative quantity by a factor in $[0,1]$, so it cannot increase.
- **`collisionProb_one`** (= 0), **`collisionProb_nonneg`**, **`collisionProb_le_one`**: a genuine probability.

## Verification

- Typechecked via `lake env lean Proofs/BirthdayProblemOQ02OQ01OQ03.lean` (exit 0; Docker unavailable this session).
- `#print axioms` on `collisionProb_monotone` and `birthdayProduct_antitone` = only `propext, Classical.choice, Quot.sound` → **0 counted axioms**. No `native_decide`. Status `verified`, badge `original`.

## Note on self-containment

The file imports only Mathlib and restates the standard `birthdayProduct` rather than importing the lineage parent, because **`BirthdayProblemOQ02OQ01.lean` does not compile against the current Mathlib (v4.26.0)** — it uses deprecated API (`div_le_iff`, `Finset.sum_range_id_eq_sum_range_succ_div_two`, `Nat.eq_or_gt_of_le`). This is flagged in `state.md` as a separate API-refresh repair; the monotonicity result needs only the product recurrence, so the dependency was unnecessary anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)