### PR TITLE
research(derangements-oq-02-oq-04): low-codimension fixed-point counts S(n,n−2)=C(n,2), S(n,n−3)=2·C(n,3) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1044,6 +1044,7 @@ import Proofs.DerangementsOQ02OQ01
 import Proofs.DerangementsOQ02OQ01OQ01
 import Proofs.DerangementsOQ02OQ02
 import Proofs.DerangementsOQ02OQ02OQ01
+import Proofs.DerangementsOQ02OQ04
 import Proofs.DerangementsOQ03
 import Proofs.DerangementsOQ03OQ01
 import Proofs.DerangementsOQ03OQ01OQ02

--- a/proofs/Proofs/DerangementsOQ02OQ04.lean
+++ b/proofs/Proofs/DerangementsOQ02OQ04.lean
@@ -1,0 +1,59 @@
+import Mathlib
+import Proofs.DerangementsOQ02
+
+/-
+  Low-Codimension Fixed-Point Counts (derangements-oq-02-oq-04)
+
+  The parent `derangements-oq-02` proved the partial-derangement count
+    S(n,k) = C(n,k) · D(n−k)
+  (permutations of `Fin n` with exactly `k` fixed points), together with the two
+  extreme "high-codimension" cases:
+    S(n,n)   = 1        (`permsWithAllFixed_card_eq_one`, the identity)
+    S(n,n−1) = 0        (`permsWithNMinus1Fixed_eq_zero`, impossible).
+
+  This entry continues the table downward, evaluating the next two cases in closed
+  form by specialising the main formula at `D(2)=1` and `D(3)=2`:
+
+    S(n,n−2) = C(n,2)        — exactly the transpositions: choose the 2 moved
+                               points (C(n,2) ways), and there is a unique
+                               derangement of 2 points (the swap);
+    S(n,n−3) = 2·C(n,3)      — choose the 3 moved points (C(n,3) ways), each with
+                               D(3)=2 derangements (the two 3-cycles).
+
+  Together with the parent this gives the complete top of the fixed-point
+  distribution: counts `1, 0, C(n,2), 2·C(n,3), …` for `k = n, n−1, n−2, n−3, …`.
+  Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound`; the two
+  `decide`s evaluate `D(2)`, `D(3)` by kernel reduction) and `sorry`-free.
+-/
+
+namespace DerangementsOQ02OQ04
+
+open Finset Nat PartialDerangements
+
+/-- `D(2) = 1`: the unique derangement of two points is the transposition. -/
+theorem numDerangements_two : numDerangements 2 = 1 := by decide
+
+/-- `D(3) = 2`: the two derangements of three points are the two 3-cycles. -/
+theorem numDerangements_three : numDerangements 3 = 2 := by decide
+
+/-- **Permutations with exactly `n−2` fixed points are the transpositions.**
+`S(n,n−2) = C(n,2)` for `n ≥ 2`: choose the two moved points (`C(n,2)` ways);
+the unique derangement of two points (`D(2)=1`) is the swap. -/
+theorem card_perms_n_minus_two_fixed {n : ℕ} (hn : 2 ≤ n) :
+    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+      (Finset.univ.filter (fun x => σ x = x)).card = n - 2)).card = n.choose 2 := by
+  rw [card_perms_with_kfixed n (n - 2) (Nat.sub_le n 2)]
+  have h1 : n - (n - 2) = 2 := by omega
+  rw [h1, numDerangements_two, mul_one, Nat.choose_symm hn]
+
+/-- **Permutations with exactly `n−3` fixed points: `S(n,n−3) = 2·C(n,3)` for
+`n ≥ 3`.** Choose the three moved points (`C(n,3)` ways); each admits `D(3)=2`
+derangements (the two 3-cycles). -/
+theorem card_perms_n_minus_three_fixed {n : ℕ} (hn : 3 ≤ n) :
+    (Finset.univ.filter (fun σ : Equiv.Perm (Fin n) =>
+      (Finset.univ.filter (fun x => σ x = x)).card = n - 3)).card = 2 * n.choose 3 := by
+  rw [card_perms_with_kfixed n (n - 3) (Nat.sub_le n 3)]
+  have h1 : n - (n - 3) = 3 := by omega
+  rw [h1, numDerangements_three, Nat.choose_symm hn, Nat.mul_comm]
+
+end DerangementsOQ02OQ04

--- a/research/problems/derangements-oq-02-oq-04/knowledge.md
+++ b/research/problems/derangements-oq-02-oq-04/knowledge.md
@@ -1,0 +1,44 @@
+# Knowledge: derangements-oq-02-oq-04
+
+## Summary
+
+Closed forms for the top of the fixed-point distribution of permutations of
+`Fin n`, extending the parent's extreme cases:
+
+| k (fixed points) | S(n,k) = #{σ : exactly k fixed} |
+|---|---|
+| n | 1 (parent) |
+| n−1 | 0 (parent) |
+| n−2 | C(n,2)  (**this entry**, transpositions) |
+| n−3 | 2·C(n,3) (**this entry**) |
+
+## What is formalized (researcher-9, 2026-06-25)
+
+`proofs/Proofs/DerangementsOQ02OQ04.lean`, namespace `DerangementsOQ02OQ04`,
+0 ax / 0 sorry:
+
+- `numDerangements_two : numDerangements 2 = 1` (decide)
+- `numDerangements_three : numDerangements 3 = 2` (decide)
+- `card_perms_n_minus_two_fixed {n} (2 ≤ n) : S(n,n−2) = n.choose 2`
+- `card_perms_n_minus_three_fixed {n} (3 ≤ n) : S(n,n−3) = 2 * n.choose 3`
+
+## Proof
+
+Both specialise the parent `PartialDerangements.card_perms_with_kfixed (n k)
+(hk : k ≤ n) : S(n,k) = n.choose k * numDerangements (n−k)`:
+- rw at k=n−2 (resp. n−3); `n − (n−2) = 2` (resp. 3) by omega;
+- rw the small derangement value (D(2)=1 / D(3)=2);
+- `Nat.choose_symm hn : n.choose (n−k) = n.choose k` turns C(n,n−2)→C(n,2) etc.;
+- `mul_one` / `Nat.mul_comm` finish.
+
+## Lineage / dependencies
+
+- Parent `Proofs.DerangementsOQ02`, namespace `PartialDerangements`, opens
+  `Finset Fintype Nat Equiv.Perm`. `numDerangements` = `Nat.numDerangements`.
+  Olean in store; source matches origin/main.
+- `S(n,k)` is the filter-card `(univ.filter fun σ => (univ.filter fun x => σ x = x).card = k).card`.
+
+## Approaches Tried
+
+- Direct specialisation of the parent formula — worked first try; the only fiddle
+  was using `Nat.choose_symm` to flip C(n,n−2) into C(n,2).

--- a/research/problems/derangements-oq-02-oq-04/state.md
+++ b/research/problems/derangements-oq-02-oq-04/state.md
@@ -1,0 +1,37 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Iteration**: 1
+**Status**: in-progress
+
+## Current Focus
+
+Empty stub. Continued the partial-derangement table of the parent
+(derangements-oq-02): closed forms for the next fixed-point codimensions
+(researcher-9).
+
+## Delivered (PR pending)
+
+`proofs/Proofs/DerangementsOQ02OQ04.lean` — 4 theorems, 0 axioms, 0 sorries
+(typechecked `lake env lean`, Docker down; `#print axioms` = only
+propext/Classical.choice/Quot.sound):
+
+- `card_perms_n_minus_two_fixed {n} (2 ≤ n) : S(n,n−2) = C(n,2)` — the
+  transpositions (D(2)=1).
+- `card_perms_n_minus_three_fixed {n} (3 ≤ n) : S(n,n−3) = 2·C(n,3)` (D(3)=2).
+- `numDerangements_two` (D(2)=1), `numDerangements_three` (D(3)=2), by decide.
+
+Specialises the parent's `PartialDerangements.card_perms_with_kfixed`
+(S(n,k)=C(n,k)·D(n−k)) at k=n−2, n−3, using `Nat.choose_symm` and the small
+derangement values.
+
+## Notes
+
+Parent already had the extremes S(n,n)=1 (`permsWithAllFixed_card_eq_one`) and
+S(n,n−1)=0 (`permsWithNMinus1Fixed_eq_zero`); this fills codimensions 2 and 3.
+
+## Next Action
+
+Follow-up: S(n,n−4) = 9·C(n,4) (D(4)=9), or the expected number of fixed points
+= 1 (∑_k k·S(n,k) = n!).

