### PR TITLE
Audit: re-badge algebraic-numbers-countable original → mathlib (Tier B wrapper)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -2,7 +2,7 @@
   "id": "algebraic-numbers-countable",
   "title": "Countability of Algebraic Numbers",
   "slug": "algebraic-numbers-countable",
-  "description": "A formalization of Cantor's 1874 theorem that the algebraic numbers are countable. Proves countability and cardinality ℵ₀ for algebraic reals and complex numbers, stratification by minimal polynomial degree, the countable union decomposition, and cardinality equality between algebraic numbers and ℚ.",
+  "description": "A formalization of Cantor's 1874 theorem that the algebraic numbers are countable. The core countability and cardinality ℵ₀ results for algebraic reals and complex numbers are obtained directly from Mathlib's `Algebraic.countable` and `Algebraic.cardinalMk_of_countable_of_charZero`; this entry's original contribution is the degree-stratification infrastructure built on top: stratification by minimal polynomial degree, the countable union decomposition, the monotone bounded-degree filtration, and cardinality equality between algebraic numbers and ℚ.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
@@ -18,7 +18,7 @@
       "cardinality",
       "field-theory"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -67,10 +67,10 @@
       "result": "clean"
     },
     "algebraic-numbers-countable": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
-      "result": "clean"
+      "lastAudited": "2026-06-27T05:09:41Z",
+      "result": "issues-fixed"
     },
     "algebraic-numbers-countable-oq-02": {
       "auditCount": 2,
@@ -133,9 +133,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T05:01:53Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03-oq-03": {


### PR DESCRIPTION
## Integrity Audit Finding (MEDIUM)

**Proof**: `algebraic-numbers-countable` (Countability of Algebraic Numbers, Cantor 1874)
**Problem**: Mathlib wrapper for the core result badged `original`.

## Evidence

The four headline theorems are **one-line delegations to Mathlib**:

```lean
theorem algebraic_reals_countable := Algebraic.countable ℚ ℝ
theorem algebraic_complex_countable := Algebraic.countable ℚ ℂ
theorem card_algebraic_reals_eq_aleph0 := Algebraic.cardinalMk_of_countable_of_charZero ℚ ℝ
theorem card_algebraic_complex_eq_aleph0 := Algebraic.cardinalMk_of_countable_of_charZero ℚ ℂ
```

The headline claim — countability of algebraic numbers — **is** Mathlib's `Algebraic.countable`, applied directly. Per the auditor Tier B classification and narrative failure-mode 5 ("0 sorries with hidden imports"), when the core/headline result is obtained by calling a deep Mathlib theorem, the badge must be `mathlib`, not `original`.

The entry was already internally honest elsewhere (`mathlibDependencies`, `assumptions`, and the line-169 annotation all credit `Algebraic.countable` and scope `originalContributions` to the degree-stratification layer) — only the **badge** overclaimed.

## Fix

- `badge`: `original` → `mathlib` (consistent with 653 existing `mathlib`-badge entries; `status: verified` retained since the file is genuinely 0-sorry / 0-axiom / fully machine-checked).
- `description`: now credits Mathlib's `Algebraic.countable` / `cardinalMk_of_countable_of_charZero` for the core result and frames the degree-stratification infrastructure as this entry's original contribution.

## Verification against source (`proofs/Proofs/AlgebraicNumbersCountable.lean`)

| Field | meta.json | source | match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 18 | 18 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| lineCount | 254 | 254 | ✓ |

The genuine original contributions (degree stratification, exact/bounded-degree countability, iUnion decompositions, monotone filtration, cardinality equality with ℚ) are unaffected.

---
Discovered during gallery integrity audit.