### PR TITLE
Enrich Newton-Girard for the cubic (solution-of-cubic-oq-03-oq-04): annotation depth

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-04/annotations.json
@@ -1,5 +1,20 @@
 [
   {
+    "id": "ann-definitions",
+    "proofId": "solution-of-cubic-oq-03-oq-04",
+    "range": {
+      "startLine": 42,
+      "endLine": 59
+    },
+    "type": "definition",
+    "title": "Symmetric Functions, Power Sums, and the Base Value p₀ = 3",
+    "content": "The development is parameterized over an arbitrary commutative ring R (variable {R : Type*} [CommRing R]), so nothing here is special to ℂ. It defines the three elementary symmetric functions e₁ = a+b+c, e₂ = ab+bc+ca, e₃ = abc, the power sum pₙ = aⁿ+bⁿ+cⁿ, and records the base value powerSum_zero: p₀ = a⁰+b⁰+c⁰ = 3. That '3' is not a convention but a count of the variables, and it is exactly the constant that later makes the unified recurrence reproduce the +3e₃ term of the third Newton identity.",
+    "mathContext": "$e_1 = a+b+c,\\quad e_2 = ab+bc+ca,\\quad e_3 = abc,\\quad p_n = a^n+b^n+c^n,\\quad p_0 = 3$",
+    "significance": "supporting",
+    "relatedConcepts": ["elementary symmetric polynomials", "power sums", "commutative ring", "Vieta's formulas"],
+    "prerequisites": ["elementary symmetric polynomials of three variables", "commutative ring axioms"]
+  },
+  {
     "id": "ann-engine",
     "proofId": "solution-of-cubic-oq-03-oq-04",
     "range": {
@@ -8,7 +23,11 @@
     },
     "type": "insight",
     "title": "The Hidden Ring Identity that Powers Everything",
-    "content": "root_a_cubic proves a³ = (a+b+c)a² − (ab+bc+ca)a + abc — and this is provable by plain `ring`, with no hypothesis that a is a 'root' of anything. The reason: the b- and c-terms on the right cancel exactly, leaving a³. Yet this very identity IS the statement that a is a root of (X−a)(X−b)(X−c) = X³ − e₁X² + e₂X − e₃. Multiplying through by aⁿ (pow_rec_a) gives aⁿ⁺³ = e₁aⁿ⁺² − e₂aⁿ⁺¹ + e₃aⁿ; `ring` handles the symbolic exponent by normalizing aⁿ⁺² = aⁿ·a². The symmetric statements for b and c are the other two summands of the Newton–Girard recurrence."
+    "content": "root_a_cubic proves a³ = (a+b+c)a² − (ab+bc+ca)a + abc — and this is provable by plain `ring`, with no hypothesis that a is a 'root' of anything. The reason: the b- and c-terms on the right cancel exactly, leaving a³. Yet this very identity IS the statement that a is a root of (X−a)(X−b)(X−c) = X³ − e₁X² + e₂X − e₃. Multiplying through by aⁿ (pow_rec_a) gives aⁿ⁺³ = e₁aⁿ⁺² − e₂aⁿ⁺¹ + e₃aⁿ; `ring` handles the symbolic exponent by normalizing aⁿ⁺² = aⁿ·a². The symmetric statements for b and c are the other two summands of the Newton–Girard recurrence.",
+    "mathContext": "$a^3 = e_1 a^2 - e_2 a + e_3,\\qquad a^{n+3} = e_1 a^{n+2} - e_2 a^{n+1} + e_3 a^n$",
+    "significance": "key",
+    "relatedConcepts": ["roots of a polynomial", "Vieta's formulas", "ring tactic", "symbolic exponents"],
+    "prerequisites": ["(X−a)(X−b)(X−c) = X³ − e₁X² + e₂X − e₃", "the ring normalization tactic"]
   },
   {
     "id": "ann-recurrence",
@@ -19,7 +38,26 @@
     },
     "type": "insight",
     "title": "Newton–Girard Without Induction",
-    "content": "newton_recurrence proves pₙ₊₃ = e₁pₙ₊₂ − e₂pₙ₊₁ + e₃pₙ for ALL n in a single `linear_combination` of the three per-root recurrences — no induction. Summing aⁿ⁺³+bⁿ⁺³+cⁿ⁺³ against the three identities reassembles exactly the symmetric-function-weighted power sums on the right. This is the linear recurrence (with symmetric-function coefficients) that, seeded by p₀=3, p₁=e₁, p₂=e₁²−2e₂, generates every power sum of a, b, c from the elementary symmetric functions alone."
+    "content": "newton_recurrence proves pₙ₊₃ = e₁pₙ₊₂ − e₂pₙ₊₁ + e₃pₙ for ALL n in a single `linear_combination` of the three per-root recurrences — no induction. Summing aⁿ⁺³+bⁿ⁺³+cⁿ⁺³ against the three identities reassembles exactly the symmetric-function-weighted power sums on the right. This is the linear recurrence (with symmetric-function coefficients) that, seeded by p₀=3, p₁=e₁, p₂=e₁²−2e₂, generates every power sum of a, b, c from the elementary symmetric functions alone. newton_recurrence_succ restates it as pₙ₊₄ = … to expose the homogeneous range k ≥ 4 without a side hypothesis.",
+    "mathContext": "$p_{n+3} = e_1\\,p_{n+2} - e_2\\,p_{n+1} + e_3\\,p_n \\quad (\\forall n \\ge 0)$",
+    "significance": "key",
+    "relatedConcepts": ["Newton's identities", "linear recurrence", "linear_combination tactic", "symmetric functions"],
+    "prerequisites": ["the per-root recurrences", "linear combinations of ring identities"]
+  },
+  {
+    "id": "ann-closed-forms",
+    "proofId": "solution-of-cubic-oq-03-oq-04",
+    "range": {
+      "startLine": 128,
+      "endLine": 156
+    },
+    "type": "concept",
+    "title": "Closed Forms p₁…p₄ as Symmetric Polynomials",
+    "content": "Section V records the explicit closed forms p₁ = e₁, p₂ = e₁²−2e₂, p₃ = e₁³−3e₁e₂+3e₃, p₄ = e₁⁴−4e₁²e₂+4e₁e₃+2e₂², each proved by unfolding and `ring`. These are the symmetric-polynomial expressions one gets by unrolling the recurrence from the base values, and they exhibit every power sum as an integer-coefficient polynomial in the elementary symmetric functions (the fundamental theorem of symmetric functions made concrete for n = 3). newton_p1 and newton_p2 then restate p₁ and p₂ in the recursive triangular form p₂ = e₁p₁ − 2e₂.",
+    "mathContext": "$p_2 = e_1^2 - 2e_2,\\quad p_3 = e_1^3 - 3e_1 e_2 + 3e_3,\\quad p_4 = e_1^4 - 4e_1^2 e_2 + 4e_1 e_3 + 2e_2^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["fundamental theorem of symmetric functions", "power sums", "triangular Newton identities", "ring tactic"],
+    "prerequisites": ["the Newton–Girard recurrence", "the base values p₀, p₁, p₂"]
   },
   {
     "id": "ann-three",
@@ -30,7 +68,11 @@
     },
     "type": "concept",
     "title": "Why p₃ Has a +3e₃: the Number Three Counts the Variables",
