### PR TITLE
audit: confirm godel-incompleteness-oq-04 clean (V_κ ⊨ ZFC closure core)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24865,6 +24865,12 @@
       "lastAudited": "2026-06-27T03:41:26Z",
       "result": "clean",
       "issues": []
+    },
+    "godel-incompleteness-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T03:45:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: godel-incompleteness-oq-04
**Title**: Large Cardinals and Arithmetic Independence: the V_κ ⊨ ZFC closure core
**Source**: `proofs/Proofs/GodelIncompletenessOQ04.lean`
**Result**: clean — no integrity issues. HIGH-risk topic (Gödel / foundational independence), handled responsibly.

## Checks Performed

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✅ |
| axiom decls | 0 | 0 | ✅ |
| native_decide | none | none | ✅ |
| True stubs | — | 0 | ✅ |
| theoremCount | 13 | 13 | ✅ |
| definitionCount | 0 | 0 | ✅ |
| lineCount | 176 | 176 | ✅ |
| assumption-carrying structures | — | none | ✅ |

## Narrative / Risk Assessment

**Famous-theorem handling is exemplary.** Despite the `godel-incompleteness` slug, the entry makes **no** claim to formalize Gödel's incompleteness theorems or the independence of `Con(ZFC)`:

- Title scoped to "the V_κ ⊨ ZFC closure core".
- The file carries an explicit **"What this does NOT do"** section: it does not arithmetize provability, does not build `V_κ ⊨ ZFC` inside Lean, does not prove `Con(ZFC)` is unprovable.
- No axiom-masking, no delegation opacity, no unqualified famous-theorem claim.

**Tier-B-flavored, correctly badged.** Many of the 13 theorems thinly wrap Mathlib's inaccessible-cardinal API (`isStrongLimit.two_power_lt`, `isRegular`, `isInaccessible_def`, `IsInaccessible.univ`, `Ordinal.iSup_lt`). This reliance is **disclosed** in `mathlibDependencies` and the narrative explicitly credits Mathlib ("packaging Mathlib's isInaccessible_def") and flags which lemmas hold for any infinite cardinal. The genuine new content (e.g. `inaccessible_power_lt` via `a^b ≤ (2^a)^b = 2^(a·b)`, the bundled closure statement) is modest but real.

`badge: verified` denotes machine-checked / 0-assumption (accurate); the entry does **not** use `original`, so makes no novelty/independence claim. No forbidden Tier-B phrases ("first formalization", "we proved"). If anything the entry under-claims.

Updates audit-tracker.json only. Queue: 0 unaudited remaining after this — gallery fully audited (4007/4007).

---
Discovered during gallery integrity audit.