### PR TITLE
Enrich Banach–Steinhaus resonance entry: add annotations

### DIFF
--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-bs-oq0101-header",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 49 },
+    "type": "context",
+    "title": "Target: a continuous function with divergent Fourier series",
+    "content": "The docstring frames the classical du Bois-Reymond / Banach–Steinhaus result: some continuous 2π-periodic function has a Fourier series diverging at a point. The standard proof studies the partial-sum-at-0 functionals Sₙ : C(𝕋) → ℂ, Sₙ f = ∫ f·Dₙ (Dₙ the Dirichlet kernel), whose operator norms are exactly the Lebesgue constants ‖Sₙ‖ = ‖Dₙ‖_{L¹} ~ (4/π²)log n → ∞. The contrapositive of uniform boundedness then forces a resonating f. The file's honest scope: Mathlib has `banach_steinhaus` but NOT the Dirichlet kernel, the partial-sum operators, or the Lebesgue-constant divergence. So this file verifies only the functional-analysis CORE (the resonance principle), leaving the analytic estimate ‖Dₙ‖_{L¹} → ∞ as the documented Mathlib gap — kept outside the verified core rather than baked into an axiom.",
+    "mathContext": "$S_n f = \\frac{1}{2\\pi}\\int_{-\\pi}^{\\pi} f(t)\\,D_n(t)\\,dt$, $\\;\\|S_n\\| = \\|D_n\\|_{L^1} = \\frac{1}{2\\pi}\\int |D_n| \\sim \\frac{4}{\\pi^2}\\log n \\to \\infty$, where $D_n(t) = \\frac{\\sin((n+\\frac12)t)}{\\sin(t/2)}$.",
+    "significance": "context",
+    "relatedConcepts": ["Banach–Steinhaus theorem", "Dirichlet kernel", "Lebesgue constants", "Fourier series", "condensation of singularities"],
+    "prerequisites": ["Fourier series", "functional analysis", "operator norm"]
+  },
+  {
+    "id": "ann-bs-oq0101-setup",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 57 },
+    "type": "definition",
+    "title": "The Banach-space setting",
+    "content": "The variable block fixes the abstract setting in which Banach–Steinhaus lives: a nontrivially normed scalar field 𝕜, a source space E that is a normed 𝕜-space and `CompleteSpace` (the Banach hypothesis — completeness is exactly what the proof needs, via the Baire category theorem underlying `banach_steinhaus`), and a target normed space F. Stating the core at this generality — rather than specializing to E = C(𝕋), F = ℂ — is what makes the resonance principle a reusable lemma; the Fourier application is just one instantiation. `open Filter Topology Set` brings `range`, `atTop`, and the filter API into scope.",
+    "mathContext": "$E$ a Banach space over $\\mathbb{K}$ (complete normed space), $F$ a normed space; the continuous linear maps $E \\to_{L} F$ form the normed space $\\mathcal{B}(E,F)$ with the operator norm $\\|g\\| = \\sup_{\\|x\\|\\le 1}\\|g x\\|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Banach space", "completeness", "Baire category theorem", "continuous linear map", "operator norm"],
+    "prerequisites": ["normed spaces", "completeness", "bounded operators"]
+  },
+  {
+    "id": "ann-bs-oq0101-resonance",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 81 },
+    "type": "insight",
+    "title": "The resonance principle: contrapositive of uniform boundedness",
+    "content": "`exists_unbounded_orbit_of_not_bddAbove_norm` is the centerpiece: for CLMs g i : E →L[𝕜] F, if the operator norms {‖g i‖} are not bounded above, then some single point x has unbounded orbit {‖g i x‖}. The proof is the clean contrapositive of `banach_steinhaus`: `by_contra` + `push_neg` turns the goal into the assumption that every x has bounded orbit (pointwise boundedness); this is repackaged into the shape ∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C that `banach_steinhaus` consumes (using `mem_range_self`); uniform boundedness then yields a uniform bound C' on the operator norms, contradicting the unboundedness hypothesis h. The `BddAbove (range …)` phrasing keeps the statement idiomatic, with the bridge to ∃ C, ∀ i, … just `rintro ⟨i, rfl⟩`.",
+    "mathContext": "Contrapositive of UBP: $\\neg\\,\\mathrm{BddAbove}\\{\\|g_i\\|\\} \\Rightarrow \\exists x,\\ \\neg\\,\\mathrm{BddAbove}\\{\\|g_i x\\|\\}$. Equivalently, if $\\sup_x \\|g_i x\\| < \\infty$ for every $x$ then $\\sup_i\\|g_i\\| < \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["uniform boundedness principle", "contrapositive", "pointwise boundedness", "BddAbove", "resonance"],
+    "prerequisites": ["Banach–Steinhaus theorem", "proof by contradiction", "operator norm"]
+  },
+  {
+    "id": "ann-bs-oq0101-corollary",
+    "proofId": "banach-steinhaus-theorem-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 95 },
+    "type": "technique",
+    "title": "Sequential corollary: ‖gₙ‖ → ∞ forces resonance",
+    "content": "`exists_unbounded_orbit_of_tendsto_norm_atTop` specializes the index type to ℕ and the unboundedness hypothesis to the concrete form ‖g n‖ → ∞ (Tendsto … atTop atTop) — exactly the shape the Lebesgue-constant divergence supplies in the Fourier application. The proof feeds the core lemma a proof that {‖g n‖} is not bounded above: assuming a bound C, `Filter.Tendsto.eventually_gt_atTop` produces an n with ‖g n‖ > C, and `absurd` closes the contradiction. Instantiating this corollary with E = C(𝕋), g n = Sₙ, and ‖Sₙ‖ = ‖Dₙ‖_{L¹} → ∞ immediately yields a continuous function whose Fourier series diverges at 0 — the verified core is ready to receive that one analytic input.",
+    "mathContext": "$\\|g_n\\| \\to \\infty \\Rightarrow \\exists x,\\ \\sup_n \\|g_n x\\| = \\infty$. With $g_n = S_n$ and $\\|S_n\\| = \\|D_n\\|_{L^1} \\to \\infty$: some $f \\in C(\\mathbb{T})$ has $\\sup_n |S_n f(0)| = \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["sequential limit", "Filter.Tendsto", "eventually_gt_atTop", "Lebesgue constants", "Fourier divergence"],
+    "prerequisites": ["filters and limits to atTop", "Banach–Steinhaus theorem", "Fourier series"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `banach-steinhaus-theorem-oq-01-oq-01` (Resonance principle for Fourier divergence — functional-analysis core).

## Gap addressed
Rich `meta.json` (overview, 2 sections, conclusion, crossReferences) but **no `annotations.json`** — zero inline annotation coverage.

## Changes
Added `annotations.json` with **4 inline annotations** spanning the 95-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. Header: the Fourier-divergence target, Lebesgue constants ‖Dₙ‖_{L¹} ~ (4/π²)log n, and the honest Mathlib-gap scope
2. The Banach-space variable setting (completeness ⇒ Baire ⇒ Banach–Steinhaus)
3. The resonance principle `exists_unbounded_orbit_of_not_bddAbove_norm` (contrapositive of UBP via by_contra/push_neg)
4. The sequential corollary `exists_unbounded_orbit_of_tendsto_norm_atTop` (‖gₙ‖ → ∞ ⇒ resonance), the form consumed by the Fourier application

## Verification
- JSON validates; all 4 annotations carry the full field set.
- No meta.json changes (remains verified/original/0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)