### PR TITLE
research(euler-polyhedral-oq-01-oq-03): girth-6 planar graphs are 3-colorable [verified, 0 sorry/0 axiom]

### DIFF
--- a/proofs/Proofs/EulerPolyhedralOQ01OQ03.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ01OQ03.lean
@@ -1,0 +1,241 @@
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Finite
+import Mathlib.Combinatorics.SimpleGraph.DegreeSum
+import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Tactic
+
+/-
+# Girth-6 Planar Graphs are 3-Colorable (OQ-03)
+
+## The Open Question
+
+The parent entry `euler-polyhedral-oq-01` lists as its third open question:
+
+> *Girth-6 planar graphs (E ≤ 3V/2 − 3): are they 3-colorable? (Grötzsch's
+> theorem, not formalized)*
+
+The **full** Grötzsch theorem — every *triangle-free* (girth ≥ 4) planar graph
+is 3-colorable — is genuinely deep and requires discharging-style arguments;
+it remains unformalized in Lean 4.  The literal question posed, however,
+restricts to **girth ≥ 6**, and that weak form has a clean, fully
+elementary affirmative answer via **2-degeneracy**, which we formalize here.
+
+## The Mathematics
+
+A planar graph `G` with girth ≥ 6 satisfies the face–edge double count
+`6F ≤ 2E`, which combined with Euler's formula gives `2E ≤ 3V − 6`
+(this is `edge_bound_girth6` in the parent file).  The key point is that this
+bound is **hereditary**: every subgraph induced on a vertex subset `W` is still
+planar with girth ≥ 6, so it too has few edges.  Counting neighbours *inside*
+`W`, every nonempty `W` satisfies
+
+  `∑_{v ∈ W} dᵥ(W) = 2·e(W) < 3·|W|`
+
+(the strict `< 3|W|` form absorbs both the cyclic case `2e ≤ 3|W|−6` and the
+forest case `2e ≤ 2|W|−2`).  Averaging then yields a vertex `v ∈ W` with at
+most `2` neighbours inside `W`.  This is exactly the statement that `G` is
+**2-degenerate**, and a 2-degenerate graph is 3-colorable by greedy coloring.
+
+## What This File Contributes
+
+The parent file `EulerPolyhedralOQ01.lean` records the colouring step only
+*schematically* (`six_colorable_from_degeneracy` reduces to `5 + 1 = 6`).  The
+core contribution here is a **genuine** `SimpleGraph.Colorable` proof of the
+greedy-coloring / degeneracy theorem:
+
+* `proper_coloring_on_finset` — greedy coloring by strong induction on a
+  vertex subset (the heart of the argument).
+* `colorable_of_degenerate` — **`k`-degenerate ⟹ `G.Colorable (k+1)`**, a real
+  `SimpleGraph.Colorable` statement (not an encoded numeral).
+* `exists_low_degree_in_subset` — the averaging lemma turning an edge/degree
+  bound into a low-degree witness.
+* `girth6_planar_three_colorable` — **girth-6 planar ⟹ `G.Colorable 3`**, the
+  affirmative answer to the open question (with the hereditary edge bound made
+  explicit as the precise content of "planar with girth ≥ 6").
+* `girth6_exists_low_degree_vertex` — the global degeneracy witness
+  (`∃ v, G.degree v ≤ 2`) proved from `2E ≤ 3V − 6` via the handshaking lemma,
+  mirroring the parent's `exists_low_degree_vertex` (degree ≤ 5).
+
+Everything is `sorry`-free and `axiom`-free.
+
+## References
+- Grötzsch (1959). "Ein Dreifarbensatz für dreikreisfreie Netze auf der Kugel."
+- Diestel, "Graph Theory" (5th ed.), §5.1 (degeneracy and greedy coloring),
+  §6.5 (Grötzsch's theorem).
+- Parent entry: `euler-polyhedral-oq-01` (`EulerPolyhedralOQ01.lean`).
+-/
+
+set_option linter.unusedVariables false
+set_option linter.unusedSectionVars false
+
+namespace EulerPolyhedralGirth6
+
+open SimpleGraph Finset
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+-- ============================================================
+-- PART 1: Averaging — a low-degree witness inside any subset
+-- ============================================================
+
+/-- The number of neighbours of `v` lying inside the vertex subset `W`. -/
+def degIn (G : SimpleGraph V) [DecidableRel G.Adj] (W : Finset V) (v : V) : ℕ :=
+  (W.filter (fun w => G.Adj v w)).card
+
+/-- **Averaging.**  If the total number of in-subset incidences is strictly less
+    than `(k+1)·|W|`, some vertex of `W` has at most `k` neighbours inside `W`.
+
+    This is the engine that converts the (hereditary) edge bound of a girth-6
+    planar graph into a degeneracy witness: with `∑ degIn < 3|W|` and `k = 2`
+    we obtain a vertex of in-degree ≤ 2. -/
+theorem exists_low_degree_in_subset (G : SimpleGraph V) [DecidableRel G.Adj]
+    (W : Finset V) (hW : W.Nonempty) (k : ℕ)
+    (hsum : ∑ v ∈ W, degIn G W v < (k + 1) * W.card) :
+    ∃ v ∈ W, degIn G W v ≤ k := by
+  by_contra h
+  push_neg at h
+  -- Every vertex of `W` has in-degree ≥ k+1, so the sum is ≥ (k+1)·|W|.
+  have hlb : W.card • (k + 1) ≤ ∑ v ∈ W, degIn G W v :=
+    Finset.card_nsmul_le_sum W _ (k + 1) (fun v hv => h v hv)
+  simp only [smul_eq_mul] at hlb
+  -- Contradiction with the strict upper bound.
+  have : (k + 1) * W.card ≤ ∑ v ∈ W, degIn G W v := by
+    rw [mul_comm]; exact hlb
+  omega
+
+-- ============================================================
+-- PART 2: Greedy coloring — the degeneracy theorem
+-- ============================================================
+
+/-- **Greedy coloring on a subset.**  If `G` is `k`-degenerate — i.e. every
+    nonempty vertex subset has a vertex with at most `k` neighbours inside that
+    subset — then for *every* subset `W` there is a `(k+1)`-coloring of `V` that
+    is proper on `W`.
+
+    The proof is the classical greedy argument, by strong induction on `|W|`:
+    delete a low-degree vertex `v`, colour the rest by induction, then give `v`
+    one of the `k+1` colours avoided by its (≤ `k`) coloured neighbours. -/
+theorem proper_coloring_on_finset (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ)
+    (hdeg : ∀ W : Finset V, W.Nonempty → ∃ v ∈ W, degIn G W v ≤ k) :
+    ∀ W : Finset V, ∃ c : V → Fin (k + 1),
+      ∀ u ∈ W, ∀ w ∈ W, G.Adj u w → c u ≠ c w := by
+  intro W
+  induction W using Finset.strongInductionOn with
+  | _ W IH =>
+    rcases W.eq_empty_or_nonempty with hW | hW
+    · -- Empty subset: any constant colouring is vacuously proper.
+      exact ⟨fun _ => 0, by simp [hW]⟩
+    · -- Pick a low-degree vertex `v` of `W`.
+      obtain ⟨v, hvW, hvdeg⟩ := hdeg W hW
+      have hsub : W.erase v ⊂ W := Finset.erase_ssubset hvW
+      obtain ⟨c', hc'⟩ := IH (W.erase v) hsub
+      -- Colours used by the in-`W` neighbours of `v`.
+      set Nv := W.filter (fun w => G.Adj v w) with hNv
+      set used := Nv.image c' with hused
+      have hused_card : used.card ≤ k := le_trans (Finset.card_image_le) hvdeg
+      -- A free colour exists, since `|used| ≤ k < k + 1 = |Fin (k+1)|`.
+      have hfree : ∃ col : Fin (k + 1), col ∉ used := by
+        by_contra hc
+        push_neg at hc
+        have hsubset : (Finset.univ : Finset (Fin (k + 1))) ⊆ used :=
+          fun x _ => hc x
+        have := Finset.card_le_card hsubset
+        simp only [Finset.card_univ, Fintype.card_fin] at this
+        omega
+      obtain ⟨col, hcol⟩ := hfree
+      refine ⟨Function.update c' v col, ?_⟩
+      intro u hu w hw huw
+      -- Case analysis on whether `u`, `w` equal the freshly coloured vertex `v`.
+      by_cases huv : u = v
+      · subst huv
+        -- u = v.  Then w ≠ v (Adj is irreflexive) and w is a coloured neighbour.
+        have hwv : w ≠ u := (G.ne_of_adj huw).symm
+        have hwNv : w ∈ Nv := by
+          rw [hNv]; exact Finset.mem_filter.mpr ⟨hw, huw⟩
+        have : c' w ∈ used := by rw [hused]; exact Finset.mem_image_of_mem c' hwNv
+        rw [Function.update_self, Function.update_of_ne hwv]
+        intro hbad; exact hcol (hbad ▸ this)
+      · by_cases hwv : w = v
+        · subst hwv
+          -- w = v.  Then u ≠ v and u is a coloured neighbour (Adj is symmetric).
+          have huNv : u ∈ Nv := by
+            rw [hNv]; exact Finset.mem_filter.mpr ⟨hu, G.adj_symm huw⟩
+          have : c' u ∈ used := by rw [hused]; exact Finset.mem_image_of_mem c' huNv
+          rw [Function.update_self, Function.update_of_ne huv]
+          intro hbad; exact hcol (hbad ▸ this)
+        · -- Neither is `v`: both lie in `W.erase v`, use the inductive colouring.
+          rw [Function.update_of_ne huv, Function.update_of_ne hwv]
+          exact hc' u (Finset.mem_erase.mpr ⟨huv, hu⟩) w
+            (Finset.mem_erase.mpr ⟨hwv, hw⟩) huw
+
+/-- **Degeneracy ⟹ colorability.**  A `k`-degenerate finite graph is
+    `(k+1)`-colorable.  This is a genuine `SimpleGraph.Colorable` statement,
+    obtained by specialising `proper_coloring_on_finset` to the full vertex set
+    and packaging the resulting colouring as a `SimpleGraph.Coloring`. -/
+theorem colorable_of_degenerate (G : SimpleGraph V) [DecidableRel G.Adj] (k : ℕ)
+    (hdeg : ∀ W : Finset V, W.Nonempty → ∃ v ∈ W, degIn G W v ≤ k) :
+    G.Colorable (k + 1) := by
+  obtain ⟨c, hc⟩ := proper_coloring_on_finset G k hdeg Finset.univ
+  exact ⟨Coloring.mk c (fun {u w} huw =>
+    hc u (Finset.mem_univ u) w (Finset.mem_univ w) huw)⟩
+
+-- ============================================================
+-- PART 3: Application — girth-6 planar graphs are 3-colorable
+-- ============================================================
+
+/-- **Main result (open question OQ-03).**  A planar graph of girth ≥ 6 is
+    3-colorable.
+
+    The hypothesis `h_hereditary` is exactly the (hereditary) content of
+    "planar with girth ≥ 6": every nonempty induced subgraph on `W` has
+    `2·e(W) = ∑_{v∈W} dᵥ(W) < 3|W|`, the strict average-degree-below-3 bound
+    that follows from `6F ≤ 2E` + Euler's formula on each subgraph (cyclic case
+    `2e ≤ 3|W| − 6`, forest case `2e ≤ 2|W| − 2`, both `< 3|W|`).
+
+    From it, `exists_low_degree_in_subset` (with `k = 2`) shows `G` is
+    2-degenerate, and `colorable_of_degenerate` upgrades that to a real
+    3-colouring. -/
+theorem girth6_planar_three_colorable (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h_hereditary : ∀ W : Finset V, W.Nonempty →
+      ∑ v ∈ W, degIn G W v < 3 * W.card) :
+    G.Colorable 3 := by
+  have hdeg : ∀ W : Finset V, W.Nonempty → ∃ v ∈ W, degIn G W v ≤ 2 := by
+    intro W hW
+    exact exists_low_degree_in_subset G W hW 2 (by
+      have := h_hereditary W hW
+      simpa using this)
+  -- `colorable_of_degenerate` with `k = 2` gives `Colorable (2 + 1) = Colorable 3`.
+  exact colorable_of_degenerate G 2 hdeg
+
+-- ============================================================
+-- PART 4: The global degeneracy witness (mirrors the parent)
+-- ============================================================
+
+/-- **Global degeneracy witness.**  In a planar graph of girth ≥ 6 (edge bound
+    `2E ≤ 3V − 6`) there is a vertex of degree ≤ 2.
+
+    This mirrors the parent file's `exists_low_degree_vertex` (which gives a
+    degree-≤ 5 vertex from the *general* planar bound `E ≤ 3V − 6`) and is
+    proved the same way: if every degree were ≥ 3, the handshaking lemma would
+    force `2E ≥ 3V`, contradicting `2E ≤ 3V − 6`. -/
+theorem girth6_exists_low_degree_vertex (G : SimpleGraph V) [DecidableRel G.Adj]
+    (hV : 3 ≤ Fintype.card V)
+    (h_girth6 : 2 * (G.edgeFinset.card : ℤ) ≤ 3 * Fintype.card V - 6) :
+    ∃ v : V, G.degree v ≤ 2 := by
+  by_contra h
+  push_neg at h
+  -- Every vertex has degree ≥ 3.
+  have hsum_lower : 3 * Fintype.card V ≤ ∑ v, G.degree v := by
+    calc 3 * Fintype.card V
+        = ∑ _v : V, 3 := by
+          rw [Finset.sum_const, Finset.card_univ, smul_eq_mul, mul_comm]
+      _ ≤ ∑ v, G.degree v := Finset.sum_le_sum (fun v _ => h v)
+  have hshake := G.sum_degrees_eq_twice_card_edges
+  -- So 3V ≤ 2E, contradicting 2E ≤ 3V − 6.
+  have hcast : (3 : ℤ) * Fintype.card V ≤ 2 * G.edgeFinset.card := by
+    have : (3 * Fintype.card V : ℤ) ≤ ((∑ v, G.degree v : ℕ) : ℤ) := by exact_mod_cast hsum_lower
+    rw [hshake] at this; push_cast at this ⊢; linarith
+  linarith
+
+end EulerPolyhedralGirth6

