### PR TITLE
Enrich Catalan ratio deficit (erdos-396-oq-04-oq-01-oq-01): add sections, deepen annotations

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/annotations.json
@@ -9,7 +9,18 @@
     "type": "definition",
     "title": "The deficit and the harmonic number",
     "content": "Two definitions set the stage: the **deficit** $\\delta\\,n = 4 - r\\,n$, measuring how far the $n$-th Catalan step lags the limiting growth rate $4$; and the real **harmonic number** $H\\,m = \\sum_{i<m} 1/(i+1)$, the running sum the deficits will turn out to equal. The ratio $r\\,n$ is imported from the parent entry.",
-    "mathContext": "$\\delta\\,n = 4 - r\\,n$, $\\quad H\\,m = \\sum_{i=0}^{m-1} \\frac{1}{i+1}$."
+    "mathContext": "$\\delta\\,n = 4 - r\\,n$, $\\quad H\\,m = \\sum_{i=0}^{m-1} \\frac{1}{i+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "harmonic number",
+      "recurrence ratio",
+      "growth rate"
+    ],
+    "prerequisites": [
+      "finite sums (Finset.range)",
+      "the parent ratio identity"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01-deficit-eq",
@@ -21,7 +32,17 @@
     "type": "key-step",
     "title": "The deficit is a harmonic tail",
     "content": "Directly from the parent's partial-fraction identity $r\\,n = 4 - 6/(n+2)$, the deficit is *exactly* $\\delta\\,n = 6/(n+2)$ — a single $\\texttt{ring}$ rewrite. This is the crux: the shortfall from the rate $4$ is a harmonic term, decaying like $1/n$ rather than geometrically.",
-    "mathContext": "$\\delta\\,n = 4 - \\left(4 - \\frac{6}{n+2}\\right) = \\frac{6}{n+2}$."
+    "mathContext": "$\\delta\\,n = 4 - \\left(4 - \\frac{6}{n+2}\\right) = \\frac{6}{n+2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partial fractions",
+      "harmonic decay 1/n",
+      "Catalan recurrence ratio"
+    ],
+    "prerequisites": [
+      "the parent identity r n = 4 − 6/(n+2)",
+      "the ring tactic"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01-tendsto-zero",
@@ -33,7 +54,17 @@
     "type": "observation",
     "title": "Each step's deficit vanishes",
     "content": "Since $r\\,n \\to 4$ (parent), the deficit $\\delta\\,n = 4 - r\\,n \\to 0$. Individually the steps race up to the limiting rate $4$. This is one half of the dichotomy; the other half — that the deficits nonetheless sum to infinity — is the heart of the entry.",
-    "mathContext": "$\\delta\\,n \\to 4 - 4 = 0$."
+    "mathContext": "$\\delta\\,n \\to 4 - 4 = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "limit of a sequence",
+      "Filter.Tendsto",
+      "convergence to a rate"
+    ],
+    "prerequisites": [
+      "limits (Tendsto, nhds)",
+      "the parent limit r n → 4"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01-sum-eq",
@@ -45,7 +76,19 @@
     "type": "key-step",
     "title": "Cumulative deficit is a harmonic partial sum",
     "content": "The headline identity $\\sum_{k<n} \\delta\\,k = 6\\,(H_{n+1} - 1)$, proved by induction on $n$. The base case computes $H_1 = 1$. The successor case peels the top term with $\\texttt{Finset.sum\\_range\\_succ}$, expands $H_{m+2} = H_{m+1} + 1/(m+2)$ via the harmonic recurrence (with a $\\texttt{push\\_cast}$ to align $\\uparrow(m+1)+1 = \\uparrow m + 2$), and closes by $\\texttt{ring}$. The constant $-1$ reflects dropping the $i=0$ term $1/1$, since the deficit sum starts at $1/(0+2)$.",
-    "mathContext": "$\\sum_{k=0}^{n-1} \\frac{6}{k+2} = 6\\sum_{j=2}^{n+1}\\frac{1}{j} = 6\\,(H_{n+1} - 1)$."
+    "mathContext": "$\\sum_{k=0}^{n-1} \\frac{6}{k+2} = 6\\sum_{j=2}^{n+1}\\frac{1}{j} = 6\\,(H_{n+1} - 1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction on n",
+      "harmonic partial sum",
+      "Finset.sum_range_succ",
+      "telescoping / index shift"
+    ],
+    "prerequisites": [
+      "induction",
+      "finite-sum manipulation",
+      "the harmonic recurrence H(m+1) = H m + 1/(m+1)"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01-divergence",
@@ -57,7 +100,18 @@
     "type": "key-step",
     "title": "The cumulative shortfall diverges",
     "content": "The sharp contrast with $\\delta\\,n \\to 0$: because $\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1)$ is a harmonic partial sum, it diverges to $+\\infty$. The proof transports Mathlib's harmonic-series divergence $\\texttt{Real.tendsto\\_sum\\_range\\_one\\_div\\_nat\\_succ\\_atTop}$ along the closed form: shift $n \\mapsto n+1$, subtract the constant $1$, scale by $6 > 0$, then rewrite by the closed form with $\\texttt{Tendsto.congr}$. Terms tending to $0$ whose series diverges — the textbook phenomenon, here forced by a combinatorial recurrence.",
-    "mathContext": "$\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1) \\to \\infty$ since $H_m \\to \\infty$."
+    "mathContext": "$\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1) \\to \\infty$ since $H_m \\to \\infty$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divergence of the harmonic series",
+      "terms → 0 but series diverges",
+      "Tendsto.const_mul_atTop",
+      "atTop filter"
+    ],
+    "prerequisites": [
+      "harmonic-series divergence in Mathlib",
+      "limit transport (Tendsto.congr, tendsto_add_atTop_nat)"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01-ratio-sum",
@@ -69,6 +123,16 @@
     "type": "key-step",
     "title": "Closed form for the ratio running sum",
     "content": "Splitting $r\\,k = 4 - \\delta\\,k$ and summing via $\\texttt{Finset.sum\\_sub\\_distrib}$ gives the closed form $\\sum_{k<n} r\\,k = 4n - 6\\,(H_{n+1} - 1)$, expressing the partial sums of the Catalan ratios entirely in terms of harmonic numbers.",
-    "mathContext": "$\\sum_{k<n} r\\,k = 4n - \\sum_{k<n}\\delta\\,k = 4n - 6\\,(H_{n+1}-1)$."
+    "mathContext": "$\\sum_{k<n} r\\,k = 4n - \\sum_{k<n}\\delta\\,k = 4n - 6\\,(H_{n+1}-1)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_sub_distrib",
+      "closed-form partial sum",
+      "harmonic numbers"
+    ],
+    "prerequisites": [
+      "finite-sum splitting",
+      "the cumulative deficit identity"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01/meta.json
@@ -46,6 +46,56 @@
       "Limits of real sequences (Filter.Tendsto, atTop) and finite-sum manipulation"
     ]
   },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions: the deficit and the harmonic number",
