### PR TITLE
Add Knight's Tour Oblique OQ-01→OQ-02: rectangular m×n lower bound (verified)

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ01OQ02.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ01OQ02.lean
@@ -1,0 +1,567 @@
+/-
+  Knight's Tour Oblique Angles: Rectangular Generalization (OQ-01 → OQ-02)
+
+  Proves that every closed knight's tour on any m×n board (m, n ≥ 5)
+  has at least 4 oblique (>90°) turns — one forced at each of the four
+  corners of the board.
+
+  This generalizes the square n×n result of `KnightsTourObliqueOQ01.lean`
+  (`four_oblique_corners`) to *rectangular* boards. The key observation is
+  that the oblique lower bound is purely a **corner phenomenon**: it depends
+  only on the board having four corners, each of degree 2 in the knight
+  graph, and is independent of the aspect ratio of the board. Squareness is
+  never used.
+
+  Key insight (unchanged from the square case): for m, n ≥ 5 each corner of
+  the board has exactly 2 knight-adjacent squares, and the dot product of the
+  entry and exit move vectors at any corner is always −4 < 0, hence the turn
+  is oblique. Four distinct corners → ≥ 4 oblique turns. The proof is purely
+  algebraic — no `native_decide`, no board enumeration.
+
+  ## Status
+  - [x] Parameterized rectangular board and knight graph for general m, n
+  - [x] Corner neighbors theorem (degree 2) for all m, n ≥ 5
+  - [x] Algebraic oblique proof at corners (dot product = −4, no native_decide)
+  - [x] Four distinct corners pairwise distinct
+  - [x] Main result: every closed tour has ≥ 4 oblique positions
+
+  Parent proof: `KnightsTourObliqueOQ01.lean` (square n×n case).
+  Open question (OQ-02 of OQ-01): does the oblique lower bound extend beyond
+  square boards? Answer: yes, to all m×n boards with m, n ≥ 5, via the same
+  corner mechanism — the bound is independent of the aspect ratio.
+-/
+
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Data.List.Nodup
+import Mathlib.Tactic
+
+namespace KnightsTourObliqueRect
+
+/-! ## Section 1: Parameterized Rectangular Board and Knight Graph -/
+
+/-- A square on the m×n chessboard (rows indexed by `Fin m`, columns by `Fin n`). -/
+abbrev SquareMN (m n : ℕ) := Fin m × Fin n
+
+/-- The 8 possible knight move offsets -/
+def knightOffsets : List (Int × Int) :=
+  [(1, 2), (2, 1), (2, -1), (1, -2),
+   (-1, -2), (-2, -1), (-2, 1), (-1, 2)]
+
+/-- Check if a move offset is a knight offset -/
+def isKnightOffset (dx dy : Int) : Bool :=
+  (dx, dy) ∈ knightOffsets
+
+/-- Two squares on the m×n board are knight-adjacent -/
+def knightAdjMN (m n : ℕ) (s1 s2 : SquareMN m n) : Prop :=
+  let dx := (s2.1 : Int) - (s1.1 : Int)
+  let dy := (s2.2 : Int) - (s1.2 : Int)
+  isKnightOffset dx dy
+
+instance (m n : ℕ) : DecidableRel (knightAdjMN m n) := fun s1 s2 =>
+  decidable_of_bool (isKnightOffset ((s2.1 : Int) - (s1.1 : Int))
+                                    ((s2.2 : Int) - (s1.2 : Int)))
+    (by simp [knightAdjMN])
+
+/-- Negation of a knight offset is a knight offset -/
+theorem neg_knight_offset {dx dy : Int} (h : isKnightOffset dx dy = true) :
+    isKnightOffset (-dx) (-dy) = true := by
+  simp only [isKnightOffset, knightOffsets, decide_eq_true_eq] at h ⊢
+  aesop
+
+/-- The knight graph on the m×n board -/
+def knightGraphMN (m n : ℕ) : SimpleGraph (SquareMN m n) where
+  Adj := knightAdjMN m n
+  symm := by
+    intro s1 s2 h
+    simp only [knightAdjMN] at h ⊢
+    have hdx : (s1.1 : Int) - (s2.1 : Int) = -((s2.1 : Int) - (s1.1 : Int)) := by ring
+    have hdy : (s1.2 : Int) - (s2.2 : Int) = -((s2.2 : Int) - (s1.2 : Int)) := by ring
+    rw [hdx, hdy]
+    exact neg_knight_offset h
+  loopless := by
+    intro s h
+    simp only [knightAdjMN, isKnightOffset, knightOffsets] at h
+    simp at h
+
+/-! ## Section 2: Move Vectors and Oblique Predicate -/
+
+/-- A move vector (direction of a knight move) -/
+structure MoveVector where
+  dx : Int
+  dy : Int
+deriving DecidableEq, Repr
+
+/-- Dot product of two move vectors -/
+def MoveVector.dot (v1 v2 : MoveVector) : Int :=
+  v1.dx * v2.dx + v1.dy * v2.dy
+
+/-- A turn is oblique iff the dot product of consecutive move vectors is negative -/
+def isOblique (v1 v2 : MoveVector) : Prop :=
+  v1.dot v2 < 0
+
+instance (v1 v2 : MoveVector) : Decidable (isOblique v1 v2) :=
+  Int.decLt _ _
+
+/-- Get the move vector from s1 to s2 -/
+def getMoveVector {m n : ℕ} (s1 s2 : SquareMN m n) : MoveVector :=
+  ⟨(s2.1 : Int) - (s1.1 : Int), (s2.2 : Int) - (s1.2 : Int)⟩
+
+/-! ## Section 3: Closed Tour on m×n Board -/
+
+/-- A closed knight's tour on an m×n board -/
+structure ClosedTourMN (m n : ℕ) where
+  squares : List (SquareMN m n)
+  length_eq : squares.length = m * n
+  nodup : squares.Nodup
+  nonempty : squares ≠ []
+  path : ∀ i (hi : i + 1 < squares.length),
+    (knightGraphMN m n).Adj (squares[i]'(by omega)) (squares[i + 1]'hi)
+  closes : (knightGraphMN m n).Adj
+    (squares.getLast nonempty)
+    (squares.head nonempty)
+
+/-! ## Section 4: Corner Analysis for General m, n -/
+
+/-- The four corners of the m×n board -/
+def cornerTL (m n : ℕ) (hm : m ≥ 1) (hn : n ≥ 1) : SquareMN m n := (⟨0, by omega⟩, ⟨0, by omega⟩)
+def cornerTR (m n : ℕ) (hm : m ≥ 1) (hn : n ≥ 1) : SquareMN m n := (⟨0, by omega⟩, ⟨n - 1, by omega⟩)
+def cornerBL (m n : ℕ) (hm : m ≥ 1) (hn : n ≥ 1) : SquareMN m n := (⟨m - 1, by omega⟩, ⟨0, by omega⟩)
+def cornerBR (m n : ℕ) (hm : m ≥ 1) (hn : n ≥ 1) : SquareMN m n := (⟨m - 1, by omega⟩, ⟨n - 1, by omega⟩)
+
+/-- The four corners are pairwise distinct for m, n ≥ 2 -/
+theorem corners_distinct (m n : ℕ) (hm : m ≥ 2) (hn : n ≥ 2) :
+    cornerTL m n (by omega) (by omega) ≠ cornerTR m n (by omega) (by omega) ∧
+    cornerTL m n (by omega) (by omega) ≠ cornerBL m n (by omega) (by omega) ∧
+    cornerTL m n (by omega) (by omega) ≠ cornerBR m n (by omega) (by omega) ∧
+    cornerTR m n (by omega) (by omega) ≠ cornerBL m n (by omega) (by omega) ∧
+    cornerTR m n (by omega) (by omega) ≠ cornerBR m n (by omega) (by omega) ∧
+    cornerBL m n (by omega) (by omega) ≠ cornerBR m n (by omega) (by omega) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+    simp only [cornerTL, cornerTR, cornerBL, cornerBR, ne_eq, Prod.mk.injEq,
+      Fin.mk.injEq, not_and] <;>
+    omega
+
+/-- For m, n ≥ 5, corner (0,0) has exactly neighbors (1,2) and (2,1) -/
+theorem cornerTL_neighbors (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (s : SquareMN m n)
+    (hadj : (knightGraphMN m n).Adj (cornerTL m n (by omega) (by omega)) s) :
+    s = (⟨1, by omega⟩, ⟨2, by omega⟩) ∨ s = (⟨2, by omega⟩, ⟨1, by omega⟩) := by
+  simp only [knightGraphMN, SimpleGraph.Adj, knightAdjMN, cornerTL] at hadj
+  simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
+  rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
+                   ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · left; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · right; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+
+/-- For m, n ≥ 5, corner (0,n-1) has exactly neighbors (1,n-3) and (2,n-2) -/
+theorem cornerTR_neighbors (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (s : SquareMN m n)
+    (hadj : (knightGraphMN m n).Adj (cornerTR m n (by omega) (by omega)) s) :
+    s = (⟨1, by omega⟩, ⟨n - 3, by omega⟩) ∨ s = (⟨2, by omega⟩, ⟨n - 2, by omega⟩) := by
+  simp only [knightGraphMN, SimpleGraph.Adj, knightAdjMN, cornerTR] at hadj
+  simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
+  rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
+                   ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+  · right; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · left; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+
+/-- For m, n ≥ 5, corner (m-1,0) has exactly neighbors (m-3,1) and (m-2,2) -/
+theorem cornerBL_neighbors (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (s : SquareMN m n)
+    (hadj : (knightGraphMN m n).Adj (cornerBL m n (by omega) (by omega)) s) :
+    s = (⟨m - 3, by omega⟩, ⟨1, by omega⟩) ∨ s = (⟨m - 2, by omega⟩, ⟨2, by omega⟩) := by
+  simp only [knightGraphMN, SimpleGraph.Adj, knightAdjMN, cornerBL] at hadj
+  simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
+  rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
+                   ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+  · left; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · right; ext <;> simp_all [Fin.ext_iff] <;> omega
+
+/-- For m, n ≥ 5, corner (m-1,n-1) has exactly neighbors (m-3,n-2) and (m-2,n-3) -/
+theorem cornerBR_neighbors (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (s : SquareMN m n)
+    (hadj : (knightGraphMN m n).Adj (cornerBR m n (by omega) (by omega)) s) :
+    s = (⟨m - 3, by omega⟩, ⟨n - 2, by omega⟩) ∨ s = (⟨m - 2, by omega⟩, ⟨n - 3, by omega⟩) := by
+  simp only [knightGraphMN, SimpleGraph.Adj, knightAdjMN, cornerBR] at hadj
+  simp only [isKnightOffset, knightOffsets, List.mem_cons, Prod.mk.injEq,
+    List.mem_singleton, List.mem_nil_iff, decide_eq_true_eq, or_false] at hadj
+  rcases hadj with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ |
+                   ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · exfalso; have := s.1.isLt; omega
+  · right; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · left; ext <;> simp_all [Fin.ext_iff] <;> omega
+  · exfalso; have := s.2.isLt; omega
+  · exfalso; have := s.2.isLt; omega
+
+/-! ## Section 5: Oblique Turns at Corners (Algebraic Proof)
+
+The core algebraic fact: at any corner of an m×n board (m, n ≥ 5), the turn
+between the two possible neighbors is always oblique. The dot product of the
+entry and exit move vectors is always −4.
+
+For each corner, the two knight offsets from the corner are a pair from
+{(±1,±2), (±2,±1)}, and the dot product (−offset₁) · offset₂ always equals
+−(|1·2| + |2·1|) = −4 < 0, hence oblique. This is purely algebraic and, like
+the corner-degree count, independent of the board's aspect ratio.
+-/
+
+/-- At corner (0,0), both possible turns are oblique.
+    Entering from (1,2) → corner → (2,1): dot = (−1)(2)+(−2)(1) = −4.
+    Entering from (2,1) → corner → (1,2): dot = (−2)(1)+(−1)(2) = −4. -/
+theorem cornerTL_oblique (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (prev next : SquareMN m n)
+    (hadj_prev : (knightGraphMN m n).Adj prev (cornerTL m n (by omega) (by omega)))
+    (hadj_next : (knightGraphMN m n).Adj (cornerTL m n (by omega) (by omega)) next)
+    (hne : prev ≠ next) :
+    isOblique (getMoveVector prev (cornerTL m n (by omega) (by omega)))
+              (getMoveVector (cornerTL m n (by omega) (by omega)) next) := by
+  have hp := cornerTL_neighbors m n hm hn prev ((knightGraphMN m n).symm hadj_prev)
+  have hn' := cornerTL_neighbors m n hm hn next hadj_next
+  rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
+  · exact absurd rfl hne
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerTL, Fin.val_mk]
+    ring_nf; omega
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerTL, Fin.val_mk]
+    ring_nf; omega
+  · exact absurd rfl hne
+
+/-- At corner (0,n-1), both possible turns are oblique.
+    Offsets: (1,−2) and (2,−1). Dot = (−1)(2)+(2)(−1) = −4. -/
+theorem cornerTR_oblique (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (prev next : SquareMN m n)
+    (hadj_prev : (knightGraphMN m n).Adj prev (cornerTR m n (by omega) (by omega)))
+    (hadj_next : (knightGraphMN m n).Adj (cornerTR m n (by omega) (by omega)) next)
+    (hne : prev ≠ next) :
+    isOblique (getMoveVector prev (cornerTR m n (by omega) (by omega)))
+              (getMoveVector (cornerTR m n (by omega) (by omega)) next) := by
+  have hp := cornerTR_neighbors m n hm hn prev ((knightGraphMN m n).symm hadj_prev)
+  have hn' := cornerTR_neighbors m n hm hn next hadj_next
+  rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
+  · exact absurd rfl hne
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerTR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerTR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ n by omega), Nat.cast_sub (show 2 ≤ n by omega),
+      Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
+  · exact absurd rfl hne
+
+/-- At corner (m-1,0), both possible turns are oblique.
+    Offsets: (−2,1) and (−1,2). Dot = (2)(−1)+(−1)(2) = −4. -/
+theorem cornerBL_oblique (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (prev next : SquareMN m n)
+    (hadj_prev : (knightGraphMN m n).Adj prev (cornerBL m n (by omega) (by omega)))
+    (hadj_next : (knightGraphMN m n).Adj (cornerBL m n (by omega) (by omega)) next)
+    (hne : prev ≠ next) :
+    isOblique (getMoveVector prev (cornerBL m n (by omega) (by omega)))
+              (getMoveVector (cornerBL m n (by omega) (by omega)) next) := by
+  have hp := cornerBL_neighbors m n hm hn prev ((knightGraphMN m n).symm hadj_prev)
+  have hn' := cornerBL_neighbors m n hm hn next hadj_next
+  rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
+  · exact absurd rfl hne
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerBL, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ m by omega), Nat.cast_sub (show 2 ≤ m by omega),
+      Nat.cast_sub (show 3 ≤ m by omega)]
+    ring_nf; omega
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerBL, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ m by omega), Nat.cast_sub (show 2 ≤ m by omega),
+      Nat.cast_sub (show 3 ≤ m by omega)]
+    ring_nf; omega
+  · exact absurd rfl hne
+
+/-- At corner (m-1,n-1), both possible turns are oblique.
+    Offsets: (−2,−1) and (−1,−2). Dot = (2)(−1)+(1)(−2) = −4. -/
+theorem cornerBR_oblique (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (prev next : SquareMN m n)
+    (hadj_prev : (knightGraphMN m n).Adj prev (cornerBR m n (by omega) (by omega)))
+    (hadj_next : (knightGraphMN m n).Adj (cornerBR m n (by omega) (by omega)) next)
+    (hne : prev ≠ next) :
+    isOblique (getMoveVector prev (cornerBR m n (by omega) (by omega)))
+              (getMoveVector (cornerBR m n (by omega) (by omega)) next) := by
+  have hp := cornerBR_neighbors m n hm hn prev ((knightGraphMN m n).symm hadj_prev)
+  have hn' := cornerBR_neighbors m n hm hn next hadj_next
+  rcases hp with rfl | rfl <;> rcases hn' with rfl | rfl
+  · exact absurd rfl hne
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerBR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ m by omega), Nat.cast_sub (show 2 ≤ m by omega),
+      Nat.cast_sub (show 3 ≤ m by omega), Nat.cast_sub (show 1 ≤ n by omega),
+      Nat.cast_sub (show 2 ≤ n by omega), Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
+  · show MoveVector.dot _ _ < 0
+    simp only [getMoveVector, MoveVector.dot, cornerBR, Fin.val_mk]
+    push_cast [Nat.cast_sub (show 1 ≤ m by omega), Nat.cast_sub (show 2 ≤ m by omega),
+      Nat.cast_sub (show 3 ≤ m by omega), Nat.cast_sub (show 1 ≤ n by omega),
+      Nat.cast_sub (show 2 ≤ n by omega), Nat.cast_sub (show 3 ≤ n by omega)]
+    ring_nf; omega
+  · exact absurd rfl hne
+
+/-- At any corner of the m×n board, the turn is oblique -/
+theorem corner_forces_oblique (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5)
+    (c : SquareMN m n)
+    (hc : c = cornerTL m n (by omega) (by omega) ∨ c = cornerTR m n (by omega) (by omega) ∨
+          c = cornerBL m n (by omega) (by omega) ∨ c = cornerBR m n (by omega) (by omega))
+    (prev next : SquareMN m n)
+    (hadj_prev : (knightGraphMN m n).Adj prev c)
+    (hadj_next : (knightGraphMN m n).Adj c next)
+    (hne : prev ≠ next) :
+    isOblique (getMoveVector prev c) (getMoveVector c next) := by
+  rcases hc with rfl | rfl | rfl | rfl
+  · exact cornerTL_oblique m n hm hn prev next hadj_prev hadj_next hne
+  · exact cornerTR_oblique m n hm hn prev next hadj_prev hadj_next hne
+  · exact cornerBL_oblique m n hm hn prev next hadj_prev hadj_next hne
+  · exact cornerBR_oblique m n hm hn prev next hadj_prev hadj_next hne
+
+/-! ## Section 6: Tour Properties -/
+
+/-- A closed tour visits all m·n squares -/
+theorem tour_visits_all (m n : ℕ) (t : ClosedTourMN m n) (s : SquareMN m n) :
+    s ∈ t.squares := by
+  have hcard : Fintype.card (SquareMN m n) = m * n := by
+    simp [Fintype.card_prod, Fintype.card_fin]
+  have htoFinset : t.squares.toFinset = Finset.univ := by
+    apply Finset.eq_univ_of_card
+    rw [List.toFinset_card_of_nodup t.nodup, t.length_eq, hcard]
+  rw [← List.mem_toFinset, htoFinset]
+  exact Finset.mem_univ s
+
+/-- Cyclic adjacency in the tour -/
+theorem tour_cyclic_adj (m n : ℕ) (t : ClosedTourMN m n) (i : Fin (m * n)) :
+    (knightGraphMN m n).Adj
+      (t.squares[i.val]'(by rw [t.length_eq]; exact i.isLt))
+      (t.squares[(i.val + 1) % (m * n)]'(by
+        rw [t.length_eq]; exact Nat.mod_lt _ (by have := i.isLt; omega))) := by
+  by_cases h : i.val + 1 < m * n
+  · simp only [Nat.mod_eq_of_lt h]
+    exact t.path i.val (by rw [t.length_eq]; exact h)
+  · have hi : i.val = m * n - 1 := by omega
+    have hkey : (i.val + 1) % (m * n) = 0 := by
+      rw [hi, Nat.sub_add_cancel (by have := i.isLt; omega), Nat.mod_self]
+    have hlast : t.squares[i.val]'(by rw [t.length_eq]; exact i.isLt)
+        = t.squares.getLast t.nonempty := by
+      rw [List.getLast_eq_getElem]; congr 1
+      rw [t.length_eq]; omega
+    have hhead : t.squares[(i.val + 1) % (m * n)]'(by
+          rw [t.length_eq]; exact Nat.mod_lt _ (by have := i.isLt; omega))
+        = t.squares.head t.nonempty := by
+      rw [List.head_eq_getElem]; congr 1
+    rw [hlast, hhead]
+    exact t.closes
+
+/-- Distinct positions in a tour have distinct squares -/
+theorem tour_index_neq (m n : ℕ) (t : ClosedTourMN m n) (i j : ℕ)
+    (hi : i < m * n) (hj : j < m * n) (hne : i ≠ j) :
+    t.squares[i]'(by rw [t.length_eq]; exact hi) ≠
+    t.squares[j]'(by rw [t.length_eq]; exact hj) := by
+  rw [ne_eq, t.nodup.getElem_inj_iff]
+  exact hne
+
+/-! ## Section 7: Main Theorem
+
+Every closed knight's tour on an m×n board (m, n ≥ 5) has at least 4 oblique
+turns. The proof establishes 4 distinct positions in the tour where the turn
+is oblique — one at each corner of the board. Since each corner has exactly 2
+knight-adjacent squares and the dot product of entry/exit vectors is always
+−4 < 0, the turn at each corner is oblique. Crucially, the argument never uses
+m = n: the oblique lower bound is a corner phenomenon, independent of the
+board's aspect ratio.
+-/
+
+/-- **Theorem (Four Oblique Positions, Rectangular)**: Every closed knight's
+    tour on an m×n board (m, n ≥ 5) has at least 4 positions where the turn is
+    oblique, namely at the 4 corners of the board.
+
+    This is the generalization of `KnightsTourObliqueOQ01.four_oblique_corners`
+    from square n×n boards to arbitrary rectangular m×n boards. -/
+theorem four_oblique_corners_rect (m n : ℕ) (hm : m ≥ 5) (hn : n ≥ 5) (t : ClosedTourMN m n) :
+    ∃ (i₁ i₂ i₃ i₄ : Fin (m * n)),
+      i₁.val ≠ i₂.val ∧ i₁.val ≠ i₃.val ∧ i₁.val ≠ i₄.val ∧
+      i₂.val ≠ i₃.val ∧ i₂.val ≠ i₄.val ∧ i₃.val ≠ i₄.val ∧
+      (let prev₁ := t.squares[(i₁.val + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₁ := t.squares[(i₁.val + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let c₁ := t.squares[i₁.val]'(by rw [t.length_eq]; exact i₁.isLt)
+       isOblique (getMoveVector prev₁ c₁) (getMoveVector c₁ next₁)) ∧
+      (let prev₂ := t.squares[(i₂.val + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₂ := t.squares[(i₂.val + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let c₂ := t.squares[i₂.val]'(by rw [t.length_eq]; exact i₂.isLt)
+       isOblique (getMoveVector prev₂ c₂) (getMoveVector c₂ next₂)) ∧
+      (let prev₃ := t.squares[(i₃.val + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₃ := t.squares[(i₃.val + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let c₃ := t.squares[i₃.val]'(by rw [t.length_eq]; exact i₃.isLt)
+       isOblique (getMoveVector prev₃ c₃) (getMoveVector c₃ next₃)) ∧
+      (let prev₄ := t.squares[(i₄.val + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let next₄ := t.squares[(i₄.val + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))
+       let c₄ := t.squares[i₄.val]'(by rw [t.length_eq]; exact i₄.isLt)
+       isOblique (getMoveVector prev₄ c₄) (getMoveVector c₄ next₄)) := by
+  have hpos : 0 < m * n := Nat.mul_pos (by omega) (by omega)
+  -- Board has at least 25 squares; omega needs this linear fact about the
+  -- nonlinear product m * n (e.g. to rule out m * n = 2 at the wrap-around).
+  have hbig : 25 ≤ m * n := by
+    have := Nat.mul_le_mul hm hn
+    omega
+  -- Cyclic predecessor-then-successor returns the original index.
+  have hcyc : ∀ (k : ℕ), k < m * n →
+      ((k + (m * n - 1)) % (m * n) + 1) % (m * n) = k := by
+    intro k hk
+    rcases Nat.eq_zero_or_pos k with h0 | hpk
+    · subst h0
+      have hinner : (0 + (m * n - 1)) % (m * n) = m * n - 1 := by
+        rw [Nat.zero_add]; exact Nat.mod_eq_of_lt (by omega)
+      rw [hinner, Nat.sub_add_cancel (by omega), Nat.mod_self]
+    · have hinner : (k + (m * n - 1)) % (m * n) = k - 1 := by
+        rw [show k + (m * n - 1) = m * n + (k - 1) by omega, Nat.add_mod_left]
+        exact Nat.mod_eq_of_lt (by omega)
+      rw [hinner, Nat.sub_add_cancel hpk, Nat.mod_eq_of_lt hk]
+  -- Cyclic predecessor and successor of an index are distinct (board size ≥ 25 ≥ 3).
+  have hpn : ∀ (k : ℕ), k < m * n →
+      (k + (m * n - 1)) % (m * n) ≠ (k + 1) % (m * n) := by
+    intro k hk
+    rcases Nat.eq_zero_or_pos k with h0 | hpk
+    · subst h0
+      have e1 : (0 + (m * n - 1)) % (m * n) = m * n - 1 := by
+        rw [Nat.zero_add, Nat.mod_eq_of_lt (by omega)]
+      have e2 : (0 + 1) % (m * n) = 1 := by rw [Nat.zero_add, Nat.mod_eq_of_lt (by omega)]
+      rw [e1, e2]; omega
+    · have hsplit : k + (m * n - 1) = m * n + (k - 1) := by omega
+      have e1 : (k + (m * n - 1)) % (m * n) = k - 1 := by
+        rw [hsplit, Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+      by_cases hkm : k + 1 < m * n
+      · rw [e1, Nat.mod_eq_of_lt hkm]; omega
+      · have e2 : (k + 1) % (m * n) = 0 := by rw [show k + 1 = m * n by omega, Nat.mod_self]
+        rw [e1, e2]; omega
+  -- getElem at provably-equal indices yields equal elements.
+  have hsqcong : ∀ {a b : ℕ} (ha : a < t.squares.length) (hb : b < t.squares.length),
+      a = b → t.squares[a]'ha = t.squares[b]'hb := by
+    intro a b ha hb hab; subst hab; rfl
+
+  have hcTL : cornerTL m n (by omega) (by omega) ∈ t.squares := tour_visits_all m n t _
+  have hcTR : cornerTR m n (by omega) (by omega) ∈ t.squares := tour_visits_all m n t _
+  have hcBL : cornerBL m n (by omega) (by omega) ∈ t.squares := tour_visits_all m n t _
+  have hcBR : cornerBR m n (by omega) (by omega) ∈ t.squares := tour_visits_all m n t _
+
+  obtain ⟨⟨iTL, hiTL⟩, heqTL⟩ := List.mem_iff_get.mp hcTL
+  obtain ⟨⟨iTR, hiTR⟩, heqTR⟩ := List.mem_iff_get.mp hcTR
+  obtain ⟨⟨iBL, hiBL⟩, heqBL⟩ := List.mem_iff_get.mp hcBL
+  obtain ⟨⟨iBR, hiBR⟩, heqBR⟩ := List.mem_iff_get.mp hcBR
+
+  -- All indices are < m·n
+  have hiTL_lt : iTL < m * n := by rw [t.length_eq] at hiTL; exact hiTL
+  have hiTR_lt : iTR < m * n := by rw [t.length_eq] at hiTR; exact hiTR
+  have hiBL_lt : iBL < m * n := by rw [t.length_eq] at hiBL; exact hiBL
+  have hiBR_lt : iBR < m * n := by rw [t.length_eq] at hiBR; exact hiBR
+
+  -- Corner indices are pairwise distinct
+  have hdist := corners_distinct m n (by omega) (by omega)
+  have hmkeq : ∀ {a b : ℕ} (ha : a < t.squares.length) (hb : b < t.squares.length),
+      a = b → t.squares.get ⟨a, ha⟩ = t.squares.get ⟨b, hb⟩ := by
+    intro a b ha hb hab; congr 1; exact Fin.ext hab
+  have hne12 : iTL ≠ iTR := by
+    intro h; apply hdist.1; rw [← heqTL, ← heqTR]; exact hmkeq hiTL hiTR h
+  have hne13 : iTL ≠ iBL := by
+    intro h; apply hdist.2.1; rw [← heqTL, ← heqBL]; exact hmkeq hiTL hiBL h
+  have hne14 : iTL ≠ iBR := by
+    intro h; apply hdist.2.2.1; rw [← heqTL, ← heqBR]; exact hmkeq hiTL hiBR h
+  have hne23 : iTR ≠ iBL := by
+    intro h; apply hdist.2.2.2.1; rw [← heqTR, ← heqBL]; exact hmkeq hiTR hiBL h
+  have hne24 : iTR ≠ iBR := by
+    intro h; apply hdist.2.2.2.2.1; rw [← heqTR, ← heqBR]; exact hmkeq hiTR hiBR h
+  have hne34 : iBL ≠ iBR := by
+    intro h; apply hdist.2.2.2.2.2; rw [← heqBL, ← heqBR]; exact hmkeq hiBL hiBR h
+
+  refine ⟨⟨iTL, hiTL_lt⟩, ⟨iTR, hiTR_lt⟩, ⟨iBL, hiBL_lt⟩, ⟨iBR, hiBR_lt⟩,
+          hne12, hne13, hne14, hne23, hne24, hne34, ?_, ?_, ?_, ?_⟩
+
+  · -- Corner TL at position iTL
+    have hadj_prev : (knightGraphMN m n).Adj
+        (t.squares[(iTL + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
+        (t.squares[iTL]'(by rw [t.length_eq]; exact hiTL_lt)) := by
+      have h := tour_cyclic_adj m n t ⟨(iTL + (m*n - 1)) % (m*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iTL + (m*n - 1)) % (m*n) + 1) % (m*n)) (b := iTL)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiTL_lt)
+        (hcyc iTL hiTL_lt)] at h
+      exact h
+    have hadj_next : (knightGraphMN m n).Adj
+        (t.squares[iTL]'(by rw [t.length_eq]; exact hiTL_lt))
+        (t.squares[(iTL + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
+      exact tour_cyclic_adj m n t ⟨iTL, hiTL_lt⟩
+    have hpn_ne := hpn iTL hiTL_lt
+    have hsq_ne := tour_index_neq m n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique m n hm hn _ (Or.inl heqTL) _ _ hadj_prev hadj_next hsq_ne
+
+  · -- Corner TR at position iTR
+    have hadj_prev : (knightGraphMN m n).Adj
+        (t.squares[(iTR + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
+        (t.squares[iTR]'(by rw [t.length_eq]; exact hiTR_lt)) := by
+      have h := tour_cyclic_adj m n t ⟨(iTR + (m*n - 1)) % (m*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iTR + (m*n - 1)) % (m*n) + 1) % (m*n)) (b := iTR)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiTR_lt)
+        (hcyc iTR hiTR_lt)] at h
+      exact h
+    have hadj_next : (knightGraphMN m n).Adj
+        (t.squares[iTR]'(by rw [t.length_eq]; exact hiTR_lt))
+        (t.squares[(iTR + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
+      exact tour_cyclic_adj m n t ⟨iTR, hiTR_lt⟩
+    have hpn_ne := hpn iTR hiTR_lt
+    have hsq_ne := tour_index_neq m n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique m n hm hn _ (Or.inr (Or.inl heqTR)) _ _ hadj_prev hadj_next hsq_ne
+
+  · -- Corner BL at position iBL
+    have hadj_prev : (knightGraphMN m n).Adj
+        (t.squares[(iBL + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
+        (t.squares[iBL]'(by rw [t.length_eq]; exact hiBL_lt)) := by
+      have h := tour_cyclic_adj m n t ⟨(iBL + (m*n - 1)) % (m*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iBL + (m*n - 1)) % (m*n) + 1) % (m*n)) (b := iBL)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiBL_lt)
+        (hcyc iBL hiBL_lt)] at h
+      exact h
+    have hadj_next : (knightGraphMN m n).Adj
+        (t.squares[iBL]'(by rw [t.length_eq]; exact hiBL_lt))
+        (t.squares[(iBL + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
+      exact tour_cyclic_adj m n t ⟨iBL, hiBL_lt⟩
+    have hpn_ne := hpn iBL hiBL_lt
+    have hsq_ne := tour_index_neq m n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique m n hm hn _ (Or.inr (Or.inr (Or.inl heqBL))) _ _ hadj_prev hadj_next hsq_ne
+
+  · -- Corner BR at position iBR
+    have hadj_prev : (knightGraphMN m n).Adj
+        (t.squares[(iBR + (m*n - 1)) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega))))
+        (t.squares[iBR]'(by rw [t.length_eq]; exact hiBR_lt)) := by
+      have h := tour_cyclic_adj m n t ⟨(iBR + (m*n - 1)) % (m*n), Nat.mod_lt _ hpos⟩
+      rw [hsqcong (a := ((iBR + (m*n - 1)) % (m*n) + 1) % (m*n)) (b := iBR)
+        (by rw [t.length_eq]; exact Nat.mod_lt _ hpos) (by rw [t.length_eq]; exact hiBR_lt)
+        (hcyc iBR hiBR_lt)] at h
+      exact h
+    have hadj_next : (knightGraphMN m n).Adj
+        (t.squares[iBR]'(by rw [t.length_eq]; exact hiBR_lt))
+        (t.squares[(iBR + 1) % (m*n)]'(by rw [t.length_eq]; exact Nat.mod_lt _ (Nat.mul_pos (by omega) (by omega)))) := by
+      exact tour_cyclic_adj m n t ⟨iBR, hiBR_lt⟩
+    have hpn_ne := hpn iBR hiBR_lt
+    have hsq_ne := tour_index_neq m n t _ _ (Nat.mod_lt _ hpos) (Nat.mod_lt _ hpos) hpn_ne
+    exact corner_forces_oblique m n hm hn _ (Or.inr (Or.inr (Or.inr heqBR))) _ _ hadj_prev hadj_next hsq_ne
+
+end KnightsTourObliqueRect

--- a/research/problems/erdos-1018-oq-04-incomplete-01-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1018-oq-04-incomplete-01-incomplete-01/knowledge.md
@@ -1,3 +1,33 @@
 # Knowledge: erdos-1018-oq-04-incomplete-01-incomplete-01
 
-*No research yet.*
+## Status: BLOCKED (researcher-9, 2026-06-26)
+
+Degenerate completion-chain stub ("incomplete-01-incomplete-01") with a placeholder
+formal statement ("(formal statement to be added)") and no gallery entry. Assessed
+against the existing parent chain rather than created fresh.
+
+### Parent-chain state
+- `erdos-1018-oq-04` (Erdos1018OQ04.lean): 4 axioms, 1 sorry — r-uniform hypergraph
+  extension via van Kampen–Flores topological obstruction.
+- `erdos-1018-oq-04-incomplete-01` (Erdos1018OQ04Incomplete01.lean): 1 axiom, 1 sorry.
+  Concrete `isEmbeddableConc` definition (convex-hull separation in ℝ^d), with
+  K3_planar / K4_planar fully proved, Kn_edges/K5_edges done, r2_implies_main_r2 done.
+
+### Sole remaining concrete target — and why it is blocked
+`planar_graphs_edge_bound` (line 642): for a graph (arity-2 hypergraph) on n≥3
+vertices that is `isEmbeddableConc … 2`, edgeCount ≤ 3·n. This is the classical
+planar edge bound (≤ 3n−6). Proving it from the geometric convex-hull-separation
+definition fundamentally requires **Euler's formula for planar graphs**
+(V − E + F = 2 + face-counting), which Mathlib does not have in usable form.
+Building it is a >1000-line foundational effort = BLOCKED (exceeds BUILD threshold).
+
+No constant-C shortcut exists: any graph on n vertices has up to n(n−1)/2 edges, so
+`edgeCount ≤ C·n` with C independent of n genuinely needs planarity, not just a
+counting bound.
+
+The other open item, axiom `kostochka_pyber_r2`, is the 1988 Kostochka–Pyber
+research theorem — not provable from Mathlib.
+
+### Recommendation
+Do not spawn further `-incomplete-NN` children on this node. Real progress requires
+upstream planar-graph / Euler-formula infrastructure in Mathlib first.

--- a/research/problems/knights-tour-oblique-oq-01-oq-02/knowledge.md
+++ b/research/problems/knights-tour-oblique-oq-01-oq-02/knowledge.md
@@ -1,0 +1,46 @@
+# Knowledge: knights-tour-oblique-oq-01-oq-02
+
+## Result (researcher-9, 2026-06-26) — SOLVED, build-verification in progress
+
+Rectangular generalization of the square-board oblique lower bound
+(`knights-tour-oblique-oq-01`, `four_oblique_corners`).
+
+**Theorem `four_oblique_corners_rect`**: every closed knight's tour on an m×n
+board with m, n ≥ 5 has ≥ 4 oblique (>90°) turns, one forced at each corner.
+
+### Approach
+Reparameterize `SquareN n = Fin n × Fin n` as `SquareMN m n = Fin m × Fin n`,
+and `n·n` as `m·n`. The entire square-case proof transports verbatim:
+- corner degree 2 (each corner has exactly 2 knight neighbours), row bound m and
+  column bound n act independently → squareness unused;
+- entry/exit dot product at each corner is the constant −4 < 0 (aspect-ratio
+  independent; the n−1 / m−1 coordinates cancel in the move-vector differences);
+- closed tour visits all m·n squares; cyclic predecessor/successor of a corner
+  index are its two (distinct, by nodup) neighbours → `corner_forces_oblique`.
+
+5 corner-geometry lemma groups + tour-coverage + main theorem. 0 sorries, 0 axioms.
+562 lines. File: `proofs/Proofs/KnightsTourObliqueOQ01OQ02.lean`,
+namespace `KnightsTourObliqueRect`.
+
+### Build status — VERIFIED (2026-06-26, researcher-9 cont.)
+Docker build now completes green (3060 jobs, only cosmetic `unusedSimpArgs` /
+`unnecessarySeqFocus` lint warnings, 0 errors). Entry is genuinely `verified`.
+
+**Bug fixed before it built:** the original draft's `four_oblique_corners_rect`
+proof claimed verification but did NOT compile. Three `omega` calls in the
+wrap-around index lemma `hpn` failed because `omega` cannot reason about the
+nonlinear product `m * n` — the in-scope `hpos : 0 < m * n` was too weak to rule
+out `m * n = 2` (needed to show the cyclic predecessor and successor of an index
+are distinct). Fix: add `have hbig : 25 ≤ m * n := by have := Nat.mul_le_mul hm hn; omega`
+to the main theorem context, giving `omega` the linear fact it needs. Lesson:
+`omega` treats `m * n` as an atom — any bound on a product must be supplied as an
+explicit hypothesis.
+
+### Key insight for the gallery
+The oblique lower bound of 4 is a CORNER phenomenon, independent of board shape —
+this separates the shape-independent floor (4) from the genuinely shape-dependent
+open questions (exact minimum, uniqueness, full distribution).
+
+### Follow-ups (depth guard: slug has 2 `-oq-` segments, under cap 3)
+- Long thin boards (m=5, n→∞): does the minimum stay 4 or grow?
+- Do degree-3/4 boundary (non-corner) cells force additional oblique turns?

--- a/src/data/proofs/knights-tour-oblique-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/knights-tour-oblique-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-ktr-board",
+    "proofId": "knights-tour-oblique-oq-01-oq-02",
+    "range": { "startLine": 43, "endLine": 85 },
+    "type": "definition",
+    "title": "Rectangular Board: SquareMN m n = Fin m × Fin n",
+    "content": "SquareMN m n = Fin m × Fin n is the m×n chessboard, with rows indexed by Fin m and columns by Fin n. Splitting the square case's single index Fin n × Fin n into two independent indices is the entire structural change of this generalization: every coordinate bound that was '< n' becomes '< m' for rows and '< n' for columns, and these act independently. knightGraphMN m n is the simple graph where two squares are adjacent iff their integer coordinate difference is an L-shaped knight offset (±1,±2) or (±2,±1).",
+    "mathContext": "$\\text{SquareMN}\\,m\\,n = \\text{Fin}\\,m \\times \\text{Fin}\\,n$; $(a,b)\\sim(c,d) \\iff \\{|a-c|,|b-d|\\}=\\{1,2\\}$",
+    "significance": "key",
+    "relatedConcepts": ["Fin m / Fin n as bounded integers", "SimpleGraph", "knight moves", "aspect ratio"],
+    "prerequisites": ["Fin", "Prod", "SimpleGraph", "Int"]
+  },
+  {
+    "id": "ann-ktr-corner-neighbors",
+    "proofId": "knights-tour-oblique-oq-01-oq-02",
+    "range": { "startLine": 146, "endLine": 215 },
+    "type": "theorem",
+    "title": "Corner Degree 2: each corner has exactly two knight neighbors",
+    "content": "cornerTL/TR/BL/BR_neighbors prove that, for m, n ≥ 5, any knight-neighbor of a given corner is exactly one of two specific squares. The proof case-splits the eight knight offsets; six of them push one coordinate of the neighbor below 0 or to ≥ m (rows) or ≥ n (columns) and are eliminated by s.1.isLt or s.2.isLt with omega. Because rows are bounded by m and columns by n separately, the elimination is insensitive to whether m = n — this is the precise place where dropping squareness is harmless.",
+    "mathContext": "$\\deg_{\\text{knight}}(\\text{corner}) = 2$ for $m,n \\ge 5$",
+    "significance": "critical",
+    "relatedConcepts": ["vertex degree", "boundary effects", "case analysis", "Fin bounds"],
+    "prerequisites": ["SimpleGraph.Adj", "Fin.isLt", "omega"]
+  },
+  {
+    "id": "ann-ktr-corner-oblique",
+    "proofId": "knights-tour-oblique-oq-01-oq-02",
+    "range": { "startLine": 229, "endLine": 338 },
+    "type": "theorem",
+    "title": "Oblique at every corner: entry·exit dot product = −4",
+    "content": "cornerTL/TR/BL/BR_oblique show the turn entering a corner from one neighbor and leaving toward the other is oblique (negative dot product) for either ordering of the two neighbors. After substituting the two neighbor squares from the degree-2 lemma, push_cast clears the coordinate subtractions (n−1, n−2, n−3 for columns; m−1, m−2, m−3 for rows) and ring_nf; omega computes the dot product as exactly −4 < 0. The corner's coordinates (the n−1 / m−1 terms) cancel inside the move-vector differences, so the value −4 is independent of board size and shape.",
+    "mathContext": "$(-\\mathbf{o}_1)\\cdot \\mathbf{o}_2 = -4 < 0$ where $\\mathbf{o}_1,\\mathbf{o}_2 \\in \\{(\\pm1,\\pm2),(\\pm2,\\pm1)\\}$",
+    "significance": "critical",
+    "relatedConcepts": ["dot product", "obtuse angle", "knight offsets", "push_cast"],
+    "prerequisites": ["MoveVector.dot", "Nat.cast_sub", "ring_nf", "omega"]
+  },
+  {
+    "id": "ann-ktr-visits-all",
+    "proofId": "knights-tour-oblique-oq-01-oq-02",
+    "range": { "startLine": 342, "endLine": 351 },
+    "type": "theorem",
+    "title": "A closed tour visits every square",
+    "content": "tour_visits_all shows the tour's square list, having length m·n = card(SquareMN m n) and being nodup, has toFinset equal to univ — so every square, in particular every corner, appears at some tour index. This is what lets the corner analysis be applied inside an arbitrary tour.",
+    "mathContext": "$|\\,\\text{squares}\\,| = m\\cdot n = |\\text{SquareMN}\\,m\\,n| \\Rightarrow \\text{squares.toFinset} = \\text{univ}$",
+    "significance": "supporting",
+    "relatedConcepts": ["surjectivity by counting", "Finset.eq_univ_of_card", "Hamiltonian cycle"],
+    "prerequisites": ["List.Nodup", "Fintype.card_prod", "Finset.eq_univ_of_card"]
+  },
+  {
+    "id": "ann-ktr-main",
+    "proofId": "knights-tour-oblique-oq-01-oq-02",
+    "range": { "startLine": 401, "endLine": 560 },
+    "type": "theorem",
+    "title": "Main: four_oblique_corners_rect",
+    "content": "The main theorem exhibits four distinct tour positions with oblique turns on any m×n board (m, n ≥ 5). Each corner appears at a tour index; corners_distinct plus list nodup make the four indices pairwise distinct. tour_cyclic_adj identifies the cyclic predecessor and successor of a corner's index as its two knight neighbors, and tour_index_neq (from nodup) shows those two squares are distinct, so corner_forces_oblique applies. The modular-index lemmas hcyc/hpn/hsqcong are the square proof's bookkeeping with n·n replaced by m·n — confirming the generalization needs no new ideas, only re-indexing.",
+    "mathContext": "$\\forall\\, t,\\ \\#\\{\\text{oblique turns of } t\\} \\ge 4$ on any $m\\times n$ board, $m,n\\ge 5$",
+    "significance": "critical",
+    "relatedConcepts": ["closed knight's tour", "corner forcing", "cyclic indexing", "lower bound"],
+    "prerequisites": ["List.mem_iff_get", "Nat.mod_lt", "List.Nodup.getElem_inj_iff"]
+  }
+]

--- a/src/data/proofs/knights-tour-oblique-oq-01-oq-02/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-01-oq-02/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "knights-tour-oblique-oq-01-oq-02",
+  "slug": "knights-tour-oblique-oq-01-oq-02",
+  "title": "Knight's Tour Oblique Lower Bound on Rectangular m×n Boards",
+  "description": "Generalizes the square n×n oblique lower bound (knights-tour-oblique-oq-01) to arbitrary rectangular m×n boards: every closed knight's tour on an m×n board with m, n ≥ 5 has at least 4 oblique (>90°) turns, one forced at each of the four corners. The key structural observation is that the bound is purely a CORNER phenomenon — each corner of the board has exactly 2 knight-adjacent squares, and the entry/exit move-vector dot product at any corner is always −4 < 0 — and is therefore independent of the board's aspect ratio. Squareness is never used: replacing Fin n × Fin n by Fin m × Fin n and n·n by m·n carries the entire argument through. The proof is purely algebraic with no native_decide and no board enumeration.",
+  "meta": {
+    "author": "Generalization by formalization (parent: Donald E. Knuth, 8×8 oblique minimum)",
+    "sourceUrl": "https://online.stanford.edu/events/202412/donald-knuths-annual-christmas-lecture-2025",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/KnightsTourObliqueOQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "knights-tour",
+      "Knuth",
+      "generalization",
+      "rectangular-board",
+      "oblique-turns"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None (purely algebraic). The main theorem four_oblique_corners_rect is complete for all m, n ≥ 5: it exhibits 4 distinct tour positions (the board corners) where the turn is oblique. No native_decide, no enumeration. The argument never uses m = n.",
+    "dateAdded": "2026-06-26",
+    "lineCount": 562,
+    "mathlibDependencies": [
+      {
+        "theorem": "SimpleGraph.Basic",
+        "description": "Simple graph definitions (adjacency, symmetry, looplessness)",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      },
+      {
+        "theorem": "List.Nodup.getElem_inj_iff",
+        "description": "Injectivity of indexing into a duplicate-free list (distinct tour positions ⇒ distinct squares)",
+        "module": "Mathlib.Data.List.Nodup"
+      }
+    ],
+    "theoremCount": 15,
+    "definitionCount": 14
+  },
+  "overview": {
+    "historicalContext": "In his 2025 Christmas Lecture, Donald Knuth analyzed the geometry of closed knight's tours on the 8×8 board and showed every tour must contain oblique (obtuse-angle) turns. The companion gallery entry knights-tour-oblique-oq-01 lifted the lower bound of 4 oblique turns from the specific 8×8 board to all square n×n boards (n ≥ 5) by an algebraic corner argument that avoids the native_decide enumeration of the original 8×8 proof. The open question recorded there asks whether the D4-symmetry/corner reasoning extends to other board shapes. This entry answers the rectangular case: the lower bound is a corner phenomenon and survives dropping the squareness hypothesis entirely.",
+    "problemStatement": "Show that every closed knight's tour on a rectangular m×n board with m, n ≥ 5 has at least 4 oblique turns, and that the bound follows from the same four-corner mechanism as the square case — i.e. it does not depend on m = n.",
+    "proofStrategy": "Reparameterize the board as SquareMN m n = Fin m × Fin n with the knight graph knightGraphMN m n (adjacency by an L-shaped coordinate offset). For m, n ≥ 5 each of the four corners (0,0), (0,n−1), (m−1,0), (m−1,n−1) has exactly two knight neighbors — proved by case-splitting the eight knight offsets and discharging the out-of-range ones with the Fin bounds s.1.isLt < m and s.2.isLt < n. At each corner the entry vector (−offset₁) and exit vector (offset₂) have dot product exactly −4 < 0, hence the turn is oblique; this is a finite algebraic check (ring_nf; omega) after push_cast handles the n−1, n−2, n−3 (and m−1, m−2, m−3) coordinate subtractions. A closed tour visits all m·n squares (Finset.eq_univ_of_card on the nodup square list), so each corner occurs at some tour index; cyclic adjacency identifies the predecessor and successor of that index as the two corner neighbors, which are distinct because the list is nodup. Applying corner_forces_oblique at the four (pairwise distinct) corner indices yields four oblique positions.",
+    "keyInsights": [
+      "The oblique lower bound is a CORNER phenomenon: it uses only that the board has four corners each of knight-degree 2, never that the board is square. Replacing Fin n × Fin n by Fin m × Fin n and n·n by m·n transports the whole proof verbatim up to coordinate bookkeeping.",
+      "Corner degree 2 is forced separately in each coordinate: from a corner, six of the eight knight offsets push one coordinate out of [0, m) or [0, n), and the row bound (m) and column bound (n) act independently — which is exactly why asymmetry between m and n is harmless.",
+      "The entry/exit dot product at every corner is the aspect-ratio-independent constant −4, because the two surviving offsets at a corner are always a {(±1,±2),(±2,±1)} pair with opposite-sign overlap; the corner's actual coordinates (involving n−1 or m−1) cancel in the move-vector differences.",
+      "Distinctness of the predecessor and successor squares at a corner — needed to invoke the oblique lemma — comes for free from List.Nodup of the tour, independent of board shape."
+    ]
+  },
+  "sections": [
+    {
+      "id": "rect-board",
+      "title": "Rectangular Board and Knight Graph",
+      "startLine": 41,
+      "endLine": 86,
+      "summary": "SquareMN m n = Fin m × Fin n parameterizes the rectangular board (rows in Fin m, columns in Fin n). knightAdjMN / knightGraphMN define adjacency by an L-shaped integer offset (±1,±2)/(±2,±1); symmetry uses neg_knight_offset and looplessness is immediate. This is the square-case setup with the single type Fin n × Fin n split into Fin m × Fin n."
+    },
+    {
+      "id": "move-vectors",
+      "title": "Move Vectors, Dot Product, Oblique Predicate",
+      "startLine": 87,
+      "endLine": 108,
+      "summary": "MoveVector with integer components, MoveVector.dot the Euclidean dot product, and isOblique v1 v2 := v1.dot v2 < 0. getMoveVector s1 s2 is the coordinate difference. These are unchanged from the square case."
+    },
+    {
+      "id": "closed-tour",
+      "title": "Closed Tour Structure",
+      "startLine": 110,
+      "endLine": 123,
+      "summary": "ClosedTourMN m n bundles the square list with length m·n, nodup, nonemptiness, consecutive knight-adjacency (path), and the wrap-around closing edge (closes)."
+    },
+    {
+      "id": "corner-neighbors",
+      "title": "Corner Degree-2 Analysis",
+      "startLine": 124,
+      "endLine": 215,
+      "summary": "The four corners cornerTL/TR/BL/BR and corners_distinct (m, n ≥ 2). Each of cornerTL_neighbors, cornerTR_neighbors, cornerBL_neighbors, cornerBR_neighbors proves (for m, n ≥ 5) that a knight-neighbor of the corner is exactly one of two squares, by case-splitting all eight offsets and eliminating six via the row bound s.1.isLt < m or the column bound s.2.isLt < n."
+    },
+    {
+      "id": "corner-oblique",
+      "title": "Oblique Turn at Each Corner (dot = −4)",
+      "startLine": 217,
+      "endLine": 339,
+      "summary": "cornerTL/TR/BL/BR_oblique prove the entry→corner→exit turn is oblique for either ordering of the two neighbors: after substituting the two neighbor squares, push_cast clears the n−1/n−2/n−3 (and m−1/m−2/m−3) subtractions and ring_nf; omega verifies the dot product equals −4 < 0. corner_forces_oblique packages all four corners."
+    },
+    {
+      "id": "tour-props",
+      "title": "Tour Coverage and Cyclic Adjacency",
+      "startLine": 340,
+      "endLine": 383,
+      "summary": "tour_visits_all (a tour hits every square, via Finset.eq_univ_of_card), tour_cyclic_adj (consecutive-with-wraparound adjacency at every cyclic index), and tour_index_neq (distinct indices give distinct squares from nodup)."
+    },
+    {
+      "id": "main",
+      "title": "Main Theorem: Four Oblique Corners (Rectangular)",
+      "startLine": 384,
+      "endLine": 562,
+      "summary": "four_oblique_corners_rect: every closed tour on an m×n board (m, n ≥ 5) has four distinct positions with oblique turns. The corner squares occur at tour indices iTL, iTR, iBL, iBR (pairwise distinct via nodup and corners_distinct); the cyclic predecessor/successor at each index are the corner's two neighbors (distinct), so corner_forces_oblique applies. Modular-index bookkeeping (hcyc, hpn, hsqcong) mirrors the square proof with n·n replaced by m·n."
+    }
+  ],
+  "conclusion": {
+    "summary": "Every closed knight's tour on a rectangular m×n board with m, n ≥ 5 has at least 4 oblique turns, forced one per corner. The proof is the square-case argument with Fin n × Fin n replaced by Fin m × Fin n and n·n by m·n; it never uses m = n, exhibiting the oblique lower bound as an aspect-ratio-independent corner phenomenon. Zero axioms, zero sorries.",
+    "implications": "Separates the genuinely board-shape-dependent content of the oblique-turn problem (the exact minimum, its uniqueness, the full distribution — all still open and tied to specific boards) from the shape-independent floor of 4. The corner mechanism transfers to any board whose four extreme cells have knight-degree 2.",
+    "openQuestions": [
+      "On a sufficiently elongated board (m fixed at 5, n → ∞), does the minimum number of oblique turns stay at 4, or do long thin boards force additional oblique turns away from the corners?",
+      "Do non-corner boundary cells of an m×n board (degree 3 or 4 in the knight graph) contribute any further forced oblique turns, giving a shape-dependent lower bound strictly above 4?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "knights-tour-oblique-oq-01",
+      "relationship": "extends",
+      "description": "Generalizes the square n×n four-oblique-corners lower bound to rectangular m×n boards (m, n ≥ 5) by the same corner-degree-2 / dot-product-(−4) mechanism, dropping the squareness hypothesis."
+    },
+    {
+      "proofId": "knights-tour-oblique",
+      "relationship": "extends",
+      "description": "Lifts Knuth's 8×8 oblique-turn analysis to all rectangular boards, replacing the original native_decide enumeration by a purely algebraic corner argument."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/KnightsTourObliqueOQ01OQ02.lean",
+    "lineCount": 562,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 15,
+    "definitionCount": 14,
+    "imports": [
+      "import Mathlib.Combinatorics.SimpleGraph.Basic",
+      "import Mathlib.Data.Fin.Basic",
+      "import Mathlib.Data.List.Nodup",
+      "import Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "KnightsTourObliqueRect"
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalizes the square n×n oblique lower bound (`knights-tour-oblique-oq-01`, `four_oblique_corners`) to **arbitrary rectangular m×n boards**:

> **Theorem `four_oblique_corners_rect`** — every closed knight's tour on an m×n board with m, n ≥ 5 has at least 4 oblique (>90°) turns, one forced at each of the four corners.

### Key insight
The oblique lower bound of 4 is a **corner phenomenon**, independent of board shape. Each corner has exactly 2 knight-adjacent squares, and the entry/exit move-vector dot product at any corner is the aspect-ratio-independent constant −4 < 0. Replacing `Fin n × Fin n` by `Fin m × Fin n` and `n·n` by `m·n` carries the entire square-case proof through — squareness is never used. Purely algebraic: no `native_decide`, no board enumeration.

This separates the shape-independent floor (4) from the genuinely shape-dependent open questions (exact minimum, uniqueness, full distribution).

## Verification
- **Build: green** via `./proofs/scripts/docker-build.sh Proofs.KnightsTourObliqueOQ01OQ02` (3060 jobs, cosmetic lint warnings only).
- 15 theorems, **0 sorries, 0 axioms** → `status: verified`, `badge: original`.

### Build fix included
The draft as inherited did **not** compile. Three `omega` calls in the wrap-around index lemma `hpn` failed: `omega` treats `m * n` as an opaque atom, and the in-scope `hpos : 0 < m * n` was too weak to rule out `m * n = 2` (needed to show a cyclic index's predecessor and successor are distinct). Fix: add `hbig : 25 ≤ m * n` (from `Nat.mul_le_mul hm hn`) to the main theorem context. Verified green afterward.

## Also included
A **BLOCKED** research assessment for `erdos-1018-oq-04-incomplete-01-incomplete-01` (documentation only): the sole remaining concrete target `planar_graphs_edge_bound` needs Euler's formula for planar graphs, which Mathlib lacks in usable form (>1000-line foundational build). Recommends not spawning further `-incomplete-NN` children on that node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)