### PR TITLE
research(sqrt2-irrational-oq-03): full nth-root irrationality iff + decidable perfect-power test

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3994,6 +3994,7 @@ import Proofs.Sqrt2FromAxiomsOQ01
 import Proofs.Sqrt2Irrational
 import Proofs.Sqrt2IrrationalFromAxioms
 import Proofs.Sqrt2IrrationalOQ02
+import Proofs.Sqrt2IrrationalOQ03
 import Proofs.Sqrt2Minpoly
 import Proofs.Sqrt2MinpolyOQ01
 import Proofs.Sqrt2MinpolyOQ01OQ02

--- a/proofs/Proofs/Sqrt2IrrationalOQ03.lean
+++ b/proofs/Proofs/Sqrt2IrrationalOQ03.lean
@@ -1,0 +1,144 @@
+/-
+Proof: Irrationality of nth Roots — the full iff characterization
+Source problem: sqrt2-irrational-oq-03
+  "Can this generalize to √[n]{m}? Yes! √[n]{m} is irrational iff m is not a
+   perfect n-th power."
+
+This file answers the open question attached to the √2-irrationality entry by
+upgrading the *one-directional* result already in the gallery
+(`NthRootIrrational.irrational_nthRoot`, which only gives
+"not a perfect power ⟹ irrational") to a complete **iff characterization**:
+
+    Irrational (m ^ (1/n))  ↔  ¬ ∃ k : ℕ, k ^ n = m        (for n ≠ 0).
+
+Mathlib packages the *square-root* case as an iff
+(`irrational_sqrt_natCast_iff : Irrational (√n) ↔ ¬IsSquare n`) but provides only
+a one-directional lemma for general nth roots (`irrational_nrt_of_notint_nrt`).
+We close that gap here.
+
+We additionally reduce the perfect-power test to a **bounded, decidable** search
+(`exists_nthPow_iff_bounded`), which lets every concrete instance be discharged by
+`decide`. This subsumes the case-by-case enumeration in `NthRootIrrational.lean`
+(`two_not_perfect_cube`, `three_not_perfect_cube`, `two_not_perfect_fifth`, …):
+each of those becomes a one-line `decide`.
+
+No sorries, no axioms beyond Mathlib's foundations.
+-/
+import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+
+namespace Sqrt2IrrationalOQ03
+
+/- ## The nth root function -/
+
+/-- The real nth root of a natural number `m`, namely `m ^ (1/n)`. -/
+noncomputable def nthRoot (n m : ℕ) : ℝ := (m : ℝ) ^ ((n : ℝ)⁻¹)
+
+theorem nthRoot_nonneg (n m : ℕ) : 0 ≤ nthRoot n m :=
+  Real.rpow_nonneg (by positivity) _
+
+/-- The defining identity: `(m ^ (1/n)) ^ n = m` for `n ≠ 0`. -/
+theorem nthRoot_pow {n : ℕ} (m : ℕ) (hn : n ≠ 0) : nthRoot n m ^ n = m := by
+  unfold nthRoot
+  exact Real.rpow_inv_natCast_pow (by positivity) hn
+
+/- ## The iff characterization -/
+
+/-- **nth roots: the full characterization.**
+
+For `n ≠ 0`, the real number `m ^ (1/n)` is irrational **iff** `m` is not a perfect
+nth power. Both directions are proved:
+
+* (⟸) If no natural `k` has `k ^ n = m`, then `m ^ (1/n)` is irrational
+  (via Mathlib's `irrational_nrt_of_notint_nrt`).
+* (⟹) If some `k` has `k ^ n = m`, then `m ^ (1/n) = k` is a natural number,
+  hence not irrational. -/
+theorem irrational_nthRoot_iff {n m : ℕ} (hn : n ≠ 0) :
+    Irrational (nthRoot n m) ↔ ¬ ∃ k : ℕ, k ^ n = m := by
+  constructor
+  · -- irrational ⟹ not a perfect power
+    rintro hirr ⟨k, hk⟩
+    have hval : nthRoot n m = (k : ℝ) := by
+      unfold nthRoot
+      rw [← hk]
+      push_cast
+      exact Real.pow_rpow_inv_natCast (Nat.cast_nonneg k) hn
+    rw [hval] at hirr
+    exact (Nat.not_irrational k) hirr
+  · -- not a perfect power ⟹ irrational
+    intro hm
+    have hpow : nthRoot n m ^ n = ((m : ℤ) : ℝ) := by
+      have := nthRoot_pow m hn; push_cast; push_cast at this; exact this
+    apply irrational_nrt_of_notint_nrt n (m : ℤ) hpow _ (Nat.pos_of_ne_zero hn)
+    rintro ⟨y, hy⟩
+    apply hm
+    -- `y` is the integer value of the root; it is nonnegative
+    have hy0 : (0 : ℝ) ≤ (y : ℝ) := hy ▸ nthRoot_nonneg n m
+    have hyZ : (0 : ℤ) ≤ y := by exact_mod_cast hy0
+    -- transport the power identity along `nthRoot n m = y`
+    have hyn : (y : ℤ) ^ n = (m : ℤ) := by
+      have : ((y : ℝ)) ^ n = ((m : ℤ) : ℝ) := by rw [← hy]; exact hpow
+      exact_mod_cast this
+    refine ⟨y.toNat, ?_⟩
+    have : ((y.toNat : ℤ)) = y := Int.toNat_of_nonneg hyZ
+    have : ((y.toNat : ℤ)) ^ n = (m : ℤ) := by rw [this]; exact hyn
+    exact_mod_cast this
+
+/- ## Bounded, decidable perfect-power test -/
+
+/-- The unbounded perfect-power existential reduces to a **bounded** one: any witness
+`k` with `k ^ n = m` satisfies `k ≤ m` (because `k ≤ k ^ n` for `n ≠ 0`). The
+right-hand side is decidable, so concrete instances are settled by `decide`. -/
+theorem exists_nthPow_iff_bounded {n : ℕ} (m : ℕ) (hn : n ≠ 0) :
+    (∃ k : ℕ, k ^ n = m) ↔ ∃ k ∈ Finset.range (m + 1), k ^ n = m := by
+  constructor
+  · rintro ⟨k, hk⟩
+    have hkm : k ≤ m := by
+      calc k ≤ k ^ n := Nat.le_self_pow hn k
+        _ = m := hk
+    exact ⟨k, Finset.mem_range.mpr (by omega), hk⟩
+  · rintro ⟨k, _, hk⟩
+    exact ⟨k, hk⟩
+
+/-- Decidable repackaging: for `n ≠ 0`, irrationality of `m ^ (1/n)` is equivalent to
+a decidable bounded search failing. -/
+theorem irrational_nthRoot_iff_bounded {n m : ℕ} (hn : n ≠ 0) :
+    Irrational (nthRoot n m) ↔ ¬ ∃ k ∈ Finset.range (m + 1), k ^ n = m := by
+  rw [irrational_nthRoot_iff hn, exists_nthPow_iff_bounded m hn]
+
+/- ## The converse direction, stated cleanly -/
+
+/-- If `m` **is** a perfect nth power, then `m ^ (1/n)` is rational (a natural
+number), hence not irrational. This is the contrapositive content of the forward
+implication, isolated for reference. -/
+theorem not_irrational_nthRoot_of_perfectPow {n m : ℕ} (hn : n ≠ 0)
+    (h : ∃ k : ℕ, k ^ n = m) : ¬ Irrational (nthRoot n m) := by
+  rw [irrational_nthRoot_iff hn]; exact fun hneg => hneg h
+
+/- ## Concrete instances — each a one-line `decide`, replacing manual enumeration -/
+
+/-- `∛2` is irrational (n = 3, m = 2). -/
+theorem irrational_cbrt_two : Irrational (nthRoot 3 2) := by
+  rw [irrational_nthRoot_iff_bounded (by norm_num)]; decide
+
+/-- `∛3` is irrational. -/
+theorem irrational_cbrt_three : Irrational (nthRoot 3 3) := by
+  rw [irrational_nthRoot_iff_bounded (by norm_num)]; decide
+
+/-- `⁴√3` is irrational (n = 4, m = 3). -/
+theorem irrational_fourthRoot_three : Irrational (nthRoot 4 3) := by
+  rw [irrational_nthRoot_iff_bounded (by norm_num)]; decide
+
+/-- `⁵√2` is irrational (n = 5, m = 2). -/
+theorem irrational_fifthRoot_two : Irrational (nthRoot 5 2) := by
+  rw [irrational_nthRoot_iff_bounded (by norm_num)]; decide
+
+/-- `√2` is irrational, recovered as the n = 2 case of the same characterization. -/
+theorem irrational_sqrt_two : Irrational (nthRoot 2 2) := by
+  rw [irrational_nthRoot_iff_bounded (by norm_num)]; decide
+
+/-- The converse side in action: `∛8 = 2` is **not** irrational, since `8 = 2³`. -/
+theorem not_irrational_cbrt_eight : ¬ Irrational (nthRoot 3 8) :=
+  not_irrational_nthRoot_of_perfectPow (by norm_num) ⟨2, by norm_num⟩
+
+end Sqrt2IrrationalOQ03

--- a/research/problems/sqrt2-irrational-oq-03/knowledge.md
+++ b/research/problems/sqrt2-irrational-oq-03/knowledge.md
@@ -72,3 +72,37 @@ None - proof is complete.
 
 - Problem was completed 2026-02-08 but pool entry wasn't updated
 - The src/data/research/problems/sqrt2-irrational-oq-03.json was deleted in commit feeb8c1c9 as part of format migration, but pool wasn't updated
+
+## Session 2026-06-26 (Strengthening) - Full iff + Decidability
+
+**Mode**: REVISIT (problem already graduated via forward direction)
+**Outcome**: progress (new infrastructure on a completed problem)
+
+### What I Did
+- Found that the prior graduation (`NthRootIrrational.lean` → gallery `nth-root-irrational`)
+  delivered only the FORWARD direction plus a hand-written enumeration of non-powers
+  (`two_not_perfect_cube`, `three_not_perfect_cube`, …). The OQ itself asks for an *iff*.
+- Wrote `proofs/Proofs/Sqrt2IrrationalOQ03.lean` (12 thm / 1 def / 0 sorry / 0 axiom, builds
+  in Docker, Mathlib v4.26.0) providing:
+  - `irrational_nthRoot_iff`: the full iff `Irrational (m^(1/n)) ↔ ¬∃k, k^n=m` for `n ≠ 0`.
+  - `exists_nthPow_iff_bounded` + `irrational_nthRoot_iff_bounded`: a bounded, decidable
+    reduction of the perfect-power test (`k ≤ k^n = m` via `Nat.le_self_pow`), so concrete
+    cases (∛2, ∛3, ⁴√3, ⁵√2, √2) are one-line `decide` — subsuming the manual enumeration.
+  - `not_irrational_nthRoot_of_perfectPow`: the converse, with ∛8 = 2 as a worked instance.
+- Added gallery entry `src/data/proofs/sqrt2-irrational-oq-03/` (verified, badge mathlib),
+  cross-referenced to `sqrt2-irrational` (extends) and `nth-root-irrational` (generalizes).
+
+### Key Findings
+- Mathlib packages the iff only for SQUARE roots (`irrational_sqrt_natCast_iff`); the
+  general nth-root iff is an upstream gap — a clean Mathlib-contribution candidate.
+- Bounding the witness (`k ≤ k^n = m`) is exactly what turns the characterization decidable.
+
+### Files Modified
+- proofs/Proofs/Sqrt2IrrationalOQ03.lean (new)
+- proofs/Proofs.lean (import)
+- src/data/proofs/sqrt2-irrational-oq-03/meta.json (new)
+- src/data/research/problems/sqrt2-irrational-oq-03.json (knowledge)
+
+### Next Steps
+- Upstream `irrational_nthRoot_iff` to Mathlib.
+- Extend to rational radicands; add a global `Decidable (Irrational (nthRoot n m))` instance.

--- a/src/data/proofs/sqrt2-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-irrational-oq-03/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "sqrt2-irrational-oq-03",
+  "title": "nth Roots: Irrational iff Not a Perfect Power",
+  "slug": "sqrt2-irrational-oq-03",
+  "description": "Generalizes the parent's square-root result to all nth roots, and upgrades the gallery's one-directional nth-root lemma to a full iff characterization: for n ≠ 0, the real number m^(1/n) is irrational if and only if m is not a perfect n-th power. Mathlib packages the square-root case as an iff (irrational_sqrt_natCast_iff) but offers only a one-directional lemma for general nth roots; this entry closes that gap. A bounded, decidable reduction of the perfect-power test then collapses the usual case-by-case enumeration (∛2, ⁴√3, ⁵√2, …) into single-line `decide` proofs. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-26",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2IrrationalOQ03.lean",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "nth-roots",
+      "perfect-powers",
+      "decidability",
+      "rpow"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-26",
+    "axiomCount": 0,
+    "assumptions": "None (0 axioms, 0 sorries). The forward implication reuses Mathlib's irrational_nrt_of_notint_nrt and the rpow inverse-power identities (Real.rpow_inv_natCast_pow, Real.pow_rpow_inv_natCast); the concrete instances use the kernel `decide` tactic (not `native_decide`), so the only axioms are the foundational propext, Classical.choice, Quot.sound — no Lean.ofReduceBool.",
+    "lineCount": 144,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "originalContributions": [
+      "irrational_nthRoot_iff: the full iff characterization Irrational (m^(1/n)) ↔ ¬∃ k, k^n = m for n ≠ 0 — both directions, generalizing Mathlib's square-root-only irrational_sqrt_natCast_iff and the gallery's one-directional irrational_nthRoot",
+      "exists_nthPow_iff_bounded: reduces the unbounded perfect-power existential to a bounded Finset search (any witness k satisfies k ≤ k^n = m), making the test decidable",
+      "irrational_nthRoot_iff_bounded: decidable repackaging that lets every concrete nth-root irrationality be proved by `decide`",
+      "not_irrational_nthRoot_of_perfectPow: the converse side, isolating perfect-power ⟹ rational",
+      "irrational_cbrt_two/irrational_cbrt_three/irrational_fourthRoot_three/irrational_fifthRoot_two/irrational_sqrt_two: concrete instances, each a one-line `decide`, replacing the manual two_not_perfect_cube-style enumeration",
+      "not_irrational_cbrt_eight: the converse in action — ∛8 = 2 is rational since 8 = 2³"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classical proof that √2 is irrational generalizes to √n for non-square n, and further to nth roots: m^(1/n) is rational only when m is a perfect n-th power. The square-root case is the one most often formalized, and Mathlib records it as a clean equivalence (irrational_sqrt_natCast_iff). For general nth roots Mathlib supplies the harder forward direction (irrational_nrt_of_notint_nrt) but stops short of the iff. The gallery's NthRootIrrational entry likewise proves only 'not a perfect power ⟹ irrational' and then enumerates individual non-powers (2 is not a cube, 3 is not a cube, …).",
+    "problemStatement": "Does the √2 irrationality argument generalize to nth roots, and can the characterization be stated as a single iff? Answer: yes — m^(1/n) is irrational iff m is not a perfect n-th power.",
+    "text": "We define nthRoot n m = m^(1/n) via real rpow and prove the defining identity (nthRoot n m)^n = m for n ≠ 0. The main theorem irrational_nthRoot_iff gives both directions: if m is not a perfect n-th power then m^(1/n) is irrational (Mathlib's irrational_nrt_of_notint_nrt applied to the power identity, after ruling out an integer value); conversely if m = k^n then m^(1/n) = k is a natural number and hence not irrational. We then observe that any witness k of k^n = m satisfies k ≤ k^n = m (Nat.le_self_pow), so the perfect-power test is a bounded Finset search — exists_nthPow_iff_bounded — and irrational_nthRoot_iff_bounded turns the whole characterization decidable. Concrete irrationalities (∛2, ∛3, ⁴√3, ⁵√2, √2) follow by `decide`.",
+    "proofStrategy": "Reduce irrationality to a power identity via Mathlib's nth-root machinery for the forward direction; invert the root through Real.pow_rpow_inv_natCast for the converse; then bound the perfect-power existential to obtain decidability.",
+    "keyInsights": [
+      "The iff is the right object: it subsumes both the irrationality of non-powers and the rationality of powers, where Mathlib and the gallery previously had only the forward half for nth roots.",
+      "Bounding the perfect-power test (k ≤ k^n = m) is what makes the characterization decidable, replacing bespoke non-power lemmas with `decide`.",
+      "The rpow inverse identities Real.rpow_inv_natCast_pow and Real.pow_rpow_inv_natCast are exactly what connects m^(1/n) back to m in both directions."
+    ],
+    "prerequisites": [
+      "Irrationality (Irrational) and Mathlib's nth-root irrationality lemma irrational_nrt_of_notint_nrt",
+      "Real power (Real.rpow) and its inverse-power identities",
+      "Decidability of bounded existentials over Finset.range"
+    ]
+  },
+  "conclusion": {
+    "summary": "For n ≠ 0, m^(1/n) is irrational iff m is not a perfect n-th power — a full iff generalizing the gallery's one-directional nth-root result and Mathlib's square-root-only equivalence, with a decidable bounded test that proves concrete cases by `decide`. 12 theorems, 1 definition, 144 lines, 0 axioms, 0 sorries.",
+    "implications": "Consolidates the entire √n / ∛n / nth-root irrationality strand: instead of proving each 'm is not a perfect power' by hand, any instance is now one `decide`. The iff and its decidable form are reusable, and the iff is a natural Mathlib-contribution candidate (the nth-root analogue of irrational_sqrt_natCast_iff).",
+    "openQuestions": [
+      "Contribute irrational_nthRoot_iff upstream as the nth-root analogue of irrational_sqrt_natCast_iff, phrased with IsSquare-style perfect-power predicates.",
+      "Extend the characterization from natural-number radicands to rational radicands (m/d)^(1/n).",
+      "Provide a global Decidable instance for Irrational (nthRoot n m) when n ≠ 0, mirroring Mathlib's Decidable (Irrational √n)."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Sqrt2IrrationalOQ03",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/Sqrt2IrrationalOQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "extends",
+      "description": "Parent: irrationality of √n for non-square n (the n = 2 case). This entry generalizes to all nth roots and states the result as an iff."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "generalizes",
+      "description": "The gallery's nth-root entry proves only the forward direction (not a perfect power ⟹ irrational) and enumerates individual non-powers; this entry upgrades it to a full iff and replaces the enumeration with a decidable bounded test."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "irrational_nthRoot_iff",
+      "type": "headline",
+      "description": "The answer to OQ-03: for n ≠ 0, the real nth root m^(1/n) is irrational if and only if m is not a perfect n-th power. Both directions proved.",
+      "leanType": "Irrational (nthRoot n m) ↔ ¬ ∃ k : ℕ, k ^ n = m"
+    },
+    {
+      "name": "exists_nthPow_iff_bounded",
+      "type": "core",
+      "description": "The perfect-power test is a bounded, decidable search: any witness k of k^n = m satisfies k ≤ m, so the existential ranges over Finset.range (m+1).",
+      "leanType": "(∃ k : ℕ, k ^ n = m) ↔ ∃ k ∈ Finset.range (m + 1), k ^ n = m"
+    },
+    {
+      "name": "irrational_nthRoot_iff_bounded",
+      "type": "core",
+      "description": "Decidable repackaging of the characterization, enabling `decide` for concrete instances.",
+      "leanType": "Irrational (nthRoot n m) ↔ ¬ ∃ k ∈ Finset.range (m + 1), k ^ n = m"
+    },
+    {
+      "name": "not_irrational_nthRoot_of_perfectPow",
+      "type": "supporting",
+      "description": "The converse direction in isolation: if m is a perfect n-th power then m^(1/n) is rational, hence not irrational.",
+      "leanType": "(∃ k : ℕ, k ^ n = m) → ¬ Irrational (nthRoot n m)"
+    },
+    {
+      "name": "irrational_cbrt_two",
+      "type": "supporting",
+      "description": "∛2 is irrational, proved by `decide` via the bounded characterization — the n = 3, m = 2 instance, subsuming the manual two_not_perfect_cube lemma.",
+      "leanType": "Irrational (nthRoot 3 2)"
+    },
+    {
+      "name": "not_irrational_cbrt_eight",
+      "type": "supporting",
+      "description": "∛8 = 2 is not irrational, since 8 = 2³ — the converse direction at work.",
+      "leanType": "¬ Irrational (nthRoot 3 8)"
+    }
+  ],
+  "sections": [
+    {
+      "id": "nth-root",
+      "title": "The nth root function and its power identity",
+      "startLine": 36,
+      "endLine": 49,
+      "summary": "nthRoot n m = m^(1/n) via real rpow, with nonnegativity and the defining identity (nthRoot n m)^n = m for n ≠ 0 from Mathlib's rpow inverse-power lemmas.",
+      "mathContext": "$x = m^{1/n}$, $x^n = m$ for $n\\neq 0$, $m\\ge 0$."
+    },
+    {
+      "id": "iff",
+      "title": "The iff characterization",
+      "startLine": 51,
+      "endLine": 95,
+      "summary": "irrational_nthRoot_iff proves both directions: not-a-perfect-power ⟹ irrational (via irrational_nrt_of_notint_nrt) and perfect-power ⟹ a natural number (via Real.pow_rpow_inv_natCast).",
+      "mathContext": "$\\mathrm{Irrational}(m^{1/n})\\iff \\neg\\exists k,\\ k^n=m$."
+    },
+    {
+      "id": "decidable",
+      "title": "Bounded decidable test and concrete instances",
+      "startLine": 97,
+      "endLine": 144,
+      "summary": "exists_nthPow_iff_bounded bounds the perfect-power search (k ≤ k^n = m); irrational_nthRoot_iff_bounded makes it decidable; ∛2, ∛3, ⁴√3, ⁵√2, √2 follow by `decide`, and ∛8 illustrates the converse.",
+      "mathContext": "$k\\le k^n=m$, so the witness search is finite and `decide`-able."
+    }
+  ],
+  "sorries": []
+}

