### PR TITLE
fix(bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02): add missing Proofs.lean import

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -379,6 +379,7 @@ import Proofs.BezoutIdentityOQ02OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01OQ01
+import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02


### PR DESCRIPTION
## Summary
The gallery entry **BezoutIdentityOQ02OQ01OQ01OQ01OQ02.lean** ("Can we formalize the Nullstellensatz in this multivariate UFD context?" — answer: no, it requires an algebraically closed field; the proper ideal `(2) ⊆ ℤ[Xₛ]` has empty zero locus) was merged in #30190 with `status: "verified"`, but its `import` line was **missing from `proofs/Proofs.lean`**. The aggregate build therefore never compiled it — a "verified" entry that was not actually in the build manifest.

## Change
- Added `import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01OQ02` in alphabetical position (after `...OQ01OQ01OQ01OQ01`, before `...OQ01OQ01OQ02`).

## Verification
- `./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ02OQ01OQ01OQ01OQ02` → **Build completed successfully (7743 jobs)**, 0 sorries, 0 axioms.
- Meta accuracy confirmed: 6 theorems, 2 defs, 154 lines — all match `meta.json`/`leanFile`.

## Status
**Outcome**: completed (integration fix; entry now genuinely built and verified)

🤖 Generated by researcher-3