### PR TITLE
research: regular bipartite graphs have a perfect matching (halls-theorem-oq-01-oq-03)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3238,6 +3238,7 @@ import Proofs.HallMarriageTheoremOQ01OQ01OQ01
 import Proofs.HallMarriageTheoremOQ01OQ01OQ01OQ01
 import Proofs.HallsTheoremOQ01
 import Proofs.HallsTheoremOQ01OQ01
+import Proofs.HallsTheoremOQ01OQ03
 import Proofs.HallsTheoremOQ02
 import Proofs.HaltingProblem
 import Proofs.HappyNumberOQ01

--- a/proofs/Proofs/HallsTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/HallsTheoremOQ01OQ03.lean
@@ -1,0 +1,150 @@
+/-
+# Regular bipartite graphs have a perfect matching (Hall, OQ-01 → OQ-03)
+
+Open Question: halls-theorem-oq-01-oq-03
+Parent gallery entry: halls-theorem-oq-01 (the full biconditional bipartite Hall theorem).
+
+## Context
+
+The parent `HallsTheoremOQ01` and its companions establish Hall's marriage theorem as a
+biconditional for (locally finite) bipartite graphs. This file records two consequences at
+the **`Finset` transversal** level, where Mathlib packages the marriage theorem as
+
+  `Finset.all_card_le_biUnion_card_iff_exists_injective`
+    `: (∀ s, #s ≤ #(s.biUnion t)) ↔ ∃ f, Function.Injective f ∧ ∀ i, f i ∈ t i`,
+
+i.e. an injective **system of distinct representatives** (SDR) exists iff Hall's condition
+holds. The first consequence (`exists_sdr_of_hall`) is exactly the forward direction, recorded
+explicitly as the SDR existence statement.
+
+The second, and the genuinely new content, is the classical **regularity application**, which
+is absent from both Mathlib and the existing gallery (the gallery has the *conditional* matching
+theorems, but not the regular case): *every `k`-regular bipartite graph with `k ≥ 1` carries a
+perfect matching.* The whole point is that regularity is verified by a **double-counting**
+estimate rather than checked by hand:
+
+* `sum_card_eq` — the fundamental double-counting identity: the incidences leaving a left set
+  `s` can be summed either over `s` (by degree) or over the right vertices (by `s`-back-degree);
+* `card_eq_of_regular` — `k`-biregularity (`k ≥ 1`) forces `|ι| = |α|` (balance);
+* `hall_condition_of_regular` — `k`-biregularity forces Hall's condition `#s ≤ #(s.biUnion t)`
+  (the core estimate `k·#s ≤ k·#(s.biUnion t)`);
+* `exists_perfect_matching_of_regular` — combining the two with the marriage theorem yields a
+  **bijective** transversal `f : ι → α` with `f i ∈ t i`: a perfect matching.
+
+This is the matching-theory backbone behind, e.g., bipartite edge-colouring and the
+Birkhoff–von Neumann theorem, where regularity is the standard hypothesis that makes Hall's
+condition automatic.
+
+## Sorries: 0   Axioms: 0
+-/
+import Mathlib
+
+open Finset
+
+namespace HallsTheoremOQ01OQ03
+
+variable {ι α : Type*} [Fintype ι] [Fintype α] [DecidableEq ι] [DecidableEq α]
+
+/-- The neighbourhood function `t` of a bipartite incidence structure is **`k`-biregular** if
+every left vertex `i` has exactly `k` neighbours, and every right vertex `a` is a neighbour of
+exactly `k` left vertices. -/
+structure IsBiregular (t : ι → Finset α) (k : ℕ) : Prop where
+  /-- Every left vertex has degree `k`. -/
+  left : ∀ i, (t i).card = k
+  /-- Every right vertex has back-degree `k`. -/
+  right : ∀ a, (univ.filter (fun i => a ∈ t i)).card = k
+
+omit [Fintype ι] [Fintype α] [DecidableEq ι] in
+/-- **Double-counting identity.** For a set `s` of left vertices and any superset `B` of the
+neighbourhood `s.biUnion t`, the total number of incidences emanating from `s` equals the sum,
+over the right vertices in `B`, of the number of `s`-neighbours of each. Both sides count the
+set of incident pairs `{(i, a) : i ∈ s, a ∈ t i}`. -/
+lemma sum_card_eq (t : ι → Finset α) (s : Finset ι) {B : Finset α}
+    (hB : s.biUnion t ⊆ B) :
+    ∑ i ∈ s, (t i).card = ∑ a ∈ B, (s.filter (fun i => a ∈ t i)).card := by
+  -- Expand each degree as a sum of indicators over `B`.
+  have key : ∀ i ∈ s, (t i).card = ∑ a ∈ B, (if a ∈ t i then 1 else 0) := by
+    intro i hi
+    have hsub : t i ⊆ B := fun a ha => hB (Finset.mem_biUnion.mpr ⟨i, hi, ha⟩)
+    have hfilt : (B.filter (fun a => a ∈ t i)) = t i := by
+      apply Finset.ext; intro a
+      simp only [Finset.mem_filter]
+      exact ⟨fun h => h.2, fun h => ⟨hsub h, h⟩⟩
+    calc (t i).card = (B.filter (fun a => a ∈ t i)).card := by rw [hfilt]
+      _ = ∑ a ∈ B, (if a ∈ t i then 1 else 0) := by rw [Finset.card_filter]
+  calc ∑ i ∈ s, (t i).card
+      = ∑ i ∈ s, ∑ a ∈ B, (if a ∈ t i then 1 else 0) := Finset.sum_congr rfl key
+    _ = ∑ a ∈ B, ∑ i ∈ s, (if a ∈ t i then 1 else 0) := Finset.sum_comm
+    _ = ∑ a ∈ B, (s.filter (fun i => a ∈ t i)).card := by
+          apply Finset.sum_congr rfl; intro a _; rw [Finset.card_filter]
+
+/-- **Balance.** A `k`-biregular incidence structure with `k ≥ 1` has equally many left and
+right vertices: `|ι| = |α|`. Both counts equal the total number of incidences divided by `k`. -/
+lemma card_eq_of_regular {t : ι → Finset α} {k : ℕ} (h : IsBiregular t k) (hk : 1 ≤ k) :
+    Fintype.card ι = Fintype.card α := by
+  have hsum : ∑ i : ι, (t i).card
+      = ∑ a : α, (univ.filter (fun i => a ∈ t i)).card :=
+    sum_card_eq t univ (Finset.subset_univ _)
+  have hL : ∑ i : ι, (t i).card = Fintype.card ι * k := by
+    rw [Finset.sum_congr rfl (fun i _ => h.left i), Finset.sum_const, Finset.card_univ,
+      smul_eq_mul]
+  have hR : ∑ a : α, (univ.filter (fun i => a ∈ t i)).card = Fintype.card α * k := by
+    rw [Finset.sum_congr rfl (fun a _ => h.right a), Finset.sum_const, Finset.card_univ,
+      smul_eq_mul]
+  have : Fintype.card ι * k = Fintype.card α * k := by rw [← hL, ← hR, hsum]
+  exact Nat.eq_of_mul_eq_mul_right hk this
+
+/-- **Hall's condition holds for regular structures.** If `t` is `k`-biregular with `k ≥ 1`,
+then every set `s` of left vertices satisfies `#s ≤ #(s.biUnion t)`. The estimate comes from
+double counting: the `k·#s` incidences out of `s` all land in `s.biUnion t`, where each vertex
+absorbs at most `k` of them, so `k·#s ≤ k·#(s.biUnion t)`. -/
+lemma hall_condition_of_regular {t : ι → Finset α} {k : ℕ} (h : IsBiregular t k) (hk : 1 ≤ k)
+    (s : Finset ι) : s.card ≤ (s.biUnion t).card := by
+  have hcount : ∑ i ∈ s, (t i).card
+      = ∑ a ∈ s.biUnion t, (s.filter (fun i => a ∈ t i)).card :=
+    sum_card_eq t s (subset_refl _)
+  have hLHS : ∑ i ∈ s, (t i).card = k * s.card := by
+    rw [Finset.sum_congr rfl (fun i _ => h.left i), Finset.sum_const, smul_eq_mul, mul_comm]
+  -- Each right vertex has at most `k` back-neighbours in `s` (it has exactly `k` overall).
+  have hfib : ∀ a ∈ s.biUnion t, (s.filter (fun i => a ∈ t i)).card ≤ k := by
+    intro a _
+    calc (s.filter (fun i => a ∈ t i)).card
+        ≤ (univ.filter (fun i => a ∈ t i)).card :=
+          Finset.card_le_card (Finset.filter_subset_filter _ (Finset.subset_univ s))
+      _ = k := h.right a
+  have hRHS : ∑ a ∈ s.biUnion t, (s.filter (fun i => a ∈ t i)).card
+      ≤ k * (s.biUnion t).card := by
+    calc ∑ a ∈ s.biUnion t, (s.filter (fun i => a ∈ t i)).card
+        ≤ ∑ _a ∈ s.biUnion t, k := Finset.sum_le_sum hfib
+      _ = k * (s.biUnion t).card := by rw [Finset.sum_const, smul_eq_mul, mul_comm]
+  have hkey : k * s.card ≤ k * (s.biUnion t).card := by rw [← hLHS, hcount]; exact hRHS
+  exact Nat.le_of_mul_le_mul_left hkey hk
+
+omit [Fintype ι] [Fintype α] [DecidableEq ι] in
+/-- **System of distinct representatives (SDR) from Hall's condition.** The forward direction of
+Mathlib's marriage theorem, recorded explicitly: if every subfamily `s` satisfies
+`#s ≤ #(s.biUnion t)`, then the family `t` admits an injective transversal `f` with `f i ∈ t i`
+for every `i`. -/
+theorem exists_sdr_of_hall (t : ι → Finset α)
+    (H : ∀ s : Finset ι, s.card ≤ (s.biUnion t).card) :
+    ∃ f : ι → α, Function.Injective f ∧ ∀ i, f i ∈ t i :=
+  (Finset.all_card_le_biUnion_card_iff_exists_injective t).1 H
+
+/-- **Every `k`-regular bipartite graph with `k ≥ 1` has a perfect matching.**
+Phrased via the neighbourhood function `t`: there is a **bijection** `f : ι → α` with
+`f i ∈ t i` for every left vertex `i`.
+
+The proof assembles three facts: regularity forces Hall's condition
+(`hall_condition_of_regular`), Hall's condition yields an injective transversal
+(`exists_sdr_of_hall`), and regularity forces `|ι| = |α|` (`card_eq_of_regular`), so the
+injective transversal between equinumerous finite types is automatically bijective. -/
+theorem exists_perfect_matching_of_regular {t : ι → Finset α} {k : ℕ}
+    (h : IsBiregular t k) (hk : 1 ≤ k) :
+    ∃ f : ι → α, Function.Bijective f ∧ ∀ i, f i ∈ t i := by
+  obtain ⟨f, hinj, hf⟩ :=
+    exists_sdr_of_hall t (hall_condition_of_regular h hk)
+  refine ⟨f, ?_, hf⟩
+  rw [Fintype.bijective_iff_injective_and_card]
+  exact ⟨hinj, card_eq_of_regular h hk⟩
+
+end HallsTheoremOQ01OQ03

