### PR TITLE
Enrich solution-of-cubic-oq-01-oq-01: add index.ts, fix invisible annotations

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
@@ -1,46 +1,62 @@
 [
   {
+    "id": "ann-soc-oq0101-defs",
+    "proofId": "solution-of-cubic-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 70 },
+    "type": "definition",
+    "title": "The General and Depressed Discriminants",
+    "content": "Two definitions set the stage. generalDiscriminant a b c d = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² is the classical discriminant of the general cubic a x³ + b x² + c x + d, written as a polynomial in its four coefficients. depressedDisc p q = −4p³ − 27q² is the standard discriminant of the depressed cubic t³ + p t + q. These are the two objects the file relates; note the depressed form differs from the parent's Cardano discriminant q²/4 + p³/27 by the constant factor −108, reconciled later.",
+    "mathContext": "$\\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2$; depressed: $-4p^3 - 27q^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["discriminant of a polynomial", "depressed cubic", "Tschirnhaus transformation"],
+    "prerequisites": ["polynomial coefficients", "cubic equations"]
+  },
+  {
     "id": "ann-soc-oq0101-shift",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 85,
-      "endLine": 90
-    },
+    "range": { "startLine": 85, "endLine": 90 },
     "type": "insight",
     "title": "The Discriminant under the Tschirnhaus Shift",
-    "body": "general_discriminant_eq_shift is the central identity: Δ(a,b,c,d) = a⁴·(−4p³ − 27q²). It packages two facts true in any degree. First, translation invariance: the depressed cubic t³ + pt + q has exactly the same root differences as the original (the shift x = t − b/(3a) adds the same constant to every root), so its monic discriminant −4p³ − 27q² already captures the root-difference data. Second, the leading-coefficient scaling a^(2n−2) = a⁴ for n = 3. The proof unfolds p, q (with their denominators 3a² and 27a³), clears them with field_simp under a ≠ 0, and closes with ring."
+    "content": "general_discriminant_eq_shift is the central identity: Δ(a,b,c,d) = a⁴·(−4p³ − 27q²). It packages two facts true in any degree. First, translation invariance: the depressed cubic t³ + pt + q has exactly the same root differences as the original (the shift x = t − b/(3a) adds the same constant to every root), so its monic discriminant −4p³ − 27q² already captures the root-difference data. Second, the leading-coefficient scaling a^(2n−2) = a⁴ for n = 3. The proof unfolds p, q (with their denominators 3a² and 27a³), clears them with field_simp under a ≠ 0, and closes with ring.",
+    "mathContext": "$\\Delta(a,b,c,d) = a^4\\,(-4p^3 - 27q^2)$, with $p = \\dfrac{3ac-b^2}{3a^2},\\; q = \\dfrac{2b^3 - 9abc + 27a^2d}{27a^3}$. The factor $a^4 = a^{2\\cdot 3 - 2}$ is the discriminant's scaling under a leading coefficient.",
+    "significance": "critical",
+    "relatedConcepts": ["translation invariance", "discriminant scaling a^(2n-2)", "depressed cubic", "field_simp"],
+    "prerequisites": ["Tschirnhaus shift x = t − b/(3a)", "field arithmetic with a ≠ 0", "ring tactic"]
   },
   {
     "id": "ann-soc-oq0101-cardano-bridge",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 100,
-      "endLine": 113
-    },
+    "range": { "startLine": 100, "endLine": 113 },
     "type": "insight",
     "title": "Two Discriminants Differ by −108",
-    "body": "The parent uses Δ_C = q²/4 + p³/27, the quantity under the square root in Cardano's formula. The standard polynomial discriminant is −4p³ − 27q² = −108·Δ_C. The factor −108 is nonzero, so the two notions vanish together and carry the same repeated-root information; depressedDisc_eq_cardano makes this precise and general_discriminant_eq_cardano lifts it to Δ = −108·a⁴·Δ_C — the explicit bridge the parent's open question asked for."
+    "content": "The parent uses Δ_C = q²/4 + p³/27, the quantity under the square root in Cardano's formula. The standard polynomial discriminant is −4p³ − 27q² = −108·Δ_C. The factor −108 is nonzero, so the two notions vanish together and carry the same repeated-root information; depressedDisc_eq_cardano makes this precise and general_discriminant_eq_cardano lifts it to Δ = −108·a⁴·Δ_C — the explicit bridge the parent's open question asked for.",
+    "mathContext": "$-4p^3 - 27q^2 = -108\\left(\\dfrac{q^2}{4} + \\dfrac{p^3}{27}\\right)$, hence $\\Delta(a,b,c,d) = -108\\,a^4\\,\\Delta_C$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardano discriminant", "radicand of Cardano's formula", "normalization constant"],
+    "prerequisites": ["depressed discriminant", "Cardano's formula", "ring tactic"]
   },
   {
     "id": "ann-soc-oq0101-zero-iff",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 122,
-      "endLine": 132
-    },
+    "range": { "startLine": 122, "endLine": 132 },
     "type": "technique",
     "title": "a⁴ ≠ 0 Transfers the Vanishing Condition",
