### PR TITLE
Enrich cubic discriminant sign-test (solution-of-cubic-oq-01-oq-02): fix annotation schema + depth

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -8,7 +8,20 @@
     },
     "type": "insight",
     "title": "Three Distinct Real Roots Force Δ > 0",
-    "body": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters."
+    "content": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters. The Lean proof rewrites with realDiscriminant_eq_root_form and closes by `positivity` once the product is shown nonzero.",
+    "mathContext": "$\\Delta = a^4\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^2$. Over $\\mathbb{R}$ a square is $\\ge 0$, and $>0$ iff its base is nonzero; distinctness of the roots makes each factor $x_i-x_j\\ne 0$, so $\\Delta>0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant of a cubic",
+      "Vandermonde product ∏(xᵢ−xⱼ)",
+      "positivity tactic",
+      "ordered field structure of ℝ"
+    ],
+    "prerequisites": [
+      "the symmetric root form of the discriminant",
+      "squares are nonnegative in an ordered field",
+      "a ≠ 0 ⟹ a⁴ > 0"
+    ]
   },
   {
     "id": "ann-soc-oq0102-conjpair",
@@ -19,7 +32,21 @@
     },
     "type": "insight",
     "title": "The Conjugate-Pair Case is a Real Ring Identity",
-    "body": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity reads off Δ < 0 — the second leg of the discriminant test."
+    "content": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one `ring` call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity reads off Δ < 0 — the second leg of the discriminant test (realDiscriminant_neg_of_conj_pair closes by nlinarith on the positive product).",
+    "mathContext": "$\\Delta = -4a^4 n^2\\big((r-m)^2+n^2\\big)^2$. Each factor $a^4, n^2, ((r-m)^2+n^2)^2$ is positive when $a,n\\ne 0$, so the leading $-4$ forces $\\Delta<0$. The negativity originates from $(w-\\bar w)^2 = (2ni)^2 = -4n^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex conjugate roots",
+      "Vieta's formulas",
+      "ring tactic (polynomial identity)",
+      "nlinarith",
+      "(w − w̄)² = −4n²"
+    ],
+    "prerequisites": [
+      "Vieta coefficients of r, m±ni",
+      "polynomial identities over ℝ",
+      "sign reasoning from a product of positives"
+    ]
   },
   {
     "id": "ann-soc-oq0102-bridge",
@@ -28,9 +55,22 @@
       "startLine": 186,
       "endLine": 204
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Casting Back to Certify the Conjugate Pair",
-    "body": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization."
+    "content": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and `ring` closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization.",
+    "mathContext": "Bridge: $(\\Delta_{\\mathbb{R}} : \\mathbb{C}) = a^4\\big((r-w)(r-\\bar w)(w-\\bar w)\\big)^2$ with $w=m+ni$. The cast $\\mathbb{R}\\to\\mathbb{C}$ is a ring hom, so the real identity transports; componentwise $\\mathrm{re}/\\mathrm{im}$ checks confirm the Vieta data matches the complex roots $r,w,\\bar w$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ℝ → ℂ ring homomorphism cast",
+      "Complex.ext (componentwise equality)",
+      "starRingEnd / complex conjugation",
+      "generalDiscriminant_eq_root_form (sibling)"
+    ],
+    "prerequisites": [
+      "the sibling's complex root form of the discriminant",
+      "real/imaginary part simp lemmas (ofReal_re, ofReal_im)",
+      "casting real polynomials into ℂ"
+    ]
   },
   {
     "id": "ann-soc-oq0102-trichotomy",
@@ -41,6 +81,18 @@
     },
     "type": "insight",
     "title": "One Cubic in Each Regime",
-    "body": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0."
+    "content": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0, each verified by `norm_num` after unfolding realDiscriminant.",
+    "mathContext": "Trichotomy worked out: $\\Delta(x^3-x)=4>0$ (roots $0,\\pm1$); $\\Delta(x^3+x)=-4<0$ (root $0$, pair $\\pm i$); $\\Delta(x^3-3x+2)=0$ (double root $1$, simple root $-2$). These realize the three branches $\\Delta>0,\\ \\Delta<0,\\ \\Delta=0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discriminant test trichotomy",
+      "worked examples / sanity checks",
+      "norm_num",
+      "repeated-root boundary Δ = 0"
+    ],
+    "prerequisites": [
+      "the three sign theorems above",
+      "factoring simple cubics"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-02` (quality 65, pass 0).

## Changes
- **Schema/rendering fix:** All 4 annotations stored their text under a non-standard `body` key, but the `Annotation` type (src/types/proof.ts) requires `content`. Renamed `body`→`content` so the annotation text actually renders on the page. (This pattern affects ~13 gallery files; fixed here for this entry.)
- **Required field:** Added the required `significance` field (was absent): key / key / supporting / supporting.
- **Depth:** Added `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 4 annotations — the root-form positivity (Δ>0), the conjugate-pair ring identity (Δ<0 via (w−w̄)²=−4n²), the ℝ→ℂ bridge certification, and the trichotomy sanity checks.

## Verification
- `pnpm build` passes (exit 0)
- All 4 annotations now use `content`, carry a valid `significance` (critical|key|supporting), and have mathContext/relatedConcepts/prerequisites
- No meta.json changes; verified/verified/axiomCount:0 untouched (matches Lean: 0 sorries, 0 axioms, 8 theorems)