### PR TITLE
Enrich Abel–Ruffini Obstruction (abel-ruffini-obstruction-oq-06)

### DIFF
--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/annotations.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/annotations.json
@@ -8,7 +8,8 @@
     "content": "The symmetric group on $n$ symbols is **not solvable** for every $n \\ge 5$. Mathlib supplies only the single case `Equiv.Perm.fin_5_not_solvable` (for `Fin 5`); here it is generalized to the whole range by invoking `Equiv.Perm.not_solvable`, whose hypothesis is a *cardinal* bound $5 \\le \\#X$. Rewriting $\\#(\\mathrm{Fin}\\ n) = n$ with `Cardinal.mk_fin` and casting $5 \\le n$ closes it. The mathematical reason it cannot be solvable: any such group contains $S_5$, and the alternating group $A_5$ is a nonabelian simple group equal to its own commutator subgroup, so the derived series stalls and never reaches the trivial subgroup.",
     "mathContext": "$\\neg\\,\\mathrm{IsSolvable}(S_n)$ for all $n \\ge 5$.",
     "significance": "key",
-    "relatedConcepts": ["Solvable group", "Derived series", "Simple group A₅", "Symmetric group"]
+    "relatedConcepts": ["Solvable group", "Derived series", "Simple group A₅", "Symmetric group"],
+    "prerequisites": ["group theory: derived/commutator series", "simplicity of A₅", "cardinality of finite types (Cardinal.mk_fin)"]
   },
   {
     "id": "ann-s2-solvable",
@@ -16,10 +17,23 @@
     "range": { "startLine": 68, "endLine": 69 },
     "type": "theorem",
     "title": "S₂ Solvable (Abelian Endpoint)",
-    "content": "The low endpoint of the threshold: $S_2$ is cyclic of order two, hence abelian, hence solvable, via `isSolvable_of_comm` with commutativity discharged by `decide`. Together with the $n \\ge 5$ result this pins both ends of the Abel–Ruffini frontier — solvability of $S_n$ is *exactly* what separates the radically-solvable low degrees (1–4) from the unsolvable ones.",
+    "content": "The low endpoint of the threshold: $S_2$ is cyclic of order two, hence abelian, hence solvable, via `isSolvable_of_comm` with commutativity discharged by `decide`. Together with the $n \\ge 5$ result this pins both ends of the Abel–Ruffini frontier — solvability of $S_n$ is *exactly* what separates the radically-solvable low degrees (1–4) from the unsolvable ones. The `decide` here is *kernel* decidability (not `native_decide`), so it introduces no `Lean.ofReduceBool` and the entry remains genuinely axiom-free.",
     "mathContext": "$\\mathrm{IsSolvable}(S_2)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Abelian group", "Solvable group", "Decidability"]
