### PR TITLE
audit: mark Jordan–Hölder-modules + erdos-111-oq-01 clean (queue persistence)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24829,6 +24829,18 @@
       "issues": [],
       "lastAudited": "2026-06-27T02:00:00Z",
       "result": "clean"
+    },
+    "abel-ruffini-galois-extensions-oq-04-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T02:14:00Z",
+      "result": "clean"
+    },
+    "erdos-111-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T02:14:00Z",
+      "result": "clean"
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 2 entries CLEAN

Two unaudited entries verified and persisted to the audit tracker so the queue stops re-surfacing them each cycle.

### abel-ruffini-galois-extensions-oq-04-oq-02 — *The Jordan–Hölder Theorem for Modules*
- **116L / 8 thm / 1 def / 0 sorry / 0 axiom** — all counts match `Proofs/AbelRuffiniGaloisExtensionsOQ04OQ02.lean`.
- Correct **Tier B**: `badge: mathlib`, `status: verified`. Description, overview, `proofStrategy`, and `assumptions` all explicitly credit Mathlib's `CompositionSeries.jordan_holder` (deep induction) and `JordanHolderModule.instJordanHolderLattice`. Contribution honestly scoped to the module specialization + length-invariance / factor-bijection / simple-module corollaries.
- No delegation opacity, no "first formalization" overclaim. No True stubs, no `native_decide`.

### erdos-111-oq-01 — *Bipartite Covers of Large-Chromatic Graphs*
- **154L / 4 thm / 4 def / 0 sorry / 0 axiom** — all counts match `Proofs/Erdos111OQ01.lean`.
- Genuine **Tier A**: `badge: original`. Defines `BipartiteCover` and proves the sharp equivalence `G.Colorable (2^k) ↔ Nonempty (BipartiteCover G (Fin k))` on Mathlib's `Coloring` primitives — not a single-theorem wrapper.
- Exemplary honesty: explicit note that Mathlib's ℕ∞-valued `chromaticNumber` collapses ℵ₁ to `⊤`, so the ℵ₁ corollary is scoped as the "verifiable shadow" (not finitely colorable ⇒ no finite bipartite cover). No inequality≠theorem masking.

Tracker-only change (12-line insertion, `ensure_ascii` preserved to avoid noise diff). No code or meta.json changes — both entries already accurate.

---
Discovered during gallery integrity audit.