### PR TITLE
Audit: desargues-theorem-oq-01-oq-01 clean (Moulton plane Desargues counterexample)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14287,9 +14287,9 @@
       "issues": []
     },
     "desargues-theorem-oq-01-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-03T22:16:59Z",
-      "result": "issues-fixed",
+      "auditCount": 3,
+      "lastAudited": "2026-06-27T05:17:20Z",
+      "result": "clean",
       "issues": []
     },
     "dissection-of-cubes-oq-01-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: desargues-theorem-oq-01-oq-01 — *Non-Desarguesian Planes: The Moulton Plane Counterexample*

Re-audit of the stalest tracker batch (2026-05-03, auditCount 2→3; previously `issues-fixed`, now re-verified clean). Queue is otherwise drained; brianchon-theorem-oq-01-oq-01 remains the sole "unaudited" only because its clean-audit PR #30559 is still open.

### Verification

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status | `verified` | 0 sorry, 0 axiom, no `True` stubs | ✓ |
| badge | `original` | Moulton plane not in Mathlib; assembled in-file | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no `native_decide` → no `Lean.ofReduceBool`) | ✓ |
| lineCount | 297 | 297 | ✓ |
| theoremCount | 30 | 30 | ✓ |
| definitionCount | 12 | 12 | ✓ |

### Tier classification: A (original), correctly badged

- Imports are only `Mathlib.Data.Real.Basic` + `Mathlib.Tactic` — **no heavy Mathlib theorem performs the core work**, so `original` (not `mathlib`) is correct.
- `desargues_fails : ¬ MoultonCollinear P_pt Q_pt R_pt` is a genuine proof: it case-splits on vertical / `m ≤ 0` / `m > 0`, extracts the three bent-line equations, derives `11m = 2` and `61m = 16` via `linear_combination`, and closes with `linarith` (122 ≠ 176). Not a stub.
- `moulton_counterexample` is a real 22-component conjunction built from named lemmas.
- Title is appropriately qualified ("Non-Desarguesian … Counterexample") — no overclaim of proving Desargues. Risk: **LOW**.

No issues found. Tracker updated to reflect the clean re-audit.

---
Discovered during gallery integrity audit.