### PR TITLE
Enrich Cos 2π/n OQ-02→OQ-01: add annotations and index.ts

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/index.ts
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionCos20GalOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const angleTrisectionCos20GalOq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionCos20GalOq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionCos20GalOq02Oq01Data: ProofData = {
+  proof: angleTrisectionCos20GalOq02Oq01Proof,
+  annotations: angleTrisectionCos20GalOq02Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal-oq-02-oq-01` (first pass, was missing key files).

## Changes
- **Created `index.ts`** — the entry had only `meta.json`, so the page would render 'proof not found' on the live site despite appearing in the gallery listing.
- **Added `annotations.json`** with 6 substantive annotations covering all four proof parts:
  - `conj_zeta` — conjugation sends ζ to the other root (key technique)
  - `quadratic_factor` — quadratic factors over its conjugate-pair roots (Vieta)
  - `conj_two_cos` — conjugation fixes the real coefficient (fixed field)
  - `zeta_im` — Im(ζ)=sin θ as the distinctness oracle
  - sin(2π/n)>0 — sharpness of the index-2 step for all n≥3
  - φ(n)/2 consistency checks
- Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (13.3 KB, well under caps) and accurate vs the Lean source (13 theorems, 0 sorries, 0 axioms, status verified) — left as-is.

`pnpm build` passes.