### PR TITLE
research(schauder-fixed-point-oq-04): the topology of the fixed-point set — nonempty & compact for self-maps of [a,b] [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3861,6 +3861,7 @@ import Proofs.SchauderFixedPoint
 import Proofs.SchauderFixedPointOQ01
 import Proofs.SchauderFixedPointOQ03
 import Proofs.SchauderFixedPointOQ03OQ01
+import Proofs.SchauderFixedPointOQ04
 import Proofs.SchroderNumbersOQ01
 import Proofs.SchroederBernstein
 import Proofs.SchroederBernsteinOQ01

--- a/proofs/Proofs/SchauderFixedPointOQ04.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ04.lean
@@ -1,0 +1,78 @@
+import Mathlib
+
+/-
+# Schauder Fixed Point — OQ-04: the topology of the fixed-point set
+
+The base entry (`schauder-fixed-point`) and its siblings establish *existence* of
+fixed points (Brouwer, Schauder, Kakutani), several of them resting on deep
+axioms. This entry takes a complementary, fully elementary and **axiom-free**
+angle: the *structure* of the fixed-point set itself.
+
+For a continuous self-map of a real interval `[a,b]` we show the fixed-point set
+is not merely nonempty but a **nonempty compact set**:
+
+* `isClosed_fixedPoints` — for continuous `f` on a Hausdorff space, `{x | f x = x}`
+  is closed (it is the equaliser of `f` and `id`);
+* `isCompact_fixedPoints_inter` — its intersection with any compact set is compact;
+* `exists_fixedPoint_Icc` — the one-dimensional Brouwer theorem: a continuous
+  `f : [a,b] → [a,b]` has a fixed point, via the intermediate value theorem
+  applied to `g x = f x − x` (`g a ≥ 0 ≥ g b`);
+* `fixedPoints_Icc_nonempty_isCompact` — combining the above: the fixed-point set
+  of a continuous self-map of `[a,b]` is nonempty and compact.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free; it imports only Mathlib (not the axiom-bearing base file).
+-/
+
+namespace SchauderFixedPointOQ04
+
+open Set
+
+/-- The fixed-point set of a self-map `f`. -/
+def fixedPoints {α : Type*} (f : α → α) : Set α := {x | f x = x}
+
+@[simp] theorem mem_fixedPoints {α : Type*} {f : α → α} {x : α} :
+    x ∈ fixedPoints f ↔ f x = x := Iff.rfl
+
+/-- **The fixed-point set of a continuous map is closed.** In a Hausdorff space,
+`{x | f x = x}` is the equaliser of `f` and `id`, hence closed. -/
+theorem isClosed_fixedPoints {α : Type*} [TopologicalSpace α] [T2Space α]
+    {f : α → α} (hf : Continuous f) : IsClosed (fixedPoints f) :=
+  isClosed_eq hf continuous_id
+
+/-- **The fixed-point set inside a compact set is compact.** A closed subset of a
+compact set is compact. -/
+theorem isCompact_fixedPoints_inter {α : Type*} [TopologicalSpace α] [T2Space α]
+    {f : α → α} (hf : Continuous f) {K : Set α} (hK : IsCompact K) :
+    IsCompact (K ∩ fixedPoints f) :=
+  hK.inter_right (isClosed_fixedPoints hf)
+
+/-- **One-dimensional Brouwer fixed-point theorem.** A continuous self-map of a
+closed interval `[a,b]` has a fixed point. Proof: `g x = f x − x` is continuous
+with `g a = f a − a ≥ 0` and `g b = f b − b ≤ 0` (because `f` maps into `[a,b]`),
+so by the intermediate value theorem `g` vanishes somewhere in `[a,b]`. -/
+theorem exists_fixedPoint_Icc {a b : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hf : Continuous f) (hmaps : ∀ x ∈ Icc a b, f x ∈ Icc a b) :
+    ∃ x ∈ Icc a b, f x = x := by
+  have hga : (0 : ℝ) ≤ f a - a := by
+    have := (hmaps a ⟨le_refl a, hab⟩).1; linarith
+  have hgb : f b - b ≤ 0 := by
+    have := (hmaps b ⟨hab, le_refl b⟩).2; linarith
+  have hgcont : ContinuousOn (fun x => f x - x) (Icc a b) :=
+    (hf.sub continuous_id).continuousOn
+  -- 0 ∈ [g b, g a] ⊆ image of g, by the (decreasing) intermediate value theorem
+  have hmem : (0 : ℝ) ∈ Icc (f b - b) (f a - a) := ⟨hgb, hga⟩
+  obtain ⟨x, hx, hgx⟩ := intermediate_value_Icc' hab hgcont hmem
+  exact ⟨x, hx, by linarith [hgx]⟩
+
+/-- **The fixed-point set of a continuous self-map of `[a,b]` is nonempty and
+compact.** Existence is one-dimensional Brouwer; compactness is the closedness of
+the fixed-point set intersected with the compact interval. -/
+theorem fixedPoints_Icc_nonempty_isCompact {a b : ℝ} (hab : a ≤ b) {f : ℝ → ℝ}
+    (hf : Continuous f) (hmaps : ∀ x ∈ Icc a b, f x ∈ Icc a b) :
+    (Icc a b ∩ fixedPoints f).Nonempty ∧ IsCompact (Icc a b ∩ fixedPoints f) := by
+  refine ⟨?_, isCompact_fixedPoints_inter hf isCompact_Icc⟩
+  obtain ⟨x, hx, hfx⟩ := exists_fixedPoint_Icc hab hf hmaps
+  exact ⟨x, hx, hfx⟩
+
+end SchauderFixedPointOQ04

--- a/research/problems/schauder-fixed-point-oq-04/knowledge.md
+++ b/research/problems/schauder-fixed-point-oq-04/knowledge.md
@@ -1,0 +1,39 @@
+# Knowledge: schauder-fixed-point-oq-04
+
+## Summary
+
+The topology of the fixed-point set: for a continuous self-map of [a,b], the
+fixed-point set is a nonempty compact set (axiom-free).
+
+## What is formalized (researcher-9, 2026-06-25)
+
+`proofs/Proofs/SchauderFixedPointOQ04.lean`, namespace `SchauderFixedPointOQ04`,
+0 ax / 0 sorry:
+
+- `fixedPoints f := {x | f x = x}`
+- `isClosed_fixedPoints (hf : Continuous f) : IsClosed (fixedPoints f)` [T2]
+- `isCompact_fixedPoints_inter (hf) (hK : IsCompact K) : IsCompact (K ∩ fixedPoints f)`
+- `exists_fixedPoint_Icc (hab : a ≤ b) (hf) (hmaps) : ∃ x ∈ Icc a b, f x = x`
+- `fixedPoints_Icc_nonempty_isCompact : (Icc a b ∩ fixedPoints f).Nonempty ∧ IsCompact ...`
+
+## Key Mathlib facts
+
+- `isClosed_eq (hf) (hg) : IsClosed {x | f x = g x}` — fixed-point set = equaliser
+  with `id`.
+- `IsCompact.inter_right (hK) (hclosed) : IsCompact (K ∩ s)`.
+- `intermediate_value_Icc' (hab) (hcont : ContinuousOn g (Icc a b)) :
+  Icc (g b) (g a) ⊆ g '' Icc a b` — the decreasing-direction IVT. For
+  g(x)=f(x)−x, 0 ∈ Icc (g b) (g a) since g b ≤ 0 ≤ g a.
+- `isCompact_Icc`.
+
+## Design choice
+
+Imports ONLY Mathlib, deliberately NOT the base `SchauderFixedPoint.lean`, which
+carries deep axioms (brouwer_compact_convex, mazur_compact_convex_hull,
+brouwer_finite_dim_subset, peano_existence_via_schauder, infinite_dim_counterexample).
+1D Brouwer is re-derived from the IVT so the whole file stays 0-axiom.
+
+## Approaches Tried
+
+- Direct: equaliser-closedness + IVT — worked first try. The IVT direction needed
+  is `intermediate_value_Icc'` (decreasing), since g(a) ≥ g(b).

--- a/research/problems/schauder-fixed-point-oq-04/state.md
+++ b/research/problems/schauder-fixed-point-oq-04/state.md
@@ -1,0 +1,38 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-25T00:00:00Z
+**Iteration**: 1
+**Status**: in-progress
+
+## Current Focus
+
+Empty stub. The Schauder lineage's existence theorems rest on deep axioms
+(brouwer/mazur/kakutani). Chose a complementary, fully **axiom-free** angle: the
+topology of the fixed-point set (researcher-9).
+
+## Delivered (PR pending)
+
+`proofs/Proofs/SchauderFixedPointOQ04.lean` — 5 theorems, 1 def, 0 axioms,
+0 sorries (typechecked `lake env lean`, Docker down; `#print axioms` = only
+propext/Classical.choice/Quot.sound; imports only Mathlib):
+
+- `isClosed_fixedPoints` — `{x | f x = x}` closed for continuous f (T2), as the
+  equaliser of f and id (`isClosed_eq`).
+- `isCompact_fixedPoints_inter` — ∩ with a compact set is compact.
+- `exists_fixedPoint_Icc` — 1D Brouwer: continuous f:[a,b]→[a,b] has a fixed
+  point, via `intermediate_value_Icc'` on g(x)=f(x)−x (g a ≥ 0 ≥ g b).
+- `fixedPoints_Icc_nonempty_isCompact` — the fixed-point set of a continuous
+  self-map of [a,b] is nonempty AND compact.
+
+## Why non-duplicate / why self-contained
+
+The base `SchauderFixedPoint.lean` proves only *existence* (`interval_fixed_point`)
+and carries axioms (brouwer_compact_convex, mazur_compact_convex_hull, …). This
+entry adds the *structure* of the fixed-point set (closed/compact) and re-derives
+1D Brouwer directly from the IVT, importing only Mathlib to stay 0-axiom.
+
+## Next Action
+
+Follow-up: least/greatest fixed point exists (sInf/sSup of the compact set);
+uniqueness under strict contraction (Banach, 1D).

--- a/src/data/proofs/schauder-fixed-point-oq-04/annotations.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-closed",
+    "proofId": "schauder-fixed-point-oq-04",
+    "range": { "startLine": 39, "endLine": 43 },
+    "type": "theorem",
+    "title": "The Fixed-Point Set is Closed",
+    "content": "For a continuous map $f$ into a Hausdorff space, the fixed-point set $\\{x \\mid f(x) = x\\}$ is **closed** — it is the equaliser of $f$ and the identity, and equalisers into $T_2$ spaces are closed (`isClosed_eq f id`). This is the topological backbone: closed sets inside compacta are compact.",
+    "mathContext": "$\\mathrm{IsClosed}\\,\\{x \\mid f(x) = x\\}$ for continuous $f$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Equaliser", "Hausdorff space", "Closed set", "Fixed point"]
+  },
+  {
+    "id": "ann-brouwer-1d",
+    "proofId": "schauder-fixed-point-oq-04",
+    "range": { "startLine": 54, "endLine": 69 },
+    "type": "theorem",
+    "title": "One-Dimensional Brouwer via IVT",
+    "content": "A continuous self-map $f:[a,b]\\to[a,b]$ has a fixed point. The trick: $g(x) = f(x) - x$ is continuous with $g(a) = f(a) - a \\ge 0$ and $g(b) = f(b) - b \\le 0$ (since $f$ lands in $[a,b]$). The intermediate value theorem (`intermediate_value_Icc'`, decreasing direction) puts $0$ in the image of $g$, i.e. some $c$ with $f(c) = c$. This is the axiom-free, one-dimensional shadow of Brouwer's theorem.",
+    "mathContext": "$\\exists c \\in [a,b],\\ f(c) = c$ for continuous $f:[a,b]\\to[a,b]$.",
+    "significance": "key",
+    "relatedConcepts": ["Brouwer fixed-point theorem", "Intermediate value theorem", "Continuity"]
+  },
+  {
+    "id": "ann-nonempty-compact",
+    "proofId": "schauder-fixed-point-oq-04",
+    "range": { "startLine": 71, "endLine": 79 },
+    "type": "theorem",
+    "title": "Nonempty Compact Fixed-Point Set",
+    "content": "Combining the two: the fixed-point set of a continuous self-map of $[a,b]$ is **nonempty** (1D Brouwer) and **compact** (closed subset of the compact interval). Where the base Schauder entry stops at existence, this records the full topological shape of the solution set — a nonempty compactum, so e.g. it has a least and greatest fixed point.",
+    "mathContext": "$([a,b] \\cap \\{x \\mid f(x)=x\\})$ is nonempty and compact.",
+    "significance": "key",
+    "relatedConcepts": ["Compactness", "Fixed-point set", "Brouwer", "Extreme value theorem"]
+  }
+]

