### PR TITLE
research(erdos-574-oq-01): bipartite ⟹ C_{2k−1}-free — the lower-bound transfer core [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos574Problem.lean
+++ b/proofs/Proofs/Erdos574Problem.lean
@@ -11,14 +11,40 @@ The conjectured answer matches the extremal number for forbidding
 C_{2k} alone (even cycle), suggesting that also forbidding C_{2k−1}
 does not reduce the extremal number asymptotically.
 
-Status: OPEN
+Status: OPEN (the matching *upper* bound is the open content, and is at
+least as hard as the exact even-cycle constant ex(n; C_{2k}), itself
+open for general k).
+
+## What is proved here (unconditional, 0 axioms, 0 sorries)
+
+The *lower-bound* half is not conjectural: the dense C_{2k}-free graphs
+furnished by incidence geometry (projective planes / generalized
+polygons; Wenger 1991, Lazebnik–Ustimenko–Woldar 1995) are **bipartite**,
+hence contain **no odd cycle at all**, hence are automatically
+C_{2k−1}-free. Forbidding the odd cycle is therefore "free" on the
+lower-bound side — as a theorem, not as evidence.
+
+This file formalizes that structural core:
+
+* `bipartite_not_hasCycle_odd` — a bipartite graph has no cycle of any
+  odd length (a 2-colouring alternates along a closed walk, so the walk
+  length must be even).
+* `bipartite_no_odd_consecutive` — consequently a bipartite graph
+  contains no C_{2k−1}, for every k ≥ 1.
+* `bipartite_evenFree_consecutiveFree` — a bipartite, C_{2k}-free graph
+  is `{C_{2k−1}, C_{2k}}`-free; the even-cycle condition is the only real
+  constraint. This is exactly why the lower bound for
+  ex(n; {C_{2k−1}, C_{2k}}) transfers, with no loss, from ex(n; C_{2k}).
+
 Reference: https://erdosproblems.com/574
 Source: [ErSi82] Erdős–Simonovits
 -/
 
 import Mathlib.Data.Nat.Basic
+import Mathlib.Algebra.Ring.Parity
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Finset.Basic
+import Mathlib.Logic.Function.Iterate
 import Mathlib.Tactic
 
 /- ## Definitions -/
@@ -29,6 +55,7 @@ structure SimpleGraph' (n : ℕ) where
   symm : ∀ u v, adj u v → adj v u
   irrefl : ∀ v, ¬adj v v
 
+open Classical in
 /-- The number of edges in a graph. -/
 noncomputable def edgeCount' {n : ℕ} (G : SimpleGraph' n) : ℕ :=
   Finset.card (Finset.filter (fun p : Fin n × Fin n => p.1 < p.2 ∧ G.adj p.1 p.2) Finset.univ)
