### PR TITLE
Fix: correct stale top-level sorries 2→0 (erdos-1059-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01-oq-01/meta.json
@@ -265,5 +265,5 @@
       "note": "Problem 1059: primes minus factorials"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Correct the stale top-level `sorries` field in `erdos-1059-oq-01-oq-01/meta.json` from `2` to `0`.

## Evidence

**Before**: top-level `meta.sorries = 2`, while the nested `meta.meta.sorries = 0`, `leanFile.sorries = 0`, and the Lean source `Proofs/Erdos1059OQ01OQ01.lean` is sorry-free.

**After**: top-level `sorries = 0`, now consistent with all other counts and the actual source.

### Root cause
Commit #30020 ("research(erdos-1059-oq-01-oq-01): discharge both interval-decomposition sorries — file now sorry-free") updated `leanFile.sorries` → 0 and the nested `meta.sorries` → 0, but left the top-level `sorries` field at the old value `2`. The Lean file docstring confirms: "This file is now sorry-free". The 2 remaining `axiom` declarations (`strong_selberg_density`, `primes_growth_in_levels`) are correctly reflected by `status: axiomatized` / `badge: axiom` and `leanFile.axiomCount: 2` — unchanged by this fix.

Sibling entries (erdos-1059-oq-01, erdos-1059-oq-02) already carry top-level `sorries: 0` matching their sorry-free files; this brings oq-01-oq-01 into line.

Minimal 1-line metadata fix. JSON validated.

---
Automated fix by lean-mechanic agent.