### PR TITLE
Research: prob-method-applications-wip-01 — genuine first-moment existence engine

### DIFF
--- a/proofs/Proofs/ProbMethodApplicationsWIP.lean
+++ b/proofs/Proofs/ProbMethodApplicationsWIP.lean
@@ -1,0 +1,179 @@
+/-
+  Probabilistic Method Applications — Work in Progress completion.
+
+  The companion file `ProbMethodApplications.lean` states several headline
+  consequences of the probabilistic method (Ramsey lower bounds, Property B,
+  tournament domination, ...), but the theorems there are *vacuous*: e.g.
+  `ramsey_lower_bound` only asserts `∃ n, n ≥ 2^((k-1)/2)`, discharged by
+  `⟨2^((k-1)/2), le_refl _⟩`, and none of the stated hypotheses are used.
+
+  This file supplies the genuine engine those statements were standing in for:
+  the **first-moment / union-bound existence principle** in its exact counting
+  form, together with an honest, non-vacuous Ramsey-style application proved
+  from it.
+
+  Counting form of the first moment method:
+    if the total size of finitely many "bad" subsets of a finite sample space
+    is strictly smaller than the size of the whole space, then some sample
+    point avoids every bad set.
+
+  Everything here is `0 sorry`, `0 axiom`.
+-/
+import Mathlib
+
+open Finset
+
+namespace ProbMethod.Core
+
+/-! ## The first-moment / union-bound existence principle -/
+
+variable {Ω : Type*} [Fintype Ω] [DecidableEq Ω] {ι : Type*}
+
+/-- **First-moment existence (counting union bound).**
+If the cardinalities of finitely many subsets `A i` of a finite sample space
+`Ω` sum to strictly less than `|Ω|`, then there is a point `ω` lying in none of
+them. This is the combinatorial heart of the probabilistic method: a "bad
+event" that is rare on average must be avoidable. -/
+theorem exists_avoiding_all (s : Finset ι) (A : ι → Finset Ω)
+    (h : ∑ i ∈ s, (A i).card < Fintype.card Ω) :
+    ∃ ω : Ω, ∀ i ∈ s, ω ∉ A i := by
+  have hbu : (s.biUnion A).card < Fintype.card Ω :=
+    lt_of_le_of_lt (Finset.card_biUnion_le) h
+  have hne : (s.biUnion A)ᶜ.Nonempty := by
+    rw [← Finset.card_pos, Finset.card_compl]
+    omega
+  obtain ⟨ω, hω⟩ := hne
+  refine ⟨ω, ?_⟩
+  intro i hi
+  rw [Finset.mem_compl, Finset.mem_biUnion] at hω
+  push_neg at hω
+  exact hω i hi
+
+/-- **Uniform union bound.** If every bad set has size at most `B` and
+`|s| * B < |Ω|`, then a good point exists. This is the form most directly used
+in applications, where each bad event has the same size bound. -/
+theorem exists_good_of_card_bound (s : Finset ι) (A : ι → Finset Ω) (B : ℕ)
+    (hbound : ∀ i ∈ s, (A i).card ≤ B)
+    (h : s.card * B < Fintype.card Ω) :
+    ∃ ω : Ω, ∀ i ∈ s, ω ∉ A i := by
+  apply exists_avoiding_all s A
+  calc ∑ i ∈ s, (A i).card
+      ≤ ∑ _i ∈ s, B := Finset.sum_le_sum hbound
+    _ = s.card * B := by rw [Finset.sum_const, smul_eq_mul]
+    _ < Fintype.card Ω := h
+
+/-! ## Counting two-colourings (sample space `Finset E`)
+
+We model a 2-colouring of a finite "edge" set `E` as a `Finset E` (the edges
+coloured `true`).  A block `K ⊆ E` is *monochromatic* under colouring `S` when
+`S` is constant on `K`, i.e. `K ⊆ S` (all `true`) or `Disjoint K S` (all
+`false`).  The number of colourings making a fixed `K` monochromatic is small,
+which is exactly what the union bound needs. -/
+
+variable {E : Type*} [Fintype E] [DecidableEq E]
+
+/-- A colouring `S` makes the block `K` monochromatic. Marked reducible so that
+`DecidablePred (Mono K)` is found by instance search when filtering. -/
+@[reducible] def Mono (K S : Finset E) : Prop := K ⊆ S ∨ Disjoint K S
+
+/-- At most `2 ^ (|E| - |K|)` colourings contain `K` (all-`true` on `K`). -/
+theorem card_supersets_le (K : Finset E) :
+    ((univ : Finset (Finset E)).filter (fun S => K ⊆ S)).card
+      ≤ 2 ^ (Fintype.card E - K.card) := by
+  calc ((univ : Finset (Finset E)).filter (fun S => K ⊆ S)).card
+      ≤ ((univ \ K).powerset).card := by
+        apply Finset.card_le_card_of_injOn (fun S => S \ K)
+        · intro S _hS
+          have hsub : S \ K ⊆ univ \ K := by
+            intro x hx; rw [mem_sdiff] at hx ⊢; exact ⟨mem_univ x, hx.2⟩
+          simp only [Finset.mem_coe, Finset.mem_powerset]
+          exact hsub
+        · intro S hS S' hS' hSS'
+          simp only [Finset.coe_filter, Set.mem_setOf_eq, Finset.mem_univ,
+            true_and] at hS hS'
+          dsimp only at hSS'
+          have hrec : (S \ K) ∪ K = (S' \ K) ∪ K := by rw [hSS']
+          rwa [Finset.sdiff_union_of_subset hS, Finset.sdiff_union_of_subset hS']
+            at hrec
+    _ = 2 ^ (Fintype.card E - K.card) := by
+        rw [card_powerset, ← Finset.compl_eq_univ_sdiff, Finset.card_compl]
+
+/-- At most `2 ^ (|E| - |K|)` colourings are disjoint from `K` (all-`false` on
+`K`). -/
+theorem card_disjoint_le (K : Finset E) :
+    ((univ : Finset (Finset E)).filter (fun S => Disjoint K S)).card
+      ≤ 2 ^ (Fintype.card E - K.card) := by
+  have hsub : (univ : Finset (Finset E)).filter (fun S => Disjoint K S)
+      ⊆ (Kᶜ).powerset := by
+    intro S hS
+    rw [mem_filter] at hS
+    rw [mem_powerset]
+    intro x hx
+    rw [mem_compl]
+    intro hxK
+    exact (Finset.disjoint_left.mp hS.2) hxK hx
+  calc ((univ : Finset (Finset E)).filter (fun S => Disjoint K S)).card
+      ≤ (Kᶜ).powerset.card := card_le_card hsub
+    _ = 2 ^ (Fintype.card E - K.card) := by
+        rw [card_powerset, card_compl]
+
+/-- The number of colourings making `K` monochromatic is at most
+`2 ^ (|E| - |K| + 1)`. -/
+theorem card_mono_le (K : Finset E) :
+    ((univ : Finset (Finset E)).filter (fun S => Mono K S)).card
+      ≤ 2 ^ (Fintype.card E - K.card + 1) := by
+  have hsplit : (univ : Finset (Finset E)).filter (fun S => Mono K S)
+      = ((univ : Finset (Finset E)).filter (fun S => K ⊆ S))
+        ∪ ((univ : Finset (Finset E)).filter (fun S => Disjoint K S)) := by
+    rw [← Finset.filter_or]
+  have h1 := card_supersets_le K
+  have h2 := card_disjoint_le K
+  have hpow : 2 ^ (Fintype.card E - K.card) + 2 ^ (Fintype.card E - K.card)
+      = 2 ^ (Fintype.card E - K.card + 1) := by
+    rw [pow_succ]; ring
+  rw [hsplit]
+  calc (((univ : Finset (Finset E)).filter (fun S => K ⊆ S))
+          ∪ ((univ : Finset (Finset E)).filter (fun S => Disjoint K S))).card
+      ≤ ((univ : Finset (Finset E)).filter (fun S => K ⊆ S)).card
+        + ((univ : Finset (Finset E)).filter (fun S => Disjoint K S)).card :=
+        Finset.card_union_le _ _
+    _ ≤ 2 ^ (Fintype.card E - K.card + 1) := by omega
+
+/-! ## Ramsey-style avoidance (honest probabilistic existence) -/
+
+/-- **Ramsey lower bound, avoidance form.**
+Let `E` be a finite set of "edges" and `cliques` a family of `m`-element blocks.
+If the expected number of monochromatic blocks is below one — concretely if
+`|cliques| * 2 ^ (|E| - m + 1) < 2 ^ |E|` — then there is a 2-colouring of `E`
+in which *no* block is monochromatic.
+
+Instantiating `E` as the edge set of `K_n` (so `|E| = C(n,2)`) and `cliques` as
+the `C(n,m)` copies of `K_m`, the hypothesis becomes
+`C(n,m) * 2 ^ (C(n,2) - C(m,2) + 1) < 2 ^ C(n,2)`, i.e. the classical
+`C(n,m) * 2^(1 - C(m,2)) < 1`, and the conclusion is the Erdős (1947) lower
+bound `R(m,m) > n`.  Unlike the placeholder `ramsey_lower_bound`, every
+hypothesis here does real work. -/
+theorem ramsey_avoidance
+    (cliques : Finset (Finset E)) (m : ℕ)
+    (hm : ∀ K ∈ cliques, K.card = m)
+    (h : cliques.card * (2 ^ (Fintype.card E - m + 1)) < 2 ^ (Fintype.card E)) :
+    ∃ S : Finset E, ∀ K ∈ cliques, ¬ Mono K S := by
+  have hcard : Fintype.card (Finset E) = 2 ^ Fintype.card E := Fintype.card_finset
+  have hbound : ∀ K ∈ cliques,
+      ((univ : Finset (Finset E)).filter (fun S => Mono K S)).card
+        ≤ 2 ^ (Fintype.card E - m + 1) := by
+    intro K hK
+    have := card_mono_le K
+    rwa [hm K hK] at this
+  have hlt : cliques.card * (2 ^ (Fintype.card E - m + 1))
+      < Fintype.card (Finset E) := by rw [hcard]; exact h
+  obtain ⟨S, hS⟩ := exists_good_of_card_bound (Ω := Finset E) cliques
+    (fun K => (univ : Finset (Finset E)).filter (fun S => Mono K S))
+    (2 ^ (Fintype.card E - m + 1)) hbound hlt
+  refine ⟨S, fun K hK => ?_⟩
+  have hmem := hS K hK
+  rw [mem_filter] at hmem
+  push_neg at hmem
+  exact not_or.mpr (hmem (mem_univ S))
+
+end ProbMethod.Core

--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "prob-method-applications-wip-01",
+  "title": "Probabilistic Method: First-Moment Existence Engine",
+  "slug": "prob-method-applications-wip-01",
+  "description": "The genuine counting form of the probabilistic method's first-moment principle, with an honest, non-vacuous Ramsey-style avoidance theorem proved from it. Completes the work-in-progress applications module, whose headline theorems were vacuous placeholders.",
+  "meta": {
+    "author": "Paul Erdős (1947), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
+    "date": "1947",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodApplicationsWIP.lean",
+    "tags": [
+      "probabilistic-method",
+      "combinatorics",
+      "ramsey-theory",
+      "union-bound",
+      "first-moment-method"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_biUnion_le",
+        "description": "Cardinality of a union is at most the sum of cardinalities (union bound)",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_powerset",
+        "description": "The powerset of a finite set has 2^n elements",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "An injection from s into t bounds |s| by |t|",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Fintype.card_finset",
+        "description": "There are 2^|E| subsets of a finite type E (the colouring sample space)",
+        "module": "Mathlib.Data.Fintype.Powerset"
+      }
+    ],
+    "originalContributions": [
+      "exists_avoiding_all: the first-moment / union-bound existence principle in exact counting form — if the bad sets sum to fewer than |Ω| points, some point avoids all of them",
+      "exists_good_of_card_bound: the uniform union bound (|s| * B < |Ω|) used directly in applications",
+      "card_supersets_le / card_disjoint_le / card_mono_le: tight 2^(|E|-|K|) cardinality bounds on the colourings that are monochromatic on a block K",
+      "ramsey_avoidance: honest Ramsey lower bound (avoidance form). If |cliques| * 2^(|E|-m+1) < 2^|E| then a 2-colouring with no monochromatic block exists — instantiating to K_n recovers Erdős's R(m,m) > n. Unlike the placeholder ramsey_lower_bound, every hypothesis does real work."
+    ],
+    "dateAdded": "2026-06-27",
+    "prerequisites": [
+      "Finite probability / counting on finite sample spaces",
+      "The union bound and first moment method",
+      "Ramsey theory and Ramsey number lower bounds"
+    ],
+    "axiomCount": 0,
+    "relatedProblems": [
+      {
+        "id": "prob-method-applications",
+        "relationship": "Completes the work-in-progress applications module by supplying the genuine first-moment engine its placeholder theorems stood in for"
+      },
+      {
+        "id": "prob-method-expectation",
+        "relationship": "Provides the counting (cardinality) form of the first moment existence principle"
+      }
+    ],
+    "assumptions": "0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound). Fully machine-checked against Mathlib v4.26.0.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The probabilistic method, introduced by Paul Erdős in his 1947 proof of a lower bound on Ramsey numbers, establishes the existence of combinatorial objects without constructing them: if a randomly chosen object fails to have a desired property with probability less than one, then a good object must exist. The companion gallery entry prob-method-applications collected the headline consequences of this method, but its theorems were vacuous placeholders (for instance ramsey_lower_bound merely asserted the existence of a natural number above a given bound, with none of its hypotheses used). This entry supplies the real engine and an honest application.",
+    "problemStatement": "State and prove the first-moment principle of the probabilistic method in its exact finite-counting form, and use it to derive a genuine (non-vacuous) Ramsey-style existence theorem: a 2-colouring of a finite edge set with no monochromatic block of a prescribed size, under an explicit counting hypothesis that specialises to the classical Erdős bound R(m,m) > n.",
+    "text": "The genuine counting form of the first-moment method plus an honest Ramsey avoidance theorem, replacing the vacuous placeholders of the work-in-progress applications module.",
+    "proofStrategy": "Model a 2-colouring of a finite edge set E as an element S of Finset E (the edges coloured true); the sample space has 2^|E| points. The core lemma exists_avoiding_all observes that if finitely many bad sets A i sum to fewer than |Ω| points, their union (bounded by card_biUnion_le) cannot cover Ω, so the complement is nonempty. The uniform corollary exists_good_of_card_bound replaces the sum by |s| * B. For the Ramsey application, a block K is monochromatic under S exactly when K ⊆ S or K is disjoint from S; the colourings of the first kind inject (via S ↦ S \\ K) into the powerset of the complement of K, and those of the second kind sit inside the powerset of the complement of K, so each contributes at most 2^(|E|-|K|), giving at most 2^(|E|-m+1) monochromatic colourings per block. The union bound then yields a colouring avoiding every block.",
+    "keyInsights": [
+      "The probabilistic method's first moment principle is, over a finite sample space, a pure pigeonhole statement about cardinalities — no measure theory is required.",
+      "Counting monochromatic colourings reduces to powerset cardinalities via an explicit injection S ↦ S \\ K, avoiding any exact bijection.",
+      "Stating Ramsey in avoidance form over an abstract edge set and an abstract family of blocks makes the theorem both fully provable and directly instantiable to K_n.",
+      "The contrast with the placeholder version is the point: here every hypothesis (block size m, the counting inequality) is genuinely consumed by the proof."
+    ],
+    "prerequisites": [
+      "Finite probability / counting on finite sample spaces",
+      "The union bound and first moment method",
+      "Ramsey theory and Ramsey number lower bounds"
+    ]
+  },
+  "conclusion": {
+    "summary": "A fully verified, axiom-free formalization of the first-moment existence principle in counting form, together with an honest Ramsey-avoidance theorem derived from it. This replaces the vacuous placeholders of the work-in-progress applications module with mathematics in which every hypothesis does real work.",
+    "implications": "The exists_avoiding_all and exists_good_of_card_bound lemmas are reusable across the probabilistic-method gallery: any existence-by-counting argument (Property B, tournament domination, hypergraph 2-colouring) can be discharged by exhibiting bad-event cardinality bounds and an arithmetic inequality, rather than restating a placeholder.",
+    "openQuestions": [
+      "Instantiate ramsey_avoidance to the explicit edge set of K_n to obtain the numeric bound R(m,m) > n with C(n,2) and C(m,2) substituted.",
+      "Formalize Property B (m(k) ≥ 2^(k-1)) directly from exists_good_of_card_bound using the same monochromatic-colouring count.",
+      "Prove the tournament domination bound by bounding the number of tournaments with no dominating set of size k."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ProbMethod.Core",
+    "lineCount": 179,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/ProbMethodApplicationsWIP.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Alon, Noga; Spencer, Joel H.",
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "The definitive textbook; Chapter 1 covers the first moment method and the Ramsey lower bound formalized here"
+    },
+    {
+      "authors": "Erdős, Paul",
+      "title": "Some remarks on the theory of graphs",
+      "year": "1947",
+      "venue": "Bulletin of the AMS 53, 292–294",
+      "note": "Original probabilistic lower bound on Ramsey numbers"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/prob-method-applications-wip-01.json
+++ b/src/data/research/problems/prob-method-applications-wip-01.json
@@ -1,0 +1,91 @@
+{
+  "slug": "prob-method-applications-wip-01",
+  "title": "Complete Probabilistic Method Applications (Work in Progress)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Supply the genuine first-moment / union-bound existence principle (counting form) underpinning the probabilistic-method applications module, and derive an honest, non-vacuous Ramsey-style existence theorem from it.",
+    "plain": "The applications module's headline theorems (Ramsey lower bounds, Property B, ...) were vacuous placeholders whose hypotheses were unused. Complete it by formalizing the real engine and at least one genuine application.",
+    "whyMatters": [
+      "The probabilistic method is one of the central tools of 20th-century combinatorics; its first-moment principle is the foundation of Erdős's 1947 Ramsey lower bound.",
+      "Replacing vacuous placeholders with mathematics where every hypothesis does real work restores the gallery's credibility for this module."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "exists_avoiding_all: first-moment / union-bound existence in exact counting form (0 axiom).",
+      "exists_good_of_card_bound: uniform union bound |s|*B < |Ω|.",
+      "card_supersets_le / card_disjoint_le / card_mono_le: <= 2^(|E|-|K|) bounds on colourings monochromatic on a block K.",
+      "ramsey_avoidance: honest Ramsey lower bound (avoidance form); instantiates to Erdős's R(m,m) > n."
+    ],
+    "open": [
+      "Numeric K_n instantiation substituting C(n,2), C(m,2) into ramsey_avoidance.",
+      "Property B (m(k) >= 2^(k-1)) directly from exists_good_of_card_bound.",
+      "Tournament domination via counting tournaments with no small dominating set."
+    ],
+    "goal": "A verified, axiom-free first-moment engine plus a non-vacuous Ramsey application."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-27T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "Formalized the counting first-moment principle and an honest Ramsey-avoidance theorem; verified offline (0 sorry / 0 axiom) against Mathlib v4.26.0.",
+    "blockers": [],
+    "nextAction": "Optional follow-ups: K_n numeric instantiation, Property B, tournament domination.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Created Proofs/ProbMethodApplicationsWIP.lean (namespace ProbMethod.Core): exists_avoiding_all, exists_good_of_card_bound, card_supersets_le, card_disjoint_le, card_mono_le, ramsey_avoidance. 6 theorems, 1 def, 0 sorry, 0 axiom. Verified offline via LAKE_UNSAFE=1 lake env lean (EXIT 0); #print axioms reports only propext/Classical.choice/Quot.sound.",
+    "builtItems": [
+      "First-moment / union-bound existence engine (counting form)",
+      "Powerset cardinality bounds on monochromatic colourings",
+      "Honest Ramsey avoidance theorem"
+    ],
+    "insights": [
+      "Over a finite sample space the first-moment principle is pure pigeonhole on cardinalities; no measure theory needed.",
+      "Counting monochromatic colourings reduces to powerset cardinalities via the injection S -> S \\ K, avoiding exact bijections.",
+      "Stating Ramsey in avoidance form over an abstract edge set keeps the theorem fully provable and directly instantiable to K_n."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Instantiate ramsey_avoidance to K_n for the numeric R(m,m) > n bound.",
+      "Formalize Property B from the same monochromatic count."
+    ],
+    "markdown": "# Knowledge Base: prob-method-applications-wip-01\n\n## Problem Understanding\n\nThe applications module ProbMethodApplications.lean stated headline probabilistic-method consequences as vacuous placeholders (every hypothesis unused; e.g. ramsey_lower_bound discharged by `le_refl`).\n\n## Resolution\n\nFormalized the genuine engine in Proofs/ProbMethodApplicationsWIP.lean (ProbMethod.Core), 0 sorry / 0 axiom:\n- `exists_avoiding_all` (counting first moment)\n- `exists_good_of_card_bound` (uniform union bound)\n- `card_supersets_le` / `card_disjoint_le` / `card_mono_le`\n- `ramsey_avoidance` (honest Ramsey lower bound, avoidance form)\n\nVerified offline (LAKE_UNSAFE=1 lake env lean, EXIT 0) against Mathlib v4.26.0; PR #30657.\n\n## Dead Ends\n\n- Exact bijective counting of monochromatic colourings is avoidable: upper bounds via powerset injection suffice for a lower-bound existence result.\n"
+  },
+  "tags": [
+    "probabilistic-method",
+    "combinatorics",
+    "ramsey-theory",
+    "graph-theory",
+    "advanced",
+    "wip"
+  ],
+  "relatedProofs": [
+    "prob-method-applications",
+    "prob-method-applications-wip-01"
+  ],
+  "references": {
+    "papers": [
+      "Alon & Spencer, The Probabilistic Method (Wiley, 4th ed., 2016)",
+      "Erdős, Some remarks on the theory of graphs, Bull. AMS 53 (1947), 292-294"
+    ],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Probabilistic_method"
+    ],
+    "mathlib": [
+      "Finset.card_biUnion_le",
+      "Finset.card_powerset",
+      "Finset.card_le_card_of_injOn",
+      "Fintype.card_finset"
+    ]
+  },
+  "started": "2026-06-15T00:27:06.649Z",
+  "lastUpdate": "2026-06-27T00:00:00.000Z"
+}


