### PR TITLE
research(stars-and-bars-weak-compositions-oq-02): bounded-parts refinement via inclusion–exclusion

### DIFF
--- a/proofs/Proofs/StarsAndBarsWeakCompositionsOQ02.lean
+++ b/proofs/Proofs/StarsAndBarsWeakCompositionsOQ02.lean
@@ -1,0 +1,208 @@
+import Mathlib.Data.Sym.Card
+import Mathlib.Combinatorics.Enumerative.InclusionExclusion
+import Mathlib.Tactic
+import Proofs.StarsAndBarsWeakCompositions
+
+/-
+# Bounded-Parts Refinement of Weak Compositions via Inclusion–Exclusion
+
+## What This Proves
+
+A *weak composition* of `n` into `k` parts is a function `f : Fin k → ℕ` with
+`∑ i, f i = n` (parts may be zero). The parent entry
+(`StarsAndBarsWeakCompositions.lean`) counts **all** of them: there are
+`C(n + k − 1, n)` weak compositions (stars and bars).
+
+This entry **refines** that count by imposing an upper bound `b` on every part.
+Counting weak compositions of `n` into `k` parts with each part `≤ b` is the
+classical *bounded composition* problem, and the answer is the inclusion–exclusion
+alternating sum
+
+  `#{f : Fin k → ℕ | ∑ f = n, ∀ i, f i ≤ b}`
+      `= ∑_{j=0}^{k} (−1)^j · C(k, j) · C(n − (b+1)·j + k − 1, k − 1)`,
+
+where the binomial `C(n − (b+1)·j + k − 1, k − 1)` is interpreted as `0` when
+`(b+1)·j > n` (there is no room left after forcing `j` parts to overflow).
+
+## The argument
+
+For an index set `t ⊆ Fin k`, let `A t` be the set of weak compositions whose part
+is `≥ b+1` at every index in `t` (the "overflow at `t`" event). Subtracting `b+1`
+from each over-budget part is a bijection
+
+  `A t  ≃  {weak compositions of n − (b+1)·|t| into k parts}`,
+
+valid exactly when `(b+1)·|t| ≤ n` (otherwise `A t` is empty). Hence
+`#(A t) = C(n − (b+1)|t| + k − 1, k − 1)` (or `0`). Mathlib's
+`Finset.inclusion_exclusion_card_inf_compl` turns the count of compositions
+avoiding *all* overflow events — i.e. with every part `≤ b` — into the alternating
+sum over `t`; since `#(A t)` depends only on `|t|`, regrouping by `|t| = j`
+introduces the `C(k, j)` factor and yields the closed form.
+
+## What Mathlib has — and what this adds
+
+Mathlib has the inclusion–exclusion principle
+(`Finset.inclusion_exclusion_card_inf_compl`) and the unrestricted stars-and-bars
+count (via `Sym.card_sym_eq_choose`, packaged for tuples by the parent), but **not**
+the bounded-parts refinement. The new content is the shift bijection `shiftEquiv`
+(the heart of the proof) and the resulting count `card_boundedComposition`.
+
+**Sorry count**: 0. **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+open Finset
+
+namespace StarsAndBarsBounded
+
+variable {k n b : ℕ}
+
+/-- Weak compositions of `n` into `k` parts: functions `Fin k → ℕ` summing to `n`. -/
+abbrev WC (k n : ℕ) : Type := {f : Fin k → ℕ // ∑ i, f i = n}
+
+/-! ## The shift bijection
+
+Forcing the parts indexed by `t` to be `≥ b+1` and then subtracting `b+1` from each
+is a bijection onto the weak compositions of `n − (b+1)·|t|`. -/
+
+/-- The shift amount at index `i` for the overflow set `t`: `b+1` on `t`, `0` off it. -/
+private def shift (b : ℕ) (t : Finset (Fin k)) (i : Fin k) : ℕ :=
+  if i ∈ t then b + 1 else 0
+
+private theorem sum_shift (b : ℕ) (t : Finset (Fin k)) :
+    ∑ i, shift b t i = (b + 1) * t.card := by
+  unfold shift
+  rw [Finset.sum_ite_mem, Finset.univ_inter, Finset.sum_const, mul_comm, smul_eq_mul]
+
+/-- **The shift bijection.**  When `(b+1)·|t| ≤ n`, subtracting `b+1` from every part
+indexed by `t` is a bijection from the weak compositions of `n` with all `t`-parts
+`≥ b+1` onto the weak compositions of `n − (b+1)·|t|`. -/
+def shiftEquiv (b : ℕ) (t : Finset (Fin k)) (n : ℕ) (hle : (b + 1) * t.card ≤ n) :
+    {f : WC k n // ∀ i ∈ t, b + 1 ≤ f.val i} ≃ WC k (n - (b + 1) * t.card) where
+  toFun f := ⟨fun i => f.val.val i - shift b t i, by
+    have hpt : ∀ i, shift b t i ≤ f.val.val i := by
+      intro i; unfold shift; split
+      · exact f.2 i ‹_›
+      · exact Nat.zero_le _
+    show ∑ i, (f.val.val i - shift b t i) = n - (b + 1) * t.card
+    rw [Finset.sum_tsub_distrib univ (fun i _ => hpt i), f.val.2, sum_shift]⟩
+  invFun g := ⟨⟨fun i => g.val i + shift b t i, by
+    rw [Finset.sum_add_distrib, g.2, sum_shift, Nat.sub_add_cancel hle]⟩, by
+    intro i hi
+    show b + 1 ≤ g.val i + shift b t i
+    simp only [shift, if_pos hi]; exact Nat.le_add_left _ _⟩
+  left_inv f := by
+    apply Subtype.ext; apply Subtype.ext; funext i
+    have hpt : shift b t i ≤ f.val.val i := by
+      unfold shift; split
+      · exact f.2 i ‹_›
+      · exact Nat.zero_le _
+    exact Nat.sub_add_cancel hpt
+  right_inv g := by
+    apply Subtype.ext; funext i
+    show g.val i + shift b t i - shift b t i = g.val i
+    exact Nat.add_sub_cancel _ _
+
+/-! ## The overflow events and their cardinalities -/
+
+variable (k n b)
+
+/-- The overflow event for index `i`: weak compositions of `n` whose `i`-th part is
+`≥ b+1`. -/
+private def overflow (i : Fin k) : Finset (WC k n) :=
+  univ.filter (fun f => b + 1 ≤ f.val i)
+
+variable {k n b}
+
+private theorem mem_inf_overflow (t : Finset (Fin k)) (f : WC k n) :
+    f ∈ t.inf (overflow k n b) ↔ ∀ i ∈ t, b + 1 ≤ f.val i := by
+  rw [← Finset.singleton_subset_iff, ← Finset.le_iff_subset, Finset.le_inf_iff]
+  refine forall₂_congr fun i _ => ?_
+  rw [Finset.le_iff_subset, Finset.singleton_subset_iff, overflow, Finset.mem_filter]
+  simp
+
+/-- The cardinality of the `t`-overflow event: the stars-and-bars count
+`C(m + k − 1, m)` with `m = n − (b+1)|t|` when `(b+1)|t| ≤ n`, else `0`. -/
+private theorem card_inf_overflow (t : Finset (Fin k)) :
+    (t.inf (overflow k n b)).card
+      = if (b + 1) * t.card ≤ n then
+          (n - (b + 1) * t.card + k - 1).choose (n - (b + 1) * t.card) else 0 := by
+  split_ifs with hle
+  · -- bijection to WC k (n - (b+1)|t|), then parent stars-and-bars count
+    have hset : t.inf (overflow k n b)
+        = univ.filter (fun f : WC k n => ∀ i ∈ t, b + 1 ≤ f.val i) := by
+      ext f; rw [mem_inf_overflow]; simp [Finset.mem_filter]
+    have hcard : (t.inf (overflow k n b)).card
+        = Fintype.card {f : WC k n // ∀ i ∈ t, b + 1 ≤ f.val i} := by
+      rw [hset]; exact (Fintype.card_subtype _).symm
+    rw [hcard, Fintype.card_congr (shiftEquiv b t n hle)]
+    exact StarsAndBars.card_weakComposition k (n - (b + 1) * t.card)
+  · -- the event is empty: forcing |t| parts ≥ b+1 needs (b+1)|t| ≤ n
+    rw [Finset.card_eq_zero, Finset.eq_empty_iff_forall_notMem]
+    intro f hf
+    rw [mem_inf_overflow] at hf
+    apply hle
+    calc (b + 1) * t.card = ∑ i ∈ t, (b + 1) := by rw [Finset.sum_const, smul_eq_mul, mul_comm]
+      _ ≤ ∑ i ∈ t, f.val i := Finset.sum_le_sum (fun i hi => hf i hi)
+      _ ≤ ∑ i, f.val i := Finset.sum_le_sum_of_subset (Finset.subset_univ _)
+      _ = n := f.2
+
+/-! ## The bounded count via inclusion–exclusion -/
+
+private theorem mem_inf_compl_overflow (f : WC k n) :
+    f ∈ (univ : Finset (Fin k)).inf (fun i => (overflow k n b i)ᶜ) ↔ ∀ i, f.val i ≤ b := by
+  rw [← Finset.singleton_subset_iff, ← Finset.le_iff_subset, Finset.le_inf_iff]
+  simp only [Finset.mem_univ, forall_true_left, Finset.le_iff_subset, Finset.singleton_subset_iff,
+    Finset.mem_compl, overflow, Finset.mem_filter, true_and, not_le, Nat.lt_succ_iff]
+
+/-- The bounded weak compositions form a finite type (a subtype of the finite type of
+weak compositions of `n`). -/
+instance instFintypeBounded (k n b : ℕ) :
+    Fintype {f : Fin k → ℕ // (∑ i, f i = n) ∧ ∀ i, f i ≤ b} :=
+  Fintype.ofEquiv {x : WC k n // ∀ i, x.val i ≤ b}
+    (Equiv.subtypeSubtypeEquivSubtypeInter
+      (fun f : Fin k → ℕ => ∑ i, f i = n) (fun f => ∀ i, f i ≤ b))
+
+/-- **Bounded weak compositions, inclusion–exclusion form.**  The number of weak
+compositions of `n` into `k` parts with every part `≤ b` is the alternating sum over
+index subsets `t ⊆ Fin k` of the overflow counts `C(n − (b+1)|t| + k − 1, n − (b+1)|t|)`
+(read as `0` when `(b+1)|t| > n`). -/
+theorem card_boundedComposition_powerset (k n b : ℕ) :
+    (Fintype.card {f : Fin k → ℕ // (∑ i, f i = n) ∧ ∀ i, f i ≤ b} : ℤ)
+      = ∑ t ∈ (univ : Finset (Fin k)).powerset, (-1 : ℤ) ^ t.card *
+          (if (b + 1) * t.card ≤ n then
+            ((n - (b + 1) * t.card + k - 1).choose (n - (b + 1) * t.card) : ℤ) else 0) := by
+  have hbridge : Fintype.card {f : Fin k → ℕ // (∑ i, f i = n) ∧ ∀ i, f i ≤ b}
+      = ((univ : Finset (Fin k)).inf (fun i => (overflow k n b i)ᶜ)).card := by
+    rw [← Fintype.card_congr (Equiv.subtypeSubtypeEquivSubtypeInter
+          (fun f : Fin k → ℕ => ∑ i, f i = n) (fun f => ∀ i, f i ≤ b)),
+        Fintype.card_subtype]
+    congr 1
+    ext f
+    rw [Finset.mem_filter, mem_inf_compl_overflow]
+    simp
+  rw [hbridge, Finset.inclusion_exclusion_card_inf_compl univ (overflow k n b)]
+  refine Finset.sum_congr rfl fun t _ => ?_
+  rw [card_inf_overflow]
+  by_cases h : (b + 1) * t.card ≤ n <;> simp [h]
+
+/-- **Bounded weak compositions, closed form.**  Grouping the inclusion–exclusion sum by
+the size `j = |t|` of the overflow set introduces the `C(k, j)` factor, giving the
+classical bounded-composition count
+
+  `#{f : Fin k → ℕ | ∑ f = n, ∀ i, f i ≤ b}`
+      `= ∑_{j=0}^{k} (−1)^j · C(k, j) · C(n − (b+1)·j + k − 1, n − (b+1)·j)`,
+
+where the binomial is read as `0` when `(b+1)·j > n`. -/
+theorem card_boundedComposition (k n b : ℕ) :
+    (Fintype.card {f : Fin k → ℕ // (∑ i, f i = n) ∧ ∀ i, f i ≤ b} : ℤ)
+      = ∑ j ∈ Finset.range (k + 1), (k.choose j : ℤ) * ((-1 : ℤ) ^ j *
+          (if (b + 1) * j ≤ n then
+            ((n - (b + 1) * j + k - 1).choose (n - (b + 1) * j) : ℤ) else 0)) := by
+  rw [card_boundedComposition_powerset, Finset.sum_powerset]
+  simp only [Finset.card_univ, Fintype.card_fin]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  rw [Finset.sum_powersetCard j univ (fun m => (-1 : ℤ) ^ m *
+        (if (b + 1) * m ≤ n then ((n - (b + 1) * m + k - 1).choose (n - (b + 1) * m) : ℤ) else 0)),
+      Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+
+end StarsAndBarsBounded

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02/annotations.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "stars-and-bars-weak-compositions-oq-02",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "Bounded compositions and the inclusion–exclusion plan",
+    "content": "The header refines the parent's count by capping every part at b. The number of weak compositions of n into k parts with each part ≤ b is the alternating sum ∑_{j=0}^{k} (−1)ʲ C(k, j) C(n − (b+1)j + k − 1, n − (b+1)j), the binomial read as 0 once (b+1)j > n. The plan: 'every part ≤ b' is 'in no overflow event' {f i ≥ b+1}, which is membership in the intersection of the complements — exactly the shape of Mathlib's Finset.inclusion_exclusion_card_inf_compl. Each overflow event is evaluated by the shift bijection (subtract b+1 from the over-budget parts), reducing it to the parent's unrestricted stars-and-bars count. Mathlib has both inclusion–exclusion and the unbounded count, but not this bounded refinement.",
+    "mathContext": "$\\#\\{f \\mid \\sum_i f(i)=n,\\ \\forall i\\,f(i)\\le b\\} = \\sum_{j=0}^{k}(-1)^j\\binom{k}{j}\\binom{n-(b+1)j+k-1}{\\,n-(b+1)j\\,}$.",
+    "significance": "context",
+    "relatedConcepts": ["bounded composition", "inclusion–exclusion", "stars and bars", "generating function (1+x+…+xᵇ)ᵏ"],
+    "prerequisites": ["binomial coefficients", "weak compositions (parent entry)"]
+  },
+  {
+    "id": "ann-shift-bijection",
+    "proofId": "stars-and-bars-weak-compositions-oq-02",
+    "range": { "startLine": 60, "endLine": 99 },
+    "type": "technique",
+    "title": "The shift bijection (shift, sum_shift, shiftEquiv)",
+    "content": "shift b t i = (if i ∈ t then b+1 else 0) is the per-index decrement, and sum_shift evaluates its total to (b+1)·|t| (Finset.sum_ite_mem + sum_const). shiftEquiv is the heart of the proof: when (b+1)|t| ≤ n it is the explicit equivalence {f ∈ WC k n // ∀ i ∈ t, f i ≥ b+1} ≃ WC k (n − (b+1)|t|). The forward map subtracts the shift from each part; it is well-defined because the shift is pointwise ≤ the part (on t the part exceeds b by hypothesis, off t the shift is 0), so Finset.sum_tsub_distrib gives ∑(f i − shift i) = ∑ f i − ∑ shift i = n − (b+1)|t|. The inverse adds the shift back, with Nat.sub_add_cancel restoring the sum to n using (b+1)|t| ≤ n, and the over-budget condition holds since adding b+1 on t makes each t-part ≥ b+1. The round-trips are the pointwise cancellations Nat.sub_add_cancel and Nat.add_sub_cancel. This single Equiv is what reduces every inclusion–exclusion term to the parent's count and is the genuine content absent from Mathlib.",
+    "mathContext": "$\\{f \\in WC\\,k\\,n \\mid \\forall i \\in t,\\ f(i) \\ge b+1\\} \\simeq WC\\,k\\,(n-(b+1)|t|)$ when $(b+1)|t| \\le n$.",
+    "significance": "key",
+    "relatedConcepts": ["explicit equivalence", "truncated subtraction", "Finset.sum_tsub_distrib", "Nat.sub_add_cancel"],
+    "prerequisites": ["Equiv construction (toFun/invFun/left_inv/right_inv)", "Finset sums with ℕ subtraction"]
+  },
+  {
+    "id": "ann-overflow-counts",
+    "proofId": "stars-and-bars-weak-compositions-oq-02",
+    "range": { "startLine": 101, "endLine": 149 },
+    "type": "technique",
+    "title": "Overflow events and their cardinalities (overflow, mem_inf_overflow, card_inf_overflow)",
+    "content": "overflow i is the finset of weak compositions with f(i) ≥ b+1. mem_inf_overflow characterizes membership in the finset-lattice inf t.inf overflow as 'overflow at every index of t', proved via Finset.le_inf_iff after recasting f ∈ X as {f} ⊆ X (Finset.singleton_subset_iff / le_iff_subset). card_inf_overflow evaluates the t-overflow count. When (b+1)|t| ≤ n it rewrites the inf as a subtype, transports shiftEquiv through Fintype.card_congr, and reads off the parent's card_weakComposition, giving C(n−(b+1)|t|+k−1, n−(b+1)|t|). When (b+1)|t| > n the event is empty: any f overflowing on all of t would force ∑_{i∈t}(b+1) = (b+1)|t| ≤ ∑ f = n, a contradiction — so the count is 0, which is why the formula carries the explicit 'if (b+1)|t| ≤ n' guard rather than the bare (truncated) binomial.",
+    "mathContext": "$\\#\\big(\\bigcap_{i \\in t}\\{f \\mid f(i)\\ge b+1\\}\\big) = \\binom{n-(b+1)|t|+k-1}{\\,n-(b+1)|t|\\,}$ if $(b+1)|t|\\le n$, else $0$.",
+    "significance": "key",
+    "relatedConcepts": ["finset lattice inf", "Finset.le_inf_iff", "Fintype.card_congr", "empty event"],
+    "prerequisites": ["shiftEquiv", "parent card_weakComposition"]
+  },
+  {
+    "id": "ann-inclusion-exclusion-form",
+    "proofId": "stars-and-bars-weak-compositions-oq-02",
+    "range": { "startLine": 150, "endLine": 194 },
+    "type": "theorem",
+    "title": "The inclusion–exclusion count (mem_inf_compl_overflow, instFintypeBounded, card_boundedComposition_powerset)",
+    "content": "mem_inf_compl_overflow identifies the intersection of complements univ.inf (fun i => (overflow i)ᶜ) with the bounded compositions {f | ∀ i, f i ≤ b} (¬(b+1 ≤ x) ↔ x ≤ b via Nat.lt_succ_iff). instFintypeBounded gives the Fintype instance on the conjunction subtype {f : Fin k → ℕ // (∑ f = n) ∧ ∀ i, f i ≤ b} through Equiv.subtypeSubtypeEquivSubtypeInter and the parent's instance — necessary because Lean cannot synthesise a Fintype for a subtype of the infinite Fin k → ℕ directly. card_boundedComposition_powerset then applies Mathlib's Finset.inclusion_exclusion_card_inf_compl with the overflow family and rewrites each term by card_inf_overflow, expressing the bounded count as the alternating sum over all index subsets t of the overflow counts.",
+    "mathContext": "$\\#\\{f \\mid \\forall i,\\ f(i) \\le b\\} = \\sum_{t \\subseteq \\mathrm{Fin}\\,k}(-1)^{|t|}\\,\\#(\\text{overflow on }t)$.",
+    "significance": "key",
+    "relatedConcepts": ["inclusion–exclusion principle", "intersection of complements", "Equiv.subtypeSubtypeEquivSubtypeInter"],
+    "prerequisites": ["card_inf_overflow", "Finset.inclusion_exclusion_card_inf_compl"]
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "stars-and-bars-weak-compositions-oq-02",
+    "range": { "startLine": 195, "endLine": 208 },
+    "type": "theorem",
+    "title": "The closed form with C(k, j) (card_boundedComposition)",
+    "content": "card_boundedComposition is the headline closed form ∑_{j=0}^{k} (−1)ʲ C(k, j) C(n−(b+1)j+k−1, n−(b+1)j). Because the t-overflow count depends on t only through |t|, the 2^k-term subset sum from card_boundedComposition_powerset collapses to a k+1-term sum over sizes j: Finset.sum_powerset reorganizes the powerset sum as a double sum over cardinality classes, and Finset.sum_powersetCard evaluates each class — the summand being constant on subsets of fixed size — to (card (Fin k)).choose j times that value, i.e. the binomial C(k, j). The formula was numerically cross-checked: (k,n,b) = (2,3,2) evaluates to 2 (the compositions (1,2),(2,1)) and (3,5,2) to 3 ((1,2,2),(2,1,2),(2,2,1)).",
+    "mathContext": "$\\sum_{j=0}^{k}(-1)^j\\binom{k}{j}\\binom{n-(b+1)j+k-1}{\\,n-(b+1)j\\,}$.",
+    "significance": "key",
+    "relatedConcepts": ["regroup by subset size", "Finset.sum_powersetCard", "binomial closed form"],
+    "prerequisites": ["card_boundedComposition_powerset", "Finset.sum_powerset"]
+  }
+]

--- a/src/data/proofs/stars-and-bars-weak-compositions-oq-02/meta.json
+++ b/src/data/proofs/stars-and-bars-weak-compositions-oq-02/meta.json
@@ -1,0 +1,136 @@
+{
+  "id": "stars-and-bars-weak-compositions-oq-02",
+  "title": "Bounded-Parts Refinement of Weak Compositions via Inclusion–Exclusion",
+  "slug": "stars-and-bars-weak-compositions-oq-02",
+  "description": "A weak composition of n into k parts is a function f : Fin k → ℕ with ∑ᵢ f(i) = n (parts may be zero). The parent entry counts all of them by stars and bars: C(n+k−1, n). This entry refines that count by capping every part at b. The number of weak compositions of n into k parts with each part ≤ b is the inclusion–exclusion alternating sum ∑_{j=0}^{k} (−1)ʲ C(k, j) C(n − (b+1)j + k − 1, n − (b+1)j), where the binomial is read as 0 once (b+1)j > n. The core is an explicit shift bijection shiftEquiv: for an index set t ⊆ Fin k with (b+1)|t| ≤ n, subtracting b+1 from each part indexed by t is a bijection from the weak compositions of n whose t-parts all exceed b onto the weak compositions of n − (b+1)|t|; hence the t-overflow event has cardinality C(n − (b+1)|t| + k − 1, n − (b+1)|t|) (or 0). Mathlib's Finset.inclusion_exclusion_card_inf_compl turns the count of compositions avoiding every overflow event — i.e. with all parts ≤ b — into the alternating sum over t; since the overflow count depends only on |t|, regrouping by |t| = j (Finset.sum_powerset + Finset.sum_powersetCard) introduces the C(k, j) factor and yields the closed form. Mathlib has both the inclusion–exclusion principle and the unrestricted stars-and-bars count, but not this bounded-parts refinement; the new content is the shift bijection and the resulting count.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Sym.Card",
+      "Mathlib.Combinatorics.Enumerative.InclusionExclusion",
+      "Mathlib.Tactic",
+      "Proofs.StarsAndBarsWeakCompositions"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "StarsAndBarsBounded",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "path": "Proofs/StarsAndBarsWeakCompositionsOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Stars_and_bars_(combinatorics)#Theorem_two",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StarsAndBarsWeakCompositionsOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "stars-and-bars",
+      "weak-compositions",
+      "bounded-compositions",
+      "inclusion-exclusion",
+      "bijective-proof",
+      "binomial-coefficients",
+      "counting"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-25",
+    "relatedProblems": [
+      {
+        "id": "stars-and-bars-weak-compositions",
+        "relationship": "Direct parent. That entry counts ALL weak compositions of n into k parts as C(n+k−1, n) via the bijection to size-n multisets; this entry refines that by bounding every part by b. The parent's count is the b → ∞ limit of the formula here (for b ≥ n every part is automatically ≤ b, so only the j = 0 term survives and the sum collapses to C(n+k−1, n)). The proof reuses the parent's card_weakComposition to evaluate each overflow event."
+      },
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Sibling enumerative count in the same family: that entry counts compositions of n into exactly k POSITIVE parts as C(n−1, k−1). The bounded refinement here is the natural 'upper bound' counterpart to the 'lower bound' (≥ 1) constraint in the positive-parts model; both are obtained by shifting parts and counting the slack."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 208,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. Both public theorems (card_boundedComposition_powerset, card_boundedComposition), the bijection shiftEquiv, and the supporting lemmas were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. The result is unconditional for all k, n, b ≥ 0. The new content beyond Mathlib is the shift bijection shiftEquiv and the two count theorems; Mathlib supplies the inclusion–exclusion principle (Finset.inclusion_exclusion_card_inf_compl) and, via the imported parent, the unrestricted stars-and-bars count. A Fintype instance on the bounded-composition subtype is supplied through the parent's Fintype instance (it is not auto-derivable, since the codomain ℕ is infinite). The closed form was cross-checked numerically: for (k,n,b) = (2,3,2) it evaluates to 2 (the compositions (1,2),(2,1)) and for (3,5,2) to 3 ((1,2,2),(2,1,2),(2,2,1)).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Counting the nonnegative integer solutions of x₁ + ⋯ + x_k = n with each xᵢ ≤ b is the bounded version of the stars-and-bars problem. Without the upper bound the answer is the multichoose number C(n+k−1, n); the bound is what makes the problem genuinely combinatorial rather than a single binomial coefficient. The standard tool is inclusion–exclusion: a composition violates the bound at index i if xᵢ ≥ b+1, and subtracting b+1 from an over-budget part trades 'an index in violation' for 'a smaller composition'. Summing over which indices are forced to overflow, with the usual alternating signs, gives ∑ⱼ (−1)ʲ C(k, j) C(n − (b+1)j + k − 1, k − 1). The same formula is the coefficient of xⁿ in the generating function (1 + x + ⋯ + xᵇ)ᵏ = ((1 − x^{b+1})/(1 − x))ᵏ, whose numerator expands by the binomial theorem into the (−1)ʲ C(k,j) x^{(b+1)j} terms and whose denominator contributes the C(·+k−1, k−1) stars-and-bars coefficients.",
+    "problemStatement": "Show that the number of weak compositions of n into k parts with every part at most b — functions f : Fin k → ℕ with ∑ᵢ f(i) = n and f(i) ≤ b for all i — is the inclusion–exclusion sum\n\n$$\\#\\{f : \\mathrm{Fin}\\ k \\to \\mathbb{N} \\mid \\textstyle\\sum_i f(i) = n,\\ \\forall i,\\ f(i) \\le b\\} = \\sum_{j=0}^{k} (-1)^j \\binom{k}{j} \\binom{n - (b+1)j + k - 1}{\\,n - (b+1)j\\,},$$\n\nwhere each binomial is interpreted as 0 when (b+1)j > n.",
+    "text": "The parent entry (stars-and-bars-weak-compositions) counts all weak compositions of n into k parts as C(n+k−1, n) by a bijection to size-n multisets, and supplies the Fintype instance on the summing subtype. This entry imports that result and refines the count by an upper bound b on every part. Mathlib provides the inclusion–exclusion principle Finset.inclusion_exclusion_card_inf_compl for the cardinality of an intersection of complements, which is exactly the count of objects avoiding a family of 'bad' events; here the bad event at index i is 'part i overflows', f(i) ≥ b+1.",
+    "proofStrategy": "Work inside the finite type WC k n = {f : Fin k → ℕ // ∑ i, f i = n} of weak compositions (a Fintype by the parent). For each index i define the overflow event overflow i = {f ∈ WC k n | f i ≥ b+1}. The bounded compositions are precisely the elements lying in the intersection of all complements (overflow i)ᶜ, so mem_inf_compl_overflow identifies univ.inf (fun i => (overflow i)ᶜ) with {f | ∀ i, f i ≤ b}. The heart of the proof is shiftEquiv: when (b+1)|t| ≤ n, the map f ↦ (i ↦ f i − shift(t, i)) — subtracting b+1 from each part indexed by t and leaving the rest — is a bijection from {f ∈ WC k n | ∀ i ∈ t, f i ≥ b+1} onto WC k (n − (b+1)|t|); its inverse adds b+1 back. Forward well-definedness uses Finset.sum_tsub_distrib (the pointwise shift is ≤ the part by hypothesis) and ∑ shift = (b+1)|t| (sum_shift); the inverse uses Nat.sub_add_cancel with (b+1)|t| ≤ n. Consequently card_inf_overflow evaluates the t-overflow count to C(n − (b+1)|t| + k − 1, n − (b+1)|t|) when (b+1)|t| ≤ n (transport the bijection through Fintype.card_congr and read off the parent's card_weakComposition) and to 0 otherwise (forcing |t| parts ≥ b+1 already needs (b+1)|t| ≤ n, else the event is empty). Inclusion–exclusion (Finset.inclusion_exclusion_card_inf_compl univ overflow) then expresses the bounded count as ∑_{t ⊆ Fin k} (−1)^{|t|} · (overflow count) — this is card_boundedComposition_powerset. Finally, since the overflow count depends on t only through |t|, regrouping the powerset sum by cardinality (Finset.sum_powerset followed by Finset.sum_powersetCard, with card (Fin k) = k) collapses each cardinality class to a C(k, j) factor, yielding the closed form card_boundedComposition.",
+    "keyInsights": [
+      "**Bounding parts = avoiding a family of overflow events**: 'every part ≤ b' is exactly 'in no overflow event', i.e. membership in the intersection of the complements of the events {f i ≥ b+1}. This is precisely the shape Mathlib's Finset.inclusion_exclusion_card_inf_compl is built to count, so the bounded problem is an instance of inclusion–exclusion rather than something requiring new combinatorial machinery.",
+      "**The shift bijection is the whole content**: subtracting b+1 from every over-budget part indexed by t bijects 'compositions of n that overflow on t' with 'compositions of n − (b+1)|t|'. This single Equiv (shiftEquiv) reduces every term of the inclusion–exclusion sum to the parent's unrestricted stars-and-bars count, and it is the genuine gap not present in Mathlib.",
+      "**The hypothesis is self-enforcing, but the guard is still needed**: requiring ∀ i ∈ t, f i ≥ b+1 forces (b+1)|t| ≤ ∑ f = n, so the constraint is consistent only below the budget. When (b+1)|t| > n the overflow event is empty (cardinality 0), whereas the naive binomial C(n−(b+1)|t|+k−1, …) with truncated ℕ subtraction would be nonzero — hence the explicit 'if (b+1)j ≤ n' guard in the formula.",
+      "**Depends only on size, so the powerset sum collapses**: the t-overflow count depends on t only through |t|. Finset.sum_powerset + Finset.sum_powersetCard turn the 2^k-term alternating sum over subsets into the k+1-term sum over sizes j, the binomial C(k, j) counting the subsets of each size. This is the standard step that converts a subset-indexed inclusion–exclusion into its familiar binomial closed form.",
+      "**The parent is the b → ∞ degeneration**: for b ≥ n the bound is vacuous, only the j = 0 term survives, and the formula recovers the parent's C(n+k−1, n). The bounded count is thus a strict refinement that contains the unrestricted stars-and-bars count as a limiting case."
+    ],
+    "prerequisites": [
+      "The unrestricted stars-and-bars count C(n+k−1, n) and the Fintype instance on the summing subtype from the parent entry (Proofs/StarsAndBarsWeakCompositions.lean)",
+      "Mathlib's inclusion–exclusion principle for an intersection of complements (Finset.inclusion_exclusion_card_inf_compl), and the lattice inf of finsets with its membership characterization (Finset.le_inf_iff)",
+      "Truncated natural subtraction over Finset sums (Finset.sum_tsub_distrib, Nat.sub_add_cancel, Nat.add_sub_cancel) used to build and invert the shift bijection",
+      "Regrouping a sum over a powerset by subset size: Finset.sum_powerset and Finset.sum_powersetCard, with card (Fin k) = k",
+      "Transporting cardinality along an equivalence (Fintype.card_congr) and the subtype-of-subtype equivalence (Equiv.subtypeSubtypeEquivSubtypeInter) used to build the Fintype instance on the bounded subtype"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement-and-strategy",
+      "title": "Bounded Compositions and the Inclusion–Exclusion Plan",
+      "startLine": 1,
+      "endLine": 47,
+      "mathContext": "$\\#\\{f \\mid \\sum_i f(i) = n,\\ \\forall i\\, f(i) \\le b\\} = \\sum_{j=0}^k (-1)^j \\binom{k}{j} \\binom{n-(b+1)j+k-1}{\\,n-(b+1)j\\,}$.",
+      "summary": "The module docstring fixes the object (weak compositions of n into k parts with every part ≤ b), states the inclusion–exclusion closed form, and lays out the plan: bound the parts by avoiding the overflow events {f i ≥ b+1}, evaluate each event by the shift bijection that subtracts b+1 from the over-budget parts, and feed the counts into Mathlib's inclusion–exclusion principle. It records the precise gap — Mathlib has both inclusion–exclusion and the unrestricted count but not this refinement."
+    },
+    {
+      "id": "shift-bijection",
+      "title": "The Shift Bijection",
+      "startLine": 60,
+      "endLine": 99,
+      "mathContext": "$\\{f \\in WC\\,k\\,n \\mid \\forall i \\in t,\\ f(i) \\ge b+1\\} \\simeq WC\\,k\\,(n - (b+1)|t|)$ when $(b+1)|t| \\le n$.",
+      "summary": "shift packages the per-index decrement (b+1 on t, 0 off it) and sum_shift evaluates its total to (b+1)|t|. shiftEquiv is the explicit equivalence: forward, subtract the shift from each part — well-defined because the shift is pointwise ≤ the part (the t-parts exceed b by hypothesis, off-t parts subtract 0), so Finset.sum_tsub_distrib gives the new sum n − (b+1)|t|; backward, add the shift back, with Nat.sub_add_cancel restoring the sum n using (b+1)|t| ≤ n. The round-trips are Nat.sub_add_cancel and Nat.add_sub_cancel pointwise. This bijection is the engine that reduces each overflow term to the parent's count."
+    },
+    {
+      "id": "overflow-counts",
+      "title": "The Overflow Events and Their Cardinalities",
+      "startLine": 101,
+      "endLine": 149,
+      "mathContext": "$\\#\\big(\\bigcap_{i \\in t}\\{f \\mid f(i) \\ge b+1\\}\\big) = \\binom{n-(b+1)|t|+k-1}{\\,n-(b+1)|t|\\,}$ if $(b+1)|t| \\le n$, else $0$.",
+      "summary": "overflow i is the finset of weak compositions with f(i) ≥ b+1, and mem_inf_overflow characterizes membership in the finset-lattice inf t.inf overflow as 'overflow at every index of t' (via Finset.le_inf_iff). card_inf_overflow then evaluates this intersection: when (b+1)|t| ≤ n it transports shiftEquiv through Fintype.card_congr and reads off the parent's card_weakComposition, giving C(n−(b+1)|t|+k−1, n−(b+1)|t|); otherwise the event is empty, because ∀ i ∈ t, f i ≥ b+1 forces (b+1)|t| ≤ ∑ f = n."
+    },
+    {
+      "id": "inclusion-exclusion-form",
+      "title": "The Inclusion–Exclusion Count",
+      "startLine": 150,
+      "endLine": 194,
+      "mathContext": "$\\#\\{f \\mid \\forall i,\\ f(i) \\le b\\} = \\sum_{t \\subseteq \\mathrm{Fin}\\,k} (-1)^{|t|}\\, \\#(\\text{overflow on } t)$.",
+      "summary": "mem_inf_compl_overflow identifies the intersection of complements univ.inf (fun i => (overflow i)ᶜ) with the bounded compositions {f | ∀ i, f i ≤ b}, and instFintypeBounded supplies the Fintype instance on the conjunction subtype via Equiv.subtypeSubtypeEquivSubtypeInter through the parent's instance. card_boundedComposition_powerset then applies Mathlib's Finset.inclusion_exclusion_card_inf_compl and rewrites each term by card_inf_overflow, giving the alternating sum over all index subsets t of the overflow counts."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Form with C(k, j)",
+      "startLine": 195,
+      "endLine": 208,
+      "mathContext": "$\\sum_{j=0}^{k} (-1)^j \\binom{k}{j} \\binom{n-(b+1)j+k-1}{\\,n-(b+1)j\\,}$.",
+      "summary": "card_boundedComposition is the headline closed form. Because the t-overflow count depends only on |t|, regrouping the powerset sum by subset size with Finset.sum_powerset and Finset.sum_powersetCard collapses each size class to a binomial coefficient C(k, j) = (card (Fin k)).choose j, turning the 2^k-term subset sum into the k+1-term binomial sum. Numerically verified: (k,n,b) = (2,3,2) gives 2 and (3,5,2) gives 3, matching direct enumeration."
+    }
+  ],
+  "conclusion": {
+    "summary": "The bounded-parts refinement of stars and bars — weak compositions of n into k parts with every part ≤ b — is formalized sorry-free and axiom-free, in two equivalent forms: an inclusion–exclusion sum over index subsets (card_boundedComposition_powerset) and the classical binomial closed form ∑ⱼ (−1)ʲ C(k, j) C(n−(b+1)j+k−1, n−(b+1)j) (card_boundedComposition). The mathematical content beyond Mathlib is the explicit shift bijection shiftEquiv, which reduces each overflow event to the parent's unrestricted stars-and-bars count by subtracting b+1 from the over-budget parts. Mathlib supplies the inclusion–exclusion principle and (through the parent) the unrestricted count, but not this refinement.",
+    "implications": "Delivering shiftEquiv as an explicit Equiv (not just a cardinality equation) makes the per-event reduction reusable for any constrained-composition count of the same shape (lower bounds, fixed-part conditions, mixed bounds). The closed form specializes cleanly: b ≥ n recovers the parent's C(n+k−1, n) (only the j = 0 term survives), b = 0 forces the all-zero composition, and b = 1 counts 0/1 compositions, i.e. C(k, n). The development is a candidate for upstreaming a general bounded-stars-and-bars lemma to Mathlib, which currently records only the unbounded multiset form.",
+    "openQuestions": [
+      "Derive the same closed form analytically as the coefficient of xⁿ in (1 + x + ⋯ + xᵇ)ᵏ = ((1 − x^{b+1})/(1 − x))ᵏ, connecting the inclusion–exclusion proof to the generating-function expansion and the binomial theorem applied to the numerator.",
+      "Prove the symmetry n ↦ k·b − n of the bounded count (complementing each part by b sends parts ≤ b summing to n to parts ≤ b summing to kb − n), exhibiting it as an explicit involution and recovering the symmetry of the q-binomial / Gaussian coefficient whose value at q = 1 is this count."
+    ]
+  },
+  "crossReferences": [
+    "stars-and-bars-weak-compositions",
+    "composition-parts-choose-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Refines the parent stars-and-bars count by capping every part at `b`. Proves the number of **weak compositions of `n` into `k` parts with every part `≤ b`** is the inclusion–exclusion closed form

```
#{f : Fin k → ℕ | ∑ f = n, ∀ i, f i ≤ b}
   = ∑_{j=0}^{k} (−1)^j · C(k, j) · C(n − (b+1)j + k − 1, n − (b+1)j)
```

(each binomial read as 0 when `(b+1)j > n`).

## Mathematical content

- **`shiftEquiv`** (the heart): for an index set `t` with `(b+1)|t| ≤ n`, subtracting `b+1` from every part indexed by `t` is an explicit bijection from the weak compositions of `n` overflowing on `t` onto the weak compositions of `n − (b+1)|t|`. This reduces each inclusion–exclusion term to the **parent's** unrestricted count `card_weakComposition`.
- **`card_inf_overflow`**: the `t`-overflow event has cardinality `C(n−(b+1)|t|+k−1, n−(b+1)|t|)` (or 0 when over budget — the event is then empty).
- **`card_boundedComposition_powerset`**: applies Mathlib's `Finset.inclusion_exclusion_card_inf_compl` to express the bounded count as the alternating sum over index subsets.
- **`card_boundedComposition`**: regroups the powerset sum by subset size (`Finset.sum_powerset` + `Finset.sum_powersetCard`) to introduce the `C(k, j)` factor and give the closed form.

## What Mathlib has vs. what this adds

Mathlib has the inclusion–exclusion principle and (via the imported parent) the unrestricted stars-and-bars count, but **not** the bounded-parts refinement. The new content is `shiftEquiv` and the two count theorems.

## Verification

- **0 sorries, 0 axiom declarations.** `#print axioms` on both public theorems and `shiftEquiv` shows dependence only on `propext` / `Classical.choice` / `Quot.sound`. No `native_decide`.
- Closed form cross-checked numerically: `(k,n,b)=(2,3,2) → 2` (compositions (1,2),(2,1)); `(3,5,2) → 3` ((1,2,2),(2,1,2),(2,2,1)).
- This problem is exactly the bounded-parts open question listed in the parent entry's `openQuestions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)