### PR TITLE
Enrich prime-power Zolotarev (oq-01-oq-03-oq-01-oq-01-oq-01-oq-01): deepen annotations, map sections

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,11 +1,44 @@
 [
   {
+    "id": "ann-eqr-oq010301010101-part0",
+    "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 76 },
+    "type": "definition",
+    "title": "A monoid's units are its IsUnit subtype",
+    "content": "unitsEquivIsUnit is the generic equivalence Mˣ ≃ {x : M // IsUnit x} for any monoid M: a unit maps to its underlying element (which is a unit), and an IsUnit element maps to its associated unit. This bookkeeping isomorphism is what lets the units block of the sign factorization — phrased over the predicate IsUnit on the whole ring — be transported to the parent's left-regular-representation statement, which lives on the unit group (ℤ/pⁿ)ˣ.",
+    "mathContext": "$M^\\times \\;\\simeq\\; \\{x \\in M \\mid \\mathrm{IsUnit}(x)\\}$, with $u \\mapsto (u : M)$ and $x \\mapsto x.\\mathrm{unit}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unit group",
+      "IsUnit predicate",
+      "type equivalence",
+      "monoid"
+    ],
+    "prerequisites": [
+      "monoids and units in Mathlib",
+      "subtypes / Equiv"
+    ]
+  },
+  {
     "id": "ann-eqr-oq010301010101-bridge",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 84, "endLine": 89 },
     "type": "theorem",
     "title": "The p-multiplication bridge",
