### PR TITLE
audit: confirm triangle-angle-sum-oq-07 clean (degenerate/collinear angle sum)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24853,6 +24853,12 @@
       "issues": [],
       "lastAudited": "2026-06-27T02:14:00Z",
       "result": "clean"
+    },
+    "triangle-angle-sum-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T03:33:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Audited the sole unaudited gallery entry **triangle-angle-sum-oq-07** (degenerate triangle angle sums under Mathlib's unoriented angle).

### Verification (meta.json vs Lean source)
| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| lineCount | 75 | 75 | ✓ |
| sorries | 0 | 0 (the one `sorry` hit is docstring prose "no `sorry`") | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier / badge
`badge=original` / `status=verified` is **Tier-A defensible**: the result genuinely composes basic Mathlib unoriented-angle lemmas (`angle_comm`, `angle_eq_zero_of_angle_eq_pi_left`, `Sbtw.angle₁₂₃_eq_pi`, `angle_self_left`) to settle the degenerate cases that Mathlib's `angle_add_angle_add_angle_eq_pi` *explicitly excludes* — it is **not** a single-theorem wrapper. Description credits the parent's Mathlib theorem and scopes this entry to degenerate cases; the `assumptions` field honestly discloses the Mathlib lemmas used and the foundational-only axiom footprint (propext/Choice/Quot.sound, no native_decide). **Risk: LOW.**

Queue now **4005/4005 audited, 0 issues**.

---
Discovered during gallery integrity audit.