### PR TITLE
research(sqrt2-examples-oq-01-oq-01): totality is essential for sq_nonneg — the Artin–Schreier obstruction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3993,6 +3993,7 @@ import Proofs.Sqrt2MinpolyOQ01OQ02PrimePow
 import Proofs.Sqrt2MinpolyOQ02
 import Proofs.Sqrt2MinpolyOQ03
 import Proofs.Sqrt2OQ01
+import Proofs.Sqrt2OQ01OQ01
 import Proofs.Sqrt2PlusSqrt3Irrational
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ02
 import Proofs.Sqrt2PlusSqrt3IrrationalOQ03

--- a/proofs/Proofs/Sqrt2OQ01OQ01.lean
+++ b/proofs/Proofs/Sqrt2OQ01OQ01.lean
@@ -1,0 +1,139 @@
+/-
+  The Artin–Schreier Obstruction: Totality Is Essential for `sq_nonneg`
+
+  Open Question (sqrt2-examples-oq-01-oq-01):
+  "Is `LinearOrderedSemiring` the *minimal* typeclass for `mul_self_nonneg`
+   (0 ≤ x²)?  Concretely: can the totality of the order be dropped to a mere
+   partial order, or is it essential?  Exhibit a partially-ordered (not totally
+   ordered) ordered ring with an element whose square is negative."
+
+  Answer: TOTALITY IS ESSENTIAL.  We pin the obstruction to a single hypothesis.
+
+  Mathlib proves `sq_nonneg` under exactly
+      `[Semiring R] [LinearOrder R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]`.
+  Its proof (a `le_or_gt 0 a` case split) genuinely uses the `LinearOrder`.  We show
+  this `LinearOrder` cannot be weakened to `PartialOrder` by producing an *explicit
+  witness*: the complex numbers ℂ with their canonical order (`ComplexOrder`,
+  `z ≤ w ↔ w - z` is real and ≥ 0).  This ℂ satisfies **every** other hypothesis of
+  `sq_nonneg` — it is a commutative ring carrying `PartialOrder`, `ExistsAddOfLE`,
+  `PosMulMono`, and `AddLeftMono` — yet `Complex.I ^ 2 = -1 < 0`.  The single missing
+  ingredient is totality of the order, and indeed `I` and `0` are incomparable.
+
+  This is the Artin–Schreier phenomenon: ℂ is not *formally real* (−1 is a square),
+  so it admits no order making it a linearly ordered ring.  The parent entry
+  (`sqrt2-examples-oq-01`) showed the *positive* direction generalizes freely to any
+  linearly ordered ring; this entry shows the *negative* direction — the linearity
+  hypothesis is not redundant decoration but the load-bearing assumption.
+
+  Tags: ordered-rings, algebra, artin-schreier, formally-real, counterexample
+-/
+
+import Mathlib
+
+open scoped ComplexOrder
+
+namespace Sqrt2OQ01OQ01
+
+/-! ## Part I. The positive result: with a *linear* order, squares are nonnegative.
+
+These are the exact hypotheses Mathlib's `sq_nonneg` / `mul_self_nonneg` carry. They
+serve as the baseline against which Part III measures what happens when `LinearOrder`
+is removed. -/
+
+/-- Squares are nonnegative in any linearly ordered semiring (the `^2` form). This is
+the precise hypothesis set of Mathlib's `sq_nonneg`. -/
+theorem sq_nonneg_of_linearOrder {R : Type*} [Semiring R] [LinearOrder R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] (x : R) : 0 ≤ x ^ 2 :=
+  sq_nonneg x
+
+/-- Squares are nonnegative in any linearly ordered semiring (the `x * x` form). -/
+theorem mul_self_nonneg_of_linearOrder {R : Type*} [Semiring R] [LinearOrder R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] (x : R) : 0 ≤ x * x :=
+  mul_self_nonneg x
+
+/-! ## Part II. ℂ with `ComplexOrder` satisfies every *non-totality* hypothesis.
+
+We record, as machine-checked instance lookups, that ℂ is a commutative ring with a
+compatible partial order possessing all three algebraic mixins required by
+`sq_nonneg`. The *only* hypothesis it lacks is `LinearOrder`. -/
+
+example : CommRing ℂ := inferInstance
+example : PartialOrder ℂ := inferInstance
+example : ExistsAddOfLE ℂ := inferInstance
+example : AddLeftMono ℂ := inferInstance
+example : PosMulMono ℂ := inferInstance
+
+/-- A self-contained checklist: ℂ carries every `sq_nonneg` hypothesis *except*
+totality, packaged as a single proposition so the gap is explicit. -/
+theorem complex_has_all_but_linearOrder :
+    Nonempty (ExistsAddOfLE ℂ) ∧ Nonempty (PosMulMono ℂ) ∧ Nonempty (AddLeftMono ℂ) :=
+  ⟨⟨inferInstance⟩, ⟨inferInstance⟩, ⟨inferInstance⟩⟩
+
+/-! ## Part III. The obstruction: over ℂ, `sq_nonneg` fails — totality is essential. -/
+
+/-- The imaginary unit has a strictly negative square: `I² = -1 < 0`. -/
+theorem I_sq_lt_zero : Complex.I ^ 2 < 0 := by
+  rw [Complex.I_sq]
+  exact neg_lt_zero.mpr zero_lt_one
+
+/-- **Main counterexample.** Nonnegativity of squares *fails* over ℂ: there is no way
+to derive `0 ≤ z²` for every complex `z`, because the imaginary unit violates it.
+Equivalently, `mul_self_nonneg` is *false* once `LinearOrder` is dropped to
+`PartialOrder`, even with all other `sq_nonneg` hypotheses in force. -/
+theorem sq_nonneg_fails_on_complex : ¬ ∀ z : ℂ, 0 ≤ z ^ 2 := by
+  intro h
+  exact absurd (lt_of_le_of_lt (h Complex.I) I_sq_lt_zero) (lt_irrefl 0)
+
+/-- The `x * x` form fails likewise. -/
+theorem mul_self_nonneg_fails_on_complex : ¬ ∀ z : ℂ, 0 ≤ z * z := by
+  intro h
+  have hle : (0 : ℂ) ≤ Complex.I * Complex.I := h Complex.I
+  rw [Complex.I_mul_I] at hle
+  have hlt : (-1 : ℂ) < 0 := neg_lt_zero.mpr zero_lt_one
+  exact absurd (lt_of_le_of_lt hle hlt) (lt_irrefl 0)
+
+/-! ## Part IV. Locating the obstruction precisely at *totality*.
+
+The failure in Part III is not caused by any algebraic defect — ℂ has all the ring
+mixins. It is caused by the order being merely partial: `I` and `0` are incomparable,
+so a total-order case split (`le_or_gt 0 I`) is unavailable. -/
+
+/-- `I` and `0` are incomparable under `ComplexOrder`. -/
+theorem I_incomparable_zero : ¬ (Complex.I ≤ 0) ∧ ¬ (0 ≤ Complex.I) := by
+  refine ⟨?_, ?_⟩
+  · rw [Complex.nonpos_iff]; simp [Complex.I_re, Complex.I_im]
+  · rw [Complex.nonneg_iff]; simp [Complex.I_re, Complex.I_im]
+
+/-- Therefore the canonical order on ℂ is **not total**: this is the one and only
+hypothesis of `sq_nonneg` that ℂ fails to satisfy. -/
+theorem complexOrder_not_total : ¬ ∀ z w : ℂ, z ≤ w ∨ w ≤ z := by
+  intro h
+  rcases h Complex.I 0 with h₁ | h₂
+  · exact I_incomparable_zero.1 h₁
+  · exact I_incomparable_zero.2 h₂
+
+/-! ## Part V. The Artin–Schreier root cause: ℂ is not formally real.
+
+A field admits a linearly ordered ring structure only if it is *formally real* (−1 is
+not a sum of squares). In ℂ, −1 is already a single square, `(-1) = I·I`, so ℂ is not
+formally real — which is *why* no compatible linear order can exist. We make both ends
+of this explicit. -/
+
+/-- −1 is a square in ℂ (so ℂ is not formally real). -/
+theorem neg_one_isSquare_complex : IsSquare (-1 : ℂ) :=
+  ⟨Complex.I, Complex.I_mul_I.symm⟩
+
+/-- **Artin–Schreier obstruction, abstract form.** In *any* linearly ordered ring,
+−1 is never a square. Contrapositive: a ring in which −1 is a square (such as ℂ)
+admits no order making it a linearly ordered ring — the structural reason `sq_nonneg`
+cannot hold over ℂ. -/
+theorem neg_one_not_isSquare_of_linearOrder {R : Type*} [Ring R] [LinearOrder R]
+    [IsStrictOrderedRing R] : ¬ IsSquare (-1 : R) := by
+  rintro ⟨r, hr⟩
+  have hnonneg : (0 : R) ≤ r * r := mul_self_nonneg r
+  rw [← hr] at hnonneg
+  -- `0 ≤ -1` forces `1 ≤ 0`, contradicting `0 < 1`.
+  rw [neg_nonneg] at hnonneg
+  exact absurd hnonneg (not_le.mpr zero_lt_one)
+
+end Sqrt2OQ01OQ01

