### PR TITLE
research(erdos-230): make file compile + prove Kahane disproof of Erdős–Newman

### DIFF
--- a/proofs/Proofs/Erdos230Problem.lean
+++ b/proofs/Proofs/Erdos230Problem.lean
@@ -30,7 +30,7 @@ Tags: analysis, polynomials, harmonic-analysis, ultraflat
 -/
 
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Complex.Exponential
+import Mathlib.Analysis.Complex.Exponential
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.Normed.Field.Basic
 import Mathlib.Data.Real.Sqrt
@@ -50,7 +50,7 @@ A polynomial P(z) = Σ a_k z^k where all coefficients satisfy |a_k| = 1.
 -/
 structure UnimodularPolynomial (n : ℕ) where
   coeffs : Fin n → ℂ
-  unimodular : ∀ k, Complex.abs (coeffs k) = 1
+  unimodular : ∀ k, ‖coeffs k‖ = 1
 
 /--
 **Evaluate unimodular polynomial:**
@@ -64,7 +64,7 @@ noncomputable def evaluate {n : ℕ} (P : UnimodularPolynomial n) (z : ℂ) : �
 ‖P‖_∞ = max_{|z|=1} |P(z)|
 -/
 noncomputable def supNormOnCircle {n : ℕ} (P : UnimodularPolynomial n) : ℝ :=
-  ⨆ (z : ℂ) (_ : Complex.abs z = 1), Complex.abs (evaluate P z)
+  ⨆ (z : ℂ) (_ : ‖z‖ = 1), ‖evaluate P z‖
 
 /-
 ## Part II: Parseval's Identity
@@ -84,15 +84,24 @@ noncomputable def l2NormOnCircle {n : ℕ} (P : UnimodularPolynomial n) : ℝ :=
 theorem parseval_identity {n : ℕ} (P : UnimodularPolynomial n) :
     (l2NormOnCircle P) ^ 2 = n := by
   unfold l2NormOnCircle
-  simp [Real.sq_sqrt (by linarith : (n : ℝ) ≥ 0)]
+  exact Real.sq_sqrt (by positivity)
+
+/--
+**L∞ ≥ L² inequality** (standard harmonic-analysis fact).
+With respect to the normalized Haar measure on the unit circle the sup norm
+dominates the L² norm.  A fully formal proof needs Lebesgue integration over
+the circle, so we record this comparison as a stated assumption.
+-/
+axiom supNorm_ge_l2norm {n : ℕ} (P : UnimodularPolynomial n) (hn : n ≥ 1) :
+    supNormOnCircle P ≥ Real.sqrt n
 
 /--
 **Trivial lower bound:**
 ‖P‖_∞ ≥ ‖P‖_2 = √n.
 -/
 theorem sup_ge_l2 {n : ℕ} (P : UnimodularPolynomial n) (hn : n ≥ 1) :
-    supNormOnCircle P ≥ Real.sqrt n := by
-  sorry -- From general inequality ‖·‖_∞ ≥ ‖·‖_2 for bounded measures
+    supNormOnCircle P ≥ Real.sqrt n :=
+  supNorm_ge_l2norm P hn
 
 /-
 ## Part III: The Erdős-Newman Conjecture (DISPROVED)
@@ -110,13 +119,11 @@ def ErdosNewmanConjecture : Prop :=
     ∀ n : ℕ, n ≥ 2 → ∀ P : UnimodularPolynomial n,
       supNormOnCircle P ≥ (1 + c) * Real.sqrt n
 
-/--
-**The conjecture is FALSE:**
+/-
+**The conjecture is FALSE.**
+This is proven below as `erdos_newman_false` in Part IV, once Kahane's
+ultraflat-polynomial theorem (`kahane_ultraflat`) has been stated.
 -/
-theorem erdos_newman_false : ¬ErdosNewmanConjecture := by
-  intro ⟨c, hc, hconj⟩
-  -- Kahane's ultraflat polynomials give a contradiction
-  sorry
 
 /-
 ## Part IV: Ultraflat Polynomials (Kahane 1980)
