### PR TITLE
Enrich triangle-angle-sum-oq-07: add missing index.ts, deepen annotations

### DIFF
--- a/src/data/proofs/triangle-angle-sum-oq-07/annotations.json
+++ b/src/data/proofs/triangle-angle-sum-oq-07/annotations.json
@@ -1,24 +1,62 @@
 [
   {
-    "id": "ann-collinear-strictly-between",
+    "id": "ann-header-open-question",
     "proofId": "triangle-angle-sum-oq-07",
-    "range": {
-      "startLine": 46,
-      "endLine": 65
-    },
+    "range": { "startLine": 4, "endLine": 37 },
+    "type": "context",
+    "title": "The Degenerate-Cases Open Question",
+    "content": "The docstring frames the problem. The parent entry triangle-angle-sum verifies ∠ABC + ∠BCA + ∠CAB = π only for a genuine triangle: Mathlib's angle_add_angle_add_angle_eq_pi requires two vertices distinct from the third, so it says nothing when the points become collinear. This file answers the parent's open question about that gap, fully verified. The summary it announces: for the unoriented angle ∠ (valued in [0, π]), a strictly-between collinear configuration (Sbtw ℝ A B C) still sums to π — the identity extends continuously through the flattening — whereas three coincident vertices sum to 3π/2 under Mathlib's ∠AAA = π/2 convention. So the angle sum survives one kind of degeneration and breaks at the other.",
+    "mathContext": "Non-degenerate: $\\angle ABC+\\angle BCA+\\angle CAB=\\pi$. Strictly-between collinear: still $\\pi$. Coincident: $\\tfrac{3\\pi}{2}$. The unoriented angle $\\angle$ takes values in $[0,\\pi]$.",
+    "significance": "context",
+    "relatedConcepts": ["Euclid Elements I.32", "unoriented angle", "degenerate triangle", "continuity under limits"],
+    "prerequisites": ["Euclidean angle sum theorem", "collinearity and betweenness", "Mathlib EuclideanGeometry.angle conventions"]
+  },
+  {
+    "id": "ann-ambient-setup",
+    "proofId": "triangle-angle-sum-oq-07",
+    "range": { "startLine": 39, "endLine": 44 },
+    "type": "definition",
+    "title": "Ambient Euclidean Setup",
+    "content": "The results are stated over an abstract real inner-product geometry, not a fixed coordinate space: points live in a NormedAddTorsor P over an inner-product space V (the standard Mathlib formulation of a Euclidean affine space). open scoped EuclideanGeometry brings the ∠ notation for the unoriented angle into scope. Working at this generality means the degenerate angle-sum facts hold in every Euclidean space at once (any dimension), rather than just ℝ² — the proofs use only the abstract angle API, never coordinates.",
+    "mathContext": "$V$ a real inner-product space, $P$ a torsor over $V$ (an affine Euclidean space); $\\angle$ denotes EuclideanGeometry.angle $: P \\to P \\to P \\to [0,\\pi]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["inner product space", "NormedAddTorsor", "affine space", "dimension-independence"],
+    "prerequisites": ["torsors / affine spaces", "InnerProductSpace typeclass"]
+  },
+  {
+    "id": "ann-abstract-form",
+    "proofId": "triangle-angle-sum-oq-07",
+    "range": { "startLine": 46, "endLine": 57 },
     "type": "theorem",
-    "title": "Strictly-Between Collinear Degeneration (angle sum = π)",
-    "content": "angle_sum_of_angle_eq_pi proves ∠ABC + ∠BCA + ∠CAB = π from the bare hypothesis ∠ABC = π. Mathlib's angle_comm turns ∠ABC = π into ∠CBA = π, and angle_eq_zero_of_angle_eq_pi_left collapses each straight angle into a vanishing end angle: ∠BCA = 0 directly, and ∠CAB = 0 after one more angle_comm. Substituting gives π + 0 + 0 = π. Sbtw.angle_sum_eq_pi restates this for the geometric hypothesis Sbtw ℝ A B C (B strictly between A and C): Sbtw.angle₁₂₃_eq_pi supplies ∠ABC = π and the abstract form finishes. This is exactly the limit of a non-degenerate triangle flattening with one vertex onto the opposite edge — the middle angle tends to the straight angle π while both end angles tend to 0, so the classical identity ∠ABC + ∠BCA + ∠CAB = π persists through the degeneration. Mathlib's non-degenerate theorem angle_add_angle_add_angle_eq_pi excludes this configuration (it requires two vertices distinct from the third); these theorems cover it."
+    "title": "Abstract Straight-Angle Form (sum = π)",
+    "content": "angle_sum_of_angle_eq_pi derives ∠ABC + ∠BCA + ∠CAB = π from the bare hypothesis ∠ABC = π. The mechanism: a straight middle angle forces the two end angles to vanish. angle_comm rewrites ∠ABC = π as ∠CBA = π, and angle_eq_zero_of_angle_eq_pi_left (if the angle at the middle vertex is π then the angle at an end vertex is 0) gives ∠BCA = 0 and, after another angle_comm, ∠CAB = 0. Substituting yields π + 0 + 0 = π (closed by ring). Stating it from ∠ABC = π rather than from betweenness keeps the lemma purely about the angle algebra, so the geometric version below is a one-line corollary.",
+    "mathContext": "$\\angle ABC=\\pi \\implies \\angle BCA=0 \\wedge \\angle CAB=0 \\implies \\angle ABC+\\angle BCA+\\angle CAB=\\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["straight angle", "angle_comm", "angle_eq_zero_of_angle_eq_pi_left", "vanishing end angles"],
+    "prerequisites": ["unoriented angle symmetry", "ring tactic"]
+  },
+  {
+    "id": "ann-betweenness-form",
+    "proofId": "triangle-angle-sum-oq-07",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "theorem",
+    "title": "Geometric Betweenness Form (sum = π)",
+    "content": "Sbtw.angle_sum_eq_pi restates the result for the genuinely geometric hypothesis Sbtw ℝ A B C — B lies strictly between A and C, i.e. a flattened triangle with B the middle vertex. Sbtw.angle₁₂₃_eq_pi converts strict betweenness into ∠ABC = π, and the abstract form finishes. Because Mathlib's angle_eq_pi_iff_sbtw makes ∠ABC = π and Sbtw ℝ A B C equivalent, this corollary and the abstract lemma are two faces of the same fact; this one is the statement a reader thinking geometrically would want.",
+    "mathContext": "$\\mathrm{Sbtw}\\,\\mathbb{R}\\,A\\,B\\,C \\iff \\angle ABC=\\pi$ (angle_eq_pi_iff_sbtw); hence the angle sum is $\\pi$ for $B$ strictly between $A$ and $C$.",
+    "significance": "key",
+    "relatedConcepts": ["strict betweenness Sbtw", "angle_eq_pi_iff_sbtw", "collinearity", "flattened triangle"],
+    "prerequisites": ["Sbtw.angle₁₂₃_eq_pi", "betweenness ↔ straight angle"]
   },
   {
     "id": "ann-coincident",
     "proofId": "triangle-angle-sum-oq-07",
-    "range": {
-      "startLine": 67,
-      "endLine": 74
-    },
+    "range": { "startLine": 67, "endLine": 74 },
     "type": "theorem",
-    "title": "Fully Coincident Degeneration (angle sum = 3π/2)",
-    "content": "angle_sum_self computes the interior angle sum when all three vertices coincide. Mathlib's convention angle_self_left : ∠ p₀ p₀ p = π/2 makes ∠AAA = π/2, so the sum is 3·(π/2) = 3π/2 ≠ π (closed by ring). This shows the degenerate angle sum is NOT universally π: the value π is special to the strictly-between collinear case. Note the proof works with Real.pi explicitly rather than the π notation, since the π notation is not in scope in this file (matching the parent TriangleAngleSum.lean convention) — using a bare π would auto-bind it as a free variable distinct from Real.pi."
+    "title": "Fully Coincident Degeneration (sum = 3π/2)",
+    "content": "angle_sum_self computes the interior angle sum when all three vertices coincide. Mathlib's convention angle_self_left : ∠ p₀ p₀ p = π/2 makes ∠AAA = π/2, so the sum is 3·(π/2) = 3π/2 ≠ π (closed by ring). This shows the degenerate angle sum is NOT universally π: the value π is special to the strictly-between collinear case. Note the proof works with Real.pi explicitly rather than the π notation, since the π notation is not in scope in this file (matching the parent TriangleAngleSum.lean convention) — a bare π would auto-bind as a free variable distinct from Real.pi.",
+    "mathContext": "$\\angle AAA=\\tfrac{\\pi}{2}$ (angle_self_left convention) $\\implies \\angle AAA+\\angle AAA+\\angle AAA=\\tfrac{3\\pi}{2}\\neq\\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["angle_self_left convention", "coincident vertices", "non-universality of π", "degenerate conventions"],
+    "prerequisites": ["Mathlib angle-of-repeated-point convention", "ring tactic"]
   }
 ]

--- a/src/data/proofs/triangle-angle-sum-oq-07/index.ts
+++ b/src/data/proofs/triangle-angle-sum-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TriangleAngleSumOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const triangleAngleSumOQ07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const triangleAngleSumOQ07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const triangleAngleSumOQ07Data: ProofData = {
+  proof: triangleAngleSumOQ07Proof,
+  annotations: triangleAngleSumOQ07Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `triangle-angle-sum-oq-07` (degenerate/collinear triangle angle sums).

**Critical fix:** `index.ts` was missing — without it the proof page renders 'proof not found' on the live site despite appearing in the gallery listing. Created following the sibling convention (`triangleAngleSumOQ07*` exports, `TriangleAngleSumOQ07.lean?raw` source).

**Annotation depth:** expanded 2 → 5 annotations, each now carrying `significance`, `relatedConcepts`, and `prerequisites` (previously none had them). Added a header annotation (open-question framing) and an ambient-setup annotation (the abstract NormedAddTorsor / InnerProductSpace context, explaining dimension-independence), and split the strictly-between theorem into its abstract straight-angle form and its geometric betweenness corollary.

meta.json already met depth targets (9.2 KB, well under cap) — left as-is. `pnpm build` passes; JSON validates.