### PR TITLE
Enrich second supplement via Zolotarev (oq-...-oq-01-oq-02): deepen annotations, map sections

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -5,7 +5,20 @@
     "range": { "startLine": 91, "endLine": 111 },
     "type": "theorem",
     "title": "Parity of the supplement exponent",
-    "content": "exponent_parity: for odd n, ((n²-1)/8) % 2 = (if n % 8 = 1 ∨ n % 8 = 7 then 0 else 1). Writing n = 2m+1, the ring identity (2m+1)² = 4·m(m+1)+1 lets omega conclude (n²-1)/8 = m(m+1)/2, the m-th triangular number T_m. Decomposing m = 4j+s (interval_cases on s < 4) and rewriting m(m+1) = 2·(8j²+…) per residue class turns the division by 2 and the subsequent mod 2 into linear arithmetic; split_ifs resolves the disjunctive n-mod-8 side condition that omega cannot case-split, and omega finishes each branch."
+    "content": "exponent_parity: for odd n, ((n²-1)/8) % 2 = (if n % 8 = 1 ∨ n % 8 = 7 then 0 else 1). Writing n = 2m+1, the ring identity (2m+1)² = 4·m(m+1)+1 lets omega conclude (n²-1)/8 = m(m+1)/2, the m-th triangular number T_m. Decomposing m = 4j+s (interval_cases on s < 4) and rewriting m(m+1) = 2·(8j²+…) per residue class turns the division by 2 and the subsequent mod 2 into linear arithmetic; split_ifs resolves the disjunctive n-mod-8 side condition that omega cannot case-split, and omega finishes each branch.",
+    "mathContext": "$\\dfrac{n^2-1}{8} = \\dfrac{m(m+1)}{2} = T_m$ (with $n=2m+1$), and $T_m$ is even $\\iff n \\equiv \\pm 1 \\pmod 8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "triangular numbers",
+      "residues mod 8",
+      "parity of an exponent",
+      "omega / linear arithmetic"
+    ],
+    "prerequisites": [
+      "modular arithmetic mod 8",
+      "Nat division",
+      "the omega tactic"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010102-negonepow",
@@ -13,7 +26,19 @@
     "range": { "startLine": 114, "endLine": 124 },
     "type": "theorem",
     "title": "The supplement value as a signed power",
-    "content": "neg_one_pow_exponent: (-1)^((n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1). From exponent_parity, the exponent is even exactly when n ≡ ±1 (mod 8); Even.neg_one_pow / Odd.neg_one_pow then evaluate the power to +1 there and -1 at n ≡ ±3 (mod 8)."
+    "content": "neg_one_pow_exponent: (-1)^((n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1). From exponent_parity, the exponent is even exactly when n ≡ ±1 (mod 8); Even.neg_one_pow / Odd.neg_one_pow then evaluate the power to +1 there and -1 at n ≡ ±3 (mod 8).",
+    "mathContext": "$(-1)^{\\frac{n^2-1}{8}} = \\begin{cases} +1 & n \\equiv \\pm 1 \\pmod 8 \\\\ -1 & n \\equiv \\pm 3 \\pmod 8 \\end{cases}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Even.neg_one_pow",
+      "sign of a power of -1",
+      "case split mod 8",
+      "quadratic residue of 2"
+    ],
+    "prerequisites": [
+      "parity of the exponent",
+      "(-1)^k evaluation"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010102-chi8",
@@ -21,7 +46,20 @@
     "range": { "startLine": 136, "endLine": 138 },
     "type": "theorem",
     "title": "Closed-form power formula for χ₈",
-    "content": "chi8_eq_neg_one_pow: χ₈ n = (-1)^((n²-1)/8) for odd n. Mathlib carries the octic character only as a mod-8 case split (ZMod.χ₈_nat_eq_if_mod_eight); this is the explicit power form, the octic analogue of ZMod.χ₄_eq_neg_one_pow and the genuinely new content of the entry. Proved by rewriting χ₈ through the case split and matching it to neg_one_pow_exponent, with the n-even branch killed by oddness — a reusable lemma suitable for upstreaming."
+    "content": "chi8_eq_neg_one_pow: χ₈ n = (-1)^((n²-1)/8) for odd n. Mathlib carries the octic character only as a mod-8 case split (ZMod.χ₈_nat_eq_if_mod_eight); this is the explicit power form, the octic analogue of ZMod.χ₄_eq_neg_one_pow and the genuinely new content of the entry. Proved by rewriting χ₈ through the case split and matching it to neg_one_pow_exponent, with the n-even branch killed by oddness — a reusable lemma suitable for upstreaming.",
+    "mathContext": "$\\chi_8(n) = (-1)^{\\frac{n^2-1}{8}}$ for odd $n$ — the octic analogue of $\\chi_4(n) = (-1)^{\\frac{n-1}{2}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "octic character χ₈",
+      "Dirichlet characters mod 8",
+      "ZMod.χ₄_eq_neg_one_pow analogue",
+      "Mathlib upstreaming"
+    ],
+    "prerequisites": [
+      "Dirichlet character χ₈",
+      "ZMod.χ₈_nat_eq_if_mod_eight",
+      "the signed-power form"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010102-supplement",
@@ -29,7 +67,20 @@
     "range": { "startLine": 152, "endLine": 154 },
     "type": "theorem",
     "title": "The second supplement to quadratic reciprocity",
-    "content": "jacobiSym_two: J(2 | n) = (-1)^((n²-1)/8) for every odd n > 0. Mathlib's jacobiSym.at_two rewrites J(2 | n) as the octic character χ₈ n, and chi8_eq_neg_one_pow puts it in closed power form. This is the second supplementary law, the a = 2 companion of the first supplement's J(-1 | n) = (-1)^((n-1)/2)."
+    "content": "jacobiSym_two: J(2 | n) = (-1)^((n²-1)/8) for every odd n > 0. Mathlib's jacobiSym.at_two rewrites J(2 | n) as the octic character χ₈ n, and chi8_eq_neg_one_pow puts it in closed power form. This is the second supplementary law, the a = 2 companion of the first supplement's J(-1 | n) = (-1)^((n-1)/2).",
+    "mathContext": "$\\left(\\dfrac{2}{n}\\right) = (-1)^{\\frac{n^2-1}{8}}$ for odd $n>0$ — the second supplementary law, companion to $\\left(\\frac{-1}{n}\\right) = (-1)^{\\frac{n-1}{2}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "second supplementary law",
+      "Jacobi symbol at 2",
+      "jacobiSym.at_two",
+      "Zolotarev's lemma"
+    ],
+    "prerequisites": [
+      "Jacobi symbol",
+      "the χ₈ power formula",
+      "first supplement (companion result)"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010102-signdoubling",
@@ -37,7 +88,20 @@
     "range": { "startLine": 164, "endLine": 184 },
     "type": "theorem",
     "title": "The doubling permutation sign",
-    "content": "sign_ringMulPerm_two and sign_doubling: the parent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit u of residue 2 and integer representative 2) gives sign(x ↦ 2·x on ℤ/n) = J(2 | n) = (-1)^((n²-1)/8). The canonical hypothesis-free form sign_doubling uses ZMod.unitOfCoprime 2 with Nat.Coprime 2 n from oddness. This reads the second supplement off Zolotarev's doubling permutation; honestly, the sign value is supplied through χ₈ rather than an independent inversion count (which would reprove Gauss's lemma for 2), since unlike negation, doubling is not an involution."
+    "content": "sign_ringMulPerm_two and sign_doubling: the parent's full odd-modulus identity sign_ringMulPerm_eq_jacobiSym_odd (with a unit u of residue 2 and integer representative 2) gives sign(x ↦ 2·x on ℤ/n) = J(2 | n) = (-1)^((n²-1)/8). The canonical hypothesis-free form sign_doubling uses ZMod.unitOfCoprime 2 with Nat.Coprime 2 n from oddness. This reads the second supplement off Zolotarev's doubling permutation; honestly, the sign value is supplied through χ₈ rather than an independent inversion count (which would reprove Gauss's lemma for 2), since unlike negation, doubling is not an involution.",
+    "mathContext": "$\\mathrm{sign}(x \\mapsto 2x \\text{ on } \\mathbb{Z}/n) = J(2\\mid n) = (-1)^{\\frac{n^2-1}{8}}$, via Zolotarev's lemma for the doubling permutation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "doubling permutation",
+      "Zolotarev permutation sign",
+      "ZMod.unitOfCoprime",
+      "Gauss's lemma for 2"
+    ],
+    "prerequisites": [
+      "the parent odd-modulus Zolotarev identity",
+      "units of ℤ/n from coprimality",
+      "the second supplement value"
+    ]
   },
   {
     "id": "ann-eqr-oq010301010101010102-legendre",
@@ -45,6 +109,18 @@
     "range": { "startLine": 186, "endLine": 191 },
     "type": "theorem",
     "title": "Euler's criterion / Legendre special case",
-    "content": "legendreSym_two: for an odd prime p, (2 / p) = (-1)^((p²-1)/8) — the classical second supplement / Euler-criterion form, equivalently 2 is a quadratic residue mod p iff p ≡ ±1 (mod 8). Obtained by specializing jacobiSym_two to a prime modulus via jacobiSym.legendreSym.to_jacobiSym (legendreSym p a = J(a | p)) and Nat.Prime.odd_of_ne_two."
+    "content": "legendreSym_two: for an odd prime p, (2 / p) = (-1)^((p²-1)/8) — the classical second supplement / Euler-criterion form, equivalently 2 is a quadratic residue mod p iff p ≡ ±1 (mod 8). Obtained by specializing jacobiSym_two to a prime modulus via jacobiSym.legendreSym.to_jacobiSym (legendreSym p a = J(a | p)) and Nat.Prime.odd_of_ne_two.",
+    "mathContext": "$\\left(\\dfrac{2}{p}\\right) = (-1)^{\\frac{p^2-1}{8}}$ for an odd prime $p$: $2$ is a quadratic residue mod $p$ iff $p \\equiv \\pm 1 \\pmod 8$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre symbol",
+      "Euler's criterion",
+      "quadratic residue of 2",
+      "primes ≡ ±1 mod 8"
+    ],
+    "prerequisites": [
+      "Legendre symbol",
+      "specialization Jacobi → Legendre at a prime"
+    ]
   }
 ]

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -44,18 +44,26 @@
   "sections": [
     {
       "title": "Parity of the supplement exponent",
+      "startLine": 80,
+      "endLine": 113,
       "content": "exponent_parity: for odd n, ((n²-1)/8) % 2 = (if n % 8 = 1 ∨ n % 8 = 7 then 0 else 1). With n = 2m+1, (n²-1)/8 = m(m+1)/2 = T_m (the m-th triangular number), proved by omega from (2m+1)² = 4·m(m+1)+1. Decomposing m = 4j+s and rewriting m(m+1) = 2·(8j²+…) per residue, split_ifs + omega finish both the exponent parity and the n-mod-8 side condition."
     },
     {
       "title": "The supplement value as a signed power",
+      "startLine": 114,
+      "endLine": 126,
       "content": "neg_one_pow_exponent: (-1)^((n²-1)/8) = (if n % 8 = 1 ∨ n % 8 = 7 then 1 else -1), obtained from exponent_parity via Even.neg_one_pow / Odd.neg_one_pow: +1 when n ≡ ±1 (mod 8), -1 when n ≡ ±3 (mod 8)."
     },
     {
       "title": "Closed-form power formula for χ₈",
+      "startLine": 127,
+      "endLine": 141,
       "content": "chi8_eq_neg_one_pow: χ₈ n = (-1)^((n²-1)/8) for odd n — the octic analogue of ZMod.χ₄_eq_neg_one_pow, absent from Mathlib (which has only the case split χ₈_nat_eq_if_mod_eight). Proved by rewriting χ₈ via the case split and matching it to neg_one_pow_exponent, the n-even branch being killed by oddness."
     },
     {
       "title": "The second supplement and the doubling permutation",
+      "startLine": 142,
+      "endLine": 197,
       "content": "jacobiSym_two: J(2 | n) = (-1)^((n²-1)/8) by jacobiSym.at_two (J(2 | n) = χ₈ n) and chi8_eq_neg_one_pow. sign_ringMulPerm_two / sign_doubling: the parent's sign_ringMulPerm_eq_jacobiSym_odd gives sign(x ↦ 2·x on ℤ/n) = J(2 | n) = (-1)^((n²-1)/8), in a unit-hypothesis form and a canonical hypothesis-free form using ZMod.unitOfCoprime 2. legendreSym_two: the Legendre/Euler-criterion case (2 / p) = (-1)^((p²-1)/8) at an odd prime."
     }
   ],


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02` (second supplement $J(2\mid n) = (-1)^{(n^2-1)/8}$ via Zolotarev's doubling permutation).

## Changes
- **Deepened all 6 annotations.** Previously content-only; added LaTeX `mathContext`, `significance`, 4 `relatedConcepts`, and `prerequisites` to each: the triangular-number exponent parity $\tfrac{n^2-1}{8} = T_m$, the signed-power value, the χ₈ closed form $\chi_8(n)=(-1)^{(n^2-1)/8}$, the second supplement $J(2\mid n)$, the doubling-permutation sign, and the Legendre/Euler-criterion $(2/p)$ case.
- **Mapped the sections.** Added `startLine`/`endLine` to all 4 sections, covering the full PART I–III structure of the 197-line file (they previously had no line ranges).

## Notes
- meta.json ~15.7 KB, well under the 60 KB cap. Axiom integrity unchanged (`verified`, 0 axioms, 0 sorries).
- Verified no competing in-flight PR for this entry before working it (the sibling entries in this Zolotarev family already have open enricher PRs — #30617/#30619 — this `-oq-02` sibling did not).
- Annotation startLines all land on `theorem` declarations (validated against the source); `annotations:build` type/range checks pass for this id.