### PR TITLE
Enrich Catalan Factor of Central Binomial Recurrence (erdos-396-oq-04): annotation depth + sections

### DIFF
--- a/src/data/proofs/erdos-396-oq-04/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04/annotations.json
@@ -9,7 +9,10 @@
     "type": "key-step",
     "title": "Closed form: C(2(n+1),n+1) = 2(2n+1)·catalan n",
     "content": "Mathlib's `Nat.succ_mul_centralBinom_succ` states $(n+1)\\,C(2(n+1),n+1) = 2(2n+1)\\,C(2n,n)$. Rewriting $C(2n,n) = (n+1)\\,\\mathrm{catalan}\\,n$ via `succ_mul_catalan_eq_centralBinom` and cancelling the nonzero factor $n+1$ with `Nat.eq_of_mul_eq_mul_left` yields $C(2(n+1),n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$. This exposes the Catalan number as the exact cofactor of $2(2n+1)$ — a form Mathlib does not record, since it proves Catalan integrality through a Gosper telescoping instead.",
-    "mathContext": "$C(2(n+1),n+1) = 2(2n+1)\\,C_n$ where $C_n = \\mathrm{catalan}\\,n$."
+    "mathContext": "$C(2(n+1),n+1) = 2(2n+1)\\,C_n$ where $C_n = \\mathrm{catalan}\\,n$.",
+    "significance": "critical",
+    "relatedConcepts": ["central binomial coefficient", "Catalan numbers", "Nat.eq_of_mul_eq_mul_left", "cancellation", "closed form"],
+    "prerequisites": ["combinatorics", "natural number arithmetic"]
   },
   {
     "id": "ann-e396oq04-divisibility",
@@ -21,7 +24,10 @@
     "type": "concept",
     "title": "Divisibility refinements",
     "content": "Reading the closed form as a product gives four divisibilities of the next central binomial coefficient: by $\\mathrm{catalan}\\,n$ (cofactor $2(2n+1)$), by $2(2n+1)$, by the odd factor $2n+1$, and by $2$. The odd-factor statement strengthens Mathlib's `two_dvd_centralBinom_succ`, which records only the even factor.",
-    "mathContext": "$\\mathrm{catalan}\\,n \\mid C(2(n+1),n+1)$ and $(2n+1) \\mid C(2(n+1),n+1)$."
+    "mathContext": "$\\mathrm{catalan}\\,n \\mid C(2(n+1),n+1)$ and $(2n+1) \\mid C(2(n+1),n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["divisibility", "central binomial coefficient", "Catalan numbers", "odd factor", "Erdős problem #396"],
+    "prerequisites": ["divisibility", "number theory"]
   },
   {
     "id": "ann-e396oq04-recurrence",
@@ -33,7 +39,10 @@
     "type": "key-step",
     "title": "Two-term Catalan recurrence",
     "content": "Applying `succ_mul_catalan_eq_centralBinom` at index $n+1$ gives $(n+2)\\,\\mathrm{catalan}(n+1) = C(2(n+1),n+1)$; substituting the closed form yields the elementary recurrence $(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ — the standard computational recurrence for Catalan numbers, here obtained without binomial coefficients.",
-    "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{2(2n+1)}{n+2} C_n$."
+    "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{2(2n+1)}{n+2} C_n$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan recurrence", "Catalan numbers", "central binomial coefficient", "integer sequence", "Gosper telescoping"],
+    "prerequisites": ["combinatorics", "recurrence relations"]
   },
   {
     "id": "ann-e396oq04-coprime",
@@ -45,6 +54,9 @@
     "type": "concept",
     "title": "Coprimality of the divisors",
     "content": "The two natural divisors $n+1$ and $2n+1$ of consecutive central binomial coefficients are coprime: peeling $2n+1 = n + 1\\cdot(n+1)$ reduces $\\gcd(n+1, 2n+1)$ to $\\gcd(n+1, n) = \\gcd(n, 1) = 1$. This explains why the two divisibility constraints act independently.",
-    "mathContext": "$\\gcd(n+1,\\,2n+1) = 1$ for all $n$."
+    "mathContext": "$\\gcd(n+1,\\,2n+1) = 1$ for all $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["coprimality", "Euclidean algorithm", "greatest common divisor", "independent divisors"],
+    "prerequisites": ["number theory", "gcd"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04/meta.json
+++ b/src/data/proofs/erdos-396-oq-04/meta.json
@@ -51,6 +51,48 @@
       "Which composite divisors d ∣ C(2(n+1),n+1) are forced beyond 2(2n+1) and n+2, and how do they relate to the descending-factorial products in the #396 conjecture?"
     ]
   },
