### PR TITLE
research(erdos-10-wip-01-oq-01): smallest ODD witness 905 [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos10WIP01OQ01.lean
+++ b/proofs/Proofs/Erdos10WIP01OQ01.lean
@@ -41,6 +41,14 @@ for which `not_prime_of_proper_divisor` below is the kernel-fast tool.
   (`16` is not a prime plus `≤ 1` power of two), certified by kernel `decide`
   through the offset criterion. This is the first *axiom-free* (no `native_decide`)
   member of the Erdős #10 witness family.
+* `not_isPrimePlusKPowers_one_905` — the smallest *odd* witness `905 = 5·181`,
+  also axiom-free. The de Polignac numbers below it are all prime (hence
+  representable with zero powers), so `905` is the first odd integer genuinely
+  neither prime nor prime-plus-a-power-of-two. Its `~900`-sized complements
+  overflow the kernel's default primality `decide`, so compositeness is supplied
+  by `norm_num`'s factor-exhibiting extension — a stepping stone between the tiny
+  `decide`-closed `16` and the small-divisor certificate path the `~10⁹` witnesses
+  need.
 
 The full `1117175146` witness needs its covering-congruence factor table as input data
 (≈ 5000 `(offset, small prime divisor)` pairs); assembling that table is left as data
@@ -181,6 +189,36 @@ theorem not_isPrimePlusKPowers_one_sixteen : ¬ IsPrimePlusKPowers 1 16 := by
       omega
     interval_cases a <;> decide              -- 16 − 2^a ∈ {15,14,12,8,0}, none prime
 
+/-- **Smallest *odd* witness, axiom-free.** `905 = 5·181` is not a prime plus at most one
+power of two. Where `16` is the smallest witness overall (and even), `905` is the smallest
+*odd* one: the de Polignac numbers below it — odd integers not of the form `prime + 2^a` —
+namely `127, 149, 251, 331, 337, 373, 509, 599, 701, 757, 809, 877`, are *all themselves
+prime*, hence representable here with zero powers (`m = 0`). `905 = 5·181` is the first that
+is genuinely neither prime nor prime-plus-a-power-of-two, so it is the smallest odd member of
+the Erdős #10 witness family. Proved through the same offset criterion with no `native_decide`
+(so no `Lean.ofReduceBool`): the popcount-`≤ 1` offsets are `0` and the powers `2^a ≤ 905`
+(so `a ≤ 9`), and each complement
+`905 − m ∈ {905, 904, 903, 901, 897, 889, 873, 841, 777, 649, 393}` is composite — `norm_num`
+exhibits a factor (`5, 2, 3, 17, 3, 7, 3, 29, 3, 11, 3` respectively). Unlike the tiny `16`
+case (numbers `< 16`, closed by kernel `decide`), the `~900`-sized complements overflow the
+kernel's default primality `decide`, so compositeness here is discharged by `norm_num`'s
+factor-exhibiting primality extension — the lightweight analogue of the small-divisor
+certificate `not_prime_of_proper_divisor` that the genuine `~10⁹` witnesses require. -/
+theorem not_isPrimePlusKPowers_one_905 : ¬ IsPrimePlusKPowers 1 905 := by
+  rw [not_isPrimePlusKPowers_iff]
+  intro m hm hpc
+  rw [popcount_le_one_iff] at hpc
+  obtain rfl | ⟨a, rfl⟩ := hpc
+  · norm_num                                  -- m = 0:  905 = 5·181, not prime
+  · -- m = 2^a with 2^a ≤ 905, hence a ≤ 9
+    have ha : a ≤ 9 := by
+      by_contra h
+      have h1024 : (1024 : ℕ) ≤ 2 ^ a := by
+        calc (1024 : ℕ) = 2 ^ 10 := by norm_num
+          _ ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) (by omega)
+      omega
+    interval_cases a <;> norm_num             -- each 905 − 2^a is composite
+
 /-- Sanity check that the offset criterion is the *right* equivalence: `15` *is* a prime
 plus one power of two (`15 = 13 + 2`), witnessed by the offset `m = 2`. -/
 theorem isPrimePlusKPowers_one_fifteen : IsPrimePlusKPowers 1 15 := by
