### PR TITLE
audit(gallery): 6 fresh proofs CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24522,6 +24522,42 @@
       "lastAudited": "2026-06-25T21:23:53Z",
       "result": "clean",
       "issues": []
+    },
+    "hermite-legendre-factorial": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:37:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hermite-sawtooth-identity": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:37:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "infinitude-primes-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:37:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "nicomachus-sum-of-cubes-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:37:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "stars-and-bars-weak-compositions-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:37:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "unit-distance-independence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T21:37:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 6 fresh proofs, all CLEAN

Audited 6 genuinely-uncovered fresh proofs (those NOT already covered by open audit PR #30291). Every meta.json claim matches the Lean source. Tracker updated; no integrity issues found.

| Proof | Tier | Verdict |
|-------|------|---------|
| hermite-legendre-factorial | B (transparent) | Mathlib `padicValNat_factorial` = Legendre core; new Hermite refinement proved from gallery's own Hermite identity. Dependency fully disclosed in `assumptions`. ✓ |
| hermite-sawtooth-identity | A/B | Reuses parent `hermite_floor_identity`; companion sawtooth identity ∑{x+k/n}={nx}+(n−1)/2 not in Mathlib. ✓ |
| infinitude-primes-oq-04 | — | Green–Tao recorded **only as a `Prop` (`def GreenTao`), NOT proved**; all 9 theorems are the verified elementary surroundings. `decide` is kernel over ZMod 3 (not `native_decide`). Title qualifier honest. ✓ |
| nicomachus-sum-of-cubes-oq-03 | A | ∑(2k−1)³=n²(2n²−1); real statements, 0 sorry / 0 axiom. ✓ |
| stars-and-bars-weak-compositions-oq-02 | A | `shiftEquiv` bijection + 2 count theorems original; Mathlib inclusion–exclusion disclosed in `assumptions`. ✓ |
| unit-distance-independence-oq-01 | A | χ(ℝ²)≥4 via Moser spindle. Lone `native_decide` grep hit is a **docstring false-positive** (line 22: "no `native_decide`"); real non-3-colorability uses kernel `decide` over Fin 3 (3⁴ cases), not `Lean.ofReduceBool`. ✓ |

### Checks run
- `sorry` / `^axiom ` / `admit` / `True`-stub counts: **0** across all six
- `native_decide`: only the unit-distance docstring mention (verified false-positive)
- Structure-encoded assumptions: none (0 structures/classes in all files)
- Status/badge vs. source: consistent; disclosures in `assumptions` accurate

### Not in this PR
6 of the 12 currently-unaudited proofs (birthday, burnside, cauchy-schwarz, erdos-395, feuerbach, quadratic-gauss-sum) are already covered by open PR #30291 — skipped to avoid duplication.

---
Discovered during autonomous gallery integrity audit.