### PR TITLE
Enrich Riesz representation on L² (cauchy-schwarz-oq-02-oq-05): annotation depth

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-05/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 34 },
     "type": "concept",
     "title": "Riesz in L²: the inner-product route",
-    "content": "Riesz (1907) proved that every continuous linear functional on L² is integration against a fixed L² function — the prototype of (L²)* ≅ L². Because L² is a Hilbert space, the representing element comes for free from the inner product structure (the Fréchet–Riesz argument), with no Radon–Nikodým theorem, unlike the general-Lp case. Mathlib packages this as InnerProductSpace.toDual, an isometric conjugate-linear equivalence E ≃ StrongDual 𝕜 E for any complete inner product space E. This file specializes it to E = L² = α →₂[μ] 𝕜 and records the L²-specific consequences: the integral form and the norm identity."
+    "content": "Riesz (1907) proved that every continuous linear functional on L² is integration against a fixed L² function — the prototype of (L²)* ≅ L². Because L² is a Hilbert space, the representing element comes for free from the inner product structure (the Fréchet–Riesz argument), with no Radon–Nikodým theorem, unlike the general-Lp case. Mathlib packages this as InnerProductSpace.toDual, an isometric conjugate-linear equivalence E ≃ StrongDual 𝕜 E for any complete inner product space E. This file specializes it to E = L² = α →₂[μ] 𝕜 and records the L²-specific consequences: the integral form and the norm identity.",
+    "mathContext": "$(L^2)^{*} \\cong L^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["Riesz representation theorem", "Fréchet–Riesz", "Hilbert space duality", "Radon–Nikodým"],
+    "prerequisites": ["Hilbert spaces and inner products", "continuous linear functionals / dual space"]
   },
   {
     "id": "ann-setup",
@@ -13,7 +17,11 @@
     "range": { "startLine": 39, "endLine": 49 },
     "type": "definition",
     "title": "L² as a complete inner product space",
-    "content": "Variables: a measure μ on a measurable space α and an RCLike scalar field 𝕜 (covering ℝ and ℂ uniformly). Then L² = α →₂[μ] 𝕜 = Lp 𝕜 2 μ is automatically a complete inner product space — MeasureTheory.L2.innerProductSpace supplies the inner product, Lp completeness with Fact (1 ≤ 2) supplies completeness — so InnerProductSpace.toDual applies with no extra hypotheses. Every instance below is found by typeclass resolution."
+    "content": "Variables: a measure μ on a measurable space α and an RCLike scalar field 𝕜 (covering ℝ and ℂ uniformly). Then L² = α →₂[μ] 𝕜 = Lp 𝕜 2 μ is automatically a complete inner product space — MeasureTheory.L2.innerProductSpace supplies the inner product, Lp completeness with Fact (1 ≤ 2) supplies completeness — so InnerProductSpace.toDual applies with no extra hypotheses. Every instance below is found by typeclass resolution.",
+    "mathContext": "$L^2 = \\alpha \\to_2[\\mu]\\ \\mathbb{k} = L^p(\\mu)\\big|_{p=2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Lp spaces", "RCLike scalar field", "typeclass resolution", "completeness"],
+    "prerequisites": ["measure theory and Lp spaces", "the L² inner product"]
   },
   {
     "id": "ann-exists",
@@ -21,7 +29,11 @@
     "range": { "startLine": 50, "endLine": 56 },
     "type": "theorem",
     "title": "Existence: the representing element",
-    "content": "riesz_L2_exists: every bounded functional g on L² is g h = ⟪f, h⟫ for some f. The witness is f = (InnerProductSpace.toDual 𝕜 _).symm g, and the defining property is immediate from toDual_symm_apply, which states ⟪(toDual).symm y, x⟫ = y x. No orthogonal-projection bookkeeping is needed at this level — Mathlib's toDual already carries the Fréchet–Riesz construction."
+    "content": "riesz_L2_exists: every bounded functional g on L² is g h = ⟪f, h⟫ for some f. The witness is f = (InnerProductSpace.toDual 𝕜 _).symm g, and the defining property is immediate from toDual_symm_apply, which states ⟪(toDual).symm y, x⟫ = y x. No orthogonal-projection bookkeeping is needed at this level — Mathlib's toDual already carries the Fréchet–Riesz construction.",
+    "mathContext": "$g(h) = \\langle f, h\\rangle,\\qquad f = (\\mathrm{toDual}_{\\mathbb{k}})^{-1} g$",
+    "significance": "key",
+    "relatedConcepts": ["Riesz representation", "InnerProductSpace.toDual", "Fréchet–Riesz construction"],
+    "prerequisites": ["the toDual equivalence", "bounded linear functionals"]
   },
   {
     "id": "ann-inner-ext",
@@ -29,7 +41,11 @@
     "range": { "startLine": 57, "endLine": 64 },
     "type": "lemma",
     "title": "Uniqueness via inner-product extensionality",
-    "content": "riesz_L2_inner_ext: if ⟪f₁, h⟫ = ⟪f₂, h⟫ for all h ∈ L², then f₁ = f₂. This is ext_inner_right — an element of an inner product space is determined by its inner products against everything. It is the uniqueness half of Riesz: two representing elements for the same functional have equal inner products against all h, hence coincide."
+    "content": "riesz_L2_inner_ext: if ⟪f₁, h⟫ = ⟪f₂, h⟫ for all h ∈ L², then f₁ = f₂. This is ext_inner_right — an element of an inner product space is determined by its inner products against everything. It is the uniqueness half of Riesz: two representing elements for the same functional have equal inner products against all h, hence coincide.",
+    "mathContext": "$\\langle f_1, h\\rangle = \\langle f_2, h\\rangle\\ \\forall h \\;\\Rightarrow\\; f_1 = f_2$",
+    "significance": "supporting",
+    "relatedConcepts": ["inner-product extensionality", "ext_inner_right", "nondegeneracy"],
+    "prerequisites": ["nondegeneracy of the inner product"]
   },
   {
     "id": "ann-exists-unique",
@@ -37,7 +53,11 @@
     "range": { "startLine": 65, "endLine": 75 },
     "type": "theorem",
     "title": "The Riesz theorem (∃! form)",
-    "content": "riesz_L2_existsUnique: every bounded linear functional on L² is inner product with a unique element, ∃! f, ∀ h, g h = ⟪f, h⟫. This is the parent's fifth open question verbatim. It combines riesz_L2_exists (existence) with riesz_L2_inner_ext (uniqueness): any other representative f' satisfies ⟪f', h⟫ = g h = ⟪f, h⟫ for all h, so f' = f."
+    "content": "riesz_L2_existsUnique: every bounded linear functional on L² is inner product with a unique element, ∃! f, ∀ h, g h = ⟪f, h⟫. This is the parent's fifth open question verbatim. It combines riesz_L2_exists (existence) with riesz_L2_inner_ext (uniqueness): any other representative f' satisfies ⟪f', h⟫ = g h = ⟪f, h⟫ for all h, so f' = f.",
+    "mathContext": "$\\exists!\\,f,\\ \\forall h,\\ g(h) = \\langle f, h\\rangle$",
+    "significance": "critical",
+    "relatedConcepts": ["Riesz representation theorem", "existence and uniqueness", "dual space isomorphism"],
+    "prerequisites": ["the existence and uniqueness lemmas"]
   },
   {
     "id": "ann-integral",
@@ -45,7 +65,11 @@
     "range": { "startLine": 76, "endLine": 84 },
     "type": "theorem",
     "title": "The classical integral form",
-    "content": "riesz_L2_integral: the functional is integration against the representing element, g h = ∫ a, ⟪f a, h a⟫ ∂μ. Starting from g h = ⟪f, h⟫, the L² inner product is unfolded pointwise by L2.inner_def (⟪f, h⟫ = ∫ a, ⟪f a, h a⟫ ∂μ). This recovers Riesz's original 1907 statement — functional = integration against a fixed function — which is the concrete content beyond the abstract Hilbert-space lemma."
+    "content": "riesz_L2_integral: the functional is integration against the representing element, g h = ∫ a, ⟪f a, h a⟫ ∂μ. Starting from g h = ⟪f, h⟫, the L² inner product is unfolded pointwise by L2.inner_def (⟪f, h⟫ = ∫ a, ⟪f a, h a⟫ ∂μ). This recovers Riesz's original 1907 statement — functional = integration against a fixed function — which is the concrete content beyond the abstract Hilbert-space lemma.",
+    "mathContext": "$g(h) = \\int_\\alpha \\langle f(a), h(a)\\rangle\\,d\\mu(a)$",
+    "significance": "key",
+    "relatedConcepts": ["integral representation", "pointwise L² inner product", "Riesz 1907"],
+    "prerequisites": ["the L² inner product as an integral (L2.inner_def)"]
   },
   {
     "id": "ann-norm",
@@ -53,6 +77,10 @@
     "range": { "startLine": 85, "endLine": 90 },
     "type": "theorem",
     "title": "The representation is isometric",
-    "content": "riesz_L2_norm: the representing element has the same norm as the functional, ‖(toDual).symm g‖ = ‖g‖. Mathlib's toDual is a LinearIsometryEquiv, so its inverse preserves norms (LinearIsometryEquiv.norm_map). This is genuine Hilbert (p = 2) content: Riesz identifies L² with its dual norm-preservingly and conjugate-linearly — the foundation for adjoints, the weak topology, and the spectral theorem on L²."
+    "content": "riesz_L2_norm: the representing element has the same norm as the functional, ‖(toDual).symm g‖ = ‖g‖. Mathlib's toDual is a LinearIsometryEquiv, so its inverse preserves norms (LinearIsometryEquiv.norm_map). This is genuine Hilbert (p = 2) content: Riesz identifies L² with its dual norm-preservingly and conjugate-linearly — the foundation for adjoints, the weak topology, and the spectral theorem on L².",
+    "mathContext": "$\\big\\|(\\mathrm{toDual})^{-1} g\\big\\| = \\|g\\|$",
+    "significance": "key",
+    "relatedConcepts": ["isometric isomorphism", "LinearIsometryEquiv", "conjugate-linearity", "adjoint operators"],
+    "prerequisites": ["norm-preservation of isometric equivalences"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-02-oq-05` (Riesz representation theorem on L²: (L²)* ≅ L² with existence/uniqueness, integral form, and isometry).

## Changes (annotations.json)
Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 7 annotations. Existing `content` and `type` values were already good.

meta.json was already comprehensive (~13.8 KB, 5 keyInsights) — left unchanged. JSON validated by the gallery data-generation step of `pnpm build`.