### PR TITLE
research(erdos-476-oq-05): prove corrected ap_sdiff_endpoint (Vosper AP pull-back), verified 0/0

### DIFF
--- a/proofs/Proofs/Erdos476OQ05APEndpoint.lean
+++ b/proofs/Proofs/Erdos476OQ05APEndpoint.lean
@@ -1,0 +1,206 @@
+/-
+Erdős Problem #476, Open Question 5: Vosper's Theorem — AP endpoint position analysis.
+
+Standalone proof of `ap_sdiff_endpoint`, the lemma that identifies the position of
+a removed element `a₀` relative to the arithmetic progression `A' = A.erase a₀`,
+used in the AP pull-back step of the Dyson e-transform induction. This discharges
+the `sorry` at `Erdos476OQ05Aristotle.lean:132`.
+
+Math: map both APs to "intervals mod p" via x ↦ (x - s₂)·d⁻¹ (a ZMod-p bijection).
+AP₂ becomes {0,…,m-1} and AP₁ becomes {c, c+1, …, c+(n-1)} with c = (s₁-s₂)·d⁻¹.
+With n + m ≤ p there is no double wraparound, so |AP₁ \ AP₂| = #{i < n : (γ+i) mod p ≥ m}
+where γ = c.val. Setting this count to 1 forces γ = m-n+1 (successor) or γ = p-1
+(predecessor), i.e. s₁ = s₂ + (m-n+1)·d or s₁ = s₂ - d.
+
+No `sorry`, no `axiom`.
+-/
+import Mathlib
+
+open Finset Function
+open scoped Pointwise
+
+namespace Erdos476OQ05APEndpoint
+
+variable {p : ℕ} [hp : Fact p.Prime]
+
+/-- An arithmetic progression in ZMod p starting at `a` with difference `d`. -/
+def IsArithmeticProgression (A : Finset (ZMod p)) (a d : ZMod p) : Prop :=
+  A = (Finset.range A.card).image (fun (i : ℕ) => a + (i : ZMod p) * d)
+
+/-- Pure-Nat counting core: with no double wraparound (`n + m ≤ p`), the count of
+`i < n` whose shifted residue `(γ + i) mod p` lands at or beyond `m` equals 1 only
+when `γ = m - n + 1` (no wrap) or `γ = p - 1` (wrap). -/
+lemma count_eq_one_aux {n m p γ : ℕ} (hn : 2 ≤ n) (hnm : n ≤ m)
+    (hnmp : n + m ≤ p) (hγ : γ < p)
+    (hcount : ((Finset.range n).filter (fun i => m ≤ (γ + i) % p)).card = 1) :
+    γ = m - n + 1 ∨ γ = p - 1 := by
+  by_cases hwrap : γ + n ≤ p
+  · -- No wrap: every residue is exact, the count is a clean interval length.
+    left
+    have hfilter : (Finset.range n).filter (fun i => m ≤ (γ + i) % p)
+        = Finset.Ico (m - γ) n := by
+      ext i
+      simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+      constructor
+      · rintro ⟨hi, hmod⟩
+        have hlt : γ + i < p := by omega
+        rw [Nat.mod_eq_of_lt hlt] at hmod
+        omega
+      · rintro ⟨hge, hi⟩
+        refine ⟨hi, ?_⟩
+        have hlt : γ + i < p := by omega
+        rw [Nat.mod_eq_of_lt hlt]
+        omega
+    rw [hfilter, Nat.card_Ico] at hcount
+    omega
+  · -- Wrap: exactly the high block {γ,…,p-1} clears the threshold, count = p - γ.
+    right
+    push_neg at hwrap
+    have hfilter : (Finset.range n).filter (fun i => m ≤ (γ + i) % p)
+        = Finset.range (p - γ) := by
+      ext i
+      simp only [Finset.mem_filter, Finset.mem_range]
+      constructor
+      · rintro ⟨hi, hmod⟩
+        by_cases hip : γ + i < p
+        · omega
+        · -- i ≥ p - γ would push the wrapped residue below m, contradicting hmod
+          have hmodval : (γ + i) % p = γ + i - p := by
+            conv_lhs => rw [show γ + i = p + (γ + i - p) by omega]
+            rw [Nat.add_mod_left, Nat.mod_eq_of_lt (by omega)]
+          rw [hmodval] at hmod
+          omega
+      · intro hi
+        have hin : i < n := by omega
+        have hlt : γ + i < p := by omega
+        refine ⟨hin, ?_⟩
+        rw [Nat.mod_eq_of_lt hlt]
+        omega
+    rw [hfilter, Finset.card_range] at hcount
+    omega
+
+/-- **Position analysis** (Vosper AP pull-back). When `AP₁` (start `s₁`, length `n`,
+diff `d`) and `AP₂` (start `s₂`, length `m`, diff `d`) satisfy `(AP₁ \ AP₂).card = 1`
+with `n ≤ m` and `n + m ≤ p`, then `s₁ = s₂ - d` (predecessor) or
+`s₁ = s₂ + (m - n + 1)·d` (successor). -/
+lemma ap_sdiff_endpoint (AP₁ AP₂ : Finset (ZMod p)) (s₁ s₂ d : ZMod p)
+    (hAP₁ : IsArithmeticProgression AP₁ s₁ d)
+    (hAP₂ : IsArithmeticProgression AP₂ s₂ d)
+    (hd : d ≠ 0)
+    (h₁ : 2 ≤ AP₁.card)
+    (h₁₂ : AP₁.card ≤ AP₂.card)
+    (hlt : AP₁.card + AP₂.card ≤ p)
+    (h_sdiff : (AP₁ \ AP₂).card = 1) :
+    s₁ = s₂ - d ∨ s₁ = s₂ + ((AP₂.card - AP₁.card + 1 : ℕ) : ZMod p) * d := by
+  haveI : NeZero p := ⟨hp.out.pos.ne'⟩
+  -- Abbreviations
+  set n := AP₁.card with hn_def
+  set m := AP₂.card with hm_def
+  set f : ℕ → ZMod p := fun i => s₁ + (i : ZMod p) * d with hf_def
+  set c : ZMod p := (s₁ - s₂) * d⁻¹ with hc_def
+  set γ : ℕ := c.val with hγ_def
+  -- AP defining equations
+  simp only [IsArithmeticProgression] at hAP₁ hAP₂
+  rw [← hn_def] at hAP₁
+  rw [← hm_def] at hAP₂
+  -- Bounds
+  have hn2 : 2 ≤ n := h₁
+  have hnm : n ≤ m := h₁₂
+  have hnmp : n + m ≤ p := hlt
+  have hnp : n < p := by omega
+  have hmp : m < p := by omega
+  have hγp : γ < p := ZMod.val_lt c
+  -- `f` is injective on `range n` (n < p, d ≠ 0)
+  have hf_inj : Set.InjOn f (Finset.range n) := by
+    intro i hi j hj hfij
+    simp only [Finset.coe_range, Set.mem_Iio] at hi hj
+    rw [hf_def] at hfij
+    simp only at hfij
+    have h1 : (i : ZMod p) * d = (j : ZMod p) * d := by
+      have := add_left_cancel hfij; exact this
+    have h2 : (i : ZMod p) = (j : ZMod p) := mul_right_cancel₀ hd h1
+    have hval := congrArg ZMod.val h2
+    rwa [ZMod.val_natCast, ZMod.val_natCast, Nat.mod_eq_of_lt (by omega),
+      Nat.mod_eq_of_lt (by omega)] at hval
+  -- Residue bridge: for i < p, (c + i).val = (γ + i) % p
+  have hres : ∀ i : ℕ, i < p → (c + (i : ZMod p)).val = (γ + i) % p := by
+    intro i hip
+    rw [ZMod.val_add, ZMod.val_natCast, Nat.mod_eq_of_lt hip, hγ_def]
+  -- Membership characterization: for i < n, f i ∈ AP₂ ↔ (γ + i) % p < m
+  have hmem : ∀ i : ℕ, i < n → (f i ∈ AP₂ ↔ (γ + i) % p < m) := by
+    intro i hin
+    have hip : i < p := by omega
+    rw [hAP₂]
+    simp only [Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨j, hj, hji⟩
+      -- s₂ + j·d = f i = s₁ + i·d  ⟹  (j : ZMod p) = c + i
+      have hjc : (j : ZMod p) = c + (i : ZMod p) := by
+        rw [hf_def] at hji; simp only at hji
+        have hstep : (j : ZMod p) * d = (s₁ - s₂) + (i : ZMod p) * d := by
+          linear_combination hji
+        apply mul_right_cancel₀ hd
+        rw [hstep, hc_def, add_mul, mul_assoc, inv_mul_cancel₀ hd, mul_one]
+      have hvalj : (γ + i) % p = j := by
+        rw [← hres i hip, ← hjc, ZMod.val_natCast, Nat.mod_eq_of_lt (by omega)]
+      omega
+    · intro hwm
+      refine ⟨(γ + i) % p, by omega, ?_⟩
+      -- reconstruct: s₂ + ((γ+i)%p)·d = f i
+      have hcast : (((γ + i) % p : ℕ) : ZMod p) = c + (i : ZMod p) := by
+        rw [← hres i hip, ZMod.natCast_zmod_val]
+      rw [hf_def]; simp only
+      rw [hcast, hc_def]
+      field_simp
+      ring
+  -- Reduce |AP₁ \ AP₂| to the Nat count
+  have hsdiff_eq : AP₁ \ AP₂
+      = ((Finset.range n).filter (fun i => m ≤ (γ + i) % p)).image f := by
+    ext x
+    simp only [Finset.mem_sdiff, Finset.mem_image, Finset.mem_filter, Finset.mem_range]
+    constructor
+    · rintro ⟨hx1, hx2⟩
+      rw [hAP₁] at hx1
+      simp only [Finset.mem_image, Finset.mem_range] at hx1
+      obtain ⟨i, hin, hfi⟩ := hx1
+      refine ⟨i, ⟨hin, ?_⟩, hfi⟩
+      rw [← hfi] at hx2
+      have := (hmem i hin).not.mp hx2
+      omega
+    · rintro ⟨i, ⟨hin, hge⟩, hfi⟩
+      refine ⟨?_, ?_⟩
+      · rw [hAP₁]; simp only [Finset.mem_image, Finset.mem_range]; exact ⟨i, hin, hfi⟩
+      · rw [← hfi]
+        rw [hmem i hin]; omega
+  have hcard : (AP₁ \ AP₂).card
+      = ((Finset.range n).filter (fun i => m ≤ (γ + i) % p)).card := by
+    rw [hsdiff_eq, Finset.card_image_of_injOn]
+    apply hf_inj.mono
+    intro x hx
+    simp only [Finset.coe_filter, Finset.mem_coe, Finset.mem_range, Set.mem_setOf_eq] at hx ⊢
+    exact hx.1
+  rw [hcard] at h_sdiff
+  -- Apply the Nat counting core
+  have hcore := count_eq_one_aux hn2 hnm hnmp hγp h_sdiff
+  -- Translate γ-conclusion back to s₁
+  have hcd : c * d = s₁ - s₂ := by
+    rw [hc_def, mul_assoc, inv_mul_cancel₀ hd, mul_one]
+  rcases hcore with hgeq | hgeq
+  · -- γ = m - n + 1  ⟹  c = (m-n+1 : ZMod p)  ⟹  successor
+    right
+    have hcval : c = ((m - n + 1 : ℕ) : ZMod p) := by
+      rw [← ZMod.natCast_zmod_val c, ← hγ_def, hgeq]
+    have : s₁ - s₂ = ((m - n + 1 : ℕ) : ZMod p) * d := by rw [← hcd, hcval]
+    rw [hm_def, hn_def] at this ⊢
+    linear_combination this
+  · -- γ = p - 1  ⟹  c = -1  ⟹  predecessor
+    left
+    have hcval : c = ((p - 1 : ℕ) : ZMod p) := by
+      rw [← ZMod.natCast_zmod_val c, ← hγ_def, hgeq]
+    have hcneg : c = -1 := by
+      rw [hcval, Nat.cast_sub hp.out.pos, ZMod.natCast_self]
+      simp
+    have : s₁ - s₂ = -1 * d := by rw [← hcd, hcneg]
+    linear_combination this
+
+end Erdos476OQ05APEndpoint

--- a/research/knowledge/technique-index.json
+++ b/research/knowledge/technique-index.json
@@ -46,6 +46,14 @@
       "outcome": "blocked",
       "date": "2026-06-25",
       "description": "Established that the product-outer-measure Fubini section bound (lambda*_n(E) <= integral of section outer measures) is the FALSE direction for non-measurable families (Sierpinski counterexample), refuting the proposed OuterMeasure.le_prod_outer helper for Erdos-Hajnal finite independence. Real crux is joint measurability of a measurable-hull family."
+    },
+    {
+      "name": "ZMod d⁻¹-rescale to intervals-mod-p (AP set-difference counting)",
+      "used_in_problems": [
+        "erdos-476-oq-05"
+      ],
+      "outcome": "success",
+      "date": "2026-06-26"
     }
   ]
 }

