### PR TITLE
research(basel-problem-oq-04-oq-03-oq-01): coprime k-tuple density → 1/ζ(k) [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -960,6 +960,7 @@ import Proofs.ContinuumHypothesis
 import Proofs.ContinuumHypothesisOQ01
 import Proofs.ContinuumHypothesisOQ02
 import Proofs.ContinuumHypothesisOQ02OQ01
+import Proofs.CoprimeKTupleDensity
 import Proofs.CramersRule
 import Proofs.CramersRuleOQ01
 import Proofs.CramersRuleOQ01OQ02

--- a/proofs/Proofs/CoprimeKTupleDensity.lean
+++ b/proofs/Proofs/CoprimeKTupleDensity.lean
@@ -1,0 +1,503 @@
+/-
+# Coprime k-Tuple Density = 1/ζ(k)
+
+**Statement**: For every integer `k ≥ 2`, the natural density of coprime
+`k`-tuples of positive integers equals `1/ζ(k)`:
+
+  lim_{N→∞} |{a : Fin k → ℕ | 1 ≤ a i ≤ N, gcd(a₁,…,a_k) = 1}| / Nᵏ = 1/ζ(k)
+
+This generalises the classical Cesàro result for pairs (`k = 2`, density `6/π² = 1/ζ(2)`,
+formalised in `BaselProblemOQ04OQ03`) to arbitrary dimension. The probability that
+`k` random integers share no common factor is `1/ζ(k) = ∏_p (1 − p⁻ᵏ)`.
+
+## Proof Architecture
+
+The proof follows the same three-step skeleton as the `k = 2` case, with the square
+`⌊N/d⌋²` replaced by the `k`-th power `⌊N/d⌋ᵏ`.
+
+### Step 1: Möbius Decomposition
+Using Möbius inversion (`[n=1] = Σ_{d|n} μ(d)`), a finite Fubini exchange gives
+
+  countCoprimeTuples k N = Σ_{d=1}^N μ(d) · ⌊N/d⌋ᵏ.
+
+The `k`-tuple count of `d`-divisible tuples factors as `⌊N/d⌋ᵏ` (a product over the
+`k` coordinates, `Fintype.card_piFinset_const`).
+
+### Step 2: The Möbius Dirichlet Series (key identity)
+For integer `k ≥ 2`,
+
+  Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k).
+
+This is the central analytic fact. It generalises `Σ μ(d)/d² = 6/π²` and is proved from
+the L-series identity `L(ζ, k)·L(μ, k) = 1` together with `ζ(k) = Σ 1/nᵏ`
+(`zeta_nat_eq_tsum_of_gt_one`). No closed form for `ζ(k)` is needed; the value is carried
+symbolically as the real number `rZeta k = Σ' n, 1/nᵏ`.
+
+### Step 3: Density Limit
+Tannery's dominated-convergence theorem with dominator `1/dᵏ` (summable for `k ≥ 2`,
+`summable_one_div_nat_pow`) and pointwise limit `⌊N/d⌋/N → 1/d` upgrades the finite
+Möbius sum to the infinite series, yielding the density `1/ζ(k)`.
+
+## Axiom Count: 0
+
+References:
+- Nymann, "On the probability that `k` positive integers are relatively prime",
+  J. Number Theory 4 (1972), 469–473.
+- Hardy & Wright, *Theory of Numbers* §18.5 (the `k = 2` case).
+- Mathlib: `LSeries_zeta_mul_Lseries_moebius`, `zeta_nat_eq_tsum_of_gt_one`,
+  `tendsto_tsum_of_dominated_convergence`.
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction
+import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
+import Mathlib.NumberTheory.EulerProduct.DirichletLSeries
+import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.Order
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Analysis.Normed.Group.Tannery
+import Mathlib.Tactic
+
+open Filter Finset BigOperators Real Nat ArithmeticFunction
+
+open scoped LSeries.notation
+
+-- Helper: (⌊N/d⌋ : ℝ) / N → 1/d as N → ∞ (for any fixed d).  [k-independent; identical to
+-- the `k = 2` development in BaselProblemOQ04OQ03]
+private lemma nat_div_div_tendsto (d : ℕ) :
+    Tendsto (fun N : ℕ => (N / d : ℕ) / (N : ℝ)) atTop (nhds (1 / (d : ℝ))) := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · simp [Nat.div_zero]
+  · have hd' : (0 : ℝ) < d := Nat.cast_pos.mpr hd
+    rw [Metric.tendsto_atTop]
+    intro ε hε
+    refine ⟨max 1 ⌈(d : ℝ) / ε⌉₊, fun N hN => ?_⟩
+    have hN1 : 1 ≤ N := (Nat.le_max_left 1 _).trans hN
+    have hN' : (0 : ℝ) < N := Nat.cast_pos.mpr (by omega)
+    have hd_ne : (d : ℝ) ≠ 0 := hd'.ne'
+    have hN_ne : (N : ℝ) ≠ 0 := hN'.ne'
+    have hdm : (N / d : ℕ) * d + N % d = N := by
+      rw [Nat.mul_comm (N / d) d]; exact Nat.div_add_mod N d
+    have hdmR : ((N / d : ℕ) : ℝ) * d + ((N % d : ℕ) : ℝ) = N := by exact_mod_cast hdm
+    have heq : (N / d : ℕ) / (N : ℝ) - 1 / d
+        = -(((N % d : ℕ) : ℝ) / ((d : ℝ) * N)) := by
+      have h1 : ((N / d : ℕ) : ℝ) = ((N : ℝ) - (N % d : ℕ)) / d := by
+        rw [eq_div_iff hd_ne]; linarith [hdmR]
+      rw [h1]; field_simp; ring
+    rw [Real.dist_eq, heq, abs_neg, abs_of_nonneg (by positivity)]
+    rw [div_lt_iff₀ (by positivity)]
+    have hmod : ((N % d : ℕ) : ℝ) < (d : ℝ) := by exact_mod_cast Nat.mod_lt N hd
+    have hN_ge : (d : ℝ) ≤ ε * N := by
+      have h1 : (d : ℝ) / ε ≤ ⌈(d : ℝ) / ε⌉₊ := Nat.le_ceil _
+      have h2 : (⌈(d : ℝ) / ε⌉₊ : ℝ) ≤ N := by
+        exact_mod_cast (Nat.le_max_right 1 _).trans hN
+      calc (d : ℝ) = d / ε * ε := by field_simp
+        _ ≤ ↑⌈↑d / ε⌉₊ * ε := by nlinarith
+        _ ≤ N * ε := by nlinarith
+        _ = ε * N := mul_comm _ _
+    have h1d : (1 : ℝ) ≤ d := by exact_mod_cast hd
+    have hkey : (0 : ℝ) ≤ ((d : ℝ) - 1) * (ε * N) :=
+      mul_nonneg (by linarith) (le_of_lt (mul_pos hε hN'))
+    nlinarith [hmod, hN_ge, h1d, hkey, mul_pos hε hN', mul_pos hd' hN']
+
+namespace CoprimeKTupleDensity
+
+-- ============================================================
+-- SECTION I: The Real ζ(k) Value
+-- ============================================================
+
+/-- The real value `ζ(k) = Σ' n, 1/nᵏ`. For `k ≥ 2` this series converges and equals the
+(real, positive) Riemann zeta value `riemannZeta k`. -/
+noncomputable def rZeta (k : ℕ) : ℝ := ∑' n : ℕ, 1 / (n : ℝ) ^ k
+
+/-- For `k ≥ 2`, the defining series of `rZeta k` is summable. -/
+lemma rZeta_summable {k : ℕ} (hk : 2 ≤ k) :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ k) :=
+  summable_one_div_nat_pow.mpr (by omega)
+
+/-- `rZeta k > 0` (the `n = 1` term contributes `1`). -/
+lemma rZeta_pos {k : ℕ} (hk : 2 ≤ k) : 0 < rZeta k := by
+  refine (rZeta_summable hk).tsum_pos (fun n => by positivity) 1 ?_
+  norm_num
+
+/-- The bridge to the complex Riemann zeta function: for `k ≥ 2`,
+`riemannZeta k = rZeta k` (as a complex number via `ofReal`). -/
+lemma riemannZeta_nat_eq_ofReal_rZeta {k : ℕ} (hk : 2 ≤ k) :
+    riemannZeta (k : ℂ) = ((rZeta k : ℝ) : ℂ) := by
+  rw [zeta_nat_eq_tsum_of_gt_one (by omega : 1 < k), rZeta, Complex.ofReal_tsum]
+  apply tsum_congr
+  intro n
+  push_cast
+  ring
+
+/-- `1 < rZeta k` for `k ≥ 2`: the first two terms `1 + 1/2ᵏ` already exceed `1`.
+Hence the density `1/ζ(k)` lies strictly below `1`. -/
+lemma one_lt_rZeta {k : ℕ} (hk : 2 ≤ k) : 1 < rZeta k := by
+  have hsum := rZeta_summable hk
+  -- The partial sum over `{1, 2}` is a lower bound for the (nonneg) series.
+  have hle : ∑ n ∈ ({1, 2} : Finset ℕ), 1 / (n : ℝ) ^ k ≤ rZeta k :=
+    sum_le_hasSum _ (fun i _ => by positivity) hsum.hasSum
+  have hlb : (1 : ℝ) < ∑ n ∈ ({1, 2} : Finset ℕ), 1 / (n : ℝ) ^ k := by
+    rw [Finset.sum_pair (by norm_num : (1 : ℕ) ≠ 2)]
+    have e1 : (1 : ℝ) / ((1 : ℕ) : ℝ) ^ k = 1 := by simp
+    have e2 : (0 : ℝ) < 1 / ((2 : ℕ) : ℝ) ^ k := by positivity
+    rw [e1]; linarith
+  linarith
+
+-- ============================================================
+-- SECTION II: Möbius Inversion Foundation  (k-independent)
+-- ============================================================
+
+/-- **Key Lemma** (Möbius Inversion): for `n ≥ 1`, `Σ_{d|n} μ(d) = [n = 1]`.
+This is the Dirichlet convolution `μ * ζ = 1`. -/
+theorem moebius_sum_divisors (n : ℕ) (hn : 0 < n) :
+    ∑ d ∈ n.divisors, (ArithmeticFunction.moebius d : ℤ) =
+      if n = 1 then 1 else 0 := by
+  trans (((ArithmeticFunction.moebius : ArithmeticFunction ℤ) *
+         ↑(ArithmeticFunction.zeta : ArithmeticFunction ℕ)) n)
+  · rw [ArithmeticFunction.mul_apply]
+    simp_rw [ArithmeticFunction.natCoe_apply, ArithmeticFunction.zeta_apply]
+    have h_simp : ∀ x ∈ n.divisorsAntidiagonal,
+        ArithmeticFunction.moebius x.1 * (↑(if x.2 = 0 then (0 : ℕ) else 1) : ℤ) =
+        ArithmeticFunction.moebius x.1 := by
+      intro x hx
+      have hmem := Nat.mem_divisorsAntidiagonal.mp hx
+      have hx2 : x.2 ≠ 0 := by
+        intro h; exact hmem.2 (by rw [← hmem.1, h, mul_zero])
+      simp [hx2]
+    rw [Finset.sum_congr rfl h_simp]
+    symm
+    apply Finset.sum_nbij Prod.fst
+    · intro x hx
+      have hmem := Nat.mem_divisorsAntidiagonal.mp hx
+      exact Nat.mem_divisors.mpr ⟨⟨x.2, hmem.1.symm⟩, hmem.2⟩
+    · intro x₁ hx₁ x₂ hx₂ h
+      have h1 := (Nat.mem_divisorsAntidiagonal.mp hx₁).1
+      have h2 := (Nat.mem_divisorsAntidiagonal.mp hx₂).1
+      have h2_ne := (Nat.mem_divisorsAntidiagonal.mp hx₂).2
+      have h_ne : x₂.1 ≠ 0 := by
+        intro hz; exact h2_ne (by rw [← h2, hz, zero_mul])
+      have h_eq : x₁.1 * x₁.2 = x₂.1 * x₂.2 := h1.trans h2.symm
+      ext
+      · exact h
+      · exact mul_left_cancel₀ h_ne (by rwa [h] at h_eq)
+    · intro d hd
+      exact ⟨(d, n / d), Nat.mem_divisorsAntidiagonal.mpr
+        ⟨Nat.mul_div_cancel' (Nat.dvd_of_mem_divisors hd), hn.ne'⟩, rfl⟩
+    · intro _ _; rfl
+  · rw [ArithmeticFunction.moebius_mul_coe_zeta, ArithmeticFunction.one_apply]
+
+-- ============================================================
+-- SECTION III: Counting Multiples and Divisible Tuples
+-- ============================================================
+
+/-- The number of multiples of `d` in `{1, …, N}` equals `⌊N/d⌋`.  [k-independent] -/
+theorem card_multiples (d N : ℕ) (hd : 0 < d) :
+    (Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N)).card = N / d := by
+  have h_eq : Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N) =
+      (Finset.range (N / d)).image (fun j => (j + 1) * d) := by
+    ext a
+    simp only [Finset.mem_filter, Finset.mem_Icc, Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨⟨ha1, haN⟩, ⟨k, rfl⟩⟩
+      have hk_pos : 0 < k := by
+        by_contra h; push_neg at h; interval_cases k; simp at ha1
+      have hk_le : k ≤ N / d := by
+        rw [Nat.le_div_iff_mul_le hd]
+        calc k * d = d * k := mul_comm k d
+          _ ≤ N := haN
+      exact ⟨k - 1, by omega, by rw [Nat.sub_add_cancel (by omega : 1 ≤ k), mul_comm]⟩
+    · rintro ⟨j, hj, rfl⟩
+      refine ⟨⟨?_, ?_⟩, dvd_mul_left d (j + 1)⟩
+      · exact Nat.one_le_iff_ne_zero.mpr (mul_ne_zero (by omega) hd.ne')
+      · calc (j + 1) * d ≤ N / d * d := by nlinarith
+          _ ≤ N := Nat.div_mul_le_self N d
+  rw [h_eq]
+  rw [Finset.card_image_of_injective _ (fun a b h => by
+    have := mul_right_cancel₀ hd.ne' h; omega)]
+  exact Finset.card_range _
+
+/-- The number of `k`-tuples `a : Fin k → ℕ` with each `a i ∈ {1, …, N}` and `d ∣ a i`
+for all `i` equals `⌊N/d⌋ᵏ`. (The `k`-dimensional analogue of `card_pairs_divisible`.) -/
+theorem card_tuples_divisible (k d N : ℕ) (hd : 0 < d) :
+    ((Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+      (fun a => ∀ i, d ∣ a i)).card = (N / d) ^ k := by
+  have h_eq : (Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+        (fun a => ∀ i, d ∣ a i)
+      = Fintype.piFinset (fun _ : Fin k => Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N)) := by
+    ext a
+    simp only [Finset.mem_filter, Fintype.mem_piFinset]
+    constructor
+    · rintro ⟨ha, hdvd⟩ i; exact ⟨ha i, hdvd i⟩
+    · intro h; exact ⟨fun i => (h i).1, fun i => (h i).2⟩
+  rw [h_eq, Fintype.card_piFinset_const, card_multiples d N hd]
+
+-- ============================================================
+-- SECTION IV: The Coprime Tuple Count and Möbius Decomposition
+-- ============================================================
+
+/-- The number of `k`-tuples `a : Fin k → ℕ` with `1 ≤ a i ≤ N` for all `i` and
+`gcd(a₁, …, a_k) = 1`. -/
+noncomputable def countCoprimeTuples (k N : ℕ) : ℕ :=
+  ((Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+    (fun a => Finset.univ.gcd a = 1)).card
+
+/-- **Möbius Decomposition**: `countCoprimeTuples k N = Σ_{d=1}^N μ(d) · ⌊N/d⌋ᵏ`.
+
+Both sides count triples `(a, d)` with `a ∈ [1,N]ᵏ` and `d | gcd(a)`, weighted by `μ(d)`.
+A finite Fubini exchange swaps the order of summation. -/
+theorem countCoprimeTuples_moebius (k N : ℕ) (hk1 : 0 < k) (hN : 0 < N) :
+    (countCoprimeTuples k N : ℤ) =
+    ∑ d ∈ Finset.Icc 1 N, (ArithmeticFunction.moebius d : ℤ) * (N / d : ℕ) ^ k := by
+  unfold countCoprimeTuples
+  -- Step 1: Cardinality = sum of coprimality indicators
+  have h_card_sum :
+      (((Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+        (fun a => Finset.univ.gcd a = 1)).card : ℤ) =
+      ∑ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+        if Finset.univ.gcd a = 1 then (1 : ℤ) else 0 := by
+    rw [← Finset.sum_boole]
+  rw [h_card_sum]
+  -- Step 2: Replace each indicator by `Σ_{e | gcd a} μ(e)` (Möbius inversion).
+  have hgcd_pos : ∀ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+      0 < Finset.univ.gcd a := by
+    intro a ha
+    have ha0 := (Fintype.mem_piFinset.mp ha) ⟨0, hk1⟩
+    rw [Finset.mem_Icc] at ha0
+    refine Nat.pos_of_ne_zero ?_
+    rw [Ne, Finset.gcd_eq_zero_iff]
+    push_neg
+    exact ⟨⟨0, hk1⟩, Finset.mem_univ _, by omega⟩
+  have h_moebius : ∀ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+      (if Finset.univ.gcd a = 1 then (1 : ℤ) else 0) =
+      ∑ e ∈ (Finset.univ.gcd a).divisors, (ArithmeticFunction.moebius e : ℤ) :=
+    fun a ha => (moebius_sum_divisors _ (hgcd_pos a ha)).symm
+  rw [Finset.sum_congr rfl h_moebius]
+  -- Step 3: Inner divisor sum = sum over `e ∈ [1,N]` with `∀ i, e ∣ a i`.
+  have h_step3 : ∀ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+      ∑ e ∈ (Finset.univ.gcd a).divisors, (ArithmeticFunction.moebius e : ℤ) =
+      ∑ e ∈ Finset.Icc 1 N,
+        if (∀ i, e ∣ a i) then (ArithmeticFunction.moebius e : ℤ) else 0 := by
+    intro a ha
+    rw [← Finset.sum_filter]
+    congr 1
+    ext e
+    rw [Nat.mem_divisors, Finset.mem_filter, Finset.mem_Icc]
+    constructor
+    · rintro ⟨hdvd_gcd, _⟩
+      have hall : ∀ i, e ∣ a i := fun i => hdvd_gcd.trans (Finset.gcd_dvd (Finset.mem_univ i))
+      have hi0 := hall ⟨0, hk1⟩
+      have ha0 := (Fintype.mem_piFinset.mp ha) ⟨0, hk1⟩
+      rw [Finset.mem_Icc] at ha0
+      exact ⟨⟨Nat.pos_of_dvd_of_pos hi0 (by omega),
+        le_trans (Nat.le_of_dvd (by omega) hi0) ha0.2⟩, hall⟩
+    · rintro ⟨_, hall⟩
+      exact ⟨Finset.dvd_gcd (fun i _ => hall i), (hgcd_pos a ha).ne'⟩
+  rw [Finset.sum_congr rfl h_step3, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro e he
+  simp only [Finset.mem_Icc] at he
+  rw [← Finset.sum_filter, Finset.sum_const, card_tuples_divisible k e N (by omega)]
+  simp only [nsmul_eq_mul]
+  push_cast
+  ring
+
+-- ============================================================
+-- SECTION V: The Möbius Dirichlet Series  Σ μ(d)/dᵏ = 1/ζ(k)
+-- ============================================================
+
+/-- **Theorem (Möbius Dirichlet Series)**: for integer `k ≥ 2`,
+
+  Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k).
+
+This is the key analytic identity. Generalises `moebius_dirichlet_series_at_two`
+(`Σ μ(d)/d² = 6/π²`). Proof: at `s = k` the L-series identity `L(ζ, k)·L(μ, k) = 1`
+combined with `L(ζ, k) = ζ(k)` gives `L(μ, k) = 1/ζ(k)`; transfer to a real `HasSum`. -/
+theorem moebius_dirichlet_series {k : ℕ} (hk : 2 ≤ k) :
+    HasSum (fun d : ℕ => (ArithmeticFunction.moebius d : ℝ) / (d : ℝ) ^ k)
+    (1 / rZeta k) := by
+  rw [← Complex.hasSum_ofReal]
+  have hval : ((1 / rZeta k : ℝ) : ℂ) = (rZeta k : ℂ)⁻¹ := by
+    rw [Complex.ofReal_div, Complex.ofReal_one, one_div]
+  rw [hval]
+  have hkre : 1 < ((k : ℕ) : ℂ).re := by
+    rw [Complex.natCast_re]; exact_mod_cast (show 1 < k by omega)
+  have hmu_sum : LSeriesSummable ↗moebius (k : ℂ) :=
+    LSeriesSummable_moebius_iff.mpr hkre
+  have hprod : L ↗zeta (k : ℂ) * L ↗moebius (k : ℂ) = 1 :=
+    LSeries_zeta_mul_Lseries_moebius hkre
+  have hzeta : L ↗zeta (k : ℂ) = (rZeta k : ℂ) := by
+    rw [LSeries_zeta_eq_riemannZeta hkre, riemannZeta_nat_eq_ofReal_rZeta hk]
+  have hz_ne : (rZeta k : ℂ) ≠ 0 := by
+    rw [Ne, Complex.ofReal_eq_zero]; exact (rZeta_pos hk).ne'
+  have hL_mu : L ↗moebius (k : ℂ) = (rZeta k : ℂ)⁻¹ := by
+    have h : (rZeta k : ℂ) * L ↗moebius (k : ℂ) = 1 := hzeta ▸ hprod
+    calc L ↗moebius (k : ℂ)
+        = (rZeta k : ℂ)⁻¹ * ((rZeta k : ℂ) * L ↗moebius (k : ℂ)) := by
+            rw [← mul_assoc, inv_mul_cancel₀ hz_ne, one_mul]
+      _ = (rZeta k : ℂ)⁻¹ * 1 := by rw [h]
+      _ = (rZeta k : ℂ)⁻¹ := mul_one _
+  have hLHS : LSeriesHasSum ↗moebius (k : ℂ) ((rZeta k : ℂ)⁻¹) :=
+    hL_mu ▸ hmu_sum.LSeriesHasSum
+  have hfun : LSeries.term ↗moebius (k : ℂ) =
+      fun n : ℕ => (((moebius n : ℝ) / (n : ℝ) ^ k : ℝ) : ℂ) := by
+    funext n
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · simp [LSeries.term_zero]
+    · rw [LSeries.term_of_ne_zero hn.ne', Complex.cpow_natCast]
+      push_cast
+      ring
+  rwa [← hfun]
+
+/-- The Möbius Dirichlet series as a `tsum`: `Σ' d, μ(d)/dᵏ = 1/ζ(k)`. -/
+theorem tsum_moebius_div_pow {k : ℕ} (hk : 2 ≤ k) :
+    ∑' d : ℕ, (ArithmeticFunction.moebius d : ℝ) / (d : ℝ) ^ k = 1 / rZeta k :=
+  (moebius_dirichlet_series hk).tsum_eq
+
+-- ============================================================
+-- SECTION VI: The Density Limit
+-- ============================================================
+
+/-- **Main Theorem** (Nymann 1972): for every integer `k ≥ 2`, the natural density of
+coprime `k`-tuples of positive integers equals `1/ζ(k)`:
+
+  lim_{N→∞} countCoprimeTuples k N / Nᵏ = 1/ζ(k).
+
+Proof via Tannery's dominated-convergence theorem: the Möbius decomposition rewrites the
+count as `Σ_d μ(d)·(⌊N/d⌋/N)ᵏ`, each term tends to `μ(d)/dᵏ`, the family is dominated by
+the summable `1/dᵏ`, and the limit series sums to `1/ζ(k)` (`moebius_dirichlet_series`). -/
+theorem coprime_tuple_density_limit {k : ℕ} (hk : 2 ≤ k) :
+    Filter.Tendsto
+      (fun N : ℕ => (countCoprimeTuples k N : ℝ) / (N : ℝ) ^ k)
+      Filter.atTop
+      (nhds (1 / rZeta k)) := by
+  rw [show (1 / rZeta k) = ∑' d : ℕ, (moebius d : ℝ) / (d : ℝ) ^ k
+    from (tsum_moebius_div_pow hk).symm]
+  have h_congr : ∀ᶠ N : ℕ in atTop,
+      (countCoprimeTuples k N : ℝ) / N ^ k =
+      ∑' d : ℕ, (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k := by
+    apply eventually_atTop.mpr ⟨1, fun N hN => ?_⟩
+    have hN' : (0 : ℝ) < N := Nat.cast_pos.mpr (by omega)
+    have hN2 : (N : ℝ) ^ k ≠ 0 := pow_ne_zero k hN'.ne'
+    have hdecomp := countCoprimeTuples_moebius k N (by omega) (by omega)
+    have hcast : (countCoprimeTuples k N : ℝ) =
+        ∑ d ∈ Finset.Icc 1 N, (moebius d : ℝ) * ((N / d : ℕ) : ℝ) ^ k := by
+      have h := congr_arg (Int.cast : ℤ → ℝ) hdecomp
+      push_cast at h
+      exact h
+    have h_fin_eq : ∑' d : ℕ, (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k =
+        ∑ d ∈ Finset.Icc 1 N, (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k := by
+      apply tsum_eq_sum
+      intro d hd
+      simp only [Finset.mem_Icc, not_and_or, not_le] at hd
+      rcases hd with hd0 | hdN
+      · have : d = 0 := by omega
+        subst this; simp
+      · have hzero : N / d = 0 := Nat.div_eq_of_lt (by omega)
+        rw [hzero]; simp [zero_pow (show k ≠ 0 by omega)]
+    rw [h_fin_eq, hcast, Finset.sum_div]
+    apply Finset.sum_congr rfl
+    intro d _
+    rw [mul_div_assoc, ← div_pow]
+  apply (tendsto_tsum_of_dominated_convergence
+    (f := fun N d => (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k)
+    (g := fun d => (moebius d : ℝ) / (d : ℝ) ^ k)
+    (bound := fun d => 1 / (d : ℝ) ^ k)
+    (h_sum := summable_one_div_nat_pow.mpr (by omega : 1 < k))
+    (hab := fun d => by
+      rcases Nat.eq_zero_or_pos d with rfl | hd
+      · have hμ0 : (moebius 0 : ℝ) = 0 := by simp
+        simp only [hμ0, zero_mul, zero_div]
+        exact tendsto_const_nhds
+      · have h := (nat_div_div_tendsto d).pow k
+        have hc : Tendsto (fun _ : ℕ => (moebius d : ℝ)) atTop (nhds (moebius d : ℝ)) :=
+          tendsto_const_nhds
+        have h2 := hc.mul h
+        rwa [show (moebius d : ℝ) * (1 / (d : ℝ)) ^ k = (moebius d : ℝ) / (d : ℝ) ^ k
+          from by rw [div_pow, one_pow, mul_one_div]] at h2)
+    (h_bound := by
+      filter_upwards [eventually_ge_atTop 1] with N hN d
+      have hN' : (0 : ℝ) < N := Nat.cast_pos.mpr (by omega)
+      rcases Nat.eq_zero_or_pos d with rfl | hd
+      · have hμ0 : (moebius 0 : ℝ) = 0 := by simp
+        rw [hμ0, zero_mul, norm_zero]
+        exact div_nonneg (by norm_num) (by positivity)
+      · simp only [Real.norm_eq_abs, abs_mul, abs_pow]
+        have hmu : |(moebius d : ℝ)| ≤ 1 := by exact_mod_cast abs_moebius_le_one
+        have hdiv : |(N / d : ℕ) / (N : ℝ)| ≤ 1 / (d : ℝ) := by
+          rw [abs_of_nonneg (by positivity), div_le_div_iff₀ hN' (Nat.cast_pos.mpr hd)]
+          simp only [one_mul]
+          push_cast
+          exact_mod_cast Nat.div_mul_le_self N d
+        calc |(moebius d : ℝ)| * |(N / d : ℕ) / (N : ℝ)| ^ k
+            ≤ 1 * (1 / (d : ℝ)) ^ k :=
+              mul_le_mul hmu (pow_le_pow_left₀ (abs_nonneg _) hdiv k)
+                (pow_nonneg (abs_nonneg _) k) (by norm_num)
+          _ = 1 / (d : ℝ) ^ k := by rw [one_mul, div_pow, one_pow])).congr'
+    (Filter.EventuallyEq.symm h_congr)
+
+-- ============================================================
+-- SECTION VII: Consequences
+-- ============================================================
+
+/-- The density `1/ζ(k)` is strictly positive. -/
+theorem density_pos {k : ℕ} (hk : 2 ≤ k) : 0 < 1 / rZeta k :=
+  div_pos one_pos (rZeta_pos hk)
+
+/-- The density `1/ζ(k)` is strictly less than `1` (since `ζ(k) > 1`).
+So coprimality of `k`-tuples is a genuine, non-degenerate event. -/
+theorem density_lt_one {k : ℕ} (hk : 2 ≤ k) : 1 / rZeta k < 1 := by
+  rw [div_lt_one (rZeta_pos hk)]
+  exact one_lt_rZeta hk
+
+/-- The density lies in the open unit interval `(0, 1)` — a bona fide probability. -/
+theorem density_in_unit_interval {k : ℕ} (hk : 2 ≤ k) :
+    1 / rZeta k ∈ Set.Ioo (0 : ℝ) 1 :=
+  ⟨density_pos hk, density_lt_one hk⟩
+
+-- ============================================================
+-- SECTION VIII: Consistency with the Pair Case (k = 2)
+-- ============================================================
+
+/-- Cross-check: `ζ(2) = π²/6`, recovering the Basel constant. -/
+theorem rZeta_two_eq : rZeta 2 = Real.pi ^ 2 / 6 := by
+  have h := riemannZeta_nat_eq_ofReal_rZeta (k := 2) (by norm_num)
+  rw [show ((2 : ℕ) : ℂ) = (2 : ℂ) by norm_num, riemannZeta_two] at h
+  have hc : ((rZeta 2 : ℝ) : ℂ) = ((Real.pi ^ 2 / 6 : ℝ) : ℂ) := by
+    rw [← h]; push_cast; ring
+  exact_mod_cast hc
+
+/-- Cross-check: the `k = 2` density is `6/π²`, matching `coprime_pair_density`
+(`BaselProblemOQ04OQ03`). -/
+theorem density_two_eq : 1 / rZeta 2 = 6 / Real.pi ^ 2 := by
+  rw [rZeta_two_eq, one_div_div]
+
+-- ============================================================
+-- SECTION IX: Summary
+-- ============================================================
+
+/-
+## Summary
+
+**Theorem (Nymann 1972)**: for every integer `k ≥ 2`,
+  lim_{N→∞} |{a ∈ [1,N]ᵏ : gcd(a) = 1}| / Nᵏ = 1/ζ(k).
+
+**Proof Architecture** (faithful `k`-dimensional generalisation of the `k = 2` Basel
+development in `BaselProblemOQ04OQ03`):
+1. Möbius decomposition: `countCoprimeTuples k N = Σ_{d≤N} μ(d)·⌊N/d⌋ᵏ`
+   (`countCoprimeTuples_moebius`), via `Fintype.card_piFinset_const`.
+2. Dirichlet series: `Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k)` (`moebius_dirichlet_series`),
+   via `LSeries_zeta_mul_Lseries_moebius` + `zeta_nat_eq_tsum_of_gt_one`.
+3. Density limit: `coprime_tuple_density_limit`, via Tannery's theorem with dominator
+   `1/dᵏ` (`summable_one_div_nat_pow`, valid for `k ≥ 2`).
+
+**Specialisation** `k = 2` recovers `6/π² = 1/ζ(2)` (`density_two_eq`).
+
+Axiom count: 0.  Sorry count: 0.
+-/
+
+end CoprimeKTupleDensity

--- a/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-piFinset-const",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 220,
+      "endLine": 231
+    },
+    "type": "insight",
+    "title": "The Exponent k Enters Only Through Fintype.card_piFinset_const",
+    "content": "card_tuples_divisible is the single place where the dimension k touches the combinatorics. The filter {a ∈ [1,N]ᵏ : ∀i, d|aᵢ} is rewritten coordinate-wise as a product Finset Fintype.piFinset (fun _ => filter (d ∣ ·) (Icc 1 N)), because the divisibility constraint on each coordinate is independent of the others. Fintype.card_piFinset_const then collapses the product to a k-th power |S|ᵏ, and card_multiples evaluates the per-coordinate count as ⌊N/d⌋. The result ⌊N/d⌋ᵏ is the only structural change from the k=2 pair case (which used ⌊N/d⌋²) — every other lemma in the file generalizes verbatim.",
+    "mathContext": "$|\\{a\\in[1,N]^k : \\forall i,\\, d\\mid a_i\\}| = \\prod_{i\\in\\mathrm{Fin}\\,k} |\\{m\\in[1,N] : d\\mid m\\}| = \\lfloor N/d\\rfloor^k.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fintype.piFinset",
+      "Fintype.card_piFinset_const",
+      "independence of coordinate constraints",
+      "card_multiples"
+    ],
+    "prerequisites": [
+      "product Finsets",
+      "counting multiples in an interval"
+    ]
+  },
+  {
+    "id": "ann-moebius-decomposition",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 247,
+      "endLine": 306
+    },
+    "type": "insight",
+    "title": "Möbius Decomposition via a Finite Fubini Exchange",
+    "content": "countCoprimeTuples_moebius is the combinatorial heart: countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)⌊N/d⌋ᵏ. The proof turns the cardinality into a sum of coprimality indicators 1_{gcd(a)=1}, replaces each indicator by the Möbius sum Σ_{e|gcd a} μ(e) (moebius_sum_divisors, the identity μ * ζ = 1), recasts the inner divisor condition e | gcd(a) as the tuple condition ∀i, e|aᵢ, then swaps the order of summation with Finset.sum_comm and applies card_tuples_divisible. Both sides count the same set of pairs (a, d) with a ∈ [1,N]ᵏ and d | gcd(a), weighted by μ(d) — the swap is a finite Fubini step requiring no convergence hypothesis.",
+    "mathContext": "$|\\{a\\in[1,N]^k:\\gcd(a)=1\\}| = \\sum_{a} \\sum_{d\\mid\\gcd(a)}\\mu(d) = \\sum_{d=1}^N \\mu(d)\\,|\\{a : \\forall i,\\, d\\mid a_i\\}| = \\sum_{d=1}^N \\mu(d)\\lfloor N/d\\rfloor^k.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Möbius inversion",
+      "Finset.sum_comm",
+      "Dirichlet convolution μ * ζ = 1",
+      "indicator-to-sum conversion"
+    ],
+    "prerequisites": [
+      "Möbius function",
+      "exchange of finite sums",
+      "gcd of a finite family"
+    ]
+  },
+  {
+    "id": "ann-dirichlet-series",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 319,
+      "endLine": 353
+    },
+    "type": "insight",
+    "title": "Σ μ(d)/dᵏ = 1/ζ(k) with ζ(k) Carried Symbolically",
+    "content": "moebius_dirichlet_series is the analytic core. Rather than computing any closed form for ζ(k), the value is held abstractly as rZeta k = Σ' 1/nᵏ. The proof transfers to ℂ (Complex.hasSum_ofReal), invokes Mathlib's L-series factorization LSeries_zeta_mul_Lseries_moebius giving L(ζ,k)·L(μ,k) = 1, identifies L(ζ,k) with rZeta k via riemannZeta_nat_eq_ofReal_rZeta, and solves L(μ,k) = (rZeta k)⁻¹. Matching the L-series term against the real summand μ(d)/dᵏ yields the real HasSum. Because ζ(k) never needs evaluation, the identity Σ μ(d)/dᵏ = 1/ζ(k) holds uniformly for all k ≥ 2 at once.",
+    "mathContext": "At $s=k$: $L(\\zeta,k)\\,L(\\mu,k) = 1$ and $L(\\zeta,k) = \\zeta(k)$, hence $\\sum_{d\\ge 1}\\mu(d)/d^k = L(\\mu,k) = 1/\\zeta(k)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Dirichlet series",
+      "Riemann zeta function",
+      "LSeries_zeta_mul_Lseries_moebius",
+      "complex-to-real HasSum transfer"
+    ],
+    "prerequisites": [
+      "L-series",
+      "Euler products / Dirichlet convolution as L-series",
+      "tsum / HasSum"
+    ]
+  },
+  {
+    "id": "ann-density-limit",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 372,
+      "endLine": 443
+    },
+    "type": "theorem",
+    "title": "Density Limit via Tannery, with k ≥ 2 as the Exact Convergence Range",
+    "content": "coprime_tuple_density_limit assembles the result: lim_{N→∞} countCoprimeTuples(k,N)/Nᵏ = 1/ζ(k). The Möbius decomposition rewrites the normalized count as a tsum Σ_d μ(d)·(⌊N/d⌋/N)ᵏ (truncating to [1,N]); each term tends to μ(d)/dᵏ using the floor-ratio limit ⌊N/d⌋/N → 1/d; the family is dominated by 1/dᵏ via |μ(d)| ≤ 1 and ⌊N/d⌋/N ≤ 1/d; and tendsto_tsum_of_dominated_convergence (Tannery) passes the limit inside the sum to land on 1/ζ(k). The hypothesis k ≥ 2 is not incidental: the dominator 1/dᵏ is summable iff k > 1 (summable_one_div_nat_pow), so k ≥ 2 is precisely the range where the density limit exists.",
+    "mathContext": "$\\lim_{N\\to\\infty}\\frac{|\\{a\\in[1,N]^k:\\gcd(a)=1\\}|}{N^k} = \\sum_{d\\ge 1}\\frac{\\mu(d)}{d^k} = \\frac{1}{\\zeta(k)},\\quad k\\ge 2.$",
+    "significance": "central",
+    "relatedConcepts": [
+      "Tannery's theorem",
+      "tendsto_tsum_of_dominated_convergence",
+      "dominated convergence",
+      "natural density"
+    ],
+    "prerequisites": [
+      "dominated convergence for series",
+      "p-series summability",
+      "the floor-ratio limit ⌊N/d⌋/N → 1/d"
+    ]
+  },
+  {
+    "id": "ann-pair-consistency",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": {
+      "startLine": 467,
+      "endLine": 478
+    },
+    "type": "insight",
+    "title": "The k = 2 Specialization Recovers Cesàro's 6/π²",
+    "content": "As a built-in consistency check, rZeta_two_eq derives rZeta 2 = π²/6 from Mathlib's riemannZeta_two (the Basel value), and density_two_eq concludes 1/ζ(2) = 6/π². This recovers the classical coprime-pair density formalized in basel-problem-oq-04-oq-03 as the base case k = 2 of the k-tuple family, confirming the generalization is faithful. The interval bounds density_in_unit_interval (0 < 1/ζ(k) < 1) further certify the limit as a genuine probability for every k ≥ 2.",
+    "mathContext": "$\\zeta(2) = \\pi^2/6 \\Rightarrow 1/\\zeta(2) = 6/\\pi^2 \\approx 0.6079$, the Cesàro (1885) coprime-pair density.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Basel problem",
+      "riemannZeta_two",
+      "specialization / sanity check"
+    ],
+    "prerequisites": [
+      "ζ(2) = π²/6"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/meta.json
@@ -1,0 +1,235 @@
+{
+  "id": "basel-problem-oq-04-oq-03-oq-01",
+  "title": "Coprime k-Tuple Density: Pr[gcd(a₁,…,a_k)=1] → 1/ζ(k)",
+  "slug": "basel-problem-oq-04-oq-03-oq-01",
+  "description": "The natural density of coprime k-tuples of positive integers equals 1/ζ(k) for every integer k ≥ 2. This generalizes the classical Cesàro coprime-pair density 6/π² = 1/ζ(2) to arbitrary dimension, with the square ⌊N/d⌋² replaced by the k-th power ⌊N/d⌋ᵏ.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-26",
+    "status": "verified",
+    "note": "Fully symbolic, axiom-free generalization of the coprime-pair density to k-tuples. The main theorem coprime_tuple_density_limit establishes lim_{N→∞} countCoprimeTuples(k,N)/Nᵏ = 1/ζ(k) for all k ≥ 2 via Möbius decomposition + the Dirichlet-series identity Σ μ(d)/dᵏ = 1/ζ(k) + Tannery's dominated-convergence theorem. No native_decide is used anywhere, so the entry is genuinely verified (0 axioms, 0 sorries). The k=2 specialization recovers the Basel pair density 6/π² (density_two_eq).",
+    "proofRepoPath": "Proofs/CoprimeKTupleDensity.lean",
+    "tags": [
+      "number-theory",
+      "probability",
+      "zeta-function",
+      "mobius-function",
+      "natural-density",
+      "coprimality",
+      "dirichlet-series",
+      "basel-problem"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-26",
+    "mathlibDependencies": [
+      {
+        "theorem": "LSeries_zeta_mul_Lseries_moebius",
+        "description": "L(ζ,s)·L(μ,s) = 1 for Re(s) > 1 — the L-series form of μ * ζ = 1",
+        "module": "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+      },
+      {
+        "theorem": "zeta_nat_eq_tsum_of_gt_one",
+        "description": "riemannZeta(k) = Σ' n, 1/nᵏ for k > 1 (bridge complex ζ to the real series)",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      },
+      {
+        "theorem": "ArithmeticFunction.moebius_mul_coe_zeta",
+        "description": "Dirichlet convolution μ * ζ = 1 (identity arithmetic function)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction"
+      },
+      {
+        "theorem": "tendsto_tsum_of_dominated_convergence",
+        "description": "Tannery's theorem: termwise limits of a dominated summable family converge to the limit series",
+        "module": "Mathlib.Analysis.Normed.Group.Tannery"
+      },
+      {
+        "theorem": "summable_one_div_nat_pow",
+        "description": "Σ 1/dᵏ is summable iff k > 1 (the dominator, valid exactly for k ≥ 2)",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "Fintype.card_piFinset_const",
+        "description": "|∏_{i∈Fin k} S| = |S|ᵏ — factors the divisible-tuple count over the k coordinates",
+        "module": "Mathlib.Data.Fintype.Pi"
+      },
+      {
+        "theorem": "riemannZeta_two",
+        "description": "ζ(2) = π²/6 (Basel problem) — used only for the k=2 cross-check",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      }
+    ],
+    "originalContributions": [
+      "coprime_tuple_density_limit: the main theorem lim_{N→∞} countCoprimeTuples(k,N)/Nᵏ = 1/ζ(k) for all k ≥ 2, axiom-free and native_decide-free",
+      "countCoprimeTuples_moebius: the k-dimensional Möbius decomposition countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)⌊N/d⌋ᵏ via a finite Fubini exchange",
+      "card_tuples_divisible: |{a ∈ [1,N]ᵏ : ∀i, d|aᵢ}| = ⌊N/d⌋ᵏ, the k-dimensional counting lemma via Fintype.card_piFinset_const",
+      "moebius_dirichlet_series: HasSum Σ μ(d)/dᵏ = 1/ζ(k) for k ≥ 2, with ζ(k) carried symbolically as rZeta k = Σ' 1/nᵏ (no closed form needed)",
+      "rZeta infrastructure: rZeta_pos, one_lt_rZeta, riemannZeta_nat_eq_ofReal_rZeta bridging the real series to complex riemannZeta",
+      "density_in_unit_interval: 0 < 1/ζ(k) < 1, establishing coprimality as a genuine non-degenerate probability for every k ≥ 2",
+      "density_two_eq: the k=2 specialization recovers the Basel pair density 6/π², cross-checking consistency with basel-problem-oq-04-oq-03"
+    ],
+    "axiomCount": 0,
+    "lineCount": 503,
+    "assumptions": "None. All results are proved symbolically with 0 axioms and 0 sorries; no native_decide is used.",
+    "theoremCount": 17,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "That two random integers are coprime with probability 6/π² = 1/ζ(2) was stated by Ernesto Cesàro in 1885. The k-dimensional generalization — that k random positive integers share no common factor with probability 1/ζ(k) = ∏_p (1 − p⁻ᵏ) — was treated by J. E. Nymann, \"On the probability that k positive integers are relatively prime\" (J. Number Theory 4 (1972), 469–473). The probabilistic heuristic is transparent: for each prime p, the probability that p divides all k coordinates is p⁻ᵏ, so the probability p divides their gcd is (1 − p⁻ᵏ); the Chinese Remainder Theorem makes these events independent across primes, giving ∏_p (1 − p⁻ᵏ) = 1/ζ(k). As k → ∞ the density tends to 1: high-dimensional tuples are almost surely coprime, since ζ(k) → 1.",
+    "problemStatement": "Prove that for every integer k ≥ 2 the natural density of coprime k-tuples equals 1/ζ(k): lim_{N→∞} |{a : Fin k → ℕ | 1 ≤ aᵢ ≤ N, gcd(a₁,…,a_k) = 1}| / Nᵏ = 1/ζ(k).",
+    "text": "The probability that k randomly chosen positive integers are collectively coprime equals 1/ζ(k), generalizing Cesàro's 6/π² for pairs.",
+    "proofStrategy": "The proof follows the same three-step skeleton as the k=2 case, with ⌊N/d⌋² replaced throughout by ⌊N/d⌋ᵏ:\n1. Möbius decomposition: using [n=1] = Σ_{d|n} μ(d), a finite Fubini exchange gives countCoprimeTuples(k,N) = Σ_{d=1}^N μ(d)·⌊N/d⌋ᵏ. The d-divisible tuple count factors as ⌊N/d⌋ᵏ over the k coordinates (Fintype.card_piFinset_const).\n2. Dirichlet series: Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k), obtained from the L-series identity L(ζ,k)·L(μ,k) = 1 together with L(ζ,k) = ζ(k). The value ζ(k) is carried symbolically as rZeta k = Σ' 1/nᵏ; no closed form is needed.\n3. Density limit: Tannery's dominated-convergence theorem with dominator 1/dᵏ (summable exactly for k ≥ 2) and pointwise limit ⌊N/d⌋/N → 1/d upgrades the finite Möbius sum to the infinite series 1/ζ(k).",
+    "keyInsights": [
+      "Only one structural change separates the k-tuple proof from the pair case: replace ⌊N/d⌋² by ⌊N/d⌋ᵏ. Fintype.card_piFinset_const factors the divisible-tuple count over the k coordinates, so every counting lemma generalizes verbatim.",
+      "No closed form for ζ(k) is required. Carrying it symbolically as rZeta k = Σ' 1/nᵏ, the L-series identity L(ζ,k)·L(μ,k) = 1 with L(ζ,k) = ζ(k) pins Σ μ(d)/dᵏ = 1/ζ(k) for all k ≥ 2 at once.",
+      "The hypothesis k ≥ 2 is exactly the convergence range: the dominator 1/dᵏ is summable iff k > 1 (summable_one_div_nat_pow), so Tannery's theorem applies precisely when the density limit exists.",
+      "0 < 1/ζ(k) < 1 for every k ≥ 2, because ζ(k) > 1 + 2⁻ᵏ > 1 (one_lt_rZeta): coprimality of k-tuples is always a genuine, non-degenerate event.",
+      "The k=2 specialization recovers ζ(2) = π²/6 and density 6/π², cross-checking the generalization against the established coprime-pair entry."
+    ],
+    "prerequisites": [
+      "Number theory: Möbius function, arithmetic functions, Dirichlet convolution, natural density",
+      "Analysis: Riemann zeta function, Dirichlet/L-series, Tannery's dominated-convergence theorem",
+      "Combinatorics: counting multiples in [1,N], product Finsets (Fintype.piFinset)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and the Floor-Ratio Limit",
+      "startLine": 1,
+      "endLine": 99,
+      "summary": "Proof architecture (k-dimensional Möbius decomposition, the Möbius Dirichlet series Σ μ(d)/dᵏ = 1/ζ(k), and the density limit via Tannery), imports, and the k-independent private helper nat_div_div_tendsto: for any fixed d, (⌊N/d⌋ : ℝ)/N → 1/d as N → ∞.",
+      "mathContext": "For fixed $d$, $\\lfloor N/d\\rfloor / N \\to 1/d$ as $N\\to\\infty$, proved via an explicit $\\varepsilon$-$N$ bound using $N = \\lfloor N/d\\rfloor\\, d + (N \\bmod d)$ with $N \\bmod d < d$. This elementary limit drives the density convergence in every dimension $k$."
+    },
+    {
+      "id": "rzeta-value",
+      "title": "The Real ζ(k) Value",
+      "startLine": 101,
+      "endLine": 143,
+      "summary": "Defines rZeta k = Σ' n, 1/nᵏ and establishes its basic properties for k ≥ 2: summability (rZeta_summable), positivity (rZeta_pos), the bridge riemannZeta(k) = rZeta(k) via ofReal (riemannZeta_nat_eq_ofReal_rZeta), and 1 < rZeta k (one_lt_rZeta), which forces the density below 1.",
+      "mathContext": "$\\zeta(k) = \\sum_{n\\ge 1} 1/n^k$ converges for $k\\ge 2$ and exceeds $1 + 2^{-k} > 1$. Carried symbolically as $\\mathrm{rZeta}\\,k$, it needs no closed form; the complex bridge $\\zeta_{\\mathbb C}(k) = \\mathrm{ofReal}(\\mathrm{rZeta}\\,k)$ connects to Mathlib's L-series machinery."
+    },
+    {
+      "id": "mobius-inversion",
+      "title": "Möbius Inversion Foundation",
+      "startLine": 145,
+      "endLine": 186,
+      "summary": "Proves moebius_sum_divisors: Σ_{d|n} μ(d) = [n=1] for n ≥ 1, derived from the Dirichlet convolution μ * ζ = 1 (moebius_mul_coe_zeta) through an explicit divisorsAntidiagonal ↔ divisors bijection. This k-independent identity is the coprimality detector.",
+      "mathContext": "$\\sum_{d\\mid n}\\mu(d) = [n=1]$ — the fundamental Möbius inversion identity, equivalent to $\\mu * \\zeta = 1$. Applied to $n = \\gcd(a_1,\\dots,a_k)$ it detects coprimality of the whole tuple."
+    },
+    {
+      "id": "counting",
+      "title": "Counting Multiples and Divisible Tuples",
+      "startLine": 188,
+      "endLine": 231,
+      "summary": "Proves card_multiples: |{m ∈ [1,N] : d|m}| = ⌊N/d⌋ (via an explicit image bijection), and card_tuples_divisible: |{a ∈ [1,N]ᵏ : ∀i, d|aᵢ}| = ⌊N/d⌋ᵏ, the k-dimensional building block, obtained by factoring the piFinset filter coordinate-wise and applying Fintype.card_piFinset_const.",
+      "mathContext": "The count of multiples of $d$ in $[1,N]$ is $\\lfloor N/d\\rfloor$. Independence of the $k$ coordinate divisibility conditions gives $|\\{a\\in[1,N]^k : \\forall i,\\, d\\mid a_i\\}| = \\lfloor N/d\\rfloor^k$ — the only place the exponent $k$ enters the combinatorics."
+    },
+    {
+      "id": "mobius-decomposition",
+      "title": "The Coprime Tuple Count and Möbius Decomposition",
+      "startLine": 233,
+      "endLine": 306,
+      "summary": "Defines countCoprimeTuples(k,N) = |{a ∈ [1,N]ᵏ : gcd(a) = 1}| and proves countCoprimeTuples_moebius: (countCoprimeTuples k N : ℤ) = Σ_{d≤N} μ(d)·⌊N/d⌋ᵏ. The proof rewrites the cardinality as a sum of coprimality indicators, replaces each by Σ_{e|gcd a} μ(e) (Möbius inversion), recasts the inner divisor sum as a sum over e ∈ [1,N] with ∀i, e|aᵢ, then swaps summation order (Finset.sum_comm) and applies card_tuples_divisible.",
+      "mathContext": "$|\\{a\\in[1,N]^k : \\gcd(a)=1\\}| = \\sum_{d=1}^N \\mu(d)\\lfloor N/d\\rfloor^k$ — the central combinatorial identity. Both sides count pairs $(a,d)$ with $a\\in[1,N]^k$ and $d\\mid\\gcd(a)$, weighted by $\\mu(d)$; a finite Fubini exchange swaps the order of summation."
+    },
+    {
+      "id": "dirichlet-series",
+      "title": "The Möbius Dirichlet Series Σ μ(d)/dᵏ = 1/ζ(k)",
+      "startLine": 308,
+      "endLine": 358,
+      "summary": "Proves moebius_dirichlet_series: HasSum (μ(d)/dᵏ) (1/ζ(k)) for k ≥ 2, the key analytic identity. Transfers to ℂ via Complex.hasSum_ofReal, uses LSeries_zeta_mul_Lseries_moebius (L(ζ,k)·L(μ,k)=1) and L(ζ,k) = rZeta k to get L(μ,k) = (rZeta k)⁻¹, then identifies the L-series term with the real summand. tsum_moebius_div_pow records the tsum form.",
+      "mathContext": "$\\sum_{d\\ge 1}\\mu(d)/d^k = 1/\\zeta(k)$, the heart of the analysis. At $s=k$ the Euler-product identity $L(\\zeta,k)\\,L(\\mu,k)=1$ combined with $L(\\zeta,k)=\\zeta(k)$ forces $L(\\mu,k)=1/\\zeta(k)$; the complex HasSum is pulled back to a real one."
+    },
+    {
+      "id": "density-limit",
+      "title": "The Density Limit (Main Theorem)",
+      "startLine": 360,
+      "endLine": 443,
+      "summary": "Proves coprime_tuple_density_limit: lim_{N→∞} countCoprimeTuples(k,N)/Nᵏ = 1/ζ(k) for k ≥ 2. Rewrites the count via the Möbius decomposition as Σ_d μ(d)·(⌊N/d⌋/N)ᵏ (a tsum truncating to [1,N]), shows each term → μ(d)/dᵏ (using nat_div_div_tendsto), bounds the family by the summable 1/dᵏ (|μ| ≤ 1 and ⌊N/d⌋/N ≤ 1/d), and applies Tannery's dominated-convergence theorem.",
+      "mathContext": "$\\lim_{N\\to\\infty} |\\{a\\in[1,N]^k:\\gcd(a)=1\\}|/N^k = 1/\\zeta(k)$. The Möbius decomposition turns the count into $\\sum_d \\mu(d)(\\lfloor N/d\\rfloor/N)^k$; termwise $\\to \\mu(d)/d^k$, dominated by $1/d^k$ (summable for $k\\ge 2$), so Tannery yields the series $1/\\zeta(k)$."
+    },
+    {
+      "id": "consequences",
+      "title": "Density in the Unit Interval",
+      "startLine": 444,
+      "endLine": 461,
+      "summary": "Proves density_pos (0 < 1/ζ(k)), density_lt_one (1/ζ(k) < 1 from ζ(k) > 1), and density_in_unit_interval (1/ζ(k) ∈ (0,1)), establishing the limit as a bona fide probability for every k ≥ 2.",
+      "mathContext": "$0 < 1/\\zeta(k) < 1$ for all $k\\ge 2$, since $\\zeta(k) > 1$. Coprimality of a $k$-tuple is therefore always a genuine, non-degenerate event."
+    },
+    {
+      "id": "pair-consistency",
+      "title": "Consistency with the Pair Case (k = 2)",
+      "startLine": 462,
+      "endLine": 478,
+      "summary": "Cross-checks the generalization: rZeta_two_eq derives rZeta 2 = π²/6 from riemannZeta_two, and density_two_eq concludes 1/ζ(2) = 6/π², matching the coprime-pair density of basel-problem-oq-04-oq-03.",
+      "mathContext": "$\\zeta(2) = \\pi^2/6$ and the $k=2$ density $1/\\zeta(2) = 6/\\pi^2 \\approx 0.6079$, recovering Cesàro's classical constant as the base case of the $k$-tuple family."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 479,
+      "endLine": 503,
+      "summary": "Closing comment block recapitulating Nymann's theorem, the three-step proof architecture (Möbius decomposition → Dirichlet series Σ μ(d)/dᵏ = 1/ζ(k) → density limit via Tannery), the k=2 specialization to 6/π², and the final tally: 0 axioms, 0 sorries.",
+      "mathContext": "Final tally: for every $k\\ge 2$, $\\sum_{d\\ge 1}\\mu(d)/d^k = 1/\\zeta(k)$ and $\\lim_N \\mathrm{countCoprimeTuples}(k,N)/N^k = 1/\\zeta(k)$, fully formalized with no axioms or sorries."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified, axiom-free formal proof that the natural density of coprime k-tuples equals 1/ζ(k) for every integer k ≥ 2 (Nymann 1972), generalizing the Cesàro coprime-pair density 6/π². The combinatorial Möbius decomposition, the Dirichlet-series identity Σ μ(d)/dᵏ = 1/ζ(k), and the density limit (via Tannery's dominated-convergence theorem) are all proved symbolically — no native_decide, 0 axioms, 0 sorries. The k=2 case recovers 6/π², cross-checking against basel-problem-oq-04-oq-03.",
+    "openQuestions": [
+      "Quantitative error term: bound |countCoprimeTuples(k,N) − Nᵏ/ζ(k)|, expected O(Nᵏ⁻¹) for k ≥ 3 (and O(N log N) for k = 2).",
+      "Does the k-tuple coprime density extend to rings of integers of number fields, with limit 1/ζ_K(k) in terms of the Dedekind zeta function?"
+    ],
+    "implications": "The result completes the dimensional generalization of the coprime-density phenomenon: the Riemann zeta value ζ(k) controls the probability that k random integers are collectively coprime, for every k ≥ 2 simultaneously. Carrying ζ(k) symbolically shows the argument is uniform in k and isolates k ≥ 2 as exactly the range where the density exists. As k → ∞ the density tends to 1, quantifying the intuition that high-dimensional integer tuples are almost surely coprime."
+  },
+  "crossReferences": [
+    {
+      "proofId": "basel-problem-oq-04-oq-03",
+      "relationship": "parent",
+      "description": "Parent: the coprime-pair density 1/ζ(2) = 6/π² (Cesàro 1885) — this entry is the k-tuple generalization, recovering it as the k=2 case (density_two_eq)"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "foundational-for",
+      "description": "The Basel identity ζ(2) = π²/6 is the analytic ingredient of the k=2 specialization"
+    },
+    {
+      "targetId": "basel-problem-oq-04",
+      "relationship": "related",
+      "description": "Euler product ∏_p (1 − p⁻ᵏ) = 1/ζ(k) gives the probabilistic 'independence over primes' reading of the density"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction",
+      "Mathlib.NumberTheory.LSeries.RiemannZeta",
+      "Mathlib.NumberTheory.LSeries.HurwitzZetaValues",
+      "Mathlib.NumberTheory.EulerProduct.DirichletLSeries",
+      "Mathlib.Algebra.GCDMonoid.Finset",
+      "Mathlib.Data.Fintype.Pi",
+      "Mathlib.Data.Fintype.BigOperators",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.Order",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Analysis.Normed.Group.Tannery",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Finset",
+      "BigOperators",
+      "Real",
+      "Nat",
+      "ArithmeticFunction"
+    ],
+    "namespace": "CoprimeKTupleDensity",
+    "lineCount": 503,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/CoprimeKTupleDensity.lean"
+  }
+}

--- a/src/data/research/problems/basel-problem-oq-04-oq-03-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-04-oq-03-oq-01.json
@@ -1,0 +1,492 @@
+{
+  "slug": "basel-problem-oq-04-oq-03-oq-01",
+  "title": "k-tuple coprimality density: Pr[gcd(a₁,…,a_k)=1] → 1/ζ(k) for k ≥ 3",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Generalize to k-tuples: does Pr[gcd(a₁,…,a_k)=1] → 1/ζ(k) for k ≥ 3, reusing the same Möbius-decomposition + Dirichlet-series argument?.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T19:46:54.765Z",
+    "iteration": 1,
+    "focus": "Coprime k-tuple density fully formalized and integrated into the gallery.",
+    "blockers": [],
+    "nextAction": "None - entry complete (verified, 0 sorry / 0 axiom).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: density of coprime k-tuples → 1/zeta(k) for all k >= 2 fully formalized AND DOCKER-VERIFIED (CoprimeKTupleDensity.lean, 497L, 0 sorry / 0 axiom, no native_decide). Integrated into gallery as basel-problem-oq-04-oq-03-oq-01 (meta.json + annotations.json).",
+    "builtItems": [
+      "coprime_tuple_density_limit (CoprimeKTupleDensity.lean): MAIN - lim countCoprimeTuples(k,N)/N^k = 1/zeta(k) for k>=2, axiom-free",
+      "countCoprimeTuples_moebius: Mobius decomposition sum_{d<=N} mu(d)floor(N/d)^k",
+      "card_tuples_divisible: |{a in [1,N]^k : forall i, d|a_i}| = floor(N/d)^k",
+      "moebius_dirichlet_series: HasSum sum mu(d)/d^k = 1/zeta(k) (k>=2)",
+      "rZeta + rZeta_pos/one_lt_rZeta/riemannZeta_nat_eq_ofReal_rZeta; density_pos/density_lt_one/density_in_unit_interval; rZeta_two_eq/density_two_eq"
+    ],
+    "insights": [
+      "BUILD-FIX (researcher-10, 2026-06-26): the orphan file (researcher-8) was NEVER compiled — \"0 sorry/0 axiom\" was only a grep count. Docker build revealed ~11 Mathlib version-drift errors masked by earlier `tail`-truncated logs: (a) Nat.div_add_mod arg order flipped (d*(N/d) not (N/d)*d) → derive via Nat.mul_comm; (b) `(N % d : ℝ)` mis-parsed as REAL modulo ↑N%↑d → force ((N%d:ℕ):ℝ); (c) deprecated/renamed lemmas div_lt_iff→div_lt_iff₀, div_le_div_iff→div_le_div_iff₀, pow_le_pow_left→pow_le_pow_left₀, sum_le_tsum→sum_le_hasSum (with .hasSum); (d) `simp [map_zero]` ambiguous (ArithmeticFunction opened); (e) wrong rewrite dir `←hcast`→`hcast`; (f) hfun ℂ-division vs ofReal-of-real cast mismatch → force (… : ℝ) ascription; (g) `.symm` dot-notation failed on Eventually head → Filter.EventuallyEq.symm; (h) brittle `apply eventually_atTop.mpr ⟨1,fun N hN d=>?_⟩` for h_bound → filter_upwards [eventually_ge_atTop 1]; (i) redundant closing tactics → \"No goals\". Docker-VERIFIED 0 sorry/0 axiom/0 native_decide at 503L, status=verified. Lesson: grep counts NEVER imply buildability; the sibling k=2 file BaselProblemOQ04OQ03 shares several of these and would also fail to rebuild now.",
+      "The k-tuple density 1/zeta(k) needs only one structural change from the pair case: replace floor(N/d)^2 by floor(N/d)^k; Fintype.card_piFinset_const factors the divisible-tuple count over the k coordinates.",
+      "No closed form for zeta(k) is required - carry it symbolically as rZeta k = tsum 1/n^k; the L-series identity L(zeta,k)*L(mu,k)=1 with L(zeta,k)=zeta(k) pins sum mu(d)/d^k = 1/zeta(k).",
+      "Tannery (tendsto_tsum_of_dominated_convergence) with dominator 1/d^k (summable iff k >= 2, summable_one_div_nat_pow) upgrades the finite Mobius sum to the infinite series - the k>=2 hypothesis is exactly the convergence range.",
+      "0 < 1/zeta(k) < 1 for all k >= 2 since zeta(k) > 1 + 2^-k (one_lt_rZeta); density_two_eq recovers the Basel pair density 6/pi^2."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Quantitative error term: bound |countCoprimeTuples(k,N) - N^k/zeta(k)| (O(N^{k-1}) for k>=3).",
+      "Extend to rings of integers of number fields with 1/zeta_K(k).",
+      "Package the Mobius-decomposition + Tannery template as a reusable Mathlib density lemma."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "coprimality",
+    "zeta-function",
+    "mobius",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "basel-problem",
+    "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-03",
+    "basel-problem-oq-01-oq-01-oq-03",
+    "basel-problem-oq-01-oq-03",
+    "basel-problem-oq-01-oq-05",
+    "basel-problem-oq-02",
+    "basel-problem-oq-03",
+    "basel-problem-oq-03-oq-01",
+    "basel-problem-oq-04",
+    "basel-problem-oq-04-oq-03",
+    "basel-problem-oq-05",
+    "basel-problem-oq-05-oq-03",
+    "basel-problem-oq-08",
+    "basel-problem-oq-08-oq-02",
+    "basel-problem-oq-08-oq-02-oq-01",
+    "basel-problem-oq-09",
+    "basel-problem-oq-09-oq-01",
+    "basel-problem-oq-10",
+    "basel-problem-oq-10-oq-01",
+    "basel-problem-oq-11",
+    "basel-problem-oq-11-oq-01",
+    "basel-problem-oq-12",
+    "basel-problem-oq-13",
+    "basel-problem-oq-13-oq-01",
+    "basel-problem-oq-14",
+    "basel-problem-oq-14-oq-01",
+    "basel-problem-oq-15"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T19:46:54.765Z",
+  "lastUpdate": "2026-06-26 (researcher-10: fixed 4 build errors, Docker-verified, integrated into gallery)",
+  "significance": 7,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BaselProblem.lean",
+      "filename": "BaselProblem.lean",
+      "lineCount": 165,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblem.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01.lean",
+      "lineCount": 145,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02.lean",
+      "lineCount": 953,
+      "theoremCount": 46,
+      "axiomCount": 5,
+      "defCount": 9,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "lineCount": 206,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 142,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+      "lineCount": 159,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ02.lean",
+      "lineCount": 973,
+      "theoremCount": 37,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ03.lean",
+      "lineCount": 1803,
+      "theoremCount": 74,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ01OQ03.lean",
+      "lineCount": 182,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ05.lean",
+      "filename": "BaselProblemOQ01OQ05.lean",
+      "lineCount": 194,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ05.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ02.lean",
+      "filename": "BaselProblemOQ02.lean",
+      "lineCount": 349,
+      "theoremCount": 19,
+      "axiomCount": 5,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ02Aristotle.lean",
+      "filename": "BaselProblemOQ02Aristotle.lean",
+      "lineCount": 96,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ03.lean",
+      "filename": "BaselProblemOQ03.lean",
+      "lineCount": 178,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ03OQ01.lean",
+      "filename": "BaselProblemOQ03OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ04.lean",
+      "filename": "BaselProblemOQ04.lean",
+      "lineCount": 108,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ04.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ04OQ03.lean",
+      "filename": "BaselProblemOQ04OQ03.lean",
+      "lineCount": 559,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ05.lean",
+      "filename": "BaselProblemOQ05.lean",
+      "lineCount": 190,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ05.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ05OQ03.lean",
+      "filename": "BaselProblemOQ05OQ03.lean",
+      "lineCount": 167,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ05OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08.lean",
+      "filename": "BaselProblemOQ08.lean",
+      "lineCount": 48,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08OQ02.lean",
+      "filename": "BaselProblemOQ08OQ02.lean",
+      "lineCount": 77,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08OQ02OQ01.lean",
+      "filename": "BaselProblemOQ08OQ02OQ01.lean",
+      "lineCount": 99,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ09.lean",
+      "filename": "BaselProblemOQ09.lean",
+      "lineCount": 149,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ09.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ0901.lean",
+      "filename": "BaselProblemOQ0901.lean",
+      "lineCount": 190,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ0901.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ09OQ01.lean",
+      "filename": "BaselProblemOQ09OQ01.lean",
+      "lineCount": 193,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ09OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ10.lean",
+      "filename": "BaselProblemOQ10.lean",
+      "lineCount": 94,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ10.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ10OQ01.lean",
+      "filename": "BaselProblemOQ10OQ01.lean",
+      "lineCount": 135,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ10OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ11.lean",
+      "filename": "BaselProblemOQ11.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ11.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ11OQ01.lean",
+      "filename": "BaselProblemOQ11OQ01.lean",
+      "lineCount": 156,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ11OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ12.lean",
+      "filename": "BaselProblemOQ12.lean",
+      "lineCount": 78,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ12.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ13.lean",
+      "filename": "BaselProblemOQ13.lean",
+      "lineCount": 86,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ13.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ13OQ01.lean",
+      "filename": "BaselProblemOQ13OQ01.lean",
+      "lineCount": 111,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ13OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ14.lean",
+      "filename": "BaselProblemOQ14.lean",
+      "lineCount": 114,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ14.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ14OQ01.lean",
+      "filename": "BaselProblemOQ14OQ01.lean",
+      "lineCount": 167,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ14OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ15.lean",
+      "filename": "BaselProblemOQ15.lean",
+      "lineCount": 91,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ15.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry **basel-problem-oq-04-oq-03-oq-01**: the natural density of coprime *k*-tuples of positive integers equals **1/ζ(k)** for every integer *k ≥ 2* (Nymann 1972), generalizing the classical Cesàro coprime-pair density 6/π² = 1/ζ(2) to arbitrary dimension.

Main theorem `coprime_tuple_density_limit`:
$$\lim_{N\to\infty}\frac{|\{a\in[1,N]^k:\gcd(a)=1\}|}{N^k} = \frac{1}{\zeta(k)},\quad k\ge 2.$$

### Proof architecture (faithful k-dimensional generalization of the k=2 Basel development)
1. **Möbius decomposition** — `countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)⌊N/d⌋ᵏ` via a finite Fubini exchange; the only structural change from the pair case is `⌊N/d⌋²  → ⌊N/d⌋ᵏ` (`Fintype.card_piFinset_const`).
2. **Dirichlet series** — `Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k)` from `LSeries_zeta_mul_Lseries_moebius`, with ζ(k) carried symbolically as `rZeta k = Σ' 1/nᵏ` (no closed form needed → uniform in k).
3. **Density limit** — Tannery's dominated-convergence theorem with dominator `1/dᵏ`, summable exactly for k ≥ 2.

The k=2 specialization recovers ζ(2)=π²/6 and density 6/π² (`density_two_eq`), cross-checking against `basel-problem-oq-04-oq-03`.

## Provenance / repair

The Lean file existed as an **untracked orphan** from a prior agent that was **never compiled** — its "0 sorry / 0 axiom" was only a grep count. The Docker build surfaced ~11 Mathlib version-drift errors (previously masked by `tail`-truncated logs), all fixed:
- `Nat.div_add_mod` argument order flipped; `(N % d : ℝ)` mis-parsed as *real* modulo
- renamed lemmas: `div_lt_iff→div_lt_iff₀`, `div_le_div_iff→div_le_div_iff₀`, `pow_le_pow_left→pow_le_pow_left₀`, `sum_le_tsum→sum_le_hasSum`
- ambiguous `simp [map_zero]`, wrong rewrite direction, ℂ-vs-`ofReal` cast mismatch, `EventuallyEq.symm` dot-notation, brittle `eventually_atTop` idiom → `filter_upwards`, redundant closing tactics

## Verification

**Docker-built clean** (`docker-build.sh Proofs.CoprimeKTupleDensity`, 3288 jobs):
- **0 sorries, 0 `axiom` declarations, 0 `native_decide`** → genuinely `verified` / `badge: verified` / `axiomCount: 0`
- 503 lines, 17 theorems/lemmas, 2 definitions

## Files
- `proofs/Proofs/CoprimeKTupleDensity.lean` (new, verified)
- `proofs/Proofs.lean` (register import)
- `src/data/proofs/basel-problem-oq-04-oq-03-oq-01/{meta,annotations}.json` (gallery)
- `src/data/research/problems/basel-problem-oq-04-oq-03-oq-01.json` (research record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)