### PR TITLE
audit(abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-02): confirm clean — Tier B mathlib bridge

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24937,6 +24937,12 @@
       "lastAudited": "2026-06-27T06:53:30Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T06:58:21Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-02` ("The Solvability Extension Characterization")
**Result**: No integrity issues found. Records the clean audit in `audit-tracker.json`.

### What was checked

The entry states `IsSolvable G ↔ IsSolvable N ∧ IsSolvable (G ⧸ N)` for any normal subgroup N ⊴ G — the abstract extension-closure fact behind the parent's Aα ↔ Sα solvability bridge.

| Check | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| sorries | 0 | 0 (only docstring prose mentions) | ✓ |
| axiomCount | 0 | 0 `axiom` decls, 0 structure-encoded | ✓ |
| native_decide | n/a | 0 (only docstring prose) | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 120 | 120 | ✓ |

### Tier classification

**Tier B (badge `mathlib`)** — correct. The core result packages three Mathlib directional facts (`solvable_of_ker_le_range`, `subgroup_solvable_of_solvable`, `solvable_quotient_of_solvable`) into the two-sided iff that Mathlib's group theory does not state.

- **No delegation opacity**: the description's first paragraph and the overview both explicitly credit Mathlib for the directional pieces.
- **`originalContributions` honestly scoped**: limited to the packaged iff, the reusable extension lemma, and the abelian-quotient / contrapositive corollaries — not the underlying Mathlib theorems.
- `status: verified` + `badge: mathlib` is the established gallery pattern for sorry/axiom-free entries whose core relies on a Mathlib bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)