### PR TITLE
audit(erdos-ko-rado-oq-03): confirm clean — Tier A boundary counterexample

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24931,6 +24931,12 @@
       "lastAudited": "2026-06-27T06:10:10Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-ko-rado-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T06:53:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-ko-rado-oq-03

**Result: CLEAN** ✅

### Counts (meta.json vs Lean source `Proofs/ErdosKoRadoOQ03.lean`)
| Field | meta | source | match |
|-------|------|--------|-------|
| lineCount | 158 | 158 | ✅ |
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 | ✅ |
| theoremCount | 11 | 11 | ✅ |
| definitionCount | 3 | 3 | ✅ |

### Integrity findings
- **No True stubs.** Theorems prove substantive statements.
- **No `native_decide`** (only plain `decide`), so the entry is genuinely axiom-free — no `Lean.ofReduceBool`. The `assumptions` field (none) is accurate.
- **`verified` status/badge justified.** The core original result `ekr_uniqueness_fails_at_2k` (the n = 2k boundary non-uniqueness counterexample — the triangle {01,12,02} is a non-star maximizer distinct from `Star 0`) is fully self-contained via `decide`.
- **Mathlib reliance fully disclosed, not masked.** `Finset.erdos_ko_rado` is used only to certify the auxiliary maximality of the counterexample (`ekr_bound`/`triangle_is_maximum`), and this is transparently stated in both `mathlibDependencies` and `originalContributions`. Not failure mode #5 (hidden imports).
- **Claim correctly scoped.** Title/description/conclusion pin the claim to "the necessity of the strict inequality n > 2k", not the full uniqueness theorem, which is explicitly recorded as an open question.

No changes to meta.json needed. Updates `audit-tracker.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)