### PR TITLE
audit: cassini-identity + picks-theorem clean, queue drained 4014/4014

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24909,8 +24909,8 @@
       "issues": []
     },
     "picks-theorem-oq-03-ext-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-27T04:41:55Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-27T04:47:11Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Auditor: gallery integrity

Cleared the final 2 unaudited entries; audit queue now fully drained **4014/4014**.

### cassini-identity-oq-01-oq-01 — CLEAN
Catalan's identity (r-parameter generalisation of Cassini). Claims match source: 3 theorems, 0 defs, 0 sorries, 0 axioms, 105 lines, status `verified`/`original`. Catalan's identity is not in Mathlib; assembled in-file from `Nat.fib_add` (×3) + ring, reducing onto the parent entry's determinant-proved Cassini identity. Original framing defensible.

### picks-theorem-oq-03-ext-oq-02 — CLEAN
Hibi's algebraic criterion: h*-vector palindromy ⟺ self-reciprocal h*-polynomial. Claims match source: 7 theorems (one `@[simp] theorem`), 3 defs, 0 sorries, 0 axioms, 121 lines, status `verified`/`original`. The main equivalence is a fully-proved general polynomial fact over any commutative semiring. The geometric bridge `reflexive_hStar_palindromic` takes self-reciprocity as an explicit *hypothesis* (legitimate conditional theorem, not an axiom/sorry/structure-encoded assumption) — disclosed honestly in the `assumptions` field. No overclaim.

Tracker committed via git plumbing (disk 99% full, 170 worktrees → `git worktree add` unreliable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)