### PR TITLE
research(erdos-1002-oq-02): Cauchy distribution connection — density ↔ CDF and total mass one

### DIFF
--- a/proofs/Proofs/Erdos1002OQ02.lean
+++ b/proofs/Proofs/Erdos1002OQ02.lean
@@ -1,0 +1,133 @@
+/-
+  Erdős Problem #1002 — OQ-02: the Cauchy Distribution *Connection*.
+
+  Background.  Erdős #1002 asks whether the weighted fractional sum
+      f(α, n) = (1/log n) · Σ_{k≤n} (1/2 − {αk})
+  has an asymptotic distribution function.  Kesten (1960) proved the
+  *two-parameter* variant converges to a **Cauchy law**; the one-parameter case
+  remains open.  The sibling entry `Erdos1002OQ01` records the Cauchy law only
+  through its *cumulative distribution function* (CDF)
+
+      cauchyDistribution ρ c = (1/π)·arctan(ρ c) + 1/2,
+
+  proving it is a genuine distribution function (monotone, limits 0 and 1).
+  But the CDF is only one half of the story: the object that actually appears in
+  Kesten's theorem is the Cauchy **probability density**
+
+      cauchyDensity ρ x = ρ / (π·(1 + (ρ x)²)).
+
+  This file supplies the missing *connection* between the two — the analytic
+  content that makes "Cauchy distribution" mean a bona-fide probability law,
+  not just an abstract increasing function:
+
+  * `cauchyDistribution_hasDerivAt` — the CDF differentiates to the density:
+        d/dc [cauchyDistribution ρ c] = cauchyDensity ρ c.
+  * `integral_cauchyDensity` — the Fundamental Theorem of Calculus form: the CDF
+    is the running integral of the density,
+        ∫ x in a..b, cauchyDensity ρ x = cauchyDistribution ρ b − cauchyDistribution ρ a.
+  * `integral_cauchyDensity_univ` — the **normalization** that certifies the
+    density is a probability density: for ρ > 0,
+        ∫ x, cauchyDensity ρ x = 1
+    (total mass one over all of ℝ), obtained from Mathlib's
+    `integral_univ_inv_one_add_sq` (∫ (1+x²)⁻¹ = π) via the scaling x ↦ ρx.
+  * supporting: `cauchyDensity_pos` (strict positivity for ρ > 0),
+    `cauchyDensity_even` (symmetry about the median 0), and
+    `cauchyDensity_continuous`.
+
+  Together with the sibling CDF results, this realises the Cauchy law as a true
+  probability distribution with density — the precise sense in which Kesten's
+  limit, and hence the conjectured limit in #1002, is "Cauchy".
+
+  Self-contained: imports only Mathlib, axiom-free, no `sorry`.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 400000
+
+open Real MeasureTheory
+open scoped Real Topology
+
+namespace Erdos1002OQ02
+
+/-- The Cauchy cumulative distribution function with scale `ρ`
+(mirrors `Erdos1002OQ01.cauchyDistribution`): `g_ρ(c) = (1/π)·arctan(ρ c) + 1/2`. -/
+noncomputable def cauchyDistribution (ρ c : ℝ) : ℝ :=
+  1 / π * arctan (ρ * c) + 1 / 2
+
+/-- The Cauchy probability density with scale `ρ`:
+`f_ρ(x) = ρ / (π·(1 + (ρ x)²))`. -/
+noncomputable def cauchyDensity (ρ x : ℝ) : ℝ :=
+  ρ / (π * (1 + (ρ * x) ^ 2))
+
+/-! ## Elementary shape of the density -/
+
+/-- For a positive scale `ρ`, the Cauchy density is strictly positive everywhere. -/
+theorem cauchyDensity_pos (ρ : ℝ) (hρ : 0 < ρ) (x : ℝ) : 0 < cauchyDensity ρ x := by
+  rw [cauchyDensity]
+  exact div_pos hρ (mul_pos pi_pos (by positivity))
+
+/-- The Cauchy density is symmetric about its median `0`: `f_ρ(−x) = f_ρ(x)`. -/
+theorem cauchyDensity_even (ρ x : ℝ) : cauchyDensity ρ (-x) = cauchyDensity ρ x := by
+  simp only [cauchyDensity, mul_neg, neg_sq]
+
+/-- The Cauchy density is continuous. -/
+theorem cauchyDensity_continuous (ρ : ℝ) : Continuous (cauchyDensity ρ) := by
+  unfold cauchyDensity
+  refine continuous_const.div (by fun_prop) (fun x => ?_)
+  exact (mul_pos pi_pos (by positivity)).ne'
+
+/-! ## The density–CDF connection -/
+
+/-- **The CDF differentiates to the density.**  This is the precise sense in
+which `cauchyDensity ρ` is the density *of* the distribution `cauchyDistribution ρ`. -/
+theorem cauchyDistribution_hasDerivAt (ρ c : ℝ) :
+    HasDerivAt (cauchyDistribution ρ) (cauchyDensity ρ c) c := by
+  have hπ : π ≠ 0 := pi_ne_zero
+  have hden : (1 : ℝ) + (ρ * c) ^ 2 ≠ 0 := by positivity
+  -- inner linear map `y ↦ ρ y`
+  have hin : HasDerivAt (fun y : ℝ => ρ * y) ρ c := by
+    simpa using (hasDerivAt_id c).const_mul ρ
+  -- chain rule for `arctan (ρ ·)`
+  have harc : HasDerivAt (fun y : ℝ => arctan (ρ * y)) ((1 + (ρ * c) ^ 2)⁻¹ * ρ) c :=
+    (hasDerivAt_arctan' (ρ * c)).comp c hin
+  -- scale by `1/π` and shift by `1/2`
+  have h := (harc.const_mul (1 / π)).add_const (1 / 2)
+  have hval : (1 / π) * ((1 + (ρ * c) ^ 2)⁻¹ * ρ) = cauchyDensity ρ c := by
+    rw [cauchyDensity]; field_simp
+  rw [hval] at h
+  exact h
+
+/-- **Fundamental Theorem of Calculus form.**  The CDF is the running integral of
+the density: `∫_a^b f_ρ = g_ρ(b) − g_ρ(a)`. -/
+theorem integral_cauchyDensity (ρ a b : ℝ) :
+    ∫ x in a..b, cauchyDensity ρ x = cauchyDistribution ρ b - cauchyDistribution ρ a := by
+  refine intervalIntegral.integral_eq_sub_of_hasDerivAt (fun x _ => ?_) ?_
+  · exact cauchyDistribution_hasDerivAt ρ x
+  · exact (cauchyDensity_continuous ρ).intervalIntegrable a b
+
+/-- **Normalization: total mass one.**  For a positive scale, the Cauchy density
+integrates to `1` over all of `ℝ`, certifying it is a probability density.
+
+The proof reduces to Mathlib's `integral_univ_inv_one_add_sq` (`∫ (1+x²)⁻¹ = π`)
+through the change of variables `x ↦ ρ x`. -/
+theorem integral_cauchyDensity_univ (ρ : ℝ) (hρ : 0 < ρ) :
+    ∫ x, cauchyDensity ρ x = 1 := by
+  have hπ : π ≠ 0 := pi_ne_zero
+  have hρ' : ρ ≠ 0 := hρ.ne'
+  -- the scaled inner integral, from `∫ (1+y²)⁻¹ = π` and `x ↦ ρ x`
+  have hinner : ∫ x : ℝ, (1 + (ρ * x) ^ 2)⁻¹ = ρ⁻¹ * π := by
+    have h := Measure.integral_comp_mul_left (fun y : ℝ => (1 + y ^ 2)⁻¹) ρ
+    simpa only [integral_univ_inv_one_add_sq, smul_eq_mul,
+      abs_of_pos (inv_pos.mpr hρ)] using h
+  -- pull the constant `ρ/π` out of the integral
+  have key : ∫ x, cauchyDensity ρ x = (ρ / π) * ∫ x, (1 + (ρ * x) ^ 2)⁻¹ := by
+    rw [← MeasureTheory.integral_const_mul]
+    refine MeasureTheory.integral_congr_ae (Filter.Eventually.of_forall (fun x => ?_))
+    have hd : (1 : ℝ) + (ρ * x) ^ 2 ≠ 0 := by positivity
+    rw [cauchyDensity]; field_simp
+  rw [key, hinner]
+  have : ρ / π * (ρ⁻¹ * π) = (ρ * ρ⁻¹) * (π / π) := by ring
+  rw [this, mul_inv_cancel₀ hρ', div_self hπ, mul_one]
+
+end Erdos1002OQ02

--- a/src/data/proofs/erdos-1002-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-02/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 55, "endLine": 61 },
+    "type": "definition",
+    "title": "Cauchy CDF and Density",
+    "content": "cauchyDistribution ρ c = (1/π)·arctan(ρc) + 1/2 is the Cauchy cumulative distribution function at scale ρ (mirroring the sibling Erdos1002OQ01). cauchyDensity ρ x = ρ/(π(1+(ρx)²)) is the corresponding Cauchy probability density. For ρ = 1 these specialise to the classical F(x) = 1/2 + arctan(x)/π and f(x) = 1/(π(1+x²)). The whole file establishes the analytic relationship between these two objects."
+  },
+  {
+    "id": "ann-density-pos",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 66, "endLine": 68 },
+    "type": "theorem",
+    "title": "Strict Positivity",
+    "content": "cauchyDensity_pos: for ρ > 0 the density is strictly positive everywhere. The numerator ρ is positive and the denominator π(1+(ρx)²) is a product of positives (pi_pos and a sum-of-squares handled by positivity), so div_pos concludes. Positivity is one of the defining features of a probability density supported on all of ℝ."
+  },
+  {
+    "id": "ann-density-even",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 71, "endLine": 73 },
+    "type": "theorem",
+    "title": "Symmetry About the Median",
+    "content": "cauchyDensity_even: f_ρ(−x) = f_ρ(x). The Cauchy law is symmetric about its median 0; the proof is immediate from (ρ·(−x))² = (ρx)² (simp with mul_neg and neg_sq). This symmetry is why the median is 0 even though the Cauchy distribution has no mean."
+  },
+  {
+    "id": "ann-continuity",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 75, "endLine": 77 },
+    "type": "theorem",
+    "title": "Continuity",
+    "content": "cauchyDensity_continuous: f_ρ is continuous. Written as a constant divided by x ↦ π(1+(ρx)²), continuity follows from continuous_const.div once the denominator is shown never to vanish (it is a product of the positive constant π and the positive 1+(ρx)²). Continuity is the hypothesis that unlocks the Fundamental Theorem of Calculus in the next part."
+  },
+  {
+    "id": "ann-hasDerivAt",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 84, "endLine": 101 },
+    "type": "theorem",
+    "title": "The CDF Differentiates to the Density",
+    "content": "cauchyDistribution_hasDerivAt: d/dc [g_ρ(c)] = f_ρ(c). This is the central bridge making f_ρ literally the density of g_ρ. By the chain rule, the inner map c ↦ ρc has derivative ρ and Mathlib's hasDerivAt_arctan' gives d/du arctan(u) = (1+u²)⁻¹, so d/dc arctan(ρc) = (1+(ρc)²)⁻¹·ρ. Scaling by 1/π (HasDerivAt.const_mul) and shifting by 1/2 (HasDerivAt.add_const) gives derivative (1/π)·(1+(ρc)²)⁻¹·ρ, which field_simp identifies with ρ/(π(1+(ρc)²)) = f_ρ(c)."
+  },
+  {
+    "id": "ann-ftc",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 103, "endLine": 112 },
+    "type": "theorem",
+    "title": "Fundamental Theorem of Calculus Form",
+    "content": "integral_cauchyDensity: ∫_a^b f_ρ = g_ρ(b) − g_ρ(a). Since g_ρ has derivative f_ρ at every point (previous theorem) and f_ρ is continuous (hence interval-integrable), intervalIntegral.integral_eq_sub_of_hasDerivAt applies directly. This recovers the CDF as the running integral (antiderivative) of the density."
+  },
+  {
+    "id": "ann-normalization",
+    "proofId": "erdos-1002-oq-02",
+    "range": { "startLine": 114, "endLine": 131 },
+    "type": "theorem",
+    "title": "Normalization: Total Mass One",
+    "content": "integral_cauchyDensity_univ: ∫_ℝ f_ρ = 1 for ρ > 0, the property that promotes f_ρ to a genuine probability density. Writing f_ρ(x) = (ρ/π)·(1+(ρx)²)⁻¹, the constant is pulled out with integral_const_mul. The change of variables x ↦ ρx via Measure.integral_comp_mul_left (∫ g(ρx) = |ρ⁻¹|·∫ g) reduces the inner integral to |ρ⁻¹|·∫_ℝ (1+y²)⁻¹ = ρ⁻¹·π using Mathlib's integral_univ_inv_one_add_sq (∫_ℝ (1+y²)⁻¹ = π) and ρ > 0. Finally (ρ/π)·(ρ⁻¹·π) = 1."
+  }
+]

