### PR TITLE
Enrich Weighted LGV Multiplicativity: structured annotation fields

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02-oq-01/annotations.json
@@ -8,7 +8,22 @@
     },
     "type": "definition",
     "title": "Composition of Two Weighted Path Systems",
-    "content": "`comp W₁ W₂` builds a composite weighted-path configuration: a composite path from source $i$ to sink $j$ is a dependent triple — an intermediate sink $k$, a first-layer path $i \\to k$ of $W_1$, and a second-layer path $k \\to j$ of $W_2$ — so the path type is $\\Sigma_k\\, (W_1.\\text{Path}\\, i\\, k) \\times (W_2.\\text{Path}\\, k\\, j)$. Its weight is the product $W_1.\\text{weight}(p) \\cdot W_2.\\text{weight}(q)$ of the two constituent weights. This is the generating-function abstraction of 'concatenate a path through an intermediate lattice layer', the operation underlying every multi-layer LGV product formula. The infix notation is `∘w`."
+    "content": "`comp W₁ W₂` builds a composite weighted-path configuration: a composite path from source $i$ to sink $j$ is a dependent triple — an intermediate sink $k$, a first-layer path $i \\to k$ of $W_1$, and a second-layer path $k \\to j$ of $W_2$ — so the path type is $\\Sigma_k\\, (W_1.\\text{Path}\\, i\\, k) \\times (W_2.\\text{Path}\\, k\\, j)$. Its weight is the product $W_1.\\text{weight}(p) \\cdot W_2.\\text{weight}(q)$ of the two constituent weights. This is the generating-function abstraction of 'concatenate a path through an intermediate lattice layer', the operation underlying every multi-layer LGV product formula. The infix notation is `∘w`.",
+    "mathContext": "$(W_1 \\circ W_2).\\mathrm{Path}\\,(i,j) \\;=\\; \\Sigma_{k}\\,\\big(W_1.\\mathrm{Path}(i,k)\\times W_2.\\mathrm{Path}(k,j)\\big),\\qquad \\mathrm{weight}(k,p,q) = W_1.\\mathrm{weight}(p)\\cdot W_2.\\mathrm{weight}(q).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "path concatenation",
+      "dependent sum (Sigma type)",
+      "generating function",
+      "transfer matrix",
+      "intermediate layer / contraction index"
+    ],
+    "prerequisites": [
+      "dependent types and Sigma types in Lean 4",
+      "finite types (Fintype)",
+      "commutative ring of weights",
+      "the WeightedLGV abstraction (sibling entry)"
+    ]
   },
   {
     "id": "ann-comp-matrix",
@@ -19,7 +34,21 @@
     },
     "type": "theorem",
     "title": "(★) The Generating-Function Matrix is Multiplicative",
-    "content": "`comp_matrix`: the matrix of a composite path system is the ordinary matrix product of the two layers' generating-function matrices, $H(W_1 \\circ W_2) = H(W_1)\\cdot H(W_2)$. Entrywise this is the distributive law $\\left(\\sum_p w_1(p)\\right)\\left(\\sum_q w_2(q)\\right) = \\sum_{(p,q)} w_1(p)\\,w_2(q)$, summed over the choice of intermediate sink $k$. The Lean proof rewrites with `Matrix.mul_apply`, regroups the composite sum with `Fintype.sum_sigma` (over $k$) and `Fintype.sum_prod_type` (over $(p,q)$), and collapses the inner double sum with `Fintype.sum_mul_sum`. The dependent sum over intermediate sinks is exactly the matrix-product contraction index."
+    "content": "`comp_matrix`: the matrix of a composite path system is the ordinary matrix product of the two layers' generating-function matrices, $H(W_1 \\circ W_2) = H(W_1)\\cdot H(W_2)$. Entrywise this is the distributive law $\\left(\\sum_p w_1(p)\\right)\\left(\\sum_q w_2(q)\\right) = \\sum_{(p,q)} w_1(p)\\,w_2(q)$, summed over the choice of intermediate sink $k$. The Lean proof rewrites with `Matrix.mul_apply`, regroups the composite sum with `Fintype.sum_sigma` (over $k$) and `Fintype.sum_prod_type` (over $(p,q)$), and collapses the inner double sum with `Fintype.sum_mul_sum`. The dependent sum over intermediate sinks is exactly the matrix-product contraction index.",
+    "mathContext": "$H(W_1\\circ W_2)_{ij} = \\sum_{k}\\sum_{(p,q)} w_1(p)\\,w_2(q) = \\sum_{k}\\Big(\\sum_{p} w_1(p)\\Big)\\Big(\\sum_{q} w_2(q)\\Big) = \\sum_{k} H(W_1)_{ik}\\,H(W_2)_{kj} = \\big(H(W_1)\\,H(W_2)\\big)_{ij}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "matrix multiplication",
+      "distributive law (sum of products)",
+      "Fintype.sum_mul_sum",
+      "contraction over an intermediate index",
+      "Matrix.mul_apply"
+    ],
+    "prerequisites": [
+      "matrix product entry formula Matrix.mul_apply",
+      "big-operator manipulation (Fintype.sum_sigma, sum_prod_type, sum_mul_sum)",
+      "the WeightedLGV.matrix definition"
+    ]
   },
   {
     "id": "ann-det-comp",
@@ -30,7 +59,21 @@
     },
     "type": "theorem",
     "title": "(★★) Multiplicativity of the LGV Determinant",
