### PR TITLE
Enrich Katona's Cyclic-Interval Lemma (erdos-ko-rado-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/erdos-ko-rado-oq-01/annotations.json
+++ b/src/data/proofs/erdos-ko-rado-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "Turning Arcs into Modular Equations",
-    "content": "The parent defines an arc A_i as the image of {0,…,k-1} under j ↦ (i+j) mod n. mem_cyclicInterval rephrases membership as a modular equation: x ∈ A_i iff x ≡ i+a (mod n) for some offset a < k. inter_nonempty_iff then says two arcs meet iff some offsets a,b < k satisfy (i+a) ≡ (j+b) (mod n). This calculus is what makes the rest of the proof a matter of Nat.ModEq bookkeeping rather than reasoning about Finset images directly — and it is precisely the step that was missing when the lemma 'resisted formalization'."
+    "content": "The parent defines an arc A_i as the image of {0,…,k-1} under j ↦ (i+j) mod n. mem_cyclicInterval rephrases membership as a modular equation: x ∈ A_i iff x ≡ i+a (mod n) for some offset a < k. inter_nonempty_iff then says two arcs meet iff some offsets a,b < k satisfy (i+a) ≡ (j+b) (mod n). This calculus is what makes the rest of the proof a matter of Nat.ModEq bookkeeping rather than reasoning about Finset images directly — and it is precisely the step that was missing when the lemma 'resisted formalization'.",
+    "mathContext": "$A_i = \\{(i+j) \\bmod n : 0 \\le j < k\\}$; membership $x \\in A_i \\iff \\exists\\, a < k,\\ (i+a) \\equiv x \\pmod n$, and $A_i \\cap A_j \\neq \\varnothing \\iff \\exists\\, a,b < k,\\ i+a \\equiv j+b \\pmod n$.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic interval", "modular arithmetic", "Nat.ModEq", "Finset.image", "intersecting family"],
+    "prerequisites": ["modular arithmetic", "finite sets"]
   },
   {
     "id": "ann-offset-range",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "Why Intersecting Arcs Cluster Near the Anchor",
-    "content": "Fix one arc A_{i₀} of the family. Any other member A_j meets it, so by inter_nonempty_iff there are offsets a,b < k with (i₀+a) ≡ (j+b) (mod n). Rearranging gives the circular offset r(j) = (j + (n−i₀)) mod n congruent to a−b. Since a,b < k, this offset is squeezed into the lower block [0,k) (when a ≥ b) or the upper block (n−k,n) (when a < b, wrapping around). The proof makes this precise by reducing to whether r(j)+b overflows n, closed by omega. This two-block constraint is exactly what lets the collapse map target a k-element set."
+    "content": "Fix one arc A_{i₀} of the family. Any other member A_j meets it, so by inter_nonempty_iff there are offsets a,b < k with (i₀+a) ≡ (j+b) (mod n). Rearranging gives the circular offset r(j) = (j + (n−i₀)) mod n congruent to a−b. Since a,b < k, this offset is squeezed into the lower block [0,k) (when a ≥ b) or the upper block (n−k,n) (when a < b, wrapping around). The proof makes this precise by reducing to whether r(j)+b overflows n, closed by omega. This two-block constraint is exactly what lets the collapse map target a k-element set.",
+    "mathContext": "Circular offset $r(j) = (j - i_0) \\bmod n$. Intersection forces $r(j) \\equiv a - b \\pmod n$ with $a,b < k$, hence $r(j) \\in \\{0,\\dots,k-1\\} \\cup \\{n-k+1,\\dots,n-1\\}$ — the lower and upper blocks of width $k-1$ around the anchor.",
+    "significance": "key",
+    "relatedConcepts": ["circular offset", "case analysis", "omega tactic", "wraparound", "pigeonhole structure"],
+    "prerequisites": ["modular arithmetic", "integer inequalities"]
   },
   {
     "id": "ann-disjointness",
@@ -30,7 +38,11 @@
     },
     "type": "insight",
     "title": "The Pairing: Offsets k Apart Are Disjoint",
