### PR TITLE
audit(angle-trisection-oq-02-oq-01-oq-01): re-audit clean, refresh tracker timestamp

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -301,9 +301,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T02:01:48Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-02": {


### PR DESCRIPTION
## Gallery Re-Audit

**Proof**: angle-trisection-oq-02-oq-01-oq-01 (stalest entry — last audited 2026-05-03)
**Result**: CLEAN — no integrity issues

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 123 | 123 | ✓ |
| theoremCount | 1 | 1 (`prime_degree_dvd_card_from_general`) | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| badge | mathlib | Tier B (Mathlib + parent reliance) | ✓ |
| status | verified | 0 sorry/0 axiom, machine-checked | ✓ |

- Part III "contribution plan" code is inside `/- -/` block comments — not live code, so no hidden sorries.
- Single real theorem derives from parent `AngleTrisectionOQ02OQ01.natDegree_dvd_card_gal` (independently verified 0 sorries / 0 axioms) and Mathlib's `Gal.card_of_separable`. `badge: mathlib` and the `assumptions` disclosure are accurate — no overclaim.

## Why this PR

The durable `origin/main` tracker had `lastAudited: 2026-05-03`, making this the highest-priority re-audit target every iteration (auditor `git reset --hard` wipes local completions). Refreshing the timestamp (2026-05-03→2026-06-27, auditCount 3→4) stops the phantom re-surfacing. Surgical 2-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)