### PR TITLE
audit: re-confirm angle-trisection-cos-20-gal-oq-01-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -265,10 +265,10 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "notes": "Untracked gallery entry (not in git); Lean file missing from git but PR #12837 is open \u2014 marked clean",
+      "lastAudited": "2026-06-27T02:30:00Z",
+      "notes": "Re-audited clean: 442L/0sorry/0axiom/33thm/4def (1 abbrev pCos5 + 3 def), no True stubs, no native_decide. Main theorem cos_36_gal_card genuinely proves |Gal(4X2-2X-1)|=2 via card_of_separable on degree-2 splitting field. gal_order_eq_totient_div2_general is a tautology placeholder, honestly disclosed in assumptions+docstring+inline comments. badge=original consistent with cos-20-gal family. (Supersedes stale 2026-05-03 note: file now present and verified.)",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit

Re-audited the stalest gallery entry `angle-trisection-cos-20-gal-oq-01-oq-02` (audit queue is fully clean: 4002/4002, 0 issues). Surfaced via `find-targets --next` by staleness (last audited 2026-05-03).

### Findings — CLEAN

All meta.json claims match the Lean source (`Proofs/AngleTrisectionCos20GalOQ01OQ02.lean`):

| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 442 | 442 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`) | ✓ |
| theoremCount | 33 | 33 | ✓ |
| definitionCount | 4 | 4 (1 abbrev `pCos5` + 3 `def`) | ✓ |
| True stubs | — | none | ✓ |

- **Main theorem** `cos_36_gal_card` genuinely proves |Gal(4X²−2X−1)| = 2 via `Polynomial.Gal.card_of_separable` applied to the degree-2 splitting field (built from Eisenstein-at-5 irreducibility + the Vieta identity β = 1/2 − α, all proved in-file).
- **Placeholder honesty**: `gal_order_eq_totient_div2_general` is a tautology (`x = x`), but this is prominently disclosed in the meta `assumptions` field, the docstring NOTE, and inline comments. No overclaiming.
- **badge=original** is consistent with the cos-20-gal sibling family convention — the substantive content (irreducibility, splitting-field degree) is independently formalized; Mathlib supplies only the generic bridge lemma.

### Change

Surgical 3-line tracker update: refreshes the stale 2026-05-03 note ("Lean file missing from git" — the file is now present and verified) and bumps `lastAudited` / `auditCount` so the stalest-entry pointer advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)