-    "content": "`det_comp`: the determinant of the composite generating-function matrix is the product of the two layers' determinants, $\\det H(W_1 \\circ W_2) = \\det H(W_1) \\cdot \\det H(W_2)$ — an immediate consequence of (★) `comp_matrix` and the Cauchy–Binet law `Matrix.det_mul`. This is the algebraic engine behind the LGV product formulas (Schur polynomials via Jacobi–Trudi, MacMahon's box formula, Aztec-diamond tilings): a multi-layer non-intersecting-path count factors as a product of single-layer determinants. `det_comp_comm` records that the determinant is the same in either stacking order (the matrices need not commute, but their determinants do)."
+    "content": "`det_comp`: the determinant of the composite generating-function matrix is the product of the two layers' determinants, $\\det H(W_1 \\circ W_2) = \\det H(W_1) \\cdot \\det H(W_2)$ — an immediate consequence of (★) `comp_matrix` and the Cauchy–Binet law `Matrix.det_mul`. This is the algebraic engine behind the LGV product formulas (Schur polynomials via Jacobi–Trudi, MacMahon's box formula, Aztec-diamond tilings): a multi-layer non-intersecting-path count factors as a product of single-layer determinants. `det_comp_comm` records that the determinant is the same in either stacking order (the matrices need not commute, but their determinants do).",
+    "mathContext": "$\\det H(W_1\\circ W_2) = \\det\\big(H(W_1)\\,H(W_2)\\big) = \\det H(W_1)\\cdot \\det H(W_2),$ via $\\det(AB)=\\det A\\,\\det B$ (`Matrix.det_mul`, the square Cauchy–Binet law). Commutativity at the determinant level: $\\det H(W_1\\circ W_2)=\\det H(W_2\\circ W_1)$ even though $H(W_1)H(W_2)\\neq H(W_2)H(W_1)$ in general.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Binet formula",
+      "det(AB) = det(A)·det(B)",
+      "Jacobi–Trudi identity",
+      "MacMahon box formula",
+      "Aztec-diamond tilings"
+    ],
+    "prerequisites": [
+      "the determinant-of-product law Matrix.det_mul",
+      "comp_matrix (★)",
+      "commutativity of multiplication in the base ring"
+    ]
   },
   {
     "id": "ann-det-comp-list",
@@ -41,7 +84,20 @@
     },
     "type": "theorem",
     "title": "Iterated Multiplicativity for a Stack of Layers",
-    "content": "`det_comp_list`: folding composition over a list of layers $W_s$ with a base layer $W_0$ yields $\\det H(W_1 \\circ \\cdots \\circ W_n \\circ W_0) = \\left(\\prod_i \\det H(W_i)\\right)\\cdot \\det H(W_0)$. This is the transfer-matrix viewpoint: a length-$n$ stack of path layers is a product of $n$ transfer matrices, and its LGV determinant factors as the product of its $n$ single-step determinants — the structural reason multi-layer enumeration problems have product formulas. Proved by `List.foldr` induction (base case `simp`; cons step is `det_comp` + the inductive hypothesis + `ring`)."
+    "content": "`det_comp_list`: folding composition over a list of layers $W_s$ with a base layer $W_0$ yields $\\det H(W_1 \\circ \\cdots \\circ W_n \\circ W_0) = \\left(\\prod_i \\det H(W_i)\\right)\\cdot \\det H(W_0)$. This is the transfer-matrix viewpoint: a length-$n$ stack of path layers is a product of $n$ transfer matrices, and its LGV determinant factors as the product of its $n$ single-step determinants — the structural reason multi-layer enumeration problems have product formulas. Proved by `List.foldr` induction (base case `simp`; cons step is `det_comp` + the inductive hypothesis + `ring`).",
+    "mathContext": "$\\det H\\!\\left(\\mathrm{foldr}\\,\\circ\\,W_0\\,[W_1,\\dots,W_n]\\right) = \\Big(\\prod_{i=1}^{n} \\det H(W_i)\\Big)\\cdot \\det H(W_0).$ Inductive step: $\\det H(W\\circ \\mathrm{rest}) = \\det H(W)\\cdot \\det H(\\mathrm{rest})$ by `det_comp`, then the inductive hypothesis closes by `ring`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "transfer-matrix method",
+      "List.foldr induction",
+      "telescoping product of determinants",
+      "multi-layer enumeration product formulas"
+    ],
+    "prerequisites": [
+      "structural induction over lists (List.foldr)",
+      "det_comp (★★)",
+      "the ring tactic for commutative-ring identities"
+    ]
   },
   {
     "id": "ann-bridges",
@@ -52,6 +108,20 @@
     },
     "type": "theorem",
     "title": "Unweighted Specialisation and Signed Family-Sum Bridge",
