### PR TITLE
research(abel-ruffini-oq-04-oq-01-oq-02): Galois group of irreducible polynomial is a transitive subgroup of S_n

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ01OQ02.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ01OQ02.lean
@@ -1,0 +1,107 @@
+/-
+  Abel–Ruffini, concrete-quintic branch (oq-04-oq-01), open question oq-02:
+
+      "Generalize to transitive subgroups of `S_n` via Galois theory."
+
+  The parent entry (`AbelRuffiniOQ04OQ01`, "Gal(x⁵ − 4x + 2) ≅ S₅") computes a
+  *single* Galois group by hand, and the sibling `AbelRuffiniOQ04OQ01OQ04`
+  proves the abstract group-theory lemma "a transitive subgroup of `S_p`
+  (`p` prime) containing a transposition is all of `S_p`" — but takes the
+  transitivity `[IsPretransitive G α]` as a *hypothesis*. Neither file records
+  the Galois-theoretic fact that supplies that hypothesis in the first place:
+
+      **the Galois group of an irreducible polynomial really is a transitive
+      subgroup of the symmetric group on its roots.**
+
+  This file fills that gap, axiom-free, working over an *arbitrary* base field
+  and for an *arbitrary* degree (not just the prime-degree quintic case):
+
+  * `galActionHom_range_isPretransitive` — for an irreducible `p` that splits in
+    `E`, the image `(galActionHom p E).range ≤ Equiv.Perm (rootSet p E)` acts
+    transitively on the roots. This is the precise sense in which `Gal p` *is a
+    transitive subgroup of `S_n`* (`n = #roots`); it is the Galois-theoretic
+    input that the sibling `eq_top_of_isPretransitive_of_mem_isSwap` consumes.
+  * `galMulEquivRange` — `Gal p ≃* (galActionHom p E).range`, packaging the
+    standard injectivity of `galActionHom` so that `Gal p` is *literally*
+    realised as a (transitive) permutation group of the roots.
+  * `natDegree_dvd_card` — the orbit–stabiliser payoff in Galois-theoretic
+    form: for any irreducible `p` (char `0`), `p.natDegree ∣ Nat.card p.Gal`.
+    This **generalises Mathlib's `Polynomial.Gal.prime_degree_dvd_card`**, which
+    states the same divisibility only when `p.natDegree` is prime; the parent
+    entry used the prime case as Stage 3's "5 ∣ |Gal|".
+
+  Together these say: passing from the concrete quintic to general `n` is not
+  ad hoc — every irreducible polynomial hands you a transitive subgroup of `Sₙ`,
+  with `n ∣ |Gal|` automatically.
+-/
+
+import Mathlib
+
+open Polynomial Polynomial.Gal MulAction
+open scoped IntermediateField
+
+namespace AbelRuffiniOQ04OQ01OQ02
+
+variable {F : Type*} [Field F] (p : F[X]) (E : Type*) [Field E] [Algebra F E]
+
+/-- **The Galois group of an irreducible polynomial is a transitive subgroup of
+the symmetric group on its roots.**
+
+For an irreducible `p` that splits in `E`, the image of the permutation
+representation `galActionHom p E : p.Gal →* Equiv.Perm (rootSet p E)` is a
+subgroup of `Equiv.Perm (rootSet p E)` whose tautological action on the roots is
+transitive. Mathlib's `Polynomial.Gal.galAction_isPretransitive` gives
+transitivity of the `p.Gal`-action; this transports it to the realised
+permutation subgroup, which is exactly "a transitive subgroup of `Sₙ`". -/
+theorem galActionHom_range_isPretransitive
+    [Fact ((p.map (algebraMap F E)).Splits)] (hp : Irreducible p) :
+    MulAction.IsPretransitive (galActionHom p E).range (p.rootSet E) := by
+  have ht := galAction_isPretransitive p E hp
+  refine ⟨fun x y => ?_⟩
+  obtain ⟨g, hg⟩ := ht.exists_smul_eq x y
+  -- `galActionHom p E g` lies in the range and acts on `x` exactly as `g` does.
+  refine ⟨⟨galActionHom p E g, g, rfl⟩, ?_⟩
+  have hstep : (⟨galActionHom p E g, g, rfl⟩ : (galActionHom p E).range) • x
+      = g • x := rfl
+  rw [hstep]
+  exact hg
+
+/-- `Gal p` is realised, via `galActionHom`, as the transitive permutation
+subgroup `(galActionHom p E).range` of `Equiv.Perm (rootSet p E)`. This packages
+Mathlib's `galActionHom_injective` as the group isomorphism onto the range. -/
+noncomputable def galMulEquivRange [Fact ((p.map (algebraMap F E)).Splits)] :
+    p.Gal ≃* (galActionHom p E).range :=
+  MonoidHom.ofInjective (galActionHom_injective p E)
+
+/-- **Degree divides the order of the Galois group, in any degree.**
+
+For an irreducible polynomial `p` over a characteristic-zero field,
+`p.natDegree ∣ Nat.card p.Gal`. This is the orbit–stabiliser consequence of the
+transitive action on the `natDegree`-many roots, and it generalises Mathlib's
+`Polynomial.Gal.prime_degree_dvd_card` (which assumes `p.natDegree` prime).
+
+The proof mirrors Mathlib's prime-degree argument: it only used primality to
+secure `p.degree ≠ 0`, which for an irreducible polynomial is automatic
+(`Irreducible.natDegree_pos`). -/
+theorem natDegree_dvd_card [CharZero F] (hirr : Irreducible p) :
+    p.natDegree ∣ Nat.card p.Gal := by
+  rw [Polynomial.Gal.card_of_separable hirr.separable]
+  have hdeg : p.degree ≠ 0 := fun h =>
+    (hirr.natDegree_pos).ne' (natDegree_eq_zero_iff_degree_le_zero.mpr h.le)
+  let α : p.SplittingField :=
+    rootOfSplits (SplittingField.splits p) (by rwa [degree_map])
+  have hα : IsIntegral F α := .of_finite F α
+  use Module.finrank F⟮α⟯ p.SplittingField
+  suffices (minpoly F α).natDegree = p.natDegree by
+    letI _ : AddCommGroup F⟮α⟯ := Ring.toAddCommGroup
+    rw [← Module.finrank_mul_finrank F F⟮α⟯ p.SplittingField,
+      IntermediateField.adjoin.finrank hα, this]
+  suffices minpoly F α ∣ p by
+    have key := (minpoly.irreducible hα).dvd_symm hirr this
+    apply le_antisymm
+    · exact natDegree_le_of_dvd this hirr.ne_zero
+    · exact natDegree_le_of_dvd key (minpoly.ne_zero hα)
+  apply minpoly.dvd F α
+  rw [← eval_map_algebraMap, eval_rootOfSplits]
+
+end AbelRuffiniOQ04OQ01OQ02

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/annotations.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "ann-transitive-subgroup",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
+    "range": {
+      "startLine": 55,
+      "endLine": 69
+    },
+    "type": "theorem",
+    "title": "Gal as a Transitive Subgroup of S_n",
+    "content": "The central result: for an irreducible polynomial p that splits in E, the image (galActionHom p E).range of the permutation representation is a subgroup of Equiv.Perm (rootSet p E) whose tautological action on the roots is transitive. This is the precise sense in which 'the Galois group is a transitive subgroup of S_n.' Mathlib's galAction_isPretransitive supplies transitivity of the abstract p.Gal-action; the proof transfers it to the realised permutation subgroup by noting the corestriction p.Gal → range is a surjective equivariant map — given roots x, y choose g with g • x = y, then ⟨galActionHom p E g, _⟩ moves x to y by the very same permutation (rfl). This is exactly the transitivity hypothesis that the sibling lemma eq_top_of_isPretransitive_of_mem_isSwap takes for granted.",
+    "mathContext": "$p$ irreducible $\\implies (\\mathrm{galActionHom}\\,p\\,E).\\mathrm{range} \\le \\mathrm{Perm}(\\mathrm{rootSet}\\,p\\,E)$ acts transitively on the roots.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "transitive permutation group",
+      "Galois action on roots",
+      "irreducible polynomial",
+      "permutation representation"
+    ],
+    "prerequisites": [
+      "Polynomial.Gal.galAction_isPretransitive",
+      "MulAction.IsPretransitive.exists_smul_eq",
+      "MonoidHom.range"
+    ]
+  },
+  {
+    "id": "ann-iso-onto-range",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
+    "range": {
+      "startLine": 71,
+      "endLine": 75
+    },
+    "type": "definition",
+    "title": "Realising Gal as the Permutation Group",
+    "content": "Packages the standard injectivity of galActionHom (galActionHom_injective) into the group isomorphism Gal p ≃* (galActionHom p E).range via MonoidHom.ofInjective. Combined with the transitivity result above, this says Gal p is literally realised — not merely mapped — as a transitive subgroup of the symmetric group on the roots: the embedding is an isomorphism onto its image.",
+    "mathContext": "$\\mathrm{Gal}\\,p \\;\\simeq^*\\; (\\mathrm{galActionHom}\\,p\\,E).\\mathrm{range} \\le \\mathrm{Perm}(\\mathrm{rootSet}\\,p\\,E).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "group isomorphism onto range",
+      "faithful permutation representation",
+      "embedding into a symmetric group"
+    ],
+    "prerequisites": [
+      "Polynomial.Gal.galActionHom_injective",
+      "MonoidHom.ofInjective"
+    ]
+  },
+  {
+    "id": "ann-degree-divides-order",
+    "proofId": "abel-ruffini-oq-04-oq-01-oq-02",
+    "range": {
+      "startLine": 85,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "Degree Divides |Gal| in Any Degree",
+    "content": "The orbit–stabilizer payoff in Galois-theoretic form: for any irreducible p over a characteristic-zero field, p.natDegree ∣ Nat.card p.Gal. This generalizes Mathlib's prime_degree_dvd_card, which states the identical divisibility only when p.natDegree is prime. The key observation is that Mathlib's prime-degree proof used primality for nothing more than securing p.degree ≠ 0; for an irreducible polynomial that is automatic via Irreducible.natDegree_pos, and the remaining minimal-polynomial / finrank-tower argument (minpoly F α ∣ p, IntermediateField.adjoin.finrank, Module.finrank_mul_finrank, card_of_separable) goes through verbatim. The parent entry's Stage-3 fact '5 | |Gal|' is the prime instance n = 5.",
+    "mathContext": "$p$ irreducible, $\\mathrm{char}\\,F = 0 \\implies \\deg p \\mid |\\mathrm{Gal}\\,p|$, for every degree (not only prime).",
+    "significance": "key",
+    "relatedConcepts": [
+      "orbit–stabilizer theorem",
+      "prime_degree_dvd_card generalization",
+      "minimal polynomial degree",
+      "field extension degree"
+    ],
+    "prerequisites": [
+      "Polynomial.Gal.card_of_separable",
+      "Irreducible.natDegree_pos",
+      "IntermediateField.adjoin.finrank",
+      "minpoly.dvd"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "abel-ruffini-oq-04-oq-01-oq-02",
+  "title": "The Galois group of an irreducible polynomial is a transitive subgroup of S_n",
+  "slug": "abel-ruffini-oq-04-oq-01-oq-02",
+  "description": "Open question oq-02 of the concrete-quintic entry (Gal(x^5-4x+2) ≅ S_5) asks to generalize from that single computation to transitive subgroups of S_n via Galois theory. The parent computes one Galois group by hand, and the sibling oq-04 proves the abstract lemma 'a transitive subgroup of S_p containing a transposition is S_p' but takes transitivity as a hypothesis. Neither records the Galois-theoretic fact that supplies that hypothesis: the Galois group of an irreducible polynomial really is a transitive subgroup of the symmetric group on its roots. This entry fills that gap over an arbitrary base field and arbitrary degree. It proves (1) galActionHom_range_isPretransitive — for irreducible p splitting in E, the image (galActionHom p E).range ≤ Equiv.Perm (rootSet p E) acts transitively on the roots, the precise sense in which Gal p is a transitive subgroup of S_n; (2) galMulEquivRange — Gal p ≃* (galActionHom p E).range, realising Gal p literally as that permutation group; and (3) natDegree_dvd_card — p.natDegree ∣ Nat.card p.Gal for every irreducible p in characteristic 0, generalizing Mathlib's prime_degree_dvd_card (which assumes prime degree) and recovering the parent's '5 | |Gal|' step for arbitrary n.",
+  "meta": {
+    "author": "Galois / classical; Lean formalization original (researcher-4)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ01OQ02.lean",
+    "tags": [
+      "group-theory",
+      "symmetric-group",
+      "permutation-group",
+      "transitive-action",
+      "galois-theory",
+      "galois-group",
+      "irreducible-polynomial",
+      "orbit-stabilizer",
+      "abel-ruffini",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. Machine-checked with 0 axioms and 0 sorries (foundational propext/Classical.choice/Quot.sound only). Builds on Mathlib's galAction_isPretransitive (irreducible ⟹ Gal acts transitively on the roots), galActionHom_injective, MonoidHom.ofInjective, card_of_separable, and the minpoly/finrank machinery behind prime_degree_dvd_card. natDegree_dvd_card additionally assumes the base field has characteristic zero (so that an irreducible polynomial is separable).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Gal.galAction_isPretransitive",
+        "description": "For irreducible p splitting in E, p.Gal acts transitively on the root set",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      },
+      {
+        "theorem": "Polynomial.Gal.galActionHom_injective",
+        "description": "The permutation representation Gal p → Perm (rootSet p E) is injective",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      },
+      {
+        "theorem": "MonoidHom.ofInjective",
+        "description": "An injective group hom is a group isomorphism onto its range",
+        "module": "Mathlib.Algebra.Group.Subgroup.Ker"
+      },
+      {
+        "theorem": "Polynomial.Gal.card_of_separable",
+        "description": "For separable p, Nat.card p.Gal = finrank F p.SplittingField",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      },
+      {
+        "theorem": "Polynomial.Gal.prime_degree_dvd_card",
+        "description": "The prime-degree special case generalized here to arbitrary degree",
+        "module": "Mathlib.FieldTheory.PolynomialGaloisGroup"
+      }
+    ],
+    "originalContributions": [
+      "galActionHom_range_isPretransitive: irreducible p (splitting in E) ⟹ (galActionHom p E).range is a transitive subgroup of Equiv.Perm (rootSet p E) — the Galois-theoretic input that the sibling eq_top_of_isPretransitive_of_mem_isSwap consumes as a hypothesis.",
+      "galMulEquivRange: the group isomorphism Gal p ≃* (galActionHom p E).range realising the Galois group as a transitive permutation group of the roots.",
+      "natDegree_dvd_card: p.natDegree ∣ Nat.card p.Gal for every irreducible p in characteristic 0 — a strict generalization of Mathlib's prime_degree_dvd_card from prime degree to arbitrary degree."
+    ],
+    "lineCount": 107,
+    "theoremCount": 2,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "path": "Proofs/AbelRuffiniOQ04OQ01OQ02.lean",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Galois group of a separable polynomial f over a field F acts faithfully on the finite set of roots of f, hence embeds into the symmetric group S_n where n is the number of roots. A central classical observation — going back to Galois — is that f is irreducible if and only if this action is transitive: the roots of an irreducible polynomial form a single orbit because any two are conjugate over F (they share the same minimal polynomial, namely f up to a unit). This is the foundational reason Galois-group computations for irreducible polynomials always begin 'the group is a transitive subgroup of S_n.' The concrete-quintic entry Gal(x^5-4x+2) ≅ S_5 and its sibling 'transitive + transposition ⟹ S_p' both rely on transitivity, but neither establishes it from irreducibility; Mathlib itself records the divisibility n | |Gal| only for prime degree (prime_degree_dvd_card). This entry isolates the general Galois-theoretic statement — irreducible ⟹ Gal is a transitive subgroup of S_n, with n | |Gal| in every degree.",
+    "problemStatement": "Let p be a polynomial over a field F that splits in an extension E, with root set rootSet p E. The permutation representation galActionHom p E : p.Gal → Equiv.Perm (rootSet p E) realises Gal p as a subgroup (galActionHom p E).range of the symmetric group on the roots. Prove that when p is irreducible this subgroup acts transitively, that Gal p is isomorphic to it, and that — in characteristic zero — p.natDegree divides Nat.card p.Gal for every irreducible p (not only prime-degree p).",
+    "proofStrategy": "Transitivity: Mathlib's galAction_isPretransitive gives that p.Gal acts transitively on rootSet p E for irreducible p. The corestriction galActionHom p E : p.Gal → (galActionHom p E).range is surjective and intertwines the two actions, so transitivity transfers to the range subgroup directly: given roots x, y pick g with g • x = y, then ⟨galActionHom p E g, _⟩ moves x to y because the subgroup acts by the same permutation. Isomorphism: galActionHom is injective (galActionHom_injective), so MonoidHom.ofInjective packages it as Gal p ≃* range. Divisibility: Mathlib's prime_degree_dvd_card used primality only to secure p.degree ≠ 0; for an irreducible polynomial that is automatic (Irreducible.natDegree_pos), and the remaining minpoly/finrank tower argument (minpoly F α divides p, adjoin.finrank, finrank_mul_finrank) goes through unchanged, giving p.natDegree ∣ Nat.card p.Gal in any degree.",
+    "keyInsights": [
+      "Irreducibility is exactly transitivity of the Galois action: the roots of an irreducible polynomial are mutually conjugate, hence form a single orbit. This is the Galois-theoretic source of the 'transitive subgroup of S_n' hypothesis that the sibling lemma consumes abstractly.",
+      "Transitivity transfers from the abstract group action to the realised permutation subgroup with no extra work, because the corestriction onto the range is a surjective equivariant map — the subgroup acts by the very same permutations.",
+      "Mathlib's prime_degree_dvd_card is not really about prime degree: primality was used solely to know the degree is nonzero. Replacing that with Irreducible.natDegree_pos yields the divisibility n | |Gal| for all n, recovering the parent's '5 | |Gal|' as the prime instance.",
+      "The orbit–stabilizer divisibility n | |Gal| is the quantitative shadow of transitivity: a transitive action of Gal on the n roots forces n to divide |Gal|, which is precisely how one knows a degree-n irreducible polynomial has Galois group of order a multiple of n."
+    ],
+    "prerequisites": [
+      "Galois theory of polynomials: splitting fields, p.Gal, the action on roots",
+      "Group actions: orbits, stabilizers, transitivity (MulAction.IsPretransitive), orbit–stabilizer",
+      "Permutation representations and embedding a group into a symmetric group",
+      "Separability in characteristic zero and the degree of the minimal polynomial"
+    ]
+  },
+  "sections": [
+    {
+      "id": "transitive-subgroup",
+      "title": "Gal as a Transitive Subgroup of S_n",
+      "startLine": 55,
+      "endLine": 69,
+      "summary": "galActionHom_range_isPretransitive: for irreducible p splitting in E, (galActionHom p E).range acts transitively on rootSet p E. Transitivity of the p.Gal-action (galAction_isPretransitive) transfers to the realised permutation subgroup."
+    },
+    {
+      "id": "iso-onto-range",
+      "title": "Realising Gal as the Permutation Group",
+      "startLine": 71,
+      "endLine": 75,
+      "summary": "galMulEquivRange: Gal p ≃* (galActionHom p E).range, via MonoidHom.ofInjective applied to galActionHom_injective."
+    },
+    {
+      "id": "degree-divides-order",
+      "title": "Degree Divides |Gal| in Any Degree",
+      "startLine": 85,
+      "endLine": 105,
+      "summary": "natDegree_dvd_card: p.natDegree ∣ Nat.card p.Gal for irreducible p over a characteristic-zero field, generalizing prime_degree_dvd_card; primality is replaced by Irreducible.natDegree_pos."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an irreducible polynomial p that splits in E, the Galois group Gal p embeds via galActionHom as a transitive subgroup of Equiv.Perm (rootSet p E) (galActionHom_range_isPretransitive), is isomorphic to that subgroup (galMulEquivRange), and — in characteristic zero — has order divisible by p.natDegree for every degree, not only prime degree (natDegree_dvd_card).",
+    "significance": "Supplies the Galois-theoretic foundation under the concrete-quintic chain: it is the reason a Galois-group computation may begin 'the group is a transitive subgroup of S_n', exactly the transitivity hypothesis the sibling 'transitive + transposition ⟹ S_p' lemma takes for granted, and it generalizes Mathlib's prime-degree divisibility to all degrees.",
+    "implications": [
+      "Provides the transitivity hypothesis for eq_top_of_isPretransitive_of_mem_isSwap from the irreducibility of the polynomial, closing the gap between the concrete quintic and the abstract group-theory lemma.",
+      "Generalizes prime_degree_dvd_card so that n | |Gal| is available for irreducible polynomials of any degree."
+    ],
+    "openQuestions": [
+      "Combine with the sibling lemma to conclude: an irreducible separable polynomial of prime degree whose Galois group contains a transposition has Galois group the full symmetric group, for arbitrary prime degree.",
+      "State and prove the converse: transitivity of the Galois action implies irreducibility, giving the full equivalence irreducible ⟺ transitive Galois action."
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "child-of",
+      "description": "Supplies the transitive-subgroup foundation generalizing the concrete-quintic entry Gal(x^5-4x+2) ≅ S_5",
+      "targetId": "abel-ruffini-oq-04-oq-01"
+    },
+    {
+      "relationship": "related-to",
+      "description": "Provides the transitivity hypothesis consumed by the sibling 'transitive subgroup of S_p with a transposition is S_p' lemma",
+      "targetId": "abel-ruffini-oq-04-oq-01-oq-04"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open question **oq-02** of the concrete-quintic Abel–Ruffini entry (`Gal(x⁵−4x+2) ≅ S₅`) asks to generalize from that single hand computation to **transitive subgroups of Sₙ via Galois theory**. The parent entry computes one Galois group by hand; the sibling `oq-04` proves the abstract lemma *"a transitive subgroup of Sₚ containing a transposition is Sₚ"* but takes transitivity as a **hypothesis**. Neither records the Galois-theoretic fact that supplies that hypothesis. This entry fills the gap, over an **arbitrary base field and arbitrary degree**:

1. **`galActionHom_range_isPretransitive`** — for irreducible `p` splitting in `E`, the realised permutation subgroup `(galActionHom p E).range ≤ Equiv.Perm (rootSet p E)` acts transitively on the roots. This is the precise sense in which `Gal p` *is a transitive subgroup of Sₙ* (`n = #roots`).
2. **`galMulEquivRange`** — `Gal p ≃* (galActionHom p E).range`, realising `Gal p` literally as that permutation group (packaging `galActionHom_injective` via `MonoidHom.ofInjective`).
3. **`natDegree_dvd_card`** — `p.natDegree ∣ Nat.card p.Gal` for **every** irreducible `p` in characteristic 0. This generalizes Mathlib's `Polynomial.Gal.prime_degree_dvd_card` (which assumes prime degree) and recovers the parent's "5 ∣ |Gal|" step for arbitrary `n`.

Together: passing from the concrete quintic to general `n` is not ad hoc — every irreducible polynomial hands you a transitive subgroup of Sₙ, with `n ∣ |Gal|` automatically.

## Verification

- **Build:** `Built Proofs.AbelRuffiniOQ04OQ01OQ02 (7743 jobs, exit 0)` via the Docker wrapper.
- **0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `status: verified`, `badge: original`, `axiomCount: 0` (foundational `propext`/`Classical.choice`/`Quot.sound` only).
- `natDegree_dvd_card` additionally assumes `CharZero F` (so an irreducible polynomial is separable) — disclosed in `assumptions`.

## Files

- `proofs/Proofs/AbelRuffiniOQ04OQ01OQ02.lean` (107 lines)
- `src/data/proofs/abel-ruffini-oq-04-oq-01-oq-02/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)