### PR TITLE
audit: confirm baire-category-theorem-oq-01-oq-01-oq-01 clean (OMT/Inverse/CGT from gallery Baire)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -18150,6 +18150,12 @@
       "lastAudited": "2026-06-24T12:27:19Z",
       "result": "clean"
     },
+    "baire-category-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T03:27:07Z",
+      "result": "clean"
+    },
     "baire-category-theorem-oq-01-oq-02": {
       "auditCount": 1,
       "issues": [],


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Audited the sole remaining unaudited gallery entry: **baire-category-theorem-oq-01-oq-01-oq-01** (Open Mapping, Inverse Mapping, and Closed Graph theorems derived from the gallery Baire category theorem).

### Integrity checks

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 256 | 256 | ✓ |
| sorries | 0 | 0 (2 grep hits are prose: "`sorry`" in docstring, "admits" L134) | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 (only proof-local `let`) | ✓ |
| True stubs | — | 0 | ✓ |

### Tier classification — Tier A, defensible

The file **genuinely re-proves** the three theorems from the gallery Baire theorem (`BaireCategoryTheoremOQ01.baire_nonempty_interior`). It does **not** call Mathlib's `ContinuousLinearMap.isOpenMap`. The listed `mathlibDependencies` (`rescale_to_shell`, `summable_geometric_two`, `completeSpace_coe_iff_isComplete`, `graph_eq_range_prod`, and the Baire category form) are genuine infrastructure lemmas — none is the open mapping theorem itself.

Framing is honest: the first docstring paragraph and the overview state the single Baire dependency up front, and the references credit Mathlib's `Banach.lean` as the analogous internal route. No delegation opacity, no axiom masking, no inequality/pipeline inflation. `badge: verified` / `status: verified` is correct.

**Result: clean.** Audit queue now 4004/4004 audited, 0 unaudited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)