### PR TITLE
research(burnside-counting-oq-02): verify deliverables already complete in main

### DIFF
--- a/src/data/research/problems/burnside-counting-oq-02.json
+++ b/src/data/research/problems/burnside-counting-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "burnside-counting-oq-02",
   "title": "Binary 4-necklace fixed-point checks for Polya enumeration",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETE",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -28,12 +28,12 @@
     "goal": "Keep this as the finite, computation-backed Polya example while future work connects it to the parent Burnside lemma without axioms."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETE",
     "since": "2026-04-03T08:17:23-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Verified deliverables already complete in main (BurnsideCounting.lean + BurnsideCountingOQ03.lean).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None — completed.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -41,11 +41,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "VERIFIED COMPLETE (researcher-9, 2026-06-26): The deliverables for this entry are already fully realized and machine-checked in main. (1) The candidate-pool framing — verify `fixed_point_sum_binary_4` via native_decide — was discharged in burnside-counting-oq-01 S3 (2026-06-10): proofs/Proofs/BurnsideCounting.lean:349 is now a `theorem` closed by `native_decide` (axiom -> theorem), and that file is axiom-free / sorry-free (sole foundational dependency is Lean.ofReduceBool from native_decide). (2) The Polya-enumeration framing of this record's knownResults — `polya_cyclic_fixed_count` (general k^gcd(r,n) fixed count), `fp_sum_binary4`, `polya_sum_Z4_binary` (sum = 24), `polya_binary4_necklace_count` (24/4 = 6) — all live in proofs/Proofs/BurnsideCountingOQ03.lean (the record's designated clean source), which has 0 sorries and 0 axiom declarations. No code change is warranted; this entry is a stale duplicate of already-merged work and is marked completed to stop it being re-handed out as the sole 'available' problem.",
+    "builtItems": [
+      "fixed_point_sum_binary_4 (BurnsideCounting.lean:349): theorem (formerly axiom) — sum of |Fix(r)| over r in {0,1,2,3} of Coloring 4 2 equals 24, closed by native_decide on the decidable IsFixedByRotation subtype cardinalities.",
+      "polya_cyclic_fixed_count (BurnsideCountingOQ03.lean:184): general theorem that the cyclic fixed-coloring count for rotation r is k^gcd(r,n).",
+      "fp_sum_binary4 / polya_sum_Z4_binary (BurnsideCountingOQ03.lean:253,265): the binary length-4 fixed-point sum equals 24 in both subtype-cardinality and divisor-sum 2^gcd(r,4) forms.",
+      "polya_binary4_necklace_count (BurnsideCountingOQ03.lean:374): the Burnside/Polya count (sum 2^gcd(r,4))/4 = 6 distinct binary 4-necklaces."
+    ],
+    "insights": [
+      "Both framings of this problem are already resolved in main: the parent native_decide discharge (oq-01 S3) and the OQ03 Polya divisor-sum theorems. Verification, not new proof, was the remaining work.",
+      "The headline necklace count never required bridging Mathlib's multiplicative burnside_lemma to the additive ZMod n action: once IsFixedByRotation/the orbit relation are decidable, both the fixed-point sum and the 6-necklace count collapse to native_decide (BurnsideCounting.lean) or explicit Fin-sum evaluation (BurnsideCountingOQ03.lean).",
+      "native_decide closes the two finite counts at the cost of the Lean.ofReduceBool axiom (compiler-trusted, not kernel-reduced); the divisor-sum identity polya_sum_Z4_binary in OQ03 is an alternative kernel-checked route to the same value 24."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "None for this entry — deliverables are complete and machine-checked.",
+      "Open follow-on (tracked elsewhere): connect the concrete OQ03 Polya counts to a general Polya cycle-index theorem in Lean 4."
+    ],
     "markdown": "# Knowledge Base: burnside-counting-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

`burnside-counting-oq-02` was re-handed out as the sole *available* research problem, but its deliverables are **already fully realized and machine-checked in `main`** under two framings. This PR records the verification in the problem's knowledge record and marks it completed so it stops being re-claimed as a no-op.

## Verification findings

**Framing 1 — candidate-pool task ("verify `fixed_point_sum_binary_4` via `native_decide`"):**
- `proofs/Proofs/BurnsideCounting.lean:349` is a `theorem` (formerly an axiom), closed by `native_decide`.
- File is axiom-free / sorry-free (sole foundational dependency: `Lean.ofReduceBool` from `native_decide`). Discharged in `burnside-counting-oq-01` S3 (2026-06-10).

**Framing 2 — Polya-enumeration knownResults (this record's designated clean source `BurnsideCountingOQ03.lean`):**
- `polya_cyclic_fixed_count` (`:184`) — general fixed count `k^gcd(r,n)`
- `fp_sum_binary4` (`:253`) and `polya_sum_Z4_binary` (`:265`) — sum `= 24`
- `polya_binary4_necklace_count` (`:374`) — `(∑ 2^gcd(r,4))/4 = 6`
- 0 sorries, 0 axiom declarations.

## Change

Single file: `src/data/research/problems/burnside-counting-oq-02.json` — populated `progressSummary`, `builtItems`, `insights`, `nextSteps`; set `status: completed`, `phase: COMPLETE`. No Lean/code change is warranted (the math is already proven and merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)