### PR TITLE
audit: 9 fresh gallery entries verified clean (tracker persist)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24678,6 +24678,60 @@
       "lastAudited": "2026-06-25T22:42:15Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-schwarz-oq-02-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-pnt-bridge-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-10-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-897-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fatou-lemma-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gamma-reflection-formula-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "konigsberg-oq-01-oq-02-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schur-lemma-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:53Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-02-ext-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:32:53Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited **9 never-before-audited** gallery entries this cycle. **All CLEAN** — meta.json claims match Lean source exactly (theorem/def counts verified, 0 sorry / 0 axiom / 0 `native_decide` / 0 `True`-stubs / 0 overclaimed badges).

| Slug | status/badge | thm | Notes |
|------|--------------|-----|-------|
| cauchy-schwarz-oq-02-oq-04-oq-02 | verified/original | 8 | Energy Cauchy–Schwarz genuinely re-derived from `discrim_le_zero` — no canned Mathlib CS; `original` honest |
| chebyshev-pnt-bridge-oq-05-oq-01 | verified/verified | 5 | |
| erdos-10-oq-01-incomplete-01 | verified/verified | 13 | |
| erdos-897-oq-01 | verified/original | 9 | |
| fatou-lemma-oq-01-oq-02 | verified/synthesis | 6 | |
| gamma-reflection-formula-oq-01-oq-02 | verified/original | 13 | |
| konigsberg-oq-01-oq-02-incomplete-01 | verified/verified | 12 | |
| schur-lemma-oq-02 | verified/verified | 6 | 6th thm is `private smul_right_cancel₀`; parent `SchursLemma.lean` honestly credited in overview — no delegation opacity |
| wilsons-theorem-oq-02-ext-oq-03 | verified/original | 6 | |

No integrity issues found. Queue fully drained (0 unaudited, 0 issues).

### Why a PR
`src/data/proofs/audit-tracker.json` is git-tracked, and the auditor sync loop (`git reset --hard origin/main`) reverts uncommitted completions — confirmed again this cycle when a concurrent agent's reset wiped the in-place completions. Persisting via PR per precedent #30337 / #30319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)