### PR TITLE
research(fourier-divergence): verified resonance principle for Fourier series divergence

### DIFF
--- a/proofs/Proofs/FourierDivergenceResonance.lean
+++ b/proofs/Proofs/FourierDivergenceResonance.lean
@@ -1,0 +1,95 @@
+import Mathlib.Analysis.Normed.Operator.BanachSteinhaus
+
+/-!
+# Resonance Principle for Fourier Series Divergence (functional-analysis core)
+
+## The Target
+
+A classical application of the Banach–Steinhaus theorem (uniform boundedness
+principle): **there exists a continuous `2π`-periodic function whose Fourier series
+diverges at a point.** The standard proof considers the partial-sum-at-`0`
+functionals `Sₙ : C(𝕋) → ℂ`, `Sₙ f = (Sₙf)(0) = ∫ f · Dₙ` (`Dₙ` the Dirichlet
+kernel), observes that `‖Sₙ‖ = ‖Dₙ‖_{L¹}` (the *Lebesgue constants*) and that
+`‖Dₙ‖_{L¹} → ∞`, and then invokes uniform boundedness in its contrapositive form: a
+sequence of bounded functionals whose operator norms are unbounded must have a point
+of **resonance** — a function `f` whose orbit `‖Sₙ f‖` is unbounded, i.e. whose
+Fourier series diverges at `0`.
+
+## What This File Provides (fully verified, no `sorry`, no `axiom`)
+
+Mathlib has the Banach–Steinhaus theorem (`banach_steinhaus`) but **not** the
+Dirichlet kernel, the Lebesgue constants, or their divergence. This file isolates and
+verifies the **functional-analysis core** of the divergence argument — the resonance
+principle — in a form ready to be applied once the analytic input `‖Dₙ‖_{L¹} → ∞`
+is available:
+
+* `exists_unbounded_orbit_of_not_bddAbove_norm` — the **contrapositive of uniform
+  boundedness**: for continuous linear maps `g i : E →L[𝕜] F` on a Banach space `E`,
+  if the operator norms `{‖g i‖}` are not bounded above, then there is a point `x`
+  whose orbit `{‖g i x‖}` is not bounded above.
+* `exists_unbounded_orbit_of_tendsto_norm_atTop` — the sequential corollary used in
+  the Fourier application: if `‖g n‖ → ∞`, then some `x` has unbounded orbit.
+
+Applying the second result with `E = C(𝕋)`, `g n = Sₙ`, and the (still-missing in
+Mathlib) fact `‖Sₙ‖ = ‖Dₙ‖_{L¹} → ∞` immediately yields a continuous function with
+divergent Fourier series at `0`. The only gap is the analytic estimate on the
+Lebesgue constants; the functional-analysis half is complete and machine-checked.
+
+## Mathlib Dependencies
+
+- `banach_steinhaus` : pointwise-bounded family of CLMs on a Banach space is
+  uniformly norm-bounded (`Mathlib.Analysis.Normed.Operator.BanachSteinhaus`)
+- `Filter.Tendsto.eventually_gt_atTop` : `f → ∞` eventually exceeds any constant
+
+## Status
+
+`verified` — every declaration is machine-checked with no `sorry` and no `axiom`.
+The full Fourier-divergence theorem is *not* claimed; see
+`research/problems/banach-steinhaus-theorem-oq-01-oq-01/knowledge.md`.
+-/
+
+open Filter Topology Set
+
+namespace FourierDivergenceResonance
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- **Resonance principle** (contrapositive of the uniform boundedness principle).
+
+If a family of continuous linear maps `g i : E →L[𝕜] F` out of a Banach space `E` has
+operator norms `{‖g i‖}` that are *not* bounded above, then there exists a single
+point `x : E` whose orbit `{‖g i x‖}` is *not* bounded above.
+
+This is exactly the form of Banach–Steinhaus used to produce a continuous function
+with divergent Fourier series: unbounded Lebesgue constants force a resonating `f`. -/
+theorem exists_unbounded_orbit_of_not_bddAbove_norm {ι : Type*}
+    {g : ι → E →L[𝕜] F} (h : ¬ BddAbove (range fun i => ‖g i‖)) :
+    ∃ x, ¬ BddAbove (range fun i => ‖g i x‖) := by
+  by_contra hcon
+  push_neg at hcon
+  -- `hcon : ∀ x, BddAbove (range fun i => ‖g i x‖)` — the family is pointwise bounded.
+  apply h
+  -- Repackage pointwise boundedness in the shape `banach_steinhaus` expects.
+  have hpt : ∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C := by
+    intro x
+    obtain ⟨C, hC⟩ := hcon x
+    exact ⟨C, fun i => hC (mem_range_self i)⟩
+  -- Uniform boundedness then bounds the operator norms.
+  obtain ⟨C', hC'⟩ := banach_steinhaus hpt
+  exact ⟨C', by rintro _ ⟨i, rfl⟩; exact hC' i⟩
+
+/-- Sequential form of the resonance principle, as used for Fourier divergence: if the
+operator norms of `g n : E →L[𝕜] F` tend to infinity, some point `x` has an unbounded
+orbit `{‖g n x‖}`. -/
+theorem exists_unbounded_orbit_of_tendsto_norm_atTop
+    {g : ℕ → E →L[𝕜] F} (h : Tendsto (fun n => ‖g n‖) atTop atTop) :
+    ∃ x, ¬ BddAbove (range fun n => ‖g n x‖) := by
+  refine exists_unbounded_orbit_of_not_bddAbove_norm ?_
+  rintro ⟨C, hC⟩
+  -- `hC` bounds every `‖g n‖` by `C`, contradicting `‖g n‖ → ∞`.
+  obtain ⟨n, hn⟩ := (h.eventually_gt_atTop C).exists
+  exact absurd (hC (mem_range_self n)) (not_le.2 hn)
+
+end FourierDivergenceResonance

