### PR TITLE
research(nicomachus-sum-of-cubes-oq-03): ∑(2k−1)³ = n²(2n²−1) [verified, 0 axiom]

### DIFF
--- a/proofs/Proofs/NicomachusOddCubes.lean
+++ b/proofs/Proofs/NicomachusOddCubes.lean
@@ -1,0 +1,93 @@
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-
+# Sum of the First n Odd Cubes: ∑ (2k−1)³ = n²(2n²−1)
+
+## Open Question (nicomachus-sum-of-cubes-oq-03)
+
+The odd-cube analogue of Nicomachus's theorem.  Where the parent identity sums
+*all* cubes `1³ + 2³ + ⋯ + n³ = (∑k)²`, here we sum only the **odd** cubes:
+
+    1³ + 3³ + 5³ + ⋯ + (2n−1)³ = n²(2n²−1).
+
+Indexing the `n` odd numbers as `2k+1` for `k = 0,…,n−1` (so `range n` produces
+`1, 3, …, 2n−1`), the statement reads `∑_{k<n} (2k+1)³ = n²(2n²−1)`.
+
+Check: `n=1 → 1 = 1·1`, `n=2 → 1+27 = 28 = 4·7`, `n=3 → 1+27+125 = 153 = 9·17`.
+
+## Result
+
+A fully machine-checked, self-contained proof by induction.
+
+The closed form `n²(2n²−1)` carries a subtraction, which is the enemy of `ring`
+over ℕ (truncated subtraction is not a ring operation).  We sidestep it entirely
+by proving the **subtraction-free** equivalent
+
+    `(∑_{k<n} (2k+1)³) + n² = 2·n⁴`        (`sum_odd_cubes_add`),
+
+obtained by adding `n²` to both sides of `n²(2n²−1) = 2n⁴ − n²`.  Every term is a
+genuine natural number, so the inductive step closes by a single polynomial
+identity (`ring` for the algebra, `omega` to combine it with the hypothesis).
+The headline form `n²(2n²−1)` is then recovered over ℤ via `push_cast`, where the
+subtraction is honest.
+
+## Novelty
+
+Mathlib has neither the odd-cube identity nor its subtraction-free repackaging.
+This file supplies both, mirroring the additive clear-denominator technique used
+for the parent Nicomachus and Faulhaber-type sums in the gallery.
+
+0 sorries, 0 axioms.
+-/
+
+namespace NicomachusOddCubes
+
+open Finset
+
+/-- **Subtraction-free odd-cube identity.**  Adding `n²` to both sides of the
+headline `∑(2k+1)³ = n²(2n²−1) = 2n⁴ − n²` clears the truncated subtraction, so
+the whole statement lives cleanly in ℕ:
+
+`(∑_{k<n} (2k+1)³) + n² = 2·n⁴`.
+
+The induction step is a pure polynomial identity; `omega` splices it together
+with the inductive hypothesis. -/
+theorem sum_odd_cubes_add (n : ℕ) :
+    (∑ k ∈ range n, (2 * k + 1) ^ 3) + n ^ 2 = 2 * n ^ 4 := by
+  induction n with
+  | zero => rfl
+  | succ m ih =>
+    rw [sum_range_succ]
+    -- The algebraic heart, a subtraction-free polynomial identity over ℕ:
+    have key : 2 * m ^ 4 + (2 * m + 1) ^ 3 + (m + 1) ^ 2
+        = 2 * (m + 1) ^ 4 + m ^ 2 := by ring
+    -- `ih : (∑ k ∈ range m, (2k+1)³) + m² = 2·m⁴` and `key` are linear in the
+    -- nonlinear atoms; `omega` closes the goal.
+    omega
+
+/-- **Sum of the first `n` odd cubes** (headline form, over ℤ).  Stating the
+identity over ℤ lets the closed form `n²(2n²−1)` use honest subtraction:
+
+`∑_{k<n} (2k+1)³ = n²·(2n²−1)`. -/
+theorem sum_odd_cubes (n : ℕ) :
+    (∑ k ∈ range n, ((2 * (k : ℤ) + 1) ^ 3)) = (n : ℤ) ^ 2 * (2 * (n : ℤ) ^ 2 - 1) := by
+  have h := sum_odd_cubes_add n
+  -- Push the ℕ identity into ℤ, isolate the sum, then `ring` clears the product.
+  have hℤ := congrArg (Nat.cast : ℕ → ℤ) h
+  push_cast at hℤ
+  -- hℤ : (∑ k ∈ range n, (2·↑k+1)³) + ↑n² = 2·↑n⁴
+  have hsum : (∑ k ∈ range n, ((2 * (k : ℤ) + 1) ^ 3)) = 2 * (n : ℤ) ^ 4 - (n : ℤ) ^ 2 := by
+    linarith [hℤ]
+  rw [hsum]; ring
+
+/-- **Triangular/closed multiplicative form.**  Four times the sum of the first
+`n` odd cubes plus `4n²` equals `8n⁴` — the same content as `sum_odd_cubes_add`,
+scaled, recorded for callers who prefer the `2n²−1` factor cleared into a
+product.  Kept over ℕ and subtraction-free. -/
+theorem four_mul_sum_odd_cubes (n : ℕ) :
+    4 * (∑ k ∈ range n, (2 * k + 1) ^ 3) + 4 * n ^ 2 = 8 * n ^ 4 := by
+  have h := sum_odd_cubes_add n
+  omega
+
+end NicomachusOddCubes

