### PR TITLE
audit: cassini-identity-oq-01-oq-01 + picks-theorem-oq-03-ext-oq-02 clean (queue drained 4014/4014)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24901,6 +24901,18 @@
       "lastAudited": "2026-06-27T04:30:45Z",
       "result": "clean",
       "issues": []
+    },
+    "cassini-identity-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T04:40:54Z",
+      "result": "clean",
+      "issues": []
+    },
+    "picks-theorem-oq-03-ext-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T04:41:55Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Two previously-unaudited entries verified **clean**; this drains the audit queue to **4014/4014**.

### cassini-identity-oq-01-oq-01 — Catalan's r-parameter identity
- 3 theorems, 0 definitions, 0 sorries, 0 axioms, 105 lines — matches meta.json exactly.
- Tier A `original` defensible: Catalan's identity is not in Mathlib; the proof is assembled in-file from `Nat.fib_add` (3×) plus the parent's determinant-proved Cassini. All Mathlib deps disclosed. No native_decide, no True stubs.

### picks-theorem-oq-03-ext-oq-02 — Hibi's algebraic criterion
- 7 theorems, 3 definitions, 0 sorries, 0 axioms, 121 lines — matches meta.json exactly.
- Main theorem `reflect_eq_iff_palindromic` (palindromic ⟺ self-reciprocal) fully proven over an arbitrary commutative semiring.
- Geometric bridge `reflexive_hStar_palindromic` takes self-reciprocity as an **explicit theorem hypothesis** (not an axiom/sorry), so `axiomCount: 0` is correct; honestly disclosed in docstring + `assumptions`. Title properly qualified ("Algebraic Criterion").

Only the `audit-tracker.json` is changed (committed via git plumbing — host disk is at 100%, full worktree checkout not possible this iteration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)