### PR TITLE
Enrich Brahmagupta identity / norm-form multiplicativity (oq-07): annotation depth

### DIFF
--- a/src/data/proofs/fermat-two-squares-oq-07/annotations.json
+++ b/src/data/proofs/fermat-two-squares-oq-07/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "concept",
     "title": "The General Brahmagupta Identity",
-    "content": "`brahmagupta` states (a²+N·b²)(c²+N·d²) = (ac−N·bd)² + N·(ad+bc)² over an arbitrary commutative ring, closed by `ring`. This is the multiplicativity of the norm N(x+y√−N) = x²+N·y² on the quadratic ring ℤ[√−N]. Stating it over a general `CommRing R` makes plain that it is a purely formal polynomial identity — the number theory is downstream. The N=1 instance is the Brahmagupta–Fibonacci identity (Gaussian integers) already in the parent entry."
+    "content": "`brahmagupta` states (a²+N·b²)(c²+N·d²) = (ac−N·bd)² + N·(ad+bc)² over an arbitrary commutative ring, closed by `ring`. This is the multiplicativity of the norm N(x+y√−N) = x²+N·y² on the quadratic ring ℤ[√−N]. Stating it over a general `CommRing R` makes plain that it is a purely formal polynomial identity — the number theory is downstream. The N=1 instance is the Brahmagupta–Fibonacci identity (Gaussian integers) already in the parent entry.",
+    "mathContext": "$(a^2+Nb^2)(c^2+Nd^2) = (ac-Nbd)^2 + N(ad+bc)^2$ — multiplicativity of the norm $N(x+y\\sqrt{-N}) = x^2+Ny^2$ on $\\mathbb{Z}[\\sqrt{-N}]$ (a formal `ring` identity over any CommRing).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci identity",
+      "norm form",
+      "quadratic ring ℤ[√−N]",
+      "multiplicativity"
+    ],
+    "prerequisites": [
+      "commutative rings",
+      "norm forms"
+    ]
   },
   {
     "id": "ann-sign-variant",
@@ -19,7 +31,19 @@
     },
     "type": "insight",
     "title": "Two Sign Variants ⇒ Multiple Representations",
-    "content": "`brahmagupta'` is the conjugate variant (a²+N·b²)(c²+N·d²) = (ac+N·bd)² + N·(ad−bc)², obtained from the first by sending d ↦ −d. The existence of two composition laws is precisely why a product of two distinct represented numbers usually has two distinct representations — the classical reason composite sums of two squares decompose in several ways."
+    "content": "`brahmagupta'` is the conjugate variant (a²+N·b²)(c²+N·d²) = (ac+N·bd)² + N·(ad−bc)², obtained from the first by sending d ↦ −d. The existence of two composition laws is precisely why a product of two distinct represented numbers usually has two distinct representations — the classical reason composite sums of two squares decompose in several ways.",
+    "mathContext": "$(a^2+Nb^2)(c^2+Nd^2) = (ac+Nbd)^2 + N(ad-bc)^2$ — the conjugate variant ($d \\mapsto -d$); two composition laws ⇒ multiple representations.",
+    "significance": "key",
+    "relatedConcepts": [
+      "composition law",
+      "conjugation",
+      "multiple representations",
+      "Brahmagupta identity"
+    ],
+    "prerequisites": [
+      "norm forms",
+      "ring identities"
+    ]
   },
   {
     "id": "ann-normform-mul",
@@ -30,7 +54,19 @@
     },
     "type": "concept",
     "title": "The Norm Form Is Multiplicative",
-    "content": "`normForm N x y = x²+N·y²` packages the form as a function and `normForm_mul` restates the identity as N(z₁)·N(z₂) = N(z₁ ⊙ z₂) with explicit composition ⊙ on the arguments. This exhibits the represented values as a multiplicative monoid — the shadow of multiplication in ℤ[√−N]. Brahmagupta used the x²−N·y² (real-quadratic) sibling of this law to compose Pell solutions."
+    "content": "`normForm N x y = x²+N·y²` packages the form as a function and `normForm_mul` restates the identity as N(z₁)·N(z₂) = N(z₁ ⊙ z₂) with explicit composition ⊙ on the arguments. This exhibits the represented values as a multiplicative monoid — the shadow of multiplication in ℤ[√−N]. Brahmagupta used the x²−N·y² (real-quadratic) sibling of this law to compose Pell solutions.",
+    "mathContext": "$\\mathrm{normForm}\\,N\\,x\\,y = x^2+Ny^2$; $N(z_1)\\,N(z_2) = N(z_1 \\odot z_2)$ — represented values form a multiplicative monoid (the shadow of $\\times$ in $\\mathbb{Z}[\\sqrt{-N}]$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "norm form",
+      "multiplicative monoid",
+      "Pell's equation",
+      "quadratic integers"
+    ],
+    "prerequisites": [
+      "norm forms",
+      "monoids"
+    ]
   },
   {
     "id": "ann-represents-mul",
@@ -41,7 +77,19 @@
     },
     "type": "concept",
     "title": "Multiplicative Closure for Every N",
