### PR TITLE
Enrich General Remainder-Bound Limit Lemma (lhopital-oq-05-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/lhopital-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/lhopital-oq-05-oq-02/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-header",
+    "proofId": "lhopital-oq-05-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 50
+    },
+    "type": "context",
+    "title": "The Open Question: an Order-n Engine from Remainder Bounds Alone",
+    "content": "The docstring states OQ-05-OQ-02's request: a single order-n lemma that, from an explicit Taylor remainder bound alone, produces the indeterminate limit (f(x) − T_{n−1}(x))/xⁿ → f^{(n)}(0)/n! — generalising the parent L'Hôpital entry's sine-specific deviation lemma abs_sub_le to arbitrary order and arbitrary functions. The engine tendsto_of_remainder_bound consumes only a higher-degree bound |e(x)| ≤ C·|x|^m (n < m, |x| ≤ 1) and squeezes; no differentiation, L'Hôpital, or Mean Value Theorem. Two instances follow (cosine n=2, sine n=3), each with target L the leading Taylor coefficient. The file imports only Mathlib and works in `open Filter Topology`.",
+    "mathContext": "$\\dfrac{f(x) - T_{n-1}(x)}{x^n} \\to \\dfrac{f^{(n)}(0)}{n!}$ given $|e(x)| \\le C|x|^m$ with $n<m$ on $|x|\\le 1$; the proof squeezes $\\dfrac{|e(x)|}{|x|^n} \\le C|x|^{m-n} \\le C|x| \\to 0$.",
+    "significance": "context",
+    "relatedConcepts": ["L'Hôpital's rule", "Taylor remainder", "indeterminate forms", "squeeze theorem"],
+    "prerequisites": ["limits and the nhds filter", "Taylor/Maclaurin expansion", "Lean 4 / Mathlib basics"]
+  },
+  {
     "id": "ann-general-lemma",
     "proofId": "lhopital-oq-05-oq-02",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "From an Explicit Remainder Bound to the Limit — Generalising abs_sub_le",
-    "content": "tendsto_of_remainder_bound is the order-n principle OQ-02 requests. It takes a difference quotient g whose deviation from a target L is exactly −e(x)/xⁿ, plus an explicit remainder bound |e(x)| ≤ C·|x|^m valid on |x| ≤ 1 with n < m — and returns g x → L, from the remainder bound alone (no differentiation, no L'Hôpital, no MVT). The proof reduces limit-to-L to limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope C·|x|. On the punctured closed unit ball |x| ≤ 1, so |g x − L| = |e x|/|x|ⁿ; the key move is pow_le_pow_of_le_one, which weakens |x|^m to |x|^{n+1} on the unit ball, collapsing the bound to the linear C·|x| → 0. The denominator degree n and remainder degree m are free parameters, so the lemma applies to any function whose Taylor remainder Mathlib bounds — exactly the generalisation of the parent's sine-only abs_sub_le."
+    "content": "tendsto_of_remainder_bound is the order-n principle OQ-02 requests. It takes a difference quotient g whose deviation from a target L is exactly −e(x)/xⁿ, plus an explicit remainder bound |e(x)| ≤ C·|x|^m valid on |x| ≤ 1 with n < m — and returns g x → L, from the remainder bound alone (no differentiation, no L'Hôpital, no MVT). The proof reduces limit-to-L to limit-to-0 (tendsto_sub_nhds_zero_iff) and applies the eventual normed squeeze squeeze_zero_norm' with envelope C·|x|. On the punctured closed unit ball |x| ≤ 1, so |g x − L| = |e x|/|x|ⁿ; the key move is pow_le_pow_of_le_one, which weakens |x|^m to |x|^{n+1} on the unit ball, collapsing the bound to the linear C·|x| → 0. The denominator degree n and remainder degree m are free parameters, so the lemma applies to any function whose Taylor remainder Mathlib bounds — exactly the generalisation of the parent's sine-only abs_sub_le.",
+    "mathContext": "On $0<|x|\\le 1$: $|g(x)-L| = \\dfrac{|e(x)|}{|x|^n} \\le C|x|^{m-n} \\le C|x|^{1} \\to 0$ via $|x|^m \\le |x|^{n+1}$ (pow_le_pow_of_le_one) and squeeze_zero_norm'.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze_zero_norm'", "pow_le_pow_of_le_one", "tendsto_sub_nhds_zero_iff", "order-n generalization"],
+    "prerequisites": ["normed squeeze (sandwich) lemmas", "eventual (filter) inequalities", "powers on the unit ball"]
   },
   {
     "id": "ann-cosine-deviation",
@@ -19,7 +38,11 @@
     },
     "type": "insight",
     "title": "Order-2 Deviation: Divide the Cosine Remainder by x²",
