### PR TITLE
audit: confirm basel-problem-oq-04-oq-03-oq-01 clean (coprime k-tuple density = 1/ζ(k))

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24877,6 +24877,12 @@
       "lastAudited": "2026-06-27T03:52:40Z",
       "result": "clean",
       "issues": []
+    },
+    "basel-problem-oq-04-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T03:56:24Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `basel-problem-oq-04-oq-03-oq-01` — Coprime k-Tuple Density: Pr[gcd(a₁,…,a_k)=1] → 1/ζ(k) (Nymann 1972)
**Source**: `proofs/Proofs/CoprimeKTupleDensity.lean`

### Verification (all meta counts match source exactly)

| Check | meta.json | Source | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom`, 0 `native_decide`, 0 assumption-carrying structures | ✓ |
| lineCount | 503 | 503 | ✓ |
| theoremCount | 17 | 17 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| True stubs | — | 0 | ✓ |

### Tier classification: Tier A (original formalization)

The main theorem `coprime_tuple_density_limit` formalizes Nymann's k-tuple coprime density — **not present in Mathlib**. It is assembled from genuinely original in-file work: the k-dimensional Möbius decomposition (`countCoprimeTuples_moebius`), the counting lemmas (`card_multiples`, `card_tuples_divisible` via `Fintype.card_piFinset_const`), and the density limit via Tannery's dominated-convergence theorem.

Mathlib supplies only the analytic backbone (the L-series identity `LSeries_zeta_mul_Lseries_moebius`, `tendsto_tsum_of_dominated_convergence`), which is **properly disclosed** in `mathlibDependencies`, the `note`, and the in-file docstrings — no delegation opacity, no axiom masking. The `verified` badge is appropriate; `originalContributions` is accurately scoped; no "first formalization" overclaim.

**Verdict: CLEAN.** No changes to meta.json required. Updates `audit-tracker.json` only.

---
Discovered during gallery integrity audit.