### PR TITLE
Enrich Bounded-Power Band Dichotomy: annotation depth

### DIFF
--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "context",
     "title": "From a fixed band to an n-dependent band",
-    "content": "The docstring states the parent's first open question: generalize the bounded-power trap from the fixed band [−1, 1] to a magnitude-≤ B base, whose powers live in the n-dependent band [−Bⁿ, Bⁿ], and characterize which lines escape it. The answer is a sharp dichotomy at the critical value B = 1 — shrinking/critical band (B ≤ 1) lines escape, growing band (B > 1) every line is captured."
+    "content": "The docstring states the parent's first open question: generalize the bounded-power trap from the fixed band [−1, 1] to a magnitude-≤ B base, whose powers live in the n-dependent band [−Bⁿ, Bⁿ], and characterize which lines escape it. The answer is a sharp dichotomy at the critical value B = 1 — shrinking/critical band (B ≤ 1) lines escape, growing band (B > 1) every line is captured.",
+    "mathContext": "For $|x| \\le B$ the powers satisfy $x^n \\in [-B^n, B^n]$. The question: for which affine maps $n \\mapsto b + ns$ does the line eventually leave this band? Answer governed by $B \\gtrless 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Bernoulli inequality", "geometric vs arithmetic growth", "phase transition", "Archimedean property"],
+    "prerequisites": ["real analysis", "powers and exponentials", "limits of sequences"]
   },
   {
     "id": "ann-bern-oq01010201-trap",
@@ -19,7 +23,11 @@
     },
     "type": "technique",
     "title": "The generalized trap",
-    "content": "abs_pow_le proves |xⁿ| ≤ Bⁿ from |x| ≤ B using abs_pow (|xⁿ| = |x|ⁿ) and pow_le_pow_left₀ (monotonicity of powers). abs_le then splits this into the two walls −Bⁿ ≤ xⁿ (neg_pow_le_pow) and xⁿ ≤ Bⁿ (pow_le_pow_band). This is the verbatim generalization of the parent's [−1, 1] band."
+    "content": "abs_pow_le proves |xⁿ| ≤ Bⁿ from |x| ≤ B using abs_pow (|xⁿ| = |x|ⁿ) and pow_le_pow_left₀ (monotonicity of powers). abs_le then splits this into the two walls −Bⁿ ≤ xⁿ (neg_pow_le_pow) and xⁿ ≤ Bⁿ (pow_le_pow_band). This is the verbatim generalization of the parent's [−1, 1] band.",
+    "mathContext": "$|x| \\le B \\Rightarrow |x^n| = |x|^n \\le B^n$, equivalently $-B^n \\le x^n \\le B^n$. Uses monotonicity $0 \\le a \\le b \\Rightarrow a^n \\le b^n$ (pow_le_pow_left₀).",
+    "significance": "supporting",
+    "relatedConcepts": ["absolute value of powers", "monotonicity of powers", "two-sided bound abs_le"],
+    "prerequisites": ["absolute value inequalities", "ordered semiring power laws"]
   },
   {
     "id": "ann-bern-oq01010201-engine",
@@ -30,7 +38,11 @@
     },
     "type": "technique",
     "title": "The escape engine (any B)",
-    "content": "Two transitivity one-liners: lt_pow_of_lt_neg_pow says anything below the lower wall (c < −Bⁿ) is beaten by every power (c < xⁿ); pow_lt_of_pow_lt is the mirror above the upper wall. Both are B-agnostic — they need nothing about the sign or size of B."
+    "content": "Two transitivity one-liners: lt_pow_of_lt_neg_pow says anything below the lower wall (c < −Bⁿ) is beaten by every power (c < xⁿ); pow_lt_of_pow_lt is the mirror above the upper wall. Both are B-agnostic — they need nothing about the sign or size of B.",
+    "mathContext": "$c < -B^n \\le x^n \\Rightarrow c < x^n$, and dually $x^n \\le B^n < c \\Rightarrow x^n < c$. Pure transitivity through the band walls; independent of $B$.",
+    "significance": "supporting",
+    "relatedConcepts": ["transitivity of inequalities", "band walls", "strict/non-strict chaining"],
+    "prerequisites": ["order axioms", "lt_of_lt_of_le transitivity"]
   },
   {
     "id": "ann-bern-oq01010201-shrinking",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "Shrinking/critical band B ≤ 1: lines still escape",
-    "content": "When B ≤ 1 the wall Bⁿ ≤ 1 (pow_le_one₀), so the band sits inside [−1, 1]. eventually_line_lt_pow_band: a negative-slope line drops below −1 ≤ −Bⁿ past the Archimedean threshold N > (b+1)/(−s), hence below every power. eventually_pow_lt_line_band is the positive-slope mirror. These generalize the parent's lemmas from B = 1 to every B ≤ 1."
+    "content": "When B ≤ 1 the wall Bⁿ ≤ 1 (pow_le_one₀), so the band sits inside [−1, 1]. eventually_line_lt_pow_band: a negative-slope line drops below −1 ≤ −Bⁿ past the Archimedean threshold N > (b+1)/(−s), hence below every power. eventually_pow_lt_line_band is the positive-slope mirror. These generalize the parent's lemmas from B = 1 to every B ≤ 1.",
+    "mathContext": "$B \\le 1 \\Rightarrow B^n \\le 1$, so $[-B^n, B^n] \\subseteq [-1,1]$. For $s < 0$, once $n > \\frac{b+1}{-s}$ we get $b + ns < -1 \\le -B^n \\le x^n$. The threshold is Archimedean.",
+    "significance": "key",
+    "relatedConcepts": ["Archimedean property", "contracting band", "negative slope escape", "powers ≤ 1"],
+    "prerequisites": ["Archimedean property of ℝ", "eventually filter (Filter.Eventually)"]
   },
   {
     "id": "ann-bern-oq01010201-tendsto",
@@ -52,7 +68,11 @@
     },
     "type": "technique",
     "title": "Exponential dominates linear",
