### PR TITLE
research(isoperimetric-theorem-oq-01-oq-01): sharp equality locus for the Fourier isoperimetric inequality

### DIFF
--- a/proofs/Proofs/IsoperimetricFourierOQ0101.lean
+++ b/proofs/Proofs/IsoperimetricFourierOQ0101.lean
@@ -218,4 +218,55 @@ example :
       (fun _ => 0) (fun n => if n = 1 then 1 else 0) {1} = 1 := by
   norm_num [areaFourier, Finset.sum_singleton]
 
+/-!
+## Part VI: The exact equality locus
+
+`equality_implies_circle` (Part IV) records only one direction, and only its
+projection onto the higher modes `n ≥ 2`. The full picture is an *iff*: the
+isoperimetric inequality is saturated **iff every per-mode Hurwitz term
+vanishes**. Because `hurwitzTerm n = (n aₙ − βₙ)² + (n αₙ + bₙ)² + (n²−1)(βₙ²+bₙ²)`
+this pins the equality locus exactly — for the fundamental mode `n = 1` the last
+coefficient `n²−1` is `0`, so equality forces only `a₁ = β₁` and `α₁ = −b₁`
+(the genuine-circle relation), while every higher mode is killed outright.
+-/
+
+/-- **Equality locus (iff).** For Fourier data on modes `n ≥ 1`, the isoperimetric
+inequality is saturated (`E = 2·Ar`) **iff** every per-mode Hurwitz term is zero.
+This is the sharp two-sided form of Wirtinger's inequality; `equality_implies_circle`
+is the easy consequence for modes `n ≥ 2`. -/
+theorem equality_iff_terms_vanish (s : Finset ℕ) (hs : ∀ n ∈ s, 1 ≤ n) :
+    lengthEnergy a α b β s = 2 * areaFourier a α b β s ↔
+      ∀ n ∈ s, hurwitzTerm a α b β n = 0 := by
+  have hdef := hurwitz_deficit_identity a α b β s
+  constructor
+  · intro heq
+    have hsum : ∑ n ∈ s, hurwitzTerm a α b β n = 0 := by rw [← hdef]; linarith
+    exact (Finset.sum_eq_zero_iff_of_nonneg
+      fun n hn => hurwitzTerm_nonneg a α b β n (hs n hn)).mp hsum
+  · intro hz
+    have hsum : ∑ n ∈ s, hurwitzTerm a α b β n = 0 := Finset.sum_eq_zero hz
+    rw [hsum] at hdef; linarith
+
+/-- **The fundamental mode at equality is a circle.** When equality holds and the
+mode `n = 1` is present, its coefficients satisfy the exact circle relations
+`a₁ = β₁` and `α₁ = −b₁` (e.g. `x = a₁ cos s − b₁ sin s`, `y = b₁ cos s + a₁ sin s`,
+a circle of radius `√(a₁²+b₁²)`). Combined with `equality_implies_circle`, every
+mode `n ≥ 2` vanishes, so the saturating curve is exactly a circle. -/
+theorem fundamental_mode_circle_condition (s : Finset ℕ) (hs : ∀ n ∈ s, 1 ≤ n)
+    (heq : lengthEnergy a α b β s = 2 * areaFourier a α b β s) (h1 : 1 ∈ s) :
+    a 1 = β 1 ∧ α 1 = - b 1 := by
+  have hz := (equality_iff_terms_vanish a α b β s hs).mp heq 1 h1
+  have hzero : ((1 : ℝ) * a 1 - β 1) ^ 2 + ((1 : ℝ) * α 1 + b 1) ^ 2 = 0 := by
+    have hexp : hurwitzTerm a α b β 1
+        = ((1 : ℝ) * a 1 - β 1) ^ 2 + ((1 : ℝ) * α 1 + b 1) ^ 2 := by
+      simp only [hurwitzTerm]; norm_num
+    rw [hexp] at hz; exact hz
+  have s1 : ((1 : ℝ) * a 1 - β 1) ^ 2 = 0 :=
+    le_antisymm (by nlinarith [sq_nonneg ((1 : ℝ) * α 1 + b 1)]) (sq_nonneg _)
+  have s2 : ((1 : ℝ) * α 1 + b 1) ^ 2 = 0 :=
+    le_antisymm (by nlinarith [sq_nonneg ((1 : ℝ) * a 1 - β 1)]) (sq_nonneg _)
+  have q1 : (1 : ℝ) * a 1 - β 1 = 0 := (pow_eq_zero_iff (n := 2) (by norm_num)).mp s1
+  have q2 : (1 : ℝ) * α 1 + b 1 = 0 := (pow_eq_zero_iff (n := 2) (by norm_num)).mp s2
+  exact ⟨by linarith, by linarith⟩
+
 end IsoperimetricFourier

--- a/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-01-oq-01/meta.json
@@ -9,14 +9,18 @@
   "difficulty": "intermediate",
   "leanFile": {
     "path": "Proofs/IsoperimetricFourierOQ0101.lean",
-    "imports": ["Mathlib"],
-    "opens": ["Finset"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "IsoperimetricFourier",
-    "lineCount": 221,
+    "lineCount": 272,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 7
+    "theoremCount": 9
   },
   "lineCount": 221,
   "theoremCount": 7,


### PR DESCRIPTION
## Summary

`isoperimetric-theorem-oq-01-oq-01` already proves the Hurwitz–Wirtinger **Fourier method** for the classical isoperimetric inequality `L² ≥ 4πA` (0 sorry / 0 axiom, 7 theorems). Its equality treatment, however, only records the *one-way projection onto higher modes*: `equality_implies_circle` shows saturation ⇒ every mode `n ≥ 2` vanishes.

This PR adds **Part VI** with the sharp, two-sided characterization of the equality locus.

## New theorems (2)

- **`equality_iff_terms_vanish`** — `E = 2·Ar` **iff** every per-mode Hurwitz term is zero. This is the precise equality locus of Wirtinger's inequality; the previous `equality_implies_circle` becomes an immediate corollary.
- **`fundamental_mode_circle_condition`** — at equality, with the fundamental mode present, its coefficients satisfy the exact circle relations `a₁ = β₁` and `α₁ = −b₁` (the `n²−1` weight vanishes at `n = 1`, so the fundamental mode is constrained but not killed).

Together with `equality_implies_circle`, this pins the saturating curve to a genuine circle: all higher modes die and the surviving `n = 1` mode obeys the circle relation.

## Honest scope

Self-contained algebra over finite Fourier data — a sharpening of an already-verified Euclidean entry. It does **not** transport the method to spherical/hyperbolic surfaces (the broader open question the entry is filed under); the Parseval bridge from L²-integrals remains documented, not re-derived, exactly as in the original.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.IsoperimetricFourierOQ0101` → `✔ Built Proofs.IsoperimetricFourierOQ0101` (7743 jobs, exit 0).
- 0 sorry, 0 axiom. Theorems 7 → 9; lines 221 → 272. `meta.json` `leanFile` counts updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)