### PR TITLE
Enrich abelian inverse Galois (abel-ruffini-oq-03): annotation depth fields

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-03/annotations.json
@@ -6,9 +6,22 @@
       "startLine": 3,
       "endLine": 51
     },
-    "type": "context",
+    "type": "concept",
     "title": "The abelian case is a theorem — this verifies its arithmetic core",
-    "content": "The inverse Galois problem (which finite groups are Gal(L/ℚ)?) is open in general and is Shafarevich's theorem for solvable groups (axiomatized in the sibling abel-ruffini-galois-extensions-oq-05). For ABELIAN groups it is a theorem, classically derived from Kronecker–Weber plus Dirichlet's theorem on primes in arithmetic progressions. This file isolates the part Mathlib supports in full and proves it with zero axioms: for every n ≥ 1 the n-th cyclotomic field ℚ(ζₙ) is an abelian Galois extension of ℚ with Galois group (ZMod n)ˣ. That family of groups is precisely the building block of the Kronecker–Weber realization of an arbitrary finite abelian group; the two remaining classical reductions are named in the closing docstring but not asserted."
+    "content": "The inverse Galois problem (which finite groups are Gal(L/ℚ)?) is open in general and is Shafarevich's theorem for solvable groups (axiomatized in the sibling abel-ruffini-galois-extensions-oq-05). For ABELIAN groups it is a theorem, classically derived from Kronecker–Weber plus Dirichlet's theorem on primes in arithmetic progressions. This file isolates the part Mathlib supports in full and proves it with zero axioms: for every n ≥ 1 the n-th cyclotomic field ℚ(ζₙ) is an abelian Galois extension of ℚ with Galois group (ZMod n)ˣ. That family of groups is precisely the building block of the Kronecker–Weber realization of an arbitrary finite abelian group; the two remaining classical reductions are named in the closing docstring but not asserted.",
+    "mathContext": "$\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\cong (\\mathbb{Z}/n\\mathbb{Z})^\\times$ — the building block of every finite abelian Galois group over $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "inverse Galois problem",
+      "Kronecker–Weber theorem",
+      "cyclotomic fields",
+      "abelian extensions"
+    ],
+    "prerequisites": [
+      "Galois theory",
+      "finite abelian groups",
+      "roots of unity"
+    ]
   },
   {
     "id": "arar-oq03-ann-galois-group",
@@ -17,9 +30,22 @@
       "startLine": 52,
       "endLine": 66
     },
-    "type": "key-step",
+    "type": "insight",
     "title": "Gal(ℚ(ζₙ)/ℚ) ≅ (ZMod n)ˣ for all n",
-    "content": "cyclotomicField_isGalois packages IsCyclotomicExtension.isGalois: ℚ(ζₙ)/ℚ is a Galois extension. autEquivUnitsZMod is the arithmetic heart: Mathlib's IsCyclotomicExtension.autEquivPow produces Gal(L/K) ≃* (ZMod n)ˣ whenever the n-th cyclotomic polynomial is irreducible over the base field K. Over K = ℚ that irreducibility is cyclotomic.irreducible_rat, which holds for EVERY n ≥ 1 — so the isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ is unconditional. This is the single deep fact behind the abelian inverse Galois problem; everything else is transport of structure."
+    "content": "cyclotomicField_isGalois packages IsCyclotomicExtension.isGalois: ℚ(ζₙ)/ℚ is a Galois extension. autEquivUnitsZMod is the arithmetic heart: Mathlib's IsCyclotomicExtension.autEquivPow produces Gal(L/K) ≃* (ZMod n)ˣ whenever the n-th cyclotomic polynomial is irreducible over the base field K. Over K = ℚ that irreducibility is cyclotomic.irreducible_rat, which holds for EVERY n ≥ 1 — so the isomorphism Gal(ℚ(ζₙ)/ℚ) ≃* (ZMod n)ˣ is unconditional. This is the single deep fact behind the abelian inverse Galois problem; everything else is transport of structure.",
+    "mathContext": "$\\sigma \\mapsto (k : \\zeta_n \\mapsto \\zeta_n^k)$ gives $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q}) \\xrightarrow{\\ \\sim\\ } (\\mathbb{Z}/n\\mathbb{Z})^\\times$, unconditional via $\\Phi_n$ irreducible over $\\mathbb{Q}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "cyclotomic polynomial irreducibility",
+      "Galois group of a cyclotomic extension",
+      "IsCyclotomicExtension.autEquivPow",
+      "multiplicative group of units mod n"
+    ],
+    "prerequisites": [
+      "cyclotomic.irreducible_rat",
+      "IsCyclotomicExtension.isGalois",
+      "group isomorphism (≃*)"
+    ]
   },
   {
     "id": "arar-oq03-ann-abelian",
@@ -28,9 +54,21 @@
       "startLine": 67,
       "endLine": 80
     },