--- a/src/data/proofs/schauder-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-04/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "schauder-fixed-point-oq-04",
+  "title": "The Topology of the Fixed-Point Set: Nonempty and Compact for Self-Maps of [a,b]",
+  "slug": "schauder-fixed-point-oq-04",
+  "description": "A fully elementary, axiom-free complement to the Schauder fixed-point lineage, whose existence theorems (Brouwer, Schauder, Kakutani) rest on deep axioms. Instead of existence, this entry studies the STRUCTURE of the fixed-point set itself. For a continuous map f, the fixed-point set {x | f x = x} is the equaliser of f and the identity, hence closed in any Hausdorff space (isClosed_fixedPoints); its intersection with a compact set is therefore compact (isCompact_fixedPoints_inter). For a continuous self-map of a closed interval [a,b], the one-dimensional Brouwer theorem (exists_fixedPoint_Icc) — proved from the intermediate value theorem applied to g(x) = f(x) − x, with g(a) ≥ 0 ≥ g(b) — gives nonemptiness. Combining, the fixed-point set of a continuous self-map of [a,b] is a nonempty compact set (fixedPoints_Icc_nonempty_isCompact). The base entry proves only existence; the closed/compact structure is new. 0 axioms, 0 sorries; imports only Mathlib.",
+  "meta": {
+    "author": "Brouwer (1911), IVT (Bolzano/Cauchy); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Brouwer_fixed-point_theorem",
+    "date": "1911",
+    "status": "verified",
+    "tags": [
+      "topology",
+      "fixed-point-theory",
+      "brouwer",
+      "intermediate-value-theorem",
+      "compactness",
+      "real-analysis",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SchauderFixedPointOQ04.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "isClosed_eq",
+        "description": "If f and g are continuous into a T2 space then {x | f x = g x} is closed. With g = id this makes the fixed-point set closed.",
+        "module": "Mathlib.Topology.Separation"
+      },
+      {
+        "theorem": "IsCompact.inter_right",
+        "description": "A compact set intersected with a closed set is compact. Gives compactness of the fixed-point set inside [a,b].",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "intermediate_value_Icc'",
+        "description": "For a ≤ b and g continuous on [a,b], the interval [g b, g a] is contained in the image g '' [a,b]. Applied to g(x) = f(x) − x to locate a fixed point (decreasing-direction IVT).",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      },
+      {
+        "theorem": "isCompact_Icc",
+        "description": "A closed real interval [a,b] is compact. The ambient compact set for the fixed-point set.",
+        "module": "Mathlib.Topology.Order.Compact"
+      }
+    ],
+    "originalContributions": [
+      "isClosed_fixedPoints: the fixed-point set {x | f x = x} of a continuous map into a Hausdorff space is closed, as the equaliser of f and the identity (isClosed_eq f id)",
+      "exists_fixedPoint_Icc: the one-dimensional Brouwer fixed-point theorem — a continuous self-map of [a,b] has a fixed point — proved directly from the intermediate value theorem on g(x) = f(x) − x, using g(a) ≥ 0 ≥ g(b) because f maps into [a,b]",
+      "fixedPoints_Icc_nonempty_isCompact: the fixed-point set of a continuous self-map of [a,b] is nonempty AND compact — combining 1D Brouwer (nonemptiness) with closedness-in-a-compact (compactness). The base Schauder entry proves only existence; the topological structure of the solution set is the new content",
+      "isCompact_fixedPoints_inter: a general lemma that the fixed-point set of a continuous map, intersected with any compact set, is compact"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 80,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms on fixedPoints_Icc_nonempty_isCompact and exists_fixedPoint_Icc reports only the foundational propext, Classical.choice, Quot.sound (none of which count as assumptions). No native_decide, no structure-encoded hypotheses. Imports only Mathlib — deliberately NOT the axiom-bearing base file SchauderFixedPoint.lean (which carries brouwer/mazur axioms).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "closed-compact",
+      "title": "The Fixed-Point Set is Closed and Compact",
+      "startLine": 31,
+      "endLine": 52,
+      "summary": "fixedPoints f := {x | f x = x}. isClosed_fixedPoints: closed for continuous f into a T2 space (equaliser of f and id, via isClosed_eq). isCompact_fixedPoints_inter: its intersection with any compact set is compact."
+    },
+    {
+      "id": "brouwer-1d",
+      "title": "One-Dimensional Brouwer",
+      "startLine": 54,
+      "endLine": 69,
+      "summary": "exists_fixedPoint_Icc: a continuous f:[a,b]→[a,b] has a fixed point. g(x) = f(x) − x is continuous with g(a) = f(a) − a ≥ 0 and g(b) = f(b) − b ≤ 0; intermediate_value_Icc' places 0 in the image of g, giving a fixed point."
+    },
+    {
+      "id": "nonempty-compact",
+      "title": "Nonempty Compact Fixed-Point Set",
+      "startLine": 71,
+      "endLine": 79,
+      "summary": "fixedPoints_Icc_nonempty_isCompact: the fixed-point set of a continuous self-map of [a,b] is nonempty (1D Brouwer) and compact (closed ∩ compact)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A fully elementary, **axiom-free** complement to the Schauder lineage, whose existence theorems (Brouwer/Schauder/Kakutani) rest on deep axioms. Instead of existence, this entry studies the **structure of the fixed-point set** itself. **5 theorems, 1 def, 0 axioms, 0 sorries; imports only Mathlib.**

- **`isClosed_fixedPoints`**: for continuous $f$ into a Hausdorff space, $\{x \mid f(x)=x\}$ is closed (the equaliser of $f$ and $\mathrm{id}$, via `isClosed_eq`).
- **`isCompact_fixedPoints_inter`**: its intersection with any compact set is compact.
- **`exists_fixedPoint_Icc`**: the **one-dimensional Brouwer theorem** — a continuous $f:[a,b]\to[a,b]$ has a fixed point, via the IVT on $g(x)=f(x)-x$ with $g(a)\ge 0\ge g(b)$.
- **`fixedPoints_Icc_nonempty_isCompact`**: the fixed-point set of a continuous self-map of $[a,b]$ is **nonempty and compact**.

## Why non-duplicate / self-contained

The base `SchauderFixedPoint.lean` proves only *existence* (`interval_fixed_point`) and carries axioms (`brouwer_compact_convex`, `mazur_compact_convex_hull`, …). This entry adds the *topological structure* of the solution set (closed/compact) and re-derives 1D Brouwer directly from the IVT, importing **only Mathlib** to stay 0-axiom.

## Verification

- Typechecked via `lake env lean Proofs/SchauderFixedPointOQ04.lean` (exit 0; Docker unavailable this session).
- `#print axioms` on `fixedPoints_Icc_nonempty_isCompact` and `exists_fixedPoint_Icc` = only `propext, Classical.choice, Quot.sound` → **0 counted axioms**. No `native_decide`. Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)