### PR TITLE
research(shapley-folkman-oq-02): API-verified ACT-ready scaffold (blackout iteration 3)

### DIFF
--- a/research/problems/shapley-folkman-oq-02/draft-ShapleyFolkmanOQ02.lean
+++ b/research/problems/shapley-folkman-oq-02/draft-ShapleyFolkmanOQ02.lean
@@ -1,0 +1,150 @@
+/-
+  DRAFT SCAFFOLD — Shapley–Folkman–Starr quantitative metric bound (OQ-02)
+
+  STATUS: UNVERIFIED DRAFT. This file lives under `research/` (NOT `proofs/Proofs/`)
+  on purpose — it is NOT part of the gallery build and must NOT be added to
+  `proofs/Proofs.lean` until it compiles. The verification backends were both down
+  when this was written (Docker daemon flapping + containerd "unexpected EOF" crash;
+  Aristotle MCP returning 404). Every `sorry` below is an ACT target to discharge
+  (manually or via Aristotle) the moment a backend returns. The statements are
+  name-checked against the parent file and Mathlib v4.26.0 source; the proofs are NOT.
+
+  GOAL (Starr 1969 / Cassels 1975):
+    d_H( Σ_{i∈t} S_i , conv Σ_{i∈t} S_i )  ≤  √(min |t| n) · maxᵢ rad(S_i),   n = finrank ℝ E.
+  The headline feature is that the bound is INDEPENDENT of the number of summands |t|
+  (it saturates at √n). Numerically de-risked in `verify_starr_bound.py` (0 violations,
+  m-independence confirmed sharp; see knowledge.md).
+
+  WHAT THE PARENT ALREADY GIVES (proofs/Proofs/ShapleyFolkman.lean, in `main`):
+    theorem sum_close_to_convexHull [FiniteDimensional ℝ E]
+        {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+        (hne : ∀ i ∈ t, (S i).Nonempty)
+        {x : E} (hx : x ∈ convexHull ℝ (∑ i ∈ t, S i)) :
+        ∃ (f : ι → E),
+          (∀ i ∈ t, f i ∈ convexHull ℝ (S i)) ∧
+          ∑ i ∈ t, f i = x ∧
+          (t.filter (fun i => f i ∉ S i)).card ≤ Module.finrank ℝ E
+  i.e. the COMBINATORIAL content: x = Σ fᵢ with each fᵢ ∈ conv(Sᵢ) and at most
+  n = finrank summands convexified. The METRIC upgrade below is the new work.
+
+  KEY API CORRECTION (this session, vs prior ORIENT notes):
+   * The parent file's ambient context is `variable {E : Type*} [AddCommGroup E] [Module ℝ E]`
+     — module-only, NO norm. The metric bound MUST add `[NormedAddCommGroup E]
+     [InnerProductSpace ℝ E]`. So OQ-02 cannot live in the parent's namespace context
+     unchanged; it re-states `sum_close_to_convexHull`'s conclusion under the richer
+     structure (the parent theorem still applies, since a normed ℝ-space is an ℝ-module).
+   * Mathlib v4.26.0 has NO general circumradius / minimal-enclosing-ball API for
+     arbitrary bounded sets (only `Affine.Simplex.circumradius` for simplices). So `rad`
+     must be defined here. The diam-based surrogate `‖f − s‖ ≤ Metric.diam (S i)` gives a
+     correct but non-sharp first pass; the sharp constant needs the min-enclosing-ball
+     radius `rad`.
+-/
+
+import Mathlib
+
+open Set Finset Pointwise Metric Real
+
+namespace ShapleyFolkmanOQ02
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]
+
+/-! ### 1. A radius for an arbitrary set
+
+`rad S` = the infimum over centers `c` of the smallest radius enclosing `S`
+(the Chebyshev / minimal-enclosing-ball radius). For the *bound* it is enough to
+have, for the nearest point, `‖f − s‖ ≤ rad (S i)` whenever `f ∈ conv (S i)`.
+A correct-but-loose first pass replaces `rad` by `Metric.diam`. -/
+
+/-- Minimal enclosing-ball radius of a set: `sInf` over centers `c` of `sSup_{x∈S} ‖x−c‖`.
+    (DRAFT: the exact `iInf/iSup` packaging and junk-value handling for unbounded `S`
+    need to be pinned down against `Metric` API; `Metric.diam` is the available fallback.) -/
+noncomputable def rad (S : Set E) : ℝ :=
+  ⨅ c : E, ⨆ x : S, ‖(x : E) - c‖
+  -- TODO(ACT): confirm `⨆ x : S, _` typechecks (bddAbove for bounded S); else use
+  -- `sInf {r | ∃ c, ∀ x ∈ S, ‖x - c‖ ≤ r}`. Prove `rad_le_diam : rad S ≤ Metric.diam S`
+  -- and `rad_nonneg`.
+
+theorem rad_nonneg (S : Set E) : 0 ≤ rad S := by sorry
+
+/-- The min-enclosing-ball radius is bounded by the diameter (so the diam-based first
+    pass is a relaxation of the sharp `rad` bound). -/
+theorem rad_le_diam (S : Set E) (hb : IsBounded S) : rad S ≤ Metric.diam S := by sorry
+
+/-! ### 2. Per-summand displacement
+
+For a hull point `f ∈ conv (S i)` there is an actual point `s ∈ S i` within `rad (S i)`.
+Via Carathéodory (`eq_pos_convex_span_of_mem_convexHull`) `f` is a convex combination of
+points of `S i`; the nearest such point is within the enclosing radius. -/
+theorem exists_nearby_point {S : Set E} (hne : S.Nonempty) (hb : IsBounded S)
+    {f : E} (hf : f ∈ convexHull ℝ S) :
+    ∃ s ∈ S, ‖f - s‖ ≤ rad S := by
+  -- ACT sketch: `eq_pos_convex_span_of_mem_convexHull hf` gives f = Σ wⱼ • zⱼ, zⱼ ∈ S,
+  -- wⱼ > 0, Σwⱼ = 1. With c the enclosing center, ‖f − c‖ = ‖Σ wⱼ(zⱼ−c)‖ ≤ Σ wⱼ‖zⱼ−c‖ ≤ rad.
+  -- Then the nearest zⱼ to f satisfies ‖f − zⱼ‖ ≤ ‖f − c‖ + ‖c − zⱼ‖ ... refine to ≤ rad.
+  sorry
+
+/-! ### 3. THE CRUX — ℓ² aggregation (source of the √n, NOT triangle/CS-on-norms)
+
+This is the one genuinely non-routine lemma and the open core of OQ-02. Over the
+`≤ n` convexified ("excess") indices, the deviation vectors `vᵢ = fᵢ − sᵢ` satisfy
+the Cassels–Starr estimate
+
+    ‖∑_{i ∈ excess} vᵢ‖  ≤  √(excess.card) · maxᵢ ‖vᵢ‖.
+
+NOTE (honest): this does NOT follow from the triangle inequality (`norm_sum_le`,
+which only gives `excess.card · max`), NOR from Cauchy–Schwarz applied to `∑‖vᵢ‖`
+(that also only reaches `excess.card · max`). The √-improvement is Cassels' lemma:
+it uses that each `vᵢ` is a deviation of a point of `conv Sᵢ` from a point of `Sᵢ`,
+i.e. a genuine convex-geometry fact, NOT a generic inner-product identity. Porting
+Cassels' argument (or an equivalent) is the substantial remaining work. -/
+theorem cassels_starr_aggregation {ι : Type*} (excess : Finset ι) (v : ι → E) (L : ℝ)
+    (hL : ∀ i ∈ excess, ‖v i‖ ≤ L) (hL0 : 0 ≤ L)
+    -- Cassels' structural hypothesis: each vᵢ = fᵢ − sᵢ with fᵢ ∈ conv(Sᵢ), sᵢ ∈ Sᵢ a
+    -- nearest point; encode precisely during ACT. WITHOUT such a hypothesis the bound is
+    -- FALSE (aligned vectors give excess.card · L), so this signature is a PLACEHOLDER.
+    :
+    ‖∑ i ∈ excess, v i‖ ≤ Real.sqrt (excess.card) * L := by
+  sorry
+
+/-! ### 4. One-sided Hausdorff bound — TRIANGLE version (routine, correct, non-sharp)
+
+The honestly-provable fallback that does NOT need Cassels: replace each convexified
+`fᵢ` by a nearby `sᵢ ∈ Sᵢ` and bound by the triangle inequality. Constant is `n` (or
+`|t|`), not `√n`. This is a complete correct theorem and a good first ACT target. -/
+theorem hausdorff_bound_linear {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty) (hb : ∀ i ∈ t, IsBounded (S i))
+    {x : E} (hx : x ∈ convexHull ℝ (∑ i ∈ t, S i)) :
+    ∃ y ∈ (∑ i ∈ t, S i), ‖x - y‖ ≤ (Module.finrank ℝ E) * (⨆ i : t, rad (S i)) := by
+  -- ACT sketch: apply `sum_close_to_convexHull hne hx` → f with excess.card ≤ finrank.
+  -- On non-excess i, fᵢ ∈ Sᵢ already; on excess i, `exists_nearby_point` gives sᵢ ∈ Sᵢ
+  -- with ‖fᵢ − sᵢ‖ ≤ rad(Sᵢ). Set y = Σ sᵢ ∈ Σ Sᵢ. Then
+  -- ‖x − y‖ = ‖Σ_{excess}(fᵢ − sᵢ)‖ ≤ Σ_{excess} rad ≤ excess.card · max rad ≤ finrank · max rad.
+  sorry
+
+/-! ### 5. One-sided Hausdorff bound — STARR version (the headline target)
+
+Same construction, but bound the excess deviation sum via `cassels_starr_aggregation`,
+yielding the sharp `√(min |t| finrank)` constant — independent of |t|. -/
+theorem hausdorff_bound_starr {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty) (hb : ∀ i ∈ t, IsBounded (S i))
+    {x : E} (hx : x ∈ convexHull ℝ (∑ i ∈ t, S i)) :
+    ∃ y ∈ (∑ i ∈ t, S i),
+      ‖x - y‖ ≤ Real.sqrt (min t.card (Module.finrank ℝ E)) * (⨆ i : t, rad (S i)) := by
+  -- ACT sketch: as in `hausdorff_bound_linear`, but apply `cassels_starr_aggregation`
+  -- to the excess deviations (card ≤ finrank, and ≤ t.card), giving the √ factor.
+  sorry
+
+/-! ### 6. Full two-sided Hausdorff-distance corollary
+
+`Σ Sᵢ ⊆ conv Σ Sᵢ` makes the reverse direction trivial (dist 0), so the one-sided
+bound upgrades to `Metric.hausdorffDist` via `hausdorffDist_le_of_mem_dist`. -/
+theorem shapley_folkman_starr {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
+    (hne : ∀ i ∈ t, (S i).Nonempty) (hb : ∀ i ∈ t, IsBounded (S i)) :
+    Metric.hausdorffDist (∑ i ∈ t, S i) (convexHull ℝ (∑ i ∈ t, S i))
+      ≤ Real.sqrt (min t.card (Module.finrank ℝ E)) * (⨆ i : t, rad (S i)) := by
+  -- ACT sketch: `hausdorffDist_le_of_mem_dist` with r = √(min ..)·max rad ≥ 0.
+  -- Forward (x ∈ conv): `hausdorff_bound_starr`. Reverse (x ∈ Σ Sᵢ ⊆ conv): dist 0
+  -- via `subset_convexHull` and `self_mem` ⇒ choose y = x.
+  sorry
+
+end ShapleyFolkmanOQ02

--- a/research/problems/shapley-folkman-oq-02/knowledge.md
+++ b/research/problems/shapley-folkman-oq-02/knowledge.md
@@ -6,6 +6,14 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
+**Phase: ORIENT→PRE-ACT (iteration 3, researcher-3, 2026-06-26).** Verification
+blackout STILL in force (Docker daemon flapping + containerd "unexpected EOF" crash,
+exit 125; Aristotle MCP returns 404 "Resource not found"). No gallery `.lean` committed;
+instead this iteration produced a **name-checked, ACT-ready Lean scaffold**
+`draft-ShapleyFolkmanOQ02.lean` (research dir only — NOT in `proofs/Proofs/`, so it is
+not built by CI until it compiles). See "Session 3" below for the API corrections that
+de-risk the eventual build.
+
 **Phase: ORIENT (iteration 2, researcher-3, 2026-06-14).** Build-free session
 under the Docker + Aristotle verification blackout — no `.lean` committed.
 
@@ -118,3 +126,65 @@ squared-deviation aggregation.
   weaker `diam`-based bound used for a first pass).
 - (No Lean attempted this session — blocked by the verification blackout; the
   above is ORIENT only.)
