### PR TITLE
research(british-flag-oq-01-oq-02-oq-01): 4th-moment defect vanishes for n≥5

### DIFF
--- a/proofs/Proofs/BritishFlagFourthMomentOQ010201.lean
+++ b/proofs/Proofs/BritishFlagFourthMomentOQ010201.lean
@@ -1,0 +1,379 @@
+/-
+  Fourth-Moment British Flag Defect for a General Parallelepiped
+  Open-question follow-up: british-flag-theorem-oq-01-oq-02-oq-01 (higher moments)
+
+  The parent file (`BritishFlagParallelepipedOQ010201`) proves that the alternating
+  *squared*-distance defect over the `2ⁿ` vertices of a parallelepiped,
+
+      defect₂ = ∑_{t ⊆ {0,…,n-1}} (-1)^{|t|} · ‖X − vertex t‖²,
+
+  vanishes for `n ≥ 3`.  The mechanism: `‖X − vertex t‖²` is a degree-`2` polynomial
+  in the membership indicators `[i ∈ t]`, and the operator `g ↦ ∑_t (-1)^{|t|} g t`
+  is the `n`-th iterated finite difference, which annihilates every monomial that
+  omits at least one coordinate.  For `n ≥ 3` every degree-`2` monomial omits a
+  coordinate, so the defect is identically zero.
+
+  ## What this file adds
+
+  The next moment.  We study the **fourth-moment** defect
+
+      defect₄ = ∑_{t ⊆ {0,…,n-1}} (-1)^{|t|} · ‖X − vertex t‖⁴.
+
+  Now `‖X − vertex t‖⁴ = (‖X − vertex t‖²)²` is a degree-`4` polynomial in the
+  indicators, so the same finite-difference mechanism forces `defect₄ = 0` as soon as
+  every degree-`4` monomial omits a coordinate, i.e. for `n ≥ 5`.
+
+  ### Key generalization: the finite-difference principle as one clean lemma
+
+  We isolate the mechanism as a single statement, `monomial_term_zero`:
+
+      for any proper subset `S ⊊ univ`, the signed powerset sum of the indicator
+      `[S ⊆ t]` vanishes.
+
+  Taking `S = ∅, {i}, {i,j}` recovers the constant / linear / quadratic pieces of the
+  parent.  Taking `|S| = 3, 4` gives the new `cubic_term_zero` (needs `n ≥ 4`) and
+  `quartic_term_zero` (needs `n ≥ 5`) pieces, which — together with the parent's three
+  lower pieces — annihilate every term in the expansion of `(‖w‖² − 2L + Q)²`.
+
+  ## Main results
+
+  * `monomial_term_zero` — the finite-difference principle: `∑_t (-1)^{|t|} [S ⊆ t] = 0`
+    whenever `S ≠ univ`.  Short proof from the parent's structural heart
+    `alt_sum_eq_zero_of_indep`.
+  * `cubic_term_zero` / `quartic_term_zero` — the degree-`3` / degree-`4` term
+    vanishing (`n ≥ 4` / `n ≥ 5`).
+  * `fourth_moment_defect_eq_zero` — **headline**: for `n ≥ 5`, `defect₄ = 0` for every
+    parallelepiped, observer `X`, base `c`, and arbitrary (possibly skew) edges `u`.
+
+  Everything is `sorry`-free and axiom-free; the parent's lemmas are reused by import.
+
+  The first nonzero case `n = 4` carries an explicit top-degree "pairing" defect
+      8 · (⟪u₀,u₁⟫⟪u₂,u₃⟫ + ⟪u₀,u₂⟫⟪u₁,u₃⟫ + ⟪u₀,u₃⟫⟪u₁,u₂⟫),
+  which is left as a documented next step.
+-/
+
+import Mathlib
+import Proofs.BritishFlagParallelepipedOQ010201
+
+open Finset
+open scoped RealInnerProductSpace
+
+namespace BritishFlagFourthMomentOQ010201
+
+open BritishFlagParallelepipedOQ010201
+
+variable {n : ℕ} {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+
+/-! ### Restriction helper: a full-universe sum with an indicator is a sum over the set -/
+
+/-- `∑_{i} [i ∈ t] · f i = ∑_{i ∈ t} f i`.  Self-contained so the file does not depend
+    on the exact spelling of any Mathlib restriction lemma. -/
+private theorem sum_ite_mem_eq' (t : Finset (Fin n)) (f : Fin n → ℝ) :
+    (∑ i, if i ∈ t then f i else 0) = ∑ i ∈ t, f i := by
+  rw [← Finset.sum_filter]
+  apply Finset.sum_congr _ (fun _ _ => rfl)
+  ext x; simp
+
+/-! ### The finite-difference principle as a monomial lemma -/
+
+/-- **Finite-difference / monomial vanishing.**  For any subset `S ≠ univ`, the signed
+    powerset sum of the indicator `[S ⊆ t]` (scaled by a constant `a`) vanishes.
+
+    This is the heart of the British-flag mechanism, abstracted away from the specific
+    moment: `S = ∅, {i}, {i,j}` recover the constant, linear, and quadratic pieces of
+    the parent.  Proof: pick a coordinate `k ∉ S`; the indicator `[S ⊆ ·]` does not
+    depend on `k`, so the parent's `alt_sum_eq_zero_of_indep` applies. -/
+theorem monomial_term_zero (S : Finset (Fin n)) (hS : S ≠ univ) (a : ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (if S ⊆ t then a else 0) = 0 := by
+  classical
+  obtain ⟨k, hk⟩ : ∃ k, k ∉ S := by
+    by_contra h
+    push_neg at h
+    apply hS
+    ext x
+    simpa using h x
+  refine alt_sum_eq_zero_of_indep k (fun t => if S ⊆ t then a else 0) ?_
+  intro s hks
+  have hiff : S ⊆ insert k s ↔ S ⊆ s := by
+    constructor
+    · intro h x hx
+      rcases mem_insert.mp (h hx) with rfl | hxs
+      · exact absurd hx hk
+      · exact hxs
+    · exact fun h => h.trans (subset_insert k s)
+  simp only [hiff]
+
+/-! ### Cubic and quartic term vanishing -/
+
+/-- Bridge: membership of three points in `t` is `{i,j,l} ⊆ t`. -/
+private theorem mem3_iff_subset (i j l : Fin n) (t : Finset (Fin n)) :
+    (i ∈ t ∧ j ∈ t ∧ l ∈ t) ↔ ({i, j, l} : Finset (Fin n)) ⊆ t := by
+  simp [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+
+/-- Bridge: membership of four points in `t` is `{i,j,k,l} ⊆ t`. -/
+private theorem mem4_iff_subset (i j k l : Fin n) (t : Finset (Fin n)) :
+    (i ∈ t ∧ j ∈ t ∧ k ∈ t ∧ l ∈ t) ↔ ({i, j, k, l} : Finset (Fin n)) ⊆ t := by
+  simp [Finset.insert_subset_iff, Finset.singleton_subset_iff]
+
+/-- **The cubic piece vanishes for `n ≥ 4`.**  `∑_t (-1)^{|t|} ∑_{i,j,l ∈ t} c i j l = 0`. -/
+theorem cubic_term_zero (hn : 4 ≤ n) (c : Fin n → Fin n → Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ∑ l ∈ t, c i j l) = 0 := by
+  classical
+  -- rewrite the triple `∑_{·∈t}` as a triple `∑_·` with a single conjunction indicator
+  have hrw : ∀ t : Finset (Fin n),
+      (∑ i ∈ t, ∑ j ∈ t, ∑ l ∈ t, c i j l)
+        = ∑ i, ∑ j, ∑ l, if i ∈ t ∧ j ∈ t ∧ l ∈ t then c i j l else 0 := by
+    intro t
+    have inner2 : ∀ i j, (∑ l ∈ t, c i j l) = ∑ l, if l ∈ t then c i j l else 0 :=
+      fun i j => (sum_ite_mem_eq' t (c i j)).symm
+    simp_rw [inner2]
+    have inner1 : ∀ i, (∑ j ∈ t, ∑ l, if l ∈ t then c i j l else 0)
+        = ∑ j, if j ∈ t then (∑ l, if l ∈ t then c i j l else 0) else 0 :=
+      fun i => (sum_ite_mem_eq' t _).symm
+    simp_rw [inner1]
+    rw [← sum_ite_mem_eq' t
+      (fun i => ∑ j, if j ∈ t then (∑ l, if l ∈ t then c i j l else 0) else 0)]
+    apply Finset.sum_congr rfl
+    intro i _
+    by_cases hi : i ∈ t
+    · rw [if_pos hi]
+      apply Finset.sum_congr rfl
+      intro j _
+      by_cases hj : j ∈ t
+      · rw [if_pos hj]
+        apply Finset.sum_congr rfl
+        intro l _
+        by_cases hl : l ∈ t
+        · rw [if_pos hl, if_pos ⟨hi, hj, hl⟩]
+        · rw [if_neg hl, if_neg (by tauto)]
+      · rw [if_neg hj, eq_comm]
+        apply Finset.sum_eq_zero
+        intro l _
+        rw [if_neg (by tauto)]
+    · rw [if_neg hi, eq_comm]
+      apply Finset.sum_eq_zero
+      intro j _
+      apply Finset.sum_eq_zero
+      intro l _
+      rw [if_neg (by tauto)]
+  simp_rw [hrw, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro i _
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro j _
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro l _
+  -- now a pure monomial term: `{i,j,l} ⊆ t`, and `{i,j,l} ≠ univ` since `n ≥ 4`
+  have hne : ({i, j, l} : Finset (Fin n)) ≠ univ := by
+    intro heq
+    have h3 : ({i, j, l} : Finset (Fin n)).card ≤ 3 := by
+      have a := Finset.card_insert_le i ({j, l} : Finset (Fin n))
+      have b := Finset.card_insert_le j ({l} : Finset (Fin n))
+      simp only [Finset.card_singleton] at b
+      omega
+    have hc : ({i, j, l} : Finset (Fin n)).card = n := by
+      rw [heq, Finset.card_univ, Fintype.card_fin]
+    omega
+  simp_rw [mem3_iff_subset i j l]
+  exact monomial_term_zero _ hne _
+
+/-- **The quartic piece vanishes for `n ≥ 5`.**  `∑_t (-1)^{|t|} ∑_{i,j,k,l ∈ t} d i j k l = 0`. -/
+theorem quartic_term_zero (hn : 5 ≤ n) (d : Fin n → Fin n → Fin n → Fin n → ℝ) :
+    ∑ t ∈ (univ : Finset (Fin n)).powerset,
+        (-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ∑ k ∈ t, ∑ l ∈ t, d i j k l) = 0 := by
+  classical
+  have hrw : ∀ t : Finset (Fin n),
+      (∑ i ∈ t, ∑ j ∈ t, ∑ k ∈ t, ∑ l ∈ t, d i j k l)
+        = ∑ i, ∑ j, ∑ k, ∑ l, if i ∈ t ∧ j ∈ t ∧ k ∈ t ∧ l ∈ t then d i j k l else 0 := by
+    intro t
+    have inner3 : ∀ i j k, (∑ l ∈ t, d i j k l) = ∑ l, if l ∈ t then d i j k l else 0 :=
+      fun i j k => (sum_ite_mem_eq' t (d i j k)).symm
+    simp_rw [inner3]
+    have inner2 : ∀ i j, (∑ k ∈ t, ∑ l, if l ∈ t then d i j k l else 0)
+        = ∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0 :=
+      fun i j => (sum_ite_mem_eq' t _).symm
+    simp_rw [inner2]
+    have inner1 : ∀ i, (∑ j ∈ t, ∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0)
+        = ∑ j, if j ∈ t then
+            (∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0) else 0 :=
+      fun i => (sum_ite_mem_eq' t _).symm
+    simp_rw [inner1]
+    rw [← sum_ite_mem_eq' t
+      (fun i => ∑ j, if j ∈ t then
+        (∑ k, if k ∈ t then (∑ l, if l ∈ t then d i j k l else 0) else 0) else 0)]
+    apply Finset.sum_congr rfl
+    intro i _
+    by_cases hi : i ∈ t
+    · rw [if_pos hi]
+      apply Finset.sum_congr rfl
+      intro j _
+      by_cases hj : j ∈ t
+      · rw [if_pos hj]
+        apply Finset.sum_congr rfl
+        intro k _
+        by_cases hk : k ∈ t
+        · rw [if_pos hk]
+          apply Finset.sum_congr rfl
+          intro l _
+          by_cases hl : l ∈ t
+          · rw [if_pos hl, if_pos ⟨hi, hj, hk, hl⟩]
+          · rw [if_neg hl, if_neg (by tauto)]
+        · rw [if_neg hk, eq_comm]
+          apply Finset.sum_eq_zero
+          intro l _
+          rw [if_neg (by tauto)]
+      · rw [if_neg hj, eq_comm]
+        apply Finset.sum_eq_zero
+        intro k _
+        apply Finset.sum_eq_zero
+        intro l _
+        rw [if_neg (by tauto)]
+    · rw [if_neg hi, eq_comm]
+      apply Finset.sum_eq_zero
+      intro j _
+      apply Finset.sum_eq_zero
+      intro k _
+      apply Finset.sum_eq_zero
+      intro l _
+      rw [if_neg (by tauto)]
+  simp_rw [hrw, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro i _
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro j _
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro k _
+  rw [Finset.sum_comm]
+  apply Finset.sum_eq_zero
+  intro l _
+  have hne : ({i, j, k, l} : Finset (Fin n)) ≠ univ := by
+    intro heq
+    have h4 : ({i, j, k, l} : Finset (Fin n)).card ≤ 4 := by
+      have a := Finset.card_insert_le i ({j, k, l} : Finset (Fin n))
+      have b := Finset.card_insert_le j ({k, l} : Finset (Fin n))
+      have e := Finset.card_insert_le k ({l} : Finset (Fin n))
+      simp only [Finset.card_singleton] at e
+      omega
+    have hc : ({i, j, k, l} : Finset (Fin n)).card = n := by
+      rw [heq, Finset.card_univ, Fintype.card_fin]
+    omega
+  simp_rw [mem4_iff_subset i j k l]
+  exact monomial_term_zero _ hne _
+
+/-! ### The fourth-moment defect -/
+
+/-- The fourth power of the distance from the observer `X` to the parallelepiped vertex
+    indexed by `t`. -/
+def sqDist4 (X c : V) (u : Fin n → V) (t : Finset (Fin n)) : ℝ :=
+  ‖X - pVertex c u t‖ ^ 4
+
+/-- The **fourth-moment British-flag defect**: the alternating (`(-1)^{|t|}`-weighted) sum
+    of fourth powers of distances over all `2ⁿ` vertices of the parallelepiped. -/
+def defect4 (X c : V) (u : Fin n → V) : ℝ :=
+  ∑ t ∈ (univ : Finset (Fin n)).powerset, (-1 : ℝ) ^ t.card * sqDist4 X c u t
+
+/-- **Fourth-moment defect formula, `n ≥ 5`.**  For any parallelepiped in a real inner
+    product space with base `c`, arbitrary (possibly skew) edge vectors `u`, and any
+    observer `X`, the alternating fourth-power defect over the `2ⁿ` vertices is identically
+    zero whenever `n ≥ 5`.
+
+    `‖X − vertex t‖⁴ = (‖w‖² − 2 ∑_{i∈t}⟪w,uᵢ⟫ + ∑_{i,j∈t}⟪uᵢ,uⱼ⟫)²` is a degree-`4`
+    polynomial in the indicators; expanding the square produces six pieces of degrees
+    `0,1,2,2,3,4`, each annihilated by the signed powerset sum once `n` exceeds its
+    degree.  The binding constraint is the degree-`4` piece, requiring `n ≥ 5`. -/
+theorem fourth_moment_defect_eq_zero (hn : 5 ≤ n) (X c : V) (u : Fin n → V) :
+    defect4 X c u = 0 := by
+  -- expand each summand of `defect₄` into the six pieces via `sqDist_expand` and `ring`
+  have key : ∀ t : Finset (Fin n), (-1 : ℝ) ^ t.card * sqDist4 X c u t
+      = (-1 : ℝ) ^ t.card * (‖X - c‖ ^ 2) ^ 2
+        - (-1 : ℝ) ^ t.card * (4 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ⟪X - c, u i⟫))
+        + (-1 : ℝ) ^ t.card * (2 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫))
+        + (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫)))
+        - (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫)))
+        + (-1 : ℝ) ^ t.card * ((∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫)) := by
+    intro t
+    have hsq : sqDist4 X c u t = (sqDist X c u t) ^ 2 := by
+      simp only [sqDist4, sqDist]; ring
+    rw [hsq, sqDist_expand]
+    ring
+  -- the six pieces, each killed by the appropriate term lemma
+  have h1 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (‖X - c‖ ^ 2) ^ 2 = 0 :=
+    const_term_zero (by omega) ((‖X - c‖ ^ 2) ^ 2)
+  have h2 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (4 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ⟪X - c, u i⟫)) = 0 := by
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (4 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ⟪X - c, u i⟫))
+          = 4 * ‖X - c‖ ^ 2 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ⟪X - c, u i⟫)) := fun t => by ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum, linear_term_zero (by omega) (fun i => ⟪X - c, u i⟫), mul_zero]
+  have h3 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (2 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫)) = 0 := by
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (2 * ‖X - c‖ ^ 2 * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫))
+          = 2 * ‖X - c‖ ^ 2 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫)) :=
+      fun t => by ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum, quadratic_term_zero (by omega) (fun i j => ⟪u i, u j⟫), mul_zero]
+  have h4 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫))) = 0 := by
+    have hconv : ∀ t : Finset (Fin n),
+        (∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫)
+          = ∑ i ∈ t, ∑ j ∈ t, ⟪X - c, u i⟫ * ⟪X - c, u j⟫ := by
+      intro t; rw [Finset.sum_mul_sum]
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ⟪X - c, u j⟫)))
+          = 4 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ⟪X - c, u i⟫ * ⟪X - c, u j⟫)) := by
+      intro t; rw [hconv t]; ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum,
+      quadratic_term_zero (by omega) (fun i j => ⟪X - c, u i⟫ * ⟪X - c, u j⟫), mul_zero]
+  have h5 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫))) = 0 := by
+    have hconv : ∀ t : Finset (Fin n),
+        (∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫)
+          = ∑ i ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪X - c, u i⟫ * ⟪u j, u l⟫ := by
+      intro t
+      rw [Finset.sum_mul_sum]
+      apply Finset.sum_congr rfl; intro i _
+      apply Finset.sum_congr rfl; intro j _
+      rw [Finset.mul_sum]
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * (4 * ((∑ i ∈ t, ⟪X - c, u i⟫) * (∑ j ∈ t, ∑ l ∈ t, ⟪u j, u l⟫)))
+          = 4 * ((-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪X - c, u i⟫ * ⟪u j, u l⟫)) := by
+      intro t; rw [hconv t]; ring
+    simp_rw [hpt]
+    rw [← Finset.mul_sum,
+      cubic_term_zero (by omega) (fun i j l => ⟪X - c, u i⟫ * ⟪u j, u l⟫), mul_zero]
+  have h6 : ∑ t ∈ (univ : Finset (Fin n)).powerset,
+      (-1 : ℝ) ^ t.card * ((∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫)) = 0 := by
+    have hconv : ∀ t : Finset (Fin n),
+        (∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫)
+          = ∑ i ∈ t, ∑ k ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪u i, u j⟫ * ⟪u k, u l⟫ := by
+      intro t
+      rw [Finset.sum_mul_sum]
+      apply Finset.sum_congr rfl; intro i _
+      apply Finset.sum_congr rfl; intro k _
+      rw [Finset.sum_mul_sum]
+    have hpt : ∀ t : Finset (Fin n),
+        (-1 : ℝ) ^ t.card * ((∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫) * (∑ k ∈ t, ∑ l ∈ t, ⟪u k, u l⟫))
+          = (-1 : ℝ) ^ t.card * (∑ i ∈ t, ∑ k ∈ t, ∑ j ∈ t, ∑ l ∈ t, ⟪u i, u j⟫ * ⟪u k, u l⟫) := by
+      intro t; rw [hconv t]
+    simp_rw [hpt]
+    exact quartic_term_zero (by omega) (fun i k j l => ⟪u i, u j⟫ * ⟪u k, u l⟫)
+  -- assemble
+  unfold defect4
+  simp_rw [key]
+  simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+  rw [h1, h2, h3, h4, h5, h6]
+  ring
+
+end BritishFlagFourthMomentOQ010201

