### PR TITLE
research(synthesis-curvature-ptolemy-oq-03): joint continuity of curvatureSin across the Euclidean seam [verified, 0 axioms]

### DIFF
--- a/proofs/Proofs/Erdos1005ProblemOQ02.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ02.lean
@@ -252,4 +252,66 @@ theorem mediant_is_min_denominator {a b c d : ℕ} (hb : 0 < b) (hd : 0 < d)
     have hpos : (0 : ℚ) < 1 / (d * (b + d) : ℚ) := by positivity
     linarith [hgap, hpos]
 
+-- ══════════════════════════════════════════════════════════════════
+-- § 5: Strict denominator growth and depth-two refinement (toward counting)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The mediant denominator strictly exceeds the **left** endpoint denominator. -/
+theorem mediant_denom_gt_left {b d : ℕ} (hd : 0 < d) : b < b + d := by omega
+
+/-- The mediant denominator strictly exceeds the **right** endpoint denominator. -/
+theorem mediant_denom_gt_right {b d : ℕ} (hb : 0 < b) : d < b + d := by omega
+
+/-- **Strict growth of interior denominators.**  Every fraction strictly inside a
+unimodular gap has denominator strictly larger than *both* endpoint denominators:
+`q ≥ b + d > max b d`.  Refinement therefore strictly increases the smallest
+denominator present — the engine of any depth/counting argument. -/
+theorem interior_denom_gt_max {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q) (hhi : (p : ℚ) / q < (c : ℚ) / d) :
+    max b d < q := by
+  have hge := denom_ge_of_between hb hd hq h hlo hhi
+  omega
+
+/-- **Depth-two bound, left sub-gap.**  The left sub-gap `(a/b, (a+c)/(b+d))` is
+itself unimodular (`unimodular_left`), so any fraction strictly inside it has
+denominator `≥ b + (b+d) = 2b + d`. -/
+theorem denom_ge_left_subgap {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (↑(a + c) : ℚ) / ↑(b + d)) :
+    b + (b + d) ≤ q := by
+  have hbd : 0 < b + d := by omega
+  exact denom_ge_of_between hb hbd hq (unimodular_left h) hlo hhi
+
+/-- **Depth-two bound, right sub-gap.**  The right sub-gap `((a+c)/(b+d), c/d)` is
+itself unimodular (`unimodular_right`), so any fraction strictly inside it has
+denominator `≥ (b+d) + d = b + 2d`. -/
+theorem denom_ge_right_subgap {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (↑(a + c) : ℚ) / ↑(b + d) < (p : ℚ) / q)
+    (hhi : (p : ℚ) / q < (c : ℚ) / d) :
+    (b + d) + d ≤ q := by
+  have hbd : 0 < b + d := by omega
+  exact denom_ge_of_between hbd hd hq (unimodular_right h) hlo hhi
+
+/-- **Second-smallest interior denominator.**  Every fraction strictly inside the
+gap *other than the mediant* falls in one of the two sub-gaps, so its denominator
+is `≥ (b+d) + min b d`.  Hence the mediant is the *unique* fraction of denominator
+`b+d` in the gap, and the next admissible denominator jumps by at least `min b d`.
+Iterating this strict growth is precisely the depth/counting route flagged as the
+next step toward the `1/12` run lower bound. -/
+theorem denom_ge_of_between_ne_mediant {a b c d p q : ℕ} (hb : 0 < b) (hd : 0 < d)
+    (hq : 0 < q) (h : Unimodular a b c d)
+    (hlo : (a : ℚ) / b < (p : ℚ) / q) (hhi : (p : ℚ) / q < (c : ℚ) / d)
+    (hne : (p : ℚ) / q ≠ (↑(a + c) : ℚ) / ↑(b + d)) :
+    (b + d) + min b d ≤ q := by
+  rcases lt_or_gt_of_ne hne with hM | hM
+  · -- p/q lies strictly below the mediant ⇒ inside the left sub-gap
+    have hsub := denom_ge_left_subgap hb hd hq h hlo hM
+    omega
+  · -- p/q lies strictly above the mediant ⇒ inside the right sub-gap
+    have hsub := denom_ge_right_subgap hb hd hq h hM hhi
+    omega
+
 end Erdos1005OQ02

