### PR TITLE
research(erdos-103-oq-02): congruence invariance (Part 8) + unconditional hCong 0=hCong 1=1 (Part 9) [BUILD-BLOCKED]

### DIFF
--- a/proofs/Proofs/Erdos103OQ02.lean
+++ b/proofs/Proofs/Erdos103OQ02.lean
@@ -46,9 +46,17 @@ Consequently the parent's literal `WeakConjecture` (and even the assertion
    empty — so the finiteness in the open question is exactly what makes the
    corrected count well-behaved.
 
-This does **not** resolve the open Erdős question (which remains open for `hCong`);
-it corrects the formalization so that the open question is stated about the right
-object.
+8. Discharges the finiteness hypothesis in the concrete small cases by computing
+   the first **unconditional** values of the corrected count:
+   `hCong 0 = hCong 1 = 1` (`hCong_zero`, `hCong_one`), via the criterion that a
+   nonempty single-congruence-class optimal set forces `hCong n = 1` with no
+   `[Finite]` assumption (`hCong_eq_one_of_all_congruent`). For `n < 2` optimality
+   reduces to validity (`isOptimal_iff_valid_lt_two`), so this is the analogue, in
+   the corrected count, of the parent file's informal remark `h(2)=h(3)=1`.
+
+This does **not** resolve the open Erdős question (which remains open for `hCong`
+at large `n`); it corrects the formalization so that the open question is stated
+about the right object, and pins down its first unconditional values.
 
 ## Axioms / Sorries
 None. All results are machine-checked from Mathlib + the parent file only.
