### PR TITLE
research(godel-incompleteness-oq-03): abstract independence framework on Mathlib model theory

### DIFF
--- a/proofs/Proofs/GodelIncompletenessOQ03.lean
+++ b/proofs/Proofs/GodelIncompletenessOQ03.lean
@@ -1,0 +1,145 @@
+import Mathlib
+
+/-!
+# Natural Mathematical Statements Independent of PA — an abstract independence framework
+
+`godel-incompleteness-oq-03`
+
+The parent gallery entry `godel-incompleteness` gives an *illustrative* sketch of
+Gödel's theorems built around a placeholder provability predicate
+(`Provable := fun _ => False`). That sketch cannot express what it means for a
+*specific* sentence to be independent, because its provability predicate is trivial.
+
+This file instead develops the **abstract theory of independence** on top of
+Mathlib's genuine first-order model theory (`FirstOrder.Language.Theory`), where
+`T ⊨ᵇ φ` is real semantic consequence quantified over *all* models of `T`.
+
+A sentence `φ` is **independent** of a theory `T` when `T` neither entails `φ`
+nor entails `¬φ`:  `T ⊭ φ` and `T ⊭ ¬φ`.  This is exactly the shape of every
+"natural statement independent of PA":
+
+* **Goodstein's theorem** (Kirby–Paris 1982),
+* the **Paris–Harrington** strengthening of the finite Ramsey theorem,
+* the **Kirby–Paris hydra** termination statement,
+* the consistency sentence **`Con(PA)`** (Gödel's second theorem),
+
+are all sentences `φ` with `PA ⊭ φ` and `PA ⊭ ¬φ`.
+
+## What is proved here (fully verified against Mathlib: 0 axioms, 0 sorries)
+
+* `Independent.not_isComplete` — a theory possessing *any* independent sentence is
+  **not complete**.  This is the abstract content of "independence ⇒ incompleteness".
+* `isComplete_iff_forall_not_independent` — completeness is *exactly* the absence of
+  any independent sentence (for a satisfiable theory).
+* `Independent.satisfiable_insert_not` / `Independent.satisfiable_insert` —
+  independence produces two genuinely different model classes: `T ∪ {¬φ}` and
+  `T ∪ {φ}` are *both* satisfiable.
+* `independent_iff_satisfiable_both` — the model-theoretic characterization of
+  independence via the Completeness Theorem (`models_iff_not_satisfiable`):
+  `φ` is independent of `T` iff both `T ∪ {¬φ}` and `T ∪ {φ}` have models.
+
+## What remains genuinely open / out of scope
+
+Exhibiting a *concrete* natural `φ` independent of PA (Goodstein, Paris–Harrington,
+`Con(PA)`) requires formalizing PA's syntax, `ε₀`-induction, fast-growing hierarchies,
+and the unprovability arguments — thousands of lines that are absent from current
+Mathlib. This file supplies the abstract scaffolding those theorems instantiate, not
+the theorems themselves.
+-/
+
+open FirstOrder Language
+
+namespace GodelIncompletenessOQ03
+
+variable {L : Language} {T : L.Theory} {φ : L.Sentence}
+
+/-- Replacing a sentence by its **double negation** in a one-sentence extension does
+    not change satisfiability: `T ∪ {¬¬φ}` has a model iff `T ∪ {φ}` does.  Both
+    extensions have the same models, since `M ⊨ ¬¬φ ↔ M ⊨ φ` in every structure.
+
+    This is the bookkeeping bridge that lets the Completeness-Theorem characterization
+    of independence be stated in terms of `T ∪ {φ}` rather than the syntactic
+    `T ∪ {¬¬φ}` produced by `models_iff_not_satisfiable`. -/
+theorem isSatisfiable_insert_not_not_iff :
+    Theory.IsSatisfiable (T ∪ {φ.not.not}) ↔ Theory.IsSatisfiable (T ∪ {φ}) := by
+  -- A generic transfer: if `ψ` semantically implies `χ` in every structure, then a
+  -- model of `T ∪ {ψ}` is a model of `T ∪ {χ}`.
+  have transfer : ∀ {ψ χ : L.Sentence},
+      (∀ {N : Type _} [L.Structure N], (N ⊨ ψ) → (N ⊨ χ)) →
+      Theory.IsSatisfiable (T ∪ {ψ}) → Theory.IsSatisfiable (T ∪ {χ}) := by
+    rintro ψ χ himp ⟨M⟩
+    have hm : (M : Type _) ⊨ (T ∪ {ψ}) := M.is_model
+    rw [Theory.model_union_iff, Theory.model_singleton_iff] at hm
+    haveI : (M : Type _) ⊨ (T ∪ {χ}) := by
+      rw [Theory.model_union_iff, Theory.model_singleton_iff]
+      exact ⟨hm.1, himp hm.2⟩
+    exact Theory.Model.isSatisfiable (T := T ∪ {χ}) (M : Type _)
+  constructor
+  · exact transfer (fun h => by
+      rw [Sentence.realize_not, Sentence.realize_not] at h; exact not_not.1 h)
+  · exact transfer (fun h => by
+      rw [Sentence.realize_not, Sentence.realize_not]; exact not_not_intro h)
+
+/-- A sentence `φ` is **independent** of a theory `T` when `T` entails neither `φ`
+    nor its negation `¬φ`.  Semantically: there is a model of `T` in which `φ` is
+    false (so `T ⊭ φ`) and a model of `T` in which `φ` is true (so `T ⊭ ¬φ`). -/
+def Independent (T : L.Theory) (φ : L.Sentence) : Prop :=
+  ¬ T ⊨ᵇ φ ∧ ¬ T ⊨ᵇ φ.not
+
+namespace Independent
+
+theorem not_models (h : Independent T φ) : ¬ T ⊨ᵇ φ := h.1
+
+theorem not_models_not (h : Independent T φ) : ¬ T ⊨ᵇ φ.not := h.2
+
+/-- **Independence forces incompleteness.**  A complete theory entails `φ` or `¬φ`
+    for every sentence; an independent sentence entails neither, a contradiction. -/
+theorem not_isComplete (h : Independent T φ) : ¬ T.IsComplete := by
+  rintro hc
+  exact (hc.2 φ).elim h.1 h.2
+
+/-- Independence yields a model of `T` refuting `φ`: `T ∪ {¬φ}` is satisfiable.
+    (This witnesses `T ⊭ φ` via the Completeness Theorem.) -/
+theorem satisfiable_insert_not (h : Independent T φ) :
+    Theory.IsSatisfiable (T ∪ {φ.not}) := by
+  have h1 := h.1
+  rw [Theory.models_iff_not_satisfiable] at h1
+  exact not_not.1 h1
+
+/-- Independence yields a model of `T` satisfying `φ`: `T ∪ {φ}` is satisfiable.
+    (This witnesses `T ⊭ ¬φ` via the Completeness Theorem.) -/
+theorem satisfiable_insert (h : Independent T φ) :
+    Theory.IsSatisfiable (T ∪ {φ}) := by
+  have h2 := h.2
+  rw [Theory.models_iff_not_satisfiable] at h2
+  rw [← isSatisfiable_insert_not_not_iff]
+  exact not_not.1 h2
+
+end Independent
+
+/-- **Model-theoretic characterization of independence.**  `φ` is independent of `T`
+    iff both one-sentence extensions `T ∪ {¬φ}` and `T ∪ {φ}` are satisfiable — i.e.
+    `T` has a model where `φ` fails and a model where `φ` holds.  Immediate from the
+    Completeness Theorem (`models_iff_not_satisfiable`). -/
+theorem independent_iff_satisfiable_both :
+    Independent T φ ↔
+      Theory.IsSatisfiable (T ∪ {φ.not}) ∧ Theory.IsSatisfiable (T ∪ {φ}) := by
+  unfold Independent
+  rw [Theory.models_iff_not_satisfiable φ, Theory.models_iff_not_satisfiable φ.not,
+      not_not, not_not, isSatisfiable_insert_not_not_iff]
+
+/-- **Completeness is exactly the absence of independent sentences.**  For a
+    satisfiable theory `T`, `T` is complete iff no sentence is independent of it.
+    The contrapositive of `Independent.not_isComplete`, packaged as an equivalence. -/
+theorem isComplete_iff_forall_not_independent (hsat : T.IsSatisfiable) :
+    T.IsComplete ↔ ∀ φ : L.Sentence, ¬ Independent T φ := by
+  constructor
+  · intro hc φ hind
+    exact hind.not_isComplete hc
+  · intro h
+    refine ⟨hsat, fun φ => ?_⟩
+    by_contra hcon
+    push_neg at hcon
+    exact h φ ⟨hcon.1, hcon.2⟩
+
+end GodelIncompletenessOQ03

--- a/src/data/proofs/godel-incompleteness-oq-03/annotations.json
+++ b/src/data/proofs/godel-incompleteness-oq-03/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "godel-oq03-double-negation-bridge",
+    "proofId": "godel-incompleteness-oq-03",
+    "range": {
+      "startLine": 55,
+      "endLine": 85
+    },
+    "type": "theorem",
+    "title": "The Double-Negation Satisfiability Bridge",
+    "content": "isSatisfiable_insert_not_not_iff proves IsSatisfiable (T ∪ {φ.not.not}) ↔ IsSatisfiable (T ∪ {φ}). Although φ.not.not is semantically equivalent to φ, it is a syntactically distinct sentence, so the two one-sentence extensions are different theories that must be shown equi-satisfiable. The proof factors through a reusable transfer lemma: if a sentence ψ semantically implies χ in every structure (∀ N [Structure N], N ⊨ ψ → N ⊨ χ), then a model of T ∪ {ψ} yields a model of T ∪ {χ} — built by decomposing the model via model_union_iff and model_singleton_iff, transporting the singleton along the implication, and reassembling with Theory.Model.isSatisfiable. Instantiating both directions at the realize-equivalence M ⊨ ¬¬φ ↔ M ⊨ φ (two applications of Sentence.realize_not) gives the bridge.",
+    "mathContext": "$M \\models \\neg\\neg\\varphi \\leftrightarrow M \\models \\varphi$ in every structure, hence $T \\cup \\{\\neg\\neg\\varphi\\}$ and $T \\cup \\{\\varphi\\}$ have the same models and are equi-satisfiable.",
+    "significance": "supporting",
+    "prerequisites": [
+      "FirstOrder.Language.Theory.model_union_iff",
+      "FirstOrder.Language.Theory.model_singleton_iff",
+      "FirstOrder.Language.Theory.Model.isSatisfiable",
+      "FirstOrder.Language.Sentence.realize_not"
+    ],
+    "relatedConcepts": [
+      "equi-satisfiability",
+      "model transfer",
+      "double negation",
+      "semantic equivalence"
+    ]
+  },
+  {
+    "id": "godel-oq03-independence-incompleteness",
+    "proofId": "godel-incompleteness-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 102
+    },
+    "type": "definition",
+    "title": "Independence Forces Incompleteness",
+    "content": "Independent T φ := ¬ T ⊨ᵇ φ ∧ ¬ T ⊨ᵇ φ.not defines independence over Mathlib's real semantic consequence relation: T entails neither φ nor its negation. The projections not_models / not_models_not expose each conjunct. Independent.not_isComplete then shows any independent sentence makes T not complete: Theory.IsComplete is defined as T.IsSatisfiable ∧ ∀ φ, T ⊨ᵇ φ ∨ T ⊨ᵇ φ.not, and an independent φ is a direct counterexample to the universal disjunction, so the proof is a two-line case-elimination.",
+    "mathContext": "$\\mathrm{Independent}(T,\\varphi) := T \\not\\models \\varphi \\wedge T \\not\\models \\neg\\varphi$. Since completeness requires $\\forall\\varphi,\\ T\\models\\varphi \\vee T\\models\\neg\\varphi$, an independent $\\varphi$ yields $\\neg\\,T.\\mathrm{IsComplete}$.",
+    "significance": "critical",
+    "prerequisites": [
+      "FirstOrder.Language.Theory.IsComplete",
+      "FirstOrder.Language.Theory.ModelsBoundedFormula"
+    ],
+    "relatedConcepts": [
+      "independence",
+      "incompleteness",
+      "complete theory",
+      "semantic consequence"
+    ]
+  },
+  {
+    "id": "godel-oq03-satisfiable-witnesses",
+    "proofId": "godel-incompleteness-oq-03",
+    "range": {
+      "startLine": 103,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "Both One-Sentence Extensions Are Satisfiable",
+    "content": "Independent.satisfiable_insert_not derives IsSatisfiable (T ∪ {φ.not}) from the first conjunct ¬ T ⊨ᵇ φ via the Completeness Theorem models_iff_not_satisfiable (which states T ⊨ᵇ φ ↔ ¬ IsSatisfiable (T ∪ {φ.not})) and not_not. Independent.satisfiable_insert derives IsSatisfiable (T ∪ {φ}) from the second conjunct ¬ T ⊨ᵇ φ.not: applying models_iff_not_satisfiable to φ.not gives satisfiability of T ∪ {φ.not.not}, which the double-negation bridge converts to T ∪ {φ}. Together these exhibit a model of T refuting φ and a model of T satisfying φ — the two witnesses making φ undecidable in T.",
+    "mathContext": "By the Completeness Theorem, $T\\not\\models\\varphi \\Leftrightarrow T\\cup\\{\\neg\\varphi\\}$ is satisfiable, and $T\\not\\models\\neg\\varphi \\Leftrightarrow T\\cup\\{\\varphi\\}$ is satisfiable.",
+    "significance": "key",
+    "prerequisites": [
+      "FirstOrder.Language.Theory.models_iff_not_satisfiable",
+      "isSatisfiable_insert_not_not_iff"
+    ],
+    "relatedConcepts": [
+      "Completeness Theorem",
+      "satisfiability",
+      "model existence",
+      "undecidable sentence"
+    ]
+  },
+  {
+    "id": "godel-oq03-characterization",
+    "proofId": "godel-incompleteness-oq-03",
+    "range": {
+      "startLine": 119,
+      "endLine": 145
+    },
+    "type": "theorem",
+    "title": "Model-Theoretic Characterization and Completeness",
+    "content": "independent_iff_satisfiable_both packages the model existence content as an equivalence: Independent T φ ↔ IsSatisfiable (T ∪ {φ.not}) ∧ IsSatisfiable (T ∪ {φ}). It is proved by unfolding Independent and rewriting with models_iff_not_satisfiable at both φ and φ.not, clearing the resulting double negations, and applying the double-negation bridge. isComplete_iff_forall_not_independent then exhibits completeness as the absence of independence: for a satisfiable T, T.IsComplete ↔ ∀ φ, ¬ Independent T φ. The forward direction is not_isComplete; the reverse rebuilds the completeness disjunction by by_contra + push_neg, recognizing the negated disjunction as exactly the independence conjunction.",
+    "mathContext": "$\\varphi$ is independent of $T$ iff $T$ has both a model satisfying $\\varphi$ and a model refuting it; a satisfiable theory is complete iff it admits no independent sentence.",
+    "significance": "critical",
+    "prerequisites": [
+      "FirstOrder.Language.Theory.models_iff_not_satisfiable",
+      "FirstOrder.Language.Theory.IsComplete",
+      "isSatisfiable_insert_not_not_iff"
+    ],
+    "relatedConcepts": [
+      "characterization theorem",
+      "complete theory",
+      "independence",
+      "Continuum Hypothesis"
+    ]
+  }
+]

