### PR TITLE
Enrich Euler's Product for the Basel Problem (fundamental-arithmetic-oq-03)

### DIFF
--- a/src/data/proofs/fundamental-arithmetic-oq-03/annotations.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-03/annotations.json
@@ -88,5 +88,29 @@
     "prerequisites": [
       "convergent products of nonzero factors are nonzero"
     ]
+  },
+  {
+    "id": "ann-convergence-halfplane",
+    "proofId": "fundamental-arithmetic-oq-03",
+    "range": {
+      "startLine": 39,
+      "endLine": 40
+    },
+    "type": "technique",
+    "title": "The Re s > 1 Hypothesis: Boundary of Absolute Convergence",
+    "content": "Every theorem in this file is unlocked by a single trivial-looking hypothesis: 1 < (s : ℂ).re, discharged by norm_num in the private lemmas one_lt_re_two and one_lt_re_four. This bound is not a technicality — it is the exact half-plane in which the Dirichlet series ∑ₙ n⁻ˢ (and hence the Euler product) converges absolutely, so that the FTA rearrangement of sum into product is legitimate. At s=2 and s=4 the bound holds comfortably (Re s = 2, 4 > 1). The interest lies at the boundary: as s → 1⁺ the product ∏ₚ(1-p⁻ˢ)⁻¹ diverges to +∞, because ∑ 1/p diverges — and this divergence is Euler's analytic proof that there are infinitely many primes. The same Re s > 1 condition is what powers riemannZeta_ne_zero_of_one_lt_re used in the non-vanishing results; extending non-vanishing to the line Re s = 1 is the deep analytic step behind the prime number theorem.",
+    "mathContext": "The series $\\sum_n n^{-s}$ converges absolutely iff $\\mathrm{Re}\\,s > 1$, since $|n^{-s}| = n^{-\\mathrm{Re}\\,s}$. On that half-plane the Euler product $\\prod_p (1-p^{-s})^{-1}$ converges and equals $\\zeta(s)$. At the boundary $s=1$ the product behaves like $\\prod_{p\\le x}(1-1/p)^{-1} \\sim e^\\gamma \\log x \\to \\infty$ (Mertens), recovering the infinitude of primes and $\\sum_p 1/p = \\infty$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "abscissa of absolute convergence",
+      "Mertens' theorems",
+      "divergence of the harmonic series",
+      "Euler's proof of the infinitude of primes",
+      "riemannZeta_ne_zero_of_one_lt_re"
+    ],
+    "prerequisites": [
+      "absolute convergence of Dirichlet series",
+      "complex power n^{-s} and |n^{-s}| = n^{-Re s}"
+    ]
   }
 ]

--- a/src/data/proofs/fundamental-arithmetic-oq-03/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-03/meta.json
@@ -109,6 +109,21 @@
       "proofId": "fundamental-arithmetic-oq-02",
       "relationship": "Sibling open question",
       "description": "Where oq-02 exhibits the FAILURE of unique factorization in Z[√-5], this entry exploits its SUCCESS in Z to derive the Euler product and Euler's prime-product evaluations."
+    },
+    {
+      "proofId": "basel-problem",
+      "relationship": "Supplies the special value",
+      "description": "The headline identity rewrites the Euler product at s=2 with ζ(2)=π²/6 — exactly the Basel value formalized there. The Basel problem provides the right-hand side; this entry provides the prime-product left-hand side that Euler equated to it in 1737."
+    },
+    {
+      "proofId": "prime-number-theorem",
+      "relationship": "Downstream consequence",
+      "description": "The non-vanishing of ζ for Re s > 1 recorded here (basel_value_ne_zero, via riemannZeta_ne_zero_of_one_lt_re) is the Euler-product seed of the analytic input to PNT: pushing non-vanishing to the boundary line Re s = 1 is what yields the asymptotic π(x) ~ x/log x."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "Euler's analytic refinement",
+      "description": "Euler's product diverges at s=1 (the harmonic series), which gives an analytic proof that there are infinitely many primes — strengthened to the divergence of ∑ 1/p. This entry's first open question asks to formalize that boundary behaviour; infinitude-primes records the elementary (Euclid) counterpart."
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
Enrichment pass for `fundamental-arithmetic-oq-03` (quality 91, pass 0).

## Changes
- **Cross-references (+3, now 6):** Added genuine mathematical links to gallery entries:
  - `basel-problem` — supplies the special value ζ(2)=π²/6 that the headline identity rewrites with
  - `prime-number-theorem` — the non-vanishing of ζ for Re s > 1 recorded here is the Euler-product seed of PNT's analytic input
  - `infinitude-primes` — the s=1 divergence of the Euler product is Euler's analytic proof of infinitely many primes (this entry's first open question)
- **Annotation (+1, now 5):** Added `ann-convergence-halfplane` explaining the `1 < (s:ℂ).re` private-lemma hypotheses as the boundary of absolute convergence — why the FTA rearrangement is legitimate for Re s > 1, and how the s→1⁺ divergence (Mertens) recovers the infinitude of primes.

## Verification
- `pnpm build` passes (exit 0)
- meta.json 12.4 KB (well under ~60 KB cap); 6 cross-refs (cap 20); 5 annotations
- No content removed; `verified`/`mathlib`/axiomCount:0 status untouched and accurate (matches Lean source: 0 sorries, 0 axioms)