### PR TITLE
research(ballot-problem-oq-04-oq-02-oq-01): reduce nonCrossingCount n = catalan n to the Catalan recurrence

### DIFF
--- a/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean
@@ -1,0 +1,114 @@
+/-
+# Non-Crossing Partitions are Counted by the Catalan Numbers
+## (ballot-problem-oq-04-oq-02-oq-01)
+
+**Open question** (from `ballot-problem-oq-04-oq-02`, the countable Finpartition model):
+the sibling entry `ballot-problem-oq-04-oq-02` introduced `nonCrossingCount n`, the number
+of non-crossing partitions of `Fin n`, as a well-typed `Fintype.card`, and pinned down its
+first divergence from the Bell numbers at `n = 4`. The *exact value* was left open:
+
+> `nonCrossingCount n = catalan n`.
+
+This file supplies the **structural reduction** of that counting statement to a single
+combinatorial recurrence, and discharges everything except that recurrence.
+
+## The reduction
+
+Mathlib's Catalan numbers satisfy the convolution recurrence
+(`Mathlib.Combinatorics.Enumerative.Catalan`):
+* `catalan 0 = 1`;
+* `catalan (n+1) = ∑ (i,j) ∈ antidiagonal n, catalan i * catalan j`  (`catalan_succ'`).
+
+So `nonCrossingCount = catalan` follows by strong induction the moment we know
+`nonCrossingCount` obeys the *same* two laws:
+
+* **Base** (`nonCrossingCount_zero`): there is a unique partition of the empty set, and it
+  is (vacuously) non-crossing, so `nonCrossingCount 0 = 1`. **Proved here, 0 sorry.**
+
+* **Recurrence** (`nonCrossingCount_recurrence`):
+  `nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i * nonCrossingCount j`.
+  This is the genuine combinatorial content — the classical Catalan decomposition of a
+  non-crossing partition of `{0,…,n}` according to the block structure around a distinguished
+  point — and is **not** in Mathlib in any form. It remains a `sorry` here (HARD,
+  bijection-level formalization; see `## Status` below).
+
+Given those two, `nonCrossingCount_eq_catalan` is a four-line strong induction matching the
+`antidiagonal` shape of `catalan_succ'`. The point of this file is that it isolates the
+*entire* difficulty of `nonCrossing = Catalan` into the one recurrence lemma: a reduction in
+the spirit of "one structural theorem in place of an explicit bijection".
+
+## Status
+
+**Sorry count**: 1 (`nonCrossingCount_recurrence`). **Axiom count**: 0 literal `axiom`
+declarations; the reduction and base case use only the foundational
+`propext`/`Classical.choice`/`Quot.sound`. Because a `sorry` remains, the gallery status of
+this entry is `formalized`, not `verified`.
+
+The outstanding recurrence is the natural target for proof search: it is *known* mathematics
+(the non-crossing-partition Catalan recurrence) requiring a delicate but standard
+decomposition, exactly the regime where automated formalization is appropriate.
+-/
+
+import Mathlib
+import Proofs.BallotProblemOQ04
+import Proofs.BallotProblemOQ04OQ02
+
+open Finset
+open scoped BigOperators
+
+namespace BallotProblemOQ04OQ02OQ01
+
+open BallotProblemOQ04OQ02 (IsNonCrossingFp nonCrossingCount nonCrossingCount_eq_card_of_n_le_three)
+
+/-! ## The base case `n = 0` -/
+
+/-- **Base case.** There is exactly one partition of the empty set `Fin 0`, and (with no four
+indices to cross) it is non-crossing, so `nonCrossingCount 0 = 1 = catalan 0`. -/
+theorem nonCrossingCount_zero : nonCrossingCount 0 = 1 := by
+  rw [nonCrossingCount_eq_card_of_n_le_three (n := 0) (by norm_num)]
+  have hbot : (univ : Finset (Fin 0)) = ⊥ := by
+    rw [Finset.univ_eq_empty, Finset.bot_eq_empty]
+  simp only [hbot]
+  exact Fintype.card_unique
+
+/-! ## The combinatorial recurrence (HARD — outstanding `sorry`) -/
+
+/-- **Catalan recurrence for non-crossing partitions.** The non-crossing partitions of
+`Fin (n+1)` split — according to the classical "first return" / block decomposition of a
+non-crossing partition of a linearly ordered set — into pairs of independent non-crossing
+partitions whose sizes `(i, j)` run over `antidiagonal n`. Equivalently:
+`nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i * nonCrossingCount j`.
+
+This is the same convolution that defines `catalan` (`catalan_succ'`); proving it for
+`nonCrossingCount` is the entire combinatorial content of `nonCrossing = Catalan`, and is not
+available in Mathlib. **Outstanding `sorry`** (HARD, bijection-level). -/
+theorem nonCrossingCount_recurrence (n : ℕ) :
+    nonCrossingCount (n + 1)
+      = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 := by
+  sorry
+
+/-! ## The counting theorem -/
+
+/-- **Non-crossing partitions are counted by the Catalan numbers.**
+`nonCrossingCount n = catalan n` for every `n`. Strong induction: the base case is
+`nonCrossingCount_zero`, and the step matches `nonCrossingCount_recurrence` against
+`catalan_succ'` term-by-term over `antidiagonal n`, rewriting each factor by the inductive
+hypothesis (both indices in an `antidiagonal n` pair are `< n+1`). -/
+theorem nonCrossingCount_eq_catalan (n : ℕ) : nonCrossingCount n = catalan n := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    match n with
+    | 0 => simpa using nonCrossingCount_zero
+    | m + 1 =>
+      rw [nonCrossingCount_recurrence, catalan_succ']
+      refine Finset.sum_congr rfl ?_
+      intro ij hij
+      rw [Finset.mem_antidiagonal] at hij
+      have h1 : ij.1 < m + 1 := by omega
+      have h2 : ij.2 < m + 1 := by omega
+      rw [ih ij.1 h1, ih ij.2 h2]
+
+#check @nonCrossingCount_zero
+#check @nonCrossingCount_eq_catalan
+
+end BallotProblemOQ04OQ02OQ01

--- a/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-04-oq-02-oq-01/knowledge.md
@@ -1,0 +1,60 @@
+# ballot-problem-oq-04-oq-02-oq-01 — Non-Crossing Partitions are Counted by Catalan
+
+**Goal:** `nonCrossingCount n = catalan n`, where `nonCrossingCount n` (from
+`ballot-problem-oq-04-oq-02`) is `Fintype.card {P : Finpartition (univ : Finset (Fin n)) // IsNonCrossingFp P}`.
+
+This is **openQuestion[2]** of the sibling entry `ballot-problem-oq-04-oq-02`:
+> "Establish the Catalan recurrence directly on the Finpartition model — decompose by the
+> block containing the last index (or by first return) to obtain
+> `nonCrossingCount (n+1) = ∑ nonCrossingCount i · nonCrossingCount (n−i)`, matching Mathlib's
+> catalan recurrence without constructing the full bijection."
+
+## Summary of state
+
+The open counting statement has been **reduced to one combinatorial recurrence**. Everything
+except that recurrence is proved with 0 sorry.
+
+## Session 2026-06-26 (Session 1) — Structural reduction
+
+**Mode:** FRESH
+**Outcome:** progress (reduction + base case proved; recurrence isolated as 1 sorry)
+
+### What I did
+- Triaged the available pool. Found three Seeker "gallery-gap" candidates were already
+  proved in the gallery/Mathlib (composite Wilson converse → `WilsonsTheoremOQ01`/`OQ05OQ01`;
+  Basel π²/8 → `BaselProblemOQ09.lean:116`; X³−2 irreducibility →
+  `AngleTrisectionOQ02OQ01OQ02.lean:128`) and that Jordan–Hölder for modules is already in
+  Mathlib (`JordanHolderModule.instJordanHolderLattice`). Selected this candidate as the
+  genuine, substantive gap building on the deepest existing infrastructure.
+- Created `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean`:
+  - `nonCrossingCount_zero : nonCrossingCount 0 = 1` (0 sorry).
+  - `nonCrossingCount_recurrence` — STATED to match Mathlib's `catalan_succ'`
+    (`∑ ij ∈ antidiagonal n, …`); body is the single outstanding `sorry`.
+  - `nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n` — proved by
+    `Nat.strong_induction_on`, rewriting each antidiagonal factor by the IH (0 sorry beyond
+    its dependence on the recurrence).
+- Created the gallery entry data and research problem JSON.
+
+### Key findings
+- Mathlib's `catalan` is *defined* by the antidiagonal convolution, and `catalan_succ'`
+  exposes it; so `nonCrossingCount = catalan` is a 4-line strong induction once the same
+  recurrence is known for `nonCrossingCount`. The whole problem collapses to the recurrence.
+- The recurrence must be proved combinatorially and independently (assuming the goal would be
+  circular).
+- Mathlib has **no** non-crossing partition theory and **no** Finpartition block-gap
+  decomposition lemma — both would need to be built for the recurrence.
+
+### Files modified
+- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (new, 1 sorry)
+- `src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json` (new)
+- `src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/` (new gallery entry)
+
+### Next steps
+- Prove `nonCrossingCount_recurrence` via the first-return block decomposition: in a
+  non-crossing Finpartition of `Fin (n+1)`, the block of `0` splits the remaining indices into
+  intervals each carrying an independent non-crossing partition; assemble the `Equiv` to
+  `Σ ij ∈ antidiagonal n, (nc of Fin i) × (nc of Fin j)` and take `Fintype.card`.
+- Or build the explicit Dyck↔partition bijection (sibling `ballot-problem-oq-04-oq-01`) and
+  transport `DyckWord.card_dyckWord_semilength_eq_catalan`.
+- Retry Aristotle on the recurrence sorry — the MCP endpoint returned "Resource not found"
+  this session (service unavailable), so the async submission did not register.

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ballot-oq040201-ann-header",
+    "proofId": "ballot-problem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 62
+    },
+    "type": "context",
+    "title": "Reducing 'Non-Crossing = Catalan' to One Recurrence",
+    "content": "The parent entry built nonCrossingCount n, the count of non-crossing partitions of Fin n, but left its exact value open. The key observation here is that Mathlib's catalan is DEFINED by the antidiagonal convolution catalan (n+1) = ∑ (i,j) ∈ antidiagonal n, catalan i · catalan j (exposed as catalan_succ'). So nonCrossingCount = catalan follows by strong induction the instant nonCrossingCount is shown to satisfy the same base case and the same convolution. This file proves the base case and the strong-induction reduction outright, isolating the entire remaining difficulty into a single combinatorial recurrence lemma.",
+    "mathContext": "$\\mathrm{catalan}\\,(n{+}1) = \\sum_{i+j=n}\\mathrm{catalan}\\,i\\cdot\\mathrm{catalan}\\,j$",
+    "significance": "context",
+    "relatedConcepts": [
+      "non-crossing partitions",
+      "Catalan numbers",
+      "convolution recurrence",
+      "strong induction",
+      "proof reduction"
+    ],
+    "prerequisites": [
+      "Mathlib's catalan and catalan_succ'",
+      "the Finpartition model nonCrossingCount"
+    ]
+  },
+  {
+    "id": "ballot-oq040201-ann-base",
+    "proofId": "ballot-problem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Base Case from Uniqueness of the Empty Partition",
+    "content": "nonCrossingCount 0 = 1 is proved without any enumeration. The carrier univ : Finset (Fin 0) is the empty Finset, which is ⊥ in the Finset lattice, and Mathlib provides Unique (Finpartition ⊥): the empty set has exactly one partition. Since for n ≤ 3 every partition is vacuously non-crossing (a crossing needs four increasing indices), nonCrossingCount 0 equals Fintype.card (Finpartition ⊥) = 1 via Fintype.card_unique — matching catalan 0 = 1.",
+    "mathContext": "$\\mathrm{Finpartition}\\,\\bot$ is $\\mathrm{Unique} \\Rightarrow \\mathrm{nonCrossingCount}\\,0 = 1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Unique types",
+      "Fintype cardinality",
+      "empty partition"
+    ],
+    "prerequisites": [
+      "Unique (Finpartition ⊥)",
+      "Fintype.card_unique"
+    ]
+  },
+  {
+    "id": "ballot-oq040201-ann-recurrence",
+    "proofId": "ballot-problem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 89
+    },
+    "type": "context",
+    "title": "The Outstanding Combinatorial Recurrence (sorry)",
+    "content": "nonCrossingCount_recurrence states the Catalan convolution for the Finpartition model: nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i · nonCrossingCount j. Mathematically this is the classical block / first-return decomposition — the block containing a distinguished endpoint splits the remaining indices into intervals each carrying an independent non-crossing partition, of total size n. Mathlib has no non-crossing partition theory and no Finpartition block-gap decomposition lemma, so this must be built from scratch; it is the single sorry in the file and the reason the entry's status is 'formalized', not 'verified'. The statement is deliberately phrased to match catalan_succ' so the downstream induction is purely formal.",
+    "mathContext": "$\\mathrm{nonCrossingCount}\\,(n{+}1) = \\sum_{i+j=n}\\mathrm{nonCrossingCount}\\,i\\cdot\\mathrm{nonCrossingCount}\\,j$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "block decomposition",
+      "first-return decomposition",
+      "Catalan convolution",
+      "Mathlib gap"
+    ],
+    "prerequisites": [
+      "structure of non-crossing partitions",
+      "Fintype.card of sigma types"
+    ]
+  },
+  {
+    "id": "ballot-oq040201-ann-induction",
+    "proofId": "ballot-problem-oq-04-oq-02-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "Strong Induction Matching the Antidiagonal Sums",
+    "content": "nonCrossingCount_eq_catalan is proved by Nat.strong_induction_on. The n=0 case is nonCrossingCount_zero. For n = m+1, rewrite the left side by nonCrossingCount_recurrence and the right by catalan_succ', producing two sums over antidiagonal m; Finset.sum_congr then reduces to a term-by-term equality, and for each pair (i,j) with i+j = m the inductive hypothesis rewrites nonCrossingCount i to catalan i and nonCrossingCount j to catalan j, since both i, j < m+1. This four-line argument is exactly the reduction: every line is formal once the recurrence is available.",
+    "mathContext": "$\\mathrm{nonCrossingCount}\\,n = \\mathrm{catalan}\\,n$ (conditional on the recurrence)",
+    "significance": "critical",
+    "relatedConcepts": [
+      "strong induction",
+      "Finset.sum_congr",
+      "antidiagonal",
+      "inductive hypothesis"
+    ],
+    "prerequisites": [
+      "Nat.strong_induction_on",
+      "catalan_succ'",
+      "Finset.mem_antidiagonal"
+    ]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "ballot-problem-oq-04-oq-02-oq-01",
+  "title": "Non-Crossing Partitions are Counted by the Catalan Numbers: the Recurrence Reduction",
+  "slug": "ballot-problem-oq-04-oq-02-oq-01",
+  "description": "Answers openQuestion[2] of the sibling ballot-problem-oq-04-oq-02 up to a single combinatorial recurrence. That entry built nonCrossingCount n := Fintype.card {P : Finpartition (univ : Finset (Fin n)) // IsNonCrossingFp P}, a well-typed count of the non-crossing partitions of Fin n, and located their first divergence from the Bell numbers at n = 4, but left the exact value nonCrossingCount n = catalan n open. This entry supplies the STRUCTURAL REDUCTION of that statement to one lemma. Mathlib's Catalan numbers are defined by the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ (i,j) ∈ antidiagonal n, catalan i · catalan j), so nonCrossingCount = catalan follows by strong induction the moment nonCrossingCount obeys the same two laws. We prove the base case nonCrossingCount 0 = 1 (the empty set has a unique, vacuously non-crossing partition) and the reduction nonCrossingCount_eq_catalan (a four-line Nat.strong_induction_on matching the antidiagonal shape of catalan_succ' term-by-term), discharging everything EXCEPT the recurrence nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i · nonCrossingCount j. That recurrence — the classical block / first-return decomposition of a non-crossing partition of a linearly ordered (n+1)-element set into two independent non-crossing partitions whose sizes sum to n — is the genuine combinatorial content, is not in Mathlib in any form, and remains a single sorry. The contribution is the isolation of the entire difficulty of 'non-crossing = Catalan' into that one recurrence: a reduction in the spirit of replacing an explicit bijection with one structural identity.",
+  "meta": {
+    "author": "Non-crossing partitions (Kreweras 1972); formalized via Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Noncrossing_partition",
+    "date": "1972",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/BallotProblemOQ04OQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "non-crossing-partitions",
+      "catalan",
+      "finpartition",
+      "recurrence",
+      "strong-induction",
+      "ballot-problem",
+      "research",
+      "open-problem"
+    ],
+    "badge": "wip",
+    "sorries": 1,
+    "axiomCount": 0,
+    "assumptions": "1 sorry: nonCrossingCount_recurrence (the combinatorial Catalan convolution recurrence for non-crossing Finpartitions; HARD, bijection-level, no Mathlib support). 0 literal `axiom` declarations. The proved parts (nonCrossingCount_zero, and the nonCrossingCount_eq_catalan reduction) depend only on the foundational axioms propext / Classical.choice / Quot.sound; no native_decide, no Lean.ofReduceBool. Because a sorry remains, this entry is `formalized`, not `verified` — the headline equality nonCrossingCount n = catalan n is proved CONDITIONAL on the outstanding recurrence.",
+    "dateAdded": "2026-06-26",
+    "lineCount": 114,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "catalan_succ'",
+        "description": "catalan (n+1) = ∑ ij ∈ antidiagonal n, catalan ij.1 * catalan ij.2 — exposes the Catalan numbers as the antidiagonal convolution, the exact shape the recurrence reduction matches against",
+        "module": "Mathlib.Combinatorics.Enumerative.Catalan"
+      },
+      {
+        "theorem": "Nat.strong_induction_on",
+        "description": "strong induction on ℕ; both antidiagonal indices i, j of an antidiagonal n pair are < n+1, so the inductive hypothesis applies to each factor",
+        "module": "Mathlib.Init.Data.Nat.Lemmas"
+      },
+      {
+        "theorem": "Fintype.card_unique",
+        "description": "Fintype.card α = 1 when α is Unique; with Unique (Finpartition ⊥) gives the base case nonCrossingCount 0 = 1",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finpartition.instUnique (Finpartition ⊥)",
+        "description": "there is a unique partition of the empty (bottom) set; underlies nonCrossingCount 0 = 1 after rewriting univ : Finset (Fin 0) = ⊥",
+        "module": "Mathlib.Order.Partition.Finpartition"
+      },
+      {
+        "theorem": "Finset.mem_antidiagonal",
+        "description": "ij ∈ antidiagonal n ↔ ij.1 + ij.2 = n; used to bound both indices below n+1 so the IH applies",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      }
+    ],
+    "originalContributions": [
+      "nonCrossingCount_zero : nonCrossingCount 0 = 1 — the empty set has a unique, vacuously non-crossing partition (via nonCrossingCount_eq_card_of_n_le_three, Unique (Finpartition ⊥), Fintype.card_unique). 0 sorry.",
+      "nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n — the reduction: a Nat.strong_induction_on whose step rewrites nonCrossingCount (n+1) by the recurrence, rewrites catalan (n+1) by catalan_succ', and matches the two antidiagonal sums term-by-term using the inductive hypothesis on each factor (both < n+1). 0 sorry beyond its dependence on the recurrence.",
+      "nonCrossingCount_recurrence (statement): nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — the Catalan convolution for the Finpartition model, stated to match catalan_succ' so the reduction is purely formal. Its proof (the block/first-return decomposition) is the single outstanding sorry and the entire remaining combinatorial content."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Non-crossing partitions of a linearly ordered n-element set (Kreweras 1972) are one of the canonical Catalan families, alongside Dyck words and ballot sequences. The grandparent entry ballot-problem-oq-04 introduced them to Lean as a setoid predicate; the parent ballot-problem-oq-04-oq-02 ported them to Mathlib's Fintype-bearing Finpartition, defined the count nonCrossingCount n, and proved n = 4 is the first point where the count drops below the Bell number (catalan 4 = 14 < 15 = Bell 4). The exact enumeration nonCrossingCount n = catalan n was left as the parent's openQuestion[2], to be proved either by the explicit Dyck-word bijection (sibling oq-04-oq-01) or by establishing the Catalan recurrence directly on the Finpartition model. This entry takes the latter route and carries it as far as a single combinatorial lemma.",
+    "problemStatement": "Prove nonCrossingCount n = catalan n. Reduce it, with full rigour, to the single recurrence nonCrossingCount (n+1) = ∑ (i,j) ∈ antidiagonal n, nonCrossingCount i · nonCrossingCount j, matching Mathlib's catalan recurrence.",
+    "proofStrategy": "Mathlib's catalan is DEFINED by the antidiagonal convolution and catalan_succ' exposes it. So if nonCrossingCount satisfies (i) nonCrossingCount 0 = 1 and (ii) the same convolution recurrence, then nonCrossingCount = catalan by strong induction. (i) is proved here: univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, and for n ≤ 3 every partition is non-crossing, so nonCrossingCount 0 = Fintype.card (Finpartition ⊥) = 1. (ii) is STATED as nonCrossingCount_recurrence and used to prove nonCrossingCount_eq_catalan: Nat.strong_induction_on n; the n=0 case is (i); the n=m+1 case rewrites the left side by the recurrence, the right by catalan_succ', and applies Finset.sum_congr over antidiagonal m, rewriting each factor nonCrossingCount i (resp. j) to catalan i (resp. j) by the inductive hypothesis, valid because i, j < m+1. The recurrence's own proof — decomposing a non-crossing Finpartition of Fin (n+1) by the block structure around a distinguished point into independent non-crossing partitions of complementary intervals — is the outstanding sorry.",
+    "keyInsights": [
+      "**The whole problem collapses to one recurrence.** Because Mathlib's catalan IS the antidiagonal convolution (catalan_succ'), proving nonCrossingCount obeys the identical convolution plus the base case settles nonCrossingCount = catalan by a four-line strong induction. The reduction isolates 100% of the difficulty into nonCrossingCount_recurrence.",
+      "**The recurrence cannot be assumed.** Deriving it requires an independent combinatorial argument (the block / first-return decomposition); using nonCrossingCount = catalan to obtain it would be circular. This is why it is the genuine content and the honest sorry.",
+      "**Base case via uniqueness, not computation.** nonCrossingCount 0 = 1 falls out of Unique (Finpartition ⊥) once univ : Finset (Fin 0) is identified with ⊥ — no enumeration, and it matches catalan 0 = 1 exactly.",
+      "**Mathlib has no non-crossing partition theory.** There is no nonCrossing/NonCrossingPartition anywhere in Mathlib and no Finpartition block-gap decomposition lemma, so the recurrence has nothing to transport from and must be built from scratch — the reason it remains open."
+    ],
+    "prerequisites": [
+      "The parent's Finpartition model nonCrossingCount and nonCrossingCount_eq_card_of_n_le_three (ballot-problem-oq-04-oq-02)",
+      "Mathlib's Catalan numbers and catalan_succ' (antidiagonal convolution)",
+      "Strong induction on ℕ and Finset.sum_congr over antidiagonal",
+      "Uniqueness of the partition of the empty set (Unique (Finpartition ⊥)) and Fintype.card_unique"
+    ],
+    "what": "A rigorous reduction of the open enumeration nonCrossingCount n = catalan n to a single combinatorial recurrence: the base case nonCrossingCount 0 = 1 and the strong-induction argument nonCrossingCount_eq_catalan are proved (0 sorry), leaving only the Catalan convolution recurrence nonCrossingCount_recurrence (1 sorry) as the entire remaining content.",
+    "how": "State nonCrossingCount_recurrence to match Mathlib's catalan_succ'; prove nonCrossingCount 0 = 1 from Unique (Finpartition ⊥); then prove nonCrossingCount_eq_catalan by strong induction, matching the two antidiagonal sums term-by-term via the inductive hypothesis.",
+    "significance": "Reduces the parent entry's openQuestion[2] to one well-defined lemma, demonstrating that 'non-crossing partitions are counted by Catalan' is, modulo the standard block decomposition, a purely formal consequence of Mathlib's definition of catalan. It pinpoints the exact missing piece (a Finpartition block/first-return decomposition, absent from Mathlib) and packages it as a single sorry suitable for focused proof search, rather than leaving the whole enumeration open."
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement and Reduction Plan",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring: the reduction of nonCrossingCount n = catalan n to the base case plus the Catalan convolution recurrence, the strong-induction argument that closes the gap, and an honest status note (1 sorry, the recurrence).",
+      "mathContext": "$\\mathrm{nonCrossingCount}\\,n = \\mathrm{catalan}\\,n$"
+    },
+    {
+      "id": "base-case",
+      "title": "The Base Case n = 0",
+      "startLine": 63,
+      "endLine": 73,
+      "summary": "nonCrossingCount_zero : nonCrossingCount 0 = 1 — univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, and every partition for n ≤ 3 is non-crossing, so the count is Fintype.card_unique = 1.",
+      "mathContext": "$\\mathrm{nonCrossingCount}\\,0 = 1 = \\mathrm{catalan}\\,0$"
+    },
+    {
+      "id": "recurrence",
+      "title": "The Combinatorial Recurrence (Outstanding sorry)",
+      "startLine": 74,
+      "endLine": 89,
+      "summary": "nonCrossingCount_recurrence : nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — the block/first-return decomposition of a non-crossing partition into independent sub-partitions; stated to match catalan_succ', proof is the single sorry.",
+      "mathContext": "$\\mathrm{nonCrossingCount}\\,(n{+}1) = \\sum_{i+j=n} \\mathrm{nonCrossingCount}\\,i \\cdot \\mathrm{nonCrossingCount}\\,j$"
+    },
+    {
+      "id": "counting-theorem",
+      "title": "The Counting Theorem via Strong Induction",
+      "startLine": 90,
+      "endLine": 114,
+      "summary": "nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n — Nat.strong_induction_on; base case from nonCrossingCount_zero, step rewrites by the recurrence and catalan_succ' and matches the antidiagonal sums term-by-term via the IH (both indices < n+1).",
+      "mathContext": "$\\mathrm{nonCrossingCount}\\,n = \\mathrm{catalan}\\,n$"
+    }
+  ],
+  "conclusion": {
+    "summary": "Reduces the open enumeration nonCrossingCount n = catalan n to a single combinatorial recurrence. The base case nonCrossingCount 0 = 1 (uniqueness of the empty partition) and the reduction nonCrossingCount_eq_catalan (strong induction matching Mathlib's catalan_succ' term-by-term) are proved with 0 sorry; the Catalan convolution recurrence for the Finpartition model remains a single sorry. Status formalized (not verified): the headline equality is proved conditional on that recurrence.",
+    "implications": "Pinpoints the exact remaining obstacle to the parent's openQuestion[2]: a block/first-return decomposition of non-crossing Finpartitions, which Mathlib lacks entirely. Once that recurrence is proved (by direct decomposition or by transporting the explicit Dyck-word bijection of sibling oq-04-oq-01), nonCrossingCount n = catalan n follows immediately from this file.",
+    "openQuestions": [
+      "Prove nonCrossingCount_recurrence directly: build the Equiv from non-crossing Finpartitions of Fin (n+1) to Σ (i,j) ∈ antidiagonal n of pairs of non-crossing Finpartitions (via the block of the last/first point and the gaps it induces), then take Fintype.card.",
+      "Alternatively transport DyckWord.card_dyckWord_semilength_eq_catalan along the explicit Dyck-word ↔ non-crossing-partition bijection (sibling ballot-problem-oq-04-oq-01) to obtain the recurrence or the equality directly."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "xref-ballot-oq0402-parent",
+      "targetId": "ballot-problem-oq-04-oq-02",
+      "relationship": "extends",
+      "description": "Answers the parent's openQuestion[2] up to one recurrence: reuses nonCrossingCount and nonCrossingCount_eq_card_of_n_le_three to prove the base case and reduce nonCrossingCount n = catalan n to the Catalan convolution on the Finpartition model."
+    },
+    {
+      "id": "xref-ballot-oq0401-sibling",
+      "targetId": "ballot-problem-oq-04-oq-01",
+      "relationship": "relatedTo",
+      "description": "The sibling explicit Dyck-word ↔ non-crossing-partition bijection is the alternative route to the outstanding recurrence; transporting DyckWord.card_dyckWord_semilength_eq_catalan along it would discharge this entry's remaining sorry."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 114,
+    "path": "Proofs/BallotProblemOQ04OQ02OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 1,
+    "definitionCount": 0,
+    "theoremCount": 3
+  },
+  "sorries": 1
+}

