### PR TITLE
Enrich Hurwitz universal square-identities entry: annotation depth + crossRef fix

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/annotations.json
@@ -8,18 +8,26 @@
     },
     "type": "concept",
     "title": "The Norm and the Four Multiplication Tables",
-    "content": "Over a generic `CommRing R`, `normSq v = ∑ i, (v i)^2` is the squared norm of an n-vector. The four bilinear products oneMul, twoMul, fourMul, eightMul are exactly the multiplication tables of the real numbers ℝ (n=1), the complex numbers ℂ (n=2), the quaternions ℍ (n=4), and the octonions 𝕆 (n=8). Crucially, every coefficient in these tables is ±1, an integer — so the products, and the identities they satisfy, are formal expressions valid over any commutative ring, with no appeal to ℝ or to a division-algebra structure."
+    "content": "Over a generic `CommRing R`, `normSq v = ∑ i, (v i)^2` is the squared norm of an n-vector. The four bilinear products oneMul, twoMul, fourMul, eightMul are exactly the multiplication tables of the real numbers ℝ (n=1), the complex numbers ℂ (n=2), the quaternions ℍ (n=4), and the octonions 𝕆 (n=8). Crucially, every coefficient in these tables is ±1, an integer — so the products, and the identities they satisfy, are formal expressions valid over any commutative ring, with no appeal to ℝ or to a division-algebra structure.",
+    "mathContext": "$\\mathrm{normSq}(v) = \\sum_{i} v_i^2$; the products realise $|ab|^2 = |a|^2|b|^2$ for $\\mathbb{R},\\mathbb{C},\\mathbb{H},\\mathbb{O}$ at $n=1,2,4,8$, e.g. $n=2$: $(a_0b_0-a_1b_1,\\ a_0b_1+a_1b_0)$, the complex product.",
+    "significance": "key",
+    "relatedConcepts": ["composition algebra", "normed division algebra", "quaternions", "octonions", "Cayley–Dickson construction"],
+    "prerequisites": ["commutative rings", "bilinear forms", "finite-dimensional algebras"]
   },
   {
     "id": "ann-universal-identities",
     "proofId": "hurwitz-theorem-oq-03-incomplete-01",
     "range": {
-      "startLine": 85,
+      "startLine": 80,
       "endLine": 116
     },
-    "type": "proof-technique",
+    "type": "technique",
     "title": "One `ring` Call per Identity",
-    "content": "Each identity normSq a * normSq b = normSq (nMul a b) is proved by expanding the finite sum (Fin.sum_univ_two / four, or a helper for Fin 8) and the matrix literals (Matrix.cons_val_*), then invoking `ring`. Because `ring` is a decision procedure for commutative-ring equalities, a successful call is a complete machine-checked proof — and it certifies the (sign-sensitive) Degen 8-square identity just as readily as the simpler n=2 case. The n=8 expansion has hundreds of monomials on each side, so it needs a raised `maxHeartbeats`, but it remains a single decision-procedure call with no case analysis."
+    "content": "Each identity normSq a * normSq b = normSq (nMul a b) is proved by expanding the finite sum (Fin.sum_univ_two / four, or the sum_fin_eight helper for Fin 8) and the matrix literals (Matrix.cons_val_*), then invoking `ring`. Because `ring` is a decision procedure for commutative-ring equalities, a successful call is a complete machine-checked proof — and it certifies the (sign-sensitive) Degen 8-square identity just as readily as the simpler n=2 case. The n=8 expansion has hundreds of monomials on each side, so it needs a raised `maxHeartbeats` (32000000), but it remains a single decision-procedure call with no case analysis.",
+    "mathContext": "$\\left(\\sum_i x_i^2\\right)\\left(\\sum_i y_i^2\\right) = \\sum_i z_i^2$ with each $z_i$ bilinear and integer-coefficiented; a polynomial identity in $\\mathbb{Z}[x,y]$, so `ring` decides it over any $\\mathrm{CommRing}$.",
+    "significance": "key",
+    "relatedConcepts": ["ring normalization", "decision procedure", "polynomial identities", "Degen's eight-square identity", "Euler's four-square identity"],
+    "prerequisites": ["Lean ring tactic", "polynomial identities over commutative rings"]
   },
   {
     "id": "ann-closure",
@@ -28,9 +36,13 @@
       "startLine": 117,
       "endLine": 163
     },
-    "type": "key-insight",
+    "type": "insight",
     "title": "Norm-Multiplicativity = Closure of Sums of Squares",
