### PR TITLE
Enrich cubic-discriminant-as-resultant entry: body→content + depth + range fixes

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01-oq-02/annotations.json
@@ -3,44 +3,60 @@
     "id": "ann-soc-oq010102-cubicpoly",
     "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 60,
-      "endLine": 116
+      "startLine": 59,
+      "endLine": 103
     },
     "type": "technique",
     "title": "Realizing the Cubic as a Polynomial",
-    "body": "To apply Mathlib's intrinsic resultant and discriminant, the cubic must be an honest element of ℂ[X]: cubicPoly a b c d = C a·X³ + C b·X² + C c·X + C d. Its coefficients (a, b, c, d at degrees 3, 2, 1, 0) fall out of simp with coeff_X_pow. The degree facts use compute_degree!, which proves natDegree = 3 and degree = 3 once the leading coefficient a is known nonzero. The leading coefficient is then coeff 3 = a, and the derivative is 3a·X² + 2b·X + c (combining the C-factors with C_mul before ring)."
+    "content": "To apply Mathlib's intrinsic resultant and discriminant, the cubic must be an honest element of ℂ[X]: cubicPoly a b c d = C a·X³ + C b·X² + C c·X + C d. Its coefficients (a, b, c, d at degrees 3, 2, 1, 0) fall out of simp with coeff_X_pow. The degree facts use compute_degree!, which proves natDegree = 3 and degree = 3 once the leading coefficient a is known nonzero. The leading coefficient is then coeff 3 = a, and the derivative is 3a·X² + 2b·X + c (combining the C-factors with C_mul before ring).",
+    "mathContext": "$f(X) = aX^3 + bX^2 + cX + d \\in \\mathbb{C}[X]$, $a\\neq 0$; $\\deg f = 3$, leading coeff $a$, and $f'(X) = 3aX^2 + 2bX + c$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial ring", "degree of a polynomial", "formal derivative", "compute_degree tactic", "leading coefficient"],
+    "prerequisites": ["polynomials over ℂ", "Lean Polynomial API"]
   },
   {
     "id": "ann-soc-oq010102-discr-bridge",
     "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 124,
-      "endLine": 131
+      "startLine": 105,
+      "endLine": 118
     },
     "type": "insight",
     "title": "Two Definitions of the Discriminant Coincide",
-    "body": "cubic_discr_eq_generalDiscriminant identifies Mathlib's intrinsic Polynomial.discr — defined as the determinant of the (normalized) Sylvester matrix of f and f′, times a sign — with the parent's hand-written coefficient polynomial generalDiscriminant a b c d. Mathlib's discr_of_degree_eq_three gives discr f in terms of f.coeff 0..3; substituting the computed coefficients and calling ring matches it to 18abcd − 4b³d + b²c² − 4ac³ − 27a²d². The ad-hoc polynomial and the basis-free Sylvester determinant are the same object."
+    "content": "cubic_discr_eq_generalDiscriminant identifies Mathlib's intrinsic Polynomial.discr — defined as the determinant of the (normalized) Sylvester matrix of f and f′, times a sign — with the parent's hand-written coefficient polynomial generalDiscriminant a b c d. Mathlib's discr_of_degree_eq_three gives discr f in terms of f.coeff 0..3; substituting the computed coefficients and calling ring matches it to 18abcd − 4b³d + b²c² − 4ac³ − 27a²d². The ad-hoc polynomial and the basis-free Sylvester determinant are the same object.",
+    "mathContext": "$\\operatorname{disc} f = \\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2$ — Mathlib's Sylvester-determinant discriminant equals the parent's coefficient formula.",
+    "significance": "key",
+    "relatedConcepts": ["discriminant", "Sylvester matrix", "resultant", "symmetric functions of roots"],
+    "prerequisites": ["discriminant of a polynomial", "determinants"]
   },
   {
     "id": "ann-soc-oq010102-resultant",
     "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 142,
-      "endLine": 159
+      "startLine": 120,
+      "endLine": 143
     },
     "type": "insight",
     "title": "Res(f, f′) = −a·Δ",
