### PR TITLE
Enrich Weighted (generating-function) LGV algebraic core — annotation depth

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-03/annotations.json
@@ -8,7 +8,21 @@
     },
     "type": "definition",
     "title": "Weighted-Path Configuration and Generating-Function Matrix",
-    "content": "`WeightedLGV R r` abstracts a weighted LGV configuration over a commutative ring $R$: for each source $i$ and target $j$, a finite type `Path i j` of lattice paths and a weight `weight i j : Path i j → R`. The generating-function matrix is $H_{ij} = \\sum_{P : i \\to j} w(P)$ (`WeightedLGV.matrix`), the weighted replacement for the parent's binomial path-count matrix. A $\\sigma$-path family (`Family σ`) chooses a path $i \\to \\sigma(i)$ for every $i$, with multiplicative weight $\\prod_i w(f_i)$ (`familyWeight`)."
+    "content": "`WeightedLGV R r` abstracts a weighted LGV configuration over a commutative ring $R$: for each source $i$ and target $j$, a finite type `Path i j` of lattice paths and a weight `weight i j : Path i j → R`. The generating-function matrix is $H_{ij} = \\sum_{P : i \\to j} w(P)$ (`WeightedLGV.matrix`), the weighted replacement for the parent's binomial path-count matrix. A $\\sigma$-path family (`Family σ`) chooses a path $i \\to \\sigma(i)$ for every $i$, with multiplicative weight $\\prod_i w(f_i)$ (`familyWeight`).",
+    "mathContext": "$H_{ij} = \\sum_{P : A_i \\to B_j} w(P)$ replaces the unweighted count $e(A_i,B_j)=\\#\\{P : A_i\\to B_j\\}$. A $\\sigma$-family is an element of the dependent product $\\prod_i \\mathrm{Path}(i,\\sigma i)$ with weight $\\prod_i w(f_i)$. Setting $w\\equiv 1$ recovers $H_{ij}=e(A_i,B_j)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "generating functions",
+      "Lindström–Gessel–Viennot lemma",
+      "lattice paths",
+      "path weights / monomials",
+      "matrix of formal sums"
+    ],
+    "prerequisites": [
+      "commutative rings",
+      "finite types and Fintype",
+      "matrices over a ring"
+    ]
   },
   {
     "id": "ann-wlgv-algebraic-core",
@@ -19,7 +33,21 @@
     },
     "type": "theorem",
     "title": "Algebraic Core: det H = Signed Generating Function of Path Families",
-    "content": "`det_matrix_eq_signed_family_sum` is the unconditional algebraic half of weighted LGV: $\\det H = \\sum_\\sigma \\operatorname{sign}(\\sigma)\\, \\sum_{f : \\text{Family }\\sigma} \\prod_i w(f_i)$. The proof transposes to the column Leibniz form ($\\det H = \\det H^\\top$, then `Matrix.det_apply`) giving $\\sum_\\sigma \\operatorname{sign}(\\sigma)\\prod_i H_{i,\\sigma(i)}$, and expands each product of entrywise generating functions into a sum over path families via `Fintype.prod_sum` ($\\prod_i \\sum_j f_{ij} = \\sum_{x} \\prod_i f_i(x_i)$). No lattice geometry is used, so it holds over any commutative ring."
+    "content": "`det_matrix_eq_signed_family_sum` is the unconditional algebraic half of weighted LGV: $\\det H = \\sum_\\sigma \\operatorname{sign}(\\sigma)\\, \\sum_{f : \\text{Family }\\sigma} \\prod_i w(f_i)$. The proof transposes to the column Leibniz form ($\\det H = \\det H^\\top$, then `Matrix.det_apply`) giving $\\sum_\\sigma \\operatorname{sign}(\\sigma)\\prod_i H_{i,\\sigma(i)}$, and expands each product of entrywise generating functions into a sum over path families via `Fintype.prod_sum` ($\\prod_i \\sum_j f_{ij} = \\sum_{x} \\prod_i f_i(x_i)$). No lattice geometry is used, so it holds over any commutative ring.",
+    "mathContext": "$\\det H = \\sum_{\\sigma\\in S_r} \\operatorname{sign}(\\sigma)\\sum_{f\\in\\prod_i\\mathrm{Path}(i,\\sigma i)}\\prod_i w(f_i)$. Key step — distributivity of product over sum (the finite product-of-sums identity): $\\prod_i\\bigl(\\sum_{p} g_{i,p}\\bigr) = \\sum_{f\\in\\prod_i I_i}\\prod_i g_{i,f_i}$, applied to the Leibniz term $\\prod_i H_{i,\\sigma i}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Leibniz determinant expansion",
+      "Matrix.det_apply",
+      "Fintype.prod_sum (distributivity)",
+      "sign of a permutation",
+      "transpose invariance det Hᵀ = det H"
+    ],
+    "prerequisites": [
+      "determinant as a signed permutation sum",
+      "distributivity of products over sums",
+      "permutations Perm (Fin r)"
+    ]
   },
   {
     "id": "ann-wlgv-card-specialisation",
@@ -30,7 +58,20 @@
     },
     "type": "theorem",
     "title": "Weight-1 Specialisation Recovers the Unweighted Determinant",
