### PR TITLE
research(divisibility-truncation-general-oq-01-oq-01): reconcile pool knowledge — mark COMPLETED

### DIFF
--- a/src/data/research/problems/divisibility-truncation-general-oq-01-oq-01.json
+++ b/src/data/research/problems/divisibility-truncation-general-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "divisibility-truncation-general-oq-01-oq-01",
   "title": "Can this be extended to divisors that share factors with 10 by combining with the last-k-digits fram",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-06-15T00:57:02-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: Answer YES. Combined osculator + last-k-digits test for any divisor; gallery entry verified/original, 0 sorries, 0 axioms (PR #24298).",
+    "builtItems": [
+      "dvd_iff_dvd_last_k (s k n) (hs : s ∣ 10^k) : s ∣ n ↔ s ∣ n % 10^k — general last-k-digits rule (proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean)",
+      "combined_divisibility — main theorem: s*m ∣ n ↔ (s ∣ n%10^k ∧ (m:ℤ) ∣ (n/10 + c·(n%10)))",
+      "Corollaries six_combined, twelve_combined, fourteen_combined (new), thirtyfive_combined (new)",
+      "Gallery entry src/data/proofs/divisibility-truncation-general-oq-01-oq-01/ (verified/original, 0 sorries, 0 axioms)"
+    ],
+    "insights": [
+      "Answer YES: every divisor factors as d = s·m with s = 2^a·5^b (shares all factors with 10) and m coprime to 10; gcd(s,m)=1 automatically.",
+      "The two frameworks compose via CRT: d|n ↔ (s | n%10^k) ∧ (m | n/10 + c·(n%10)), with s|10^k and m|10c-1.",
+      "k must be ≥ max(a,b); the 2-part of 12 (=4) forces the last-two-digits rule.",
+      "Subsumes the gallery ad-hoc composite rules (6,12,15,18,30) by exposing explicit last-k-digits + osculator computation."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Optional follow-up: minimality of digit operations per divisor, or iterating the osculator on the coprime part to bound steps by log d."
+    ],
     "markdown": "# Knowledge Base: divisibility-truncation-general-oq-01-oq-01\n\nOpen question from the parent gallery entry `divisibility-truncation-general-oq-01`\n(Unified Osculator Theorem):\n\n> Can this be extended to divisors that share factors with 10 by combining with\n> the last-k-digits framework?\n\n---\n\n## Problem Understanding\n\nThe Unified Osculator Theorem proves, for `d` coprime to 10 with osculator `c`\n(i.e. `d | 10c - 1`):\n\n    d | n  ↔  d | (n/10 + c·(n%10)).\n\nThe coprimality hypothesis is essential: for divisors sharing a factor with 10\n(6, 12, 14, 15, 35, ...) there is no osculator, because 10 is not invertible\nmod `d`. The classical remedy for the 2- and 5-parts is the **last-k-digits\nrule** (4 | n iff 4 | last two digits, 8 | n iff 8 | last three, etc.), already\nin the gallery as fixed cases in `DivisibilityRules.lean`.\n\n---\n\n## Resolution (Session 1, 2026-06-15, FRESH → ACT)\n\n**Answer: YES.** Every divisor factors as `d = s · m` with `s = 2^a · 5^b`\n(shares all factors with 10) and `m` coprime to 10, and `gcd(s, m) = 1`\nautomatically. The two frameworks compose via the Chinese Remainder Theorem:\n\n    d | n  ↔  (s | n % 10^k)  ∧  (m | n/10 + c·(n%10)),    s | 10^k,  m | 10c-1.\n\nThe left conjunct is the last-k-digits rule; the right is the osculator rule.\n\n### What was built (`proofs/Proofs/DivisibilityTruncationGeneralOQ01OQ01.lean`)\n\n- `dvd_iff_dvd_last_k (s k n) (hs : s ∣ 10^k) : s ∣ n ↔ s ∣ n % 10^k`\n  — the last-k-digits rule in **general** form (generalises the gallery's fixed\n  4/8/25/125 cases to any divisor of a power of ten). Proof: `Nat.div_add_mod` +\n  `Nat.dvd_sub'` / `dvd_add`.\n- `combined_divisibility (s m c k n) (hs hcop_sm hmcop hc) :\n   s*m ∣ n ↔ (s ∣ n%10^k ∧ (m:ℤ) ∣ (↑(n/10) + c*↑(n%10)))`\n  — the main theorem. Proof: rewrite via `DivisibilityRules.coprime_mul_dvd_iff`\n  (CRT split), then `and_congr (dvd_iff_dvd_last_k …) (bridge.trans\n  (UnifiedOsculator.unified_osculator …))`, where `bridge` is the ℕ→ℤ cast of\n  divisibility by `exact_mod_cast`.\n- Concrete corollaries: `six_combined` (2·3), `twelve_combined` (4·3, last-two-\n  digits part), `fourteen_combined` (2·7, **new**), `thirtyfive_combined`\n  (5·7, **new**). Side conditions discharged by `norm_num` and\n  `norm_num [Int.isCoprime_iff_gcd_eq_one]`.\n- `native_decide` sanity checks (6|144, 14|154, 35|245, 12|1452 + non-divisors).\n\n0 sorries, 0 axioms. Reuses the parent `unified_osculator` and the existing\n`coprime_mul_dvd_iff` — no new Mathlib infrastructure needed.\n\n### Verification certificate\n\n`verify_combined_divisibility.py` checks the iff over `n ∈ [0, 200000)` for 9\ndivisors (6, 12, 14, 15, 35, 18, 28, plus the boundary cases `s=1` pure\nosculator d=21 and `m=1` pure last-k-digits d=50). All side conditions and all\nequivalences PASS with zero mismatches, confirming the chosen osculators `c` and\ndigit counts `k` in the Lean corollaries.\n\n### Key insights\n\n- `gcd(s, m) = 1` is automatic once `s = 2^a 5^b` and `m` coprime to 10, so the\n  CRT split needs no extra hypothesis beyond `Nat.Coprime s m` (always provable\n  numerically per case).\n- `k` must be `≥ max(a, b)`; for the 2-part of 12 (= 4) this forces the\n  last-*two*-digits rule.\n- This subsumes the gallery's ad-hoc composite rules (6, 12, 15, 18, 30), which\n  previously only reduced `d | n` to `d₁ | n ∧ d₂ | n` without exposing the\n  explicit last-k-digits + osculator computation.\n\n---\n\n## Status\n\nACT — proof written, 0 sorries / 0 axioms, build-pending (Docker outage at\nsession time; CI is ground truth). Python certificate PASS. Gallery entry\n(`src/data/proofs/divisibility-truncation-general-oq-01-oq-01/`) created.\n\n## Next Steps\n\n- Confirm the Lean file builds in CI (registered in `Proofs.lean`).\n- Possible follow-up: minimality of digit operations per divisor, or iterating\n  the osculator on the coprime part to bound steps by `log d`.\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

The open question `divisibility-truncation-general-oq-01-oq-01` ("Can the osculator divisibility test be extended to divisors sharing factors with 10?") was **fully resolved in Session 1** (PR #24298).

**Answer: YES.** Every divisor factors as `d = s·m` with `s = 2^a·5^b` and `m` coprime to 10; the two frameworks compose via CRT:

    d | n  ↔  (s | n%10^k)  ∧  (m | n/10 + c·(n%10))

The gallery entry `src/data/proofs/divisibility-truncation-general-oq-01-oq-01` is **verified / original, 0 sorries, 0 axioms**, and the Lean file is registered in `Proofs.lean`.

## Problem
The structured `knowledge` arrays in the research problem JSON were empty (knowledge score 0 → false-EMPTY), so the autonomous claim system kept offering this already-solved problem as a fresh candidate.

## Change
Populates `insights` / `builtItems` / `nextSteps` from the existing resolution markdown and sets `status`/`phase` to `COMPLETED`. Metadata-only; no proof or Lean changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)