### PR TITLE
research(erdos-1146-oq-04): verified O((log N)²) upper bound for 3-smooth counting function [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1510,6 +1510,7 @@ import Proofs.Erdos1143Problem
 import Proofs.Erdos1144Problem
 import Proofs.Erdos1145Problem
 import Proofs.Erdos1146Problem
+import Proofs.Erdos1146OQ04
 import Proofs.Erdos1147Problem
 import Proofs.Erdos1148Problem
 import Proofs.Erdos1149Aristotle

--- a/proofs/Proofs/Erdos1146OQ04.lean
+++ b/proofs/Proofs/Erdos1146OQ04.lean
@@ -1,0 +1,108 @@
+/-
+  Erdős Problem #1146 — OQ-04
+  A verified upper bound on the 3-smooth counting function.
+
+  Erdős #1146 (OPEN) asks whether the 3-smooth numbers
+  `B = {2^m · 3^n : m, n ≥ 0}` form an *essential component*.  The delicacy of the
+  problem comes entirely from the *size* of `B`: by Ruzsa's theorem an essential
+  component must satisfy `|A ∩ [1,N]| ≥ (log N)^{1+c}`, and the 3-smooth numbers
+  have counting function on the order of `(log N)²` — right at the threshold.
+
+  The parent file `Erdos1146Problem.lean` records the growth `~ C·(log N)²` as an
+  *axiom* (`smooth23_counting`).  This file removes the need for that axiom on the
+  **upper-bound side**: it proves, with no axioms and no `sorry`, the elementary
+  estimate
+
+      countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1)²,
+
+  i.e. `|B ∩ [1,N]| = O((log N)²)`.  The argument is pure lattice-point counting:
+  every 3-smooth number `≤ N` is `2^m·3^n` with both `2^m ≤ N` and `2^n ≤ 3^n ≤ N`,
+  so both exponents are at most `log₂ N`, giving at most `(log₂ N + 1)²` pairs and
+  hence at most that many values.
+
+  This is the honest, infrastructure-free half of the `(log N)²` counting claim
+  (the matching lower bound `Ω((log N)²)`, which pins the constant and the exact
+  threshold position, is recorded as future work).
+
+  Status: 0 sorries, 0 axioms, no native_decide.
+-/
+import Mathlib
+import Proofs.Erdos37Problem
+
+namespace Erdos1146.OQ04
+
+open Finset Erdos37
+
+/-- The exponent pairs `(m, n)` whose 3-smooth value `2^m·3^n` is a positive
+    integer `≤ N`.  Searching `m, n < N+1` is wasteful but harmless: it is a finite
+    superset of the genuinely-occurring pairs, which is all the upper bound needs. -/
+def pairBound (N : ℕ) : Finset (ℕ × ℕ) :=
+  (Finset.range (N + 1) ×ˢ Finset.range (N + 1)).filter (fun p => 2 ^ p.1 * 3 ^ p.2 ≤ N)
+
+/-- The 3-smooth numbers in `[1, N]` are exactly the values `2^m·3^n` of the pairs in
+    `pairBound N`.  (Unique factorization is *not* needed: this is a set equality, and
+    the upper bound only uses `⊆`.) -/
+theorem smooth_inter_eq_image (N : ℕ) :
+    smoothNumbers23 ∩ Set.Icc 1 N
+      = ↑((pairBound N).image (fun p => 2 ^ p.1 * 3 ^ p.2)) := by
+  ext k
+  simp only [smoothNumbers23, Set.mem_inter_iff, Set.mem_setOf_eq, Set.mem_Icc,
+    Finset.coe_image, Set.mem_image, Finset.mem_coe, pairBound, Finset.mem_filter,
+    Finset.mem_product, Finset.mem_range]
+  constructor
+  · rintro ⟨⟨m, n, rfl⟩, hk1, hkN⟩
+    have h2m : 2 ^ m ≤ 2 ^ m * 3 ^ n := Nat.le_mul_of_pos_right _ (by positivity)
+    have h3n : 3 ^ n ≤ 2 ^ m * 3 ^ n := Nat.le_mul_of_pos_left _ (by positivity)
+    have hmlt : m < N + 1 := by
+      have : m < 2 ^ m := Nat.lt_two_pow_self
+      omega
+    have hnlt : n < N + 1 := by
+      have hn2 : n < 2 ^ n := Nat.lt_two_pow_self
+      have hn23 : (2 : ℕ) ^ n ≤ 3 ^ n := Nat.pow_le_pow_left (by norm_num) n
+      omega
+    exact ⟨(m, n), ⟨⟨hmlt, hnlt⟩, hkN⟩, rfl⟩
+  · rintro ⟨⟨m, n⟩, ⟨⟨_, _⟩, hle⟩, rfl⟩
+    refine ⟨⟨m, n, rfl⟩, ?_, hle⟩
+    exact Nat.one_le_iff_ne_zero.mpr (by positivity)
+
+/-- The pair-search box has at most `(log₂ N + 1)²` admissible pairs: any pair with
+    `2^m·3^n ≤ N` has both `m ≤ log₂ N` and `n ≤ log₂ N`. -/
+theorem pairBound_card_le (N : ℕ) :
+    (pairBound N).card ≤ (Nat.log 2 N + 1) ^ 2 := by
+  have hsub : pairBound N ⊆
+      Finset.range (Nat.log 2 N + 1) ×ˢ Finset.range (Nat.log 2 N + 1) := by
+    intro p hp
+    simp only [pairBound, Finset.mem_filter, Finset.mem_product, Finset.mem_range] at hp
+    obtain ⟨_, hle⟩ := hp
+    have h2m : 2 ^ p.1 ≤ 2 ^ p.1 * 3 ^ p.2 := Nat.le_mul_of_pos_right _ (by positivity)
+    have h3n : 3 ^ p.2 ≤ 2 ^ p.1 * 3 ^ p.2 := Nat.le_mul_of_pos_left _ (by positivity)
+    have hn23 : (2 : ℕ) ^ p.2 ≤ 3 ^ p.2 := Nat.pow_le_pow_left (by norm_num) p.2
+    have hm : p.1 ≤ Nat.log 2 N := Nat.le_log_of_pow_le (by norm_num) (le_trans h2m hle)
+    have hn : p.2 ≤ Nat.log 2 N := Nat.le_log_of_pow_le (by norm_num) (le_trans (le_trans hn23 h3n) hle)
+    simp only [Finset.mem_product, Finset.mem_range]
+    omega
+  calc (pairBound N).card
+      ≤ (Finset.range (Nat.log 2 N + 1) ×ˢ Finset.range (Nat.log 2 N + 1)).card :=
+        Finset.card_le_card hsub
+    _ = (Nat.log 2 N + 1) ^ 2 := by
+        rw [Finset.card_product, Finset.card_range, sq]
+
+/-- **Verified upper bound on the 3-smooth counting function.**
+    The number of 3-smooth integers in `[1, N]` is at most `(log₂ N + 1)²`, hence
+    `|{2^m·3^n} ∩ [1,N]| = O((log N)²)`.  This is the elementary, axiom-free half of
+    the parent file's `smooth23_counting` claim, and it is the property that places
+    Erdős #1146 exactly at Ruzsa's `(log N)^{1+c}` threshold. -/
+theorem smooth23_counting_upper (N : ℕ) :
+    countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1) ^ 2 := by
+  unfold countingFunction
+  rw [smooth_inter_eq_image, Set.ncard_coe_finset]
+  exact le_trans (Finset.card_image_le) (pairBound_card_le N)
+
+/-- Restated as genuine `O((log N)²)` growth: with the explicit constant `1`, for all `N`,
+    `countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1)²`.  The bound is uniform in `N`
+    (no large-`N` hypothesis), so it certifies the big-O claim outright. -/
+theorem smooth23_counting_isBigO :
+    ∃ C : ℕ, 0 < C ∧ ∀ N : ℕ, countingFunction smoothNumbers23 N ≤ C * (Nat.log 2 N + 1) ^ 2 :=
+  ⟨1, one_pos, fun N => by simpa using smooth23_counting_upper N⟩
+
+end Erdos1146.OQ04