+
+---
+
+## Session 3 (researcher-3, 2026-06-26) — API-verified scaffold
+
+Blackout persists (Docker + Aristotle both down — see header). Built the ACT-ready
+scaffold `draft-ShapleyFolkmanOQ02.lean` and **verified the bearer API against actual
+source** (parent file + local Mathlib v4.26.0). Two corrections to the prior plan that
+would otherwise have made the eventual Lean fail to elaborate:
+
+### Correction A — the parent context is module-only, not normed
+`proofs/Proofs/ShapleyFolkman.lean` opens with
+`variable {E : Type*} [AddCommGroup E] [Module ℝ E]` (open `Set Finset Pointwise`,
+`namespace ShapleyFolkman`). There is **no norm** in scope. So OQ-02 cannot extend the
+parent namespace unchanged; it must introduce
+`[NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDimensional ℝ E]` itself and
+re-invoke `sum_close_to_convexHull` (which still applies — a normed ℝ-space is an
+ℝ-module). Exact parent conclusion to build on (line 1184):
+`∃ f, (∀ i ∈ t, f i ∈ convexHull ℝ (S i)) ∧ ∑ i ∈ t, f i = x ∧ (t.filter (fun i => f i ∉ S i)).card ≤ Module.finrank ℝ E`.
+
+### Correction B — Cassels, not "Cauchy–Schwarz", is the √n source
+The prior note said "the ℓ²/Cauchy–Schwarz route" yields `√n·L`. On inspection that is
+**not** quite right and the distinction matters for the Lean:
+- `norm_sum_le` (triangle) gives `‖Σvᵢ‖ ≤ Σ‖vᵢ‖ ≤ card·L`.
+- Cauchy–Schwarz on the *scalar* sum `Σ‖vᵢ‖ = Σ 1·‖vᵢ‖ ≤ √card · √(Σ‖vᵢ‖²) ≤ √card·√(card·L²) = card·L` — **also only `card·L`**.
+So neither generic route beats the triangle bound. The `√n` improvement is a genuine
+**convex-geometry** fact (Cassels 1975 / Starr): it uses that each `vᵢ = fᵢ − sᵢ` is a
+deviation of a hull point of `Sᵢ` from a nearest point of `Sᵢ`, not an arbitrary
+vector. Without that structural hypothesis `‖Σvᵢ‖ ≤ √card·L` is **FALSE** (aligned
+vectors saturate `card·L`). The scaffold's `cassels_starr_aggregation` therefore carries
+a placeholder structural hypothesis to be pinned during ACT — this is the open core.
+
+### Correction C — no general circumradius API (confirmed)
+Mathlib v4.26.0 has only `Affine.Simplex.circumradius`/`circumcenter` (simplices). No
+min-enclosing-ball radius for arbitrary bounded sets. `rad` is defined in the scaffold
+as `⨅ c, ⨆ x∈S, ‖x−c‖` (packaging TBD); the diam surrogate (`Metric.diam`, with
+`rad_le_diam`) gives a correct non-sharp first pass.
+
+### Bearer reference sheet (exact, from source)
+| Need | Lemma (v4.26.0) | File |
+|------|-----------------|------|
+| combinatorial SF | `ShapleyFolkman.sum_close_to_convexHull` | repo `proofs/Proofs/ShapleyFolkman.lean:1184` |
+| Carathéodory (pos convex span) | `eq_pos_convex_span_of_mem_convexHull` | `Mathlib/Analysis/Convex/Caratheodory.lean` |
+| convex combination form | `convexHull_eq`, `Finset.centerMass_mem_convexHull` | `Mathlib/Analysis/Convex/Combination.lean` |
+| CS for inner product | `norm_inner_le_norm`, `real_inner_le_norm` | `Mathlib/Analysis/InnerProductSpace/Basic.lean` |
+| diameter | `Metric.diam`, `diam_le_of_forall_dist_le`, `diam_nonneg` | `Mathlib/Topology/MetricSpace/Bounded.lean` |
+| Hausdorff dist | `Metric.hausdorffDist`, `hausdorffDist_le_of_mem_dist`, `hausdorffDist_le_diam` | `Mathlib/Topology/MetricSpace/HausdorffDistance.lean` |
+| finrank bound | `Module.finrank`, `fintype_card_le_finrank` | `Mathlib/LinearAlgebra/Dimension/*` |
+
+### ACT plan (when a backend returns), easiest → hardest
+1. `rad_nonneg`, `rad_le_diam`, `exists_nearby_point` (Carathéodory + nearest point).
+2. `hausdorff_bound_linear` — the **routine `card·rad` (= finrank·rad) bound**; a
+   complete correct theorem, good first verified deliverable, needs no Cassels.
+3. `shapley_folkman_starr` packaging via `hausdorffDist_le_of_mem_dist` (reverse
+   direction trivial: `Σ Sᵢ ⊆ conv Σ Sᵢ`).
+4. `cassels_starr_aggregation` — the √n crux (open core; the rest is plumbing).
+
+**Recommended honest milestone:** land the `finrank·rad` (triangle) Hausdorff bound as a
+*verified* gallery entry first, with the sharp √n constant flagged as the remaining
+Cassels step — mirrors the erdos-633 "prove what's honestly provable, document the hard
+core" pattern. Do NOT ship the √n statement as verified until `cassels_starr_aggregation`
+is genuinely proved.

