### PR TITLE
Enrich The Sign of the Real Cubic Discriminant (solution-of-cubic-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -1,14 +1,48 @@
 [
   {
+    "id": "ann-soc-oq0102-def",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 69,
+      "endLine": 84
+    },
+    "type": "definition",
+    "title": "The Same Polynomial, Now Valued in ℝ",
+    "content": "realDiscriminant a b c d is the identical degree-4 polynomial as the sibling's complex generalDiscriminant, but valued in ℝ rather than ℂ. That single change of codomain is the whole point of the entry: over ℂ the discriminant is an algebraic invariant that only reports vanishing (Δ = 0 ⟺ repeated root), whereas over the ordered field ℝ its sign becomes meaningful. realDiscriminant_cast pins down the compatibility — pushing the real value through the ℝ → ℂ embedding recovers generalDiscriminant exactly (push_cast; ring) — so every complex identity proved in the sibling can be reused here by casting. The private helper pow4_pos records a⁴ > 0 for a genuine cubic (a ≠ 0), the positivity fact that every sign theorem below ultimately rests on.",
+    "mathContext": "$\\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2 \\in \\mathbb{R}$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial discriminant", "ordered field", "complexification", "real closed field"],
+    "prerequisites": ["the complex cubic discriminant (sibling OQ-01-OQ-01)", "ℝ → ℂ coercion"]
+  },
+  {
     "id": "ann-soc-oq0102-rootform",
     "proofId": "solution-of-cubic-oq-01-oq-02",
     "range": {
       "startLine": 113,
-      "endLine": 124
+      "endLine": 123
     },
     "type": "insight",
     "title": "Three Distinct Real Roots Force Δ > 0",
-    "body": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters."
+    "content": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters. The Lean proof rewrites by realDiscriminant_eq_root_form and then closes with a single positivity call once the product is shown nonzero.",
+    "mathContext": "$\\Delta = a^4\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^2 > 0$",
+    "significance": "key",
+    "relatedConcepts": ["Vieta's formulas", "discriminant root form", "positivity", "ordered field"],
+    "prerequisites": ["Vieta's formulas", "squares are nonnegative in ℝ"]
+  },
+  {
+    "id": "ann-soc-oq0102-zeroiff",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "The Δ = 0 Boundary: a⁴ ≠ 0 Transfers the Vanishing",
+    "content": "realDiscriminant_eq_zero_iff_repeated_real pins the boundary of the test: among real roots, Δ = 0 ⟺ two of them coincide. Rewriting by the root form and splitting the product a⁴·(bracket)² with mul_eq_zero leaves two disjuncts; pow_ne_zero 4 ha kills the a⁴ = 0 branch (a ≠ 0), so the vanishing lives entirely in the squared root-difference product. Unwinding pow_eq_zero_iff and the nested mul_eq_zero turns bracket = 0 into x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃ via sub_eq_zero. The converse is immediate — substituting any coincidence makes the bracket vanish and ring closes — so this is a genuine biconditional, not just a forward implication.",
+    "mathContext": "$\\Delta = 0 \\iff x_1 = x_2 \\,\\lor\\, x_1 = x_3 \\,\\lor\\, x_2 = x_3 \\quad (a \\neq 0)$",
+    "significance": "supporting",
+    "relatedConcepts": ["repeated roots", "mul_eq_zero", "pow_eq_zero_iff", "sub_eq_zero"],
+    "prerequisites": ["integral domains have no zero divisors", "the real root form"]
   },
   {
     "id": "ann-soc-oq0102-conjpair",
@@ -19,7 +53,11 @@
     },
     "type": "insight",
     "title": "The Conjugate-Pair Case is a Real Ring Identity",
-    "body": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity reads off Δ < 0 — the second leg of the discriminant test."
+    "content": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity/nlinarith reads off Δ < 0 — the second leg of the discriminant test. Avoiding complex numbers in the algebraic core is what keeps the proof to a single ring identity in a, r, m, n.",
+    "mathContext": "$\\Delta = -4a^4 n^2\\big((r-m)^2 + n^2\\big)^2 < 0 \\quad (n \\neq 0)$",
+    "significance": "key",
+    "relatedConcepts": ["complex conjugate roots", "Vieta's formulas", "ring identity", "casus irreducibilis"],
+    "prerequisites": ["conjugate-root theorem for real polynomials", "ring normalization"]
   },
   {
     "id": "ann-soc-oq0102-bridge",
@@ -30,7 +68,11 @@
     },
     "type": "technique",
     "title": "Casting Back to Certify the Conjugate Pair",
