### PR TITLE
research(erdos-395-oq-02): scope the d=1 boundary of fixed-dimension reverse Littlewood–Offord

### DIFF
--- a/proofs/Proofs/Erdos395OQ02Aristotle.lean
+++ b/proofs/Proofs/Erdos395OQ02Aristotle.lean
@@ -1,0 +1,101 @@
+/-
+  Aristotle targets for Erdős Problem #395 — Open Question oq-02
+  Dimension-one reverse Littlewood–Offord (the lower boundary case).
+
+  See Erdos395OQ02.lean for the main formalization (the orthogonality
+  obstruction and the sharp dichotomy, both verified, 0 axioms).
+
+  ## Why these targets
+
+  The main file records the fixed-dimension question
+
+      ReverseLO_fixedDim d :  ∃ C c > 0, ∀ m > 0, ∀ unit z : Fin m → ℝ^d,
+                                P(‖Σ εᵢ zᵢ‖ ≤ C) ≥ c/m
+
+  as an *unproven* Prop.  Its two boundary dimensions are in fact settled:
+  `d = 2` is the parent theorem (HJNS 2024, unit complex vectors), and `d = 1`
+  is the classical one-dimensional reverse Littlewood–Offord, which is
+  elementary.  These targets formalize the `d = 1` case so that, once proved,
+  the genuinely open question is pinned to `d ≥ 3`.
+
+  ## The d = 1 argument
+
+  In `EuclideanSpace ℝ (Fin 1)` a unit vector has its single coordinate equal to
+  `±1`, so `‖Σ εᵢ zᵢ‖ = |Σ εᵢ (zᵢ)₀|` is the absolute value of an ordinary `±1`
+  walk of length `m`.  The favourable event `|Σ ±1| ≤ 1` is realized by at least
+  the central-binomial number `C(m, ⌊m/2⌋)` of the `2ᵐ` sign patterns:
+  the map sending a `⌊m/2⌋`-subset `S ⊆ Fin m` to the pattern whose `i`-th signed
+  term is `+1` for `i ∈ S` and `-1` otherwise is injective and lands in the
+  favourable set (its signed sum is `2⌊m/2⌋ - m ∈ {0,-1}`, of absolute value
+  `≤ 1`).  Since `C(m, ⌊m/2⌋)` is the largest of the `m+1` binomial coefficients
+  summing to `2ᵐ`, we get `C(m, ⌊m/2⌋) ≥ 2ᵐ/(m+1)`, hence
+
+      P(‖Σ εᵢ zᵢ‖ ≤ 1) ≥ C(m, ⌊m/2⌋)/2ᵐ ≥ 1/(m+1) ≥ (1/2)/m,
+
+  so `ReverseLO_fixedDim 1` holds with threshold `C = 1` and constant `c = 1/2`.
+
+  Criteria for inclusion (per research/SORRY-CLASSIFICATION.md):
+  - NOT the main open conjecture (that is `ReverseLO_fixedDim d` for `d ≥ 3`).
+  - Known / classical results, each a clean theorem with no definition sorries.
+  - No axioms.
+-/
+import Mathlib
+
+namespace Erdos395OQ02Aristotle
+
+/-- Boolean encoding of a sign (`true ↦ +1`, `false ↦ -1`). -/
+def toSign (b : Bool) : ℝ := if b then 1 else -1
+
+/-- The signed sum `Σ εᵢ zᵢ` for a Boolean sign pattern, in dimension one. -/
+def signedSum {m : ℕ} (z : Fin m → EuclideanSpace ℝ (Fin 1)) (s : Fin m → Bool) :
+    EuclideanSpace ℝ (Fin 1) :=
+  ∑ i, toSign (s i) • z i
+
+/-- Number of sign patterns whose signed sum has norm `≤ C`. -/
+noncomputable def smallSumCount {m : ℕ} (z : Fin m → EuclideanSpace ℝ (Fin 1))
+    (C : ℝ) : ℕ :=
+  (Finset.univ.filter (fun s : Fin m → Bool => ‖signedSum z s‖ ≤ C)).card
+
+/-- **Target 1 (routine).** Central-binomial bound: the middle coefficient is the
+largest of the `m+1` terms summing to `2ᵐ`, so `2ᵐ ≤ (m+1)·C(m, ⌊m/2⌋)`.
+Provable from `Nat.sum_range_choose` and `Nat.choose_le_middle`. -/
+theorem two_pow_le_succ_mul_choose_half (m : ℕ) :
+    2 ^ m ≤ (m + 1) * Nat.choose m (m / 2) := by
+  sorry
+
+/-- **Target 2 (routine).** In dimension one, a unit vector's single coordinate
+is `±1`.  Provable from `EuclideanSpace.norm_eq` / `Real.sqrt_sq_eq_abs` and
+`abs_eq`. -/
+theorem coord_eq_one_or {m : ℕ} (z : Fin m → EuclideanSpace ℝ (Fin 1)) (i : Fin m)
+    (h : ‖z i‖ = 1) : z i 0 = 1 ∨ z i 0 = -1 := by
+  sorry
+
+/-- **Target 3 (routine).** In dimension one, the norm of a signed sum is the
+absolute value of the ordinary scalar signed sum of the coordinates.  Provable
+from `EuclideanSpace.norm_eq`, `Fin.sum_univ_one`, and `Finset.sum_apply`. -/
+theorem norm_signedSum_dim_one {m : ℕ} (z : Fin m → EuclideanSpace ℝ (Fin 1))
+    (s : Fin m → Bool) :
+    ‖signedSum z s‖ = |∑ i, toSign (s i) * z i 0| := by
+  sorry
+
+/-- **Target 4 (the combinatorial core).** At least `C(m, ⌊m/2⌋)` of the `2ᵐ`
+sign patterns give a signed sum of norm `≤ 1`.  Proof: the injection sending a
+`⌊m/2⌋`-subset `S` to the pattern making the `i`-th signed term `+1` on `S` and
+`-1` off `S` lands in the favourable set (signed sum `2⌊m/2⌋ - m ∈ {0,-1}`), so
+`Finset.card_le_card_of_injOn` with `Finset.card_powersetCard` gives the bound. -/
+theorem choose_le_smallSumCount_dim_one {m : ℕ}
+    (z : Fin m → EuclideanSpace ℝ (Fin 1)) (hz : ∀ i, ‖z i‖ = 1) :
+    Nat.choose m (m / 2) ≤ smallSumCount z 1 := by
+  sorry
+
+/-- **Target 5 (assembly).** The fixed-dimension reverse Littlewood–Offord
+question is TRUE for `d = 1`: with threshold `C = 1` and constant `c = 1/2`,
+every one-dimensional unit configuration satisfies `P(‖Σ εᵢ zᵢ‖ ≤ 1) ≥ (1/2)/m`.
+Assembled from Targets 1 and 4 by real arithmetic. -/
+theorem reverseLO_dim_one :
+    ∃ C c : ℝ, 0 < c ∧
+      ∀ m : ℕ, 0 < m → ∀ z : Fin m → EuclideanSpace ℝ (Fin 1),
+        (∀ i, ‖z i‖ = 1) → c / (m : ℝ) ≤ (smallSumCount z C : ℝ) / (2 : ℝ) ^ m := by
+  sorry
+
+end Erdos395OQ02Aristotle

