### PR TITLE
Enrich degree-2 Fibonacci–Lucas relations: annotation depth

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 4, "endLine": 47 },
     "type": "concept",
     "title": "Completing the Degree-2 Fibonacci–Lucas Trio",
-    "content": "The parent proved the sign-carrying difference Lₙ² − 5Fₙ² = 4(−1)ⁿ. This entry adds its two companions — the sum-of-squares identity Lₙ² + 5Fₙ² = 2L₂ₙ and the cross identity Lₙ·Fₙ = F₂ₙ — to complete the classical trio of quadratic relations between the Fibonacci and Lucas sequences. The three are the P = 1, Q = −1, D = 5 case of the general Lucas-sequence relations Vₙ² − D·Uₙ² = 4Qⁿ. Mathlib has no Lucas sequence, so the parent defines `lucas` from scratch and this file works over ℤ throughout."
+    "content": "The parent proved the sign-carrying difference Lₙ² − 5Fₙ² = 4(−1)ⁿ. This entry adds its two companions — the sum-of-squares identity Lₙ² + 5Fₙ² = 2L₂ₙ and the cross identity Lₙ·Fₙ = F₂ₙ — to complete the classical trio of quadratic relations between the Fibonacci and Lucas sequences. The three are the P = 1, Q = −1, D = 5 case of the general Lucas-sequence relations Vₙ² − D·Uₙ² = 4Qⁿ. Mathlib has no Lucas sequence, so the parent defines `lucas` from scratch and this file works over ℤ throughout.",
+    "mathContext": "$L_n^2 + 5F_n^2 = 2L_{2n}$ and $L_n F_n = F_{2n}$, completing the trio alongside the parent's $L_n^2 - 5F_n^2 = 4(-1)^n$; the $P{=}1, Q{=}{-}1, D{=}5$ case of $V_n^2 - D\\,U_n^2 = 4Q^n$.",
+    "significance": "context",
+    "relatedConcepts": ["Lucas sequences", "Fibonacci numbers", "Lucas numbers", "quadratic identities", "Pell-type relations"],
+    "prerequisites": ["Fibonacci and Lucas sequences", "elementary number theory"]
   },
   {
     "id": "fib-lucas-deg2-doubling-cast",
@@ -13,7 +17,11 @@
     "range": { "startLine": 53, "endLine": 62 },
     "type": "technique",
     "title": "Lifting Truncated ℕ Subtraction to ℤ",
-    "content": "Mathlib's Nat.fib_two_mul reads F₂ₙ = Fₙ·(2Fₙ₊₁ − Fₙ), but its subtraction is truncated ℕ subtraction. To use it inside an integer ring computation, fib_two_mul_int discharges the side condition Fₙ ≤ 2Fₙ₊₁ — itself from Fₙ ≤ Fₙ₊₁ (fib_mono) — and applies `zify [hle]` so the subtraction becomes honest integer subtraction. This cast is the only non-algebraic step in the whole file."
+    "content": "Mathlib's Nat.fib_two_mul reads F₂ₙ = Fₙ·(2Fₙ₊₁ − Fₙ), but its subtraction is truncated ℕ subtraction. To use it inside an integer ring computation, fib_two_mul_int discharges the side condition Fₙ ≤ 2Fₙ₊₁ — itself from Fₙ ≤ Fₙ₊₁ (fib_mono) — and applies `zify [hle]` so the subtraction becomes honest integer subtraction. This cast is the only non-algebraic step in the whole file.",
+    "mathContext": "$F_{2n} = F_n(2F_{n+1} - F_n)$ over $\\mathbb{Z}$; valid because $F_n \\le 2F_{n+1}$, so the truncated $\\mathbb{N}$ subtraction agrees with $\\mathbb{Z}$ subtraction under `zify`.",
+    "significance": "supporting",
+    "relatedConcepts": ["truncated natural subtraction", "zify tactic", "Fibonacci doubling identity", "monotonicity of Fibonacci"],
+    "prerequisites": ["Lean ℕ vs ℤ casts", "Fibonacci recurrence"]
   },
   {
     "id": "fib-lucas-deg2-signfree",
@@ -21,7 +29,11 @@
     "range": { "startLine": 84, "endLine": 90 },
     "type": "insight",
     "title": "Why the Sum Carries No Sign",
-    "content": "Substituting Lₙ = 2Fₙ₊₁ − Fₙ and the Fₙ, Fₙ₊₁ form of L₂ₙ, both sides of Lₙ² + 5Fₙ² = 2L₂ₙ collapse to the same quadratic 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ². No (−1)ⁿ ever appears — `ring` closes it outright. All of the parity information lives in the parent's difference identity; the sum is its sign-free dual."
+    "content": "Substituting Lₙ = 2Fₙ₊₁ − Fₙ and the Fₙ, Fₙ₊₁ form of L₂ₙ, both sides of Lₙ² + 5Fₙ² = 2L₂ₙ collapse to the same quadratic 4Fₙ₊₁² − 4FₙFₙ₊₁ + 6Fₙ². No (−1)ⁿ ever appears — `ring` closes it outright. All of the parity information lives in the parent's difference identity; the sum is its sign-free dual.",
+    "mathContext": "$L_n^2 + 5F_n^2 = 2L_{2n}$: both sides reduce to $4F_{n+1}^2 - 4F_nF_{n+1} + 6F_n^2$, a pure polynomial identity with no $(-1)^n$ — unlike the parent's sign-carrying difference.",
+    "significance": "key",
+    "relatedConcepts": ["parity", "polynomial identities", "ring tactic", "Lucas doubling", "sign-free identity"],
+    "prerequisites": ["Fibonacci/Lucas closed forms", "polynomial algebra"]
   },
   {
     "id": "fib-lucas-deg2-bridge",
@@ -29,6 +41,10 @@
     "range": { "startLine": 91, "endLine": 99 },
     "type": "insight",
     "title": "Sum and Difference Are One Fact",
-    "content": "Adding the sign-free sum Lₙ² + 5Fₙ² = 2L₂ₙ to the parent's sign-carrying difference Lₙ² = 5Fₙ² + 4(−1)ⁿ and cancelling the 5Fₙ² term returns the classical Lucas doubling formula L₂ₙ = Lₙ² − 2(−1)ⁿ. The two degree-2 identities are therefore two faces of a single relation, with `linarith` performing the recombination."
+    "content": "Adding the sign-free sum Lₙ² + 5Fₙ² = 2L₂ₙ to the parent's sign-carrying difference Lₙ² = 5Fₙ² + 4(−1)ⁿ and cancelling the 5Fₙ² term returns the classical Lucas doubling formula L₂ₙ = Lₙ² − 2(−1)ⁿ. The two degree-2 identities are therefore two faces of a single relation, with `linarith` performing the recombination.",
+    "mathContext": "$\\tfrac12\\big[(L_n^2 + 5F_n^2) + (L_n^2 - 5F_n^2)\\big] = L_n^2$ feeds $L_{2n} = L_n^2 - 2(-1)^n$; eliminating $5F_n^2$ between sum and difference recovers Lucas doubling.",
+    "significance": "key",
+    "relatedConcepts": ["Lucas doubling formula", "linear combination of identities", "linarith", "sum and difference of squares"],
+    "prerequisites": ["Fibonacci/Lucas identities", "linear arithmetic"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-02-oq-01-oq-01-oq-02` (quality 65, passes 0). Verified entry (0 sorries / 0 axioms) completing the degree-2 Fibonacci–Lucas trio (sum-of-squares $L_n^2+5F_n^2=2L_{2n}$ and cross $L_nF_n=F_{2n}$).

meta.json (structured overview/conclusion, 5 sections, crossRefs) was already solid; the gap was annotation depth.

**Change (annotations.json):** added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 4 annotations (previously bare `content` only). No content/range/type changes.

Validated: JSON parses, resolver 4/4 aligned, `gallery:check-size` passes, `annotations:build` clean for this id.