-    "content": "The k−1 pairs {s, s+(n−k)} (lower offset s, upper offset s+(n−k)) are the crux. not_intersect_mixed shows that two arcs with these paired offsets have starting positions differing by exactly k, so an overlap would force k + a ≡ b (mod n) with a,b < k. But k + a < 2k ≤ n, so the congruence collapses to the literal equation k + a = b — impossible since b < k. Hence the arcs are disjoint, and a pairwise-intersecting family can contain at most one arc from each pair. This is the only place the hypotheses 'pairwise intersecting' and n ≥ 2k are used. offset_inj handles the easy within-block injectivity."
+    "content": "The k−1 pairs {s, s+(n−k)} (lower offset s, upper offset s+(n−k)) are the crux. not_intersect_mixed shows that two arcs with these paired offsets have starting positions differing by exactly k, so an overlap would force k + a ≡ b (mod n) with a,b < k. But k + a < 2k ≤ n, so the congruence collapses to the literal equation k + a = b — impossible since b < k. Hence the arcs are disjoint, and a pairwise-intersecting family can contain at most one arc from each pair. This is the only place the hypotheses 'pairwise intersecting' and n ≥ 2k are used. offset_inj handles the easy within-block injectivity.",
+    "mathContext": "Arcs whose offsets differ by $n-k$ have starts $k$ apart; overlap would need $k + a \\equiv b \\pmod n$ with $a,b < k$. Since $k + a < 2k \\le n$, the congruence becomes the equation $k + a = b$, contradicting $b < k$. So at most one arc per pair $\\{s,\\, s+(n-k)\\}$ survives.",
+    "significance": "critical",
+    "relatedConcepts": ["disjoint sets", "Katona pairing", "n ≥ 2k hypothesis", "intersecting family", "congruence collapse"],
+    "prerequisites": ["modular arithmetic", "combinatorics"]
   },
   {
     "id": "ann-main",
@@ -41,6 +53,10 @@
     },
     "type": "insight",
     "title": "Katona's Pairing as an Injection into range k",
-    "content": "The collapse map g(j) = r(j) on the lower block and r(j) − (n−k) on the upper block sends the whole family injectively into {0,…,k−1}. offset_range guarantees it lands in range k; the three-case injectivity argument (lower/lower and upper/upper via offset_inj, lower/upper via not_intersect_mixed) guarantees it is injective. Finset.card_le_card_of_injOn then yields |I| ≤ |range k| = k. This is Katona's textbook pairing argument rendered as an explicit injection — the combinatorial heart of his Erdős–Ko–Rado proof, now machine-checked with zero axioms."
+    "content": "The collapse map g(j) = r(j) on the lower block and r(j) − (n−k) on the upper block sends the whole family injectively into {0,…,k−1}. offset_range guarantees it lands in range k; the three-case injectivity argument (lower/lower and upper/upper via offset_inj, lower/upper via not_intersect_mixed) guarantees it is injective. Finset.card_le_card_of_injOn then yields |I| ≤ |range k| = k. This is Katona's textbook pairing argument rendered as an explicit injection — the combinatorial heart of his Erdős–Ko–Rado proof, now machine-checked with zero axioms.",
+    "mathContext": "Collapse map $g(j) = r(j)$ on the lower block, $g(j) = r(j) - (n-k)$ on the upper block, with $g : I \\hookrightarrow \\{0,\\dots,k-1\\}$ injective. Then $|I| \\le |\\mathrm{range}\\,k| = k$ via Finset.card_le_card_of_injOn — the bound the parent had assumed axiomatically.",
+    "significance": "critical",
+    "relatedConcepts": ["injection", "Finset.card_le_card_of_injOn", "Katona's cyclic permutation method", "Erdős–Ko–Rado theorem", "de-axiomatization"],
+    "prerequisites": ["combinatorics", "finite cardinality", "injective functions"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `erdos-ko-rado-oq-01`

This entry (quality 63, passes 0) already had a complete `overview`, `conclusion`, `sections`, and 4 well-written annotations — but the annotations carried only `title` + `content`, with **no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`**. That is the role's #1 mission (annotation depth) and this entry's primary remaining gap.

### Added (to all 4 annotations)
- **`mathContext`**: LaTeX capturing the modular/combinatorial content — arc membership as a congruence, the two-block offset constraint, the disjointness collapse $k+a=b$ contradiction, and the final injection $g : I \hookrightarrow \{0,\dots,k-1\}$.
- **`significance`**: `critical` for the disjointness pairing and the headline injection, `key` for the arc calculus and offset-clustering steps.
- **`relatedConcepts`** and **`prerequisites`** on each.

### Verification
- JSON valid; annotation alignment **4 valid / 0 misaligned** via `scripts/annotations/resolver.ts`.
- `content`/`title`/`range` preserved verbatim — only depth fields added.
- No meta.json change; `status`/`badge`/`axiomCount` untouched (the entry de-axiomatizes the parent's cyclic-interval lemma with 0 axioms / 0 sorries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)