### PR TITLE
Enrich Low-Codimension Fixed-Point Counts: add overview, conclusion, annotations

### DIFF
--- a/src/data/proofs/derangements-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/derangements-oq-02-oq-04/annotations.json
@@ -1,24 +1,50 @@
 [
   {
+    "id": "ann-der0204-setup",
+    "proofId": "derangements-oq-02-oq-04",
+    "range": { "startLine": 4, "endLine": 31 },
+    "type": "context",
+    "title": "Setup: Continuing the Rencontres Table Toward the Identity",
+    "content": "The file imports Mathlib and the parent module DerangementsOQ02. The docstring recalls the parent's main count S(n,k) = C(n,k)·D(n−k) — permutations of Fin n with exactly k fixed points — and its two extreme 'high-codimension' cases S(n,n) = 1 (the identity, permsWithAllFixed_card_eq_one) and S(n,n−1) = 0 (impossible: you cannot move exactly one point, permsWithNMinus1Fixed_eq_zero). The plan is to continue the table downward by specialising the formula at the small derangement values D(2) = 1 and D(3) = 2, producing S(n,n−2) = C(n,2) and S(n,n−3) = 2·C(n,3). The `open` line brings Finset, Nat, and the parent's PartialDerangements namespace into scope so card_perms_with_kfixed resolves unqualified. The two `decide`s below are kernel reductions (not native_decide), keeping the file axiom-free.",
+    "mathContext": "$S(n,k) = \\binom{n}{k}D(n-k)$; the table of counts for $k = n, n{-}1, n{-}2, n{-}3,\\dots$ is $1,\\,0,\\,\\binom{n}{2},\\,2\\binom{n}{3},\\dots$",
+    "significance": "context",
+    "relatedConcepts": ["rencontres numbers", "partial derangements", "fixed points of permutations", "derangement number D(n)"],
+    "prerequisites": ["the parent formula S(n,k) = C(n,k)·D(n−k)", "derangement numbers and fixed-point sets", "permutations of Fin n"]
+  },
+  {
+    "id": "ann-der0204-small-derangements",
+    "proofId": "derangements-oq-02-oq-04",
+    "range": { "startLine": 33, "endLine": 37 },
+    "type": "theorem",
+    "title": "Small Derangement Values D(2) = 1 and D(3) = 2",
+    "content": "Two one-line facts evaluated by kernel `decide`: numDerangements_two proves D(2) = 1 (the unique derangement of two points is the single transposition) and numDerangements_three proves D(3) = 2 (the two derangements of three points are the two 3-cycles). Because `numDerangements` on a fixed small numeral is a decidable computation over the finite Derangements type, the kernel reduces it directly — crucially this is `decide`, not `native_decide`, so it incurs no Lean.ofReduceBool axiom and the downstream counts remain genuinely verified. These constants are the only new arithmetic input; everything else is the parent's structural formula.",
+    "mathContext": "$D(2) = 1$ (one swap), $D(3) = 2$ (two 3-cycles); $D(m)$ counts fixed-point-free permutations of $m$ points.",
+    "significance": "supporting",
+    "relatedConcepts": ["derangement number", "numDerangements", "kernel decide vs native_decide", "axiom integrity"],
+    "prerequisites": ["the definition of D(m) = numDerangements m", "decidable evaluation over a finite type", "the distinction between decide and native_decide"]
+  },
+  {
     "id": "ann-codim-two",
     "proofId": "derangements-oq-02-oq-04",
-    "range": { "startLine": 42, "endLine": 50 },
+    "range": { "startLine": 39, "endLine": 47 },
     "type": "theorem",
     "title": "Exactly n−2 Fixed Points: the Transpositions",
-    "content": "For $n \\ge 2$, the number of permutations of $\\mathrm{Fin}\\,n$ with **exactly** $n-2$ fixed points is $\\binom{n}{2}$. These are precisely the transpositions: pick the two moved points ($\\binom{n}{2}$ ways), and the only derangement of two points is the swap ($D(2)=1$). Formally this specialises the parent's $S(n,k)=\\binom{n}{k}D(n-k)$ at $k=n-2$: $n-(n-2)=2$, $D(2)=1$, and $\\binom{n}{n-2}=\\binom{n}{2}$ by `Nat.choose_symm`.",
+    "content": "For $n \\ge 2$, the number of permutations of $\\mathrm{Fin}\\,n$ with **exactly** $n-2$ fixed points is $\\binom{n}{2}$. These are precisely the transpositions: pick the two moved points ($\\binom{n}{2}$ ways), and the only derangement of two points is the swap ($D(2)=1$). The proof specialises the parent's $S(n,k)=\\binom{n}{k}D(n-k)$ at $k=n-2$: rewrite by `card_perms_with_kfixed`, simplify the codimension $n-(n-2)=2$ with `omega`, drop the factor via `numDerangements_two` + `mul_one`, and convert $\\binom{n}{n-2}=\\binom{n}{2}$ by `Nat.choose_symm` (which consumes the hypothesis $n \\ge 2$).",
     "mathContext": "$S(n,n-2) = \\binom{n}{2}$ for $n \\ge 2$.",
     "significance": "key",
-    "relatedConcepts": ["Partial derangements", "Transpositions", "Rencontres numbers", "Binomial coefficient"]
+    "relatedConcepts": ["partial derangements", "transpositions", "rencontres numbers", "binomial coefficient", "Nat.choose_symm"],
+    "prerequisites": ["the parent count card_perms_with_kfixed", "D(2) = 1", "binomial symmetry C(n,n−2) = C(n,2)", "omega for the codimension arithmetic"]
   },
   {
     "id": "ann-codim-three",
     "proofId": "derangements-oq-02-oq-04",
-    "range": { "startLine": 52, "endLine": 57 },
+    "range": { "startLine": 49, "endLine": 57 },
     "type": "theorem",
-    "title": "Exactly n−3 Fixed Points",
-    "content": "For $n \\ge 3$, the number of permutations with exactly $n-3$ fixed points is $2\\binom{n}{3}$: choose the three moved points ($\\binom{n}{3}$ ways), each admitting the two 3-cycles ($D(3)=2$). Again a specialisation of $S(n,k)=\\binom{n}{k}D(n-k)$, at $k=n-3$. Together with the parent's $S(n,n)=1$, $S(n,n-1)=0$ and the codimension-2 case, this completes the top of the fixed-point distribution: $1, 0, \\binom{n}{2}, 2\\binom{n}{3}, \\dots$",
+    "title": "Exactly n−3 Fixed Points: Pairs of 3-Cycles",
+    "content": "For $n \\ge 3$, the number of permutations with exactly $n-3$ fixed points is $2\\binom{n}{3}$: choose the three moved points ($\\binom{n}{3}$ ways), each set of three admitting the two 3-cycles ($D(3)=2$). Again a specialisation of $S(n,k)=\\binom{n}{k}D(n-k)$ at $k=n-3$ — rewrite by `card_perms_with_kfixed`, reduce $n-(n-3)=3$ by `omega`, substitute `numDerangements_three` (D(3)=2), apply `Nat.choose_symm` for $\\binom{n}{n-3}=\\binom{n}{3}$, and reorient with `Nat.mul_comm` to the form $2\\binom{n}{3}$. Together with the parent's $S(n,n)=1$, $S(n,n-1)=0$ and the codimension-2 case, this completes the top of the fixed-point distribution: $1, 0, \\binom{n}{2}, 2\\binom{n}{3}, \\dots$",
     "mathContext": "$S(n,n-3) = 2\\binom{n}{3}$ for $n \\ge 3$.",
     "significance": "supporting",
-    "relatedConcepts": ["Partial derangements", "3-cycles", "Rencontres numbers"]
+    "relatedConcepts": ["partial derangements", "3-cycles", "rencontres numbers", "Nat.choose_symm", "binomial coefficient"],
+    "prerequisites": ["the parent count card_perms_with_kfixed", "D(3) = 2", "binomial symmetry C(n,n−3) = C(n,3)", "omega for the codimension arithmetic"]
   }
 ]

