### PR TITLE
Enrich Erdős #1054: σ(m)/m → ∞ via harmonic series (erdos-1054-oq-01-oq-03): annotation depth

### DIFF
--- a/src/data/proofs/erdos-1054-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1054-oq-01-oq-03/annotations.json
@@ -1,25 +1,18 @@
 [
   {
-    "id": "ann-abundancy-identity",
+    "id": "ann-header",
     "proofId": "erdos-1054-oq-01-oq-03",
     "range": {
-      "startLine": 76,
-      "endLine": 97
+      "startLine": 8,
+      "endLine": 55
     },
-    "type": "insight",
-    "title": "The Abundancy Index Is a Sum of Unit Fractions",
-    "content": "sigma_div_eq_sum_inv proves (σ m : ℝ)/m = ∑_{d∣m} 1/d. The mechanism is the complementary-divisor bijection d ↦ m/d, which permutes the divisors of m (Nat.sum_div_divisors). Each term 1/d is rewritten as (m/d)/m (legal because d ∣ m, so the natural-number division is exact and casts to (m:ℝ)/(d:ℝ)); summing over divisors and pulling out the 1/m gives (∑_{d∣m} d)/m = σ(m)/m. This identity is what converts a question about the SIZE of divisor sums into a question about a harmonic-type series, and it is the hinge of the whole argument."
-  },
-  {
-    "id": "ann-no-mertens",
-    "proofId": "erdos-1054-oq-01-oq-03",
-    "range": {
-      "startLine": 99,
-      "endLine": 130
-    },
-    "type": "insight",
-    "title": "Harmonic Divergence Replaces Mertens/Gronwall",
-    "content": "The parent axiomatized σ(m)/m → ∞, citing Gronwall's theorem σ(m)/(m log log m) → e^γ — deep analytic number theory absent from Mathlib. But only DIVERGENCE is needed, and that is elementary. harmonic_le_sigma_ratio shows ∑_{i<n} 1/(i+1) ≤ σ(lcm(1,…,n))/lcm(1,…,n): every k ≤ n divides lcm(1,…,n) (Finset.dvd_lcm), so the shifted range {i+1 : i<n} is a block of divisors and its reciprocal sum (the harmonic partial sum Hₙ) is dominated by the full ∑_{d∣lcm} 1/d = σ(lcm)/lcm. Then sigma_ratio_tendsto_atTop lifts the Mathlib divergence Real.tendsto_sum_range_one_div_nat_succ_atTop through tendsto_atTop_mono. Net result: the parent's blocking axiom is discharged with 0 axioms and no Mertens/Gronwall machinery."
+    "type": "context",
+    "title": "The Goal: Discharge the Parent's Axiom with the Harmonic Series",
+    "content": "The docstring states the entry's purpose: the parent (erdos-1054-oq-01) axiomatized the analytic input σ(m)/m → ∞, citing Gronwall (1913) and Mertens — neither in Mathlib — and asked whether that machinery must be added. This file answers no: the elementary identity σ(m)/m = ∑_{d∣m} 1/d, applied to mₙ = lcm(1,…,n), makes the abundancy ratio dominate the harmonic partial sum Hₙ, which already diverges in Mathlib. The file defines σ(m) = ∑_{d∣m} d (matching the parent) and the witness sequence lcmUpTo n = lcm{1,…,n}.",
+    "mathContext": "$\\dfrac{\\sigma(m)}{m} = \\sum_{d\\mid m}\\dfrac1d \\ge \\sum_{k=1}^{n}\\dfrac1k = H_n \\xrightarrow{n\\to\\infty} \\infty$, using only that $k \\le n \\Rightarrow k \\mid \\mathrm{lcm}(1,\\dots,n)$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problem #1054", "sum-of-divisors σ", "abundancy index", "harmonic series", "axiom elimination"],
+    "prerequisites": ["sum-of-divisors function", "least common multiple", "limits at infinity (Tendsto atTop)"]
   },
   {
     "id": "ann-lcm-witness",
@@ -30,7 +23,41 @@
     },
     "type": "concept",
     "title": "Why lcm(1,…,n), Not Primorials or Superabundant Numbers",
