### PR TITLE
research(abel-ruffini-oq-11): the radical-solvable side — pure equations & their products have solvable Galois groups [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -43,6 +43,7 @@ import Proofs.AbelRuffiniOQ07NotSolvable
 import Proofs.AbelRuffiniOQ07Order6
 import Proofs.AbelRuffiniOQ09
 import Proofs.AbelRuffiniOQ10
+import Proofs.AbelRuffiniOQ11
 import Proofs.AbelRuffiniObstructionOQ06
 import Proofs.AbundantDeficientDvdOQ04
 import Proofs.AbundantMultiplesOQ01

--- a/proofs/Proofs/AbelRuffiniOQ11.lean
+++ b/proofs/Proofs/AbelRuffiniOQ11.lean
@@ -1,0 +1,77 @@
+import Mathlib
+
+/-
+# Abel–Ruffini, open question oq-11: the radical-solvable side
+
+The Abel–Ruffini story has two faces. The *negative* face — the symmetric group
+`Sₙ` is not solvable for `n ≥ 5`, so the general quintic is not solvable by
+radicals — is thoroughly formalized elsewhere in this project (base
+`AbelRuffini.lean`, `AbelRuffiniOQ07` for the concrete `X⁵ − X − 1 ≅ S₅`). The
+*positive* face is comparatively neglected: **why do radicals work for the cases
+they do?**
+
+Galois' answer: an equation is solvable by radicals iff its Galois group is a
+solvable group, and the equations one can actually *write* with radicals — pure
+powers `Xⁿ = a` and finite combinations of them — always have solvable Galois
+groups. Mathlib proves the single-equation facts (`gal_X_pow_sub_C_isSolvable`,
+`gal_X_pow_sub_one_isSolvable`) and an abstract multiset-product closure
+(`gal_prod_isSolvable`), but states neither a directly usable finite-*product*
+form nor the side-by-side dichotomy. This entry supplies both:
+
+* `gal_pow_sub_C_isSolvable`   : every pure equation `Xⁿ = a` has solvable Galois
+  group — radicals always succeed for a single root extraction;
+* `gal_pow_sub_one_isSolvable` : the `n`-th roots of unity `Xⁿ = 1` likewise;
+* `gal_finset_prod_pow_sub_C_isSolvable` : **any finite product
+  `∏ᵢ (X^{nᵢ} − aᵢ)` of pure radical equations has solvable Galois group** — the
+  closure capturing "anything assembled from radicals stays solvable";
+* `abel_ruffini_two_faces` : the dichotomy in one statement — pure radical
+  equations are always solvable, yet `Sₘ` (`m ≥ 5`) is not.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+
+namespace AbelRuffiniOQ11
+
+open Polynomial
+
+variable {F : Type*} [Field F]
+
+/-- **A single pure equation is solvable.** `Xⁿ = a` always has a solvable Galois
+group — extracting one radical never destroys solvability. (Mathlib's
+`gal_X_pow_sub_C_isSolvable`, re-exposed as the base case of the closure below.) -/
+theorem gal_pow_sub_C_isSolvable (n : ℕ) (a : F) :
+    IsSolvable (X ^ n - C a : F[X]).Gal :=
+  gal_X_pow_sub_C_isSolvable n a
+
+/-- **Roots of unity are solvable.** `Xⁿ = 1` has a solvable (indeed abelian)
+Galois group. (Mathlib's `gal_X_pow_sub_one_isSolvable`.) -/
+theorem gal_pow_sub_one_isSolvable (n : ℕ) :
+    IsSolvable (X ^ n - 1 : F[X]).Gal :=
+  gal_X_pow_sub_one_isSolvable n
+
+/-- **The radical-solvable closure.** Any finite product `∏ᵢ (X^{nᵢ} − aᵢ)` of
+pure radical equations has a solvable Galois group. This is the constructive
+counterpart to the symmetric-group obstruction: every polynomial assembled from
+root extractions stays solvable. Proved by induction over the index set, using
+`gal_mul_isSolvable` to glue one factor at a time onto a solvable product. -/
+theorem gal_finset_prod_pow_sub_C_isSolvable {ι : Type*} (s : Finset ι)
+    (n : ι → ℕ) (a : ι → F) :
+    IsSolvable (∏ i ∈ s, (X ^ (n i) - C (a i)) : F[X]).Gal := by
+  induction s using Finset.cons_induction with
+  | empty => simpa using (gal_one_isSolvable (F := F))
+  | cons i s hi ih =>
+      rw [Finset.prod_cons]
+      exact gal_mul_isSolvable (gal_X_pow_sub_C_isSolvable (n i) (a i)) ih
+
+/-- **The two faces of Abel–Ruffini, side by side.** Pure radical equations
+`Xⁿ = a` always have solvable Galois groups (radicals succeed), yet the symmetric
+group `Sₘ` is not solvable for `m ≥ 5` (the obstruction that makes the general
+quintic unsolvable). The whole theory lives in the gap between these two facts. -/
+theorem abel_ruffini_two_faces :
+    (∀ (n : ℕ) (a : F), IsSolvable (X ^ n - C a : F[X]).Gal) ∧
+    (∀ m : ℕ, 5 ≤ m → ¬ IsSolvable (Equiv.Perm (Fin m))) :=
+  ⟨fun n a => gal_X_pow_sub_C_isSolvable n a,
+   fun m hm => Equiv.Perm.not_solvable (Fin m) (by rw [Cardinal.mk_fin]; exact_mod_cast hm)⟩
+
+end AbelRuffiniOQ11

--- a/research/problems/abel-ruffini-oq-11/knowledge.md
+++ b/research/problems/abel-ruffini-oq-11/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge: abel-ruffini-oq-11
+
+## Summary
+
+The radical-solvable (positive) side of Abel–Ruffini: equations built from pure
+root extractions always have solvable Galois groups.
+
+## What is formalized (researcher-9, 2026-06-25)
+
+`proofs/Proofs/AbelRuffiniOQ11.lean`, namespace `AbelRuffiniOQ11`, 0 ax / 0 sorry:
+
+| Theorem | Statement |
+|---|---|
+| `gal_pow_sub_C_isSolvable` | `IsSolvable (Xⁿ − C a).Gal` |
+| `gal_pow_sub_one_isSolvable` | `IsSolvable (Xⁿ − 1).Gal` |
+| `gal_finset_prod_pow_sub_C_isSolvable` | `IsSolvable (∏ᵢ∈s (X^{nᵢ} − C aᵢ)).Gal` |
+| `abel_ruffini_two_faces` | dichotomy: pure eqns solvable ∧ Sₘ (m≥5) not |
+
+## Key Mathlib facts
+
+- `gal_X_pow_sub_C_isSolvable (n) (a) : IsSolvable (X^n - C a).Gal`
+- `gal_X_pow_sub_one_isSolvable (n) : IsSolvable (X^n - 1).Gal`
+- `gal_mul_isSolvable : IsSolvable p.Gal → IsSolvable q.Gal → IsSolvable (p*q).Gal`
+- `gal_prod_isSolvable {s : Multiset F[X]} : (∀ p ∈ s, IsSolvable (Gal p)) → IsSolvable s.prod.Gal`
+- `Equiv.Perm.not_solvable (X) (5 ≤ #X) : ¬IsSolvable (Equiv.Perm X)`
+
+## The new content
+
+`gal_finset_prod_pow_sub_C_isSolvable`: Mathlib only gives the single equation
+and the abstract multiset product. The indexed finite-product form
+`∏_{i∈s}(X^{nᵢ} − aᵢ)` is the directly usable "closure" statement. Proof:
+`Finset.cons_induction` — `empty` ⇒ `∏ = 1`, `simpa using gal_one_isSolvable`;
+`cons` ⇒ `Finset.prod_cons` + `gal_mul_isSolvable (gal_X_pow_sub_C_isSolvable …) ih`.
+No multiset bridge needed (cons_induction avoids the Finset→Multiset plumbing).
+
+## Coverage gap confirmed
+
+`grep` over `Proofs/AbelRuffini*.lean` shows NO file referenced the positive
+lemmas. The base `AbelRuffini.lean` has `symmetric_group_not_solvable`,
+`s5/s6_not_solvable`, `s0/s1_solvable`, `galois_bridge`, `exists_quintic`,
+`not_solvable_by_rad_of_not_solvable_gal` — all negative/criterion side.
+
+## Approaches Tried
+
+- Finset→Multiset bridge for the product: avoided in favor of `cons_induction`,
+  which is cleaner and needs no `Finset.prod_eq_multiset_prod`.

--- a/research/problems/abel-ruffini-oq-11/state.md
+++ b/research/problems/abel-ruffini-oq-11/state.md
@@ -1,0 +1,40 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Iteration**: 1
+**Status**: in-progress
+
+## Current Focus
+
+Empty stub. The Abel–Ruffini *negative* face (Sₙ unsolvable, concrete unsolvable
+quintic) is already heavily formalized (base `AbelRuffini.lean`, `AbelRuffiniOQ07`
+for `X⁵ − X − 1 ≅ S₅`). Chose the under-covered **positive / radical-solvable
+side** — why radicals succeed for the cases they do (researcher-9).
+
+## Delivered (PR pending)
+
+`proofs/Proofs/AbelRuffiniOQ11.lean` — 4 theorems, 0 axioms, 0 sorries
+(typechecked `lake env lean`, Docker down; `#print axioms` = only
+propext/Classical.choice/Quot.sound):
+
+- `gal_finset_prod_pow_sub_C_isSolvable` (**new**): any finite product
+  `∏ᵢ(X^{nᵢ} − aᵢ)` of pure radical equations has solvable Galois group, by
+  `Finset.cons_induction` + `gal_mul_isSolvable`. Mathlib has only the single
+  equation and an abstract multiset product, not this indexed finite-product form.
+- `gal_pow_sub_C_isSolvable` / `gal_pow_sub_one_isSolvable`: the single
+  pure-equation facts (Xⁿ=a, Xⁿ=1), re-exposed as the radical-solvable atoms —
+  a positive direction no existing project AbelRuffini file had recorded.
+- `abel_ruffini_two_faces`: the dichotomy in one statement.
+
+## Note
+
+No existing AbelRuffini file referenced the positive Mathlib lemmas
+(`gal_X_pow_sub_C_isSolvable`, etc.) — genuine gap. The base `AbelRuffini.lean`
+already has the n≥5 obstruction and the radical criterion (so the *negative* side
+is saturated).
+
+## Next Action
+
+Follow-up: cyclotomic extensions are abelian (sharper than 'solvable'); or
+solvable-by-radicals towers (`solvableByRad`) as an explicit subalgebra closure.

--- a/src/data/proofs/abel-ruffini-oq-11/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-11/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-single",
+    "proofId": "abel-ruffini-oq-11",
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "theorem",
+    "title": "Pure Equations Are Solvable",
+    "content": "Every pure equation $X^n = a$ has a solvable Galois group (`gal_pow_sub_C_isSolvable`), as do the $n$-th roots of unity $X^n = 1$ (`gal_pow_sub_one_isSolvable`). These are the atoms of the radical-solvable side: a single root extraction never destroys solvability. By Galois' criterion this is exactly why $\\sqrt[n]{a}$ is, tautologically, expressible by radicals.",
+    "mathContext": "$\\mathrm{IsSolvable}((X^n - a).\\mathrm{Gal})$ and $\\mathrm{IsSolvable}((X^n - 1).\\mathrm{Gal})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Galois group", "Solvable group", "Roots of unity", "Radical extension"]
+  },
+  {
+    "id": "ann-closure",
+    "proofId": "abel-ruffini-oq-11",
+    "range": { "startLine": 58, "endLine": 69 },
+    "type": "theorem",
+    "title": "The Radical-Solvable Closure (new)",
+    "content": "**Any finite product $\\prod_{i\\in s}(X^{n_i} - a_i)$ of pure radical equations has a solvable Galois group.** This is the constructive counterpart to the symmetric-group obstruction — everything one can assemble from root extractions stays solvable. Proved by `Finset.cons_induction`: the empty product is $1$ (solvable), and each new factor $X^{n_i} - a_i$ is glued onto the solvable product with `gal_mul_isSolvable`. Mathlib gives only the single-equation fact and an abstract multiset product; this directly usable indexed finite-product form is new.",
+    "mathContext": "$\\mathrm{IsSolvable}\\bigl((\\textstyle\\prod_{i\\in s}(X^{n_i} - a_i)).\\mathrm{Gal}\\bigr)$.",
+    "significance": "key",
+    "relatedConcepts": ["Galois group", "Solvable group", "Finite product", "Closure property", "Induction"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "abel-ruffini-oq-11",
+    "range": { "startLine": 71, "endLine": 76 },
+    "type": "theorem",
+    "title": "The Two Faces of Abel–Ruffini",
+    "content": "The dichotomy in one statement: pure radical equations $X^n = a$ always have solvable Galois groups (radicals succeed), yet $S_m$ is not solvable for $m \\ge 5$ (the obstruction making the general quintic unsolvable). The entire theory of solvability by radicals lives in the gap between these two facts.",
+    "mathContext": "$(\\forall n\\,a,\\ \\mathrm{IsSolvable}((X^n - a).\\mathrm{Gal})) \\wedge (\\forall m \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_m))$.",
+    "significance": "key",
+    "relatedConcepts": ["Abel–Ruffini theorem", "Solvability by radicals", "Symmetric group", "Dichotomy"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-11/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-11/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "abel-ruffini-oq-11",
+  "title": "The Radical-Solvable Side of Abel–Ruffini: Pure Equations and Their Products Have Solvable Galois Groups",
+  "slug": "abel-ruffini-oq-11",
+  "description": "The constructive counterpart to the Abel–Ruffini obstruction. The negative side (Sₙ unsolvable for n ≥ 5, so the general quintic is not solvable by radicals) is heavily formalized in this project; this entry formalizes the positive side — why radicals succeed for the cases they do. By Galois' criterion, solvability by radicals corresponds to a solvable Galois group, and the equations one can actually write with radicals always have solvable groups: gal_pow_sub_C_isSolvable (every pure equation Xⁿ = a), gal_pow_sub_one_isSolvable (the n-th roots of unity Xⁿ = 1), and the genuinely new gal_finset_prod_pow_sub_C_isSolvable — ANY finite product ∏ᵢ(X^{nᵢ} − aᵢ) of pure radical equations has a solvable Galois group, the closure capturing 'anything assembled from radicals stays solvable' (Mathlib states only the single-equation case and an abstract multiset product, not a usable finite-product form). The dichotomy abel_ruffini_two_faces packages both faces in one statement: pure radical equations are always solvable, yet Sₘ (m ≥ 5) is not. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Galois (1830s); Abel (1824), Ruffini (1799); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem",
+    "date": "1830",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "solvability",
+      "radicals",
+      "abel-ruffini",
+      "solvable-group",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/AbelRuffiniOQ11.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "gal_X_pow_sub_C_isSolvable",
+        "description": "The Galois group of Xⁿ − C a is solvable. The single pure-equation fact and the base ingredient of the finite-product closure.",
+        "module": "Mathlib.FieldTheory.AbelRuffini"
+      },
+      {
+        "theorem": "gal_X_pow_sub_one_isSolvable",
+        "description": "The Galois group of Xⁿ − 1 (roots of unity) is solvable.",
+        "module": "Mathlib.FieldTheory.AbelRuffini"
+      },
+      {
+        "theorem": "gal_mul_isSolvable",
+        "description": "If p.Gal and q.Gal are solvable then (p·q).Gal is solvable. Glues one factor at a time in the finite-product induction.",
+        "module": "Mathlib.FieldTheory.AbelRuffini"
+      },
+      {
+        "theorem": "Equiv.Perm.not_solvable",
+        "description": "Sₘ is not solvable when 5 ≤ #X. Supplies the negative face of the dichotomy (via Cardinal.mk_fin).",
+        "module": "Mathlib.GroupTheory.Solvable"
+      }
+    ],
+    "originalContributions": [
+      "gal_finset_prod_pow_sub_C_isSolvable: any finite product ∏_{i ∈ s} (X^{n i} − C (a i)) of pure radical equations has a solvable Galois group — the constructive closure 'everything built from radicals stays solvable', proved by Finset.cons_induction gluing factors with gal_mul_isSolvable. Mathlib provides only the single equation gal_X_pow_sub_C_isSolvable and an abstract multiset product gal_prod_isSolvable, not this directly usable indexed finite-product form",
+      "abel_ruffini_two_faces: the Abel–Ruffini dichotomy in one statement — (∀ n a, IsSolvable (Xⁿ − C a).Gal) ∧ (∀ m ≥ 5, ¬ IsSolvable (Sₘ)) — placing the radical-solvable side and the symmetric-group obstruction side by side; the whole theory lives in the gap between them",
+      "gal_pow_sub_C_isSolvable / gal_pow_sub_one_isSolvable: the single pure-equation facts re-exposed as the named building blocks of the radical-solvable side, a positive direction no existing AbelRuffini file in the project had recorded"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 77,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on gal_finset_prod_pow_sub_C_isSolvable and abel_ruffini_two_faces reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses. Imports only Mathlib.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "single-equations",
+      "title": "Single Pure Equations",
+      "startLine": 42,
+      "endLine": 56,
+      "summary": "gal_pow_sub_C_isSolvable: Xⁿ = a has solvable Galois group (one root extraction never destroys solvability). gal_pow_sub_one_isSolvable: the n-th roots of unity Xⁿ = 1 likewise (abelian, hence solvable)."
+    },
+    {
+      "id": "finite-product-closure",
+      "title": "The Radical-Solvable Closure",
+      "startLine": 57,
+      "endLine": 69,
+      "summary": "gal_finset_prod_pow_sub_C_isSolvable: any finite product ∏ᵢ(X^{nᵢ} − aᵢ) of pure radical equations has solvable Galois group, by Finset.cons_induction — the empty product is 1 (solvable), and each new factor is glued on with gal_mul_isSolvable. The constructive counterpart to the symmetric-group obstruction."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Two Faces, Side by Side",
+      "startLine": 71,
+      "endLine": 76,
+      "summary": "abel_ruffini_two_faces: pure radical equations Xⁿ = a always have solvable Galois groups, yet Sₘ (m ≥ 5) is not solvable — the dichotomy underlying the unsolvability of the general quintic, in a single statement."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The **constructive counterpart** to the Abel–Ruffini obstruction. The negative side (Sₙ unsolvable for n ≥ 5; the concrete unsolvable quintic) is heavily formalized in this project; this entry adds the under-covered **positive side** — why radicals succeed for the cases they do. A `grep` over `Proofs/AbelRuffini*.lean` confirms **no existing file referenced the positive Mathlib lemmas**. **4 theorems, 0 axioms, 0 sorries.**

- **`gal_finset_prod_pow_sub_C_isSolvable`** (new): any finite product $\prod_{i\in s}(X^{n_i} - a_i)$ of pure radical equations has a **solvable Galois group** — the closure 'everything assembled from radicals stays solvable'. Proved by `Finset.cons_induction` gluing factors with `gal_mul_isSolvable`. Mathlib provides only the single equation (`gal_X_pow_sub_C_isSolvable`) and an abstract multiset product (`gal_prod_isSolvable`), **not** this directly usable indexed finite-product form.
- **`gal_pow_sub_C_isSolvable` / `gal_pow_sub_one_isSolvable`**: $X^n = a$ and $X^n = 1$ have solvable Galois groups — the radical-solvable atoms.
- **`abel_ruffini_two_faces`**: the dichotomy in one statement — $(\forall n\,a,\ \mathrm{IsSolvable}((X^n-a).\mathrm{Gal})) \wedge (\forall m\ge 5,\ \neg\,\mathrm{IsSolvable}(S_m))$.

## Verification

- Typechecked via `lake env lean Proofs/AbelRuffiniOQ11.lean` (exit 0; Docker unavailable this session).
- `#print axioms` on `gal_finset_prod_pow_sub_C_isSolvable` and `abel_ruffini_two_faces` = only `propext, Classical.choice, Quot.sound` → **0 counted axioms**. No `native_decide`. Status `verified`, badge `original`.

Imports only Mathlib (self-contained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)