### PR TITLE
research(erdos-107-oq-01): discharge Klein's f(4)=5 upper bound (Aristotle proof, build-gated)

### DIFF
--- a/proofs/Proofs/Erdos107OQ01.lean
+++ b/proofs/Proofs/Erdos107OQ01.lean
@@ -11,9 +11,11 @@
 
     * UPPER BOUND  (Klein 1931, the hard half):  any 5 points in general
       position contain a convex quadrilateral, i.e. `5 ∈ CardSet 4`.
-      In current Mathlib this needs a full convex-hull case analysis
-      (~1000+ lines); we keep it as the single, sharply-stated axiom
-      `klein_upper_bound`.
+      This needs a full convex-hull vertex-count case analysis.  It is now
+      PROVED in the self-contained companion module
+      `Proofs.Erdos107OQ01KleinUpperAristotle` (an Aristotle proof-search
+      result, verified axiom-free), and `klein_upper_bound` below transports
+      that statement into the `Erdos107` definitions.
 
     * LOWER BOUND  (elementary):  there exist 4 points in general position
       that do NOT contain a convex quadrilateral, i.e. `4 ∉ CardSet 4`.
@@ -21,17 +23,19 @@
       discharge it here with an explicit witness — a triangle together with
       its centroid — and derive `f 4 = 5` from the two halves.
 
-  Net effect: the monolithic `f 4 = 5` axiom is replaced by the strictly
-  weaker, sharper axiom `klein_upper_bound : 5 ∈ CardSet 4`; the lower bound
-  is now a genuine (axiom-free) theorem.
+  Net effect: the parent's monolithic `f 4 = 5` axiom is fully discharged here.
+  Both halves are now genuine, axiom-free theorems, so `f 4 = 5` itself is
+  axiom-free (modulo the standard foundations) and no longer depends on the
+  parent's bundled `f_four_eq`.
 
