### PR TITLE
research(wilsons-theorem-oq-02-ext-oq-03): build fix — open Nat for factorial notation

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ02ExtOQ03.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ02ExtOQ03.lean
@@ -56,7 +56,7 @@ product. Zero axioms, zero sorries.
 
 namespace WilsonsTheoremOQ02ExtOQ03
 
-open Finset ZMod
+open Finset ZMod Nat
 
 variable (p : ℕ) [Fact p.Prime]
 

--- a/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-03.json
+++ b/src/data/research/problems/wilsons-theorem-oq-02-ext-oq-03.json
@@ -1,15 +1,16 @@
 {
   "id": "wilsons-theorem-oq-02-ext-oq-03",
   "title": "Gauss-Wilson → quadratic character: the half-factorial bridge",
-  "status": "in-progress",
-  "phase": "ACT",
+  "status": "completed",
+  "phase": "COMPLETED",
   "knowledge": {
     "insights": [
       "The bridge the open question asks for (Wilson product → Legendre symbol) is the classical half-factorial identity (((p-1)/2)!)² ≡ (-1)^((p-1)/2 + 1) mod p, obtained by folding (p-1)! along the involution k ↦ p-k where k(p-k) ≡ -k².",
       "Mathlib has ZMod.wilsons_lemma and the full quadratic-residue API (legendreSym, euler_criterion, exists_sq_eq_neg_one_iff, quadratic_reciprocity, gauss_lemma) but NOT the half-factorial identity that links Wilson's product to that API — a genuine gap, not a re-export.",
       "The result gives the EXPLICIT Gauss square root of -1 (namely (p/2)!) for p ≡ 1 mod 4, strengthening Mathlib's existence-only ZMod.exists_sq_eq_neg_one_iff to a constructive IsSquare witness.",
       "Field structure enters precisely at the upper-half reindexing: ∏_{k=m+1}^{2m} k reindexes via k ↦ p-k to ∏(p-j) ≡ ∏(-j) = (-1)^m m!, turning an index translation into a sign extracted by Finset.prod_neg.",
-      "Distinct from existing siblings: OQ-02-ext-OQ-01 generalizes the two-involution trick to abelian groups (Miller), OQ-02-ext-OQ-02 extends to rings of integers O_K/𝔞 — neither touches the quadratic character. This node is the number-theoretic bridge."
+      "Distinct from existing siblings: OQ-02-ext-OQ-01 generalizes the two-involution trick to abelian groups (Miller), OQ-02-ext-OQ-02 extends to rings of integers O_K/𝔞 — neither touches the quadratic character. This node is the number-theoretic bridge.",
+      "Build-verification gotcha: the half-factorial notation (p/2)! parses only when Nat is opened — the factorial postfix ! is scoped notation:10000 in namespace Nat. The originally-merged file opened Finset ZMod (not Nat) so every (p/2)! raised \"unexpected token !\"; it had been marked verified without ever compiling. One-line fix (open Finset ZMod Nat) makes all 5 theorems build."
     ],
     "builtItems": [
       "factorial_half_sq (Proofs/WilsonsTheoremOQ02ExtOQ03.lean:67): (((p/2)! : ZMod p))² = (-1)^(p/2+1) for odd prime p — the bridge identity.",
@@ -22,11 +23,10 @@
       "Mathlib lacks the half-factorial congruence (((p-1)/2)!)² ≡ (-1)^((p-1)/2+1) mod p (the classical Wilson square root of -1); legendreSym.at_neg_one routes through χ₄ instead, never exhibiting the witness."
     ],
     "nextSteps": [
-      "Machine-verify the build once Docker/lake infrastructure is restored (build was UNVERIFIED at authoring time — Docker Desktop containerd corruption + .lake bind-mount permission denials blocked docker-build.sh).",
       "Follow-up OQ: does the same factorial folding give effective square roots for general quadratic residues a (explicit-witness Euler's criterion)?",
       "Follow-up OQ: lift the half-factorial identity to (ZMod n)× via CRT, relating local Wilson witnesses to the Jacobi symbol."
     ],
-    "progressSummary": "PROGRESS (build-unverified): complete 5-theorem elementary proof of the Wilson→Legendre half-factorial bridge, 0 axioms/0 sorries in source; machine verification pending infra recovery."
+    "progressSummary": "COMPLETE (machine-verified): 5-theorem elementary proof of the Wilson→Legendre half-factorial bridge, 0 axioms / 0 sorries, docker build exit 0 on Lean 4.26.0. The previously-shipped source did not compile (factorial notation n! is scoped in Nat but the file opened only Finset ZMod); fixed by adding Nat to the open clause."
   },
   "relatedProofs": [
     "wilsons-theorem",


### PR DESCRIPTION
## Summary

The gallery entry **wilsons-theorem-oq-02-ext-oq-03** ("The Half-Factorial Bridge: Wilson's Theorem to the Quadratic Character") was marked `status: verified` / `badge: original` / `0 axioms` / `0 sorries`, but it **had never actually compiled**. It was authored (PR #30380) while the Docker/lake build infrastructure was down, so the "verified" claim was never machine-checked.

This PR machine-verifies it and fixes the one bug that blocked compilation.

## The bug

Every occurrence of the half-factorial `(p / 2)!` failed to parse:

```
error: Proofs/WilsonsTheoremOQ02ExtOQ03.lean:68:13: unexpected token '!'; expected ')', ',' or ':'
```

Root cause: the factorial postfix notation `n !` is `scoped notation:10000 ... => Nat.factorial n` in namespace `Nat`, but the file opened only `Finset ZMod` — never `Nat` — so `!` was not in scope.

## The fix

One line:

```diff
-open Finset ZMod
+open Finset ZMod Nat
```

## Verification

`./proofs/scripts/docker-build.sh Proofs.WilsonsTheoremOQ02ExtOQ03` →

```
✔ [3059/3059] Built Proofs.WilsonsTheoremOQ02ExtOQ03 (6.1s)
Build completed successfully (3059 jobs).
```

All 5 theorems compile. No `sorry`, no `native_decide`, no `axiom` declarations — genuinely 0-axiom. Line count unchanged (163), so existing `meta.json` counts remain accurate; no `meta.json` change needed.

The problem-tracking JSON is updated to `completed` / `COMPLETED` with a machine-verified progress summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)