-    "content": "mul_p_eq_zero_iff: in ℤ/pⁿ⁺¹, p·z = 0 iff z reduces to 0 in ℤ/pⁿ — both express pⁿ ∣ z.val. Proof writes z = ↑n (natCast surjective) and applies ZMod.natCast_eq_zero_iff to both sides, then cancels one factor of p (Nat.mul_dvd_mul_iff_left). This single fact, promoted to p·u = p·v ⟺ castHom u = castHom v, drives both the injectivity of the non-unit isomorphism and its intertwining with the a-action."
+    "content": "mul_p_eq_zero_iff: in ℤ/pⁿ⁺¹, p·z = 0 iff z reduces to 0 in ℤ/pⁿ — both express pⁿ ∣ z.val. Proof writes z = ↑n (natCast surjective) and applies ZMod.natCast_eq_zero_iff to both sides, then cancels one factor of p (Nat.mul_dvd_mul_iff_left). This single fact, promoted to p·u = p·v ⟺ castHom u = castHom v, drives both the injectivity of the non-unit isomorphism and its intertwining with the a-action.",
+    "mathContext": "In $\\mathbb{Z}/p^{n+1}$: $\\;p\\cdot z = 0 \\iff p^{n} \\mid z.\\mathrm{val} \\iff \\bar z = 0 \\text{ in } \\mathbb{Z}/p^{n}$; hence $p\\cdot u = p\\cdot v \\iff u \\equiv v \\pmod{p^{n}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximal ideal (p)",
+      "ZMod reduction homomorphism",
+      "divisibility of valuations",
+      "quotient rings"
+    ],
+    "prerequisites": [
+      "ZMod arithmetic",
+      "ZMod.natCast_eq_zero_iff",
+      "divisibility"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101-nonunitsfun",
@@ -13,7 +46,19 @@
     "range": { "startLine": 129, "endLine": 131 },
     "type": "definition",
     "title": "The maximal ideal as p·(lift y)",
-    "content": "nonUnitsFun sends y : ℤ/pⁿ to the non-unit p·(lift y) of ℤ/pⁿ⁺¹. Every non-unit of ℤ/pⁿ⁺¹ is a multiple of p (the maximal ideal (p)), and p·(anything) is never a unit (not_isUnit_mul_p, via ZMod.isUnit_iff_coprime), so this lands in the non-units. It is the forward map of the additive isomorphism (p) ≅ ℤ/pⁿ that turns the non-unit block into a smaller copy of the whole problem."
+    "content": "nonUnitsFun sends y : ℤ/pⁿ to the non-unit p·(lift y) of ℤ/pⁿ⁺¹. Every non-unit of ℤ/pⁿ⁺¹ is a multiple of p (the maximal ideal (p)), and p·(anything) is never a unit (not_isUnit_mul_p, via ZMod.isUnit_iff_coprime), so this lands in the non-units. It is the forward map of the additive isomorphism (p) ≅ ℤ/pⁿ that turns the non-unit block into a smaller copy of the whole problem.",
+    "mathContext": "$\\mu : \\mathbb{Z}/p^{n} \\to (p) \\subset \\mathbb{Z}/p^{n+1},\\quad y \\mapsto p\\cdot\\widetilde{y}$, where the image $(p)$ is exactly the set of non-units (the unique maximal ideal).",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximal ideal",
+      "local ring ℤ/pⁿ",
+      "non-units",
+      "additive isomorphism"
+    ],
+    "prerequisites": [
+      "ZMod.isUnit_iff_coprime",
+      "ideals of ℤ/pⁿ"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101-bijective",
@@ -21,7 +66,20 @@
     "range": { "startLine": 133, "endLine": 154 },
     "type": "theorem",
     "title": "Bijectivity by injectivity and counting",
-    "content": "nonUnitsFun_bijective: injective via the bridge (p·↑y.val = p·↑y'.val forces y = y' after reducing mod pⁿ), and surjective by cardinality — the non-units of ℤ/pⁿ⁺¹ number pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ⁺¹ − pⁿ(p−1) = pⁿ (Fintype.card_subtype_compl, ZMod.card_units_eq_totient, Nat.totient_prime_pow_succ), matching |ℤ/pⁿ|. No explicit inverse is needed (Fintype.bijective_iff_injective_and_card)."
+    "content": "nonUnitsFun_bijective: injective via the bridge (p·↑y.val = p·↑y'.val forces y = y' after reducing mod pⁿ), and surjective by cardinality — the non-units of ℤ/pⁿ⁺¹ number pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ⁺¹ − pⁿ(p−1) = pⁿ (Fintype.card_subtype_compl, ZMod.card_units_eq_totient, Nat.totient_prime_pow_succ), matching |ℤ/pⁿ|. No explicit inverse is needed (Fintype.bijective_iff_injective_and_card).",
+    "mathContext": "$\\#\\{\\text{non-units of } \\mathbb{Z}/p^{n+1}\\} = p^{n+1} - \\varphi(p^{n+1}) = p^{n+1} - p^{n}(p-1) = p^{n} = \\#\\,\\mathbb{Z}/p^{n}$; injective + equal cardinality $\\Rightarrow$ bijective.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euler totient",
+      "Nat.totient_prime_pow_succ",
+      "pigeonhole / counting bijection",
+      "cardinality of unit group"
+    ],
+    "prerequisites": [
+      "Fintype cardinality",
+      "Euler's totient function",
+      "bijective_iff_injective_and_card"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101-recursion",
@@ -29,14 +87,40 @@
     "range": { "startLine": 180, "endLine": 257 },
     "type": "theorem",
     "title": "The block recursion sign_ringMulPerm_succ",
-    "content": "The heart of the file. ringMulPerm a preserves IsUnit (a is a unit; IsUnit.mul_iff), so Equiv.Perm.sign_subtypeCongr factors sign(ringMulPerm a) = sign(units block)·sign(non-unit block). The units block is transported (sign_eq_sign_of_equiv along the units↔IsUnit-subtype equiv) to sign(Equiv.mulLeft a) = legendreSym p (a mod p) — the parent units-level lemma. The non-unit block is transported along the p·(lift y) bijection to sign(ringMulPerm ā) on ℤ/pⁿ⁻¹; the required intertwining μ(ā·y) = a·μ(y) is exactly the p-multiplication bridge."
+    "content": "The heart of the file. ringMulPerm a preserves IsUnit (a is a unit; IsUnit.mul_iff), so Equiv.Perm.sign_subtypeCongr factors sign(ringMulPerm a) = sign(units block)·sign(non-unit block). The units block is transported (sign_eq_sign_of_equiv along the units↔IsUnit-subtype equiv) to sign(Equiv.mulLeft a) = legendreSym p (a mod p) — the parent units-level lemma. The non-unit block is transported along the p·(lift y) bijection to sign(ringMulPerm ā) on ℤ/pⁿ⁻¹; the required intertwining μ(ā·y) = a·μ(y) is exactly the p-multiplication bridge.",
+    "mathContext": "$\\mathrm{sign}(a\\cdot \\text{ on } \\mathbb{Z}/p^{n+1}) = \\underbrace{\\mathrm{sign}(a\\cdot \\text{ on units})}_{\\left(\\frac{a}{p}\\right)} \\cdot \\underbrace{\\mathrm{sign}(\\bar a\\cdot \\text{ on } \\mathbb{Z}/p^{n})}_{\\text{recursion}}$, using $\\mu(\\bar a\\cdot y) = a\\cdot\\mu(y)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Equiv.Perm.sign_subtypeCongr",
+      "invariant block decomposition",
+      "left regular representation",
+      "intertwining map / recursion"
+    ],
+    "prerequisites": [
+      "permutation sign over invariant subtypes",
+      "transport of sign across an equiv",
+      "the parent units-level lemma"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101-headline",
     "proofId": "elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 267, "endLine": 320 },
+    "range": { "startLine": 267, "endLine": 318 },
     "type": "theorem",
     "title": "Prime-power Zolotarev: legendre power and Jacobi form",
-    "content": "sign_ringMulPerm_eq_legendre_pow inducts the one-step recursion on the exponent to get sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ (base case n = 1: the non-unit block is the singleton {0}, sign 1). jacobiSym_prime_pow proves J(A | pⁿ) = (legendreSym p A)ⁿ via jacobiSym.mul_right, and sign_ringMulPerm_eq_jacobiSym packages the headline as the Jacobi symbol J(a | pⁿ) — closing the prime-power case of the Frobenius/Zolotarev identity."
+    "content": "sign_ringMulPerm_eq_legendre_pow inducts the one-step recursion on the exponent to get sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ (base case n = 1: the non-unit block is the singleton {0}, sign 1). jacobiSym_prime_pow proves J(A | pⁿ) = (legendreSym p A)ⁿ via jacobiSym.mul_right, and sign_ringMulPerm_eq_jacobiSym packages the headline as the Jacobi symbol J(a | pⁿ) — closing the prime-power case of the Frobenius/Zolotarev identity.",
+    "mathContext": "$\\mathrm{sign}(a\\cdot \\text{ on } \\mathbb{Z}/p^{n}) = \\left(\\tfrac{a \\bmod p}{p}\\right)^{n} = J\\!\\left(a \\mid p^{n}\\right)$, for an odd prime $p$ and a unit $a$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre symbol",
+      "Jacobi symbol",
+      "jacobiSym.mul_right",
+      "induction on the exponent"
+    ],
+    "prerequisites": [
+      "Legendre and Jacobi symbols",
+      "multiplicativity of the Jacobi symbol",
+      "induction"
+    ]
   }
 ]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -43,20 +43,34 @@
   },
   "sections": [
     {
+      "title": "A monoid's units are its IsUnit subtype",
+      "startLine": 63,
+      "endLine": 76,
+      "content": "PART 0 (generic bookkeeping). unitsEquivIsUnit: the equivalence Mˣ ≃ {x : M // IsUnit x} for any monoid M. This isomorphism lets the units block of the sign factorization — phrased over the predicate IsUnit on the whole ring ℤ/pⁿ — be transported to the parent's left-regular-representation lemma, which lives on the unit group (ℤ/pⁿ)ˣ."
+    },
+    {
       "title": "The p-multiplication bridge on ℤ/pⁿ⁺¹",
-      "content": "mul_p_eq_zero_iff: p·z = 0 in ℤ/pⁿ⁺¹ iff z reduces to 0 in ℤ/pⁿ (both express pⁿ ∣ z.val), via ZMod.natCast_eq_zero_iff and cancelling one factor of p (Nat.mul_dvd_mul_iff_left). mul_p_of_castHom_eq and castHom_eq_of_mul_p_eq promote this to p·u = p·v ⟺ castHom u = castHom v — the single fact behind both the non-unit isomorphism and its intertwining."
+      "startLine": 77,
+      "endLine": 112,
+      "content": "PART I. mul_p_eq_zero_iff: p·z = 0 in ℤ/pⁿ⁺¹ iff z reduces to 0 in ℤ/pⁿ (both express pⁿ ∣ z.val), via ZMod.natCast_eq_zero_iff and cancelling one factor of p (Nat.mul_dvd_mul_iff_left). mul_p_of_castHom_eq and castHom_eq_of_mul_p_eq promote this to p·u = p·v ⟺ castHom u = castHom v — the single fact behind both the non-unit isomorphism and its intertwining."
     },
     {
       "title": "The non-unit block is ℤ/pⁿ⁻¹",
-      "content": "not_isUnit_mul_p: p·z is never a unit (ZMod.isUnit_iff_coprime). nonUnitsFun / nonUnitsFun_bijective / nonUnitsEquiv: y ↦ p·(lift y) is a bijection ℤ/pⁿ ≃ {non-units of ℤ/pⁿ⁺¹}, injective by the bridge and surjective by counting (pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ)."
+      "startLine": 113,
+      "endLine": 172,
+      "content": "PART II. not_isUnit_mul_p: p·z is never a unit (ZMod.isUnit_iff_coprime). nonUnitsFun / nonUnitsFun_bijective / nonUnitsEquiv: y ↦ p·(lift y) is a bijection ℤ/pⁿ ≃ {non-units of ℤ/pⁿ⁺¹}, injective by the bridge and surjective by counting (pⁿ⁺¹ − φ(pⁿ⁺¹) = pⁿ)."
     },
     {
       "title": "The prime-power recursion for the whole-ring sign",
-      "content": "sign_ringMulPerm_succ: for a unit a : (ℤ/pⁿ⁺¹)ˣ, sign(ringMulPerm a) = legendreSym p (a mod p) · sign(ringMulPerm ā on ℤ/pⁿ). Proof: sign_subtypeCongr factors the sign over the units / non-units partition; the units block is sign(Equiv.mulLeft a) = legendreSym p (a mod p) (parent lemma, transported via units↔IsUnit-subtype equiv); the non-unit block is sign(ringMulPerm ā) (transported via the μ-bijection, intertwining from the bridge)."
+      "startLine": 173,
+      "endLine": 260,
+      "content": "PART III. sign_ringMulPerm_succ: for a unit a : (ℤ/pⁿ⁺¹)ˣ, sign(ringMulPerm a) = legendreSym p (a mod p) · sign(ringMulPerm ā on ℤ/pⁿ). Proof: sign_subtypeCongr factors the sign over the units / non-units partition; the units block is sign(Equiv.mulLeft a) = legendreSym p (a mod p) (parent lemma, transported via units↔IsUnit-subtype equiv); the non-unit block is sign(ringMulPerm ā) (transported via the μ-bijection, intertwining from the bridge)."
     },
     {
       "title": "The prime-power Zolotarev–Frobenius identity",
-      "content": "sign_ringMulPerm_eq_legendre_pow: iterating the recursion, sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ. jacobiSym_prime_pow + sign_ringMulPerm_eq_jacobiSym: J(A | pⁿ) = (legendreSym p A)ⁿ (jacobiSym.mul_right), so the sign equals the Jacobi symbol J(a | pⁿ) — closing the prime-power case."
+      "startLine": 261,
+      "endLine": 318,
+      "content": "PART IV. sign_ringMulPerm_eq_legendre_pow: iterating the recursion, sign(ringMulPerm a on ℤ/pⁿ) = legendreSym p (a mod p)ⁿ. jacobiSym_prime_pow + sign_ringMulPerm_eq_jacobiSym: J(A | pⁿ) = (legendreSym p A)ⁿ (jacobiSym.mul_right), so the sign equals the Jacobi symbol J(a | pⁿ) — closing the prime-power case."
     }
   ],
   "meta": {


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01` (whole-ring prime-power Zolotarev/Frobenius sign identity).

## Changes
- **Deepened all annotations.** Previously every annotation had only `content` — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`. Added all four to each: LaTeX `mathContext` (the bridge $p\cdot u = p\cdot v \iff u \equiv v\,(p^n)$, the totient count $p^{n+1}-\varphi(p^{n+1})=p^n$, the block factorization, the headline $\mathrm{sign} = (\tfrac{a}{p})^n = J(a\mid p^n)$, etc.), a `significance` tier, 4 `relatedConcepts`, and `prerequisites` per annotation.
- **Added a 6th annotation for PART 0** (`unitsEquivIsUnit`, the $M^\times \simeq \{x \mid \mathrm{IsUnit}\,x\}$ bookkeeping equivalence), which had no coverage, and corrected the headline annotation's end line to the true last line (318).
- **Mapped the sections to the source.** Added `startLine`/`endLine` to every section (they previously had none) and a new PART 0 section, so the `sections` array now covers the full 318-line file (PART 0–IV) contiguously.

## Notes
- meta.json ~15 KB, well under the 60 KB cap. Axiom integrity unchanged: `verified`/`verified`, 0 axioms, 0 sorries (consistent with `#print axioms` depending only on propext/Classical.choice/Quot.sound).
- `annotations:build` validates this entry with **0 errors** (annotation types match the Lean constructs at each startLine; line ranges in bounds). The 3032 errors it reports are pre-existing across other gallery entries, not introduced here.