### PR TITLE
Enrich Fibonacci Recurrence as Shadow of Pascal's Rule: add annotations

### DIFF
--- a/src/data/proofs/combinations-formula-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-08-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-cf0801-setup-defD",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 3, "endLine": 62 },
+    "type": "definition",
+    "title": "Setup and the Shallow-Diagonal Total D(n)",
+    "content": "The parent entry combinations-formula-oq-08 proved that Fibonacci numbers are the sums along the shallow diagonals of Pascal's triangle: fib(n+1) = ∑_{k} C(n−k, k). This file takes the genuinely combinatorial next step — deriving the Fibonacci recurrence F(n+2) = F(n+1) + F(n) directly from those diagonal sums via Pascal's rule, with no appeal to Nat.fib_add_two, generating functions, or matrix powers. The definition `D n := ∑ k ∈ range (n+1), C(n−k, k)` names the n-th shallow-diagonal total, e.g. D(6) = C(6,0)+C(5,1)+C(4,2)+C(3,3) = 1+5+6+1 = 13. Everything downstream is phrased in terms of D, so the combinatorial recurrence and the Fibonacci recurrence are cleanly separated.",
+    "mathContext": "$D(n) = \\sum_{k=0}^{n} \\binom{n-k}{k}$, the sum along the $n$-th shallow diagonal of Pascal's triangle.",
+    "significance": "context",
+    "relatedConcepts": ["Fibonacci numbers", "Pascal's triangle", "shallow diagonals", "binomial coefficients"],
+    "prerequisites": ["binomial coefficients C(n,k)", "finite sums over Finset.range", "the parent shallow-diagonal identity"]
+  },
+  {
+    "id": "ann-cf0801-parent-identity",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 64, "endLine": 80 },
+    "type": "theorem",
+    "title": "The Parent Identity D(n) = fib(n+1)",
+    "content": "`fib_eq_sum_range_choose` reproves the parent's shallow-diagonal formula fib(n+1) = ∑_{k} C(n−k, k) inline so the file stands alone. It starts from Mathlib's antidiagonal form `Nat.fib_succ_eq_sum_choose`, converts the antidiagonal sum to a range sum via `sum_antidiagonal_eq_sum_range_succ`, and applies the index reflection k ↦ n−k (`Finset.sum_range_reflect`) to land on the shallow-diagonal indexing; the residual term-by-term match uses `Nat.sub_sub_self`. `D_eq_fib` then records the same fact in terms of D: D(n) = fib(n+1). This identity is the bridge that converts the combinatorial recurrence on D into the Fibonacci recurrence.",
+    "mathContext": "$\\mathrm{fib}(n+1) = \\sum_{k=0}^{n}\\binom{n-k}{k}$, equivalently $D(n) = \\mathrm{fib}(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.fib_succ_eq_sum_choose", "antidiagonal sums", "Finset.sum_range_reflect", "index reflection"],
+    "prerequisites": ["Mathlib's antidiagonal Fibonacci form", "reindexing finite sums", "the reflection k ↦ n−k"]
+  },
+  {
+    "id": "ann-cf0801-pascal-step",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 82, "endLine": 96 },
+    "type": "theorem",
+    "title": "The Pascal Step: Splitting One Diagonal Term",
+    "content": "`choose_shift_succ` is the single arithmetic fact driving the whole recurrence: for k ≤ n, C(n+1−k, k+1) = C(n−k, k) + C(n−k, k+1). The proof rewrites n+1−k = (n−k)+1 (by `omega`, valid because k ≤ n) and applies `Nat.choose_succ_succ`, which is exactly Pascal's rule C(a+1, b+1) = C(a, b) + C(a, b+1). Geometrically, the entry on diagonal n+1 splits into the two entries directly below it on diagonal n — the local move that, summed across a diagonal, produces the global Fibonacci recurrence.",
+    "mathContext": "$\\binom{n+1-k}{k+1} = \\binom{n-k}{k} + \\binom{n-k}{k+1}$ for $k \\le n$ (Pascal's rule on a shifted index).",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's rule", "Nat.choose_succ_succ", "binomial recurrence", "truncated subtraction (omega)"],
+    "prerequisites": ["Pascal's identity C(a+1,b+1)=C(a,b)+C(a,b+1)", "ℕ subtraction arithmetic via omega"]
+  },
+  {
+    "id": "ann-cf0801-peeling",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 91, "endLine": 123 },
+    "type": "technique",
+    "title": "Index-Shift Normal Forms: Peeling the k = 0 Term",
+    "content": "Two lemmas put D(n+2) and D(n+1) into a common shape so the Pascal step can be applied term-by-term. `D_add_two_peel` uses `Finset.sum_range_succ'` to peel the k = 0 term of D(n+2) (a constant C(n+2,0) = 1), then `Finset.sum_range_succ` to split off and discard the vanishing top term C(0, n+2) = 0 (via `Nat.choose_eq_zero_of_lt`), leaving D(n+2) = (∑_{k<n+1} C(n+1−k, k+1)) + 1; the term-by-term index match n+2−(k+1) = n+1−k is closed by `omega`. `D_add_one_peel` does the same for D(n+1), giving (∑_{k<n+1} C(n−k, k+1)) + 1. Both sums now range over range(n+1) with shifted upper binomial argument k+1, ready for choose_shift_succ.",
+    "mathContext": "$D(n{+}2) = \\big(\\sum_{k<n+1}\\binom{n+1-k}{k+1}\\big) + 1$ and $D(n{+}1) = \\big(\\sum_{k<n+1}\\binom{n-k}{k+1}\\big) + 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_range_succ'", "Finset.sum_range_succ", "Nat.choose_eq_zero_of_lt", "boundary-term peeling", "reindexing"],
+    "prerequisites": ["peeling first/last terms of a range sum", "vanishing binomials C(a,b)=0 for b>a", "omega for index arithmetic"]
+  },
+  {
+    "id": "ann-cf0801-recurrence",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 125, "endLine": 150 },
+    "type": "theorem",
+    "title": "The Combinatorial Core: D(n+2) = D(n+1) + D(n)",
+    "content": "`D_recurrence` is the heart of the file. After rewriting both sides by the peeling lemmas, it expands each term of the D(n+2) sum by Pascal's rule (choose_shift_succ, valid since k ≤ n on range(n+1)), giving ∑ (C(n−k,k) + C(n−k,k+1)). Then `Finset.sum_add_distrib` splits this into ∑ C(n−k,k) + ∑ C(n−k,k+1) — the first is D(n), the second is the peeled D(n+1) sum — and `ring` reconciles the +1 constants. So the Fibonacci recurrence emerges purely from summing Pascal's local splitting across a diagonal. `fib_recurrence_via_pascal` then transports D_recurrence along D(n) = fib(n+1) to reprove fib(n+3) = fib(n+2) + fib(n+1) independently of Nat.fib_add_two — exhibiting the recurrence as a shadow of Pascal's rule.",
+    "mathContext": "$D(n{+}2) = D(n{+}1) + D(n)$, hence $\\mathrm{fib}(n{+}3) = \\mathrm{fib}(n{+}2) + \\mathrm{fib}(n{+}1)$, derived from Pascal's rule alone.",
+    "significance": "key",
+    "relatedConcepts": ["Fibonacci recurrence", "Finset.sum_add_distrib", "term-by-term Pascal expansion", "transport along D = fib"],
+    "prerequisites": ["the peeling normal forms", "the Pascal step choose_shift_succ", "splitting a sum of sums"]
+  },
+  {
+    "id": "ann-cf0801-lucas",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 152, "endLine": 194 },
+    "type": "theorem",
+    "title": "Link to the Lucas Partial-Sum Identity",
+    "content": "The second half connects the diagonals to the Lucas partial-sum identity ∑_{i<n} fib i = fib(n+1) − 1. `fib_partial_sum` proves the subtraction-free form (∑_{i<n} fib i) + 1 = fib(n+1) by induction using Nat.fib_add_two, and `fib_partial_sum_sub` derives the textbook form by `omega`. `shallow_diag_partial_sum` then recasts it for the diagonal totals: ∑_{i<n} D i = fib(n+2) − 1. The proof rewrites each D i = fib(i+1) (D_eq_fib), shifts the summation index with `Finset.sum_range_succ'` so ∑_{i<n} fib(i+1) = (∑_{i<n+1} fib i) − fib 0, and applies fib_partial_sum_sub. This says fib 1 + fib 2 + ⋯ + fib n = fib(n+2) − 1, the Lucas identity read along shallow diagonals.",
+    "mathContext": "$\\sum_{i<n}\\mathrm{fib}\\,i = \\mathrm{fib}(n{+}1) - 1$ and $\\sum_{i<n} D(i) = \\mathrm{fib}(n{+}2) - 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas partial-sum identity", "telescoping Fibonacci sums", "Nat.fib_add_two", "index shift sum_range_succ'", "subtraction-free formulation"],
+    "prerequisites": ["induction on range sums", "the Fibonacci two-step recurrence", "D(i) = fib(i+1)"]
+  },
+  {
+    "id": "ann-cf0801-verification",
+    "proofId": "combinations-formula-oq-08-oq-01",
+    "range": { "startLine": 196, "endLine": 204 },
+    "type": "context",
+    "title": "Worked Verifications by decide",
+    "content": "Three kernel-`decide` sanity checks ground the abstractions in concrete numbers: D(6) = 13 = fib 7 (from C(6,0)+C(5,1)+C(4,2)+C(3,3) = 1+5+6+1); the recurrence instance D(6) = D(5) + D(4), i.e. 13 = 8 + 5; and the partial-sum instance D(0)+D(1)+D(2)+D(3) = 7 = fib 6 − 1, i.e. 1+1+2+3. These are `decide` (kernel reduction), not native_decide, so they add no Lean.ofReduceBool axiom — the file remains axiom-free.",
+    "mathContext": "$D(6) = 13$, $D(6) = D(5)+D(4)$, $\\sum_{i<4} D(i) = 7$.",
+    "significance": "technical",
+    "relatedConcepts": ["kernel decide", "concrete verification", "axiom integrity"],
+    "prerequisites": ["evaluating D on small numerals", "decidable equality of naturals"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-08-oq-01` (quality 43, passes 0) — deriving F(n+2)=F(n+1)+F(n) directly from the shallow-diagonal binomial sums via Pascal's rule.

## Gap addressed
Rich meta.json (overview, conclusion, 7 sections, crossReference, leanFile) but **no annotations.json** — zero inline coverage of the 206-line file.

## Changes
Added `annotations.json` with 7 line-anchored annotations, one per section, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:

1. Setup + D(n) definition (L3–62)
2. Parent identity D(n) = fib(n+1) (L64–80)
3. The Pascal step choose_shift_succ (L82–96)
4. Peeling normal forms D_add_two/one_peel (L91–123)
5. Combinatorial core D_recurrence + fib_recurrence_via_pascal (L125–150)
6. Lucas partial-sum link (L152–194)
7. decide verifications (L196–204)

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof; all 7 anchor to real Lean constructs.
- annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, axiomCount 0 — accurate (the sanity checks use kernel `decide`, not native_decide, so no Lean.ofReduceBool).