### PR TITLE
Enrich Fibonacci–Lucas doubling (F_2n = F_n·L_n): annotation depth

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-03/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 3, "endLine": 35 },
     "type": "context",
     "title": "From Difference of Squares to the Fibonacci–Lucas Product",
-    "content": "**Module framing.** The open question asks for the doubled-index identities $F_{2n+1} = F_{n+1}^2 + F_n^2$ and the *symmetric* even form $F_{2n} = F_{n+1}^2 - F_{n-1}^2$. The odd case is Mathlib's `Nat.fib_two_mul_add_one`. The new content is reading the even case as a genuine **difference of two squares that factors**: $F_{n+1}^2 - F_{n-1}^2 = (F_{n+1}-F_{n-1})(F_{n+1}+F_{n-1}) = F_n \\cdot L_n$, where $L_n = F_{n-1}+F_{n+1}$ is the $n$-th **Lucas number**. This is the classical Fibonacci–Lucas doubling identity $F_{2n} = F_n L_n$. Lucas numbers appear nowhere in the Fibonacci gallery, so they are introduced here."
+    "content": "**Module framing.** The open question asks for the doubled-index identities $F_{2n+1} = F_{n+1}^2 + F_n^2$ and the *symmetric* even form $F_{2n} = F_{n+1}^2 - F_{n-1}^2$. The odd case is Mathlib's `Nat.fib_two_mul_add_one`. The new content is reading the even case as a genuine **difference of two squares that factors**: $F_{n+1}^2 - F_{n-1}^2 = (F_{n+1}-F_{n-1})(F_{n+1}+F_{n-1}) = F_n \\cdot L_n$, where $L_n = F_{n-1}+F_{n+1}$ is the $n$-th **Lucas number**. This is the classical Fibonacci–Lucas doubling identity $F_{2n} = F_n L_n$. Lucas numbers appear nowhere in the Fibonacci gallery, so they are introduced here.",
+    "mathContext": "$F_{2n} = F_{n+1}^2 - F_{n-1}^2 = (F_{n+1}-F_{n-1})(F_{n+1}+F_{n-1}) = F_n \\, L_n$, with $L_n = F_{n-1}+F_{n+1}$.",
+    "significance": "context",
+    "relatedConcepts": ["Fibonacci numbers", "Lucas numbers", "difference of squares", "doubling identities"],
+    "prerequisites": ["Fibonacci recurrence", "factoring a difference of squares"]
   },
   {
     "id": "ann-fiboq0303-2",
@@ -13,7 +17,11 @@
     "range": { "startLine": 39, "endLine": 51 },
     "type": "definition",
     "title": "Lucas Numbers and Their Recurrence",
-    "content": "**Definition.** `lucas` is the companion sequence $L_0 = 2$, $L_1 = 1$, $L_{n+2} = L_n + L_{n+1}$, starting $2, 1, 3, 4, 7, 11, 18, \\dots$. It shares the Fibonacci recurrence but with different seeds. The defining step `lucas_add_two` ($L_{n+2} = L_n + L_{n+1}$) holds by `rfl`, as do the base values $L_0 = 2$, $L_1 = 1$."
+    "content": "**Definition.** `lucas` is the companion sequence $L_0 = 2$, $L_1 = 1$, $L_{n+2} = L_n + L_{n+1}$, starting $2, 1, 3, 4, 7, 11, 18, \\dots$. It shares the Fibonacci recurrence but with different seeds. The defining step `lucas_add_two` ($L_{n+2} = L_n + L_{n+1}$) holds by `rfl`, as do the base values $L_0 = 2$, $L_1 = 1$.",
+    "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$ — same recurrence as $F$, different seeds: $2, 1, 3, 4, 7, 11, 18, \\dots$",
+    "significance": "supporting",
+    "relatedConcepts": ["Lucas numbers", "linear recurrence", "companion sequence", "Fibonacci numbers"],
+    "prerequisites": ["recurrence relations", "definitional equality (rfl) in Lean"]
   },
   {
     "id": "ann-fiboq0303-3",
@@ -21,7 +29,11 @@
     "range": { "startLine": 53, "endLine": 74 },
     "type": "key-step",
     "title": "The Bridge L_{n+1} = F_n + F_{n+2} by Two-Step Induction",
-    "content": "**Lucas via Fibonacci.** The key lemma `lucas_succ_eq_fib_add_fib` proves $L_{n+1} = F_n + F_{n+2}$ (equivalently $L_m = F_{m-1}+F_{m+1}$) by `Nat.twoStepInduction`: both sides satisfy $x_{n+2}=x_n+x_{n+1}$ and agree at $n=0,1$ (checked by `decide`), so they coincide. In the step, `lucas_add_two` supplies $L_{n+3} = L_{n+1}+L_{n+2}$ and the two induction hypotheses relate the Lucas terms to Fibonacci sums; `omega` closes the linear identity given the recurrences $F_{n+2}=F_n+F_{n+1}$, $F_{n+3}=F_{n+1}+F_{n+2}$, $F_{n+4}=F_{n+2}+F_{n+3}$. A subtlety: `Nat.twoStepInduction` returns the second hypothesis with un-normalised indices ($F_{n+1+2}$), which `omega` would atomise separately from $F_{n+3}$ — restating it in canonical $n+3$ form first is what lets `omega` share atoms and close."
+    "content": "**Lucas via Fibonacci.** The key lemma `lucas_succ_eq_fib_add_fib` proves $L_{n+1} = F_n + F_{n+2}$ (equivalently $L_m = F_{m-1}+F_{m+1}$) by `Nat.twoStepInduction`: both sides satisfy $x_{n+2}=x_n+x_{n+1}$ and agree at $n=0,1$ (checked by `decide`), so they coincide. In the step, `lucas_add_two` supplies $L_{n+3} = L_{n+1}+L_{n+2}$ and the two induction hypotheses relate the Lucas terms to Fibonacci sums; `omega` closes the linear identity given the recurrences $F_{n+2}=F_n+F_{n+1}$, $F_{n+3}=F_{n+1}+F_{n+2}$, $F_{n+4}=F_{n+2}+F_{n+3}$. A subtlety: `Nat.twoStepInduction` returns the second hypothesis with un-normalised indices ($F_{n+1+2}$), which `omega` would atomise separately from $F_{n+3}$ — restating it in canonical $n+3$ form first is what lets `omega` share atoms and close.",
+    "mathContext": "$L_{n+1} = F_n + F_{n+2}$, i.e. $L_m = F_{m-1} + F_{m+1}$ — the standard expression of a Lucas number through neighbouring Fibonacci numbers.",
+    "significance": "key",
+    "relatedConcepts": ["two-step induction", "Lucas–Fibonacci relation", "linear recurrence", "omega tactic"],
+    "prerequisites": ["two-step / strong induction", "Fibonacci recurrence", "omega linear arithmetic"]
   },
   {
     "id": "ann-fiboq0303-4",
@@ -29,7 +41,11 @@
     "range": { "startLine": 76, "endLine": 100 },
     "type": "key-step",
     "title": "The Fibonacci–Lucas Doubling Identity F_{2n} = F_n · L_n",
-    "content": "**The factorisation made explicit.** `fib_two_mul_add_two_eq_fib_mul_lucas` rewrites Mathlib's even-doubling product $F_{2n+2} = F_{n+1}(2F_n + F_{n+1})$ and recognises the second factor as $F_n + F_{n+2} = L_{n+1}$, giving $F_{2n+2} = F_{n+1} L_{n+1}$; `ring` finishes after substituting $F_{n+2}=F_n+F_{n+1}$. Reindexing $m=n+1$ yields the headline identity `fib_two_mul_eq_fib_mul_lucas`: $F_{2m} = F_m L_m$ for $m \\ge 1$. The odd companion $F_{2n+1}=F_{n+1}^2+F_n^2$ is recorded alongside for the pair named in the question."
+    "content": "**The factorisation made explicit.** `fib_two_mul_add_two_eq_fib_mul_lucas` rewrites Mathlib's even-doubling product $F_{2n+2} = F_{n+1}(2F_n + F_{n+1})$ and recognises the second factor as $F_n + F_{n+2} = L_{n+1}$, giving $F_{2n+2} = F_{n+1} L_{n+1}$; `ring` finishes after substituting $F_{n+2}=F_n+F_{n+1}$. Reindexing $m=n+1$ yields the headline identity `fib_two_mul_eq_fib_mul_lucas`: $F_{2m} = F_m L_m$ for $m \\ge 1$. The odd companion $F_{2n+1}=F_{n+1}^2+F_n^2$ is recorded alongside for the pair named in the question.",
+    "mathContext": "$F_{2n+2} = F_{n+1}(2F_n + F_{n+1}) = F_{n+1} L_{n+1}$, hence $F_{2m} = F_m L_m$ ($m \\ge 1$); odd companion $F_{2n+1} = F_{n+1}^2 + F_n^2$.",
+    "significance": "key",
+    "relatedConcepts": ["doubling formula", "Fibonacci–Lucas product", "reindexing", "ring normalization"],
+    "prerequisites": ["Fibonacci doubling identities", "algebraic manipulation"]
   },
   {
     "id": "ann-fiboq0303-5",
@@ -37,6 +53,10 @@
     "range": { "startLine": 101, "endLine": 142 },
     "type": "key-step",
     "title": "Difference-of-Squares ⇒ Product Bridge and Numerical Checks",
-    "content": "**Tying the two readings together.** `fib_sq_sub_sq_eq_fib_mul_lucas` proves over $\\mathbb{Z}$ that $F_{n+2}^2 - F_n^2 = F_{n+1}\\,L_{n+1}$ — the even-index difference of two squares *is* the Lucas product — by combining the additive form $F_{2n+2}+F_n^2 = F_{n+2}^2$ with the product form via `linarith`. `fib_two_mul_symmetric_diff_sq` then states the question's exact symmetric identity $F_{2m} = F_{m+1}^2 - F_{m-1}^2$ ($m\\ge1$, over $\\mathbb{Z}$, no truncated subtraction). The `decide` checks ($L_5=11$, $F_{10}=F_5 L_5=55$, $F_{12}=F_6 L_6=144$) use kernel reduction, not `native_decide`, so the entry is $0$-axiom."
+    "content": "**Tying the two readings together.** `fib_sq_sub_sq_eq_fib_mul_lucas` proves over $\\mathbb{Z}$ that $F_{n+2}^2 - F_n^2 = F_{n+1}\\,L_{n+1}$ — the even-index difference of two squares *is* the Lucas product — by combining the additive form $F_{2n+2}+F_n^2 = F_{n+2}^2$ with the product form via `linarith`. `fib_two_mul_symmetric_diff_sq` then states the question's exact symmetric identity $F_{2m} = F_{m+1}^2 - F_{m-1}^2$ ($m\\ge1$, over $\\mathbb{Z}$, no truncated subtraction). The `decide` checks ($L_5=11$, $F_{10}=F_5 L_5=55$, $F_{12}=F_6 L_6=144$) use kernel reduction, not `native_decide`, so the entry is $0$-axiom.",
+    "mathContext": "$F_{n+2}^2 - F_n^2 = F_{n+1} L_{n+1}$ over $\\mathbb{Z}$; symmetric form $F_{2m} = F_{m+1}^2 - F_{m-1}^2$. Sanity checks: $L_5 = 11$, $F_{10} = F_5 L_5 = 55$, $F_{12} = F_6 L_6 = 144$.",
+    "significance": "supporting",
+    "relatedConcepts": ["difference of squares", "integer identities", "linarith", "decide vs native_decide"],
+    "prerequisites": ["integer arithmetic over ℤ", "linarith", "kernel reduction (decide)"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `fibonacci-identities-oq-03-oq-03`

`meta.json` is already richly structured (overview, conclusion, sections, references). The gap was in **annotations**: the 5 annotations carried only `title`/`content`, but the page renders `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Changes (annotations.json)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations — covering the difference-of-squares factoring, the Lucas-number definition, the $L_{n+1}=F_n+F_{n+2}$ bridge, the doubling identity $F_{2n}=F_nL_n$, and the symmetric difference-of-squares form.
- annotations.json 4.2 KB → ~7 KB; meta.json unchanged.

### Verification
- Valid JSON; all 5 annotations have `mathContext`, `significance`, `relatedConcepts`.
- `pnpm build` passes.
- No axiom/status changes (entry remains 0-axiom; `decide`, not `native_decide`).