@@ -192,5 +230,6 @@ theorem isPrimePlusKPowers_one_fifteen : IsPrimePlusKPowers 1 15 := by
 #check @not_prime_of_proper_divisor
 #check @popcount_le_one_iff
 #check @not_isPrimePlusKPowers_one_sixteen
+#check @not_isPrimePlusKPowers_one_905
 
 end Erdos10WIP01

--- a/src/data/proofs/erdos-10-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/annotations.json
@@ -2,73 +2,163 @@
   {
     "id": "ann-offset-reformulation",
     "proofId": "erdos-10-wip-01-oq-01",
-    "range": { "startLine": 71, "endLine": 83 },
+    "range": {
+      "startLine": 79,
+      "endLine": 91
+    },
     "type": "insight",
     "title": "Offset reformulation: search m = n − p, not p",
     "content": "Re-indexes the prime-plus-popcount characterization by the offset m = n − p. The parent file's `isPrimePlusKPowers_iff_popcount` quantifies over primes p ≤ n; here the proof substitutes m = n − p and uses that p ↦ n − p is its own inverse on {· ≤ n}. The forward direction sends a witnessing prime p to the offset n − p (with `Nat.sub_sub_self hpn` rewriting n − (n − p) back to p); the reverse sends an offset m to the prime n − m. The payoff is the search space: the offsets that can possibly work are exactly those with popcount ≤ k, of which there are only Θ((log n)^k), versus Θ(n) primes below n.",
     "mathContext": "$\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\exists\\,m \\le n,\\ \\operatorname{popcount} m \\le k \\ \\wedge\\ (n-m)\\ \\text{prime}$, via the involution $n-(n-x)=x$.",
     "significance": "key",
-    "relatedConcepts": ["change of index variable", "involution / self-inverse map", "binary popcount", "Nat.sub_sub_self"],
-    "prerequisites": ["natural-number subtraction in Lean", "the prime-plus-popcount characterization (parent file)"]
+    "relatedConcepts": [
+      "change of index variable",
+      "involution / self-inverse map",
+      "binary popcount",
+      "Nat.sub_sub_self"
+    ],
+    "prerequisites": [
+      "natural-number subtraction in Lean",
+      "the prime-plus-popcount characterization (parent file)"
+    ]
   },
   {
     "id": "ann-refutation-criterion",
     "proofId": "erdos-10-wip-01-oq-01",
-    "range": { "startLine": 85, "endLine": 93 },
+    "range": {
+      "startLine": 93,
+      "endLine": 101
+    },
     "type": "technique",
     "title": "Finite, kernel-decidable refutation criterion",
     "content": "Negates the offset reformulation with `push_neg` to obtain a bounded universal: n is NOT a prime plus ≤ k powers of two iff every offset m ≤ n with popcount ≤ k has composite complement n − m. Crucially the right-hand side is a `∀ m ≤ n` with a decidable body, so the kernel `decide` can check it directly — no `native_decide`, hence no `Lean.ofReduceBool` axiom. This is the architectural fix the parent WIP file left open: it converts certifying a witness from a Θ(n) prime search (which forced `native_decide`) into a finite, auditable verification.",
     "mathContext": "$\\neg\\,\\mathrm{IsPrimePlusKPowers}\\,k\\,n \\iff \\forall\\,m \\le n,\\ \\operatorname{popcount} m \\le k \\Rightarrow \\neg\\,(n-m)\\ \\text{prime}$.",
     "significance": "key",
-    "relatedConcepts": ["contrapositive", "bounded quantifier", "Decidable instances", "kernel decide vs native_decide", "Lean.ofReduceBool"],
-    "prerequisites": ["push_neg tactic", "decidability of bounded ∀ over ℕ"]
+    "relatedConcepts": [
+      "contrapositive",
+      "bounded quantifier",
+      "Decidable instances",
+      "kernel decide vs native_decide",
+      "Lean.ofReduceBool"
+    ],
+    "prerequisites": [
+      "push_neg tactic",
+      "decidability of bounded ∀ over ℕ"
+    ]
   },
   {
     "id": "ann-compositeness-certificate",
     "proofId": "erdos-10-wip-01-oq-01",
-    "range": { "startLine": 106, "endLine": 112 },
+    "range": {
+      "startLine": 114,
+      "endLine": 120
+    },
     "type": "technique",
     "title": "Compositeness from a single proper divisor",
     "content": "A one-line lemma that certifies ¬ q.Prime by exhibiting a single proper divisor 1 < d < q. The proof assumes q is prime, invokes `Nat.Prime.eq_one_or_self_of_dvd` to force d ∈ {1, q}, and `omega` closes both cases against the strict bounds. For the genuine ~10⁹ witnesses each obligation ¬ (n − m).Prime is discharged this way — by naming the small prime from the relevant covering congruence — rather than by trial division, which is infeasible in the kernel. It is the kernel-fast tool that makes the refutation criterion scale.",
     "mathContext": "If $1 < d < q$ and $d \\mid q$ then $q$ is composite: a prime's only divisors are $1$ and $q$.",
     "significance": "supporting",
-    "relatedConcepts": ["primality vs compositeness", "covering congruences", "divisibility certificate", "Nat.Prime.eq_one_or_self_of_dvd"],
-    "prerequisites": ["definition of prime in Mathlib", "omega tactic"]
+    "relatedConcepts": [
+      "primality vs compositeness",
+      "covering congruences",
+      "divisibility certificate",
+      "Nat.Prime.eq_one_or_self_of_dvd"
+    ],
+    "prerequisites": [
+      "definition of prime in Mathlib",
+      "omega tactic"
+    ]
   },
   {
     "id": "ann-popcount-le-one",
     "proofId": "erdos-10-wip-01-oq-01",
-    "range": { "startLine": 127, "endLine": 149 },
+    "range": {
+      "startLine": 135,
+      "endLine": 157
+    },
     "type": "concept",
     "title": "Popcount ≤ 1 structure lemma (avoids kernel-stuck bitIndices)",
     "content": "Characterizes the offsets with popcount ≤ 1 as exactly {0} ∪ {2^a}. This is the load-bearing kernel-friendliness move: `popcount = (Nat.bitIndices ·).length` does not reduce under kernel `decide` (only the compiler evaluates it), so the witness cannot simply compute popcount. Instead the proof case-splits on the bit-index list — empty list forces m = 0, a singleton [a] forces m = 2^a — reading m back off its bits via `Nat.twoPowSum_bitIndices`. `List.length_eq_zero_iff` collapses the tail to []. This replaces computation with a reusable structure theorem.",
     "mathContext": "$\\operatorname{popcount} m \\le 1 \\iff m = 0 \\ \\vee\\ \\exists a,\\ m = 2^{a}$, proved from $\\sum_{i \\in \\mathrm{bitIndices}(m)} 2^{i} = m$.",
     "significance": "key",
-    "relatedConcepts": ["binary representation", "Hamming weight / popcount", "Nat.bitIndices", "Nat.twoPowSum_bitIndices", "kernel reduction limits"],
-    "prerequisites": ["binary expansion of natural numbers", "List case analysis in Lean"]
+    "relatedConcepts": [
+      "binary representation",
+      "Hamming weight / popcount",
+      "Nat.bitIndices",
+      "Nat.twoPowSum_bitIndices",
+      "kernel reduction limits"
+    ],
+    "prerequisites": [
+      "binary expansion of natural numbers",
+      "List case analysis in Lean"
+    ]
   },
   {
     "id": "ann-smallest-witness",
     "proofId": "erdos-10-wip-01-oq-01",
-    "range": { "startLine": 164, "endLine": 182 },
+    "range": {
+      "startLine": 172,
+      "endLine": 190
+    },
     "type": "insight",
     "title": "Smallest witness 16, certified with no native_decide",
     "content": "Assembles the pieces to prove 16 is not a prime plus ≤ 1 power of two — the smallest such integer and the first Erdős #10 witness certified axiom-free. The refutation criterion reduces the goal to checking the popcount-≤1 offsets m ≤ 16; the structure lemma turns those into m = 0 and m = 2^a. The exponent is bounded a ≤ 4 (since 2^5 = 32 > 16, proved by a `calc`/`omega` argument), and `interval_cases a <;> decide` discharges the five compositeness checks on complements {16, 15, 14, 12, 8, 0}, none prime. Every `decide` runs on numbers below 16, so the kernel checks it without `native_decide` — `#print axioms` shows only propext / Classical.choice / Quot.sound.",
     "mathContext": "$\\neg\\,\\mathrm{IsPrimePlusKPowers}\\,1\\,16$: offsets $\\{0,1,2,4,8,16\\}$ give complements $\\{16,15,14,12,8,0\\}$, none prime.",
     "significance": "key",
-    "relatedConcepts": ["interval_cases", "decide on small numerals", "axiom-free verification", "smallest counterexample"],
-    "prerequisites": ["powers of two", "the refutation criterion and popcount structure lemma above"]
+    "relatedConcepts": [
+      "interval_cases",
+      "decide on small numerals",
+      "axiom-free verification",
+      "smallest counterexample"
+    ],
+    "prerequisites": [
+      "powers of two",
+      "the refutation criterion and popcount structure lemma above"
+    ]
+  },
+  {
+    "id": "ann-smallest-odd-witness",
+    "proofId": "erdos-10-wip-01-oq-01",
+    "range": {
+      "startLine": 192,
+      "endLine": 220
+    },
+    "type": "insight",
+    "title": "Smallest odd witness 905 = 5·181, still no native_decide",
+    "content": "Pushes the axiom-free witness family past the tiny even case 16 to a genuine odd de Polignac number. 905 is the smallest odd integer that is neither prime nor prime-plus-a-power-of-two: the odd numbers below it that are not of the form prime + 2^a — 127, 149, 251, 331, 337, 373, 509, 599, 701, 757, 809, 877 — are every one of them prime, hence representable here with zero powers (the m = 0 case), so 905 = 5·181 is the first that genuinely fails. The proof reuses the popcount-≤1 structure lemma verbatim: offsets are 0 and 2^a ≤ 905 (a ≤ 9 by a 2^10 = 1024 bound), giving complements {905,904,903,901,897,889,873,841,777,649,393}. The methodological point is the contrast with 16: those complements are ~900-sized and overflow the kernel default primality decide (max recursion), so compositeness is supplied by norm_num's factor-exhibiting extension — the lightweight stand-in for the explicit small-divisor certificate not_prime_of_proper_divisor that the ~10⁹ witnesses will need. #print axioms still shows only propext / Classical.choice / Quot.sound.",
+    "mathContext": "$\\neg\\,\\mathrm{IsPrimePlusKPowers}\\,1\\,905$: offsets $\\{0,1,2,4,8,16,32,64,128,256,512\\}$ give complements $\\{905,904,903,901,897,889,873,841,777,649,393\\}$, each composite (factors $5,2,3,17,3,7,3,29,3,11,3$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "de Polignac numbers",
+      "smallest odd counterexample",
+      "norm_num primality extension",
+      "kernel decide recursion limits",
+      "axiom-free verification"
+    ],
+    "prerequisites": [
+      "the refutation criterion and popcount structure lemma above",
+      "the even witness 16 directly above"
+    ]
   },
   {
     "id": "ann-positive-sanity-check",
     "proofId": "erdos-10-wip-01-oq-01",
-    "range": { "startLine": 184, "endLine": 188 },
+    "range": {
+      "startLine": 222,
+      "endLine": 226
+    },
     "type": "context",
     "title": "Positive sanity check: 15 = 13 + 2",
     "content": "Confirms the offset criterion is the correct equivalence and not vacuously satisfied: 15 IS a prime plus one power of two, witnessed by the offset m = 2 (so n − m = 13 is prime and popcount 2 = 1). Exhibiting a genuine positive instance guards against an equivalence that accidentally always refutes, complementing the negative witness 16 directly above.",
     "mathContext": "$\\mathrm{IsPrimePlusKPowers}\\,1\\,15$ via offset $m = 2$: $15 - 2 = 13$ prime, $\\operatorname{popcount} 2 = 1$.",
     "significance": "context",
-    "relatedConcepts": ["worked positive instance", "test of an equivalence", "powers of two"],
-    "prerequisites": ["the offset reformulation above"]
+    "relatedConcepts": [
+      "worked positive instance",
+      "test of an equivalence",
+      "powers of two"
+    ],
+    "prerequisites": [
+      "the offset reformulation above"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-10-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-wip-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 196,
+    "lineCount": 235,
     "assumptions": "0 literal `axiom` declarations, 0 sorries, and — the point of the file — NO `native_decide`. `#print axioms` reports only the ordinary foundational axioms (propext, Classical.choice, Quot.sound) for every declaration, including the concrete `16` witness; in particular `Lean.ofReduceBool` is absent. Imports the verified Erdos10WIP01 file (and through it Erdos10OQ02 / Erdos10OQ02Popcount) and reuses `popcount`, `isPrimePlusKPowers_iff_popcount`, `Nat.bitIndices`, `Nat.twoPowSum_bitIndices`, and `Nat.bitIndices_two_pow`.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -43,7 +43,7 @@
       }
     ],
     "dateAdded": "2026-06-28",
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "parentDependencies": [
       "Erdos10WIP01"
@@ -102,7 +102,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Resolves the parent's open question by supplying the missing decision architecture: re-index the Erdős #10 predicate by the offset m = n−p so that refuting a witness becomes a finite, kernel-decidable ∀ over offsets of bounded popcount, and certify each compositeness obligation by a single small divisor. The smallest concrete witness — 16 is not a prime plus ≤ 1 power of two — is proved axiom-free (no native_decide, no Lean.ofReduceBool), the first member of the Erdős #10 witness family with that status.",
+    "summary": "Resolves the parent's open question by supplying the missing decision architecture: re-index the Erdős #10 predicate by the offset m = n−p so that refuting a witness becomes a finite, kernel-decidable ∀ over offsets of bounded popcount, and certify each compositeness obligation by a single small divisor. Two concrete witnesses are proved axiom-free (no native_decide, no Lean.ofReduceBool): 16, the smallest witness overall (even, closed by kernel decide on its <16 complements), and 905 = 5·181, the smallest ODD witness — every de Polignac number below it is prime, hence representable with zero powers, so 905 is the first odd integer genuinely neither prime nor prime-plus-a-power-of-two. The 905 complements are ~900-sized, overflowing kernel decide, so their compositeness is supplied by norm_num's factor-exhibiting extension — the lightweight analogue of the small-divisor certificate the ~10⁹ witnesses require.",
     "implications": "The offset reformulation is the practical engine for native_decide-free witness certification at any scale: for Grechuk's 1117175146 it reduces the claim to ≈ 5000 compositeness obligations, each dischargeable by not_prime_of_proper_divisor once the covering-congruence factor table (a finite (offset, small prime) data set) is supplied. The proof obligations are all in place; only the data table remains, moving the 10⁹ witness from a native_decide black box to an auditable, axiom-free certificate.",
     "openQuestions": [
       "Assemble the covering-congruence factor table for 1117175146 (≈ 5000 (offset, small prime divisor) pairs) and feed it to not_isPrimePlusKPowers_iff + not_prime_of_proper_divisor for a fully axiom-free certificate of Grechuk's witness.",
@@ -129,9 +129,9 @@
       "Erdos10OQ02"
     ],
     "namespace": "Erdos10WIP01",
-    "lineCount": 196,
+    "lineCount": 235,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 0,
     "mainTheorems": [
       {
@@ -157,6 +157,12 @@
         "type": "key",
         "description": "Compositeness certificate: a single small proper divisor refutes primality in the kernel",
         "leanType": "{d q : ℕ} → 1 < d → d < q → d ∣ q → ¬ q.Prime"
+      },
+      {
+        "name": "not_isPrimePlusKPowers_one_905",
+        "type": "key",
+        "description": "Smallest ODD witness, axiom-free: 905 = 5·181 is not a prime plus ≤ 1 power of two. The de Polignac numbers below it are all prime (representable with zero powers), so 905 is the first odd integer genuinely neither prime nor prime-plus-a-power-of-two; ~900-sized complements overflow kernel decide so compositeness is via norm_num (no native_decide)",
+        "leanType": "¬ IsPrimePlusKPowers 1 905"
       }
     ],
     "path": "Proofs/Erdos10WIP01OQ01.lean",


### PR DESCRIPTION
## Summary
Research session on the SOLVED gallery entry `erdos-10-wip-01-oq-01` ("Certifying Witnesses by a Finite Offset Search, no native_decide"). Extends its axiom-free Erdős #10 witness family past the trivial even `16` to **`905 = 5·181`, the smallest ODD witness** — the first odd integer that is genuinely neither prime nor prime-plus-a-power-of-two.

Why 905 is the smallest odd witness: the de Polignac numbers below it (odd integers not of the form `prime + 2^a`) — `127, 149, 251, 331, 337, 373, 509, 599, 701, 757, 809, 877` — are **all themselves prime**, hence representable here with zero powers (the `m = 0` case). `905 = 5·181` is the first that fails.

## Progress
- **`not_isPrimePlusKPowers_one_905 : ¬ IsPrimePlusKPowers 1 905`** — proved through the file's existing offset refutation criterion + `popcount_le_one_iff` (reused verbatim). Offsets are `0` and `2^a ≤ 905` (`a ≤ 9`); complements `{905,904,903,901,897,889,873,841,777,649,393}` are all composite (factors `5,2,3,17,3,7,3,29,3,11,3`).
- **Methodological step beyond `16`**: those complements are `~900`-sized and overflow the kernel's default primality `decide` (max recursion depth), so compositeness is discharged by `norm_num`'s factor-exhibiting primality extension — the lightweight analogue of the small-divisor certificate `not_prime_of_proper_divisor` that the genuine `~10⁹` witnesses will require.

## Files modified
- `proofs/Proofs/Erdos10WIP01OQ01.lean` (+ theorem, header docstring, `#check`)
- `src/data/proofs/erdos-10-wip-01-oq-01/meta.json` (theoremCount 6→7, lineCount, mainTheorems, conclusion summary)
- `src/data/proofs/erdos-10-wip-01-oq-01/annotations.json` (realigned ranges + new `ann-smallest-odd-witness`)

## Verification
Built with `lake env lean Proofs/Erdos10WIP01OQ01.lean` (Docker host shared; used the allowed `lake env` typecheck path). Clean: **0 sorries, 0 `axiom` declarations, no `native_decide`**. `#print axioms not_isPrimePlusKPowers_one_905` → `[propext, Classical.choice, Quot.sound]` only (no `Lean.ofReduceBool`).

## Status
**Outcome**: completed (SOLVED entry extended with a genuine new axiom-free witness)
**Next steps** (unchanged, already in entry's openQuestions): `popcount_le_two_iff` for the `k=2` even witness `906`; assemble the covering-congruence factor table for Grechuk's `1117175146`.

🤖 Generated by researcher-9