### PR TITLE
Enrich nth-root irrationality entry (sqrt2-irrational-oq-03): add annotations

### DIFF
--- a/src/data/proofs/sqrt2-irrational-oq-03/annotations.json
+++ b/src/data/proofs/sqrt2-irrational-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sqrt2oq03-header",
+    "proofId": "sqrt2-irrational-oq-03",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "context",
+    "title": "Closing the nth-root iff gap",
+    "content": "The header states the open question attached to the √2-irrationality entry: does the argument generalize to m^(1/n), and can it be phrased as an iff? Mathlib already packages the square-root case as an equivalence (`irrational_sqrt_natCast_iff : Irrational √n ↔ ¬IsSquare n`), but for general nth roots it offers only the one-directional `irrational_nrt_of_notint_nrt`; the gallery's `NthRootIrrational` likewise proves only 'not a perfect power ⟹ irrational' and then enumerates individual non-powers. This entry closes that gap with the full iff and a bounded decidable test. Imports are minimal: `Mathlib.NumberTheory.Real.Irrational` (the irrationality API) and `Mathlib.Analysis.SpecialFunctions.Pow.NNReal` (real rpow).",
+    "mathContext": "$\\mathrm{Irrational}(m^{1/n}) \\iff \\neg\\exists k\\in\\mathbb{N},\\ k^n = m \\quad (n\\neq 0)$, the nth-root analogue of $\\mathrm{Irrational}(\\sqrt n)\\iff\\neg\\,\\mathrm{IsSquare}(n)$.",
+    "significance": "context",
+    "relatedConcepts": ["irrationality", "perfect power", "nth roots", "Mathlib gap", "iff characterization"],
+    "prerequisites": ["irrational numbers", "real powers", "Mathlib irrationality lemmas"]
+  },
+  {
+    "id": "ann-sqrt2oq03-nthroot",
+    "proofId": "sqrt2-irrational-oq-03",
+    "range": { "startLine": 32, "endLine": 43 },
+    "type": "definition",
+    "title": "The nth root via real rpow and its power identity",
+    "content": "`nthRoot n m = (m : ℝ) ^ (n : ℝ)⁻¹` defines m^(1/n) through Mathlib's real power `Real.rpow` (noncomputable, since rpow is). `nthRoot_nonneg` records nonnegativity (rpow of a nonnegative base). The crucial `nthRoot_pow` proves the defining identity (m^(1/n))^n = m for n ≠ 0, a one-liner from `Real.rpow_inv_natCast_pow`: raising m^(1/n) to the n-th power inverts the (1/n)-th power exactly when n ≠ 0 (the n = 0 case would make 1/n undefined as an inverse). This identity is the hinge both directions of the main theorem turn on.",
+    "mathContext": "$\\mathrm{nthRoot}\\,n\\,m := m^{1/n}$ with $(m^{1/n})^n = m$ for $n\\neq 0,\\ m\\ge 0$. Via rpow, $m^{1/n} = e^{(\\log m)/n}$ for $m>0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow", "rpow_inv_natCast_pow", "noncomputable definition", "power identity"],
+    "prerequisites": ["real exponentiation", "rpow inverse-power lemmas"]
+  },
+  {
+    "id": "ann-sqrt2oq03-iff",
+    "proofId": "sqrt2-irrational-oq-03",
+    "range": { "startLine": 45, "endLine": 85 },
+    "type": "insight",
+    "title": "The iff characterization, both directions",
+    "content": "`irrational_nthRoot_iff` is the headline: for n ≠ 0, Irrational(m^(1/n)) ↔ ¬∃ k, k^n = m. Forward (irrational ⟹ not a perfect power): if m = k^n then m^(1/n) = k exactly (via `Real.pow_rpow_inv_natCast`), and a natural number is never irrational (`Nat.not_irrational`) — contradiction. Converse (not a perfect power ⟹ irrational): the power identity nthRoot^n = (m:ℤ) feeds Mathlib's `irrational_nrt_of_notint_nrt`, which gives irrationality provided the root is not itself an integer; the proof discharges that side condition by showing any integer value y would, after `Int.toNat_of_nonneg` (y ≥ 0 since the root is nonnegative), exhibit m as the perfect power y.toNat^n. The careful ℕ→ℤ→ℝ casting (push_cast, exact_mod_cast) is what makes the integer/nonnegativity bookkeeping go through.",
+    "mathContext": "$(\\Leftarrow)$ $\\neg\\exists k,\\ k^n=m \\Rightarrow m^{1/n}\\notin\\mathbb{Q}$ via $\\mathrm{irrational\\_nrt\\_of\\_notint\\_nrt}$; $(\\Rightarrow)$ $m=k^n \\Rightarrow m^{1/n}=k\\in\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": ["irrational_nrt_of_notint_nrt", "Nat.not_irrational", "Real.pow_rpow_inv_natCast", "integer-root side condition", "casting"],
+    "prerequisites": ["Mathlib irrationality lemmas", "integer/real casts", "case analysis"]
+  },
+  {
+    "id": "ann-sqrt2oq03-bounded",
+    "proofId": "sqrt2-irrational-oq-03",
+    "range": { "startLine": 87, "endLine": 116 },
+    "type": "technique",
+    "title": "Bounding the perfect-power test to make it decidable",
+    "content": "`exists_nthPow_iff_bounded` is the decidability engine: the unbounded existential ∃ k, k^n = m is equivalent to the bounded ∃ k ∈ Finset.range (m+1), k^n = m, because any witness satisfies k ≤ k^n = m (`Nat.le_self_pow`, valid for n ≠ 0). A bounded existential over a Finset is `Decidable`, so `irrational_nthRoot_iff_bounded` (the iff rewritten through this bound) turns the whole irrationality question into a finite, kernel-decidable check. `not_irrational_nthRoot_of_perfectPow` isolates the converse direction cleanly for reuse. This is the structural move that replaces bespoke non-power lemmas (two_not_perfect_cube, …) with a single uniform `decide`.",
+    "mathContext": "$k^n = m \\Rightarrow k \\le k^n = m$, so a witness lives in $\\{0,\\dots,m\\}$; the bounded predicate is decidable.",
+    "significance": "key",
+    "relatedConcepts": ["decidability", "bounded existential", "Nat.le_self_pow", "Finset.range", "decide tactic"],
+    "prerequisites": ["decidable predicates", "Finset bounded quantifiers", "monotonicity of powers"]
+  },
+  {
+    "id": "ann-sqrt2oq03-instances",
+    "proofId": "sqrt2-irrational-oq-03",
+    "range": { "startLine": 118, "endLine": 144 },
+    "type": "context",
+    "title": "Concrete instances: one-line decide, plus the converse",
+    "content": "The decidable form pays off: ∛2, ∛3, ⁴√3, ⁵√2, and even √2 (the n = 2 case of the same machinery) each become `rw [irrational_nthRoot_iff_bounded …]; decide` — kernel `decide`, not `native_decide`, so no `Lean.ofReduceBool` enters and the entry stays at 0 counted axioms. These single lines subsume the manual enumeration (two_not_perfect_cube, three_not_perfect_cube, two_not_perfect_fifth, …) that earlier nth-root entries spelled out. `not_irrational_cbrt_eight` shows the converse in action: ∛8 = 2 is rational because 8 = 2³, supplied as the explicit witness ⟨2, …⟩.",
+    "mathContext": "$\\sqrt[3]{2},\\sqrt[3]{3},\\sqrt[4]{3},\\sqrt[5]{2},\\sqrt{2}$ irrational by `decide`; $\\sqrt[3]{8}=2$ rational since $8=2^3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide vs native_decide", "axiom integrity", "worked instances", "converse direction"],
+    "prerequisites": ["decision procedures", "Lean kernel reduction"]
+  }
+]

