### PR TITLE
audit: erdos-1002-oq-02 clean (Cauchy density↔CDF connection)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24895,6 +24895,12 @@
       "lastAudited": "2026-06-27T04:16:31Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1002-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T04:30:45Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1002-oq-02

**Result: CLEAN** ✅

Audited the last unaudited gallery entry; queue now fully drained (4012/4012).

### Verified against Lean source (`Proofs/Erdos1002OQ02.lean`)
| Field | meta.json | actual | match |
|-------|-----------|--------|-------|
| definitions | 2 | 2 | ✅ |
| theorems | 6 | 6 | ✅ |
| lineCount | 133 | 133 | ✅ |
| axiomCount | 0 | 0 | ✅ |
| sorries | 0 | 0 | ✅ |

- No `True` stubs, no `native_decide` → `axiomCount: 0` correct (standard foundational axioms only).
- **Tier/badge**: `verified`/`original` defensible. The three headline results (CDF differentiates to density, FTC running-integral form, total-mass-one normalization) are assembled in-file from Mathlib analytic primitives (`hasDerivAt_arctan'`, `integral_univ_inv_one_add_sq`, `Measure.integral_comp_mul_left`) — original infrastructure, not a thin re-export of a single deep theorem.
- **No overclaim**: title names Erdős #1002 (open) but is repeatedly qualified — the parent one-parameter asymptotic-distribution question is explicitly disclosed as open. The `assumptions` field is exemplary (foundational axioms, ρ>0 hypothesis, Mathlib deps all listed).

Tracker-only change; no content modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)