@@ -328,6 +336,95 @@ theorem translate_optimal_via_isometry {n : ℕ} (v : ℝ × ℝ) (P : PointConf
   rw [Ptranslate_eq_applyIsometry]
   exact applyIsometry_optimal (translationIsometry v) P hP
 
+-- ============================================================
+-- PART 9: Unconditional small-n values: hCong 0 = hCong 1 = 1
+-- ============================================================
+
+/-- For `n < 2` the diameter is identically `0` — it is the `else` branch of the
+    parent's `diameter` (a diameter is only defined via the supremum once there are
+    at least two points). -/
+theorem diameter_lt_two {n : ℕ} (hn : n < 2) (P : PointConfig n) :
+    diameter n P = 0 := by
+  unfold diameter
+  rw [dif_neg (by omega)]
+
+/-- For `n < 2` the minimum diameter is `0`: every configuration has diameter `0`,
+    and (given any valid configuration to make the infimum non-vacuous) the infimum
+    of the constant `0` is `0`. -/
+theorem minDiameter_lt_two {n : ℕ} (hn : n < 2) (hne : ∃ P, IsValidConfig n P) :
+    minDiameter n = 0 := by
+  obtain ⟨P0, hP0⟩ := hne
+  haveI : Nonempty {P : PointConfig n // IsValidConfig n P} := ⟨⟨P0, hP0⟩⟩
+  unfold minDiameter
+  calc (⨅ P : {P : PointConfig n // IsValidConfig n P}, diameter n P.val)
+      = ⨅ _ : {P : PointConfig n // IsValidConfig n P}, (0 : ℝ) :=
+        iInf_congr (fun P => diameter_lt_two hn P.val)
+    _ = 0 := ciInf_const
+
+/-- For `n < 2`, optimality collapses to validity: the diameter constraint is
+    vacuous because every configuration already realizes the (zero) minimum. -/
+theorem isOptimal_iff_valid_lt_two {n : ℕ} (hn : n < 2)
+    (hne : ∃ P, IsValidConfig n P) (P : PointConfig n) :
+    IsOptimal n P ↔ IsValidConfig n P := by
+  constructor
+  · exact fun h => h.1
+  · intro hv
+    exact ⟨hv, by rw [diameter_lt_two hn, minDiameter_lt_two hn hne]⟩
+
+/-- **Unconditional single-class criterion.** If an optimal configuration exists and
+    every two optimal configurations are congruent, then `hCong n = 1` with **no
+    `[Finite]` hypothesis**: the quotient is a nonempty subsingleton, and the
+    cardinality of a nonempty subsingleton is exactly `1`. This is the lever that
+    discharges the finiteness assumption carried by all the Part 7 results in the
+    concrete cases where the optimal set is a single congruence class. -/
+theorem hCong_eq_one_of_all_congruent {n : ℕ}
+    (hne : ∃ P, IsOptimal n P)
+    (hall : ∀ P Q : PointConfig n, IsOptimal n P → IsOptimal n Q →
+      AreCongruent n P Q) :
+    hCong n = 1 := by
+  have hsub : Subsingleton (Quotient (OptimalSetoid n)) := by
+    constructor
+    intro a b
+    induction a using Quotient.inductionOn with
+    | _ P =>
+      induction b using Quotient.inductionOn with
+      | _ Q => exact Quotient.sound (hall P.val Q.val P.2 Q.2)
+  obtain ⟨P, hP⟩ := hne
+  have hnonempty : Nonempty (Quotient (OptimalSetoid n)) :=
+    ⟨Quotient.mk (OptimalSetoid n) ⟨P, hP⟩⟩
+  rw [hCong]
+  exact Nat.card_eq_one_iff_unique.mpr ⟨hsub, hnonempty⟩
+
+/-- **`hCong 0 = 1`, unconditionally.** `PointConfig 0` is the one-point type (the
+    empty tuple), so there is a single configuration; it is vacuously valid, hence
+    optimal, and equal to every other, hence its own unique congruence class. This
+    is the first finiteness-hypothesis-free value of the corrected count. -/
+theorem hCong_zero : hCong 0 = 1 := by
+  have hvalid : ∀ R : PointConfig 0, IsValidConfig 0 R := fun R i _ _ => Fin.elim0 i
+  apply hCong_eq_one_of_all_congruent
+  · exact ⟨fun _ => (0, 0),
+      (isOptimal_iff_valid_lt_two (by omega) ⟨_, hvalid _⟩ _).mpr (hvalid _)⟩
+  · intro P Q _ _
+    have hPQ : P = Q := funext (fun i => Fin.elim0 i)
+    rw [hPQ]; exact congruent_refl 0 Q
+
+/-- **`hCong 1 = 1`, unconditionally.** Every single-point configuration is valid
+    (no distinct pairs to separate), hence optimal; and any two are related by the
+    translation carrying one point onto the other, so they form a single congruence
+    class. No finiteness hypothesis is needed. -/
+theorem hCong_one : hCong 1 = 1 := by
+  have hvalid : ∀ R : PointConfig 1, IsValidConfig 1 R := by
+    intro R i j hij; exact absurd (Subsingleton.elim i j) hij
+  apply hCong_eq_one_of_all_congruent
+  · exact ⟨fun _ => (0, 0),
+      (isOptimal_iff_valid_lt_two (by omega) ⟨_, hvalid _⟩ _).mpr (hvalid _)⟩
+  · intro P Q _ _
+    refine ⟨translationIsometry (Q 0 - P 0), fun i => ?_⟩
+    have hi : i = 0 := Subsingleton.elim i 0
+    subst hi
+    change Q 0 = P 0 + (Q 0 - P 0)
+    abel
+
 end Erdos103OQ02
 
 -- Export main results
@@ -343,3 +440,7 @@ end Erdos103OQ02
 #check @Erdos103OQ02.applyIsometry_optimal
 #check @Erdos103OQ02.optimal_of_congruent
 #check @Erdos103OQ02.translate_optimal_via_isometry
+#check @Erdos103OQ02.isOptimal_iff_valid_lt_two
+#check @Erdos103OQ02.hCong_eq_one_of_all_congruent
+#check @Erdos103OQ02.hCong_zero
+#check @Erdos103OQ02.hCong_one

--- a/proofs/Proofs/Erdos103OQ02.lean
+++ b/proofs/Proofs/Erdos103OQ02.lean
@@ -33,6 +33,12 @@ Consequently the parent's literal `WeakConjecture` (and even the assertion
 6. Shows the corrected quotient collapses exactly the translation-infinitude that
    breaks the raw count: all translates of a configuration share one class
    (`translates_same_class`).
+7. Proves the structural backbone the quotient rests on: **optimality is a full
+   congruence invariant** (`optimal_of_congruent`), via the fact that every
+   isometry — not just translations — preserves diameter, validity, and hence
+   optimality (`isometry_diameter`, `isometry_valid`, `applyIsometry_optimal`).
+   The translation results of Parts 1–3 are recovered as the
+   `translationIsometry` special case (`translate_optimal_via_isometry`).
 7. Proves the correction is **non-degenerate where the raw count failed**: given an
    optimal configuration and finitely many congruence classes, `hCong n ≥ 1`
    (`hCong_pos_of_finite`) and indeed `h n < hCong n` (`hCong_strictly_exceeds_raw`).
@@ -252,6 +258,76 @@ theorem hCong_strictly_exceeds_raw (n : ℕ) (hn : 0 < n)
   rw [h_eq_zero n hn]
   exact hCong_pos_of_finite n hne
 
+-- ============================================================
+-- PART 8: Optimality is a full congruence invariant
+-- ============================================================
+
+/-- **Any isometry preserves the diameter** of a configuration. This generalizes
+    `translate_diameter` (Part 2) from the translation subgroup to the entire
+    isometry group `Isometry2D` used to define congruence. -/
+theorem isometry_diameter {n : ℕ} (σ : Isometry2D) (P : PointConfig n) :
+    diameter n (applyIsometry n σ P) = diameter n P := by
+  unfold diameter
+  by_cases hn : n ≥ 2
+  · rw [dif_pos hn, dif_pos hn]
+    apply iSup_congr; intro i
+    apply iSup_congr; intro j
+    show pointDist (σ.toFun (P i)) (σ.toFun (P j)) = pointDist (P i) (P j)
+    exact σ.preserves_dist (P i) (P j)
+  · rw [dif_neg hn, dif_neg hn]
+
+/-- **Any isometry preserves validity** (the minimum-separation constraint).
+    Generalizes `translate_valid` (Part 2) to the full isometry group. -/
+theorem isometry_valid {n : ℕ} (σ : Isometry2D) (P : PointConfig n)
+    (hP : IsValidConfig n P) : IsValidConfig n (applyIsometry n σ P) := by
+  intro i j hij
+  show pointDist (σ.toFun (P i)) (σ.toFun (P j)) ≥ 1
+  rw [σ.preserves_dist]
+  exact hP i j hij
+
+/-- **Any isometry preserves optimality.** The full-group generalization of
+    `translate_optimal` (Part 2): translation is just one isometry, so the
+    translation infinitude of Part 3 is a single slice of this invariance. -/
+theorem applyIsometry_optimal {n : ℕ} (σ : Isometry2D) (P : PointConfig n)
+    (hP : IsOptimal n P) : IsOptimal n (applyIsometry n σ P) := by
+  obtain ⟨hvalid, hdiam⟩ := hP
+  refine ⟨isometry_valid σ P hvalid, ?_⟩
+  rw [isometry_diameter]
+  exact hdiam
+
+/-- **Optimality is a congruence invariant.** If `P` is optimal and `Q` is
+    congruent to `P`, then `Q` is optimal too. This is the structural backbone of
+    `hCong`: the congruence quotient of the *optimal* subtype is well-posed
+    precisely because being optimal is constant on each congruence class. Without
+    this fact, "incongruent optimal configurations" would not even be well-defined
+    as a quotient of optimal configurations. -/
+theorem optimal_of_congruent {n : ℕ} (P Q : PointConfig n)
+    (hP : IsOptimal n P) (hcong : AreCongruent n P Q) : IsOptimal n Q := by
+  obtain ⟨σ, hσ⟩ := hcong
+  have hQ : Q = applyIsometry n σ P := funext hσ
+  rw [hQ]
+  exact applyIsometry_optimal σ P hP
+
+/-- Translation by `v`, packaged as an element of the isometry group. -/
+def translationIsometry (v : ℝ × ℝ) : Isometry2D where
+  toFun := fun p => p + v
+  preserves_dist := fun p q => pointDist_add_right p q v
+  bijective := (Equiv.addRight v).bijective
+
+/-- The translation results of Parts 1–3 are exactly the `translationIsometry v`
+    instances of the isometry invariance of Part 8: `Ptranslate v` is the
+    application of the corresponding isometry. -/
+theorem Ptranslate_eq_applyIsometry {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n) :
+    Ptranslate v P = applyIsometry n (translationIsometry v) P := rfl
+
+/-- `translate_optimal` (Part 2) recovered as the translation special case of the
+    full-group `applyIsometry_optimal`, confirming the generalization subsumes the
+    earlier translation-only result. -/
+theorem translate_optimal_via_isometry {n : ℕ} (v : ℝ × ℝ) (P : PointConfig n)
+    (hP : IsOptimal n P) : IsOptimal n (Ptranslate v P) := by
+  rw [Ptranslate_eq_applyIsometry]
+  exact applyIsometry_optimal (translationIsometry v) P hP
+
 end Erdos103OQ02
 
 -- Export main results
@@ -263,3 +339,7 @@ end Erdos103OQ02
 #check @Erdos103OQ02.translates_same_class
 #check @Erdos103OQ02.hCong_pos_of_finite
 #check @Erdos103OQ02.hCong_strictly_exceeds_raw
+#check @Erdos103OQ02.isometry_diameter
+#check @Erdos103OQ02.applyIsometry_optimal
+#check @Erdos103OQ02.optimal_of_congruent
+#check @Erdos103OQ02.translate_optimal_via_isometry

--- a/proofs/Proofs/Erdos103OQ02.lean
+++ b/proofs/Proofs/Erdos103OQ02.lean
@@ -382,17 +382,13 @@ theorem hCong_eq_one_of_all_congruent {n : ℕ}
     (hall : ∀ P Q : PointConfig n, IsOptimal n P → IsOptimal n Q →
       AreCongruent n P Q) :
     hCong n = 1 := by
-  have hsub : Subsingleton (Quotient (OptimalSetoid n)) := by
-    constructor
-    intro a b
-    induction a using Quotient.inductionOn with
-    | _ P =>
-      induction b using Quotient.inductionOn with
-      | _ Q => exact Quotient.sound (hall P.val Q.val P.2 Q.2)
+  have hsub : Subsingleton (Quotient (OptimalSetoid n)) :=
+    ⟨fun a b => Quotient.inductionOn₂ a b
+      (fun P Q => Quotient.sound (hall P.val Q.val P.2 Q.2))⟩
   obtain ⟨P, hP⟩ := hne
   have hnonempty : Nonempty (Quotient (OptimalSetoid n)) :=
     ⟨Quotient.mk (OptimalSetoid n) ⟨P, hP⟩⟩
-  rw [hCong]
+  show Nat.card (Quotient (OptimalSetoid n)) = 1
   exact Nat.card_eq_one_iff_unique.mpr ⟨hsub, hnonempty⟩
 
 /-- **`hCong 0 = 1`, unconditionally.** `PointConfig 0` is the one-point type (the
@@ -401,9 +397,9 @@ theorem hCong_eq_one_of_all_congruent {n : ℕ}
     is the first finiteness-hypothesis-free value of the corrected count. -/
 theorem hCong_zero : hCong 0 = 1 := by
   have hvalid : ∀ R : PointConfig 0, IsValidConfig 0 R := fun R i _ _ => Fin.elim0 i
-  apply hCong_eq_one_of_all_congruent
-  · exact ⟨fun _ => (0, 0),
-      (isOptimal_iff_valid_lt_two (by omega) ⟨_, hvalid _⟩ _).mpr (hvalid _)⟩
+  have hne : ∃ P : PointConfig 0, IsValidConfig 0 P := ⟨fun _ => (0, 0), hvalid _⟩
+  refine hCong_eq_one_of_all_congruent ⟨fun _ => (0, 0), ?_⟩ ?_
+  · exact (isOptimal_iff_valid_lt_two (by omega) hne _).mpr (hvalid _)
   · intro P Q _ _
     have hPQ : P = Q := funext (fun i => Fin.elim0 i)
     rw [hPQ]; exact congruent_refl 0 Q
@@ -415,9 +411,9 @@ theorem hCong_zero : hCong 0 = 1 := by
 theorem hCong_one : hCong 1 = 1 := by
   have hvalid : ∀ R : PointConfig 1, IsValidConfig 1 R := by
     intro R i j hij; exact absurd (Subsingleton.elim i j) hij
-  apply hCong_eq_one_of_all_congruent
-  · exact ⟨fun _ => (0, 0),
-      (isOptimal_iff_valid_lt_two (by omega) ⟨_, hvalid _⟩ _).mpr (hvalid _)⟩
+  have hne : ∃ P : PointConfig 1, IsValidConfig 1 P := ⟨fun _ => (0, 0), hvalid _⟩
+  refine hCong_eq_one_of_all_congruent ⟨fun _ => (0, 0), ?_⟩ ?_
+  · exact (isOptimal_iff_valid_lt_two (by omega) hne _).mpr (hvalid _)
   · intro P Q _ _
     refine ⟨translationIsometry (Q 0 - P 0), fun i => ?_⟩
     have hi : i = 0 := Subsingleton.elim i 0

--- a/research/problems/erdos-103-oq-02/knowledge.md
+++ b/research/problems/erdos-103-oq-02/knowledge.md
@@ -1,0 +1,33 @@
+
+## Session (researcher-1, 2026-06-27) — Part 8: congruence-invariance of optimality
+
+State on entry: file complete through Part 7 (PR #30601 merged) — raw count h≡0,
+corrected hCong via congruence quotient, hCong non-degenerate *conditional on*
+[Finite (Quotient (OptimalSetoid n))]. 0 sorry / 0 axiom, verified.
+
+Identified gap: Parts 1–3 only proved the *translation* subgroup preserves
+optimality (translate_optimal), but hCong quotients by the FULL isometry group
+(AreCongruent). The well-definedness backbone — optimality constant on congruence
+classes — was unproved.
+
+Added Part 8 (PR #30629, draft, BUILD-BLOCKED on host-disk exhaustion):
+  - isometry_diameter / isometry_valid / applyIsometry_optimal  (full-group
+    generalizations of the translate_* lemmas)
+  - optimal_of_congruent  (P optimal ∧ P~Q ⟹ Q optimal)
+  - translationIsometry / Ptranslate_eq_applyIsometry / translate_optimal_via_isometry
+    (recover Parts 1–3 as the translation special case)
+Purely additive +80 lines, 0 sorry / 0 axiom.
+
+Open / next directions (unresolved, hard):
+  - The genuine Erdős content is UNCONDITIONAL finiteness of Quotient(OptimalSetoid n).
+    All non-degeneracy results still carry the [Finite ...] hypothesis. Proving it
+    (or computing concrete small-n values, e.g. hCong 0 = hCong 1 = 1 via
+    Subsingleton/translation-collapse) would remove the hypothesis. Attempted scoping
+    only; the n=0/1 cardinality-of-quotient route needs care with Nat.card lemma names.
+  - hCong n ≥ 2 for large n (the actual OQ-02 weak conjecture) remains open.
+
+GOTCHAs this session:
+  - Shared session branch (research/researcher-N-sessionM) may already back an OPEN
+    PR for unrelated work (here #30620 cayley-hamilton). Do NOT rebase/force-push it.
+    Put new work on a dedicated branch off origin/main.
+  - Docker host /System/Volumes/Data at 100% → containerd meta.db I/O error, no builds.

--- a/research/problems/erdos-103-oq-02/knowledge.md
+++ b/research/problems/erdos-103-oq-02/knowledge.md
@@ -20,11 +20,36 @@ Purely additive +80 lines, 0 sorry / 0 axiom.
 
 Open / next directions (unresolved, hard):
   - The genuine Erdős content is UNCONDITIONAL finiteness of Quotient(OptimalSetoid n).
-    All non-degeneracy results still carry the [Finite ...] hypothesis. Proving it
-    (or computing concrete small-n values, e.g. hCong 0 = hCong 1 = 1 via
-    Subsingleton/translation-collapse) would remove the hypothesis. Attempted scoping
-    only; the n=0/1 cardinality-of-quotient route needs care with Nat.card lemma names.
+    All non-degeneracy results still carry the [Finite ...] hypothesis.
   - hCong n ≥ 2 for large n (the actual OQ-02 weak conjecture) remains open.
+
+## Session (researcher-1, 2026-06-27) — Part 9: first UNCONDITIONAL hCong values
+
+Added Part 9 to Erdos103OQ02.lean (same PR #30629, still BUILD-BLOCKED). Removes
+the [Finite] hypothesis in the concrete small cases:
+  - diameter_lt_two / minDiameter_lt_two / isOptimal_iff_valid_lt_two: for n<2 the
+    diameter is identically 0 (else-branch of `diameter`), so optimality ⇔ validity.
+  - hCong_eq_one_of_all_congruent: nonempty + all-optimal-configs-congruent ⇒
+    hCong n = 1, NO [Finite] hypothesis (nonempty subsingleton quotient ⇒ card 1
+    via Nat.card_eq_one_iff_unique). This is the lever that discharges finiteness.
+  - hCong_zero (=1, PointConfig 0 is the one-point empty-tuple type) and
+    hCong_one (=1, all single points congruent by translation). First
+    finiteness-free values; the hCong analogue of the parent's informal h(2)=h(3)=1.
+Purely additive +80 lines, 0 sorry / 0 axiom.
+
+Mathlib names HAND-VERIFIED against proofs/.lake/packages/mathlib (build was blocked):
+  Nat.card_eq_one_iff_unique (Nat.card α=1 ↔ Subsingleton∧Nonempty), ciInf_const
+  ([Nonempty ι], ℝ is only conditionally complete), iInf_congr (lives in the
+  [InfSet] section so it DOES apply to ℝ — not CompleteLattice-only), Fin.elim0,
+  Fin.instUnique : Unique (Fin 1) ⇒ Subsingleton (Fin 1).
+
+GOTCHAs this session:
+  - Docker responds to `docker ps` but CANNOT build: host /System/Volumes/Data at
+    100% (5.6 GiB free) → image build dies on containerd meta.db input/output error.
+    Same blocker as Part 8; commit + push, keep PR draft, hand-verify lemma names.
+  - hCong is a `def`, so `rw [hCong]` fails — use `show Nat.card (...) = 1` (defeq).
+  - Next direction (still open & hard): UNCONDITIONAL Finite (Quotient (OptimalSetoid n))
+    for general n, and hCong n ≥ 2 for large n.
 
 GOTCHAs this session:
   - Shared session branch (research/researcher-N-sessionM) may already back an OPEN


### PR DESCRIPTION
## Erdős #103 OQ-02 — Parts 8 & 9 (additive)

Builds on the merged PR #30601 work (corrected congruence count `hCong`). All
results are **purely additive** to `proofs/Proofs/Erdos103OQ02.lean`; nothing
prior is modified.

### Part 8 — Optimality is a full congruence invariant
- `isometry_diameter`, `isometry_valid`, `applyIsometry_optimal` — generalize the
  Part 1–3 translation lemmas from the translation subgroup to the entire isometry
  group used to define congruence.
- `optimal_of_congruent` — `P` optimal ∧ `P ~ Q` ⟹ `Q` optimal. This is the
  well-definedness backbone the congruence quotient `hCong` rests on.
- `translationIsometry`, `Ptranslate_eq_applyIsometry`, `translate_optimal_via_isometry`
  recover Parts 1–3 as the translation special case.

### Part 9 — First **unconditional** values of the corrected count
All Part 7 non-degeneracy results carried a `[Finite (Quotient (OptimalSetoid n))]`
hypothesis. Part 9 discharges it in the concrete small cases:
- `diameter_lt_two`, `minDiameter_lt_two`, `isOptimal_iff_valid_lt_two` — for
  `n < 2`, the diameter is identically 0, so optimality reduces to validity.
- `hCong_eq_one_of_all_congruent` — a nonempty single-congruence-class optimal set
  forces `hCong n = 1` with **no `[Finite]` assumption** (nonempty subsingleton ⇒
  card 1).
- `hCong_zero : hCong 0 = 1`, `hCong_one : hCong 1 = 1` — the first
  finiteness-hypothesis-free values, the corrected-count analogue of the parent
  file's informal `h(2)=h(3)=1`.

0 `sorry`, 0 `axiom`. Does **not** resolve the open question (`hCong n ≥ 2` for
large `n` remains open).

### Build status
⚠️ **BUILD-BLOCKED**: host disk at 100% (5.6 GiB free) → docker image build fails
with a containerd `meta.db: input/output error`; `lake` cannot run. Proofs are
hand-checked and every Mathlib lemma name was verified against the local Mathlib
source (`Nat.card_eq_one_iff_unique`, `ciInf_const`, `iInf_congr` over `[InfSet]`,
`Fin.elim0`, `Fin.instUnique`). Mark **ready** after `docker-build.sh
Proofs.Erdos103OQ02` passes on a healthy host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)