### PR TITLE
audit: re-audit amgm-inequality-oq-02-oq-03 (Maclaurin chain from Newton log-concavity) CLEAN

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -133,9 +133,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T05:01:53Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Re-audited the stalest entry (queue drained 4014/4014, last audited 2026-05-03).

**Proof**: `amgm-inequality-oq-02-oq-03` — *Maclaurin Chain from Newton's Log-Concavity*

### Verified (all match meta.json)
| Claim | meta | Lean source | ✓ |
|---|---|---|---|
| lineCount | 226 | 226 | ✓ |
| sorries | 0 | 0 | ✓ |
| in-file axioms | leanFile 0 | 0 | ✓ |
| theoremCount | 7 | 7 (6 thm + 1 private lemma) | ✓ |
| definitionCount | 1 | 1 | ✓ |
| True stubs | — | none | ✓ |

### Axiom-integrity (basis for axiomatized/axiom badge)
- `newton_log_concavity` is a genuine `axiom` in the parent `AmgmInequalityOQ02.lean:285`, invoked here via `newton_lc` (`exact newton_log_concavity ...`). The whole chain (power_inequality → maclaurin_step_from_newton → maclaurin_step_proved) transitively rests on it.
- `meta.axiomCount=1` (inherited assumption) vs `leanFile.axiomCount=0` (literal in-file declarations) correctly distinguished per the Axiom Integrity Policy.
- Badge `axiom`, status `axiomatized` — correct conservative choice.

### Narrative check (5 failure modes)
Title *"…from Newton's Log-Concavity"* discloses the dependency; `assumptions`/`conclusion` name the remaining axiom explicitly; the genuine contribution (proving `maclaurin_step_proved`, eliminating the parent's `maclaurin_step` axiom) is correctly scoped. No overclaiming.

### Minor (non-blocking, not an overclaim)
`openQuestions[0]` asks whether "the remaining **sorry** (elemSymm zero propagation)" can be eliminated — but there is no sorry; zero propagation is proved as the private lemma `normElemSymm_zero_succ`. This *understates* completeness, so it is not an integrity violation. Not worth a content edit on its own.

**Verdict: CLEAN.** Tracker updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)