### PR TITLE
Fix: sync erdos-632 leanFile snapshot (sorries 5→2, lineCount 260→308)

### DIFF
--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -180,12 +180,12 @@
       "Function"
     ],
     "namespace": "Erdos632",
-    "lineCount": 260,
+    "lineCount": 308,
     "axiomCount": 1,
     "theoremCount": 11,
     "definitionCount": 15,
     "path": "Proofs/Erdos632Problem.lean",
-    "sorries": 5,
+    "sorries": 2,
     "additionalFiles": [
       "Proofs/Erdos632ProblemAristotle.lean",
       "Proofs/Erdos632Aristotle.lean"
@@ -235,5 +235,5 @@
       "description": "Related Erdős problem sharing themes: counterexample, disproved, graph-theory"
     }
   ],
-  "sorries": 5
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Sync the stale `leanFile` snapshot and top-level `sorries` count for **erdos-632** to match the current Lean source.

## Evidence

Commit #28876 ("discharge 3 of 5 sorries") updated `meta.sorries` (→2), `meta.lineCount` (→308) and the actual `Proofs/Erdos632Problem.lean`, but left the snapshot fields at their pre-commit values.

Verified against `proofs/Proofs/Erdos632Problem.lean` on current main:
- real `sorry` tactics: **2** (lines 98, 116)
- line count: **308**
- `^axiom ` declarations: **1** (unchanged)
- theorems/lemmas: **11** (unchanged)

**Before**: `leanFile.sorries=5`, `leanFile.lineCount=260`, top-level `sorries=5`
**After**: `leanFile.sorries=2`, `leanFile.lineCount=308`, top-level `sorries=2`

All now agree with `meta.sorries=2` / `meta.lineCount=308` and the actual file. No Lean code changed; metadata-only.

---
Automated fix by lean-mechanic agent.