### PR TITLE
Enrich Binary Rate–Distortion Function (shannon-source-coding-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/shannon-source-coding-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/shannon-source-coding-oq-01-oq-03/annotations.json
@@ -1,24 +1,122 @@
 [
   {
-    "id": "ann-definition-endpoints",
+    "id": "ann-header-overview",
     "proofId": "shannon-source-coding-oq-01-oq-03",
-    "range": {
-      "startLine": 49,
-      "endLine": 60
-    },
-    "type": "theorem",
-    "title": "Definition and Endpoint Values of R(D) = H(p) − H(D)",
-    "content": "rateDistortion p D is defined as binEntropy p − binEntropy D, the explicit binary rate–distortion function for a Bernoulli(p) source under Hamming distortion. The two endpoints are immediate: rateDistortion_zero proves R(p, 0) = H(p) (simp with binEntropy_zero — lossless coding needs the full source entropy rate), and rateDistortion_self proves R(p, p) = 0 (simp with sub_self — at distortion equal to the source bias the required rate drops to zero). These are the two extremes of the rate–distortion curve: keeping all of the source's h(p) bits of entropy versus discarding all of them."
+    "range": { "startLine": 4, "endLine": 39 },
+    "type": "context",
+    "title": "What This File Discharges: Open Question #3 of the Parent Entry",
+    "content": "The header docstring explains the file's purpose. The parent entry `shannon-source-coding-oq-01` records the binary rate–distortion function only as a comment; its open question #3 asks whether Lean can turn that commented formula into a concrete, connected object. This file does so, building directly on Mathlib's `Real.binEntropy`. It also fixes the working regime — `0 ≤ D ≤ p ≤ 1/2`, so that `min(p, 1−p) = p` — and notes the symmetry `binEntropy (1 − p) = binEntropy p` that extends every result to `p ≥ 1/2`. A unit caveat is recorded: Mathlib's `binEntropy` uses the natural logarithm, so entropy is in nats, but the formula `R = h(p) − h(D)` is base-independent (a change of log base scales both terms equally).",
+    "mathContext": "$R(D) = h(p) - h(D)$ for $0 \\le D \\le \\min(p, 1-p)$; here the regime is $0 \\le D \\le p \\le \\tfrac12$. Base-independence: $h_b(x) = h_e(x)/\\ln b$, so $R$ scales uniformly.",
+    "significance": "context",
+    "prerequisites": [
+      "rate–distortion theory (Shannon 1959)",
+      "binary entropy function",
+      "Lean 4 docstring conventions"
+    ],
+    "relatedConcepts": [
+      "rate–distortion function R(D)",
+      "Bernoulli source / Hamming distortion",
+      "binary entropy symmetry h(1−p) = h(p)",
+      "nats vs bits"
+    ]
   },
   {
-    "id": "ann-structural-properties",
+    "id": "ann-definition",
     "proofId": "shannon-source-coding-oq-01-oq-03",
-    "range": {
-      "startLine": 62,
-      "endLine": 89
-    },
+    "range": { "startLine": 45, "endLine": 47 },
+    "type": "definition",
+    "title": "The Rate–Distortion Function as a Difference of Entropies",
+    "content": "`rateDistortion p D := binEntropy p − binEntropy D` is the central definition: the entire rate–distortion curve for a binary source is a single difference of binary entropies. Marked `noncomputable` because `Real.binEntropy` is defined via the real logarithm. Every theorem below is a statement about this one expression; the elegance of the binary case is that the operationally meaningful quantity 'minimum rate to achieve average Hamming distortion D' collapses to this closed form, so its properties become facts about the function `binEntropy` rather than about codes or channels.",
+    "mathContext": "$R(p, D) := H(p) - H(D)$ where $H = \\texttt{Real.binEntropy}$, $H(x) = -x\\ln x - (1-x)\\ln(1-x)$.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.binEntropy",
+      "noncomputable definitions over ℝ"
+    ],
+    "relatedConcepts": [
+      "rate–distortion function",
+      "binary entropy",
+      "closed-form vs variational definition"
+    ]
+  },
+  {
+    "id": "ann-endpoints",
+    "proofId": "shannon-source-coding-oq-01-oq-03",
+    "range": { "startLine": 49, "endLine": 55 },
     "type": "theorem",
-    "title": "Nonnegativity, Monotonicity in D, and the Entropy Bound",
-    "content": "rateDistortion_nonneg (R(p,D) ≥ 0) and rateDistortion_antitone_in_D (R(p,·) decreasing in D) both reduce, after simp only [rateDistortion] and linarith, to a single inequality binEntropy D ≤ binEntropy p (resp. binEntropy D₁ ≤ binEntropy D₂) supplied by binEntropy_strictMonoOn.monotoneOn — binary entropy is increasing on [0, 1/2], and the hypotheses 0 ≤ D ≤ p ≤ 1/2 give the Set.Icc 0 2⁻¹ memberships. Thus the shape of the rate–distortion curve is exactly the monotonicity of binary entropy. rateDistortion_le_binEntropy bounds the rate by the source entropy (since H(D) ≥ 0 via binEntropy_nonneg), and rateDistortion_le_log_two bounds it by one bit (log 2 nats) via binEntropy_le_log_two — a binary source carries at most one bit of entropy per symbol."
+    "title": "The Two Endpoints: Lossless and Maximal-Distortion",
+    "content": "`rateDistortion_zero` proves `R(p, 0) = H(p)` — with zero distortion the required rate is the full source entropy, the lossless-coding limit (Shannon's source-coding theorem); it follows by `simp` from `binEntropy_zero` (H(0) = 0). `rateDistortion_self` proves `R(p, p) = 0` — when the tolerated distortion equals the source bias p, the rate drops to zero; it follows by `simp` via `sub_self`. These two endpoints pin the curve at its extremes: discard no entropy versus discard all of it.",
+    "mathContext": "$R(p, 0) = H(p) - H(0) = H(p)$ since $H(0) = 0$; $R(p, p) = H(p) - H(p) = 0$.",
+    "significance": "supporting",
+    "prerequisites": [
+      "binEntropy_zero",
+      "simp normal forms"
+    ],
+    "relatedConcepts": [
+      "lossless source coding",
+      "boundary conditions of R(D)",
+      "Shannon source-coding theorem"
+    ]
+  },
+  {
+    "id": "ann-nonneg",
+    "proofId": "shannon-source-coding-oq-01-oq-03",
+    "range": { "startLine": 57, "endLine": 65 },
+    "type": "theorem",
+    "title": "Nonnegativity from Monotonicity of Binary Entropy",
+    "content": "`rateDistortion_nonneg` proves `R(p, D) ≥ 0` on the regime `0 ≤ D ≤ p ≤ 1/2`. The argument is purely monotonicity: `binEntropy_strictMonoOn.monotoneOn` says H is increasing on `[0, 1/2]`, so the hypotheses give `H(D) ≤ H(p)`, and `simp only [rateDistortion]; linarith` concludes `H(p) − H(D) ≥ 0`. The `Set.Icc 0 2⁻¹` memberships needed by the monotonicity lemma are assembled from the chain `0 ≤ D ≤ p ≤ 1/2` with `le_trans`. A rate must be nonnegative, and here that physical fact is exactly the increasingness of binary entropy.",
+    "mathContext": "$0 \\le D \\le p \\le \\tfrac12 \\Rightarrow H(D) \\le H(p) \\Rightarrow R(p,D) = H(p) - H(D) \\ge 0$.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.binEntropy_strictMonoOn",
+      "StrictMonoOn.monotoneOn",
+      "Set.Icc membership",
+      "linarith"
+    ],
+    "relatedConcepts": [
+      "monotonicity of binary entropy on [0,1/2]",
+      "nonnegativity of rate",
+      "order reasoning"
+    ]
+  },
+  {
+    "id": "ann-antitone",
+    "proofId": "shannon-source-coding-oq-01-oq-03",
+    "range": { "startLine": 67, "endLine": 76 },
+    "type": "theorem",
+    "title": "Decreasing in Distortion: More Tolerance, Less Rate",
+    "content": "`rateDistortion_antitone_in_D` proves `R(p, ·)` is decreasing in `D`: for `0 ≤ D₁ ≤ D₂ ≤ p ≤ 1/2`, `R(p, D₂) ≤ R(p, D₁)`. Like nonnegativity it reduces to a single application of `binEntropy_strictMonoOn.monotoneOn`, here giving `H(D₁) ≤ H(D₂)`, after which `linarith` flips the subtraction. This is the defining qualitative shape of a rate–distortion curve — allowing more average error can only reduce the bits needed — and it is captured entirely by the monotonicity of `binEntropy`, with no analysis of the curve's derivative.",
+    "mathContext": "$D_1 \\le D_2 \\Rightarrow H(D_1) \\le H(D_2) \\Rightarrow R(p,D_2) = H(p) - H(D_2) \\le H(p) - H(D_1) = R(p,D_1)$.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.binEntropy_strictMonoOn",
+      "antitone functions",
+      "linarith"
+    ],
+    "relatedConcepts": [
+      "monotone decreasing R(D)",
+      "rate–distortion tradeoff",
+      "qualitative curve shape"
+    ]
+  },
+  {
+    "id": "ann-upper-bounds",
+    "proofId": "shannon-source-coding-oq-01-oq-03",
+    "range": { "startLine": 78, "endLine": 88 },
+    "type": "theorem",
+    "title": "Upper Bounds: Never More Than the Source Entropy, Never More Than One Bit",
+    "content": "Two ceilings. `rateDistortion_le_binEntropy` proves `R(p, D) ≤ H(p)` for any valid `0 ≤ D ≤ 1`, because `H(D) ≥ 0` (`binEntropy_nonneg`) means subtracting it can only lower the value — the rate never exceeds the source's own entropy. `rateDistortion_le_log_two` then chains that with `binEntropy_le_log_two` (a binary entropy is at most `log 2` nats) to give `R(p, D) ≤ log 2`: a binary source carries at most one bit per symbol, so no rate–distortion point can demand more. Together with nonnegativity these confine the entire curve to `[0, H(p)] ⊆ [0, log 2]`.",
+    "mathContext": "$H(D) \\ge 0 \\Rightarrow R(p,D) = H(p) - H(D) \\le H(p)$; and $H(p) \\le \\ln 2 \\Rightarrow R(p,D) \\le \\ln 2$ (one bit).",
+    "significance": "supporting",
+    "prerequisites": [
+      "binEntropy_nonneg",
+      "binEntropy_le_log_two",
+      "transitivity of ≤"
+    ],
+    "relatedConcepts": [
+      "entropy upper bound",
+      "one bit per binary symbol",
+      "log 2 nats = 1 bit"
+    ]
   }
 ]

