### PR TITLE
Enrich Erdős #396 sharp Catalan asymptotic: annotation depth

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -9,7 +9,10 @@
     "type": "key-step",
     "title": "The square-root-free bridge (reused engine)",
     "content": "For $n \\ge 1$, $C(2n,n)^2\\,n/16^n = \\operatorname{stirlingSeq}(2n)^2/\\operatorname{stirlingSeq}(n)^4$. Squaring the target turns $(\\sqrt{4n})^2 = 4n$ and $(\\sqrt{2n})^4 = (2n)^2$, so no square root survives and the identity is a rational function closed by $\\texttt{field\\_simp}$. This reproves the central-binomial engine self-contained from Mathlib's Stirling limit.",
-    "mathContext": "$\\dfrac{C(2n,n)^2\\,n}{16^n} = \\dfrac{\\operatorname{stirlingSeq}(2n)^2}{\\operatorname{stirlingSeq}(n)^4},\\qquad \\operatorname{stirlingSeq}(n) = \\dfrac{n!}{\\sqrt{2n}\\,(n/e)^n}.$"
+    "mathContext": "$\\dfrac{C(2n,n)^2\\,n}{16^n} = \\dfrac{\\operatorname{stirlingSeq}(2n)^2}{\\operatorname{stirlingSeq}(n)^4},\\qquad \\operatorname{stirlingSeq}(n) = \\dfrac{n!}{\\sqrt{2n}\\,(n/e)^n}.$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "Stirling's approximation", "stirlingSeq", "rational-function normalization", "field_simp"],
+    "prerequisites": ["real analysis", "Stirling's formula", "limits of sequences"]
   },
   {
     "id": "ann-e396-catsharp-cblimit",
@@ -21,7 +24,10 @@
     "type": "key-step",
     "title": "The central-binomial Wallis limit",
     "content": "Composing $\\texttt{tendsto\\_stirlingSeq\\_sqrt\\_pi}$ with $n \\mapsto 2n$ and applying $\\texttt{Tendsto.pow}$/$\\texttt{Tendsto.div}$ sends the bridge's right side to $\\pi/\\pi^2 = 1/\\pi$. Transferring across the bridge gives $(C(2n,n)\\sqrt n/4^n)^2 \\to 1/\\pi$, and a final $\\texttt{Filter.Tendsto.sqrt}$ (the sequence is non-negative) yields the Wallis constant $1/\\sqrt\\pi$.",
-    "mathContext": "$\\dfrac{C(2n,n)\\,\\sqrt n}{4^n} \\longrightarrow \\dfrac{1}{\\sqrt\\pi}.$"
+    "mathContext": "$\\dfrac{C(2n,n)\\,\\sqrt n}{4^n} \\longrightarrow \\dfrac{1}{\\sqrt\\pi}.$",
+    "significance": "key",
+    "relatedConcepts": ["Wallis product", "central binomial coefficient", "convergence of sequences", "filters and Tendsto", "the constant π"],
+    "prerequisites": ["real analysis", "filters and limits", "continuity of √"]
   },
   {
     "id": "ann-e396-catsharp-weight",
@@ -33,7 +39,10 @@
     "type": "key-step",
     "title": "The Catalan weight n/(n+1) → 1",
     "content": "The only gap between the central binomial and the Catalan normalisation is the factor $n/(n+1)$ from $(n+1)\\,C_n = C(2n,n)$. Writing $n/(n+1) = 1 - 1/(n+1)$ and using $\\texttt{tendsto\\_one\\_div\\_add\\_atTop\\_nhds\\_zero\\_nat}$ gives $n/(n+1) \\to 1$ — a bounded reweighting that shifts the exponent $1/2 \\mapsto 3/2$ but contributes nothing to the limiting constant.",
-    "mathContext": "$\\dfrac{n}{n+1} = 1 - \\dfrac{1}{n+1} \\longrightarrow 1.$"
+    "mathContext": "$\\dfrac{n}{n+1} = 1 - \\dfrac{1}{n+1} \\longrightarrow 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "limits of rational sequences", "telescoping reweighting"],
+    "prerequisites": ["sequences and limits", "elementary algebra"]
   },
   {
     "id": "ann-e396-catsharp-main",
@@ -45,6 +54,9 @@
     "type": "key-step",
     "title": "The sharp Catalan asymptotic Cₙ ∼ 4ⁿ/(√π·n^{3/2})",
     "content": "Multiplying the two limits ($\\texttt{Tendsto.mul}$) gives $1/\\sqrt\\pi \\cdot 1 = 1/\\sqrt\\pi$. The exact factorisation $C_n\\,(n\\sqrt n)/4^n = (C(2n,n)\\sqrt n/4^n)\\cdot(n/(n+1))$ — verified on $n \\ge 1$ by rewriting $C(2n,n) = (n+1)C_n$ ($\\texttt{exact\\_mod\\_cast succ\\_mul\\_catalan\\_eq\\_centralBinom}$) and $\\texttt{field\\_simp}$ — identifies the product with the target. The extra factor of $n$ over the central binomial's $\\sqrt n$ is the square-root-free spelling $n\\sqrt n = n^{3/2}$.",
-    "mathContext": "$C_n\\,\\dfrac{n\\sqrt n}{4^n} = \\dfrac{C(2n,n)\\sqrt n}{4^n}\\cdot\\dfrac{n}{n+1} \\longrightarrow \\dfrac{1}{\\sqrt\\pi},\\qquad C_n \\sim \\dfrac{4^n}{\\sqrt\\pi\\,n^{3/2}}.$"
+    "mathContext": "$C_n\\,\\dfrac{n\\sqrt n}{4^n} = \\dfrac{C(2n,n)\\sqrt n}{4^n}\\cdot\\dfrac{n}{n+1} \\longrightarrow \\dfrac{1}{\\sqrt\\pi},\\qquad C_n \\sim \\dfrac{4^n}{\\sqrt\\pi\\,n^{3/2}}.$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "asymptotic analysis", "Stirling's approximation", "central binomial coefficient", "Wallis product"],
+    "prerequisites": ["real analysis", "asymptotic analysis", "Catalan numbers"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01-oq-01` (quality 65, passes 0). Verified entry (0 sorries / 0 axioms) proving the sharp Catalan asymptotic $C_n \sim 4^n/(\sqrt\pi\,n^{3/2})$ via Stirling/Wallis.

The meta.json and crossReferences were already in good shape; the gap was annotation depth.

**Change (annotations.json):** added `significance`, `relatedConcepts`, and `prerequisites` to all 4 `key-step` annotations (they previously carried `content` + `mathContext` only). No content/range/type changes.

Validated: JSON parses, resolver 4/4 aligned, `gallery:check-size` passes, `annotations:build` clean for this id.