--- a/src/data/proofs/halls-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "htoq0103-ann-01",
+    "proofId": "halls-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 51,
+      "endLine": 56
+    },
+    "type": "definition",
+    "title": "IsBiregular: Modelling a k-Regular Bipartite Graph by its Neighbourhoods",
+    "content": "`IsBiregular t k` packages the two regularity conditions on the neighbourhood function `t : ι → Finset α` of a bipartite graph: `left` says every left vertex `i` has exactly `k` neighbours, `#(t i) = k`; `right` says every right vertex `a` is a neighbour of exactly `k` left vertices, `#(univ.filter (fun i => a ∈ t i)) = k`. Encoding the bipartite structure by `t` rather than a `SimpleGraph` keeps the whole development at the indexed-Finset level, exactly where Mathlib's marriage theorem lives, so no graph/ncard plumbing is needed.",
+    "mathContext": "$\\forall i,\\ |t\\,i| = k \\quad\\text{and}\\quad \\forall a,\\ |\\{i : a \\in t\\,i\\}| = k.$",
+    "significance": "high",
+    "relatedConcepts": [
+      "regular bipartite graph",
+      "neighbourhood function",
+      "left-degree and right-back-degree"
+    ],
+    "prerequisites": [
+      "Finset.card",
+      "Finset.filter"
+    ]
+  },
+  {
+    "id": "htoq0103-ann-02",
+    "proofId": "halls-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 62,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "sum_card_eq: Counting Incidences Two Ways",
+    "content": "`sum_card_eq` is the engine of the entire proof. For a set `s` of left vertices and any superset `B` of the neighbourhood `s.biUnion t`, it equates the two ways of counting the incident pairs `{(i,a) : i ∈ s, a ∈ t i}`: summing degrees over `s` on the left, summing `s`-back-degrees over `B` on the right. The proof rewrites each degree `#(t i)` as a sum of 0/1 indicators via `Finset.card_filter`, then swaps the order of the resulting double sum with `Finset.sum_comm`, and reads the inner sums back as cardinalities. Allowing an arbitrary superset `B` is what makes the lemma do double duty downstream (B = univ for balance, B = s.biUnion t for Hall's condition).",
+    "mathContext": "$\\sum_{i \\in s} |t\\,i| \\;=\\; \\sum_{a \\in B} |\\{i \\in s : a \\in t\\,i\\}| \\qquad (s.\\mathrm{biUnion}\\,t \\subseteq B).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "double counting",
+      "incidence pairs",
+      "Fubini for finite sums"
+    ],
+    "prerequisites": [
+      "Finset.card_filter",
+      "Finset.sum_comm"
+    ]
+  },
+  {
+    "id": "htoq0103-ann-03",
+    "proofId": "halls-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 83,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "card_eq_of_regular: Regularity Forces |ι| = |α|",
+    "content": "Instantiating `sum_card_eq` with `B = univ` makes both sides count all incidences of the graph. By `left` the total degree is `k·|ι|`; by `right` the total back-degree is `k·|α|`. Hence `k·|ι| = k·|α|`, and cancelling the positive factor `k` (here `1 ≤ k`) gives the balance `|ι| = |α|`. This balance is precisely what later turns an injective transversal into a bijection.",
+    "mathContext": "$k\\,|\\iota| = \\sum_i |t\\,i| = \\sum_a |\\{i : a \\in t\\,i\\}| = k\\,|\\alpha| \\;\\Rightarrow\\; |\\iota| = |\\alpha|.$",
+    "significance": "high",
+    "relatedConcepts": [
+      "double counting the edge set",
+      "balanced bipartition",
+      "cancellation of a positive factor"
+    ],
+    "prerequisites": [
+      "Finset.sum_const",
+      "Nat.eq_of_mul_eq_mul_right"
+    ]
+  },
+  {
+    "id": "htoq0103-ann-04",
+    "proofId": "halls-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 101,
+      "endLine": 125
+    },
+    "type": "technique",
+    "title": "hall_condition_of_regular: Regularity Forces Hall's Condition",
+    "content": "The crux. Instantiating `sum_card_eq` with `B = s.biUnion t` writes the `k·#s` incidences leaving `s` (left side, by `left`) as a sum over the right vertices of `s.biUnion t`. Each such vertex absorbs at most its full back-degree `k` (the `s`-back-degree is bounded by the universal one, which equals `k` by `right`), so the right side is at most `k·#(s.biUnion t)`. Therefore `k·#s ≤ k·#(s.biUnion t)`, and cancelling `k > 0` yields Hall's condition `#s ≤ #(s.biUnion t)`. This is where regularity is converted, with no hand-checking, into the hypothesis the marriage theorem needs.",
+    "mathContext": "$k\\,\\#s = \\sum_{a \\in N(s)} |\\{i \\in s : a \\in t\\,i\\}| \\le \\sum_{a \\in N(s)} k = k\\,\\#N(s) \\;\\Rightarrow\\; \\#s \\le \\#N(s).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Hall's condition",
+      "double counting bound",
+      "back-degree at most k"
+    ],
+    "prerequisites": [
+      "Finset.sum_le_sum",
+      "Finset.card_le_card",
+      "Nat.le_of_mul_le_mul_left"
+    ]
+  },
+  {
+    "id": "htoq0103-ann-05",
+    "proofId": "halls-theorem-oq-01-oq-03",
+    "range": {
+      "startLine": 128,
+      "endLine": 150
+    },
+    "type": "concept",
+    "title": "From SDR to a Perfect Matching",
+    "content": "`exists_sdr_of_hall` records the forward direction of Mathlib's marriage theorem explicitly as system-of-distinct-representatives existence — the open question's literal ask. `exists_perfect_matching_of_regular` then assembles the result: `hall_condition_of_regular` feeds Hall's condition into the marriage theorem to get an injective transversal `f : ι → α` with `f i ∈ t i`, and `card_eq_of_regular` supplies `|ι| = |α|`, so `Fintype.bijective_iff_injective_and_card` upgrades the injection to a bijection. A bijective transversal respecting the neighbourhoods is exactly a perfect matching of the regular bipartite graph.",
+    "mathContext": "$\\text{Hall} \\Rightarrow \\exists f\\ \\text{inj},\\ f i \\in t\\,i;\\quad |\\iota| = |\\alpha| \\Rightarrow f\\ \\text{bijective} \\Rightarrow \\text{perfect matching}.$",
+    "significance": "high",
+    "relatedConcepts": [
+      "system of distinct representatives",
+      "perfect matching",
+      "injection between equinumerous finite types is a bijection"
+    ],
+    "prerequisites": [
+      "Finset.all_card_le_biUnion_card_iff_exists_injective",
+      "Fintype.bijective_iff_injective_and_card"
+    ]
+  }
+]

