### PR TITLE
Enrich Pascal for rational-normal conic (brianchon-theorem-oq-01-oq-01): annotations + sections

### DIFF
--- a/src/data/proofs/brianchon-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/brianchon-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "brianchon-oq0101-ann-header",
+    "proofId": "brianchon-theorem-oq-01-oq-01",
+    "range": { "startLine": 5, "endLine": 55 },
+    "type": "concept",
+    "title": "Removing the Pascal Axiom on the Conic's Computational Core",
+    "content": "Both the gallery's Brianchon and Pascal entries rest on a single geometric axiom, `conic_implies_pascal`: six points on a conic make the three meets of opposite hexagon sides collinear. This file *removes* that axiom on the part that carries the actual geometric content — the **rational-normal conic** $xz = y^2$ parametrized by $t \\mapsto (t^2, t, 1)$ (the Veronese / rational normal curve). For any six parameters the three Pascal points are collinear, proved as a single polynomial identity with **no axiom, no `sorry`, no `native_decide`**. The only gap to a full discharge of the abstract axiom (for an arbitrary symmetric matrix $C$) is the projective-normalization / Sylvester transfer carrying a nondegenerate $C$ onto the standard conic — heavier linear algebra, documented as the next step. The docstring also flags that the bare abstract axiom is *false* without a $\\det C \\ne 0$ nondegeneracy hypothesis (e.g. $C = 0$).",
+    "mathContext": "$xz = y^2,\\qquad t \\mapsto (t^2, t, 1).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Pascal's hexagon theorem",
+      "rational normal curve / Veronese conic",
+      "projective conics",
+      "discharging an axiom on a special case"
+    ],
+    "prerequisites": [
+      "projective geometry in the homogeneous model",
+      "conics as quadratic forms"
+    ]
+  },
+  {
+    "id": "brianchon-oq0101-ann-model",
+    "proofId": "brianchon-theorem-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 78 },
+    "type": "definition",
+    "title": "Join, Meet, and Collinearity via Cross Product and Determinant",
+    "content": "The homogeneous $\\mathbb{R}^3$ model uses explicit component formulas so the entire Pascal identity collapses to one `ring` call. `cross u v` is the vector cross product, doing double duty: the **join** of two projective points (the line through them) and the **meet** of two projective lines (their intersection) are *both* the cross product — the self-duality of the projective plane. `det3 u v w` is the scalar triple product $u \\cdot (v \\times w)$, equivalently the $3\\times 3$ determinant with rows $u, v, w$. `Collinear p q r` is defined as `det3 p q r = 0`: three projective points are collinear exactly when that determinant vanishes (they span a plane through the origin, i.e. a projective line).",
+    "mathContext": "$u \\wedge v = u \\times v;\\quad \\mathrm{det3}(u,v,w) = u \\cdot (v \\times w) = \\det[u\\;v\\;w];\\quad \\mathrm{Collinear} \\iff \\det = 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "homogeneous coordinates",
+      "projective duality (join = meet = cross product)",
+      "scalar triple product",
+      "collinearity as a vanishing determinant"
+    ],
+    "prerequisites": [
+      "cross product and determinant in ℝ³",
+      "the projective plane ℝP²"
+    ]
+  },
+  {
+    "id": "brianchon-oq0101-ann-conicpt",
+    "proofId": "brianchon-theorem-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 88 },
+    "type": "definition",
+    "title": "The Parametrized Conic Point",
+    "content": "`conicPt t := (t², t, 1)` is the parametrization of the rational-normal conic, and `conicPt_mem` checks that it satisfies the conic's quadratic form: $x z - y^2 = t^2 \\cdot 1 - t^2 = 0$. After unfolding the `Matrix.cons` accessors with `simp`, the statement is a one-line `ring` identity. This parametrization is what reduces a *geometric* incidence question (six points on a conic) to an *algebraic* one (a polynomial identity in six real parameters), the move that makes the whole theorem `ring`-provable.",
+    "mathContext": "$x z - y^2 = t^2 \\cdot 1 - t^2 = 0$ for $(x,y,z) = (t^2, t, 1).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "rational parametrization of a conic",
+      "quadratic form of a conic",
+      "Matrix.cons vector notation"
+    ],
+    "prerequisites": [
+      "conics as zero loci of quadratic forms",
+      "the !\\[...\\] vector notation"
+    ]
+  },
+  {
+    "id": "brianchon-oq0101-ann-pascal",
+    "proofId": "brianchon-theorem-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 117 },
+    "type": "theorem",
+    "title": "Pascal's Theorem as One ring Identity",
+    "content": "`pascalX/Y/Z` define the three Pascal points of the inscribed hexagon $A B C D E F$ as nested cross products — $X = (AB) \\wedge (DE)$, $Y = (BC) \\wedge (EF)$, $Z = (CD) \\wedge (FA)$, each a meet of two opposite sides. `pascal_parametrized` is the headline result: for *any* six parameters $a, \\dots, f$, the points $\\mathrm{conicPt}\\,a, \\dots, \\mathrm{conicPt}\\,f$ have collinear Pascal points. The proof `simp`-unfolds every definition (Collinear, det3, pascalX/Y/Z, cross, conicPt) into a raw polynomial in the six parameters and closes it with a single `ring`. This is precisely the axiom `conic_implies_pascal`, now proved unconditionally for the parametrized conic — the genuine Pascal incidence theorem, machine-checked.",
+    "mathContext": "$\\det\\big[(AB){\\wedge}(DE)\\ \\ (BC){\\wedge}(EF)\\ \\ (CD){\\wedge}(FA)\\big] = 0$ identically in $a,b,c,d,e,f.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Pascal's mystic hexagon",
+      "meets of opposite sides",
+      "polynomial identity closed by ring",
+      "axiom discharge for a special conic"
+    ],
+    "prerequisites": [
+      "the cross-product join/meet model",
+      "the ring tactic on polynomial identities"
+    ]
+  },
+  {
+    "id": "brianchon-oq0101-ann-infinity",
+    "proofId": "brianchon-theorem-oq-01-oq-01",
+    "range": { "startLine": 119, "endLine": 145 },
+    "type": "theorem",
+    "title": "Covering the Point at Infinity",
+    "content": "The parametrization $t \\mapsto (t^2, t, 1)$ misses exactly one point of the conic: $(1, 0, 0)$, the limit as $t \\to \\infty$. To show the theorem holds on the *full* conic (not just the affine chart), `conicInf := (1,0,0)` is verified on the conic by `conicInf_mem`, and `pascal_with_infinity` proves Pascal collinearity for the hexagon $\\infty\\,B\\,C\\,D\\,E\\,F$ with the remaining five vertices parametrized — again a pure `ring` identity. This handles the projective completion: the rational parametrization plus this single extra point exhaust the conic.",
+    "mathContext": "$\\infty = (1,0,0) = \\lim_{t\\to\\infty}\\big(1, \\tfrac1t, \\tfrac1{t^2}\\big)$ on $xz = y^2.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "point at infinity / projective completion",
+      "limiting parametrization",
+      "full coverage of the conic"
+    ],
+    "prerequisites": [
+      "projective points at infinity",
+      "the parametrized Pascal identity"
+    ]
+  },
+  {
+    "id": "brianchon-oq0101-ann-sanity",
+    "proofId": "brianchon-theorem-oq-01-oq-01",
+    "range": { "startLine": 147, "endLine": 159 },
+    "type": "insight",
+    "title": "Sanity Checks: Concrete and Degenerate",
+    "content": "`pascal_example` instantiates `pascal_parametrized` at the concrete parameters $0,1,2,3,4,5$, a witness that the identity is non-vacuous. The accompanying remark records the degenerate collapse: if two opposite hexagon vertices coincide the Pascal line remains well defined and collinearity is vacuously/automatically true — confirming the polynomial identity is not an artifact of genericity but holds across the whole parameter space. Both checks use `ring`, never `native_decide`, so the entry stays fully axiom-free.",
+    "mathContext": "Witness: $(a,\\dots,f) = (0,1,2,3,4,5)$; degenerate coincidences keep $\\det = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "concrete instantiation",
+      "degenerate cases of an incidence theorem",
+      "axiom-free verification (ring, not native_decide)"
+    ],
+    "prerequisites": [
+      "the parametrized Pascal theorem"
+    ]
+  }
+]