+    "relatedConcepts": ["Abelian group", "Solvable group", "Decidability"],
+    "prerequisites": ["abelian ⟹ solvable (isSolvable_of_comm)", "kernel decidability vs native_decide"]
+  },
+  {
+    "id": "ann-symmetric-threshold",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": { "startLine": 79, "endLine": 82 },
+    "type": "theorem",
+    "title": "The Symmetric Threshold (Both Endpoints)",
+    "content": "`symmetric_threshold` bundles the two endpoint facts into one statement: $S_2$ is solvable while $S_n$ is not solvable for any $n \\ge 5$. This is the group-theoretic skeleton of Abel–Ruffini made explicit — solvability of the symmetric group is precisely the dividing line between the radically-solvable degrees ($n \\le 4$: linear, quadratic, Cardano, Ferrari) and the radically-unsolvable degrees ($n \\ge 5$). The proof is a trivial pairing of the two preceding theorems; its value is documentary, stating the frontier as a single mathematical object.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_2) \\,\\wedge\\, \\forall n \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Solvable group", "Abel–Ruffini threshold", "Symmetric group", "Radical solvability"],
+    "prerequisites": ["the two endpoint theorems above", "solvable Galois group ⟺ solvable by radicals (context)"]
   },
   {
     "id": "ann-radical-criterion",
@@ -30,6 +44,19 @@
     "content": "The Galois bridge from groups to equations: if $\\alpha$ is a root of an **irreducible** polynomial $q \\in F[X]$ whose Galois group $\\mathrm{Gal}(q)$ is **not solvable**, then $\\alpha$ is **not solvable by radicals** over $F$. This is the contrapositive of Mathlib's `solvableByRad.isSolvable'` (radicals $\\Rightarrow$ solvable Galois group) and is the precise implication used to certify a concrete unsolvable quintic: exhibit an irreducible degree-5 polynomial with Galois group $S_5$ (unsolvable by the theorem above), and its roots provably cannot be written with radicals.",
     "mathContext": "$\\neg\\,\\mathrm{IsSolvable}(q.\\mathrm{Gal}) \\Rightarrow \\neg\\,\\mathrm{IsSolvableByRad}\\ F\\ \\alpha$ for irreducible $q$ with $q(\\alpha)=0$.",
     "significance": "key",
-    "relatedConcepts": ["Galois group", "Solvability by radicals", "Irreducible polynomial", "Contrapositive"]
+    "relatedConcepts": ["Galois group", "Solvability by radicals", "Irreducible polynomial", "Contrapositive"],
+    "prerequisites": ["Galois theory: Gal(q) and the fundamental correspondence", "solvable group ⟺ radical solvability", "irreducibility in F[X]"]
+  },
+  {
+    "id": "ann-converse-criterion",
+    "proofId": "abel-ruffini-obstruction-oq-06",
+    "range": { "startLine": 116, "endLine": 119 },
+    "type": "theorem",
+    "title": "Converse: Radicals Force a Solvable Galois Group",
+    "content": "`solvable_gal_of_solvableByRad` re-exposes the forward direction of Galois' theorem under a local name: a root $\\alpha$ that *is* solvable by radicals, being a root of irreducible $q$, forces $\\mathrm{Gal}(q)$ to be solvable. It is definitionally Mathlib's `solvableByRad.isSolvable'`; stating it here lets the criterion and its converse sit side by side, making the underlying equivalence (radical solvability $\\Leftrightarrow$ solvable Galois group) visible as two implications used for opposite purposes — one to *prove impossibility*, the other to *extract structure*.",
+    "mathContext": "$\\mathrm{IsSolvableByRad}\\ F\\ \\alpha \\Rightarrow \\mathrm{IsSolvable}(q.\\mathrm{Gal})$ for irreducible $q$ with $q(\\alpha)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Galois group", "Solvability by radicals", "Logical equivalence", "Galois correspondence"],
+    "prerequisites": ["Galois theory", "solvableByRad.isSolvable'", "contrapositive vs direct implication"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
@@ -57,6 +57,18 @@
     "theoremCount": 5,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "The impossibility of a general radical formula for the quintic is one of the oldest deep results in algebra. Paolo Ruffini gave a long, incomplete argument in 1799; Niels Henrik Abel produced the first essentially complete proof in 1824, working before the group concept existed. Évariste Galois, in the manuscripts written before his death in 1832, supplied the conceptual explanation that subsumes both: a polynomial is solvable by radicals if and only if its Galois group is a solvable group. The obstruction for n ≥ 5 is then a purely group-theoretic fact — the symmetric group Sₙ fails to be solvable — which Galois traced to the simplicity of the alternating group A₅. Camille Jordan and later authors made the structure theory precise; the modern statement (radical solvability ⟺ solvable Galois group) is the form formalized in Mathlib's FieldTheory.AbelRuffini, on which this file builds.",
+    "problemStatement": "Show, fully machine-checked, the group-theoretic core of Abel–Ruffini: the symmetric group $S_n$ is not solvable for every $n \\ge 5$ (not merely $n = 5$), while $S_2$ is solvable, and convert this into the usable polynomial criterion that a root of an irreducible $q \\in F[X]$ with non-solvable Galois group is not expressible by radicals.",
+    "proofStrategy": "Two moves. (1) Generalize Mathlib's single-case Equiv.Perm.fin_5_not_solvable to all n ≥ 5 by routing through the cardinal-indexed Equiv.Perm.not_solvable: rewrite #(Fin n) = n via Cardinal.mk_fin and cast the bound 5 ≤ n. The low endpoint S₂ is handled by isSolvable_of_comm with commutativity settled by kernel decide. (2) Take the contrapositive of Mathlib's solvableByRad.isSolvable' to obtain not_solvableByRad_of_not_solvable_gal — the bridge that turns the group obstruction into a statement about actual polynomial roots.",
+    "keyInsights": [
+      "Solvability of the symmetric group is the *exact* frontier of radical solvability: Sₙ solvable ⟺ n ≤ 4, so the threshold sits precisely between degree 4 (Ferrari) and degree 5. symmetric_threshold pins both endpoints in a single statement.",
+      "The non-solvability is uniform in n: rather than re-proving each degree, one cardinal argument (Cardinal.mk_fin converting #(Fin n) = n) discharges the entire range n ≥ 5 at once, where Mathlib only ships the Fin 5 instance.",
+      "The deep content is hidden in Mathlib's Equiv.Perm.not_solvable: A₅ is a nonabelian simple group equal to its own commutator subgroup, so the derived series stalls and never reaches the trivial group — that is the irreducible reason no radical formula can exist.",
+      "The Galois bridge is a one-line contrapositive: non-solvable Galois group ⟹ root not solvable by radicals. This abstract criterion is what every concrete unsolvable-quintic certificate (e.g. an irreducible degree-5 polynomial with Galois group S₅) actually invokes.",
+      "Separating the criterion (not_solvableByRad_of_not_solvable_gal) from its converse (solvable_gal_of_solvableByRad) makes the logical structure of Galois' theorem explicit: the two implications are distinct directions of the same equivalence, used for opposite purposes (proving impossibility vs. extracting structure)."
+    ]
+  },
   "sections": [
     {
       "id": "symmetric-obstruction",
@@ -71,6 +83,32 @@
       "startLine": 84,
       "endLine": 120,
       "summary": "not_solvableByRad_of_not_solvable_gal: a root of an irreducible q with non-solvable Galois group is not solvable by radicals — the contrapositive of Mathlib's solvableByRad.isSolvable'. solvable_gal_of_solvableByRad re-exposes the forward direction. Together they are the Galois bridge from the symmetric-group obstruction to actual polynomial equations."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 121-line, axiom-free, sorry-free file isolates the group-theoretic heart of Abel–Ruffini and makes it directly usable. It proves the symmetric group Sₙ is not solvable for every n ≥ 5 (symmetricGroup_not_solvable, a uniform-in-n generalization of Mathlib's Fin-5-only instance), that S₂ is solvable, and packages both endpoints in symmetric_threshold. It then states the Abel–Ruffini criterion not_solvableByRad_of_not_solvable_gal — non-solvable Galois group implies a root not expressible by radicals — as the contrapositive of Mathlib's solvableByRad.isSolvable', with the converse re-exposed alongside it.",
+    "implications": "The criterion is the reusable engine for certifying concrete unsolvable polynomials: any irreducible degree-n polynomial (n ≥ 5) whose Galois group contains a non-solvable symmetric group has roots provably not expressible by radicals. Combined with a route that pins a specific polynomial's Galois group to S₅ — such as the discriminant/Jordan argument for X⁵ − X − 1 — it yields a fully formal proof that a named quintic has no radical solution. The uniform n ≥ 5 statement also means no per-degree re-proof is ever needed downstream.",
+    "openQuestions": [
+      "Formalize a self-contained construction of an irreducible quintic with Galois group exactly S₅ (e.g. via the discriminant being a non-square plus a transposition from a single real pair of complex roots), so an end-to-end 'this specific polynomial is unsolvable by radicals' theorem chains directly off this criterion.",
+      "Extend the solvable side to the full threshold by formalizing solvability of S₃ and S₄ (and hence the existence of the Cardano and Ferrari radical formulas), completing the 'Sₙ solvable ⟺ n ≤ 4' equivalence rather than only its two endpoints.",
+      "Address the characteristic-p story left out of scope: radical solvability in positive characteristic interacts with wild ramification and inseparability, and the Abhyankar conjecture (Raynaud–Harbater) on Galois groups of covers of curves lies far beyond the characteristic-independent core formalized here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-07-discriminant",
+      "relationship": "related",
+      "description": "Supplies a concrete input to this file's criterion: the discriminant/Jordan route showing X⁵ − X − 1 has Galois group S₅. Combined with not_solvableByRad_of_not_solvable_gal and symmetricGroup_not_solvable, it certifies that specific quintic as unsolvable by radicals."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "extends",
+      "description": "The base Abel–Ruffini gallery entry. This file sharpens the group-theoretic obstruction to a uniform statement for all n ≥ 5 and exposes the radical-solvability criterion as a standalone reusable lemma."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "related",
+      "description": "Companion development of the surrounding Galois machinery (extensions, fixed fields, the Galois correspondence) that underlies the radical-solvability equivalence invoked here."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-obstruction-oq-06` — the group-theoretic core of Abel–Ruffini (Sₙ unsolvable for n ≥ 5; the radical-solvability criterion).

## Gaps addressed
The entry had solid `meta.meta` + 2 sections + 3 annotations, but **no `overview`, no `conclusion`, and no `crossReferences`**, and annotations lacked `prerequisites`.

## Changes
**meta.json**
- **overview**: historicalContext (Ruffini 1799 → Abel 1824 → Galois, A₅ simplicity, Mathlib's FieldTheory.AbelRuffini), problemStatement, proofStrategy, and 5 keyInsights (the Sₙ-solvable ⟺ n ≤ 4 frontier; uniform-in-n via `Cardinal.mk_fin`; A₅ perfect/simple as the real obstruction; the one-line Galois contrapositive; criterion vs converse as two directions of one equivalence).
- **conclusion**: summary, implications (criterion as the engine for certifying concrete unsolvable quintics), and 3 openQuestions (end-to-end named-quintic theorem; formalizing S₃/S₄ solvability for the full threshold; the out-of-scope characteristic-p / Abhyankar story).
- **crossReferences**: `abel-ruffini-oq-07-discriminant` (concrete S₅ quintic X⁵−X−1 — a direct input to this file's criterion), `abel-ruffini` (base), `abel-ruffini-galois-extensions` (companion machinery). All three targets verified present.

**annotations.json**
- Expanded 3 → 5 annotations: added `symmetric_threshold` (both endpoints) and `solvable_gal_of_solvableByRad` (the converse).
- Added `prerequisites` to all five.
- Noted in the S₂ annotation that the `decide` is kernel decidability (not `native_decide`), so no `Lean.ofReduceBool` — consistent with the entry's axiom-free / status:verified claim.

## Validation
`pnpm annotations:build` reports **0 errors for this proof**; both JSON files parse. (Full `pnpm build` is blocked only by an unrelated env issue — better-sqlite3 native build fails, so the sqlite-backed `research:build` step can't emit its generated listings — independent of this content change.)