### PR TITLE
Enrich norm-preserving Tietze extension (urysohns-lemma-oq-01-oq-01-oq-02): annotation coverage + valid enums

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02/annotations.json
@@ -1,16 +1,62 @@
 [
   {
+    "id": "ann-module-framing",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 40
+    },
+    "type": "concept",
+    "title": "From a Crude Bound to the Sharp Norm-Preserving Form",
+    "content": "**The gap this entry closes.** The parent entry (`urysohns-lemma-oq-01-oq-01-oq-01`) builds the Tietze extension by hand as a convergent series $G = \\sum' _n g_n$ in the Banach space of bounded continuous functions, proving $G = f$ on the closed set $s$ and the sup-bound $\\|G\\| \\le M$ for *any* ambient bound $M$ on the data. That bound is not sharp: it controls $G$ by whatever $M$ happened to be supplied, not by $f$ itself. This entry tracks the sup-norm *through* the series to upgrade $\\|G\\| \\le M$ into the sharp norm-preserving equality $\\|G\\| = \\|f\\|$ — by specialising $M$ to the actual sup-norm $\\|f\\|$, then proving the reverse inequality for free from the extension property. Nothing here touches Mathlib's `TietzeExtension` machinery; it is the explicit Urysohn series throughout.",
+    "mathContext": "$G = \\sum'_n g_n \\in C_b(X,\\mathbb{R}),\\quad G|_s = f,\\quad \\|G\\| = \\|f\\|.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Tietze extension theorem",
+      "Urysohn's lemma",
+      "sup-norm preservation",
+      "Banach space of bounded continuous functions"
+    ],
+    "prerequisites": [
+      "Urysohn's lemma and the parent series construction",
+      "the sup-norm on bounded continuous functions"
+    ]
+  },
+  {
+    "id": "ann-setup-variables",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 42,
+      "endLine": 47
+    },
+    "type": "definition",
+    "title": "Ambient Setup: Normal Space, Closed Set, Bounded Data",
+    "content": "**The standing hypotheses.** The `TietzeTsum` namespace fixes a normal topological space $X$, a closed subset $s \\subseteq X$, a continuous $f : C(s, \\mathbb{R})$, and a nonnegative bound $M$ with $|f\\,x| \\le M$ for all $x \\in s$. Normality (`NormalSpace X`) is exactly the separation strength Urysohn's lemma needs — disjoint closed sets can be separated by a continuous $[0,1]$-valued function — and it is what powers each correction term $g_i$ in the parent series. The bound hypothesis `hf` is the data $f$ being controlled by $M$; the headline theorem later instantiates $M = \\|f\\|$ to make this control sharp.",
+    "mathContext": "$X$ normal, $s$ closed, $f \\in C(s,\\mathbb{R}),\\ 0 \\le M,\\ \\forall x\\in s,\\ |f\\,x|\\le M.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "normal topological space",
+      "closed sets",
+      "continuous functions on a subspace",
+      "uniform bound on data"
+    ],
+    "prerequisites": [
+      "topological separation axioms",
+      "continuous maps between spaces"
+    ]
+  },
+  {
     "id": "ann-partial-sum-tracking",
     "proofId": "urysohns-lemma-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 51,
-      "endLine": 73
+      "startLine": 49,
+      "endLine": 67
     },
     "type": "lemma",
     "title": "Tracking the Sup-Norm of the Partial Sums",
     "content": "`partialSum_norm_le` is the norm-tracking core of the entry: every finite partial sum of the Urysohn correction series stays within the data bound, `‖∑_{i<n} gᵢ‖ ≤ M`. The estimate chains four steps. The triangle inequality for finite sums (`norm_sum_le`) bounds the norm of the sum by the sum of the norms, `∑_{i<n} ‖gᵢ‖`. The parent's per-term geometric bound `gbcf_norm_le` replaces each `‖gᵢ‖` by `(2/3)ⁱ·(M/3)`. Monotonicity of partial sums against a nonnegative summable series (`Summable.sum_le_tsum`, with positivity of the terms) bounds this finite head by the full tail `∑'_i (2/3)ⁱ·(M/3)`. Finally the geometric value `tsum_geometric_of_lt_one` (with `(1 − 2/3)⁻¹ = 3` and `tsum_mul_right`) evaluates that to exactly `M`. So the partial sums never overshoot the bound the residual is decaying inside — the norm-level shadow of the residual recursion.",
     "mathContext": "$\\bigl\\|\\sum_{i<n} g_i\\bigr\\| \\le \\sum_{i<n}\\|g_i\\| \\le \\sum_{i<n}(2/3)^i\\tfrac M3 \\le \\sum_{i}(2/3)^i\\tfrac M3 = M.$",
