### PR TITLE
Enrich prime-power Zolotarev lemma (elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 69, "endLine": 72 },
     "type": "definition",
     "title": "The left regular representation",
-    "content": "mulLeftHom : G →* Perm G packages left translation x ↦ a·x of an arbitrary finite group as a monoid homomorphism into its symmetric group. This is the abstract home of Zolotarev's lemma: the map x ↦ u·x on a unit group is left translation, and its sign is the object to be computed. Stating it generically isolates the purely group-theoretic core from the number theory."
+    "content": "mulLeftHom : G →* Perm G packages left translation x ↦ a·x of an arbitrary finite group as a monoid homomorphism into its symmetric group. This is the abstract home of Zolotarev's lemma: the map x ↦ u·x on a unit group is left translation, and its sign is the object to be computed. Stating it generically isolates the purely group-theoretic core from the number theory.",
+    "mathContext": "$\\mathrm{mulLeftHom} : G \\to \\mathrm{Perm}(G),\\quad a \\mapsto (x \\mapsto a\\cdot x)$",
+    "significance": "supporting",
+    "relatedConcepts": ["left regular representation", "Cayley's theorem", "group homomorphism", "Zolotarev's lemma"],
+    "prerequisites": ["permutation groups", "the regular action of a group on itself"]
   },
   {
     "id": "ann-eqr-oq0103010101-nofixed",
@@ -13,7 +17,11 @@
     "range": { "startLine": 75, "endLine": 91 },
     "type": "theorem",
     "title": "A generator's translation is a single cycle",
-    "content": "mulLeft_no_fixed: translation by a ≠ 1 has no fixed point, since a·x = x forces a = 1 by mul_right_cancel. mulLeft_generator_isCycle: when g generates the group (every element is a power of g), repeatedly translating 1 reaches every element, so Equiv.mulLeft g is a single cycle. Together with full support this pins down the cycle structure exactly."
+    "content": "mulLeft_no_fixed: translation by a ≠ 1 has no fixed point, since a·x = x forces a = 1 by mul_right_cancel. mulLeft_generator_isCycle: when g generates the group (every element is a power of g), repeatedly translating 1 reaches every element, so Equiv.mulLeft g is a single cycle. Together with full support this pins down the cycle structure exactly.",
+    "mathContext": "$a\\cdot x = x \\Rightarrow a = 1;\\quad g \\text{ generates } G \\Rightarrow x\\mapsto g x \\text{ is a single } |G|\\text{-cycle}$",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point-free permutation", "cyclic group", "cycle structure", "cancellation"],
+    "prerequisites": ["cancellation in groups", "cyclic generators"]
   },
   {
     "id": "ann-eqr-oq0103010101-signgen",
@@ -21,7 +29,11 @@
     "range": { "startLine": 93, "endLine": 125 },
     "type": "theorem",
     "title": "Sign of translation by a generator",
-    "content": "generator_ne_one: a generator of a group with more than one element is non-trivial. sign_mulLeft_generator: a single |G|-cycle has sign -(-1)^|G|, which equals -1 precisely when |G| is even (Even.neg_one_pow). sign_mulLeft_pow: sign of translation is multiplicative under powers, because sign ∘ mulLeftHom is a homomorphism. These three facts reduce the whole computation to the parity of |G| and the value at a single generator."
+    "content": "generator_ne_one: a generator of a group with more than one element is non-trivial. sign_mulLeft_generator: a single |G|-cycle has sign -(-1)^|G|, which equals -1 precisely when |G| is even (Even.neg_one_pow). sign_mulLeft_pow: sign of translation is multiplicative under powers, because sign ∘ mulLeftHom is a homomorphism. These three facts reduce the whole computation to the parity of |G| and the value at a single generator.",
+    "mathContext": "$\\mathrm{sgn}\\big(\\text{single } |G|\\text{-cycle}\\big) = -(-1)^{|G|} = \\begin{cases}-1 & |G| \\text{ even}\\\\ +1 & |G| \\text{ odd}\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["sign of a cycle", "parity of a permutation", "homomorphism", "Even.neg_one_pow"],
+    "prerequisites": ["sign of an n-cycle = (-1)^{n-1}", "multiplicativity of sign"]
   },
   {
     "id": "ann-eqr-oq0103010101-cardeven",
@@ -29,7 +41,11 @@
     "range": { "startLine": 131, "endLine": 140 },
     "type": "theorem",
     "title": "The prime-power unit group has even order",
-    "content": "card_units_prime_pow_even: |(ℤ/pⁿ)ˣ| equals the totient pⁿ⁻¹(p-1) (ZMod.card_units_eq_totient and Nat.totient_prime_pow), which is even because p-1 is even for an odd prime p. This even-order fact is exactly what makes a generator's single full-length cycle an odd permutation (sign -1)."
+    "content": "card_units_prime_pow_even: |(ℤ/pⁿ)ˣ| equals the totient pⁿ⁻¹(p-1) (ZMod.card_units_eq_totient and Nat.totient_prime_pow), which is even because p-1 is even for an odd prime p. This even-order fact is exactly what makes a generator's single full-length cycle an odd permutation (sign -1).",
+    "mathContext": "$\\big|(\\mathbb{Z}/p^n)^{\\times}\\big| = \\varphi(p^n) = p^{n-1}(p-1) \\equiv 0 \\pmod 2 \\quad (p \\text{ odd})$",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient", "unit group of ℤ/pⁿ", "parity", "odd prime"],
+    "prerequisites": ["|(ℤ/pⁿ)ˣ| = φ(pⁿ)", "totient of a prime power"]
   },
   {
     "id": "ann-eqr-oq0103010101-main",
@@ -37,7 +53,11 @@
     "range": { "startLine": 148, "endLine": 186 },
     "type": "theorem",
     "title": "The units-level prime-power Zolotarev lemma",
-    "content": "sign_mulLeft_eq_quadraticChar: instantiating the generic machinery at the cyclic group (ℤ/pⁿ)ˣ (cyclic by ZMod.isCyclic_units_of_prime_pow for odd p). Pick a generator g; the reduction ρ = ZMod.unitsMap (p ∣ pⁿ) is surjective (ZMod.unitsMap_surjective), so ρ g generates (ℤ/p)ˣ and is a non-residue (reusing the parent's generator_not_isSquare), giving quadraticChar(ρ g) = -1; the even-order single-cycle argument gives sign(mulLeft g) = -1. Writing u = gᵏ, both sign(mulLeft u) and quadraticChar(ρ u) collapse to (-1)ᵏ, so they coincide."
+    "content": "sign_mulLeft_eq_quadraticChar: instantiating the generic machinery at the cyclic group (ℤ/pⁿ)ˣ (cyclic by ZMod.isCyclic_units_of_prime_pow for odd p). Pick a generator g; the reduction ρ = ZMod.unitsMap (p ∣ pⁿ) is surjective (ZMod.unitsMap_surjective), so ρ g generates (ℤ/p)ˣ and is a non-residue (reusing the parent's generator_not_isSquare), giving quadraticChar(ρ g) = -1; the even-order single-cycle argument gives sign(mulLeft g) = -1. Writing u = gᵏ, both sign(mulLeft u) and quadraticChar(ρ u) collapse to (-1)ᵏ, so they coincide.",
+    "mathContext": "$\\mathrm{sgn}\\big(x \\mapsto u\\,x \\text{ on } (\\mathbb{Z}/p^n)^{\\times}\\big) = \\chi(\\rho\\, u),\\qquad \\rho : (\\mathbb{Z}/p^n)^{\\times} \\twoheadrightarrow (\\mathbb{Z}/p)^{\\times}$",
+    "significance": "critical",
+    "relatedConcepts": ["Zolotarev's lemma", "quadratic character", "cyclic unit group", "surjective reduction"],
+    "prerequisites": ["(ℤ/pⁿ)ˣ is cyclic for odd p", "the even-order single-cycle sign argument"]
   },
   {
     "id": "ann-eqr-oq0103010101-legendre",
@@ -45,6 +65,10 @@
     "range": { "startLine": 188, "endLine": 195 },
     "type": "theorem",
     "title": "Legendre-symbol form",
-    "content": "sign_mulLeft_eq_legendre: converts the field quadratic character of the reduced unit back into the Legendre symbol mod p via the parent's legendreSym_unit_eq, giving the clean statement sign(x ↦ u·x on (ℤ/pⁿ)ˣ) = legendreSym p ((ρ u).val) — the prime-power generalization of the prime base case."
+    "content": "sign_mulLeft_eq_legendre: converts the field quadratic character of the reduced unit back into the Legendre symbol mod p via the parent's legendreSym_unit_eq, giving the clean statement sign(x ↦ u·x on (ℤ/pⁿ)ˣ) = legendreSym p ((ρ u).val) — the prime-power generalization of the prime base case.",
+    "mathContext": "$\\mathrm{sgn}\\big(x \\mapsto u\\,x \\text{ on } (\\mathbb{Z}/p^n)^{\\times}\\big) = \\left(\\tfrac{(\\rho u)}{p}\\right) = \\mathrm{legendreSym}\\,p\\,(\\rho u)$",
+    "significance": "key",
+    "relatedConcepts": ["Legendre symbol", "quadratic character vs Legendre symbol", "prime-power generalization"],
+    "prerequisites": ["legendreSym = quadraticChar on the field ℤ/p", "the quadratic-character form of the lemma"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -1,14 +1,48 @@
 [
   {
+    "id": "ann-soc-oq0102-def",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 69,
+      "endLine": 84
+    },
+    "type": "definition",
+    "title": "The Same Polynomial, Now Valued in ℝ",
+    "content": "realDiscriminant a b c d is the identical degree-4 polynomial as the sibling's complex generalDiscriminant, but valued in ℝ rather than ℂ. That single change of codomain is the whole point of the entry: over ℂ the discriminant is an algebraic invariant that only reports vanishing (Δ = 0 ⟺ repeated root), whereas over the ordered field ℝ its sign becomes meaningful. realDiscriminant_cast pins down the compatibility — pushing the real value through the ℝ → ℂ embedding recovers generalDiscriminant exactly (push_cast; ring) — so every complex identity proved in the sibling can be reused here by casting. The private helper pow4_pos records a⁴ > 0 for a genuine cubic (a ≠ 0), the positivity fact that every sign theorem below ultimately rests on.",
+    "mathContext": "$\\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2 \\in \\mathbb{R}$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial discriminant", "ordered field", "complexification", "real closed field"],
+    "prerequisites": ["the complex cubic discriminant (sibling OQ-01-OQ-01)", "ℝ → ℂ coercion"]
+  },
+  {
     "id": "ann-soc-oq0102-rootform",
     "proofId": "solution-of-cubic-oq-01-oq-02",
     "range": {
       "startLine": 113,
-      "endLine": 124
+      "endLine": 123
     },
     "type": "insight",
     "title": "Three Distinct Real Roots Force Δ > 0",
-    "body": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters."
+    "content": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters. The Lean proof rewrites by realDiscriminant_eq_root_form and then closes with a single positivity call once the product is shown nonzero.",
+    "mathContext": "$\\Delta = a^4\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^2 > 0$",
+    "significance": "key",
+    "relatedConcepts": ["Vieta's formulas", "discriminant root form", "positivity", "ordered field"],
+    "prerequisites": ["Vieta's formulas", "squares are nonnegative in ℝ"]
+  },
+  {
+    "id": "ann-soc-oq0102-zeroiff",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "The Δ = 0 Boundary: a⁴ ≠ 0 Transfers the Vanishing",
+    "content": "realDiscriminant_eq_zero_iff_repeated_real pins the boundary of the test: among real roots, Δ = 0 ⟺ two of them coincide. Rewriting by the root form and splitting the product a⁴·(bracket)² with mul_eq_zero leaves two disjuncts; pow_ne_zero 4 ha kills the a⁴ = 0 branch (a ≠ 0), so the vanishing lives entirely in the squared root-difference product. Unwinding pow_eq_zero_iff and the nested mul_eq_zero turns bracket = 0 into x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃ via sub_eq_zero. The converse is immediate — substituting any coincidence makes the bracket vanish and ring closes — so this is a genuine biconditional, not just a forward implication.",
+    "mathContext": "$\\Delta = 0 \\iff x_1 = x_2 \\,\\lor\\, x_1 = x_3 \\,\\lor\\, x_2 = x_3 \\quad (a \\neq 0)$",
+    "significance": "supporting",
+    "relatedConcepts": ["repeated roots", "mul_eq_zero", "pow_eq_zero_iff", "sub_eq_zero"],
+    "prerequisites": ["integral domains have no zero divisors", "the real root form"]
   },
   {
     "id": "ann-soc-oq0102-conjpair",
@@ -19,7 +53,11 @@
     },
     "type": "insight",
     "title": "The Conjugate-Pair Case is a Real Ring Identity",
-    "body": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity reads off Δ < 0 — the second leg of the discriminant test."
+    "content": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity/nlinarith reads off Δ < 0 — the second leg of the discriminant test. Avoiding complex numbers in the algebraic core is what keeps the proof to a single ring identity in a, r, m, n.",
+    "mathContext": "$\\Delta = -4a^4 n^2\\big((r-m)^2 + n^2\\big)^2 < 0 \\quad (n \\neq 0)$",
+    "significance": "key",
+    "relatedConcepts": ["complex conjugate roots", "Vieta's formulas", "ring identity", "casus irreducibilis"],
+    "prerequisites": ["conjugate-root theorem for real polynomials", "ring normalization"]
   },
   {
     "id": "ann-soc-oq0102-bridge",
@@ -30,7 +68,11 @@
     },
     "type": "technique",
     "title": "Casting Back to Certify the Conjugate Pair",
