### PR TITLE
Enrich Ballot Problem OQ-04-OQ-01: first crossing partition (annotations + crossRefs)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-01/annotations.json
@@ -1,24 +1,77 @@
 [
   {
-    "id": "ann-crossing-definition",
+    "id": "ann-crossing4-def",
     "proofId": "ballot-problem-oq-04-oq-01",
     "range": {
-      "startLine": 27,
-      "endLine": 42
+      "startLine": 26,
+      "endLine": 29
     },
     "type": "definition",
     "title": "The Crossing Partition {{0,2},{1,3}} as Same-Parity",
-    "content": "crossing4 is defined as Setoid.ker (fun x : Fin 4 => x.val % 2) — the same-parity equivalence relation on Fin 4. Its even block is {0, 2} and its odd block is {1, 3}: this is the partition pairing opposite vertices of a square, the diagonal partition whose blocks must cross. crossing4_iff records that crossing4 x y reduces definitionally to x.val % 2 = y.val % 2. crossing4_blocks exhibits the interleaving structure: the outer pair 0 ~ 2 and inner pair 1 ~ 3 are each related, but ¬ 0 ~ 1 (different blocks) — all three discharged by decide via show, which exposes the kernel equality form so the decidable Nat-equality instance applies."
+    "content": "crossing4 is defined as Setoid.ker (fun x : Fin 4 => x.val % 2) — the same-parity equivalence relation on Fin 4. Its even block is {0, 2} and its odd block is {1, 3}: this is the partition pairing opposite vertices of a square, the diagonal partition whose blocks must cross. Realizing it as the kernel of the parity map is the key modelling choice: it turns every membership question into a decidable arithmetic fact about x.val % 2, so the entire discriminator can be proved by decide with no manual case analysis.",
+    "mathContext": "$\\mathrm{crossing4} = \\ker\\big(x \\mapsto x \\bmod 2\\big),\\quad \\text{blocks } \\{0,2\\},\\ \\{1,3\\}$",
+    "significance": "key",
+    "relatedConcepts": ["non-crossing partitions", "Setoid.ker", "equivalence relation", "Catalan numbers"],
+    "prerequisites": ["Setoid and equivalence kernels", "the parent predicate IsNonCrossing (ballot-problem-oq-04)"]
   },
   {
-    "id": "ann-discriminator",
+    "id": "ann-crossing4-iff",
     "proofId": "ballot-problem-oq-04-oq-01",
     "range": {
-      "startLine": 44,
-      "endLine": 59
+      "startLine": 31,
+      "endLine": 32
+    },
+    "type": "technique",
+    "title": "Membership Reduces to Equal Parity",
+    "content": "crossing4_iff records that crossing4 x y ↔ x.val % 2 = y.val % 2, and the proof is literally Iff.rfl: because crossing4 is a kernel Setoid, its relation unfolds definitionally to equality of the parity values. This definitional transparency is what lets every downstream fact be discharged by decide — no rewriting or unfolding lemmas are needed, the relation already IS the decidable proposition x.val % 2 = y.val % 2.",
+    "mathContext": "$x \\sim y \\iff x \\bmod 2 = y \\bmod 2$",
+    "significance": "supporting",
+    "relatedConcepts": ["definitional equality", "Iff.rfl", "decidable propositions", "kernel relation"],
+    "prerequisites": ["Setoid.ker unfolds to equality of images", "definitional reduction"]
+  },
+  {
+    "id": "ann-crossing4-blocks",
+    "proofId": "ballot-problem-oq-04-oq-01",
+    "range": {
+      "startLine": 34,
+      "endLine": 41
+    },
+    "type": "insight",
+    "title": "The Interleaving: 0 ~ 2, 1 ~ 3, but ¬ 0 ~ 1",
+    "content": "crossing4_blocks exhibits the structure that makes the partition cross: the outer pair 0 ~ 2 and the inner pair 1 ~ 3 are each related (same parity), but they live in different blocks (¬ 0 ~ 1). Each of the three facts is discharged by decide, using show to expose the underlying kernel equality form (0).val % 2 = (2).val % 2 etc. so the decidable Nat-equality instance applies. The geometric content: reading 0 < 1 < 2 < 3 around the circle, the chord {0,2} and the chord {1,3} interleave and therefore must cross.",
+    "mathContext": "$0 \\sim 2,\\quad 1 \\sim 3,\\quad \\neg\\,(0 \\sim 1)$",
+    "significance": "key",
+    "relatedConcepts": ["interleaving chords", "decide tactic", "parity", "crossing condition"],
+    "prerequisites": ["decidability of Nat/Fin equality", "the show tactic to expose definitional forms"]
+  },
+  {
+    "id": "ann-not-isnoncrossing",
+    "proofId": "ballot-problem-oq-04-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 49
     },
     "type": "theorem",
     "title": "The n = 4 Discriminator: ¬ IsNonCrossing crossing4",
-    "content": "not_isNonCrossing_crossing4 proves the same-parity partition is not non-crossing. The parent's IsNonCrossing requires that any quadruple a < b < c < d with a ~ c and b ~ d must also have a ~ b; applying this to 0 < 1 < 2 < 3 with 0 ~ 2 and 1 ~ 3 forces 0 ~ 1, contradicting crossing4_blocks. crossing4_has_crossing repackages the same quadruple as the forbidden existential ∃ a b c d, a < b ∧ b < c ∧ c < d ∧ a ~ c ∧ b ~ d ∧ ¬ a ~ b negated in the parent's isNonCrossing_iff. This is the unique crossing partition of Fin 4 — the single partition separating the Bell number B₄ = 15 from catalan 4 = 14, the smallest witness that non-crossing partitions are strictly fewer than all partitions."
+    "content": "not_isNonCrossing_crossing4 proves the same-parity partition is not non-crossing. The parent's IsNonCrossing requires that any quadruple a < b < c < d with a ~ c and b ~ d must also have a ~ b; applying this hypothesis to 0 < 1 < 2 < 3 with 0 ~ 2 and 1 ~ 3 forces 0 ~ 1, contradicting crossing4_blocks. This is the unique crossing partition of Fin 4 — the single partition separating the Bell number B₄ = 15 from catalan 4 = 14, the smallest witness that non-crossing partitions are strictly fewer than all partitions.",
+    "mathContext": "$\\neg\\,\\mathrm{IsNonCrossing}\\ \\mathrm{crossing4};\\qquad B_4 = 15,\\ C_4 = 14,\\ 15 - 14 = 1$",
+    "significance": "key",
+    "relatedConcepts": ["Bell numbers", "Catalan numbers", "proof by contradiction", "non-crossing predicate"],
+    "prerequisites": ["the parent's IsNonCrossing definition", "Bell number B₄ = 15 and catalan 4 = 14"]
+  },
+  {
+    "id": "ann-has-crossing",
+    "proofId": "ballot-problem-oq-04-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 58
+    },
+    "type": "theorem",
+    "title": "Restated as the Forbidden Existential",
+    "content": "crossing4_has_crossing repackages the contradiction as the explicit existential ∃ a b c d, a < b ∧ b < c ∧ c < d ∧ a ~ c ∧ b ~ d ∧ ¬ a ~ b — exactly the configuration negated in the parent's isNonCrossing_iff reformulation. Supplying the witness (0, 1, 2, 3) with the order facts by decide and the relation facts from crossing4_blocks certifies the crossing positively, matching the parent's 'a partition is non-crossing iff it contains no such quadruple'. Having both the negation form and the existential form lets either parent lemma be applied directly downstream.",
+    "mathContext": "$\\exists\\,a<b<c<d:\\ a \\sim c \\,\\land\\, b \\sim d \\,\\land\\, \\neg\\,(a \\sim b)$",
+    "significance": "supporting",
+    "relatedConcepts": ["existential witness", "isNonCrossing_iff", "non-crossing partitions", "ballot problem"],
+    "prerequisites": ["the parent's isNonCrossing_iff reformulation", "constructing existential witnesses"]
   }
 ]

