### PR TITLE
audit: confirm basel-problem-oq-06-oq-01 clean (∑1/(2k+1)²=π²/8)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -746,6 +746,12 @@
       "lastAudited": "2026-05-04T04:04:47Z",
       "result": "clean"
     },
+    "basel-problem-oq-06-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T03:21:51Z",
+      "result": "clean"
+    },
     "basel-problem-oq-01": {
       "auditCount": 4,
       "issues": [],


### PR DESCRIPTION
## Gallery Integrity Audit — basel-problem-oq-06-oq-01

Audited the **sole remaining unaudited** gallery entry (queue was 4002/4003). Verified `meta.json` against `Proofs/BaselProblemOQ06OQ01.lean`.

### Findings: CLEAN ✓

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `axiom`, no `native_decide`) | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 1 | 1 (`f`) | ✓ |
| lineCount | 118 | 118 | ✓ |
| True stubs | — | 0 | ✓ |
| structure-encoded assumptions | — | 0 | ✓ |

### Narrative integrity
- **Tier B**, badge `mathlib` — correctly credits Mathlib's `hasSum_zeta_two` as the sole analytic input. No delegation opacity: the description's first sentence states "splits Mathlib's hasSum_zeta_two."
- `originalContributions` correctly scoped to the even/odd decomposition work (`hasSum_even`/`hasSum_odd`, tsum form, consistency identity) — does **not** claim to prove the Basel identity itself.
- `mathlibDependencies` all accurate and actually used in the source (hasSum_zeta_two, HasSum.even_add_odd, .mul_left, .unique, Summable.comp_injective).
- Proves the genuine `HasSum (k ↦ 1/(2k+1)²) (π²/8)` equality, not just an inequality/bound.

Gallery is now **4003/4003 audited, 0 issues**.

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)