-    "type": "key-step",
+    "type": "insight",
     "title": "The extension is abelian (and finite) by transport",
-    "content": "galois_mul_comm proves ℚ(ζₙ)/ℚ is an ABELIAN extension without any hand computation on automorphisms: apply the isomorphism e = autEquivUnitsZMod to σ·τ and τ·σ, use map_mul and mul_comm on the commutative unit group (ZMod n)ˣ, and conclude σ·τ = τ·σ by injectivity of e. galois_finite likewise transports finiteness of (ZMod n)ˣ across e.symm. Both are clean instances of the principle that a group isomorphism carries group-theoretic properties (commutativity, finiteness) between its two sides."
+    "content": "galois_mul_comm proves ℚ(ζₙ)/ℚ is an ABELIAN extension without any hand computation on automorphisms: apply the isomorphism e = autEquivUnitsZMod to σ·τ and τ·σ, use map_mul and mul_comm on the commutative unit group (ZMod n)ˣ, and conclude σ·τ = τ·σ by injectivity of e. galois_finite likewise transports finiteness of (ZMod n)ˣ across e.symm. Both are clean instances of the principle that a group isomorphism carries group-theoretic properties (commutativity, finiteness) between its two sides.",
+    "mathContext": "$e(\\sigma\\tau) = e(\\sigma)e(\\tau) = e(\\tau)e(\\sigma) = e(\\tau\\sigma)$ in the commutative $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, so $\\sigma\\tau = \\tau\\sigma$ by injectivity of $e$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "transport of structure along an isomorphism",
+      "commutative groups",
+      "injectivity of a MulEquiv",
+      "finiteness of (ZMod n)ˣ"
+    ],
+    "prerequisites": [
+      "MulEquiv.map_mul and injectivity",
+      "mul_comm in a commutative group"
+    ]
   },
   {
     "id": "arar-oq03-ann-realization",
@@ -39,9 +77,22 @@
       "startLine": 81,
       "endLine": 110
     },
-    "type": "key-step",
+    "type": "definition",
     "title": "Realizability bundle: (ZMod n)ˣ is Gal(L/ℚ)",