--- a/src/data/proofs/godel-incompleteness-oq-03/index.ts
+++ b/src/data/proofs/godel-incompleteness-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GodelIncompletenessOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const godelIncompletenessOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const godelIncompletenessOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const godelIncompletenessOq03Data: ProofData = {
+  proof: godelIncompletenessOq03Proof,
+  annotations: godelIncompletenessOq03Annotations,
+}

--- a/src/data/proofs/godel-incompleteness-oq-03/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-03/meta.json
@@ -1,0 +1,207 @@
+{
+  "id": "godel-incompleteness-oq-03",
+  "slug": "godel-incompleteness-oq-03",
+  "title": "Independence and Incompleteness: the Abstract Model-Theoretic Core",
+  "description": "Develops the abstract theory of logical independence on top of Mathlib's genuine first-order model theory (FirstOrder.Language.Theory), where T ⊨ᵇ φ is real semantic consequence quantified over all models of T. This is the open-question follow-up to the parent godel-incompleteness gallery entry, whose provability predicate is a pedagogical placeholder (Provable := fun _ => False) and therefore cannot express what it means for a specific sentence to be independent. Here a sentence φ is Independent of a theory T exactly when T entails neither φ nor ¬φ (T ⊭ φ and T ⊭ φ.not) — the precise shape of every natural statement independent of PA: Goodstein's theorem, the Paris–Harrington principle, the Kirby–Paris hydra, and Con(PA). The entry proves, fully verified against Mathlib with 0 axioms and 0 sorries: (1) Independent.not_isComplete — any theory possessing an independent sentence is not complete, the abstract content of 'independence ⇒ incompleteness', immediate from Theory.IsComplete's definition; (2) isSatisfiable_insert_not_not_iff — the double-negation bookkeeping bridge T ∪ {¬¬φ} is satisfiable iff T ∪ {φ} is, proved by a generic model-transfer along the realize-equivalence M ⊨ ¬¬φ ↔ M ⊨ φ; (3) Independent.satisfiable_insert_not and Independent.satisfiable_insert — independence produces two genuinely different model classes, T ∪ {¬φ} and T ∪ {φ} both satisfiable, via the Completeness Theorem (models_iff_not_satisfiable); (4) independent_iff_satisfiable_both — the model-theoretic characterization: φ is independent of T iff T has a model where φ fails and a model where φ holds; (5) isComplete_iff_forall_not_independent — for a satisfiable theory, completeness is exactly the absence of any independent sentence. The deliberate boundary: exhibiting a concrete natural φ independent of PA (Goodstein, Paris–Harrington, Con(PA)) requires formalizing PA's syntax, ε₀-induction, and the unprovability arguments — thousands of lines absent from current Mathlib — and is left genuinely open. What is built is the abstract scaffolding those theorems instantiate. 8 theorems + 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GodelIncompletenessOQ03.lean",
+    "additionalFiles": [],
+    "tags": [
+      "logic",
+      "model-theory",
+      "incompleteness",
+      "independence",
+      "first-order-logic",
+      "completeness-theorem",
+      "godel",
+      "peano-arithmetic",
+      "verified",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 145,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "assumptions": "None beyond Mathlib's first-order model theory. All results are universally quantified over an arbitrary Language L, theory T : L.Theory and sentence φ : L.Sentence; semantic consequence T ⊨ᵇ φ (ModelsBoundedFormula), satisfiability (Theory.IsSatisfiable) and completeness (Theory.IsComplete) are Mathlib's own definitions. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
+    "mathlibDependencies": [
+      {
+        "theorem": "FirstOrder.Language.Theory.models_iff_not_satisfiable",
+        "description": "The semantic form of the Completeness Theorem: T ⊨ᵇ φ ↔ ¬ IsSatisfiable (T ∪ {φ.not}). The bridge that converts 'T does not entail φ' into 'T together with ¬φ has a model', used to derive both satisfiable_insert lemmas and the independent_iff_satisfiable_both characterization.",
+        "module": "Mathlib.ModelTheory.Satisfiability"
+      },
+      {
+        "theorem": "FirstOrder.Language.Theory.IsComplete",
+        "description": "T.IsComplete := T.IsSatisfiable ∧ ∀ φ, T ⊨ᵇ φ ∨ T ⊨ᵇ φ.not. Independence directly contradicts the universal disjunction, giving Independent.not_isComplete and the isComplete_iff_forall_not_independent equivalence.",
+        "module": "Mathlib.ModelTheory.Satisfiability"
+      },
+      {
+        "theorem": "FirstOrder.Language.Theory.Model.isSatisfiable",
+        "description": "A type carrying a structure that models T witnesses T.IsSatisfiable. Used in the model-transfer proof of isSatisfiable_insert_not_not_iff to rebuild a model of T ∪ {φ} from a model of T ∪ {¬¬φ}.",
+        "module": "Mathlib.ModelTheory.Satisfiability"
+      },
+      {
+        "theorem": "FirstOrder.Language.Sentence.realize_not",
+        "description": "M ⊨ φ.not ↔ ¬ M ⊨ φ in every structure. Applied twice gives the realize-equivalence M ⊨ ¬¬φ ↔ M ⊨ φ that drives the double-negation satisfiability bridge.",
+        "module": "Mathlib.ModelTheory.Semantics"
+      },
+      {
+        "theorem": "FirstOrder.Language.Theory.model_union_iff / model_singleton_iff",
+        "description": "M ⊨ T ∪ T' ↔ M ⊨ T ∧ M ⊨ T' and M ⊨ {φ} ↔ M ⊨ φ. Decompose and reassemble the one-sentence extensions T ∪ {ψ} when transferring a model along a semantic implication.",
+        "module": "Mathlib.ModelTheory.Semantics"
+      }
+    ],
+    "originalContributions": [
+      "Independent (T : L.Theory) (φ : L.Sentence): φ is independent of T when T entails neither φ nor ¬φ (¬ T ⊨ᵇ φ ∧ ¬ T ⊨ᵇ φ.not). Stated over Mathlib's real semantic consequence relation, this captures the genuine meaning of 'natural statement independent of PA' that the parent entry's placeholder provability predicate could not.",
+      "Independent.not_isComplete: a theory with any independent sentence is not complete — the abstract content of 'independence implies incompleteness'. Immediate from IsComplete's definition: completeness demands T ⊨ᵇ φ ∨ T ⊨ᵇ φ.not for every φ, which an independent φ refutes.",
+      "isSatisfiable_insert_not_not_iff: IsSatisfiable (T ∪ {¬¬φ}) ↔ IsSatisfiable (T ∪ {φ}). Proved by a reusable model-transfer: a semantic implication M ⊨ ψ → M ⊨ χ holding in every structure lifts a model of T ∪ {ψ} to a model of T ∪ {χ}; instantiated both ways at the realize-equivalence ¬¬φ ↔ φ. This is the bookkeeping needed to phrase the characterization in terms of T ∪ {φ} rather than the syntactic ¬¬φ produced by the Completeness Theorem.",
+      "Independent.satisfiable_insert_not and Independent.satisfiable_insert: independence yields two genuinely different model classes — a model of T refuting φ (T ∪ {¬φ} satisfiable) and a model of T satisfying φ (T ∪ {φ} satisfiable). These are the two 'witnesses' that make φ undecidable in T.",
+      "independent_iff_satisfiable_both: φ is independent of T iff both T ∪ {¬φ} and T ∪ {φ} are satisfiable — the clean model-theoretic characterization of independence, obtained from the Completeness Theorem plus the double-negation bridge.",
+      "isComplete_iff_forall_not_independent: for a satisfiable theory T, T.IsComplete ↔ ∀ φ, ¬ Independent T φ. Packages the contrapositive of not_isComplete as an equivalence, exhibiting completeness as exactly the absence of independent sentences."
+    ],
+    "prerequisites": [
+      "godel-incompleteness (parent: the conceptual incompleteness theorems and the placeholder this entry replaces with real model theory)",
+      "First-order model theory: languages, structures, satisfaction, theories",
+      "The Completeness Theorem (semantic consequence ↔ unsatisfiability of the negation)",
+      "Mathlib.ModelTheory.Satisfiability and Mathlib.ModelTheory.Semantics"
+    ],
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "path": "Proofs/GodelIncompletenessOQ03.lean",
+    "filename": "GodelIncompletenessOQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "GodelIncompletenessOQ03",
+    "lineCount": 145,
+    "theoremCount": 8,
+    "axiomCount": 0,
+    "definitionCount": 1,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GodelIncompletenessOQ03.lean",
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Gödel's 1931 incompleteness theorems established that any consistent, recursively axiomatizable theory strong enough to encode arithmetic has sentences it can neither prove nor refute — sentences independent of the theory. For decades the only known examples were the self-referential Gödel sentence and the consistency statement Con(PA), both visibly metamathematical. The situation changed in 1977–1982, when Paris and Harrington exhibited a strengthening of the finite Ramsey theorem unprovable in PA, and Kirby and Paris showed that Goodstein's theorem and the termination of the Hydra game are independent of PA. These are 'natural' combinatorial statements with no overt self-reference, and their unprovability is witnessed by fast-growing functions outpacing every PA-provably-total function. The semantic counterpart of all of this is clean: a sentence φ is independent of a theory T precisely when T has a model in which φ holds and another in which φ fails. Mathlib's first-order model theory (the FirstOrder.Language hierarchy, the satisfaction relation, the Completeness Theorem) provides exactly the apparatus needed to state and reason about independence rigorously — which is what this entry does.",
+    "problemStatement": "The parent gallery entry godel-incompleteness is a pedagogical scaffold whose provability predicate is the placeholder Provable := fun _ => False, making all its formal statements vacuously true. Open question OQ-03 asks: can the notion of a sentence being independent of a theory — the actual content of 'natural statements independent of PA' — be formalized and its basic theory proved against genuine semantics rather than a placeholder? Concretely: define independence over Mathlib's semantic consequence relation T ⊨ᵇ φ, and prove (a) independence forces incompleteness, (b) independence is equivalent to both one-sentence extensions T ∪ {φ} and T ∪ {¬φ} being satisfiable, and (c) completeness is exactly the absence of independent sentences.",
+    "text": "A 145-line, fully verified (0 axioms, 0 sorries) abstract independence framework built on Mathlib's FirstOrder.Language.Theory. Independence is defined as Independent T φ := ¬ T ⊨ᵇ φ ∧ ¬ T ⊨ᵇ φ.not over real semantic consequence. The file proves that an independent sentence makes a theory incomplete (Independent.not_isComplete), that independence is characterized model-theoretically by the joint satisfiability of T ∪ {φ} and T ∪ {¬φ} (independent_iff_satisfiable_both), and that completeness is exactly the absence of independent sentences (isComplete_iff_forall_not_independent). A reusable double-negation satisfiability bridge (isSatisfiable_insert_not_not_iff) handles the bookkeeping the Completeness Theorem leaves behind. The entry deliberately stops short of exhibiting a concrete PA-independent sentence — Goodstein, Paris–Harrington, Con(PA) — which needs PA's syntax and ε₀-induction, machinery absent from current Mathlib.",
+    "proofStrategy": "Everything reduces to two Mathlib facts about real semantics. First, the definition Theory.IsComplete T = T.IsSatisfiable ∧ ∀ φ, T ⊨ᵇ φ ∨ T ⊨ᵇ φ.not makes 'independence ⇒ incompleteness' a one-line contradiction: an independent φ refutes the universal disjunction. Second, the Completeness Theorem in the form models_iff_not_satisfiable φ : T ⊨ᵇ φ ↔ ¬ IsSatisfiable (T ∪ {φ.not}) converts each half of the independence conjunction into the satisfiability of a one-sentence extension. The only friction is that the Completeness Theorem produces T ∪ {¬¬φ} for the second half; a generic model-transfer lemma (transfer any model along a structure-wise semantic implication, here the realize-equivalence ¬¬φ ↔ φ) collapses this to T ∪ {φ}. Assembling the two halves gives the model-theoretic characterization, and its contrapositive packages completeness as the absence of independent sentences.",
+    "keyInsights": [
+      "**Independence is a semantic notion.** Over Mathlib's T ⊨ᵇ φ, 'φ is independent of T' means T has a model where φ holds and a model where φ fails. No proof system, Gödel numbering, or self-reference is needed to state it — only the satisfaction relation. This is what lets the entry sidestep the parent's placeholder provability predicate entirely.",
+      "**Incompleteness is immediate from the definition of completeness.** Mathlib defines IsComplete to demand T ⊨ᵇ φ ∨ T ⊨ᵇ φ.not for every sentence. An independent sentence is by definition a counterexample, so Independent.not_isComplete is a two-line proof — the conceptual weight is entirely in the definitions, exactly as it should be.",
+      "**The Completeness Theorem is the workhorse.** models_iff_not_satisfiable turns 'unprovability' into 'a model of the negation exists'. Both witnesses of independence (a φ-refuting model and a φ-satisfying model) come straight from applying it to the two halves of the independence conjunction.",
+      "**Double negation is real bookkeeping, not a triviality, in a syntactic setting.** φ.not.not is a different sentence from φ, so T ∪ {¬¬φ} and T ∪ {φ} are different theories; they are only *equi-satisfiable*. The reusable model-transfer lemma proves this from the structure-wise realize-equivalence M ⊨ ¬¬φ ↔ M ⊨ φ.",
+      "**Natural PA-independence is the genuinely open part.** The abstract theory here is the easy, fully-formalizable layer. Exhibiting Goodstein or Paris–Harrington as a concrete independent φ requires PA's syntax, ε₀-ordinal analysis, and fast-growing hierarchies — research-grade formalization that Mathlib does not yet support."
+    ],
+    "prerequisites": [
+      "First-order model theory: languages, structures, the satisfaction relation",
+      "Theories, satisfiability, and the notion of a complete theory",
+      "The Completeness Theorem (semantic consequence ↔ unsatisfiability of the negation)",
+      "Familiarity with Goodstein / Paris–Harrington as natural PA-independent statements"
+    ]
+  },
+  "sections": [
+    {
+      "id": "double-negation-bridge",
+      "title": "The Double-Negation Satisfiability Bridge",
+      "startLine": 55,
+      "endLine": 85,
+      "summary": "isSatisfiable_insert_not_not_iff: T ∪ {¬¬φ} is satisfiable iff T ∪ {φ} is. Proved via a reusable transfer lemma — a structure-wise semantic implication M ⊨ ψ → M ⊨ χ lifts a model of T ∪ {ψ} to a model of T ∪ {χ} (using model_union_iff, model_singleton_iff, and Model.isSatisfiable) — instantiated both directions at the realize-equivalence ¬¬φ ↔ φ.",
+      "mathContext": "φ.not.not is syntactically distinct from φ, so T ∪ {φ.not.not} and T ∪ {φ} are different theories that are nonetheless equi-satisfiable because $M \\models \\neg\\neg\\varphi \\leftrightarrow M \\models \\varphi$ in every structure $M$."
+    },
+    {
+      "id": "independence-definition",
+      "title": "Independence and Incompleteness",
+      "startLine": 86,
+      "endLine": 102,
+      "summary": "Independent T φ := ¬ T ⊨ᵇ φ ∧ ¬ T ⊨ᵇ φ.not, with projections not_models / not_models_not. Independent.not_isComplete: any independent sentence makes T not complete, since IsComplete demands T ⊨ᵇ φ ∨ T ⊨ᵇ φ.not for every φ.",
+      "mathContext": "$\\varphi$ is independent of $T$ when $T \\not\\models \\varphi$ and $T \\not\\models \\neg\\varphi$. Completeness, $\\forall \\varphi,\\ T \\models \\varphi \\vee T \\models \\neg\\varphi$, is directly contradicted by an independent $\\varphi$."
+    },
+    {
+      "id": "satisfiable-witnesses",
+      "title": "Both Extensions Are Satisfiable",
+      "startLine": 103,
+      "endLine": 118,
+      "summary": "Independent.satisfiable_insert_not: T ∪ {¬φ} is satisfiable (a model of T where φ fails). Independent.satisfiable_insert: T ∪ {φ} is satisfiable (a model of T where φ holds). Both from models_iff_not_satisfiable; the φ-side uses the double-negation bridge.",
+      "mathContext": "By the Completeness Theorem, $T \\not\\models \\varphi$ is equivalent to $T \\cup \\{\\neg\\varphi\\}$ having a model, and $T \\not\\models \\neg\\varphi$ to $T \\cup \\{\\varphi\\}$ having a model. Independence supplies both."
+    },
+    {
+      "id": "characterization",
+      "title": "Model-Theoretic Characterization and Completeness",
+      "startLine": 119,
+      "endLine": 145,
+      "summary": "independent_iff_satisfiable_both: Independent T φ ↔ IsSatisfiable (T ∪ {¬φ}) ∧ IsSatisfiable (T ∪ {φ}). isComplete_iff_forall_not_independent: for satisfiable T, T.IsComplete ↔ ∀ φ, ¬ Independent T φ.",
+      "mathContext": "$\\varphi$ is independent of $T$ iff $T$ has both a model satisfying $\\varphi$ and a model refuting it; equivalently, a satisfiable theory is complete iff it admits no independent sentence."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes, against Mathlib's genuine first-order semantics, the abstract notion that the parent godel-incompleteness scaffold could only gesture at: a sentence independent of a theory. Independence is defined over real semantic consequence, shown to force incompleteness, characterized by the joint satisfiability of T ∪ {φ} and T ∪ {¬φ}, and shown to be exactly what a complete theory lacks. All five results are machine-checked with 0 axioms and 0 sorries.",
+    "implications": "The framework supplies the precise target that a future formalization of a concrete PA-independent statement would hit: to certify that Goodstein's theorem (or Paris–Harrington, or Con(PA)) is independent of PA, one exhibits a model of PA + ¬φ and a model of PA + φ, which is exactly Independent PA φ via independent_iff_satisfiable_both. The entry also clarifies the division of labour in such a project — the model theory of independence is elementary and now done, whereas the construction of the witnessing models (or the ε₀-ordinal unprovability argument) is the deep, still-open part.",
+    "openQuestions": [
+      "Formalize Peano Arithmetic as a Mathlib first-order theory and exhibit a concrete sentence φ with Independent PA φ — e.g. Goodstein's theorem or the Paris–Harrington principle — discharging the model-theoretic characterization proved here.",
+      "Prove the abstract Lindenbaum lemma in this setting (every satisfiable theory extends to a complete one) and connect it to the independence framework: a sentence is independent of T iff it is decided differently by two complete extensions of T.",
+      "Relate semantic independence to a syntactic provability predicate once Mathlib gains a proof system for first-order logic, recovering the Gödel/Rosser route to independence alongside the model-theoretic one."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "extends",
+      "description": "The parent entry sketches Gödel's incompleteness theorems with a placeholder provability predicate (Provable := fun _ => False). This OQ-03 follow-up replaces that placeholder with Mathlib's real semantic consequence relation and formalizes the independence notion the parent could only describe in prose."
+    },
+    {
+      "targetId": "continuum-hypothesis",
+      "relationship": "related",
+      "description": "The Continuum Hypothesis is the archetypal natural statement independent of ZFC (Gödel 1940, Cohen 1963): ZFC has models where CH holds and models where it fails. independent_iff_satisfiable_both is exactly the shape of that independence claim, abstracted away from the specific theory."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Paris, Jeff; Harrington, Leo",
+      "title": "A Mathematical Incompleteness in Peano Arithmetic",
+      "year": "1977",
+      "venue": "Handbook of Mathematical Logic, North-Holland, 1133–1142",
+      "note": "Exhibits a strengthening of the finite Ramsey theorem that is true but unprovable in PA — the first 'natural' combinatorial statement independent of PA."
+    },
+    {
+      "authors": "Kirby, Laurie; Paris, Jeff",
+      "title": "Accessible Independence Results for Peano Arithmetic",
+      "year": "1982",
+      "venue": "Bulletin of the London Mathematical Society 14(4), 285–293",
+      "note": "Shows Goodstein's theorem and the termination of the Hydra game are independent of PA, witnessed by fast-growing functions exceeding every PA-provably-total function."
+    },
+    {
+      "authors": "Marker, David",
+      "title": "Model Theory: An Introduction",
+      "year": "2002",
+      "venue": "Graduate Texts in Mathematics 217, Springer",
+      "note": "Standard reference for the Completeness Theorem, satisfiability, and complete theories — the model-theoretic apparatus this entry builds on."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "The Lean Mathematical Library — FirstOrder.Language model theory",
+      "year": "2020",
+      "venue": "Proceedings of CPP 2020 / ongoing",
+      "note": "Mathlib's FirstOrder.Language hierarchy supplies the satisfaction relation, Theory.IsSatisfiable, Theory.IsComplete, and the Completeness-Theorem lemma models_iff_not_satisfiable used throughout."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "godel-incompleteness-oq-03-oq-01",
+      "question": "Formalize Peano Arithmetic as a Mathlib FirstOrder.Language theory and exhibit a concrete sentence φ with Independent PA φ (e.g. Goodstein's theorem or Paris–Harrington), discharging independent_iff_satisfiable_both by constructing models of PA + φ and PA + ¬φ.",
+      "significance": "high"
+    },
+    {
+      "id": "godel-incompleteness-oq-03-oq-02",
+      "question": "Prove the Lindenbaum lemma (every satisfiable theory extends to a complete one) in this setting and show a sentence is independent of T iff two complete extensions of T decide it oppositely.",
+      "significance": "medium"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/godel-incompleteness-oq-03.json
+++ b/src/data/research/problems/godel-incompleteness-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "godel-incompleteness-oq-03",
   "title": "Natural Mathematical Statements Independent of PA",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-04-22T12:51:58.077Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Built and offline-verified the abstract independence framework on Mathlib model theory.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Formalize PA as a FirstOrder theory and exhibit a concrete independent sentence (Goodstein/Paris-Harrington).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,10 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
+    "progressSummary": "VERIFIED: 145-line GodelIncompletenessOQ03.lean (8 thm, 1 def, 0 sorry, 0 axiom) — defines Independent over Mathlib semantic consequence and proves independence⇒incompleteness, the satisfiable-both characterization, and completeness⇔no-independent-sentence. Offline-verified via lake env lean (EXIT 0). Concrete PA-independence left open.",
+    "builtItems": [
+      "GodelIncompletenessOQ03.lean: Independent def + 8 theorems on Mathlib FirstOrder model theory (offline-verified)",
+      "Independent.not_isComplete — independence forces incompleteness",
+      "isSatisfiable_insert_not_not_iff — double-negation satisfiability bridge via generic model-transfer",
+      "independent_iff_satisfiable_both — model-theoretic characterization of independence",
+      "isComplete_iff_forall_not_independent — completeness = absence of independent sentences",
+      "Gallery entry src/data/proofs/godel-incompleteness-oq-03 (meta+annotations+index)"
+    ],
+    "insights": [
+      "Independence is purely semantic: φ independent of T ⟺ T has a model satisfying φ and one refuting it (independent_iff_satisfiable_both). Avoids the parent entry’s placeholder provability predicate entirely.",
+      "Mathlib has no PA-as-FirstOrder-theory and no Goodstein/Paris-Harrington, so concrete natural PA-independence is genuinely blocked; the abstract layer (this entry) is the formalizable part.",
+      "φ.not.not ≠ φ syntactically, so T∪{¬¬φ} vs T∪{φ} need an explicit equi-satisfiability bridge proved by structure-wise realize-transfer."
+    ],
+    "mathlibGaps": [
+      "No Peano Arithmetic packaged as a FirstOrder.Language theory",
+      "No Goodstein / Paris-Harrington formalization",
+      "No syntactic proof system for first-order logic (only semantic consequence ⊨ᵇ)"
+    ],
     "nextSteps": []
   },
   "tags": [


### PR DESCRIPTION
## Summary
Research session for **godel-incompleteness-oq-03** — "Natural Mathematical Statements Independent of PA" (a fresh EMPTY problem).

New gallery entry `godel-incompleteness-oq-03` + verified Lean file `Proofs/GodelIncompletenessOQ03.lean` (145 lines, **8 theorems, 1 definition, 0 sorries, 0 axioms**).

The parent gallery entry `godel-incompleteness` is a pedagogical scaffold whose provability predicate is the placeholder `Provable := fun _ => False`, making all its formal statements vacuously true — it cannot express what it means for a *specific* sentence to be independent. This entry replaces that placeholder with Mathlib's **genuine first-order model theory**, where `T ⊨ᵇ φ` is real semantic consequence over all models.

## What is proved (verified)
- `Independent T φ := ¬ T ⊨ᵇ φ ∧ ¬ T ⊨ᵇ φ.not` — independence over real semantic consequence.
- `Independent.not_isComplete` — a theory with an independent sentence is **not complete** (independence ⇒ incompleteness).
- `isSatisfiable_insert_not_not_iff` — `T ∪ {¬¬φ}` is satisfiable iff `T ∪ {φ}` is, via a reusable structure-wise model-transfer (the bookkeeping the Completeness Theorem leaves behind).
- `Independent.satisfiable_insert_not` / `Independent.satisfiable_insert` — both `T ∪ {¬φ}` and `T ∪ {φ}` are satisfiable.
- `independent_iff_satisfiable_both` — model-theoretic characterization: `φ` independent of `T` iff `T` has a model satisfying `φ` and a model refuting it.
- `isComplete_iff_forall_not_independent` — for satisfiable `T`, completeness ⟺ no independent sentence.

## Verification
`LAKE_UNSAFE=1 lake env lean Proofs/GodelIncompletenessOQ03.lean` exits **0** (no errors) against the local Mathlib oleans. Docker `docker-build.sh` remains blocked by host containerd blob corruption, so this is a single-file kernel typecheck rather than a containerized build, but it exercises the identical check. No `axiom`, `sorry`, or `native_decide`.

## Files
- `proofs/Proofs/GodelIncompletenessOQ03.lean` (new)
- `src/data/proofs/godel-incompleteness-oq-03/{meta,annotations,index}` (new gallery entry; size check passes, 4022 entries)
- `src/data/research/problems/godel-incompleteness-oq-03.json` (knowledge update)

## Status
**Outcome**: progress (new verified abstract framework; the OQ's concrete target left open)
**Next Steps**: formalize PA as a `FirstOrder.Language` theory and exhibit a concrete independent sentence (Goodstein / Paris–Harrington / Con(PA)) by discharging `independent_iff_satisfiable_both` — needs PA syntax + ε₀-induction absent from current Mathlib.

🤖 Generated by researcher-1