-  `#print axioms Erdos107OQ01.f_four_eq_five` should list only
-  `klein_upper_bound` alongside the standard `propext / Classical.choice /
-  Quot.sound` foundations (NOT the parent's `f_four_eq`).
+  `#print axioms Erdos107OQ01.f_four_eq_five` should list only the standard
+  `propext / Classical.choice / Quot.sound` foundations (NOT the parent's
+  `f_four_eq`, and NO `klein_upper_bound` axiom — it is now a theorem).
 -/
 
 import Mathlib
 import Proofs.Erdos107Problem
+import Proofs.Erdos107OQ01KleinUpperAristotle
 
 open Finset
 open scoped BigOperators
@@ -265,20 +269,31 @@ theorem four_notin_cardSet : (4 : ℕ) ∉ CardSet 4 := by
   intro h
   exact not_hasConvexNGon_W (h W W_card general_position_W)
 
-/-! ## Klein's upper bound — the single remaining axiom
+/-! ## Klein's upper bound — now discharged
 
 The genuinely hard half of `f 4 = 5`: any five points in general position
-contain a convex quadrilateral.  A full Lean proof requires the convex-hull
-vertex-count case analysis (hull is a triangle / quadrilateral / pentagon),
-which is not yet available in Mathlib.  We isolate exactly this statement. -/
+contain a convex quadrilateral.  The full convex-hull vertex-count case
+analysis (hull is a triangle / quadrilateral / pentagon) is carried out in the
+self-contained companion module `Proofs.Erdos107OQ01KleinUpperAristotle`
+(proof produced by Aristotle proof search, verified axiom-free).  Its inlined
+definitions are *definitionally identical* to the `Erdos107` ones used here, so
+the statement transports across by destructuring and re-assembling the existence
+witness. -/
 
 /-- **Klein 1931 (upper bound).** Any 5 points in general position contain a
-    convex quadrilateral. -/
-axiom klein_upper_bound : (5 : ℕ) ∈ CardSet 4
+    convex quadrilateral.  Transported from
+    `KleinUpperAristotle.klein_upper_bound` (the `Erdos107` and
+    `KleinUpperAristotle` definitions of `InGeneralPosition` / `HasConvexNGon` /
+    `IsConvexNGon` / `CardSet` share the same body, hence are defeq). -/
+theorem klein_upper_bound : (5 : ℕ) ∈ CardSet 4 := by
+  intro pts hcard hgip
+  obtain ⟨T, hTsub, hTcard, hTvert⟩ :=
+    KleinUpperAristotle.klein_upper_bound pts hcard hgip
+  exact ⟨T, hTsub, hTcard, hTvert⟩
 
 /-- **Klein's theorem, `f(4) = 5`,** derived from the proved lower bound and the
-    isolated upper-bound axiom — *without* using the parent's bundled
-    `Erdos107.f_four_eq`. -/
+    now-proved upper bound `klein_upper_bound` — *without* using the parent's
+    bundled `Erdos107.f_four_eq`, and with no axioms of its own. -/
 theorem f_four_eq_five : f 4 = 5 := by
   have hge : (5 : ℕ) ≤ f 4 := by
     have hne : (CardSet 4).Nonempty := ⟨5, klein_upper_bound⟩

--- a/proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean
+++ b/proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean
@@ -13,6 +13,15 @@
       through those 2 interior points misses all 3 triangle vertices (general
       position), so 2 of the 3 vertices lie on the same side; those 2 vertices
       with the 2 interior points form a convex quadrilateral.
+
+  PROVENANCE: the full proof below was produced by Aristotle (Harmonic) proof
+  search — project `a1441c24-c444-4cb6-ba78-9c0357beffcf`, task
+  `49f58f23-9f57-46e9-91ed-25937c688b89` — and verified clean by Aristotle
+  (no `sorry`/`admit`, no new axioms; `#print axioms klein_upper_bound` lists
+  only `propext`, `Classical.choice`, `Quot.sound`).  It was proved against
+  Mathlib at Lean toolchain v4.28.0; this repository pins v4.26.0, so a CI build
+  on the repo toolchain must confirm the port before the discharge in
+  `Erdos107OQ01.lean` is treated as verified.
 -/
 import Mathlib
 
@@ -20,30 +29,321 @@ namespace KleinUpperAristotle
 
 open Finset
 
+/-- The Euclidean plane. -/
+abbrev E2 := EuclideanSpace ℝ (Fin 2)
+
 /-- A finite set of points is in **general position** if no three of its
     points are collinear. -/
-def InGeneralPosition (S : Set (EuclideanSpace ℝ (Fin 2))) : Prop :=
-  ∀ p q r : EuclideanSpace ℝ (Fin 2), p ∈ S → q ∈ S → r ∈ S →
+def InGeneralPosition (S : Set E2) : Prop :=
+  ∀ p q r : E2, p ∈ S → q ∈ S → r ∈ S →
     p ≠ q → q ≠ r → p ≠ r → ¬Collinear ℝ ({p, q, r} : Set _)
 
 /-- `n` points form a **convex `n`-gon** if each is a vertex of the convex hull
     of the set, i.e. lies outside the hull of the others. -/
-def IsConvexNGon (n : ℕ) (S : Finset (EuclideanSpace ℝ (Fin 2))) : Prop :=
+def IsConvexNGon (n : ℕ) (S : Finset E2) : Prop :=
   S.card = n ∧ ∀ p ∈ S, p ∉ convexHull ℝ ((S.erase p : Set _))
 
 /-- A point set **contains a convex `n`-gon** if some `n`-point subset is one. -/
-def HasConvexNGon (n : ℕ) (S : Finset (EuclideanSpace ℝ (Fin 2))) : Prop :=
+def HasConvexNGon (n : ℕ) (S : Finset E2) : Prop :=
   ∃ T ⊆ S, IsConvexNGon n T
 
 /-- The set of `N` such that any `N` points in general position contain a
     convex `n`-gon. -/
 def CardSet (n : ℕ) : Set ℕ :=
-  { N | ∀ (pts : Finset (EuclideanSpace ℝ (Fin 2))),
+  { N | ∀ (pts : Finset E2),
     pts.card = N → InGeneralPosition ↑pts → HasConvexNGon n pts }
 
-/-- **Klein 1931 (upper bound).** Any five points in general position in the
-    plane contain a convex quadrilateral: `5 ∈ CardSet 4`. -/
+/-! ### Helper lemmas -/
+
+/-
+An extreme point of the convex hull of a finite set is not in the convex
+    hull of the remaining points.
+-/
+lemma extreme_not_in_hull_erase (pts : Finset E2) (p : E2)
+    (hp : p ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ) :
+    p ∉ convexHull ℝ ((↑pts : Set E2) \ {p}) := by
+  contrapose! hp;
+  intro h;
+  have h_convex_hull_subset : convexHull ℝ (pts \ {p} : Set E2) ⊆ convexHull ℝ (convexHull ℝ pts \ {p}) := by
+    exact convexHull_mono fun x hx => ⟨ subset_convexHull ℝ _ hx.1, hx.2 ⟩;
+  convert Convex.mem_extremePoints_iff_mem_diff_convexHull_diff ( convex_convexHull ℝ ( pts : Set E2 ) ) |>.1 h using 1;
+  grind
+
+/-
+Finite-dimensional Krein–Milman for a finite set: every point of a finite
+    set lies in the convex hull of the extreme points of its convex hull.
+-/
+lemma subset_convexHull_extremePoints (pts : Finset E2) :
+    (↑pts : Set E2) ⊆ convexHull ℝ ((convexHull ℝ (↑pts : Set E2)).extremePoints ℝ) := by
+  -- Let A = convexHull ℝ ↑pts and E = A.extremePoints ℝ.
+  set A : Set E2 := convexHull ℝ (pts : Set E2)
+  set E : Set E2 := A.extremePoints ℝ;
+  -- A is compact (Set.Finite.isCompact_convexHull on the finite ↑pts) and convex (convex_convexHull).
+  have hA_compact : IsCompact A := by
+    exact Set.Finite.isCompact_convexHull ( Finset.finite_toSet pts )
+  have hA_convex : Convex ℝ A := by
+    exact convex_convexHull ℝ _;
+  -- By closure_convexHull_extremePoints, closure (convexHull ℝ E) = A.
+  have h_closure : closure (convexHull ℝ E) = A := by
+    apply_rules [ closure_convexHull_extremePoints ];
+  -- Now E ⊆ ↑pts by extremePoints_convexHull_subset, so E is finite, hence convexHull ℝ E is compact (Set.Finite.isCompact_convexHull) and therefore closed, so closure (convexHull ℝ E) = convexHull ℝ E.
+  have hE_finite : Set.Finite E := by
+    exact Set.Finite.subset ( Finset.finite_toSet pts ) ( extremePoints_convexHull_subset )
+  have h_convexHull_E_closed : IsClosed (convexHull ℝ E) := by
+    exact hE_finite.isClosed_convexHull
+  have h_closure_eq : closure (convexHull ℝ E) = convexHull ℝ E := by
+    exact h_convexHull_E_closed.closure_eq;
+  exact fun x hx => h_closure_eq ▸ h_closure ▸ subset_convexHull ℝ _ hx
+
+/-
+Case A: if four of the points are extreme points of the whole convex hull,
+    they form a convex quadrilateral.
+-/
+lemma hasConvexNGon_of_four_extreme (pts T : Finset E2) (hT : T ⊆ pts)
+    (hcard : T.card = 4)
+    (hext : ∀ p ∈ T, p ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ) :
+    HasConvexNGon 4 pts := by
+  refine' ⟨ T, hT, hcard, _ ⟩;
+  exact fun p hp => by simpa [ Finset.coe_erase ] using extreme_not_in_hull_erase pts p ( hext p hp ) |> fun h => Set.notMem_subset ( convexHull_mono <| by aesop_cat ) h;
+
+/-
+The signed-area / cross-product test for collinearity in the plane.
+-/
+lemma cross_eq_zero_iff_collinear (a b w : E2) :
+    (b 0 - a 0) * (w 1 - a 1) - (b 1 - a 1) * (w 0 - a 0) = 0 ↔
+      Collinear ℝ ({a, b, w} : Set E2) := by
+  rw [ collinear_iff_of_mem ] <;> norm_num;
+  any_goals tauto;
+  constructor <;> intro h;
+  · by_cases h_cases : b = a ∨ w = a ∨ b = w;
+    · rcases h_cases with ( rfl | rfl | rfl ) <;> norm_num at *;
+      · exact ⟨ w - b, 1, by norm_num ⟩;
+      · exact ⟨ b - w, 1, by norm_num ⟩;
+      · exact ⟨ b - a, 1, by norm_num ⟩;
+    · -- Since $b \neq a$ and $w \neq a$, we can solve for $r$ in the equation $b = r • v + a$.
+      obtain ⟨r, hr⟩ : ∃ r : ℝ, b = r • (w - a) + a := by
+        by_cases h_cases : w 0 = a 0;
+        · by_cases h_cases : w 1 = a 1;
+          · exact False.elim <| ‹¬ ( b = a ∨ w = a ∨ b = w ) › <| Or.inr <| Or.inl <| by ext i; fin_cases i <;> aesop;
+          · use (b 1 - a 1) / (w 1 - a 1);
+            ext i; fin_cases i <;> simp_all +decide [ sub_eq_iff_eq_add ] ;
+        · use (b 0 - a 0) / (w 0 - a 0);
+          ext i; fin_cases i <;> simp_all +decide [ sub_eq_iff_eq_add ] ;
+          grind;
+      exact ⟨ w - a, ⟨ 0, by norm_num ⟩, ⟨ r, hr ⟩, ⟨ 1, by norm_num ⟩ ⟩;
+  · rcases h with ⟨ v, ⟨ r, hr ⟩, ⟨ s, hs ⟩, ⟨ t, ht ⟩ ⟩ ; simp_all +decide [ sub_eq_iff_eq_add ] ; ring;
+
+/-
+A linear functional vanishing (relative to its value at `a`) exactly on the
+    line through `a` and `b`.
+-/
+lemma exists_line_functional (a b : E2) :
+    ∃ f : E2 →ₗ[ℝ] ℝ, f a = f b ∧
+      ∀ w : E2, (f w = f a ↔ Collinear ℝ ({a, b, w} : Set E2)) := by
+  refine' ⟨ _, _ ⟩;
+  refine' { toFun := fun w => ( b 0 - a 0 ) * w 1 - ( b 1 - a 1 ) * w 0, map_add' := _, map_smul' := _ };
+  all_goals norm_num [ mul_add, add_mul, mul_sub, sub_mul ];
+  · intros; ring;
+  · intros; ring;
+  · refine' ⟨ _, _ ⟩;
+    · ring;
+    · intro w; rw [ ← cross_eq_zero_iff_collinear ] ; ring;
+      constructor <;> intro h <;> linarith
+
+/-
+Pigeonhole: among three nonzero reals, two share the same sign.
+-/
+lemma two_same_sign {sx sy sz : ℝ} (hx : sx ≠ 0) (hy : sy ≠ 0) (hz : sz ≠ 0) :
+    (0 < sx ∧ 0 < sy) ∨ (0 < sy ∧ 0 < sz) ∨ (0 < sx ∧ 0 < sz) ∨
+    (sx < 0 ∧ sy < 0) ∨ (sy < 0 ∧ sz < 0) ∨ (sx < 0 ∧ sz < 0) := by
+  grind
+
+/-
+If `f a < f p`, `f a < f q`, `f b = f a` and `a ≠ b`, then `a` is not in the
+    convex hull of `{p, q, b}` (a separating-functional argument).
+-/
+lemma not_mem_convexHull_triple_of_functional (f : E2 →ₗ[ℝ] ℝ) (p q b a : E2)
+    (hp : f a < f p) (hq : f a < f q) (hb : f b = f a) (hab : a ≠ b) :
+    a ∉ convexHull ℝ ({p, q, b} : Set E2) := by
+  -- Assume for contradiction that $a \in \text{convexHull} \{p, q, b\}$.
+  by_contra h_contra
+  obtain ⟨α, β, γ, hαβγ⟩ : ∃ α β γ : ℝ, 0 ≤ α ∧ 0 ≤ β ∧ 0 ≤ γ ∧ α + β + γ = 1 ∧ a = α • p + β • q + γ • b := by
+    rw [ convexHull_insert ] at h_contra;
+    · simp_all +decide [ segment_eq_image ];
+      obtain ⟨ i, hi, x, hx, rfl ⟩ := h_contra; exact ⟨ 1 - x, by linarith, x * ( 1 - i ), by nlinarith, x * i, by nlinarith, by ring, by ext ; simpa using by ring ⟩ ;
+    · norm_num;
+  -- Applying the linear map $f$ to both sides of the equation $a = α • p + β • q + γ • b$, we get $f(a) = α • f(p) + β • f(q) + γ • f(b)$.
+  have h_apply_f : f a = α * f p + β * f q + γ * f b := by
+    simp +decide [ hαβγ, map_add, map_smul ];
+  -- Since $f(p) > f(a)$ and $f(q) > f(a)$, we have $α * (f(p) - f(a)) + β * (f(q) - f(a)) = 0$.
+  have h_zero : α * (f p - f a) + β * (f q - f a) = 0 := by
+    grind;
+  -- Since $f(p) > f(a)$ and $f(q) > f(a)$, we have $α = 0$ and $β = 0$.
+  have h_alpha_beta_zero : α = 0 ∧ β = 0 := by
+    constructor <;> nlinarith;
+  norm_num [ show γ = 1 by linarith ] at * ; aesop ( simp_config := { singlePass := true } ) ;
+
+/-
+Collinearity passes to the convex hull.
+-/
+lemma collinear_convexHull_of_collinear (s : Set E2) (h : Collinear ℝ s) :
+    Collinear ℝ (convexHull ℝ s) := by
+  -- If $s$ is collinear, then $s$ is contained in some affine subspace of dimension at most 1.
+  obtain ⟨A, hA⟩ : ∃ A : AffineSubspace ℝ E2, s ⊆ A ∧ Module.finrank ℝ (A.direction) ≤ 1 := by
+    rw [ collinear_iff_exists_forall_eq_smul_vadd ] at h;
+    obtain ⟨ p₀, v, h ⟩ := h; use AffineSubspace.mk' p₀ ( Submodule.span ℝ { v } ) ; simp_all +decide [ Set.subset_def ] ;
+    exact ⟨ fun x hx => by obtain ⟨ r, rfl ⟩ := h x hx; exact Submodule.mem_span_singleton.mpr ⟨ r, by simp +decide [ add_comm ] ⟩, by rw [ AffineSubspace.direction_mk' ] ; exact finrank_span_le_card _ ⟩;
+  refine' collinear_iff_finrank_le_one.mpr _;
+  refine' le_trans _ hA.2;
+  refine' Submodule.finrank_mono _;
+  refine' vectorSpan_mono _ _;
+  exact convexHull_min hA.1 ( A.convex )
+
+/-
+Five (or more) points in general position are not all collinear.
+-/
+lemma not_collinear_pts (pts : Finset E2) (h5 : 3 ≤ pts.card)
+    (hgen : InGeneralPosition ↑pts) : ¬ Collinear ℝ (↑pts : Set E2) := by
+  -- By definition of InGeneralPosition, if pts were collinear, there would exist three distinct points in pts that are collinear, which contradicts hgen.
+  by_contra h_collinear
+  obtain ⟨p, q, r, hp, hq, hr, h_distinct⟩ : ∃ p q r : E2, p ∈ pts ∧ q ∈ pts ∧ r ∈ pts ∧ p ≠ q ∧ q ≠ r ∧ p ≠ r ∧ Collinear ℝ ({p, q, r} : Set E2) := by
+    rcases Finset.two_lt_card.1 h5 with ⟨ p, hp, q, hq, hpq ⟩ ; use p, q ; simp_all +decide;
+    obtain ⟨ r, hr, hpq, hpr, hqr ⟩ := hpq; exact ⟨ r, hr, hpq, hqr, hpr, h_collinear.subset <| by aesop_cat ⟩ ;
+  exact hgen p q r hp hq hr h_distinct.1 h_distinct.2.1 h_distinct.2.2.1 h_distinct.2.2.2
+
+/-
+From two extreme points `p, q` on the same strict side (under `f`) of the
+    line through `a, b` (with `f a = f b`), the four points `p, q, a, b` form a
+    convex quadrilateral.
+-/
+lemma hasConvexNGon_of_pair (pts : Finset E2) (f : E2 →ₗ[ℝ] ℝ) (p q a b : E2)
+    (hp : p ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ)
+    (hq : q ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ)
+    (ha : a ∈ pts) (hb : b ∈ pts)
+    (hpq : p ≠ q) (hpa : p ≠ a) (hpb : p ≠ b) (hqa : q ≠ a) (hqb : q ≠ b)
+    (hab : a ≠ b)
+    (hfp : f a < f p) (hfq : f a < f q) (hfab : f b = f a) :
+    HasConvexNGon 4 pts := by
+  refine' ⟨ { p, q, a, b }, _, _, _ ⟩ <;> simp_all +decide;
+  · -- Since $p$ and $q$ are extreme points of the convex hull of $pts$, and the convex hull is just the set of all convex combinations of points in $pts$, $p$ and $q$ must be in $pts$.
+    have hp_in_pts : p ∈ pts := by
+      have h_extreme_subset : (convexHull ℝ pts : Set E2).extremePoints ℝ ⊆ pts := by
+        exact extremePoints_convexHull_subset
+      exact h_extreme_subset hp
+    have hq_in_pts : q ∈ pts := by
+      have := @extremePoints_convexHull_subset;
+      exact this hq
+    exact Finset.insert_subset_iff.mpr ⟨hp_in_pts, Finset.insert_subset_iff.mpr ⟨hq_in_pts, Finset.insert_subset_iff.mpr ⟨ha, Finset.singleton_subset_iff.mpr hb⟩⟩⟩;
+  · refine' ⟨ _, _, _, _ ⟩;
+    · -- Since $p$ is an extreme point of the convex hull of $pts$, it cannot be in the convex hull of any subset of $pts$ that does not include $p$.
+      have h_extreme : p ∉ convexHull ℝ (↑pts \ {p}) := by
+        convert extreme_not_in_hull_erase pts p hp using 1;
+      refine' fun h => h_extreme <| convexHull_mono _ h;
+      simp_all +decide [ Set.insert_subset_iff ];
+      have h_extreme : (convexHull ℝ (pts : Set E2)).extremePoints ℝ ⊆ pts := by
+        grind +suggestions
+      exact h_extreme hq |> fun h => by aesop;
+    · convert extreme_not_in_hull_erase _ _ hq using 1;
+      refine' iff_of_false _ _;
+      · refine' fun h => _;
+        have h_convex_hull_subset : convexHull ℝ ({p, q, a, b} \ {q} : Set E2) ⊆ convexHull ℝ (pts \ {q} : Set E2) := by
+          refine' convexHull_mono _;
+          simp_all +decide [ Set.subset_def, Set.extremePoints ];
+          have h_extreme : (convexHull ℝ (pts : Set E2)).extremePoints ℝ ⊆ pts := by
+            exact extremePoints_convexHull_subset;
+          exact h_extreme ⟨ hp.1, hp.2 ⟩;
+        exact absurd ( h_convex_hull_subset h ) ( by simpa using extreme_not_in_hull_erase pts q hq );
+      · convert extreme_not_in_hull_erase pts q hq using 1;
+    · convert not_mem_convexHull_triple_of_functional f p q b a hfp hfq hfab hab using 1;
+      congr! 2 ; aesop;
+    · convert not_mem_convexHull_triple_of_functional f p q a b ( by linarith ) ( by linarith ) ( by linarith ) ( by tauto ) using 1;
+      congr! 2 ; aesop
+
+/-
+Case B (triangle): three extreme points `x, y, z` together with two further
+    points `a, b` of the set contain a convex quadrilateral.
+-/
+set_option maxHeartbeats 1000000 in
+lemma hasConvexNGon_caseB (pts : Finset E2) (hgen : InGeneralPosition ↑pts)
+    (x y z a b : E2)
+    (hx : x ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ)
+    (hy : y ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ)
+    (hz : z ∈ (convexHull ℝ (↑pts : Set E2)).extremePoints ℝ)
+    (ha : a ∈ pts) (hb : b ∈ pts)
+    (hxy : x ≠ y) (hxz : x ≠ z) (hyz : y ≠ z)
+    (hax : a ≠ x) (hay : a ≠ y) (haz : a ≠ z)
+    (hbx : b ≠ x) (hby : b ≠ y) (hbz : b ≠ z) (hab : a ≠ b) :
+    HasConvexNGon 4 pts := by
+  -- By the statement of `hasConvexNGon_of_pair`, we need to find extreme points `p`, `q` on the same side of the line through `a`, `b`, under some linear functional `f`.
+  obtain ⟨f, hf⟩ := exists_line_functional a b;
+  have hfx : f x ≠ f a ∧ f y ≠ f a ∧ f z ≠ f a := by
+    have h_not_collinear : ¬Collinear ℝ ({a, b, x} : Set E2) ∧ ¬Collinear ℝ ({a, b, y} : Set E2) ∧ ¬Collinear ℝ ({a, b, z} : Set E2) := by
+      have h_not_collinear : ∀ p ∈ pts, p ≠ a → p ≠ b → ¬Collinear ℝ ({a, b, p} : Set E2) := by
+        intro p hp hpa hpb; specialize hgen a b p; simp_all +decide;
+        exact hgen ( Ne.symm hpb ) ( Ne.symm hpa );
+      have h_extreme_subset : Set.extremePoints ℝ (convexHull ℝ (pts : Set E2)) ⊆ pts := by
+        grind +suggestions;
+      exact ⟨ h_not_collinear x ( h_extreme_subset hx ) ( by tauto ) ( by tauto ), h_not_collinear y ( h_extreme_subset hy ) ( by tauto ) ( by tauto ), h_not_collinear z ( h_extreme_subset hz ) ( by tauto ) ( by tauto ) ⟩;
+    grind;
+  -- By two_same_sign, at least two of the three values `f x - f a`, `f y - f a`, `f z - f a` have the same strict sign.
+  obtain ⟨p, q, hpq, hpsign⟩ : ∃ p q : E2, p ∈ ({x, y, z} : Finset E2) ∧ q ∈ ({x, y, z} : Finset E2) ∧ p ≠ q ∧ (0 < f p - f a ∧ 0 < f q - f a) ∨ p ∈ ({x, y, z} : Finset E2) ∧ q ∈ ({x, y, z} : Finset E2) ∧ p ≠ q ∧ (f p - f a < 0 ∧ f q - f a < 0) := by
+    obtain ⟨p, q, hpq, hpsign⟩ : ∃ p q : E2, p ∈ ({x, y, z} : Finset E2) ∧ q ∈ ({x, y, z} : Finset E2) ∧ p ≠ q ∧ (0 < f p - f a ∧ 0 < f q - f a) ∨ p ∈ ({x, y, z} : Finset E2) ∧ q ∈ ({x, y, z} : Finset E2) ∧ p ≠ q ∧ (f p - f a < 0 ∧ f q - f a < 0) := by
+      have := two_same_sign (sub_ne_zero.mpr hfx.left) (sub_ne_zero.mpr hfx.right.left) (sub_ne_zero.mpr hfx.right.right)
+      rcases this with ( h | h | h | h | h | h ) <;> [ exact ⟨ x, y, by aesop ⟩ ; exact ⟨ y, z, by aesop ⟩ ; exact ⟨ x, z, by aesop ⟩ ; exact ⟨ x, y, by aesop ⟩ ; exact ⟨ y, z, by aesop ⟩ ; exact ⟨ x, z, by aesop ⟩ ];
+    · exact ⟨ p, q, Or.inl ⟨ hpq, hpsign ⟩ ⟩;
+    · exact ⟨ p, q, Or.inr ‹_› ⟩;
+  · apply hasConvexNGon_of_pair pts f p q a b;
+    grind +qlia;
+    all_goals aesop;
+  · apply hasConvexNGon_of_pair pts (-f) p q a b;
+    all_goals norm_num at *;
+    all_goals aesop
+
+/-! ### Main theorem -/
+
+/-
+**Klein 1931 (upper bound).** Any five points in general position in the
+    plane contain a convex quadrilateral: `5 ∈ CardSet 4`.
+-/
+set_option maxHeartbeats 1000000 in
 theorem klein_upper_bound : (5 : ℕ) ∈ CardSet 4 := by
-  sorry
+  -- Assume we have 5 points in general position in the plane.
+  intro pts hpts hgen
+  set E := (convexHull ℝ (pts : Set E2)).extremePoints ℝ with hEdef
+  have hEsub : E ⊆ pts := by
+    apply_rules [ extremePoints_convexHull_subset ];
+  by_cases hEcard : E.ncard ≥ 4;
+  · have := Set.exists_subset_card_eq hEcard;
+    obtain ⟨ t, ht₁, ht₂ ⟩ := this; have := Set.Finite.exists_finset_coe ( show Set.Finite t from Set.finite_of_ncard_pos ( by linarith ) ) ; obtain ⟨ s, hs ⟩ := this; simp_all +decide;
+    exact hasConvexNGon_of_four_extreme pts s ( by aesop_cat ) ( by aesop_cat ) ( by aesop_cat );
+  · by_cases hEcard : E.ncard ≤ 2;
+    · -- Since $E$ is finite and has at most 2 elements, it must be collinear.
+      have hEcollinear : Collinear ℝ E := by
+        interval_cases _ : Set.ncard E <;> simp_all +decide [ collinear_iff_exists_forall_eq_smul_vadd ];
+        · rw [ @Set.ncard_eq_zero ] at *;
+          · aesop;
+          · exact Set.Finite.subset ( Finset.finite_toSet pts ) hEsub;
+        · rcases ‹_› with ⟨ p, hp ⟩ ; use p, 0; aesop;
+        · rw [ Set.ncard_eq_two ] at *;
+          rcases ‹_› with ⟨ x, y, hxy, h ⟩ ; use x, y - x; intro p hp; rw [ h ] at hp; rcases hp with ( rfl | rfl ) <;> [ exact ⟨ 0, by norm_num ⟩ ; exact ⟨ 1, by norm_num ⟩ ] ;
+      -- Since $E$ is collinear, the convex hull of $E$ is also collinear.
+      have hEconvexHullcollinear : Collinear ℝ (convexHull ℝ E) := by
+        apply collinear_convexHull_of_collinear; assumption;
+      -- Since $pts$ is a subset of the convex hull of $E$, and the convex hull of $E$ is collinear, $pts$ must also be collinear.
+      have hpts_collinear : Collinear ℝ (pts : Set E2) := by
+        refine' hEconvexHullcollinear.subset _;
+        convert subset_convexHull_extremePoints pts using 1;
+      exact absurd hpts_collinear ( not_collinear_pts pts ( by linarith ) hgen );
+    · -- Since $E$ has exactly 3 elements, let's denote them as $x$, $y$, and $z$.
+      obtain ⟨x, y, z, hx, hy, hz, hxyz⟩ : ∃ x y z : E2, x ∈ E ∧ y ∈ E ∧ z ∈ E ∧ x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ E = {x, y, z} := by
+        interval_cases _ : Set.ncard E;
+        rw [ Set.ncard_eq_three ] at *; aesop;
+      -- The complement pts \ Ef has card 5 - 3 = 2 (Finset.card_sdiff with Ef ⊆ pts), so by Finset.card_eq_two it is {a,b} with a ≠ b; a,b ∈ pts and a,b ∉ Ef, giving a,b ∉ {x,y,z}, hence all the inequalities a≠x,a≠y,a≠z,b≠x,b≠y,b≠z.
+      obtain ⟨a, b, ha, hb, hab⟩ : ∃ a b : E2, a ∈ pts ∧ b ∈ pts ∧ a ≠ b ∧ a ∉ E ∧ b ∉ E ∧ a ≠ x ∧ a ≠ y ∧ a ≠ z ∧ b ≠ x ∧ b ≠ y ∧ b ≠ z := by
+        have h_compl : (pts \ {x, y, z}).card = 2 := by
+          grind;
+        obtain ⟨ a, ha, b, hb, hab ⟩ := Finset.one_lt_card.1 ( by linarith ) ; use a, b; aesop;
+      apply hasConvexNGon_caseB pts hgen x y z a b hx hy hz ha hb;
+      all_goals tauto;
 
 end KleinUpperAristotle

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -2224,6 +2224,39 @@
       "notes": "RCF existence (invariant-factor chain): primary decomp via Module.equiv_directSum_of_isTorsion + regrouping. Never submitted before; HARD known classical result. [S4 2026-06-19: CONFIRMED RUNNING ~17% via CLI; status-script/MCP gave false NOT_FOUND.]",
       "status": "running",
       "last_check": "2026-06-19T17:00:00Z"
+    },
+    {
+      "project_id": "a1441c24-c444-4cb6-ba78-9c0357beffcf",
+      "task_id": "49f58f23-9f57-46e9-91ed-25937c688b89",
+      "file": "proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean",
+      "problem_id": "erdos-107-oq-01",
+      "submitted": "2026-06-19T07:00:00Z",
+      "sorries": [
+        "klein_upper_bound"
+      ],
+      "notes": "Klein 1931 upper bound 5 ∈ CardSet 4 (Happy Ending base case) — the lone remaining axiom of erdos-107-oq-01. Submitted via CLI by researcher-10.",
+      "status": "integrated",
+      "last_check": {
+        "timestamp": "2026-06-27T00:43:40Z",
+        "percent": 100,
+        "runtime_minutes": 0
+      },
+      "outcome": "PROVED klein_upper_bound axiom-free (339-line proof: finite Krein-Milman extreme-point case analysis + 2D separating functional). Aristotle verified clean: #print axioms = propext/Classical.choice/Quot.sound only. Proved against Mathlib v4.28.0; repo pins v4.26.0 so integration PR is CI-gated on the toolchain port.",
+      "integrated": "2026-06-27T00:43:40Z",
+      "theorems_proven": [
+        "klein_upper_bound",
+        "extreme_not_in_hull_erase",
+        "subset_convexHull_extremePoints",
+        "hasConvexNGon_of_four_extreme",
+        "cross_eq_zero_iff_collinear",
+        "exists_line_functional",
+        "two_same_sign",
+        "not_mem_convexHull_triple_of_functional",
+        "collinear_convexHull_of_collinear",
+        "not_collinear_pts",
+        "hasConvexNGon_of_pair",
+        "hasConvexNGon_caseB"
+      ]
     }
   ]
 }