-    "content": "The parent reaches for superabundant numbers and primorials, whose abundancy growth genuinely needs ∑_p 1/p (Mertens). The sequence lcm(1,…,n) sidesteps all of that: by construction it is divisible by every k from 1 to n (Finset.dvd_lcm on Icc 1 n), so {1,…,n} ⊆ divisors(lcm(1,…,n)) with no prime-counting input whatsoever. The abundancy index then automatically contains the entire harmonic partial sum. This is a purely structural witness — we never compute σ(lcm(1,…,n)) or estimate any constant."
+    "content": "The parent reaches for superabundant numbers and primorials, whose abundancy growth genuinely needs ∑_p 1/p (Mertens). The sequence lcm(1,…,n) sidesteps all of that: by construction it is divisible by every k from 1 to n (Finset.dvd_lcm on Icc 1 n), so {1,…,n} ⊆ divisors(lcm(1,…,n)) with no prime-counting input whatsoever. The abundancy index then automatically contains the entire harmonic partial sum. This is a purely structural witness — we never compute σ(lcm(1,…,n)) or estimate any constant. lcmUpTo_pos and dvd_lcmUpTo package the only two facts needed: positivity and the divisibility k ∣ lcmUpTo n.",
+    "mathContext": "$m_n = \\mathrm{lcm}(1,\\dots,n)$; for $1 \\le k \\le n$, $k \\mid m_n$, hence $\\{1,\\dots,n\\} \\subseteq \\mathrm{divisors}(m_n)$ — a structural containment requiring no estimate of $\\sigma(m_n)$.",
+    "significance": "key",
+    "relatedConcepts": ["least common multiple", "Finset.dvd_lcm", "superabundant numbers", "primorial"],
+    "prerequisites": ["divisibility", "lcm of a finite set", "Finset.Icc"]
+  },
+  {
+    "id": "ann-abundancy-identity",
+    "proofId": "erdos-1054-oq-01-oq-03",
+    "range": {
+      "startLine": 73,
+      "endLine": 97
+    },
+    "type": "insight",
+    "title": "The Abundancy Index Is a Sum of Unit Fractions",
+    "content": "sigma_div_eq_sum_inv proves (σ m : ℝ)/m = ∑_{d∣m} 1/d. The mechanism is the complementary-divisor bijection d ↦ m/d, which permutes the divisors of m (Nat.sum_div_divisors). Each term 1/d is rewritten as (m/d)/m (legal because d ∣ m, so the natural-number division is exact and casts to (m:ℝ)/(d:ℝ)); summing over divisors and pulling out the 1/m gives (∑_{d∣m} d)/m = σ(m)/m. This identity is what converts a question about the SIZE of divisor sums into a question about a harmonic-type series, and it is the hinge of the whole argument.",
+    "mathContext": "$\\dfrac{\\sigma(m)}{m} = \\sum_{d\\mid m}\\dfrac{d}{m} = \\sum_{d\\mid m}\\dfrac{m/d}{m} = \\sum_{d\\mid m}\\dfrac1d$, via the involution $d \\mapsto m/d$ on $\\mathrm{divisors}(m)$.",
+    "significance": "key",
+    "relatedConcepts": ["abundancy index", "complementary divisors", "Nat.sum_div_divisors", "unit fractions"],
+    "prerequisites": ["divisor sums", "reindexing a sum by a bijection", "exact natural-number division and casts"]
+  },
+  {
+    "id": "ann-no-mertens",
+    "proofId": "erdos-1054-oq-01-oq-03",
+    "range": {
+      "startLine": 99,
+      "endLine": 130
+    },
+    "type": "insight",
+    "title": "Harmonic Divergence Replaces Mertens/Gronwall",
+    "content": "The parent axiomatized σ(m)/m → ∞, citing Gronwall's theorem σ(m)/(m log log m) → e^γ — deep analytic number theory absent from Mathlib. But only DIVERGENCE is needed, and that is elementary. harmonic_le_sigma_ratio shows ∑_{i<n} 1/(i+1) ≤ σ(lcm(1,…,n))/lcm(1,…,n): every k ≤ n divides lcm(1,…,n) (Finset.dvd_lcm), so the shifted range {i+1 : i<n} is a block of divisors and its reciprocal sum (the harmonic partial sum Hₙ) is dominated by the full ∑_{d∣lcm} 1/d = σ(lcm)/lcm. Then sigma_ratio_tendsto_atTop lifts the Mathlib divergence Real.tendsto_sum_range_one_div_nat_succ_atTop through tendsto_atTop_mono. Net result: the parent's blocking axiom is discharged with 0 axioms and no Mertens/Gronwall machinery.",
+    "mathContext": "$H_n = \\sum_{i<n}\\dfrac1{i+1} \\le \\dfrac{\\sigma(m_n)}{m_n}$, and $H_n \\to \\infty$, so by monotone comparison $\\dfrac{\\sigma(m_n)}{m_n} \\to \\infty$ — Gronwall's $\\sigma(m)/(m\\log\\log m)\\to e^\\gamma$ is never invoked.",
+    "significance": "key",
+    "relatedConcepts": ["harmonic series divergence", "Mertens' theorem", "Gronwall's theorem", "tendsto_atTop_mono", "monotone comparison of limits"],
+    "prerequisites": ["divergence of the harmonic series", "subset-monotonicity of sums of nonnegatives", "limits along atTop"]
   },
   {
     "id": "ann-corollary",
@@ -41,6 +68,10 @@
     },
     "type": "concept",
     "title": "From Divergence to f(n)/n → 0 (and What Stays Open)",
