### PR TITLE
Enrich ∞/∞ L'Hôpital growth limits (lhopital-oq-02-incomplete-01): annotation depth

### DIFF
--- a/src/data/proofs/lhopital-oq-02-incomplete-01/annotations.json
+++ b/src/data/proofs/lhopital-oq-02-incomplete-01/annotations.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "lhop02inc-ann-strategy",
+    "proofId": "lhopital-oq-02-incomplete-01",
+    "range": {
+      "startLine": 6,
+      "endLine": 58
+    },
+    "type": "context",
+    "title": "Putting the ∞/∞ rule to work: the corollary recipe",
+    "content": "The docstring explains the entry's role. The parent (LHopitalOQ02) supplies the ∞/∞ form of L'Hôpital's rule — content Mathlib lacks, since its 26 L'Hôpital variants cover only the 0/0 form — but states it abstractly. This leaf derives three classic growth-comparison limits as direct corollaries of LHopitalInfty.lhopital_infty_atTop. The uniform recipe for each indeterminate f/g with g → +∞: supply the derivatives f', g', check g' ≠ 0, verify g → atTop, and compute the elementary limit of f'/g'; the parent rule then delivers the conclusion. Two limits exercise the c = 0 case and one the general c ≠ 0 case, confirming the rule is not silently specialised to vanishing ratios.",
+    "mathContext": "L'Hôpital (∞/∞): if $f,g$ are differentiable, $g(x)\\to\\infty$, $g'\\ne 0$, and $\\frac{f'(x)}{g'(x)}\\to c$, then $\\frac{f(x)}{g(x)}\\to c$. The three corollaries use $(f,g) = (\\ln, \\mathrm{id})$, $(\\mathrm{id}, \\exp)$, $(\\mathrm{id}+\\ln, \\mathrm{id})$ with limits $0, 0, 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "L'Hôpital's rule (∞/∞ form)",
+      "indeterminate forms",
+      "growth comparison / asymptotic dominance",
+      "Filter.Tendsto atTop"
+    ],
+    "prerequisites": [
+      "derivatives and HasDerivAt",
+      "limits along the atTop filter",
+      "the parent ∞/∞ rule LHopitalInfty.lhopital_infty_atTop"
+    ]
+  },
+  {
     "id": "lhop02inc-ann-01",
     "proofId": "lhopital-oq-02-incomplete-01",
     "range": {
@@ -9,7 +33,18 @@
     "type": "result",
     "title": "(ln x)/x → 0 from the ∞/∞ rule",
     "content": "log_div_id_atTop instantiates the parent's LHopitalInfty.lhopital_infty_atTop with f = log, g = id. The derivative hypotheses are Real.hasDerivAt_log (ne_of_gt hx) (giving f' x = x⁻¹ on Ioi 0) and hasDerivAt_id' (giving g' = 1). The denominator derivative 1 is nonzero, g = id diverges (tendsto_id), and the easy ratio f'/g' = x⁻¹/1 → 0 is supplied by tendsto_inv_atTop_zero (after a `simpa` to clear the /1). The parent rule then returns (log x)/x → 0.",
-    "mathContext": "$\\lim_{x\\to\\infty}\\frac{\\ln x}{x}=0$: the logarithm grows slower than the identity (the $c=0$ case)."
+    "mathContext": "$\\lim_{x\\to\\infty}\\frac{\\ln x}{x}=0$: the logarithm grows slower than the identity (the $c=0$ case).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.hasDerivAt_log",
+      "tendsto_inv_atTop_zero",
+      "logarithmic growth rate",
+      "derivative of log is x⁻¹"
+    ],
+    "prerequisites": [
+      "derivative of the natural logarithm",
+      "x⁻¹ → 0 as x → +∞"
+    ]
   },
   {
     "id": "lhop02inc-ann-02",
@@ -21,7 +56,18 @@
     "type": "result",
     "title": "x/eˣ → 0: exponential dominance",
     "content": "id_div_exp_atTop uses f = id, g = exp. Derivatives come from hasDerivAt_id' (f' = 1) and Real.hasDerivAt_exp (g' x = eˣ). The denominator derivative eˣ is nonzero via (Real.exp_pos x).ne', and g = exp diverges by Real.tendsto_exp_atTop. The auxiliary ratio f'/g' = 1/eˣ = (eˣ)⁻¹ → 0 is obtained by composing tendsto_inv_atTop_zero with Real.tendsto_exp_atTop and rewriting 1/eˣ via one_div. The parent rule yields x/eˣ → 0 — the canonical ∞/∞ example the parent file only mentioned in commentary.",
-    "mathContext": "$\\lim_{x\\to\\infty}\\frac{x}{e^x}=0$: the exponential dominates the identity (the $c=0$ case)."
+    "mathContext": "$\\lim_{x\\to\\infty}\\frac{x}{e^x}=0$: the exponential dominates the identity (the $c=0$ case).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.hasDerivAt_exp",
+      "Real.tendsto_exp_atTop",
+      "exponential dominates polynomials",
+      "Filter.Tendsto.comp"
+    ],
+    "prerequisites": [
+      "derivative of exp is exp",
+      "exp x → +∞ and (exp x)⁻¹ → 0"
+    ]
   },
   {
     "id": "lhop02inc-ann-03",
@@ -33,6 +79,17 @@
     "type": "technique",
     "title": "(x + ln x)/x → 1: the nonzero-limit case",
     "content": "id_add_log_div_id_atTop exercises the general c ≠ 0 form with f = x + log x, g = id. The derivative of f is assembled by (hasDerivAt_id' x).add (Real.hasDerivAt_log (ne_of_gt hx)), giving f' x = 1 + x⁻¹; g' = 1. The ratio f'/g' = 1 + x⁻¹ → 1 + 0 = 1 via tendsto_const_nhds.add tendsto_inv_atTop_zero (a `simpa` normalizes 1 + 0 to 1). With g = id → +∞, the parent rule returns (x + log x)/x → 1, confirming the theorem handles a genuinely nonzero target limit rather than only vanishing ratios.",
-    "mathContext": "$\\lim_{x\\to\\infty}\\frac{x+\\ln x}{x}=1$: the leading term $x$ dominates (the general $c\\ne 0$ case, here $c=1$)."
+    "mathContext": "$\\lim_{x\\to\\infty}\\frac{x+\\ln x}{x}=1$: the leading term $x$ dominates (the general $c\\ne 0$ case, here $c=1$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasDerivAt.add",
+      "tendsto_const_nhds",
+      "nonzero limit form of L'Hôpital",
+      "sum rule for derivatives"
+    ],
+    "prerequisites": [
+      "derivative of a sum",
+      "limit of a sum (1 + x⁻¹ → 1)"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lhopital-oq-02-incomplete-01` (quality 65, pass 0). (Despite the legacy 'incomplete' id, the entry is verified: 0 sorries, 0 axioms, badge original.)

## Changes
- **Annotation fields:** The 3 existing annotations had only content + mathContext. Added significance, relatedConcepts, prerequisites to each (logarithmic/exponential growth rates, the relevant Mathlib derivative + tendsto lemmas, the c=0 vs c≠0 distinction).
- **Coverage (+1 annotation):** Added lhop02inc-ann-strategy covering the docstring/proof-strategy section (lines 6-58, the uniform 'supply f', g', check g'≠0, compute f'/g'' recipe), previously uncovered.

## Verification
- `pnpm build` passes (exit 0)
- 4 annotations, all with mathContext/significance/relatedConcepts/prerequisites
- No meta.json changes; verified/original/axiomCount:0 untouched (matches Lean: 0 sorries, 0 axioms, 3 theorems)