### PR TITLE
research(brianchon-theorem-oq-01-oq-01-oq-01): Pascal transfers to every linear image — projective covariance

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -540,6 +540,7 @@ import Proofs.BoundedPrimeGapsSieve
 import Proofs.BoundedPrimeGapsTPC
 import Proofs.BrianchonTheorem
 import Proofs.BrianchonTheoremAristotle
+import Proofs.BrianchonTheoremOQ01OQ01OQ01
 import Proofs.BrianchonTheoremOQ01OQ02
 import Proofs.BritishFlagDefect
 import Proofs.BritishFlagTheorem

--- a/proofs/Proofs/BrianchonTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/BrianchonTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,203 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic
+
+/-
+# Pascal transfers to every linear image of the conic — projective covariance, axiom-free
+
+## What This Proves
+
+The parent `BrianchonTheoremOQ01OQ01.lean` proves Pascal's hexagon theorem for the
+**rational-normal conic** `xz = y²` (parametrized `t ↦ (t², t, 1)`) axiom-free, in
+the homogeneous `ℝ³` cross-product / determinant model.  Its docstring identifies
+the **only** remaining ingredient separating that result from a full discharge of
+the abstract `conic_implies_pascal` axiom:
+
+> the projective-normalization / Sylvester transfer — that Pascal's conclusion is
+> invariant under projective maps, so the parametrized case carries over to an
+> arbitrary nondegenerate conic.
+
+This file formalizes the **projective-covariance half** of that transfer, axiom-free.
+We show Pascal's collinearity conclusion survives applying **any** linear map
+`m : ℝ³ → ℝ³` to all six hexagon vertices — hence Pascal holds for every linear
+image of the rational-normal conic.  Two classical identities of the `ℝ³` model do
+all the work, each a single `ring` computation:
+
+* **Cross-product covariance** (`cross_applyM`):
+  `(m u) × (m v) = cof(m) · (u × v)`, where `cof(m)` is the cofactor matrix
+  (`= adj(m)ᵀ`).  The join/meet of transformed points is the transformed join/meet.
+* **Determinant covariance** (`det3_applyM`):
+  `det₃(m u, m v, m w) = det(m) · det₃(u, v, w)`.  Collinearity (vanishing of `det₃`)
+  is therefore a projective invariant.
+
+Applying `cross_applyM` three times shows each transformed Pascal point is the SAME
+matrix `cof(cof(m))` applied to the original Pascal point; `det3_applyM` then sends
+the original (zero) collinearity determinant to zero.  No invertibility of `m` is
+needed — the conclusion is a polynomial identity — so the result holds for every
+linear map, and specializes to the genuine projective transfer when `det(m) ≠ 0`.
+
+## Relation to the `conic_implies_pascal` axiom
+
+Together with a Sylvester normalization (every nondegenerate symmetric `C` has an
+invertible `M` carrying its zero locus `xᵀ C x = 0` onto `xz = y²`), this covariance
+step would discharge `conic_implies_pascal` for nondegenerate conics: pull the six
+points back along `M`, apply the parent's `pascal_parametrized`, and push forward by
+`pascal_image` here.  The Sylvester normalization (the symmetric-matrix linear
+algebra) is the remaining piece; the covariance is done here.
+
+## Status
+- [x] Cross-product and determinant covariance under a linear map — 0 sorries, 0 axioms
+- [x] Pascal transfers to every linear image of the rational-normal conic
+- [x] Same homogeneous `ℝ³` cross/det model as the parent; pure `ring` identities
+- [x] No `sorry`, no `axiom`, no `native_decide`
+-/
+
+namespace BrianchonOQ01OQ01OQ01
+
+/-! ## Homogeneous `ℝ³` model (cross product, determinant, collinearity)
+Reproduced from the parent entry so this file is self-contained. -/
+
+/-- The cross product of two vectors in `ℝ³` — the join of two projective points
+and the meet of two projective lines. -/
+noncomputable def cross (u v : Fin 3 → ℝ) : Fin 3 → ℝ :=
+  ![u 1 * v 2 - u 2 * v 1, u 2 * v 0 - u 0 * v 2, u 0 * v 1 - u 1 * v 0]
+
+/-- The scalar triple product `u · (v × w)` = the `3×3` determinant with rows
+`u, v, w`.  Three projective points are collinear iff this vanishes. -/
+noncomputable def det3 (u v w : Fin 3 → ℝ) : ℝ :=
+  u 0 * (v 1 * w 2 - v 2 * w 1)
+    - u 1 * (v 0 * w 2 - v 2 * w 0)
+    + u 2 * (v 0 * w 1 - v 1 * w 0)
+
+/-- Three projective points are collinear iff their determinant vanishes. -/
+def Collinear (p q r : Fin 3 → ℝ) : Prop := det3 p q r = 0
+
+/-- A point of the rational-normal conic `xz = y²`, parametrized by `t ↦ (t², t, 1)`. -/
+noncomputable def conicPt (t : ℝ) : Fin 3 → ℝ := ![t ^ 2, t, 1]
+
+/-! ## A linear map on `ℝ³` and its determinant / cofactor matrix
+Given as explicit component formulas (matching the parent's style) so every
+covariance identity reduces to a single `ring` call. -/
+
+/-- Apply the `3×3` matrix `m` (rows `m 0, m 1, m 2`) to a vector `u`. -/
+noncomputable def applyM (m : Fin 3 → Fin 3 → ℝ) (u : Fin 3 → ℝ) : Fin 3 → ℝ :=
+  ![m 0 0 * u 0 + m 0 1 * u 1 + m 0 2 * u 2,
+    m 1 0 * u 0 + m 1 1 * u 1 + m 1 2 * u 2,
+    m 2 0 * u 0 + m 2 1 * u 1 + m 2 2 * u 2]
+
+/-- The determinant of the `3×3` matrix `m` (cofactor expansion along row 0). -/
+noncomputable def detM (m : Fin 3 → Fin 3 → ℝ) : ℝ :=
+  m 0 0 * (m 1 1 * m 2 2 - m 1 2 * m 2 1)
+    - m 0 1 * (m 1 0 * m 2 2 - m 1 2 * m 2 0)
+    + m 0 2 * (m 1 0 * m 2 1 - m 1 1 * m 2 0)
+
+/-- The **cofactor matrix** `cof(m)` (`= adj(m)ᵀ`): entry `(i, j)` is the signed
+`(i, j)` cofactor of `m`.  It satisfies `(m u) × (m v) = cof(m) · (u × v)`. -/
+noncomputable def cof (m : Fin 3 → Fin 3 → ℝ) : Fin 3 → Fin 3 → ℝ :=
+  ![![m 1 1 * m 2 2 - m 1 2 * m 2 1, m 1 2 * m 2 0 - m 1 0 * m 2 2,
+      m 1 0 * m 2 1 - m 1 1 * m 2 0],
+    ![m 0 2 * m 2 1 - m 0 1 * m 2 2, m 0 0 * m 2 2 - m 0 2 * m 2 0,
+      m 0 1 * m 2 0 - m 0 0 * m 2 1],
+    ![m 0 1 * m 1 2 - m 0 2 * m 1 1, m 0 2 * m 1 0 - m 0 0 * m 1 2,
+      m 0 0 * m 1 1 - m 0 1 * m 1 0]]
+
+/-! ## The two covariance identities -/
+
+/-- **Cross-product covariance.** The join/meet of two transformed points is the
+cofactor matrix applied to the join/meet: `(m u) × (m v) = cof(m) · (u × v)`. -/
+theorem cross_applyM (m : Fin 3 → Fin 3 → ℝ) (u v : Fin 3 → ℝ) :
+    cross (applyM m u) (applyM m v) = applyM (cof m) (cross u v) := by
+  funext i
+  fin_cases i <;>
+    · simp only [cross, applyM, cof, Matrix.cons_val_zero, Matrix.cons_val_one,
+        Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons]
+      ring
+
+/-- **Determinant covariance.** `det₃(m u, m v, m w) = det(m) · det₃(u, v, w)`, so
+collinearity (the vanishing of `det₃`) is preserved by every linear map. -/
+theorem det3_applyM (m : Fin 3 → Fin 3 → ℝ) (u v w : Fin 3 → ℝ) :
+    det3 (applyM m u) (applyM m v) (applyM m w) = detM m * det3 u v w := by
+  simp only [det3, applyM, detM, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- **Collinearity is a projective invariant** (for invertible `m`): if `det(m) ≠ 0`
+then the images `m u, m v, m w` are collinear iff `u, v, w` are. -/
+theorem collinear_applyM_iff {m : Fin 3 → Fin 3 → ℝ} (hm : detM m ≠ 0)
+    (u v w : Fin 3 → ℝ) :
+    Collinear (applyM m u) (applyM m v) (applyM m w) ↔ Collinear u v w := by
+  unfold Collinear
+  rw [det3_applyM, mul_eq_zero]
+  constructor
+  · rintro (h | h)
+    · exact absurd h hm
+    · exact h
+  · intro h; exact Or.inr h
+
+/-! ## Pascal transfers to every linear image of the conic -/
+
+/-- The three Pascal points of an inscribed hexagon `A B C D E F`
+(`X = (AB) ∧ (DE)`, `Y = (BC) ∧ (EF)`, `Z = (CD) ∧ (FA)`). -/
+noncomputable def pascalX (A B _C D E _F : Fin 3 → ℝ) : Fin 3 → ℝ :=
+  cross (cross A B) (cross D E)
+noncomputable def pascalY (_A B C _D E F : Fin 3 → ℝ) : Fin 3 → ℝ :=
+  cross (cross B C) (cross E F)
+noncomputable def pascalZ (A _B C D _E F : Fin 3 → ℝ) : Fin 3 → ℝ :=
+  cross (cross C D) (cross F A)
+
+/-- Each Pascal point of the transformed hexagon is the SAME matrix `cof(cof m)`
+applied to the original Pascal point — apply `cross_applyM` three times. -/
+theorem pascalX_applyM (m : Fin 3 → Fin 3 → ℝ) (A B C D E F : Fin 3 → ℝ) :
+    pascalX (applyM m A) (applyM m B) (applyM m C) (applyM m D) (applyM m E) (applyM m F)
+      = applyM (cof (cof m)) (pascalX A B C D E F) := by
+  simp only [pascalX]
+  rw [cross_applyM, cross_applyM, cross_applyM]
+
+theorem pascalY_applyM (m : Fin 3 → Fin 3 → ℝ) (A B C D E F : Fin 3 → ℝ) :
+    pascalY (applyM m A) (applyM m B) (applyM m C) (applyM m D) (applyM m E) (applyM m F)
+      = applyM (cof (cof m)) (pascalY A B C D E F) := by
+  simp only [pascalY]
+  rw [cross_applyM, cross_applyM, cross_applyM]
+
+theorem pascalZ_applyM (m : Fin 3 → Fin 3 → ℝ) (A B C D E F : Fin 3 → ℝ) :
+    pascalZ (applyM m A) (applyM m B) (applyM m C) (applyM m D) (applyM m E) (applyM m F)
+      = applyM (cof (cof m)) (pascalZ A B C D E F) := by
+  simp only [pascalZ]
+  rw [cross_applyM, cross_applyM, cross_applyM]
+
+/-- **Pascal's theorem for the rational-normal conic (parametrized case).**
+Re-proved here self-containedly: for any six parameters the Pascal points are
+collinear. -/
+theorem pascal_parametrized (a b c d e f : ℝ) :
+    Collinear
+      (pascalX (conicPt a) (conicPt b) (conicPt c) (conicPt d) (conicPt e) (conicPt f))
+      (pascalY (conicPt a) (conicPt b) (conicPt c) (conicPt d) (conicPt e) (conicPt f))
+      (pascalZ (conicPt a) (conicPt b) (conicPt c) (conicPt d) (conicPt e) (conicPt f)) := by
+  simp only [Collinear, det3, pascalX, pascalY, pascalZ, cross, conicPt,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons]
+  ring
+
+/-- **Main theorem — Pascal transfers to every linear image of the conic.**
+For any linear map `m` and any six parameters, the six points
+`m · conicPt a, …, m · conicPt f` (the image of the rational-normal conic under `m`)
+have collinear Pascal points.  The transformed Pascal points are `cof(cof m)` applied
+to the originals (`pascal{X,Y,Z}_applyM`), and `det3_applyM` carries the original
+zero collinearity determinant to zero — no invertibility of `m` required.  For
+invertible `m` (`det m ≠ 0`) this is the genuine projective transfer of Pascal's
+theorem to the conic `m · (xz = y²)`. -/
+theorem pascal_image (m : Fin 3 → Fin 3 → ℝ) (a b c d e f : ℝ) :
+    Collinear
+      (pascalX (applyM m (conicPt a)) (applyM m (conicPt b)) (applyM m (conicPt c))
+        (applyM m (conicPt d)) (applyM m (conicPt e)) (applyM m (conicPt f)))
+      (pascalY (applyM m (conicPt a)) (applyM m (conicPt b)) (applyM m (conicPt c))
+        (applyM m (conicPt d)) (applyM m (conicPt e)) (applyM m (conicPt f)))
+      (pascalZ (applyM m (conicPt a)) (applyM m (conicPt b)) (applyM m (conicPt c))
+        (applyM m (conicPt d)) (applyM m (conicPt e)) (applyM m (conicPt f))) := by
+  unfold Collinear
+  rw [pascalX_applyM, pascalY_applyM, pascalZ_applyM, det3_applyM]
+  have h := pascal_parametrized a b c d e f
+  unfold Collinear at h
+  rw [h, mul_zero]
+
+end BrianchonOQ01OQ01OQ01

--- a/src/data/proofs/brianchon-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/brianchon-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,118 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "brianchon-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 99
+    },
+    "type": "concept",
+    "title": "The Projective-Covariance Half of the Sylvester Transfer",
+    "content": "The parent entry proves Pascal for the rational-normal conic xz = y² axiom-free and flags one remaining ingredient toward discharging the abstract conic_implies_pascal axiom: that Pascal's conclusion is invariant under projective (linear) maps, so the parametrized case transports to an arbitrary conic. This file supplies exactly that covariance, reproducing the parent's homogeneous ℝ³ model — projective points are vectors, the join/meet of points/lines is the cross product, three points are collinear iff their 3×3 determinant det3 vanishes — and adding a linear map applyM, its determinant detM, and the cofactor matrix cof(m) = adj(m)ᵀ. Everything is written as explicit component formulas so each covariance identity is a single ring call.",
+    "mathContext": "\\text{points } \\in \\mathbb{R}^3,\\quad \\text{join/meet} = \\times,\\quad \\text{collinear} \\iff \\det_3 = 0",
+    "significance": "key",
+    "relatedConcepts": [
+      "projective invariance",
+      "homogeneous coordinates",
+      "cofactor matrix",
+      "Pascal's theorem"
+    ],
+    "prerequisites": [
+      "ℝ³ cross-product / determinant model",
+      "Pascal for xz = y²",
+      "cofactor / adjugate matrices"
+    ]
+  },
+  {
+    "id": "ann-cross-covariance",
+    "proofId": "brianchon-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 100,
+      "endLine": 117
+    },
+    "type": "proof-technique",
+    "title": "Cross-Product Covariance",
+    "content": "`cross_applyM` proves the classical identity (m u) × (m v) = cof(m)·(u × v), where cof(m) is the cofactor matrix (equivalently adj(m)ᵀ): the join/meet of two transformed projective points is the transformed join/meet. The proof is component-wise — `funext i; fin_cases i` splits into the three coordinates, `simp only` unfolds cross, applyM, and cof, and `ring` closes each polynomial identity. This is the engine of the whole transfer: it is what lets a linear map be pushed through the cross products that define the Pascal points.",
+    "mathContext": "(m\\,u) \\times (m\\,v) = \\mathrm{cof}(m)\\,(u \\times v) = \\mathrm{adj}(m)^{\\mathsf T}(u \\times v)",
+    "significance": "key",
+    "relatedConcepts": [
+      "cross product",
+      "cofactor matrix",
+      "adjugate",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "cofactor matrix",
+      "fin_cases over Fin 3",
+      "polynomial identities"
+    ]
+  },
+  {
+    "id": "ann-det-covariance",
+    "proofId": "brianchon-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 118,
+      "endLine": 138
+    },
+    "type": "insight",
+    "title": "Determinant Covariance and Collinearity Invariance",
+    "content": "`det3_applyM` proves det₃(m u, m v, m w) = det(m)·det₃(u, v, w) — the determinant of the matrix with transformed rows scales by det(m). Since collinearity is defined by det₃ = 0, this makes collinearity a projective invariant: `collinear_applyM_iff` packages the invertible case (det m ≠ 0) as a genuine iff. For the Pascal transfer only the easy direction is needed — if the original determinant is zero, so is the transformed one — and that holds for every m, invertible or not.",
+    "mathContext": "\\det_3(m\\,u, m\\,v, m\\,w) = \\det(m)\\,\\det_3(u, v, w)",
+    "significance": "key",
+    "relatedConcepts": [
+      "determinant multiplicativity",
+      "projective invariant",
+      "collinearity"
+    ],
+    "prerequisites": [
+      "3×3 determinant",
+      "mul_eq_zero"
+    ]
+  },
+  {
+    "id": "ann-pascal-points",
+    "proofId": "brianchon-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 139,
+      "endLine": 168
+    },
+    "type": "proof-technique",
+    "title": "Transformed Pascal Points Share One Matrix",
+    "content": "The Pascal points X = (AB)∧(DE), Y = (BC)∧(EF), Z = (CD)∧(FA) are each a doubly-nested cross product. Applying cross_applyM three times — twice on the inner joins, once on the outer meet — `pascalX_applyM` (and Y, Z) shows each transformed Pascal point equals cof(cof m) applied to the original. The crucial point is that this is the SAME matrix K = cof(cof m) for all three Pascal points, so the next step can scale all three uniformly. (For 3×3, cof(cof m) = det(m)·m, though the proof does not need to simplify it.)",
+    "mathContext": "\\text{pascalX}(m\\cdot) = \\mathrm{cof}(\\mathrm{cof}\\,m)\\cdot \\text{pascalX}(\\cdot), \\text{ likewise Y, Z}",
+    "significance": "key",
+    "relatedConcepts": [
+      "cross product nesting",
+      "cof(cof m) = det(m)·m",
+      "Pascal points"
+    ],
+    "prerequisites": [
+      "cross_applyM",
+      "join/meet of projective objects"
+    ]
+  },
+  {
+    "id": "ann-pascal-image",
+    "proofId": "brianchon-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 169,
+      "endLine": 203
+    },
+    "type": "insight",
+    "title": "Pascal Holds for Every Linear Image — the Main Theorem",
+    "content": "`pascal_parametrized` re-proves Pascal for the conic xz = y² (a single ring identity). `pascal_image` then transfers it: rewriting each Pascal point of the image hexagon via pascalX/Y/Z_applyM turns the goal into det₃(K·pX, K·pY, K·pZ), which det3_applyM equals det(K)·det₃(pX, pY, pZ); the parent's collinearity gives det₃(pX, pY, pZ) = 0, so the product is 0. No invertibility of m is used — the statement is a polynomial identity holding for every linear map, and it specializes to the genuine projective transfer of Pascal's theorem to the conic m·(xz = y²) when det m ≠ 0. This is the covariance ingredient the parent flagged as the path to discharging conic_implies_pascal.",
+    "mathContext": "\\det_3(K p_X, K p_Y, K p_Z) = \\det(K)\\cdot 0 = 0,\\quad K = \\mathrm{cof}(\\mathrm{cof}\\,m)",
+    "significance": "key",
+    "relatedConcepts": [
+      "projective transfer",
+      "Sylvester normalization",
+      "conic_implies_pascal",
+      "axiom discharge"
+    ],
+    "prerequisites": [
+      "pascalX_applyM",
+      "det3_applyM",
+      "pascal_parametrized"
+    ]
+  }
+]

