### PR TITLE
Enrich Eulerian palindromy (geometric-series-oq-07…oq-02-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -1,11 +1,44 @@
 [
   {
+    "id": "eul-palin-context",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 4, "endLine": 47 },
+    "type": "context",
+    "title": "Setup: palindromy as a finite-difference phenomenon",
+    "content": "The docstring situates the entry as the analytic settlement of the parent's open question oq-02. The parent (geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02) established the explicit inclusion–exclusion formula ⟨n,k⟩ = eulerianExplicit n k = ∑_{i=0}^{k}(-1)ⁱ·C(n+1,i)·(k+1-i)ⁿ; this entry derives the palindromic symmetry ⟨n,k⟩ = ⟨n,n-1-k⟩ directly from that finite sum by the reindexing i ↦ n+1-i, rather than by coefficient extraction on the generating polynomial (the route taken by sibling oq-05). The two opens (Finset, and the parent namespaces) bring eulerianExplicit, eulerian, and eulerian_eq_explicit into scope. The single conceptual key: the explicit formula is a truncated finite difference, and extending it to full length exposes a reflection symmetry that the truncation hides.",
+    "mathContext": "The Eulerian numbers satisfy $\\langle n,k\\rangle = \\langle n, n-1-k\\rangle$, equivalently the generating-polynomial functional equation $A_n(t) = t^{n-1}A_n(1/t)$. Here this is obtained from the closed form $\\text{eulerianExplicit}\\,n\\,k = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n$ by an index reflection on the finite sum.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Eulerian numbers",
+      "descent statistic",
+      "inclusion–exclusion",
+      "generating polynomial A_n(t)",
+      "forward difference"
+    ],
+    "prerequisites": [
+      "Parent entry: the explicit inclusion–exclusion formula eulerian_eq_explicit",
+      "permutations and the descent statistic"
+    ]
+  },
+  {
     "id": "eul-palin-nonneg",
     "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
     "range": { "startLine": 55, "endLine": 57 },
     "type": "theorem",
     "title": "Non-negativity of the explicit Eulerian sum",
-    "content": "`eulerianExplicit_nonneg` records that $\\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n \\ge 0$. Although the summand alternates in sign, the whole sum is non-negative because — by the parent's identity `eulerian_eq_explicit` — it equals the cast of the natural number $\\langle n,k\\rangle$, which counts something and is therefore $\\ge 0$. This settles the *easy* half of the sibling open question oq-01; the genuinely combinatorial half (that the sum equals the number of permutations with exactly $k$ descents) is left as a follow-up."
+    "content": "`eulerianExplicit_nonneg` records that $\\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n \\ge 0$. Although the summand alternates in sign, the whole sum is non-negative because — by the parent's identity `eulerian_eq_explicit` — it equals the cast of the natural number $\\langle n,k\\rangle$, which counts something and is therefore $\\ge 0$. This settles the *easy* half of the sibling open question oq-01; the genuinely combinatorial half (that the sum equals the number of permutations with exactly $k$ descents) is left as a follow-up.",
+    "mathContext": "A signed sum that is secretly a count: $\\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n = \\langle n,k\\rangle \\in \\mathbb{N}$, so $0 \\le \\text{eulerianExplicit}\\,n\\,k$. The two-line proof rewrites through `eulerian_eq_explicit` and applies `Nat.zero_le` via `exact_mod_cast`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "eulerian_eq_explicit",
+      "Nat.cast monotonicity",
+      "exact_mod_cast",
+      "alternating sums that count"
+    ],
+    "prerequisites": [
+      "the parent identity ⟨n,k⟩ = eulerianExplicit n k",
+      "casting ℕ ≥ 0 into ℤ"
+    ]
   },
   {
     "id": "eul-palin-fdiff",
@@ -13,7 +46,21 @@
     "range": { "startLine": 65, "endLine": 107 },
     "type": "theorem",
     "title": "Finite-difference vanishing: the full alternating sum is zero",
-    "content": "`full_alt_sum_zero` is the engine of the palindromy proof: the alternating sum extended *one term past* the support of `eulerianExplicit`, $\\sum_{i=0}^{n+1}(-1)^i\\binom{n+1}{i}(k+1-i)^n$, vanishes. The reason is that this is precisely the $(n+1)$-st forward difference of the polynomial $P(x)=(k+1-x)^n$, whose degree $n$ is strictly less than the differencing order $n+1$; an order-$(n+1)$ finite difference annihilates any degree-$n$ polynomial. The proof builds $P$ as `(C (k+1) - X)^n`, invokes Mathlib's `Polynomial.fwdDiff_iter_eq_zero_of_degree_lt`, expands the difference with `fwdDiff_iter_eq_sum_shift`, and reconciles that lemma's sign $(-1)^{n+1-i}$ with the target $(-1)^i$ by factoring out the global sign $(-1)^{n+1}$."
+    "content": "`full_alt_sum_zero` is the engine of the palindromy proof: the alternating sum extended *one term past* the support of `eulerianExplicit`, $\\sum_{i=0}^{n+1}(-1)^i\\binom{n+1}{i}(k+1-i)^n$, vanishes. The reason is that this is precisely the $(n+1)$-st forward difference of the polynomial $P(x)=(k+1-x)^n$, whose degree $n$ is strictly less than the differencing order $n+1$; an order-$(n+1)$ finite difference annihilates any degree-$n$ polynomial. The proof builds $P$ as `(C (k+1) - X)^n`, invokes Mathlib's `Polynomial.fwdDiff_iter_eq_zero_of_degree_lt`, expands the difference with `fwdDiff_iter_eq_sum_shift`, and reconciles that lemma's sign $(-1)^{n+1-i}$ with the target $(-1)^i$ by factoring out the global sign $(-1)^{n+1}$.",
+    "mathContext": "The forward difference $\\Delta f(x) = f(x+1)-f(x)$ iterated $m$ times gives $\\Delta^m f(x) = \\sum_{i=0}^{m}(-1)^{m-i}\\binom{m}{i}f(x+i)$. For a polynomial $f$ of degree $< m$, $\\Delta^m f \\equiv 0$. With $m=n+1$, $f(x)=(k+1-x)^n$ (degree $n$), and $x=0$: $\\sum_{i=0}^{n+1}(-1)^{n+1-i}\\binom{n+1}{i}(k+1-i)^n = 0$. Multiplying by $(-1)^{n+1}$ converts the sign to $(-1)^i$, giving the stated form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Polynomial.fwdDiff_iter_eq_zero_of_degree_lt",
+      "fwdDiff_iter_eq_sum_shift",
+      "forward difference operator Δ",
+      "finite differences annihilate low-degree polynomials",
+      "natDegree of (C a - X)^n"
+    ],
+    "prerequisites": [
+      "forward-difference calculus (Mathlib.Algebra.Group.ForwardDiff)",
+      "degree of polynomial powers",
+      "sign bookkeeping (-1)^{n+1-i} vs (-1)^i"
+    ]
   },
   {
     "id": "eul-palin-explicit",
@@ -21,7 +68,22 @@
     "range": { "startLine": 111, "endLine": 172 },
     "type": "theorem",
     "title": "Palindromy of the explicit sum, by reflection i ↦ n+1−i",
-    "content": "`eulerianExplicit_palindrome` proves $\\text{eulerianExplicit}\\,n\\,k = \\text{eulerianExplicit}\\,n\\,(n-1-k)$ for $k<n$. The full vanishing sum splits (`Finset.sum_range_add`) as `head + tail = 0`, where the head $i=0\\dots k$ is by definition `eulerianExplicit n k`. Reflecting the tail via $i\\mapsto n+1-i$ (`Finset.sum_range_reflect`) restores the coefficient through the binomial symmetry $\\binom{n+1}{n+1-i}=\\binom{n+1}{i}$, reflects the base via $(k+1)-(n+1-i)=-\\big((n-1-k)+1-i\\big)$, and collapses the parity to a single sign by $(-1)^{n+1-i}\\cdot(-1)^n=-(-1)^i$. The length-mismatch overhang term is killed by $0^n=0$ (valid since $k<n\\Rightarrow n\\ge 1$), so the tail equals $-\\text{eulerianExplicit}\\,n\\,(n-1-k)$ and palindromy follows."
+    "content": "`eulerianExplicit_palindrome` proves $\\text{eulerianExplicit}\\,n\\,k = \\text{eulerianExplicit}\\,n\\,(n-1-k)$ for $k<n$. The full vanishing sum splits (`Finset.sum_range_add`) as `head + tail = 0`, where the head $i=0\\dots k$ is by definition `eulerianExplicit n k`. Reflecting the tail via $i\\mapsto n+1-i$ (`Finset.sum_range_reflect`) restores the coefficient through the binomial symmetry $\\binom{n+1}{n+1-i}=\\binom{n+1}{i}$, reflects the base via $(k+1)-(n+1-i)=-\\big((n-1-k)+1-i\\big)$, and collapses the parity to a single sign by $(-1)^{n+1-i}\\cdot(-1)^n=-(-1)^i$. The length-mismatch overhang term is killed by $0^n=0$ (valid since $k<n\\Rightarrow n\\ge 1$), so the tail equals $-\\text{eulerianExplicit}\\,n\\,(n-1-k)$ and palindromy follows.",
+    "mathContext": "Write $S = \\sum_{i=0}^{n+1} T_i = 0$ with $T_i = (-1)^i\\binom{n+1}{i}(k+1-i)^n$. Split $S = \\underbrace{\\sum_{i=0}^{k}T_i}_{\\text{eulerianExplicit }n\\,k} + \\sum_{i=k+1}^{n+1}T_i$. The reflection $i\\mapsto n+1-i$ sends $\\binom{n+1}{i}\\to\\binom{n+1}{i}$ (symmetry), the base $(k+1)-i \\to -((n-1-k)+1-i)$, and the sign by $(-1)^{n+1-i}(-1)^n = -(-1)^i$ (using $(-\\beta)^n=(-1)^n\\beta^n$), so the tail $= -\\sum_{i=0}^{n-1-k}(-1)^i\\binom{n+1}{i}((n-1-k)+1-i)^n = -\\text{eulerianExplicit}\\,n\\,(n-1-k)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_add",
+      "Finset.sum_range_reflect",
+      "Nat.choose_symm",
+      "neg_pow",
+      "linear_combination tactic",
+      "0^n vanishing (zero_pow)"
+    ],
+    "prerequisites": [
+      "the finite-difference vanishing lemma full_alt_sum_zero",
+      "Finset reindexing and reflection",
+      "ℕ-to-ℤ subtraction casts (Nat.cast_sub, push_cast)"
+    ]
   },
   {
     "id": "eul-palin-combinatorial",
@@ -29,6 +91,19 @@
     "range": { "startLine": 174, "endLine": 180 },
     "type": "theorem",
     "title": "Palindromy of the combinatorial Eulerian numbers",
-    "content": "`eulerian_palindrome` transfers the symmetry to the combinatorial numbers themselves: $\\langle n,k\\rangle=\\langle n,n-1-k\\rangle$ for $k<n$. This is a one-line consequence of the explicit-sum palindromy and the parent's identity `eulerian_eq_explicit`, casting the $\\mathbb{Z}$-identity back to $\\mathbb{N}$. Combinatorially it is the descent/ascent duality: reversing a permutation of $\\{1,\\dots,n\\}$ turns its $k$ descents into $n-1-k$ descents."
+    "content": "`eulerian_palindrome` transfers the symmetry to the combinatorial numbers themselves: $\\langle n,k\\rangle=\\langle n,n-1-k\\rangle$ for $k<n$. This is a one-line consequence of the explicit-sum palindromy and the parent's identity `eulerian_eq_explicit`, casting the $\\mathbb{Z}$-identity back to $\\mathbb{N}$. Combinatorially it is the descent/ascent duality: reversing a permutation of $\\{1,\\dots,n\\}$ turns its $k$ descents into $n-1-k$ descents.",
+    "mathContext": "Descent/ascent duality: the reversal $\\sigma \\mapsto \\sigma^{R}$ (where $\\sigma^R(i)=\\sigma(n+1-i)$) is a bijection on $S_n$ sending a permutation with $k$ descents to one with $n-1-k$ descents, hence $\\langle n,k\\rangle=\\langle n,n-1-k\\rangle$. The Lean proof obtains the same identity analytically: rewrite both sides through $\\langle n,\\cdot\\rangle = \\text{eulerianExplicit}\\,n\\,\\cdot$ and apply `eulerianExplicit_palindrome`, then `exact_mod_cast` back to $\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "descent/ascent duality",
+      "permutation reversal",
+      "eulerian_eq_explicit",
+      "Eulerian triangle symmetry",
+      "exact_mod_cast"
+    ],
+    "prerequisites": [
+      "eulerianExplicit_palindrome",
+      "the parent identity ⟨n,k⟩ = eulerianExplicit n k"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02` (quality 65, pass 0).

## Changes
- **Annotation enrichment fields:** All 4 existing annotations previously had only id/proofId/range/type/title/content. Added the core enricher fields mathContext (LaTeX), significance, relatedConcepts, prerequisites to each — the forward-difference expansion for the vanishing engine, the reflection sign/base/binomial mechanics for the palindromy step, and descent/ascent duality for the combinatorial statement.
- **Coverage (+1 annotation):** Added eul-palin-context covering the docstring/setup section (lines 4-47), previously uncovered.

## Verification
- pnpm build passes (exit 0)
- All 5 annotations now carry mathContext/significance/relatedConcepts/prerequisites
- annotations.json 8.7 KB; meta.json 18.7 KB (well under ~60 KB cap)
- No existing content removed; verified/original/axiomCount:0 untouched (matches Lean: 0 sorries, 0 axioms, 4 theorems)