--- a/research/problems/banach-steinhaus-theorem-oq-01-oq-01/knowledge.md
+++ b/research/problems/banach-steinhaus-theorem-oq-01-oq-01/knowledge.md
@@ -1,0 +1,87 @@
+# Fourier Series Divergence via Uniform Boundedness (banach-steinhaus-theorem-oq-01-oq-01)
+
+## Problem Summary
+
+Formalize the classical application of the Banach–Steinhaus (uniform boundedness)
+theorem: **there exists a continuous `2π`-periodic function whose Fourier series
+diverges at a point.** The route is the resonance form of uniform boundedness applied
+to the partial-sum-at-`0` functionals `Sₙ : C(𝕋) → ℂ`, using that their operator norms
+— the Lebesgue constants `‖Sₙ‖ = ‖Dₙ‖_{L¹}` — tend to infinity.
+
+## The Standard Proof (4 steps)
+
+1. **Functionals.** For `f ∈ C(𝕋)` (continuous `2π`-periodic, sup norm), the `n`-th
+   symmetric partial sum at `0` is `Sₙ f = ∑_{|k|≤n} f̂(k) = (1/2π)∫_{-π}^{π} f(t) Dₙ(t) dt`,
+   where `Dₙ(t) = ∑_{|k|≤n} e^{ikt} = sin((n+½)t)/sin(t/2)` is the Dirichlet kernel.
+   Each `Sₙ` is a bounded linear functional on the Banach space `C(𝕋)`.
+2. **Operator norm = Lebesgue constant.** `‖Sₙ‖ = (1/2π)‖Dₙ‖_{L¹([-π,π])} =: Lₙ`
+   (the supremum is attained in the limit by functions approximating `sgn Dₙ`).
+3. **Lebesgue constants diverge.** `Lₙ = (4/π²) log n + O(1) → ∞`. The clean lower
+   bound `Lₙ ≥ c·log n` comes from `∫|sin((n+½)t)/sin(t/2)| dt ≥ ∑_{k} (1/kπ)∫|sin| ≍ log n`.
+4. **Resonance.** `C(𝕋)` is complete, so by the contrapositive of Banach–Steinhaus a
+   family of functionals with `sup_n ‖Sₙ‖ = ∞` cannot be pointwise bounded: there is
+   `f ∈ C(𝕋)` with `sup_n |Sₙ f| = ∞`, i.e. the Fourier series of `f` diverges at `0`.
+
+## Mathlib Status (v4.26.0) — Gap Analysis
+
+**Has:**
+- `banach_steinhaus` — uniform boundedness principle for CLMs out of a complete space
+  (`Mathlib.Analysis.Normed.Operator.BanachSteinhaus`).
+- `fourierCoeff`, Fourier series on `AddCircle T`, `L²` convergence, Parseval
+  (`Mathlib.Analysis.Fourier.AddCircle`).
+- `C(X, ℂ)` / `BoundedContinuousFunction` as a Banach space (sup norm, complete).
+
+**Lacks (the analytic core — the genuine blocker):**
+- The **Dirichlet kernel** `Dₙ` and its closed form.
+- The **partial-sum functionals `Sₙ` as bounded operators** on `C(𝕋)`, and the identity
+  `‖Sₙ‖ = ‖Dₙ‖_{L¹}`.
+- **Divergence of the Lebesgue constants** `‖Dₙ‖_{L¹} → ∞` (the `log n` lower bound).
+
+Steps 1–3 are a real formalization project (estimating the `L¹` norm of `Dₙ` from
+below by a logarithm is the crux). Step 4 is pure functional analysis and is the part
+done here.
+
+## Approach Taken — Verified Functional-Analysis Core (step 4)
+
+`proofs/Proofs/FourierDivergenceResonance.lean` isolates and proves the resonance
+principle that step 4 needs, in reusable abstract form:
+
+- `exists_unbounded_orbit_of_not_bddAbove_norm` — contrapositive of `banach_steinhaus`:
+  CLMs `g i : E →L[𝕜] F` on a Banach space `E` with `{‖g i‖}` unbounded above ⟹ some
+  `x` has `{‖g i x‖}` unbounded above.
+- `exists_unbounded_orbit_of_tendsto_norm_atTop` — sequential corollary: `‖g n‖ → ∞`
+  ⟹ some `x` has unbounded orbit. This is exactly what consumes the Lebesgue-constant
+  divergence: instantiate `E = C(𝕋)`, `g n = Sₙ`, `‖g n‖ = Lₙ → ∞` to get a continuous
+  `f` with divergent Fourier series at `0`.
+
+Mirrors the "reduce to an explicit hypothesis, don't axiomatize" pattern: the verified
+core is the resonance principle; the missing analysis (`Lₙ → ∞`) is documented, not
+assumed inside an axiom.
+
+### Lean notes
+- Contrapositive via `by_contra` + `push_neg` turns the goal into the pointwise-bounded
+  hypothesis of `banach_steinhaus`; repackage `BddAbove (range …)` ↔ `∃ C, ∀ i, … ≤ C`
+  with `mem_range_self` / `rintro ⟨i, rfl⟩`.
+- Sequential corollary: `‖g n‖ → ∞` contradicts any bound `C` via
+  `(h.eventually_gt_atTop C).exists`.
+
+## Session 2026-06-26 (Session 1)
+
+**Mode:** FRESH (EMPTY tier; prior `problem.md`/`state.md` present but phase NEW, 0 attempts).
+**Outcome:** progress — verified resonance core drafted; analytic core (Lebesgue
+constants) BLOCKED on missing Mathlib infrastructure.
+
+**BUILD STATUS:** VERIFIED — `./proofs/scripts/docker-build.sh
+Proofs.FourierDivergenceResonance` → Build succeeded (1787 jobs), 0 sorries, 0 axioms.
+(The build host was transiently unstable mid-session — Docker Desktop OOM-killed
+containers when its VM dropped to 7.65 GiB; resolved after a clean restart returned the
+VM to 23 GiB.) Gallery `meta.json` added (status `verified`, scoped to the
+functional-analysis core only).
+
+### Next Steps
+1. Build the analytic core in Mathlib/local file: Dirichlet kernel `Dₙ`, the operator
+   `Sₙ` on `C(𝕋)`, `‖Sₙ‖ = ‖Dₙ‖_{L¹}`, and the `log n` lower bound `Lₙ → ∞`.
+3. Compose: `exists_unbounded_orbit_of_tendsto_norm_atTop` + `Lₙ → ∞` ⟹ continuous
+   function with Fourier series diverging at `0`.
+4. Candidate Aristotle target: the Lebesgue-constant lower bound
+   `∫_{-π}^{π} |sin((n+½)t)/sin(t/2)| dt ≥ c·log n`.

