### PR TITLE
research(triangle-angle-sum-oq-07): degenerate (collinear) triangle angle sums (verified)

### DIFF
--- a/proofs/Proofs/TriangleAngleSumOQ07.lean
+++ b/proofs/Proofs/TriangleAngleSumOQ07.lean
@@ -1,0 +1,75 @@
+import Mathlib.Geometry.Euclidean.Triangle
+import Mathlib.Tactic
+
+/-!
+# Triangle Angle Sum — Degenerate (Collinear) Cases (oq-07)
+
+## The Open Question
+
+The parent entry `triangle-angle-sum` verifies the classical identity
+`∠ABC + ∠BCA + ∠CAB = π` for a non-degenerate triangle (Mathlib's
+`EuclideanGeometry.angle_add_angle_add_angle_eq_pi`, which requires two vertices
+distinct from the third). One of its listed open questions asks:
+
+> *How does Mathlib's unoriented angle handle degenerate cases (collinear points),
+> and what is the angle sum for a "triangle" with collinear vertices?*
+
+This file answers it precisely, with fully verified Lean (no `sorry`, no `axiom`).
+
+## The Answer
+
+For the unoriented angle `∠` (`EuclideanGeometry.angle`, valued in `[0, π]`):
+
+1. **One vertex strictly between the other two** (the generic collinear case,
+   `Sbtw ℝ A B C`): the middle angle is the straight angle `π` and the two end
+   angles collapse to `0`, so the sum is **still `π`**. The Euclidean angle-sum
+   identity therefore extends continuously to this degenerate configuration.
+2. The same conclusion holds from the bare hypothesis `∠ A B C = π` (equivalent to
+   strict betweenness, `angle_eq_pi_iff_sbtw`).
+3. **All three vertices coincide**: every angle is `∠ A A A = π/2` (Mathlib's
+   convention `angle_self_left : ∠ p₀ p₀ p = π/2`), so the sum is `3π/2 ≠ π`.
+   This shows the degenerate angle sum is *not* universally `π` — the value `π`
+   is special to the strictly-between collinear configuration.
+
+So Mathlib's unoriented angle behaves cleanly on collinear inputs, and the
+"triangle angle sum" survives the strictly-between degeneration but breaks at the
+fully-coincident one.
+-/
+
+namespace TriangleAngleSumOQ07
+
+open scoped EuclideanGeometry
+
+variable {V : Type*} {P : Type*}
+variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P] [NormedAddTorsor V P]
+
+/-- **Degenerate triangle angle sum (abstract form).**
+If the angle at `B` is the straight angle `π` (i.e. `B` lies strictly between `A`
+and `C`), the two remaining angles vanish and the angle sum is still `π`. -/
+theorem angle_sum_of_angle_eq_pi {A B C : P} (h : ∠ A B C = Real.pi) :
+    ∠ A B C + ∠ B C A + ∠ C A B = Real.pi := by
+  have hCA : ∠ B C A = 0 := by
+    have hCBA : ∠ C B A = Real.pi := by rw [EuclideanGeometry.angle_comm]; exact h
+    exact EuclideanGeometry.angle_eq_zero_of_angle_eq_pi_left hCBA
+  have hAB : ∠ C A B = 0 := by
+    have hBAC : ∠ B A C = 0 := EuclideanGeometry.angle_eq_zero_of_angle_eq_pi_left h
+    rw [EuclideanGeometry.angle_comm]; exact hBAC
+  rw [h, hCA, hAB]; ring
+
+/-- **Degenerate triangle angle sum (betweenness form).**
+If `B` lies strictly between `A` and `C` (a collinear "triangle" with `B` the middle
+vertex), the unoriented interior angle sum equals `π` — the classical identity
+persists through this degeneration. -/
+theorem Sbtw.angle_sum_eq_pi {A B C : P} (h : Sbtw ℝ A B C) :
+    ∠ A B C + ∠ B C A + ∠ C A B = Real.pi :=
+  angle_sum_of_angle_eq_pi h.angle₁₂₃_eq_pi
+
+/-- **Fully coincident degeneration.**
+When all three vertices coincide, Mathlib's convention `∠ A A A = π/2` makes the
+angle sum `3π/2`, not `π`. Hence the degenerate angle sum is not universally `π`:
+the value `π` is special to the strictly-between collinear case above. -/
+theorem angle_sum_self (A : P) :
+    ∠ A A A + ∠ A A A + ∠ A A A = 3 * (Real.pi / 2) := by
+  rw [EuclideanGeometry.angle_self_left]; ring
+
+end TriangleAngleSumOQ07