--- a/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/british-flag-theorem-oq-01-oq-02-oq-01/meta.json
@@ -33,7 +33,9 @@
       "parallelepiped_defect_two_orthogonal (PROVED): orthogonal edges (⟪u₀,u₁⟫ = 0) in n = 2 force the defect to vanish — the classical British Flag Theorem recovered as a corollary, explicitly closing the loop with the parent orthotope entry",
       "alt_sum_eq_zero_of_indep (PROVED, structural heart): if g t does not change when a coordinate k is inserted into a k-free set, the signed powerset sum ∑_t (−1)^{|t|}·g t = 0; proved by pairing each subset s ⊆ univ∖{k} with insert k s (equal g-value, opposite sign). This is the finite-difference annihilation lemma that kills every coordinate-independent monomial",
       "sqDist_expand (PROVED, support): the explicit degree-≤2 inner-product expansion ‖X − vertex t‖² = ‖X−c‖² − 2∑_{i∈t}⟪X−c,uᵢ⟫ + ∑_{i∈t}∑_{j∈t}⟪uᵢ,uⱼ⟫, exhibiting the squared distance as a quadratic in the membership indicators",
-      "const_term_zero / linear_term_zero / quadratic_term_zero (PROVED): the constant, linear, and quadratic pieces of the expansion have vanishing alternating sum for n ≥ 1, n ≥ 2, n ≥ 3 respectively — each reduced to alt_sum_eq_zero_of_indep by exhibiting an unused coordinate, the degree-vs-dimension threshold that makes n ≥ 3 the exact hypothesis for total vanishing"
+      "const_term_zero / linear_term_zero / quadratic_term_zero (PROVED): the constant, linear, and quadratic pieces of the expansion have vanishing alternating sum for n ≥ 1, n ≥ 2, n ≥ 3 respectively — each reduced to alt_sum_eq_zero_of_indep by exhibiting an unused coordinate, the degree-vs-dimension threshold that makes n ≥ 3 the exact hypothesis for total vanishing",
+      "fourth_moment_defect_eq_zero (PROVED, FOLLOW-UP — Proofs/BritishFlagFourthMomentOQ010201.lean): the parent's first open question (higher moments) settled for the fourth moment. defect_4 = signed powerset sum of ||X - vertex t||^4 is identically 0 for n >= 5, any observer X, base c, and arbitrary skew edges u. Mechanism: ||.||^4 = (||.||^2)^2 is degree-4 in the indicators, expanded into six pieces of degrees 0,1,2,2,3,4 (via sqDist_expand and ring), each annihilated by the signed powerset sum; the binding piece is degree 4, requiring n >= 5. Verified, 0-axiom, 0-sorry",
+      "monomial_term_zero (PROVED, FOLLOW-UP — the finite-difference principle abstracted): for any proper subset S != univ, signed powerset sum of [S subseteq t] = 0 — a ~12-line consequence of alt_sum_eq_zero_of_indep (pick a coordinate k notin S; the indicator [S subseteq .] is k-independent). S = empty, {i}, {i,j} recover the parent's const/linear/quadratic pieces; |S| = 3, 4 give the new cubic_term_zero (n >= 4) and quartic_term_zero (n >= 5) that drive the fourth-moment vanishing"
     ],
     "mathlibDependencies": [
       {
@@ -158,7 +160,7 @@
     "summary": "Machine-verified in an arbitrary real inner product space: the British Flag defect of a general parallelepiped is the n-th finite difference of the degree-2 squared-distance polynomial, hence identically zero for n ≥ 3 (independent of observer, base, and edges) and equal to 2⟪u₀,u₁⟫ for n = 2. The orthotope of the parent and the parallelogram defect of the sibling are unified as the two slices of one formula; orthogonal n = 2 edges recover the classical theorem. Zero sorries, zero extra axioms.",
     "implications": "**General defect formula proved**: the parent's first open question is settled in full generality — for n ≥ 3 the alternating vertex sum vanishes for every parallelepiped, skew or not, answering 'prove the general defect formula' affirmatively with the cleanest possible answer (it is zero).\\n\\n**Sharp dimension threshold**: n ≥ 3 is exactly the regime of unconditional vanishing because the squared distance has degree exactly 2; n = 2 is the boundary where the top monomial survives as 2⟪u₀,u₁⟫ and n = 1 is observer-dependent.\\n\\n**Finite differences as the organizing principle**: recasting the metric defect as an iterated finite difference on the Boolean cube explains both the vanishing and the surviving defect in one stroke, and generalizes to any vertex functional that is polynomial of bounded degree in the indicators.",
     "openQuestions": [
-      "Higher moments: replace ‖X − vertex‖² by ‖X − vertex‖^{2k}. This is a degree-2k polynomial in the indicators, so the defect should vanish for n ≥ 2k+1 and have an explicit top-degree defect at the threshold n = 2k — determine that defect (a sum over perfect matchings / pairings of the 2k edge slots) and the sharp dimension boundary.",
+      "Higher moments (FOURTH MOMENT NOW PROVED — Proofs/BritishFlagFourthMomentOQ010201.lean): replacing ||X - vertex||^2 by ||X - vertex||^(2k) gives a degree-2k polynomial in the indicators, so the defect vanishes for n >= 2k+1. The k = 2 case is settled: fourth_moment_defect_eq_zero proves defect_4 = 0 for n >= 5, organized around the abstracted finite-difference lemma monomial_term_zero (signed powerset sum of [S subseteq t] = 0 for S != univ). STILL OPEN: (a) the explicit top-degree defect at the threshold n = 2k (for k = 2, n = 4, it is 8*(<u0,u1><u2,u3> + <u0,u2><u1,u3> + <u0,u3><u1,u2>), a sum over perfect matchings of the 2k edge slots — computed on paper, not yet formalized); (b) the general 2k-th moment for all k via a single variadic finite-difference lemma.",
       "Exact n = 2 defect in terms of signed area: ⟪u₀,u₁⟫ = ‖u₀‖‖u₁‖cos θ; relate the defect 2⟪u₀,u₁⟫ to the deviation of the parallelogram from a rectangle and to the discrete Laplacian / mixed second difference of the squared-distance field over the cube."
     ]
   },
@@ -192,6 +194,18 @@
       "type": "supporting",
       "description": "Degree-≤2 inner-product expansion of the squared distance to a parallelepiped vertex.",
       "leanType": "(X c : V) → (u : Fin n → V) → (t : Finset (Fin n)) → sqDist X c u t = ‖X − c‖² − 2 * (∑ i ∈ t, ⟪X − c, u i⟫) + ∑ i ∈ t, ∑ j ∈ t, ⟪u i, u j⟫"
+    },
+    {
+      "name": "fourth_moment_defect_eq_zero",
+      "type": "core",
+      "description": "Follow-up (Proofs/BritishFlagFourthMomentOQ010201.lean): the fourth-moment defect (alternating sum of ||X - vertex t||^4) is identically zero for n >= 5, for any observer X, base c, and arbitrary skew edges u — the first higher-moment case of the parent's open question.",
+      "leanType": "(hn : 5 <= n) -> (X c : V) -> (u : Fin n -> V) -> defect4 X c u = 0"
+    },
+    {
+      "name": "monomial_term_zero",
+      "type": "supporting",
+      "description": "Follow-up (Proofs/BritishFlagFourthMomentOQ010201.lean): the finite-difference principle abstracted — for any proper subset S != univ, the signed powerset sum of the indicator [S subseteq t] vanishes. Recovers the parent's const/linear/quadratic pieces (S = empty, {i}, {i,j}) and drives cubic_term_zero / quartic_term_zero.",
+      "leanType": "(S : Finset (Fin n)) -> S != univ -> (a : R) -> signed powerset sum of (if S subseteq t then a else 0) = 0"
     }
   ],
   "sorries": 0,
