### PR TITLE
research(schur-lemma-oq-02): the commutant of an absolutely simple module is exactly the scalars [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SchursLemmaOQ02.lean
+++ b/proofs/Proofs/SchursLemmaOQ02.lean
@@ -1,0 +1,129 @@
+import Mathlib.RingTheory.SimpleModule.Basic
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.LinearAlgebra.Dimension.Finrank
+import Mathlib.Tactic
+import Proofs.SchursLemma
+
+/-!
+# Schur's Lemma OQ-02 — the endomorphism algebra is *exactly* the scalars
+
+## What This Proves
+
+The parent file (`SchursLemma.lean`) proves the **scalar form** of Schur's Lemma:
+over an algebraically closed field `k`, every `A`-linear endomorphism of a
+finite-dimensional simple `A`-module `M` is multiplication by *some* scalar
+`c : k` (`schur_endomorphism_scalar`).  Existence of `c` is the part used to *find*
+a scalar; this file supplies the complementary half — **uniqueness** — and packages
+the two into the structural statement that the endomorphism algebra collapses
+completely onto `k`.
+
+Concretely:
+
+* `schur_scalar_unique` — the scalar is **unique**: `∃! c, ∀ m, f m = c • m`.
+* `schur_scalar_bijective` — the scalar map `c ↦ c • id : k → End_A(M)` is a
+  **bijection**.  (Injective by uniqueness; surjective by the parent's scalar form.)
+* `scalarEquiv` — hence a `k`-linear equivalence `k ≃ₗ[k] End_A(M)`.
+* `finrank_end_eq_one` — therefore `dim_k End_A(M) = 1`: the endomorphism algebra
+  of an absolutely simple module is one-dimensional, i.e. *exactly* the scalars.
+
+This is the precise sense in which a finite-dimensional simple module over an
+algebraically closed field is **absolutely simple**: its commutant is just `k`.
+It is the structural upgrade of the parent's existence statement and the engine
+behind the dimension counts of character theory.
+
+## Approach
+
+Uniqueness is the one new analytic ingredient.  If `c • v = c' • v` for a nonzero
+vector `v` (which exists since a simple module is nontrivial), then `(c - c') • v = 0`;
+because `M` is a vector space over the field `k`, scaling by the inverse of a nonzero
+`c - c'` would force `v = 0`, a contradiction.  Everything else is bookkeeping on top
+of the parent results.
+
+## References
+* Serre, *Linear Representations of Finite Groups*, §2.2 (Schur's lemma and its
+  corollary that the commutant of an irreducible is the scalars).
+* Curtis–Reiner, *Representation Theory of Finite Groups and Associative Algebras*,
+  §27 (absolutely simple modules).
+-/
+
+open Module
+
+namespace SchursLemmaOQ02
+
+variable {k : Type*} [Field k] [IsAlgClosed k]
+variable {A : Type*} [Ring A] [Algebra k A]
+variable {M : Type*} [AddCommGroup M] [Module k M] [Module A M]
+  [IsScalarTower k A M] [IsSimpleModule A M] [FiniteDimensional k M]
+
+/-- Cancellation for the `k`-action on a nonzero vector of a vector space: if two
+scalars agree after scaling a single nonzero vector, they are equal. -/
+private theorem smul_right_cancel₀ {c c' : k} {v : M} (hv : v ≠ 0)
+    (h : c • v = c' • v) : c = c' := by
+  by_contra hcc
+  have hkey : (c - c') • v = 0 := by rw [sub_smul, h, sub_self]
+  have hne : c - c' ≠ 0 := sub_ne_zero.mpr hcc
+  apply hv
+  have hcong := congrArg (fun x => (c - c')⁻¹ • x) hkey
+  simpa [smul_smul, inv_mul_cancel₀ hne] using hcong
+
+/-- **Uniqueness of the Schur scalar.** Over an algebraically closed field, the
+scalar `c` with `f = c • id` (whose existence is `schur_endomorphism_scalar`) is
+unique. -/
+theorem schur_scalar_unique (f : M →ₗ[A] M) : ∃! c : k, ∀ m, f m = c • m := by
+  obtain ⟨c, hc⟩ := SchursLemma.schur_endomorphism_scalar (k := k) f
+  refine ⟨c, hc, ?_⟩
+  intro c' hc'
+  haveI : Nontrivial M := IsSimpleModule.nontrivial A M
+  obtain ⟨v, hv⟩ := exists_ne (0 : M)
+  have h1 : c' • v = c • v := (hc' v).symm.trans (hc v)
+  exact smul_right_cancel₀ hv h1
+
+/-- The scalar map `c ↦ c • id : k → End_A(M)` is **injective** (Schur uniqueness). -/
+theorem schur_scalar_injective :
+    Function.Injective (fun c : k => (c • LinearMap.id : Module.End A M)) := by
+  intro c c' h
+  haveI : Nontrivial M := IsSimpleModule.nontrivial A M
+  obtain ⟨v, hv⟩ := exists_ne (0 : M)
+  have hv2 : c • v = c' • v := by
+    have := LinearMap.congr_fun h v
+    simpa using this
+  exact smul_right_cancel₀ hv hv2
+
+/-- The scalar map `c ↦ c • id : k → End_A(M)` is **surjective** (Schur scalar form). -/
+theorem schur_scalar_surjective :
+    Function.Surjective (fun c : k => (c • LinearMap.id : Module.End A M)) := by
+  intro f
+  obtain ⟨c, hc⟩ := SchursLemma.schur_endomorphism_eq_smul_id (k := k) f
+  exact ⟨c, hc.symm⟩
+
+/-- **The endomorphism algebra is exactly the scalars.** The map `c ↦ c • id` is a
+bijection `k → End_A(M)`. -/
+theorem schur_scalar_bijective :
+    Function.Bijective (fun c : k => (c • LinearMap.id : Module.End A M)) :=
+  ⟨schur_scalar_injective, schur_scalar_surjective⟩
+
+/-- The scalar map packaged as a `k`-linear map `k →ₗ[k] End_A(M)`. -/
+noncomputable def scalarLinearMap : k →ₗ[k] Module.End A M where
+  toFun c := c • LinearMap.id
+  map_add' a b := by rw [add_smul]
+  map_smul' a b := by
+    simp only [RingHom.id_apply, smul_eq_mul, mul_smul]
+
+/-- The `k`-linear equivalence `k ≃ₗ[k] End_A(M)` realizing the commutant as the
+scalars. -/
+noncomputable def scalarEquiv : k ≃ₗ[k] Module.End A M :=
+  LinearEquiv.ofBijective scalarLinearMap schur_scalar_bijective
+
+/-- **The commutant is one-dimensional.** The endomorphism algebra of a
+finite-dimensional simple `A`-module over an algebraically closed field is
+one-dimensional over `k` — the precise statement that the module is *absolutely
+simple*. -/
+theorem finrank_end_eq_one : Module.finrank k (Module.End A M) = 1 := by
+  rw [← LinearEquiv.finrank_eq scalarEquiv]
+  exact finrank_self k
+
+#check @schur_scalar_unique
+#check @schur_scalar_bijective
+#check @finrank_end_eq_one
+
+end SchursLemmaOQ02

--- a/src/data/proofs/schur-lemma-oq-02/annotations.json
+++ b/src/data/proofs/schur-lemma-oq-02/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-header-schurlemmaoq02",
+    "proofId": "schur-lemma-oq-02",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "From 'some scalar' to 'exactly the scalars'",
+    "content": "The parent file proves the scalar form of Schur's Lemma — every A-linear endomorphism of a finite-dimensional simple A-module over an algebraically closed field k equals c·id for SOME c. That existence statement is what you use to FIND a scalar. This entry adds the complementary half, uniqueness, and assembles both into the structural fact that the endomorphism algebra End_A(M) is exactly k: the scalar is unique, the map c ↦ c·id is a bijection, it is a k-linear equivalence k ≃ₗ End_A(M), and dim_k End_A(M) = 1. This one-dimensionality of the commutant is the formal meaning of absolute simplicity."
+  },
+  {
+    "id": "ann-cancellation-schurlemmaoq02",
+    "proofId": "schur-lemma-oq-02",
+    "range": { "startLine": 58, "endLine": 70 },
+    "type": "technique",
+    "title": "Why uniqueness holds: vector-space cancellation",
+    "content": "`smul_right_cancel₀` is the only genuinely new analytic step. If c·v = c'·v for a nonzero vector v, then (c − c')·v = 0. Over a field k, if c ≠ c' then c − c' is invertible, so scaling by (c − c')⁻¹ gives v = ((c−c')⁻¹·(c−c'))·v = 1·v = v on one side and (c−c')⁻¹·0 = 0 on the other, forcing v = 0 — a contradiction. This is exactly where 'k is a field' (and M is therefore a torsion-free vector space) is used; the same fact fails over a general ring."
+  },
+  {
+    "id": "ann-uniqueness-schurlemmaoq02",
+    "proofId": "schur-lemma-oq-02",
+    "range": { "startLine": 72, "endLine": 80 },
+    "type": "key-step",
+    "title": "Uniqueness of the Schur scalar",
+    "content": "`schur_scalar_unique` states ∃! c, ∀ m, f m = c·m. Existence is imported from the parent's `schur_endomorphism_scalar`. For uniqueness, a competing scalar c' satisfying the same pointwise identity agrees with c on a nonzero vector v (which exists because a simple module is nontrivial, `IsSimpleModule.nontrivial`), and the cancellation lemma collapses c' = c. This promotes the parent's existential to the unique scalar genuinely used in character theory."
+  },
+  {
+    "id": "ann-bijection-schurlemmaoq02",
+    "proofId": "schur-lemma-oq-02",
+    "range": { "startLine": 82, "endLine": 104 },
+    "type": "key-step",
+    "title": "The scalar map is a bijection",
+    "content": "The map c ↦ c·id : k → End_A(M) is injective (`schur_scalar_injective`, from the cancellation lemma applied to a nonzero vector) and surjective (`schur_scalar_surjective`, directly the parent's `schur_endomorphism_eq_smul_id`). `schur_scalar_bijective` bundles them. This is the clean statement that the endomorphisms commuting with the action are precisely the scalar multiples of the identity — nothing more."
+  },
+  {
+    "id": "ann-finrank-schurlemmaoq02",
+    "proofId": "schur-lemma-oq-02",
+    "range": { "startLine": 106, "endLine": 129 },
+    "type": "key-step",
+    "title": "Linear equivalence and the one-dimensional commutant",
+    "content": "`scalarLinearMap` repackages c ↦ c·id as a k-linear map k →ₗ[k] End_A(M) (additivity is `add_smul`, homogeneity is `mul_smul`). `scalarEquiv` upgrades the bijection to a linear equivalence `k ≃ₗ[k] End_A(M)` via `LinearEquiv.ofBijective`. Transporting dimension across it (`LinearEquiv.finrank_eq`) and using `finrank_self k = 1` gives `finrank_end_eq_one`: dim_k End_A(M) = 1. This is the headline — the endomorphism algebra of an absolutely simple module is one-dimensional, i.e. exactly the base field."
+  }
+]

--- a/src/data/proofs/schur-lemma-oq-02/meta.json
+++ b/src/data/proofs/schur-lemma-oq-02/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "schur-lemma-oq-02",
+  "title": "Schur's Lemma: the endomorphism algebra of an absolutely simple module is exactly the scalars",
+  "slug": "schur-lemma-oq-02",
+  "description": "The parent Schur's Lemma entry proves the scalar form — every A-linear endomorphism of a finite-dimensional simple A-module over an algebraically closed field k is multiplication by SOME scalar. This entry supplies the complementary half, uniqueness, and packages both into the structural statement that the endomorphism algebra collapses completely onto k: the Schur scalar is unique, the scalar map c ↦ c·id : k → End_A(M) is a bijection (hence a k-linear equivalence k ≃ₗ End_A(M)), and therefore dim_k End_A(M) = 1. This is the precise sense in which the module is absolutely simple — its commutant is just k.",
+  "meta": {
+    "author": "Research formalization 2026",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Schur%27s_lemma",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchursLemmaOQ02.lean",
+    "tags": [
+      "representation-theory",
+      "schur-lemma",
+      "module-theory",
+      "simple-modules",
+      "algebraically-closed",
+      "endomorphism-algebra",
+      "absolute-simplicity"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 129,
+    "assumptions": "None. Fully machine-checked: 0 axiom declarations, 0 sorries, no native_decide. Builds on the parent file's verified scalar form of Schur's Lemma; all new content uses standard Mathlib (field inverses, LinearEquiv.ofBijective, finrank_self) and depends only on the standard foundational axioms.",
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Schur's Lemma has two halves. The dichotomy (a map between simple modules is an isomorphism or zero) gives that the endomorphism ring of a simple module is a division ring. Over an algebraically closed field, finite-dimensionality collapses that division ring further: the only endomorphisms commuting with the action are the scalars. Serre (Linear Representations of Finite Groups, §2.2) states this corollary as the foundation of character theory; Curtis–Reiner (§27) phrase it as absolute simplicity. The parent gallery entry proves the existence of the Schur scalar; this entry establishes uniqueness and the resulting one-dimensionality of the commutant.",
+    "problemStatement": "Given a simple A-module M, finite-dimensional over an algebraically closed field k, show the endomorphism algebra End_A(M) is exactly k: the scalar c with f = c·id is unique, the scalar map k → End_A(M) is a bijection, and dim_k End_A(M) = 1.",
+    "text": "Upgrades the parent's existence-only scalar form of Schur's Lemma to the full structural statement that the commutant of an absolutely simple module is one-dimensional.",
+    "proofStrategy": "Uniqueness is the single new analytic ingredient: if c·v = c'·v for a nonzero vector v (which exists because a simple module is nontrivial), then (c − c')·v = 0; since M is a vector space over the field k, scaling by (c − c')⁻¹ would force v = 0 unless c = c'. Injectivity of the scalar map follows from this cancellation; surjectivity is the parent's scalar form. Bundling gives a bijection, hence (with k-linearity) a LinearEquiv k ≃ₗ End_A(M), and finrank_self yields dim_k End_A(M) = 1.",
+    "keyInsights": [
+      "**Uniqueness via vector-space cancellation**: over a field, a nonzero vector cannot be annihilated by a nonzero scalar, so the Schur scalar is unique (`schur_scalar_unique`).",
+      "**Bijection of the scalar map**: `c ↦ c·id : k → End_A(M)` is injective (uniqueness) and surjective (parent scalar form), hence bijective (`schur_scalar_bijective`).",
+      "**Linear equivalence**: the bijection is k-linear, giving `k ≃ₗ[k] End_A(M)` (`scalarEquiv`).",
+      "**One-dimensional commutant**: therefore `dim_k End_A(M) = 1` (`finrank_end_eq_one`) — the formal content of absolute simplicity.",
+      "**Existence vs structure**: the parent supplied 'some scalar'; the new uniqueness half turns that into 'exactly the scalars', the form actually used in character theory."
+    ],
+    "prerequisites": [
+      "Simple modules and Schur's dichotomy",
+      "Scalar form of Schur's Lemma (parent entry)",
+      "Vector spaces over a field (no nonzero scalar annihilates a nonzero vector)",
+      "Linear equivalences and finrank",
+      "Endomorphism algebra of a module"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Header and Overview",
+      "summary": "Frames the entry as the structural upgrade of the parent scalar form: existence of the Schur scalar (parent) plus uniqueness (here) yields that the endomorphism algebra of a finite-dimensional simple module over an algebraically closed field is exactly k. Lists the four results: uniqueness, bijection, linear equivalence, one-dimensionality.",
+      "startLine": 1,
+      "endLine": 56,
+      "mathContext": "End_A(M) ≅ k for M a finite-dimensional simple A-module over an algebraically closed field k (absolute simplicity)."
+    },
+    {
+      "id": "cancellation",
+      "title": "Vector-space cancellation",
+      "summary": "`smul_right_cancel₀`: if c·v = c'·v for a nonzero v in a vector space over a field k, then c = c'. Proof scales the relation (c − c')·v = 0 by (c − c')⁻¹, forcing v = 0 unless c = c'.",
+      "startLine": 58,
+      "endLine": 70,
+      "mathContext": "Over a field, c·v = c'·v with v ≠ 0 ⟹ c = c'."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of the Schur scalar",
+      "summary": "`schur_scalar_unique`: ∃! c, ∀ m, f m = c·m. Existence is the parent's `schur_endomorphism_scalar`; uniqueness applies the cancellation lemma to a nonzero vector of the (nontrivial) simple module.",
+      "startLine": 72,
+      "endLine": 80,
+      "mathContext": "The scalar c with f = c·id is unique."
+    },
+    {
+      "id": "bijection",
+      "title": "The scalar map is a bijection",
+      "summary": "`schur_scalar_injective` (from uniqueness/cancellation), `schur_scalar_surjective` (from the parent's `schur_endomorphism_eq_smul_id`), and `schur_scalar_bijective`: the map c ↦ c·id : k → End_A(M) is a bijection.",
+      "startLine": 82,
+      "endLine": 104,
+      "mathContext": "c ↦ c·id : k → End_A(M) is bijective."
+    },
+    {
+      "id": "equivalence-finrank",
+      "title": "Linear equivalence and one-dimensional commutant",
+      "summary": "`scalarLinearMap` packages c ↦ c·id as a k-linear map; `scalarEquiv` upgrades the bijection to `k ≃ₗ[k] End_A(M)` via `LinearEquiv.ofBijective`; `finrank_end_eq_one` concludes dim_k End_A(M) = 1 using `finrank_self`.",
+      "startLine": 106,
+      "endLine": 129,
+      "mathContext": "k ≃ₗ[k] End_A(M); dim_k End_A(M) = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "Schur's Lemma over an algebraically closed field collapses the endomorphism algebra of a finite-dimensional simple module entirely onto the scalars. This entry adds the uniqueness half that the parent's existence statement lacked, and assembles the two into the structural conclusion: the scalar map k → End_A(M) is a bijection, a k-linear equivalence k ≃ₗ End_A(M), and dim_k End_A(M) = 1. The module is absolutely simple — its commutant is exactly k. Everything is fully machine-checked with no axioms or sorries, on top of the verified parent entry.",
+    "significance": "The one-dimensionality of the commutant is the precise statement underlying the dimension counts of character theory (e.g. that the regular representation decomposes with multiplicities equal to dimensions). Formalizing uniqueness turns the parent's 'some scalar' into the usable 'exactly the scalars'.",
+    "futureWork": "Promote `scalarEquiv` to a k-algebra isomorphism k ≃ₐ[k] End_A(M); derive the hom-space dimension count between non-isomorphic simples (Hom = 0) and isomorphic simples (dim = 1) in module language; connect to the FDRep/character-theory orthogonality results."
+  },
+  "crossReferences": [
+    {
+      "targetId": "schur-lemma-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the scalar form of Schur's Lemma (existence of the Schur scalar)."
+    },
+    {
+      "targetId": "schur-lemma-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling: irreducible representations of abelian groups are one-dimensional (another consequence of the scalar form)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Serre, J.-P.",
+      "title": "Linear Representations of Finite Groups",
+      "year": "1977",
+      "venue": "Graduate Texts in Mathematics 42, §2.2",
+      "note": "Schur's lemma and the corollary that the commutant of an irreducible is the scalars."
+    },
+    {
+      "authors": "Curtis, C. W., Reiner, I.",
+      "title": "Representation Theory of Finite Groups and Associative Algebras",
+      "year": "1962",
+      "venue": "§27",
+      "note": "Absolutely simple modules: the endomorphism algebra is the base field."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.SimpleModule.Basic",
+      "Mathlib.LinearAlgebra.Eigenspace.Triangularizable",
+      "Mathlib.LinearAlgebra.Dimension.Finrank",
+      "Mathlib.Tactic",
+      "Proofs.SchursLemma"
+    ],
+    "namespace": "SchursLemmaOQ02",
+    "lineCount": 129,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "path": "Proofs/SchursLemmaOQ02.lean",
+    "sorries": 0,
+    "definitionCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent Schur's Lemma entry (`SchursLemma.lean`) proves the **scalar form**: over an algebraically closed field `k`, every `A`-linear endomorphism of a finite-dimensional simple `A`-module `M` is multiplication by *some* scalar. That existence statement lets you *find* a scalar. This entry adds the complementary half — **uniqueness** — and packages both into the structural statement that the endomorphism algebra collapses completely onto `k`.

## Results (all verified, 0 axioms)

- `schur_scalar_unique` — the Schur scalar is **unique**: `∃! c, ∀ m, f m = c • m`.
- `schur_scalar_bijective` — the scalar map `c ↦ c • id : k → End_A(M)` is a **bijection** (injective by uniqueness, surjective by the parent's scalar form).
- `scalarEquiv` — hence a `k`-linear equivalence `k ≃ₗ[k] End_A(M)`.
- `finrank_end_eq_one` — therefore `dim_k End_A(M) = 1`: the endomorphism algebra of an absolutely simple module is one-dimensional, i.e. **exactly the scalars**.

## The one new ingredient

Uniqueness rests on vector-space cancellation (`smul_right_cancel₀`): if `c • v = c' • v` for a nonzero `v`, then `(c − c') • v = 0`, and over a field scaling by `(c − c')⁻¹` forces `v = 0` unless `c = c'`. This is exactly where "k is a field" is used. Everything else is bookkeeping on top of the verified parent results.

## Significance

The one-dimensionality of the commutant is the precise statement of **absolute simplicity** and the engine behind the dimension counts of character theory. The parent supplied "some scalar"; the uniqueness half turns that into the usable "exactly the scalars".

## Files
- `proofs/Proofs/SchursLemmaOQ02.lean` (129 lines, 6 theorems, 2 defs, 0 axioms, 0 sorries)
- `src/data/proofs/schur-lemma-oq-02/{meta,annotations}.json`

## Verification
`lake env lean Proofs/SchursLemmaOQ02.lean` elaborates cleanly. No `axiom`/`sorry`/`native_decide`; builds on the verified parent entry, so it depends only on the standard foundational axioms — status `verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)