### PR TITLE
Enrich Legendre's Formula through Hermite's Identity: add annotations

### DIFF
--- a/src/data/proofs/hermite-legendre-factorial/annotations.json
+++ b/src/data/proofs/hermite-legendre-factorial/annotations.json
@@ -1,0 +1,125 @@
+[
+  {
+    "id": "ann-hlf-setup",
+    "proofId": "hermite-legendre-factorial",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "type": "concept",
+    "title": "Setup: Routing Legendre's Formula through Hermite's Identity",
+    "content": "The module docstring fixes the goal precisely. Legendre's formula (de Polignac, 1808) gives the exact prime-power content of a factorial, v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋, and Mathlib already has it as `padicValNat_factorial` over the finite window Ico 1 b for any b > log_p n (the tail vanishes because ⌊n/p^i⌋ = 0 once p^i > n). The new content is a *refinement layer*: each Legendre quotient ⌊n/p^i⌋ is rewritten through Hermite's floor-summation identity ∑_{k=0}^{m-1} ⌊x + k/m⌋ = ⌊m·x⌋, imported from the gallery as `HermiteFloorIdentity.hermite_floor_identity`. The plan announced in the docstring has three movements: (1) identify the real floor ⌊(n:ℝ)/m^j⌋ with the natural Euclidean quotient, (2) specialise Hermite at x = n/m^{j+1} to split a single summand, (3) feed the split term-by-term into Mathlib's Legendre core. The single `import Mathlib` pulls in the p-adic valuation, floor, and Euclidean-division APIs; `import Proofs.HermiteFloorIdentity` supplies the engine.",
+    "mathContext": "$v_p(n!) = \\sum_{i\\ge 1}\\lfloor n/p^i\\rfloor$ (Legendre) is rewritten via $\\sum_{k=0}^{m-1}\\lfloor x + k/m\\rfloor = \\lfloor m x\\rfloor$ (Hermite) specialised at $x = n/m^{j+1}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Legendre's formula",
+      "Hermite's floor identity",
+      "p-adic valuation",
+      "padicValNat_factorial",
+      "Kummer's theorem"
+    ],
+    "prerequisites": [
+      "the floor function ⌊·⌋ on ℝ and ℤ",
+      "p-adic valuation of an integer",
+      "finite sums over Finset.range and Finset.Ico"
+    ]
+  },
+  {
+    "id": "ann-hlf-floor-natcast-div-pow",
+    "proofId": "hermite-legendre-factorial",
+    "range": {
+      "startLine": 43,
+      "endLine": 47
+    },
+    "type": "technique",
+    "title": "The Bridge Lemma: Real Floor Equals Euclidean Quotient",
+    "content": "`floor_natCast_div_pow` is the small but load-bearing lemma that lets Hermite's real-valued identity meet Legendre's natural-number quotients without any error term. It proves ⌊(n:ℝ)/m^j⌋ = ↑(n/m^j), i.e. the real floor of a ratio of naturals is exactly their Euclidean quotient cast to ℤ. The proof first rewrites the real power (m:ℝ)^j as the cast of the natural power ((m^j:ℕ):ℝ) via `push_cast; ring`, so that the divisor is visibly a cast of a natural. Then `Int.floor_div_natCast` applies the division-floor law ⌊a/d⌋ = ⌊a⌋/d (valid because flooring commutes with division by a positive natural), `Int.floor_natCast` collapses ⌊(n:ℝ)⌋ to n, and `Int.natCast_div` matches the integer Euclidean quotient (n:ℤ)/(m^j) with the cast of the natural quotient ↑(n/m^j). This is the only place the real/natural boundary is crossed, and it crosses it cleanly.",
+    "mathContext": "$\\lfloor (n:\\mathbb{R})/m^j\\rfloor = \\lfloor n/m^j\\rfloor_{\\mathbb{N}}$. The key law is $\\lfloor a/d\\rfloor = \\lfloor a\\rfloor / d$ for a positive integer divisor $d$, so floor and division by $m^j$ commute.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.floor_div_natCast",
+      "Int.floor_natCast",
+      "Int.natCast_div",
+      "Euclidean division",
+      "cast normalization (push_cast)"
+    ],
+    "prerequisites": [
+      "the division-floor identity ⌊a/n⌋ = ⌊a⌋/n",
+      "casting ℕ → ℤ → ℝ and push_cast",
+      "Euclidean division on ℤ"
+    ]
+  },
+  {
+    "id": "ann-hlf-summand-split",
+    "proofId": "hermite-legendre-factorial",
+    "range": {
+      "startLine": 49,
+      "endLine": 65
+    },
+    "type": "insight",
+    "title": "Hermite Splitting of a Single Legendre Summand",
+    "content": "`legendre_summand_split` is the heart of the synthesis: for any m ≥ 1 it shows the integer quotient n/m^j equals the Hermite floor sum one level down, ↑(n/m^j) = ∑_{k<m} ⌊n/m^{j+1} + k/m⌋. The proof instantiates `HermiteFloorIdentity.hermite_floor_identity` at the real point x = n/m^{j+1} with m copies, which immediately gives ∑_{k<m} ⌊n/m^{j+1} + k/m⌋ = ⌊m·(n/m^{j+1})⌋. The remaining work is algebraic: the scalar m·(n/m^{j+1}) collapses to n/m^j (proved by `field_simp` then `ring`, using that m ≠ 0 forces m^{j+1} = m·m^j to be invertible), and the bridge lemma `floor_natCast_div_pow` rewrites ⌊n/m^j⌋ as ↑(n/m^j). Conceptually this says the p (here m) equally spaced floor samples around n/m^{j+1} reassemble exactly into the coarser carry-count ⌊n/m^j⌋ — Hermite's identity *is* the refinement operator that drops a Legendre quotient one prime-power level. Note the lemma is uniform in m and j, so it can be iterated to any depth.",
+    "mathContext": "$\\lfloor n/m^j\\rfloor = \\sum_{k=0}^{m-1}\\lfloor n/m^{j+1} + k/m\\rfloor$. Hermite at $x = n/m^{j+1}$ gives $\\lfloor m\\cdot(n/m^{j+1})\\rfloor = \\lfloor n/m^j\\rfloor$; the $m$ samples recover the coarser floor.",
+    "significance": "key",
+    "relatedConcepts": [
+      "HermiteFloorIdentity.hermite_floor_identity",
+      "floor sampling at equally spaced shifts",
+      "field_simp / ring normalization",
+      "pow_ne_zero",
+      "uniform refinement in m and j"
+    ],
+    "prerequisites": [
+      "Hermite's floor identity ∑_{k<m} ⌊x + k/m⌋ = ⌊m·x⌋",
+      "real arithmetic with field_simp and ring",
+      "the bridge lemma floor_natCast_div_pow"
+    ]
+  },
+  {
+    "id": "ann-hlf-headline",
+    "proofId": "hermite-legendre-factorial",
+    "range": {
+      "startLine": 67,
+      "endLine": 81
+    },
+    "type": "insight",
+    "title": "Legendre's Formula Refined into a Double Hermite Floor Sum",
+    "content": "`legendre_factorial_hermite` is the headline result: for a prime p and any bound b > log_p n, (padicValNat p n! : ℤ) = ∑_{i∈Ico 1 b} ∑_{k<p} ⌊n/p^{i+1} + k/p⌋. The proof composes the previous pieces with remarkable economy. First `padicValNat_factorial` (Mathlib's Legendre core) rewrites v_p(n!) as the finite sum ∑_{i∈Ico 1 b} n/p^i; the hypothesis hb : log_p n < b guarantees the window is wide enough that the omitted tail terms are all zero. Then `Nat.cast_sum` pushes the cast ℕ → ℤ inside the sum, and a single `Finset.sum_congr rfl` applies `legendre_summand_split p n i` (with m = p, j = i, using p.Prime.pos for m ≥ 1) to each summand. Because the split lemma is exactly an equality of each Legendre quotient with its Hermite refinement, the whole double-sum identity follows term-by-term — the Legendre layer and the Hermite layer compose with no glue beyond sum_congr. This is the open question explicitly posed by the sibling entry hermite-floor-identity, now answered.",
+    "mathContext": "$v_p(n!) = \\sum_{i=1}^{b-1}\\sum_{k=0}^{p-1}\\lfloor n/p^{i+1} + k/p\\rfloor$ for any $b > \\log_p n$. Each Legendre quotient $\\lfloor n/p^i\\rfloor$ is resolved into its $p$-term Hermite refinement.",
+    "significance": "key",
+    "relatedConcepts": [
+      "padicValNat_factorial",
+      "Nat.cast_sum",
+      "Finset.sum_congr",
+      "Finset.Ico window for Legendre's sum",
+      "Nat.Prime.pos"
+    ],
+    "prerequisites": [
+      "Legendre's formula via padicValNat_factorial",
+      "casting and reindexing finite sums",
+      "legendre_summand_split (the per-term Hermite refinement)"
+    ]
+  },
+  {
+    "id": "ann-hlf-bound-window",
+    "proofId": "hermite-legendre-factorial",
+    "range": {
+      "startLine": 71,
+      "endLine": 78
+    },
+    "type": "context",
+    "title": "Why the Finite Window Ico 1 b Suffices",
+    "content": "Both the statement and proof of `legendre_factorial_hermite` use the finite window Ico 1 b under the hypothesis hb : Nat.log p n < b rather than the infinite sum ∑_{i≥1}. This is not a loss of generality: Legendre's true sum is infinite only nominally, since ⌊n/p^i⌋ = 0 as soon as p^i > n, i.e. for all i > log_p n. Any bound b strictly above log_p n therefore captures every nonzero term, and Mathlib's `padicValNat_factorial` is stated in exactly this truncated form. The Hermite refinement preserves this: the inner sum ∑_{k<p} ⌊n/p^{i+1} + k/p⌋ reconstructs ⌊n/p^i⌋ at each level i, so the doubly-indexed sum has the same finite support. The reader should read 'b > log_p n' as 'far enough out that nothing is dropped'.",
+    "mathContext": "$\\lfloor n/p^i\\rfloor = 0$ for $p^i > n$, i.e. $i > \\log_p n$; so $\\sum_{i\\ge 1} = \\sum_{i=1}^{b-1}$ whenever $b > \\log_p n$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Nat.log",
+      "Finset.Ico",
+      "finite support of Legendre's sum",
+      "truncation of a convergent integer series"
+    ],
+    "prerequisites": [
+      "behaviour of ⌊n/p^i⌋ as i grows",
+      "the integer logarithm Nat.log"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `hermite-legendre-factorial` (quality 41, passes 0).

## Gap addressed
The entry had a rich meta.json but **no annotations.json** — zero inline annotation coverage. (Note: `index.ts` is not required; the gallery now discovers proofs at build time via meta.json per issue #20993, so the role doc's index.ts instruction is stale.)

## Changes
Added `annotations.json` with 5 line-anchored annotations covering the full 82-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Setup** (L1–41) — frames the Legendre→Hermite synthesis and the three-step plan.
2. **floor_natCast_div_pow** (L43–47) — the real-floor / Euclidean-quotient bridge lemma.
3. **legendre_summand_split** (L49–65) — key insight: Hermite as the per-term refinement operator.
4. **legendre_factorial_hermite** (L67–81) — key: the headline double Hermite floor sum.
5. **Finite window** (L71–78) — technical: why `Ico 1 b` with `b > log_p n` loses nothing.

## Verification
- `pnpm annotations:build` clean — **no warnings for this proof**; all 5 annotations anchor to real Lean constructs.
- meta.json/annotations.json JSON validated; public asset regenerated.
- Axiom integrity preserved: status `verified`, axiomCount 0 — accurate (`#print axioms` lists only propext/Classical.choice/Quot.sound; no native_decide, no structure-encoded assumptions).