### PR TITLE
Enrich Perfect Complete Metric Spaces ≥ Continuum: annotation depth

### DIFF
--- a/src/data/proofs/baire-category-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-03/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 42, "endLine": 47 },
     "type": "insight",
     "title": "The Cantor Space Has Cardinality the Continuum",
-    "content": "mk_nat_arrow_bool reads off #(ℕ → Bool) = 𝔠 in one chain. Cardinal.power_def rewrites the function space as a power #Bool ^ #ℕ; mk_bool gives #Bool = 2 and mk_nat gives #ℕ = ℵ₀; and two_power_aleph0 closes with 2 ^ ℵ₀ = 𝔠. This is the cardinal that the Cantor-scheme embedding will transfer into any nonempty perfect set — the whole point is that a perfect set contains a topological copy of Cantor space, and Cantor space already has continuum cardinality."
+    "content": "mk_nat_arrow_bool reads off #(ℕ → Bool) = 𝔠 in one chain. Cardinal.power_def rewrites the function space as a power #Bool ^ #ℕ; mk_bool gives #Bool = 2 and mk_nat gives #ℕ = ℵ₀; and two_power_aleph0 closes with 2 ^ ℵ₀ = 𝔠. This is the cardinal that the Cantor-scheme embedding will transfer into any nonempty perfect set — the whole point is that a perfect set contains a topological copy of Cantor space, and Cantor space already has continuum cardinality.",
+    "mathContext": "$\\#(\\mathbb{N}\\to\\mathrm{Bool}) = \\#\\mathrm{Bool}^{\\#\\mathbb{N}} = 2^{\\aleph_0} = \\mathfrak{c}$. The function-space cardinal is a cardinal exponential, and $2^{\\aleph_0} = \\mathfrak{c}$ is the definition of the continuum.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cantor space", "cardinal exponentiation", "continuum 𝔠", "cardinal arithmetic", "power set cardinality"],
+    "prerequisites": ["cardinal arithmetic", "cardinal exponentiation", "definition of 𝔠 = 2^ℵ₀"]
   },
   {
     "id": "ann-core-perfect-bound",
@@ -13,7 +17,11 @@
     "range": { "startLine": 50, "endLine": 64 },
     "type": "insight",
     "title": "Corestrict the Cantor-Scheme Injection to the Perfect Set",
-    "content": "continuum_le_mk_of_perfect is the core. Mathlib's Perfect.exists_nat_bool_injection supplies a continuous injection f : (ℕ → Bool) → X whose range lies inside C (the Cantor scheme: nested closed balls of vanishing diameter, whose limit points are indexed by binary sequences). Since range f ⊆ C, every f x lands in C, so g x := ⟨f x, hmem x⟩ corestricts f to the subtype ↥C; corestriction preserves injectivity (congrArg Subtype.val). Then mk_le_of_injective gives #(ℕ → Bool) ≤ #C, and mk_nat_arrow_bool rewrites the left side to 𝔠. The bound is a property of perfect SETS, not just perfect spaces."
+    "content": "continuum_le_mk_of_perfect is the core. Mathlib's Perfect.exists_nat_bool_injection supplies a continuous injection f : (ℕ → Bool) → X whose range lies inside C (the Cantor scheme: nested closed balls of vanishing diameter, whose limit points are indexed by binary sequences). Since range f ⊆ C, every f x lands in C, so g x := ⟨f x, hmem x⟩ corestricts f to the subtype ↥C; corestriction preserves injectivity (congrArg Subtype.val). Then mk_le_of_injective gives #(ℕ → Bool) ≤ #C, and mk_nat_arrow_bool rewrites the left side to 𝔠. The bound is a property of perfect SETS, not just perfect spaces.",
+    "mathContext": "An injection $g:(\\mathbb{N}\\to\\mathrm{Bool})\\hookrightarrow C$ gives $\\#(\\mathbb{N}\\to\\mathrm{Bool}) \\le \\#C$, i.e. $\\mathfrak{c} \\le \\#C$. The Cantor scheme builds nested closed balls $B_s$ ($s$ a finite binary string) with $\\operatorname{diam}(B_s)\\to 0$; completeness sends each branch $x\\in 2^{\\mathbb{N}}$ to a unique limit point in $C$.",
+    "significance": "key",
+    "relatedConcepts": ["Cantor scheme", "perfect set", "nested closed balls", "completeness", "injective corestriction", "Cantor–Bendixson theorem"],
+    "prerequisites": ["complete metric spaces", "perfect sets", "cardinal comparison via injections"]
   },
   {
     "id": "ann-not-countable",
@@ -21,7 +29,11 @@
     "range": { "startLine": 66, "endLine": 74 },
     "type": "insight",
     "title": "Uncountability as a Corollary of the Cardinal Bound",
-    "content": "not_countable_of_perfect recovers the qualitative Cantor–Bendixson fact (perfect sets are uncountable) from the quantitative one. If C were countable then Countable ↥C (countable_coe_iff), giving #C ≤ ℵ₀ (mk_le_aleph0_iff). But the core bound gives 𝔠 ≤ #C, so 𝔠 ≤ ℵ₀ — contradicting aleph0_lt_continuum (ℵ₀ < 𝔠). The strict gap between ℵ₀ and 𝔠 is exactly what upgrades 'at least continuum' to 'uncountable'."
+    "content": "not_countable_of_perfect recovers the qualitative Cantor–Bendixson fact (perfect sets are uncountable) from the quantitative one. If C were countable then Countable ↥C (countable_coe_iff), giving #C ≤ ℵ₀ (mk_le_aleph0_iff). But the core bound gives 𝔠 ≤ #C, so 𝔠 ≤ ℵ₀ — contradicting aleph0_lt_continuum (ℵ₀ < 𝔠). The strict gap between ℵ₀ and 𝔠 is exactly what upgrades 'at least continuum' to 'uncountable'.",
+    "mathContext": "Suppose $C$ countable: then $\\#C \\le \\aleph_0$. With $\\mathfrak{c} \\le \\#C$ this forces $\\mathfrak{c} \\le \\aleph_0$, contradicting Cantor's theorem $\\aleph_0 < 2^{\\aleph_0} = \\mathfrak{c}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["uncountability", "Cantor's theorem", "ℵ₀ < 𝔠", "proof by contradiction", "Cantor–Bendixson theorem"],
+    "prerequisites": ["countable vs uncountable sets", "Cantor's diagonal theorem"]
   },
   {
     "id": "ann-whole-space",
@@ -29,7 +41,11 @@
     "range": { "startLine": 76, "endLine": 86 },
     "type": "insight",
     "title": "Whole-Space Form: No Isolated Points",
-    "content": "continuum_le_mk_of_perfectSpace specializes the core to C = univ. The hypothesis is PerfectSpace α — a space with no isolated points (perfectSpace_iff_forall_not_isolated equates this with NeBot (𝓝[≠] x) at every point). PerfectSpace.univ_perfect makes univ a perfect set and univ_nonempty supplies nonemptiness; mk_univ rewrites #↥univ = #α. uncountable_of_perfectSpace then chains ℵ₀ < 𝔠 ≤ #α through aleph0_lt_mk_iff to conclude Uncountable α. Completeness powers the convergence of the nested balls; no-isolated-points powers the room to keep splitting — both Baire-flavored hypotheses are load-bearing."
+    "content": "continuum_le_mk_of_perfectSpace specializes the core to C = univ. The hypothesis is PerfectSpace α — a space with no isolated points (perfectSpace_iff_forall_not_isolated equates this with NeBot (𝓝[≠] x) at every point). PerfectSpace.univ_perfect makes univ a perfect set and univ_nonempty supplies nonemptiness; mk_univ rewrites #↥univ = #α. uncountable_of_perfectSpace then chains ℵ₀ < 𝔠 ≤ #α through aleph0_lt_mk_iff to conclude Uncountable α. Completeness powers the convergence of the nested balls; no-isolated-points powers the room to keep splitting — both Baire-flavored hypotheses are load-bearing.",
+    "mathContext": "A $\\mathrm{PerfectSpace}$ has no isolated points: $\\mathcal{N}_{\\ne}(x) \\ne \\bot$ (the punctured neighborhood filter is nontrivial) at every $x$. Then $\\mathrm{univ}$ is perfect, so $\\mathfrak{c} \\le \\#\\,\\mathrm{univ} = \\#\\alpha$.",
+    "significance": "key",
+    "relatedConcepts": ["PerfectSpace", "isolated points", "neighborhood filter", "Baire category theorem", "complete metric space"],
+    "prerequisites": ["topological isolated points", "neighborhood filters", "perfect sets"]
   },
   {
     "id": "ann-real-witness",
@@ -37,6 +53,10 @@
     "range": { "startLine": 88, "endLine": 93 },
     "type": "insight",
     "title": "The Real Line Falls Out for Free",
-    "content": "continuum_le_mk_real : 𝔠 ≤ #ℝ is just the whole-space form at α = ℝ — no real-analysis input. ℝ is a complete metric space, and it is a PerfectSpace purely formally: the instance [T1Space α] [ConnectedSpace α] [Nontrivial α] → PerfectSpace α fires because ℝ is connected, T1, and nontrivial, so it has no isolated points. This recovers and quantitatively sharpens the parent entry's real_uncountable: not merely uncountable, but of cardinality at least the continuum."
+    "content": "continuum_le_mk_real : 𝔠 ≤ #ℝ is just the whole-space form at α = ℝ — no real-analysis input. ℝ is a complete metric space, and it is a PerfectSpace purely formally: the instance [T1Space α] [ConnectedSpace α] [Nontrivial α] → PerfectSpace α fires because ℝ is connected, T1, and nontrivial, so it has no isolated points. This recovers and quantitatively sharpens the parent entry's real_uncountable: not merely uncountable, but of cardinality at least the continuum.",
+    "mathContext": "$\\mathfrak{c} \\le \\#\\mathbb{R}$. The instance chain $T_1 + \\text{connected} + \\text{nontrivial} \\Rightarrow \\mathrm{PerfectSpace}$ holds because a connected $T_1$ space with $\\ge 2$ points has no isolated point (an isolated point would be clopen). Combined with the upper bound $\\#\\mathbb{R} \\le \\mathfrak{c}$ this gives the classical $\\#\\mathbb{R} = \\mathfrak{c}$.",
+    "significance": "key",
+    "relatedConcepts": ["cardinality of the reals", "connected spaces", "T1 separation", "typeclass inference", "real_uncountable"],
+    "prerequisites": ["topology of ℝ", "connectedness", "separation axioms"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `baire-category-theorem-oq-01-oq-03`.

meta.json was already rich (historicalContext, 5 keyInsights, conclusion, sections with mathContext, cross-reference, references). The gap: all 5 annotations carried only `content`. This pass adds the structured depth fields:

- **`mathContext`** — LaTeX for each annotation: $\#(\mathbb{N}\to\mathrm{Bool})=2^{\aleph_0}=\mathfrak{c}$, the Cantor-scheme injection $\mathfrak{c}\le\#C$, the $\aleph_0<\mathfrak{c}$ contradiction, the PerfectSpace/no-isolated-points characterization, and the $T_1+\text{connected}+\text{nontrivial}\Rightarrow\mathrm{PerfectSpace}$ instance giving $\mathfrak{c}\le\#\mathbb{R}$.
- **`significance`** — key/supporting per annotation.
- **`relatedConcepts`** — Cantor scheme, PerfectSpace, Cantor–Bendixson, cardinal exponentiation, etc.
- **`prerequisites`** — per-annotation background.

No content deleted; meta.json untouched (15.3 KB, under cap). Annotation line ranges verified against the Lean source. JSON validated.