### PR TITLE
Enrich Origami Constructibility & 3-Smooth Degrees (angle-trisection-oq-03-oq-03)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-03-oq-03/annotations.json
@@ -2,45 +2,61 @@
   {
     "id": "ann-criterion",
     "proofId": "angle-trisection-oq-03-oq-03",
-    "range": {
-      "startLine": 44,
-      "endLine": 55
-    },
+    "range": { "startLine": 41, "endLine": 55 },
     "type": "concept",
     "title": "From Power-of-2 to 3-Smooth",
-    "content": "Straightedge and compass build numbers in towers of quadratic extensions, so the constructible degrees are exactly the powers of 2. Origami's signature fold solves a general cubic, adding cube roots, so its admissible degrees gain a factor of 3: the 3-smooth numbers 2^a·3^b. `ThreeSmooth d` and `IsOrigamiConstructible α d` encode this criterion, parallel to the parent's CompassConstructibleDegree (power of 2)."
+    "content": "Straightedge and compass build numbers in towers of quadratic extensions, so the constructible degrees are exactly the powers of 2. Origami's signature fold solves a general cubic, adding cube roots, so its admissible degrees gain a factor of 3: the 3-smooth numbers 2^a·3^b. `ThreeSmooth d` and `IsOrigamiConstructible α d` encode this criterion, parallel to the parent's CompassConstructibleDegree (power of 2).",
+    "mathContext": "Compass: $d = 2^k$. Origami: $d = 2^a 3^b$ (3-smooth). The extra factor 3 is the cube-root direction the Huzita–Hatori fold supplies.",
+    "significance": "key",
+    "relatedConcepts": ["Constructible number", "Field extension degree", "Quadratic/cubic extensions", "Origami axioms (Huzita–Hatori)", "Smooth numbers"],
+    "prerequisites": ["tower law for field extensions", "compass constructibility = power-of-2 degree", "origami can solve cubics"]
   },
   {
     "id": "ann-characterization",
     "proofId": "angle-trisection-oq-03-oq-03",
-    "range": {
-      "startLine": 92,
-      "endLine": 120
-    },
+    "range": { "startLine": 92, "endLine": 120 },
     "type": "insight",
     "title": "Prime-Factor Characterization by Peeling",
-    "content": "`threeSmooth_iff_primeFactors` proves d is 3-smooth ⟺ every prime factor is 2 or 3. The hard direction is strong induction: for d > 1, peel off a prime factor p (necessarily 2 or 3 by hypothesis); the quotient d/p is smaller and inherits the hypothesis (its prime factors still divide d), so by induction d/p = 2^a·3^b and d = p·(d/p) is 3-smooth. Because the condition is a finite check over the Finset d.primeFactors, this yields a Decidable instance for origami constructibility — the origami analogue of the parent's decidable power-of-2 criterion."
+    "content": "`threeSmooth_iff_primeFactors` proves d is 3-smooth ⟺ every prime factor is 2 or 3. The hard direction is strong induction: for d > 1, peel off a prime factor p (necessarily 2 or 3 by hypothesis); the quotient d/p is smaller and inherits the hypothesis (its prime factors still divide d), so by induction d/p = 2^a·3^b and d = p·(d/p) is 3-smooth. Because the condition is a finite check over the Finset d.primeFactors, this yields a Decidable instance for origami constructibility — the origami analogue of the parent's decidable power-of-2 criterion.",
+    "mathContext": "$d = 2^a 3^b \\iff \\mathrm{primeFactors}(d) \\subseteq \\{2,3\\}$; the finite check makes $\\mathrm{IsOrigamiConstructible}$ decidable.",
+    "significance": "key",
+    "relatedConcepts": ["Strong induction", "Prime factorization", "Decidability", "Nat.primeFactors", "Smooth numbers"],
+    "prerequisites": ["Nat.strong_induction_on", "Nat.exists_prime_and_dvd", "divisibility of prime factors of a quotient"]
   },
   {
     "id": "ann-separation",
     "proofId": "angle-trisection-oq-03-oq-03",
-    "range": {
-      "startLine": 145,
-      "endLine": 165
-    },
+    "range": { "startLine": 145, "endLine": 165 },
     "type": "insight",
     "title": "Degree 3: Where Origami Beats Compass",
-    "content": "`origami_trisects_but_compass_cannot` is the headline: degree 3 is origami-constructible (3 = 2^0·3^1 is 3-smooth) but not compass-constructible (3 = 2^k would force 2 ∣ 3). This is exactly the classical content — ℚ(cos 20°)/ℚ has degree 3 (angle trisection) and ℚ(∛2)/ℚ has degree 3 (doubling the cube), both impossible by compass yet solvable by paper folding. The inclusion constructible_imp_origami (b = 0) confirms origami loses nothing compass had."
+    "content": "`origami_trisects_but_compass_cannot` is the headline: degree 3 is origami-constructible (3 = 2^0·3^1 is 3-smooth) but not compass-constructible (3 = 2^k would force 2 ∣ 3). This is exactly the classical content — ℚ(cos 20°)/ℚ has degree 3 (angle trisection) and ℚ(∛2)/ℚ has degree 3 (doubling the cube), both impossible by compass yet solvable by paper folding. The inclusion constructible_imp_origami (b = 0) confirms origami loses nothing compass had.",
+    "mathContext": "$[\\mathbb{Q}(\\cos 20^\\circ):\\mathbb{Q}] = [\\mathbb{Q}(\\sqrt[3]{2}):\\mathbb{Q}] = 3$, 3-smooth but not a power of 2.",
+    "significance": "key",
+    "relatedConcepts": ["Angle trisection", "Doubling the cube", "Minimal polynomial degree", "Classical impossibility theorems"],
+    "prerequisites": ["degree of ℚ(cos 20°) and ℚ(∛2)", "2 ∤ 3", "the compass power-of-2 criterion"]
+  },
+  {
+    "id": "ann-compass-subset-origami",
+    "proofId": "angle-trisection-oq-03-oq-03",
+    "range": { "startLine": 131, "endLine": 135 },
+    "type": "theorem",
+    "title": "Compass ⊆ Origami",
+    "content": "`constructible_imp_origami` records the containment: every compass-constructible degree is origami-constructible, because a power of 2 is the 3-smooth number with b = 0 (`threeSmooth_of_pow_two`). Origami strictly extends straightedge-and-compass — it can do everything compass can (the b = 0 slice) and more (any b > 0, the cubic directions). This inclusion is what makes the degree-3 separation a genuine *strict* gain rather than an incomparable alternative.",
+    "mathContext": "$\\{2^k\\} \\subseteq \\{2^a 3^b\\}$ (take $a=k,\\ b=0$), so compass-constructible $\\Rightarrow$ origami-constructible.",
+    "significance": "supporting",
+    "relatedConcepts": ["Subset of construction methods", "Power of two as 3-smooth", "Constructibility hierarchy"],
+    "prerequisites": ["threeSmooth_of_pow_two", "compass degree criterion"]
   },
   {
     "id": "ann-limits",
     "proofId": "angle-trisection-oq-03-oq-03",
-    "range": {
-      "startLine": 169,
-      "endLine": 185
-    },
+    "range": { "startLine": 156, "endLine": 172 },
     "type": "concept",
     "title": "Origami Still Has Limits",
-    "content": "`not_five_dvd_threeSmooth` shows 5 ∤ 2^a·3^b (a prime dividing the product would be 2 or 3), so any degree divisible by 5 is not 3-smooth. In particular the regular 11-gon, for which [ℚ(cos 2π/11):ℚ] = 5, is not origami-constructible (not_origami_eleven_gon). Origami extends compass by exactly the cubic directions — it does not make every algebraic number constructible."
+    "content": "`not_five_dvd_threeSmooth` shows 5 ∤ 2^a·3^b (a prime dividing the product would be 2 or 3), so any degree divisible by 5 is not 3-smooth. In particular the regular 11-gon, for which [ℚ(cos 2π/11):ℚ] = 5, is not origami-constructible (not_origami_eleven_gon). Origami extends compass by exactly the cubic directions — it does not make every algebraic number constructible.",
+    "mathContext": "$5 \\nmid 2^a 3^b$; $[\\mathbb{Q}(\\cos 2\\pi/11):\\mathbb{Q}] = 5$, so the regular 11-gon is not origami-constructible.",
+    "significance": "supporting",
+    "relatedConcepts": ["Regular polygon constructibility", "Cyclotomic degree", "5-smoothness boundary", "Limits of origami"],
+    "prerequisites": ["Euclid's lemma for primes", "degree of ℚ(cos 2π/11)", "prime dividing a product of prime powers"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-03-oq-03` — origami (Huzita–Hatori) constructibility characterized by 3-smooth degrees 2^a·3^b.

## Gap addressed
Rich `meta.json` (overview, conclusion, 2 crossReferences, sections, mainTheorems, references) but the 4 annotations were **bare** — `title` + `content` only, with no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`.

## Changes (annotations.json only)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` to every annotation.
- Added a 5th annotation for `constructible_imp_origami` (compass ⊆ origami — the inclusion that makes the degree-3 separation a *strict* gain).
- Fixed two pre-existing line ranges that started on blank lines (44→41, 169→156) so each annotation resolves to a real Lean construct (caught by `annotations:build`).
- `meta.json` already complete — left untouched.

## Validation
`pnpm annotations:build` reports **0 errors for this proof**; JSON parses. (Full `pnpm build` is blocked only by the unrelated better-sqlite3 native-build env issue.)