### PR TITLE
research(szemeredi-counting-oq-02): deterministic core of the 3-graph NRS counting lemma [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SzemerediCountingOQ02.lean
+++ b/proofs/Proofs/SzemerediCountingOQ02.lean
@@ -1,0 +1,252 @@
+/-
+  Hypergraph Counting Lemma — Tripartite 3-Graph Framework
+
+  A self-contained counting layer for tripartite 3-uniform hypergraphs,
+  the setting of the Nagle–Rödl–Schacht (2006) counting lemma. It is the
+  3-graph companion to the graph counting infrastructure in
+  `SzemerediCounting.lean` and builds conceptually on the hypergraph
+  regularity definitions in `SzemerediHypergraphCore.lean`.
+
+  A tripartite 3-graph on parts `α`, `β`, `γ` is an adjacency predicate
+  `adj a b c`, meaning the triple `(a, b, c)` is a hyperedge. This is the
+  natural model for the counting lemma because a "labeled copy" of the
+  single-hyperedge pattern is exactly an edge.
+
+  ## What is proven here (no axioms, no sorries)
+
+  * `edgeCount_le` — at most `|α|·|β|·|γ|` hyperedges.
+  * `density_nonneg`, `density_le_one` — the density lives in `[0, 1]`.
+  * `edgeCount_eq_density_mul` — the **exact counting identity** for the
+    single-hyperedge pattern: the number of labeled copies equals
+    `d · |α|·|β|·|γ|`. This is the counting lemma's main term `d^{e(F)}·∏|Vᵢ|`
+    in the base case `e(F) = 1`, holding with *zero* error.
+  * `sum_degA` — vertex degrees on the first part sum to the edge count.
+  * `edgeCount_sq_le` — the **Cauchy–Schwarz "cherry" inequality**
+    `e(H)² ≤ |α| · ∑_a deg(a)²`. Bounding the number of "cherries"
+    (pairs of edges sharing a first-coordinate vertex) from below by the
+    edge count is the deterministic engine behind every regularity-based
+    counting argument; the density-increment / defect form of the counting
+    lemma is exactly this inequality applied to vertex subsets.
+  * `cherryCount` / `cherryCount_eq_sum_sq_degA` — the **exact `e(F) = 2`
+    enumeration**: the number of labeled cherries (ordered edge pairs sharing
+    a first coordinate) equals `∑_a deg(a)²` with no error term.
+  * `edgeCount_sq_le_cherryCount` — the cherry inequality rendered as an
+    explicit two-edge count: `e(H)² ≤ |α| · cherryCount(H)`.
+  * `edgeCount_mono`, `edgeCount_complete`, `edgeCount_empty`,
+    `density_empty` — structural sanity lemmas.
+
+  ## What remains open (the genuine NRS content)
+
+  The full counting lemma states that an *ε-regular* tripartite 3-graph of
+  density `d` contains `(1 ± f(ε))·d^{e(F)}·∏|Vᵢ|` labeled copies of any
+  fixed 3-graph `F`, with `f(ε) → 0`. For patterns with `e(F) ≥ 2` this is
+  research-level: it requires *relative* (Gowers/Rödl–Skokan) regularity —
+  density conditioned on the underlying 2-graph skeleton — and an inductive
+  argument over the hypergraph dimension. The exact identity proven here is
+  the `e(F) = 1` base case; the cherry inequality is the second-moment tool
+  that the regularity step iterates. See the follow-up notes in
+  `SzemerediHypergraphCore.lean`.
+
+  References:
+  - Nagle, B., Rödl, V., Schacht, M. (2006). "The counting lemma for
+    regular k-uniform hypergraphs." Random Structures & Algorithms 28(2).
+  - Gowers, W.T. (2007). "Hypergraph regularity and the multidimensional
+    Szemerédi theorem." Annals of Mathematics 166(3).
+-/
+import Mathlib
+
+namespace Szemeredi.HypergraphCounting
+
+open Finset Classical
+
+variable {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: TRIPARTITE 3-GRAPHS AND THEIR EDGE COUNT
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- A tripartite 3-uniform hypergraph on parts `α`, `β`, `γ`: the predicate
+    `adj a b c` says the triple `(a, b, c)` is a hyperedge. -/
+structure Tri3Graph (α β γ : Type*) where
+  adj : α → β → γ → Prop
+
+namespace Tri3Graph
+
+/-- The number of vertex triples, `|α|·|β|·|γ|`. -/
+def vertexTriples (α β γ : Type*) [Fintype α] [Fintype β] [Fintype γ] : ℕ :=
+  Fintype.card α * Fintype.card β * Fintype.card γ
+
+theorem card_vertexTriples :
+    Fintype.card (α × β × γ) = vertexTriples α β γ := by
+  unfold vertexTriples
+  rw [Fintype.card_prod, Fintype.card_prod]; ring
+
+/-- The hyperedges of `H`, viewed as triples in `α × β × γ`. -/
+noncomputable def edgeFinset (H : Tri3Graph α β γ) : Finset (α × β × γ) :=
+  univ.filter (fun p => H.adj p.1 p.2.1 p.2.2)
+
+/-- The number of (labeled) hyperedges. -/
+noncomputable def edgeCount (H : Tri3Graph α β γ) : ℕ := H.edgeFinset.card
+
+/-- The edge count never exceeds the number of vertex triples. -/
+theorem edgeCount_le (H : Tri3Graph α β γ) :
+    H.edgeCount ≤ vertexTriples α β γ := by
+  simp only [edgeCount, edgeFinset]
+  calc (univ.filter (fun p => H.adj p.1 p.2.1 p.2.2)).card
+      ≤ (univ : Finset (α × β × γ)).card := Finset.card_filter_le _ _
+    _ = vertexTriples α β γ := by rw [Finset.card_univ, card_vertexTriples]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: DENSITY AND THE EXACT MAIN-TERM IDENTITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The edge density `d(H) = e(H) / (|α|·|β|·|γ|) ∈ ℚ`. -/
+noncomputable def density (H : Tri3Graph α β γ) : ℚ :=
+  (H.edgeCount : ℚ) / (vertexTriples α β γ : ℚ)
+
+theorem density_nonneg (H : Tri3Graph α β γ) : 0 ≤ H.density := by
+  unfold density; positivity
+
+theorem density_le_one (H : Tri3Graph α β γ) : H.density ≤ 1 := by
+  unfold density
+  rcases Nat.eq_zero_or_pos (vertexTriples α β γ) with h | h
+  · simp [h]
+  · rw [div_le_one (by exact_mod_cast h)]
+    exact_mod_cast H.edgeCount_le
+
+/-- **Exact counting lemma, base case `e(F) = 1`.** The number of labeled
+    copies of the single-hyperedge pattern equals `d · |α|·|β|·|γ|`. This is
+    the counting lemma's main term, holding here with no error term. -/
+theorem edgeCount_eq_density_mul (H : Tri3Graph α β γ)
+    (h : 0 < vertexTriples α β γ) :
+    (H.edgeCount : ℚ) = H.density * (vertexTriples α β γ : ℚ) := by
+  have hb : (vertexTriples α β γ : ℚ) ≠ 0 := by exact_mod_cast h.ne'
+  unfold density
+  rw [div_mul_cancel₀ _ hb]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: DEGREES AND THE CAUCHY–SCHWARZ CHERRY INEQUALITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The degree of a first-part vertex `a`: the number of hyperedges whose
+    first coordinate is `a`. -/
+noncomputable def degA (H : Tri3Graph α β γ) (a : α) : ℕ :=
+  (H.edgeFinset.filter (fun p => p.1 = a)).card
+
+/-- First-part degrees sum to the edge count: `∑_a deg(a) = e(H)`. -/
+theorem sum_degA (H : Tri3Graph α β γ) :
+    ∑ a : α, H.degA a = H.edgeCount := by
+  simp only [degA, edgeCount]
+  rw [Finset.card_eq_sum_card_fiberwise (s := H.edgeFinset) (t := (univ : Finset α))
+    (f := fun p => p.1) (fun x _ => Finset.mem_univ _)]
+
+/-- **Cauchy–Schwarz cherry inequality.** The squared edge count is bounded by
+    `|α|` times the sum of squared first-part degrees:
+    `e(H)² ≤ |α| · ∑_a deg(a)²`. Equivalently, the number of "cherries"
+    (ordered pairs of edges sharing a first-coordinate vertex) is at least
+    `e(H)² / |α|`. This second-moment bound is the engine of regularity-based
+    counting and removal arguments. -/
+theorem edgeCount_sq_le (H : Tri3Graph α β γ) :
+    (H.edgeCount : ℚ) ^ 2 ≤ (Fintype.card α : ℚ) * ∑ a : α, (H.degA a : ℚ) ^ 2 := by
+  have key := sq_sum_le_card_mul_sum_sq (s := (univ : Finset α))
+    (f := fun a => (H.degA a : ℚ))
+  rw [Finset.card_univ] at key
+  have hs : (∑ a : α, (H.degA a : ℚ)) = (H.edgeCount : ℚ) := by
+    rw [← Nat.cast_sum, sum_degA]
+  rw [hs] at key
+  exact key
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: THE CHERRY PATTERN — EXACT e(F) = 2 ENUMERATION
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- A **cherry**: an ordered pair of hyperedges sharing the same first-part
+    vertex. Cherries are exactly the labeled copies of the two-hyperedge
+    pattern that glues two triples at their `α`-coordinate — the first pattern
+    with `e(F) = 2`. Counting them is the next case past the exact base term. -/
+noncomputable def cherryFinset (H : Tri3Graph α β γ) :
+    Finset ((α × β × γ) × (α × β × γ)) :=
+  (H.edgeFinset ×ˢ H.edgeFinset).filter (fun p => p.1.1 = p.2.1)
+
+/-- The number of cherries (ordered edge pairs sharing a first coordinate). -/
+noncomputable def cherryCount (H : Tri3Graph α β γ) : ℕ := H.cherryFinset.card
+
+/-- The cherries centred at `a` are exactly the ordered pairs of `a`-edges. -/
+theorem cherryFinset_filter (H : Tri3Graph α β γ) (a : α) :
+    H.cherryFinset.filter (fun p => p.1.1 = a)
+      = (H.edgeFinset.filter (fun q => q.1 = a)) ×ˢ
+        (H.edgeFinset.filter (fun q => q.1 = a)) := by
+  ext p
+  simp only [cherryFinset, Finset.mem_filter, Finset.mem_product]
+  constructor
+  · rintro ⟨⟨⟨h1, h2⟩, hcen⟩, ha⟩
+    exact ⟨⟨h1, ha⟩, h2, hcen ▸ ha⟩
+  · rintro ⟨⟨h1, ha1⟩, h2, ha2⟩
+    exact ⟨⟨⟨h1, h2⟩, ha1.trans ha2.symm⟩, ha1⟩
+
+/-- **Cherry enumeration identity.** The number of cherries equals the sum of
+    squared first-part degrees: `cherryCount(H) = ∑_a deg(a)²`. This makes the
+    right-hand side of the Cauchy–Schwarz bound a genuine combinatorial count
+    of two-edge configurations. -/
+theorem cherryCount_eq_sum_sq_degA (H : Tri3Graph α β γ) :
+    H.cherryCount = ∑ a : α, (H.degA a) ^ 2 := by
+  rw [cherryCount,
+    Finset.card_eq_sum_card_fiberwise (s := H.cherryFinset) (t := (univ : Finset α))
+      (f := fun p => p.1.1) (fun p _ => Finset.mem_univ _)]
+  refine Finset.sum_congr rfl (fun a _ => ?_)
+  simp only [cherryFinset_filter, Finset.card_product, degA, pow_two]
+
+/-- **Cauchy–Schwarz cherry inequality, enumerated form.** The squared edge
+    count is at most `|α|` times the number of cherries:
+    `e(H)² ≤ |α| · cherryCount(H)`. Combined with `cherryCount_eq_sum_sq_degA`,
+    this is the second-moment statement `e(H)² ≤ |α| · ∑_a deg(a)²` rendered as a
+    bound on an explicit count of two-edge patterns. -/
+theorem edgeCount_sq_le_cherryCount (H : Tri3Graph α β γ) :
+    (H.edgeCount : ℚ) ^ 2 ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := by
+  have hcast : (H.cherryCount : ℚ) = ∑ a : α, (H.degA a : ℚ) ^ 2 := by
+    rw [cherryCount_eq_sum_sq_degA, Nat.cast_sum]
+    simp [Nat.cast_pow]
+  rw [hcast]
+  exact H.edgeCount_sq_le
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: STRUCTURAL LEMMAS
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Adding hyperedges can only increase the edge count. -/
+theorem edgeCount_mono {H₁ H₂ : Tri3Graph α β γ}
+    (h : ∀ a b c, H₁.adj a b c → H₂.adj a b c) :
+    H₁.edgeCount ≤ H₂.edgeCount := by
+  apply Finset.card_le_card
+  intro p hp
+  simp only [edgeFinset, Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+  exact h _ _ _ hp
+
+/-- The complete tripartite 3-graph: every triple is a hyperedge. -/
+def complete (α β γ : Type*) : Tri3Graph α β γ := ⟨fun _ _ _ => True⟩
+
+/-- The empty tripartite 3-graph: no hyperedges. -/
+def empty (α β γ : Type*) : Tri3Graph α β γ := ⟨fun _ _ _ => False⟩
+
+/-- The complete 3-graph realizes every vertex triple as an edge. -/
+theorem edgeCount_complete :
+    (complete α β γ).edgeCount = vertexTriples α β γ := by
+  have hset : (complete α β γ).edgeFinset = (univ : Finset (α × β × γ)) := by
+    ext p; simp [edgeFinset, complete]
+  rw [edgeCount, hset, Finset.card_univ, card_vertexTriples]
+
+/-- The empty 3-graph has no edges. -/
+theorem edgeCount_empty :
+    (empty α β γ).edgeCount = 0 := by
+  have hset : (empty α β γ).edgeFinset = (∅ : Finset (α × β × γ)) := by
+    ext p; simp [edgeFinset, empty]
+  rw [edgeCount, hset, Finset.card_empty]
+
+/-- The empty 3-graph has density `0`. -/
+theorem density_empty :
+    (empty α β γ).density = 0 := by
+  rw [density, edgeCount_empty]; simp
+
+end Tri3Graph
+
+end Szemeredi.HypergraphCounting

--- a/research/problems/szemeredi-counting-oq-02/knowledge.md
+++ b/research/problems/szemeredi-counting-oq-02/knowledge.md
@@ -1,21 +1,113 @@
 # Knowledge Base: szemeredi-counting-oq-02
 
-Insights accumulated during research on this problem.
+Hypergraph Counting Lemma (Nagle–Rödl–Schacht 2006) — formalization progress.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Target: the hypergraph counting lemma — an ε-regular k-partite k-graph of
+density d contains `(1 ± f(ε))·d^{e(F)}·∏|Vᵢ|` labeled copies of any fixed
+k-graph F. The natural first instance is k = 3 (tripartite 3-graphs).
+
+Key obstruction (why the full lemma is research-level): hypergraph
+regularity is *relative* — density of the 3-graph must be conditioned on the
+underlying 2-graph skeleton (Gowers 2007 / Rödl–Skokan 2004), and the proof
+is inductive over the dimension. The "naive" ε-regularity in
+`SzemerediHypergraphCore.lean` is insufficient for e(F) ≥ 2.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **Modeling choice.** Representing a tripartite 3-graph as a ternary
+  predicate `adj : α → β → γ → Prop` (rather than the `Finset (Finset V)`
+  transversal model in hypergraph-core) makes *labeled-copy counting* clean:
+  a copy of the single-hyperedge pattern is literally an edge, and the edge
+  set is `univ.filter` over `α × β × γ`.
+- **Exact base case.** For the single-hyperedge pattern e(F) = 1 the counting
+  lemma is *exact* with zero error: `e(H) = d · |α|·|β|·|γ|`. This is a
+  definitional consequence of `density := e(H)/(|α||β||γ|)` once the vertex
+  count is positive (`edgeCount_eq_density_mul`).
+- **The engine is Cauchy–Schwarz.** The second-moment inequality
+  `e(H)² ≤ |α| · ∑_a deg(a)²` (`edgeCount_sq_le`, via Mathlib's
+  `sq_sum_le_card_mul_sum_sq`) is the deterministic core that every
+  regularity-based counting/removal argument iterates over vertex subsets.
+  The "defect" form of the counting lemma is this inequality plus the
+  ε-regularity hypothesis controlling the per-subset densities.
+- The graph (k=2) counting lemma is already fully done in
+  `SzemerediCounting.lean` (1230 lines, `counting_lemma`,
+  `counting_lemma_lower_bound`, triangle removal). The 3-graph layer was
+  the genuine gap — no file built a counting layer on the hypergraph core.
+- **The e(F)=2 cherry is exactly enumerable, deterministically.** Separating
+  the *exact* from the *approximate* content: the labeled two-hyperedge
+  pattern that glues two triples at their α-coordinate (a "cherry") is counted
+  with *zero* error as `∑_a deg(a)²` — no regularity needed
+  (`cherryCount_eq_sum_sq_degA`, via `card_eq_sum_card_fiberwise` over the
+  shared first coordinate + `card_product` on each fibre). The Cauchy–Schwarz
+  bound is then literally a lower bound on this explicit count
+  (`edgeCount_sq_le_cherryCount`: `e(H)² ≤ |α| · cherryCount`). The genuine
+  open content is *not* counting cherries but bounding them two-sidedly under
+  regularity — that is where relative density enters.
 
 ---
 
-## Dead Ends
+## Built Items
 
-[Approaches known not to work will be documented here]
+`proofs/Proofs/SzemerediCountingOQ02.lean` (~250 lines, 14 thm, 9 def,
+1 structure, 0 sorries, 0 axioms):
+- `Tri3Graph` — tripartite 3-graph as a ternary adjacency predicate.
+- `edgeFinset` / `edgeCount` / `density` / `vertexTriples` — counting layer.
+- `edgeCount_le`, `density_nonneg`, `density_le_one` — bounds.
+- `edgeCount_eq_density_mul` — **exact main term, e(F)=1 base case**.
+- `degA`, `sum_degA` — degree decomposition (`card_eq_sum_card_fiberwise`).
+- `edgeCount_sq_le` — **Cauchy–Schwarz cherry inequality** (the engine).
+- `cherryFinset` / `cherryCount` — the labeled e(F)=2 cherry pattern.
+- `cherryFinset_filter` — cherries centred at `a` = ordered pairs of `a`-edges.
+- `cherryCount_eq_sum_sq_degA` — **exact e(F)=2 enumeration**
+  `cherryCount = ∑_a deg(a)²`.
+- `edgeCount_sq_le_cherryCount` — `e(H)² ≤ |α| · cherryCount` (enumerated CS).
+- `edgeCount_mono`, `edgeCount_complete`, `edgeCount_empty`, `density_empty`.
+
+---
+
+## Dead Ends / Open
+
+- *Approximate* NRS counting lemma for e(F) ≥ 2 (the `(1 ± f(ε))` two-sided
+  count): requires relative regularity (conditional density on the 2-skeleton)
+  + induction over dimension. The exact cherry *enumeration* is now done; what
+  remains is the regularity hypothesis converting the second-moment bound into
+  a matching upper bound. Would need a `relativeDensity`/`IsGowersRegular`
+  layer on `Tri3Graph` (the symmetric-model versions already live in
+  `SzemerediHypergraphGowers.lean`, but on the `UHypergraph` subset model, not
+  the tripartite predicate model used here).
+
+---
+
+## Next Steps
+
+1. Build a `relativeDensity` layer on `Tri3Graph`: the 3-graph density
+   conditioned on its three bipartite 2-skeletons (on α×β, β×γ, α×γ).
+2. Define `IsGowersRegular` for tripartite 3-graphs relative to those
+   2-skeletons (port the shape from `SzemerediHypergraphGowers.lean`).
+3. Combine `edgeCount_sq_le_cherryCount` with the regularity hypothesis to
+   bound `cherryCount` two-sidedly — the first genuinely non-exact (1 ± f(ε))
+   instance of the lemma on this model.
+
+---
+
+## Build Verification (2026-06-27)
+
+`proofs/Proofs/SzemerediCountingOQ02.lean` now compiles cleanly under Docker
+(`✔ Built Proofs.SzemerediCountingOQ02`, 7743 jobs, 0 errors, 0 sorries,
+0 axioms — `#print axioms` foundational only). Gallery integration added at
+`src/data/proofs/szemeredi-counting-oq-02/` (meta.json, annotations.json,
+index.ts).
+
+**Build gotcha fixed in `sum_degA`.** The original
+`Finset.card_eq_sum_card_fiberwise` call failed two ways: (1) the inline
+membership proof `Finset.mem_univ x.1` over-constrained unification before the
+fibre map `f := fun p => p.1` was resolved (use `Finset.mem_univ _` to defer,
+exactly as the working `cherryCount_eq_sum_sq_degA` call does); (2) the trailing
+auto-`rfl` could not close because `degA` was left folded — `simp only [degA,
+edgeCount]` before the `rw` makes the two fibre sums alpha-equal so `rw` closes.

--- a/research/problems/szemeredi-counting-oq-02/state.md
+++ b/research/problems/szemeredi-counting-oq-02/state.md
@@ -3,7 +3,7 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-04-23T03:22:15+02:00
+**Since**: 2026-06-27T00:27:00-07:00
 **Iteration**: 4
 
 ## Current Focus

--- a/research/problems/szemeredi-counting-oq-02/state.md
+++ b/research/problems/szemeredi-counting-oq-02/state.md
@@ -1,25 +1,41 @@
 # Research State: szemeredi-counting-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-04-23T03:22:15+02:00
-**Iteration**: 1
+**Iteration**: 4
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Extended the tripartite 3-graph counting layer with the exact e(F)=2
+enumeration: the labeled cherry (ordered edge pair sharing a first
+coordinate) is counted exactly as `∑_a deg(a)²`, and the Cauchy–Schwarz
+bound is restated as `e(H)² ≤ |α| · cherryCount(H)` — a bound on an explicit
+two-edge configuration count. Base layer: exact e(F)=1 main term plus the
+Cauchy–Schwarz cherry inequality.
 
 ## Active Approach
-None yet.
+Self-contained counting framework on a ternary adjacency predicate
+`Tri3Graph (adj : α → β → γ → Prop)`, proving the deterministic skeleton of
+the NRS counting lemma with 0 sorries / 0 axioms. The relative-regularity
+content (e(F) ≥ 2) is deferred to a future `relativeDensity`/`IsGowersRegular`
+layer.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+The *approximate* (1 ± f(ε)) NRS lemma for e(F) ≥ 2 needs relative
+(Gowers/Rödl–Skokan) regularity — density conditioned on the 2-skeleton —
+which is not yet formalized on the `Tri3Graph` model. The *exact*
+deterministic e(F)=2 enumeration (cherry count) is now done; the genuine gap
+is the regularity hypothesis that turns the second-moment bound into a
+two-sided count.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Build the `relativeDensity` layer (3-graph density conditioned on the three
+bipartite 2-skeletons) on `Tri3Graph`, define `IsGowersRegular`, and combine
+with `edgeCount_sq_le_cherryCount` to bound the cherry count two-sidedly under
+regularity — the first non-exact instance of the lemma.

--- a/research/registry.json
+++ b/research/registry.json
@@ -24205,11 +24205,11 @@
     },
     {
       "slug": "szemeredi-counting-oq-02",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-04-22T13:25:38.671Z",
       "status": "active",
-      "lastUpdate": "2026-04-24T23:03:34.508Z"
+      "lastUpdate": "2026-06-27T00:27:00-07:00"
     },
     {
       "slug": "szemeredi-full",

--- a/src/data/proofs/szemeredi-counting-oq-02/annotations.json
+++ b/src/data/proofs/szemeredi-counting-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "shc-tri3graph-edgecount",
+    "proofId": "szemeredi-counting-oq-02",
+    "range": { "startLine": 68, "endLine": 97 },
+    "type": "definition",
+    "title": "Tripartite 3-Graphs and the Edge Count",
+    "content": "A tripartite 3-uniform hypergraph is modeled as a ternary adjacency predicate Tri3Graph (adj : α → β → γ → Prop): the triple (a,b,c) is a hyperedge when adj a b c holds. This predicate model — rather than the Finset-transversal model of the hypergraph core — is chosen precisely so that a labeled copy of the single-hyperedge pattern is literally an element of edgeFinset = univ.filter over α × β × γ. vertexTriples = |α|·|β|·|γ| is shown equal to Fintype.card (α × β × γ), and edgeCount_le bounds the edge count by it via card_filter_le.",
+    "mathContext": "$e(H) = |\\{(a,b,c) : \\mathrm{adj}\\,a\\,b\\,c\\}| \\le |\\alpha||\\beta||\\gamma|$",
+    "significance": "key",
+    "prerequisites": ["Finset.filter", "Fintype.card_prod", "Finset.card_filter_le"],
+    "relatedConcepts": ["k-uniform hypergraph", "labeled copy counting", "adjacency predicate", "tripartite structure"]
+  },
+  {
+    "id": "shc-exact-main-term",
+    "proofId": "szemeredi-counting-oq-02",
+    "range": { "startLine": 103, "endLine": 125 },
+    "type": "theorem",
+    "title": "The Exact Main Term: e(H) = d·|α||β||γ| (e(F) = 1)",
+    "content": "The counting lemma's headline count is d^{e(F)}·∏|Vᵢ|·(1 ± f(ε)). edgeCount_eq_density_mul proves that in the single-hyperedge base case e(F) = 1 this is EXACT with zero error: e(H) = d·|α||β||γ|. The proof is just clearing the denominator of density := e(H)/(|α||β||γ|) with div_mul_cancel₀, valid once the vertex count is positive. The density is also shown to live in [0,1] (density_nonneg by positivity; density_le_one by div_le_one + edgeCount_le). The lesson: the (1 ± f(ε)) error is entirely a phenomenon of patterns with two or more hyperedges.",
+    "mathContext": "$e(H) = d \\cdot |\\alpha||\\beta||\\gamma|$, exactly, with $d = e(H)/(|\\alpha||\\beta||\\gamma|) \\in [0,1]$",
+    "significance": "critical",
+    "prerequisites": ["div_mul_cancel₀", "div_le_one", "positivity"],
+    "relatedConcepts": ["edge density", "main term", "counting lemma base case", "exact vs approximate"]
+  },
+  {
+    "id": "shc-cherry-inequality",
+    "proofId": "szemeredi-counting-oq-02",
+    "range": { "startLine": 131, "endLine": 157 },
+    "type": "theorem",
+    "title": "The Cauchy–Schwarz Cherry Inequality (the Engine)",
+    "content": "The second-moment bound e(H)² ≤ |α|·∑_a deg(a)² (edgeCount_sq_le) is the deterministic engine every regularity-based counting and removal argument iterates over vertex subsets. The proof first decomposes the edge count over first-coordinate fibres: sum_degA gives ∑_a deg(a) = e(H) via card_eq_sum_card_fiberwise. Feeding this sum into Mathlib's sq_sum_le_card_mul_sum_sq over univ : Finset α turns (∑ deg)² ≤ |α|·∑ deg² into the stated inequality. No regularity hypothesis is used — this is pure Cauchy–Schwarz; the 'defect' form of the counting lemma is exactly this inequality plus the regularity bound on per-subset densities.",
+    "mathContext": "$e(H)^2 = \\left(\\sum_a \\deg(a)\\right)^2 \\le |\\alpha| \\sum_a \\deg(a)^2$",
+    "significance": "critical",
+    "prerequisites": ["Finset.sq_sum_le_card_mul_sum_sq", "Finset.card_eq_sum_card_fiberwise", "second moment method"],
+    "relatedConcepts": ["Cauchy–Schwarz", "second moment", "degree sequence", "regularity method", "defect inequality"]
+  },
+  {
+    "id": "shc-cherry-enumeration",
+    "proofId": "szemeredi-counting-oq-02",
+    "range": { "startLine": 163, "endLine": 210 },
+    "type": "theorem",
+    "title": "Exact e(F) = 2 Enumeration: cherryCount = ∑_a deg(a)²",
+    "content": "A cherry is an ordered pair of hyperedges sharing the same first-part vertex — the labeled copy of the two-hyperedge pattern that glues two triples at their α-coordinate (the first pattern with e(F) = 2). cherryCount_eq_sum_sq_degA enumerates these EXACTLY as ∑_a deg(a)² with no error: cherryFinset_filter shows the cherries centred at a are exactly (a-edges) ×ˢ (a-edges), so fibering over the shared coordinate (card_eq_sum_card_fiberwise) and applying card_product gives deg(a)·deg(a) per fibre. Casting to ℚ, edgeCount_sq_le_cherryCount restates Cauchy–Schwarz as e(H)² ≤ |α|·cherryCount(H) — a clean lower bound on an explicit count of two-edge configurations. This separates the deterministic content (counting cherries) from the open content (bounding them two-sidedly under regularity).",
+    "mathContext": "$\\mathrm{cherryCount}(H) = \\sum_a \\deg(a)^2, \\quad e(H)^2 \\le |\\alpha| \\cdot \\mathrm{cherryCount}(H)$",
+    "significance": "key",
+    "prerequisites": ["Finset.product", "Finset.card_product", "Finset.card_eq_sum_card_fiberwise"],
+    "relatedConcepts": ["cherry / path of length two", "two-edge configuration", "labeled copy", "exact enumeration"]
+  },
+  {
+    "id": "shc-structural",
+    "proofId": "szemeredi-counting-oq-02",
+    "range": { "startLine": 216, "endLine": 249 },
+    "type": "theorem",
+    "title": "Structural Sanity: Monotonicity and the Extremes",
+    "content": "edgeCount_mono shows the edge count is monotone in adjacency (adding hyperedges can only increase it, via card_le_card). The complete tripartite 3-graph (every triple an edge) and the empty one realize the extreme values: edgeCount_complete = vertexTriples, edgeCount_empty = 0, density_empty = 0. Together with edgeCount_le and density ∈ [0,1] these pin the range of the counting functions.",
+    "mathContext": "$0 = e(\\text{empty}) \\le e(H) \\le e(\\text{complete}) = |\\alpha||\\beta||\\gamma|$",
+    "significance": "supporting",
+    "prerequisites": ["Finset.card_le_card", "Finset.card_univ", "Finset.card_empty"],
+    "relatedConcepts": ["monotonicity", "complete hypergraph", "empty hypergraph", "extremal values"]
+  }
+]

--- a/src/data/proofs/szemeredi-counting-oq-02/index.ts
+++ b/src/data/proofs/szemeredi-counting-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SzemerediCountingOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const szemerediCountingOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const szemerediCountingOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const szemerediCountingOq02Data: ProofData = {
+  proof: szemerediCountingOq02Proof,
+  annotations: szemerediCountingOq02Annotations,
+}

--- a/src/data/proofs/szemeredi-counting-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-counting-oq-02/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "szemeredi-counting-oq-02",
+  "title": "Hypergraph Counting Lemma: the Exact Base Term and the Cherry Engine",
+  "slug": "szemeredi-counting-oq-02",
+  "description": "Builds the self-contained counting layer for tripartite 3-uniform hypergraphs that underlies the Nagle–Rödl–Schacht (2006) hypergraph counting lemma, and isolates exactly the part of that lemma that is deterministic — provable with no regularity hypothesis and no error term. A tripartite 3-graph is modeled as a ternary adjacency predicate Tri3Graph (adj : α → β → γ → Prop), making a labeled copy of the single-hyperedge pattern literally an edge of α × β × γ. The entry proves: (1) edgeCount_eq_density_mul — the EXACT counting identity e(H) = d · |α||β||γ| for the single-hyperedge pattern, the counting lemma's main term d^{e(F)}·∏|Vᵢ| in the base case e(F) = 1, holding with zero error; (2) edgeCount_sq_le — the Cauchy–Schwarz 'cherry' inequality e(H)² ≤ |α| · ∑_a deg(a)², the second-moment engine every regularity-based counting/removal argument iterates, obtained from Mathlib's sq_sum_le_card_mul_sum_sq after sum_degA decomposes the edge count over first-coordinate fibres; (3) cherryCount_eq_sum_sq_degA — the EXACT e(F) = 2 enumeration, counting labeled cherries (ordered edge pairs sharing a first coordinate) as ∑_a deg(a)² with no error, via card_eq_sum_card_fiberwise over the shared α-coordinate plus card_product on each fibre; and (4) edgeCount_sq_le_cherryCount — the same Cauchy–Schwarz bound rendered as e(H)² ≤ |α| · cherryCount(H), an inequality on an explicit count of two-edge configurations. The deliberate boundary: the approximate (1 ± f(ε)) NRS lemma for e(F) ≥ 2 needs RELATIVE (Gowers / Rödl–Skokan) regularity — density conditioned on the bipartite 2-skeletons — which is research-level and left open. What is exact (the e(F)=1 main term and the e(F)=2 cherry count) is separated cleanly from what needs regularity (the two-sided bound on the cherry count). 14 theorems + 10 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SzemerediCountingOQ02.lean",
+    "additionalFiles": [],
+    "tags": [
+      "szemeredi",
+      "combinatorics",
+      "hypergraph",
+      "counting-lemma",
+      "regularity",
+      "nagle-rodl-schacht",
+      "cauchy-schwarz",
+      "extremal-combinatorics",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 252,
+    "theoremCount": 14,
+    "definitionCount": 10,
+    "assumptions": "None beyond finite vertex parts. All results are universally quantified over a Tri3Graph H on Fintype parts α, β, γ; the adjacency predicate is an arbitrary Prop and decidability is supplied classically (open Classical), so edgeFinset/degA/cherryFinset are noncomputable Finset filters with no DecidableRel hypothesis. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sq_sum_le_card_mul_sum_sq",
+        "description": "The Cauchy–Schwarz / power-mean inequality (∑ f)² ≤ |s| · ∑ f² over a Finset. Instantiated at the first-part degree function to give the cherry inequality e(H)² ≤ |α| · ∑_a deg(a)².",
+        "module": "Mathlib.Analysis.MeanInequalities / Mathlib.Algebra.Order.Chebyshev"
+      },
+      {
+        "theorem": "Finset.card_eq_sum_card_fiberwise",
+        "description": "Partitioning a Finset by a fibre map and summing fibre cardinalities. Used twice: sum_degA decomposes e(H) over the first coordinate, and cherryCount_eq_sum_sq_degA decomposes the cherry count over the shared α-vertex.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_product",
+        "description": "|s ×ˢ t| = |s| · |t|. The cherries centred at a vertex a are exactly the ordered pairs of a-edges, so each fibre has card deg(a)·deg(a) = deg(a)².",
+        "module": "Mathlib.Data.Finset.Prod"
+      },
+      {
+        "theorem": "Finset.card_filter_le",
+        "description": "The edge Finset is a filter of the universal triple Finset, so e(H) ≤ |univ| = |α||β||γ| = vertexTriples.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "div_mul_cancel₀ / div_le_one",
+        "description": "Field arithmetic turning the definitional density e(H)/(|α||β||γ|) into the exact main term e(H) = d · |α||β||γ| and bounding density ≤ 1 from edgeCount_le.",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Tri3Graph (α β γ): a tripartite 3-uniform hypergraph modeled as a ternary adjacency predicate adj : α → β → γ → Prop. Unlike the Finset-transversal model in SzemerediHypergraphCore.lean, this makes labeled-copy counting definitional — a copy of the single-hyperedge pattern is literally an element of the edge Finset over α × β × γ — which is the right shape for the NRS counting lemma.",
+      "edgeCount_eq_density_mul (the EXACT main term, e(F) = 1): e(H) = d · |α||β||γ| with no error term, the counting lemma's main term d^{e(F)}·∏|Vᵢ| in the base case where it holds deterministically. A consequence of the density definition once the vertex count is positive.",
+      "sum_degA: ∑_a deg(a) = e(H), the first-coordinate degree decomposition of the edge count via card_eq_sum_card_fiberwise — the bridge that lets Cauchy–Schwarz see the edge count as a sum.",
+      "edgeCount_sq_le (the CHERRY INEQUALITY, the engine): e(H)² ≤ |α| · ∑_a deg(a)², the second-moment bound that drives every regularity-based counting and removal argument. Obtained by feeding sum_degA into Mathlib's sq_sum_le_card_mul_sum_sq; the defect form of the counting lemma is this inequality plus an ε-regularity hypothesis controlling the per-subset densities.",
+      "cherryFinset / cherryCount and cherryCount_eq_sum_sq_degA (the EXACT e(F) = 2 enumeration): the labeled two-hyperedge pattern that glues two triples at their α-coordinate (a 'cherry') is counted with zero error as ∑_a deg(a)². Proved by fibering the cherry Finset over the shared first coordinate (card_eq_sum_card_fiberwise) and identifying each fibre as a self-product of the a-edges (cherryFinset_filter + card_product).",
+      "edgeCount_sq_le_cherryCount: e(H)² ≤ |α| · cherryCount(H) — the Cauchy–Schwarz bound rephrased as a lower bound on an EXPLICIT count of two-edge configurations, separating the deterministic content (counting cherries) from the open content (bounding them two-sidedly under regularity).",
+      "Structural sanity layer edgeCount_le, density_nonneg, density_le_one, edgeCount_mono, edgeCount_complete, edgeCount_empty, density_empty: the edge count lives in [0, |α||β||γ|], the density in [0,1], the count is monotone in adjacency, and the complete/empty 3-graphs realize the extreme values."
+    ],
+    "prerequisites": [
+      "szemeredi-counting (parent: the graph (k=2) counting lemma and quantitative triangle removal)",
+      "szemeredi-hypergraph-core (the hypergraph regularity definitions this layer is the counting companion to)",
+      "Nagle–Rödl–Schacht counting lemma and Gowers / Rödl–Skokan hypergraph regularity",
+      "Cauchy–Schwarz / second-moment method and fiberwise cardinality counting in Mathlib"
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Szemerédi regularity lemma and its counting lemma underpin the graph removal lemma and Roth-type density results. Extending this machinery to $k$-uniform hypergraphs — needed for Szemerédi's theorem on arithmetic progressions of every length via the multidimensional / hypergraph removal route — was a major undertaking completed independently by Nagle, Rödl and Schacht (2006) and by Gowers (2007). The crux is that hypergraph regularity is *relative*: the density of a $3$-graph must be measured conditionally on the underlying bipartite $2$-graphs ('the $2$-skeleton'), and the counting lemma is proved by an induction over the uniformity. Naive $\\varepsilon$-regularity (a single global density condition) is provably insufficient to count copies of patterns with two or more hyperedges. This entry formalizes the part of the $3$-graph counting lemma that is *deterministic* — the exact main term and the second-moment engine — and marks precisely where the relative-regularity content begins.",
+    "problemStatement": "For a tripartite $3$-uniform hypergraph $H$ on finite parts $\\alpha, \\beta, \\gamma$ with edge density $d$, the NRS counting lemma asserts that if $H$ is $\\varepsilon$-regular then it contains $(1 \\pm f(\\varepsilon))\\, d^{e(F)} \\prod_i |V_i|$ labeled copies of any fixed $3$-graph $F$, with $f(\\varepsilon) \\to 0$. Formalize the deterministic core: prove the exact base case $e(H) = d\\,|\\alpha||\\beta||\\gamma|$ ($e(F) = 1$, no error), the Cauchy–Schwarz cherry inequality $e(H)^2 \\le |\\alpha| \\sum_a \\deg(a)^2$, and the exact enumeration of the $e(F) = 2$ cherry pattern as $\\sum_a \\deg(a)^2$ — isolating the regularity-free content from the open $(1 \\pm f(\\varepsilon))$ statement for $e(F) \\ge 2$.",
+    "text": "A tripartite 3-graph's edge count obeys two exact identities and one inequality that together form the deterministic skeleton of the hypergraph counting lemma: the single-edge pattern is counted exactly by d·|α||β||γ| (the main term, zero error), the two-edge 'cherry' pattern is counted exactly by ∑_a deg(a)², and Cauchy–Schwarz bounds e(H)² ≤ |α|·cherryCount. The genuinely open content — the approximate (1 ± f(ε)) count for two or more hyperedges — is exactly the step that needs relative regularity, and is deliberately left out.",
+    "proofStrategy": "**Model.** A `Tri3Graph α β γ` packages a predicate `adj : α → β → γ → Prop`; its `edgeFinset` is `univ.filter (fun p => H.adj p.1 p.2.1 p.2.2)` over `α × β × γ` and `edgeCount := edgeFinset.card`. The `vertexTriples` count is `|α|·|β|·|γ|` (proved equal to `Fintype.card (α × β × γ)`), and `density := e(H)/vertexTriples : ℚ`. **Exact main term.** `edgeCount_le` is `card_filter_le`; `density_le_one` follows by `div_le_one`; and `edgeCount_eq_density_mul` is `div_mul_cancel₀` once the vertex count is positive — the $e(F)=1$ case is exact by definition of density. **Degree decomposition.** `degA H a` counts edges with first coordinate `a`; `sum_degA` is `card_eq_sum_card_fiberwise` over the projection `p ↦ p.1`, giving `∑_a deg(a) = e(H)`. **Cherry inequality.** Feeding `sum_degA` into Mathlib's `sq_sum_le_card_mul_sum_sq` over `univ : Finset α` yields `edgeCount_sq_le`: `e(H)² ≤ |α| · ∑_a deg(a)²`. **Exact cherry count.** `cherryFinset` filters `edgeFinset ×ˢ edgeFinset` to ordered edge pairs sharing a first coordinate; `cherryFinset_filter` shows the cherries centred at `a` are exactly `(a`-edges`) ×ˢ (a`-edges`)`, so by `card_eq_sum_card_fiberwise` over the shared coordinate and `card_product`, `cherryCount_eq_sum_sq_degA` gives `cherryCount = ∑_a deg(a)²` with no error. Casting to ℚ, `edgeCount_sq_le_cherryCount` restates the second-moment bound as `e(H)² ≤ |α| · cherryCount`. **Sanity.** `edgeCount_mono`, `edgeCount_complete`, `edgeCount_empty`, `density_empty` pin the extremes.",
+    "keyInsights": [
+      "**The $e(F)=1$ main term is exact, definitionally.** The counting lemma's headline $d^{e(F)}\\prod|V_i|$ holds with *zero* error in the single-hyperedge base case, because that is just the definition of edge density cleared of its denominator (`edgeCount_eq_density_mul`). The $(1 \\pm f(\\varepsilon))$ error is entirely a phenomenon of $e(F) \\ge 2$.",
+      "**Cauchy–Schwarz is the deterministic engine.** The whole regularity method runs on one inequality applied over and over to vertex subsets: $e(H)^2 \\le |\\alpha| \\sum_a \\deg(a)^2$ (`edgeCount_sq_le`). It needs no regularity hypothesis — it is pure second moment — and the 'defect' form of the counting lemma is exactly this inequality together with the regularity bound on per-subset densities.",
+      "**The two-edge pattern is *also* exactly countable.** Separating exact from approximate: the labeled cherry (two triples glued at their $\\alpha$-coordinate) is enumerated with no error as $\\sum_a \\deg(a)^2$ (`cherryCount_eq_sum_sq_degA`). So the Cauchy–Schwarz right-hand side is a genuine combinatorial count of two-edge configurations, and `edgeCount_sq_le_cherryCount` is a clean lower bound $e(H)^2 \\le |\\alpha|\\cdot\\mathrm{cherryCount}$ on it.",
+      "**The open content is the *two-sided* cherry bound, not the count.** What requires relative (Gowers / Rödl–Skokan) regularity is not enumerating cherries but bounding their number two-sidedly so that the second-moment inequality becomes a matching $(1 \\pm f(\\varepsilon))$ count. That is precisely the step this entry stops short of — and pinpoints — by leaving `relativeDensity` / `IsGowersRegular` on the tripartite model for future work."
+    ],
+    "prerequisites": [
+      "Edge density and labeled-copy counting for hypergraphs",
+      "The second-moment / Cauchy–Schwarz method (sq_sum_le_card_mul_sum_sq)",
+      "Fiberwise cardinality counting (card_eq_sum_card_fiberwise, card_product)",
+      "Hypergraph regularity (NRS / Gowers) and why it must be relative to the 2-skeleton"
+    ]
+  },
+  "conclusion": {
+    "summary": "In 252 lines, 0 sorries, 0 axioms, the entry builds a tripartite 3-graph counting layer on a ternary adjacency predicate and proves the deterministic core of the Nagle–Rödl–Schacht counting lemma: the exact main term e(H) = d·|α||β||γ| (the e(F)=1 base case, no error), the Cauchy–Schwarz cherry inequality e(H)² ≤ |α|·∑_a deg(a)², and the exact e(F)=2 enumeration cherryCount = ∑_a deg(a)², combined into e(H)² ≤ |α|·cherryCount. The model makes a labeled single-edge copy literally an edge, so the base term is definitional, and the cherry count is computed by fibering over the shared first coordinate.",
+    "implications": "This isolates exactly which part of the hypergraph counting lemma is regularity-free: the e(F)=1 main term and the e(F)=2 cherry enumeration are both exact, and Cauchy–Schwarz supplies the one-sided second-moment bound. The genuine NRS content — the two-sided (1 ± f(ε)) count for e(F) ≥ 2 — is precisely the step that needs relative (Gowers / Rödl–Skokan) regularity, density conditioned on the bipartite 2-skeletons, which the entry leaves as the named next layer (relativeDensity / IsGowersRegular on Tri3Graph). It is the 3-graph companion to the verified graph counting lemma in SzemerediCounting.lean and the natural home for a future inductive counting argument over the uniformity.",
+    "openQuestions": [
+      "Build a relativeDensity layer on Tri3Graph: the 3-graph density conditioned on its three bipartite 2-skeletons (on α×β, β×γ, α×γ), and define IsGowersRegular relative to those skeletons — the missing hypothesis that turns the one-sided cherry inequality into a two-sided bound.",
+      "Combine edgeCount_sq_le_cherryCount with the relative-regularity hypothesis to bound cherryCount two-sidedly, proving the first genuinely non-exact (1 ± f(ε)) instance of the counting lemma on the tripartite predicate model.",
+      "Carry out the induction over uniformity: derive the full e(F)-edge NRS count d^{e(F)}∏|Vᵢ|·(1 ± f(ε)) for an arbitrary fixed 3-graph F from the cherry/second-moment base via the relative-regularity layer."
+    ]
+  },
+  "sections": [
+    {
+      "id": "tri3graph-edgecount",
+      "title": "Part I — Tripartite 3-Graphs and Their Edge Count",
+      "startLine": 64,
+      "endLine": 97,
+      "summary": "Defines Tri3Graph as a ternary adjacency predicate, vertexTriples = |α||β||γ| (= Fintype.card (α × β × γ)), edgeFinset as a filter over α × β × γ, and edgeCount = edgeFinset.card. edgeCount_le bounds the count by |α||β||γ| via card_filter_le.",
+      "mathContext": "$e(H) \\le |\\alpha||\\beta||\\gamma|$; a labeled single-hyperedge copy is literally an element of the edge Finset."
+    },
+    {
+      "id": "density-main-term",
+      "title": "Part II — Density and the Exact Main-Term Identity",
+      "startLine": 99,
+      "endLine": 125,
+      "summary": "density = e(H)/vertexTriples ∈ ℚ, with density_nonneg and density_le_one (via div_le_one and edgeCount_le). edgeCount_eq_density_mul is the exact counting identity e(H) = d·|α||β||γ| — the counting lemma's main term in the e(F)=1 base case, holding with no error term.",
+      "mathContext": "$e(H) = d \\cdot |\\alpha||\\beta||\\gamma|$ exactly; the $(1 \\pm f(\\varepsilon))$ error only appears for $e(F) \\ge 2$."
+    },
+    {
+      "id": "cherry-inequality",
+      "title": "Part III — Degrees and the Cauchy–Schwarz Cherry Inequality",
+      "startLine": 127,
+      "endLine": 157,
+      "summary": "degA a counts edges with first coordinate a; sum_degA gives ∑_a deg(a) = e(H) via card_eq_sum_card_fiberwise. Feeding this into Mathlib's sq_sum_le_card_mul_sum_sq yields edgeCount_sq_le: e(H)² ≤ |α|·∑_a deg(a)² — the second-moment engine of regularity-based counting.",
+      "mathContext": "$e(H)^2 \\le |\\alpha| \\sum_a \\deg(a)^2$ — pure Cauchy–Schwarz, no regularity needed."
+    },
+    {
+      "id": "cherry-enumeration",
+      "title": "Part IV — The Cherry Pattern: Exact e(F) = 2 Enumeration",
+      "startLine": 159,
+      "endLine": 210,
+      "summary": "cherryFinset filters edgeFinset ×ˢ edgeFinset to ordered edge pairs sharing a first coordinate; cherryFinset_filter identifies the cherries centred at a as (a-edges) ×ˢ (a-edges). cherryCount_eq_sum_sq_degA gives cherryCount = ∑_a deg(a)² exactly (card_eq_sum_card_fiberwise + card_product), and edgeCount_sq_le_cherryCount restates CS as e(H)² ≤ |α|·cherryCount.",
+      "mathContext": "$\\mathrm{cherryCount}(H) = \\sum_a \\deg(a)^2$ exactly; $e(H)^2 \\le |\\alpha| \\cdot \\mathrm{cherryCount}(H)$."
+    },
+    {
+      "id": "structural",
+      "title": "Part V — Structural Lemmas",
+      "startLine": 212,
+      "endLine": 249,
+      "summary": "edgeCount_mono (count monotone in adjacency), and the extreme cases: complete/empty tripartite 3-graphs with edgeCount_complete = vertexTriples, edgeCount_empty = 0, density_empty = 0.",
+      "mathContext": "$0 = e(\\text{empty}) \\le e(H) \\le e(\\text{complete}) = |\\alpha||\\beta||\\gamma|$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "szemeredi-counting",
+      "relationship": "extends",
+      "description": "Parent: the graph (k=2) counting lemma and quantitative triangle removal. This entry is the 3-graph companion, building the analogous counting layer (edge count, density, second-moment cherry bound) one uniformity up, where the lemma stops being exact for e(F) ≥ 2."
+    },
+    {
+      "targetId": "szemeredi-hypergraph-core",
+      "relationship": "related",
+      "description": "Supplies the hypergraph regularity definitions this layer is the counting companion to. The core uses a Finset-transversal model; this entry uses a ternary predicate model better suited to labeled-copy counting, and identifies the relative-regularity layer (relativeDensity / IsGowersRegular) that must be ported to close the e(F) ≥ 2 gap."
+    }
+  ],
+  "references": [
+    {
+      "title": "The counting lemma for regular k-uniform hypergraphs",
+      "author": "B. Nagle, V. Rödl, M. Schacht",
+      "year": "2006",
+      "venue": "Random Structures & Algorithms 28(2), 113–179",
+      "description": "Proves the counting lemma for ε-regular k-uniform hypergraphs — the (1 ± f(ε))·d^{e(F)}·∏|Vᵢ| count whose deterministic base term and cherry engine are formalized here."
+    },
+    {
+      "title": "Hypergraph regularity and the multidimensional Szemerédi theorem",
+      "author": "W. T. Gowers",
+      "year": "2007",
+      "venue": "Annals of Mathematics 166(3), 897–946",
+      "description": "Independent development of hypergraph regularity and counting, emphasizing that regularity must be measured relative to the lower-uniformity skeleton — the relative-density content this entry leaves open for e(F) ≥ 2."
+    },
+    {
+      "title": "Regularity Lemma for k-uniform hypergraphs",
+      "author": "V. Rödl, J. Skokan",
+      "year": "2004",
+      "venue": "Random Structures & Algorithms 25(1), 1–42",
+      "description": "The companion regularity lemma to the NRS counting lemma; together they give the hypergraph removal lemma and Szemerédi's theorem. The relative density conditioned on the 2-skeleton is the missing piece for the e(F) ≥ 2 count."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/SzemerediCountingOQ02.lean",
+    "filename": "SzemerediCountingOQ02.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Szemeredi.HypergraphCounting",
+    "lineCount": 252,
+    "theoremCount": 14,
+    "axiomCount": 0,
+    "definitionCount": 10,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCountingOQ02.lean",
+    "additionalFiles": []
+  },
+  "openQuestions": [
+    {
+      "id": "szemeredi-counting-oq-02-oq-01",
+      "question": "Build a relativeDensity layer on Tri3Graph — the 3-graph density conditioned on its three bipartite 2-skeletons — and define IsGowersRegular relative to those skeletons, the hypothesis that turns the one-sided cherry inequality into a two-sided bound.",
+      "significance": "high"
+    },
+    {
+      "id": "szemeredi-counting-oq-02-oq-02",
+      "question": "Combine edgeCount_sq_le_cherryCount with the relative-regularity hypothesis to bound cherryCount two-sidedly, proving the first genuinely non-exact (1 ± f(ε)) instance of the counting lemma on the tripartite predicate model.",
+      "significance": "high"
+    },
+    {
+      "id": "szemeredi-counting-oq-02-oq-03",
+      "question": "Carry out the induction over uniformity to derive the full e(F)-edge NRS count d^{e(F)}·∏|Vᵢ|·(1 ± f(ε)) for an arbitrary fixed 3-graph F from the cherry/second-moment base.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/szemeredi-counting-oq-02.json
+++ b/src/data/research/problems/szemeredi-counting-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "szemeredi-counting-oq-02",
   "title": "Szemerédi Regularity: Hypergraph Counting Lemma Formalization",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "ACT",
+  "status": "surveyed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -29,11 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: deterministic core of the 3-graph NRS counting lemma formalized (0-sorry, 0-axiom) — exact e(F)=1 main term, Cauchy–Schwarz cherry engine, exact e(F)=2 cherry enumeration. Open: two-sided (1±f(ε)) count for e(F)≥2 needs relative regularity.",
+    "builtItems": [
+      "Tri3Graph (proofs/Proofs/SzemerediCountingOQ02.lean) — tripartite 3-graph as ternary adjacency predicate; edgeFinset/edgeCount/density/vertexTriples counting layer.",
+      "edgeCount_eq_density_mul — exact main term e(H)=d·|α||β||γ| (e(F)=1 base case, no error).",
+      "edgeCount_sq_le — Cauchy–Schwarz cherry inequality e(H)²≤|α|·∑_a deg(a)² (the engine).",
+      "sum_degA — ∑_a deg(a)=e(H) via card_eq_sum_card_fiberwise.",
+      "cherryFinset/cherryCount + cherryCount_eq_sum_sq_degA — exact e(F)=2 enumeration cherryCount=∑_a deg(a)².",
+      "edgeCount_sq_le_cherryCount — e(H)²≤|α|·cherryCount(H) (enumerated CS).",
+      "Structural: edgeCount_le, density_nonneg/le_one, edgeCount_mono/complete/empty, density_empty. 14 thm + 10 def, 0 sorries, 0 axioms."
+    ],
+    "insights": [
+      "The e(F)=1 main term of the NRS counting lemma is EXACT (zero error): e(H)=d·|α||β||γ| is just the density definition cleared of its denominator (edgeCount_eq_density_mul). The (1±f(ε)) error is purely an e(F)≥2 phenomenon.",
+      "Cauchy–Schwarz is the deterministic engine: e(H)² ≤ |α|·∑_a deg(a)² (edgeCount_sq_le) needs no regularity — pure second moment via Mathlib sq_sum_le_card_mul_sum_sq after sum_degA decomposes e(H) over first-coordinate fibres.",
+      "The e(F)=2 cherry pattern is ALSO exactly countable: labeled cherries (ordered edge pairs sharing an α-vertex) number ∑_a deg(a)² with zero error (cherryCount_eq_sum_sq_degA), via card_eq_sum_card_fiberwise over the shared coordinate + card_product on each fibre.",
+      "The genuine open content is the TWO-SIDED cherry bound, not the count: turning e(H)²≤|α|·cherryCount into a matching (1±f(ε)) count needs relative (Gowers/Rödl–Skokan) regularity — density conditioned on the bipartite 2-skeletons.",
+      "Modeling a tripartite 3-graph as a ternary predicate adj:α→β→γ→Prop (not the Finset-transversal model of hypergraph-core) makes labeled-copy counting definitional: a single-edge copy is literally an element of edgeFinset over α×β×γ.",
+      "GOTCHA: Finset.card_eq_sum_card_fiberwise with an inline membership proof must defer the element (Finset.mem_univ _, not ...x.1) so f stays a metavar during unification, and the predicate must be unfolded (simp only [degA]) before rw can close by rfl — explicit x.1 + auto-rfl both fail."
+    ],
+    "mathlibGaps": [
+      "No relative (Gowers/Rödl–Skokan) hypergraph regularity on the tripartite predicate model: density conditioned on the three bipartite 2-skeletons (α×β, β×γ, α×γ). The symmetric-model versions live in SzemerediHypergraphGowers.lean on the UHypergraph subset model, not portable verbatim to Tri3Graph.",
+      "No inductive counting argument over hypergraph uniformity in Mathlib; the NRS proof is dimension-recursive."
+    ],
+    "nextSteps": [
+      "Build a relativeDensity layer on Tri3Graph (density conditioned on the three bipartite 2-skeletons).",
+      "Define IsGowersRegular for tripartite 3-graphs relative to those 2-skeletons (port shape from SzemerediHypergraphGowers.lean).",
+      "Combine edgeCount_sq_le_cherryCount with relative regularity to bound cherryCount two-sidedly — the first non-exact (1±f(ε)) instance of the lemma on this model."
+    ]
   },
   "tags": [
     "combinatorics",


### PR DESCRIPTION
## Summary

Formalizes the **deterministic core** of the Nagle–Rödl–Schacht (2006) hypergraph counting lemma for tripartite 3-uniform hypergraphs — the part provable with **no regularity hypothesis and no error term** — and cleanly isolates it from the open relative-regularity content.

A tripartite 3-graph is modeled as a ternary adjacency predicate `Tri3Graph (adj : α → β → γ → Prop)`, so a labeled copy of the single-hyperedge pattern is literally an edge of `α × β × γ`.

### What is proven (0 sorries, 0 axioms)
- **`edgeCount_eq_density_mul`** — the **exact main term** `e(H) = d·|α||β||γ|`: the counting lemma's `d^{e(F)}·∏|Vᵢ|` in the `e(F)=1` base case, with zero error.
- **`edgeCount_sq_le`** — the **Cauchy–Schwarz cherry inequality** `e(H)² ≤ |α|·∑_a deg(a)²`, the second-moment engine of regularity-based counting (`sum_degA` + Mathlib `sq_sum_le_card_mul_sum_sq`).
- **`cherryCount_eq_sum_sq_degA`** — the **exact `e(F)=2` enumeration**: labeled cherries number `∑_a deg(a)²` with no error (`card_eq_sum_card_fiberwise` + `card_product`).
- **`edgeCount_sq_le_cherryCount`** — `e(H)² ≤ |α|·cherryCount(H)`, CS as a bound on an explicit two-edge count.
- Structural sanity: `edgeCount_le`, `density_nonneg/le_one`, `edgeCount_mono/complete/empty`, `density_empty`.

### Deliberate boundary (left open)
The approximate `(1 ± f(ε))` NRS lemma for `e(F) ≥ 2` needs **relative** (Gowers / Rödl–Skokan) regularity — density conditioned on the bipartite 2-skeletons. What is exact (the `e(F)=1` main term and the `e(F)=2` cherry count) is separated from what needs regularity (the two-sided bound on the cherry count). Three open questions recorded for the `relativeDensity` / `IsGowersRegular` layer.

## Verification
- **14 theorems + 10 definitions, 252 lines, 0 sorries, 0 axioms.**
- Docker build: `✔ Built Proofs.SzemerediCountingOQ02` (7743 jobs, 0 errors).
- `#print axioms` foundational only (`propext`/`Classical.choice`/`Quot.sound`); no `native_decide`, no `sorryAx`. → `status: verified`, `badge: original`.

## Files
- `proofs/Proofs/SzemerediCountingOQ02.lean` (new)
- `src/data/proofs/szemeredi-counting-oq-02/` — meta.json, annotations.json, index.ts (new)
- `src/data/research/problems/szemeredi-counting-oq-02.json`, `research/problems/szemeredi-counting-oq-02/{knowledge,state}.md` (knowledge accumulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)