### PR TITLE
research(hermite-sawtooth-identity-oq-01): Raabe multiplication formula for Bernoulli polynomials (m=0,1,2) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/HermiteSawtoothIdentityOQ01.lean
+++ b/proofs/Proofs/HermiteSawtoothIdentityOQ01.lean
@@ -1,0 +1,116 @@
+import Mathlib
+
+/-
+# Raabe Multiplication Formula for Bernoulli Polynomials (low orders)
+
+## Open Question (hermite-sawtooth-identity-oq-01)
+
+The parent entry `HermiteSawtoothIdentity` proves the `m = 1` *fractional-part*
+sawtooth identity `∑_{k<n} {x + k/n} = {n x} + (n-1)/2`.  Its Bernoulli-polynomial
+form is the `m = 1` case of the **Raabe multiplication theorem**
+
+    `∑_{k=0}^{n-1} Bₘ(x + k/n) = n^{1-m} · Bₘ(n x)`,
+
+where `Bₘ` is the `m`-th Bernoulli polynomial (`Polynomial.bernoulli`).  The full
+theorem (general `m`) is classically proved through the exponential generating
+function `t e^{xt}/(e^t - 1)` — heavy machinery in a formal setting.
+
+This file proves the theorem for the **low orders** `m = 0, 1, 2`, where `n^{1-m}`
+is a concrete coefficient (`n`, `1`, `1/n`) and the identity reduces to an
+elementary power-sum computation.  For each order we evaluate `Bₘ` to its
+explicit polynomial and close the sum with the Gauss / square power-sum formulas
+
+* `∑_{k<n} k     = n(n-1)/2`        (`sum_range_id_rat`),
+* `∑_{k<n} k²    = n(n-1)(2n-1)/6`  (`sum_range_sq_rat`).
+
+The `m = 1` case (`raabe_one`) is the Bernoulli-polynomial twin of the parent
+sawtooth identity, now with `n^{1-1} = 1`.
+
+Everything is over ℚ, fully machine-checked, `0`-axiom.  Mathlib provides the
+Bernoulli polynomials and `sum_bernoulli` but not the multiplication theorem.
+-/
+
+open Polynomial Finset
+
+namespace HermiteSawtoothIdentityOQ01
+
+/-! ### Explicit evaluations of the low Bernoulli polynomials -/
+
+/-- `B₀(x) = 1`. -/
+theorem bernoulli_eval_zero' (x : ℚ) : (Polynomial.bernoulli 0).eval x = 1 := by
+  simp [Polynomial.bernoulli]
+
+/-- `B₁(x) = x - 1/2`. -/
+theorem bernoulli_eval_one' (x : ℚ) : (Polynomial.bernoulli 1).eval x = x - 1 / 2 := by
+  simp [Polynomial.bernoulli, Finset.sum_range_succ]; ring
+
+/-- `B₂(x) = x² - x + 1/6`. -/
+theorem bernoulli_eval_two' (x : ℚ) :
+    (Polynomial.bernoulli 2).eval x = x ^ 2 - x + 1 / 6 := by
+  simp [Polynomial.bernoulli, Finset.sum_range_succ]; ring
+
+/-! ### Power-sum lemmas over ℚ -/
+
+/-- Gauss sum over ℚ: `∑_{k<n} k = n(n-1)/2`. -/
+theorem sum_range_id_rat (n : ℕ) :
+    ∑ k ∈ range n, (k : ℚ) = (n : ℚ) * ((n : ℚ) - 1) / 2 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, ih]
+    push_cast
+    ring
+
+/-- Sum of squares over ℚ: `∑_{k<n} k² = n(n-1)(2n-1)/6`. -/
+theorem sum_range_sq_rat (n : ℕ) :
+    ∑ k ∈ range n, (k : ℚ) ^ 2 = (n : ℚ) * ((n : ℚ) - 1) * (2 * (n : ℚ) - 1) / 6 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    rw [sum_range_succ, ih]
+    push_cast
+    ring
+
+/-! ### The Raabe multiplication formula at `m = 0, 1, 2` -/
+
+/-- **Raabe, `m = 0`.**  `∑_{k<n} B₀(x + k/n) = n · B₀(n x)`, i.e. `n^{1-0} = n`.
+Both sides are `n`. -/
+theorem raabe_zero (x : ℚ) (n : ℕ) :
+    ∑ k ∈ range n, (Polynomial.bernoulli 0).eval (x + (k : ℚ) / (n : ℚ))
+      = (n : ℚ) * (Polynomial.bernoulli 0).eval ((n : ℚ) * x) := by
+  simp only [bernoulli_eval_zero']
+  simp
+
+/-- **Raabe, `m = 1`.**  `∑_{k<n} B₁(x + k/n) = B₁(n x)` (since `n^{1-1} = 1`).
+The Bernoulli-polynomial form of the parent sawtooth identity. -/
+theorem raabe_one (x : ℚ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, (Polynomial.bernoulli 1).eval (x + (k : ℚ) / (n : ℚ))
+      = (Polynomial.bernoulli 1).eval ((n : ℚ) * x) := by
+  have hn0 : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  simp only [bernoulli_eval_one', Finset.sum_sub_distrib, Finset.sum_add_distrib,
+      Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+  rw [← Finset.sum_div, sum_range_id_rat]
+  field_simp
+  ring
+
+/-- **Raabe, `m = 2`.**  `∑_{k<n} B₂(x + k/n) = (1/n) · B₂(n x)` (since
+`n^{1-2} = n⁻¹`), for `n ≥ 1`. -/
+theorem raabe_two (x : ℚ) (n : ℕ) (hn : 0 < n) :
+    ∑ k ∈ range n, (Polynomial.bernoulli 2).eval (x + (k : ℚ) / (n : ℚ))
+      = (1 / (n : ℚ)) * (Polynomial.bernoulli 2).eval ((n : ℚ) * x) := by
+  have hn0 : (n : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hn.ne'
+  simp only [bernoulli_eval_two']
+  -- expand each square and split the sum into the three power sums
+  have hexp : ∀ k : ℕ, (x + (k : ℚ) / (n : ℚ)) ^ 2 - (x + (k : ℚ) / (n : ℚ)) + 1 / 6
+      = x ^ 2 - x + 1 / 6 + (2 * x - 1) / (n : ℚ) * (k : ℚ) + (1 / (n : ℚ) ^ 2) * (k : ℚ) ^ 2 := by
+    intro k
+    field_simp
+    ring
+  rw [Finset.sum_congr rfl (fun k _ => hexp k)]
+  simp only [Finset.sum_add_distrib, Finset.sum_const, Finset.card_range,
+      nsmul_eq_mul, ← Finset.mul_sum]
+  rw [sum_range_id_rat, sum_range_sq_rat]
+  field_simp
+  ring
+
+end HermiteSawtoothIdentityOQ01

--- a/src/data/proofs/hermite-sawtooth-identity-oq-01/annotations.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-evals",
+    "proofId": "hermite-sawtooth-identity-oq-01",
+    "range": { "startLine": 37, "endLine": 50 },
+    "type": "theorem",
+    "title": "Explicit evaluations: B₀=1, B₁=x−1/2, B₂=x²−x+1/6",
+    "content": "The Raabe sums become tractable only once the Bernoulli polynomial $B_m$ is replaced by its explicit closed form. Mathlib's `Polynomial.bernoulli m` evaluates cheaply: `simp [Polynomial.bernoulli, Finset.sum_range_succ]` reduces $B_0$ outright, and a trailing `ring` finishes $B_1(x) = x - \\tfrac12$ and $B_2(x) = x^2 - x + \\tfrac16$. These three lemmas are the bridge from the abstract `Polynomial.bernoulli` API to the elementary power-sum computations that follow.",
+    "mathContext": "$B_0(x)=1,\\quad B_1(x)=x-\\tfrac12,\\quad B_2(x)=x^2-x+\\tfrac16$.",
+    "significance": "supporting",
+    "prerequisites": ["Polynomial.bernoulli", "Polynomial.eval"],
+    "relatedConcepts": ["Bernoulli polynomials", "simp normalization"]
+  },
+  {
+    "id": "ann-power-sums",
+    "proofId": "hermite-sawtooth-identity-oq-01",
+    "range": { "startLine": 52, "endLine": 72 },
+    "type": "theorem",
+    "title": "ℚ power sums: ∑k = n(n−1)/2, ∑k² = n(n−1)(2n−1)/6",
+    "content": "The two closing identities. Each is a one-line induction over ℚ: `Finset.sum_range_succ` peels the top term, `push_cast` clears the $\\uparrow(m+1)$ successor cast, and `ring` verifies the resulting polynomial step ($m(m-1)(2m-1) + 6m^2 = m(m+1)(2m+1)$ for the squares). Stating them directly over ℚ avoids any truncated-ℕ-subtraction friction and lets them slot straight into the order-1 and order-2 Raabe computations.",
+    "mathContext": "$\\sum_{k<n} k = \\tfrac{n(n-1)}2,\\quad \\sum_{k<n} k^2 = \\tfrac{n(n-1)(2n-1)}6$.",
+    "significance": "key",
+    "prerequisites": ["Mathematical induction", "Finset.sum_range_succ"],
+    "relatedConcepts": ["Gauss sum", "Faulhaber identities", "push_cast"]
+  },
+  {
+    "id": "ann-raabe-one",
+    "proofId": "hermite-sawtooth-identity-oq-01",
+    "range": { "startLine": 86, "endLine": 96 },
+    "type": "theorem",
+    "title": "Raabe m=1: ∑ B₁(x+k/n) = B₁(nx) — the sawtooth, on polynomials",
+    "content": "With $n^{1-1} = 1$ the multiplication formula reads $\\sum_{k<n} B_1(x+k/n) = B_1(nx)$, the Bernoulli-polynomial twin of the parent's fractional-part sawtooth identity. After substituting $B_1(y) = y - \\tfrac12$, the sum splits via `sum_sub_distrib`/`sum_add_distrib`/`sum_const`; the $\\sum_{k<n} k/n$ term is regrouped as $(\\sum k)/n$ (`← Finset.sum_div`) and collapsed by `sum_range_id_rat`; `field_simp` and `ring` then verify $nx + \\tfrac{n-1}2 - \\tfrac n2 = nx - \\tfrac12$.",
+    "mathContext": "$\\sum_{k<n} B_1\\!\\left(x+\\tfrac kn\\right) = B_1(nx) = nx - \\tfrac12$.",
+    "significance": "critical",
+    "prerequisites": ["Finset.sum_add_distrib", "Finset.sum_div"],
+    "relatedConcepts": ["Raabe multiplication theorem", "Sawtooth identity", "Bernoulli polynomials"]
+  },
+  {
+    "id": "ann-raabe-two",
+    "proofId": "hermite-sawtooth-identity-oq-01",
+    "range": { "startLine": 98, "endLine": 114 },
+    "type": "theorem",
+    "title": "Raabe m=2: ∑ B₂(x+k/n) = (1/n)·B₂(nx)",
+    "content": "The first order whose prefactor is a genuine reciprocal, $n^{1-2} = 1/n$. Each summand is expanded pointwise (`Finset.sum_congr`) into $x^2 - x + \\tfrac16 + \\tfrac{2x-1}{n}k + \\tfrac1{n^2}k^2$, exposing exactly the constant, linear and quadratic power sums. `sum_add_distrib`/`sum_const` split them, `← Finset.mul_sum` factors the $1/n$ powers out, and `sum_range_id_rat`/`sum_range_sq_rat` collapse $\\sum k$ and $\\sum k^2$. A final `field_simp` + `ring` confirms the whole thing equals $\\tfrac1n(n^2x^2 - nx + \\tfrac16) = \\tfrac1n B_2(nx)$ — the constant terms telescoping to $\\tfrac1{6n}$.",
+    "mathContext": "$\\sum_{k<n} B_2\\!\\left(x+\\tfrac kn\\right) = \\tfrac1n B_2(nx)$.",
+    "significance": "critical",
+    "prerequisites": ["Finset.mul_sum", "Sum-of-squares formula"],
+    "relatedConcepts": ["Raabe multiplication theorem", "Power sums", "Bernoulli polynomials"]
+  }
+]

--- a/src/data/proofs/hermite-sawtooth-identity-oq-01/meta.json
+++ b/src/data/proofs/hermite-sawtooth-identity-oq-01/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "hermite-sawtooth-identity-oq-01",
+  "title": "Raabe Multiplication Formula for Bernoulli Polynomials (orders m = 0, 1, 2)",
+  "slug": "hermite-sawtooth-identity-oq-01",
+  "description": "A fully machine-checked proof of the Raabe (Hurwitz) multiplication theorem for Bernoulli polynomials, ∑_{k=0}^{n-1} Bₘ(x + k/n) = n^{1-m}·Bₘ(nx), at the low orders m = 0, 1, 2 for general n ≥ 1. These are exactly the orders where the prefactor n^{1-m} is a concrete coefficient (n, 1, 1/n) and the identity reduces to an elementary power-sum computation, sidestepping the exponential-generating-function machinery that the general-m theorem requires. The m = 1 case (raabe_one) is the Bernoulli-polynomial twin of the parent's fractional-part sawtooth identity. Each order evaluates Bₘ to its explicit polynomial (bernoulli_eval_zero'/one'/two', proved by simp on Polynomial.bernoulli) and closes the sum with the Gauss and sum-of-squares formulas over ℚ. Mathlib provides the Bernoulli polynomials and sum_bernoulli but not the multiplication theorem. Verified with 0 axioms and 0 sorries.",
+  "meta": {
+    "author": "Joseph Ludwig Raabe (1851) / Adolf Hurwitz; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli_polynomials#Multiplication_theorems",
+    "date": "1851",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "bernoulli-polynomials",
+      "raabe-multiplication",
+      "power-sums",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/HermiteSawtoothIdentityOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.bernoulli",
+        "description": "The Bernoulli polynomials Bₘ ∈ ℚ[X], defined via the Bernoulli numbers. Evaluating B₀, B₁, B₂ to their explicit closed forms is done by `simp [Polynomial.bernoulli, Finset.sum_range_succ]`.",
+        "module": "Mathlib.NumberTheory.BernoulliPolynomials"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "Peels the top term off a range-sum; the engine of the two power-sum inductions ∑k and ∑k².",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The Raabe multiplication formula ∑_{k=0}^{n-1} Bₘ(x + k/n) = n^{1-m}·Bₘ(nx) machine-checked at orders m = 0 (raabe_zero, prefactor n), m = 1 (raabe_one, prefactor 1) and m = 2 (raabe_two, prefactor 1/n) for general n ≥ 1 — absent from Mathlib, which has the Bernoulli polynomials but not their multiplication theorem",
+      "raabe_one as the Bernoulli-polynomial form of the parent's fractional-part sawtooth identity: with n^{1-1} = 1 it reads ∑_{k<n} B₁(x+k/n) = B₁(nx), the polynomial face of ∑{x+k/n} = {nx} + (n-1)/2",
+      "Self-contained ℚ power-sum lemmas sum_range_id_rat (∑k = n(n-1)/2) and sum_range_sq_rat (∑k² = n(n-1)(2n-1)/6), each by a one-line `ring`-closed induction, used to evaluate the order-1 and order-2 sums",
+      "Explicit evaluation lemmas bernoulli_eval_zero'/one'/two' reducing Polynomial.bernoulli 0,1,2 to 1, x−1/2, x²−x+1/6 directly from the Mathlib definition"
+    ],
+    "dateAdded": "2026-06-25",
+    "axiomCount": 0,
+    "lineCount": 116,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for all results. No native_decide, no sorryAx, no structure-encoded hypotheses. Scope is the orders m = 0, 1, 2; the general-m theorem (requiring the exponential generating function) is left as the stated open question.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "sections": [
+    {
+      "id": "evals",
+      "title": "Explicit evaluations of the low Bernoulli polynomials",
+      "startLine": 37,
+      "endLine": 50,
+      "summary": "bernoulli_eval_zero'/one'/two': B₀(x) = 1, B₁(x) = x − 1/2, B₂(x) = x² − x + 1/6, each reduced from Mathlib's Polynomial.bernoulli by `simp [Polynomial.bernoulli, Finset.sum_range_succ]` (plus `ring` for orders 1 and 2). These closed forms are what turn the Raabe sums into power-sum computations."
+    },
+    {
+      "id": "power-sums",
+      "title": "Power-sum lemmas over ℚ",
+      "startLine": 52,
+      "endLine": 72,
+      "summary": "sum_range_id_rat: ∑_{k<n} k = n(n-1)/2, and sum_range_sq_rat: ∑_{k<n} k² = n(n-1)(2n-1)/6, each proved by induction over ℚ — `sum_range_succ` peels the top term, `push_cast` clears the successor cast, and `ring` closes the step. These supply the order-1 and order-2 closing identities."
+    },
+    {
+      "id": "raabe",
+      "title": "The Raabe multiplication formula at m = 0, 1, 2",
+      "startLine": 74,
+      "endLine": 114,
+      "summary": "raabe_zero: ∑_{k<n} B₀(x+k/n) = n·B₀(nx) (both sides n). raabe_one: ∑_{k<n} B₁(x+k/n) = B₁(nx) for n ≥ 1 — split the sum with sum_sub/add_distrib, pull out 1/n, apply sum_range_id_rat, then field_simp+ring. raabe_two: ∑_{k<n} B₂(x+k/n) = (1/n)·B₂(nx) — expand each square pointwise into x²−x+1/6 + (2x−1)/n·k + (1/n²)·k², split into the three power sums, apply both sum lemmas, then field_simp+ring."
+    }
+  ],
+  "overview": {
+    "historicalContext": "**Raabe's multiplication theorem**\n\nThe Bernoulli polynomials $B_m(x)$ satisfy a remarkable *multiplication* (or *distribution*) relation, due to Joseph Ludwig Raabe (1851) and generalized by Hurwitz:\n$$\\sum_{k=0}^{n-1} B_m\\!\\left(x + \\frac{k}{n}\\right) = n^{1-m}\\, B_m(nx).$$\nIt is the Bernoulli-polynomial shadow of the distribution relation satisfied by the Hurwitz zeta function, and it underlies the functional equations of $L$-functions. The parent gallery entry proves the $m = 1$ *fractional-part* face of this identity ($\\sum_{k<n}\\{x+k/n\\} = \\{nx\\} + (n-1)/2$); this entry records the Bernoulli-polynomial form at the low orders. Mathlib carries the Bernoulli polynomials and the binomial `sum_bernoulli` identity, but not the multiplication theorem.",
+    "problemStatement": "**Raabe multiplication for Bernoulli polynomials**\n\nProve, for the Bernoulli polynomials $B_m$ (`Polynomial.bernoulli`) and $n \\ge 1$,\n$$\\sum_{k=0}^{n-1} B_m\\!\\left(x + \\tfrac{k}{n}\\right) = n^{1-m} B_m(nx),$$\ngeneralizing the $m = 1$ sawtooth identity of the parent. This entry establishes the cases $m = 0, 1, 2$ for general $n$ with no axioms and no sorries; the general-$m$ statement is left open.",
+    "proofStrategy": "**Evaluate, split, and sum**\n\nFor each fixed order the prefactor $n^{1-m}$ collapses to a concrete coefficient — $n$ for $m=0$, $1$ for $m=1$, $1/n$ for $m=2$ — so no real exponentiation is involved. The recipe is uniform: (1) replace $B_m$ by its explicit polynomial via the `bernoulli_eval_*` lemmas; (2) expand each summand $B_m(x+k/n)$ into a polynomial in $k$ with coefficients in $x$ and $1/n$; (3) split the finite sum with `Finset.sum_add_distrib`/`sum_sub_distrib`/`sum_const`, factoring out the $1/n$ powers; (4) collapse the surviving $\\sum_{k<n} k$ and $\\sum_{k<n} k^2$ with the Gauss and sum-of-squares lemmas; (5) finish with `field_simp` and `ring`. The two power-sum lemmas are themselves one-line `ring`-closed inductions. For the general-$m$ case this elementary route is unavailable — the standard proof passes through the exponential generating function $te^{xt}/(e^t-1)$ and a finite geometric series — which is why the scope here is $m \\le 2$.",
+    "keyInsights": [
+      "**At fixed low order the multiplier $n^{1-m}$ is a rational coefficient, not a power.** For $m = 0, 1, 2$ it is $n, 1, 1/n$, so the identity stays inside elementary ℚ-arithmetic and avoids real exponentiation entirely.",
+      "**The whole theorem is a power-sum identity in disguise.** Once $B_m$ is its explicit polynomial, the left side is a finite sum of $\\sum k^j$ for $j \\le m$; the Gauss and sum-of-squares formulas close $m = 1$ and $m = 2$ outright.",
+      "**The $m = 1$ case is the parent sawtooth, lifted to polynomials.** With $n^{0} = 1$ it reads $\\sum_{k<n} B_1(x+k/n) = B_1(nx)$ — the same content as $\\sum\\{x+k/n\\} = \\{nx\\}+(n-1)/2$ once $B_1(y) = y - 1/2$ and $\\{y\\} = y - \\lfloor y\\rfloor$ are matched.",
+      "**Evaluation is `simp`-cheap.** `Polynomial.bernoulli m` evaluates to its closed form by a single `simp` on the definition, so the friction usually associated with the Bernoulli API never appears."
+    ],
+    "prerequisites": [
+      "Bernoulli polynomials (Polynomial.bernoulli)",
+      "Finite sums over Finset.range",
+      "Gauss and sum-of-squares power-sum formulas",
+      "Mathematical induction"
+    ]
+  },
+  "conclusion": {
+    "summary": "The Raabe multiplication theorem $\\sum_{k<n} B_m(x+k/n) = n^{1-m} B_m(nx)$ is established for $m = 0, 1, 2$ and general $n \\ge 1$ by an elementary route: evaluate $B_m$ to its explicit polynomial, split the sum, and close with the Gauss ($\\sum k$) and sum-of-squares ($\\sum k^2$) formulas — all over ℚ with `field_simp` and `ring`. The $m = 1$ case is the Bernoulli-polynomial form of the parent's fractional-part sawtooth identity. 6 theorems, 0 axioms, 0 sorries.",
+    "implications": [
+      "Supplies the low-order Raabe/Hurwitz multiplication identities for Bernoulli polynomials, absent from Mathlib, in a form reusable by downstream zeta/L-function work.",
+      "Connects the gallery's fractional-part sawtooth identity to its Bernoulli-polynomial origin, exhibiting the m = 1 case as one face of a single multiplication theorem.",
+      "Provides standalone ℚ power-sum lemmas (∑k, ∑k²) and clean `simp`-based evaluations of B₀, B₁, B₂ for reuse."
+    ],
+    "openQuestions": [
+      "Prove the Raabe multiplication theorem for general m: ∑_{k<n} Bₘ(x+k/n) = n^{1-m} Bₘ(nx), most likely via Mathlib's exponential generating function `bernoulli_generating_function` and a finite geometric-series summation, handling the real exponent n^{1-m}.",
+      "Derive the companion Hurwitz-zeta distribution relation, of which the Bernoulli multiplication theorem is the polynomial specialization.",
+      "Extend the elementary power-sum route to m = 3, 4 (each a fixed Faulhaber identity), charting how far the generating-function-free method reaches before the algebra becomes unwieldy."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "hermite-sawtooth-identity",
+      "relationship": "parent",
+      "description": "Parent entry: the fractional-part sawtooth identity ∑_{k<n} {x+k/n} = {nx} + (n-1)/2, the m = 1 face of the Raabe multiplication theorem. This entry answers its open question oq-01 by proving the Bernoulli-polynomial multiplication formula at orders m = 0, 1, 2."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Raabe, Joseph Ludwig",
+      "title": "Zurückführung einiger Summen und bestimmten Integrale auf die Jakob Bernoullische Function",
+      "year": "1851",
+      "note": "Journal für die reine und angewandte Mathematik 42 — the multiplication theorem ∑ Bₘ(x+k/n) = n^{1-m} Bₘ(nx)."
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "note": "Springer — Bernoulli polynomials, the multiplication theorem, and the Hurwitz zeta distribution relation."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent **fractional-part sawtooth** open question `oq-01`: the Bernoulli-polynomial **Raabe (Hurwitz) multiplication theorem**

$$\sum_{k=0}^{n-1} B_m\!\left(x + \tfrac{k}{n}\right) = n^{1-m}\, B_m(nx)$$

at the low orders **m = 0, 1, 2** for general `n ≥ 1`.

## Why these orders

For fixed low `m` the prefactor `n^{1-m}` collapses to a concrete coefficient — `n`, `1`, `1/n` — so no real exponentiation is involved and the identity reduces to an **elementary power-sum computation**. The general-`m` theorem instead requires the exponential generating function `t·e^{xt}/(e^t−1)` and a finite geometric series; that is left as the stated open question.

The `m = 1` case (`raabe_one`) is the **Bernoulli-polynomial twin of the parent's sawtooth identity**: with `n^{1-1} = 1` it reads `∑_{k<n} B₁(x+k/n) = B₁(nx)`, the polynomial face of `∑{x+k/n} = {nx} + (n−1)/2`.

## Approach (uniform across orders)

1. Evaluate `Bₘ` to its explicit polynomial — `bernoulli_eval_zero'/one'/two'` give `1`, `x−1/2`, `x²−x+1/6` directly from `Polynomial.bernoulli` via `simp`.
2. Expand each summand and split the finite sum (`sum_add_distrib`/`sum_const`/`mul_sum`), factoring out the `1/n` powers.
3. Collapse `∑_{k<n} k` and `∑_{k<n} k²` with the self-contained ℚ lemmas `sum_range_id_rat` (`= n(n-1)/2`) and `sum_range_sq_rat` (`= n(n-1)(2n-1)/6`), each a one-line `ring`-closed induction.
4. Finish with `field_simp` + `ring`.

## Verification

- `proofs/Proofs/HermiteSawtoothIdentityOQ01.lean` typechecks cleanly against Mathlib v4.26.0 (single-file `lake env lean`).
- `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all results — no `native_decide`, no `sorryAx`.
- **6 theorems, 0 definitions, 0 sorries, 0 axioms.**

Mathlib carries the Bernoulli polynomials and `sum_bernoulli` but **not** the multiplication theorem.

## Files

- `proofs/Proofs/HermiteSawtoothIdentityOQ01.lean` (new, 116 lines)
- `src/data/proofs/hermite-sawtooth-identity-oq-01/{meta.json,annotations.json}` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)