@@ -227,6 +241,19 @@
       "year": "2011",
       "venue": "Cambridge University Press",
       "note": "Inclusion–exclusion and alternating subset sums; here read as iterated finite differences on the Boolean cube, the mechanism behind the degree-vs-dimension vanishing."
+    }
+  ],
+  "additionalFiles": [
+    {
+      "path": "Proofs/BritishFlagFourthMomentOQ010201.lean",
+      "namespace": "BritishFlagFourthMomentOQ010201",
+      "lineCount": 379,
+      "axiomCount": 0,
+      "theoremCount": 7,
+      "definitionCount": 2,
+      "sorries": 0,
+      "description": "Fourth-moment follow-up. Imports the primary file and reuses alt_sum_eq_zero_of_indep, sqDist_expand, and the parent's const/linear/quadratic term lemmas. Adds monomial_term_zero (finite-difference principle), cubic_term_zero (n >= 4), quartic_term_zero (n >= 5), sqDist4/defect4, and the headline fourth_moment_defect_eq_zero (defect_4 = 0 for n >= 5). Verified, 0-axiom, 0-sorry.",
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BritishFlagFourthMomentOQ010201.lean"
     }
   ]
 }

--- a/src/data/research/problems/british-flag-theorem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/british-flag-theorem-oq-01-oq-02-oq-01.json
@@ -8,7 +8,7 @@
   "tractability": 8,
   "significance": 6,
   "started": "2026-06-24",