-    "body": "The headline cubic_resultant_eq_neg_smul_discriminant specializes Mathlib's resultant_deriv, Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·discr f, to the cubic. At n = natDegree = 3 the sign exponent is 3·2/2 = 3, so (−1)³ = −1; the leading coefficient aₙ is a; and discr f is Δ by the bridge. Hence Res(f, f′) = −a·Δ(a,b,c,d). For the depressed cubic X³ + p·X + q this is the textbook 4p³ + 27q² = −(−4p³ − 27q²)."
+    "content": "The headline cubic_resultant_eq_neg_smul_discriminant specializes Mathlib's resultant_deriv, Res(f, f′) = (−1)^{n(n−1)/2}·aₙ·discr f, to the cubic. At n = natDegree = 3 the sign exponent is 3·2/2 = 3, so (−1)³ = −1; the leading coefficient aₙ is a; and discr f is Δ by the bridge. Hence Res(f, f′) = −a·Δ(a,b,c,d). For the depressed cubic X³ + p·X + q this is the textbook 4p³ + 27q² = −(−4p³ − 27q²).",
+    "mathContext": "$\\operatorname{Res}(f,f') = (-1)^{n(n-1)/2} a_n \\operatorname{disc} f = -a\\,\\Delta$ at $n=3$; for $X^3+pX+q$, $\\operatorname{Res}(f,f') = 4p^3 + 27q^2$.",
+    "significance": "key",
+    "relatedConcepts": ["resultant", "discriminant", "eliminant", "depressed cubic", "Sylvester matrix"],
+    "prerequisites": ["resultant of two polynomials", "discriminant"]
   },
   {
     "id": "ann-soc-oq010102-eliminant",
     "proofId": "solution-of-cubic-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 165,
-      "endLine": 180
+      "startLine": 145,
+      "endLine": 170
     },
     "type": "technique",
     "title": "The Resultant as an Eliminant",
-    "body": "Because a ≠ 0, the factor −a in Res(f, f′) = −a·Δ never vanishes, so cubic_resultant_eq_zero_iff gives Res(f, f′) = 0 ⟺ Δ = 0 (mul_eq_zero plus neg_eq_zero discard the −a branch). Chaining the parent's repeated_root_iff then yields cubic_resultant_eq_zero_iff_repeated_root: for a cubic given by Vieta data on roots x₁, x₂, x₃, the resultant of f with f′ vanishes iff two of the roots coincide — the classical statement that the discriminant is the eliminant of f and its derivative."
+    "content": "Because a ≠ 0, the factor −a in Res(f, f′) = −a·Δ never vanishes, so cubic_resultant_eq_zero_iff gives Res(f, f′) = 0 ⟺ Δ = 0 (mul_eq_zero plus neg_eq_zero discard the −a branch). Chaining the parent's repeated_root_iff then yields cubic_resultant_eq_zero_iff_repeated_root: for a cubic given by Vieta data on roots x₁, x₂, x₃, the resultant of f with f′ vanishes iff two of the roots coincide — the classical statement that the discriminant is the eliminant of f and its derivative.",
+    "mathContext": "$\\operatorname{Res}(f,f') = 0 \\iff \\Delta = 0 \\iff x_1=x_2 \\lor x_1=x_3 \\lor x_2=x_3$ (a repeated root), since $a\\neq 0$.",
+    "significance": "key",
+    "relatedConcepts": ["eliminant", "repeated root", "Vieta's formulas", "discriminant vanishing", "multiple roots"],
+    "prerequisites": ["resultant and elimination", "Vieta's formulas"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-01-oq-02` (quality 63, passes 0). Verified entry (0 sorries / 0 axioms) deriving the cubic discriminant as $\operatorname{Res}(f,f') = -a\,\Delta$ via Mathlib's resultant theory.

**Changes (annotations.json) — three issues fixed:**
1. **Non-rendering text** — all 4 annotations stored their prose under a legacy `body` key; the renderer reads `content`, so the annotation bodies displayed empty. Converted `body` → `content`.
2. **Missing depth** — added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all 4.
3. **Shifted ranges** — every annotation's range was offset one section forward of the code it describes (the discriminant-bridge annotation pointed at the resultant section; the eliminant annotation at lines 165–180 ran past the relevant theorems). Ranges now match content (Part 1 59–103, Part 2 105–118, Part 3 120–143, Part 4 145–170).

Validated: JSON parses, resolver 4/4 aligned, `gallery:check-size` passes, `annotations:build` clean for this id.