### PR TITLE
Audit: fix stale counts in erdos-95 meta.json (sorries 2→0)

### DIFF
--- a/src/data/proofs/erdos-95/meta.json
+++ b/src/data/proofs/erdos-95/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "dateAdded": "2026-01-24",
     "mathlib_version": "4.26.0",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 95,
     "erdosUrl": "https://erdosproblems.com/95",
     "erdosProblemStatus": "solved",
@@ -49,21 +49,21 @@
       "sumSquaredMultiplicities: the sum ∑f(d)²",
       "ErdosConjecture: formal ∀ε>0, ∑f(d)² ≤ C·n^{3+ε}",
       "guth_katz_theorem: ∑f(d)² ≤ C·n³·log(n) axiom",
-      "erdos_conjecture_proved: derives conjecture from Guth-Katz (1 sorry)",
+      "erdos_conjecture_proved: derives conjecture from Guth-Katz (complete proof)",
       "convex_polygon_case: Fishburn/Altman axiom",
       "erdos_95: combined main theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 184,
-    "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details.",
-    "theoremCount": 3,
+    "lineCount": 250,
+    "assumptions": "2 axiom(s) (guth_katz_theorem, convex_polygon_case) and 0 sorry(s). See the Lean source for details.",
+    "theoremCount": 4,
     "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #95: Sum of Squared Distance Multiplicities**\n\nThis problem is part of Erdős's famous family of distinct distances problems, which he began studying in the 1940s. While Problem #94 asks for the minimum number of distinct distances among $n$ points in the plane, this companion problem asks about the *distribution* of distance multiplicities.\n\n**Historical Timeline:**\n- 1946: Erdős proved the lower bound $\\Omega(n^{1/2})$ for distinct distances and conjectured $\\Omega(n/\\sqrt{\\log n})$\n- 1963: Altman proved the convex polygon case: $O(n)$ distinct distances, each with multiplicity $O(n)$\n- 1983: Chung computed extremal configurations for small $n$ and established the lattice as near-extremal\n- 2001: Solymosi and Tóth improved the distinct distances lower bound to $\\Omega(n^{4/5})$\n- 2010: Elekes and Sharir developed the framework reducing distance problems to 3D incidence problems\n- 2015: Guth and Katz proved $\\sum f(d)^2 \\ll n^3 \\log n$ AND the distinct distances conjecture $\\Omega(n/\\log n)$ in the same landmark *Annals of Mathematics* paper\n\n**Why the Lattice is Extremal:** For the $\\sqrt{n} \\times \\sqrt{n}$ integer lattice, a distance $d$ occurs $f(d) \\sim \\frac{n}{\\sqrt{\\log n}} \\cdot r_2(d^2)$ times on average, where $r_2(m)$ is the number of representations of $m$ as a sum of two squares. Since $\\sum_{m \\le x} r_2(m)^2 \\sim cx \\log x$ (Ramanujan), we get $\\sum f(d)^2 = \\Theta(n^3 \\log n)$.\n\n**The Polynomial Revolution:** The Guth-Katz paper introduced polynomial partitioning to combinatorial geometry, spawning an entirely new research program. The technique has since been applied to problems in incidence geometry, harmonic analysis, and theoretical computer science.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $x_1, \\ldots, x_n \\in \\mathbb{R}^2$ determine distances $\\{u_1, \\ldots, u_t\\}$. If distance $u_i$ occurs between $f(u_i)$ pairs of points, prove:\n$$\\sum_{i=1}^{t} f(u_i)^2 \\ll_\\varepsilon n^{3+\\varepsilon} \\quad \\text{for all } \\varepsilon > 0$$\n\n**Answer: YES** (Guth-Katz 2015)\n\nThey proved the stronger bound $\\sum f(u_i)^2 \\ll n^3 \\log n$, removing the $\\varepsilon$ and replacing $n^\\varepsilon$ with $\\log n$. Prize: \\$500.",
     "text": "For n points in ℝ² with distance multiplicities f(uᵢ), prove ∑f(uᵢ)² ≪ n^{3+ε}. Solved by Guth and Katz (2015) with the stronger bound n³ log n, as part of their landmark distinct distances paper.",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Euclidean Setup:** `Point := EuclideanSpace ℝ (Fin 2)` with `dist p q := ‖p - q‖` and `PointConfig` structure\n2. **Distance Framework:** `distanceSet P` via `Finset.image` on the Cartesian product, `multiplicity P d` via `Finset.filter`\n3. **Target Quantity:** `sumSquaredMultiplicities P` computing $\\sum_d f(d)^2$ via `Finset.sum`\n4. **Conjecture:** `ErdosConjecture` as $\\forall \\varepsilon > 0, \\exists C > 0, \\forall P, \\sum f(d)^2 \\le C \\cdot n^{3+\\varepsilon}$\n5. **Guth-Katz:** `guth_katz_theorem` axiom giving $C \\cdot n^3 \\log n$ bound\n6. **Derivation:** `erdos_conjecture_proved` using $\\log n = o(n^\\varepsilon)$ (sorry)\n7. **Special Case:** `convex_polygon_case` axiom (Fishburn/Altman, $O(n^3)$ without log)\n8. **Main Result:** `erdos_95` combining conjecture and Guth-Katz as conjunction",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Euclidean Setup:** `Point := EuclideanSpace ℝ (Fin 2)` with `dist p q := ‖p - q‖` and `PointConfig` structure\n2. **Distance Framework:** `distanceSet P` via `Finset.image` on the Cartesian product, `multiplicity P d` via `Finset.filter`\n3. **Target Quantity:** `sumSquaredMultiplicities P` computing $\\sum_d f(d)^2$ via `Finset.sum`\n4. **Conjecture:** `ErdosConjecture` as $\\forall \\varepsilon > 0, \\exists C > 0, \\forall P, \\sum f(d)^2 \\le C \\cdot n^{3+\\varepsilon}$\n5. **Guth-Katz:** `guth_katz_theorem` axiom giving $C \\cdot n^3 \\log n$ bound\n6. **Derivation:** `erdos_conjecture_proved` using $\\log n = o(n^\\varepsilon)$, fully proved via the helper lemma `eps_log_le_rpow`\n7. **Special Case:** `convex_polygon_case` axiom (Fishburn/Altman, $O(n^3)$ without log)\n8. **Main Result:** `erdos_95` combining conjecture and Guth-Katz as conjunction",
     "keyInsights": [
       "**Cauchy-Schwarz duality**: By Cauchy-Schwarz, $\\sum f(d)^2 \\ge (\\sum f(d))^2 / t = n^2(n-1)^2/t$ where $t = |\\Delta(P)|$. So an upper bound on $\\sum f(d)^2$ gives a lower bound on distinct distances $t$. The Guth-Katz bound $n^3 \\log n$ recovers $t \\ge \\Omega(n/\\log n)$",
       "**Lattice optimality**: The $\\sqrt{n} \\times \\sqrt{n}$ integer lattice achieves $\\sum f(d)^2 = \\Theta(n^3 \\log n)$, making the Guth-Katz bound **tight** up to the constant. The $\\log n$ factor comes from $\\sum r_2(m)^2 \\sim cm \\log m$ (Ramanujan), where $r_2(m)$ counts representations as sums of two squares",
@@ -98,8 +98,8 @@
       "title": "The Sum of Squared Multiplicities",
       "startLine": 62,
       "endLine": 74,
-      "summary": "States `sum_multiplicities` (sorry): $\\sum_d f(d) = n(n-1)$. Defines `sumSquaredMultiplicities P := \\sum_d f(d)^2$ via `Finset.sum`.",
-      "mathContext": "Formal definition: States `sum_multiplicities` (sorry): $\\sum_d f(d) = n(n-1)$. Defines `sumSquaredMultiplicities P := \\sum_d f(d)^2$ via `Finset.sum`."
+      "summary": "Proves `sum_multiplicities`: $\\sum_d f(d) = n(n-1)$ (via fiberwise counting over the off-diagonal). Defines `sumSquaredMultiplicities P := \\sum_d f(d)^2$ via `Finset.sum`.",
+      "mathContext": "Formal definition: Proves `sum_multiplicities`: $\\sum_d f(d) = n(n-1)$ (via fiberwise counting over the off-diagonal). Defines `sumSquaredMultiplicities P := \\sum_d f(d)^2$ via `Finset.sum`."
     },
     {
       "id": "erdos-conjecture",
@@ -114,8 +114,8 @@
       "title": "Guth-Katz Theorem (2015)",
       "startLine": 87,
       "endLine": 113,
-      "summary": "Axiomatizes `guth_katz_theorem`: $\\sum f(d)^2 \\le C \\cdot n^3 \\log n$. Derives `erdos_conjecture_proved` from it (1 sorry for $\\log n = o(n^\\varepsilon)$).",
-      "mathContext": "Axiomatizes `guth_katz_theorem`: $\\sum f(d)^2 \\le C \\cdot $n^{3}$ \\$\\log n$$. Derives `erdos_conjecture_proved` from it (1 sorry for $\\$\\log n$ = o(n^\\varepsilon)$)."
+      "summary": "Axiomatizes `guth_katz_theorem`: $\\sum f(d)^2 \\le C \\cdot n^3 \\log n$. Derives `erdos_conjecture_proved` from it (complete proof; $\\log n = o(n^\\varepsilon)$ handled by the helper lemma `eps_log_le_rpow`).",
+      "mathContext": "Axiomatizes `guth_katz_theorem`: $\\sum f(d)^2 \\le C \\cdot $n^{3}$ \\$\\log n$$. Derives `erdos_conjecture_proved` from it (complete proof; $\\$\\log n$ = o(n^\\varepsilon)$ handled by `eps_log_le_rpow`)."
     },
     {
       "id": "polynomial-method",
@@ -143,7 +143,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #95 on the sum of squared distance multiplicities. Guth and Katz (2015) proved ∑f(d)² ≪ n³ log n, strictly stronger than the conjectured n^{3+ε}. The formalization defines the Euclidean plane setup (Point, PointConfig, distanceSet, multiplicity), the target quantity (sumSquaredMultiplicities), Erdős's conjecture, the Guth-Katz axiom, the derivation (1 sorry for log n = o(n^ε)), the convex special case (Fishburn/Altman axiom), and the combined main theorem. 2 sorries. $500 prize collected.",
+    "summary": "The formalization captures Erdős Problem #95 on the sum of squared distance multiplicities. Guth and Katz (2015) proved ∑f(d)² ≪ n³ log n, strictly stronger than the conjectured n^{3+ε}. The formalization defines the Euclidean plane setup (Point, PointConfig, distanceSet, multiplicity), the target quantity (sumSquaredMultiplicities), Erdős's conjecture, the Guth-Katz axiom, the derivation (complete proof; log n = o(n^ε) via the helper lemma eps_log_le_rpow), the convex special case (Fishburn/Altman axiom), and the combined main theorem. 0 sorries; 2 axioms (guth_katz_theorem, convex_polygon_case). $500 prize collected.",
     "implications": "**Theoretical Significance**: **Connections to Combinatorial Geometry**\n\n1. **Distinct Distances**: The Cauchy-Schwarz duality links ∑f(d)² to the distinct distances count — the Guth-Katz bound recovers Ω(n/log n) distinct distances\n2. **Polynomial Method**: Established polynomial partitioning as a fundamental tool in combinatorics, spawning results in incidence geometry, harmonic analysis, and CS theory\n**3. Elekes-Sharir Framework**: The reduction from distances to 3D incidences created a new paradigm for attacking geometric combinatorics problems\n4. **Algebraic Geometry in Combinatorics**: Showed that deep algebraic tools (ruled surfaces, Bezout's theorem) can resolve hard combinatorial problems\n5. **Higher Dimensions**: The techniques extend to higher-dimensional distance problems, though optimal bounds remain open in ℝ³ and beyond.",
     "openQuestions": [
       "Is the $\\log n$ factor in the Guth-Katz bound necessary, or can it be removed for non-lattice configurations?",
@@ -163,12 +163,12 @@
       "Finset"
     ],
     "namespace": "Erdos95",
-    "lineCount": 184,
+    "lineCount": 250,
     "axiomCount": 2,
-    "theoremCount": 3,
+    "theoremCount": 4,
     "definitionCount": 9,
     "path": "Proofs/Erdos95Problem.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -215,5 +215,5 @@
       "note": "Improved bounds on distinct distances using crossing number inequality"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-95

Audited `erdos-95` (Erdős Problem #95: Sum of Squared Distance Multiplicities). The meta.json was **stale** relative to the Lean source `Proofs/Erdos95Problem.lean`: both previously-`sorry`'d theorems now carry complete proofs.

### Evidence

`grep sorry Proofs/Erdos95Problem.lean` → **NONE**. The two formerly-incomplete theorems are fully proved:
- `sum_multiplicities` — proved via fiberwise counting over the off-diagonal (`Finset.card_eq_sum_card_fiberwise`)
- `erdos_conjecture_proved` — proved via new helper lemma `eps_log_le_rpow` (`ε·log x ≤ x^ε`)

### Fixes (meta block + leanFile block + trailing duplicates)

| Field | Was | Now |
|-------|-----|-----|
| `sorries` | 2 | 0 |
| `theoremCount` | 3 | 4 |
| `lineCount` | 184 | 250 |

Also removed stale `(sorry)` / `2 sorries` prose from `assumptions`, `proofStrategy`, two section summaries, and the conclusion.

### Status unchanged — correctly axiomatized

`status: "axiomatized"` / `badge: "axiom"` stay as-is. Two genuine axioms remain and are correctly disclosed:
- `guth_katz_theorem` (the deep 2015 result, intentionally axiomatized)
- `convex_polygon_case` (Fishburn/Altman)

`axiomCount: 2` already matched. **No overclaim** — the mismatch *understated* completeness, so this is a low-severity accuracy cleanup.

---
Discovered during gallery integrity audit.