--- a/src/data/proofs/derangements-oq-02-oq-04/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-04/meta.json
@@ -53,6 +53,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "§0: Imports and the Fixed-Point Table",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Imports Mathlib and the parent module DerangementsOQ02. The docstring recalls the parent's main count S(n,k) = C(n,k)·D(n−k) and its two extreme cases S(n,n) = 1 (identity) and S(n,n−1) = 0 (impossible), then states the plan: evaluate the next two codimensions by specialising the formula at D(2) = 1 and D(3) = 2, yielding the table 1, 0, C(n,2), 2·C(n,3), …. Opens Finset, Nat, and the parent's PartialDerangements namespace.",
+      "mathContext": "$S(n,k) = \\binom{n}{k}\\,D(n-k)$ specialised at codimensions $0,1,2,3$ gives $1,\\,0,\\,\\binom{n}{2},\\,2\\binom{n}{3}$."
+    },
+    {
       "id": "small-derangements",
       "title": "Small Derangement Values",
       "startLine": 33,
@@ -73,5 +81,79 @@
       "endLine": 57,
       "summary": "card_perms_n_minus_three_fixed: S(n,n−3) = 2·C(n,3) for n ≥ 3, similarly with D(3) = 2 and Nat.choose_symm."
     }
-  ]
+  ],
+  "overview": {
+    "historicalContext": "The numbers S(n,k) counting permutations of an n-element set with exactly k fixed points are the rencontres numbers (French rencontre, 'encounter' or 'coincidence'), studied since Pierre Rémond de Montmort's 1708/1713 Essay d'analyse sur les jeux de hazard in connection with the game treize ('thirteen'). The k = 0 column is the derangement count D(n) = n!·∑_{i=0}^{n}(−1)ⁱ/i!, whose ratio D(n)/n! → 1/e is the classic 'probability of no match'. The full triangle S(n,k) = C(n,k)·D(n−k) factors as 'choose the k fixed points, derange the rest'. This entry, with its parent derangements-oq-02, formalizes the high-codimension end of that triangle — the rows nearest the identity — where the small derangement values D(0)=1, D(1)=0, D(2)=1, D(3)=2 produce strikingly simple closed forms.",
+    "problemStatement": "Evaluate the partial-derangement count S(n,k) = #{σ ∈ Perm(Fin n) : |Fix σ| = k} at codimensions 2 and 3: prove S(n,n−2) = C(n,2) for n ≥ 2 and S(n,n−3) = 2·C(n,3) for n ≥ 3, extending the parent's extreme cases S(n,n) = 1 and S(n,n−1) = 0.",
+    "proofStrategy": "Both theorems are short specialisations of the parent's main result card_perms_with_kfixed : S(n,k) = C(n,k)·D(n−k). (1) Rewrite the target count by that formula at k = n−2 (resp. n−3). (2) Simplify the codimension n−(n−2) = 2 (resp. n−(n−3) = 3) by `omega`. (3) Evaluate the small derangement number — D(2) = 1 and D(3) = 2 — by kernel `decide` (numDerangements_two, numDerangements_three), so mul_one drops the factor in the codim-2 case. (4) Convert the binomial C(n,n−2) → C(n,2) (resp. C(n,n−3) → C(n,3)) by `Nat.choose_symm`, which needs the hypotheses n ≥ 2, n ≥ 3. The codim-3 case finishes with `Nat.mul_comm` to match the 2·C(n,3) orientation.",
+    "keyInsights": [
+      "The whole entry rests on the parent's factorisation S(n,k) = C(n,k)·D(n−k): counting permutations with a prescribed number of fixed points decouples into 'choose which points are fixed' (binomial) times 'derange the rest' (derangement number). The codimension cases are simply this formula read at small derangement arguments.",
+      "Low codimension means small derangement number, and the small derangement numbers are tiny constants: D(0)=1, D(1)=0, D(2)=1, D(3)=2. That is exactly why S(n,n)=1, S(n,n−1)=0, S(n,n−2)=C(n,2), S(n,n−3)=2C(n,3) all collapse to a binomial times a small constant — the combinatorial content lives entirely in choosing the moved points.",
+      "The symmetry C(n,n−k) = C(n,k) (Nat.choose_symm) is what turns the 'codimension' index n−k back into the natural 'choose k moved points' reading; without it the answers would be stated awkwardly as C(n,n−2), C(n,n−3).",
+      "Evaluating D(2) and D(3) by kernel `decide` (not native_decide) keeps the proof axiom-free: it is genuine kernel reduction over the finite Derangements type, so #print axioms shows no Lean.ofReduceBool — a deliberate choice consistent with the project's axiom-integrity policy.",
+      "The result n−2 ↦ transpositions, n−3 ↦ pairs of 3-cycles is the start of a pattern: codimension c contributes C(n,c)·D(c), and D(c) is the number of fixed-point-free permutations of the c moved points, so each new row needs only one more derangement value."
+    ],
+    "prerequisites": [
+      "permutations of a finite type (Equiv.Perm (Fin n)) and their fixed-point sets",
+      "derangement numbers D(m) = numDerangements m and the values D(2)=1, D(3)=2",
+      "the partial-derangement / rencontres formula S(n,k) = C(n,k)·D(n−k) (parent derangements-oq-02)",
+      "binomial symmetry C(n,n−k) = C(n,k) (Nat.choose_symm)",
+      "kernel decision procedures (decide) and Finset.filter cardinalities"
+    ]
+  },
+  "conclusion": {
+    "summary": "Establishes the two low-codimension rencontres counts S(n,n−2) = C(n,2) (n ≥ 2, the transpositions) and S(n,n−3) = 2·C(n,3) (n ≥ 3, pairs of 3-cycles), each a one-line specialisation of the parent's S(n,k) = C(n,k)·D(n−k) at the kernel-evaluated derangement values D(2) = 1, D(3) = 2, with binomial symmetry restoring the 'choose the moved points' index. With the parent's S(n,n) = 1 and S(n,n−1) = 0 this completes the top of the fixed-point distribution. 0 axioms, 0 sorries.",
+    "implications": "Demonstrates how a single structural count (the parent's factorised S(n,k)) yields an entire family of clean corollaries simply by plugging in tabulated derangement values, with no further combinatorial work. The pattern is mechanical: each successive codimension c needs only the next derangement number D(c), so the table 1, 0, C(n,2), 2·C(n,3), 9·C(n,4), 44·C(n,5), … (with D(4)=9, D(5)=44) can be extended indefinitely by the same recipe. It also exemplifies the axiom-discipline of using kernel `decide` rather than native_decide for small finite evaluations, keeping downstream results verified.",
+    "openQuestions": [
+      "Extend the table to codimensions 4 and 5 (S(n,n−4) = 9·C(n,4), S(n,n−5) = 44·C(n,5)) using D(4) = 9, D(5) = 44, confirming the recipe scales.",
+      "Prove the column recurrence / generating function for the rencontres numbers ∑_{n,k} S(n,k) xᵏ yⁿ/n! = e^{xy}/(something) and recover these closed forms as coefficients, rather than one codimension at a time.",
+      "Formalize the limiting statement that the fraction of permutations with exactly k fixed points tends to e^{-1}/k! as n → ∞ (Poisson(1) limit), of which the derangement ratio D(n)/n! → 1/e is the k = 0 case.",
+      "Relate S(n,n−c) = C(n,c)·D(c) to the cycle-type stratification of the symmetric group, identifying which conjugacy classes contribute at each codimension (codim 2: a single transposition; codim 3: a single 3-cycle)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "derangements-oq-02",
+      "relationship": "extends",
+      "description": "Direct parent: proves the main partial-derangement formula card_perms_with_kfixed (S(n,k) = C(n,k)·D(n−k)) and the extreme cases S(n,n) = 1, S(n,n−1) = 0. This entry specialises that formula at codimensions 2 and 3 to continue the table downward."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Base entry on derangement numbers D(n) (the k = 0 column of the rencontres triangle, counting fixed-point-free permutations); the small values D(2) = 1, D(3) = 2 used here are instances of that count."
+    }
+  ],
+  "references": [
+    {
+      "author": "Montmort, P. R. de",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": 1713,
+      "note": "Second edition; origin of the rencontres ('treize') problem and the study of permutations by number of coincidences/fixed points"
+    },
+    {
+      "author": "OEIS Foundation",
+      "title": "A008290 — Triangle of rencontres numbers",
+      "year": 2026,
+      "note": "https://oeis.org/A008290 — the triangle S(n,k) of permutations of n elements with exactly k fixed points"
+    },
+    {
+      "author": "Stanley, R. P.",
+      "title": "Enumerative Combinatorics, Vol. 1",
+      "year": 2011,
+      "note": "Ch. 2 treats the inclusion–exclusion derivation of derangements and the rencontres distribution"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsOQ02"
+    ],
+    "namespace": "DerangementsOQ02OQ04",
+    "lineCount": 59,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsOQ02OQ04.lean",
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
Enrichment pass for `derangements-oq-02-oq-04` (quality 34, passes 0) — closed forms S(n,n−2) = C(n,2) and S(n,n−3) = 2·C(n,3) for the top of the rencontres (fixed-point) distribution.

## Gaps addressed
The entry had a description, originalContributions, and 3 sections but was missing the entire `overview`, `conclusion`, `crossReferences`, `references`, and `leanFile` blocks, plus preamble coverage and fine annotations.

## Changes
**meta.json**
- **overview**: historicalContext (Montmort's 1708/1713 rencontres/treize problem, D(n)/n!→1/e), problemStatement, proofStrategy, 5 keyInsights.
- **conclusion**: summary, implications (the recipe scales: D(4)=9, D(5)=44, …), 4 openQuestions.
- **crossReferences**: parent `derangements-oq-02` (extends) and base `derangements` (related).
- **references**: Montmort, OEIS A008290, Stanley EC1.
- **leanFile** block + new **preamble** section (L1–32).

**annotations.json** — grew 2 → 4, each with mathContext/significance/relatedConcepts/prerequisites:
1. Setup / rencontres table (L4–31)
2. Small derangement values D(2)=1, D(3)=2 by kernel `decide` (L33–37)
3. Codim-2 transpositions (L39–47)
4. Codim-3 pairs of 3-cycles (L49–57)

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof.
- meta.json/annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, badge `original`, axiomCount 0 — accurate; the D(2)/D(3) evaluations use kernel `decide` (not native_decide), so no Lean.ofReduceBool, as meta.json documents.