### PR TITLE
research(erdos-ko-rado-oq-03): EKR uniqueness needs strict n > 2k — boundary counterexample

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2892,6 +2892,7 @@ import Proofs.ErdosGinzburgZivOQ01
 import Proofs.ErdosGinzburgZivOQ01OQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosKoRadoOQ02
+import Proofs.ErdosKoRadoOQ03
 import Proofs.ErdosMordellChordIdentity
 import Proofs.ErdosMordellChordReduction
 import Proofs.ErdosMordellFeetAngleAristotle

--- a/proofs/Proofs/ErdosKoRadoOQ03.lean
+++ b/proofs/Proofs/ErdosKoRadoOQ03.lean
@@ -1,0 +1,158 @@
+/-
+# Erdős–Ko–Rado, OQ-03: the n = 2k boundary — why the star characterization needs strict n > 2k
+
+The Erdős–Ko–Rado theorem has two halves. The **bound** says an intersecting
+family of `k`-subsets of `Fin n` with `n ≥ 2k` has at most `C(n-1, k-1)` members;
+the **uniqueness** (or *star characterization*) says that, **when `n > 2k`**, the
+only families attaining that bound are the *stars* — all `k`-sets through a fixed
+point.
+
+The gallery already covers the bound:
+* `ErdosKoRadoOQ01` proves Katona's cyclic-interval lemma (at most `k` pairwise
+  intersecting arcs), axiom-free;
+* `ErdosKoRadoOQ02` discharges the upper bound `|A| ≤ C(n-1, k-1)` via Mathlib's
+  Kruskal–Katona route (`Finset.erdos_ko_rado`) and shows the star **attains** it
+  (`IsGreatest`).
+
+What remains for OQ-03 is the *converse* extremal statement: that the maximizer is
+**unique** (a star) for `n > 2k`. Mathlib does not have this — the Kruskal–Katona
+file lists "Characterise the equality case" as an explicit TODO — and a full Lean
+proof of EKR uniqueness is a substantial project (it is strictly harder than the
+bound, and at `n = 2k` it is simply *false*).
+
+This entry pins down the part of OQ-03 that is both **sharp and provable**: the
+**necessity of the strict inequality `n > 2k`**. We exhibit, at the boundary
+`n = 2k` (concretely `n = 4`, `k = 2`), an intersecting family that
+
+  1. attains the EKR maximum `C(n-1, k-1) = 3`, yet
+  2. is **not a star** — it has no common element, so it differs from every
+     `Star x`.
+
+Hence at `n = 2k` the maximizer is *not* unique: the "triangle" `{01, 12, 02}` and
+the star `Star 0 = {01, 02, 03}` are two distinct maximum intersecting families.
+This is exactly why the uniqueness half of EKR carries the *strict* hypothesis
+`n > 2k`, and it bounds what any future formalization of the full characterization
+can claim. The general `n > 2k` uniqueness is recorded as the remaining open target.
+
+## Results (0 sorries, 0 axioms — fully proved)
+The EKR bound is re-derived from Mathlib (`Finset.erdos_ko_rado`, as in OQ-02);
+the boundary counterexample is verified by `decide` over `Fin 4`.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace ErdosKoRadoOQ03
+
+/- ## Definitions (verbatim from the parent / OQ-02 entries) -/
+
+/-- A family of `k`-sets is intersecting if every two members share an element. -/
+def IsIntersectingFamily {n : ℕ} (A : Finset (Finset (Fin n))) (k : ℕ) : Prop :=
+  (∀ s ∈ A, s.card = k) ∧
+  ∀ s t, s ∈ A → t ∈ A → (s ∩ t).Nonempty
+
+/-- The star centered at `x`: all `k`-subsets of `Fin n` containing `x`. -/
+def Star {n : ℕ} (x : Fin n) (k : ℕ) : Finset (Finset (Fin n)) :=
+  (powersetCard k (univ : Finset (Fin n))).filter (fun s => x ∈ s)
+
+/-- Every member of a star contains its center. -/
+theorem mem_Star_imp_mem {n k : ℕ} {x : Fin n} {s : Finset (Fin n)}
+    (hs : s ∈ Star x k) : x ∈ s := by
+  rw [Star, mem_filter] at hs
+  exact hs.2
+
+-- ============================================================
+-- PART I: The EKR upper bound (de-axiomatized, as in OQ-02)
+-- ============================================================
+
+/-- **The Erdős–Ko–Rado upper bound.** For an intersecting family of `k`-sets in
+`Fin n` with `n ≥ 2k`, `|A| ≤ C(n-1, k-1)`.  Bridges the bespoke predicate to
+Mathlib's `Set.Intersecting` / `Set.Sized` and invokes `Finset.erdos_ko_rado`.
+No cyclic intervals, no axioms. -/
+theorem ekr_bound {n k : ℕ} (hn : n ≥ 2 * k)
+    (A : Finset (Finset (Fin n))) (hA : IsIntersectingFamily A k) :
+    A.card ≤ (n - 1).choose (k - 1) := by
+  have hsized : (A : Set (Finset (Fin n))).Sized k := fun s hs => hA.1 s (mem_coe.mp hs)
+  have hinter : (A : Set (Finset (Fin n))).Intersecting := by
+    intro s hs t ht
+    rw [Finset.not_disjoint_iff_nonempty_inter]
+    exact hA.2 s t (mem_coe.mp hs) (mem_coe.mp ht)
+  have hle : k ≤ n / 2 := by
+    rw [Nat.le_div_iff_mul_le (by norm_num)]
+    omega
+  exact Finset.erdos_ko_rado hinter hsized hle
+
+-- ============================================================
+-- PART II: The boundary counterexample at n = 4 = 2·2
+-- ============================================================
+
+/-- The "triangle" family of `2`-subsets of `Fin 4`: `{0,1}`, `{1,2}`, `{0,2}`.
+Every two of these share a vertex, but the three share no common vertex. -/
+def triangle : Finset (Finset (Fin 4)) := {{0, 1}, {1, 2}, {0, 2}}
+
+/-- The triangle is an intersecting family of `2`-sets. -/
+theorem triangle_intersecting : IsIntersectingFamily triangle 2 := by
+  unfold IsIntersectingFamily; decide
+
+/-- The triangle has three members. -/
+theorem triangle_card : triangle.card = 3 := by decide
+
+/-- The EKR maximum value at `n = 4`, `k = 2` is `C(3,1) = 3`. -/
+theorem ekr_value : (4 - 1).choose (2 - 1) = 3 := by decide
+
+/-- **The triangle attains the EKR maximum at the boundary `n = 2k = 4`.**
+Its size equals the bound `C(3,1) = 3`, and (by `ekr_bound`, valid since
+`4 ≥ 2·2`) no intersecting family of `2`-sets in `Fin 4` is larger. -/
+theorem triangle_is_maximum :
+    triangle.card = (4 - 1).choose (2 - 1) ∧
+      ∀ A : Finset (Finset (Fin 4)), IsIntersectingFamily A 2 →
+        A.card ≤ triangle.card := by
+  refine ⟨by decide, fun A hA => ?_⟩
+  rw [triangle_card]
+  have h := ekr_bound (n := 4) (k := 2) (by norm_num) A hA
+  rw [ekr_value] at h
+  exact h
+
+/-- The triangle has no common element. -/
+theorem triangle_no_common : ¬ ∃ x : Fin 4, ∀ s ∈ triangle, x ∈ s := by decide
+
+/-- **The triangle is not a star.** It differs from `Star x` for every center `x`,
+because a star's members all share the center while the triangle's do not. -/
+theorem triangle_ne_star : ∀ x : Fin 4, triangle ≠ Star x 2 := by
+  intro x h
+  exact triangle_no_common ⟨x, fun s hs => mem_Star_imp_mem (h ▸ hs)⟩
+
+-- ============================================================
+-- PART III: Non-uniqueness at n = 2k
+-- ============================================================
+
+/-- The star `Star 0` at `n = 4`, `k = 2` also has three members, so it too is a
+maximum intersecting family — a *distinct* maximizer from the triangle. -/
+theorem star_zero_card : (Star (0 : Fin 4) 2).card = 3 := by decide
+
+/-- The star `Star 0` is intersecting (every member contains `0`). -/
+theorem star_zero_intersecting : IsIntersectingFamily (Star (0 : Fin 4) 2) 2 := by
+  unfold IsIntersectingFamily; decide
+
+/-- **Main theorem — EKR uniqueness fails at `n = 2k`.**
+At the boundary `n = 2k = 4`, `k = 2`, the triangle is a maximum intersecting
+family of `2`-sets (it attains the bound `C(3,1) = 3`) that is **not a star**.
+Together with the genuine star `Star 0` (also a size-`3` maximizer), this gives
+two distinct maximizers, so the EKR maximizer is *not* unique when `n = 2k`.
+This is precisely why the star-characterization half of Erdős–Ko–Rado (OQ-03)
+requires the **strict** inequality `n > 2k`. -/
+theorem ekr_uniqueness_fails_at_2k :
+    -- the triangle is a maximum intersecting family ...
+    IsIntersectingFamily triangle 2 ∧
+      triangle.card = (4 - 1).choose (2 - 1) ∧
+      -- ... that is not any star ...
+      (∀ x : Fin 4, triangle ≠ Star x 2) ∧
+      -- ... while a genuine star is a distinct maximizer of the same size.
+      IsIntersectingFamily (Star (0 : Fin 4) 2) 2 ∧
+      (Star (0 : Fin 4) 2).card = 3 ∧
+      triangle ≠ Star (0 : Fin 4) 2 :=
+  ⟨triangle_intersecting, by decide, triangle_ne_star, star_zero_intersecting,
+    star_zero_card, triangle_ne_star 0⟩
+
+end ErdosKoRadoOQ03

