### PR TITLE
Enrich ζ at Negative Integers from Faulhaber: annotation depth

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-03/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "The Value Formula as the Endpoint of Analytic Continuation",
-    "content": "`zeta_neg_nat` is a clean restatement of Mathlib's `riemannZeta_neg_nat_eq_bernoulli'`: ζ(−n) = −B'_{n+1}/(n+1). This single line is the literal answer to the parent's open question. The hard work — meromorphically continuing ζ from the half-plane Re(s) > 1 to all of ℂ and proving the functional equation — lives entirely in Mathlib's Hurwitz/Riemann zeta development. The gallery contribution is to expose this endpoint with a clear name and then connect it back to the power-sum origin."
+    "content": "`zeta_neg_nat` is a clean restatement of Mathlib's `riemannZeta_neg_nat_eq_bernoulli'`: ζ(−n) = −B'_{n+1}/(n+1). This single line is the literal answer to the parent's open question. The hard work — meromorphically continuing ζ from the half-plane Re(s) > 1 to all of ℂ and proving the functional equation — lives entirely in Mathlib's Hurwitz/Riemann zeta development. The gallery contribution is to expose this endpoint with a clear name and then connect it back to the power-sum origin.",
+    "mathContext": "$\\zeta(-n) = -\\dfrac{B'_{n+1}}{n+1}$ for $n \\ge 0$. The Dirichlet series $\\zeta(s) = \\sum_{k\\ge 1} k^{-s}$ converges only for $\\operatorname{Re}(s) > 1$; the right-hand side here is its analytic continuation evaluated at the non-positive integers, where it is always rational.",
+    "significance": "key",
+    "relatedConcepts": ["Riemann zeta function", "analytic continuation", "Bernoulli numbers", "functional equation", "Hurwitz zeta function"],
+    "prerequisites": ["complex analysis", "meromorphic continuation", "Dirichlet series"]
   },
   {
     "id": "ann-convention",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "Two Conventions, One Value",
-    "content": "Mathlib ships the value formula twice: ζ(−n) = −B'_{n+1}/(n+1) (with B'_1 = +1/2) and ζ(−n) = (−1)^n·B_{n+1}/(n+1) (with B_1 = −1/2). `bernoulli_convention_eq` proves the numerators agree using B'_m = (−1)^m·B_m. The conventions differ only at the m = 1 entry, which is precisely why ζ(0) = −B'_1 = −1/2 needs the sign correction (−1)^0·B_1 = −1/2 to match."
+    "content": "Mathlib ships the value formula twice: ζ(−n) = −B'_{n+1}/(n+1) (with B'_1 = +1/2) and ζ(−n) = (−1)^n·B_{n+1}/(n+1) (with B_1 = −1/2). `bernoulli_convention_eq` proves the numerators agree using B'_m = (−1)^m·B_m. The conventions differ only at the m = 1 entry, which is precisely why ζ(0) = −B'_1 = −1/2 needs the sign correction (−1)^0·B_1 = −1/2 to match.",
+    "mathContext": "$B'_m = (-1)^m B_m$, hence $-B'_{n+1} = (-1)^{n+1}(-1)B_{n+1} = (-1)^n B_{n+1}$. The two families coincide except at $m=1$, where $B'_1 = +\\tfrac12$ but $B_1 = -\\tfrac12$; for all $m \\ne 1$ they are identical because $B_m = 0$ for odd $m > 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bernoulli numbers", "sign conventions", "exponential generating functions", "even and odd Bernoulli numbers"],
+    "prerequisites": ["Bernoulli number definitions", "generating functions"]
   },
   {
     "id": "ann-bridge",
@@ -30,7 +38,11 @@
     },
     "type": "insight",
     "title": "ζ(−p) Is the Missing Constant Term of the Faulhaber Polynomial",
