### PR TITLE
Enrich Erdős #396 Catalan telescoping-product: sections + deeper annotations

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/annotations.json
@@ -1,50 +1,92 @@
 [
   {
+    "id": "ann-e396oq04oq01oq01oq01-header",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "The multiplicative view of the Catalan recurrence",
+    "content": "This entry sits in a chain of follow-ups to Erdős #396. The grandparent (Erdos396OQ04OQ01) reads the two-term Catalan recurrence through its ratio $r_n = (4n+2)/(n+2) = 4 - 6/(n+2)$, with $\\mathrm{catalan}(n+1) = r_n\\cdot\\mathrm{catalan}\\,n$; the parent (OQ-01→OQ-01) studies the *additive* running total $\\sum_{k<n} r_k = 4n - 6(H_{n+1}-1)$. This file answers the grandparent's first open question by taking the **multiplicative** view: because each recurrence step is a multiplication by $r_k$, the recurrence telescopes into a closed product. Everything is derived from the grandparent's ratio identities — no Stirling estimate, no central-binomial bound.",
+    "mathContext": "$\\mathrm{catalan}\\,n = \\frac{1}{n+1}\\binom{2n}{n}$, with $\\mathrm{catalan}(n+1) = r_n\\cdot\\mathrm{catalan}\\,n$ and $r_n = \\frac{4n+2}{n+2}$. Asymptotically $\\mathrm{catalan}\\,n \\sim \\frac{4^n}{n^{3/2}\\sqrt\\pi}$.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan numbers", "two-term recurrence", "telescoping product", "additive vs multiplicative views", "Erdős problem #396"],
+    "prerequisites": ["Catalan numbers", "recurrence relations", "finite products"]
+  },
+  {
     "id": "ann-e396oq04oq01oq01oq01-telescope",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
     "range": {
       "startLine": 55,
-      "endLine": 65
+      "endLine": 75
     },
     "type": "key-step",
     "title": "The recurrence telescopes into a closed product",
-    "content": "`catalan_eq_prod_ratio` proves $(\\mathrm{catalan}\\,n : \\mathbb{R}) = \\prod_{k<n} r_k$ where $r_k = (4k+2)/(k+2)$. The proof is a one-line induction: `Finset.prod_range_succ` peels off the top factor $r_m$, and the grandparent's quotient identity $\\mathrm{catalan}(m+1) = r_m\\cdot\\mathrm{catalan}\\,m$ matches it, closed by `ring`. Because every step of the recurrence is exactly a multiplication by $r_k$, iterating it collapses to a finite product — the multiplicative companion of the parent's additive identity $\\sum_{k<n} r_k = 4n - 6(H_{n+1}-1)$.",
-    "mathContext": "$(\\mathrm{catalan}\\,n : \\mathbb{R}) = \\prod_{k<n}\\frac{4k+2}{k+2}$"
+    "content": "`catalan_eq_prod_ratio` proves $(\\mathrm{catalan}\\,n : \\mathbb{R}) = \\prod_{k<n} r_k$ where $r_k = (4k+2)/(k+2)$. The proof is a one-line induction: `Finset.prod_range_succ` peels off the top factor $r_m$, and the grandparent's quotient identity $\\mathrm{catalan}(m+1) = r_m\\cdot\\mathrm{catalan}\\,m$ matches it, closed by `ring`. Because every step of the recurrence is exactly a multiplication by $r_k$, iterating it collapses to a finite product — the multiplicative companion of the parent's additive identity $\\sum_{k<n} r_k = 4n - 6(H_{n+1}-1)$. `prod_ratio_pos` records that the product is strictly positive (`Finset.prod_pos` over `ratio_pos`), the fact every later step relies on.",
+    "mathContext": "$(\\mathrm{catalan}\\,n : \\mathbb{R}) = \\prod_{k<n}\\frac{4k+2}{k+2}$",
+    "significance": "key",
+    "relatedConcepts": ["telescoping product", "Finset.prod_range_succ", "induction", "Catalan recurrence", "ratio_pos"],
+    "prerequisites": ["mathematical induction", "finite products over Finset.range"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01-logbridge",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 79,
+      "startLine": 77,
       "endLine": 88
     },
     "type": "insight",
     "title": "Logarithms bridge the sum and product views",
-    "content": "`log_catalan_eq_sum_log_ratio` gives $\\log(\\mathrm{catalan}\\,n) = \\sum_{k<n}\\log(r_k)$ via `Real.log_prod` applied to the telescoping product (each factor is nonzero by the grandparent's `ratio_pos`). This is the precise link between this entry's multiplicative identity and the parent's additive running total: the logarithm of the product is the sum of the log-ratios.",
-    "mathContext": "$\\log(\\mathrm{catalan}\\,n) = \\sum_{k<n}\\log\\frac{4k+2}{k+2}$"
+    "content": "`log_catalan_eq_sum_log_ratio` gives $\\log(\\mathrm{catalan}\\,n) = \\sum_{k<n}\\log(r_k)$ via `Real.log_prod` applied to the telescoping product (each factor is nonzero by the grandparent's `ratio_pos`). This is the precise link between this entry's multiplicative identity and the parent's additive running total: the logarithm of the product is the sum of the log-ratios. It is the formal reason the additive and multiplicative readings of the recurrence are two sides of one coin — $\\log$ is the homomorphism carrying $(\\mathbb{R}_{>0},\\times)$ to $(\\mathbb{R},+)$.",
+    "mathContext": "$\\log(\\mathrm{catalan}\\,n) = \\sum_{k<n}\\log\\frac{4k+2}{k+2}$",
+    "significance": "key",
+    "relatedConcepts": ["logarithm of a product", "Real.log_prod", "group homomorphism", "harmonic sum", "additive–multiplicative duality"],
+    "prerequisites": ["properties of logarithms", "finite sums and products"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01-strictanti",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
     "range": {
       "startLine": 90,
-      "endLine": 125
+      "endLine": 124
     },
     "type": "key-step",
     "title": "The normalized sequence catalan n / 4^n is strictly decreasing",
-    "content": "`catalan_div_four_pow_eq_prod` writes $\\mathrm{catalan}\\,n / 4^n = \\prod_{k<n}(r_k/4)$ by distributing the division over the product (`Finset.prod_div_distrib`, with $\\prod_{k<n} 4 = 4^n$). Every factor satisfies $r_k/4 < 1$ (`ratio_div_four_lt_one`, from the grandparent's $r_k < 4$). Factoring out one step gives $\\mathrm{catalan}(n+1)/4^{n+1} = (r_n/4)\\cdot(\\mathrm{catalan}\\,n/4^n)$, so `catalan_div_four_pow_strictAnti` concludes strict decrease via `mul_lt_mul_of_pos_right`: multiplying a positive quantity by a factor below 1 strictly shrinks it. This is the multiplicative, recurrence-level shadow of the polynomial correction $1/(n^{3/2}\\sqrt\\pi)$ below the bare exponential $4^n$.",
-    "mathContext": "$\\frac{\\mathrm{catalan}(n+1)}{4^{n+1}} < \\frac{\\mathrm{catalan}\\,n}{4^n}$"
+    "content": "`catalan_div_four_pow_eq_prod` writes $\\mathrm{catalan}\\,n / 4^n = \\prod_{k<n}(r_k/4)$ by distributing the division over the product (`Finset.prod_div_distrib`, with $\\prod_{k<n} 4 = 4^n$). Every factor satisfies $r_k/4 < 1$ (`ratio_div_four_lt_one`, from the grandparent's $r_k < 4$). Factoring out one step (`catalan_div_four_pow_succ`) gives $\\mathrm{catalan}(n+1)/4^{n+1} = (r_n/4)\\cdot(\\mathrm{catalan}\\,n/4^n)$, so `catalan_div_four_pow_strictAnti` concludes strict decrease via `mul_lt_mul_of_pos_right`: multiplying a positive quantity by a factor below 1 strictly shrinks it. This is the multiplicative, recurrence-level shadow of the polynomial correction $1/(n^{3/2}\\sqrt\\pi)$ below the bare exponential $4^n$.",
+    "mathContext": "$\\frac{\\mathrm{catalan}(n+1)}{4^{n+1}} = \\frac{r_n}{4}\\cdot\\frac{\\mathrm{catalan}\\,n}{4^n} < \\frac{\\mathrm{catalan}\\,n}{4^n}$",
+    "significance": "key",
+    "relatedConcepts": ["normalized sequence", "strict monotonicity", "Finset.prod_div_distrib", "mul_lt_mul_of_pos_right", "asymptotic correction factor"],
+    "prerequisites": ["monotone sequences", "inequalities on products", "real exponentiation"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01-prodbound",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
     "range": {
-      "startLine": 127,
-      "endLine": 145
+      "startLine": 125,
+      "endLine": 144
     },
     "type": "key-step",
     "title": "The 4^n growth bound as a strict product inequality",
-    "content": "`prod_ratio_lt_four_pow` proves $\\prod_{k<n} r_k < 4^n$ for $n\\ge 1$ using `Finset.prod_lt_prod_of_nonempty`: every factor is positive (`ratio_pos`) and strictly below 4 (`ratio_lt_four`), and the range is nonempty. Combined with the telescoping identity this recovers the grandparent's bound $\\mathrm{catalan}\\,n < 4^n$ — now multiplicatively, as a strict product comparison rather than by induction.",
-    "mathContext": "$\\prod_{k<n} r_k < \\prod_{k<n} 4 = 4^n,\\quad n\\ge 1$"
+    "content": "`prod_ratio_lt_four_pow` proves $\\prod_{k<n} r_k < 4^n$ for $n\\ge 1$ using `Finset.prod_lt_prod_of_nonempty`: every factor is positive (`ratio_pos`) and strictly below 4 (`ratio_lt_four`), and the range is nonempty. Combined with the telescoping identity, `catalan_lt_four_pow_of_prod` recovers the grandparent's bound $\\mathrm{catalan}\\,n < 4^n$ — now multiplicatively, as a strict factor-by-factor product comparison rather than by induction. The $n\\ge 1$ hypothesis is essential: at $n=0$ both sides equal 1, so strictness fails.",
+    "mathContext": "$\\prod_{k<n} r_k < \\prod_{k<n} 4 = 4^n,\\quad n\\ge 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["growth bound", "Finset.prod_lt_prod_of_nonempty", "strict product inequality", "ratio_lt_four", "exponential bound 4^n"],
+    "prerequisites": ["inequalities on finite products", "nonempty Finset.range"]
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq01-sanity",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 160
+    },
+    "type": "context",
+    "title": "Numerical sanity checks",
+    "content": "Two worked `example`s pin the identities to concrete numbers, expanding the product symbolically with repeated `Finset.prod_range_succ` and unfolding `catalanRatio`. The first confirms $\\prod_{k<3} r_k = r_0\\cdot r_1\\cdot r_2 = 1\\cdot 2\\cdot\\tfrac52 = 5 = \\mathrm{catalan}\\,3$; the second confirms the normalized value $\\mathrm{catalan}\\,3 / 4^3 = 5/64$. These guard against off-by-one and indexing errors in the telescoping definitions and make the abstract product identity tangible.",
+    "mathContext": "$r_0\\cdot r_1\\cdot r_2 = 1\\cdot 2\\cdot\\tfrac52 = 5,\\qquad \\frac{\\mathrm{catalan}\\,3}{4^3} = \\frac{5}{64}$",
+    "significance": "technical",
+    "relatedConcepts": ["worked examples", "regression test", "catalanRatio", "Finset.prod_range_succ"],
+    "prerequisites": ["evaluation of finite products"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01/meta.json
@@ -45,6 +45,43 @@
       "Real logarithm of a product (Real.log_prod)"
     ]
   },
+  "sections": [
+    {
+      "id": "telescoping-product",
+      "title": "The telescoping product",
+      "startLine": 53,
+      "endLine": 75,
+      "summary": "catalan_eq_prod_ratio: (catalan n : ℝ) = ∏_{k<n} r k by a one-line induction (Finset.prod_range_succ + the grandparent's catalan_succ_eq_ratio_mul, closed by ring). prod_ratio_pos gives strict positivity (Finset.prod_pos, ratio_pos), and catalan_div_four_pow_pos records catalan n / 4^n > 0."
+    },
+    {
+      "id": "sum-product-bridge",
+      "title": "The sum–product bridge",
+      "startLine": 77,
+      "endLine": 86,
+      "summary": "log_catalan_eq_sum_log_ratio: log(catalan n) = ∑_{k<n} log(r k) via Real.log_prod on the telescoping product (each factor nonzero by ratio_pos), tying this multiplicative identity to the parent's additive running total of the ratios."
+    },
+    {
+      "id": "normalized-sequence",
+      "title": "The normalized sequence catalan n / 4^n",
+      "startLine": 88,
+      "endLine": 123,
+      "summary": "ratio_div_four_lt_one (r n / 4 < 1 from ratio_lt_four); catalan_div_four_pow_eq_prod (= ∏_{k<n} r k/4 by Finset.prod_div_distrib + ∏ 4 = 4^n); catalan_div_four_pow_succ factors out one step; catalan_div_four_pow_strictAnti concludes strict decrease via mul_lt_mul_of_pos_right."
+    },
+    {
+      "id": "growth-bound-product",
+      "title": "Growth bound, product form",
+      "startLine": 125,
+      "endLine": 144,
+      "summary": "prod_ratio_lt_four_pow: ∏_{k<n} r k < 4^n (n ≥ 1) via Finset.prod_lt_prod_of_nonempty (every factor positive and < 4); catalan_lt_four_pow_of_prod recovers the grandparent's catalan n < 4^n multiplicatively rather than by induction."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity checks",
+      "startLine": 146,
+      "endLine": 160,
+      "summary": "Two worked examples confirm the identities numerically: ∏_{k<3} r k = 1·2·(5/2) = 5 = catalan 3, and catalan 3 / 4^3 = 5/64."
+    }
+  ],
   "conclusion": {
     "summary": "The Catalan recurrence multiplies by r k = (4k+2)/(k+2) at each step, so it telescopes into the closed product (catalan n : ℝ) = ∏_{k<n} r k. Logarithms bridge this to the parent's additive identity: log(catalan n) = ∑_{k<n} log(r k). Dividing by 4^n gives catalan n / 4^n = ∏_{k<n} (r k / 4), where each factor r k / 4 < 1, so the normalized sequence catalan n / 4^n is strictly decreasing. The product form also recovers catalan n < 4^n (n ≥ 1) as a strict product inequality, since every factor r k < 4. All eight theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The result completes the multiplicative reading of the Catalan recurrence requested by the grandparent's open question: the same step ratios whose additive total is harmonic have a multiplicative total that is exactly the Catalan number. The strictly decreasing normalized sequence catalan n / 4^n is the recurrence-level reason Catalan growth sits below the bare exponential 4^n, obtained without Stirling or any central-binomial estimate. The logarithmic identity ties the additive (parent) and multiplicative (this entry) views together.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-01` (Catalan as a telescoping product of recurrence ratios).

## What changed
The entry had a rich `meta.json` and 4 good annotations, but two structural gaps:

1. **No `sections` array** — added a 5-section map covering the full 162-line Lean file: the telescoping product, the sum–product (logarithmic) bridge, the normalized sequence `catalan n / 4^n`, the product-form growth bound, and the numerical sanity checks.
2. **Annotations missing taxonomy fields** — added `significance`, `relatedConcepts`, and `prerequisites` to all 4 existing annotations, and added 2 more (header/overview context and the numerical sanity checks) for **6 total**, each with full `mathContext`.

## Axiom integrity
No change: entry remains `verified` / badge `verified` / `axiomCount` 0 (foundational `propext`/`Classical.choice`/`Quot.sound` only), accurately reflecting the Lean file.

## Build
`gallery:check-size`, `annotations:build` (no warnings for this entry), `tsc -b`, and `vite build` all pass.

_Note: pushed to a per-target branch because the agent's default `feature/enricher-1` branch is occupied by still-open PR #30395._