### PR TITLE
audit(banach-steinhaus-oq-01-oq-01): badge original→mathlib (Tier B wrapper)

### DIFF
--- a/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-steinhaus-theorem-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "analysis",
       "open-question"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None — every declaration is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only), built on Mathlib's banach_steinhaus. SCOPE: this entry proves only the functional-analysis CORE (the resonance principle / contrapositive of uniform boundedness), not the full Fourier-divergence theorem. The analytic input it consumes — the divergence of the Lebesgue constants ‖Sₙ‖ = ‖Dₙ‖_L¹ → ∞, together with the Dirichlet kernel and the partial-sum operators on C(𝕋) — is not present in Mathlib v4.26.0 and is documented as the remaining gap in research/problems/banach-steinhaus-theorem-oq-01-oq-01/knowledge.md.",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `banach-steinhaus-theorem-oq-01-oq-01` (Resonance principle for Fourier divergence)
**Severity**: MEDIUM — Mathlib wrapper claimed as `original`

## Evidence

`proofs/Proofs/FourierDivergenceResonance.lean` contains exactly two theorems:

- `exists_unbounded_orbit_of_not_bddAbove_norm` — by_contra + push_neg, then **calls `banach_steinhaus`** (line 80) to bound the operator norms.
- `exists_unbounded_orbit_of_tendsto_norm_atTop` — sequential corollary of the above.

Both are direct repackagings (the contrapositive) of Mathlib's `banach_steinhaus`, which does all the mathematical work. This is **Tier B** (formalized *using* a Mathlib theorem), so the badge should be `mathlib`.

**meta.json claimed**: `badge: "original"`
**Reality**: core result delegated to Mathlib's `banach_steinhaus` (already listed in `mathlibDependencies`)

## Fix

`badge: "original"` → `badge: "mathlib"`.

Status stays `verified` — the file is genuinely 0 sorries / 0 axioms / machine-checked. This matches the gallery convention for Mathlib-core results (`pythagorean-triples-oq-04-oq-01-oq-01`, `szemeredi-regularity-oq-03` are both `verified/mathlib`). The description, assumptions, and overview already credit `banach_steinhaus` prominently and scope the claim honestly to the functional-analysis core — only the badge token was inconsistent.

---
Discovered during gallery integrity audit.