### PR TITLE
research(erdos-884): closed-form reindexing of the index double sum

### DIFF
--- a/proofs/Proofs/Erdos884Problem.lean
+++ b/proofs/Proofs/Erdos884Problem.lean
@@ -495,4 +495,90 @@ theorem allPairsSum_le_indexSum (n : ℕ) (hn : n > 1) :
   have ⟨hij, hjτ⟩ := Finset.mem_Ioo.mp hj
   exact reciprocal_gap_index_bound n hn hij hjτ
 
+/- ## Closed Form of the Index Double Sum -/
+
+/-- **Reindexing identity.** The index-based double sum over pairs `0 ≤ i < j < τ`,
+    weighted by the reciprocal of the gap `j - i`, collapses to a single sum over the
+    gap value `k = j - i`. For each gap `k` with `1 ≤ k ≤ τ - 1` there are exactly
+    `τ - k` pairs `(i, j)` with `j - i = k` (namely `i = 0, …, τ-1-k`), so
+
+    `Σ_{0≤i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k`.
+
+    The proof reindexes the inner sum `j ↦ j - i` (turning `Ioo i τ` into a range of
+    gaps), swaps the order of summation with `Finset.sum_comm'`, and counts the `τ - k`
+    constant inner terms. Purely combinatorial: independent of any divisor structure. -/
+theorem indexDoubleSum_closed_form (τ : ℕ) :
+    (∑ i ∈ Finset.range τ, ∑ j ∈ Finset.Ioo i τ, (1 : ℝ) / ((j - i : ℕ) : ℝ))
+      = ∑ k ∈ Finset.Ico 1 τ, ((τ - k : ℕ) : ℝ) / (k : ℝ) := by
+  calc
+    (∑ i ∈ Finset.range τ, ∑ j ∈ Finset.Ioo i τ, (1 : ℝ) / ((j - i : ℕ) : ℝ))
+        = ∑ i ∈ Finset.range τ,
+            ∑ k ∈ Finset.range (τ - i - 1), (1 : ℝ) / ((k + 1 : ℕ) : ℝ) := by
+          -- Inner reindex: `j ↦ j - i` over `Ioo i τ = Ico (i+1) τ`.
+          apply Finset.sum_congr rfl
+          intro i _
+          have hIoo : Finset.Ioo i τ = Finset.Ico (i + 1) τ := by
+            ext x; simp only [Finset.mem_Ioo, Finset.mem_Ico]; omega
+          rw [hIoo, Finset.sum_Ico_eq_sum_range]
+          have hset : τ - (i + 1) = τ - i - 1 := by omega
+          rw [hset]
+          apply Finset.sum_congr rfl
+          intro k _
+          have hsub : i + 1 + k - i = k + 1 := by omega
+          rw [hsub]
+      _ = ∑ k ∈ Finset.range (τ - 1),
+            ∑ _i ∈ Finset.range (τ - 1 - k), (1 : ℝ) / ((k + 1 : ℕ) : ℝ) := by
+          -- Swap the order of the (triangular) summation.
+          apply Finset.sum_comm'
+          intro i k
+          simp only [Finset.mem_range]
+          omega
+      _ = ∑ k ∈ Finset.range (τ - 1), ((τ - 1 - k : ℕ) : ℝ) / ((k + 1 : ℕ) : ℝ) := by
+          -- Inner term is constant in `i`; there are `τ - 1 - k` of them.
+          apply Finset.sum_congr rfl
+          intro k _
+          rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_one_div]
+      _ = ∑ k ∈ Finset.Ico 1 τ, ((τ - k : ℕ) : ℝ) / (k : ℝ) := by
+          -- Reindex `k ↦ k + 1`, turning `range (τ-1)` back into `Ico 1 τ`.
+          rw [Finset.sum_Ico_eq_sum_range]
+          apply Finset.sum_congr rfl
+          intro k _
+          have h1 : τ - (1 + k) = τ - 1 - k := by omega
+          have h2 : 1 + k = k + 1 := by omega
+          rw [h1, h2]
+
+/-- **Harmonic decomposition.** The gap sum splits into a harmonic part and a constant:
+    `Σ_{k=1}^{τ-1} (τ-k)/k = Σ_{k=1}^{τ-1} (τ/k - 1) = τ·H_{τ-1} - (τ-1)`.
+    Term-by-term, `(τ-k)/k = τ/k - 1` since `k ≤ τ` and `k ≥ 1 > 0`. This exhibits the
+    `O(τ log τ)` growth of the index double sum explicitly. -/
+theorem gapHarmonicSum_eq (τ : ℕ) :
+    (∑ k ∈ Finset.Ico 1 τ, ((τ - k : ℕ) : ℝ) / (k : ℝ))
+      = ∑ k ∈ Finset.Ico 1 τ, ((τ : ℝ) / (k : ℝ) - 1) := by
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [Finset.mem_Ico] at hk
+  have hkτ : k ≤ τ := by omega
+  have hk0 : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  rw [Nat.cast_sub hkτ, sub_div, div_self hk0]
+
+/-- **Unconditional `O(τ log τ)` bound on the all-pairs sum.** Combining the index-sum
+    upper bound with the reindexing identity and harmonic decomposition gives, for `n > 1`
+    with `τ = τ(n)` divisors,
+    `allPairsSum n ≤ Σ_{k=1}^{τ-1} (τ/k - 1) = τ·H_{τ-1} - (τ-1)`,
+    a bound depending only on the *number* of divisors, not their arithmetic.
+    Companion to `allPairsSum_le_tau_mul_consecutive`; this one is fully unconditional. -/
+theorem allPairsSum_le_harmonic (n : ℕ) (hn : n > 1) :
+    allPairsSum n ≤
+      ∑ k ∈ Finset.Ico 1 (numDivisors n),
+        ((numDivisors n : ℝ) / (k : ℝ) - 1) := by
+  calc allPairsSum n
+      ≤ ∑ i ∈ Finset.range (numDivisors n),
+          ∑ j ∈ Finset.Ioo i (numDivisors n),
+            (1 : ℝ) / ((j - i : ℕ) : ℝ) := allPairsSum_le_indexSum n hn
+    _ = ∑ k ∈ Finset.Ico 1 (numDivisors n),
+          ((numDivisors n - k : ℕ) : ℝ) / (k : ℝ) :=
+        indexDoubleSum_closed_form (numDivisors n)
+    _ = ∑ k ∈ Finset.Ico 1 (numDivisors n), ((numDivisors n : ℝ) / (k : ℝ) - 1) :=
+        gapHarmonicSum_eq (numDivisors n)
+
 end Erdos884