--- a/research/problems/nicomachus-sum-of-cubes-oq-03/knowledge.md
+++ b/research/problems/nicomachus-sum-of-cubes-oq-03/knowledge.md
@@ -1,0 +1,47 @@
+# nicomachus-sum-of-cubes-oq-03
+
+**Problem:** Prove the odd-cube analogue of Nicomachus's theorem,
+∑_{k=1}^n (2k−1)³ = n²(2n²−1) — the sum of the first n odd cubes.
+
+**Status:** COMPLETED (verified, 0 sorries, 0 axioms).
+
+## Summary
+
+Indexing the n odd numbers as `2k+1` for `k ∈ range n` (giving 1, 3, …, 2n−1),
+the identity is `∑_{k<n} (2k+1)³ = n²(2n²−1)`. Proved fully in Lean 4 + Mathlib.
+
+## Session 2026-06-25 (Session 1) — FRESH
+
+**Mode:** FRESH
+**Outcome:** completed
+
+### What I Did
+- Recognized the closed form n²(2n²−1) = 2n⁴ − n² carries a subtraction hostile to
+  `ring` over ℕ.
+- Proved the subtraction-free equivalent `∑(2k+1)³ + n² = 2n⁴` by induction
+  (`sum_odd_cubes_add`). The inductive step is the single polynomial identity
+  `2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m²` (closed by `ring`), spliced into the
+  hypothesis by `omega` (which atomizes the nonlinear power terms).
+- Recovered the headline `∑(2k+1)³ = n²(2n²−1)` over ℤ via `push_cast` + `linarith`
+  + `ring` (`sum_odd_cubes`).
+- Added a division-free scaled form `4·∑(2k+1)³ + 4n² = 8n⁴` (`four_mul_sum_odd_cubes`).
+
+### Key Findings
+- The "clear the subtraction by adding a term" technique keeps signed closed-form
+  power sums entirely in ℕ — complements the parent's "case-split over cast" trick.
+- `ring`-then-`omega` is a clean reusable pattern for inductive sum identities whose
+  step is a fixed polynomial identity plus linear hypothesis bookkeeping.
+- Only Mathlib dependency: `Finset.sum_range_succ`.
+
+### Files Modified
+- `proofs/Proofs/NicomachusOddCubes.lean` (new, 93 lines, 3 theorems, 0 def)
+- `src/data/proofs/nicomachus-sum-of-cubes-oq-03/{meta.json,annotations.json}` (new)
+
+### Verification
+- `lake env lean Proofs/NicomachusOddCubes.lean` → exit 0, no errors.
+- `#print axioms` on all three theorems → only propext, Classical.choice, Quot.sound
+  (no sorryAx, no Lean.ofReduceBool). 0 axioms, 0 sorries.
+
+### Next Steps
+- Follow-up OQs (see meta.json openQuestions): general odd-power sums ∑(2k−1)^p;
+  bijective/geometric proof.

