### PR TITLE
research(picks-theorem-oq-03-ext-oq-02): Hibi's algebraic criterion — h*-palindromic ⟺ self-reciprocal h*-polynomial

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3734,6 +3734,7 @@ import Proofs.PicksTheoremOQ02
 import Proofs.PicksTheoremOQ03
 import Proofs.PicksTheoremOQ03CrossPoly
 import Proofs.PicksTheoremOQ03Ext
+import Proofs.PicksTheoremOQ03ExtOQ02
 import Proofs.PicksTheoremOQ03Product
 import Proofs.PiTranscendental
 import Proofs.PlanarGraphDischarging

--- a/proofs/Proofs/PicksTheoremOQ03ExtOQ02.lean
+++ b/proofs/Proofs/PicksTheoremOQ03ExtOQ02.lean
@@ -1,0 +1,121 @@
+/-
+# Pick's Theorem OQ-03 Extension, follow-up OQ-02
+# Abstract Characterization of h*-Vector Palindromy (Hibi's Criterion)
+
+The parent entry (`PicksTheoremOQ03Ext.lean`) verifies h*-vector palindromy for
+**specific** reflexive polytopes — the octahedron `(1,3,3,1)`, the cube,
+the simplex — and the Ehrhart–Macdonald reciprocity identities on concrete
+examples.  This follow-up proves the **general algebraic characterization** that
+those examples instantiate, the combinatorial heart of Hibi's palindromy theorem
+(1991):
+
+  > The h*-vector `(h₀,…,h_d)` of a lattice polytope is *palindromic*
+  >   (`h_i = h_{d-i}` for all `i ≤ d`)
+  > **iff** its h*-polynomial `H(X) = Σ h_i Xⁱ` is *self-reciprocal*, i.e. equal
+  >   to its own degree-`d` reflection `reflect d H = H`.
+
+This is `reflect_eq_iff_palindromic`.  It is a clean, fully general fact about
+polynomials over an arbitrary commutative semiring — no Ehrhart machinery, no
+case analysis on a fixed dimension.
+
+The link to geometry is `reflexive_hStar_palindromic`: for a reflexive
+`d`-polytope, Ehrhart–Macdonald reciprocity (`L°(n) = (-1)^d L(-n)` together with
+`L°(n) = L(n-1)`) forces precisely the self-reciprocity of the h*-polynomial, and
+palindromy then follows from the general characterization.  We record this bridge
+taking the self-reciprocity (the reciprocity content) as an explicit hypothesis on
+the input — honest about what is assumed, since the generating-function machinery
+producing it is not yet available in Mathlib.
+
+Finally we recover the parent's octahedron example as a corollary of the general
+theorem, confirming the abstraction is faithful, and derive the standard
+"reflexive normalization" `h₀ = h_d`.
+
+## Results (0 sorries, 0 axioms — fully proved)
+Pure polynomial algebra; the main theorem holds over any commutative semiring.
+-/
+
+import Mathlib
+
+namespace PicksOQ03ExtOQ02
+
+open Polynomial Finset
+
+variable {R : Type*} [Semiring R]
+
+/-- The **h*-polynomial** of an h*-vector `h` supported on `{0,…,d}`:
+    `H(X) = Σ_{i=0}^{d} h_i Xⁱ`. -/
+noncomputable def hStarPoly (d : ℕ) (h : ℕ → R) : R[X] :=
+  ∑ i ∈ range (d + 1), C (h i) * X ^ i
+
+/-- A vector is **palindromic** through index `d` when `h_i = h_{d-i}` for `i ≤ d`. -/
+def Palindromic (d : ℕ) (h : ℕ → R) : Prop := ∀ i ≤ d, h i = h (d - i)
+
+/-- The coefficients of the h*-polynomial are exactly the entries of `h` up to `d`. -/
+@[simp] theorem coeff_hStarPoly (d : ℕ) (h : ℕ → R) (k : ℕ) :
+    (hStarPoly d h).coeff k = if k ≤ d then h k else 0 := by
+  simp only [hStarPoly, finset_sum_coeff, coeff_C_mul, coeff_X_pow, mul_ite, mul_one,
+    mul_zero]
+  rw [Finset.sum_ite_eq (range (d + 1)) k (fun i => h i)]
+  simp only [Finset.mem_range, Nat.lt_succ_iff]
+
+/-- **Main theorem (Hibi's criterion, algebraic core).**
+The h*-vector `h` is palindromic through `d` iff its h*-polynomial is
+self-reciprocal, `reflect d (hStarPoly d h) = hStarPoly d h`. -/
+theorem reflect_eq_iff_palindromic (d : ℕ) (h : ℕ → R) :
+    reflect d (hStarPoly d h) = hStarPoly d h ↔ Palindromic d h := by
+  constructor
+  · intro hH i hi
+    have hk := Polynomial.ext_iff.mp hH i
+    rw [coeff_reflect, revAt_le hi, coeff_hStarPoly, coeff_hStarPoly,
+      if_pos (Nat.sub_le d i), if_pos hi] at hk
+    exact hk.symm
+  · intro hp
+    ext k
+    rw [coeff_reflect, coeff_hStarPoly, coeff_hStarPoly]
+    rcases le_or_gt k d with hk | hk
+    · rw [revAt_le hk, if_pos (Nat.sub_le d k), if_pos hk]
+      exact (hp k hk).symm
+    · rw [revAt_eq_self_of_lt hk]
+
+/-- **Reflexive ⟹ palindromic h*-vector** (the reduction step in Hibi's theorem).
+For a reflexive `d`-polytope, Ehrhart–Macdonald reciprocity forces the
+h*-polynomial to be self-reciprocal; palindromy of the h*-vector is then immediate
+from `reflect_eq_iff_palindromic`.  The self-reciprocity is taken as a hypothesis
+on the input (its derivation from the Ehrhart series is the reciprocity content). -/
+theorem reflexive_hStar_palindromic (d : ℕ) (h : ℕ → R)
+    (hreflexive : reflect d (hStarPoly d h) = hStarPoly d h) :
+    Palindromic d h :=
+  (reflect_eq_iff_palindromic d h).mp hreflexive
+
+/-- **Reflexive normalization.** A palindromic h*-vector has matching extreme
+entries `h₀ = h_d`; for a lattice polytope `h₀ = 1`, so a reflexive polytope has
+`h_d = 1` (the Gorenstein/reflexive normalization). -/
+theorem hStar_constant_eq_leading (d : ℕ) (h : ℕ → R) (hp : Palindromic d h) :
+    h 0 = h d := by
+  have := hp 0 (Nat.zero_le d)
+  simpa using this
+
+-- ============================================================
+-- Recovering the parent's octahedron example from the general theorem
+-- ============================================================
+
+/-- The octahedron (3D cross-polytope) h*-vector `(1, 3, 3, 1)` as a function. -/
+def octaH : ℕ → ℚ := fun i => if i = 0 then 1 else if i = 1 then 3 else
+  if i = 2 then 3 else if i = 3 then 1 else 0
+
+/-- The octahedron h*-vector is palindromic — an instance of the general criterion. -/
+theorem octaH_palindromic : Palindromic 3 octaH := by
+  intro i hi
+  interval_cases i <;> simp [octaH]
+
+/-- Equivalently, the octahedron h*-polynomial is self-reciprocal — obtained from
+palindromy through the general equivalence, demonstrating the bridge is faithful. -/
+theorem octaH_self_reciprocal :
+    reflect 3 (hStarPoly 3 octaH) = hStarPoly 3 octaH :=
+  (reflect_eq_iff_palindromic 3 octaH).mpr octaH_palindromic
+
+/-- Consistency check: the octahedron satisfies the reflexive normalization. -/
+theorem octaH_normalization : octaH 0 = octaH 3 :=
+  hStar_constant_eq_leading 3 octaH octaH_palindromic
+
+end PicksOQ03ExtOQ02

--- a/src/data/proofs/picks-theorem-oq-03-ext-oq-02/annotations.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-oq03extoq02-overview",
+    "proofId": "picks-theorem-oq-03-ext-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 36
+    },
+    "type": "concept",
+    "title": "From Examples to a Theorem: Hibi's Palindromy Criterion",
+    "content": "The parent entry verified that specific reflexive polytopes have palindromic h*-vectors -- the octahedron's (1,3,3,1), and the failure of palindromy for the cube and simplex. Those are instances of a single dimension-free fact, which this file isolates and proves: the h*-vector (h_0,...,h_d) is palindromic (h_i = h_{d-i}) if and only if its h*-polynomial H(X) = sum_{i<=d} h_i X^i is self-reciprocal, meaning H equals its own degree-d coefficient reflection. Concretely, Mathlib's Polynomial.reflect d sends the coefficient at index i to the coefficient at revAt d i = d - i (for i <= d), so reflect d H = H is exactly the coefficient-wise palindromy condition. This is the combinatorial heart of Hibi's 1991 theorem characterizing reflexive polytopes. Where does reflexivity itself enter? Ehrhart-Macdonald reciprocity L*(n) = (-1)^d L(-n), together with the reflexive relation L*(n) = L(n-1), forces H(t) = t^d H(1/t) on the Ehrhart series H/(1-t)^{d+1}, i.e. self-reciprocity of the h*-polynomial. Mathlib has no Ehrhart generating-series machinery, so this derivation is recorded as an explicit hypothesis rather than proved from first principles; the algebraic core and the octahedron corollary are fully proved, with no sorries and no axioms.",
+    "mathContext": "h*-polynomial: $H(X) = \\sum_{i=0}^{d} h^*_i X^i$. Self-reciprocity: $\\mathrm{reflect}_d H = H$, equivalently $\\mathrm{coeff}_i H = \\mathrm{coeff}_{d-i} H$. Ehrhart series: $\\sum_{n\\ge 0} L(n) t^n = H(t)/(1-t)^{d+1}$, with reflexivity giving $H(t) = t^d H(1/t)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflexive polytope",
+      "h*-vector palindromy",
+      "Hibi's theorem (1991)",
+      "Ehrhart-Macdonald reciprocity",
+      "self-reciprocal (palindromic) polynomial"
+    ],
+    "prerequisites": [
+      "Ehrhart polynomial and h*-vector",
+      "Polynomial.reflect and coefficient reflection",
+      "lattice polytope basics"
+    ]
+  },
+  {
+    "id": "ann-oq03extoq02-hstarpoly",
+    "proofId": "picks-theorem-oq-03-ext-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 62
+    },
+    "type": "definition",
+    "title": "The h*-Polynomial and the Palindromy Predicate",
+    "content": "Two definitions package the data. hStarPoly d h := sum_{i in range (d+1)} C (h i) * X^i is the h*-polynomial of an h*-vector h supported on {0,...,d}, over an arbitrary commutative semiring R. Palindromic d h := for all i <= d, h i = h (d-i) is the palindromy predicate. The bridge lemma coeff_hStarPoly proves that the polynomial coefficients are exactly the vector entries: (hStarPoly d h).coeff k = h k for k <= d and 0 otherwise. Its proof expands the finite sum's coefficient (finset_sum_coeff), uses coeff_C_mul and coeff_X_pow to collapse each term to an indicator, and resolves the resulting Finset.sum_ite_eq, rewriting membership k in range (d+1) to k <= d. This lemma is what lets the reflection identity on polynomials be read back as a statement about the vector h.",
+    "mathContext": "$H(X) = \\sum_{i=0}^{d} h_i X^i$, $\\mathrm{coeff}_k H = h_k$ for $k \\le d$ and $0$ otherwise. Palindromic: $h_i = h_{d-i}$ for $0 \\le i \\le d$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "h*-polynomial",
+      "polynomial coefficient extraction",
+      "Finset.sum_ite_eq"
+    ],
+    "prerequisites": [
+      "Polynomial.coeff",
+      "Finset.sum over range"
+    ]
+  },
+  {
+    "id": "ann-oq03extoq02-criterion",
+    "proofId": "picks-theorem-oq-03-ext-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 97
+    },
+    "type": "theorem",
+    "title": "Hibi's Criterion: Palindromy = Self-Reciprocity",
+    "content": "The main theorem reflect_eq_iff_palindromic states reflect d (hStarPoly d h) = hStarPoly d h <-> Palindromic d h, over any commutative semiring. The forward direction reads off coefficient i of the polynomial identity: coeff_reflect gives (reflect d H).coeff i = H.coeff (revAt d i), and for i <= d the lemma revAt_le rewrites revAt d i = d - i, so equality of coefficients i is h (d-i) = h i. The reverse direction proves the polynomial identity by Polynomial.ext: for k <= d use revAt_le and palindromy; for k > d use revAt_eq_self_of_lt (so reflection fixes index k) and both coefficients vanish. The geometric reduction reflexive_hStar_palindromic packages the forward implication: if the h*-polynomial is self-reciprocal -- the form Ehrhart-Macdonald reciprocity takes for a reflexive polytope -- then the h*-vector is palindromic. Finally hStar_constant_eq_leading derives h_0 = h_d from palindromy (instantiating i = 0), the reflexive/Gorenstein normalization: with h_0 = 1 the top coefficient is also 1.",
+    "mathContext": "$\\mathrm{reflect}_d H = H \\iff (\\forall i \\le d,\\ h_i = h_{d-i})$. Reflexive $\\Rightarrow$ self-reciprocal $H(t) = t^d H(1/t) \\Rightarrow$ palindromic. Normalization: $h_0 = h_d$, so $h_0 = 1 \\Rightarrow h_d = 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "self-reciprocal polynomial",
+      "Polynomial.reflect / coeff_reflect / revAt",
+      "Hibi's palindromy theorem",
+      "Gorenstein normalization"
+    ],
+    "prerequisites": [
+      "Polynomial.ext and coeff_reflect",
+      "revAt_le, revAt_eq_self_of_lt"
+    ]
+  },
+  {
+    "id": "ann-oq03extoq02-octahedron",
+    "proofId": "picks-theorem-oq-03-ext-oq-02",
+    "range": {
+      "startLine": 99,
+      "endLine": 121
+    },
+    "type": "example",
+    "title": "Recovering the Octahedron (1,3,3,1) as a Corollary",
+    "content": "To confirm the abstraction is faithful to the parent's example, the octahedron h*-vector (1,3,3,1) is defined as octaH : N -> Q and shown palindromic by octaH_palindromic via interval_cases over i <= 3. The companion octaH_self_reciprocal then obtains the polynomial identity reflect 3 (hStarPoly 3 octaH) = hStarPoly 3 octaH directly from palindromy through the general equivalence reflect_eq_iff_palindromic -- exercising the criterion in the mpr direction. octaH_normalization records h_0 = h_3 = 1. Thus the parent's stand-alone decide-based octahedron palindromy is reproduced here as an instance of the general theorem, with the self-reciprocity of its h*-polynomial as a free consequence.",
+    "mathContext": "Octahedron (3D cross-polytope) is reflexive with $h^* = (1,3,3,1)$, sum $8 = 3! \\cdot 4/3$. Here $(1,3,3,1)$ is palindromic, so $\\mathrm{reflect}_3 H = H$ and $h_0 = h_3 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cross-polytope / octahedron",
+      "reflexive polytope example",
+      "interval_cases"
+    ],
+    "prerequisites": [
+      "the general criterion reflect_eq_iff_palindromic"
+    ]
+  }
+]