--- a/src/data/proofs/brianchon-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/brianchon-theorem-oq-01-oq-01/meta.json
@@ -72,6 +72,48 @@
       "Formalize the projective-invariance of Pascal collinearity under arbitrary invertible projective maps as a reusable lemma, completing the Sylvester reduction"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: Discharging the Pascal Axiom on the Rational-Normal Conic",
+      "startLine": 5,
+      "endLine": 55,
+      "summary": "Module docstring. Both the Brianchon and Pascal gallery entries rest on the single geometric axiom conic_implies_pascal (six points on a conic make the three meets of opposite hexagon sides collinear). This file removes the axiom on the computational core: the rational-normal conic xz = y² parametrized by t ↦ (t², t, 1). The only ingredient still separating this from a full discharge of the abstract axiom is the projective-normalization / Sylvester transfer (carrying a nondegenerate symmetric C onto the standard conic), documented as the next step.",
+      "mathContext": "$xz = y^2,\\quad t \\mapsto (t^2, t, 1)$ — the rational normal (Veronese) conic."
+    },
+    {
+      "id": "model",
+      "title": "The Homogeneous ℝ³ Model",
+      "startLine": 59,
+      "endLine": 88,
+      "summary": "Explicit component formulas (chosen so the whole Pascal identity reduces to one ring call): cross is the cross product, serving as both the join of two projective points and the meet of two projective lines; det3 is the scalar triple product / 3×3 determinant; Collinear p q r := det3 p q r = 0. conicPt t := (t², t, 1) is a point of the conic, and conicPt_mem verifies it satisfies xz − y² = 0.",
+      "mathContext": "$\\mathrm{Collinear}(p,q,r) \\iff \\det[p\\;q\\;r] = 0;\\quad u \\wedge v = u \\times v.$"
+    },
+    {
+      "id": "pascal-main",
+      "title": "Pascal's Theorem for the Parametrized Conic",
+      "startLine": 90,
+      "endLine": 117,
+      "summary": "pascalX/Y/Z define the three Pascal points X = (AB)∧(DE), Y = (BC)∧(EF), Z = (CD)∧(FA) as nested cross products. pascal_parametrized is the headline: for ANY six parameters a…f, the Pascal points of the inscribed hexagon are collinear — proved by unfolding all definitions and closing with a single ring call. This is exactly conic_implies_pascal, unconditional for the parametrized conic.",
+      "mathContext": "$X=(AB)\\wedge(DE),\\ Y=(BC)\\wedge(EF),\\ Z=(CD)\\wedge(FA);\\quad \\det[X\\;Y\\;Z]=0.$"
+    },
+    {
+      "id": "infinity",
+      "title": "The Point at Infinity",
+      "startLine": 119,
+      "endLine": 145,
+      "summary": "The parametrization t ↦ (t², t, 1) misses the single conic point (1,0,0) (the limit t → ∞). conicInf := (1,0,0) with conicInf_mem on the conic, and pascal_with_infinity proves Pascal collinearity for the hexagon ∞ B C D E F — again a pure ring identity — so the theorem covers the full conic, not just the affine chart.",
+      "mathContext": "$\\infty = (1,0,0) = \\lim_{t\\to\\infty}(1, 1/t, 1/t^2)$ on $xz = y^2$."
+    },
+    {
+      "id": "sanity",
+      "title": "Sanity Checks",
+      "startLine": 147,
+      "endLine": 159,
+      "summary": "pascal_example instantiates the parameters 0,1,2,3,4,5 as a concrete witness. The degenerate-collapse remark records that the identity is not an artifact of genericity: coincident opposite vertices leave the Pascal line well defined (collinearity vacuous/automatic).",
+      "mathContext": "Concrete instance: parameters $0,1,2,3,4,5$."
+    }
+  ],
   "crossReferences": [
     {
       "relationship": "Discharges, for the rational-normal conic, the conic_implies_pascal axiom that the Brianchon entry takes as its single assumption; uses the identical homogeneous ℝ³ cross-product / determinant model",


### PR DESCRIPTION
Enrichment pass for `brianchon-theorem-oq-01-oq-01` (Pascal's theorem for the rational-normal conic xz = y², axiom-free).

This entry had **no annotations and no sections** (quality scan: annotations=0, sections=0). This PR adds:
- **annotations.json** with 6 fully-fielded annotations (mathContext/significance/relatedConcepts/prerequisites) covering the framing, the homogeneous ℝ³ join/meet/determinant model, the conic parametrization, the headline `pascal_parametrized` ring identity, the point-at-infinity case, and the sanity checks.
- **5 meta.json sections** covering the full 161-line file.

`index.ts` is intentionally not added — the gallery loads via the central manifest (`src/data/proofs/index.ts`), not per-proof shims (only 455/4016 dirs have one). `pnpm build` passes.