### PR TITLE
fix(deploy): tolerate benign fetch ref-lock race in merge step

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -271,9 +271,14 @@ assert_main_intact() {
 merge_prs() {
     print_header "Merging Pull Requests"
 
-    # Update main first
+    # Update main first. Retry once and never abort on the benign
+    # "unable to update local ref" race: when a prior merge in this same loop
+    # just advanced origin/main, a concurrent fetch can fail to lock the
+    # remote-tracking ref even though the data is fetched into FETCH_HEAD and
+    # the ref ends up current. Under `set -e` an unguarded fetch would kill the
+    # whole merge step after merging only ~1 PR (see issue: deploy fetch race).
     print_info "Updating main branch..."
-    git fetch origin main
+    git fetch origin main --quiet || git fetch origin main --quiet || true
     # Stash before checkout — dirty files block branch switch
     git stash 2>/dev/null || true
     git checkout main 2>/dev/null || git checkout -b main origin/main 2>/dev/null || true
@@ -395,8 +400,11 @@ merge_prs() {
         (
             cd "$worktree_path"
             git stash 2>/dev/null || true
-            git fetch origin main
-            git fetch origin "$branch"
+            # Tolerate the benign "unable to update local ref" race (a prior
+            # merge in this loop just moved origin/main); FETCH_HEAD is still
+            # populated and the ref ends up current, so don't let set -e abort.
+            git fetch origin main --quiet || git fetch origin main --quiet || true
+            git fetch origin "$branch" --quiet || true
             git reset --hard "origin/$branch" 2>/dev/null || true
 
             if git rebase origin/main 2>/dev/null; then
@@ -517,8 +525,8 @@ fs.writeFileSync('$conflict_file', JSON.stringify(ours, null, 2) + '\n');
 
     print_success "Merged $merged PRs ($failed failed/skipped)"
 
-    # Update main again after merges
-    git fetch origin main
+    # Update main again after merges (tolerate the ref-lock race, see above)
+    git fetch origin main --quiet || git fetch origin main --quiet || true
     git reset --hard origin/main
 
     # Safety net: confirm the merges did not collapse main's tree.


### PR DESCRIPTION
## Problem

The deployer's merge step (`scripts/deploy/sync-and-deploy.sh`) runs `git fetch origin main` **unguarded** under `set -euo pipefail` in three places:
- line 276 — before the merge loop
- line 398 — inside the per-PR rebase subshell
- line 521 — after merges

Whenever a PR merge in the same loop advances `origin/main`, the *next* fetch can fail with:

```
error: cannot lock ref 'refs/remotes/origin/main': is at <new> but expected <old>
 ! <old>..<new>  main -> origin/main  (unable to update local ref)
```

This is **benign** — the data is fetched into `FETCH_HEAD` and the remote-tracking ref ends up current — but under `set -e` the non-zero exit **aborts the entire merge step** after merging only ~1 PR per invocation. The CONFLICTING-PR rebase loop therefore almost never runs.

## Observed live

During a deploy cycle: `Found 94 eligible PRs ... Merged 0`. Re-running `--merge` merged exactly one PR (#30354) then died immediately on the ref-lock error while starting the rebase of the next PR.

## Fix

Guard the three fetches with retry-once-then-continue (`git fetch ... || git fetch ... || true`), matching the already-tolerant pattern at lines 161/171. The subsequent `git reset --hard origin/main` relies on the local ref, which is current after the race, so conflict resolution stays correct.

Validated with `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)