### PR TITLE
audit: confirm shannon-source-coding-oq-01-oq-03 clean (binary rate-distortion formula)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24883,6 +24883,12 @@
       "lastAudited": "2026-06-27T03:56:24Z",
       "result": "clean",
       "issues": []
+    },
+    "shannon-source-coding-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T04:00:01Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `shannon-source-coding-oq-01-oq-03` — The Binary Rate–Distortion Function R(D) = H(p) − H(D)
**Source**: `proofs/Proofs/ShannonSourceCodingOQ01OQ03.lean`

### Verification (all meta counts match source exactly)

| Check | meta.json | Source | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 (only a docstring mention "0 `sorry`") | ✓ |
| axiomCount | 0 | 0 `axiom`, 0 `native_decide`, 0 structures | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 1 | 1 | ✓ |
| lineCount | 90 | 90 | ✓ |
| True stubs | — | 0 | ✓ |

### Famous-named title — HIGH-risk profile checked, NOT an overclaim

The title names the binary rate–distortion function, a famous information-theory result. The file `defines` `R := binEntropy p − binEntropy D` and proves its structural properties (endpoint values `R(p,0)=H(p)`, `R(p,p)=0`; nonnegativity; antitone in D; `R ≤ H(p) ≤ log 2`). It does **not** prove the operational rate–distortion theorem (variational `R(D)=inf I(X;X̂)` or achievability/converse).

This is correctly and **repeatedly disclosed** across every public-facing field:
- `description`: "gives the formula a concrete object … proves the defining structural properties"
- `overview.text`: "It does not derive the formula from the variational definition … nor prove operational achievability"
- `assumptions` SCOPE: "formalizes the explicit binary FORMULA … not the variational characterization … nor the operational achievability theorem"
- `conclusion`: "answers the parent's open question #3 by turning the commented formula into a checked function"

No delegation opacity, no axiom masking, no inequality-as-theorem inflation. `binEntropy_*` lemmas are disclosed as Mathlib infrastructure. `status: verified` is accurate (machine-checked); `badge: original` is appropriate (original formalization, not a wrapper of a named Mathlib theorem). Empty `originalContributions` is a minor under-disclosure, not an overclaim.

**Verdict: CLEAN.** No changes to meta.json required. Updates `audit-tracker.json` only.

---
Discovered during gallery integrity audit.