--- a/research/problems/erdos-476-oq-05/state.md
+++ b/research/problems/erdos-476-oq-05/state.md
@@ -4,15 +4,25 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-15T15:38:43-07:00
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
-Two open sorries remain in `Erdos476OQ05Aristotle.lean`, both Aristotle targets:
-- `ap_sdiff_endpoint` (was line 114): AP set-difference endpoint lemma.
-- line ~269 (case1_exists `|B|≥3` branch): Dyson e-transform induction, ~150–200 LOC.
+`ap_sdiff_endpoint` is now PROVEN (verified standalone, 0/0). Remaining open work
+in `Erdos476OQ05Aristotle.lean`:
+- line ~287 (case1_exists `|B|≥3` branch): Dyson e-transform induction `sorry`.
+- **PRE-EXISTING ROT in `case1_exists`** (file never built at HEAD; confirmed by
+  building HEAD baseline this session). Six sites, independent of any new work:
+  - `Nat.inf_eq_min` removed from mathlib — `simp only [Nat.inf_eq_min]` (~L171).
+    Fix: `inf_of_le_right (show … ≤ p by omega)`.
+  - genuine gap: `non_redundant_b_gives_a` needs `A.card+B.card < p` but caller only
+    has `A.card+B.card-1 < p` (could be `=p`) (~L179).
+  - `▸`-on-`Ne` (`(hall a haA).symm ▸ …`, ~L161) → use `have hne := hall a haA; omega`.
+  - `eq_sub_of_add_eq` type mismatches (~L233, L242) → add `.symm`/reorder.
 
 ## Active Approach
