### PR TITLE
Research: Jordan–Hölder theorem for modules (abel-ruffini-galois-extensions-oq-04-oq-02)

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean
@@ -1,0 +1,116 @@
+import Mathlib
+
+/-
+# The Jordan–Hölder Theorem for Modules
+
+The Abel–Ruffini family in this gallery repeatedly invokes the Jordan–Hölder
+theorem for the *Galois group*: any two composition series of a finite group
+have the same length and isomorphic composition factors, which is what makes
+"solvability" a well-defined property independent of the chosen subnormal
+series.  Exactly the same statement holds for **modules**, and that is what we
+formalize here.
+
+Mathlib proves the Jordan–Hölder theorem abstractly for any `JordanHolderLattice`
+(`CompositionSeries.jordan_holder`, in `Mathlib/Order/JordanHolder.lean`) and
+supplies the instance `JordanHolderLattice (Submodule R M)`
+(`JordanHolderModule.instJordanHolderLattice`, in
+`Mathlib/RingTheory/SimpleModule/Basic.lean`).  In that instance:
+
+* the maximality relation `IsMaximal N N'` is the covering relation `N ⋖ N'`,
+  equivalently "`N'/N` is a simple module";
+* the isomorphism relation `Iso (A,B) (C,D)` is a linear equivalence of the
+  successive quotients `B/A ≃ₗ[R] D/C` — i.e. equality of *composition factors*.
+
+This file pulls those two pieces together to state the module-theoretic
+Jordan–Hölder theorem, derives the well-definedness of composition length, and
+specializes to simple modules (whose composition length is `1`).
+
+The mathematical content is Mathlib's (Tier B): the deep induction is
+`CompositionSeries.jordan_holder`.  Our contribution is the explicit
+module-theoretic specialization and its consequences, which were not previously
+present in the gallery.
+-/
+
+open CompositionSeries
+
+variable {R : Type*} [Ring R] {M : Type*} [AddCommGroup M] [Module R M]
+
+namespace JordanHolderModuleGallery
+
+/-- **Jordan–Hölder for modules.**  Two composition series of submodules of an
+`R`-module `M` that share the same bottom term (`head`) and top term (`last`)
+are *equivalent*: there is a bijection between their composition factors under
+which corresponding factors are `R`-linearly isomorphic.
+
+This is `CompositionSeries.jordan_holder` instantiated at the lattice
+`Submodule R M`. -/
+theorem jordanHolder_module (s₁ s₂ : CompositionSeries (Submodule R M))
+    (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
+    s₁.Equivalent s₂ :=
+  CompositionSeries.jordan_holder s₁ s₂ hb ht
+
+/-- The **composition length** of a module is well defined: any two composition
+series of `M` with the same endpoints have the same length.  This is the
+invariance that lets one speak of *the* length of a module of finite length. -/
+theorem compositionSeries_length_eq (s₁ s₂ : CompositionSeries (Submodule R M))
+    (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
+    s₁.length = s₂.length :=
+  (jordanHolder_module s₁ s₂ hb ht).length_eq
+
+/-- Unpacking the conclusion: there is an explicit bijection `f` between the
+factor indices of the two series such that, for every `i`, the `i`-th
+composition factor of `s₁` is `JordanHolderLattice`-isomorphic to the `f i`-th
+composition factor of `s₂`.  For `Submodule R M` this isomorphism is a linear
+equivalence of the successive quotients. -/
+theorem exists_factor_bijection (s₁ s₂ : CompositionSeries (Submodule R M))
+    (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
+    ∃ f : Fin s₁.length ≃ Fin s₂.length, ∀ i : Fin s₁.length,
+      JordanHolderLattice.Iso
+        (s₁ (Fin.castSucc i), s₁ i.succ)
+        (s₂ (Fin.castSucc (f i)), s₂ (Fin.succ (f i))) :=
+  jordanHolder_module s₁ s₂ hb ht
+
+/-- Equivalence of composition series is symmetric (inherited from the abstract
+theory), so the roles of the two series may be exchanged. -/
+theorem jordanHolder_module_symm (s₁ s₂ : CompositionSeries (Submodule R M))
+    (hb : s₁.head = s₂.head) (ht : s₁.last = s₂.last) :
+    s₂.Equivalent s₁ :=
+  (jordanHolder_module s₁ s₂ hb ht).symm
+
+/-! ### Specialization to simple modules
+
+A nonzero module `M` is *simple* (`IsSimpleModule R M`) exactly when its only
+submodules are `⊥` and `⊤`, i.e. `⊥ ⋖ ⊤`.  Then `[⊥, ⊤]` is a composition
+series of length `1`, and Jordan–Hölder forces *every* composition series of `M`
+to have length `1`. -/
+
+/-- The canonical length-`1` composition series `⊥ ⋖ ⊤` of a simple module. -/
+def simpleSeries (R : Type*) [Ring R] (M : Type*) [AddCommGroup M] [Module R M]
+    [IsSimpleModule R M] : CompositionSeries (Submodule R M) where
+  length := 1
+  toFun := ![⊥, ⊤]
+  step := by
+    intro i
+    fin_cases i
+    show (⊥ : Submodule R M) ⋖ ⊤
+    exact bot_covBy_top
+
+@[simp] theorem simpleSeries_head [IsSimpleModule R M] :
+    (simpleSeries R M).head = ⊥ := rfl
+
+@[simp] theorem simpleSeries_last [IsSimpleModule R M] :
+    (simpleSeries R M).last = ⊤ := rfl
+
+@[simp] theorem simpleSeries_length [IsSimpleModule R M] :
+    (simpleSeries R M).length = 1 := rfl
+
+/-- **A simple module has composition length `1`.**  Every composition series of
+a simple module `M` (running from `⊥` to `⊤`) has length exactly `1`. -/
+theorem simpleModule_compositionSeries_length_eq_one [IsSimpleModule R M]
+    (s : CompositionSeries (Submodule R M)) (hb : s.head = ⊥) (ht : s.last = ⊤) :
+    s.length = 1 := by
+  have h := compositionSeries_length_eq s (simpleSeries R M)
+    (by rw [hb, simpleSeries_head]) (by rw [ht, simpleSeries_last])
+  simpa using h
+
+end JordanHolderModuleGallery

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-jordanholder-module",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "range": {
+      "startLine": 46,
+      "endLine": 53
+    },
+    "type": "theorem",
+    "title": "Jordan–Hölder for Modules",
+    "content": "The module-theoretic Jordan–Hölder theorem: two composition series s₁, s₂ of submodules of M that share the same bottom term (head) and top term (last) are equivalent. The proof is a one-line specialization of Mathlib's abstract CompositionSeries.jordan_holder to the lattice X = Submodule R M, using the instance JordanHolderModule.instJordanHolderLattice. Equivalence means there is a bijection between the two series' composition-factor indices under which corresponding factors are R-linearly isomorphic.",
+    "mathContext": "If $\\bot = N_0 \\lessdot N_1 \\lessdot \\cdots \\lessdot N_k = M$ and $\\bot = N'_0 \\lessdot \\cdots \\lessdot N'_\\ell = M$ are composition series of $M$, then $k=\\ell$ and there is a permutation $\\sigma$ with $N_{i+1}/N_i \\cong_R N'_{\\sigma(i)+1}/N'_{\\sigma(i)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "composition series",
+      "composition factors",
+      "JordanHolderLattice"
+    ],
+    "prerequisites": [
+      "CompositionSeries.jordan_holder",
+      "JordanHolderModule.instJordanHolderLattice"
+    ]
+  },
+  {
+    "id": "ann-length-invariance",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "Composition Length is Well Defined",
+    "content": "Any two composition series of M with the same endpoints have the same length, obtained by applying CompositionSeries.Equivalent.length_eq to the equivalence from the main theorem. This is the statement that the composition length of a finite-length module is an invariant, not an artifact of the chosen series — the prerequisite for speaking of 'the' length of M.",
+    "mathContext": "$s_1 \\sim s_2 \\Rightarrow \\mathrm{length}(s_1) = \\mathrm{length}(s_2)$; the common value is the composition length $\\ell_R(M)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "composition length",
+      "module length",
+      "invariance"
+    ],
+    "prerequisites": [
+      "CompositionSeries.Equivalent.length_eq"
+    ]
+  },
+  {
+    "id": "ann-factor-bijection",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 80
+    },
+    "type": "theorem",
+    "title": "The Composition-Factor Bijection",
+    "content": "exists_factor_bijection unfolds the Equivalent predicate into its concrete data: a bijection f : Fin s₁.length ≃ Fin s₂.length together with, for each index i, a JordanHolderLattice isomorphism between the i-th factor of s₁ and the f(i)-th factor of s₂. Under the Submodule instance this Iso is a linear equivalence of the successive quotients, so the multiset of composition factors is permutation-invariant. jordanHolder_module_symm records that the equivalence is symmetric.",
+    "mathContext": "$\\mathrm{Equivalent}(s_1,s_2) = \\exists f: \\mathrm{Fin}\\,s_1.\\mathrm{length} \\simeq \\mathrm{Fin}\\,s_2.\\mathrm{length},\\ \\forall i,\\ \\mathrm{Iso}\\,(s_1\\,i, s_1\\,i^+)\\,(s_2\\,(f i), s_2\\,(f i)^+).$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "factor bijection",
+      "linear equivalence of quotients",
+      "permutation of factors"
+    ],
+    "prerequisites": [
+      "CompositionSeries.Equivalent"
+    ]
+  },
+  {
+    "id": "ann-simple-series",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "range": {
+      "startLine": 82,
+      "endLine": 106
+    },
+    "type": "definition",
+    "title": "The Canonical Series of a Simple Module",
+    "content": "simpleSeries is the length-1 composition series ⊥ ⋖ ⊤ of a simple module, with toFun = ![⊥, ⊤]. Its single step is bot_covBy_top, available because IsSimpleModule R M unfolds to IsSimpleOrder (Submodule R M). The @[simp] lemmas simpleSeries_head, simpleSeries_last, simpleSeries_length record head = ⊥, last = ⊤, length = 1 by rfl, so it can be compared definitionally against any other series.",
+    "mathContext": "$\\mathrm{simpleSeries} : \\bot \\lessdot \\top$, the unique-up-to-equivalence composition series of a simple module, of length $1$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "simple module",
+      "covering relation",
+      "IsSimpleOrder"
+    ],
+    "prerequisites": [
+      "bot_covBy_top",
+      "IsSimpleModule"
+    ]
+  },
+  {
+    "id": "ann-simple-length-one",
+    "proofId": "abel-ruffini-galois-extensions-oq-04-oq-02",
+    "range": {
+      "startLine": 108,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Simple Modules Have Composition Length 1",
+    "content": "Every composition series of a simple module M (running from ⊥ to ⊤) has length exactly 1: compare it to simpleSeries via the length-invariance corollary. This identifies simple modules as the atoms of composition theory — the length-1 building blocks whose stacking produces all finite-length modules.",
+    "mathContext": "$M$ simple $\\Rightarrow$ every composition series of $M$ has length $1$, i.e. $\\ell_R(M)=1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "simple module",
+      "composition length",
+      "atoms of the submodule lattice"
+    ],
+    "prerequisites": [
+      "simpleSeries",
+      "compositionSeries_length_eq"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "abel-ruffini-galois-extensions-oq-04-oq-02",
+  "title": "The Jordan–Hölder Theorem for Modules",
+  "slug": "abel-ruffini-galois-extensions-oq-04-oq-02",
+  "description": "Open question oq-02 of the Jordan–Hölder branch asks for the module analogue of the JordanHolderLattice instance: instantiate the Jordan–Hölder theorem for modules over a ring, where composition factors are simple subquotients. Unlike the group case (oq-01), Mathlib already supplies the instance JordanHolderModule.instJordanHolderLattice : JordanHolderLattice (Submodule R M), in which IsMaximal N N' is the covering relation N ⋖ N' and Iso (A,B) (C,D) is a linear equivalence of successive quotients B/A ≃ₗ[R] D/C. This entry pulls that instance together with the abstract CompositionSeries.jordan_holder to state the module-theoretic Jordan–Hölder theorem — any two composition series of M with the same endpoints are equivalent — derives the well-definedness of the composition length, exposes the explicit factor bijection, and specializes to simple modules (composition length 1). The deep induction is Mathlib's; the gallery contribution is the module specialization and its corollaries, which were not previously present.",
+  "meta": {
+    "author": "Jordan, Hölder; Lean formalization original (researcher-8)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean",
+    "tags": [
+      "module-theory",
+      "jordan-holder",
+      "composition-series",
+      "simple-module",
+      "submodule-lattice",
+      "composition-length",
+      "abel-ruffini",
+      "open-question"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None beyond Mathlib. Every result is machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). The mathematical content is Tier B: the deep Jordan–Hölder induction is Mathlib's CompositionSeries.jordan_holder, and the lattice instance is Mathlib's JordanHolderModule.instJordanHolderLattice. The gallery contribution is the explicit module-theoretic specialization, the composition-length invariance corollary, the factor-bijection unpacking, and the simple-module length-1 result.",
+    "mathlibDependencies": [
+      {
+        "theorem": "CompositionSeries.jordan_holder",
+        "description": "Abstract Jordan–Hölder theorem: in any JordanHolderLattice, two composition series with equal head and last are Equivalent",
+        "module": "Mathlib.Order.JordanHolder"
+      },
+      {
+        "theorem": "JordanHolderModule.instJordanHolderLattice",
+        "description": "JordanHolderLattice (Submodule R M): IsMaximal = ⋖ (covering / simple subquotient), Iso = linear equivalence of successive quotients",
+        "module": "Mathlib.RingTheory.SimpleModule.Basic"
+      },
+      {
+        "theorem": "CompositionSeries.Equivalent.length_eq",
+        "description": "Equivalent composition series have equal length",
+        "module": "Mathlib.Order.JordanHolder"
+      },
+      {
+        "theorem": "bot_covBy_top",
+        "description": "In a simple order, ⊥ ⋖ ⊤ — the single covering step of a simple module's lattice of submodules",
+        "module": "Mathlib.Order.Atoms"
+      }
+    ],
+    "originalContributions": [
+      "jordanHolder_module: the module-theoretic Jordan–Hölder theorem, CompositionSeries.jordan_holder specialized to Submodule R M",
+      "compositionSeries_length_eq: well-definedness of the composition length of a module (any two composition series with equal endpoints have equal length)",
+      "exists_factor_bijection: explicit bijection of factor indices realizing the composition-factor isomorphisms",
+      "simpleSeries: the canonical length-1 composition series ⊥ ⋖ ⊤ of a simple module, with @[simp] head/last/length",
+      "simpleModule_compositionSeries_length_eq_one: a simple module has composition length exactly 1"
+    ],
+    "lineCount": 116,
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 8
+  },
+  "overview": {
+    "historicalContext": "The Jordan–Hölder theorem (Camille Jordan, 1870; Otto Hölder, 1889) was first proved for finite groups: any two composition series have the same length and, up to permutation and isomorphism, the same simple composition factors. The statement is lattice-theoretic in nature and holds verbatim for modules over a ring, where a composition series is a finite maximal chain of submodules ⊥ = N₀ ⋖ N₁ ⋖ ⋯ ⋖ Nₖ = M whose successive quotients Nᵢ₊₁/Nᵢ are simple modules. It is the foundational uniqueness theorem behind the notions of composition length and composition factors of a module, and (in the group form) behind the Abel–Ruffini theorem: a polynomial is solvable by radicals iff the composition factors of its Galois group are all abelian. Mathlib captures the common abstraction in the JordanHolderLattice typeclass and proves the theorem once, for any instance. For modules the relevant instance — JordanHolderLattice (Submodule R M) — is already part of Mathlib, so the module Jordan–Hölder theorem follows by instantiation; this is exactly the analogue that open question oq-02 of the parent entry requests.",
+    "problemStatement": "Let R be a ring and M an R-module. Prove the Jordan–Hölder theorem for M: any two composition series of submodules of M — finite maximal chains ⊥ = N₀ ⋖ ⋯ ⋖ Nₖ = M — that share the same bottom term ⊥ and top term M are equivalent, meaning there is a bijection between their successive-quotient indices under which corresponding composition factors Nᵢ₊₁/Nᵢ are R-linearly isomorphic. Deduce that the composition length of M is well defined, and that a simple module has composition length 1.",
+    "proofStrategy": "Instantiate Mathlib's abstract CompositionSeries.jordan_holder at the lattice X = Submodule R M, using the existing instance JordanHolderModule.instJordanHolderLattice in which IsMaximal is the covering relation ⋖ (so each step is a simple subquotient) and Iso is a linear equivalence of successive quotients. The main theorem jordanHolder_module is then a one-line specialization. Composition-length invariance (compositionSeries_length_eq) follows by applying CompositionSeries.Equivalent.length_eq to the resulting equivalence. The factor bijection (exists_factor_bijection) is obtained by unfolding the definition of Equivalent, which packages precisely an index bijection together with the per-step Iso witnesses. For the simple-module specialization, construct the canonical length-1 series simpleSeries = [⊥, ⊤]; its single step ⊥ ⋖ ⊤ is bot_covBy_top, available because IsSimpleModule R M is by definition IsSimpleOrder (Submodule R M). Comparing any composition series of a simple module to simpleSeries via the length invariant forces length 1.",
+    "keyInsights": [
+      "The module Jordan–Hölder theorem is not a separate proof but a specialization: Mathlib proves the theorem once for the JordanHolderLattice abstraction, and the lattice of submodules is already an instance, so the module statement is recovered by instantiation alone.",
+      "Under the Submodule R M instance the abstract data acquires concrete meaning: IsMaximal N N' unfolds to the covering relation N ⋖ N' (equivalently N'/N simple), and Iso (A,B) (C,D) is a genuine R-linear isomorphism B/A ≃ₗ D/C of composition factors.",
+      "Equivalence of series is exactly a bijection of factor indices together with per-step factor isomorphisms, so 'same length' and 'same factors up to permutation' are two readings of the single Equivalent predicate — length invariance is the immediate length_eq corollary.",
+      "A module is simple precisely when its submodule lattice is a simple order (⊥ ⋖ ⊤ is the only step), so simple modules are the atoms of composition theory: they have a one-step composition series and therefore composition length 1.",
+      "The group analogue (oq-01) had to first build the JordanHolderLattice (Subgroup G) instance by hand, because Mathlib lacks it; the module case is the mirror image where the instance is already present, isolating the pure act of specialization."
+    ],
+    "prerequisites": [
+      "Modules over a ring, submodules, and subquotients M ⧸ N",
+      "Simple modules and IsSimpleModule / IsSimpleOrder (Submodule R M)",
+      "The covering relation ⋖ and the lattice of submodules",
+      "Composition series, the JordanHolderLattice abstraction, and the abstract Jordan–Hölder theorem"
+    ]
+  },
+  "sections": [
+    {
+      "id": "main-theorem",
+      "title": "Jordan–Hölder for Modules",
+      "startLine": 46,
+      "endLine": 53,
+      "summary": "jordanHolder_module: two composition series of submodules with equal head and last are Equivalent, via CompositionSeries.jordan_holder at Submodule R M."
+    },
+    {
+      "id": "length-invariance",
+      "title": "Composition Length is Well Defined",
+      "startLine": 55,
+      "endLine": 62,
+      "summary": "compositionSeries_length_eq: equivalent series have equal length, so the composition length of a module is an invariant."
+    },
+    {
+      "id": "factor-bijection",
+      "title": "The Composition-Factor Bijection",
+      "startLine": 64,
+      "endLine": 80,
+      "summary": "exists_factor_bijection unpacks Equivalent into an explicit index bijection with per-step factor isomorphisms; jordanHolder_module_symm records symmetry."
+    },
+    {
+      "id": "simple-modules",
+      "title": "Simple Modules Have Length 1",
+      "startLine": 82,
+      "endLine": 115,
+      "summary": "simpleSeries is the canonical ⊥ ⋖ ⊤ series; simpleModule_compositionSeries_length_eq_one forces every composition series of a simple module to have length 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "Because Mathlib already provides JordanHolderLattice (Submodule R M), the Jordan–Hölder theorem for modules is obtained by instantiating the abstract CompositionSeries.jordan_holder: any two composition series of M with the same endpoints are equivalent, with R-linearly isomorphic composition factors matched by a bijection. This yields the well-definedness of composition length and, by comparison with the canonical ⊥ ⋖ ⊤ series, that simple modules have composition length 1. The entry is the module mirror of the group-theoretic oq-01 bridge, with the lattice instance supplied rather than built.",
+    "implications": [
+      "Composition length and composition factors of a module are well-defined invariants, the module-theoretic basis of Jordan–Hölder reasoning.",
+      "Confirms the module branch of the Jordan–Hölder open question is already resolved inside Mathlib, in contrast to the group branch which still lacks the JordanHolderLattice (Subgroup G) instance."
+    ],
+    "openQuestions": [
+      "Define the composition-factor multiset of a finite-length module and prove its multiplicities are invariant directly from exists_factor_bijection.",
+      "Connect composition length to Module.length / IsNoetherian + IsArtinian and recover additivity over short exact sequences."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Provides the module analogue of the JordanHolderLattice instantiation requested by the Jordan–Hölder lattice entry",
+      "targetId": "abel-ruffini-galois-extensions-oq-04"
+    },
+    {
+      "relationship": "sibling-of",
+      "description": "Mirror of the group-theoretic simple-quotient ⇔ maximal-normal bridge; the module case has its lattice instance already in Mathlib",
+      "targetId": "abel-ruffini-galois-extensions-oq-04-oq-01"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **Jordan–Hölder theorem for modules** as the module analogue requested by open question oq-02 of the Jordan–Hölder branch.

Mathlib already supplies the instance `JordanHolderModule.instJordanHolderLattice : JordanHolderLattice (Submodule R M)` (in which `IsMaximal N N'` is the covering relation `N ⋖ N'` and `Iso (A,B) (C,D)` is a linear equivalence `B/A ≃ₗ[R] D/C` of successive quotients). This entry pulls that instance together with the abstract `CompositionSeries.jordan_holder` to obtain the module statement, then derives its standard consequences.

Unlike the **group** analogue (`oq-01`), which had to build `JordanHolderLattice (Subgroup G)` by hand because Mathlib lacks it, the **module** instance is already present — so this PR isolates the pure act of specialization plus its corollaries.

## Results (Tier B, mathlib-backed)
- `jordanHolder_module` — two composition series of `M` with equal `head`/`last` are `Equivalent`
- `compositionSeries_length_eq` — composition length of a module is well defined
- `exists_factor_bijection` — explicit index bijection realizing the factor isomorphisms
- `simpleSeries` (+ `@[simp]` head/last/length) — the canonical `⊥ ⋖ ⊤` series of a simple module
- `simpleModule_compositionSeries_length_eq_one` — a simple module has composition length 1

## Verification
- **8 theorems, 1 definition, 0 sorries, 0 axioms** (foundational `propext`/`Classical.choice`/`Quot.sound` only; no `native_decide`)
- Docker-build verified: `✔ Built Proofs.AbelRuffiniGaloisExtensionsOQ04OQ02 (298s)`
- Gallery entry: `src/data/proofs/abel-ruffini-galois-extensions-oq-04-oq-02/` (status `verified`, badge `mathlib`)

## Honesty note
The deep Jordan–Hölder induction and the lattice instance are **Mathlib's** (hence Tier B / `mathlib` badge, not `original`). The gallery contribution is the module-theoretic specialization, the length-invariance corollary, the factor-bijection unpacking, and the simple-module length-1 result — none previously in the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)