### PR TITLE
Enrich The Second Chebyshev Function ψ and Legendre's Identity (chebyshev-bounds-oq-02)

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02/annotations.json
@@ -8,7 +8,44 @@
     },
     "type": "concept",
     "title": "The Second Chebyshev Function in von Mangoldt Form",
-    "content": "ψ(x) = ∑_{p^k ≤ x} log p sums log p once for each prime power p^k ≤ x. Written with the von Mangoldt function Λ — which is log p on prime powers p^k and 0 elsewhere — this is simply ψ(n) = ∑_{m ≤ n} Λ(m). This packaging is what makes Mathlib's vonMangoldt_sum (∑_{d∣m} Λ(d) = log m) directly usable, and it gives nonnegativity and monotonicity for free from the same property of Λ."
+    "content": "ψ(x) = ∑_{p^k ≤ x} log p sums log p once for each prime power p^k ≤ x. Written with the von Mangoldt function Λ — which is log p on prime powers p^k and 0 elsewhere — this is simply ψ(n) = ∑_{m ≤ n} Λ(m). This packaging is what makes Mathlib's vonMangoldt_sum (∑_{d∣m} Λ(d) = log m) directly usable, and it gives nonnegativity and monotonicity for free from the same property of Λ.",
+    "mathContext": "$\\psi(x) = \\sum_{p^k \\le x} \\log p = \\sum_{m \\le n} \\Lambda(m)$, where $\\Lambda(m) = \\log p$ if $m = p^k$ is a prime power and $0$ otherwise. Nonnegativity $0 \\le \\psi(n)$ and monotonicity $\\psi(m) \\le \\psi(n)$ for $m \\le n$ both reduce to $\\Lambda \\ge 0$ termwise.",
+    "significance": "key",
+    "relatedConcepts": [
+      "von Mangoldt function",
+      "Chebyshev functions θ and ψ",
+      "prime-counting function π(x)",
+      "prime powers"
+    ],
+    "prerequisites": [
+      "the von Mangoldt function Λ",
+      "Finset summation over an interval",
+      "monotonicity of sums of nonnegative terms"
+    ]
+  },
+  {
+    "id": "ann-prod-factorial",
+    "proofId": "chebyshev-bounds-oq-02",
+    "range": {
+      "startLine": 57,
+      "endLine": 62
+    },
+    "type": "technique",
+    "title": "The Factorial as a Product Over [1,n]",
+    "content": "Before logarithms enter, n! is reorganised as the product ∏_{m∈[1,n]} m by a one-line induction (prod_Icc_succ_top peels off the top factor, mul_comm matches Nat.factorial_succ). This product form is the hinge that lets Real.log_prod turn log(n!) into ∑_{m≤n} log m — the step both Legendre's identity and the ψ-bound start from.",
+    "mathContext": "$\\prod_{m=1}^{n} m = n!$, proved by induction with $\\prod_{m=1}^{n+1} m = \\big(\\prod_{m=1}^{n} m\\big)\\cdot(n+1)$. Casting to $\\mathbb{R}$ and applying $\\log(\\prod a_i) = \\sum \\log a_i$ (valid as each $m \\ge 1 > 0$) gives $\\log(n!) = \\sum_{m=1}^{n} \\log m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "factorial",
+      "logarithm of a product",
+      "induction over Finset.Icc",
+      "Real.log_prod"
+    ],
+    "prerequisites": [
+      "factorials and finite products",
+      "induction on the upper bound of an interval",
+      "log of a product of positive reals"
+    ]
   },
   {
     "id": "ann-divisors-filter",
@@ -19,7 +56,20 @@
     },
     "type": "insight",
     "title": "Making Both Inner Sums Range Over [1,n]",
-    "content": "The summation swap needs both inner sums over the *same fixed* set. `divisors_eq_filter` does this: for m ∈ [1,n], every divisor of m is itself ≤ m ≤ n, so m.divisors equals the elements of [1,n] dividing m. With that, log m = ∑_{d∈[1,n]} (if d∣m then Λ d else 0). `card_multiples_Icc` supplies the dual count — the number of multiples of d in [1,n] is ⌊n/d⌋ — by rewriting [1,n] as (0,n] and invoking Nat.Ioc_filter_dvd_card_eq_div."
+    "content": "The summation swap needs both inner sums over the *same fixed* set. `divisors_eq_filter` does this: for m ∈ [1,n], every divisor of m is itself ≤ m ≤ n, so m.divisors equals the elements of [1,n] dividing m. With that, log m = ∑_{d∈[1,n]} (if d∣m then Λ d else 0). `card_multiples_Icc` supplies the dual count — the number of multiples of d in [1,n] is ⌊n/d⌋ — by rewriting [1,n] as (0,n] and invoking Nat.Ioc_filter_dvd_card_eq_div.",
+    "mathContext": "For $m \\in [1,n]$: $\\{d : d \\mid m\\} = \\{d \\in [1,n] : d \\mid m\\}$ since $d \\mid m \\Rightarrow d \\le m \\le n$. Dually $\\#\\{x \\in [1,n] : d \\mid x\\} = \\lfloor n/d \\rfloor$, after rewriting $[1,n] = (0,n]$ to match Mathlib's $\\texttt{Nat.Ioc\\_filter\\_dvd\\_card\\_eq\\_div}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisor sets",
+      "Fubini / interchange of summation",
+      "floor function ⌊n/d⌋",
+      "counting multiples in an interval"
+    ],
+    "prerequisites": [
+      "divisibility and divisor sets in Mathlib",
+      "Finset.filter and cardinality",
+      "the identity #multiples of d in [1,n] = ⌊n/d⌋"
+    ]
   },
   {
     "id": "ann-legendre",
@@ -30,7 +80,21 @@
     },
     "type": "insight",
     "title": "Legendre's Identity — a Fubini Swap",
