### PR TITLE
Enrich Catenoid surface area (arsinh-log-formula-oq-01-oq-01-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,62 +5,94 @@
     "range": { "startLine": 1, "endLine": 41 },
     "type": "concept",
     "title": "From catenary length to catenoid area",
-    "content": "The parent entry `arsinh-log-formula-oq-01-oq-01-oq-01` proved the catenary arc length (the length of y = cosh x over [0, b] is sinh b) and built the antiderivative of √(1+t²). Its open question asked for two upgrades, supplied here: the *affine* boundary case of the general arc-length integral ∫ √(1 + f'²), and the *surface-of-revolution* integral for the catenoid (the surface swept by revolving the catenary). Both are governed by the single identity √(1 + sinh²x) = cosh x."
+    "content": "The parent entry `arsinh-log-formula-oq-01-oq-01-oq-01` proved the catenary arc length (the length of y = cosh x over [0, b] is sinh b) and built the antiderivative of √(1+t²). Its open question asked for two upgrades, supplied here: the *affine* boundary case of the general arc-length integral ∫ √(1 + f'²), and the *surface-of-revolution* integral for the catenoid (the surface swept by revolving the catenary). Both are governed by the single identity √(1 + sinh²x) = cosh x.",
+    "mathContext": "$\\sqrt{1 + \\sinh^2 x} = \\cosh x$",
+    "significance": "supporting",
+    "relatedConcepts": ["catenary", "catenoid", "arc length", "surface of revolution"],
+    "prerequisites": ["the parent catenary arc-length entry", "hyperbolic functions cosh, sinh"]
   },
   {
     "id": "ann-affine-deriv",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 43, "endLine": 49 },
-    "type": "technique",
+    "type": "tactic",
     "title": "The affine integrand is constant",
-    "content": "`hasDerivAt_affine` differentiates x ↦ m·x + c to the constant m (from `hasDerivAt_id.const_mul` and `add_const`). Since f'(t) = m is constant, the arc-length integrand √(1 + f'(t)²) is the t-independent constant √(1 + m²) — the degenerate edge of the smooth arc-length family."
+    "content": "`hasDerivAt_affine` differentiates x ↦ m·x + c to the constant m (from `hasDerivAt_id.const_mul` and `add_const`). Since f'(t) = m is constant, the arc-length integrand √(1 + f'(t)²) is the t-independent constant √(1 + m²) — the degenerate edge of the smooth arc-length family.",
+    "mathContext": "$\\frac{d}{dx}(m x + c) = m$",
+    "significance": "supporting",
+    "relatedConcepts": ["derivative of an affine map", "HasDerivAt", "const_mul"],
+    "prerequisites": ["differentiation rules in Mathlib", "the arc-length integrand √(1 + f'²)"]
   },
   {
     "id": "ann-line-arclength",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 51, "endLine": 56 },
-    "type": "key-step",
+    "type": "insight",
     "title": "Affine arc length = (b − a)·√(1 + m²)",
-    "content": "With a constant integrand, `intervalIntegral.integral_const` gives ∫_a^b √(1 + m²) dt = (b − a) • √(1 + m²); `smul_eq_mul` rewrites the scalar action as multiplication. Geometrically this is the straight-line distance between the endpoints (a, ma+c) and (b, mb+c) — Pythagoras for the segment."
+    "content": "With a constant integrand, `intervalIntegral.integral_const` gives ∫_a^b √(1 + m²) dt = (b − a) • √(1 + m²); `smul_eq_mul` rewrites the scalar action as multiplication. Geometrically this is the straight-line distance between the endpoints (a, ma+c) and (b, mb+c) — Pythagoras for the segment.",
+    "mathContext": "$\\int_a^b \\sqrt{1 + m^2}\\,dt = (b - a)\\sqrt{1 + m^2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["interval integral of a constant", "Pythagorean distance", "arc length"],
+    "prerequisites": ["integral of a constant function", "the affine derivative"]
   },
   {
     "id": "ann-sqrt-sinh",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 58, "endLine": 65 },
-    "type": "key-step",
+    "type": "insight",
     "title": "The Pythagorean collapse √(1 + sinh²x) = cosh x",
-    "content": "From `Real.cosh_sq` (cosh²x = sinh²x + 1) we get 1 + sinh²x = cosh²x, and `Real.sqrt_sq` with cosh x > 0 (`Real.cosh_pos`) gives √(cosh²x) = cosh x. This is the identity that flattens both the catenary length element and the catenoid area element, removing the surd."
+    "content": "From `Real.cosh_sq` (cosh²x = sinh²x + 1) we get 1 + sinh²x = cosh²x, and `Real.sqrt_sq` with cosh x > 0 (`Real.cosh_pos`) gives √(cosh²x) = cosh x. This is the identity that flattens both the catenary length element and the catenoid area element, removing the surd.",
+    "mathContext": "$\\sqrt{1 + \\sinh^2 x} = \\sqrt{\\cosh^2 x} = \\cosh x \\quad (\\cosh x > 0)$",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic Pythagorean identity", "Real.sqrt_sq", "cosh positivity"],
+    "prerequisites": ["cosh²x − sinh²x = 1", "√ of a square equals the absolute value"]
   },
   {
     "id": "ann-coshsq-antideriv",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 66, "endLine": 89 },
-    "type": "key-step",
+    "type": "insight",
     "title": "The hand-built antiderivative of cosh²",
