### PR TITLE
Enrich four-square-distribution-oq-05: cover full factor of 8, fix stale scope

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-05/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-05/annotations.json
@@ -5,7 +5,7 @@
     "range": { "startLine": 1, "endLine": 57 },
     "type": "concept",
     "title": "Sign Symmetry and Jacobi's Factor of 8",
-    "content": "The header frames the contribution: the parent file decomposes r₄(n) by type t (a sorted tuple of absolute values) and assigns each type a symmetry multiplier `contribution(t) = permutations(t)·signFactor(t)`, where `signFactor(t) = 2^(nonzeroCount t)` counts the sign choices on the nonzero coordinates. This file isolates the 2-adic, sign-change half of the hyperoctahedral group B₄ = (ℤ/2)⁴ ⋊ S₄: the subgroup (ℤ/2)^(nonzeroCount) of order 2^(nonzeroCount) always divides the contribution. The honest-scope note records that the full `8 ∣ r₄(n)` additionally needs the permutation parity in the one- and two-nonzero cases, which is deliberately out of scope.",
+    "content": "The header frames the contribution: the parent file decomposes r₄(n) by type t (a sorted tuple of absolute values) and assigns each type a symmetry multiplier `contribution(t) = permutations(t)·signFactor(t)`, where `signFactor(t) = 2^(nonzeroCount t)` counts the sign choices on the nonzero coordinates. This file isolates the 2-adic, sign-change half of the hyperoctahedral group B₄ = (ℤ/2)⁴ ⋊ S₄: the subgroup (ℤ/2)^(nonzeroCount) of order 2^(nonzeroCount) always divides the contribution. It then closes the per-type factor of 8 in full: the later section supplies the permutation parity in the one- and two-nonzero cases, yielding `8 ∣ contribution t` for every type with ≥ 1 nonzero entry. The honest-scope note records that deriving the global `8 ∣ r₄(n)` additionally needs the parent's summation `r₄(n) = Σ contribution t`, which lives upstream.",
     "mathContext": "$\\mathrm{contribution}(t) = \\mathrm{permutations}(t)\\cdot 2^{\\mathrm{nonzeroCount}(t)}, \\qquad B_4 = (\\mathbb{Z}/2)^4 \\rtimes S_4, \\quad |B_4| = 2^4\\cdot 4! = 384.$",
     "significance": "key",
     "relatedConcepts": ["hyperoctahedral group", "Jacobi four-square theorem", "sign-change symmetry", "orbit-stabilizer"],
@@ -70,5 +70,41 @@
     "significance": "key",
     "relatedConcepts": ["factor of 8", "specialization", "simp normalization of numerals"],
     "prerequisites": ["two_pow_dvd_contribution_of_le", "simpa"]
