### PR TITLE
Enrich (In)dependence of Gödel's Five Axioms (godel-first-incompleteness-oq01-oq-03): annotation depth

### DIFF
--- a/src/data/proofs/godel-first-incompleteness-oq01-oq-03/annotations.json
+++ b/src/data/proofs/godel-first-incompleteness-oq01-oq-03/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "The Axioms Are Constraints on Two Atoms",
-    "content": "The parent's axioms only ever mention three sentences: G, Prov(⌜G⌝), and ¬G (codes 42, 84, 43). Abstracting the provability predicate to P : ℕ → Prop and reading off these codes, the four substantive axioms become purely propositional constraints on the two atoms p = P(G) and q = P(Prov⌜G⌝): D1G is p → q, SelfRef is p ↔ ¬q, OmegaCons is ¬p → ¬q, NegGProv is P(¬G) → q. Working abstractly keeps this file from importing — and being poisoned by — the parent's (inconsistent) global axioms."
+    "content": "The parent's axioms only ever mention three sentences: G, Prov(⌜G⌝), and ¬G (codes 42, 84, 43). Abstracting the provability predicate to P : ℕ → Prop and reading off these codes, the four substantive axioms become purely propositional constraints on the two atoms p = P(G) and q = P(Prov⌜G⌝): D1G is p → q, SelfRef is p ↔ ¬q, OmegaCons is ¬p → ¬q, NegGProv is P(¬G) → q. Working abstractly keeps this file from importing — and being poisoned by — the parent's (inconsistent) global axioms.",
+    "mathContext": "With $p = P(G)$, $q = P(\\mathrm{Prov}\\ulcorner G\\urcorner)$: $\\mathrm{D1G} \\equiv (p \\to q)$, $\\mathrm{SelfRef} \\equiv (p \\leftrightarrow \\neg q)$, $\\mathrm{OmegaCons} \\equiv (\\neg p \\to \\neg q)$, $\\mathrm{NegGProv} \\equiv (P(\\neg G) \\to q)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gödel numbering", "provability predicate", "propositional abstraction", "self-reference", "diagonal lemma"],
+    "prerequisites": ["mathematical logic", "propositional logic"]
   },
   {
     "id": "ann-inconsistency",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "Three Axioms Contradict",
-    "content": "`core_inconsistency` derives False from D1G ∧ SelfRef ∧ OmegaCons. The argument: D1G (p→q) and SelfRef (p↔¬q) together give p→(q∧¬q), so ¬p; then SelfRef turns ¬p into q, while OmegaCons turns ¬p into ¬q — contradiction. So `no_model_of_all_axioms`: no provability predicate satisfies the parent's axioms. Its First Incompleteness theorem is therefore vacuously true (it follows from contradictory hypotheses) — the same vacuity failure as Provable := fun _ => False, just hidden behind the meta-level self-reference axiom."
+    "content": "`core_inconsistency` derives False from D1G ∧ SelfRef ∧ OmegaCons. The argument: D1G (p→q) and SelfRef (p↔¬q) together give p→(q∧¬q), so ¬p; then SelfRef turns ¬p into q, while OmegaCons turns ¬p into ¬q — contradiction. So `no_model_of_all_axioms`: no provability predicate satisfies the parent's axioms. Its First Incompleteness theorem is therefore vacuously true (it follows from contradictory hypotheses) — the same vacuity failure as Provable := fun _ => False, just hidden behind the meta-level self-reference axiom.",
+    "mathContext": "$p \\to q$ and $p \\leftrightarrow \\neg q$ give $p \\to (q \\wedge \\neg q)$, so $\\neg p$; then $p \\leftrightarrow \\neg q$ gives $q$ while $\\neg p \\to \\neg q$ gives $\\neg q$ — contradiction. No $P$ models all three.",
+    "significance": "critical",
+    "relatedConcepts": ["inconsistency", "vacuous truth", "ω-consistency", "no model", "soundness of axiomatization"],
+    "prerequisites": ["mathematical logic", "proof by contradiction"]
   },
   {
     "id": "ann-derivable",
@@ -30,7 +38,11 @@
     },
     "type": "insight",
     "title": "The Fourth Axiom Is Redundant",
