### PR TITLE
Enrich Asymptotics of the Catalan Recurrence Ratio (erdos-396-oq-04-oq-01): annotation depth + sections

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/annotations.json
@@ -9,7 +9,10 @@
     "type": "key-step",
     "title": "The two-term Catalan recurrence (self-contained)",
     "content": "The file re-derives the closed form $C(2(n+1),n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ and the recurrence $(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$ directly from Mathlib's `Nat.succ_mul_centralBinom_succ` and `succ_mul_catalan_eq_centralBinom`, so it does not depend on the parent build. It also supplies `catalan_pos`, which Mathlib lacks, from $(n+1)\\,\\mathrm{catalan}\\,n = C(2n,n) > 0$.",
-    "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{4n+2}{n+2}\\,C_n$."
+    "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$, i.e. $C_{n+1} = \\frac{4n+2}{n+2}\\,C_n$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan recurrence", "central binomial coefficient", "catalan_pos", "self-contained derivation", "Catalan numbers"],
+    "prerequisites": ["combinatorics", "recurrence relations"]
   },
   {
     "id": "ann-e396oq04oq01-partialfraction",
@@ -21,7 +24,10 @@
     "type": "key-step",
     "title": "Partial-fraction form r n = 4 − 6/(n+2)",
     "content": "The multiplicative step is `catalanRatio n = (4n+2)/(n+2)`. The single identity $r(n) = 4 - \\frac{6}{n+2}$ (proved by `field_simp; ring`, using $4(n+2) - (4n+2) = 6$) encodes the whole asymptotic story: the constant $4$ is the limit, and the positive tail $\\frac{6}{n+2}$ forces both $r(n) < 4$ and strict growth of $r$. The step is the genuine quotient of consecutive Catalan numbers: $(\\mathrm{catalan}(n+1):\\mathbb{R}) = r(n)\\cdot\\mathrm{catalan}\\,n$.",
-    "mathContext": "$r(n) = \\dfrac{4n+2}{n+2} = 4 - \\dfrac{6}{n+2}$."
+    "mathContext": "$r(n) = \\dfrac{4n+2}{n+2} = 4 - \\dfrac{6}{n+2}$.",
+    "significance": "critical",
+    "relatedConcepts": ["partial fractions", "Catalan ratio", "asymptotic constant", "field_simp", "consecutive ratio"],
+    "prerequisites": ["real analysis", "algebraic manipulation"]
   },
   {
     "id": "ann-e396oq04oq01-limit",
@@ -33,7 +39,10 @@
     "type": "key-step",
     "title": "Ratio bounded by 4, increasing, and converging to 4",
     "content": "From the partial-fraction form: `ratio_lt_four` ($r(n) < 4$, the step never reaches $4$); `ratio_strictMono` ($r$ strictly increases, since $\\frac{6}{n+2}$ strictly decreases — via `div_lt_div_iff₀`); and `ratio_tendsto_four` ($r(n) \\to 4$), proved by sending $n+2 \\to \\infty$ with `Tendsto.inv_tendsto_atTop` so that $\\frac{6}{n+2} \\to 0$. This is the recurrence-level shadow of the exponential growth rate $4$ in $\\mathrm{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt{\\pi})$.",
-    "mathContext": "$r(n) < 4$, $r$ strictly increasing, $\\lim_{n\\to\\infty} r(n) = 4$."
+    "mathContext": "$r(n) < 4$, $r$ strictly increasing, $\\lim_{n\\to\\infty} r(n) = 4$.",
+    "significance": "critical",
+    "relatedConcepts": ["limit of a sequence", "monotone convergence", "Tendsto.inv_tendsto_atTop", "Catalan asymptotics", "growth rate 4"],
+    "prerequisites": ["real analysis", "limits", "monotonicity"]
   },
   {
     "id": "ann-e396oq04oq01-growth",
@@ -45,6 +54,9 @@
     "type": "concept",
     "title": "Catalan growth bounds from the recurrence",
     "content": "Because $4n+2 < 4(n+2)$, the recurrence gives `catalan_succ_lt_four_mul`: $\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$, by cancelling the positive factor $n+2$ with `Nat.lt_of_mul_lt_mul_left`. Induction then yields `catalan_le_four_pow`: $\\mathrm{catalan}\\,n \\le 4^n$ for all $n$ (and the strict `catalan_lt_four_pow`: $\\mathrm{catalan}\\,n < 4^n$ for $n \\ge 1$) — the standard upper bound, obtained purely from the recurrence with no Stirling estimate.",
-    "mathContext": "$\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$ and $\\mathrm{catalan}\\,n \\le 4^n$."
+    "mathContext": "$\\mathrm{catalan}(n+1) < 4\\,\\mathrm{catalan}\\,n$ and $\\mathrm{catalan}\\,n \\le 4^n$.",
+    "significance": "key",
+    "relatedConcepts": ["growth bound", "induction", "exponential bound 4^n", "Catalan numbers", "Stirling-free estimate"],
+    "prerequisites": ["combinatorics", "induction", "inequalities"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01/meta.json
@@ -53,6 +53,40 @@
       "Does the same ratio-as-partial-fraction technique applied to (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) give the matching central-binomial growth law C(2n,n) ∼ 4^n/√(πn) at the recurrence level?"
     ]
   },