--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-03/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-03/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "ann-subtraction-free",
+    "proofId": "nicomachus-sum-of-cubes-oq-03",
+    "range": { "startLine": 56, "endLine": 67 },
+    "type": "theorem",
+    "title": "Subtraction-free core: ∑(2k+1)³ + n² = 2n⁴",
+    "content": "The whole development is built on this lemma. The target closed form $n^2(2n^2-1)$ equals $2n^4 - n^2$, and that $-n^2$ is truncated subtraction in $\\mathbb{N}$ — invisible to `ring`. Adding $n^2$ to both sides moves it to $\\sum_{k<n}(2k+1)^3 + n^2 = 2n^4$, where every term is a genuine natural number. The induction's base case is `rfl`; the step uses `sum_range_succ` to expose the top odd cube $(2m+1)^3$, then leans on the standalone polynomial identity proved on the next line.",
+    "mathContext": "$\\sum_{k<n}(2k+1)^3 + n^2 = 2n^4$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
+    "relatedConcepts": ["Truncated natural subtraction", "Power sums", "Faulhaber identities"]
+  },
+  {
+    "id": "ann-ring-omega-step",
+    "proofId": "nicomachus-sum-of-cubes-oq-03",
+    "range": { "startLine": 63, "endLine": 67 },
+    "type": "insight",
+    "title": "ring for the algebra, omega for the splice",
+    "content": "The inductive step is closed by a clean division of labor. The `key` hypothesis $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$ is a fixed, subtraction-free polynomial identity that `ring` verifies outright. Then `omega` finishes: it treats the nonlinear terms $m^4$, $(2m+1)^3$, $(m+1)^2$, $(m+1)^4$ and the sum as opaque atoms and does the purely *linear* algebra needed to combine `key` with the inductive hypothesis $\\sum_{k<m}(2k+1)^3 + m^2 = 2m^4$. Neither tactic does the other's job — `ring` cannot use the hypothesis, `omega` cannot expand the polynomials.",
+    "mathContext": "$2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$.",
+    "significance": "key",
+    "relatedConcepts": ["ring tactic", "omega tactic", "Atomization of nonlinear terms"]
+  },
+  {
+    "id": "ann-headline-cast",
+    "proofId": "nicomachus-sum-of-cubes-oq-03",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "theorem",
+    "title": "Headline form over ℤ: ∑(2k+1)³ = n²(2n²−1)",
+    "content": "The closed form is stated over $\\mathbb{Z}$ so the subtraction in $2n^2-1$ is honest. `congrArg Nat.cast` lifts the ℕ identity, `push_cast` distributes the cast through the sum and powers, and `linarith` isolates $\\sum_{k<n}(2k+1)^3 = 2n^4 - n^2$. A final `ring` recognizes that $n^2(2n^2-1) = 2n^4 - n^2$, closing the goal. The integers are used only to *state* the result — all the inductive work happened in $\\mathbb{N}$.",
+    "mathContext": "$\\sum_{k<n}(2k+1)^3 = n^2(2n^2-1)$ over $\\mathbb{Z}$.",
+    "significance": "critical",
+    "prerequisites": ["Integer casts (push_cast)"],
+    "relatedConcepts": ["Nat.cast", "push_cast", "Closed-form power sums"]
+  },
+  {
+    "id": "ann-scaled-form",
+    "proofId": "nicomachus-sum-of-cubes-oq-03",
+    "range": { "startLine": 88, "endLine": 91 },
+    "type": "theorem",
+    "title": "Scaled multiplicative form: 4·∑(2k+1)³ + 4n² = 8n⁴",
+    "content": "A division-free, ℕ-native packaging of the same content, scaled by 4 and derived in a single `omega` step from the core lemma. Useful for downstream callers that prefer to avoid casting to $\\mathbb{Z}$ entirely; the factor of 4 keeps everything multiplicative and subtraction-free.",
+    "mathContext": "$4\\sum_{k<n}(2k+1)^3 + 4n^2 = 8n^4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Natural-number division avoidance", "Closed-form power sums"]
+  }
+]

