### PR TITLE
Enrich Erdős #1029 first-moment Ramsey bound (erdos-1029-oq-01): annotation depth + crossRefs

### DIFF
--- a/src/data/proofs/erdos-1029-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1029-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 9, "endLine": 30 },
     "type": "concept",
     "title": "Colorings as Functions on Edges",
-    "content": "A 2-coloring is modelled as `c : Sym2 (Fin n) → Bool`, a function on unordered pairs of vertices. `IsMono c S b` asserts that every edge between two distinct vertices of S receives color b, and `HasMonoClique c k` that some k-vertex set is monochromatic. The key auxiliary object is `edgesWithin S = S.offDiag.image Sym2.mk`, the set of edges spanned by S; for |S| = k it has exactly C(k,2) elements. Because the whole argument is a finite count, the diagonal of Sym2 is harmless — it never appears among the constrained edges and cancels out of every ratio."
+    "content": "A 2-coloring is modelled as `c : Sym2 (Fin n) → Bool`, a function on unordered pairs of vertices. `IsMono c S b` asserts that every edge between two distinct vertices of S receives color b, and `HasMonoClique c k` that some k-vertex set is monochromatic. The key auxiliary object is `edgesWithin S = S.offDiag.image Sym2.mk`, the set of edges spanned by S; for |S| = k it has exactly C(k,2) elements. Because the whole argument is a finite count, the diagonal of Sym2 is harmless — it never appears among the constrained edges and cancels out of every ratio.",
+    "mathContext": "A coloring is $c : \\mathrm{Sym}^2(\\mathrm{Fin}\\,n) \\to \\{0,1\\}$; the edge set of a $k$-vertex clique has $\\binom{k}{2}$ elements, and the complete graph $K_n$ has $N = \\binom{n}{2}$ edges total, so there are $2^N$ colorings.",
+    "significance": "supporting",
+    "relatedConcepts": ["edge 2-coloring", "Sym2", "complete graph", "monochromatic clique", "binomial coefficient"],
+    "prerequisites": ["graph theory", "finite sets"]
   },
   {
     "id": "ann-counting-lemma",
@@ -13,7 +17,11 @@
     "range": { "startLine": 32, "endLine": 60 },
     "type": "technique",
     "title": "Counting Colorings Constant on an Edge Set",
-    "content": "constOn_card_le bounds the number of colorings that are constant equal to b on a fixed edge set T by 2^(N − |T|), where N is the total number of edges. The trick is a restriction map ρ sending a coloring to its values on the complement Tᶜ. On the set of colorings constant on T this map is injective: two such colorings already agree on T (both equal b), so agreeing on Tᶜ makes them equal. Hence their count is at most the number of functions Tᶜ → Bool, which Fintype.card_fun evaluates to 2^(N − |T|). This is the heart of the 'first moment' estimate, done with cardinalities rather than a probability measure."
+    "content": "constOn_card_le bounds the number of colorings that are constant equal to b on a fixed edge set T by 2^(N − |T|), where N is the total number of edges. The trick is a restriction map ρ sending a coloring to its values on the complement Tᶜ. On the set of colorings constant on T this map is injective: two such colorings already agree on T (both equal b), so agreeing on Tᶜ makes them equal. Hence their count is at most the number of functions Tᶜ → Bool, which Fintype.card_fun evaluates to 2^(N − |T|). This is the heart of the 'first moment' estimate, done with cardinalities rather than a probability measure.",
+    "mathContext": "$\\#\\{c : c \\equiv b \\text{ on } T\\} \\le 2^{N - |T|}$, via the injective restriction $\\rho : c \\mapsto c|_{T^c}$ into $\\mathrm{Fun}(T^c, \\{0,1\\})$ of size $2^{N-|T|}$. Probabilistically this is $\\Pr[c \\equiv b \\text{ on } T] = 2^{-|T|}$.",
+    "significance": "key",
+    "relatedConcepts": ["restriction map", "injective function", "Fintype.card_fun", "first moment method", "counting argument"],
+    "prerequisites": ["combinatorics", "finite cardinality"]
   },
   {
     "id": "ann-union-bound",
@@ -21,7 +29,11 @@
     "range": { "startLine": 62, "endLine": 150 },
     "type": "proof-step",
     "title": "The Union Bound and the Cancelling Free-Edge Factor",
-    "content": "Assume for contradiction that every coloring has a monochromatic K_k. Then the universe of all 2^N colorings is covered by the union, over the C(n,k) candidate k-sets S, of the colorings monochromatic on S (in either color). Each such set has at most 2·2^(N − C(k,2)) colorings by the counting lemma applied with T = edgesWithin S. The union bound gives 2^N ≤ 2·C(n,k)·2^(N − C(k,2)). But the hypothesis 2·C(n,k) < 2^{C(k,2)}, multiplied by the positive free-edge factor 2^(N − C(k,2)) and using 2^{C(k,2)}·2^(N − C(k,2)) = 2^N (valid since C(k,2) ≤ N), forces 2^N < 2^N — a contradiction. So a coloring with no monochromatic K_k exists, i.e. R(k) > n."
+    "content": "Assume for contradiction that every coloring has a monochromatic K_k. Then the universe of all 2^N colorings is covered by the union, over the C(n,k) candidate k-sets S, of the colorings monochromatic on S (in either color). Each such set has at most 2·2^(N − C(k,2)) colorings by the counting lemma applied with T = edgesWithin S. The union bound gives 2^N ≤ 2·C(n,k)·2^(N − C(k,2)). But the hypothesis 2·C(n,k) < 2^{C(k,2)}, multiplied by the positive free-edge factor 2^(N − C(k,2)) and using 2^{C(k,2)}·2^(N − C(k,2)) = 2^N (valid since C(k,2) ≤ N), forces 2^N < 2^N — a contradiction. So a coloring with no monochromatic K_k exists, i.e. R(k) > n.",
+    "mathContext": "Union bound: $2^N \\le \\sum_{|S|=k} 2 \\cdot 2^{N-\\binom{k}{2}} = 2\\binom{n}{k} 2^{N-\\binom{k}{2}}$. The hypothesis $2\\binom{n}{k} < 2^{\\binom{k}{2}}$ then gives $2^N < 2^N$, a contradiction — so $R(k) > n$.",
+    "significance": "critical",
+    "relatedConcepts": ["union bound", "probabilistic method", "proof by contradiction", "Ramsey number lower bound", "Boole's inequality"],
+    "prerequisites": ["combinatorics", "union bound", "Ramsey theory"]
   },
   {
     "id": "ann-scope-and-consequences",
@@ -29,6 +41,10 @@
     "range": { "startLine": 152, "endLine": 169 },
     "type": "concept",
     "title": "What This Proves — and What Stays Open",
-    "content": "Instantiating the threshold gives concrete lower bounds such as R(3) > 3 and, asymptotically, R(k) ≳ 2^{k/2}. This is the elementary Erdős (1947) bound (exponential base √2), strictly weaker than Spencer's √2/e refinement via the Lovász Local Lemma, and far weaker than would be needed to settle Erdős #1029. The open conjecture R(k)/(k·2^{k/2}) → ∞ — whether the probabilistic lower bound is far from tight — is untouched here; the gap between this base √2 and the upper bound's base 4 is exactly its content. The contribution is to replace an assumed lower bound (the parent's spencer_lower_bound axiom) with a fully machine-checked, 0-axiom counting proof of its elementary form."
+    "content": "Instantiating the threshold gives concrete lower bounds such as R(3) > 3 and, asymptotically, R(k) ≳ 2^{k/2}. This is the elementary Erdős (1947) bound (exponential base √2), strictly weaker than Spencer's √2/e refinement via the Lovász Local Lemma, and far weaker than would be needed to settle Erdős #1029. The open conjecture R(k)/(k·2^{k/2}) → ∞ — whether the probabilistic lower bound is far from tight — is untouched here; the gap between this base √2 and the upper bound's base 4 is exactly its content. The contribution is to replace an assumed lower bound (the parent's spencer_lower_bound axiom) with a fully machine-checked, 0-axiom counting proof of its elementary form.",
+    "mathContext": "Optimizing $2\\binom{n}{k} < 2^{\\binom{k}{2}}$ yields $R(k) > 2^{k/2}$ (Erdős 1947). Spencer's LLL refinement gives $R(k) \\gtrsim \\frac{\\sqrt 2}{e} k\\, 2^{k/2}$; the upper bound $R(k) \\le 4^k$ leaves the base $\\sqrt 2$ vs $4$ gap open.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős 1947 bound", "Lovász Local Lemma", "Ramsey number asymptotics", "Erdős problem #1029", "de-axiomatization"],
+    "prerequisites": ["Ramsey theory", "asymptotic analysis"]
   }
 ]

