### PR TITLE
Enrich Girth-6 Planar 3-Colorability: add annotations

### DIFF
--- a/src/data/proofs/euler-polyhedral-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/euler-polyhedral-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-ep03-setup",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 8, "endLine": 77 },
+    "type": "context",
+    "title": "Setup: The Girth-6 Sub-Case of Grötzsch's Theorem",
+    "content": "The docstring frames the result against Grötzsch's theorem (every triangle-free, i.e. girth ≥ 4, planar graph is 3-colorable), which is genuinely deep, needs discharging arguments, and is unformalized in Lean 4. The parent entry euler-polyhedral-oq-01 posed the weaker girth ≥ 6 case as its third open question, and that case is elementary: a girth-6 planar graph satisfies 6F ≤ 2E, which with Euler's formula V − E + F = 2 gives 2E ≤ 3V − 6, hence average degree < 3, hence 2-degeneracy, hence 3-colorability by greedy coloring. The five Mathlib imports supply SimpleGraph basics, finiteness, the handshaking/degree-sum lemma, the Coloring API, and ordered big operators (for the averaging inequality). Linters for unused variables are disabled because several section variables are used only in later parts.",
+    "mathContext": "Girth $\\ge 6$ planar $\\Rightarrow 6F \\le 2E$ and $V-E+F=2 \\Rightarrow 2E \\le 3V-6 \\Rightarrow$ average degree $< 3 \\Rightarrow$ 2-degenerate $\\Rightarrow$ 3-colorable.",
+    "significance": "context",
+    "relatedConcepts": ["Grötzsch's theorem", "girth", "planar graphs", "Euler's formula", "degeneracy", "greedy coloring"],
+    "prerequisites": ["planar graphs and girth", "Euler's polyhedral formula", "SimpleGraph and SimpleGraph.Coloring in Mathlib"]
+  },
+  {
+    "id": "ann-ep03-degin",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 82, "endLine": 84 },
+    "type": "definition",
+    "title": "In-Subset Degree degIn",
+    "content": "`degIn G W v` counts the neighbours of v that lie inside the vertex subset W: the cardinality of W.filter (G.Adj v ·). This 'in-degree relative to W' is the right primitive for degeneracy: a graph is k-degenerate exactly when every nonempty W contains a vertex with degIn ≤ k. Working with degIn rather than the global degree is what makes the bound hereditary — restricting to a subset only removes incidences, so the average-degree bound passes to every W without re-deriving Euler's formula on the induced subgraph.",
+    "mathContext": "$d_v(W) = |\\{w \\in W : v \\sim w\\}|$, the number of neighbours of $v$ inside $W$.",
+    "significance": "supporting",
+    "relatedConcepts": ["graph degeneracy", "induced subgraph", "Finset.filter", "hereditary edge bound"],
+    "prerequisites": ["Finset and Finset.filter", "adjacency relation G.Adj", "DecidableRel for filtering"]
+  },
+  {
+    "id": "ann-ep03-averaging",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 86, "endLine": 105 },
+    "type": "theorem",
+    "title": "Averaging: a Low In-Degree Witness in Every Subset",
+    "content": "`exists_low_degree_in_subset` is the pigeonhole engine: if the total in-subset incidence ∑_{v∈W} degIn G W v is strictly below (k+1)·|W|, then some v ∈ W has degIn ≤ k. The proof is by contradiction — if every vertex had degIn ≥ k+1, then `Finset.card_nsmul_le_sum` gives |W|·(k+1) ≤ ∑ degIn, i.e. the sum is at least (k+1)|W|, contradicting the strict upper bound (closed by `omega`). This is the single step that converts an edge/incidence bound into a degeneracy witness: feeding the girth-6 bound ∑ degIn < 3|W| with k = 2 yields a vertex of in-degree ≤ 2 inside any subset.",
+    "mathContext": "$\\sum_{v\\in W} d_v(W) < (k{+}1)|W| \\;\\Rightarrow\\; \\exists v\\in W,\\ d_v(W) \\le k$ (averaging / pigeonhole).",
+    "significance": "key",
+    "relatedConcepts": ["averaging argument", "pigeonhole principle", "Finset.card_nsmul_le_sum", "proof by contradiction", "omega"],
+    "prerequisites": ["sums over Finsets", "the mean is below max ⟹ some term is below threshold", "linear arithmetic (omega)"]
+  },
+  {
+    "id": "ann-ep03-greedy",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 111, "endLine": 170 },
+    "type": "technique",
+    "title": "Greedy Coloring on a Subset by Strong Induction (the heart)",
+    "content": "`proper_coloring_on_finset` is the core argument. Assuming k-degeneracy (every nonempty subset has a vertex of in-degree ≤ k), it produces for every subset W a (k+1)-coloring of V proper on W, by `Finset.strongInductionOn` on W. Empty W is vacuous. Otherwise pick a low-degree vertex v (hdeg), recurse on the strictly smaller W.erase v to get c', and extend by `Function.update c' v col` for a colour col avoided by v's coloured neighbours. The free colour exists because the set `used` of neighbour-colours has card ≤ degIn ≤ k < k+1 = |Fin (k+1)|, so it cannot be all of univ (a clean `Finset.card_le_card`/`omega` contradiction). Properness on the extended colouring is checked by a three-way case split on whether the endpoints u, w equal v: if u = v then w is a coloured neighbour so its colour is in `used` and differs from col (irreflexivity gives w ≠ v); symmetrically if w = v (using `G.adj_symm`); and if neither, both lie in W.erase v and the inductive colouring c' already separates them.",
+    "mathContext": "Strong induction on $|W|$: remove a vertex of in-degree $\\le k$, color the rest with $k{+}1$ colors, then assign the removed vertex any of the $\\ge 1$ colors its $\\le k$ neighbours avoid.",
+    "significance": "key",
+    "relatedConcepts": ["greedy coloring", "Szekeres–Wilf bound", "Finset.strongInductionOn", "Function.update", "adjacency symmetry and irreflexivity"],
+    "prerequisites": ["strong induction on finite sets", "pointwise function update", "the Fin (k+1) palette and pigeonhole for a free colour"]
+  },
+  {
+    "id": "ann-ep03-colorable",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 172, "endLine": 181 },
+    "type": "theorem",
+    "title": "Degeneracy ⟹ Colorability (genuine SimpleGraph.Colorable)",
+    "content": "`colorable_of_degenerate` packages the greedy argument as a real Mathlib `SimpleGraph.Colorable (k+1)` for any k-degenerate finite graph. It specialises `proper_coloring_on_finset` to W = Finset.univ — yielding a colouring proper on all of V — and wraps it with `Coloring.mk`, discharging the proper-edge obligation from the universal properness via membership in univ. This is the file's headline methodological upgrade over the parent: the parent encoded '5-degenerate ⟹ 6-colorable' as the numeral identity 5 + 1 = 6, whereas here the conclusion is an honest Colorable witness reusable for any degeneracy bound (e.g. k = 5 recovers the 6-color theorem as a true Colorable 6).",
+    "mathContext": "$k$-degenerate $\\Rightarrow G.\\mathrm{Colorable}\\,(k{+}1)$, the Szekeres–Wilf inequality $\\chi(G) \\le 1 + \\mathrm{degeneracy}(G)$ as a constructive coloring.",
+    "significance": "key",
+    "relatedConcepts": ["SimpleGraph.Colorable", "SimpleGraph.Coloring.mk", "Szekeres–Wilf bound", "Finset.univ specialization"],
+    "prerequisites": ["Mathlib's Colorable / Coloring API", "proper_coloring_on_finset", "coloring number vs chromatic number"]
+  },
+  {
+    "id": "ann-ep03-application",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 187, "endLine": 209 },
+    "type": "theorem",
+    "title": "Main Result (OQ-03): Girth-6 Planar Graphs are 3-Colorable",
+    "content": "`girth6_planar_three_colorable` is the affirmative answer to the open question. Its hypothesis `h_hereditary` — ∑_{v∈W} degIn G W v < 3|W| for every nonempty W — is exactly the per-subset content of 'planar with girth ≥ 6': it absorbs both the cyclic-subgraph bound 2e ≤ 3|W|−6 and the forest bound 2e ≤ 2|W|−2, both strictly below 3|W|. Phrasing planarity this way (a function argument, not a structure-encoded axiom) sidesteps needing an induced-subgraph handshaking lemma. The proof derives 2-degeneracy by applying `exists_low_degree_in_subset` with k = 2 to each subset, then invokes `colorable_of_degenerate G 2` to get Colorable (2+1) = Colorable 3.",
+    "mathContext": "$\\forall W\\ne\\emptyset,\\ \\sum_{v\\in W} d_v(W) < 3|W| \\;\\Rightarrow\\; G.\\mathrm{Colorable}\\,3$. The hypothesis is 2-degeneracy of every girth-6 planar graph.",
+    "significance": "key",
+    "relatedConcepts": ["girth-6 planar graphs", "2-degeneracy", "hereditary hypothesis", "open question OQ-03", "Grötzsch sub-case"],
+    "prerequisites": ["the averaging lemma with k=2", "colorable_of_degenerate", "the hereditary edge bound of high-girth planar graphs"]
+  },
+  {
+    "id": "ann-ep03-global-witness",
+    "proofId": "euler-polyhedral-oq-01-oq-03",
+    "range": { "startLine": 215, "endLine": 239 },
+    "type": "technique",
+    "title": "Global Degeneracy Witness via the Handshaking Lemma",
+    "content": "`girth6_exists_low_degree_vertex` produces a single global low-degree vertex (∃ v, G.degree v ≤ 2) from the whole-graph bound 2E ≤ 3V − 6 (with V ≥ 3), mirroring the parent file's degree-≤ 5 witness for general planar graphs. The proof is by contradiction: if every degree were ≥ 3, then ∑_v degree v ≥ 3V (via `Finset.sum_le_sum` against the constant 3), and Mathlib's handshaking lemma `sum_degrees_eq_twice_card_edges` rewrites ∑ degree = 2E, giving 3V ≤ 2E over ℤ — directly contradicting 2E ≤ 3V − 6 (closed by `linarith` after `push_cast`). Casting to ℤ is needed because 3V − 6 can underflow in ℕ. This is the non-hereditary companion to the averaging lemma: it gives one witness rather than one per subset.",
+    "mathContext": "If all degrees $\\ge 3$ then $\\sum_v \\deg v \\ge 3V$; handshaking $\\sum_v \\deg v = 2E$ gives $3V \\le 2E$, contradicting $2E \\le 3V-6$.",
+    "significance": "supporting",
+    "relatedConcepts": ["handshaking lemma", "sum_degrees_eq_twice_card_edges", "proof by contradiction", "ℤ-casting to avoid ℕ underflow", "linarith"],
+    "prerequisites": ["the degree-sum (handshaking) identity", "the girth-6 edge bound 2E ≤ 3V − 6", "integer arithmetic with linarith"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `euler-polyhedral-oq-01-oq-03` (quality 35, passes 0) — the affirmative answer that girth-6 planar graphs are 3-colorable via a genuine k-degenerate ⟹ (k+1)-colorable theorem.

## Gap addressed
The entry already had a rich meta.json (overview, conclusion, crossReferences, references, leanFile, sections) but **no annotations.json** — zero inline annotation coverage of the 241-line file.

## Changes
Added `annotations.json` with 7 line-anchored annotations spanning all four parts, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Setup / Grötzsch sub-case** (L8–77) — girth-6 vs full Grötzsch, the 2-degeneracy strategy.
2. **degIn definition** (L82–84) — in-subset degree, the hereditary primitive.
3. **Averaging lemma** (L86–105) — pigeonhole witness of low in-degree.
4. **Greedy coloring** (L111–170) — the heart: strong induction + Function.update, three-way case split.
5. **colorable_of_degenerate** (L172–181) — genuine SimpleGraph.Colorable upgrade.
6. **Main result OQ-03** (L187–209) — girth-6 planar ⟹ Colorable 3.
7. **Global witness** (L215–239) — handshaking-lemma degree-≤2 vertex.

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof; all 7 anchor to real Lean constructs.
- annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, badge `original`, axiomCount 0 — accurate (`#print axioms` lists only propext/Classical.choice/Quot.sound; the hereditary edge bound is an explicit function hypothesis, not a structure-encoded assumption, as meta.json already documents).