### PR TITLE
audit: re-confirm angle-trisection-cos-20-gal clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -247,9 +247,9 @@
       "result": "clean"
     },
     "angle-trisection-cos-20-gal": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T03:00:00Z",
       "result": "clean"
     },
     "angle-trisection-cos-20-gal-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit

**Proof**: angle-trisection-cos-20-gal — |Gal(8X³−6X−1/ℚ)| = 3
**Verdict**: CLEAN (stalest entry; last audited 2026-05-03)

### Checks
| Field | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (only docstring mention) | ✓ |
| lineCount | 474 | 474 | ✓ |
| True stubs | — | 0 | ✓ |
| status/badge | verified/original | defensible | ✓ |

### Tier classification
Borderline Tier A/B. The main theorem `cos20_gal_card` delegates only the *generic* degree→cardinality step to Mathlib's `Polynomial.Gal.card_of_separable`. The substantive content — splitting-field degree = 3, via Eisenstein on the shifted X³−6X²+9X−3 plus explicit conjugate-root containment in ℚ(α) — is genuine in-file work. `badge: original` is defensible (consistent with sibling cos-20-gal-oq-01 precedent), and the Mathlib bridge is honestly disclosed in proofStrategy/keyInsights.

### Note (non-blocking)
`theoremCount: 33` is the known cos-20-gal family count-convention quirk (6 top-level decls, 51 incl. `have`); non-substantive, no overclaim.

Updates audit-tracker timestamp (2-line surgical diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)