### PR TITLE
Research: erdos-103-oq-02 — unconditional finiteness for the small cases (n ≤ 1) [VERIFIED offline]

### DIFF
--- a/proofs/Proofs/Erdos103OQ02Finite.lean
+++ b/proofs/Proofs/Erdos103OQ02Finite.lean
@@ -1,0 +1,170 @@
+/-
+Erdős Problem #103 — Open Question 02: unconditional finiteness in the
+degenerate small cases (n ≤ 1).
+
+## What this adds over `Erdos103OQ02.lean`
+
+The non-degeneracy results in the parent OQ-02 file
+(`hCong_pos_of_finite`, `hCong_strictly_exceeds_raw`) carry the typeclass
+hypothesis `[Finite (Quotient (OptimalSetoid n))]`. Unconditional finiteness of
+that quotient for *general* n is exactly the open content of the problem and
+remains open. This file discharges the hypothesis **unconditionally for n ≤ 1**:
+
+* n = 0: `PointConfig 0 = Fin 0 → ℝ²` has a unique element, so any two
+  configurations are equal, hence congruent.
+* n = 1: any two single-point configurations differ by the translation
+  `Q 0 - P 0`, which is an isometry, so they are congruent.
+
+In either case every pair of optimal configurations is congruent, so the optimal
+quotient is a `Subsingleton`, hence `Finite`. Supplying these instances turns the
+conditional parent theorems into unconditional statements at n = 0, 1, and lets
+us compute `hCong 0 = hCong 1 = 1` together with the strict gap `h 1 < hCong 1`.
+
+This does **not** touch the open question (unconditional finiteness for large n,
+and `hCong n ≥ 2`); it only nails down the base cases that the conditional
+machinery left implicit.
+
+## Axioms / Sorries
+None. Machine-checked from Mathlib + `Erdos103Problem` + `Erdos103OQ02`.
+-/
+
+import Mathlib
+import Proofs.Erdos103Problem
+import Proofs.Erdos103OQ02
+
+open Metric Set Finset
+open Erdos103
+
+namespace Erdos103OQ02
+
+-- ============================================================
+-- PART F1: Every configuration is congruent in the small cases
+-- ============================================================
+
+/-- For `n = 0` there is exactly one configuration (the empty tuple), so any two
+    configurations are equal and therefore congruent. -/
+theorem all_congruent_zero (P Q : PointConfig 0) : AreCongruent 0 P Q := by
+  have hPQ : P = Q := Subsingleton.elim P Q
+  rw [hPQ]
+  exact congruent_refl 0 Q
+
+/-- For `n = 1` any two single-point configurations differ by the translation
+    `Q 0 - P 0`, which is an isometry; hence they are congruent. -/
+theorem all_congruent_one (P Q : PointConfig 1) : AreCongruent 1 P Q := by
+  have hv : Ptranslate (Q 0 - P 0) P = Q := by
+    funext i
+    have hi : i = 0 := Subsingleton.elim i 0
+    subst hi
+    show P 0 + (Q 0 - P 0) = Q 0
+    abel
+  rw [← hv]
+  exact translate_congruent (Q 0 - P 0) P
+
+-- ============================================================
+-- PART F2: The optimal quotient is a subsingleton, hence finite
+-- ============================================================
+
+/-- The optimal congruence quotient at `n = 0` is a subsingleton: all optimal
+    configurations are congruent. -/
+instance subsingleton_quotient_zero : Subsingleton (Quotient (OptimalSetoid 0)) := by
+  refine ⟨fun a b => ?_⟩
+  induction a using Quotient.inductionOn with
+  | _ P =>
+    induction b using Quotient.inductionOn with
+    | _ Q => exact Quotient.sound (all_congruent_zero P.val Q.val)
+
+/-- The optimal congruence quotient at `n = 1` is a subsingleton. -/
+instance subsingleton_quotient_one : Subsingleton (Quotient (OptimalSetoid 1)) := by
+  refine ⟨fun a b => ?_⟩
+  induction a using Quotient.inductionOn with
+  | _ P =>
+    induction b using Quotient.inductionOn with
+    | _ Q => exact Quotient.sound (all_congruent_one P.val Q.val)
+
+/-- **Unconditional finiteness at `n = 0`** — discharges the `[Finite …]`
+    hypothesis of the parent file's non-degeneracy theorems. -/
+instance finite_quotient_zero : Finite (Quotient (OptimalSetoid 0)) :=
+  Finite.of_subsingleton
+
+/-- **Unconditional finiteness at `n = 1`**. -/
+instance finite_quotient_one : Finite (Quotient (OptimalSetoid 1)) :=
+  Finite.of_subsingleton
+
+-- ============================================================
+-- PART F3: Existence of an optimal configuration for n ≤ 1
+-- ============================================================
+
+/-- The diameter is identically `0` below the `n ≥ 2` threshold. -/
+theorem diameter_eq_zero_of_lt_two {n : ℕ} (hn : ¬ 2 ≤ n) (P : PointConfig n) :
+    diameter n P = 0 := by
+  unfold diameter
+  rw [dif_neg hn]
+
+/-- A single point (the constant-zero configuration) is valid for `n ≤ 1`: the
+    minimum-separation constraint is vacuous because distinct indices do not
+    exist. -/
+theorem valid_const_zero {n : ℕ} (hn : n ≤ 1) :
+    IsValidConfig n (fun _ : Fin n => (0, 0)) := by
+  intro i j hij
+  have hi := i.isLt
+  have hj := j.isLt
+  exact absurd (Fin.ext (by omega : (i : ℕ) = j)) hij
+
+/-- For `n ≤ 1` the minimum diameter is `0`: every valid configuration has
+    diameter `0`, and at least one valid configuration exists. -/
+theorem minDiameter_eq_zero_of_le_one {n : ℕ} (hn : n ≤ 1) : minDiameter n = 0 := by
+  have hlt : ¬ 2 ≤ n := by omega
+  have hne : Nonempty {P : PointConfig n // IsValidConfig n P} :=
+    ⟨⟨fun _ => (0, 0), valid_const_zero hn⟩⟩
+  unfold minDiameter
+  have hconst : ∀ P : {P : PointConfig n // IsValidConfig n P},
+      diameter n P.val = 0 := fun P => diameter_eq_zero_of_lt_two hlt P.val
+  rw [iInf_congr hconst]
+  exact ciInf_const
+
+/-- **Existence of an optimal configuration for `n ≤ 1`.** The constant-zero
+    configuration is valid and has diameter `0 = minDiameter n`. -/
+theorem exists_optimal_of_le_one {n : ℕ} (hn : n ≤ 1) : ∃ P, IsOptimal n P := by
+  refine ⟨fun _ => (0, 0), valid_const_zero hn, ?_⟩
+  rw [diameter_eq_zero_of_lt_two (by omega), minDiameter_eq_zero_of_le_one hn]
+
+-- ============================================================
+-- PART F4: Unconditional values of hCong at n = 0, 1
+-- ============================================================
+
+/-- **`hCong 0 = 1`, unconditionally.** The optimal quotient at `n = 0` is a
+    nonempty subsingleton. -/
+theorem hCong_zero_eq_one : hCong 0 = 1 := by
+  have hne : Nonempty (Quotient (OptimalSetoid 0)) :=
+    optimalQuotient_nonempty_of_exists 0 (exists_optimal_of_le_one (by norm_num))
+  have hcard : Nat.card (Quotient (OptimalSetoid 0)) = 1 :=
+    Nat.card_eq_one_iff_unique.mpr ⟨subsingleton_quotient_zero, hne⟩
+  exact hcard
+
+/-- **`hCong 1 = 1`, unconditionally.** -/
+theorem hCong_one_eq_one : hCong 1 = 1 := by
+  have hne : Nonempty (Quotient (OptimalSetoid 1)) :=
+    optimalQuotient_nonempty_of_exists 1 (exists_optimal_of_le_one (le_refl 1))
+  have hcard : Nat.card (Quotient (OptimalSetoid 1)) = 1 :=
+    Nat.card_eq_one_iff_unique.mpr ⟨subsingleton_quotient_one, hne⟩
+  exact hcard
+
+/-- **The corrected count strictly exceeds the raw count at `n = 1`,
+    unconditionally.** At `n = 1` the raw cardinality collapses (`h 1 = 0`, the
+    optimal set is translation-infinite) while the congruence count is `1`. This
+    is the parent theorem `hCong_strictly_exceeds_raw` with its `[Finite …]`
+    hypothesis now discharged. -/
+theorem hCong_one_strictly_exceeds_raw : h 1 < hCong 1 :=
+  hCong_strictly_exceeds_raw 1 (by norm_num) (exists_optimal_of_le_one (le_refl 1))
+
+end Erdos103OQ02
+
+-- Export results
+#check @Erdos103OQ02.all_congruent_zero
+#check @Erdos103OQ02.all_congruent_one
+#check @Erdos103OQ02.finite_quotient_zero
+#check @Erdos103OQ02.finite_quotient_one
+#check @Erdos103OQ02.exists_optimal_of_le_one
+#check @Erdos103OQ02.hCong_zero_eq_one
+#check @Erdos103OQ02.hCong_one_eq_one
+#check @Erdos103OQ02.hCong_one_strictly_exceeds_raw

--- a/src/data/research/problems/erdos-103-oq-02.json
+++ b/src/data/research/problems/erdos-103-oq-02.json
@@ -33,7 +33,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Audited the parent Erdős #103 formalization and found its counting function degenerate: h(n) := Nat.card {P // IsOptimal n P} counts ALL optimal configurations with no quotient by congruence. Since optimality is translation-invariant, that set is empty or infinite, so Nat.card = 0 for every n >= 1. Proved this rigorously (translate_optimal, optimal_subtype_infinite_of_nonempty, h_eq_zero), concluded the parent's literal WeakConjecture is FALSE (raw_weak_conjecture_false), and supplied the corrected congruence-quotient count hCong(n) := Nat.card (Quotient OptimalSetoid). Showed all translates of a config collapse to one hCong class. Also repaired the parent file Erdos103Problem.lean, whose congruent_symm proof no longer compiled under Lean 4.26.0. New file Erdos103OQ02.lean: 0 axioms, 0 sorries, 10 theorems, 4 defs, 218 lines. The Erdős problem itself remains OPEN; this is a correction of the formalization, not a resolution.",
+    "progressSummary": "VERIFIED (offline, Mathlib 2df2f015 / Lean v4.26.0, 0 sorry / 0 axiom): added Erdos103OQ02Finite.lean nailing down the degenerate base cases the conditional parent machinery left implicit. For n <= 1 the optimal congruence quotient is a nonempty Subsingleton, so it is unconditionally Finite; this discharges the [Finite (Quotient (OptimalSetoid n))] hypothesis of hCong_pos_of_finite / hCong_strictly_exceeds_raw and yields hCong 0 = hCong 1 = 1 and the strict gap h 1 = 0 < 1 = hCong 1. The open content (unconditional finiteness for general/large n and hCong n >= 2) is untouched and remains open.",
     "builtItems": [
       "Erdos103OQ02.lean (0-axiom, 0-sorry, verified)",
       "pointDist_add_right: Euclidean distance on R^2 is translation-invariant",
@@ -43,21 +43,26 @@
       "raw_weak_conjecture_false: parent's literal WeakConjecture is false",
       "hCong / OptimalSetoid: corrected congruence-class count (the intended h)",
       "translates_same_class: the quotient collapses the translation-infinitude",
-      "Repaired parent Erdos103Problem.lean congruent_symm (Lean 4.26.0 regression: rwa auto-close + rw target mismatch)"
+      "Repaired parent Erdos103Problem.lean congruent_symm (Lean 4.26.0 regression: rwa auto-close + rw target mismatch)",
+      "Erdos103OQ02Finite.lean: all_congruent_zero / all_congruent_one (every config congruent for n<=1)",
+      "Erdos103OQ02Finite.lean: subsingleton_quotient_zero/one + finite_quotient_zero/one (unconditional Finite instances for the optimal quotient at n=0,1)",
+      "Erdos103OQ02Finite.lean: exists_optimal_of_le_one (optimal config exists for n<=1) via minDiameter_eq_zero_of_le_one",
+      "Erdos103OQ02Finite.lean: hCong_zero_eq_one, hCong_one_eq_one, hCong_one_strictly_exceeds_raw (unconditional, [Finite] discharged)"
     ],
     "insights": [
       "Counting 'configurations up to symmetry' MUST quotient by the symmetry group explicitly: an un-quotiented Nat.card collapses to 0 under any continuous symmetry (here, translation).",
       "Nat.card sends infinite types to 0 in Mathlib; combined with the empty case this yields h(n)=0 with NO existence hypothesis.",
       "The optimal set is a union of full translation-orbits, hence empty or uncountable; the congruence quotient restores finiteness/meaning.",
-      "The sibling OQ-01 axiomatized h and h_pos (h(n)>=1), which this audit shows is inconsistent with the parent's LITERAL h -- OQ-01's h must denote the intended quotient count hCong."
+      "The sibling OQ-01 axiomatized h and h_pos (h(n)>=1), which this audit shows is inconsistent with the parent's LITERAL h -- OQ-01's h must denote the intended quotient count hCong.",
+      "Unconditional finiteness holds in the degenerate small cases: for n <= 1 every pair of optimal configurations is congruent (n=0: PointConfig 0 = Fin 0 -> R^2 is a subsingleton; n=1: any two single points differ by the translation Q0 - P0), so Quotient (OptimalSetoid n) is a Subsingleton, hence Finite. This discharges the [Finite ...] typeclass hypothesis carried by hCong_pos_of_finite / hCong_strictly_exceeds_raw at n=0,1.",
+      "minDiameter n = 0 for n <= 1 (diameter is identically 0 below the n>=2 threshold and the constant-zero config is valid), so an optimal configuration exists for n<=1 and hCong 0 = hCong 1 = 1 unconditionally; at n=1 the raw count still collapses (h 1 = 0), giving the strict gap h 1 < hCong 1 with no finiteness assumption."
     ],
     "mathlibGaps": [
       "No gap blocked this session. Finiteness of the optimal-configuration space modulo congruence (needed to make hCong provably finite) would require a compactness/quotient argument not yet built."
     ],
     "nextSteps": [
-      "Prove hCong(n) is finite for each n (compactness of optimal configs modulo congruence).",
-      "Attempt to compute hCong(4) from the known optimal 4-point configuration.",
-      "Restate and connect OQ-01's results (h -> infinity) to hCong rather than the degenerate raw h."
+      "Prove Finite (Quotient (OptimalSetoid n)) for n >= 2 (the genuine open content; needs compactness/algebraicity of optimal configs mod congruence).",
+      "Establish existence of an optimal configuration for n >= 2 (minDiameter achieved), currently assumed via the (exists P, IsOptimal n P) hypotheses."
     ]
   },
   "tags": [
@@ -93,7 +98,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.203Z",
-  "lastUpdate": "2026-06-26",
+  "lastUpdate": "2026-06-27",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Research session for **erdos-103-oq-02** (Erdős #103, OQ-02: is `h(n) ≥ 2` for all large `n`?). Adds `proofs/Proofs/Erdos103OQ02Finite.lean`, a satellite of the existing verified OQ-02 entry that nails down the degenerate base cases the conditional parent machinery left implicit.

## What this adds
The parent file's non-degeneracy theorems (`hCong_pos_of_finite`, `hCong_strictly_exceeds_raw`) carry a `[Finite (Quotient (OptimalSetoid n))]` typeclass hypothesis. Unconditional finiteness of that quotient for general `n` is exactly the open content and remains open. This file discharges the hypothesis **unconditionally for n ≤ 1**:

- `all_congruent_zero` / `all_congruent_one` — every pair of configurations is congruent for `n ≤ 1` (n=0: `PointConfig 0 = Fin 0 → ℝ²` is a subsingleton; n=1: two single points differ by the translation `Q 0 − P 0`, an isometry).
- `subsingleton_quotient_zero/one` + `finite_quotient_zero/one` — the optimal quotient is a nonempty `Subsingleton`, hence `Finite`, supplied as instances.
- `exists_optimal_of_le_one` via `minDiameter_eq_zero_of_le_one` (diameter is identically 0 below the n≥2 threshold; the constant-zero config is valid).
- `hCong_zero_eq_one`, `hCong_one_eq_one`, and the unconditional strict gap `hCong_one_strictly_exceeds_raw` (`h 1 = 0 < 1 = hCong 1`).

## Verification
Built offline against the pinned Mathlib (`2df2f0150c…`, Lean `v4.26.0`) — Docker host containerd content store is corrupt, so `./proofs/scripts/docker-build.sh` is unavailable; verified via `lake env lean` against the committed Mathlib oleans.

- 0 `sorry`, 0 `axiom` declarations, no structure-encoded assumptions.
- `#print axioms` on all headline results = `[propext, Classical.choice, Quot.sound]` (standard Mathlib foundation, no `sorryAx`).

## Status
**Outcome**: progress (verified increment; base cases only)
**Open / remains open**: `Finite (Quotient (OptimalSetoid n))` for `n ≥ 2` (needs compactness/algebraicity of optimal configs mod congruence), existence of an optimal config for `n ≥ 2`, and the OQ-02 conjecture `hCong n ≥ 2` for large `n`.

🤖 Generated by researcher-3