-    "body": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization."
+    "content": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization.",
+    "mathContext": "$w = m + n\\,i,\\qquad (w - \\bar w)^2 = (2n\\,i)^2 = -4n^2$",
+    "significance": "supporting",
+    "relatedConcepts": ["complex conjugation", "Complex.ext", "real-to-complex cast", "conjugate-root theorem"],
+    "prerequisites": ["complex re/im arithmetic", "the sibling's complex root form"]
   },
   {
     "id": "ann-soc-oq0102-trichotomy",
@@ -41,6 +83,10 @@
     },
     "type": "insight",
     "title": "One Cubic in Each Regime",
-    "body": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0."
+    "content": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0, each verified by norm_num after unfolding the definition.",
+    "mathContext": "$x^3-x:\\ \\Delta=4>0;\\quad x^3+x:\\ \\Delta=-4<0;\\quad x^3-3x+2:\\ \\Delta=0$",
+    "significance": "context",
+    "relatedConcepts": ["discriminant test", "worked examples", "root structure"],
+    "prerequisites": ["evaluating the discriminant on concrete coefficients"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -11,8 +11,16 @@
     "content": "realDiscriminant a b c d is the identical degree-4 polynomial as the sibling's complex generalDiscriminant, but valued in ℝ rather than ℂ. That single change of codomain is the whole point of the entry: over ℂ the discriminant is an algebraic invariant that only reports vanishing (Δ = 0 ⟺ repeated root), whereas over the ordered field ℝ its sign becomes meaningful. realDiscriminant_cast pins down the compatibility — pushing the real value through the ℝ → ℂ embedding recovers generalDiscriminant exactly (push_cast; ring) — so every complex identity proved in the sibling can be reused here by casting. The private helper pow4_pos records a⁴ > 0 for a genuine cubic (a ≠ 0), the positivity fact that every sign theorem below ultimately rests on.",
     "mathContext": "$\\Delta(a,b,c,d) = 18abcd - 4b^3d + b^2c^2 - 4ac^3 - 27a^2d^2 \\in \\mathbb{R}$",
     "significance": "key",
-    "relatedConcepts": ["polynomial discriminant", "ordered field", "complexification", "real closed field"],
-    "prerequisites": ["the complex cubic discriminant (sibling OQ-01-OQ-01)", "ℝ → ℂ coercion"]
+    "relatedConcepts": [
+      "polynomial discriminant",
+      "ordered field",
+      "complexification",
+      "real closed field"
+    ],
+    "prerequisites": [
+      "the complex cubic discriminant (sibling OQ-01-OQ-01)",
+      "ℝ → ℂ coercion"
+    ]
   },
   {
     "id": "ann-soc-oq0102-rootform",
@@ -26,8 +34,16 @@
     "content": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters. The Lean proof rewrites by realDiscriminant_eq_root_form and then closes with a single positivity call once the product is shown nonzero.",
     "mathContext": "$\\Delta = a^4\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^2 > 0$",
     "significance": "key",
-    "relatedConcepts": ["Vieta's formulas", "discriminant root form", "positivity", "ordered field"],
-    "prerequisites": ["Vieta's formulas", "squares are nonnegative in ℝ"]
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "discriminant root form",
+      "positivity",
+      "ordered field"
+    ],
+    "prerequisites": [
+      "Vieta's formulas",
+      "squares are nonnegative in ℝ"
+    ]
   },
   {
     "id": "ann-soc-oq0102-zeroiff",
@@ -36,13 +52,21 @@
       "startLine": 124,
       "endLine": 143
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "The Δ = 0 Boundary: a⁴ ≠ 0 Transfers the Vanishing",
     "content": "realDiscriminant_eq_zero_iff_repeated_real pins the boundary of the test: among real roots, Δ = 0 ⟺ two of them coincide. Rewriting by the root form and splitting the product a⁴·(bracket)² with mul_eq_zero leaves two disjuncts; pow_ne_zero 4 ha kills the a⁴ = 0 branch (a ≠ 0), so the vanishing lives entirely in the squared root-difference product. Unwinding pow_eq_zero_iff and the nested mul_eq_zero turns bracket = 0 into x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃ via sub_eq_zero. The converse is immediate — substituting any coincidence makes the bracket vanish and ring closes — so this is a genuine biconditional, not just a forward implication.",
     "mathContext": "$\\Delta = 0 \\iff x_1 = x_2 \\,\\lor\\, x_1 = x_3 \\,\\lor\\, x_2 = x_3 \\quad (a \\neq 0)$",
     "significance": "supporting",
-    "relatedConcepts": ["repeated roots", "mul_eq_zero", "pow_eq_zero_iff", "sub_eq_zero"],
-    "prerequisites": ["integral domains have no zero divisors", "the real root form"]
+    "relatedConcepts": [
+      "repeated roots",
+      "mul_eq_zero",
+      "pow_eq_zero_iff",
+      "sub_eq_zero"
+    ],
+    "prerequisites": [
+      "integral domains have no zero divisors",
+      "the real root form"
+    ]
   },
   {
     "id": "ann-soc-oq0102-conjpair",
@@ -56,8 +80,16 @@
     "content": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity/nlinarith reads off Δ < 0 — the second leg of the discriminant test. Avoiding complex numbers in the algebraic core is what keeps the proof to a single ring identity in a, r, m, n.",
     "mathContext": "$\\Delta = -4a^4 n^2\\big((r-m)^2 + n^2\\big)^2 < 0 \\quad (n \\neq 0)$",
     "significance": "key",
-    "relatedConcepts": ["complex conjugate roots", "Vieta's formulas", "ring identity", "casus irreducibilis"],
-    "prerequisites": ["conjugate-root theorem for real polynomials", "ring normalization"]
+    "relatedConcepts": [
+      "complex conjugate roots",
+      "Vieta's formulas",
+      "ring identity",
+      "casus irreducibilis"
+    ],
+    "prerequisites": [
+      "conjugate-root theorem for real polynomials",
+      "ring normalization"
+    ]
   },
   {
     "id": "ann-soc-oq0102-bridge",
@@ -66,13 +98,21 @@
       "startLine": 186,
       "endLine": 204
     },