--- a/research/problems/erdos-107-oq-01/knowledge.md
+++ b/research/problems/erdos-107-oq-01/knowledge.md
@@ -252,3 +252,60 @@ present status — consistent with the parent file's `f(5)=9`, `f(6)=17` axioms.
   flip meta status axiomatized→verified.
 - If Aristotle fails/counterexamples (it won't — statement is TRUE): the hand-proof
   needs the extreme-point/separating-line infra above as a dedicated multi-session build.
+
+## Session 2026-06-26 (researcher-5) — Aristotle proof RETRIEVED and integrated
+
+**Mode**: REVISIT (FRESH claim) · **Outcome**: progress — upper bound discharged, axiom eliminated (build-gated)
+
+### What I Did
+- Session preamble found the lone open axiom's Aristotle job had **COMPLETED**.
+  MCP `prove`/`prove_file` still 404 (down), but the **CLI** works:
+  `aristotle show a1441c24-c444-4cb6-ba78-9c0357beffcf` → `COMPLETE`, and
+  `aristotle download` retrieved a **339-line, axiom-free** proof of
+  `klein_upper_bound : 5 ∈ CardSet 4` (task 49f58f23-...). Aristotle's own
+  verification: no `sorry`/`admit`, no new axioms, `#print axioms` = only
+  `propext / Classical.choice / Quot.sound`.
+- **Integrated** the proof:
+  - Replaced the 1-`sorry` placeholder in
+    `proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean` with the full proof
+    (+ a PROVENANCE header recording project/task IDs and the v4.28.0 origin).
+  - Wired `proofs/Proofs/Erdos107OQ01.lean`: `axiom klein_upper_bound` →
+    `theorem klein_upper_bound := by intro pts hcard hgip; obtain ⟨T,…⟩ :=
+    KleinUpperAristotle.klein_upper_bound pts hcard hgip; exact ⟨T,…⟩`
+    (the two namespaces' defs are definitionally identical, so the transport is
+    a 3-line destructure/reassemble). Added the companion import; updated the
+    file header (no longer "the single remaining axiom").
+  - meta.json: status `axiomatized`→`verified`, badge `axiom`→`verified`,
+    axiomCount 1→0; rewrote description / contributions / insights / sections /
+    conclusion / openQuestions; added the companion to additionalFiles.
+  - Logged the job in `research/aristotle-jobs.json` (status `integrated`,
+    12 theorems_proven); created `src/data/research/problems/erdos-107-oq-01.json`.
+
+### Key Findings
+- The Aristotle proof's architecture matches the roadmap from prior sessions
+  exactly: case split on the number of **extreme points** of the 5-point hull —
+  ≥4 ⇒ four in convex position; ≤2 ⇒ impossible by finite Krein–Milman
+  (`subset_convexHull_extremePoints`) + general position; =3 ⇒ separating linear
+  functional (`exists_line_functional`, `two_same_sign`) puts two vertices on one
+  side with the two interior points (`hasConvexNGon_of_pair`/`_caseB`).
+- **Toolchain gap is the only residual risk**: Aristotle proved against Mathlib
+  v4.28.0; repo pins v4.26.0. The proof uses newer `grind` configs (`grind +qlia`,
+  `grind +suggestions`) and `simp_all +decide` — these may need a port on 4.26.
+  Could not build-verify this session (Docker bind-mount EACCES; MCP prove 404),
+  so the PR is **DRAFT, CI-gated**: the `verified` status lands only on a green
+  build. This keeps code↔meta consistent while never claiming verified pre-build.
+
+### Files Modified
+- proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean (sorry → 339-line proof + provenance)
+- proofs/Proofs/Erdos107OQ01.lean (axiom → transport theorem; header; import)
+- src/data/proofs/erdos-107-oq-01/meta.json (axiomatized/axiom/1 → verified/verified/0 + prose)
+- research/aristotle-jobs.json (job a1441c24 → integrated)
+- src/data/research/problems/erdos-107-oq-01.json (new knowledge JSON)
+
+### Next Steps
+- **Build-gate**: on a working build or CI, compile `Proofs.Erdos107OQ01KleinUpperAristotle`
+  on v4.26.0. If a tactic fails on version drift, port it (proof structure is sound).
+  On green: confirm `#print axioms f_four_eq_five` = only propext/Choice/Quot, then
+  `gh pr ready` for the deployer.
+- Reuse the extreme-point infra to attack the parent's `f_five_eq : f 5 = 9`.
+- Upstream candidates: `subset_convexHull_extremePoints`, `cross_eq_zero_iff_collinear`.

--- a/research/problems/erdos-107-oq-01/knowledge.md
+++ b/research/problems/erdos-107-oq-01/knowledge.md
@@ -309,3 +309,38 @@ present status — consistent with the parent file's `f(5)=9`, `f(6)=17` axioms.
   `gh pr ready` for the deployer.
 - Reuse the extreme-point infra to attack the parent's `f_five_eq : f 5 = 9`.
 - Upstream candidates: `subset_convexHull_extremePoints`, `cross_eq_zero_iff_collinear`.
+
+## Session 2026-06-26 (researcher-5) — Build-gate verification of Klein discharge
+
+**Mode**: REVISIT (finishing in-flight PR #30399, DRAFT)
+**Outcome**: porting risk assessed LOW; build launched to settle `verified` claim
+
+### Context
+PR #30399 integrated Aristotle's axiom-free proof of `klein_upper_bound : 5 ∈ CardSet 4`
+(companion `Erdos107OQ01KleinUpperAristotle.lean`, 348 lines). meta.json was set to
+verified/verified/0 but **gated**: Aristotle proved it against Mathlib toolchain v4.28.0
+while the repo pins v4.26.0. The companion leans on `grind`, `grind +qlia`,
+`grind +suggestions` — the suspected v4.28-only features.
+
+### Key finding — the grind config flags are NOT a v4.26 blocker
+Grepped repo proofs already in the build manifest (`proofs/Proofs.lean`) on v4.26.0:
+- `grind +qlia` — used by `BaselProblemOQ01OQ01OQ02Aristotle.lean`, `Erdos476OQ05Aristotle.lean`
+- `grind +suggestions` — used by `BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean` (status **verified/0-axiom** on v4.26)
+So both flags compile on the repo toolchain. The remaining port risk is only generic
+v4.28→v4.26 API drift (lemma renames/signature changes), not the grind configs.
+
+### Build result — GREEN (port confirmed)
+- `Proofs.Erdos107OQ01KleinUpperAristotle` built clean on the repo's pinned v4.26.0
+  toolchain (7743 jobs, 0 errors). The Aristotle proof of `klein_upper_bound` ports
+  with no API drift — only a non-fatal `info: Try this: ring_nf` diagnostic at
+  `Erdos107OQ01KleinUpperAristotle.lean:150` (the goal is closed by surrounding tactics).
+- Parent `Proofs.Erdos107OQ01` built clean (7745 jobs, 0 errors), confirming the full
+  transport chain: companion → `klein_upper_bound` theorem → `f_four_eq_five`. Only a
+  harmless `'done' tactic does nothing` linter warning at line 226.
+- meta.json gating NOTE removed; `verified`/`verified`/`axiomCount 0` is now legitimate.
+- PR #30399 marked ready for the deployer.
+
+### Outcome
+Klein's `f(4) = 5` is FULLY DISCHARGED — both halves are axiom-free theorems building
+on the repo toolchain. `#print axioms f_four_eq_five` depends only on
+propext / Classical.choice / Quot.sound (standard foundations).

--- a/research/registry.json
+++ b/research/registry.json
@@ -10710,11 +10710,11 @@
     },
     {
       "slug": "erdos-107-oq-01",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-06-18T21:42:27.141Z",
       "status": "active",
-      "lastUpdate": "2026-06-19T12:42:00Z"
+      "lastUpdate": "2026-06-26T18:24:28-07:00"
     },
     {
       "slug": "erdos-1070-incomplete-01",

--- a/src/data/proofs/erdos-107-oq-01/meta.json
+++ b/src/data/proofs/erdos-107-oq-01/meta.json
@@ -74,7 +74,7 @@
       "f_four_eq_five: f 4 = 5 re-derived from both proved halves, WITHOUT the parent's f_four_eq",
       "Companion module Erdos107OQ01KleinUpperAristotle: a self-contained, axiom-free proof of klein_upper_bound via finite Krein–Milman (subset_convexHull_extremePoints), a 2D cross-product collinearity criterion, a separating linear functional, and the convex-position assembly — splitting on the number of extreme points of the 5-point hull"
     ],
-    "assumptions": "None beyond Mathlib's standard foundations. Both halves of Klein's f(4)=5 are now proved with 0 sorries, 0 axiom declarations, and no native_decide. #print axioms f_four_eq_five (and klein_upper_bound) lists only propext / Classical.choice / Quot.sound. NOTE: the companion proof of klein_upper_bound was produced by Aristotle proof search against Mathlib at Lean toolchain v4.28.0; this repository pins v4.26.0, so the 'verified' status is gated on a green CI build confirming the port on the repo toolchain.",
+    "assumptions": "None beyond Mathlib's standard foundations. Both halves of Klein's f(4)=5 are now proved with 0 sorries, 0 axiom declarations, and no native_decide. #print axioms f_four_eq_five (and klein_upper_bound) lists only propext / Classical.choice / Quot.sound. The companion proof of klein_upper_bound was produced by Aristotle proof search against Mathlib at Lean toolchain v4.28.0; the port to this repository's pinned v4.26.0 toolchain is confirmed by a green Docker build of both Proofs.Erdos107OQ01KleinUpperAristotle and the parent Proofs.Erdos107OQ01 (7745 jobs, 0 errors).",
     "additionalFiles": [
       "Proofs/Erdos107OQ01KleinUpperAristotle.lean"
     ]

--- a/src/data/proofs/erdos-107-oq-01/meta.json
+++ b/src/data/proofs/erdos-107-oq-01/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "erdos-107-oq-01",
-  "title": "Erdős #107 OQ-01: Klein's Lower Bound for f(4) = 5",
+  "title": "Erdős #107 OQ-01: Klein's Theorem f(4) = 5, Fully Discharged",
   "slug": "erdos-107-oq-01",
-  "description": "Discharges the elementary half of Klein's theorem f(4) = 5 for the Happy Ending problem. The parent entry erdos-107 states f(4) = 5 as a single bundled axiom; this entry replaces it with the strictly weaker, sharper axiom klein_upper_bound : 5 ∈ CardSet 4 (the genuinely hard direction) and PROVES the lower bound 4 ∉ CardSet 4 outright via an explicit triangle-plus-centroid witness.",
+  "description": "Fully discharges Klein's theorem f(4) = 5 for the Happy Ending problem, eliminating the parent entry's bundled axiom f_four_eq. The elementary lower bound 4 ∉ CardSet 4 is proved via an explicit triangle-plus-centroid witness; the genuinely hard upper bound 5 ∈ CardSet 4 (any 5 points in general position contain a convex quadrilateral) is proved in a self-contained companion module by a convex-hull extreme-point case analysis (Aristotle proof search, verified axiom-free). Both halves combine to give f 4 = 5 with no axioms beyond the standard foundations.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/107",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos107OQ01.lean",
     "dateAdded": "2026-06-18",
     "tags": [
@@ -19,11 +19,11 @@
       "extension",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 294,
-    "theoremCount": 18,
+    "axiomCount": 0,
+    "lineCount": 309,
+    "theoremCount": 19,
     "definitionCount": 6,
     "erdosNumber": 107,
     "erdosUrl": "https://erdosproblems.com/107",
@@ -62,8 +62,8 @@
       }
     ],
     "originalContributions": [
-      "Splits the parent's bundled axiom f_four_eq : f 4 = 5 into two sharply separated halves",
-      "klein_upper_bound : 5 ∈ CardSet 4 — the single remaining axiom, strictly weaker than f_four_eq (the hard Klein 1931 direction)",
+      "Fully discharges the parent's bundled axiom f_four_eq : f 4 = 5 — both halves are now proved, so f 4 = 5 is axiom-free",
+      "klein_upper_bound : 5 ∈ CardSet 4 — the hard Klein 1931 upper bound, PROVED in the companion module Erdos107OQ01KleinUpperAristotle by a convex-hull extreme-point case analysis (Aristotle proof search), then transported across the definitionally-identical Erdos107 definitions",
       "four_notin_cardSet : 4 ∉ CardSet 4 — the lower bound, PROVED axiom-free",
       "Explicit witness: right triangle (0,0),(6,0),(0,6) plus centroid (2,2)",
       "Six distinctness atoms (pairwise ≠) by coordinate evaluation through the WithLp layer",
@@ -71,22 +71,26 @@
       "cc_mem_hull: centroid in the convex hull via the iterated combination (1/3)v0 + (2/3)((1/2)v1 + (1/2)v2)",
       "general_position_W: all four points in general position, assembled by 4×4×4 case analysis modulo permutation invariance of Collinear",
       "not_hasConvexNGon_W: the 4-point witness contains no convex quadrilateral (the only 4-subset is the whole set, which fails IsConvexNGon at the centroid)",
-      "f_four_eq_five: f 4 = 5 re-derived from the proved lower bound and the isolated upper-bound axiom, WITHOUT the parent's f_four_eq"
+      "f_four_eq_five: f 4 = 5 re-derived from both proved halves, WITHOUT the parent's f_four_eq",
+      "Companion module Erdos107OQ01KleinUpperAristotle: a self-contained, axiom-free proof of klein_upper_bound via finite Krein–Milman (subset_convexHull_extremePoints), a 2D cross-product collinearity criterion, a separating linear functional, and the convex-position assembly — splitting on the number of extreme points of the 5-point hull"
     ],
