### PR TITLE
audit: 2 fresh gallery entries verified clean (erdos-8-oq-02, de-moivre-oq-05-oq-02)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24732,6 +24732,12 @@
       "lastAudited": "2026-06-25T23:32:53Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-8-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:39:15Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24738,6 +24738,12 @@
       "lastAudited": "2026-06-25T23:39:15Z",
       "result": "clean",
       "issues": []
+    },
+    "de-moivre-oq-05-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-25T23:41:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 2 entries CLEAN

Tracker-only change (audit-tracker.json is git-tracked, so completions must land via PR to survive `git reset --hard`).

### 1. erdos-8-oq-02 — "Difficulty-Maximizing Colourings for Monochromatic Coverings" (#30338)
| Check | meta | source | OK |
|-------|------|--------|----|
| sorries / axioms / native_decide / True | 0/0/–/– | 0/0/0/0 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| definitionCount | 10 | 10 | ✓ |

- Badge `original` justified: core results (`SeparatesSmall`, `separatesSmall_avoids`, `separatesSmall_needs_ge_B_colors`) are original combinatorial content; Mathlib deps are Finset-cardinality infrastructure, not core-result wrappers.
- No axiom masking: Hough's minimum-modulus bound carried as explicit hypothesis `hbound`, never an axiom. `status: verified` / `axiomCount: 0` correct.

### 2. de-moivre-oq-05-oq-02 — "Sum of the Primitive n-th Roots of Unity is μ(n)"
| Check | meta | source | OK |
|-------|------|--------|----|
| sorries / axioms / native_decide / True | 0/0/–/– | 0/0/0/0 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 0 | 0 | ✓ |

- Badge `original` borderline-but-defensible: the identity ∑ primitive roots = μ(n) is assembled from Mathlib's Möbius-inversion + biUnion partition + geometric-sum lemmas into a result not itself in Mathlib, plus two original helper lemmas and a non-trivial single-term survival calc.
- Disclosure exemplary: `description` and `assumptions` explicitly credit Mathlib's primitive-root / Möbius-inversion APIs and delineate original vs imported work — no overclaim, no "first formalization" language.

Both entries clean. No code changes; tracker only.

---
Discovered during gallery integrity audit.