-    "significance": "medium",
+    "significance": "key",
     "relatedConcepts": [
       "geometric series majorant",
       "partial sums of a Banach-space series",
@@ -27,25 +73,48 @@
     "id": "ann-norm-preserving-tietze",
     "proofId": "urysohns-lemma-oq-01-oq-01-oq-02",
     "range": {
-      "startLine": 76,
-      "endLine": 103
+      "startLine": 71,
+      "endLine": 94
     },
     "type": "theorem",
     "title": "The Sharp Norm-Preserving Extension",
-    "content": "`tietze_extension_norm_preserving` is the headline result: for a *bounded* continuous `f : s →ᵇ ℝ` on a closed set `s` in a normal space `X`, the explicit Urysohn series `G` extends `f` with the exact sup-norm `‖G‖ = ‖f‖`. The proof specialises the parent's ambient bound to the data's own sup-norm. Because `f` is bounded, `|f x| ≤ ‖f‖` (`BoundedContinuousFunction.norm_coe_le_norm`), so `M = ‖f‖` is a legitimate bound; feeding `f.toContinuousMap` and `M = ‖f‖` into the parent's `tietze_extension_via_tsum` yields `G = ∑' n, gₙ` with `G = f` on `s` and `|G y| ≤ ‖f‖` everywhere. `BoundedContinuousFunction.norm_le` converts the pointwise bound to `‖G‖ ≤ ‖f‖`. The reverse `‖f‖ ≤ ‖G‖` is free from the extension property: `norm_le` reduces it to `‖f x‖ ≤ ‖G‖` for `x : s`, and after rewriting `f x = G (x : X)` this is exactly `norm_coe_le_norm` for `G`. `le_antisymm` gives the sharp equality — the strongest bounded form, since an extension can never have smaller sup-norm than the data it extends.",
+    "content": "`tietze_extension_norm_preserving` is the headline result: for a *bounded* continuous `f : s →ᵇ ℝ` on a closed set `s` in a normal space `X`, the explicit Urysohn series `G` extends `f` with the exact sup-norm `‖G‖ = ‖f‖`. The proof specialises the parent's ambient bound to the data's own sup-norm. Because `f` is bounded, `|f x| ≤ ‖f‖` (`BoundedContinuousFunction.norm_coe_le_norm`), so `M = ‖f‖` is a legitimate bound; feeding `f.toContinuousMap` and `M = ‖f‖` into the parent's `tietze_extension_via_tsum` yields `G = ∑' n, gₙ` with `G = f` on `s` and `|G y| ≤ ‖f‖` everywhere.",
     "mathContext": "$\\exists\\,G:\\,X\\to_b\\mathbb{R},\\quad G|_s=f \\ \\wedge\\ \\|G\\| = \\|f\\|.$",
-    "significance": "high",
+    "significance": "critical",
     "relatedConcepts": [
       "norm-preserving Tietze extension",
       "bounded Tietze extension theorem",
       "sup-norm preservation",
-      "antisymmetry of the order"
+      "specialising an ambient bound"
     ],
     "prerequisites": [
       "tietze_extension_via_tsum",
-      "BoundedContinuousFunction.norm_le",
       "BoundedContinuousFunction.norm_coe_le_norm",
+      "BoundedContinuousFunction.norm_le"
+    ]
+  },
+  {
+    "id": "ann-antisymmetry-sharpness",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 95,
+      "endLine": 103
+    },
+    "type": "insight",
+    "title": "Why the Equality Is Sharp: Both Inequalities",
+    "content": "**`le_antisymm` from two opposite bounds.** The equality `‖G‖ = ‖f‖` is assembled from two inequalities that come from genuinely different sources. The `≤` direction is *analytic*: `BoundedContinuousFunction.norm_le` reduces `‖G‖ ≤ ‖f‖` to the pointwise bound `|G y| ≤ ‖f‖`, which is exactly the parent's bound `hGle` at the sharp `M = ‖f‖`. The `≥` direction is *structural and free*: since `G` extends `f`, every value of `f` is already a value of `G`, so `norm_le` reduces `‖f‖ ≤ ‖G‖` to `|f x| ≤ ‖G‖`, and after rewriting `f x = G (x : X)` this is just `G.norm_coe_le_norm`. The conceptual content is that an extension can never have *smaller* sup-norm than the data it extends — so the parent's upper bound, once made sharp, forces equality.",
+    "mathContext": "$\\|G\\| \\le \\|f\\| \\ \\text{(sharp bound)} \\quad\\wedge\\quad \\|f\\| \\le \\|G\\| \\ \\text{(extension)} \\ \\Rightarrow\\ \\|G\\| = \\|f\\|.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "antisymmetry of ≤",
+      "extensions preserve sup-norm lower bound",
+      "pointwise-to-uniform bound conversion",
       "le_antisymm"