-  "lastUpdate": "2026-06-24",
+  "lastUpdate": "2026-06-27",
   "path": "proofs/Proofs/BritishFlagParallelepipedOQ010201.lean",
   "tags": [
     "geometry",
@@ -28,12 +28,16 @@
   },
   "knownResults": "Parent oq-01-oq-02 proved the orthotope (orthogonal-edge) case vanishes for n ≥ 2. Sibling oq-01-oq-01 proved the n = 2 parallelogram defect 2⟪u,v⟫. Mathlib supplies polarization (norm_sub_sq_real), inner-product bilinearity, and powerset machinery.",
   "knowledge": {
-    "progressSummary": "COMPLETE: general defect formula proved. The squared distance to a parallelepiped vertex is a degree-2 polynomial in the membership indicators; the alternating powerset sum is the n-th finite difference, which annihilates degree < n. Hence defect ≡ 0 for n ≥ 3 and = 2⟪u₀,u₁⟫ for n = 2. Verified / 0-axiom / original, 300 lines, 11 theorems, 3 definitions.",
+    "progressSummary": "PROGRESS: 4th-moment defect vanishing proved for n>=5 (verified, 0-axiom, new file BritishFlagFourthMomentOQ010201.lean, 379 lines, 4 main + 3 helper theorems). Key generalization: monomial_term_zero isolates the finite-difference principle. Parent (2nd moment, n>=3) COMPLETE. Open: explicit n=4 pairing defect; general 2k-th moment via variadic infra.",
     "insights": [
       "The squared distance ‖X − vertex t‖² is a polynomial of degree exactly 2 in the membership indicators [i ∈ t], with constant coeff ‖X−c‖², linear coeffs ⟪X−c,uᵢ⟫, and quadratic coeffs ⟪uᵢ,uⱼ⟫. The parent's orthotope hid this because there the quadratic coefficients are all zero.",
       "The alternating powerset sum g ↦ ∑_t (−1)^{|t|}·g t is the n-th iterated finite difference on the Boolean cube; it annihilates every monomial omitting a coordinate, hence every polynomial of degree < n. This single fact explains both the n ≥ 3 vanishing and the surviving n = 2 defect.",
       "n ≥ 3 is the SHARP threshold for unconditional vanishing because the squared distance has degree exactly 2: the defect vanishes for all configurations iff n > 2. At n = 2 only the top monomial [0∈t][1∈t] survives (coefficient 2⟪u₀,u₁⟫); at n = 1 even the linear term survives and the defect is observer-dependent.",
-      "The cleanest formalization of 'finite difference kills low degree' is monomial-by-monomial: an indicator monomial constant in coordinate k is invariant under inserting k, so its alternating sum vanishes by the antipodal pairing s ↔ insert k s. Free coordinate exists exactly when the monomial degree < n."
+      "The cleanest formalization of 'finite difference kills low degree' is monomial-by-monomial: an indicator monomial constant in coordinate k is invariant under inserting k, so its alternating sum vanishes by the antipodal pairing s ↔ insert k s. Free coordinate exists exactly when the monomial degree < n.",
+      "The k=1 squared-distance result (parent, vanishes n>=3) generalizes to the 2k-th moment: ||X-vertex||^(2k) is degree-2k in indicators, so defect_2k=0 for n>=2k+1. The 4th moment (k=2) is the first new case: vanishes for n>=5.",
+      "Clean organizing lemma is monomial_term_zero: every even-moment expansion is a sum of indicator monomials [S subseteq t], and the signed powerset sum kills each S != univ. Subsumes parent const/linear/quadratic_term_zero (S=empty,{i},{i,j}) and scales to any degree.",
+      "Per-degree new infra is only (a) conjunction-indicator rewrite of nested sum_{i1..im in t} into sum over univ^m with [i1 in t and ...] indicator (by_cases cascade, parent-style), and (b) product-of-sums -> nested-sum via Finset.sum_mul_sum. ring handles (P-2L+Q)^2 with L,Q as atoms (alpha-equiv sums collapse to one atom).",
+      "Sharp boundary at n=2k (here n=4): only the top degree-2k monomial survives, giving explicit defect = sum over perfect matchings of the 2k edge slots. For 4th moment: 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) — computed on paper (24 perms / 3 matchings x symmetry), not yet formalized."
     ],
     "builtItems": [
       "alt_sum_eq_zero_of_indep (BritishFlagParallelepipedOQ010201.lean:90): finite-difference annihilation — coordinate-independent g ⟹ ∑_t (−1)^{|t|}·g t = 0",
@@ -41,12 +45,19 @@
       "const_term_zero / linear_term_zero / quadratic_term_zero (lines 166/173/193): the three monomial pieces vanish for n ≥ 1 / 2 / 3",
       "parallelepiped_defect_eq_zero (line 243): MAIN — n ≥ 3 ⟹ defect = 0 for any parallelepiped",
       "parallelepiped_defect_two (line 276): n = 2 ⟹ defect = 2⟪u₀,u₁⟫; quadSum_two (line 261) enumerates the four subsets of {0,1}",
-      "parallelepiped_defect_two_orthogonal (line 295): orthogonal n = 2 recovers the classical British Flag Theorem"
+      "parallelepiped_defect_two_orthogonal (line 295): orthogonal n = 2 recovers the classical British Flag Theorem",
+      "monomial_term_zero (Proofs/BritishFlagFourthMomentOQ010201.lean): the finite-difference principle abstracted — for any S != univ, signed powerset sum of [S subseteq t] = 0; ~12-line proof from parent alt_sum_eq_zero_of_indep (pick k notin S; [S subseteq .] is k-independent)",
+      "cubic_term_zero (n>=4) and quartic_term_zero (n>=5): degree-3/4 term vanishing via conjunction-indicator hrw + monomial_term_zero with card({i,j,l})<=3<n / card({i,j,k,l})<=4<n bound",
+      "fourth_moment_defect_eq_zero (HEADLINE): defect_4 = signed powerset sum of ||X-vertex t||^4 = 0 for n>=5, any X,c,skew edges u — verified, 0-axiom, 0-sorry",
+      "sqDist4 / defect4 definitions; key expansion (sqDist)^2 = (P-2L+Q)^2 split into 6 pieces (deg 0,1,2,2,3,4) each killed by const/linear/quadratic(x2)/cubic/quartic term lemmas via sum_mul_sum product->multisum conversions"
     ],
     "mathlibGaps": "none — the proof is self-contained over Mathlib's inner-product and Finset libraries.",
     "nextSteps": [
       "Higher moments: ‖X − vertex‖^{2k} is degree 2k in the indicators, so the defect should vanish for n ≥ 2k+1 with an explicit top-degree defect (sum over pairings) at n = 2k.",
-      "Relate the n = 2 defect 2⟪u₀,u₁⟫ to the deviation of the parallelogram from a rectangle and to the mixed second difference of the squared-distance field over the cube."
+      "Relate the n = 2 defect 2⟪u₀,u₁⟫ to the deviation of the parallelogram from a rectangle and to the mixed second difference of the squared-distance field over the cube.",
+      "Formalize explicit n=4 fourth-moment defect = 8*(<u0,u1><u2,u3>+<u0,u2><u1,u3>+<u0,u3><u1,u2>) by enumerating the 16 subsets of Fin 4 (decide-style powerset + surviving quartic top monomial). Orthogonal edges => 0.",
+      "General 2k-th moment: state/prove defect_2k=0 for n>=2k+1 uniformly via a variadic mfold_term_zero (sum over p:Fin m->Fin n with image subseteq t indicator), removing per-degree by_cases hrw. Mathlib gap: no off-the-shelf 'n-th finite difference annihilates degree<n' lemma on the Boolean cube.",
+      "Odd moments ||X-vertex||^(2k+1) are not polynomial in the indicators (norm, not squared-norm) — likely no clean finite-difference vanishing; document the parity asymmetry."
     ]
   },
   "leanFiles": [
@@ -82,6 +93,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BritishFlagTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BritishFlagFourthMomentOQ010201.lean",
+      "filename": "BritishFlagFourthMomentOQ010201.lean",
+      "lineCount": 379,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BritishFlagFourthMomentOQ010201.lean"
     }
   ],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Follow-up on the `british-flag-theorem-oq-01-oq-02-oq-01` open question's **"higher moments"** next step. The parent entry proves the *squared*-distance British flag defect vanishes for n ≥ 3. This PR adds the next moment.

