### PR TITLE
Enrich Radical-Solvable Side of Abel–Ruffini: add overview, conclusion, annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-11/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-11/annotations.json
@@ -1,35 +1,50 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "abel-ruffini-oq-11",
+    "range": { "startLine": 3, "endLine": 38 },
+    "type": "context",
+    "title": "Setup: The Two Faces of Abel–Ruffini",
+    "content": "The docstring frames the entry against the negative face of Abel–Ruffini — Sₙ unsolvable for n ≥ 5, hence the general quintic is not solvable by radicals — which is formalized elsewhere in this project (AbelRuffini.lean, and AbelRuffiniOQ07 for the concrete X⁵ − X − 1 ≅ S₅). The positive face addressed here is Galois' answer to 'why do radicals work for the cases they do': by Galois' criterion an equation is solvable by radicals iff its Galois group is solvable, and the polynomials one can write with radicals (pure powers Xⁿ = a and their finite combinations) always have solvable groups. Mathlib provides the single-equation facts and an abstract multiset product but neither a usable finite-product form nor the side-by-side dichotomy; both are supplied below. The file imports only Mathlib and opens Polynomial over a field F.",
+    "mathContext": "Galois' criterion: solvable by radicals $\\iff$ solvable Galois group. Positive face: pure powers and their products have solvable groups.",
+    "significance": "context",
+    "relatedConcepts": ["Abel–Ruffini theorem", "Galois' criterion", "solvable group", "solvability by radicals", "symmetric group obstruction"],
+    "prerequisites": ["Galois theory and the Galois group of a polynomial", "solvable groups", "the unsolvability of Sₙ for n ≥ 5"]
+  },
+  {
     "id": "ann-single",
     "proofId": "abel-ruffini-oq-11",
     "range": { "startLine": 43, "endLine": 51 },
     "type": "theorem",
     "title": "Pure Equations Are Solvable",
-    "content": "Every pure equation $X^n = a$ has a solvable Galois group (`gal_pow_sub_C_isSolvable`), as do the $n$-th roots of unity $X^n = 1$ (`gal_pow_sub_one_isSolvable`). These are the atoms of the radical-solvable side: a single root extraction never destroys solvability. By Galois' criterion this is exactly why $\\sqrt[n]{a}$ is, tautologically, expressible by radicals.",
+    "content": "Every pure equation $X^n = a$ has a solvable Galois group (`gal_pow_sub_C_isSolvable`), as do the $n$-th roots of unity $X^n = 1$ (`gal_pow_sub_one_isSolvable`). These are the atoms of the radical-solvable side: a single root extraction never destroys solvability. By Galois' criterion this is exactly why $\\sqrt[n]{a}$ is, tautologically, expressible by radicals. Both re-expose Mathlib's gal_X_pow_sub_C_isSolvable / gal_X_pow_sub_one_isSolvable as named building blocks; the roots-of-unity group is in fact abelian (a subgroup of the cyclotomic units), hence solvable a fortiori.",
     "mathContext": "$\\mathrm{IsSolvable}((X^n - a).\\mathrm{Gal})$ and $\\mathrm{IsSolvable}((X^n - 1).\\mathrm{Gal})$.",
     "significance": "supporting",
-    "relatedConcepts": ["Galois group", "Solvable group", "Roots of unity", "Radical extension"]
+    "relatedConcepts": ["Galois group", "solvable group", "roots of unity", "radical extension", "cyclotomic field"],
+    "prerequisites": ["the Galois group of Xⁿ − a", "abelian ⟹ solvable", "Mathlib's single-equation AbelRuffini lemmas"]
   },
   {
     "id": "ann-closure",
     "proofId": "abel-ruffini-oq-11",
-    "range": { "startLine": 58, "endLine": 69 },
+    "range": { "startLine": 53, "endLine": 65 },
     "type": "theorem",
     "title": "The Radical-Solvable Closure (new)",
-    "content": "**Any finite product $\\prod_{i\\in s}(X^{n_i} - a_i)$ of pure radical equations has a solvable Galois group.** This is the constructive counterpart to the symmetric-group obstruction — everything one can assemble from root extractions stays solvable. Proved by `Finset.cons_induction`: the empty product is $1$ (solvable), and each new factor $X^{n_i} - a_i$ is glued onto the solvable product with `gal_mul_isSolvable`. Mathlib gives only the single-equation fact and an abstract multiset product; this directly usable indexed finite-product form is new.",
-    "mathContext": "$\\mathrm{IsSolvable}\\bigl((\\textstyle\\prod_{i\\in s}(X^{n_i} - a_i)).\\mathrm{Gal}\\bigr)$.",
+    "content": "**Any finite product $\\prod_{i\\in s}(X^{n_i} - a_i)$ of pure radical equations has a solvable Galois group.** This is the constructive counterpart to the symmetric-group obstruction — everything one can assemble from root extractions stays solvable. Proved by `Finset.cons_induction`: the empty product is $1$, solvable by gal_one_isSolvable, and each new factor $X^{n_i} - a_i$ is glued onto the solvable running product with `gal_mul_isSolvable` (p.Gal, q.Gal solvable ⟹ (p·q).Gal solvable). Mathlib gives only the single-equation fact and an abstract multiset product gal_prod_isSolvable; this directly usable indexed finite-product form, polymorphic in the index type ι, is the entry's new content.",
+    "mathContext": "$\\mathrm{IsSolvable}\\bigl((\\textstyle\\prod_{i\\in s}(X^{n_i} - a_i)).\\mathrm{Gal}\\bigr)$ for any finite $s$.",
     "significance": "key",
-    "relatedConcepts": ["Galois group", "Solvable group", "Finite product", "Closure property", "Induction"]
+    "relatedConcepts": ["Galois group", "solvable group", "closure under products", "Finset.cons_induction", "gal_mul_isSolvable"],
+    "prerequisites": ["solvability closed under polynomial multiplication", "induction over a Finset", "the single-equation base case"]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "abel-ruffini-oq-11",
-    "range": { "startLine": 71, "endLine": 76 },
+    "range": { "startLine": 67, "endLine": 76 },
     "type": "theorem",
     "title": "The Two Faces of Abel–Ruffini",
-    "content": "The dichotomy in one statement: pure radical equations $X^n = a$ always have solvable Galois groups (radicals succeed), yet $S_m$ is not solvable for $m \\ge 5$ (the obstruction making the general quintic unsolvable). The entire theory of solvability by radicals lives in the gap between these two facts.",
+    "content": "The dichotomy in one statement: pure radical equations $X^n = a$ always have solvable Galois groups (radicals succeed), yet $S_m$ is not solvable for $m \\ge 5$ (the obstruction making the general quintic unsolvable). The proof pairs gal_X_pow_sub_C_isSolvable with `Equiv.Perm.not_solvable (Fin m)`, the cardinality hypothesis 5 ≤ #(Fin m) coming from `Cardinal.mk_fin`. The entire theory of solvability by radicals lives in the gap between these two facts: the general quintic's group is Sₙ, which escapes the radical-solvable closure exactly at n = 5.",
     "mathContext": "$(\\forall n\\,a,\\ \\mathrm{IsSolvable}((X^n - a).\\mathrm{Gal})) \\wedge (\\forall m \\ge 5,\\ \\neg\\,\\mathrm{IsSolvable}(S_m))$.",
     "significance": "key",
-    "relatedConcepts": ["Abel–Ruffini theorem", "Solvability by radicals", "Symmetric group", "Dichotomy"]
+    "relatedConcepts": ["Abel–Ruffini theorem", "solvability by radicals", "symmetric group Sₘ", "Equiv.Perm.not_solvable", "dichotomy"],
+    "prerequisites": ["the radical-solvable side above", "non-solvability of Sₘ for m ≥ 5", "Cardinal.mk_fin"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-11/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-11/meta.json
@@ -57,6 +57,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "§0: Imports and the Two Faces of Abel–Ruffini",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Imports Mathlib and opens Polynomial over a field F. The docstring frames the entry: the negative face of Abel–Ruffini (Sₙ unsolvable for n ≥ 5, formalized elsewhere in AbelRuffini.lean / AbelRuffiniOQ07 for X⁵ − X − 1 ≅ S₅) versus the comparatively neglected positive face — why radicals succeed. Galois' criterion (solvable by radicals ⇔ solvable Galois group) makes the positive side the statement that pure powers and their finite combinations always have solvable groups; Mathlib has the single-equation facts and an abstract multiset product but not the usable finite-product form or the dichotomy, both supplied here.",
+      "mathContext": "Galois' criterion: an equation is solvable by radicals iff its Galois group is a solvable group."
+    },
+    {
       "id": "single-equations",
       "title": "Single Pure Equations",
       "startLine": 42,
@@ -77,5 +85,78 @@
       "endLine": 76,
       "summary": "abel_ruffini_two_faces: pure radical equations Xⁿ = a always have solvable Galois groups, yet Sₘ (m ≥ 5) is not solvable — the dichotomy underlying the unsolvability of the general quintic, in a single statement."
     }
-  ]
+  ],
+  "overview": {
+    "historicalContext": "Whether the general quintic could be solved by radicals was open for nearly three centuries after the cubic and quartic were cracked by del Ferro, Cardano, and Ferrari in the 1500s. Paolo Ruffini gave a largely-correct but incomplete proof of impossibility in 1799; Niels Henrik Abel completed it in 1824 (the Abel–Ruffini theorem). Évariste Galois, in manuscripts from the early 1830s, recast the whole question group-theoretically: an equation is solvable by radicals if and only if its Galois group is a solvable group. The unsolvability of the general quintic then reduces to the single group-theoretic fact that the symmetric group Sₙ is not solvable for n ≥ 5 (its only proper nontrivial normal subgroup Aₙ is simple and nonabelian). Most formal developments — including this project's AbelRuffini base file — emphasize this negative face. The positive face, that the equations expressible by radicals have solvable groups, is the constructive complement formalized here.",
+    "problemStatement": "Formalize the radical-solvable (positive) side of Abel–Ruffini: prove that pure equations Xⁿ = a and Xⁿ = 1 have solvable Galois groups, extend this to a directly usable finite-product closure — any ∏_{i∈s}(X^{nᵢ} − aᵢ) has a solvable Galois group — and package the dichotomy (radical equations always solvable vs Sₘ unsolvable for m ≥ 5) in one statement.",
+    "proofStrategy": "Four theorems built on Mathlib's AbelRuffini infrastructure. (1) gal_pow_sub_C_isSolvable and (2) gal_pow_sub_one_isSolvable simply re-expose Mathlib's single-equation facts gal_X_pow_sub_C_isSolvable / gal_X_pow_sub_one_isSolvable as named building blocks. (3) gal_finset_prod_pow_sub_C_isSolvable is the genuinely new content: a `Finset.cons_induction` over the index set s, with the empty product = 1 solvable (gal_one_isSolvable) as base case, and each new factor glued onto the solvable running product by gal_mul_isSolvable (which says p.Gal, q.Gal solvable ⟹ (p·q).Gal solvable). (4) abel_ruffini_two_faces conjoins the positive direction with the negative one, the latter from Equiv.Perm.not_solvable applied to Fin m once Cardinal.mk_fin gives 5 ≤ #(Fin m).",
+    "keyInsights": [
+      "Galois' criterion turns 'solvable by radicals' into a purely group-theoretic property of the Galois group, so the positive side of Abel–Ruffini becomes: the polynomials you can write with radicals have solvable groups. The entry makes this concrete by exhibiting those polynomials (pure powers and their products) and proving solvability directly.",
+      "The finite-product closure is the conceptual payoff: solvability of Galois groups is closed under multiplication of polynomials (gal_mul_isSolvable), so 'anything assembled from radical equations stays solvable'. Mathlib had only the single-equation case and an abstract multiset product; the indexed Finset product proved here is the form a user actually reaches for.",
+      "Stating the closure by `Finset.cons_induction` (rather than over multisets) gives a clean two-case proof — empty product is the solvable unit, cons glues one factor — and keeps the result polymorphic in the index type ι.",
+      "Putting both faces in one theorem (abel_ruffini_two_faces) dramatizes that the entire theory of solvability by radicals lives in the gap between 'pure radical equations are always solvable' and 'S₅ is not solvable': the general quintic's Galois group is Sₙ, which escapes the radical-solvable closure exactly at n = 5.",
+      "The whole positive side is 0-axiom and rests only on Mathlib's existing solvable-group and Galois-group API — no new axioms, no native_decide — showing the constructive complement was a packaging gap rather than a missing hard theorem."
+    ],
+    "prerequisites": [
+      "Galois theory: the Galois group of a polynomial and Galois' solvability criterion",
+      "solvable groups and their closure properties (subgroups, quotients, extensions)",
+      "Mathlib's AbelRuffini API: gal_X_pow_sub_C_isSolvable, gal_mul_isSolvable",
+      "the non-solvability of Sₙ for n ≥ 5 (Equiv.Perm.not_solvable)",
+      "induction over a Finset via Finset.cons_induction"
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalizes the radical-solvable (positive) side of Abel–Ruffini with 0 axioms and 0 sorries: pure equations Xⁿ = a and Xⁿ = 1 have solvable Galois groups (gal_pow_sub_C_isSolvable, gal_pow_sub_one_isSolvable), any finite product ∏ᵢ(X^{nᵢ} − aᵢ) of pure radical equations has a solvable Galois group (gal_finset_prod_pow_sub_C_isSolvable, the new content), and the dichotomy with the Sₘ obstruction is stated in one theorem (abel_ruffini_two_faces).",
+    "implications": "Completes the gallery's Abel–Ruffini picture by recording the constructive complement to the heavily-formalized unsolvability results: it pins down exactly which Galois groups arise from radicals (solvable ones) and gives a reusable finite-product closure lemma that downstream solvability arguments can cite directly, rather than re-deriving from the single-equation case or the abstract multiset product. The side-by-side dichotomy clarifies that the unsolvability of the quintic is precisely the failure of the general equation's group (Sₙ, n ≥ 5) to lie in the radical-solvable closure.",
+    "openQuestions": [
+      "Prove the converse closure direction: if a polynomial's Galois group is solvable then it is solvable by radicals (the full strength of Galois' criterion), making the positive side an iff.",
+      "Connect the finite-product closure to a formal notion of 'radical tower' / solvable field extension, showing the polynomials with solvable group are exactly those split by an iterated-radical extension.",
+      "Give an explicit radical-solvability witness (a radical expression for the roots) for the solvable cases, not just solvability of the abstract group.",
+      "Extend abel_ruffini_two_faces to exhibit a specific solvable-by-radicals quintic alongside the unsolvable general one, sharpening the dichotomy into a concrete boundary."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "extends",
+      "description": "Base entry formalizing the negative face (Sₙ unsolvable for n ≥ 5, general quintic not solvable by radicals). This entry supplies the complementary positive face — why radicals succeed for the cases they do."
+    },
+    {
+      "targetId": "abel-ruffini-oq-07",
+      "relationship": "related",
+      "description": "Sibling giving the concrete obstruction X⁵ − X − 1 with Galois group S₅; the explicit unsolvable instance against which this entry's radical-solvable closure is the counterpart."
+    }
+  ],
+  "references": [
+    {
+      "author": "Abel, N. H.",
+      "title": "Mémoire sur les équations algébriques où l'on démontre l'impossibilité de la résolution de l'équation générale du cinquième degré",
+      "year": 1824,
+      "note": "Abel's completion of the impossibility proof for the general quintic"
+    },
+    {
+      "author": "Galois, É.",
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": 1831,
+      "note": "Galois' criterion: solvability by radicals ⇔ solvable Galois group, the foundation of both faces"
+    },
+    {
+      "author": "Stewart, I.",
+      "title": "Galois Theory (4th ed.)",
+      "year": 2015,
+      "note": "Standard modern treatment of the Galois correspondence, solvable groups, and the Abel–Ruffini theorem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "AbelRuffiniOQ11",
+    "lineCount": 77,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AbelRuffiniOQ11.lean",
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-11` (quality 48, passes 0) — the constructive positive side of Abel–Ruffini: pure radical equations and their finite products have solvable Galois groups.

## Gaps addressed
The entry had description + originalContributions + 3 sections/annotations but was missing the entire `overview`, `conclusion`, `crossReferences`, `references`, and `leanFile` blocks, plus preamble coverage and annotation prerequisites.

## Changes
**meta.json**
- **overview**: historicalContext (Ruffini 1799, Abel 1824, Galois' 1830s criterion), problemStatement, proofStrategy, 5 keyInsights, prerequisites.
- **conclusion**: summary, implications, 4 openQuestions.
- **crossReferences**: base `abel-ruffini` (extends) and sibling `abel-ruffini-oq-07` (related, the X⁵−X−1 ≅ S₅ obstruction).
- **references**: Abel 1824, Galois 1831, Stewart.
- **leanFile** block + new **preamble** section (L1–41).

**annotations.json** — grew 3 → 4 (added setup context annotation), added `prerequisites` to all four, and deepened the closure/dichotomy entries (gal_mul_isSolvable, Cardinal.mk_fin).

## Verification
- `pnpm annotations:build` — clean, **no anchor warnings** for this proof.
- meta.json/annotations.json JSON validated.
- Axiom integrity preserved: status `verified`, badge `original`, axiomCount 0 — accurate (only foundational axioms; no native_decide; imports only Mathlib).

Note: pushed from `feature/enricher-1-abel-oq11` to avoid contention on the shared branch.