+    ],
+    "prerequisites": [
+      "le_antisymm",
+      "BoundedContinuousFunction.norm_le",
+      "BoundedContinuousFunction.norm_coe_le_norm"
     ]
   }
 ]

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-02/meta.json
@@ -36,6 +36,22 @@
   },
   "sections": [
     {
+      "id": "module-framing",
+      "title": "Overview: Upgrading the Bound to a Sharp Equality",
+      "startLine": 4,
+      "endLine": 40,
+      "summary": "Module docstring. The parent entry builds the Tietze extension as a convergent series G = ∑' n, gₙ with the crude bound ‖G‖ ≤ M for any ambient bound M. This entry tracks the sup-norm through the series (via partialSum_norm_le) to specialise M = ‖f‖ and recover the sharp norm-preserving form ‖G‖ = ‖f‖, never invoking Mathlib's TietzeExtension machinery.",
+      "mathContext": "$\\|G\\| \\le M \\ \\leadsto\\ \\|G\\| = \\|f\\|$ by setting $M = \\|f\\|$."
+    },
+    {
+      "id": "setup-variables",
+      "title": "Ambient Setup and Hypotheses",
+      "startLine": 42,
+      "endLine": 47,
+      "summary": "The TietzeTsum namespace fixes a normal space X, a closed set s ⊆ X, a continuous f : C(s, ℝ), and a nonnegative bound M with |f x| ≤ M on s. Normality is the separation strength Urysohn's lemma needs to build each correction term; the bound hypothesis hf is later instantiated at M = ‖f‖.",
+      "mathContext": "$X$ normal, $s$ closed, $f \\in C(s,\\mathbb{R}),\\ 0 \\le M,\\ \\forall x,\\ |f\\,x| \\le M.$"
+    },
+    {
       "id": "partial-sum-tracking",
       "title": "Tracking the Sup-Norm of the Partial Sums",
       "startLine": 51,


### PR DESCRIPTION
Enrichment pass for `urysohns-lemma-oq-01-oq-01-oq-02` (sharp norm-preserving Tietze extension, ‖G‖ = ‖f‖).

- Fixes invalid `significance` values (`medium`/`high` → `key`/`critical`) on both existing annotations.
- Adds 3 annotations (2 → 5) covering the previously uncovered module header, ambient setup, and the `le_antisymm` sharpness argument — all with `mathContext`/`relatedConcepts`/`prerequisites`.
- Adds matching meta.json `sections` for the header and setup (line coverage 51–103 → 4–103).

`pnpm build` passes.