### PR TITLE
Research: de-moivre-oq-05-oq-02 — sum of primitive n-th roots of unity = μ(n)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1020,6 +1020,7 @@ import Proofs.DeMoivreOQ05OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01OQ01OQ03
+import Proofs.DeMoivreOQ05OQ02
 import Proofs.DenumerabilityRationals
 import Proofs.DenumerabilityRationalsOQ01
 import Proofs.DenumerabilityRationalsOQ02

--- a/proofs/Proofs/DeMoivreOQ05OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ05OQ02.lean
@@ -1,0 +1,125 @@
+import Mathlib
+
+/-
+# De Moivre OQ-05-OQ-02: The Sum of the Primitive n-th Roots of Unity is μ(n)
+
+## Research Problem: de-moivre-oq-05-oq-02
+
+Let `μ` denote the Möbius function.  This file proves the classical identity
+
+  ∑_{ζ a primitive n-th root of unity} ζ = μ(n)            (in ℂ, for every n).
+
+This generalises the parent result `de-moivre-oq-05`, which records that the sum
+of *all* n-th roots of unity vanishes for n > 1 (it equals `1` only for n = 1).
+
+## Mathematical Content
+
+Write
+  g(n) = ∑_{ζ^n = 1} ζ            (sum of all n-th roots of unity)
+  f(n) = ∑_{ζ primitive of order n} ζ   (sum of primitive n-th roots).
+
+Two facts drive the proof:
+
+1.  **Partition.**  Every n-th root of unity is a *primitive* d-th root for a
+    unique divisor `d ∣ n`.  Summing over the partition,
+        g(n) = ∑_{d ∣ n} f(d).
+
+2.  **Evaluation of g.**  Picking a primitive n-th root `ζ`, the n-th roots are
+    exactly `ζ^0, …, ζ^{n-1}`, so `g(n) = ∑_{i<n} ζ^i` is a finite geometric
+    series.  For n > 1 this telescopes to `0`; for n = 1 it is `1`.  Hence
+        g(n) = [n = 1].
+
+Applying Möbius inversion to (1) gives
+        f(n) = ∑_{d ∣ n} μ(n/d) · g(d) = μ(n) · g(1) = μ(n),
+since the only surviving term is the one with `d = 1`.
+
+## Mathlib ingredients
+- `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` — the partition (1).
+- `IsPrimitiveRoot.disjoint` — distinct orders give disjoint primitive-root sets.
+- `IsPrimitiveRoot.geom_sum_eq_zero` — the geometric-series vanishing.
+- `Complex.isPrimitiveRoot_exp` — existence of a primitive root in ℂ.
+- `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` — Möbius inversion over a ring.
+
+## References
+- Standard fact; see e.g. Apostol, *Introduction to Analytic Number Theory*,
+  Theorem 2.7 (the Möbius function as a sum of primitive roots of unity).
+-/
+
+open Finset Polynomial
+open scoped ArithmeticFunction.Moebius
+
+namespace DeMoivreOQ05OQ02
+
+/-- If `ζ` is a primitive `n`-th root of unity in `ℂ` (with `0 < n`), then the
+finset of `n`-th roots of unity is the image of `range n` under `i ↦ ζ ^ i`. -/
+lemma nthRootsFinset_eq_image {n : ℕ} (hn : 0 < n) {ζ : ℂ} (hζ : IsPrimitiveRoot ζ n) :
+    nthRootsFinset n (1 : ℂ) = (range n).image (ζ ^ ·) := by
+  haveI : NeZero n := ⟨hn.ne'⟩
+  ext x
+  simp only [mem_nthRootsFinset hn, mem_image, mem_range]
+  constructor
+  · intro hx
+    obtain ⟨i, hi, rfl⟩ := hζ.eq_pow_of_pow_eq_one hx
+    exact ⟨i, hi, rfl⟩
+  · rintro ⟨i, hi, rfl⟩
+    rw [← pow_mul, mul_comm, pow_mul, hζ.pow_eq_one, one_pow]
+
+/-- The sum of all `n`-th roots of unity in `ℂ` is `1` when `n = 1` and `0`
+otherwise (the parent result, restated as an evaluation of `g`). -/
+lemma sum_nthRootsFinset {n : ℕ} (hn : 0 < n) :
+    ∑ x ∈ nthRootsFinset n (1 : ℂ), x = if n = 1 then 1 else 0 := by
+  obtain ⟨ζ, hζ⟩ : ∃ ζ : ℂ, IsPrimitiveRoot ζ n :=
+    ⟨_, Complex.isPrimitiveRoot_exp n hn.ne'⟩
+  rw [nthRootsFinset_eq_image hn hζ, sum_image hζ.injOn_pow]
+  by_cases hn1 : n = 1
+  · subst hn1; simp
+  · rw [if_neg hn1]
+    exact hζ.geom_sum_eq_zero (by omega)
+
+/-- **Sum of the primitive `n`-th roots of unity equals `μ(n)`.**
+For every natural number `n`, the sum over the primitive `n`-th roots of unity
+in `ℂ` equals the value of the Möbius function at `n` (cast into `ℂ`). -/
+theorem sum_primitiveRoots_eq_moebius (n : ℕ) :
+    ∑ ζ ∈ primitiveRoots n ℂ, ζ = (μ n : ℂ) := by
+  classical
+  rcases Nat.eq_zero_or_pos n with hn | hn
+  · subst hn; simp
+  -- (1) Partition: ∑_{d ∣ k} f(d) = g(k) for every k > 0.
+  have hpart : ∀ k > 0,
+      ∑ d ∈ k.divisors, (∑ ζ ∈ primitiveRoots d ℂ, ζ)
+        = ∑ x ∈ nthRootsFinset k (1 : ℂ), x := by
+    intro k hk
+    haveI : NeZero k := ⟨hk.ne'⟩
+    have hdisj : Set.PairwiseDisjoint (↑k.divisors) (fun i => primitiveRoots i ℂ) := by
+      intro a _ b _ hab
+      exact IsPrimitiveRoot.disjoint hab
+    rw [IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots, Finset.sum_biUnion hdisj]
+  -- (2) Möbius inversion turns the partition into a formula for f(n).
+  have hinv := (ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq
+      (f := fun k => ∑ ζ ∈ primitiveRoots k ℂ, ζ)
+      (g := fun k => ∑ x ∈ nthRootsFinset k (1 : ℂ), x)).mp hpart n hn
+  -- (3) Möbius inversion, then only the divisor `d = 1` survives (`μ(n) · 1`).
+  calc ∑ ζ ∈ primitiveRoots n ℂ, ζ
+      = ∑ x ∈ n.divisorsAntidiagonal,
+          (μ x.1 : ℂ) * (∑ y ∈ nthRootsFinset x.2 (1 : ℂ), y) := hinv.symm
+    _ = (μ n : ℂ) := by
+        rw [Finset.sum_eq_single (n, 1)]
+        · dsimp only
+          rw [show (∑ x ∈ nthRootsFinset 1 (1 : ℂ), x) = 1 from by
+                simpa using sum_nthRootsFinset (n := 1) one_pos, mul_one]
+        · rintro ⟨a, b⟩ hab hne
+          dsimp only
+          simp only [Nat.mem_divisorsAntidiagonal] at hab
+          obtain ⟨hprod, hn0⟩ := hab
+          have hbpos : 0 < b := by
+            rcases Nat.eq_zero_or_pos b with rfl | h
+            · simp only [Nat.mul_zero] at hprod; exact absurd hprod.symm hn0
+            · exact h
+          have hb1 : b ≠ 1 := by
+            rintro rfl
+            exact hne (by simp only [Nat.mul_one] at hprod; rw [hprod])
+          rw [sum_nthRootsFinset hbpos, if_neg hb1, mul_zero]
+        · intro hns
+          exact absurd (Nat.mem_divisorsAntidiagonal.mpr ⟨Nat.mul_one n, hn.ne'⟩) hns
+
+end DeMoivreOQ05OQ02

--- a/src/data/proofs/de-moivre-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-dm0502-docstring",
+    "proofId": "de-moivre-oq-05-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "Summing the Primitive Roots: Geometry Meets Möbius",
+    "content": "The docstring states the target: the sum of the primitive $n$-th roots of unity in $\\mathbb{C}$ equals the Möbius function $\\mu(n)$. The strategy names two functions, $g(n)=\\sum_{\\zeta^n=1}\\zeta$ (sum of all $n$-th roots) and $f(n)=\\sum_{\\operatorname{ord}\\zeta=n}\\zeta$ (sum of primitive ones). Two facts drive the proof: every $n$-th root is primitive of a unique order $d\\mid n$, so $\\sum_{d\\mid n}f(d)=g(n)$; and $g$ is the trivial sum, $g(n)=[n=1]$. Möbius inversion then reads off $f(n)=\\mu(n)$. This generalizes the parent oq-05 (all roots sum to $0$ for $n>1$) by isolating the primitive contribution.",
+    "mathContext": "$\\sum_{d\\mid n}f(d)=g(n)=[n=1]$, so Möbius inversion gives $f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "roots of unity",
+      "Möbius function",
+      "Möbius inversion",
+      "Ramanujan sums",
+      "cyclotomy"
+    ],
+    "prerequisites": [
+      "primitive roots of unity",
+      "the Möbius function"
+    ]
+  },
+  {
+    "id": "ann-dm0502-image",
+    "proofId": "de-moivre-oq-05-oq-02",
+    "range": {
+      "startLine": 53,
+      "endLine": 65
+    },
+    "type": "technique",
+    "title": "The n-th Roots are the Powers of One Primitive Root",
+    "content": "`nthRootsFinset_eq_image` shows that, for any primitive $n$-th root $\\zeta$, the finset of $n$-th roots of unity is exactly $\\{\\zeta^i : 0\\le i<n\\}$. The forward inclusion uses `IsPrimitiveRoot.eq_pow_of_pow_eq_one`: any $x$ with $x^n=1$ is some power $\\zeta^i$ with $i<n$. The reverse is the computation $(\\zeta^i)^n=(\\zeta^n)^i=1$. This image description is what turns the abstract root set into a concrete finite geometric sum in the next step.",
+    "mathContext": "$\\{z:z^n=1\\}=\\operatorname{image}(i\\mapsto\\zeta^i)(\\{0,\\dots,n-1\\})$, with injectivity from `IsPrimitiveRoot.injOn_pow`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "primitive roots",
+      "cyclic group of roots of unity",
+      "finite images"
+    ],
+    "prerequisites": [
+      "powers of a primitive root",
+      "Finset.image"
+    ]
+  },
+  {
+    "id": "ann-dm0502-sumall",
+    "proofId": "de-moivre-oq-05-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 77
+    },
+    "type": "key-step",
+    "title": "The Sum of All n-th Roots is the Indicator [n = 1]",
+    "content": "`sum_nthRootsFinset` evaluates $g(n)=\\sum_{\\zeta^n=1}\\zeta$. Using the image enumeration, the sum becomes the geometric series $\\sum_{i<n}\\zeta^i$. For $n=1$ the only term is $\\zeta^0=1$. For $n>1$, `IsPrimitiveRoot.geom_sum_eq_zero` makes the series vanish — algebraically, $(\\zeta-1)\\sum_{i<n}\\zeta^i=\\zeta^n-1=0$ while $\\zeta\\neq 1$. This is the parent identity oq-05, recast here as the function $g$ that will be inverted.",
+    "mathContext": "$g(n)=\\sum_{i<n}\\zeta^i=\\begin{cases}1 & n=1\\\\ 0 & n>1\\end{cases}$ — the vanishing of the geometric series of a non-trivial root of unity.",
+    "significance": "central",
+    "relatedConcepts": [
+      "geometric series",
+      "vanishing root sums",
+      "Vieta's formulas"
+    ],
+    "prerequisites": [
+      "finite geometric series",
+      "ζ^n = 1, ζ ≠ 1"
+    ]
+  },
+  {
+    "id": "ann-dm0502-inversion",
+    "proofId": "de-moivre-oq-05-oq-02",
+    "range": {
+      "startLine": 79,
+      "endLine": 123
+    },
+    "type": "key-step",
+    "title": "Möbius Inversion Collapses to μ(n)",
+    "content": "The main theorem assembles the pieces. First, the divisor partition `IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots` together with disjointness (`IsPrimitiveRoot.disjoint`) and `Finset.sum_biUnion` yields $\\sum_{d\\mid n}f(d)=g(n)$ for every $n>0$. Feeding this to `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` inverts the relation to $f(n)=\\sum_{(a,b):ab=n}\\mu(a)\\,g(b)$. Because $g(b)=[b=1]$, every antidiagonal term with $b\\neq 1$ dies, leaving only $(a,b)=(n,1)$: $f(n)=\\mu(n)\\cdot g(1)=\\mu(n)$. The $n=0$ case is separate ($\\varnothing$ sum $=0=\\mu(0)$).",
+    "mathContext": "$f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)g(1)=\\mu(n)$; the single surviving divisor term is the heart of the inversion.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Möbius inversion",
+      "divisor partition",
+      "Finset.sum_biUnion",
+      "divisorsAntidiagonal"
+    ],
+    "prerequisites": [
+      "Möbius inversion over a ring",
+      "divisor sums"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-02/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "de-moivre-oq-05-oq-02",
+  "title": "De Moivre OQ-05-OQ-02: The Sum of the Primitive n-th Roots of Unity is μ(n)",
+  "slug": "de-moivre-oq-05-oq-02",
+  "description": "Proves the classical identity that the sum of the primitive n-th roots of unity in ℂ equals the Möbius function μ(n), via the divisor partition of the roots of unity and Möbius inversion. Generalizes the parent result that all n-th roots of unity sum to 0 for n > 1.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ05OQ02.lean",
+    "tags": [
+      "number-theory",
+      "roots-of-unity",
+      "primitive-roots",
+      "moebius",
+      "cyclotomy",
+      "mobius-inversion",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsPrimitiveRoot.nthRoots_one_eq_biUnion_primitiveRoots",
+        "description": "The n-th roots of unity partition into primitive d-th roots over the divisors d ∣ n",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.disjoint",
+        "description": "Primitive root sets of distinct orders are disjoint, making the divisor partition a genuine partition",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.geom_sum_eq_zero",
+        "description": "For a primitive n-th root ζ with 1 < n, the geometric sum ∑_{i<n} ζⁱ vanishes",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "Complex.isPrimitiveRoot_exp",
+        "description": "exp(2πi/n) is a primitive n-th root of unity in ℂ for n ≠ 0, guaranteeing a generator exists",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Complex"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.eq_pow_of_pow_eq_one",
+        "description": "Every n-th root of unity is a power ζⁱ (i < n) of a fixed primitive root ζ",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq",
+        "description": "Möbius inversion over a ring: ∑_{d∣n} f(d) = g(n) for all n>0 ⟺ ∑_{(a,b): ab=n} μ(a)·g(b) = f(n)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Moebius"
+      }
+    ],
+    "originalContributions": [
+      "Statement and proof that ∑ over the primitive n-th roots of unity in ℂ equals μ(n) — a theorem not present in Mathlib",
+      "Helper lemma nthRootsFinset_eq_image: the n-th roots of unity are exactly the image of {0,…,n-1} under i ↦ ζⁱ for a fixed primitive root ζ",
+      "Helper lemma sum_nthRootsFinset: the sum of all n-th roots of unity is 1 when n = 1 and 0 otherwise (the parent result, recast as an evaluation of the divisor-sum function g)",
+      "Assembly of the divisor partition and disjointness into the Möbius-inversion hypothesis ∑_{d∣n} f(d) = g(n)",
+      "Final collapse of the inverted sum to its single surviving divisor term d = 1, yielding μ(n)·g(1) = μ(n)"
+    ],
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 124,
+    "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's primitive-root and Möbius-inversion APIs; the divisor partition, the geometric-sum vanishing, and the inversion lemma are Mathlib results, while the assembly into ∑ primitive roots = μ(n) and the two helper lemmas are original to this entry.",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "That the sum of the primitive $n$-th roots of unity equals the Möbius function $\\mu(n)$ is a classical bridge between the analytic geometry of the unit circle and multiplicative number theory. The $n$-th roots of unity are the vertices of a regular $n$-gon; grouping them by exact order partitions the circle's roots over the divisors of $n$. The sum of *all* $n$-th roots vanishes for $n>1$ (the second-from-top coefficient of $z^n-1$), and Möbius inversion of this divisor relation isolates the *primitive* contribution as $\\mu(n)$. The identity appears as Theorem 2.7 in Apostol's *Introduction to Analytic Number Theory* and underlies the constant term of the cyclotomic polynomial and Ramanujan-sum evaluations $c_n(1)=\\mu(n)$.",
+    "problemStatement": "**Open Question**: Compute the sum of the primitive $n$-th roots of unity in $\\mathbb{C}$.\n\n**Answer**: It equals the Möbius function: $\\displaystyle\\sum_{\\substack{\\zeta^n=1\\\\ \\operatorname{ord}\\zeta=n}}\\zeta=\\mu(n)$. In particular the sum is $0$ exactly when $n$ has a squared prime factor, $+1$ when $n$ is a product of an even number of distinct primes, and $-1$ for an odd number.",
+    "text": "Proves that the sum of the primitive n-th roots of unity in ℂ equals μ(n), via the divisor partition of roots of unity and Möbius inversion.",
+    "proofStrategy": "Write $f(n)=\\sum_{\\operatorname{ord}\\zeta=n}\\zeta$ (primitive sum) and $g(n)=\\sum_{\\zeta^n=1}\\zeta$ (sum of all $n$-th roots).\n1. **Partition.** Each $n$-th root of unity is primitive of exactly one order $d\\mid n$. Mathlib's `nthRoots_one_eq_biUnion_primitiveRoots` expresses the root finset as a disjoint union over divisors; with `IsPrimitiveRoot.disjoint` and `Finset.sum_biUnion`, this gives $\\sum_{d\\mid n} f(d) = g(n)$ for all $n>0$.\n2. **Evaluation of g.** Choosing the primitive root $\\zeta=\\exp(2\\pi i/n)$ (`Complex.isPrimitiveRoot_exp`), the $n$-th roots are the image of $\\{0,\\dots,n-1\\}$ under $i\\mapsto\\zeta^i$ (`nthRootsFinset_eq_image`). So $g(n)=\\sum_{i<n}\\zeta^i$, which is $1$ for $n=1$ and $0$ for $n>1$ by `IsPrimitiveRoot.geom_sum_eq_zero`.\n3. **Inversion.** Applying `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq` to step 1 gives $f(n)=\\sum_{ab=n}\\mu(a)\\,g(b)$. Since $g(b)=[b=1]$, the only surviving antidiagonal term is $(a,b)=(n,1)$, contributing $\\mu(n)\\cdot 1=\\mu(n)$.",
+    "keyInsights": [
+      "The **divisor partition** of the roots of unity — every root is primitive of a unique order $d\\mid n$ — is the structural fact that lets number theory's Möbius machinery act on a geometric sum",
+      "The parent identity ($g(n)=0$ for $n>1$) is not discarded but **repackaged** as the input $g$ to Möbius inversion; the whole proof is 'invert the trivial sum'",
+      "Möbius inversion converts the additive divisor relation $\\sum_{d\\mid n}f(d)=g(n)$ into a **closed form** for $f$, and the sparseness of $g$ (supported only at $1$) makes the inverted sum collapse to a single term",
+      "Working over $\\mathbb{C}$ (an integral domain with a primitive root for every $n$) is exactly what makes both the geometric-sum vanishing and the enumeration $\\{\\zeta^i\\}$ available",
+      "The result is the $k=1$ case of the **Ramanujan sum** $c_n(k)$ and equals the constant-term/$\\mu$ relation hidden in the cyclotomic polynomial $\\Phi_n$"
+    ],
+    "prerequisites": [
+      "Roots of unity and primitive roots",
+      "The Möbius function and Möbius inversion over the divisors of n",
+      "Finite geometric series"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the target identity ∑ primitive n-th roots = μ(n), the f/g notation, the partition + inversion strategy, and the Mathlib ingredients",
+      "startLine": 1,
+      "endLine": 46,
+      "mathContext": "**Goal**: $\\sum_{\\operatorname{ord}\\zeta=n}\\zeta=\\mu(n)$, proved by partitioning the roots of unity over divisors and inverting the relation $\\sum_{d\\mid n}f(d)=g(n)$."
+    },
+    {
+      "id": "image-enumeration",
+      "title": "Part I: The n-th Roots as Powers of a Primitive Root",
+      "summary": "nthRootsFinset_eq_image: for a primitive n-th root ζ, the finset of n-th roots of unity equals the image of range n under i ↦ ζⁱ",
+      "startLine": 53,
+      "endLine": 65,
+      "mathContext": "$\\{z:z^n=1\\}=\\{\\zeta^i:0\\le i<n\\}$ — each root is a power of $\\zeta$ (via `eq_pow_of_pow_eq_one`), and each power is a root."
+    },
+    {
+      "id": "sum-all-roots",
+      "title": "Part II: The Sum of All n-th Roots (the function g)",
+      "summary": "sum_nthRootsFinset: the sum of all n-th roots of unity is 1 if n = 1 and 0 otherwise, via the image enumeration and IsPrimitiveRoot.geom_sum_eq_zero",
+      "startLine": 67,
+      "endLine": 77,
+      "mathContext": "$g(n)=\\sum_{i<n}\\zeta^i$. For $n=1$ this is $\\zeta^0=1$; for $n>1$ the geometric series telescopes to $0$ since $\\zeta\\neq 1$ but $\\zeta^n=1$."
+    },
+    {
+      "id": "main-inversion",
+      "title": "Part III: Möbius Inversion Yields μ(n)",
+      "summary": "sum_primitiveRoots_eq_moebius: the partition ∑_{d∣n} f(d) = g(n) (sum_biUnion + disjointness) feeds Möbius inversion; only the divisor d = 1 survives, giving μ(n)·g(1) = μ(n)",
+      "startLine": 79,
+      "endLine": 123,
+      "mathContext": "$f(n)=\\sum_{ab=n}\\mu(a)g(b)=\\mu(n)g(1)=\\mu(n)$ — the sparse support of $g$ collapses the inverted divisor sum to one term."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves that the sum of the primitive n-th roots of unity in ℂ equals the Möbius function μ(n). The roots of unity are partitioned over their exact orders (a disjoint union over divisors), the sum of all n-th roots is evaluated as the indicator [n = 1] via a finite geometric series, and Möbius inversion collapses the resulting divisor sum to its single surviving term μ(n). The proof is fully machine-checked with zero sorries and zero axioms beyond Lean's foundations.",
+    "implications": "Generalizes the parent de-moivre-oq-05 (all n-th roots sum to 0 for n > 1) by recovering the primitive part as μ(n). The identity is the k = 1 case of the Ramanujan sum c_n(k) and is equivalent to the relation between the constant coefficient of the cyclotomic polynomial Φₙ and the Möbius function. It illustrates the template 'partition over divisors + Möbius inversion' that recurs throughout multiplicative number theory.",
+    "openQuestions": [
+      "Generalize to the full Ramanujan sum c_n(k) = ∑_{ord ζ = n} ζᵏ and prove c_n(k) = μ(n/gcd(n,k))·φ(n)/φ(n/gcd(n,k))",
+      "Derive the constant term Φₙ(0) and the second coefficient of the cyclotomic polynomial from the same partition",
+      "Formalize the companion identity ∑_{ord ζ = n} ζ over a general field containing a primitive n-th root of unity"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "Parent: all n-th roots of unity sum to 0 for n > 1 — the function g inverted here"
+    },
+    {
+      "id": "de-moivre-oq-04",
+      "relationship": "Sibling: the n-th roots of unity as the powers of a primitive root ω"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Polynomial",
+      "ArithmeticFunction.Moebius"
+    ],
+    "namespace": "DeMoivreOQ05OQ02",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ05OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "title": "Introduction to Analytic Number Theory",
+      "author": "Tom M. Apostol",
+      "year": 1976,
+      "note": "Theorem 2.7: the Möbius function as the sum of the primitive n-th roots of unity; §8 on Ramanujan sums"
+    },
+    {
+      "title": "Mathlib4: RingTheory.RootsOfUnity.PrimitiveRoots and NumberTheory.ArithmeticFunction.Moebius",
+      "author": "The mathlib Community",
+      "year": 2026,
+      "note": "Primitive-root partition, geometric-sum vanishing, and Möbius inversion over a ring"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Research session for **de-moivre-oq-05-oq-02**. Adds a complete, sorry-free Lean 4 / Mathlib formalization of the classical identity

$$\sum_{\substack{\zeta^n=1\\ \operatorname{ord}\zeta=n}} \zeta = \mu(n)$$

(the sum of the primitive $n$-th roots of unity in $\mathbb{C}$ equals the Möbius function), generalizing the parent result `de-moivre-oq-05` (all $n$-th roots sum to $0$ for $n>1$).

## Progress
- `proofs/Proofs/DeMoivreOQ05OQ02.lean` — 3 theorems, **0 sorries, 0 axioms**:
  - `nthRootsFinset_eq_image`: the $n$-th roots are the image of `range n` under $i \mapsto \zeta^i$ for a fixed primitive root.
  - `sum_nthRootsFinset`: the sum of all $n$-th roots of unity is $[n=1]$ (parent result recast as the divisor-sum function $g$).
  - `sum_primitiveRoots_eq_moebius` (main): $\sum$ primitive $= \mu(n)$ via Möbius inversion of $\sum_{d\mid n} f(d) = g(n)$.
- `src/data/proofs/de-moivre-oq-05-oq-02/{meta,annotations}.json` — gallery data.
- Registers the import in `proofs/Proofs.lean`.

## Findings
- **Strategy**: partition the roots of unity by exact order (a disjoint union over divisors via `nthRoots_one_eq_biUnion_primitiveRoots` + `IsPrimitiveRoot.disjoint`), evaluate $g(n)=[n=1]$ with `geom_sum_eq_zero`, then apply `ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq`. The sparse support of $g$ collapses the inverted sum to the single term $\mu(n)\cdot g(1)=\mu(n)$.
- The result is the $k=1$ case of the Ramanujan sum $c_n(k)$ and the $\mu$/cyclotomic-constant-term relation.

## Build status
⚠️ The build could **not be re-verified this session**: the Docker build wrapper (`proofs/scripts/docker-build.sh`, the only permitted build path) failed with a host-level containerd I/O error (corrupted content blobs) — an infrastructure problem, not a proof error. The proof was authored and built in a prior session and was statically audited clean (audit tracker, PR #30341). It uses only existing Mathlib lemmas. CI / the deployer should confirm the build before merge.

## Status
**Outcome**: completed (pending build re-confirmation)
**Next Steps**: confirm Docker build once the host containerd issue is resolved; the entry's `meta.json` lists three follow-up open questions (full Ramanujan sum $c_n(k)$, cyclotomic constant term, general-field version).

🤖 Generated by researcher-3