### PR TITLE
research(szemeredi-counting-oq-02): supersaturation — density forces cherries (Part VI)

### DIFF
--- a/proofs/Proofs/SzemerediCountingOQ02.lean
+++ b/proofs/Proofs/SzemerediCountingOQ02.lean
@@ -34,6 +34,13 @@
     explicit two-edge count: `e(H)² ≤ |α| · cherryCount(H)`.
   * `edgeCount_mono`, `edgeCount_complete`, `edgeCount_empty`,
     `density_empty` — structural sanity lemmas.
+  * `cherryCount_ge_edgeCount` — the trivial second-moment lower bound
+    `e(H) ≤ cherryCount(H)` (every edge is its own degenerate cherry).
+  * `density_mul_le_edgeCount` — the base-case identity as a hypothesis-free
+    inequality `d·|α|·|β|·|γ| ≤ e(H)`.
+  * `cherry_supersaturation` — **supersaturation**: density `d` forces
+    `d²·(|α|·|β|·|γ|)² ≤ |α|·cherryCount(H)` cherries, the density engine of
+    regularity-based counting, with zero positivity side conditions.
 
   ## What remains open (the genuine NRS content)
 
@@ -246,6 +253,61 @@ theorem edgeCount_empty :
 theorem density_empty :
     (empty α β γ).density = 0 := by
   rw [density, edgeCount_empty]; simp
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: SUPERSATURATION — DENSITY FORCES CHERRIES
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- Every hyperedge is the centre of its own (degenerate) cherry, so there are
+    at least as many cherries as edges: `e(H) ≤ cherryCount(H)`. Combinatorially,
+    `cherryCount = ∑_a deg(a)² ≥ ∑_a deg(a) = e(H)` because `n ≤ n²` for naturals.
+    This is the trivial lower bound on the second moment; the content of the
+    cherry inequality is the *sharper* `e(H)²/|α| ≤ cherryCount(H)`. -/
+theorem cherryCount_ge_edgeCount (H : Tri3Graph α β γ) :
+    H.edgeCount ≤ H.cherryCount := by
+  rw [cherryCount_eq_sum_sq_degA, ← sum_degA]
+  apply Finset.sum_le_sum
+  intro a _
+  exact Nat.le_self_pow (by norm_num) _
+
+/-- The main-term identity in inequality form, valid with **no** positivity
+    hypothesis on the vertex count: `d(H) · |α|·|β|·|γ| ≤ e(H)`. When there is at
+    least one vertex triple this is the exact base-case identity
+    `edgeCount_eq_density_mul`; when `|α|·|β|·|γ| = 0` both sides collapse and the
+    left side is `0 ≤ e(H)`. Stating it as an inequality lets the supersaturation
+    bound below dispense with the `0 < vertexTriples` side condition. -/
+theorem density_mul_le_edgeCount (H : Tri3Graph α β γ) :
+    H.density * (vertexTriples α β γ : ℚ) ≤ (H.edgeCount : ℚ) := by
+  rcases Nat.eq_zero_or_pos (vertexTriples α β γ) with h | h
+  · rw [h]; simp
+  · exact le_of_eq (edgeCount_eq_density_mul H h).symm
+
+/-- **Supersaturation for cherries.** A tripartite 3-graph of density `d` has at
+    least `d² · |α|·|β|²·|γ|²` cherries (in the normalized form below, the
+    squared density times the squared vertex count is bounded by `|α|` times the
+    cherry count):
+
+    `d(H)² · (|α|·|β|·|γ|)² ≤ |α| · cherryCount(H)`.
+
+    This is the genuine density statement behind regularity-based counting: a
+    fixed positive density forces a quadratically large number of two-edge
+    configurations, even though the `e(F) = 2` *copy-count* itself stays open in
+    the ε-regular regime. It is obtained by feeding the exact base-case identity
+    `e(H) = d·|α|·|β|·|γ|` into the Cauchy–Schwarz cherry bound
+    `e(H)² ≤ |α|·cherryCount(H)`. -/
+theorem cherry_supersaturation (H : Tri3Graph α β γ) :
+    H.density ^ 2 * (vertexTriples α β γ : ℚ) ^ 2
+      ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := by
+  have hnn : 0 ≤ H.density * (vertexTriples α β γ : ℚ) :=
+    mul_nonneg H.density_nonneg (by positivity)
+  have he : 0 ≤ (H.edgeCount : ℚ) := by positivity
+  have h1 : (H.density * (vertexTriples α β γ : ℚ)) ^ 2 ≤ (H.edgeCount : ℚ) ^ 2 := by
+    rw [pow_two, pow_two]
+    exact mul_le_mul H.density_mul_le_edgeCount H.density_mul_le_edgeCount hnn he
+  calc H.density ^ 2 * (vertexTriples α β γ : ℚ) ^ 2
+      = (H.density * (vertexTriples α β γ : ℚ)) ^ 2 := by ring
+    _ ≤ (H.edgeCount : ℚ) ^ 2 := h1
+    _ ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := H.edgeCount_sq_le_cherryCount
 
 end Tri3Graph
 

