### PR TITLE
research(erdos-606-oq-01): gap-set robustness under larger collinear groups

### DIFF
--- a/proofs/Proofs/Erdos606OQ01.lean
+++ b/proofs/Proofs/Erdos606OQ01.lean
@@ -201,4 +201,55 @@ theorem forbidden_line_counts (n : ℕ) (hn : 4 ≤ n) :
 theorem exactly_two_gaps : ({1, 3} : Set ℕ).ncard = 2 := by
   rw [Set.ncard_pair (by norm_num)]
 
+/-! ## Part IV: Robustness — larger collinear groups don't change the gap set
+
+    Parts I–III used only collinear triples (deficit `2`) and quadruples
+    (deficit `5`). One might worry that allowing richer collinear groups —
+    quintuples (`lineDeficit 5 = 9`), sextuples (`lineDeficit 6 = 14`), … —
+    could fill in one of the two gaps `1` or `3`, or create achievable deficits
+    outside `⟨2,5⟩`. It cannot: every `lineDeficit k` for `k ≥ 3` is already a
+    non-negative combination of `2` and `5`, and representable deficits are
+    closed under addition. So the achievable deficit set — and hence the
+    forbidden line counts — is unchanged by allowing groups of any size. The two
+    generators `2, 5` are therefore not merely sufficient but *canonical*. -/
+
+/-- **Closure.** The representable deficits form a numerical semigroup: a sum of
+    two representable deficits is representable. -/
+theorem representable_add {m n : ℕ} (hm : Representable m) (hn : Representable n) :
+    Representable (m + n) := by
+  obtain ⟨a, b, rfl⟩ := hm
+  obtain ⟨c, d, rfl⟩ := hn
+  exact ⟨a + c, b + d, by ring⟩
+
+/-- **Every collinear group's deficit lies in ⟨2,5⟩.** For any group size
+    `k ≥ 3`, `lineDeficit k = C(k,2) - 1` is representable. (`k = 3` gives the
+    generator `2`; every `k ≥ 4` has `C(k,2) ≥ 6`, hence deficit `≥ 5`, which is
+    representable since the only gaps are `1` and `3`.) Larger collinear groups
+    thus add no new achievable deficits beyond those from triples and
+    quadruples. -/
+theorem lineDeficit_representable (k : ℕ) (hk : 3 ≤ k) :
+    Representable (lineDeficit k) := by
+  rw [representable_iff]
+  rcases Nat.lt_or_ge k 4 with hlt | hge
+  · -- 3 ≤ k < 4, so k = 3 and lineDeficit 3 = 2
+    interval_cases k
+    decide
+  · -- k ≥ 4 ⇒ C(k,2) ≥ 6 ⇒ lineDeficit k ≥ 5
+    have h : 4 * 3 / 2 ≤ k * (k - 1) / 2 := by
+      apply Nat.div_le_div_right
+      calc 4 * 3 ≤ k * 3 := by exact Nat.mul_le_mul_right 3 hge
+        _ ≤ k * (k - 1) := by exact Nat.mul_le_mul_left k (by omega)
+    unfold lineDeficit
+    omega
+
+/-- **Gap set is robust under richer collinear groups.** Augmenting an achievable
+    configuration (deficit `d` representable) with any collinear group of size
+    `k ≥ 3` keeps the induced deficit `d + lineDeficit k` representable. The
+    achievable deficit set is closed under *all* group deficits, not only those
+    of triples and quadruples — so the only non-representable deficits remain
+    `1` and `3`. -/
+theorem deficit_closed_under_group {d k : ℕ} (hd : Representable d) (hk : 3 ≤ k) :
+    Representable (d + lineDeficit k) :=
+  representable_add hd (lineDeficit_representable k hk)
+
 end Erdos606OQ01

--- a/src/data/proofs/erdos-606-oq-01/meta.json
+++ b/src/data/proofs/erdos-606-oq-01/meta.json
@@ -96,9 +96,9 @@
       "Mathlib.Tactic"
     ],
     "namespace": "Erdos606OQ01",
-    "lineCount": 204,
+    "lineCount": 255,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 17,
     "definitionCount": 4,
     "path": "Proofs/Erdos606OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`erdos-606-oq-01` was already fully verified on `main` (0 sorry / 0 axiom, 14 theorems): it derives the two Erdős–Salamon forbidden line counts `C(n,2)-1` and `C(n,2)-3` from the numerical semigroup ⟨2,5⟩ generated by the line-count deficits of collinear **triples** (deficit 2) and **quadruples** (deficit 5).

This PR adds **Part IV: Robustness**, answering the natural sharpness question the existing file left implicit — *could richer collinear groups (quintuples, sextuples, …) fill one of the gaps `1`/`3` or create achievable counts outside ⟨2,5⟩?* They cannot.

## New theorems (3)

- **`representable_add`** — representable deficits are closed under addition (the numerical-semigroup property).
- **`lineDeficit_representable`** — for every group size `k ≥ 3`, `lineDeficit k = C(k,2)-1` already lies in ⟨2,5⟩. (`k = 3` gives the generator `2`; every `k ≥ 4` has `C(k,2) ≥ 6`, hence deficit `≥ 5`, never a gap.)
- **`deficit_closed_under_group`** — adding a collinear group of *any* size `k ≥ 3` to an achievable configuration keeps it achievable.

Conclusion: the two generators `2, 5` are not merely sufficient but **canonical** — the gap set `{1,3}` is robust under arbitrarily rich collinear groups.

## Honest scope

This is a modest, self-contained arithmetic strengthening of an already-solved entry. It does **not** touch geometric realizability or the Erdős–Salamon threshold `N₀` (still axiomatized in the parent file, as documented there).

## Verification

- Build-verified via `./proofs/scripts/docker-build.sh Proofs.Erdos606OQ01` → `✔ Built Proofs.Erdos606OQ01` (3058 jobs, exit 0).
- 0 sorry, 0 axiom. Theorems 14 → 17; lines 204 → 255. `meta.json` `leanFile` counts updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)