### PR TITLE
Enrich Schur's Lemma OQ-02 (endomorphism algebra is exactly the scalars)

### DIFF
--- a/src/data/proofs/schur-lemma-oq-02/annotations.json
+++ b/src/data/proofs/schur-lemma-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 56 },
     "type": "concept",
     "title": "From 'some scalar' to 'exactly the scalars'",
-    "content": "The parent file proves the scalar form of Schur's Lemma — every A-linear endomorphism of a finite-dimensional simple A-module over an algebraically closed field k equals c·id for SOME c. That existence statement is what you use to FIND a scalar. This entry adds the complementary half, uniqueness, and assembles both into the structural fact that the endomorphism algebra End_A(M) is exactly k: the scalar is unique, the map c ↦ c·id is a bijection, it is a k-linear equivalence k ≃ₗ End_A(M), and dim_k End_A(M) = 1. This one-dimensionality of the commutant is the formal meaning of absolute simplicity."
+    "content": "The parent file proves the scalar form of Schur's Lemma — every A-linear endomorphism of a finite-dimensional simple A-module over an algebraically closed field k equals c·id for SOME c. That existence statement is what you use to FIND a scalar. This entry adds the complementary half, uniqueness, and assembles both into the structural fact that the endomorphism algebra End_A(M) is exactly k: the scalar is unique, the map c ↦ c·id is a bijection, it is a k-linear equivalence k ≃ₗ End_A(M), and dim_k End_A(M) = 1. This one-dimensionality of the commutant is the formal meaning of absolute simplicity.",
+    "mathContext": "$\\operatorname{End}_A(M) \\cong k$ for $M$ a finite-dimensional simple $A$-module over an algebraically closed field $k$; equivalently $\\dim_k \\operatorname{End}_A(M) = 1$. The commutant of an absolutely simple module is exactly the scalar multiples of the identity.",
+    "significance": "context",
+    "relatedConcepts": ["Schur's lemma", "endomorphism algebra", "absolute simplicity", "commutant", "character theory"],
+    "prerequisites": ["simple modules", "representation theory"]
   },
   {
     "id": "ann-cancellation-schurlemmaoq02",
@@ -13,7 +17,11 @@
     "range": { "startLine": 58, "endLine": 70 },
     "type": "technique",
     "title": "Why uniqueness holds: vector-space cancellation",
-    "content": "`smul_right_cancel₀` is the only genuinely new analytic step. If c·v = c'·v for a nonzero vector v, then (c − c')·v = 0. Over a field k, if c ≠ c' then c − c' is invertible, so scaling by (c − c')⁻¹ gives v = ((c−c')⁻¹·(c−c'))·v = 1·v = v on one side and (c−c')⁻¹·0 = 0 on the other, forcing v = 0 — a contradiction. This is exactly where 'k is a field' (and M is therefore a torsion-free vector space) is used; the same fact fails over a general ring."
+    "content": "`smul_right_cancel₀` is the only genuinely new analytic step. If c·v = c'·v for a nonzero vector v, then (c − c')·v = 0. Over a field k, if c ≠ c' then c − c' is invertible, so scaling by (c − c')⁻¹ gives v = ((c−c')⁻¹·(c−c'))·v = 1·v = v on one side and (c−c')⁻¹·0 = 0 on the other, forcing v = 0 — a contradiction. This is exactly where 'k is a field' (and M is therefore a torsion-free vector space) is used; the same fact fails over a general ring.",
+    "mathContext": "Over a field $k$: $c\\cdot v = c'\\cdot v$ with $v \\neq 0 \\implies c = c'$. From $(c-c')\\cdot v = 0$ and $c-c' \\neq 0$ invertible, $v = (c-c')^{-1}(c-c')\\cdot v = (c-c')^{-1}\\cdot 0 = 0$, contradiction. A nonzero scalar never annihilates a nonzero vector in a $k$-vector space.",
+    "significance": "key",
+    "relatedConcepts": ["field invertibility", "torsion-free modules", "scalar cancellation", "vector spaces", "proof by contradiction"],
+    "prerequisites": ["fields and inverses", "module/vector-space axioms"]
   },
   {
     "id": "ann-uniqueness-schurlemmaoq02",
@@ -21,7 +29,11 @@
     "range": { "startLine": 72, "endLine": 80 },
     "type": "key-step",
     "title": "Uniqueness of the Schur scalar",
-    "content": "`schur_scalar_unique` states ∃! c, ∀ m, f m = c·m. Existence is imported from the parent's `schur_endomorphism_scalar`. For uniqueness, a competing scalar c' satisfying the same pointwise identity agrees with c on a nonzero vector v (which exists because a simple module is nontrivial, `IsSimpleModule.nontrivial`), and the cancellation lemma collapses c' = c. This promotes the parent's existential to the unique scalar genuinely used in character theory."
+    "content": "`schur_scalar_unique` states ∃! c, ∀ m, f m = c·m. Existence is imported from the parent's `schur_endomorphism_scalar`. For uniqueness, a competing scalar c' satisfying the same pointwise identity agrees with c on a nonzero vector v (which exists because a simple module is nontrivial, `IsSimpleModule.nontrivial`), and the cancellation lemma collapses c' = c. This promotes the parent's existential to the unique scalar genuinely used in character theory.",
+    "mathContext": "$\\exists!\\, c \\in k,\\ \\forall m,\\ f(m) = c\\cdot m$. Existence: parent's $\\texttt{schur\\_endomorphism\\_scalar}$. Uniqueness: a simple module is nontrivial ($M \\neq 0$), so pick $v \\neq 0$; if $c' \\cdot v = c \\cdot v$ then cancellation forces $c' = c$.",
+    "significance": "key",
+    "relatedConcepts": ["existential uniqueness (∃!)", "nontriviality of simple modules", "Schur scalar", "IsSimpleModule.nontrivial", "character theory"],
+    "prerequisites": ["simple modules are nonzero", "scalar cancellation"]
   },
   {
     "id": "ann-bijection-schurlemmaoq02",
@@ -29,7 +41,11 @@
     "range": { "startLine": 82, "endLine": 104 },
     "type": "key-step",
     "title": "The scalar map is a bijection",
-    "content": "The map c ↦ c·id : k → End_A(M) is injective (`schur_scalar_injective`, from the cancellation lemma applied to a nonzero vector) and surjective (`schur_scalar_surjective`, directly the parent's `schur_endomorphism_eq_smul_id`). `schur_scalar_bijective` bundles them. This is the clean statement that the endomorphisms commuting with the action are precisely the scalar multiples of the identity — nothing more."
+    "content": "The map c ↦ c·id : k → End_A(M) is injective (`schur_scalar_injective`, from the cancellation lemma applied to a nonzero vector) and surjective (`schur_scalar_surjective`, directly the parent's `schur_endomorphism_eq_smul_id`). `schur_scalar_bijective` bundles them. This is the clean statement that the endomorphisms commuting with the action are precisely the scalar multiples of the identity — nothing more.",
+    "mathContext": "$\\varphi : k \\to \\operatorname{End}_A(M),\\ c \\mapsto c\\cdot \\mathrm{id}$ is bijective. Injective: $\\varphi(c) = \\varphi(c') \\Rightarrow c\\cdot v = c'\\cdot v \\Rightarrow c = c'$. Surjective: every $A$-linear $f$ is $c\\cdot\\mathrm{id}$ for some $c$ (parent scalar form). Hence $\\operatorname{End}_A(M) = k\\cdot\\mathrm{id}$.",
+    "significance": "key",
+    "relatedConcepts": ["bijection", "injectivity and surjectivity", "scalar matrices", "Module.End", "LinearMap.congr_fun"],
+    "prerequisites": ["injective/surjective functions", "endomorphism module"]
   },
   {
     "id": "ann-finrank-schurlemmaoq02",
@@ -37,6 +53,10 @@
     "range": { "startLine": 106, "endLine": 129 },
     "type": "key-step",
     "title": "Linear equivalence and the one-dimensional commutant",
-    "content": "`scalarLinearMap` repackages c ↦ c·id as a k-linear map k →ₗ[k] End_A(M) (additivity is `add_smul`, homogeneity is `mul_smul`). `scalarEquiv` upgrades the bijection to a linear equivalence `k ≃ₗ[k] End_A(M)` via `LinearEquiv.ofBijective`. Transporting dimension across it (`LinearEquiv.finrank_eq`) and using `finrank_self k = 1` gives `finrank_end_eq_one`: dim_k End_A(M) = 1. This is the headline — the endomorphism algebra of an absolutely simple module is one-dimensional, i.e. exactly the base field."
+    "content": "`scalarLinearMap` repackages c ↦ c·id as a k-linear map k →ₗ[k] End_A(M) (additivity is `add_smul`, homogeneity is `mul_smul`). `scalarEquiv` upgrades the bijection to a linear equivalence `k ≃ₗ[k] End_A(M)` via `LinearEquiv.ofBijective`. Transporting dimension across it (`LinearEquiv.finrank_eq`) and using `finrank_self k = 1` gives `finrank_end_eq_one`: dim_k End_A(M) = 1. This is the headline — the endomorphism algebra of an absolutely simple module is one-dimensional, i.e. exactly the base field.",
+    "mathContext": "The bijection is $k$-linear ($\\varphi(a+b) = \\varphi(a)+\\varphi(b)$ via $\\texttt{add\\_smul}$; $\\varphi(ab) = a\\,\\varphi(b)$ via $\\texttt{mul\\_smul}$), so it lifts to $k \\simeq_{\\ell}[k] \\operatorname{End}_A(M)$. Dimension is a linear-equivalence invariant, hence $\\dim_k \\operatorname{End}_A(M) = \\dim_k k = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["LinearEquiv.ofBijective", "finrank invariance", "finrank_self", "one-dimensional vector space", "k-algebra structure"],
+    "prerequisites": ["linear equivalences", "finite-dimensional vector spaces", "finrank"]
   }
 ]

