### PR TITLE
research(cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01): Schur's majorization theorem (forward Schur–Horn), VERIFIED

### DIFF
--- a/proofs/Proofs/SchurHornMajorization.lean
+++ b/proofs/Proofs/SchurHornMajorization.lean
@@ -1,0 +1,178 @@
+import Mathlib
+
+/-
+# Schur's majorization theorem (the forward / "Schur" direction of Schur–Horn)
+
+The **Schur–Horn theorem** relates the diagonal entries of a Hermitian matrix to
+its eigenvalue spectrum.  Its *forward* direction — due to **Issai Schur (1923)** —
+says that the diagonal is **majorized** by the spectrum:
+
+  `diag(A) ≺ spec(A)`.
+
+This file formalizes that direction in the cleanest equivalent form, the one given
+by the **Hardy–Littlewood–Pólya / Karamata** characterization of majorization:
+a real tuple `d` is majorized by `λ` iff `∑ φ(dᵢ) ≤ ∑ φ(λⱼ)` for *every* convex
+`φ`.  We prove exactly this inequality for the diagonal of an arbitrary symmetric
+(Hermitian) operator with respect to *any* orthonormal basis.
+
+## Mathematical content
+
+Let `T` be a symmetric operator on a finite-dimensional inner product space over
+`𝕜 = ℝ` or `ℂ`, with spectral data from Mathlib's `LinearMap.IsSymmetric`:
+an orthonormal eigenbasis `v` (`hT.eigenvectorBasis hn`) and eigenvalues `λ`
+(`hT.eigenvalues hn`).  Fix *any* orthonormal basis `e`.  The "diagonal" of `T` in
+the basis `e` is the tuple
+
+  `d i := re ⟪T (e i), e i⟫`.
+
+The matrix `D i j := ‖⟪v j, e i⟫‖²` is **doubly stochastic** (rows and columns sum
+to `1`, by Parseval), and the diagonal is the doubly-stochastic image of the
+spectrum:
+
+  `d i = ∑ j, D i j • λ j`     (each `d i` is a convex combination of eigenvalues).
+
+The majorization inequality then follows by **Jensen** applied row-by-row and a
+sum swap using the column sums:
+
+  `∑ i, φ (d i) ≤ ∑ i ∑ j, D i j • φ (λ j) = ∑ j, (∑ i, D i j) • φ (λ j) = ∑ j, φ (λ j)`.
+
+Specializations recorded here:
+* `schur_trace_eq` — basis independence of the trace, `∑ d i = ∑ λ j` (the `k = n`
+  equality case of majorization, needing no convexity);
+* `schur_sum_sq_le` — `∑ (d i)² ≤ ∑ (λ j)²` (the `φ = (·)²` instance), i.e. the
+  diagonal has no larger Euclidean length than the spectrum.
+
+## Relation to Mathlib
+
+Mathlib has the spectral theorem (`LinearMap.IsSymmetric.eigenvectorBasis`,
+`eigenvalues`) and Birkhoff's theorem on doubly stochastic matrices
+(`exists_eq_sum_perm_of_mem_doublyStochastic`), but it has **no majorization
+predicate and no Schur–Horn theorem** (only a comment mentioning Schur–Horn in
+`Mathlib.Analysis.InnerProductSpace.Spectrum`).  This file supplies the forward
+direction in its convex-function (Karamata) form, which is self-contained: it
+needs only Parseval, the spectral theorem, and Jensen's inequality — not Birkhoff.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped BigOperators
+
+namespace SchurHorn
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+  [FiniteDimensional 𝕜 E] {n : ℕ}
+  {T : E →ₗ[𝕜] E} (hT : T.IsSymmetric) (hn : Module.finrank 𝕜 E = n)
+  (e : OrthonormalBasis (Fin n) 𝕜 E)
+
+/-- The doubly-stochastic weight matrix `D i j = ‖⟪v j, e i⟫‖²`, where `v` is the
+orthonormal eigenbasis of `T` and `e` is the chosen orthonormal basis. -/
+noncomputable def dsWeight (i j : Fin n) : ℝ :=
+  ‖@inner 𝕜 E _ (hT.eigenvectorBasis hn j) (e i)‖ ^ 2
+
+/-- Every weight is nonnegative (it is a squared norm). -/
+theorem dsWeight_nonneg (i j : Fin n) : 0 ≤ dsWeight hT hn e i j :=
+  sq_nonneg _
+
+/-- **Rows sum to one.**  By Parseval for the eigenbasis `v`,
+`∑ j, ‖⟪v j, e i⟫‖² = ‖e i‖² = 1`. -/
+theorem dsWeight_row_sum (i : Fin n) : ∑ j, dsWeight hT hn e i j = 1 := by
+  simp only [dsWeight]
+  rw [(hT.eigenvectorBasis hn).sum_sq_norm_inner_right (e i),
+      e.orthonormal.norm_eq_one i, one_pow]
+
+/-- **Columns sum to one.**  By Parseval for the basis `e`,
+`∑ i, ‖⟪v j, e i⟫‖² = ‖v j‖² = 1`. -/
+theorem dsWeight_col_sum (j : Fin n) : ∑ i, dsWeight hT hn e i j = 1 := by
+  simp only [dsWeight]
+  rw [e.sum_sq_norm_inner_left (hT.eigenvectorBasis hn j),
+      (hT.eigenvectorBasis hn).orthonormal.norm_eq_one j, one_pow]
+
+/-- **Diagonal = doubly-stochastic image of the spectrum.**  The diagonal entry
+`re ⟪T (e i), e i⟫` of `T` in the basis `e` is the convex combination
+`∑ j, λ j · D i j` of the eigenvalues.  Expanding `e i` in the eigenbasis and using
+`T v j = λ j • v j` together with `conj z · z = ‖z‖²`. -/
+theorem diag_decomp (i : Fin n) :
+    RCLike.re (@inner 𝕜 E _ (T (e i)) (e i))
+      = ∑ j, hT.eigenvalues hn j * dsWeight hT hn e i j := by
+  -- per-term identity in 𝕜
+  have hsummand : ∀ j,
+      @inner 𝕜 E _ (T (e i)) (hT.eigenvectorBasis hn j)
+        * @inner 𝕜 E _ (hT.eigenvectorBasis hn j) (e i)
+      = ((hT.eigenvalues hn j * dsWeight hT hn e i j : ℝ) : 𝕜) := by
+    intro j
+    have e1 : @inner 𝕜 E _ (hT.eigenvectorBasis hn j) (T (e i))
+        = (hT.eigenvalues hn j : 𝕜) * @inner 𝕜 E _ (hT.eigenvectorBasis hn j) (e i) := by
+      have h := LinearMap.IsSymmetric.eigenvectorBasis_apply_self_apply hT hn (e i) j
+      rwa [(hT.eigenvectorBasis hn).repr_apply_apply,
+           (hT.eigenvectorBasis hn).repr_apply_apply] at h
+    rw [← inner_conj_symm (T (e i)) (hT.eigenvectorBasis hn j), e1, map_mul,
+        RCLike.conj_ofReal, mul_assoc, RCLike.conj_mul]
+    simp only [dsWeight]
+    push_cast
+    ring
+  have hk : @inner 𝕜 E _ (T (e i)) (e i)
+      = ∑ j, ((hT.eigenvalues hn j * dsWeight hT hn e i j : ℝ) : 𝕜) := by
+    rw [← (hT.eigenvectorBasis hn).sum_inner_mul_inner (T (e i)) (e i)]
+    exact Finset.sum_congr rfl (fun j _ => hsummand j)
+  rw [hk, map_sum]
+  exact Finset.sum_congr rfl (fun j _ => RCLike.ofReal_re _)
+
+/-- **Schur's majorization theorem (convex / Karamata form).**  For any convex
+function `φ` on a set `s` containing all eigenvalues of the symmetric operator `T`,
+the diagonal of `T` in *any* orthonormal basis `e` satisfies
+
+  `∑ i, φ (re ⟪T (e i), e i⟫) ≤ ∑ j, φ (λ j)`.
+
+This is the forward (Schur) direction of the Schur–Horn theorem: `diag T ≺ spec T`.
+The proof is Jensen's inequality applied row-by-row to the doubly-stochastic matrix
+`D i j = ‖⟪v j, e i⟫‖²`, followed by a sum swap using the column sums `∑ i, D i j = 1`. -/
+theorem schur_majorization_convexOn {φ : ℝ → ℝ} {s : Set ℝ} (hφ : ConvexOn ℝ s φ)
+    (hmem : ∀ j, hT.eigenvalues hn j ∈ s) :
+    ∑ i, φ (RCLike.re (@inner 𝕜 E _ (T (e i)) (e i))) ≤ ∑ j, φ (hT.eigenvalues hn j) := by
+  -- Row-by-row Jensen.
+  have step : ∀ i, φ (RCLike.re (@inner 𝕜 E _ (T (e i)) (e i)))
+      ≤ ∑ j, dsWeight hT hn e i j • φ (hT.eigenvalues hn j) := by
+    intro i
+    have hJ := hφ.map_sum_le (t := Finset.univ) (w := fun j => dsWeight hT hn e i j)
+      (p := fun j => hT.eigenvalues hn j)
+      (fun j _ => dsWeight_nonneg hT hn e i j) (dsWeight_row_sum hT hn e i)
+      (fun j _ => hmem j)
+    have hsum : (∑ j, dsWeight hT hn e i j • hT.eigenvalues hn j)
+        = RCLike.re (@inner 𝕜 E _ (T (e i)) (e i)) := by
+      rw [diag_decomp hT hn e i]
+      exact Finset.sum_congr rfl (fun j _ => by rw [smul_eq_mul, mul_comm])
+    rwa [hsum] at hJ
+  -- Sum the rows, swap, collapse columns.
+  calc ∑ i, φ (RCLike.re (@inner 𝕜 E _ (T (e i)) (e i)))
+      ≤ ∑ i, ∑ j, dsWeight hT hn e i j • φ (hT.eigenvalues hn j) :=
+        Finset.sum_le_sum (fun i _ => step i)
+    _ = ∑ j, (∑ i, dsWeight hT hn e i j) • φ (hT.eigenvalues hn j) := by
+        rw [Finset.sum_comm]
+        exact Finset.sum_congr rfl (fun j _ => by rw [Finset.sum_smul])
+    _ = ∑ j, φ (hT.eigenvalues hn j) := by
+        exact Finset.sum_congr rfl (fun j _ => by rw [dsWeight_col_sum hT hn e j, one_smul])
+
+/-- **Basis independence of the trace** (the `k = n` equality case of majorization).
+The sum of the diagonal entries of `T` in any orthonormal basis equals the sum of
+its eigenvalues: `∑ i, re ⟪T (e i), e i⟫ = ∑ j, λ j`.  No convexity needed. -/
+theorem schur_trace_eq :
+    ∑ i, RCLike.re (@inner 𝕜 E _ (T (e i)) (e i)) = ∑ j, hT.eigenvalues hn j := by
+  calc ∑ i, RCLike.re (@inner 𝕜 E _ (T (e i)) (e i))
+      = ∑ i, ∑ j, hT.eigenvalues hn j * dsWeight hT hn e i j :=
+        Finset.sum_congr rfl (fun i _ => diag_decomp hT hn e i)
+    _ = ∑ j, hT.eigenvalues hn j * (∑ i, dsWeight hT hn e i j) := by
+        rw [Finset.sum_comm]
+        exact Finset.sum_congr rfl (fun j _ => by rw [Finset.mul_sum])
+    _ = ∑ j, hT.eigenvalues hn j := by
+        exact Finset.sum_congr rfl (fun j _ => by rw [dsWeight_col_sum hT hn e j, mul_one])
+
+/-- **Sum-of-squares bound** (the `φ = (·)²` instance of Schur majorization).  The
+diagonal of `T` in any orthonormal basis has Euclidean length no larger than the
+spectrum: `∑ i, (re ⟪T (e i), e i⟫)² ≤ ∑ j, (λ j)²`. -/
+theorem schur_sum_sq_le :
+    ∑ i, (RCLike.re (@inner 𝕜 E _ (T (e i)) (e i))) ^ 2 ≤ ∑ j, (hT.eigenvalues hn j) ^ 2 :=
+  schur_majorization_convexOn hT hn e
+    (φ := fun x => x ^ 2) (s := Set.univ)
+    (Even.convexOn_pow (by decide)) (fun _ => Set.mem_univ _)
+
+end SchurHorn

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-dsWeight",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 69, "endLine": 88 },
+    "type": "definition",
+    "title": "The Doubly Stochastic Change-of-Basis Matrix",
+    "content": "`dsWeight` defines `D i j = ‖⟪v j, e i⟫‖²`, the squared moduli of the inner products between the orthonormal eigenbasis `v = hT.eigenvectorBasis hn` of `T` and the chosen orthonormal basis `e`. `dsWeight_nonneg` is `sq_nonneg`. `dsWeight_row_sum` (∑ j, D i j = 1) and `dsWeight_col_sum` (∑ i, D i j = 1) are Parseval's identity: `OrthonormalBasis.sum_sq_norm_inner_right` for the eigenbasis (rows, ‖e i‖² = 1) and `sum_sq_norm_inner_left` for `e` (columns, ‖v j‖² = 1). Thus `D` is doubly stochastic.",
+    "mathContext": "The matrix D_ij = |⟨vⱼ, eᵢ⟩|² of overlap probabilities between two orthonormal bases is doubly stochastic — the bridge from the spectral theorem to majorization, requiring no Birkhoff theorem.",
+    "significance": "key",
+    "relatedConcepts": ["doubly stochastic matrix", "Parseval identity", "orthonormal basis", "change of basis"]
+  },
+  {
+    "id": "ann-diag-decomp",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 94, "endLine": 118 },
+    "type": "theorem",
+    "title": "Diagonal as Doubly-Stochastic Image of the Spectrum",
+    "content": "`diag_decomp` proves `re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ · D i j`. The expansion `⟪T(e i), e i⟫ = ∑ⱼ ⟪T(e i), v j⟫ · ⟪v j, e i⟫` comes from `OrthonormalBasis.sum_inner_mul_inner`. Each cross term is collapsed using `eigenvectorBasis_apply_self_apply` (⟪v j, T(e i)⟫ = (λ j)·⟪v j, e i⟫), `inner_conj_symm`, `RCLike.conj_ofReal` (the eigenvalue is real), and `RCLike.conj_mul` (conj z · z = ‖z‖²), giving (λ j)·‖⟪v j, e i⟫‖²; taking real parts term by term (`map_sum`, `RCLike.ofReal_re`) yields the identity.",
+    "mathContext": "Each diagonal entry re⟪T eᵢ, eᵢ⟫ of a Hermitian operator is the convex combination ∑ⱼ λⱼ |⟨vⱼ, eᵢ⟩|² of its eigenvalues — the single nontrivial step from which majorization follows by Jensen.",
+    "significance": "key",
+    "relatedConcepts": ["spectral theorem", "resolution of identity", "convex combination", "eigenvalues"]
+  },
+  {
+    "id": "ann-schur-majorization-convexOn",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 129, "endLine": 153 },
+    "type": "theorem",
+    "title": "Schur's Majorization Theorem (Karamata Form)",
+    "content": "`schur_majorization_convexOn` is the headline: for every convex `φ` on a set `s` containing the spectrum, `∑ᵢ φ(re ⟪T (e i), e i⟫) ≤ ∑ⱼ φ(λⱼ)` — the forward direction of Schur–Horn, diag(T) ≺ spec(T). Row-by-row, `ConvexOn.map_sum_le` (Jensen) bounds `φ(d i) ≤ ∑ⱼ D i j • φ(λ j)` using the nonnegative weights `D i j` summing to 1 (`dsWeight_row_sum`) at points `λ j ∈ s`; summing over `i` (`Finset.sum_le_sum`), swapping (`Finset.sum_comm`, `Finset.sum_smul`), and collapsing each column with `dsWeight_col_sum` and `one_smul` finishes.",
+    "mathContext": "The Hardy–Littlewood–Pólya / Karamata characterization: a tuple is majorized by another iff ∑φ(dᵢ) ≤ ∑φ(λⱼ) for all convex φ. Proved here for the diagonal versus the spectrum of any Hermitian operator.",
+    "significance": "key",
+    "relatedConcepts": ["majorization", "Jensen inequality", "Schur–Horn theorem", "convex function", "Karamata inequality"]
+  },
+  {
+    "id": "ann-schur-trace-eq",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 158, "endLine": 167 },
+    "type": "theorem",
+    "title": "Basis Independence of the Trace",
+    "content": "`schur_trace_eq` is the equality (k=n) case of majorization, needing no convexity: `∑ᵢ re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ`. It follows from `diag_decomp` summed over `i`, a swap (`Finset.sum_comm`, `Finset.mul_sum`), and the column sums `∑ᵢ D i j = 1` (`dsWeight_col_sum`, `mul_one`).",
+    "mathContext": "The trace of a Hermitian operator equals the sum of its eigenvalues regardless of the orthonormal basis — the equality constraint that distinguishes majorization from weak majorization.",
+    "significance": "important",
+    "relatedConcepts": ["trace", "majorization equality case", "basis independence"]
+  },
+  {
+    "id": "ann-schur-sum-sq-le",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 172, "endLine": 176 },
+    "type": "theorem",
+    "title": "Sum-of-Squares Bound",
+    "content": "`schur_sum_sq_le` instantiates the master theorem at `φ = (·)²` (convex on all of ℝ by `Even.convexOn_pow` at n=2): `∑ᵢ (re ⟪T (e i), e i⟫)² ≤ ∑ⱼ λⱼ²`. The diagonal of a Hermitian operator is no larger in Euclidean (Hilbert–Schmidt) norm than its spectrum.",
+    "mathContext": "The Schur inequality ∑ dᵢ² ≤ ∑ λⱼ²: the diagonal vector has Euclidean length at most that of the eigenvalue vector — a direct consequence of majorization with the convex function x².",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of squares", "convex function", "majorization", "Hilbert–Schmidt norm"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+  "title": "Schur's Majorization Theorem (Forward Direction of Schur–Horn), Karamata Form",
+  "description": "Formalizes the forward (Schur) direction of the Schur–Horn theorem — the diagonal of a Hermitian operator is majorized by its eigenvalue spectrum, diag(T) ≺ spec(T) — answering the standalone open question of cauchy-interlacing-theorem-oq-01-oq-02-oq-02. It is stated in the cleanest equivalent form, the Hardy–Littlewood–Pólya / Karamata characterization of majorization: for every convex φ, ∑ᵢ φ(dᵢ) ≤ ∑ⱼ φ(λⱼ), where dᵢ = re ⟪T (e i), e i⟫ is the diagonal of T in ANY orthonormal basis e and λ is the spectrum. The headline schur_majorization_convexOn proves exactly this inequality. The engine is that D i j := ‖⟪v j, e i⟫‖² (v the orthonormal eigenbasis) is doubly stochastic — rows and columns sum to 1 by Parseval (dsWeight_row_sum, dsWeight_col_sum) — and the diagonal is its doubly-stochastic image of the spectrum, dᵢ = ∑ⱼ D i j · λⱼ (diag_decomp), making each dᵢ a convex combination of eigenvalues; row-by-row Jensen then a column-sum swap give the majorization. Two specializations are recorded: schur_trace_eq (basis independence of the trace, ∑ dᵢ = ∑ λⱼ, the k=n equality case, needing no convexity) and schur_sum_sq_le (∑ dᵢ² ≤ ∑ λⱼ², the φ=(·)² instance). Mathlib has the spectral theorem and Birkhoff's theorem on doubly stochastic matrices but NO majorization predicate and NO Schur–Horn theorem (only a comment); this entry supplies the forward direction self-contained from Parseval + spectral theorem + Jensen, not using Birkhoff. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Issai Schur (1923); Hardy–Littlewood–Pólya / Karamata (majorization characterization); formalized for lean-genius",
+    "status": "verified",
+    "badge": "verified",
+    "proofRepoPath": "Proofs/SchurHornMajorization.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "dateAdded": "2026-06-26",
+    "mathlib_version": "4.26.0",
+    "lineCount": 178,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "difficulty": "advanced",
+    "category": "linear-algebra",
+    "mathlibDependencies": [
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvectorBasis",
+        "description": "the orthonormal eigenbasis of a symmetric operator on a finite-dimensional inner product space, supplied by Mathlib's finite-dimensional spectral theorem; its eigenvalue family eigenvalues hn provides the spectrum λ",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvectorBasis_apply_self_apply",
+        "description": "the spectral relation v.repr (T x) j = (eigenvalues j) * v.repr x j in the eigenbasis coordinates — the source of the per-term identity ⟪T(e i), v j⟫ = (λ j) · conj ⟪v j, e i⟫ in diag_decomp",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "OrthonormalBasis.sum_sq_norm_inner_right",
+        "description": "Parseval's identity ∑ j, ‖⟪b j, x⟫‖² = ‖x‖² for an orthonormal basis — gives the row sums ∑ j, D i j = ‖e i‖² = 1 (and, with sum_sq_norm_inner_left, the column sums)",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "OrthonormalBasis.sum_inner_mul_inner",
+        "description": "the resolution-of-identity expansion ∑ j, ⟪x, b j⟫ * ⟪b j, y⟫ = ⟪x, y⟫ — used to expand ⟪T(e i), e i⟫ over the eigenbasis in diag_decomp",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "ConvexOn.map_sum_le",
+        "description": "Jensen's inequality, finite-sum form: f(∑ w i • p i) ≤ ∑ w i • f(p i) for convex f and weights summing to 1 — applied row-by-row with weights D i j and points λ j to bound φ(d i)",
+        "module": "Mathlib.Analysis.Convex.Jensen"
+      },
+      {
+        "theorem": "RCLike.conj_mul",
+        "description": "conj z * z = ‖z‖² in ℝ or ℂ — collapses each cross term conj ⟪v j, e i⟫ · ⟪v j, e i⟫ to the real weight ‖⟪v j, e i⟫‖² = D i j",
+        "module": "Mathlib.Analysis.RCLike.Basic"
+      },
+      {
+        "theorem": "Even.convexOn_pow",
+        "description": "x ↦ xⁿ is convex on all of ℝ for even n — instantiated at n = 2 to obtain the sum-of-squares corollary schur_sum_sq_le from the master theorem",
+        "module": "Mathlib.Analysis.Convex.Mul"
+      }
+    ],
+    "originalContributions": [
+      "schur_majorization_convexOn: the forward (Schur) direction of Schur–Horn in Karamata form — for every convex φ on a set containing the spectrum, ∑ᵢ φ(re ⟪T (e i), e i⟫) ≤ ∑ⱼ φ(λⱼ), i.e. diag(T) ≺ spec(T), for the diagonal of a Hermitian operator in any orthonormal basis",
+      "diag_decomp: the diagonal entry re ⟪T (e i), e i⟫ equals the convex combination ∑ⱼ λⱼ · ‖⟪v j, e i⟫‖² of the eigenvalues — the doubly-stochastic-image identity at the heart of the proof",
+      "dsWeight_row_sum / dsWeight_col_sum: double stochasticity of D i j = ‖⟪v j, e i⟫‖² (both row and column sums equal 1) directly from Parseval for the two orthonormal bases",
+      "schur_trace_eq: basis independence of the trace ∑ᵢ re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ, the equality (k=n) case of majorization, proved without convexity",
+      "schur_sum_sq_le: the sum-of-squares bound ∑ᵢ (re ⟪T (e i), e i⟫)² ≤ ∑ⱼ λⱼ², the φ=(·)² instance — the diagonal is no longer in Euclidean norm than the spectrum"
+    ],
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Self-contained over Mathlib's finite-dimensional spectral theorem, Parseval's identity, and Jensen's inequality; does not use Birkhoff's theorem. The Even 2 convexity side-condition is discharged by kernel-checked decide (not native_decide), so no Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound.",
+    "tags": [
+      "Schur–Horn",
+      "majorization",
+      "doubly stochastic",
+      "Jensen inequality",
+      "spectral theorem",
+      "eigenvalues",
+      "Hermitian operator",
+      "Karamata",
+      "convex function",
+      "trace"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators"
+    ],
+    "namespace": "SchurHorn",
+    "lineCount": 178,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/SchurHornMajorization.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 proof of the forward (Schur) direction of the Schur–Horn theorem: the diagonal of a Hermitian operator is majorized by its eigenvalue spectrum, diag(T) ≺ spec(T). The result is stated in the Hardy–Littlewood–Pólya / Karamata form — for every convex φ, ∑ᵢ φ(dᵢ) ≤ ∑ⱼ φ(λⱼ), where dᵢ = re ⟪T (e i), e i⟫ is the diagonal in an arbitrary orthonormal basis e. The proof identifies the diagonal as the doubly-stochastic image of the spectrum, dᵢ = ∑ⱼ D i j · λⱼ with D i j = ‖⟪v j, e i⟫‖² (rows and columns summing to 1 by Parseval), and applies Jensen's inequality row-by-row followed by a column-sum swap. Two corollaries record the equality case (basis independence of the trace, ∑ dᵢ = ∑ λⱼ) and the φ=(·)² instance (∑ dᵢ² ≤ ∑ λⱼ²).",
+    "implications": "Answers the standalone open question posed by cauchy-interlacing-theorem-oq-01-oq-02-oq-02, which derived only the positivity and spectral-range (weak Schur-half) consequences of compression interlacing and flagged the full Schur–Horn theorem as genuinely distinct. This entry supplies the forward direction of that theorem in a form (the Karamata convex-function inequality) that is exactly equivalent to majorization, self-contained from the spectral theorem, Parseval, and Jensen. It contributes the first majorization-flavored result of this kind to the gallery: Mathlib has the spectral theorem and Birkhoff's theorem on doubly stochastic matrices but provides no majorization predicate and no Schur–Horn theorem.",
+    "openQuestions": [
+      "The converse (Horn, 1954) realizability direction: every real tuple majorized by λ arises as the diagonal of some Hermitian operator with spectrum λ. This requires a doubly-stochastic / Birkhoff–von Neumann construction (Mathlib has exists_eq_sum_perm_of_mem_doublyStochastic) plus an explicit conjugation, and together with the forward direction proved here would complete the full Schur–Horn theorem.",
+      "A reusable majorization predicate (sorted partial-sum form) for real tuples together with the Hardy–Littlewood–Pólya equivalence between it and the Karamata convex-function inequality proved here, which would let this result be restated literally as diag(T) ≺ spec(T)."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Issai Schur proved in 1923 that the diagonal entries of a Hermitian matrix are majorized by its eigenvalues; Alfred Horn proved the converse in 1954, that every majorized tuple is realizable as a diagonal, giving the Schur–Horn theorem. Majorization d ≺ λ — every top-k partial sum of the sorted d is at most that of the sorted λ, with equality at k=n — is characterized in three equivalent ways (Hardy, Littlewood, and Pólya; Karamata; Birkhoff): d ≺ λ iff d = Dλ for a doubly stochastic D, iff ∑ φ(dᵢ) ≤ ∑ φ(λⱼ) for every convex φ. The forward direction of Schur–Horn is the cleanest illustration of the first two: the diagonal of a Hermitian operator in any orthonormal basis is the doubly-stochastic image (D i j = |⟨vⱼ, eᵢ⟩|²) of the spectrum, so the convex-function inequality is immediate from Jensen.",
+    "problemStatement": "Prove the forward direction of the Schur–Horn theorem: for a Hermitian (symmetric) operator T on a finite-dimensional inner product space, the diagonal of T in any orthonormal basis is majorized by its eigenvalue spectrum.\n\n**Answer.** schur_majorization_convexOn establishes the majorization in its Karamata form: for every convex φ on a set containing the spectrum, ∑ᵢ φ(re ⟪T (e i), e i⟫) ≤ ∑ⱼ φ(λⱼ). The proof builds the doubly stochastic matrix D i j = ‖⟪v j, e i⟫‖² from the orthonormal eigenbasis v and the chosen basis e, shows the diagonal equals the doubly-stochastic image ∑ⱼ D i j · λⱼ of the spectrum, and applies Jensen row-by-row, collapsing the columns with ∑ᵢ D i j = 1.",
+    "text": "Each diagonal entry of T is a convex combination of the eigenvalues — the coefficients being the squared moduli of the change-of-basis inner products, which form a doubly stochastic matrix by Parseval. Convexity (Jensen) applied to each entry and summed, with the column sums used to collapse the eigenvalue weights back to 1, yields the majorization inequality. The trace equality and the sum-of-squares bound are the k=n and φ=(·)² readings.",
+    "proofStrategy": "Define D i j = ‖⟪v j, e i⟫‖² (dsWeight). (1) Double stochasticity: dsWeight_row_sum and dsWeight_col_sum apply Parseval (OrthonormalBasis.sum_sq_norm_inner_right / _left) for the eigenbasis v and the basis e, with ‖e i‖ = ‖v j‖ = 1. (2) diag_decomp: expand ⟪T(e i), e i⟫ via OrthonormalBasis.sum_inner_mul_inner over v; per term, eigenvectorBasis_apply_self_apply gives ⟪v j, T(e i)⟫ = (λ j)·⟪v j, e i⟫, then inner_conj_symm, conj of a real scalar (RCLike.conj_ofReal), and RCLike.conj_mul collapse the cross term to (λ j)·‖⟪v j, e i⟫‖²; taking real parts gives re ⟪T(e i), e i⟫ = ∑ⱼ λⱼ · D i j. (3) schur_majorization_convexOn: ConvexOn.map_sum_le bounds φ(d i) ≤ ∑ⱼ D i j • φ(λⱼ) (weights D i j ≥ 0 summing to 1, points λ j ∈ s); Finset.sum_le_sum, Finset.sum_comm, Finset.sum_smul, and the column sums finish. Corollaries schur_trace_eq (no convexity) and schur_sum_sq_le (Even.convexOn_pow at n=2) specialize.",
+    "keyInsights": [
+      "The Karamata convex-function inequality ∑ φ(dᵢ) ≤ ∑ φ(λⱼ) is the form of majorization that proves itself: it needs only that each dᵢ is a convex combination of the λⱼ, which is exactly Jensen — no sorting, no partial-sum bookkeeping",
+      "The change-of-basis squared-modulus matrix D i j = |⟨vⱼ, eᵢ⟩|² is automatically doubly stochastic by Parseval applied in each of the two orthonormal bases — this is the bridge from the spectral theorem to majorization and needs no Birkhoff theorem",
+      "diag_decomp re ⟪T(e i), e i⟫ = ∑ⱼ λⱼ |⟨vⱼ, eᵢ⟩|² is the single nontrivial identity; everything downstream is Jensen plus a Fubini-style sum swap collapsed by the column sums",
+      "Phrasing the result for an abstract convex φ on an arbitrary set s containing the spectrum makes the trace equality and the sum-of-squares inequality immediate specializations rather than separate proofs"
+    ],
+    "prerequisites": [
+      "The finite-dimensional spectral theorem: a symmetric operator has an orthonormal eigenbasis (LinearMap.IsSymmetric.eigenvectorBasis) with real eigenvalues",
+      "Parseval's identity for an orthonormal basis (∑ ‖⟪b i, x⟫‖² = ‖x‖²) and the resolution of identity ∑ ⟪x, b i⟫⟪b i, y⟫ = ⟪x, y⟫",
+      "Jensen's inequality in finite-sum form for convex functions (ConvexOn.map_sum_le)",
+      "Majorization and its Hardy–Littlewood–Pólya / Karamata / Birkhoff characterizations (background for interpreting the convex-function statement as diag ≺ spec)"
+    ]
+  },
+  "sections": [
+    {
+      "title": "The Doubly Stochastic Change-of-Basis Matrix",
+      "content": "dsWeight defines D i j = ‖⟪v j, e i⟫‖², the squared moduli of the inner products between the orthonormal eigenbasis v of T and the chosen orthonormal basis e. dsWeight_nonneg is sq_nonneg. dsWeight_row_sum and dsWeight_col_sum prove ∑ j, D i j = 1 and ∑ i, D i j = 1 by Parseval — OrthonormalBasis.sum_sq_norm_inner_right for v (rows, giving ‖e i‖² = 1) and sum_sq_norm_inner_left for e (columns, giving ‖v j‖² = 1) — so D is doubly stochastic."
+    },
+    {
+      "title": "Diagonal as Doubly-Stochastic Image of the Spectrum",
+      "content": "diag_decomp proves re ⟪T (e i), e i⟫ = ∑ⱼ λⱼ · D i j. Expand ⟪T(e i), e i⟫ = ∑ⱼ ⟪T(e i), v j⟫⟪v j, e i⟫ by OrthonormalBasis.sum_inner_mul_inner. Each cross term is rewritten using eigenvectorBasis_apply_self_apply (⟪v j, T(e i)⟫ = (λ j)·⟪v j, e i⟫), inner_conj_symm, RCLike.conj_ofReal (the eigenvalue is real, so its conjugate is itself), and RCLike.conj_mul (conj z · z = ‖z‖²), giving (λ j)·‖⟪v j, e i⟫‖² = (λ j)·D i j; taking real parts term by term yields the claim. This exhibits each diagonal entry as a convex combination of eigenvalues."
+    },
+    {
+      "title": "Majorization by Jensen, and Specializations",
+      "content": "schur_majorization_convexOn: for convex φ on s ⊇ spectrum, ConvexOn.map_sum_le applied with weights D i j (nonnegative, summing to 1 by the row sums) and points λ j ∈ s gives φ(d i) ≤ ∑ⱼ D i j • φ(λ j); summing over i, swapping the order (Finset.sum_comm), and collapsing each column with ∑ᵢ D i j = 1 (Finset.sum_smul, one_smul) yields ∑ᵢ φ(d i) ≤ ∑ⱼ φ(λ j). schur_trace_eq specializes to the equality case ∑ d i = ∑ λ j directly from diag_decomp and the column sums (no convexity), and schur_sum_sq_le applies the master theorem with φ = (·)² (Even.convexOn_pow at n=2) to bound ∑ d i² ≤ ∑ λ j²."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "note": "The Schur–Horn theorem, majorization, and doubly stochastic matrices (Chapters 4 and 8)"
+    },
+    {
+      "authors": "Bhatia, R.",
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "note": "Majorization, the Schur–Horn theorem, and the Hardy–Littlewood–Pólya / Birkhoff characterizations (Chapter II)"
+    },
+    {
+      "authors": "Marshall, A. W., Olkin, I., and Arnold, B. C.",
+      "title": "Inequalities: Theory of Majorization and Its Applications",
+      "year": "2011",
+      "note": "Definitive treatment of majorization, the doubly-stochastic and convex-function (Karamata) characterizations, and Schur–Horn with its converse"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Answers its flagged standalone open question — the full Schur–Horn theorem — by proving the forward (Schur) direction diag(T) ≺ spec(T), going beyond the positivity and spectral-range (weak Schur-half) consequences of compression interlacing derived there."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "The Ky Fan weak-majorization sibling: that entry weakly majorizes a compression's spectrum by the largest eigenvalues of the full operator (an interlacing consequence); this entry proves the genuine majorization of a Hermitian operator's diagonal by its own spectrum via doubly stochastic matrices and Jensen."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "related",
+      "description": "Root of the Cauchy interlacing family. The Schur–Horn theorem is the classical companion of interlacing in the theory of eigenvalue inequalities and majorization for Hermitian operators."
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01.json
@@ -1,0 +1,89 @@
+{
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01",
+  "title": "Schur's majorization theorem (forward direction of Schur–Horn), Karamata convex-function form",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "T = T^*,\\ \\lambda = \\operatorname{spec}(T),\\ e\\ \\text{orthonormal}\\ \\Rightarrow\\ \\operatorname{diag}_e(T)\\prec\\lambda,\\ \\text{i.e.}\\ \\forall\\,\\varphi\\ \\text{convex},\\ \\sum_i \\varphi(d_i)\\le\\sum_j \\varphi(\\lambda_j)",
+    "plain": "Prove the forward (Schur) direction of the Schur–Horn theorem: the diagonal of a Hermitian operator in any orthonormal basis is majorized by its eigenvalue spectrum, stated in the Hardy–Littlewood–Pólya / Karamata form ∑ φ(dᵢ) ≤ ∑ φ(λⱼ) for every convex φ.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "schur_majorization_convexOn: for every convex φ on a set containing the spectrum, ∑ᵢ φ(re⟪T(e i),e i⟫) ≤ ∑ⱼ φ(λⱼ) — the forward direction diag(T) ≺ spec(T) in Karamata form",
+      "diag_decomp: re⟪T(e i),e i⟫ = ∑ⱼ λⱼ·‖⟪v j,e i⟫‖² — diagonal is the doubly-stochastic image of the spectrum",
+      "dsWeight_row_sum / dsWeight_col_sum: D i j = ‖⟪v j,e i⟫‖² is doubly stochastic (Parseval in both bases)",
+      "schur_trace_eq: ∑ᵢ re⟪T(e i),e i⟫ = ∑ⱼ λⱼ (basis independence of trace; equality/k=n case, no convexity)",
+      "schur_sum_sq_le: ∑ᵢ (re⟪T(e i),e i⟫)² ≤ ∑ⱼ λⱼ² (φ=(·)² instance via Even.convexOn_pow)"
+    ],
+    "open": [
+      "Converse (Horn, 1954): every tuple majorized by λ is realizable as a diagonal of a Hermitian operator with spectrum λ — needs a Birkhoff/doubly-stochastic construction; together with this forward direction completes full Schur–Horn",
+      "A reusable sorted-partial-sum majorization predicate + Hardy–Littlewood–Pólya equivalence with the Karamata form proved here, to restate the result literally as diag(T) ≺ spec(T)"
+    ],
+    "goal": "Forward direction of Schur–Horn (diag ≺ spec) in convex-function form, self-contained from spectral theorem + Parseval + Jensen."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-26T00:00:00Z",
+    "iteration": 1,
+    "focus": "Forward (Schur) direction of Schur–Horn via doubly-stochastic change-of-basis matrix D i j = ‖⟪v j, e i⟫‖² and row-by-row Jensen. VERIFIED via docker build (7743 jobs, 0 axioms / 0 sorries).",
+    "blockers": [],
+    "nextAction": "PR opened. Forward direction complete and build-verified; converse (Horn) realizability is the remaining standalone follow-up.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Wrote and VERIFIED (docker build LEAN_MEMORY_LIMIT=28672, 7743 jobs, exit 0, 0 axioms / 0 sorries) Proofs/SchurHornMajorization.lean. Proves the forward (Schur) direction of the Schur–Horn theorem in Karamata convex-function form: for any symmetric/Hermitian T over ℝ or ℂ and ANY orthonormal basis e, ∑ᵢ φ(re⟪T(e i),e i⟫) ≤ ∑ⱼ φ(λⱼ) for every convex φ — i.e. diag(T) ≺ spec(T). Self-contained from Mathlib's finite-dimensional spectral theorem, Parseval, and Jensen; does NOT use Birkhoff. Answers the standalone open question flagged by the parent oq-01-oq-02-oq-02. Gallery entry created at src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01.",
+    "builtItems": [
+      "dsWeight (def): D i j = ‖⟪v j, e i⟫‖²",
+      "dsWeight_nonneg, dsWeight_row_sum, dsWeight_col_sum (double stochasticity by Parseval)",
+      "diag_decomp: re⟪T(e i),e i⟫ = ∑ⱼ λⱼ·D i j",
+      "schur_majorization_convexOn (headline, Karamata form)",
+      "schur_trace_eq (trace basis-independence)",
+      "schur_sum_sq_le (sum-of-squares instance)"
+    ],
+    "insights": [
+      "The Karamata convex-function form of majorization (∑ φ(dᵢ) ≤ ∑ φ(λⱼ)) proves itself: it requires only that each dᵢ be a convex combination of the λⱼ, which is exactly Jensen — no sorting and no partial-sum bookkeeping, far cleaner than the sorted-top-k definition.",
+      "D i j = |⟨vⱼ, eᵢ⟩|² is doubly stochastic for free by Parseval applied in each of the two orthonormal bases; the route from the spectral theorem to majorization needs no Birkhoff theorem.",
+      "diag_decomp (re⟪T eᵢ, eᵢ⟫ = ∑ⱼ λⱼ |⟨vⱼ,eᵢ⟩|²) is the only nontrivial step; the RCLike algebra is conj of a real eigenvalue (RCLike.conj_ofReal) + conj z·z = ‖z‖² (RCLike.conj_mul), then real parts.",
+      "Stating the theorem for an abstract convex φ on a set s ⊇ spectrum makes trace equality (k=n) and ∑dᵢ² ≤ ∑λⱼ² immediate specializations rather than separate proofs.",
+      "BUILD: import Mathlib needs ≥ ~28GB for the elaboration spike (16384 was OOM-killed at the loader/elaboration stage even though the cache was downloaded); use LEAN_MEMORY_LIMIT=28672."
+    ],
+    "mathlibGaps": [
+      "Mathlib still has no majorization predicate and no Schur–Horn theorem (only a comment in InnerProductSpace.Spectrum). doublyStochastic + Birkhoff (exists_eq_sum_perm_of_mem_doublyStochastic) are present and would power the converse (Horn) direction."
+    ],
+    "nextSteps": [
+      "Converse (Horn) realizability: given d ≺ λ, construct a Hermitian operator with spectrum λ and diagonal d, via a doubly-stochastic / Birkhoff–von Neumann argument — completes the full Schur–Horn theorem.",
+      "Define a sorted-partial-sum majorization predicate and prove its Hardy–Littlewood–Pólya equivalence with the Karamata form here, to restate the theorem as diag(T) ≺ spec(T)."
+    ]
+  },
+  "tags": [
+    "linear-algebra",
+    "eigenvalues",
+    "cauchy-interlacing",
+    "majorization",
+    "schur-horn",
+    "doubly-stochastic",
+    "jensen",
+    "spectral-theorem"
+  ],
+  "relatedProofs": [
+    "cauchy-interlacing-theorem",
+    "cauchy-interlacing-theorem-oq-01-oq-02-oq-02",
+    "cauchy-interlacing-theorem-oq-01-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-26T00:00:00.000Z",
+  "lastUpdate": "2026-06-26T00:00:00.000Z",
+  "significance": 7,
+  "tractability": 6
+}

--- a/src/data/research/problems/cauchy-interlacing-theorem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-interlacing-theorem-oq-01-oq-02-oq-02.json
@@ -54,7 +54,8 @@
       "No majorization predicate and no Schur–Horn theorem in Mathlib (only a motivating comment in InnerProductSpace.Spectrum); doublyStochastic + Birkhoff (exists_eq_sum_perm_of_mem_doublyStochastic) are present, so full Schur–Horn is buildable as a separate multi-hundred-line problem."
     ],
     "nextSteps": [
-      "Standalone problem: formalize the full Schur–Horn theorem (forward Hardy–Littlewood–Pólya majorization + Birkhoff converse) — genuinely novel, not a corollary of this interlacing machinery.",
+      "DONE (cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01): forward Schur–Horn (Schur majorization, diag ≺ spec) proved in Karamata convex-function form via doubly-stochastic D i j = ‖⟪v j,e i⟫‖² + Jensen — VERIFIED, 0 axioms/0 sorries. Self-contained, no Birkhoff.",
+      "Remaining: the converse (Horn 1954) realizability direction via Birkhoff to complete full Schur–Horn.",
       "Optional: zero-padded full majorization of the rank-n compression viewed as an operator on all of V (needs the trace-equality case)."
     ]
   },


