### PR TITLE
Enrich combined supplement J(-2|n) (elementary-quadratic-reciprocity ...-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 91, "endLine": 94 },
     "type": "theorem",
     "title": "The combined supplement in power form",
-    "content": "jacobiSym_neg_two: J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8) for every odd n > 0. Multiplicativity of the Jacobi symbol in its top argument (jacobiSym.mul_left) splits -2 = (-1)·2 into J(-1 | n)·J(2 | n); the two factors are rewritten by the sibling supplements jacobiSym_neg_one ((-1)^((n-1)/2)) and jacobiSym_two ((-1)^((n²-1)/8)), and pow_add (reversed) fuses the exponents into the single sum (n-1)/2 + (n²-1)/8."
+    "content": "jacobiSym_neg_two: J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8) for every odd n > 0. Multiplicativity of the Jacobi symbol in its top argument (jacobiSym.mul_left) splits -2 = (-1)·2 into J(-1 | n)·J(2 | n); the two factors are rewritten by the sibling supplements jacobiSym_neg_one ((-1)^((n-1)/2)) and jacobiSym_two ((-1)^((n²-1)/8)), and pow_add (reversed) fuses the exponents into the single sum (n-1)/2 + (n²-1)/8.",
+    "mathContext": "$J(-2 \\mid n) = (-1)^{\\frac{n-1}{2} + \\frac{n^2-1}{8}}$",
+    "significance": "key",
+    "relatedConcepts": ["Jacobi symbol", "first supplement (−1)", "second supplement (2)", "multiplicativity"],
+    "prerequisites": ["the supplements J(−1|n) and J(2|n)", "multiplicativity of the Jacobi symbol"]
   },
   {
     "id": "ann-eqr-oq0103010101010102oq02-eq",
@@ -13,7 +17,11 @@
     "range": { "startLine": 102, "endLine": 105 },
     "type": "theorem",
     "title": "Mod-8 indicator for the combined supplement",
-    "content": "jacobiSym_neg_two_eq: J(-2 | n) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1) for odd n — i.e. -2 is a quadratic residue exactly for n ≡ 1, 3 (mod 8). The value form, read off Mathlib's -2 character via jacobiSym.at_neg_two (J(-2|n) = χ₈' n) and ZMod.χ₈'_nat_eq_if_mod_eight, with the n-even branch discarded since n is odd."
+    "content": "jacobiSym_neg_two_eq: J(-2 | n) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1) for odd n — i.e. -2 is a quadratic residue exactly for n ≡ 1, 3 (mod 8). The value form, read off Mathlib's -2 character via jacobiSym.at_neg_two (J(-2|n) = χ₈' n) and ZMod.χ₈'_nat_eq_if_mod_eight, with the n-even branch discarded since n is odd.",
+    "mathContext": "$J(-2 \\mid n) = 1 \\iff n \\equiv 1,\\,3 \\pmod 8$",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residue", "mod-8 residue classes", "χ₈' character", "Jacobi symbol"],
+    "prerequisites": ["the −2 Dirichlet character χ₈'", "case split on n mod 8"]
   },
   {
     "id": "ann-eqr-oq0103010101010102oq02-chi8prime",
@@ -21,7 +29,11 @@
     "range": { "startLine": 114, "endLine": 118 },
     "type": "theorem",
     "title": "Closed-form power formula for χ₈'",
-    "content": "chi8'_eq_neg_one_pow: χ₈' n = (-1)^((n-1)/2 + (n²-1)/8) for odd n. Mathlib carries the -2 character only as a mod-8 case split (ZMod.χ₈'_nat_eq_if_mod_eight); this is the explicit power form, the -2 analogue of the second supplement's chi8_eq_neg_one_pow and the genuinely new reusable content of the entry. Proved by chaining jacobiSym_neg_two_eq and jacobiSym_neg_two so the χ₈' case split is matched to the fused power."
+    "content": "chi8'_eq_neg_one_pow: χ₈' n = (-1)^((n-1)/2 + (n²-1)/8) for odd n. Mathlib carries the -2 character only as a mod-8 case split (ZMod.χ₈'_nat_eq_if_mod_eight); this is the explicit power form, the -2 analogue of the second supplement's chi8_eq_neg_one_pow and the genuinely new reusable content of the entry. Proved by chaining jacobiSym_neg_two_eq and jacobiSym_neg_two so the χ₈' case split is matched to the fused power.",
+    "mathContext": "$\\chi_8'(n) = (-1)^{\\frac{n-1}{2} + \\frac{n^2-1}{8}}$",
+    "significance": "critical",
+    "relatedConcepts": ["χ₈' Dirichlet character", "closed-form power formula", "second supplement analogue", "reusable lemma"],
+    "prerequisites": ["Mathlib's mod-8 form of χ₈'", "the fused-power supplement"]
   },
   {
     "id": "ann-eqr-oq0103010101010102oq02-negonepow",
@@ -29,7 +41,11 @@
     "range": { "startLine": 122, "endLine": 125 },
     "type": "theorem",
     "title": "The fused exponent as a signed power",
-    "content": "neg_one_pow_neg_two: (-1)^((n-1)/2 + (n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1), the dual reading of jacobiSym_neg_two_eq — +1 at n ≡ 1, 3 (mod 8) and -1 at n ≡ 5, 7 (mod 8). The exponent is even iff exactly an even number of the two summands (n-1)/2 and (n²-1)/8 are odd, which holds precisely on the residues 1, 3."
+    "content": "neg_one_pow_neg_two: (-1)^((n-1)/2 + (n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 3 then 1 else -1), the dual reading of jacobiSym_neg_two_eq — +1 at n ≡ 1, 3 (mod 8) and -1 at n ≡ 5, 7 (mod 8). The exponent is even iff exactly an even number of the two summands (n-1)/2 and (n²-1)/8 are odd, which holds precisely on the residues 1, 3.",
+    "mathContext": "$(-1)^{\\frac{n-1}{2} + \\frac{n^2-1}{8}} = \\begin{cases}+1 & n \\equiv 1,3\\\\ -1 & n \\equiv 5,7\\end{cases} \\!\\!\\pmod 8$",
+    "significance": "supporting",
+    "relatedConcepts": ["parity of an exponent", "mod-8 residues", "value vs power form"],
+    "prerequisites": ["parity of (n-1)/2 and (n²-1)/8 by residue class"]
   },
   {
     "id": "ann-eqr-oq0103010101010102oq02-sign",
@@ -37,7 +53,11 @@
     "range": { "startLine": 140, "endLine": 154 },
     "type": "theorem",
     "title": "The x ↦ -2·x permutation sign",
-    "content": "sign_ringMulPerm_neg_two and sign_neg_two: the grandparent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit u of residue -2 and integer representative -2) gives sign(x ↦ -2·x on ℤ/n) = J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8). The canonical hypothesis-free form sign_neg_two builds the unit as -(ZMod.unitOfCoprime 2 _), using Nat.Coprime 2 n from oddness and Units.val_neg. This reads the combined supplement off the composition of Zolotarev's negation and doubling permutations."
+    "content": "sign_ringMulPerm_neg_two and sign_neg_two: the grandparent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit u of residue -2 and integer representative -2) gives sign(x ↦ -2·x on ℤ/n) = J(-2 | n) = (-1)^((n-1)/2 + (n²-1)/8). The canonical hypothesis-free form sign_neg_two builds the unit as -(ZMod.unitOfCoprime 2 _), using Nat.Coprime 2 n from oddness and Units.val_neg. This reads the combined supplement off the composition of Zolotarev's negation and doubling permutations.",
+    "mathContext": "$\\mathrm{sgn}\\big(x \\mapsto -2x \\text{ on } \\mathbb{Z}/n\\big) = J(-2 \\mid n)$",
+    "significance": "key",
+    "relatedConcepts": ["Zolotarev's lemma", "permutation sign", "composition of permutations", "Jacobi symbol"],
+    "prerequisites": ["the grandparent's odd-modulus Zolotarev identity", "−2 coprime to odd n"]
   },
   {
     "id": "ann-eqr-oq0103010101010102oq02-legendre",
@@ -45,6 +65,10 @@
     "range": { "startLine": 167, "endLine": 191 },
     "type": "theorem",
     "title": "Legendre special case and the QR characterization",
-    "content": "legendreSym_neg_two: for an odd prime p, (-2 / p) = (-1)^((p-1)/2 + (p²-1)/8), via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two. legendreSym_neg_two_eq gives the prime mod-8 indicator, and neg_two_qr_iff packages the classical statement legendreSym p (-2) = 1 ↔ p ≡ 1 or 3 (mod 8): -2 is a quadratic residue mod p exactly for those residues."
+    "content": "legendreSym_neg_two: for an odd prime p, (-2 / p) = (-1)^((p-1)/2 + (p²-1)/8), via jacobiSym.legendreSym.to_jacobiSym and Nat.Prime.odd_of_ne_two. legendreSym_neg_two_eq gives the prime mod-8 indicator, and neg_two_qr_iff packages the classical statement legendreSym p (-2) = 1 ↔ p ≡ 1 or 3 (mod 8): -2 is a quadratic residue mod p exactly for those residues.",
+    "mathContext": "$\\left(\\tfrac{-2}{p}\\right) = (-1)^{\\frac{p-1}{2} + \\frac{p^2-1}{8}},\\qquad = 1 \\iff p \\equiv 1,\\,3 \\pmod 8$",
+    "significance": "key",
+    "relatedConcepts": ["Legendre symbol", "quadratic residue criterion", "supplements to quadratic reciprocity", "odd primes"],
+    "prerequisites": ["Legendre = Jacobi at a prime", "the mod-8 indicator form"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for the −2 combined supplement entry (J(-2|n) = (-1)^((n-1)/2 + (n²-1)/8); −2 is a QR iff n ≡ 1,3 mod 8; the χ₈' closed power form; and the Zolotarev permutation-sign reading).

## Changes (annotations.json)
Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 6 annotations. Existing `content` and `type` values were already valid.

meta.json was already comprehensive (~15.5 KB) — left unchanged. JSON validated by the gallery data-generation step of `pnpm build`.