### PR TITLE
Enrich Robertson–Schrödinger Uncertainty: structured annotation fields

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -8,7 +8,20 @@
     },
     "type": "insight",
     "title": "The Squared-Modulus Split: Re² + Im²",
-    "content": "`cnorm_sq z : ‖z‖² = (Re z)² + (Im z)²` (via `Complex.sq_norm` then `Complex.normSq_apply`) is the algebraic heart of the strengthening. Cauchy–Schwarz controls the full modulus ‖⟪u,v⟫‖²; this identity resolves it into two nonnegative pieces — the imaginary part (Robertson's commutator term) and the real part (the covariance Robertson discards). Keeping both gives Schrödinger."
+    "content": "`cnorm_sq z : ‖z‖² = (Re z)² + (Im z)²` (via `Complex.sq_norm` then `Complex.normSq_apply`) is the algebraic heart of the strengthening. Cauchy–Schwarz controls the full modulus ‖⟪u,v⟫‖²; this identity resolves it into two nonnegative pieces — the imaginary part (Robertson's commutator term) and the real part (the covariance Robertson discards). Keeping both gives Schrödinger.",
+    "mathContext": "$\\|z\\|^2 = (\\operatorname{Re} z)^2 + (\\operatorname{Im} z)^2$. Applied to $z = \\langle u,v\\rangle$: $\\|\\langle u,v\\rangle\\|^2 = (\\operatorname{Re}\\langle u,v\\rangle)^2 + (\\operatorname{Im}\\langle u,v\\rangle)^2$, the covariance² plus the commutator² split.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complex modulus / normSq",
+      "real and imaginary decomposition",
+      "Robertson–Schrödinger uncertainty relation",
+      "sum of two nonnegative squares"
+    ],
+    "prerequisites": [
+      "complex numbers z = Re z + i·Im z",
+      "‖z‖² = Re z² + Im z² (Complex.normSq)",
+      "the parent Cauchy–Schwarz / Robertson inequality"
+    ]
   },
   {
     "id": "rs-02",
@@ -19,7 +32,20 @@
     },
     "type": "definition",
     "title": "The Covariance Functional Robertson Throws Away",
-    "content": "`anticommutatorEV A B ψ = ⟪ψ,(AB+BA)ψ⟫` and `covarianceEV A B ψ = Re(½⟨{A,B}⟩ − ⟨A⟩⟨B⟩)`. This is the quantum covariance of the observables A and B in the state ψ. Robertson's 1929 inequality drops it entirely; Schrödinger's 1930 refinement is exactly what you get by keeping it."
+    "content": "`anticommutatorEV A B ψ = ⟪ψ,(AB+BA)ψ⟫` and `covarianceEV A B ψ = Re(½⟨{A,B}⟩ − ⟨A⟩⟨B⟩)`. This is the quantum covariance of the observables A and B in the state ψ. Robertson's 1929 inequality drops it entirely; Schrödinger's 1930 refinement is exactly what you get by keeping it.",
+    "mathContext": "$\\langle\\{A,B\\}\\rangle = \\langle\\psi|(AB+BA)|\\psi\\rangle$ (anticommutator). $\\operatorname{Cov}(A,B) = \\operatorname{Re}\\!\\big(\\tfrac12\\langle\\{A,B\\}\\rangle - \\langle A\\rangle\\langle B\\rangle\\big)$, the symmetric quantum covariance.",
+    "significance": "key",
+    "relatedConcepts": [
+      "anticommutator {A,B} = AB + BA",
+      "expectation value ⟨A⟩",
+      "quantum covariance of observables",
+      "Robertson (1929) vs Schrödinger (1930)"
+    ],
+    "prerequisites": [
+      "self-adjoint operators as observables",
+      "expectation value ⟨A⟩ = ⟪ψ, Aψ⟫",
+      "inner product on a complex Hilbert space"
+    ]
   },
   {
     "id": "rs-03",
@@ -30,7 +56,20 @@
     },
     "type": "technique",
     "title": "Covariance = Real Part of the Centered Inner Product",
-    "content": "`covarianceEV_eq_re` proves Cov(A,B) = Re⟪u,v⟫ for the centered vectors u = Aψ−⟨A⟩ψ, v = Bψ−⟨B⟩ψ. Since ⟪v,u⟫ = conj⟪u,v⟫, the symmetric sum ⟪u,v⟫ + ⟪v,u⟫ = 2·Re⟪u,v⟫ expands (reusing the parent's `inner_centered_eq`) to ⟨{A,B}⟩ − 2⟨A⟩⟨B⟩. Halving via `Complex.div_ofNat_re` matches covarianceEV exactly — the real part Robertson never uses."
+    "content": "`covarianceEV_eq_re` proves Cov(A,B) = Re⟪u,v⟫ for the centered vectors u = Aψ−⟨A⟩ψ, v = Bψ−⟨B⟩ψ. Since ⟪v,u⟫ = conj⟪u,v⟫, the symmetric sum ⟪u,v⟫ + ⟪v,u⟫ = 2·Re⟪u,v⟫ expands (reusing the parent's `inner_centered_eq`) to ⟨{A,B}⟩ − 2⟨A⟩⟨B⟩. Halving via `Complex.div_ofNat_re` matches covarianceEV exactly — the real part Robertson never uses.",
+    "mathContext": "With $u = A\\psi - \\langle A\\rangle\\psi$, $v = B\\psi - \\langle B\\rangle\\psi$: $\\langle u,v\\rangle + \\langle v,u\\rangle = 2\\operatorname{Re}\\langle u,v\\rangle$ (since $\\langle v,u\\rangle = \\overline{\\langle u,v\\rangle}$) $= \\langle\\{A,B\\}\\rangle - 2\\langle A\\rangle\\langle B\\rangle$. Hence $\\operatorname{Cov}(A,B) = \\operatorname{Re}\\langle u,v\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "centered/fluctuation vectors",
+      "conjugate symmetry ⟪v,u⟫ = conj⟪u,v⟫",
+      "z + conj z = 2·Re z",
+      "symmetric (IsSymmetric) operators"
+    ],
+    "prerequisites": [
+      "sesquilinearity of the complex inner product",
+      "inner_centered_eq (parent helper)",
+      "real part of a half (Complex.div_ofNat_re)"
+    ]
   },
   {
     "id": "rs-04",
@@ -41,7 +80,20 @@
     },
     "type": "insight",
     "title": "Full Cauchy–Schwarz Gives Both Terms at Once",