--- a/src/data/proofs/derangements-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/derangements-oq-02-oq-04/annotations.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "ann-codim-two",
+    "proofId": "derangements-oq-02-oq-04",
+    "range": { "startLine": 42, "endLine": 50 },
+    "type": "theorem",
+    "title": "Exactly n−2 Fixed Points: the Transpositions",
+    "content": "For $n \\ge 2$, the number of permutations of $\\mathrm{Fin}\\,n$ with **exactly** $n-2$ fixed points is $\\binom{n}{2}$. These are precisely the transpositions: pick the two moved points ($\\binom{n}{2}$ ways), and the only derangement of two points is the swap ($D(2)=1$). Formally this specialises the parent's $S(n,k)=\\binom{n}{k}D(n-k)$ at $k=n-2$: $n-(n-2)=2$, $D(2)=1$, and $\\binom{n}{n-2}=\\binom{n}{2}$ by `Nat.choose_symm`.",
+    "mathContext": "$S(n,n-2) = \\binom{n}{2}$ for $n \\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Partial derangements", "Transpositions", "Rencontres numbers", "Binomial coefficient"]
+  },
+  {
+    "id": "ann-codim-three",
+    "proofId": "derangements-oq-02-oq-04",
+    "range": { "startLine": 52, "endLine": 57 },
+    "type": "theorem",
+    "title": "Exactly n−3 Fixed Points",
+    "content": "For $n \\ge 3$, the number of permutations with exactly $n-3$ fixed points is $2\\binom{n}{3}$: choose the three moved points ($\\binom{n}{3}$ ways), each admitting the two 3-cycles ($D(3)=2$). Again a specialisation of $S(n,k)=\\binom{n}{k}D(n-k)$, at $k=n-3$. Together with the parent's $S(n,n)=1$, $S(n,n-1)=0$ and the codimension-2 case, this completes the top of the fixed-point distribution: $1, 0, \\binom{n}{2}, 2\\binom{n}{3}, \\dots$",
+    "mathContext": "$S(n,n-3) = 2\\binom{n}{3}$ for $n \\ge 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Partial derangements", "3-cycles", "Rencontres numbers"]
+  }
+]