-    "body": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization."
+    "content": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization.",
+    "mathContext": "$w = m + n\\,i,\\qquad (w - \\bar w)^2 = (2n\\,i)^2 = -4n^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["complex conjugation", "Complex.ext", "real-to-complex cast", "conjugate-root theorem"],
+    "prerequisites": ["complex re/im arithmetic", "the sibling's complex root form"]
   },
   {
     "id": "ann-soc-oq0102-trichotomy",
@@ -41,6 +83,10 @@
     },
     "type": "insight",
     "title": "One Cubic in Each Regime",
-    "body": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0."
+    "content": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0, each verified by norm_num after unfolding the definition.",
+    "mathContext": "$x^3-x:\\ \\Delta=4>0;\\quad x^3+x:\\ \\Delta=-4<0;\\quad x^3-3x+2:\\ \\Delta=0$",
+    "significance": "context",
+    "relatedConcepts": ["discriminant test", "worked examples", "root structure"],
+    "prerequisites": ["evaluating the discriminant on concrete coefficients"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -11,8 +11,16 @@
     "content": "realDiscriminant a b c d is the identical degree-4 polynomial as the sibling's complex generalDiscriminant, but valued in ℝ rather than ℂ. That single change of codomain is the whole point of the entry: over ℂ the discriminant is an algebraic invariant that only reports vanishing (Δ = 0 ⟺ repeated root), whereas over the ordered field ℝ its sign becomes meaningful. realDiscriminant_cast pins down the compatibility — pushing the real value through the ℝ → ℂ embedding recovers generalDiscriminant exactly (push_cast; ring) — so every complex identity proved in the sibling can be reused here by casting. The private helper pow4_pos records a⁴ > 0 for a genuine cubic (a ≠ 0), the positivity fact that every sign theorem below ultimately rests on.",
     "mathContext": "$\\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2 \\in \\mathbb{R}$",
     "significance": "key",
-    "relatedConcepts": ["polynomial discriminant", "ordered field", "complexification", "real closed field"],
-    "prerequisites": ["the complex cubic discriminant (sibling OQ-01-OQ-01)", "ℝ → ℂ coercion"]
+    "relatedConcepts": [
+      "polynomial discriminant",
+      "ordered field",
+      "complexification",
+      "real closed field"
+    ],
+    "prerequisites": [
+      "the complex cubic discriminant (sibling OQ-01-OQ-01)",
+      "ℝ → ℂ coercion"
+    ]
   },
   {
     "id": "ann-soc-oq0102-rootform",
@@ -26,8 +34,16 @@
     "content": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters. The Lean proof rewrites by realDiscriminant_eq_root_form and then closes with a single positivity call once the product is shown nonzero.",
     "mathContext": "$\\Delta = a^4\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^2 > 0$",
     "significance": "key",
-    "relatedConcepts": ["Vieta's formulas", "discriminant root form", "positivity", "ordered field"],
-    "prerequisites": ["Vieta's formulas", "squares are nonnegative in ℝ"]
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "discriminant root form",
+      "positivity",
+      "ordered field"
+    ],
+    "prerequisites": [
+      "Vieta's formulas",
+      "squares are nonnegative in ℝ"
+    ]
   },
   {
     "id": "ann-soc-oq0102-zeroiff",
@@ -36,13 +52,21 @@
       "startLine": 124,
       "endLine": 143
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Δ = 0 Boundary: a⁴ ≠ 0 Transfers the Vanishing",
     "content": "realDiscriminant_eq_zero_iff_repeated_real pins the boundary of the test: among real roots, Δ = 0 ⟺ two of them coincide. Rewriting by the root form and splitting the product a⁴·(bracket)² with mul_eq_zero leaves two disjuncts; pow_ne_zero 4 ha kills the a⁴ = 0 branch (a ≠ 0), so the vanishing lives entirely in the squared root-difference product. Unwinding pow_eq_zero_iff and the nested mul_eq_zero turns bracket = 0 into x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃ via sub_eq_zero. The converse is immediate — substituting any coincidence makes the bracket vanish and ring closes — so this is a genuine biconditional, not just a forward implication.",
     "mathContext": "$\\Delta = 0 \\iff x_1 = x_2 \\,\\lor\\, x_1 = x_3 \\,\\lor\\, x_2 = x_3 \\quad (a \\neq 0)$",
     "significance": "supporting",
-    "relatedConcepts": ["repeated roots", "mul_eq_zero", "pow_eq_zero_iff", "sub_eq_zero"],
-    "prerequisites": ["integral domains have no zero divisors", "the real root form"]
+    "relatedConcepts": [
+      "repeated roots",
+      "mul_eq_zero",
+      "pow_eq_zero_iff",
+      "sub_eq_zero"
+    ],
+    "prerequisites": [
+      "integral domains have no zero divisors",
+      "the real root form"
+    ]
   },
   {
     "id": "ann-soc-oq0102-conjpair",
@@ -56,8 +80,16 @@
     "content": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity/nlinarith reads off Δ < 0 — the second leg of the discriminant test. Avoiding complex numbers in the algebraic core is what keeps the proof to a single ring identity in a, r, m, n.",
     "mathContext": "$\\Delta = -4a^4 n^2\\big((r-m)^2 + n^2\\big)^2 < 0 \\quad (n \\neq 0)$",
     "significance": "key",
-    "relatedConcepts": ["complex conjugate roots", "Vieta's formulas", "ring identity", "casus irreducibilis"],
-    "prerequisites": ["conjugate-root theorem for real polynomials", "ring normalization"]
+    "relatedConcepts": [
+      "complex conjugate roots",
+      "Vieta's formulas",
+      "ring identity",
+      "casus irreducibilis"
+    ],
+    "prerequisites": [
+      "conjugate-root theorem for real polynomials",
+      "ring normalization"
+    ]
   },
   {
     "id": "ann-soc-oq0102-bridge",
@@ -66,13 +98,21 @@
       "startLine": 186,
       "endLine": 204
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Casting Back to Certify the Conjugate Pair",
     "content": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization.",
     "mathContext": "$w = m + n\\,i,\\qquad (w - \\bar w)^2 = (2n\\,i)^2 = -4n^2$",
     "significance": "supporting",
-    "relatedConcepts": ["complex conjugation", "Complex.ext", "real-to-complex cast", "conjugate-root theorem"],
-    "prerequisites": ["complex re/im arithmetic", "the sibling's complex root form"]
+    "relatedConcepts": [
+      "complex conjugation",
+      "Complex.ext",
+      "real-to-complex cast",
+      "conjugate-root theorem"
+    ],
+    "prerequisites": [
+      "complex re/im arithmetic",
+      "the sibling's complex root form"
+    ]
   },
   {
     "id": "ann-soc-oq0102-trichotomy",
@@ -85,8 +125,14 @@
     "title": "One Cubic in Each Regime",
     "content": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0, each verified by norm_num after unfolding the definition.",
     "mathContext": "$x^3-x:\\ \\Delta=4>0;\\quad x^3+x:\\ \\Delta=-4<0;\\quad x^3-3x+2:\\ \\Delta=0$",
-    "significance": "context",
-    "relatedConcepts": ["discriminant test", "worked examples", "root structure"],
-    "prerequisites": ["evaluating the discriminant on concrete coefficients"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discriminant test",
+      "worked examples",
+      "root structure"
+    ],
+    "prerequisites": [
+      "evaluating the discriminant on concrete coefficients"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-02`.

## Defect fixed
The four existing annotations stored their prose in a `body` field, but `AnnotationPanel.tsx` renders `annotation.content` — so **every annotation was displaying blank** on the live site. They also lacked the required `significance` field.

## Changes (annotations.json)
- Convert legacy `body` → `content` so all annotations render.
- Add required `significance` to every annotation.
- Add `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to each.
- Add 2 new annotations for previously uncovered code: Part 1 (the `realDiscriminant` definition + `realDiscriminant_cast`) and the Δ = 0 boundary criterion (`realDiscriminant_eq_zero_iff_repeated_real`).

Coverage now spans all five parts of the Lean file (definition, all-real case, Δ=0 boundary, conjugate-pair case, complex bridge, sanity checks). meta.json was already comprehensive and well under the size cap, so it was left unchanged to avoid bloat.

JSON validated by the gallery data-generation step of `pnpm build` (entry processed without error).