### PR TITLE
research(basel-problem-oq-06-oq-01): ∑ 1/(2k+1)² = π²/8 via even/odd split [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -330,6 +330,7 @@ import Proofs.BaselProblemOQ04
 import Proofs.BaselProblemOQ04OQ03
 import Proofs.BaselProblemOQ05
 import Proofs.BaselProblemOQ05OQ03
+import Proofs.BaselProblemOQ06OQ01
 import Proofs.BaselProblemOQ08
 import Proofs.BaselProblemOQ08OQ02
 import Proofs.BaselProblemOQ08OQ02OQ01

--- a/proofs/Proofs/BaselProblemOQ06OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ06OQ01.lean
@@ -1,0 +1,120 @@
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.NatInt
+import Mathlib.Analysis.PSeries
+import Mathlib.Tactic
+
+/-!
+# Sum of Reciprocal Odd Squares: ∑ 1/(2k+1)² = π²/8
+
+## What This Proves
+Restricting the Basel sum ∑ 1/n² = π²/6 to the **odd** integers gives
+
+  ∑_{k=0}^∞ 1/(2k+1)² = π²/8.
+
+## Approach
+This is an elementary corollary of the Basel identity (`hasSum_zeta_two`).
+Split the full sum over ℕ into its even- and odd-indexed subsequences using
+`HasSum.even_add_odd`:
+
+  ∑_{n} 1/n²  =  ∑_{k} 1/(2k)²  +  ∑_{k} 1/(2k+1)².
+
+The even part rescales the original series:
+
+  ∑_{k} 1/(2k)² = (1/4) ∑_{k} 1/k² = (1/4)·(π²/6) = π²/24.
+
+Both the even part and the full sum have known values, so by uniqueness of
+infinite sums the odd part must equal
+
+  π²/6 − π²/24 = π²/8.
+
+No new analysis is required beyond Mathlib's `hasSum_zeta_two`; the content is
+the even/odd decomposition and the arithmetic identity 6 = 24 − ... that pins
+the odd tail. The companion identity ∑ 1/(2k)² = π²/24 (sum of reciprocal even
+squares) falls out of the same decomposition and is recorded as well.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axioms)
+- [x] Uses Mathlib for the underlying Basel identity
+
+## Mathlib Dependencies
+- `hasSum_zeta_two` : the Basel identity ∑ 1/n² = π²/6
+- `HasSum.even_add_odd` : splits a `HasSum` over ℕ into even/odd subsequences
+- `HasSum.mul_left`, `HasSum.unique`
+
+Original formalization for Lean Genius.
+-/
+
+namespace BaselProblemOQ06OQ01
+
+open Filter Topology Real
+
+/-- The base summand `f n = 1/n²`. -/
+private noncomputable def f (n : ℕ) : ℝ := 1 / (n : ℝ) ^ 2
+
+/-- **Basel identity** (Mathlib): `∑ 1/n² = π²/6`. -/
+theorem basel_hasSum : HasSum f (π ^ 2 / 6) := hasSum_zeta_two
+
+/-- **Sum of reciprocal even squares**: `∑_{k} 1/(2k)² = π²/24`.
+
+Each even-indexed term is `1/(2k)² = (1/4)·(1/k²)`, so the even subsequence is
+the original Basel series scaled by `1/4`, giving `(1/4)·(π²/6) = π²/24`. -/
+theorem hasSum_even : HasSum (fun k : ℕ => f (2 * k)) (π ^ 2 / 24) := by
+  have h : HasSum (fun n : ℕ => (1 / 4 : ℝ) * f n) ((1 / 4) * (π ^ 2 / 6)) :=
+    basel_hasSum.mul_left (1 / 4)
+  have hval : (1 / 4 : ℝ) * (π ^ 2 / 6) = π ^ 2 / 24 := by ring
+  rw [hval] at h
+  refine h.congr_fun ?_  -- reduce to a pointwise function identity
+  intro k
+  show f (2 * k) = (1 / 4 : ℝ) * f k
+  unfold f
+  push_cast
+  rw [show (2 * (k : ℝ)) ^ 2 = 4 * (k : ℝ) ^ 2 from by ring, one_div_mul_one_div]
+
+/-- The odd subsequence `k ↦ 1/(2k+1)²` is summable (a subseries of a summable
+nonnegative series). -/
+theorem summable_odd : Summable (fun k : ℕ => f (2 * k + 1)) := by
+  have hi : Function.Injective (fun k : ℕ => 2 * k + 1) := by
+    intro a b hab
+    have hab' : 2 * a + 1 = 2 * b + 1 := hab
+    omega
+  exact basel_hasSum.summable.comp_injective hi
+
+/-- **Sum of reciprocal odd squares**: `∑_{k} 1/(2k+1)² = π²/8`.
+
+The even part (π²/24) plus the odd part recovers the full Basel sum (π²/6), so
+the odd part equals `π²/6 − π²/24 = π²/8`. -/
+theorem hasSum_odd : HasSum (fun k : ℕ => f (2 * k + 1)) (π ^ 2 / 8) := by
+  -- Let `b` be the (a priori unknown) value of the odd sum.
+  obtain ⟨b, hb⟩ := summable_odd
+  -- Even + odd reconstructs the whole series.
+  have hcombined : HasSum f (π ^ 2 / 24 + b) := hasSum_even.even_add_odd hb
+  -- Uniqueness against the Basel value pins `b`.
+  have heq : π ^ 2 / 6 = π ^ 2 / 24 + b := basel_hasSum.unique hcombined
+  have hb_val : b = π ^ 2 / 8 := by linarith
+  rwa [hb_val] at hb
+
+/-- **Main theorem** in the natural `(2k+1 : ℝ)` form:
+`∑_{k=0}^∞ 1/(2k+1)² = π²/8`. -/
+theorem odd_squares_hasSum :
+    HasSum (fun k : ℕ => 1 / (2 * (k : ℝ) + 1) ^ 2) (π ^ 2 / 8) := by
+  have h := hasSum_odd
+  refine h.congr_fun ?_
+  intro k
+  show 1 / (2 * (k : ℝ) + 1) ^ 2 = f (2 * k + 1)
+  unfold f
+  push_cast
+  ring
+
+/-- The `tsum` form: `∑' k, 1/(2k+1)² = π²/8`. -/
+theorem odd_squares_tsum :
+    ∑' k : ℕ, 1 / (2 * (k : ℝ) + 1) ^ 2 = π ^ 2 / 8 :=
+  odd_squares_hasSum.tsum_eq
+
+/-- Sanity check: the odd-square sum is positive. -/
+theorem odd_squares_pos : (0 : ℝ) < π ^ 2 / 8 := by positivity
+
+/-- Consistency: even part + odd part = full Basel sum. -/
+theorem even_add_odd_eq_basel : π ^ 2 / 24 + π ^ 2 / 8 = π ^ 2 / 6 := by ring
+
+end BaselProblemOQ06OQ01