--- a/src/data/proofs/sqrt2-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-irrational-oq-03/meta.json
@@ -41,7 +41,8 @@
     "keyInsights": [
       "The iff is the right object: it subsumes both the irrationality of non-powers and the rationality of powers, where Mathlib and the gallery previously had only the forward half for nth roots.",
       "Bounding the perfect-power test (k ≤ k^n = m) is what makes the characterization decidable, replacing bespoke non-power lemmas with `decide`.",
-      "The rpow inverse identities Real.rpow_inv_natCast_pow and Real.pow_rpow_inv_natCast are exactly what connects m^(1/n) back to m in both directions."
+      "The rpow inverse identities Real.rpow_inv_natCast_pow and Real.pow_rpow_inv_natCast are exactly what connects m^(1/n) back to m in both directions.",
+      "Using kernel `decide` rather than `native_decide` keeps the concrete instances axiom-free: native_decide would pull in Lean.ofReduceBool, whereas the bounded Finset search is small enough for the kernel to evaluate directly, so the entry truthfully reports 0 axioms."
     ],
     "prerequisites": [
       "Irrationality (Irrational) and Mathlib's nth-root irrationality lemma irrational_nrt_of_notint_nrt",


### PR DESCRIPTION
Enrichment pass for `sqrt2-irrational-oq-03` (nth Roots: Irrational iff Not a Perfect Power).

## Gap addressed
Rich `meta.json` (overview, conclusion, 3 line-ranged sections, mainTheorems, crossReferences) but **no `annotations.json`**.

## Changes
**annotations.json** — 5 inline annotations spanning the 144-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
1. Header: the nth-root iff gap (Mathlib has only the square-root iff + one-directional nth-root lemma)
2. `nthRoot` via rpow and the power identity (m^(1/n))^n = m
3. The iff characterization, both directions (irrational_nrt_of_notint_nrt; the integer-root side condition)
4. Bounding the perfect-power test (k ≤ k^n = m) to make it decidable
5. Concrete instances: one-line `decide`, plus the converse ∛8 = 2

**meta.json** — added one keyInsight (3 → 4) on kernel `decide` vs `native_decide` preserving axiom-freeness (relevant to the axiom-integrity policy).

## Verification
- meta.json + annotations.json validate; all 5 annotations carry the full field set.
- meta.json ~10.5 KB (under cap). Status/badge unchanged (verified / mathlib / 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)