-    "content": "`negGProv_derivable` shows the object-level diagonal axiom NegGProv (P(¬G) → q) follows from D1G ∧ SelfRef: those two already force q = P(Prov⌜G⌝) to be true (¬p ⟹ q via self-reference, and ¬p holds), so an implication into q is automatic. Hence NegGProv is not independent — a direct answer to the OQ's 'could any be derived from the others?'."
+    "content": "`negGProv_derivable` shows the object-level diagonal axiom NegGProv (P(¬G) → q) follows from D1G ∧ SelfRef: those two already force q = P(Prov⌜G⌝) to be true (¬p ⟹ q via self-reference, and ¬p holds), so an implication into q is automatic. Hence NegGProv is not independent — a direct answer to the OQ's 'could any be derived from the others?'.",
+    "mathContext": "From $\\mathrm{D1G} \\wedge \\mathrm{SelfRef}$: $\\neg p$ holds and $\\neg p \\to q$, so $q$ is true; hence any implication $(\\cdot \\to q)$ — in particular $\\mathrm{NegGProv}$ — holds automatically. So $\\mathrm{NegGProv}$ is not independent.",
+    "significance": "key",
+    "relatedConcepts": ["logical independence", "derivable axiom", "redundancy", "diagonal axiom"],
+    "prerequisites": ["mathematical logic", "propositional logic"]
   },
   {
     "id": "ann-minimal",
@@ -41,6 +53,10 @@
     },
     "type": "concept",
     "title": "A Minimal Inconsistent Set",
-    "content": "The three contradictory axioms are each independent of the other two, witnessed by explicit provability predicates: P = (· = G) satisfies SelfRef and OmegaCons but not D1G; P = (fun _ => False) satisfies D1G and OmegaCons but not SelfRef; P = (· = Prov⌜G⌝) satisfies D1G and SelfRef but not OmegaCons. So no two of them imply the third — the inconsistency genuinely needs all three, and the fix must change one of them (the meta self-reference) rather than simply drop a redundant axiom."
+    "content": "The three contradictory axioms are each independent of the other two, witnessed by explicit provability predicates: P = (· = G) satisfies SelfRef and OmegaCons but not D1G; P = (fun _ => False) satisfies D1G and OmegaCons but not SelfRef; P = (· = Prov⌜G⌝) satisfies D1G and SelfRef but not OmegaCons. So no two of them imply the third — the inconsistency genuinely needs all three, and the fix must change one of them (the meta self-reference) rather than simply drop a redundant axiom.",
+    "mathContext": "Each axiom has a model of the other two: $P = (\\cdot = G)$ ⊨ SelfRef, OmegaCons, ⊭ D1G; $P = \\lambda\\_.\\bot$ ⊨ D1G, OmegaCons, ⊭ SelfRef; $P = (\\cdot = \\mathrm{Prov}\\ulcorner G\\urcorner)$ ⊨ D1G, SelfRef, ⊭ OmegaCons. So the inconsistent triple is minimal.",
+    "significance": "key",
+    "relatedConcepts": ["minimal inconsistent set", "independence model", "countermodel", "axiom independence"],
+    "prerequisites": ["mathematical logic", "model theory"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `godel-first-incompleteness-oq01-oq-03`

Quality 63, passes 0. Complete `overview`/`conclusion`/`sections` and correctly-schema'd cross-references; the gap was 4 annotations with only `title` + `content`.

### Added (annotation depth — role's #1 mission)
- **`mathContext`** (LaTeX of the propositional reduction p→q, p↔¬q, ¬p→¬q and the inconsistency derivation), **`significance`** (`critical` for the joint-inconsistency of D1G∧SelfRef∧OmegaCons; `key` for the redundancy of NegGProv and the minimal-inconsistent-set result; `supporting` for the two-atom encoding), **`relatedConcepts`**, **`prerequisites`** on all 4 annotations.
- `content`/`range`/`type` preserved verbatim. Resolver: **4 valid / 0 misaligned**.

### Verification
- JSON valid; annotation alignment 4/4. No meta.json change; `status`/`badge`/`axiomCount` untouched (0-axiom abstract analysis; the finding is that the parent's five-axiom set has no model, so its incompleteness theorem holds only vacuously).

🤖 Generated with [Claude Code](https://claude.com/claude-code)