### PR TITLE
Enrich Descartes' Total Angular Defect Theorem (euler-polyhedral-formula-oq-01-oq-02-oq-01): annotation depth + crossRef fix

### DIFF
--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "Total Face Angle = (Σ sizes)·π − 2π·F",
-    "content": "A planar n-gon has interior angles summing to (n−2)π. `totalFaceAngle` sums this over the multiset of all face sizes; the closed form totalFaceAngle = (Σ sizes)·π − 2π·F is obtained by a one-line induction over the multiset (`Multiset.induction_on`, then `push_cast; ring`). This is the crucial reorganisation: it replaces the unknown per-vertex angles by the known per-face angle sums, which only depend on how many sides each face has."
+    "content": "A planar n-gon has interior angles summing to (n−2)π. `totalFaceAngle` sums this over the multiset of all face sizes; the closed form totalFaceAngle = (Σ sizes)·π − 2π·F is obtained by a one-line induction over the multiset (`Multiset.induction_on`, then `push_cast; ring`). This is the crucial reorganisation: it replaces the unknown per-vertex angles by the known per-face angle sums, which only depend on how many sides each face has.",
+    "mathContext": "$\\sum_{f} (s_f - 2)\\pi = \\left(\\sum_f s_f\\right)\\pi - 2\\pi F$, where $s_f$ is the number of sides of face $f$ and $F$ the number of faces.",
+    "significance": "key",
+    "relatedConcepts": ["interior angle sum", "polygon", "Multiset.induction_on", "face sizes", "angle bookkeeping"],
+    "prerequisites": ["Euclidean geometry", "finite sums"]
   },
   {
     "id": "ann-surface-model",
@@ -19,7 +23,11 @@
     },
     "type": "concept",
     "title": "The Combinatorial Polyhedral Surface",
-    "content": "`PolyhedralSurface` packages the data needed for Descartes' theorem: vertex/edge/face counts V,E,F, the multiset of face sizes (each ≥ 3), the face–edge handshake Σ(face sizes) = 2E (every edge borders exactly two faces), and Euler's formula V−E+F=2. No embedding into ℝ³ is assumed — only the combinatorial incidence data and the angle bookkeeping it determines."
+    "content": "`PolyhedralSurface` packages the data needed for Descartes' theorem: vertex/edge/face counts V,E,F, the multiset of face sizes (each ≥ 3), the face–edge handshake Σ(face sizes) = 2E (every edge borders exactly two faces), and Euler's formula V−E+F=2. No embedding into ℝ³ is assumed — only the combinatorial incidence data and the angle bookkeeping it determines.",
+    "mathContext": "Data: $V, E, F$, face sizes $s_f \\ge 3$, handshake $\\sum_f s_f = 2E$, and $V - E + F = 2$. Purely combinatorial — no metric embedding.",
+    "significance": "supporting",
+    "relatedConcepts": ["polyhedral surface", "handshake lemma", "Euler characteristic", "combinatorial structure", "face–edge incidence"],
+    "prerequisites": ["graph theory", "polyhedra"]
   },
   {
     "id": "ann-gauss-bonnet",
@@ -28,9 +36,13 @@
       "startLine": 80,
       "endLine": 116
     },
-    "type": "key-insight",
+    "type": "insight",
     "title": "Discrete Gauss–Bonnet: totalDefect = 2π·χ",
-    "content": "The total angular defect is 2π per vertex minus the total face angle. Substituting the closed form and the handshake Σ sizes = 2E gives totalDefect = 2π·V − (2E·π − 2π·F) = 2π·(V − E + F) — the discrete Gauss–Bonnet identity, total defect equals 2π times the Euler characteristic. Note this step uses ONLY the handshake, not Euler's formula. Descartes' constant 4π then drops out by evaluating χ = 2 for a sphere (`exact_mod_cast` from the ℤ-valued Euler field, then `linear_combination`/`ring`). The proof is linear in the symbol π, so no analytic property of π is invoked."
+    "content": "The total angular defect is 2π per vertex minus the total face angle. Substituting the closed form and the handshake Σ sizes = 2E gives totalDefect = 2π·V − (2E·π − 2π·F) = 2π·(V − E + F) — the discrete Gauss–Bonnet identity, total defect equals 2π times the Euler characteristic. Note this step uses ONLY the handshake, not Euler's formula. Descartes' constant 4π then drops out by evaluating χ = 2 for a sphere (`exact_mod_cast` from the ℤ-valued Euler field, then `linear_combination`/`ring`). The proof is linear in the symbol π, so no analytic property of π is invoked.",
+    "mathContext": "$\\sum_v \\left(2\\pi - \\text{(face angles at }v)\\right) = 2\\pi(V - E + F) = 2\\pi\\chi$; for a sphere $\\chi = 2$, giving Descartes' total defect $4\\pi$.",
+    "significance": "critical",
+    "relatedConcepts": ["Gauss–Bonnet theorem", "angular defect", "Euler characteristic", "Descartes' theorem", "discrete curvature"],
+    "prerequisites": ["differential geometry", "Euler characteristic"]
   },
   {
     "id": "ann-platonic",
@@ -41,6 +53,10 @@
     },
     "type": "concept",
     "title": "The Five Platonic Solids Realise 4π",
