### PR TITLE
research(nicomachus-sum-of-cubes-oq-02): Faulhaber fourth-power sum ∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/NicomachusFourthPowers.lean
+++ b/proofs/Proofs/NicomachusFourthPowers.lean
@@ -1,0 +1,111 @@
+import Mathlib.Algebra.BigOperators.Intervals
+import Mathlib.Tactic
+
+/-
+# Faulhaber's Fourth-Power Sum: ∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30
+
+## Open Question (nicomachus-sum-of-cubes-oq-02)
+
+The fourth-power (`p = 4`) member of the Faulhaber family, extending the parent
+Nicomachus sum-of-cubes identity `∑ k³ = (∑ k)²`.  The classical closed form is
+
+    1⁴ + 2⁴ + ⋯ + n⁴ = n(n+1)(2n+1)(3n²+3n−1)/30.
+
+Indexing over `range (n+1)` (the `k = 0` term vanishes) the sum reads
+`∑_{k ≤ n} k⁴`.
+
+Check: `n=1 → 1 = 1·2·3·5/30`, `n=2 → 1+16 = 17 = 2·3·5·17/30`,
+`n=3 → 1+16+81 = 98 = 3·4·7·35/30`.
+
+## Result
+
+A fully machine-checked, self-contained proof by induction.
+
+The closed form `n(n+1)(2n+1)(3n²+3n−1)/30` carries both a division and (after
+clearing it) a subtraction — `30·∑ k⁴ = 6n⁵ + 15n⁴ + 10n³ − n` — and truncated
+subtraction is the enemy of `ring` over ℕ.  We sidestep both by proving the
+**subtraction-free, division-free** equivalent
+
+    `30·(∑_{k ≤ n} k⁴) + n = 6n⁵ + 15n⁴ + 10n³`        (`sum_fourth_powers_add`),
+
+obtained by adding `n` to both sides.  Every term is a genuine natural number, so
+the inductive step closes by a single polynomial identity (`ring` for the
+algebra, `omega` to splice it with the hypothesis).  The headline factored form
+is then recovered over ℤ (`thirty_mul_sum_fourth`, where the subtraction is
+honest) and finally over ℚ with the explicit `/30` (`sum_fourth_powers_rat`).
+
+## Novelty
+
+Mathlib has the Gauss triangular-number identity and, via this gallery, the
+Nicomachus cube sum and the odd-cube sum, but not the `p = 4` Faulhaber closed
+form.  This file supplies it, mirroring the additive clear-denominator technique
+used for the sibling power-sum entries.
+
+0 sorries, 0 axioms.
+-/
+
+namespace NicomachusFourthPowers
+
+open Finset
+
+/-- **Subtraction-free fourth-power identity.**  Adding `n` to both sides of the
+headline `30·∑ k⁴ = 6n⁵ + 15n⁴ + 10n³ − n` clears the truncated subtraction, so
+the whole statement lives cleanly in ℕ:
+
+`30·(∑_{k ≤ n} k⁴) + n = 6n⁵ + 15n⁴ + 10n³`.
+
+The induction step is a pure polynomial identity; `omega` splices it together
+with the inductive hypothesis (treating the powers as opaque atoms). -/
+theorem sum_fourth_powers_add (n : ℕ) :
+    30 * (∑ k ∈ range (n + 1), k ^ 4) + n = 6 * n ^ 5 + 15 * n ^ 4 + 10 * n ^ 3 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ]
+    -- The algebraic heart, a subtraction-free polynomial identity over ℕ:
+    have key : 6 * m ^ 5 + 15 * m ^ 4 + 10 * m ^ 3 + 30 * (m + 1) ^ 4 + 1
+        = 6 * (m + 1) ^ 5 + 15 * (m + 1) ^ 4 + 10 * (m + 1) ^ 3 := by ring
+    -- `ih` and `key` are linear in the nonlinear atoms; `omega` closes the goal.
+    omega
+
+/-- **Factored form over ℤ.**  Thirty times the sum of the first `n` fourth powers
+equals the classical product `n(n+1)(2n+1)(3n²+3n−1)`:
+
+`30·(∑_{k ≤ n} k⁴) = n(n+1)(2n+1)(3n²+3n−1)`.
+
+Stated over ℤ so the factor `3n²+3n−1` uses honest subtraction. -/
+theorem thirty_mul_sum_fourth (n : ℕ) :
+    30 * (∑ k ∈ range (n + 1), (k : ℤ) ^ 4)
+      = (n : ℤ) * (n + 1) * (2 * n + 1) * (3 * n ^ 2 + 3 * n - 1) := by
+  have h := sum_fourth_powers_add n
+  have hℤ := congrArg (Nat.cast : ℕ → ℤ) h
+  push_cast at hℤ
+  -- hℤ : 30·(∑ ↑k⁴) + ↑n = 6·↑n⁵ + 15·↑n⁴ + 10·↑n³
+  have hsum : 30 * (∑ k ∈ range (n + 1), (k : ℤ) ^ 4)
+      = 6 * (n : ℤ) ^ 5 + 15 * (n : ℤ) ^ 4 + 10 * (n : ℤ) ^ 3 - (n : ℤ) := by
+    linarith [hℤ]
+  rw [hsum]; ring
+
+/-- **Headline closed form over ℚ.**  The Faulhaber `p = 4` identity in its
+classical divided form:
+
+`∑_{k ≤ n} k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30`. -/
+theorem sum_fourth_powers_rat (n : ℕ) :
+    (∑ k ∈ range (n + 1), (k : ℚ) ^ 4)
+      = (n : ℚ) * (n + 1) * (2 * n + 1) * (3 * n ^ 2 + 3 * n - 1) / 30 := by
+  have h := sum_fourth_powers_add n
+  have hℚ := congrArg (Nat.cast : ℕ → ℚ) h
+  push_cast at hℚ
+  -- hℚ : 30·(∑ ↑k⁴) + ↑n = 6·↑n⁵ + 15·↑n⁴ + 10·↑n³
+  have hsum : (∑ k ∈ range (n + 1), (k : ℚ) ^ 4)
+      = (6 * (n : ℚ) ^ 5 + 15 * (n : ℚ) ^ 4 + 10 * (n : ℚ) ^ 3 - (n : ℚ)) / 30 := by
+    linarith [hℚ]
+  rw [hsum]; ring
+
+/-- Sanity check: `∑_{k ≤ 3} k⁴ = 1 + 16 + 81 = 98`. -/
+example : ∑ k ∈ range 4, k ^ 4 = 98 := by decide
+
+/-- Sanity check (factored): `30·∑_{k ≤ 3} k⁴ = 3·4·7·35 = 2940`. -/
+example : 30 * (∑ k ∈ range 4, k ^ 4) = 2940 := by decide
+
+end NicomachusFourthPowers

