### PR TITLE
Enrich Jacobi two-square (δ = ζ*χ₄): annotation depth

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-04/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-04/annotations.json
@@ -8,18 +8,26 @@
     },
     "type": "concept",
     "title": "δ as a Dirichlet Convolution ζ * χ₄",
-    "content": "The divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) is defined as the Dirichlet convolution of ζ (the constant function 1) with the character χ₄ mod 4, taken over ℤ. This mirrors Mathlib's `DirichletCharacter.zetaMul`, which is defined only for ℂ-valued quadratic characters (for Dirichlet-L non-vanishing); porting it to the integer-valued χ₄ is what lets it connect to the ℕ-valued representability criterion. Multiplicativity is then immediate: δ is the Dirichlet product of the multiplicative ζ and the completely multiplicative χ₄, so `isMultiplicative_zeta.natCast.mul (isMultiplicative_toArithmeticFunction χ₄)` finishes it."
+    "content": "The divisor-character sum δ(n) = ∑_{d∣n} χ₄(d) is defined as the Dirichlet convolution of ζ (the constant function 1) with the character χ₄ mod 4, taken over ℤ. This mirrors Mathlib's `DirichletCharacter.zetaMul`, which is defined only for ℂ-valued quadratic characters (for Dirichlet-L non-vanishing); porting it to the integer-valued χ₄ is what lets it connect to the ℕ-valued representability criterion. Multiplicativity is then immediate: δ is the Dirichlet product of the multiplicative ζ and the completely multiplicative χ₄, so `isMultiplicative_zeta.natCast.mul (isMultiplicative_toArithmeticFunction χ₄)` finishes it.",
+    "mathContext": "$\\delta = \\zeta * \\chi_4$, i.e. $\\delta(n) = \\sum_{d \\mid n} \\chi_4(d)$, where $\\chi_4$ is the non-principal character mod 4 ($\\chi_4(m) = 0,1,-1$ for $m \\equiv 0,1,3$) and $\\zeta \\equiv 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "multiplicative function", "Dirichlet character mod 4", "arithmetic function"],
+    "prerequisites": ["Dirichlet convolution", "multiplicative functions", "Dirichlet characters"]
   },
   {
     "id": "ann-apply",
     "proofId": "fermat-two-squares-oq-04",
     "range": {
       "startLine": 73,
-      "endLine": 80
+      "endLine": 84
     },
     "type": "technique",
     "title": "Unfolding the Convolution to a Divisor Sum",
-    "content": "`coe_zeta_mul_apply` is the key identity (ζ * f) n = ∑_{d∣n} f d: convolution with ζ is precisely the divisor sum. The auxiliary `toArithmeticFunction` wrapper sends 0 ↦ 0 and otherwise applies χ₄; on the nonzero divisors d of n it equals χ₄(d), so `simp` with the divisor positivity `Nat.pos_of_mem_divisors` collapses it to δ(n) = ∑_{d∣n} χ₄(d)."
+    "content": "`jacobiSum_apply` (via `coe_zeta_mul_apply`) is the key identity (ζ * f) n = ∑_{d∣n} f d: convolution with ζ is precisely the divisor sum. The auxiliary `toArithmeticFunction` wrapper sends 0 ↦ 0 and otherwise applies χ₄; on the nonzero divisors d of n it equals χ₄(d), so `simp` with the divisor positivity `Nat.pos_of_mem_divisors` collapses it to δ(n) = ∑_{d∣n} χ₄(d).",
+    "mathContext": "$(\\zeta * f)(n) = \\sum_{d \\mid n} f(d)$; specialized to $f = \\chi_4$ this gives $\\delta(n) = \\sum_{d \\mid n} \\chi_4(d)$ for $n \\neq 0$.",
+    "significance": "technical",
+    "relatedConcepts": ["Dirichlet convolution", "divisor sum", "arithmetic function evaluation"],
+    "prerequisites": ["Dirichlet convolution", "divisors in Lean 4/Mathlib"]
   },
   {
     "id": "ann-prime-pow",
@@ -30,18 +38,26 @@
     },
     "type": "key-step",
     "title": "Prime Powers Give a Geometric Series",
