### PR TITLE
Enrich Solution of Cubic OQ-01-OQ-01: fix annotation schema + index.ts

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/annotations.json
@@ -2,45 +2,49 @@
   {
     "id": "ann-soc-oq0101-shift",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 85,
-      "endLine": 90
-    },
+    "range": { "startLine": 85, "endLine": 90 },
     "type": "insight",
     "title": "The Discriminant under the Tschirnhaus Shift",
-    "body": "general_discriminant_eq_shift is the central identity: Δ(a,b,c,d) = a⁴·(−4p³ − 27q²). It packages two facts true in any degree. First, translation invariance: the depressed cubic t³ + pt + q has exactly the same root differences as the original (the shift x = t − b/(3a) adds the same constant to every root), so its monic discriminant −4p³ − 27q² already captures the root-difference data. Second, the leading-coefficient scaling a^(2n−2) = a⁴ for n = 3. The proof unfolds p, q (with their denominators 3a² and 27a³), clears them with field_simp under a ≠ 0, and closes with ring."
+    "content": "general_discriminant_eq_shift is the central identity: Δ(a,b,c,d) = a⁴·(−4p³ − 27q²). It packages two facts true in any degree. First, translation invariance: the depressed cubic t³ + pt + q has exactly the same root differences as the original (the shift x = t − b/(3a) adds the same constant to every root), so its monic discriminant −4p³ − 27q² already captures the root-difference data. Second, the leading-coefficient scaling a^(2n−2) = a⁴ for n = 3. The proof unfolds p, q (with their denominators 3a² and 27a³), clears them with field_simp under a ≠ 0, and closes with ring.",
+    "mathContext": "$\\Delta(a,b,c,d) = a^{4}\\,(-4p^{3} - 27q^{2})$, with $p = \\tfrac{3ac - b^{2}}{3a^{2}}$, $q = \\tfrac{2b^{3} - 9abc + 27a^{2}d}{27a^{3}}$; the $a^{4} = a^{2n-2}$ scaling plus translation invariance.",
+    "significance": "key",
+    "relatedConcepts": ["Tschirnhaus transformation", "discriminant of a polynomial", "translation invariance", "depressed cubic"],
+    "prerequisites": ["field_simp / ring tactics", "the parent's depression p, q"]
   },
   {
     "id": "ann-soc-oq0101-cardano-bridge",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 100,
-      "endLine": 113
-    },
+    "range": { "startLine": 100, "endLine": 113 },
     "type": "insight",
     "title": "Two Discriminants Differ by −108",
-    "body": "The parent uses Δ_C = q²/4 + p³/27, the quantity under the square root in Cardano's formula. The standard polynomial discriminant is −4p³ − 27q² = −108·Δ_C. The factor −108 is nonzero, so the two notions vanish together and carry the same repeated-root information; depressedDisc_eq_cardano makes this precise and general_discriminant_eq_cardano lifts it to Δ = −108·a⁴·Δ_C — the explicit bridge the parent's open question asked for."
+    "content": "The parent uses Δ_C = q²/4 + p³/27, the quantity under the square root in Cardano's formula. The standard polynomial discriminant is −4p³ − 27q² = −108·Δ_C. The factor −108 is nonzero, so the two notions vanish together and carry the same repeated-root information; depressedDisc_eq_cardano makes this precise and general_discriminant_eq_cardano lifts it to Δ = −108·a⁴·Δ_C — the explicit bridge the parent's open question asked for.",
+    "mathContext": "$-4p^{3} - 27q^{2} = -108\\left(\\tfrac{q^{2}}{4} + \\tfrac{p^{3}}{27}\\right)$, hence $\\Delta = -108\\,a^{4}\\,\\Delta_{C}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cardano's formula", "radicand of the cubic", "discriminant normalization", "casus irreducibilis"],
+    "prerequisites": ["the parent's Cardano discriminant Δ_C", "ring identities"]
   },
   {
     "id": "ann-soc-oq0101-zero-iff",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 122,
-      "endLine": 132
-    },
-    "type": "technique",
+    "range": { "startLine": 122, "endLine": 132 },
+    "type": "tactic",
     "title": "a⁴ ≠ 0 Transfers the Vanishing Condition",
