### PR TITLE
Enrich Hasse Multiplicity Factor Theorem in all characteristics (factor-remainder-theorem-oq-01-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-02/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "factor-remainder-theorem-oq-01-oq-02",
+    "range": {
+      "startLine": 7,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "Why the Parent's Char-0 Criterion Breaks, and the Hasse Fix",
+    "content": "The docstring frames the entry against its parent (factor-remainder-theorem-oq-01), which proves (X−a)ᵏ ∣ p ↔ p(a)=p′(a)=⋯=p^{(k−1)}(a)=0 only over a characteristic-zero field, because it divides by the factorials m! produced by ordinary iterated derivatives. In positive characteristic this collapses: over ZMod p the polynomial Xᵖ has every ordinary derivative identically zero, so the char-0 criterion would certify arbitrarily high multiplicity at 0. The fix is Hasse's divided-power derivative hasseDeriv m, whose value is the Taylor coefficient (taylor a p).coeff m WITHOUT dividing by m!, yielding a criterion valid over an arbitrary commutative ring (every characteristic, no p ≠ 0 hypothesis). The file works in CommRing R.",
+    "mathContext": "Parent (char 0): $(X-a)^k \\mid p \\iff \\forall m<k,\\ p^{(m)}(a)=0$. This entry (any ring): $(X-a)^k \\mid p \\iff \\forall m<k,\\ (\\mathrm{hasseDeriv}_m p)(a) = 0$, since $\\mathrm{hasseDeriv}_m p\\,(a) = (\\mathrm{taylor}_a p).\\mathrm{coeff}\\,m$ has no $m!$ denominator.",
+    "significance": "context",
+    "relatedConcepts": ["root multiplicity", "Hasse derivative", "positive characteristic", "Taylor coefficient", "Factor Theorem"],
+    "prerequisites": ["polynomial rings over a commutative ring", "characteristic of a ring", "Lean 4 / Mathlib basics"]
+  },
+  {
     "id": "ann-taylor-transfer",
     "proofId": "factor-remainder-theorem-oq-01-oq-02",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "Divisibility Transfers Through the Taylor Shift X ↦ X + a",
-    "content": "pow_X_sub_C_dvd_iff_taylor reduces a shifted divisibility (X − a)ᵏ ∣ p to the pure-power divisibility Xᵏ ∣ taylor a p. The mechanism is that q ↦ q.comp (X + C a) is a ring automorphism of R[X] (its inverse is q ↦ q.comp (X − C a)) carrying X − a to X, so it preserves divisibility both ways. The proof uses only the composition lemmas mul_comp, pow_comp, sub_comp, add_comp and comp_assoc — crucially, no characteristic hypothesis enters. This is the step that makes coefficient vanishing transparent: divisibility by Xᵏ is just the vanishing of the first k coefficients."
+    "content": "pow_X_sub_C_dvd_iff_taylor reduces a shifted divisibility (X − a)ᵏ ∣ p to the pure-power divisibility Xᵏ ∣ taylor a p. The mechanism is that q ↦ q.comp (X + C a) is a ring automorphism of R[X] (its inverse is q ↦ q.comp (X − C a)) carrying X − a to X, so it preserves divisibility both ways. The proof uses only the composition lemmas mul_comp, pow_comp, sub_comp, add_comp and comp_assoc — crucially, no characteristic hypothesis enters. This is the step that makes coefficient vanishing transparent: divisibility by Xᵏ is just the vanishing of the first k coefficients.",
+    "mathContext": "$(X-a)^k \\mid p \\iff X^k \\mid \\mathrm{taylor}_a p$, via the automorphism $q \\mapsto q(X+a)$ (inverse $q \\mapsto q(X-a)$) sending $X-a \\mapsto X$; no characteristic assumption used.",
+    "significance": "key",
+    "relatedConcepts": ["Taylor shift", "ring automorphism of R[X]", "polynomial composition", "divisibility reflection"],
+    "prerequisites": ["polynomial composition lemmas", "ring automorphisms", "Polynomial.taylor"]
   },
   {
     "id": "ann-main",
@@ -19,7 +38,11 @@
     },
     "type": "insight",
     "title": "The Hasse Multiplicity Factor Theorem in Every Characteristic",
-    "content": "pow_X_sub_C_dvd_iff_hasseDeriv_eval_eq_zero is the entry's headline: over any commutative ring, (X − a)ᵏ ∣ p ↔ ∀ m < k, (hasseDeriv m p)(a) = 0. It chains three facts — the Taylor transfer, X_pow_dvd_iff (Xᵏ ∣ q ↔ the first k coefficients of q vanish), and taylor_coeff (the d-th coefficient of taylor a p is exactly (hasseDeriv d p)(a)). The key point is that the Hasse derivative records the Taylor coefficient WITHOUT dividing by d!, so the criterion stays meaningful when d! = 0 in R. This drops both the characteristic-zero and the p ≠ 0 hypotheses of the parent — content absent from Mathlib."
+    "content": "pow_X_sub_C_dvd_iff_hasseDeriv_eval_eq_zero is the entry's headline: over any commutative ring, (X − a)ᵏ ∣ p ↔ ∀ m < k, (hasseDeriv m p)(a) = 0. It chains three facts — the Taylor transfer, X_pow_dvd_iff (Xᵏ ∣ q ↔ the first k coefficients of q vanish), and taylor_coeff (the d-th coefficient of taylor a p is exactly (hasseDeriv d p)(a)). The key point is that the Hasse derivative records the Taylor coefficient WITHOUT dividing by d!, so the criterion stays meaningful when d! = 0 in R. This drops both the characteristic-zero and the p ≠ 0 hypotheses of the parent — content absent from Mathlib.",
+    "mathContext": "$(X-a)^k \\mid p \\iff \\forall m<k,\\ (\\mathrm{hasseDeriv}_m p)(a)=0$ over any $\\mathrm{CommRing}$, by composing the Taylor transfer with $X^k \\mid q \\iff \\forall d<k,\\ q.\\mathrm{coeff}\\,d=0$ and $(\\mathrm{taylor}_a p).\\mathrm{coeff}\\,d = (\\mathrm{hasseDeriv}_d p)(a)$.",
+    "significance": "key",
+    "relatedConcepts": ["Hasse derivative", "X_pow_dvd_iff", "taylor_coeff", "divided powers"],
+    "prerequisites": ["polynomial coefficients", "Hasse derivatives", "evaluation of polynomials"]
   },
   {
     "id": "ann-cases",
@@ -30,7 +53,11 @@
     },
     "type": "concept",
     "title": "Factor Theorem, Double Root, and the Multiplicity Reading",
