### PR TITLE
research(basel-oq-04-oq-03-oq-01): coprime k-tuple density = 1/ζ(k), build-verified

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -957,6 +957,7 @@ import Proofs.ContinuumHypothesis
 import Proofs.ContinuumHypothesisOQ01
 import Proofs.ContinuumHypothesisOQ02
 import Proofs.ContinuumHypothesisOQ02OQ01
+import Proofs.CoprimeKTupleDensity
 import Proofs.CramersRule
 import Proofs.CramersRuleOQ01
 import Proofs.CramersRuleOQ01OQ02

--- a/proofs/Proofs/CoprimeKTupleDensity.lean
+++ b/proofs/Proofs/CoprimeKTupleDensity.lean
@@ -1,0 +1,501 @@
+/-
+# Coprime k-Tuple Density = 1/ζ(k)
+
+**Statement**: For every integer `k ≥ 2`, the natural density of coprime
+`k`-tuples of positive integers equals `1/ζ(k)`:
+
+  lim_{N→∞} |{a : Fin k → ℕ | 1 ≤ a i ≤ N, gcd(a₁,…,a_k) = 1}| / Nᵏ = 1/ζ(k)
+
+This generalises the classical Cesàro result for pairs (`k = 2`, density `6/π² = 1/ζ(2)`,
+formalised in `BaselProblemOQ04OQ03`) to arbitrary dimension. The probability that
+`k` random integers share no common factor is `1/ζ(k) = ∏_p (1 − p⁻ᵏ)`.
+
+## Proof Architecture
+
+The proof follows the same three-step skeleton as the `k = 2` case, with the square
+`⌊N/d⌋²` replaced by the `k`-th power `⌊N/d⌋ᵏ`.
+
+### Step 1: Möbius Decomposition
+Using Möbius inversion (`[n=1] = Σ_{d|n} μ(d)`), a finite Fubini exchange gives
+
+  countCoprimeTuples k N = Σ_{d=1}^N μ(d) · ⌊N/d⌋ᵏ.
+
+The `k`-tuple count of `d`-divisible tuples factors as `⌊N/d⌋ᵏ` (a product over the
+`k` coordinates, `Fintype.card_piFinset_const`).
+
+### Step 2: The Möbius Dirichlet Series (key identity)
+For integer `k ≥ 2`,
+
+  Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k).
+
+This is the central analytic fact. It generalises `Σ μ(d)/d² = 6/π²` and is proved from
+the L-series identity `L(ζ, k)·L(μ, k) = 1` together with `ζ(k) = Σ 1/nᵏ`
+(`zeta_nat_eq_tsum_of_gt_one`). No closed form for `ζ(k)` is needed; the value is carried
+symbolically as the real number `rZeta k = Σ' n, 1/nᵏ`.
+
+### Step 3: Density Limit
+Tannery's dominated-convergence theorem with dominator `1/dᵏ` (summable for `k ≥ 2`,
+`summable_one_div_nat_pow`) and pointwise limit `⌊N/d⌋/N → 1/d` upgrades the finite
+Möbius sum to the infinite series, yielding the density `1/ζ(k)`.
+
+## Axiom Count: 0
+
+References:
+- Nymann, "On the probability that `k` positive integers are relatively prime",
+  J. Number Theory 4 (1972), 469–473.
+- Hardy & Wright, *Theory of Numbers* §18.5 (the `k = 2` case).
+- Mathlib: `LSeries_zeta_mul_Lseries_moebius`, `zeta_nat_eq_tsum_of_gt_one`,
+  `tendsto_tsum_of_dominated_convergence`.
+-/
+
+import Mathlib.NumberTheory.ArithmeticFunction
+import Mathlib.NumberTheory.LSeries.RiemannZeta
+import Mathlib.NumberTheory.LSeries.HurwitzZetaValues
+import Mathlib.NumberTheory.EulerProduct.DirichletLSeries
+import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Analysis.PSeries
+import Mathlib.Topology.Algebra.InfiniteSum.Order
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Analysis.Normed.Group.Tannery
+import Mathlib.Tactic
+
+open Filter Finset BigOperators Real Nat ArithmeticFunction
+
+open scoped LSeries.notation
+
+-- Helper: (⌊N/d⌋ : ℝ) / N → 1/d as N → ∞ (for any fixed d).  [k-independent; identical to
+-- the `k = 2` development in BaselProblemOQ04OQ03]
+private lemma nat_div_div_tendsto (d : ℕ) :
+    Tendsto (fun N : ℕ => (N / d : ℕ) / (N : ℝ)) atTop (nhds (1 / (d : ℝ))) := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · simp [Nat.div_zero]
+  · have hd' : (0 : ℝ) < d := Nat.cast_pos.mpr hd
+    rw [Metric.tendsto_atTop]
+    intro ε hε
+    refine ⟨max 1 ⌈(d : ℝ) / ε⌉₊, fun N hN => ?_⟩
+    have hN1 : 1 ≤ N := (Nat.le_max_left 1 _).trans hN
+    have hN' : (0 : ℝ) < N := Nat.cast_pos.mpr (by omega)
+    have hd_ne : (d : ℝ) ≠ 0 := hd'.ne'
+    have hN_ne : (N : ℝ) ≠ 0 := hN'.ne'
+    have hdm : ((N / d : ℕ) : ℝ) * d + ((N % d : ℕ) : ℝ) = N := by
+      exact_mod_cast Nat.div_add_mod' N d
+    have hkey : ((N / d : ℕ) : ℝ) = ((N : ℝ) - ((N % d : ℕ) : ℝ)) / (d : ℝ) := by
+      rw [eq_div_iff hd_ne]; linarith
+    have heq : (N / d : ℕ) / (N : ℝ) - 1 / d = -((N % d : ℕ) : ℝ) / ((d : ℝ) * N) := by
+      rw [hkey]; field_simp; ring
+    rw [Real.dist_eq, heq, neg_div, abs_neg, abs_of_nonneg (by positivity)]
+    rw [div_lt_iff₀ (by positivity)]
+    have hmod : ((N % d : ℕ) : ℝ) < d := by exact_mod_cast Nat.mod_lt N hd
+    have hN_ge : (d : ℝ) ≤ ε * N := by
+      have h1 : (d : ℝ) / ε ≤ ⌈(d : ℝ) / ε⌉₊ := Nat.le_ceil _
+      have h2 : (⌈(d : ℝ) / ε⌉₊ : ℝ) ≤ N := by
+        exact_mod_cast (Nat.le_max_right 1 _).trans hN
+      calc (d : ℝ) = d / ε * ε := by field_simp
+        _ ≤ ↑⌈↑d / ε⌉₊ * ε := by nlinarith
+        _ ≤ N * ε := by nlinarith
+        _ = ε * N := mul_comm _ _
+    have h1d : (1 : ℝ) ≤ d := by exact_mod_cast hd
+    nlinarith [hmod, hN_ge, h1d, hd', hN', mul_le_mul_of_nonneg_left hN_ge hd'.le,
+      mul_le_mul_of_nonneg_left h1d hd'.le]
+
+namespace CoprimeKTupleDensity
+
+-- ============================================================
+-- SECTION I: The Real ζ(k) Value
+-- ============================================================
+
+/-- The real value `ζ(k) = Σ' n, 1/nᵏ`. For `k ≥ 2` this series converges and equals the
+(real, positive) Riemann zeta value `riemannZeta k`. -/
+noncomputable def rZeta (k : ℕ) : ℝ := ∑' n : ℕ, 1 / (n : ℝ) ^ k
+
+/-- For `k ≥ 2`, the defining series of `rZeta k` is summable. -/
+lemma rZeta_summable {k : ℕ} (hk : 2 ≤ k) :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ k) :=
+  summable_one_div_nat_pow.mpr (by omega)
+
+/-- `rZeta k > 0` (the `n = 1` term contributes `1`). -/
+lemma rZeta_pos {k : ℕ} (hk : 2 ≤ k) : 0 < rZeta k := by
+  refine (rZeta_summable hk).tsum_pos (fun n => by positivity) 1 ?_
+  norm_num
+
+/-- The bridge to the complex Riemann zeta function: for `k ≥ 2`,
+`riemannZeta k = rZeta k` (as a complex number via `ofReal`). -/
+lemma riemannZeta_nat_eq_ofReal_rZeta {k : ℕ} (hk : 2 ≤ k) :
+    riemannZeta (k : ℂ) = ((rZeta k : ℝ) : ℂ) := by
+  rw [zeta_nat_eq_tsum_of_gt_one (by omega : 1 < k), rZeta, Complex.ofReal_tsum]
+  apply tsum_congr
+  intro n
+  push_cast
+  ring
+
+/-- `1 < rZeta k` for `k ≥ 2`: the first two terms `1 + 1/2ᵏ` already exceed `1`.
+Hence the density `1/ζ(k)` lies strictly below `1`. -/
+lemma one_lt_rZeta {k : ℕ} (hk : 2 ≤ k) : 1 < rZeta k := by
+  have hsum := rZeta_summable hk
+  -- The partial sum over `{1, 2}` is a lower bound for the (nonneg) series.
+  have hle : ∑ n ∈ ({1, 2} : Finset ℕ), 1 / (n : ℝ) ^ k ≤ rZeta k :=
+    hsum.sum_le_tsum _ (fun i _ => by positivity)
+  have hlb : (1 : ℝ) < ∑ n ∈ ({1, 2} : Finset ℕ), 1 / (n : ℝ) ^ k := by
+    rw [Finset.sum_pair (by norm_num : (1 : ℕ) ≠ 2)]
+    have e1 : (1 : ℝ) / ((1 : ℕ) : ℝ) ^ k = 1 := by simp
+    have e2 : (0 : ℝ) < 1 / ((2 : ℕ) : ℝ) ^ k := by positivity
+    rw [e1]; linarith
+  linarith
+
+-- ============================================================
+-- SECTION II: Möbius Inversion Foundation  (k-independent)
+-- ============================================================
+
+/-- **Key Lemma** (Möbius Inversion): for `n ≥ 1`, `Σ_{d|n} μ(d) = [n = 1]`.
+This is the Dirichlet convolution `μ * ζ = 1`. -/
+theorem moebius_sum_divisors (n : ℕ) (hn : 0 < n) :
+    ∑ d ∈ n.divisors, (ArithmeticFunction.moebius d : ℤ) =
+      if n = 1 then 1 else 0 := by
+  trans (((ArithmeticFunction.moebius : ArithmeticFunction ℤ) *
+         ↑(ArithmeticFunction.zeta : ArithmeticFunction ℕ)) n)
+  · rw [ArithmeticFunction.mul_apply]
+    simp_rw [ArithmeticFunction.natCoe_apply, ArithmeticFunction.zeta_apply]
+    have h_simp : ∀ x ∈ n.divisorsAntidiagonal,
+        ArithmeticFunction.moebius x.1 * (↑(if x.2 = 0 then (0 : ℕ) else 1) : ℤ) =
+        ArithmeticFunction.moebius x.1 := by
+      intro x hx
+      have hmem := Nat.mem_divisorsAntidiagonal.mp hx
+      have hx2 : x.2 ≠ 0 := by
+        intro h; exact hmem.2 (by rw [← hmem.1, h, mul_zero])
+      simp [hx2]
+    rw [Finset.sum_congr rfl h_simp]
+    symm
+    apply Finset.sum_nbij Prod.fst
+    · intro x hx
+      have hmem := Nat.mem_divisorsAntidiagonal.mp hx
+      exact Nat.mem_divisors.mpr ⟨⟨x.2, hmem.1.symm⟩, hmem.2⟩
+    · intro x₁ hx₁ x₂ hx₂ h
+      have h1 := (Nat.mem_divisorsAntidiagonal.mp hx₁).1
+      have h2 := (Nat.mem_divisorsAntidiagonal.mp hx₂).1
+      have h2_ne := (Nat.mem_divisorsAntidiagonal.mp hx₂).2
+      have h_ne : x₂.1 ≠ 0 := by
+        intro hz; exact h2_ne (by rw [← h2, hz, zero_mul])
+      have h_eq : x₁.1 * x₁.2 = x₂.1 * x₂.2 := h1.trans h2.symm
+      ext
+      · exact h
+      · exact mul_left_cancel₀ h_ne (by rwa [h] at h_eq)
+    · intro d hd
+      exact ⟨(d, n / d), Nat.mem_divisorsAntidiagonal.mpr
+        ⟨Nat.mul_div_cancel' (Nat.dvd_of_mem_divisors hd), hn.ne'⟩, rfl⟩
+    · intro _ _; rfl
+  · rw [ArithmeticFunction.moebius_mul_coe_zeta, ArithmeticFunction.one_apply]
+
+-- ============================================================
+-- SECTION III: Counting Multiples and Divisible Tuples
+-- ============================================================
+
+/-- The number of multiples of `d` in `{1, …, N}` equals `⌊N/d⌋`.  [k-independent] -/
+theorem card_multiples (d N : ℕ) (hd : 0 < d) :
+    (Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N)).card = N / d := by
+  have h_eq : Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N) =
+      (Finset.range (N / d)).image (fun j => (j + 1) * d) := by
+    ext a
+    simp only [Finset.mem_filter, Finset.mem_Icc, Finset.mem_image, Finset.mem_range]
+    constructor
+    · rintro ⟨⟨ha1, haN⟩, ⟨k, rfl⟩⟩
+      have hk_pos : 0 < k := by
+        by_contra h; push_neg at h; interval_cases k; simp at ha1
+      have hk_le : k ≤ N / d := by
+        rw [Nat.le_div_iff_mul_le hd]
+        calc k * d = d * k := mul_comm k d
+          _ ≤ N := haN
+      exact ⟨k - 1, by omega, by rw [Nat.sub_add_cancel (by omega : 1 ≤ k), mul_comm]⟩
+    · rintro ⟨j, hj, rfl⟩
+      refine ⟨⟨?_, ?_⟩, dvd_mul_left d (j + 1)⟩
+      · exact Nat.one_le_iff_ne_zero.mpr (mul_ne_zero (by omega) hd.ne')
+      · calc (j + 1) * d ≤ N / d * d := by nlinarith
+          _ ≤ N := Nat.div_mul_le_self N d
+  rw [h_eq]
+  rw [Finset.card_image_of_injective _ (fun a b h => by
+    have := mul_right_cancel₀ hd.ne' h; omega)]
+  exact Finset.card_range _
+
+/-- The number of `k`-tuples `a : Fin k → ℕ` with each `a i ∈ {1, …, N}` and `d ∣ a i`
+for all `i` equals `⌊N/d⌋ᵏ`. (The `k`-dimensional analogue of `card_pairs_divisible`.) -/
+theorem card_tuples_divisible (k d N : ℕ) (hd : 0 < d) :
+    ((Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+      (fun a => ∀ i, d ∣ a i)).card = (N / d) ^ k := by
+  have h_eq : (Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+        (fun a => ∀ i, d ∣ a i)
+      = Fintype.piFinset (fun _ : Fin k => Finset.filter (fun a => d ∣ a) (Finset.Icc 1 N)) := by
+    ext a
+    simp only [Finset.mem_filter, Fintype.mem_piFinset]
+    constructor
+    · rintro ⟨ha, hdvd⟩ i; exact ⟨ha i, hdvd i⟩
+    · intro h; exact ⟨fun i => (h i).1, fun i => (h i).2⟩
+  rw [h_eq, Fintype.card_piFinset_const, card_multiples d N hd]
+
+-- ============================================================
+-- SECTION IV: The Coprime Tuple Count and Möbius Decomposition
+-- ============================================================
+
+/-- The number of `k`-tuples `a : Fin k → ℕ` with `1 ≤ a i ≤ N` for all `i` and
+`gcd(a₁, …, a_k) = 1`. -/
+noncomputable def countCoprimeTuples (k N : ℕ) : ℕ :=
+  ((Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+    (fun a => Finset.univ.gcd a = 1)).card
+
+/-- **Möbius Decomposition**: `countCoprimeTuples k N = Σ_{d=1}^N μ(d) · ⌊N/d⌋ᵏ`.
+
+Both sides count triples `(a, d)` with `a ∈ [1,N]ᵏ` and `d | gcd(a)`, weighted by `μ(d)`.
+A finite Fubini exchange swaps the order of summation. -/
+theorem countCoprimeTuples_moebius (k N : ℕ) (hk1 : 0 < k) (hN : 0 < N) :
+    (countCoprimeTuples k N : ℤ) =
+    ∑ d ∈ Finset.Icc 1 N, (ArithmeticFunction.moebius d : ℤ) * (N / d : ℕ) ^ k := by
+  unfold countCoprimeTuples
+  -- Step 1: Cardinality = sum of coprimality indicators
+  have h_card_sum :
+      (((Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N)).filter
+        (fun a => Finset.univ.gcd a = 1)).card : ℤ) =
+      ∑ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+        if Finset.univ.gcd a = 1 then (1 : ℤ) else 0 := by
+    rw [← Finset.sum_boole]
+  rw [h_card_sum]
+  -- Step 2: Replace each indicator by `Σ_{e | gcd a} μ(e)` (Möbius inversion).
+  have hgcd_pos : ∀ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+      0 < Finset.univ.gcd a := by
+    intro a ha
+    have ha0 := (Fintype.mem_piFinset.mp ha) ⟨0, hk1⟩
+    rw [Finset.mem_Icc] at ha0
+    refine Nat.pos_of_ne_zero ?_
+    rw [Ne, Finset.gcd_eq_zero_iff]
+    push_neg
+    exact ⟨⟨0, hk1⟩, Finset.mem_univ _, by omega⟩
+  have h_moebius : ∀ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+      (if Finset.univ.gcd a = 1 then (1 : ℤ) else 0) =
+      ∑ e ∈ (Finset.univ.gcd a).divisors, (ArithmeticFunction.moebius e : ℤ) :=
+    fun a ha => (moebius_sum_divisors _ (hgcd_pos a ha)).symm
+  rw [Finset.sum_congr rfl h_moebius]
+  -- Step 3: Inner divisor sum = sum over `e ∈ [1,N]` with `∀ i, e ∣ a i`.
+  have h_step3 : ∀ a ∈ Fintype.piFinset (fun _ : Fin k => Finset.Icc 1 N),
+      ∑ e ∈ (Finset.univ.gcd a).divisors, (ArithmeticFunction.moebius e : ℤ) =
+      ∑ e ∈ Finset.Icc 1 N,
+        if (∀ i, e ∣ a i) then (ArithmeticFunction.moebius e : ℤ) else 0 := by
+    intro a ha
+    rw [← Finset.sum_filter]
+    congr 1
+    ext e
+    rw [Nat.mem_divisors, Finset.mem_filter, Finset.mem_Icc]
+    constructor
+    · rintro ⟨hdvd_gcd, _⟩
+      have hall : ∀ i, e ∣ a i := fun i => hdvd_gcd.trans (Finset.gcd_dvd (Finset.mem_univ i))
+      have hi0 := hall ⟨0, hk1⟩
+      have ha0 := (Fintype.mem_piFinset.mp ha) ⟨0, hk1⟩
+      rw [Finset.mem_Icc] at ha0
+      exact ⟨⟨Nat.pos_of_dvd_of_pos hi0 (by omega),
+        le_trans (Nat.le_of_dvd (by omega) hi0) ha0.2⟩, hall⟩
+    · rintro ⟨_, hall⟩
+      refine ⟨Finset.dvd_gcd (fun i _ => hall i), ?_⟩
+      rw [Ne, Finset.gcd_eq_zero_iff]
+      push_neg
+      have ha0 := (Fintype.mem_piFinset.mp ha) ⟨0, hk1⟩
+      rw [Finset.mem_Icc] at ha0
+      exact ⟨⟨0, hk1⟩, Finset.mem_univ _, by omega⟩
+  rw [Finset.sum_congr rfl h_step3, Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro e he
+  simp only [Finset.mem_Icc] at he
+  rw [← Finset.sum_filter, Finset.sum_const, card_tuples_divisible k e N (by omega)]
+  simp only [nsmul_eq_mul]
+  push_cast
+  ring
+
+-- ============================================================
+-- SECTION V: The Möbius Dirichlet Series  Σ μ(d)/dᵏ = 1/ζ(k)
+-- ============================================================
+
+/-- **Theorem (Möbius Dirichlet Series)**: for integer `k ≥ 2`,
+
+  Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k).
+
+This is the key analytic identity. Generalises `moebius_dirichlet_series_at_two`
+(`Σ μ(d)/d² = 6/π²`). Proof: at `s = k` the L-series identity `L(ζ, k)·L(μ, k) = 1`
+combined with `L(ζ, k) = ζ(k)` gives `L(μ, k) = 1/ζ(k)`; transfer to a real `HasSum`. -/
+theorem moebius_dirichlet_series {k : ℕ} (hk : 2 ≤ k) :
+    HasSum (fun d : ℕ => (ArithmeticFunction.moebius d : ℝ) / (d : ℝ) ^ k)
+    (1 / rZeta k) := by
+  rw [← Complex.hasSum_ofReal]
+  have hval : ((1 / rZeta k : ℝ) : ℂ) = (rZeta k : ℂ)⁻¹ := by
+    rw [Complex.ofReal_div, Complex.ofReal_one, one_div]
+  rw [hval]
+  have hkre : 1 < ((k : ℕ) : ℂ).re := by
+    rw [Complex.natCast_re]; exact_mod_cast (show 1 < k by omega)
+  have hmu_sum : LSeriesSummable ↗moebius (k : ℂ) :=
+    LSeriesSummable_moebius_iff.mpr hkre
+  have hprod : L ↗zeta (k : ℂ) * L ↗moebius (k : ℂ) = 1 :=
+    LSeries_zeta_mul_Lseries_moebius hkre
+  have hzeta : L ↗zeta (k : ℂ) = (rZeta k : ℂ) := by
+    rw [LSeries_zeta_eq_riemannZeta hkre, riemannZeta_nat_eq_ofReal_rZeta hk]
+  have hz_ne : (rZeta k : ℂ) ≠ 0 := by
+    rw [Ne, Complex.ofReal_eq_zero]; exact (rZeta_pos hk).ne'
+  have hL_mu : L ↗moebius (k : ℂ) = (rZeta k : ℂ)⁻¹ := by
+    have h : (rZeta k : ℂ) * L ↗moebius (k : ℂ) = 1 := hzeta ▸ hprod
+    calc L ↗moebius (k : ℂ)
+        = (rZeta k : ℂ)⁻¹ * ((rZeta k : ℂ) * L ↗moebius (k : ℂ)) := by
+            rw [← mul_assoc, inv_mul_cancel₀ hz_ne, one_mul]
+      _ = (rZeta k : ℂ)⁻¹ * 1 := by rw [h]
+      _ = (rZeta k : ℂ)⁻¹ := mul_one _
+  have hLHS : LSeriesHasSum ↗moebius (k : ℂ) ((rZeta k : ℂ)⁻¹) :=
+    hL_mu ▸ hmu_sum.LSeriesHasSum
+  have hfun : LSeries.term ↗moebius (k : ℂ) =
+      fun n : ℕ => (((moebius n : ℝ) / (n : ℝ) ^ k : ℝ) : ℂ) := by
+    funext n
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · simp [LSeries.term_zero]
+    · rw [LSeries.term_of_ne_zero hn.ne', Complex.cpow_natCast]
+      push_cast
+      ring
+  rwa [← hfun]
+
+/-- The Möbius Dirichlet series as a `tsum`: `Σ' d, μ(d)/dᵏ = 1/ζ(k)`. -/
+theorem tsum_moebius_div_pow {k : ℕ} (hk : 2 ≤ k) :
+    ∑' d : ℕ, (ArithmeticFunction.moebius d : ℝ) / (d : ℝ) ^ k = 1 / rZeta k :=
+  (moebius_dirichlet_series hk).tsum_eq
+
+-- ============================================================
+-- SECTION VI: The Density Limit
+-- ============================================================
+
+/-- **Main Theorem** (Nymann 1972): for every integer `k ≥ 2`, the natural density of
+coprime `k`-tuples of positive integers equals `1/ζ(k)`:
+
+  lim_{N→∞} countCoprimeTuples k N / Nᵏ = 1/ζ(k).
+
+Proof via Tannery's dominated-convergence theorem: the Möbius decomposition rewrites the
+count as `Σ_d μ(d)·(⌊N/d⌋/N)ᵏ`, each term tends to `μ(d)/dᵏ`, the family is dominated by
+the summable `1/dᵏ`, and the limit series sums to `1/ζ(k)` (`moebius_dirichlet_series`). -/
+theorem coprime_tuple_density_limit {k : ℕ} (hk : 2 ≤ k) :
+    Filter.Tendsto
+      (fun N : ℕ => (countCoprimeTuples k N : ℝ) / (N : ℝ) ^ k)
+      Filter.atTop
+      (nhds (1 / rZeta k)) := by
+  rw [show (1 / rZeta k) = ∑' d : ℕ, (moebius d : ℝ) / (d : ℝ) ^ k
+    from (tsum_moebius_div_pow hk).symm]
+  have h_congr : ∀ᶠ N : ℕ in atTop,
+      (countCoprimeTuples k N : ℝ) / N ^ k =
+      ∑' d : ℕ, (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k := by
+    apply eventually_atTop.mpr ⟨1, fun N hN => ?_⟩
+    have hN' : (0 : ℝ) < N := Nat.cast_pos.mpr (by omega)
+    have hN2 : (N : ℝ) ^ k ≠ 0 := pow_ne_zero k hN'.ne'
+    have hdecomp := countCoprimeTuples_moebius k N (by omega) (by omega)
+    have hcast : (countCoprimeTuples k N : ℝ) =
+        ∑ d ∈ Finset.Icc 1 N, (moebius d : ℝ) * ((N / d : ℕ) : ℝ) ^ k := by
+      have h := congr_arg (Int.cast : ℤ → ℝ) hdecomp
+      push_cast at h
+      exact h
+    have h_fin_eq : ∑' d : ℕ, (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k =
+        ∑ d ∈ Finset.Icc 1 N, (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k := by
+      apply tsum_eq_sum
+      intro d hd
+      simp only [Finset.mem_Icc, not_and_or, not_le] at hd
+      rcases hd with hd0 | hdN
+      · have : d = 0 := by omega
+        subst this; simp
+      · have hzero : N / d = 0 := Nat.div_eq_of_lt (by omega)
+        rw [hzero]; simp [zero_pow (show k ≠ 0 by omega)]
+    rw [h_fin_eq, hcast, Finset.sum_div]
+    apply Finset.sum_congr rfl
+    intro d _
+    rw [mul_div_assoc, ← div_pow]
+  apply (tendsto_tsum_of_dominated_convergence
+    (f := fun N d => (moebius d : ℝ) * ((N / d : ℕ) / (N : ℝ)) ^ k)
+    (g := fun d => (moebius d : ℝ) / (d : ℝ) ^ k)
+    (bound := fun d => 1 / (d : ℝ) ^ k)
+    (h_sum := summable_one_div_nat_pow.mpr (by omega : 1 < k))
+    (hab := fun d => by
+      rcases Nat.eq_zero_or_pos d with rfl | hd
+      · simp
+      · have h := (nat_div_div_tendsto d).pow k
+        have hc : Tendsto (fun _ : ℕ => (moebius d : ℝ)) atTop (nhds (moebius d : ℝ)) :=
+          tendsto_const_nhds
+        have h2 := hc.mul h
+        rwa [show (moebius d : ℝ) * (1 / (d : ℝ)) ^ k = (moebius d : ℝ) / (d : ℝ) ^ k
+          from by rw [div_pow, one_pow, mul_one_div]] at h2)
+    (h_bound := by
+      refine eventually_atTop.mpr ⟨1, fun N hN d => ?_⟩
+      have hN' : (0 : ℝ) < N := Nat.cast_pos.mpr (by omega)
+      rcases Nat.eq_zero_or_pos d with rfl | hd
+      · simp
+      · simp only [Real.norm_eq_abs, abs_mul, abs_pow]
+        have hmu : |(moebius d : ℝ)| ≤ 1 := by exact_mod_cast abs_moebius_le_one
+        have hdiv : |(N / d : ℕ) / (N : ℝ)| ≤ 1 / (d : ℝ) := by
+          rw [abs_of_nonneg (by positivity), div_le_div_iff₀ hN' (Nat.cast_pos.mpr hd)]
+          simp only [one_mul]
+          push_cast
+          exact_mod_cast Nat.div_mul_le_self N d
+        calc |(moebius d : ℝ)| * |(N / d : ℕ) / (N : ℝ)| ^ k
+            ≤ 1 * (1 / (d : ℝ)) ^ k :=
+              mul_le_mul hmu (pow_le_pow_left₀ (abs_nonneg _) hdiv k)
+                (pow_nonneg (abs_nonneg _) k) (by norm_num)
+          _ = 1 / (d : ℝ) ^ k := by rw [one_mul, div_pow, one_pow])).congr'
+    (Filter.EventuallyEq.symm h_congr)
+
+-- ============================================================
+-- SECTION VII: Consequences
+-- ============================================================
+
+/-- The density `1/ζ(k)` is strictly positive. -/
+theorem density_pos {k : ℕ} (hk : 2 ≤ k) : 0 < 1 / rZeta k :=
+  div_pos one_pos (rZeta_pos hk)
+
+/-- The density `1/ζ(k)` is strictly less than `1` (since `ζ(k) > 1`).
+So coprimality of `k`-tuples is a genuine, non-degenerate event. -/
+theorem density_lt_one {k : ℕ} (hk : 2 ≤ k) : 1 / rZeta k < 1 := by
+  rw [div_lt_one (rZeta_pos hk)]
+  exact one_lt_rZeta hk
+
+/-- The density lies in the open unit interval `(0, 1)` — a bona fide probability. -/
+theorem density_in_unit_interval {k : ℕ} (hk : 2 ≤ k) :
+    1 / rZeta k ∈ Set.Ioo (0 : ℝ) 1 :=
+  ⟨density_pos hk, density_lt_one hk⟩
+
+-- ============================================================
+-- SECTION VIII: Consistency with the Pair Case (k = 2)
+-- ============================================================
+
+/-- Cross-check: `ζ(2) = π²/6`, recovering the Basel constant. -/
+theorem rZeta_two_eq : rZeta 2 = Real.pi ^ 2 / 6 := by
+  have h := riemannZeta_nat_eq_ofReal_rZeta (k := 2) (by norm_num)
+  rw [show ((2 : ℕ) : ℂ) = (2 : ℂ) by norm_num, riemannZeta_two] at h
+  have hc : ((rZeta 2 : ℝ) : ℂ) = ((Real.pi ^ 2 / 6 : ℝ) : ℂ) := by
+    rw [← h]; push_cast; ring
+  exact_mod_cast hc
+
+/-- Cross-check: the `k = 2` density is `6/π²`, matching `coprime_pair_density`
+(`BaselProblemOQ04OQ03`). -/
+theorem density_two_eq : 1 / rZeta 2 = 6 / Real.pi ^ 2 := by
+  rw [rZeta_two_eq, one_div_div]
+
+-- ============================================================
+-- SECTION IX: Summary
+-- ============================================================
+
+/-
+## Summary
+
+**Theorem (Nymann 1972)**: for every integer `k ≥ 2`,
+  lim_{N→∞} |{a ∈ [1,N]ᵏ : gcd(a) = 1}| / Nᵏ = 1/ζ(k).
+
+**Proof Architecture** (faithful `k`-dimensional generalisation of the `k = 2` Basel
+development in `BaselProblemOQ04OQ03`):
+1. Möbius decomposition: `countCoprimeTuples k N = Σ_{d≤N} μ(d)·⌊N/d⌋ᵏ`
+   (`countCoprimeTuples_moebius`), via `Fintype.card_piFinset_const`.
+2. Dirichlet series: `Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k)` (`moebius_dirichlet_series`),
+   via `LSeries_zeta_mul_Lseries_moebius` + `zeta_nat_eq_tsum_of_gt_one`.
+3. Density limit: `coprime_tuple_density_limit`, via Tannery's theorem with dominator
+   `1/dᵏ` (`summable_one_div_nat_pow`, valid for `k ≥ 2`).
+
+**Specialisation** `k = 2` recovers `6/π² = 1/ζ(2)` (`density_two_eq`).
+
+Axiom count: 0.  Sorry count: 0.
+-/
+
+end CoprimeKTupleDensity

--- a/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 100 },
+    "type": "concept",
+    "title": "Proof Architecture and the Floor-Ratio Limit",
+    "content": "The header documents a three-step strategy that is a faithful k-dimensional lift of the k=2 coprime-pair proof: (1) a combinatorial Möbius decomposition countCoprimeTuples(k,N) = Σ μ(d)⌊N/d⌋ᵏ, (2) the Dirichlet-series identity Σ μ(d)/dᵏ = 1/ζ(k), and (3) a density limit via Tannery's dominated-convergence theorem. The private helper nat_div_div_tendsto proves the k-independent floor-ratio limit ⌊N/d⌋/N → 1/d through an explicit ε-N estimate using N = ⌊N/d⌋·d + (N mod d).",
+    "mathContext": "$\\lim_{N\\to\\infty} \\frac{|\\{a\\in[N]^k:\\gcd(a)=1\\}|}{N^k} = \\frac{1}{\\zeta(k)}$ for every integer $k\\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Möbius function", "natural density", "Dirichlet series", "Tannery's theorem"],
+    "prerequisites": ["Riemann zeta function", "Möbius inversion formula", "natural density"]
+  },
+  {
+    "id": "ann-real-zeta",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 101, "endLine": 143 },
+    "type": "definition",
+    "title": "Carrying ζ(k) Symbolically as rZeta k",
+    "content": "rZeta k = Σ' n, 1/nᵏ is the real ζ(k) value. The section proves it is summable (k ≥ 2), strictly positive, equal to the complex riemannZeta(k) via zeta_nat_eq_tsum_of_gt_one, and strictly greater than 1 (the n=1,2 terms already exceed 1). Carrying ζ(k) symbolically — with no closed form — is what makes the whole argument k-uniform; only ζ(2) = π²/6 is special, and that is deferred to the consistency cross-check.",
+    "mathContext": "$\\zeta(k) = \\sum_{n\\ge 1} 1/n^k > 1$ for $k\\ge 2$, matching the complex $\\texttt{riemannZeta}(k)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Riemann zeta function", "p-series convergence", "complex analysis bridge"],
+    "prerequisites": ["tsum / HasSum", "summable_one_div_nat_pow"]
+  },
+  {
+    "id": "ann-mobius-inversion",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 145, "endLine": 187 },
+    "type": "theorem",
+    "title": "Möbius Inversion: Σ_{d|n} μ(d) = [n=1]",
+    "content": "moebius_sum_divisors establishes the fundamental identity Σ_{d|n} μ(d) = [n=1] by recognizing it as the Dirichlet convolution μ * ζ = 1 (moebius_mul_coe_zeta) and reindexing the divisor antidiagonal onto the divisor set. This is the coprimality-detection engine: applied to n = gcd(a), it turns the indicator [gcd(a)=1] into a tractable divisor sum. The lemma is entirely k-independent.",
+    "mathContext": "$\\sum_{d\\mid n} \\mu(d) = [n=1]$ — the Dirichlet convolution $\\mu * \\zeta = 1$.",
+    "significance": "important",
+    "relatedConcepts": ["Möbius function", "Dirichlet convolution", "arithmetic functions"],
+    "prerequisites": ["divisor antidiagonal", "moebius_mul_coe_zeta"]
+  },
+  {
+    "id": "ann-counting-tuples",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 188, "endLine": 232 },
+    "type": "theorem",
+    "title": "Counting d-Divisible k-Tuples as ⌊N/d⌋ᵏ",
+    "content": "card_multiples counts the multiples of d in [1,N] as ⌊N/d⌋ (via an explicit bijection with range(N/d)), and card_tuples_divisible lifts this to k dimensions: the d-divisible k-tuples in [1,N]ᵏ form a constant piFinset, so Fintype.card_piFinset_const gives the count ⌊N/d⌋ᵏ. The passage from the square to the k-th power is the single structural change from the pair case.",
+    "mathContext": "$|\\{a\\in[N]^k : \\forall i,\\, d\\mid a_i\\}| = \\lfloor N/d\\rfloor^k$.",
+    "significance": "important",
+    "relatedConcepts": ["counting multiples", "piFinset", "product of independent conditions"],
+    "prerequisites": ["Fintype.card_piFinset_const", "Finset.card_image_of_injective"]
+  },
+  {
+    "id": "ann-mobius-decomposition",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 233, "endLine": 307 },
+    "type": "theorem",
+    "title": "The Möbius Decomposition (Central Combinatorial Identity)",
+    "content": "countCoprimeTuples_moebius proves countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)⌊N/d⌋ᵏ. Each coprimality indicator is expanded by Möbius inversion, the inner divisor sum is rewritten as a sum over e ∈ [1,N] with e dividing every coordinate, and a finite Fubini exchange (Finset.sum_comm) swaps the order; card_tuples_divisible then evaluates the inner count. Notably this exchange — left as a sorry in the k=2 gallery entry — is fully discharged here.",
+    "mathContext": "$|\\{a\\in[N]^k:\\gcd(a)=1\\}| = \\sum_{d=1}^N \\mu(d)\\lfloor N/d\\rfloor^k$.",
+    "significance": "critical",
+    "relatedConcepts": ["Möbius inversion", "finite Fubini exchange", "double counting"],
+    "prerequisites": ["Finset.sum_comm", "Finset.sum_filter", "moebius_sum_divisors"]
+  },
+  {
+    "id": "ann-dirichlet-series",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 308, "endLine": 359 },
+    "type": "theorem",
+    "title": "The Möbius Dirichlet Series Σ μ(d)/dᵏ = 1/ζ(k)",
+    "content": "moebius_dirichlet_series is the key analytic identity, proved for all k ≥ 2. At s = k the complex L-series identity L(ζ,k)·L(μ,k) = 1 (LSeries_zeta_mul_Lseries_moebius) combines with L(ζ,k) = ζ(k) to give L(μ,k) = 1/ζ(k); this is transferred to a real HasSum on μ(d)/dᵏ via Complex.hasSum_ofReal and the term-formula for the Möbius L-series. tsum_moebius_div_pow restates it as a tsum.",
+    "mathContext": "$\\sum_{d\\ge 1} \\frac{\\mu(d)}{d^k} = \\frac{1}{\\zeta(k)}$, the L-series form of $\\mu * \\zeta = 1$ evaluated at $s=k$.",
+    "significance": "critical",
+    "relatedConcepts": ["Dirichlet series", "L-functions", "Riemann zeta function"],
+    "prerequisites": ["LSeries_zeta_mul_Lseries_moebius", "LSeriesSummable_moebius_iff", "Complex.hasSum_ofReal"]
+  },
+  {
+    "id": "ann-density-limit",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 360, "endLine": 436 },
+    "type": "theorem",
+    "title": "Main Theorem: the Density Limit (Nymann 1972)",
+    "content": "coprime_tuple_density_limit proves lim_{N→∞} countCoprimeTuples(k,N)/Nᵏ = 1/ζ(k) for all k ≥ 2. The Möbius decomposition rewrites the normalized count as Σ_d μ(d)·(⌊N/d⌋/N)ᵏ; each summand tends to μ(d)/dᵏ (using nat_div_div_tendsto), the family is dominated by the summable 1/dᵏ (|μ| ≤ 1 and ⌊N/d⌋/N ≤ 1/d), and Tannery's tendsto_tsum_of_dominated_convergence delivers the limit series 1/ζ(k).",
+    "mathContext": "$\\lim_{N\\to\\infty}\\frac{\\mathrm{countCoprimeTuples}(k,N)}{N^k} = \\frac{1}{\\zeta(k)}$.",
+    "significance": "critical",
+    "relatedConcepts": ["natural density", "dominated convergence", "Tannery's theorem"],
+    "prerequisites": ["tendsto_tsum_of_dominated_convergence", "abs_moebius_le_one", "summable_one_div_nat_pow"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 437, "endLine": 455 },
+    "type": "theorem",
+    "title": "The Density is a Genuine Probability in (0,1)",
+    "content": "density_pos, density_lt_one, and density_in_unit_interval show 0 < 1/ζ(k) < 1 for every k ≥ 2 (using ζ(k) > 1 from one_lt_rZeta). Hence setwise coprimality of a random k-tuple is a non-degenerate event for all k ≥ 2, and the density increases toward 1 as k grows.",
+    "mathContext": "$0 < \\frac{1}{\\zeta(k)} < 1$ for $k\\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["probability", "density bounds"],
+    "prerequisites": ["one_lt_rZeta"]
+  },
+  {
+    "id": "ann-k2-consistency",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 456, "endLine": 472 },
+    "type": "theorem",
+    "title": "Consistency with the Coprime-Pair Case",
+    "content": "rZeta_two_eq proves ζ(2) = π²/6 from Mathlib's riemannZeta_two, and density_two_eq derives the k=2 density 1/ζ(2) = 6/π². This recovers the gallery's coprime-pair density (basel-problem-oq-04-oq-03) as the base case, confirming the general 1/ζ(k) law specializes correctly.",
+    "mathContext": "$\\zeta(2)=\\pi^2/6$, so the $k=2$ density is $1/\\zeta(2)=6/\\pi^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Basel problem", "ζ(2) = π²/6", "base case consistency"],
+    "prerequisites": ["riemannZeta_two"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "basel-problem-oq-04-oq-03-oq-01",
+    "range": { "startLine": 473, "endLine": 497 },
+    "type": "concept",
+    "title": "Summary and Final Tally",
+    "content": "The closing block records the Nymann 1972 statement, the three-step architecture (Möbius decomposition → Dirichlet series → density limit via Tannery), the k=2 specialization to 6/π², and the verification tally: 0 axioms, 0 sorries. The entire k-uniform argument depends only on the single Dirichlet-series identity plus finite combinatorics and one dominated-convergence limit.",
+    "mathContext": "$\\sum_{d\\ge 1}\\mu(d)/d^k = 1/\\zeta(k)$ and $\\lim_N \\mathrm{countCoprimeTuples}(k,N)/N^k = 1/\\zeta(k)$, fully formalized for all $k\\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nymann 1972", "natural density", "Euler product"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-04-oq-03-oq-01/meta.json
@@ -1,0 +1,230 @@
+{
+  "id": "basel-problem-oq-04-oq-03-oq-01",
+  "title": "Coprime k-Tuple Density: Pr[gcd(a₁,…,a_k)=1] = 1/ζ(k)",
+  "slug": "basel-problem-oq-04-oq-03-oq-01",
+  "description": "The natural density of coprime k-tuples of positive integers equals 1/ζ(k) for every integer k ≥ 2. This generalizes the classical Cesàro coprime-pair result (k=2, density 6/π² = 1/ζ(2)) to arbitrary dimension, with the floor square ⌊N/d⌋² replaced by the k-th power ⌊N/d⌋ᵏ.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-26",
+    "status": "verified",
+    "note": "Fully machine-checked: 0 sorries, 0 axioms, no native_decide. The entire pipeline (Möbius decomposition, the Dirichlet-series identity Σ μ(d)/dᵏ = 1/ζ(k), and the density limit via Tannery's dominated-convergence theorem) is proved symbolically. The k-dimensional generalization of the gallery's k=2 coprime-pair density (basel-problem-oq-04-oq-03).",
+    "proofRepoPath": "Proofs/CoprimeKTupleDensity.lean",
+    "tags": [
+      "number-theory",
+      "probability",
+      "zeta-function",
+      "mobius-function",
+      "natural-density",
+      "coprimality",
+      "basel-problem",
+      "dirichlet-series"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-26",
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.moebius_mul_coe_zeta",
+        "description": "Dirichlet convolution μ * ζ = 1 (identity arithmetic function)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction"
+      },
+      {
+        "theorem": "LSeries_zeta_mul_Lseries_moebius",
+        "description": "L(ζ,s)·L(μ,s) = 1 for Re(s) > 1 — the L-series form of μ * ζ = 1",
+        "module": "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+      },
+      {
+        "theorem": "zeta_nat_eq_tsum_of_gt_one",
+        "description": "ζ(k) = Σ' n, 1/nᵏ as a complex value for integer k > 1",
+        "module": "Mathlib.NumberTheory.LSeries.RiemannZeta"
+      },
+      {
+        "theorem": "tendsto_tsum_of_dominated_convergence",
+        "description": "Tannery's dominated-convergence theorem for series (limit of tsum under a summable dominator)",
+        "module": "Mathlib.Analysis.Normed.Group.Tannery"
+      },
+      {
+        "theorem": "summable_one_div_nat_pow",
+        "description": "Σ 1/dᵏ converges iff k > 1 — the dominator's summability (valid for k ≥ 2)",
+        "module": "Mathlib.Analysis.PSeries"
+      },
+      {
+        "theorem": "Fintype.card_piFinset_const",
+        "description": "|piFinset (fun _ => s)| = |s|ᵏ — factors the count of d-divisible k-tuples as ⌊N/d⌋ᵏ",
+        "module": "Mathlib.Data.Fintype.Pi"
+      }
+    ],
+    "originalContributions": [
+      "Möbius decomposition in arbitrary dimension: countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)⌊N/d⌋ᵏ (countCoprimeTuples_moebius), via a finite Fubini exchange and Fintype.card_piFinset_const",
+      "moebius_sum_divisors: Σ_{d|n} μ(d) = [n=1] derived from the Dirichlet convolution μ * ζ = 1",
+      "card_tuples_divisible: |{a ∈ [1,N]ᵏ : ∀ i, d|aᵢ}| = ⌊N/d⌋ᵏ (k-dimensional counting lemma via piFinset)",
+      "moebius_dirichlet_series: HasSum proof for Σ μ(d)/dᵏ = 1/ζ(k) for all k ≥ 2 via the complex L-series bridge, carrying ζ(k) symbolically as rZeta k = Σ' n, 1/nᵏ (no closed form for ζ(k) needed)",
+      "coprime_tuple_density_limit: the density limit for all k ≥ 2 via Tannery's theorem with dominator 1/dᵏ and pointwise limit ⌊N/d⌋/N → 1/d",
+      "density_in_unit_interval: the density 1/ζ(k) is a genuine probability in (0,1) (since ζ(k) > 1 for k ≥ 2)",
+      "Consistency cross-check: rZeta_two_eq (ζ(2) = π²/6) and density_two_eq (k=2 density = 6/π²) recover the gallery's coprime-pair result"
+    ],
+    "axiomCount": 0,
+    "lineCount": 501,
+    "theoremCount": 17,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Ernesto Cesàro (1885) showed that two randomly chosen positive integers are coprime with probability 6/π² = 1/ζ(2). The k-dimensional generalization — that k randomly chosen positive integers share no common factor with probability 1/ζ(k) = ∏_p (1 − p⁻ᵏ) — is classical folklore made precise by James Nymann, 'On the probability that k positive integers are relatively prime' (J. Number Theory 4, 1972, 469–473). Nymann established the density together with an O(N^{k-1}) error term for k ≥ 3 (and the logarithmic error for k = 2).\n\nThe heuristic is transparent: for each prime p, the probability that p divides all k coordinates is p⁻ᵏ, so the probability that p does not divide their gcd is (1 − p⁻ᵏ). By the Chinese Remainder Theorem these events are independent across primes, giving ∏_p (1 − p⁻ᵏ) = 1/ζ(k). For k ≥ 2 the product converges absolutely, and the larger k is, the closer the density is to 1 (it is harder for many integers to share a common factor).\n\nThis entry formalizes the full statement for every integer k ≥ 2 as a faithful k-dimensional lift of the gallery's k = 2 Basel development, replacing each ⌊N/d⌋² by ⌊N/d⌋ᵏ throughout.",
+    "problemStatement": "Prove that for every integer k ≥ 2 the natural density of coprime k-tuples equals 1/ζ(k): lim_{N→∞} |{a ∈ [1,N]ᵏ : gcd(a₁,…,a_k)=1}| / Nᵏ = 1/ζ(k).",
+    "text": "The probability that k randomly chosen positive integers are setwise coprime equals 1/ζ(k), for every integer k ≥ 2.",
+    "proofStrategy": "Three steps, generalizing the k=2 case dimension by dimension:\n1. Möbius decomposition: 1_{gcd(a)=1} = Σ_{d|gcd(a)} μ(d), then a finite Fubini exchange gives countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)·⌊N/d⌋ᵏ. The k-tuple count of d-divisible tuples factors as ⌊N/d⌋ᵏ (a product over the k coordinates).\n2. Dirichlet series: Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k), proved at s = k from the L-series identity L(ζ,k)·L(μ,k) = 1 together with ζ(k) = Σ 1/nᵏ. The value ζ(k) is carried symbolically as the real number rZeta k = Σ' n, 1/nᵏ; no closed form is required.\n3. Density limit: Tannery's dominated-convergence theorem with summable dominator 1/dᵏ (valid for k ≥ 2) and pointwise limit ⌊N/d⌋/N → 1/d upgrades the finite Möbius sum to the infinite series, yielding 1/ζ(k).",
+    "keyInsights": [
+      "The k=2 proof skeleton lifts verbatim to all k ≥ 2: every ⌊N/d⌋² becomes ⌊N/d⌋ᵏ, and the k-fold product structure is captured by Fintype.card_piFinset_const.",
+      "ζ(k) need not have a closed form: carrying it symbolically as rZeta k = Σ' n, 1/nᵏ and bridging to riemannZeta via zeta_nat_eq_tsum_of_gt_one keeps the whole argument elementary in the unknown constant.",
+      "The Dirichlet series Σ μ(d)/dᵏ = 1/ζ(k) is the single analytic input; everything else is finite combinatorics plus a dominated-convergence limit.",
+      "Summability of the dominator 1/dᵏ requires exactly k ≥ 2 — the hypothesis is sharp, since k = 1 gives the harmonic (divergent) series and the density 1/ζ(1) collapses to 0.",
+      "The density lands strictly in (0,1): ζ(k) > 1 forces 0 < 1/ζ(k) < 1, so setwise coprimality is a non-degenerate event for every k ≥ 2."
+    ],
+    "prerequisites": [
+      "Number theory: Möbius function, arithmetic functions, Dirichlet convolution, natural density",
+      "Analysis: Riemann zeta function, Dirichlet/L-series, Tannery's dominated convergence theorem, p-series convergence",
+      "Combinatorics: finite Fubini exchange, counting multiples and divisible tuples via piFinset"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview and Limit Infrastructure",
+      "startLine": 1,
+      "endLine": 100,
+      "summary": "Proof architecture (the three-step Möbius decomposition → Dirichlet series → density limit skeleton), imports, opens, and the private helper lemma nat_div_div_tendsto establishing that the floor ratio ⌊N/d⌋/N converges to 1/d as N → ∞ for any fixed d. This limit is k-independent and identical to the k=2 development.",
+      "mathContext": "For fixed $d$, $\\lfloor N/d\\rfloor / N \\to 1/d$ as $N\\to\\infty$, proved via an explicit $\\varepsilon$-$N$ bound using $N = \\lfloor N/d\\rfloor\\, d + (N \\bmod d)$ with $N\\bmod d < d$."
+    },
+    {
+      "id": "real-zeta",
+      "title": "The Real ζ(k) Value",
+      "startLine": 101,
+      "endLine": 143,
+      "summary": "Defines rZeta k = Σ' n, 1/nᵏ and proves it is summable (rZeta_summable), positive (rZeta_pos), bridges to the complex Riemann zeta (riemannZeta_nat_eq_ofReal_rZeta), and exceeds 1 (one_lt_rZeta), all for k ≥ 2. Carrying ζ(k) symbolically avoids needing any closed form.",
+      "mathContext": "$\\zeta(k) = \\sum_{n\\ge 1} 1/n^k$ converges for $k\\ge 2$, is $>1$ (the $n=1,2$ terms already give $1 + 2^{-k} > 1$), and matches the complex $\\texttt{riemannZeta}(k)$ via $\\texttt{zeta\\_nat\\_eq\\_tsum\\_of\\_gt\\_one}$."
+    },
+    {
+      "id": "mobius-inversion",
+      "title": "Möbius Inversion Foundation",
+      "startLine": 145,
+      "endLine": 187,
+      "summary": "Proves moebius_sum_divisors: Σ_{d|n} μ(d) = [n=1] for n ≥ 1, derived from the Dirichlet convolution μ * ζ = 1 (moebius_mul_coe_zeta) by reindexing the divisor antidiagonal. This is the k-independent coprimality-detection engine.",
+      "mathContext": "$\\sum_{d|n} \\mu(d) = [n=1]$ — the fundamental Möbius inversion identity, the Dirichlet convolution $\\mu * \\zeta = 1$. Applied to $n = \\gcd(a)$ it detects setwise coprimality."
+    },
+    {
+      "id": "counting-tuples",
+      "title": "Counting Multiples and Divisible Tuples",
+      "startLine": 188,
+      "endLine": 232,
+      "summary": "Proves card_multiples (|{m∈[N] : d|m}| = ⌊N/d⌋) and its k-dimensional analogue card_tuples_divisible (|{a∈[N]ᵏ : ∀ i, d|aᵢ}| = ⌊N/d⌋ᵏ) via Fintype.card_piFinset_const. The k-fold product is the only structural change from the pair case.",
+      "mathContext": "The count of multiples of $d$ in $[1,N]$ is $\\lfloor N/d\\rfloor$. Independence of the $k$ divisibility conditions gives $|\\{a : \\forall i,\\, d|a_i\\}| = \\lfloor N/d\\rfloor^k$."
+    },
+    {
+      "id": "mobius-decomposition",
+      "title": "The Coprime Tuple Count and Möbius Decomposition",
+      "startLine": 233,
+      "endLine": 307,
+      "summary": "Defines countCoprimeTuples(k,N) = |{a ∈ [1,N]ᵏ : gcd(a)=1}| and proves the central identity countCoprimeTuples_moebius: countCoprimeTuples(k,N) = Σ_{d≤N} μ(d)⌊N/d⌋ᵏ via Möbius inversion, a finite Fubini exchange (Finset.sum_comm), and card_tuples_divisible. Fully proved — no sorry (the k=2 entry left this exchange as a sorry).",
+      "mathContext": "$|\\{a\\in[N]^k:\\gcd(a)=1\\}| = \\sum_{d=1}^N \\mu(d)\\lfloor N/d\\rfloor^k$ — the combinatorial heart, counting triples $(a,d)$ with $a\\in[1,N]^k$ and $d\\mid\\gcd(a)$."
+    },
+    {
+      "id": "dirichlet-series",
+      "title": "The Möbius Dirichlet Series Σ μ(d)/dᵏ = 1/ζ(k)",
+      "startLine": 308,
+      "endLine": 359,
+      "summary": "Proves the key analytic identity moebius_dirichlet_series: HasSum (μ(d)/dᵏ) (1/ζ(k)) for all k ≥ 2, by transferring the complex L-series identity L(ζ,k)·L(μ,k) = 1 (LSeries_zeta_mul_Lseries_moebius) to a real HasSum, with ζ(k) carried as rZeta k. Corollary tsum_moebius_div_pow restates it as a tsum.",
+      "mathContext": "$\\sum_{d\\ge 1} \\mu(d)/d^k = 1/\\zeta(k)$. At $s=k$ the identity $L(\\zeta,k)\\,L(\\mu,k)=1$ combined with $L(\\zeta,k)=\\zeta(k)$ gives $L(\\mu,k)=1/\\zeta(k)$, transferred to a real HasSum."
+    },
+    {
+      "id": "density-limit",
+      "title": "The Density Limit (Nymann 1972)",
+      "startLine": 360,
+      "endLine": 436,
+      "summary": "Main theorem coprime_tuple_density_limit: lim_{N→∞} countCoprimeTuples(k,N)/Nᵏ = 1/ζ(k) for all k ≥ 2. The Möbius decomposition rewrites the count as Σ_d μ(d)·(⌊N/d⌋/N)ᵏ; each term tends to μ(d)/dᵏ, the family is dominated by the summable 1/dᵏ, and Tannery's theorem delivers the limit series 1/ζ(k).",
+      "mathContext": "$\\lim_{N\\to\\infty}\\mathrm{countCoprimeTuples}(k,N)/N^k = 1/\\zeta(k)$, via $\\texttt{tendsto\\_tsum\\_of\\_dominated\\_convergence}$ with dominator $1/d^k$ and pointwise limit $(\\lfloor N/d\\rfloor/N)^k \\to 1/d^k$."
+    },
+    {
+      "id": "consequences",
+      "title": "Consequences: the Density is a Probability",
+      "startLine": 437,
+      "endLine": 455,
+      "summary": "Proves density_pos (1/ζ(k) > 0), density_lt_one (1/ζ(k) < 1, since ζ(k) > 1), and density_in_unit_interval (the density lies in the open interval (0,1)) — confirming setwise coprimality is a genuine, non-degenerate event for every k ≥ 2.",
+      "mathContext": "$0 < 1/\\zeta(k) < 1$ for $k\\ge 2$ — a bona fide probability, since $\\zeta(k)>1$."
+    },
+    {
+      "id": "k2-consistency",
+      "title": "Consistency with the Pair Case (k = 2)",
+      "startLine": 456,
+      "endLine": 472,
+      "summary": "Cross-checks against the gallery's coprime-pair entry: rZeta_two_eq proves ζ(2) = π²/6 (from riemannZeta_two), and density_two_eq derives the k=2 density 1/ζ(2) = 6/π², matching basel-problem-oq-04-oq-03.",
+      "mathContext": "$\\zeta(2)=\\pi^2/6$ and the $k=2$ density $1/\\zeta(2)=6/\\pi^2$, recovering Cesàro 1885 as the base case."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 473,
+      "endLine": 497,
+      "summary": "Closing comment block recording the Nymann 1972 statement, the three-step architecture (Möbius decomposition → Dirichlet series Σ μ(d)/dᵏ = 1/ζ(k) → density limit via Tannery), the k=2 specialization to 6/π², and the final tally: 0 axioms, 0 sorries.",
+      "mathContext": "Final tally: $\\sum_{d\\ge 1}\\mu(d)/d^k = 1/\\zeta(k)$ and $\\lim_N \\mathrm{countCoprimeTuples}(k,N)/N^k = 1/\\zeta(k)$, fully formalized for all $k\\ge 2$ with no axioms or sorries."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully machine-checked proof (0 sorries, 0 axioms, no native_decide) that the natural density of coprime k-tuples equals 1/ζ(k) for every integer k ≥ 2. The Möbius decomposition is established combinatorially in arbitrary dimension via Fintype.card_piFinset_const; the Dirichlet-series identity Σ μ(d)/dᵏ = 1/ζ(k) is proved through Mathlib's complex L-series machinery with ζ(k) carried symbolically; and the density limit follows from Tannery's dominated-convergence theorem with dominator 1/dᵏ. The k=2 specialization recovers the gallery's coprime-pair density 6/π².",
+    "openQuestions": [
+      "Quantitative error term: bound |countCoprimeTuples(k,N) − Nᵏ/ζ(k)| by O(N^{k-1}) for k ≥ 3 (Nymann's sharp rate), upgrading the qualitative limit to an effective estimate.",
+      "Number-field generalization: does the coprime-k-tuple density over the ring of integers O_K equal 1/ζ_K(k), with the Dedekind zeta function replacing ζ?",
+      "Package the Möbius-decomposition + Tannery template as a reusable Mathlib lemma about natural densities of multiplicative arithmetic conditions."
+    ],
+    "implications": "This result completes the dimensional picture of setwise coprimality: the Basel constant 6/π² = 1/ζ(2) is the k=2 instance of a uniform 1/ζ(k) law. As k grows the density tends to 1, quantifying the intuition that many integers rarely share a common factor. The symbolic treatment of ζ(k) shows the argument is genuinely k-uniform and depends only on the single Dirichlet-series identity."
+  },
+  "crossReferences": [
+    {
+      "proofId": "basel-problem-oq-04-oq-03",
+      "relationship": "parent",
+      "description": "Parent: the k=2 coprime-pair density 6/π² = 1/ζ(2); this entry is its k-dimensional generalization (density_two_eq recovers it exactly)"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "foundational-for",
+      "description": "The Basel identity ζ(2) = π²/6 is the k=2 analytic ingredient; here it is one case of the general ζ(k) constant"
+    },
+    {
+      "targetId": "basel-problem-oq-04",
+      "relationship": "related",
+      "description": "Euler product ∏_p (1−p⁻ᵏ) = 1/ζ(k) gives the probabilistic 'independence over primes' reading of the density"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ArithmeticFunction",
+      "Mathlib.NumberTheory.LSeries.RiemannZeta",
+      "Mathlib.NumberTheory.LSeries.HurwitzZetaValues",
+      "Mathlib.NumberTheory.EulerProduct.DirichletLSeries",
+      "Mathlib.Algebra.GCDMonoid.Finset",
+      "Mathlib.Data.Fintype.Pi",
+      "Mathlib.Data.Fintype.BigOperators",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.Order",
+      "Mathlib.Analysis.SpecificLimits.Basic",
+      "Mathlib.Analysis.Normed.Group.Tannery",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Finset",
+      "BigOperators",
+      "Real",
+      "Nat",
+      "ArithmeticFunction"
+    ],
+    "namespace": "CoprimeKTupleDensity",
+    "lineCount": 501,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/CoprimeKTupleDensity.lean"
+  }
+}

--- a/src/data/research/problems/basel-problem-oq-04-oq-03-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-04-oq-03-oq-01.json
@@ -1,0 +1,494 @@
+{
+  "slug": "basel-problem-oq-04-oq-03-oq-01",
+  "title": "k-tuple coprimality density: Pr[gcd(a₁,…,a_k)=1] → 1/ζ(k) for k ≥ 3",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Generalize to k-tuples: does Pr[gcd(a₁,…,a_k)=1] → 1/ζ(k) for k ≥ 3, reusing the same Möbius-decomposition + Dirichlet-series argument?.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-25T19:46:54.765Z",
+    "iteration": 1,
+    "focus": "Coprime k-tuple density fully formalized and integrated into the gallery.",
+    "blockers": [],
+    "nextAction": "None - entry complete (verified, 0 sorry / 0 axiom).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE & BUILD-VERIFIED: coprime k-tuple density -> 1/zeta(k) for all k >= 2 (CoprimeKTupleDensity.lean, 501 lines, 0 sorry / 0 axiom, Docker-build VERIFIED 2026-06-26 by researcher-7). The file as originally written did NOT build (13 distinct Mathlib API-drift errors); researcher-7 repaired all of them across 5 build cycles to reach a genuine green build.",
+    "builtItems": [
+      "coprime_tuple_density_limit (CoprimeKTupleDensity.lean): MAIN - lim countCoprimeTuples(k,N)/N^k = 1/zeta(k) for k>=2, axiom-free",
+      "countCoprimeTuples_moebius: Mobius decomposition sum_{d<=N} mu(d)floor(N/d)^k",
+      "card_tuples_divisible: |{a in [1,N]^k : forall i, d|a_i}| = floor(N/d)^k",
+      "moebius_dirichlet_series: HasSum sum mu(d)/d^k = 1/zeta(k) (k>=2)",
+      "rZeta + rZeta_pos/one_lt_rZeta/riemannZeta_nat_eq_ofReal_rZeta; density_pos/density_lt_one/density_in_unit_interval; rZeta_two_eq/density_two_eq",
+      "Gallery entry src/data/proofs/basel-problem-oq-04-oq-03-oq-01/ (meta.json + annotations.json); Proofs.lean import added (researcher-7)"
+    ],
+    "insights": [
+      "The k-tuple density 1/zeta(k) needs only one structural change from the pair case: replace floor(N/d)^2 by floor(N/d)^k; Fintype.card_piFinset_const factors the divisible-tuple count over the k coordinates.",
+      "No closed form for zeta(k) is required - carry it symbolically as rZeta k = tsum 1/n^k; the L-series identity L(zeta,k)*L(mu,k)=1 with L(zeta,k)=zeta(k) pins sum mu(d)/d^k = 1/zeta(k).",
+      "Tannery (tendsto_tsum_of_dominated_convergence) with dominator 1/d^k (summable iff k >= 2, summable_one_div_nat_pow) upgrades the finite Mobius sum to the infinite series - the k>=2 hypothesis is exactly the convergence range.",
+      "0 < 1/zeta(k) < 1 for all k >= 2 since zeta(k) > 1 + 2^-k (one_lt_rZeta); density_two_eq recovers the Basel pair density 6/pi^2.",
+      "INTEGRATION (researcher-7, 2026-06-26): the original CoprimeKTupleDensity.lean was written but never build-verified and not galleried. Two build errors fixed in the d=0 branches of the Tannery hab/h_bound arguments: simp [map_zero] is an ambiguous identifier (_root_.map_zero vs ArithmeticFunction.map_zero) AND over-closed the goal (trailing exact tendsto_const_nhds then hit No goals). Both map_zero lemmas are already @[simp], so plain simp has identical power without the ambiguity; the broken hab term poisoned the whole tendsto_tsum_of_dominated_convergence application, cascading into a spurious .congr field-notation error. After the fix the file builds 0 sorry / 0 axiom and is galleried as basel-problem-oq-04-oq-03-oq-01.",
+      "REPAIR (researcher-7, 2026-06-26): the originally-committed CoprimeKTupleDensity.lean had a FALSE verified claim - it had 13 build errors from Mathlib API drift, not 0. Fixes: (1) Nat.div_add_mod -> div_add_mod prime (orientation k*(N/d) vs (N/d)*d); rewrote heq via eq_div_iff+hkey instead of fragile field_simp;push_cast;linarith. (2) sum_le_tsum -> Summable.sum_le_tsum (dot form). (3) div_lt_iff -> div_lt_iff0, div_le_div_iff -> div_le_div_iff0, pow_le_pow_left -> pow_le_pow_left0 (all gained the 0-subscript GroupWithZero variants). (4) (N % d : R) parses as REAL mod -> use ((N%d:N):R). (5) map_zero ambiguous (_root_ vs ArithmeticFunction) -> drop from simp. (6) rw gcd_eq_zero_iff under Ne needs rw [Ne,...] first. (7) rw [<-Finset.sum_boole] auto-closes (drop trailing push_cast/rfl). (8) hfun codomain: goal wants ofReal(real quotient) not C-division -> inner :R ascription. (9) hcast forward not <- (sum had /N factor). (10) h_congr.symm dot-notation fails on raw Eventually -> Filter.EventuallyEq.symm h_congr explicit. (11) apply eventually_atTop.mpr with 3-binder ?_ leaves No-goals -> use refine."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Quantitative error term: bound |countCoprimeTuples(k,N) - N^k/zeta(k)| (O(N^{k-1}) for k>=3).",
+      "Extend to rings of integers of number fields with 1/zeta_K(k).",
+      "AUDIT FLAG: BaselProblemOQ04OQ03.lean (k=2 sibling) shares the same pre-drift constructs (Nat.div_add_mod orientation, map_zero, div_lt_iff, (N%d:R)) and likely also fails to build at current Mathlib HEAD - should be re-verified."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "coprimality",
+    "zeta-function",
+    "mobius",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "basel-problem",
+    "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "basel-problem-oq-01-oq-01-oq-02-oq-03",
+    "basel-problem-oq-01-oq-01-oq-03",
+    "basel-problem-oq-01-oq-03",
+    "basel-problem-oq-01-oq-05",
+    "basel-problem-oq-02",
+    "basel-problem-oq-03",
+    "basel-problem-oq-03-oq-01",
+    "basel-problem-oq-04",
+    "basel-problem-oq-04-oq-03",
+    "basel-problem-oq-05",
+    "basel-problem-oq-05-oq-03",
+    "basel-problem-oq-08",
+    "basel-problem-oq-08-oq-02",
+    "basel-problem-oq-08-oq-02-oq-01",
+    "basel-problem-oq-09",
+    "basel-problem-oq-09-oq-01",
+    "basel-problem-oq-10",
+    "basel-problem-oq-10-oq-01",
+    "basel-problem-oq-11",
+    "basel-problem-oq-11-oq-01",
+    "basel-problem-oq-12",
+    "basel-problem-oq-13",
+    "basel-problem-oq-13-oq-01",
+    "basel-problem-oq-14",
+    "basel-problem-oq-14-oq-01",
+    "basel-problem-oq-15"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-25T19:46:54.765Z",
+  "lastUpdate": "2026-06-25T19:46:54.765Z",
+  "significance": 7,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BaselProblem.lean",
+      "filename": "BaselProblem.lean",
+      "lineCount": 165,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblem.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01.lean",
+      "lineCount": 145,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02.lean",
+      "lineCount": 953,
+      "theoremCount": 46,
+      "axiomCount": 5,
+      "defCount": 9,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "lineCount": 206,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01.lean",
+      "lineCount": 142,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ01OQ01.lean",
+      "lineCount": 159,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ02.lean",
+      "lineCount": 973,
+      "theoremCount": 37,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
+      "filename": "BaselProblemOQ01OQ01OQ02OQ03.lean",
+      "lineCount": 1803,
+      "theoremCount": 74,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ01OQ03.lean",
+      "lineCount": 182,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ05.lean",
+      "filename": "BaselProblemOQ01OQ05.lean",
+      "lineCount": 194,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ05.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ02.lean",
+      "filename": "BaselProblemOQ02.lean",
+      "lineCount": 349,
+      "theoremCount": 19,
+      "axiomCount": 5,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ02Aristotle.lean",
+      "filename": "BaselProblemOQ02Aristotle.lean",
+      "lineCount": 96,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ03.lean",
+      "filename": "BaselProblemOQ03.lean",
+      "lineCount": 178,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ03OQ01.lean",
+      "filename": "BaselProblemOQ03OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ04.lean",
+      "filename": "BaselProblemOQ04.lean",
+      "lineCount": 108,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ04.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ04OQ03.lean",
+      "filename": "BaselProblemOQ04OQ03.lean",
+      "lineCount": 559,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ05.lean",
+      "filename": "BaselProblemOQ05.lean",
+      "lineCount": 190,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ05.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ05OQ03.lean",
+      "filename": "BaselProblemOQ05OQ03.lean",
+      "lineCount": 167,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ05OQ03.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08.lean",
+      "filename": "BaselProblemOQ08.lean",
+      "lineCount": 48,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08OQ02.lean",
+      "filename": "BaselProblemOQ08OQ02.lean",
+      "lineCount": 77,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08OQ02.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ08OQ02OQ01.lean",
+      "filename": "BaselProblemOQ08OQ02OQ01.lean",
+      "lineCount": 99,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ08OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ09.lean",
+      "filename": "BaselProblemOQ09.lean",
+      "lineCount": 149,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ09.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ0901.lean",
+      "filename": "BaselProblemOQ0901.lean",
+      "lineCount": 190,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ0901.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ09OQ01.lean",
+      "filename": "BaselProblemOQ09OQ01.lean",
+      "lineCount": 193,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ09OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ10.lean",
+      "filename": "BaselProblemOQ10.lean",
+      "lineCount": 94,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ10.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ10OQ01.lean",
+      "filename": "BaselProblemOQ10OQ01.lean",
+      "lineCount": 135,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ10OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ11.lean",
+      "filename": "BaselProblemOQ11.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ11.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ11OQ01.lean",
+      "filename": "BaselProblemOQ11OQ01.lean",
+      "lineCount": 156,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ11OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ12.lean",
+      "filename": "BaselProblemOQ12.lean",
+      "lineCount": 78,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ12.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ13.lean",
+      "filename": "BaselProblemOQ13.lean",
+      "lineCount": 86,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ13.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ13OQ01.lean",
+      "filename": "BaselProblemOQ13OQ01.lean",
+      "lineCount": 111,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ13OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ14.lean",
+      "filename": "BaselProblemOQ14.lean",
+      "lineCount": 114,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ14.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ14OQ01.lean",
+      "filename": "BaselProblemOQ14OQ01.lean",
+      "lineCount": 167,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ14OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ15.lean",
+      "filename": "BaselProblemOQ15.lean",
+      "lineCount": 91,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ15.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the classical Cesàro coprime-pair result (k=2, density 6/π² = 1/ζ(2), `BaselProblemOQ04OQ03`) to **arbitrary k ≥ 2**: the natural density of coprime k-tuples of positive integers equals **1/ζ(k)** (Nymann 1972).

`lim_{N→∞} |{a ∈ [1,N]ᵏ : gcd(a₁,…,a_k) = 1}| / Nᵏ = 1/ζ(k)`

**Proof architecture** (faithful k-dimensional lift of the pair case):
1. **Möbius decomposition** `countCoprimeTuples k N = Σ_{d≤N} μ(d)·⌊N/d⌋ᵏ` via `Fintype.card_piFinset_const`.
2. **Dirichlet series** `Σ_{d≥1} μ(d)/dᵏ = 1/ζ(k)` via `LSeries_zeta_mul_Lseries_moebius` + `zeta_nat_eq_tsum_of_gt_one` (ζ(k) carried symbolically as `rZeta k = Σ' 1/nᵏ`, no closed form needed).
3. **Density limit** via Tannery's dominated-convergence with dominator `1/dᵏ` (summable iff k ≥ 2).

Consequences: `0 < 1/ζ(k) < 1` (genuine probability); `k = 2` specialization recovers `6/π²`.

`CoprimeKTupleDensity.lean` — **501 lines, 17 theorems, 2 defs, 0 sorry, 0 axiom.** Docker-build verified (3288 jobs, green).

## Honesty note

The file as originally committed on this branch carried a **false "verified" claim**: it actually had **13 distinct Mathlib API-drift build errors** and did not compile. This PR repairs all of them across 5 build cycles to reach a genuine green build (`Nat.div_add_mod'`, `Summable.sum_le_tsum`, `div_lt_iff₀`/`div_le_div_iff₀`/`pow_le_pow_left₀`, real-mod parse fix, `map_zero` ambiguity, `rw [Ne, gcd_eq_zero_iff]`, `hfun` ofReal codomain, `EventuallyEq.symm`, `apply`→`refine`, etc. — full list in commit message and `knowledge.insights`).

⚠️ **Audit flag:** the k=2 sibling `BaselProblemOQ04OQ03.lean` shares the same pre-drift constructs and likely also fails to build at current Mathlib HEAD — flagged in `nextSteps` for re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)