+      "startLine": 47,
+      "endLine": 52,
+      "summary": "catalanDeficit n = 4 − catalanRatio n (the shortfall of the n-th step from the limiting rate 4), and realHarmonic m = ∑_{i<m} 1/(i+1), the real m-th harmonic number whose partial sums the deficits will equal.",
+      "mathContext": "$\\delta\\,n = 4 - r\\,n$, $\\quad H\\,m = \\sum_{i<m} \\frac{1}{i+1}$."
+    },
+    {
+      "id": "deficit-identity",
+      "title": "The deficit identity and its vanishing",
+      "startLine": 54,
+      "endLine": 67,
+      "summary": "deficit_eq: δ n = 6/(n+2) by a one-line ring rewrite of the parent identity r n = 4 − 6/(n+2); deficit_pos: δ n > 0 by positivity; deficit_tendsto_zero: δ n → 0 from r n → 4. Each step's shortfall is a harmonic term that vanishes individually.",
+      "mathContext": "$\\delta\\,n = 4 - (4 - \\tfrac{6}{n+2}) = \\tfrac{6}{n+2} \\to 0$."
+    },
+    {
+      "id": "harmonic-recurrence",
+      "title": "Harmonic-number recurrence and base case",
+      "startLine": 69,
+      "endLine": 76,
+      "summary": "realHarmonic_succ: H(m+1) = H m + 1/(m+1) via Finset.sum_range_succ; realHarmonic_one: H 1 = 1. The two facts needed to run the induction for the cumulative-deficit identity.",
+      "mathContext": "$H_{m+1} = H_m + \\tfrac{1}{m+1}$, $\\quad H_1 = 1$."
+    },
+    {
+      "id": "cumulative-deficit",
+      "title": "Cumulative deficit is a harmonic partial sum",
+      "startLine": 78,
+      "endLine": 99,
+      "summary": "deficit_sum_eq: ∑_{k<n} δ k = 6·(H_{n+1} − 1) by induction (peel with sum_range_succ, expand the harmonic recurrence with push_cast, close by ring). ratio_sum_eq: splitting r k = 4 − δ k gives ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1).",
+      "mathContext": "$\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1)$, $\\quad \\sum_{k<n} r\\,k = 4n - 6\\,(H_{n+1}-1)$."
+    },
+    {
+      "id": "divergence",
+      "title": "The cumulative shortfall diverges",
+      "startLine": 101,
+      "endLine": 119,
+      "summary": "realHarmonic_tendsto_atTop: harmonic partial sums diverge (Mathlib's Real.tendsto_sum_range_one_div_nat_succ_atTop); deficit_sum_tendsto_atTop: ∑_{k<n} δ k → ∞ by transporting that divergence along the closed form (shift, subtract 1, scale by 6, Tendsto.congr). The sharp contrast with δ n → 0.",
+      "mathContext": "$\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1)\\to\\infty$ since $H_m\\to\\infty$."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Numerical sanity checks",
+      "startLine": 121,
+      "endLine": 133,
+      "summary": "Worked examples: δ 0 = 3 (r 0 = 1 lags 4 by 3), and ∑_{k<2} δ k = 3 + 2 = 5 = 6·(H₃ − 1), confirming the closed form on small cases.",
+      "mathContext": "$\\delta\\,0 = 3$, $\\quad \\delta\\,0 + \\delta\\,1 = 5 = 6\\,(H_3 - 1)$."
+    }
+  ],
   "conclusion": {
     "summary": "The deficit δ n = 4 − r n of the Catalan recurrence ratio equals exactly 6/(n+2). Individually the deficits vanish (δ n → 0), but their running total is the harmonic partial sum ∑_{k<n} δ k = 6·(H_{n+1} − 1), which diverges to +∞. As a corollary the running sum of the ratios is ∑_{k<n} r k = 4n − 6·(H_{n+1} − 1). All nine theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The result pinpoints, purely at the level of the integer recurrence, why the Catalan numbers grow strictly slower than 4^n by a polynomial factor: the multiplicative deficits from the rate 4 are harmonic and so do not sum to a finite constant. It exhibits a clean textbook instance of the distinction between a sequence tending to 0 and its series converging, arising naturally from a combinatorial recurrence.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01` (the Catalan recurrence-ratio deficit $\delta n = 4 - r n = 6/(n+2)$ is harmonic, so it vanishes pointwise yet sums to a divergent harmonic series).

## Changes
- **Added a `sections` array** — the entry had **none**. Six sections now map the full 133-line file: definitions, the deficit identity + vanishing, the harmonic-number recurrence, the cumulative-deficit identity + ratio running sum, the divergence, and the numerical sanity checks. Each carries `startLine`/`endLine`, a `summary`, and LaTeX `mathContext`.
- **Deepened all 6 annotations** with `significance`, `relatedConcepts`, and `prerequisites` (they previously had only `content` + `mathContext`).

## Notes
- meta.json ~11 KB, well under the 60 KB cap. Axiom integrity unchanged (`verified`, 0 axioms, 0 sorries; `#print axioms` clean per the existing assumptions note).
- Verified no competing in-flight PR for this entry before working it.
- `annotations:build` reports **0 errors for this id** (the pre-existing `key-step`/`observation` annotation types validate; my added sections and fields introduce no new errors).