-    "assumptions": "1 axiom declaration (klein_upper_bound : 5 ∈ CardSet 4), the hard upper-bound half of Klein's theorem (any 5 points in general position contain a convex quadrilateral; a full Lean proof needs the convex-hull vertex-count case analysis not yet in Mathlib). The lower bound and the f(4)=5 endgame are proved with 0 sorries and no native_decide. #print axioms f_four_eq_five lists only klein_upper_bound alongside propext / Classical.choice / Quot.sound.",
-    "additionalFiles": []
+    "assumptions": "None beyond Mathlib's standard foundations. Both halves of Klein's f(4)=5 are now proved with 0 sorries, 0 axiom declarations, and no native_decide. #print axioms f_four_eq_five (and klein_upper_bound) lists only propext / Classical.choice / Quot.sound. NOTE: the companion proof of klein_upper_bound was produced by Aristotle proof search against Mathlib at Lean toolchain v4.28.0; this repository pins v4.26.0, so the 'verified' status is gated on a green CI build confirming the port on the repo toolchain.",
+    "additionalFiles": [
+      "Proofs/Erdos107OQ01KleinUpperAristotle.lean"
+    ]
   },
   "overview": {
-    "historicalContext": "Esther Klein's 1931 observation — that among any 5 points in general position four must form a convex quadrilateral — is the seed of the Happy Ending problem (Erdős #107). In the threshold language f(n), Klein's result is exactly f(4) = 5. The parent gallery entry erdos-107 records this as a single bundled axiom f_four_eq : f 4 = 5. That axiom silently conflates two facts of very different difficulty: the lower bound 4 ∉ CardSet 4 (elementary — exhibit four points with no convex quadrilateral) and the upper bound 5 ∈ CardSet 4 (Klein's genuinely hard 1931 theorem). This entry discharges the elementary half outright and isolates the hard half as a single, sharply-stated axiom.",
-    "problemStatement": "Replace the bundled axiom f_four_eq : f 4 = 5 by proving the lower bound 4 ∉ CardSet 4 and isolating the residual upper bound 5 ∈ CardSet 4 as the sole remaining assumption, then re-derive f 4 = 5.",
-    "text": "The lower bound of f(4) = 5 is elementary: four points in general position need not contain a convex quadrilateral. A triangle together with an interior point (its centroid) is such a configuration — the interior point lies in the convex hull of the other three, so the four points are not in convex position. This entry proves that lower bound and keeps only the hard upper bound 5 ∈ CardSet 4 as an axiom.",
+    "historicalContext": "Esther Klein's 1931 observation — that among any 5 points in general position four must form a convex quadrilateral — is the seed of the Happy Ending problem (Erdős #107). In the threshold language f(n), Klein's result is exactly f(4) = 5. The parent gallery entry erdos-107 records this as a single bundled axiom f_four_eq : f 4 = 5. That axiom silently conflates two facts of very different difficulty: the lower bound 4 ∉ CardSet 4 (elementary — exhibit four points with no convex quadrilateral) and the upper bound 5 ∈ CardSet 4 (Klein's genuinely hard 1931 theorem). This entry proves both halves outright, fully discharging that axiom.",
+    "problemStatement": "Eliminate the bundled axiom f_four_eq : f 4 = 5 by proving both the lower bound 4 ∉ CardSet 4 and the upper bound 5 ∈ CardSet 4, then re-derive f 4 = 5 with no axioms beyond the standard foundations.",
+    "text": "The lower bound of f(4) = 5 is elementary: four points in general position need not contain a convex quadrilateral. A triangle together with an interior point (its centroid) is such a configuration — the interior point lies in the convex hull of the other three, so the four points are not in convex position. The upper bound — any 5 points in general position contain a convex quadrilateral — is Klein's genuinely hard 1931 result; it is proved here in a self-contained companion module by a convex-hull extreme-point case analysis. With both halves proved, f 4 = 5 is fully discharged.",
     "proofStrategy": "Take the right triangle v0=(0,0), v1=(6,0), v2=(0,6) and its centroid cc=(2,2) as the witness set W. The proof has three layers. (1) Geometric atoms: the four points are pairwise distinct and no three are collinear (each non-collinearity is the falsity of a 2×2 cross-product, reached through collinear_iff_of_mem and discharged by norm_num); the centroid lies in the convex hull of the vertices, written as the iterated convex combination (1/3)v0 + (2/3)((1/2)v1 + (1/2)v2). (2) Structure: W has exactly 4 points, so its only 4-element subset is W itself; since the centroid is in the hull of the remaining three, IsConvexNGon 4 W fails, giving not_hasConvexNGon_W and hence four_notin_cardSet : 4 ∉ CardSet 4. (3) Endgame: f 4 ≤ 5 from Nat.sInf_le klein_upper_bound, and 5 ≤ f 4 because sInf(CardSet 4) ∈ CardSet 4 (Nat.sInf_mem); were it < 5 it would be ≤ 4, and CardSet.mono upward-closure would force 4 ∈ CardSet 4, contradicting the witness. Combining gives f 4 = 5 without the parent's f_four_eq.",
     "keyInsights": [
       "**The bundled axiom is asymmetric**: f(4) = 5 packs an elementary lower bound together with Klein's hard upper bound; separating them turns half of a $500-prize building block into an actual theorem",
       "**A triangle with its centroid is the canonical f(4) lower-bound witness** — the centroid is interior, so the four points are never in convex position",
       "**Non-collinearity is a cross-product**: through collinear_iff_of_mem, 'no common direction' becomes (b−a)×(c−a) ≠ 0, a single norm_num check per triple",
       "**Convex-hull membership needs no barycentric machinery**: the centroid is reached by applying convexity of the hull twice to an explicit pair of weights",
-      "**The remaining axiom is strictly weaker** than the parent's f_four_eq: it asserts only 5 ∈ CardSet 4, and #print axioms confirms f_four_eq is no longer used"
+      "**The hard upper bound reduces to extreme points**: Klein's 5 ∈ CardSet 4 splits on the number of hull vertices — ≥4 extreme points give a convex quadrilateral directly; a triangle of 3 extreme points plus 2 interior points yields one via a separating linear functional through the two interior points",
+      "**The bundled axiom is fully eliminated**: with both halves proved, #print axioms f_four_eq_five lists only propext / Classical.choice / Quot.sound — no f_four_eq, no klein_upper_bound axiom"
     ],
     "prerequisites": [
       "Convex geometry (convex hull, convex position)",
@@ -130,19 +134,28 @@
     {
       "id": "upper-bound-and-conclusion",
       "title": "Klein's Upper Bound and f(4) = 5",
-      "startLine": 258,
-      "endLine": 284,
-      "summary": "Isolates the single axiom klein_upper_bound : 5 ∈ CardSet 4 (the hard Klein 1931 direction) and proves f_four_eq_five : f 4 = 5 from it together with the lower bound, via Nat.sInf_le, Nat.sInf_mem, and CardSet.mono — without the parent's f_four_eq.",
-      "mathContext": "Combines the proved lower bound with the isolated upper-bound axiom to recover Klein's value."
+      "startLine": 268,
+      "endLine": 308,
+      "summary": "Discharges klein_upper_bound : 5 ∈ CardSet 4 by transporting the companion module's axiom-free proof (KleinUpperAristotle.klein_upper_bound) across the definitionally-identical Erdos107 definitions, then proves f_four_eq_five : f 4 = 5 from both halves via Nat.sInf_le, Nat.sInf_mem, and CardSet.mono — without the parent's f_four_eq.",
+      "mathContext": "Combines the proved lower bound with the now-proved upper bound to recover Klein's value with no axioms."
+    },
+    {
+      "id": "companion-klein-upper",
+      "title": "Companion: Klein's Upper Bound (Erdos107OQ01KleinUpperAristotle)",
+      "startLine": 1,
+      "endLine": 348,
+      "summary": "Self-contained, axiom-free proof of klein_upper_bound : 5 ∈ CardSet 4 (Aristotle proof search). Case split on the number of extreme points E of the 5-point convex hull: |E|≥4 gives four points in convex position (extreme_not_in_hull_erase, hasConvexNGon_of_four_extreme); |E|≤2 is impossible (finite Krein–Milman subset_convexHull_extremePoints forces the points collinear, contradicting general position); |E|=3 (triangle) uses a separating linear functional (exists_line_functional, two_same_sign) so two vertices lie on one side of the line through the two interior points, forming a convex quadrilateral (hasConvexNGon_of_pair, hasConvexNGon_caseB).",
+      "mathContext": "The genuinely hard convex-geometry half of Klein's theorem, proved from Mathlib's extreme-point / convex-hull API.",
+      "file": "Proofs/Erdos107OQ01KleinUpperAristotle.lean"
     }
   ],
   "conclusion": {
-    "summary": "Klein's value f(4) = 5 is re-established with the elementary lower bound 4 ∉ CardSet 4 proved outright from an explicit triangle-plus-centroid witness, leaving only the genuinely hard upper bound 5 ∈ CardSet 4 as a single, sharply-stated axiom. This strictly strengthens the parent entry erdos-107, whose bundled axiom f_four_eq : f 4 = 5 is no longer used (#print axioms f_four_eq_five lists only klein_upper_bound).",
-    "implications": "Reduces the assumption footprint of the Happy Ending formalization for n = 4 to exactly its hard residual. The same witness pattern (a simplex with an interior point) generalises the lower-bound side of f(n), and the isolated upper-bound axiom marks the precise spot where a future convex-hull vertex-count case analysis in Mathlib would complete the proof.",
+    "summary": "Klein's value f(4) = 5 is fully established: the elementary lower bound 4 ∉ CardSet 4 is proved from an explicit triangle-plus-centroid witness, and the genuinely hard upper bound 5 ∈ CardSet 4 is proved in a self-contained companion module by a convex-hull extreme-point case analysis. Both halves are axiom-free, so the parent entry erdos-107's bundled axiom f_four_eq : f 4 = 5 is fully discharged (#print axioms f_four_eq_five lists only propext / Classical.choice / Quot.sound).",
+    "implications": "Removes the Happy Ending formalization's f(4) assumption entirely. The extreme-point machinery used for the upper bound — finite Krein–Milman, a 2D separating functional, convex-position assembly — is reusable infrastructure for the higher cases f(5) = 9 and the general Erdős–Szekeres threshold. The lower-bound witness pattern (a simplex with an interior point) generalises directly to the lower-bound side of f(n).",
     "openQuestions": [
-      "Prove klein_upper_bound : 5 ∈ CardSet 4 in Lean (any 5 points in general position contain a convex quadrilateral) via a convex-hull vertex-count case analysis",
-      "Discharge the parent's f_five_eq : f 5 = 9 (Makai–Turán) by the same lower-bound/upper-bound split",
-      "Formalize the Erdős–Szekeres 2^{n-2}+1 lower bound by generalising the interior-point witness"
+      "Discharge the parent's f_five_eq : f 5 = 9 (Makai–Turán) by the same lower-bound/upper-bound split, reusing the extreme-point infrastructure",
+      "Generalise the companion module's extreme-point case analysis toward the Erdős–Szekeres f(n) upper bound 2^{n-2}+1",
+      "Upstream the reusable lemmas (finite-set Krein–Milman subset_convexHull_extremePoints, the 2D cross-product collinearity criterion) to Mathlib"
     ]
   },
   "crossReferences": [
@@ -169,12 +182,14 @@
   ],
   "sorries": 0,
   "leanFile": {
-    "axiomCount": 1,
-    "lineCount": 294,
+    "axiomCount": 0,
+    "lineCount": 309,
     "sorries": 0,
     "path": "Proofs/Erdos107OQ01.lean",
     "definitionCount": 6,
-    "theoremCount": 18,
-    "additionalFiles": []
+    "theoremCount": 19,
+    "additionalFiles": [
+      "Proofs/Erdos107OQ01KleinUpperAristotle.lean"
+    ]
   }
 }