--- a/src/data/research/problems/sqrt2-irrational-oq-03.json
+++ b/src/data/research/problems/sqrt2-irrational-oq-03.json
@@ -40,11 +40,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE + STRENGTHENED: forward direction graduated earlier (nth-root-irrational); this session added the full iff characterization and a decidable bounded test (Sqrt2IrrationalOQ03.lean, 12 thm / 1 def / 0 sorry / 0 axiom, builds).",
+    "builtItems": [
+      "irrational_nthRoot_iff in Proofs/Sqrt2IrrationalOQ03.lean: full iff Irrational (m^(1/n)) ↔ ¬∃k, k^n=m for n≠0 (both directions)",
+      "exists_nthPow_iff_bounded + irrational_nthRoot_iff_bounded: bounded decidable reduction (k ≤ k^n = m via Nat.le_self_pow) making concrete instances provable by `decide`, subsuming two_not_perfect_cube-style enumeration",
+      "not_irrational_nthRoot_of_perfectPow: isolated converse direction"
+    ],
+    "insights": [
+      "2026-06-26: The prior graduation (NthRootIrrational.lean → nth-root-irrational) delivered only the FORWARD direction (not-a-perfect-power ⟹ irrational) plus a manual enumeration of non-powers. The OQ literally asks for an iff; that iff was not packaged in the gallery, nor in Mathlib for general nth roots (Mathlib has it only for square roots via irrational_sqrt_natCast_iff)."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the nth-root analogue of irrational_sqrt_natCast_iff (an iff); it provides only the one-directional irrational_nrt_of_notint_nrt — a genuine upstream contribution opportunity."
+    ],
+    "nextSteps": [
+      "Contribute irrational_nthRoot_iff upstream to Mathlib as the nth-root analogue of irrational_sqrt_natCast_iff.",
+      "Extend characterization to rational radicands and add a global Decidable instance for Irrational (nthRoot n m) when n≠0."
+    ],
     "markdown": "# Problem: Irrationality of nth Roots of Non-Perfect Powers\n\n**ID**: sqrt2-irrational-oq-03\n**Status**: COMPLETE\n**Tier**: B → A (upgraded on completion)\n**Significance**: 7/10 | **Tractability**: 7/10\n\n## Problem Statement\n\nFor any integers n ≥ 2 and m ≥ 1, if m is not a perfect nth power (no integer k\nsatisfies k^n = m), then the nth root m^(1/n) is irrational.\n\nThis is the natural generalization of the classical √2 irrationality proof to all roots.\n\n## Proof Location\n\n**File**: `proofs/Proofs/NthRootIrrational.lean`\n**Gallery**: `src/data/proofs/nth-root-irrational/`\n**Status**: 0 sorries, 0 axioms, builds in Docker (Mathlib v4.26.0)\n\n## Key Approach\n\nUses Mathlib's `irrational_nrt_of_notint_nrt` with a 3-step pattern:\n1. Power identity: (m^(1/n))^n = m\n2. Not-an-integer: m^(1/n) ∉ ℤ when m is not a perfect nth power (by contrapositive)\n3. Conclude via `irrational_nrt_of_notint_nrt`\n\n## Session 2026-02-08 (Session 1) - Complete Proof via Mathlib\n\n**Mode**: FRESH\n**Outcome**: completed\n\n### What I Did\n\n- Created `proofs/Proofs/NthRootIrrational.lean` with general theorem + 15 corollaries\n- Built general theorem `irrational_nthRoot` using `irrational_nrt_of_notint_nrt`\n- Proved \"not a perfect power\" lemmas for: 2,3,5 (squares), 2,3,5 (cubes), 2,3 (4th powers), 2 (5th powers)\n- Proved corollaries: √2,√3,√5, ∛2,∛3,∛5, ⁴√2,⁴√3, ⁵√2\n- Fixed /-! docstrings → /- for Aristotle parser compatibility\n- Created gallery entry `src/data/proofs/nth-root-irrational/`\n\n### Key Findings\n\n- `irrational_nrt_of_notint_nrt` (Mathlib.NumberTheory.Real.Irrational) is the key tool\n- For odd powers: k ≤ 0 implies k^n ≤ 0, contradicting k^n = m > 0\n- For even powers: Int.natAbs_sq reduces to natural number case where bounds are simpler\n- `nlinarith` handles polynomial bounds (k ≥ 2 → k^n ≥ 2^n)\n- `interval_cases` resolves bounded integer case analysis elegantly\n\n### Files Modified\n\n- `proofs/Proofs/NthRootIrrational.lean` (created)\n- `src/data/proofs/nth-root-irrational/` (gallery entry, created)\n\n### Next Steps\n\nNone - proof is complete.\n\n## Session 2026-02-21 (Session 2) - Housekeeping\n\n**Mode**: FRESH (re-claimed because pool showed available)\n**Outcome**: completed\n\n### What I Did\n\n- Rediscovered proof was already complete (NthRootIrrational.lean, 0 sorries)\n- Gallery entry confirmed complete (src/data/proofs/nth-root-irrational/)\n- Updated candidate pool to mark as completed\n- Created this knowledge.md\n\n### Key Findings\n\n- Problem was completed 2026-02-08 but pool entry wasn't updated\n- The src/data/research/problems/sqrt2-irrational-oq-03.json was deleted in commit feeb8c1c9 as part of format migration, but pool wasn't updated\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Answers the open question on the √2-irrationality entry (`sqrt2-irrational-oq-03`):