+  },
+  {
+    "id": "fsd-oq05-ann-zero-pattern",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 125, "endLine": 146 },
+    "type": "lemma",
+    "title": "Sortedness Pins the Zero Pattern",
+    "content": "The sign part alone delivers `8 ∣ contribution` only for `nonzeroCount ≥ 3`; the remaining `nonzeroCount ∈ {1,2}` cases need the permutation count, which first requires knowing *where* the zeros sit. Because a `RepType` is sorted (`a₁ ≤ a₂ ≤ a₃ ≤ a₄`), the nonzero entries must be the *largest* ones: `zero_pattern_one` forces shape `(0,0,0,a₄)` and `zero_pattern_two` forces `(0,0,a₃,a₄)`. Each is dispatched by splitting on whether each coordinate vanishes (`by_cases … <;> simp_all`), with sortedness ruling out the impossible interleavings (e.g. a nonzero entry below a zero).",
+    "mathContext": "$\\mathrm{nonzeroCount}(t)=1 \\implies t=(0,0,0,a_4),\\ a_4\\neq 0; \\qquad \\mathrm{nonzeroCount}(t)=2 \\implies t=(0,0,a_3,a_4),\\ a_3,a_4\\neq 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["sorted tuples", "case analysis", "structural normal form"],
+    "prerequisites": ["RepType.sorted", "by_cases", "simp_all"]
+  },
+  {
+    "id": "fsd-oq05-ann-perm-counts",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 148, "endLine": 189 },
+    "type": "technique",
+    "title": "Multinomial Permutation Counts for Low-Nonzero Types",
+    "content": "With the zero pattern fixed, the permutation count is computed explicitly as the multinomial coefficient 4!/(∏ multiplicities!). `permutations_one_nonzero` shows `(0,0,0,a₄)` has exactly `4 = 4!/3!` distinct orderings (three equal zeros). `two_dvd_permutations_two_nonzero` shows `(0,0,a₃,a₄)` has an *even* count — `6 = 4!/(2!·2!)` when a₃ = a₄ and `12 = 4!/2!` when a₃ ≠ a₄ — by casing on `he : a₃ = a₄`. Both unfold `RepType.permutations`, normalize the underlying multiset via `List.dedup`/`List.count` rewrites, and finish with `decide`. The evenness (not the exact value) is all that is needed downstream.",
+    "mathContext": "$\\binom{4}{3,1}=4,\\quad \\binom{4}{2,2}=6,\\quad \\binom{4}{2,1,1}=12; \\qquad 2 \\mid \\mathrm{permutations}(t)\\ \\text{when}\\ \\mathrm{nonzeroCount}(t)=2.$",
+    "significance": "key",
+    "relatedConcepts": ["multinomial coefficient", "permutations with repetition", "multiset deduplication", "decide"],
+    "prerequisites": ["List.dedup", "List.count", "RepType.permutations"]
+  },
+  {
+    "id": "fsd-oq05-ann-eight-pos",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 191, "endLine": 212 },
+    "type": "theorem",
+    "title": "The Full Type-Level Factor of 8",
+    "content": "`eight_dvd_contribution_of_pos` is the file's culminating result: every type with at least one nonzero entry contributes a multiple of 8. It splits `nonzeroCount` into `1 | 2 | ≥3` (via `omega`, using `nonzeroCount_le_four`). For one nonzero, `permutations = 4` and `signFactor = 2^1 = 2` give exactly `4·2 = 8` (`decide`). For two nonzero, the even permutation count `perm = 2m` times `signFactor = 2^2 = 4` gives `2m·4 = 8m` (explicit witness `⟨m, by ring⟩`). For `≥3`, the sign part `eight_dvd_contribution_of_three_le` already suffices. This is the per-summand divisibility behind Jacobi's `8 ∣ r₄(n)`: combined with the parent's `r₄(n) = Σ contribution t`, every summand — and hence the total — is a multiple of 8.",
+    "mathContext": "$1 \\le \\mathrm{nonzeroCount}(t) \\implies 8 \\mid \\mathrm{contribution}(t); \\qquad r_4(n) = \\sum_t \\mathrm{contribution}(t) \\implies 8 \\mid r_4(n).$",
+    "significance": "critical",
+    "relatedConcepts": ["Jacobi four-square theorem", "factor of 8", "case exhaustion", "per-summand divisibility"],
+    "prerequisites": ["zero_pattern_one", "zero_pattern_two", "permutations_one_nonzero", "two_dvd_permutations_two_nonzero", "omega"]
   }
 ]

--- a/src/data/proofs/four-square-distribution-oq-05/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-05/meta.json
@@ -2,7 +2,7 @@
   "id": "four-square-distribution-oq-05",
   "title": "The 2-adic structure of the four-square symmetry multiplier",
   "slug": "four-square-distribution-oq-05",
