### PR TITLE
Enrich ∛3 via Eisenstein's Criterion (cube-root-3-irrational-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-01/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "cube-root-3-irrational-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "context",
+    "title": "From rational-root to Eisenstein: the open question answered",
+    "content": "The docstring frames the entry against its parent **cube-root-3-irrational**, which proves ∛3 ∉ ℚ by the rational root theorem and asks for a cleaner Eisenstein-based proof. This file delivers the general theorem the rational-root approach cannot reach: for every prime p and every n ≥ 1, Xⁿ − p is irreducible over ℤ (and, after Gauss, over ℚ). The file imports only Mathlib and works inside `namespace CubeRoot3IrrationalOQ01` with `open Polynomial` for the `X`, `C`, and ideal/coefficient lemmas.",
+    "mathContext": "Goal: $X^n - p$ irreducible over $\\mathbb{Z}$ and $\\mathbb{Q}$ for prime $p$, $n \\ge 1$. Since $X^n - p$ is the minimal polynomial of $p^{1/n}$, irreducibility pins $[\\mathbb{Q}(p^{1/n}):\\mathbb{Q}] = n$ — strictly stronger than mere irrationality ($n > 1$).",
+    "significance": "context",
+    "relatedConcepts": ["minimal polynomial", "algebraic degree", "rational root theorem", "Eisenstein's criterion"],
+    "prerequisites": ["polynomial rings ℤ[X], ℚ[X]", "field extensions", "Lean 4 / Mathlib basics"]
+  },
+  {
     "id": "ann-eisenstein-int",
     "proofId": "cube-root-3-irrational-oq-01",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "The Four Eisenstein Hypotheses for Xⁿ − p",
-    "content": "irreducible_X_pow_sub_C_prime_int verifies Mathlib's Eisenstein criterion at the prime ideal P = span{p}: (1) the leading coefficient is 1, not in the proper ideal P; (2) every lower coefficient of Xⁿ − p is 0 or −p, both in P; (3) the degree n is positive; (4) the constant coefficient −p is NOT in P² = span{p²}, because p² ∣ p would cancel to p ∣ 1, impossible for a prime; (5) the polynomial is monic, hence primitive. No candidate-root case analysis appears anywhere — that is the whole point of Eisenstein over the rational root theorem."
+    "content": "irreducible_X_pow_sub_C_prime_int verifies Mathlib's Eisenstein criterion at the prime ideal P = span{p}: (1) the leading coefficient is 1, not in the proper ideal P; (2) every lower coefficient of Xⁿ − p is 0 or −p, both in P; (3) the degree n is positive; (4) the constant coefficient −p is NOT in P² = span{p²}, because p² ∣ p would cancel to p ∣ 1, impossible for a prime; (5) the polynomial is monic, hence primitive. No candidate-root case analysis appears anywhere — that is the whole point of Eisenstein over the rational root theorem.",
+    "mathContext": "Eisenstein at $P = (p)$: $\\mathrm{lead} = 1 \\notin P$; for $0 \\le m < n$, $\\mathrm{coeff}_m \\in \\{0, -p\\} \\subseteq P$; $\\deg = n > 0$; $\\mathrm{coeff}_0 = -p \\notin P^2 = (p^2)$ since $p^2 \\mid p \\Rightarrow p \\mid 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein's criterion", "prime ideal", "monic polynomial", "primitive polynomial"],
+    "prerequisites": ["ideals of ℤ", "polynomial coefficients", "prime elements"]
   },
   {
     "id": "ann-gauss-rat",
@@ -19,28 +38,40 @@
     },
     "type": "concept",
     "title": "Gauss's Lemma: ℤ-Irreducible ⟹ ℚ-Irreducible",