--- a/proofs/Proofs/SynthesisCurvaturePtolemyOQ03.lean
+++ b/proofs/Proofs/SynthesisCurvaturePtolemyOQ03.lean
@@ -1,0 +1,247 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.Topology.Order.LeftRight
+import Mathlib.Data.Real.Sqrt
+import Mathlib.Tactic
+
+/-
+# Joint Continuity of `curvatureSin K t` in Both Curvature `K` and Parameter `t` (OQ-03)
+
+## What This Proves
+
+The parent entry (`SynthesisCurvaturePtolemy.lean`) defines the curvature-parametrized
+sine function
+
+  `curvatureSin K t =`
+    `t`                         if `K = 0`   (Euclidean),
+    `sin(√K · t) / √K`          if `K > 0`   (spherical),
+    `sinh(√(−K) · t) / √(−K)`   if `K < 0`   (hyperbolic),
+
+which unifies the three constant-curvature geometries.  The parent proves
+properties for *fixed* `K` (the ODE, the derivative at `0`, special values).  This
+entry proves the **joint continuity** of the map
+
+  `(K, t) ↦ curvatureSin K t`
+
+as a function `ℝ × ℝ → ℝ`.  This is the precise sense in which "the three geometries
+vary continuously with the curvature": there is no discontinuity at the Euclidean
+seam `K = 0`, even though the defining *formula* switches there between `sin` and
+`sinh`.
+
+## The argument
+
+The piecewise definition makes a direct two-variable seam analysis awkward, so we
+factor the seam into a single real variable.  Define the **curvature sinc**
+
+  `curvatureSinc x =`
+    `1`                         if `x = 0`,
+    `sin(√x) / √x`              if `x > 0`,
+    `sinh(√(−x)) / √(−x)`       if `x < 0`,
+
+and prove the algebraic identity
+
+  `curvatureSin K t = t · curvatureSinc (K · t²)`   (`curvatureSin_eq`).
+
+The identity collapses the three branches of `curvatureSin` (with their `±` sign
+bookkeeping from the oddness of `sin`/`sinh`) onto the three branches of the *even*
+function `curvatureSinc`, using `√(K t²) = √K · |t|`.
+
+Continuity then reduces to two facts:
+
+* `curvatureSinc` is continuous at every `x ≠ 0` (a quotient of continuous functions,
+  the denominator being nonzero there); and
+* `curvatureSinc` is continuous at the seam `x = 0`.  Here the two one-sided limits
+  are both `1`: from the right `sin(√x)/√x → 1` and from the left `sinh(√(−x))/√(−x)
+  → 1`, each obtained from the *slope-to-derivative* characterisation
+  (`HasDerivAt.tendsto_slope`) applied to `sin` and `sinh` at `0` — i.e. `sin' 0 =
+  cos 0 = 1` and `sinh' 0 = cosh 0 = 1`.  The two punctured-neighbourhood limits are
+  glued via `𝓝[<] 0 ⊔ 𝓝[>] 0 = 𝓝[≠] 0` and lifted to `ContinuousAt` through
+  `continuousAt_iff_punctured_nhds`.
+
+Joint continuity of `(K, t) ↦ t · curvatureSinc (K t²)` is then immediate from
+continuity of `curvatureSinc` and the ring operations.
+
+## What Mathlib has — and what this adds
+
+Mathlib has `continuous_sin`, `continuous_sinh`, `Real.continuous_sqrt`, the slope
+characterisation of the derivative, and the order/topology gluing lemmas, but it has
+no `curvatureSin`/`curvatureSinc` and hence nothing about the continuity of the
+constant-curvature `sn_K` family across the curvature seam.  The new content is the
+single-variable factorisation `curvatureSin_eq`, the continuity of `curvatureSinc`
+(seam included), and the joint continuity `continuous_curvatureSin`.
+
+**Sorry count**: 0.  **Axiom count**: 0 (only Lean/Mathlib foundational axioms).
+-/
+
+open Filter Topology
+
+namespace SynthesisCurvaturePtolemyOQ03
+
+/-- The **curvatureSin K** function, reproduced verbatim from the parent entry
+`SynthesisCurvaturePtolemy.lean` so that this continuity development is
+self-contained (it depends only on Mathlib):
+
+- `K > 0` (spherical): `curvatureSin K t = sin(√K · t) / √K`
+- `K = 0` (Euclidean): `curvatureSin 0 t = t`
+- `K < 0` (hyperbolic): `curvatureSin K t = sinh(√(−K) · t) / √(−K)` -/
+noncomputable def curvatureSin (K t : ℝ) : ℝ :=
+  if K = 0 then t
+  else if 0 < K then Real.sin (Real.sqrt K * t) / Real.sqrt K
+  else Real.sinh (Real.sqrt (-K) * t) / Real.sqrt (-K)
+
+/-- For `K > 0`, `curvatureSin K t = sin(√K · t) / √K`. -/
+lemma curvatureSin_pos {K : ℝ} (hK : 0 < K) (t : ℝ) :
+    curvatureSin K t = Real.sin (Real.sqrt K * t) / Real.sqrt K := by
+  simp only [curvatureSin, if_neg (ne_of_gt hK), if_pos hK]
+
+/-- For `K < 0`, `curvatureSin K t = sinh(√(−K) · t) / √(−K)`. -/
+lemma curvatureSin_neg {K : ℝ} (hK : K < 0) (t : ℝ) :
+    curvatureSin K t = Real.sinh (Real.sqrt (-K) * t) / Real.sqrt (-K) := by
+  simp only [curvatureSin, if_neg (ne_of_lt hK), if_neg (not_lt.mpr (le_of_lt hK))]
+
+/-- The **curvature sinc** function: the even, entire "cardinal sine" underlying
+`curvatureSin`.  It equals `sin(√x)/√x` for `x > 0`, `sinh(√(−x))/√(−x)` for `x < 0`,
+and is normalised to `1` at the seam `x = 0` (the common value of both one-sided
+limits).  The key identity `curvatureSin K t = t · curvatureSinc (K · t²)` reduces the
+two-variable continuity problem to the single seam of `curvatureSinc` at `0`. -/
+noncomputable def curvatureSinc (x : ℝ) : ℝ :=
+  if x = 0 then 1
+  else if 0 < x then Real.sin (Real.sqrt x) / Real.sqrt x
+  else Real.sinh (Real.sqrt (-x)) / Real.sqrt (-x)
+
+@[simp] lemma curvatureSinc_zero : curvatureSinc 0 = 1 := by simp [curvatureSinc]
+
+/-- The one-variable factorisation: `curvatureSin K t = t · curvatureSinc (K · t²)`.
+This is the heart of the reduction — it folds the three sign-laden branches of
+`curvatureSin` onto the three branches of the even `curvatureSinc`. -/
+theorem curvatureSin_eq (K t : ℝ) :
+    curvatureSin K t = t * curvatureSinc (K * t ^ 2) := by
+  by_cases hK : K = 0
+  · subst hK; simp [curvatureSin, curvatureSinc]
+  · by_cases ht : t = 0
+    · subst ht; simp [curvatureSin]
+    · have ht2 : (0 : ℝ) < t ^ 2 := by positivity
+      rcases lt_or_gt_of_ne hK with hKneg | hKpos
+      · -- K < 0 (hyperbolic branch)
+        have hKt2 : K * t ^ 2 < 0 := mul_neg_of_neg_of_pos hKneg ht2
+        have hsK : Real.sqrt (-K) ≠ 0 := Real.sqrt_ne_zero'.mpr (neg_pos.mpr hKneg)
+        rw [curvatureSin_neg hKneg, curvatureSinc, if_neg (ne_of_lt hKt2),
+          if_neg (not_lt.mpr hKt2.le), show -(K * t ^ 2) = (-K) * t ^ 2 by ring,
+          Real.sqrt_mul (neg_nonneg.mpr hKneg.le), Real.sqrt_sq_eq_abs]
+        rcases lt_or_gt_of_ne ht with htneg | htpos
+        · rw [abs_of_neg htneg, mul_neg, Real.sinh_neg]; field_simp
+        · rw [abs_of_pos htpos]; field_simp
+      · -- K > 0 (spherical branch)
+        have hKt2 : (0 : ℝ) < K * t ^ 2 := mul_pos hKpos ht2
+        have hsK : Real.sqrt K ≠ 0 := Real.sqrt_ne_zero'.mpr hKpos
+        rw [curvatureSin_pos hKpos, curvatureSinc, if_neg (ne_of_gt hKt2),
+          if_pos hKt2, Real.sqrt_mul hKpos.le, Real.sqrt_sq_eq_abs]
+        rcases lt_or_gt_of_ne ht with htneg | htpos
+        · rw [abs_of_neg htneg, mul_neg, Real.sin_neg]; field_simp
+        · rw [abs_of_pos htpos]; field_simp
+
+/-- `sin u / u → 1` as `u → 0` (punctured), i.e. the cardinal-sine limit, obtained
+from `sin' 0 = cos 0 = 1` via the slope characterisation of the derivative. -/
+private lemma tendsto_sin_div : Tendsto (fun u => Real.sin u / u) (𝓝[≠] (0 : ℝ)) (𝓝 1) := by
+  have h := (Real.hasDerivAt_sin 0).tendsto_slope
+  rw [Real.cos_zero] at h
+  have heq : slope Real.sin 0 = fun u => Real.sin u / u := by
+    funext u; simp [slope_def_field, Real.sin_zero]
+  rwa [heq] at h
+
+/-- `sinh u / u → 1` as `u → 0` (punctured), from `sinh' 0 = cosh 0 = 1`. -/
+private lemma tendsto_sinh_div : Tendsto (fun u => Real.sinh u / u) (𝓝[≠] (0 : ℝ)) (𝓝 1) := by
+  have h := (Real.hasDerivAt_sinh 0).tendsto_slope
+  rw [Real.cosh_zero] at h
+  have heq : slope Real.sinh 0 = fun u => Real.sinh u / u := by
+    funext u; simp [slope_def_field, Real.sinh_zero]
+  rwa [heq] at h
+
+/-- `√` maps the right-punctured neighbourhood of `0` into the punctured
+neighbourhood of `0`. -/
+private lemma tendsto_sqrt_right :
+    Tendsto Real.sqrt (𝓝[>] (0 : ℝ)) (𝓝[≠] (0 : ℝ)) := by
+  rw [tendsto_nhdsWithin_iff]
+  refine ⟨?_, ?_⟩
+  · have h : Tendsto Real.sqrt (𝓝 (0 : ℝ)) (𝓝 (Real.sqrt 0)) := Real.continuous_sqrt.tendsto 0
+    rw [Real.sqrt_zero] at h
+    exact h.mono_left nhdsWithin_le_nhds
+  · filter_upwards [self_mem_nhdsWithin] with x hx
+    rw [Set.mem_Ioi] at hx
+    exact Real.sqrt_ne_zero'.mpr hx
+
+/-- `x ↦ √(−x)` maps the left-punctured neighbourhood of `0` into the punctured
+neighbourhood of `0`. -/
+private lemma tendsto_sqrt_neg_left :
+    Tendsto (fun x => Real.sqrt (-x)) (𝓝[<] (0 : ℝ)) (𝓝[≠] (0 : ℝ)) := by
+  rw [tendsto_nhdsWithin_iff]
+  refine ⟨?_, ?_⟩
+  · have h : Tendsto (fun x => Real.sqrt (-x)) (𝓝 (0 : ℝ)) (𝓝 (Real.sqrt (-0))) :=
+      (Real.continuous_sqrt.comp continuous_neg).tendsto 0
+    simp only [neg_zero, Real.sqrt_zero] at h
+    exact h.mono_left nhdsWithin_le_nhds
+  · filter_upwards [self_mem_nhdsWithin] with x hx
+    rw [Set.mem_Iio] at hx
+    exact Real.sqrt_ne_zero'.mpr (neg_pos.mpr hx)
+
+/-- `curvatureSinc` is continuous everywhere — including across the Euclidean seam
+`x = 0`, where both one-sided limits equal the value `1`. -/
+theorem continuous_curvatureSinc : Continuous curvatureSinc := by
+  rw [continuous_iff_continuousAt]
+  intro x
+  rcases lt_trichotomy x 0 with hx | hx | hx
+  · -- x < 0 : agrees with the (continuous) hyperbolic formula near x
+    have hden : Real.sqrt (-x) ≠ 0 := Real.sqrt_ne_zero'.mpr (neg_pos.mpr hx)
+    have hcont : ContinuousAt (fun y => Real.sinh (Real.sqrt (-y)) / Real.sqrt (-y)) x :=
+      ((Real.continuous_sinh.comp (Real.continuous_sqrt.comp continuous_neg)).continuousAt).div
+        ((Real.continuous_sqrt.comp continuous_neg).continuousAt) hden
+    refine hcont.congr ?_
+    filter_upwards [Iio_mem_nhds hx] with y hy
+    rw [Set.mem_Iio] at hy
+    simp only [curvatureSinc, if_neg hy.ne, if_neg (not_lt.mpr hy.le)]
+  · -- x = 0 : the seam
+    subst hx
+    rw [continuousAt_iff_punctured_nhds, curvatureSinc_zero, ← nhdsLT_sup_nhdsGT (0 : ℝ)]
+    refine tendsto_sup.mpr ⟨?_, ?_⟩
+    · -- left limit via sinh
+      have hcomp := tendsto_sinh_div.comp tendsto_sqrt_neg_left
+      refine hcomp.congr' ?_
+      filter_upwards [self_mem_nhdsWithin] with x hx
+      rw [Set.mem_Iio] at hx
+      simp only [Function.comp_apply, curvatureSinc, if_neg hx.ne, if_neg (not_lt.mpr hx.le)]
+    · -- right limit via sin
+      have hcomp := tendsto_sin_div.comp tendsto_sqrt_right
+      refine hcomp.congr' ?_
+      filter_upwards [self_mem_nhdsWithin] with x hx
+      rw [Set.mem_Ioi] at hx
+      simp only [Function.comp_apply, curvatureSinc, if_neg hx.ne', if_pos hx]
+  · -- x > 0 : agrees with the (continuous) spherical formula near x
+    have hden : Real.sqrt x ≠ 0 := Real.sqrt_ne_zero'.mpr hx
+    have hcont : ContinuousAt (fun y => Real.sin (Real.sqrt y) / Real.sqrt y) x :=
+      ((Real.continuous_sin.comp Real.continuous_sqrt).continuousAt).div
+        (Real.continuous_sqrt.continuousAt) hden
+    refine hcont.congr ?_
+    filter_upwards [Ioi_mem_nhds hx] with y hy
+    rw [Set.mem_Ioi] at hy
+    simp only [curvatureSinc, if_neg hy.ne', if_pos hy]
+
+/-- **Joint continuity of `curvatureSin`.**  The map `(K, t) ↦ curvatureSin K t` is
+continuous on all of `ℝ × ℝ`; in particular the three constant-curvature geometries
+glue together continuously across the Euclidean seam `K = 0`. -/
+theorem continuous_curvatureSin :
+    Continuous (fun p : ℝ × ℝ => curvatureSin p.1 p.2) := by
+  have hrw : (fun p : ℝ × ℝ => curvatureSin p.1 p.2)
+      = fun p : ℝ × ℝ => p.2 * curvatureSinc (p.1 * p.2 ^ 2) := by
+    funext p; exact curvatureSin_eq p.1 p.2
+  rw [hrw]
+  exact continuous_snd.mul
+    (continuous_curvatureSinc.comp (continuous_fst.mul (continuous_snd.pow 2)))
+
+/-- Restatement via `Function.uncurry`, the standard packaging of "jointly
+continuous in both arguments". -/
+theorem continuous_uncurry_curvatureSin :
+    Continuous (Function.uncurry curvatureSin) :=
+  continuous_curvatureSin
+
+end SynthesisCurvaturePtolemyOQ03

--- a/research/problems/erdos-1005-oq-02/state.md
+++ b/research/problems/erdos-1005-oq-02/state.md
@@ -2,12 +2,12 @@
 
 **Phase**: FORMALIZED (verified infrastructure; open problem itself remains open)
 **Since**: 2026-06-25
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
 Formalized the exact arithmetic of mediant insertion on Farey gaps:
-`proofs/Proofs/Erdos1005ProblemOQ02.lean` (256 lines, 13 theorems, 1 def,
+`proofs/Proofs/Erdos1005ProblemOQ02.lean` (317 lines, 19 theorems, 1 def,
 0 sorries, 0 axioms; #print axioms reports only propext / Classical.choice /
 Quot.sound).
 
@@ -30,6 +30,18 @@ on the longest run of *similarly ordered* Farey fractions — is **not**
 addressed. That constant `c ∈ [1/12, 1/4]` remains open. This session
 formalizes the verified mediant calculus that such constructions rest on, not
 a resolution of the bound.
+
+## Iteration 3 addition (verified)
+
+Added **§5 (strict denominator growth + depth-two refinement)**, 0-sorry /
+0-axiom: `interior_denom_gt_max` (every in-gap fraction has denominator
+> max(b,d) — refinement strictly raises the smallest denominator);
+`denom_ge_left_subgap`/`denom_ge_right_subgap` (each sub-gap is again
+unimodular, giving depth-two bounds q ≥ 2b+d, q ≥ b+2d); and the headline
+`denom_ge_of_between_ne_mediant` — the mediant is the *unique* denominator-(b+d)
+point, and the next admissible denominator jumps by ≥ min(b,d). This is the
+strict-growth step the counting argument rests on; the 1/12 run constant itself
+remains open.
 
 ## Next Action
 

--- a/src/data/proofs/erdos-1005-oq-02/meta.json
+++ b/src/data/proofs/erdos-1005-oq-02/meta.json
@@ -5,12 +5,12 @@
   "title": "Mediant Insertion and the Farey Gap Calculus: The Mediant Is the Unique Smallest-Denominator Fraction in a Gap",
   "description": "A self-contained, axiom-free formalization of the exact arithmetic of mediant insertion — the operation that refines the Farey sequence F_n into F_{n+1} by inserting, between adjacent fractions a/b < c/d, their mediant (a+c)/(b+d). Two threads are proved. First, the gap-splitting calculus: a unimodular gap of size 1/(bd) is split by its mediant into a left sub-gap 1/(b(b+d)) and a right sub-gap 1/(d(b+d)); these sum back to 1/(bd), stand in ratio d:b, and each is strictly smaller than the whole. Second, the headline minimal-denominator theorem: any fraction p/q strictly between two unimodular neighbours has denominator q ≥ b+d, and equality forces p/q = (a+c)/(b+d) exactly. Hence the mediant is the unique fraction of smallest denominator inside any Farey gap, and b+d is a hard lower bound on refining it — no construction can introduce a fraction of smaller denominator. The parent entry (Erdős #1005) records the open lower bound f(n) ≥ (1/12−o(1))n on runs of similarly ordered Farey fractions; that constant remains open and is NOT addressed here. This entry formalizes the verified mediant calculus on which such lower-bound constructions are built.",
   "leanFile": {
-    "lineCount": 256,
+    "lineCount": 317,
     "axiomCount": 0,
     "path": "Proofs/Erdos1005ProblemOQ02.lean",
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 13
+    "theoremCount": 19
   },
   "meta": {
     "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot mediant theory)",
@@ -101,6 +101,13 @@
       "startLine": 152,
       "endLine": 254,
       "summary": "denom_identity (the ℤ kernel q = b·(cq−pd) + d·(pb−aq)); denom_ge_of_between (any in-gap fraction has q ≥ b+d); eq_mediant_of_denom_eq (equality forces p = a+c, the mediant); mediant_is_min_denominator (packaged: the mediant lies in the gap and minimises the denominator)."
+    },
+    {
+      "id": "denominator-growth",
+      "title": "§5 Strict denominator growth and depth-two refinement (toward counting)",
+      "startLine": 255,
+      "endLine": 316,
+      "summary": "mediant_denom_gt_left/_right (b < b+d, d < b+d); interior_denom_gt_max (every in-gap fraction has q > max b d, so refinement strictly raises the smallest denominator); denom_ge_left_subgap/denom_ge_right_subgap (the two sub-gaps are themselves unimodular, giving depth-two bounds q ≥ 2b+d and q ≥ b+2d); denom_ge_of_between_ne_mediant (every in-gap fraction other than the mediant has q ≥ (b+d)+min b d — the mediant is the unique denominator-(b+d) point, and the next admissible denominator jumps by at least min b d)."
     }
   ],
   "crossReferences": [
@@ -145,6 +152,12 @@
       "type": "supporting",
       "description": "The algebraic kernel over ℤ behind the denominator bound: q = b·(cq − pd) + d·(pb − aq), an unconditional identity once bc − ad = 1, verified by linear_combination.",
       "leanType": "∀ {a b c d p q : ℤ}, b * c = a * d + 1 → q = b * (c * q - p * d) + d * (p * b - a * q)"
+    },
+    {
+      "name": "denom_ge_of_between_ne_mediant",
+      "type": "headline",
+      "description": "Second-smallest interior denominator: every fraction p/q strictly inside a unimodular gap a/b < c/d that is NOT the mediant (a+c)/(b+d) lies in one of the two (again unimodular) sub-gaps, hence has q ≥ (b+d)+min b d. So the mediant is the unique fraction of denominator b+d in the gap, and the next admissible denominator is at least min b d larger — the strict-growth step underlying any depth/counting argument toward the 1/12 run bound.",
+      "leanType": "∀ {a b c d p q : ℕ}, 0 < b → 0 < d → 0 < q → Unimodular a b c d → (a:ℚ)/b < (p:ℚ)/q → (p:ℚ)/q < (c:ℚ)/d → (p:ℚ)/q ≠ (↑(a+c):ℚ)/↑(b+d) → (b+d)+min b d ≤ q"
     }
   ]
 }