--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-02/annotations.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-02/annotations.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "ann-subtraction-free",
+    "proofId": "nicomachus-sum-of-cubes-oq-02",
+    "range": { "startLine": 59, "endLine": 69 },
+    "type": "theorem",
+    "title": "Subtraction-free, division-free core: 30·∑k⁴ + n = 6n⁵+15n⁴+10n³",
+    "content": "The whole development is built on this lemma. The target closed form $n(n+1)(2n+1)(3n^2+3n-1)/30$ has a division by 30 and, once cleared, a subtraction: $30\\sum k^4 = 6n^5 + 15n^4 + 10n^3 - n$. Both are hostile to `ring` over $\\mathbb{N}$ (no division; truncated subtraction is not a ring operation). Multiplying by 30 and moving the $-n$ to the left gives $30\\sum_{k\\le n} k^4 + n = 6n^5 + 15n^4 + 10n^3$, where every term is a genuine natural number. The induction's base case is `simp` (the $k=0$ term vanishes); the step uses `sum_range_succ` to expose the top fourth power $(m+1)^4$, then leans on the standalone polynomial identity proved on the next line.",
+    "mathContext": "$30\\sum_{k\\le n} k^4 + n = 6n^5 + 15n^4 + 10n^3$.",
+    "significance": "critical",
+    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
+    "relatedConcepts": ["Truncated natural subtraction", "Power sums", "Faulhaber's formula"]
+  },
+  {
+    "id": "ann-ring-omega-step",
+    "proofId": "nicomachus-sum-of-cubes-oq-02",
+    "range": { "startLine": 64, "endLine": 69 },
+    "type": "insight",
+    "title": "ring for the algebra, omega for the splice",
+    "content": "The inductive step is closed by a clean division of labor. The `key` hypothesis $6m^5 + 15m^4 + 10m^3 + 30(m+1)^4 + 1 = 6(m+1)^5 + 15(m+1)^4 + 10(m+1)^3$ is a fixed, subtraction-free degree-5 polynomial identity that `ring` verifies outright. Then `omega` finishes: it treats the nonlinear terms $m^5, m^4, m^3, (m+1)^5, (m+1)^4, (m+1)^3$ and the sum as opaque atoms and does the purely *linear* algebra needed to combine `key` with the inductive hypothesis $30\\sum_{k\\le m} k^4 + m = 6m^5 + 15m^4 + 10m^3$. Neither tactic does the other's job — `ring` cannot use the hypothesis, `omega` cannot expand the polynomials.",
+    "mathContext": "$6m^5 + 15m^4 + 10m^3 + 30(m+1)^4 + 1 = 6(m+1)^5 + 15(m+1)^4 + 10(m+1)^3$.",
+    "significance": "key",
+    "relatedConcepts": ["ring tactic", "omega tactic", "Atomization of nonlinear terms"]
+  },
+  {
+    "id": "ann-factored-int",
+    "proofId": "nicomachus-sum-of-cubes-oq-02",
+    "range": { "startLine": 77, "endLine": 87 },
+    "type": "theorem",
+    "title": "Factored form over ℤ: 30·∑k⁴ = n(n+1)(2n+1)(3n²+3n−1)",
+    "content": "The classical factored product is stated over $\\mathbb{Z}$ so the factor $3n^2+3n-1$ uses honest subtraction. `congrArg Nat.cast` lifts the $\\mathbb{N}$ identity, `push_cast` distributes the cast through the sum and powers, and `linarith` isolates $30\\sum_{k\\le n} k^4 = 6n^5 + 15n^4 + 10n^3 - n$. A final `ring` recognizes that the product $n(n+1)(2n+1)(3n^2+3n-1)$ equals $6n^5+15n^4+10n^3-n$, closing the goal. The integers are used only to *state* the result — all the inductive work happened in $\\mathbb{N}$.",
+    "mathContext": "$30\\sum_{k\\le n} k^4 = n(n+1)(2n+1)(3n^2+3n-1)$ over $\\mathbb{Z}$.",
+    "significance": "critical",
+    "prerequisites": ["Integer casts (push_cast)"],
+    "relatedConcepts": ["Nat.cast", "push_cast", "Closed-form power sums"]
+  },
+  {
+    "id": "ann-headline-rat",
+    "proofId": "nicomachus-sum-of-cubes-oq-02",
+    "range": { "startLine": 93, "endLine": 103 },
+    "type": "theorem",
+    "title": "Headline form over ℚ: ∑k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30",
+    "content": "The headline divided form lives over $\\mathbb{Q}$, where the $/30$ is a genuine division. The same $\\mathbb{N}$ core is cast with `push_cast`, `linarith` isolates the sum as $(6n^5+15n^4+10n^3-n)/30$, and `ring` clears the product against the $/30$ to recognize the factored numerator. This is the form a reader recognizes as Faulhaber's $p=4$ identity; the rationals are used only for the final statement.",
+    "mathContext": "$\\sum_{k\\le n} k^4 = \\dfrac{n(n+1)(2n+1)(3n^2+3n-1)}{30}$ over $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Rational casts", "Division in fields", "Closed-form power sums"]
+  }
+]