-    "type": "technique",
+    "type": "tactic",
     "title": "Casting Back to Certify the Conjugate Pair",
     "content": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization.",
     "mathContext": "$w = m + n\\,i,\\qquad (w - \\bar w)^2 = (2n\\,i)^2 = -4n^2$",
     "significance": "supporting",
-    "relatedConcepts": ["complex conjugation", "Complex.ext", "real-to-complex cast", "conjugate-root theorem"],
-    "prerequisites": ["complex re/im arithmetic", "the sibling's complex root form"]
+    "relatedConcepts": [
+      "complex conjugation",
+      "Complex.ext",
+      "real-to-complex cast",
+      "conjugate-root theorem"
+    ],
+    "prerequisites": [
+      "complex re/im arithmetic",
+      "the sibling's complex root form"
+    ]
   },
   {
     "id": "ann-soc-oq0102-trichotomy",
@@ -85,8 +125,14 @@
     "title": "One Cubic in Each Regime",
     "content": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0, each verified by norm_num after unfolding the definition.",
     "mathContext": "$x^3-x:\\ \\Delta=4>0;\\quad x^3+x:\\ \\Delta=-4<0;\\quad x^3-3x+2:\\ \\Delta=0$",
-    "significance": "context",
-    "relatedConcepts": ["discriminant test", "worked examples", "root structure"],
-    "prerequisites": ["evaluating the discriminant on concrete coefficients"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discriminant test",
+      "worked examples",
+      "root structure"
+    ],
+    "prerequisites": [
+      "evaluating the discriminant on concrete coefficients"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01` (Zolotarev's lemma at prime-power modulus: sign of left-translation on (ℤ/pⁿ)ˣ equals the quadratic character / Legendre symbol).

## Changes (annotations.json)
Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 6 annotations (left regular representation, generator single-cycle, sign computation, even order of the unit group, the main lemma, and the Legendre form). Existing `content` and `type` values were already valid.

meta.json was already comprehensive (~13.2 KB, 5 keyInsights) — left unchanged. JSON validated by the gallery data-generation step of `pnpm build`.