### PR TITLE
Enrich Stirling Formula Bernoulli corrections (stirling-formula-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/stirling-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/stirling-formula-oq-01-oq-01/annotations.json
@@ -1,46 +1,114 @@
 [
   {
-    "id": "ann-logcoeff",
+    "id": "ann-coeff-def",
     "proofId": "stirling-formula-oq-01-oq-01",
     "range": {
-      "startLine": 73,
-      "endLine": 92
+      "startLine": 38,
+      "endLine": 48
     },
-    "type": "insight",
-    "title": "The Stirling Series Is Made of Bernoulli Numbers",
-    "content": "The genuine Stirling series — the logarithmic one — has coefficients gₖ = B_{2k}/(2k(2k−1)). `stirlingLogCoeff_one` computes g₁ = B₂/2 = (1/6)/2 = 1/12 (the first correction), and `stirlingLogCoeff_two` computes g₂ = B₄/12 = (−1/30)/12 = −1/360 (the third-order log term). These are the only Bernoulli inputs needed through third order; the multiplicative coefficients are built from them."
-  },
-  {
-    "id": "ann-a2",
-    "proofId": "stirling-formula-oq-01-oq-01",
-    "range": {
-      "startLine": 96,
-      "endLine": 100
-    },
-    "type": "insight",
-    "title": "The Second Correction Is Just the Square of the First",
-    "content": "`stirlingCoeff_two_eq` shows a₂ = g₁²/2. Exponentiating the log-series exp(g₁/n + g₂/n³ + ⋯), the 1/n² coefficient comes purely from the ½(g₁/n)² term — there is no 1/n² term in the log-series itself. So 1/288 = (1/12)²/2 carries no new Bernoulli information; it is determined entirely by the first correction."
-  },
-  {
-    "id": "ann-a3",
-    "proofId": "stirling-formula-oq-01-oq-01",
-    "range": {
-      "startLine": 102,
-      "endLine": 110
-    },
-    "type": "insight",
-    "title": "The Third Correction Mixes g₂ and g₁³",
-    "content": "`stirlingCoeff_three_eq` shows a₃ = g₂ + g₁³/6. The 1/n³ coefficient of the exponential picks up the genuinely new log term g₂ = −1/360 plus the cube term (g₁/n)³/6. Exact rational arithmetic gives −1/360 + (1/12)³/6 = −139/51840. This is precisely where the famously odd constant −139/51840 comes from — a Bernoulli number (B₄) plus the cube of B₂'s contribution."
+    "type": "definition",
+    "title": "The Multiplicative Stirling Coefficients",
+    "content": "stirlingCoeff mirrors StirlingExpansion.stirlingCoeff, recording the multiplicative coefficients a₀ = 1, a₁ = 1/12, a₂ = 1/288, a₃ = −139/51840 of the expansion n!/[√(2πn)(n/e)ⁿ] = ∑ aₖ/nᵏ. The point of this file is not to restate these magic constants but to *derive* a₂ and a₃ from Bernoulli numbers, so the rfl lemmas stirlingCoeff_one/two/three just pin the values for later use.",
+    "mathContext": "$\\frac{n!}{\\sqrt{2\\pi n}\\,(n/e)^n} = \\sum_k \\frac{a_k}{n^k}$ with $a_0=1,\\ a_1=\\tfrac1{12},\\ a_2=\\tfrac1{288},\\ a_3=-\\tfrac{139}{51840}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Stirling's approximation",
+      "asymptotic expansion",
+      "multiplicative correction coefficients"
+    ],
+    "prerequisites": [
+      "Stirling's formula",
+      "the parent StirlingExpansion.lean"
+    ]
   },
   {
     "id": "ann-partial4",
     "proofId": "stirling-formula-oq-01-oq-01",
     "range": {
-      "startLine": 56,
-      "endLine": 67
+      "startLine": 54,
+      "endLine": 62
     },
     "type": "concept",
     "title": "The Fourth Partial Sum",
-    "content": "`stirlingPartial_four` gives the closed form S₄(n) = 1 + 1/(12n) + 1/(288n²) − 139/(51840n³), extending the parent's S₃. Together with the Bernoulli relations, every coefficient through the third correction is now both stated and grounded."
+    "content": "stirlingPartial_four gives the closed form S₄(n) = 1 + 1/(12n) + 1/(288n²) − 139/(51840n³), extending the parent's S₃ by the third correction. The proof expands the Finset.range 4 sum termwise (Finset.sum_range_succ), substitutes the stirlingCoeff values, and closes with field_simp; ring. Together with the Bernoulli relations below, every coefficient through third order is now both stated and grounded.",
+    "mathContext": "$S_4(n) = 1 + \\frac{1}{12n} + \\frac{1}{288 n^2} - \\frac{139}{51840 n^3}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partial sum of an asymptotic series",
+      "Finset.sum_range_succ",
+      "field_simp / ring"
+    ],
+    "prerequisites": [
+      "the stirlingCoeff values",
+      "finite sums over range"
+    ]
+  },
+  {
+    "id": "ann-logcoeff",
+    "proofId": "stirling-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 66,
+      "endLine": 83
+    },
+    "type": "insight",
+    "title": "The Stirling Series Is Made of Bernoulli Numbers",
+    "content": "The genuine Stirling series — the logarithmic one — has coefficients gₖ = B_{2k}/(2k(2k−1)). stirlingLogCoeff_one computes g₁ = B₂/2 = (1/6)/2 = 1/12 (the first correction), and stirlingLogCoeff_two computes g₂ = B₄/12 = (−1/30)/12 = −1/360 (the third-order log term, using bernoulli_eq_bernoulli'_of_ne_one and bernoulli'_four). These are the only Bernoulli inputs needed through third order; the multiplicative coefficients are built from them.",
+    "mathContext": "$g_k = \\frac{B_{2k}}{2k(2k-1)}$; $g_1 = \\frac{B_2}{2} = \\frac{1}{12}$, $g_2 = \\frac{B_4}{12} = -\\frac{1}{360}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Stirling log-series",
+      "Bernoulli numbers",
+      "log Γ asymptotic expansion",
+      "bernoulli_two / bernoulli'_four"
+    ],
+    "prerequisites": [
+      "Bernoulli numbers in Mathlib",
+      "the asymptotic expansion of log Γ"
+    ]
+  },
+  {
+    "id": "ann-a2",
+    "proofId": "stirling-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "The Second Correction Is Just the Square of the First",
+    "content": "stirlingCoeff_two_eq shows a₂ = g₁²/2. Exponentiating the log-series exp(g₁/n + g₂/n³ + ⋯), the 1/n² coefficient comes purely from the ½(g₁/n)² term — there is no 1/n² term in the log-series itself. So 1/288 = (1/12)²/2 carries no new Bernoulli information; it is determined entirely by the first correction.",
+    "mathContext": "$a_2 = \\frac{g_1^2}{2} = \\frac{(1/12)^2}{2} = \\frac{1}{288}$ (the $\\tfrac12(g_1/n)^2$ term of $\\exp$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "exponential of a power series",
+      "no 1/n² term in the log-series",
+      "second-order coefficient"
+    ],
+    "prerequisites": [
+      "exp of an asymptotic series",
+      "g₁ = 1/12"
+    ]
+  },
+  {
+    "id": "ann-a3",
+    "proofId": "stirling-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 96
+    },
+    "type": "insight",
+    "title": "The Third Correction Mixes g₂ and g₁³",
+    "content": "stirlingCoeff_three_eq shows a₃ = g₂ + g₁³/6. The 1/n³ coefficient of the exponential picks up the genuinely new log term g₂ = −1/360 plus the cube term (g₁/n)³/6. Exact rational arithmetic gives −1/360 + (1/12)³/6 = −139/51840. This is precisely where the famously odd constant −139/51840 comes from — a Bernoulli number (B₄) plus the cube of B₂'s contribution.",
+    "mathContext": "$a_3 = g_2 + \\frac{g_1^3}{6} = -\\frac{1}{360} + \\frac{(1/12)^3}{6} = -\\frac{139}{51840}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "exponential cross-terms",
+      "the constant −139/51840",
+      "B₄ contribution plus B₂ cube",
+      "exact rational arithmetic (norm_num)"
+    ],
+    "prerequisites": [
+      "g₁ = 1/12 and g₂ = −1/360",
+      "exp of an asymptotic series to third order"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `stirling-formula-oq-01-oq-01` (quality 61, 0 prior passes; verified under-enriched on latest main — freshness re-checked before push).

## Gaps addressed
meta.json (overview, 3 sections, conclusion) was already rich. The gaps were:
- **Annotation depth**: the 4 existing annotations had only `title` + `content`. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all.
- **Coverage + range accuracy**: added a 5th annotation for the `stirlingCoeff` definition (lines 38-48), and realigned the a₂/a₃ annotation ranges onto the actual theorem lines (the old ranges 96-100 / 102-110 sat past `stirlingCoeff_two_eq` 87-90 and `stirlingCoeff_three_eq` 92-96).

Now 5 annotations, all with full metadata.

## Verification
- JSON validates (5 annotations, all four metadata fields present).
- Annotation ranges validate against the Lean source — no 'No Lean construct found' warnings for this entry.

Axiom integrity unchanged: status `verified`, axiomCount 0 (0 sorries, 0 axioms, no `native_decide`).