--- a/src/data/proofs/triangle-angle-sum-oq-07/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-07/annotations.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "ann-collinear-strictly-between",
+    "proofId": "triangle-angle-sum-oq-07",
+    "range": {
+      "startLine": 46,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "Strictly-Between Collinear Degeneration (angle sum = π)",
+    "content": "angle_sum_of_angle_eq_pi proves ∠ABC + ∠BCA + ∠CAB = π from the bare hypothesis ∠ABC = π. Mathlib's angle_comm turns ∠ABC = π into ∠CBA = π, and angle_eq_zero_of_angle_eq_pi_left collapses each straight angle into a vanishing end angle: ∠BCA = 0 directly, and ∠CAB = 0 after one more angle_comm. Substituting gives π + 0 + 0 = π. Sbtw.angle_sum_eq_pi restates this for the geometric hypothesis Sbtw ℝ A B C (B strictly between A and C): Sbtw.angle₁₂₃_eq_pi supplies ∠ABC = π and the abstract form finishes. This is exactly the limit of a non-degenerate triangle flattening with one vertex onto the opposite edge — the middle angle tends to the straight angle π while both end angles tend to 0, so the classical identity ∠ABC + ∠BCA + ∠CAB = π persists through the degeneration. Mathlib's non-degenerate theorem angle_add_angle_add_angle_eq_pi excludes this configuration (it requires two vertices distinct from the third); these theorems cover it."
+  },
+  {
+    "id": "ann-coincident",
+    "proofId": "triangle-angle-sum-oq-07",
+    "range": {
+      "startLine": 67,
+      "endLine": 74
+    },
+    "type": "theorem",
+    "title": "Fully Coincident Degeneration (angle sum = 3π/2)",
+    "content": "angle_sum_self computes the interior angle sum when all three vertices coincide. Mathlib's convention angle_self_left : ∠ p₀ p₀ p = π/2 makes ∠AAA = π/2, so the sum is 3·(π/2) = 3π/2 ≠ π (closed by ring). This shows the degenerate angle sum is NOT universally π: the value π is special to the strictly-between collinear case. Note the proof works with Real.pi explicitly rather than the π notation, since the π notation is not in scope in this file (matching the parent TriangleAngleSum.lean convention) — using a bare π would auto-bind it as a free variable distinct from Real.pi."
+  }
+]