-    "content": "`robertson_schrodinger_inequality` applies ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖, squares it, and splits ‖⟪u,v⟫‖² = Re² + Im². The real part is the covariance (Part II); the imaginary part carries the commutator — the parent's identity ⟪u,v⟫ − conj⟪u,v⟫ = ⟨[A,B]⟩ shows [A,B] is purely imaginary with im = 2·Im⟪u,v⟫, so ‖⟨[A,B]⟩‖² = 4·(Im⟪u,v⟫)². Assembling: σ_A²σ_B² ≥ Cov² + (½|⟨[A,B]⟩|)²."
+    "content": "`robertson_schrodinger_inequality` applies ‖⟪u,v⟫‖ ≤ ‖u‖·‖v‖, squares it, and splits ‖⟪u,v⟫‖² = Re² + Im². The real part is the covariance (Part II); the imaginary part carries the commutator — the parent's identity ⟪u,v⟫ − conj⟪u,v⟫ = ⟨[A,B]⟩ shows [A,B] is purely imaginary with im = 2·Im⟪u,v⟫, so ‖⟨[A,B]⟩‖² = 4·(Im⟪u,v⟫)². Assembling: σ_A²σ_B² ≥ Cov² + (½|⟨[A,B]⟩|)².",
+    "mathContext": "$\\sigma_A^2\\sigma_B^2 = \\|u\\|^2\\|v\\|^2 \\ge \\|\\langle u,v\\rangle\\|^2 = (\\operatorname{Re}\\langle u,v\\rangle)^2 + (\\operatorname{Im}\\langle u,v\\rangle)^2 = \\operatorname{Cov}(A,B)^2 + \\big(\\tfrac12|\\langle[A,B]\\rangle|\\big)^2$, using $\\langle[A,B]\\rangle = 2i\\operatorname{Im}\\langle u,v\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Schwarz ‖⟪u,v⟫‖ ≤ ‖u‖‖v‖",
+      "commutator [A,B] = AB − BA purely imaginary",
+      "variance σ² = ‖centered vector‖²",
+      "Robertson–Schrödinger relation"
+    ],
+    "prerequisites": [
+      "Cauchy–Schwarz in a complex inner-product space",
+      "the parent commutator identity ⟪u,v⟫ − conj⟪u,v⟫ = ⟨[A,B]⟩",
+      "the Re²+Im² split (rs-01)"
+    ]
   },
   {
     "id": "rs-05",
@@ -52,6 +104,19 @@
     },
     "type": "insight",
     "title": "Robertson is the Corollary; the Gap is Cov²",
-    "content": "`robertson_of_schrodinger` recovers the parent's σ_A·σ_B ≥ ½|⟨[A,B]⟩| by dropping the nonnegative Cov(A,B)² and taking square roots. `schrodinger_gap_nonneg` records the exact improvement: σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)². Equality in Robertson therefore forces Cov(A,B) = 0 — the strengthening is genuine precisely for correlated observables."
+    "content": "`robertson_of_schrodinger` recovers the parent's σ_A·σ_B ≥ ½|⟨[A,B]⟩| by dropping the nonnegative Cov(A,B)² and taking square roots. `schrodinger_gap_nonneg` records the exact improvement: σ_A²σ_B² − (½|⟨[A,B]⟩|)² ≥ Cov(A,B)². Equality in Robertson therefore forces Cov(A,B) = 0 — the strengthening is genuine precisely for correlated observables.",
+    "mathContext": "$\\sigma_A^2\\sigma_B^2 - \\big(\\tfrac12|\\langle[A,B]\\rangle|\\big)^2 \\ge \\operatorname{Cov}(A,B)^2 \\ge 0$. Dropping $\\operatorname{Cov}^2$ and taking $\\sqrt{\\cdot}$ recovers Robertson $\\sigma_A\\sigma_B \\ge \\tfrac12|\\langle[A,B]\\rangle|$; equality $\\Rightarrow \\operatorname{Cov}(A,B)=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strengthening vs corollary",
+      "equality conditions",
+      "uncorrelated observables (Cov = 0)",
+      "monotonicity of √"
+    ],
+    "prerequisites": [
+      "robertson_schrodinger_inequality (rs-04)",
+      "nonnegativity of a real square",
+      "monotonicity of the square root"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-01-oq-01-oq-02-oq-01` (Schrödinger's strengthening of the Robertson uncertainty relation via the full Cauchy–Schwarz modulus).

## Changes
- Added `mathContext` (display-LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations (Re²+Im² split, quantum covariance functional, Cov = Re⟪u,v⟫, σ_A²σ_B² ≥ Cov² + (½|⟨[A,B]⟩|)², Robertson as corollary).

## Not changed
- `meta.json` already comprehensive (14.0 KB, under caps); verified status verified / 0 axioms / 0 sorries against the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)