### PR TITLE
fix(research): exclude skipped problems from claim-random

### DIFF
--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -307,7 +307,7 @@ claim_random_problem() {
         score=$(get_knowledge_score "$problem_id")
         available+=("$problem_id")
         scores+=("$score")
-    done < <(jq -r '.candidates[] | select(.status != "completed" and .status != "blocked" and .status != "graduated") | .id' "$POOL_FILE" 2>/dev/null)
+    done < <(jq -r '.candidates[] | select(.status != "completed" and .status != "blocked" and .status != "graduated" and .status != "skipped") | .id' "$POOL_FILE" 2>/dev/null)
 
     if [[ ${#available[@]} -eq 0 ]]; then
         echo "No available problems to claim" >&2


### PR DESCRIPTION
## Summary
`scripts/research/claim-problem.sh` `claim-random` filters the candidate pool with `select(.status != "completed" and .status != "blocked" and .status != "graduated")` — it never excluded `"skipped"`. All 26 skipped problems therefore remained claimable, and because the selector is depth-first (prioritizing MODERATE+ knowledge), subsumed follow-ups with accumulated knowledge sat in **tier 1** and got handed out first.

This wasted researcher cycles on known-dead work. Two concrete examples hit this session:
- `ballot-problem-oq-04-oq-01` — its Finpartition non-crossing model is already delivered by the merged sibling `ballot-problem-oq-04-oq-02` (verified, 0 sorries).
- `triangle-angle-sum-oq-07` — `sin x + sin y = 2·sin((x+y)/2)·cos((x−y)/2)` is already proven as `theorem sin_add_sin` (line 79) in the merged `triangle-angle-sum-oq-06` entry, which is explicitly titled "OQ-06/07".

## Change
One-line filter addition: `and .status != "skipped"`.

After the fix, the local pool's available count drops 379 → 353 (the 26 skipped entries) and selection advances past the dead tier-1 problem to genuinely open work (verified by re-running `claim-random`).

## Status
**Outcome**: fix (infrastructure) + pool hygiene (marked `triangle-angle-sum-oq-07` skipped with a subsumption note; `ballot-problem-oq-04-oq-01` was already skipped).
**Next Steps**: none required.

🤖 Generated by researcher-8