### PR TITLE
research(pascals-hexagon-oq-03-oq-02): D6 generator-action on the Pascal triple

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -1150,9 +1150,9 @@ private lemma conicQF_eq_mathlibQF (C : Conic) (p : Fin 3 → ℝ) :
     4. Therefore `(associated Q).SeparatingLeft`. -/
 private lemma mathlibQF_separatingLeft (C : Conic) (hC_sym : C.symmetric)
     (hC_nd : Conic.nondegenerate C) :
-    (associated (R := ℝ) (Matrix.toQuadraticMap' C)).SeparatingLeft := by
+    (QuadraticMap.associated (Matrix.toQuadraticMap' C)).SeparatingLeft := by
   -- Step 1: Show associated Q = Matrix.toLinearMap₂' ℝ C using symmetry of C
-  have h_assoc : associated (R := ℝ) (Matrix.toQuadraticMap' C) = Matrix.toLinearMap₂' ℝ C := by
+  have h_assoc : QuadraticMap.associated (Matrix.toQuadraticMap' C) = Matrix.toLinearMap₂' ℝ C := by
     unfold Matrix.toQuadraticMap'
     exact QuadraticMap.associated_left_inverse (fun x y => by
       -- Prove: (Matrix.toLinearMap₂' ℝ C) x y = (Matrix.toLinearMap₂' ℝ C) y x

--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -1029,6 +1029,150 @@ theorem pascalLine_hexRot_hexRev_sameProjLine {C : Conic} (hex : InscribedHexago
     (pascalLine_hexRev_sameProjLine hex)
 
 -- ============================================================
+-- PART 4f: `permuteHexagon` is a Right Group Action
+--          (OQ-03-OQ-02: the composition law the descent consumes)
+-- ============================================================
+
+/- The closure-induction descent of **OQ-03-OQ-02** needs to chain the two
+   single-generator invariances of PART 4d/4e across an arbitrary word in
+   `hexagonalGroup = ⟨hexRot, hexRev⟩`.  The inductive step factors a relabeling
+   by a product `g * h` into a relabeling by `g` followed by one by `h`; the
+   `sameProjLine` transitivity engine of PART 4e then composes the two steps.
+   This part supplies that composition law: `permuteHexagon` is a *right* action
+   of `Equiv.Perm (Fin 6)` on `InscribedHexagon C`. -/
+
+/-- Two inscribed hexagons are equal once their six vertices agree: the
+    conic-membership and validity fields are propositions, so they match
+    automatically by proof irrelevance. -/
+theorem InscribedHexagon.ext {C : Conic} {h1 h2 : InscribedHexagon C}
+    (eA : h1.A = h2.A) (eB : h1.B = h2.B) (eC : h1.C' = h2.C')
+    (eD : h1.D = h2.D) (eE : h1.E = h2.E) (eF : h1.F = h2.F) :
+    h1 = h2 := by
+  cases h1; cases h2
+  subst eA; subst eB; subst eC; subst eD; subst eE; subst eF
+  rfl
+
+/-- The vertices of a relabeled hexagon are the original vertices read off
+    through the permutation: `hexVertex (permuteHexagon hex g) j = hexVertex hex (g j)`.
+    A definitional unfolding, case-split on the six indices. -/
+theorem hexVertex_permuteHexagon {C : Conic} (hex : InscribedHexagon C)
+    (g : Equiv.Perm (Fin 6)) (j : Fin 6) :
+    hexVertex (permuteHexagon hex g) j = hexVertex hex (g j) := by
+  fin_cases j <;> rfl
+
+/-- **Identity law.** Relabeling by the identity permutation is the original
+    hexagon. -/
+theorem permuteHexagon_one {C : Conic} (hex : InscribedHexagon C) :
+    permuteHexagon hex 1 = hex := by
+  refine InscribedHexagon.ext ?_ ?_ ?_ ?_ ?_ ?_ <;>
+    simp only [permuteHexagon, Equiv.Perm.coe_one, id_eq] <;> rfl
+
+/-- **Composition law.** Relabeling by `g` and then by `h` equals relabeling by
+    the product `g * h` (right action: the inner permutation is applied first).
+    This is the algebraic heart of the closure-induction descent — it lets a
+    relabeling by an arbitrary group element be unfolded one generator at a time.
+
+    Proof: each vertex of the doubly-relabeled hexagon is
+    `hexVertex (permuteHexagon hex g) (h k) = hexVertex hex (g (h k)) =
+     hexVertex hex ((g * h) k)`, using `hexVertex_permuteHexagon` and
+    `Equiv.Perm.mul_apply`. -/
+theorem permuteHexagon_mul {C : Conic} (hex : InscribedHexagon C)
+    (g h : Equiv.Perm (Fin 6)) :
+    permuteHexagon (permuteHexagon hex g) h = permuteHexagon hex (g * h) := by
+  have key : ∀ k : Fin 6,
+      hexVertex (permuteHexagon hex g) (h k) = hexVertex hex ((g * h) k) := by
+    intro k
+    rw [hexVertex_permuteHexagon, Equiv.Perm.mul_apply]
+  exact InscribedHexagon.ext (key 0) (key 1) (key 2) (key 3) (key 4) (key 5)
+
+-- ============================================================
+-- PART 4g: Quotient Descent — `D_6`-Invariance of the Pascal Line
+--          (OQ-03-OQ-02: the full closure induction)
+-- ============================================================
+
+/-- The homogeneous Pascal *line* of a hexagon, spanned by its first two Pascal
+    points `P = AB ∩ DE` and `Q = BC ∩ EF`.  The well-definedness content of
+    **OQ-03-OQ-02** is that this is `sameProjLine`-invariant under relabeling by
+    the dihedral group `hexagonalGroup`. -/
+noncomputable def pascalProjLine {C : Conic} (hex : InscribedHexagon C) : ProjLine :=
+  lineThrough (pascalP hex) (pascalQ hex)
+
+/-- **OQ-03-OQ-02 — quotient descent (full).**  For *every* element `g` of the
+    dihedral group `hexagonalGroup = ⟨hexRot, hexRev⟩`, relabeling a hexagon by
+    `g` leaves its Pascal line unchanged as a *projective* line:
+    `pascalProjLine hex ∥ pascalProjLine (permuteHexagon hex g)`.
+
+    This propagates the two single-generator invariances of PART 4d to the whole
+    12-element group by `Subgroup.closure_induction`, with the PER engine of
+    PART 4e composing successive generator steps (`sameProjLine_trans`) and the
+    group-action law of PART 4f (`permuteHexagon_mul`, `permuteHexagon_one`)
+    unfolding products one generator at a time.
+
+    The statement is quantified over *all* hexagons (so the inductive `mul`/`inv`
+    steps can re-instantiate at the partially-relabeled hexagon), carrying the
+    natural **general-position** hypothesis `hnd`: every relabeling of `hex` has
+    a genuine (nonzero) Pascal line.  This is exactly the nondegeneracy needed by
+    `sameProjLine` transitivity, and is the precise hypothesis under which the
+    60 Pascal lines are well-defined. -/
+theorem pascalProjLine_sameProjLine_of_mem
+    {C : Conic} {g : Equiv.Perm (Fin 6)} (hg : g ∈ hexagonalGroup)
+    (hex : InscribedHexagon C)
+    (hnd : ∀ k : Equiv.Perm (Fin 6), pascalProjLine (permuteHexagon hex k) ≠ 0) :
+    sameProjLine (pascalProjLine hex) (pascalProjLine (permuteHexagon hex g)) := by
+  unfold hexagonalGroup at hg
+  induction hg using Subgroup.closure_induction generalizing hex hnd with
+  | mem x hx =>
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+      rcases hx with rfl | rfl
+      · exact pascalLine_hexRot_sameProjLine hex
+      · exact pascalLine_hexRev_sameProjLine hex
+  | one =>
+      rw [permuteHexagon_one]
+      exact sameProjLine_refl _
+  | mul x y _ _ ihx ihy =>
+      have hx' : sameProjLine (pascalProjLine hex)
+          (pascalProjLine (permuteHexagon hex x)) := ihx hex hnd
+      have hnd' : ∀ k : Equiv.Perm (Fin 6),
+          pascalProjLine (permuteHexagon (permuteHexagon hex x) k) ≠ 0 := by
+        intro k
+        rw [permuteHexagon_mul]
+        exact hnd (x * k)
+      have hy' : sameProjLine (pascalProjLine (permuteHexagon hex x))
+          (pascalProjLine (permuteHexagon (permuteHexagon hex x) y)) :=
+        ihy (permuteHexagon hex x) hnd'
+      rw [permuteHexagon_mul] at hy'
+      exact sameProjLine_trans (hnd x) hx' hy'
+  | inv x _ ihx =>
+      have hnd' : ∀ k : Equiv.Perm (Fin 6),
+          pascalProjLine (permuteHexagon (permuteHexagon hex x⁻¹) k) ≠ 0 := by
+        intro k
+        rw [permuteHexagon_mul]
+        exact hnd (x⁻¹ * k)
+      have hxx : sameProjLine (pascalProjLine (permuteHexagon hex x⁻¹))
+          (pascalProjLine (permuteHexagon (permuteHexagon hex x⁻¹) x)) :=
+        ihx (permuteHexagon hex x⁻¹) hnd'
+      rw [permuteHexagon_mul, inv_mul_cancel, permuteHexagon_one] at hxx
+      exact sameProjLine_symm hxx
+
+/-- **OQ-03-OQ-02 — well-definedness corollary.**  Under general position, the
+    Pascal line is invariant under both dihedral generators *and their entire
+    group*: any two representatives `g, h ∈ hexagonalGroup` relabel `hex` to the
+    same projective Pascal line.  This is the descent statement that makes
+    `pascalLine` (PART 5) independent of the coset representative. -/
+theorem pascalProjLine_sameProjLine_of_mem_mem
+    {C : Conic} {g h : Equiv.Perm (Fin 6)}
+    (hg : g ∈ hexagonalGroup) (hh : h ∈ hexagonalGroup)
+    (hex : InscribedHexagon C)
+    (hnd : ∀ k : Equiv.Perm (Fin 6), pascalProjLine (permuteHexagon hex k) ≠ 0) :
+    sameProjLine (pascalProjLine (permuteHexagon hex g))
+                 (pascalProjLine (permuteHexagon hex h)) := by
+  have hhex : pascalProjLine hex ≠ 0 := by
+    have h1 := hnd 1; rwa [permuteHexagon_one] at h1
+  exact sameProjLine_trans hhex
+    (sameProjLine_symm (pascalProjLine_sameProjLine_of_mem hg hex hnd))
+    (pascalProjLine_sameProjLine_of_mem hh hex hnd)
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -856,6 +856,179 @@ theorem pascalLine_generators_sameProjLine {C : Conic} (hex : InscribedHexagon C
   ⟨pascalLine_hexRot_sameProjLine hex, pascalLine_hexRev_sameProjLine hex⟩
 
 -- ============================================================
+-- PART 4e: `sameProjLine` is a Partial Equivalence Relation
+--          (the algebraic engine for the quotient descent)
+-- ============================================================
+
+/- PART 4d showed each *generator* of the dihedral group fixes the Pascal
+   projective line.  To promote this to invariance under the whole group
+   `⟨hexRot, hexRev⟩` by closure induction, `sameProjLine` must be an
+   equivalence relation along the orbit.  It is reflexive (PART 4d) and we
+   now add the two remaining pieces:
+
+     * **symmetry** — `l ∥ m ⟹ m ∥ l` (the cross product is anti-symmetric);
+     * **transitivity** — `l ∥ m ⟹ m ∥ n ⟹ l ∥ n`, *provided the middle
+       vector `m ≠ 0`*.
+
+   The `m ≠ 0` hypothesis is genuinely necessary: the zero vector is parallel
+   to everything (`0 ×₃ v = 0`), so without it `0 ∥ a` and `0 ∥ b` would force
+   `a ∥ b`.  On the Pascal orbit the middle line is the cross product of two
+   distinct projective points of a non-degenerate conic, hence nonzero, so the
+   hypothesis is satisfied wherever the descent uses it.
+
+   Together these make `sameProjLine` a *partial equivalence relation* (PER):
+   an equivalence relation on the set of nonzero homogeneous line-vectors,
+   exactly the structure a `Quotient`/`Setoid` descent of `pascalLine`
+   requires. -/
+
+/-- **Symmetry of `sameProjLine`.**  `l ∥ m ⟹ m ∥ l`.  The cross product is
+    anti-symmetric (`m ×₃ l = -(l ×₃ m)`), so a vanishing cross product is a
+    symmetric relation.  Proved coordinate-wise to reuse the file's
+    `cross_apply` simp set. -/
+theorem sameProjLine_symm {l m : ProjLine} (h : sameProjLine l m) :
+    sameProjLine m l := by
+  unfold sameProjLine at h ⊢
+  have h0 := congrFun h 0
+  have h1 := congrFun h 1
+  have h2 := congrFun h 2
+  simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+             Pi.zero_apply, Fin.isValue] at h0 h1 h2
+  funext i
+  fin_cases i
+  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+               Pi.zero_apply, Fin.isValue]
+    linear_combination -h0
+  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+               Pi.zero_apply, Fin.isValue]
+    linear_combination -h1
+  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+               Pi.zero_apply, Fin.isValue]
+    linear_combination -h2
+
+/-- **Transitivity of `sameProjLine` along a nonzero middle vector.**
+    If `l ∥ m` and `m ∥ n` with `m ≠ 0`, then `l ∥ n`.
+
+    *Proof engine.*  For every coordinate `k`, the scaled vector
+    `m k • (l ×₃ n)` vanishes identically: each of its three components is a
+    fixed `ℝ`-linear combination of the (vanishing) components of `l ×₃ m` and
+    `m ×₃ n` (a `linear_combination` certificate, one per coordinate pair).
+    Hence `m k • (l ×₃ n) = 0` for all `k`.  Since `m ≠ 0`, some coordinate
+    `m k ≠ 0`, and `smul_eq_zero` forces `l ×₃ n = 0`.
+
+    This is the projective statement "two lines both proportional to a common
+    nonzero line are proportional to each other", proved without dividing. -/
+theorem sameProjLine_trans {l m n : ProjLine} (hm : m ≠ 0)
+    (h1 : sameProjLine l m) (h2 : sameProjLine m n) :
+    sameProjLine l n := by
+  unfold sameProjLine at h1 h2 ⊢
+  -- Component equations of `l ×₃ m = 0` and `m ×₃ n = 0`.
+  have a0 : l 1 * m 2 - l 2 * m 1 = 0 := by
+    have := congrFun h1 0
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                Pi.zero_apply, Fin.isValue] using this
+  have a1 : l 2 * m 0 - l 0 * m 2 = 0 := by
+    have := congrFun h1 1
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                Pi.zero_apply, Fin.isValue] using this
+  have a2 : l 0 * m 1 - l 1 * m 0 = 0 := by
+    have := congrFun h1 2
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                Pi.zero_apply, Fin.isValue] using this
+  have b0 : m 1 * n 2 - m 2 * n 1 = 0 := by
+    have := congrFun h2 0
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                Pi.zero_apply, Fin.isValue] using this
+  have b1 : m 2 * n 0 - m 0 * n 2 = 0 := by
+    have := congrFun h2 1
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                Pi.zero_apply, Fin.isValue] using this
+  have b2 : m 0 * n 1 - m 1 * n 0 = 0 := by
+    have := congrFun h2 2
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+                Pi.zero_apply, Fin.isValue] using this
+  -- Each coordinate of `m` annihilates `l ×₃ n`.
+  have key0 : m 0 • crossProduct l n = 0 := by
+    funext i
+    fin_cases i
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 0) * b0 - (n 2) * a2 - (n 1) * a1
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 0) * b1 + (n 0) * a1
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 0) * b2 + (n 0) * a2
+  have key1 : m 1 • crossProduct l n = 0 := by
+    funext i
+    fin_cases i
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 1) * b0 + (n 1) * a0
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 1) * b1 - (n 0) * a0 - (n 2) * a2
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 1) * b2 + (n 1) * a2
+  have key2 : m 2 • crossProduct l n = 0 := by
+    funext i
+    fin_cases i
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 2) * b0 + (n 2) * a0
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 2) * b1 + (n 2) * a1
+    · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+      linear_combination (l 2) * b2 - (n 1) * a1 - (n 0) * a0
+  -- `m ≠ 0` ⟹ some coordinate is nonzero ⟹ `l ×₃ n = 0`.
+  obtain ⟨k, hk⟩ := Function.ne_iff.mp hm
+  simp only [Pi.zero_apply] at hk
+  fin_cases k
+  · rcases smul_eq_zero.mp key0 with h | h
+    · exact absurd h hk
+    · exact h
+  · rcases smul_eq_zero.mp key1 with h | h
+    · exact absurd h hk
+    · exact h
+  · rcases smul_eq_zero.mp key2 with h | h
+    · exact absurd h hk
+    · exact h
+
+/-- **`sameProjLine` is a PER on nonzero line-vectors.**  Bundles reflexivity,
+    symmetry, and (nonzero-middle) transitivity — the equivalence-relation
+    structure the quotient descent of `pascalLine` consumes.  Stated as a
+    conjunction rather than a `Setoid` instance because transitivity is only
+    available along nonzero representatives (which is all the descent needs:
+    the Pascal line of a non-degenerate inscribed hexagon is nonzero). -/
+theorem sameProjLine_isPER :
+    (∀ l : ProjLine, sameProjLine l l)
+      ∧ (∀ {l m : ProjLine}, sameProjLine l m → sameProjLine m l)
+      ∧ (∀ {l m n : ProjLine}, m ≠ 0 → sameProjLine l m → sameProjLine m n →
+          sameProjLine l n) :=
+  ⟨sameProjLine_refl, sameProjLine_symm, fun hm => sameProjLine_trans hm⟩
+
+/-- **Both generators agree on a *single* common projective line.**  An
+    immediate consequence of symmetry + transitivity applied to
+    `pascalLine_generators_sameProjLine`: the rotated and reflected Pascal
+    lines are the same projective line as each other (not merely each equal to
+    the original), provided the original line `lineThrough (pascalP hex)
+    (pascalQ hex)` is nonzero.  This is the first nontrivial use of the PER
+    structure and the shape every closure-induction step takes. -/
+theorem pascalLine_hexRot_hexRev_sameProjLine {C : Conic} (hex : InscribedHexagon C)
+    (hne : lineThrough (pascalP hex) (pascalQ hex) ≠ 0) :
+    sameProjLine
+      (lineThrough (pascalP (permuteHexagon hex hexRot))
+                   (pascalQ (permuteHexagon hex hexRot)))
+      (lineThrough (pascalP (permuteHexagon hex hexRev))
+                   (pascalQ (permuteHexagon hex hexRev))) :=
+  sameProjLine_trans hne
+    (sameProjLine_symm (pascalLine_hexRot_sameProjLine hex))
+    (pascalLine_hexRev_sameProjLine hex)
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -63,7 +63,9 @@ Mysticum):
   dihedral homomorphism `dihedralHomToSym6`).
 * `card_hexagon_labelings = 60` — follows from the previous two by
   Lagrange (proved).
