### PR TITLE
audit: confirm ballot-problem-oq-04-oq-01 clean (n=4 crossing discriminator)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24889,6 +24889,12 @@
       "lastAudited": "2026-06-27T04:00:01Z",
       "result": "clean",
       "issues": []
+    },
+    "ballot-problem-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T04:16:31Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: ballot-problem-oq-04-oq-01 — *The First Crossing Partition (the n=4 Discriminator)*

Drains the audit queue: **4011/4011 audited, 0 unaudited, 0 issues.**

### Verdict: CLEAN (Tier A, badge `original` defensible)

Exhibits the unique crossing partition of `Fin 4` — the same-parity equivalence `crossing4 = Setoid.ker (x ↦ x.val % 2)`, blocks `{0,2}`/`{1,3}` — and proves `¬ IsNonCrossing crossing4`. This is the single partition separating `B₄ = 15` from `catalan 4 = 14`.

### Checks (meta.json vs `Proofs/BallotProblemOQ04OQ01.lean`)

| Field | meta | source | ✓ |
|-------|------|--------|---|
| lineCount | 60 | 60 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 1 | 1 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 (grep hit is docstring prose "0 `sorry`") | ✓ |

- **No True stubs**, **no `native_decide`** — facts discharged by ordinary `decide` on decidable Fin/Nat props, so dependence is only on foundational `propext`/`Classical.choice`/`Quot.sound` (NOT `Lean.ofReduceBool`). meta's `assumptions` field states this accurately.
- **`original` defensible**: core argument builds on the project's *own* parent predicate `IsNonCrossing`/`isNonCrossing_iff` (ballot-problem-oq-04), not a deep Mathlib theorem. Mathlib supplies only `Setoid.ker` + `decide` infrastructure. No delegation opacity.
- **Honestly scoped**: title/description frame this as a concrete witness / "step toward" the open `nonCrossingCount n = catalan n` goal — no overclaim of the full Catalan count.

**Risk: LOW.**

---
Gallery integrity audit. Tracker-only change.