### PR TITLE
Enrich Cauchy density normalization (erdos-1002-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/erdos-1002-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 55, "endLine": 61 },
     "type": "definition",
     "title": "Cauchy CDF and Density",
-    "content": "cauchyDistribution ρ c = (1/π)·arctan(ρc) + 1/2 is the Cauchy cumulative distribution function at scale ρ (mirroring the sibling Erdos1002OQ01). cauchyDensity ρ x = ρ/(π(1+(ρx)²)) is the corresponding Cauchy probability density. For ρ = 1 these specialise to the classical F(x) = 1/2 + arctan(x)/π and f(x) = 1/(π(1+x²)). The whole file establishes the analytic relationship between these two objects."
+    "content": "cauchyDistribution ρ c = (1/π)·arctan(ρc) + 1/2 is the Cauchy cumulative distribution function at scale ρ (mirroring the sibling Erdos1002OQ01). cauchyDensity ρ x = ρ/(π(1+(ρx)²)) is the corresponding Cauchy probability density. For ρ = 1 these specialise to the classical F(x) = 1/2 + arctan(x)/π and f(x) = 1/(π(1+x²)). The whole file establishes the analytic relationship between these two objects.",
+    "mathContext": "$F_\\rho(c) = \\tfrac{1}{\\pi}\\arctan(\\rho c) + \\tfrac{1}{2},\\qquad f_\\rho(x) = \\frac{\\rho}{\\pi(1+(\\rho x)^2)}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy distribution", "cumulative distribution function", "probability density", "arctangent"],
+    "prerequisites": ["the arctangent function", "scale parameter of a distribution"]
   },
   {
     "id": "ann-density-pos",
@@ -13,7 +17,11 @@
     "range": { "startLine": 66, "endLine": 68 },
     "type": "theorem",
     "title": "Strict Positivity",
-    "content": "cauchyDensity_pos: for ρ > 0 the density is strictly positive everywhere. The numerator ρ is positive and the denominator π(1+(ρx)²) is a product of positives (pi_pos and a sum-of-squares handled by positivity), so div_pos concludes. Positivity is one of the defining features of a probability density supported on all of ℝ."
+    "content": "cauchyDensity_pos: for ρ > 0 the density is strictly positive everywhere. The numerator ρ is positive and the denominator π(1+(ρx)²) is a product of positives (pi_pos and a sum-of-squares handled by positivity), so div_pos concludes. Positivity is one of the defining features of a probability density supported on all of ℝ.",
+    "mathContext": "$f_\\rho(x) > 0 \\quad \\forall x \\in \\mathbb{R} \\ (\\rho > 0)$",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "probability density", "full support", "div_pos"],
+    "prerequisites": ["π > 0", "sum of squares is positive"]
   },
   {
     "id": "ann-density-even",
@@ -21,7 +29,11 @@
     "range": { "startLine": 71, "endLine": 73 },
     "type": "theorem",
     "title": "Symmetry About the Median",
-    "content": "cauchyDensity_even: f_ρ(−x) = f_ρ(x). The Cauchy law is symmetric about its median 0; the proof is immediate from (ρ·(−x))² = (ρx)² (simp with mul_neg and neg_sq). This symmetry is why the median is 0 even though the Cauchy distribution has no mean."
+    "content": "cauchyDensity_even: f_ρ(−x) = f_ρ(x). The Cauchy law is symmetric about its median 0; the proof is immediate from (ρ·(−x))² = (ρx)² (simp with mul_neg and neg_sq). This symmetry is why the median is 0 even though the Cauchy distribution has no mean.",
+    "mathContext": "$f_\\rho(-x) = f_\\rho(x)$",
+    "significance": "supporting",
+    "relatedConcepts": ["even function", "symmetric distribution", "median", "undefined mean"],
+    "prerequisites": ["evenness of squaring", "median vs mean"]
   },
   {
     "id": "ann-continuity",
@@ -29,7 +41,11 @@
     "range": { "startLine": 75, "endLine": 77 },
     "type": "theorem",
     "title": "Continuity",
-    "content": "cauchyDensity_continuous: f_ρ is continuous. Written as a constant divided by x ↦ π(1+(ρx)²), continuity follows from continuous_const.div once the denominator is shown never to vanish (it is a product of the positive constant π and the positive 1+(ρx)²). Continuity is the hypothesis that unlocks the Fundamental Theorem of Calculus in the next part."
+    "content": "cauchyDensity_continuous: f_ρ is continuous. Written as a constant divided by x ↦ π(1+(ρx)²), continuity follows from continuous_const.div once the denominator is shown never to vanish (it is a product of the positive constant π and the positive 1+(ρx)²). Continuity is the hypothesis that unlocks the Fundamental Theorem of Calculus in the next part.",
+    "mathContext": "$f_\\rho \\in C(\\mathbb{R}),\\qquad \\pi(1+(\\rho x)^2) \\neq 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["continuity", "nonvanishing denominator", "interval integrability"],
+    "prerequisites": ["continuity of quotients with nonzero denominator"]
   },
   {
     "id": "ann-hasDerivAt",
@@ -37,7 +53,11 @@
     "range": { "startLine": 84, "endLine": 101 },
     "type": "theorem",
     "title": "The CDF Differentiates to the Density",
-    "content": "cauchyDistribution_hasDerivAt: d/dc [g_ρ(c)] = f_ρ(c). This is the central bridge making f_ρ literally the density of g_ρ. By the chain rule, the inner map c ↦ ρc has derivative ρ and Mathlib's hasDerivAt_arctan' gives d/du arctan(u) = (1+u²)⁻¹, so d/dc arctan(ρc) = (1+(ρc)²)⁻¹·ρ. Scaling by 1/π (HasDerivAt.const_mul) and shifting by 1/2 (HasDerivAt.add_const) gives derivative (1/π)·(1+(ρc)²)⁻¹·ρ, which field_simp identifies with ρ/(π(1+(ρc)²)) = f_ρ(c)."
+    "content": "cauchyDistribution_hasDerivAt: d/dc [g_ρ(c)] = f_ρ(c). This is the central bridge making f_ρ literally the density of g_ρ. By the chain rule, the inner map c ↦ ρc has derivative ρ and Mathlib's hasDerivAt_arctan' gives d/du arctan(u) = (1+u²)⁻¹, so d/dc arctan(ρc) = (1+(ρc)²)⁻¹·ρ. Scaling by 1/π (HasDerivAt.const_mul) and shifting by 1/2 (HasDerivAt.add_const) gives derivative (1/π)·(1+(ρc)²)⁻¹·ρ, which field_simp identifies with ρ/(π(1+(ρc)²)) = f_ρ(c).",
+    "mathContext": "$\\frac{d}{dc}\\,F_\\rho(c) = \\frac{\\rho}{\\pi(1+(\\rho c)^2)} = f_\\rho(c)$",
+    "significance": "key",
+    "relatedConcepts": ["chain rule", "derivative of arctangent", "CDF–density relationship", "HasDerivAt"],
+    "prerequisites": ["d/du arctan(u) = 1/(1+u²)", "the chain rule"]
   },
   {
     "id": "ann-ftc",
@@ -45,7 +65,11 @@
     "range": { "startLine": 103, "endLine": 112 },
     "type": "theorem",
     "title": "Fundamental Theorem of Calculus Form",
-    "content": "integral_cauchyDensity: ∫_a^b f_ρ = g_ρ(b) − g_ρ(a). Since g_ρ has derivative f_ρ at every point (previous theorem) and f_ρ is continuous (hence interval-integrable), intervalIntegral.integral_eq_sub_of_hasDerivAt applies directly. This recovers the CDF as the running integral (antiderivative) of the density."
+    "content": "integral_cauchyDensity: ∫_a^b f_ρ = g_ρ(b) − g_ρ(a). Since g_ρ has derivative f_ρ at every point (previous theorem) and f_ρ is continuous (hence interval-integrable), intervalIntegral.integral_eq_sub_of_hasDerivAt applies directly. This recovers the CDF as the running integral (antiderivative) of the density.",
+    "mathContext": "$\\int_a^b f_\\rho = F_\\rho(b) - F_\\rho(a)$",
+    "significance": "key",
+    "relatedConcepts": ["fundamental theorem of calculus", "antiderivative", "CDF as running integral"],
+    "prerequisites": ["the CDF differentiates to the density", "continuity ⟹ interval-integrable"]
   },
   {
     "id": "ann-normalization",
@@ -53,6 +77,10 @@
     "range": { "startLine": 114, "endLine": 131 },
     "type": "theorem",
     "title": "Normalization: Total Mass One",
-    "content": "integral_cauchyDensity_univ: ∫_ℝ f_ρ = 1 for ρ > 0, the property that promotes f_ρ to a genuine probability density. Writing f_ρ(x) = (ρ/π)·(1+(ρx)²)⁻¹, the constant is pulled out with integral_const_mul. The change of variables x ↦ ρx via Measure.integral_comp_mul_left (∫ g(ρx) = |ρ⁻¹|·∫ g) reduces the inner integral to |ρ⁻¹|·∫_ℝ (1+y²)⁻¹ = ρ⁻¹·π using Mathlib's integral_univ_inv_one_add_sq (∫_ℝ (1+y²)⁻¹ = π) and ρ > 0. Finally (ρ/π)·(ρ⁻¹·π) = 1."
+    "content": "integral_cauchyDensity_univ: ∫_ℝ f_ρ = 1 for ρ > 0, the property that promotes f_ρ to a genuine probability density. Writing f_ρ(x) = (ρ/π)·(1+(ρx)²)⁻¹, the constant is pulled out with integral_const_mul. The change of variables x ↦ ρx via Measure.integral_comp_mul_left (∫ g(ρx) = |ρ⁻¹|·∫ g) reduces the inner integral to |ρ⁻¹|·∫_ℝ (1+y²)⁻¹ = ρ⁻¹·π using Mathlib's integral_univ_inv_one_add_sq (∫_ℝ (1+y²)⁻¹ = π) and ρ > 0. Finally (ρ/π)·(ρ⁻¹·π) = 1.",
+    "mathContext": "$\\int_{\\mathbb{R}} f_\\rho\\,dx = 1,\\qquad \\int_{\\mathbb{R}} \\frac{dy}{1+y^2} = \\pi$",
+    "significance": "critical",
+    "relatedConcepts": ["normalization", "probability density", "change of variables", "∫1/(1+y²) = π"],
+    "prerequisites": ["change of variables in an integral", "the standard integral of 1/(1+y²)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1002-oq-02` (the Cauchy density f_ρ as the derivative of its CDF, FTC form, and total-mass-one normalization).

## Changes (annotations.json)
Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 7 annotations (definitions, positivity, evenness, continuity, CDF→density derivative, FTC form, and ∫_ℝ f_ρ = 1). Existing `content` and `type` values were already valid.

meta.json was already comprehensive (~14.1 KB, 5 keyInsights) — left unchanged. JSON validated by the gallery data-generation step of `pnpm build`.