### PR TITLE
audit(gallery): 4 fresh proofs CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24636,8 +24636,32 @@
       "issues": [],
       "lastAudited": "2026-06-25T22:30:00Z",
       "result": "clean"
+    },
+    "erdos-1146-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T23:00:00Z",
+      "result": "clean"
+    },
+    "schauder-fixed-point-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T23:00:00Z",
+      "result": "clean"
+    },
+    "hermite-sawtooth-identity-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T23:00:00Z",
+      "result": "clean"
+    },
+    "sqrt2-examples-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T23:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T22:30:00Z"
+  "lastUpdated": "2026-06-25T23:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 4 proofs CLEAN

Audited 4 newly-landed gallery proofs against current `origin/main`. All confirm **CLEAN**: 0 sorries, 0 `axiom` declarations, 0 `native_decide`, 0 True-stubs, 0 structure-encoded assumptions. status/badge/sorries/axiomCount match the Lean source.

| Slug | Verdict | Notes |
|------|---------|-------|
| `erdos-1146-oq-04` | CLEAN | O((log N)²) upper bound for the 3-smooth counting function. **Critical check passed**: imports axiom-bearing `Proofs.Erdos37Problem` but only reuses its pure `def`s; `smooth23_counting_upper` proves via in-file `pairBound` counting + Mathlib card lemmas, **not** the parent axioms (`smooth23_counting`/`mann_theorem`). `axiomCount=0` accurate. Title honestly scoped to the upper-bound side. |
| `schauder-fixed-point-oq-04` | CLEAN | Fixed-point set nonempty + compact for self-maps of [a,b]. Transparent Mathlib IVT (`intermediate_value_Icc'`) + `isCompact_Icc` packaging; deps disclosed. Deliberately imports only Mathlib (not the axiom-bearing base file). |
| `hermite-sawtooth-identity-oq-01` | CLEAN | Raabe multiplication formula for Bernoulli polynomials, orders m=0,1,2. Title + `assumptions` honestly scope to m=0,1,2; the general-m theorem is explicitly left open. |
| `sqrt2-examples-oq-01-oq-01` | CLEAN | "Totality is essential for `sq_nonneg`" — genuine theorems with ℂ (I²<0) as the partial-order counterexample. 0 axiom, no famous-theorem overclaim. |

All `sorry`/`native_decide` grep hits were docstring false positives. No overclaims, no axiom masking, no inequality-as-theorem inflation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)