### PR TITLE
research(chebyshev-pnt-bridge-oq-05-oq-01): two-sided Chebyshev bound π(x) = Θ(x/log x) [verified, 0 axiom]

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ02.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ02.lean
@@ -108,9 +108,9 @@ lemma chebyshev_lower_pos (n : ℕ) (hn : 1 ≤ n) :
       induction n with
       | zero => omega
       | succ k ih =>
-        rcases Nat.eq_or_gt_of_le hn with rfl | hk
+        rcases Nat.eq_zero_or_pos k with rfl | hk
         · norm_num
-        · have hk1 : 1 ≤ k := by omega
+        · have hk1 : 1 ≤ k := hk
           have ihk := ih hk1
           calc 2 * (k + 1) + 1 = 2 * k + 3 := by ring
             _ < 4 * (2 * k + 1) := by omega

--- a/proofs/Proofs/ChebyshevPNTBridgeOQ05OQ01.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ05OQ01.lean
@@ -1,0 +1,229 @@
+/-
+# Chebyshev–PNT Bridge OQ-05·OQ-01: The Two-Sided Chebyshev Bound for π(x)
+
+The Prime Number Theorem states `π(x) ~ x / log x`. Decades before PNT,
+Chebyshev proved the *order of magnitude* is correct: `π(x)` is squeezed
+between two constant multiples of `x / log x`. Historically this two-sided
+estimate is the pivotal pre-PNT result and the quantitative backbone of
+Bertrand's postulate, Mertens' theorems, and prime density statements.
+
+The two halves already live in the gallery, in separate files:
+
+* **Lower half** — `ChebyshevPNTBridgeOQ05.primeCounting_mul_log_lower`:
+  for every `m ≥ 2`,
+  `⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m`,
+  i.e. the Chebyshev lower density `π(m)·log m / m ≥ log 2 − o(1)`.
+
+* **Upper half** — `ChebyshevPNTBridgeOQ02.chebyshev_upper_real`
+  (itself re-exporting `Erdos31PrimesDensity.primeCounting_le_chebyshev`):
+  for every `N ≥ 2`,
+  `π(N) ≤ 2·N·log 4 / log N + √N + 1`,
+  i.e. the Chebyshev upper density `π(N)·log N / N ≤ 2·log 4 + o(1)`.
+
+This file packages the two halves into single citable theorems, the natural
+API other gallery entries should depend on.
+
+## Results
+
+* **`primeCounting_two_sided_exact`** — the raw conjunction of the two parent
+  bounds, valid for every `m ≥ 2` with their exact error terms.
+
+* **`primeCounting_le_order`** — a clean *order* upper bound with one explicit
+  constant: for `m ≥ 2`,
+  `π(m) ≤ (2·log 4 + 4)·(m / log m)`.
+  The `+4` uniformly absorbs the `√m + 1` error term over the whole range
+  `m ≥ 2` (using `log m ≤ 2√m` and `√m ≤ m`).
+
+* **`primeCounting_ge_order`** — a clean *order* lower bound with one explicit
+  constant and threshold: for `m ≥ 65`,
+  `(2/5)·(m / log m) ≤ π(m)`.
+  The threshold and the modest constant `2/5 < log 2` come from absorbing the
+  `−log(m+1)` and `⌊m/2⌋ vs m/2` losses (using `log(m+1) ≤ 2√(m+1) ≤ m/4` for
+  `m ≥ 65` and the explicit lower bound `log 2 > 0.6931471803`).
+
+* **`chebyshev_order_two_sided`** — the headline packaged statement: for
+  `m ≥ 65`,
+  `(2/5)·(m / log m) ≤ π(m) ≤ (2·log 4 + 4)·(m / log m)`,
+  the single "`π(x)` is of order `x / log x`" lemma.
+
+Everything is derived from the two parent results plus elementary `Real.log` /
+`Real.sqrt` estimates; the whole dependency chain
+(`ChebyshevPNTBridge`, `ChebyshevPNTBridgeOQ02`, `ChebyshevPNTBridgeOQ05`,
+`Erdos31PrimesDensity`) is `0 sorries, 0 axioms`, so this file is too.
+`0 sorries, 0 axioms`.
+-/
+
+import Mathlib
+import Proofs.ChebyshevPNTBridgeOQ02
+import Proofs.ChebyshevPNTBridgeOQ05
+
+namespace ChebyshevPNTBridgeOQ05OQ01
+
+open Nat
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART 0: ELEMENTARY LOG/SQRT HELPER
+
+A single clean estimate `log x ≤ 2√x` (for `x ≥ 0`) powers both the uniform
+absorption of the upper-bound error term `√m + 1` and the lower-bound error
+term `log(m+1)`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- For every `x ≥ 0`, `log x ≤ 2·√x`. Obtained from `log t ≤ t − 1` applied to
+`t = √x`, since `log x = 2·log √x ≤ 2·(√x − 1) ≤ 2·√x`. -/
+theorem log_le_two_mul_sqrt {x : ℝ} (hx : 0 ≤ x) :
+    Real.log x ≤ 2 * Real.sqrt x := by
+  rcases eq_or_lt_of_le hx with rfl | hx_pos
+  · simp
+  · have hsqrt_pos : 0 < Real.sqrt x := Real.sqrt_pos.mpr hx_pos
+    have hlog_sqrt : Real.log (Real.sqrt x) ≤ Real.sqrt x - 1 :=
+      Real.log_le_sub_one_of_pos hsqrt_pos
+    have hmul : Real.sqrt x * Real.sqrt x = x := Real.mul_self_sqrt hx
+    have hsplit : Real.log x = 2 * Real.log (Real.sqrt x) := by
+      conv_lhs => rw [← hmul]
+      rw [Real.log_mul (ne_of_gt hsqrt_pos) (ne_of_gt hsqrt_pos)]; ring
+    rw [hsplit]; linarith
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: THE EXACT TWO-SIDED BOUND (ALL m ≥ 2)
+
+The literal conjunction of the two parent results, with their exact error
+terms. This is the most precise consolidated statement.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Two-sided Chebyshev bound, exact form.** For every `m ≥ 2`,
+
+    (⌊m/2⌋·log 4 − log(m+1)) / log m  ≤  π(m)  ≤  2·m·log 4 / log m + √m + 1.
+
+The lower half is `ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log`; the upper
+half is `ChebyshevPNTBridgeOQ02.chebyshev_upper_real`. -/
+theorem primeCounting_two_sided_exact (m : ℕ) (hm : 2 ≤ m) :
+    ((m / 2 : ℕ) * Real.log 4 - Real.log (m + 1)) / Real.log m
+        ≤ (Nat.primeCounting m : ℝ)
+      ∧ (Nat.primeCounting m : ℝ)
+        ≤ 2 * m * Real.log 4 / Real.log m + Nat.sqrt m + 1 :=
+  ⟨ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log m hm,
+   ChebyshevPNTBridgeOQ02.chebyshev_upper_real m hm⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: CLEAN ORDER UPPER BOUND (ALL m ≥ 2)
+
+`π(m) ≤ (2·log 4 + 4)·(m / log m)`. The `√m + 1` error term is absorbed into
+the `+4` uniformly over `m ≥ 2`, via `log m ≤ 2√m` and `√m ≤ m`:
+`(√m + 1)·log m ≤ (√m + 1)·2√m = 2m + 2√m ≤ 4m`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Chebyshev order upper bound.** For every `m ≥ 2`,
+`π(m) ≤ (2·log 4 + 4)·(m / log m)`. -/
+theorem primeCounting_le_order (m : ℕ) (hm : 2 ≤ m) :
+    (Nat.primeCounting m : ℝ) ≤ (2 * Real.log 4 + 4) * ((m : ℝ) / Real.log m) := by
+  have hm_real : (2 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  have hlogm_pos : 0 < Real.log m := Real.log_pos (by exact_mod_cast (by omega : 1 < m))
+  have hupper := ChebyshevPNTBridgeOQ02.chebyshev_upper_real m hm
+  -- log m ≤ 2√m and √m ≤ m
+  have hlogm_le : Real.log m ≤ 2 * Real.sqrt m := log_le_two_mul_sqrt (by positivity)
+  have hsqrt_le : Real.sqrt (m : ℝ) ≤ (m : ℝ) := by
+    have hmm : (m : ℝ) ≤ (m : ℝ) ^ 2 := by nlinarith [hm_real, sq_nonneg ((m : ℝ) - 1)]
+    have h : Real.sqrt (m : ℝ) ≤ Real.sqrt ((m : ℝ) ^ 2) := Real.sqrt_le_sqrt hmm
+    rwa [Real.sqrt_sq (by positivity)] at h
+  have hsqrt_nonneg : 0 ≤ Real.sqrt (m : ℝ) := Real.sqrt_nonneg _
+  -- (√m + 1)·log m ≤ 4m
+  have htail : (Real.sqrt (m : ℝ) + 1) * Real.log m ≤ 4 * (m : ℝ) := by
+    have h1 : (Real.sqrt (m : ℝ) + 1) * Real.log m
+        ≤ (Real.sqrt (m : ℝ) + 1) * (2 * Real.sqrt m) :=
+      mul_le_mul_of_nonneg_left hlogm_le (by positivity)
+    have hsq : Real.sqrt (m : ℝ) * Real.sqrt (m : ℝ) = (m : ℝ) :=
+      Real.mul_self_sqrt (by positivity)
+    nlinarith [h1, hsq, hsqrt_le, hsqrt_nonneg]
+  -- hence √m + 1 ≤ 4·(m / log m)
+  have htail2 : Real.sqrt (m : ℝ) + 1 ≤ 4 * ((m : ℝ) / Real.log m) := by
+    rw [← mul_div_assoc, le_div_iff₀ hlogm_pos]; linarith [htail]
+  -- expand the target constant and combine
+  have hexpand : (2 * Real.log 4 + 4) * ((m : ℝ) / Real.log m)
+      = 2 * (m : ℝ) * Real.log 4 / Real.log m + 4 * ((m : ℝ) / Real.log m) := by ring
+  rw [hexpand]
+  -- π(m) ≤ 2 m log4/log m + (√m + 1) ≤ 2 m log4/log m + 4·(m/log m)
+  have hsqrt_cast : (↑(Nat.sqrt m) : ℝ) ≤ Real.sqrt (m : ℝ) := by
+    rw [← Real.sqrt_sq (Nat.cast_nonneg (Nat.sqrt m))]
+    exact Real.sqrt_le_sqrt (by exact_mod_cast Nat.sqrt_le' m)
+  linarith [hupper, htail2, hsqrt_cast]
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART III: CLEAN ORDER LOWER BOUND (m ≥ 65)
+
+`(2/5)·(m / log m) ≤ π(m)`. From the parent lower bound
+`⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m`, using `⌊m/2⌋·log 4 ≥ (m−1)·log 2`
+(since `log 4 = 2·log 2`) and the absorption `log(m+1) ≤ 2√(m+1) ≤ m/4`
+valid for `m ≥ 65`. With `log 2 > 0.6931471803` the residual
+`(m−1)·log 2 − m/4 ≥ (2/5)·m` for all `m ≥ 65`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Chebyshev order lower bound.** For every `m ≥ 65`,
+`(2/5)·(m / log m) ≤ π(m)`. -/
+theorem primeCounting_ge_order (m : ℕ) (hm : 65 ≤ m) :
+    (2 / 5 : ℝ) * ((m : ℝ) / Real.log m) ≤ (Nat.primeCounting m : ℝ) := by
+  have hm2 : 2 ≤ m := by omega
+  have hm_real : (65 : ℝ) ≤ (m : ℝ) := by exact_mod_cast hm
+  have hlogm_pos : 0 < Real.log m := Real.log_pos (by exact_mod_cast (by omega : 1 < m))
+  have hlower := ChebyshevPNTBridgeOQ05.primeCounting_mul_log_lower m hm2
+  -- log(m+1) ≤ m/4
+  have hlog_m1 : Real.log ((m : ℝ) + 1) ≤ (m : ℝ) / 4 := by
+    have h1 : Real.log ((m : ℝ) + 1) ≤ 2 * Real.sqrt ((m : ℝ) + 1) :=
+      log_le_two_mul_sqrt (by positivity)
+    have h2 : Real.sqrt ((m : ℝ) + 1) ≤ (m : ℝ) / 8 := by
+      have hsq : (m : ℝ) + 1 ≤ ((m : ℝ) / 8) ^ 2 := by
+        nlinarith [hm_real, sq_nonneg ((m : ℝ) - 65)]
+      have hb : Real.sqrt ((m : ℝ) + 1) ≤ Real.sqrt (((m : ℝ) / 8) ^ 2) :=
+        Real.sqrt_le_sqrt hsq
+      rwa [Real.sqrt_sq (by positivity)] at hb
+    linarith
+  -- log 4 = 2 log 2
+  have hlog4 : Real.log 4 = 2 * Real.log 2 := by
+    rw [show (4 : ℝ) = 2 ^ 2 by norm_num, Real.log_pow]; push_cast; ring
+  -- m ≤ 2⌊m/2⌋ + 1
+  have hfloor : (m : ℝ) ≤ 2 * ((m / 2 : ℕ) : ℝ) + 1 := by
+    have h : m ≤ 2 * (m / 2) + 1 := by omega
+    calc (m : ℝ) ≤ ((2 * (m / 2) + 1 : ℕ) : ℝ) := by exact_mod_cast h
+      _ = 2 * ((m / 2 : ℕ) : ℝ) + 1 := by push_cast; ring
+  have hlog2_lb : (0.6931471803 : ℝ) < Real.log 2 := Real.log_two_gt_d9
+  -- (2/5)·m ≤ ⌊m/2⌋·log 4 − log(m+1)
+  have hkey : (2 / 5 : ℝ) * (m : ℝ)
+      ≤ ((m / 2 : ℕ) : ℝ) * Real.log 4 - Real.log ((m : ℝ) + 1) := by
+    have h2q : (m : ℝ) - 1 ≤ 2 * ((m / 2 : ℕ) : ℝ) := by linarith [hfloor]
+    have hlog2_pos : (0 : ℝ) < Real.log 2 := by linarith [hlog2_lb]
+    have hprod : ((m : ℝ) - 1) * Real.log 2 ≤ 2 * ((m / 2 : ℕ) : ℝ) * Real.log 2 :=
+      mul_le_mul_of_nonneg_right h2q hlog2_pos.le
+    rw [hlog4]
+    have hprod2 : (0 : ℝ) ≤ ((m : ℝ) - 1) * (Real.log 2 - 0.6931471803) :=
+      mul_nonneg (by linarith [hm_real]) (by linarith [hlog2_lb])
+    nlinarith [hprod, hlog_m1, hlog2_lb, hm_real, hprod2]
+  -- combine with the parent lower bound and divide by log m
+  have hcomb : (2 / 5 : ℝ) * (m : ℝ) ≤ (Nat.primeCounting m : ℝ) * Real.log m :=
+    le_trans hkey hlower
+  rw [← mul_div_assoc, div_le_iff₀ hlogm_pos]
+  linarith [hcomb]
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART IV: THE PACKAGED TWO-SIDED ORDER BOUND
+
+The headline statement: `π(x)` is of order `x / log x`, as a single lemma with
+explicit constants `c₁ = 2/5`, `c₂ = 2·log 4 + 4` and threshold `x₀ = 65`.
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Two-sided Chebyshev order bound (headline).** For every `m ≥ 65`,
+
+    (2/5)·(m / log m)  ≤  π(m)  ≤  (2·log 4 + 4)·(m / log m).
+
+This is the single "`π(x)` is of order `x / log x`" lemma, with explicit
+constants `0 < 2/5 ≤ 2·log 4 + 4` and threshold `65`. -/
+theorem chebyshev_order_two_sided (m : ℕ) (hm : 65 ≤ m) :
+    (2 / 5 : ℝ) * ((m : ℝ) / Real.log m) ≤ (Nat.primeCounting m : ℝ)
+      ∧ (Nat.primeCounting m : ℝ) ≤ (2 * Real.log 4 + 4) * ((m : ℝ) / Real.log m) :=
+  ⟨primeCounting_ge_order m hm, primeCounting_le_order m (by omega)⟩
+
+#check @primeCounting_two_sided_exact  -- exact two-sided, all m ≥ 2
+#check @primeCounting_le_order          -- order upper bound, all m ≥ 2
+#check @primeCounting_ge_order          -- order lower bound, m ≥ 65
+#check @chebyshev_order_two_sided       -- packaged two-sided order bound
+
+end ChebyshevPNTBridgeOQ05OQ01

--- a/proofs/Proofs/Erdos31PrimesDensity.lean
+++ b/proofs/Proofs/Erdos31PrimesDensity.lean
@@ -58,10 +58,9 @@ theorem chebyshevTheta_le (n : ℕ) : chebyshevTheta n ≤ n * Real.log 4 := by
   unfold chebyshevTheta
   by_cases hn : n = 0
   · subst hn
-    have : Finset.filter Nat.Prime (Finset.range 1) = ∅ := by
-      ext x; simp only [Finset.mem_filter, Finset.mem_range, Finset.not_mem_empty, iff_false, not_and]
-      intro hx; interval_cases x; exact Nat.not_prime_zero
-    simp [this]
+    have hempty : Finset.filter Nat.Prime (Finset.range (0 + 1)) = ∅ := by decide
+    rw [hempty, Finset.sum_empty]
+    simp
   have hprim_pos : 0 < primorial n := primorial_pos n
   have hprim_real : (primorial n : ℝ) ≤ ((4 : ℕ) ^ n : ℕ) := by
     exact_mod_cast primorial_le_4_pow n
@@ -72,7 +71,7 @@ theorem chebyshevTheta_le (n : ℕ) : chebyshevTheta n ≤ n * Real.log 4 := by
       ∏ p ∈ Finset.filter Nat.Prime (Finset.range (n + 1)), (p : ℝ) := by
     unfold primorial; simp only [Nat.cast_prod]
   rw [hprod_cast] at hlog
-  rw [Real.log_prod _ _ (fun p hp => by exact_mod_cast (Finset.mem_filter.mp hp).2.ne_zero)] at hlog
+  rw [Real.log_prod (fun p hp => by exact_mod_cast (Finset.mem_filter.mp hp).2.ne_zero)] at hlog
   linarith
 
 /-! ## Upper bound on π(N) from Chebyshev
@@ -133,7 +132,8 @@ theorem primeCounting_le_chebyshev (N : ℕ) (hN : 2 ≤ N) :
       have hp_sq_gt : N < p * p := by
         have hp_ge : sqrtN + 1 ≤ p := hpgt
         have h_succ_sq : N < (sqrtN + 1) * (sqrtN + 1) := by
-          rw [hsqrtN_def]; exact Nat.lt_succ_sqrt' N
+          rw [hsqrtN_def]
+          simpa [Nat.succ_eq_add_one, pow_two] using Nat.lt_succ_sqrt' N
         nlinarith [Nat.mul_le_mul hp_ge hp_ge]
       have hp_pos : (0 : ℝ) < (p : ℝ) := by exact_mod_cast hpS.2.pos
       have hp_sq_real : (N : ℝ) < (p : ℝ) * (p : ℝ) := by exact_mod_cast hp_sq_gt
@@ -188,7 +188,7 @@ theorem chebyshev_bound_tendsto_zero :
         exact this.congr' (by filter_upwards [eventually_ge_atTop 0] with N _; simp [Real.sqrt_eq_rpow])
       have := (tendsto_inv_atTop_zero.comp hsqrt).const_mul 2
       simp only [mul_zero] at this
-      exact this.congr' (by filter_upwards with N; ring)
+      exact this.congr' (by filter_upwards with N; simp only [Function.comp_apply]; ring)
     apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h_upper
     · filter_upwards with N using div_nonneg (by positivity) (Nat.cast_nonneg _)
     · filter_upwards [eventually_ge_atTop 4] with N hN
@@ -200,8 +200,13 @@ theorem chebyshev_bound_tendsto_zero :
         exact Real.sqrt_le_sqrt (by exact_mod_cast Nat.sqrt_le' N)
       have hsq : Real.sqrt N ^ 2 = N := Real.sq_sqrt (le_of_lt hN_pos)
       -- Need: (Nat.sqrt N + 1) * √N ≤ 2 * N
-      -- (√N + 1) * √N = √N² + √N = N + √N ≤ 2N since √N ≤ N
-      nlinarith [sq_nonneg (Real.sqrt N - 1)]
+      -- (√N + 1) * √N = √N² + √N = N + √N ≤ 2N since 1 ≤ √N ≤ N
+      have hs_ge_1 : (1 : ℝ) ≤ Real.sqrt N := by
+        rw [show (1 : ℝ) = Real.sqrt 1 by simp]
+        exact Real.sqrt_le_sqrt (by exact_mod_cast (by omega : (1 : ℕ) ≤ N))
+      nlinarith [hsqrt_le, hsq, hN_sqrt_pos, hs_ge_1,
+        mul_le_mul_of_nonneg_right hsqrt_le hN_sqrt_pos.le,
+        mul_nonneg (by linarith [hs_ge_1] : (0 : ℝ) ≤ Real.sqrt N - 1) hN_sqrt_pos.le]
   have := h1.add h2
   simp only [zero_add] at this
   exact this

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/annotations.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "chebyshev-pnt-bridge-oq-05-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "type": "context",
+    "title": "Packaging the Two Halves of Chebyshev's Estimate",
+    "content": "Chebyshev (1852) proved that π(x) has the right order of magnitude — squeezed between constant multiples of x/log x — decades before the sharp Prime Number Theorem. In the formalized bridge the two halves live in separate files: the lower density π(m)·log m ≥ m·log 2 − o(1) (parent OQ-05) and the upper density π(N) ≤ 2N·log 4/log N + √N + 1 (exported, via the repaired Erdos31PrimesDensity, through ChebyshevPNTBridgeOQ02). This entry consolidates them into single citable theorems: an exact two-sided bound for all m ≥ 2 and a clean order form for m ≥ 65. 0 axioms, 0 sorries.",
+    "mathContext": "$\\log 2 - o(1) \\le \\dfrac{\\pi(x)\\log x}{x} \\le 2\\log 4 + o(1)$, packaged as one lemma.",
+    "significance": "context",
+    "relatedConcepts": [
+      "prime-counting function π",
+      "Chebyshev's theorem",
+      "Prime Number Theorem",
+      "order of magnitude Θ(x/log x)"
+    ],
+    "prerequisites": [
+      "the parent OQ-05 lower density",
+      "the Chebyshev upper bound via central binomials",
+      "Real.log and Real.sqrt basics"
+    ]
+  },
+  {
+    "id": "ann-helper",
+    "proofId": "chebyshev-pnt-bridge-oq-05-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 86
+    },
+    "type": "insight",
+    "title": "One Estimate to Absorb Both Error Terms: log x ≤ 2√x",
+    "content": "log_le_two_mul_sqrt proves log x ≤ 2√x for every x ≥ 0. The proof applies Real.log_le_sub_one_of_pos (log t ≤ t − 1) to t = √x and uses log x = 2·log √x (from √x·√x = x), giving log x ≤ 2(√x − 1) ≤ 2√x. This single inequality is the workhorse of both order bounds: in the upper bound it tames the additive √N + 1 error term (via log m ≤ 2√m), and in the lower bound it tames the subtractive log(m+1) term (via log(m+1) ≤ 2√(m+1) ≤ m/4). Concentrating both error analyses into one reusable lemma keeps the two order proofs short and parallel.",
+    "mathContext": "$\\log x = 2\\log\\sqrt{x} \\le 2(\\sqrt{x}-1) \\le 2\\sqrt{x}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_le_sub_one_of_pos",
+      "Real.mul_self_sqrt",
+      "error-term absorption",
+      "logarithm vs square root growth"
+    ],
+    "prerequisites": [
+      "log t ≤ t − 1 for t > 0",
+      "√x · √x = x for x ≥ 0",
+      "monotonicity of multiplication"
+    ]
+  },
+  {
+    "id": "ann-exact",
+    "proofId": "chebyshev-pnt-bridge-oq-05-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "The Exact Two-Sided Bound: A Verbatim Conjunction",
+    "content": "primeCounting_two_sided_exact states, for every m ≥ 2, both (⌊m/2⌋·log 4 − log(m+1))/log m ≤ π(m) and π(m) ≤ 2m·log 4/log m + √m + 1, as a single ⟨lower, upper⟩ pair. The proof introduces no new analysis: the lower half is exactly ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log and the upper half is exactly ChebyshevPNTBridgeOQ02.chebyshev_upper_real. This is the most precise consolidated statement — it keeps the exact error terms — and serves as the foundation the cleaner order forms are derived from.",
+    "mathContext": "$\\dfrac{\\lfloor m/2\\rfloor\\log 4 - \\log(m+1)}{\\log m} \\le \\pi(m) \\le \\dfrac{2m\\log 4}{\\log m} + \\sqrt{m} + 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "two-sided estimate",
+      "prime-counting bounds",
+      "interface consolidation"
+    ],
+    "prerequisites": [
+      "the parent lower bound primeCounting_ge_div_log",
+      "the Chebyshev upper bound chebyshev_upper_real"
+    ]
+  },
+  {
+    "id": "ann-order-upper",
+    "proofId": "chebyshev-pnt-bridge-oq-05-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 150
+    },
+    "type": "insight",
+    "title": "Clean Order Upper Bound: π(m) ≤ (2·log 4 + 4)·(m/log m)",
+    "content": "primeCounting_le_order absorbs the √m + 1 error term into a single explicit constant, valid for ALL m ≥ 2. Starting from π(m) ≤ 2m·log 4/log m + √m + 1, it suffices to show √m + 1 ≤ 4·(m/log m), equivalently (√m+1)·log m ≤ 4m. Using log m ≤ 2√m (the helper) and √m ≤ m gives (√m+1)·log m ≤ (√m+1)·2√m = 2m + 2√m ≤ 4m. No threshold is needed because √m ≤ m holds for all m ≥ 1. The result is c₂ = 2·log 4 + 4 ≈ 6.77, looser than the asymptotic 2·log 4 ≈ 2.77 but uniform with no o(1).",
+    "mathContext": "$(\\sqrt m+1)\\log m \\le (\\sqrt m+1)\\,2\\sqrt m = 2m + 2\\sqrt m \\le 4m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniform constant vs asymptotic constant",
+      "le_div_iff₀",
+      "error-term absorption",
+      "Nat.sqrt vs Real.sqrt"
+    ],
+    "prerequisites": [
+      "the Chebyshev upper bound",
+      "log x ≤ 2√x",
+      "√m ≤ m for m ≥ 1"
+    ]
+  },
+  {
+    "id": "ann-order-lower",
+    "proofId": "chebyshev-pnt-bridge-oq-05-oq-01",
+    "range": {
+      "startLine": 152,
+      "endLine": 205
+    },
+    "type": "insight",
+    "title": "Clean Order Lower Bound: (2/5)·(m/log m) ≤ π(m) for m ≥ 65",
+    "content": "primeCounting_ge_order converts the parent lower bound into the order form. From ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m, bound ⌊m/2⌋·log 4 ≥ (m−1)·log 2 (since log 4 = 2 log 2 and 2⌊m/2⌋ ≥ m−1) and log(m+1) ≤ 2√(m+1) ≤ m/4 — the latter because √(m+1) ≤ m/8 ⟺ 64(m+1) ≤ m², true for m ≥ 65. With the explicit bound log 2 > 0.6931471803 (Real.log_two_gt_d9), the residual (m−1)·log 2 − m/4 ≥ (2/5)·m for all m ≥ 65. The threshold and the modest c₁ = 2/5 < log 2 are the price of a uniform, o(1)-free statement.",
+    "mathContext": "$(m-1)\\log 2 - \\tfrac{m}{4} \\ge \\tfrac{2}{5}m$ for $m \\ge 65$, using $\\log 2 > 0.6931471803$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_two_gt_d9",
+      "floor lower bound 2⌊m/2⌋ ≥ m − 1",
+      "explicit threshold",
+      "log 4 = 2 log 2"
+    ],
+    "prerequisites": [
+      "the parent lower bound primeCounting_mul_log_lower",
+      "log(m+1) ≤ 2√(m+1)",
+      "explicit numeric bound on log 2"
+    ]
+  },
+  {
+    "id": "ann-packaged",
+    "proofId": "chebyshev-pnt-bridge-oq-05-oq-01",
+    "range": {
+      "startLine": 207,
+      "endLine": 229
+    },
+    "type": "insight",
+    "title": "The Headline: π(x) = Θ(x / log x) as One Lemma",
+    "content": "chebyshev_order_two_sided conjoins the two order bounds into (2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m) for every m ≥ 65 — the single 'π(x) is of order x/log x' statement with explicit constants 0 < 2/5 ≤ 2·log 4 + 4 and threshold x₀ = 65. This is the natural API other gallery entries (Bertrand's postulate, Mertens' theorems, prime density) should depend on, replacing imports of two separate one-sided files. All four exported theorems were machine-verified to depend only on propext / Classical.choice / Quot.sound — 0 axioms, no native_decide.",
+    "mathContext": "$\\tfrac{2}{5}\\cdot\\tfrac{m}{\\log m} \\le \\pi(m) \\le (2\\log 4 + 4)\\cdot\\tfrac{m}{\\log m},\\quad m \\ge 65$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Θ(x/log x)",
+      "single-lemma API",
+      "Bertrand's postulate",
+      "Mertens' theorems"
+    ],
+    "prerequisites": [
+      "the order upper bound",
+      "the order lower bound"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevPNTBridgeOQ05OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevPntBridgeOq05Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevPntBridgeOq05Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevPntBridgeOq05Oq01Data: ProofData = {
+  proof: chebyshevPntBridgeOq05Oq01Proof,
+  annotations: chebyshevPntBridgeOq05Oq01Annotations,
+}

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-05-oq-01",
+  "title": "The Two-Sided Chebyshev Bound: π(x) = Θ(x / log x)",
+  "slug": "chebyshev-pnt-bridge-oq-05-oq-01",
+  "description": "Packages the two halves of Chebyshev's pre-PNT estimate into single citable theorems. The parent OQ-05 supplied the lower density ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m (π(m)·log m / m ≥ log 2 − o(1)); the bridge chain (via the repaired Erdos31PrimesDensity) supplies the upper density π(N) ≤ 2N·log 4 / log N + √N + 1 (≤ 2 log 4 + o(1)). This entry combines them: an exact two-sided bound for all m ≥ 2, and clean order forms (2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m) — the latter holding for m ≥ 65 — giving the single 'π(x) is of order x / log x' lemma. As a prerequisite the broken parent Erdos31PrimesDensity.lean and ChebyshevPNTBridgeOQ02.lean were repaired for Mathlib v4.26 (renamed Real.log_prod, Nat.lt_succ_sqrt', Nat.eq_or_gt_of_le). 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Pafnuty Chebyshev",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ05OQ01.lean",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev",
+      "analytic-number-theory",
+      "prime-number-theorem",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_le_sub_one_of_pos",
+        "description": "log t ≤ t − 1 for t > 0; applied to t = √x it yields the clean estimate log x ≤ 2√x that absorbs both error terms (√N+1 above, log(m+1) below)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.sqrt_le_sqrt / Real.sqrt_sq",
+        "description": "monotonicity of √ and √(a²) = a; turn the polynomial bounds √m ≤ m and √(m+1) ≤ m/8 into the m/log m normalization",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.log_two_gt_d9",
+        "description": "0.6931471803 < log 2, the explicit lower bound that fixes the lower-density constant 2/5 < log 2 and the threshold m ≥ 65",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "div_le_iff₀ / le_div_iff₀",
+        "description": "convert between the π(m)·log m form of the parent bounds and the c·(m/log m) order form",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      },
+      {
+        "theorem": "Nat.sqrt_le'",
+        "description": "(Nat.sqrt m)² ≤ m; bridges the integer error term Nat.sqrt N in the upper bound to the real √N used in the absorption",
+        "module": "Mathlib.Algebra.Order.Ring.Nat"
+      }
+    ],
+    "originalContributions": [
+      "primeCounting_two_sided_exact: the literal conjunction of the parent lower bound (ChebyshevPNTBridgeOQ05.primeCounting_ge_div_log) and the Chebyshev upper bound (ChebyshevPNTBridgeOQ02.chebyshev_upper_real) as a single two-sided statement valid for every m ≥ 2 with the exact error terms",
+      "primeCounting_le_order: a clean order upper bound π(m) ≤ (2·log 4 + 4)·(m/log m) for all m ≥ 2, where the +4 uniformly absorbs the √m + 1 error term via log m ≤ 2√m and √m ≤ m: (√m+1)·log m ≤ (√m+1)·2√m = 2m + 2√m ≤ 4m",
+      "primeCounting_ge_order: a clean order lower bound (2/5)·(m/log m) ≤ π(m) for m ≥ 65, absorbing the −log(m+1) and ⌊m/2⌋-vs-m/2 losses via log(m+1) ≤ 2√(m+1) ≤ m/4 and log 2 > 0.6931471803",
+      "chebyshev_order_two_sided: the packaged headline 'π(x) = Θ(x/log x)' lemma (2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m) for m ≥ 65, the natural single API other gallery entries should depend on",
+      "log_le_two_mul_sqrt: the reusable elementary estimate log x ≤ 2√x (x ≥ 0) that powers both error-term absorptions",
+      "Repaired the broken prerequisite chain for Mathlib v4.26: Erdos31PrimesDensity.lean (Real.log_prod now takes implicit s/f; Nat.lt_succ_sqrt' returns succ²; Finset.range base case via decide; nlinarith/Function.comp_apply fixes) and ChebyshevPNTBridgeOQ02.lean (Nat.eq_or_gt_of_le → Nat.eq_zero_or_pos)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 229,
+    "assumptions": "None — fully verified from Mathlib and the parent bridge files with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The clean order constants are deliberately loose (c₁ = 2/5 < log 2 ≈ 0.693, c₂ = 2·log 4 + 4 ≈ 6.77) so that the bounds hold uniformly without an o(1) term; the sharp Chebyshev constants 0.921 / 1.106 and the full PNT limit π(x)·log x / x → 1 remain separate open questions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 memoir established that π(x) has the right order of magnitude — squeezed between two constant multiples of x/log x — decades before Hadamard and de la Vallée Poussin proved the sharp Prime Number Theorem π(x) ~ x/log x in 1896. The two-sided estimate is the quantitative backbone of Bertrand's postulate, Mertens' theorems, and elementary prime-density results. In the formalized bridge the two halves were proved separately: the lower density (along even arguments, then all m in OQ-05) and the upper density (via the prime factorization of central binomials, exported through Erdos31PrimesDensity). This entry consolidates them.",
+    "problemStatement": "The lower half π(m)·log m ≥ m·log 2 − o(1) (parent OQ-05) and the upper half π(N) ≤ 2N·log 4/log N + √N + 1 live in separate files. State the two-sided 'π(x) is of order x/log x' as a single citable theorem with explicit constants c₁ ≤ c₂ and a threshold x₀.",
+    "text": "Combines the parent lower bound and the Chebyshev upper bound into an exact two-sided estimate for all m ≥ 2 and a clean order form (2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m) for m ≥ 65.",
+    "proofStrategy": "Part I conjoins the two parent results verbatim (no new analysis). Part II derives the order upper bound: from π(m) ≤ 2m·log 4/log m + √m + 1, absorb the error term using the single estimate log m ≤ 2√m (from log t ≤ t−1 at t = √m) together with √m ≤ m, giving (√m+1)·log m ≤ 2m + 2√m ≤ 4m, hence the +4 in c₂. Part III derives the order lower bound: from ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m, bound ⌊m/2⌋·log 4 ≥ (m−1)·log 2 (since log 4 = 2 log 2) and log(m+1) ≤ 2√(m+1) ≤ m/4 for m ≥ 65; with log 2 > 0.6931471803 the residual (m−1)·log 2 − m/4 ≥ (2/5)·m for all m ≥ 65. Part IV packages the two halves. Dividing/multiplying by log m > 0 moves between the π·log m form and the c·(m/log m) form.",
+    "keyInsights": [
+      "A single elementary estimate log x ≤ 2√x (from log t ≤ t − 1 applied to t = √x) absorbs BOTH error terms: the additive √N + 1 in the upper bound and the subtractive log(m+1) in the lower bound",
+      "Choosing loose constants (c₁ = 2/5, c₂ = 2·log 4 + 4) trades the asymptotically sharp log 2 / 2 log 4 for bounds that hold uniformly with no o(1), making the result a clean drop-in for downstream proofs",
+      "The lower bound needs a threshold (m ≥ 65) only because √(m+1) ≤ m/8 fails for small m; the upper bound needs none since √m ≤ m for all m ≥ 1",
+      "The consolidation required first repairing the broken prerequisite chain (Erdos31PrimesDensity, ChebyshevPNTBridgeOQ02) against Mathlib v4.26 — a reminder that 'verified' gallery files can silently rot under toolchain drift"
+    ],
+    "prerequisites": [
+      "the prime-counting function π and its monotonicity",
+      "the parent OQ-05 Chebyshev lower density",
+      "the Chebyshev upper bound via central-binomial / θ estimates (Erdos31PrimesDensity)",
+      "elementary Real.log and Real.sqrt inequalities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring framing OQ-05·OQ-01: package the separate lower and upper Chebyshev halves into single two-sided theorems, exact and clean-order."
+    },
+    {
+      "id": "helper",
+      "title": "Elementary log/√ estimate",
+      "startLine": 64,
+      "endLine": 86,
+      "summary": "log_le_two_mul_sqrt: log x ≤ 2√x for x ≥ 0, from log t ≤ t − 1 at t = √x. The single tool that absorbs both error terms."
+    },
+    {
+      "id": "exact",
+      "title": "Exact two-sided bound (all m ≥ 2)",
+      "startLine": 88,
+      "endLine": 107,
+      "summary": "primeCounting_two_sided_exact: the verbatim conjunction of the parent lower bound and the Chebyshev upper bound, with their exact error terms."
+    },
+    {
+      "id": "order-upper",
+      "title": "Clean order upper bound",
+      "startLine": 109,
+      "endLine": 150,
+      "summary": "primeCounting_le_order: π(m) ≤ (2·log 4 + 4)·(m/log m) for all m ≥ 2, the √m+1 term absorbed into +4 via log m ≤ 2√m and √m ≤ m."
+    },
+    {
+      "id": "order-lower",
+      "title": "Clean order lower bound",
+      "startLine": 152,
+      "endLine": 205,
+      "summary": "primeCounting_ge_order: (2/5)·(m/log m) ≤ π(m) for m ≥ 65, the −log(m+1) and floor losses absorbed via log(m+1) ≤ m/4 and log 2 > 0.6931471803."
+    },
+    {
+      "id": "packaged",
+      "title": "Packaged two-sided order bound",
+      "startLine": 207,
+      "endLine": 229,
+      "summary": "chebyshev_order_two_sided: the headline (2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m) for m ≥ 65 — the single π(x) = Θ(x/log x) lemma."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) consolidation of Chebyshev's two-sided estimate. The exact form combines the parent halves for all m ≥ 2; the clean order form (2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m) for m ≥ 65 states 'π(x) = Θ(x/log x)' as one citable lemma. A single estimate log x ≤ 2√x absorbs both o(1) error terms into uniform constants.",
+    "implications": "Provides the natural single-lemma API for the two-sided Chebyshev bound that downstream gallery entries (Bertrand, Mertens, prime density) can depend on, rather than importing two one-sided files. The accompanying Mathlib v4.26 repair of Erdos31PrimesDensity and ChebyshevPNTBridgeOQ02 restores the whole upper-bound chain to a compiling state.",
+    "openQuestions": [
+      "Sharpen the loose constants 2/5 and 2·log 4 + 4 toward Chebyshev's original 0.921 / 1.106 by a finer analysis of the central-binomial valuations.",
+      "Extend to a statement over real x ≥ 2 (using π(x) = π(⌊x⌋)) rather than integer m.",
+      "Formalize the full PNT limit π(x)·log x / x → 1 — a separate open question of the parent bridge."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-05",
+      "relationship": "parent",
+      "description": "Direct parent supplying the lower density ⌊m/2⌋·log 4 − log(m+1) ≤ π(m)·log m for all m ≥ 2, conjoined here as the lower half"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-02",
+      "relationship": "uses",
+      "description": "Source of the Chebyshev upper bound π(N) ≤ 2N·log 4/log N + √N + 1 (chebyshev_upper_real), re-exported from the repaired Erdos31PrimesDensity"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "ancestor",
+      "description": "Root of the bridge chain establishing π(x) = Θ(x/log x); this entry packages its two-sided conclusion as a single lemma"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevPNTBridgeOQ02",
+      "Proofs.ChebyshevPNTBridgeOQ05"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "ChebyshevPNTBridgeOQ05OQ01",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPNTBridgeOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Packages the two halves of Chebyshev's pre-PNT estimate into single citable theorems, answering open question **chebyshev-pnt-bridge-oq-05-oq-01**. The Prime Number Theorem says π(x) ~ x/log x; Chebyshev (1852) proved the *order* is correct — π(x) is squeezed between constant multiples of x/log x. The lower half (parent OQ-05) and upper half (the bridge chain via Erdos31PrimesDensity) lived in separate files; this entry consolidates them.

## New file: `proofs/Proofs/ChebyshevPNTBridgeOQ05OQ01.lean` (5 theorems, 0 def)

- **`primeCounting_two_sided_exact`** — verbatim conjunction of the parent lower bound (`OQ05.primeCounting_ge_div_log`) and the Chebyshev upper bound (`OQ02.chebyshev_upper_real`), exact error terms, all `m ≥ 2`.
- **`primeCounting_le_order`** — `π(m) ≤ (2·log 4 + 4)·(m/log m)` for all `m ≥ 2`. The `+4` uniformly absorbs the `√m + 1` error term via `log m ≤ 2√m` and `√m ≤ m`.
- **`primeCounting_ge_order`** — `(2/5)·(m/log m) ≤ π(m)` for `m ≥ 65`. Absorbs `−log(m+1)` and the `⌊m/2⌋` loss via `log(m+1) ≤ 2√(m+1) ≤ m/4` and `log 2 > 0.6931471803`.
- **`chebyshev_order_two_sided`** — the packaged headline `(2/5)·(m/log m) ≤ π(m) ≤ (2·log 4 + 4)·(m/log m)` for `m ≥ 65`: the single "π(x) = Θ(x/log x)" lemma.
- **`log_le_two_mul_sqrt`** — reusable `log x ≤ 2√x`, the single estimate that tames *both* o(1) error terms.

All four exported theorems machine-verified to depend only on `propext / Classical.choice / Quot.sound` — **0 axioms, 0 sorries, no native_decide**.

## Prerequisite repair (Mathlib v4.26 drift)

The upper-bound source did not compile under the repo's current Mathlib and was repaired so the chain (and this entry) builds:

- **`Erdos31PrimesDensity.lean`** — `Real.log_prod` now takes implicit `s`/`f`; `Nat.lt_succ_sqrt'` returns `succ²` shape; empty `Finset.filter` base case via `decide`; `Function.comp_apply` before `ring`; `linarith → nlinarith` (with `1 ≤ √N`) for `(√N.nat+1)·√N ≤ 2N`.
- **`ChebyshevPNTBridgeOQ02.lean`** — removed `Nat.eq_or_gt_of_le` → `Nat.eq_zero_or_pos`.

## Verification

Built per-file with `lake env lean` (Docker was unavailable): the new file and both repaired files elaborate with **0 errors / 0 warnings / 0 sorries**. `#print axioms` on all four exported theorems lists only the standard foundational axioms.

## Gallery

`src/data/proofs/chebyshev-pnt-bridge-oq-05-oq-01/` — `meta.json` (status `verified`, badge `verified`, axiomCount 0), `annotations.json` (6 annotations), `index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)