-    "content": "`Represents N n := ∃ x y, n = x²+N·y²`; `Represents_mul` destructs the two witnesses and feeds the Brahmagupta-composed pair (ac−N·bd, ad+bc) back in, proving the represented set is closed under multiplication for EVERY parameter N. The parent entry proves only the N=1 case (closure of sums of two squares); here the same one-line proof works uniformly across the whole family of norm forms."
+    "content": "`Represents N n := ∃ x y, n = x²+N·y²`; `Represents_mul` destructs the two witnesses and feeds the Brahmagupta-composed pair (ac−N·bd, ad+bc) back in, proving the represented set is closed under multiplication for EVERY parameter N. The parent entry proves only the N=1 case (closure of sums of two squares); here the same one-line proof works uniformly across the whole family of norm forms.",
+    "mathContext": "$\\mathrm{Represents}\\,N\\,n := \\exists x\\,y,\\ n = x^2+Ny^2$; closed under $\\times$ for *every* $N$ via the Brahmagupta-composed pair $(ac-Nbd,\\ ad+bc)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multiplicative closure",
+      "norm form",
+      "sum of two squares (N = 1)",
+      "quadratic forms"
+    ],
+    "prerequisites": [
+      "existential witnesses",
+      "norm forms"
+    ]
   },
   {
     "id": "ann-two-reps",
@@ -52,6 +100,18 @@
     },
     "type": "example",
     "title": "65 = 4² + 7² = 8² + 1²: Two Distinct Representations",
-    "content": "Applying the two sign variants to 65 = 5·13 = (2²+1²)(3²+2²) yields (2·3−1·2, 2·2+1·3) = (4,7) and (2·3+1·2, 2·2−1·3) = (8,1). `sixtyFive_two_distinct_reps` proves both 65 = 4²+7² and 65 = 8²+1², and that the unordered pairs {4,7} and {1,8} differ (by `decide`). This is the smallest classical witness of the multiple-representation phenomenon forced by Brahmagupta's identity."
+    "content": "Applying the two sign variants to 65 = 5·13 = (2²+1²)(3²+2²) yields (2·3−1·2, 2·2+1·3) = (4,7) and (2·3+1·2, 2·2−1·3) = (8,1). `sixtyFive_two_distinct_reps` proves both 65 = 4²+7² and 65 = 8²+1², and that the unordered pairs {4,7} and {1,8} differ (by `decide`). This is the smallest classical witness of the multiple-representation phenomenon forced by Brahmagupta's identity.",
+    "mathContext": "$65 = 5 \\cdot 13 = (2^2+1^2)(3^2+2^2)$; the two sign variants give $(4,7)$ and $(8,1)$, so $65 = 4^2+7^2 = 8^2+1^2$ with $\\{4,7\\} \\ne \\{1,8\\}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "multiple representations",
+      "Brahmagupta composition",
+      "sum of two squares",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "sum of two squares",
+      "Brahmagupta identity"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `fermat-two-squares-oq-07`

`meta.json` is already richly structured (overview, conclusion, 6 sections, references). The gap was in **annotations**: the 5 annotations carried only `title`/`content`, but the page renders `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### Changes (annotations.json)
- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations — covering the general Brahmagupta identity, the conjugate sign variant, norm-form multiplicativity, multiplicative closure of the represented set for every $N$, and the $65 = 4^2+7^2 = 8^2+1^2$ two-representation witness.
- annotations.json 3.3 KB → ~6 KB; meta.json unchanged.

### Verification
- Valid JSON; all 5 annotations have `mathContext`, `significance`, `relatedConcepts`.
- `pnpm build` passes.
- No axiom/status changes.