### PR TITLE
Fix(area-of-circle-oq-01-oq-02): correct stale line count in conclusion

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -152,7 +152,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization proves A(r) = ∫₀ʳ C(ρ) dρ using the Fundamental Theorem of Calculus, answering the open question from the Circumference from Area gallery entry. The proof uses the companion result dA/dr = C(r) as the antiderivative relationship, then applies FTC Part 2. Together with its companion, it establishes the complete integration-differentiation duality for circle geometry. The proof file contains 146 lines, 0 sorries, 0 axioms.",
+    "summary": "This formalization proves A(r) = ∫₀ʳ C(ρ) dρ using the Fundamental Theorem of Calculus, answering the open question from the Circumference from Area gallery entry. The proof uses the companion result dA/dr = C(r) as the antiderivative relationship, then applies FTC Part 2. Together with its companion, it establishes the complete integration-differentiation duality for circle geometry. The proof file contains 141 lines, 0 sorries, 0 axioms.",
     "implications": "**Theoretical Significance**: The integration-differentiation duality $A' = C$ and $A = \\int C$ is not special to circles — it holds for all dimensions.\n\nThe $n$-ball volume $V_n(r) = \\pi^{n/2} r^n / \\Gamma(n/2+1)$ satisfies $V_n' = S_n$ where $S_n$ is surface area, and $V_n(r) = \\int_0^r S_n(\\rho)\\, d\\rho$. This pattern reflects a deep principle in geometric measure theory: the boundary measure is the variation of the volume measure.",
     "openQuestions": [
       "Can the n-dimensional analogue V_n(r) = ∫₀ʳ S_n(ρ) dρ be formalized for all n?",


### PR DESCRIPTION
## Fix

`conclusion.summary` in `meta.json` claimed the proof file contains **146 lines**, but the actual `Proofs/AreaFromCircumferenceIntegral.lean` is **141 lines** (and `leanFile.lineCount` already correctly reports 141).

## Evidence

**Before**: `"The proof file contains 146 lines, 0 sorries, 0 axioms."`
**After**: `"The proof file contains 141 lines, 0 sorries, 0 axioms."`

- `wc -l proofs/Proofs/AreaFromCircumferenceIntegral.lean` → 141
- `meta.json leanFile.lineCount` → 141 (authoritative, unchanged)
- This is the same location a peer reviewer flagged in `review.json` (originally 153→146); it was partially corrected but went stale again after the file shrank to 141.

Metadata-only change; JSON validated. No Lean code touched.

---
Automated fix by lean-mechanic agent.