### PR TITLE
Research: erdos-633 — diagnose similar-dissection model over-counting (5→4 sorries, correct 'hard #634' mislabel)

### DIFF
--- a/proofs/Proofs/Erdos633Problem.lean
+++ b/proofs/Proofs/Erdos633Problem.lean
@@ -376,17 +376,70 @@ theorem right_isoceles_dissects_to_2 : ∃ T : Triangle,
 
 /-! ## Similar vs Congruent Dissections -/
 
-/-- For similar (not congruent) dissections, the situation is different -/
+/-- For similar (not congruent) dissections, the situation is different.
+
+    NOTE (model adequacy): like `CongruentDissection`, this predicate encodes
+    only *necessary numeric* conditions — equal side ratios (`S` similar to `T`)
+    and area compatibility (`T.area = n · S.area`). It does NOT encode a real
+    geometric tiling into similar pieces. As `canDissectIntoSimilar_of_one_le`
+    proves below, it therefore OVER-counts exactly as the congruent model does:
+    the scaled copy `T.scale (1/√n)` is similar to `T` and has area `T.area / n`,
+    so it witnesses `CanDissectIntoSimilar T n` for *every* `n ≥ 1`. Hence the
+    two statements below are model-artifacts, not the hard #634 geometric content
+    (correcting an earlier classification of them as "hard"). -/
 def CanDissectIntoSimilar (T : Triangle) (n : ℕ) : Prop :=
   ∃ S : Triangle, S.a / S.b = T.a / T.b ∧ S.b / S.c = T.b / T.c ∧
     T.area = n * S.area
 
-/-- Every triangle can be dissected into n similar triangles for n ≠ 2, 3, 5 -/
-theorem similar_dissection_characterization (T : Triangle) (n : ℕ) (hn : n ≥ 1) :
-    n ∉ ({2, 3, 5} : Set ℕ) → CanDissectIntoSimilar T n := by
-  sorry
+/-- **Over-counting of the similar model.** The scaled copy `T.scale (1/√n)` is
+    similar to `T` (same side ratios) and, by `Triangle.area_scale`, has area
+    `T.area / n`; so `CanDissectIntoSimilar T n` holds for *every* `n ≥ 1`,
+    independent of any geometric realizability. This is the similar-dissection
+    analogue of `all_counts_achievable`, and it shows the area+similarity model
+    is inadequate for the similar problem too. -/
+theorem canDissectIntoSimilar_of_one_le (T : Triangle) (n : ℕ) (hn : n ≥ 1) :
+    CanDissectIntoSimilar T n := by
+  have hnR : (0:ℝ) < (n:ℝ) := by exact_mod_cast hn
+  have hsq : (0:ℝ) < Real.sqrt n := Real.sqrt_pos.mpr hnR
+  have hne : (1 / Real.sqrt n) ≠ 0 := ne_of_gt (one_div_pos.mpr hsq)
+  refine ⟨T.scale (1 / Real.sqrt n) (one_div_pos.mpr hsq), ?_, ?_, ?_⟩
+  · simp only [Triangle.scale]
+    exact mul_div_mul_left T.a T.b hne
+  · simp only [Triangle.scale]
+    exact mul_div_mul_left T.b T.c hne
+  · rw [Triangle.area_scale, div_pow, one_pow, Real.sq_sqrt (le_of_lt hnR),
+        ← mul_assoc, mul_one_div, div_self (ne_of_gt hnR), one_mul]
 
-/-- Some triangles cannot be dissected into 2, 3, or 5 similar triangles -/
+/-- Every triangle can be dissected into n similar triangles for n ≠ 2, 3, 5.
+
+    NOTE (model adequacy): in the area+similarity model this is a *weaker* and
+    vacuous consequence of `canDissectIntoSimilar_of_one_le` — the hypothesis
+    `n ∉ {2,3,5}` is unused because the over-counting witness `T.scale (1/√n)`
+    works for *all* `n ≥ 1`. The genuine #634 geometric statement (an actual
+    tiling into similar pieces) is what the model cannot see; this proof is the
+    honest model-content only. -/
+theorem similar_dissection_characterization (T : Triangle) (n : ℕ) (hn : n ≥ 1) :
+    n ∉ ({2, 3, 5} : Set ℕ) → CanDissectIntoSimilar T n :=
+  fun _ => canDissectIntoSimilar_of_one_le T n hn
+
+/-- **The exceptional cases vanish in the model.** Every triangle satisfies
+    `CanDissectIntoSimilar T n` for `n = 2, 3, 5`, so no triangle is exceptional
+    in the area+similarity model — the existence claim `exceptional_similar_cases`
+    is model-FALSE (this is its direct refutation, the similar analogue of
+    `no_square_only_in_model`). -/
+theorem no_exceptional_similar_in_model (T : Triangle) :
+    CanDissectIntoSimilar T 2 ∧ CanDissectIntoSimilar T 3 ∧ CanDissectIntoSimilar T 5 :=
+  ⟨canDissectIntoSimilar_of_one_le T 2 (by norm_num),
+   canDissectIntoSimilar_of_one_le T 3 (by norm_num),
+   canDissectIntoSimilar_of_one_le T 5 (by norm_num)⟩
+
+/-- Some triangles cannot be dissected into 2, 3, or 5 similar triangles.
+
+    NOTE (model adequacy): this is *model-false* — `no_exceptional_similar_in_model`
+    proves every triangle has all three counts in the area+similarity model. It is
+    retained as an aspirational restatement of the genuine #634 geometric fact
+    (real exceptional similar dissections exist), dischargeable only after
+    `CanDissectIntoSimilar` is replaced by a faithful tiling predicate. -/
 theorem exceptional_similar_cases :
     ∃ T : Triangle, ¬CanDissectIntoSimilar T 2 ∧
       ¬CanDissectIntoSimilar T 3 ∧ ¬CanDissectIntoSimilar T 5 := by