-Correctness audit of the helper lemmas before delegating to Aristotle.
+Iteration 3 (this session): hand-proved the corrected `ap_sdiff_endpoint` as a
+standalone companion (rescale by d⁻¹ → intervals mod p → wrap/no-wrap residue
+count). Docker build-green v4.26 (7743 jobs). PR #30476.
 
 ## Attempt Count
 - Total attempts: 1
@@ -20,9 +30,13 @@ Correctness audit of the helper lemmas before delegating to Aristotle.
 - Approaches tried: 1
 
 ## Blockers
-- Aristotle backend 404 (live-probed) — cannot delegate the two HARD sorries.
-- Local `.lake` is a circular self-symlink (0 oleans); Docker saturated (5 containers,
-  incl 7h zombie) — cannot Docker-verify a hand proof this cycle.
+- `case1_exists` pre-existing rot (above) blocks a full green build of the parent
+  Aristotle file → wiring (import + 1-line delegation) of the proven
+  `ap_sdiff_endpoint` is deferred until that rot is repaired. The delegation itself
+  was confirmed to elaborate cleanly (cross-namespace `IsArithmeticProgression`
+  are defeq; the only errors in the wired build were the pre-existing case1 ones).
+- Docker VM cap = 23.4 GB: inlining the ~110-line proof into the (Cauchy-Davenport)
+  parent OOMs at 20 GB. Keep it in a separate compilation unit (per-module memory).
 
 ## Key Finding (this session)
 `ap_sdiff_endpoint` was stated with `0 < AP₁.card`, which makes it **FALSE**.