-    "body": "general_discriminant_eq_zero_iff shows Δ = 0 ⟺ −4p³ − 27q² = 0. From Δ = a⁴·depressedDisc, mul_eq_zero splits a product into a⁴ = 0 ∨ depressedDisc = 0; pow_ne_zero 4 ha kills the first disjunct because a ≠ 0 in the field ℂ, leaving depressedDisc = 0. The shift moves the roots but preserves the condition that two of them collide."
+    "content": "general_discriminant_eq_zero_iff shows Δ = 0 ⟺ −4p³ − 27q² = 0. From Δ = a⁴·depressedDisc, mul_eq_zero splits a product into a⁴ = 0 ∨ depressedDisc = 0; pow_ne_zero 4 ha kills the first disjunct because a ≠ 0 in the field ℂ, leaving depressedDisc = 0. The shift moves the roots but preserves the condition that two of them collide.",
+    "mathContext": "$\\Delta = 0 \\iff a^{4}\\,(-4p^{3}-27q^{2}) = 0 \\iff -4p^{3}-27q^{2} = 0$, since $a \\neq 0 \\Rightarrow a^{4} \\neq 0$ in a field.",
+    "significance": "supporting",
+    "relatedConcepts": ["NoZeroDivisors", "mul_eq_zero", "pow_ne_zero", "repeated-root locus"],
+    "prerequisites": ["integral domains / fields have no zero divisors"]
   },
   {
     "id": "ann-soc-oq0101-root-form",
     "proofId": "solution-of-cubic-oq-01-oq-01",
-    "range": {
-      "startLine": 146,
-      "endLine": 176
-    },
+    "range": { "startLine": 146, "endLine": 176 },
     "type": "insight",
     "title": "Symmetric Root Form and the Repeated-Root Criterion",
-    "body": "generalDiscriminant_eq_root_form substitutes the Vieta expressions b = −a·σ₁, c = a·σ₂, d = −a·σ₃ and lets ring verify Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))². Exposing Δ as a square (up to a⁴) makes repeated_root_iff immediate: over ℂ a product of differences squared is zero iff one difference is zero, i.e. two roots coincide — proved by chaining sq_eq_zero_iff, mul_eq_zero, and sub_eq_zero."
+    "content": "generalDiscriminant_eq_root_form substitutes the Vieta expressions b = −a·σ₁, c = a·σ₂, d = −a·σ₃ and lets ring verify Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))². Exposing Δ as a square (up to a⁴) makes repeated_root_iff immediate: over ℂ a product of differences squared is zero iff one difference is zero, i.e. two roots coincide — proved by chaining sq_eq_zero_iff, mul_eq_zero, and sub_eq_zero.",
+    "mathContext": "$\\Delta = a^{4}\\prod_{i<j}(x_i - x_j)^{2} = a^{4}\\big((x_1-x_2)(x_1-x_3)(x_2-x_3)\\big)^{2}$; $\\Delta = 0 \\iff x_i = x_j$ for some $i \\neq j$.",
+    "significance": "key",
+    "relatedConcepts": ["Vieta's formulas", "symmetric polynomials", "discriminant as squared Vandermonde", "repeated roots"],
+    "prerequisites": ["Vieta root-coefficient relations", "sq_eq_zero_iff over ℂ"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-01/index.ts
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SolutionOfCubicOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const solutionOfCubicOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const solutionOfCubicOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const solutionOfCubicOq01Oq01Data: ProofData = {
+  proof: solutionOfCubicOq01Oq01Proof,
+  annotations: solutionOfCubicOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-01` (first pass).

## Changes
- **Created `index.ts`** — entry had `meta.json` and `annotations.json` but no `index.ts`, so the page would render 'proof not found' on the live site.
- **Fixed annotation schema bugs** (annotations were not rendering correctly):
  - renamed `body` → `content` (the field the renderer reads — text was invisible)
  - added the required `significance` field (was absent on all 4)
  - fixed invalid `type: "technique"` → `tactic` (valid `AnnotationType`)
- **Enriched** all 4 annotations with `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`.

meta.json was already rich (13.6 KB, within caps) and accurate vs the Lean source (5 theorems + defs/examples, 0 sorries, 0 axioms, status verified) — left as-is.

`pnpm build` passes.