-    "content": "Define `IsSumOfSquares n r := ∃ v : Fin n → R, normSq v = r`. The identity normSq a * normSq b = normSq (nMul a b) says precisely that if x and y are each sums of n squares then so is x·y — the witness for the product is nMul of the two witnesses. This gives isSumOfSquares_two_mul / four_mul / eight_mul in any commutative ring. The set also always contains 0 (the zero vector) and 1 (a standard basis vector), so for n ∈ {1,2,4,8} the sums of n squares form a multiplicative submonoid of R."
+    "content": "Define `IsSumOfSquares n r := ∃ v : Fin n → R, normSq v = r`. The identity normSq a * normSq b = normSq (nMul a b) says precisely that if x and y are each sums of n squares then so is x·y — the witness for the product is nMul of the two witnesses (isSumOfSquares_two_mul / four_mul / eight_mul). The set also always contains 0 (the zero vector, isSumOfSquares_zero) and 1 (a standard basis vector via Pi.single, isSumOfSquares_one), so for n ∈ {1,2,4,8} the sums of n squares form a multiplicative submonoid of R.",
+    "mathContext": "$S_n = \\{\\,r : \\exists v\\in R^n,\\ \\textstyle\\sum v_i^2 = r\\,\\}$ is a submonoid of $(R,\\cdot)$ for $n\\in\\{1,2,4,8\\}$: $0,1\\in S_n$ and $x,y\\in S_n \\Rightarrow xy\\in S_n$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative closure", "submonoid", "sums of squares", "norm form"],
+    "prerequisites": ["monoids", "existential witnesses", "sums of squares"]
   },
   {
     "id": "ann-integers",
@@ -41,6 +53,10 @@
     },
     "type": "concept",
     "title": "The Classical Arithmetic Corollary over ℤ",
-    "content": "Specialising R := ℤ recovers the elementary multiplicative steps behind two classical theorems: int_sumTwoSq_mul (a product of two sums of two squares is a sum of two squares — the Brahmagupta–Fibonacci step in Fermat's two-square theorem) and int_sumFourSq_mul (the Euler step that reduces Lagrange's four-square theorem to primes). The worked witnesses 3 = 1²+1²+1²+0² and 5 = 2²+1²+0²+0² combine through Euler's identity to exhibit 15 = 3·5 as a sum of four squares — a concrete instance of the abstract closure lemma."
+    "content": "Specialising R := ℤ recovers the elementary multiplicative steps behind two classical theorems: int_sumTwoSq_mul (a product of two sums of two squares is a sum of two squares — the Brahmagupta–Fibonacci step in Fermat's two-square theorem) and int_sumFourSq_mul (the Euler step that reduces Lagrange's four-square theorem to primes). The worked witnesses 3 = 1²+1²+1²+0² and 5 = 2²+1²+0²+0² combine through Euler's identity to exhibit 15 = 3·5 as a sum of four squares — a concrete instance of the abstract closure lemma.",
+    "mathContext": "Over $\\mathbb{Z}$: $(a^2+b^2)(c^2+d^2)$ is a sum of two squares; $3=1^2+1^2+1^2+0^2$, $5=2^2+1^2+0^2+0^2$, so $15$ is a sum of four squares — the 'easy' multiplicative direction of Lagrange / Fermat.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange's four-square theorem", "Fermat's two-square theorem", "Brahmagupta–Fibonacci identity", "multiplicativity of norms"],
+    "prerequisites": ["elementary number theory", "sums of squares over ℤ"]
   }
 ]

--- a/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03-incomplete-01/meta.json
@@ -123,8 +123,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "hurwitz-theorem-oq-03",
-      "relevance": "Parent entry: formalizes the existence direction over ℝ (n=4 via Mathlib quaternions) and leaves the impossibility direction for n ∉ {1,2,4,8} as a sorry. This entry generalises the existence direction to all commutative rings and extracts the arithmetic consequence."
+      "targetId": "hurwitz-theorem-oq-03",
+      "relationship": "generalizes",
+      "description": "Parent entry: formalizes the existence direction over ℝ (n=4 via Mathlib quaternions) and leaves the impossibility direction for n ∉ {1,2,4,8} as a sorry. This entry generalises the existence direction to all commutative rings and extracts the arithmetic consequence."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `hurwitz-theorem-oq-03-incomplete-01` (quality 63, passes 0). The entry's Lean file is fully verified (0 sorries / 0 axioms; `status: verified` accurate — the 'incomplete' slug refers to covering only the *existence* direction of Hurwitz's theorem, not to any sorry).

**Changes:**
- **annotations.json** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 annotations (previously bare `content`-only).
- **Type/alignment fixes** — `proof-technique` → `technique`, `key-insight` → `insight` (both invalid for the annotated constructs); realigned `ann-universal-identities` `startLine` 85 → 80 (line 85 was blank — no Lean construct). Resolver now reports **4/4 aligned** (was 3/4); `annotations:build` clean for this id.
- **meta.json crossReference** — converted the dead `slug`/`relevance` schema to `targetId`/`relationship`/`description`. `ProofConclusion.tsx` reads `proofId ?? targetId` and `description ?? relationship`, so the old keys rendered **nothing**; the parent link to `hurwitz-theorem-oq-03` now displays.

Validated: JSON parses, `gallery:check-size` passes (meta 11.7 KB < 60 KB cap), resolver 4/4, annotations:build 0 errors for this id.