### PR TITLE
Enrich Discriminant/Jordan Route to S₅ (abel-ruffini-oq-07-discriminant)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-07-discriminant/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-07-discriminant/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 47 },
     "type": "concept",
     "title": "The Discriminant Route to S₅",
-    "content": "The docstring contrasts two ways to pin down Gal(X⁵−X−1) ≅ S₅. The sibling entry (abel-ruffini-oq-07) uses a distinguished transposition, the cube of the order-6 Frobenius at p=2. This file uses the discriminant: Δ(X⁵−X−1) = 2869 = 19·151 is not a perfect square, so Gal ⊄ A₅ — it contains SOME odd permutation, not necessarily a transposition. Together with a transitive prime-degree action (from irreducibility) and a 3-cycle (from 3 ∣ |Gal|, which rules out the Frobenius group F₂₀), Jordan's theorem forces Gal = S₅. This route is more robust precisely because it consumes any odd element."
+    "content": "The docstring contrasts two ways to pin down Gal(X⁵−X−1) ≅ S₅. The sibling entry (abel-ruffini-oq-07) uses a distinguished transposition, the cube of the order-6 Frobenius at p=2. This file uses the discriminant: Δ(X⁵−X−1) = 2869 = 19·151 is not a perfect square, so Gal ⊄ A₅ — it contains SOME odd permutation, not necessarily a transposition. Together with a transitive prime-degree action (from irreducibility) and a 3-cycle (from 3 ∣ |Gal|, which rules out the Frobenius group F₂₀), Jordan's theorem forces Gal = S₅. This route is more robust precisely because it consumes any odd element.",
+    "mathContext": "Transitive subgroups of S₅ containing an odd permutation are $\\{F_{20}, S_5\\}$; a 3-cycle (order 3 ∤ 20) excludes $F_{20}$, leaving $\\text{Gal} = S_5$.",
+    "significance": "context",
+    "relatedConcepts": ["Abel–Ruffini theorem", "Discriminant criterion", "Jordan's theorem", "Frobenius group F₂₀"],
+    "prerequisites": ["Galois group as a permutation group on the roots", "Transitive subgroups of S₅", "Discriminant criterion Gal ⊆ Aₙ ⟺ disc is a square"]
   },
   {
     "id": "ann-aro07d-setup",
@@ -13,22 +17,46 @@
     "range": { "startLine": 48, "endLine": 63 },
     "type": "concept",
     "title": "Setup: S₅ and the Prime Degree",
-    "content": "S5 abbreviates Equiv.Perm (Fin 5). card_fin5_prime records that the degree 5 is prime — the structural fact that lets MulAction.IsPreprimitive.of_prime_card upgrade a transitive action to a primitive one, which is the hypothesis Jordan's theorem needs."
+    "content": "S5 abbreviates Equiv.Perm (Fin 5). card_fin5_prime records that the degree 5 is prime — the structural fact that lets MulAction.IsPreprimitive.of_prime_card upgrade a transitive action to a primitive one, which is the hypothesis Jordan's theorem needs. Without primitivity, transitivity alone is not enough to invoke Jordan.",
+    "mathContext": "$\\operatorname{Nat.card}(\\mathrm{Fin}\\,5) = 5$ is prime; a pretransitive action of prime degree is preprimitive.",
+    "significance": "supporting",
+    "relatedConcepts": ["Prime degree", "Primitive permutation group", "Pretransitive action"],
+    "prerequisites": ["Nat.Prime and Fintype.card_fin", "MulAction.IsPreprimitive.of_prime_card"]
   },
   {
     "id": "ann-aro07d-assembler",
     "proofId": "abel-ruffini-oq-07-discriminant",
-    "range": { "startLine": 64, "endLine": 99 },
+    "range": { "startLine": 64, "endLine": 93 },
     "type": "theorem",
     "title": "The Discriminant-Route Assembler",
-    "content": "gal_eq_top_of_transitive_threeCycle_odd is the core result: a transitive subgroup G ≤ S₅ containing a 3-cycle g and an odd permutation h equals ⊤. Proof: (1) prime degree 5 makes the transitive action primitive (of_prime_card); (2) Jordan's theorem (alternatingGroup_le_of_isPreprimitive_of_isThreeCycle_mem) applied to g gives A₅ ≤ G; (3) since A₅ has index 2, Subgroup.index_dvd_of_le gives G.index ∣ 2; the odd element h rules out G.index = 2 (which would force G = A₅ by eq_alternatingGroup_of_index_eq_two), leaving G.index = 1, i.e. G = ⊤. All three inputs are explicit hypotheses, never axioms."
+    "content": "gal_eq_top_of_transitive_threeCycle_odd is the core result: a transitive subgroup G ≤ S₅ containing a 3-cycle g and an odd permutation h equals ⊤. Proof: (1) prime degree 5 makes the transitive action primitive (of_prime_card); (2) Jordan's theorem (alternatingGroup_le_of_isPreprimitive_of_isThreeCycle_mem) applied to g gives A₅ ≤ G; (3) since A₅ has index 2, Subgroup.index_dvd_of_le gives G.index ∣ 2; the odd element h rules out G.index = 2 (which would force G = A₅ by eq_alternatingGroup_of_index_eq_two), leaving G.index = 1, i.e. G = ⊤. All three inputs are explicit hypotheses, never axioms.",
+    "mathContext": "primitive $+$ 3-cycle $\\Rightarrow A_5 \\le G$ (Jordan); $[S_5 : A_5] = 2 \\Rightarrow G.\\mathrm{index} \\mid 2$; an odd element forces $G.\\mathrm{index} = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Jordan's theorem", "Primitive permutation group", "Index-2 subgroup", "Alternating group"],
+    "prerequisites": ["Equiv.Perm.alternatingGroup_le_of_isPreprimitive_of_isThreeCycle_mem", "Subgroup.index_dvd_of_le", "alternatingGroup.index_eq_two"]
+  },
+  {
+    "id": "ann-aro07d-index2",
+    "proofId": "abel-ruffini-oq-07-discriminant",
+    "range": { "startLine": 87, "endLine": 92 },
+    "type": "tactic",
+    "title": "Closing the Index-2 Gap with One Odd Element",
+    "content": "The crux of why a single odd permutation suffices. Once A₅ ≤ G, Subgroup.index_dvd_of_le gives G.index ∣ [S₅ : A₅] = 2, so by Nat.dvd_prime the index is either 1 or 2. The case G.index = 2 is impossible: eq_alternatingGroup_of_index_eq_two would identify G with A₅, contradicting that the odd h ∈ G lies outside A₅. Hence G.index = 1, i.e. G = ⊤. This is exactly the step that makes the discriminant route work with ANY odd element rather than a specific transposition.",
+    "mathContext": "$G.\\mathrm{index} \\mid 2 \\Rightarrow G.\\mathrm{index} \\in \\{1,2\\}$; $G.\\mathrm{index} = 2 \\Rightarrow G = A_5$, contradicting $h \\notin A_5$; so $G = \\top$.",
+    "significance": "key",
+    "relatedConcepts": ["Subgroup index", "Uniqueness of the index-2 subgroup", "Sign homomorphism", "Proof by contradiction"],
+    "prerequisites": ["Nat.dvd_prime", "Subgroup.index_eq_one", "Equiv.Perm.eq_alternatingGroup_of_index_eq_two"]
   },
   {
     "id": "ann-aro07d-discriminant",
     "proofId": "abel-ruffini-oq-07-discriminant",
-    "range": { "startLine": 100, "endLine": 115 },
+    "range": { "startLine": 94, "endLine": 115 },
     "type": "theorem",
     "title": "The Discriminant 2869 and Its Non-Squareness",
-    "content": "disc_value computes the trinomial discriminant 4⁴a⁵ + 5⁵b⁴ at a = b = −1: 256·(−1)⁵ + 3125·(−1)⁴ = 2869. disc_factorization records 2869 = 19·151 (squarefree). disc_not_square proves ¬ IsSquare (2869 : ℤ) by mapping along ℤ → ZMod 7 (IsSquare.map): 2869 ≡ 6 (mod 7), and 6 is a quadratic non-residue, dispatched by decide. This is the formal content 'Gal ⊄ A₅' — the odd-permutation input the assembler consumes."
+    "content": "disc_value computes the trinomial discriminant 4⁴a⁵ + 5⁵b⁴ at a = b = −1: 256·(−1)⁵ + 3125·(−1)⁴ = 2869. disc_factorization records 2869 = 19·151 (squarefree). disc_not_square proves ¬ IsSquare (2869 : ℤ) by mapping along ℤ → ZMod 7 (IsSquare.map): 2869 ≡ 6 (mod 7), and 6 is a quadratic non-residue, dispatched by decide. This is the formal content 'Gal ⊄ A₅' — the odd-permutation input the assembler consumes.",
+    "mathContext": "$\\mathrm{disc}(X^5+aX+b) = 4^4 a^5 + 5^5 b^4$; at $a=b=-1$ this is $2869 \\equiv 6 \\pmod 7$, a non-residue, so $2869$ is not a square.",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial discriminant", "Trinomial discriminant formula", "Quadratic non-residue", "Reduction mod p"],
+    "prerequisites": ["IsSquare and IsSquare.map under a ring hom", "Quadratic residues in ZMod 7", "decide on a finite ZMod"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-07-discriminant`.

## Quality improvements
- **Annotations**: every annotation now carries `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` (previously bare content-only)
- **New annotation** on the index-2 closing argument — isolating *why a single odd permutation suffices* (Subgroup.index ∣ 2, eq_alternatingGroup_of_index_eq_two contradiction), the conceptual heart distinguishing the discriminant route from the swap-based sibling
- Refined annotation line ranges to align with the assembler vs. discriminant split in the Lean source

Entry already had a strong overview/conclusion/crossReferences/mainTheorems/references; this pass closes the annotation-depth gap. `pnpm build` passes (0 axioms, 0 sorries entry).