### PR TITLE
Enrich Counting Automorphic Residues as 2^ω(n): add overview, conclusion, cross-refs

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-01/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-01/meta.json
@@ -159,5 +159,56 @@
       "summary": "primeFactors_ten_pow: ω(10^k)=2 via Nat.primeFactors_pow then splitting 10 = 2·5 (Nat.primeFactors_mul, Nat.Prime.primeFactors). automorphic_count_ten_pow: substituting into idempotent_count gives 2^2 = 4 — the four classical automorphic residues 0, 1, …5, …6 mod 10^k.",
       "mathContext": "The decimal '4' of the parent entry is exactly 2^ω(10^k) = 2^2; the same theorem gives 2 for any prime power, 8 for n with three prime factors, etc."
     }
+  ],
+  "overview": {
+    "historicalContext": "Automorphic numbers — integers whose square ends in the same digits, like $5^2 = 25$, $6^2 = 36$, $25^2 = 625$, $76^2 = 5776$ — were a recreational-mathematics staple long before they had a structural explanation, appearing in the puzzle columns of the late 19th and early 20th centuries and in the work of writers such as W. W. Rouse Ball. The folklore observation that there are *exactly two* nontrivial $k$-digit automorphic numbers for every $k$ (together with the trivial $0$ and $1$) is the decimal shadow of a clean algebraic fact: the residues $e$ with $e^2 \\equiv e \\pmod{10^k}$ are precisely the **idempotents** of the ring $\\mathbb{Z}/10^k\\mathbb{Z}$. The systematic study of idempotents in finite commutative rings via the Chinese Remainder Theorem matured with the structure theory of Artinian rings in the early 20th century (Wedderburn, and later the commutative theory). The count of idempotents as $2^{\\omega(n)}$ is implicit in any decomposition of $\\mathbb{Z}/n\\mathbb{Z}$ into a product of local rings $\\mathbb{Z}/p^k\\mathbb{Z}$, where $\\omega(n)$ denotes the number of distinct prime divisors of $n$ — an arithmetic function studied since Gauss and central to the Hardy–Ramanujan theorem on the normal order of $\\omega(n)$. This entry makes that structural count fully formal in Lean 4, generalizing the parent entry's concrete '$4$ mod $10^k$' to an arbitrary modulus.",
+    "problemStatement": "For an integer $n \\geq 1$, count the idempotent elements of the ring $\\mathbb{Z}/n\\mathbb{Z}$, i.e. the residues $e$ satisfying $e^2 \\equiv e \\pmod{n}$ (the 'automorphic residues' modulo $n$). The claim is that this count is exactly $2^{\\omega(n)}$, where $\\omega(n) = \\#\\{p \\text{ prime} : p \\mid n\\}$ is the number of distinct prime factors of $n$. Formally: $0 < n \\implies \\operatorname{Nat.card}\\,\\{e : \\mathbb{Z}/n\\mathbb{Z} \\mid e \\cdot e = e\\} = 2^{\\omega(n)}$.",
+    "proofStrategy": "Package the idempotent count as an arithmetic function $\\operatorname{numIdem}(n) = \\#\\{\\text{idempotents of } \\mathbb{Z}/n\\mathbb{Z}\\}$ (with the convention $\\operatorname{numIdem}(0) = 0$) and prove it is **multiplicative**. Two facts inherited from the parent file supply multiplicativity: the Chinese Remainder ring isomorphism $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ for coprime $m, n$ transports idempotents bijectively (idemCongr), and the idempotents of a product ring are exactly the pairs of idempotents (idemProd). Hence $\\operatorname{numIdem}(mn) = \\operatorname{numIdem}(m)\\cdot\\operatorname{numIdem}(n)$ on coprime arguments, and with $\\operatorname{numIdem}(1) = 1$ this gives an honest multiplicative arithmetic function. Mathlib's IsMultiplicative.multiplicative_factorization then evaluates it over the prime factorization: $\\operatorname{numIdem}(n) = \\prod_{p^k \\,\\|\\, n} \\operatorname{numIdem}(p^k)$. The parent's prime-power lemma gives $\\operatorname{numIdem}(p^k) = 2$ for every prime $p$ and $k \\geq 1$ (a local ring $\\mathbb{Z}/p^k\\mathbb{Z}$ has only the trivial idempotents $0$ and $1$), so the product is $2$ raised to the number of factors, namely $2^{\\omega(n)}$. The classical decimal count is recovered as the corollary $\\omega(10^k) = 2$.",
+    "keyInsights": [
+      "The mysterious '$4$' of the classical decimal automorphic numbers is $2^2$, where the exponent $2$ counts the distinct primes of $10 = 2 \\cdot 5$ — the size of $n$ is irrelevant, only $\\omega(n)$ matters.",
+      "Idempotents $e^2 = e$ in $\\mathbb{Z}/n\\mathbb{Z}$ are exactly the automorphic residues $e^2 \\equiv e \\pmod n$; the recreational notion and the ring-theoretic notion coincide on the nose.",
+      "Counting idempotents is a *multiplicative arithmetic function*, and the proof's real content is establishing that multiplicativity — the formula $2^{\\omega(n)}$ then follows mechanically from how multiplicative functions evaluate across a factorization.",
+      "The Chinese Remainder Theorem is the engine: $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ turns one idempotent modulo $mn$ into an independent pair of idempotents, so choices multiply.",
+      "A local ring $\\mathbb{Z}/p^k\\mathbb{Z}$ has *exactly two* idempotents, $0$ and $1$ — connected idempotent-wise — which is why each distinct prime contributes a factor of $2$ rather than something larger.",
+      "Phrasing the count through Mathlib's ArithmeticFunction.IsMultiplicative API lets a single lemma (multiplicative_factorization) do the work of an induction on the number of prime factors, a clean example of reusing library structure instead of reproving it.",
+      "The $2^{\\omega(n)}$ formula mirrors other CRT-driven counts — e.g. the number of square roots of $1$ modulo $n$ is also $2^{\\omega(n)}$ for odd $n$ — reflecting the same decomposition of $\\mathbb{Z}/n\\mathbb{Z}$ into local factors."
+    ]
+  },
+  "conclusion": {
+    "summary": "The number of idempotents of $\\mathbb{Z}/n\\mathbb{Z}$ — equivalently the number of automorphic residues $e^2 \\equiv e \\pmod n$ — is exactly $2^{\\omega(n)}$, where $\\omega(n)$ is the count of distinct prime divisors of $n$. The result is obtained by recognizing the idempotent count as a multiplicative arithmetic function (via the Chinese Remainder Theorem) whose only prime-power value is the constant $2$, then evaluating it across the prime factorization. The parent entry's 'exactly four automorphic residues mod $10^k$' is recovered as the special case $\\omega(10^k) = 2$, so $2^2 = 4$. The formalization is fully machine-checked: $0$ sorries, $0$ axioms, no `native_decide` (the only `decide` calls are kernel decisions on the concrete finite data of $\\mathbb{Z}/1\\mathbb{Z}$ and the set $\\{2, 5\\}$).",
+    "implications": "The theorem explains a recreational curiosity through ring structure: automorphic numbers are not a decimal accident but a manifestation of how $\\mathbb{Z}/n\\mathbb{Z}$ factors into local rings under CRT, with each prime contributing an independent binary choice of idempotent. The same $2^{\\omega(n)}$ count governs related objects — the connected components of $\\operatorname{Spec}(\\mathbb{Z}/n\\mathbb{Z})$, the number of ways to split the modulus into coprime 'complementary' factors, and (for odd $n$) the square roots of unity — all flowing from the same CRT decomposition. Methodologically, the proof is a template for counting structure in $\\mathbb{Z}/n\\mathbb{Z}$: identify a multiplicative invariant, compute it on prime powers, and let Mathlib's arithmetic-function machinery assemble the global formula, avoiding any explicit induction on $\\omega(n)$.",
+    "openQuestions": [
+      "How does the count of idempotents generalize to the ring of integers $\\mathcal{O}_K$ of a number field modulo an ideal $\\mathfrak{a}$? The CRT decomposition over prime ideals suggests $2^{(\\text{number of distinct prime ideals dividing } \\mathfrak{a})}$.",
+      "For a general finite commutative ring $R$, the idempotents biject with the clopen subsets of $\\operatorname{Spec}(R)$, giving $2^{(\\text{number of connected components})}$; can this topological count be formalized and connected to the arithmetic statement here?",
+      "Can the explicit automorphic residues (not merely their count) be computed uniformly, e.g. via Hensel lifting of the idempotents $0, 1$ in each local factor $\\mathbb{Z}/p^k\\mathbb{Z}$ and CRT recombination?",
+      "What is the average order of the idempotent-counting function $\\sum_{n \\leq x} 2^{\\omega(n)}$, and how does it compare to the Dirichlet series $\\sum_n 2^{\\omega(n)} n^{-s} = \\zeta(s)^2/\\zeta(2s)$ familiar from multiplicative number theory?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "automorphic-number-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "The Complementary Pairing of Automorphic Idempotents mod 10^k — explores the structure of the four idempotents mod $10^k$ that this entry counts: they pair up complementarily ($e \\mapsto 1-e$), reflecting the two-factor CRT splitting $10^k = 2^k \\cdot 5^k$."
+    },
+    {
+      "proofId": "automorphic-number-oq-01-oq-03",
+      "relationship": "sibling",
+      "description": "Automorphic Numbers Lift Uniquely: The Reduction Tower of Idempotents — how idempotents lift uniquely along the reduction maps $\\mathbb{Z}/10^{k+1}\\mathbb{Z} \\to \\mathbb{Z}/10^k\\mathbb{Z}$, complementing the static count proved here with the dynamics of the tower."
+    },
+    {
+      "proofId": "chinese-remainder-constructive",
+      "relationship": "uses",
+      "description": "Chinese Remainder Theorem (Constructive) — supplies the ring isomorphism $\\mathbb{Z}/mn\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ that is the engine of multiplicativity: it transports idempotents and makes the count factor over coprime moduli."
+    },
+    {
+      "proofId": "euler-totient",
+      "relationship": "related-technique",
+      "description": "Euler's Generalization of Fermat's Little Theorem — Euler's totient $\\varphi$ is the archetypal multiplicative arithmetic function evaluated across a prime factorization; the idempotent count here uses the same ArithmeticFunction.IsMultiplicative machinery, with the constant prime-power value $2$ in place of $\\varphi(p^k) = p^k - p^{k-1}$."
+    },
+    {
+      "proofId": "fundamental-arithmetic",
+      "relationship": "foundation",
+      "description": "Fundamental Theorem of Arithmetic — unique prime factorization underlies $\\omega(n)$ and the factorization product over which the multiplicative count is evaluated; without it the reduction to the prime-power case is meaningless."
+    }
   ]
 }