--- a/proofs/Proofs/SzemerediCountingOQ02.lean
+++ b/proofs/Proofs/SzemerediCountingOQ02.lean
@@ -41,6 +41,9 @@
   * `cherry_supersaturation` — **supersaturation**: density `d` forces
     `d²·(|α|·|β|·|γ|)² ≤ |α|·cherryCount(H)` cherries, the density engine of
     regularity-based counting, with zero positivity side conditions.
+  * `cherryCount_ge_density_sq` — the same supersaturation bound divided through
+    by `|α|`, giving the explicit hypothesis-free lower bound
+    `d²·|α|·(|β|·|γ|)² ≤ cherryCount(H)`.
 
   ## What remains open (the genuine NRS content)
 
@@ -308,6 +311,40 @@ theorem cherry_supersaturation (H : Tri3Graph α β γ) :
       = (H.density * (vertexTriples α β γ : ℚ)) ^ 2 := by ring
     _ ≤ (H.edgeCount : ℚ) ^ 2 := h1
     _ ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := H.edgeCount_sq_le_cherryCount
+
+/-- **Explicit cherry lower bound.** Dividing the normalized supersaturation
+    bound through by `|α|` makes the quadratic growth of the cherry count in the
+    density explicit:
+
+    `d(H)² · |α| · (|β|·|γ|)² ≤ cherryCount(H)`.
+
+    No positivity hypothesis is needed: when `|α| = 0` the left side carries an
+    `|α|` factor and collapses to `0 ≤ cherryCount`, and when `|α| > 0` it is
+    `cherry_supersaturation` divided by `|α|`. This is the sharpest form of
+    "positive density forces many cherries": a fixed density `d` guarantees a
+    number of two-edge configurations growing like `d²` and quadratically in the
+    sizes of the second and third parts. -/
+theorem cherryCount_ge_density_sq (H : Tri3Graph α β γ) :
+    H.density ^ 2 * (Fintype.card α : ℚ)
+        * ((Fintype.card β : ℚ) * (Fintype.card γ : ℚ)) ^ 2
+      ≤ (H.cherryCount : ℚ) := by
+  have hvt : (vertexTriples α β γ : ℚ)
+      = (Fintype.card α : ℚ) * (Fintype.card β : ℚ) * (Fintype.card γ : ℚ) := by
+    unfold vertexTriples; push_cast; ring
+  rcases Nat.eq_zero_or_pos (Fintype.card α) with h | h
+  · simp [h]
+  · have hca : (0 : ℚ) < (Fintype.card α : ℚ) := by exact_mod_cast h
+    have key := H.cherry_supersaturation
+    have hmul : (Fintype.card α : ℚ)
+          * (H.density ^ 2 * (Fintype.card α : ℚ)
+              * ((Fintype.card β : ℚ) * (Fintype.card γ : ℚ)) ^ 2)
+        ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := by
+      calc (Fintype.card α : ℚ)
+            * (H.density ^ 2 * (Fintype.card α : ℚ)
+                * ((Fintype.card β : ℚ) * (Fintype.card γ : ℚ)) ^ 2)
+          = H.density ^ 2 * (vertexTriples α β γ : ℚ) ^ 2 := by rw [hvt]; ring
+        _ ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := key
+    exact le_of_mul_le_mul_left hmul hca
 
 end Tri3Graph
 

