### PR TITLE
audit(pythagorean-triples-oq-04-oq-01-oq-01): badge verified→mathlib (Tier-B bridge)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/PythagoreanTriplesOQ04OQ01OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-06-26",
     "lineCount": 186,
-    "assumptions": "0 axioms, 0 sorries. Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms; no native_decide / Lean.ofReduceBool). The core biconditional Nat.eq_sq_add_sq_iff is from Mathlib; the all-primes repackaging, the necessity corollary, the prime-case recovery, and the worked composite witnesses are the contribution.",
+    "assumptions": "0 axioms, 0 sorries (core result via Mathlib bridge). Only the foundational axioms propext, Classical.choice, Quot.sound are used (verified via #print axioms; no native_decide / Lean.ofReduceBool). The hard analytic content — the core biconditional Nat.eq_sq_add_sq_iff — is from Mathlib and is obtained here by a direct rewrite (hence badge 'mathlib'); the all-primes repackaging, the necessity corollary, the prime-case recovery, and the worked composite witnesses are the contribution.",
     "theoremCount": 14,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Gallery integrity fix

**Proof**: `pythagorean-triples-oq-04-oq-01-oq-01` — "Sum of Two Squares: the Full General-n Characterization"
**Problem**: Badge `verified` overstates independence for a Tier-B Mathlib bridge.

## Evidence

The headline theorem is a one-step rewrite over Mathlib's core biconditional:

```lean
theorem sum_two_squares_iff (n : ℕ) :
    (∃ x y : ℕ, n = x ^ 2 + y ^ 2) ↔
      ∀ p : ℕ, p.Prime → p % 4 = 3 → Even (padicValNat p n) := by
  rw [Nat.eq_sq_add_sq_iff]   -- hard analytic content is Mathlib's
  ...                         -- only reconciles the primeFactors side condition
```

`meta.json` already lists `Nat.eq_sq_add_sq_iff` as a `mathlibDependency` ("Supplies the hard analytic content") and the Lean docstring has an explicit *Honest Provenance* section. The prose is honest; only the **badge** was inconsistent.

Per the auditor rules:
- **Mathlib Wrapper Detection (rule #3)**: a proof that obtains its main result by calling a Mathlib theorem should use badge `mathlib`.
- **Failure mode #5** ("0 sorries with hidden imports"): 0 sorries but main result via a deep Mathlib call → badge must be `mathlib`, not `verified`.
- Same fix pattern as the prior abel-ruffini-oq-04-oq-04 badge correction (#30366).

## Fix

- `badge`: `verified` → `mathlib`
- `assumptions`: clarified to "0 axioms, 0 sorries (core result via Mathlib bridge)".

No change to `status` (`verified` is accurate — the file is fully machine-checked, 0 sorries/0 axioms) or to the listed contributions, which remain genuine.

---
Discovered during gallery integrity audit (auditor agent). Severity: MEDIUM (badge only; prose already honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)