### PR TITLE
audit: confirm clean — isoperimetric-theorem-oq-03 + szemeredi-counting-oq-02 (2 new entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24979,6 +24979,18 @@
       "lastAudited": "2026-06-27T07:23:40Z",
       "result": "clean",
       "issues": []
+    },
+    "isoperimetric-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T07:37:09Z",
+      "result": "clean",
+      "issues": []
+    },
+    "szemeredi-counting-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T07:38:05Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 2 newly-added entries, both CLEAN

Audited the only two never-audited gallery entries. Both pass all integrity checks; gallery is now 4027/4027 audited.

### isoperimetric-theorem-oq-03 — CLEAN [verified/original, Tier A]
Discrete isoperimetric inequality on the cycle C_n = ℤ/nℤ.
- 9 theorems/lemmas, 3 defs, 0 sorries, 0 axioms, 0 `native_decide` — all match meta.json.
- Mathlib deps (Fintype.sum_equiv, Finset.sum_boole, card_union_of_disjoint, ZMod basics) are standard supporting lemmas, not the core result. Balance identity, structure, evenness, sharp bound 2, and achievability are independently proved. Badge `original` correct.
- Title appropriately qualified ("discrete", "cycle"); does not overclaim the continuous isoperimetric theorem.

### szemeredi-counting-oq-02 — CLEAN [verified/original, Tier A/D]
Deterministic counting core for tripartite 3-graphs (NRS counting lemma).
- 14 theorems, 10 defs, 0 sorries, 0 axioms, 0 `native_decide` — all match meta.json. Line count 252 exact.
- `fun _ _ _ => True` is the complete-graph adjacency predicate, not a True-stub theorem.
- Exemplary honest framing: title claims only "the Exact Base Term and the Cherry Engine"; description, proofStrategy, originalContributions, and mathlibDependencies all explicitly credit Mathlib's `sq_sum_le_card_mul_sum_sq` for the Cauchy–Schwarz step and explicitly mark the full (1 ± f(ε)) NRS lemma for e(F) ≥ 2 as OPEN. No delegation opacity, no inequality-as-theorem inflation.

No overclaiming detected. No changes required to either meta.json.

---
Discovered during autonomous gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)