### PR TITLE
Enrich Erdős #103 OQ-02: index.ts + annotations

### DIFF
--- a/src/data/proofs/erdos-103-oq-02/annotations.json
+++ b/src/data/proofs/erdos-103-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-erdos103-oq02-isometry",
+    "proofId": "erdos-103-oq-02",
+    "range": { "startLine": 63, "endLine": 73 },
+    "type": "theorem",
+    "title": "Translation is a Distance-Preserving Map",
+    "content": "Ptranslate v P shifts every point of the configuration by a common vector v. pointDist_add_right proves the pairwise distance is unchanged: the shift v cancels in each coordinate difference, so d(p+v, q+v) = d(p,q). This single isometry fact drives everything that follows — both the degeneracy of the raw count and the well-behavedness of the congruence count.",
+    "mathContext": "$d(p+v,\\,q+v) = \\sqrt{((p_1+v_1)-(q_1+v_1))^2 + ((p_2+v_2)-(q_2+v_2))^2} = d(p,q)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["isometry", "Euclidean distance", "translation group of ℝ²", "rigid motion"],
+    "prerequisites": ["Euclidean metric", "coordinate arithmetic"]
+  },
+  {
+    "id": "ann-erdos103-oq02-translate-optimal",
+    "proofId": "erdos-103-oq-02",
+    "range": { "startLine": 79, "endLine": 107 },
+    "type": "theorem",
+    "title": "Translation Preserves Optimality",
+    "content": "Because every pairwise distance is preserved, translation leaves both the minimum-separation constraint (translate_valid) and the diameter (translate_diameter, a double-iSup of preserved distances) invariant. Hence translate_optimal carries any optimal configuration to an optimal configuration. This means the optimal set is closed under the continuous translation group — the seed of the degeneracy.",
+    "mathContext": "$\\mathrm{diam}(P+v) = \\mathrm{diam}(P)$ and min-separation is preserved, so $\\mathrm{IsOptimal}(P) \\Rightarrow \\mathrm{IsOptimal}(P+v)$.",
+    "significance": "key",
+    "relatedConcepts": ["diameter", "optimal point configuration", "iSup congruence", "translation invariance"],
+    "prerequisites": ["the isometry lemma", "definition of IsOptimal / diameter"]
+  },
+  {
+    "id": "ann-erdos103-oq02-infinite",
+    "proofId": "erdos-103-oq-02",
+    "range": { "startLine": 113, "endLine": 130 },
+    "type": "insight",
+    "title": "The Optimal Set is Infinite When Nonempty",
+    "content": "optimal_subtype_infinite_of_nonempty builds an injection t ↦ (P₀ shifted by (t,0)) from ℝ into the optimal subtype: distinct horizontal shifts move the 0-th point to distinct positions (add_right_inj), and all shifts stay optimal by translate_optimal. Since ℝ is infinite, so is the optimal subtype whenever it is nonempty — there is no finite count to take.",
+    "mathContext": "$t \\mapsto P_0 + (t,0)$ injects $\\mathbb{R} \\hookrightarrow \\{P : \\mathrm{IsOptimal}\\,n\\,P\\}$, so the optimal subtype is infinite.",
+    "significance": "key",
+    "relatedConcepts": ["Infinite.of_injective", "cardinality of ℝ", "continuous symmetry group", "moduli of configurations"],
+    "prerequisites": ["injective maps and Infinite", "translate_optimal"]
+  },
+  {
+    "id": "ann-erdos103-oq02-degeneracy",
+    "proofId": "erdos-103-oq-02",
+    "range": { "startLine": 136, "endLine": 160 },
+    "type": "theorem",
+    "title": "The Raw Count h(n) is Identically Zero",
+    "content": "h_eq_zero proves the parent's literal count h n = Nat.card {optimal P} = 0 for every n ≥ 1: the optimal subtype is either empty or infinite (Part 3), and Nat.card returns 0 in both cases. Consequently raw_weak_conjecture_false: the parent's WeakConjecture ∃N ∀n≥N, h n ≥ 2 is outright false. This is the formalization-audit core — the raw cardinality is the wrong object.",
+    "mathContext": "$h(n) = \\mathrm{Nat.card}\\{P : \\mathrm{IsOptimal}\\,n\\,P\\} = 0$ for $n \\geq 1$, since $\\mathrm{Nat.card}$ of an infinite (or empty) type is $0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Nat.card of infinite types", "degenerate definition", "formalization audit", "Erdős #103"],
+    "prerequisites": ["Nat.card_eq_zero", "the infinitude lemma"]
+  },
+  {
+    "id": "ann-erdos103-oq02-corrected",
+    "proofId": "erdos-103-oq-02",
+    "range": { "startLine": 166, "endLine": 202 },
+    "type": "definition",
+    "title": "The Corrected Count: Congruence Classes",
+    "content": "OptimalSetoid puts the congruence equivalence on optimal configurations, and hCong n := Nat.card of the quotient — the number of INCONGRUENT optimal configurations, which is what Erdős #103 actually asks about. translates_same_class shows all translates of a fixed configuration land in one class (a translate is congruent to the original), so the quotient collapses exactly the translation-infinitude that made the raw count vanish.",
+    "mathContext": "$h_{\\mathrm{Cong}}(n) = \\mathrm{Nat.card}\\big(\\{P : \\mathrm{IsOptimal}\\,n\\,P\\}/{\\cong}\\big)$; all translates of $P$ form a single class.",
+    "significance": "key",
+    "relatedConcepts": ["setoid / quotient type", "congruence of point sets", "Quotient.sound", "moduli up to isometry"],
+    "prerequisites": ["equivalence relations and quotients", "AreCongruent"]
+  },
+  {
+    "id": "ann-erdos103-oq02-nondegenerate",
+    "proofId": "erdos-103-oq-02",
+    "range": { "startLine": 220, "endLine": 253 },
+    "type": "insight",
+    "title": "The Correction is Non-Degenerate Where the Raw Count Failed",
+    "content": "optimalQuotient_nonempty_of_exists shows the quotient is nonempty whenever an optimal configuration exists, so emptiness can never drag hCong to 0. Given finitely many congruence classes, hCong_pos_of_finite gives hCong n ≥ 1 (Nat.card_pos), and hCong_strictly_exceeds_raw gives h n = 0 < 1 ≤ hCong n. The finiteness hypothesis is precisely the content of the open Erdős question — given it, the congruence count behaves.",
+    "mathContext": "With $[\\,\\mathrm{Finite}\\,(\\text{Quotient})\\,]$ and an optimal config: $h(n) = 0 < 1 \\le h_{\\mathrm{Cong}}(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card_pos", "finiteness hypothesis", "well-posed conjecture", "open problem framing"],
+    "prerequisites": ["Nat.card_pos for nonempty finite types", "the degeneracy theorem"]
+  }
+]

--- a/src/data/proofs/erdos-103-oq-02/index.ts
+++ b/src/data/proofs/erdos-103-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos103OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos103Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos103Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos103Oq02Data: ProofData = {
+  proof: erdos103Oq02Proof,
+  annotations: erdos103Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-103-oq-02` (first pass).

## Changes
- **Created `index.ts`** — entry had only `meta.json`, so the page would render 'proof not found' on the live site.
- **Added `annotations.json`** with 6 annotations covering all parts of the formalization-audit file:
  - translation isometry (`pointDist_add_right`)
  - translation preserves optimality (`translate_optimal`)
  - infinitude of the optimal set (`optimal_subtype_infinite_of_nonempty`)
  - the raw count is identically zero / parent WeakConjecture false (`h_eq_zero`, `raw_weak_conjecture_false`)
  - the corrected congruence count (`hCong`, `translates_same_class`)
  - non-degeneracy of the correction (`hCong_strictly_exceeds_raw`)
- Each annotation includes `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

meta.json was already rich (15.9 KB, within caps; sections + conclusion + crossReferences + references present) and accurate vs the Lean source (13 theorems, 0 sorries, 0 axioms, status verified) — left as-is.

`pnpm build` passes.