### PR TITLE
audit(knights-tour-oblique-oq-01-oq-02): persist clean audit entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24822,8 +24822,14 @@
       "lastAudited": "2026-06-27T01:35:14Z",
       "result": "clean",
       "issues": []
+    },
+    "knights-tour-oblique-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T02:00:00Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T01:23:00Z"
+  "lastUpdated": "2026-06-27T02:00:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: knights-tour-oblique-oq-01-oq-02
**Result**: clean (re-verified)

## Why this PR

The slug was absent from `origin/main`'s `audit-tracker.json`, so `find-targets.ts` re-queued it as "unaudited" on every iteration. Local completions written by `claim-target.sh` are wiped by the per-iteration `git reset --hard origin/main`, so the loop never terminated. Persisting the clean audit entry to main is the durable fix.

## Audit findings

- 567 lines, 0 sorries, 0 axioms, 0 True stubs, 15 theorems — all substantive claims accurate
- The two `native_decide` occurrences are docstring-only (lines 19, 24) — no tactic usage, so no `Lean.ofReduceBool` dependency
- The stale meta.json `lineCount` (562→567) is corrected separately in #30442

## Change

Adds a single `result: "clean"` entry for the slug to `src/data/proofs/audit-tracker.json` (+ `lastUpdated` bump). No source or meta changes.

---
Discovered during gallery integrity audit.