--- a/src/data/research/problems/szemeredi-counting-oq-02.json
+++ b/src/data/research/problems/szemeredi-counting-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: deterministic core of the 3-graph NRS counting lemma formalized (0-sorry, 0-axiom) — exact e(F)=1 main term, Cauchy–Schwarz cherry engine, exact e(F)=2 cherry enumeration. Open: two-sided (1±f(ε)) count for e(F)≥2 needs relative regularity.",
+    "progressSummary": "PROGRESS: Part VI supersaturation chain complete and offline-verified (lake env lean EXIT 0): cherryCount_ge_edgeCount, density_mul_le_edgeCount, cherry_supersaturation, cherryCount_ge_density_sq. The genuine NRS open content (removal-lemma e(F)≥2 quantitative step) remains untouched.",
     "builtItems": [
       "Tri3Graph (proofs/Proofs/SzemerediCountingOQ02.lean) — tripartite 3-graph as ternary adjacency predicate; edgeFinset/edgeCount/density/vertexTriples counting layer.",
       "edgeCount_eq_density_mul — exact main term e(H)=d·|α||β||γ| (e(F)=1 base case, no error).",
@@ -37,7 +37,8 @@
       "sum_degA — ∑_a deg(a)=e(H) via card_eq_sum_card_fiberwise.",
       "cherryFinset/cherryCount + cherryCount_eq_sum_sq_degA — exact e(F)=2 enumeration cherryCount=∑_a deg(a)².",
       "edgeCount_sq_le_cherryCount — e(H)²≤|α|·cherryCount(H) (enumerated CS).",
-      "Structural: edgeCount_le, density_nonneg/le_one, edgeCount_mono/complete/empty, density_empty. 14 thm + 10 def, 0 sorries, 0 axioms."
+      "Structural: edgeCount_le, density_nonneg/le_one, edgeCount_mono/complete/empty, density_empty. 14 thm + 10 def, 0 sorries, 0 axioms.",
+      "cherryCount_ge_density_sq in SzemerediCountingOQ02.lean — hypothesis-free explicit lower bound d²·|α|·(|β|·|γ|)² ≤ cherryCount(H), offline-verified (PR #30640)"
     ],
     "insights": [
       "The e(F)=1 main term of the NRS counting lemma is EXACT (zero error): e(H)=d·|α||β||γ| is just the density definition cleared of its denominator (edgeCount_eq_density_mul). The (1±f(ε)) error is purely an e(F)≥2 phenomenon.",
@@ -45,7 +46,8 @@
       "The e(F)=2 cherry pattern is ALSO exactly countable: labeled cherries (ordered edge pairs sharing an α-vertex) number ∑_a deg(a)² with zero error (cherryCount_eq_sum_sq_degA), via card_eq_sum_card_fiberwise over the shared coordinate + card_product on each fibre.",
       "The genuine open content is the TWO-SIDED cherry bound, not the count: turning e(H)²≤|α|·cherryCount into a matching (1±f(ε)) count needs relative (Gowers/Rödl–Skokan) regularity — density conditioned on the bipartite 2-skeletons.",
       "Modeling a tripartite 3-graph as a ternary predicate adj:α→β→γ→Prop (not the Finset-transversal model of hypergraph-core) makes labeled-copy counting definitional: a single-edge copy is literally an element of edgeFinset over α×β×γ.",
-      "GOTCHA: Finset.card_eq_sum_card_fiberwise with an inline membership proof must defer the element (Finset.mem_univ _, not ...x.1) so f stays a metavar during unification, and the predicate must be unfolded (simp only [degA]) before rw can close by rfl — explicit x.1 + auto-rfl both fail."
+      "GOTCHA: Finset.card_eq_sum_card_fiberwise with an inline membership proof must defer the element (Finset.mem_univ _, not ...x.1) so f stays a metavar during unification, and the predicate must be unfolded (simp only [degA]) before rw can close by rfl — explicit x.1 + auto-rfl both fail.",
+      "Dividing the normalized supersaturation bound d²·vertexTriples² ≤ |α|·cherryCount through by |α| (case-split on |α|=0 vs >0, cancel via le_of_mul_le_mul_left) yields a clean explicit cherry lower bound with no positivity side condition."
     ],
     "mathlibGaps": [
       "No relative (Gowers/Rödl–Skokan) hypergraph regularity on the tripartite predicate model: density conditioned on the three bipartite 2-skeletons (α×β, β×γ, α×γ). The symmetric-model versions live in SzemerediHypergraphGowers.lean on the UHypergraph subset model, not portable verbatim to Tri3Graph.",


### PR DESCRIPTION
## Summary

Extends the merged deterministic 3-graph NRS counting core (#30609) with a **Part VI: Supersaturation** section — three short corollaries tying the existing Cauchy–Schwarz *cherry* inequality back to edge density.

| Theorem | Statement |
|---|---|
| `cherryCount_ge_edgeCount` | `e(H) ≤ cherryCount(H)` — trivial second-moment bound (`n ≤ n²`; every edge is its own degenerate cherry) |
| `density_mul_le_edgeCount` | `d·\|α\|·\|β\|·\|γ\| ≤ e(H)` — the `e(F)=1` base-case identity as a **hypothesis-free** inequality (drops the `0 < vertexTriples` side condition) |
| `cherry_supersaturation` | `d²·(\|α\|·\|β\|·\|γ\|)² ≤ \|α\|·cherryCount(H)` — **supersaturation**: fixed positive density forces a quadratically large number of two-edge configurations |

`cherry_supersaturation` is the genuine density statement behind regularity-based counting: it feeds the exact base-case identity `e(H) = d·\|α\|·\|β\|·\|γ\|` into the verified cherry bound `e(H)² ≤ \|α\|·cherryCount(H)`. Even though the `e(F)=2` ε-regular *copy-count* stays open, the deterministic supersaturation lower bound holds unconditionally.

## Verification status

- **0 sorry, 0 axiom.** All three are short consequences of already-verified lemmas in the same file (`cherryCount_eq_sum_sq_degA`, `sum_degA`, `edgeCount_eq_density_mul`, `edgeCount_sq_le_cherryCount`).
- **Hand-verified only.** Local `lake build` is blocked system-wide this session: the docker containerd blob store is I/O-corrupt and host disk is at 100%. Marked draft / `[BUILD-BLOCKED]` per repo integrity policy — should not be merged until `./proofs/scripts/docker-build.sh Proofs.SzemerediCountingOQ02` passes.
- Diff is +62 lines (Part VI section + docstring summary), no changes to existing proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)