### PR TITLE
Enrich ⁴√2 degree-4 entry: fix sections schema for TOC navigation

### DIFF
--- a/src/data/proofs/fourth-root-2-irrational/meta.json
+++ b/src/data/proofs/fourth-root-2-irrational/meta.json
@@ -100,20 +100,32 @@
   ],
   "sections": [
     {
+      "id": "arithmetic-input",
       "title": "The arithmetic input: 2 has no rational fourth root",
-      "content": "no_rat_fourth_two shows q⁴ ≠ 2 for all q ∈ ℚ. If q⁴ = 2, then r := q² satisfies (r:ℝ)² = 2 with r ≥ 0, so √2 = r is rational — contradicting irrational_sqrt_two. This gives fr2_irrational (⁴√2 ∉ ℚ)."
+      "startLine": 44,
+      "endLine": 79,
+      "summary": "fr2 := √√2 with fr2_sq ((⁴√2)² = √2) and fr2_pow_four ((⁴√2)⁴ = 2). no_rat_fourth_two shows q⁴ ≠ 2 for all q ∈ ℚ: if q⁴ = 2 then r := q² satisfies (r:ℝ)² = 2 with r ≥ 0, so √2 = r is rational — contradicting irrational_sqrt_two. This gives fr2_irrational (⁴√2 ∉ ℚ)."
     },
     {
+      "id": "irreducibility-eisenstein-gauss",
       "title": "Irreducibility of X⁴ − 2: Eisenstein at 2, then Gauss",
-      "content": "The dedicated Mathlib lemmas X_pow_sub_C_irreducible_of_prime_pow and _of_odd require p ≠ 2 / odd exponent, so they miss 4 = 2². Instead, over ℤ we apply Polynomial.irreducible_of_eisenstein_criterion with the prime ideal P = (2): the leading coefficient 1 ∉ (2), every lower coefficient (0, 0, 0, −2) lies in (2), and the constant term −2 ∉ (2)² = (4). This yields irreducibility over ℤ; Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) then descends it to ℚ."
+      "startLine": 80,
+      "endLine": 132,
+      "summary": "The dedicated Mathlib lemmas X_pow_sub_C_irreducible_of_prime_pow and _of_odd require p ≠ 2 / odd exponent, so they miss 4 = 2². Instead, over ℤ irreducible_X4_sub_2_int applies Polynomial.irreducible_of_eisenstein_criterion with the prime ideal P = (2): the leading coefficient 1 ∉ (2), every lower coefficient (0, 0, 0, −2) lies in (2), and the constant term −2 ∉ (2)² = (4). irreducible_X4_sub_2_rat then descends to ℚ by Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast)."
     },
     {
+      "id": "minpoly-degree",
       "title": "Minimal polynomial and field degree",
-      "content": "Since ⁴√2 is a root of the monic irreducible X⁴ − 2, minpoly.eq_of_irreducible_of_monic gives minpoly ℚ (⁴√2) = X⁴ − 2. The simple-extension dimension formula IntermediateField.adjoin.finrank then gives [ℚ(⁴√2) : ℚ] = natDegree(X⁴ − 2) = 4."
+      "startLine": 134,
+      "endLine": 147,
+      "summary": "Since ⁴√2 is a root of the monic irreducible X⁴ − 2, minpoly.eq_of_irreducible_of_monic gives minpoly ℚ (⁴√2) = X⁴ − 2 (minpoly_fr2). The simple-extension dimension formula IntermediateField.adjoin.finrank then gives [ℚ(⁴√2) : ℚ] = natDegree(X⁴ − 2) = 4 (finrank_adjoin_fr2)."
     },
     {
+      "id": "tower-power-basis",
       "title": "The quadratic tower and the power basis",
-      "content": "Because (⁴√2)² = √2, we have √2 ∈ ℚ(⁴√2), and [ℚ(√2):ℚ] = 2 (X² − 2 is irreducible since √2 ∉ ℚ), exhibiting the tower ℚ ⊂ ℚ(√2) ⊂ ℚ(⁴√2) with 4 = 2 · 2. Finally, linearIndependent_pow at the minimal-polynomial degree shows {1, ⁴√2, √2, ⁴√8} is ℚ-linearly independent; fr2_no_cubic_relation restates this as the absence of any rational degree-≤3 relation."
+      "startLine": 148,
+      "endLine": 208,
+      "summary": "Because (⁴√2)² = √2, we have √2 ∈ ℚ(⁴√2) (sqrt2_mem_adjoin_fr2), and [ℚ(√2):ℚ] = 2 (finrank_adjoin_sqrt2, X² − 2 irreducible since √2 ∉ ℚ), exhibiting the tower ℚ ⊂ ℚ(√2) ⊂ ℚ(⁴√2) with 4 = 2 · 2. linearIndependent_fr2_powers shows {1, ⁴√2, √2, ⁴√8} is ℚ-linearly independent via linearIndependent_pow; fr2_no_cubic_relation restates this as the absence of any rational degree-≤3 relation."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `fourth-root-2-irrational` (⁴√2 has degree 4 over ℚ).

## Gap addressed
The entry was already richly enriched (8 full-field annotations, detailed overview/conclusion, 4 crossReferences, 6 references). The one defect: its `sections` entries had only `{title, content}`, but the `ProofSection` type requires `{id, title, startLine, endLine, summary}`. The TableOfContents / ProofViewer read `startLine`, so section navigation and line anchoring were broken for this page.

## Changes
Normalized all 4 sections to the schema:
- Added `id`, `startLine`, `endLine` (line ranges verified against the 208-line Lean file)
- Renamed `content` → `summary`, and added the relevant theorem names as anchors

No content was removed; this is a structural conformance fix. Annotations and the rest of meta.json are unchanged.

## Verification
- meta.json validates; all 4 sections conform to ProofSection (id/title/startLine/endLine/summary).
- meta.json 10.7 KB (well under cap). Status remains verified/original/0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)