### PR TITLE
audit: re-confirm angle-trisection-cos-20-gal-oq-03 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -272,9 +272,9 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T02:25:30Z",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit

Re-audited the stalest gallery entry **angle-trisection-cos-20-gal-oq-03** ("Galois Group of cos(40°) Minimal Polynomial has Order 3"), last audited 2026-05-03.

### Verification (vs `proofs/Proofs/AngleTrisectionCos20GalOQ03.lean`)

| Claim | meta.json | Lean source | OK |
|-------|-----------|-------------|----|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 (no `axiom`, no True stubs) | ✅ |
| lineCount | 434 | 434 | ✅ |
| theoremCount | 32 | 32 | ✅ |
| status / badge | verified / mathlib | Tier B (Eisenstein irreducibility + `Gal.card` via Mathlib) | ✅ |

### Note (not actionable)
`definitionCount: 0` undercounts the 4 private defs/abbrevs (`p`, `q_eis_int`, `q_eis_rat`, `root_in_sf`). This is the known family-wide convention (private defs uncounted) — a conservative undercount, not an overclaim.

**Result: CLEAN.** Only the tracker timestamp/auditCount is bumped (surgical 2-line edit).

---
Discovered during gallery integrity audit.