### PR TITLE
Enrich Monster 𝕄 inverse-Galois entry: add annotations

### DIFF
--- a/src/data/proofs/inverse-galois-oq-03/annotations.json
+++ b/src/data/proofs/inverse-galois-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header-monster",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 5, "endLine": 70 },
+    "type": "context",
+    "title": "The Monster, Thompson's theorem, and the M₂₃ contrast",
+    "content": "The docstring frames the research question — is the Monster 𝕄 (the largest sporadic simple group) realizable as a Galois group over ℚ? — and answers it: YES, by Thompson (1984), via his rigidity criterion applied to a rigid rational triple of conjugacy classes (2A, 3B, 29A). The entry is the positive bookend to OQ-02 (M₂₃, still open): the same structural chain simplicity ⟹ non-solvability ⟹ beyond Shafarevich applies to both, but the realizability bit differs. Because 𝕄 has no small faithful permutation representation (the smallest has degree ≈ 10¹⁹, versus M₂₃ ⊂ S₂₃), it is axiomatized as an abstract finite group rather than a concrete subgroup of some Sₙ.",
+    "mathContext": "Thompson's rigidity criterion: a finite group $G$ admitting a rigid rational triple $(C_1, C_2, C_3)$ of conjugacy classes is realizable as $\\mathrm{Gal}(K/\\mathbb{Q})$. $|\\mathbb{M}| \\approx 8\\times10^{53}$, yet it is realized, while $|M_{23}|\\approx 10^7$ is open — difficulty is class-geometry, not size.",
+    "significance": "context",
+    "relatedConcepts": ["inverse Galois problem", "rigidity method", "rational rigidity", "sporadic groups", "monstrous moonshine"],
+    "prerequisites": ["Galois theory", "finite simple groups", "classification of finite simple groups"]
+  },
+  {
+    "id": "ann-axiomatization",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 76, "endLine": 105 },
+    "type": "definition",
+    "title": "Part I: Axiomatizing 𝕄 (4 of the 6 axioms)",
+    "content": "Because the Monster has no small permutation carrier, even its underlying type is introduced axiomatically. Four axioms are declared here: `Monster` (the type), `instGroupMonster` (its group structure), `instFintypeMonster` (finiteness), and `Monster_card` (Griess's 1982 order, the 54-digit number). `Monster_isSimple` records simplicity from CFSG. These are cited mathematical facts, not conjectures and not reproved — exactly the kind of well-established input the axiom integrity policy permits, with axiomCount honestly set to 6 (the 5 here plus Thompson's realizability axiom in Part V). The `attribute [instance]` lines register the group and fintype axioms so typeclass resolution can use them downstream.",
+    "mathContext": "$|\\mathbb{M}| = 808{,}017{,}424{,}794{,}512{,}875{,}886{,}459{,}904{,}961{,}710{,}757{,}005{,}754{,}368{,}000{,}000{,}000$. Simplicity: $\\mathbb{M}$ has no normal subgroup other than $\\{1\\}$ and $\\mathbb{M}$ itself.",
+    "significance": "key",
+    "relatedConcepts": ["axiomatization", "Griess algebra", "simple group", "Fintype instance"],
+    "prerequisites": ["abstract group theory", "Lean axioms and instances", "cardinality of finite types"]
+  },
+  {
+    "id": "ann-order-factored",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 111, "endLine": 150 },
+    "type": "technique",
+    "title": "Part II: Order arithmetic by norm_num",
+    "content": "From the single order axiom, `norm_num` mechanically verifies the 15-prime factorization |𝕄| = 2⁴⁶·3²⁰·5⁹·7⁶·11²·13³·17·19·23·29·31·41·47·59·71, that |𝕄| > 1, and divisibility by each prime factor (2, 3, 5, 7, …, 71 — the Sylow-existence inputs). The pivotal lemma is `Monster_card_not_prime`: it exhibits 2 as an explicit divisor (with the cofactor written out) and derives a contradiction from `Nat.Prime.eq_one_or_self_of_dvd`, so |𝕄| is composite. This compositeness is the only group-specific lever needed for the entire structural chain in Part III.",
+    "mathContext": "$|\\mathbb{M}| = 2^{46}\\cdot3^{20}\\cdot5^{9}\\cdot7^{6}\\cdot11^{2}\\cdot13^{3}\\cdot17\\cdot19\\cdot23\\cdot29\\cdot31\\cdot41\\cdot47\\cdot59\\cdot71$. 71 is the largest prime factor and the largest prime element order in $\\mathbb{M}$. Compositeness follows from $2 \\mid |\\mathbb{M}|$ and $|\\mathbb{M}| \\neq 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime factorization", "norm_num", "Sylow theory", "divisibility", "supersingular primes"],
+    "prerequisites": ["prime numbers", "decision procedures in Lean", "Nat.Prime API"]
+  },
+  {
+    "id": "ann-non-commutative",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 166, "endLine": 176 },
+    "type": "insight",
+    "title": "Part III(a): 𝕄 is non-commutative",
+    "content": "`Monster_not_commutative` is the first link of the structural chain. The argument: if 𝕄 were abelian, then being simple it would have prime order by `Group.is_simple_iff_prime_card` (an abelian simple group is cyclic of prime order). But Part II proved |𝕄| is not prime. The proof installs an `IsMulCommutative` instance from the assumed commutativity, extracts primality of `Nat.card Monster`, rewrites to `Fintype.card`, and contradicts `Monster_card_not_prime`. This is the place where the composite order does its work.",
+    "mathContext": "$G$ simple and abelian $\\Rightarrow$ $G \\cong \\mathbb{Z}/p\\mathbb{Z}$ (any nontrivial subgroup would be normal, so the only subgroups are $\\{1\\}$ and $G$, forcing prime order). Contrapositive with $|\\mathbb{M}|$ composite gives non-abelian.",
+    "significance": "key",
+    "relatedConcepts": ["abelian simple group", "cyclic group of prime order", "Group.is_simple_iff_prime_card"],
+    "prerequisites": ["simple groups", "abelian groups", "Lagrange's theorem"]
+  },
+  {
+    "id": "ann-perfect",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 178, "endLine": 193 },
+    "type": "insight",
+    "title": "Part III(b): 𝕄 is perfect, [𝕄,𝕄] = 𝕄",
+    "content": "`Monster_commutator_eq_top` shows the commutator subgroup is all of 𝕄. Since [𝕄,𝕄] is always normal, simplicity (`eq_bot_or_eq_top_of_normal`) forces it to be ⊥ or ⊤. The ⊥ branch is killed: [𝕄,𝕄] = ⊥ is equivalent to the center being everything (`commutator_eq_bot_iff_center_eq_top`), which would make 𝕄 abelian — contradicting Part III(a). So [𝕄,𝕄] = ⊤, i.e. 𝕄 is perfect. Perfectness is the hinge between non-commutativity and non-solvability: a perfect nontrivial group cannot have a terminating derived series.",
+    "mathContext": "$[\\mathbb{M},\\mathbb{M}] \\trianglelefteq \\mathbb{M}$, so simplicity gives $[\\mathbb{M},\\mathbb{M}] \\in \\{\\bot, \\top\\}$. $[\\mathbb{M},\\mathbb{M}] = \\bot \\iff Z(\\mathbb{M}) = \\mathbb{M} \\iff \\mathbb{M}$ abelian. Non-abelian $\\Rightarrow [\\mathbb{M},\\mathbb{M}] = \\top$, the definition of a perfect group.",
+    "significance": "key",
+    "relatedConcepts": ["commutator subgroup", "perfect group", "center of a group", "derived series"],
+    "prerequisites": ["commutator subgroups", "normal subgroups", "simple groups"]
+  },
+  {
+    "id": "ann-not-solvable",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 195, "endLine": 217 },
+    "type": "insight",
+    "title": "Part III(c) & IV: non-solvability and the Shafarevich barrier",
+    "content": "`Monster_not_solvable` closes the chain: a solvable simple group is abelian (`IsSimpleGroup.comm_iff_isSolvable`), but 𝕄 is non-commutative, so 𝕄 is not solvable. Part IV reuses this verbatim as `Monster_not_solvable_barrier` to make the Galois-theoretic point: Shafarevich's theorem (1954) realizes every finite *solvable* group over ℚ, so it says nothing about 𝕄. Any realization of the Monster must therefore go beyond class field theory — precisely the gap the rigidity method fills.",
+    "mathContext": "$G$ simple and solvable $\\Rightarrow$ the derived series $G \\supsetneq [G,G] \\supsetneq \\cdots$ must hit $\\{1\\}$, but $[G,G] \\in \\{1, G\\}$ by simplicity; non-triviality forces $[G,G] = 1$, i.e. abelian. Contrapositive: non-abelian simple $\\Rightarrow$ non-solvable. Shafarevich covers only solvable $G$.",
+    "significance": "key",
+    "relatedConcepts": ["solvable group", "Shafarevich's theorem", "IsSimpleGroup.comm_iff_isSolvable", "class field theory"],
+    "prerequisites": ["solvable groups", "derived series", "Shafarevich's theorem"]
+  },
+  {
+    "id": "ann-realizability",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 219, "endLine": 245 },
+    "type": "context",
+    "title": "Part V: Thompson's realizability theorem (the 6th axiom)",
+    "content": "`Monster_realizable_over_Q` records Thompson's 1984 result as the sixth and final axiom: there exists a finite Galois extension K/ℚ with Gal(K/ℚ) ≅ 𝕄, packaged as an existential bundling the field, its ℚ-algebra and finite-dimensionality, the `IsGalois` instance, and a `MulEquiv` to the Monster. As with Shafarevich's theorem in the parent entry, this deep landmark is cited, not reproved. `Monster_realized_beyond_Shafarevich` then pairs non-solvability with realizability in a single statement — the precise affirmative analogue of the open M₂₃ case: a non-solvable simple group that nonetheless IS realized over ℚ.",
+    "mathContext": "$\\exists K,\\ \\mathbb{Q} \\subseteq K$ finite Galois, $\\mathrm{Gal}(K/\\mathbb{Q}) \\cong \\mathbb{M}$. Thompson's proof is non-constructive (rigidity yields existence of the triple's associated cover, not an explicit polynomial).",
+    "significance": "key",
+    "relatedConcepts": ["Galois realization", "rigidity method", "IsGalois", "MulEquiv", "Thompson's theorem"],
+    "prerequisites": ["Galois extensions", "field theory", "group isomorphisms"]
+  },
+  {
+    "id": "ann-census",
+    "proofId": "inverse-galois-oq-03",
+    "range": { "startLine": 247, "endLine": 261 },
+    "type": "context",
+    "title": "Part VI: The sporadic realizability census",
+    "content": "`sporadic_census : 25 + 1 = 26` is a deliberately trivial arithmetic statement whose value is documentary: of the 26 sporadic simple groups, 25 are known to be realizable over ℚ (including the Monster, via this file) and exactly one — M₂₃ — remains open (OQ-02). The theorem anchors the surrounding prose, recording the precise state of the sporadic-group frontier of the inverse Galois problem as a machine-checked tally rather than free text.",
+    "mathContext": "$25 \\text{ realized} + 1 \\text{ open } (M_{23}) = 26 \\text{ sporadic groups}$. The Monster contributes to the 25; $M_{23}$ is the sole obstruction to a complete sporadic resolution over $\\mathbb{Q}$.",
+    "significance": "context",
+    "relatedConcepts": ["sporadic groups", "inverse Galois problem", "M₂₃", "research frontier"],
+    "prerequisites": ["finite simple group classification"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `inverse-galois-oq-03` (Inverse Galois Problem: The Monster 𝕄 — A Resolved Sporadic Case).

## Gap addressed
Rich `meta.json` (overview, 6 sections, conclusion, crossReferences) but **no `annotations.json`** — zero inline annotation coverage.

## Changes
Added `annotations.json` with **8 inline annotations** across all six parts, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. Header: Thompson's theorem & the M₂₃ contrast (rigidity method)
2. Part I: axiomatization of 𝕄 (the 6-axiom design, integrity-honest)
3. Part II: order arithmetic by `norm_num`, compositeness lever
4. Part III(a): non-commutativity (abelian simple ⟹ prime order)
5. Part III(b): perfectness, [𝕄,𝕄] = 𝕄
6. Part III(c) & IV: non-solvability and the Shafarevich barrier
7. Part V: Thompson's realizability axiom
8. Part VI: the sporadic realizability census (25 + 1 = 26)

## Verification
- JSON validates; structure checked (all annotations have range/type/title/significance).
- No changes to meta.json. Entry remains `axiomatized` / `axiom` / axiomCount 6 — annotations explicitly explain each of the 6 axioms, consistent with the axiom-integrity policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)