--- a/src/data/proofs/erdos-1146-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1146-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "e1146oq04-pairbound",
+    "proofId": "erdos-1146-oq-04",
+    "range": { "startLine": 36, "endLine": 40 },
+    "type": "definition",
+    "title": "The Exponent-Pair Search Box",
+    "content": "pairBound N is the finset of exponent pairs (m,n) with m,n < N+1 and 2^m·3^n ≤ N. The bounds m,n < N+1 form a deliberately loose but finite search box — every 3-smooth number ≤ N actually uses exponents far smaller (≤ log₂ N), but starting from this coarse box and the single decidable inequality 2^m·3^n ≤ N keeps the set concrete and computable. The genuine counting bound comes later by intersecting with the logarithmic constraint.",
+    "mathContext": "$\\mathrm{pairBound}(N) = \\{(m,n) : m,n \\le N,\\ 2^m 3^n \\le N\\}$",
+    "significance": "supporting",
+    "prerequisites": ["Finset.product", "Finset.filter", "decidable inequalities"],
+    "relatedConcepts": ["lattice points", "smooth number exponents"]
+  },
+  {
+    "id": "e1146oq04-image-eq",
+    "proofId": "erdos-1146-oq-04",
+    "range": { "startLine": 42, "endLine": 68 },
+    "type": "theorem",
+    "title": "3-Smooth Numbers in [1,N] are Exactly the Pair Images",
+    "content": "A set equality: smoothNumbers23 ∩ [1,N] equals the image of pairBound N under (m,n) ↦ 2^m·3^n. Forward direction — a 3-smooth k = 2^m·3^n with 1 ≤ k ≤ N has m < 2^m ≤ k ≤ N and n < 2^n ≤ 3^n ≤ k ≤ N, so (m,n) lands in the search box, and 2^m·3^n ≤ N is exactly k ≤ N. Backward — every image value is 3-smooth by construction, is ≤ N by the filter, and is ≥ 1 by positivity of 2^m·3^n. Crucially this is proved without unique factorization: it is a statement about the image set, and the upper bound only uses one inclusion.",
+    "mathContext": "$\\{2^m 3^n\\} \\cap [1,N] = \\{2^m 3^n : (m,n) \\in \\mathrm{pairBound}(N)\\}$",
+    "significance": "key",
+    "prerequisites": ["Nat.lt_two_pow_self", "Nat.pow_le_pow_left", "set extensionality"],
+    "relatedConcepts": ["image of a finite set", "smooth numbers", "exponent bounds"]
+  },
+  {
+    "id": "e1146oq04-box-card",
+    "proofId": "erdos-1146-oq-04",
+    "range": { "startLine": 69, "endLine": 93 },
+    "type": "theorem",
+    "title": "At Most (log₂ N + 1)² Admissible Pairs",
+    "content": "The heart of the logarithmic count. For any (m,n) with 2^m·3^n ≤ N: from 2^m ≤ 2^m·3^n ≤ N we get m ≤ log₂ N (Nat.le_log_of_pow_le), and from 2^n ≤ 3^n ≤ 2^m·3^n ≤ N we get n ≤ log₂ N. So pairBound N is contained in the (log₂ N + 1) × (log₂ N + 1) box, whose cardinality is (log₂ N + 1)². The trick is routing the 3-exponent n through 2^n ≤ 3^n, so one base-2 logarithm bounds both coordinates.",
+    "mathContext": "$|\\mathrm{pairBound}(N)| \\le (\\lfloor \\log_2 N \\rfloor + 1)^2$",
+    "significance": "critical",
+    "prerequisites": ["Nat.le_log_of_pow_le", "Finset.card_product", "Finset.card_range"],
+    "relatedConcepts": ["integer logarithm", "exponent bound", "lattice-point count"]
+  },
+  {
+    "id": "e1146oq04-main",
+    "proofId": "erdos-1146-oq-04",
+    "range": { "startLine": 94, "endLine": 102 },
+    "type": "theorem",
+    "title": "Verified Upper Bound on the Counting Function",
+    "content": "The payoff: countingFunction smoothNumbers23 N ≤ (log₂ N + 1)². Unfolding countingFunction (defined as Set.ncard of the slice smoothNumbers23 ∩ [1,N]), rewrite the slice as the coercion of the image finset, convert ncard to finset card via Set.ncard_coe_finset, then chain card_image_le (distinct values ≤ pairs) with the box bound. This is the axiom-free upper half of the parent file's axiomatized smooth23_counting (~ C·(log N)²), so |{2^m·3^n} ∩ [1,N]| = O((log N)²) is now machine-checked.",
+    "mathContext": "$|\\{2^m 3^n\\} \\cap [1,N]| \\le (\\lfloor \\log_2 N \\rfloor + 1)^2$",
+    "significance": "critical",
+    "prerequisites": ["Set.ncard_coe_finset", "Finset.card_image_le", "the two preceding lemmas"],
+    "relatedConcepts": ["smooth number counting function", "Ruzsa threshold", "essential components"]
+  },
+  {
+    "id": "e1146oq04-bigo",
+    "proofId": "erdos-1146-oq-04",
+    "range": { "startLine": 103, "endLine": 106 },
+    "type": "theorem",
+    "title": "Explicit Big-O Certificate",
+    "content": "Repackages the bound as ∃ C > 0, ∀ N, countingFunction smoothNumbers23 N ≤ C·(log₂ N + 1)² with C = 1. Because the inequality holds for every N (no large-N hypothesis), this is a genuine, uniform O((log N)²) certificate — convenient for any downstream argument that needs a concrete constant, and the precise sense in which the 3-smooth numbers sit at Ruzsa's (log N)^{1+c} threshold.",
+    "mathContext": "$\\exists C > 0,\\ \\forall N,\\ |\\{2^m 3^n\\} \\cap [1,N]| \\le C (\\log_2 N + 1)^2$",
+    "significance": "supporting",
+    "prerequisites": ["smooth23_counting_upper"],
+    "relatedConcepts": ["big-O notation", "uniform bound", "explicit constant"]
+  }
+]

