### PR TITLE
Enrich prime-power Zolotarev (whole ring): index.ts + annotation fields

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 84, "endLine": 89 },
     "type": "theorem",
     "title": "The p-multiplication bridge",
-    "content": "mul_p_eq_zero_iff: in ℤ/pⁿ⁺¹, p·z = 0 iff z reduces to 0 in ℤ/pⁿ — both express pⁿ ∣ z.val. Proof writes z = ↑n (natCast surjective) and applies ZMod.natCast_eq_zero_iff to both sides, then cancels one factor of p (Nat.mul_dvd_mul_iff_left). This single fact, promoted to p·u = p·v ⟺ castHom u = castHom v, drives both the injectivity of the non-unit isomorphism and its intertwining with the a-action."
+    "content": "mul_p_eq_zero_iff: in ℤ/pⁿ⁺¹, p·z = 0 iff z reduces to 0 in ℤ/pⁿ — both express pⁿ ∣ z.val. Proof writes z = ↑n (natCast surjective) and applies ZMod.natCast_eq_zero_iff to both sides, then cancels one factor of p (Nat.mul_dvd_mul_iff_left). This single fact, promoted to p·u = p·v ⟺ castHom u = castHom v, drives both the injectivity of the non-unit isomorphism and its intertwining with the a-action.",
+    "mathContext": "$p\\cdot z = 0$ in $\\mathbb{Z}/p^{n+1}$ $\\iff$ $\\bar z = 0$ in $\\mathbb{Z}/p^{n}$ (both say $p^{n}\\mid z$); hence $p u = p v \\iff u \\equiv v \\pmod{p^{n}}$.",
+    "significance": "key",
+    "relatedConcepts": ["maximal ideal (p)", "quotient ring ℤ/pⁿ", "reduction homomorphism", "p-adic filtration"],
+    "prerequisites": ["ZMod.natCast_eq_zero_iff", "divisibility in ℤ/pⁿ"]
   },
   {
     "id": "ann-eqr-oq010301010101-nonunitsfun",
@@ -13,7 +17,11 @@
     "range": { "startLine": 129, "endLine": 131 },
     "type": "definition",
     "title": "The maximal ideal as p·(lift y)",
-    "content": "nonUnitsFun sends y : ℤ/pⁿ to the non-unit p·(lift y) of ℤ/pⁿ⁺¹. Every non-unit of ℤ/pⁿ⁺¹ is a multiple of p (the maximal ideal (p)), and p·(anything) is never a unit (not_isUnit_mul_p, via ZMod.isUnit_iff_coprime), so this lands in the non-units. It is the forward map of the additive isomorphism (p) ≅ ℤ/pⁿ that turns the non-unit block into a smaller copy of the whole problem."
+    "content": "nonUnitsFun sends y : ℤ/pⁿ to the non-unit p·(lift y) of ℤ/pⁿ⁺¹. Every non-unit of ℤ/pⁿ⁺¹ is a multiple of p (the maximal ideal (p)), and p·(anything) is never a unit (not_isUnit_mul_p, via ZMod.isUnit_iff_coprime), so this lands in the non-units. It is the forward map of the additive isomorphism (p) ≅ ℤ/pⁿ that turns the non-unit block into a smaller copy of the whole problem.",
+    "mathContext": "$\\mu : \\mathbb{Z}/p^{n} \\to (p) \\subset \\mathbb{Z}/p^{n+1}$, $y \\mapsto p\\cdot\\tilde y$; the non-units are exactly $(p)$, and $\\gcd(p\\cdot\\text{anything}, p^{n+1}) > 1$ so $p\\cdot z$ is never a unit.",
+    "significance": "supporting",
+    "relatedConcepts": ["maximal ideal", "additive group isomorphism", "non-units = (p)", "ZMod.isUnit_iff_coprime"],
+    "prerequisites": ["maximal ideal of a local ring", "units of ℤ/pⁿ"]
   },
   {
     "id": "ann-eqr-oq010301010101-bijective",
@@ -21,7 +29,11 @@
     "range": { "startLine": 133, "endLine": 154 },
     "type": "theorem",
     "title": "Bijectivity by injectivity and counting",
-    "content": "nonUnitsFun_bijective: injective via the bridge (p·↑y.val = p·↑y'.val forces y = y' after reducing mod pⁿ), and surjective by cardinality — the non-units of ℤ/pⁿ⁺¹ number pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ⁺¹ − pⁿ(p−1) = pⁿ (Fintype.card_subtype_compl, ZMod.card_units_eq_totient, Nat.totient_prime_pow_succ), matching |ℤ/pⁿ|. No explicit inverse is needed (Fintype.bijective_iff_injective_and_card)."
+    "content": "nonUnitsFun_bijective: injective via the bridge (p·↑y.val = p·↑y'.val forces y = y' after reducing mod pⁿ), and surjective by cardinality — the non-units of ℤ/pⁿ⁺¹ number pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ⁺¹ − pⁿ(p−1) = pⁿ (Fintype.card_subtype_compl, ZMod.card_units_eq_totient, Nat.totient_prime_pow_succ), matching |ℤ/pⁿ|. No explicit inverse is needed (Fintype.bijective_iff_injective_and_card).",
+    "mathContext": "$\\#\\{\\text{non-units of }\\mathbb{Z}/p^{n+1}\\} = p^{n+1} - \\varphi(p^{n+1}) = p^{n+1} - p^{n}(p-1) = p^{n} = \\#(\\mathbb{Z}/p^{n})$, so injective $\\Rightarrow$ bijective.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler totient of prime power", "pigeonhole / counting bijection", "ZMod.card_units_eq_totient", "Fintype cardinality"],
+    "prerequisites": ["Nat.totient_prime_pow_succ", "injective + equal cardinality ⇒ bijective"]
   },
   {
     "id": "ann-eqr-oq010301010101-recursion",
@@ -29,7 +41,11 @@
     "range": { "startLine": 180, "endLine": 257 },
     "type": "theorem",
     "title": "The block recursion sign_ringMulPerm_succ",
-    "content": "The heart of the file. ringMulPerm a preserves IsUnit (a is a unit; IsUnit.mul_iff), so Equiv.Perm.sign_subtypeCongr factors sign(ringMulPerm a) = sign(units block)·sign(non-unit block). The units block is transported (sign_eq_sign_of_equiv along the units↔IsUnit-subtype equiv) to sign(Equiv.mulLeft a) = legendreSym p (a mod p) — the parent units-level lemma. The non-unit block is transported along the p·(lift y) bijection to sign(ringMulPerm ā) on ℤ/pⁿ⁻¹; the required intertwining μ(ā·y) = a·μ(y) is exactly the p-multiplication bridge."
+    "content": "The heart of the file. ringMulPerm a preserves IsUnit (a is a unit; IsUnit.mul_iff), so Equiv.Perm.sign_subtypeCongr factors sign(ringMulPerm a) = sign(units block)·sign(non-unit block). The units block is transported (sign_eq_sign_of_equiv along the units↔IsUnit-subtype equiv) to sign(Equiv.mulLeft a) = legendreSym p (a mod p) — the parent units-level lemma. The non-unit block is transported along the p·(lift y) bijection to sign(ringMulPerm ā) on ℤ/pⁿ⁻¹; the required intertwining μ(ā·y) = a·μ(y) is exactly the p-multiplication bridge.",
+    "mathContext": "$\\mathrm{sgn}(a\\cdot\\text{ on }\\mathbb{Z}/p^{n+1}) = \\mathrm{sgn}(a\\cdot\\text{ on }(\\mathbb{Z}/p^{n+1})^{\\times})\\cdot\\mathrm{sgn}(\\bar a\\cdot\\text{ on }\\mathbb{Z}/p^{n}) = \\left(\\tfrac{a}{p}\\right)\\cdot\\mathrm{sgn}(\\bar a\\cdot\\text{ on }\\mathbb{Z}/p^{n})$.",
+    "significance": "key",
+    "relatedConcepts": ["Equiv.Perm.sign_subtypeCongr", "invariant block decomposition", "left regular representation", "sign transport across an equiv"],
+    "prerequisites": ["permutation sign on invariant blocks", "the units-level parent lemma", "the p-multiplication bridge"]
   },
   {
     "id": "ann-eqr-oq010301010101-headline",
@@ -37,6 +53,10 @@
     "range": { "startLine": 267, "endLine": 320 },
     "type": "theorem",
     "title": "Prime-power Zolotarev: legendre power and Jacobi form",
-    "content": "sign_ringMulPerm_eq_legendre_pow inducts the one-step recursion on the exponent to get sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ (base case n = 1: the non-unit block is the singleton {0}, sign 1). jacobiSym_prime_pow proves J(A | pⁿ) = (legendreSym p A)ⁿ via jacobiSym.mul_right, and sign_ringMulPerm_eq_jacobiSym packages the headline as the Jacobi symbol J(a | pⁿ) — closing the prime-power case of the Frobenius/Zolotarev identity."
+    "content": "sign_ringMulPerm_eq_legendre_pow inducts the one-step recursion on the exponent to get sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ (base case n = 1: the non-unit block is the singleton {0}, sign 1). jacobiSym_prime_pow proves J(A | pⁿ) = (legendreSym p A)ⁿ via jacobiSym.mul_right, and sign_ringMulPerm_eq_jacobiSym packages the headline as the Jacobi symbol J(a | pⁿ) — closing the prime-power case of the Frobenius/Zolotarev identity.",
+    "mathContext": "$\\mathrm{sgn}(x\\mapsto a x \\text{ on } \\mathbb{Z}/p^{n}) = \\left(\\tfrac{a}{p}\\right)^{n} = \\left(\\tfrac{a}{p^{n}}\\right)_{J}$, the Jacobi symbol $J(a\\mid p^{n})$.",
+    "significance": "key",
+    "relatedConcepts": ["Zolotarev's lemma", "Jacobi symbol multiplicativity", "Legendre symbol", "induction on the exponent"],
+    "prerequisites": ["jacobiSym.mul_right", "Legendre-to-Jacobi specialization", "the block recursion"]
   }
 ]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const elementaryQuadraticReciprocityOq01Oq03Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const elementaryQuadraticReciprocityOq01Oq03Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const elementaryQuadraticReciprocityOq01Oq03Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: elementaryQuadraticReciprocityOq01Oq03Oq01Oq01Oq01Oq01Proof,
+  annotations: elementaryQuadraticReciprocityOq01Oq03Oq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01` (first pass).

## Changes
- **Created `index.ts`** — the entry had `meta.json` and `annotations.json` but no `index.ts`, so the page would render 'proof not found' on the live site.
- **Enriched all 5 annotations** with the structured fields they were missing: `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Annotation prose (already substantive) left intact.

meta.json was already rich (14.3 KB, within caps) and accurate vs the Lean source (10 theorems, 3 defs, 0 sorries, 0 axioms, status verified) — left as-is.

`pnpm build` passes.