### PR DESCRIPTION
## Summary

Proves the **forward (Schur) direction of the Schur–Horn theorem** — the diagonal of a Hermitian operator is **majorized** by its eigenvalue spectrum, `diag(T) ≺ spec(T)` — in the cleanest equivalent **Hardy–Littlewood–Pólya / Karamata** form:

> for every convex `φ` (on a set containing the spectrum), `∑ᵢ φ(re⟪T(e i),e i⟫) ≤ ∑ⱼ φ(λⱼ)`

for the diagonal of `T` in **any** orthonormal basis `e`.

This answers the standalone open question flagged by the parent entry `cauchy-interlacing-theorem-oq-01-oq-02-oq-02`, which derived only the positivity and spectral-range (weak Schur-half) consequences of compression interlacing and explicitly named the full Schur–Horn theorem as genuinely distinct.

## Proof

- `dsWeight i j := ‖⟪v j, e i⟫‖²` (v = orthonormal eigenbasis) is **doubly stochastic** — rows and columns sum to 1 by **Parseval** (`dsWeight_row_sum`, `dsWeight_col_sum`).
- `diag_decomp`: the diagonal is the doubly-stochastic image of the spectrum, `re⟪T(e i),e i⟫ = ∑ⱼ λⱼ·D i j`, so each diagonal entry is a convex combination of eigenvalues.
- `schur_majorization_convexOn`: **Jensen** (`ConvexOn.map_sum_le`) row-by-row, then a column-sum swap, gives the majorization.

