### PR TITLE
fix(szemeredi-regularity-oq-03): correct meta theoremCount/lineCount to match source

### DIFF
--- a/src/data/proofs/szemeredi-regularity-oq-03/meta.json
+++ b/src/data/proofs/szemeredi-regularity-oq-03/meta.json
@@ -41,10 +41,10 @@
       "regularity_rounds_le_eps_pow: with the standard ε⁵ energy increment, T ≤ ε⁻⁵",
       "n-independence example: at ε = 1/10 the round count is ≤ 100000 regardless of graph size"
     ],
-    "lineCount": 217,
+    "lineCount": 251,
     "assumptions": "0 axioms, 0 sorries. The per-round energy increment enters as a theorem hypothesis (the ADLRY algorithmic input), not as an axiom: the gallery's 1/k²-normalised partitionEnergy does not admit a direct increment proof. All results are fully machine-checked.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 0
   },
   "overview": {


### PR DESCRIPTION
Follow-up to merged PR #30401. The top-level `meta` block carried stale counts (`theoremCount: 8`, `lineCount: 217`) while the actual Lean source `proofs/Proofs/SzemerediRegularityOQ03.lean` has **11 theorems over 251 lines** — already reflected correctly in the `leanFile` block and in #30401's description. This aligns the gallery-displayed counts with the source.

No proof or status changes: still `verified` / `mathlib`, 0 axioms / 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)