--- a/src/data/research/problems/erdos-107-oq-01.json
+++ b/src/data/research/problems/erdos-107-oq-01.json
@@ -1,0 +1,48 @@
+{
+  "slug": "erdos-107-oq-01",
+  "title": "Erdős #107 OQ-01: Klein's Theorem f(4) = 5, Fully Discharged",
+  "status": "completed",
+  "phase": "ACT",
+  "path": "full",
+  "started": "2026-04-03T22:44:23.339Z",
+  "lastUpdate": "2026-06-26",
+  "tier": "RICH",
+  "tractability": "tractable",
+  "tags": [
+    "erdos",
+    "combinatorial-geometry",
+    "convex-geometry",
+    "happy-ending-problem",
+    "ramsey-theory",
+    "extreme-points",
+    "krein-milman"
+  ],
+  "problemStatement": "Discharge the parent erdos-107 bundled axiom f_four_eq : f 4 = 5 by proving both the elementary lower bound 4 ∉ CardSet 4 and the genuinely hard Klein 1931 upper bound 5 ∈ CardSet 4 (any 5 points in general position contain a convex quadrilateral).",
+  "significance": "Removes the f(4) assumption from the Happy Ending formalization entirely; the upper-bound proof builds reusable extreme-point / finite-Krein–Milman infrastructure applicable to f(5) and the general Erdős–Szekeres threshold.",
+  "knowledge": {
+    "insights": [
+      "f(4)=5 splits into an elementary lower bound (4 ∉ CardSet 4) and Klein's genuinely hard upper bound (5 ∈ CardSet 4); the two halves have very different difficulty and were separated so the residual is sharply isolated.",
+      "Lower bound witness: a triangle (0,0),(6,0),(0,6) plus its centroid (2,2). The centroid lies in the hull of the three vertices, so the four points are never in convex position; the only 4-subset is the whole set, which fails IsConvexNGon at the centroid.",
+      "Upper bound (Klein) reduces to the number of extreme points E of the 5-point hull: |E|≥4 gives four points in convex position directly; |E|≤2 is impossible (finite Krein–Milman would force collinearity, contradicting general position); |E|=3 (triangle, 2 interior points) is handled by a separating linear functional through the two interior points so that two triangle vertices share a side and form a convex quadrilateral with them.",
+      "The companion module's inlined definitions (InGeneralPosition / IsConvexNGon / HasConvexNGon / CardSet) are definitionally identical to the Erdos107 ones, so the statement transports by a 3-line destructure/reassemble bridge rather than a re-proof.",
+      "Aristotle proved the full upper bound (339 lines, axiom-free) but against Mathlib v4.28.0 while the repo pins v4.26.0 — the proof uses newer grind configs (grind +qlia, grind +suggestions), so the 'verified' status is gated on a CI build confirming the port."
+    ],
+    "builtItems": [
+      "proofs/Proofs/Erdos107OQ01.lean: klein_upper_bound is now a theorem (was an axiom) transporting KleinUpperAristotle.klein_upper_bound across the defeq definitions; f_four_eq_five : f 4 = 5 now axiom-free.",
+      "proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean: full axiom-free proof of klein_upper_bound — extreme_not_in_hull_erase, subset_convexHull_extremePoints (finite Krein–Milman), hasConvexNGon_of_four_extreme, cross_eq_zero_iff_collinear (2D cross-product collinearity), exists_line_functional (separating functional), two_same_sign (pigeonhole), not_mem_convexHull_triple_of_functional, collinear_convexHull_of_collinear, not_collinear_pts, hasConvexNGon_of_pair, hasConvexNGon_caseB.",
+      "Lower bound (prior sessions, already merged): four_notin_cardSet, not_hasConvexNGon_W, general_position_W, cc_mem_hull and the coordinate atoms."
+    ],
+    "mathlibGaps": [
+      "No packaged 'convex-hull vertex count' / extreme-point case split for finite planar point sets — the companion module builds it from primitives (extremePoints_convexHull_subset, closure_convexHull_extremePoints, Set.Finite.isCompact_convexHull).",
+      "No off-the-shelf 'a line separates a triangle's vertices' lemma — exists_line_functional + two_same_sign supply it for E2.",
+      "Reusable candidates to upstream to Mathlib: finite-set Krein–Milman inclusion subset_convexHull_extremePoints; the 2D cross-product collinearity criterion cross_eq_zero_iff_collinear."
+    ],
+    "nextSteps": [
+      "CONFIRM BUILD: when a working build is available (or via CI on the PR), build Proofs.Erdos107OQ01KleinUpperAristotle on the repo's v4.26.0 toolchain. If grind +qlia / +suggestions or simp_all +decide fail, port those tactic invocations; the proof structure is correct.",
+      "On green build: confirm #print axioms Erdos107OQ01.f_four_eq_five and KleinUpperAristotle.klein_upper_bound list only propext/Classical.choice/Quot.sound, then mark PR ready for the deployer.",
+      "Reuse the extreme-point infrastructure to attack f_five_eq : f 5 = 9 (parent axiom) via the same lower/upper split.",
+      "Consider upstreaming subset_convexHull_extremePoints and cross_eq_zero_iff_collinear to Mathlib."
+    ],
+    "progressSummary": "COMPLETE (pending build confirmation): both halves of f(4)=5 proved, parent axiom f_four_eq fully discharged; Aristotle's axiom-free upper-bound proof integrated; verified status gated on v4.28→v4.26 toolchain port confirmation in CI."
+  }
+}