--- a/src/data/proofs/triangle-angle-sum-oq-07/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-07/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "triangle-angle-sum-oq-07",
+  "title": "Triangle Angle Sum OQ-07: Degenerate (Collinear) Triangles and the Angle Sum",
+  "slug": "triangle-angle-sum-oq-07",
+  "description": "The parent entry triangle-angle-sum verifies the classical identity ∠ABC + ∠BCA + ∠CAB = π for a non-degenerate triangle (Mathlib's EuclideanGeometry.angle_add_angle_add_angle_eq_pi, which requires two vertices distinct from the third), and lists as an open question how Mathlib's unoriented angle behaves on degenerate (collinear) configurations and what the angle sum is there. This entry answers that question, fully verified (0 sorries, 0 axioms). For the unoriented angle ∠ (valued in [0, π]): when one vertex lies strictly between the other two (the generic collinear case, Sbtw ℝ A B C), the middle angle is the straight angle π and the two end angles collapse to 0, so the interior angle sum is STILL π — the Euclidean identity extends continuously to this degeneration. The same conclusion follows from the bare hypothesis ∠ABC = π (equivalent to strict betweenness by Mathlib's angle_eq_pi_iff_sbtw). By contrast, when all three vertices coincide, every angle is ∠AAA = π/2 (Mathlib's convention angle_self_left : ∠ p₀ p₀ p = π/2), so the sum is 3π/2 ≠ π. Thus the unoriented angle is well behaved on collinear inputs, and the triangle angle sum survives the strictly-between degeneration but breaks at the fully-coincident one. NOTE: the sum-to-product reading of the oq-07 slug (the sin x + sin y identity) is already subsumed by triangle-angle-sum-oq-06; this entry instead resolves the parent's degenerate-cases open question.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Geometry.Euclidean.Triangle",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "EuclideanGeometry"
+    ],
+    "namespace": "TriangleAngleSumOQ07",
+    "lineCount": 75,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/TriangleAngleSumOQ07.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Euclidean/Angle/Unoriented/Affine.html",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TriangleAngleSumOQ07.lean",
+    "tags": [
+      "euclidean-geometry",
+      "triangle",
+      "angle-sum",
+      "degenerate",
+      "collinear",
+      "betweenness"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-26",
+    "relatedProblems": [
+      {
+        "id": "triangle-angle-sum",
+        "relationship": "Answers the parent's listed open question on degenerate (collinear) cases: the non-degenerate angle-sum identity ∠ABC+∠BCA+∠CAB=π (angle_add_angle_add_angle_eq_pi) extends to the strictly-between collinear configuration, and the entry pins down exactly where it breaks (fully coincident vertices give 3π/2)."
+      },
+      {
+        "id": "triangle-angle-sum-oq-06",
+        "relationship": "Disambiguation: the sum-to-product (sin x + sin y) reading of the oq-07 slug is already subsumed by oq-06's sin_add_sin; this entry takes up the parent's distinct degenerate-cases open question instead."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 75,
+    "assumptions": "0 axioms, 0 sorries, no native_decide, no Lean.ofReduceBool. All three theorems depend only on the foundational propext / Classical.choice / Quot.sound. They are built directly on Mathlib's unoriented-angle API: Sbtw.angle₁₂₃_eq_pi, angle_eq_zero_of_angle_eq_pi_left, angle_comm, and angle_self_left. The strictly-between case carries the genuine geometric hypothesis Sbtw ℝ A B C (equivalently ∠ABC = π); the coincident case is unconditional.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Euclidean triangle angle-sum theorem (Euclid, Elements I.32) is stated for genuine triangles — three non-collinear points. A natural formal-mathematics question is what the statement becomes when the triangle degenerates: when the three vertices become collinear, or when some of them coincide. Mathlib formalizes the unoriented angle ∠ p₁ p₂ p₃ (the angle at the middle vertex p₂, valued in [0, π]) for arbitrary points, with fixed conventions on the degenerate inputs (∠ at a straight configuration is π; the angle of a point with a repeated vertex is π/2). This entry reads off the angle sum under those conventions.",
+    "problemStatement": "For Mathlib's unoriented angle ∠ on a real inner-product (Euclidean) space, determine the interior angle sum ∠ABC + ∠BCA + ∠CAB of a degenerate 'triangle': (i) when one vertex lies strictly between the other two (collinear), and (ii) when all three vertices coincide.",
+    "text": "Mathlib proves the angle sum equals π only for non-degenerate triangles (angle_add_angle_add_angle_eq_pi needs two vertices distinct from the third). This entry handles the degenerate inputs that lemma excludes: the strictly-between collinear case still sums to π, while the fully-coincident case sums to 3π/2.",
+    "proofStrategy": "angle_sum_of_angle_eq_pi: from ∠ABC = π, angle_comm gives ∠CBA = π, and angle_eq_zero_of_angle_eq_pi_left turns each straight angle into a vanishing end angle (∠BCA = 0 and, after angle_comm, ∠CAB = 0); substituting gives π + 0 + 0 = π. Sbtw.angle_sum_eq_pi: Sbtw ℝ A B C yields ∠ABC = π via Sbtw.angle₁₂₃_eq_pi, then reuses the abstract form. angle_sum_self: angle_self_left rewrites each ∠AAA to π/2, and ring gives 3·(π/2).",
+    "keyInsights": [
+      "**The straight-angle case is continuous**: as a non-degenerate triangle flattens with one vertex approaching the opposite edge, the middle angle tends to π and the two end angles tend to 0, so the angle sum stays π in the limit — and Mathlib's conventions make this exact at the degenerate configuration via Sbtw.angle₁₂₃_eq_pi and angle_eq_zero_of_angle_eq_pi_left.",
+      "**Strict betweenness is exactly ∠ = π**: Mathlib's angle_eq_pi_iff_sbtw identifies the analytic hypothesis ∠ABC = π with the order-theoretic Sbtw ℝ A B C, so the abstract and geometric statements of the result are interchangeable.",
+      "**The angle sum is not universally π under degeneration**: the fully-coincident configuration gives ∠AAA = π/2 thrice, hence 3π/2. The value π is special to the strictly-between collinear case, distinguishing the two kinds of degeneration."
+    ],
+    "prerequisites": [
+      "Mathlib's unoriented angle EuclideanGeometry.angle and its conventions on degenerate inputs",
+      "Sbtw.angle₁₂₃_eq_pi and angle_eq_pi_iff_sbtw (strict betweenness ⟺ straight angle)",
+      "angle_eq_zero_of_angle_eq_pi_left and angle_comm",
+      "angle_self_left : ∠ p₀ p₀ p = π/2"
+    ]
+  },
+  "sections": [
+    {
+      "id": "collinear-strictly-between",
+      "title": "Strictly-Between Collinear Degeneration (sum = π)",
+      "startLine": 46,
+      "endLine": 65,
+      "mathContext": "$\\angle ABC + \\angle BCA + \\angle CAB = \\pi$ when $B$ lies strictly between $A$ and $C$.",
+      "summary": "angle_sum_of_angle_eq_pi proves the angle sum is π from the bare hypothesis ∠ABC = π (the middle angle is straight, both end angles vanish). Sbtw.angle_sum_eq_pi restates it for strict betweenness Sbtw ℝ A B C, the geometric form of a flattened triangle with B as the middle vertex."
+    },
+    {
+      "id": "coincident",
+      "title": "Fully Coincident Degeneration (sum = 3π/2)",
+      "startLine": 67,
+      "endLine": 74,
+      "mathContext": "$\\angle AAA + \\angle AAA + \\angle AAA = 3\\pi/2$.",
+      "summary": "angle_sum_self computes the angle sum when all three vertices coincide: Mathlib's convention ∠AAA = π/2 gives 3π/2, showing the degenerate angle sum is not universally π."
+    }
+  ],
+  "conclusion": {
+    "summary": "The behaviour of Mathlib's unoriented angle on degenerate triangles is settled, sorry-free and axiom-free: the interior angle sum is π when one vertex is strictly between the other two (collinear), and 3π/2 when all three vertices coincide. The first result extends the classical Euclidean identity continuously through the strictly-between degeneration; the second locates exactly where it fails.",
+    "implications": "Together with the parent entry's non-degenerate theorem, this gives a complete picture of the triangle angle sum across both genuine and degenerate configurations under Mathlib's angle conventions, answering the parent's open question on collinear vertices.",
+    "openQuestions": [
+      "What is the angle sum when exactly two of the three vertices coincide (and the third is distinct)?",
+      "Can an analogous degeneracy analysis be carried out for the oriented angle ∡, where signs distinguish the configurations?",
+      "Does the strictly-between angle-sum-π result generalise to the perimeter angle sum of a degenerate (collinear) polygon?"
+    ]
+  },
+  "crossReferences": [
+    "triangle-angle-sum",
+    "triangle-angle-sum-oq-06"
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent `triangle-angle-sum` entry's listed open question on **degenerate cases**: how Mathlib's unoriented angle behaves on collinear vertices, and what the angle sum is. Fully verified (0 sorry, 0 axiom; Docker build `Built Proofs.TriangleAngleSumOQ07`, 3082 jobs, Lean v4.26).

## Theorems (`proofs/Proofs/TriangleAngleSumOQ07.lean`)

| Theorem | Statement |
|---------|-----------|
| `angle_sum_of_angle_eq_pi` | `∠ABC = π ⟹ ∠ABC + ∠BCA + ∠CAB = π` |
| `Sbtw.angle_sum_eq_pi` | `Sbtw ℝ A B C ⟹ ∠ABC + ∠BCA + ∠CAB = π` (B strictly between A and C) |
| `angle_sum_self` | `∠AAA + ∠AAA + ∠AAA = 3·(π/2)` (all vertices coincident) |

**The answer:** when one vertex lies strictly between the other two (collinear), the middle angle is the straight angle `π` and the two end angles collapse to `0`, so the interior angle sum is **still `π`** — the Euclidean identity extends continuously through the degeneration. When all three vertices coincide, every angle is `∠AAA = π/2`, so the sum is `3π/2 ≠ π`, locating exactly where the identity breaks. Mathlib's non-degenerate `angle_add_angle_add_angle_eq_pi` requires two vertices distinct from the third and excludes these configurations.

## Gallery

Adds `src/data/proofs/triangle-angle-sum-oq-07/` (meta.json + annotations.json, `status: verified`, `badge: original`). Passes `annotations:validate` and `gallery:check-size` cleanly.

## Note on the slug

The sum-to-product (`sin x + sin y`) reading of the `oq-07` slug is already **subsumed by `triangle-angle-sum-oq-06`** (`sin_add_sin`). This entry takes up the parent's distinct degenerate-cases open question instead, and the cross-references record the disambiguation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)