### PR TITLE
Enrich Toward Burnside's pᵃqᵇ theorem: add annotation layer

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 5 },
+    "type": "context",
+    "title": "Mathlib group-theory imports",
+    "content": "The file draws on exactly four Mathlib group-theory modules, one per ingredient of the argument: Nilpotent (for 'p-groups are nilpotent, hence solvable'), Solvable (the derived-series definition of solvability and the homological extension principle), PGroup (recognizing a group of prime-power order as a p-group), and Index (Lagrange/index arithmetic to certify that the subgroup and quotient are strictly smaller). QuotientGroup.Defs supplies the projection G ↠ G ⧸ N. No representation-theory module is imported — precisely because the character-theoretic core of Burnside's theorem is not yet in Mathlib.",
+    "mathContext": "Solvability is defined via the derived series $G \\supseteq G^{(1)} \\supseteq G^{(2)} \\supseteq \\cdots$ with $G^{(i+1)} = [G^{(i)}, G^{(i)}]$; $G$ is solvable iff $G^{(n)} = 1$ for some $n$.",
+    "significance": "context",
+    "relatedConcepts": ["derived series", "p-groups", "nilpotent groups", "subgroup index"],
+    "prerequisites": ["group theory", "Lean 4 / Mathlib import system"]
+  },
+  {
+    "id": "ann-header",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 7, "endLine": 62 },
+    "type": "concept",
+    "title": "The target theorem and what is (and is not) proved",
+    "content": "Burnside's pᵃqᵇ theorem (1904) states that every finite group whose order has only two prime divisors is solvable — equivalently, that a finite simple group with at most two distinct prime factors is cyclic of prime order. Every known proof routes through the character theory of finite groups: the degrees of the irreducible complex representations divide |G|, and an algebraic-integer argument (Burnside's vanishing lemma) forces a proper nontrivial normal subgroup in any nonabelian such group. The 'elementary' representation-free proofs found in the 1970s–80s (Goldschmidt, Matsuyama, Bender) are still substantial. This file does NOT claim the unconditional theorem; it builds the fully verified outer scaffolding and isolates the single missing input as an explicit hypothesis.",
+    "mathContext": "Goal: for finite $G$ with $|G| = p^a q^b$ ($p,q$ prime), show $G$ is solvable. Character-theoretic key fact: $\\chi(1) \\mid |G|$ for every irreducible character $\\chi$, and Burnside's vanishing lemma $\\gcd(|g^G|, \\chi(1)) = 1 \\Rightarrow \\chi(g) = 0$ or $\\rho(g)$ scalar.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's theorem", "character theory", "irreducible representations", "Feit–Thompson theorem", "Mathlib gaps"],
+    "prerequisites": ["representation theory of finite groups", "solvable groups", "algebraic integers"]
+  },
+  {
+    "id": "ann-base-pgroup",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 70, "endLine": 82 },
+    "type": "technique",
+    "title": "Base case: prime-power order ⟹ solvable",
+    "content": "The leaves of the induction (and the a=0 / b=0 edges of the pᵃqᵇ grid) are handled by isSolvable_of_isPGroup and isSolvable_of_card_prime_pow. The chain is: a finite group of order pⁿ is a p-group (IsPGroup.of_card), every finite p-group is nilpotent (IsPGroup.isNilpotent, via the nontrivial-center / ascending-central-series argument), and nilpotent groups are solvable (the IsNilpotent.to_isSolvable instance). The Lean proof is just `haveI := h.isNilpotent; infer_instance` — typeclass resolution finds the solvability instance once nilpotency is in scope.",
+    "mathContext": "A finite $p$-group has nontrivial center (class equation: $|Z(G)| \\equiv |G| \\pmod p$), so its upper central series reaches $G$; nilpotent $\\Rightarrow$ derived series terminates $\\Rightarrow$ solvable. Solvability is strictly weaker than nilpotency: $S_3$ is solvable but not nilpotent.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-groups", "nilpotent groups", "class equation", "upper central series", "Sylow theory"],
+    "prerequisites": ["p-groups", "center of a group", "nilpotency"]
+  },
+  {
+    "id": "ann-extension",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 84, "endLine": 95 },
+    "type": "technique",
+    "title": "Inductive engine: extensions of solvable groups are solvable",
+    "content": "solvable_of_normal_extension is the reassembly step: given N ⊴ G with both N and G ⧸ N solvable, G is solvable. It is built from Mathlib's solvable_of_ker_le_range applied to the subgroup inclusion N ↪ G and the quotient projection G ↠ G ⧸ N. The hypothesis ker(mk') ≤ range(subtype) is discharged by rewriting with QuotientGroup.ker_mk' (the kernel of the projection is exactly N) and Subgroup.range_subtype (the range of the inclusion is exactly N), making the two coincide. This is the formal content of '1 → N → G → G/N → 1 short exact, with the ends solvable, gives the middle solvable'.",
+    "mathContext": "For a short exact sequence $1 \\to N \\to G \\to Q \\to 1$, solvability is an extension-closed property: $N, Q$ solvable $\\Rightarrow G$ solvable. Concretely $G^{(i)}$ projects into $Q^{(i)}$ and, once $Q^{(m)} = 1$, $G^{(m)} \\subseteq N$, whose derived series then terminates.",
+    "significance": "key",
+    "relatedConcepts": ["short exact sequence", "group extension", "derived series", "normal subgroup", "quotient group"],
+    "prerequisites": ["normal subgroups", "quotient groups", "exact sequences"]
+  },
+  {
+    "id": "ann-ordertwoprimes",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 97, "endLine": 106 },
+    "type": "definition",
+    "title": "OrderTwoPrimes: the pᵃqᵇ hypothesis as a divisibility predicate",
+    "content": "Rather than literally asserting |G| = pᵃqᵇ with existential exponents, the file encodes the hypothesis as OrderTwoPrimes p q G: every prime r dividing |G| equals p or q. This phrasing is deliberately chosen because it is automatically inherited by subgroups and quotients — their orders divide |G| (Lagrange / index arithmetic), so any prime dividing them already divides |G| and is therefore p or q. That closure under passing to N and G ⧸ N is exactly what a strong induction on |G| needs, and it sidesteps any need to track the exponents a, b through the recursion.",
+    "mathContext": "$|G| = p^a q^b \\iff \\forall r\\ \\text{prime},\\ r \\mid |G| \\Rightarrow r \\in \\{p, q\\}$. Closure: $H \\le G \\Rightarrow |H| \\mid |G|$ and $|G/N| \\mid |G|$, so the prime-divisor set only shrinks.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange's theorem", "prime factorization", "divisibility", "closure under subgroups and quotients"],
+    "prerequisites": ["Lagrange's theorem", "prime divisors", "predicates in Lean"]
+  },
+  {
+    "id": "ann-reduction-induction",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 108, "endLine": 138 },
+    "type": "insight",
+    "title": "The verified reduction: strong induction on |G|, non-simplicity as hypothesis",
+    "content": "burnside_reduces_to_nonsimplicity is the centerpiece. It takes as an explicit hypothesis `not_simple` — the (currently un-formalized) character-theoretic fact that every finite nonabelian pᵃqᵇ-group has a proper nontrivial normal subgroup — and proves that every finite pᵃqᵇ-group is solvable. The key formalization move (line 124) is to state the induction over an explicit order parameter: `∀ n, ∀ H, Nat.card H = n → …` and induct on n with Nat.strong_induction_on. A direct `induction (Nat.card H) generalizing H` is ill-formed because the measure |H| lives inside the type. The case split is clean: abelian groups are solvable outright (isSolvable_of_comm); a nonabelian group is nontrivial, so `not_simple` delivers the proper nontrivial normal N.",
+    "mathContext": "Strong induction schema: $\\big(\\forall n,\\ (\\forall m < n,\\ P(m)) \\Rightarrow P(n)\\big) \\Rightarrow \\forall n,\\ P(n)$, with $P(n) :=$ 'every finite $H$ with $|H| = n$ and OrderTwoPrimes is solvable'. Decomposing the type-internal measure into an external $n$ is the standard fix for well-founded recursion over a cardinality.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "well-founded recursion", "Nat.strong_induction_on", "universe-0 types", "simple groups"],
+    "prerequisites": ["mathematical induction", "dependent types", "simple groups"]
+  },
+  {
+    "id": "ann-strict-drops",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+    "range": { "startLine": 139, "endLine": 164 },
+    "type": "technique",
+    "title": "Strict order drops and reassembly via index arithmetic",
+    "content": "To apply the induction hypothesis to N and G ⧸ N, the proof must certify both are strictly smaller than G. N ≠ ⊤ gives index > 1 (one_lt_index_of_ne_top), and card_mul_index N (|N|·[G:N] = |G|) then yields |N| < |G|. Symmetrically N ≠ ⊥ gives |N| > 1, and index_mul_card N yields |G ⧸ N| = [G:N] < |G|. Divisibility (card_subgroup_dvd_card, card_quotient_dvd_card) transports OrderTwoPrimes to both pieces. The induction hypothesis then makes N and G ⧸ N solvable, and solvable_of_normal_extension reassembles G — closing the induction with zero sorries and zero axioms.",
+    "mathContext": "Lagrange/index identity: $|N| \\cdot [G : N] = |G| = [G : N] \\cdot |G/N|$. With $[G:N] > 1$ (from $N \\ne G$) and $|N| > 1$ (from $N \\ne 1$), both $|N| < |G|$ and $|G/N| < |G|$ strictly. Both orders divide $|G|$, preserving the two-prime condition.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange's theorem", "subgroup index", "card_mul_index", "strong induction measure", "group extension"],
+    "prerequisites": ["Lagrange's theorem", "subgroup index", "divisibility of orders"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-03-oq-01` (Toward Burnside's pᵃqᵇ theorem: verified reduction to non-simplicity).

## What changed
The entry had a rich `meta.json` (overview, sections, conclusion, cross-references) but **zero annotation coverage**. This PR adds `annotations.json` with 7 substantive annotations spanning the full 166-line Lean file:

1. **Imports** — the four Mathlib group-theory modules and why no representation-theory module appears (the character-theoretic core is the missing piece).
2. **Header / target** — what Burnside's pᵃqᵇ theorem says and the explicit scope disclaimer that the unconditional theorem is *not* claimed.
3. **Base case** — prime-power order ⟹ p-group ⟹ nilpotent ⟹ solvable.
4. **Extension engine** — `solvable_of_normal_extension` as the short-exact-sequence reassembly step.
5. **OrderTwoPrimes** — the divisibility-predicate encoding of the pᵃqᵇ hypothesis, chosen for closure under subgroups/quotients.
6. **The verified reduction** — strong induction on |G| with non-simplicity isolated as an explicit hypothesis; the universe-0 / external-order-parameter formalization trick.
7. **Strict drops** — index arithmetic certifying |N| < |G| and |G⧸N| < |G| for the induction.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Axiom integrity
No changes to `status`/`badge`/`axiomCount`. The entry remains `verified` (0 sorries, 0 axioms) with the character-theoretic core correctly held as an explicit hypothesis of `burnside_reduces_to_nonsimplicity`, not an axiom — the annotations reinforce this framing.

## Build
`tsc -b` and `vite build` both pass; `gallery:check-size` and `annotations:build` clean. (Worktree needed `pnpm install --ignore-scripts` to bypass an unrelated `better-sqlite3` native-build failure under Node v26.)