-    "content": "Eisenstein's criterion lives over ℤ (it needs the prime ideal (p)), but minimal polynomials live over ℚ. Gauss's lemma — Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast — bridges them: a primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is. Since Xⁿ − p is monic (hence primitive) and its cast is again Xⁿ − p, the ℚ-irreducibility follows immediately."
+    "content": "Eisenstein's criterion lives over ℤ (it needs the prime ideal (p)), but minimal polynomials live over ℚ. Gauss's lemma — Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast — bridges them: a primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is. Since Xⁿ − p is monic (hence primitive) and its cast is again Xⁿ − p, the ℚ-irreducibility follows immediately.",
+    "mathContext": "Gauss: for primitive $f \\in \\mathbb{Z}[X]$, $\\mathrm{Irreducible}(f) \\iff \\mathrm{Irreducible}(f \\bmod \\mathbb{Q})$. Here $f = X^n - p$ is monic so primitive, and $\\mathrm{map}_{\\mathbb{Z}\\to\\mathbb{Q}}(X^n - C\\,p) = X^n - C\\,p$.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss's lemma", "primitive polynomial", "content of a polynomial", "ring homomorphism on polynomials"],
+    "prerequisites": ["unique factorization domains", "polynomial map under ℤ → ℚ"]
   },
   {
     "id": "ann-cbrt3",
     "proofId": "cube-root-3-irrational-oq-01",
     "range": {
       "startLine": 102,
-      "endLine": 109
+      "endLine": 113
     },
     "type": "insight",
     "title": "∛3 Has Degree Exactly 3",
-    "content": "Specializing p = 3, n = 3 gives the irreducibility of X³ − 3 over ℚ — the minimal polynomial of ∛3. This is exactly the parent entry's requested 'cleaner algebraic proof via the degree argument': irreducibility of a degree-3 polynomial with ∛3 as a root means ∛3 has algebraic degree 3 over ℚ, which is strictly stronger than 'irrational' (degree > 1). The rational-root argument gives only the latter."
+    "content": "Specializing p = 3, n = 3 gives the irreducibility of X³ − 3 over ℤ and ℚ — the minimal polynomial of ∛3. This is exactly the parent entry's requested 'cleaner algebraic proof via the degree argument': irreducibility of a degree-3 polynomial with ∛3 as a root means ∛3 has algebraic degree 3 over ℚ, which is strictly stronger than 'irrational' (degree > 1). The rational-root argument gives only the latter. The `simpa` calls just normalize the cast `((3:ℕ):ℤ) = 3` and `((3:ℕ):ℚ) = 3`.",
+    "mathContext": "$X^3 - 3$ irreducible over $\\mathbb{Q}$ $\\Rightarrow [\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}] = 3$, so $\\sqrt[3]{3} \\notin \\mathbb{Q}$ (and lies in no field extension of degree $< 3$). Eisenstein at $p = 3$: $3 \\mid 3$, $9 \\nmid 3$.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "algebraic degree", "irrationality of ∛3", "Eisenstein at p=3"],
+    "prerequisites": ["degree of a field extension", "minimal polynomials"]
   },
   {
     "id": "ann-general",
     "proofId": "cube-root-3-irrational-oq-01",
     "range": {
-      "startLine": 113,
-      "endLine": 124
+      "startLine": 117,
+      "endLine": 128
     },
     "type": "concept",
     "title": "One Theorem, Every Radical of a Prime",
-    "content": "Because the proof is uniform in p and n, ⁵√7 (X⁵ − 7, degree 5) and √5 (X² − 5, degree 2) drop out by the same six-line instantiation. Where the rational-root theorem must enumerate divisors afresh for each number, Eisenstein handles the entire family Xⁿ − p in a single argument — the structural advantage the parent's open question was pointing at."
+    "content": "Because the proof is uniform in p and n, ⁵√7 (X⁵ − 7, degree 5) and √5 (X² − 5, degree 2) drop out by the same instantiation. Where the rational-root theorem must enumerate divisors afresh for each number, Eisenstein handles the entire family Xⁿ − p in a single argument — the structural advantage the parent's open question was pointing at. Each specialization is one line: instantiate p and n with `by norm_num` discharging primality and positivity, then `simpa` normalizes the casts.",
+    "mathContext": "Same lemma at $(p,n) = (7,5)$ and $(5,2)$ yields $[\\mathbb{Q}(\\sqrt[5]{7}):\\mathbb{Q}] = 5$ and $[\\mathbb{Q}(\\sqrt{5}):\\mathbb{Q}] = 2$ — irrationality plus exact degree, uniformly.",
+    "significance": "supporting",
+    "relatedConcepts": ["uniformity of Eisenstein", "radicals of primes", "algebraic degree", "parametric theorems"],
+    "prerequisites": ["instantiating universally quantified theorems", "norm_num for primality"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-01`. The entry already had a rich `meta.json`, but its 4 annotations carried only `content` — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- Added a **header annotation** (lines 1–38) covering the docstring/imports and framing the entry against its parent's open question.
- Tightened ranges to align with the four theorem blocks. 5 annotations total.

## Notes
- `meta.json` left untouched — already within size caps (13 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)