--- a/research/problems/erdos-633/knowledge.md
+++ b/research/problems/erdos-633/knowledge.md
@@ -1,8 +1,8 @@
 # Erdős #633 — Square-Only Triangle Dissections (knowledge)
 
 ## State
-- OPEN ($25). Gallery file `proofs/Proofs/Erdos633Problem.lean`, badge `wip`, 5 real sorries.
-- Model: `CongruentDissection` encodes ONLY area-compatibility (`area T = n·area S`) + side-ratio similarity. It does NOT encode a real tiling.
+- OPEN ($25). Gallery file `proofs/Proofs/Erdos633Problem.lean`, badge `wip`, **4 real sorries** (was 5; `similar_dissection_characterization` filled as a vacuous model-fact this session).
+- Model: BOTH `CongruentDissection` (congruent) and `CanDissectIntoSimilar` (similar) encode ONLY area-compatibility (`area T = n·area S`) + side-ratio similarity. Neither encodes a real tiling.
 
 ## Key structural fact (CRITICAL)
 The model **over-counts**: by `Triangle.area_scale`, the scaled copy `T.scale (1/√n)` satisfies both numeric conditions for *every* `n ≥ 1`. Hence `DissectionCounts T = {n | n ≥ 1}` for every triangle, so the square-only direction is **model-false**, not just unproved.