@@ -128,9 +135,9 @@ A unimodular polynomial P such that |P(z)| is nearly constant on |z| = 1.
 Specifically: |P(z)| = (1 + o(1))√n uniformly.
 -/
 def IsUltraflat {n : ℕ} (P : UnimodularPolynomial n) (ε : ℝ) : Prop :=
-  ∀ z : ℂ, Complex.abs z = 1 →
-    Complex.abs (evaluate P z) ≥ (1 - ε) * Real.sqrt n ∧
-    Complex.abs (evaluate P z) ≤ (1 + ε) * Real.sqrt n
+  ∀ z : ℂ, ‖z‖ = 1 →
+    ‖evaluate P z‖ ≥ (1 - ε) * Real.sqrt n ∧
+    ‖evaluate P z‖ ≤ (1 + ε) * Real.sqrt n
 
 /--
 **Kahane's Theorem (1980):**
@@ -147,18 +154,44 @@ Ultraflat polynomials show the sup norm can be arbitrarily close to √n.
 -/
 theorem kahane_disproves : ¬ErdosNewmanConjecture := by
   intro ⟨c, hc, hconj⟩
-  -- Choose ε = c/2, get ultraflat polynomial
-  obtain ⟨N, hN⟩ := kahane_ultraflat (c/2) (by linarith)
-  -- For n ≥ max(N, 2), ultraflat P has ‖P‖_∞ ≤ (1 + c/2)√n
-  -- But conjecture says ‖P‖_∞ ≥ (1 + c)√n
-  -- Contradiction for large n
-  sorry
+  -- Choose ε = c/2 and obtain ultraflat polynomials for all large degrees.
+  obtain ⟨N, hN⟩ := kahane_ultraflat (c / 2) (by linarith)
+  -- Work at degree n = max N 2, which is ≥ 2 and ≥ N.
+  set n : ℕ := max N 2 with hn_def
+  have hn2 : n ≥ 2 := le_max_right _ _
+  have hnN : N ≤ n := le_max_left _ _
+  obtain ⟨P, hP⟩ := hN n hnN
+  -- The upper-bound target is nonnegative.
+  have hsqrt_nonneg : (0 : ℝ) ≤ Real.sqrt n := Real.sqrt_nonneg _
+  have hB : (0 : ℝ) ≤ (1 + c / 2) * Real.sqrt n :=
+    mul_nonneg (by linarith) hsqrt_nonneg
+  -- Pointwise ultraflatness transfers to the sup norm: ‖P‖_∞ ≤ (1 + c/2)√n.
+  have hupp : supNormOnCircle P ≤ (1 + c / 2) * Real.sqrt n := by
+    unfold supNormOnCircle
+    refine Real.iSup_le (fun z => ?_) hB
+    exact Real.iSup_le (fun hz => (hP z hz).2) hB
+  -- The (false) conjecture forces the opposing bound ‖P‖_∞ ≥ (1 + c)√n.
+  have hlow : supNormOnCircle P ≥ (1 + c) * Real.sqrt n := hconj n hn2 P
+  -- √n > 0 since n ≥ 2.
+  have hsqrt_pos : 0 < Real.sqrt n :=
+    Real.sqrt_pos.mpr (by exact_mod_cast (by omega : 0 < n))
+  -- (1 + c)√n ≤ (1 + c/2)√n is impossible for c > 0.
+  have hcombine : (1 + c) * Real.sqrt n ≤ (1 + c / 2) * Real.sqrt n :=
+    le_trans hlow hupp
+  nlinarith [hcombine, mul_pos hc hsqrt_pos]
+
+/--
+**Kahane disproves the Erdős–Newman conjecture (1980).**
+Identical statement to `kahane_disproves`; recorded here under the historical
+name for the false conjecture.
+-/
+theorem erdos_newman_false : ¬ErdosNewmanConjecture := kahane_disproves
 
 /-
 ## Part V: Körner's Construction (1980)
 -/
 
-/--
+/-
 **Körner's polynomials:**
 Körner constructed unimodular polynomials with |P(z)| bounded above and below
 by constant multiples of √n on the unit circle.
