### PR TITLE
Enrich Euler's formula from the series definition: annotation depth

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-02-oq-01/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "insight",
     "title": "The Series ARE the Definitions",
-    "content": "Here cosSeries and sinSeries are noncomputable definitions equal to their Maclaurin series Σ (−1)ᵏ z^{2k}/(2k)! and Σ (−1)ᵏ z^{2k+1}/(2k+1)!. This is the classical (Euler 1748) foundation: the trigonometric functions are *defined* by these power series, in deliberate contrast to Mathlib (and the parent entry), which defines cos z = (e^{iz}+e^{−iz})/2 and proves the series as theorems. The whole file then asks: with this definition, does Euler's formula still hold? It does — and the proof never uses Complex.cos until the very end."
+    "content": "Here cosSeries and sinSeries are noncomputable definitions equal to their Maclaurin series Σ (−1)ᵏ z^{2k}/(2k)! and Σ (−1)ᵏ z^{2k+1}/(2k+1)!. This is the classical (Euler 1748) foundation: the trigonometric functions are *defined* by these power series, in deliberate contrast to Mathlib (and the parent entry), which defines cos z = (e^{iz}+e^{−iz})/2 and proves the series as theorems. The whole file then asks: with this definition, does Euler's formula still hold? It does — and the proof never uses Complex.cos until the very end.",
+    "mathContext": "$\\cos z := \\sum_k (-1)^k \\dfrac{z^{2k}}{(2k)!}$, $\\sin z := \\sum_k (-1)^k \\dfrac{z^{2k+1}}{(2k+1)!}$ — the power series taken as the *definition* (Euler, 1748), not derived from $e^{iz}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Maclaurin series",
+      "power-series definition",
+      "trigonometric functions",
+      "Euler (1748)"
+    ],
+    "prerequisites": [
+      "power series",
+      "complex analysis"
+    ]
   },
   {
     "id": "ann-euler-summability",
@@ -19,7 +31,19 @@
     },
     "type": "technique",
     "title": "Convergence with No Trigonometry",
-    "content": "Each defining series converges absolutely, proved with no trigonometric input. The norm of the k-th cosine term is exactly ‖z‖^{2k}/(2k)!, a subseries of the exponential series Σ ‖z‖ⁿ/n! (Real.summable_pow_div_factorial). The subseries is reached by composing with the injective reindexing k ↦ 2k (resp. k ↦ 2k+1) via Summable.comp_injective, and the comparison is closed by Summable.of_norm_bounded. So summability of cos/sin is a fact about the exponential alone."
+    "content": "Each defining series converges absolutely, proved with no trigonometric input. The norm of the k-th cosine term is exactly ‖z‖^{2k}/(2k)!, a subseries of the exponential series Σ ‖z‖ⁿ/n! (Real.summable_pow_div_factorial). The subseries is reached by composing with the injective reindexing k ↦ 2k (resp. k ↦ 2k+1) via Summable.comp_injective, and the comparison is closed by Summable.of_norm_bounded. So summability of cos/sin is a fact about the exponential alone.",
+    "mathContext": "$\\big\\|(-1)^k z^{2k}/(2k)!\\big\\| = \\|z\\|^{2k}/(2k)!$, a subseries of $\\sum_n \\|z\\|^n/n!$ — absolute convergence by comparison with $\\exp$, reindexed via $k \\mapsto 2k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "absolute convergence",
+      "comparison test",
+      "exponential series",
+      "reindexing (Summable.comp_injective)"
+    ],
+    "prerequisites": [
+      "summability",
+      "series comparison"
+    ]
   },
   {
     "id": "ann-euler-resummation",
@@ -30,7 +54,19 @@
     },
     "type": "insight",
     "title": "Euler's Formula IS the Even/Odd Split of e^{iz}",
