### PR TITLE
research(unit-distance-independence-oq-01): χ(ℝ²) ≥ 4 via Moser spindle [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/UnitDistanceIndependenceOQ01.lean
+++ b/proofs/Proofs/UnitDistanceIndependenceOQ01.lean
@@ -1,0 +1,300 @@
+/-
+# A Machine-Checked Lower Bound χ(ℝ²) ≥ 4 via the Moser Spindle
+
+Open question OQ-01 of `unit-distance-independence`.
+
+The parent formalization (`UnitDistanceIndependence.lean`) records the
+Hadwiger–Nelson bounds `5 ≤ χ(ℝ²) ≤ 7`: the upper bound `≤ 7` is a fully
+machine-checked theorem (hexagonal 7-colouring, `UnitDistanceHN7.lean`), while
+the lower bound `χ(ℝ²) ≥ 5` is **axiomatized** (de Grey 2018 — a genuinely hard
+1581-vertex construction).
+
+This file supplies the *strongest unconditional, fully verified* lower bound the
+gallery was missing: a 0-axiom proof that
+
+    χ(ℝ²) ≥ 4,
+
+i.e. **no 3-colouring of the plane avoids monochromatic unit-distance pairs**.
+This is the classical Moser–Moser (1961) bound, obtained by exhibiting the
+**Moser spindle**: a 7-vertex, 11-edge unit-distance graph whose chromatic
+number is 4.
+
+**Strategy** (entirely elementary, no `native_decide`):
+
+1. *Combinatorics.* The abstract spindle graph on `Fin 7` is not properly
+   3-colourable: for every `f : Fin 7 → Fin 3` two adjacent vertices share a
+   colour. This is a finite check (`decide`, 3⁷ = 2187 colourings).
+
+2. *Geometry.* The 7 vertices are realized in ℝ² so that every spindle edge has
+   Euclidean length exactly 1. The construction is two rhombi (each a pair of
+   unit equilateral triangles) sharing a vertex at the origin, the second
+   rhombus being the first rotated by the angle `θ` with `cos θ = 5/6`,
+   `sin θ = √11/6` — the unique rotation bringing the two far tips to unit
+   distance. The irrationality `√11` is intrinsic to the spindle.
+
+3. *Bridge.* Any unit-distance-avoiding colouring of the plane, restricted to
+   the 7 vertices, would be a proper 3-colouring of the spindle — impossible.
+
+Together with the parent's verified `χ(ℝ²) ≤ 7`, this gives the fully
+machine-checked window `4 ≤ χ(ℝ²) ≤ 7`, with the sharper `≥ 5` remaining the one
+axiomatized (de Grey) input.
+
+**Status**: VERIFIED (0 sorries, 0 axioms).
+Tags: combinatorial-geometry, unit-distance-graphs, hadwiger-nelson, moser-spindle
+-/
+
+import Mathlib.Analysis.InnerProductSpace.EuclideanDist
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Tactic
+
+namespace UnitDistanceIndependenceOQ01
+
+open Finset
+
+/-- The plane as the 2-dimensional Euclidean space. -/
+abbrev Plane := EuclideanSpace ℝ (Fin 2)
+
+noncomputable section
+
+/-- `√3`, the height parameter of the unit equilateral triangle. -/
+def s3 : ℝ := Real.sqrt 3
+
+/-- `√11`; `√11 / 6 = sin θ` for the spindle's rotation angle. -/
+def s11 : ℝ := Real.sqrt 11
+
+/-- Construct a plane point from its two Cartesian coordinates. -/
+def mk (x y : ℝ) : Plane := (EuclideanSpace.equiv (Fin 2) ℝ).symm ![x, y]
+
+/-- The rotation by the spindle angle `θ` (`cos θ = 5/6`, `sin θ = √11/6`)
+    about the origin. -/
+def rot (p : Plane) : Plane :=
+  mk (5 / 6 * p 0 - s11 / 6 * p 1) (s11 / 6 * p 0 + 5 / 6 * p 1)
+
+/-- Reading back the first coordinate of `mk x y`. -/
+theorem mk_zero (x y : ℝ) : (mk x y) 0 = x := by
+  simp only [mk, PiLp.continuousLinearEquiv_symm_apply, PiLp.toLp_apply,
+             Matrix.cons_val_zero]
+
+/-- Reading back the second coordinate of `mk x y`. -/
+theorem mk_one (x y : ℝ) : (mk x y) 1 = y := by
+  simp only [mk, PiLp.continuousLinearEquiv_symm_apply, PiLp.toLp_apply,
+             Matrix.cons_val_one, Matrix.cons_val_zero]
+
+/-- Squared distance between two explicit points is the sum of squared
+    coordinate differences. -/
+theorem dist_mk_sq (x₁ y₁ x₂ y₂ : ℝ) :
+    dist (mk x₁ y₁) (mk x₂ y₂) ^ 2 = (x₁ - x₂) ^ 2 + (y₁ - y₂) ^ 2 := by
+  rw [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two]
+  simp only [mk, PiLp.continuousLinearEquiv_symm_apply, PiLp.toLp_apply,
+             Matrix.cons_val_zero, Matrix.cons_val_one,
+             Real.dist_eq, sq_abs]
+
+/-- From a squared-distance computation equal to `1`, conclude the distance is
+    `1` (using `dist ≥ 0`). -/
+theorem dist_eq_one_of (x₁ y₁ x₂ y₂ : ℝ)
+    (h : (x₁ - x₂) ^ 2 + (y₁ - y₂) ^ 2 = 1) :
+    dist (mk x₁ y₁) (mk x₂ y₂) = 1 := by
+  have hsq : dist (mk x₁ y₁) (mk x₂ y₂) ^ 2 = 1 := by rw [dist_mk_sq]; exact h
+  have hnn : (0 : ℝ) ≤ dist (mk x₁ y₁) (mk x₂ y₂) := dist_nonneg
+  have hfac :
+      (dist (mk x₁ y₁) (mk x₂ y₂) - 1) * (dist (mk x₁ y₁) (mk x₂ y₂) + 1) = 0 := by
+    linear_combination hsq
+  rcases mul_eq_zero.mp hfac with h₁ | h₁
+  · linarith
+  · linarith
+
+/-- `rot` evaluated on an explicit point. -/
+theorem rot_mk (a b : ℝ) :
+    rot (mk a b) = mk (5 / 6 * a - s11 / 6 * b) (s11 / 6 * a + 5 / 6 * b) := by
+  simp only [rot, mk_zero, mk_one]
+
+/-- The origin is fixed by the rotation. -/
+theorem rot_origin : rot (mk 0 0) = mk 0 0 := by
+  rw [rot_mk]; norm_num
+
+/-- `rot` is an isometry: it preserves Euclidean distance. -/
+theorem rot_isometry (p q : Plane) : dist (rot p) (rot q) = dist p q := by
+  have hs11 : s11 ^ 2 = 11 := Real.sq_sqrt (by norm_num)
+  have hpq : dist p q ^ 2 = (p 0 - q 0) ^ 2 + (p 1 - q 1) ^ 2 := by
+    rw [EuclideanSpace.dist_sq_eq, Fin.sum_univ_two]
+    simp only [Real.dist_eq, sq_abs]
+  have hrot : dist (rot p) (rot q) ^ 2 =
+      (5 / 6 * p 0 - s11 / 6 * p 1 - (5 / 6 * q 0 - s11 / 6 * q 1)) ^ 2 +
+      (s11 / 6 * p 0 + 5 / 6 * p 1 - (s11 / 6 * q 0 + 5 / 6 * q 1)) ^ 2 := by
+    simp only [rot]; rw [dist_mk_sq]
+  have hsq : dist (rot p) (rot q) ^ 2 = dist p q ^ 2 := by
+    rw [hrot, hpq]
+    linear_combination
+      (((p 0 - q 0) ^ 2 + (p 1 - q 1) ^ 2) / 36) * hs11
+  have h₁ : (0 : ℝ) ≤ dist (rot p) (rot q) := dist_nonneg
+  have h₂ : (0 : ℝ) ≤ dist p q := dist_nonneg
+  nlinarith [hsq, h₁, h₂]
+
+/-! ## The seven vertices of the Moser spindle -/
+
+/-- The seven spindle vertices.
+
+* `0`–`3`: the first rhombus (origin, two unit triangles).
+* `4`–`6`: the second rhombus, the rotation of vertices `1`–`3` by `θ`. -/
+def pt : Fin 7 → Plane
+  | 0 => mk 0 0
+  | 1 => mk 1 0
+  | 2 => mk (1 / 2) (s3 / 2)
+  | 3 => mk (3 / 2) (s3 / 2)
+  | 4 => rot (mk 1 0)
+  | 5 => rot (mk (1 / 2) (s3 / 2))
+  | 6 => rot (mk (3 / 2) (s3 / 2))
+
+/-! ### The eleven edges have unit length
+
+First-rhombus edges (only `√3` enters). -/
+
+theorem dist01 : dist (pt 0) (pt 1) = 1 := by
+  apply dist_eq_one_of; norm_num
+
+theorem dist02 : dist (pt 0) (pt 2) = 1 := by
+  apply dist_eq_one_of
+  have hs3 : s3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  linear_combination (1 / 4 : ℝ) * hs3
+
+theorem dist12 : dist (pt 1) (pt 2) = 1 := by
+  apply dist_eq_one_of
+  have hs3 : s3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  linear_combination (1 / 4 : ℝ) * hs3
+
+theorem dist13 : dist (pt 1) (pt 3) = 1 := by
+  apply dist_eq_one_of
+  have hs3 : s3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  linear_combination (1 / 4 : ℝ) * hs3
+
+theorem dist23 : dist (pt 2) (pt 3) = 1 := by
+  apply dist_eq_one_of; ring
+
+/-! Second-rhombus edges, via the isometry `rot` and the fixed origin. -/
+
+theorem dist04 : dist (pt 0) (pt 4) = 1 := by
+  show dist (mk 0 0) (rot (mk 1 0)) = 1
+  rw [← rot_origin, rot_isometry]; exact dist01
+
+theorem dist05 : dist (pt 0) (pt 5) = 1 := by
+  show dist (mk 0 0) (rot (mk (1 / 2) (s3 / 2))) = 1
+  rw [← rot_origin, rot_isometry]; exact dist02
+
+theorem dist45 : dist (pt 4) (pt 5) = 1 := by
+  show dist (rot (mk 1 0)) (rot (mk (1 / 2) (s3 / 2))) = 1
+  rw [rot_isometry]; exact dist12
+
+theorem dist46 : dist (pt 4) (pt 6) = 1 := by
+  show dist (rot (mk 1 0)) (rot (mk (3 / 2) (s3 / 2))) = 1
+  rw [rot_isometry]; exact dist13
+
+theorem dist56 : dist (pt 5) (pt 6) = 1 := by
+  show dist (rot (mk (1 / 2) (s3 / 2))) (rot (mk (3 / 2) (s3 / 2))) = 1
+  rw [rot_isometry]; exact dist23
+
+/-! The bridging edge between the two far tips `D` and `D'` — the unit distance
+the rotation angle was chosen to produce. This is the one computation that uses
+both `√3` and `√11` (the `√33` cross term cancels). -/
+
+theorem dist36 : dist (pt 3) (pt 6) = 1 := by
+  show dist (mk (3 / 2) (s3 / 2)) (rot (mk (3 / 2) (s3 / 2))) = 1
+  rw [rot_mk]
+  apply dist_eq_one_of
+  have hs3 : s3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have hs11 : s11 ^ 2 = 11 := Real.sq_sqrt (by norm_num)
+  linear_combination ((s11 ^ 2 + 1) / 144) * hs3 + (12 / 144 : ℝ) * hs11
+
+/-! ### The abstract spindle graph and its chromatic obstruction -/
+
+/-- The 11 edges of the Moser spindle (canonical orientation `i < j`). -/
+def isEdge : Fin 7 → Fin 7 → Bool
+  | 0, 1 => true
+  | 0, 2 => true
+  | 1, 2 => true
+  | 1, 3 => true
+  | 2, 3 => true
+  | 0, 4 => true
+  | 0, 5 => true
+  | 4, 5 => true
+  | 4, 6 => true
+  | 5, 6 => true
+  | 3, 6 => true
+  | _, _ => false
+
+/-- In `Fin 3` (three colours), a vertex's colour is determined by the two
+    colours it must avoid: if `c` and `d` both differ from the two distinct
+    colours `a, b`, then `c = d`. The combinatorial heart of the rhombus
+    argument. A 3⁴ = 81-case finite check. -/
+theorem fin3_third (a b c d : Fin 3) :
+    a ≠ b → c ≠ a → c ≠ b → d ≠ a → d ≠ b → c = d := by
+  revert a b c d; decide
+
+/-- **The Moser spindle is not 3-colourable.** For every assignment of 3 colours
+    to its 7 vertices, some edge is monochromatic.
+
+    Proof (no brute force over 3⁷ colourings): each rhombus forces its two far
+    tips to share a colour. In rhombus `{0,1,2,3}` the triangles `012` and `123`
+    use all three colours, so vertices `0` and `3` (each the unique colour
+    avoided by `1,2`) satisfy `f 0 = f 3`; likewise `f 0 = f 6` in rhombus
+    `{0,4,5,6}`. Hence `f 3 = f 6`, but `3—6` is an edge. -/
+theorem spindle_not_3colorable (f : Fin 7 → Fin 3) :
+    ∃ i j, isEdge i j = true ∧ f i = f j := by
+  by_contra hcon
+  push_neg at hcon
+  -- All eleven edges are assumed bichromatic.
+  have e01 : f 0 ≠ f 1 := hcon 0 1 (by decide)
+  have e02 : f 0 ≠ f 2 := hcon 0 2 (by decide)
+  have e12 : f 1 ≠ f 2 := hcon 1 2 (by decide)
+  have e13 : f 1 ≠ f 3 := hcon 1 3 (by decide)
+  have e23 : f 2 ≠ f 3 := hcon 2 3 (by decide)
+  have e04 : f 0 ≠ f 4 := hcon 0 4 (by decide)
+  have e05 : f 0 ≠ f 5 := hcon 0 5 (by decide)
+  have e45 : f 4 ≠ f 5 := hcon 4 5 (by decide)
+  have e46 : f 4 ≠ f 6 := hcon 4 6 (by decide)
+  have e56 : f 5 ≠ f 6 := hcon 5 6 (by decide)
+  have e36 : f 3 ≠ f 6 := hcon 3 6 (by decide)
+  -- Far tips of each rhombus share a colour.
+  have c03 : f 0 = f 3 := fin3_third (f 1) (f 2) (f 0) (f 3) e12 e01 e02 e13.symm e23.symm
+  have c06 : f 0 = f 6 := fin3_third (f 4) (f 5) (f 0) (f 6) e45 e04 e05 e46.symm e56.symm
+  exact e36 (c03.symm.trans c06)
+
+set_option maxRecDepth 4000 in
+/-- Every spindle edge is realized as a unit distance in the plane. -/
+theorem edge_unit (i j : Fin 7) (h : isEdge i j = true) :
+    dist (pt i) (pt j) = 1 := by
+  fin_cases i <;> fin_cases j <;>
+    first
+      | (exfalso; revert h; decide)
+      | exact dist01 | exact dist02 | exact dist12 | exact dist13 | exact dist23
+      | exact dist04 | exact dist05 | exact dist45 | exact dist46 | exact dist56
+      | exact dist36
+
+/-! ### Main result -/
+
+/-- **χ(ℝ²) ≥ 4 (Moser spindle, fully verified, 0 axioms).**
+
+No colouring of the plane with 3 colours can avoid monochromatic unit-distance
+pairs: for every `c : Plane → Fin 3` there are two points `p, q` at distance `1`
+with `c p = c q`.
+
+Restricting any such colouring to the 7 Moser-spindle vertices yields a
+3-colouring of the spindle, which `spindle_not_3colorable` forbids; the
+offending edge is a genuine unit distance by `edge_unit`. -/
+theorem chromatic_plane_ge_four (c : Plane → Fin 3) :
+    ∃ p q : Plane, dist p q = 1 ∧ c p = c q := by
+  obtain ⟨i, j, he, hcol⟩ := spindle_not_3colorable (fun k => c (pt k))
+  exact ⟨pt i, pt j, edge_unit i j he, hcol⟩
+
+/-- Restatement matching the parent file's phrasing of chromatic lower bounds:
+    no proper 3-colouring of the unit-distance graph on the plane exists. This is
+    the **verified** companion to the parent's *axiomatized* de Grey bound
+    (`hadwiger_nelson_lower_bound`, `χ(ℝ²) ≥ 5`). -/
+theorem no_proper_3coloring_of_plane :
+    ¬ ∃ c : Plane → Fin 3, ∀ p q : Plane, dist p q = 1 → c p ≠ c q := by
+  rintro ⟨c, hc⟩
+  obtain ⟨p, q, hd, hcol⟩ := chromatic_plane_ge_four c
+  exact hc p q hd hcol
+
+end
+
+end UnitDistanceIndependenceOQ01

--- a/src/data/proofs/unit-distance-independence-oq-01/meta.json
+++ b/src/data/proofs/unit-distance-independence-oq-01/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "unit-distance-independence-oq-01",
+  "title": "A Machine-Checked Lower Bound χ(ℝ²) ≥ 4 via the Moser Spindle",
+  "slug": "unit-distance-independence-oq-01",
+  "description": "Open question OQ-01 of unit-distance-independence. Supplies the strongest fully verified (0-axiom) lower bound for the Hadwiger-Nelson problem: no 3-coloring of the plane avoids monochromatic unit-distance pairs, i.e. χ(ℝ²) ≥ 4. The bound is the classical Moser (1961) result, obtained by an explicit unit-distance embedding of the 7-vertex Moser spindle and a kernel-checked proof that the spindle graph is not 3-colorable. Together with the parent's verified upper bound χ(ℝ²) ≤ 7, this gives the machine-checked window 4 ≤ χ(ℝ²) ≤ 7, with the sharper de Grey bound χ(ℝ²) ≥ 5 remaining the one axiomatized input. 23 theorems, 6 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius (researcher-2)",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UnitDistanceIndependenceOQ01.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "unit-distance-graphs",
+      "hadwiger-nelson",
+      "moser-spindle",
+      "chromatic-number",
+      "graph-coloring"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "assumptions": "None. The result depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No `axiom` declarations, no structure-encoded assumptions, and crucially no `native_decide` — the spindle's non-3-colorability is proved by an elementary rhombus argument reduced to a 3⁴-case Fin 3 lemma (kernel `decide`), not by brute force over the 3⁷ colourings, and not by the compiler-trusting `Lean.ofReduceBool`.",
+    "lineCount": 300,
+    "theoremCount": 23,
+    "definitionCount": 6,
+    "originalContributions": [
+      "chromatic_plane_ge_four: fully machine-checked χ(ℝ²) ≥ 4 — for every c : Plane → Fin 3 there exist points p, q at distance 1 with c p = c q (0 axioms)",
+      "no_proper_3coloring_of_plane: the verified companion to the parent's axiomatized de Grey bound — no proper 3-coloring of the unit-distance graph on ℝ² exists",
+      "Explicit unit-distance embedding of the Moser spindle: 7 points (pt) with all 11 edges proved to have Euclidean length exactly 1",
+      "rot / rot_isometry: the spindle rotation by θ (cos θ = 5/6, sin θ = √11/6) and a proof it is an isometry, so five of the six second-rhombus edges reduce to first-rhombus distances without re-computation",
+      "dist36: the one direct √3/√11 coordinate computation (the bridging edge D—D'); the √33 cross term cancels and linear_combination closes it",
+      "spindle_not_3colorable: an elementary, brute-force-free proof that the Moser spindle is not 3-colorable, via fin3_third (the two far tips of each rhombus must share a colour)",
+      "dist_mk_sq / dist_eq_one_of: reusable helpers turning a sum-of-squared-coordinate-differences identity into a Euclidean unit-distance fact"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Hadwiger-Nelson problem (1950) asks for the chromatic number χ(ℝ²) of the plane, where two points are adjacent iff they are exactly unit distance apart. The first nontrivial lower bound, χ(ℝ²) ≥ 4, was established by William and Leo Moser in 1961 via the **Moser spindle**: a 7-vertex, 11-edge unit-distance graph with chromatic number 4. The spindle is built from two rhombi — each a pair of unit equilateral triangles — that share a vertex, with the second rhombus rotated so that the two far tips land exactly one unit apart. This 4 ≤ χ(ℝ²) ≤ 7 window stood for 57 years until Aubrey de Grey's 2018 construction of a 1581-vertex unit-distance graph with chromatic number 5 raised the lower bound to 5. The exact value remains open: χ(ℝ²) ∈ {5, 6, 7}.",
+    "problemStatement": "The parent formalization records 5 ≤ χ(ℝ²) ≤ 7 with the upper bound proved (hexagonal 7-coloring) but the lower bound 5 ≤ χ(ℝ²) axiomatized (de Grey's hard construction). OQ-01 asks: can we supply a fully verified, axiom-free lower bound? The answer is the Moser bound χ(ℝ²) ≥ 4 — the strongest lower bound provable by elementary means.",
+    "proofStrategy": "Three ingredients. (1) Combinatorics: the abstract spindle graph on Fin 7 is not properly 3-colorable. Rather than enumerate all 3⁷ colourings, we use the classical rhombus argument: in each rhombus the two triangles use all three colours, forcing the two far tips to receive the same colour; the two rhombi then force f 3 = f 6, contradicting the bridging edge 3—6. The only finite check is fin3_third, an 81-case Fin 3 lemma. (2) Geometry: the 7 vertices are realized in ℝ² with every spindle edge of length exactly 1. The second rhombus is the rotation of the first by θ with cos θ = 5/6, sin θ = √11/6; rot is proved an isometry fixing the origin, so all but one second-rhombus edge reduce to first-rhombus distances. The lone bridging edge D—D' is computed directly — the √33 cross term cancels. (3) Bridge: any unit-distance-avoiding colouring of the plane restricts to a proper 3-colouring of the spindle, which is impossible.",
+    "keyInsights": [
+      "Two far tips of a 'double-triangle' rhombus must share a colour in any 3-coloring — the combinatorial crux, captured by fin3_third over Fin 3",
+      "The Moser spindle's irrationality is intrinsic: the rotation needs sin θ = √11/6, so √11 cannot be avoided in any unit-distance embedding",
+      "Using rot as an isometry collapses five edge computations to one — only the bridging edge D—D' requires direct √3/√11 coordinate algebra",
+      "The √33 = √3·√11 cross terms in the bridging-edge squared distance cancel exactly, leaving a rational identity that linear_combination discharges from s3² = 3 and s11² = 11",
+      "Avoiding native_decide keeps the result genuinely axiom-free: #print axioms shows only propext, Classical.choice, Quot.sound",
+      "This is the verified counterpart to the axiomatized de Grey bound: 4 ≤ χ(ℝ²) ≤ 7 is now fully machine-checked, while 5 ≤ χ(ℝ²) remains the single axiomatized input"
+    ],
+    "prerequisites": [
+      "Euclidean distance in EuclideanSpace ℝ (Fin 2)",
+      "Graph coloring: proper colorings and chromatic number",
+      "Elementary plane geometry: rotations, equilateral triangles, rhombi",
+      "Real square roots and the cancellation of cross terms in squared distances"
+    ],
+    "text": "The Moser spindle gives the elementary lower bound for the chromatic number of the plane. We embed its 7 vertices explicitly: vertices 0–3 form the first rhombus (origin and two unit equilateral triangles), vertices 4–6 are the rotation of 1–3 by the angle θ with cos θ = 5/6 and sin θ = √11/6. All 11 edges are proved to be unit distances — five second-rhombus edges for free via the isometry rot, the bridging edge D—D' by a direct computation where the √33 cross term vanishes. Combinatorially, each rhombus forces its far tips to share a colour in any 3-coloring, so a proper 3-coloring would give f 3 = f 6 while 3 and 6 are adjacent. Hence no 3-coloring of the plane can avoid monochromatic unit-distance pairs: χ(ℝ²) ≥ 4, fully verified."
+  },
+  "sections": [
+    {
+      "id": "sec-udioq01-setup",
+      "title": "Coordinates, the rotation, and distance helpers",
+      "startLine": 46,
+      "endLine": 131,
+      "description": "The plane as EuclideanSpace ℝ (Fin 2); point constructor mk and coordinate read-back lemmas; the spindle rotation rot (cos θ = 5/6, sin θ = √11/6); the squared-distance helper dist_mk_sq and the unit-distance helper dist_eq_one_of; rot_isometry (rot preserves distance) and rot_origin (the origin is fixed).",
+      "mathContext": "$\\mathrm{rot}$ is the rotation with $\\cos\\theta = 5/6,\\ \\sin\\theta = \\sqrt{11}/6$; $\\mathrm{rot}$ is an isometry fixing the origin."
+    },
+    {
+      "id": "sec-udioq01-vertices",
+      "title": "The seven vertices of the Moser spindle",
+      "startLine": 133,
+      "endLine": 147,
+      "description": "The seven spindle vertices pt : Fin 7 → Plane. Vertices 0–3 are the first rhombus; vertices 4–6 are the rotations of 1–3.",
+      "mathContext": "First rhombus: $(0,0),(1,0),(\\tfrac12,\\tfrac{\\sqrt3}{2}),(\\tfrac32,\\tfrac{\\sqrt3}{2})$. Second rhombus: their images under $\\mathrm{rot}$."
+    },
+    {
+      "id": "sec-udioq01-edges",
+      "title": "The eleven edges have unit length",
+      "startLine": 148,
+      "endLine": 205,
+      "description": "All 11 spindle edges are proved to be Euclidean unit distances. First-rhombus edges use only √3; second-rhombus edges (dist04, dist05, dist45, dist46, dist56) reduce to first-rhombus distances via rot_isometry; the bridging edge dist36 (D—D') is the one direct √3/√11 computation, where the √33 cross term cancels.",
+      "mathContext": "Each edge $\\{i,j\\}$: $\\operatorname{dist}(\\mathrm{pt}\\,i,\\mathrm{pt}\\,j) = 1$."
+    },
+    {
+      "id": "sec-udioq01-obstruction",
+      "title": "The spindle graph and its chromatic obstruction",
+      "startLine": 207,
+      "endLine": 270,
+      "description": "isEdge encodes the 11 edges; fin3_third is the 3⁴-case Fin 3 lemma that a vertex's colour is fixed by the two it must avoid; spindle_not_3colorable proves the spindle is not 3-colorable by the rhombus argument (far tips share a colour, contradicting edge 3—6); edge_unit packages the 11 distance facts.",
+      "mathContext": "No $f:\\mathrm{Fin}\\,7\\to\\mathrm{Fin}\\,3$ makes every edge bichromatic."
+    },
+    {
+      "id": "sec-udioq01-main",
+      "title": "Main result: χ(ℝ²) ≥ 4",
+      "startLine": 272,
+      "endLine": 300,
+      "description": "chromatic_plane_ge_four: for every c : Plane → Fin 3 there exist p, q at distance 1 with c p = c q. no_proper_3coloring_of_plane restates this as the nonexistence of a proper 3-coloring of the plane's unit-distance graph — the verified companion to the parent's axiomatized de Grey bound.",
+      "mathContext": "$\\forall c:\\mathbb{R}^2\\to\\{0,1,2\\},\\ \\exists p,q:\\ \\|p-q\\|=1 \\wedge c(p)=c(q)$, i.e. $\\chi(\\mathbb{R}^2)\\ge 4$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Moser spindle is realized as an explicit unit-distance graph in ℝ² and proved non-3-colorable by an elementary, brute-force-free argument, yielding a fully machine-checked χ(ℝ²) ≥ 4. 23 theorems, 6 definitions, 300 lines, 0 axioms, 0 sorries (only propext / Classical.choice / Quot.sound).",
+    "implications": "Combined with the parent file's verified upper bound χ(ℝ²) ≤ 7, the window 4 ≤ χ(ℝ²) ≤ 7 is now entirely machine-checked. The sharper de Grey lower bound χ(ℝ²) ≥ 5 remains the single axiomatized input; this entry makes precise how much of the Hadwiger-Nelson bound is unconditionally verified versus assumed.",
+    "openQuestions": [
+      "Formalize de Grey's 2018 construction to replace the axiomatized χ(ℝ²) ≥ 5 with a verified proof",
+      "Prove the chromatic number of the rational plane χ(ℚ²) = 4 (Woodall 1973), highlighting why irrational coordinates are essential for the de Grey leap",
+      "Formalize a smaller 5-chromatic unit-distance graph (post-2018 reductions below 553 vertices) toward a tractable verified χ(ℝ²) ≥ 5",
+      "Prove the fractional chromatic number bound χ_f(ℝ²) ≥ 3.5 (Frankl-Wilson 1981)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "unit-distance-independence",
+      "relationship": "parent",
+      "description": "The parent formalization records the Hadwiger-Nelson bounds 5 ≤ χ(ℝ²) ≤ 7 with the lower bound axiomatized (de Grey). This entry supplies the verified, axiom-free lower bound χ(ℝ²) ≥ 4 via the Moser spindle, the strongest lower bound provable by elementary means."
+    },
+    {
+      "targetId": "four-color-theorem",
+      "relationship": "related",
+      "description": "Both concern chromatic numbers of geometric/combinatorial structures. The four-color theorem bounds χ(planar graphs) ≤ 4; here the Moser spindle gives a lower bound χ(ℝ²) ≥ 4 for the plane's unit-distance graph."
+    },
+    {
+      "targetId": "ramseys-theorem",
+      "relationship": "related",
+      "description": "Both are coloring problems on combinatorial structures; the Moser-spindle obstruction is a finite-gadget argument analogous in spirit to Ramsey-type forced-monochromatic configurations."
+    }
+  ],
+  "leanFile": {
+    "namespace": "UnitDistanceIndependenceOQ01",
+    "lineCount": 300,
+    "axiomCount": 0,
+    "theoremCount": 23,
+    "definitionCount": 6,
+    "path": "Proofs/UnitDistanceIndependenceOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open question **OQ-01** of `unit-distance-independence`. The parent formalization records the Hadwiger–Nelson bounds 5 ≤ χ(ℝ²) ≤ 7 with the **upper** bound proved (hexagonal 7-coloring) but the **lower** bound χ(ℝ²) ≥ 5 *axiomatized* (de Grey 2018 — a genuinely hard 1581-vertex construction).

This PR supplies the strongest **fully verified, 0-axiom** lower bound the gallery was missing:

> **χ(ℝ²) ≥ 4** — no 3-coloring of the plane avoids monochromatic unit-distance pairs (Moser 1961).

## How

1. **Geometry.** The 7-vertex Moser spindle is realized explicitly in ℝ² and all **11 edges proved to be unit distances**. The second rhombus is the first rotated by θ (cos θ = 5/6, sin θ = √11/6); `rot` is proved an isometry fixing the origin, so five second-rhombus edges reduce to first-rhombus distances. Only the bridging edge D—D' is computed directly — the √33 = √3·√11 cross term cancels and `linear_combination` closes it.
2. **Combinatorics.** `spindle_not_3colorable` is proved by the classical **rhombus argument** (the two far tips of each rhombus must share a colour in any 3-coloring, forcing `f 3 = f 6` against the edge 3—6) — reduced to an 81-case `Fin 3` lemma. **No brute force over 3⁷ colourings, no `native_decide`.**
3. **Bridge.** Any unit-distance-avoiding colouring of the plane restricts to a proper 3-coloring of the spindle — impossible.

## Verification

- `lake env lean Proofs/UnitDistanceIndependenceOQ01.lean`: **0 errors, 0 warnings**.
- `#print axioms chromatic_plane_ge_four` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`). **Genuinely 0-axiom.**
- 23 theorems, 6 definitions, 300 lines, 0 sorries.

## Result

Together with the parent's verified χ(ℝ²) ≤ 7, the window **4 ≤ χ(ℝ²) ≤ 7 is now fully machine-checked**; the sharper de Grey bound χ(ℝ²) ≥ 5 remains the single axiomatized input. New files only — no changes to the parent.

## Status
**Outcome**: completed (verified, 0-axiom)
**Next steps**: formalize a small 5-chromatic unit-distance graph toward a verified χ(ℝ²) ≥ 5; χ(ℚ²) = 4 (Woodall).

🤖 Generated by researcher-2