### PR TITLE
Enrich quintic Bernoulli endpoint entry: deepen annotations

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -2,67 +2,85 @@
   {
     "id": "ann-bernOQ01010101-overview",
     "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
-    "range": {
-      "startLine": 3,
-      "endLine": 49
-    },
+    "range": { "startLine": 3, "endLine": 49 },
     "type": "context",
-    "title": "Locating the Quintic Bernoulli Endpoint",
-    "content": "The parent pinned the cubic endpoint a₃* = −3 from (1+a)³ − (1+3a) = a²(a+3) and conjectured that the per-exponent odd endpoints creep up toward the sharp uniform bound −2. This file resolves the next odd case n = 5. The same algebra gives (1+a)⁵ − (1+5a) = a²·g(a) with g(a) = a³ + 5a² + 10a + 10, but g has no rational root, so the endpoint a₅* must be located rather than computed. Showing g strictly increasing makes the endpoint unique, and a sign change pins it inside (−3, −2), confirming a₃* = −3 < a₅* < −2."
+    "title": "Locating the quintic Bernoulli endpoint",
+    "content": "The parent entry pinned the cubic endpoint a₃* = −3 from (1+a)³ − (1+3a) = a²(a+3), proved −2 is the sharp uniform (n-independent) left endpoint of 1 + n·a < (1+a)ⁿ, and conjectured the per-exponent odd endpoints a₃* < a₅* < a₇* < ⋯ creep up toward −2. This file resolves the next odd case n = 5. The same algebra gives (1+a)⁵ − (1+5a) = a²·g(a) with g(a) = a³ + 5a² + 10a + 10, but g has no rational root, so a₅* must be located, not computed. The strategy: show g strictly increasing (unique root), then pin that root inside (−3, −2) by a sign change — confirming a₃* = −3 < a₅* < −2, the first step of the creep.",
+    "mathContext": "$(1+a)^5 - (1+5a) = a^2\\,g(a)$, $g(a) = a^3 + 5a^2 + 10a + 10$; goal $a_5^* \\in (-3,-2)$ with $a_3^* = -3 < a_5^* < -2 = \\sup_n a_n^*$.",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli's inequality", "sharp endpoint", "monotone creep", "intermediate value theorem", "irrational root"],
+    "prerequisites": ["Bernoulli inequality", "polynomial factorization", "real analysis"]
   },
   {
     "id": "ann-bernOQ01010101-factor",
     "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
-    "range": {
-      "startLine": 55,
-      "endLine": 66
-    },
+    "range": { "startLine": 51, "endLine": 61 },
     "type": "insight",
-    "title": "The Residual Cubic",
-    "content": "The double factor a² (the source of the always-equality at a = 0) splits off, leaving the residual cubic g(a) = a³ + 5a² + 10a + 10 to govern the sign of the strict inequality. This mirrors the parent's a²(a+3) — but where a+3 was linear with root −3, here the residual is a genuine cubic."
+    "title": "The residual cubic factorization",
+    "content": "`residualCubic a = a³ + 5a² + 10a + 10` is defined, and `quintic_factor` proves the residual factorization (1+a)⁵ − (1+5a) = a²·g(a) by `ring`. The double factor a² (the source of the always-equality at a = 0) splits off, leaving the residual cubic g to govern the sign of the strict inequality. This mirrors the parent's a²(a+3) — but where a+3 was linear with rational root −3, here the residual is a genuine cubic with no rational root, which is exactly why the endpoint becomes irrational and must be located rather than read off.",
+    "mathContext": "$(1+a)^5 - (1+5a) = a^2\\,(a^3 + 5a^2 + 10a + 10)$; the binomial expansion's $a^2$ term onward all carry a factor $a^2$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial factorization", "binomial expansion", "ring tactic", "double root at a=0"],
+    "prerequisites": ["polynomial algebra", "binomial theorem"]
   },
   {
     "id": "ann-bernOQ01010101-mono",
     "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
-    "range": {
-      "startLine": 68,
-      "endLine": 83
-    },
-    "type": "insight",
-    "title": "Sum-of-Squares Monotonicity",
-    "content": "The divided difference g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10) has a positive-definite bracket: 12 times it equals (3a+3b+10)² + 3(a−b)² + 20, a sum of squares plus a positive constant. So g is strictly increasing — without differentiating — which both makes the endpoint unique and yields the clean equivalence 0 < g(a) ↔ a₅* < a."
+    "range": { "startLine": 63, "endLine": 80 },
+    "type": "technique",
+    "title": "Sum-of-squares monotonicity (no calculus)",
+    "content": "`residualCubic_strictMono` proves g strictly increasing without differentiating. The divided difference g(b) − g(a) = (b−a)·(a²+ab+b²+5a+5b+10) has a positive-definite bracket: 12·bracket = (3a+3b+10)² + 3(a−b)² + 20 > 0, a sum of squares plus a positive constant, discharged by `nlinarith` with the two `sq_nonneg` hints. So g is strictly monotone, hence injective with at most one real root — making the endpoint unique. `continuous_residualCubic` (a one-line `fun_prop`) supplies the continuity the IVT needs next. Strict monotonicity also yields the clean equivalence 0 < g(a) ↔ a₅* < a used in the headline.",
+    "mathContext": "$g(b)-g(a) = (b-a)(a^2+ab+b^2+5a+5b+10)$ and $12(a^2+ab+b^2+5a+5b+10) = (3a+3b+10)^2 + 3(a-b)^2 + 20 > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["strict monotonicity", "divided difference", "sum of squares", "nlinarith", "positive-definite quadratic"],
+    "prerequisites": ["monotone functions", "sum-of-squares certificates", "Lean nlinarith"]
+  },
+  {
+    "id": "ann-bernOQ01010101-signform",
+    "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 99 },
+    "type": "technique",
+    "title": "Reducing the strict inequality to the sign of g",
+    "content": "`quintic_iff_residual_pos` proves 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ 0 < g(a). The factorization makes the gap a²·g(a); since a² ≥ 0, the gap is positive exactly when a ≠ 0 (so a² > 0) and g(a) > 0. The forward direction rules out a = 0 by `norm_num` on g(0) and the sign of g by contradiction (`nlinarith` with mul_nonneg of a² and −g(a)); the reverse multiplies a² > 0 by g(a) > 0. This is the bridge that converts the transcendental-looking inequality into a purely sign-of-a-polynomial condition, ready for the monotonicity/IVT argument.",
+    "mathContext": "$1 + 5a < (1+a)^5 \\iff a \\ne 0 \\wedge 0 < g(a)$, since the gap equals $a^2 g(a)$ and $a^2 \\ge 0$ with equality iff $a = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sign analysis", "nonnegativity of squares", "nlinarith", "case split on a=0"],
+    "prerequisites": ["inequalities", "sign of products", "proof by contradiction"]
   },
   {
     "id": "ann-bernOQ01010101-endpoint",
     "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
-    "range": {
-      "startLine": 111,
-      "endLine": 130
-    },
+    "range": { "startLine": 101, "endLine": 127 },
     "type": "insight",
-    "title": "IVT Pins the Irrational Endpoint",
-    "content": "Because g(−3) = −2 < 0 < 2 = g(−2), the intermediate value theorem places a root a₅* in (−3, −2); strict monotonicity makes it the only one. The result 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a is the exact analogue of the parent's cubic_iff, now with an irrational endpoint, and −3 < a₅* < −2 is the first step of the creep."
+    "title": "IVT pins the irrational endpoint",
+    "content": "`quintic_endpoint` is the headline. Because g(−3) = −2 < 0 < 2 = g(−2), `intermediate_value_Ioo` (with the continuity lemma) places a root a₅* in (−3, −2); strict monotonicity makes it the only one. The proof then rewrites the inequality through `quintic_iff_residual_pos` and converts 0 < g(a) ↔ a₅* < a using `residualCubic_strictMono.lt_iff_lt` at the root (g(a₅*) = 0). The result 1 + 5a < (1+a)⁵ ↔ a ≠ 0 ∧ a₅* < a is the exact analogue of the parent's cubic_iff, now with an irrational endpoint, and −3 < a₅* < −2 realizes the first step of the creep.",
+    "mathContext": "$g(-3) = -2 < 0 < 2 = g(-2) \\Rightarrow \\exists! a_5^* \\in (-3,-2),\\ g(a_5^*) = 0$; then $0 < g(a) \\iff a_5^* < a$ by strict monotonicity.",
+    "significance": "key",
+    "relatedConcepts": ["intermediate value theorem", "uniqueness of root", "lt_iff_lt", "irrational endpoint", "cubic_iff analogue"],
+    "prerequisites": ["intermediate value theorem", "continuity", "strict monotonicity"]
   },
   {
     "id": "ann-bernOQ01010101-witness",
     "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
-    "range": {
-      "startLine": 132,
-      "endLine": 151
-    },
+    "range": { "startLine": 129, "endLine": 146 },
     "type": "insight",
-    "title": "The Creep Made Concrete",
-    "content": "At a = −29/10 the cubic inequality (n = 3) still holds — since −29/10 > a₃* = −3 — but the quintic inequality (n = 5) fails, because a₅* > −29/10. A single rational point thus witnesses that the endpoint has strictly risen from −3 to a₅*. The point −5/2 lies on the other side (n = 5 holds there), bracketing a₅* ∈ (−29/10, −5/2)."
+    "title": "The creep made concrete",
+    "content": "Three rational witnesses (all `norm_num`) bracket a₅* and exhibit the creep. `strict_at_neg_five_halves`: the n = 5 inequality holds at a = −5/2 (g(−5/2) = 5/8 > 0), so a₅* < −5/2. `quintic_fails_at_neg_29`: at a = −29/10 the n = 5 inequality fails (g < 0), so a₅* > −29/10. `cubic_holds_at_neg_29`: at the very same −29/10 the n = 3 inequality still holds (−29/10 > a₃* = −3). The pair shows a single rational point where n = 3 succeeds but n = 5 fails — the endpoint has strictly risen from −3 — and brackets a₅* ∈ (−29/10, −5/2).",
+    "mathContext": "$a_5^* \\in (-\\tfrac{29}{10}, -\\tfrac52)$: $g(-\\tfrac52) > 0$ (n=5 holds), $g(-\\tfrac{29}{10}) < 0$ (n=5 fails), while $n=3$ holds at $-\\tfrac{29}{10}$ since $-\\tfrac{29}{10} > a_3^* = -3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["rational witness", "bracketing", "norm_num", "monotone creep"],
+    "prerequisites": ["rational arithmetic", "decidable numeric inequalities"]
   },
   {
     "id": "ann-bernOQ01010101-belowneg2",
     "proofId": "bernoulli-inequality-oq-01-oq-01-oq-01-oq-01",
-    "range": {
-      "startLine": 153,
-      "endLine": 160
-    },
+    "range": { "startLine": 148, "endLine": 161 },
     "type": "insight",
-    "title": "Why the Creep Stays Below −2",
-    "content": "For every odd n the power (1 + (−2))ⁿ = (−1)ⁿ = −1 already beats the line value 1 − 2n once n ≥ 2, so the strict inequality holds at a = −2 for all odd n. Hence −2 is interior to the strict domain of each odd exponent and aₙ* < −2 universally: the endpoints rise toward −2 = supₙ aₙ* but never reach it."
+    "title": "Why the creep stays below −2",
+    "content": "`strict_at_neg_two_odd` gives the structural reason every odd endpoint sits below −2. For every odd n ≥ 2, at a = −2 the power (1+a)ⁿ = (−1)ⁿ = −1 (via `Odd.neg_one_pow`), which beats the line value 1 + n·(−2) = 1 − 2n ≤ −3 (since n ≥ 2). The `nlinarith` closes −1 > 1 − 2n. So a = −2 is interior to the strict domain of every odd exponent, forcing aₙ* < −2 universally: the endpoints rise toward −2 = supₙ aₙ* but never reach it — matching the parent's identification of −2 as the sharp uniform bound.",
+    "mathContext": "For odd $n \\ge 2$: $(1+(-2))^n = (-1)^n = -1 > 1 - 2n = 1 + n(-2)$, so the strict inequality holds at $a=-2$ and $a_n^* < -2$ for all odd $n$.",
+    "significance": "key",
+    "relatedConcepts": ["odd powers of −1", "Odd.neg_one_pow", "supremum approached from below", "uniform sharp bound"],
+    "prerequisites": ["parity of exponents", "powers of negative numbers", "nlinarith"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-01-oq-01-oq-01` (the quintic Bernoulli endpoint a₅* ∈ (−3,−2) and the creep toward −2).

## Gap addressed
Rich `meta.json` (6 line-ranged sections, 4 keyInsights, conclusion, crossReferences), but the 6 annotations carried only `content` — no `mathContext`/`significance`/`relatedConcepts`/`prerequisites` — and the `quintic_iff_residual_pos` region (lines 82–99) had no annotation.

## Changes
`annotations.json` (6 → 7, all now with the full field set):
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all annotations
- New annotation for `quintic_iff_residual_pos` (the sign-of-g reduction)
- Ranges adjusted to tile the whole 161-line file (overview, factorization, SOS-monotonicity, sign-form, IVT endpoint, concrete witnesses, below-−2)

## Verification
- annotations.json validates; all 7 annotations carry mathContext/significance/relatedConcepts/prerequisites.
- meta.json unchanged (15 KB, under cap; status verified/0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)