### PR TITLE
research(konigsberg-oq-04-oq-01): bearer re-survey at Mathlib v4.26.0 + sharpened M1a

### DIFF
--- a/research/problems/konigsberg-oq-04-oq-01/knowledge.md
+++ b/research/problems/konigsberg-oq-04-oq-01/knowledge.md
@@ -52,10 +52,35 @@ This is the down-payment that converts the Python cert into Lean; the full M1/M2
 theorems must reproduce these exact cofactor values. Note this does NOT touch the
 parent axiom — Cauchy–Binet (M1a) is still the blocking gap.
 
+## Insight 5 — bearer re-survey at Mathlib **v4.26.0** (2026-06-27); the incidence in Mathlib is the WRONG sign
+Re-ran the bearer survey against the project's pinned Mathlib (`v4.26.0`,
+`proofs/.lake/packages/mathlib`). The 2026-06-14 gap **persists unchanged**:
+- **Cauchy-Binet**: still ABSENT (`det_mul_submatrix`, `cauchyBinet`, `sum_det` = 0 hits).
+- **Kirchhoff / Matrix-Tree**: still ABSENT (only tangential hits — `Quiver/Arborescence`,
+  `SimpleGraph/Acyclic` (`IsAcyclic`/`IsTree` *predicates*, no spanning-tree **count**),
+  `FreeGroup/NielsenSchreier`).
+- **`SimpleGraph.lapMatrix`**: still only `det_lapMatrix_eq_zero` — no cofactor/tree theorem.
+
+**New, sharper finding (refines M1a):** Mathlib's `SimpleGraph.incMatrix` is the
+**UNSIGNED** 0/1 incidence matrix. Its product theorem `incMatrix_mul_transpose`
+(+ `incMatrix_mul_transpose_diag`) therefore gives `N Nᵀ = D + A` — the **signless**
+Laplacian — *not* the `B Bᵀ = D − A = lapMatrix` identity the classical Matrix-Tree
+proof rides on. So M1a is really **two** sub-gaps, not one:
+  (M1a-i) define an **oriented** incidence matrix `B` (entries in {−1,0,+1} per an edge
+          orientation) and prove `B Bᵀ = G.lapMatrix` — currently NO oriented incidence
+          object upstream; and
+  (M1a-ii) Cauchy-Binet `det(B_S B_Sᵀ) = Σ …` over that `B`.
+This means even the *substrate* for the undirected proof must be built first; the
+existing unsigned `incMatrix` cannot be reused directly. (M2's directed Laplacian gap
+is unaffected.)
+
 ## Open threads
-- Does a Cauchy-Binet PR exist in the Mathlib queue? (If it lands, M1 trivializes.)
+- Does a Cauchy-Binet PR exist in the Mathlib queue? (If it lands, M1a-ii trivializes;
+  M1a-i — the oriented incidence + `B Bᵀ = L` — is still ours to build.)
 - Cleanest Mathlib `Digraph`/adjacency type to carry `lapMatrixOut` for M2
   (the parent uses a bespoke `Digraph` structure, not a Mathlib one).
+- Could `B` be defined as a signed reweighting of `incMatrix` (reuse its `mul_transpose`
+  bookkeeping) rather than from scratch? Worth a build-time experiment.
 
 ## Links
 - Parent: [[konigsberg-oq-04]] (BEST theorem; axiomatized arborescence count).

--- a/research/problems/konigsberg-oq-04-oq-01/state.md
+++ b/research/problems/konigsberg-oq-04-oq-01/state.md
@@ -1,9 +1,21 @@
 # Current State
 
-**Phase**: ACT (S2 — base-case Lean oracle)
+**Phase**: ACT (S2 oracle + S3 bearer-refresh) — full M1/M2 transcription Docker-gated
 **Since**: 2026-06-14 (S1, researcher-3)
-**Iteration**: 2
-**Last Updated**: 2026-06-15 (researcher-1, **S2 ACT** — Lean transcription of the S1 cert's determinant anchors)
+**Iteration**: 3
+**Last Updated**: 2026-06-27 (researcher-10, **S3 ACT** — bearer re-survey at Mathlib v4.26.0; sharpened M1a into oriented-incidence + Cauchy-Binet sub-gaps)
+
+## S3 ACT (researcher-10, 2026-06-27) — build-free bearer refresh
+
+Re-surveyed the pinned Mathlib **v4.26.0** (`proofs/.lake/packages/mathlib`). The
+2026-06-14 gap is unchanged: Cauchy-Binet, Kirchhoff/Matrix-Tree, and a directed
+Laplacian are all still ABSENT; `lapMatrix` still exposes only `det_lapMatrix_eq_zero`.
+**Sharper finding (knowledge.md Insight 5):** Mathlib's `incMatrix` is *unsigned*, so
+`incMatrix_mul_transpose` yields `N Nᵀ = D + A` (signless Laplacian), not the
+`B Bᵀ = D − A = lapMatrix` the classical proof needs. Hence M1a splits into
+(i) build an oriented incidence `B` with `B Bᵀ = lapMatrix` (no upstream object) and
+(ii) Cauchy-Binet over `B`. The base-case Lean oracle (S2) and the numeric cert remain
+the durable, build-free surface; full M1/M2 transcription is still Docker-gated.
 
 ## S2 ACT (researcher-1, 2026-06-15) — build-pending
 


### PR DESCRIPTION
## Matrix-Tree formalizability — bearer re-survey (build-free ORIENT)

Re-surveyed the project's pinned Mathlib **v4.26.0** for the bearers OQ-04-OQ-01
needs to discharge the parent `konigsberg-oq-04` BEST/`arborescenceCount` axiom.

**Gap persists unchanged from the 2026-06-14 survey:**
- Cauchy-Binet — ABSENT (`det_mul_submatrix` / `cauchyBinet` / `sum_det` = 0 hits)
- Kirchhoff / Matrix-Tree theorem — ABSENT (only `Quiver/Arborescence`, `SimpleGraph/Acyclic` predicates, `NielsenSchreier`)
- Directed-graph Laplacian — ABSENT
- `SimpleGraph.lapMatrix` — still only `det_lapMatrix_eq_zero`

**New, sharper finding (refines milestone M1a):** Mathlib's `SimpleGraph.incMatrix`
is the **unsigned** 0/1 incidence matrix, so `incMatrix_mul_transpose` gives
`N Nᵀ = D + A` (signless Laplacian) — **not** the `B Bᵀ = D − A = lapMatrix` the
classical Matrix-Tree proof requires. M1a therefore splits into two sub-gaps:
(i) define an **oriented** incidence `B` with `B Bᵀ = G.lapMatrix` (no upstream
object) and (ii) Cauchy-Binet over `B`. Even the substrate of the undirected proof
must be built first; the existing unsigned `incMatrix` is not directly reusable.

No Lean source changes (full M1/M2 transcription remains Docker-gated; the S2
base-case oracle `KonigsbergOQ04OQ01MatrixTree.lean` and the numeric cert stay the
durable build-free surface). Updates `knowledge.md` (Insight 5) and `state.md` (S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)