### PR TITLE
audit: re-confirm amgm-inequality-oq-03-oq-04 clean (Rényi↔power-mean equivalence)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -211,9 +211,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T03:06:49Z",
       "result": "clean"
     },
     "amgm-inequality-oq-04": {


### PR DESCRIPTION
## Gallery integrity re-audit — CLEAN

Stalest-entry re-audit of `amgm-inequality-oq-03-oq-04` (Rényi entropy ↔ power-mean monotonicity equivalence).

### Verified against Lean source (`Proofs/AmgmInequalityOQ03OQ04.lean`)
| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| lineCount | 232 | 232 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no axiom/native_decide) | ✓ |
| definitionCount | 2 | 2 | ✓ |
| theoremCount | 10 | 10 | ✓ |

### Tier classification: A (original)
`badge=original` / `status=verified` is defensible. The file genuinely proves the central identity H_α = −log(M_{α−1}) and the monotonicity **biconditional**, honestly framed as an *equivalence* between the two monotonicity statements (conditional on the monotonicity hypotheses) — it does **not** claim to prove power-mean monotonicity itself (that is the parent entry). Listed Mathlib dependencies (rpow_add, log_rpow, exp_log, …) are elementary building blocks, not a deep theorem doing the core work. No delegation opacity, no True stubs, no axiom masking.

Tracker timestamp refreshed (auditCount 2→3, lastAudited → 2026-06-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)