### PR TITLE
audit: confirm amgm-inequality-oq-03-oq-02-oq-01 clean (re-audit, stalest entry)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -175,9 +175,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T04:22:30Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: amgm-inequality-oq-03-oq-02-oq-01 — *Power Mean Crossing Zero: M_r ≤ GM ≤ M_s for r < 0 < s*

Re-audited the stalest gallery entry; the audit queue is fully drained (4011/4011).

### Verification (meta.json vs proofs/Proofs/PowerMeanCrossZeroOQ.lean)

| Check | meta.json | source | match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True-stubs | — | 0 | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 225 | 225 | ✓ |

Parent `AmgmInequalityOQ03` (defines `weightedPowerMean`/`weightedGeomMean`) is also 0 sorry / 0 axiom; the whole import chain rests on foundational Mathlib only.

### Tier classification: A (original) — defensible

The crossing-zero power-mean case (r < 0 < s) is genuinely not in Mathlib. It uses Mathlib's weighted AM-GM (`Real.geom_mean_le_arith_mean_weighted`) only as an *ingredient* — properly disclosed in `mathlibDependencies` and the overview, not masked — and derives the result via its own core inequality GM^r ≤ ∑ wᵢzᵢ^r, two monotonicity lemmas, and transitivity. `originalContributions` are accurately scoped to what is independently proved. Title is precise and qualified.

**Risk: LOW. Verdict: CLEAN.** Only change: tracker `auditCount` 2→3, `lastAudited` 2026-06-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)