### PR TITLE
Enrich Fermat two-squares mod-4 obstruction (oq-05): annotation depth

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-05/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-05/annotations.json
@@ -8,7 +8,20 @@
     },
     "type": "concept",
     "title": "The Core Obstruction in ZMod 4",
-    "content": "Every element of ZMod 4 squares to 0 or 1 (the squares are 0²=0, 1²=1, 2²=0, 3²=1). Hence a sum of two squares lies in {0, 1, 2} and can never equal 3. The lemma `zmod_four_sq_add_sq_ne_three` proves `∀ a b : ZMod 4, a² + b² ≠ 3` by `revert a b; decide`, an exhaustive kernel check over all 16 pairs. This single finite computation is the entire arithmetic content of the necessary direction of Fermat's two-squares theorem."
+    "content": "Every element of ZMod 4 squares to 0 or 1 (the squares are 0²=0, 1²=1, 2²=0, 3²=1). Hence a sum of two squares lies in {0, 1, 2} and can never equal 3. The lemma `zmod_four_sq_add_sq_ne_three` proves `∀ a b : ZMod 4, a² + b² ≠ 3` by `revert a b; decide`, an exhaustive kernel check over all 16 pairs. This single finite computation is the entire arithmetic content of the necessary direction of Fermat's two-squares theorem.",
+    "mathContext": "In $\\mathbb{Z}/4$, $a^2 \\in \\{0,1\\}$, so $a^2 + b^2 \\in \\{0,1,2\\} \\not\\ni 3$ — checked by `decide` over all $16$ pairs (kernel reduction, axiom-free).",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues mod 4",
+      "sum of two squares",
+      "ZMod",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "quadratic residues",
+      "decidability"
+    ]
   },
   {
     "id": "ann-int-transport",
@@ -19,7 +32,19 @@
     },
     "type": "technique",
     "title": "Transporting Congruences into ZMod via Casts",
-    "content": "To use the finite ZMod 4 check on an integer congruence, `ZMod.intCast_eq_intCast_iff` rewrites `a² + b² ≡ 3 [ZMOD 4]` as the equality `(↑(a²+b²) : ZMod 4) = ↑3`, and `push_cast` distributes the ring homomorphism over `+` and `^` to expose `(↑a)² + (↑b)²`. The only friction is that the modulus literal is a Nat in `ZMod 4` but an Int in `[ZMOD 4]`; `exact_mod_cast` bridges the two. The statement `int_sq_add_sq_not_three_mod_four` is phrased purely about the equation, making clear that nothing about a target n is used beyond its residue."
+    "content": "To use the finite ZMod 4 check on an integer congruence, `ZMod.intCast_eq_intCast_iff` rewrites `a² + b² ≡ 3 [ZMOD 4]` as the equality `(↑(a²+b²) : ZMod 4) = ↑3`, and `push_cast` distributes the ring homomorphism over `+` and `^` to expose `(↑a)² + (↑b)²`. The only friction is that the modulus literal is a Nat in `ZMod 4` but an Int in `[ZMOD 4]`; `exact_mod_cast` bridges the two. The statement `int_sq_add_sq_not_three_mod_four` is phrased purely about the equation, making clear that nothing about a target n is used beyond its residue.",
+    "mathContext": "$a^2+b^2 \\equiv 3 \\pmod 4 \\iff (\\bar a)^2 + (\\bar b)^2 = \\bar 3$ in $\\mathbb{Z}/4$, via `ZMod.intCast_eq_intCast_iff` and `push_cast`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ring homomorphism",
+      "ZMod casts",
+      "integer congruences",
+      "push_cast"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "ring homomorphisms in Lean 4"
+    ]
   },
   {
     "id": "ann-nat-form",
@@ -30,7 +55,19 @@
     },
     "type": "concept",
     "title": "Natural-Number Form",
