### PR TITLE
Enrich The Monotone Birthday Paradox (birthday-problem-oq-02-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-definitions",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 41, "endLine": 48 },
+    "type": "definition",
+    "title": "All-Distinct and Collision Probabilities",
+    "content": "Two definitions set the stage. `birthdayProduct k d` $= \\prod_{i<k}\\bigl(1 - \\tfrac{i}{d}\\bigr)$ is the probability that all $k$ birthdays are distinct among $d$ equally likely days — equivalently the falling factorial $d^{\\underline{k}}/d^k$, since the $(i{+}1)$-th person has $d-i$ unused days out of $d$. `collisionProb k d` $= 1 - \\text{birthdayProduct}\\,k\\,d$ is its complement, the probability that at least two people share a birthday. Both are `noncomputable` reals because the factors involve real division.",
+    "mathContext": "$P(\\text{distinct}) = \\prod_{i<k}\\bigl(1 - \\tfrac{i}{d}\\bigr) = \\dfrac{d^{\\underline{k}}}{d^k}, \\quad \\text{collisionProb} = 1 - P(\\text{distinct}).$",
+    "significance": "context",
+    "relatedConcepts": ["Falling factorial", "Complementary event", "Uniform distribution"],
+    "prerequisites": ["Finite products over Finset.range", "Probability of a complementary event"]
+  },
+  {
     "id": "ann-recurrence",
     "proofId": "birthday-problem-oq-02-oq-01-oq-03",
     "range": { "startLine": 50, "endLine": 55 },
@@ -8,28 +20,67 @@
     "content": "The product form $P(\\text{all distinct}) = \\prod_{i<k}\\bigl(1 - \\tfrac{i}{d}\\bigr)$ satisfies $P(k+1) = P(k)\\cdot\\bigl(1 - \\tfrac{k}{d}\\bigr)$, peeling the top factor with `Finset.prod_range_succ`. The new factor $1 - k/d$ is the conditional probability that the $(k{+}1)$-th person avoids the first $k$ birthdays. This single recurrence drives all the monotonicity below.",
     "mathContext": "$P(k+1) = P(k)\\,(1 - k/d)$.",
     "significance": "supporting",
-    "relatedConcepts": ["Falling factorial", "Conditional probability", "Telescoping product"]
+    "relatedConcepts": ["Falling factorial", "Conditional probability", "Telescoping product"],
+    "prerequisites": ["Finset.prod_range_succ", "Conditional probability of avoidance"]
+  },
+  {
+    "id": "ann-factor-bounds",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 56, "endLine": 84 },
+    "type": "theorem",
+    "title": "Each Factor Lives in [0,1]",
+    "content": "The whole argument turns on two cheap bounds on the avoidance factor. `factor_nonneg`: for $i \\le d$, $0 \\le 1 - i/d$ (since $i/d \\le 1$). `factor_le_one`: $1 - i/d \\le 1$ always (since $i/d \\ge 0$). Feeding these to `Finset.prod_nonneg` and `Finset.prod_le_one` gives `birthdayProduct_nonneg` and `birthdayProduct_le_one`: the all-distinct probability lies in $[0,1]$ for $k \\le d+1$. These are exactly the hypotheses the monotonicity step and the probability-axiom facts consume.",
+    "mathContext": "$i \\le d \\Rightarrow 0 \\le 1 - \\tfrac{i}{d} \\le 1 \\;\\Rightarrow\\; 0 \\le \\prod_{i<k}\\bigl(1 - \\tfrac{i}{d}\\bigr) \\le 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Bounded factors", "Finset.prod_nonneg", "Finset.prod_le_one"],
+    "prerequisites": ["div_le_one and casting ℕ → ℝ", "Products of factors in [0,1]"]
   },
   {
     "id": "ann-step",
     "proofId": "birthday-problem-oq-02-oq-01-oq-03",
-    "range": { "startLine": 88, "endLine": 97 },
+    "range": { "startLine": 86, "endLine": 96 },
     "type": "theorem",
     "title": "One Person Can Only Lower P(all distinct)",
-    "content": "For $k \\le d$, $P(k+1) \\le P(k)$: the recurrence multiplies the nonnegative quantity $P(k)$ by the factor $1 - k/d \\in [0,1]$, which cannot increase it (`mul_le_mul_of_nonneg_left`). This is the inductive step behind the global monotonicity.",
-    "mathContext": "$P(k+1) \\le P(k)$ for $k \\le d$.",
+    "content": "For $k \\le d$, $P(k+1) \\le P(k)$: the recurrence multiplies the nonnegative quantity $P(k)$ by the factor $1 - k/d \\in [0,1]$, which cannot increase it (`mul_le_mul_of_nonneg_left`). This is the inductive step behind the global monotonicity. Notice the birthday-specific value $k/d$ never matters — only that the factor sits in $[0,1]$.",
+    "mathContext": "$P(k+1) = P(k)\\,(1 - k/d) \\le P(k)\\cdot 1 = P(k)$ for $k \\le d$.",
     "significance": "key",
-    "relatedConcepts": ["Monotonicity", "Nonnegative product"]
+    "relatedConcepts": ["Monotonicity", "Nonnegative product", "Survival product"],
+    "prerequisites": ["mul_le_mul_of_nonneg_left", "birthdayProduct_succ recurrence"]
+  },
+  {
+    "id": "ann-antitone",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 97, "endLine": 105 },
+    "type": "theorem",
+    "title": "Globalizing via Nat.le_induction",
+    "content": "`birthdayProduct_antitone` lifts the one-step bound to the whole range: if $j \\le k \\le d$ then $P(k) \\le P(j)$. The proof is `Nat.le_induction` starting from the base $j$; the base case is reflexivity and the successor case chains the one-step bound $P(k{+}1) \\le P(k)$ with the inductive hypothesis $P(k) \\le P(j)$ by transitivity. This is the standard 'one step ⇒ all steps' upgrade for a monotone sequence.",
+    "mathContext": "$j \\le k \\le d \\Rightarrow P(k) \\le P(j)$, by induction on $k \\ge j$.",
+    "significance": "key",
+    "relatedConcepts": ["Mathematical induction", "Antitone sequence", "Transitivity of ≤"],
+    "prerequisites": ["Nat.le_induction", "Transitivity (le_trans / .trans)"]
   },
   {
     "id": "ann-monotone",
     "proofId": "birthday-problem-oq-02-oq-01-oq-03",
-    "range": { "startLine": 111, "endLine": 117 },
+    "range": { "startLine": 107, "endLine": 117 },
     "type": "theorem",
     "title": "The Monotone Birthday Paradox",
-    "content": "The headline: the collision probability $1 - P(\\text{all distinct})$ is **non-decreasing** in the number of people (for $j \\le k \\le d$). Formally $\\text{collisionProb}(j,d) \\le \\text{collisionProb}(k,d)$. This is the precise content of the paradox's intuition — adding people can only make a shared birthday more likely, never less — a statement the classic two-sided exponential estimates (sibling OQ-02-OQ-01) leave implicit. It follows immediately from `birthdayProduct_antitone` (proved by `Nat.le_induction` from the one-step bound).",
+    "content": "The headline: the collision probability $1 - P(\\text{all distinct})$ is **non-decreasing** in the number of people (for $j \\le k \\le d$). Formally $\\text{collisionProb}(j,d) \\le \\text{collisionProb}(k,d)$. This is the precise content of the paradox's intuition — adding people can only make a shared birthday more likely, never less — a statement the classic two-sided exponential estimates (sibling OQ-02-OQ-01) leave implicit. It follows immediately from `birthdayProduct_antitone` by taking complements (a one-line `linarith`).",
     "mathContext": "$j \\le k \\le d \\Rightarrow \\text{collisionProb}(j,d) \\le \\text{collisionProb}(k,d)$.",
     "significance": "key",
-    "relatedConcepts": ["Birthday paradox", "Monotonicity", "Antitone", "Mathematical induction"]
+    "relatedConcepts": ["Birthday paradox", "Monotonicity", "Complementary event", "Mathematical induction"],
+    "prerequisites": ["birthdayProduct_antitone", "Order-reversal under x ↦ 1 − x (linarith)"]
+  },
+  {
+    "id": "ann-probability-facts",
+    "proofId": "birthday-problem-oq-02-oq-01-oq-03",
+    "range": { "startLine": 118, "endLine": 134 },
+    "type": "theorem",
+    "title": "collisionProb Is a Genuine Probability",
+    "content": "Three sanity checks certify `collisionProb` behaves like a probability. `collisionProb_one`: with a single person there is no collision, $\\text{collisionProb}\\,1\\,d = 0$ (the empty-then-singleton product equals $1$). `collisionProb_nonneg` and `collisionProb_le_one`: $0 \\le \\text{collisionProb}\\,k\\,d \\le 1$ for $k \\le d+1$, read straight off the $[0,1]$ bounds on $P(\\text{all distinct})$ via `linarith`.",
+    "mathContext": "$\\text{collisionProb}\\,1\\,d = 0, \\qquad 0 \\le \\text{collisionProb}\\,k\\,d \\le 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Probability axioms", "Boundary case", "Complementary event"],
+    "prerequisites": ["birthdayProduct_nonneg / birthdayProduct_le_one", "Simplification of an empty/singleton product"]
   }
 ]

