### PR TITLE
audit: re-confirm angle-trisection-cos-20-gal-oq-03-oq-01 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -278,9 +278,9 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T02:20:15Z",
       "result": "clean"
     },
     "angle-trisection-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `angle-trisection-cos-20-gal-oq-03-oq-01` (|Gal(4X²+2X−1/ℚ)| = 2, minimal polynomial of cos(2π/5))

Stalest entry surfaced by `find-targets.ts --next` (lastAudited 2026-05-03). Re-verified against the Lean source.

### Verification

| Claim (meta.json) | Lean source | ✓ |
|---|---|---|
| status `verified` / badge `original` | real theorem, no stubs | ✓ |
| sorries 0 | `grep sorry` = 0 | ✓ |
| axiomCount 0 | `grep '^axiom'` = 0 | ✓ |
| lineCount 462 | `wc -l` = 462 | ✓ |
| theoremCount 28 | 28 private-inclusive theorem decls | ✓ |
| True stubs | 0 | ✓ |

Main theorem `cos72_gal_card : Fintype.card (4X²+2X−1).Gal = 2` is substantive — derives via `Polynomial.Gal.card_of_separable` + an original degree-2 splitting-field computation (explicit factorization, Eisenstein-shift irreducibility). Heavy Mathlib reliance is disclosed in `assumptions`, so badge `original` is defensible.

**Note (not fixed):** `definitionCount: 0` while the file has 4 private helper defs/abbrevs — but this is a family-wide convention (siblings `…-oq-03`, `…-oq-01` identically report 0 with 4 private defs each), it *under*counts work, and changing one file would desync the family. No credibility impact; left as-is.

Updates `audit-tracker.json` only (surgical 2-line timestamp/count bump; persists the re-audit so `--next` advances past this entry).

---
Discovered during gallery integrity audit.