--- a/src/data/proofs/erdos-1002-oq-02/meta.json
+++ b/src/data/proofs/erdos-1002-oq-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "erdos-1002-oq-02",
+  "title": "Erdős #1002 OQ-02: The Cauchy Distribution Connection — Density ↔ CDF and Total Mass One",
+  "slug": "erdos-1002-oq-02",
+  "description": "Open question OQ-02 of Erdős #1002 asks for the Cauchy-distribution connection behind the inner sum S(α,n) = Σ_{k≤n}(1/2 − {αk}): Kesten (1960) showed the two-parameter variant converges to a Cauchy law. The sibling OQ-01 records the Cauchy law only through its CDF g_ρ(c) = (1/π)·arctan(ρc) + 1/2 (monotone with limits 0 and 1). This entry supplies the missing analytic bridge to the Cauchy probability density f_ρ(x) = ρ/(π(1+(ρx)²)): the CDF differentiates to the density (cauchyDistribution_hasDerivAt), the CDF is the running integral of the density (integral_cauchyDensity, the FTC form), and the density integrates to 1 over all of ℝ (integral_cauchyDensity_univ, normalization), certifying it is a bona-fide probability density. Fully verified over an arbitrary positive scale, no axioms, no sorries.",
+  "meta": {
+    "author": "Kesten / classical; Lean formalization original (researcher-4)",
+    "sourceUrl": "https://erdosproblems.com/1002",
+    "date": "",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1002OQ02.lean",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "probability",
+      "cauchy-distribution",
+      "probability-density",
+      "fundamental-theorem-of-calculus",
+      "erdos",
+      "distribution-functions",
+      "fractional-parts"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 1002,
+    "erdosUrl": "https://erdosproblems.com/1002",
+    "erdosProblemStatus": "open",
+    "relatedProblems": [
+      "erdos-1002",
+      "erdos-1002-oq-01",
+      "erdos-1002-oq-03"
+    ],
+    "axiomCount": 0,
+    "lineCount": 133,
+    "assumptions": "No axioms. All six theorems depend only on Lean's standard foundational axioms (propext, Classical.choice, Quot.sound); no sorryAx and no Lean.ofReduceBool, and no native_decide is used. The normalization theorem integral_cauchyDensity_univ additionally assumes the scale ρ > 0 (so |ρ⁻¹| = ρ⁻¹). The parent Erdős #1002 (the one-parameter asymptotic-distribution question) remains open; this file formalizes only the classical analytic facts that make the limiting law a genuine Cauchy probability distribution, building on Mathlib's hasDerivAt_arctan', integral_univ_inv_one_add_sq (∫ (1+x²)⁻¹ = π), and Measure.integral_comp_mul_left.",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1002 concerns the limiting distribution of the inner sum S(α, n) = Σ_{k=1}^n (1/2 − {αk}), where {·} is the fractional part. Kesten (1960), resolving a conjecture of Erdős and Szüsz, proved that for the two-parameter variant Σ_{k≤n}(1/2 − {αk + β}) a suitable normalization converges in distribution to a Cauchy law; whether the one-parameter sum f(α,n) = S(α,n)/log n has an asymptotic distribution function remains open. Across this circle of results the limiting object is always the Cauchy distribution — the heavy-tailed law with no mean, characterised by the density f(x) = 1/(π(1+x²)) and the cumulative distribution function F(x) = 1/2 + arctan(x)/π.\n\nThe sibling entry OQ-01 records the Cauchy law only through its CDF, proving that g_ρ(c) = (1/π)·arctan(ρc) + 1/2 is a valid distribution function (monotone, with limits 0 at −∞ and 1 at +∞). But a distribution function alone does not exhibit the law as a probability measure with a density. This file closes that gap by formalizing the analytic connection between the CDF and the Cauchy probability density f_ρ(x) = ρ/(π(1+(ρx)²)): the density is the derivative of the CDF, the CDF is the running integral of the density (the Fundamental Theorem of Calculus), and the density has total mass one over ℝ. Together these certify that the object appearing in Kesten's theorem is a genuine Cauchy probability distribution.",
+    "problemStatement": "**The Cauchy distribution connection (scale ρ > 0).** Let g_ρ(c) = (1/π)·arctan(ρc) + 1/2 be the Cauchy CDF (as in OQ-01) and f_ρ(x) = ρ/(π(1+(ρx)²)) the Cauchy density.\n\n1. `cauchyDistribution_hasDerivAt`: d/dc [g_ρ(c)] = f_ρ(c) — the CDF differentiates to the density.\n\n2. `integral_cauchyDensity`: ∫_a^b f_ρ = g_ρ(b) − g_ρ(a) — the CDF is the running integral of the density (FTC).\n\n3. `integral_cauchyDensity_univ`: ∫_ℝ f_ρ = 1 — the density is normalized to total mass one, so it is a genuine probability density.",
+    "text": "The Cauchy CDF g_ρ(c) = (1/π)arctan(ρc) + 1/2 differentiates to the Cauchy density f_ρ(x) = ρ/(π(1+(ρx)²)); equivalently the CDF is the running integral of the density (FTC), and the density integrates to 1 over ℝ — certifying the limiting law in Erdős #1002 / Kesten as a bona-fide Cauchy probability distribution.",
+    "proofStrategy": "**Derivative (density = d/dc CDF).** Differentiate g_ρ(c) = (1/π)·arctan(ρc) + 1/2 by the chain rule: the inner map c ↦ ρc has derivative ρ, and Mathlib's `hasDerivAt_arctan'` gives d/du arctan(u) = (1+u²)⁻¹, so d/dc arctan(ρc) = (1+(ρc)²)⁻¹·ρ. Scaling by 1/π (`HasDerivAt.const_mul`) and shifting by 1/2 (`HasDerivAt.add_const`) yields derivative (1/π)·(1+(ρc)²)⁻¹·ρ, which field_simp identifies with f_ρ(c) = ρ/(π(1+(ρc)²)).\n\n**Running integral (FTC).** Since g_ρ has derivative f_ρ everywhere and f_ρ is continuous (`continuous_const.div` with a nonvanishing denominator), `intervalIntegral.integral_eq_sub_of_hasDerivAt` gives ∫_a^b f_ρ = g_ρ(b) − g_ρ(a) directly.\n\n**Normalization (total mass one).** Write f_ρ(x) = (ρ/π)·(1+(ρx)²)⁻¹ and pull the constant out with `integral_const_mul`. The change of variables x ↦ ρx, via `Measure.integral_comp_mul_left` (∫ g(ρx) = |ρ⁻¹|·∫ g), reduces ∫_ℝ (1+(ρx)²)⁻¹ to |ρ⁻¹|·∫_ℝ (1+y²)⁻¹ = ρ⁻¹·π using Mathlib's `integral_univ_inv_one_add_sq` (∫_ℝ (1+y²)⁻¹ = π) and ρ > 0. Then (ρ/π)·(ρ⁻¹·π) = 1.",
+    "keyInsights": [
+      "The Cauchy law enters Erdős #1002 / Kesten through both its CDF and its density; OQ-01 captured only the CDF (monotone, limits 0 and 1), and this file adds the density and the exact analytic relationship between them",
+      "The single identity d/dc [(1/π)arctan(ρc) + 1/2] = ρ/(π(1+(ρc)²)) is the bridge: it makes f_ρ literally the density of the distribution g_ρ, not merely a function with the right shape",
+      "The Fundamental Theorem of Calculus turns the derivative statement into the running-integral statement ∫_a^b f_ρ = g_ρ(b) − g_ρ(a), so the CDF is recovered as the antiderivative of the density",
+      "Total mass one is the property that promotes f_ρ from a positive integrable function to a probability density; it follows from Mathlib's ∫_ℝ (1+x²)⁻¹ = π plus the scaling x ↦ ρx, which contributes exactly the |ρ⁻¹| Jacobian that cancels the ρ in the numerator",
+      "Working at an arbitrary positive scale ρ (matching OQ-01's parameter) keeps the result faithful to Kesten's normalization, where the scale is set by the implicit constant in the log n scaling"
+    ],
+    "prerequisites": [
+      "Real analysis: derivative of arctan (hasDerivAt_arctan'), the chain rule and linearity of HasDerivAt",
+      "Integration: the Fundamental Theorem of Calculus (intervalIntegral.integral_eq_sub_of_hasDerivAt), continuity ⟹ interval integrability",
+      "Measure theory: the Lebesgue integral over ℝ, change of variables under scaling (Measure.integral_comp_mul_left), and the closed form ∫_ℝ (1+x²)⁻¹ = π"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions: Cauchy CDF and Density",
+      "summary": "Two definitions at an arbitrary scale ρ: cauchyDistribution ρ c = (1/π)·arctan(ρc) + 1/2 (the Cauchy CDF, mirroring the sibling Erdos1002OQ01), and cauchyDensity ρ x = ρ/(π(1+(ρx)²)) (the Cauchy probability density).",
+      "startLine": 55,
+      "endLine": 61,
+      "mathContext": "The CDF g_ρ and density f_ρ are the two standard descriptions of the Cauchy law. For ρ = 1 these are the classical F(x) = 1/2 + arctan(x)/π and f(x) = 1/(π(1+x²)); the scale ρ stretches the distribution horizontally while preserving total mass."
+    },
+    {
+      "id": "elementary-shape",
+      "title": "Part I: Elementary Shape of the Density",
+      "summary": "Three basic properties of f_ρ: cauchyDensity_pos (strict positivity for ρ > 0, via div_pos and positivity), cauchyDensity_even (symmetry about the median 0, f_ρ(−x) = f_ρ(x), since (ρ·(−x))² = (ρx)²), and cauchyDensity_continuous (continuity via continuous_const.div with the never-vanishing denominator π(1+(ρx)²)).",
+      "startLine": 63,
+      "endLine": 78,
+      "mathContext": "Positivity, evenness, and continuity are the qualitative features of a probability density centred at 0. Continuity is exactly what is needed to invoke the Fundamental Theorem of Calculus in Part II; positivity and evenness record that the Cauchy law is a symmetric, everywhere-supported distribution."
+    },
+    {
+      "id": "density-cdf-connection",
+      "title": "Part II: The Density–CDF Connection",
+      "summary": "The three connecting theorems: cauchyDistribution_hasDerivAt (d/dc g_ρ(c) = f_ρ(c), by the chain rule on arctan with hasDerivAt_arctan', const_mul and add_const, finished by field_simp), integral_cauchyDensity (the FTC form ∫_a^b f_ρ = g_ρ(b) − g_ρ(a), from integral_eq_sub_of_hasDerivAt and continuity), and integral_cauchyDensity_univ (∫_ℝ f_ρ = 1 for ρ > 0, via integral_const_mul, the scaling Measure.integral_comp_mul_left, and integral_univ_inv_one_add_sq).",
+      "startLine": 80,
+      "endLine": 131,
+      "mathContext": "These three results are the analytic heart of the entry. The derivative identity makes f_ρ the density of g_ρ; the FTC restates this as g_ρ being the antiderivative (running integral) of f_ρ; and the total-mass-one normalization certifies f_ρ as a probability density. Together they realise the limiting law of Kesten's theorem as a genuine Cauchy probability distribution."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Cauchy-distribution connection underlying Erdős #1002 is formalized, axiom-free, at an arbitrary positive scale ρ. The Cauchy CDF g_ρ(c) = (1/π)arctan(ρc) + 1/2 differentiates to the Cauchy density f_ρ(x) = ρ/(π(1+(ρx)²)); equivalently the CDF is the running integral of the density (∫_a^b f_ρ = g_ρ(b) − g_ρ(a)); and the density has total mass one over ℝ. Combined with the sibling OQ-01 (the CDF is a valid distribution function), this exhibits the limiting law as a bona-fide Cauchy probability distribution with density.",
+    "implications": "This pins down the precise sense in which the Erdős #1002 / Kesten limit is 'Cauchy': not merely an increasing function with the right limits, but a probability measure with a normalized density, linked to its CDF by the Fundamental Theorem of Calculus. The normalization argument (∫_ℝ (1+x²)⁻¹ = π together with the scaling Jacobian |ρ⁻¹|) is a reusable template for certifying scaled densities, and the derivative/FTC pair is the standard density↔CDF bridge applicable to any location-scale family. The parent one-parameter asymptotic-distribution question of #1002 remains open; what is settled here is the analytic identity of the limiting distribution.",
+    "openQuestions": [
+      "Characteristic function: can one formalize that the Cauchy density f_ρ has characteristic function e^{−|t|/ρ}, the property from which the stability of the Cauchy family (sum of independent Cauchys is Cauchy) — the structural reason Cauchy appears as a limit — follows?",
+      "Measure-level statement: can the density be packaged as a genuine MeasureTheory probability measure (with a Measure.withDensity / IsProbabilityMeasure instance) so that the CDF equals the measure of (−∞, c], connecting this entry directly to Mathlib's probability-theory API?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "Supplies the density side of the Cauchy law for open question OQ-02 of Erdős #1002; the parent's one-parameter asymptotic-distribution question (whether S(α,n)/log n has a limiting distribution) remains open",
+      "targetId": "erdos-1002"
+    },
+    {
+      "relationship": "Companion to OQ-01, which proves the Cauchy CDF g_ρ(c) = (1/π)arctan(ρc) + 1/2 is a valid distribution function (monotone, limits 0 and 1); this file connects that CDF to the Cauchy density via differentiation, the FTC, and total-mass-one normalization",
+      "targetId": "erdos-1002-oq-01"
+    },
+    {
+      "relationship": "Sibling resolving the rational case of the inner sum (exact period constant 1/2 and linear growth); together with this density entry the two cover the elementary (rational, deterministic) and the distributional (Cauchy density) ends of the #1002 spectrum",
+      "targetId": "erdos-1002-oq-03"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "H. Kesten"
+      ],
+      "title": "On a conjecture of Erdős and Szüsz related to uniform distribution mod 1",
+      "venue": "Acta Arithmetica",
+      "year": "1960",
+      "volume": "5",
+      "pages": "369–380",
+      "notes": "Proves that the normalized two-parameter inner sum converges to a Cauchy limit distribution — the result that identifies the limiting law of Erdős #1002 as Cauchy, the distribution whose density↔CDF connection is formalized here."
+    },
+    {
+      "authors": [
+        "W. Feller"
+      ],
+      "title": "An Introduction to Probability Theory and Its Applications, Vol. II",
+      "venue": "Wiley",
+      "year": "1971",
+      "notes": "Standard reference for the Cauchy distribution: density 1/(π(1+x²)), CDF 1/2 + arctan(x)/π, total mass one, characteristic function e^{−|t|}, and the stability of the Cauchy family."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "Erdos1002OQ02",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1002OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Open question **OQ-02** of Erdős Problem #1002 concerns the **Cauchy-distribution connection** behind the inner sum `S(α,n) = Σ_{k≤n}(1/2 − {αk})`. Kesten (1960) proved the two-parameter variant converges to a **Cauchy law**. The sibling entry `erdos-1002-oq-01` records that law only through its **CDF** `g_ρ(c) = (1/π)·arctan(ρc) + 1/2` (monotone, limits 0 and 1) — but a distribution function alone does not exhibit the law as a probability measure with a density. This entry supplies the missing analytic bridge to the Cauchy **density** `f_ρ(x) = ρ/(π(1+(ρx)²))`, at an arbitrary positive scale `ρ`:

1. **`cauchyDistribution_hasDerivAt`** — `d/dc [g_ρ(c)] = f_ρ(c)`. The CDF differentiates to the density (chain rule on `arctan` via `hasDerivAt_arctan'`, then `const_mul`/`add_const`).
2. **`integral_cauchyDensity`** — `∫_a^b f_ρ = g_ρ(b) − g_ρ(a)`. The Fundamental Theorem of Calculus form: the CDF is the running integral (antiderivative) of the density.
3. **`integral_cauchyDensity_univ`** — `∫_ℝ f_ρ = 1` for `ρ > 0`. The normalization that certifies `f_ρ` as a genuine probability density, via Mathlib's `integral_univ_inv_one_add_sq` (`∫_ℝ (1+x²)⁻¹ = π`) and the scaling `x ↦ ρx` (`Measure.integral_comp_mul_left`).
4. supporting: `cauchyDensity_pos` (strict positivity), `cauchyDensity_even` (symmetry about the median 0), `cauchyDensity_continuous`.

Together with OQ-01 (the CDF is a valid distribution function), this realises the limiting law of Kesten's theorem as a bona-fide Cauchy probability distribution with density.

## Verification

- **Build:** `Built Proofs.Erdos1002OQ02 (7743 jobs, exit 0)` via the Docker wrapper.
- **6 theorems, 2 definitions, 0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `status: verified`, `badge: original`, `axiomCount: 0` (foundational `propext`/`Classical.choice`/`Quot.sound` only).
- `integral_cauchyDensity_univ` additionally assumes the scale `ρ > 0` (so `|ρ⁻¹| = ρ⁻¹`) — disclosed in `assumptions`. The parent one-parameter asymptotic-distribution question of #1002 remains open; what is settled here is the analytic identity of the limiting distribution.

## Files

- `proofs/Proofs/Erdos1002OQ02.lean` (133 lines)
- `src/data/proofs/erdos-1002-oq-02/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)