### PR TITLE
research(baire-category-theorem-oq-01-oq-01-oq-01): open mapping + closed graph from gallery Baire, VERIFIED

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -275,6 +275,7 @@ import Proofs.AutomorphicNumberOQ01OQ03OQ01
 import Proofs.BaireCantorBendixsonOQ010202
 import Proofs.BaireCategoryTheoremOQ01
 import Proofs.BaireCategoryTheoremOQ01OQ01
+import Proofs.BaireCategoryTheoremOQ01OQ01OQ01
 import Proofs.BaireCategoryTheoremOQ01OQ03
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01

--- a/proofs/Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,256 @@
+import Mathlib
+import Proofs.BaireCategoryTheoremOQ01
+
+/-!
+# The Open Mapping and Closed Graph theorems from Baire's theorem
+
+This file completes the *three pillars of linear functional analysis* in the gallery.
+The parent file `BaireCategoryTheoremOQ01OQ01.lean` derived the **Uniform Boundedness
+Principle** (Banach–Steinhaus) from the gallery Baire category theorem; this file derives
+the other two cornerstones — the **Open Mapping Theorem** and the **Closed Graph
+Theorem** — from the *same* gallery category theorem
+(`BaireCategoryTheoremOQ01.baire_nonempty_interior`).
+
+## The role of Baire
+
+All three theorems share a single Baire-theoretic engine.  For the open mapping theorem the
+engine appears in exactly one place: the image of the unit ball under a surjective operator
+covers the target by a countable union of closed sets, so Baire's category theorem hands us
+one whose closure has nonempty interior.  Everything afterwards — the rescaling shell
+estimate, the convergent successive-approximation series, the open-map and inverse-map
+deductions — is pure metric/completeness bookkeeping with **no further appeal to Baire**.
+
+Here the single category-theorem call is routed through the gallery theorem
+`baire_nonempty_interior` (the re-export of `nonempty_interior_of_iUnion_of_closed`),
+making Baire genuinely load-bearing for this entry, exactly as in the parent's
+Banach–Steinhaus derivation.
+
+## Main results
+
+* `exists_approx_preimage_norm_le` — the Baire step: every `y` is approximated to within
+  `‖y‖/2` by the image of an element of norm `≤ C‖y‖`.
+* `exists_preimage_norm_le` — the quantitative open mapping theorem: every `y` has an exact
+  preimage of controlled norm `‖x‖ ≤ C‖y‖` (completeness of the source).
+* `isOpenMap` — the **Open Mapping Theorem**: a surjective bounded operator between Banach
+  spaces is an open map.
+* `continuous_linearEquiv_symm` — the **Inverse Mapping (Banach isomorphism) Theorem**: the
+  inverse of a continuous linear bijection between Banach spaces is continuous.
+* `continuous_of_isClosed_graph` — the **Closed Graph Theorem**: a linear map between Banach
+  spaces with closed graph is continuous.
+
+The argument follows the classical Baire proof (the same route Mathlib takes internally);
+the contribution of this entry is to present the open mapping and closed graph theorems as
+explicit, fully machine-checked consequences of the gallery Baire category theorem.  No
+`sorry`, no extra axioms.
+-/
+
+namespace BaireCategoryTheoremOQ01OQ01OQ01
+
+open Set Metric Function Filter
+open scoped Topology
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- **First (Baire) step of the open mapping theorem.** For a surjective bounded operator
+`T : E →L[𝕜] F` with `F` complete, every `y ∈ F` is approximated to within `‖y‖/2` by the
+image of some `x` with `‖x‖ ≤ C‖y‖`. The *only* use of Baire's theorem in the whole
+development happens here, supplied by the gallery category theorem
+`BaireCategoryTheoremOQ01.baire_nonempty_interior`. -/
+theorem exists_approx_preimage_norm_le [CompleteSpace F] (T : E →L[𝕜] F)
+    (surj : Surjective T) :
+    ∃ C ≥ 0, ∀ y, ∃ x, dist (T x) y ≤ 1 / 2 * ‖y‖ ∧ ‖x‖ ≤ C * ‖y‖ := by
+  haveI : Nonempty F := ⟨0⟩
+  -- The closed sets `closure (T '' ball 0 n)` cover `F` by surjectivity.
+  have A : ⋃ n : ℕ, closure (T '' ball 0 n) = Set.univ := by
+    refine Subset.antisymm (subset_univ _) fun y _ => ?_
+    rcases surj y with ⟨x, hx⟩
+    rcases exists_nat_gt ‖x‖ with ⟨n, hn⟩
+    refine mem_iUnion.2 ⟨n, subset_closure ?_⟩
+    refine (mem_image _ _ _).2 ⟨x, ⟨?_, hx⟩⟩
+    rwa [mem_ball, dist_eq_norm, sub_zero]
+  -- **The Baire category theorem** (gallery re-export): one of them has nonempty interior.
+  have hbaire : ∃ n : ℕ, (interior (closure (T '' ball 0 n))).Nonempty :=
+    BaireCategoryTheoremOQ01.baire_nonempty_interior (fun n => isClosed_closure) A
+  rcases hbaire with ⟨n, a, ha⟩
+  rw [mem_interior_iff_mem_nhds, Metric.mem_nhds_iff] at ha
+  rcases ha with ⟨ε, εpos, H⟩
+  rcases NormedField.exists_one_lt_norm 𝕜 with ⟨c, hc⟩
+  refine ⟨(ε / 2)⁻¹ * ‖c‖ * 2 * n, by positivity, fun y => ?_⟩
+  rcases eq_or_ne y 0 with rfl | hy
+  · simp
+  · rcases rescale_to_shell hc (half_pos εpos) hy with ⟨d, hd, ydlt, -, dinv⟩
+    let δ := ‖d‖ * ‖y‖ / 4
+    have δpos : 0 < δ := by positivity
+    -- two points of `closure (T '' ball 0 n)` near `a + d • y` and `a`
+    have ha₁ : a + d • y ∈ ball a ε := by
+      simp [dist_eq_norm, lt_of_le_of_lt ydlt.le (half_lt_self εpos)]
+    rcases Metric.mem_closure_iff.1 (H ha₁) _ δpos with ⟨z₁, z₁im, h₁⟩
+    rcases (mem_image _ _ _).1 z₁im with ⟨x₁, hx₁, xz₁⟩
+    rw [← xz₁] at h₁
+    rw [mem_ball, dist_eq_norm, sub_zero] at hx₁
+    have ha₂ : a ∈ ball a ε := by
+      simp only [mem_ball, dist_self]; exact εpos
+    rcases Metric.mem_closure_iff.1 (H ha₂) _ δpos with ⟨z₂, z₂im, h₂⟩
+    rcases (mem_image _ _ _).1 z₂im with ⟨x₂, hx₂, xz₂⟩
+    rw [← xz₂] at h₂
+    rw [mem_ball, dist_eq_norm, sub_zero] at hx₂
+    let x := x₁ - x₂
+    -- the difference image is close to `d • y`
+    have I : ‖T x - d • y‖ ≤ 2 * δ :=
+      calc
+        ‖T x - d • y‖ = ‖T x₁ - (a + d • y) - (T x₂ - a)‖ := by
+          congr 1; simp only [x, T.map_sub]; abel
+        _ ≤ ‖T x₁ - (a + d • y)‖ + ‖T x₂ - a‖ := norm_sub_le _ _
+        _ ≤ 2 * δ := by grind [dist_eq_norm']
+    -- rescale by `d⁻¹` to land near `y`
+    have J : ‖T (d⁻¹ • x) - y‖ ≤ 1 / 2 * ‖y‖ := by
+      have hxy : T (d⁻¹ • x) - y = d⁻¹ • (T x - d • y) := by
+        rw [T.map_smul, smul_sub, smul_smul, inv_mul_cancel₀ hd, one_smul]
+      rw [hxy, norm_smul, norm_inv]
+      calc
+        ‖d‖⁻¹ * ‖T x - d • y‖ ≤ ‖d‖⁻¹ * (2 * δ) := by gcongr
+        _ = 1 / 2 * ‖y‖ := by
+          simp only [δ]
+          field_simp
+          ring
+    rw [← dist_eq_norm] at J
+    have hd' : ‖d‖⁻¹ ≤ (ε / 2)⁻¹ * ‖c‖ * ‖y‖ := by simpa using dinv
+    have hxx : ‖x₁ - x₂‖ ≤ (n : ℝ) + n :=
+      le_trans (norm_sub_le _ _) (add_le_add hx₁.le hx₂.le)
+    have K : ‖d⁻¹ • x‖ ≤ (ε / 2)⁻¹ * ‖c‖ * 2 * ↑n * ‖y‖ := by
+      have h1 : ‖d⁻¹ • x‖ = ‖d‖⁻¹ * ‖x₁ - x₂‖ := by rw [norm_smul, norm_inv]
+      rw [h1]
+      calc
+        ‖d‖⁻¹ * ‖x₁ - x₂‖ ≤ (ε / 2)⁻¹ * ‖c‖ * ‖y‖ * ((n : ℝ) + n) :=
+          mul_le_mul hd' hxx (norm_nonneg _) (by positivity)
+        _ = (ε / 2)⁻¹ * ‖c‖ * 2 * ↑n * ‖y‖ := by ring
+    exact ⟨d⁻¹ • x, J, K⟩
+
+variable [CompleteSpace E] [CompleteSpace F]
+
+/-- **The Open Mapping Theorem (quantitative form).** A surjective bounded linear map between
+Banach spaces admits, for every target `y`, an exact preimage `x` with `‖x‖ ≤ C‖y‖`. The
+preimage is built as a convergent successive-approximation series, using completeness of the
+source `E`. -/
+theorem exists_preimage_norm_le (T : E →L[𝕜] F) (surj : Surjective T) :
+    ∃ C > 0, ∀ y, ∃ x, T x = y ∧ ‖x‖ ≤ C * ‖y‖ := by
+  obtain ⟨C, C0, hC⟩ := exists_approx_preimage_norm_le T surj
+  choose g hg using hC
+  let h y := y - T (g y)
+  have hle : ∀ y, ‖h y‖ ≤ 1 / 2 * ‖y‖ := by
+    intro y
+    rw [← dist_eq_norm, dist_comm]
+    exact (hg y).1
+  refine ⟨2 * C + 1, by linarith, fun y => ?_⟩
+  have hnle : ∀ n : ℕ, ‖h^[n] y‖ ≤ (1 / 2) ^ n * ‖y‖ := by
+    intro n
+    induction n with
+    | zero => simp only [one_div, one_mul, iterate_zero_apply, pow_zero, le_rfl]
+    | succ n IH =>
+      rw [iterate_succ']
+      apply le_trans (hle _) _
+      rw [pow_succ', mul_assoc]
+      gcongr
+  let u n := g (h^[n] y)
+  have ule : ∀ n, ‖u n‖ ≤ (1 / 2) ^ n * (C * ‖y‖) := fun n ↦ by
+    apply le_trans (hg _).2
+    calc
+      C * ‖h^[n] y‖ ≤ C * ((1 / 2) ^ n * ‖y‖) := mul_le_mul_of_nonneg_left (hnle n) C0
+      _ = (1 / 2) ^ n * (C * ‖y‖) := by ring
+  have sNu : Summable fun n => ‖u n‖ := by
+    refine .of_nonneg_of_le (fun n => norm_nonneg _) ule ?_
+    exact Summable.mul_right _ (summable_geometric_of_lt_one (by norm_num) (by norm_num))
+  have su : Summable u := sNu.of_norm
+  let x := tsum u
+  have x_ineq : ‖x‖ ≤ (2 * C + 1) * ‖y‖ :=
+    calc
+      ‖x‖ ≤ ∑' n, ‖u n‖ := norm_tsum_le_tsum_norm sNu
+      _ ≤ ∑' n, (1 / 2) ^ n * (C * ‖y‖) :=
+        sNu.tsum_le_tsum ule <| Summable.mul_right _ summable_geometric_two
+      _ = (∑' n, (1 / 2) ^ n) * (C * ‖y‖) := tsum_mul_right
+      _ = 2 * C * ‖y‖ := by rw [tsum_geometric_two, mul_assoc]
+      _ ≤ 2 * C * ‖y‖ + ‖y‖ := le_add_of_nonneg_right (norm_nonneg y)
+      _ = (2 * C + 1) * ‖y‖ := by ring
+  have fsumeq : ∀ n : ℕ, T (∑ i ∈ Finset.range n, u i) = y - h^[n] y := by
+    intro n
+    induction n with
+    | zero => simp [T.map_zero]
+    | succ n IH => rw [Finset.sum_range_succ, T.map_add, IH, iterate_succ_apply', sub_add]
+  have hxlim : Tendsto (fun n => ∑ i ∈ Finset.range n, u i) atTop (𝓝 x) :=
+    su.hasSum.tendsto_sum_nat
+  have L₁ : Tendsto (fun n => T (∑ i ∈ Finset.range n, u i)) atTop (𝓝 (T x)) :=
+    (T.continuous.tendsto _).comp hxlim
+  simp only [fsumeq] at L₁
+  have L₂ : Tendsto (fun n => y - h^[n] y) atTop (𝓝 (y - 0)) := by
+    refine tendsto_const_nhds.sub ?_
+    rw [tendsto_iff_norm_sub_tendsto_zero]
+    simp only [sub_zero]
+    refine squeeze_zero (fun _ => norm_nonneg _) hnle ?_
+    rw [← zero_mul ‖y‖]
+    refine (_root_.tendsto_pow_atTop_nhds_zero_of_lt_one ?_ ?_).mul tendsto_const_nhds <;>
+      norm_num
+  have feq : T x = y - 0 := tendsto_nhds_unique L₁ L₂
+  rw [sub_zero] at feq
+  exact ⟨x, feq, x_ineq⟩
+
+/-- **The Open Mapping Theorem.** A surjective bounded linear map between Banach spaces is an
+open map. -/
+protected theorem isOpenMap (T : E →L[𝕜] F) (surj : Surjective T) : IsOpenMap T := by
+  intro s hs
+  rcases exists_preimage_norm_le T surj with ⟨C, Cpos, hC⟩
+  refine isOpen_iff.2 fun y yfs => ?_
+  rcases yfs with ⟨x, xs, fxy⟩
+  rcases isOpen_iff.1 hs x xs with ⟨ε, εpos, hε⟩
+  refine ⟨ε / C, div_pos εpos Cpos, fun z hz => ?_⟩
+  rcases hC (z - y) with ⟨w, wim, wnorm⟩
+  have hxw : T (x + w) = z := by rw [T.map_add, wim, fxy, add_sub_cancel]
+  rw [← hxw]
+  have hmem : x + w ∈ ball x ε :=
+    calc
+      dist (x + w) x = ‖w‖ := by simp
+      _ ≤ C * ‖z - y‖ := wnorm
+      _ < C * (ε / C) := by
+        apply mul_lt_mul_of_pos_left _ Cpos
+        rwa [mem_ball, dist_eq_norm] at hz
+      _ = ε := mul_div_cancel₀ _ (ne_of_gt Cpos)
+  exact Set.mem_image_of_mem _ (hε hmem)
+
+/-- **The Inverse Mapping (Banach isomorphism) Theorem.** The inverse of a continuous linear
+bijection between Banach spaces is continuous. -/
+theorem continuous_linearEquiv_symm (e : E ≃ₗ[𝕜] F) (h : Continuous e) :
+    Continuous e.symm := by
+  set T : E →L[𝕜] F := ⟨e.toLinearMap, h⟩ with hT
+  have hTe : ∀ x, T x = e x := fun _ => rfl
+  rw [continuous_def]
+  intro s hs
+  -- `e.symm ⁻¹' s = e '' s` since `e` is a bijection; the image is open by the open mapping theorem
+  have hset : ⇑e.symm ⁻¹' s = T '' s := by
+    ext y
+    simp only [Set.mem_preimage, Set.mem_image, hTe]
+    constructor
+    · intro hy; exact ⟨e.symm y, hy, by simp⟩
+    · rintro ⟨x, hx, rfl⟩; simpa using hx
+  rw [hset]
+  exact BaireCategoryTheoremOQ01OQ01OQ01.isOpenMap T e.surjective s hs
+
+/-- **The Closed Graph Theorem.** A linear map between Banach spaces whose graph is closed is
+continuous. The graph is a closed (hence complete) subspace of `E × F`; the first projection
+restricts to a continuous linear bijection onto `E`, whose inverse is continuous by the
+inverse mapping theorem, and the map is recovered as the second projection composed with that
+inverse. -/
+theorem continuous_of_isClosed_graph (g : E →ₗ[𝕜] F)
+    (hg : IsClosed (g.graph : Set (E × F))) : Continuous g := by
+  letI : CompleteSpace g.graph := completeSpace_coe_iff_isComplete.mpr hg.isComplete
+  let φ₀ : E →ₗ[𝕜] E × F := LinearMap.id.prod g
+  have hli : Function.LeftInverse Prod.fst φ₀ := fun _ => rfl
+  let φ : E ≃ₗ[𝕜] g.graph :=
+    (LinearEquiv.ofLeftInverse hli).trans (LinearEquiv.ofEq _ _ g.graph_eq_range_prod.symm)
+  have hsymm : Continuous (φ.symm) := continuous_subtype_val.fst
+  have hφ : Continuous (φ : E → g.graph) := by
+    have hc := continuous_linearEquiv_symm φ.symm hsymm
+    rwa [LinearEquiv.symm_symm] at hc
+  exact (continuous_subtype_val.comp hφ).snd
+
+end BaireCategoryTheoremOQ01OQ01OQ01

--- a/research/problems/baire-category-theorem-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/baire-category-theorem-oq-01-oq-01-oq-01/knowledge.md
@@ -1,0 +1,62 @@
+# Open Mapping & Closed Graph theorems from the gallery Baire theorem
+
+**Candidate:** baire-category-theorem-oq-01-oq-01-oq-01
+**Status:** COMPLETED (verified, 0 axioms, 0 sorries)
+**Lean file:** `proofs/Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean`
+**Gallery:** `src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/`
+
+## Summary
+
+Resolves the lead open question of the sibling Banach–Steinhaus entry
+(`baire-category-theorem-oq-01-oq-01`): derive the **open mapping**, **inverse
+mapping (Banach isomorphism)** and **closed graph** theorems for Banach spaces from
+the *same* gallery Baire category theorem
+(`BaireCategoryTheoremOQ01.baire_nonempty_interior`), completing the three classical
+Baire-powered pillars of linear functional analysis in the gallery.
+
+## Session 2026-06-26 (Session 1) — FRESH, COMPLETED
+
+**Mode:** FRESH
+**Outcome:** completed
+
+### What I Did
+- Selected this EMPTY-tier available candidate; the only candidate whose notes describe
+  a clean Mathlib-instantiable target (open mapping + closed graph from Baire). An
+  abandoned local branch `research/baire-open-mapping-closed-graph` had 0 commits, so
+  the candidate was effectively free.
+- Studied Mathlib's `Mathlib/Analysis/Normed/Operator/Banach.lean`: the Baire step is
+  `exists_approx_preimage_norm_le` using `nonempty_interior_of_iUnion_of_closed`, which
+  the gallery re-exports verbatim as `baire_nonempty_interior`.
+- Reproduced the classical chain (approx-preimage → series → open map → inverse map →
+  closed graph) in a fresh namespace, specialized from Mathlib's semilinear `→SL[σ]` to
+  plain `→L[𝕜]`, routing the single Baire call through the gallery theorem.
+- Docker build-verified: `✔ [7744/7744] Built Proofs.BaireCategoryTheoremOQ01OQ01OQ01`,
+  0 sorries, 0 axioms, 256 lines, 5 theorems.
+
+### Key Findings
+- The gallery Baire theorem is genuinely load-bearing: exactly one Baire invocation, in
+  `exists_approx_preimage_norm_le`; all later steps are completeness bookkeeping.
+- Porting gotchas (cost two build cycles): (1) `gcongr` in the K norm-bound calc emitted
+  side goals in an order the bullets didn't match — replaced with explicit `mul_le_mul`;
+  (2) `IsOpenMap f` unfolds to `∀ U, IsOpen U → IsOpen (f '' U)` with `U` **explicit**,
+  so the set must be passed (`isOpenMap T surj s hs`, mirroring Mathlib's `continuous_symm`);
+  (3) `LinearEquiv.image_eq_preimage` is phrased via `toAddEquiv.symm` and won't rewrite
+  `⇑e.symm` — used an explicit `e.symm ⁻¹' s = e '' s` ext proof instead.
+- Infrastructure: host was severely memory-contended (9–10 concurrent Docker builds,
+  <1 GB free, heavy compression); the first build OOM-killed at the 18 GB container limit.
+  Waited for contention to drop to ≤4 builds, then built at LEAN_MEMORY_LIMIT=20000.
+
+### Files Modified
+- `proofs/Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean` (new, 256 lines)
+- `proofs/Proofs.lean` (manifest import)
+- `src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/{meta,annotations}.json` (new)
+
+### Next Steps
+- Follow-up oq-01-oq-01-oq-01-oq-01: bundle a continuous linear bijection into `E ≃L[𝕜] F`
+  and characterise injective bounded operators with closed range via a bounded left inverse.
+
+### Honesty Note
+The mathematics is classical and the proof follows Mathlib's own internal Baire argument
+(it is NOT a novel proof distinct from Mathlib). The contribution is presenting the open
+mapping, inverse mapping and closed graph theorems as explicit, machine-checked
+consequences of the gallery's own Baire category theorem, completing the three-pillar trio.

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ann-baire-oq010101-docstring",
+    "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 45 },
+    "type": "context",
+    "title": "Open Mapping and Closed Graph from Baire — Goal and Plan",
+    "content": "The docstring fixes the objective: derive the open mapping theorem, the inverse mapping (Banach isomorphism) theorem and the closed graph theorem from the gallery Baire category theorem (BaireCategoryTheoremOQ01.baire_nonempty_interior), completing the three classical pillars of functional analysis begun with the parent's Uniform Boundedness Principle. The key structural point flagged here: all three theorems share a single Baire-theoretic engine, and that engine is invoked exactly once — in exists_approx_preimage_norm_le. Everything afterwards is metric/completeness bookkeeping with no further appeal to Baire. The argument follows the classical (and Mathlib-internal) route; the entry's contribution is making the dependency on the gallery Baire theorem explicit and machine-checked end-to-end.",
+    "mathContext": "A surjective bounded linear map between Banach spaces is open; a linear map with closed graph is continuous.",
+    "significance": "context",
+    "relatedConcepts": ["Baire category theorem", "open mapping theorem", "closed graph theorem", "Banach space", "bounded linear operator"]
+  },
+  {
+    "id": "ann-baire-oq010101-approx",
+    "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 131 },
+    "type": "key-step",
+    "title": "The Baire Step: Approximate Preimages",
+    "content": "exists_approx_preimage_norm_le is the heart of the entry and the ONLY place Baire is used. Surjectivity writes F as the countable union of the closed sets closure (T '' ball 0 n); the gallery category theorem baire_nonempty_interior returns one with nonempty interior — a ball ball a ε contained in closure (T '' ball 0 n). The fixed-radius, off-centre ball is made homogeneous by rescale_to_shell together with the difference of two near-images (one near a + d·y, one near a): their difference is the image of a point of norm ≤ C‖y‖ and lands within ‖y‖/2 of y. No completeness of the source is needed yet — only that of the target F, which supplies the BaireSpace hypothesis.",
+    "mathContext": "Baire ⇒ ball $a$ $\\varepsilon \\subseteq \\overline{T(B(0,n))}$; subtracting two near-images gives $\\mathrm{dist}(Tx, y) \\le \\tfrac12\\|y\\|$ with $\\|x\\| \\le C\\|y\\|$.",
+    "significance": "critical",
+    "relatedConcepts": ["Baire category theorem", "rescale_to_shell", "closure of image", "nonempty interior"]
+  },
+  {
+    "id": "ann-baire-oq010101-exact",
+    "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 133, "endLine": 197 },
+    "type": "key-step",
+    "title": "Exact Preimages by Series Summation",
+    "content": "exists_preimage_norm_le upgrades approximate preimages to exact ones using completeness of the SOURCE E. The approximate-preimage map h y = y − T(g y) shrinks the residual by a factor 1/2 each step, so ‖h^[n] y‖ ≤ (1/2)^n ‖y‖. The corrective terms u n = g(h^[n] y) satisfy ‖u n‖ ≤ (1/2)^n C‖y‖, a geometric bound, hence ∑ u n converges in the Banach space E. Its sum x has ‖x‖ ≤ (2C+1)‖y‖, and continuity of T lets it pass through the limit of partial sums: T x = y. This is the quantitative open mapping theorem.",
+    "mathContext": "Successive approximation: $\\|h^{[n]}y\\| \\le 2^{-n}\\|y\\|$, $\\sum_n u_n$ converges, $T(\\sum_n u_n) = y$, $\\|x\\| \\le (2C+1)\\|y\\|$.",
+    "significance": "critical",
+    "relatedConcepts": ["successive approximation", "geometric series", "completeness", "Summable", "tsum"]
+  },
+  {
+    "id": "ann-baire-oq010101-openmap",
+    "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 198, "endLine": 219 },
+    "type": "key-step",
+    "title": "The Open Mapping Theorem",
+    "content": "isOpenMap turns the quantitative preimage bound into the topological statement that T maps open sets to open sets. Given an open s and a point y = T x in its image, an ε-ball around x inside s is transported through the norm bound ‖preimage‖ ≤ C‖z − y‖: every z within ε/C of y has a preimage x + w with x + w ∈ ball x ε ⊆ s, so z ∈ T '' s. Hence T '' s contains a ball around each of its points and is open.",
+    "mathContext": "If $T$ has $C$-controlled preimages then $T(B(x,\\varepsilon)) \\supseteq B(Tx, \\varepsilon/C)$, so $T$ is an open map.",
+    "significance": "major",
+    "relatedConcepts": ["open map", "image of open set", "operator norm bound"]
+  },
+  {
+    "id": "ann-baire-oq010101-inverse",
+    "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 220, "endLine": 237 },
+    "type": "key-step",
+    "title": "The Inverse Mapping (Banach Isomorphism) Theorem",
+    "content": "continuous_linearEquiv_symm shows the inverse of a continuous linear bijection is automatically continuous — with no separate argument. Continuity of e.symm means preimages of opens are open; but for a bijection e.symm ⁻¹' s = e '' s, and e '' s is open by the open mapping theorem applied to the continuous linear bijection. So 'open bijection' is exactly 'continuous inverse'.",
+    "mathContext": "For a bijection, $e^{-1}{}^{-1}(s) = e(s)$; the open mapping theorem makes $e(s)$ open, so $e^{-1}$ is continuous.",
+    "significance": "major",
+    "relatedConcepts": ["Banach isomorphism theorem", "continuous inverse", "linear equivalence", "homeomorphism"]
+  },
+  {
+    "id": "ann-baire-oq010101-closedgraph",
+    "proofId": "baire-category-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 238, "endLine": 255 },
+    "type": "key-step",
+    "title": "The Closed Graph Theorem",
+    "content": "continuous_of_isClosed_graph deduces continuity of a linear map g from closedness of its graph, via the inverse mapping theorem. The graph is a closed — hence complete — subspace of the Banach space E × F. The first projection restricts to a continuous linear bijection φ from E onto the graph (x ↦ (x, g x)); by continuous_linearEquiv_symm its inverse is continuous, and g is recovered as the second projection composed with that continuous inverse. So the closed graph theorem inherits exactly the same single Baire dependency as the open mapping theorem.",
+    "mathContext": "Closed graph $\\Gamma_g \\subseteq E \\times F$ is complete; $\\pi_1|_{\\Gamma_g}$ is a continuous linear bijection onto $E$ with continuous inverse, and $g = \\pi_2 \\circ (\\pi_1|_{\\Gamma_g})^{-1}$.",
+    "significance": "major",
+    "relatedConcepts": ["closed graph theorem", "graph of a linear map", "complete subspace", "projection"]
+  }
+]

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "baire-category-theorem-oq-01-oq-01-oq-01",
+  "slug": "baire-category-theorem-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BaireCategoryTheoremOQ01"
+    ],
+    "opens": [
+      "Set",
+      "Metric",
+      "Function",
+      "Filter"
+    ],
+    "namespace": "BaireCategoryTheoremOQ01OQ01OQ01",
+    "lineCount": 256,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Open Mapping and Closed Graph Theorems from Baire's Theorem",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "functional-analysis",
+      "open-mapping-theorem",
+      "closed-graph-theorem",
+      "inverse-mapping-theorem",
+      "baire-category",
+      "banach-space",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 256,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "verified",
+    "originalContributions": [
+      "isOpenMap: the Open Mapping Theorem — a surjective bounded linear map T : E →L[𝕜] F between Banach spaces is an open map. Derived from the gallery Baire category theorem (BaireCategoryTheoremOQ01.baire_nonempty_interior), completing the trio of Baire-powered cornerstones of functional analysis alongside the parent's Uniform Boundedness Principle.",
+      "exists_approx_preimage_norm_le: the single Baire step of the whole development. The images of the unit balls cover F by a countable union of closed sets closure (T '' ball 0 n); the gallery category theorem hands back one with nonempty interior, and a rescaling shell estimate turns this into: every y is approximated within ‖y‖/2 by the image of an element of norm ≤ C‖y‖. This is the ONLY appeal to Baire — everything downstream is completeness bookkeeping.",
+      "exists_preimage_norm_le: the quantitative open mapping theorem — every y has an EXACT preimage x with ‖x‖ ≤ C‖y‖, obtained from the approximate-preimage step by a convergent successive-approximation series summed in the complete source space E.",
+      "continuous_linearEquiv_symm: the Inverse Mapping (Banach isomorphism) Theorem — the inverse of a continuous linear bijection between Banach spaces is automatically continuous, read off from isOpenMap applied to the bijection.",
+      "continuous_of_isClosed_graph: the Closed Graph Theorem — a linear map g : E →ₗ[𝕜] F between Banach spaces whose graph is closed is continuous. The graph is a closed, hence complete, subspace of E × F; the first projection restricts to a continuous linear bijection onto E, whose inverse is continuous by continuous_linearEquiv_symm, and g is recovered as the second projection composed with that inverse — so the closed graph theorem inherits the same single Baire dependency."
+    ],
+    "prerequisites": [
+      "The gallery Baire category theorem in category form (BaireCategoryTheoremOQ01.baire_nonempty_interior): a countable closed cover of a nonempty Baire space has a member with nonempty interior.",
+      "CompleteSpace ⇒ BaireSpace for a normed space (Mathlib instance), supplying the Baire hypothesis on the complete target F from completeness.",
+      "Completeness of the source E for the successive-approximation series, and completeness of E × F (hence of any closed subspace such as a closed graph) for the closed graph deduction.",
+      "rescale_to_shell and NormedField.exists_one_lt_norm: a nontrivially normed field has an element of norm > 1, the scalar driving the shell rescaling that makes the Baire ball homogeneous.",
+      "Geometric-series summability (summable_geometric_two, tsum_geometric_two) and continuity of T to pass the operator through the limit of partial sums."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "nonempty_interior_of_iUnion_of_closed",
+        "description": "The category form of Baire's theorem, re-exported by the gallery as baire_nonempty_interior: a countable closed cover of a nonempty Baire space has a member with nonempty interior. The sole Baire input, used once in exists_approx_preimage_norm_le.",
+        "module": "Mathlib.Topology.GDelta.Baire"
+      },
+      {
+        "theorem": "rescale_to_shell",
+        "description": "Given 1 < ‖c‖, ε > 0 and x ≠ 0, produces a scalar d with ‖d • x‖ in a controlled shell below ε and ‖d‖⁻¹ bounded; converts the off-center, fixed-radius Baire ball into a homogeneous norm estimate.",
+        "module": "Mathlib.Analysis.Normed.Field.Basic"
+      },
+      {
+        "theorem": "summable_geometric_two",
+        "description": "Summability of ∑ (1/2)^n with tsum_geometric_two giving the value 2; bounds the norm of the successive-approximation series and hence the preimage norm.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "completeSpace_coe_iff_isComplete",
+        "description": "A subtype is a complete space iff the underlying set is complete; applied to a closed graph (closed ⇒ complete) so the open mapping theorem can act on the projection out of the graph.",
+        "module": "Mathlib.Topology.MetricSpace.Completion"
+      },
+      {
+        "theorem": "LinearMap.graph_eq_range_prod",
+        "description": "The graph of a linear map equals the range of id.prod g; identifies the graph subspace with the image of E under x ↦ (x, g x), giving the continuous linear bijection used in the closed graph deduction.",
+        "module": "Mathlib.LinearAlgebra.Prod"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "baire-category-theorem-oq-01-oq-01-oq-01-oq-01",
+      "question": "Package the inverse mapping theorem into a Banach-space isomorphism API: turn a continuous linear bijection between Banach spaces into a bundled E ≃L[𝕜] F (continuous linear equivalence) directly from continuous_linearEquiv_symm, and characterise injective bounded operators with closed range as having a bounded left inverse.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "baire-category-theorem-oq-01-oq-01",
+      "relationship": "Sibling entry deriving the Uniform Boundedness Principle from the same gallery Baire theorem; this entry resolves its lead open question by supplying the other two pillars (open mapping and closed graph)."
+    },
+    {
+      "slug": "baire-category-theorem-oq-01",
+      "relationship": "Grandparent entry providing the Baire category theorem (baire_nonempty_interior) on which the single Baire step of this derivation rests."
+    }
+  ],
+  "references": [
+    {
+      "title": "Stefan Banach, Théorie des opérations linéaires",
+      "author": "S. Banach",
+      "year": "1932",
+      "venue": "Monografie Matematyczne",
+      "description": "Original development of the open mapping theorem, the inverse mapping theorem and the closed graph theorem for complete normed (Banach) spaces."
+    },
+    {
+      "title": "Walter Rudin, Functional Analysis",
+      "author": "W. Rudin",
+      "year": "1991",
+      "venue": "McGraw-Hill",
+      "description": "Textbook treatment of the open mapping and closed graph theorems via Baire's category theorem (Theorems 2.11–2.15), the argument formalized here."
+    },
+    {
+      "title": "Mathlib4: Analysis.Normed.Operator.Banach",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Mathlib's open mapping / closed graph theorems. The same classical Baire argument is followed here, but the single category-theorem call is routed through the gallery's own baire_nonempty_interior, making the gallery Baire entry load-bearing for these results."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The open mapping theorem, the inverse mapping theorem and the closed graph theorem are, with the uniform boundedness principle, the classical consequences of Baire's category theorem in linear functional analysis — all due to Banach and his school in the late 1920s and early 1930s. The parent gallery entry derived the uniform boundedness principle from the gallery Baire theorem; this entry supplies the remaining two pillars from the very same category-theorem statement. The mathematics is the classical Baire argument (the route Mathlib itself takes internally); the contribution of this entry is to present these theorems as explicit, machine-checked consequences of the gallery's own Baire category theorem rather than as opaque library facts, keeping the dependency on Baire honest and visible.",
+    "problemStatement": "Let E and F be Banach spaces over a nontrivially normed field 𝕜. Prove: (open mapping) a surjective bounded linear map T : E →L[𝕜] F is an open map; (quantitative form) every y has a preimage x with ‖x‖ ≤ C‖y‖ for a fixed C; (inverse mapping) a continuous linear bijection has continuous inverse; (closed graph) a linear map g : E →ₗ[𝕜] F whose graph is closed in E × F is continuous. Derive all of them from the gallery Baire category theorem.",
+    "proofStrategy": "Surjectivity writes F as the countable union of the closed sets closure (T '' ball 0 n); the gallery category form baire_nonempty_interior produces one with nonempty interior, i.e. a ball ball a ε inside closure (T '' ball 0 n). Subtracting two near-images centred at a and a + d·y (the rescale_to_shell device makes this homogeneous) shows every y is within ‖y‖/2 of the image of a point of norm ≤ C‖y‖ (exists_approx_preimage_norm_le) — the one and only Baire step. Iterating this approximation gives a geometric series ∑ u n in the complete space E whose sum is an exact preimage with ‖x‖ ≤ (2C+1)‖y‖ (exists_preimage_norm_le). Controlled preimages make T an open map (isOpenMap). The inverse mapping theorem is isOpenMap applied to a bijection (image of an open set under the inverse is open). The closed graph theorem applies the inverse mapping theorem to the continuous linear bijection x ↦ (x, g x) from E onto the closed (hence complete) graph subspace, recovering g as the second projection of the continuous inverse.",
+    "keyInsights": [
+      "Baire is invoked exactly once, in exists_approx_preimage_norm_le, and only through the gallery theorem baire_nonempty_interior. Every later step — the shell rescaling, the convergent series, the open-map and inverse-map deductions, the closed-graph reduction — is pure metric and completeness bookkeeping, so the entire trio rests transparently on the one category-theorem call.",
+      "The Baire ball is off-centre and of fixed radius; rescale_to_shell together with the difference of two near-images (centred at a and a + d·y) is the device that turns this into a homogeneous estimate 'image of norm ≤ C‖y‖ approximates y to within ‖y‖/2'.",
+      "Approximate preimages become exact ones by completeness of the SOURCE: the errors halve at each step, so the corrective terms form a geometric series ∑ u n with ‖u n‖ ≤ (1/2)^n C‖y‖, summable in the Banach space E, and T passes through the limit by continuity.",
+      "The inverse mapping theorem is not a separate argument: a continuous linear bijection is open by the open mapping theorem, and 'open bijection' is exactly 'continuous inverse' (e.symm ⁻¹' s = e '' s).",
+      "The closed graph theorem is the inverse mapping theorem in disguise: the graph of g, when closed, is a Banach space on which the first projection is a continuous linear bijection onto E; its continuous inverse exhibits g = (second projection) ∘ (that inverse) as a composite of continuous maps."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Open Mapping and Closed Graph from Baire",
+      "startLine": 3,
+      "endLine": 45,
+      "summary": "States the goal — derive the open mapping, inverse mapping and closed graph theorems from the gallery Baire category theorem, completing the three pillars of functional analysis — and isolates the single Baire step from the surrounding completeness bookkeeping.",
+      "mathContext": "Open mapping / inverse mapping / closed graph theorems for Banach spaces, all from one Baire category call."
+    },
+    {
+      "id": "baire-step",
+      "title": "The Baire Step: Approximate Preimages",
+      "startLine": 56,
+      "endLine": 131,
+      "summary": "exists_approx_preimage_norm_le: closure (T '' ball 0 n) cover F by surjectivity; baire_nonempty_interior yields a ball inside one of them; rescale_to_shell and the difference of two near-images give an approximate preimage of norm ≤ C‖y‖ within ‖y‖/2 of y. This is the only use of Baire.",
+      "mathContext": "Baire ⇒ ball a ε ⊆ closure (T '' ball 0 n); difference trick ⇒ dist (T x) y ≤ ‖y‖/2 with ‖x‖ ≤ C‖y‖."
+    },
+    {
+      "id": "exact-preimage",
+      "title": "Exact Preimages by Series Summation",
+      "startLine": 133,
+      "endLine": 197,
+      "summary": "exists_preimage_norm_le: iterating the approximate-preimage map halves the residual each step; the corrective terms form a geometric series summable in the complete source E; its sum is an exact preimage with ‖x‖ ≤ (2C+1)‖y‖, with T passing through the limit by continuity.",
+      "mathContext": "Successive approximation: ‖h^[n] y‖ ≤ (1/2)^n‖y‖, ∑ u n converges, T (∑ u n) = y."
+    },
+    {
+      "id": "open-inverse-graph",
+      "title": "Open Mapping, Inverse Mapping and Closed Graph",
+      "startLine": 198,
+      "endLine": 255,
+      "summary": "isOpenMap: controlled preimages make T open. continuous_linearEquiv_symm: a continuous linear bijection is open, so its inverse is continuous. continuous_of_isClosed_graph: the first projection out of the closed (complete) graph subspace is a continuous linear bijection onto E, whose continuous inverse exhibits g as a composite of continuous maps.",
+      "mathContext": "IsOpenMap T; Continuous e.symm; Continuous g from a closed graph."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The open mapping theorem (isOpenMap, with quantitative form exists_preimage_norm_le), the inverse mapping / Banach isomorphism theorem (continuous_linearEquiv_symm) and the closed graph theorem (continuous_of_isClosed_graph) are all derived from the gallery Baire category theorem, with Baire invoked exactly once in exists_approx_preimage_norm_le and routed through baire_nonempty_interior. 256 lines, 5 theorems, 0 axioms, 0 sorries.",
+    "implications": "Together with the sibling Uniform Boundedness Principle entry, this completes the three classical Baire-powered pillars of linear functional analysis in the gallery, all resting on the gallery's own category form of Baire's theorem. The argument follows the classical (and Mathlib-internal) Baire route; its value is making the dependency on Baire explicit and machine-checked end-to-end. A natural follow-up is to bundle the inverse mapping theorem into a continuous-linear-equivalence API and characterise injective operators with closed range.",
+    "openQuestions": [
+      "Bundle a continuous linear bijection between Banach spaces into an E ≃L[𝕜] F and characterise injective bounded operators with closed range via a bounded left inverse."
+    ]
+  }
+}

--- a/src/data/research/problems/baire-category-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/baire-category-theorem-oq-01-oq-01-oq-01.json
@@ -1,0 +1,26 @@
+{
+  "id": "baire-category-theorem-oq-01-oq-01-oq-01",
+  "title": "Open Mapping and Closed Graph theorems from the gallery Baire theorem",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "knowledge": {
+    "insights": [
+      "All three Baire-powered pillars of functional analysis (UBP, open mapping, closed graph) share a single Baire invocation; for the open mapping theorem it lives entirely in exists_approx_preimage_norm_le and is supplied by the gallery's baire_nonempty_interior (a re-export of nonempty_interior_of_iUnion_of_closed).",
+      "Everything after the Baire step — shell rescaling, the geometric successive-approximation series, the open-map and inverse-map deductions, the closed-graph reduction — is pure metric/completeness bookkeeping with no further appeal to Baire.",
+      "The inverse mapping theorem needs no separate argument: for a bijection e.symm ⁻¹' s = e '' s, which is open by the open mapping theorem; the closed graph theorem is the inverse mapping theorem applied to the first projection out of the (closed, hence complete) graph subspace.",
+      "Porting Mathlib's semilinear (→SL[σ]) proof to the plain linear (→L[𝕜]) statement: replace f.map_smulₛₗ/σ'/RingHomIsometric.norm_map by the direct d⁻¹ • (T x − d • y) identity; the gcongr in the norm-bound calc is order-fragile, an explicit mul_le_mul is more robust; IsOpenMap unfolds to ∀ U, IsOpen U → ... with U EXPLICIT, so the set argument must be passed (isOpenMap T surj s hs)."
+    ],
+    "builtItems": [
+      "exists_approx_preimage_norm_le (Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean:61) — Baire step",
+      "exists_preimage_norm_le (…:137) — quantitative open mapping via series",
+      "isOpenMap (…:200) — open mapping theorem",
+      "continuous_linearEquiv_symm (…:222) — inverse mapping / Banach isomorphism theorem",
+      "continuous_of_isClosed_graph (…:243) — closed graph theorem"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Bundle a continuous linear bijection between Banach spaces into an E ≃L[𝕜] F and characterise injective bounded operators with closed range via a bounded left inverse (follow-up oq-01-oq-01-oq-01-oq-01)."
+    ],
+    "progressSummary": "COMPLETE: 5 theorems, 0 axioms, 0 sorries, Docker build-verified. Open mapping, inverse mapping and closed graph theorems derived from the gallery Baire category theorem."
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the lead open question of the Banach–Steinhaus entry `baire-category-theorem-oq-01-oq-01`: derive the **open mapping theorem**, the **inverse mapping (Banach isomorphism) theorem**, and the **closed graph theorem** for Banach spaces from the *same* gallery Baire category theorem (`BaireCategoryTheoremOQ01.baire_nonempty_interior`), completing the three classical Baire-powered pillars of linear functional analysis in the gallery.

## What is proved (`Proofs/BaireCategoryTheoremOQ01OQ01OQ01.lean`)

- `exists_approx_preimage_norm_le` — the single Baire step: images of unit balls cover `F` by a countable closed union; the gallery category theorem hands back one with nonempty interior; a shell rescaling gives approximate preimages of controlled norm.
- `exists_preimage_norm_le` — quantitative open mapping theorem (exact preimages via a geometric successive-approximation series in the complete source).
- `isOpenMap` — the **Open Mapping Theorem**.
- `continuous_linearEquiv_symm` — the **Inverse Mapping / Banach isomorphism theorem**.
- `continuous_of_isClosed_graph` — the **Closed Graph Theorem**.

Baire is invoked **exactly once** (in `exists_approx_preimage_norm_le`), routed through the gallery's re-export of `nonempty_interior_of_iUnion_of_closed`; everything else is completeness bookkeeping.

## Honesty note

The mathematics is classical and the proof follows Mathlib's own internal Baire argument (specialized from the semilinear `→SL[σ]` form to plain `→L[𝕜]`) — it is **not** a novel proof distinct from Mathlib. The contribution is presenting these theorems as explicit, machine-checked consequences of the gallery's own Baire category theorem, completing the three-pillar trio. Badge `verified`.

## Verification

- **Docker build:** `✔ [7744/7744] Built Proofs.BaireCategoryTheoremOQ01OQ01OQ01` — build completed successfully.
- 5 theorems, **0 axioms, 0 sorries**, 256 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)