-    "content": "Each Platonic solid is built as a PolyhedralSurface whose faces are all congruent — a single replicated face size (e.g. the cube is six squares, `Multiset.replicate 6 4`). The handshake and Euler fields are discharged by `decide`. `platonic_defects` then derives total defect 4π for all five from the general `descartes` theorem. A formula-free `cube_defect_direct` cross-checks the cube directly: 8 vertices each of defect 2π − 3·(π/2) = π/2, totalling 4π."
+    "content": "Each Platonic solid is built as a PolyhedralSurface whose faces are all congruent — a single replicated face size (e.g. the cube is six squares, `Multiset.replicate 6 4`). The handshake and Euler fields are discharged by `decide`. `platonic_defects` then derives total defect 4π for all five from the general `descartes` theorem. A formula-free `cube_defect_direct` cross-checks the cube directly: 8 vertices each of defect 2π − 3·(π/2) = π/2, totalling 4π.",
+    "mathContext": "Cube: 8 vertices, each defect $2\\pi - 3\\cdot\\tfrac{\\pi}{2} = \\tfrac{\\pi}{2}$; total $8\\cdot\\tfrac{\\pi}{2} = 4\\pi$. All five Platonic solids realise the same $4\\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["Platonic solids", "Multiset.replicate", "decide", "vertex defect", "regular polyhedra"],
+    "prerequisites": ["polyhedra", "Platonic solids"]
   }
 ]

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02-oq-01/meta.json
@@ -123,12 +123,14 @@
   ],
   "crossReferences": [
     {
-      "slug": "euler-polyhedral-formula-oq-01-oq-02",
-      "relevance": "Parent entry: surveys the planar-graph / Four-Colour-Theorem side of Euler's formula. This entry gives the metric/curvature counterpart — the total angular defect — of the same Euler characteristic."
+      "proofId": "euler-polyhedral-formula-oq-01-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: surveys the planar-graph / Four-Colour-Theorem side of Euler's formula. This entry gives the metric/curvature counterpart — the total angular defect — of the same Euler characteristic."
     },
     {
-      "slug": "euler-polyhedral-formula",
-      "relevance": "Base entry: states Euler's polyhedral formula and the Platonic-solids classification from the Schläfli inequality. Descartes' theorem here is the angular-defect form of that same formula."
+      "proofId": "euler-polyhedral-formula",
+      "relationship": "ancestor",
+      "description": "Base entry: states Euler's polyhedral formula and the Platonic-solids classification from the Schläfli inequality. Descartes' theorem here is the angular-defect form of that same formula."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Enrichment pass for `euler-polyhedral-formula-oq-01-oq-02-oq-01`

Quality 63, passes 0. Complete `overview`/`conclusion`/`sections`; the gaps were bare annotations and dead-schema cross-references.

### Annotation depth (role's #1 mission)
Added `mathContext` (LaTeX), `significance` (`critical` for the discrete Gauss–Bonnet identity totalDefect = 2π·χ; `key` for the total-face-angle closed form and the Platonic realisation; `supporting` for the surface model), `relatedConcepts`, `prerequisites` to all 4 annotations. Also corrected an invalid `type: "key-insight"` to `"insight"` (the resolver rejects key-insight on a theorem construct). Resolver: **4 valid / 0 misaligned**.

### Cross-reference fix
The 2 crossRefs used `slug`/`relevance`, which `ProofConclusion.tsx` does not read — so they rendered nothing. Converted to the `proofId`/`relationship`/`description` schema. Both targets (`euler-polyhedral-formula-oq-01-oq-02`, `euler-polyhedral-formula`) verified present on `main`.

### Verification
- JSON valid; meta.json 11KB (under 60KB cap); annotation alignment 4/4.
- `status`/`badge`/`axiomCount` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)