-  "description": "Supplies the divisibility structure of the per-type symmetry multiplier in the four-square type decomposition: the sign-change subgroup of order 2^(nonzeroCount) always divides a type's contribution. This is the '2^k' half of the hyperoctahedral symmetry B₄ = (ℤ/2)⁴ ⋊ S₄ underlying Jacobi's factor of 8, isolated per type — in particular 8 ∣ contribution once a type has ≥ 3 nonzero entries, and 16 ∣ contribution when all four are nonzero. The parent file proved only the bounds (≤ 384) and no divisibility.",
+  "description": "Supplies the divisibility structure of the per-type symmetry multiplier in the four-square type decomposition: the sign-change subgroup of order 2^(nonzeroCount) always divides a type's contribution. This is the '2^k' half of the hyperoctahedral symmetry B₄ = (ℤ/2)⁴ ⋊ S₄ underlying Jacobi's factor of 8, isolated per type — in particular 16 ∣ contribution when all four entries are nonzero. The file then closes the per-type factor of 8 in full: 8 ∣ contribution for EVERY type with ≥ 1 nonzero entry, by computing the permutation parity in the one- and two-nonzero cases. The parent file proved only the bounds (≤ 384) and no divisibility.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-23",
@@ -57,8 +57,9 @@
     "keyInsights": [
       "The contribution literally contains the sign factor as a multiplicative component, so the 2-adic divisibility is structural, not arithmetic — no number-theoretic input is needed.",
       "This isolates the sign-change half (ℤ/2)^k of the hyperoctahedral symmetry: it is exactly the part of Jacobi's factor of 8 that is visible per type, regardless of how the permutation part behaves.",
-      "8 ∣ contribution holds outright once a type has ≥ 3 nonzero entries. The remaining low-nonzero cases (1 or 2 nonzero entries) need the parity of the permutation count and are deliberately left out of scope here.",
-      "The result complements the parent's upper bound: together they sandwich each type's contribution between a fixed power of 2 (as a divisor) and 384 (as a bound)."
+      "8 ∣ contribution holds for EVERY nonzero type, not just those with ≥ 3 nonzero entries. The ≥ 3 case is pure sign symmetry; the 1- and 2-nonzero cases are closed by computing the permutation count (4!/multiplicities!), whose own factors of 2 make up the shortfall left by the smaller sign factor.",
+      "The result complements the parent's upper bound: together they sandwich each type's contribution between a fixed power of 2 (as a divisor) and 384 (as a bound).",
+      "Proving 8 ∣ contribution per type — rather than 8 ∣ r₄(n) directly — gives a per-summand proof architecture for Jacobi's factor of 8: since r₄(n) = Σ_types contribution t, divisibility of every summand transfers to the sum by Finset.dvd_sum, reducing a global congruence to a finite, type-local computation."
     ],
     "prerequisites": [
       "The parent file's RepType, contribution, signFactor (= 2^nonzeroCount), and nonzeroCount definitions",
@@ -78,9 +79,17 @@
       "id": "sec-divisibility",
       "title": "Sign-Part Divisibility of the Multiplier",
       "startLine": 59,
-      "endLine": 110,
+      "endLine": 123,
       "summary": "one_le_signFactor; signFactor_dvd_contribution; two_pow_nonzeroCount_dvd_contribution; the tower two_pow_dvd_contribution_of_le; and the corollaries two/four/eight/sixteen_dvd_contribution by nonzeroCount.",
       "mathContext": "2^k ∣ contribution t for k ≤ nonzeroCount t; the factor of 8 appears once a type has ≥ 3 nonzero entries."
+    },
+    {
+      "id": "sec-full-eight",
+      "title": "The Full Type-Level Factor of 8",
+      "startLine": 125,
+      "endLine": 213,
+      "summary": "Closes the per-type factor of 8 for the low-nonzero cases the sign part cannot reach: zero_pattern_one/two pin the zero pattern from sortedness; permutations_one_nonzero (= 4) and two_dvd_permutations_two_nonzero (even) compute the multinomial permutation count; eight_dvd_contribution_of_pos then gives 8 ∣ contribution t for every type with ≥ 1 nonzero entry.",
+      "mathContext": "1 ≤ nonzeroCount t ⟹ 8 ∣ contribution t; the 1- and 2-nonzero cases use permutations(t) ∈ {4, 6, 12}, all even·signFactor giving 8."
     }
   ],
   "crossReferences": [
@@ -101,10 +110,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Machine-verified divisibility structure of the four-square symmetry multiplier: 2^(nonzeroCount t) ∣ contribution t for every type, hence 8 ∣ contribution t once a type has ≥ 3 nonzero entries and 16 ∣ contribution t when all four are nonzero. Zero sorries, zero axioms beyond the foundational ones.",
-    "implications": "Isolates the sign-change half of the hyperoctahedral symmetry behind Jacobi's factor of 8 at the per-type level, complementing the parent's upper bound. The full 8 ∣ r₄(n) refinement (needing the permutation parity in the one- and two-nonzero cases) is identified as the remaining step.",
+    "summary": "Machine-verified divisibility structure of the four-square symmetry multiplier: 2^(nonzeroCount t) ∣ contribution t for every type (the sign part), and 16 ∣ contribution t when all four entries are nonzero. The file then proves the full per-type factor of 8: 8 ∣ contribution t for EVERY type with ≥ 1 nonzero entry, supplying the permutation parity in the one- and two-nonzero cases the sign part cannot reach. Zero sorries, zero axioms beyond the foundational ones.",
+    "implications": "Establishes the complete per-summand factor of 8 behind Jacobi's 8 ∣ r₄(n): combined with the parent's additive decomposition r₄(n) = Σ contribution t, every summand is a multiple of 8 and hence so is the total. The ≥ 3 case is pure sign symmetry; the 1- and 2-nonzero cases are closed by the multinomial permutation count, complementing the parent's upper bound. Only the upstream summation lemma r₄(n) = Σ contribution t (proved in the parent) is needed to globalize the result.",
     "openQuestions": [
-      "Can the permutation parity in the one- and two-nonzero cases be supplied so that 8 ∣ contribution t holds for every type with ≥ 1 nonzero entry, yielding a fully type-local proof of Jacobi's 8 ∣ r₄(n) for n ≥ 1?",
+      "The per-type factor of 8 (8 ∣ contribution t for every nonzero type) is now established here; the remaining step to a fully formal Jacobi 8 ∣ r₄(n) for n ≥ 1 is to combine it with the parent's additive decomposition r₄(n) = Σ contribution t over the finite set of types. Can that summation be discharged in Lean so the global divisibility follows by Finset.dvd_sum?",
       "Does the same sign-part argument generalize to sums of 2k squares, giving 2^(nonzeroCount) ∣ contribution under the hyperoctahedral group B_{2k} = (ℤ/2)^{2k} ⋊ S_{2k}, and how does the resulting power of two compare with the known factor in r_{2k}(n)?",
       "What is the exact 2-adic valuation v₂(contribution t) — i.e. when does the permutation count permutations(t) contribute additional factors of 2 beyond the sign part established here?"
     ]


### PR DESCRIPTION
Enrichment pass for `four-square-distribution-oq-05`. (This branch/PR was reused from a prior enricher-2 run; its content is now the four-square enrichment below.)

**Accuracy fix (primary):** the Lean file proves `eight_dvd_contribution_of_pos` — the full per-type factor of 8 for *every* type with ≥ 1 nonzero entry — but several narrative fields still described the 1-/2-nonzero cases as out-of-scope or open. Corrected in: `description`, `overview.keyInsights`, `conclusion.summary`/`implications`, `conclusion.openQuestions[0]`, and the header annotation.

**Coverage:** lines 125-213 (zero-pattern lemmas, multinomial permutation counts, and `eight_dvd_contribution_of_pos`) had no annotation or section coverage. Added:
- 3 annotations: `fsd-oq05-ann-zero-pattern`, `fsd-oq05-ann-perm-counts`, `fsd-oq05-ann-eight-pos`
- new `sec-full-eight` section; extended `sec-divisibility` to line 123

**Depth:** added a keyInsight on the per-summand proof architecture (`Finset.dvd_sum`) and reframed `openQuestions[0]` around the genuine remaining step.

meta.json 12.4 KB (under cap). `pnpm build` passes; both JSON files validate.