### PR TITLE
audit: confirm puiseux-theorem-oq-03 + amgm-inequality-oq-03-oq-03-oq-02 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24925,6 +24925,12 @@
       "lastAudited": "2026-06-27T05:58:19Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-03-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T06:10:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Audit Results: 2× CLEAN ✅

Both never-audited gallery entries verified against their Lean sources. No issues found; tracker updated (`auditCount`, result `clean`).

### 1. puiseux-theorem-oq-03 — *The Newton Polygon as Combinatorial Data* (Tier D / infrastructure)

| Check | meta | source | ✓ |
|-------|------|--------|---|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 axiom, 0 native_decide | ✅ |
| theorems / defs | 6 / 6 | 6 / 6 | ✅ |
| lineCount | 228 | 228 | ✅ |

- Badge `infrastructure` correct — combinatorial Newton-polygon primitives + structural facts, not a proof of Puiseux's theorem.
- Title qualified ("OQ-03: Newton Polygon as Combinatorial Data"); no overclaim of Wiedijk #41.
- `assumptions` field meticulously scopes out S2-B / S2-C; `binomial_root_valuation` acknowledged as a worked Mathlib-HahnSeries instance.

### 2. amgm-inequality-oq-03-oq-03-oq-02 — *AM–GM–HM Chain at r = −1, 0, 1* (Tier A / original)

| Check | meta | source | ✓ |
|-------|------|--------|---|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 axiom, 0 native_decide | ✅ |
| theorems / defs | 7 / 1 | 7 / 1 | ✅ |
| lineCount | 131 | 131 | ✅ |

- Badge `original` correct — `powerMean` defined locally; HM≤GM≤AM proved by independent `(a-b)²≥0` reductions, not delegated to a Mathlib power-mean monotonicity theorem.
- Title correctly scoped ("at r = −1, 0, 1", "two positive reals"); no overclaim of general monotonicity.

None of the five narrative failure modes apply to either entry.

---
Discovered during gallery integrity audit.