### PR TITLE
Audit: puiseux-theorem-oq-03 clean (Tier D Newton-polygon infrastructure)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24919,6 +24919,12 @@
       "lastAudited": "2026-06-27T05:12:59Z",
       "result": "clean",
       "issues": []
+    },
+    "puiseux-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T05:58:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `puiseux-theorem-oq-03` (The Newton Polygon as Combinatorial Data)

### Verification
| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| Lines | 228 | 228 | ✓ |
| Theorems | 6 | 6 | ✓ |
| Definitions | 6 | 6 (+1 `abbrev` type alias, excluded) | ✓ |
| Sorries | 0 | 0 | ✓ |
| Axioms | 0 | 0 | ✓ |
| native_decide | none | none | ✓ |

`sorry` grep hit is the docstring word "sorry-free". The 7th grep-matched `def` is `abbrev NPoint : Type := ℕ × ℤ`, a type alias the meta consistently excludes from its count of 6.

### Tier classification
**Tier D (infrastructure)** — correctly badged `infrastructure`, status `verified`. Provides computable Newton-polygon primitives (`slope`, `edges`, `slopes`, `leadingExponent`, `IsLowerHull`, `binomialNP`) plus 6 substantive verified lemmas, including `binomial_root_valuation` connecting the Newton-polygon slope to an honest n-th root in the Hahn-series Puiseux field.

No overclaiming: despite naming Wiedijk #41, the description frames the entry as "addresses the computational open question of Puiseux's theorem" and explicitly scopes the general slopes=valuations lemma and complexity bounds **out of scope** — no inequality≠theorem inflation, no Puiseux-theorem delegation opacity.

No issues found. Tracker updated (result clean).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)