--- a/research/problems/shapley-folkman-oq-02/state.md
+++ b/research/problems/shapley-folkman-oq-02/state.md
@@ -1,36 +1,45 @@
 # Research State: shapley-folkman-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ORIENT → PRE-ACT (scaffold ready)
 **Path**: full
 **Since**: 2026-06-14
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Build-free ORIENT under the Docker + Aristotle verification blackout. Pinned
-the precise gap between the gallery parent and Starr's metric bound, mapped the
-Mathlib bearer landscape, and produced a durable numerical verification of the
-bound (constant, m-independence, sharpness).
+Verification blackout STILL in force (iteration 3, 2026-06-26): Docker daemon
+flapping + containerd "unexpected EOF" crash (exit 125); Aristotle MCP returns 404.
+No gallery `.lean` committed. This iteration produced a **name-checked, ACT-ready Lean
+scaffold** (`draft-ShapleyFolkmanOQ02.lean`, research dir only) and verified the bearer
+API against actual source, correcting three points that would otherwise have broken the
+eventual build (see knowledge.md "Session 3").
 
 ## Active Approach
-Approach 1 (problem.md): Shapley-Folkman decomposition + per-summand radius
-bound + sqrt(min(m,n)) ℓ² aggregation. The combinatorial half already exists in
-the parent file as `sum_close_to_convexHull`; the open work is the *metric*
-upgrade (replace each convexified summand by a nearest point of S_i and bound
-the aggregate displacement).
+Approach 1: build the metric upgrade on the parent's `sum_close_to_convexHull`. Scaffold
+splits it into: `rad` def + `rad_le_diam`; `exists_nearby_point` (Carathéodory + nearest
+point); `hausdorff_bound_linear` (routine `finrank·rad` triangle bound — first verified
+target); `cassels_starr_aggregation` (the √n crux — open core); `shapley_folkman_starr`
+(packaging via `hausdorffDist_le_of_mem_dist`).
 
 ## Attempt Count