@@ -167,7 +200,7 @@ by constant multiples of √n on the unit circle.
 ## Part VI: Bombieri-Bourgain Improvement (2009)
 -/
 
-/--
+/-
 **Bombieri-Bourgain (2009):**
 Improved Kahane's construction to get better error terms:
 |P(z)| = √n + O(n^{7/18} (log n)^{O(1)})
@@ -183,7 +216,7 @@ def bombieriBorgainExponent : ℚ := 7 / 18
 ## Part VII: Random Polynomial Heuristics
 -/
 
-/--
+/-
 **Rudin-Shapiro polynomials:**
 A deterministic family of unimodular polynomials with |P(z)| ≤ 2√n.
 Not ultraflat (lower bound can be small).
@@ -220,7 +253,7 @@ theorem erdos_230_summary :
   · intro n hn P
     exact sup_ge_l2 P hn
 
-/--
+/-
 **Historical note:**
 Erdős and Newman conjectured (1+c)√n in 1957/1961.
 The problem appeared as Problem 4.31 in Halberstam (1974).

--- a/src/data/proofs/erdos-230/annotations.json
+++ b/src/data/proofs/erdos-230/annotations.json
@@ -159,13 +159,13 @@
     "id": "ann-trivial-bound",
     "proofId": "erdos-230",
     "range": {
-      "startLine": 93,
-      "endLine": 95
+      "startLine": 102,
+      "endLine": 104
     },
     "type": "concept",
     "title": "Trivial Lower Bound: sup ≥ √n",
     "content": "The sup norm always exceeds the $L^2$ norm: $\\|P\\|_\\infty \\geq \\sqrt{n}$ for any unimodular polynomial of degree $n \\geq 1$. This is the baseline lower bound that Erdős asked whether one can improve by a multiplicative constant $(1+c)$.",
-    "mathContext": "From the general inequality $\\|f\\|_\\infty \\geq \\|f\\|_2$ (for probability measures on compact spaces), we get $\\sup_{|z|=1} |P(z)| \\geq \\left(\\frac{1}{2\\pi}\\int_0^{2\\pi} |P(e^{i\\theta})|^2 d\\theta\\right)^{1/2} = \\sqrt{n}$. The proof is marked `sorry` as it requires the measure-theoretic inequality.",
+    "mathContext": "From the general inequality $\\|f\\|_\\infty \\geq \\|f\\|_2$ (for probability measures on compact spaces), we get $\\sup_{|z|=1} |P(z)| \\geq \\left(\\frac{1}{2\\pi}\\int_0^{2\\pi} |P(e^{i\\theta})|^2 d\\theta\\right)^{1/2} = \\sqrt{n}$. This measure-theoretic comparison is recorded as the explicit axiom `supNorm_ge_l2norm` (a full Lean proof would require Lebesgue integration over the circle); `sup_ge_l2` is derived from it.",
     "significance": "key",
     "relatedConcepts": [
       "Lp norm comparison",
@@ -181,8 +181,8 @@
     "id": "ann-false-conj",
     "proofId": "erdos-230",
     "range": {
-      "startLine": 108,
-      "endLine": 111
+      "startLine": 117,
+      "endLine": 120
     },
     "type": "definition",
     "title": "The False Erdős-Newman Conjecture",
@@ -204,12 +204,12 @@
     "id": "ann-conj-false",
     "proofId": "erdos-230",
     "range": {
-      "startLine": 116,
-      "endLine": 119
+      "startLine": 155,
+      "endLine": 188
     },
     "type": "concept",
     "title": "Conjecture Is False",
-    "content": "States that the Erdős-Newman conjecture is false ($\\neg \\texttt{ErdosNewmanConjecture}$). The proof sketch extracts a contradiction from Kahane's ultraflat theorem but is currently marked `sorry`.",
+    "content": "States that the Erdős-Newman conjecture is false ($\\neg \\texttt{ErdosNewmanConjecture}$). `kahane_disproves` gives the complete proof — extracting a contradiction from Kahane's ultraflat theorem — and `erdos_newman_false` is the same result under the historical name.",
     "mathContext": "The proof strategy: assume the conjecture holds with constant $c > 0$. Apply Kahane's theorem with $\\varepsilon = c/2$ to get an ultraflat $P$ with $\\|P\\|_\\infty \\leq (1 + c/2)\\sqrt{n} < (1+c)\\sqrt{n}$, contradicting the conjecture.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-230/meta.json
+++ b/src/data/proofs/erdos-230/meta.json
@@ -17,13 +17,13 @@
       "ultraflat"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 230,
     "erdosUrl": "https://erdosproblems.com/230",
     "erdosProblemStatus": "solved",
-    "axiomCount": 1,
-    "lineCount": 230,
-    "assumptions": "1 axiom: kahane_ultraflat. 3 sorries.",
+    "axiomCount": 2,
+    "lineCount": 263,
+    "assumptions": "2 axioms: kahane_ultraflat (Kahane's 1980 existence theorem for ultraflat unimodular polynomials) and supNorm_ge_l2norm (the standard L∞ ≥ L² comparison on the circle, requiring Lebesgue integration to prove). 0 sorries. The disproof of the Erdős–Newman conjecture (erdos_newman_false / kahane_disproves) is fully derived from kahane_ultraflat.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
     "definitionCount": 7,
@@ -146,12 +146,12 @@
       "Finset"
     ],
     "namespace": "Erdos230",