--- a/src/data/proofs/basel-problem-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-06-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "baseloq0601-header",
+    "proofId": "basel-problem-oq-06-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Module Header and Setup",
+    "content": "The open question asks for the odd-integer restriction of the Basel sum: $\\sum_{k=0}^\\infty 1/(2k+1)^2 = \\pi^2/8$. The strategy is an even/odd split of the same series Euler summed. The base summand is $f(n) = 1/n^2$, and the only analytic input is Mathlib's `hasSum_zeta_two`, the Basel identity $\\sum 1/n^2 = \\pi^2/6$.",
+    "mathContext": "Target: $\\sum_{k\\ge 0} 1/(2k+1)^2 = \\pi^2/8$, the value $\\lambda(2) = (1-2^{-2})\\zeta(2)$."
+  },
+  {
+    "id": "baseloq0601-even",
+    "proofId": "basel-problem-oq-06-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 74
+    },
+    "type": "technique",
+    "title": "Basel Identity and the Even Part",
+    "content": "`basel_hasSum` re-exports `hasSum_zeta_two`. The even subsequence is the Basel series rescaled by $1/4$: since $(2k)^2 = 4k^2$, we have $1/(2k)^2 = \\tfrac14\\cdot 1/k^2$ (valid even at $k=0$, where both sides are $0$). Applying `HasSum.mul_left (1/4)` to the Basel identity gives `hasSum_even`: $\\sum_k 1/(2k)^2 = \\tfrac14\\cdot\\tfrac{\\pi^2}{6} = \\tfrac{\\pi^2}{24}$. The pointwise identity is discharged by `push_cast` and `one_div_mul_one_div`.",
+    "mathContext": "$\\sum_k 1/(2k)^2 = \\tfrac14\\sum_k 1/k^2 = \\tfrac{\\pi^2}{24}$."
+  },
+  {
+    "id": "baseloq0601-odd",
+    "proofId": "basel-problem-oq-06-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 95
+    },
+    "type": "key-step",
+    "title": "Summability and Value of the Odd Part",
+    "content": "`summable_odd` makes the odd subsequence summable: the reindexing $k\\mapsto 2k+1$ is injective, so `Summable.comp_injective` applies. The value is pinned without computing it directly: let $b$ be the unknown odd sum. `HasSum.even_add_odd` reassembles the even part ($\\pi^2/24$) and the odd part ($b$) into the full Basel series, giving $\\mathrm{HasSum}\\,f\\,(\\pi^2/24 + b)$. Since the full series also sums to $\\pi^2/6$, `HasSum.unique` forces $\\pi^2/6 = \\pi^2/24 + b$, hence $b = \\pi^2/8$ (`linarith`).",
+    "mathContext": "$\\tfrac{\\pi^2}{24} + b = \\tfrac{\\pi^2}{6} \\Rightarrow b = \\tfrac{\\pi^2}{8}$."
+  },
+  {
+    "id": "baseloq0601-main",
+    "proofId": "basel-problem-oq-06-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 118
+    },
+    "type": "concept",
+    "title": "Main Theorem and Corollaries",
+    "content": "`odd_squares_hasSum` and `odd_squares_tsum` present the result in the natural $(2k+1 : \\mathbb{R})$ form (a `push_cast`/`ring` reindexing of `hasSum_odd`): $\\mathrm{HasSum}\\,(k\\mapsto 1/(2k+1)^2)\\,(\\pi^2/8)$ and $\\sum' k,\\,1/(2k+1)^2 = \\pi^2/8$. `odd_squares_pos` records positivity, and `even_add_odd_eq_basel` verifies the consistency identity $\\pi^2/24 + \\pi^2/8 = \\pi^2/6$.",
+    "mathContext": "$\\sum_{k=0}^\\infty 1/(2k+1)^2 = \\pi^2/8$, with $\\pi^2/24 + \\pi^2/8 = \\pi^2/6$."
+  }
+]

