### PR TITLE
Enrich Sum of Squares of Fibonacci Numbers (fibonacci-identities-oq-03-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02/annotations.json
@@ -5,30 +5,46 @@
     "range": { "startLine": 3, "endLine": 28 },
     "type": "context",
     "title": "The Square-Sum Identity and Its Rectangle Tiling",
-    "content": "**Module framing.** The sum of the squares of the first $n$ Fibonacci numbers equals the product of consecutive Fibonacci numbers, $F_1^2 + F_2^2 + \\cdots + F_n^2 = F_n F_{n+1}$. Geometrically the squares of side $F_1,\\dots,F_n$ tile an $F_n \\times F_{n+1}$ rectangle — the picture behind the Fibonacci/golden spiral. Mathlib records the *linear* sum (`Nat.fib_succ_eq_succ_sum`) but **not** the sum of squares, so this is a genuine gap. Because Mathlib's `fib` is $0$-indexed with $F_0 = 0$, the $i=0$ term vanishes and the $1$-indexed classical sum coincides with the $0$-indexed `∑_{i ∈ range (n+1)} fib i²`."
+    "content": "**Module framing.** The sum of the squares of the first $n$ Fibonacci numbers equals the product of consecutive Fibonacci numbers, $F_1^2 + F_2^2 + \\cdots + F_n^2 = F_n F_{n+1}$. Geometrically the squares of side $F_1,\\dots,F_n$ tile an $F_n \\times F_{n+1}$ rectangle — the picture behind the Fibonacci/golden spiral. Mathlib records the *linear* sum (`Nat.fib_succ_eq_succ_sum`) but **not** the sum of squares, so this is a genuine gap. Because Mathlib's `fib` is $0$-indexed with $F_0 = 0$, the $i=0$ term vanishes and the $1$-indexed classical sum coincides with the $0$-indexed `∑_{i ∈ range (n+1)} fib i²`.",
+    "mathContext": "$\\sum_{i=1}^{n} F_i^2 = F_n F_{n+1}$; the squares of sides $F_1,\\dots,F_n$ tile an $F_n \\times F_{n+1}$ rectangle. With Mathlib's $0$-indexed $F_0 = 0$, $\\sum_{i \\in \\mathrm{range}(n+1)} F_i^2 = \\sum_{i=1}^{n} F_i^2$.",
+    "significance": "context",
+    "relatedConcepts": ["Fibonacci numbers", "telescoping identity", "rectangle tiling", "golden spiral", "0- vs 1-indexing"],
+    "prerequisites": ["Fibonacci recurrence", "finite sums over Finset.range", "Lean 4 / Mathlib basics"]
   },
   {
     "id": "ann-fiboq0302-2",
     "proofId": "fibonacci-identities-oq-03-oq-02",
     "range": { "startLine": 32, "endLine": 47 },
-    "type": "key-step",
+    "type": "insight",
     "title": "One-Line Induction: ∑ fib i² = fib n · fib(n+1)",
-    "content": "**Telescoping is the whole proof.** In the step, `Finset.sum_range_succ` peels the top square off: $\\sum_{i \\in \\mathrm{range}(k+2)} F_i^2 = \\big(\\sum_{i \\in \\mathrm{range}(k+1)} F_i^2\\big) + F_{k+1}^2$. The induction hypothesis rewrites the first summand to $F_k F_{k+1}$, and the recurrence `Nat.fib_add_two` ($F_{k+2} = F_k + F_{k+1}$) plus `ring` close $F_k F_{k+1} + F_{k+1}^2 = F_{k+1} F_{k+2}$ — i.e. adding the next square advances the consecutive product by exactly one index. No Fibonacci machinery beyond the defining recurrence is used."
+    "content": "**Telescoping is the whole proof.** In the step, `Finset.sum_range_succ` peels the top square off: $\\sum_{i \\in \\mathrm{range}(k+2)} F_i^2 = \\big(\\sum_{i \\in \\mathrm{range}(k+1)} F_i^2\\big) + F_{k+1}^2$. The induction hypothesis rewrites the first summand to $F_k F_{k+1}$, and the recurrence `Nat.fib_add_two` ($F_{k+2} = F_k + F_{k+1}$) plus `ring` close $F_k F_{k+1} + F_{k+1}^2 = F_{k+1} F_{k+2}$ — i.e. adding the next square advances the consecutive product by exactly one index. No Fibonacci machinery beyond the defining recurrence is used.",
+    "mathContext": "Step: $F_k F_{k+1} + F_{k+1}^2 = F_{k+1}(F_k + F_{k+1}) = F_{k+1} F_{k+2}$, using $F_{k+2} = F_k + F_{k+1}$ — closed by `ring`.",
+    "significance": "key",
+    "relatedConcepts": ["induction on ℕ", "Finset.sum_range_succ", "Nat.fib_add_two", "ring tactic"],
+    "prerequisites": ["proof by induction", "Fibonacci recurrence", "Finset sum manipulation"]
   },
   {
     "id": "ann-fiboq0302-3",
     "proofId": "fibonacci-identities-oq-03-oq-02",
     "range": { "startLine": 49, "endLine": 62 },
-    "type": "key-step",
+    "type": "technique",
     "title": "Reconciling the 1-indexed Classical Form",
-    "content": "**The vanishing $i=0$ term.** To recover the textbook statement $\\sum_{i=1}^n F_i^2 = F_n F_{n+1}$ over `Icc 1 n`, write `range (n+1) = insert 0 (Icc 1 n)` (an `ext`/`omega` set identity) and split off the head with `Finset.sum_insert`. The discarded term is $F_0^2 = 0$, so `simp` reduces the `Icc` form to `fib_sum_sq`. This is exactly where Mathlib's $0$-indexing and the classical $1$-indexing are reconciled."
+    "content": "**The vanishing $i=0$ term.** To recover the textbook statement $\\sum_{i=1}^n F_i^2 = F_n F_{n+1}$ over `Icc 1 n`, write `range (n+1) = insert 0 (Icc 1 n)` (an `ext`/`omega` set identity) and split off the head with `Finset.sum_insert`. The discarded term is $F_0^2 = 0$, so `simp` reduces the `Icc` form to `fib_sum_sq`. This is exactly where Mathlib's $0$-indexing and the classical $1$-indexing are reconciled.",
+    "mathContext": "$\\mathrm{range}(n+1) = \\{0\\} \\sqcup \\mathrm{Icc}\\,1\\,n$; splitting off $i=0$ contributes $F_0^2 = 0$, so $\\sum_{\\mathrm{Icc}\\,1\\,n} F_i^2 = \\sum_{\\mathrm{range}(n+1)} F_i^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_insert", "index-set rewriting", "Finset.Icc vs range", "indexing conventions"],
+    "prerequisites": ["Finset membership (ext/omega)", "splitting a sum over a partition"]
   },
   {
     "id": "ann-fiboq0302-4",
     "proofId": "fibonacci-identities-oq-03-oq-02",
     "range": { "startLine": 64, "endLine": 95 },
-    "type": "key-step",
+    "type": "concept",
     "title": "Integer, Telescoping, and Oblong Readings",
-    "content": "**Packaging.** `fib_sum_sq_int` casts the identity to $\\mathbb{Z}$ by `exact_mod_cast` (for combination with subtractive Fibonacci identities). `fib_sum_sq_succ` records the inductive step in standalone form, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} F_i^2\\big) + F_{n+1}^2 = F_{n+1} F_{n+2}$, exhibiting the partial sums as the consecutive products $F_n F_{n+1}$. `fib_sum_sq_isConsecutiveProduct` reads each partial sum as a Fibonacci oblong number $F_m F_{m+1}$. The numerical check $F_6 F_7 = 104 = 0+1+1+4+9+25+64$ uses `decide` (kernel reduction, not `native_decide`), keeping the entry $0$-axiom."
+    "content": "**Packaging.** `fib_sum_sq_int` casts the identity to $\\mathbb{Z}$ by `exact_mod_cast` (for combination with subtractive Fibonacci identities). `fib_sum_sq_succ` records the inductive step in standalone form, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} F_i^2\\big) + F_{n+1}^2 = F_{n+1} F_{n+2}$, exhibiting the partial sums as the consecutive products $F_n F_{n+1}$. `fib_sum_sq_isConsecutiveProduct` reads each partial sum as a Fibonacci oblong number $F_m F_{m+1}$. The numerical check $F_6 F_7 = 104 = 0+1+1+4+9+25+64$ uses `decide` (kernel reduction, not `native_decide`), keeping the entry $0$-axiom.",
+    "mathContext": "Partial sums are oblong numbers $F_m F_{m+1}$; check at $n=6$: $0+1+1+4+9+25+64 = 104 = F_6 F_7 = 8\\cdot 13$, verified by `decide` (no `Lean.ofReduceBool`).",
+    "significance": "supporting",
+    "relatedConcepts": ["oblong (pronic) numbers", "exact_mod_cast", "decide vs native_decide", "ℤ-valued identities"],
+    "prerequisites": ["casting ℕ identities to ℤ", "existential corollaries", "kernel-checked decidability"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-03-oq-02`. The entry already had a rich `meta.json` and good annotation `content`, but the annotations lacked structured fields.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 annotations.
- Normalized two nonstandard `key-step` `type` values to standard `insight`/`technique`/`concept`.
- Annotations already span the whole 98-line file (framing & tiling, the telescoping induction, the 0-vs-1-indexed reconciliation, and the int/telescoping/oblong packaging).

## Notes
- `meta.json` left untouched — already within size caps (13 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)