--- a/src/data/proofs/erdos-1146-oq-04/index.ts
+++ b/src/data/proofs/erdos-1146-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1146OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1146Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1146Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1146Oq04Data: ProofData = {
+  proof: erdos1146Oq04Proof,
+  annotations: erdos1146Oq04Annotations,
+}

--- a/src/data/proofs/erdos-1146-oq-04/meta.json
+++ b/src/data/proofs/erdos-1146-oq-04/meta.json
@@ -1,0 +1,205 @@
+{
+  "id": "erdos-1146-oq-04",
+  "title": "Erdős #1146 OQ-04: A Verified O((log N)²) Upper Bound for the 3-Smooth Counting Function",
+  "slug": "erdos-1146-oq-04",
+  "description": "An axiom-free upper bound on the counting function of the 3-smooth numbers B = {2^m·3^n : m,n ≥ 0}: for every N, |B ∩ [1,N]| ≤ (⌊log₂ N⌋ + 1)², hence |B ∩ [1,N]| = O((log N)²). Erdős #1146 (OPEN) asks whether B is an essential component; the difficulty is precisely that B sits at Ruzsa's (log N)^{1+c} threshold, where the counting function is on the order of (log N)². The parent file Erdos1146Problem.lean records the growth ~ C·(log N)² as an axiom (smooth23_counting); this entry removes that dependence on the upper-bound side with a fully elementary lattice-point argument: every 3-smooth number ≤ N is 2^m·3^n with 2^m ≤ N and 2^n ≤ 3^n ≤ N, so both exponents are at most log₂ N, bounding the count by (log₂ N + 1)². Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (elementary counting; context Erdős #1146, Ruzsa)",
+    "sourceUrl": "https://erdosproblems.com/1146",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1146OQ04.lean",
+    "tags": [
+      "erdos",
+      "additive-number-theory",
+      "smooth-numbers",
+      "counting-function",
+      "schnirelmann-density",
+      "essential-component"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.le_log_of_pow_le",
+        "description": "For 1 < b, b^m ≤ n implies m ≤ Nat.log b n. Turns 2^m ≤ N (and 2^n ≤ N) into m ≤ log₂ N (and n ≤ log₂ N), the bound on each exponent.",
+        "module": "Mathlib.Data.Nat.Log"
+      },
+      {
+        "theorem": "Nat.lt_two_pow_self",
+        "description": "m < 2^m. Used to show each exponent m is < N+1 (since 2^m ≤ 2^m·3^n ≤ N), so the pair-search box Finset.range (N+1) ×ˢ range (N+1) really contains every occurring pair.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.pow_le_pow_left",
+        "description": "a ≤ b → a^k ≤ b^k. Gives 2^n ≤ 3^n, so the 3-exponent is also controlled by 2^n ≤ N and hence n ≤ log₂ N.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Set.ncard_coe_finset",
+        "description": "(↑s : Set α).ncard = s.card. Converts the set-cardinality definition of countingFunction (Set.ncard) into a Finset card once the 3-smooth slice is exhibited as the coercion of an explicit image finset.",
+        "module": "Mathlib.Data.Set.Card"
+      },
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "(s.image f).card ≤ s.card. Bounds the number of distinct 3-smooth values by the number of exponent pairs, sidestepping any appeal to unique factorization.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "smooth23_counting_upper: the headline 0-axiom bound countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1)², i.e. |{2^m·3^n} ∩ [1,N]| ≤ (⌊log₂ N⌋ + 1)². This is the elementary, axiom-free half of the parent file's axiomatized smooth23_counting (~ C·(log N)²), and the property that places Erdős #1146 exactly at Ruzsa's (log N)^{1+c} threshold.",
+      "smooth_inter_eq_image: the 3-smooth numbers in [1,N] are exactly the image of the exponent-pair finset pairBound N under (m,n) ↦ 2^m·3^n — a set equality, so the counting function is the cardinality of an explicit finite set. Unique factorization is not used (the upper bound only needs the ⊆ direction via card_image_le).",
+      "pairBound_card_le: the pair-search box has ≤ (log₂ N + 1)² admissible pairs, because any pair with 2^m·3^n ≤ N has both m ≤ log₂ N (from 2^m ≤ N) and n ≤ log₂ N (from 2^n ≤ 3^n ≤ N).",
+      "smooth23_counting_isBigO: the same bound packaged as an explicit big-O statement ∃ C > 0, ∀ N, countingFunction smoothNumbers23 N ≤ C·(log₂ N + 1)² with constant C = 1, certifying |B ∩ [1,N]| = O((log N)²) uniformly in N (no large-N hypothesis)."
+    ],
+    "dateAdded": "2026-06-25",
+    "relatedProblems": [
+      {
+        "id": "erdos-1146",
+        "relationship": "Removes the upper-bound half of the parent file's axiom smooth23_counting (the ~ C·(log N)² growth), replacing it with a machine-checked, 0-axiom bound |B ∩ [1,N]| ≤ (log₂ N + 1)². This is the counting estimate that frames the whole open question — why the 3-smooth numbers sit exactly at Ruzsa's threshold for essential components."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 108,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The file imports Proofs.Erdos37Problem to reuse the definitions countingFunction (Set.ncard (A ∩ Icc 1 N)) and smoothNumbers23 ({n | ∃ m k, n = 2^m·3^k}); although that parent file contains axioms (e.g. smooth23_counting, mann_theorem), #print axioms confirms that smooth23_counting_upper, smooth23_counting_isBigO, and smooth_inter_eq_image depend on none of them — only the foundational propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool). Only the upper bound is proved; the matching lower bound Ω((log N)²) is recorded as future work.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "sections": [
+    {
+      "id": "pairbound",
+      "title": "The Exponent-Pair Search Box",
+      "startLine": 36,
+      "endLine": 40,
+      "mathContext": "$\\mathrm{pairBound}(N) = \\{(m,n) : m,n \\le N,\\ 2^m 3^n \\le N\\}$",
+      "summary": "pairBound N collects the exponent pairs (m,n) with m,n < N+1 and 2^m·3^n ≤ N — a finite, decidable search box that is a loose superset of the genuinely-occurring exponents."
+    },
+    {
+      "id": "image-eq",
+      "title": "3-Smooth Slice as a Pair Image",
+      "startLine": 42,
+      "endLine": 68,
+      "mathContext": "$\\{2^m 3^n\\} \\cap [1,N] = \\{2^m 3^n : (m,n) \\in \\mathrm{pairBound}(N)\\}$",
+      "summary": "smooth_inter_eq_image proves the 3-smooth numbers in [1,N] are exactly the image of pairBound N under (m,n) ↦ 2^m·3^n, reducing the Set.ncard counting function to a Finset cardinality without using unique factorization."
+    },
+    {
+      "id": "box-card",
+      "title": "Logarithmic Bound on the Pair Count",
+      "startLine": 69,
+      "endLine": 93,
+      "mathContext": "$|\\mathrm{pairBound}(N)| \\le (\\lfloor \\log_2 N \\rfloor + 1)^2$",
+      "summary": "pairBound_card_le shows both exponents are ≤ log₂ N (the 3-exponent via 2^n ≤ 3^n), so the pairs fit in a (log₂ N + 1)² box."
+    },
+    {
+      "id": "main",
+      "title": "The Counting-Function Upper Bound",
+      "startLine": 94,
+      "endLine": 106,
+      "mathContext": "$|\\{2^m 3^n\\} \\cap [1,N]| \\le (\\lfloor \\log_2 N \\rfloor + 1)^2$",
+      "summary": "smooth23_counting_upper chains the image equality, ncard-to-card conversion, and card_image_le with the box bound; smooth23_counting_isBigO repackages it as an explicit O((log N)²) certificate with constant 1."
+    }
+  ],
+  "overview": {
+    "historicalContext": "A set A ⊆ ℕ is an essential component (Khintchine, 1930s) if it strictly increases Schnirelmann density: d_s(A+B) > d_s(B) for every B with 0 < d_s(B) < 1. Khintchine's first examples were the squares; Erdős, Linnik, and others sought the sparsest possible essential components. Ruzsa (1987) proved a lower bound on their size — an essential component must satisfy |A ∩ [1,N]| ≥ (log N)^{1+c} for some c > 0 — ruling out lacunary sets, and later (1999) constructed essential components nearly meeting this bound. Erdős #1146 asks whether a specific, very natural sparse set — the 3-smooth numbers B = {2^m·3^n} — is an essential component. The question is delicate precisely because the counting function of B is of order (log N)², sitting right at Ruzsa's threshold (c = 1). Quantifying that counting function is therefore the first concrete step in any analysis of the problem.",
+    "problemStatement": "Bound the counting function of the 3-smooth numbers. Writing smoothNumbers23 = {n | ∃ m k, n = 2^m·3^k} and countingFunction A N = |A ∩ [1,N]|, show countingFunction smoothNumbers23 N ≤ (⌊log₂ N⌋ + 1)² for every N, hence |{2^m·3^n} ∩ [1,N]| = O((log N)²).",
+    "text": "A 3-smooth number in [1,N] is some 2^m·3^n with 2^m·3^n ≤ N. Since 3^n ≥ 1 we have 2^m ≤ N, so m ≤ log₂ N; and since 2^n ≤ 3^n ≤ 2^m·3^n ≤ N we also get n ≤ log₂ N. Thus every 3-smooth number ≤ N is the value of a pair (m,n) lying in the (⌊log₂ N⌋+1) × (⌊log₂ N⌋+1) box of exponents, and there are at most (⌊log₂ N⌋+1)² such pairs — hence at most that many 3-smooth values. The bound is uniform in N and requires no unique-factorization input: distinct pairs may a priori collide, which only makes the count smaller.",
+    "proofStrategy": "Everything is finite and elementary; the counting function (defined via Set.ncard) is reduced to a Finset cardinality.\n\n1. **pairBound N (definition).** The finset of pairs (m,n) ∈ range(N+1) × range(N+1) with 2^m·3^n ≤ N. The decidable inequality keeps the set computable; the search box range(N+1)² is a deliberately loose but finite superset of the occurring exponents.\n\n2. **smooth_inter_eq_image.** Prove smoothNumbers23 ∩ Icc 1 N = ↑((pairBound N).image (fun p => 2^p.1·3^p.2)) as sets. Forward: a 3-smooth k = 2^m·3^n in [1,N] has m,n < N+1 (since m < 2^m ≤ N and n < 2^n ≤ 3^n ≤ N) and 2^m·3^n ≤ N, so (m,n) ∈ pairBound and k is its image. Backward: any image value is 3-smooth, ≤ N (the filter condition), and ≥ 1 (positivity of 2^m·3^n).\n\n3. **pairBound_card_le.** Show pairBound N ⊆ range(log₂N+1) × range(log₂N+1): for (m,n) in pairBound, 2^m ≤ 2^m·3^n ≤ N gives m ≤ log₂N (Nat.le_log_of_pow_le), and 2^n ≤ 3^n ≤ 2^m·3^n ≤ N gives n ≤ log₂N. Hence card ≤ (log₂N+1)² by card_product and card_range.\n\n4. **smooth23_counting_upper.** Unfold countingFunction, rewrite the 3-smooth slice as the image finset (step 2) and its ncard as the finset card (Set.ncard_coe_finset), then chain card_image_le with step 3.\n\n5. **smooth23_counting_isBigO.** Repackage step 4 with explicit constant C = 1.",
+    "keyInsights": [
+      "**The exponents are doubly logarithmic in disguise.** Both m and n are at most log₂ N, so a 3-smooth number ≤ N is determined by a pair from a (log₂ N)-sized box — the source of the (log N)² count. The key trick is bounding the 3-exponent through 2^n ≤ 3^n, so a single base-2 logarithm controls both coordinates.",
+      "**No unique factorization needed.** The bound counts exponent pairs, and distinct pairs can only collapse to fewer values (card_image_le). This avoids invoking 2^m·3^n injectivity, keeping the proof minimal — injectivity would be required only for a matching lower bound.",
+      "**This is the axiom-free half of the parent's growth claim.** Erdos1146Problem.lean posits smooth23_counting (~ C·(log N)²) as an axiom; the upper inequality is in fact elementary, and proving it here shrinks the axiomatic surface of the gallery's #1146 treatment.",
+      "**Why the threshold matters.** Ruzsa's theorem forces essential components to have ≥ (log N)^{1+c} elements up to N. The 3-smooth numbers achieve exactly (log N)² = (log N)^{1+1}, so they are a borderline candidate — neither obviously too sparse (lacunary sets, excluded) nor comfortably large. This bound makes the borderline position precise.",
+      "**Uniform, not asymptotic.** The estimate holds for every N with an explicit constant, so it is a genuine big-O certificate rather than an eventually-true statement — convenient for any downstream formalization that needs a concrete bound."
+    ],
+    "prerequisites": [
+      "Schnirelmann density and the notion of an essential component",
+      "Smooth (friable) numbers and their counting functions",
+      "Integer logarithm Nat.log and the equivalence b^m ≤ n ↔ m ≤ log_b n",
+      "Counting via images of finite sets (card_image_le)"
+    ]
+  },
+  "conclusion": {
+    "summary": "A machine-checked, 0-axiom upper bound on the 3-smooth counting function: countingFunction smoothNumbers23 N ≤ (⌊log₂ N⌋ + 1)² for every N, equivalently |{2^m·3^n} ∩ [1,N]| = O((log N)²) with explicit constant 1. The proof is a finite lattice-point count — every 3-smooth number ≤ N has both exponents bounded by log₂ N — and needs neither unique factorization nor any analytic input.",
+    "implications": "This removes the upper-bound half of the parent file's axiomatized growth claim (smooth23_counting), tightening the gallery's treatment of Erdős #1146. Quantitatively it pins down why the 3-smooth numbers sit exactly at Ruzsa's (log N)^{1+c} threshold for essential components: their counting function is Θ((log N)²) and this entry verifies the ≤ direction. The reusable pieces — the exponent-box bound and the image-counting reduction of a Set.ncard counting function — apply verbatim to any P-smooth set with a fixed finite prime support.",
+    "openQuestions": [
+      "Prove the matching lower bound countingFunction smoothNumbers23 N ≥ c·(log N)² (e.g. via the (⌊½log₂N⌋+1)(⌊½log₃N⌋+1) sub-box of pairs with 2^m, 3^n ≤ √N), which requires 2^m·3^n injectivity for the count of distinct values and pins the constant.",
+      "Sharpen to the true asymptotic |B ∩ [1,N]| ~ (log N)²/(2 log 2 · log 3) by a careful lattice-point estimate in the triangle m log 2 + n log 3 ≤ log N.",
+      "Resolve Erdős #1146 itself: decide whether the 3-smooth numbers form an essential component, the open question this counting bound only frames."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1146",
+      "relationship": "extends",
+      "description": "Supplies a verified, 0-axiom proof of the upper bound |B ∩ [1,N]| ≤ (log₂ N + 1)², replacing the upper-bound content of the parent file's axiom smooth23_counting and making precise the (log N)² counting function that defines the problem's difficulty."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/Erdos1146OQ04.lean",
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos37Problem"
+    ],
+    "opens": [
+      "Finset",
+      "Erdos37"
+    ],
+    "namespace": "Erdos1146.OQ04",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "references": [
+    {
+      "authors": "Ruzsa, Imre Z.",
+      "title": "Essential components",
+      "year": "1987",
+      "venue": "Proceedings of the London Mathematical Society 54, 38–56",
+      "note": "Proves essential components satisfy |A ∩ [1,N]| ≥ (log N)^{1+c}; the threshold against which the 3-smooth (log N)² counting function is measured."
+    },
+    {
+      "authors": "Ruzsa, Imre Z.",
+      "title": "Additive completion of lacunary sequences",
+      "year": "1999",
+      "venue": "Combinatorica 19, 167–186",
+      "note": "Context for Ruzsa's question on near-threshold essential components; Erdős #1146 asks specifically about the 3-smooth numbers."
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #1146",
+      "year": "—",
+      "venue": "erdosproblems.com/1146",
+      "note": "Is B = {2^m·3^n} an essential component? Open."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "smooth23_counting_upper",
+      "type": "core",
+      "description": "The number of 3-smooth integers in [1,N] is at most (⌊log₂ N⌋ + 1)²: countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1)².",
+      "leanType": "(N : ℕ) → countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1) ^ 2"
+    },
+    {
+      "name": "smooth23_counting_isBigO",
+      "type": "core",
+      "description": "Big-O packaging with explicit constant: ∃ C > 0, ∀ N, countingFunction smoothNumbers23 N ≤ C·(log₂ N + 1)².",
+      "leanType": "∃ C : ℕ, 0 < C ∧ ∀ N : ℕ, countingFunction smoothNumbers23 N ≤ C * (Nat.log 2 N + 1) ^ 2"
+    },
+    {
+      "name": "smooth_inter_eq_image",
+      "type": "supporting",
+      "description": "The 3-smooth numbers in [1,N] are exactly the image of the exponent-pair finset pairBound N under (m,n) ↦ 2^m·3^n.",
+      "leanType": "(N : ℕ) → smoothNumbers23 ∩ Set.Icc 1 N = ↑((pairBound N).image (fun p => 2 ^ p.1 * 3 ^ p.2))"
+    },
+    {
+      "name": "pairBound_card_le",
+      "type": "supporting",
+      "description": "At most (log₂ N + 1)² exponent pairs satisfy 2^m·3^n ≤ N, since both exponents are ≤ log₂ N.",
+      "leanType": "(N : ℕ) → (pairBound N).card ≤ (Nat.log 2 N + 1) ^ 2"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Erdős **#1146** (OPEN) asks whether the 3-smooth numbers `B = {2^m·3^n : m,n ≥ 0}` form an **essential component**. The problem is delicate precisely because `B` sits at **Ruzsa's `(log N)^{1+c}` threshold**: its counting function is of order `(log N)²`. The parent file `Erdos1146Problem.lean` records this growth `~ C·(log N)²` as an **axiom** (`smooth23_counting`).

This PR **removes the upper-bound half of that axiom**, proving with 0 axioms:

> `countingFunction smoothNumbers23 N ≤ (⌊log₂ N⌋ + 1)²`  for all N,
> i.e. **`|{2^m·3^n} ∩ [1,N]| = O((log N)²)`** with explicit constant 1.

## What's new (`proofs/Proofs/Erdos1146OQ04.lean`, 108 lines, 4 thm + 1 def)

- `smooth23_counting_upper` — `countingFunction smoothNumbers23 N ≤ (Nat.log 2 N + 1)²`.
- `smooth23_counting_isBigO` — explicit big-O packaging, `∃ C>0, ∀ N, … ≤ C·(log₂N+1)²` (C=1).
- `smooth_inter_eq_image` — the 3-smooth slice `B ∩ [1,N]` is exactly the image of the exponent-pair finset.
- `pairBound_card_le` — at most `(log₂N+1)²` pairs satisfy `2^m·3^n ≤ N`.

## Proof idea

Pure lattice-point counting. Every 3-smooth `k = 2^m·3^n ≤ N` has `2^m ≤ N` (so `m ≤ log₂N`) and `2^n ≤ 3^n ≤ N` (so `n ≤ log₂N`). Hence the count is bounded by the `(log₂N+1)²` exponent pairs. **No unique factorization** is needed — distinct pairs can only collide to *fewer* values (`card_image_le`).

The 3-exponent is controlled through `2^n ≤ 3^n`, so a single base-2 logarithm bounds both coordinates.

## Verification

- `lake env lean Proofs/Erdos1146OQ04.lean` — clean, **0 errors, 0 warnings, 0 sorries** (single-file check against cached Mathlib oleans; Docker host daemon down).
- `#print axioms` on `smooth23_counting_upper`, `smooth23_counting_isBigO`, `smooth_inter_eq_image` → `[propext, Classical.choice, Quot.sound]` only. The file imports the axiom-laden parent `Erdos37Problem` solely to **reuse the definitions** `countingFunction`/`smoothNumbers23`; **none of its axioms are used** (no `sorryAx`, no `Lean.ofReduceBool`).
- Registered in `proofs/Proofs.lean`; gallery entry `src/data/proofs/erdos-1146-oq-04/` (meta + 5 annotations + 4 sections + index.ts), JSON validated.

## Scope

Only the **upper bound** is proved. The matching `Ω((log N)²)` lower bound (which pins the constant and needs `2^m·3^n` injectivity) is recorded as future work in `openQuestions`. Erdős #1146 itself remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)