--- a/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01-oq-03/meta.json
@@ -54,6 +54,25 @@
     "theoremCount": 9,
     "definitionCount": 2
   },
+  "overview": {
+    "historicalContext": "The birthday problem — that a group of just 23 people is more likely than not to contain a shared birthday — was first posed by Richard von Mises in 1939 and popularized through William Feller's *An Introduction to Probability Theory and Its Applications* (1950). Its counter-intuitive force comes from the quadratic growth of the number of pairs: among k people there are k(k−1)/2 potential matches, so the all-distinct probability ∏_{i<k}(1 − i/d) decays far faster than naïve linear intuition suggests. The classical literature is overwhelmingly *quantitative* — sharp exponential estimates ∏(1−i/d) ≈ exp(−k(k−1)/2d), pursued in this proof's own lineage (siblings OQ-02 upper bound and OQ-02-OQ-01 lower bound). What those two-sided estimates leave unstated is the qualitative backbone everyone tacitly assumes: that the collision probability *moves in one direction*. This entry isolates and formalizes precisely that monotonicity, a statement that needs none of the exponential machinery — only the product recurrence and the observation that a probability factor lives in [0,1].",
+    "problemStatement": "With d equally likely birthdays and k people, let P(all distinct) = ∏_{i<k}(1 − i/d) and let the collision probability be its complement collisionProb(k,d) = 1 − P(all distinct). Prove that the collision probability is non-decreasing in the group size: for j ≤ k ≤ d, collisionProb(j,d) ≤ collisionProb(k,d). Establish also the boundary and well-formedness facts collisionProb(1,d) = 0 and 0 ≤ collisionProb(k,d) ≤ 1, certifying it is a genuine probability.",
+    "proofStrategy": "Everything is driven by one recurrence, P(k+1) = P(k)·(1 − k/d), obtained by peeling the top factor of the range-product with Finset.prod_range_succ. Two elementary bounds on the new factor — 0 ≤ 1 − i/d (when i ≤ d) and 1 − i/d ≤ 1 — give P(all distinct) ∈ [0,1] via Finset.prod_nonneg and Finset.prod_le_one. The one-step monotonicity P(k+1) ≤ P(k) is then immediate: the recurrence multiplies the nonnegative P(k) by a factor ≤ 1 (mul_le_mul_of_nonneg_left). Nat.le_induction lifts this single step to the global antitone statement birthdayProduct_antitone, and taking complements (a one-line linarith) turns 'P(all distinct) is non-increasing' into 'collisionProb is non-decreasing'. The probability facts follow from the same [0,1] product bounds.",
+    "keyInsights": [
+      "The 'paradox' has a purely qualitative core — more people can only raise the chance of a shared birthday — that is logically prior to, and far cheaper than, the famous exponential estimates; it requires neither 1−x ≤ e^{−x} nor Gauss's summation formula.",
+      "A single recurrence, P(k+1) = P(k)·(1 − k/d), encodes the entire mechanism: each new person contributes a conditional 'avoidance' factor 1 − k/d ∈ [0,1], so the all-distinct probability is a running product that can only shrink.",
+      "Monotonicity is a structural consequence of multiplying a nonnegative quantity by a factor in [0,1] — the birthday-specific value k/d never enters the inductive argument, only the bound 1 − k/d ∈ [0,1] does. The same proof skeleton governs any survival/no-collision product.",
+      "The constraint k ≤ d is essential: once k > d the factor 1 − k/d turns negative (and P(all distinct) becomes 0 anyway by the pigeonhole-forced collision), so the clean 'multiply by something in [0,1]' picture — and hence the monotonicity argument — is confined to the regime where distinctness is still possible.",
+      "Taking complements is a free operation: antitone P(all distinct) ⟺ monotone collisionProb, so a single induction on the product yields the headline together with all the probability-axiom facts (collisionProb 1 d = 0, 0 ≤ collisionProb ≤ 1)."
+    ],
+    "prerequisites": [
+      "Finite products over Finset.range and the peeling lemma Finset.prod_range_succ: ∏_{i<k+1} f i = (∏_{i<k} f i)·f k",
+      "Order lemmas for products: Finset.prod_nonneg and Finset.prod_le_one (a product of factors in [0,1] lies in [0,1])",
+      "mul_le_mul_of_nonneg_left: monotonicity of multiplication by a nonnegative scalar",
+      "Nat.le_induction: induction starting from a base j ≤ k, used to globalize a one-step bound",
+      "Basic discrete-probability framing of the birthday problem: P(all distinct) as a falling factorial d^{underline k}/d^k and collisionProb as its complement"
+    ]
+  },
   "sections": [
     {
       "id": "definitions",
@@ -83,5 +102,50 @@
       "endLine": 134,
       "summary": "collisionProb_one: collisionProb 1 d = 0 (no collision with a single person). collisionProb_nonneg / collisionProb_le_one: 0 ≤ collisionProb k d ≤ 1 for k ≤ d+1."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "This file formalizes the qualitative heart of the birthday paradox: the collision probability collisionProb(k,d) = 1 − ∏_{i<k}(1 − i/d) is non-decreasing in the number of people k for 1 ≤ k ≤ d (collisionProb_monotone), so growing the group can only make a shared birthday more likely. The proof rests on a single product recurrence P(k+1) = P(k)·(1 − k/d) and the elementary fact that each conditional avoidance factor lies in [0,1]; Nat.le_induction lifts the one-step bound to the global antitone statement, and taking complements yields the headline. Companion lemmas certify collisionProb is a genuine probability (collisionProb 1 d = 0 and 0 ≤ collisionProb ≤ 1). Everything is machine-checked with 0 axioms and 0 sorries.",
+    "implications": [
+      "Supplies the monotonicity guarantee that the lineage's two-sided exponential estimates (siblings OQ-02 and OQ-02-OQ-01) silently presuppose but never prove, completing the picture: those bounds locate the collision probability, this entry certifies which way it moves.",
+      "The argument is template-grade: any 'survival product' ∏(1 − hazardᵢ) with hazards in [0,1] is monotone by the identical recurrence-plus-induction skeleton, so the proof transfers verbatim to coupon-collector survival, reliability of series systems, and hash-collision avoidance.",
+      "Isolating the qualitative core from the quantitative estimates clarifies what genuinely makes the paradox 'paradoxical' — the quadratic pair count drives the *speed* of decay, while the monotonicity proved here guarantees only its *direction*."
+    ],
+    "openQuestions": [
+      "Can the monotonicity be upgraded to strict monotonicity on 2 ≤ k ≤ d (where every avoidance factor 1 − k/d is strictly < 1 and P(k) > 0), giving collisionProb(j,d) < collisionProb(k,d) for j < k ≤ d?",
+      "Does the non-uniform birthday distribution preserve monotonicity? With unequal probabilities pᵢ the all-distinct probability is no longer a clean falling-factorial product (cf. sibling OQ-02-OQ-01-OQ-02 on uniform minimizing two-draw collisions) — is collisionProb still monotone in k for every fixed p?",
+      "Can monotonicity in the second argument be formalized too — that for fixed k, collisionProb(k,d) is non-increasing in the number of days d (more available birthdays ⇒ collisions no more likely)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "birthday-problem-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct parent. Proves the matching exponential lower bound ∏(1−i/d) ≥ exp(−k(k−1)/2d − k²(k−1)²/4d²) for the all-distinct probability. This entry supplies the qualitative monotonicity that the parent's two-sided estimate leaves implicit."
+    },
+    {
+      "targetId": "birthday-problem-oq-02",
+      "relationship": "related",
+      "description": "Grandparent. Establishes the matching exponential upper bound ∏(1−i/d) ≤ exp(−k(k−1)/2d) via 1−x ≤ e^{−x} and Gauss's summation. Together with OQ-02-OQ-01 it brackets the collision probability that this entry shows is monotone."
+    },
+    {
+      "targetId": "birthday-problem-oq-02-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling in the non-uniform direction: among all distributions on d outcomes, the uniform one minimizes the two-draw collision probability ∑pᵢ². Motivates the open question of whether monotonicity in group size survives non-uniform birthday distributions."
+    },
+    {
+      "targetId": "birthday-problem",
+      "relationship": "related",
+      "description": "Root of the lineage: the classic statement that 23 people suffice for a >50% chance of a shared birthday. This entry formalizes the monotonicity premise underlying that headline figure."
+    }
+  ],
+  "leanFile": {
+    "namespace": "BirthdayProblemOQ02OQ01OQ03",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/BirthdayProblemOQ02OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-02-oq-01-oq-03`.

## Quality improvements
- **overview** (new): historicalContext (von Mises 1939, Feller 1950, quadratic pair-count intuition), problemStatement, proofStrategy, 5 keyInsights, 5 prerequisites
- **conclusion** (new): summary, 3 implications, 3 openQuestions (strict monotonicity, non-uniform distributions, monotonicity in d)
- **crossReferences** (new): 4 links across the OQ-02 birthday lineage (parent OQ-02-OQ-01 lower bound, grandparent OQ-02 upper bound, sibling OQ-02-OQ-01-OQ-02 non-uniform, root birthday-problem)
- **annotations**: expanded 3 → 7, now covering definitions, factor/product bounds, the Nat.le_induction globalization, and the probability-axiom facts; every annotation carries mathContext, significance, relatedConcepts, and prerequisites
- **leanFile** metadata block added

All content is mathematically accurate and preserves existing material. `pnpm build` passes (0 axioms, 0 sorries entry).