--- a/src/data/proofs/schur-lemma-oq-02/index.ts
+++ b/src/data/proofs/schur-lemma-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SchursLemmaOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const schurLemmaOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const schurLemmaOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const schurLemmaOq02Data: ProofData = {
+  proof: schurLemmaOq02Proof,
+  annotations: schurLemmaOq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `schur-lemma-oq-02`.

## Critical fix
- **Created missing `index.ts`** — without it, Vite's `import.meta.glob` could not discover the proof, so the page showed *"proof not found"* on the live site despite appearing in the gallery listing.

## Annotation depth (all 5 annotations)
- Added `mathContext` with LaTeX: $\operatorname{End}_A(M)\cong k$, vector-space cancellation $(c-c')v=0\Rightarrow c=c'$, the $\exists!$ Schur scalar, bijectivity of $c\mapsto c\cdot\mathrm{id}$, and $\dim_k\operatorname{End}_A(M)=1$ via linear-equivalence invariance.
- Added `significance`, `relatedConcepts`, and `prerequisites` to each annotation.

## Verification
- `pnpm build` succeeds (data enrichment + tsc typecheck + vite build).
- Axiom integrity unchanged and accurate: `status: verified`, `badge: verified`, `axiomCount: 0` — the Lean file has 0 axioms, 0 sorries, no `native_decide`; builds on the verified parent `SchursLemma`.