### PR TITLE
Enrich Eulerian fourth column ⟨n,3⟩: add overview, conclusion, annotations

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/annotations.json
@@ -1,13 +1,50 @@
 [
   {
-    "id": "ann-col-three",
+    "id": "ann-gs-eul3-setup",
     "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
-    "range": { "startLine": 54, "endLine": 79 },
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "Setup: Continuing the Eulerian-Triangle Column Program",
+    "content": "The file imports Mathlib and the parent module that supplies columns 0–2 of the Eulerian triangle. The docstring recalls the parent's results — ⟨n,0⟩ = 1, ⟨n,1⟩ = 2ⁿ − n − 1 (A000295), 2·⟨n,2⟩ = 2·3ⁿ − (n+1)·2ⁿ⁺¹ + n·(n+1) (A000460) — and states the new target ⟨n,3⟩ = 4ⁿ − (n+1)·3ⁿ + C(n+1,2)·2ⁿ − C(n+1,3) (A000498), the third nontrivial case of the Eulerian inclusion–exclusion formula ⟨n,k⟩ = ∑_{i=0}^{k}(−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ. It is stated cleared of its /6 so the identity stays over ℤ. The docstring also performs the arithmetic sanity checks ⟨3,3⟩=0, ⟨4,3⟩=1, ⟨5,3⟩=26 and previews the induction-via-recurrence method. The `open` line brings the Nat, Finset, and both ancestor namespaces into scope so `eulerian` and `eulerian_col_two` resolve unqualified.",
+    "mathContext": "$\\langle n,k\\rangle = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k{+}1{-}i)^n$; this entry is the $k=3$ column, OEIS A000498.",
+    "significance": "context",
+    "relatedConcepts": ["Eulerian numbers", "Eulerian triangle", "Worpitzky identity", "inclusion–exclusion", "OEIS A000498"],
+    "prerequisites": ["Eulerian numbers and ascent statistics", "the parent column-two formula", "OEIS column sequences A000295/A000460/A000498"]
+  },
+  {
+    "id": "ann-gs-eul3-statement",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 50, "endLine": 59 },
     "type": "theorem",
-    "title": "Fourth Column Closed Form ⟨n,3⟩",
-    "content": "The closed form for the fourth column of the Eulerian triangle: $\\langle n,3\\rangle = 4^n - (n{+}1)3^n + \\binom{n+1}{2}2^n - \\binom{n+1}{3}$ (OEIS A000498), stated as $6\\langle n,3\\rangle = 6\\cdot4^n - 6(n{+}1)3^n + 3n(n{+}1)2^n - (n{-}1)n(n{+}1)$ to stay over $\\mathbb{Z}$ with no division. It is the third nontrivial case of the Eulerian inclusion–exclusion formula $\\langle n,k\\rangle = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k{+}1{-}i)^n$. The proof inducts on $n$ using the definitional recurrence $\\langle n{+}1,3\\rangle = 4\\langle n,3\\rangle + (n{-}2)\\langle n,2\\rangle$ (`rfl`), the inductive hypothesis, and the parent's `eulerian_col_two`. The truncated $(n-2:\\mathbb{N})$ is handled by splitting $n\\in\\{0,1,\\ge 2\\}$: for $n\\in\\{0,1\\}$ the column-two value $\\langle n,2\\rangle = 0$ zeroes the term either way. Checks: $\\langle 3,3\\rangle=0$, $\\langle 4,3\\rangle=1$, $\\langle 5,3\\rangle=26$.",
-    "mathContext": "$6\\langle n,3\\rangle = 6\\cdot4^n - 6(n{+}1)3^n + 3n(n{+}1)2^n - (n{-}1)n(n{+}1)$.",
+    "title": "Fourth Column Closed Form ⟨n,3⟩ and the Base Case",
+    "content": "The headline theorem `eulerian_col_three` states $6\\langle n,3\\rangle = 6\\cdot4^n - 6(n{+}1)3^n + 3n(n{+}1)2^n - (n{-}1)n(n{+}1)$ over ℤ — the closed form cleared of its denominator 6 so every term is an integer and the inductive step reduces to a single `ring` call. Equivalently $\\langle n,3\\rangle = 4^n - (n{+}1)3^n + \\binom{n+1}{2}2^n - \\binom{n+1}{3}$, OEIS A000498. The proof is `induction n`; the base case `zero` is `norm_num [eulerian]`, which unfolds the Eulerian definition at n=0 (where ⟨0,3⟩ = 0) and checks 6·0 = 6·1 − 6·1 + 0 − (−1)·0·1 = 0 numerically. Casting the whole statement to ℤ is what enables an honest subtraction (n:ℤ)−1 in the last term rather than truncated ℕ subtraction.",
+    "mathContext": "$6\\langle n,3\\rangle = 6\\cdot4^n - 6(n{+}1)3^n + 3n(n{+}1)2^n - (n{-}1)n(n{+}1)$; base case $n=0$ gives $0=0$.",
     "significance": "key",
-    "relatedConcepts": ["Eulerian numbers", "Eulerian triangle", "Inclusion–exclusion", "Worpitzky identity", "OEIS A000498"]
+    "relatedConcepts": ["closed form", "induction over ℤ", "cleared denominator", "OEIS A000498", "norm_num"],
+    "prerequisites": ["the Eulerian number definition", "casting ℕ statements to ℤ", "norm_num on definitional values"]
+  },
+  {
+    "id": "ann-gs-eul3-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 60, "endLine": 66 },
+    "type": "technique",
+    "title": "The Column Recurrence by Definitional Unfolding (rfl)",
+    "content": "In the successor case the hypothesis `hrec` records the single-step Eulerian recurrence for column 3: 6·⟨n+1,3⟩ = 4·(6·⟨n,3⟩) + 3·(n−2)·(2·⟨n,2⟩). The crucial line `rw [show eulerian (n+1) 3 = 4 * eulerian n 3 + (n - 2) * eulerian n 2 from rfl]` obtains the recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩ purely by `rfl` — it is the gallery's triangle recurrence ⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩ definitionally unfolded at k=2 (so k+2 = 4, n−k = n−2). Because `eulerian` is defined directly by this recurrence and the second index is the fixed literal 3, Lean reduces it with no separate lemma. The surrounding `push_cast; ring` rescales by 6 and distributes the coefficient 3 to match the cleared-denominator statement.",
+    "mathContext": "$\\langle n{+}1,3\\rangle = 4\\langle n,3\\rangle + (n{-}2)\\langle n,2\\rangle$, the triangle recurrence $\\langle n{+}1,k{+}1\\rangle = (k{+}2)\\langle n,k{+}1\\rangle + (n{-}k)\\langle n,k\\rangle$ at $k=2$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian triangle recurrence", "definitional equality (rfl)", "push_cast", "ring"],
+    "prerequisites": ["the triangle recurrence for Eulerian numbers", "definitional unfolding in Lean", "ring normalization over ℤ"]
+  },
+  {
+    "id": "ann-gs-eul3-truncated-sub",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02",
+    "range": { "startLine": 67, "endLine": 78 },
+    "type": "insight",
+    "title": "Reconciling Truncated ℕ-Subtraction (n−2) and Closing the Step",
+    "content": "The recurrence coefficient (n−2) is a truncated natural subtraction: for n ∈ {0,1} it collapses to 0, so ((n−2:ℕ):ℤ) ≠ (n:ℤ)−2 there. The hypothesis `key` shows this discrepancy is harmless by feeding the parent's `eulerian_col_two` and case-splitting n via `rcases n with _ | _ | m`. For n=0 and n=1 (`norm_num`), the column-two value ⟨n,2⟩ = 0 multiplies the coefficient, so both sides are 0 regardless of which subtraction is used. For n = m+2 (≥2), `hsub : ((m+1+1−2:ℕ):ℤ) = (m:ℤ)` (`simp`) confirms the natural and integer subtractions agree, and `push_cast; ring` finishes. The final line `rw [hrec, ih, key]; push_cast [pow_succ]; ring` substitutes the recurrence, the inductive hypothesis (6·⟨n,3⟩), and the reconciled column-two term, then closes the entire successor case as one polynomial identity over ℤ. This is the same structural fix the parent used for (n−1) in column 2, one column shallower — the truncation always lands exactly where the multiplied Eulerian value vanishes.",
+    "mathContext": "$(n{-}2:\\mathbb{N})$ truncates for $n<2$, but $\\langle n,2\\rangle = 0$ there, so $(n{-}2)\\langle n,2\\rangle$ is unaffected; for $n\\ge 2$, $((n{-}2:\\mathbb{N}):\\mathbb{Z}) = (n:\\mathbb{Z})-2$.",
+    "significance": "key",
+    "relatedConcepts": ["truncated natural subtraction", "case analysis (rcases)", "eulerian_col_two", "Nat.cast and simp", "induction step closure"],
+    "prerequisites": ["truncated ℕ subtraction and its cast to ℤ", "the parent column-two closed form", "the vanishing ⟨0,2⟩ = ⟨1,2⟩ = 0"]
   }
 ]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02/meta.json