-    "content": "The textbook Newton identity p₃ = e₁p₂ − e₂p₁ + 3e₃ looks anomalous next to the homogeneous tail p₄ = e₁p₃ − e₂p₂ + e₃p₁. But the unified recurrence pₙ₊₃ = e₁pₙ₊₂ − e₂pₙ₊₁ + e₃pₙ at n=0 gives p₃ = e₁p₂ − e₂p₁ + e₃·p₀, and p₀ = a⁰+b⁰+c⁰ = 3. The constant '3' is literally the number of variables, not a special rule — the same recurrence governs every order."
+    "content": "The textbook Newton identity p₃ = e₁p₂ − e₂p₁ + 3e₃ looks anomalous next to the homogeneous tail p₄ = e₁p₃ − e₂p₂ + e₃p₁. But the unified recurrence pₙ₊₃ = e₁pₙ₊₂ − e₂pₙ₊₁ + e₃pₙ at n=0 gives p₃ = e₁p₂ − e₂p₁ + e₃·p₀, and p₀ = a⁰+b⁰+c⁰ = 3. The constant '3' is literally the number of variables, not a special rule — the same recurrence governs every order. newton_p4 is the first fully homogeneous case (4 > 3), confirming the pattern.",
+    "mathContext": "$p_3 = e_1 p_2 - e_2 p_1 + 3e_3 = e_1 p_2 - e_2 p_1 + e_3 p_0,\\qquad p_0 = 3$",
+    "significance": "key",
+    "relatedConcepts": ["Newton's identities", "homogeneity", "number of variables", "boundary terms"],
+    "prerequisites": ["the unified recurrence", "p₀ = 3"]
   },
   {
     "id": "ann-depressed",
@@ -41,6 +83,10 @@
     },
     "type": "concept",
     "title": "Back to the Parent's Depressed Cubic",
-    "content": "Substituting Vieta for x³+px+q (e₁=0, e₂=p, e₃=−q) collapses the three-term recurrence to two terms: pₙ₊₃ = −p·pₙ₊₁ − q·pₙ, with p₁ = 0 and p₂ = −2p. At n=0 this yields the classical sum of cubes of the roots, a³+b³+c³ = −3q. So the power sums of exactly the Cardano roots from the parent entry are generated by a two-term recurrence built from the cubic's own coefficients p and q."
+    "content": "Substituting Vieta for x³+px+q (e₁=0, e₂=p, e₃=−q) collapses the three-term recurrence to two terms: pₙ₊₃ = −p·pₙ₊₁ − q·pₙ, with p₁ = 0 and p₂ = −2p. At n=0 this yields the classical sum of cubes of the roots, a³+b³+c³ = −3q. So the power sums of exactly the Cardano roots from the parent entry are generated by a two-term recurrence built from the cubic's own coefficients p and q — the abstract Newton–Girard machinery specialized to the concrete object of the parent.",
+    "mathContext": "$e_1 = 0,\\ e_2 = p,\\ e_3 = -q:\\quad p_{n+3} = -p\\,p_{n+1} - q\\,p_n,\\qquad a^3+b^3+c^3 = -3q$",
+    "significance": "supporting",
+    "relatedConcepts": ["depressed cubic", "Cardano's formula", "Vieta's formulas", "sum of cubes"],
+    "prerequisites": ["the parent's depressed cubic x³+px+q", "Vieta for the depressed cubic (e₁=0)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-03-oq-04` (Newton–Girard identities for three quantities over a commutative ring).

## Changes (annotations.json)
The 4 existing annotations had good `content` but were missing the structured fields the annotation panel renders. This pass:
- Adds `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to every annotation.
- Adds 2 new annotations covering previously-uncovered code: **Section I** (elementary symmetric functions, power sums, and the base value `p₀ = 3`) and **Section V** (closed forms `p₁…p₄` as symmetric polynomials).

meta.json was already comprehensive (6 keyInsights, full per-section `mathContext`, conclusion with open questions) and ~15.8 KB — well under the size cap — so it was left unchanged to avoid bloat.

JSON validated by the gallery data-generation step of `pnpm build`.