### PR TITLE
audit(gallery): 3 fresh proofs CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24660,6 +24660,24 @@
       "issues": [],
       "lastAudited": "2026-06-25T23:00:00Z",
       "result": "clean"
+    },
+    "buffons-needle-oq-01-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T22:42:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-160-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T22:42:15Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-01-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T22:42:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 3 fresh proofs, all CLEAN

Audited 3 freshly-added gallery proofs against their Lean sources. Every public claim matches what the Lean kernel guarantees.

| Proof | Tier | sorries | axioms | counts match | Verdict |
|-------|------|---------|--------|--------------|---------|
| `buffons-needle-oq-01-oq-01-oq-03` | A | 0 | 0 | 9 thm / 7 def ✓ | CLEAN |
| `erdos-160-incomplete-01` | A | 0 | 0 | 3 thm / 0 def ✓ | CLEAN |
| `angle-trisection-oq-01-oq-04-oq-02` | A | 0 | 0 | 5 thm / 0 def ✓ | CLEAN |

### Notes per proof
- **buffons-needle-oq-01-oq-01-oq-03** (Cauchy–Crofton for polygonal curves): all 9 results proved in-file; sole dependency is the parent's verified `angular_average` (confirmed sorry-free). Badge `original` justified. `mathlibDependencies` honestly disclosed.
- **erdos-160-incomplete-01** (exact small-N floor of the 4-AP 3-diverse colouring number): the meta's `#print axioms` claim was verified — `not_achievable_le_two`, `h_ge_three`, `h_four` depend only on foundational axioms (`propext`/`Classical.choice`/`Quot.sound`), **not** the parent's axiomatised asymptotic bounds. `h_four` uses kernel `decide`, not `native_decide`. Title honestly scopes to the small-N floor; the open Erdős #160 growth question is not overclaimed.
- **angle-trisection-oq-01-oq-04-oq-02** (Fermat-number exponent lemma): `isPowerOfTwo_of_prime` is derived independently via an explicit constructive compositeness obstruction; it does **not** delegate to Mathlib's `Nat.pow_of_pow_add_prime`. Badge `original` justified.

No integrity issues found — no axiom masking, no True stubs, no sorry-count mismatches, no Mathlib-wrapper overclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)