--- a/src/data/proofs/nicomachus-sum-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/nicomachus-sum-of-cubes-oq-02/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "nicomachus-sum-of-cubes-oq-02",
+  "title": "Faulhaber's Fourth-Power Sum: ∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30",
+  "slug": "nicomachus-sum-of-cubes-oq-02",
+  "description": "A fully machine-checked, self-contained proof of the Faulhaber p=4 closed form: the sum of the first n fourth powers equals n(n+1)(2n+1)(3n²+3n−1)/30, i.e. ∑_{k≤n} k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30. The closed form carries both a division (/30) and, after clearing it, a subtraction (30·∑ = 6n⁵+15n⁴+10n³ − n), and truncated subtraction is hostile to `ring` over ℕ. The engine of the proof is the subtraction-free, division-free repackaging 30·(∑ k⁴) + n = 6n⁵+15n⁴+10n³, proved by induction with a single polynomial `ring` identity spliced into the hypothesis by `omega`. The factored form is recovered over ℤ and the headline /30 form over ℚ via push_cast. Extends the parent Nicomachus sum-of-cubes identity; Mathlib has neither.",
+  "meta": {
+    "author": "Classical (Faulhaber, 1631; Jakob Bernoulli); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Faulhaber%27s_formula",
+    "date": "1631",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "power-sums",
+      "faulhaber",
+      "fourth-powers",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/NicomachusFourthPowers.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum: ∑_{i<n+1} f i = (∑_{i<n} f i) + f n. The engine of the inductive step.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The Faulhaber fourth-power identity ∑_{k≤n} k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30 — the sum of the first n fourth powers 1⁴ + 2⁴ + ⋯ + n⁴ — machine-checked with 0 axioms and 0 sorries (Mathlib has neither this nor its parent sum-of-cubes identity)",
+      "The subtraction-free, division-free repackaging 30·(∑_{k≤n} k⁴) + n = 6n⁵ + 15n⁴ + 10n³: clearing the /30 and moving the −n of the closed form to the left makes every term a genuine natural number, so the whole induction lives in ℕ with no truncated subtraction, no division, and no casts in the core lemma",
+      "The 'ring-then-omega' inductive step: the algebraic content is a single subtraction-free polynomial identity 6m⁵ + 15m⁴ + 10m³ + 30(m+1)⁴ + 1 = 6(m+1)⁵ + 15(m+1)⁴ + 10(m+1)³ (closed by `ring`), which `omega` then combines linearly with the inductive hypothesis treating the power terms as opaque atoms",
+      "Two downstream packagings: the factored integer form 30·∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1) over ℤ (`thirty_mul_sum_fourth`) and the classical divided form over ℚ with the explicit /30 (`sum_fourth_powers_rat`)"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 111,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions) for all three theorems. The two sanity-check examples use kernel `decide` (not native_decide), so no Lean.ofReduceBool. No sorryAx, no structure-encoded hypotheses.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "subtraction-free",
+      "title": "Subtraction-free, division-free core",
+      "startLine": 59,
+      "endLine": 69,
+      "summary": "The core lemma 30·(∑_{k≤n} k⁴) + n = 6n⁵ + 15n⁴ + 10n³, proved by induction. The base case is `simp`. The step peels the top fourth power with sum_range_succ, then a single subtraction-free `ring` identity 6m⁵ + 15m⁴ + 10m³ + 30(m+1)⁴ + 1 = 6(m+1)⁵ + 15(m+1)⁴ + 10(m+1)³ is combined with the inductive hypothesis by `omega` (which atomizes the power terms). No truncated ℕ subtraction and no division ever appears."
+    },
+    {
+      "id": "factored-int",
+      "title": "Factored form over ℤ",
+      "startLine": 77,
+      "endLine": 87,
+      "summary": "30·(∑_{k≤n} k⁴) = n(n+1)(2n+1)(3n²+3n−1). Casting the ℕ identity to ℤ with push_cast lets the factor 3n²+3n−1 use honest subtraction; `linarith` isolates 30·∑ = 6n⁵+15n⁴+10n³ − n and a final `ring` recognizes that the product equals 6n⁵+15n⁴+10n³ − n."
+    },
+    {
+      "id": "headline-rat",
+      "title": "Headline closed form over ℚ",
+      "startLine": 93,
+      "endLine": 103,
+      "summary": "∑_{k≤n} k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30, the classical divided form. The same ℕ core is cast to ℚ, `linarith` isolates the sum as (6n⁵+15n⁴+10n³ − n)/30, and `ring` clears the product against the /30."
+    },
+    {
+      "id": "sanity",
+      "title": "Concrete sanity checks",
+      "startLine": 105,
+      "endLine": 109,
+      "summary": "Two kernel-`decide` checks at n=3: ∑_{k≤3} k⁴ = 1+16+81 = 98, and the factored 30·∑ = 3·4·7·35 = 2940. Kernel decide, not native_decide — no Lean.ofReduceBool."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Faulhaber's formula and the power sums**\n\nNicomachus of Gerasa (c. 100 AD) observed that the sum of the *first n cubes* is the square of the $n$-th triangular number, $\\sum_{k\\le n} k^3 = (\\sum_{k\\le n} k)^2$. The general question — a closed form for $\\sum_{k\\le n} k^p$ for each fixed power $p$ — was settled by Johann Faulhaber (1631) and put on a uniform footing by Jakob Bernoulli, whose numbers $B_p$ encode the coefficients. For $p = 4$ the closed form is\n$$1^4 + 2^4 + \\cdots + n^4 = \\frac{n(n+1)(2n+1)(3n^2+3n-1)}{30},$$\na degree-5 polynomial in $n$ that Mathlib's BigOperators library does not currently provide. This entry supplies it, as the $p=4$ sibling of the parent Nicomachus sum-of-cubes formalization.",
+    "problemStatement": "**Sum of the first n fourth powers**\n\nIndexing over `range (n+1)` (the $k=0$ term vanishes, so the sum counts $1^4, \\ldots, n^4$), prove that for every natural number $n$,\n$$\\sum_{k\\le n} k^4 = \\frac{n(n+1)(2n+1)(3n^2+3n-1)}{30}.$$\nThe goal is a fully machine-checked proof with no axioms and no sorries.",
+    "proofStrategy": "**Clear the division and the subtraction, then induct**\n\nThe closed form has two features hostile to a `ring`-driven induction over $\\mathbb{N}$: the division by $30$, and the subtraction that survives clearing it, $30\\sum k^4 = 6n^5 + 15n^4 + 10n^3 - n$. The fix is to clear both at once — multiply through by $30$ and add $n$ to both sides — giving the **subtraction-free, division-free** identity\n$$30\\Big(\\sum_{k\\le n} k^4\\Big) + n = 6n^5 + 15n^4 + 10n^3,$$\nin which every term is an honest natural number. This is proved by induction: `sum_range_succ` peels off the top fourth power $(m+1)^4$, and the inductive step is the single polynomial identity $6m^5 + 15m^4 + 10m^3 + 30(m+1)^4 + 1 = 6(m+1)^5 + 15(m+1)^4 + 10(m+1)^3$ — proved by `ring` — which `omega` then splices together with the inductive hypothesis (treating $m^5, m^4, \\ldots$ as opaque atoms). The classical factored form $n(n+1)(2n+1)(3n^2+3n-1)$ is recovered over $\\mathbb{Z}$ (`push_cast`, where the subtraction is honest), and the headline $/30$ form over $\\mathbb{Q}$.",
+    "keyInsights": [
+      "**Clear the denominator *and* the subtraction up front.** Multiplying by $30$ removes the rational coefficients, and adding $n$ removes the only remaining minus sign, so the entire core induction lives in $\\mathbb{N}$ with no casts and no truncated subtraction.",
+      "**ring for algebra, omega for bookkeeping.** The genuinely algebraic content of the step is one subtraction-free degree-5 polynomial identity; `omega` does only the linear splicing with the hypothesis, atomizing the nonlinear power terms. Neither tactic does the other's job.",
+      "**Cast only at the end.** $\\mathbb{Z}$ and $\\mathbb{Q}$ are needed solely to *state* the headline factored and divided forms honestly; `push_cast` plus `ring` transports the $\\mathbb{N}$ result there, so the heavy lifting never leaves $\\mathbb{N}$.",
+      "**A Faulhaber polynomial that does not factor over ℤ.** Unlike $\\sum k^3 = (\\sum k)^2$ or the odd-cube $n^2(2n^2-1)$, the $p=4$ sum keeps the irreducible quadratic factor $3n^2+3n-1$ and a genuine $/30$, illustrating how Bernoulli denominators enter for even $p$."
+    ],
+    "prerequisites": [
+      "Mathematical induction",
+      "Finite sums over `Finset.range`",
+      "Truncated natural-number subtraction",
+      "Integer/rational casts (push_cast)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Faulhaber fourth-power identity $\\sum_{k\\le n} k^4 = n(n+1)(2n+1)(3n^2+3n-1)/30$ is established by a short induction. The closed form's division and subtraction are dissolved by proving the equivalent subtraction-free, division-free statement $30\\sum k^4 + n = 6n^5 + 15n^4 + 10n^3$ in $\\mathbb{N}$; the inductive step is one `ring` identity combined with the hypothesis by `omega`, and the headline forms are recovered over $\\mathbb{Z}$ and $\\mathbb{Q}$ with `push_cast`. The proof depends on a single Mathlib lemma (`sum_range_succ`). 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the p=4 Faulhaber power-sum identity ∑ k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30, absent from Mathlib's BigOperators library, in three reusable forms (ℕ subtraction-free, ℤ factored, ℚ divided).",
+      "Demonstrates that the 'clear the denominator, add a term to clear the subtraction' technique extends from the cube and odd-cube sums to power sums whose closed form has genuine rational coefficients.",
+      "The 'ring-then-omega' split scales to a degree-5 polynomial step, confirming it as a robust pattern for inductive sum identities whose step is a fixed polynomial identity plus linear hypothesis bookkeeping."
+    ],
+    "openQuestions": [
+      "Does the same 'clear denominator and subtraction, then ring-and-omega' recipe extend uniformly to ∑ k⁵, ∑ k⁶, …, or does the growing Bernoulli denominator make the integer core lemma progressively harder to state subtraction-free?",
+      "Can the family ∑ k^p be unified into a single Lean theorem parameterized by p via the Bernoulli numbers (Faulhaber's formula proper), rather than one entry per power?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent **Nicomachus sum-of-cubes** open question `oq-02`: the **Faulhaber fourth-power closed form**, the `p=4` sibling of `∑ k³ = (∑ k)²`.

$$\sum_{k\le n} k^4 = \frac{n(n+1)(2n+1)(3n^2+3n-1)}{30}.$$

## Approach

The closed form has two features hostile to a `ring`-driven induction over ℕ — a division by 30 and, once cleared, a subtraction (`30·∑ k⁴ = 6n⁵+15n⁴+10n³ − n`). Both are dissolved up front by proving the **subtraction-free, division-free** equivalent:

```
sum_fourth_powers_add :  30·(∑_{k≤n} k⁴) + n = 6n⁵ + 15n⁴ + 10n³
```

by induction — `Finset.sum_range_succ` peels the top fourth power, and a single subtraction-free degree-5 `ring` identity

```
6m⁵ + 15m⁴ + 10m³ + 30(m+1)⁴ + 1 = 6(m+1)⁵ + 15(m+1)⁴ + 10(m+1)³
```

is spliced into the inductive hypothesis by `omega` (powers treated as opaque atoms). The classical factored form is recovered over ℤ (`thirty_mul_sum_fourth`) and the headline `/30` form over ℚ (`sum_fourth_powers_rat`) via `push_cast`.

## Verification

- `proofs/Proofs/NicomachusFourthPowers.lean` typechecks cleanly against Mathlib v4.26.0 (single-file `lake env lean`).
- `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all three theorems.
- Two sanity checks use **kernel** `decide` (∑_{k≤3} k⁴ = 98; 30·∑ = 2940) — no `native_decide`, hence no `Lean.ofReduceBool`.
- **3 theorems, 0 definitions, 0 sorries, 0 axioms.**

Mathlib has neither this `p=4` Faulhaber identity nor its parent sum-of-cubes identity.

## Files

- `proofs/Proofs/NicomachusFourthPowers.lean` (new, 111 lines)
- `src/data/proofs/nicomachus-sum-of-cubes-oq-02/{meta.json,annotations.json}` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)