--- a/src/data/proofs/sqrt2-examples-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/sqrt2-examples-oq-01-oq-01/annotations.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": "sq-nonneg-true-hypotheses",
+    "proofId": "sqrt2-examples-oq-01-oq-01",
+    "range": {
+      "startLine": 45,
+      "endLine": 52
+    },
+    "type": "insight",
+    "title": "The True Hypotheses of sq_nonneg",
+    "content": "Mathlib does not state `sq_nonneg` for a bundled `LinearOrderedSemiring`; in this version it carries the unbundled hypotheses `[Semiring R] [LinearOrder R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]`. Writing them out explicitly is the key move: it isolates the one hypothesis — `LinearOrder` — whose necessity is in question. `sq_nonneg_of_linearOrder` and `mul_self_nonneg_of_linearOrder` are the positive baseline against which the rest of the file measures what breaks when totality is removed.",
+    "mathContext": "0 ≤ x² and 0 ≤ x·x hold whenever the order is linear and the three ring-order mixins (`ExistsAddOfLE`, `PosMulMono`, `AddLeftMono`) are present. Mathlib's proof of `sq_nonneg` splits on `le_or_gt 0 a`, which requires `LinearOrder`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sq_nonneg",
+      "mul_self_nonneg",
+      "ExistsAddOfLE",
+      "PosMulMono",
+      "AddLeftMono",
+      "unbundled typeclasses"
+    ],
+    "prerequisites": [
+      "ordered algebra",
+      "Lean 4 typeclasses",
+      "Mathlib ordered-ring mixins"
+    ]
+  },
+  {
+    "id": "complex-all-but-totality",
+    "proofId": "sqrt2-examples-oq-01-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 70
+    },
+    "type": "insight",
+    "title": "ℂ Satisfies Everything but Totality",
+    "content": "Under `open scoped ComplexOrder`, the complex numbers acquire their canonical partial order (z ≤ w iff w - z is real and ≥ 0). Via `RCLike.toIsStrictOrderedRing`, ℂ then carries the mixins `ExistsAddOfLE`, `PosMulMono`, and `AddLeftMono`. The five `example` instance lookups, summarized in `complex_has_all_but_linearOrder`, machine-check that ℂ meets every hypothesis of `sq_nonneg` except `LinearOrder`. This is what makes ℂ a clean, single-variable witness: nothing algebraic is missing.",
+    "mathContext": "ℂ is a `CommRing` with `PartialOrder`, `ExistsAddOfLE`, `PosMulMono`, `AddLeftMono` — but provably not a `LinearOrder`, because incomparable elements exist.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ComplexOrder",
+      "RCLike.toIsStrictOrderedRing",
+      "PartialOrder",
+      "PosMulMono",
+      "instance resolution"
+    ],
+    "prerequisites": [
+      "complex numbers",
+      "Mathlib RCLike hierarchy",
+      "scoped instances"
+    ]
+  },
+  {
+    "id": "i-squared-counterexample",
+    "proofId": "sqrt2-examples-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 93
+    },
+    "type": "key-step",
+    "title": "The Counterexample: I² = -1 < 0",
+    "content": "The imaginary unit refutes non-negativity of squares: `Complex.I_sq` gives I² = -1, and -1 < 0 follows from `neg_lt_zero.mpr zero_lt_one`. Because ℂ is only a `PartialOrder`, the usual `not_le` (which needs a linear order) is unavailable; the contradiction is instead derived by chaining `lt_of_le_of_lt` with `lt_irrefl 0`. The theorems `sq_nonneg_fails_on_complex` and `mul_self_nonneg_fails_on_complex` conclude that ¬ ∀ z, 0 ≤ z² over ℂ — sq_nonneg is genuinely false once `LinearOrder` is dropped.",
+    "mathContext": "I² = -1 and -1 < 0 in ℂ, so 0 ≤ z² fails at z = I. The proof avoids `not_le` (a `LinearOrder` lemma) by using only `Preorder` transitivity: 0 ≤ I² together with I² < 0 yields 0 < 0.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Complex.I_sq",
+      "neg_lt_zero",
+      "lt_of_le_of_lt",
+      "lt_irrefl",
+      "counterexample"
+    ],
+    "prerequisites": [
+      "complex arithmetic",
+      "order axioms",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "obstruction-is-totality",
+    "proofId": "sqrt2-examples-oq-01-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 113
+    },
+    "type": "insight",
+    "title": "The Obstruction Is Exactly Totality",
+    "content": "The failure in Part III is purely order-theoretic. `I_incomparable_zero` shows, via `Complex.nonpos_iff` and `Complex.nonneg_iff`, that neither I ≤ 0 nor 0 ≤ I holds (I has imaginary part 1 ≠ 0). Hence `complexOrder_not_total`: the canonical order on ℂ fails `∀ z w, z ≤ w ∨ w ≤ z`. This is the single hypothesis of `sq_nonneg` that ℂ does not meet, and it is precisely the one Mathlib's proof exploits through its `le_or_gt 0 a` case split.",
+    "mathContext": "I and 0 are incomparable because their imaginary parts differ, so totality fails. The proof of `sq_nonneg` needs to compare an arbitrary element to 0; without totality that comparison does not exist.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Complex.nonneg_iff",
+      "Complex.nonpos_iff",
+      "totality",
+      "linear order",
+      "incomparability"
+    ],
+    "prerequisites": [
+      "partial vs total orders",
+      "complex order definition"
+    ]
+  },
+  {
+    "id": "artin-schreier-root-cause",
+    "proofId": "sqrt2-examples-oq-01-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 138
+    },
+    "type": "insight",
+    "title": "Artin–Schreier: Why No Linear Order Exists",
+    "content": "The structural reason ℂ cannot be linearly ordered is captured abstractly. `neg_one_not_isSquare_of_linearOrder` proves that in ANY linearly ordered ring -1 is not a square: if -1 = r·r then 0 ≤ r·r = -1 forces 1 ≤ 0, contradicting 0 < 1. Contrapositively, a ring where -1 IS a square — such as ℂ, recorded by `neg_one_isSquare_complex` with -1 = I·I — admits no order making it a linearly ordered ring. This is the Artin–Schreier criterion: orderability requires formal reality.",
+    "mathContext": "Artin–Schreier (1926): a field is orderable iff it is formally real (-1 is not a sum of squares). Here the single-square case suffices: -1 = I² in ℂ obstructs all compatible linear orders.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Artin–Schreier theory",
+      "formally real field",
+      "IsSquare",
+      "IsStrictOrderedRing",
+      "orderability"
+    ],
+    "prerequisites": [
+      "ordered fields",
+      "formally real fields",
+      "sums of squares"
+    ]
+  }
+]