-    "body": "general_discriminant_eq_zero_iff shows Δ = 0 ⟺ −4p³ − 27q² = 0. From Δ = a⁴·depressedDisc, mul_eq_zero splits a product into a⁴ = 0 ∨ depressedDisc = 0; pow_ne_zero 4 ha kills the first disjunct because a ≠ 0 in the field ℂ, leaving depressedDisc = 0. The shift moves the roots but preserves the condition that two of them collide."
+    "content": "general_discriminant_eq_zero_iff shows Δ = 0 ⟺ −4p³ − 27q² = 0. From Δ = a⁴·depressedDisc, mul_eq_zero splits a product into a⁴ = 0 ∨ depressedDisc = 0; pow_ne_zero 4 ha kills the first disjunct because a ≠ 0 in the field ℂ, leaving depressedDisc = 0. The shift moves the roots but preserves the condition that two of them collide.",
+    "mathContext": "$a^4\\,D = 0 \\wedge a \\neq 0 \\iff D = 0$ over the field $\\mathbb{C}$ (no zero divisors): the repeated-root locus is shift-invariant.",
+    "significance": "supporting",
+    "relatedConcepts": ["mul_eq_zero", "pow_ne_zero", "no zero divisors", "repeated-root locus"],
+    "prerequisites": ["fields have no zero divisors", "a ≠ 0 ⟹ a⁴ ≠ 0"]
   },
   {
     "id": "ann-soc-oq0101-root-form",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 146,
-      "endLine": 176
-    },
+    "range": { "startLine": 146, "endLine": 176 },
     "type": "insight",
     "title": "Symmetric Root Form and the Repeated-Root Criterion",
-    "body": "generalDiscriminant_eq_root_form substitutes the Vieta expressions b = −a·σ₁, c = a·σ₂, d = −a·σ₃ and lets ring verify Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))². Exposing Δ as a square (up to a⁴) makes repeated_root_iff immediate: over ℂ a product of differences squared is zero iff one difference is zero, i.e. two roots coincide — proved by chaining sq_eq_zero_iff, mul_eq_zero, and sub_eq_zero."
+    "content": "generalDiscriminant_eq_root_form substitutes the Vieta expressions b = −a·σ₁, c = a·σ₂, d = −a·σ₃ and lets ring verify Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))². Exposing Δ as a square (up to a⁴) makes repeated_root_iff immediate: over ℂ a product of differences squared is zero iff one difference is zero, i.e. two roots coincide — proved by chaining sq_eq_zero_iff, mul_eq_zero, and sub_eq_zero.",
+    "mathContext": "$\\Delta = a^4\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^2$; hence $\\Delta = 0 \\iff x_1=x_2 \\vee x_1=x_3 \\vee x_2=x_3$. Vieta: $b=-a\\sigma_1,\\,c=a\\sigma_2,\\,d=-a\\sigma_3$.",
+    "significance": "key",
+    "relatedConcepts": ["Vieta's formulas", "symmetric functions of roots", "product of root differences", "sq_eq_zero_iff"],
+    "prerequisites": ["Vieta substitution", "ring tactic", "sub_eq_zero / mul_eq_zero"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/index.ts
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SolutionOfCubicOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const solutionOfCubicOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const solutionOfCubicOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const solutionOfCubicOq01Oq01Data: ProofData = {
+  proof: solutionOfCubicOq01Oq01Proof,
+  annotations: solutionOfCubicOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-01` (discriminant of the general cubic under the Tschirnhaus shift).

**Two correctness fixes:**
1. `index.ts` was missing — the page renders 'proof not found' on the live site without it. Created per sibling convention (`solutionOfCubicOq01Oq01*` exports, `SolutionOfCubicOQ01OQ01.lean?raw`).
2. **Annotations rendered empty**: all 4 used a `body` key, but the renderer (`AnnotationPanel.tsx`) reads `annotation.content` — so their text never displayed. Renamed `body`→`content` throughout.

**Annotation depth:** added `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` to every annotation (none had them) and added a definitions annotation (Part 1, the two discriminant defs) for 5 total.

meta.json was already structurally complete (description, overview, 6 sections, conclusion) and left as-is. `pnpm build` passes; JSON validates.