Corollaries: `schur_trace_eq` (basis independence of the trace, the `k=n` equality case, no convexity) and `schur_sum_sq_le` (`∑ dᵢ² ≤ ∑ λⱼ²`, the `φ=(·)²` instance).

## Relation to Mathlib

Mathlib has the finite-dimensional spectral theorem and Birkhoff's theorem on doubly stochastic matrices, but **no majorization predicate and no Schur–Horn theorem** (only a comment in `InnerProductSpace.Spectrum`). This file is self-contained from **spectral theorem + Parseval + Jensen** — it does **not** use Birkhoff.

## Verification

- Docker build: **7743 jobs, exit 0, 0 axioms, 0 sorries**.
- `Even 2` side-condition discharged by kernel-checked `decide` (not `native_decide`), so no `Lean.ofReduceBool` — genuinely axiom-free (`propext`/`Classical.choice`/`Quot.sound` only).
- 178 lines, 7 theorems, 1 def. `status: verified`, `badge: verified`.
- Gallery entry: `src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/`.

## Files

- `proofs/Proofs/SchurHornMajorization.lean` (new, research file — not registered in `Proofs.lean`)
- `src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01/{meta,annotations}.json` (new gallery entry)
- `src/data/research/problems/cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01.json` (new) + parent knowledge update

🤖 Generated with [Claude Code](https://claude.com/claude-code)