--- a/src/data/proofs/euler-polyhedral-oq-01-oq-03/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-01-oq-03/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "euler-polyhedral-oq-01-oq-03",
+  "title": "Girth-6 Planar Graphs are 3-Colorable: A Real Degeneracy-Coloring Theorem",
+  "slug": "euler-polyhedral-oq-01-oq-03",
+  "description": "An affirmative answer to the open question (from euler-polyhedral-oq-01) of whether girth-6 planar graphs are 3-colorable. The file proves a genuine SimpleGraph.Colorable degeneracy-coloring theorem — k-degenerate implies (k+1)-colorable via greedy coloring by strong induction on vertex subsets — and applies it with k = 2 to girth-6 planar graphs, whose hereditary edge bound (2·e(W) < 3|W| on every subgraph) makes them 2-degenerate.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gr%C3%B6tzsch%27s_theorem",
+    "date": "Classical results (Grötzsch 1959, greedy coloring); formalized 2026",
+    "status": "verified",
+    "tags": [
+      "graph-theory",
+      "planar-graphs",
+      "graph-coloring",
+      "chromatic-number",
+      "degeneracy",
+      "greedy-coloring",
+      "girth",
+      "grotzsch-theorem",
+      "three-colorability"
+    ],
+    "proofRepoPath": "Proofs/EulerPolyhedralOQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean's foundational axioms (propext, Classical.choice, Quot.sound). #print axioms confirms no sorryAx and no Lean.ofReduceBool. The main applied theorem girth6_planar_three_colorable takes the hereditary edge bound (∑_{v∈W} dᵥ(W) < 3|W| for every nonempty subset W) as an explicit hypothesis — this is a function argument expressing the precise content of 'planar with girth ≥ 6', not a structure-encoded assumption.",
+    "originalContributions": [
+      "proper_coloring_on_finset: greedy coloring of a vertex subset by strong induction on |W| — delete a low in-degree vertex, color the rest, then choose one of the k+1 colors avoided by its ≤ k colored neighbors.",
+      "colorable_of_degenerate: a genuine SimpleGraph.Colorable proof that every k-degenerate finite graph is (k+1)-colorable, packaged as a real SimpleGraph.Coloring. This upgrades the parent file's schematic six_colorable_from_degeneracy (which reduced to the numeral identity 5 + 1 = 6) to an actual colorability theorem.",
+      "exists_low_degree_in_subset: the averaging engine (∑ degIn < (k+1)|W| ⟹ some vertex has ≤ k in-subset neighbors), via Finset.card_nsmul_le_sum.",
+      "girth6_planar_three_colorable: the affirmative answer to OQ-03 — a girth-6 planar graph is G.Colorable 3 — with the hereditary 2-degeneracy hypothesis exhibited as the explicit content of girth-6 planarity.",
+      "girth6_exists_low_degree_vertex: the global degeneracy witness ∃ v, G.degree v ≤ 2 from 2E ≤ 3V − 6 via Mathlib's handshaking lemma, mirroring the parent's degree-≤ 5 witness for general planar graphs."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Grötzsch's theorem (1959) states that every triangle-free (girth ≥ 4) planar graph is 3-colorable. Its proof is genuinely deep, using discharging-style arguments, and has not been formalized in Lean 4. The parent entry euler-polyhedral-oq-01 raised, as its third open question, the literal sub-case 'are girth-6 planar graphs 3-colorable?'. That weak form does not need Grötzsch's machinery: a planar graph with girth ≥ 6 has so few edges (2E ≤ 3V − 6) that it is 2-degenerate, and 2-degenerate graphs are 3-colorable by the classical greedy algorithm of Szekeres–Wilf type. This file formalizes that elementary affirmative answer with a fully verified, axiom-free greedy-coloring engine.",
+    "mathematicalSignificance": "The contribution is methodological as much as mathematical: the parent file proved every numeric face of the degeneracy story (edge bounds, low-degree witnesses, the handshaking lemma) but stopped short of an actual SimpleGraph.Colorable conclusion, encoding '5-degenerate ⟹ 6-colorable' as the numeral identity 5 + 1 = 6. Here the colorability step is real — colorable_of_degenerate builds an honest SimpleGraph.Coloring by greedy induction — so the gallery now has a reusable, genuine k-degenerate ⟹ (k+1)-colorable theorem, of which 3-colorability of girth-6 planar graphs is one corollary.",
+    "keyInsight": "Degeneracy is hereditary and is exactly what greedy coloring consumes. Phrasing the planarity hypothesis as the per-subset incidence bound ∑_{v∈W} dᵥ(W) < 3|W| (which both the cyclic case 2e ≤ 3|W|−6 and the forest case 2e ≤ 2|W|−2 satisfy) sidesteps any need for an induced-subgraph handshaking lemma: averaging directly yields a vertex of in-degree ≤ 2 in every subset, which is precisely 2-degeneracy."
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-polyhedral-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. This file answers its third open question (girth-6 planar 3-colorability) and replaces the parent's schematic six_colorable_from_degeneracy with a genuine SimpleGraph.Colorable degeneracy theorem."
+    },
+    {
+      "targetId": "euler-polyhedral-formula",
+      "relationship": "depends-on",
+      "description": "Uses the girth-6 edge bound 2E ≤ 3V − 6 derived (in the parent line) from Euler's formula V − E + F = 2 and the face count 6F ≤ 2E."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Herbert Grötzsch"],
+      "title": "Ein Dreifarbensatz für dreikreisfreie Netze auf der Kugel",
+      "year": 1959,
+      "venue": "Wiss. Z. Martin-Luther-Univ. Halle-Wittenberg Math.-Natur. Reihe",
+      "volume": "8",
+      "pages": "109–120",
+      "note": "Original triangle-free (girth ≥ 4) planar 3-colorability theorem. The girth-6 sub-case formalized here is the elementary, degeneracy-based fragment."
+    },
+    {
+      "authors": ["George Szekeres", "Herbert S. Wilf"],
+      "title": "An inequality for the chromatic number of a graph",
+      "year": 1968,
+      "venue": "Journal of Combinatorial Theory",
+      "volume": "4",
+      "pages": "1–3",
+      "note": "Degeneracy (coloring number) bound χ(G) ≤ 1 + degeneracy(G), the principle behind colorable_of_degenerate."
+    },
+    {
+      "authors": ["Reinhard Diestel"],
+      "title": "Graph Theory (5th ed.)",
+      "year": 2017,
+      "venue": "Springer GTM 173",
+      "note": "§5.1 (greedy coloring and degeneracy), §6.5 (Grötzsch's theorem and high-girth planar coloring)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Combinatorics.SimpleGraph.Finite",
+      "Mathlib.Combinatorics.SimpleGraph.DegreeSum",
+      "Mathlib.Combinatorics.SimpleGraph.Coloring",
+      "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+    ],
+    "namespace": "EulerPolyhedralGirth6",
+    "lineCount": 241,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/EulerPolyhedralOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 77,
+      "summary": "Five Mathlib imports (SimpleGraph Basic/Finite/DegreeSum/Coloring plus the ordered-big-operators file for the averaging lemma) and Mathlib.Tactic. The docstring distinguishes the full Grötzsch theorem (girth ≥ 4, unformalized) from the girth ≥ 6 sub-case answered here, and explains the 2-degeneracy strategy. Namespace EulerPolyhedralGirth6 with variables {V} [Fintype V] [DecidableEq V].",
+      "mathContext": "Establishes the SimpleGraph + Finset + ordered-monoid infrastructure. No mathematical content of its own."
+    },
+    {
+      "id": "averaging",
+      "title": "Part 1 — Averaging: a low-degree witness inside any subset",
+      "startLine": 79,
+      "endLine": 106,
+      "summary": "Defines degIn G W v = (W.filter (G.Adj v)).card, the number of neighbors of v inside the subset W, and proves exists_low_degree_in_subset: if ∑_{v∈W} degIn G W v < (k+1)·|W| then some v ∈ W has degIn ≤ k. Proof by contradiction via Finset.card_nsmul_le_sum.",
+      "mathContext": "The pigeonhole/averaging step: average in-subset degree below k+1 forces a vertex of in-degree ≤ k. This is what converts an edge bound into a degeneracy witness."
+    },
+    {
+      "id": "greedy-coloring",
+      "title": "Part 2 — Greedy coloring: the degeneracy theorem",
+      "startLine": 108,
+      "endLine": 182,
+      "summary": "proper_coloring_on_finset: assuming k-degeneracy (every nonempty subset has a vertex of in-degree ≤ k), every subset W admits a (k+1)-coloring of V proper on W. Proved by Finset.strongInductionOn: erase a low-degree vertex v, color W.erase v by induction, then assign v a color outside the ≤ k colors used by its neighbors (a free color exists since |used| ≤ k < k+1). The case analysis (u = v, w = v, or neither) uses Function.update and adjacency symmetry. colorable_of_degenerate then specializes to W = univ and packages the result as a SimpleGraph.Coloring, yielding G.Colorable (k+1).",
+      "mathContext": "The classical greedy / Szekeres–Wilf argument, here a genuine SimpleGraph.Colorable proof rather than an encoded numeral. The heart of the file."
+    },
+    {
+      "id": "girth6-application",
+      "title": "Part 3 — Application: girth-6 planar graphs are 3-colorable",
+      "startLine": 184,
+      "endLine": 210,
+      "summary": "girth6_planar_three_colorable: given the hereditary edge bound ∑_{v∈W} degIn G W v < 3|W| for every nonempty subset W (the exact content of 'planar with girth ≥ 6'), G is Colorable 3. Derives 2-degeneracy from exists_low_degree_in_subset with k = 2 and applies colorable_of_degenerate.",
+      "mathContext": "The affirmative answer to open question OQ-03. The hereditary hypothesis absorbs both the cyclic bound 2e ≤ 3|W|−6 and the forest bound 2e ≤ 2|W|−2, both < 3|W|."
+    },
+    {
+      "id": "global-witness",
+      "title": "Part 4 — The global degeneracy witness",
+      "startLine": 212,
+      "endLine": 241,
+      "summary": "girth6_exists_low_degree_vertex: in a graph with 2·|edgeFinset| ≤ 3·|V| − 6 (and |V| ≥ 3) there is a vertex of degree ≤ 2. Proof: if all degrees were ≥ 3, the handshaking lemma sum_degrees_eq_twice_card_edges would give 3V ≤ 2E, contradicting the bound.",
+      "mathContext": "Mirrors the parent file's exists_low_degree_vertex (degree ≤ 5 from E ≤ 3V − 6); here the tighter girth-6 bound yields the degree ≤ 2 needed for 2-degeneracy."
+    }
+  ],
+  "conclusion": {
+    "summary": "A 241-line, axiom-free, sorry-free Lean 4 file answering the third open question of euler-polyhedral-oq-01: girth-6 planar graphs are 3-colorable. The mathematical core is colorable_of_degenerate, a genuine SimpleGraph.Colorable proof that every k-degenerate finite graph is (k+1)-colorable by greedy coloring (strong induction on vertex subsets), which the parent file had only stated schematically.",
+    "implications": "The gallery now contains a real, reusable degeneracy ⟹ colorability theorem. Any class of graphs whose subgraphs all have small average degree (high-girth planar graphs, graphs of bounded arboricity, planar graphs in general for the 6-color theorem) becomes colorable by feeding the appropriate per-subset edge bound into exists_low_degree_in_subset and colorable_of_degenerate. In particular the parent's six_colorable_from_degeneracy can be re-derived as an honest SimpleGraph.Colorable 6 statement using colorable_of_degenerate with k = 5.",
+    "openQuestions": [
+      "Full Grötzsch theorem: extend from girth ≥ 6 to girth ≥ 4 (triangle-free planar ⟹ 3-colorable). This requires discharging arguments and is far beyond the degeneracy method — triangle-free planar graphs can have average degree approaching 4 and are not 2-degenerate.",
+      "Derive the hereditary hypothesis of girth6_planar_three_colorable from a structural planarity predicate, so the 3-colorability follows from 'G is planar with girth ≥ 6' directly rather than from the per-subset incidence bound. This needs a Lean notion of planar embedding with an induced-subgraph handshaking lemma.",
+      "Sharpness: girth-5 planar graphs are also 3-colorable (a harder theorem), but they are not 2-degenerate (average degree can reach 10/3 > 3), so the greedy method here genuinely stops at girth 6."
+    ]
+  },
+  "sorries": []
+}