> *Can this generalize to √[n]{m}? Yes! √[n]{m} is irrational iff m is not a perfect n-th power.*

The OQ asks for an **iff**. The prior graduation of this OQ (`NthRootIrrational.lean` → gallery `nth-root-irrational`) delivered only the **forward** direction (not-a-perfect-power ⟹ irrational) plus a hand-written enumeration of individual non-powers (`two_not_perfect_cube`, `three_not_perfect_cube`, …). This PR adds what was missing:

```
irrational_nthRoot_iff : Irrational (m^(1/n)) ↔ ¬ ∃ k : ℕ, k ^ n = m     -- for n ≠ 0
```

- **Forward** (`¬∃k ⟹ irrational`): Mathlib's `irrational_nrt_of_notint_nrt` applied to the power identity `(m^(1/n))^n = m`, ruling out an integer value.
- **Converse** (`∃k ⟹ rational`): `Real.pow_rpow_inv_natCast` collapses `(k^n)^(1/n) = k`.

Mathlib packages this iff **only for square roots** (`irrational_sqrt_natCast_iff`); the general nth-root iff is an upstream gap, so this is also a natural Mathlib-contribution candidate.

## Decidability (subsumes the manual enumeration)

Any witness `k` of `k^n = m` satisfies `k ≤ k^n = m` (`Nat.le_self_pow`), so the perfect-power test is a **bounded Finset search**:

```
exists_nthPow_iff_bounded     : (∃ k, k^n = m) ↔ ∃ k ∈ Finset.range (m+1), k^n = m
irrational_nthRoot_iff_bounded: Irrational (m^(1/n)) ↔ ¬ ∃ k ∈ Finset.range (m+1), k^n = m
```

Concrete instances (∛2, ∛3, ⁴√3, ⁵√2, √2) become **one-line `decide`**, replacing the bespoke non-power lemmas. `not_irrational_cbrt_eight` (∛8 = 2) exercises the converse.

## Verification

- Builds in Docker (`./proofs/scripts/docker-build.sh Proofs.Sqrt2IrrationalOQ03`, Mathlib v4.26.0): `✔ [2009/2009] Built Proofs.Sqrt2IrrationalOQ03`.
- 12 theorems, 1 definition, **0 sorries, 0 axiom declarations**.
- `decide` is the **kernel** tactic (not `native_decide`), so no `Lean.ofReduceBool` — only the foundational `propext` / `Classical.choice` / `Quot.sound`. Status: **verified**.

## Honesty note

This strengthens an already-graduated OQ rather than answering an open one. The value-add over `nth-root-irrational` is precisely the **iff** (converse direction packaged) and the **decidable reduction** that subsumes the case-by-case enumeration — neither of which was present in the gallery or, for general nth roots, in Mathlib.

## Files

- `proofs/Proofs/Sqrt2IrrationalOQ03.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/sqrt2-irrational-oq-03/meta.json` (new gallery entry, cross-refs `sqrt2-irrational` and `nth-root-irrational`)
- `src/data/research/problems/sqrt2-irrational-oq-03.json`, `research/problems/sqrt2-irrational-oq-03/knowledge.md` (knowledge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)