### PR TITLE
Enrich Taylor-Coefficient Factor Theorem (factor-remainder-theorem-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 57
+    },
+    "type": "context",
+    "title": "The Open Question: a Division-Free Multiplicity Criterion",
+    "content": "The docstring frames the entry against its ancestors: the grandparent proves the Factor Theorem (X−a) ∣ p ↔ p(a)=0, and OQ-01 gives the multiplicity version over a characteristic-zero field via iterated derivatives p(a)=p′(a)=⋯=p^{(k−1)}(a)=0. This entry answers OQ-01's first open question: phrase multiplicity through Taylor coefficients. Because Mathlib defines (taylor a p).coeff m via Hasse derivatives — with NO division by m! — the resulting criterion holds over an arbitrary commutative ring, strictly generalizing the parent and remaining valid in positive characteristic. The file works in `section CommRing` with `variable {R} [CommRing R]`.",
+    "mathContext": "$(X-a)^k \\mid p \\iff \\forall m < k,\\ (\\mathrm{taylor}_a\\,p).\\mathrm{coeff}\\,m = 0$, where $(\\mathrm{taylor}_a\\,p).\\mathrm{coeff}\\,m = (\\mathrm{hasseDeriv}_m\\,p)(a)$ — no factorial denominators.",
+    "significance": "context",
+    "relatedConcepts": ["Factor Theorem", "root multiplicity", "Taylor expansion of a polynomial", "Hasse derivative"],
+    "prerequisites": ["polynomial rings over a commutative ring", "divisibility of polynomials", "Lean 4 / Mathlib basics"]
+  },
+  {
     "id": "ann-reflection",
     "proofId": "factor-remainder-theorem-oq-01-oq-01",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "Multiplicity Is Monomial Divisibility After Translating the Root to 0",
-    "content": "X_pow_dvd_taylor_iff is the geometric heart of the proof: Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p. The substitution X ↦ X + a is Mathlib's Polynomial.taylorEquiv, an algebra EQUIVALENCE of R[X]. It sends (X − a)ᵏ to Xᵏ (since taylor a (X − a) = (X + a) − a = X via taylor_X and taylor_C), and because it is an equivalence it both preserves AND reflects divisibility — map_dvd_iff turns taylor a ((X − a)ᵏ) ∣ taylor a p into the desired ‘iff’ with no separate converse. Conceptually: a root of multiplicity k at a becomes a root of multiplicity k at 0, where ‘(X − a)ᵏ divides’ is just ‘Xᵏ divides’, i.e. the first k coefficients vanish."
+    "content": "X_pow_dvd_taylor_iff is the geometric heart of the proof: Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p. The substitution X ↦ X + a is Mathlib's Polynomial.taylorEquiv, an algebra EQUIVALENCE of R[X]. It sends (X − a)ᵏ to Xᵏ (since taylor a (X − a) = (X + a) − a = X via taylor_X and taylor_C), and because it is an equivalence it both preserves AND reflects divisibility — map_dvd_iff turns taylor a ((X − a)ᵏ) ∣ taylor a p into the desired ‘iff’ with no separate converse. Conceptually: a root of multiplicity k at a becomes a root of multiplicity k at 0, where ‘(X − a)ᵏ divides’ is just ‘Xᵏ divides’, i.e. the first k coefficients vanish.",
+    "mathContext": "$\\mathrm{taylorEquiv}_a : R[X] \\xrightarrow{\\sim} R[X]$, $X \\mapsto X+a$, sends $(X-a)^k \\mapsto X^k$; being an equivalence, $f \\mid g \\iff \\mathrm{taylor}_a f \\mid \\mathrm{taylor}_a g$.",
+    "significance": "key",
+    "relatedConcepts": ["Polynomial.taylorEquiv", "algebra equivalence", "divisibility reflection (map_dvd_iff)", "change of variable"],
+    "prerequisites": ["ring/algebra equivalences", "Polynomial.taylor", "divisibility under isomorphism"]
   },
   {
     "id": "ann-main",
@@ -19,7 +38,11 @@
     },
     "type": "insight",
     "title": "The Taylor-Coefficient Form — and Why It Holds in Every Characteristic",
-    "content": "pow_dvd_iff_taylor_coeff_eq_zero is the open question's target: (X − a)ᵏ ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0. It is a one-line consequence of X_pow_dvd_taylor_iff followed by Mathlib's X_pow_dvd_iff (Xⁿ ∣ f ↔ ∀ d < n, f.coeff d = 0). The decisive point is that Mathlib defines the Taylor coefficient through Hasse derivatives, (taylor a p).coeff m = (hasseDeriv m p).eval a, with NO division by m!. So unlike the parent (which needed a characteristic-zero field to make factorials invertible), this statement — and its restatement pow_dvd_iff_hasseDeriv_eval_eq_zero — holds over an arbitrary commutative ring. In positive characteristic p the ordinary derivative of Xᵖ is 0, but the divided-power Hasse derivative still detects the multiplicity correctly."
+    "content": "pow_dvd_iff_taylor_coeff_eq_zero is the open question's target: (X − a)ᵏ ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0. It is a one-line consequence of X_pow_dvd_taylor_iff followed by Mathlib's X_pow_dvd_iff (Xⁿ ∣ f ↔ ∀ d < n, f.coeff d = 0). The decisive point is that Mathlib defines the Taylor coefficient through Hasse derivatives, (taylor a p).coeff m = (hasseDeriv m p).eval a, with NO division by m!. So unlike the parent (which needed a characteristic-zero field to make factorials invertible), this statement — and its restatement pow_dvd_iff_hasseDeriv_eval_eq_zero — holds over an arbitrary commutative ring. In positive characteristic p the ordinary derivative of Xᵖ is 0, but the divided-power Hasse derivative still detects the multiplicity correctly.",
+    "mathContext": "$X^n \\mid f \\iff \\forall d < n,\\ f.\\mathrm{coeff}\\,d = 0$ (a monomial divides iff low coefficients vanish); composing with the translation gives the multiplicity test. In char $p$, $\\frac{d}{dX}X^p = 0$ but $\\mathrm{hasseDeriv}_m$ still works.",
+    "significance": "key",
+    "relatedConcepts": ["Hasse derivative", "X_pow_dvd_iff", "positive characteristic", "divided powers"],
+    "prerequisites": ["polynomial coefficients", "Hasse derivatives", "characteristic of a ring"]
   },
   {
     "id": "ann-cases",
@@ -30,7 +53,11 @@
     },
     "type": "insight",
     "title": "Recovering the Factor Theorem and the Double-Root Criterion",
