### PR TITLE
audit(knights-tour-oblique-oq-01-oq-02): correct lineCount 562→567

### DIFF
--- a/src/data/proofs/knights-tour-oblique-oq-01-oq-02/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None (purely algebraic). The main theorem four_oblique_corners_rect is complete for all m, n ≥ 5: it exhibits 4 distinct tour positions (the board corners) where the turn is oblique. No native_decide, no enumeration. The argument never uses m = n.",
     "dateAdded": "2026-06-26",
-    "lineCount": 562,
+    "lineCount": 567,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Basic",
@@ -97,7 +97,7 @@
       "id": "main",
       "title": "Main Theorem: Four Oblique Corners (Rectangular)",
       "startLine": 384,
-      "endLine": 562,
+      "endLine": 567,
       "summary": "four_oblique_corners_rect: every closed tour on an m×n board (m, n ≥ 5) has four distinct positions with oblique turns. The corner squares occur at tour indices iTL, iTR, iBL, iBR (pairwise distinct via nodup and corners_distinct); the cyclic predecessor/successor at each index are the corner's two neighbors (distinct), so corner_forces_oblique applies. Modular-index bookkeeping (hcyc, hpn, hsqcong) mirrors the square proof with n·n replaced by m·n."
     }
   ],
@@ -123,7 +123,7 @@
   ],
   "leanFile": {
     "path": "Proofs/KnightsTourObliqueOQ01OQ02.lean",
-    "lineCount": 562,
+    "lineCount": 567,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 15,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: knights-tour-oblique-oq-01-oq-02
**Result**: substantively CLEAN, one minor metadata drift fixed

## Finding (LOW severity)

`leanFile.lineCount` and `meta.lineCount` recorded **562**, but the Lean source `Proofs/KnightsTourObliqueOQ01OQ02.lean` is **567 lines**. The main-theorem section `endLine` (which tracks the file's last line) also read 562. All three updated to 567.

## Verified accurate (no change needed)

- `status: verified` / `badge: original` — appropriate (0 sorries, 0 axioms, genuinely new rectangular generalization)
- 0 sorries, 0 axioms (confirmed against source)
- 15 theorems, 14 definitions — match source
- **No native_decide** — the two grep hits are docstring text only; the `assumptions` claim "No native_decide, no enumeration" is accurate
- No True stubs
- Structures `MoveVector` (pure data) and `ClosedTourMN` (definitional bundle) carry **no injected axioms**
- Main theorem `four_oblique_corners_rect` honestly takes `(t : ClosedTourMN m n)` as hypothesis — proves a property of any given tour, does not assume existence

---
Discovered during gallery integrity audit.