-    "content": "`not_sq_add_sq_of_mod_four_eq_three` states the obstruction in the form most directly comparable to Fermat: if n % 4 = 3 then n is not a sum of two natural-number squares. The hypothesis is moved into ZMod 4 via `ZMod.natCast_eq_natCast_iff'`, whose side condition `(x²+y²) % 4 = 3 % 4` is discharged by `omega`."
+    "content": "`not_sq_add_sq_of_mod_four_eq_three` states the obstruction in the form most directly comparable to Fermat: if n % 4 = 3 then n is not a sum of two natural-number squares. The hypothesis is moved into ZMod 4 via `ZMod.natCast_eq_natCast_iff'`, whose side condition `(x²+y²) % 4 = 3 % 4` is discharged by `omega`.",
+    "mathContext": "$n \\equiv 3 \\pmod 4 \\Rightarrow \\neg\\,\\exists x, y \\in \\mathbb{N},\\ n = x^2 + y^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sum of two squares",
+      "natural-number casts",
+      "ZMod",
+      "omega tactic"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "ℕ → ZMod casting"
+    ]
   },
   {
     "id": "ann-biconditional",
@@ -41,7 +78,19 @@
     },
     "type": "concept",
     "title": "Assembling Fermat's Biconditional",
-    "content": "Mathlib's `Nat.Prime.sq_add_sq` supplies the sufficient direction (p % 4 ≠ 3 → ∃ a b, a²+b² = p). Combining it with the obstruction yields `prime_sq_add_sq_iff_mod_four_ne_three`: a prime p is a sum of two squares iff p % 4 ≠ 3. For odd primes p % 4 ∈ {1,3}, so `odd_prime_sq_add_sq_iff_mod_four_eq_one` collapses this to the classical statement p = x² + y² ↔ p ≡ 1 (mod 4), closed by `omega` after unfolding oddness."
+    "content": "Mathlib's `Nat.Prime.sq_add_sq` supplies the sufficient direction (p % 4 ≠ 3 → ∃ a b, a²+b² = p). Combining it with the obstruction yields `prime_sq_add_sq_iff_mod_four_ne_three`: a prime p is a sum of two squares iff p % 4 ≠ 3. For odd primes p % 4 ∈ {1,3}, so `odd_prime_sq_add_sq_iff_mod_four_eq_one` collapses this to the classical statement p = x² + y² ↔ p ≡ 1 (mod 4), closed by `omega` after unfolding oddness.",
+    "mathContext": "$p = x^2 + y^2 \\iff p \\not\\equiv 3 \\pmod 4$ (sufficiency = Mathlib `Nat.Prime.sq_add_sq`); for odd primes this collapses to $\\iff p \\equiv 1 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fermat's two-square theorem",
+      "prime numbers",
+      "biconditional",
+      "Nat.Prime.sq_add_sq"
+    ],
+    "prerequisites": [
+      "Fermat's theorem on sums of two squares",
+      "prime residues mod 4"
+    ]
   },
   {
     "id": "ann-witnesses",
@@ -52,6 +101,16 @@
     },
     "type": "example",
     "title": "Concrete Witnesses",
-    "content": "The smallest obstruction is 3; 7 and the prime 11 are further examples ≡ 3 (mod 4). By contrast 5 = 1² + 2² and 13 = 2² + 3² are ≡ 1 (mod 4) and decompose, witnessing both directions of the biconditional on small inputs."
+    "content": "The smallest obstruction is 3; 7 and the prime 11 are further examples ≡ 3 (mod 4). By contrast 5 = 1² + 2² and 13 = 2² + 3² are ≡ 1 (mod 4) and decompose, witnessing both directions of the biconditional on small inputs.",
+    "mathContext": "$3, 7, 11 \\equiv 3 \\pmod 4$ are non-representable; $5 = 1^2 + 2^2$ and $13 = 2^2 + 3^2$ are $\\equiv 1 \\pmod 4$ — both directions on small inputs.",
+    "significance": "context",
+    "relatedConcepts": [
+      "sum of two squares",
+      "worked examples",
+      "decidability"
+    ],
+    "prerequisites": [
+      "sum of two squares theorem"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `fermat-two-squares-oq-05`

`meta.json` is already richly structured (overview, conclusion, 6 sections, references). The gap was in **annotations**: the 5 annotations carried only `title`/`content`, but the page renders `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Changes (annotations.json)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations — covering the $\mathbb{Z}/4$ obstruction ($a^2+b^2 \ne 3$), the cast transport into ZMod, the ℕ form, the Fermat biconditional ($p = x^2+y^2 \iff p \not\equiv 3 \pmod 4$), and the concrete witnesses.
- annotations.json 3.1 KB → ~6 KB; meta.json unchanged.

### Verification
- Valid JSON; all 5 annotations have `mathContext`, `significance`, `relatedConcepts`.
- `pnpm build` passes.
- No axiom/status changes (entry uses `decide`, not `native_decide`; 0 axioms).