### PR TITLE
Mark algebraic-reals-meager-oq-02 resolved (verified, complete)

### DIFF
--- a/src/data/research/problems/algebraic-reals-meager-oq-02.json
+++ b/src/data/research/problems/algebraic-reals-meager-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "algebraic-reals-meager-oq-02",
   "title": "algebraic-reals-meager-oq-02",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "RESOLVED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -22,7 +22,7 @@
     "focus": "Documenting that OQ-02 is already fully resolved and verified across two gallery",
     "activeApproach": "None — problem resolved. Both halves are machine-checked:",
     "blockers": [],
-    "nextAction": "None. Problem resolved; claim released.",
+    "nextAction": "None. Problem resolved, verified, and marked completed in the pool; claim released.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 0,
@@ -30,12 +30,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "RESOLVED — verified, 0 axioms, 0 sorries. Both halves of OQ-02 are machine-checked across two gallery files. (1) The literal ask: the transcendental reals {x : ℝ | ¬ IsAlgebraic ℚ x} are an explicit dense Gδ set (proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean), realized as ⋂ a, {a}ᶜ over the countable algebraic reals — mirroring Mathlib's IsGδ.setOf_irrational — hence residual/comeagre; with the sharp dual that the algebraic reals are NOT Gδ. (2) The category-vs-measure contrast (proofs/Proofs/AlgebraicRealsMeagerOQ02.lean): algebraic reals are Lebesgue-null, a.e. real is transcendental, Liouville numbers form a dense comeagre null set, giving comeagre ⇏ conull and Disjoint (residual ℝ) (ae volume). #print axioms shows only propext/Classical.choice/Quot.sound — no native_decide, no Lean.ofReduceBool, no sorryAx.",
+    "builtItems": [
+      "AlgebraicRealsMeagerDenseGDelta.lean: isGδ_compl_of_countable / dense_compl_of_countable / isGδ_dense_compl_of_countable (general perfect-T1 lemmas); transcendentalReals_isGδ, transcendentalReals_dense_isGδ, transcendentalReals_residual_of_dense_Gδ; algebraicReals_not_isGδ (sharp dual).",
+      "AlgebraicRealsMeagerOQ02.lean: algebraicReals_null, ae_transcendental; liouville_residual / liouville_dense / liouville_null; exists_residual_dense_null (comeagre ⇏ conull); residual_ae_disjoint (Disjoint residual / ae volume).",
+      "Problem directory + structured knowledge base recording the cross-file resolution so the seeker no longer re-mints OQ-02 as a fresh candidate."
+    ],
+    "insights": [
+      "The transcendental reals are not merely 'contained in' a dense Gδ — they ARE one literally, as ⋂ over the countable algebraic reals of the complements of singletons (the IsGδ.setOf_irrational pattern transplanted to algebraic/transcendental).",
+      "Sharp dual: a dense meagre set in a Baire space cannot be Gδ, so the algebraic reals are NOT Gδ (algebraicReals_not_isGδ) — the asymmetry between the two complementary sets.",
+      "Category and measure are orthogonal here: Disjoint (residual ℝ) (ae volume), witnessed concretely by the Liouville numbers — dense, comeagre, yet Lebesgue-null — establishing comeagre ⇏ conull."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
-    "markdown": "# algebraic-reals-meager-oq-02 — Knowledge Base\n\n## Problem\n\nQuantify the comeagre transcendental complement as an explicit dense Gδ set, and\nrelate comeagreness (category) to conullness (measure).\n\n## Status\n\n**RESOLVED — verified, 0 axioms, 0 sorries.**\n\n## Resolution (cross-file)\n\nThe two halves of OQ-02 are fully formalized:\n\n### 1. The transcendentals are an explicit dense Gδ (the literal ask)\nFile: `proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean`\n- `isGδ_compl_of_countable` / `dense_compl_of_countable` / `isGδ_dense_compl_of_countable`\n  — general: in a perfect T1 space the complement of a countable set is a dense Gδ.\n- `transcendentalReals_isGδ`, `transcendentalReals_dense_isGδ` — the transcendental\n  reals `{x : ℝ | ¬ IsAlgebraic ℚ x}` *are* a dense Gδ (not merely \"contain one\"), as\n  `⋂ a, {a}ᶜ` over the countable algebraic reals — mirroring Mathlib's `IsGδ.setOf_irrational`.\n- `transcendentalReals_residual_of_dense_Gδ` — hence residual (comeagre).\n- `algebraicReals_not_isGδ` — sharp dual: the algebraic reals are NOT Gδ (a dense\n  meagre set in a Baire space cannot be Gδ).\n\n### 2. Category vs measure (the contrast)\nFile: `proofs/Proofs/AlgebraicRealsMeagerOQ02.lean`\n- `algebraicReals_null` — algebraic reals are Lebesgue-null (measure counterpart of meagre).\n- `ae_transcendental` — a.e. real is transcendental (transcendentals conull).\n- `liouville_residual` / `liouville_dense` / `liouville_null` — Liouville numbers are a\n  dense comeagre set of measure zero.\n- `exists_residual_dense_null` — **comeagre ⇏ conull**: ∃ dense comeagre null set.\n- `residual_ae_disjoint` — `Disjoint (residual ℝ) (ae volume)`: the two σ-ideals are orthogonal.\n\n## Verification\n\nBoth files compile under `lake env lean` (mathlib 4.26.0). `#print axioms` on the\ntranscendental-Gδ theorems shows only propext / Classical.choice / Quot.sound — no\n`native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.\n\n## Sessions\n\n### Session 2026-06-25 (researcher-5)\nClaimed `algebraic-reals-meager-oq-02` (fresh, knowledge score 0). Investigation found\nthe problem is **already fully resolved and verified** across the two files above; the\nseeker had re-minted it because the `research/problems/algebraic-reals-meager-oq-02`\ndirectory was missing (only `oq-01` existed). Per the project's credibility policy\n(no fabricated/redundant theorems), this session records the resolution and adds the\nmissing problem directory so the problem is no longer re-selected as fresh. Confirmed\nboth Lean files still build cleanly offline.\n"
+    "markdown": "# algebraic-reals-meager-oq-02 — Knowledge Base\n\n## Problem\n\nQuantify the comeagre transcendental complement as an explicit dense Gδ set, and\nrelate comeagreness (category) to conullness (measure).\n\n## Status\n\n**RESOLVED — verified, 0 axioms, 0 sorries.**\n\n## Resolution (cross-file)\n\nThe two halves of OQ-02 are fully formalized:\n\n### 1. The transcendentals are an explicit dense Gδ (the literal ask)\nFile: `proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean`\n- `isGδ_compl_of_countable` / `dense_compl_of_countable` / `isGδ_dense_compl_of_countable`\n  — general: in a perfect T1 space the complement of a countable set is a dense Gδ.\n- `transcendentalReals_isGδ`, `transcendentalReals_dense_isGδ` — the transcendental\n  reals `{x : ℝ | ¬ IsAlgebraic ℚ x}` *are* a dense Gδ (not merely \"contain one\"), as\n  `⋂ a, {a}ᶜ` over the countable algebraic reals — mirroring Mathlib's `IsGδ.setOf_irrational`.\n- `transcendentalReals_residual_of_dense_Gδ` — hence residual (comeagre).\n- `algebraicReals_not_isGδ` — sharp dual: the algebraic reals are NOT Gδ (a dense\n  meagre set in a Baire space cannot be Gδ).\n\n### 2. Category vs measure (the contrast)\nFile: `proofs/Proofs/AlgebraicRealsMeagerOQ02.lean`\n- `algebraicReals_null` — algebraic reals are Lebesgue-null (measure counterpart of meagre).\n- `ae_transcendental` — a.e. real is transcendental (transcendentals conull).\n- `liouville_residual` / `liouville_dense` / `liouville_null` — Liouville numbers are a\n  dense comeagre set of measure zero.\n- `exists_residual_dense_null` — **comeagre ⇏ conull**: ∃ dense comeagre null set.\n- `residual_ae_disjoint` — `Disjoint (residual ℝ) (ae volume)`: the two σ-ideals are orthogonal.\n\n## Verification\n\nBoth files compile under `lake env lean` (mathlib 4.26.0). `#print axioms` on the\ntranscendental-Gδ theorems shows only propext / Classical.choice / Quot.sound — no\n`native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.\n\n## Sessions\n\n### Session 2026-06-25 (researcher-5)\nClaimed `algebraic-reals-meager-oq-02` (fresh, knowledge score 0). Investigation found\nthe problem is **already fully resolved and verified** across the two files above; the\nseeker had re-minted it because the `research/problems/algebraic-reals-meager-oq-02`\ndirectory was missing (only `oq-01` existed). Per the project's credibility policy\n(no fabricated/redundant theorems), this session records the resolution and adds the\nmissing problem directory so the problem is no longer re-selected as fresh. Confirmed\nboth Lean files still build cleanly offline.\n\n### Session 2026-06-26 (researcher-5)\nRe-claimed after the seeker re-offered OQ-02 as a fresh candidate (its structured knowledge fields were empty, so the pool never saw it as resolved). Verified both Lean files still present with 0 sorries / 0 axioms, populated progressSummary / insights / builtItems from the existing cross-file resolution, and marked the pool status `completed` (quality gate passed) so OQ-02 is no longer re-minted.\n"
   },
   "tags": [
     "topology",


### PR DESCRIPTION
## Summary

`algebraic-reals-meager-oq-02` was being **re-minted by the seeker as a fresh candidate** even though both halves are already fully machine-checked. The cause: its structured knowledge fields (`progressSummary`, `insights`, `builtItems`) were empty, so the pool's quality gate never recognized it as resolved and kept offering it.

This PR records the existing resolution in structured form and marks the problem completed. **No new theorems are fabricated** — the Lean resolution predates this session and is unchanged.

## Verified resolution (0 sorries, 0 axioms)

**The literal ask — transcendentals are an explicit dense Gδ** (`AlgebraicRealsMeagerDenseGDelta.lean`):
- `transcendentalReals_isGδ` / `transcendentalReals_dense_isGδ` — `{x : ℝ | ¬ IsAlgebraic ℚ x}` *is* a dense Gδ, realized as `⋂ a, {a}ᶜ` over the countable algebraic reals (the `IsGδ.setOf_irrational` pattern).
- `transcendentalReals_residual_of_dense_Gδ` — hence residual/comeagre.
- `algebraicReals_not_isGδ` — sharp dual: the algebraic reals are NOT Gδ.

**Category vs measure contrast** (`AlgebraicRealsMeagerOQ02.lean`):
- `algebraicReals_null`, `ae_transcendental` — algebraic reals Lebesgue-null; a.e. real transcendental.
- `liouville_residual` / `liouville_dense` / `liouville_null` — Liouville numbers: dense, comeagre, measure zero.
- `exists_residual_dense_null` — **comeagre ⇏ conull**; `residual_ae_disjoint` — `Disjoint (residual ℝ) (ae volume)`.

`#print axioms` shows only propext / Classical.choice / Quot.sound — no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`.

## Changes
- Populate structured knowledge fields from the verified cross-file resolution.
- Set problem status `active`→`completed`, phase `OBSERVE`→`RESOLVED`.
- Pool entry marked `completed` (quality gate passed) so OQ-02 is no longer re-selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)