@@ -15,12 +15,47 @@ Turned the informal over-counting note into proved theorems (mirroring the alrea
 - `no_square_only_in_model (T) : ¬ HasSquareOnlyProperty T` (2 is achievable & non-square).
 Added doc notes to `soifer_square_only` and `erdos_633` flagging they are model-false (refuted by `no_square_only_in_model`).
 
-## Why the 5 sorries can't be filled here
-`soifer_square_only`, `soifer_family_square_only`, `integral_independence_implies_square_only` are model-false. The two `CanDissectIntoSimilar` sorries (`similar_dissection_characterization`, `exceptional_similar_cases`) are the hard #634 content.
+## Session 2026-06-26 (researcher-1) — CORRECTION + similar-model diagnosis
+The prior note (below) called the two `CanDissectIntoSimilar` sorries "the hard
+#634 content." **That was a mischaracterization.** `CanDissectIntoSimilar` is
+*also area-only*, so it over-counts identically to the congruent model. Proved:
+- `canDissectIntoSimilar_of_one_le (T) (n) (hn : n ≥ 1) : CanDissectIntoSimilar T n`
+  — witness `T.scale (1/√n)` (the similar analogue of `all_counts_achievable`).
+- `similar_dissection_characterization` — FILLED (sorry removed) as an immediate,
+  vacuous consequence (the `n ∉ {2,3,5}` hypothesis is unused). Documented as a
+  model-artifact, not real geometry.
+- `no_exceptional_similar_in_model (T) : CanDissectIntoSimilar T 2 ∧ … 3 ∧ … 5`
+  — proves `exceptional_similar_cases` is model-FALSE (its direct refutation,
+  similar analogue of `no_square_only_in_model`). `exceptional_similar_cases`
+  retained as a model-false aspirational sorry, doc corrected.
+
+## Why the (now 4) sorries can't be filled here
+All four are *model-false* in the area+similarity model: `soifer_square_only`,
+`integral_independence_implies_square_only`, `exceptional_similar_cases`,
+`soifer_family_square_only`. They are genuine geometric statements awaiting a
+faithful tiling predicate.
 
 ## Next directions
-- Replace `CongruentDissection` with a faithful geometric tiling predicate (the open, hard core). Only then do the square-only statements become *true* targets.
-- Do NOT keep adding lemmas on top of the over-counting model — they are area-compatibility facts, not dissection facts.
+- Replace `CongruentDissection` AND `CanDissectIntoSimilar` with a faithful
+  geometric tiling predicate (the open, hard core). Only then do these statements
+  become *true* targets rather than model-artifacts.
+- Do NOT add further area-compatibility lemmas pretending to be dissection
+  progress. The model-inadequacy diagnosis is now COMPLETE for both predicates
+  (congruent over-counts → `dissectionCounts_eq`/`no_square_only_in_model`;
+  similar over-counts → `canDissectIntoSimilar_of_one_le`/`no_exceptional_similar_in_model`).
 
-## Build note
-Could not machine-verify this session: Docker daemon was not running in the worktree (`docker-build.sh` → "Docker daemon is not running"). New proofs are copies of verified tactic patterns already in the file.
+## Build note (2026-06-26)
+Could not machine-verify: Docker build blocked by the persistent Mathlib-cache
+`.ltar` Permission-denied error (cached path) / OOM at the ~7.65GB VM ceiling
+(from-source path). New proofs mirror the already-verified `all_counts_achievable`
+rewrite chain and use only standard Mathlib lemmas (`mul_div_mul_left`,
+`Triangle.area_scale`, `Real.sq_sqrt`), all confirmed present in pinned Mathlib.
+
+---
+## (Prior) Session 2026-06-26 (researcher-3)
+Turned the informal over-counting note into proved theorems (mirroring the already-verified `universal_square_dissection` / `equilateral_dissects_to_3`):
+- `all_counts_achievable (T) (n) (hn : n ≥ 1) : CanDissectInto T n` — witness `T.scale (1/√n)`.
+- `dissectionCounts_eq : DissectionCounts T = {n | 1 ≤ n}`.
+- `not_isPerfectSquare_two : ¬ IsPerfectSquare 2`.
+- `no_square_only_in_model (T) : ¬ HasSquareOnlyProperty T` (2 is achievable & non-square).
+Added doc notes to `soifer_square_only` and `erdos_633` flagging they are model-false (refuted by `no_square_only_in_model`).

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -18,7 +18,7 @@
       "tiling-theory"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 633,
     "erdosUrl": "https://erdosproblems.com/633",
     "erdosProblemStatus": "open",
@@ -57,10 +57,10 @@
       "SoiferFamily generalization to (√p, √q, √r) triangles"
     ],
     "axiomCount": 0,
