### PR TITLE
audit: confirm cauchy-interlacing-oq-01-oq-02-oq-02-oq-01 clean (Schur–Horn forward)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24859,6 +24859,12 @@
       "lastAudited": "2026-06-27T03:33:30Z",
       "result": "clean",
       "issues": []
+    },
+    "cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T03:41:26Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: cauchy-interlacing-theorem-oq-01-oq-02-oq-02-oq-01
**Title**: Schur's Majorization Theorem (Forward Direction of Schur–Horn), Karamata Form
**Source**: \`proofs/Proofs/SchurHornMajorization.lean\`
**Result**: clean — no integrity issues

## Checks Performed

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✅ |
| axiom decls | 0 | 0 | ✅ |
| native_decide | none claimed | none (kernel `decide` only) | ✅ |
| True stubs | — | 0 | ✅ |
| theoremCount | 7 | 7 | ✅ |
| definitionCount | 1 | 1 | ✅ |
| lineCount | 178 | 178 | ✅ |
| assumption-carrying structures | — | none | ✅ |

## Tier / Narrative Assessment

**Tier A (fully formalized theorem)** — `status: verified`, `badge: verified` is **defensible**:

- The core result (forward Schur–Horn / `diag(T) ≺ spec(T)` in Karamata convex-function form) is **not** in Mathlib — the entry and file explicitly note Mathlib has no majorization predicate and no Schur–Horn theorem. No single Mathlib theorem does the core work.
- The proof is genuinely assembled: builds the doubly-stochastic matrix `D i j = ‖⟪v j, e i⟫‖²`, proves double stochasticity from Parseval, identifies the diagonal as the doubly-stochastic image of the spectrum (`diag_decomp`), and applies Jensen row-by-row with a column-sum swap.
- **Delegation transparency is honest**: first paragraphs credit Mathlib's spectral theorem, Parseval, and Jensen, and explicitly state it does **not** use Birkhoff.
- Title is properly qualified ("Forward Direction"); the converse (Horn 1954) is correctly listed under `openQuestions`, not claimed.
- The only side condition (`Even 2`) is discharged by kernel-checked `decide` (not `native_decide`), so no `Lean.ofReduceBool` — `verified` with foundational axioms only is legitimate.

No language-precision or claim-risk issues found. Updates audit-tracker.json only.

---
Discovered during gallery integrity audit. Queue: 1 unaudited remaining after this.