-    "content": "The classical low-order cases drop out of the Taylor form by reading the lowest coefficients. For k = 1, factor_theorem_taylor uses taylor_coeff_zero ((taylor a p).coeff 0 = p.eval a) to get (X − a) ∣ p ↔ p(a) = 0. For k = 2, double_root_iff_taylor adds taylor_coeff_one ((taylor a p).coeff 1 = p′.eval a) to get (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0 — the repeated-root criterion used to detect discriminant vanishing or a common root of p and p′. Both proofs simply interval_cases over m < k and rewrite the corresponding coefficient lemma."
+    "content": "The classical low-order cases drop out of the Taylor form by reading the lowest coefficients. For k = 1, factor_theorem_taylor uses taylor_coeff_zero ((taylor a p).coeff 0 = p.eval a) to get (X − a) ∣ p ↔ p(a) = 0. For k = 2, double_root_iff_taylor adds taylor_coeff_one ((taylor a p).coeff 1 = p′.eval a) to get (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0 — the repeated-root criterion used to detect discriminant vanishing or a common root of p and p′. Both proofs simply interval_cases over m < k and rewrite the corresponding coefficient lemma.",
+    "mathContext": "$k=1$: $(X-a)\\mid p \\iff p(a)=0$. $k=2$: $(X-a)^2 \\mid p \\iff p(a)=0 \\wedge p'(a)=0$ (repeated root / discriminant vanishing), since $\\mathrm{coeff}_0 = p(a)$, $\\mathrm{coeff}_1 = p'(a)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Factor Theorem", "repeated root", "discriminant", "common root of p and p′"],
+    "prerequisites": ["polynomial evaluation", "derivative of a polynomial", "interval_cases tactic"]
   },
   {
     "id": "ann-bridge",
@@ -41,6 +68,10 @@
     },
     "type": "insight",
     "title": "The New Form Generalizes the Parent, Not Replaces It",
-    "content": "Over a characteristic-zero field the two criteria coincide. iterate_derivative_eval_eq_factorial_smul_taylor_coeff proves the exact relation (derivative^[m] p).eval a = m! · (taylor a p).coeff m — the polynomial form of Taylor's theorem cₘ = p^{(m)}(a)/m! — using Mathlib's factorial_smul_hasseDeriv (m! • hasseDeriv m = derivative^[m]). Since m! ≠ 0 in characteristic zero, pow_dvd_iff_iterate_derivative_eval_eq_zero then shows the Taylor-coefficient form is EQUIVALENT to the parent's iterated-derivative form. This certifies that the more general statement specializes back to exactly the parent entry."
+    "content": "Over a characteristic-zero field the two criteria coincide. iterate_derivative_eval_eq_factorial_smul_taylor_coeff proves the exact relation (derivative^[m] p).eval a = m! · (taylor a p).coeff m — the polynomial form of Taylor's theorem cₘ = p^{(m)}(a)/m! — using Mathlib's factorial_smul_hasseDeriv (m! • hasseDeriv m = derivative^[m]). Since m! ≠ 0 in characteristic zero, pow_dvd_iff_iterate_derivative_eval_eq_zero then shows the Taylor-coefficient form is EQUIVALENT to the parent's iterated-derivative form. This certifies that the more general statement specializes back to exactly the parent entry.",
+    "mathContext": "$(\\frac{d}{dX})^{m} p\\,(a) = m!\\cdot (\\mathrm{taylor}_a p).\\mathrm{coeff}\\,m$, i.e. $c_m = p^{(m)}(a)/m!$; in char 0, $m! \\ne 0$ makes the Taylor form $\\iff$ the iterated-derivative form.",
+    "significance": "supporting",
+    "relatedConcepts": ["Taylor's theorem", "factorial_smul_hasseDeriv", "characteristic zero", "specialization to parent"],
+    "prerequisites": ["iterated derivatives", "invertibility of factorials in char 0", "relation between Hasse and ordinary derivatives"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01-oq-01`. The entry already had a rich `meta.json`, but its 4 annotations carried only `content`.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- Added a **header annotation** (lines 5–57) covering the open question and the division-free `CommRing` generalization.
- 5 annotations total, ranges aligned to the proof's structure (`taylorEquiv` reflection, Taylor-coefficient form, low-order Factor/double-root cases, the char-0 bridge back to the parent).

## Notes
- `meta.json` left untouched — already within size caps (15.5 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)