### PR TITLE
Enrich Distribution of Odd Catalan Numbers: annotation depth

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 39 },
     "type": "context",
     "title": "From Parity to Distribution",
-    "content": "The parent entry (catalan-numbers-oq-01-oq-02) proves the classical parity fact that Cₙ is odd exactly when n+1 is a power of two. This file, imported on top of it, answers the parent's open question 2: where do the odd Catalan numbers sit, and how many are there? Since the odd indices are precisely the shifted powers of two n = 2ᵏ − 1 (0,1,3,7,15,…), the answers are crisp — the gaps double and the count below N is the binary length ⌊log₂ N⌋ + 1, so the odd Catalan numbers have density 0."
+    "content": "The parent entry (catalan-numbers-oq-01-oq-02) proves the classical parity fact that Cₙ is odd exactly when n+1 is a power of two. This file, imported on top of it, answers the parent's open question 2: where do the odd Catalan numbers sit, and how many are there? Since the odd indices are precisely the shifted powers of two n = 2ᵏ − 1 (0,1,3,7,15,…), the answers are crisp — the gaps double and the count below N is the binary length ⌊log₂ N⌋ + 1, so the odd Catalan numbers have density 0.",
+    "mathContext": "$C_n$ odd $\\iff n+1 = 2^k \\iff n = 2^k-1$. The odd-index set is $\\{0,1,3,7,15,\\dots\\}$; its counting function below $N$ is $\\lfloor\\log_2 N\\rfloor + 1$, so the density $\\tfrac{1}{N}\\#\\{n<N: C_n\\text{ odd}\\} \\to 0$.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan numbers", "parity", "powers of two", "natural density", "Kummer's theorem"],
+    "prerequisites": ["Catalan numbers Cₙ", "binary representation", "asymptotic density"]
   },
   {
     "id": "ann-odd-index-set",
@@ -13,7 +17,11 @@
     "range": { "startLine": 40, "endLine": 60 },
     "type": "key-step",
     "title": "The Odd Indices Are Exactly {2ᵏ − 1}",
-    "content": "odd_catalan_iff_eq rewrites the parent's odd_catalan_iff (n+1 = 2ᵏ) into the canonical form n = 2ᵏ − 1 — valid because 1 ≤ 2ᵏ, so adding/subtracting 1 is reversible (discharged by omega with that bound). oddIndices_eq_range then packages the set {n | Cₙ odd} as the explicit range of k ↦ 2ᵏ − 1, the indices 0,1,3,7,15,…."
+    "content": "odd_catalan_iff_eq rewrites the parent's odd_catalan_iff (n+1 = 2ᵏ) into the canonical form n = 2ᵏ − 1 — valid because 1 ≤ 2ᵏ, so adding/subtracting 1 is reversible (discharged by omega with that bound). oddIndices_eq_range then packages the set {n | Cₙ odd} as the explicit range of k ↦ 2ᵏ − 1, the indices 0,1,3,7,15,….",
+    "mathContext": "$n+1 = 2^k \\iff n = 2^k - 1$ (reversible since $2^k \\ge 1$). Hence $\\{n : C_n\\text{ odd}\\} = \\{2^k - 1 : k \\in \\mathbb{N}\\}$, the image of $k \\mapsto 2^k - 1$.",
+    "significance": "key",
+    "relatedConcepts": ["set as image of a map", "powers of two minus one", "Mersenne-like indices", "omega tactic"],
+    "prerequisites": ["natural-number subtraction", "set-builder / image equality"]
   },
   {
     "id": "ann-gap-structure",
@@ -21,7 +29,11 @@
     "range": { "startLine": 61, "endLine": 81 },
     "type": "key-step",
     "title": "Geometric Gaps ⟹ Sparsity",
-    "content": "oddIndex_strictMono shows the enumerating map k ↦ 2ᵏ − 1 is strictly monotone: from 2ⁱ < 2ʲ (Nat.pow_lt_pow_right) and 1 ≤ 2ⁱ, omega gives 2ⁱ − 1 < 2ʲ − 1. This yields injectivity, used in the counting argument. oddIndex_gap computes the exact gap (2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ (from 2^{k+1} = 2·2ᵏ by omega); since 2ᵏ grows without bound, the odd Catalan numbers thin out geometrically."
+    "content": "oddIndex_strictMono shows the enumerating map k ↦ 2ᵏ − 1 is strictly monotone: from 2ⁱ < 2ʲ (Nat.pow_lt_pow_right) and 1 ≤ 2ⁱ, omega gives 2ⁱ − 1 < 2ʲ − 1. This yields injectivity, used in the counting argument. oddIndex_gap computes the exact gap (2^{k+1} − 1) − (2ᵏ − 1) = 2ᵏ (from 2^{k+1} = 2·2ᵏ by omega); since 2ᵏ grows without bound, the odd Catalan numbers thin out geometrically.",
+    "mathContext": "Gap: $(2^{k+1}-1) - (2^k-1) = 2^k$, doubling each step. Strict monotonicity of $k\\mapsto 2^k-1$ gives injectivity of the enumeration, the engine of the count.",
+    "significance": "key",
+    "relatedConcepts": ["strict monotonicity", "injectivity", "geometric growth", "consecutive gaps"],
+    "prerequisites": ["monotone power functions", "Nat.pow_lt_pow_right"]
   },
   {
     "id": "ann-counting",
@@ -29,7 +41,11 @@
     "range": { "startLine": 82, "endLine": 114 },
     "type": "key-step",
     "title": "The Exact Count ⌊log₂ N⌋ + 1",
-    "content": "card_odd_catalan_below is the centrepiece: for N ≥ 1, #{ n < N : Cₙ odd } = ⌊log₂ N⌋ + 1. The proof identifies the filtered Finset with (range (⌊log₂ N⌋ + 1)).image (k ↦ 2ᵏ − 1). The membership equivalence reduces to 2ᵏ − 1 < N ⟺ k ≤ ⌊log₂ N⌋: since 1 ≤ 2ᵏ, the inequality 2ᵏ − 1 < N is equivalent to 2ᵏ ≤ N, which Nat.le_log_iff_pow_le converts to k ≤ ⌊log₂ N⌋. As k ↦ 2ᵏ − 1 is injective, the image has cardinality card (range (⌊log₂ N⌋ + 1)) = ⌊log₂ N⌋ + 1. card_odd_catalan_below_pow specialises this to N = 2^K via Nat.log_pow, giving K + 1."
+    "content": "card_odd_catalan_below is the centrepiece: for N ≥ 1, #{ n < N : Cₙ odd } = ⌊log₂ N⌋ + 1. The proof identifies the filtered Finset with (range (⌊log₂ N⌋ + 1)).image (k ↦ 2ᵏ − 1). The membership equivalence reduces to 2ᵏ − 1 < N ⟺ k ≤ ⌊log₂ N⌋: since 1 ≤ 2ᵏ, the inequality 2ᵏ − 1 < N is equivalent to 2ᵏ ≤ N, which Nat.le_log_iff_pow_le converts to k ≤ ⌊log₂ N⌋. As k ↦ 2ᵏ − 1 is injective, the image has cardinality card (range (⌊log₂ N⌋ + 1)) = ⌊log₂ N⌋ + 1. card_odd_catalan_below_pow specialises this to N = 2^K via Nat.log_pow, giving K + 1.",
+    "mathContext": "$\\#\\{n<N : C_n\\text{ odd}\\} = \\lfloor\\log_2 N\\rfloor + 1$ for $N\\ge 1$. Key step: $2^k - 1 < N \\iff 2^k \\le N \\iff k \\le \\lfloor\\log_2 N\\rfloor$ (Nat.le_log_iff_pow_le). At $N = 2^K$ this is $K+1$.",
+    "significance": "key",
+    "relatedConcepts": ["counting via injective image", "integer logarithm ⌊log₂⌋", "Nat.le_log_iff_pow_le", "Finset cardinality"],
+    "prerequisites": ["floor logarithm", "Finset.image cardinality of injective maps"]
   },
   {
     "id": "ann-examples",
@@ -37,6 +53,10 @@
     "range": { "startLine": 115, "endLine": 126 },
     "type": "observation",
     "title": "Concrete Counts, Axiom-Free",
-    "content": "The examples instantiate card_odd_catalan_below_pow: 4 odd Catalan numbers below 8 = 2³ (C₀,C₁,C₃,C₇) and 5 below 16 = 2⁴ (adding C₁₅). They are direct theorem applications rather than kernel computations on catalan (which does not reduce by decide), so the file stays free of native_decide and of any extra axioms — every theorem depends only on propext, Classical.choice, Quot.sound."
+    "content": "The examples instantiate card_odd_catalan_below_pow: 4 odd Catalan numbers below 8 = 2³ (C₀,C₁,C₃,C₇) and 5 below 16 = 2⁴ (adding C₁₅). They are direct theorem applications rather than kernel computations on catalan (which does not reduce by decide), so the file stays free of native_decide and of any extra axioms — every theorem depends only on propext, Classical.choice, Quot.sound.",
+    "mathContext": "Below $8=2^3$: $C_0,C_1,C_3,C_7$ are odd, count $3+1=4$. Below $16=2^4$: add $C_{15}$, count $4+1=5$. Obtained by applying the theorem, not by reducing $C_n$ — so no native_decide.",
+    "significance": "supporting",
+    "relatedConcepts": ["axiom auditing", "avoiding native_decide", "worked instances", "theorem application vs computation"],
+    "prerequisites": ["card_odd_catalan_below_pow", "axiom integrity policy"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-02-oq-02` (odd Catalan indices are the shifted powers of two; exact count $\lfloor\log_2 N\rfloor+1$).

meta.json was already rich (4 keyInsights, conclusion, 5 sections, 3 crossRefs). The gap: all 5 annotations carried only `content`. This pass adds `mathContext` (LaTeX: $C_n\text{ odd}\iff n=2^k-1$, the doubling gap $2^k$, the count $\lfloor\log_2 N\rfloor+1$ via $2^k-1<N\iff k\le\lfloor\log_2 N\rfloor$, density 0), `significance`, `relatedConcepts` (natural density, floor logarithm, injective counting, axiom integrity), and `prerequisites` to each.

No content deleted; meta.json untouched (15.0 KB, under cap). Ranges verified against the Lean source. JSON validated.