### PR TITLE
Enrich Cos 2π/n conjugation witness: add annotations (was uncovered)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-at-cos20-context",
+    "proofId": "angle-trisection-cos-20-gal-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "The Index-2 Step Behind [ℚ(cos 2π/n):ℚ] = φ(n)/2",
+    "content": "The file advances OQ-1 of the parent: realize complex conjugation as the order-2 automorphism behind [ℚ(ζ_n):ℚ(cos 2π/n)] = 2, the '÷2' in the degree formula [ℚ(cos 2π/n):ℚ] = φ(n)/2. The abstract Galois fixed-field statement needs the maximal-real-subfield degree (absent from Mathlib) and stays open; this entry instead supplies, with 0 axioms, the complete ELEMENT-LEVEL witness, sharpening the parent's '≤ 2' to a genuine '= 2' for every cyclotomic n ≥ 3. The honest boundary — what is and is not proved — is stated up front.",
+    "mathContext": "$[\\mathbb{Q}(\\cos 2\\pi/n):\\mathbb{Q}] = \\tfrac{\\varphi(n)}{2}$, the $\\div 2$ being the index of the real subfield $\\mathbb{Q}(\\cos 2\\pi/n)$ in the cyclotomic field $\\mathbb{Q}(\\zeta_n)$, witnessed by complex conjugation $\\zeta \\mapsto \\zeta^{-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["cyclotomic fields", "Euler totient φ(n)", "maximal real subfield", "angle trisection", "Galois theory"],
+    "prerequisites": ["field extensions and degrees", "cyclotomic fields", "complex conjugation as automorphism"]
+  },
+  {
+    "id": "ann-at-cos20-conj-roots",
+    "proofId": "angle-trisection-cos-20-gal-oq-02-oq-01",
+    "range": { "startLine": 49, "endLine": 84 },
+    "type": "key-step",
+    "title": "Conjugation Maps ζ to the Other Root",
+    "content": "conj_zeta proves conj(e^{iθ}) = e^{−iθ} via Complex.exp_conj (exp commutes with conjugation). zeta_mul gives the unit-circle product e^{iθ}·e^{−iθ} = 1; zeta_add gives the sum e^{iθ} + e^{−iθ} = 2cos θ (Complex.two_cos). quadratic_factor assembles these into (z − e^{iθ})(z − e^{−iθ}) = z² − (2cos θ)z + 1. The two roots are a complex-conjugate pair, so conjugation is exactly the swap of the two roots of this real quadratic.",
+    "mathContext": "$\\overline{e^{i\\theta}} = e^{-i\\theta}$; $e^{i\\theta}e^{-i\\theta}=1$, $e^{i\\theta}+e^{-i\\theta}=2\\cos\\theta$; hence $(z-e^{i\\theta})(z-e^{-i\\theta}) = z^2 - (2\\cos\\theta)z + 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's formula", "complex conjugate roots", "Vieta's formulas", "minimal polynomial of ζ over ℝ"],
+    "prerequisites": ["complex exponential", "exp_conj", "roots and coefficients of quadratics"]
+  },
+  {
+    "id": "ann-at-cos20-fixes-coeff",
+    "proofId": "angle-trisection-cos-20-gal-oq-02-oq-01",
+    "range": { "startLine": 85, "endLine": 94 },
+    "type": "key-step",
+    "title": "Conjugation Fixes the Real Coefficient 2cos θ",
+    "content": "conj_two_cos proves conj(2cos θ) = 2cos θ. This certifies that the quadratic X²−(2cos θ)X+1 genuinely lives over the real subfield ℚ(cos θ): the automorphism that swaps the roots ζ and ζ⁻¹ leaves the base-field coefficient fixed, exactly as the tower ℚ(cos θ) ⊆ ℚ(ζ) demands of a ℚ(cos θ)-automorphism.",
+    "mathContext": "$\\overline{2\\cos\\theta} = 2\\cos\\theta$ (a real number). So conjugation is a $\\mathbb{Q}(\\cos\\theta)$-automorphism of $\\mathbb{Q}(\\zeta)$: it fixes the base field while permuting the roots.",
+    "significance": "key",
+    "relatedConcepts": ["fixed field", "base-field automorphism", "real subfield", "Galois group action"],
+    "prerequisites": ["conjugation fixes reals", "field automorphisms over a subfield"]
+  },
+  {
+    "id": "ann-at-cos20-roots-distinct",
+    "proofId": "angle-trisection-cos-20-gal-oq-02-oq-01",
+    "range": { "startLine": 95, "endLine": 148 },
+    "type": "insight",
+    "title": "The Two Roots Are Genuinely Distinct (n ≥ 3)",
+    "content": "zeta_im computes Im(e^{iθ}) = sin θ; conj_zeta_ne_self_iff reduces 'conjugation moves ζ' to sin θ ≠ 0 (Complex.conj_eq_iff_im). sin_two_pi_div_pos proves sin(2π/n) > 0 for n ≥ 3 (Real.sin_pos_of_pos_of_lt_pi, since 0 < 2π/n < π), and sin_two_pi_div_ne_zero, cyclotomic_conj_ne_self, cyclotomic_roots_distinct conclude that conjugation acts nontrivially and the two roots are distinct for every cyclotomic angle n ≥ 3. This is exactly what upgrades the parent's '≤ 2' to a sharp '= 2'.",
+    "mathContext": "$\\mathrm{Im}(e^{i\\theta}) = \\sin\\theta$, so $\\overline{\\zeta}\\ne\\zeta \\iff \\sin\\theta\\ne0$. For $\\theta = 2\\pi/n$ with $n\\ge3$: $0 < 2\\pi/n < \\pi \\Rightarrow \\sin(2\\pi/n) > 0$, so the roots $\\zeta, \\zeta^{-1}$ are distinct and $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}(\\cos 2\\pi/n)] = 2$.",
+    "significance": "key",
+    "relatedConcepts": ["trigonometric positivity on (0,π)", "distinct roots", "separability", "sharpness of degree bound"],
+    "prerequisites": ["sin positivity", "conj_eq_iff_im", "imaginary part of e^{iθ}"]
+  },
+  {
+    "id": "ann-at-cos20-consistency",
+    "proofId": "angle-trisection-cos-20-gal-oq-02-oq-01",
+    "range": { "startLine": 149, "endLine": 161 },
+    "type": "observation",
+    "title": "Consistency Checks: φ(9)/2 = φ(7)/2 = 3",
+    "content": "totient_div_two_nine and totient_div_two_seven verify φ(9)/2 = 3 (cos 40°, the cos 20° trisection sibling) and φ(7)/2 = 3 (regular heptagon). The verified degree-2 step is precisely the ÷2 carrying Euler's totient φ(n) down to the gallery's computed cubic degrees — the cubics whose irreducibility makes trisecting 120° and constructing the heptagon impossible by straightedge and compass.",
+    "mathContext": "$\\varphi(9)/2 = 6/2 = 3$ and $\\varphi(7)/2 = 6/2 = 3$: the degree-3 minimal polynomials of $\\cos 40°$ and $\\cos(2\\pi/7)$, both obstructions to ruler-and-compass construction.",
+    "significance": "supporting",
+    "relatedConcepts": ["constructibility", "regular heptagon", "cos 20° cubic 8x³−6x−1", "totient values"],
+    "prerequisites": ["Euler totient computation", "degree and constructibility"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-02-oq-01`.

This entry had **no annotations.json at all** (zero inline coverage — the reason for its low quality score). Created a full `annotations.json` with 5 annotations covering every section of the Lean file, each carrying `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Context** — the index-2 step behind $[\mathbb{Q}(\cos 2\pi/n):\mathbb{Q}] = \varphi(n)/2$.
2. **Conjugation maps ζ to the other root** — $\overline{e^{i\theta}}=e^{-i\theta}$ and the quadratic factorization.
3. **Conjugation fixes 2cos θ** — the $\mathbb{Q}(\cos\theta)$-automorphism property.
4. **Roots distinct for n ≥ 3** — via $\mathrm{Im}(e^{i\theta})=\sin\theta$ and $\sin(2\pi/n)>0$.
5. **Consistency** — $\varphi(9)/2=\varphi(7)/2=3$.

Annotation line ranges aligned to the meta sections and verified against the Lean source. meta.json untouched. JSON validated.