### PR TITLE
audit(abel-ruffini-galois-extensions-oq-02): badge verified→mathlib (Tier B Mathlib bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02/meta.json
@@ -18,7 +18,7 @@
       "advanced"
     ],
     "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 201,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: abel-ruffini-galois-extensions-oq-02 — *The Fundamental Theorem of Galois Theory — Subfields ↔ Subgroups*
**Severity**: MEDIUM (Mathlib wrapper badged as independent `verified`)
**Tier**: B (Formalized using Mathlib theorem)

## Finding

The headline result is a direct Mathlib alias:

```lean
noncomputable def galoisCorrespondence :
    IntermediateField F E ≃o (Subgroup (E ≃ₐ[F] E))ᵒᵈ :=
  IsGalois.intermediateFieldEquivSubgroup
```

and most of the file's 10 theorems (`fixedField_fixingSubgroup`, `fixingSubgroup_fixedField`, `fixingSubgroup_bot/top`, `fixedField_top`, `card_fixingSubgroup_eq_finrank`, `normalQuotientEquiv`, `isGalois_fixedField_of_normal`) are likewise direct Mathlib aliases. This is auditor **failure mode 5** — *0 sorries, but the core result is obtained by calling a deep Mathlib theorem*.

Per the auditor Tier rules, such a file must carry badge **`mathlib`**, not `verified`/`original`, which signal independent full machine-checking.

## What was already correct

The **narrative disclosure is honest** and needs no change:
- `description`, `overview`, and `proofStrategy` all lead with "Mathlib already contains the core theorem … this file packages it".
- `assumptions` states it is a "faithful packaging of Mathlib's already-machine-checked Fundamental Theorem of Galois Theory".
- `mathlibDependencies` lists all 11 imported declarations.
- `originalContributions` is correctly scoped to the genuinely derived corollaries (`le_iff_fixingSubgroup_le`, `finrank_eq_index_fixingSubgroup`, the count bijection, the quintic instantiation).

Only the `badge` field overclaimed independence.

## Change

`badge`: `"verified"` → `"mathlib"`.

`status` stays `"verified"` — this is the dominant gallery convention for Mathlib bridges (648 entries pair `status: verified` + `badge: mathlib`).

## Verification against Lean source

`proofs/Proofs/AbelRuffiniGaloisExtensionsOQ02.lean`:
- sorries: **0** (the lone `sorry` grep hit is the docstring phrase "0 sorry, 0 axiom") ✓ matches meta
- `axiom` declarations: **0** ✓
- `native_decide`: **0** ✓
- theorems/lemmas: **10** ✓ matches `theoremCount`
- defs: **3** ✓ matches `definitionCount`
- lines: **201** ✓ matches `lineCount`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)