### PR TITLE
Enrich Similarity Invariants (Cramer OQ-05): annotation depth

### DIFF
--- a/src/data/proofs/cramers-rule-oq-05/annotations.json
+++ b/src/data/proofs/cramers-rule-oq-05/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 47 },
     "type": "concept",
     "title": "Setup: Imports and the Commutative-Ring Setting",
-    "content": "The file imports Mathlib's determinant, trace, and characteristic-polynomial libraries and fixes a finite decidable index type n and a commutative ring R. The choice of CommRing (rather than a field) is deliberate: the similarity invariants require only conjugation by a *unit* matrix, so they remain valid over ℤ and polynomial rings where invertible scalars are scarce. This makes the results applicable in commutative algebra and representation theory, not just over fields."
+    "content": "The file imports Mathlib's determinant, trace, and characteristic-polynomial libraries and fixes a finite decidable index type n and a commutative ring R. The choice of CommRing (rather than a field) is deliberate: the similarity invariants require only conjugation by a *unit* matrix, so they remain valid over ℤ and polynomial rings where invertible scalars are scarce. This makes the results applicable in commutative algebra and representation theory, not just over fields.",
+    "mathContext": "Work over a commutative ring $R$ and finite index type $n$, with matrices $M \\in \\mathrm{Mat}_n(R)$ and units $U \\in \\mathrm{GL}_n(R) = (\\mathrm{Mat}_n(R))^\\times$. CommRing (not a field) suffices because only $U$ need be invertible.",
+    "significance": "context",
+    "relatedConcepts": ["commutative ring", "general linear group GLₙ(R)", "matrix algebra", "representation theory"],
+    "prerequisites": ["matrices over a ring", "units and invertibility", "determinant and trace"]
   },
   {
     "id": "ann-cro05-conj",
@@ -13,7 +17,11 @@
     "range": { "startLine": 48, "endLine": 55 },
     "type": "definition",
     "title": "Conjugation by a Unit Matrix",
-    "content": "conj U N := U.val * N * U⁻¹.val packages the change-of-basis action on the matrix of an endomorphism: U is an element of the unit group (Matrix n n R)ˣ, so its inverse is genuinely a matrix over R, and U N U⁻¹ represents the same linear map in a U-transformed basis. Giving this a name turns three separate Mathlib lemmas into a coherent 'similarity' API; the simp lemma conj_apply unfolds it on demand."
+    "content": "conj U N := U.val * N * U⁻¹.val packages the change-of-basis action on the matrix of an endomorphism: U is an element of the unit group (Matrix n n R)ˣ, so its inverse is genuinely a matrix over R, and U N U⁻¹ represents the same linear map in a U-transformed basis. Giving this a name turns three separate Mathlib lemmas into a coherent 'similarity' API; the simp lemma conj_apply unfolds it on demand.",
+    "mathContext": "$\\mathrm{conj}_U(N) = U N U^{-1}$. With $U$ a unit, $U^{-1}$ is again a matrix over $R$; $UNU^{-1}$ is the matrix of the same endomorphism after the change of basis given by $U$.",
+    "significance": "key",
+    "relatedConcepts": ["change of basis", "conjugation / inner automorphism", "similarity transformation", "group action on matrices"],
+    "prerequisites": ["matrix inverse of a unit", "basis change for endomorphisms"]
   },
   {
     "id": "ann-cro05-invariants",
@@ -21,7 +29,11 @@
     "range": { "startLine": 56, "endLine": 75 },
     "type": "technique",
     "title": "The Three Similarity Invariants",
-    "content": "det_conj, trace_conj, and charpoly_conj re-express Mathlib's det_units_conj, trace_units_conj, and charpoly_units_conj through conj. Determinant invariance follows from multiplicativity (det U · det N · det U⁻¹ = det N); trace invariance from cyclic invariance trace(AB) = trace(BA); characteristic-polynomial invariance because conjugation commutes with forming X·I − N over R[X]. Each is a one-line wrapper, but together they constitute the basis-independent data of the operator."
+    "content": "det_conj, trace_conj, and charpoly_conj re-express Mathlib's det_units_conj, trace_units_conj, and charpoly_units_conj through conj. Determinant invariance follows from multiplicativity (det U · det N · det U⁻¹ = det N); trace invariance from cyclic invariance trace(AB) = trace(BA); characteristic-polynomial invariance because conjugation commutes with forming X·I − N over R[X]. Each is a one-line wrapper, but together they constitute the basis-independent data of the operator.",
+    "mathContext": "$\\det(UNU^{-1}) = \\det N$ (multiplicativity), $\\operatorname{tr}(UNU^{-1}) = \\operatorname{tr}(N)$ (cyclicity $\\operatorname{tr}(AB)=\\operatorname{tr}(BA)$), and $\\chi_{UNU^{-1}}(X) = \\chi_N(X)$ (conjugation commutes with $XI - N$).",
+    "significance": "key",
+    "relatedConcepts": ["determinant multiplicativity", "trace cyclicity", "characteristic polynomial", "conjugation-invariant functions"],
+    "prerequisites": ["det(AB)=det A·det B", "tr(AB)=tr(BA)", "characteristic polynomial χ_N(X)=det(XI−N)"]
   },
   {
     "id": "ann-cro05-bundle",
@@ -29,7 +41,11 @@
     "range": { "startLine": 76, "endLine": 92 },
     "type": "concept",
     "title": "Packaging the Invariants",
-    "content": "similarity_invariants bundles the three facts into a single conjunction: conjugation by a unit preserves det, trace, and charpoly simultaneously. The packaging is the point — det and trace are (up to sign) the constant and subleading coefficients of the characteristic polynomial, so the three invariances are not independent but form a coherent whole, which the conjunction makes explicit and reusable downstream."
+    "content": "similarity_invariants bundles the three facts into a single conjunction: conjugation by a unit preserves det, trace, and charpoly simultaneously. The packaging is the point — det and trace are (up to sign) the constant and subleading coefficients of the characteristic polynomial, so the three invariances are not independent but form a coherent whole, which the conjunction makes explicit and reusable downstream.",
+    "mathContext": "$\\chi_N(X) = X^n - \\operatorname{tr}(N)X^{n-1} + \\cdots + (-1)^n\\det(N)$: trace and determinant are the subleading and constant coefficients, so $\\chi$-invariance subsumes the other two.",
+    "significance": "supporting",
+    "relatedConcepts": ["coefficients of the characteristic polynomial", "Newton's identities", "invariant bundling", "reusable API"],
+    "prerequisites": ["characteristic polynomial coefficients", "relation of det/trace to χ"]
   },
   {
     "id": "ann-cro05-similarity",
@@ -37,7 +53,11 @@
     "range": { "startLine": 93, "endLine": 118 },
     "type": "technique",
     "title": "The Similarity Relation and Its Corollaries",
-    "content": "IsSimilar M N := ∃ U, N = conj U M is the textbook similarity relation. After proving reflexivity (conjugate by the identity unit), the corollaries IsSimilar.det_eq, trace_eq, and charpoly_eq are discharged by destructuring the witness U and applying the corresponding invariance. This yields the familiar statement 'similar matrices have the same determinant, trace, and characteristic polynomial' directly in the ∃-quantified form used in linear-algebra texts."
+    "content": "IsSimilar M N := ∃ U, N = conj U M is the textbook similarity relation. After proving reflexivity (conjugate by the identity unit), the corollaries IsSimilar.det_eq, trace_eq, and charpoly_eq are discharged by destructuring the witness U and applying the corresponding invariance. This yields the familiar statement 'similar matrices have the same determinant, trace, and characteristic polynomial' directly in the ∃-quantified form used in linear-algebra texts.",
+    "mathContext": "$M \\sim N :\\iff \\exists U,\\ N = UMU^{-1}$. An equivalence relation; here reflexivity is shown (conjugate by $1$), and similar matrices share $\\det$, $\\operatorname{tr}$, and $\\chi$.",
+    "significance": "key",
+    "relatedConcepts": ["similarity equivalence relation", "conjugacy classes", "existential witness destructuring", "canonical forms"],
+    "prerequisites": ["equivalence relations", "existential quantifiers in Lean"]
   },
   {
     "id": "ann-cro05-summary",
@@ -45,6 +65,10 @@
     "range": { "startLine": 119, "endLine": 148 },
     "type": "concept",
     "title": "Summary: Coherence of the Invariants",
-    "content": "The closing table pairs each invariant with its Mathlib backing and records the structural observation that determinant and trace invariance descend from characteristic-polynomial invariance, because both quantities are coefficients of the characteristic polynomial. The IsSimilar relation packaged here is the natural launching point for formalizing canonical forms and the invariance of the minimal polynomial."
+    "content": "The closing table pairs each invariant with its Mathlib backing and records the structural observation that determinant and trace invariance descend from characteristic-polynomial invariance, because both quantities are coefficients of the characteristic polynomial. The IsSimilar relation packaged here is the natural launching point for formalizing canonical forms and the invariance of the minimal polynomial.",
+    "mathContext": "All three invariants flow from $\\chi$-invariance. Next steps build on $M\\sim N$: invariance of the minimal polynomial, and canonical forms (Jordan, rational/Frobenius).",
+    "significance": "context",
+    "relatedConcepts": ["minimal polynomial", "Jordan canonical form", "rational canonical form", "conjugacy invariants"],
+    "prerequisites": ["the three invariance lemmas", "similarity relation"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cramers-rule-oq-05` (det/trace/charpoly invariance under conjugation by a unit; the similarity relation over a commutative ring).

meta.json was already rich (4 keyInsights, ~1 KB historicalContext, conclusion, 6 sections). The gap: all 6 annotations carried only `content`. This pass adds `mathContext` (LaTeX: $\mathrm{conj}_U(N)=UNU^{-1}$, the three invariances, $\chi_N(X)=X^n-\operatorname{tr}(N)X^{n-1}+\cdots+(-1)^n\det N$, the similarity relation), `significance`, `relatedConcepts` (change of basis, trace cyclicity, conjugacy classes, canonical forms), and `prerequisites` to each annotation.

No content deleted; meta.json untouched. Ranges verified against the Lean source. JSON validated.