--- a/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03-ext-oq-02/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "picks-theorem-oq-03-ext-oq-02",
+  "title": "Reflexive Polytopes and Palindromic h*-Vectors: Hibi's Algebraic Criterion",
+  "slug": "picks-theorem-oq-03-ext-oq-02",
+  "description": "The general, dimension-free algebraic core of Hibi's palindromy theorem: the h*-vector (h_0,...,h_d) of a lattice polytope is palindromic (h_i = h_{d-i}) if and only if its h*-polynomial H(X) = sum h_i X^i is self-reciprocal, reflect d H = H. This abstracts the example-based palindromy of the parent entry into a single theorem over any commutative semiring, gives the reflexive-implies-palindromic reduction step of Hibi's theorem, and recovers the octahedron (1,3,3,1) example as a corollary. 7 theorems, 3 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PicksTheoremOQ03ExtOQ02.lean",
+    "tags": [
+      "combinatorics",
+      "ehrhart-theory",
+      "polytopes",
+      "h-star-vector",
+      "reflexive-polytopes",
+      "hibi-theorem",
+      "palindromic-polynomial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 121,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "assumptions": "None for the algebraic core. The geometric bridge theorem reflexive_hStar_palindromic takes the self-reciprocity of the h*-polynomial (the Ehrhart-Macdonald reciprocity content for a reflexive polytope) as an explicit hypothesis on the input vector, since Mathlib has no Ehrhart generating-series infrastructure to derive it from first principles.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.reflect",
+        "description": "Degree-N coefficient reflection of a polynomial, with coeff_reflect and revAt; the primitive expressing h*-polynomial self-reciprocity",
+        "module": "Mathlib.Algebra.Polynomial.Reverse"
+      }
+    ],
+    "dateAdded": "2026-06-26",
+    "mathlib_version": "4.26.0",
+    "namespace": "PicksOQ03ExtOQ02",
+    "path": "Proofs/PicksTheoremOQ03ExtOQ02.lean"
+  },
+  "overview": {
+    "historicalContext": "Takayuki Hibi (1991) characterized reflexive polytopes by h*-palindromy: a lattice polytope P is reflexive (its polar dual is again a lattice polytope, equivalently the origin is the unique interior lattice point of suitable dilates) if and only if its h*-vector is palindromic, h*_i = h*_{d-i}. This sits on top of Ehrhart's polynomial theory (1962) and the Ehrhart-Macdonald reciprocity theorem (Macdonald 1971), L*(n) = (-1)^d L(-n), relating the interior lattice-point counting polynomial L* to L at negative integers. The parent gallery entry verified Hibi palindromy only on concrete examples; the symmetry it observed is in fact a dimension-free algebraic identity on the h*-polynomial, which is what this entry isolates and proves.",
+    "problemStatement": "Prove the general statement behind the parent's example-based observations: the h*-vector is palindromic if and only if the h*-polynomial is self-reciprocal (equal to its own degree-d reflection), and record how reflexivity (via Ehrhart-Macdonald reciprocity) supplies exactly that self-reciprocity.",
+    "proofStrategy": "Encode the h*-vector as a polynomial H(X) = sum_{i<=d} h_i X^i (hStarPoly). Palindromy h_i = h_{d-i} is, coefficient-by-coefficient, the statement that reflecting H about degree d (Mathlib's Polynomial.reflect d, which sends coeff i to coeff (revAt d i) = coeff (d-i) for i <= d) returns H. The equivalence reflect_eq_iff_palindromic is proved by Polynomial.ext together with coeff_reflect and the two branches of revAt (revAt_le for i <= d, revAt_eq_self_of_lt for i > d). The geometric reduction reflexive_hStar_palindromic is then a direct application of the equivalence; the octahedron example is recovered by interval_cases.",
+    "keyInsights": [
+      "**Palindromy is self-reciprocity**: h*_i = h*_{d-i} for all i is exactly the polynomial identity reflect d H = H. This makes Hibi's combinatorial symmetry a single algebraic equation, independent of dimension and of the specific polytope.",
+      "**Dimension-free generality**: the criterion holds over an arbitrary commutative semiring, so it covers all lattice polytopes uniformly rather than one fixed (1,3,3,1)-style example at a time.",
+      "**Where reflexivity enters**: Ehrhart-Macdonald reciprocity L*(n) = (-1)^d L(-n) plus the reflexive relation L*(n) = L(n-1) forces H(t) = t^d H(1/t) on the Ehrhart series H/(1-t)^{d+1}, i.e. self-reciprocity of the h*-polynomial; palindromy is then automatic.",
+      "**Reflexive normalization**: a palindromic h*-vector has h_0 = h_d, so the standard normalization h_0 = 1 forces h_d = 1 (the Gorenstein/reflexive normalization).",
+      "**Honest assumption boundary**: Mathlib lacks Ehrhart generating-series infrastructure, so the step deriving self-reciprocity from reciprocity is taken as a hypothesis; the algebraic core and the octahedron corollary are fully proved with no axioms."
+    ]
+  },
+  "sections": [
+    {
+      "id": "hstar-polynomial",
+      "title": "Section I: The h*-Polynomial and Palindromy",
+      "startLine": 47,
+      "endLine": 62,
+      "summary": "Defines hStarPoly d h = sum_{i in range (d+1)} C (h i) * X^i and Palindromic d h := for all i <= d, h i = h (d-i). Proves coeff_hStarPoly: the polynomial coefficients are exactly the entries of h up to d.",
+      "mathContext": "The h*-polynomial $H(X) = \\sum_{i=0}^{d} h^*_i X^i$ packages the h*-vector; palindromy is $h^*_i = h^*_{d-i}$."
+    },
+    {
+      "id": "hibi-criterion",
+      "title": "Section II: Hibi's Criterion (Algebraic Core)",
+      "startLine": 64,
+      "endLine": 97,
+      "summary": "reflect_eq_iff_palindromic: reflect d (hStarPoly d h) = hStarPoly d h <-> Palindromic d h, over any semiring. reflexive_hStar_palindromic: self-reciprocity (reflexivity) implies palindromy. hStar_constant_eq_leading: palindromic implies h_0 = h_d.",
+      "mathContext": "Self-reciprocity $\\mathrm{reflect}_d H = H$ means $\\mathrm{coeff}_i = \\mathrm{coeff}_{d-i}$; this is Hibi's reflexive iff palindromic, reduced to its algebraic skeleton."
+    },
+    {
+      "id": "octahedron-corollary",
+      "title": "Section III: Octahedron Example as a Corollary",
+      "startLine": 99,
+      "endLine": 121,
+      "summary": "octaH = (1,3,3,1); octaH_palindromic via interval_cases; octaH_self_reciprocal obtained from palindromy through the general equivalence; octaH_normalization confirms h_0 = h_3.",
+      "mathContext": "The octahedron (3D cross-polytope) is reflexive; its h*-vector $(1,3,3,1)$ is palindromic, recovered here as an instance of the general theorem."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "picks-theorem-oq-03-ext",
+      "relationship": "extends",
+      "description": "Parent entry verifies h*-palindromy and reciprocity on concrete examples (octahedron, cube, simplex); this entry proves the general dimension-free algebraic criterion those examples instantiate and recovers the octahedron case as a corollary"
+    },
+    {
+      "targetId": "picks-theorem-oq-03-cross-poly",
+      "relationship": "related",
+      "description": "Sibling on cross-polytope (octahedron) Ehrhart theory; the octahedron palindromy proved here as a corollary connects to the full octahedron Ehrhart polynomial there"
+    },
+    {
+      "targetId": "picks-theorem-oq-03-product",
+      "relationship": "sibling",
+      "description": "Sibling Ehrhart extension on product formulas and h*-vectors under products; complements the palindromy criterion isolated here"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "reflect_eq_iff_palindromic",
+      "type": "core",
+      "statement": "reflect d (hStarPoly d h) = hStarPoly d h <-> Palindromic d h, over any commutative semiring",
+      "description": "The general algebraic core of Hibi's palindromy theorem: the h*-vector is palindromic iff the h*-polynomial is self-reciprocal.",
+      "significance": "Abstracts the parent's example-based palindromy into a single dimension-free theorem"
+    },
+    {
+      "name": "reflexive_hStar_palindromic",
+      "type": "core",
+      "statement": "If the h*-polynomial is self-reciprocal (reflect d H = H) then the h*-vector is palindromic",
+      "description": "The reflexive-implies-palindromic reduction step of Hibi's theorem, with self-reciprocity (the Ehrhart-Macdonald reciprocity content) as hypothesis.",
+      "significance": "Connects the algebraic criterion to the geometry of reflexive polytopes"
+    },
+    {
+      "name": "hStar_constant_eq_leading",
+      "type": "corollary",
+      "statement": "A palindromic h*-vector satisfies h_0 = h_d",
+      "description": "Reflexive/Gorenstein normalization: with h_0 = 1 this forces h_d = 1.",
+      "significance": "Standard consequence of palindromy for reflexive polytopes"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the **general, dimension-free algebraic core of Hibi's palindromy theorem** (1991):

> The h*-vector $(h_0,\dots,h_d)$ of a lattice polytope is *palindromic* ($h_i = h_{d-i}$) **iff** its h*-polynomial $H(X)=\sum h_i X^i$ is *self-reciprocal* ($\mathrm{reflect}\ d\ H = H$).

This abstracts the parent entry `picks-theorem-oq-03-ext` (which verified palindromy only on concrete examples — octahedron, cube, simplex) into a single theorem over an arbitrary commutative semiring.

## Results — 7 theorems, 3 definitions, 0 sorries, 0 axioms (VERIFIED)

- `reflect_eq_iff_palindromic` — the algebraic core (main theorem), proved via `Polynomial.ext` + `coeff_reflect` + the two `revAt` branches.
- `reflexive_hStar_palindromic` — the reflexive ⟹ palindromic reduction step. Self-reciprocity (the Ehrhart–Macdonald reciprocity content) is taken as an **explicit hypothesis** on the input, honestly disclosing that Mathlib has no Ehrhart generating-series infrastructure to derive it.
- `hStar_constant_eq_leading` — reflexive/Gorenstein normalization $h_0 = h_d$.
- Octahedron $(1,3,3,1)$ recovered as a corollary (`octaH_palindromic`, `octaH_self_reciprocal`, `octaH_normalization`), confirming the abstraction is faithful.

## Verification

Built via `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ03ExtOQ02` — `Build completed successfully`. Only a cosmetic `unusedSectionVars` linter hint remains (non-blocking).

Also fixed a corrupted `meta.json` (two concatenated JSON objects → kept the canonical one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)