-    "content": "hasSum_euler is the mathematical heart of the reversal. Starting from the single fact e^{iz} = Σ (iz)ⁿ/n!, it transports the HasSum across ℕ ≃ ℕ × Fin 2 (Nat.divModEquiv 2) and collapses fibers with HasSum.prod_fiberwise. The k-th fiber sum (iz)^{2k}/(2k)! + (iz)^{2k+1}/(2k+1)! simplifies — using I² = −1, after rewriting I^{2k} = (−1)ᵏ — to cosTerm k + i·sinTerm k, closed by ring. Euler's formula is thus literally the statement that the exponential series decomposes into its even-indexed (cosine) and odd-indexed (i·sine) parts."
+    "content": "hasSum_euler is the mathematical heart of the reversal. Starting from the single fact e^{iz} = Σ (iz)ⁿ/n!, it transports the HasSum across ℕ ≃ ℕ × Fin 2 (Nat.divModEquiv 2) and collapses fibers with HasSum.prod_fiberwise. The k-th fiber sum (iz)^{2k}/(2k)! + (iz)^{2k+1}/(2k+1)! simplifies — using I² = −1, after rewriting I^{2k} = (−1)ᵏ — to cosTerm k + i·sinTerm k, closed by ring. Euler's formula is thus literally the statement that the exponential series decomposes into its even-indexed (cosine) and odd-indexed (i·sine) parts.",
+    "mathContext": "$e^{iz} = \\sum_n (iz)^n/n!$ split across $\\mathbb{N} \\simeq \\mathbb{N} \\times \\mathrm{Fin}\\,2$: fiber $k$ collapses to $\\cos_k + i\\,\\sin_k$ (using $i^2 = -1$, $i^{2k} = (-1)^k$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "even/odd index split",
+      "HasSum.prod_fiberwise",
+      "exponential series",
+      "Euler's formula"
+    ],
+    "prerequisites": [
+      "summable families",
+      "reindexing equivalences"
+    ]
   },
   {
     "id": "ann-euler-uniqueness",
@@ -41,7 +77,18 @@
     },
     "type": "technique",
     "title": "Reading Off Euler's Formula by Uniqueness of Sums",
-    "content": "Because the two series converge (Section II), each has a HasSum to its own tsum (cosSeries z, sinSeries z). Their combination cosTerm k + i·sinTerm k therefore has sum cosSeries z + i·sinSeries z. But hasSum_euler shows the same interleaved series sums to e^{iz}. Uniqueness of sums (HasSum.unique) forces e^{iz} = cosSeries z + i·sinSeries z — no property of Complex.cos is invoked anywhere in the derivation."
+    "content": "Because the two series converge (Section II), each has a HasSum to its own tsum (cosSeries z, sinSeries z). Their combination cosTerm k + i·sinTerm k therefore has sum cosSeries z + i·sinSeries z. But hasSum_euler shows the same interleaved series sums to e^{iz}. Uniqueness of sums (HasSum.unique) forces e^{iz} = cosSeries z + i·sinSeries z — no property of Complex.cos is invoked anywhere in the derivation.",
+    "mathContext": "The interleaved series $\\sum_k (\\cos_k + i\\,\\sin_k)$ sums both to $\\cos z + i\\,\\sin z$ and to $e^{iz}$; `HasSum.unique` forces $e^{iz} = \\cos z + i\\,\\sin z$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of sums",
+      "HasSum",
+      "Euler's formula"
+    ],
+    "prerequisites": [
+      "convergent series",
+      "uniqueness of limits"
+    ]
   },
   {
     "id": "ann-euler-identity",
@@ -52,6 +99,18 @@
     },
     "type": "insight",
     "title": "Closing the Loop: Identification and e^{iπ} = −1",
-    "content": "Only now is the series-definition tied to the standard function: cosSeries_eq_cos / sinSeries_eq_sin are precisely Mathlib's cos_eq_tsum / sin_eq_tsum read backwards. With that bridge, the Pythagorean identity cos²+sin²=1 and Euler's identity e^{iπ} = −1 fall out within the series framework, meeting the parent entry from the opposite foundational direction."
+    "content": "Only now is the series-definition tied to the standard function: cosSeries_eq_cos / sinSeries_eq_sin are precisely Mathlib's cos_eq_tsum / sin_eq_tsum read backwards. With that bridge, the Pythagorean identity cos²+sin²=1 and Euler's identity e^{iπ} = −1 fall out within the series framework, meeting the parent entry from the opposite foundational direction.",
+    "mathContext": "$\\cos_{\\text{series}} = \\mathrm{Complex.cos}$, $\\sin_{\\text{series}} = \\mathrm{Complex.sin}$; then $\\cos^2 z + \\sin^2 z = 1$ and $e^{i\\pi} = -1$ follow within the series framework.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euler's identity",
+      "Pythagorean identity",
+      "Mathlib cos_eq_tsum / sin_eq_tsum",
+      "series-to-function bridge"
+    ],
+    "prerequisites": [
+      "Euler's formula",
+      "Mathlib trigonometric API"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `euler-identity-oq-01-oq-02-oq-01`

`meta.json` is already richly structured (overview, conclusion, 4 sections, references). The gap was in **annotations**: the 5 annotations carried only `title`/`content`, but the page renders `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Changes (annotations.json)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations — covering the series-as-definition framing (Euler 1748), trigonometry-free convergence via comparison with $\exp$, the even/odd resummation of $e^{iz}$, reading off Euler's formula by uniqueness of sums, and closing with $e^{i\pi} = -1$.
- annotations.json 3.7 KB → ~6.5 KB; meta.json unchanged.

### Verification
- Valid JSON; all 5 annotations have `mathContext`, `significance`, `relatedConcepts`.
- `pnpm build` passes.
- No axiom/status changes.