### PR TITLE
fix(gallery): badge abel-ruffini-obstruction-oq-06 & abel-ruffini-oq-11 as 'mathlib' (#30326)

### DIFF
--- a/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
+++ b/src/data/proofs/abel-ruffini-obstruction-oq-06/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AbelRuffiniObstructionOQ06.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-11/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-11/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AbelRuffiniOQ11.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Summary

Repairs gallery integrity issue #30326. Two Abel–Ruffini entries badged `original` + `status: verified`, but their **flagship results are direct calls to Mathlib theorems** (Mathlib Wrapper Detection). Per gallery convention (cf. #11921, #12530), they should badge `mathlib`.

## Changes (badge-accuracy only)

- `abel-ruffini-obstruction-oq-06`: `badge` `original` → `mathlib`
  - Core results are `Equiv.Perm.not_solvable` and `solvableByRad.isSolvable'` re-exposed.
- `abel-ruffini-oq-11`: `badge` `original` → `mathlib`
  - Flagship results are `gal_X_pow_sub_C_isSolvable` / `gal_X_pow_sub_one_isSolvable` aliases + `Equiv.Perm.not_solvable`. (The genuinely new `gal_finset_prod_pow_sub_C_isSolvable` infrastructure remains, but does not justify an `original` flagship badge.)

`status: "verified"` retained (0 sorries / 0 axioms accurate). The `overview`, `originalContributions`, and `mathlibDependencies` prose was already scrupulously honest and is left unchanged — only the one-word machine-readable badge overclaimed.

Closes #30326

🤖 Generated with [Claude Code](https://claude.com/claude-code)