-    "lineCount": 230,
-    "axiomCount": 1,
+    "lineCount": 263,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7,
     "path": "Proofs/Erdos230Problem.lean",
-    "sorries": 3,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos230ProblemAristotle.lean"
     ]
@@ -183,5 +183,5 @@
       "description": "Related Erdős problem sharing themes: analysis, polynomials"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Erdős Problem #230 — Ultraflat Polynomials (SOLVED / disproved by Kahane 1980)

The gallery's `Proofs/Erdos230Problem.lean` **never compiled**: `Complex.abs` was removed in Mathlib v4.26 (the structure field `unimodular : ∀ k, Complex.abs (coeffs k) = 1` failed to elaborate, cascading to every downstream declaration), and several `/--` docstrings were floating with no declaration to attach to (parse errors). This PR makes it compile and fills the mathematical heart of the disproof.

### Changes
- **Compile fix:** replace `Complex.abs` → norm `‖·‖` throughout; convert floating `/--` doc-comments (Körner / Bombieri–Bourgain / Rudin–Shapiro / historical note) to plain `/-`; fix deprecated `Mathlib.Data.Complex.Exponential` import.
- **`kahane_disproves` — proven in full** from the `kahane_ultraflat` axiom. At degree `n = max N 2`, pointwise ultraflatness transfers to the sup norm via `Real.iSup_le` giving `‖P‖_∞ ≤ (1+c/2)√n`, contradicting the conjecture's `‖P‖_∞ ≥ (1+c)√n` since `√n > 0` (`nlinarith`).
- **`erdos_newman_false`** is now `:= kahane_disproves` (was a separate duplicate `sorry`).
- **`sup_ge_l2`:** the standard L∞ ≥ L² comparison on the circle (a genuine measure-theoretic fact requiring Lebesgue integration) is recorded as the explicit axiom `supNorm_ge_l2norm`; the theorem is derived from it.
- Tidy `parseval_identity` (`exact Real.sq_sqrt`).

### Verification
- Typechecks under Lean v4.26 / Mathlib (Docker daemon was down; verified with `lake env lean`). 0 errors, **0 sorries**.
- `#print axioms Erdos230.erdos_230_summary` → `[propext, Classical.choice, kahane_ultraflat, supNorm_ge_l2norm, Quot.sound]` — only the two declared problem axioms plus the standard foundational ones. No `sorryAx`, no `Lean.ofReduceBool`.

### Status
`axiomatized` — **2 axioms** (`kahane_ultraflat`, `supNorm_ge_l2norm`), **0 sorries**, 5 theorems, 7 defs. `meta.json` / `annotations.json` updated (counts, line ranges, removed stale "marked `sorry`" claims).