### PR TITLE
Enrich off-diagonal Beta integral (beta-integral-recurrence-oq-01-oq-03-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-03-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 40 },
     "type": "concept",
     "title": "The off-diagonal real Beta integral, two ways",
-    "content": "The parent leaf brought the diagonal Beta value ∫₀¹ xⁿ(1-x)ⁿ = (n!)²/(2n+1)! down to ℝ. This entry answers its first open question: the full off-diagonal value ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! for independent m, n. It is proved two independent ways — Route 1 reuses Mathlib's complex Beta theory via a ℂ→ℝ bridge; Route 2 is a self-contained real proof using a single integration by parts and induction, invoking no complex analysis at all."
+    "content": "The parent leaf brought the diagonal Beta value ∫₀¹ xⁿ(1-x)ⁿ = (n!)²/(2n+1)! down to ℝ. This entry answers its first open question: the full off-diagonal value ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)! for independent m, n. It is proved two independent ways — Route 1 reuses Mathlib's complex Beta theory via a ℂ→ℝ bridge; Route 2 is a self-contained real proof using a single integration by parts and induction, invoking no complex analysis at all.",
+    "mathContext": "$\\int_0^1 x^m(1-x)^n\\,dx = \\frac{m!\\,n!}{(m+n+1)!}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Beta function", "Euler integral", "two independent proofs", "factorials"],
+    "prerequisites": ["the parent's diagonal Beta integral", "Mathlib Complex.betaIntegral"]
   },
   {
     "id": "ann-bridge",
@@ -13,7 +17,11 @@
     "range": { "startLine": 44, "endLine": 57 },
     "type": "theorem",
     "title": "Route 1: the off-diagonal ℂ → ℝ bridge",
-    "content": "ofReal_integral_offdiag: ↑(∫ x in 0..1, xᵐ(1-x)ⁿ) = Complex.betaIntegral (m+1)(n+1). The complex integrand is (x:ℂ)^((m+1)-1)·(1-x)^((n+1)-1); each exponent reduces to a natural (m, n), so Complex.cpow_natCast turns the complex powers into monoid powers with no positivity side condition, and the integrand becomes ↑(xᵐ(1-x)ⁿ). intervalIntegral.integral_ofReal (via integral_congr on [0,1]) descends the integral. This generalizes the parent's diagonal bridge by treating the two exponents separately."
+    "content": "ofReal_integral_offdiag: ↑(∫ x in 0..1, xᵐ(1-x)ⁿ) = Complex.betaIntegral (m+1)(n+1). The complex integrand is (x:ℂ)^((m+1)-1)·(1-x)^((n+1)-1); each exponent reduces to a natural (m, n), so Complex.cpow_natCast turns the complex powers into monoid powers with no positivity side condition, and the integrand becomes ↑(xᵐ(1-x)ⁿ). intervalIntegral.integral_ofReal (via integral_congr on [0,1]) descends the integral. This generalizes the parent's diagonal bridge by treating the two exponents separately.",
+    "mathContext": "$\\Big(\\int_0^1 x^m(1-x)^n\\,dx\\Big)_{\\mathbb{R}\\hookrightarrow\\mathbb{C}} = \\mathrm{betaIntegral}(m{+}1,\\,n{+}1)$",
+    "significance": "key",
+    "relatedConcepts": ["real-to-complex descent", "cpow_natCast", "integral_ofReal", "Complex.betaIntegral"],
+    "prerequisites": ["Complex.betaIntegral definition", "casting integrals through ℝ → ℂ"]
   },
   {
     "id": "ann-value",
@@ -21,7 +29,11 @@
     "range": { "startLine": 59, "endLine": 71 },
     "type": "theorem",
     "title": "The closed form from the complex value",
-    "content": "integral_offdiag_eq_factorial: ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!. Rewrite the bridge's right side with the grandparent's betaIntegral_nat_nat (= m!·n!/(m+n+1)! over ℂ), recognize the real and complex casts agree (push_cast), and transfer the equality back to ℝ by injectivity of the ℝ→ℂ cast (exact_mod_cast). This is the parent's open question, answered."
+    "content": "integral_offdiag_eq_factorial: ∫ x in 0..1, xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!. Rewrite the bridge's right side with the grandparent's betaIntegral_nat_nat (= m!·n!/(m+n+1)! over ℂ), recognize the real and complex casts agree (push_cast), and transfer the equality back to ℝ by injectivity of the ℝ→ℂ cast (exact_mod_cast). This is the parent's open question, answered.",
+    "mathContext": "$\\int_0^1 x^m(1-x)^n\\,dx = \\frac{m!\\,n!}{(m+n+1)!}$",
+    "significance": "critical",
+    "relatedConcepts": ["Euler Beta integral", "Beta-Gamma relation", "factorials", "cast injectivity"],
+    "prerequisites": ["the off-diagonal ℂ→ℝ bridge", "betaIntegral_nat_nat from the grandparent"]
   },
   {
     "id": "ann-recurrence",
@@ -29,7 +41,11 @@
     "range": { "startLine": 82, "endLine": 130 },
     "type": "theorem",
     "title": "Route 2: the integration-by-parts recurrence",
-    "content": "integral_recurrence: ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ. Apply integral_mul_deriv_eq_deriv_mul with u = (1-x)ⁿ⁺¹ (derivative via HasDerivAt.pow) and v = xᵐ⁺¹/(m+1) (derivative via hasDerivAt_pow.div_const, value x^m). Both boundary terms vanish: at x=1, (1-1)ⁿ⁺¹ = 0; at x=0, 0ᵐ⁺¹ = 0 (zero_pow on a successor). Pulling the constant out with integral_const_mul leaves the pure recurrence. This recurrence is not in Mathlib and is the engine of the independent real proof."
+    "content": "integral_recurrence: ∫₀¹ xᵐ(1-x)ⁿ⁺¹ = ((n+1)/(m+1))·∫₀¹ xᵐ⁺¹(1-x)ⁿ. Apply integral_mul_deriv_eq_deriv_mul with u = (1-x)ⁿ⁺¹ (derivative via HasDerivAt.pow) and v = xᵐ⁺¹/(m+1) (derivative via hasDerivAt_pow.div_const, value x^m). Both boundary terms vanish: at x=1, (1-1)ⁿ⁺¹ = 0; at x=0, 0ᵐ⁺¹ = 0 (zero_pow on a successor). Pulling the constant out with integral_const_mul leaves the pure recurrence. This recurrence is not in Mathlib and is the engine of the independent real proof.",
+    "mathContext": "$\\int_0^1 x^m(1-x)^{n+1}\\,dx = \\frac{n+1}{m+1}\\int_0^1 x^{m+1}(1-x)^n\\,dx$",
+    "significance": "key",
+    "relatedConcepts": ["integration by parts", "reduction formula", "vanishing boundary terms", "HasDerivAt"],
+    "prerequisites": ["integration by parts (integral_mul_deriv_eq_deriv_mul)", "derivatives of powers"]
   },
   {
     "id": "ann-induction",
@@ -37,7 +53,11 @@
     "range": { "startLine": 132, "endLine": 159 },
     "type": "theorem",
     "title": "Closed form without leaving ℝ",
-    "content": "integral_offdiag_via_ibp: the same closed form m!·n!/(m+n+1)!, proved by induction on n with m generalized. Base case: ∫₀¹ xᵐ = 1/(m+1) (integral_base) matches m!·0!/(m+1)!. Successor: apply integral_recurrence and the induction hypothesis ih(m+1), then close with factorial arithmetic (Nat.factorial_succ, field_simp). This route uses only the fundamental theorem of calculus over ℝ — no Complex.Gamma — giving an independent confirmation of the value from Route 1."
+    "content": "integral_offdiag_via_ibp: the same closed form m!·n!/(m+n+1)!, proved by induction on n with m generalized. Base case: ∫₀¹ xᵐ = 1/(m+1) (integral_base) matches m!·0!/(m+1)!. Successor: apply integral_recurrence and the induction hypothesis ih(m+1), then close with factorial arithmetic (Nat.factorial_succ, field_simp). This route uses only the fundamental theorem of calculus over ℝ — no Complex.Gamma — giving an independent confirmation of the value from Route 1.",
+    "mathContext": "$\\int_0^1 x^m\\,dx = \\frac{1}{m+1};\\quad \\text{induct on } n \\Rightarrow \\frac{m!\\,n!}{(m+n+1)!}$",
+    "significance": "key",
+    "relatedConcepts": ["induction with generalized parameter", "reduction formula", "fundamental theorem of calculus", "factorial arithmetic"],
+    "prerequisites": ["the IBP recurrence", "the base integral ∫₀¹ xᵐ = 1/(m+1)"]
   },
   {
     "id": "ann-symmetry",
@@ -45,6 +65,10 @@
     "range": { "startLine": 161, "endLine": 169 },
     "type": "theorem",
     "title": "The m ↔ n symmetry",
-    "content": "integral_offdiag_symm: ∫₀¹ xᵐ(1-x)ⁿ = ∫₀¹ xⁿ(1-x)ᵐ. Both sides equal m!·n!/(m+n+1)! (commutativity of m+n in the denominator), so the symmetry — geometrically the substitution x ↦ 1-x — is read directly off the closed form."
+    "content": "integral_offdiag_symm: ∫₀¹ xᵐ(1-x)ⁿ = ∫₀¹ xⁿ(1-x)ᵐ. Both sides equal m!·n!/(m+n+1)! (commutativity of m+n in the denominator), so the symmetry — geometrically the substitution x ↦ 1-x — is read directly off the closed form.",
+    "mathContext": "$\\int_0^1 x^m(1-x)^n\\,dx = \\int_0^1 x^n(1-x)^m\\,dx = \\frac{m!\\,n!}{(m+n+1)!}$",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetry B(m,n) = B(n,m)", "substitution x ↦ 1-x", "Beta function"],
+    "prerequisites": ["the closed-form value", "commutativity of addition"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01-oq-03-oq-01` (off-diagonal ∫₀¹ xᵐ(1-x)ⁿ = m!·n!/(m+n+1)!, proved two independent ways).

## Changes (annotations.json)
Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 6 annotations (Route 1 ℂ→ℝ bridge, closed form, Route 2 IBP recurrence + induction, and the m↔n symmetry). Existing `content` and `type` values were already good.

meta.json was already comprehensive (~15.4 KB, 5 keyInsights) — left unchanged.

JSON validated by the gallery data-generation step of `pnpm build`.