@@ -37,7 +64,7 @@ noncomputable def edgeCount' {n : ℕ} (G : SimpleGraph' n) : ℕ :=
 def HasCycle {n : ℕ} (G : SimpleGraph' n) (ℓ : ℕ) : Prop :=
   ∃ (cycle : Fin ℓ → Fin n),
     Function.Injective cycle ∧ ℓ ≥ 3 ∧
-    (∀ i : Fin ℓ, G.adj (cycle i) (cycle ⟨(i.val + 1) % ℓ, Nat.mod_lt _ (by omega)⟩))
+    (∀ i : Fin ℓ, G.adj (cycle i) (cycle ⟨(i.val + 1) % ℓ, Nat.mod_lt _ (by have := i.isLt; omega)⟩))
 
 /-- A graph is {C_{2k−1}, C_{2k}}-free. -/
 def IsConsecutiveCycleFree {n : ℕ} (G : SimpleGraph' n) (k : ℕ) : Prop :=
@@ -51,28 +78,111 @@ noncomputable def exConsecutiveCycles (n k : ℕ) : ℕ :=
     (Finset.range 1))
     id
 
-/- ## Main Conjecture -/
+/-- A graph is **bipartite**: its vertices admit a 2-colouring with no
+    monochromatic edge. -/
+def IsBipartite {n : ℕ} (G : SimpleGraph' n) : Prop :=
+  ∃ c : Fin n → Bool, ∀ u v, G.adj u v → c u ≠ c v
 
-/-- **Erdős–Simonovits Conjecture**: For k ≥ 2,
-    ex(n; {C_{2k−1}, C_{2k}}) = (1+o(1)) · (n/2)^{1+1/k}. -/
+/- ## The odd-cycle constraint is free on bipartite graphs -/
+
+/-- Iterating Boolean negation `m` times flips the bit iff `m` is odd. -/
+private lemma not_iterate_eq (m : ℕ) (b : Bool) :
+    (fun x => !x)^[m] b = if Even m then b else !b := by
+  induction m with
+  | zero => simp
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', ih]
+    by_cases hk : Even k <;> simp [hk, Nat.even_add_one, Bool.not_not]
+
+/-- **Bipartite graphs have no odd cycle.**
+
+    A proper 2-colouring alternates along every closed walk, so a closed
+    walk that returns to its start must have even length. Hence a
+    bipartite graph contains no cycle of odd length. (Injectivity of the
+    cycle is irrelevant; only the closed-walk adjacencies are used.) -/
+theorem bipartite_not_hasCycle_odd {n : ℕ} (G : SimpleGraph' n)
+    (hG : IsBipartite G) {ℓ : ℕ} (hodd : Odd ℓ) : ¬ HasCycle G ℓ := by
+  rintro ⟨cycle, _hinj, hℓ3, hcyc⟩
+  obtain ⟨c, hc⟩ := hG
+  have hℓpos : 0 < ℓ := by omega
+  -- the closed walk, indexed by ℕ via wrap-around
+  set w : ℕ → Fin n := fun j => cycle ⟨j % ℓ, Nat.mod_lt _ hℓpos⟩ with hw
+  -- consecutive walk vertices are adjacent
+  have hadj : ∀ j : ℕ, G.adj (w j) (w (j + 1)) := by
+    intro j
+    simp only [hw]
+    have h1 : (j + 1) % ℓ = (j % ℓ + 1) % ℓ := by
+      rw [Nat.add_mod j 1 ℓ, Nat.mod_eq_of_lt (show 1 < ℓ by omega)]
+    have key := hcyc ⟨j % ℓ, Nat.mod_lt _ hℓpos⟩
+    have hfin : (⟨(j % ℓ + 1) % ℓ, Nat.mod_lt _ hℓpos⟩ : Fin ℓ)
+        = ⟨(j + 1) % ℓ, Nat.mod_lt _ hℓpos⟩ := Fin.ext h1.symm
+    rw [hfin] at key
+    exact key
+  -- the colouring flips at each step
+  have hflip : ∀ j : ℕ, c (w (j + 1)) = !(c (w j)) := by
+    intro j
+    have hne := hc _ _ (hadj j)
+    generalize c (w j) = a at hne ⊢
+    generalize c (w (j + 1)) = b at hne ⊢
+    cases a <;> cases b <;> simp_all
+  -- closed form for the colour along the walk
+  have hiter : ∀ j : ℕ, c (w j) = (fun x => !x)^[j] (c (w 0)) := by
+    intro j
+    induction j with
+    | zero => simp
+    | succ k ih => rw [Function.iterate_succ_apply', ← ih, hflip k]
+  -- the walk closes up after ℓ steps
+  have hclose : w ℓ = w 0 := by
+    simp only [hw]
+    congr 1
+    apply Fin.ext
+    simp [Nat.mod_self, Nat.zero_mod]
+  have hnotEven : ¬ Even ℓ := by
+    rw [Nat.even_iff]; rw [Nat.odd_iff] at hodd; omega
+  have h0 := hiter ℓ
+  rw [hclose, not_iterate_eq, if_neg hnotEven] at h0
+  -- h0 : c (w 0) = !(c (w 0)), impossible
+  have hbad : c (w 0) ≠ !(c (w 0)) := by
+    generalize c (w 0) = b
+    cases b <;> simp
+  exact hbad h0
+
+/-- **A bipartite graph contains no `C_{2k-1}`** (the odd member of the
+    consecutive pair), for every `k ≥ 1`. -/
+theorem bipartite_no_odd_consecutive {n : ℕ} (G : SimpleGraph' n)
+    (hG : IsBipartite G) (k : ℕ) (hk : 1 ≤ k) : ¬ HasCycle G (2 * k - 1) := by
+  apply bipartite_not_hasCycle_odd G hG
+  exact ⟨k - 1, by omega⟩
+
+/-- **The lower-bound transfer.** A bipartite, `C_{2k}`-free graph is
+    automatically `{C_{2k-1}, C_{2k}}`-free: on bipartite witnesses, the
+    even-cycle condition already implies the full consecutive-pair
+    constraint. This is the structural reason the lower bound for
+    `ex(n; {C_{2k-1}, C_{2k}})` matches that of `ex(n; C_{2k})` —
+    forbidding the odd cycle costs nothing. -/
+theorem bipartite_evenFree_consecutiveFree {n : ℕ} (G : SimpleGraph' n)
+    (hG : IsBipartite G) (k : ℕ) (hk : 1 ≤ k)
+    (hev : ¬ HasCycle G (2 * k)) : IsConsecutiveCycleFree G k :=
+  ⟨bipartite_no_odd_consecutive G hG k hk, hev⟩
+
+/- ## Main Conjecture (OPEN) -/
+
+/- **Erdős–Simonovits Conjecture**: For k ≥ 2,
+    ex(n; {C_{2k−1}, C_{2k}}) = (1+o(1)) · (n/2)^{1+1/k}.
+    The matching upper bound is open. -/
+
 /- ## Known Results -/
 
-/-- **Even cycle Turán number**: ex(n; C_{2k}) = Θ(n^{1+1/k}).
+/- **Even cycle Turán number**: ex(n; C_{2k}) = Θ(n^{1+1/k}).
     The Bondy–Simonovits theorem gives the upper bound.
-    Algebraic constructions give matching lower bounds for
-    k = 2, 3, 5 and some other values. -/
-/-- **Bondy–Simonovits upper bound**: ex(n; C_{2k}) ≤ c · n^{1+1/k}
-    for some constant c depending on k. -/
-/-- **Case k = 2 (Problem #573)**: ex(n; {C₃, C₄}) is studied
-    separately. The extremal graphs are related to incidence
-    geometries and polarity graphs. -/
+    Algebraic (bipartite) constructions give matching lower bounds for
+    k = 2, 3, 5 and some other values; being bipartite, they are also
+    C_{2k−1}-free — see `bipartite_evenFree_consecutiveFree`. -/
+
 /- ## Observations -/
 
 /- **The conjecture says forbidding C_{2k−1} is "free"**: since
     ex(n; C_{2k}) already has the conjectured form, additionally
-    forbidding C_{2k−1} should not change the asymptotics. -/
-
-/- **Algebraic constructions**: For k = 2, 3, 5, algebraic
-    constructions (e.g., incidence graphs of projective planes)
-    provide C_{2k}-free graphs with ~(n/2)^{1+1/k} edges that
-    also happen to avoid C_{2k−1}. -/
+    forbidding C_{2k−1} should not change the asymptotics. On the
+    lower-bound side this is now a theorem (the bipartite witnesses have
+    no odd cycle); the open content is the matching upper bound. -/

--- a/research/erdos-574-oq-01/knowledge.md
+++ b/research/erdos-574-oq-01/knowledge.md
@@ -91,3 +91,73 @@ asymptotic constant, not just a few data points.
 ### Files
 - `research/erdos-574-oq-01/verify_lower_bound.py` (new, runs clean)
 - `research/erdos-574-oq-01/knowledge.md` (this file)
+
+---
+
+## Session 2026-06-25 (Session 2) — ACT
+
+**Mode:** continue from Session 1
+**Outcome:** progress (ACT — formalized the reusable "odd cycle is free"
+core; 3 verified theorems, 0 axioms, 0 sorries)
+
+### What was done
+
+Took Session 1's flagged next step ("Generalize the 'bipartite ⟹
+`C_{2k-1}`-free' lemma to all `k` — the reusable core, `O(50)` LOC") and
+formalized it in `proofs/Proofs/Erdos574Problem.lean` against the file's
+own lightweight `SimpleGraph'` / `HasCycle` definitions (no PG(2,q)
+construction needed — that is the heavier, separable lower-bound witness
+project deferred for later).
+
+New declarations (all machine-checked, `#print axioms` shows only
+`propext`/`Classical.choice`/`Quot.sound`, which do not count):
+
+- `def IsBipartite` — vertices 2-colourable (`Fin n → Bool`) with no
+  monochromatic edge.
+- `theorem bipartite_not_hasCycle_odd` — **a bipartite graph has no cycle
+  of any odd length.** Proof: lift the cycle to a closed walk on ℕ via
+  wrap-around `w j = cycle ⟨j % ℓ, _⟩`; the 2-colouring flips at each
+  step (`c (w (j+1)) = !(c (w j))`), so by induction
+  `c (w j) = (!·)^[j] (c (w 0))`; the walk closes (`w ℓ = w 0`), giving
+  `c (w 0) = (!·)^[ℓ] (c (w 0))`, and for odd `ℓ` the iterate flips,
+  contradiction. Injectivity of the cycle is **not used** — only the
+  closed-walk adjacencies.
+- `theorem bipartite_no_odd_consecutive` — bipartite ⟹ no `C_{2k-1}` for
+  `k ≥ 1` (since `2k-1` is odd).
+- `theorem bipartite_evenFree_consecutiveFree` — bipartite + `C_{2k}`-free
+  ⟹ `{C_{2k-1}, C_{2k}}`-free. **This is the lower-bound transfer**: on
+  bipartite witnesses the even-cycle condition already gives the whole
+  consecutive-pair constraint, so the lower bound for
+  `ex(n; {C_{2k-1}, C_{2k}})` matches `ex(n; C_{2k})` with no loss.
+
+Supporting `private lemma not_iterate_eq`: `(!·)^[m] b = if Even m then b
+else !b`.
+
+### Gotchas / build notes
+- **Docker still down.** Typechecked with the explicitly-safe
+  `lake env lean <file>` (single file, bounded memory — *not* the blocked
+  runaway `lake build`), using the main repo's prebuilt Mathlib oleans.
+- `Mathlib.Data.Nat.Parity` olean does **not exist** in this v4.26 build;
+  use `Mathlib.Algebra.Ring.Parity` instead. `Nat.odd_iff_not_even` is
+  also gone — derive `¬ Even ℓ` via `Nat.even_iff` + `Nat.odd_iff` +
+  `omega`.
+- The pre-existing `edgeCount'` needed `open Classical in` (predicate over
+  `G.adj` is not decidable). `open Classical in` must precede the
+  docstring, not sit between docstring and `def`.
+- The pre-existing `HasCycle` `(by omega)` for `0 < ℓ` couldn't see the
+  bound; `(by have := i.isLt; omega)` fixes it.
+- Floating `/-- … -/` doc-comments (no following declaration) are parse
+  errors — the trailing commentary blocks must be `/- … -/`.
+
+### Status
+Headline conjecture **still OPEN** (only the matching upper bound is the
+open content). Entry kept `status: axiomatized`, `badge: wip` per the
+open-conjecture rule; the conjecture is stated only as commentary, never
+claimed proven. The three new theorems are genuinely verified.
+
+### Next steps
+- (Optional, larger) Formalize the `PG(2,q)` incidence-graph witness as a
+  concrete `SimpleGraph'` and prove it `IsBipartite` + `C_4`-free + edge
+  count, then feed `bipartite_evenFree_consecutiveFree` to get an explicit
+  `k = 2` lower-bound graph. Few-hundred-LOC finite-geometry project.
+- Upper bound stays OPEN; do not submit to Aristotle.

--- a/research/problems/erdos-574/state.md
+++ b/research/problems/erdos-574/state.md
@@ -1,27 +1,34 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-13T16:48:35.123Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-06-25
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalized the reusable lower-bound core: bipartite ⟹ no odd cycle ⟹
+C_{2k-1}-free, so the odd-cycle constraint is "free" on bipartite
+witnesses.
 
 ## Active Approach
 
-None yet.
+Lean theorems in `proofs/Proofs/Erdos574Problem.lean`
+(`bipartite_not_hasCycle_odd`, `bipartite_no_odd_consecutive`,
+`bipartite_evenFree_consecutiveFree`); all verified, 0 axioms, 0 sorries.
 
 ## Blockers
 
-None.
+Docker down (typechecked via safe single-file `lake env lean`). Headline
+upper bound is genuinely OPEN.
 
 ## Next Action
 
-Begin problem exploration.
+Optional: formalize the PG(2,q) incidence-graph witness as a concrete
+`SimpleGraph'` and apply the transfer lemma for an explicit k=2 lower
+bound. Upper bound stays open; do not submit to Aristotle.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -19,12 +19,12 @@
     "erdosUrl": "https://erdosproblems.com/574",
     "axiomCount": 0,
     "badge": "wip",
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "assumptions": "0 axioms, 0 sorries. The headline Erdős–Simonovits conjecture (#574) remains OPEN and is stated only as commentary, not as a proven theorem — hence the 'axiomatized' status. The file now contributes three machine-checked theorems formalizing the unconditional lower-bound core: a bipartite graph has no cycle of odd length (bipartite_not_hasCycle_odd), hence contains no C_{2k−1} (bipartite_no_odd_consecutive), hence a bipartite C_{2k}-free graph is automatically {C_{2k−1}, C_{2k}}-free (bipartite_evenFree_consecutiveFree). This is the structural reason the lower bound for ex(n; {C_{2k−1}, C_{2k}}) transfers with no loss from ex(n; C_{2k}); the only open content is the matching upper bound.",
     "proofRepoPath": "Proofs/Erdos574Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 78,
-    "theoremCount": 0,
-    "definitionCount": 5
+    "lineCount": 188,
+    "theoremCount": 3,
+    "definitionCount": 6
   },
   "sections": [
     {
@@ -101,21 +101,25 @@
     "https://erdosproblems.com/574"
   ],
   "leanFile": {
-    "lineCount": 78,
+    "lineCount": 188,
     "structureCount": 1,
     "axiomCount": 0,
-    "theoremCount": 0,
-    "lemmaCount": 0,
+    "theoremCount": 3,
+    "lemmaCount": 1,
     "imports": [
       "Mathlib.Data.Nat.Basic",
+      "Mathlib.Algebra.Ring.Parity",
       "Mathlib.Data.Real.Basic",
       "Mathlib.Data.Finset.Basic",
+      "Mathlib.Logic.Function.Iterate",
       "Mathlib.Tactic"
     ],
-    "opens": [],
+    "opens": [
+      "Classical"
+    ],
     "path": "Proofs/Erdos574Problem.lean",
     "sorries": 0,
-    "definitionCount": 5
+    "definitionCount": 6
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Erdős #574 — Turán number for consecutive cycle pairs

**Problem (OPEN):** for $k \ge 2$, is $\mathrm{ex}(n; \{C_{2k-1}, C_{2k}\}) = (1+o(1))(n/2)^{1+1/k}$? I.e. does additionally forbidding the *odd* cycle $C_{2k-1}$ cost nothing asymptotically beyond forbidding $C_{2k}$ alone?

The genuinely open content is the matching **upper** bound (at least as hard as the exact even-cycle constant, itself open for general $k$). This PR formalizes the **lower-bound** side, which is *not* conjectural.

### What is proved (all machine-checked, 0 axioms, 0 sorries)

The dense $C_{2k}$-free extremal graphs from incidence geometry (projective planes / generalized polygons; Wenger 1991, Lazebnik–Ustimenko–Woldar 1995) are **bipartite**, hence contain **no odd cycle at all**, hence are automatically $C_{2k-1}$-free. So forbidding the odd cycle is "free" on the lower-bound side — as a theorem, not as evidence. This PR captures that structural core against the file's lightweight `SimpleGraph'` / `HasCycle` definitions:

- `def IsBipartite` — vertices 2-colourable (`Fin n → Bool`) with no monochromatic edge.
- `theorem bipartite_not_hasCycle_odd` — **a bipartite graph has no cycle of any odd length.** The 2-colouring alternates along the closed walk, so a walk that returns to its start must have even length. (Cycle injectivity is not even used — only the closed-walk adjacencies.)
- `theorem bipartite_no_odd_consecutive` — consequently a bipartite graph contains no $C_{2k-1}$, for every $k \ge 1$.
- `theorem bipartite_evenFree_consecutiveFree` — a bipartite, $C_{2k}$-free graph is `{C_{2k-1}, C_{2k}}`-free. **This is the lower-bound transfer**: the even-cycle condition is the only real constraint, so $\mathrm{ex}(n; \{C_{2k-1}, C_{2k}\})$ matches $\mathrm{ex}(n; C_{2k})$ with no loss.

Plus a supporting `private lemma not_iterate_eq`: iterating Boolean negation $m$ times flips the bit iff $m$ is odd.

`#print axioms` on all three theorems lists only `propext` / `Classical.choice` / `Quot.sound` (the ordinary foundational axioms, which do not count).

### Status

The **headline conjecture stays OPEN** (only the matching upper bound is the open content). The entry keeps `status: axiomatized`, `badge: wip` per the open-conjecture rule; the conjecture is stated only as commentary, never claimed proven. Earlier sessions' lower-bound verification (`verify_lower_bound.py`, exact $k=2$ leading constant via $PG(2,q)$) is unchanged.

### Build note

Docker was down; the file was typechecked with the explicitly-safe single-file `lake env lean` (bounded memory — not the blocked runaway `lake build`) against the prebuilt Mathlib v4.26 oleans. Clean, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)