### PR TITLE
audit: persist 2 clean gallery audits (break phantom re-queue)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24810,6 +24810,18 @@
       "lastAudited": "2026-06-27T01:23:00Z",
       "result": "clean",
       "issues": []
+    },
+    "cramers-rule-oq-04-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T01:35:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-02-oq-01-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T01:35:14Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit Persistence

Two newly-merged gallery entries were audited **CLEAN** this iteration. Persisting their audit results to `main` so they stop re-queueing every 20 minutes (local completes are wiped by `git reset --hard origin/main` at the start of each auditor cycle — the documented phantom re-queue mechanism, same fix pattern as #30433).

## Verified Clean

| Slug | Lean source | meta | Tier / badge |
|------|-------------|------|--------------|
| `cramers-rule-oq-04-oq-01-oq-01-oq-01` | 158L, 0 sorry, 0 axiom, 10 thm, 0 def, no native_decide | all match | B / `mathlib` (specializes Mathlib `det_fin_two`/`det_fin_three`) |
| `angle-trisection-oq-02-oq-01-oq-02-oq-02` | 213L, 0 sorry, 0 axiom, 16 thm, 3 def, no native_decide/decide | all match | `verified` |

Both metas are honest: counts match the Lean files exactly, status/badge appropriate, no True stubs, no axiom masking, no Mathlib-wrapper overclaim.

---
Discovered during gallery integrity audit.