### PR TITLE
audit(angle-trisection-oq-01): correct theoremCount 44→40

### DIFF
--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "assumptions": "One assumption: `Lean.ofReduceBool`. 0 `axiom` declarations, 0 sorries. The presented Fermat-primality facts (`prime_257`, `prime_65537`) and the regular-n-gon constructibility theorems (`triangle_constructible`, `pentagon_constructible`, `heptadecagon_constructible`, and the non-constructibility witnesses) discharge their decidable cores by `native_decide`. Under the gallery convention (CLAUDE.md), a presented result discharged by `native_decide` depends on `Lean.ofReduceBool` (the kernel trusts the compiler's reduction), so the entry is `axiomatized` with `axiomCount` 1; `leanFile.axiomCount` stays 0 (no literal `axiom` declarations).",
     "lineCount": 366,
-    "theoremCount": 44,
+    "theoremCount": 40,
     "definitionCount": 3,
     "originalContributions": [
       "prime_dvd_pow_two_eq_two: any prime dividing 2^n equals 2",
@@ -57,7 +57,7 @@
     ]
   },
   "conclusion": {
-    "summary": "The minimal polynomial degree criterion for non-constructibility is fully formalized: d has an odd prime factor ↔ d is not constructible. Regular polygon constructibility is classified for n=3..20 and all 5 known Fermat primes are verified. 44 theorems, 0 axioms, 0 sorries.",
+    "summary": "The minimal polynomial degree criterion for non-constructibility is fully formalized: d has an odd prime factor ↔ d is not constructible. Regular polygon constructibility is classified for n=3..20 and all 5 known Fermat primes are verified. 40 theorems, 0 axioms, 0 sorries.",
     "implications": "This formalization provides the theoretical foundation for understanding compass-and-straightedge impossibility beyond angle trisection: cube root doubling (degree 3), regular heptagon (degree 6 = 2·3), etc. The Fermat prime criterion is the gateway to understanding which classical problems are impossible. The proof technique — converting a geometric impossibility claim into an arithmetic divisibility contradiction — is widely reusable: any problem reducible to a field extension of degree with an odd prime factor is immediately non-constructible.",
     "openQuestions": [
       "Prove there are infinitely many (or finitely many) Fermat primes — a major open problem",
@@ -70,7 +70,7 @@
     "namespace": "AngleTrisectionOQ01",
     "lineCount": 366,
     "axiomCount": 0,
-    "theoremCount": 44,
+    "theoremCount": 40,
     "definitionCount": 3,
     "path": "Proofs/AngleTrisectionOQ01.lean",
     "sorries": 0

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -284,9 +284,10 @@
       "result": "clean"
     },
     "angle-trisection-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "auditCount": 5,
+      "issues": [],
+      "lastAudited": "2026-06-27T02:09:19Z",
+      "result": "issues-fixed"
     },
     "angle-trisection-oq-02": {
       "auditCount": 6,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: angle-trisection-oq-01 (Minimal Polynomial Degree for Non-Constructibility)

### Verified accurate
- status: `axiomatized`, badge: `axiom`
- axiomCount: 1 — native_decide (21 sites) → `Lean.ofReduceBool`, correctly disclosed in `assumptions`; `leanFile.axiomCount` 0 (no literal `axiom` declarations) ✓
- sorries: 0 ✓
- definitionCount: 3 ✓
- lineCount: 366 ✓
- 0 True-stubs ✓

### Issue fixed
**theoremCount overstated by 4**: meta claimed **44** theorems but the Lean source (`proofs/Proofs/AngleTrisectionOQ01.lean`) contains exactly **40** `theorem` declarations (verified by enumeration; 0 `lemma`, no indented/protected variants).

Corrected `44 → 40` in:
- `meta.theoremCount`
- `leanFile.theoremCount`
- `conclusion.summary` ("44 theorems" → "40 theorems")

Also refreshed the `audit-tracker.json` entry (`issues-fixed`, timestamp) to break the stalest-re-audit re-queue.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)