--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-03/meta.json
@@ -1,0 +1,95 @@
+{
+  "id": "nicomachus-sum-of-cubes-oq-03",
+  "title": "Sum of the First n Odd Cubes: ∑ (2k−1)³ = n²(2n²−1)",
+  "slug": "nicomachus-sum-of-cubes-oq-03",
+  "description": "A fully machine-checked, self-contained proof of the odd-cube analogue of Nicomachus's theorem: the sum of the first n odd cubes equals n²(2n²−1), i.e. ∑_{k<n} (2k+1)³ = n²(2n²−1). The closed form carries a subtraction (2n²−1), which is hostile to `ring` over ℕ, so the engine of the proof is the subtraction-free repackaging ∑(2k+1)³ + n² = 2n⁴, proved by induction with a single polynomial `ring` identity spliced into the hypothesis by `omega`. The headline n²(2n²−1) form is then recovered over ℤ via push_cast. Mathlib has neither identity.",
+  "meta": {
+    "author": "Classical (odd-cube companion to Nicomachus, c. 100 AD); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Squared_triangular_number",
+    "date": "c. 100",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "sum-of-cubes",
+      "power-sums",
+      "odd-numbers",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NicomachusOddCubes.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. The engine of the inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The odd-cube identity ∑_{k<n} (2k+1)³ = n²(2n²−1) — the sum of the first n odd cubes 1³ + 3³ + ⋯ + (2n−1)³ — machine-checked with 0 axioms and 0 sorries (Mathlib has neither this nor its parent sum-of-cubes identity)",
+      "The subtraction-free repackaging ∑_{k<n} (2k+1)³ + n² = 2n⁴: by moving the −n² of the closed form to the left, every term becomes a genuine natural number, so the whole induction lives in ℕ with no truncated subtraction and no integer casts in the core lemma",
+      "The 'ring-then-omega' inductive step: the algebraic content is a single subtraction-free polynomial identity 2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m² (closed by `ring`), which `omega` then combines linearly with the inductive hypothesis treating the power terms as opaque atoms",
+      "The scaled multiplicative form 4·∑(2k+1)³ + 4n² = 8n⁴, recording the result division-free for downstream reuse"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 93,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no sorryAx, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "subtraction-free",
+      "title": "Subtraction-free odd-cube identity",
+      "startLine": 56,
+      "endLine": 67,
+      "summary": "The core lemma ∑_{k<n} (2k+1)³ + n² = 2n⁴, proved by induction. The base case is `rfl`. The step peels the top odd cube with sum_range_succ, then a single subtraction-free `ring` identity 2m⁴ + (2m+1)³ + (m+1)² = 2(m+1)⁴ + m² is combined with the inductive hypothesis by `omega` (which atomizes the power terms). No truncated ℕ subtraction ever appears."
+    },
+    {
+      "id": "headline",
+      "title": "Headline form over ℤ",
+      "startLine": 73,
+      "endLine": 82,
+      "summary": "∑_{k<n} (2k+1)³ = n²(2n²−1). Casting the ℕ identity to ℤ with push_cast lets the closed form use honest subtraction; `linarith` isolates the sum as 2n⁴ − n² and a final `ring` recognizes n²(2n²−1) = 2n⁴ − n²."
+    },
+    {
+      "id": "scaled-form",
+      "title": "Scaled multiplicative form",
+      "startLine": 88,
+      "endLine": 91,
+      "summary": "4·∑(2k+1)³ + 4n² = 8n⁴, the subtraction-free core scaled by 4, derived in one `omega` step from the core lemma for callers who want a division-free product form."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Odd cubes and the squared triangular number**\n\nNicomachus of Gerasa (c. 100 AD) observed that the sum of the *first n cubes* is the square of the $n$-th triangular number: $1^3 + 2^3 + \\cdots + n^3 = (1 + 2 + \\cdots + n)^2$. A natural companion restricts the sum to the **odd** cubes. Where the full sum telescopes to a perfect square, the odd-cube sum has its own crisp closed form,\n$$1^3 + 3^3 + 5^3 + \\cdots + (2n-1)^3 = n^2(2n^2 - 1),$$\na Faulhaber-type identity that Mathlib does not currently provide. This entry supplies it, as a follow-up to the parent Nicomachus formalization.",
+    "problemStatement": "**Sum of the first n odd cubes**\n\nIndexing the $n$ odd numbers as $2k+1$ for $k = 0, \\ldots, n-1$ (so `range n` enumerates $1, 3, \\ldots, 2n-1$), prove that for every natural number $n$,\n$$\\sum_{k<n} (2k+1)^3 = n^2(2n^2 - 1).$$\nThe goal is a fully machine-checked proof with no axioms and no sorries.",
+    "proofStrategy": "**Clear the subtraction, then induct**\n\nThe closed form $n^2(2n^2-1) = 2n^4 - n^2$ carries a subtraction, and over $\\mathbb{N}$ truncated subtraction is not a ring operation, so `ring` cannot touch it. The fix is to add $n^2$ to both sides, giving the **subtraction-free** identity\n$$\\sum_{k<n} (2k+1)^3 + n^2 = 2n^4,$$\nin which every term is an honest natural number. This is proved by induction: `sum_range_succ` peels off the top odd cube $(2m+1)^3$, and the inductive step is the single polynomial identity $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$ — proved by `ring` — which `omega` then splices together with the inductive hypothesis (treating $m^4$, $(2m+1)^3$, etc. as opaque atoms). The headline $n^2(2n^2-1)$ form is recovered at the end by casting to $\\mathbb{Z}$ (`push_cast`), where the subtraction is honest.",
+    "keyInsights": [
+      "**Move the subtraction out of ℕ.** The only obstacle to a `ring`-driven induction is the $-1$ in $2n^2-1$. Adding $n^2$ to both sides turns $2n^4 - n^2$ into $2n^4$ and the entire core proof lives in $\\mathbb{N}$ with no casts.",
+      "**ring for algebra, omega for bookkeeping.** The genuinely algebraic content of the step is one subtraction-free polynomial identity; `omega` does only the linear splicing with the hypothesis, atomizing the nonlinear power terms. Neither tactic does the other's job.",
+      "**Cast only at the end.** $\\mathbb{Z}$ is needed solely to *state* the headline $n^2(2n^2-1)$ honestly; a single `push_cast` plus `ring` transports the ℕ result there, so the heavy lifting never leaves $\\mathbb{N}$.",
+      "**A clean Faulhaber sibling.** Unlike $\\sum k^p$ for even $p$, the odd-cube sum factors over the integers as $n^2(2n^2-1)$, giving a short closed form with no rational coefficients."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range`",
+      "Truncated natural-number subtraction"
+    ]
+  },
+  "conclusion": {
+    "summary": "The odd-cube identity $\\sum_{k<n} (2k+1)^3 = n^2(2n^2-1)$ is established by a short induction. The closed form's subtraction is dissolved by proving the equivalent subtraction-free statement $\\sum (2k+1)^3 + n^2 = 2n^4$ in $\\mathbb{N}$; the inductive step is one `ring` identity combined with the hypothesis by `omega`, and the headline form is recovered over $\\mathbb{Z}$ with `push_cast`. The proof depends on a single Mathlib lemma (`sum_range_succ`). 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the odd-cube power-sum identity ∑(2k+1)³ = n²(2n²−1), absent from Mathlib's BigOperators library, in a form directly reusable by other gallery proofs.",
+      "Demonstrates the 'add a term to clear the subtraction' technique for keeping signed closed-form power sums inside ℕ, complementing the parent Nicomachus's case-split technique.",
+      "The 'ring-then-omega' split is a reusable pattern for inductive sum identities whose step is a fixed polynomial identity plus linear hypothesis bookkeeping."
+    ],
+    "openQuestions": [
+      "Does the same 'clear the subtraction, then ring-and-omega' recipe extend to the general odd-power sums ∑(2k−1)^p, or does the closed form stop factoring as cleanly as n²(2n²−1) for higher p?",
+      "Can the odd-cube identity be given a bijective/geometric proof in Lean matching the visual nested-square dissection, rather than the inductive one?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Formalizes the **odd-cube analogue of Nicomachus's theorem** (follow-up open question `nicomachus-sum-of-cubes-oq-03`):

$$\sum_{k=1}^{n} (2k-1)^3 = n^2(2n^2-1)$$

i.e. the sum of the first $n$ odd cubes $1^3 + 3^3 + \cdots + (2n-1)^3$. Indexed in Lean as $\sum_{k<n}(2k+1)^3$.

Checks: $n{=}1 \to 1{=}1\cdot1$, $n{=}2 \to 28{=}4\cdot7$, $n{=}3 \to 153{=}9\cdot17$.

## Proof technique

The closed form $n^2(2n^2-1) = 2n^4 - n^2$ carries a subtraction, which `ring` cannot handle over $\mathbb{N}$ (truncated subtraction is not a ring op). The fix:

1. **Clear the subtraction.** Add $n^2$ to both sides → the subtraction-free identity $\sum(2k+1)^3 + n^2 = 2n^4$, every term a genuine natural number (`sum_odd_cubes_add`).
2. **ring-then-omega step.** The inductive step is one fixed polynomial identity $2m^4 + (2m+1)^3 + (m+1)^2 = 2(m+1)^4 + m^2$ (closed by `ring`), which `omega` splices into the hypothesis, atomizing the power terms.
3. **Recover the headline over $\mathbb{Z}$.** `push_cast` + `linarith` + `ring` transport the ℕ result to the signed closed form (`sum_odd_cubes`).
4. Plus a division-free scaled form $4\sum(2k+1)^3 + 4n^2 = 8n^4$ (`four_mul_sum_odd_cubes`).

Only Mathlib dependency: `Finset.sum_range_succ`.

## Verification

- `lake env lean Proofs/NicomachusOddCubes.lean` → exit 0, no errors, **0 sorries**.
- `#print axioms` on all 3 theorems → only `propext`, `Classical.choice`, `Quot.sound` (foundational, non-counting). No `sorryAx`, no `Lean.ofReduceBool`. **0 axioms.**

## Files

- `proofs/Proofs/NicomachusOddCubes.lean` (93 lines, 3 theorems)
- `src/data/proofs/nicomachus-sum-of-cubes-oq-03/{meta.json,annotations.json}`
- `research/problems/nicomachus-sum-of-cubes-oq-03/knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)