--- a/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json
@@ -1,0 +1,58 @@
+{
+  "slug": "ballot-problem-oq-04-oq-02-oq-01",
+  "title": "Non-Crossing Partitions are Counted by the Catalan Numbers (nonCrossingCount n = catalan n)",
+  "status": "in-progress",
+  "phase": "ACT",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 8,
+  "problemStatement": "Prove nonCrossingCount n = catalan n, where nonCrossingCount n (from ballot-problem-oq-04-oq-02) is the cardinality of non-crossing Finpartitions of Fin n. This is openQuestion[2] of the sibling entry: establish the Catalan convolution recurrence directly on the Finpartition model rather than via the full Dyck-word bijection.",
+  "knowledge": {
+    "progressSummary": "PROGRESS: reduced the open counting statement to a single combinatorial recurrence. Base case (nonCrossingCount 0 = 1) and the strong-induction reduction (recurrence + base ⟹ nonCrossingCount = catalan) proved with 0 sorry; the recurrence itself remains 1 sorry (HARD, bijection-level).",
+    "builtItems": [
+      "BallotProblemOQ04OQ02OQ01.nonCrossingCount_zero : nonCrossingCount 0 = 1 (via nonCrossingCount_eq_card_of_n_le_three + Unique (Finpartition ⊥) + Fintype.card_unique). 0 sorry.",
+      "BallotProblemOQ04OQ02OQ01.nonCrossingCount_eq_catalan : nonCrossingCount n = catalan n, proved by Nat.strong_induction_on, matching nonCrossingCount_recurrence against Mathlib catalan_succ' term-by-term over antidiagonal n. Depends on the recurrence sorry; reduction itself 0 sorry.",
+      "BallotProblemOQ04OQ02OQ01.nonCrossingCount_recurrence (n) : nonCrossingCount (n+1) = ∑ ij ∈ antidiagonal n, nonCrossingCount ij.1 * nonCrossingCount ij.2 — STATED, body is the single outstanding sorry."
+    ],
+    "insights": [
+      "Mathlib's catalan is defined by exactly the antidiagonal convolution (catalan_succ': catalan (n+1) = ∑ ij ∈ antidiagonal n, catalan ij.1 * catalan ij.2), so proving nonCrossingCount obeys the SAME recurrence + base reduces nonCrossingCount = catalan to a four-line strong induction. The entire difficulty is isolated into the one recurrence lemma.",
+      "Base case n=0 is clean: univ : Finset (Fin 0) = ⊥, Finpartition ⊥ is Unique, all partitions are non-crossing for n ≤ 3, so nonCrossingCount 0 = 1 = catalan 0.",
+      "The recurrence must be proved INDEPENDENTLY (combinatorially) — one cannot assume nonCrossingCount = catalan to get it, else the induction is circular. It is the genuine block/first-return decomposition of a non-crossing partition of a linearly ordered (n+1)-set.",
+      "This is exactly the path the sibling ballot-problem-oq-04-oq-02 flagged as its openQuestion[2] ('establish the Catalan recurrence directly on the Finpartition model ... without constructing the full bijection')."
+    ],
+    "mathlibGaps": [
+      "Mathlib has no theory of non-crossing partitions at all (confirmed: no nonCrossing/NonCrossingPartition anywhere in Mathlib source). The recurrence has no Mathlib analogue to transport.",
+      "No Mathlib lemma decomposes a Finpartition of Fin (n+1) by the block containing a distinguished index into independent sub-partitions of the complementary gaps; this is the missing infrastructure for the recurrence."
+    ],
+    "nextSteps": [
+      "Prove nonCrossingCount_recurrence. Recommended decomposition: in a non-crossing Finpartition of Fin (n+1), split on the position k where the block of the last point 'first returns' (the smallest element sharing 0's block, or the arch closing at 0), giving an independent non-crossing partition of an i-element interval and an (n−i)-element interval. Build the Equiv to Σ ij ∈ antidiagonal n, (nc partitions of Fin i) × (nc partitions of Fin j) and take Fintype.card.",
+      "Alternative: construct the explicit Dyck-word ↔ non-crossing-partition bijection (sibling ballot-problem-oq-04-oq-01) and transport DyckWord.card_dyckWord_semilength_eq_catalan; heavier but reuses Mathlib's Dyck side.",
+      "Aristotle submission of the recurrence sorry was attempted but the MCP endpoint returned 'Resource not found' (service unavailable this session); retry the async submission next session."
+    ]
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-26T00:00:00.000Z",
+    "iteration": 1,
+    "focus": "Structural reduction of nonCrossingCount = catalan to the Catalan convolution recurrence on the Finpartition model.",
+    "blockers": [
+      "The combinatorial recurrence nonCrossingCount_recurrence (block decomposition of non-crossing Finpartitions) — HARD, bijection-level, no Mathlib support."
+    ],
+    "nextAction": "Prove nonCrossingCount_recurrence via the first-return block decomposition, or submit to Aristotle when the endpoint recovers.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "tags": [
+    "combinatorics",
+    "non-crossing-partitions",
+    "catalan",
+    "finpartition",
+    "ballot-problem",
+    "research",
+    "open-problem"
+  ],
+  "lastUpdate": "2026-06-26T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

Addresses **openQuestion[2]** of the sibling gallery entry `ballot-problem-oq-04-oq-02`:

> "Establish the Catalan recurrence directly on the Finpartition model … to obtain
> `nonCrossingCount (n+1) = ∑ nonCrossingCount i · nonCrossingCount (n−i)`, matching Mathlib's
> catalan recurrence without constructing the full bijection."

This PR supplies the **structural reduction** of `nonCrossingCount n = catalan n` to that one
combinatorial recurrence, and discharges everything except the recurrence.

## What is proved (build-verified, 0 sorry in these)

- `nonCrossingCount_zero : nonCrossingCount 0 = 1` — the empty set has a unique, vacuously
  non-crossing partition (`Unique (Finpartition ⊥)` + `Fintype.card_unique`).
- `nonCrossingCount_eq_catalan : ∀ n, nonCrossingCount n = catalan n` — a four-line
  `Nat.strong_induction_on` that matches `nonCrossingCount_recurrence` against Mathlib's
  `catalan_succ'` term-by-term over `antidiagonal n`, rewriting each factor by the IH.

## What remains (1 sorry)

- `nonCrossingCount_recurrence` — the Catalan convolution for the Finpartition model: the
  classical block / first-return decomposition of a non-crossing partition of a linearly
  ordered `(n+1)`-set into two independent non-crossing partitions. **Not in Mathlib** (no
  non-crossing partition theory, no Finpartition block-gap decomposition); it is the entire
  remaining combinatorial content. The reduction isolates 100% of the difficulty here.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ04OQ02OQ01` → **Build completed
  successfully**; only warning is the expected `sorry` (line 88, the recurrence).
- 1 `sorry`, 0 `axiom` declarations. Gallery status: `formalized` / badge `wip` / `sorries: 1`.
  The headline equality is proved **conditional** on the outstanding recurrence (disclosed
  honestly in `meta.json`).

## Files
- `proofs/Proofs/BallotProblemOQ04OQ02OQ01.lean` (new)
- `src/data/proofs/ballot-problem-oq-04-oq-02-oq-01/{meta,annotations}.json` (new gallery entry)
- `src/data/research/problems/ballot-problem-oq-04-oq-02-oq-01.json` + `research/problems/.../knowledge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)