### PR TITLE
Enrich Lucas square-sum (fibonacci-identities-oq-03-oq-02-oq-02): annotation depth fields

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-02-oq-02/annotations.json
@@ -3,9 +3,21 @@
     "id": "ann-fiboq030202-1",
     "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
     "range": { "startLine": 3, "endLine": 31 },
-    "type": "context",
+    "type": "concept",
     "title": "The Lucas Square-Sum and Its −2 Correction",
-    "content": "**Module framing.** The sum of the squares of the first $n$ Lucas numbers is a consecutive Lucas product shifted by a constant, $L_1^2 + L_2^2 + \\cdots + L_n^2 = L_n L_{n+1} - 2$. This is the Lucas analogue of the *exact* Fibonacci square-sum $\\sum F_i^2 = F_n F_{n+1}$ (entry `fibonacci-identities-oq-03-oq-02`). The $-2$ is the fingerprint of the Lucas seed: where Fibonacci has $F_0 = 0$ (a vanishing square), Lucas has $L_0 = 2$, contributing $L_0^2 = 4$, and $4 - 2 = 2$ is exactly the constant the clean $0$-indexed form $\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2 = L_n L_{n+1} + 2$ carries. Mathlib packages neither the Lucas sequence nor either square-sum, so this is a genuine gap."
+    "content": "**Module framing.** The sum of the squares of the first $n$ Lucas numbers is a consecutive Lucas product shifted by a constant, $L_1^2 + L_2^2 + \\cdots + L_n^2 = L_n L_{n+1} - 2$. This is the Lucas analogue of the *exact* Fibonacci square-sum $\\sum F_i^2 = F_n F_{n+1}$ (entry `fibonacci-identities-oq-03-oq-02`). The $-2$ is the fingerprint of the Lucas seed: where Fibonacci has $F_0 = 0$ (a vanishing square), Lucas has $L_0 = 2$, contributing $L_0^2 = 4$, and $4 - 2 = 2$ is exactly the constant the clean $0$-indexed form $\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2 = L_n L_{n+1} + 2$ carries. Mathlib packages neither the Lucas sequence nor either square-sum, so this is a genuine gap.",
+    "mathContext": "$\\sum_{i=1}^{n} L_i^2 = L_n L_{n+1} - 2$, versus the exact Fibonacci form $\\sum_{i=1}^{n} F_i^2 = F_n F_{n+1}$; the offset is $L_0^2 - 2 = 4 - 2 = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Lucas numbers",
+      "Fibonacci square-sum identity",
+      "telescoping sums",
+      "consecutive-product closed forms"
+    ],
+    "prerequisites": [
+      "Fibonacci and Lucas sequences",
+      "finite sums over Finset.range"
+    ]
   },
   {
     "id": "ann-fiboq030202-2",
@@ -13,30 +25,80 @@
     "range": { "startLine": 33, "endLine": 47 },
     "type": "definition",
     "title": "The Lucas Sequence (defined locally)",
-    "content": "**Lucas numbers are not in Mathlib.** The sequence $L_0 = 2$, $L_1 = 1$, $L_{n+2} = L_n + L_{n+1}$ — i.e. $2, 1, 3, 4, 7, 11, 18, \\dots$ — is defined locally, matching the convention used elsewhere in the Fibonacci gallery. The seeds get `@[simp]` lemmas and the recurrence `lucas_add_two` is a definitional `rfl`, supplying everything the induction needs."
+    "content": "**Lucas numbers are not in Mathlib.** The sequence $L_0 = 2$, $L_1 = 1$, $L_{n+2} = L_n + L_{n+1}$ — i.e. $2, 1, 3, 4, 7, 11, 18, \\dots$ — is defined locally, matching the convention used elsewhere in the Fibonacci gallery. The seeds get `@[simp]` lemmas and the recurrence `lucas_add_two` is a definitional `rfl`, supplying everything the induction needs.",
+    "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$ — same recurrence as the Fibonacci numbers, different seeds.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linear recurrence",
+      "initial conditions",
+      "definitional equality (rfl)",
+      "simp normal form"
+    ],
+    "prerequisites": [
+      "recursive function definitions in Lean",
+      "the Fibonacci recurrence"
+    ]
   },
   {
     "id": "ann-fiboq030202-3",
     "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
     "range": { "startLine": 49, "endLine": 64 },
-    "type": "key-step",
+    "type": "insight",
     "title": "One-Line Induction: ∑ Lᵢ² = Lₙ·Lₙ₊₁ + 2",
-    "content": "**Telescoping, with the constant inert.** In the step, `Finset.sum_range_succ` peels the top square off: $\\sum_{i \\in \\mathrm{range}(k+2)} L_i^2 = \\big(\\sum_{i \\in \\mathrm{range}(k+1)} L_i^2\\big) + L_{k+1}^2$. The induction hypothesis rewrites the first summand to $L_k L_{k+1} + 2$, and the recurrence `lucas_add_two` ($L_{k+2} = L_k + L_{k+1}$) plus `ring` close $L_k L_{k+1} + 2 + L_{k+1}^2 = L_{k+1} L_{k+2} + 2$. The telescoping $L_{k+1} L_{k+2} - L_k L_{k+1} = L_{k+1}^2$ is identical to the Fibonacci case; the additive constant simply rides along. The base case $n = 0$ ($L_0^2 = 4 = 2 \\cdot 1 + 2$) is `decide`."
+    "content": "**Telescoping, with the constant inert.** In the step, `Finset.sum_range_succ` peels the top square off: $\\sum_{i \\in \\mathrm{range}(k+2)} L_i^2 = \\big(\\sum_{i \\in \\mathrm{range}(k+1)} L_i^2\\big) + L_{k+1}^2$. The induction hypothesis rewrites the first summand to $L_k L_{k+1} + 2$, and the recurrence `lucas_add_two` ($L_{k+2} = L_k + L_{k+1}$) plus `ring` close $L_k L_{k+1} + 2 + L_{k+1}^2 = L_{k+1} L_{k+2} + 2$. The telescoping $L_{k+1} L_{k+2} - L_k L_{k+1} = L_{k+1}^2$ is identical to the Fibonacci case; the additive constant simply rides along. The base case $n = 0$ ($L_0^2 = 4 = 2 \\cdot 1 + 2$) is `decide`.",
+    "mathContext": "Step identity: $L_k L_{k+1} + 2 + L_{k+1}^2 = L_{k+1} L_{k+2} + 2$, since $L_{k+1}(L_{k+2} - L_k) = L_{k+1}^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "mathematical induction",
+      "Finset.sum_range_succ",
+      "telescoping",
+      "ring normalization"
+    ],
+    "prerequisites": [
+      "induction on natural numbers",
+      "the ring tactic",
+      "the Lucas recurrence"
+    ]
   },
   {
     "id": "ann-fiboq030202-4",
     "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
     "range": { "startLine": 66, "endLine": 96 },
-    "type": "key-step",
+    "type": "insight",
     "title": "Recovering the Classical −2 (ℕ and ℤ forms)",
-    "content": "**The $i = 0$ term is where the $-2$ appears.** To reach the textbook statement over `Icc 1 n`, write `range (n+1) = insert 0 (Icc 1 n)` (an `ext`/`omega` set identity) and split off the head with `Finset.sum_insert`. The discarded term is now $L_0^2 = 4$ (not $0$, as it was for Fibonacci), so `omega` rearranges $4 + \\sum_{i \\in \\mathrm{Icc}\\,1\\,n} L_i^2 = L_n L_{n+1} + 2$ into the subtraction-free $\\big(\\sum_{i \\in \\mathrm{Icc}\\,1\\,n} L_i^2\\big) + 2 = L_n L_{n+1}$ — staying inside $\\mathbb{N}$. `lucas_sum_sq_Icc_int` then `push_cast`s into $\\mathbb{Z}$ and `linarith` exposes the literal $\\sum_{i=1}^n L_i^2 = L_n L_{n+1} - 2$."
+    "content": "**The $i = 0$ term is where the $-2$ appears.** To reach the textbook statement over `Icc 1 n`, write `range (n+1) = insert 0 (Icc 1 n)` (an `ext`/`omega` set identity) and split off the head with `Finset.sum_insert`. The discarded term is now $L_0^2 = 4$ (not $0$, as it was for Fibonacci), so `omega` rearranges $4 + \\sum_{i \\in \\mathrm{Icc}\\,1\\,n} L_i^2 = L_n L_{n+1} + 2$ into the subtraction-free $\\big(\\sum_{i \\in \\mathrm{Icc}\\,1\\,n} L_i^2\\big) + 2 = L_n L_{n+1}$ — staying inside $\\mathbb{N}$. `lucas_sum_sq_Icc_int` then `push_cast`s into $\\mathbb{Z}$ and `linarith` exposes the literal $\\sum_{i=1}^n L_i^2 = L_n L_{n+1} - 2$.",
+    "mathContext": "$\\sum_{i \\in \\mathrm{range}(n+1)} = L_0^2 + \\sum_{i \\in \\mathrm{Icc}\\,1\\,n}$, so $4 + \\sum_{\\mathrm{Icc}} L_i^2 = L_n L_{n+1} + 2 \\iff \\sum_{\\mathrm{Icc}} L_i^2 = L_n L_{n+1} - 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_insert",
+      "truncated subtraction in ℕ",
+      "push_cast (ℕ → ℤ)",
+      "linarith"
+    ],
+    "prerequisites": [
+      "Finset.Icc and Finset.range",
+      "natural-number versus integer subtraction",
+      "the omega and linarith tactics"
+    ]
   },
   {
     "id": "ann-fiboq030202-5",
     "proofId": "fibonacci-identities-oq-03-oq-02-oq-02",
     "range": { "startLine": 97, "endLine": 117 },
-    "type": "key-step",
+    "type": "insight",
     "title": "Telescoping Step and Numerical Check",
-    "content": "**Packaging.** `lucas_sum_sq_succ` records the inductive step in standalone form, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2\\big) + L_{n+1}^2 = L_{n+1} L_{n+2} + 2$, exhibiting the partial sums as the shifted consecutive products $L_n L_{n+1} + 2$. The numerical check at $n = 4$, $1 + 9 + 16 + 49 = 75 = L_4 L_5 - 2 = 7 \\cdot 11 - 2$, uses `decide` (kernel reduction, not `native_decide`), keeping the entry $0$-axiom."
+    "content": "**Packaging.** `lucas_sum_sq_succ` records the inductive step in standalone form, $\\big(\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2\\big) + L_{n+1}^2 = L_{n+1} L_{n+2} + 2$, exhibiting the partial sums as the shifted consecutive products $L_n L_{n+1} + 2$. The numerical check at $n = 4$, $1 + 9 + 16 + 49 = 75 = L_4 L_5 - 2 = 7 \\cdot 11 - 2$, uses `decide` (kernel reduction, not `native_decide`), keeping the entry $0$-axiom.",
+    "mathContext": "$\\big(\\sum_{i \\in \\mathrm{range}(n+1)} L_i^2\\big) + L_{n+1}^2 = L_{n+1} L_{n+2} + 2$; at $n=4$: $1+9+16+49 = 75 = 7 \\cdot 11 - 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "telescoping step",
+      "decide (kernel reduction)",
+      "axiom-free verification",
+      "numerical sanity check"
+    ],
+    "prerequisites": [
+      "the decide tactic and Lean.ofReduceBool distinction",
+      "the Lucas sequence values"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-03-oq-02-oq-02` (∑ Lᵢ² = Lₙ·Lₙ₊₁ − 2).

meta.json was already richly enriched and under the size cap; the gap was in annotations.json:
- Adds the **required `significance`** field to all 5 annotations (was absent).
- Adds **`mathContext`**, **`relatedConcepts`**, **`prerequisites`** to all 5.
- Fixes invalid `AnnotationType` values (`context`→`concept`, `key-step`→`insight`).

`pnpm build` passes.