### PR TITLE
audit: confirm abel-ruffini-oq-04-oq-01-oq-02 clean (Galois group of irreducible poly = transitive subgroup of Sₙ)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24871,6 +24871,12 @@
       "lastAudited": "2026-06-27T03:45:05Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T03:52:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: abel-ruffini-oq-04-oq-01-oq-02 — *The Galois group of an irreducible polynomial is a transitive subgroup of S_n*
**Lean**: `proofs/Proofs/AbelRuffiniOQ04OQ01OQ02.lean`

Re-audit of stalest entry. Queue otherwise fully drained (4007/4007, 0 issues).

### Verified meta.json ↔ source match
| Field | meta.json | source | ✓ |
|-------|-----------|--------|---|
| status | verified | — | ✓ |
| badge | original | — | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axiom, 0 structure assumptions | ✓ |
| theoremCount | 2 | 2 (`galActionHom_range_isPretransitive`, `natDegree_dvd_card`) | ✓ |
| definitionCount | 1 | 1 (`galMulEquivRange`) | ✓ |
| lineCount | 107 | 107 | ✓ |

### Tier review — `original` defensible, no delegation opacity
The core transitivity fact is **Mathlib's `galAction_isPretransitive`**, and the entry credits it everywhere: `assumptions`, `mathlibDependencies`, `description`, `overview`, and the file docstring (line 53: "Mathlib's galAction_isPretransitive gives transitivity… this transports it to the realised permutation subgroup").

The file's own named results are genuine, not re-exports:
1. **`galActionHom_range_isPretransitive`** — transports transitivity from the abstract `p.Gal`-action to the *realised* range subgroup `(galActionHom p E).range ≤ Perm (rootSet)` (real transport proof, lines 60–67) — a distinct statement, the precise "transitive subgroup of Sₙ" the sibling consumes as a hypothesis.
2. **`galMulEquivRange`** — packages `MonoidHom.ofInjective (galActionHom_injective)` (honestly described as packaging).
3. **`natDegree_dvd_card`** — `p.natDegree ∣ Nat.card p.Gal` for *every* irreducible `p` in char 0: a **strict generalization** of Mathlib's `prime_degree_dvd_card` (prime degree only) — content Mathlib does not have.

No forbidden Tier-B language; `originalContributions` scoped accurately. No overclaim. No action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)