### PR DESCRIPTION
## Summary

The work-in-progress problem `prob-method-applications-wip-01` asks to complete the probabilistic-method applications module. The existing `ProbMethodApplications.lean` states the headline consequences (Ramsey lower bounds, Property B, tournament domination, …) but the theorems are **vacuous placeholders**: e.g.

```lean
theorem ramsey_lower_bound (k : ℕ) (hk : 3 ≤ k) : ∃ n : ℕ, n ≥ 2 ^ ((k - 1) / 2) :=
  ⟨2 ^ ((k - 1) / 2), le_refl _⟩
```

— none of the stated hypotheses are used (the offline build confirms `hk`, `hn`, etc. are all unused).

This PR supplies the **genuine engine** those placeholders stood in for, in a new file `ProbMethodApplicationsWIP.lean` (namespace `ProbMethod.Core`), `0 sorry / 0 axiom`:

- **`exists_avoiding_all`** — first-moment / union-bound existence in exact counting form: if the bad sets `A i` sum to fewer than `|Ω|` points, some point avoids all of them (via `Finset.card_biUnion_le` + complement nonempty).
- **`exists_good_of_card_bound`** — the uniform union bound `|s|·B < |Ω|`, the form used directly in applications.
- **`card_supersets_le` / `card_disjoint_le` / `card_mono_le`** — tight `≤ 2^(|E|-|K|)` bounds on the colourings monochromatic on a block `K`, via the injection `S ↦ S \ K` into the powerset of `Kᶜ`.
- **`ramsey_avoidance`** — honest Ramsey lower bound (avoidance form): if `|cliques|·2^(|E|-m+1) < 2^|E|` then there is a 2-colouring of the edge set with **no** monochromatic block. Instantiating `E` to the edges of `K_n` recovers Erdős's `R(m,m) > n`. Every hypothesis (block size `m`, the counting inequality) is genuinely consumed.

## Verification

- Offline: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/ProbMethodApplicationsWIP.lean` → **EXIT 0**, no warnings (docker build infra remains containerd-corrupt on this host).
- `#print axioms ProbMethod.Core.ramsey_avoidance` → `[propext, Classical.choice, Quot.sound]` only → status **verified**, 0 axioms.
- Mathlib v4.26.0.

## Honesty note

This is the counting (finite-cardinality) form of the first-moment method, not a measure-theoretic one — appropriate and complete for these combinatorial existence statements. It does not by itself recompute the numeric `R(m,m)` bound; the `K_n` instantiation (substituting `C(n,2)`, `C(m,2)`) is left as a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)