### PR DESCRIPTION
## Enrichment pass for `automorphic-number-oq-01-oq-01`

This entry (quality 45, passes 0) had detailed `sections`, `mainTheorems`, and `annotations.json`, but was **missing the `overview`, `conclusion`, and `crossReferences` keys entirely** — so the proof page rendered no overview or conclusion section at all. This is the render-blocking gap.

### Added
- **`overview`** (was absent): `historicalContext` (recreational origins of automorphic numbers → CRT structure theory; ω(n) since Gauss / Hardy–Ramanujan), `problemStatement`, `proofStrategy`, and **7 `keyInsights`** grounding the count in the multiplicative-arithmetic-function argument.
- **`conclusion`** (was absent): `summary`, `implications`, and **4 `openQuestions`** (number-field generalization, Spec connected components, Hensel lifting, average order / Dirichlet series).
- **5 `crossReferences`** using the correct `proofId` schema: the two sibling automorphic entries, the constructive CRT (the multiplicativity engine), Euler's totient (archetypal multiplicative function), and the Fundamental Theorem of Arithmetic. All targets verified present on `main`.

### Verification
- JSON valid; `gallery:check-size` passes (meta.json 11KB → 21KB, under the 60KB cap).
- Field names checked against `ProofOverview`, `ProofConclusion`, `CrossReference` types (crossRefs use `proofId`, not `slug`, which the component requires).
- Mathematically accurate to the Lean source: idempotent count = 2^ω(n) via numIdem multiplicativity + factorization; no claims altered.
- `status`/`badge`/`axiomCount` unchanged (verified/original/0 — accurate, no native_decide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)