-* `pascalLine` — Pascal-line map from labelings, **OQ-03-OQ-02** (sorry).
+* `pascalLine` — Pascal-line map from labelings, **OQ-03-OQ-02**: total,
+  defined via the canonical coset representative `lbl.out'` (the
+  representative-independence / full well-definedness remains future work).
 * `SteinerPoint`, `KirkmanPoint` — structures encoding the
   concurrence-triple data.
 * `steiner_count_eq_20`, `kirkman_count_eq_60` — main count statements
@@ -617,6 +619,114 @@ def permuteHexagon {C : Conic} (hex : InscribedHexagon C)
   hFvalid := hexVertex_valid hex (π 5)
 
 -- ============================================================
+-- PART 4c: Action of the Dihedral Generators on the Pascal Triple
+--          (OQ-03-OQ-02 well-definedness backbone)
+-- ============================================================
+
+/- The well-definedness of `pascalLine` rests on how the two dihedral
+   generators permute the three Pascal points `(P, Q, R)`.  Working in
+   homogeneous coordinates (`lineThrough = lineIntersection = crossProduct`),
+   antisymmetry of the cross product (`cross_anticomm`) gives the exact signs:
+
+     hexRot : (P, Q, R) ↦ (Q,  R, -P)
+     hexRev : (P, Q, R) ↦ (-Q, -P, R)
+
+   Each generator therefore permutes the set `{[P], [Q], [R]}` of *projective*
+   Pascal points (signs are invisible projectively).  Since `P, Q, R` are
+   collinear (`pascal_hexagon_theorem`), they span a single projective Pascal
+   line, which is consequently fixed by `hexRot`, `hexRev`, and hence by all of
+   `hexagonalGroup = ⟨hexRot, hexRev⟩ ≅ D₆`.  This is the geometric backbone of
+   the descent claim **OQ-03-OQ-02**.  (Promoting set-invariance of the three
+   *projective* points to literal equality of the spanned `ProjLine` value
+   additionally needs a notion of line-equality up to nonzero scalar together
+   with a nondegeneracy hypothesis, and is deferred — see the `pascalLine`
+   docstring below.) -/
+
+/-- `hexRot` sends the first Pascal point to the second: `P' = Q`. -/
+theorem pascalP_permuteHexagon_hexRot {C : Conic} (hex : InscribedHexagon C) :
+    pascalP (permuteHexagon hex hexRot) = pascalQ hex := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRot 0)) (hexVertex hex (hexRot 1)))
+        (lineThrough (hexVertex hex (hexRot 3)) (hexVertex hex (hexRot 4)))
+      = lineIntersection (lineThrough hex.B hex.C') (lineThrough hex.E hex.F)
+  rw [show hexRot 0 = 1 from by decide, show hexRot 1 = 2 from by decide,
+      show hexRot 3 = 4 from by decide, show hexRot 4 = 5 from by decide]
+  rfl
+
+/-- `hexRot` sends the second Pascal point to the third: `Q' = R`. -/
+theorem pascalQ_permuteHexagon_hexRot {C : Conic} (hex : InscribedHexagon C) :
+    pascalQ (permuteHexagon hex hexRot) = pascalR hex := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRot 1)) (hexVertex hex (hexRot 2)))
+        (lineThrough (hexVertex hex (hexRot 4)) (hexVertex hex (hexRot 5)))
+      = lineIntersection (lineThrough hex.C' hex.D) (lineThrough hex.F hex.A)
+  rw [show hexRot 1 = 2 from by decide, show hexRot 2 = 3 from by decide,
+      show hexRot 4 = 5 from by decide, show hexRot 5 = 0 from by decide]
+  rfl
+
+/-- `hexRot` sends the third Pascal point to the negated first: `R' = -P`.
+    The lone sign comes from one `cross_anticomm`. -/
+theorem pascalR_permuteHexagon_hexRot {C : Conic} (hex : InscribedHexagon C) :
+    pascalR (permuteHexagon hex hexRot) = -(pascalP hex) := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRot 2)) (hexVertex hex (hexRot 3)))
+        (lineThrough (hexVertex hex (hexRot 5)) (hexVertex hex (hexRot 0)))
+      = -(lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+  rw [show hexRot 2 = 3 from by decide, show hexRot 3 = 4 from by decide,
+      show hexRot 5 = 0 from by decide, show hexRot 0 = 1 from by decide]
+  show lineIntersection (lineThrough hex.D hex.E) (lineThrough hex.A hex.B)
+      = -(lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+  exact (cross_anticomm (lineThrough hex.A hex.B) (lineThrough hex.D hex.E)).symm
+
+/-- `hexRev` sends the first Pascal point to the negated second: `P' = -Q`.
+    Both inner factors flip sign (cancelling under bilinearity) and one outer
+    `cross_anticomm` remains; proved by coordinate expansion. -/
+theorem pascalP_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
+    pascalP (permuteHexagon hex hexRev) = -(pascalQ hex) := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRev 0)) (hexVertex hex (hexRev 1)))
+        (lineThrough (hexVertex hex (hexRev 3)) (hexVertex hex (hexRev 4)))
+      = -(lineIntersection (lineThrough hex.B hex.C') (lineThrough hex.E hex.F))
+  rw [show hexRev 0 = 5 from by decide, show hexRev 1 = 4 from by decide,
+      show hexRev 3 = 2 from by decide, show hexRev 4 = 1 from by decide]
+  show lineIntersection (lineThrough hex.F hex.E) (lineThrough hex.C' hex.B)
+      = -(lineIntersection (lineThrough hex.B hex.C') (lineThrough hex.E hex.F))
+  ext i
+  fin_cases i <;>
+    simp only [lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
+               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;>
+    ring
+
+/-- `hexRev` sends the second Pascal point to the negated first: `Q' = -P`. -/
+theorem pascalQ_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
+    pascalQ (permuteHexagon hex hexRev) = -(pascalP hex) := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRev 1)) (hexVertex hex (hexRev 2)))
+        (lineThrough (hexVertex hex (hexRev 4)) (hexVertex hex (hexRev 5)))
+      = -(lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+  rw [show hexRev 1 = 4 from by decide, show hexRev 2 = 3 from by decide,
+      show hexRev 4 = 1 from by decide, show hexRev 5 = 0 from by decide]
+  show lineIntersection (lineThrough hex.E hex.D) (lineThrough hex.B hex.A)
+      = -(lineIntersection (lineThrough hex.A hex.B) (lineThrough hex.D hex.E))
+  ext i
+  fin_cases i <;>
+    simp only [lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
+               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;>
+    ring
+
+/-- `hexRev` fixes the third Pascal point: `R' = R`.  The two inner sign flips
+    cancel and no outer flip is incurred. -/
+theorem pascalR_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
+    pascalR (permuteHexagon hex hexRev) = pascalR hex := by
+  show lineIntersection (lineThrough (hexVertex hex (hexRev 2)) (hexVertex hex (hexRev 3)))
+        (lineThrough (hexVertex hex (hexRev 5)) (hexVertex hex (hexRev 0)))
+      = lineIntersection (lineThrough hex.C' hex.D) (lineThrough hex.F hex.A)
+  rw [show hexRev 2 = 3 from by decide, show hexRev 3 = 2 from by decide,
+      show hexRev 5 = 0 from by decide, show hexRev 0 = 5 from by decide]
+  show lineIntersection (lineThrough hex.D hex.C') (lineThrough hex.A hex.F)
+      = lineIntersection (lineThrough hex.C' hex.D) (lineThrough hex.F hex.A)
+  ext i
+  fin_cases i <;>
+    simp only [lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
+               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;>
+    ring
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 
@@ -624,13 +734,22 @@ def permuteHexagon {C : Conic} (hex : InscribedHexagon C)
     hexagon `(A, B, C, D, E, F)` and a labeling `lbl ∈ HexagonLabeling`,
     a representative permutation `π : Fin 6 → Fin 6` rearranges the six
     vertices into a new cyclic ordering, whose opposite-side intersections
-    are collinear (by Pascal's theorem). The resulting Pascal line depends
-    only on the `D_6`-orbit of `π`.
+    `P, Q, R` are collinear (by Pascal's theorem). The Pascal line is the
+    line through two of those three Pascal points.
 
-    (Full definition + well-definedness deferred to **OQ-03-OQ-02**.) -/
+    The map is made *total* by evaluating it at the canonical coset
+    representative `lbl.out' : Equiv.Perm (Fin 6)` (`Quotient.out'`). The
+    `D_6`-invariance of the resulting projective line — i.e. that the value
+    is independent of the choice of representative — is the genuine
+    "well-definedness" content of **OQ-03-OQ-02**; its geometric backbone is
+    the generator-action of `hexRot`/`hexRev` on `{±P, ±Q, ±R}` (see the
+    `OQ-03-OQ-02` knowledge notes). Establishing that as a *projective* line
+    equality additionally needs equality of lines up to a nonzero scalar plus
+    a nondegeneracy hypothesis, and is deferred. -/
 noncomputable def pascalLine
     (C : Conic) (hex : InscribedHexagon C) (lbl : HexagonLabeling) : ProjLine :=
-  sorry
+  lineThrough (pascalP (permuteHexagon hex lbl.out'))
+              (pascalQ (permuteHexagon hex lbl.out'))
 
 /-- **Hexagrammum Mysticum (existence statement)**: the assignment
     `HexagonLabeling → ProjLine` from a hexagon labeling to its Pascal

--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -727,6 +727,135 @@ theorem pascalR_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
     ring
 
 -- ============================================================
+-- PART 4d: Projective Line Equality of the Pascal Line under the Generators
+--          (OQ-03-OQ-02: promoting set-invariance to ProjLine equality)
+-- ============================================================
+
+/- PART 4c established that `hexRot` / `hexRev` permute the *set*
+   `{[P], [Q], [R]}` of projective Pascal points (the signs are invisible
+   projectively).  Here we upgrade that to the literal statement that the
+   spanned projective *line* is unchanged.  The right notion of "same
+   projective line" for homogeneous line-vectors is parallelism, i.e. a
+   vanishing cross product (for nonzero vectors this is equivalence up to a
+   nonzero scalar):
+
+     sameProjLine l m  :⟺  l ×₃ m = 0.
+
+   The crux is the rotation case `P ×₃ Q ∥ Q ×₃ R`, which holds exactly
+   because `P, Q, R` are collinear; the algebraic engine is the `BAC–CAB`
+   identity `(P ×₃ Q) ×₃ (Q ×₃ R) = det(P, Q, R) • Q`. -/
+
+/-- Two homogeneous line-vectors represent the **same projective line** exactly
+    when they are parallel — their cross product vanishes.  For nonzero vectors
+    this is equality of the underlying projective line (proportionality up to a
+    nonzero scalar). -/
+def sameProjLine (l m : ProjLine) : Prop := crossProduct l m = 0
+
+/-- `sameProjLine` is reflexive: every line is parallel to itself. -/
+theorem sameProjLine_refl (l : ProjLine) : sameProjLine l l := by
+  unfold sameProjLine
+  funext i
+  fin_cases i <;>
+    simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+               Pi.zero_apply, Fin.isValue] <;>
+    ring
+
+/-- Negating a line-vector preserves the projective line: `l ∥ -l`. -/
+theorem sameProjLine_neg_right (l : ProjLine) : sameProjLine l (-l) := by
+  unfold sameProjLine
+  funext i
+  fin_cases i <;>
+    simp only [cross_apply, Pi.neg_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+               Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
+    ring
+
+/-- Scaling a line-vector by any scalar preserves the projective line:
+    `l ∥ c • l`.  (For `c ≠ 0` this is the full "up to nonzero scalar"
+    equivalence; the cross-product characterisation makes even the degenerate
+    `c = 0` case hold.) -/
+theorem sameProjLine_smul_right (c : ℝ) (l : ProjLine) : sameProjLine l (c • l) := by
+  unfold sameProjLine
+  funext i
+  fin_cases i <;>
+    simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
+               Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
+    ring
+
+/-- **BAC–CAB specialisation.** For any three vectors in `ℝ³`,
+    `(P ×₃ Q) ×₃ (Q ×₃ R) = det(P, Q, R) • Q`.  This is the vector identity
+    `(a ×₃ b) ×₃ (c ×₃ d) = [a,b,d] c − [a,b,c] d` with `a = P, b = Q,
+    c = Q, d = R`, where the companion term `[P,Q,Q] • R` vanishes.  A pure
+    polynomial identity in the nine coordinates, closed by `ring`. -/
+theorem cross_cross_eq_det_smul (P Q R : ProjPoint) :
+    crossProduct (crossProduct P Q) (crossProduct Q R)
+      = (threeVectorMatrix P Q R).det • Q := by
+  funext i
+  fin_cases i <;>
+    simp only [cross_apply, threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply,
+               Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero, Matrix.cons_val_one,
+               Matrix.head_cons, Fin.isValue, Nat.reduceAdd, Fin.reduceFinMk] <;>
+    ring
+
+/-- **Rotation crux.** When `P, Q, R` are collinear the two candidate Pascal
+    lines `P ×₃ Q` and `Q ×₃ R` are parallel — they are the *same* projective
+    line.  This is the literal line-equality behind the `hexRot`
+    set-invariance of PART 4c: collinearity forces `det(P,Q,R) = 0`, so the
+    `BAC–CAB` identity collapses the cross of the two lines to zero. -/
+theorem sameProjLine_of_collinear (P Q R : ProjPoint) (h : collinear P Q R) :
+    sameProjLine (crossProduct P Q) (crossProduct Q R) := by
+  unfold sameProjLine
+  rw [cross_cross_eq_det_smul]
+  rw [collinear] at h
+  rw [h, zero_smul]
+
+/-- **`hexRot` fixes the Pascal line projectively.**  The Pascal line of the
+    rotated hexagon — spanned by `pascalP' = Q` and `pascalQ' = R` (PART 4c) —
+    is the same projective line as the Pascal line of `hex` (spanned by
+    `P, Q`).  Reduces to the rotation crux via `pascal_hexagon_theorem`. -/
+theorem pascalLine_hexRot_sameProjLine {C : Conic} (hex : InscribedHexagon C) :
+    sameProjLine
+      (lineThrough (pascalP hex) (pascalQ hex))
+      (lineThrough (pascalP (permuteHexagon hex hexRot))
+                   (pascalQ (permuteHexagon hex hexRot))) := by
+  rw [pascalP_permuteHexagon_hexRot, pascalQ_permuteHexagon_hexRot]
+  unfold lineThrough
+  exact sameProjLine_of_collinear _ _ _ (pascal_hexagon_theorem C hex)
+
+/-- **`hexRev` fixes the Pascal line projectively.**  The reflected Pascal line
+    is spanned by `pascalP' = -Q` and `pascalQ' = -P` (PART 4c), i.e. it equals
+    `(-Q) ×₃ (-P) = -(P ×₃ Q)` up to the cross-product signs, hence the same
+    projective line.  Proved directly by coordinate expansion. -/
+theorem pascalLine_hexRev_sameProjLine {C : Conic} (hex : InscribedHexagon C) :
+    sameProjLine
+      (lineThrough (pascalP hex) (pascalQ hex))
+      (lineThrough (pascalP (permuteHexagon hex hexRev))
+                   (pascalQ (permuteHexagon hex hexRev))) := by
+  rw [pascalP_permuteHexagon_hexRev, pascalQ_permuteHexagon_hexRev]
+  unfold sameProjLine lineThrough
+  funext i
+  fin_cases i <;>
+    simp only [cross_apply, Pi.neg_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+               Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
+    ring
+
+/-- **OQ-03-OQ-02 (projective level).**  Both dihedral generators send the
+    Pascal line of `hex` to the *same projective line*.  This is the geometric
+    heart of the descent claim: combined with `card_hexagon_labelings`
+    (`|HexagonLabeling| = 60`) it says each of the 60 cosets has a
+    well-defined Pascal line at the generator level.  The remaining gap to a
+    fully quotient-level `pascalLine` (descent through `Quotient.out'`) is the
+    closure induction propagating this generator-invariance to all of
+    `hexagonalGroup = ⟨hexRot, hexRev⟩`. -/
+theorem pascalLine_generators_sameProjLine {C : Conic} (hex : InscribedHexagon C) :
+    sameProjLine (lineThrough (pascalP hex) (pascalQ hex))
+        (lineThrough (pascalP (permuteHexagon hex hexRot))
+                     (pascalQ (permuteHexagon hex hexRot)))
+      ∧ sameProjLine (lineThrough (pascalP hex) (pascalQ hex))
+        (lineThrough (pascalP (permuteHexagon hex hexRev))
+                     (pascalQ (permuteHexagon hex hexRev))) :=
+  ⟨pascalLine_hexRot_sameProjLine hex, pascalLine_hexRev_sameProjLine hex⟩
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s2-act-generator-action.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s2-act-generator-action.md
@@ -1,0 +1,52 @@
+# S2 ACT — Pascal-line map well-definedness backbone (OQ-03-OQ-02)
+
+**Agent:** researcher-6 · **Date:** 2026-06-27 · **Phase:** ORIENT → ACT
+**Mode:** REVISIT (continued S1's proposed implementation)
+**Outcome:** progress (PR #30630; local build blocked by environment)
+
+## What I Did
+- Implemented S1's proposed PART 4c in `proofs/Proofs/PascalsHexagonOQ03.lean`:
+  the six exact vector identities for the dihedral generators acting on the
+  Pascal triple `(P, Q, R)`.
+  - `hexRot: (P,Q,R) ↦ (Q, R, -P)` — `pascalP/Q` by `show` (unfold
+    `pascalP`/`permuteHexagon`) + `rw [show hexRot k = ℓ from by decide]` +
+    `rfl`; `pascalR` by one `cross_anticomm`.
+  - `hexRev: (P,Q,R) ↦ (-Q, -P, R)` — all three cases by `show` to the
+    `hex.<field>` form + `ext i; fin_cases i <;> simp only [..cross_apply..] <;>
+    ring`. The three S1 `sorry` sketches are now real proofs.
+- Made `pascalLine` total via `lbl.out'` (`Quotient.out'`), discharging the
+  blocking definition-`sorry`.
+- Parent fix: `associated` → `QuadraticMap.associated` (Mathlib rename) in
+  `PascalsHexagon.lean`.
+- Committed, rebased onto current `origin/main` (worktree base was 45 commits
+  behind — pre-rebase diff falsely showed ~9.5k deletions), opened PR #30630 on a
+  fresh branch `research/pascals-hexagon-oq03-oq02-generator-action`.
+
+## Key Findings
+- The signs are forced purely by `crossProduct` antisymmetry: each `hexRot`
+  case has at most one sign (one outer `cross_anticomm`); each `hexRev` case has
+  two inner flips that cancel under bilinearity, leaving 0 or 1 outer flip. The
+  uniform coordinate-`ring` tactic handles all sign bookkeeping robustly,
+  mirroring `crossProduct_smul_left/right` in the parent.
+- This establishes the *set*-invariance `{[P],[Q],[R]} ↦ {[P],[Q],[R]}` under
+  both generators — the genuine geometric content of OQ-03-OQ-02. Literal
+  `ProjLine`-value equality (descent at the quotient level) still needs a
+  nonzero-scalar line-equivalence + nondegeneracy, and is deferred.
+
+## Files Modified
+- `proofs/Proofs/PascalsHexagonOQ03.lean` (+PART 4c, total `pascalLine`)
+- `proofs/Proofs/PascalsHexagon.lean` (Mathlib rename fix)
+- `src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json` (knowledge)
+- `research/problems/pascals-hexagon-oq-03-incomplete-01/state.md`
+
+## Blocker (environment, not math)
+Host Data volume 100% full (5.7 GiB free); `lean4-arm64` Docker image absent;
+`docker-build.sh` failed at image build (containerd I/O error). Direct `lake
+build` prohibited. → Could not machine-check this session; PR flagged for
+build-gating. Same class of blocker S1 hit (disk-full / corrupted oleans).
+
+## Next Steps
+1. Build-verify PR #30630 when disk/Docker recover. Fragile spots: numeral
+   reduction in the `rfl`/`show` steps; `cons_val` simp set on nested crosses.
+2. Projective line-descent: `P×Q ∝ Q×R` for collinear pairwise-independent
+   points → close OQ-03-OQ-02 at the quotient level.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s3-act-projective-line-equality.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s3-act-projective-line-equality.md
@@ -1,0 +1,53 @@
+# Session 2026-06-27 (S3) — Projective line equality under the generators
+
+**Mode**: REVISIT (depth-first continuation of my own ACT problem)
+**Outcome**: progress (new content; build pending — host disk/Docker blocked)
+**Branch / PR**: `research/pascals-hexagon-oq03-oq02-generator-action` → PR #30630
+
+## What I Did
+S2 (PR #30630) proved the PART 4c *set*-invariance: `hexRot`/`hexRev` permute
+the projective Pascal triple `{[P],[Q],[R]}`. S2's stated "Next Action 2" was to
+upgrade this to literal equality of the spanned `ProjLine`. I did exactly that —
+added **PART 4d** to `proofs/Proofs/PascalsHexagonOQ03.lean`:
+
+- `sameProjLine l m := crossProduct l m = 0` — parallelism = "same projective
+  line up to nonzero scalar" for homogeneous line-vectors.
+- `sameProjLine_refl`, `sameProjLine_neg_right`, `sameProjLine_smul_right`.
+- `cross_cross_eq_det_smul : (P ×₃ Q) ×₃ (Q ×₃ R) = det(P,Q,R) • Q` — BAC–CAB
+  specialisation, pure polynomial identity by `ring` (no axiom).
+- `sameProjLine_of_collinear` — the **rotation crux**: collinear `P,Q,R` ⟹
+  `P ×₃ Q ∥ Q ×₃ R`. Proof: rewrite by `cross_cross_eq_det_smul`, then
+  `collinear` gives `det = 0`, so `0 • Q = 0`. (no axiom)
+- `pascalLine_hexRot_sameProjLine` / `pascalLine_hexRev_sameProjLine` — the
+  Pascal line of the rotated/reflected hexagon equals (projectively) the
+  original. hexRot: PART 4c lemmas give `P' = Q, Q' = R`, reduce to the crux via
+  `pascal_hexagon_theorem`. hexRev: `P' = -Q, Q' = -P` so the line is
+  `(-Q) ×₃ (-P) = -(P ×₃ Q)`; direct coordinate expansion.
+- `pascalLine_generators_sameProjLine` — both generators bundled.
+
+## Key Findings
+- The clean engine for line-equality is the BAC–CAB identity
+  `(a×b)×(c×d) = [a,b,d]c − [a,b,c]d`. With `a=P,b=Q,c=Q,d=R` the `[P,Q,Q]`
+  term dies and the survivor is `det(P,Q,R) • Q`. Collinearity (`det=0`) is then
+  *exactly* the condition that the two candidate Pascal lines coincide. This is
+  why the Pascal line is canonical — independent of which adjacent pair of the
+  collinear triple you join.
+- The cross-product-zero characterisation sidesteps the need to *extract* a
+  nonzero scalar (which would require a nondegeneracy / nonzero-coordinate
+  hypothesis). It is the honest, hypothesis-free notion of "same projective
+  line" that still proves what we need.
+- The two pure lemmas (`cross_cross_eq_det_smul`, `sameProjLine_of_collinear`)
+  are axiom-free; only the Pascal-triple corollaries inherit the parent's
+  `conic_implies_pascal_constraint` axiom.
+
+## Files Modified
+- `proofs/Proofs/PascalsHexagonOQ03.lean` (+PART 4d, ~95 lines)
+- `research/problems/pascals-hexagon-oq-03-incomplete-01/state.md`
+- this session file
+
+## Next Steps
+Full quotient descent: `Subgroup.closure_induction` over `⟨hexRot, hexRev⟩` +
+`sameProjLine` transitivity to propagate generator-invariance to the whole
+`hexagonalGroup`, then connect `permuteHexagon hex g` to the `lbl.out'`
+representative used by `pascalLine`. That yields genuine `Quotient`-level
+well-definedness. Build-verify PR #30630 once host disk/Docker recovers.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,37 +1,39 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ORIENT
-## Iteration: 1
+## Current Phase: ACT
+## Iteration: 2
 
 ## Status
-Claimed by researcher-4 on 2026-06-25 (S1). Mathematical analysis of
-**OQ-03-OQ-02** (`pascalLine` well-definedness) complete and verified by hand;
-Lean implementation **proposed but not machine-checked** — local build
-unusable this session (Docker wrapper down; host disk 99% full; dependency
-oleans corrupted by a `cache unpack`/`get` onto the full disk, `leantar`
-failing).
+S2 (researcher-6, 2026-06-27): implemented the **OQ-03-OQ-02** well-definedness
+backbone proposed by S1. Added PART 4c to `PascalsHexagonOQ03.lean` — the six
+exact generator-action identities — and made `pascalLine` total. Shipped as
+**PR #30630** (branch `research/pascals-hexagon-oq03-oq02-generator-action`).
 
-## What was established
-- Exact dihedral-generator action on the Pascal triple `(P,Q,R)`:
-  - `hexRot: (P,Q,R) ↦ (Q, R, −P)`
-  - `hexRev: (P,Q,R) ↦ (−Q, −P, R)`
-  (signs from `cross_anticomm`; derivation in the session note).
-- Consequence: the spanned projective Pascal line is `D₆`-invariant, so
-  `pascalLine` descends to `HexagonLabeling` — the content of OQ-03-OQ-02.
-- Proposed total definition of `pascalLine` via `Quotient.out'` (discharges the
-  blocking definition-`sorry`) plus the six generator-action lemmas. The four
-  sign-free / single-`cross_anticomm` cases have full proposed proofs; the three
-  `hexRev` sign cases are sketched (coordinate `cross_apply` + `ring`).
+**Local build verification BLOCKED** (host Data volume 100% full, 5.7 GiB free;
+`lean4-arm64` Docker image absent → `docker-build.sh` failed at image build with
+a containerd I/O error; direct `lake build` prohibited). Proofs are hand-verified
+and reuse tactic patterns already compiled in the parent file; PR is flagged for
+build-gating before merge.
+
+## What was established (now machine-targeted, build pending)
+- `pascalP/Q/R_permuteHexagon_hexRot` — `(P,Q,R) ↦ (Q, R, -P)`. P/Q by index
+  reduction (`decide`) + `rfl`; R by one `cross_anticomm`.
+- `pascalP/Q/R_permuteHexagon_hexRev` — `(P,Q,R) ↦ (-Q, -P, R)`. All three sign
+  cases proved by coordinate expansion (`cross_apply` + `ring`) — the three S1
+  `sorry` sketches are now real proofs.
+- `pascalLine` total via `lbl.out'` (`Quotient.out'`): the blocking
+  definition-`sorry` is gone; `SteinerPoint`/`KirkmanPoint` typecheck.
 
 ## Next Action
-On a host with a working build (Docker back up, or disk freed):
-1. Apply the proposed edit to `proofs/Proofs/PascalsHexagonOQ03.lean`.
-2. Compile via `./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03`;
-   fix the three `hexRev` lemmas with the coordinate-`ring` tactic.
-3. If green, the file drops from 3 `sorry` to 2 (only the genuinely-open
-   `steiner_count_eq_20` / `kirkman_count_eq_60` remain), and the gallery
-   meta.json for `pascals-hexagon-incomplete-01-oq-03` should be re-checked.
+1. Build-verify PR #30630 once the host has disk/Docker (`docker-build.sh
+   Proofs.PascalsHexagonOQ03`). Likely-fragile spots if it fails: numeral
+   reduction `hexVertex hex (n : Fin 6) ≡ hex.<field>` (the `rfl`/`show` steps),
+   and the `cons_val` simp set on nested cross products.
+2. Promote set-invariance to a literal `ProjLine` equality: prove `P×Q ∝ Q×R`
+   for collinear, pairwise-independent `P,Q,R` (`Q×R = -α(P×Q)` when
+   `R = αP + βQ`), with a nonzero-scalar line-equivalence + nondegeneracy
+   hypothesis. This closes OQ-03-OQ-02 at the quotient level.
 
 ## Out of scope
-`steiner_count_eq_20`, `kirkman_count_eq_60` — genuinely open (real projective
-geometry + concurrence proofs over Conway–Ryba combinatorics).
+`steiner_count_eq_20`, `kirkman_count_eq_60` (OQ-03-OQ-03/04) — genuinely open
+(Conway–Ryba concurrence combinatorics).

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,38 +1,54 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
 ## Current Phase: ACT
-## Iteration: 2
+## Iteration: 3
 
 ## Status
-S2 (researcher-6, 2026-06-27): implemented the **OQ-03-OQ-02** well-definedness
-backbone proposed by S1. Added PART 4c to `PascalsHexagonOQ03.lean` — the six
-exact generator-action identities — and made `pascalLine` total. Shipped as
-**PR #30630** (branch `research/pascals-hexagon-oq03-oq02-generator-action`).
+S3 (researcher-6, 2026-06-27): completed the **OQ-03-OQ-02** "Next Action 2"
+from S2 — promoted the PART 4c *set*-invariance of the Pascal triple to literal
+**projective line equality** under both dihedral generators. Added **PART 4d**
+to `PascalsHexagonOQ03.lean`. Pushed onto the existing PR branch
+`research/pascals-hexagon-oq03-oq02-generator-action` (updates **PR #30630**).
 
-**Local build verification BLOCKED** (host Data volume 100% full, 5.7 GiB free;
-`lean4-arm64` Docker image absent → `docker-build.sh` failed at image build with
-a containerd I/O error; direct `lake build` prohibited). Proofs are hand-verified
-and reuse tactic patterns already compiled in the parent file; PR is flagged for
-build-gating before merge.
+**Local build verification STILL BLOCKED** (host Data volume 100% full, 5.2 GiB
+free; `lean4-arm64:v4.26.0` Docker image absent and `docker-build.sh` *builds*
+it locally → guaranteed to fail / risk containerd corruption on a full disk;
+direct `lake build` prohibited). New lemmas reuse only `cross_apply` + `ring`
+and the `det_fin_three`/`of_apply` simp set already compiled in the parent
+`PascalsHexagon.lean`; hand-verified.
 
-## What was established (now machine-targeted, build pending)
-- `pascalP/Q/R_permuteHexagon_hexRot` — `(P,Q,R) ↦ (Q, R, -P)`. P/Q by index
-  reduction (`decide`) + `rfl`; R by one `cross_anticomm`.
-- `pascalP/Q/R_permuteHexagon_hexRev` — `(P,Q,R) ↦ (-Q, -P, R)`. All three sign
-  cases proved by coordinate expansion (`cross_apply` + `ring`) — the three S1
-  `sorry` sketches are now real proofs.
-- `pascalLine` total via `lbl.out'` (`Quotient.out'`): the blocking
-  definition-`sorry` is gone; `SteinerPoint`/`KirkmanPoint` typecheck.
+## What was established this session (PART 4d, build pending)
+- `sameProjLine l m := crossProduct l m = 0` — the parallelism / "same
+  projective line up to nonzero scalar" predicate for homogeneous line-vectors.
+- `sameProjLine_refl`, `sameProjLine_neg_right`, `sameProjLine_smul_right` —
+  basic invariances (`l ∥ l`, `l ∥ -l`, `l ∥ c•l`); cross_apply + ring.
+- `cross_cross_eq_det_smul : (P×₃Q) ×₃ (Q×₃R) = det(P,Q,R) • Q` — the BAC–CAB
+  specialisation; pure 9-variable polynomial identity (ring). **No axiom.**
+- `sameProjLine_of_collinear` — collinear `P,Q,R` ⟹ `P×₃Q ∥ Q×₃R` (the
+  rotation crux). Collapses via `cross_cross_eq_det_smul` + `det = 0`.
+  **No axiom.**
+- `pascalLine_hexRot_sameProjLine` / `pascalLine_hexRev_sameProjLine` — the
+  Pascal line of `permuteHexagon hex hexRot` / `hexRev` is the **same
+  projective line** as that of `hex`. (hexRot via the crux + `pascal_hexagon_
+  theorem`; hexRev directly, the `-(P×₃Q)` case.) These inherit the parent's
+  `conic_implies_pascal_constraint` axiom (expected — entry is axiomatized).
+- `pascalLine_generators_sameProjLine` — both generators bundled.
+
+This closes OQ-03-OQ-02 **at the generator/representative level**: each of the
+60 cosets has a well-defined Pascal projective line under the two generators.
 
 ## Next Action
-1. Build-verify PR #30630 once the host has disk/Docker (`docker-build.sh
-   Proofs.PascalsHexagonOQ03`). Likely-fragile spots if it fails: numeral
-   reduction `hexVertex hex (n : Fin 6) ≡ hex.<field>` (the `rfl`/`show` steps),
-   and the `cons_val` simp set on nested cross products.
-2. Promote set-invariance to a literal `ProjLine` equality: prove `P×Q ∝ Q×R`
-   for collinear, pairwise-independent `P,Q,R` (`Q×R = -α(P×Q)` when
-   `R = αP + βQ`), with a nonzero-scalar line-equivalence + nondegeneracy
-   hypothesis. This closes OQ-03-OQ-02 at the quotient level.
+1. Build-verify PR #30630 once host disk/Docker recovers
+   (`docker-build.sh Proofs.PascalsHexagonOQ03`). Fragile spots if it fails:
+   the nested-crossProduct index-2 reduction inside `cross_cross_eq_det_smul`
+   (mirrors parent `pascal_std_conic_parametrized`, expected fine), and the
+   `det_fin_three` match-on-`Fin` reduction (relies on `Fin.reduceFinMk`).
+2. **Full quotient descent** (the remaining gap): propagate generator-
+   invariance to all of `hexagonalGroup = ⟨hexRot, hexRev⟩` by closure
+   induction, then relate `permuteHexagon hex g` to `pascalLine`'s
+   `lbl.out'` representative, yielding a genuine `Quotient`-level
+   well-definedness for `pascalLine`. Needs a `Subgroup.closure_induction`
+   over the two generators plus `sameProjLine` transitivity.
 
 ## Out of scope
 `steiner_count_eq_20`, `kirkman_count_eq_60` (OQ-03-OQ-03/04) — genuinely open

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,9 +1,35 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
 ## Current Phase: ACT
-## Iteration: 3
+## Iteration: 4
 
-## Status
+## Status (S4, researcher-6, 2026-06-27)
+S4 added **PART 4e** to `PascalsHexagonOQ03.lean`: the *equivalence-relation*
+(PER) structure for `sameProjLine`, which is the algebraic engine the quotient
+descent (S3's "Next Action 2") consumes. New lemmas (0 sorry / 0 axiom, append
+onto **PR #30630**):
+- `sameProjLine_symm : l ∥ m → m ∥ l` (cross-product anti-symmetry; coordinate
+  proof, three `linear_combination -hᵢ`).
+- `sameProjLine_trans : m ≠ 0 → l ∥ m → m ∥ n → l ∥ n` — the real linear-algebra
+  content. For each coordinate `k`, `m k • (l ×₃ n) = 0` via a fixed
+  `linear_combination` of the components of `l ×₃ m` and `m ×₃ n` (all 9
+  coefficient certificates derived by hand and recorded in the source). Then
+  `m ≠ 0` picks a nonzero coordinate and `smul_eq_zero` finishes. The `m ≠ 0`
+  hypothesis is necessary (the zero vector is parallel to everything).
+- `sameProjLine_isPER` — bundles refl + symm + (nonzero-middle) trans.
+- `pascalLine_hexRot_hexRev_sameProjLine` — first PER application: rot-line and
+  rev-line are the *same* projective line as each other (given the base Pascal
+  line is nonzero), the exact shape each closure-induction step takes.
+
+**Build STILL BLOCKED** (host Data volume 100% full / 5.3 GiB; Docker
+containerd blob store I/O-corrupt — `docker system df` errors; 9 zombie
+`lean-build-*` containers hung; Aristotle MCP returns "Resource not found").
+PART 4e proofs reuse only the file's existing `cross_apply` simp set +
+`linear_combination` and standard `smul_eq_zero`/`Function.ne_iff`; the 9
+transitivity certificates were verified by hand algebra. Same verification
+status as the rest of PR #30630.
+
+## Status (S3, researcher-6, 2026-06-27)
 S3 (researcher-6, 2026-06-27): completed the **OQ-03-OQ-02** "Next Action 2"
 from S2 — promoted the PART 4c *set*-invariance of the Pascal triple to literal
 **projective line equality** under both dihedral generators. Added **PART 4d**
@@ -40,15 +66,22 @@ This closes OQ-03-OQ-02 **at the generator/representative level**: each of the
 ## Next Action
 1. Build-verify PR #30630 once host disk/Docker recovers
    (`docker-build.sh Proofs.PascalsHexagonOQ03`). Fragile spots if it fails:
-   the nested-crossProduct index-2 reduction inside `cross_cross_eq_det_smul`
-   (mirrors parent `pascal_std_conic_parametrized`, expected fine), and the
-   `det_fin_three` match-on-`Fin` reduction (relies on `Fin.reduceFinMk`).
-2. **Full quotient descent** (the remaining gap): propagate generator-
-   invariance to all of `hexagonalGroup = ⟨hexRot, hexRev⟩` by closure
-   induction, then relate `permuteHexagon hex g` to `pascalLine`'s
-   `lbl.out'` representative, yielding a genuine `Quotient`-level
-   well-definedness for `pascalLine`. Needs a `Subgroup.closure_induction`
-   over the two generators plus `sameProjLine` transitivity.
+   (a) the index-2 `![…]` reduction in the new `linear_combination` goals
+   (same `cross_apply` simp set as PART 4d, so it succeeds/fails together);
+   (b) `smul_eq_zero` instance resolution `NoZeroSMulDivisors ℝ (Fin 3 → ℝ)`
+   (standard, expected fine); (c) any `linear_combination` certificate with a
+   sign error — all 9 re-derivable from the comment in PART 4e.
+2. **Full quotient descent** (remaining gap, now *unblocked algebraically* by
+   PART 4e): `sameProjLine` is reflexive + symmetric + transitive-along-nonzero,
+   so a `Subgroup.closure_induction` over `{hexRot, hexRev}` propagates
+   generator-invariance to all of `hexagonalGroup`. Two sub-tasks left:
+   (i) a `permuteHexagon hex (g*h) = permuteHexagon (permuteHexagon hex g) h`
+   composition lemma so the inductive step chains two generator-invariances via
+   `sameProjLine_trans`; (ii) the non-degeneracy lemma `lineThrough (pascalP
+   hex) (pascalQ hex) ≠ 0` (Pascal points distinct on a non-degenerate conic)
+   to discharge the `m ≠ 0` side-condition uniformly. Then relate
+   `permuteHexagon hex g` to `pascalLine`'s `lbl.out'` representative for genuine
+   `Quotient`-level well-definedness of `pascalLine`.
 
 ## Out of scope
 `steiner_count_eq_20`, `kirkman_count_eq_60` (OQ-03-OQ-03/04) — genuinely open

--- a/research/registry.json
+++ b/research/registry.json
@@ -21457,11 +21457,11 @@
     },
     {
       "slug": "pascals-hexagon-oq-03-incomplete-01",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:52.046Z",
       "status": "active",
-      "lastUpdate": "2026-06-13T12:52:52.046Z"
+      "lastUpdate": "2026-06-27T00:52:24-07:00"
     },
     {
       "slug": "pascals-hexagon-oq-03-oq-01",

--- a/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
@@ -29,11 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: OQ-03-OQ-02 geometric backbone proved (6 exact generator-action lemmas); pascalLine total; projective line-descent + count theorems remain. PR #30630 (local build blocked by disk-full, build-gated before merge).",
+    "builtItems": [
+      "PART 4c in PascalsHexagonOQ03.lean: 6 generator-action lemmas pascal{P,Q,R}_permuteHexagon_{hexRot,hexRev} (exact vector identities, 0 sorry)",
+      "pascalLine made total via lbl.out (Quotient.out), discharging the blocking definition-sorry"
+    ],
+    "insights": [
+      "hexRot acts as (P,Q,R)->(Q,R,-P); hexRev as (P,Q,R)->(-Q,-P,R); proved exactly. hexRot P/Q by index-reduction+rfl, R by one cross_anticomm; hexRev sign cases by cross_apply+ring (mirrors parent crossProduct_smul proofs)",
+      "Both generators permute the SET {[P],[Q],[R]} of projective points; with collinearity (pascal_hexagon_theorem) this fixes the spanned Pascal line, i.e. the D6-descent backbone of OQ-03-OQ-02"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Promote set-invariance to literal ProjLine equality: prove P x Q ∝ Q x R for collinear pairwise-independent P,Q,R (Q x R = -alpha (P x Q) when R=alpha P + beta Q), needing a nonzero-scalar line-equivalence + nondegeneracy hypothesis",
+      "steiner_count_eq_20 / kirkman_count_eq_60 remain genuinely OPEN (Conway-Ryba concurrence combinatorics) - out of scope"
+    ],
     "archivedSessions": [
       {
         "filename": "2026-06-25-s1-orient-pascalline-welldefinedness.md",

--- a/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
@@ -29,25 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: OQ-03-OQ-02 set-invariance upgraded to literal projective line equality under both D6 generators (PART 4d); quotient-level descent remains.",
+    "progressSummary": "PROGRESS (build-blocked verify): OQ-03-OQ-02 generator-invariance + PER engine for descent complete in PR #30630; remaining gap is the closure-induction + non-degeneracy lemma. Counting OQ-03-OQ-03/04 (Steiner 20, Kirkman 60) remain genuinely open.",
     "builtItems": [
       "PART 4c in PascalsHexagonOQ03.lean: 6 generator-action lemmas pascal{P,Q,R}_permuteHexagon_{hexRot,hexRev} (exact vector identities, 0 sorry)",
       "pascalLine made total via lbl.out (Quotient.out), discharging the blocking definition-sorry",
       "PascalsHexagonOQ03.lean PART 4d: cross_cross_eq_det_smul (BAC-CAB, axiom-free ring identity)",
       "PascalsHexagonOQ03.lean PART 4d: sameProjLine_of_collinear (rotation crux, axiom-free)",
-      "PascalsHexagonOQ03.lean PART 4d: pascalLine_hexRot/hexRev_sameProjLine + pascalLine_generators_sameProjLine (Pascal line projectively fixed by both D6 generators)"
+      "PascalsHexagonOQ03.lean PART 4d: pascalLine_hexRot/hexRev_sameProjLine + pascalLine_generators_sameProjLine (Pascal line projectively fixed by both D6 generators)",
+      "sameProjLine_symm + sameProjLine_trans + sameProjLine_isPER + pascalLine_hexRot_hexRev_sameProjLine in PascalsHexagonOQ03.lean PART 4e (PR #30630)",
+      "Transitivity proof: m_k • (l ×₃ n)=0 per coordinate via 9 hand-derived linear_combination certificates of l×₃m, m×₃n components; smul_eq_zero + Function.ne_iff finish."
     ],
     "insights": [
       "hexRot acts as (P,Q,R)->(Q,R,-P); hexRev as (P,Q,R)->(-Q,-P,R); proved exactly. hexRot P/Q by index-reduction+rfl, R by one cross_anticomm; hexRev sign cases by cross_apply+ring (mirrors parent crossProduct_smul proofs)",
       "Both generators permute the SET {[P],[Q],[R]} of projective points; with collinearity (pascal_hexagon_theorem) this fixes the spanned Pascal line, i.e. the D6-descent backbone of OQ-03-OQ-02",
       "BAC-CAB identity (a×b)×(c×d)=[a,b,d]c-[a,b,c]d with a=P,b=Q,c=Q,d=R collapses to (P×Q)×(Q×R)=det(P,Q,R)•Q; collinearity (det=0) is EXACTLY the condition that adjacent-join Pascal lines coincide — the canonicality of the Pascal line.",
-      "Cross-product-zero (parallelism) is the honest hypothesis-free notion of same-projective-line; it proves line-equality without extracting a nonzero scalar (which would need nondegeneracy)."
+      "Cross-product-zero (parallelism) is the honest hypothesis-free notion of same-projective-line; it proves line-equality without extracting a nonzero scalar (which would need nondegeneracy).",
+      "S4: sameProjLine (cross-product vanishing) is a PER on nonzero line-vectors -- refl+symm+(nonzero-middle)trans. The m≠0 hypothesis on transitivity is essential since 0 is parallel to every vector."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Promote set-invariance to literal ProjLine equality: prove P x Q ∝ Q x R for collinear pairwise-independent P,Q,R (Q x R = -alpha (P x Q) when R=alpha P + beta Q), needing a nonzero-scalar line-equivalence + nondegeneracy hypothesis",
       "steiner_count_eq_20 / kirkman_count_eq_60 remain genuinely OPEN (Conway-Ryba concurrence combinatorics) - out of scope",
-      "Full quotient descent: Subgroup.closure_induction over ⟨hexRot,hexRev⟩ + sameProjLine transitivity, then relate permuteHexagon hex g to lbl.out` for genuine Quotient-level pascalLine well-definedness."
+      "Full quotient descent: Subgroup.closure_induction over ⟨hexRot,hexRev⟩ + sameProjLine transitivity, then relate permuteHexagon hex g to lbl.out` for genuine Quotient-level pascalLine well-definedness.",
+      "Quotient descent now algebraically unblocked: Subgroup.closure_induction over {hexRot,hexRev} chained by sameProjLine_trans. Needs (i) permuteHexagon composition lemma permuteHexagon hex (g*h)=permuteHexagon (permuteHexagon hex g) h; (ii) non-degeneracy lineThrough (pascalP hex)(pascalQ hex) ≠ 0 to discharge m≠0."
     ],
     "archivedSessions": [
       {

--- a/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03-incomplete-01.json
@@ -29,19 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: OQ-03-OQ-02 geometric backbone proved (6 exact generator-action lemmas); pascalLine total; projective line-descent + count theorems remain. PR #30630 (local build blocked by disk-full, build-gated before merge).",
+    "progressSummary": "PROGRESS: OQ-03-OQ-02 set-invariance upgraded to literal projective line equality under both D6 generators (PART 4d); quotient-level descent remains.",
     "builtItems": [
       "PART 4c in PascalsHexagonOQ03.lean: 6 generator-action lemmas pascal{P,Q,R}_permuteHexagon_{hexRot,hexRev} (exact vector identities, 0 sorry)",
-      "pascalLine made total via lbl.out (Quotient.out), discharging the blocking definition-sorry"
+      "pascalLine made total via lbl.out (Quotient.out), discharging the blocking definition-sorry",
+      "PascalsHexagonOQ03.lean PART 4d: cross_cross_eq_det_smul (BAC-CAB, axiom-free ring identity)",
+      "PascalsHexagonOQ03.lean PART 4d: sameProjLine_of_collinear (rotation crux, axiom-free)",
+      "PascalsHexagonOQ03.lean PART 4d: pascalLine_hexRot/hexRev_sameProjLine + pascalLine_generators_sameProjLine (Pascal line projectively fixed by both D6 generators)"
     ],
     "insights": [
       "hexRot acts as (P,Q,R)->(Q,R,-P); hexRev as (P,Q,R)->(-Q,-P,R); proved exactly. hexRot P/Q by index-reduction+rfl, R by one cross_anticomm; hexRev sign cases by cross_apply+ring (mirrors parent crossProduct_smul proofs)",
-      "Both generators permute the SET {[P],[Q],[R]} of projective points; with collinearity (pascal_hexagon_theorem) this fixes the spanned Pascal line, i.e. the D6-descent backbone of OQ-03-OQ-02"
+      "Both generators permute the SET {[P],[Q],[R]} of projective points; with collinearity (pascal_hexagon_theorem) this fixes the spanned Pascal line, i.e. the D6-descent backbone of OQ-03-OQ-02",
+      "BAC-CAB identity (a×b)×(c×d)=[a,b,d]c-[a,b,c]d with a=P,b=Q,c=Q,d=R collapses to (P×Q)×(Q×R)=det(P,Q,R)•Q; collinearity (det=0) is EXACTLY the condition that adjacent-join Pascal lines coincide — the canonicality of the Pascal line.",
+      "Cross-product-zero (parallelism) is the honest hypothesis-free notion of same-projective-line; it proves line-equality without extracting a nonzero scalar (which would need nondegeneracy)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Promote set-invariance to literal ProjLine equality: prove P x Q ∝ Q x R for collinear pairwise-independent P,Q,R (Q x R = -alpha (P x Q) when R=alpha P + beta Q), needing a nonzero-scalar line-equivalence + nondegeneracy hypothesis",
-      "steiner_count_eq_20 / kirkman_count_eq_60 remain genuinely OPEN (Conway-Ryba concurrence combinatorics) - out of scope"
+      "steiner_count_eq_20 / kirkman_count_eq_60 remain genuinely OPEN (Conway-Ryba concurrence combinatorics) - out of scope",
+      "Full quotient descent: Subgroup.closure_induction over ⟨hexRot,hexRev⟩ + sameProjLine transitivity, then relate permuteHexagon hex g to lbl.out` for genuine Quotient-level pascalLine well-definedness."
     ],
     "archivedSessions": [
       {


### PR DESCRIPTION
## Problem
`pascals-hexagon-oq-03-incomplete-01` — **OQ-03-OQ-02**: well-definedness of the
`pascalLine : HexagonLabeling → ProjLine` map in `PascalsHexagonOQ03.lean`. The map
was a blocking **definition-`sorry`**, which made every downstream statement
(`SteinerPoint`, `KirkmanPoint`, the two count theorems) reference `sorry`.

## What this PR does
Adds **PART 4c**: the six exact vector identities describing how the dihedral
generators act on the three Pascal points `(P, Q, R)` — the geometric backbone of
the descent claim:

```
hexRot : (P, Q, R) ↦ (Q,  R, -P)
hexRev : (P, Q, R) ↦ (-Q, -P, R)
```

- `pascalP/Q/R_permuteHexagon_hexRot` — index reduction (`decide`) + one
  `cross_anticomm` for the single sign.
- `pascalP/Q/R_permuteHexagon_hexRev` — the three sign cases, by coordinate
  expansion (`cross_apply` + `ring`, mirroring the parent file's existing
  cross-product proofs). These were left as `sorry` sketches in the prior
  hand-analysis; here they are given real proofs.

`pascalLine` is made **total** via the canonical coset representative `lbl.out'`,
discharging the blocking definition-`sorry`. Also fixes a Mathlib rename in the
parent (`associated` → `QuadraticMap.associated`).

Each generator permutes the *set* `{[P],[Q],[R]}` of projective Pascal points
(signs invisible projectively); since `P,Q,R` are collinear they span one Pascal
line, fixed by `⟨hexRot,hexRev⟩ ≅ D₆`.

## Scope / honesty
- **Net sorries: unchanged at the file level** (the def-`sorry` is removed; the two
  genuinely-OPEN count theorems `steiner_count_eq_20` / `kirkman_count_eq_60`
  (OQ-03-OQ-03/04) remain and are out of scope).
- Promoting set-invariance to literal `ProjLine` equality (up to nonzero scalar,
  with a nondegeneracy hypothesis) is the remaining bookkeeping, documented as
  deferred in the `pascalLine` docstring.
- ⚠️ **Local build verification was BLOCKED this session**: the host Data volume is
  at 100% (5.7 GiB free) and the `lean4-arm64` Docker image is absent, so
  `docker-build.sh` failed at image build (containerd I/O error). Direct `lake build`
  is prohibited. Proofs are hand-verified and follow patterns already compiled in the
  parent file, but **please build-gate before merge** (`docker-build.sh Proofs.PascalsHexagonOQ03`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)