--- a/src/data/proofs/erdos-ko-rado-oq-03/annotations.json
+++ b/src/data/proofs/erdos-ko-rado-oq-03/annotations.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "erdos-ko-rado-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "The Uniqueness Half of EKR and the Role of Strict n > 2k",
+    "content": "Erdős–Ko–Rado has two halves: the bound (|A| ≤ C(n-1,k-1) for an intersecting family of k-sets with n ≥ 2k) and the uniqueness/star characterization (for n > 2k, equality forces A to be a star). The gallery already covers the bound — OQ-01 proves Katona's cyclic-interval lemma, OQ-02 discharges the bound via Mathlib's Kruskal–Katona route and shows the star attains it. What remains is uniqueness, which Mathlib does not have (its Kruskal–Katona file lists 'Characterise the equality case' as a TODO) and which is FALSE at n = 2k. This entry isolates the sharp, provable core: the necessity of the strict inequality. It reproduces the parent's `IsIntersectingFamily` and `Star` predicates and the basic fact `mem_Star_imp_mem` (a star's members all contain its center).",
+    "mathContext": "Star x = \\{ S \\in \\binom{[n]}{k} : x \\in S \\}; \\quad \\text{uniqueness: } |A| = \\binom{n-1}{k-1} \\wedge n > 2k \\Rightarrow A = \\text{Star } x",
+    "significance": "key",
+    "relatedConcepts": [
+      "intersecting families",
+      "star characterization",
+      "Erdős–Ko–Rado uniqueness",
+      "Kruskal–Katona equality case"
+    ],
+    "prerequisites": [
+      "Erdős–Ko–Rado bound",
+      "stars as canonical maximizers",
+      "finite set families in Lean"
+    ]
+  },
+  {
+    "id": "ann-ekr-bound",
+    "proofId": "erdos-ko-rado-oq-03",
+    "range": {
+      "startLine": 65,
+      "endLine": 84
+    },
+    "type": "proof-technique",
+    "title": "Re-deriving the EKR Bound Axiom-Free",
+    "content": "`ekr_bound` re-establishes |A| ≤ C(n-1,k-1) for the bespoke `IsIntersectingFamily` predicate, exactly as OQ-02 does: it bridges the predicate to Mathlib's `Set.Sized k` and `Set.Intersecting` (the latter via `not_disjoint_iff_nonempty_inter`), checks the side condition `k ≤ n/2` from `2k ≤ n` with `omega`, and invokes `Finset.erdos_ko_rado` (proved through the Kruskal–Katona shadow inequality). No cyclic intervals, no axioms. Here its purpose is to CERTIFY MAXIMALITY of the counterexample: combined with the explicit cardinality, it shows the triangle is a true maximizer, not merely a large family.",
+    "mathContext": "n \\ge 2k \\Rightarrow |A| \\le \\binom{n-1}{k-1}, \\text{ via } \\texttt{Finset.erdos\\_ko\\_rado}",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.erdos_ko_rado",
+      "Set.Intersecting",
+      "Set.Sized",
+      "Kruskal–Katona"
+    ],
+    "prerequisites": [
+      "Mathlib's EKR theorem",
+      "predicate bridging",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-triangle-def",
+    "proofId": "erdos-ko-rado-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 99
+    },
+    "type": "definition",
+    "title": "The Triangle: a Non-Star Maximizer at n = 4",
+    "content": "The counterexample lives at the smallest boundary case n = 4 = 2·2, k = 2. The `triangle` family `{0,1}, {1,2}, {0,2}` consists of three edges of Fin 4 forming a triangle on vertices {0,1,2}. `triangle_intersecting` (by `decide`, after unfolding the predicate so Lean can synthesize decidability) verifies every two edges share a vertex, and `triangle_card` confirms |triangle| = 3. The choice of n = 4 is forced: it is the smallest n with a non-star maximum intersecting family, and it makes every check a finite `decide` over the 16 subsets of Fin 4.",
+    "mathContext": "\\text{triangle} = \\{\\{0,1\\}, \\{1,2\\}, \\{0,2\\}\\}, \\quad |\\text{triangle}| = 3",
+    "significance": "key",
+    "relatedConcepts": [
+      "triangle graph",
+      "intersecting family",
+      "decide over Fin n"
+    ],
+    "prerequisites": [
+      "Finset literals over Fin 4",
+      "decidable propositions"
+    ]
+  },
+  {
+    "id": "ann-triangle-max",
+    "proofId": "erdos-ko-rado-oq-03",
+    "range": {
+      "startLine": 102,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "The Triangle Attains the EKR Maximum",
+    "content": "`ekr_value` records C(3,1) = 3, and `triangle_is_maximum` shows the triangle is genuinely a maximum: its card equals the bound, and (via `ekr_bound` with n = 4 ≥ 2·2 = 4, valid at equality) every intersecting family of 2-sets in Fin 4 has at most 3 members. This is the crux that makes the counterexample meaningful — without certified maximality, a non-star intersecting family says nothing about uniqueness of MAXIMIZERS. Note n = 2k is the largest n for which the bound's hypothesis n ≥ 2k still holds at the boundary, and exactly where uniqueness breaks.",
+    "mathContext": "|\\text{triangle}| = \\binom{3}{1} = 3 = \\max \\{ |A| : A \\text{ intersecting 2-family in } \\mathrm{Fin}\\,4 \\}",
+    "significance": "key",
+    "relatedConcepts": [
+      "extremal maximizer",
+      "EKR bound at the boundary",
+      "binomial coefficient"
+    ],
+    "prerequisites": [
+      "ekr_bound",
+      "Nat.choose evaluation"
+    ]
+  },
+  {
+    "id": "ann-not-star",
+    "proofId": "erdos-ko-rado-oq-03",
+    "range": {
+      "startLine": 118,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "The Triangle Is Not a Star — for Every Center",
+    "content": "`triangle_no_common` (by `decide`) establishes that no vertex of Fin 4 lies in all three edges: 0 ∉ {1,2}, 1 ∉ {0,2}, 2 ∉ {0,1}, and 3 is in none. `triangle_ne_star` upgrades this structurally to `triangle ≠ Star x` for EVERY center x: if the triangle equaled Star x, then by `mem_Star_imp_mem` every edge would contain x, contradicting the no-common-element fact. Proving it for all x at once (rather than checking each star) is what makes 'not a star' a clean, general statement.",
+    "mathContext": "\\neg \\exists x,\\ \\forall S \\in \\text{triangle},\\ x \\in S \\quad\\Rightarrow\\quad \\forall x,\\ \\text{triangle} \\ne \\text{Star } x",
+    "significance": "key",
+    "relatedConcepts": [
+      "star characterization",
+      "common element",
+      "structural disproof"
+    ],
+    "prerequisites": [
+      "mem_Star_imp_mem",
+      "decide"
+    ]
+  },
+  {
+    "id": "ann-non-uniqueness",
+    "proofId": "erdos-ko-rado-oq-03",
+    "range": {
+      "startLine": 126,
+      "endLine": 158
+    },
+    "type": "insight",
+    "title": "Non-Uniqueness at n = 2k — the Main Result",
+    "content": "`star_zero_card` and `star_zero_intersecting` show the genuine star `Star 0` is also a size-3 intersecting family. The main theorem `ekr_uniqueness_fails_at_2k` bundles the witnesses: the triangle is a maximum intersecting family that is not a star, and Star 0 is a distinct maximizer of the same size. Two distinct maximizers at n = 2k means the EKR maximizer is not unique there, so the star-characterization half of EKR genuinely requires the STRICT inequality n > 2k. The general mechanism is complementation: for n = 2k, S and Sᶜ are disjoint k-sets, so an intersecting family takes at most one of each complementary pair; the many non-star selections (of which the triangle is the smallest) all attain the maximum.",
+    "mathContext": "\\text{triangle} \\ne \\text{Star } 0, \\quad |\\text{triangle}| = |\\text{Star } 0| = 3 = \\binom{n-1}{k-1} \\text{ at } n = 2k = 4",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness failure",
+      "complementary pairs",
+      "Hilton–Milner",
+      "strict hypothesis necessity"
+    ],
+    "prerequisites": [
+      "triangle_is_maximum",
+      "triangle_ne_star",
+      "star cardinality"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-ko-rado-oq-03/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-03/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "erdos-ko-rado-oq-03",
+  "title": "Erdős–Ko–Rado Uniqueness: Why the Star Characterization Needs Strict n > 2k",
+  "slug": "erdos-ko-rado-oq-03",
+  "description": "The uniqueness half of Erdős–Ko–Rado says that for n > 2k the only maximum intersecting families of k-sets are the stars. This entry pins down the sharp, provable core of that statement: the necessity of the strict inequality. At the boundary n = 2k (concretely n = 4, k = 2) it exhibits a verified non-star maximizer — the triangle {01, 12, 02} — that attains the EKR bound C(n-1,k-1) = 3 yet has no common element, alongside the genuine star Star 0 of the same size. So at n = 2k the maximizer is not unique, which is exactly why the star characterization carries the strict hypothesis n > 2k. Fully verified: 11 theorems, 3 defs, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Erdős, Ko, Rado (1961); Hilton–Milner (1967); formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Ko%E2%80%93Rado_theorem",
+    "date": "1961",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosKoRadoOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "erdos",
+      "extremal-set-theory",
+      "intersecting-families",
+      "erdos-ko-rado",
+      "uniqueness"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-26",
+    "axiomCount": 0,
+    "lineCount": 158,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "originalContributions": [
+      "ekr_uniqueness_fails_at_2k: the main result — at the boundary n = 2k = 4 the triangle {01,12,02} is a maximum intersecting family of 2-sets that is not a star, while the star Star 0 is a distinct maximizer of the same size, so the EKR maximizer is NOT unique at n = 2k. This is the formal reason the star-characterization half of EKR (OQ-03's target) requires the strict inequality n > 2k.",
+      "triangle_is_maximum: the triangle attains the EKR bound C(3,1) = 3 and (via the de-axiomatized ekr_bound, valid since 4 ≥ 2·2) no intersecting family of 2-sets in Fin 4 is larger — so it is genuinely a maximum, not merely large.",
+      "triangle_ne_star: the triangle differs from Star x for EVERY center x, proved structurally from the fact that a star's members all share the center (mem_Star_imp_mem) while the triangle has no common element (triangle_no_common).",
+      "ekr_bound: the Erdős–Ko–Rado upper bound for the bespoke IsIntersectingFamily predicate, re-derived with zero axioms by bridging to Mathlib's Set.Intersecting / Set.Sized and invoking Finset.erdos_ko_rado (the same route as OQ-02), here used to certify maximality of the counterexample.",
+      "The finite checks (intersecting-ness, cardinality, no-common-element) use plain decide over Fin 4, so the entry remains axiom-free — no native_decide and hence no Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "Erdős–Ko–Rado theorem: an intersecting family of k-sets of an n-set with n ≥ 2k has at most C(n-1,k-1) members",
+      "The uniqueness/equality case of EKR (star characterization), which holds only for n > 2k",
+      "Mathlib's Finset.erdos_ko_rado (proved via the Kruskal–Katona shadow inequality)",
+      "Elementary Finset reasoning over Fin n and the decide tactic"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.erdos_ko_rado",
+        "description": "The Erdős–Ko–Rado theorem in Mathlib: an intersecting, r-sized family in Fin n with r ≤ n/2 has card ≤ (n-1).choose (r-1), proved via Kruskal–Katona. Its equality/uniqueness case is an explicit TODO in the Mathlib source.",
+        "module": "Mathlib.Combinatorics.SetFamily.KruskalKatona"
+      },
+      {
+        "theorem": "Finset.not_disjoint_iff_nonempty_inter",
+        "description": "¬Disjoint s t ↔ (s ∩ t).Nonempty — bridges the bespoke pairwise-intersection predicate to Mathlib's Set.Intersecting.",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Erdős–Ko–Rado theorem (proved 1938, published 1961) has two halves: a bound and a uniqueness statement. The bound says an intersecting family of k-subsets of an n-set with n ≥ 2k has at most C(n-1,k-1) members. The uniqueness (or star characterization) says that for n > 2k the only families attaining the bound are the stars — all k-sets through a fixed point. The strictness of n > 2k is essential: at n = 2k the bound is still attained, but by many non-star families (one chooses one set from each complementary pair {S, Sᶜ}), so uniqueness collapses. Hilton and Milner (1967) sharpened the picture by determining the largest intersecting family that is not a star. In the gallery, the EKR bound is already formalized: ErdosKoRadoOQ01 proves Katona's cyclic-interval lemma, and ErdosKoRadoOQ02 discharges the bound axiom-free via Mathlib's Kruskal–Katona route and shows the star attains it (IsGreatest). The remaining target for OQ-03 is the uniqueness half — which Mathlib does not have (its Kruskal–Katona file lists 'Characterise the equality case' as an open TODO) and which is false at n = 2k.",
+    "problemStatement": "Let A be an intersecting family of k-subsets of Fin n with n ≥ 2k. The EKR bound gives |A| ≤ C(n-1,k-1). The uniqueness conjecture (OQ-03) asks: for n > 2k, is every A attaining |A| = C(n-1,k-1) a star Star x (all k-sets containing some fixed x)? This entry addresses the sharpness of the hypothesis: it asks whether the strict inequality n > 2k can be weakened to n ≥ 2k, and answers no by constructing, at n = 2k, an intersecting family attaining the bound that is not a star.",
+    "proofStrategy": "The entry works in three parts. PART I re-derives the EKR upper bound `ekr_bound` for the bespoke `IsIntersectingFamily` predicate with zero axioms, bridging to Mathlib's `Set.Intersecting`/`Set.Sized` and invoking `Finset.erdos_ko_rado` — the same Kruskal–Katona route as OQ-02 — so that maximality of the counterexample can be certified. PART II constructs the boundary counterexample at n = 4 = 2·2: the triangle family `{0,1}, {1,2}, {0,2}` of 2-subsets of Fin 4. It is verified (by `decide`) to be intersecting and to have cardinality 3 = C(3,1), and `triangle_is_maximum` combines this with `ekr_bound` to show no intersecting family of 2-sets in Fin 4 is larger. `triangle_no_common` (`decide`) shows the triangle has no common element, and `triangle_ne_star` upgrades this structurally to `triangle ≠ Star x` for every center x (a star's members all contain its center). PART III records non-uniqueness: the star `Star 0` is also a size-3 intersecting family, giving two distinct maximizers, and the main theorem `ekr_uniqueness_fails_at_2k` bundles the witnesses. All finite checks use plain `decide` (not `native_decide`), keeping the entry axiom-free.",
+    "keyInsights": [
+      "EKR uniqueness requires n > 2k strictly: at the boundary n = 2k the bound C(n-1,k-1) is still attained, but by non-star families — so the strictness in the star characterization is not a technicality but a genuine necessity.",
+      "The smallest witness is n = 4, k = 2: the 'triangle' of edges {01, 12, 02} is pairwise intersecting (each pair shares a vertex) and has size 3 = C(3,1), the EKR maximum, yet no single vertex lies in all three edges — so it is not a star.",
+      "Maximality is certified, not assumed: ekr_bound (n ≥ 2k = 4 holds at equality) shows every intersecting family of 2-sets in Fin 4 has at most 3 members, so the triangle is a true maximizer rather than merely a large family.",
+      "Not-a-star is proved for every center at once: a star Star x has all members containing x (mem_Star_imp_mem), so the structural fact that the triangle has no common element rules out equality with Star x for all x simultaneously.",
+      "Plain decide keeps the entry axiom-free: the finite verifications over Fin 4 reduce in the kernel without native_decide, so no Lean.ofReduceBool is introduced — the result is fully verified.",
+      "At n = 2k the general mechanism behind non-uniqueness is complementation: |S| = |Sᶜ| = k and S ∩ Sᶜ = ∅, so an intersecting family takes at most one of each complementary pair; the C(2k,k)/2 = C(2k-1,k-1) pairs can be selected in many non-star ways, of which the triangle is the smallest instance."
+    ],
+    "prerequisites": [
+      "The Erdős–Ko–Rado bound and the notion of an intersecting family of k-sets",
+      "Stars: all k-sets through a fixed element, the canonical EKR maximizers",
+      "Mathlib's Finset.erdos_ko_rado and the Set.Intersecting / Set.Sized predicates",
+      "The decide tactic for finite decidable propositions over Fin n"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and Definitions",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Docstring positioning the entry as the sharp, provable core of OQ-03 (necessity of strict n > 2k). Reproduces the parent's `IsIntersectingFamily` and `Star` predicates verbatim, plus `mem_Star_imp_mem`: every member of a star contains its center."
+    },
+    {
+      "id": "ekr-bound",
+      "title": "PART I: The EKR Upper Bound, De-Axiomatized",
+      "startLine": 65,
+      "endLine": 84,
+      "summary": "`ekr_bound`: |A| ≤ C(n-1,k-1) for the bespoke predicate with n ≥ 2k, via the bridge to Mathlib's Set.Intersecting / Set.Sized and Finset.erdos_ko_rado. Zero axioms; reused to certify maximality of the counterexample."
+    },
+    {
+      "id": "counterexample",
+      "title": "PART II: The Boundary Counterexample at n = 4 = 2·2",
+      "startLine": 86,
+      "endLine": 124,
+      "summary": "Defines `triangle = {01, 12, 02}` of 2-subsets of Fin 4. `triangle_intersecting`, `triangle_card = 3`, `ekr_value = C(3,1) = 3` (all by decide); `triangle_is_maximum` certifies it attains the EKR max via ekr_bound. `triangle_no_common` and `triangle_ne_star` show it is not a star (for any center)."
+    },
+    {
+      "id": "non-uniqueness",
+      "title": "PART III: Non-Uniqueness at n = 2k",
+      "startLine": 126,
+      "endLine": 158,
+      "summary": "`star_zero_card = 3` and `star_zero_intersecting` exhibit the genuine star Star 0 as a distinct size-3 maximizer. `ekr_uniqueness_fails_at_2k` bundles the witnesses: a non-star maximizer and a star maximizer of equal size, so the EKR maximizer is not unique at n = 2k."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry isolates the part of the EKR uniqueness question (OQ-03) that is both sharp and fully provable: the necessity of the strict inequality n > 2k. At the boundary n = 2k = 4 it exhibits, with 0 sorries and 0 axioms (plain decide, no native_decide), a non-star intersecting family of 2-sets — the triangle {01,12,02} — that attains the EKR maximum C(3,1) = 3, alongside a genuine star Star 0 of the same size. Two distinct maximizers at n = 2k means the star characterization cannot hold with n ≥ 2k; the strict n > 2k is essential.",
+    "implications": "The result bounds what any future Lean formalization of the full EKR uniqueness can claim: the star characterization is a strictly-n > 2k phenomenon, and the boundary case must be excluded. It complements ErdosKoRadoOQ02's IsGreatest result (the star attains the maximum) by showing the converse — maximum implies star — fails precisely when n = 2k. More broadly it illustrates the Hilton–Milner landscape: away from a single star, intersecting families at n = 2k can still be maximum, a phenomenon driven by complementation that disappears for n > 2k.",
+    "openQuestions": [
+      "The full uniqueness: for n > 2k, is every intersecting family of k-sets attaining C(n-1,k-1) members a star? Mathlib lists 'Characterise the equality case' of Kruskal–Katona as an open TODO; a Lean proof would be a substantial new contribution.",
+      "Can the Hilton–Milner theorem (the maximum size of a non-star intersecting family for n > 2k, namely C(n-1,k-1) - C(n-k-1,k-1) + 1) be formalized, quantitatively separating stars from all other intersecting families?",
+      "Can the n = 2k non-uniqueness be characterized in general — i.e. count or describe all maximum intersecting families at the boundary (the 'one set per complementary pair' selections), of which the triangle is the n = 4 instance?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-ko-rado",
+      "relationship": "extends",
+      "description": "Parent Erdős–Ko–Rado entry. Its docstring lists 'Proves uniqueness (star characterization)' as unchecked; this entry addresses the uniqueness half by establishing the necessity of the strict hypothesis n > 2k."
+    },
+    {
+      "targetId": "erdos-ko-rado-oq-02",
+      "relationship": "extends",
+      "description": "OQ-02 proves the EKR bound axiom-free and that the star attains it (IsGreatest). This entry reuses the same ekr_bound route and supplies the converse-direction obstruction: at n = 2k the maximizer is not unique, so 'maximum ⟹ star' needs strict n > 2k."
+    },
+    {
+      "targetId": "erdos-ko-rado-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 proves Katona's cyclic-interval lemma (the combinatorial heart of the bound). This entry concerns the uniqueness half rather than the bound."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, P.; Ko, C.; Rado, R.",
+      "title": "Intersection theorems for systems of finite sets",
+      "year": "1961",
+      "venue": "Quarterly Journal of Mathematics 12 (1): 313–320"
+    },
+    {
+      "authors": "Hilton, A. J. W.; Milner, E. C.",
+      "title": "Some intersection theorems for systems of finite sets",
+      "year": "1967",
+      "venue": "Quarterly Journal of Mathematics 18 (1): 369–384"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "ekr_uniqueness_fails_at_2k",
+      "type": "core",
+      "description": "At n = 2k = 4, the triangle is a non-star maximum intersecting family of 2-sets and Star 0 is a distinct maximizer of equal size — so the EKR maximizer is not unique at n = 2k, requiring strict n > 2k for the star characterization",
+      "leanType": "IsIntersectingFamily triangle 2 ∧ triangle.card = (4-1).choose (2-1) ∧ (∀ x : Fin 4, triangle ≠ Star x 2) ∧ IsIntersectingFamily (Star 0 2) 2 ∧ (Star 0 2).card = 3 ∧ triangle ≠ Star 0 2"
+    },
+    {
+      "name": "triangle_is_maximum",
+      "type": "core",
+      "description": "The triangle attains the EKR bound C(3,1) = 3 and no intersecting family of 2-sets in Fin 4 is larger (via the de-axiomatized ekr_bound)",
+      "leanType": "triangle.card = (4-1).choose (2-1) ∧ ∀ A, IsIntersectingFamily A 2 → A.card ≤ triangle.card"
+    },
+    {
+      "name": "triangle_ne_star",
+      "type": "core",
+      "description": "The triangle differs from Star x for every center x — it is not a star",
+      "leanType": "∀ x : Fin 4, triangle ≠ Star x 2"
+    },
+    {
+      "name": "ekr_bound",
+      "type": "supporting",
+      "description": "The Erdős–Ko–Rado upper bound |A| ≤ C(n-1,k-1) for the bespoke predicate, re-derived axiom-free via Mathlib's Finset.erdos_ko_rado",
+      "leanType": "n ≥ 2 * k → IsIntersectingFamily A k → A.card ≤ (n - 1).choose (k - 1)"
+    },
+    {
+      "name": "mem_Star_imp_mem",
+      "type": "supporting",
+      "description": "Every member of a star contains its center",
+      "leanType": "s ∈ Star x k → x ∈ s"
+    }
+  ],
+  "leanFile": {
+    "namespace": "ErdosKoRadoOQ03",
+    "axiomCount": 0,
+    "lineCount": 158,
+    "path": "Proofs/ErdosKoRadoOQ03.lean",
+    "sorries": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **`erdos-ko-rado-oq-03`** — *Erdős–Ko–Rado Uniqueness: Why the Star Characterization Needs Strict n > 2k*.

The **uniqueness** half of EKR (for `n > 2k`, every maximum intersecting family of `k`-sets is a *star*) is **not in Mathlib** — its Kruskal–Katona file explicitly lists *"Characterise the equality case"* as an open TODO, and a full Lean proof is a substantial project (it is strictly harder than the bound, and at `n = 2k` it is simply **false**).

This entry isolates the part of OQ-03 that is both **sharp and provable**: the **necessity of the strict inequality `n > 2k`**.

## What is proved (`Proofs/ErdosKoRadoOQ03.lean`)

At the boundary `n = 2k = 4`, `k = 2`, the **triangle** family `{0,1}, {1,2}, {0,2}` of 2-subsets of `Fin 4`:

- `triangle_intersecting` / `triangle_card` — is intersecting, with `|triangle| = 3`;
- `triangle_is_maximum` — **attains** the EKR bound `C(3,1) = 3`, and (via a de-axiomatized `ekr_bound`, valid since `4 ≥ 2·2`) no intersecting family of 2-sets in `Fin 4` is larger — so it is a genuine **maximizer**;
- `triangle_no_common` / `triangle_ne_star` — has **no common element**, hence `triangle ≠ Star x` for **every** center `x` — it is **not a star**;
- `ekr_uniqueness_fails_at_2k` (main) — bundles this with the genuine star `Star 0` (a distinct size-3 maximizer): **two distinct maximizers at `n = 2k`**, so the star characterization genuinely requires **strict `n > 2k`**.

## Relation to siblings

- `erdos-ko-rado-oq-01` — Katona's cyclic-interval lemma (the bound).
- `erdos-ko-rado-oq-02` — the EKR bound axiom-free + the star attains it (`IsGreatest`). This entry supplies the **converse-direction obstruction**: *maximum ⟹ star* fails precisely at `n = 2k`.

## Verification

- **11 theorems, 3 definitions, 0 sorries, 0 axioms.**
- `./proofs/scripts/docker-build.sh Proofs.ErdosKoRadoOQ03` → **Build succeeded (7743 jobs)**.
- Finite checks use **plain `decide`** (not `native_decide`), so **no `Lean.ofReduceBool`** — the entry is genuinely axiom-free. Status `verified`.

The full `n > 2k` uniqueness (and the Hilton–Milner refinement) is documented as the remaining open target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)