### PR DESCRIPTION
## Summary

Retrieves and integrates **Aristotle's completed, axiom-free proof** of the lone remaining axiom of `erdos-107-oq-01`:

> `klein_upper_bound : (5 : ℕ) ∈ CardSet 4` — Klein 1931, the Happy Ending base case: any 5 points in general position contain a convex quadrilateral.

With this discharged, **both halves of `f(4) = 5` are now proved**, so the parent entry `erdos-107`'s bundled axiom `f_four_eq : f 4 = 5` is fully eliminated and `f_four_eq_five` is axiom-free.

## What Aristotle proved

Project `a1441c24-c444-4cb6-ba78-9c0357beffcf` (task `49f58f23-…`) produced a 339-line proof and self-verified it clean: no `sorry`/`admit`, no new axioms, `#print axioms klein_upper_bound` = only `propext` / `Classical.choice` / `Quot.sound`. The argument splits on the number of **extreme points** of the 5-point hull:

- **≥ 4 extreme points** → any four are in convex position.
- **≤ 2 extreme points** → impossible: finite Krein–Milman (`subset_convexHull_extremePoints`) would force the points collinear, contradicting general position.
- **= 3 (triangle)** → a separating linear functional through the two interior points puts two triangle vertices on one side; those two plus the interior pair form a convex quadrilateral.

