### PR TITLE
audit(gallery): 12 fresh proofs CLEAN (abel-ruffini, chebyshev, twin-primes, +9)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24444,6 +24444,84 @@
       "lastAudited": "2026-06-25T21:01:58Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-obstruction-oq-06 burnside-counting-oq-06 chebyshev-bounds-oq-02-oq-01-oq-01 chinese-remainder-non-coprime-oq-02-oq-01 combinations-formula-oq-08-oq-01 descartes-rule-of-signs-oq-01-oq-03 frobenius-number-oq-02-oq-01 lucas-sum-oq-01 odd-cubes-sum-oq-01 odd-squares-sum-oq-01 stars-and-bars-weak-compositions-oq-03 twin-primes-special-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:26Z",
+      "result": "clean",
+      "issues": []
+    },
+    "abel-ruffini-obstruction-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:43Z",
+      "result": "clean",
+      "issues": []
+    },
+    "burnside-counting-oq-06": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-bounds-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-non-coprime-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-08-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "descartes-rule-of-signs-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "frobenius-number-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lucas-sum-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "odd-cubes-sum-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "odd-squares-sum-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stars-and-bars-weak-compositions-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "twin-primes-special-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:23:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 12 proofs CLEAN

Audited the 12 genuinely-uncovered unaudited gallery proofs (the other 5 unaudited are already covered by open audit PRs #30277 and #30226). All public claims match the Lean kernel guarantee — no overclaiming found.

### Mathlib-heavy 'verified/original' — checked for delegation opacity
- **abel-ruffini-obstruction-oq-06** — Transparently credits Mathlib's `Equiv.Perm.not_solvable` and the contrapositive of `solvableByRad.isSolvable'` in both `mathlibDependencies` and the description. The original contribution (`symmetricGroup_not_solvable`: uniform-in-n non-solvability for **all** n≥5, generalizing Mathlib's single `Fin 5` case via `Cardinal.mk_fin`) is genuine and self-proved. No "first/independent proof" language. CLEAN.
- **chebyshev-bounds-oq-02-oq-01-oq-01** — Honest: description states "Mathlib provides only the upper inequality… has no lower bound. The new content is the lower bound." The novel linear θ lower bound is self-derived from the project's ψ bound. CLEAN.

### Axiomatized — verified faithfully stated & counted
- **twin-primes-special-oq-02** — `status: axiomatized`, `badge: axiom`, `axiomCount: 1`. The lone axiom `hardy_littlewood_conjecture_B` is the open Hardy–Littlewood Conjecture B, faithfully stated; all other results machine-checked. CLEAN.
- **descartes-rule-of-signs-oq-01-oq-03** — `status: axiomatized`, `badge: axiom`, `axiomCount: 1`. The `SturmReduction` bridge **structure** carries the assumption; correctly counted as 1 per the axiom-integrity policy (`leanFile.axiomCount` = 0, legitimately). CLEAN.

### Elementary self-proved — 0 sorry / 0 axiom
- **burnside-counting-oq-06** — grep hits for `sorry`/`native_decide` are a single docstring line asserting their *absence*; file is 0-sorry/0-axiom/4-theorem. CLEAN.
- **chinese-remainder-non-coprime-oq-02-oq-01, combinations-formula-oq-08-oq-01, frobenius-number-oq-02-oq-01, lucas-sum-oq-01, odd-cubes-sum-oq-01, odd-squares-sum-oq-01, stars-and-bars-weak-compositions-oq-03** — elementary identities/bijections, 0 sorry / 0 axiom, Mathlib deps limited to `sum_range_succ`-style plumbing. CLEAN.

### Checks run
sorry count, `axiom` declarations, `native_decide`/`Lean.ofReduceBool`, True stubs, Tier classification & badge accuracy, mathlib-wrapper delegation opacity.

Only `src/data/proofs/audit-tracker.json` is modified (12 entries → `clean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)