-    "content": "RealizationOverRat G bundles the data witnessing that a finite group G is a Galois group over ℚ: a carrier field L (with its Field and Algebra ℚ instances packaged as instance fields so that L ≃ₐ[ℚ] L type-checks), a proof IsGalois ℚ L, and an isomorphism (L ≃ₐ[ℚ] L) ≃* G. unitsZModRealization instantiates the bundle with L = CyclotomicField n ℚ, and unitsZMod_realizableOverRat states the existence form: Nonempty (RealizationOverRat (ZMod n)ˣ). This is exactly the inverse-Galois shape 'G = Gal(L/ℚ)', proved for the cyclotomic family over the fixed arithmetic base ℚ."
+    "content": "RealizationOverRat G bundles the data witnessing that a finite group G is a Galois group over ℚ: a carrier field L (with its Field and Algebra ℚ instances packaged as instance fields so that L ≃ₐ[ℚ] L type-checks), a proof IsGalois ℚ L, and an isomorphism (L ≃ₐ[ℚ] L) ≃* G. unitsZModRealization instantiates the bundle with L = CyclotomicField n ℚ, and unitsZMod_realizableOverRat states the existence form: Nonempty (RealizationOverRat (ZMod n)ˣ). This is exactly the inverse-Galois shape 'G = Gal(L/ℚ)', proved for the cyclotomic family over the fixed arithmetic base ℚ.",
+    "mathContext": "$\\mathrm{RealizationOverRat}\\,G := \\{\\,L,\\ \\mathrm{IsGalois}\\,\\mathbb{Q}\\,L,\\ (L \\simeq_{\\mathbb{Q}} L) \\simeq^* G\\,\\};\\quad G = (\\mathbb{Z}/n\\mathbb{Z})^\\times,\\ L = \\mathbb{Q}(\\zeta_n).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "inverse Galois realizability",
+      "bundled structure with instance fields",
+      "Nonempty existence form",
+      "AlgEquiv (L ≃ₐ[ℚ] L)"
+    ],
+    "prerequisites": [
+      "structures with typeclass instance fields",
+      "IsGalois ℚ L",
+      "the autEquivUnitsZMod isomorphism"
+    ]
   },
   {
     "id": "arar-oq03-ann-target",
@@ -50,8 +101,20 @@
       "startLine": 111,
       "endLine": 131
     },
-    "type": "context",
+    "type": "concept",
     "title": "What is left to reach an arbitrary abelian group",
-    "content": "The closing docstring records the full Kronecker–Weber realization target — every finite abelian group A is Gal(L/ℚ) — and names the two classical inputs that bridge from the verified family (ZMod n)ˣ: (1) Dirichlet's theorem on primes in arithmetic progressions, used to choose n so that A is a quotient of (ZMod n)ˣ (e.g. distinct primes pᵢ ≡ 1 mod the invariant factors mᵢ of A); and (2) the Galois correspondence for abelian extensions, by which a quotient G/N of an abelian Galois group is realized by the fixed field L^N, itself Galois over ℚ with group G/N. These are provable but out of scope here, and are deliberately NOT introduced as axioms."
+    "content": "The closing docstring records the full Kronecker–Weber realization target — every finite abelian group A is Gal(L/ℚ) — and names the two classical inputs that bridge from the verified family (ZMod n)ˣ: (1) Dirichlet's theorem on primes in arithmetic progressions, used to choose n so that A is a quotient of (ZMod n)ˣ (e.g. distinct primes pᵢ ≡ 1 mod the invariant factors mᵢ of A); and (2) the Galois correspondence for abelian extensions, by which a quotient G/N of an abelian Galois group is realized by the fixed field L^N, itself Galois over ℚ with group G/N. These are provable but out of scope here, and are deliberately NOT introduced as axioms.",
+    "mathContext": "$A \\cong (\\mathbb{Z}/n\\mathbb{Z})^\\times / N$ for a suitable $n$ (Dirichlet) $\\Rightarrow A \\cong \\mathrm{Gal}(L^N/\\mathbb{Q})$ (Galois correspondence).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Dirichlet's theorem on arithmetic progressions",
+      "Galois correspondence for abelian extensions",
+      "quotients of (ZMod n)ˣ",
+      "invariant factors of a finite abelian group"
+    ],
+    "prerequisites": [
+      "structure theorem for finite abelian groups",
+      "fixed fields and the fundamental theorem of Galois theory"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-03` (cyclotomic realization of the abelian inverse Galois problem over ℚ).

- Adds the missing `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations (the quality scan flagged mathContext=0, significance=0).
- Fixes invalid `AnnotationType` values (`context`→`concept`, `key-step`→`insight`/`definition`).

meta.json already meets quality targets; no changes there. `pnpm build` passes.