--- a/src/data/research/problems/erdos-884.json
+++ b/src/data/research/problems/erdos-884.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added allPairsSum_le_indexSum (unconditional index-based double-sum bound, companion to allPairsSum_le_tau_mul_consecutive). 29 theorems, 1 axiom (open conjecture), 0 sorries.",
+    "progressSummary": "PROGRESS: Closed-form reindexing identity for the index double sum (indexDoubleSum_closed_form) + exact harmonic decomposition (gapHarmonicSum_eq) + assembled unconditional bound allPairsSum n ≤ τ·H_{τ-1}−(τ-1) (allPairsSum_le_harmonic). 32 theorems, 1 axiom (open conjecture), 0 sorries. BUILD-PENDING (docker host down).",
     "builtItems": [
       "theorem allPairsSum_nonneg: sum_nonneg + div_nonneg",
       "theorem consecutivePairsSum_nonneg: sum_nonneg + div_nonneg",
@@ -56,7 +56,10 @@
       "consecutiveGap_le_generalGap: any interior consecutive gap ≤ general gap (Erdos884Problem.lean:348)",
       "reciprocal_gap_index_bound: 1/(d_j-d_i) ≤ 1/(j-i) via generalGap_ge_diff + div_le_div_iff (Erdos884Problem.lean:365)",
       "reciprocal_gap_consecutive_bound: 1/(d_j-d_i) ≤ 1/g_i via gap_lower_bound + div_le_div_iff (Erdos884Problem.lean:378)",
-      "allPairsSum_le_indexSum: unconditional bound allPairsSum n ≤ Σ_{i<j<τ} 1/(j-i) via reciprocal_gap_index_bound (Erdos884Problem.lean:482)"
+      "allPairsSum_le_indexSum: unconditional bound allPairsSum n ≤ Σ_{i<j<τ} 1/(j-i) via reciprocal_gap_index_bound (Erdos884Problem.lean:482)",
+      "indexDoubleSum_closed_form (Erdos884Problem.lean): reindexing identity Σ_{0≤i<j<τ}1/(j-i) = Σ_{k=1}^{τ-1}(τ-k)/k, via inner reindex j↦j-i + Finset.sum_comm swap + constant inner count. Purely combinatorial, any τ:ℕ.",
+      "gapHarmonicSum_eq (Erdos884Problem.lean): Σ_{k=1}^{τ-1}(τ-k)/k = Σ(τ/k − 1) = τ·H_{τ-1} − (τ-1), termwise via Nat.cast_sub + sub_div + div_self.",
+      "allPairsSum_le_harmonic (Erdos884Problem.lean): assembled unconditional bound allPairsSum n ≤ Σ_{k=1}^{τ-1}(τ/k − 1) = τ·H_{τ-1} − (τ-1), depends only on τ(n)."
     ],
     "insights": [
       "divisorList is noncomputable (prevents native_decide for concrete values like divisors_6)",
@@ -85,14 +88,18 @@
       "Index bound implies allPairsSum ≤ Σ_{s=1}^{τ-1} (τ-s)/s ≈ τ·H(τ) via rearrangement by offset s=j-i",
       "Consecutive bound implies allPairsSum ≤ (τ-1)·consecutivePairsSum via counting j > i for each fixed i",
       "Tighter bound needs AM-HM/Cauchy-Schwarz: 1/(d_j-d_i) ≤ (1/(j-i)²)·Σ_{k∈[i,j)} 1/g_k — gives O(log τ) factor",
-      "Index-based sum bound is unconditional in consecutivePairsSum: complements the (τ-1)·consecutivePairsSum bound by routing through reciprocal_gap_index_bound rather than reciprocal_gap_consecutive_bound. Closed form Σ_{i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k = τ·H_{τ-1} - (τ-1) gives O(τ log τ)."
+      "Index-based sum bound is unconditional in consecutivePairsSum: complements the (τ-1)·consecutivePairsSum bound by routing through reciprocal_gap_index_bound rather than reciprocal_gap_consecutive_bound. Closed form Σ_{i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k = τ·H_{τ-1} - (τ-1) gives O(τ log τ).",
+      "The index double-sum bound is exactly τ·H_{τ-1} − (τ-1): the O(τ log τ) growth is now explicit and exact (not just an estimate). This is the unconditional ceiling for allPairsSum from the index argument alone — closing the gap to the absolute-constant conjecture requires using divisor arithmetic, not just counting.",
+      "Reindexing key fact: for gap k∈[1,τ-1] there are exactly τ-k pairs (i,j) with j-i=k; Finset.sum_comm handles the triangular swap cleanly given a membership iff dischargeable by omega."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Prove closed form Σ_{i<j<τ} 1/(j-i) = Σ_{k=1}^{τ-1} (τ-k)/k via reindexing (k = j-i)",
       "Combine with harmonic-sum estimate to get O(τ log τ) unconditional bound on allPairsSum",
       "Formalize AM-HM inequality for finite sums to bridge to absolute-constant conjecture",
-      "Prove conjecture for prime power case n=p^k where geometric series converge"
+      "Prove conjecture for prime power case n=p^k where geometric series converge",
+      "Bound H_{τ-1} ≤ 1 + Real.log τ (Mathlib: Real harmonic vs log) to state allPairsSum n ≤ τ(1+log τ) as a closed analytic ceiling.",
+      "Attack the conjecture gap: the τ·H_{τ-1} bound is loose because it ignores that most divisor gaps d_j-d_i greatly exceed j-i. Quantify Σ 1/(d_j-d_i) using d_j-d_i ≥ d_{i+1}-d_i and multiplicativity for prime-power n=p^k."
     ],
     "markdown": "# Erdős #884 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that, for any $n$, if $d_1<\\cdots <d_t$ are the divisors of $n$, then\\[\\sum_{1\\leq i<j\\leq t}\\frac{1}{d_j-d_i} \\ll 1+\\sum_{1\\leq i<t}\\frac{1}{d_{i+1}-d_i},\\]where the implied constant is absolute?\n\n\n\nSee also [144].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #144\n- Problem #883\n- Problem #885\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er98\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },


### PR DESCRIPTION
## Summary

Advances **Erdős #884** (open: is `Σ_{i<j} 1/(d_j−d_i) ≪ 1 + Σ_i 1/(d_{i+1}−d_i)`?) by giving the **exact** value of the unconditional index-based bound that the previous theorem `allPairsSum_le_indexSum` left as an unevaluated double sum.

Three new theorems in `proofs/Proofs/Erdos884Problem.lean`:

1. **`indexDoubleSum_closed_form (τ : ℕ)`** — the reindexing identity
   `Σ_{0≤i<j<τ} 1/(j−i) = Σ_{k=1}^{τ−1} (τ−k)/k`.
   Proof: reindex the inner sum `j ↦ j−i` (so `Ioo i τ` becomes a range of gaps), swap the order of summation with `Finset.sum_comm'`, then count the `τ−k` constant inner terms for each gap `k`. Purely combinatorial — holds for *any* `τ : ℕ`, independent of divisor structure.

2. **`gapHarmonicSum_eq (τ : ℕ)`** — exact harmonic decomposition
   `Σ_{k=1}^{τ−1} (τ−k)/k = Σ_{k=1}^{τ−1} (τ/k − 1) = τ·H_{τ−1} − (τ−1)`.

3. **`allPairsSum_le_harmonic (n) (hn : n > 1)`** — assembled unconditional bound
   `allPairsSum n ≤ τ·H_{τ−1} − (τ−1)`, depending only on the *number* of divisors `τ = τ(n)`.

### Why this is progress

The previous index bound left the right-hand side as an opaque double sum. It is now evaluated **exactly** as `τ·H_{τ−1} − (τ−1)`, making the `O(τ log τ)` ceiling explicit. This also clarifies the path to the conjecture: the counting bound is provably loose (it ignores that divisor gaps `d_j − d_i` vastly exceed index gaps `j − i`), so closing the remaining gap requires divisor *arithmetic*, not just counting.

### Integrity

- **0 sorries**, **0 new axioms**. The pre-existing `axiom erdos_884` (the OPEN conjecture) is untouched; axiom count unchanged at 1.
- ⚠️ **BUILD-PENDING / UNVERIFIED.** The docker build host is currently down (containerd blob-store I/O corruption), so the file is **not yet machine-checked**. Every Mathlib lemma used (`Finset.sum_comm'`, `Finset.sum_Ico_eq_sum_range`, `Finset.sum_const`, `nsmul_eq_mul`, `mul_one_div`, `Nat.cast_sub`, `sub_div`, `div_self`) was hand-verified against the `proofs/.lake` Mathlib source for exact name and signature. Mark ready / merge after `./proofs/scripts/docker-build.sh Proofs.Erdos884Problem` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)