--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-03/annotations.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-scp-oq03-defs",
+    "proofId": "synthesis-curvature-ptolemy-oq-03",
+    "range": { "startLine": 88, "endLine": 116 },
+    "type": "concept",
+    "title": "curvatureSin and the curvature sinc",
+    "content": "`curvatureSin K t` is the constant-curvature sine: `sin(√K·t)/√K` for `K>0`, the identity `t` for `K=0`, and `sinh(√(−K)·t)/√(−K)` for `K<0`. It is reproduced verbatim from the parent entry so this development depends only on Mathlib.\n\nThe **curvature sinc** `curvatureSinc x` is the even companion: `sin(√x)/√x` for `x>0`, `1` at `x=0`, and `sinh(√(−x))/√(−x)` for `x<0`. It carries the entire seam analysis on a single real variable.",
+    "mathContext": "curvatureSin K is the unique solution of the Jacobi equation y'' + K·y = 0 with y(0)=0, y'(0)=1. The curvature sinc is the entire function ∑ₙ (−x)ⁿ/(2n+1)!, equal to sin(√x)/√x for x>0 and sinh(√(−x))/√(−x) for x<0.",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi field", "Cardinal sine", "Constant curvature"],
+    "prerequisites": ["Real sin and sinh", "Real.sqrt"]
+  },
+  {
+    "id": "ann-scp-oq03-factorization",
+    "proofId": "synthesis-curvature-ptolemy-oq-03",
+    "range": { "startLine": 118, "endLine": 144 },
+    "type": "technique",
+    "title": "One-variable factorization curvatureSin K t = t·curvatureSinc(K·t²)",
+    "content": "The key identity that makes the proof tractable. It folds the three sign-laden branches of `curvatureSin` onto the three branches of the **even** `curvatureSinc`, using `√(K·t²) = √K·|t|` and the oddness of `sin` and `sinh` to absorb the sign of `t` against the leading factor `t`.\n\nProof is by cases on `K = 0`, `t = 0`, and the signs of `K` and `t`; each leaf closes by `field_simp` after rewriting the absolute value and the relevant odd-function identity.",
+    "mathContext": "Because u ↦ sin(u)/u and u ↦ sinh(u)/u are even, sin(√K·t)/√K = t·(sin(√K·|t|)/(√K·|t|)) regardless of the sign of t. The two-variable seam line K=0 is thereby reduced to the single seam point x=0 of curvatureSinc.",
+    "significance": "key",
+    "relatedConcepts": ["Even and odd functions", "Absolute value", "Square root of a product"],
+    "prerequisites": ["Real.sqrt_mul", "Real.sqrt_sq_eq_abs", "sin_neg / sinh_neg"]
+  },
+  {
+    "id": "ann-scp-oq03-sinc-limits",
+    "proofId": "synthesis-curvature-ptolemy-oq-03",
+    "range": { "startLine": 146, "endLine": 189 },
+    "type": "technique",
+    "title": "Cardinal-sine limits from the slope characterization",
+    "content": "`sin(u)/u → 1` and `sinh(u)/u → 1` over the punctured neighbourhood of `0` are obtained directly from `HasDerivAt.tendsto_slope`: the slope `(f(u) − f(0))/(u − 0)` of `sin` (resp. `sinh`) at `0` tends to the derivative `cos 0 = 1` (resp. `cosh 0 = 1`). Companion lemmas show `√` and `x ↦ √(−x)` carry the right/left punctured neighbourhood of 0 into the punctured neighbourhood of 0, so the limits transport to the curvature sinc.",
+    "mathContext": "Avoiding any explicit cubic Taylor estimate: the cardinal-sine limit is literally the definition of the derivative at 0, packaged by Mathlib's slope-to-derivative equivalence.",
+    "significance": "key",
+    "relatedConcepts": ["Slope of the derivative", "Punctured neighbourhood", "Cardinal sine"],
+    "prerequisites": ["HasDerivAt.tendsto_slope", "Real.hasDerivAt_sin / Real.hasDerivAt_sinh", "tendsto_nhdsWithin_iff"]
+  },
+  {
+    "id": "ann-scp-oq03-joint",
+    "proofId": "synthesis-curvature-ptolemy-oq-03",
+    "range": { "startLine": 190, "endLine": 247 },
+    "type": "main_result",
+    "title": "Continuity of the curvature sinc and joint continuity of curvatureSin",
+    "content": "Away from `0`, `curvatureSinc` is a quotient of continuous functions with nonzero denominator. At the seam `x = 0`, the two one-sided limits both equal the value `1`, so gluing them via `𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0` and `continuousAt_iff_punctured_nhds` gives `ContinuousAt curvatureSinc 0`. Joint continuity of `(K,t) ↦ curvatureSin K t = t·curvatureSinc(K·t²)` then follows from the ring operations. A `Function.uncurry` restatement is also provided.",
+    "mathContext": "The seam value 1 is forced as the common value of both one-sided limits and of the Euclidean branch curvatureSin 0 t = t — it is the normalization y'(0)=1 of the Jacobi equation. The three constant-curvature geometries glue continuously across K=0.",
+    "significance": "key",
+    "relatedConcepts": ["Joint continuity", "Order-topology gluing", "Comparison geometry"],
+    "prerequisites": ["continuousAt_iff_punctured_nhds", "nhdsLT_sup_nhdsGT", "ContinuousAt.div"]
+  }
+]