-- Total attempts: 1 (ORIENT survey + numerical verification)
-- Current approach attempts: 1
+- Total attempts: 2 (ORIENT survey + numerical verification; then API-verified scaffold)
+- Current approach attempts: 2
 - Approaches tried: 1
 
 ## Blockers
-- Docker down + Aristotle 404 (verification blackout, 2026-06-14): no Lean
-  build possible this session. No `.lean` committed.
+- Verification blackout persists (2026-06-26): Docker containerd EOF crash + Aristotle
+  404. Cannot compile or prove-check any Lean. Scaffold statements are name-checked
+  against source but the proofs are UNVERIFIED.
+- The √n constant is NOT reachable by triangle/Cauchy–Schwarz (see knowledge.md
+  Correction B); it requires the Cassels–Starr convex-geometry argument — the genuine
+  open core.
 
 ## Next Action
-ACT (when a backend is up): formalize the metric bound on top of
-`sum_close_to_convexHull`. Define `rad`/circumradius via `Metric.diam` or a
-minimum-enclosing-ball, prove the per-summand displacement bound, then the
-sqrt(min(m,n)) aggregation (the only genuinely new lemma). See knowledge.md for
-the bearer map and the empirically-confirmed constant.
+ACT (when a backend returns), easiest → hardest:
+1. `rad_nonneg` / `rad_le_diam` / `exists_nearby_point`.
+2. `hausdorff_bound_linear` — land the **`finrank·rad` (triangle) Hausdorff bound** as a
+   verified gallery entry first (honest milestone; no Cassels needed).
+3. `shapley_folkman_starr` packaging.
+4. `cassels_starr_aggregation` — the √n crux (open core).
+Do NOT ship the √n statement as verified until step 4 is genuinely proved. Submit the
+provable supporting lemmas (steps 1–3) to Aristotle the moment it is back up.


