### PR TITLE
Enrich Method of Types (type partition identity): annotation depth

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-04-incomplete-01/annotations.json
@@ -1,46 +1,77 @@
 [
   {
+    "id": "ann-typeindex",
+    "proofId": "shannon-source-coding-oq-04-incomplete-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 66
+    },
+    "type": "definition",
+    "title": "Indexing the Types as Bounded Count Vectors",
+    "content": "A type is an empirical distribution: a count vector recording how often each symbol occurs, so its entries are nonnegative and sum to the block length n. `empDist_le` notes each count is ≤ n, which lets the counts be packaged as values in Fin (n+1) = {0,…,n}. `typeIndex n` is then the finite set of such count vectors g : Fin k → Fin (n+1) constrained by ∑ᵢ g(i) = n — exactly the index set behind the parent's count_types_le bound of (n+1)^k types. `typeIndex_sum` extracts the defining sum condition back from membership.",
+    "mathContext": "$\\mathrm{typeIndex}(n) = \\{\\, g : \\mathrm{Fin}\\,k \\to \\mathrm{Fin}(n{+}1) \\mid \\sum_i g(i) = n \\,\\}$. Each empirical count $\\le n$, so $|\\mathrm{typeIndex}(n)| \\le (n+1)^k$ — only polynomially many types.",
+    "significance": "supporting",
+    "relatedConcepts": ["empirical distribution", "type (method of types)", "composition of an integer", "Finset filter"],
+    "prerequisites": ["method of types", "finite types in Lean 4", "counting"]
+  },
+  {
     "id": "ann-typemap",
     "proofId": "shannon-source-coding-oq-04-incomplete-01",
     "range": {
-      "startLine": 78,
-      "endLine": 90
+      "startLine": 56,
+      "endLine": 66
     },
     "type": "concept",
     "title": "The Type Map: Sequence ↦ Empirical Distribution",
-    "content": "`typeMap n x i = ⟨empDist n x i, …⟩` records, for each symbol i, how many times it appears in x — packaged as a value in Fin (n+1) since counts never exceed n (`empDist_le`). `typeMap_mem` then shows the result is a valid type: the counts sum to the block length n (the parent's `empDist_sum`). This map is the lens through which the sequence space is organized by type."
+    "content": "`typeMap n x i = ⟨empDist n x i, …⟩` records, for each symbol i, how many times it appears in x — packaged as a value in Fin (n+1) since counts never exceed n (`empDist_le`). `typeMap_mem` then shows the result is a valid type: the counts sum to the block length n (the parent's `empDist_sum`). This map is the lens through which the sequence space is organized by type; its fibers will turn out to be the type classes.",
+    "mathContext": "$F = \\mathrm{typeMap}_n : (\\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,k) \\to (\\mathrm{Fin}\\,k \\to \\mathrm{Fin}(n{+}1))$, $F(x)(i) = \\#\\{ j : x_j = i \\}$, with $\\sum_i F(x)(i) = n$ so $F(x) \\in \\mathrm{typeIndex}(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["empirical distribution", "fiber of a map", "histogram", "type class"],
+    "prerequisites": ["method of types", "functions on finite types"]
   },
   {
     "id": "ann-fiber",
     "proofId": "shannon-source-coding-oq-04-incomplete-01",
     "range": {
-      "startLine": 98,
-      "endLine": 105
+      "startLine": 78,
+      "endLine": 83
     },
     "type": "insight",
     "title": "The Fiber Is a Type Class",
-    "content": "`fiber_eq_typeClass` is the bridge: the set of sequences mapping to a given type g — the fiber of the type map over g — is exactly the parent's type class T_g. Both sides reduce, via Fin.ext_iff and funext_iff, to the condition `∀ i, empDist n x i = (g i).val`. Once the fibers are identified with the type classes, the partition identity is immediate."
+    "content": "`fiber_eq_typeClass` is the bridge: the set of sequences mapping to a given type g — the fiber of the type map over g — is exactly the parent's type class T_g. Both sides reduce, via Fin.ext_iff and funext_iff, to the condition `∀ i, empDist n x i = (g i).val`. Once the fibers are identified with the type classes, the partition identity is immediate — the type map's fibers ARE the combinatorial objects the parent already measured.",
+    "mathContext": "$F^{-1}(g) = \\{ x \\mid \\forall i,\\ \\mathrm{empDist}(x)(i) = g(i) \\} = T_g$, the type class of $g$. The fibers of $F$ are precisely the type classes.",
+    "significance": "key",
+    "relatedConcepts": ["fiber of a map", "type class", "preimage", "extensionality (funext, Fin.ext)"],
+    "prerequisites": ["method of types", "preimages and fibers", "Lean extensionality lemmas"]
   },
   {
     "id": "ann-partition",
     "proofId": "shannon-source-coding-oq-04-incomplete-01",
     "range": {
-      "startLine": 124,
-      "endLine": 145
+      "startLine": 96,
+      "endLine": 118
     },
     "type": "insight",
     "title": "The Partition Identity = the Multinomial Theorem",
-    "content": "`total_eq_sum_type_class_card` applies `Finset.card_eq_sum_card_fiberwise` to the type map: the k^n sequences split, class by class, across the types, so k^n = ∑_{types g} |T_g|. Rewriting each class by the parent's `type_class_size_eq_multinomial` gives `total_eq_sum_multinomial`: k^n = ∑_{types g} multinomial(g). This is the multinomial theorem (1+⋯+1)^n = k^n, obtained not by algebraic expansion but by partitioning sequences according to their empirical distribution — the combinatorial accounting at the heart of the method of types."
+    "content": "`total_eq_sum_type_class_card` applies `Finset.card_eq_sum_card_fiberwise` to the type map: the k^n sequences split, class by class, across the types, so k^n = ∑_{types g} |T_g|. Rewriting each class by the parent's `type_class_size_eq_multinomial` gives `total_eq_sum_multinomial`: k^n = ∑_{types g} multinomial(g). This is the multinomial theorem (1+⋯+1)^n = k^n, obtained not by algebraic expansion but by partitioning sequences according to their empirical distribution — the combinatorial accounting at the heart of the method of types.",
+    "mathContext": "$k^n = \\sum_{g \\in \\mathrm{typeIndex}(n)} |T_g| = \\sum_{g} \\binom{n}{g_1,\\dots,g_k}$, i.e. $(1+\\cdots+1)^n = k^n$ realized via the partition $\\{T_g\\}$ of the $k^n$ sequences.",
+    "significance": "key",
+    "relatedConcepts": ["multinomial theorem", "partition of a set", "fiberwise cardinality", "multinomial coefficient"],
+    "prerequisites": ["multinomial coefficients", "Finset.card_eq_sum_card_fiberwise", "method of types"]
   },
   {
     "id": "ann-dominant",
     "proofId": "shannon-source-coding-oq-04-incomplete-01",
     "range": {
-      "startLine": 161,
-      "endLine": 180
+      "startLine": 132,
+      "endLine": 179
     },
     "type": "insight",
     "title": "The Dominant Type Class, Straight from the Partition",
-    "content": "`exists_dominant_type_class` derives the dominant-type lower bound k^n ≤ (n+1)^k·|T_g| by a clean averaging argument: the sum of class sizes equals k^n, there are at most (n+1)^k classes (`count_types_le`), so the largest class is at least the average. This recovers the parent's `dominant_type_lower_bound` directly from the partition identity, without a separate pigeonhole over the k^n sequences — the exponential share carried by the dominant type is exactly what powers the source coding achievability bound."
+    "content": "`exists_dominant_type_class` derives the dominant-type lower bound k^n ≤ (n+1)^k·|T_g| by a clean averaging argument: the sum of class sizes equals k^n, there are at most (n+1)^k classes (`typeIndex_card_le` / `count_types_le`), so the largest class is at least the average. The Lean proof takes the max-size type via `Finset.exists_max_image`, bounds the partition sum above by (#types)·(max size), then replaces #types by (n+1)^k. This recovers the parent's `dominant_type_lower_bound` directly from the partition identity, without a separate pigeonhole over the k^n sequences — the exponential share carried by the dominant type is exactly what powers the source coding achievability bound.",
+    "mathContext": "From $k^n = \\sum_{g} |T_g|$ over $\\le (n+1)^k$ types, the maximal class satisfies $|T_{g^\\*}| \\ge \\dfrac{k^n}{(n+1)^k}$, i.e. $k^n \\le (n+1)^k \\cdot |T_{g^\\*}|$. Since $(n+1)^k$ is polynomial in $n$, $|T_{g^\\*}| \\approx k^n$ exponentially.",
+    "significance": "supporting",
+    "relatedConcepts": ["averaging argument", "pigeonhole principle", "dominant type", "source coding theorem", "asymptotic equipartition"],
+    "prerequisites": ["averaging / pigeonhole", "method of types", "information theory"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `shannon-source-coding-oq-04-incomplete-01`

The `meta.json` is already richly structured (overview, conclusion, sections with mathContext, mainTheorems, references). The gap was in **annotations**: the 4 existing annotations carried only `title`/`content`, but the page renders `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Changes (annotations.json)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all existing annotations.
- Added a 5th annotation covering **Part I** (`typeIndex` / `empDist_le` / `typeMap_mem`), which was previously uncovered (annotations started at the type map).
- annotations.json 2.8 KB → 6.3 KB; meta.json left unchanged (already at quality).

### Verification
- Valid JSON; all 5 annotations have `mathContext`, `significance`, `relatedConcepts`.
- `pnpm build` passes.
- No axiom/status changes (entry remains `verified`, 0 axioms, 0 sorries).