### PR TITLE
research(erdos-103-oq-02): raw count h(n) is degenerate (≡0); supply corrected congruence count [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos103OQ02.lean
+++ b/proofs/Proofs/Erdos103OQ02.lean
@@ -1,0 +1,218 @@
+/-
+Erdős Problem #103 — Open Question 02
+Is h(n) ≥ 2 for all sufficiently large n?
+
+## Open Question
+OQ-02 (the "WeakConjecture" of the parent file): even the weaker statement that
+there exist *two* incongruent optimal configurations for every large n is unknown.
+
+## What This File Actually Establishes (a formalization audit)
+
+The parent file `Erdos103Problem.lean` defines
+
+    h (n) := Nat.card {P : PointConfig n // IsOptimal n P}
+
+and states `WeakConjecture := ∃ N, ∀ n ≥ N, h n ≥ 2`. **As literally written, this
+`h` does NOT count incongruent optimal configurations** — it counts *all* optimal
+configurations, with no quotient by congruence. Because optimality is invariant
+under the continuous group of translations of ℝ², the optimal set is either empty
+or infinite, so `Nat.card` of it is `0` for every `n ≥ 1`.
+
+Consequently the parent's literal `WeakConjecture` (and even the assertion
+`h n ≥ 1`) is **false** under its own definitions. This file:
+
+1. Proves translation is an isometry preserving `IsOptimal` (`translate_optimal`).
+2. Proves the optimal subtype is infinite whenever it is nonempty
+   (`optimal_subtype_infinite_of_nonempty`).
+3. Proves the raw count is degenerate: `h n = 0` for all `n ≥ 1` (`h_eq_zero`).
+4. Concludes the parent's literal `WeakConjecture` is false
+   (`raw_weak_conjecture_false`).
+5. Supplies the **corrected** count `hCong n`, the number of *congruence classes*
+   of optimal configurations (the quantity Erdős actually asks about), and restates
+   the weak conjecture against it (`WeakConjectureCorrect`).
+6. Shows the corrected quotient collapses exactly the translation-infinitude that
+   breaks the raw count: all translates of a configuration share one class
+   (`translates_same_class`).
+
+This does **not** resolve the open Erdős question (which remains open for `hCong`);
+it corrects the formalization so that the open question is stated about the right
+object.
+
+## Axioms / Sorries
+None. All results are machine-checked from Mathlib + the parent file only.
+-/
+
+import Mathlib
+import Proofs.Erdos103Problem
+
+open Metric Set Finset
+open Erdos103
+
+namespace Erdos103OQ02
+
+-- ============================================================
+-- PART 1: Translation as a distance-preserving map
+-- ============================================================
+
+/-- Translation of a single point by a vector `v`. -/
+def Ptranslate {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n) : PointConfig n :=
+  fun i => P i + v
+
+/-- `pointDist` is translation-invariant: differences cancel the shift. -/
+theorem pointDist_add_right (p q v : ℝ × ℝ) :
+    pointDist (p + v) (q + v) = pointDist p q := by
+  unfold pointDist
+  congr 1
+  simp only [Prod.fst_add, Prod.snd_add]
+  ring
+
+-- ============================================================
+-- PART 2: Translation preserves optimality
+-- ============================================================
+
+/-- Translation preserves the diameter of a configuration. -/
+theorem translate_diameter {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n) :
+    diameter n (Ptranslate v P) = diameter n P := by
+  unfold diameter
+  by_cases hn : n ≥ 2
+  · rw [dif_pos hn, dif_pos hn]
+    apply iSup_congr; intro i
+    apply iSup_congr; intro j
+    show pointDist (P i + v) (P j + v) = pointDist (P i) (P j)
+    exact pointDist_add_right (P i) (P j) v
+  · rw [dif_neg hn, dif_neg hn]
+
+/-- Translation preserves validity (minimum separation). -/
+theorem translate_valid {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n)
+    (hP : IsValidConfig n P) : IsValidConfig n (Ptranslate v P) := by
+  intro i j hij
+  show pointDist (P i + v) (P j + v) ≥ 1
+  rw [pointDist_add_right]
+  exact hP i j hij
+
+/-- **Translation preserves optimality.** Since translation preserves both the
+    minimum-separation constraint and the diameter, an optimal configuration is
+    carried to an optimal configuration. -/
+theorem translate_optimal {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n)
+    (hP : IsOptimal n P) : IsOptimal n (Ptranslate v P) := by
+  obtain ⟨hvalid, hdiam⟩ := hP
+  refine ⟨translate_valid v P hvalid, ?_⟩
+  rw [translate_diameter]
+  exact hdiam
+
+-- ============================================================
+-- PART 3: The optimal set is infinite when nonempty
+-- ============================================================
+
+/-- **Infinitude of the optimal set.** For `n ≥ 1`, if even one optimal
+    configuration exists, then there are infinitely many: the horizontal
+    translates `P₀(· ) + (t,0)` for `t : ℝ` are pairwise distinct and all optimal. -/
+theorem optimal_subtype_infinite_of_nonempty (n : ℕ) (hn : 0 < n)
+    (hne : ∃ P, IsOptimal n P) :
+    Infinite {P : PointConfig n // IsOptimal n P} := by
+  obtain ⟨P₀, hP₀⟩ := hne
+  have hinj : Function.Injective
+      (fun t : ℝ =>
+        (⟨Ptranslate (t, 0) P₀, translate_optimal (t, 0) P₀ hP₀⟩ :
+          {P : PointConfig n // IsOptimal n P})) := by
+    intro s t hst
+    have hval : Ptranslate (s, 0) P₀ = Ptranslate (t, 0) P₀ := congrArg Subtype.val hst
+    have h0 := congrFun hval ⟨0, hn⟩
+    -- h0 : P₀ ⟨0,_⟩ + (s,0) = P₀ ⟨0,_⟩ + (t,0)
+    have hpair : ((s, 0) : ℝ × ℝ) = (t, 0) := (add_right_inj (P₀ ⟨0, hn⟩)).mp h0
+    exact (Prod.ext_iff.mp hpair).1
+  exact Infinite.of_injective _ hinj
+
+-- ============================================================
+-- PART 4: The raw count h(n) is degenerate (≡ 0)
+-- ============================================================
+
+/-- **The parent's raw count is identically zero for `n ≥ 1`.**
+    Either no optimal configuration exists (the subtype is empty) or one does
+    (the subtype is infinite by Part 3). In both cases `Nat.card = 0`. Hence the
+    literal `h` defined in the parent file fails to count incongruent
+    configurations — it is the constant `0`. -/
+theorem h_eq_zero (n : ℕ) (hn : 0 < n) : h n = 0 := by
+  have hh : h n = Nat.card {P : PointConfig n // IsOptimal n P} := rfl
+  rw [hh, Nat.card_eq_zero]
+  by_cases hne : Nonempty {P : PointConfig n // IsOptimal n P}
+  · right
+    obtain ⟨⟨P₀, hP₀⟩⟩ := hne
+    exact optimal_subtype_infinite_of_nonempty n hn ⟨P₀, hP₀⟩
+  · left
+    exact not_nonempty_iff.mp hne
+
+/-- **The parent's literal `WeakConjecture` is false.** Because `h n = 0` for every
+    `n ≥ 1`, no threshold `N` can satisfy `∀ n ≥ N, h n ≥ 2`. This is exactly why
+    the open question must be stated against the *congruence count* `hCong` below,
+    not the raw cardinality. -/
+theorem raw_weak_conjecture_false : ¬ Erdos103.WeakConjecture := by
+  rintro ⟨N, hN⟩
+  have hge : h (max N 1) ≥ 2 := hN (max N 1) (le_max_left _ _)
+  have hpos : 0 < max N 1 := lt_of_lt_of_le Nat.one_pos (le_max_right _ _)
+  rw [h_eq_zero (max N 1) hpos] at hge
+  omega
+
+-- ============================================================
+-- PART 5: The corrected count — congruence classes
+-- ============================================================
+
+/-- Congruence as an equivalence relation on the *optimal* configurations.
+    This is the setoid whose classes Erdős's `h(n)` is meant to count. -/
+def OptimalSetoid (n : ℕ) : Setoid {P : PointConfig n // IsOptimal n P} where
+  r P Q := AreCongruent n P.val Q.val
+  iseqv :=
+    ⟨fun P => congruent_refl n P.val,
+     fun h => congruent_symm n _ _ h,
+     fun h₁ h₂ => congruent_trans n _ _ _ h₁ h₂⟩
+
+/-- **The corrected count.** `hCong n` is the number of incongruent optimal
+    configurations — the cardinality of the quotient of the optimal set by
+    congruence. This is the quantity in Erdős Problem #103, in contrast to the
+    degenerate raw cardinality `h n`. -/
+noncomputable def hCong (n : ℕ) : ℕ := Nat.card (Quotient (OptimalSetoid n))
+
+/-- The weak conjecture, correctly stated against the congruence count. -/
+def WeakConjectureCorrect : Prop := ∃ N : ℕ, ∀ n ≥ N, hCong n ≥ 2
+
+/-- Any configuration is congruent to each of its translates (translation is an
+    isometry). -/
+theorem translate_congruent {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n) :
+    AreCongruent n P (Ptranslate v P) := by
+  refine ⟨⟨fun p => p + v, fun p q => pointDist_add_right p q v,
+    (Equiv.addRight v).bijective⟩, ?_⟩
+  intro i; rfl
+
+/-- **The quotient collapses the translation-infinitude.** All horizontal (indeed
+    arbitrary) translates of a fixed optimal configuration map to the *same* class
+    of `hCong`. This is precisely why `hCong` is finite/meaningful where the raw
+    count `h` collapsed to `0`: the infinitely many translates that killed the raw
+    cardinality are a single congruence class. -/
+theorem translates_same_class {n : ℕ} (v : ℝ × ℝ)
+    (P : {P : PointConfig n // IsOptimal n P}) :
+    (Quotient.mk (OptimalSetoid n) P) =
+      Quotient.mk (OptimalSetoid n)
+        ⟨Ptranslate v P.val, translate_optimal v P.val P.2⟩ :=
+  Quotient.sound (translate_congruent v P.val)
+
+-- ============================================================
+-- PART 6: Logical relationships of the corrected conjectures
+-- ============================================================
+
+/-- The corrected weak conjecture follows from the (corrected) main conjecture
+    `∀ C, ∃ N, ∀ n ≥ N, hCong n > C`. -/
+theorem correct_main_implies_weak
+    (hmain : ∀ C : ℕ, ∃ N : ℕ, ∀ n ≥ N, hCong n > C) :
+    WeakConjectureCorrect := by
+  obtain ⟨N, hN⟩ := hmain 1
+  exact ⟨N, fun n hn => hN n hn⟩
+
+end Erdos103OQ02
+
+-- Export main results
+#check @Erdos103OQ02.translate_optimal
+#check @Erdos103OQ02.optimal_subtype_infinite_of_nonempty
+#check @Erdos103OQ02.h_eq_zero
+#check @Erdos103OQ02.raw_weak_conjecture_false
+#check @Erdos103OQ02.hCong
+#check @Erdos103OQ02.translates_same_class

--- a/proofs/Proofs/Erdos103Problem.lean
+++ b/proofs/Proofs/Erdos103Problem.lean
@@ -111,9 +111,9 @@ theorem congruent_symm (n : ℕ) (P Q : PointConfig n) :
   refine ⟨⟨g, fun p q => ?_, ?_⟩, fun i => ?_⟩
   · have := σ.preserves_dist (g p) (g q)
     rw [hg_right, hg_right] at this; exact this.symm
-  · exact ⟨fun p q h => by rwa [← hg_right p, ← hg_right q, h],
+  · exact ⟨fun p q h => by rw [← hg_right p, ← hg_right q, h],
            fun p => ⟨σ.toFun p, hg_left p⟩⟩
-  · rw [hσ i, hg_left]
+  · rw [hσ i]; exact (hg_left (P i)).symm
 
 theorem congruent_trans (n : ℕ) (P Q R : PointConfig n) :
     AreCongruent n P Q → AreCongruent n Q R → AreCongruent n P R := by

--- a/src/data/proofs/erdos-103-oq-02/meta.json
+++ b/src/data/proofs/erdos-103-oq-02/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "erdos-103-oq-02",
+  "title": "Erdos #103 OQ-02: Is h(n) ≥ 2 for all large n? (a formalization audit)",
+  "slug": "erdos-103-oq-02",
+  "description": "Investigation of the 'weak conjecture' for Erdős Problem #103 — whether h(n) ≥ 2 for all sufficiently large n. The key finding is that the parent file's literal definition h(n) := Nat.card {P // IsOptimal n P} does NOT count incongruent configurations: because optimality is translation-invariant, the optimal set is either empty or infinite, so the raw cardinality is identically 0 for every n ≥ 1. Consequently the parent's literal WeakConjecture (and even h(n) ≥ 1) is false under its own definitions. This file proves the degeneracy, then supplies the corrected congruence-quotient count hCong(n) against which the open question is properly stated. The Erdős problem itself remains OPEN; this is a correction of the formalization, not a resolution.",
+  "meta": {
+    "author": "researcher-1",
+    "sourceUrl": "https://erdosproblems.com/103",
+    "date": "2026-06-26",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos103OQ02.lean",
+    "tags": [
+      "erdos",
+      "geometry",
+      "distances",
+      "packing",
+      "congruence",
+      "open",
+      "formalization-audit",
+      "quotient",
+      "isometry"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axioms": 0,
+    "erdosNumber": 103,
+    "erdosUrl": "https://erdosproblems.com/103",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "pointDist_add_right: Euclidean distance on ℝ² is translation-invariant (differences cancel the shift)",
+      "translate_valid / translate_diameter: translation preserves minimum separation and diameter",
+      "translate_optimal: translation by any vector carries optimal configurations to optimal configurations",
+      "optimal_subtype_infinite_of_nonempty: for n ≥ 1, if one optimal config exists then there are infinitely many (the horizontal translates are pairwise distinct and all optimal)",
+      "h_eq_zero: the parent's raw count h(n) = Nat.card {P // IsOptimal n P} is identically 0 for all n ≥ 1 (empty or infinite ⟹ Nat.card = 0)",
+      "raw_weak_conjecture_false: the parent's literal WeakConjecture (∃N, ∀n≥N, h n ≥ 2) is false — the open question must be stated about congruence classes",
+      "hCong: the corrected count — number of congruence classes of optimal configurations (the quantity Erdős actually asks about)",
+      "translate_congruent / translates_same_class: the congruence quotient collapses exactly the translation-infinitude that broke the raw count; all translates share one class",
+      "correct_main_implies_weak: the corrected conjecture hierarchy for hCong",
+      "Repaired parent Erdos103Problem.lean: congruent_symm no longer compiled under Lean 4.26.0 (rwa auto-closing + rw target mismatch); fixed to restore the 0-axiom 0-sorry parent build"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.card_eq_zero",
+        "description": "Nat.card α = 0 ↔ IsEmpty α ∨ Infinite α",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "An injection from an infinite type makes the codomain infinite",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Equiv.addRight",
+        "description": "Right translation x ↦ x + v is a bijection of an additive group",
+        "module": "Mathlib.Algebra.Group.Equiv.Basic"
+      },
+      {
+        "theorem": "iSup_congr",
+        "description": "Suprema agree when their indexed families agree pointwise",
+        "module": "Mathlib.Order.CompleteLattice"
+      }
+    ],
+    "historicalContext": "Erdős Problem #103 (1994) asks whether h(n) → ∞, where h(n) counts incongruent sets of n points in ℝ² minimizing diameter with pairwise separation ≥ 1. Even the weak statement h(n) ≥ 2 for all large n is unknown. This investigation does not resolve the open question; instead it audits the existing formalization and discovers that the parent file's literal counting function is degenerate. Because optimality is preserved by the continuous translation group, the set of optimal configurations is closed under translation, hence either empty or infinite — so its Nat.card is 0. The intended quantity is the cardinality of the quotient by congruence, which this file defines as hCong. The fix relocates the open question onto the correct object.",
+    "axiomCount": 0,
+    "lineCount": 218,
+    "assumptions": "None. 0 axioms, 0 sorries. All results machine-checked from Mathlib and the (repaired) parent file. NOTE: this entry does NOT resolve the open Erdős #103 conjecture; it corrects the formalization so the open question is stated against the congruence count hCong.",
+    "theoremCount": 10,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #103, from his 1994 collection \"Some of my favourite unsolved problems,\" asks whether h(n) → ∞, where h(n) counts incongruent n-point configurations in ℝ² that minimize diameter subject to pairwise distances ≥ 1. The weakest meaningful form — h(n) ≥ 2 for all large n — is itself open. The problem sits in the classical theory of optimal point configurations (Fejes Tóth, 1953) and modern extremal packing.",
+    "problemStatement": "**Weak conjecture (OPEN):** Is h(n) ≥ 2 for all sufficiently large n?\n\n**Key finding:** The parent formalization defines h(n) := Nat.card {P // IsOptimal n P} — the raw count of optimal configurations with NO quotient by congruence. Since optimality is translation-invariant, that set is empty or infinite, so h(n) = 0 for every n ≥ 1. The parent's literal WeakConjecture is therefore false, and the open question must be restated against the congruence-class count hCong(n). This file proves the degeneracy and supplies hCong; it does NOT resolve the Erdős problem.",
+    "text": "A formalization audit of Erdős #103: the literal optimal-configuration count is degenerate (≡ 0) because optimality is translation-invariant; the corrected count is the congruence quotient hCong.",
+    "proofStrategy": "1. Prove pointDist is translation-invariant. 2. Deduce translation preserves min-separation, diameter, and hence optimality. 3. Construct an injection ℝ ↪ {optimal configs} via horizontal translates, giving infinitude when nonempty. 4. Conclude Nat.card = 0 in both the empty and infinite cases, so the raw h ≡ 0 and the literal WeakConjecture is false. 5. Define the congruence setoid on optimal configs and the corrected count hCong. 6. Show all translates collapse to one hCong class, explaining why hCong is the right (finite) object.",
+    "keyInsights": [
+      "**Translation-invariance is the culprit**: IsOptimal is preserved by every translation of ℝ², so the optimal set is a union of full translation-orbits — uncountably infinite whenever nonempty.",
+      "**Infinite ⟹ Nat.card = 0**: Mathlib's Nat.card sends infinite types to 0. Combined with the empty case, h(n) = 0 unconditionally for n ≥ 1 — no existence hypothesis needed.",
+      "**The literal WeakConjecture is decidably false**: since h(max N 1) = 0 < 2, no threshold N can witness ∀ n ≥ N, h n ≥ 2.",
+      "**The quotient repairs the count**: congruence collapses each translation-orbit to a single class, so hCong is finite/meaningful exactly where the raw count collapsed to 0.",
+      "**Audit, not resolution**: nothing here makes progress on whether hCong(n) ≥ 2 for large n — that remains the open Erdős question. The contribution is relocating the question onto a well-posed definition."
+    ],
+    "prerequisites": [
+      "Real analysis: Euclidean distance on ℝ²",
+      "Cardinality: Nat.card and its behavior on infinite types",
+      "Quotients and setoids in Lean/Mathlib",
+      "Group actions: translations as isometries"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Overview and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Documents Erdős #103 OQ-02 and the audit finding: the parent's raw count is degenerate, and supplies the corrected congruence count. Imports Mathlib and the parent file Erdos103Problem.",
+      "mathContext": "Weak conjecture (open): $\\exists N, \\forall n \\geq N, h(n) \\geq 2$, where $h$ should count optimal configurations up to congruence."
+    },
+    {
+      "id": "translation-isometry",
+      "title": "Translation as a Distance-Preserving Map",
+      "startLine": 58,
+      "endLine": 67,
+      "summary": "Defines Ptranslate (shift every point by v) and proves pointDist is translation-invariant: the coordinate differences are unchanged by a common shift.",
+      "mathContext": "$d(p+v, q+v) = \\sqrt{((p_1+v_1)-(q_1+v_1))^2 + \\cdots} = d(p,q)$."
+    },
+    {
+      "id": "translate-optimal",
+      "title": "Translation Preserves Optimality",
+      "startLine": 69,
+      "endLine": 101,
+      "summary": "Proves translation preserves the diameter (the double supremum of pairwise distances is unchanged) and minimum separation, hence carries optimal configurations to optimal configurations.",
+      "mathContext": "Since every pairwise distance is preserved, $\\mathrm{diam}(P+v) = \\mathrm{diam}(P)$ and $\\mathrm{IsOptimal}(P) \\Rightarrow \\mathrm{IsOptimal}(P+v)$."
+    },
+    {
+      "id": "infinitude",
+      "title": "The Optimal Set is Infinite When Nonempty",
+      "startLine": 103,
+      "endLine": 124,
+      "summary": "For n ≥ 1, builds an injection t ↦ (P₀ shifted by (t,0)) from ℝ into the optimal subtype: distinct shifts move the 0-th point to distinct positions. Hence the optimal subtype is infinite.",
+      "mathContext": "$t \\mapsto P_0(\\cdot) + (t,0)$ is injective into the optimal set, and $\\mathbb{R}$ is infinite, so the optimal set is infinite."
+    },
+    {
+      "id": "degeneracy",
+      "title": "The Raw Count h(n) is Identically Zero",
+      "startLine": 126,
+      "endLine": 154,
+      "summary": "Proves h(n) = 0 for all n ≥ 1: the optimal subtype is empty or infinite, and Nat.card is 0 in both cases. Concludes the parent's literal WeakConjecture is false.",
+      "mathContext": "$h(n) = \\mathrm{Nat.card}\\,\\{P : \\mathrm{IsOptimal}\\,n\\,P\\} = 0$ for $n \\geq 1$, so $\\neg(\\exists N, \\forall n \\geq N,\\ h(n) \\geq 2)$."
+    },
+    {
+      "id": "corrected-count",
+      "title": "The Corrected Count: Congruence Classes",
+      "startLine": 156,
+      "endLine": 196,
+      "summary": "Defines the congruence setoid on optimal configurations and hCong(n) := Nat.card of the quotient — the intended incongruent count. Shows all translates of a configuration share one class, so the quotient collapses the translation-infinitude.",
+      "mathContext": "$h_{\\mathrm{Cong}}(n) = \\mathrm{Nat.card}\\,(\\{P : \\mathrm{IsOptimal}\\,n\\,P\\} / {\\cong})$. Translates of $P$ are congruent, hence one class."
+    },
+    {
+      "id": "verification",
+      "title": "Conjecture Hierarchy and Export",
+      "startLine": 198,
+      "endLine": 218,
+      "summary": "States the corrected weak conjecture against hCong and derives it from the corrected main conjecture. #check statements verify the six headline results.",
+      "mathContext": "Corrected weak conjecture: $\\exists N, \\forall n \\geq N, h_{\\mathrm{Cong}}(n) \\geq 2$ — the genuinely open statement."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file audits the Erdős #103 formalization and finds the parent's raw counting function degenerate: h(n) = Nat.card {P // IsOptimal n P} is identically 0 for n ≥ 1 because optimality is translation-invariant (the optimal set is empty or infinite). It proves this rigorously (10 theorems, 0 sorries, 0 axioms), shows the parent's literal WeakConjecture is therefore false, and supplies the corrected congruence-quotient count hCong against which the open question is properly posed. It also repairs the parent file, whose congruent_symm proof no longer compiled under Lean 4.26.0.",
+    "implications": "The open Erdős #103 question is unchanged in difficulty, but is now stated about a well-posed object (hCong) rather than a definitionally-zero one. The episode is a cautionary example: counting 'configurations up to symmetry' must quotient by the symmetry group explicitly, since the un-quotiented count collapses under a continuous symmetry. The corrected definition is the foundation any future progress on h(n) ≥ 2 must build on.",
+    "openQuestions": [
+      "Is hCong(n) ≥ 2 for all sufficiently large n? (The genuinely open weak conjecture.)",
+      "Is hCong(n) finite for each n? Finiteness requires compactness of the optimal-configuration space modulo congruence.",
+      "Does hCong(n) → ∞? (The full Erdős #103 conjecture, restated correctly.)",
+      "Can hCong(4) be computed explicitly from the known optimal 4-point configuration?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-103",
+      "relationship": "extends",
+      "description": "Parent problem: audits and repairs the parent formalization, exposing that its raw count h(n) is degenerate and supplying the corrected congruence count"
+    },
+    {
+      "targetId": "erdos-103-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question (does h(n) → ∞?); OQ-01 corrected the unbounded↔tends-to-∞ equivalence, OQ-02 corrects the counting function itself"
+    },
+    {
+      "targetId": "erdos-101",
+      "relationship": "related",
+      "description": "Erdős #101 (four-point lines): both concern extremal configurations of points in ℝ² under geometric constraints"
+    },
+    {
+      "targetId": "erdos-104",
+      "relationship": "related",
+      "description": "Erdős #104 (unit circles through 3+ points): shares the theme of counting extremal geometric configurations in the plane"
+    }
+  ],
+  "references": [
+    {
+      "key": "Er94b",
+      "authors": [
+        "P. Erdos"
+      ],
+      "title": "Some of my favourite unsolved problems",
+      "venue": "A Tribute to Paul Erdos, Cambridge University Press",
+      "year": "1994",
+      "pages": "467-478",
+      "note": "Original source posing Problem #103"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.Erdos103Problem"
+    ],
+    "opens": [
+      "Metric",
+      "Set",
+      "Finset",
+      "Erdos103"
+    ],
+    "namespace": "Erdos103OQ02",
+    "lineCount": 218,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos103OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-103-oq-02.json
+++ b/src/data/research/problems/erdos-103-oq-02.json
@@ -1,12 +1,12 @@
 {
   "slug": "erdos-103-oq-02",
   "title": "Is h(n) ≥ 2 for all sufficiently large n",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
+    "formal": "\\exists N, \\forall n \\geq N, h(n) \\geq 2 \\text{ where } h(n) = |\\{P \\subset \\mathbb{R}^2 : |P|=n,\\ d_{\\min}\\geq 1,\\ \\mathrm{diam\\ minimal}\\}/{\\cong}|",
     "plain": "Formal investigation in geometry: Is h(n) ≥ 2 for all sufficiently large n.",
     "whyMatters": [
       "Research value"
@@ -15,27 +15,50 @@
   "knownResults": {
     "proven": [],
     "open": [],
-    "goal": ""
+    "goal": "Determine whether at least two incongruent optimal configurations exist for all large n (OPEN). This session corrects the formalization of h(n) rather than resolving the open question."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-29T19:14:09.204Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "COMPLETED",
+    "since": "2026-06-26",
+    "iteration": 2,
+    "focus": "Formalization audit of the counting function h(n); supplied corrected congruence-quotient definition.",
+    "blockers": [
+      "The open Erdős #103 weak conjecture (hCong(n) >= 2 for large n) is genuinely open and not addressed by this session."
+    ],
+    "nextAction": "Future work: study finiteness/compactness of the optimal-configuration space modulo congruence; attempt hCong(4).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "Audited the parent Erdős #103 formalization and found its counting function degenerate: h(n) := Nat.card {P // IsOptimal n P} counts ALL optimal configurations with no quotient by congruence. Since optimality is translation-invariant, that set is empty or infinite, so Nat.card = 0 for every n >= 1. Proved this rigorously (translate_optimal, optimal_subtype_infinite_of_nonempty, h_eq_zero), concluded the parent's literal WeakConjecture is FALSE (raw_weak_conjecture_false), and supplied the corrected congruence-quotient count hCong(n) := Nat.card (Quotient OptimalSetoid). Showed all translates of a config collapse to one hCong class. Also repaired the parent file Erdos103Problem.lean, whose congruent_symm proof no longer compiled under Lean 4.26.0. New file Erdos103OQ02.lean: 0 axioms, 0 sorries, 10 theorems, 4 defs, 218 lines. The Erdős problem itself remains OPEN; this is a correction of the formalization, not a resolution.",
+    "builtItems": [
+      "Erdos103OQ02.lean (0-axiom, 0-sorry, verified)",
+      "pointDist_add_right: Euclidean distance on R^2 is translation-invariant",
+      "translate_optimal: translation preserves optimality (min-separation + diameter)",
+      "optimal_subtype_infinite_of_nonempty: nonempty optimal set => infinite (via horizontal-translate injection R -> optimal subtype)",
+      "h_eq_zero: parent raw count h(n) = 0 for all n >= 1 (degeneracy)",
+      "raw_weak_conjecture_false: parent's literal WeakConjecture is false",
+      "hCong / OptimalSetoid: corrected congruence-class count (the intended h)",
+      "translates_same_class: the quotient collapses the translation-infinitude",
+      "Repaired parent Erdos103Problem.lean congruent_symm (Lean 4.26.0 regression: rwa auto-close + rw target mismatch)"
+    ],
+    "insights": [
+      "Counting 'configurations up to symmetry' MUST quotient by the symmetry group explicitly: an un-quotiented Nat.card collapses to 0 under any continuous symmetry (here, translation).",
+      "Nat.card sends infinite types to 0 in Mathlib; combined with the empty case this yields h(n)=0 with NO existence hypothesis.",
+      "The optimal set is a union of full translation-orbits, hence empty or uncountable; the congruence quotient restores finiteness/meaning.",
+      "The sibling OQ-01 axiomatized h and h_pos (h(n)>=1), which this audit shows is inconsistent with the parent's LITERAL h -- OQ-01's h must denote the intended quotient count hCong."
+    ],
+    "mathlibGaps": [
+      "No gap blocked this session. Finiteness of the optimal-configuration space modulo congruence (needed to make hCong provably finite) would require a compactness/quotient argument not yet built."
+    ],
+    "nextSteps": [
+      "Prove hCong(n) is finite for each n (compactness of optimal configs modulo congruence).",
+      "Attempt to compute hCong(4) from the known optimal 4-point configuration.",
+      "Restate and connect OQ-01's results (h -> infinity) to hCong rather than the degenerate raw h."
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -70,7 +93,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.203Z",
-  "lastUpdate": "2026-05-29T19:14:09.203Z",
+  "lastUpdate": "2026-06-26",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Erdős Problem #103, OQ-02 — Is h(n) ≥ 2 for all large n?

**Status of the math question: OPEN.** This session does **not** resolve the
weak conjecture; it is a **formalization audit + correction** of the existing
Erdős #103 gallery files, plus a repair of a build regression.

### The finding

The parent file `Erdos103Problem.lean` defines the counting function as

```lean
noncomputable def h (n : ℕ) : ℕ := Nat.card {P : PointConfig n // IsOptimal n P}
```

and states `WeakConjecture := ∃ N, ∀ n ≥ N, h n ≥ 2`. **As literally written this
`h` does not count incongruent configurations** — there is no quotient by
congruence. Because `IsOptimal` is invariant under the continuous translation
group of ℝ², the optimal set is a union of full translation-orbits, hence **empty
or infinite**, so `Nat.card` of it is `0` for every `n ≥ 1`.

Consequently the parent's literal `WeakConjecture` (and even the assertion
`h n ≥ 1`) is **false under its own definitions**. The open question must be
stated against the **congruence-class count**, which this file supplies as
`hCong`.

### New file `Erdos103OQ02.lean` — 0 axioms, 0 sorries, 10 theorems, 4 defs, 218 lines

| Result | Statement |
|--------|-----------|
| `pointDist_add_right` | Euclidean distance on ℝ² is translation-invariant |
| `translate_optimal` | translation by any `v` preserves `IsOptimal` (min-separation + diameter) |
| `optimal_subtype_infinite_of_nonempty` | for `n ≥ 1`, one optimal config ⟹ infinitely many (injection `ℝ ↪` optimal subtype via horizontal translates) |
| `h_eq_zero` | the parent raw count `h n = 0` for all `n ≥ 1` (empty or infinite ⟹ `Nat.card = 0`) |
| `raw_weak_conjecture_false` | the parent's literal `WeakConjecture` is false |
| `hCong` / `OptimalSetoid` | the corrected count: `Nat.card` of the quotient of optimal configs by congruence — the quantity Erdős actually asks about |
| `translates_same_class` | all translates of a config share one `hCong` class: the quotient collapses exactly the translation-infinitude that broke the raw count |
| `correct_main_implies_weak` | corrected conjecture hierarchy for `hCong` |

### Parent repair

`Erdos103Problem.lean`'s `congruent_symm` proof no longer compiled under
Lean 4.26.0 — a fresh Mathlib cache exposed two regressions: `rwa` now
auto-closes the goal (leaving "no goals to be solved"), and a `rw [hσ i]`
rewrite target was wrapped behind a structure projection. Fixed both (2 lines),
restoring the parent's 0-axiom / 0-sorry build. Both files build green via the
Docker wrapper.

### Honesty note

- The Erdős #103 weak conjecture (now correctly `∃ N, ∀ n ≥ N, hCong n ≥ 2`)
  remains **open**; nothing here bounds `hCong`.
- Take-away: counting "configurations up to symmetry" must quotient by the
  symmetry group explicitly — the un-quotiented `Nat.card` collapses to `0` under
  any continuous symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)