--- a/src/data/proofs/shannon-source-coding-oq-01-oq-03/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-01-oq-03/meta.json
@@ -61,7 +61,8 @@
     "keyInsights": [
       "**Discarding distortion is discarding entropy**: R(D) = h(p) − h(D) literally subtracts the entropy h(D) of the tolerated error pattern from the source entropy h(p). The endpoint identities R(p,0) = h(p) and R(p,p) = 0 are the two extremes — lossless coding keeps all the entropy, while distortion up to the source bias removes all of it.",
       "**The curve's shape is the monotonicity of binary entropy**: that R(D) is nonnegative and decreasing on 0 ≤ D ≤ p ≤ 1/2 is precisely the statement that binEntropy is increasing on [0, 1/2] — Mathlib's binEntropy_strictMonoOn does all the analytic work, so the rate–distortion structural properties are corollaries of a single monotonicity fact.",
-      "**One bit is the ceiling**: R(p, D) ≤ h(p) ≤ log 2 says a binary source carries at most one bit (log 2 nats) of entropy per symbol, so no rate–distortion point can demand more — a direct consequence of binEntropy_le_log_two."
+      "**One bit is the ceiling**: R(p, D) ≤ h(p) ≤ log 2 says a binary source carries at most one bit (log 2 nats) of entropy per symbol, so no rate–distortion point can demand more — a direct consequence of binEntropy_le_log_two.",
+      "**Closed form sidesteps the variational definition**: operationally R(D) = inf I(X;X̂) over test channels meeting the distortion constraint, an optimization over probability distributions. The binary/Hamming case admits the closed form h(p) − h(D), so this entry can verify the curve's structural properties as facts about a single real function, deferring the mutual-information convexity argument (open question) that would derive the formula from first principles."
     ],
     "prerequisites": [
       "Mathlib's binary entropy Real.binEntropy and its lemmas (binEntropy_zero, binEntropy_nonneg, binEntropy_le_log_two)",
@@ -70,6 +71,14 @@
     ]
   },
   "sections": [
+    {
+      "id": "overview-and-scope",
+      "title": "Overview: Discharging Open Question #3",
+      "startLine": 1,
+      "endLine": 39,
+      "mathContext": "$R(D) = h(p) - h(D)$ for $0 \\le D \\le \\min(p, 1-p)$; regime $0 \\le D \\le p \\le \\tfrac12$.",
+      "summary": "The docstring states the goal — turn the parent's commented binary rate–distortion formula into a concrete verified object on Mathlib's Real.binEntropy — fixes the working regime 0 ≤ D ≤ p ≤ 1/2, and notes base-independence (entropy in nats) and the symmetry h(1−p) = h(p) covering p ≥ 1/2."
+    },
     {
       "id": "definition-and-endpoints",
       "title": "Definition and Endpoint Values",


### PR DESCRIPTION
Enrichment pass for `shannon-source-coding-oq-01-oq-03` (passes: 0, quality: 45).

## What was missing
The entry had a strong `meta.json` but only **2 coarse annotations**, each spanning a large line range and lacking `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Changes
- **Rebuilt `annotations.json`** — 2 → **6 per-theorem annotations**, each fully fielded (mathContext in LaTeX, significance, relatedConcepts, prerequisites), covering: the docstring/scope, the `rateDistortion` definition, the two endpoints, nonnegativity, antitone-in-D, and the two upper bounds.
- **Added an overview `section`** for the docstring header (lines 1–39).
- **Added a 4th `keyInsight`** contrasting the closed form `h(p) − h(D)` with the variational definition `R(D) = inf I(X;X̂)`.

## Verification
- `meta.json` within all size caps; JSON validated; `pnpm build` passes.
- No claims altered: `status: verified`, `badge: original`, `axiomCount: 0` all match the 90-line Lean source (0 axioms, 0 sorries, no native_decide).