-    "content": "`det_matrix_eq_signed_card_sum` sets every weight to $1$: each `familyWeight` collapses to $\\prod 1 = 1$, so the inner sum counts the families and $\\det H = \\sum_\\sigma \\operatorname{sign}(\\sigma)\\,\\#(\\text{Family }\\sigma)$ — exactly the parent's unweighted `det_pathMatrix_eq_signed_sum`. This confirms the weighted statement is a genuine generalisation."
+    "content": "`det_matrix_eq_signed_card_sum` sets every weight to $1$: each `familyWeight` collapses to $\\prod 1 = 1$, so the inner sum counts the families and $\\det H = \\sum_\\sigma \\operatorname{sign}(\\sigma)\\,\\#(\\text{Family }\\sigma)$ — exactly the parent's unweighted `det_pathMatrix_eq_signed_sum`. This confirms the weighted statement is a genuine generalisation.",
+    "mathContext": "With $w\\equiv 1$: $\\prod_i w(f_i)=1$, so $\\sum_{f\\in\\mathrm{Family}\\,\\sigma}1 = \\#\\mathrm{Family}(\\sigma)$ and $\\det H = \\sum_\\sigma \\operatorname{sign}(\\sigma)\\,\\#\\mathrm{Family}(\\sigma)$, the counting form. The weighted identity is thus a strict refinement: the same signed sum graded by monomial weight rather than collapsed to a cardinality.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialisation w = 1",
+      "Finset.sum_const / counting",
+      "unweighted LGV (parent)",
+      "generalisation check",
+      "Fintype.card"
+    ],
+    "prerequisites": [
+      "the algebraic-core identity",
+      "summing a constant over a finite type"
+    ]
   },
   {
     "id": "ann-wlgv-open-goal",
@@ -41,6 +82,19 @@
     },
     "type": "remark",
     "title": "Open Goal: The Full Weighted LGV Lemma",
-    "content": "`WeightedLGVConjecture` records the full theorem $\\det H = \\sum_{\\text{non-intersecting identity families}} \\prod_i w(f_i)$ as a `def : Prop`. The algebraic core reduces it to weight-invariance of the Gessel–Viennot sign-reversing involution (the tail swap proved unweighted in the parent's `gv_involution_cancellation`): the swap only redistributes existing steps among a family's paths, preserving their total multiset and hence $\\prod w$. This statement is neither proved nor assumed here — nothing in the file depends on it."
+    "content": "`WeightedLGVConjecture` records the full theorem $\\det H = \\sum_{\\text{non-intersecting identity families}} \\prod_i w(f_i)$ as a `def : Prop`. The algebraic core reduces it to weight-invariance of the Gessel–Viennot sign-reversing involution (the tail swap proved unweighted in the parent's `gv_involution_cancellation`): the swap only redistributes existing steps among a family's paths, preserving their total multiset and hence $\\prod w$. This statement is neither proved nor assumed here — nothing in the file depends on it.",
+    "mathContext": "Target: $\\det H = \\sum_{f\\in\\mathrm{Family}\\,1,\\ \\text{non-intersecting}}\\prod_i w(f_i)$. The remaining gap is showing the tail-swap involution $\\iota$ satisfies $\\operatorname{sign}(\\sigma_{\\iota(f)})\\prod w(\\iota(f)_i) = -\\operatorname{sign}(\\sigma_f)\\prod w(f_i)$, i.e. it is weight-preserving (the multiset of steps is invariant) and sign-reversing, so all intersecting / $\\sigma\\neq 1$ terms cancel pairwise.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gessel–Viennot involution",
+      "sign-reversing involution",
+      "non-intersecting path families",
+      "tail swap",
+      "open problem / future work"
+    ],
+    "prerequisites": [
+      "the unweighted LGV involution (parent)",
+      "multisets of steps along a path"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-03-oq-02-oq-03`.

The entry already had a structured `overview`, `conclusion`, and 4 `sections`, but its 4 annotations lacked the dedicated `mathContext`/`significance`/`relatedConcepts`/`prerequisites` fields. This pass adds them.

## Added to all 4 annotations
- **`mathContext`** (LaTeX): the generating-function matrix $H_{ij}=\sum_P w(P)$, the algebraic-core identity $\det H = \sum_\sigma \operatorname{sign}(\sigma)\sum_f \prod_i w(f_i)$ via the product-of-sums distributivity $\prod_i\sum_p g_{i,p}=\sum_f\prod_i g_{i,f_i}$, the $w\equiv1$ counting specialisation, and the open Gessel–Viennot weight-invariant sign-reversing involution.
- **`significance`**, **`relatedConcepts`**, **`prerequisites`** on each.

## Verification
- `pnpm build` succeeds.
- Axiom integrity unchanged: 0 axioms, 0 sorries; the open `WeightedLGVConjecture` is a `def : Prop` that is neither proved nor assumed (nothing depends on it), so the file remains the unconditional algebraic half.