--- a/src/data/proofs/basel-problem-oq-06-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-06-oq-01/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "basel-problem-oq-06-oq-01",
+  "title": "Sum of Reciprocal Odd Squares: ∑ 1/(2k+1)² = π²/8",
+  "slug": "basel-problem-oq-06-oq-01",
+  "description": "Restricting the Basel sum ∑ 1/n² = π²/6 to the odd integers gives ∑_{k≥0} 1/(2k+1)² = π²/8. The proof splits Mathlib's hasSum_zeta_two over even and odd indices via HasSum.even_add_odd: the even part is the Basel series rescaled by 1/4 (giving π²/24), so by uniqueness of infinite sums the odd part is forced to π²/6 − π²/24 = π²/8. The companion even-square value ∑ 1/(2k)² = π²/24 falls out of the same decomposition.",
+  "meta": {
+    "author": "Euler (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Basel_problem",
+    "date": "1735",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "basel-problem",
+      "riemann-zeta",
+      "infinite-series",
+      "euler",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BaselProblemOQ06OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "HasSum (fun n => 1/n²) (π²/6) — the classical Basel value, the sole analytic input",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "HasSum.even_add_odd",
+        "description": "Splits a HasSum over ℕ into its even- and odd-indexed subsequences: HasSum (k ↦ f(2k)) m → HasSum (k ↦ f(2k+1)) m' → HasSum f (m + m')",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "HasSum.mul_left",
+        "description": "Scales a HasSum by a constant on the left — used to rescale the Basel series by 1/4 for the even part",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Ring"
+      },
+      {
+        "theorem": "HasSum.unique",
+        "description": "An infinite sum has a unique value in a T2 space — pins the odd part once even and full sums are known",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "A subseries indexed by an injective reindexing of a summable series is summable — gives summability of the odd subsequence",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Group"
+      }
+    ],
+    "originalContributions": [
+      "hasSum_even: ∑_{k} 1/(2k)² = π²/24, the even subsequence as the Basel series rescaled by 1/4",
+      "hasSum_odd: ∑_{k} 1/(2k+1)² = π²/8, obtained by uniqueness from the even/odd split (no a-priori value assumed for the odd tail)",
+      "odd_squares_hasSum: the headline result in the natural (2k+1 : ℝ) form, HasSum (k ↦ 1/(2k+1)²) (π²/8)",
+      "odd_squares_tsum: the tsum form ∑' k, 1/(2k+1)² = π²/8",
+      "even_add_odd_eq_basel: the consistency identity π²/24 + π²/8 = π²/6"
+    ],
+    "dateAdded": "2026-06-26",
+    "lineCount": 118,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The only Mathlib analytic input is hasSum_zeta_two (Euler's Basel identity); everything else is the even/odd decomposition and uniqueness of infinite sums.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "After Euler solved the Basel problem ζ(2) = ∑ 1/n² = π²/6 in 1735, the restriction of the sum to the odd integers, ∑ 1/(2k+1)² = π²/8, became a standard first corollary. It is the value λ(2) of the Dirichlet lambda function and equals (1 − 2⁻²)ζ(2). The split into even and odd parts is the prototype of the Euler-factor decomposition ζ(s) = ∑_{even} + ∑_{odd} that underlies the relation between ζ and the Dirichlet beta/lambda functions.",
+    "problemStatement": "**Open Question (basel-problem-oq-06-oq-01)**: Formalize ∑_{k=0}^∞ 1/(2k+1)² = π²/8, the restriction of the Basel sum to the odd integers.\n\n**Result**: odd_squares_hasSum / odd_squares_tsum prove HasSum (k ↦ 1/(2k+1)²) (π²/8) and ∑' k, 1/(2k+1)² = π²/8. The companion hasSum_even records the even-square value ∑ 1/(2k)² = π²/24.",
+    "text": "Restricting the Basel sum to odd integers gives ∑ 1/(2k+1)² = π²/8, with the even-square companion ∑ 1/(2k)² = π²/24.",
+    "proofStrategy": "**Proof Strategy: even/odd split of the Basel series.**\n\n1. **Even part.** Each even-indexed term satisfies 1/(2k)² = (1/4)·(1/k²), so the even subsequence is the Basel series scaled by 1/4. `HasSum.mul_left (1/4)` applied to `hasSum_zeta_two` gives ∑_{k} 1/(2k)² = (1/4)·(π²/6) = π²/24 (`hasSum_even`), the pointwise identity discharged by `push_cast` and `one_div_mul_one_div`.\n2. **Odd part is summable.** The reindexing k ↦ 2k+1 is injective, so `Summable.comp_injective` makes the odd subsequence summable; let b be its (a-priori unknown) sum.\n3. **Reassemble.** `HasSum.even_add_odd` combines the even part (π²/24) and the odd part (b) into the full Basel series, giving HasSum f (π²/24 + b).\n4. **Pin b by uniqueness.** Since the full series also sums to π²/6 (`hasSum_zeta_two`), `HasSum.unique` forces π²/6 = π²/24 + b, hence b = π²/8 (`linarith`). Rewriting gives `hasSum_odd`.\n5. A `push_cast`/`ring` reindexing rewrites the result into the natural (2k+1 : ℝ) form (`odd_squares_hasSum`), and `.tsum_eq` gives the tsum value.",
+    "keyInsights": [
+      "**No new analysis is needed.** The entire result rides on Mathlib's Basel identity hasSum_zeta_two; the content is the even/odd partition of ℕ and the uniqueness of infinite sums.",
+      "**The odd value is forced, not computed.** Rather than evaluate the odd tail directly, the proof leaves it as an unknown b, reconstructs the whole series as π²/24 + b, and lets uniqueness against π²/6 solve b = π²/8.",
+      "**Even = (1/4)·Basel.** Because (2k)² = 4k², the even subsequence is a literal rescaling of the full series, giving ∑ 1/(2k)² = π²/24 for free — the two companion values π²/24 and π²/8 add back to π²/6."
+    ],
+    "prerequisites": [
+      "Infinite sums / tsum and HasSum in Mathlib",
+      "The classical Basel value ζ(2) = π²/6",
+      "Even/odd decomposition of a series over ℕ",
+      "Uniqueness of infinite sums in a Hausdorff topological group"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring stating the open question and the even/odd-split strategy, Mathlib imports, the BaselProblemOQ06OQ01 namespace, Real/Filter/Topology opens, and the base summand f n = 1/n².",
+      "mathContext": "The target ∑_{k≥0} 1/(2k+1)² = π²/8 as the odd-integer restriction of the Basel sum ∑ 1/n² = π²/6."
+    },
+    {
+      "id": "basel-and-even",
+      "title": "Basel Identity and the Even Part",
+      "startLine": 56,
+      "endLine": 74,
+      "summary": "basel_hasSum re-exports Mathlib's hasSum_zeta_two for f, and hasSum_even proves ∑ 1/(2k)² = π²/24 by rescaling the Basel series by 1/4 (HasSum.mul_left plus the pointwise identity 1/(2k)² = (1/4)/k²).",
+      "mathContext": "$\\sum_{k} 1/(2k)^2 = \\tfrac14\\sum_k 1/k^2 = \\tfrac14\\cdot\\tfrac{\\pi^2}{6} = \\tfrac{\\pi^2}{24}$."
+    },
+    {
+      "id": "odd-part",
+      "title": "Summability and Value of the Odd Part",
+      "startLine": 76,
+      "endLine": 95,
+      "summary": "summable_odd makes the odd subsequence summable via the injective reindexing k ↦ 2k+1, and hasSum_odd pins its value: even (π²/24) + odd (b) reconstructs the full Basel sum (π²/6) via HasSum.even_add_odd, and HasSum.unique forces b = π²/8.",
+      "mathContext": "$\\tfrac{\\pi^2}{24} + b = \\tfrac{\\pi^2}{6} \\Rightarrow b = \\tfrac{\\pi^2}{8}$, the value of $\\sum_k 1/(2k+1)^2$."
+    },
+    {
+      "id": "main",
+      "title": "Main Theorem and Corollaries",
+      "startLine": 97,
+      "endLine": 118,
+      "summary": "odd_squares_hasSum/odd_squares_tsum present the result in the natural (2k+1 : ℝ) form, odd_squares_pos records positivity, and even_add_odd_eq_basel verifies π²/24 + π²/8 = π²/6.",
+      "mathContext": "$\\sum_{k=0}^\\infty 1/(2k+1)^2 = \\pi^2/8$, with the consistency check $\\pi^2/24 + \\pi^2/8 = \\pi^2/6$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "extends",
+      "description": "The Basel problem proves ζ(2) = ∑ 1/n² = π²/6; this entry restricts that sum to the odd integers, obtaining ∑ 1/(2k+1)² = π²/8 by an even/odd split of the same series"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of ∑_{k≥0} 1/(2k+1)² = π²/8, the odd-integer restriction of the Basel sum, together with the even-square companion ∑ 1/(2k)² = π²/24 and the consistency identity π²/24 + π²/8 = π²/6.",
+    "implications": "Demonstrates the even/odd decomposition HasSum.even_add_odd as a reusable template for splitting zeta-type series into their even and odd Euler parts — the same move that relates ζ(s) to the Dirichlet lambda and beta functions. The odd value π²/8 = λ(2) = (1 − 2⁻²)ζ(2) is the degree-2 case of that family.",
+    "openQuestions": [
+      "Formalize the general odd-restriction λ(2k) = (1 − 2^{-2k})ζ(2k), e.g. ∑ 1/(2k+1)⁴ = π⁴/96.",
+      "Formalize the alternating companion (Dirichlet beta / Leibniz family) ∑ (−1)^k/(2k+1)² = Catalan's constant, contrasting the non-elementary odd case with this elementary even one."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "BaselProblemOQ06OQ01",
+    "lineCount": 118,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/BaselProblemOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "De summis serierum reciprocarum",
+      "year": "1740",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 7, pp. 123–134",
+      "note": "Euler's solution of the Basel problem ζ(2) = π²/6, from which the odd restriction ∑ 1/(2k+1)² = π²/8 follows immediately"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/basel-problem-oq-06-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-06-oq-01.json
@@ -1,0 +1,491 @@
+{
+  "slug": "basel-problem-oq-06-oq-01",
+  "title": "Sum of Reciprocal Odd Squares Equals π²/8",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\sum_{k=0}^{\\infty} \\frac{1}{(2k+1)^2} = \\frac{\\pi^2}{8}.",
+    "plain": "Restricting the Basel sum $\\sum 1/n^2 = \\pi^2/6$ to the odd integers gives",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T16:26:13-07:00",
+    "iteration": 1,
+    "focus": "Proof complete and Docker-verified (0 sorry / 0 axiom).",
+    "blockers": [],
+    "nextAction": "Graduated to gallery as basel-problem-oq-06-oq-01.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: sum 1/(2k+1)^2 = pi^2/8 fully formalized via even/odd split of Basel (BaselProblemOQ06OQ01.lean, 0 sorry / 0 axiom). Integrated into gallery.",
+    "builtItems": [
+      "hasSum_odd (BaselProblemOQ06OQ01.lean): MAIN - HasSum (k => 1/(2k+1)^2) (pi^2/8), 0 axiom / 0 sorry",
+      "hasSum_even: HasSum (k => 1/(2k)^2) (pi^2/24)",
+      "odd_squares_hasSum / odd_squares_tsum: result in natural (2k+1:R) form",
+      "summable_odd: odd subsequence summable via injective reindex k => 2k+1"
+    ],
+    "insights": [
+      "Odd-square sum is forced, not computed: leave the odd tail as unknown b, reassemble even (pi^2/24) + odd (b) into the full Basel series via HasSum.even_add_odd, then HasSum.unique against pi^2/6 forces b = pi^2/8.",
+      "Even subsequence = (1/4) * Basel since (2k)^2 = 4k^2; HasSum.mul_left (1/4) on hasSum_zeta_two gives sum 1/(2k)^2 = pi^2/24 for free.",
+      "No new analysis beyond Mathlib hasSum_zeta_two; the content is the even/odd partition of N and uniqueness of infinite sums."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Generalize to lambda(2k) = (1 - 2^{-2k}) zeta(2k), e.g. sum 1/(2k+1)^4 = pi^4/96.",
+      "Alternating companion sum (-1)^k/(2k+1)^2 = Catalan constant (non-elementary, contrasts this even case)."
+    ],
+    "markdown": "# Knowledge Base: basel-problem-oq-06-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "basel-problem",
+    "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-03",
+    "basel-problem-oq-01-oq-01-oq-03",
+    "basel-problem-oq-01-oq-03",
+    "basel-problem-oq-01-oq-05",
+    "basel-problem-oq-02",
+    "basel-problem-oq-03",
+    "basel-problem-oq-03-oq-01",
+    "basel-problem-oq-04",
+    "basel-problem-oq-04-oq-03",
+    "basel-problem-oq-05",
+    "basel-problem-oq-05-oq-03",
+    "basel-problem-oq-06-oq-01",
+    "basel-problem-oq-08",
+    "basel-problem-oq-08-oq-02",
+    "basel-problem-oq-08-oq-02-oq-01",
+    "basel-problem-oq-09",
+    "basel-problem-oq-09-oq-01",
+    "basel-problem-oq-10",
+    "basel-problem-oq-10-oq-01",
+    "basel-problem-oq-11",
+    "basel-problem-oq-11-oq-01",
+    "basel-problem-oq-12",
+    "basel-problem-oq-13",
+    "basel-problem-oq-13-oq-01",
+    "basel-problem-oq-14",
+    "basel-problem-oq-14-oq-01",
+    "basel-problem-oq-15"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T23:57:00.723Z",
+  "lastUpdate": "2026-06-25T23:57:00.756Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/BaselProblem.lean",
+      "filename": "BaselProblem.lean",
+      "lineCount": 165,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblem.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01.lean",
+      "lineCount": 145,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02.lean",
+      "lineCount": 953,
+      "theoremCount": 46,
+      "axiomCount": 5,
+      "defCount": 9,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "lineCount": 206,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 142,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+      "lineCount": 159,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ02.lean",
+      "lineCount": 973,
+      "theoremCount": 37,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ03.lean",
+      "lineCount": 1803,
+      "theoremCount": 74,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ01OQ03.lean",
+      "lineCount": 182,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ05.lean",
+      "filename": "BaselProblemOQ01OQ05.lean",
+      "lineCount": 194,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ05.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ02.lean",
+      "filename": "BaselProblemOQ02.lean",
+      "lineCount": 349,
+      "theoremCount": 19,
+      "axiomCount": 5,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ02Aristotle.lean",
+      "filename": "BaselProblemOQ02Aristotle.lean",
+      "lineCount": 96,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ03.lean",
+      "filename": "BaselProblemOQ03.lean",
+      "lineCount": 178,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ03OQ01.lean",
+      "filename": "BaselProblemOQ03OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ04.lean",
+      "filename": "BaselProblemOQ04.lean",
+      "lineCount": 108,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ04.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ04OQ03.lean",
+      "filename": "BaselProblemOQ04OQ03.lean",
+      "lineCount": 559,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ05.lean",
+      "filename": "BaselProblemOQ05.lean",
+      "lineCount": 190,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ05.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ05OQ03.lean",
+      "filename": "BaselProblemOQ05OQ03.lean",
+      "lineCount": 167,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ05OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ06OQ01.lean",
+      "filename": "BaselProblemOQ06OQ01.lean",
+      "lineCount": 119,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ06OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08.lean",
+      "filename": "BaselProblemOQ08.lean",
+      "lineCount": 48,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08OQ02.lean",
+      "filename": "BaselProblemOQ08OQ02.lean",
+      "lineCount": 77,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08OQ02OQ01.lean",
+      "filename": "BaselProblemOQ08OQ02OQ01.lean",
+      "lineCount": 99,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ09.lean",
+      "filename": "BaselProblemOQ09.lean",
+      "lineCount": 149,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ09.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ0901.lean",
+      "filename": "BaselProblemOQ0901.lean",
+      "lineCount": 190,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ0901.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ09OQ01.lean",
+      "filename": "BaselProblemOQ09OQ01.lean",
+      "lineCount": 193,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ09OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ10.lean",
+      "filename": "BaselProblemOQ10.lean",
+      "lineCount": 94,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ10.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ10OQ01.lean",
+      "filename": "BaselProblemOQ10OQ01.lean",
+      "lineCount": 135,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ10OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ11.lean",
+      "filename": "BaselProblemOQ11.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ11.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ11OQ01.lean",
+      "filename": "BaselProblemOQ11OQ01.lean",
+      "lineCount": 156,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ11OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ12.lean",
+      "filename": "BaselProblemOQ12.lean",
+      "lineCount": 78,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ12.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ13.lean",
+      "filename": "BaselProblemOQ13.lean",
+      "lineCount": 86,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ13.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ13OQ01.lean",
+      "filename": "BaselProblemOQ13OQ01.lean",
+      "lineCount": 111,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ13OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ14.lean",
+      "filename": "BaselProblemOQ14.lean",
+      "lineCount": 114,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ14.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ14OQ01.lean",
+      "filename": "BaselProblemOQ14OQ01.lean",
+      "lineCount": 167,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ14OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ15.lean",
+      "filename": "BaselProblemOQ15.lean",
+      "lineCount": 91,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ15.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Restricts the Basel sum ∑ 1/n² = π²/6 to the **odd integers**, proving

$$\sum_{k=0}^\infty \frac{1}{(2k+1)^2} = \frac{\pi^2}{8}$$

as an elementary corollary of Mathlib's `hasSum_zeta_two`. Gallery entry `basel-problem-oq-06-oq-01`.

## Method

Split the Basel series over ℕ into even- and odd-indexed subsequences via `HasSum.even_add_odd`:

1. **Even part** (`hasSum_even`): since $(2k)^2 = 4k^2$, $1/(2k)^2 = \tfrac14\cdot 1/k^2$, so the even subsequence is the Basel series scaled by $1/4$ (`HasSum.mul_left`), giving $\sum 1/(2k)^2 = \tfrac14(\pi^2/6) = \pi^2/24$.
2. **Odd part summable** (`summable_odd`): the reindexing $k \mapsto 2k+1$ is injective, so `Summable.comp_injective` applies.
3. **Pin by uniqueness** (`hasSum_odd`): leaving the odd sum as an unknown $b$, `HasSum.even_add_odd` reconstructs the full series as `HasSum f (π²/24 + b)`; `HasSum.unique` against $\pi^2/6$ forces $b = \pi^2/8$ — the odd value is *pinned by uniqueness*, not computed directly.

Corollaries: `odd_squares_hasSum`/`odd_squares_tsum` (natural $(2k+1:\mathbb R)$ form), the even-square companion $\sum 1/(2k)^2 = \pi^2/24$, and the consistency identity $\pi^2/24 + \pi^2/8 = \pi^2/6$. This is the $s=2$ value $\lambda(2) = (3/4)\zeta(2)$ of the Dirichlet lambda function.

## Verification

- **Docker-verified**: `✔ Built Proofs.BaselProblemOQ06OQ01` (3125 jobs)
- **0 sorries, 0 axioms** — only Mathlib analytic input is `hasSum_zeta_two`
- 118 lines, 8 theorems, 1 def
- `status: verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)