--- a/src/data/research/problems/euler-polyhedral-oq-01-oq-03.json
+++ b/src/data/research/problems/euler-polyhedral-oq-01-oq-03.json
@@ -1,0 +1,66 @@
+{
+  "slug": "euler-polyhedral-oq-01-oq-03",
+  "title": "Girth-6 Planar Graphs are 3-Colorable (Grötzsch sub-case)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Every planar graph of girth ≥ 6 is 3-colorable (G.Colorable 3).",
+    "plain": "The third open question of euler-polyhedral-oq-01: are girth-6 planar graphs 3-colorable? The full Grötzsch theorem (girth ≥ 4, triangle-free) is deep and unformalized, but the girth ≥ 6 sub-case follows elementarily because such graphs are 2-degenerate.",
+    "whyMatters": [
+      "Provides the gallery's first genuine SimpleGraph.Colorable degeneracy-coloring theorem (k-degenerate ⟹ (k+1)-colorable), upgrading the parent file's schematic 5 + 1 = 6 encoding.",
+      "Cleanly separates the elementary high-girth fragment of Grötzsch's theorem from the deep discharging argument."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "colorable_of_degenerate: every k-degenerate finite graph is (k+1)-colorable, a real SimpleGraph.Colorable proof via greedy coloring (strong induction on vertex subsets).",
+      "girth6_planar_three_colorable: a girth-6 planar graph (hereditary bound ∑ degIn < 3|W|) is G.Colorable 3.",
+      "girth6_exists_low_degree_vertex: 2E ≤ 3V − 6 forces a vertex of degree ≤ 2, via the handshaking lemma.",
+      "exists_low_degree_in_subset: averaging lemma producing a low in-degree vertex from a subset edge bound.",
+      "0 sorries, 0 axioms (only propext / Classical.choice / Quot.sound)."
+    ],
+    "open": [
+      "Full Grötzsch theorem (girth ≥ 4): requires discharging; triangle-free planar graphs are not 2-degenerate so the greedy method does not reach girth 5 or 4.",
+      "A structural planarity predicate from which the hereditary degeneracy hypothesis follows automatically (needs an induced-subgraph handshaking lemma)."
+    ],
+    "goal": "Affirmatively answer the literal girth-6 question with a fully verified, reusable degeneracy-coloring engine."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T00:00:00Z",
+    "iteration": 1,
+    "focus": "Proved girth-6 planar 3-colorability via a genuine k-degenerate ⟹ (k+1)-colorable theorem. EulerPolyhedralOQ01OQ03.lean, 241 lines, 5 theorems + 1 def, 0 sorry / 0 axiom."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED: girth-6 planar graphs proved 3-colorable. Built a real greedy-coloring degeneracy theorem (colorable_of_degenerate) and applied it with k = 2. Gallery entry created.",
+    "builtItems": [
+      "EulerPolyhedralOQ01OQ03.lean (241 lines, namespace EulerPolyhedralGirth6)",
+      "proper_coloring_on_finset: greedy coloring by strong induction on a Finset of vertices",
+      "colorable_of_degenerate: k-degenerate ⟹ G.Colorable (k+1), genuine SimpleGraph.Coloring",
+      "exists_low_degree_in_subset: averaging via Finset.card_nsmul_le_sum",
+      "girth6_planar_three_colorable: G.Colorable 3 from the hereditary edge bound",
+      "girth6_exists_low_degree_vertex: ∃ v, G.degree v ≤ 2 from 2E ≤ 3V − 6"
+    ],
+    "insights": [
+      "The literal OQ-03 (girth ≥ 6) is NOT the hard Grötzsch case (girth ≥ 4); it succumbs to 2-degeneracy + greedy coloring.",
+      "Phrasing planarity hereditarily as ∑_{v∈W} degIn < 3|W| avoids needing an induced-subgraph handshaking lemma; averaging directly gives 2-degeneracy.",
+      "The parent file proved every numeric fact but encoded colorability as 5 + 1 = 6; the real Colorable proof is the missing piece this entry supplies.",
+      "Greedy stops at girth 6: girth-5 planar graphs have average degree up to 10/3 > 3 and are not 2-degenerate."
+    ]
+  },
+  "tags": [
+    "graph-theory",
+    "planar-graphs",
+    "graph-coloring",
+    "degeneracy",
+    "greedy-coloring",
+    "girth",
+    "grotzsch-theorem"
+  ],
+  "started": "2026-06-25T00:00:00Z",
+  "lastUpdate": "2026-06-25T00:00:00Z",
+  "significance": 6,
+  "tractability": 8
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `euler-polyhedral-oq-01`: *are girth-6 planar graphs 3-colorable?*

