### PR TITLE
Enrich Zolotarev base-case entry: deepen annotations

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01/annotations.json
@@ -1,34 +1,74 @@
 [
   {
+    "id": "ann-eqr-oq010301-mulperm",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
+    "range": { "startLine": 73, "endLine": 99 },
+    "type": "definition",
+    "title": "The multiplication permutation on the units (ℤ/p)ˣ",
+    "content": "mulPerm a is the bijection x ↦ a·x of the unit group (ℤ/p)ˣ, with inverse x ↦ a⁻¹·x. Bundled as a monoid homomorphism mulPermHom : (ℤ/p)ˣ →* Perm (ℤ/p)ˣ (mulPerm_one, mulPerm_mul), so that sign ∘ mulPermHom is automatically multiplicative in a — the structural fact that powers the whole units-level argument. mulPerm_no_fixed_point records that for a ≠ 1 the map has no fixed point (a·x = x forces a = 1 by right-cancellation in a group), which makes a generator's permutation a single full-length cycle. This Part 0 is re-established from scratch because the grandparent file no longer compiles.",
+    "mathContext": "$\\mathrm{mulPerm}(a)\\colon x \\mapsto a\\cdot x$ on $(\\mathbb{Z}/p)^\\times$, a group homomorphism $(\\mathbb{Z}/p)^\\times \\to \\mathrm{Sym}((\\mathbb{Z}/p)^\\times)$; $a\\neq 1 \\Rightarrow a\\cdot x \\neq x$ for all $x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["group action by left multiplication", "Cayley's theorem", "permutation group", "monoid homomorphism"],
+    "prerequisites": ["group theory", "permutations"]
+  },
+  {
     "id": "ann-eqr-oq010301-bridge",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
-    "range": { "startLine": 122, "endLine": 132 },
+    "range": { "startLine": 119, "endLine": 132 },
     "type": "theorem",
     "title": "The fixed-point sign-restriction bridge (the new content)",
-    "content": "sign_ringMulPerm_eq_sign_mulPerm proves sign(ringMulPerm a) = sign(mulPerm a): the sign of multiplication-by-a on the WHOLE field ℤ/p equals its sign on the units (ℤ/p)ˣ. Because multiplication by a unit fixes 0 and keeps nonzero residues nonzero, Equiv.Perm.sign_subtypePerm restricts the sign to {x // x ≠ 0} without changing it, and the field equivalence unitsEquivNeZero identifies that restriction with mulPerm a (transported by sign_eq_sign_of_equiv). This is exactly the 'fixed-point sign-restriction argument' the parent named as the remaining glue."
+    "content": "sign_ringMulPerm_eq_sign_mulPerm proves sign(ringMulPerm a) = sign(mulPerm a): the sign of multiplication-by-a on the WHOLE field ℤ/p equals its sign on the units (ℤ/p)ˣ. Because multiplication by a unit fixes 0 and keeps nonzero residues nonzero (ringMulPerm_ne_zero_iff, ringMulPerm_fixes_zero), Equiv.Perm.sign_subtypePerm restricts the sign to {x // x ≠ 0} without changing it, and the field equivalence unitsEquivNeZero identifies that restriction with mulPerm a (transported by sign_eq_sign_of_equiv). This is exactly the 'fixed-point sign-restriction argument' the parent named as the remaining glue — and it uses no number theory, only the permutation-theoretic fact that a fixed point contributes nothing to a sign.",
+    "mathContext": "$\\mathrm{sgn}(\\mathrm{ringMulPerm}\\,a) = \\mathrm{sgn}(\\mathrm{mulPerm}\\,a)$ since $0$ is a fixed point and $(\\mathbb{Z}/p)^\\times \\simeq \\{x \\neq 0\\}$; a fixed point splits off as a $1$-cycle and never changes the sign.",
+    "significance": "key",
+    "relatedConcepts": ["permutation sign", "fixed point", "subtype permutation", "units of a field", "sign as a homomorphism"],
+    "prerequisites": ["permutation sign", "field theory", "equivalences of types"]
   },
   {
     "id": "ann-eqr-oq010301-generator-nonsquare",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
-    "range": { "startLine": 184, "endLine": 225 },
+    "range": { "startLine": 181, "endLine": 220 },
     "type": "theorem",
     "title": "A generator of (ℤ/p)ˣ is a non-square",
-    "content": "generator_not_isSquare: if a generator g were u², then orderOf g = orderOf(u²) = orderOf u / gcd(orderOf u, 2), which is strictly smaller than the maximal order p-1 (since p-1 is even). This, together with the single-(p-1)-cycle sign computation, pins both the quadratic character and the permutation sign of a generator to -1 — the base values that drive the whole units-level Zolotarev lemma."
+    "content": "generator_not_isSquare: if a generator g were u², then orderOf g = orderOf(u²) = orderOf u / gcd(orderOf u, 2) (orderOf_pow'), which is strictly smaller than the maximal order p-1 (since p-1 is even). The Lean proof case-splits on gcd(orderOf u, 2) ∈ {1, 2}: gcd = 1 makes orderOf u = p-1 odd, contradicting p-1 even; gcd = 2 makes orderOf u = 2(p-1) > p-1, contradicting orderOf u ∣ p-1. This, together with the single-(p-1)-cycle sign computation sign_mulPerm_generator, pins both the quadratic character and the permutation sign of a generator to -1 — the base values that drive the whole units-level Zolotarev lemma.",
+    "mathContext": "A generator $g$ has $\\mathrm{ord}(g) = p-1$ (maximal); if $g = u^2$ then $\\mathrm{ord}(g) = \\mathrm{ord}(u)/\\gcd(\\mathrm{ord}(u),2) < p-1$ since $p-1$ is even — contradiction. Hence $g$ is a quadratic non-residue.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic group", "primitive root", "quadratic residue", "order of an element", "quadratic non-residue"],
+    "prerequisites": ["cyclic groups", "order arithmetic", "elementary number theory"]
+  },
+  {
+    "id": "ann-eqr-oq010301-units-zolotarev",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
+    "range": { "startLine": 222, "endLine": 252 },
+    "type": "theorem",
+    "title": "Zolotarev's lemma on the units (re-established self-contained)",
+    "content": "sign_mulPerm_eq_quadraticChar is the heart of Part II: for an odd prime p, sign(mulPerm a) = quadraticChar (ℤ/p) a for every unit a. The argument is the classic 'evaluate two multiplicative characters at a generator'. Both a ↦ sign(mulPerm a) (a homomorphism (ℤ/p)ˣ → ℤˣ via mulPermHom) and the quadratic character are multiplicative; on a generator g both equal -1 (sign_mulPerm_generator: a single (p-1)-cycle with p-1 even has sign -1; generator_not_isSquare: g is a non-square so quadraticChar g = -1). Writing an arbitrary unit as a = gⁿ, both characters become (-1)ⁿ and therefore agree everywhere. legendreSym_unit_eq then records the definitional identity legendreSym p a = quadraticChar (ℤ/p) a up to a val-cast round-trip.",
+    "mathContext": "$\\mathrm{sgn}(\\mathrm{mulPerm}\\,a) = \\chi(a)$ for the quadratic character $\\chi$: both are homomorphisms $(\\mathbb{Z}/p)^\\times \\to \\{\\pm 1\\}$ agreeing on a generator ($-1$), hence on $a = g^n \\mapsto (-1)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Zolotarev's lemma", "quadratic character", "Legendre symbol", "characters of cyclic groups", "multiplicativity"],
+    "prerequisites": ["cyclic groups", "quadratic residues", "permutation sign", "group homomorphisms"]
   },
   {
     "id": "ann-eqr-oq010301-basecase",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
-    "range": { "startLine": 262, "endLine": 266 },
+    "range": { "startLine": 259, "endLine": 270 },
     "type": "theorem",
     "title": "The base case: sign(ringMulPerm a on ℤ/p) = legendreSym p a",
-    "content": "sign_ringMulPerm_eq_legendre chains the fixed-point bridge, the self-contained units-level Zolotarev lemma (sign_mulPerm_eq_quadraticChar), and the definitional bridge legendreSym = quadraticChar. This is the exact base case the parent (oq-01-oq-03) listed as its next step, now proved unconditionally and axiom-free for p ≠ 2."
+    "content": "sign_ringMulPerm_eq_legendre chains the fixed-point bridge (Part I), the self-contained units-level Zolotarev lemma sign_mulPerm_eq_quadraticChar (Part II), and the definitional bridge legendreSym = quadraticChar (legendreSym_unit_eq). This is the exact base case the parent (oq-01-oq-03) listed as its next step, now proved unconditionally and axiom-free for p ≠ 2. legendre_eq_sign_ringMulPerm states the reversed orientation matching the grandparent's zolotarev_lemma framing.",
+    "mathContext": "$\\mathrm{sgn}(x \\mapsto a x \\text{ on } \\mathbb{Z}/p) = \\left(\\tfrac{a}{p}\\right)$ — Zolotarev's identity, now on the whole field rather than just the units.",
+    "significance": "key",
+    "relatedConcepts": ["Zolotarev's lemma", "Legendre symbol", "quadratic reciprocity", "permutation sign"],
+    "prerequisites": ["quadratic residues", "permutation sign", "finite fields"]
   },
   {
     "id": "ann-eqr-oq010301-loopclose",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01",
-    "range": { "startLine": 283, "endLine": 297 },
+    "range": { "startLine": 277, "endLine": 296 },
     "type": "theorem",
     "title": "Closing the loop: Jacobi value on ℤ/pq",
-    "content": "sign_ringMulPerm_eq_legendre_mul combines the base case with the parent's CRT multiplicativity (ZolotarevCRT.sign_ringMulPerm_mul_of_odd): for distinct odd primes p, q the whole-ring permutation sign on ℤ/pq is the product of the Legendre symbols of the two CRT components — the two-factor Jacobi value. The general squarefree case follows by iterating over the factorization."
+    "content": "sign_ringMulPerm_eq_legendre_mul combines the base case with the parent's CRT multiplicativity (ZolotarevCRT.sign_ringMulPerm_mul_of_odd): for distinct odd primes p, q the whole-ring permutation sign on ℤ/pq is the product of the Legendre symbols of the two CRT components a₁, a₂ — the two-factor Jacobi value (a/pq) = (a/p)(a/q). The Chinese Remainder Theorem (ZMod.chineseRemainder) splits the unit a ∈ (ℤ/pq)ˣ into its components, the parent supplies the product structure, and the base case anchors each factor to a Legendre value. The general squarefree case follows by iterating over the factorization — a routine induction adding no new idea.",
+    "mathContext": "$\\mathrm{sgn}(\\mathrm{ringMulPerm}\\,a \\text{ on } \\mathbb{Z}/pq) = \\left(\\tfrac{a_1}{p}\\right)\\left(\\tfrac{a_2}{q}\\right) = \\left(\\tfrac{a}{pq}\\right)$, the Jacobi symbol, via CRT $\\mathbb{Z}/pq \\cong \\mathbb{Z}/p \\times \\mathbb{Z}/q$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi symbol", "Chinese Remainder Theorem", "Frobenius generalization", "multiplicativity of the Jacobi symbol"],
+    "prerequisites": ["Chinese Remainder Theorem", "Jacobi symbol", "quadratic residues"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01` (quality 65, passes 0).

The meta.json was already excellent (full overview/historicalContext/proofStrategy/keyInsights, sections, conclusion, references, crossReferences). The gap was the annotations file (2.8 KB, content-only).

**Changes (annotations.json, 2.8 → 8.5 KB, 4 → 6 annotations):**
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to every annotation — previously all four were bare `content`-only entries.
- Added 2 annotations covering previously-unannotated key sections:
  - **Part 0** — the units multiplication permutation `mulPerm`/`mulPermHom` and `mulPerm_no_fixed_point` (the homomorphism that makes the sign multiplicative).
  - **Part II core** — the self-contained units-level Zolotarev lemma `sign_mulPerm_eq_quadraticChar` (evaluate two multiplicative characters at a generator).

No meta/claim/status changes. All annotation line ranges validated against the Lean source — `pnpm annotations:build` reports **zero** errors for this id, and `gallery:check-size` passes (meta 11.8 KB, well under the 60 KB cap).