### PR TITLE
audit: confirm amgm-inequality-oq-03-oq-02-oq-01-oq-01 clean (unified power-mean monotonicity)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -181,9 +181,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T04:06:40Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01-oq-02": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: \`amgm-inequality-oq-03-oq-02-oq-01-oq-01\` — "Extended Power Mean Monotonicity: Unified Single Theorem"

Unifies the three power-mean monotonicity cases (positive, negative, crossing-zero) into one theorem by extending the power mean to r=0 (geometric mean): M_r ≤ M_s for **all** r ≤ s with no sign restriction.

### Verification
| Field | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| status / badge | verified / original | — | ✓ |
| sorries | 0 | 0 (file **and** full parent import chain) | ✓ |
| axiomCount | 0 | 0 (no `axiom` decls, no structure-encoded assumptions) | ✓ |
| lineCount | 138 | 138 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 1 | 1 (`extWeightedPowerMean`) | ✓ |

- All three delegated theorems (`geom_mean_le_power_mean_pos`, `power_mean_le_geom_mean_neg`, `power_mean_monotone_all`) exist and are genuinely proven in parent `AmgmInequalityOQ03OQ02OQ01.lean` (0 sorries, 0 axioms); grandparent `AmgmInequalityOQ03.lean` also 0/0.
- No `True` stubs.
- **Tier assessment**: `verified`/`original` defensible — the extended r=0 definition and four-case gluing are genuine original infrastructure built on the project's own proven parent theorems, **not** a Mathlib wrapper. The single Mathlib dependency (`Real.geom_mean_le_arith_mean_weighted`) is used only transitively.
- `assumptions` field honestly discloses "complete via delegation to parent theorems."
- Title/description accurately scoped; no overclaim. **Risk: LOW.**

No changes to proof content — tracker bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)