--- a/research/problems/erdos-395-oq-02/state.md
+++ b/research/problems/erdos-395-oq-02/state.md
@@ -1,14 +1,60 @@
 # Current State
 
-**Phase**: FORMALIZED (obstruction + sharp converse proved; fixed-dimension question remains open)
+**Phase**: FORMALIZED (obstruction + sharp converse verified; d=1 boundary scoped, d≥3 open)
 **Since**: 2026-06-26
-**Iteration**: 2
+**Iteration**: 3
 
-## Current Focus
+## Current Focus (iteration 3)
 
-Extended `proofs/Proofs/Erdos395OQ02.lean` (now 309 lines, 14 theorems, 7 defs,
-0 sorries, 0 axioms) with the **complementary saturation direction**, closing the
-characterization of the orthonormal case into a sharp 0/1 dichotomy.
+Scoped the *lower boundary* of the open `ReverseLO_fixedDim` Prop. The main file
+proves the dimension-free analogue FALSE and pins the orthonormal threshold at
+`C ~ √n`; it left the genuine fixed-dimension question open for **all** d. This
+iteration establishes (on paper, with a complete Lean proof strategy) that the
+`d = 1` case is **TRUE and elementary**, narrowing the genuinely open region to
+`d ≥ 3` (since `d = 2` is the parent HJNS 2024 result).
+
+### The d=1 reduction (complete mathematical argument)
+
+In `EuclideanSpace ℝ (Fin 1)` a unit vector's single coordinate is `±1`, so
+`‖Σ εᵢ zᵢ‖ = |Σ εᵢ (zᵢ)₀|` is the absolute value of an ordinary `±1` walk.
+The favourable event `|Σ ±1| ≤ 1` is hit by at least `C(m, ⌊m/2⌋)` of the `2ᵐ`
+sign patterns: map a `⌊m/2⌋`-subset `S ⊆ Fin m` to the pattern whose i-th signed
+term is `+1` on `S`, `-1` off `S` — injective, signed sum `= 2⌊m/2⌋ - m ∈ {0,-1}`,
+norm `≤ 1`. Since the middle binomial is the max of `m+1` terms summing to `2ᵐ`,
+`C(m,⌊m/2⌋) ≥ 2ᵐ/(m+1)`, giving
+`P ≥ C(m,⌊m/2⌋)/2ᵐ ≥ 1/(m+1) ≥ (1/2)/m`. Hence `ReverseLO_fixedDim 1` holds with
+`C = 1, c = 1/2`. Key Mathlib lemmas verified present: `Nat.sum_range_choose`,
+`Nat.choose_le_middle`, `Finset.card_powersetCard`, `EuclideanSpace.norm_eq`,
+`Real.sqrt_sq_eq_abs`, `Finset.card_le_card_of_injOn`.
+
+### Artifact
+
+`proofs/Proofs/Erdos395OQ02Aristotle.lean` — companion target file with the five
+proof obligations (binomial bound; coordinate=±1; norm reduction; the counting
+core; the assembly). Self-contained, no axioms. Ready for Aristotle once the
+service returns.
+
+### Verification status (HONEST)
+
+NOT verified this session. Both verification paths were unavailable:
+- **Docker build**: container has no Mathlib cache, rebuilds from scratch →
+  OOM/timeout (persistent infra blocker, see prior iterations).
+- **Aristotle MCP**: every call (`prove`, `prove_file`) returned
+  `"Resource not found"` (404) — consistent with prior sessions' notes that the
+  MCP intermittently 404s; no CLI installed as fallback.
+
+The main verified file `Erdos395OQ02.lean` was left **untouched** (still 0 sorry,
+0 axiom, status `verified`) — the d=1 work lives only in the companion target to
+avoid regressing the verified entry with unverifiable sorries.
+
+## Active Approach (prior, iteration 2 — verified)
+
+The same deterministic identity `‖Σεᵢzᵢ‖ = √n` drives both directions:
+
+1. **Obstruction (iteration 1)** — `C² < n ⟹` favourable set empty `⟹ P = 0`.
+2. **Saturation (NEW, iteration 2)** — `√n ≤ C ⟹` favourable set is all of
+   `{±1}ⁿ ⟹ P = 1`:
+   - `orthonormal_signedSum_le_of_sqrt_le` — every sign sum is within `C`.
 
 ## Active Approach
 


