### PR TITLE
Enrich hilbert-10-oq-04-oq-03-oq-02: add missing index.ts, deepen annotations

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/annotations.json
@@ -1,12 +1,27 @@
 [
   {
+    "id": "h10oq040302-ann-00",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "context",
+    "title": "From a Single Equation to a System",
+    "content": "The docstring frames the program. The parent file Hilbert10OQ04OQ03 decided a single linear Diophantine equation Σ aᵢxᵢ = b over ℤ by one gcd-divisibility test and packaged it as a Decidable instance; its open question oq-02 asks for the extension to whole systems A x = b. This file takes the first structural step: reduce system solvability to membership of b in the ℤ-span of the columns of A, the finitely generated submodule on which Mathlib's PID structure theory (Module.Basis.SmithNormalForm) is phrased. It deliberately stops short of a Decidable instance — turning column-span membership into invariant-factor divisibility via the Smith normal form U A V = D is the still-open decision step. The single import Mathlib and open Matrix Submodule Set bring mulVecLin, range_mulVecLin, and span into scope.",
+    "mathContext": "$A x = b$ with $A : \\mathrm{Matrix}\\,(\\mathrm{Fin}\\,m)\\,(\\mathrm{Fin}\\,n)\\,\\mathbb{Z}$, $b : \\mathrm{Fin}\\,m \\to \\mathbb{Z}$. Solvable $\\iff b \\in \\mathrm{span}_{\\mathbb{Z}}(\\text{columns of }A)$. The classical decision: $U A V = D$ (Smith normal form), solvable iff each invariant factor $d_i \\mid (Ub)_i$.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's tenth problem", "Smith normal form", "Diophantine systems", "principal ideal domain"],
+    "prerequisites": ["linear Diophantine equations", "free modules over a PID", "Decidable instances in Lean"]
+  },
+  {
     "id": "h10oq040302-ann-01",
     "proofId": "hilbert-10-oq-04-oq-03-oq-02",
     "range": { "startLine": 45, "endLine": 51 },
     "type": "concept",
     "title": "Solvability as Range Membership",
     "content": "solvable_iff_mem_range records the definitional starting point: the linear system A x = b is solvable over ℤ exactly when b lies in LinearMap.range A.mulVecLin. The proof is a one-line simp with LinearMap.mem_range (which unfolds range membership to an existential preimage) and Matrix.mulVecLin_apply (which identifies the linear map A.mulVecLin with matrix–vector multiplication A *ᵥ x). This reframes a concrete equation-solving question as a submodule-membership question, the form needed for the structural reformulation that follows.",
-    "mathContext": "For a matrix $A$ over a commutative (semi)ring, $x \\mapsto A x$ is a linear map $\\mathbb{Z}^n \\to \\mathbb{Z}^m$; solvability of $A x = b$ is membership of $b$ in its image."
+    "mathContext": "For a matrix $A$ over a commutative (semi)ring, $x \\mapsto A x$ is a linear map $\\mathbb{Z}^n \\to \\mathbb{Z}^m$; solvability of $A x = b$ is membership of $b$ in its image: $b \\in \\mathrm{range}(A\\cdot) = \\mathrm{im}(A)$.",
+    "significance": "key",
+    "relatedConcepts": ["linear map range", "image of a matrix", "matrix–vector product", "submodule membership"],
+    "prerequisites": ["LinearMap.range", "Matrix.mulVecLin", "existential unfolding"]
   },
   {
     "id": "h10oq040302-ann-02",
@@ -15,15 +30,33 @@
     "type": "concept",
     "title": "The Column-Span Bridge",
     "content": "solvable_iff_mem_colSpan is the entry's main contribution: A x = b is solvable over ℤ iff b ∈ Submodule.span ℤ (Set.range A.col). It follows by rewriting solvable_iff_mem_range with Mathlib's Matrix.range_mulVecLin, which states LinearMap.range A.mulVecLin = span ℤ (range A.col) — the image of multiplication by A is the span of its columns. The significance is that the right-hand side is a finitely generated ℤ-submodule of Fin m → ℤ, the precise object on which Mathlib's Smith-normal-form structure theory (Module.Basis.SmithNormalForm) operates. This is the reduction a Decidable instance for system solvability would build on; the decision step itself (invariant-factor divisibility) is not carried out here.",
-    "mathContext": "The set of attainable right-hand sides $\\{A x : x \\in \\mathbb{Z}^n\\}$ is the column lattice — the $\\mathbb{Z}$-span of the columns of $A$. Deciding $b$ in this lattice is exactly what Smith normal form $U A V = D$ answers."
+    "mathContext": "The set of attainable right-hand sides $\\{A x : x \\in \\mathbb{Z}^n\\}$ is the column lattice — the $\\mathbb{Z}$-span of the columns of $A$. Deciding $b$ in this lattice is exactly what Smith normal form $U A V = D$ answers.",
+    "significance": "critical",
+    "relatedConcepts": ["column lattice", "finitely generated submodule", "Smith normal form", "Matrix.range_mulVecLin"],
+    "prerequisites": ["Submodule.span", "Matrix.col", "range of mulVecLin"]
   },
   {
     "id": "h10oq040302-ann-03",
     "proofId": "hilbert-10-oq-04-oq-03-oq-02",
-    "range": { "startLine": 62, "endLine": 92 },
+    "range": { "startLine": 62, "endLine": 80 },
     "type": "technique",
-    "title": "Single-Row Consistency and a Worked System",
-    "content": "solvable_single_row_iff_sum checks the reduction against the parent: for one equation (m = 1), the matrix system (of fun _ => a) *ᵥ x = (fun _ => b) is solvable iff the scalar equation Σ j, a j * x j = b is. The forward direction evaluates the function equality at the unique index 0 (congrFun … 0) and simplifies mulVec/dotProduct; the reverse direction proves the function equality pointwise (funext, fin_cases on Fin 1). The resulting scalar equation is exactly the hypothesis form of the parent's solvable_iff_gcd_dvd, so composing the two recovers the gcd ∣ b criterion and confirms the system and single-equation entries agree on their overlap. A worked 2×2 example (x + 2y = 5, 3x + 4y = 11, witness (1,2)) shows the system statement is non-vacuous.",
-    "mathContext": "The single-equation case is the $m = 1$ slice of the system theory; the worked $2 \\times 2$ instance exhibits an explicit lattice point $A(1,2)^\\top = (5,11)^\\top$."
+    "title": "Single-Row Consistency with the Parent",
+    "content": "solvable_single_row_iff_sum checks the reduction against the parent: for one equation (m = 1), the matrix system (of fun _ => a) *ᵥ x = (fun _ => b) is solvable iff the scalar equation Σ j, a j * x j = b is. The forward direction evaluates the function equality at the unique index 0 (congrFun … 0) and simplifies mulVec/dotProduct; the reverse direction proves the function equality pointwise (funext, then fin_cases on the single index of Fin 1). The resulting scalar equation is exactly the hypothesis form of the parent's solvable_iff_gcd_dvd, so composing the two recovers the gcd ∣ b criterion and confirms the system and single-equation entries agree on their overlap — an important soundness check that the generalization did not change the answer where the two theories meet.",
+    "mathContext": "For $m = 1$, $A x = b$ unfolds to $\\sum_j a_j x_j = b$; via the parent, this is solvable iff $\\gcd(a) \\mid b$. The single-equation entry is the $m = 1$ slice of the system theory.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization to m = 1", "gcd divisibility criterion", "dotProduct", "Fin 1 case analysis"],
+    "prerequisites": ["congrFun", "funext", "fin_cases", "Matrix.mulVec / dotProduct"]
+  },
+  {
+    "id": "h10oq040302-ann-04",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-02",
+    "range": { "startLine": 82, "endLine": 92 },
+    "type": "definition",
+    "title": "A Worked 2×2 System",
+    "content": "An explicit example certifies the system statement is non-vacuous: the 2×2 system x + 2y = 5, 3x + 4y = 11 is solvable with witness (x, y) = (1, 2), since 1 + 2·2 = 5 and 3·1 + 4·2 = 11. The proof supplies the witness ![1, 2], reduces the vector equality pointwise with funext, and discharges each coordinate by fin_cases i <;> simp using Fin.sum_univ_two to expand the matrix–vector product. Concretely this exhibits a lattice point: b = (5, 11)ᵀ is the column combination 1·(1,3)ᵀ + 2·(2,4)ᵀ, an instance of the column-span membership the bridge characterizes abstractly.",
+    "mathContext": "$\\begin{pmatrix}1&2\\\\3&4\\end{pmatrix}\\begin{pmatrix}1\\\\2\\end{pmatrix} = \\begin{pmatrix}5\\\\11\\end{pmatrix}$, i.e. $(5,11)^\\top = 1\\cdot(1,3)^\\top + 2\\cdot(2,4)^\\top \\in \\mathrm{span}_{\\mathbb{Z}}\\{(1,3)^\\top,(2,4)^\\top\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["explicit witness", "non-vacuity check", "Fin.sum_univ_two", "column combination"],
+    "prerequisites": ["Matrix.of", "matrix–vector multiplication", "fin_cases"]
   }
 ]

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/index.ts
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert10OQ04OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert10OQ04OQ03OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert10OQ04OQ03OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert10OQ04OQ03OQ02Data: ProofData = {
+  proof: hilbert10OQ04OQ03OQ02Proof,
+  annotations: hilbert10OQ04OQ03OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `hilbert-10-oq-04-oq-03-oq-02` (Hilbert's 10th, linear systems → column-lattice membership).

**Critical fix:** `index.ts` was missing — without it Vite's `import.meta.glob` can't discover the proof and the page shows 'proof not found' on the live site despite appearing in the listing. Created it following the sibling convention (`hilbert10OQ04OQ03OQ02*` exports, `Hilbert10OQ04OQ03OQ02.lean?raw` source).

**Annotation depth:** expanded 3 → 5 annotations, each now carrying `significance`, `relatedConcepts`, and `prerequisites` (previously none had them). Added a header-docstring annotation (lines 1-37) and split out a dedicated worked-2×2 annotation.

meta.json already met depth targets (12.9 KB, under cap) — left as-is. `pnpm build` passes; JSON validates.