-    "content": "`comp_card_matrix`: setting every weight to $1$, the composite matrix entry counts length-two concatenated paths, $H(W_1 \\circ W_2)_{ij} = \\#\\left(\\Sigma_k\\, \\text{Path}_1\\, i\\, k \\times \\text{Path}_2\\, k\\, j\\right)$. `det_comp_signed_family_sum`: combining multiplicativity with the sibling entry's Leibniz/family expansion `det_matrix_eq_signed_family_sum`, the composite determinant is the PRODUCT of two signed family sums, $\\left(\\sum_\\sigma \\operatorname{sign}(\\sigma)\\sum_f W_1.\\text{familyWeight}(f)\\right)\\left(\\sum_\\tau \\operatorname{sign}(\\tau)\\sum_g W_2.\\text{familyWeight}(g)\\right)$ — making explicit that each layer contributes its own signed sum over path families."
+    "content": "`comp_card_matrix`: setting every weight to $1$, the composite matrix entry counts length-two concatenated paths, $H(W_1 \\circ W_2)_{ij} = \\#\\left(\\Sigma_k\\, \\text{Path}_1\\, i\\, k \\times \\text{Path}_2\\, k\\, j\\right)$. `det_comp_signed_family_sum`: combining multiplicativity with the sibling entry's Leibniz/family expansion `det_matrix_eq_signed_family_sum`, the composite determinant is the PRODUCT of two signed family sums, $\\left(\\sum_\\sigma \\operatorname{sign}(\\sigma)\\sum_f W_1.\\text{familyWeight}(f)\\right)\\left(\\sum_\\tau \\operatorname{sign}(\\tau)\\sum_g W_2.\\text{familyWeight}(g)\\right)$ — making explicit that each layer contributes its own signed sum over path families.",
+    "mathContext": "Unweighted: $H(W_1\\circ W_2)_{ij} = \\#\\big(\\Sigma_k\\,\\mathrm{Path}_1(i,k)\\times \\mathrm{Path}_2(k,j)\\big)$ (cardinality cast into $R$ via `nsmul_eq_mul`). Family-sum bridge: $\\det H(W_1\\circ W_2) = \\Big(\\sum_{\\sigma}\\operatorname{sgn}\\sigma\\!\\sum_{f}\\! W_1.\\mathrm{familyWeight}(f)\\Big)\\Big(\\sum_{\\tau}\\operatorname{sgn}\\tau\\!\\sum_{g}\\! W_2.\\mathrm{familyWeight}(g)\\Big).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Leibniz determinant formula",
+      "sign-reversing involution (Gessel–Viennot)",
+      "path families and signed family sums",
+      "cardinality cast (Finset.card_univ, nsmul_eq_mul)",
+      "unweighted path counting"
+    ],
+    "prerequisites": [
+      "the sibling's det_matrix_eq_signed_family_sum",
+      "permutation sign and the Leibniz formula",
+      "Finset.sum_const / nsmul_eq_mul for the cardinality specialisation"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-03-oq-02-oq-01` (Weighted Lindström–Gessel–Viennot — multiplicativity of the LGV determinant under path-system composition).

## Changes
- Added structured fields to all 5 annotations in `annotations.json`:
  - `mathContext` — display-LaTeX of each identity (composition, H(W₁∘W₂)=H(W₁)·H(W₂), det_mul, iterated stack law, family-sum bridge)
  - `significance` — key/supporting classification
  - `relatedConcepts` — matrix multiplication, Cauchy–Binet, Jacobi–Trudi, MacMahon box formula, transfer matrices, etc.
  - `prerequisites` — the Mathlib API and concepts each result depends on

## Not changed
- `meta.json` already comprehensive (16.8 KB, well under all size caps): rich overview, sections, conclusion, cross-references.
- Verified `status: verified` / `axiomCount: 0` / `sorries: 0` against the Lean source — accurate (standard propext/Classical.choice/Quot.sound triple only; no axiom, no sorry, no native_decide).
- Confirmed the entry loads via the build-generated manifest (present in `listings.json`); no per-proof `index.ts` shim needed under the current loader (issue #20993).

🤖 Generated with [Claude Code](https://claude.com/claude-code)