### PR TITLE
Enrich Covering-Congruence Obstruction k=1 (Erdős #10 OQ-01)

### DIFF
--- a/src/data/proofs/erdos-10-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-10-oq-01-incomplete-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 49 },
     "type": "concept",
     "title": "The k=1 case and Erdős's 1950 covering construction",
-    "content": "Erdős Problem #10 asks for a finite k making every (large) integer a prime plus at most k powers of 2. The parent OQ-01 file axiomatizes Crocker's 1971 theorem that k=2 fails. The k=1 case — integers of the form 2^a + p — is older and entirely elementary: Erdős (1950) built a covering system of congruences on the exponent a so that, for a whole arithmetic progression of n, the difference n − 2^a always shares a fixed small prime factor. The header tabulates the six exponent classes and the prime paired with each (via the multiplicative order of 2). This file formalizes the construction with no axioms and no sorries."
+    "content": "Erdős Problem #10 asks for a finite k making every (large) integer a prime plus at most k powers of 2. The parent OQ-01 file axiomatizes Crocker's 1971 theorem that k=2 fails. The k=1 case — integers of the form 2^a + p — is older and entirely elementary: Erdős (1950) built a covering system of congruences on the exponent a so that, for a whole arithmetic progression of n, the difference n − 2^a always shares a fixed small prime factor. The header tabulates the six exponent classes and the prime paired with each (via the multiplicative order of 2). This file formalizes the construction with no axioms and no sorries.",
+    "mathContext": "Covering system $\\{a\\equiv 0\\,(2),\\,0\\,(3),\\,1\\,(4),\\,3\\,(8),\\,7\\,(12),\\,23\\,(24)\\}$ paired with primes $\\{3,7,5,17,13,241\\}$; the CRT pins $n$ to one residue class mod $3\\cdot5\\cdot7\\cdot13\\cdot17\\cdot241 = 5592405$ so that $q\\mid(n-2^a)$ for every $a$.",
+    "significance": "context",
+    "relatedConcepts": ["covering systems", "Erdős problems", "powers of two", "additive number theory", "Crocker's theorem"],
+    "prerequisites": ["modular arithmetic", "prime numbers"]
   },
   {
     "id": "ann-periodicity-erdos10oq01inc01",
@@ -13,7 +17,11 @@
     "range": { "startLine": 50, "endLine": 67 },
     "type": "technique",
     "title": "Modular periodicity of 2^a",
-    "content": "`pow_two_mod_period` is the engine: if 2^d ≡ 1 (mod q) and q > 1, then 2^a mod q depends only on a mod d. The proof writes a = d·(a/d) + a%d, expands 2^a = (2^d)^(a/d) · 2^(a%d), and reduces (2^d)^(a/d) ≡ 1^(a/d) ≡ 1 (mod q) via `Nat.pow_mod`. The six `ord…` lemmas record that the order of 2 divides the stated modulus for each prime (ord 2 = 2,3,4,8,12,24 modulo 3,7,5,17,13,241), each discharged by `decide` — note 2^24 mod 241 is well within kernel reach."
+    "content": "`pow_two_mod_period` is the engine: if 2^d ≡ 1 (mod q) and q > 1, then 2^a mod q depends only on a mod d. The proof writes a = d·(a/d) + a%d, expands 2^a = (2^d)^(a/d) · 2^(a%d), and reduces (2^d)^(a/d) ≡ 1^(a/d) ≡ 1 (mod q) via `Nat.pow_mod`. The six `ord…` lemmas record that the order of 2 divides the stated modulus for each prime (ord 2 = 2,3,4,8,12,24 modulo 3,7,5,17,13,241), each discharged by `decide` — note 2^24 mod 241 is well within kernel reach.",
+    "mathContext": "If $2^d \\equiv 1 \\pmod q$ then $2^a \\equiv 2^{a \\bmod d} \\pmod q$, since $2^a = (2^d)^{\\lfloor a/d\\rfloor}\\cdot 2^{a\\bmod d}$ and $(2^d)^{\\lfloor a/d\\rfloor}\\equiv 1$. The multiplicative order $\\mathrm{ord}_q(2)$ is exactly the period of $a \\mapsto 2^a \\bmod q$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "Fermat's little theorem", "periodicity", "Nat.pow_mod", "Euclidean division"],
+    "prerequisites": ["multiplicative order modulo a prime", "modular exponentiation"]
   },
   {
     "id": "ann-covering-erdos10oq01inc01",
@@ -21,7 +29,11 @@
     "range": { "startLine": 69, "endLine": 75 },
     "type": "key-step",
     "title": "The covering system",
-    "content": "`covering` states that every natural number a lies in at least one of the six classes a≡0 (mod 2), a≡0 (mod 3), a≡1 (mod 4), a≡3 (mod 8), a≡7 (mod 12), a≡23 (mod 24). Because every congruence here depends only on a mod 24, the statement reduces to a finite check, which `omega` performs. This is the combinatorial core of the covering-congruence method: a finite set of residue classes whose union is all of ℤ."
+    "content": "`covering` states that every natural number a lies in at least one of the six classes a≡0 (mod 2), a≡0 (mod 3), a≡1 (mod 4), a≡3 (mod 8), a≡7 (mod 12), a≡23 (mod 24). Because every congruence here depends only on a mod 24, the statement reduces to a finite check, which `omega` performs. This is the combinatorial core of the covering-congruence method: a finite set of residue classes whose union is all of ℤ.",
+    "mathContext": "A covering system is a finite set of congruences $a \\equiv r_i \\pmod{m_i}$ whose union is all of $\\mathbb{Z}$. Here $\\{2,3,4,8,12,24\\}$ all divide $\\mathrm{lcm} = 24$, so coverage is a finite check on the $24$ residues; the density identity $\\tfrac12+\\tfrac13+\\tfrac14+\\tfrac18+\\tfrac1{12}+\\tfrac1{24}=\\tfrac{29}{24}>1$ is necessary (overlaps make it $=1$ effectively) for a cover.",
+    "significance": "key",
+    "relatedConcepts": ["covering systems", "least common multiple", "residue classes", "Erdős covering congruences", "omega decision procedure"],
+    "prerequisites": ["congruences", "least common multiple"]
   },
   {
     "id": "ann-obstruction-erdos10oq01inc01",
@@ -29,7 +41,11 @@
     "range": { "startLine": 77, "endLine": 119 },
     "type": "key-step",
     "title": "The covering obstruction",
-    "content": "`obstruction` shows that for any n in the CRT residue class (n ≡ 1 mod 3, 1 mod 7, 2 mod 5, 8 mod 17, 11 mod 13, 121 mod 241) and any exponent a, some covering prime q satisfies 2^a ≡ n (mod q), i.e. q ∣ (n − 2^a). Each of the six cases combines three facts with `omega` treating every `_ % q` as an atom: periodicity (2^a%q = 2^(a%d)%q), the per-class constant value (`rewrite [ha]; decide` — using `rewrite` rather than `rw` to avoid a trailing `rfl` that would force a slow kernel reduction of a concrete power), and the residue hypothesis."
+    "content": "`obstruction` shows that for any n in the CRT residue class (n ≡ 1 mod 3, 1 mod 7, 2 mod 5, 8 mod 17, 11 mod 13, 121 mod 241) and any exponent a, some covering prime q satisfies 2^a ≡ n (mod q), i.e. q ∣ (n − 2^a). Each of the six cases combines three facts with `omega` treating every `_ % q` as an atom: periodicity (2^a%q = 2^(a%d)%q), the per-class constant value (`rewrite [ha]; decide` — using `rewrite` rather than `rw` to avoid a trailing `rfl` that would force a slow kernel reduction of a concrete power), and the residue hypothesis.",
+    "mathContext": "For $n$ in the residue class and any $a$, the covering picks a class $a\\equiv r\\,(d)$ whose prime $q$ has $\\mathrm{ord}_q(2)=d$; then $2^a\\equiv 2^r\\equiv n \\pmod q$, so $q\\mid(n-2^a)$. The pairing is $(d,q,2^r\\bmod q)\\in\\{(2,3,1),(3,7,1),(4,5,2),(8,17,8),(12,13,11),(24,241,121)\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "divisibility", "multiplicative order", "covering systems", "modular constancy"],
+    "prerequisites": ["Chinese Remainder Theorem", "modular arithmetic", "divisibility"]
   },
   {
     "id": "ann-prime-forced-erdos10oq01inc01",
@@ -37,7 +53,11 @@
     "range": { "startLine": 121, "endLine": 143 },
     "type": "key-step",
     "title": "The prime is forced to be small",
-    "content": "`prime_forced_small` is the headline. For n in the residue class, if n = 2^a + p with p prime, then p ∈ {3,5,7,13,17,241}. The obstruction gives a covering prime q with 2^a ≡ n (mod q); since n = 2^a + p, this means q ∣ (n − 2^a) = p (via `Nat.modEq_iff_dvd'` and `Nat.add_sub_cancel_left`). A prime divisor of a prime equals it (`Nat.Prime.eq_one_or_self_of_dvd`, ruling out q = 1), so p = q is one of the six covering primes. Equivalently, n − 2^a is composite unless it is one of these six small primes — the elementary k=1 analogue of the parent's axiomatized k=2 Crocker theorem."
+    "content": "`prime_forced_small` is the headline. For n in the residue class, if n = 2^a + p with p prime, then p ∈ {3,5,7,13,17,241}. The obstruction gives a covering prime q with 2^a ≡ n (mod q); since n = 2^a + p, this means q ∣ (n − 2^a) = p (via `Nat.modEq_iff_dvd'` and `Nat.add_sub_cancel_left`). A prime divisor of a prime equals it (`Nat.Prime.eq_one_or_self_of_dvd`, ruling out q = 1), so p = q is one of the six covering primes. Equivalently, n − 2^a is composite unless it is one of these six small primes — the elementary k=1 analogue of the parent's axiomatized k=2 Crocker theorem.",
+    "mathContext": "$q \\mid (n-2^a)$ and $n=2^a+p$ give $q\\mid p$; with $p$ prime and $q>1$ this forces $p=q$. So $p\\in\\{3,5,7,13,17,241\\}$, i.e. $n-2^a$ is composite whenever it lies outside this six-element set. A prime $r$ has only divisors $1$ and $r$: $q\\mid p \\Rightarrow q\\in\\{1,p\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["prime divisibility", "Nat.modEq_iff_dvd'", "irreducibility of primes", "non-representability", "Goldbach-type problems"],
+    "prerequisites": ["prime numbers and divisibility", "modular congruence as divisibility"]
   },
   {
     "id": "ann-witness-erdos10oq01inc01",
@@ -45,7 +65,11 @@
     "range": { "startLine": 145, "endLine": 172 },
     "type": "technique",
     "title": "An explicit CRT witness and its residue class",
-    "content": "`witness` exhibits n₀ = 2036812, verified by `decide` to satisfy all six congruences. `residue_class_infinite` shows the residue class is infinite: the map t ↦ 2036812 + 5592405·t is injective and lands in the class because the modulus 5592405 = 3·5·7·13·17·241 is divisible by each prime modulus, so adding multiples of it preserves all six residues (membership checked by `omega`). `Set.infinite_of_injective_forall_mem` then yields infinitude."
+    "content": "`witness` exhibits n₀ = 2036812, verified by `decide` to satisfy all six congruences. `residue_class_infinite` shows the residue class is infinite: the map t ↦ 2036812 + 5592405·t is injective and lands in the class because the modulus 5592405 = 3·5·7·13·17·241 is divisible by each prime modulus, so adding multiples of it preserves all six residues (membership checked by `omega`). `Set.infinite_of_injective_forall_mem` then yields infinitude.",
+    "mathContext": "By CRT the six coprime congruences have a unique solution mod $M = 3\\cdot5\\cdot7\\cdot13\\cdot17\\cdot241 = 5592405$; here $n_0 = 2036812$. The full solution set is the arithmetic progression $\\{n_0 + Mt : t\\in\\mathbb{N}\\}$, infinite because $t\\mapsto n_0+Mt$ is injective and each $M\\equiv 0$ modulo every prime factor preserves the residues.",
+    "significance": "supporting",
+    "relatedConcepts": ["Chinese Remainder Theorem", "arithmetic progressions", "Set.Infinite", "injectivity", "explicit witnesses"],
+    "prerequisites": ["Chinese Remainder Theorem", "arithmetic progressions"]
   },
   {
     "id": "ann-main-erdos10oq01inc01",
@@ -53,6 +77,10 @@
     "range": { "startLine": 174, "endLine": 186 },
     "type": "key-step",
     "title": "Infinitely many obstructed integers",
-    "content": "`infinitely_many_forced` packages the result: there are infinitely many n such that every representation n = 2^a + p (p prime) forces p into {3,5,7,13,17,241}. It follows by monotonicity of `Set.Infinite` from `residue_class_infinite`, since each member of the residue class satisfies `prime_forced_small`. This is an infinite arithmetic progression of integers for which a single power of two plus a prime can only reach them through six fixed small primes."
+    "content": "`infinitely_many_forced` packages the result: there are infinitely many n such that every representation n = 2^a + p (p prime) forces p into {3,5,7,13,17,241}. It follows by monotonicity of `Set.Infinite` from `residue_class_infinite`, since each member of the residue class satisfies `prime_forced_small`. This is an infinite arithmetic progression of integers for which a single power of two plus a prime can only reach them through six fixed small primes.",
+    "mathContext": "Since $\\{n : \\forall a\\,p,\\ p\\text{ prime}\\wedge n=2^a+p \\Rightarrow p\\in C\\} \\supseteq$ the (infinite) CRT residue class, monotonicity of $\\mathsf{Set.Infinite}$ gives the result: an infinite AP of $n$ each representable as $2^a+p$ only via $p\\in\\{3,5,7,13,17,241\\}$. Thus all but finitely many shifts $n-2^a$ are composite.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Infinite monotonicity", "covering systems", "arithmetic progressions", "Erdős Problem #10", "additive number theory"],
+    "prerequisites": ["infinite sets", "arithmetic progressions"]
   }
 ]

--- a/src/data/proofs/erdos-10-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-10-oq-01-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos10OQ01Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos10Oq01Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos10Oq01Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos10Oq01Incomplete01Data: ProofData = {
+  proof: erdos10Oq01Incomplete01Proof,
+  annotations: erdos10Oq01Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-10-oq-01-incomplete-01`.

## Critical fix
- **Created missing `index.ts`** — without it, Vite's `import.meta.glob` could not discover the proof, so the page showed *"proof not found"* on the live site despite appearing in the gallery listing.

## Annotation depth (all 7 annotations)
- Added `mathContext` with LaTeX (covering system, multiplicative-order periodicity $2^a\equiv 2^{a\bmod d}$, CRT residue class mod 5592405, prime-divisor-of-a-prime collapse).
- Added `significance` (key/supporting/context), `relatedConcepts`, and `prerequisites` to each annotation.

## Verification
- `pnpm build` succeeds (data enrichment + tsc typecheck + vite build).
- meta.json axiom integrity unchanged and accurate: `status: verified`, `badge: verified`, `axiomCount: 0` — the Lean file has 0 axioms, 0 sorries, and uses only `decide`/`omega` (no `native_decide`).