-    "content": "On a prime power the divisors are 1, p, p², …, pᵏ, so `Nat.sum_divisors_prime_pow` rewrites the divisor sum as ∑_{i=0}^{k} χ₄(pⁱ). Because χ₄ is multiplicative, χ₄(pⁱ) = χ₄(p)ⁱ (via `Nat.cast_pow` and `map_pow`), exposing the geometric series ∑_{i≤k} χ₄(p)ⁱ. The entire prime-power behaviour of δ is now governed by the single value χ₄(p) ∈ {0, 1, -1}."
+    "content": "On a prime power the divisors are 1, p, p², …, pᵏ, so `Nat.sum_divisors_prime_pow` rewrites the divisor sum as ∑_{i=0}^{k} χ₄(pⁱ). Because χ₄ is multiplicative, χ₄(pⁱ) = χ₄(p)ⁱ (via `Nat.cast_pow` and `map_pow`), exposing the geometric series ∑_{i≤k} χ₄(p)ⁱ. The entire prime-power behaviour of δ is now governed by the single value χ₄(p) ∈ {0, 1, -1}.",
+    "mathContext": "$\\delta(p^k) = \\sum_{i=0}^{k} \\chi_4(p^i) = \\sum_{i=0}^{k} \\chi_4(p)^i$ — a geometric series whose ratio $\\chi_4(p) \\in \\{0, 1, -1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "completely multiplicative character", "prime powers", "divisors of a prime power"],
+    "prerequisites": ["geometric series", "multiplicativity", "prime factorization"]
   },
   {
     "id": "ann-dichotomy",
     "proofId": "fermat-two-squares-oq-04",
     "range": {
       "startLine": 103,
-      "endLine": 140
+      "endLine": 144
     },
     "type": "key-step",
     "title": "The Prime-Power Positivity Dichotomy",
-    "content": "Splitting on χ₄(p) via `χ₄_nat_eq_if_mod_four` gives three regimes: for p = 2 the series collapses to the single term 1 (δ(2ᵏ) = 1); for p ≡ 1 (mod 4) every term is 1, so δ(pᵏ) = k+1; for p ≡ 3 (mod 4) the series alternates, and `neg_one_geom_sum` evaluates ∑_{i≤k} (-1)ⁱ = [k even]. Combining, 0 < δ(pᵏ) ⇔ (p ≡ 3 mod 4 → k even). This single inequality is the atom from which the global representability criterion is reassembled. The `omega` calls discharge the residue bookkeeping (e.g. p % 2 = 0 forces p % 4 ≠ 3)."
+    "content": "Splitting on χ₄(p) via `χ₄_nat_eq_if_mod_four` gives three regimes: for p = 2 the series collapses to the single term 1 (δ(2ᵏ) = 1); for p ≡ 1 (mod 4) every term is 1, so δ(pᵏ) = k+1; for p ≡ 3 (mod 4) the series alternates, and `neg_one_geom_sum` evaluates ∑_{i≤k} (-1)ⁱ = [k even]. Combining, 0 < δ(pᵏ) ⇔ (p ≡ 3 mod 4 → k even). This single inequality is the atom from which the global representability criterion is reassembled. The `omega` calls discharge the residue bookkeeping (e.g. p % 2 = 0 forces p % 4 ≠ 3).",
+    "mathContext": "$\\delta(p^k) = 1$ if $p = 2$; $= k+1$ if $p \\equiv 1$; $= \\tfrac{1+(-1)^k}{2} = [k\\text{ even}]$ if $p \\equiv 3 \\pmod 4$. Hence $\\delta(p^k) > 0 \\iff \\big(p \\equiv 3 \\Rightarrow k\\text{ even}\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["alternating geometric sum", "residues mod 4", "Iverson bracket", "case analysis"],
+    "prerequisites": ["modular arithmetic", "geometric and alternating series", "case analysis"]
   },
   {
     "id": "ann-bridge",
@@ -52,7 +68,11 @@
     },
     "type": "concept",
     "title": "From Character Sum to Representability",