-    "content": "abs_sub_le_cos is the order-2 analogue of the parent's order-3 abs_sub_le. Mathlib's Real.cos_bound gives |cos x − (1 − x²/2)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the quadratic Maclaurin remainder. Rewriting the deviation as −(cos x − (1 − x²/2))/x² (field_simp; ring), then using |a/b| = |a|/|b| and |x²| = |x|², the deviation equals |cos x − (1 − x²/2)|/|x|². Dividing a degree-4 numerator bound by the degree-2 denominator leaves (5/96)·|x|²: a bound quadratic in x, one order sharper than the cubic sine case's linear bound. The general lemma needs only that this is O(|x|), but the sharper rate is recorded here for its own sake."
+    "content": "abs_sub_le_cos is the order-2 analogue of the parent's order-3 abs_sub_le. Mathlib's Real.cos_bound gives |cos x − (1 − x²/2)| ≤ |x|⁴·(5/96) for |x| ≤ 1 — the quadratic Maclaurin remainder. Rewriting the deviation as −(cos x − (1 − x²/2))/x² (field_simp; ring), then using |a/b| = |a|/|b| and |x²| = |x|², the deviation equals |cos x − (1 − x²/2)|/|x|². Dividing a degree-4 numerator bound by the degree-2 denominator leaves (5/96)·|x|²: a bound quadratic in x, one order sharper than the cubic sine case's linear bound. The general lemma needs only that this is O(|x|), but the sharper rate is recorded here for its own sake.",
+    "mathContext": "$\\left|\\dfrac{1 - \\cos x}{x^2} - \\tfrac12\\right| = \\dfrac{|\\cos x - (1 - x^2/2)|}{|x|^2} \\le \\dfrac{5}{96}|x|^2$ on $|x|\\le 1$ (from $\\mathtt{Real.cos\\_bound}$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.cos_bound", "Maclaurin remainder", "convergence rate", "field_simp/ring"],
+    "prerequisites": ["cosine Taylor expansion", "absolute value of a quotient", "Mathlib analytic bounds"]
   },
   {
     "id": "ann-cosine-instance",
@@ -30,7 +53,11 @@
     },
     "type": "concept",
     "title": "First Instance: the Cosine Limit, and 1/2 = 1/2!",
-    "content": "tendsto_cosine_quadratic is the new, non-sine instance: (1 − cos x)/x² → 1/2 as x → 0. It is one line of plumbing — instantiate tendsto_of_remainder_bound with remainder e(x) = cos x − (1 − x²/2), denominator degree n = 2, bound degree m = 4 — then discharge the deviation identity by field_simp; ring and the bound by linarith from Real.cos_bound. tendsto_cosine_factorial restates the value 1/2 as 1/2!: since 1 − cos x = x²/2 − x⁴/24 + ⋯, the limit is exactly the second Maclaurin coefficient f^{(2)}(0)/2!, the order-n reading OQ-02 asks for."
+    "content": "tendsto_cosine_quadratic is the new, non-sine instance: (1 − cos x)/x² → 1/2 as x → 0. It is one line of plumbing — instantiate tendsto_of_remainder_bound with remainder e(x) = cos x − (1 − x²/2), denominator degree n = 2, bound degree m = 4 — then discharge the deviation identity by field_simp; ring and the bound by linarith from Real.cos_bound. tendsto_cosine_factorial restates the value 1/2 as 1/2!: since 1 − cos x = x²/2 − x⁴/24 + ⋯, the limit is exactly the second Maclaurin coefficient f^{(2)}(0)/2!, the order-n reading OQ-02 asks for.",
+    "mathContext": "$\\dfrac{1-\\cos x}{x^2} \\to \\dfrac12 = \\dfrac{1}{2!}$, the leading coefficient of $1-\\cos x = \\tfrac{x^2}{2} - \\tfrac{x^4}{24} + \\cdots$; instance with $(n,m)=(2,4)$.",
+    "significance": "key",
+    "relatedConcepts": ["Maclaurin coefficient f^{(n)}(0)/n!", "cosine limit", "instantiation of a general lemma"],
+    "prerequisites": ["cosine series", "factorial notation", "applying a parametric limit lemma"]
   },
   {
     "id": "ann-sine-instance",
@@ -41,6 +68,10 @@
     },
     "type": "concept",
     "title": "Second Instance: the Parent's Sine Limit Recovered",
-    "content": "tendsto_cubic_sine_unified re-derives the parent OQ-05 result (x − sin x)/x³ → 1/6 from the very same lemma, now with remainder sin x − (x − x³/6), denominator degree n = 3, and Real.sin_bound (degree m = 4). The proof body is identical to the cosine case up to the choice of parameters and Taylor bound, and the value 1/6 = 1/3! is again the leading Taylor coefficient. Recovering the parent's sine argument as a corollary of the order-n lemma confirms the abstraction is faithful — the generalisation is justified by reproducing the original, not merely by stating something more abstract."
+    "content": "tendsto_cubic_sine_unified re-derives the parent OQ-05 result (x − sin x)/x³ → 1/6 from the very same lemma, now with remainder sin x − (x − x³/6), denominator degree n = 3, and Real.sin_bound (degree m = 4). The proof body is identical to the cosine case up to the choice of parameters and Taylor bound, and the value 1/6 = 1/3! is again the leading Taylor coefficient. Recovering the parent's sine argument as a corollary of the order-n lemma confirms the abstraction is faithful — the generalisation is justified by reproducing the original, not merely by stating something more abstract.",
+    "mathContext": "$\\dfrac{x-\\sin x}{x^3} \\to \\dfrac16 = \\dfrac{1}{3!}$, leading coefficient of $x-\\sin x = \\tfrac{x^3}{6} - \\cdots$; instance with $(n,m)=(3,4)$ from $\\mathtt{Real.sin\\_bound}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.sin_bound", "faithful generalization", "parent recovery", "sine limit"],
+    "prerequisites": ["sine series", "the parent OQ-05 cubic-sine limit"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-05-oq-02`. The entry already had a rich `meta.json`, but its 4 annotations carried only `content`.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation.
- Added a **header annotation** (lines 3–50) covering the open question and the order-n remainder-bound engine (no differentiation / L'Hôpital / MVT).
- 5 annotations total, ranges aligned to the general engine, the order-2 cosine deviation, and the cosine + sine instances.

## Notes
- `meta.json` left untouched — already within size caps (17.6 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)