The full **Grötzsch theorem** (girth ≥ 4, triangle-free → 3-colorable) is deep and unformalized in Lean. But the *literal* girth ≥ 6 sub-case has a clean elementary answer via **2-degeneracy**, formalized here with a fully verified, axiom-free greedy-coloring engine.

## Core contribution

The parent file proved every *numeric* fact of the degeneracy story but encoded the colouring step schematically (`six_colorable_from_degeneracy` reduced to `5 + 1 = 6`). This PR supplies the **real** theorem:

- `colorable_of_degenerate` — **every k-degenerate finite graph is `G.Colorable (k+1)`**, a genuine `SimpleGraph.Colorable` proof by greedy coloring (strong induction on vertex subsets, `Function.update` + adjacency symmetry for the extension step).
- `proper_coloring_on_finset` — the greedy induction itself.
- `exists_low_degree_in_subset` — averaging (`Finset.card_nsmul_le_sum`): `∑ degIn < (k+1)|W| ⟹` a vertex of in-degree ≤ k.
- `girth6_planar_three_colorable` — **girth-6 planar ⟹ `G.Colorable 3`**. The hereditary edge bound `∑_{v∈W} degIn < 3|W|` (the precise content of girth-6 planarity, absorbing both the cyclic `2e ≤ 3|W|−6` and forest `2e ≤ 2|W|−2` cases) is an explicit hypothesis.
- `girth6_exists_low_degree_vertex` — global witness `∃ v, G.degree v ≤ 2` from `2E ≤ 3V − 6` via the handshaking lemma (mirrors the parent's degree-≤5 witness).

## Verification

- `proofs/Proofs/EulerPolyhedralOQ01OQ03.lean` — 241 lines, namespace `EulerPolyhedralGirth6`, **5 theorems + 1 def**.
- **0 sorries, 0 axioms.** `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). Typechecked via `lake env lean` (Docker unavailable in this environment).
- Gallery entry: `src/data/proofs/euler-polyhedral-oq-01-oq-03/meta.json` + research problem record.

## Honest scope

The greedy method genuinely **stops at girth 6**: girth-5 planar graphs reach average degree 10/3 > 3 and are not 2-degenerate. Extending to the full Grötzsch theorem (girth ≥ 4) needs discharging and is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)