-    "content": "log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ is proved in three moves: expand log(n!) = ∑_{m≤n} log m; replace each log m by its von Mangoldt divisor sum ∑_{d∣m} Λ(d); then swap the order of the two finite sums over [1,n] (Finset.sum_comm). After the swap, the d-th inner sum collects Λ(d) once per multiple of d in [1,n] — exactly ⌊n/d⌋ of them. This is the elementary identity from which Chebyshev's bounds θ(n), ψ(n) = Θ(n) follow by telescoping log((2n)!) − 2 log(n!) and comparing with the central binomial coefficient."
+    "content": "log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ is proved in three moves: expand log(n!) = ∑_{m≤n} log m; replace each log m by its von Mangoldt divisor sum ∑_{d∣m} Λ(d); then swap the order of the two finite sums over [1,n] (Finset.sum_comm). After the swap, the d-th inner sum collects Λ(d) once per multiple of d in [1,n] — exactly ⌊n/d⌋ of them. This is the elementary identity from which Chebyshev's bounds θ(n), ψ(n) = Θ(n) follow by telescoping log((2n)!) − 2 log(n!) and comparing with the central binomial coefficient.",
+    "mathContext": "$\\log(n!) = \\sum_{m\\le n}\\log m = \\sum_{m\\le n}\\sum_{d\\mid m}\\Lambda(d) = \\sum_{d\\le n}\\Lambda(d)\\sum_{\\substack{m\\le n \\\\ d\\mid m}} 1 = \\sum_{d=1}^{n}\\Lambda(d)\\,\\big\\lfloor n/d\\big\\rfloor.$ The middle equality is $\\texttt{vonMangoldt\\_sum}$; the third is $\\texttt{Finset.sum\\_comm}$; the count of multiples is $\\lfloor n/d\\rfloor$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Legendre's formula for v_p(n!)",
+      "von Mangoldt summatory identity",
+      "interchange of double sums",
+      "Chebyshev prime-counting bounds",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "log of a product and of a factorial",
+      "∑_{d∣m} Λ(d) = log m (vonMangoldt_sum)",
+      "Finset.sum_comm and counting multiples"
+    ]
   },
   {
     "id": "ann-psi-bound",
@@ -41,6 +105,19 @@
     },
     "type": "concept",
     "title": "A First Bound: ψ(n) ≤ log(n!)",
-    "content": "Since Λ(m) ≤ log m termwise (vonMangoldt_le_log) — the von Mangoldt value is log p ≤ log m on a prime power m = p^k and 0 otherwise — summing over [1,n] gives ψ(n) = ∑ Λ(m) ≤ ∑ log m = log(n!). This is the easy half of the chain that, combined with Legendre's identity, brackets ψ(n) between constant multiples of n in the full Chebyshev argument."
+    "content": "Since Λ(m) ≤ log m termwise (vonMangoldt_le_log) — the von Mangoldt value is log p ≤ log m on a prime power m = p^k and 0 otherwise — summing over [1,n] gives ψ(n) = ∑ Λ(m) ≤ ∑ log m = log(n!). This is the easy half of the chain that, combined with Legendre's identity, brackets ψ(n) between constant multiples of n in the full Chebyshev argument.",
+    "mathContext": "$\\Lambda(m) \\le \\log m$ for every $m$ (equality forced to $0$ off prime powers), so $\\psi(n) = \\sum_{m\\le n}\\Lambda(m) \\le \\sum_{m\\le n}\\log m = \\log(n!)$. Combined with the lower bound from Legendre's identity this yields $\\psi(n) = \\Theta(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "von Mangoldt ≤ log",
+      "termwise comparison of sums",
+      "Chebyshev upper bound",
+      "asymptotic ψ(x) ∼ x (Prime Number Theorem)"
+    ],
+    "prerequisites": [
+      "Λ(n) ≤ log n (vonMangoldt_le_log)",
+      "monotonicity of finite sums",
+      "log(n!) = ∑_{m≤n} log m"
+    ]
   }
 ]

--- a/src/data/proofs/chebyshev-bounds-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02/meta.json
@@ -68,6 +68,14 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Imports, Statement, and Setup",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Imports Mathlib, opens Finset and ArithmeticFunction, and frames the goal: define the second Chebyshev function ψ in von Mangoldt form and prove Legendre's identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋, the elementary engine of the Chebyshev bounds.",
+      "mathContext": "Working namespace ChebyshevBoundsOQ02 with Λ = ArithmeticFunction.vonMangoldt; the parent's second open direction is the ψ function."
+    },
+    {
       "id": "psi-def",
       "title": "The Second Chebyshev Function ψ",
       "startLine": 38,


### PR DESCRIPTION
Enrichment pass for `chebyshev-bounds-oq-02` (quality 63, passes 0).

The entry was meta-rich (structured overview, conclusion, crossReferences, references) but its 4 annotations carried only `content` — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. Those are the highest-impact gaps.

## Changes
- **Annotation depth**: added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- **Coverage**: added a 5th annotation `ann-prod-factorial` for `prod_Icc_id_eq_factorial` (the factorial-as-product technique, lines 57–62) that the previous set skipped.
- **Sections**: added a `setup` section covering the imports/statement/namespace (lines 1–36), previously uncovered.

## Verification
- Annotation alignment: `resolver.ts validate` → **Valid: 5, Misaligned: 0**.
- `pnpm build` passes; entry present in `data-manifest.json`.
- Mathematically accurate to the Lean source; no claims altered. Axiom status (verified, 0 axioms) preserved and consistent with the file.
- No `index.ts` added (loader uses listings.json + data-manifest.json).