### PR TITLE
Enrich Specific Solvable Quintics (abel-ruffini-oq-04-oq-04): add annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-04/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-header-imports",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Imports and the menu of solvable quintics",
+    "content": "The file imports all of `Mathlib` (for the Galois-theory API) plus the sibling gallery entry `Proofs.InverseGaloisF20`, which supplies the order computation `|Gal(X⁵-2/ℚ)| = 20` and the Eisenstein irreducibility of `X⁵-2`. The docstring lays out a three-row menu: the irreducible radical `X⁵-2` (group `F₂₀`, order 20), the cyclotomic `X⁵-1` (abelian group `C₄`), and the reducible product `(X²-2)(X³-2)` (solvable as a product). The stated purpose is constructive: where Abel–Ruffini shows the *general* quintic is unsolvable (group `S₅`), this entry exhibits *specific* quintics that ARE solvable, certified by their Galois groups.",
+    "mathContext": "Galois' criterion: a polynomial $p \\in \\mathbb{Q}[X]$ is solvable by radicals $\\iff \\mathrm{Gal}(p)$ is a solvable group. The general quintic has group $S_5 \\supset A_5$ (simple, non-abelian), so it fails; the polynomials here have solvable groups, so they succeed.",
+    "significance": "context",
+    "relatedConcepts": ["Galois correspondence", "solvable by radicals", "Abel–Ruffini theorem"],
+    "prerequisites": ["Galois theory", "field extensions", "Mathlib library structure"]
+  },
+  {
+    "id": "ann-namespace-open",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 40, "endLine": 42 },
+    "type": "technique",
+    "title": "Namespace and the Polynomial namespace",
+    "content": "Work happens inside `namespace AbelRuffiniOQ04OQ04` with `open Polynomial`. Opening `Polynomial` brings the polynomial-specific notation and lemmas into scope: `X` (the indeterminate), `C` (the constant-coefficient embedding `ℚ → ℚ[X]`), the `.Gal` postfix accessor (`p.Gal` is the Galois group `Gal(splitting field of p / base field)`), and the solvability lemmas `gal_X_pow_sub_C_isSolvable`, `gal_X_pow_sub_one_isSolvable`, `gal_mul_isSolvable`.",
+    "mathContext": "`p.Gal` denotes $\\mathrm{Gal}(K_p / \\mathbb{Q})$ where $K_p$ is the splitting field of $p$ over $\\mathbb{Q}$; `C a` is the constant polynomial $a$, so `X ^ 5 - C 2` is $X^5 - 2$.",
+    "significance": "technical",
+    "relatedConcepts": ["splitting field", "Polynomial.Gal", "constant polynomial embedding"],
+    "prerequisites": ["Lean 4 namespaces", "polynomial rings"]
+  },
+  {
+    "id": "ann-x5-sub-2-solvable",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 48, "endLine": 56 },
+    "type": "insight",
+    "title": "X⁵−2 has a solvable Galois group",
+    "content": "`x5_sub_2_gal_solvable` proves `IsSolvable ((X)^5 - C 2).Gal` as a one-line instance of Mathlib's `gal_X_pow_sub_C_isSolvable 5 2`. The lemma encodes the classical fact that any radical extension `X^n - a` has a solvable Galois group: adjoining an `n`-th root sits inside a tower `ℚ ⊆ ℚ(ζₙ) ⊆ ℚ(ζₙ, ⁿ√a)` whose successive quotients are abelian (cyclotomic, then cyclic Kummer), and an iterated-abelian tower is exactly solvability. This is the solvability *half* of the headline computation.",
+    "mathContext": "$\\mathrm{Gal}(X^5-2/\\mathbb{Q})$ fits in $1 \\triangleleft C_5 \\triangleleft F_{20}$ with quotients $C_5$ and $C_4$, both abelian — the derived series reaches the trivial group, so the group is solvable.",
+    "significance": "key",
+    "relatedConcepts": ["radical extension", "Kummer theory", "derived series", "solvable group"],
+    "prerequisites": ["solvable groups", "cyclotomic fields", "roots of unity"]
+  },
+  {
+    "id": "ann-x5-sub-2-headline",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 58, "endLine": 70 },
+    "type": "insight",
+    "title": "The headline: solvable AND order 20 = the Frobenius group F₂₀",
+    "content": "`x5_sub_2_solvable_quintic` is the central result: it pairs the solvability fact with the imported order computation `InverseGaloisF20.x5_sub_2_gal_card` to state `IsSolvable Gal ∧ Fintype.card Gal = 20` in one theorem. A solvable group of order `20 = 2²·5` with a normal Sylow-5 acting on the five roots `⁵√2·ζ₅ᵏ` is the Frobenius group `F₂₀ = C₅ ⋊ C₄`. This closes the gap left by `InverseGaloisF20`, which computed the order but never stated solvability — order 20 alone does not pin down the group, but order 20 *plus* the `C₅ ⋊ C₄` structure does.",
+    "mathContext": "$F_{20} = C_5 \\rtimes C_4 = \\langle \\sigma, \\tau \\mid \\sigma^5 = \\tau^4 = 1,\\ \\tau\\sigma\\tau^{-1} = \\sigma^2 \\rangle$; the normal $C_5$ cyclically permutes the roots $\\sqrt[5]{2}\\,\\zeta_5^k$ and $C_4 \\cong (\\mathbb{Z}/5)^\\times$ acts on $\\zeta_5$.",
+    "significance": "key",
+    "relatedConcepts": ["Frobenius group", "semidirect product", "Sylow theory", "F₂₀"],
+    "prerequisites": ["semidirect products", "group order", "Sylow theorems"]
+  },
+  {
+    "id": "ann-x5-sub-2-irreducible",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 72, "endLine": 76 },
+    "type": "technique",
+    "title": "Irreducibility re-exported (Eisenstein at 2)",
+    "content": "`x5_sub_2_irreducible` re-exports `InverseGaloisF20.x_fifth_sub_2_irreducible` so the entry is self-contained about working with a genuine quintic. Irreducibility matters: it guarantees `X⁵-2` does not split into lower-degree factors over `ℚ`, so the degree-5 transitive action on its roots is real and the order-20 group is the full Galois group, not a coincidence of a reducible polynomial. The underlying proof is Eisenstein's criterion at the prime 2 (constant term `-2` is divisible by 2 but not 4).",
+    "mathContext": "Eisenstein at $p=2$: $2 \\mid 2$ (all lower coefficients are 0), $2 \\nmid 1$ (leading), $4 \\nmid 2$ (constant) $\\Rightarrow X^5 - 2$ is irreducible over $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eisenstein criterion", "irreducible polynomial", "transitive Galois action"],
+    "prerequisites": ["Eisenstein's criterion", "irreducibility over ℚ"]
+  },
+  {
+    "id": "ann-x5-sub-1-cyclotomic",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 82, "endLine": 89 },
+    "type": "insight",
+    "title": "X⁵−1: the abelian cyclotomic quintic",
+    "content": "`x5_sub_1_gal_solvable` proves `IsSolvable ((X)^5 - 1).Gal` via `gal_X_pow_sub_one_isSolvable 5`. Here `X⁵-1 = (X-1)·Φ₅(X)` factors, with splitting field the cyclotomic field `ℚ(ζ₅)` and Galois group `(ℤ/5)ˣ ≅ C₄`, which is cyclic hence abelian hence solvable. This is the 'tame' end of the menu — an abelian quintic — contrasting with the nonabelian-but-solvable `F₂₀` of `X⁵-2`.",
+    "mathContext": "$\\mathrm{Gal}(\\mathbb{Q}(\\zeta_5)/\\mathbb{Q}) \\cong (\\mathbb{Z}/5\\mathbb{Z})^\\times \\cong C_4$, generated by $\\zeta_5 \\mapsto \\zeta_5^2$; abelian groups are trivially solvable (derived series terminates in one step).",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic field", "cyclotomic polynomial Φ₅", "abelian extension", "Kronecker–Weber"],
+    "prerequisites": ["cyclotomic polynomials", "roots of unity", "abelian groups"]
+  },
+  {
+    "id": "ann-product-degree",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 95, "endLine": 100 },
+    "type": "technique",
+    "title": "Pinning the degree of the product at 5",
+    "content": "`product_quintic_natDegree` certifies `deg((X²-2)(X³-2)) = 5` — necessary to call the product a *quintic*. The proof shows each factor is nonzero (`X_pow_sub_C_ne_zero`, valid because `2 ≠ 0` and `3 ≠ 0` as exponents), then `natDegree_mul` turns the degree of a product into the sum of degrees, and `natDegree_X_pow_sub_C` twice evaluates `deg(X²-2)=2` and `deg(X³-2)=3`. Degree additivity holds because `ℚ[X]` is an integral domain (no zero divisors).",
+    "mathContext": "$\\deg(pq) = \\deg p + \\deg q = 2 + 3 = 5$ over an integral domain; the constant `-2` never inflates the leading term, so $\\deg(X^n - 2) = n$.",
+    "significance": "technical",
+    "relatedConcepts": ["natDegree_mul", "integral domain", "degree additivity"],
+    "prerequisites": ["polynomial degree", "integral domains"]
+  },
+  {
+    "id": "ann-product-solvable",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "insight",
+    "title": "(X²−2)(X³−2): solvability closed under products",
+    "content": "`product_quintic_gal_solvable` concludes `IsSolvable ((X²-2)(X³-2)).Gal` from `gal_mul_isSolvable` applied to two radical certificates `gal_X_pow_sub_C_isSolvable 2 2` and `gal_X_pow_sub_C_isSolvable 3 2`. The lemma uses the embedding `Gal(pq) ↪ Gal(p) × Gal(q)` (a subgroup of a product of solvable groups is solvable). This exhibits a solvable quintic that is neither irreducible nor a single radical: its splitting field `ℚ(√2, ³√2, ζ₃)` carries a non-trivial composite group, showing 'solvable quintic' is far broader than the irreducible-radical case.",
+    "mathContext": "$\\mathrm{Gal}(pq) \\hookrightarrow \\mathrm{Gal}(p) \\times \\mathrm{Gal}(q)$; solvability is closed under subgroups, quotients, products, and extensions, so a product of solvable groups is solvable.",
+    "significance": "key",
+    "relatedConcepts": ["closure properties of solvable groups", "product of polynomials", "compositum of fields"],
+    "prerequisites": ["subgroups and products of groups", "splitting fields"]
+  },
+  {
+    "id": "ann-menu",
+    "proofId": "abel-ruffini-oq-04-oq-04",
+    "range": { "startLine": 118, "endLine": 128 },
+    "type": "concept",
+    "title": "The menu bundled as one statement",
+    "content": "`solvable_quintics_menu` packages the three solvability certificates — `X⁵-2`, `X⁵-1`, `(X²-2)(X³-2)` — into a single conjunction. Read together they span the qualitative range of solvable quintics: nonabelian irreducible (`F₂₀`), abelian reducible (`C₄`), and composite reducible. The statement is the constructive companion to Abel–Ruffini: where `S₅` non-solvability blocks a *general* radical formula, every polynomial listed here genuinely is solvable by radicals.",
+    "mathContext": "$\\bigwedge_i \\mathrm{IsSolvable}\\,(p_i).\\mathrm{Gal}$ for $p_1 = X^5-2,\\ p_2 = X^5-1,\\ p_3 = (X^2-2)(X^3-2)$ — the constructive complement to $S_5$ being non-solvable.",
+    "significance": "supporting",
+    "relatedConcepts": ["solvable by radicals", "Abel–Ruffini complement", "Galois group classification"],
+    "prerequisites": ["solvable groups", "Galois theory"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-04` — the entry had a rich `meta.json` but no `annotations.json`, so the proof page had zero inline annotation coverage.

## What changed
- **Added `annotations.json`** with 9 inline annotations covering the full Lean file (imports/menu, namespace, the three quintic examples X⁵−2 / X⁵−1 / (X²−2)(X³−2), and the bundled menu).
- Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Notes
- `meta.json` left untouched: already rich and within size caps (15 KB ≤ 60 KB). The `badge` correction is tracked separately in #30366.
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)