--- a/src/data/proofs/synthesis-curvature-ptolemy-oq-03/meta.json
+++ b/src/data/proofs/synthesis-curvature-ptolemy-oq-03/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "synthesis-curvature-ptolemy-oq-03",
+  "title": "Joint Continuity of curvatureSin in Both Curvature K and Parameter t",
+  "slug": "synthesis-curvature-ptolemy-oq-03",
+  "description": "Proves that the constant-curvature sine function curvatureSin K t — sin(√K·t)/√K for K>0, t for K=0, sinh(√(−K)·t)/√(−K) for K<0 — is jointly continuous as a map ℝ × ℝ → ℝ. The crux is the Euclidean seam K=0, where the defining formula switches between sin and sinh: the proof factors the seam into one real variable via the identity curvatureSin K t = t·curvatureSinc(K·t²), reducing two-variable continuity to a single seam of the even 'curvature sinc' at 0, whose two one-sided limits both equal 1 by the slope-to-derivative characterization (sin′0 = cos 0 = 1, sinh′0 = cosh 0 = 1). This settles the joint-continuity open question registered in the parent entry.",
+  "meta": {
+    "author": "Lean Genius Researcher (2026)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jacobi_field",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SynthesisCurvaturePtolemyOQ03.lean",
+    "tags": [
+      "analysis",
+      "continuity",
+      "curvature",
+      "spherical-geometry",
+      "hyperbolic-geometry",
+      "trigonometry",
+      "comparison-geometry",
+      "jacobi-field",
+      "synthesis"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "originalContributions": [
+      "curvatureSin_eq: the one-variable factorization curvatureSin K t = t · curvatureSinc(K·t²), folding the three sign-laden branches of curvatureSin onto the even curvature-sinc via √(K·t²) = √K·|t|",
+      "curvatureSinc: the even, entire 'cardinal sine' underlying curvatureSin — sin(√x)/√x (x>0), 1 (x=0), sinh(√(−x))/√(−x) (x<0)",
+      "continuous_curvatureSinc: continuity of the curvature sinc across its seam at 0, gluing the two one-sided sinc limits (each = 1 from sin′0/sinh′0) via 𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0 and continuousAt_iff_punctured_nhds",
+      "continuous_curvatureSin: joint continuity of (K,t) ↦ curvatureSin K t on all of ℝ × ℝ — the three constant-curvature geometries glue continuously across the Euclidean seam K=0",
+      "continuous_uncurry_curvatureSin: the same result packaged via Function.uncurry"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 247,
+    "assumptions": "0 axioms, 0 sorries. #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Fully machine-verified. The curvatureSin definition is reproduced verbatim from the parent entry SynthesisCurvaturePtolemy.lean so this continuity development depends only on Mathlib.",
+    "mathlib_version": "4.26.0",
+    "parentProof": "synthesis-curvature-ptolemy",
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "sections": [
+    {
+      "title": "curvatureSin and the curvature sinc",
+      "startLine": 88,
+      "endLine": 144,
+      "description": "Reproduces curvatureSin K t (from the parent), defines the even curvature sinc curvatureSinc x = sin(√x)/√x (x>0), 1 (x=0), sinh(√(−x))/√(−x) (x<0), and proves the one-variable factorization curvatureSin K t = t·curvatureSinc(K·t²).",
+      "summary": "Factor the two-variable seam into one variable: curvatureSin K t = t·curvatureSinc(K·t²)",
+      "id": "factorization",
+      "mathContext": "The piecewise definition of curvatureSin makes a direct two-variable seam analysis awkward, so the proof factors out a single real variable. Because u ↦ sin(u)/u and u ↦ sinh(u)/u are even, and √(K·t²) = √K·|t|, the three sign-laden branches of curvatureSin collapse onto the three branches of the even curvatureSinc. The factorization curvatureSin K t = t·curvatureSinc(K·t²) holds for all K and t, with the ± bookkeeping handled by the oddness of sin and sinh."
+    },
+    {
+      "title": "One-sided sinc limits at the seam",
+      "startLine": 146,
+      "endLine": 189,
+      "description": "Proves sin(u)/u → 1 and sinh(u)/u → 1 over the punctured neighbourhood of 0 from the slope characterization of the derivative, and that √ (resp. x ↦ √(−x)) carries the right (resp. left) punctured neighbourhood of 0 into the punctured neighbourhood of 0.",
+      "summary": "sin(u)/u → 1 and sinh(u)/u → 1 via HasDerivAt.tendsto_slope; √ tendsto lemmas",
+      "id": "sinc-limits",
+      "mathContext": "The cardinal-sine limits sin(u)/u → 1 and sinh(u)/u → 1 are exactly the slopes (f(u) − f(0))/(u − 0) of sin and sinh at 0, so they equal sin′0 = cos 0 = 1 and sinh′0 = cosh 0 = 1 by HasDerivAt.tendsto_slope. Composing with √x → 0⁺ (right of 0) and √(−x) → 0⁺ (left of 0) transports these to the curvature sinc."
+    },
+    {
+      "title": "Continuity of the curvature sinc and joint continuity",
+      "startLine": 191,
+      "endLine": 247,
+      "description": "Proves continuous_curvatureSinc (continuity everywhere, including the seam at 0, by gluing the two one-sided limits via 𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0 and continuousAt_iff_punctured_nhds) and deduces the joint continuity of (K,t) ↦ curvatureSin K t.",
+      "summary": "curvatureSinc continuous across the seam ⇒ (K,t) ↦ curvatureSin K t jointly continuous",
+      "id": "joint-continuity",
+      "mathContext": "Away from 0 the curvature sinc is a quotient of continuous functions with nonzero denominator. At the seam the two punctured one-sided limits both equal the value 1, so continuousAt_iff_punctured_nhds upgrades the glued punctured-neighbourhood limit to ContinuousAt. Joint continuity of (K,t) ↦ t·curvatureSinc(K·t²) is then immediate from the ring operations."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The constant-curvature sine sn_K — written curvatureSin K here — is the unique solution of the Jacobi equation y'' + K·y = 0 with y(0)=0, y'(0)=1. As K varies through positive, zero, and negative values the solution passes from oscillatory (sin(√K·t)/√K), through linear (t), to hyperbolic (sinh(√(−K)·t)/√(−K)). That these regimes are joined continuously across the Euclidean seam K=0 — rather than merely agreeing in a formal limit — is the analytic content underlying the use of sn_K as a single comparison density in Riemannian geometry (Toponogov comparison, Bishop–Gromov volume comparison). The parent entry registered this joint continuity as an explicit open question; this entry settles it.",
+    "problemStatement": "Prove that the map (K, t) ↦ curvatureSin K t, defined as sin(√K·t)/√K for K>0, t for K=0, and sinh(√(−K)·t)/√(−K) for K<0, is continuous as a function ℝ × ℝ → ℝ — in particular that no discontinuity arises at the Euclidean seam K=0 where the defining formula switches between sin and sinh.",
+    "text": "The two-variable seam at K=0 is reduced to a single-variable seam by the algebraic identity curvatureSin K t = t·curvatureSinc(K·t²). Continuity of the even curvature sinc at 0 — its two one-sided limits both equal 1 — then yields joint continuity of curvatureSin.",
+    "proofStrategy": "(1) Prove curvatureSin K t = t·curvatureSinc(K·t²) by branch-and-sign analysis using √(K·t²)=√K·|t| and the oddness of sin/sinh. (2) Show curvatureSinc is continuous away from 0 (continuous quotient, nonzero denominator) and at 0 by gluing the one-sided sinc limits — each obtained from HasDerivAt.tendsto_slope for sin and sinh — through 𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0 and continuousAt_iff_punctured_nhds. (3) Conclude joint continuity of (K,t) ↦ t·curvatureSinc(K·t²) from the ring operations.",
+    "keyInsights": [
+      "Factoring the two-variable seam into one variable — curvatureSin K t = t·curvatureSinc(K·t²) — is what makes the proof tractable: the curvature sinc has a single seam point (x=0) instead of a whole seam line (K=0).",
+      "The reduction works because u ↦ sin(u)/u and u ↦ sinh(u)/u are even, so the sign of t (and the oddness of sin/sinh) cancels against the leading factor t, leaving an even function of K·t² evaluated through √(K·t²)=√K·|t|.",
+      "The seam value 1 is forced: it is simultaneously sin′0 = cos 0 and sinh′0 = cosh 0, so both one-sided limits agree with the Euclidean branch curvatureSin 0 t = t. This is precisely the normalization y'(0)=1 of the Jacobi equation, now seen as the reason continuity holds.",
+      "The slope-to-derivative characterization HasDerivAt.tendsto_slope turns the cardinal-sine limits into one-line consequences of the known derivatives of sin and sinh, avoiding any explicit cubic Taylor estimate.",
+      "The order-topology gluing 𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0 together with continuousAt_iff_punctured_nhds is the clean Mathlib idiom for assembling a two-sided continuity statement from independently proved one-sided limits."
+    ],
+    "prerequisites": [
+      "curvatureSin function definition and its three curvature regimes",
+      "Slope characterization of the derivative (HasDerivAt.tendsto_slope) and the derivatives of sin and sinh",
+      "Continuity of sin, sinh, and Real.sqrt",
+      "Order-topology neighbourhood gluing (𝓝[<], 𝓝[>], 𝓝[≠]) and continuousAt_iff_punctured_nhds"
+    ],
+    "openQuestions": [
+      "Is curvatureSin jointly real-analytic (not merely continuous) in (K, t)? The curvature sinc is the entire function ∑ₙ (−x)ⁿ/(2n+1)!, so joint analyticity should follow from an everywhere-convergent power-series representation.",
+      "Does joint continuity extend to curvatureCos K t = the K-cosine, and to the pair (curvatureSin, curvatureCos) as a continuous family of fundamental solution matrices of y'' + K·y = 0?",
+      "Can continuity be upgraded to local Lipschitz or C^∞ dependence on the curvature K, as needed for differentiating Bishop–Gromov comparison densities in K?"
+    ]
+  },
+  "conclusion": {
+    "summary": "The constant-curvature sine curvatureSin K t is proved jointly continuous on ℝ × ℝ, with the Euclidean seam K=0 handled by the one-variable factorization curvatureSin K t = t·curvatureSinc(K·t²) and the agreement of the two one-sided curvature-sinc limits at 1.",
+    "implications": "This resolves the joint-continuity open question recorded in the parent entry SynthesisCurvaturePtolemy.lean. It confirms that the spherical (K>0), Euclidean (K=0), and hyperbolic (K<0) regimes of the sn_K family glue together into a single continuous function of curvature and arc length — the analytic prerequisite for treating sn_K as one comparison density across all constant-curvature space forms (Toponogov, Bishop–Gromov). The factorization curvatureSin K t = t·curvatureSinc(K·t²) and the continuous curvature sinc are reusable infrastructure for any later development that needs the sn_K family as a function of curvature.",
+    "openQuestions": [
+      "Strengthen joint continuity to joint real-analyticity via the entire power series ∑ₙ (−x)ⁿ/(2n+1)! for the curvature sinc.",
+      "Prove the analogous joint continuity for the K-cosine and for the fundamental-solution matrix of y'' + K·y = 0.",
+      "Establish C^∞ / Lipschitz dependence on K for use in differentiating volume-comparison densities."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "synthesis-curvature-ptolemy",
+      "relationship": "parent",
+      "description": "Defines curvatureSin K t and lists 'Prove continuity of curvatureSin K in both K and t (joint continuity)' as an open question. This entry settles that question; the curvatureSin definition is reproduced verbatim from the parent so the continuity development depends only on Mathlib."
+    },
+    {
+      "targetId": "synthesis-curvature-ptolemy-oq-01",
+      "relationship": "sibling",
+      "description": "The OQ-01 sibling proves curvatureSin K satisfies the Jacobi ODE y'' + K·y = 0 with derivative curvatureCos K. The normalization y'(0)=1 appearing there is exactly the common seam value 1 that makes the joint continuity proved here hold across K=0."
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "J. Cheeger",
+        "D. G. Ebin"
+      ],
+      "title": "Comparison Theorems in Riemannian Geometry",
+      "year": "1975",
+      "venue": "North-Holland Mathematical Library, vol. 9",
+      "note": "Standard reference for the sn_K Jacobi field and its role as the comparison density in Toponogov and Bishop–Gromov comparison."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp",
+      "Mathlib.Analysis.Calculus.Deriv.Slope",
+      "Mathlib.Topology.Order.LeftRight",
+      "Mathlib.Data.Real.Sqrt",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "SynthesisCurvaturePtolemyOQ03",
+    "lineCount": 247,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "sorries": 0,
+    "path": "Proofs/SynthesisCurvaturePtolemyOQ03.lean",
+    "definitionCount": 2
+  }
+}


### PR DESCRIPTION
## Summary

Settles the joint-continuity open question registered in the parent entry **synthesis-curvature-ptolemy** (`SynthesisCurvaturePtolemy.lean`, conclusion open questions: *"Prove continuity of curvatureSin K in both K and t (joint continuity)"*).

**Result.** `(K, t) ↦ curvatureSin K t` is continuous on all of `ℝ × ℝ`, where
`curvatureSin K t = sin(√K·t)/√K` (K>0), `t` (K=0), `sinh(√(−K)·t)/√(−K)` (K<0).
In particular the spherical / Euclidean / hyperbolic regimes glue together continuously across the Euclidean seam `K = 0`, even though the defining formula switches between `sin` and `sinh` there.

## Method

The two-variable seam line `K = 0` is reduced to a single seam point via the factorization

```
curvatureSin K t = t · curvatureSinc (K · t²)
```

where `curvatureSinc` is the even "curvature sinc" (`sin(√x)/√x` for x>0, `1` at 0, `sinh(√(−x))/√(−x)` for x<0). The reduction uses `√(K·t²) = √K·|t|` and the oddness of `sin`/`sinh`.

Continuity of `curvatureSinc` at the seam: the two one-sided limits both equal `1`, obtained from the slope characterization `HasDerivAt.tendsto_slope` (so `sin'0 = cos 0 = 1` and `sinh'0 = cosh 0 = 1`), glued via `𝓝[<]0 ⊔ 𝓝[>]0 = 𝓝[≠]0` and `continuousAt_iff_punctured_nhds`. Joint continuity of `(K,t) ↦ t·curvatureSinc(K·t²)` then follows from the ring operations.

## Verification

- **0 sorries**, **0 axiom declarations**, **0 structure-encoded assumptions**.
- `#print axioms continuous_curvatureSin` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`).
- Typechecked offline with `lake env lean` (Docker unavailable this session); Mathlib-only imports.
- 247 lines, 10 theorems/lemmas, 2 definitions.

The `curvatureSin` definition is reproduced verbatim from the parent so the continuity development depends only on Mathlib (the parent's full Ptolemy import chain was not built locally this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)