-    "lineCount": 438,
-    "assumptions": "0 axiom(s) and 5 sorry(s). Fully verified: the area-homogeneity engine (Triangle.area_scale), the area-compatibility dissection theorems (universal_square_dissection, equilateral_dissects_to_3, right_isoceles_dissects_to_2), and the model-collapse results added this session (all_counts_achievable, dissectionCounts_eq, no_square_only_in_model) which prove DissectionCounts T = {n | n ≥ 1} for every triangle and hence that NO triangle has the square-only property in the simplified area+similarity model. The 5 remaining sorries are the genuinely open/hard geometric content of Erdős #633 (soifer_square_only, integral_independence_implies_square_only, similar_dissection_characterization, exceptional_similar_cases, soifer_family_square_only); they are now known to be *model-false* (refuted by no_square_only_in_model) and dischargeable only after CongruentDissection is replaced by a faithful tiling predicate. See the Lean source for details.",
+    "lineCount": 491,
+    "assumptions": "0 axiom(s) and 4 sorry(s). Fully verified: the area-homogeneity engine (Triangle.area_scale), the area-compatibility dissection theorems (universal_square_dissection, equilateral_dissects_to_3, right_isoceles_dissects_to_2), and the model-collapse results (all_counts_achievable, dissectionCounts_eq, no_square_only_in_model) which prove DissectionCounts T = {n | n ≥ 1} for every triangle and hence that NO triangle has the square-only property in the simplified area+similarity model. This session extended the model-inadequacy diagnosis to the SIMILAR-dissection predicate, correcting an earlier mischaracterization: CanDissectIntoSimilar is also area-only and over-counts identically — canDissectIntoSimilar_of_one_le proves it holds for every n ≥ 1 (witness T.scale(1/√n)). Consequently similar_dissection_characterization (n ∉ {2,3,5} → dissectable) is now a proved but vacuous model-fact (sorry removed; the n ∉ {2,3,5} hypothesis is unused), and exceptional_similar_cases is shown model-FALSE by the new no_exceptional_similar_in_model. The 4 remaining sorries are genuine geometric statements that are *model-false* in the area+similarity model (soifer_square_only, integral_independence_implies_square_only, exceptional_similar_cases, soifer_family_square_only); they are dischargeable only after CongruentDissection/CanDissectIntoSimilar is replaced by a faithful tiling predicate. BUILD-PENDING: new proofs mirror the already-verified all_counts_achievable rewrite chain and use only standard Mathlib lemmas (mul_div_mul_left, Triangle.area_scale, Real.sq_sqrt); Docker build blocked by the persistent Mathlib-cache .ltar permission/OOM infra issue.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 18,
     "additionalFiles": [
       "Proofs/Erdos633Aristotle.lean"
@@ -156,8 +156,8 @@
       "title": "Similar vs Congruent Dissections",
       "startLine": 181,
       "endLine": 198,
-      "summary": "Defines CanDissectIntoSimilar (dissection into n similar — not necessarily congruent — pieces) and states the related Problem #634 results: similar_dissection_characterization (every triangle dissects into n similar copies for n ∉ {2,3,5}) and exceptional_similar_cases (some triangle resists n = 2,3,5), both sorry.",
-      "mathContext": "For *similar* dissections the answer is known (Problem #634): every triangle is cuttable into $n$ similar copies for all $n \\notin \\{2,3,5\\}$, with genuine exceptions at $2,3,5$. This contrasts with the still-open *congruent* case of #633."
+      "summary": "Defines CanDissectIntoSimilar (dissection into n similar — not necessarily congruent — pieces). canDissectIntoSimilar_of_one_le proves this predicate OVER-counts (holds for every n ≥ 1 via T.scale(1/√n)), exactly like the congruent model. Hence similar_dissection_characterization (n ∉ {2,3,5} → dissectable) is a proved-but-vacuous model-fact, and the genuine #634 exceptions are erased: no_exceptional_similar_in_model proves every triangle has counts 2,3,5, refuting exceptional_similar_cases (retained as a model-false aspirational sorry).",
+      "mathContext": "For *similar* dissections the genuine geometric answer is known (Problem #634): every triangle is cuttable into $n$ similar copies for all $n \\notin \\{2,3,5\\}$, with genuine exceptions at $2,3,5$. The area+similarity model used here cannot see this — it over-counts, making every $n \\ge 1$ trivially 'dissectable' and erasing the exceptions. Capturing the real #634 statement (like the still-open *congruent* case of #633) requires a faithful tiling predicate."
     },
     {
       "id": "classification-problem",
@@ -215,11 +215,11 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 438,
+    "lineCount": 491,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 18,
     "definitionCount": 18,
-    "sorries": 5,
+    "sorries": 4,
     "path": "Proofs/Erdos633Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos633Aristotle.lean"
@@ -261,5 +261,5 @@
       "description": "Related Erdős problem sharing themes: dissection, geometry"
     }
   ],
-  "sorries": 5
+  "sorries": 4
 }


### PR DESCRIPTION
## Summary

Continues the Erdős #633 (square-only triangle dissections, OPEN, \$25) formalization. The prior session proved the *congruent* area+similarity model over-counts (`all_counts_achievable` → `no_square_only_in_model`), but labeled the two `CanDissectIntoSimilar` sorries as "the hard #634 content." **This was a mischaracterization** — `CanDissectIntoSimilar` is *also area-only*, so it over-counts identically. This PR proves that and corrects the record.

## Changes

- **`canDissectIntoSimilar_of_one_le`** (new): `CanDissectIntoSimilar T n` holds for **every** `n ≥ 1`, witnessed by `T.scale(1/√n)` — the similar analogue of the already-verified `all_counts_achievable`.
- **`similar_dissection_characterization`**: sorry **removed** — it follows immediately and vacuously (the `n ∉ {2,3,5}` hypothesis is unused). Documented as a model-artifact, not the real geometric content.
- **`no_exceptional_similar_in_model`** (new): every triangle has counts 2, 3, 5, so `exceptional_similar_cases` is **model-FALSE** (direct refutation, the similar analogue of `no_square_only_in_model`). `exceptional_similar_cases` is retained as a model-false aspirational sorry with corrected docs.

**Sorries 5 → 4.** The model-inadequacy diagnosis is now complete for **both** the congruent and similar predicates. The remaining 4 sorries are genuine geometric statements that are all model-false here, awaiting a faithful tiling predicate (the open, hard core of #633 — not attempted).

File: 491 lines, 18 theorems, **0 axioms**.

## Honesty / scope

- This does **not** make progress on the open mathematical problem. It is a *diagnostic correction*: it rigorously shows the similar-dissection model is inadequate (over-counts), which the prior note had wrongly flagged as hard geometric content.
- **Build-pending**: new proofs mirror the already-verified `all_counts_achievable` rewrite chain and use only standard Mathlib lemmas (`mul_div_mul_left`, `Triangle.area_scale`, `Real.sq_sqrt`) — all confirmed present in pinned Mathlib. The Docker build is blocked by the persistent Mathlib-cache `.ltar` permission-denied error (cached path) / OOM at the ~7.65 GB VM ceiling (from-source path); it never reaches this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)