### PR TITLE
research(angle-trisection-oq-01-oq-04-oq-02): 2^m+1 prime ⟹ m a power of two — the constructive Fermat-prime obstruction [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -133,6 +133,7 @@ import Proofs.AngleTrisectionCos20GalOQ03OQ01
 import Proofs.AngleTrisectionEmbedding
 import Proofs.AngleTrisectionOQ01
 import Proofs.AngleTrisectionOQ01OQ04
+import Proofs.AngleTrisectionOQ01OQ04OQ02
 import Proofs.AngleTrisectionOQ02
 import Proofs.AngleTrisectionOQ02OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01

--- a/proofs/Proofs/AngleTrisectionOQ01OQ04OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionOQ01OQ04OQ02.lean
@@ -1,0 +1,108 @@
+/-
+  A Fermat-Number Lemma: 2^m + 1 Prime Forces m to Be a Power of Two
+
+  Open Question (angle-trisection-oq-01-oq-04-oq-02):
+  "If 2^m + 1 is prime then m is a power of two. If m had an odd factor d > 1,
+   m = d·k, then 2^k + 1 divides 2^m + 1 = (2^k)^d + 1, contradicting primality.
+   Supports Gauss–Wantzel: a regular p-gon is constructible iff p is a Fermat prime."
+
+  This is the exponent half of the theory of Fermat primes. Mathlib proves the bare
+  *existence* statement `Nat.pow_of_pow_add_prime` (a^n + 1 prime ⟹ ∃ m, n = 2^m), but
+  not the *constructive* obstruction that drives it. We supply that obstruction with an
+  EXPLICIT witness:
+
+    if d is an odd factor of m with d > 1, then 2^(m/d) + 1 is a genuine *proper*
+    divisor of 2^m + 1 — strictly between 1 and 2^m + 1 — so 2^m + 1 is composite.
+
+  From this constructive compositeness criterion we derive, independently of Mathlib's
+  `pow_of_pow_add_prime`, the Fermat-prime exponent law: `2^m + 1` prime ⟹ `m = 2^k`.
+  The explicit factor is what a primality search actually exhibits (e.g. 2^6 + 1 = 65 has
+  the odd exponent-factor 3, yielding the divisor 2^2 + 1 = 5), and is the form needed in
+  the Gauss–Wantzel program for constructible regular polygons.
+
+  Tags: number-theory, fermat-primes, gauss-wantzel, divisibility, constructive
+-/
+
+import Mathlib
+
+namespace AngleTrisectionOQ01OQ04OQ02
+
+open Nat
+
+/-! ## Part I. The divisibility engine.
+
+For odd `d`, `x + y ∣ x^d + y^d`. Specialising `x = 2^k`, `y = 1` gives the exact
+factor that obstructs primality of `2^(k·d) + 1`. -/
+
+/-- For any odd exponent-multiplier `d`, `2^k + 1` divides `2^(k·d) + 1`.
+This is the algebraic core: `2^(k·d) + 1 = (2^k)^d + 1^d` and `a + b ∣ a^d + b^d`
+whenever `d` is odd. -/
+theorem two_pow_add_one_dvd (k d : ℕ) (hd : Odd d) :
+    2 ^ k + 1 ∣ 2 ^ (k * d) + 1 := by
+  have h := hd.nat_add_dvd_pow_add_pow (2 ^ k) 1
+  rwa [one_pow, ← pow_mul] at h
+
+/-! ## Part II. The constructive obstruction (beyond Mathlib).
+
+An odd factor `d > 1` of the exponent `m` produces an explicit proper divisor of
+`2^m + 1`, hence compositeness. Mathlib states only the existence half; this records
+the divisor explicitly. -/
+
+/-- **Constructive compositeness.** If `m` has an odd factor `d > 1`, then `2^m + 1`
+is not prime — witnessed by the explicit proper divisor `2^(m/d) + 1`. -/
+theorem not_prime_two_pow_add_one_of_odd_factor {m d : ℕ}
+    (hd : Odd d) (hd1 : 1 < d) (hdvd : d ∣ m) (hm : m ≠ 0) :
+    ¬ (2 ^ m + 1).Prime := by
+  obtain ⟨k, rfl⟩ := hdvd
+  -- `m = d * k`; from `m ≠ 0` both factors are positive.
+  rw [Nat.mul_ne_zero_iff] at hm
+  obtain ⟨hd0, hk0⟩ := hm
+  have hk1 : 1 ≤ k := Nat.one_le_iff_ne_zero.mpr hk0
+  -- the explicit divisor `2^k + 1` of `2^(d*k) + 1`
+  have hdvd2 : 2 ^ k + 1 ∣ 2 ^ (d * k) + 1 := by
+    rw [Nat.mul_comm d k]; exact two_pow_add_one_dvd k d hd
+  intro hp
+  rcases (hp.eq_one_or_self_of_dvd _ hdvd2) with h1 | hself
+  · -- `2^k + 1 = 1` is impossible
+    have : 1 ≤ 2 ^ k := Nat.one_le_two_pow
+    omega
+  · -- `2^k + 1 = 2^(d*k) + 1` forces `k = d*k`, impossible for `d > 1`, `k ≥ 1`
+    have hkeq : 2 ^ k = 2 ^ (d * k) := by omega
+    have : k = d * k := Nat.pow_right_injective (le_refl 2) hkeq
+    -- but `d * k ≥ 2 * k > k` since `d ≥ 2`, `k ≥ 1`
+    nlinarith [hd1, hk1]
+
+/-! ## Part III. The Fermat-prime exponent law.
+
+Independently of Mathlib's `pow_of_pow_add_prime`, the constructive obstruction yields:
+a prime of the form `2^m + 1` must have `m` a power of two. -/
+
+/-- **Fermat-prime exponent law.** If `2^m + 1` is prime (`m ≠ 0`), then `m` is a power
+of two. Proof: factor `m = 2^k · d` with `d` odd; if `d > 1`, Part II makes `2^m + 1`
+composite, so `d = 1` and `m = 2^k`. -/
+theorem isPowerOfTwo_of_prime {m : ℕ} (hm : m ≠ 0) (hP : (2 ^ m + 1).Prime) :
+    ∃ k : ℕ, m = 2 ^ k := by
+  obtain ⟨k, d, hd, hmeq⟩ := Nat.exists_eq_two_pow_mul_odd hm
+  rcases Nat.lt_or_ge d 2 with hlt | hge
+  · -- `d` odd and `d < 2` ⟹ `d = 1` ⟹ `m = 2^k`
+    have hd0 : d ≠ 0 := by rintro rfl; simp at hd
+    have : d = 1 := by omega
+    exact ⟨k, by rw [hmeq, this, Nat.mul_one]⟩
+  · -- `d ≥ 2`, and `d` odd ⟹ `d > 1` ⟹ contradiction with primality
+    exfalso
+    have hdvd : d ∣ m := ⟨2 ^ k, by rw [hmeq]; ring⟩
+    exact not_prime_two_pow_add_one_of_odd_factor hd (by omega) hdvd hm hP
+
+/-! ## Part IV. Concrete witnesses. -/
+
+/-- `2^6 + 1 = 65 = 5 · 13` is composite: the exponent `6 = 2 · 3` has the odd factor `3`,
+yielding the explicit proper divisor `2^(6/3) + 1 = 2^2 + 1 = 5`. -/
+theorem not_prime_two_pow_six_add_one : ¬ (2 ^ 6 + 1).Prime :=
+  not_prime_two_pow_add_one_of_odd_factor (d := 3) (by decide) (by decide) (by decide) (by decide)
+
+/-- Contrapositive convenience form: a prime exponent of a Fermat prime is a power of two,
+so the only candidate exponents are `1, 2, 4, 8, 16, …`. -/
+theorem exponent_isPowerOfTwo {m : ℕ} (hm : m ≠ 0) (hP : (2 ^ m + 1).Prime) :
+    ∃ k, m = 2 ^ k := isPowerOfTwo_of_prime hm hP
+
+end AngleTrisectionOQ01OQ04OQ02

--- a/src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "divisibility-engine",
+    "proofId": "angle-trisection-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 40,
+      "endLine": 43
+    },
+    "type": "key-step",
+    "title": "The One Algebraic Fact: a + b ∣ aᵈ + bᵈ for Odd d",
+    "content": "Everything rests on a single classical divisibility: for an odd exponent d, x + y divides x^d + y^d (Mathlib's `Odd.nat_add_dvd_pow_add_pow`). Specialising x = 2^k and y = 1 and rewriting 1^d = 1 and (2^k)^d = 2^(k·d) gives `two_pow_add_one_dvd : 2^k + 1 ∣ 2^(k·d) + 1`. This is the factor that obstructs primality whenever the exponent carries an odd multiplier.",
+    "mathContext": "x + y ∣ x^d + y^d for odd d (e.g. x³ + 1 = (x+1)(x²−x+1)). With x = 2^k: 2^(k·d) + 1 = (2^k)^d + 1, divisible by 2^k + 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Odd.nat_add_dvd_pow_add_pow",
+      "geometric sum factorization",
+      "pow_mul",
+      "divisibility"
+    ],
+    "prerequisites": [
+      "polynomial factorization",
+      "natural number divisibility"
+    ]
+  },
+  {
+    "id": "constructive-obstruction",
+    "proofId": "angle-trisection-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 53,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "The Constructive Obstruction (Beyond Mathlib)",
+    "content": "Mathlib's `Nat.pow_of_pow_add_prime` proves only that a prime a^n + 1 forces n to be a power of two — an existence statement. This theorem supplies the constructive heart Mathlib omits: from an odd factor d > 1 of m (write m = d·k), the explicit number 2^k + 1 is shown to be a PROPER divisor of 2^m + 1. Properness is pure exponent arithmetic — k ≥ 1 gives 2^k + 1 > 1, and d > 1 gives k < d·k hence 2^k + 1 < 2^m + 1 — so `Nat.Prime.eq_one_or_self_of_dvd` is contradicted. The impossible equalities are closed by `omega` and the injectivity of b ↦ b^n.",
+    "mathContext": "If d ∣ m, d odd, d > 1, m ≠ 0, then 2^(m/d) + 1 is a proper divisor of 2^m + 1, so 2^m + 1 is composite. This NAMES the witness rather than asserting its existence.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.Prime.eq_one_or_self_of_dvd",
+      "Nat.pow_right_injective",
+      "proper divisor",
+      "constructive proof",
+      "Nat.pow_of_pow_add_prime"
+    ],
+    "prerequisites": [
+      "primality and divisors",
+      "exponent inequalities",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "exponent-law",
+    "proofId": "angle-trisection-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 83,
+      "endLine": 94
+    },
+    "type": "key-step",
+    "title": "The Fermat-Prime Exponent Law",
+    "content": "The exponent law `isPowerOfTwo_of_prime` falls out of the obstruction. Factor m = 2^k · d with d odd (`Nat.exists_eq_two_pow_mul_odd`). Two cases: if d < 2 then d = 1 (odd and positive) and m = 2^k; if d ≥ 2 then d > 1 is an odd factor of m, so the Part II obstruction makes 2^m + 1 composite — contradicting the hypothesis. This derivation is independent of Mathlib's `pow_of_pow_add_prime`. It completes the Gauss–Wantzel link: for primes p, p − 1 is a power of 2 iff p is a Fermat prime.",
+    "mathContext": "2^m + 1 prime (m ≠ 0) ⟹ ∃ k, m = 2^k. The only candidate exponents are 1, 2, 4, 8, 16, …, giving the Fermat-prime form p = 2^(2^k) + 1.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.exists_eq_two_pow_mul_odd",
+      "Fermat prime",
+      "Gauss–Wantzel theorem",
+      "constructible polygon"
+    ],
+    "prerequisites": [
+      "odd/even factorization of naturals",
+      "Fermat numbers"
+    ]
+  },
+  {
+    "id": "concrete-witness",
+    "proofId": "angle-trisection-oq-01-oq-04-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 103
+    },
+    "type": "insight",
+    "title": "A Concrete Certificate: 2⁶ + 1 = 65 = 5·13",
+    "content": "`not_prime_two_pow_six_add_one` instantiates the obstruction with d = 3: since 3 is an odd factor of the exponent 6, the explicit divisor 2^(6/3) + 1 = 2^2 + 1 = 5 certifies that 2^6 + 1 = 65 is composite (indeed 65 = 5·13). The four hypotheses (Odd 3, 1 < 3, 3 ∣ 6, 6 ≠ 0) are discharged by kernel `decide`, keeping the proof axiom-free. This is precisely the certificate form a constructibility or primality search produces when an exponent is not a power of two.",
+    "mathContext": "6 = 2·3 is not a power of two; the odd factor 3 exposes the divisor 2^2 + 1 = 5 of 2^6 + 1 = 65. Contrast Euler's 2^32 + 1 = 641·6700417, where 32 = 2^5 IS a power of two yet the Fermat number is still composite.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "explicit factorization",
+      "kernel decide",
+      "Fermat number compositeness",
+      "Euler's factorization"
+    ],
+    "prerequisites": [
+      "decidable propositions in Lean",
+      "Fermat numbers"
+    ]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "angle-trisection-oq-01-oq-04-oq-02",
+  "title": "A Fermat-Number Lemma: 2^m + 1 Prime Forces m to Be a Power of Two (OQ-01-OQ-04-OQ-02)",
+  "slug": "angle-trisection-oq-01-oq-04-oq-02",
+  "description": "Answers the open question of the parent entry (angle-trisection-oq-01-oq-04, Gauss–Wantzel): prove that if 2^m + 1 is prime then m is a power of two, so that 'p − 1 is a power of 2' ⇔ 'p is a Fermat prime' for primes p. Mathlib proves only the bare existence statement (Nat.pow_of_pow_add_prime). This entry supplies the CONSTRUCTIVE obstruction Mathlib lacks: if m has an odd factor d > 1 then 2^(m/d) + 1 is an EXPLICIT proper divisor of 2^m + 1 (strictly between 1 and 2^m + 1), so 2^m + 1 is composite. From that constructive compositeness criterion it derives the Fermat-prime exponent law independently of Mathlib's existence lemma, and exhibits the concrete witness 2^6 + 1 = 65 = 5·13 (odd exponent-factor 3 ⟹ divisor 2^2 + 1 = 5). Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat_number",
+    "date": "2026-06-25",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ01OQ04OQ02.lean",
+    "tags": [
+      "number-theory",
+      "fermat-primes",
+      "gauss-wantzel",
+      "divisibility",
+      "constructive",
+      "constructibility",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 108,
+    "assumptions": "None. 0 axioms, 0 sorries; depends only on Mathlib. Proofs use only axiom-free tactics (rw, omega, nlinarith, ring, and kernel `decide` — not native_decide) and the foundational axioms propext/Classical.choice/Quot.sound, which do not count as assumptions.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Odd.nat_add_dvd_pow_add_pow",
+        "description": "For odd n, x + y ∣ x^n + y^n in ℕ — the divisibility engine specialised at x = 2^k, y = 1",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Nat.exists_eq_two_pow_mul_odd",
+        "description": "Every n ≠ 0 factors as n = 2^k · d with d odd — isolates the odd part of the exponent",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.eq_one_or_self_of_dvd",
+        "description": "A prime's only divisors are 1 and itself — turns the explicit proper divisor into a contradiction",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "n ↦ b^n is injective for 2 ≤ b — used to rule out 2^k = 2^(d·k)",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.pow_of_pow_add_prime",
+        "description": "Mathlib's existence-only counterpart (a^n + 1 prime ⟹ ∃ m, n = 2^m); this entry provides the explicit constructive obstruction instead",
+        "module": "Mathlib.NumberTheory.Fermat"
+      }
+    ],
+    "originalContributions": [
+      "Answers the parent entry's (angle-trisection-oq-01-oq-04) stated open question: 2^m + 1 prime ⟹ m is a power of two, completing the 'p − 1 a power of 2 ⇔ p a Fermat prime' link for the Gauss–Wantzel program",
+      "Constructive obstruction beyond Mathlib: not_prime_two_pow_add_one_of_odd_factor exhibits the EXPLICIT proper divisor 2^(m/d) + 1 when d > 1 is an odd factor of m, where Mathlib's Nat.pow_of_pow_add_prime gives only the existence of the exponent decomposition",
+      "Self-contained divisibility engine two_pow_add_one_dvd: 2^k + 1 ∣ 2^(k·d) + 1 for odd d, the algebraic heart reused for both the obstruction and the corollary",
+      "Derives the Fermat-prime exponent law isPowerOfTwo_of_prime independently of Mathlib's pow_of_pow_add_prime, by case-splitting the odd part of the exponent and invoking the explicit obstruction",
+      "Concrete certificate not_prime_two_pow_six_add_one: 2^6 + 1 = 65 is composite via the odd exponent-factor 3 and its explicit divisor 2^2 + 1 = 5 — the form a primality search actually produces"
+    ],
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "definitionCount": 0,
+    "trueStubs": 0
+  },
+  "overview": {
+    "historicalContext": "In 1796 the nineteen-year-old Gauss discovered that the regular 17-gon is constructible by ruler and compass, the first advance on the classical constructibility problem since antiquity. The full criterion — completed by Pierre Wantzel in 1837 — states that a regular n-gon is constructible if and only if n = 2^a times a product of distinct Fermat primes, where a Fermat prime is a prime of the form 2^(2^k) + 1. Fermat had conjectured in 1640 that every number 2^(2^k) + 1 is prime; Euler refuted this in 1732 by factoring 2^32 + 1 = 641 · 6700417. A basic structural fact underpins the whole theory: if 2^m + 1 is prime at all, the exponent m must itself be a power of two. The reason is elementary but constructive — any odd factor d > 1 of m exposes an explicit divisor 2^(m/d) + 1 of 2^m + 1. This entry formalizes that constructive obstruction and the exponent law it yields, the precise tool the parent Gauss–Wantzel entry flagged as missing.",
+    "problemStatement": "Prove that if 2^m + 1 is prime (m ≠ 0) then m is a power of two. Equivalently, give a constructive criterion: whenever the exponent m has an odd factor d > 1, exhibit an explicit proper divisor of 2^m + 1 certifying that it is composite.",
+    "proofStrategy": "Four parts. Part I isolates the divisibility engine: for odd d, x + y ∣ x^d + y^d (Mathlib's Odd.nat_add_dvd_pow_add_pow); specialising x = 2^k, y = 1 gives 2^k + 1 ∣ 2^(k·d) + 1. Part II is the constructive obstruction: given an odd factor d > 1 of m, write m = d·k, so 2^k + 1 divides 2^m + 1; the bounds 1 < 2^k + 1 < 2^m + 1 (from k ≥ 1 and d > 1) make it a proper divisor, contradicting primality via Nat.Prime.eq_one_or_self_of_dvd — the impossible cases are closed by omega and Nat.pow_right_injective. Part III derives the exponent law: factor m = 2^k · d with d odd (Nat.exists_eq_two_pow_mul_odd); if d = 1 then m = 2^k, and if d > 1 the Part II obstruction contradicts primality. Part IV records the concrete witness 2^6 + 1 = 65 = 5·13 via the odd exponent-factor 3, using only kernel decision procedures.",
+    "keyInsights": [
+      "The obstruction is fundamentally constructive: compositeness of 2^m + 1 (when the exponent is not a power of 2) is witnessed by a NAMED divisor 2^(m/d) + 1, not merely asserted to exist. Mathlib's Nat.pow_of_pow_add_prime states only the existence half.",
+      "The single algebraic fact doing the work is a + b ∣ a^d + b^d for odd d. Everything else is bookkeeping: rewrite 2^m + 1 = (2^k)^d + 1^d and read off the factor.",
+      "Properness of the divisor is pure arithmetic on exponents: k ≥ 1 gives 2^k + 1 > 1, and d > 1 with k ≥ 1 gives k < d·k, hence 2^k + 1 < 2^m + 1. omega and injectivity of b ↦ b^n discharge the boundary cases.",
+      "The exponent law closes the Gauss–Wantzel gap: for a prime p, 'p − 1 is a power of 2' is equivalent to 'p is a Fermat prime', because p = 2^m + 1 prime forces m = 2^k and thus p = 2^(2^k) + 1.",
+      "Euler's factorization 2^32 + 1 = 641 · 6700417 shows the converse fails: m being a power of two is necessary but not sufficient for 2^m + 1 to be prime — the supply of actual Fermat primes (only five are known) is what bounds constructible polygons."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Module docstring stating the open question and the constructive contribution; imports Mathlib; opens the Nat namespace."
+    },
+    {
+      "id": "divisibility-engine",
+      "title": "I. The Divisibility Engine",
+      "startLine": 32,
+      "endLine": 43,
+      "summary": "two_pow_add_one_dvd: for odd d, 2^k + 1 ∣ 2^(k·d) + 1, obtained from Odd.nat_add_dvd_pow_add_pow by rewriting 2^(k·d) + 1 = (2^k)^d + 1^d."
+    },
+    {
+      "id": "constructive-obstruction",
+      "title": "II. The Constructive Obstruction (Beyond Mathlib)",
+      "startLine": 45,
+      "endLine": 73,
+      "summary": "not_prime_two_pow_add_one_of_odd_factor: an odd factor d > 1 of m yields the explicit proper divisor 2^(m/d) + 1, so 2^m + 1 is composite. Boundary cases closed by omega, Nat.pow_right_injective, and nlinarith."
+    },
+    {
+      "id": "exponent-law",
+      "title": "III. The Fermat-Prime Exponent Law",
+      "startLine": 75,
+      "endLine": 94,
+      "summary": "isPowerOfTwo_of_prime: 2^m + 1 prime ⟹ ∃ k, m = 2^k. Factor m = 2^k·d with d odd; d = 1 gives the power of two, d > 1 contradicts primality via Part II — independent of Mathlib's pow_of_pow_add_prime."
+    },
+    {
+      "id": "witnesses",
+      "title": "IV. Concrete Witnesses",
+      "startLine": 96,
+      "endLine": 108,
+      "summary": "not_prime_two_pow_six_add_one: 2^6 + 1 = 65 is composite via the odd exponent-factor 3 (explicit divisor 2^2 + 1 = 5); plus a contrapositive convenience form."
+    }
+  ],
+  "conclusion": {
+    "summary": "If 2^m + 1 is prime then m is a power of two — proved constructively. The key new content over Mathlib is the explicit proper divisor 2^(m/d) + 1 produced from any odd exponent-factor d > 1, certifying compositeness, from which the Fermat-prime exponent law follows independently of Mathlib's existence-only lemma.",
+    "implications": "This supplies the exponent half of the Gauss–Wantzel program flagged as open by the parent entry: for a prime p, p − 1 is a power of 2 iff p is a Fermat prime. The reusable artifact is the constructive obstruction pattern — turning a structural 'must be a power of two' claim into a named witness divisor — which is exactly what a primality or constructibility search needs to exhibit. It also makes precise why the converse fails (Euler's 2^32 + 1 = 641 · 6700417): power-of-two exponent is necessary, not sufficient.",
+    "openQuestions": [
+      "Package the full Gauss–Wantzel biconditional: a regular n-gon is constructible iff n = 2^a · (product of distinct Fermat primes). The exponent law proved here is one structural input.",
+      "Are there infinitely many Fermat primes? Only five are known (3, 5, 17, 257, 65537); this open problem bounds the supply of odd prime factors a constructible polygon may carry.",
+      "Can the constructive divisor 2^(m/d) + 1 be sharpened to a full factorization algorithm for 2^m + 1 when m is not a power of two, recursing on the odd part of the exponent?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry (Gauss–Wantzel structural tools). Its open questions list 'Prove that 2^m + 1 prime forces m to be a power of 2'; this entry proves exactly that, constructively."
+    },
+    {
+      "targetId": "angle-trisection-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry on minimal polynomial degree for non-constructibility, within the angle-trisection / constructibility lineage."
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "Root entry on the impossibility of trisecting a general angle by ruler and compass."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "AngleTrisectionOQ01OQ04OQ02",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "substantiveTheoremCount": 3,
+    "definitionCount": 0,
+    "trueStubs": 0,
+    "path": "Proofs/AngleTrisectionOQ01OQ04OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **open question** of the parent entry `angle-trisection-oq-01-oq-04` (*Gauss–Wantzel: Structural Tools for Polygon Constructibility*), which lists:

> "Prove that 2^m + 1 prime forces m to be a power of 2 (so 'p−1 a power of 2' ⇔ 'p a Fermat prime' for primes p)."

**Done** — and constructively.

## What's new vs Mathlib

Mathlib already has `Nat.pow_of_pow_add_prime` (the bare *existence* statement: `a^n+1` prime ⟹ `∃ m, n = 2^m`). This entry supplies the **constructive obstruction** Mathlib omits:

- **`not_prime_two_pow_add_one_of_odd_factor`** — if `m` has an odd factor `d > 1`, then `2^(m/d) + 1` is an **explicit proper divisor** of `2^m + 1` (strictly between `1` and `2^m + 1`), certifying compositeness.
- **`two_pow_add_one_dvd`** — the reusable engine: `2^k + 1 ∣ 2^(k·d) + 1` for odd `d`, from `a + b ∣ a^d + b^d`.
- **`isPowerOfTwo_of_prime`** — the Fermat-prime exponent law, derived **independently** of Mathlib's `pow_of_pow_add_prime` by case-splitting the odd part of the exponent.
- **`not_prime_two_pow_six_add_one`** — concrete certificate: `2^6 + 1 = 65 = 5·13` via the odd exponent-factor `3` and its explicit divisor `2^2 + 1 = 5`.

## Verification

- **0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`; kernel `decide`, **no** `native_decide`), **0 sorries**, **5 theorems**, 108 lines.
- Compiles cleanly under `lake env lean` (Mathlib 4.26.0); module registered in `proofs/Proofs.lean`.

## Files
- `proofs/Proofs/AngleTrisectionOQ01OQ04OQ02.lean`
- `src/data/proofs/angle-trisection-oq-01-oq-04-oq-02/{meta,annotations}.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)