@@ -33,8 +47,10 @@ is inlined as a comment above the sorry. The lemma is currently unused (it is in
 support for the line-269 Dyson e-transform step), so the hypothesis strengthening is safe.
 
 ## Next Action
-When Aristotle is non-404 OR a Docker trough (≤2 containers) opens:
-1. Submit/hand-prove the corrected `ap_sdiff_endpoint` (now a TRUE statement).
-2. Then attack the line-269 Dyson e-transform induction (blueprint in knowledge.md).
-Do NOT re-submit the original `0 < AP₁.card` form — Aristotle would return the n=1
-counterexample, not a proof.
+1. DONE (iter 3): `ap_sdiff_endpoint` proven + verified standalone (PR #30476).
+2. Repair the pre-existing `case1_exists` rot (4 fixes listed under Current Focus) —
+   mechanic-style, but watch the genuine `A.card+B.card<p` gap at ~L179 (may need a
+   real argument, not a mechanical patch). After green, wire `ap_sdiff_endpoint` in
+   via `import Proofs.Erdos476OQ05APEndpoint` + a 1-line delegation at the L132 sorry.
+3. Then attack the Dyson e-transform induction sorry (~L287; blueprint in knowledge.md).
+Do NOT re-submit the original `0 < AP₁.card` form — it is FALSE (n=1 counterexample).

--- a/src/data/research/problems/erdos-476-oq-05.json
+++ b/src/data/research/problems/erdos-476-oq-05.json
@@ -38,7 +38,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: e-transform engine verified (CD-equality preservation invariant shipped, 0 sorry/0 axiom); remaining gap = AP pull-back step. API pinned without a build.",
+    "progressSummary": "PROGRESS: ap_sdiff_endpoint proven+verified (0/0, PR #30476); parent case1_exists has separate pre-existing rot blocking full green build",
     "builtItems": [
       "isAP_sdiff_card: proved A\\A.image(·+d)={a} for AP(a,d) with d≠0, |A|<p — key: start a has no predecessor (Erdos476OQ05Problem.lean:153)",
       "vosper_ap_sdiff_card: structured proof using isAP_sdiff_card, hunion, h_sdiff_one — only hpos (position analysis) remains (Erdos476OQ05Problem.lean:207)",
@@ -48,7 +48,8 @@
       "Erdos476OQ05Aristotle.lean: ap_sdiff_endpoint lemma (sorry, submitted to Aristotle)",
       "Erdos476OQ05Aristotle.lean: case1_exists lemma (sorry with partial proof sketch, submitted to Aristotle)",
       "hpos proved: a₀=a₁-d OR a₀=a₁+|A'|·d, via 3-way case split on missing AP index (Erdos476OQ05Problem.lean:248-420, Session 20)",
-      "Erdos476OQ05ETransform.lean (registered, 0 sorry/0 axiom): etransform_fst_superset, etransform_snd_subset, and etransform_preserves_cd_equality — the e-transform induction invariant (preserves Cauchy-Davenport equality below threshold p)"
+      "Erdos476OQ05ETransform.lean (registered, 0 sorry/0 axiom): etransform_fst_superset, etransform_snd_subset, and etransform_preserves_cd_equality — the e-transform induction invariant (preserves Cauchy-Davenport equality below threshold p)",
+      "Erdos476OQ05APEndpoint.lean: ap_sdiff_endpoint (corrected 2≤AP₁.card) + count_eq_one_aux — verified 0 sorry/0 axiom, Docker-green v4.26 (PR #30476)"
     ],
     "insights": [
       "Vosper 1956: equality |A+B|=|A|+|B|-1 (with |A|,|B|≥2, |A|+|B|≤p) ↔ A,B are APs with same common difference",
@@ -74,10 +75,13 @@
       "Kneser in ZMod p (prime) collapses to Cauchy-Davenport: stab(A+B)={0} whenever |A+B|<p, so Kneser does NOT characterize the equality case — prior BLOCKED sessions were right to drop it",
       "The correct tool for the remaining hard case is the Dyson e-transform, which IS in Mathlib: Finset.addDysonETransform (Mathlib/Combinatorics/Additive/ETransform.lean), with addDysonETransform.card preserving |A|+|B| and the sumset not growing",
       "Remaining gap is now a single axiom vosper_case1_exists_large (not 2 sorries): all SORRY-2 and the |B|=2 / |A|=|B|=3 sub-cases of SORRY-1 are fully proved in Erdos476OQ05Problem.lean",
-      "Pinned exact Mathlib addDysonETransform API via mathlib4_docs (no build): def = (A ∪ (e+ᵥB), B ∩ (-e+ᵥA)); addDysonETransform.card preserves |A|+|B|; addDysonETransform.subset gives (τ).1+(τ).2 ⊆ A+B"
+      "Pinned exact Mathlib addDysonETransform API via mathlib4_docs (no build): def = (A ∪ (e+ᵥB), B ∩ (-e+ᵥA)); addDysonETransform.card preserves |A|+|B|; addDysonETransform.subset gives (τ).1+(τ).2 ⊆ A+B",
+      "Parent Erdos476OQ05Aristotle.lean NEVER built at HEAD: pre-existing case1_exists rot — Nat.inf_eq_min removed from mathlib, genuine A.card+B.card<p gap (~L179), ▸-on-Ne/eq_sub_of_add_eq type mismatches. Confirmed by building HEAD baseline.",
+      "Docker VM cap 23.4GB: inlining ~110-line proof into Cauchy-Davenport parent OOMs at 20GB; keep heavy proofs in separate compilation units (memory is per-module)."
     ],
     "mathlibGaps": [
-      "No Vosper/Freiman equality-case characterization in Mathlib; must be built from the e-transform (addDysonETransform IS present) — NOT from Kneser (which only gives the CD inequality in ZMod p)"
+      "No Vosper/Freiman equality-case characterization in Mathlib; must be built from the e-transform (addDysonETransform IS present) — NOT from Kneser (which only gives the CD inequality in ZMod p)",
+      "mathlib v4.26 removed Nat.inf_eq_min; use inf_of_le_right to eliminate ⊓ on ℕ before omega"
     ],
     "nextSteps": [
       "Check Aristotle job a5594e66 for case1_exists result",
@@ -87,7 +91,8 @@
       "When Aristotle returns, submit companion case1_exists with hint: use Finset.addDysonETransform, induct on |B|",
       "Blocked this session by infra only: Docker OOM (circular proofs/.lake self-symlink) + Aristotle prove 404",
       "AP pull-back lemma: from (A,B)=addDysonETransform e (A,B) being APs with common diff d, recover (A,B) are APs — the genuine crux, ideal Aristotle target",
-      "Prove strict-shrink (τ).2 ⊊ B for non-AP B + nonemptiness of both transformed components, then assemble the induction on |B| down to vosper_base"
+      "Prove strict-shrink (τ).2 ⊊ B for non-AP B + nonemptiness of both transformed components, then assemble the induction on |B| down to vosper_base",
+      "Repair case1_exists rot (4 mechanical + 1 genuine-gap fix), then wire ap_sdiff_endpoint into parent via import+delegation"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Adds a **standalone, Docker-verified** companion `proofs/Proofs/Erdos476OQ05APEndpoint.lean` proving the **AP set-difference endpoint lemma** (`ap_sdiff_endpoint`) used in the Dyson e-transform step of Vosper's theorem (Erdős #476, Open Question 5).

- **Build**: green on Lean v4.26 (7743/7743 jobs)
- **`sorry`**: 0 · **`axiom`**: 0 · **`native_decide`**: 0 (only `propext`/`Classical.choice`/`Quot.sound`)

## The lemma

For arithmetic progressions `AP₁` (start `s₁`, length `n`, diff `d`) and `AP₂` (start `s₂`, length `m`, diff `d`) in `ZMod p` with `|AP₁ \ AP₂| = 1`, `2 ≤ n ≤ m`, and `n + m ≤ p`:
```
s₁ = s₂ - d                (AP₁ is the predecessor of AP₂)
  ∨ s₁ = s₂ + (m-n+1)·d    (AP₁ is the successor of AP₂)
```

**Proof.** Rescale by `d⁻¹` and translate so both APs become intervals mod `p`. The pure-Nat core `count_eq_one_aux` pins `γ = ((s₁-s₂)·d⁻¹).val` to `m-n+1` (no wrap) or `p-1` (wrap) through a wrap / no-wrap residue-count split, using `n + m ≤ p` to rule out double wraparound.

## Corrected hypothesis (mathematical finding)

The hypothesis must be **`2 ≤ AP₁.card`**, not `0 < AP₁.card`. With only `0 < AP₁.card` the statement is **false**: take `p=7, d=1, AP₂={0,1,2}, AP₁={4}` — then `|AP₁ \ AP₂| = 1` and `n+m=4 ≤ 7`, yet `s₁=4` is neither endpoint. A singleton AP can sit anywhere outside `AP₂`; only `n ≥ 2` forces an endpoint.

## Scope / follow-up

This lemma discharges the `ap_sdiff_endpoint` `sorry` at `Erdos476OQ05Aristotle.lean:132`. **Wiring (import + delegation) is deferred**: that companion has a separate, **pre-existing** breakage in its Aristotle-generated `case1_exists` proof that already fails to build at HEAD (verified independently), unrelated to this change:

- mathlib drift: `Nat.inf_eq_min` no longer exists (`simp only [Nat.inf_eq_min]`, ~line 171)
- a genuine logical gap: `non_redundant_b_gives_a` needs `A.card + B.card < p`, but the caller only has `A.card + B.card - 1 < p` (~line 179)
- `▸`-on-`Ne` and `eq_sub_of_add_eq` type-mismatch sites (~lines 161/233/242)

Recommend a follow-up mechanic/researcher pass to repair `case1_exists`, after which this lemma wires in via a one-line delegation (cross-namespace `IsArithmeticProgression` are defeq; the delegation was confirmed to elaborate cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)