### PR TITLE
Enrich Finite Rogers–Ramanujan (Schur) Identity (combinations-formula-oq-03-oq-03): annotation depth

### DIFF
--- a/src/data/proofs/combinations-formula-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-03-oq-03/annotations.json
@@ -3,9 +3,13 @@
     "id": "rr-context",
     "proofId": "combinations-formula-oq-03-oq-03",
     "range": { "startLine": 1, "endLine": 52 },
-    "type": "concept",
+    "type": "context",
     "title": "The Rogers–Ramanujan Identities and Their Finite Core",
-    "content": "The Rogers–Ramanujan identities ∑_{n≥0} q^{n²}/(q;q)_n = ∏_{n≥0} 1/((1-q^{5n+1})(1-q^{5n+4})) are landmark q-series identities linking partition theory, modular forms, and statistical mechanics. The series side is an infinite object in ℤ[[q]] and is beyond a single Lean development. Schur's 1917 proof replaced it with a sequence of polynomials — the Schur (Rogers–Ramanujan) polynomials — that truncate the series and satisfy a simple two-term recurrence. This entry formalizes that finite core: the Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q and its recurrence. As n→∞ the polynomials converge termwise to the series side, so the recurrence is the elementary mechanism underlying the identity. This is the tractable, honest answer to the parent's open question."
+    "content": "The Rogers–Ramanujan identities ∑_{n≥0} q^{n²}/(q;q)_n = ∏_{n≥0} 1/((1-q^{5n+1})(1-q^{5n+4})) are landmark q-series identities linking partition theory, modular forms, and statistical mechanics. The series side is an infinite object in ℤ[[q]] and is beyond a single Lean development. Schur's 1917 proof replaced it with a sequence of polynomials — the Schur (Rogers–Ramanujan) polynomials — that truncate the series and satisfy a simple two-term recurrence. This entry formalizes that finite core: the Schur sum S_n(q) = ∑_j q^{j²}·[n-j choose j]_q and its recurrence. As n→∞ the polynomials converge termwise to the series side, so the recurrence is the elementary mechanism underlying the identity. This is the tractable, honest answer to the parent's open question.",
+    "mathContext": "$\\sum_{n\\ge0}\\dfrac{q^{n^2}}{(q;q)_n} = \\prod_{n\\ge0}\\dfrac{1}{(1-q^{5n+1})(1-q^{5n+4})}$; finite core $S_n(q) = \\sum_j q^{j^2}\\genfrac[]{0pt}{}{n-j}{j}_q$, with $S_n \\to$ the series side as $n\\to\\infty$.",
+    "significance": "context",
+    "relatedConcepts": ["Rogers–Ramanujan identities", "q-series", "Gaussian (q-)binomial", "partition theory", "Schur polynomials"],
+    "prerequisites": ["q-binomial coefficients", "formal power series", "Lean 4 / Mathlib basics"]
   },
   {
     "id": "pascal-all-note",
@@ -13,7 +17,11 @@
     "range": { "startLine": 53, "endLine": 74 },
     "type": "technique",
     "title": "Hypothesis-Free Second q-Pascal Identity",
-    "content": "The parent proves the second q-Pascal identity [n+1 choose k+1]_q = q^{n-k}·[n choose k]_q + [n choose k+1]_q only under k+1 ≤ n+1. To apply it termwise inside a Finset sum (where the index runs past that bound) we remove the hypothesis: when a < k all three q-binomials vanish by qBinom_eq_zero_of_lt, and the identity degenerates to 0 = q^{a-k}·0 + 0. A single rcases on le_or_gt k a dispatches both branches. This unconditional form qBinom_pascal'_all is the workhorse of the whole file — it lets the recurrence proof rewrite every summand uniformly."
+    "content": "The parent proves the second q-Pascal identity [n+1 choose k+1]_q = q^{n-k}·[n choose k]_q + [n choose k+1]_q only under k+1 ≤ n+1. To apply it termwise inside a Finset sum (where the index runs past that bound) we remove the hypothesis: when a < k all three q-binomials vanish by qBinom_eq_zero_of_lt, and the identity degenerates to 0 = q^{a-k}·0 + 0. A single rcases on le_or_gt k a dispatches both branches. This unconditional form qBinom_pascal'_all is the workhorse of the whole file — it lets the recurrence proof rewrite every summand uniformly.",
+    "mathContext": "$\\genfrac[]{0pt}{}{a+1}{k+1}_q = q^{a-k}\\genfrac[]{0pt}{}{a}{k}_q + \\genfrac[]{0pt}{}{a}{k+1}_q$ for all $a,k$ (both sides $=0$ when $a<k$), removing the parent's $k+1\\le n+1$ guard.",
+    "significance": "key",
+    "relatedConcepts": ["q-Pascal rule", "qBinom_eq_zero_of_lt", "vanishing edge cases", "unconditional lemma form"],
+    "prerequisites": ["Gaussian binomial recurrences", "case splitting (le_or_gt)"]
   },
   {
     "id": "schur-sum-def",
@@ -21,30 +29,46 @@
     "range": { "startLine": 75, "endLine": 102 },
     "type": "definition",
     "title": "The Schur Sum S_n(q)",
-    "content": "schurSum q n = ∑_{j ∈ range (n+1)} q^{j²}·[n-j choose j]_q is a polynomial in q over any commutative ring. The Gaussian binomial [n-j choose j]_q vanishes once j > n-j, so summing to n+1 captures every nonzero term (the truncated ℕ subtraction n-j makes the tail terms identically zero). The peeling lemma schurSum_succ_peel rewrites S_{n+1} as (its j≥1 reindexed tail) + 1, exposing exactly the shape produced when the q-Pascal split is applied to S_{n+2} — this is how one half of the recurrence is recognised."
+    "content": "schurSum q n = ∑_{j ∈ range (n+1)} q^{j²}·[n-j choose j]_q is a polynomial in q over any commutative ring. The Gaussian binomial [n-j choose j]_q vanishes once j > n-j, so summing to n+1 captures every nonzero term (the truncated ℕ subtraction n-j makes the tail terms identically zero). The peeling lemma schurSum_succ_peel rewrites S_{n+1} as (its j≥1 reindexed tail) + 1, exposing exactly the shape produced when the q-Pascal split is applied to S_{n+2} — this is how one half of the recurrence is recognised.",
+    "mathContext": "$S_n(q) = \\sum_{j=0}^{n} q^{j^2}\\genfrac[]{0pt}{}{n-j}{j}_q$; terms with $j > n-j$ vanish, and $S_{n+1}$ peels as $1 + (\\text{reindexed } j\\ge1 \\text{ tail})$.",
+    "significance": "key",
+    "relatedConcepts": ["Schur polynomial", "Finset.range sum", "truncated ℕ subtraction", "reindexing (sum_range_succ')"],
+    "prerequisites": ["finite sums of polynomials", "vanishing of out-of-range q-binomials"]
   },
   {
     "id": "recurrence-core",
     "proofId": "combinations-formula-oq-03-oq-03",
     "range": { "startLine": 105, "endLine": 165 },
-    "type": "key-insight",
+    "type": "insight",
     "title": "Schur's Recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n",
-    "content": "The main theorem. Expand S_{n+2} over range (n+3); peel the bottom term (j=0, equal to 1) and the top term (j=n+2, equal to q^…·[0 choose n+2]_q = 0). Apply qBinom_pascal'_all to each surviving term [n+2-(i+1) choose i+1]_q = q^{(n-i)-i}·[n-i choose i]_q + [n-i choose i+1]_q. Summing, the [n-i choose i+1]_q terms reassemble (with the peeled 1) into S_{n+1}; the [n-i choose i]_q terms, weighted by q^{(i+1)²+(n-i)-i}, become q^{n+1}·S_n once the exponent identity (i+1)² + (n-i) - i = i² + (n+1) is applied. That identity holds exactly when 2i ≤ n; in the complementary range [n-i choose i]_q = 0 and the term drops out, so the case split le_or_gt i (n-i) closes both branches. This is the entire combinatorial content of the finite Rogers–Ramanujan identity, reduced to one q-Pascal application plus reindexing."
+    "content": "The main theorem. Expand S_{n+2} over range (n+3); peel the bottom term (j=0, equal to 1) and the top term (j=n+2, equal to q^…·[0 choose n+2]_q = 0). Apply qBinom_pascal'_all to each surviving term [n+2-(i+1) choose i+1]_q = q^{(n-i)-i}·[n-i choose i]_q + [n-i choose i+1]_q. Summing, the [n-i choose i+1]_q terms reassemble (with the peeled 1) into S_{n+1}; the [n-i choose i]_q terms, weighted by q^{(i+1)²+(n-i)-i}, become q^{n+1}·S_n once the exponent identity (i+1)² + (n-i) - i = i² + (n+1) is applied. That identity holds exactly when 2i ≤ n; in the complementary range [n-i choose i]_q = 0 and the term drops out, so the case split le_or_gt i (n-i) closes both branches. This is the entire combinatorial content of the finite Rogers–Ramanujan identity, reduced to one q-Pascal application plus reindexing.",
+    "mathContext": "$S_{n+2} = S_{n+1} + q^{n+1}S_n$; the $q$-power bookkeeping turns on $(i+1)^2 + (n-i) - i = i^2 + (n+1)$, valid when $2i \\le n$ (else the $q$-binomial vanishes).",
+    "significance": "key",
+    "relatedConcepts": ["two-term recurrence", "q-Pascal split", "exponent identity", "finite Rogers–Ramanujan"],
+    "prerequisites": ["Finset sum manipulation", "reindexing sums", "q-binomial recurrence"]
   },
   {
     "id": "fibonacci-specialization",
     "proofId": "combinations-formula-oq-03-oq-03",
     "range": { "startLine": 168, "endLine": 195 },
-    "type": "key-insight",
+    "type": "insight",
     "title": "q=1: Schur Polynomials Are q-Fibonacci Numbers",
-    "content": "At q=1 the weight q^{j²} becomes 1 and the recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n collapses to the Fibonacci recurrence S_{n+2} = S_{n+1} + S_n, with base cases S_0 = S_1 = 1 = F_1 = F_2. A two-step induction gives schurSum_at_one_eq_fib: S_n(1) = F_{n+1}. Composing with the parent's specialization [n choose k]_1 = C(n,k) yields sum_choose_eq_fib: ∑_j C(n-j,j) = F_{n+1}, the classical fact that the diagonal sums of Pascal's triangle are the Fibonacci numbers — recovered for free as the q=1 reading of the Schur sum. So the Schur polynomials are a one-parameter q-deformation of the Fibonacci sequence, and the Rogers–Ramanujan series is their analytic q-limit."
+    "content": "At q=1 the weight q^{j²} becomes 1 and the recurrence S_{n+2} = S_{n+1} + q^{n+1}·S_n collapses to the Fibonacci recurrence S_{n+2} = S_{n+1} + S_n, with base cases S_0 = S_1 = 1 = F_1 = F_2. A two-step induction gives schurSum_at_one_eq_fib: S_n(1) = F_{n+1}. Composing with the parent's specialization [n choose k]_1 = C(n,k) yields sum_choose_eq_fib: ∑_j C(n-j,j) = F_{n+1}, the classical fact that the diagonal sums of Pascal's triangle are the Fibonacci numbers — recovered for free as the q=1 reading of the Schur sum. So the Schur polynomials are a one-parameter q-deformation of the Fibonacci sequence, and the Rogers–Ramanujan series is their analytic q-limit.",
+    "mathContext": "$S_n(1) = F_{n+1}$; the diagonal Pascal sum $\\sum_j \\binom{n-j}{j} = F_{n+1}$ falls out as the $q=1$ reading, since $\\genfrac[]{0pt}{}{n}{k}_1 = \\binom{n}{k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci numbers", "q-deformation", "diagonal Pascal sums", "two-step induction"],
+    "prerequisites": ["Fibonacci recurrence", "specialization q=1 of q-binomials"]
   },
   {
     "id": "verification-values",
     "proofId": "combinations-formula-oq-03-oq-03",
     "range": { "startLine": 197, "endLine": 222 },
-    "type": "example",
+    "type": "context",
     "title": "Worked Schur Polynomials",
-    "content": "Concrete values confirm the recurrence: S_2 = 1+q, S_3 = 1+q+q², S_4 = 1+q+q²+q³+q⁴ (each over an arbitrary commutative ring), and S_5(1) = F_6 = 8. For instance S_4 = S_3 + q³·S_2 = (1+q+q²) + q³(1+q) = 1+q+q²+q³+q⁴, matching the recurrence directly."
+    "content": "Concrete values confirm the recurrence: S_2 = 1+q, S_3 = 1+q+q², S_4 = 1+q+q²+q³+q⁴ (each over an arbitrary commutative ring), and S_5(1) = F_6 = 8. For instance S_4 = S_3 + q³·S_2 = (1+q+q²) + q³(1+q) = 1+q+q²+q³+q⁴, matching the recurrence directly.",
+    "mathContext": "$S_2 = 1+q,\\ S_3 = 1+q+q^2,\\ S_4 = 1+q+q^2+q^3+q^4 = S_3 + q^3 S_2,\\ S_5(1) = F_6 = 8$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "recurrence verification", "Fibonacci value F_6"],
+    "prerequisites": ["evaluating the Schur recurrence", "polynomial arithmetic"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-03-oq-03`. The entry already had a rich `meta.json` and detailed annotation `content`, but the annotations lacked structured fields.

## What changed
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 6 annotations.
- Normalized nonstandard `key-insight`/`example` `type` values to standard `insight`/`context`.
- Annotations already span the full 222-line file (Rogers–Ramanujan context, hypothesis-free q-Pascal, the Schur sum definition, Schur's recurrence, the q=1 Fibonacci specialization, and worked values).

## Notes
- `meta.json` left untouched — already within size caps (13 KB; `check-meta-size` passes).
- Build verified: `tsc -b` + `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)