**New verified file** `proofs/Proofs/BritishFlagFourthMomentOQ010201.lean` proving the **fourth-moment defect**

```
defect₄ = ∑_{t ⊆ Fin n} (-1)^|t| · ‖X − vertex t‖⁴ = 0      for n ≥ 5
```

for any observer `X`, base `c`, and arbitrary (possibly skew) edge vectors `u` in a real inner product space.

## Key generalization

`monomial_term_zero` isolates the **finite-difference principle** as a clean reusable lemma:

> for any proper subset `S ≠ univ`, the signed powerset sum of the indicator `[S ⊆ t]` vanishes.

It is a ~12-line consequence of the parent's `alt_sum_eq_zero_of_indep` (pick a coordinate `k ∉ S`; `[S ⊆ ·]` is `k`-independent). Taking `S = ∅, {i}, {i,j}` recovers the parent's `const/linear/quadratic_term_zero`; `|S| = 3, 4` give the new `cubic_term_zero` (n ≥ 4) and `quartic_term_zero` (n ≥ 5).

The headline then follows by expanding `‖·‖⁴ = (‖·‖²)² = (P − 2L + Q)²` (via `sqDist_expand` + `ring`) into six pieces of degrees 0,1,2,2,3,4, each annihilated by the appropriate term lemma. The binding piece is degree 4, giving the sharp `n ≥ 5` threshold.

## Status
- **Verified**, 0 axioms, 0 sorries (the foundational `propext`/`Classical.choice`/`Quot.sound` only)
- Reuses the parent's lemmas by `import Proofs.BritishFlagParallelepipedOQ010201`
- Builds clean: `./proofs/scripts/docker-build.sh Proofs.BritishFlagFourthMomentOQ010201`
- 379 lines, 4 main + 3 helper theorems, 2 definitions

## Files
- `proofs/Proofs/BritishFlagFourthMomentOQ010201.lean` (new)
- gallery `meta.json`: `additionalFiles`, +2 `originalContributions`, +2 `mainTheorems`, updated first open question (4th moment now proved)
- problem JSON: knowledge (insights/builtItems/nextSteps/progressSummary), `leanFiles`

## Remaining open
- Explicit top-degree defect at `n = 2k` (for `k=2, n=4`: `8·(⟪u₀,u₁⟫⟪u₂,u₃⟫ + ⟪u₀,u₂⟫⟪u₁,u₃⟫ + ⟪u₀,u₃⟫⟪u₁,u₂⟫)`, a sum over perfect matchings)
- General `2k`-th moment via a single variadic finite-difference lemma

🤖 Generated with [Claude Code](https://claude.com/claude-code)