--- a/src/data/proofs/sqrt2-examples-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "sqrt2-examples-oq-01-oq-01",
+  "title": "Totality Is Essential for sq_nonneg: The Artin–Schreier Obstruction (OQ-01-OQ-01)",
+  "slug": "sqrt2-examples-oq-01-oq-01",
+  "description": "Answers the open question posed by the parent entry (sqrt2-examples-oq-01): is the order's totality essential for 0 ≤ x², or can LinearOrder be weakened to a partial order? Answer: totality is essential. Mathlib's sq_nonneg carries exactly [Semiring R] [LinearOrder R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]; its proof uses a le_or_gt case split that genuinely needs the LinearOrder. We pin the obstruction to that single hypothesis with an explicit witness — the complex numbers ℂ under their canonical order (ComplexOrder). ℂ satisfies every other hypothesis (it is a commutative ring carrying PartialOrder, ExistsAddOfLE, PosMulMono, AddLeftMono) yet Complex.I² = -1 < 0, and I and 0 are incomparable. The structural root cause is Artin–Schreier: ℂ is not formally real (-1 is a square), so no compatible linear order exists. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Artin%E2%80%93Schreier_theory",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2OQ01OQ01.lean",
+    "tags": [
+      "ordered-rings",
+      "algebra",
+      "artin-schreier",
+      "formally-real",
+      "counterexample",
+      "typeclass-hierarchy",
+      "complex-numbers",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 139,
+    "assumptions": "None. 0 axioms, 0 sorries; depends only on Mathlib. The proofs use only the ordinary foundational axioms (propext, Classical.choice, Quot.sound), no `axiom` declarations, no structure-encoded assumptions, and no native_decide.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "sq_nonneg",
+        "description": "0 ≤ a² under [Semiring R] [LinearOrder R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] — the exact hypothesis set this entry analyzes",
+        "module": "Mathlib.Algebra.Order.Ring.Unbundled.Basic"
+      },
+      {
+        "theorem": "mul_self_nonneg",
+        "description": "0 ≤ a * a under the same hypotheses as sq_nonneg",
+        "module": "Mathlib.Algebra.Order.Ring.Unbundled.Basic"
+      },
+      {
+        "theorem": "Complex.partialOrder",
+        "description": "The canonical partial order on ℂ: z ≤ w ↔ (w - z).re ≥ 0 ∧ (w - z).im = 0 (scoped under ComplexOrder)",
+        "module": "Mathlib.Analysis.Complex.Order"
+      },
+      {
+        "theorem": "RCLike.toIsStrictOrderedRing",
+        "description": "ℝ and ℂ are IsStrictOrderedRing under their canonical order (scoped under ComplexOrder); supplies the ExistsAddOfLE / PosMulMono / AddLeftMono mixins for ℂ",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "Complex.I_sq",
+        "description": "Complex.I ^ 2 = -1",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "Complex.nonneg_iff",
+        "description": "0 ≤ z ↔ 0 ≤ z.re ∧ 0 = z.im — used to show I and 0 are incomparable",
+        "module": "Mathlib.Analysis.Complex.Order"
+      }
+    ],
+    "originalContributions": [
+      "Answers the parent's open question (sqrt2-examples-oq-01, OQ #1) verbatim: totality of the order is ESSENTIAL for 0 ≤ x²; LinearOrder cannot be weakened to PartialOrder",
+      "Pins the obstruction to a SINGLE hypothesis: ℂ under ComplexOrder satisfies every hypothesis of Mathlib's sq_nonneg (CommRing, PartialOrder, ExistsAddOfLE, PosMulMono, AddLeftMono) EXCEPT LinearOrder, recorded as machine-checked instance lookups",
+      "Explicit witness sq_nonneg_fails_on_complex / mul_self_nonneg_fails_on_complex: the imaginary unit satisfies I² = -1 < 0, refuting non-negativity of squares over a partially-ordered ring",
+      "Localizes the failure exactly at totality (complexOrder_not_total): I and 0 are incomparable, so the le_or_gt case split that Mathlib's proof relies on is unavailable",
+      "Formalizes the Artin–Schreier root cause in abstract form (neg_one_not_isSquare_of_linearOrder): in ANY linearly ordered ring -1 is not a square, so a ring where -1 is a square (such as ℂ, neg_one_isSquare_complex) admits no compatible linear order"
+    ],
+    "theoremCount": 10,
+    "substantiveTheoremCount": 5,
+    "definitionCount": 0,
+    "trueStubs": 0
+  },
+  "overview": {
+    "historicalContext": "The non-negativity of squares (0 ≤ x²) is among the oldest facts in ordered algebra, but its precise logical content was only clarified by Emil Artin and Otto Schreier in the 1920s. Their theory of formally real fields (1926) characterizes exactly which fields can be ordered: a field admits an order making it a linearly ordered field if and only if it is formally real, meaning -1 is not a sum of squares. The complex numbers fail this dramatically — -1 = I·I is already a single square — so ℂ admits no order making it a linearly ordered ring, despite carrying a perfectly good partial order. The parent gallery entry sqrt2-examples-oq-01 established the positive direction (0 ≤ x² generalizes freely to any linearly ordered semiring) and explicitly asked, as its first open question, whether the totality of the order is essential or merely convenient. This entry settles that question.",
+    "problemStatement": "Mathlib proves sq_nonneg (0 ≤ x²) and mul_self_nonneg (0 ≤ x·x) under the hypotheses [Semiring R] [LinearOrder R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]. Is the LinearOrder hypothesis essential, or can it be weakened to a mere PartialOrder while keeping the three algebraic mixins? Equivalently: does there exist a partially-ordered (not totally ordered) ordered ring with an element whose square is negative?",
+    "proofStrategy": "Five parts. Part I records the positive baseline: sq_nonneg / mul_self_nonneg under the full linear hypotheses. Part II verifies, as instance lookups, that ℂ with its canonical order (ComplexOrder, supplied by RCLike.toIsStrictOrderedRing) satisfies every hypothesis EXCEPT LinearOrder — it is a CommRing with a PartialOrder and the ExistsAddOfLE / PosMulMono / AddLeftMono mixins. Part III exhibits the counterexample: Complex.I² = -1 < 0, so 0 ≤ z² fails for z = I, refuting non-negativity of squares over the partially-ordered ℂ. Part IV localizes the failure at totality: I and 0 are incomparable (their imaginary parts differ), so the le_or_gt 0 a case split Mathlib's proof of sq_nonneg relies upon is simply unavailable. Part V supplies the Artin–Schreier root cause in abstract form: in any linearly ordered ring -1 is not a square (because then 0 ≤ -1 forces 1 ≤ 0), whereas -1 IS a square in ℂ — so no compatible linear order can exist.",
+    "keyInsights": [
+      "Mathlib's sq_nonneg does NOT require a bundled LinearOrderedSemiring; its true hypotheses are [Semiring] [LinearOrder] plus the three mixins [ExistsAddOfLE] [PosMulMono] [AddLeftMono]. This exposes exactly which assumption to attack: LinearOrder.",
+      "The obstruction is not algebraic but order-theoretic. ℂ has all the ring-compatibility mixins; what it lacks is totality. Dropping LinearOrder to PartialOrder is therefore fatal on its own.",
+      "ℂ is the canonical witness because its order is genuinely partial: the imaginary unit I has nonzero imaginary part, so it is incomparable to every real number, including 0. Mathlib's proof of sq_nonneg case-splits on le_or_gt 0 a, which is exactly what fails here.",
+      "The structural reason traces to Artin–Schreier: a ring in which -1 is a square cannot be linearly ordered, because 0 ≤ (√-1)² = -1 would force 1 ≤ 0. ℂ realizes this with -1 = I·I.",
+      "The result sharpens the parent: the positive direction (0 ≤ x²) is robust and generalizes downward to semirings, but the linearity hypothesis underpinning it is load-bearing, not decorative — exactly the kind of distinction Lean's typeclass system makes precise."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring stating the open question and answer; imports Mathlib; opens the ComplexOrder scope and the namespace."
+    },
+    {
+      "id": "positive-baseline",
+      "title": "I. The Positive Baseline (Linear Order Suffices)",
+      "startLine": 37,
+      "endLine": 52,
+      "summary": "sq_nonneg_of_linearOrder and mul_self_nonneg_of_linearOrder: 0 ≤ x² and 0 ≤ x·x under the exact hypotheses Mathlib's sq_nonneg carries, serving as the baseline for the obstruction."
+    },
+    {
+      "id": "complex-mixins",
+      "title": "II. ℂ Has Every Hypothesis Except Totality",
+      "startLine": 54,
+      "endLine": 70,
+      "summary": "Instance lookups confirming ℂ (ComplexOrder) is a CommRing with PartialOrder, ExistsAddOfLE, PosMulMono, and AddLeftMono — all sq_nonneg hypotheses except LinearOrder, packaged in complex_has_all_but_linearOrder."
+    },
+    {
+      "id": "obstruction",
+      "title": "III. The Counterexample (sq_nonneg Fails over ℂ)",
+      "startLine": 72,
+      "endLine": 93,
+      "summary": "I_sq_lt_zero (I² = -1 < 0) and the main results sq_nonneg_fails_on_complex / mul_self_nonneg_fails_on_complex: non-negativity of squares is false once LinearOrder is dropped to PartialOrder."
+    },
+    {
+      "id": "totality",
+      "title": "IV. The Obstruction Is Exactly Totality",
+      "startLine": 95,
+      "endLine": 113,
+      "summary": "I_incomparable_zero and complexOrder_not_total: I and 0 are incomparable, so the canonical order on ℂ is not total — the single sq_nonneg hypothesis ℂ fails."
+    },
+    {
+      "id": "artin-schreier",
+      "title": "V. The Artin–Schreier Root Cause",
+      "startLine": 115,
+      "endLine": 139,
+      "summary": "neg_one_isSquare_complex (-1 = I·I is a square in ℂ) and neg_one_not_isSquare_of_linearOrder (in any linearly ordered ring -1 is never a square): ℂ is not formally real, which is why no compatible linear order exists."
+    }
+  ],
+  "conclusion": {
+    "summary": "Totality is essential. The LinearOrder hypothesis of Mathlib's sq_nonneg / mul_self_nonneg cannot be weakened to PartialOrder: the complex numbers under their canonical order satisfy every other hypothesis yet violate non-negativity of squares (I² = -1 < 0). The obstruction is localized precisely at totality (I and 0 are incomparable) and explained structurally by Artin–Schreier (ℂ is not formally real, since -1 is a square).",
+    "implications": "This closes the parent entry's first open question and turns a heuristic remark ('the total order is essential') into a machine-checked theorem with an explicit witness. The reusable content is the diagnostic pattern: take a Mathlib lemma's true hypothesis set, find a structure satisfying all but one hypothesis, and exhibit the failure — pinpointing which assumption is load-bearing. Here it certifies that ℂ's canonical order, useful as it is, can never be a linear ordered-ring order.",
+    "openQuestions": [
+      "Beyond ℂ: can one classify the formally real subfields of ℂ (those admitting a compatible linear order) and formalize Artin–Schreier's full characterization — a field is orderable iff -1 is not a sum of squares — in Lean?",
+      "Is there a partially-ordered SEMIRING (no additive inverses) with an element x and x·x < 0, or does the absence of subtraction force x·x ≥ 0 for a different reason? ℂ resolves the ring case; the genuine semiring case is subtler.",
+      "Can the bridge mixins (ExistsAddOfLE, PosMulMono, AddLeftMono) plus PartialOrder be axiomatically combined with a 'square-positivity' assumption to recover a useful intermediate class between partially and linearly ordered rings?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-examples-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry (Generalized Non-Negativity of Squares). It proved the positive direction and asked, as its first open question, whether the order's totality is essential. This entry answers: yes, with ℂ as the explicit Artin–Schreier witness."
+    },
+    {
+      "targetId": "sqrt2-examples",
+      "relationship": "related",
+      "description": "Root Basic Lean Examples entry, the original ℤ-specific square_nonneg from which this lineage descends."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped ComplexOrder"
+    ],
+    "namespace": "Sqrt2OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 5,
+    "definitionCount": 0,
+    "trueStubs": 0,
+    "path": "Proofs/Sqrt2OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent gallery entry `sqrt2-examples-oq-01` (*Generalized Non-Negativity of Squares*):

> "Is `LinearOrderedSemiring` the *minimal* typeclass for `mul_self_nonneg`? Can one construct a semiring with a partial order (not a total order) where some element x satisfies x² < 0? The Artin-Schreier theory suggests the total order is essential."

**Answer: totality is essential.** `LinearOrder` cannot be weakened to `PartialOrder`.

## The result

Mathlib's `sq_nonneg` carries the unbundled hypotheses
`[Semiring R] [LinearOrder R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]`,
and its proof case-splits on `le_or_gt 0 a` — genuinely using `LinearOrder`. We pin the
obstruction to that single hypothesis with an explicit witness: **the complex numbers ℂ**
under their canonical order (`ComplexOrder`).

- **Part I** — positive baseline: `sq_nonneg` / `mul_self_nonneg` under the full linear hypotheses.
- **Part II** — ℂ satisfies *every* hypothesis except `LinearOrder` (machine-checked instance lookups: `CommRing`, `PartialOrder`, `ExistsAddOfLE`, `PosMulMono`, `AddLeftMono`).
- **Part III** — the counterexample: `Complex.I ^ 2 = -1 < 0`, so `sq_nonneg_fails_on_complex` / `mul_self_nonneg_fails_on_complex`.
- **Part IV** — the failure is *exactly* totality: `I` and `0` are incomparable (`complexOrder_not_total`).
- **Part V** — Artin–Schreier root cause: in any linearly ordered ring `-1` is not a square (`neg_one_not_isSquare_of_linearOrder`), whereas `-1 = I·I` in ℂ (`neg_one_isSquare_complex`) — so ℂ admits no compatible linear order.

## Verification

- **0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), **0 sorries**, **10 theorems**, 0 definitions.
- Compiles cleanly under `lake env lean` (Mathlib 4.26.0).
- New module registered in `proofs/Proofs.lean`.

## Files
- `proofs/Proofs/Sqrt2OQ01OQ01.lean` (139 lines)
- `src/data/proofs/sqrt2-examples-oq-01-oq-01/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)