### PR TITLE
audit: confirm clean — isoperimetric-theorem-oq-03 + szemeredi-counting-oq-02 (2 new entries)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -24979,6 +24979,18 @@
       "lastAudited": "2026-06-27T07:23:40Z",
       "result": "clean",
       "issues": []
+    },
+    "isoperimetric-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T07:43:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "szemeredi-counting-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T07:43:46Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the 2 remaining never-audited gallery entries. Both **CLEAN** — meta.json claims match the Lean source exactly, no overclaiming.

### isoperimetric-theorem-oq-03 — Discrete Isoperimetric Inequality on the Cycle C_n
- **status** `verified`, **badge** `original` ✓
- sorries 0, axioms 0, no `native_decide` (no `Lean.ofReduceBool`) ✓
- theoremCount 9 = 9, definitionCount 3 = 3 ✓
- **Tier A**: listed Mathlib deps (`Fintype.sum_equiv`, `Finset.sum_boole`, `card_union_of_disjoint`, `ZMod.natCast_rightInverse`, `ZMod.card`) are basic infrastructure, not a deep theorem doing the core work. The balance lemma, sharp lower bound, and achievability are all genuinely proved in-file. Proves both the bound **and** achievability — no inequality≠theorem issue.

### szemeredi-counting-oq-02 — Hypergraph Counting Lemma: the Exact Base Term and the Cherry Engine
- **status** `verified`, **badge** `original` ✓
- sorries 0, axioms 0, no `native_decide` ✓
- theoremCount 14 = 14, definitionCount 10 = (9 def + `structure Tri3Graph`) ✓; lineCount 252 = 252 ✓
- **Exemplary honest scoping**: title and description explicitly isolate only the *deterministic* core, repeatedly stating the approximate `(1 ± f(ε))` NRS content for `e(F) ≥ 2` needs relative regularity and is **left open**. Avoids axiom-masking, inequality≠theorem, and pipeline-inflation failure modes. The Mathlib `sq_sum_le_card_mul_sum_sq` (Cauchy–Schwarz) is disclosed as a tool; the core identities (`edgeCount_eq_density_mul`, `cherryCount_eq_sum_sq_degA`) are proved in-file. (Note: `complete := ⟨fun _ _ _ => True⟩` at line 226 is the complete-hypergraph adjacency predicate, a legitimate definition — not a True-stub theorem.)

Gallery now **4027/4027 audited**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)