--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "banach-steinhaus-theorem-oq-01-oq-01",
+  "title": "Resonance principle for Fourier divergence (functional-analysis core)",
+  "slug": "banach-steinhaus-theorem-oq-01-oq-01",
+  "description": "The classical proof that some continuous 2π-periodic function has a Fourier series diverging at a point runs through the resonance (contrapositive) form of the Banach–Steinhaus uniform boundedness principle, applied to the partial-sum functionals Sₙ : C(𝕋) → ℂ whose operator norms — the Lebesgue constants ‖Sₙ‖ = ‖Dₙ‖_L¹ — diverge. This entry isolates and verifies (0 sorries, 0 axioms) the functional-analysis core of that argument as a reusable abstract resonance principle: exists_unbounded_orbit_of_not_bddAbove_norm shows that continuous linear maps g i : E →L[𝕜] F on a Banach space E with operator norms unbounded above must admit a point x whose orbit {‖g i x‖} is unbounded; exists_unbounded_orbit_of_tendsto_norm_atTop is the sequential corollary (‖g n‖ → ∞ ⟹ some x resonates). Instantiating E = C(𝕋), g n = Sₙ, and the Lebesgue-constant divergence ‖Sₙ‖ → ∞ yields a continuous function with divergent Fourier series at 0. The analytic input (divergence of the Lebesgue constants) is the documented Mathlib gap; the functional-analysis half is complete and machine-checked.",
+  "meta": {
+    "author": "Banach, Steinhaus (1927); du Bois-Reymond (1876, divergence example); Lean formalization original (researcher-6)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FourierDivergenceResonance.lean",
+    "tags": [
+      "functional-analysis",
+      "banach-steinhaus",
+      "uniform-boundedness",
+      "fourier-series",
+      "resonance",
+      "operator-norm",
+      "baire-category",
+      "analysis",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None — every declaration is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only), built on Mathlib's banach_steinhaus. SCOPE: this entry proves only the functional-analysis CORE (the resonance principle / contrapositive of uniform boundedness), not the full Fourier-divergence theorem. The analytic input it consumes — the divergence of the Lebesgue constants ‖Sₙ‖ = ‖Dₙ‖_L¹ → ∞, together with the Dirichlet kernel and the partial-sum operators on C(𝕋) — is not present in Mathlib v4.26.0 and is documented as the remaining gap in research/problems/banach-steinhaus-theorem-oq-01-oq-01/knowledge.md.",
+    "mathlibDependencies": [
+      {
+        "theorem": "banach_steinhaus",
+        "description": "Uniform boundedness principle: a pointwise-bounded family of continuous linear maps out of a Banach space is uniformly norm-bounded",
+        "module": "Mathlib.Analysis.Normed.Operator.BanachSteinhaus"
+      },
+      {
+        "theorem": "Filter.Tendsto.eventually_gt_atTop",
+        "description": "A function tending to atTop eventually exceeds any fixed constant",
+        "module": "Mathlib.Order.Filter.AtTopBot"
+      }
+    ],
+    "originalContributions": [
+      "exists_unbounded_orbit_of_not_bddAbove_norm: the resonance principle — CLMs on a Banach space with operator norms unbounded above admit a point of unbounded orbit (contrapositive of banach_steinhaus, packaged with BddAbove)",
+      "exists_unbounded_orbit_of_tendsto_norm_atTop: sequential corollary used in the Fourier application — ‖g n‖ → ∞ ⟹ some x has unbounded orbit"
+    ],
+    "lineCount": 95,
+    "theoremCount": 2,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "path": "Proofs/FourierDivergenceResonance.lean",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 2
+  },
+  "overview": {
+    "historicalContext": "Paul du Bois-Reymond exhibited in 1876 a continuous function whose Fourier series diverges at a point, a striking limit on pointwise convergence. The modern, conceptual proof came with the Banach–Steinhaus theorem (Stefan Banach and Hugo Steinhaus, 1927), one of the cornerstones of functional analysis: a pointwise-bounded family of bounded operators out of a Banach space is uniformly bounded. Its contrapositive — the 'condensation of singularities' or resonance principle — converts a quantitative blow-up of operator norms into the existence of a single resonating input. For Fourier series, the operators are the partial-sum functionals Sₙ on C(𝕋), their norms are the Lebesgue constants ‖Dₙ‖_L¹ ≈ (4/π²) log n, and the resonance principle hands back a continuous function whose Fourier partial sums at 0 are unbounded.",
+    "problemStatement": "Formalize the functional-analysis step of the Fourier-divergence argument: from a sequence of continuous linear functionals on a Banach space whose operator norms are unbounded (the Lebesgue constants), produce a point whose orbit is unbounded — the resonance form of Banach–Steinhaus.",
+    "proofStrategy": "Take the contrapositive of Mathlib's banach_steinhaus. If no point had unbounded orbit, the family would be pointwise bounded; banach_steinhaus would then bound the operator norms uniformly, contradicting their unboundedness. The sequential corollary specializes 'unbounded operator norms' to '‖g n‖ → ∞', which is the exact shape the Lebesgue-constant divergence supplies in the Fourier application.",
+    "keyInsights": [
+      "The resonance principle is precisely the contrapositive of uniform boundedness; by_contra + push_neg reduces the goal to the pointwise-bounded hypothesis banach_steinhaus consumes.",
+      "Phrasing boundedness as BddAbove (range …) keeps the statements idiomatic and the bridge to '∃ C, ∀ i, … ≤ C' is just mem_range_self / rintro ⟨i, rfl⟩.",
+      "Stating the core for an arbitrary index type and a separate ℕ-sequence corollary keeps it reusable: the corollary is what the Fourier divergence proof actually calls with ‖Sₙ‖ → ∞.",
+      "Isolating the analytic input (Lebesgue constants) outside the verified core, rather than baking it into an axiom, keeps the contribution honest and pinpoints the Mathlib gap."
+    ],
+    "prerequisites": [
+      "Banach spaces and continuous linear maps (operator norm)",
+      "The Banach–Steinhaus / uniform boundedness theorem",
+      "Filters and limits to atTop (for the sequential corollary)",
+      "Fourier series and the Dirichlet kernel (for the intended application)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "resonance-core",
+      "title": "Resonance principle (contrapositive of uniform boundedness)",
+      "startLine": 60,
+      "endLine": 84,
+      "summary": "exists_unbounded_orbit_of_not_bddAbove_norm: for g i : E →L[𝕜] F on a Banach space E, if {‖g i‖} is not bounded above then some x has {‖g i x‖} not bounded above. Proved by by_contra/push_neg reducing to pointwise boundedness and invoking banach_steinhaus."
+    },
+    {
+      "id": "sequential-corollary",
+      "title": "Sequential corollary for Fourier divergence",
+      "startLine": 85,
+      "endLine": 95,
+      "summary": "exists_unbounded_orbit_of_tendsto_norm_atTop: if ‖g n‖ → ∞ then some x has unbounded orbit. The bound contradicts ‖g n‖ → ∞ via eventually_gt_atTop. This is the form consumed by ‖Sₙ‖ = Lebesgue constant → ∞ to yield a continuous function with divergent Fourier series."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes, with zero sorries and zero axioms, the functional-analysis core of the classical du Bois-Reymond / Banach–Steinhaus proof that a continuous function can have a divergent Fourier series: the resonance principle that turns unbounded operator norms into a resonating input. It does not claim the full divergence theorem.",
+    "implications": "Combined with the divergence of the Lebesgue constants ‖Dₙ‖_L¹ → ∞ — the one missing analytic ingredient — the sequential corollary immediately produces a continuous 2π-periodic function whose Fourier series diverges at 0. The verified core is ready to receive that input.",
+    "openQuestions": [
+      "Formalize the Dirichlet kernel Dₙ and the partial-sum functionals Sₙ : C(𝕋) → ℂ in Mathlib, with ‖Sₙ‖ = ‖Dₙ‖_L¹.",
+      "Prove the Lebesgue-constant lower bound ‖Dₙ‖_L¹ ≥ c·log n (hence → ∞).",
+      "Compose with exists_unbounded_orbit_of_tendsto_norm_atTop to obtain the unconditional Fourier-divergence theorem."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "related-to",
+      "description": "Both reduce a hard classical theorem missing from Mathlib to a verified core plus a single documented analytic/algebraic input rather than axiomatizing it",
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-03-oq-01"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Problem **banach-steinhaus-theorem-oq-01-oq-01** — *"Fourier series divergence via uniform boundedness"* (fresh / EMPTY tier).

The classical du Bois-Reymond / Banach–Steinhaus proof that some continuous `2π`-periodic function has a Fourier series **diverging at a point** runs through the contrapositive (resonance) form of the uniform boundedness principle, applied to the partial-sum functionals `Sₙ : C(𝕋) → ℂ` whose operator norms — the Lebesgue constants `‖Sₙ‖ = ‖Dₙ‖_{L¹} ≈ (4/π²)log n` — diverge. This PR isolates and verifies the **functional-analysis core** of that argument.

## What's verified (`proofs/Proofs/FourierDivergenceResonance.lean`, builds against Mathlib v4.26.0)

| Result | Role |
|---|---|
| `exists_unbounded_orbit_of_not_bddAbove_norm` | **resonance principle** — contrapositive of `banach_steinhaus`: CLMs `g i : E →L[𝕜] F` on a Banach space with `{‖g i‖}` unbounded above ⟹ some `x` has `{‖g i x‖}` unbounded above |
| `exists_unbounded_orbit_of_tendsto_norm_atTop` | sequential corollary — `‖g n‖ → ∞` ⟹ some `x` resonates |

Instantiating `E = C(𝕋)`, `g n = Sₙ`, `‖Sₙ‖ → ∞` immediately gives a continuous function with divergent Fourier series at `0`.

## Honest scope

This PR proves the **functional-analysis core only**, not the full divergence theorem. The analytic input it consumes — the Dirichlet kernel, the operators `Sₙ` on `C(𝕋)`, and the Lebesgue-constant divergence `‖Dₙ‖_{L¹} → ∞` — is **not in Mathlib v4.26.0** and is documented as the remaining gap in `knowledge.md` (taken as the consumed hypothesis, **not an axiom**). Gallery entry is marked `verified` / `original` with `assumptions` spelling out the scope.

## Verification

`./proofs/scripts/docker-build.sh Proofs.FourierDivergenceResonance` → **Build succeeded** (1787 jobs); 2 theorems, 0 axioms, 0 sorries. Gallery size check passes (8.7 KB ≤ 60 KB).

## Files
- `proofs/Proofs/FourierDivergenceResonance.lean` (new, 95 lines)
- `src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json` (new gallery entry)
- `research/problems/banach-steinhaus-theorem-oq-01-oq-01/knowledge.md` (new — full roadmap + Mathlib gap analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)