### PR TITLE
Audit: brianchon-theorem-oq-01-oq-01 clean (axiom-free Pascal for rational-normal conic)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24913,6 +24913,12 @@
       "lastAudited": "2026-06-27T04:47:11Z",
       "result": "clean",
       "issues": []
+    },
+    "brianchon-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T05:12:59Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

Audited the sole remaining unaudited gallery entry, **brianchon-theorem-oq-01-oq-01** ("Pascal's Theorem for the Rational-Normal Conic — Axiom-Free"). Queue now **drained 4015/4015**.

### Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axioms | 0 | 0 decls, 0 structure fields | ✅ |
| sorries | 0 | 0 (grep hit is docstring "no sorry") | ✅ |
| native_decide | — | 0 (2 grep hits are docstring negations) | ✅ |
| theorems | 5 | 5 | ✅ |
| definitions | 8 | 8 | ✅ |
| lines | 161 | 161 | ✅ |

### Tier classification: A (fully formalized, original)

- Core `pascal_parametrized` is a genuine collinearity statement (`det3 = 0`) closed by `ring` — no axiom, no deep-Mathlib delegation.
- `mathlibDependencies` lists only `Matrix.cons_val_*` simp lemmas (vector-notation unfolding), not a core theorem. Badge `verified`/`original` is correct.
- No True stubs; `Collinear` is the correct det-vanishing test; Pascal points are the proper opposite-side meets `(AB)∧(DE)`, `(BC)∧(EF)`, `(CD)∧(FA)`.

### Narrative integrity

None of the five failure modes present. Title scopes the claim to the rational-normal conic; description, conclusion, and open questions explicitly disclose the remaining Sylvester/projective-normalization transfer and note the bare abstract `conic_implies_pascal` axiom is *false* at C=0. A model of well-qualified claiming — no overclaim, no axiom masking, no delegation opacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)