### PR TITLE
audit: fix stale axiom count in Brent-Salamin docstring (5→7)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ05.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ05.lean
@@ -45,7 +45,8 @@ Using (1): π²(1-2S)/(4M²) = π, so **π = 4M²/(1-2S)**.
 - [x] Series summability (axiomatized — requires quadratic convergence)
 - [x] **Main theorem proved**: π = 4M²/(1-2S)
 
-Axioms: 5 (ellipticK, ellipticE, K_eq_pi_div_2M, legendre_relation, ellipticE_agm)
+Axioms: 7 (ellipticK, ellipticE, K_eq_pi_div_2M, legendre_relation,
+  ellipticE_agm, bs_summable, S_lt_half)
 Sorries: 0
 
 Note: The OQ04 file axiomatizes K(k) and the Gauss connection. This file

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -235,10 +235,10 @@
       "result": "clean"
     },
     "amgm-inequality-oq-04-oq-05": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "lastAudited": "2026-06-27T03:01:44Z",
+      "result": "issues-fixed"
     },
     "angle-trisection": {
       "auditCount": 10,


### PR DESCRIPTION
## Gallery Integrity Audit — amgm-inequality-oq-04-oq-05 (Brent-Salamin Formula)

Re-audit of the stalest gallery entry (last audited 2026-05-03).

### Verified accurate (public meta.json vs Lean source)
- axiomCount **7** — matches 7 `axiom` declarations (ellipticK, ellipticE, K_eq_pi_div_2M, legendre_relation, ellipticE_agm, bs_summable, S_lt_half)
- sorries **0** ✓, theoremCount **8** ✓, definitionCount **6** ✓, lineCount **242** ✓
- status `axiomatized` / badge `axiom` — correct (Tier C, all 7 axioms disclosed in `assumptions`)
- No True stubs, no `native_decide`
- Framing honest: conclusion states "proved from 7 axioms"; open questions list the analytic facts to formalize

### Fixed (Lean source docstring drift)
The in-file `## Status` docstring header read `Axioms: 5` and enumerated only the five elliptic axioms, **omitting `bs_summable` and `S_lt_half`** (both declared in §2). Since the Lean source is displayed on the public proof page, this stale internal count contradicted the (correct) badge of 7 axioms. Updated the docstring to list all 7. Comment-only change — does not affect the build or kernel.

Tracker entry updated (`issues-fixed`).

---
Discovered during gallery integrity audit.