+  "sections": [
+    {
+      "id": "closed-form",
+      "title": "The closed form",
+      "startLine": 40,
+      "endLine": 57,
+      "summary": "centralBinom_succ_eq: substituting C(2n,n) = (n+1)·catalan n into Mathlib's recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) and cancelling n+1 gives the closed form C(2(n+1),n+1) = 2(2n+1)·catalan n — exposing the Catalan number as the exact cofactor of 2(2n+1).",
+      "mathContext": "$C(2(n+1),n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "divisibility-refinements",
+      "title": "Divisibility refinements",
+      "startLine": 58,
+      "endLine": 82,
+      "summary": "Reading the closed form as a product yields four divisibilities of the next central binomial coefficient: by catalan n (catalan_dvd_centralBinom_succ), by 2(2n+1) (two_mul_succ_dvd_centralBinom_succ), by the odd factor 2n+1 (odd_factor_dvd_centralBinom_succ, stronger than Mathlib's even-only fact), and by 2 (two_dvd_centralBinom_succ, re-derived as a corollary).",
+      "mathContext": "$\\mathrm{catalan}\\,n \\mid C(2(n+1),n+1)$, $\\ (2n+1) \\mid C(2(n+1),n+1)$"
+    },
+    {
+      "id": "catalan-recurrence",
+      "title": "The two-term Catalan recurrence",
+      "startLine": 84,
+      "endLine": 104,
+      "summary": "catalan_recurrence: applying succ_mul_catalan_eq_centralBinom at index n+1 and substituting the closed form gives the elementary recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n — the standard computational recurrence for Catalan numbers without binomial coefficients. succ_succ_dvd records the divisibility (n+2) ∣ 2(2n+1)·catalan n it implies.",
+      "mathContext": "$(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "coprimality",
+      "title": "Coprimality of the two divisors",
+      "startLine": 106,
+      "endLine": 116,
+      "summary": "coprime_succ_two_mul_succ: the divisors n+1 and 2n+1 are coprime, by peeling 2n+1 = n + 1·(n+1) to reduce gcd(n+1, 2n+1) to gcd(n+1, n) = gcd(n, 1) = 1 — explaining why the two divisibility constraints act independently.",
+      "mathContext": "$\\gcd(n+1,\\,2n+1) = 1$"
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity checks against explicit Catalan values",
+      "startLine": 118,
+      "endLine": 130,
+      "summary": "Three example checks confirm the formulas on concrete values: C(2,1) = 2 = 2(2·0+1)·catalan 0, C(6,3) = 20 = 2·5·catalan 2, and the recurrence at n=2 (4·catalan 3 = 2·5·catalan 2, i.e. 4·5 = 20).",
+      "mathContext": "$C(6,3) = 20 = 2\\cdot 5\\cdot\\mathrm{catalan}\\,2$"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Enrichment pass for `erdos-396-oq-04`

Quality 63, passes 0. Two concrete gaps fixed:

### Annotation depth (role's #1 mission)
The 4 annotations had `mathContext` but no `significance`/`relatedConcepts`/`prerequisites`. Added all three to each (`critical` for the closed form, `key` for divisibility + recurrence, `supporting` for coprimality). `content`/`range`/`type`/`mathContext` preserved. Resolver: **4 valid / 0 misaligned**.

### Sections (was absent)
The `sections` key was missing entirely, so the page had no section navigation. Added **5 sections** with line ranges and LaTeX `mathContext` covering the closed form, the four divisibility refinements, the two-term Catalan recurrence, coprimality of n+1 and 2n+1, and the sanity checks.

### Verification
- JSON valid; meta.json 9KB (far under 60KB cap); annotation alignment 4/4.
- crossReferences already use the correct `targetId` schema — unchanged.
- `status`/`badge`/`axiomCount` untouched (0-axiom, 0-sorry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)