### PR TITLE
Enrich Ramsey-avoidance monotonicity (erdos-129-wip-01): annotation depth

### DIFF
--- a/src/data/proofs/erdos-129-wip-01/annotations.json
+++ b/src/data/proofs/erdos-129-wip-01/annotations.json
@@ -2,67 +2,73 @@
   {
     "id": "ann-overview",
     "proofId": "erdos-129-wip-01",
-    "range": {
-      "startLine": 1,
-      "endLine": 44
-    },
+    "range": { "startLine": 1, "endLine": 44 },
     "type": "concept",
     "title": "The monotonicity laws Erdős Problem 129 deferred",
-    "content": "R(n;k,r) is the least N such that every r-coloring of K_N has an n-vertex set with no monochromatic K_k. The parent entry Erdos129Problem formalizes the predicate HasRamseyAvoid N n k r ('N ≥ R(n;k,r)') and the Erdős-Gyárfás exponential conjecture, but records the monotonicity properties only informally — their proofs, it notes, 'require embedding arguments not yet in Mathlib'. This file supplies them: HasRamseyAvoid is monotone in the host-graph size N and antitone in the number of required clique-free vertices n. Both are elementary structural facts, independent of the open asymptotics, yet they are exactly what makes R(n;k,r) a well-behaved threshold."
+    "content": "R(n;k,r) is the least N such that every r-coloring of K_N has an n-vertex set with no monochromatic K_k. The parent entry Erdos129Problem formalizes the predicate HasRamseyAvoid N n k r ('N ≥ R(n;k,r)') and the Erdős-Gyárfás exponential conjecture, but records the monotonicity properties only informally — their proofs, it notes, 'require embedding arguments not yet in Mathlib'. This file supplies them: HasRamseyAvoid is monotone in the host-graph size N and antitone in the number of required clique-free vertices n. Both are elementary structural facts, independent of the open asymptotics, yet they are exactly what makes R(n;k,r) a well-behaved threshold.",
+    "mathContext": "$R(n;k,r) = \\min\\{N : \\text{every } r\\text{-coloring of } K_N \\text{ has a mono-}K_k\\text{-free } n\\text{-set}\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Ramsey theory", "Erdős Problem 129", "Erdős–Gyárfás conjecture", "monochromatic clique"],
+    "prerequisites": ["the parent's HasRamseyAvoid predicate", "edge colorings of complete graphs"]
   },
   {
     "id": "ann-setup",
     "proofId": "erdos-129-wip-01",
-    "range": {
-      "startLine": 42,
-      "endLine": 66
-    },
+    "range": { "startLine": 42, "endLine": 66 },
     "type": "definition",
     "title": "Edge colorings and clique avoidance",
-    "content": "The definitions mirror the parent entry so the file is self-contained. An EdgeColoring N r colors ordered edges {(i,j) // i < j} of K_N with Fin r colors. A vertex set S AvoidsMono in color c if every k-subset T ⊆ S has some edge not colored c (so T is not a monochromatic K_k in color c); NoMonoClique demands this for all colors. HasRamseyAvoid N n k r holds when every coloring admits an n-vertex set S with NoMonoClique — the avoidance threshold being R(n;k,r)."
+    "content": "The definitions mirror the parent entry so the file is self-contained. An EdgeColoring N r colors ordered edges {(i,j) // i < j} of K_N with Fin r colors. A vertex set S AvoidsMono in color c if every k-subset T ⊆ S has some edge not colored c (so T is not a monochromatic K_k in color c); NoMonoClique demands this for all colors. HasRamseyAvoid N n k r holds when every coloring admits an n-vertex set S with NoMonoClique — the avoidance threshold being R(n;k,r).",
+    "mathContext": "$\\mathrm{HasRamseyAvoid}\\,N\\,n\\,k\\,r :\\Leftrightarrow \\forall \\chi\\ \\exists S,\\ |S| = n \\,\\land\\, \\mathrm{NoMonoClique}(S)$",
+    "significance": "supporting",
+    "relatedConcepts": ["edge coloring", "monochromatic K_k", "clique avoidance", "complete graph K_N"],
+    "prerequisites": ["finite graphs and cliques", "colorings with Fin r colors"]
   },
   {
     "id": "ann-noMonoClique-subset",
     "proofId": "erdos-129-wip-01",
-    "range": {
-      "startLine": 70,
-      "endLine": 79
-    },
+    "range": { "startLine": 70, "endLine": 79 },
     "type": "lemma",
     "title": "NoMonoClique is downward closed",
-    "content": "noMonoClique_subset: if S' ⊆ S and S has no monochromatic K_k, then neither does S'. The proof is one line — a k-subset T ⊆ S' is also a k-subset of S (hT.trans hsub), so the avoidance witness for S applies verbatim. Shrinking the vertex set only removes the k-subsets that must be checked, never adds any. This downward closure is the engine of antitonicity in n."
+    "content": "noMonoClique_subset: if S' ⊆ S and S has no monochromatic K_k, then neither does S'. The proof is one line — a k-subset T ⊆ S' is also a k-subset of S (hT.trans hsub), so the avoidance witness for S applies verbatim. Shrinking the vertex set only removes the k-subsets that must be checked, never adds any. This downward closure is the engine of antitonicity in n.",
+    "mathContext": "$S' \\subseteq S \\,\\land\\, \\mathrm{NoMonoClique}(S) \\;\\Rightarrow\\; \\mathrm{NoMonoClique}(S')$",
+    "significance": "key",
+    "relatedConcepts": ["downward closure", "monotone predicate", "subset transitivity"],
+    "prerequisites": ["transitivity of ⊆", "the NoMonoClique predicate"]
   },
   {
     "id": "ann-antitone-n",
     "proofId": "erdos-129-wip-01",
-    "range": {
-      "startLine": 81,
-      "endLine": 89
-    },
+    "range": { "startLine": 81, "endLine": 89 },
     "type": "theorem",
     "title": "Antitonicity in n: fewer vertices is easier",
-    "content": "hasRamseyAvoid_antitone_n: HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r. Given a coloring, the hypothesis yields an avoiding set S with |S| ≥ n ≥ m; Finset.exists_subset_card_eq cuts out an exactly-m-vertex subset S' ⊆ S, still avoiding by noMonoClique_subset. In terms of the threshold this says R(n;k,r) is non-decreasing in n: needing fewer monochromatic-clique-free vertices cannot require a larger graph."
+    "content": "hasRamseyAvoid_antitone_n: HasRamseyAvoid N n k r → m ≤ n → HasRamseyAvoid N m k r. Given a coloring, the hypothesis yields an avoiding set S with |S| ≥ n ≥ m; Finset.exists_subset_card_eq cuts out an exactly-m-vertex subset S' ⊆ S, still avoiding by noMonoClique_subset. In terms of the threshold this says R(n;k,r) is non-decreasing in n: needing fewer monochromatic-clique-free vertices cannot require a larger graph.",
+    "mathContext": "$\\mathrm{HasRamseyAvoid}\\,N\\,n\\,k\\,r \\,\\land\\, m \\le n \\;\\Rightarrow\\; \\mathrm{HasRamseyAvoid}\\,N\\,m\\,k\\,r$",
+    "significance": "key",
+    "relatedConcepts": ["antitone monotonicity", "subset of prescribed cardinality", "Ramsey threshold"],
+    "prerequisites": ["downward closure of NoMonoClique", "Finset.exists_subset_card_eq"]
   },
   {
     "id": "ann-mono-N",
     "proofId": "erdos-129-wip-01",
-    "range": {
-      "startLine": 91,
-      "endLine": 131
-    },
+    "range": { "startLine": 91, "endLine": 131 },
     "type": "theorem",
     "title": "Monotonicity in N: the embedding argument",
-    "content": "hasRamseyAvoid_mono_N: HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r — the substantive direction. Given a coloring χ' of K_{N'}, pull it back to χ on K_N by sending an edge (i,j), i < j, to χ' of (castLE i, castLE j); this is again an edge because Fin.castLE is strictly monotone (castLE_lt_castLE_iff). The hypothesis hands back an avoiding set S ⊆ Fin N, which is pushed forward to S.map (Fin.castLEEmb _) ⊆ Fin N' with the same cardinality. Any k-subset T' upstairs reflects, via Finset.subset_map_iff, to T = its preimage downstairs; the avoidance witness edge of T lifts to a witness edge of T', and because χ was defined as the pull-back the lifted edge has color χ e ≠ c by rfl. No probabilistic input is needed — just restriction and embedding."
+    "content": "hasRamseyAvoid_mono_N: HasRamseyAvoid N n k r → N ≤ N' → HasRamseyAvoid N' n k r — the substantive direction. Given a coloring χ' of K_{N'}, pull it back to χ on K_N by sending an edge (i,j), i < j, to χ' of (castLE i, castLE j); this is again an edge because Fin.castLE is strictly monotone (castLE_lt_castLE_iff). The hypothesis hands back an avoiding set S ⊆ Fin N, which is pushed forward to S.map (Fin.castLEEmb _) ⊆ Fin N' with the same cardinality. Any k-subset T' upstairs reflects, via Finset.subset_map_iff, to T = its preimage downstairs; the avoidance witness edge of T lifts to a witness edge of T', and because χ was defined as the pull-back the lifted edge has color χ e ≠ c by rfl. No probabilistic input is needed — just restriction and embedding.",
+    "mathContext": "$\\mathrm{HasRamseyAvoid}\\,N\\,n\\,k\\,r \\,\\land\\, N \\le N' \\;\\Rightarrow\\; \\mathrm{HasRamseyAvoid}\\,N'\\,n\\,k\\,r$",
+    "significance": "critical",
+    "relatedConcepts": ["graph embedding", "pullback of a coloring", "Fin.castLE monotonicity", "induced subgraph"],
+    "prerequisites": ["strict monotonicity of Fin.castLE", "pushforward/pullback along an order embedding"]
   },
   {
     "id": "ann-mono-combined",
     "proofId": "erdos-129-wip-01",
-    "range": {
-      "startLine": 133,
-      "endLine": 137
-    },
+    "range": { "startLine": 133, "endLine": 137 },
     "type": "theorem",
     "title": "The combined monotonicity law",
-    "content": "hasRamseyAvoid_mono: composing the two laws, avoidance is preserved when the host graph grows (N ≤ N') and the required clique-free set shrinks (n' ≤ n). This is the form most useful downstream: it lets one transport a known avoidance instance to any at-least-as-favorable pair (N', n'), the basic move in inductive comparisons of Ramsey values."
+    "content": "hasRamseyAvoid_mono: composing the two laws, avoidance is preserved when the host graph grows (N ≤ N') and the required clique-free set shrinks (n' ≤ n). This is the form most useful downstream: it lets one transport a known avoidance instance to any at-least-as-favorable pair (N', n'), the basic move in inductive comparisons of Ramsey values.",
+    "mathContext": "$N \\le N' \\,\\land\\, n' \\le n \\,\\land\\, \\mathrm{HasRamseyAvoid}\\,N\\,n\\,k\\,r \\;\\Rightarrow\\; \\mathrm{HasRamseyAvoid}\\,N'\\,n'\\,k\\,r$",
+    "significance": "supporting",
+    "relatedConcepts": ["composition of monotonicity laws", "Ramsey value comparison", "inductive transport"],
+    "prerequisites": ["monotonicity in N", "antitonicity in n"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-129-wip-01` (the monotonicity-in-N / antitonicity-in-n laws for the Erdős Problem 129 avoidance threshold that the parent deferred as 'embedding arguments not yet in Mathlib').

## Changes (annotations.json)
Add `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites` to all 6 annotations. Existing `content` and `type` values were already valid.

Verified the Lean file is genuinely 0-sorry / 0-axiom despite the 'wip' slug, so `status: verified` is accurate. meta.json was already comprehensive (~14.0 KB, 5 keyInsights) — left unchanged. JSON validated by the gallery data-generation step of `pnpm build`.