### PR TITLE
Enrich Hall's theorem balanced bipartite (oq-02) entry: annotations + cross-refs

### DIFF
--- a/src/data/proofs/halls-theorem-oq-02/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-header-context",
+    "proofId": "halls-theorem-oq-02",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "context",
+    "title": "Why a One-Sided Condition: Unbundling the Global Hall Hypothesis",
+    "content": "The header docstring frames the contribution. The parent `HallsTheoremOQ01` proves two biconditionals: `hall_marriage` (Hall on $p_1$ $\\iff$ a $p_1$-saturating matching) and `hall_perfect` (the **global** Hall condition over every $s : \\mathrm{Set}\\,V$ $\\iff$ a perfect matching). Mathlib's `exists_isPerfectMatching_of_forall_ncard_le` likewise needs the global condition, which silently forces both $p_1 \\cup p_2 = \\mathrm{univ}$ and $p_1.\\mathrm{ncard} = p_2.\\mathrm{ncard}$. In practice one has a *balanced* bipartition and only checks Hall on **one** side. This file isolates that textbook criterion — absent from both Mathlib and the parent — via a counting argument on top of `hall_marriage`: a $p_1$-saturating matching injects $p_1$ into $p_2$ through the matched-partner map, and balance + finiteness upgrade the injection to a bijection, saturating $p_2$ too.",
+    "mathContext": "Global Hall $\\equiv$ (one-sided Hall on $p_1$) $\\wedge$ ($p_1 \\cup p_2 = V$) $\\wedge$ ($|p_1| = |p_2|$); this entry keeps only the first and adds the latter two explicitly.",
+    "significance": "context",
+    "relatedConcepts": ["Hall's marriage theorem", "global vs one-sided condition", "balanced bipartition", "systems of distinct representatives"],
+    "prerequisites": ["bipartite graphs", "Hall's condition"]
+  },
+  {
     "id": "ann-both-sides",
     "proofId": "halls-theorem-oq-02",
     "range": { "startLine": 44, "endLine": 89 },

--- a/src/data/proofs/halls-theorem-oq-02/meta.json
+++ b/src/data/proofs/halls-theorem-oq-02/meta.json
@@ -60,6 +60,28 @@
       }
     ]
   },
+  "crossReferences": [
+    {
+      "proofId": "halls-theorem-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry, whose hall_marriage (one-sided Hall ⟺ a p₁-saturating matching) is the entire engine here. This entry strengthens the parent's perfect-matching result hall_perfect by replacing its GLOBAL Hall condition with the explicit, checkable balance + covering + one-sided-Hall hypotheses."
+    },
+    {
+      "proofId": "hall-marriage-theorem-oq-01",
+      "relationship": "related",
+      "description": "The abstract Finset-family formulation of Hall's theorem (systems of distinct representatives). Its descendants develop the defect/deficiency form — exactly the König–Ore generalisation flagged in this entry's open questions, where one-sided Hall failing by at most d still saturates all but d vertices of p₁."
+    }
+  ],
+  "references": [
+    {
+      "text": "Hall, P. (1935). On Representatives of Subsets. J. London Math. Soc. 10(1), 26–30. The marriage theorem and its bipartite/SDR formulations.",
+      "url": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem"
+    },
+    {
+      "text": "Mathlib4: SimpleGraph.Hall (exists_isMatching_of_forall_ncard_le, exists_isPerfectMatching_of_forall_ncard_le) and SimpleGraph.Matching (IsMatching.eq_of_adj_right).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
   "overview": {
     "historicalContext": "Hall's 1935 marriage theorem characterizes when a bipartite graph admits a matching saturating one side: exactly when Hall's condition |N(S)| ≥ |S| holds for every subset S of that side. The perfect-matching corollary is usually stated for balanced bipartite graphs (|p₁| = |p₂|), where saturating one side automatically saturates the other. Mathlib, however, only proves the perfect-matching version under a GLOBAL neighbourhood condition quantified over all sets of vertices, which implicitly bundles the balance and covering hypotheses. The parent gallery entry (halls-theorem-oq-01) completes the Set-valued biconditionals but inherits the same global-condition shape. This entry isolates the textbook balanced criterion: check Hall on one side, get both.",
     "problemStatement": "Let G be a locally finite bipartite graph with parts p₁, p₂ (G.IsBipartiteWith p₁ p₂), with p₂ finite and p₁.ncard = p₂.ncard. If Hall's condition holds on p₁ — every s ⊆ p₁ has s.ncard ≤ (⋃ x ∈ s, G.neighborSet x).ncard — then there is a matching M with p₁ ⊆ M.verts and p₂ ⊆ M.verts. If moreover p₁ ∪ p₂ = univ, then G has a perfect matching.",


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-02` (one-sided Hall condition suffices in the balanced bipartite case).

## Changes
- **annotations.json**: added a header/context annotation (lines 1–32) covering the previously uncovered module docstring, with full `mathContext`/`significance`/`relatedConcepts`/`prerequisites` fields. The 2 existing theorem annotations already carried all enrichment fields and are unchanged.
- **meta.json**: added a `crossReferences` array (parent `halls-theorem-oq-01`, related `hall-marriage-theorem-oq-01`) and a `references` array (Hall 1935, Mathlib modules) — both previously absent.

## Not changed
- The rest of meta.json was already comprehensive (4 keyInsights, sections with mathContext, conclusion w/ implications + open questions, originalContributions, mathlibDependencies). Final size 13.3 KB, well under the ~60 KB cap.

## Verification
- `pnpm build` passes; both JSON files validated (3 annotations, 2 crossReferences).