### PR TITLE
Enrich Zolotarev/Frobenius for squarefree odd n (elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 74, "endLine": 82 },
     "type": "theorem",
     "title": "The integer unit from a coprimality hypothesis",
-    "content": "intCast_isUnit_of_isCoprime: an integer c coprime to k casts to a unit of ℤ/k. Bezout gives x·c + y·k = 1 in ℤ; reducing mod k (where k = 0) collapses this to x·c = 1, exhibiting (x : ℤ/k) as the inverse of (c : ℤ/k). This one-line bridge manufactures the CRT component units at each prime factor of n during the induction."
+    "content": "intCast_isUnit_of_isCoprime: an integer c coprime to k casts to a unit of ℤ/k. Bezout gives x·c + y·k = 1 in ℤ; reducing mod k (where k = 0) collapses this to x·c = 1, exhibiting (x : ℤ/k) as the inverse of (c : ℤ/k). This one-line bridge manufactures the CRT component units at each prime factor of n during the induction.",
+    "mathContext": "$xc + yk = 1 \\;\\Rightarrow\\; (c \\bmod k) \\in (\\mathbb{Z}/k)^{\\times}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Bézout's identity", "units mod k", "coprimality", "ZMod"],
+    "prerequisites": ["Bézout's identity", "units of ℤ/k"]
   },
   {
     "id": "ann-eqr-oq01030101-base1",
@@ -13,31 +17,47 @@
     "range": { "startLine": 98, "endLine": 104 },
     "type": "theorem",
     "title": "Recursion base: ℤ/1 is a subsingleton",
-    "content": "When n = 1 the ring ℤ/1 has a single element, so ringMulPerm u is forced to be the identity permutation (Subsingleton.elim), its sign is 1, and jacobiSym.one_right gives J(c | 1) = 1. This anchors the strong induction."
+    "content": "When n = 1 the ring ℤ/1 has a single element, so ringMulPerm u is forced to be the identity permutation (Subsingleton.elim), its sign is 1, and jacobiSym.one_right gives J(c | 1) = 1. This anchors the strong induction.",
+    "mathContext": "$J(c \\mid 1) = 1 = \\mathrm{sgn}(\\mathrm{id})$",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi symbol", "subsingleton", "base case of induction"],
+    "prerequisites": ["ℤ/1 is trivial", "sign of the identity permutation"]
   },
   {
     "id": "ann-eqr-oq01030101-split",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
     "range": { "startLine": 107, "endLine": 122 },
-    "type": "proof",
+    "type": "insight",
     "title": "Splitting off the smallest prime factor (squarefreeness)",
-    "content": "The inductive step peels p = n.minFac off n, leaving the cofactor m = n/p. Squarefreeness is exactly what forces Coprime p m: if p ∣ m then p·p ∣ p·m = n, contradicting Squarefree n. With n = p·m odd, both p and m are odd and m < n, giving the inputs the CRT multiplicativity lemma needs and a smaller instance for the inductive hypothesis."
+    "content": "The inductive step peels p = n.minFac off n, leaving the cofactor m = n/p. Squarefreeness is exactly what forces Coprime p m: if p ∣ m then p·p ∣ p·m = n, contradicting Squarefree n. With n = p·m odd, both p and m are odd and m < n, giving the inputs the CRT multiplicativity lemma needs and a smaller instance for the inductive hypothesis.",
+    "mathContext": "$n = p \\cdot m,\\quad p = \\mathrm{minFac}(n),\\quad \\gcd(p, m) = 1 \\ (n \\text{ squarefree})$",
+    "significance": "key",
+    "relatedConcepts": ["squarefree integers", "minimal prime factor", "strong induction", "coprimality"],
+    "prerequisites": ["squarefree ⟹ no repeated prime factors", "strong induction on n"]
   },
   {
     "id": "ann-eqr-oq01030101-crtmatch",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
     "range": { "startLine": 134, "endLine": 152 },
-    "type": "proof",
+    "type": "insight",
     "title": "CRT component units and projection matching",
-    "content": "The component units u₁ : (ℤ/p)ˣ and u₂ : (ℤ/m)ˣ are built from the split coprimalities via intCast_isUnit_of_isCoprime. Because the unit is represented by the integer c, the Chinese-remainder projections match automatically: the first/second projection of (c : ℤ/n) is (c : ℤ/p) / (c : ℤ/m) by map_intCast — no residue bookkeeping is required."
+    "content": "The component units u₁ : (ℤ/p)ˣ and u₂ : (ℤ/m)ˣ are built from the split coprimalities via intCast_isUnit_of_isCoprime. Because the unit is represented by the integer c, the Chinese-remainder projections match automatically: the first/second projection of (c : ℤ/n) is (c : ℤ/p) / (c : ℤ/m) by map_intCast — no residue bookkeeping is required.",
+    "mathContext": "$\\mathbb{Z}/n \\cong \\mathbb{Z}/p \\times \\mathbb{Z}/m,\\qquad c \\bmod n \\mapsto (c \\bmod p,\\ c \\bmod m)$",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "ring isomorphism", "map_intCast", "component units"],
+    "prerequisites": ["CRT for coprime moduli", "integer casts commute with ring maps"]
   },
   {
     "id": "ann-eqr-oq01030101-assemble",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01",
     "range": { "startLine": 153, "endLine": 167 },
-    "type": "proof",
+    "type": "insight",
     "title": "Assembling the Jacobi symbol",
-    "content": "sign_ringMulPerm_mul_of_odd (grandparent) splits sign(ringMulPerm u) = sign(ringMulPerm u₁) · sign(ringMulPerm u₂). The parent's base case rewrites the prime factor as legendreSym p c = J(c | p); the inductive hypothesis rewrites the cofactor as J(c | m); and jacobiSym.mul_right reassembles J(c | p) · J(c | m) = J(c | p·m) = J(c | n). This is the structural shadow of the Jacobi symbol's own recursive definition."
+    "content": "sign_ringMulPerm_mul_of_odd (grandparent) splits sign(ringMulPerm u) = sign(ringMulPerm u₁) · sign(ringMulPerm u₂). The parent's base case rewrites the prime factor as legendreSym p c = J(c | p); the inductive hypothesis rewrites the cofactor as J(c | m); and jacobiSym.mul_right reassembles J(c | p) · J(c | m) = J(c | p·m) = J(c | n). This is the structural shadow of the Jacobi symbol's own recursive definition.",
+    "mathContext": "$\\mathrm{sgn}(\\pi_c) = \\mathrm{sgn}(\\pi_{c,1})\\cdot\\mathrm{sgn}(\\pi_{c,2}),\\qquad J(c\\mid p)\\,J(c\\mid m) = J(c\\mid n)$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicativity of the Jacobi symbol", "sign of a permutation", "Legendre symbol", "Zolotarev's lemma"],
+    "prerequisites": ["multiplicativity of sign over CRT", "the prime base case J(c|p) = legendreSym"]
   },
   {
     "id": "ann-eqr-oq01030101-main",
@@ -45,6 +65,10 @@
     "range": { "startLine": 169, "endLine": 174 },
     "type": "theorem",
     "title": "Frobenius/Zolotarev for squarefree odd n",
-    "content": "sign_ringMulPerm_eq_jacobiSym: the clean-binder statement of the result — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u on ℤ/n) = J(c | n). This is the genuine Frobenius (1914) generalization of Zolotarev's lemma for squarefree odd moduli, landing on Mathlib's jacobiSym, with 0 sorries and 0 axioms."
+    "content": "sign_ringMulPerm_eq_jacobiSym: the clean-binder statement of the result — for n odd squarefree, c coprime to n, and the unit u representing c, sign(ringMulPerm u on ℤ/n) = J(c | n). This is the genuine Frobenius (1914) generalization of Zolotarev's lemma for squarefree odd moduli, landing on Mathlib's jacobiSym, with 0 sorries and 0 axioms.",
+    "mathContext": "$\\mathrm{sgn}\\big(x \\mapsto c\\,x \\text{ on } \\mathbb{Z}/n\\big) = \\left(\\tfrac{c}{n}\\right) = J(c \\mid n)$",
+    "significance": "critical",
+    "relatedConcepts": ["Zolotarev's lemma", "Frobenius 1914", "Jacobi symbol", "quadratic reciprocity"],
+    "prerequisites": ["the inductive assembly over prime factors", "Mathlib's jacobiSym"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01` (Frobenius's generalization of Zolotarev's lemma: sign of multiplication-by-c on ℤ/n equals the Jacobi symbol, for squarefree odd n).

## Changes (annotations.json)
- Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 6 annotations.
- Fix 3 annotations whose `type` was `proof` (not in the schema) → `insight`.

meta.json was already comprehensive (~10.7 KB, 5 keyInsights) — left unchanged. JSON validated by the gallery data-generation step of `pnpm build`.