### PR TITLE
Enrich First Supplement via Zolotarev sign: structured annotation fields

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,19 @@
     "range": { "startLine": 60, "endLine": 62 },
     "type": "theorem",
     "title": "Negation is an involution",
-    "content": "ringMulPerm_neg_one_sq: the Zolotarev permutation for a = -1 is multiplication by -1, i.e. the negation map x ↦ -x, and it squares to the identity. Proof: (ringMulPerm (-1))² = ringMulPerm ((-1)·(-1)) = ringMulPerm 1 = 1, using the multiplicativity ringMulPerm_mul and (-1)·(-1) = 1 in the units (neg_one_mul, neg_neg)."
+    "content": "ringMulPerm_neg_one_sq: the Zolotarev permutation for a = -1 is multiplication by -1, i.e. the negation map x ↦ -x, and it squares to the identity. Proof: (ringMulPerm (-1))² = ringMulPerm ((-1)·(-1)) = ringMulPerm 1 = 1, using the multiplicativity ringMulPerm_mul and (-1)·(-1) = 1 in the units (neg_one_mul, neg_neg).",
+    "mathContext": "$\\sigma_{-1}: x \\mapsto -x$ on $\\mathbb{Z}/n$ satisfies $\\sigma_{-1}^2 = \\sigma_{(-1)(-1)} = \\sigma_1 = \\mathrm{id}$ — an involution, by multiplicativity $\\sigma_a\\sigma_b = \\sigma_{ab}$ and $(-1)(-1)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "involution (σ² = id)",
+      "multiplicativity of the Zolotarev permutation",
+      "negation map x ↦ −x",
+      "the unit −1 in (ℤ/n)ˣ"
+    ],
+    "prerequisites": [
+      "ringMulPerm and ringMulPerm_mul",
+      "(−1)·(−1) = 1 in a ring"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010101-fixedpoints",
@@ -13,7 +25,20 @@
     "range": { "startLine": 72, "endLine": 95 },
     "type": "theorem",
     "title": "For odd n, negation fixes exactly one point",
-    "content": "card_fixedPoints_neg_one: the fixed-point set of x ↦ -x on ℤ/n has cardinality 1 (just 0). Via Fintype.card_eq_one_iff: 0 is fixed, and any fixed x satisfies -x = x, hence 2x = 0 (linear_combination). Since n is odd, 2 is coprime to n (Nat.prime_two.coprime_iff_not_dvd + Nat.two_dvd_ne_zero + Nat.odd_iff) and therefore a unit mod n (ZMod.isUnit_iff_coprime), so x = 0 (IsUnit.mul_right_eq_zero). This single-fixed-point fact is the only real content of the parity computation; oddness is what forces it."
+    "content": "card_fixedPoints_neg_one: the fixed-point set of x ↦ -x on ℤ/n has cardinality 1 (just 0). Via Fintype.card_eq_one_iff: 0 is fixed, and any fixed x satisfies -x = x, hence 2x = 0 (linear_combination). Since n is odd, 2 is coprime to n (Nat.prime_two.coprime_iff_not_dvd + Nat.two_dvd_ne_zero + Nat.odd_iff) and therefore a unit mod n (ZMod.isUnit_iff_coprime), so x = 0 (IsUnit.mul_right_eq_zero). This single-fixed-point fact is the only real content of the parity computation; oddness is what forces it.",
+    "mathContext": "$\\mathrm{Fix}(x\\mapsto -x) = \\{x : 2x = 0\\}$. For odd $n$, $2 \\in (\\mathbb{Z}/n)^\\times$, so $2x=0 \\Rightarrow x=0$; hence $|\\mathrm{Fix}| = 1$. (For even $n$ there would be a second fixed point $n/2$.)",
+    "significance": "key",
+    "relatedConcepts": [
+      "fixed points of an involution",
+      "2 is a unit mod odd n",
+      "ZMod.isUnit_iff_coprime",
+      "oddness as the decisive hypothesis"
+    ],
+    "prerequisites": [
+      "Fintype.card_eq_one_iff",
+      "coprimality of 2 and odd n",
+      "IsUnit.mul_right_eq_zero"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010101-signnegone",
@@ -21,7 +46,20 @@
     "range": { "startLine": 106, "endLine": 110 },
     "type": "theorem",
     "title": "The parity of the negation permutation",
-    "content": "sign_neg_one: for odd n, sign(x ↦ -x on ℤ/n) = (-1)^((n-1)/2). Apply Mathlib's involution-sign formula Equiv.Perm.sign_of_pow_two_eq_one, which gives sign σ = (-1)^((|α| - |fixedPoints σ|)/2) for σ² = 1; substitute |ℤ/n| = n (ZMod.card) and |fixedPoints| = 1 (card_fixedPoints_neg_one). This is the elementary combinatorial heart: negation is a product of (n-1)/2 disjoint transpositions."
+    "content": "sign_neg_one: for odd n, sign(x ↦ -x on ℤ/n) = (-1)^((n-1)/2). Apply Mathlib's involution-sign formula Equiv.Perm.sign_of_pow_two_eq_one, which gives sign σ = (-1)^((|α| - |fixedPoints σ|)/2) for σ² = 1; substitute |ℤ/n| = n (ZMod.card) and |fixedPoints| = 1 (card_fixedPoints_neg_one). This is the elementary combinatorial heart: negation is a product of (n-1)/2 disjoint transpositions.",
+    "mathContext": "For an involution $\\sigma$: $\\operatorname{sign}\\sigma = (-1)^{(|\\alpha| - |\\mathrm{Fix}\\,\\sigma|)/2}$. Here $|\\alpha| = n$, $|\\mathrm{Fix}| = 1$, so $\\operatorname{sign}(x\\mapsto -x) = (-1)^{(n-1)/2}$ — negation is $(n-1)/2$ disjoint transpositions $\\{x,-x\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Equiv.Perm.sign_of_pow_two_eq_one",
+      "transposition decomposition of an involution",
+      "sign = (−1)^(#transpositions)",
+      "ZMod.card"
+    ],
+    "prerequisites": [
+      "the involution-sign formula",
+      "the single-fixed-point count",
+      "cardinality |ℤ/n| = n"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010101-supplement",
@@ -29,7 +67,20 @@
     "range": { "startLine": 125, "endLine": 130 },
     "type": "theorem",
     "title": "The first supplement to quadratic reciprocity",
-    "content": "jacobiSym_neg_one: J(-1 | n) = (-1)^((n-1)/2) for every odd n > 0. By the parent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with unit a = -1 and integer representative A = -1, which agree as ((-1 : ℤ) : ℤ/n) = ((-1 : (ℤ/n)ˣ) : ℤ/n)), J(-1 | n) equals the sign of the negation permutation; by sign_neg_one that sign is (-1)^((n-1)/2). No Gauss sums, Eisenstein's lemma, or Mathlib reciprocity machinery are used."
+    "content": "jacobiSym_neg_one: J(-1 | n) = (-1)^((n-1)/2) for every odd n > 0. By the parent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with unit a = -1 and integer representative A = -1, which agree as ((-1 : ℤ) : ℤ/n) = ((-1 : (ℤ/n)ˣ) : ℤ/n)), J(-1 | n) equals the sign of the negation permutation; by sign_neg_one that sign is (-1)^((n-1)/2). No Gauss sums, Eisenstein's lemma, or Mathlib reciprocity machinery are used.",
+    "mathContext": "$J(-1 \\mid n) = (-1)^{(n-1)/2}$ for all odd $n>0$ — the first supplement. Proof route: $J(-1\\mid n) = \\operatorname{sign}(x\\mapsto -x) = (-1)^{(n-1)/2}$, entirely via permutation parity (no Gauss sums / Eisenstein).",
+    "significance": "key",
+    "relatedConcepts": [
+      "first supplement to quadratic reciprocity",
+      "Zolotarev's lemma route (no Gauss sums)",
+      "Jacobi symbol J(−1 | n)",
+      "(−1)^((n−1)/2) = +1 iff n ≡ 1 (mod 4)"
+    ],
+    "prerequisites": [
+      "the parent all-odd-modulus identity sign = J(a | n)",
+      "sign_neg_one",
+      "matching the unit −1 with the integer representative −1"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010101-chi4",
@@ -37,7 +88,19 @@
     "range": { "startLine": 134, "endLine": 136 },
     "type": "theorem",
     "title": "Consistency with the quadratic character χ₄",
-    "content": "jacobiSym_neg_one_eq_chi4: the Zolotarev evaluation (-1)^((n-1)/2) equals Mathlib's character value χ₄ n (via jacobiSym.at_neg_one J(-1 | n) = χ₄ n). This recovers ZMod.χ₄_eq_neg_one_pow through the permutation-sign route, an independent cross-check of the parity computation against the analytic definition of χ₄."
+    "content": "jacobiSym_neg_one_eq_chi4: the Zolotarev evaluation (-1)^((n-1)/2) equals Mathlib's character value χ₄ n (via jacobiSym.at_neg_one J(-1 | n) = χ₄ n). This recovers ZMod.χ₄_eq_neg_one_pow through the permutation-sign route, an independent cross-check of the parity computation against the analytic definition of χ₄.",
+    "mathContext": "$(-1)^{(n-1)/2} = \\chi_4(n)$, the unique nontrivial character mod 4: $\\chi_4(n) = +1$ for $n\\equiv 1$, $-1$ for $n\\equiv 3 \\pmod 4$. Independent cross-check of the parity route against Mathlib's analytic $\\chi_4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "the mod-4 quadratic character χ₄",
+      "jacobiSym.at_neg_one",
+      "ZMod.χ₄_eq_neg_one_pow",
+      "cross-validation of two definitions"
+    ],
+    "prerequisites": [
+      "jacobiSym_neg_one",
+      "definition of χ₄ mod 4"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010101-legendre",
@@ -45,6 +108,19 @@
     "range": { "startLine": 144, "endLine": 148 },
     "type": "theorem",
     "title": "Euler's criterion / Legendre special case",
-    "content": "legendreSym_neg_one: for an odd prime p, (-1 / p) = (-1)^((p-1)/2) — the classical first supplement / Euler-criterion form. Obtained by specializing jacobiSym_neg_one to a prime modulus via jacobiSym.legendreSym.to_jacobiSym (legendreSym p a = J(a | p)) and Nat.Prime.odd_of_ne_two."
+    "content": "legendreSym_neg_one: for an odd prime p, (-1 / p) = (-1)^((p-1)/2) — the classical first supplement / Euler-criterion form. Obtained by specializing jacobiSym_neg_one to a prime modulus via jacobiSym.legendreSym.to_jacobiSym (legendreSym p a = J(a | p)) and Nat.Prime.odd_of_ne_two.",
+    "mathContext": "$\\big(\\tfrac{-1}{p}\\big) = (-1)^{(p-1)/2}$ for odd prime $p$ — equivalently $-1$ is a quadratic residue mod $p$ iff $p \\equiv 1 \\pmod 4$ (Euler's criterion / first supplement), the prime specialisation of $J(-1\\mid n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's criterion",
+      "Legendre symbol (−1/p)",
+      "−1 a QR iff p ≡ 1 (mod 4)",
+      "legendreSym = Jacobi symbol on primes"
+    ],
+    "prerequisites": [
+      "jacobiSym_neg_one",
+      "legendreSym p a = J(a | p)",
+      "an odd prime is ≠ 2"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for the first supplement J(−1|n) = (−1)^((n−1)/2), derived through the parity of the negation permutation (no Gauss sums).

## Changes
- Added `mathContext` (display-LaTeX), `significance`, `relatedConcepts`, `prerequisites` to all 6 annotations (negation involution, single fixed point for odd n, involution-sign = (−1)^((n−1)/2), first supplement, χ₄ cross-check, Legendre/Euler-criterion specialisation).

## Not changed
- `meta.json` already comprehensive (canonical overview + conclusion); verified status verified / 0 axioms / 0 sorries against the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)