### PR TITLE
Enrich Erdős–Ko–Rado de-axiomatized via Kruskal–Katona (erdos-ko-rado-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/erdos-ko-rado-oq-02/annotations.json
+++ b/src/data/proofs/erdos-ko-rado-oq-02/annotations.json
@@ -1,14 +1,33 @@
 [
   {
+    "id": "ann-header-defs",
+    "proofId": "erdos-ko-rado-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
+    "type": "context",
+    "title": "Goal and the Verbatim Definitions",
+    "content": "The docstring states the task: the parent entry ErdosKoRado formalizes EKR via Katona's cyclic-permutation proof but leaves the upper bound |𝒜| ≤ C(n-1,k-1) as an axiom (double_counting_bound), because Katona's cyclic-interval lemma (sibling OQ-01) resisted Lean. This file discharges that axiom with zero axioms via Mathlib's Kruskal–Katona route, then proves sharpness. The definitions IsIntersectingFamily (every member has card k; every two members meet) and Star x k (all k-subsets containing x) are reproduced verbatim from the parent — importing the parent directly would pull in its nine axioms.",
+    "mathContext": "EKR: an intersecting family $\\mathcal{A}$ of $k$-subsets of $[n]$ with $n \\ge 2k$ satisfies $|\\mathcal{A}| \\le \\binom{n-1}{k-1}$, with equality for the star (all $k$-sets through a fixed point).",
+    "significance": "context",
+    "relatedConcepts": ["Erdős–Ko–Rado theorem", "intersecting family", "star family", "axiom elimination"],
+    "prerequisites": ["extremal set theory", "Finset (Fin n)", "Lean 4 / Mathlib basics"]
+  },
+  {
     "id": "ann-bridge",
     "proofId": "erdos-ko-rado-oq-02",
     "range": {
-      "startLine": 53,
+      "startLine": 50,
       "endLine": 65
     },
     "type": "insight",
     "title": "The Predicate Is Already in Mathlib",
-    "content": "The parent defines IsIntersectingFamily A k as 'every member has card k, and every two members have nonempty intersection'. These two clauses are, after translation, exactly Mathlib's Set.Sized k and Set.Intersecting. The only nontrivial step is intersecting_of_isIntersectingFamily, which rewrites with not_disjoint_iff_nonempty_inter: two finsets fail to be disjoint precisely when their intersection is nonempty. Once this bridge is in place, the heavy machinery is all Mathlib's."
+    "content": "The parent defines IsIntersectingFamily A k as 'every member has card k, and every two members have nonempty intersection'. These two clauses are, after translation, exactly Mathlib's Set.Sized k and Set.Intersecting. The only nontrivial step is intersecting_of_isIntersectingFamily, which rewrites with not_disjoint_iff_nonempty_inter: two finsets fail to be disjoint precisely when their intersection is nonempty. Once this bridge is in place, the heavy machinery is all Mathlib's.",
+    "mathContext": "$\\mathrm{IsIntersectingFamily}\\,A\\,k \\iff (A : \\mathrm{Set}).\\mathrm{Sized}\\,k \\wedge (A : \\mathrm{Set}).\\mathrm{Intersecting}$; the link is $\\neg\\,\\mathrm{Disjoint}\\,s\\,t \\iff (s \\cap t).\\mathrm{Nonempty}$.",
+    "significance": "key",
+    "relatedConcepts": ["Set.Intersecting", "Set.Sized", "not_disjoint_iff_nonempty_inter", "predicate bridging"],
+    "prerequisites": ["Finset disjointness", "coercion Finset → Set", "Mathlib set-family predicates"]
   },
   {
     "id": "ann-upper-bound",
@@ -19,18 +38,26 @@
     },
     "type": "insight",
     "title": "Discharging the Axiom via Kruskal–Katona",
-    "content": "ekr_bound is the parent's axiomatized double_counting_bound, now a 0-axiom theorem. The parent reaches it through Katona's cyclic-permutation count, whose key lemma about pairwise-intersecting cyclic intervals resisted Lean formalization (sibling OQ-01, released unsolved). This proof takes Mathlib's entirely different route: Finset.erdos_ko_rado, derived from the Kruskal–Katona shadow inequality, with no cyclic intervals at all. Its side condition k ≤ n/2 is just the classical n ≥ 2k after one Nat.le_div_iff_mul_le rewrite."
+    "content": "ekr_bound is the parent's axiomatized double_counting_bound, now a 0-axiom theorem. The parent reaches it through Katona's cyclic-permutation count, whose key lemma about pairwise-intersecting cyclic intervals resisted Lean formalization (sibling OQ-01, released unsolved). This proof takes Mathlib's entirely different route: Finset.erdos_ko_rado, derived from the Kruskal–Katona shadow inequality, with no cyclic intervals at all. Its side condition k ≤ n/2 is just the classical n ≥ 2k after one Nat.le_div_iff_mul_le rewrite.",
+    "mathContext": "$|A| \\le \\binom{n-1}{k-1}$ from $\\mathtt{Finset.erdos\\_ko\\_rado}$ (Kruskal–Katona); side condition $k \\le \\lfloor n/2\\rfloor \\iff 2k \\le n$ via $\\mathtt{Nat.le\\_div\\_iff\\_mul\\_le}$.",
+    "significance": "key",
+    "relatedConcepts": ["Kruskal–Katona theorem", "shadow inequality", "Finset.erdos_ko_rado", "Katona cyclic-permutation proof"],
+    "prerequisites": ["Mathlib's EKR/Kruskal–Katona", "binomial coefficients", "Nat division inequalities"]
   },
   {
     "id": "ann-sharpness",
     "proofId": "erdos-ko-rado-oq-02",
     "range": {
-      "startLine": 99,
+      "startLine": 86,
       "endLine": 138
     },
     "type": "concept",
     "title": "Counting the Star by Erasing the Center",
-    "content": "star_card shows the star — all k-sets through a fixed center x — has exactly C(n-1,k-1) members. The bijection is s ↦ s.erase x: deleting the center sends a k-set containing x to a (k-1)-subset of the remaining n-1 points, and inserting x back is the inverse (insert_erase / erase_insert). This is the lower-bound half: a concrete intersecting family meeting the upper bound, so the bound is sharp."
+    "content": "star_card shows the star — all k-sets through a fixed center x — has exactly C(n-1,k-1) members. The bijection is s ↦ s.erase x: deleting the center sends a k-set containing x to a (k-1)-subset of the remaining n-1 points, and inserting x back is the inverse (insert_erase / erase_insert). This is the lower-bound half: a concrete intersecting family meeting the upper bound, so the bound is sharp. star_is_intersecting is immediate since every member contains x.",
+    "mathContext": "$|\\mathrm{Star}(x,k)| = \\binom{n-1}{k-1}$ via the bijection $s \\mapsto s \\setminus \\{x\\}$ onto $(k-1)$-subsets of $[n]\\setminus\\{x\\}$ (inverse $t \\mapsto t \\cup \\{x\\}$).",
+    "significance": "key",
+    "relatedConcepts": ["star family", "Finset.card_bij", "erase/insert bijection", "tightness of a bound"],
+    "prerequisites": ["cardinality via bijection", "Finset.erase and insert", "binomial coefficient identities"]
   },
   {
     "id": "ann-exact-max",
@@ -41,6 +68,10 @@
     },
     "type": "insight",
     "title": "From Inequality to Exact Maximum",
-    "content": "ekr_isGreatest combines the two directions into the full extremal statement: the maximum size over all intersecting families of k-sets (n ≥ 2k) is exactly C(n-1,k-1). The star (centered at the point 0, which exists since n ≥ 2k ≥ 2 > 0) witnesses that the value is attained, and ekr_bound caps every family from above. ekr_max_6_3 and ekr_max_4_2 instantiate this to the familiar maxima 10 = C(5,2) and 3 = C(3,1) — without native_decide, keeping the entry fully kernel-checked."
+    "content": "ekr_isGreatest combines the two directions into the full extremal statement: the maximum size over all intersecting families of k-sets (n ≥ 2k) is exactly C(n-1,k-1). The star (centered at the point 0, which exists since n ≥ 2k ≥ 2 > 0) witnesses that the value is attained, and ekr_bound caps every family from above. ekr_max_6_3 and ekr_max_4_2 instantiate this to the familiar maxima 10 = C(5,2) and 3 = C(3,1) — without native_decide, keeping the entry fully kernel-checked.",
+    "mathContext": "$\\mathrm{IsGreatest}\\,\\{|A| : A \\text{ intersecting } k\\text{-family}\\}\\,\\binom{n-1}{k-1}$; e.g. $(n,k)=(6,3)\\Rightarrow 10=\\binom52$, $(4,2)\\Rightarrow 3=\\binom31$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsGreatest", "extremal value", "kernel-checked computation", "avoiding native_decide"],
+    "prerequisites": ["IsGreatest (least upper bound attained)", "binomial evaluation"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-ko-rado-oq-02`. The entry already had a rich `meta.json`, but its 4 annotations carried only `content`.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- Added a **header/definitions annotation** (lines 1–48) covering the goal and the verbatim `IsIntersectingFamily` / `Star` definitions.
- 5 annotations total, ranges aligned to the four proof sections (Mathlib bridge, axiom-free upper bound, star sharpness, exact maximum).

## Notes
- `meta.json` left untouched — already within size caps (14 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)