### PR TITLE
Enrich χ(ℝ²) ≥ 4 via Moser Spindle: add annotations

### DIFF
--- a/src/data/proofs/unit-distance-independence-oq-01/annotations.json
+++ b/src/data/proofs/unit-distance-independence-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-udi01-setup-coords",
+    "proofId": "unit-distance-independence-oq-01",
+    "range": { "startLine": 46, "endLine": 104 },
+    "type": "definition",
+    "title": "Coordinates and Distance Helpers in the Euclidean Plane",
+    "content": "The plane is modeled as `Plane := EuclideanSpace ℝ (Fin 2)`, the genuine 2-dimensional inner-product space, so 'distance 1' means the true Euclidean unit distance (not an ℓ∞ or coordinate surrogate). `mk x y` builds a point from Cartesian coordinates via the EuclideanSpace equivalence, with `mk_zero`/`mk_one` reading the coordinates back. The two irrational parameters are named once: s3 = √3 (height of a unit equilateral triangle) and s11 = √11 (which enters the rotation angle). `dist_mk_sq` reduces the squared distance of two explicit points to (x₁−x₂)² + (y₁−y₂)² using `EuclideanSpace.dist_sq_eq` and `Fin.sum_univ_two`, and `dist_eq_one_of` upgrades a squared-distance-equals-1 computation to distance = 1 by factoring (d−1)(d+1) = 0 with d ≥ 0. These helpers turn every geometric edge-length claim into a polynomial identity over ℝ.",
+    "mathContext": "$\\mathrm{Plane} = \\mathbb{R}^2$ (Euclidean); $\\mathrm{dist}(\\mathrm{mk}\\,x_1\\,y_1,\\ \\mathrm{mk}\\,x_2\\,y_2)^2 = (x_1-x_2)^2 + (y_1-y_2)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace", "Euclidean distance", "EuclideanSpace.dist_sq_eq", "nonnegativity of distance"],
+    "prerequisites": ["inner-product / Euclidean spaces in Mathlib", "the distance formula", "factoring d²=1 with d ≥ 0"]
+  },
+  {
+    "id": "ann-udi01-rotation-isometry",
+    "proofId": "unit-distance-independence-oq-01",
+    "range": { "startLine": 106, "endLine": 131 },
+    "type": "theorem",
+    "title": "The Spindle Rotation and its Isometry",
+    "content": "`rot` is rotation about the origin by the spindle angle θ with cos θ = 5/6, sin θ = √11/6 — the unique angle bringing the two rhombi's far tips to unit distance. `rot_origin` records that the origin is fixed, and `rot_isometry` proves rot preserves Euclidean distance: dist(rot p, rot q) = dist(p, q). The isometry proof is the key reusable lemma — it expands both squared distances, then closes the difference by `linear_combination` against s11² = 11 (so the √11 terms combine into the rotation matrix's orthogonality), finishing with `nlinarith` and nonnegativity. With rot an isometry fixing the origin, the entire second rhombus's edge lengths are inherited from the first rhombus's for free, avoiding eleven separate coordinate computations.",
+    "mathContext": "$\\mathrm{rot}$: $(x,y) \\mapsto (\\tfrac{5}{6}x - \\tfrac{\\sqrt{11}}{6}y,\\ \\tfrac{\\sqrt{11}}{6}x + \\tfrac{5}{6}y)$, $\\cos\\theta = 5/6$, $\\sin\\theta = \\sqrt{11}/6$, an isometry fixing $0$.",
+    "significance": "key",
+    "relatedConcepts": ["rotation matrix", "isometry", "orthogonal transformation", "linear_combination", "√11 cancellation"],
+    "prerequisites": ["rotations as distance-preserving maps", "cos²+sin² = 1 via (5/6)²+(√11/6)²", "linear_combination and nlinarith"]
+  },
+  {
+    "id": "ann-udi01-vertices",
+    "proofId": "unit-distance-independence-oq-01",
+    "range": { "startLine": 133, "endLine": 147 },
+    "type": "definition",
+    "title": "The Seven Vertices of the Moser Spindle",
+    "content": "`pt : Fin 7 → Plane` lists the spindle's explicit coordinates. Vertices 0–3 form the first rhombus: the origin 0, and two unit equilateral triangles 0-1-2 and 1-2-3 sharing edge 1-2, with 3 the far tip. Vertices 4–6 are the images of 1, 2, 3 under `rot`, forming the second rhombus that shares the origin with the first. The construction realizes the abstract Moser spindle as a unit-distance graph: two rhombi (each two unit equilateral triangles) hinged at the origin, the second rotated by θ exactly so the far tips 3 and 6 land at unit distance. This explicit embedding is what makes the chromatic obstruction a statement about the actual plane.",
+    "mathContext": "Two unit rhombi sharing the origin; vertices $4,5,6 = \\mathrm{rot}(1),\\mathrm{rot}(2),\\mathrm{rot}(3)$.",
+    "significance": "key",
+    "relatedConcepts": ["Moser spindle", "unit-distance graph", "equilateral triangle", "rhombus", "graph embedding"],
+    "prerequisites": ["the Moser spindle as an abstract graph", "coordinates of unit equilateral triangles", "the rotation rot"]
+  },
+  {
+    "id": "ann-udi01-edges",
+    "proofId": "unit-distance-independence-oq-01",
+    "range": { "startLine": 148, "endLine": 205 },
+    "type": "theorem",
+    "title": "All Eleven Edges Have Unit Length",
+    "content": "Eleven lemmas certify that each spindle edge is a genuine Euclidean unit distance. First-rhombus edges (dist01, dist02, dist12, dist13, dist23) reduce to polynomial identities in √3 closed by `linear_combination` against s3² = 3 (or `ring`/`norm_num`). Second-rhombus edges (dist04, dist05, dist45, dist46, dist56) are obtained for free from the first via `rot_isometry` and `rot_origin` — e.g. dist45 = dist(rot 1, rot 2) = dist(1,2) = dist12 — no new coordinate algebra. The bridging edge dist36 between the two far tips is the single computation using both √3 and √11: the √33 cross term cancels, and `linear_combination` against s3² = 3 and s11² = 11 yields exactly 1. This cancellation is precisely why cos θ = 5/6 was the right choice.",
+    "mathContext": "Each edge length is $1$; the bridge $\\mathrm{dist}(3,6)=1$ is where $\\sqrt3$ and $\\sqrt{11}$ meet and the $\\sqrt{33}$ cross term vanishes.",
+    "significance": "key",
+    "relatedConcepts": ["unit distance", "isometry reuse", "linear_combination", "irrational coordinates √3, √11", "cross-term cancellation"],
+    "prerequisites": ["the distance helpers dist_eq_one_of", "rot_isometry for inherited edges", "polynomial identities in √3, √11"]
+  },
+  {
+    "id": "ann-udi01-obstruction",
+    "proofId": "unit-distance-independence-oq-01",
+    "range": { "startLine": 207, "endLine": 270 },
+    "type": "theorem",
+    "title": "The Spindle Graph is Not 3-Colourable",
+    "content": "`isEdge` encodes the 11 spindle edges (canonical orientation i < j) as a Bool. `fin3_third` is the combinatorial heart of the rhombus argument — a 3⁴ = 81-case `decide`: in three colours, if c and d both avoid the two distinct colours a, b, then c = d (the third colour is forced). `spindle_not_3colorable` then proves no f : Fin 7 → Fin 3 is a proper colouring, *without* brute-forcing all 3⁷ = 2187 assignments: assuming every edge bichromatic, fin3_third forces f 0 = f 3 (rhombus {0,1,2,3}) and f 0 = f 6 (rhombus {0,4,5,6}), hence f 3 = f 6 — contradicting that 3—6 is an edge. The per-edge membership facts use small `decide` calls. `edge_unit` ties the abstract graph back to geometry: every isEdge pair is realized at unit distance, dispatched by `fin_cases` over the 49 pairs with the eleven distance lemmas (maxRecDepth raised for the case explosion).",
+    "mathContext": "For all $f:\\mathrm{Fin}\\,7\\to\\mathrm{Fin}\\,3$, some edge is monochromatic: $f3 = f0 = f6$ but $3{-}6$ is an edge. Chromatic number of the spindle is $4$.",
+    "significance": "key",
+    "relatedConcepts": ["chromatic number", "proper colouring", "kernel decide", "Moser spindle obstruction", "fin_cases"],
+    "prerequisites": ["proper graph colouring", "the pigeonhole 'third colour is forced' lemma", "decidable finite checks"]
+  },
+  {
+    "id": "ann-udi01-main",
+    "proofId": "unit-distance-independence-oq-01",
+    "range": { "startLine": 272, "endLine": 300 },
+    "type": "theorem",
+    "title": "Main Result: χ(ℝ²) ≥ 4",
+    "content": "`chromatic_plane_ge_four` assembles the bridge: for any 3-colouring c : Plane → Fin 3, restrict it to the spindle vertices (k ↦ c (pt k)); spindle_not_3colorable produces a monochromatic edge (i,j), and edge_unit certifies dist(pt i, pt j) = 1 — so c fails to avoid a monochromatic unit-distance pair. `no_proper_3coloring_of_plane` restates this in the parent's phrasing: no c : Plane → Fin 3 properly colours the unit-distance graph of the plane. This is the strongest fully verified (0-axiom) Hadwiger–Nelson lower bound the gallery had been missing — the classical Moser (1961) χ(ℝ²) ≥ 4 — and the verified companion to the parent's axiomatized de Grey χ(ℝ²) ≥ 5, giving the machine-checked window 4 ≤ χ(ℝ²) ≤ 7.",
+    "mathContext": "$\\chi(\\mathbb{R}^2) \\ge 4$: every $c:\\mathbb{R}^2\\to\\mathrm{Fin}\\,3$ has $p,q$ with $\\mathrm{dist}(p,q)=1$ and $c(p)=c(q)$.",
+    "significance": "key",
+    "relatedConcepts": ["Hadwiger–Nelson problem", "chromatic number of the plane", "Moser 1961 bound", "de Grey ≥ 5", "unit-distance graph"],
+    "prerequisites": ["the spindle non-3-colourability", "the unit-distance edge realization", "the Hadwiger–Nelson framing of χ(ℝ²)"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `unit-distance-independence-oq-01` (quality 45, passes 0) — the fully verified Moser-spindle lower bound χ(ℝ²) ≥ 4 for Hadwiger–Nelson.

## Gap addressed
Rich meta.json (overview, conclusion, 5 sections, 3 crossReferences, leanFile) but **no annotations.json** — zero inline coverage of the 300-line file.

## Changes
Added `annotations.json` with 6 line-anchored annotations spanning all 5 sections, each with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`:

1. Coordinates & distance helpers (L46–104)
2. The rotation + isometry, cos θ=5/6, sin θ=√11/6 (L106–131)
3. The seven Moser-spindle vertices (L133–147)
4. All eleven unit edges, incl. the √33-cancelling bridge dist36 (L148–205)
5. The spindle non-3-colourability obstruction (L207–270)
6. Main result χ(ℝ²) ≥ 4 (L272–300)

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof; all 6 anchor to real Lean constructs.
- annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, badge `verified`, axiomCount 0 — accurate. The proof uses **kernel `decide` only** (3⁴ and small finite checks); the lone "native_decide" string is in the docstring at L22 ("no native_decide"), a grep false-positive, so no Lean.ofReduceBool.

Note: pushed from `feature/enricher-1-udi-oq01` (the shared `feature/enricher-1` branch still hosts open PR #30317).