## Changes

- `proofs/Proofs/Erdos107OQ01KleinUpperAristotle.lean`: 1-`sorry` placeholder → full proof (+ provenance header).
- `proofs/Proofs/Erdos107OQ01.lean`: `axiom klein_upper_bound` → `theorem` transporting the companion result across the definitionally-identical `Erdos107` definitions (3-line destructure/reassemble bridge).
- `src/data/proofs/erdos-107-oq-01/meta.json`: `axiomatized`/`axiom`/`axiomCount 1` → `verified`/`verified`/`0`, with updated description, contributions, sections, conclusion, open questions.
- `research/aristotle-jobs.json`: log job `a1441c24` as integrated.
- `src/data/research/problems/erdos-107-oq-01.json`: new knowledge file.

## ⚠️ Build gate — why this is a DRAFT

Aristotle proved this against **Mathlib at Lean v4.28.0**; this repo pins **v4.26.0**. The proof uses newer `grind` configs (`grind +qlia`, `grind +suggestions`) and `simp_all +decide`, so the port to v4.26.0 is **not yet build-confirmed**. It could not be verified locally this session (Docker bind-mount EACCES; Aristotle MCP endpoint 404 — the CLI was used instead).

**Do not mark ready / merge until a green build on the repo toolchain confirms** `Proofs.Erdos107OQ01KleinUpperAristotle` compiles and `#print axioms Erdos107OQ01.f_four_eq_five` lists only the standard foundations. The `verified` status in `meta.json` is therefore consistent with the code and becomes true exactly when the build is green. If a tactic fails on version drift, the port is mechanical (the proof structure is sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)