--- a/src/data/proofs/halls-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "halls-theorem-oq-01-oq-03",
+  "title": "Regular Bipartite Graphs Have a Perfect Matching (Hall via Double Counting)",
+  "slug": "halls-theorem-oq-01-oq-03",
+  "description": "Mathlib packages Hall's marriage theorem at the indexed-Finset level as Finset.all_card_le_biUnion_card_iff_exists_injective: a family t : ι → Finset α admits an injective system of distinct representatives (SDR) iff Hall's condition ∀ s, #s ≤ #(s.biUnion t) holds. Two consequences are recorded here. First, exists_sdr_of_hall states the forward direction explicitly as SDR existence. Second, and the genuinely new content, exists_perfect_matching_of_regular proves the classical regularity application — absent from both Mathlib and the gallery, which carry only the conditional matching theorems: every k-regular bipartite graph with k ≥ 1 has a perfect matching. We model the bipartite incidence structure by its neighbourhood function t and call it k-biregular when every left vertex i has #(t i) = k and every right vertex a has exactly k left-neighbours. The point is that Hall's condition is then automatic via double counting rather than checked by hand: the engine is sum_card_eq, the identity ∑_{i∈s} #(t i) = ∑_{a∈B} #{i∈s : a∈t i} for any B ⊇ s.biUnion t (both count the incident pairs). Applied with B = s.biUnion t and the regularity hypotheses it gives k·#s ≤ k·#(s.biUnion t), hence #s ≤ #(s.biUnion t) (hall_condition_of_regular); applied with B = univ it gives k·|ι| = k·|α|, hence |ι| = |α| (card_eq_of_regular). Feeding Hall's condition into the marriage theorem yields an injective transversal which, being an injection between equinumerous finite types, is automatically a bijection — a perfect matching. This is the matching-theory backbone behind bipartite edge-colouring and the Birkhoff–von Neumann theorem.",
+  "meta": {
+    "author": "Classical (Frobenius / König matching theory); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem",
+    "date": "1916",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "matching",
+      "halls-marriage-theorem",
+      "systems-of-distinct-representatives",
+      "regular-graph",
+      "double-counting"
+    ],
+    "proofRepoPath": "Proofs/HallsTheoremOQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 150,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.all_card_le_biUnion_card_iff_exists_injective",
+        "description": "Mathlib's marriage theorem for an indexed family of finite sets: Hall's condition ∀ s, #s ≤ #(s.biUnion t) iff there is an injective system of distinct representatives. The forward direction supplies the transversal, after the regularity hypotheses are shown to imply Hall's condition.",
+        "module": "Mathlib.Combinatorics.Hall.Basic"
+      },
+      {
+        "theorem": "Finset.card_filter",
+        "description": "#(s.filter p) = ∑ a ∈ s, if p a then 1 else 0 — converts each degree/back-degree into a sum of indicators, the bridge that lets Finset.sum_comm swap the order of the incidence count in sum_card_eq.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of a double sum, turning ∑_{i∈s} ∑_{a∈B} 1[a∈t i] (degree count) into ∑_{a∈B} ∑_{i∈s} 1[a∈t i] (back-degree count) — the heart of the double-counting identity sum_card_eq.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Fintype.bijective_iff_injective_and_card",
+        "description": "A map between finite types is bijective iff it is injective and the cardinalities agree. Upgrades the injective transversal to a bijective (perfect) matching using card_eq_of_regular.",
+        "module": "Mathlib.Logic.Equiv.Fintype"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_right / Nat.le_of_mul_le_mul_left",
+        "description": "Cancellation of a positive factor k, used to pass from k·|ι| = k·|α| to |ι| = |α| and from k·#s ≤ k·#(s.biUnion t) to #s ≤ #(s.biUnion t).",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "exists_perfect_matching_of_regular: every k-regular bipartite graph (k ≥ 1), modelled by its neighbourhood function t, admits a bijective transversal f : ι → α with f i ∈ t i — a perfect matching. Absent from Mathlib and from the gallery, both of which carry only the conditional marriage/perfect-matching theorems (matching exists IF Hall's condition holds), never the regular case where the condition is supplied automatically.",
+      "sum_card_eq: the reusable double-counting identity ∑_{i∈s} #(t i) = ∑_{a∈B} #{i∈s : a∈t i} for any superset B of s.biUnion t, proved by rewriting degrees as indicator sums (Finset.card_filter) and swapping the order of summation (Finset.sum_comm). Both sides count the incident pairs {(i,a) : i∈s, a∈t i}.",
+      "hall_condition_of_regular: k-biregularity forces Hall's condition. Instantiating sum_card_eq with B = s.biUnion t bounds the k·#s incidences out of s by the at-most-k absorbed at each of the #(s.biUnion t) right vertices, giving k·#s ≤ k·#(s.biUnion t).",
+      "card_eq_of_regular: k-biregularity forces the balance |ι| = |α|. Instantiating sum_card_eq with B = univ equates the two ways of counting the total incidences, k·|ι| = k·|α|.",
+      "exists_sdr_of_hall: the SDR existence statement recorded explicitly as the forward direction of the marriage theorem, the direct answer to the open question's literal ask."
+    ],
+    "dateAdded": "2026-06-25",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "That every regular bipartite graph decomposes into perfect matchings goes back to König (1916) and Frobenius, and is the combinatorial core behind bipartite edge-colouring (a k-regular bipartite graph is k-edge-colourable) and the Birkhoff–von Neumann theorem (a doubly stochastic matrix is a convex combination of permutation matrices). The mechanism is always the same: regularity makes Hall's condition hold automatically, by a one-line double count, so the marriage theorem applies. Mathlib formalises the marriage theorem itself (both the indexed-Finset SDR form and the bipartite SimpleGraph form) but not this regular application; the gallery's Hall entries likewise stop at the conditional statements.",
+    "problemStatement": "Model a finite bipartite incidence structure by its neighbourhood function $t : \\iota \\to \\mathrm{Finset}\\,\\alpha$, with $\\iota$ the left vertices and $\\alpha$ the right vertices. Call $t$ $k$-biregular if every left vertex $i$ has $|t\\,i| = k$ and every right vertex $a$ is a neighbour of exactly $k$ left vertices. Show that for $k \\ge 1$ there is a bijection $f : \\iota \\to \\alpha$ with $f\\,i \\in t\\,i$ for every $i$ — a perfect matching. Record en route the system-of-distinct-representatives form of Hall's theorem.",
+    "proofStrategy": "Everything reduces to one double-counting identity. sum_card_eq says that for any set s of left vertices and any superset B of the neighbourhood s.biUnion t, the incidences leaving s can be summed either over s by degree or over B by s-back-degree: ∑_{i∈s} #(t i) = ∑_{a∈B} #{i∈s : a∈t i}. It is proved by writing each degree as a sum of 0/1 indicators (Finset.card_filter) and swapping the order of summation (Finset.sum_comm); both sides count the pairs {(i,a) : i∈s, a∈t i}. Two instantiations do all the work. With B = univ, the left side is k·|ι| (every left vertex has degree k) and the right side is k·|α| (every right vertex has back-degree k), so |ι| = |α| after cancelling k > 0 (card_eq_of_regular). With B = s.biUnion t, the left side is k·#s, and on the right each of the #(s.biUnion t) vertices absorbs at most its total back-degree k, so k·#s ≤ k·#(s.biUnion t), i.e. Hall's condition #s ≤ #(s.biUnion t) (hall_condition_of_regular). Mathlib's marriage theorem turns Hall's condition into an injective transversal f with f i ∈ t i; since |ι| = |α| and the types are finite, an injection is a bijection (Fintype.bijective_iff_injective_and_card), giving the perfect matching.",
+    "keyInsights": [
+      "Regularity is exactly the hypothesis that makes Hall's condition free: the same k that bounds each vertex's degree from above bounds the back-degrees from above, and double counting turns 'degree out of s' = 'absorbed in N(s)' into the inequality #s ≤ #(N(s)).",
+      "A single identity, sum_card_eq, yields both the balance |ι| = |α| (take B = univ) and Hall's condition (take B = s.biUnion t); choosing the summation range B is the only thing that changes.",
+      "Counting incident pairs two ways is the whole proof: ∑ degrees over the left = ∑ back-degrees over the right, made rigorous by Finset.card_filter + Finset.sum_comm.",
+      "Balance plus injectivity is automatically bijectivity for finite types, so the SDR produced by the marriage theorem is already a perfect matching — no separate surjectivity argument is needed."
+    ],
+    "prerequisites": [
+      "Hall's marriage theorem and systems of distinct representatives (Finset.all_card_le_biUnion_card_iff_exists_injective)",
+      "Finset cardinality, filters, bounded unions (Finset.card, filter, biUnion)",
+      "Double counting via indicator sums and Finset.sum_comm",
+      "Injections between finite types of equal cardinality are bijections (Fintype.bijective_iff_injective_and_card)"
+    ]
+  },
+  "conclusion": {
+    "summary": "We formalised the classical theorem that every k-regular bipartite graph with k ≥ 1 has a perfect matching, in the indexed-Finset (neighbourhood function) formulation: a bijection f : ι → α with f i ∈ t i. The proof rests on a single reusable double-counting identity, sum_card_eq, which simultaneously yields the balance |ι| = |α| and Hall's condition; the marriage theorem then supplies an injective transversal that balance promotes to a bijection. The SDR form of Hall's theorem is recorded explicitly along the way. Both consequences are fully machine-checked with 0 sorries and 0 axioms.",
+    "implications": "This supplies the regular case of Hall's theorem that Mathlib and the gallery were missing: the standard route by which regularity makes the marriage theorem apply with no hand-checking of Hall's condition. The double-counting lemma sum_card_eq is reusable for other incidence estimates, and the result is the first step toward bipartite edge-colouring (k-regular bipartite graphs are k-edge-colourable, by stripping one perfect matching at a time) and the Birkhoff–von Neumann theorem.",
+    "openQuestions": [
+      "Iterate the perfect matching to prove that a k-regular bipartite graph is k-edge-colourable (its edge set partitions into k perfect matchings).",
+      "Transport the regular-matching result to the bipartite SimpleGraph framework of HallsTheoremOQ01, deriving it from Mathlib's exists_isPerfectMatching_of_forall_ncard_le.",
+      "Deduce the Birkhoff–von Neumann theorem: a doubly stochastic matrix is a convex combination of permutation matrices, via repeated extraction of perfect matchings from the support."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header, Imports and the Biregularity Structure",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports, an expository docstring placing the regular case relative to Mathlib's conditional marriage theorem, the Fintype/DecidableEq variable setup, and IsBiregular: the structure recording that every left vertex has degree k and every right vertex back-degree k."
+    },
+    {
+      "id": "sum-card-eq",
+      "title": "The Double-Counting Identity",
+      "startLine": 57,
+      "endLine": 81,
+      "summary": "sum_card_eq — for any superset B of s.biUnion t, ∑_{i∈s} #(t i) = ∑_{a∈B} #{i∈s : a∈t i}. Degrees are rewritten as indicator sums (Finset.card_filter) and the order of summation is swapped (Finset.sum_comm); both sides count the incident pairs."
+    },
+    {
+      "id": "regularity-consequences",
+      "title": "Balance and Hall's Condition from Regularity",
+      "startLine": 82,
+      "endLine": 125,
+      "summary": "card_eq_of_regular (B = univ ⇒ k·|ι| = k·|α| ⇒ |ι| = |α|) and hall_condition_of_regular (B = s.biUnion t ⇒ k·#s ≤ k·#(s.biUnion t) ⇒ #s ≤ #(s.biUnion t)), the two instantiations of the double-counting identity."
+    },
+    {
+      "id": "matching",
+      "title": "SDR and the Perfect Matching",
+      "startLine": 126,
+      "endLine": 149,
+      "summary": "exists_sdr_of_hall — the SDR existence form of the marriage theorem; and exists_perfect_matching_of_regular — combining Hall's condition (giving an injective transversal) with balance (promoting it to a bijection) into a perfect matching of a regular bipartite graph."
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "halls-theorem-oq-01",
+      "relation": "Answers a follow-up open question of this entry — the regular application of Hall's theorem — at the indexed-Finset / SDR level, complementing the parent's conditional bipartite biconditional."
+    },
+    {
+      "slug": "halls-theorem-oq-01-oq-01",
+      "relation": "Sibling Finset-level Hall result: that entry proves Ore's defect form; this one proves the regular case. Both build on Finset.all_card_le_biUnion_card_iff_exists_injective."
+    }
+  ],
+  "references": [
+    {
+      "text": "König, D. (1916). Über Graphen und ihre Anwendung auf Determinantentheorie und Mengenlehre. Mathematische Annalen, 77, 453–465.",
+      "url": "https://doi.org/10.1007/BF01456961"
+    },
+    {
+      "text": "Hall, P. (1935). On Representatives of Subsets. Journal of the London Mathematical Society, 10(1), 26–30.",
+      "url": "https://doi.org/10.1112/jlms/s1-10.37.26"
+    },
+    {
+      "text": "Hall's marriage theorem.",
+      "url": "https://en.wikipedia.org/wiki/Hall%27s_marriage_theorem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "HallsTheoremOQ01OQ03",
+    "lineCount": 150,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/HallsTheoremOQ01OQ03.lean",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **halls-theorem-oq-01-oq-03**: the *regular* application of Hall's marriage theorem at the `Finset`/SDR (system of distinct representatives) level. Answers a follow-up open question of the parent `halls-theorem-oq-01` (the full bipartite Hall biconditional).

The genuinely new content — absent from both Mathlib and the existing gallery — is that **every `k`-regular bipartite graph with `k ≥ 1` carries a perfect matching**, with regularity discharged by a *double-counting* estimate rather than checked by hand.

## Results (`proofs/Proofs/HallsTheoremOQ01OQ03.lean`)

- `IsBiregular` — structure: every left vertex has degree `k`, every right vertex back-degree `k`.
- `sum_card_eq` — double-counting identity: incidences out of a left set `s` summed by degree = summed over right vertices by `s`-back-degree.
- `card_eq_of_regular` — `k`-biregularity (`k ≥ 1`) forces `|ι| = |α|` (balance).
- `hall_condition_of_regular` — `k`-biregularity forces Hall's condition `#s ≤ #(s.biUnion t)` (core estimate `k·#s ≤ k·#(s.biUnion t)`).
- `exists_sdr_of_hall` — forward direction of Mathlib's `Finset.all_card_le_biUnion_card_iff_exists_injective`, recorded explicitly.
- `exists_perfect_matching_of_regular` — the payoff: a **bijective** transversal `f : ι → α` with `f i ∈ t i`.

## Verification

- **Build: VERIFIED** against Mathlib v4.26.0 via `./proofs/scripts/docker-build.sh Proofs.HallsTheoremOQ01OQ03` (7743 jobs, build completed successfully).
- 150 lines · 5 theorems/lemmas · 1 structure · **0 sorries · 0 axioms**.
- `status: verified`, `badge: original`.

Cross-references the parent `halls-theorem-oq-01` and sibling `halls-theorem-oq-01-oq-01` (Ore defect form), both building on the same Mathlib marriage theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)