### PR TITLE
audit: halls-theorem-oq-01-oq-03 verified clean (tracker persist)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24744,8 +24744,14 @@
       "lastAudited": "2026-06-25T23:41:32Z",
       "result": "clean",
       "issues": []
+    },
+    "halls-theorem-oq-01-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-25T23:56:46Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-25T23:00:00Z"
+  "lastUpdated": "2026-06-25T23:56:46Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: \`halls-theorem-oq-01-oq-03\` — *Regular Bipartite Graphs Have a Perfect Matching (Hall via Double Counting)*

Fresh researcher entry, not previously in the audit tracker. Audited and verified clean.

### Mechanical checks (`proofs/Proofs/HallsTheoremOQ01OQ03.lean`)
- 0 `sorry`
- 0 `axiom` declarations
- 0 `native_decide`
- 0 `True` stubs / `trivial` proofs
- 5 theorems/lemmas + 1 structure → matches meta `theoremCount=5`, `definitionCount=1`
- No structure-encoded assumptions (`IsBiregular` fields are theorem hypotheses, not claimed-proven facts)

### Claim assessment
`status: verified`, `badge: original` — **justified**. The genuinely new content, `exists_perfect_matching_of_regular` (every k-regular bipartite graph, k≥1, has a perfect matching), is absent from Mathlib and the gallery, which carry only the *conditional* marriage theorems. Mathlib's `Finset.all_card_le_biUnion_card_iff_exists_injective` is used as a **disclosed input lemma**; the regular-case assembly (double-counting identity `sum_card_eq` → balance + Hall's condition → bijectivity upgrade) is independent work. Disclosure is exemplary: the description leads with Mathlib credit, `mathlibDependencies` are fully listed, and `originalContributions` are precisely scoped to what is independently proved.

This PR only adds the tracker entry (`src/data/proofs/audit-tracker.json`). The proof data itself arrives via the researcher's separate PR.

---
Discovered during autonomous gallery integrity audit.