@@ -44,13 +44,101 @@
     "theoremCount": 1,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Eulerian numbers ⟨n,k⟩ count permutations of {1,…,n} with exactly k ascents (equivalently k descents). They were introduced by Leonhard Euler in his 1755 Institutiones calculi differentialis while studying the evaluation of the alternating-sign series ∑ kⁿ xᵏ, and the row-generating polynomials ∑ₖ ⟨n,k⟩ xᵏ are now called Eulerian polynomials. The triangle of values satisfies the recurrence ⟨n+1,k⟩ = (k+1)·⟨n,k⟩ + (n−k+1)·⟨n,k−1⟩ and is symmetric, ⟨n,k⟩ = ⟨n,n−1−k⟩. Worpitzky's 1883 identity xⁿ = ∑ₖ ⟨n,k⟩·C(x+k, n) ties them to the Newton/binomial basis and yields the inclusion–exclusion closed form for each column. Successive columns reproduce well-known integer sequences: column 1 is A000295 (Eulerian/`2ⁿ − n − 1`), column 2 is A000460, and column 3 — the subject here — is OEIS A000498. This entry continues the gallery's column-by-column program (parent geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01 settled columns 0–2) one level deeper.",
+    "problemStatement": "Prove a division-free closed form for the fourth column of the Eulerian triangle: for all n, 6·⟨n,3⟩ = 6·4ⁿ − 6·(n+1)·3ⁿ + 3·n·(n+1)·2ⁿ − (n−1)·n·(n+1), equivalently ⟨n,3⟩ = 4ⁿ − (n+1)·3ⁿ + C(n+1,2)·2ⁿ − C(n+1,3) (OEIS A000498), the k=3 instance of the inclusion–exclusion formula ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ.",
+    "proofStrategy": "Induction on n over ℤ, with the statement pre-multiplied by 6 so no division by 6 is needed and the whole identity lives in a commutative ring where `ring` can close it. The base case n=0 is definitional (`norm_num [eulerian]`). The step rests on the single-step column recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩, which holds by `rfl` because it is the defining triangle recurrence unfolded at k=2 (here k+2 = 4 and n−k = n−2). The inductive hypothesis supplies 6·⟨n,3⟩, and the parent's eulerian_col_two supplies 2·⟨n,2⟩; substituting both reduces the step to a polynomial identity discharged by `push_cast [pow_succ]; ring`. The one genuine subtlety is the truncated ℕ subtraction (n−2): a three-way case split n ∈ {0,1,≥2} reconciles ((n−2:ℕ):ℤ) with (n:ℤ)−2 — for n∈{0,1} the parent formula forces ⟨n,2⟩ = 0 so the term vanishes regardless, and for n≥2 the natural and integer subtractions agree.",
+    "keyInsights": [
+      "Pre-clearing the denominator is what makes the proof elementary: stating 6·⟨n,3⟩ (rather than ⟨n,3⟩ = …/6) keeps every quantity an integer, so the inductive step is a single `ring` call over ℤ instead of a fragile rational-arithmetic argument.",
+      "The column recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩ is true by definitional unfolding (`rfl`) — no separate recurrence lemma is needed, because the gallery's `eulerian` is defined directly by the triangle recurrence and Lean reduces it at the fixed small index k=2.",
+      "Truncated ℕ subtraction is the recurring hazard in these column proofs, and the fix is structural: the coefficient (n−k) multiplies ⟨n,k⟩, and exactly on the range where ℕ-subtraction truncates (n < k) the Eulerian value ⟨n,k⟩ is already 0, so the discrepancy multiplies zero and disappears. This mirrors the parent's handling of (n−1) for column 2, one column shallower.",
+      "Each column is genuinely a corollary of the one before it: column 3 consumes column 2 (eulerian_col_two) as its only nontrivial input, so the inclusion–exclusion closed forms cascade — a template that mechanically produces column 4, 5, … by the same induction with one more substituted predecessor.",
+      "The closed form is an alternating sum of geometric terms (k+1−i)ⁿ weighted by binomial coefficients C(n+1,i); read as inclusion–exclusion, ⟨n,3⟩ subtracts overcounted configurations across 4 'slots', the combinatorial content of the Worpitzky/inclusion–exclusion identity."
+    ],
+    "prerequisites": [
+      "Eulerian numbers and the triangle recurrence ⟨n+1,k⟩ = (k+1)·⟨n,k⟩ + (n−k+1)·⟨n,k−1⟩",
+      "induction over ℕ with a statement cast to ℤ",
+      "truncated natural-number subtraction and casting ((a−b:ℕ):ℤ) vs (a:ℤ)−b",
+      "the parent column-two closed form eulerian_col_two",
+      "polynomial normalization via push_cast and ring"
+    ]
+  },
   "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Imports, Parent Columns, and Method",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Imports Mathlib and the parent module GeometricSeriesOQ07OQ01OQ01OQ01OQ01 (columns 0–2 of the Eulerian triangle). The docstring recalls eulerian_col_zero/one/two, states the target column-three closed form 6·⟨n,3⟩ = 6·4ⁿ − 6·(n+1)·3ⁿ + 3·n·(n+1)·2ⁿ − (n−1)·n·(n+1) (OEIS A000498), checks it numerically against rows ⟨3,3⟩=0, ⟨4,3⟩=1, ⟨5,3⟩=26, and outlines the induction-via-recurrence method including the truncated-(n−2) reconciliation. Opens the Nat, Finset, and both ancestor namespaces.",