-    "content": "Faulhaber's identity reads (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}: the power-sum polynomial is the Bernoulli polynomial minus its constant term B_{p+1} = B_{p+1}(0), enforcing that the sum vanishes at n = 0. The theorem `faulhaber_constant_eq_zeta` shows this subtracted constant is exactly −(p+1)·ζ(−p) (for p ≥ 1). So the analytically-continued zeta value is, up to the factor (p+1) and a sign, the constant the power-sum polynomial 'wants but cannot have'. This is the algebraic heart of zeta-regularization."
+    "content": "Faulhaber's identity reads (p+1)·∑_{k<n} k^p = B_{p+1}(n) − B_{p+1}: the power-sum polynomial is the Bernoulli polynomial minus its constant term B_{p+1} = B_{p+1}(0), enforcing that the sum vanishes at n = 0. The theorem `faulhaber_constant_eq_zeta` shows this subtracted constant is exactly −(p+1)·ζ(−p) (for p ≥ 1). So the analytically-continued zeta value is, up to the factor (p+1) and a sign, the constant the power-sum polynomial 'wants but cannot have'. This is the algebraic heart of zeta-regularization.",
+    "mathContext": "$(p+1)\\sum_{k<n} k^p = B_{p+1}(n) - B_{p+1}$, and for $p \\ge 1$ the subtracted constant satisfies $B_{p+1} = -(p+1)\\,\\zeta(-p)$. Equivalently $\\zeta(-p) = -\\dfrac{B_{p+1}}{p+1}$, the same rational the power-sum polynomial omits at its constant term $B_{p+1}(0)$.",
+    "significance": "key",
+    "relatedConcepts": ["Faulhaber's formula", "Bernoulli polynomials", "zeta regularization", "power sums", "Euler–Maclaurin formula"],
+    "prerequisites": ["Faulhaber's formula", "Bernoulli polynomials", "polynomial evaluation"]
   },
   {
     "id": "ann-zeta-neg-one",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "ζ(−1) = −1/12 and 1 + 2 + 3 + ⋯",
-    "content": "Reading the (divergent) series 1 + 2 + 3 + ⋯ as ∑ k = ζ(−1), the regularized value is −1/12, obtained here as −B'_2/2 = −(1/6)/2. Through the bridge, −1/12 is the constant left over from the p = 1 Faulhaber polynomial ½n(n+1). This is the value that famously appears in the Casimir effect and in the bosonic-string critical dimension 26, where 1 + 2 + ⋯ + 24 is regularized to −1."
+    "content": "Reading the (divergent) series 1 + 2 + 3 + ⋯ as ∑ k = ζ(−1), the regularized value is −1/12, obtained here as −B'_2/2 = −(1/6)/2. Through the bridge, −1/12 is the constant left over from the p = 1 Faulhaber polynomial ½n(n+1). This is the value that famously appears in the Casimir effect and in the bosonic-string critical dimension 26, where 1 + 2 + ⋯ + 24 is regularized to −1.",
+    "mathContext": "$\\zeta(-1) = -\\dfrac{B'_2}{2} = -\\dfrac{1/6}{2} = -\\dfrac{1}{12}$. The Faulhaber polynomial for $p=1$ is $\\sum_{k<n} k = \\tfrac12 n(n+1) - \\tfrac12 n$... in Bernoulli form $\\tfrac12\\big(B_2(n) - B_2\\big)$ with $B_2 = \\tfrac16$, and $-(p+1)\\zeta(-p) = -2\\zeta(-1) = \\tfrac16 = B_2$.",
+    "significance": "key",
+    "relatedConcepts": ["zeta regularization", "Casimir effect", "bosonic string theory", "Ramanujan summation", "Abel summation"],
+    "prerequisites": ["divergent series", "regularization", "Bernoulli numbers"]
   },
   {
     "id": "ann-trivial-zeros",
@@ -52,6 +68,10 @@
     },
     "type": "concept",
     "title": "Trivial Zeros Are Vanishing Odd Bernoulli Numbers",
-    "content": "`zeta_neg_even` proves ζ(−2n) = 0 for n ≥ 1 not by an analytic argument but by reading the value formula: ζ(−2n) = −B'_{2n+1}/(2n+1), and B'_{2n+1} = 0 because 2n+1 is odd and exceeds 1. These are precisely the trivial zeros of ζ at the negative even integers — the ones excluded from the Riemann Hypothesis, which concerns the nontrivial zeros on the critical line Re(s) = 1/2."
+    "content": "`zeta_neg_even` proves ζ(−2n) = 0 for n ≥ 1 not by an analytic argument but by reading the value formula: ζ(−2n) = −B'_{2n+1}/(2n+1), and B'_{2n+1} = 0 because 2n+1 is odd and exceeds 1. These are precisely the trivial zeros of ζ at the negative even integers — the ones excluded from the Riemann Hypothesis, which concerns the nontrivial zeros on the critical line Re(s) = 1/2.",
+    "mathContext": "$\\zeta(-2n) = -\\dfrac{B'_{2n+1}}{2n+1} = 0$ for $n \\ge 1$, since $B'_m = 0$ for every odd $m > 1$. Contrast the functional equation $\\zeta(s) = 2^s\\pi^{s-1}\\sin\\!\\big(\\tfrac{\\pi s}{2}\\big)\\Gamma(1-s)\\zeta(1-s)$, where the factor $\\sin(\\pi s/2)$ vanishes at $s = -2, -4, \\dots$ — the analytic source of the same zeros.",
+    "significance": "key",
+    "relatedConcepts": ["trivial zeros", "Riemann hypothesis", "odd Bernoulli numbers", "critical line", "functional equation"],
+    "prerequisites": ["Bernoulli numbers", "Riemann hypothesis statement", "parity of Bernoulli numbers"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `arithmetic-series-oq-04-oq-03`.

The meta.json was already rich (historicalContext, 5 keyInsights, conclusion, sections, cross-references, references). The clear gap was that all 5 annotations carried only `content` — none of the structured depth fields. This pass adds:

- **`mathContext`** — LaTeX formulas for each annotation (value formula $\zeta(-n)=-B'_{n+1}/(n+1)$, the convention reconciliation $B'_m=(-1)^m B_m$, the Faulhaber bridge, $\zeta(-1)=-1/12$, and the trivial-zeros identity with its functional-equation counterpart).
- **`significance`** — key/supporting classification on each annotation.
- **`relatedConcepts`** — e.g. zeta regularization, Casimir effect, bosonic string theory, trivial zeros, functional equation, Euler–Maclaurin.
- **`prerequisites`** — per-annotation background (complex analysis, divergent series, Bernoulli number parity, etc.).

No content was deleted; meta.json untouched. JSON validated by the gallery prebuild step. meta.json remains 15.4 KB (well under the 60 KB cap). `index.ts` intentionally not added — the loader moved to `listings.json`/build-generated `public/data` per #20993, so shim files are legacy.