### PR TITLE
research(wilsons-theorem-oq-03-oq-02): composite converse n∣(n−1)! for composite n≠4 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4302,6 +4302,7 @@ import Proofs.WilsonsTheoremOQ02ExtOQ02
 import Proofs.WilsonsTheoremOQ02ExtOQ03
 import Proofs.WilsonsTheoremOQ02OQ02
 import Proofs.WilsonsTheoremOQ03
+import Proofs.WilsonsTheoremOQ03OQ02
 import Proofs.WilsonsTheoremOQ04
 import Proofs.WilsonsTheoremOQ04OQ02
 import Proofs.WilsonsTheoremOQ05

--- a/proofs/Proofs/WilsonsTheoremOQ03OQ02.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ03OQ02.lean
@@ -1,0 +1,128 @@
+import Mathlib
+
+/-
+# The composite converse of Wilson's theorem
+
+Wilson's theorem (in Mathlib as `Nat.prime_iff_fac_equiv_neg_one`) characterises the
+primes by the congruence `(n-1)! ≡ -1 (mod n)`.  Its classical *composite* counterpart
+sharpens the converse: for a composite modulus the factorial collapses all the way to `0`,
+with a single exception at `n = 4`.
+
+  **For every composite `n ≠ 4` one has `n ∣ (n-1)!`** (equivalently `(n-1)! ≡ 0 mod n`).
+
+The exception is genuine: `(4-1)! = 3! = 6` and `4 ∤ 6`.
+
+Mathlib already proves the *weak* form used inside Wilson's theorem — a single *proper*
+divisor `m` of `n` divides `(n-1)!` — which is only enough to rule out `(n-1)! ≡ -1`.
+The strong statement that `n` itself divides `(n-1)!` is not in Mathlib; its proof needs
+the perfect-square case `n = p²`, which is exactly where the `n = 4` exception comes from.
+
+## Proof outline
+
+A composite `n ≥ 2` factors as `n = m · q` with `2 ≤ m < n` (`exists_dvd_of_not_prime2`)
+and `2 ≤ q < n`.
+
+* If `m ≠ q`, the two factors are *distinct* and both `≤ n-1`, so `m·q = n` divides
+  `(n-1)!` because a product of two distinct factors `≤ N` divides `N!`
+  (`mul_dvd_factorial_of_lt`).
+* If `m = q`, then `n = m²`.  Since `n ≠ 4` we have `m ≥ 3`, and then `m` and `2m` are
+  distinct with `2m ≤ m² - 1 = n - 1`.  Hence `m·(2m) = 2n` divides `(n-1)!`, so `n` does
+  too.
+
+We also record the converse pieces (a prime never divides `(n-1)!`, by Wilson) to obtain
+the full characterisation `n ∣ (n-1)! ↔ ¬ n.Prime ∧ n ≠ 4` for `n ≥ 2`.
+-/
+
+namespace WilsonsTheoremOQ03OQ02
+
+open Nat
+
+/-- **Two distinct factors lemma.**  If `1 ≤ a < b ≤ N` then `a * b ∣ N !`.
+
+Both `a` and `b` occur as separate factors in `N ! = 1·2·⋯·N`: concretely `a ∣ (b-1)!`
+and `b ∣ b`, so `a·b ∣ (b-1)!·b = b!`, and `b! ∣ N!` since `b ≤ N`. -/
+theorem mul_dvd_factorial_of_lt {a b N : ℕ} (ha : 1 ≤ a) (hab : a < b) (hbN : b ≤ N) :
+    a * b ∣ N ! := by
+  have hadvd : a ∣ (b - 1)! := Nat.dvd_factorial (by omega) (by omega)
+  -- `b ! = b * (b-1)!`
+  have hbb : b ! = b * (b - 1)! := by
+    obtain ⟨c, rfl⟩ : ∃ c, b = c + 1 := ⟨b - 1, by omega⟩
+    simp [Nat.factorial_succ]
+  have key : a * b ∣ b ! := by
+    rw [hbb, Nat.mul_comm a b]
+    exact mul_dvd_mul_left b hadvd
+  exact key.trans (Nat.factorial_dvd_factorial hbN)
+
+/-- **Composite converse of Wilson's theorem (strong direction).**
+
+For every composite `n ≠ 4`, the modulus divides the factorial: `n ∣ (n-1)!`, i.e.
+`(n-1)! ≡ 0 (mod n)`. -/
+theorem composite_dvd_factorial_pred {n : ℕ} (hn : 2 ≤ n) (hnp : ¬ n.Prime)
+    (hn4 : n ≠ 4) : n ∣ (n - 1)! := by
+  obtain ⟨m, hmdvd, hm2, hmn⟩ := exists_dvd_of_not_prime2 hn hnp
+  set q := n / m with hq
+  have hmq : n = m * q := (Nat.mul_div_cancel' hmdvd).symm
+  -- `q ≥ 2`: a proper divisor's cofactor is itself proper.
+  have hqpos : 2 ≤ q := by
+    rcases Nat.lt_or_ge q 2 with h | h
+    · exfalso; interval_cases q
+      · simp at hmq; omega
+      · rw [Nat.mul_one] at hmq; omega
+    · exact h
+  -- `q < n`.
+  have hqn : q < n := Nat.div_lt_self (by omega) (by omega)
+  rcases lt_trichotomy m q with hlt | heq | hgt
+  · -- distinct factors, `m < q`
+    have h := mul_dvd_factorial_of_lt (a := m) (b := q) (N := n - 1)
+      (by omega) hlt (by omega)
+    rwa [← hmq] at h
+  · -- perfect square `n = m²`
+    -- `m ≥ 3`, otherwise `m = 2` forces `n = 4`.
+    have hm3 : 3 ≤ m := by
+      by_contra h; push_neg at h
+      have hm_eq : m = 2 := by omega
+      rw [hm_eq] at hmq heq
+      omega
+    have hnsq : n = m * m := by rw [hmq, ← heq]
+    have hbig : 2 * m + 1 ≤ m * m := by nlinarith [hm3]
+    have h2m : m * (2 * m) ∣ (n - 1)! :=
+      mul_dvd_factorial_of_lt (a := m) (b := 2 * m) (N := n - 1)
+        (by omega) (by omega) (by rw [hnsq]; omega)
+    have heq2n : m * (2 * m) = 2 * n := by rw [hnsq]; ring
+    rw [heq2n] at h2m
+    exact (dvd_mul_left n 2).trans h2m
+  · -- distinct factors, `q < m`
+    have h := mul_dvd_factorial_of_lt (a := q) (b := m) (N := n - 1)
+      (by omega) hgt (by omega)
+    rwa [Nat.mul_comm q m, ← hmq] at h
+
+/-- **A prime never divides `(n-1)!`.**  Immediate from Wilson's theorem
+`(n-1)! ≡ -1 (mod n)`: if also `n ∣ (n-1)!` then `-1 ≡ 0`, impossible in the field
+`ZMod n`. -/
+theorem prime_not_dvd_factorial_pred {n : ℕ} (hp : n.Prime) : ¬ n ∣ (n - 1)! := by
+  haveI := Fact.mk hp
+  intro hdvd
+  have hwil : ((n - 1)! : ZMod n) = -1 :=
+    (Nat.prime_iff_fac_equiv_neg_one hp.ne_one).mp hp
+  have hz : ((n - 1)! : ZMod n) = 0 := (ZMod.natCast_eq_zero_iff _ _).mpr hdvd
+  rw [hwil] at hz
+  exact one_ne_zero (neg_eq_zero.mp hz)
+
+/-- **Full characterisation.**  For `n ≥ 2`, the modulus divides `(n-1)!` precisely when
+`n` is composite and `n ≠ 4`:
+
+  `n ∣ (n-1)! ↔ ¬ n.Prime ∧ n ≠ 4`.
+
+Combined with Wilson's theorem this completely sorts the value of `(n-1)! mod n`:
+`-1` for primes, `2` for `n = 4`, and `0` for every other composite. -/
+theorem dvd_factorial_pred_iff {n : ℕ} (hn : 2 ≤ n) :
+    n ∣ (n - 1)! ↔ ¬ n.Prime ∧ n ≠ 4 := by
+  constructor
+  · intro hdvd
+    refine ⟨fun hp => prime_not_dvd_factorial_pred hp hdvd, ?_⟩
+    rintro rfl
+    exact absurd hdvd (by decide)
+  · rintro ⟨hnp, hn4⟩
+    exact composite_dvd_factorial_pred hn hnp hn4
+
+end WilsonsTheoremOQ03OQ02

--- a/src/data/proofs/wilsons-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-02/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-wilson-composite-overview",
+    "proofId": "wilsons-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "The composite companion to Wilson's theorem",
+    "content": "Wilson's theorem says a prime modulus makes (n−1)! ≡ −1. The composite companion proved here says a composite modulus makes (n−1)! collapse to 0 — except at n = 4, where 3! = 6 ≡ 2. Mathlib already contains the weak half (a single proper divisor m of n divides (n−1)!), which only rules out the residue −1; it does not contain the statement that n itself divides (n−1)!. That stronger fact requires handling the perfect-square case n = m², and it is exactly the perfect-square obstruction m = 2 that singles out n = 4.",
+    "mathContext": "Target: composite $n \\neq 4 \\implies n \\mid (n-1)!$, i.e. $(n-1)! \\equiv 0 \\pmod n$. Combined with Wilson: $(n-1)! \\bmod n$ is $-1$ (prime), $2$ ($n=4$), $0$ (other composite).",
+    "significance": "context",
+    "relatedConcepts": [
+      "Wilson's theorem",
+      "factorial",
+      "primality test",
+      "composite numbers"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "divisibility",
+      "factorials"
+    ]
+  },
+  {
+    "id": "ann-wilson-two-factors",
+    "proofId": "wilsons-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 40,
+      "endLine": 54
+    },
+    "type": "technique",
+    "title": "Two distinct factors divide N!",
+    "content": "mul_dvd_factorial_of_lt is the engine of the whole proof: if 1 ≤ a < b ≤ N then a·b ∣ N!. The point is that a and b appear as *separate* factors in N! = 1·2·⋯·N. Formally, a ∣ (b−1)! (Nat.dvd_factorial, since a ≤ b−1) and b ∣ b, so a·b ∣ (b−1)!·b = b! (using b! = b·(b−1)! from Nat.factorial_succ), and finally b! ∣ N! because b ≤ N (Nat.factorial_dvd_factorial). Distinctness a ≠ b is essential — for a coincident factor one only gets a ∣ N!, not a² ∣ N!.",
+    "mathContext": "$1 \\le a < b \\le N \\implies a\\,b \\mid N!$, via $a \\mid (b-1)!$, $\\;a\\,b \\mid b!$, $\\;b! \\mid N!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "factorial divisibility",
+      "Nat.dvd_factorial"
+    ],
+    "prerequisites": [
+      "factorials",
+      "divisibility"
+    ]
+  },
+  {
+    "id": "ann-wilson-composite-direction",
+    "proofId": "wilsons-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 97
+    },
+    "type": "technique",
+    "title": "Factor splitting with a perfect-square case",
+    "content": "composite_dvd_factorial_pred factors n = m·q with 2 ≤ m < n (Nat.exists_dvd_of_not_prime2) and shows 2 ≤ q < n for the cofactor q = n/m. A trichotomy on m vs q follows: when m < q or q < m the two factors are distinct and ≤ n−1, so mul_dvd_factorial_of_lt gives n = m·q ∣ (n−1)! at once. The hard case is m = q, i.e. n = m² a perfect square — here a single factor m is not enough. Since n ≠ 4 forces m ≥ 3, the distinct pair m and 2m works: 2m ≤ m²−1 = n−1 (nlinarith), so m·(2m) = 2n ∣ (n−1)!, hence n ∣ (n−1)!. The obstruction m = 2 is precisely n = 4.",
+    "mathContext": "$n = m^2,\\ m \\ge 3:\\ 2m \\le m^2 - 1 = n-1$, so $m\\cdot(2m) = 2n \\mid (n-1)! \\implies n \\mid (n-1)!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "perfect squares",
+      "factor pairs",
+      "exists_dvd_of_not_prime2"
+    ],
+    "prerequisites": [
+      "divisibility",
+      "case analysis"
+    ]
+  },
+  {
+    "id": "ann-wilson-converse-iff",
+    "proofId": "wilsons-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 99,
+      "endLine": 127
+    },
+    "type": "concept",
+    "title": "Wilson converse and the full biconditional",
+    "content": "prime_not_dvd_factorial_pred closes the other direction: a prime cannot divide (n−1)!, because Wilson gives ((n−1)! : ZMod n) = −1 while n ∣ (n−1)! would give = 0; in the field ZMod n that forces 1 = 0, impossible. dvd_factorial_pred_iff then bundles everything into n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4 for n ≥ 2, with the n = 4 obstruction discharged by decide (kernel reduction of 4 ∤ 3!), so no native_decide and no extra axioms.",
+    "mathContext": "$n \\ge 2:\\ n \\mid (n-1)! \\iff \\lnot\\,n\\text{ prime} \\wedge n \\neq 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wilson's theorem",
+      "ZMod",
+      "biconditional characterisation"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "finite fields"
+    ]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03-oq-02/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "wilsons-theorem-oq-03-oq-02",
+  "title": "Composite converse of Wilson's theorem: every composite n ≠ 4 divides (n−1)!",
+  "slug": "wilsons-theorem-oq-03-oq-02",
+  "description": "Proves the strong composite counterpart of Wilson's theorem: for every composite n ≠ 4 the modulus divides the factorial, n ∣ (n−1)!, i.e. (n−1)! ≡ 0 (mod n). Together with Wilson's theorem this completely determines (n−1)! mod n for n ≥ 2: it is −1 for primes, 2 for n = 4, and 0 for every other composite. Mathlib contains only the weak form used inside its proof of Wilson's theorem — that a single proper divisor m of n divides (n−1)! — which suffices only to refute (n−1)! ≡ −1; the statement that n itself divides (n−1)! is not in Mathlib. The proof factors a composite n ≥ 2 as n = m·q with 2 ≤ m < n (Nat.exists_dvd_of_not_prime2) and 2 ≤ q < n. When m ≠ q the two factors are distinct and both ≤ n−1, so m·q = n divides (n−1)! via the reusable lemma mul_dvd_factorial_of_lt (a product of two distinct factors ≤ N divides N!). When m = q the modulus is a perfect square n = m²; since n ≠ 4 this forces m ≥ 3, and then m and 2m are distinct with 2m ≤ m²−1 = n−1, so m·(2m) = 2n divides (n−1)! and hence n does too. The n = 4 exception is genuine: (4−1)! = 6 and 4 ∤ 6. The converse pieces (a prime never divides (n−1)!, by Wilson) give the full characterisation dvd_factorial_pred_iff: n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4. Verified with 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Classical (composite converse / strong form of Wilson's theorem); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ03OQ02.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "factorial",
+      "divisibility",
+      "primality",
+      "composite-numbers",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.exists_dvd_of_not_prime2",
+        "description": "2 ≤ n → ¬n.Prime → ∃ m, m ∣ n ∧ 2 ≤ m ∧ m < n. Provides the nontrivial factor m of a composite n, with its cofactor q = n/m supplying the second factor of the splitting n = m·q.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_factorial",
+        "description": "0 < m → m ≤ n → m ∣ n!. The atomic divisibility fact that each integer in [1, N] occurs as a factor of N!; applied to place a inside (b−1)! in the two-distinct-factors lemma.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_dvd_factorial",
+        "description": "m ≤ n → m! ∣ n!. Lifts b! ∣ (n−1)! once a·b ∣ b! has been established, completing the two-distinct-factors lemma.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.prime_iff_fac_equiv_neg_one",
+        "description": "n ≠ 1 → (Prime n ↔ ((n−1)! : ZMod n) = −1). Wilson's theorem, used for the converse direction: a prime n satisfies (n−1)! ≡ −1, so it cannot also satisfy (n−1)! ≡ 0.",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a. Translates the divisibility n ∣ (n−1)! into the congruence ((n−1)! : ZMod n) = 0 to collide with Wilson's −1.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "composite_dvd_factorial_pred: for every composite n ≠ 4, n ∣ (n−1)! — the strong composite converse of Wilson's theorem (the modulus itself, not merely a proper divisor, divides the factorial). Mathlib has only the proper-divisor form; the full statement and the perfect-square case that produces the n = 4 exception are assembled here.",
+      "mul_dvd_factorial_of_lt: a reusable lemma that a product of two distinct factors a < b ≤ N divides N! (via a ∣ (b−1)!, b ∣ b, hence a·b ∣ b! ∣ N!). This is the combinatorial engine that makes both branches of the main proof uniform.",
+      "dvd_factorial_pred_iff: the complete characterisation n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4 for n ≥ 2, which together with Wilson's theorem fully resolves the value of (n−1)! mod n (−1 for primes, 2 at n = 4, 0 for all other composites)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The n = 4 base case is discharged by `decide` (kernel Decidable reduction, not native_decide), so no Lean.ofReduceBool is introduced. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed by #print axioms on composite_dvd_factorial_pred and dvd_factorial_pred_iff).",
+    "lineCount": 128,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Wilson's theorem (Lagrange, 1771) states that an integer n > 1 is prime iff (n−1)! ≡ −1 (mod n). Its composite counterpart — that a composite modulus collapses the factorial to 0 modulo n — is the standard companion fact: it is what makes the factorial congruence a genuine primality test, since the residue (n−1)! mod n is −1 exactly for primes and 0 for composites, with the lone exception of n = 4 (where 3! = 6 ≡ 2). The composite direction is elementary but not entirely trivial: the obvious argument 'write n = ab with a, b < n, then ab ∣ (n−1)!' breaks when a = b (n a perfect square), and it is precisely this perfect-square case that isolates n = 4.",
+    "problemStatement": "For n ≥ 2, determine when n ∣ (n−1)!. Wilson's theorem handles the prime case ((n−1)! ≡ −1, so n ∤ (n−1)!). This entry (leaf oq-03-oq-02 of the Wilson family) proves the composite case: n ∣ (n−1)! for every composite n other than n = 4, and assembles the full biconditional n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4.",
+    "keyIdea": "Split a composite n as n = m·q with 2 ≤ m, q < n. If m ≠ q the factors are distinct and both ≤ n−1, so n = m·q divides (n−1)! because any product of two distinct factors ≤ N divides N! (place the smaller one inside (larger−1)!). If m = q then n = m² is a perfect square; excluding n = 4 forces m ≥ 3, whereupon m and 2m are distinct factors with 2m ≤ m²−1 = n−1, giving m·(2m) = 2n ∣ (n−1)! and therefore n ∣ (n−1)!. The single obstruction m = 2 (so n = 4) is exactly the classical exception."
+  },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: the composite companion to Wilson's theorem",
+      "startLine": 3,
+      "endLine": 34,
+      "summary": "Module docstring stating the strong composite converse n ∣ (n−1)! for composite n ≠ 4, contrasting it with the proper-divisor form already in Mathlib (which only refutes ≡ −1), and outlining the two-case proof (distinct factors vs. perfect square) that produces the n = 4 exception."
+    },
+    {
+      "id": "two-distinct-factors",
+      "title": "Two distinct factors divide the factorial",
+      "startLine": 40,
+      "endLine": 54,
+      "summary": "mul_dvd_factorial_of_lt: for 1 ≤ a < b ≤ N, a·b ∣ N!. Uses a ∣ (b−1)! (Nat.dvd_factorial) and b ∣ b to get a·b ∣ (b−1)!·b = b! (Nat.factorial_succ), then b! ∣ N! (Nat.factorial_dvd_factorial). The reusable engine for both branches of the main theorem."
+    },
+    {
+      "id": "composite-direction",
+      "title": "Composite n ≠ 4 divides (n−1)!",
+      "startLine": 56,
+      "endLine": 97,
+      "summary": "composite_dvd_factorial_pred: factors n = m·q via Nat.exists_dvd_of_not_prime2, derives 2 ≤ q < n, then trichotomy on m vs q. The m ≠ q branches apply mul_dvd_factorial_of_lt directly; the m = q (perfect-square) branch uses m ≥ 3 (from n ≠ 4), the bound 2m ≤ m²−1 via nlinarith, and m·(2m) = 2n to conclude n ∣ (n−1)!."
+    },
+    {
+      "id": "converse-and-iff",
+      "title": "Wilson converse and full characterisation",
+      "startLine": 99,
+      "endLine": 127,
+      "summary": "prime_not_dvd_factorial_pred: a prime cannot divide (n−1)! because Wilson gives (n−1)! ≡ −1 while divisibility would give ≡ 0, colliding in the field ZMod n. dvd_factorial_pred_iff: bundles both directions into n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4, the n = 4 obstruction discharged by decide."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Wilson, John; Lagrange, Joseph-Louis",
+      "title": "Wilson's theorem (statement by Wilson 1770; first proof by Lagrange 1771)",
+      "year": "1771",
+      "note": "The prime characterisation (n−1)! ≡ −1 (mod n); the composite companion proved here is its standard complement."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "note": "Oxford University Press, 6th ed. — §8.1 states Wilson's theorem together with the composite case (n−1)! ≡ 0 (mod n) for composite n > 4."
+    },
+    {
+      "authors": "Dickson, Leonard Eugene",
+      "title": "History of the Theory of Numbers, Volume I",
+      "year": "1919",
+      "note": "Carnegie Institution — historical account of Wilson's theorem and its converse, including the n = 4 exceptional case."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "wilsons-theorem",
+      "relationship": "parent",
+      "description": "Core Wilson's theorem ((n−1)! ≡ −1 mod n iff n prime). This entry supplies the composite-side residue (≡ 0), completing the primality dichotomy."
+    },
+    {
+      "proofId": "wilsons-theorem-oq-03",
+      "relationship": "related",
+      "description": "Sibling branch oq-03 (Legendre's formula for v_p(n!)); both quantify factorial arithmetic — Legendre's formula via prime valuations, this entry via the exact modulus n."
+    }
+  ],
+  "conclusion": {
+    "summary": "composite_dvd_factorial_pred establishes n ∣ (n−1)! for every composite n ≠ 4, and dvd_factorial_pred_iff packages the full characterisation n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4 (n ≥ 2). The proof is a single factor-splitting argument with a perfect-square sub-case, reusing the lemma mul_dvd_factorial_of_lt that any product of two distinct factors ≤ N divides N!. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Completes the residue table of (n−1)! mod n alongside Wilson's theorem: −1 for primes, 2 for n = 4, and 0 for all other composites — making the factorial congruence an exact primality criterion. The helper mul_dvd_factorial_of_lt is independently reusable for divisibility-into-factorial arguments.",
+    "openQuestions": [
+      "Strengthen the perfect-square case to the exact 2-adic/p-adic valuation of (n−1)! at n = p² (how many times does p² divide (p²−1)!?), connecting to Legendre's formula in the sibling branch.",
+      "Formalise the analogous statement for the primorial or for (n−1)!! (double factorial), identifying the corresponding exceptional moduli."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "WilsonsTheoremOQ03OQ02",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/WilsonsTheoremOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Composite converse of Wilson's theorem

Adds the gallery entry **wilsons-theorem-oq-03-oq-02**: the strong composite counterpart of Wilson's theorem.

**Main result.** For every composite `n ≠ 4`, `n ∣ (n−1)!` — i.e. `(n−1)! ≡ 0 (mod n)`. Together with Wilson's theorem this completely determines `(n−1)! mod n` for `n ≥ 2`:

| n | (n−1)! mod n |
|---|---|
| prime | −1 |
| 4 | 2 |
| other composite | 0 |

### Why it's not already in Mathlib
Mathlib's Wilson proof uses only the **weak** form — that a single *proper* divisor `m` of `n` divides `(n−1)!` — which suffices only to refute `(n−1)! ≡ −1`. The statement that `n` **itself** divides `(n−1)!` is not in Mathlib, and its proof requires the perfect-square case `n = m²` that is the source of the `n = 4` exception.

### Proof
Factor a composite `n = m·q` with `2 ≤ m,q < n` (`exists_dvd_of_not_prime2`).
- **`m ≠ q`:** distinct factors, both `≤ n−1`, so `n = m·q ∣ (n−1)!` via the reusable lemma `mul_dvd_factorial_of_lt` (a product of two distinct factors `≤ N` divides `N!`).
- **`m = q`:** then `n = m²`; since `n ≠ 4`, `m ≥ 3`, so `m` and `2m` are distinct with `2m ≤ m²−1 = n−1`, giving `m·(2m) = 2n ∣ (n−1)!` and hence `n ∣ (n−1)!`.

The converse (`prime_not_dvd_factorial_pred`, from Wilson) yields the full characterisation `dvd_factorial_pred_iff : n ∣ (n−1)! ↔ ¬n.Prime ∧ n ≠ 4`.

### Verification
- **4 theorems, 0 sorries, 0 axioms** (foundational `propext`/`Classical.choice`/`Quot.sound` only).
- `decide` (kernel reduction, **not** `native_decide`) discharges the `n = 4` base case — no `Lean.ofReduceBool`.
- Verified offline with `lake env lean`; `#print axioms` confirmed clean on all theorems (Docker build unavailable this cycle).

Files: `proofs/Proofs/WilsonsTheoremOQ03OQ02.lean`, gallery `meta.json` + `annotations.json`, and the `Proofs.lean` aggregate import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)