-    "content": "tendsto_linear_div_pow proves (|b| + |s|·n)/Bⁿ → 0 for B > 1 by writing it as |b|·(1/Bⁿ) + |s|·(n/Bⁿ) and sending both terms to 0 with tendsto_pow_const_div_const_pow_of_one_lt (k = 0 and k = 1). This is the quantitative engine that lets the exponential wall absorb any line."
+    "content": "tendsto_linear_div_pow proves (|b| + |s|·n)/Bⁿ → 0 for B > 1 by writing it as |b|·(1/Bⁿ) + |s|·(n/Bⁿ) and sending both terms to 0 with tendsto_pow_const_div_const_pow_of_one_lt (k = 0 and k = 1). This is the quantitative engine that lets the exponential wall absorb any line.",
+    "mathContext": "For $B > 1$: $\\dfrac{|b| + |s|n}{B^n} = |b|\\dfrac{1}{B^n} + |s|\\dfrac{n}{B^n} \\to 0$, since $\\dfrac{n^k}{B^n} \\to 0$ for every fixed $k$ (exponential beats any polynomial).",
+    "significance": "key",
+    "relatedConcepts": ["exponential vs polynomial growth", "limits of sequences", "Tendsto", "L'Hôpital intuition"],
+    "prerequisites": ["sequence limits", "n^k/Bⁿ → 0 for B>1", "Mathlib Filter/Tendsto API"]
   },
   {
     "id": "ann-bern-oq01010201-capture",
@@ -63,7 +83,11 @@
     },
     "type": "insight",
     "title": "Growing band B > 1: every line is captured",
-    "content": "eventually_line_mem_band turns the limit into an eventual bound (Tendsto.eventually_lt_const, div_lt_one): eventually |b| + |s|·n < Bⁿ, and bounding the line by its envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line lies strictly inside (−Bⁿ, Bⁿ). No line of any slope escapes — the exact opposite of the B ≤ 1 case."
+    "content": "eventually_line_mem_band turns the limit into an eventual bound (Tendsto.eventually_lt_const, div_lt_one): eventually |b| + |s|·n < Bⁿ, and bounding the line by its envelope (abs_add_le) gives |b + n·s| < Bⁿ, i.e. the line lies strictly inside (−Bⁿ, Bⁿ). No line of any slope escapes — the exact opposite of the B ≤ 1 case.",
+    "mathContext": "From $\\dfrac{|b|+|s|n}{B^n}\\to 0$, eventually $|b|+|s|n < B^n$. Since $|b + ns| \\le |b| + |s|n$ (triangle inequality), $|b+ns| < B^n$, i.e. $b + ns \\in (-B^n, B^n)$ for all large $n$.",
+    "significance": "key",
+    "relatedConcepts": ["triangle inequality", "eventual containment", "expanding band", "Tendsto.eventually_lt_const"],
+    "prerequisites": ["triangle inequality |a+b|≤|a|+|b|", "eventually filter", "limit ⟹ eventual bound"]
   },
   {
     "id": "ann-bern-oq01010201-dichotomy",
@@ -74,6 +98,10 @@
     },
     "type": "insight",
     "title": "The boundary dichotomy at B = 1",
-    "content": "escape_or_capture states both halves for a fixed negative-slope line: B > 1 forces capture inside the band, B ≤ 1 forces escape below every power. The single comparison B ≷ 1 flips one into the other, pinning the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about."
+    "content": "escape_or_capture states both halves for a fixed negative-slope line: B > 1 forces capture inside the band, B ≤ 1 forces escape below every power. The single comparison B ≷ 1 flips one into the other, pinning the parent's fixed band B = 1 as the precise critical threshold the parent's open question asked about.",
+    "mathContext": "Dichotomy at the critical $B = 1$: $B > 1 \\Rightarrow$ every line eventually trapped in $(-B^n, B^n)$; $B \\le 1 \\Rightarrow$ every nonconstant line eventually escapes. The parent's $[-1,1]$ band is exactly the boundary case.",
+    "significance": "key",
+    "relatedConcepts": ["phase transition", "critical threshold", "trichotomy of ℝ", "geometric vs arithmetic growth"],
+    "prerequisites": ["case analysis on B vs 1", "the two preceding regimes"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `bernoulli-inequality-oq-01-oq-01-oq-02-oq-01` (the B≷1 dichotomy for when affine lines escape the n-dependent power band [−Bⁿ, Bⁿ]).

meta.json was already rich (4 keyInsights, conclusion, 5 sections, crossRefs). The gap: all 7 annotations carried only `content`. This pass adds the structured depth fields:

- **`mathContext`** — LaTeX for each: the band $x^n\in[-B^n,B^n]$, the Archimedean escape threshold $n>\tfrac{b+1}{-s}$ for $B\le 1$, the exponential-beats-polynomial limit $\tfrac{|b|+|s|n}{B^n}\to 0$ for $B>1$, the triangle-inequality capture, and the critical $B=1$ dichotomy.
- **`significance`** — key/supporting/context per annotation.
- **`relatedConcepts`** — Archimedean property, exponential vs polynomial growth, phase transition, triangle inequality, etc.
- **`prerequisites`** — per-annotation background.

No content deleted; meta.json untouched (16.7 KB, under cap). Annotation line ranges verified against the Lean source. JSON validated.