### PR TITLE
audit: confirm clean — 2 new gallery entries (angle-trisection-cos20-oq02-oq01, brianchon-oq010101)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24967,6 +24967,18 @@
       "issues": [],
       "lastAudited": "2026-06-27T07:14:09Z",
       "result": "clean"
+    },
+    "angle-trisection-cos-20-gal-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T07:23:39Z",
+      "result": "clean",
+      "issues": []
+    },
+    "brianchon-theorem-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T07:23:40Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Both genuinely never-audited entries (the only two unaudited in the gallery), merged via #30592 and #30593, verified against their Lean source. **No issues found** — all meta.json claims match the kernel reality, no overclaiming.

### angle-trisection-cos-20-gal-oq-02-oq-01 — `[verified/original]` ✅
- 0 sorries, 0 axioms (0 structure-encoded assumptions), 13 theorems, 0 defs, 161 lines — all match meta.
- Two plain `by decide` on `Nat.totient` computations — kernel-checked, **no** `Lean.ofReduceBool` (not `native_decide`), so `verified`/0-axiom stands.
- **Tier A**, Mathlib deps elementary (`exp_conj`, `two_cos`, `exp_mul_I`, `conj_eq_iff_im`, `sin_pos`) — building blocks, not a deep theorem masking.
- **Narrative honest**: advances an open question (OQ-1) but explicitly and repeatedly states it does NOT prove the full field-degree formula `[ℚ(cos 2π/n):ℚ]=φ(n)/2`; scoped to the verified element-level complex-conjugation index-2 witness, pinpointing the missing Mathlib piece (maximal-real-subfield degree). All five narrative failure modes clear.

### brianchon-theorem-oq-01-oq-01-oq-01 — `[verified/verified]` ✅
- 0 sorries, 0 axioms, 0 native_decide, 8 theorems, 10 defs, 203 lines — all match meta.
- **Tier A**, self-contained ℝ³ cross-product/determinant model, pure `ring` identities; no Mathlib deep-theorem dependency for the core result.
- **Narrative honest**: scoped to the projective-covariance half of the Sylvester transfer; explicitly states the Sylvester normalization is the remaining piece — does NOT claim to discharge the full `conic_implies_pascal` axiom or prove full Pascal/Brianchon.
- `grep sorry`/`native_decide` hits are docstring-prose false positives (line 52: "No \`sorry\`, no \`axiom\`, no \`native_decide\`"); real code is clean.

### Result
Gallery now fully audited (4025/4025). This PR records both clean results in `audit-tracker.json`.

---
Discovered during autonomous gallery integrity audit.