### PR TITLE
Enrich Discharging the Hadamard Three-Lines Axiom (cauchy-schwarz-integral-oq-01-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-cs-hadamard-strips",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+    "range": { "startLine": 52, "endLine": 65 },
+    "type": "definition",
+    "title": "Strip Geometry and the Interpolated Bound",
+    "content": "Five definitions set up the geometry, each chosen to match the parent entry's `hadamard_three_lines` axiom character-for-character: `closedStrip` $= \\{0 \\le \\operatorname{Re} z \\le 1\\}$, `openStrip` $= \\{0 < \\operatorname{Re} z < 1\\}$, the two boundary lines, and `interpNorm θ M₀ M₁ = M₀^{1-θ}·M₁^θ`. The verbatim match is the whole point: because the statement proved below is syntactically identical to the parent's axiom, it can be dropped in to replace that axiom with no further glue.",
+    "mathContext": "$\\mathrm{interpNorm}(\\theta,M_0,M_1)=M_0^{1-\\theta}M_1^{\\theta}$; strip $S=\\{z:0\\le\\operatorname{Re}z\\le1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Vertical strip", "Complex analysis", "Interpolation", "Riesz–Thorin theorem"],
+    "prerequisites": ["complex numbers and Re z", "set-builder definitions in Lean", "rpow (real power)"]
+  },
+  {
+    "id": "ann-cs-hadamard-statement",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+    "range": { "startLine": 67, "endLine": 84 },
+    "type": "theorem",
+    "title": "The Three-Lines Lemma, Now a Theorem",
+    "content": "`hadamard_three_lines` states: if $F$ is continuous on the closed strip, holomorphic and uniformly bounded on the open strip, with $\\|F\\| \\le M_0$ on $\\operatorname{Re} z = 0$ and $\\|F\\| \\le M_1$ on $\\operatorname{Re} z = 1$, then $\\|F(t+iy)\\| \\le M_0^{1-t} M_1^{t}$ for $0 \\le t \\le 1$. This is exactly the parent Riesz–Thorin entry's axiom — here promoted to a proved theorem, so the analytic heart of the interpolation argument is no longer assumed.",
+    "mathContext": "$\\|F(t+iy)\\| \\le M_0^{1-t} M_1^{t}$, $0 \\le t \\le 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Hadamard three-lines theorem", "Maximum modulus principle", "Holomorphic function", "Riesz–Thorin theorem"],
+    "prerequisites": ["holomorphy on a strip", "the maximum modulus principle", "boundedness hypotheses"]
+  },
+  {
+    "id": "ann-cs-hypothesis-translation",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+    "range": { "startLine": 85, "endLine": 116 },
+    "type": "technique",
+    "title": "Translating Hypotheses to Mathlib's verticalStrip API",
+    "content": "The mathematical content lives in Mathlib; the work here is bridging conventions. The hand-rolled `closedStrip`/`openStrip` are identified with `verticalClosedStrip 0 1` / `verticalStrip 0 1` by `ext` + `simp`. The crucial topological fact `closure (verticalStrip 0 1) = verticalClosedStrip 0 1` (via `closure_preimage_re` and `closure_Ioo`) lets continuity-on-the-closed-strip plus holomorphy-on-the-open-strip assemble into Mathlib's `DiffContOnCl` (differentiable on a set, continuous on its closure — the hypothesis form of the maximum principle). The uniform bound becomes `BddAbove` of the norm image, and the two boundary bounds are rephrased in the `re ⁻¹' {0}` / `re ⁻¹' {1}` form Mathlib expects.",
+    "mathContext": "$\\overline{\\{0<\\operatorname{Re}z<1\\}} = \\{0\\le\\operatorname{Re}z\\le1\\}$; $\\mathrm{DiffContOnCl} = $ holomorphic on the open strip $+$ continuous on its closure.",
+    "significance": "key",
+    "relatedConcepts": ["DiffContOnCl", "Closure of a set", "BddAbove", "Preimage under Re", "API bridging"],
+    "prerequisites": ["closure of an open strip", "Mathlib's DiffContOnCl and verticalStrip", "BddAbove of an image set"]
+  },
+  {
+    "id": "ann-cs-apply-mathlib",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+    "range": { "startLine": 117, "endLine": 119 },
+    "type": "insight",
+    "title": "Invoking Mathlib's Three-Lines and Reading Off t",
+    "content": "With every hypothesis translated, one call to Mathlib's `norm_le_interp_of_mem_verticalClosedStrip₀₁'` produces the bound $\\|F z\\| \\le M_0^{1-\\operatorname{Re} z} M_1^{\\operatorname{Re} z}$, and `simpa [interpNorm]` finishes by using $(\\langle t, y\\rangle : \\mathbb{C}).\\operatorname{Re} = t$. This is the payoff of the 'open question = is it wired up?' framing: the deep proof is Mathlib's; discharging the axiom is exactly this hypothesis-matching plus one application.",
+    "mathContext": "$(\\langle t,y\\rangle:\\mathbb{C}).\\operatorname{Re}=t$, so the interpolated exponent on the line $\\operatorname{Re}z=t$ is $t$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Axiom discharge", "Mathlib reuse", "Complex.HadamardThreeLines"],
+    "prerequisites": ["norm_le_interp_of_mem_verticalClosedStrip₀₁'", "the real part of a constructed complex number"]
+  },
+  {
+    "id": "ann-cs-log-form",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+    "range": { "startLine": 121, "endLine": 142 },
+    "type": "theorem",
+    "title": "Logarithmic Convexity Form for Operator-Norm Interpolation",
+    "content": "`hadamard_three_lines_log` takes logarithms of the multiplicative bound: when $F(t+iy) \\ne 0$, $\\log\\|F(t+iy)\\| \\le (1-t)\\log M_0 + t\\log M_1$. The proof applies `Real.log_le_log` to the main theorem's bound and expands $\\log(\\mathrm{interpNorm})$ with `Real.log_mul` and `Real.log_rpow`. This exhibits $t \\mapsto \\log\\|F\\|$ as (sub)convex along the strip — precisely the convexity that interpolates operator norms in the Riesz–Thorin theorem, where $M_0, M_1$ are the endpoint operator norms.",
+    "mathContext": "$\\log\\|F(t+iy)\\| \\le (1-t)\\log M_0 + t\\log M_1$ — log-convexity of $\\|F\\|$ along the strip.",
+    "significance": "key",
+    "relatedConcepts": ["Log-convexity", "Operator norm interpolation", "Riesz–Thorin theorem", "Logarithm of rpow"],
+    "prerequisites": ["monotonicity of log (Real.log_le_log)", "log_mul and log_rpow identities", "convexity and interpolation"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02-oq-01/meta.json
@@ -74,7 +74,32 @@
       "Mathlib's Complex.HadamardThreeLines API"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "strip-geometry",
+      "title": "Strip Geometry and the Interpolated Bound",
+      "startLine": 52,
+      "endLine": 65,
+      "summary": "Five definitions reproducing the parent entry's conventions verbatim: closedStrip {0 ≤ Re z ≤ 1}, openStrip {0 < Re z < 1}, leftBoundary {Re z = 0}, rightBoundary {Re z = 1}, and interpNorm θ M₀ M₁ = M₀^(1-θ)·M₁^θ. Using identical definitions is what lets the theorem below replace the parent's axiom verbatim.",
+      "mathContext": "$\\mathrm{interpNorm}(\\theta, M_0, M_1) = M_0^{1-\\theta} M_1^{\\theta}$ on the strip $0 \\le \\operatorname{Re} z \\le 1$."
+    },
+    {
+      "id": "three-lines-theorem",
+      "title": "Hadamard Three-Lines as a Theorem",
+      "startLine": 67,
+      "endLine": 119,
+      "summary": "hadamard_three_lines: the parent's axiom, now proved. Given F continuous on the closed strip, holomorphic and uniformly bounded on the open strip, with ‖F‖ ≤ M₀ on Re z = 0 and ≤ M₁ on Re z = 1, then ‖F(t+iy)‖ ≤ M₀^(1-t)·M₁^t. The body is hypothesis translation to Mathlib's verticalStrip API (closedStrip = verticalClosedStrip 0 1; DiffContOnCl from continuity+holomorphy via closure_preimage_re + closure_Ioo; uniform bound ⇒ BddAbove; boundary bounds in re⁻¹'{0}/re⁻¹'{1} form), then norm_le_interp_of_mem_verticalClosedStrip₀₁'.",
+      "mathContext": "$\\|F(t+iy)\\| \\le M_0^{1-t} M_1^{t}$ for $0 \\le t \\le 1$ (maximum-modulus principle on the strip)."
+    },
+    {
+      "id": "log-convexity-form",
+      "title": "Logarithmic Convexity Form",
+      "startLine": 121,
+      "endLine": 142,
+      "summary": "hadamard_three_lines_log: taking logs of the multiplicative bound gives log‖F(t+iy)‖ ≤ (1-t)·log M₀ + t·log M₁ (when F(t+iy) ≠ 0), via Real.log_le_log on the main bound and Real.log_mul/Real.log_rpow to expand log(interpNorm). This convexity-of-log‖F‖ form is the statement actually used to interpolate operator norms in Riesz–Thorin.",
+      "mathContext": "$\\log\\|F(t+iy)\\| \\le (1-t)\\log M_0 + t\\log M_1$ — convexity of $t \\mapsto \\log\\|F\\|$ along the strip."
+    }
+  ],
   "conclusion": {
     "summary": "The Hadamard three-lines lemma — assumed as an axiom in the parent Riesz–Thorin-from-Hölder entry — is proved here as a fully machine-checked theorem (0 axioms, 0 sorries) by deriving it from Mathlib's Complex.HadamardThreeLines, with a statement identical to the parent's axiom so it can replace it verbatim. The logarithmic convexity form used for operator-norm interpolation is also provided.",
     "implications": [


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-02-oq-01` — proving the parent Riesz–Thorin entry's Hadamard three-lines axiom as a theorem from Mathlib.

## Gaps addressed
The entry had a rich `meta.json` (overview, conclusion, crossReference, references) but **no `annotations.json`** and an **empty `sections` array**.

## Changes
- **annotations.json** (new): 5 annotations — strip geometry/definitions, the now-proved three-lines theorem statement, the verticalStrip hypothesis-translation technique (closure_preimage_re/closure_Ioo ⇒ DiffContOnCl; uniform bound ⇒ BddAbove; boundary bounds in re⁻¹'{·} form), the one-line Mathlib application, and the log-convexity corollary used for operator-norm interpolation. Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **meta.json sections**: filled the empty array with 3 sections (strip-geometry 52–65, three-lines-theorem 67–119, log-convexity-form 121–142) with summaries and mathContext, covering the whole 143-line file.
- meta overview/conclusion/crossReferences already complete — left untouched.

## Validation
`pnpm annotations:build` reports **0 errors for this proof**; both JSON files parse. (Full `pnpm build` is blocked only by an unrelated env issue — better-sqlite3 native build fails, so the sqlite-backed `research:build` step can't emit generated listings.)