-    "content": "factor_theorem (k = 1: (X − a) ∣ p ↔ p(a) = 0) and double_root_iff (k = 2: (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0) instantiate the main theorem, using hasseDeriv_zero' (hasseDeriv 0 = id) and hasseDeriv_one' (hasseDeriv 1 = derivative) to recover the familiar low-order derivatives. Both now hold in any characteristic with no p ≠ 0 hypothesis — a strict improvement over the parent's char-0 versions. le_rootMultiplicity_iff_hasseDeriv packages the result as a multiplicity bound: for p ≠ 0, k ≤ rootMultiplicity a p iff the first k Hasse derivatives vanish at a."
+    "content": "factor_theorem (k = 1: (X − a) ∣ p ↔ p(a) = 0) and double_root_iff (k = 2: (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0) instantiate the main theorem, using hasseDeriv_zero' (hasseDeriv 0 = id) and hasseDeriv_one' (hasseDeriv 1 = derivative) to recover the familiar low-order derivatives. Both now hold in any characteristic with no p ≠ 0 hypothesis — a strict improvement over the parent's char-0 versions. le_rootMultiplicity_iff_hasseDeriv packages the result as a multiplicity bound: for p ≠ 0, k ≤ rootMultiplicity a p iff the first k Hasse derivatives vanish at a.",
+    "mathContext": "$k=1$: $(X-a)\\mid p \\iff p(a)=0$; $k=2$: $(X-a)^2 \\mid p \\iff p(a)=0 \\wedge p'(a)=0$; general: $k \\le \\mathrm{rootMultiplicity}_a p \\iff \\forall m<k,\\ (\\mathrm{hasseDeriv}_m p)(a)=0$. Uses $\\mathrm{hasseDeriv}_0 = \\mathrm{id}$, $\\mathrm{hasseDeriv}_1 = \\frac{d}{dX}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Factor Theorem", "repeated root", "rootMultiplicity", "hasseDeriv_zero'/_one'"],
+    "prerequisites": ["polynomial evaluation and derivative", "root multiplicity", "instantiating a parametric theorem"]
   },
   {
     "id": "ann-char-p",
@@ -41,6 +68,10 @@
     },
     "type": "concept",
     "title": "Why Ordinary Derivatives Fail in Characteristic p",