--- a/src/data/proofs/ballot-problem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-04-oq-01/meta.json
@@ -60,7 +60,8 @@
     "keyInsights": [
       "**The first crossing is the square's diagonals**: {{0, 2}, {1, 3}} pairs opposite vertices of a 4-gon, so its blocks must cross — the canonical and unique crossing partition at n = 4.",
       "**Crossing = same parity on Fin 4**: the diagonal partition is exactly the kernel of the parity map x ↦ x.val % 2, which makes every required relation a decidable arithmetic fact and the whole discriminator provable by decide.",
-      "**This is the single unit separating Bell from Catalan**: B₄ = 15 counts all partitions, catalan 4 = 14 counts the non-crossing ones, and the difference is precisely this one partition — the concrete obstruction any proof of nonCrossingCount n = catalan n must account for."
+      "**This is the single unit separating Bell from Catalan**: B₄ = 15 counts all partitions, catalan 4 = 14 counts the non-crossing ones, and the difference is precisely this one partition — the concrete obstruction any proof of nonCrossingCount n = catalan n must account for.",
+      "**One of the largest Catalan families**: non-crossing partitions are in bijection with Dyck paths, ballot sequences, binary trees, and polygon triangulations, and form the Kreweras lattice under refinement. The n = 4 crossing {{0, 2}, {1, 3}} is the first place this Catalan world parts from the larger Bell-counted world of all set partitions."
     ],
     "prerequisites": [
       "The parent predicate IsNonCrossing and its reformulation isNonCrossing_iff (ballot-problem-oq-04)",
@@ -96,7 +97,13 @@
     ]
   },
   "crossReferences": [
-    "ballot-problem-oq-04",
-    "ballot-problem-oq-04-oq-02-oq-01"
+    {
+      "proofId": "ballot-problem-oq-04",
+      "relationship": "Parent: defines the IsNonCrossing predicate and the isNonCrossing_iff reformulation, and proves all partitions of Fin n with n ≤ 3 are non-crossing. This entry supplies the explicit n = 4 crossing witness its open questions #1/#2 call for."
+    },
+    {
+      "proofId": "ballot-problem-oq-04-oq-02-oq-01",
+      "relationship": "Sibling toward the Catalan count: reduces nonCrossingCount n = catalan n to the Catalan recurrence; this entry pins the concrete n = 4 crossing that any such count must exclude."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-04-oq-01` (quality 45, pass 0).

## Changes
**annotations.json** — split the 2 coarse annotations into **5 focused ones** (one per declaration: `crossing4`, `crossing4_iff`, `crossing4_blocks`, `not_isNonCrossing_crossing4`, `crossing4_has_crossing`), each gaining the previously-missing `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` fields.

**meta.json**
- Convert bare-string `crossReferences` (`["ballot-problem-oq-04", ...]`) into objects with `proofId` + `relationship`. As plain strings, `ref.proofId` was `undefined` and they did **not render as links** in `ProofConclusion`/`ProofOverview`.
- Add a 4th `keyInsight` situating the result in the broader Catalan-objects family (Dyck paths, triangulations, Kreweras lattice).

meta.json is 9.9 KB — well under the size cap. JSON validated by the gallery data-generation step of `pnpm build`.