### PR TITLE
Enrich Zolotarev–Frobenius for odd moduli: structured annotation fields

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,19 @@
     "range": { "startLine": 72, "endLine": 76 },
     "type": "theorem",
     "title": "Underlying element of the units reduction map",
-    "content": "coe_unitsMap: the ring element of ZMod.unitsMap h u is castHom h (u : ℤ/n). This is the bridge between the unit-group reduction (ℤ/n)ˣ → (ℤ/m)ˣ and the ring cast ℤ/n → ℤ/m, used everywhere the proof compares a CRT component (a unit) with a numerator residue (a ring element)."
+    "content": "coe_unitsMap: the ring element of ZMod.unitsMap h u is castHom h (u : ℤ/n). This is the bridge between the unit-group reduction (ℤ/n)ˣ → (ℤ/m)ˣ and the ring cast ℤ/n → ℤ/m, used everywhere the proof compares a CRT component (a unit) with a numerator residue (a ring element).",
+    "mathContext": "$\\big(\\mathrm{unitsMap}_h\\,u\\big) = \\mathrm{castHom}_h\\,(u) \\in \\mathbb{Z}/m$ — the unit-group reduction $(\\mathbb{Z}/n)^\\times \\to (\\mathbb{Z}/m)^\\times$ has the same underlying element as the ring reduction $\\mathbb{Z}/n \\to \\mathbb{Z}/m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ZMod.unitsMap (unit-group reduction)",
+      "ring cast castHom",
+      "compatibility of unit map and ring map",
+      "coercion (ℤ/n)ˣ → ℤ/n"
+    ],
+    "prerequisites": [
+      "units of ℤ/n and their coercion to ring elements",
+      "the reduction homomorphism ℤ/n → ℤ/m"
+    ]
   },
   {
     "id": "ann-eqr-oq01030101010101-crtfst",
@@ -13,7 +25,20 @@
     "range": { "startLine": 80, "endLine": 95 },
     "type": "theorem",
     "title": "The CRT projections are the canonical casts",
-    "content": "chineseRemainder_fst / chineseRemainder_snd: the two components of ZMod.chineseRemainder h x are castHom (dvd_mul_right m n) x and castHom (dvd_mul_left n m) x. Proved without unfolding the CRT definition: any two ring homomorphisms out of ℤ/(m·n) coincide (RingHom.ext_zmod), so the first/second projection composed with the CRT isomorphism is forced to equal the canonical cast. This lets the coprime step match unitsMap-built units against the CRT components by definitional cast."
+    "content": "chineseRemainder_fst / chineseRemainder_snd: the two components of ZMod.chineseRemainder h x are castHom (dvd_mul_right m n) x and castHom (dvd_mul_left n m) x. Proved without unfolding the CRT definition: any two ring homomorphisms out of ℤ/(m·n) coincide (RingHom.ext_zmod), so the first/second projection composed with the CRT isomorphism is forced to equal the canonical cast. This lets the coprime step match unitsMap-built units against the CRT components by definitional cast.",
+    "mathContext": "For $\\gcd(m,n)=1$, $\\mathbb{Z}/mn \\cong \\mathbb{Z}/m \\times \\mathbb{Z}/n$ and the projections are $x \\mapsto (x \\bmod m,\\, x \\bmod n)$. Uniqueness: any two ring homs $\\mathbb{Z}/mn \\to R$ agreeing are equal (`RingHom.ext_zmod`), so the CRT projection IS the canonical cast.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "RingHom.ext_zmod (uniqueness of ℤ/N homs)",
+      "canonical reduction casts",
+      "definitional vs propositional equality of maps"
+    ],
+    "prerequisites": [
+      "the CRT isomorphism ℤ/mn ≅ ℤ/m × ℤ/n",
+      "uniqueness of ring homomorphisms out of ℤ/N",
+      "coprimality m, n"
+    ]
   },
   {
     "id": "ann-eqr-oq01030101010101-legendrecongr",
@@ -21,7 +46,19 @@
     "range": { "startLine": 97, "endLine": 102 },
     "type": "theorem",
     "title": "Legendre symbol depends only on the residue mod p",
-    "content": "legendreSym_congr: if (A : ℤ/p) = (B : ℤ/p) then legendreSym p A = legendreSym p B. Combines legendreSym.mod (legendreSym p A = legendreSym p (A % p)) with ZMod.intCast_eq_intCast_iff (equal images in ℤ/p mean A % p = B % p). This is what lets the prime-power base compare the parent's legendreSym of (a mod p).val against legendreSym of the chosen numerator A."
+    "content": "legendreSym_congr: if (A : ℤ/p) = (B : ℤ/p) then legendreSym p A = legendreSym p B. Combines legendreSym.mod (legendreSym p A = legendreSym p (A % p)) with ZMod.intCast_eq_intCast_iff (equal images in ℤ/p mean A % p = B % p). This is what lets the prime-power base compare the parent's legendreSym of (a mod p).val against legendreSym of the chosen numerator A.",
+    "mathContext": "$A \\equiv B \\pmod p \\;\\Rightarrow\\; \\big(\\tfrac{A}{p}\\big) = \\big(\\tfrac{B}{p}\\big)$, since the Legendre symbol factors through $A \\bmod p$ (`legendreSym.mod`).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Legendre symbol well-definedness mod p",
+      "legendreSym.mod",
+      "ZMod.intCast_eq_intCast_iff",
+      "residue-class invariance"
+    ],
+    "prerequisites": [
+      "definition of the Legendre symbol (A/p)",
+      "congruence A ≡ B (mod p)"
+    ]
   },
   {
     "id": "ann-eqr-oq01030101010101-primepowerbase",
@@ -29,7 +66,20 @@
     "range": { "startLine": 113, "endLine": 134 },
     "type": "theorem",
     "title": "Prime-power base, representative-free",
-    "content": "sign_ringMulPerm_eq_jacobiSym_of_cast: for an odd prime p, exponent k ≥ 1, a unit a : (ℤ/pᵏ)ˣ, and any integer A with A ≡ a (mod pᵏ), sign(ringMulPerm a) = J(A | pᵏ). It rewrites by the parent's sign_ringMulPerm_eq_legendre_pow (sign = legendreSym p (a mod p)ᵏ) and jacobiSym_prime_pow (J(A | pᵏ) = legendreSym p A ᵏ), then closes the gap with legendreSym_congr after casting the hypothesis A ≡ a down from ℤ/pᵏ to ℤ/p. Repackaging the numerator as an arbitrary representative is exactly what makes the numerator constant across the CRT step of the induction."
+    "content": "sign_ringMulPerm_eq_jacobiSym_of_cast: for an odd prime p, exponent k ≥ 1, a unit a : (ℤ/pᵏ)ˣ, and any integer A with A ≡ a (mod pᵏ), sign(ringMulPerm a) = J(A | pᵏ). It rewrites by the parent's sign_ringMulPerm_eq_legendre_pow (sign = legendreSym p (a mod p)ᵏ) and jacobiSym_prime_pow (J(A | pᵏ) = legendreSym p A ᵏ), then closes the gap with legendreSym_congr after casting the hypothesis A ≡ a down from ℤ/pᵏ to ℤ/p. Repackaging the numerator as an arbitrary representative is exactly what makes the numerator constant across the CRT step of the induction.",
+    "mathContext": "For $A \\equiv a \\pmod{p^k}$: $\\operatorname{sign}(x\\mapsto ax) = \\big(\\tfrac{a}{p}\\big)^k = \\big(\\tfrac{A}{p}\\big)^k = J(A \\mid p^k)$, the cast $A\\equiv a \\pmod{p^k} \\Rightarrow A \\equiv a \\pmod p$ feeding `legendreSym_congr`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "representative-free numerator",
+      "parent prime-power Zolotarev (sign = legendreSymᵏ)",
+      "jacobiSym_prime_pow",
+      "constant numerator across the CRT step"
+    ],
+    "prerequisites": [
+      "the parent prime-power identity sign = legendreSym p (a mod p)ᵏ",
+      "J(A | pᵏ) = (A/p)ᵏ",
+      "legendreSym_congr"
+    ]
   },
   {
     "id": "ann-eqr-oq01030101010101-mainaux",
@@ -37,7 +87,20 @@
     "range": { "startLine": 138, "endLine": 192 },
     "type": "theorem",
     "title": "Multiplicative induction over the odd modulus",
-    "content": "main_aux: Nat.recOnPosPrimePosCoprime on n. The zero case is excluded by NeZero; the one case uses Subsingleton (ℤ/1) so ringMulPerm a = 1 and jacobiSym.one_right; the prime_pow case derives p ≠ 2 from Odd (pᵏ) (Nat.even_pow + Nat.odd_iff) and applies the representative-free base; the coprime case n = u·v sets a₁, a₂ = ZMod.unitsMap a, proves the CRT-component hypotheses (chineseRemainder_fst/snd) and the numerator-cast hypotheses (map_intCast), splits the sign with sign_ringMulPerm_mul_of_odd, applies the two inductive hypotheses, and recombines with jacobiSym.mul_right. The same integer A is fed to both factors, mirroring J(A | u·v) = J(A | u)·J(A | v)."
+    "content": "main_aux: Nat.recOnPosPrimePosCoprime on n. The zero case is excluded by NeZero; the one case uses Subsingleton (ℤ/1) so ringMulPerm a = 1 and jacobiSym.one_right; the prime_pow case derives p ≠ 2 from Odd (pᵏ) (Nat.even_pow + Nat.odd_iff) and applies the representative-free base; the coprime case n = u·v sets a₁, a₂ = ZMod.unitsMap a, proves the CRT-component hypotheses (chineseRemainder_fst/snd) and the numerator-cast hypotheses (map_intCast), splits the sign with sign_ringMulPerm_mul_of_odd, applies the two inductive hypotheses, and recombines with jacobiSym.mul_right. The same integer A is fed to both factors, mirroring J(A | u·v) = J(A | u)·J(A | v).",
+    "mathContext": "Induction shape: $1$, prime powers $p^k$, and coprime products $u\\cdot v$ (`Nat.recOnPosPrimePosCoprime`). Coprime step: $J(A\\mid uv) = J(A\\mid u)\\,J(A\\mid v)$ matched against $\\operatorname{sign}$ splitting over $\\mathbb{Z}/uv \\cong \\mathbb{Z}/u \\times \\mathbb{Z}/v$, the SAME $A$ on both factors.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.recOnPosPrimePosCoprime (multiplicative induction)",
+      "jacobiSym.mul_right (CRT multiplicativity)",
+      "sign_ringMulPerm_mul_of_odd",
+      "Subsingleton ℤ/1 base case"
+    ],
+    "prerequisites": [
+      "multiplicative recursion on naturals",
+      "the prime-power base case",
+      "sign splitting over a CRT product"
+    ]
   },
   {
     "id": "ann-eqr-oq01030101010101-headline",
@@ -45,7 +108,19 @@
     "range": { "startLine": 194, "endLine": 205 },
     "type": "theorem",
     "title": "Zolotarev–Frobenius for every odd modulus",
-    "content": "sign_ringMulPerm_eq_jacobiSym_odd: for every odd n > 0, unit a : (ℤ/n)ˣ, and representative A ≡ a (mod n), the sign of multiplication-by-a on the whole ring ℤ/n equals J(A | n). sign_ringMulPerm_eq_jacobiSym_val: the canonical-representative corollary J((a).val | n). Together these complete the Frobenius generalization of Zolotarev's lemma for all odd moduli."
+    "content": "sign_ringMulPerm_eq_jacobiSym_odd: for every odd n > 0, unit a : (ℤ/n)ˣ, and representative A ≡ a (mod n), the sign of multiplication-by-a on the whole ring ℤ/n equals J(A | n). sign_ringMulPerm_eq_jacobiSym_val: the canonical-representative corollary J((a).val | n). Together these complete the Frobenius generalization of Zolotarev's lemma for all odd moduli.",
+    "mathContext": "$\\operatorname{sign}(x \\mapsto a x \\text{ on } \\mathbb{Z}/n) = J(A \\mid n)$ for any $A \\equiv a \\pmod n$, and $= J(a.\\mathrm{val} \\mid n)$ on the canonical representative — Frobenius's generalization of Zolotarev's lemma to all odd $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Zolotarev's lemma",
+      "Frobenius generalization to composite moduli",
+      "Jacobi symbol J(a | n)",
+      "canonical representative a.val"
+    ],
+    "prerequisites": [
+      "main_aux (the multiplicative induction)",
+      "Jacobi symbol over odd composite n"
+    ]
   },
   {
     "id": "ann-eqr-oq01030101010101-character",
@@ -53,6 +128,19 @@
     "range": { "startLine": 207, "endLine": 211 },
     "type": "theorem",
     "title": "The Zolotarev sign character IS the Jacobi symbol",
-    "content": "signRingHom_eq_jacobiSym: through ZolotarevCRT.signRingHom (the sign character (ℤ/n)ˣ → ℤˣ defined for any modulus), the Zolotarev sign of a unit a equals J((a).val | n) for odd n. This identifies the abstract sign character of the great-great-grandparent CRT file with the concrete Jacobi symbol, closing the dictionary the lineage set out to build."
+    "content": "signRingHom_eq_jacobiSym: through ZolotarevCRT.signRingHom (the sign character (ℤ/n)ˣ → ℤˣ defined for any modulus), the Zolotarev sign of a unit a equals J((a).val | n) for odd n. This identifies the abstract sign character of the great-great-grandparent CRT file with the concrete Jacobi symbol, closing the dictionary the lineage set out to build.",
+    "mathContext": "As group characters $(\\mathbb{Z}/n)^\\times \\to \\{\\pm 1\\}$: $\\mathrm{signRingHom}(a) = J(a.\\mathrm{val} \\mid n)$ for odd $n$ — the abstract Zolotarev sign character equals the Jacobi-symbol character.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sign character (ℤ/n)ˣ → ℤˣ",
+      "Jacobi symbol as a Dirichlet character",
+      "ZolotarevCRT.signRingHom",
+      "character-level identity"
+    ],
+    "prerequisites": [
+      "the value-form identity sign = J(a.val | n)",
+      "signRingHom and its apply lemma",
+      "the Jacobi symbol as a multiplicative character"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for the full odd-modulus Zolotarev/Frobenius identity (sign of mult-by-a on ℤ/n = Jacobi symbol J(a|n) for all odd n).

## Changes
- Added `mathContext` (display-LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all 7 annotations (units reduction map, CRT projections = canonical casts, Legendre congruence, representative-free prime-power base, Nat.recOnPosPrimePosCoprime induction, all-odd-n headline, signRingHom = Jacobi character).

## Not changed
- `meta.json` already comprehensive (canonical overview + conclusion); verified status verified / 0 axioms / 0 sorries against the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)