### PR TITLE
Fix: refresh stale leanFile metadata snapshots (erdos-318, erdos-1057, erdos-632)

### DIFF
--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -68,7 +68,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 1,
-    "lineCount": 1099,
+    "lineCount": 1163,
     "assumptions": "1 axiom: infinitely_many_carmichaels (Alford–Granville–Pomerance infinitude of Carmichael numbers). 0 sorries. Korselt's 1899 criterion is now fully proved in both directions (korselt_forward and korselt_backward).",
     "theoremCount": 66,
     "definitionCount": 14
@@ -300,8 +300,8 @@
       "Classical"
     ],
     "namespace": null,
-    "lineCount": 1099,
-    "axiomCount": 2,
+    "lineCount": 1163,
+    "axiomCount": 1,
     "theoremCount": 66,
     "definitionCount": 14,
     "path": "Proofs/Erdos1057Problem.lean",

--- a/src/data/proofs/erdos-318/meta.json
+++ b/src/data/proofs/erdos-318/meta.json
@@ -197,9 +197,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos318",
-    "lineCount": 409,
-    "axiomCount": 5,
-    "theoremCount": 6,
+    "lineCount": 543,
+    "axiomCount": 3,
+    "theoremCount": 8,
     "definitionCount": 14,
     "path": "Proofs/Erdos318Problem.lean",
     "sorries": 0,

--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -180,12 +180,12 @@
       "Function"
     ],
     "namespace": "Erdos632",
-    "lineCount": 260,
+    "lineCount": 308,
     "axiomCount": 1,
     "theoremCount": 11,
     "definitionCount": 15,
     "path": "Proofs/Erdos632Problem.lean",
-    "sorries": 5,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/Erdos632ProblemAristotle.lean",
       "Proofs/Erdos632Aristotle.lean"
@@ -235,5 +235,5 @@
       "description": "Related Erdős problem sharing themes: counterexample, disproved, graph-theory"
     }
   ],
-  "sorries": 5
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Three Erdős gallery entries had stale `leanFile.*` metadata snapshots: the `meta.*` headline fields had already been corrected, but the detailed `leanFile` block (and, for erdos-632, the top-level `sorries`) was left behind after the Lean source files were edited. All counts now match the actual `.lean` files, verified against source.

## Evidence (meta → corrected, matching actual source)

**erdos-318** (`Erdos318Problem.lean`, 543 lines, 3 axioms, 8 theorems):
- `leanFile.lineCount` 409 → 543
- `leanFile.axiomCount` 5 → **3** (the file's own comments document that 2 axioms — including an "overclaiming axiom" — were converted to theorems; `meta.axiomCount` already says 3)
- `leanFile.theoremCount` 6 → 8

**erdos-1057** (`Erdos1057Problem.lean`, 1163 lines, 1 axiom):
- `lineCount` 1099 → 1163 (both `meta` and `leanFile`)
- `leanFile.axiomCount` 2 → **1** (only `infinitely_many_carmichaels` remains; `meta.axiomCount` already says 1)

**erdos-632** (`Erdos632Problem.lean`, 308 lines, 2 sorries):
- `leanFile.lineCount` 260 → 308
- `leanFile.sorries` 5 → **2** and top-level `sorries` 5 → 2 (2 bare `sorry` tactics at lines 98, 116; `meta.sorries` already says 2)

Each entry's `meta`, `leanFile`, and top-level fields are now mutually consistent and match the source. Verified Lean files are single-file (companion `*Aristotle.lean` files counted separately under `additionalFiles`, not aggregated). `definitionCount` and `theoremCount` were already correct, confirming the main-file-only counting convention. Gallery data-enrichment build passes.

---
Automated fix by lean-mechanic agent.