-    "content": "hasseDeriv_detects_char_p is the concrete obstruction that motivates the whole entry. Over ZMod 2, derivative (X²) = C 2 · X = 0 because 2 = 0 — so the characteristic-zero criterion, which only sees ordinary derivatives, would find p(0) = p′(0) = p″(0) = 0 and wrongly certify (X)³ ∣ X². The second Hasse derivative tells the truth: (hasseDeriv 2 (X²))(0) = (taylor 0 (X²)).coeff 2 = (X²).coeff 2 = 1 ≠ 0, and via the Hasse multiplicity factor theorem this refutes (X)³ ∣ X². This is exactly the gap between p^{(m)}(a) = m! · (hasseDeriv m p)(a) collapsing when m! = 0 and the Hasse derivative surviving."
+    "content": "hasseDeriv_detects_char_p is the concrete obstruction that motivates the whole entry. Over ZMod 2, derivative (X²) = C 2 · X = 0 because 2 = 0 — so the characteristic-zero criterion, which only sees ordinary derivatives, would find p(0) = p′(0) = p″(0) = 0 and wrongly certify (X)³ ∣ X². The second Hasse derivative tells the truth: (hasseDeriv 2 (X²))(0) = (taylor 0 (X²)).coeff 2 = (X²).coeff 2 = 1 ≠ 0, and via the Hasse multiplicity factor theorem this refutes (X)³ ∣ X². This is exactly the gap between p^{(m)}(a) = m! · (hasseDeriv m p)(a) collapsing when m! = 0 and the Hasse derivative surviving.",
+    "mathContext": "Over $\\mathbb{Z}/2$: $\\frac{d}{dX}(X^2) = 2X = 0$, but $(\\mathrm{hasseDeriv}_2 (X^2))(0) = 1 \\ne 0$, so $X^3 \\nmid X^2$ — the relation $p^{(m)}(a) = m!\\,(\\mathrm{hasseDeriv}_m p)(a)$ degenerates when $m! = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod p", "Frobenius / vanishing derivatives", "counterexample", "divided-power survival"],
+    "prerequisites": ["arithmetic in ZMod p", "ordinary vs Hasse derivative", "the relation p^{(m)} = m!·hasseDeriv_m"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `factor-remainder-theorem-oq-01-oq-02`. The entry already had a rich `meta.json`, but its 4 annotations carried only `content`.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- Added a **header annotation** (lines 7–51) covering why the parent's char-0 criterion breaks and Hasse's divided-power fix.
- 5 annotations total, ranges aligned to the proof's structure (Taylor-shift transfer, the characteristic-free Hasse factor theorem, low-order Factor/double-root cases + multiplicity reading, and the ZMod 2 counterexample).

## Notes
- `meta.json` left untouched — already within size caps (14.5 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)