### PR TITLE
Fix: correct stale top-level sorry count on two axiomatized proofs

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -173,5 +173,5 @@
       "mathContext": "$(X_1+\\cdots+X_n)/\\sqrt{n} \\xrightarrow{d} N(0,\\sigma^2)$; proved: $\\mathbb{E}[X^2 \\cdot \\mathbf{1}_{|X|>\\varepsilon\\sqrt{n}}] \\xrightarrow{\\text{DCT}} 0$; $\\Lambda_n(\\delta) = \\mathbb{E}[|X|^{2+\\delta}]/n^{\\delta/2} \\to 0$"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -159,5 +159,5 @@
       "Proofs/Erdos117OQ01OQ01.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Two axiomatized gallery proofs carried a stale top-level `"sorries": 1` inconsistent with their own authoritative `.meta.sorries` (0) and the auto-generated `leanFile.sorries` snapshot (0).

## Evidence

| proof | top-level (before) | `.meta.sorries` | `leanFile.sorries` | main-file code sorries | status |
|-------|-----|-----|-----|-----|-----|
| `erdos-117-oq-01` | 1 | 0 | 0 | 0 (3 axioms) | axiomatized / axiom |
| `central-limit-theorem-oq-02` | 1 | 0 | 0 | 0 (1 axiom) | axiomatized / axiom |

The top-level `1` is a leftover from before each proof was converted to an axiomatized formalization. The main Lean source files have zero code sorries (CLT's only `sorry` match is a docstring "no sorry" reference; the sorries that exist live in separate `*Aristotle.lean` proof-search companions, which are not the gallery `leanFile`). After the fix all three counts agree at 0.

**Before**: same `meta.json` claimed both `0` (`.meta`/`leanFile`) and `1` (top-level).
**After**: top-level `sorries: 0` — consistent across all three fields.

Note: `ballot-problem-oq-03-oq-01-oq-02` (top=3, leanFile=0) was deliberately left untouched — it is self-consistent (`.meta.sorries=3`, `status=formalized`/`wip`) and its count reflects aggregate helper-file sorries, not the single main file.

Found via the mechanic's standing leanFile-snapshot-drift scan; no open auditor issue.

---
Automated fix by lean-mechanic agent.