--- a/src/data/proofs/erdos-1029-oq-01/meta.json
+++ b/src/data/proofs/erdos-1029-oq-01/meta.json
@@ -135,8 +135,19 @@
   ],
   "crossReferences": [
     {
-      "slug": "erdos-1029",
-      "relevance": "Parent entry: states the open conjecture R(k)/(k·2^{k/2}) → ∞ and assumes the lower bound as the axiom spencer_lower_bound. This entry discharges the elementary version of that lower bound with 0 axioms."
+      "proofId": "erdos-1029",
+      "relationship": "parent",
+      "description": "Parent entry: states the open conjecture R(k)/(k·2^{k/2}) → ∞ and assumes the lower bound as the axiom spencer_lower_bound. This entry discharges the elementary version of that lower bound with 0 axioms."
+    },
+    {
+      "proofId": "lovasz-local-lemma",
+      "relationship": "strengthened-by",
+      "description": "Spencer's √2/e refinement of this elementary √2-base bound is obtained via the Lovász Local Lemma; the parent's assumed spencer_lower_bound is the LLL-strengthened form of the counting bound proved here."
+    },
+    {
+      "proofId": "property-b-first-moment",
+      "relationship": "related-technique",
+      "description": "Property B (Erdős 1963) uses the same first-moment counting argument — bound the number of 'bad' colorings by a union bound over candidate sets and show it is below the total — to prove small k-uniform hypergraphs are 2-colorable."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for `erdos-1029-oq-01`

This entry (quality 63, passes 0) had a complete `overview`/`conclusion`/`sections` and 4 strong annotations, but the annotations carried only `title` + `content` and the single cross-reference used a schema the page never renders.

### Added (annotation depth — the role's #1 mission)
- **`mathContext`** (LaTeX), **`significance`** (`critical` for the union-bound contradiction, `key` for the counting lemma and scope, `supporting` for the setup), **`relatedConcepts`**, and **`prerequisites`** on all 4 annotations. Resolver: **4 valid / 0 misaligned**; `content`/`range`/`type` preserved verbatim.

### Fixed / extended cross-references
- The lone crossRef used `slug`/`relevance`, which `ProofConclusion.tsx` does not read (it reads `proofId`/`targetId` + `description`/`relationship`) — so it rendered nothing. Converted to the correct schema.
- Added 2 genuinely related refs: **Lovász Local Lemma** (Spencer's √2/e refinement of this elementary √2-base bound) and **Property B** (same first-moment counting argument). All 3 targets verified present on `main`.

### Verification
- JSON valid; annotation alignment 4/4; meta.json 12KB, far under the 60KB cap.
- No change to `status`/`badge`/`axiomCount` (0-axiom counting proof discharging the parent's spencer_lower_bound axiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)