### PR TITLE
research(erdos-662-oq-02): t=1 case of Erdős–Lovász–Vesztergombi proved unconditionally + bitrot repair

### DIFF
--- a/proofs/Proofs/Erdos662Problem.lean
+++ b/proofs/Proofs/Erdos662Problem.lean
@@ -163,7 +163,7 @@ private lemma mkℂ_ne_zero {v : ℝ × ℝ} (hv : v.1 ^ 2 + v.2 ^ 2 = 1) : mk�
 
 /-- Unit pair → ‖z‖ = 1. -/
 private lemma mkℂ_norm_one {v : ℝ × ℝ} (hv : v.1 ^ 2 + v.2 ^ 2 = 1) : ‖mkℂ v‖ = 1 := by
-  rw [Complex.norm_eq_abs, Complex.abs_apply]
+  rw [Complex.norm_def]
   have hns : Complex.normSq (mkℂ v) = 1 := by
     simp only [Complex.normSq_apply, mkℂ_re, mkℂ_im]
     nlinarith [sq_nonneg v.1, sq_nonneg v.2]
@@ -206,7 +206,11 @@ private lemma abs_sub_lt_of_floor_eq {a b c : ℝ} (hc : 0 < c) (ha : 0 ≤ a) (
   have h3 := Nat.lt_floor_add_one (b / c)
   have h4 := Nat.floor_le hbc
   rw [hfl] at h1 h2
-  rw [abs_lt]; constructor <;> nlinarith
+  -- a/c and b/c both lie in [⌊b/c⌋₊, ⌊b/c⌋₊+1), so |a/c - b/c| < 1; scale by c > 0.
+  have e : |a - b| / c = |a / c - b / c| := by
+    rw [← sub_div, abs_div, abs_of_pos hc]
+  rw [← div_lt_one hc, e, abs_lt]
+  constructor <;> linarith
 
 /-- |θ| < π/3 implies cos θ > 1/2, by strict anti-monotonicity of cos on [0, π]. -/
 private lemma cos_gt_half_of_abs_lt {θ : ℝ} (h : |θ| < Real.pi / 3) :
@@ -218,7 +222,7 @@ private lemma cos_gt_half_of_abs_lt {θ : ℝ} (h : |θ| < Real.pi / 3) :
   have key := Real.strictAntiOn_cos h1 h2 h
   rw [Real.cos_pi_div_three] at key
   have : Real.cos θ = Real.cos |θ| := by
-    rcases le_or_lt 0 θ with hnn | hn
+    rcases le_or_gt 0 θ with hnn | hn
     · rw [abs_of_nonneg hnn]
     · rw [abs_of_neg hn, Real.cos_neg]
   linarith
@@ -269,7 +273,7 @@ theorem kissing_number_2d (S : Finset (ℝ × ℝ))
   have floor_le : ∀ u, ⌊nAng u / (Real.pi / 3)⌋₊ ≤ 5 := by
     intro u
     have hnn : (0 : ℝ) ≤ nAng u / (Real.pi / 3) := div_nonneg (nAng_nn u) hpi3.le
-    have h6 : nAng u / (Real.pi / 3) < 6 := by rw [div_lt_iff hpi3]; linarith [nAng_ub u]
+    have h6 : nAng u / (Real.pi / 3) < 6 := by rw [div_lt_iff₀ hpi3]; linarith [nAng_ub u]
     have : ⌊nAng u / (Real.pi / 3)⌋₊ < 6 := by
       rw [Nat.floor_lt hnn]; exact_mod_cast h6
     omega
@@ -373,3 +377,33 @@ axiom erdos_662_lattice_optimal :
     ∃ N : ℕ, ∀ (pts : Finset Point2D), IsSeparated pts →
       pts.card ≥ N →
       pairsWithinDist pts t ≤ pts.card * triangularLatticeCount t / 2
+
+-- ## Unconditional Case: t = 1
+
+/-- **The t = 1 instance of the Erdős–Lovász–Vesztergombi conjecture, unconditionally.**
+
+    At t = 1 the conjectured right-hand side `pts.card * triangularLatticeCount 1 / 2`
+    collapses to `3 * pts.card`, because `triangularLatticeCount 1 = 6`
+    (`triLattice_nearest_neighbors`). The contact-number bound `contact_number_3n`
+    already establishes `pairsWithinDist pts 1 ≤ 3 * pts.card`, so the bound holds.
+
+    This is strictly stronger than what `erdos_662_lattice_optimal` asserts at t = 1:
+    no "sufficiently large n" hypothesis is needed -- the bound holds for *every*
+    1-separated finite set, however small. The open content of the conjecture lies
+    entirely in the thresholds t > 1. -/
+theorem erdos_662_unit_case (pts : Finset Point2D) (hsep : IsSeparated pts) :
+    pairsWithinDist pts 1 ≤ pts.card * triangularLatticeCount 1 / 2 := by
+  have hcount : triangularLatticeCount 1 = 6 := triLattice_nearest_neighbors
+  rw [hcount]
+  have h := contact_number_3n pts hsep
+  omega
+
+/-- The threshold form of the conjecture (as stated in `erdos_662_lattice_optimal`)
+    holds unconditionally at t = 1 with the witness `N = 0`: the bound is valid for
+    all `n`, so no threshold is required. This exhibits a concrete `t` for which the
+    conjecture is a theorem rather than an axiom. -/
+theorem erdos_662_unit_case_threshold :
+    ∃ N : ℕ, ∀ (pts : Finset Point2D), IsSeparated pts →
+      pts.card ≥ N →
+      pairsWithinDist pts 1 ≤ pts.card * triangularLatticeCount 1 / 2 :=
+  ⟨0, fun pts hsep _ => erdos_662_unit_case pts hsep⟩

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -18,12 +18,12 @@
     "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/662",
     "erdosUrl": "https://erdosproblems.com/662",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_662_lattice_optimal (the main open conjecture — unprovable). kissing_number_2d fully proved via angular sector pigeonhole (Complex.arg → normalized angle → 6 bins → injective → card ≤ 6). All supporting lemmas proved: unit_neighbor_bound, neighbor_sqDist_eq_one, neighbor_dot_le_half, contact_number_3n.",
+    "axiomCount": 2,
+    "assumptions": "2 disclosed assumptions. (1) axiom erdos_662_lattice_optimal: the main open Erdős-Lovász-Vesztergombi conjecture for general thresholds t > 1 (unprovable here). (2) Lean.ofReduceBool: the lattice point-count facts triLatticeCountInt_one (f(1)=6) and triLatticeCountInt_three (f(3)=12) are discharged by native_decide. The t = 1 instance of the conjecture is now a THEOREM, not an axiom: erdos_662_unit_case proves pairsWithinDist pts 1 ≤ pts.card * triangularLatticeCount 1 / 2 unconditionally for every 1-separated finite set (no 'sufficiently large n' threshold), via contact_number_3n (≤ 3n) and triangularLatticeCount 1 = 6; erdos_662_unit_case_threshold packages it in the conjecture's exact existential form with witness N = 0. The kissing-number infrastructure (kissing_number_2d, unit_neighbor_bound, neighbor_sqDist_eq_one, neighbor_dot_le_half, contact_number_3n) is fully proved via angular-sector pigeonhole. erdos_662_unit_case depends on {propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound} and NOT on erdos_662_lattice_optimal.",
     "proofRepoPath": "Proofs/Erdos662Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 375,
-    "theoremCount": 21,
+    "lineCount": 409,
+    "theoremCount": 23,
     "definitionCount": 12
   },
   "sections": [
@@ -152,10 +152,10 @@
     "https://erdosproblems.com/662"
   ],
   "leanFile": {
-    "lineCount": 375,
+    "lineCount": 409,
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 23,
     "lemmaCount": 10,
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/research/problems/erdos-662.json
+++ b/src/data/research/problems/erdos-662.json
@@ -21,7 +21,7 @@
     "iteration": 3,
     "focus": "Gallery already at max potential: 0 sorries, 1 axiom (erdos_662_lattice_optimal — main open conjecture, unprovable). All supporting work (kissing_number_2d, contact_number_3n, etc.) is fully proved. Pool entry marked completed 2026-04-27 by researcher-4.",
     "blockers": [],
-    "nextAction": "Problem at maximum formalization potential — only axiom is the open conjecture.",
+    "nextAction": "Open content remains thresholds t>1 (e.g. t=√3: need ≤12 bound — kissing argument fails for distances up to √3 since equilateral configs at distance √3 are allowed).",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 1A appropriate (erdos_662_lattice_optimal open conjecture), 9T proved, 0S.",
+    "progressSummary": "COMPLETE+: t=1 case now a THEOREM (erdos_662_unit_case, unconditional). 11T proved (was 9), 1 open axiom (general t), native_decide count facts disclosed. File bitrot-repaired to compile on pinned mathlib v4.26.0.",
     "builtItems": [
       {
         "name": "triLatticeNorm",
@@ -67,7 +67,9 @@
       "The argmax-to-hexagon-vertex approach FAILS: two vectors close to same vertex can have angle up to 2π/3, giving dot product as low as -1/2",
       "Algebraic (Gram matrix) approaches fail: Tr(G²) ≥ n²/2 gives Σ(v·w)² ≥ n(n-2)/4 = 35/4 for n=7, but constraint v·w ≤ 1/2 doesn't bound |v·w| ≤ 1/2 (antipodal pairs have dot=-1), so Σ(v·w)² can reach C(7,2)=21, no contradiction",
       "Verified: algebraic approach with Cauchy-Schwarz on eigenvalues also fails — rank-2 PSD matrix with diagonal 1 and off-diagonal ≤ 1/2 exists for n=7 when negative entries are allowed",
-      "Bin definition challenge: 6 half-open sectors [kπ/3, (k+1)π/3) need algebraic characterization. Using y > √3/2, y < -√3/2, and x vs ±1/2 comparisons works but boundary handling at the 6 hexagonal directions (1/2, √3/2) etc. is fiddly"
+      "Bin definition challenge: 6 half-open sectors [kπ/3, (k+1)π/3) need algebraic characterization. Using y > √3/2, y < -√3/2, and x vs ±1/2 comparisons works but boundary handling at the 6 hexagonal directions (1/2, √3/2) etc. is fiddly",
+      "t=1 case SETTLED unconditionally (erdos_662_unit_case): for every 1-separated finite set, pairsWithinDist pts 1 ≤ pts.card·triangularLatticeCount 1/2 = 3n. Because triangularLatticeCount 1 = 6 and contact_number_3n already gives ≤3n. Strictly stronger than the conjecture's threshold form — no 'large n' needed (witness N=0 in erdos_662_unit_case_threshold). Open content lies entirely in thresholds t>1.",
+      "BITROT FIX (mathlib 2df2f015 / v4.26.0): the file had stopped compiling against the pinned mathlib. Fixed Complex.norm_eq_abs→Complex.norm_def; div_lt_iff→div_lt_iff₀; le_or_lt→le_or_gt; and rewrote abs_sub_lt_of_floor_eq to scale via div_lt_one/abs_div instead of nlinarith-on-division. File now compiles green (offline lake env lean, 0 errors)."
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -87,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T18:22:04.304Z",
-  "lastUpdate": "2026-03-26T18:00:00Z",
+  "lastUpdate": "2026-06-27T00:00:00Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Working on **erdos-662-oq-02** (uniqueness/optimality of the triangular lattice). The Erdős–Lovász–Vesztergombi conjecture (`erdos_662_lattice_optimal`) remains an open axiom for general thresholds, but this PR shows the **t = 1 instance is a theorem, not an axiom**, and is in fact *stronger* than conjectured.

### New results (`proofs/Proofs/Erdos662Problem.lean`)

- **`erdos_662_unit_case`** — for *every* 1-separated finite set,
  `pairsWithinDist pts 1 ≤ pts.card * triangularLatticeCount 1 / 2`.
  Since `triangularLatticeCount 1 = 6` the RHS is exactly `3n`, and the existing
  `contact_number_3n` already proves `≤ 3n`. No "sufficiently large `n`" hypothesis
  is needed — strictly stronger than the threshold form the conjecture asserts.
- **`erdos_662_unit_case_threshold`** — the conjecture's exact existential form at
  t = 1, discharged with witness `N = 0`.

`#print axioms erdos_662_unit_case` →
`[propext, Classical.choice, Lean.ofReduceBool, Lean.trustCompiler, Quot.sound]`.
It does **not** depend on `erdos_662_lattice_optimal`. The `Lean.ofReduceBool`
dependency comes from the `native_decide` lattice-count facts (`f(1)=6`); now
disclosed in `meta.json` (`meta.axiomCount` 1 → 2, status stays `axiomatized`).

### Bitrot repair

The file had stopped compiling against the pinned Mathlib (`2df2f015`, v4.26.0):
`Complex.norm_eq_abs`, `div_lt_iff`, and `le_or_lt` were renamed/removed upstream,
and `abs_sub_lt_of_floor_eq` relied on `nlinarith` over division. Fixed:
`Complex.norm_eq_abs → Complex.norm_def`, `div_lt_iff → div_lt_iff₀`,
`le_or_lt → le_or_gt`, and rewrote the floor lemma to scale via
`div_lt_one`/`abs_div`. The whole file now compiles green.

### Verification

Docker build host is corrupted fleet-wide, so verified via offline single-file
type-check: `LAKE_UNSAFE=1 lake env lean Proofs/Erdos662Problem.lean` → **0 errors**
(two pre-existing harmless linter warnings only).

### Honest scope

The mathematical content is modest: the t = 1 case follows immediately from
already-present infrastructure. Its value is (a) making explicit that the open
conjecture is settled at t = 1 (and unconditionally in `n`), and (b) restoring
the file to a compiling state. The open content — thresholds `t > 1`, e.g.
`t = √3` where the kissing argument fails — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)