### PR TITLE
Enrich lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01: add index.ts, overview, sections

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOQ02OQ02OQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOQ02OQ02OQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeTheoremOQ02OQ02OQ01OQ01OQ01Data: ProofData = {
+  proof: lagrangeTheoremOQ02OQ02OQ01OQ01OQ01Proof,
+  annotations: lagrangeTheoremOQ02OQ02OQ01OQ01OQ01Annotations,
+}

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
   "slug": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+  "description": "Generalises the orbit-stabilizer theorem — which Mathlib provides only for Fintype — to the instance-free Nat.card form: Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G for any group action, with no Finite or Fintype hypothesis at all. The proof transports Mathlib's finiteness-free bijection orbitProdStabilizerEquivGroup through Nat.card; because Nat.card is total (0 on infinite types) and Nat.card_prod / Nat.card_congr are unconditional, no finiteness instance is ever needed — strictly more general than the parent's Finite Burnside lemma. A companion records the index form Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x) (the orbit-counting half of Lagrange's theorem), and the original Fintype statement is recovered as a corollary. 0 sorries, 0 axioms.",
   "leanFile": {
     "imports": [
       "Mathlib.GroupTheory.GroupAction.Quotient",
@@ -67,6 +68,56 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The orbit-stabilizer theorem and Lagrange's theorem are cornerstones of finite group theory, classically stated for finite groups where cardinalities are honest natural numbers. In a formal library the choice of cardinality functor matters: Mathlib originally phrased orbit-stabilizer with Fintype.card, which forces a decidable finiteness instance to even state the result. The modern Mathlib idiom prefers Nat.card — a total function defined for every type (returning 0 on infinite types) — which lets cardinality identities be stated unconditionally and specialised to the finite case on demand. This entry is part of a family (rooted at lagrange-theorem) systematically migrating the orbit-counting cluster from Fintype to Nat.card by exploiting that the mathematical content of each identity is a finiteness-free bijection.",
+    "problemStatement": "State and prove the orbit-stabilizer theorem over Nat.card, with no Fintype or Finite hypothesis: for a group G acting on X and x : X, show Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G; record the index form Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x); and confirm the generalisation subsumes Mathlib's Fintype statement.",
+    "proofStrategy": "Each identity is the image of a Mathlib bijection under Nat.card. For the product: rewrite Nat.card (orbit) · Nat.card (stabilizer) backwards through Nat.card_prod into Nat.card (orbit × stabilizer), then apply Nat.card_congr to Mathlib's finiteness-free equivalence orbitProdStabilizerEquivGroup : orbit G x × stabilizer G x ≃ G, landing on Nat.card G — two rewrites, no case split on finiteness. For the index form: a single Nat.card_congr applied to orbitEquivQuotientStabilizer : orbit G x ≃ G ⧸ stabilizer G x. For the recovery: supply constructive Fintype instances and rewrite all three occurrences with Nat.card_eq_fintype_card, turning the Nat.card identity into Mathlib's verbatim Fintype.card statement.",
+    "keyInsights": [
+      "Nat.card removes the finiteness hypothesis entirely, not just weakening Fintype to Finite. Because Nat.card is total (0 on infinite types) and its transport lemmas Nat.card_prod / Nat.card_congr hold unconditionally, the orbit-stabilizer identity is proved with no instance assumption at all — strictly stronger than the parent's Finite Burnside lemma, which still needed a Fintype to collapse its finsum.",
+      "The proof is Mathlib's own Fintype argument with Fintype.card mechanically replaced by Nat.card. The substitution is sound precisely because the underlying bijection orbitProdStabilizerEquivGroup is itself finiteness-free and the two card functors share the same transport API (card_prod, card_congr).",
+      "The index form Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x) is the orbit-counting shadow of Lagrange's theorem: orbit size equals stabilizer index, so orbit sizes divide the group order in the finite case.",
+      "Recovering Mathlib's Fintype statement as a corollary certifies the generalisation genuinely subsumes the original rather than merely resembling it — the classical theorem is exactly the finite shadow of the unconditional Nat.card version."
+    ],
+    "prerequisites": [
+      "Group actions: orbit, stabilizer, and the orbit space G ⧸ stabilizer (MulAction)",
+      "Mathlib's finiteness-free bijections orbitProdStabilizerEquivGroup and orbitEquivQuotientStabilizer",
+      "Nat.card and its transport lemmas (Nat.card_congr, Nat.card_prod, Nat.card_eq_fintype_card)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-nat-card-family",
+      "title": "From Fintype to a Nat.card Orbit-Stabilizer",
+      "startLine": 5,
+      "endLine": 55,
+      "summary": "Module docstring: the parent lifted Burnside off Fintype to Finite via a finiteness-free bijection; this file applies the same recipe to orbit-stabilizer and finds it needs no finiteness at all. Replaces every Fintype.card by the total Nat.card, adds the index form, and recovers the Fintype statement as a corollary. Imports GroupAction.Quotient, Cardinal.Finite, and Tactic; opens MulAction.",
+      "mathContext": "Mathlib: $\\mathrm{Fintype.card}\\,(\\mathrm{orbit}\\,G\\,x)\\cdot\\mathrm{Fintype.card}\\,(\\mathrm{stab}\\,G\\,x)=\\mathrm{Fintype.card}\\,G$. Here, over $\\mathrm{Nat.card}$, with no finiteness instance."
+    },
+    {
+      "id": "orbit-stabilizer-product",
+      "title": "Orbit-Stabilizer Product over Nat.card",
+      "startLine": 63,
+      "endLine": 75,
+      "summary": "card_orbit_mul_card_stabilizer_eq_card_group_nat: Nat.card (orbit G x) · Nat.card (stabilizer G x) = Nat.card G, by ← Nat.card_prod then Nat.card_congr (orbitProdStabilizerEquivGroup G x). No nonempty_fintype step; every rewrite is unconditional.",
+      "mathContext": "$\\mathrm{orbit}(x)\\times\\mathrm{Stab}(x)\\cong G \\implies \\mathrm{Nat.card}\\,(\\mathrm{orbit}\\,x)\\cdot\\mathrm{Nat.card}\\,(\\mathrm{Stab}\\,x)=\\mathrm{Nat.card}\\,G$."
+    },
+    {
+      "id": "orbit-index-form",
+      "title": "Orbit Size = Stabilizer Index",
+      "startLine": 77,
+      "endLine": 86,
+      "summary": "card_orbit_eq_card_quotient_stabilizer_nat: a single Nat.card_congr (orbitEquivQuotientStabilizer G x) gives Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x) — the orbit-counting half of Lagrange's theorem.",
+      "mathContext": "$\\mathrm{orbit}(x)\\cong G/\\mathrm{Stab}(x) \\implies \\mathrm{Nat.card}\\,(\\mathrm{orbit}\\,x)=[G:\\mathrm{Stab}(x)]$."
+    },
+    {
+      "id": "fintype-recovery",
+      "title": "Recovering the Fintype Statement",
+      "startLine": 88,
+      "endLine": 101,
+      "summary": "card_orbit_mul_card_stabilizer_eq_card_group_recovered: supplies constructive Fintype instances and derives Mathlib's exact Fintype.card identity from the Nat.card one via simpa [Nat.card_eq_fintype_card], certifying subsumption. Closes with #check lines for all three results.",
+      "mathContext": "$\\mathrm{Nat.card}\\,\\alpha=\\mathrm{Fintype.card}\\,\\alpha$ under a $\\mathrm{Fintype}\\,\\alpha$ instance; rewriting recovers the classical theorem."
+    }
+  ],
   "openQuestions": [
     {
       "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01` (orbit-stabilizer over Nat.card).

**Critical fix:** `index.ts` was missing — the page renders 'proof not found' on the live site without it. Created per sibling convention (`lagrangeTheoremOQ02OQ02OQ01OQ01OQ01*` exports).

**Structural gaps filled (all were absent):**
- top-level `description`
- `overview` block: `historicalContext`, `problemStatement`, `proofStrategy`, 4 `keyInsights`, `prerequisites`
- `sections` array covering the docstring + all three theorems with per-section mathContext

The 4 existing annotations were already strong (full `significance`/`relatedConcepts`/`prerequisites`) and were left untouched. meta.json 13.9 KB (under cap). `pnpm build` passes; JSON validates.