### PR DESCRIPTION
## Summary

Erdős #395 oq-02 asks whether the reverse Littlewood–Offord `c/n` concentration persists for unit vectors in fixed dimension `d`. The existing **verified** entry (`Erdos395OQ02.lean`, 0 sorry / 0 axiom) proves the *dimension-free* analogue FALSE and records the genuine fixed-dimension question as an open `Prop` (`ReverseLO_fixedDim d`) — left open for **all** `d`.

This PR scopes the **lower boundary**: the `d = 1` case is **TRUE and elementary**, which narrows the genuinely open region to **`d ≥ 3`** (`d = 2` is the parent HJNS 2024 result).

### The d=1 reduction
In `EuclideanSpace ℝ (Fin 1)` a unit vector's single coordinate is `±1`, so `‖Σ εᵢ zᵢ‖ = |Σ εᵢ (zᵢ)₀|` is an ordinary `±1` walk. The favourable event `|Σ ±1| ≤ 1` is hit by at least `C(m, ⌊m/2⌋)` of the `2ᵐ` sign patterns (explicit injection from `⌊m/2⌋`-subsets; signed sum `= 2⌊m/2⌋ - m ∈ {0,-1}`). Since the middle binomial is the max of `m+1` terms summing to `2ᵐ`, `C(m,⌊m/2⌋) ≥ 2ᵐ/(m+1)`, giving `P ≥ 1/(m+1) ≥ (1/2)/m`. So `ReverseLO_fixedDim 1` holds with `C = 1, c = 1/2`.

### Changes
- **`Erdos395OQ02Aristotle.lean` (new)** — self-contained companion target with the five proof obligations (central-binomial bound; coordinate=±1; norm reduction; the counting core; the real-arithmetic assembly). Auto-discoverable by `submit-batch.sh`.
- **`state.md`** — documents the reduction and verification status.

### ⚠️ Verification status (honest)
**NOT verified this session.** Both paths were unavailable:
- Docker build: container has no Mathlib cache → rebuilds from scratch → OOM/timeout.
- Aristotle MCP: every call returned `"Resource not found"` (404); no CLI fallback.

The **verified main file `Erdos395OQ02.lean` is left untouched** (still 0 sorry, 0 axiom, status `verified`). The d=1 work lives only in the companion target so the entry's verified status is **not** regressed. Targets to be discharged by Aristotle / a cache-enabled build in a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)