### PR TITLE
Enrich Large Cardinals & Arithmetic Independence (godel-incompleteness-oq-04): add annotations

### DIFF
--- a/src/data/proofs/godel-incompleteness-oq-04/annotations.json
+++ b/src/data/proofs/godel-incompleteness-oq-04/annotations.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "godel-oq04-context",
+    "proofId": "godel-incompleteness-oq-04",
+    "range": { "startLine": 1, "endLine": 75 },
+    "type": "context",
+    "title": "Large cardinals as the engine of arithmetic independence",
+    "content": "The docstring frames the whole file. Gödel's second incompleteness theorem (1931) says no consistent effective theory extending arithmetic proves its own consistency. Zermelo (1930) showed that if κ is strongly inaccessible then the rank-initial segment V_κ models ZFC; hence 'an inaccessible exists' proves Con(ZFC) and is, by Gödel 2, independent of ZFC. The file deliberately formalizes only the *cardinal-arithmetic core* of 'V_κ ⊨ ZFC' — closure of the sub-κ cardinal universe under the ZFC set-builders — and an explicit honesty note (lines 59–66) delimits what it does NOT do: it does not arithmetize provability, build a satisfaction predicate, or prove the unprovability statement itself.",
+    "mathContext": "At the level of cardinals, the ZFC set-builders become closure conditions on $\\{\\lambda : \\lambda < \\kappa\\}$: powerset $\\mapsto (a<\\kappa \\Rightarrow 2^a<\\kappa)$ (strong limit), and replacement/union $\\mapsto$ ($\\sup$ of ${<}\\kappa$-many ${<}\\kappa$ cardinals stays ${<}\\kappa$) (regular). Strong-limit $\\wedge$ regular $\\wedge$ uncountable $=$ strongly inaccessible.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gödel's second incompleteness theorem",
+      "Zermelo's theorem (V_κ ⊨ ZFC)",
+      "consistency strength",
+      "strongly inaccessible cardinal",
+      "Con(ZFC)"
+    ],
+    "prerequisites": [
+      "ZFC axioms and the cumulative hierarchy V_α",
+      "cardinal arithmetic",
+      "the notion of independence / relative consistency"
+    ]
+  },
+  {
+    "id": "godel-oq04-free-closures",
+    "proofId": "godel-incompleteness-oq-04",
+    "range": { "startLine": 94, "endLine": 103 },
+    "type": "insight",
+    "title": "Addition and multiplication closure carry no large-cardinal strength",
+    "content": "`inaccessible_add_lt` and `inaccessible_mul_lt` record that a,b<κ ⟹ a+b<κ and a·b<κ. Crucially these hold for ANY infinite cardinal (via add_lt_of_lt / mul_lt_of_lt, needing only ℵ₀ ≤ κ), so they are NOT what makes V_κ model ZFC. The file states them explicitly precisely to isolate the genuine content: of the four arithmetic closures, only powerset (strong-limit) and replacement (regularity) are load-bearing.",
+    "mathContext": "For an infinite cardinal $\\kappa$ and $a,b<\\kappa$, $a+b = a\\cdot b = \\max(a,b) < \\kappa$. Hadamard/Hessenberg cardinal arithmetic makes $+$ and $\\cdot$ degenerate above $\\aleph_0$, so closure under them is automatic and large-cardinal-free.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cardinal.add_lt_of_lt",
+      "Cardinal.mul_lt_of_lt",
+      "absorption a+b = a·b = max(a,b) for infinite cardinals",
+      "isolating load-bearing hypotheses"
+    ],
+    "prerequisites": [
+      "infinite cardinal arithmetic (absorption laws)"
+    ]
+  },
+  {
+    "id": "godel-oq04-powerset",
+    "proofId": "godel-incompleteness-oq-04",
+    "range": { "startLine": 105, "endLine": 119 },
+    "type": "theorem",
+    "title": "Powerset closure: a^b < κ from the strong-limit property",
+    "content": "`inaccessible_two_power_lt` is the strong-limit field of inaccessibility: a<κ ⟹ 2^a<κ — the cardinal shadow of 'V_κ is closed under powersets'. `inaccessible_power_lt` then lifts this to full exponentiation closure a^b<κ for a,b<κ, with no new hypothesis beyond strong-limit and the (automatic) multiplicative closure: the calc bounds a^b ≤ (2^a)^b (Cantor a < 2^a) = 2^(a·b) (power_mul), and a·b<κ gives 2^(a·b)<κ by strong-limit again.",
+    "mathContext": "A strong limit cardinal satisfies $a<\\kappa \\Rightarrow 2^a<\\kappa$. The exponentiation bound chains Cantor's $a<2^a$ with $(2^a)^b = 2^{a\\cdot b}$: $a^b \\le (2^a)^b = 2^{a\\cdot b} < \\kappa$, using $a\\cdot b<\\kappa$. This is the cardinal form of V_κ being closed under function spaces $B^A$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cardinal.IsStrongLimit.two_power_lt",
+      "Cantor's theorem (a < 2^a)",
+      "Cardinal.power_mul",
+      "powerset axiom in V_κ",
+      "function-space closure"
+    ],
+    "prerequisites": [
+      "strong limit cardinals",
+      "cardinal exponentiation laws (a^(b·c) = (a^b)^c)",
+      "Cantor's theorem"
+    ]
+  },
+  {
+    "id": "godel-oq04-replacement",
+    "proofId": "godel-incompleteness-oq-04",
+    "range": { "startLine": 121, "endLine": 136 },
+    "type": "theorem",
+    "title": "Replacement/union closure: the genuinely regularity-dependent fact",
+    "content": "`inaccessible_iSup_lt` is the load-bearing large-cardinal property: the supremum of a family f : ι → Cardinal with #ι < κ and every f i < κ is again < κ. It is the arithmetic form of ZFC's replacement (and union) axiom holding in V_κ, and it genuinely requires κ to be REGULAR — the proof feeds #ι < κ = cof(κ) into Ordinal.iSup_lt. `inaccessible_zermelo_closure` then bundles powerset + replacement as the single statement that is the arithmetic kernel of Zermelo's V_κ ⊨ ZFC.",
+    "mathContext": "Regularity $\\mathrm{cof}(\\kappa)=\\kappa$ means no ${<}\\kappa$-indexed family of ordinals ${<}\\kappa$ is cofinal in $\\kappa$; hence $\\#\\iota<\\kappa$ and $f_i<\\kappa$ for all $i$ force $\\sup_i f_i<\\kappa$. This is exactly replacement in V_κ: the image of a set in V_κ under a definable function is bounded, so it lands back in V_κ.",
+    "significance": "key",
+    "relatedConcepts": [
+      "regular cardinal (cof κ = κ)",
+      "Ordinal.iSup_lt",
+      "cofinality",
+      "replacement axiom in V_κ",
+      "Cardinal.IsRegular"
+    ],
+    "prerequisites": [
+      "cofinality and regular cardinals",
+      "suprema of families of cardinals",
+      "the replacement axiom schema"
+    ]
+  },
+  {
+    "id": "godel-oq04-structural",
+    "proofId": "godel-incompleteness-oq-04",
+    "range": { "startLine": 138, "endLine": 152 },
+    "type": "insight",
+    "title": "The closure data characterizes inaccessibility",
+    "content": "Part II records the structural identity. `inaccessible_isSuccLimit`: an inaccessible is a limit cardinal (never a successor). `inaccessible_cof_eq`: it is regular (cof κ = κ). `inaccessible_iff`: uncountable ∧ regular ∧ strong-limit ⟺ inaccessible. The point is that the very closures used in Part I are not an add-on to inaccessibility but its definition — so the consistency strength of an inaccessible is generated by exactly the powerset+replacement closures that make V_κ a model of ZFC.",
+    "mathContext": "Strong inaccessibility $\\iff \\aleph_0<\\kappa \\wedge \\mathrm{cof}(\\kappa)=\\kappa \\wedge (\\forall a<\\kappa,\\ 2^a<\\kappa)$. A strong limit is in particular a limit cardinal ($\\kappa = \\beth_\\lambda$ for a limit $\\lambda$), so it is `Order.IsSuccLimit`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cardinal.isInaccessible_def",
+      "limit cardinal vs successor cardinal",
+      "Order.IsSuccLimit",
+      "regular + strong limit = inaccessible"
+    ],
+    "prerequisites": [
+      "successor vs limit cardinals",
+      "the definition of strong inaccessibility"
+    ]
+  },
+  {
+    "id": "godel-oq04-universe-shadow",
+    "proofId": "godel-incompleteness-oq-04",
+    "range": { "startLine": 154, "endLine": 174 },
+    "type": "insight",
+    "title": "Non-vacuity: a real inaccessible one universe up",
+    "content": "Part III prevents the closure theorems from being vacuous. `univ_inaccessible` proves that Cardinal.univ.{u,v} — the cardinality of Type u, read inside Type (u+1) — is genuinely strongly inaccessible (Mathlib's IsInaccessible.univ). `univ_powerset_closed` and `univ_iSup_closed` instantiate the Part-I closures there. This universe-polymorphic witness mirrors the independence phenomenon itself: ZFC lives in a single universe and cannot exhibit an inaccessible internally, but Lean's universe hierarchy supplies one 'from outside' — exactly how the consistency of an inaccessible is available from a stronger metatheory yet unprovable inside ZFC.",
+    "mathContext": "$\\mathrm{univ}.\\{u,v\\} = \\#(\\mathrm{Type}\\,u)$ measured in $\\mathrm{Type}\\,(u{+}1)$ behaves as an inaccessible relative to the smaller universe: it is regular and strong-limit there. The Grothendieck-universe / inaccessible correspondence is precisely 'a universe is a $V_\\kappa$ for inaccessible $\\kappa$'.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cardinal.IsInaccessible.univ",
+      "universe polymorphism",
+      "Grothendieck universes",
+      "non-vacuity of hypotheses",
+      "independence 'from outside' the universe"
+    ],
+    "prerequisites": [
+      "Lean universe hierarchy and Cardinal.univ",
+      "Grothendieck universes ↔ inaccessible cardinals"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `godel-incompleteness-oq-04` (quality 43, pass 0).

## Changes
This entry had a rich meta.json (overview, sections, mainTheorems, conclusion) but **no annotations.json at all**. Created `annotations.json` with 6 annotations, each carrying `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
1. **Context** — Gödel 2 → Zermelo's V_κ ⊨ ZFC → inaccessible independence, plus the file's honesty note
2. **Free closures** — why +,· closure carries no large-cardinal strength (holds for any infinite cardinal)
3. **Powerset closure** — a^b<κ from strong-limit, via a^b ≤ (2^a)^b = 2^(a·b)
4. **Replacement closure** — iSup f<κ, the genuinely regularity-dependent fact (cof κ = κ)
5. **Structural identity** — the closures characterize inaccessibility (inaccessible_iff)
6. **Universe shadow** — univ.{u,v} as a real inaccessible one universe up (non-vacuity)

## Verification
- `pnpm build` passes (exit 0); annotations:build emitted meta+annotations for all entries
- 6 annotations, all with mathContext/significance/relatedConcepts/prerequisites
- No meta.json changes; `verified`/`verified` badge/axiomCount:0 untouched (matches Lean: 0 sorries, 0 axioms, 13 theorems)