-    "content": "Mathlib has no antiderivative for cosh², so `hasDerivAt_coshSqAntideriv` builds it. The product rule on sinh x · cosh x gives (sinh·cosh)' = cosh²x + sinh²x; adding the identity term x and dividing by 2 yields (1 + cosh²x + sinh²x)/2. The Pythagorean identity cosh²x = 1 + sinh²x makes this exactly cosh²x: after `pow_two` normalisation the value equality closes by `linarith` with `Real.cosh_sq`."
+    "content": "Mathlib has no antiderivative for cosh², so `hasDerivAt_coshSqAntideriv` builds it. The product rule on sinh x · cosh x gives (sinh·cosh)' = cosh²x + sinh²x; adding the identity term x and dividing by 2 yields (1 + cosh²x + sinh²x)/2. The Pythagorean identity cosh²x = 1 + sinh²x makes this exactly cosh²x: after `pow_two` normalisation the value equality closes by `linarith` with `Real.cosh_sq`.",
+    "mathContext": "$\\frac{d}{dx}\\,\\tfrac{1}{2}\\big(x + \\sinh x\\cosh x\\big) = \\cosh^2 x$",
+    "significance": "key",
+    "relatedConcepts": ["antiderivative", "product rule", "HasDerivAt", "power-reduction identity"],
+    "prerequisites": ["the product rule for derivatives", "cosh²x = 1 + sinh²x"]
   },
   {
     "id": "ann-integral-coshsq",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 90, "endLine": 99 },
-    "type": "key-step",
+    "type": "insight",
     "title": "FTC: ∫₀ᵇ cosh²x dx = ½(b + sinh b·cosh b)",
-    "content": "`continuous_cosh_sq` (= `Real.continuous_cosh.pow 2`) makes the integrand interval-integrable, so `intervalIntegral.integral_eq_sub_of_hasDerivAt` applies the new antiderivative ½(x + sinh x·cosh x). At the lower limit sinh 0 = 0 kills the boundary term, giving the closed form anchored at 0."
+    "content": "`continuous_cosh_sq` (= `Real.continuous_cosh.pow 2`) makes the integrand interval-integrable, so `intervalIntegral.integral_eq_sub_of_hasDerivAt` applies the new antiderivative ½(x + sinh x·cosh x). At the lower limit sinh 0 = 0 kills the boundary term, giving the closed form anchored at 0.",
+    "mathContext": "$\\int_0^b \\cosh^2 x\\,dx = \\tfrac{1}{2}\\big(b + \\sinh b\\cosh b\\big)$",
+    "significance": "key",
+    "relatedConcepts": ["fundamental theorem of calculus", "interval integrability", "boundary term"],
+    "prerequisites": ["the hand-built cosh² antiderivative", "FTC integral_eq_sub_of_hasDerivAt"]
   },
   {
     "id": "ann-catenoid",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 100, "endLine": 119 },
-    "type": "concept",
+    "type": "theorem",
     "title": "Catenoid surface area π(b + sinh b·cosh b)",
-    "content": "The surface-of-revolution element 2π·y·√(1 + y'²) for y = cosh x is 2π·cosh x·√(1 + sinh²x), which `sqrt_one_add_sinh_sq` (and cosh x · cosh x = cosh²x) collapses to 2π·cosh²x. Substituting the cosh² integral and simplifying with `ring` gives the catenoid's surface area over [0, b]: 2π · ½(b + sinh b·cosh b) = π(b + sinh b·cosh b)."
+    "content": "The surface-of-revolution element 2π·y·√(1 + y'²) for y = cosh x is 2π·cosh x·√(1 + sinh²x), which `sqrt_one_add_sinh_sq` (and cosh x · cosh x = cosh²x) collapses to 2π·cosh²x. Substituting the cosh² integral and simplifying with `ring` gives the catenoid's surface area over [0, b]: 2π · ½(b + sinh b·cosh b) = π(b + sinh b·cosh b).",
+    "mathContext": "$A = \\int_0^b 2\\pi\\cosh x\\,\\sqrt{1 + \\sinh^2 x}\\,dx = \\pi\\big(b + \\sinh b\\cosh b\\big)$",
+    "significance": "critical",
+    "relatedConcepts": ["catenoid", "surface of revolution", "minimal surface", "Pappus's theorem"],
+    "prerequisites": ["the surface-of-revolution area element 2πy√(1+y'²)", "the cosh² integral"]
   },
   {
     "id": "ann-concrete",
     "proofId": "arsinh-log-formula-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 120, "endLine": 126 },
-    "type": "observation",
+    "type": "concept",
     "title": "Concrete value over [0, 1]",
-    "content": "`catenoid_surface_area_zero_to_one` specialises b = 1: the catenoid generated by the catenary over [0, 1] has surface area π(1 + sinh 1·cosh 1), obtained by `simpa` from the general formula."
+    "content": "`catenoid_surface_area_zero_to_one` specialises b = 1: the catenoid generated by the catenary over [0, 1] has surface area π(1 + sinh 1·cosh 1), obtained by `simpa` from the general formula.",
+    "mathContext": "$A = \\pi\\big(1 + \\sinh 1\\cosh 1\\big)$",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "catenoid", "surface area"],
+    "prerequisites": ["the general catenoid surface-area formula"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-01-oq-01-oq-01` (affine arc-length boundary case + catenoid surface area).

## Changes (annotations.json)
The 8 existing annotations had strong `content` but were missing structured fields, and several used `type` values not in the schema (`technique`, `key-step`, `observation`) — these fell back to rendering the raw string instead of a proper label.

- Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 8 annotations.
- Remap invalid `type` values to the schema's allowed set (`tactic`/`insight`/`concept`/`theorem`).

meta.json was already comprehensive (~15.9 KB, under the size cap) and was left unchanged.

JSON validated by the gallery data-generation step of `pnpm build`.