+      "mathContext": "$\\langle n,3\\rangle = 4^n - (n{+}1)3^n + \\binom{n+1}{2}2^n - \\binom{n+1}{3}$, the $k=3$ case of $\\langle n,k\\rangle = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k{+}1{-}i)^n$."
+    },
     {
       "id": "col-three",
       "title": "The Fourth Column ⟨n,3⟩",
       "startLine": 50,
       "endLine": 79,
-      "summary": "eulerian_col_three: 6·⟨n,3⟩ = 6·4ⁿ − 6·(n+1)·3ⁿ + 3·n·(n+1)·2ⁿ − (n−1)·n·(n+1). Induction on n: the base is definitional; the step uses the recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩ (rfl), the inductive hypothesis, and the parent's eulerian_col_two, with a three-way case split on n to handle the truncated (n−2 : ℕ)."
+      "summary": "eulerian_col_three: 6·⟨n,3⟩ = 6·4ⁿ − 6·(n+1)·3ⁿ + 3·n·(n+1)·2ⁿ − (n−1)·n·(n+1). Induction on n: the base is definitional (norm_num [eulerian]); the step establishes the recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩ by rfl (hrec), reconciles the truncated (n−2 : ℕ) with (n−2 : ℤ) via a three-way case split feeding the parent's eulerian_col_two (key), then closes with the inductive hypothesis and push_cast [pow_succ]; ring."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Establishes the division-free closed form 6·⟨n,3⟩ = 6·4ⁿ − 6·(n+1)·3ⁿ + 3·n·(n+1)·2ⁿ − (n−1)·n·(n+1) for the fourth column of the Eulerian triangle (OEIS A000498), the third nontrivial instance of the Eulerian inclusion–exclusion formula, with 0 axioms and 0 sorries. The proof is a single induction on n closed by the definitional column recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩ and the parent's column-two formula.",
+    "implications": "Confirms that the gallery's column-by-column program for the Eulerian triangle is mechanizable to arbitrary depth: each column's closed form follows by the same induction from its immediate predecessor, with the only recurring care being the truncated ℕ subtraction (n−k), which is always neutralized by the vanishing of ⟨n,k⟩ on its truncation range. The cleared-denominator phrasing (stating 6·⟨n,3⟩ over ℤ) is the reusable trick that lets `ring` discharge the polynomial step. Together with the parent these entries formalize columns 0–3 of A008292 and link them to A000295, A000460, and A000498.",
+    "openQuestions": [
+      "Formalize the general inclusion–exclusion / Worpitzky closed form ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ for arbitrary k, rather than one column at a time, so the column lemmas become instances of a single theorem.",
+      "Prove the exponential generating function / Eulerian polynomial identity ∑ₙ Aₙ(t)·xⁿ/n! = (t−1)/(t − e^{(t−1)x}) and recover the column closed forms as Taylor coefficients.",
+      "Formalize the symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩ and verify the closed forms are consistent with it across columns.",
+      "Extend the cascade to columns 4 and 5 (OEIS A000505, A000514) to confirm the induction template scales and to populate the gallery's Eulerian family further."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "depends-on",
+      "description": "Direct parent: provides eulerian_col_two (the column-two closed form 2·⟨n,2⟩ = 2·3ⁿ − (n+1)·2ⁿ⁺¹ + n·(n+1)), the only nontrivial input to the column-three induction here, and establishes columns 0–2 that this entry extends."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "depends-on",
+      "description": "Grandparent: defines the Eulerian number `eulerian` via the triangle recurrence ⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩, whose definitional unfolding at k=2 gives the column-three recurrence ⟨n+1,3⟩ = 4·⟨n,3⟩ + (n−2)·⟨n,2⟩ used by rfl."
+    }
+  ],
+  "references": [
+    {
+      "author": "Euler, L.",
+      "title": "Institutiones calculi differentialis",
+      "year": 1755,
+      "note": "Origin of the Eulerian numbers, arising in the summation of ∑ kⁿ xᵏ"
+    },
+    {
+      "author": "Worpitzky, J.",
+      "title": "Studien über die Bernoullischen und Eulerschen Zahlen",
+      "year": 1883,
+      "note": "Worpitzky's identity xⁿ = ∑ₖ ⟨n,k⟩·C(x+k, n), source of the inclusion–exclusion closed form for each column"
+    },
+    {
+      "author": "Graham, R. L.; Knuth, D. E.; Patashnik, O.",
+      "title": "Concrete Mathematics",
+      "year": 1994,
+      "note": "§6.2 develops Eulerian numbers, the triangle recurrence, and the closed forms used here"
+    },
+    {
+      "author": "OEIS Foundation",
+      "title": "A000498 — Fourth column of the triangle of Eulerian numbers",
+      "year": 2026,
+      "note": "https://oeis.org/A000498 — the integer sequence ⟨n,3⟩ verified by this entry"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ03OQ02",
+    "lineCount": 80,
+    "axiomCount": 0,
+    "theoremCount": 1,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ03OQ02.lean",
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-03-oq-02` (quality 16, passes 0) — the closed form for the fourth column of the Eulerian triangle (OEIS A000498).

## Gaps addressed
The entry had only a description, originalContributions, one section, and a single annotation. Missing: the entire `overview`, `conclusion`, `crossReferences`, `references`, and `leanFile` blocks; preamble section coverage; and fine-grained annotations.

## Changes
**meta.json**
- **overview**: historicalContext (Euler 1755 / Worpitzky 1883, ascent statistics, Eulerian polynomials, OEIS column sequences A000295/A000460/A000498), problemStatement, proofStrategy, 5 keyInsights.
- **conclusion**: summary, implications, 4 openQuestions (general Worpitzky closed form, EGF identity, symmetry ⟨n,k⟩=⟨n,n−1−k⟩, columns 4–5).
- **crossReferences**: parent (`eulerian_col_two`) and grandparent (`eulerian` definition), both `depends-on`.
- **references**: Euler, Worpitzky, Concrete Mathematics, OEIS A000498.
- **leanFile** block + expanded **sections** to cover the previously-uncovered preamble (L1–49).

**annotations.json** — grew 1 → 4 line-anchored annotations, each with mathContext/significance/relatedConcepts/prerequisites:
1. Setup / column program (L1–49)
2. Statement + base case (L50–59)
3. Column recurrence by definitional `rfl` (L60–66)
4. Truncated ℕ-subtraction reconciliation + step closure (L67–78)

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof.
- meta.json/annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, badge `original`, axiomCount 0 — accurate (`#print axioms` lists only propext/Classical.choice/Quot.sound; no native_decide, no structure-encoded assumptions).