### PR TITLE
Add growth guardrails for autonomous enrichment & OQ-spawn loops (#30347)

### DIFF
--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -12,6 +12,46 @@ Enrich the proof gallery by deepening the quality of every entry:
 5. **Cross-references**: Link to related proofs in the gallery
 6. **Sections**: Ensure `sections` array covers the full Lean file with meaningful summaries
 
+## CRITICAL: Size Guardrails — Quality Is Curation, Not Accretion
+
+**Enrichment has an upper bound. Bigger is NOT better.** Your goal is a *readable, inviting* page, not the largest possible one. Monotonically deepening the shallowest field on every pass produces unreadable, intimidating entries that scare away users. A landing-page classic that has grown to hundreds of KB is a defect, not an achievement.
+
+Honor these hard caps on `meta.json`. Treat them as ceilings, not targets:
+
+| Limit | Cap |
+|-------|-----|
+| Whole `meta.json` file | **≤ ~60 KB** (≈3× the gallery p99 of ~34 KB) |
+| `overview.keyInsights` | **≤ 12 items** |
+| `crossReferences` | **≤ 20 items** |
+| `references` | **≤ 25 items** |
+| `relatedProblems` / `conclusion.openQuestions` | **≤ 15 items** |
+| Any single `keyInsight` / item string | **≤ ~2 KB** |
+
+### Diminishing-Returns / SKIP Rule (MANDATORY)
+
+**Before deepening anything, check the size first:**
+
+```bash
+ID=<target-id>
+SIZE=$(wc -c < "src/data/proofs/$ID/meta.json")
+echo "meta.json is $SIZE bytes"
+# Or run the guardrail check directly:
+npx tsx scripts/gallery/check-meta-size.ts "$ID"
+```
+
+Then decide:
+
+1. **If `meta.json` is already at/above ~60 KB**, OR a collection is already at its cap:
+   - **DO NOT deepen the shallowest field.** Adding more content here makes the page worse.
+   - **SKIP this entry** and move to the next target (lower-pass entries benefit far more), **or** switch to **consolidation/trimming**: merge redundant keyInsights, drop the weakest/duplicate crossReferences, tighten verbose prose. Trimming an over-cap entry back under the cap is high-value work.
+   - Log the skip: `echo "$(date +%H:%M): SKIP $ID (over size cap, $SIZE bytes)" >> "$REPO_ROOT/.loom/logs/$ENRICHER_ID.actions.log"`
+
+2. **If a collection is at its cap but the file is under 60 KB**: do not append to that collection. Either improve an *existing* item in place (without exceeding the per-item cap) or enrich a *different*, under-cap field (e.g. annotations).
+
+3. **If the entry is comfortably under all caps**: enrich normally, but stop as soon as you would cross a cap. Never split one logical insight into many items to game the per-item cap.
+
+**Reframing:** "quality" means a focused, well-curated page — not the sum of every fact you can find. When in doubt, prefer fewer, sharper insights over more, shallower ones, and prefer skipping an already-rich entry over inflating it further. The companion cleanup of already-bloated entries is tracked in #30348; do not let those entries grow further.
+
 ## Environment Setup
 
 You receive these environment variables:
@@ -90,7 +130,9 @@ For a target with id `<id>`, read:
 
 #### 3. Assess Quality Gaps
 
-Look for these common gaps:
+**First, apply the Size Guardrails / SKIP rule above.** Check `wc -c src/data/proofs/<id>/meta.json` (or `npx tsx scripts/gallery/check-meta-size.ts <id>`). If the entry is already at/above ~60 KB or any collection is at its cap, SKIP it or switch to trimming — do not deepen it.
+
+Otherwise, look for these common gaps:
 
 **In annotations.json:**
 - Missing `mathContext` field (LaTeX explanation of the math)
@@ -113,12 +155,14 @@ Look for these common gaps:
 - `sections` not covering the full Lean file
 - No `mathContext` fields
 
-**Quality target per entry:**
+**Quality target per entry** (these are *minimums to reach, then stop* — see the Size Guardrails above for the matching ceilings):
 - At least 5 annotations with `mathContext`, `significance`, and `relatedConcepts`
-- `historicalContext` > 200 characters with real historical information
-- At least 4 `keyInsights` that reveal deep mathematical understanding
-- `conclusion` with `summary`, `implications`, and 2+ `openQuestions`
+- `historicalContext` between ~200 characters and ~2 KB with real historical information
+- 4–12 `keyInsights` that reveal deep mathematical understanding (stop at 12)
+- `conclusion` with `summary`, `implications`, and 2+ `openQuestions` (≤ 15)
 - `sections` covering all major parts of the proof
+
+Once an entry meets these targets, it is **done** — do not keep deepening it on subsequent passes. Move to a lower-pass entry instead.
 
 #### 4. Make Targeted Improvements
 

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -214,6 +214,24 @@ Generate 1-2 strong follow-up questions. Apply quality criteria:
 
 If no strong follow-up exists, generate 0 questions. This is preferable to weak proposals.
 
+**OQ-chain depth guard (MANDATORY).** Follow-up questions become child gallery
+entries via the Seeker (`<parent>-oq-NN`), which can recurse without bound. Before
+proposing any follow-up:
+
+```bash
+# Count -oq- segments already in the current problem's slug.
+OQ_DEPTH=$(echo "$SLUG" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
+```
+
+- **If the current problem is already at depth ≥ 3** (its slug already contains 3 or
+  more `-oq-` segments), generate **0** follow-up questions. A depth-4 child would
+  exceed the cap and the Seeker will refuse to spawn it anyway.
+- **Never** propose a follow-up that merely re-asks the same question the current
+  problem answers (this is what produces degenerate `-oq-01-oq-01-oq-01…` loops).
+  A follow-up must open a genuinely new direction, not recurse on the same index.
+- Keep chains shallow: prefer broadening back toward the original gallery entry
+  (new sibling questions) over drilling deeper into an already-deep OQ descendant.
+
 ### Work Categories
 
 | Decision | Criteria | Action |

--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -39,7 +39,10 @@ fi
 
 # Guard 2 — Same-index repetition: refuse a slug whose tail repeats one OQ index.
 # e.g. ...-oq-01-oq-01-oq-01 is a single question being re-spawned in a loop.
-if echo "$SLUG" | grep -Eq '(-oq-[0-9]+)\1\1'; then
+# Portable + backreference-free (POSIX ERE has no backrefs; the agents' `grep`
+# resolves to ugrep, which errors on `\1`): list each -oq-NN one per line, then
+# flag 3+ consecutive identical indices via `uniq -c` + `awk`.
+if echo "$SLUG" | grep -oE -- '-oq-[0-9]+' | uniq -c | awk '$1>=3{f=1} END{exit !f}'; then
   echo "REJECT $SLUG: repeats the same -oq-NN index 3+ times in a row"
   # skip this candidate
 fi
@@ -189,7 +192,9 @@ jq -e ".candidates[] | select(.id == \"$PROBLEM_ID\")" .lean/state/candidate-poo
 # Step 4e: Initialize research workspace
 # GUARD: re-check OQ chain depth before spawning (never init past depth 3).
 OQ_DEPTH=$(echo "$PROBLEM_ID" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
-if [ "$OQ_DEPTH" -gt 3 ] || echo "$PROBLEM_ID" | grep -Eq '(-oq-[0-9]+)\1\1'; then
+# Same-index re-check: backreference-free (ugrep rejects `\1` in ERE). List each
+# -oq-NN one per line, then flag 3+ consecutive identical indices.
+if [ "$OQ_DEPTH" -gt 3 ] || echo "$PROBLEM_ID" | grep -oE -- '-oq-[0-9]+' | uniq -c | awk '$1>=3{f=1} END{exit !f}'; then
   echo "ABORT: $PROBLEM_ID violates OQ-chain guardrails (depth=$OQ_DEPTH). Pick a shallower problem."
   exit 1
 fi

--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -21,6 +21,45 @@ Problems are extracted from the lean-genius proof gallery:
 | **Millennium** | Millennium Prize Problems | `millenniumProblem` field |
 | **Hilbert** | Hilbert's 23 Problems | `hilbertNumber` field |
 
+## CRITICAL: OQ-Chain Guardrails (MANDATORY)
+
+Open-question (OQ) problems spawn a **new gallery entry** from an existing entry's open question; that child then exposes its *own* open questions, which can be spawned again — recursively, with no natural stopping point. Unbounded, this produces degenerate chains like `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` (eleven levels deep, with seven consecutive `-oq-01` segments re-spawning the same "first open question" forever).
+
+**Before selecting or initializing ANY problem whose slug contains `-oq-`, apply all three guards. REJECT the candidate if it fails any of them.**
+
+```bash
+SLUG="$PROBLEM_ID"
+
+# Guard 1 — Recursion-depth cap: at most 3 -oq- segments in a chain.
+DEPTH=$(echo "$SLUG" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
+if [ "$DEPTH" -gt 3 ]; then
+  echo "REJECT $SLUG: OQ chain depth $DEPTH exceeds cap of 3"
+  # skip this candidate; pick another problem
+fi
+
+# Guard 2 — Same-index repetition: refuse a slug whose tail repeats one OQ index.
+# e.g. ...-oq-01-oq-01-oq-01 is a single question being re-spawned in a loop.
+if echo "$SLUG" | grep -Eq '(-oq-[0-9]+)\1\1'; then
+  echo "REJECT $SLUG: repeats the same -oq-NN index 3+ times in a row"
+  # skip this candidate
+fi
+
+# Guard 3 — Sibling dedupe: refuse a child whose math content duplicates an
+# existing sibling. Compare the proposed problem statement against siblings
+# sharing the same parent prefix.
+PARENT=$(echo "$SLUG" | sed 's/-oq-[0-9]*$//')
+ls -d src/data/proofs/"$PARENT"-oq-* 2>/dev/null   # inspect existing siblings
+# If any sibling's conclusion/problemStatement is substantively the same
+# question, REJECT and pick a different open question.
+```
+
+**Rules:**
+- **Depth cap:** never spawn a child at depth > 3 (`-oq-` appears at most 3 times in the slug). Past depth 3, the marginal mathematical value is essentially zero and the page tree becomes unreadable.
+- **No same-index loops:** never spawn a child whose slug tail repeats the same `-oq-NN` index three or more times consecutively. A genuinely new question gets a new index; a repeated index signals the loop is re-asking the same question.
+- **Dedupe siblings:** never spawn a child whose mathematical content duplicates an existing sibling under the same parent. Prefer a distinct open question, or skip.
+
+These guards also belong in the Candidate Quality Gate below — reject violators there too, so they never reach `research.sh init`.
+
 ## The Problem Registry
 
 Run the extractor to generate the problem list:
@@ -148,6 +187,12 @@ python3 research/db/sync_pool.py
 jq -e ".candidates[] | select(.id == \"$PROBLEM_ID\")" .lean/state/candidate-pool.json > /dev/null
 
 # Step 4e: Initialize research workspace
+# GUARD: re-check OQ chain depth before spawning (never init past depth 3).
+OQ_DEPTH=$(echo "$PROBLEM_ID" | grep -o -- '-oq-[0-9]*' | wc -l | tr -d ' ')
+if [ "$OQ_DEPTH" -gt 3 ] || echo "$PROBLEM_ID" | grep -Eq '(-oq-[0-9]+)\1\1'; then
+  echo "ABORT: $PROBLEM_ID violates OQ-chain guardrails (depth=$OQ_DEPTH). Pick a shallower problem."
+  exit 1
+fi
 ./.lean/scripts/research.sh init $(echo $PROBLEM_ID | sed 's/-oq-[0-9]*$//')
 
 # Update problem.md with the specific question
@@ -207,6 +252,9 @@ function select_problem():
 Before returning any candidate, apply these rejection criteria:
 
 **REJECT if:**
+- **OQ chain depth > 3** (slug contains more than three `-oq-` segments) — see OQ-Chain Guardrails above
+- **Slug repeats the same `-oq-NN` index 3+ times in a row** (e.g. `-oq-01-oq-01-oq-01`) — a re-spawn loop
+- **Content duplicates an existing sibling** under the same parent prefix
 - Problem is a near-duplicate of any problem completed in the last 30 days
   (check `research/problems/*/knowledge.md` for similar titles/descriptions)
 - Problem is a shallow specialization or notation variant of an existing gallery proof

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm annotations:build && pnpm research:build && pnpm research:enrich && tsc -b && vite build",
+    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm gallery:check-size && pnpm annotations:build && pnpm research:build && pnpm research:enrich && tsc -b && vite build",
     "lint": "eslint .",
+    "gallery:check-size": "tsx scripts/gallery/check-meta-size.ts",
+    "gallery:check-size:strict": "tsx scripts/gallery/check-meta-size.ts --strict",
+    "gallery:size-report": "tsx scripts/gallery/check-meta-size.ts --report",
     "preview": "vite preview",
     "deploy": "pnpm build && wrangler pages deploy dist --project-name=lean-genius --commit-dirty=true",
     "annotations:build": "tsx scripts/annotations/build.ts",

--- a/scripts/gallery/check-meta-size.ts
+++ b/scripts/gallery/check-meta-size.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env npx tsx
+/**
+ * Gallery meta.json size guardrail.
+ *
+ * Autonomous enrichment (see .lean/roles/enricher.md) historically only ever
+ * "deepened" fields with lower bounds and no upper bound, so the most-visited
+ * entries bloated without limit (abel-ruffini grew to ~646 KB vs a ~13 KB gallery
+ * median). This check flags any src/data/proofs/<id>/meta.json that exceeds the
+ * per-file cap so regressions are caught early. Root cause + guardrails: #30347.
+ * Cleanup of the already-bloated entries is tracked separately in #30348.
+ *
+ * Defaults to WARN mode (prints offenders, exits 0) so it can run inside the
+ * build without breaking on the entries that are still pending #30348 cleanup.
+ *
+ * Run:
+ *   npx tsx scripts/gallery/check-meta-size.ts            # warn: list over-cap entries
+ *   npx tsx scripts/gallery/check-meta-size.ts <id>       # check a single entry
+ *   npx tsx scripts/gallery/check-meta-size.ts --strict   # fail (exit 1) on non-allowlisted offenders
+ *   npx tsx scripts/gallery/check-meta-size.ts --report   # one-shot report of all entries over the report threshold (feeds #30348)
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const ROOT = path.join(__dirname, '../..')
+const PROOFS_DIR = path.join(ROOT, 'src/data/proofs')
+
+// Per-file cap: ~3x the gallery p99 (~34 KB). See #30347.
+const FILE_CAP_BYTES = 60 * 1024
+// Lower threshold used only for the one-shot --report (feeds cleanup issue #30348).
+const REPORT_THRESHOLD_BYTES = 30 * 1024
+
+// Per-collection caps (mirrors .lean/roles/enricher.md). Informational in warn
+// mode; counted toward failures in --strict mode.
+const COLLECTION_CAPS: Record<string, number> = {
+  'overview.keyInsights': 12,
+  crossReferences: 20,
+  references: 25,
+  relatedProblems: 15,
+  'conclusion.openQuestions': 15,
+}
+
+// Known-bloated entries that predate the guardrails. They are exempt from
+// --strict failure until #30348 redistributes their content. Do NOT add new
+// entries here — fix the bloat instead.
+const ALLOWLIST = new Set<string>([
+  'abel-ruffini',
+  'abel-ruffini-galois-extensions',
+])
+
+const STRICT = process.argv.includes('--strict')
+const REPORT = process.argv.includes('--report')
+const SINGLE_ID = process.argv.slice(2).find((a) => !a.startsWith('--'))
+
+function kb(bytes: number): string {
+  return `${(bytes / 1024).toFixed(1)} KB`
+}
+
+function getNested(obj: unknown, dottedKey: string): unknown {
+  return dottedKey.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object' && key in (acc as Record<string, unknown>)) {
+      return (acc as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}
+
+interface Offender {
+  id: string
+  bytes: number
+  overCollections: string[]
+}
+
+function listEntryIds(): string[] {
+  if (SINGLE_ID) return [SINGLE_ID]
+  if (!fs.existsSync(PROOFS_DIR)) return []
+  return fs
+    .readdirSync(PROOFS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort()
+}
+
+function inspectEntry(id: string): { bytes: number; overCollections: string[] } | null {
+  const metaPath = path.join(PROOFS_DIR, id, 'meta.json')
+  if (!fs.existsSync(metaPath)) return null
+  const bytes = fs.statSync(metaPath).size
+
+  const overCollections: string[] = []
+  try {
+    const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'))
+    for (const [key, cap] of Object.entries(COLLECTION_CAPS)) {
+      const value = getNested(meta, key)
+      if (Array.isArray(value) && value.length > cap) {
+        overCollections.push(`${key}=${value.length} (cap ${cap})`)
+      }
+    }
+  } catch {
+    // Malformed JSON is caught by other build steps; size still reported.
+  }
+
+  return { bytes, overCollections }
+}
+
+function main(): void {
+  const ids = listEntryIds()
+  if (ids.length === 0) {
+    console.error(`No gallery entries found under ${path.relative(ROOT, PROOFS_DIR)}`)
+    process.exit(SINGLE_ID ? 1 : 0)
+  }
+
+  const offenders: Offender[] = []
+  const reportRows: Offender[] = []
+
+  for (const id of ids) {
+    const result = inspectEntry(id)
+    if (!result) {
+      if (SINGLE_ID) {
+        console.error(`Entry "${id}" has no meta.json`)
+        process.exit(1)
+      }
+      continue
+    }
+    const row: Offender = { id, bytes: result.bytes, overCollections: result.overCollections }
+    if (result.bytes > FILE_CAP_BYTES || result.overCollections.length > 0) {
+      offenders.push(row)
+    }
+    if (result.bytes > REPORT_THRESHOLD_BYTES) {
+      reportRows.push(row)
+    }
+  }
+
+  if (REPORT) {
+    reportRows.sort((a, b) => b.bytes - a.bytes)
+    console.log(`# Gallery meta.json over ${kb(REPORT_THRESHOLD_BYTES)} (feeds #30348)`)
+    console.log(`# ${reportRows.length} entries, cap is ${kb(FILE_CAP_BYTES)}\n`)
+    for (const row of reportRows) {
+      const flag = row.bytes > FILE_CAP_BYTES ? 'OVER-CAP' : 'over-report'
+      console.log(`${kb(row.bytes).padStart(10)}  ${flag.padEnd(11)}  ${row.id}`)
+    }
+    return
+  }
+
+  const overCap = offenders.filter((o) => o.bytes > FILE_CAP_BYTES)
+  const nonAllowlistedOverCap = overCap.filter((o) => !ALLOWLIST.has(o.id))
+
+  if (offenders.length === 0) {
+    console.log(`meta.json size check: all ${ids.length} entries within caps (file ≤ ${kb(FILE_CAP_BYTES)}).`)
+    return
+  }
+
+  console.log(`meta.json size check: ${overCap.length} entr${overCap.length === 1 ? 'y' : 'ies'} over the ${kb(FILE_CAP_BYTES)} file cap:`)
+  overCap
+    .sort((a, b) => b.bytes - a.bytes)
+    .forEach((o) => {
+      const tag = ALLOWLIST.has(o.id) ? ' [allowlisted — see #30348]' : ''
+      console.log(`  ${kb(o.bytes).padStart(10)}  ${o.id}${tag}`)
+    })
+
+  const collectionOffenders = offenders.filter((o) => o.overCollections.length > 0)
+  if (collectionOffenders.length > 0) {
+    console.log(`\nEntries over a per-collection cap:`)
+    collectionOffenders.forEach((o) => {
+      console.log(`  ${o.id}: ${o.overCollections.join(', ')}`)
+    })
+  }
+
+  console.log(
+    `\nGuardrails: .lean/roles/enricher.md (per-file ≤ ${kb(FILE_CAP_BYTES)}). ` +
+      `Cleanup of pre-existing bloat: #30348.`,
+  )
+
+  if (STRICT && nonAllowlistedOverCap.length > 0) {
+    console.error(
+      `\nFAIL (--strict): ${nonAllowlistedOverCap.length} non-allowlisted entr${nonAllowlistedOverCap.length === 1 ? 'y' : 'ies'} over the file cap.`,
+    )
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

Fixes the root cause of runaway gallery-entry growth: two autonomous loops grew entries with **lower bounds but no upper bounds**. This PR is **guardrails + tooling only** — no gallery content is edited (that cleanup is #30348).

### Root cause #1 — Enricher had no size ceiling
`.lean/roles/enricher.md` only enforced minimums ("deepen X"), so the most-visited entries bloated without limit (`abel-ruffini/meta.json` ~646 KB vs ~13 KB gallery median, 293 mostly-"deepen" commits).

**Fix:** added a prominent **Size Guardrails** section with hard caps and a mandatory **diminishing-returns / SKIP rule**:
- Per-file: `meta.json ≤ ~60 KB` (≈3× p99).
- Per-collection: `keyInsights ≤ 12`, `crossReferences ≤ 20`, `references ≤ 25`, `relatedProblems`/`openQuestions ≤ 15`.
- Per-item: a single keyInsight ≤ ~2 KB.
- If an entry is at/above a cap, the Enricher must **skip it or switch to consolidation/trimming** rather than deepen its shallowest field. Quality reframed as curation, not accretion. Wired into the workflow's "Assess Quality Gaps" step.

### Root cause #2 — OQ-spawner had no recursion/dedupe limit
The Seeker derived parents via `sed 's/-oq-[0-9]*$//'` with no depth or cycle check, producing an 11-deep chain with seven consecutive `-oq-01` segments.

**Fix:**
- `.lean/roles/seeker.md`: **OQ-Chain Guardrails** section — recursion-depth cap (≤ 3 `-oq-` segments), refusal of slugs that repeat the same `-oq-NN` index 3+ times, and a sibling dedupe guard. Enforced in the Candidate Quality Gate **and** guarded at the `research.sh init` step.
- `.lean/roles/researcher.md`: follow-up question generation now caps at OQ depth 3 and forbids same-question re-spawns.

### CI / validation check
- `scripts/gallery/check-meta-size.ts` + `package.json` (`gallery:check-size`, `:strict`, `gallery:size-report`).
- Wired into `pnpm build` in **warn mode** (lists offenders, exits 0) so it catches regressions without breaking the build on entries still pending #30348. The two named bloated entries (`abel-ruffini`, `abel-ruffini-galois-extensions`) are allowlisted with a comment pointing at #30348; `--strict` fails on any *non-allowlisted* over-cap entry once cleanup lands.
- `--report` emits a one-shot list of all over-cap entries (currently **62 over 30 KB**, 11 over 60 KB) to feed #30348.

## Testing
- `npx tsx scripts/gallery/check-meta-size.ts` (warn) → lists 11 over-cap entries, exits 0.
- `... abel-ruffini` (single entry) and a small entry → correct per-entry output.
- `--strict` → exits 1 on 9 non-allowlisted offenders.
- `--report` → 62 entries over 30 KB, matching the issue's diagnosis.

## Scope
Docs/role-config + tooling only. No `lake build` run. No `src/data/proofs/*/meta.json` content edited.

Closes #30347

🤖 Generated with [Claude Code](https://claude.com/claude-code)