--- a/src/data/proofs/brianchon-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/brianchon-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "brianchon-theorem-oq-01-oq-01-oq-01",
+  "title": "Pascal Transfers to Every Linear Image of the Conic — Projective Covariance",
+  "slug": "brianchon-theorem-oq-01-oq-01-oq-01",
+  "description": "The parent entry proves Pascal's hexagon theorem for the rational-normal conic xz = y² axiom-free and identifies the projective-normalization (Sylvester) transfer as the only remaining ingredient for discharging the abstract conic_implies_pascal axiom. This follow-up formalizes the covariance half of that transfer: Pascal's collinearity conclusion survives applying any linear map m to all six hexagon vertices, so Pascal holds for every linear image of the rational-normal conic. Two classical ℝ³ identities do the work — cross-product covariance (m u) × (m v) = cof(m)·(u × v) and determinant covariance det₃(m u, m v, m w) = det(m)·det₃(u, v, w) — each a single ring computation. No invertibility of m is needed; the conclusion is a polynomial identity. Fully verified: 8 theorems, 10 defs, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Robb Walters (researcher-8)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pascal%27s_theorem",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BrianchonTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "projective",
+      "conic",
+      "pascal",
+      "incidence-theorem",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 203,
+    "theoremCount": 8,
+    "definitionCount": 10,
+    "originalContributions": [
+      "cross_applyM: cross-product covariance (m u) × (m v) = cof(m)·(u × v) in the homogeneous ℝ³ model, where cof(m) is the cofactor matrix (= adj(m)ᵀ) — the join/meet of transformed projective points is the transformed join/meet. Proved by a single ring computation per component, zero axioms.",
+      "det3_applyM: determinant covariance det₃(m u, m v, m w) = det(m)·det₃(u, v, w), so collinearity (vanishing of det₃) is a projective invariant; collinear_applyM_iff packages the invertible case (det m ≠ 0) as an iff.",
+      "pascalX_applyM / pascalY_applyM / pascalZ_applyM: each Pascal point of the transformed hexagon equals the SAME matrix cof(cof m) applied to the original Pascal point — three applications of cross_applyM.",
+      "pascal_image: the main result — for any linear map m and any six parameters, the points m·conicPt a, …, m·conicPt f (the image of the rational-normal conic under m) have collinear Pascal points, carrying the parent's pascal_parametrized forward via det3_applyM. No invertibility required; specializes to the genuine projective transfer when det m ≠ 0.",
+      "Self-contained: imports only Mathlib.Data.Real.Basic / Fin.VecNotation / Tactic (no Mathlib conic or EKR machinery), matching the parent's axiom-free ℝ³ cross/determinant model; #print axioms confirms dependence only on propext, Classical.choice, Quot.sound (no sorryAx, no Lean.ofReduceBool)."
+    ],
+    "prerequisites": [
+      "The parent's homogeneous ℝ³ projective model: points as vectors, join/meet as cross product, collinearity as a vanishing 3×3 determinant",
+      "Pascal's hexagon theorem for the rational-normal conic xz = y² (the parent entry)",
+      "The cofactor / adjugate matrix and the classical identities (Mu)×(Mv) = adj(M)ᵀ(u×v) and det(Mu,Mv,Mw) = det(M)·det(u,v,w)",
+      "Projective invariance of incidence under invertible linear maps"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Pascal's theorem (1640) — the three intersections of opposite sides of a hexagon inscribed in a conic are collinear — is a projective incidence theorem, and projective theorems are invariant under projective (linear) change of coordinates. This invariance is the classical route to proving Pascal in general: verify it for one convenient conic and transport the conclusion to every projectively equivalent conic. In the gallery, BrianchonTheorem and PascalsHexagon rest on a single geometric axiom conic_implies_pascal; the parent OQ-01-OQ-01 removes that axiom on the computational core — the rational-normal conic xz = y² parametrized by t ↦ (t², t, 1) — via a pure ring identity. Its docstring isolates the one remaining ingredient: the projective transfer carrying the parametrized case to an arbitrary nondegenerate conic. That transfer has two halves: (1) the projective covariance of the cross-product / determinant formalism (formalized here), and (2) a Sylvester normalization producing, for a nondegenerate symmetric C, an invertible M sending its zero locus onto xz = y² (the remaining linear-algebra step).",
+    "problemStatement": "In the homogeneous ℝ³ model (projective points are vectors, the join/meet of two points/lines is the cross product, three points are collinear iff their 3×3 determinant vanishes), let m be any linear map on ℝ³ and let A, …, F be the six points of an inscribed hexagon. Does Pascal's conclusion — collinearity of the three Pascal points X = (AB)∧(DE), Y = (BC)∧(EF), Z = (CD)∧(FA) — survive replacing each vertex P by m·P? Equivalently: does Pascal hold for every linear image of the rational-normal conic?",
+    "proofStrategy": "Two covariance identities are proved by ring. First, cross_applyM: (m u) × (m v) = cof(m)·(u × v), where cof(m) is the cofactor matrix (= adj(m)ᵀ) — established component-by-component via fin_cases over Fin 3. Second, det3_applyM: det₃(m u, m v, m w) = det(m)·det₃(u, v, w) — a single ring identity; collinear_applyM_iff packages the det m ≠ 0 case. Applying cross_applyM three times (pascalX_applyM etc.) shows each transformed Pascal point equals cof(cof m) applied to the original Pascal point — crucially the SAME matrix K = cof(cof m) for X, Y, and Z. Then det3_applyM gives det₃(K·pX, K·pY, K·pZ) = det(K)·det₃(pX, pY, pZ), and the parent's pascal_parametrized supplies det₃(pX, pY, pZ) = 0, so the transformed determinant is det(K)·0 = 0. No invertibility of m enters, so pascal_image holds for every linear map and specializes to the genuine projective transfer when det m ≠ 0.",
+    "keyInsights": [
+      "Pascal is projectively covariant: applying a linear map m to all six vertices sends each Pascal point to cof(cof m) applied to the original Pascal point — the same matrix for all three — so the collinearity determinant is merely scaled, hence still zero.",
+      "Two ring identities carry the whole transfer: cross-product covariance (m u)×(m v) = cof(m)·(u×v) for the join/meet, and determinant covariance det₃(m u, m v, m w) = det(m)·det₃(u, v, w) for collinearity.",
+      "No invertibility is required: pascal_image is a polynomial identity that holds for every linear map m, degenerate or not; the geometrically meaningful case det m ≠ 0 is just the specialization, where m·(xz = y²) is a genuine conic.",
+      "This is exactly the covariance half of the Sylvester transfer the parent flagged as the next step toward discharging conic_implies_pascal: pull six points back along an invertible M, apply pascal_parametrized, push forward via pascal_image.",
+      "The cofactor matrix is the right object: cof(m) = adj(m)ᵀ is what transports cross products, and cof(cof m) = det(m)·m is what transports the doubly-nested cross products defining the Pascal points — all captured implicitly by composing cross_applyM."
+    ],
+    "prerequisites": [
+      "The parent entry's ℝ³ cross-product / determinant projective model",
+      "Pascal's theorem for the parametrized conic xz = y²",
+      "Cofactor and adjugate matrices; the identities (Mu)×(Mv) = adj(M)ᵀ(u×v) and the determinant product rule",
+      "Projective invariance of incidence theorems"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Header and the ℝ³ Projective Model",
+      "startLine": 1,
+      "endLine": 99,
+      "summary": "Docstring framing the entry as the projective-covariance half of the parent's Sylvester transfer. Reproduces the ℝ³ model (cross, det3, Collinear, conicPt) and introduces the linear map applyM, its determinant detM, and the cofactor matrix cof — all as explicit component formulas so every covariance identity is a single ring call."
+    },
+    {
+      "id": "covariance",
+      "title": "The Two Covariance Identities",
+      "startLine": 100,
+      "endLine": 138,
+      "summary": "`cross_applyM`: (m u) × (m v) = cof(m)·(u × v), proved component-wise by fin_cases + ring. `det3_applyM`: det₃(m u, m v, m w) = det(m)·det₃(u, v, w). `collinear_applyM_iff`: for det m ≠ 0, the images are collinear iff the originals are — collinearity is a projective invariant."
+    },
+    {
+      "id": "pascal-transfer",
+      "title": "Pascal Transfers to Every Linear Image",
+      "startLine": 139,
+      "endLine": 203,
+      "summary": "Pascal points pascalX/Y/Z; `pascalX_applyM` etc. show each transformed Pascal point equals cof(cof m) applied to the original (three uses of cross_applyM). `pascal_parametrized` re-proves Pascal for xz = y². `pascal_image`: the main theorem — for any linear m, the image points have collinear Pascal points, via det3_applyM applied to the parent's zero determinant."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes the projective-covariance half of the Sylvester transfer flagged by the parent: Pascal's collinearity conclusion is preserved under applying any linear map m to the six hexagon vertices, so Pascal holds for every linear image of the rational-normal conic xz = y². The proof rests on two ring identities — cross-product covariance (m u)×(m v) = cof(m)·(u×v) and determinant covariance det₃(m u, m v, m w) = det(m)·det₃(u, v, w) — and needs no invertibility of m. Fully verified with 0 sorries and 0 axioms (only propext, Classical.choice, Quot.sound; no native_decide).",
+    "implications": "Combined with a Sylvester normalization (every nondegenerate symmetric C admits an invertible M carrying xᵀCx = 0 onto xz = y²), this covariance step discharges conic_implies_pascal for nondegenerate conics: pull the six points back along M, apply pascal_parametrized, push forward via pascal_image. The covariance identities cross_applyM and det3_applyM are reusable for any projective incidence statement in the ℝ³ model (e.g. Brianchon by duality), making this a general-purpose bridge between the parametrized and abstract conics.",
+    "openQuestions": [
+      "The remaining Sylvester normalization: prove that every nondegenerate symmetric 3×3 matrix C has an invertible M with M·(xz = y²) = {x : xᵀCx = 0}, completing the discharge of conic_implies_pascal for nondegenerate conics.",
+      "Can pascal_image be combined with the normalization to remove the conic_implies_pascal axiom from BrianchonTheorem.lean / PascalsHexagon.lean entirely (for nondegenerate C)?",
+      "Does the same covariance machinery transfer Brianchon's theorem (the projective dual of Pascal) to every linear image, via the meet/join duality already present in the cross-product model?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "brianchon-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: proves Pascal for the rational-normal conic xz = y² axiom-free and documents the projective-normalization / Sylvester transfer as the next step. This follow-up formalizes the covariance half of that transfer."
+    },
+    {
+      "targetId": "brianchon-theorem-oq-01",
+      "relationship": "related",
+      "description": "Ancestor in the Brianchon/Pascal OQ chain, working in the same homogeneous ℝ³ cross-product / determinant model."
+    },
+    {
+      "targetId": "brianchon-theorem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling exploring another facet of the Brianchon/Pascal incidence circle in the same model."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Coxeter, H. S. M.; Greitzer, S. L.",
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America (Pascal's theorem and projective invariance)"
+    },
+    {
+      "authors": "Richter-Gebert, J.",
+      "title": "Perspectives on Projective Geometry",
+      "year": "2011",
+      "venue": "Springer (cross-product / determinant model of projective incidence)"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "pascal_image",
+      "type": "core",
+      "description": "Pascal transfers to every linear image of the conic: for any linear map m and six parameters, the points m·conicPt a, …, m·conicPt f have collinear Pascal points",
+      "leanType": "Collinear (pascalX (applyM m (conicPt a)) …) (pascalY …) (pascalZ …)"
+    },
+    {
+      "name": "cross_applyM",
+      "type": "core",
+      "description": "Cross-product covariance: the join/meet of transformed points is the cofactor matrix applied to the join/meet",
+      "leanType": "cross (applyM m u) (applyM m v) = applyM (cof m) (cross u v)"
+    },
+    {
+      "name": "det3_applyM",
+      "type": "core",
+      "description": "Determinant covariance: collinearity (vanishing of det₃) is a projective invariant",
+      "leanType": "det3 (applyM m u) (applyM m v) (applyM m w) = detM m * det3 u v w"
+    },
+    {
+      "name": "collinear_applyM_iff",
+      "type": "supporting",
+      "description": "For an invertible m (det m ≠ 0), the images are collinear iff the originals are",
+      "leanType": "detM m ≠ 0 → (Collinear (applyM m u) (applyM m v) (applyM m w) ↔ Collinear u v w)"
+    },
+    {
+      "name": "pascalX_applyM",
+      "type": "supporting",
+      "description": "Each transformed Pascal point is cof(cof m) applied to the original Pascal point",
+      "leanType": "pascalX (applyM m A) … = applyM (cof (cof m)) (pascalX A …)"
+    }
+  ],
+  "leanFile": {
+    "namespace": "BrianchonOQ01OQ01OQ01",
+    "axiomCount": 0,
+    "lineCount": 203,
+    "path": "Proofs/BrianchonTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "theoremCount": 8,
+    "definitionCount": 10,
+    "imports": [
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Data.Fin.VecNotation",
+      "Mathlib.Tactic"
+    ],
+    "opens": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **`brianchon-theorem-oq-01-oq-01-oq-01`** — *Pascal Transfers to Every Linear Image of the Conic — Projective Covariance*.

The parent (`brianchon-theorem-oq-01-oq-01`) proves Pascal's hexagon theorem for the **rational-normal conic** `xz = y²` axiom-free, and its docstring isolates the **only** remaining ingredient toward discharging the abstract `conic_implies_pascal` axiom:

> the projective-normalization / Sylvester transfer — that Pascal's conclusion is invariant under projective maps, so the parametrized case carries over to an arbitrary conic.

This follow-up formalizes the **projective-covariance half** of that transfer, axiom-free: Pascal's collinearity conclusion survives applying **any** linear map `m` to all six hexagon vertices — so Pascal holds for **every linear image** of the rational-normal conic.

## What is proved (`Proofs/BrianchonTheoremOQ01OQ01OQ01.lean`)

Two classical `ℝ³`-model identities, each a single `ring` computation:

- `cross_applyM` — **cross-product covariance**: `(m u) × (m v) = cof(m)·(u × v)` (the join/meet of transformed points is the transformed join/meet; `cof(m) = adj(m)ᵀ`).
- `det3_applyM` — **determinant covariance**: `det₃(m u, m v, m w) = det(m)·det₃(u, v, w)`, so collinearity (vanishing `det₃`) is a projective invariant (`collinear_applyM_iff` packages the `det m ≠ 0` case).

Then:
- `pascalX_applyM` / `pascalY_applyM` / `pascalZ_applyM` — each transformed Pascal point equals the **same** matrix `cof(cof m)` applied to the original (three uses of `cross_applyM`).
- `pascal_image` (main) — for any linear `m` and six parameters, the image points `m·conicPt a, …, m·conicPt f` have **collinear Pascal points**, via `det3_applyM` applied to the parent's zero determinant. **No invertibility needed**; specializes to the genuine projective transfer when `det m ≠ 0`.

## Relation to discharging the axiom

Combined with a Sylvester normalization (every nondegenerate symmetric `C` has an invertible `M` carrying `xᵀCx = 0` onto `xz = y²`), this covariance step discharges `conic_implies_pascal` for nondegenerate conics: pull six points back along `M`, apply `pascal_parametrized`, push forward via `pascal_image`. The Sylvester normalization is documented as the remaining open step.

## Verification

- **8 theorems, 10 definitions, 0 sorries, 0 axioms.**
- `./proofs/scripts/docker-build.sh Proofs.BrianchonTheoremOQ01OQ01OQ01` → **Build succeeded**.
- `#print axioms cross_applyM` / `pascal_image` → only `propext, Classical.choice, Quot.sound` (**no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`**). Self-contained: imports only `Real.Basic` / `Fin.VecNotation` / `Tactic` — no Mathlib conic machinery. Status `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)