### PR DESCRIPTION
## Summary

Iteration 3 on the **quantitative Shapley–Folkman–Starr metric bound** (`d_H(Σ Sᵢ, conv Σ Sᵢ) ≤ √(min m n)·maxᵢ rad(Sᵢ)`). The verification blackout that blocked prior sessions **persists** (Docker daemon flapping + containerd `unexpected EOF` crash, exit 125; Aristotle MCP returns 404), so this does **not** commit a gallery `.lean` — an unbuildable file in `proofs/Proofs/` would break CI. Instead it delivers a **name-checked, ACT-ready Lean scaffold** (research dir only) plus the API corrections needed for the eventual build to elaborate.

This is research-dir only: **no gallery/meta change**, no `proofs/Proofs/` file, nothing built by CI.

## What's in this PR
- `draft-ShapleyFolkmanOQ02.lean` — statement-level scaffold building on the parent's `sum_close_to_convexHull`, with every proof a `sorry` ACT-target plus a rigorous sketch. Statements name-checked against the parent file and Mathlib v4.26.0 source; proofs are **unverified** (clearly labelled).
- `knowledge.md` — Session-3 section with a bearer reference sheet (exact lemma names + source paths) and an easiest→hardest ACT plan.
- `state.md` — iteration 3 status.

## Three API corrections (would otherwise break elaboration)
1. **Parent is module-only.** `ShapleyFolkman.lean` uses `variable {E} [AddCommGroup E] [Module ℝ E]` — no norm. OQ-02 must introduce `[InnerProductSpace ℝ E]` itself and re-invoke `sum_close_to_convexHull` (still applies, since a normed ℝ-space is an ℝ-module).
2. **√n is Cassels, not Cauchy–Schwarz.** Neither the triangle inequality nor Cauchy–Schwarz on `Σ‖vᵢ‖` beats `card·L`; the √n improvement is the Cassels–Starr convex-geometry fact (each deviation is a hull-point-minus-nearest-point). Without that structural hypothesis the √n bound is *false*. This is the genuine open core, isolated as `cassels_starr_aggregation`.
3. **No general circumradius API** in Mathlib v4.26.0 (only `Affine.Simplex.circumradius`); `rad` is defined here, with `Metric.diam` as a correct non-sharp surrogate.

## Recommended next milestone
Land the routine **`finrank·rad` (triangle) one-sided Hausdorff bound** (`hausdorff_bound_linear`) as a *verified* gallery entry first — a complete correct theorem needing no Cassels — with the sharp √n constant flagged as the remaining step. Mirrors the erdos-633 "prove what's honestly provable, document the hard core" pattern. Submit the provable supporting lemmas to Aristotle once it is back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)