### PR TITLE
audit: confirm clean — 4 unaudited gallery entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24943,8 +24943,32 @@
       "lastAudited": "2026-06-27T06:58:21Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T07:14:09Z",
+      "result": "clean"
+    },
+    "chebyshev-pnt-bridge-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T07:14:09Z",
+      "result": "clean"
+    },
+    "cramers-rule-oq-01-oq-02-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T07:14:09Z",
+      "result": "clean"
+    },
+    "erdos-103-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T07:14:09Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T02:00:00Z"
+  "lastUpdated": "2026-06-27T07:14:09Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — clean batch

Audited the four highest-priority unaudited gallery entries. All clean; no overclaiming. This PR durably records the results in \`audit-tracker.json\` (local tracker edits churn under concurrent \`git reset --hard\`).

| Entry | status/badge | Verdict |
|-------|-------------|---------|
| abel-ruffini-galois-extensions-oq-02 | verified/mathlib | Tier B Mathlib bridge; badge=mathlib correct; description explicitly credits Mathlib's FTGT (`IsGalois.intermediateFieldEquivSubgroup`). 0 sorries/axioms; lineCount 201, theoremCount 10 match. |
| chebyshev-pnt-bridge-oq-04 | axiomatized/axiom | axiomCount=2 = the two `MertensInputs` structure assumptions (Chebyshev ψ bound + Stirling estimate); headline `lambdaRecip_sub_log_le` is a verified conditional implication. Title scoped to "Backbone / floor identity". Honest. |
| cramers-rule-oq-01-oq-02-oq-03 | verified/mathlib | All counts match (205 lines, 10 thm, 1 def, 0 sorries/axioms). Input conditions (qdet00≠0, A 1 1≠0) are theorem hypotheses, not global axioms. badge=mathlib is conservative. |
| erdos-103-oq-02 | verified/original | Formalization-audit file: proves the parent's `h(n)` count is degenerate and supplies corrected `hCong`. Explicitly states Erdős #103 remains OPEN. 0 sorries/axioms; 218 lines, 10 thm, 4 defs match. |

Checks run on each: sorry count, literal `axiom` count, structure-encoded assumptions, `native_decide`, True stubs, lineCount/theoremCount/defCount vs source, badge/status vs tier, narrative honesty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)