--- a/src/data/proofs/derangements-oq-02-oq-04/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-04/meta.json
@@ -1,0 +1,77 @@
+{
+  "id": "derangements-oq-02-oq-04",
+  "title": "Low-Codimension Fixed-Point Counts: S(n,n−2) = C(n,2) and S(n,n−3) = 2·C(n,3)",
+  "slug": "derangements-oq-02-oq-04",
+  "description": "Closed forms for the top of the fixed-point distribution of permutations of Fin n. The parent (derangements-oq-02) proved the partial-derangement count S(n,k) = C(n,k)·D(n−k) — permutations with exactly k fixed points — together with the two extreme cases S(n,n) = 1 (the identity) and S(n,n−1) = 0 (impossible). This entry evaluates the next two cases by specialising the main formula at the small derangement numbers D(2) = 1 and D(3) = 2: S(n,n−2) = C(n,2) for n ≥ 2 (exactly the transpositions — choose the 2 moved points, with the unique swap as their derangement) and S(n,n−3) = 2·C(n,3) for n ≥ 3 (choose the 3 moved points, each admitting the two 3-cycles). Together with the parent this gives the complete top of the distribution: 1, 0, C(n,2), 2·C(n,3), … for k = n, n−1, n−2, n−3, …. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Classical (partial derangements / rencontres numbers); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Rencontres_numbers",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "permutations",
+      "fixed-points",
+      "rencontres-numbers",
+      "binomial-coefficients",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DerangementsOQ02OQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "PartialDerangements.card_perms_with_kfixed",
+        "description": "The parent's main theorem S(n,k) = C(n,k)·D(n−k): the number of permutations of Fin n with exactly k fixed points. Specialised here at k = n−2 and k = n−3.",
+        "module": "Proofs.DerangementsOQ02"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "n.choose (n − k) = n.choose k for k ≤ n. Converts C(n,n−2), C(n,n−3) to C(n,2), C(n,3).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.numDerangements",
+        "description": "The derangement-count function D(m); D(2) = 1 and D(3) = 2 are evaluated by kernel `decide`.",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      }
+    ],
+    "originalContributions": [
+      "card_perms_n_minus_two_fixed: S(n,n−2) = C(n,2) for n ≥ 2 — the permutations of Fin n with exactly n−2 fixed points are precisely the C(n,2) transpositions, obtained from the parent's S(n,k) = C(n,k)·D(n−k) at D(2) = 1 and C(n,n−2) = C(n,2)",
+      "card_perms_n_minus_three_fixed: S(n,n−3) = 2·C(n,3) for n ≥ 3 — choose the three moved points (C(n,3) ways), each admitting the two 3-cycles (D(3) = 2)",
+      "numDerangements_two (D(2) = 1) and numDerangements_three (D(3) = 2), the small derangement values feeding the two counts, by kernel decide",
+      "Completes the top of the fixed-point distribution begun by the parent's extreme cases: 1, 0, C(n,2), 2·C(n,3), … for codimensions 0, 1, 2, 3"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 59,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on card_perms_n_minus_two_fixed and card_perms_n_minus_three_fixed reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). The two `decide`s (D(2)=1, D(3)=2) are kernel decidability, not native_decide, so no Lean.ofReduceBool. Builds on the project file DerangementsOQ02 (itself 0-axiom).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "small-derangements",
+      "title": "Small Derangement Values",
+      "startLine": 33,
+      "endLine": 38,
+      "summary": "numDerangements_two: D(2) = 1 (the unique swap); numDerangements_three: D(3) = 2 (the two 3-cycles), both by kernel decide. These feed the codimension counts below."
+    },
+    {
+      "id": "codim-two",
+      "title": "Codimension 2: the Transpositions",
+      "startLine": 42,
+      "endLine": 50,
+      "summary": "card_perms_n_minus_two_fixed: S(n,n−2) = C(n,2) for n ≥ 2. From the parent's S(n,k) = C(n,k)·D(n−k) with n − (n−2) = 2, D(2) = 1, and Nat.choose_symm turning C(n,n−2) into C(n,2)."
+    },
+    {
+      "id": "codim-three",
+      "title": "Codimension 3",
+      "startLine": 52,
+      "endLine": 57,
+      "summary": "card_perms_n_minus_three_fixed: S(n,n−3) = 2·C(n,3) for n ≥ 3, similarly with D(3) = 2 and Nat.choose_symm."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Continues the partial-derangement table of the parent (`derangements-oq-02`), which proved $S(n,k)=\binom{n}{k}D(n-k)$ (permutations of $\mathrm{Fin}\,n$ with exactly $k$ fixed points) plus the extremes $S(n,n)=1$ and $S(n,n-1)=0$. This entry evaluates the next two codimensions in closed form. **4 theorems, 0 axioms, 0 sorries.**

- **`card_perms_n_minus_two_fixed`**: $S(n,n-2)=\binom{n}{2}$ for $n\ge 2$ — exactly the **transpositions** (choose the 2 moved points; $D(2)=1$, the unique swap).
- **`card_perms_n_minus_three_fixed`**: $S(n,n-3)=2\binom{n}{3}$ for $n\ge 3$ — choose the 3 moved points; each admits the two 3-cycles ($D(3)=2$).
- **`numDerangements_two`** ($D(2)=1$), **`numDerangements_three`** ($D(3)=2$), by kernel `decide`.

Both main results specialise the parent's `card_perms_with_kfixed` at $k=n-2,n-3$, using `Nat.choose_symm` to flip $\binom{n}{n-k}$ to $\binom{n}{k}$. Together with the parent this gives the full top of the fixed-point distribution: $1, 0, \binom{n}{2}, 2\binom{n}{3}, \dots$ for $k=n,n-1,n-2,n-3,\dots$

## Verification

- Typechecked via `lake env lean Proofs/DerangementsOQ02OQ04.lean` (exit 0; Docker unavailable this session).
- `#print axioms` on both main theorems = only `propext, Classical.choice, Quot.sound` → **0 counted axioms**. The two `decide`s ($D(2),D(3)$) are kernel decidability, **not** `native_decide`. Status `verified`, badge `original`.

Builds on `DerangementsOQ02` (0-axiom, on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)