### PR TITLE
audit(gallery): 5 fresh proofs CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24606,8 +24606,38 @@
       "issues": [],
       "lastAudited": "2026-06-25T22:00:00Z",
       "result": "clean"
+    },
+    "abel-ruffini-oq-11": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T22:30:00Z",
+      "result": "clean"
+    },
+    "derangements-oq-02-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T22:30:00Z",
+      "result": "clean"
+    },
+    "euler-polyhedral-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T22:30:00Z",
+      "result": "clean"
+    },
+    "nicomachus-sum-of-cubes-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T22:30:00Z",
+      "result": "clean"
+    },
+    "prob-method-applications-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T22:30:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T22:00:00Z"
+  "lastUpdated": "2026-06-25T22:30:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 5 proofs CLEAN

Audited 5 newly-landed gallery proofs against current `origin/main`. All confirm **CLEAN**: 0 sorries, 0 `axiom` declarations, 0 True-stubs, 0 structure-encoded assumptions. status/badge/sorries/axiomCount all match the Lean source.

| Slug | Verdict | Notes |
|------|---------|-------|
| `abel-ruffini-oq-11` | CLEAN (borderline A/B) | Re-exposes Mathlib `gal_X_pow_sub_C_isSolvable`/`not_solvable`, but adds a genuinely novel `gal_finset_prod_pow_sub_C_isSolvable` (indexed finite-product induction Mathlib lacks). Description **explicitly credits Mathlib**, `mathlibDependencies` populated → `original` defensible. |
| `derangements-oq-02-oq-04` | CLEAN | S(n,n−2)=C(n,2), S(n,n−3)=2·C(n,3). Kernel `decide` on D(2),D(3) — **not** `native_decide`, so no `Lean.ofReduceBool`; 0 axiom. |
| `euler-polyhedral-oq-01-oq-03` | CLEAN | Real `SimpleGraph.Colorable 3` from hereditary 2-degeneracy. Planarity represented as edge-bound hypothesis, **disclosed** in `originalContributions` (gallery convention, mirrors parent planar-coloring file). `sorry` grep hit = docstring "sorry-free". |
| `nicomachus-sum-of-cubes-oq-02` | CLEAN | Faulhaber p=4 ∑k⁴ = n(n+1)(2n+1)(3n²+3n−1)/30 via ring+omega; 0 axiom. |
| `prob-method-applications-oq-03` | CLEAN | Erdős 1947: proves the **genuine existential** R(2m,2m) > 2^m (∃ coloring with no monochromatic 2m-clique), not merely the numeric inequality. `assumptions` discloses `#print axioms` foundational-only and honestly scopes the even-index family. `native_decide` grep = docstring "no native_decide". |

No issues found — no overclaims, no axiom masking, no inequality-as-theorem inflation. Tracker updated with 5 `clean` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)