### PR TITLE
research(burnside-paqb): verified reduction of Burnside's pᵃqᵇ theorem to non-simplicity

### DIFF
--- a/proofs/Proofs/BurnsidePaQbSolvable.lean
+++ b/proofs/Proofs/BurnsidePaQbSolvable.lean
@@ -1,0 +1,166 @@
+import Mathlib.GroupTheory.Nilpotent
+import Mathlib.GroupTheory.Solvable
+import Mathlib.GroupTheory.PGroup
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.QuotientGroup.Defs
+
+/-!
+# Toward Burnside's `pᵃqᵇ` Theorem: Verified Reduction Scaffolding
+
+## The Target
+
+**Burnside's `pᵃqᵇ` theorem** (1904): every finite group whose order has the form
+`pᵃ · qᵇ` for primes `p`, `q` is **solvable**. Equivalently, a finite simple group
+whose order has at most two distinct prime factors is cyclic of prime order.
+
+The only known proofs of the full statement go through the **character theory of
+finite groups** (the "elementary" group-theoretic proofs found decades later still
+rely on substantial machinery). The character-theoretic heart is:
+
+* the degrees of the irreducible complex representations divide `|G|`;
+* an algebraic-integer argument (Burnside's vanishing lemma): if a conjugacy class
+  has size coprime to `χ(1)` for an irreducible character `χ`, then `χ(g) = 0` or
+  the representation is scalar at `g`;
+* counting irreducibles by conjugacy classes;
+
+which together force a finite nonabelian group of order `pᵃqᵇ` to possess a proper
+nontrivial normal subgroup. Solvability then follows by induction.
+
+## What This File Provides (all fully verified, no `sorry`, no `axiom`)
+
+Mathlib currently has the *outer* layers of this argument but **not** the
+character-theoretic core. This file assembles the verified outer layers into the
+two reusable ingredients that any proof of Burnside's theorem ultimately needs:
+
+1. `isSolvable_of_isPGroup` / `isSolvable_of_card_prime_pow` — the **base case**:
+   groups of prime-power order are solvable (they are even nilpotent). This is the
+   `b = 0` (and `a = 0`) edge of the `pᵃqᵇ` grid, and the leaves of the induction.
+2. `solvable_of_normal_extension` — the **inductive step engine**: an extension of a
+   solvable group by a solvable group is solvable. Given a proper nontrivial normal
+   subgroup `N`, solvability of `N` and of `G ⧸ N` yields solvability of `G`.
+
+With these two in hand, Burnside's theorem reduces to the single purely
+group-theoretic statement
+  *"a finite nonabelian group of order `pᵃqᵇ` is not simple"*,
+which is exactly the part still missing from Mathlib (it is the character-theory
+core above). We record that reduction precisely as `burnside_reduces_to_nonsimplicity`
+below — a *conditional* theorem that takes the non-simplicity fact as an explicit
+hypothesis and is itself fully verified.
+
+## Mathlib Dependencies
+
+- `IsPGroup.of_card`, `IsPGroup.isNilpotent` : prime-power groups are nilpotent
+- `IsNilpotent.to_isSolvable` : nilpotent ⟹ solvable
+- `solvable_of_ker_le_range` : the homological extension principle for solvability
+- `QuotientGroup.ker_mk'`, `Subgroup.range_subtype` : identifying kernel and range
+
+## Status
+
+`verified` — every declaration is machine-checked with no `sorry` and no `axiom`.
+The full `pᵃqᵇ` theorem is *not* claimed here; it is documented as the open frontier
+and reduced to a single hypothesis. See `research/problems/.../knowledge.md`.
+-/
+
+open Subgroup
+
+namespace BurnsidePaQb
+
+variable {G : Type*} [Group G]
+
+/-! ### Base case: prime-power order ⟹ solvable -/
+
+/-- A finite `p`-group is solvable (indeed nilpotent). This is the leaf case of the
+inductive proof of Burnside's theorem and the `a = 0`/`b = 0` edge of the grid. -/
+theorem isSolvable_of_isPGroup [Finite G] {p : ℕ} [Fact p.Prime]
+    (h : IsPGroup p G) : IsSolvable G := by
+  haveI := h.isNilpotent
+  infer_instance
+
+/-- A finite group of prime-power order `pⁿ` is solvable. -/
+theorem isSolvable_of_card_prime_pow [Finite G] {p n : ℕ} [Fact p.Prime]
+    (h : Nat.card G = p ^ n) : IsSolvable G :=
+  isSolvable_of_isPGroup (IsPGroup.of_card h)
+
+/-! ### Inductive step: extensions of solvable groups are solvable -/
+
+/-- **Extension principle for solvability.** If `N` is a normal subgroup of `G` with
+both `N` and the quotient `G ⧸ N` solvable, then `G` is solvable.
+
+This is the engine of the induction in Burnside's theorem: a proper nontrivial
+normal subgroup splits `G` into two strictly smaller pieces, each of order again of
+the form `pᵃqᵇ`, to which the induction hypothesis applies. -/
+theorem solvable_of_normal_extension (N : Subgroup G) [N.Normal]
+    [IsSolvable N] [IsSolvable (G ⧸ N)] : IsSolvable G :=
+  solvable_of_ker_le_range N.subtype (QuotientGroup.mk' N)
+    (by rw [QuotientGroup.ker_mk', Subgroup.range_subtype])
+
+/-! ### The reduction to non-simplicity
+
+We package the two-prime hypothesis as a predicate on the order, closed under passing
+to subgroups and quotients (since their orders divide `|G|`). -/
+
+/-- `OrderTwoPrimes p q G` says every prime divisor of `|G|` is `p` or `q`; equivalently
+`|G|` has the form `pᵃqᵇ`. This is the hypothesis class of Burnside's theorem and is
+inherited by subgroups and quotients. -/
+def OrderTwoPrimes (p q : ℕ) (G : Type*) [Group G] : Prop :=
+  ∀ r : ℕ, r.Prime → r ∣ Nat.card G → r = p ∨ r = q
+
+/-- **Burnside's theorem, reduced to a single group-theoretic input.**
+
+If one supplies the (character-theoretic, currently not in Mathlib) fact that *every*
+finite nonabelian group whose order involves only the primes `p`, `q` has a proper
+nontrivial normal subgroup, then every finite group of order `pᵃqᵇ` is solvable.
+
+This theorem is fully verified: it performs the strong induction on `|G|` and the
+extension assembly, isolating the unproved mathematics into the single hypothesis
+`not_simple`. Discharging `not_simple` from Mathlib would complete Burnside's theorem. -/
+theorem burnside_reduces_to_nonsimplicity {p q : ℕ}
+    (not_simple : ∀ (H : Type) [Group H] [Finite H], OrderTwoPrimes p q H →
+      Nontrivial H → (¬ ∀ a b : H, a * b = b * a) →
+      ∃ N : Subgroup H, N.Normal ∧ N ≠ ⊥ ∧ N ≠ ⊤) :
+    ∀ (H : Type) [Group H] [Finite H], OrderTwoPrimes p q H → IsSolvable H := by
+  -- Strong induction on the order `n = |H|`, phrased so the hypothesis applies to the
+  -- subgroup `N` and quotient `H ⧸ N` (both genuine `Type`s of strictly smaller order).
+  have key : ∀ n : ℕ, ∀ (H : Type) [Group H] [Finite H],
+      Nat.card H = n → OrderTwoPrimes p q H → IsSolvable H := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro H _ _ hcard htp
+      -- Abelian groups are solvable outright; otherwise invoke non-simplicity.
+      by_cases hcomm : ∀ a b : H, a * b = b * a
+      · exact isSolvable_of_comm hcomm
+      · -- A nonabelian group is nontrivial.
+        have hnt : Nontrivial H := by
+          rcases subsingleton_or_nontrivial H with hs | hnt
+          · exact absurd (fun a b => Subsingleton.elim (a * b) (b * a)) hcomm
+          · exact hnt
+        obtain ⟨N, hNnorm, hNbot, hNtop⟩ := not_simple H htp hnt hcomm
+        haveI : N.Normal := hNnorm
+        -- `N ≠ ⊤` gives `|N| < |H|`; `N ≠ ⊥` gives `|H ⧸ N| < |H|`.
+        have hNlt : Nat.card N < Nat.card H := by
+          have hidx : 1 < N.index := Subgroup.one_lt_index_of_ne_top hNtop
+          calc Nat.card N < Nat.card N * N.index :=
+                (Nat.lt_mul_iff_one_lt_right Nat.card_pos).2 hidx
+            _ = Nat.card H := Subgroup.card_mul_index N
+        have hQlt : Nat.card (H ⧸ N) < Nat.card H := by
+          rw [← Subgroup.index_eq_card N]
+          have hpos : 0 < N.index := Nat.pos_of_ne_zero Subgroup.index_ne_zero_of_finite
+          have hcard1 : 1 < Nat.card N := N.one_lt_card_iff_ne_bot.2 hNbot
+          calc N.index < N.index * Nat.card N :=
+                (Nat.lt_mul_iff_one_lt_right hpos).2 hcard1
+            _ = Nat.card H := Subgroup.index_mul_card N
+        -- Orders of `N` and `H ⧸ N` divide `|H|`, so they still involve only `p`, `q`.
+        have hNdvd : Nat.card N ∣ Nat.card H := Subgroup.card_subgroup_dvd_card N
+        have hQdvd : Nat.card (H ⧸ N) ∣ Nat.card H := Subgroup.card_quotient_dvd_card N
+        have htpN : OrderTwoPrimes p q N := fun r hr hrd => htp r hr (hrd.trans hNdvd)
+        have htpQ : OrderTwoPrimes p q (H ⧸ N) := fun r hr hrd => htp r hr (hrd.trans hQdvd)
+        -- Apply the induction hypothesis to both strictly smaller pieces.
+        haveI : IsSolvable N := ih _ (hcard ▸ hNlt) N rfl htpN
+        haveI : IsSolvable (H ⧸ N) := ih _ (hcard ▸ hQlt) (H ⧸ N) rfl htpQ
+        -- Reassemble via the extension principle.
+        exact solvable_of_normal_extension N
+  intro H _ _ htp
+  exact key (Nat.card H) H rfl htp
+
+end BurnsidePaQb

--- a/research/problems/abel-ruffini-oq-04-oq-02-oq-03-oq-01/knowledge.md
+++ b/research/problems/abel-ruffini-oq-04-oq-02-oq-03-oq-01/knowledge.md
@@ -1,0 +1,98 @@
+# Burnside pᵃqᵇ Theorem (abel-ruffini-oq-04-oq-02-oq-03-oq-01)
+
+## Problem Summary
+
+Pool title: *"Formalize Burnside pᵃqᵇ theorem via Mathlib character theory."*
+
+**Burnside's theorem (1904):** every finite group of order `pᵃ · qᵇ` (with `p`, `q`
+prime) is solvable. Equivalently, a finite simple group with at most two distinct
+prime divisors is cyclic of prime order. This is one of the well-known "not yet in
+Mathlib" results (it appears on tracking lists of missing classical theorems).
+
+## Mathlib Status (v4.26.0) — Gap Analysis
+
+What Mathlib **has** (the outer layers of the standard proof):
+
+| Ingredient | Mathlib name |
+|---|---|
+| p-groups are nilpotent | `IsPGroup.isNilpotent` |
+| nilpotent ⟹ solvable | `IsNilpotent.to_isSolvable` (instance) |
+| prime-power order ⟹ p-group | `IsPGroup.of_card` |
+| extension principle for solvability | `solvable_of_ker_le_range` |
+| Lagrange / index arithmetic | `Subgroup.card_mul_index`, `index_mul_card`, `one_lt_index_of_ne_top` |
+| abelian ⟹ solvable | `isSolvable_of_comm` |
+| character of an `FDRep`, orthogonality | `FDRep.character`, `char_orthonormal` |
+
+What Mathlib **lacks** (the character-theoretic core), and is the genuine blocker:
+
+1. **Irreducible character degrees divide `|G|`.** Needs the algebraic-integer
+   theory of `∑ χ(g)` over conjugacy classes and the class-sum/central-character
+   machinery. Not present.
+2. **Burnside's vanishing lemma.** If `gcd(|class of g|, χ(1)) = 1` for an irreducible
+   `χ`, then `χ(g) = 0` or `ρ(g)` is scalar. Relies on an averaged-root-of-unity
+   bound (`|χ(g)/χ(1)| ≤ 1` for an algebraic integer that is also an average of roots
+   of unity ⟹ it is `0` or a root of unity). Not present.
+3. **#irreducibles = #conjugacy classes** over `ℂ`. Mathlib has orthogonality of the
+   characters that exist but not the completeness/count statement in a usable form.
+4. Assembling 1–3 into: *a finite nonabelian group of order `pᵃqᵇ` has a proper
+   nontrivial normal subgroup* (it is not simple).
+
+Estimated cost to close the gap: **>1000 lines** of new representation theory
+(class functions as an inner-product space, central characters, algebraic-integrality
+of class sums, the vanishing lemma). This is a BLOCKED target for a single session.
+
+## Approach Taken — Verified Reduction Scaffolding
+
+Rather than axiomatize the whole theorem (pure scaffolding, discouraged), this session
+delivers the **fully verified outer layers** and isolates the missing mathematics into
+a single explicit hypothesis.
+
+`proofs/Proofs/BurnsidePaQbSolvable.lean` (status: **verified**, 0 sorry, 0 axiom):
+
+- `isSolvable_of_isPGroup`, `isSolvable_of_card_prime_pow` — the **base case**
+  (`a=0` or `b=0` edge; leaves of the induction). Fully verified via Mathlib's
+  nilpotency of p-groups.
+- `solvable_of_normal_extension` — the **inductive engine**: `N ⊴ G` with `N` and
+  `G ⧸ N` solvable ⟹ `G` solvable. Derived from `solvable_of_ker_le_range` with the
+  subgroup inclusion and quotient projection (`ker_mk' = N`, `range_subtype = N`).
+- `OrderTwoPrimes p q G` — predicate "every prime divisor of `|G|` is `p` or `q`",
+  closed under subgroups/quotients (their orders divide `|G|`).
+- `burnside_reduces_to_nonsimplicity` — **the reduction theorem, fully verified**:
+  *given* that every finite nonabelian group with `OrderTwoPrimes p q` is not simple,
+  every finite group of order `pᵃqᵇ` is solvable. Performs the strong induction on
+  `|G|` and the extension assembly; the only unproved input is the non-simplicity
+  hypothesis (= the character-theory core above).
+
+Net effect: Burnside's theorem is reduced, with everything machine-checked, to the
+single clean group-theoretic statement "*order `pᵃqᵇ` nonabelian ⟹ not simple*".
+
+### Lean engineering notes
+- Stated over `H : Type` (universe 0, not `Type*`) deliberately, so the induction
+  hypothesis — quantified over all such `H` — applies to the subgroup `↥N` and the
+  quotient `H ⧸ N`, which are again `Type`s.
+- Strong induction done via `Nat.strong_induction_on` on `n = Nat.card H` with the
+  statement reformulated as `∀ n, ∀ H, Nat.card H = n → …`; this avoids the
+  ill-formed `induction (Nat.card H) generalizing H` (H occurs in the measure).
+- Strict order drops `|N| < |H|` and `|H ⧸ N| < |H|` come from
+  `Nat.lt_mul_iff_one_lt_right` plus `card_mul_index` / `index_mul_card`, using
+  `one_lt_index_of_ne_top` (for `N ≠ ⊤`) and `one_lt_card_iff_ne_bot` (for `N ≠ ⊥`).
+
+## Session 2026-06-26 (Session 1)
+
+**Mode:** FRESH (EMPTY tier, genuinely fresh — verified no prior knowledge.md/meta.json).
+**Outcome:** progress — verified scaffolding + reduction; character-theory core BLOCKED.
+
+### Status classification
+SURVEY / partially BLOCKED. The full theorem is not claimed. The verified deliverable
+is real (prime-power solvability + extension principle + the non-simplicity reduction),
+all `sorry`/`axiom`-free.
+
+### Next Steps
+1. Build the missing representation theory in Mathlib or a local file:
+   class functions inner product → central characters → integrality of class sums →
+   Burnside's vanishing lemma → non-simplicity of `pᵃqᵇ` groups.
+2. Once `burnside_not_simple` is available, discharge the hypothesis of
+   `burnside_reduces_to_nonsimplicity` to obtain the unconditional theorem.
+3. Possible intermediate target submittable to Aristotle: the **algebraic-integer
+   averaging lemma** ("an algebraic integer that is an average of `n` roots of unity
+   and has all conjugates of absolute value `≤ 1` is `0` or a root of unity").

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/meta.json
@@ -1,0 +1,127 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+  "title": "Toward Burnside's pᵃqᵇ theorem: verified reduction to non-simplicity",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+  "description": "Burnside's pᵃqᵇ theorem (1904) — every finite group of order pᵃqᵇ is solvable — is a classical result whose only known proofs go through the character theory of finite groups, and it is not yet in Mathlib. This entry contributes the fully verified (0 sorries, 0 axioms) outer layers of the standard proof and isolates the one missing ingredient. It proves the base case (groups of prime-power order are solvable, via Mathlib's nilpotency of p-groups), the inductive engine (an extension of a solvable group by a solvable group is solvable), and — the centerpiece — burnside_reduces_to_nonsimplicity: a machine-checked strong induction showing that IF every finite nonabelian group whose order involves only the primes p, q has a proper nontrivial normal subgroup (the character-theoretic core still missing from Mathlib), THEN every finite group of order pᵃqᵇ is solvable. Burnside's theorem is thereby reduced, with everything else verified, to a single clean group-theoretic statement.",
+  "meta": {
+    "author": "William Burnside (1904); Lean formalization original (researcher-6)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsidePaQbSolvable.lean",
+    "tags": [
+      "group-theory",
+      "representation-theory",
+      "solvable-group",
+      "burnside-theorem",
+      "p-group",
+      "nilpotent-group",
+      "character-theory",
+      "reduction",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None — every declaration is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). IMPORTANT SCOPE: this entry does NOT prove Burnside's pᵃqᵇ theorem itself. The unconditional theorem is reduced to, but not derived from Mathlib, because the character-theoretic core (irreducible character degrees divide |G|; Burnside's vanishing lemma; non-simplicity of pᵃqᵇ groups) is not present in Mathlib v4.26.0. That core is taken as an explicit hypothesis of burnside_reduces_to_nonsimplicity, which is itself fully verified. See research/problems/abel-ruffini-oq-04-oq-02-oq-03-oq-01/knowledge.md for the full Mathlib gap analysis and roadmap.",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsPGroup.isNilpotent",
+        "description": "A finite p-group is nilpotent",
+        "module": "Mathlib.GroupTheory.Nilpotent"
+      },
+      {
+        "theorem": "IsNilpotent.to_isSolvable",
+        "description": "Nilpotent groups are solvable (instance)",
+        "module": "Mathlib.GroupTheory.Nilpotent"
+      },
+      {
+        "theorem": "IsPGroup.of_card",
+        "description": "A group of prime-power order is a p-group",
+        "module": "Mathlib.GroupTheory.PGroup"
+      },
+      {
+        "theorem": "solvable_of_ker_le_range",
+        "description": "Homological extension principle: ker g ≤ range f with G', G'' solvable ⟹ G solvable",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "Subgroup.card_mul_index / index_mul_card / one_lt_index_of_ne_top",
+        "description": "Lagrange/index arithmetic used to bound |N| and |G ⧸ N| below |G|",
+        "module": "Mathlib.GroupTheory.Index"
+      }
+    ],
+    "originalContributions": [
+      "isSolvable_of_isPGroup / isSolvable_of_card_prime_pow: the base case — prime-power order ⟹ solvable (the a=0/b=0 edge and the leaves of the induction)",
+      "solvable_of_normal_extension: the inductive engine — N ⊴ G with N and G ⧸ N solvable ⟹ G solvable, via the subgroup inclusion and quotient projection",
+      "OrderTwoPrimes p q G: predicate 'every prime divisor of |G| is p or q', closed under subgroups and quotients",
+      "burnside_reduces_to_nonsimplicity: the verified reduction — non-simplicity of all pᵃqᵇ nonabelian groups ⟹ solvability of all pᵃqᵇ groups, by strong induction on |G| over the universe-0 class of such groups"
+    ],
+    "lineCount": 166,
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "path": "Proofs/BurnsidePaQbSolvable.lean",
+    "lineCount": 166,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4
+  },
+  "overview": {
+    "historicalContext": "William Burnside proved in 1904 that every finite group whose order has the form pᵃqᵇ, for primes p and q, is solvable — equivalently, that a finite simple group with at most two distinct prime divisors is cyclic of prime order. The result was a triumph of the then-young character theory of finite groups: Burnside's proof uses the fact that the degrees of the irreducible complex representations divide the group order, together with an algebraic-integer argument (now called Burnside's vanishing lemma) to produce, in any nonabelian such group, a proper nontrivial normal subgroup. Purely group-theoretic ('representation-free') proofs were found only in the 1970s–1980s by Goldschmidt, Matsuyama, and Bender, and remain substantial. Burnside's theorem is a stepping stone toward the Feit–Thompson odd-order theorem and is frequently listed among the classical results still missing from Mathlib.",
+    "problemStatement": "Formalize Burnside's pᵃqᵇ theorem in Lean 4 on top of Mathlib's group and character theory: for a finite group G with Nat.card G = p^a * q^b (p, q prime), prove IsSolvable G.",
+    "proofStrategy": "The standard proof is an induction on |G|: if G is abelian it is solvable; otherwise the character theory produces a proper nontrivial normal subgroup N, and solvability of N and G ⧸ N (both of order again pᵃqᵇ, strictly smaller) lifts to G. This file formalizes everything in that induction except the character-theoretic production of N, which is not yet available in Mathlib. The base case (prime-power order ⟹ nilpotent ⟹ solvable) and the extension step are proved outright; the induction and reassembly are packaged in burnside_reduces_to_nonsimplicity, which takes the non-simplicity fact as an explicit hypothesis and is fully verified. The whole theorem is thus reduced — with no sorries or axioms — to the single statement 'a finite nonabelian pᵃqᵇ-group is not simple'.",
+    "keyInsights": [
+      "Phrasing the inductive statement over H : Type (universe 0) lets the induction hypothesis apply to the subgroup ↥N and the quotient H ⧸ N, which are again Types of strictly smaller order.",
+      "The measure |H| occurs inside the type, so 'induction (Nat.card H) generalizing H' is ill-formed; reformulating as ∀ n, ∀ H, Nat.card H = n → … and inducting on n with Nat.strong_induction_on is the clean fix.",
+      "The strict drops |N| < |H| and |H ⧸ N| < |H| follow uniformly from card_mul_index / index_mul_card with one_lt_index_of_ne_top (N ≠ ⊤) and one_lt_card_iff_ne_bot (N ≠ ⊥).",
+      "Isolating the one missing input as an explicit hypothesis (rather than an axiom) keeps the contribution honest and machine-checked, and pinpoints exactly what Mathlib still needs."
+    ],
+    "prerequisites": [
+      "Solvable and nilpotent groups (derived series)",
+      "p-groups and Sylow theory (for nilpotency of prime-power groups)",
+      "Lagrange's theorem and subgroup index arithmetic",
+      "Quotient groups and the correspondence between normal subgroups and quotients"
+    ]
+  },
+  "sections": [
+    {
+      "id": "base-case",
+      "title": "Base case: prime-power order ⟹ solvable",
+      "startLine": 70,
+      "endLine": 82,
+      "summary": "isSolvable_of_isPGroup and isSolvable_of_card_prime_pow: a finite group of prime-power order is a p-group (IsPGroup.of_card), hence nilpotent (IsPGroup.isNilpotent), hence solvable. These are the a=0/b=0 edges of the pᵃqᵇ grid and the leaves of the induction."
+    },
+    {
+      "id": "extension-engine",
+      "title": "Inductive engine: extensions of solvable groups",
+      "startLine": 84,
+      "endLine": 95,
+      "summary": "solvable_of_normal_extension: for N ⊴ G, solvability of N and of G ⧸ N yields solvability of G. Built from Mathlib's solvable_of_ker_le_range applied to the inclusion N ↪ G and the projection G ↠ G ⧸ N, using ker_mk' = N and range_subtype = N."
+    },
+    {
+      "id": "reduction",
+      "title": "Reduction of Burnside's theorem to non-simplicity",
+      "startLine": 97,
+      "endLine": 166,
+      "summary": "OrderTwoPrimes p q G captures the pᵃqᵇ hypothesis and is inherited by subgroups and quotients. burnside_reduces_to_nonsimplicity then performs strong induction on |G|: abelian groups are solvable; otherwise the supplied non-simplicity hypothesis yields a proper nontrivial normal N, the induction hypothesis applies to the strictly smaller N and G ⧸ N, and solvable_of_normal_extension reassembles G. Fully verified modulo the explicit non-simplicity hypothesis."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes, with zero sorries and zero axioms, the complete outer structure of the classical proof of Burnside's pᵃqᵇ theorem: the prime-power base case, the solvable-extension inductive engine, and a verified strong induction that reduces the full theorem to the single group-theoretic statement that a finite nonabelian group of order pᵃqᵇ is not simple. It does not claim the unconditional theorem.",
+    "implications": "The reduction pinpoints precisely the representation theory Mathlib still needs to close the gap — irreducible character degrees dividing |G|, Burnside's vanishing lemma, and the count of irreducibles by conjugacy classes — and provides the verified scaffolding into which a future formalization of that character theory can be plugged to obtain Burnside's theorem unconditionally.",
+    "openQuestions": [
+      "Formalize in Mathlib that the degree of an irreducible complex representation divides the group order (the central-character / algebraic-integer argument).",
+      "Formalize Burnside's vanishing lemma: gcd(|class of g|, χ(1)) = 1 ⟹ χ(g) = 0 or ρ(g) scalar, via the averaged-root-of-unity bound.",
+      "Discharge the non-simplicity hypothesis of burnside_reduces_to_nonsimplicity to obtain the unconditional pᵃqᵇ theorem."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "depends-on",
+      "description": "Reuses Mathlib's nilpotency-of-p-groups and solvability infrastructure that also underpins the Abel–Ruffini solvability chain",
+      "targetId": "abel-ruffini"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Problem **abel-ruffini-oq-04-oq-02-oq-03-oq-01** — *"Formalize Burnside pᵃqᵇ theorem via Mathlib character theory"* (fresh / EMPTY tier).

Burnside's theorem (1904) — every finite group of order `pᵃ·qᵇ` is solvable — is a classical result that is **not yet in Mathlib**; its only known proofs go through finite-group character theory. This PR contributes the **fully verified outer layers** of the standard proof (0 sorries, 0 axioms) and isolates the single missing ingredient as an explicit hypothesis.

## What's verified (`proofs/Proofs/BurnsidePaQbSolvable.lean`, builds against Mathlib v4.26.0)

| Result | Role |
|---|---|
| `isSolvable_of_isPGroup`, `isSolvable_of_card_prime_pow` | **base case** — prime-power order ⟹ nilpotent ⟹ solvable (`IsPGroup.isNilpotent`) |
| `solvable_of_normal_extension` | **inductive engine** — `N ⊴ G` with `N`, `G ⧸ N` solvable ⟹ `G` solvable (`solvable_of_ker_le_range`) |
| `OrderTwoPrimes p q G` | the `pᵃqᵇ` hypothesis, closed under subgroups/quotients |
| `burnside_reduces_to_nonsimplicity` | **verified strong induction on `|G|`** reducing the full theorem to "*a finite nonabelian `pᵃqᵇ`-group is not simple*" |

Net effect: Burnside's theorem is reduced — with everything machine-checked — to a single clean group-theoretic statement. The character-theoretic core (character degrees divide `|G|`; Burnside's vanishing lemma; non-simplicity) is taken as an **explicit hypothesis, not an axiom**.

## Honest scope

This PR does **not** claim the unconditional theorem. The gallery entry is marked `status: verified` / `badge: original` with `assumptions` spelling out that the unconditional `pᵃqᵇ` theorem is *reduced to, not derived from* Mathlib. `knowledge.md` contains the full Mathlib gap analysis and roadmap.

## Verification

`./proofs/scripts/docker-build.sh Proofs.BurnsidePaQbSolvable` → **Build succeeded** (1344 jobs); 4 theorems, 1 def, 0 axioms, 0 sorries. Gallery size check passes (10.4 KB ≤ 60 KB cap).

## Files
- `proofs/Proofs/BurnsidePaQbSolvable.lean` (new, 166 lines)
- `src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/meta.json` (new gallery entry)
- `research/problems/abel-ruffini-oq-04-oq-02-oq-03-oq-01/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)