### PR TITLE
audit: confirm amgm-inequality-oq-03-oq-02-oq-04 clean (extreme power-mean limits M_r→max/min)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -193,9 +193,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T04:09:56Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `amgm-inequality-oq-03-oq-02-oq-04` — *Extreme Power Mean Limits: M_r → max and min*

### Checks (all pass)
| Field | meta.json | Lean source | Match |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True-stubs | — | 0 | ✓ |
| theoremCount | 6 | 6 (incl. private `card_pos`) | ✓ |
| definitionCount | 1 | 1 | ✓ |
| lineCount | 219 | 219 | ✓ |
| status/badge | verified / original | — | ✓ |

### Tier classification: A (original) — defensible
The file **defines `powerMean` itself** and genuinely proves *both* extreme limits:
- `powerMean_tendsto_max`: M_r → max via squeeze between `M·n^{-1/r}` and `M`, with `n^{-1/r}→1`.
- `powerMean_tendsto_min`: M_r → min via the duality identity `M_r(x)=(M_{-r}(1/x))⁻¹` composed with `tendsto_neg_atBot_atTop`.

Mathlib supplies only **infrastructure** (rpow arithmetic, filter limits, the generic squeeze lemma) — **no single Mathlib theorem is wrapped as the main result**. The actual `Tendsto` limits are proved (not merely bounds), so badge `original` and status `verified` are accurate.

### Narrative failure modes: none
No delegation opacity (deps honestly listed), no axioms to mask, proves the theorem not just an inequality, claims scoped to this file, not a hidden-import wrapper.

Minor non-actionable nit: `description` prose says "5 theorems" (the 5 public named theorems, excluding private `card_pos` plumbing) vs `theoremCount: 6` — an underclaim, no credibility risk.

Tracker updated: auditCount → 3, result clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)