### PR TITLE
research(erdos-1017-oq-02): register orphaned Erdos1017OQ02 in Proofs.lean [verified build]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1258,6 +1258,7 @@ import Proofs.Erdos1015OQ05
 import Proofs.Erdos1015Problem
 import Proofs.Erdos1016Problem
 import Proofs.Erdos1017OQ01
+import Proofs.Erdos1017OQ02
 import Proofs.Erdos1017OQ03
 import Proofs.Erdos1017Problem
 import Proofs.Erdos1018Aristotle


### PR DESCRIPTION
## Summary

The verified, 0-axiom proof `proofs/Proofs/Erdos1017OQ02.lean` — *balanced split is the unique edge-maximiser of complete bipartite graphs*, `a(n−a) ≤ ⌊n²/4⌋` with equality at `⌊n/2⌋` — was merged in #27759 with a full gallery entry (`status: verified`, enriched in #28251), **but the file was never added to `proofs/Proofs.lean`**. It was therefore an orphan: never imported into the project build, never kernel-checked. This is the same defect that affected `Erdos1017OQ03` before its follow-up registration (#27685).

## Change

Added `import Proofs.Erdos1017OQ02` in LC_ALL=C sort order between `Erdos1017OQ01` and `Erdos1017OQ03`. One-line change; no math content modified.

## Verification

```
./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ02
✔ [7743/7743] Built Proofs.Erdos1017OQ02 (946s)
Build completed successfully (7743 jobs).
```

The gallery's `verified` badge for erdos-1017-oq-02 is now backed by an actual project build. 0 sorries, 0 axioms, no `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)