### PR TITLE
Enrich Dihedral Reflection Cycle Counts: add annotations

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-03-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-bc030202-reflperm",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-02",
+    "range": { "startLine": 56, "endLine": 85 },
+    "type": "definition",
+    "title": "Section I — The Reflection as a Permutation reflPerm",
+    "content": "A reflection of the n-gon through the axis indexed by i acts on positions ZMod n by p ↦ −i − p. The file realizes this as `reflPerm i := Equiv.subLeft (-i) : Equiv.Perm (ZMod n)`, so the parent's group-element machinery (cyc, the Burnside master formula) applies directly to it as an arbitrary permutation. The supporting lemmas establish the geometry: `reflPerm_apply` unfolds the action, `reflPerm_eq_refl` identifies it with the sibling's position involution `refl i`, `reflPerm_mul_self` proves reflPerm i ∘ reflPerm i = 1 (closed by `ring` over ZMod n), `reflPerm_inv` records that it is its own inverse (an involution), and `reflPerm_inv_smul` rewrites the inverse action — needed because the parent's coloring action twists by g⁻¹. Casting the reflection into Equiv.Perm is the key move: it lets a single master formula handle rotations and reflections uniformly.",
+    "mathContext": "$\\mathrm{reflPerm}\\,i : p \\mapsto -i - p$ on $\\mathbb{Z}/n$, an involution ($\\mathrm{reflPerm}\\,i)^2 = 1$, so $(\\mathrm{reflPerm}\\,i)^{-1} = \\mathrm{reflPerm}\\,i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["dihedral group", "reflection", "involution", "Equiv.subLeft", "Equiv.Perm"],
+    "prerequisites": ["permutations as Equiv.Perm", "the cyclic group ZMod n", "group action of a permutation on colorings"]
+  },
+  {
+    "id": "ann-bc030202-fixed-symm",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-02",
+    "range": { "startLine": 86, "endLine": 101 },
+    "type": "insight",
+    "title": "Section II — Fixed Colorings are Axis-Symmetric",
+    "content": "`fixedBy_reflPerm_iff` shows a k-coloring c is fixed by reflPerm i (under the parent's coloring action) exactly when c is constant on the refl i-orbits, i.e. c(refl i p) = c p for all p — symmetric about the reflection axis. The proof unfolds the parent's `coloring_smul_apply` (which acts by g⁻¹) and uses `reflPerm_inv_smul` to cancel the inverse twist, so the abstract 'fixed by the permutation' condition becomes the concrete 'symmetric about the axis' condition. This translation is what connects the Burnside-style fixed-point count to the elementary combinatorial picture of axis-symmetric colorings, and is the bridge to reusing the sibling's involution-orbit count.",
+    "mathContext": "$\\mathrm{reflPerm}\\,i \\bullet c = c \\iff \\forall p,\\ c(\\mathrm{refl}\\,i\\,p) = c(p)$: fixed colorings are exactly the axis-symmetric ones.",
+    "significance": "key",
+    "relatedConcepts": ["fixed points of a group action", "invariant coloring", "axis symmetry", "inverse-twisted action"],
+    "prerequisites": ["the coloring action c ↦ g • c", "MulAction.fixedBy", "function extensionality (funext)"]
+  },
+  {
+    "id": "ann-bc030202-k2-count",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-02",
+    "range": { "startLine": 102, "endLine": 115 },
+    "type": "technique",
+    "title": "Section III — The k = 2 Count via Involution-Orbit Counting",
+    "content": "`card_fixed_two_colorings` computes #(2-colorings fixed by reflPerm i) = 2^((n + reflFix i)/2). Via `fixedBy_reflPerm_iff` it transports the fixed-coloring set to the subtype of refl i-symmetric colorings (using `Equiv.subtypeEquivRight`), then applies the sibling's `card_invariant_colorings_involutive`: the orbits of an involution are its fixed points (singletons) and its transposed pairs, so a symmetric coloring is determined by a free choice on each of the (|positions| + |fixed points|)/2 orbits, giving 2^((n + reflFix i)/2). The `ZMod.card` rewrite supplies |positions| = n. This concrete k = 2 evaluation is the anchor from which the abstract cycle count is reverse-engineered in Section IV.",
+    "mathContext": "$\\#\\{2\\text{-colorings fixed by }\\mathrm{reflPerm}\\,i\\} = 2^{(n + \\mathrm{reflFix}\\,i)/2}$; an involution has $(n + |\\mathrm{Fix}|)/2$ orbits.",
+    "significance": "key",
+    "relatedConcepts": ["involution orbits", "transposed pairs", "Equiv.subtypeEquivRight", "Fintype.card_congr", "card_invariant_colorings_involutive"],
+    "prerequisites": ["counting orbits of an involution", "cardinality transport along an equivalence", "the sibling involutive-coloring count"]
+  },
+  {
+    "id": "ann-bc030202-cycle-count",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-02",
+    "range": { "startLine": 116, "endLine": 132 },
+    "type": "theorem",
+    "title": "Section IV — The Cycle Count by Reading k = 2 Two Ways",
+    "content": "`cyc_reflPerm` is the conceptual heart: it recovers the abstract cycle count cyc(reflPerm i) = (n + reflFix i)/2 without ever enumerating orbits directly. The trick is to read the k = 2 coloring count two ways — the parent's master formula gives 2^(cyc(reflPerm i)), while `card_fixed_two_colorings` gives 2^((n + reflFix i)/2) — and then strip the common base by `Nat.pow_right_injective` (2 ≥ 2 is needed for injectivity of m ↦ 2^m). With the cycle count in hand, `card_fixedColorings_reflPerm` feeds it back into the parent's *general-k* master formula to conclude #(k-colorings fixed by reflPerm i) = k^((n + reflFix i)/2) for every k. This 'compute one invariant by counting a different specialization' is the signature technique of the entry.",
+    "mathContext": "$2^{\\mathrm{cyc}} = 2^{(n+\\mathrm{reflFix}\\,i)/2} \\Rightarrow \\mathrm{cyc}(\\mathrm{reflPerm}\\,i) = (n+\\mathrm{reflFix}\\,i)/2$, hence $\\#\\{k\\text{-colorings}\\} = k^{\\mathrm{cyc}}$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit-counting / cycle count", "Nat.pow_right_injective", "Burnside master formula k^cyc", "reading an identity two ways"],
+    "prerequisites": ["the parent's #(fixed) = k^cyc formula", "injectivity of n ↦ b^n for b ≥ 2", "the k = 2 count from Section III"]
+  },
+  {
+    "id": "ann-bc030202-parity",
+    "proofId": "burnside-counting-oq-03-oq-02-oq-02",
+    "range": { "startLine": 133, "endLine": 159 },
+    "type": "theorem",
+    "title": "Section V — Parity Specialization to the Textbook Counts",
+    "content": "Substituting the sibling's fixed-point counts reflFix_odd (= 1) and reflFix_even (∈ {0, 2}) into cyc_reflPerm recovers the classical dihedral reflection contributions for every k. Odd n: every reflection axis passes through one vertex and the opposite edge-midpoint, so reflFix = 1, cyc = (n+1)/2, count k^((n+1)/2) (cyc_reflPerm_odd, card_fixedColorings_reflPerm_odd). Even n: an axis is either vertex-to-vertex (reflFix = 2, cyc = n/2 + 1) or midpoint-to-midpoint (reflFix = 0, cyc = n/2), giving count k^(n/2+1) or k^(n/2) (cyc_reflPerm_even, ...even). The case splits use `rcases reflFix_even` and `omega` to finish the arithmetic. These are exactly the reflection terms one plugs into Burnside's lemma to count necklaces/bracelets, now derived rather than asserted, and for all k.",
+    "mathContext": "Odd $n$: $\\mathrm{cyc} = (n{+}1)/2$, count $k^{(n+1)/2}$. Even $n$: $\\mathrm{cyc} \\in \\{n/2{+}1,\\ n/2\\}$, count $k^{n/2+1}$ or $k^{n/2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["dihedral reflections", "necklace/bracelet counting", "Burnside's lemma", "parity of n", "reflFix_odd / reflFix_even"],
+    "prerequisites": ["the sibling fixed-point counts reflFix_odd, reflFix_even", "case analysis (rcases) and omega", "the general-k reflection count from Section IV"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-03-oq-02-oq-02` (quality 43, passes 0) — recovering the classical dihedral reflection counts k^cyc(g) for all k by computing each reflection's cycle count.

## Gap addressed
The entry already had a rich meta.json (full overview with what/how/historicalContext/proofStrategy/keyInsights, conclusion, 6 sections, 3 crossReferences, leanFile) but **no annotations.json** — zero inline coverage of the 171-line file.

## Changes
Added `annotations.json` with 5 line-anchored annotations aligned to the file's five sections, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Section I — reflPerm** (L56–85) — the reflection as Equiv.subLeft, involution lemmas.
2. **Section II — axis-symmetry** (L86–101) — fixed colorings ⇔ symmetric about the axis.
3. **Section III — k=2 count** (L102–115) — involution-orbit counting, (n+|Fix|)/2 orbits.
4. **Section IV — cycle count** (L116–132) — the heart: read k=2 two ways + Nat.pow_right_injective ⇒ cyc = (n+reflFix)/2, then general-k count.
5. **Section V — parity** (L133–159) — odd/even specialization to k^((n+1)/2), k^(n/2+1), k^(n/2).

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof; all 5 anchor to real Lean constructs.
- annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, badge `original`, axiomCount 0 — accurate (the file's own `#print axioms` confirms only foundational axioms; no native_decide).