### PR TITLE
Research: erdos-671 — BLOCKED assessment (remaining sorries are deep named theorems)

### DIFF
--- a/research/problems/erdos-671/state.md
+++ b/research/problems/erdos-671/state.md
@@ -1,0 +1,57 @@
+# Current State
+
+**Phase**: BLOCKED (entry at its natural ceiling; remaining sorries need deep Mathlib infrastructure)
+**Since**: 2026-06-26
+**Iteration**: 1 (assessment)
+
+## Current Focus
+
+Erdős #671 ($250) — Lagrange interpolation convergence. The gallery entry
+`Proofs/Erdos671Problem.lean` is `axiomatized` with **3 axioms + 7 sorries**
+(15 theorems total). This session was an assessment of whether any remaining
+sorry/axiom is tractable. Conclusion: **none is**, for the reasons below.
+
+## Assessment of the 3 axioms
+
+All three are the OPEN conjectures themselves and cannot be proved:
+- `question1_open : Question1` — does there exist a node sequence with a point
+  where λ_n(x) → ∞ yet L^n f(x) → f(x) for every continuous f? OPEN.
+- `question2_open : Question2` — same with λ_n(x) → ∞ for ALL x. OPEN.
+- `main_conjecture_open : MainConjecture` — the combined statement. OPEN.
+
+These are correctly axioms; they are the unsolved problem.
+
+## Assessment of the 7 sorries (all deep named theorems, NOT routine)
+
+| line | theorem | classification |
+|------|---------|----------------|
+| 200 | `bernstein` (∃ divergence point, Bernstein 1931) | DEEP, not in Mathlib |
+| 205 | `lebesgueConstant_growth` (Λ_n ≥ (2/π)log n − 1) | DEEP harmonic analysis, not in Mathlib |
+| 220 | `erdos_vertesi` (a.e. divergence, Erdős–Vértesi 1980) | DEEP + Baire category, not in Mathlib |
+| 317 | `equidistant_diverges` (Runge phenomenon) | DEEP, not in Mathlib |
+| 335 | `faber` (Faber's theorem) | DEEP, not in Mathlib |
+| 345 | `positive_measure_divergence` | DEEP, not in Mathlib |
+| 353 | `full_measure_convergence` | DEEP, not in Mathlib |
+
+None is a routine Mathlib application; each is a major formalization effort
+(the Lebesgue-constant lower bound and Faber's theorem alone are research-grade
+formalizations). They are **not Aristotle-suitable** — Aristotle spins on
+results outside its training distribution, and these are essentially open/hard.
+
+## Blockers
+
+The entry is at its natural ceiling: the open conjectures are axiomatized, and
+the supporting "known results" (Bernstein, Erdős–Vértesi, Faber, Lebesgue
+constant growth) are deep approximation-theory theorems absent from Mathlib.
+Advancing any of them requires building substantial harmonic-analysis
+infrastructure (>1000 lines), which is beyond a single session and is itself a
+research project. Additionally, Docker was down this session, so no analysis
+proof could be build-verified even if attempted.
+
+## Next Action
+
+- Do NOT re-attempt these sorries piecemeal or via Aristotle.
+- A genuine advance would require a dedicated multi-session effort to formalize
+  the Lebesgue-constant lower bound Λ_n ≥ (2/π)log n + O(1) (the most
+  self-contained of the seven), starting from Chebyshev-node estimates.
+- Until that infrastructure exists, treat this entry as complete-as-axiomatized.


### PR DESCRIPTION
## Summary
Assessment session for **erdos-671** (Erdős #671, \$250 — Lagrange interpolation convergence).

The gallery entry `Proofs/Erdos671Problem.lean` is `axiomatized` with **3 axioms + 7 sorries**. This session assessed whether any remaining sorry/axiom is tractable. **None is.**

## Findings
- **3 axioms** = the open conjectures themselves (`question1_open`, `question2_open`, `main_conjecture_open`). Correctly axiomatized; unsolvable.
- **7 sorries** = deep named approximation-theory theorems, none in Mathlib, none Aristotle-suitable:
  - `bernstein` (1931, ∃ divergence point), `lebesgueConstant_growth` (Λ_n ≥ (2/π)log n − 1), `erdos_vertesi` (1980, a.e. divergence + Baire category), `equidistant_diverges` (Runge), `faber` (Faber's theorem), `positive_measure_divergence`, `full_measure_convergence`.

Each is a major formalization effort (>1000 lines of harmonic analysis not in Mathlib). The entry is at its natural ceiling.

## Status
**Outcome**: blocked (documented insight; no fabricated progress)

This PR adds only `research/problems/erdos-671/state.md` documenting the assessment, so future agents do not re-attempt the sorries piecemeal or route them to Aristotle (which spins on results outside its training distribution). No Lean code changed. Docker was also down this session, so no analysis proof could have been build-verified.

**Next Steps**: a genuine advance requires a dedicated multi-session effort to formalize the most self-contained piece (the Lebesgue-constant lower bound Λ_n ≥ (2/π)log n + O(1)) from Chebyshev-node estimates.

🤖 Generated by researcher-1