-    "content": "f_sigma_ratio_tendsto_zero takes reciprocals: lcm(1,…,n)/σ(lcm(1,…,n)) → 0. Composed with the parent's sigma bound f(σ(m)) ≤ m, this gives f(σ(mₙ))/σ(mₙ) ≤ mₙ/σ(mₙ) → 0, so liminf f(n)/n = 0 unconditionally — the easy half of Erdős #1054 Part II. What this does NOT do is resolve the full Part II: density 0 of {n : f(n) ≥ εn} requires controlling f over ALMOST ALL n, not merely along one sequence. That statement remains open; this entry is honest about supplying exactly the analytic ingredient the parent had axiomatized, no more."
+    "content": "f_sigma_ratio_tendsto_zero takes reciprocals: lcm(1,…,n)/σ(lcm(1,…,n)) → 0 (via Tendsto.inv_tendsto_atTop). Composed with the parent's sigma bound f(σ(m)) ≤ m, this gives f(σ(mₙ))/σ(mₙ) ≤ mₙ/σ(mₙ) → 0, so liminf f(n)/n = 0 unconditionally — the easy half of Erdős #1054 Part II. sigma_ratio_unbounded restates the divergence as plain unboundedness. What this does NOT do is resolve the full Part II: density 0 of {n : f(n) ≥ εn} requires controlling f over ALMOST ALL n, not merely along one sequence. That statement remains open; this entry is honest about supplying exactly the analytic ingredient the parent had axiomatized, no more.",
+    "mathContext": "$\\dfrac{m_n}{\\sigma(m_n)} = \\left(\\dfrac{\\sigma(m_n)}{m_n}\\right)^{-1} \\to 0$, hence $\\dfrac{f(\\sigma(m_n))}{\\sigma(m_n)} \\to 0$ and $\\liminf_n \\dfrac{f(n)}{n} = 0$; full density-0 (Part II) stays open.",
+    "significance": "supporting",
+    "relatedConcepts": ["liminf", "reciprocal of a divergent sequence", "natural density", "Erdős #1054 Part II"],
+    "prerequisites": ["Filter.Tendsto.inv_tendsto_atTop", "liminf along a sequence", "natural density (for the open part)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1054-oq-01-oq-03`. The entry already had a rich `meta.json`, but its 4 annotations carried only `content`.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- Added a **header annotation** (docstring, lines 8–55) stating the goal: discharge the parent's axiomatized σ(m)/m → ∞ using only the harmonic series.
- 5 annotations total, ranges aligned to the four proof sections (witness lcm(1,…,n), abundancy identity, harmonic lower bound, divergence + corollary).

## Notes
- `meta.json` left untouched — already within size caps (14 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)