### PR TITLE
audit: re-confirm amgm-inequality-oq-03-oq-02 clean (stalest re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -169,9 +169,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T04:51:34Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: amgm-inequality-oq-03-oq-02 — *Power Mean Limit: lim_{r→0} M_r = GM*
**Lean file**: `proofs/Proofs/PowerMeanLimitOQ.lean`
**Result**: clean (re-audit of stalest tracker entry, last audited 2026-05-03)

### Verification

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axiom decls, 0 structure-encoded assumptions | ✓ |
| theoremCount | 10 | 10 theorem/lemma decls | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 316 | 316 | ✓ |
| True stubs | — | none | ✓ |
| status / badge | verified / original | — | — |

### Tier classification: A (original) — defensible

The main theorem `tendsto_powerMean_zero` (weighted power mean → geometric mean as r→0) is **not** a Mathlib theorem. It is assembled in-file from Mathlib calculus primitives (`HasDerivAt.sum`, `Real.hasStrictDerivAt_const_rpow`, `hasDerivAt_iff_tendsto_slope`, continuity of `exp`). Mathlib's `Real.geom_mean_le_arith_mean_weighted` is invoked only in the supporting HM ≤ GM ≤ AM corollary, and the `assumptions` field correctly discloses the Mathlib-infrastructure reliance ("Main limit theorem is original; uses Mathlib calculus infrastructure as building blocks"). No overclaiming.

Only change: `audit-tracker.json` entry bumped (auditCount 5→6, lastAudited refreshed).

---
Discovered during gallery integrity audit.