-    "content": "`multiplicative_factorization` writes δ(n) as the product ∏_{p∣n} δ(p^{vₚ(n)}). Every factor is nonnegative (the geometric-sum lemma), so the product is strictly positive iff every factor is — proved by `Finset.prod_pos` one way and `Finset.prod_eq_zero` the other. By the prime-power dichotomy this is exactly the condition that every prime q ≡ 3 (mod 4) appears to an even power, which `Nat.eq_sq_add_sq_iff` identifies with n being a sum of two squares. The result, δ(n) > 0 ⇔ ∃ x y, n = x² + y², is the qualitative shadow of Jacobi's theorem: the SIGN of the character sum is a complete detector of representability, with no Gaussian-integer counting."
+    "content": "`multiplicative_factorization` writes δ(n) as the product ∏_{p∣n} δ(p^{vₚ(n)}). Every factor is nonnegative (the geometric-sum lemma), so the product is strictly positive iff every factor is — proved by `Finset.prod_pos` one way and `Finset.prod_eq_zero` the other. By the prime-power dichotomy this is exactly the condition that every prime q ≡ 3 (mod 4) appears to an even power, which `Nat.eq_sq_add_sq_iff` identifies with n being a sum of two squares. The result, δ(n) > 0 ⇔ ∃ x y, n = x² + y², is the qualitative shadow of Jacobi's theorem: the SIGN of the character sum is a complete detector of representability, with no Gaussian-integer counting.",
+    "mathContext": "$\\delta(n) = \\prod_{p \\mid n} \\delta(p^{v_p(n)}) > 0 \\iff$ every prime $q \\equiv 3 \\pmod 4$ has $v_q(n)$ even $\\iff \\exists x, y,\\ n = x^2 + y^2$.",
+    "significance": "key",
+    "relatedConcepts": ["sum of two squares theorem", "multiplicative factorization", "Fermat's two-square theorem", "Finset.prod_pos"],
+    "prerequisites": ["multiplicative functions", "sum of two squares theorem", "prime factorization"]
   },
   {
     "id": "ann-prime-values",
@@ -63,6 +83,10 @@
     },
     "type": "concept",
     "title": "Jacobi's Count for Primes",
-    "content": "For a prime, the divisors are just 1 and p, so δ(p) = χ₄(1) + χ₄(p) = 1 + χ₄(p). Hence δ(p) = 2 when p ≡ 1 (mod 4), matching r₂(p) = 4·2 = 8 — the eight representations (±a, ±b), (±b, ±a) of the unique unordered pair {a, b}. And δ(p) = 0 when p ≡ 3 (mod 4), matching r₂(p) = 0. These are the smallest nontrivial instances of the full Jacobi identity r₂(n) = 4 δ(n)."
+    "content": "For a prime, the divisors are just 1 and p, so δ(p) = χ₄(1) + χ₄(p) = 1 + χ₄(p). Hence δ(p) = 2 when p ≡ 1 (mod 4), matching r₂(p) = 4·2 = 8 — the eight representations (±a, ±b), (±b, ±a) of the unique unordered pair {a, b}. And δ(p) = 0 when p ≡ 3 (mod 4), matching r₂(p) = 0. These are the smallest nontrivial instances of the full Jacobi identity r₂(n) = 4 δ(n).",
+    "mathContext": "$\\delta(p) = 1 + \\chi_4(p)$: $\\delta(p) = 2$ for $p \\equiv 1$ (so $r_2(p) = 4\\cdot 2 = 8$), $\\delta(p) = 0$ for $p \\equiv 3 \\pmod 4$. Special cases of Jacobi's $r_2(n) = 4\\,\\delta(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of two squares function r₂", "Jacobi two-square theorem", "Gaussian integers", "Dirichlet character"],
+    "prerequisites": ["Fermat's two-square theorem", "Dirichlet characters"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `fermat-two-squares-oq-04`

`meta.json` is already richly structured (overview, conclusion, sections, references). The gap was in **annotations**: the 6 annotations carried only `title`/`content`, but the page renders `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Changes (annotations.json)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 6 annotations — covering the divisor-character sum $\delta = \zeta * \chi_4$, the prime-power geometric series, the positivity dichotomy, the bridge to representability, and Jacobi's prime counts.
- Tightened two stale line ranges to match the current Lean declarations.
- annotations.json 4.5 KB → ~7.7 KB; meta.json unchanged.

### Verification
- Valid JSON; all 6 annotations have `mathContext`, `significance`, `relatedConcepts`.
- `pnpm build` passes.
- No axiom/status changes.