+  "sections": [
+    {
+      "id": "recurrence-self-contained",
+      "title": "The two-term Catalan recurrence (re-derived, self-contained)",
+      "startLine": 45,
+      "endLine": 73,
+      "summary": "centralBinom_succ_eq and catalan_recurrence re-derive the closed form C(2(n+1),n+1) = 2(2n+1)·catalan n and the recurrence (n+2)·catalan(n+1) = 2(2n+1)·catalan n directly from Mathlib, with no dependency on the parent build. catalan_pos supplies positivity of the Catalan numbers (which Mathlib lacks) from (n+1)·catalan n = C(2n,n) > 0.",
+      "mathContext": "$(n+2)\\,\\mathrm{catalan}(n+1) = 2(2n+1)\\,\\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "recurrence-ratio",
+      "title": "The recurrence ratio",
+      "startLine": 74,
+      "endLine": 135,
+      "summary": "catalanRatio n = (4n+2)/(n+2) is the multiplicative step. ratio_eq_four_sub proves the partial-fraction identity r n = 4 − 6/(n+2); catalan_succ_eq_ratio_mul shows it is the genuine ratio of consecutive Catalan numbers. From the partial-fraction form: ratio_lt_four (r n < 4), ratio_pos (0 < r n), ratio_strictMono (strictly increasing), and ratio_tendsto_four (r n → 4).",
+      "mathContext": "$r(n) = \\dfrac{4n+2}{n+2} = 4 - \\dfrac{6}{n+2} \\to 4$"
+    },
+    {
+      "id": "growth-bounds",
+      "title": "Growth bounds from the recurrence",
+      "startLine": 137,
+      "endLine": 174,
+      "summary": "catalan_succ_lt_four_mul: catalan(n+1) < 4·catalan n (since 4n+2 < 4(n+2), cancelling n+2 via Nat.lt_of_mul_lt_mul_left). By induction, catalan_le_four_pow gives catalan n ≤ 4^n for all n, and catalan_lt_four_pow gives the strict bound catalan n < 4^n for n ≥ 1 — the standard upper bound with no Stirling estimate.",
+      "mathContext": "$\\mathrm{catalan}\\,n \\le 4^n$, strict for $n \\ge 1$"
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity checks",
+      "startLine": 176,
+      "endLine": 187,
+      "summary": "Numeric example checks: r 0 = 1 (catalan 1 = catalan 0), r 2 = 10/4 = 5/2 (catalan 3 = (5/2)·catalan 2, i.e. 5 = (5/2)·2), and the growth bound at n=3 (catalan 3 = 5 < 4³ = 64).",
+      "mathContext": "$r(2) = \\tfrac{10}{4} = \\tfrac52,\\ \\mathrm{catalan}\\,3 = 5 < 64$"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Enrichment pass for `erdos-396-oq-04-oq-01`

Quality 63, passes 0. Two gaps fixed:

### Annotation depth (role's #1 mission)
The 4 annotations had `mathContext` but no `significance`/`relatedConcepts`/`prerequisites`. Added all three (`critical` for the partial-fraction identity r n = 4 − 6/(n+2) and the bounded/increasing/convergent-to-4 result; `key` for the self-contained recurrence and the 4^n growth bounds). `content`/`range`/`type`/`mathContext` preserved. Resolver: **4 valid / 0 misaligned**.

### Sections (was absent)
Added **4 sections** with line ranges and LaTeX `mathContext` covering the self-contained recurrence (+catalan_pos), the recurrence ratio and its partial-fraction asymptotics, the integer 4^n growth bounds, and the numeric sanity checks.

### Verification
- JSON valid; meta.json 9.6KB (under 60KB cap); annotation alignment 4/4.
- crossReferences already use the correct `targetId` schema — unchanged.
- `status`/`badge`/`axiomCount` untouched (0-axiom, 0-sorry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)