### PR TITLE
research(bounded-prime-gaps-oq-02): exact level-increment decomposition + convex-cone closure of the EH-bound class

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02.lean
@@ -48,6 +48,14 @@ work documented in the sibling `BoundedPrimeGapsOQ04`.
       level-monotonicity *proved* (not assumed) — a generally nonzero model of the
       hierarchy, upgrading the `LevelMonotone` hypothesis to a theorem for the
       functional that actually arises in analytic number theory
+- [x] Exact additive decomposition across levels: `discrepancySum f θ₂ = discrepancySum f θ₁
+      + discrepancyBand f θ₁ θ₂`, sharpening monotonicity from inequality to identity and
+      localizing the inter-level growth to the band of new moduli `⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋`
+- [x] The EH-bound functional class at a fixed level is a **convex cone** (closed under
+      addition `EHAtLevel_add` and nonnegative scaling `EHAtLevel_smul`)
+- [x] Quantitative converse `EHAtLevel_discrepancySum_up`: EH at level `θ₁` plus an
+      EH-type bound on the new-moduli band ⟹ EH at the higher level `θ₂` — pinning the
+      band as exactly the extra analytic input needed to raise the level of distribution
 - [x] No `axiom`, no `sorry`, no `native_decide`
 -/
 
@@ -222,5 +230,120 @@ theorem EHAtLevel_of_le_discrepancySumClamped (f : ℕ → ℝ → ℝ) (hf : �
     {θ₁ θ₂ : ℝ} (h : θ₁ ≤ θ₂) (hEH : EHAtLevel (discrepancySumClamped f) θ₂) :
     EHAtLevel (discrepancySumClamped f) θ₁ :=
   EHAtLevel_of_le _ (levelMonotone_discrepancySumClamped f hf) h hEH
+
+/-! ## Sharpening the hierarchy: the exact level increment
+
+The monotonicity lemma `discrepancySum_mono_level` is an *inequality* — the sum can only
+grow with the level.  Here we make it an *equality with explicit defect*: the gain in
+passing from level `θ₁` to a higher level `θ₂` is exactly the discrepancy contributed by
+the **band of new moduli** `⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋` that the larger level admits.  This
+localizes precisely where the growth between levels comes from, and turns the qualitative
+hierarchy into a quantitative one. -/
+
+/-- The **level-increment band**: the discrepancy contributed by the moduli
+`⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋` — exactly the new moduli that level `θ₂` admits over level `θ₁`. -/
+noncomputable def discrepancyBand (f : ℕ → ℝ → ℝ) (θ₁ θ₂ x : ℝ) : ℝ :=
+  ∑ q ∈ Finset.Ioc ⌊x ^ θ₁⌋₊ ⌊x ^ θ₂⌋₊, f q x
+
+/-- **Exact additive decomposition of the discrepancy sum across levels.**  On the
+analytic regime `x ≥ 1`, for `θ₁ ≤ θ₂`,
+`discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x`.
+The level-`θ₂` sum is the level-`θ₁` sum plus exactly the contribution of the new moduli
+band — sharpening `discrepancySum_mono_level` from an inequality to an identity. -/
+theorem discrepancySum_eq_add_band (f : ℕ → ℝ → ℝ) {θ₁ θ₂ x : ℝ}
+    (hx : 1 ≤ x) (hθ : θ₁ ≤ θ₂) :
+    discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x := by
+  have hfloor : ⌊x ^ θ₁⌋₊ ≤ ⌊x ^ θ₂⌋₊ :=
+    Nat.floor_le_floor (Real.rpow_le_rpow_of_exponent_le hx hθ)
+  have hconv : ∀ m : ℕ, Finset.Icc 1 m = Finset.Ioc 0 m :=
+    fun m => Finset.ext fun k => by simp only [Finset.mem_Icc, Finset.mem_Ioc]; omega
+  unfold discrepancySum discrepancyBand
+  simp only [hconv]
+  exact (Finset.sum_Ioc_consecutive (fun q => f q x) (Nat.zero_le _) hfloor).symm
+
+/-- The level-increment band is nonnegative for a nonnegative weight `f`. -/
+theorem discrepancyBand_nonneg (f : ℕ → ℝ → ℝ) (hf : ∀ q x, 0 ≤ f q x) (θ₁ θ₂ x : ℝ) :
+    0 ≤ discrepancyBand f θ₁ θ₂ x :=
+  Finset.sum_nonneg fun q _ => hf q x
+
+/-- Monotonicity re-derived as a corollary of the exact decomposition: the level-`θ₂` sum
+exceeds the level-`θ₁` sum by the nonnegative band contribution. -/
+theorem discrepancySum_mono_level_of_band (f : ℕ → ℝ → ℝ) (hf : ∀ q x, 0 ≤ f q x)
+    {θ₁ θ₂ x : ℝ} (hx : 1 ≤ x) (hθ : θ₁ ≤ θ₂) :
+    discrepancySum f θ₁ x ≤ discrepancySum f θ₂ x := by
+  rw [discrepancySum_eq_add_band f hx hθ]
+  linarith [discrepancyBand_nonneg f hf θ₁ θ₂ x]
+
+/-! ## The EH-bound class is a convex cone
+
+For a fixed level `θ`, the functionals satisfying the Elliott–Halberstam bound are closed
+under addition and nonnegative scaling — they form a convex cone.  This matters for the
+analytic program: the genuine von-Mangoldt discrepancy is naturally decomposed into pieces
+(major/minor arcs, dyadic ranges of moduli), and these closure lemmas say that bounding
+each piece suffices to bound the whole. -/
+
+/-- **Closed under addition.**  If `D₁` and `D₂` each satisfy the EH bound at level `θ`,
+so does their sum, with constant `C₁ + C₂`. -/
+theorem EHAtLevel_add {D₁ D₂ : ℝ → ℝ → ℝ} {θ : ℝ}
+    (h₁ : EHAtLevel D₁ θ) (h₂ : EHAtLevel D₂ θ) :
+    EHAtLevel (fun θ' x => D₁ θ' x + D₂ θ' x) θ := by
+  intro A hA
+  obtain ⟨C₁, hC₁, hb₁⟩ := h₁ A hA
+  obtain ⟨C₂, hC₂, hb₂⟩ := h₂ A hA
+  refine ⟨C₁ + C₂, by linarith, fun x hx => ?_⟩
+  show D₁ θ x + D₂ θ x ≤ (C₁ + C₂) * x / (Real.log x) ^ A
+  calc D₁ θ x + D₂ θ x
+      ≤ C₁ * x / (Real.log x) ^ A + C₂ * x / (Real.log x) ^ A := by
+        linarith [hb₁ x hx, hb₂ x hx]
+    _ = (C₁ + C₂) * x / (Real.log x) ^ A := by ring
+
+/-- **Closed under nonnegative scaling.**  If `D` satisfies the EH bound at level `θ` and
+`0 ≤ c`, then `c · D` does too (the EH-bound class is a cone, not merely a subspace). -/
+theorem EHAtLevel_smul {D : ℝ → ℝ → ℝ} {θ c : ℝ} (hc : 0 ≤ c)
+    (hD : EHAtLevel D θ) : EHAtLevel (fun θ' x => c * D θ' x) θ := by
+  intro A hA
+  obtain ⟨C, hC, hb⟩ := hD A hA
+  refine ⟨c * C + 1, by have := mul_nonneg hc hC.le; linarith, fun x hx => ?_⟩
+  show c * D θ x ≤ (c * C + 1) * x / (Real.log x) ^ A
+  have hlog : 0 < Real.log x := Real.log_pos (by linarith)
+  have hpow : 0 < (Real.log x) ^ A := Real.rpow_pos_of_pos hlog A
+  have hquot : 0 ≤ x / (Real.log x) ^ A := div_nonneg (by linarith) hpow.le
+  have hsplit : (c * C + 1) * x / (Real.log x) ^ A
+      = c * C * x / (Real.log x) ^ A + x / (Real.log x) ^ A := by ring
+  calc c * D θ x
+      ≤ c * (C * x / (Real.log x) ^ A) := mul_le_mul_of_nonneg_left (hb x hx) hc
+    _ = c * C * x / (Real.log x) ^ A := by ring
+    _ ≤ (c * C + 1) * x / (Real.log x) ^ A := by rw [hsplit]; linarith
+
+/-- **Convex-cone closure.**  Any nonnegative linear combination of two functionals each
+satisfying the EH bound at level `θ` again satisfies it — the defining property of a
+convex cone.  Specializing `c₁ = c₂ = 1` recovers `EHAtLevel_add`; `c₂ = 0` recovers
+`EHAtLevel_smul`. -/
+theorem EHAtLevel_nonneg_linear {D₁ D₂ : ℝ → ℝ → ℝ} {θ c₁ c₂ : ℝ}
+    (hc₁ : 0 ≤ c₁) (hc₂ : 0 ≤ c₂) (h₁ : EHAtLevel D₁ θ) (h₂ : EHAtLevel D₂ θ) :
+    EHAtLevel (fun θ' x => c₁ * D₁ θ' x + c₂ * D₂ θ' x) θ :=
+  EHAtLevel_add (EHAtLevel_smul hc₁ h₁) (EHAtLevel_smul hc₂ h₂)
+
+/-- **Quantitative converse: raising the level.**  The hierarchy `EHAtLevel_of_le`
+*descends* a bound (level `θ₂` ⟹ level `θ₁ ≤ θ₂`).  Here is the *ascent*: if the
+discrepancy sum satisfies EH at level `θ₁` **and** the new-moduli band
+`⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋` independently satisfies an EH-type bound, then EH holds at the higher
+level `θ₂`.  Combined with descent this pins the band down as *exactly* the extra analytic
+input needed to raise the level — the structural reason EH beyond Bombieri–Vinogradov
+(`θ = 1/2`) is hard: one must control the discrepancy over ever-larger ranges of moduli. -/
+theorem EHAtLevel_discrepancySum_up (f : ℕ → ℝ → ℝ) {θ₁ θ₂ : ℝ} (hθ : θ₁ ≤ θ₂)
+    (hlow : EHAtLevel (discrepancySum f) θ₁)
+    (hband : ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand f θ₁ θ₂ x ≤ C * x / (Real.log x) ^ A) :
+    EHAtLevel (discrepancySum f) θ₂ := by
+  intro A hA
+  obtain ⟨C₁, hC₁, hb₁⟩ := hlow A hA
+  obtain ⟨C₂, hC₂, hb₂⟩ := hband A hA
+  refine ⟨C₁ + C₂, by linarith, fun x hx => ?_⟩
+  rw [discrepancySum_eq_add_band f (by linarith) hθ]
+  calc discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x
+      ≤ C₁ * x / (Real.log x) ^ A + C₂ * x / (Real.log x) ^ A := by
+        linarith [hb₁ x hx, hb₂ x hx]
+    _ = (C₁ + C₂) * x / (Real.log x) ^ A := by ring
 
 end BoundedPrimeGapsOQ02

--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "bounded-prime-gaps-oq-02",
   "title": "Elliott–Halberstam Conjecture: Axiom-Free Level-of-Distribution Hierarchy",
   "slug": "bounded-prime-gaps-oq-02",
-  "description": "Formalizes the logical skeleton of the Elliott–Halberstam (EH) conjecture as an axiom-free level-of-distribution hierarchy. For an abstract discrepancy functional D θ x (modelling the worst-case prime-counting discrepancy summed over moduli q ≤ x^θ), we define the level-θ EH bound EHAtLevel, prove the level hierarchy (a bound at a higher level implies the bound at every lower level for a level-monotone D), define Bombieri–Vinogradov as the θ = 1/2 case and Elliott–Halberstam as all levels θ < 1, and prove EH ⟹ BV. EH itself is NOT axiomatized; only D's structural properties enter as per-theorem hypotheses, so every result is a purely logical/analytic consequence with no axiom, sorry, or native_decide. The zero functional witnesses non-vacuity.",
+  "description": "Formalizes the logical skeleton of the Elliott–Halberstam (EH) conjecture as an axiom-free level-of-distribution hierarchy. For an abstract discrepancy functional D θ x (modelling the worst-case prime-counting discrepancy summed over moduli q ≤ x^θ), we define the level-θ EH bound EHAtLevel, prove the level hierarchy (a bound at a higher level implies the bound at every lower level for a level-monotone D), define Bombieri–Vinogradov as the θ = 1/2 case and Elliott–Halberstam as all levels θ < 1, and prove EH ⟹ BV. A canonical concrete functional ∑_{q≤x^θ} f(q,x) realizes the hierarchy with level-monotonicity proved (not assumed). This session sharpens the hierarchy: (i) an EXACT additive decomposition discrepancySum θ₂ = discrepancySum θ₁ + discrepancyBand θ₁ θ₂, where the band is the discrepancy of the new moduli ⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋ that the larger level admits — upgrading monotonicity from inequality to identity; (ii) the EH-bound functional class at a fixed level is a CONVEX CONE (closed under addition and nonnegative scaling); and (iii) a quantitative converse EHAtLevel_discrepancySum_up — EH at level θ₁ plus an EH-type bound on the new-moduli band implies EH at the higher level θ₂, pinning the band as exactly the extra analytic input needed to raise the level of distribution. EH itself is NOT axiomatized; only D's structural properties enter as per-theorem hypotheses, so every result is a purely logical/analytic consequence with no axiom, sorry, or native_decide.",
   "meta": {
     "author": "Elliott–Halberstam (1968); Bombieri (1965), A.I. Vinogradov (1965); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Elliott%E2%80%93Halberstam_conjecture",
@@ -186,12 +186,19 @@
       "Real"
     ],
     "namespace": "BoundedPrimeGapsOQ02",
-    "lineCount": 226,
+    "lineCount": 349,
     "axiomCount": 0,
-    "theoremCount": 13,
-    "definitionCount": 6,
+    "theoremCount": 20,
+    "definitionCount": 7,
     "path": "Proofs/BoundedPrimeGapsOQ02.lean",
     "sorries": 0
   },
-  "sorries": 0
+  "sorries": 0,
+  "highlights": [
+    "Exact additive decomposition across levels: discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x (band = new moduli ⌊x^θ₁⌋<q≤⌊x^θ₂⌋), sharpening monotonicity to an identity",
+    "The EH-bound functional class at a fixed level is a convex cone: closed under addition (EHAtLevel_add) and nonnegative scaling (EHAtLevel_smul)",
+    "Quantitative converse (EHAtLevel_discrepancySum_up): EH at level θ₁ + EH-type bound on the new-moduli band ⟹ EH at higher level θ₂",
+    "Level hierarchy EHAtLevel_of_le: higher level ⟹ lower level for a level-monotone functional; EH ⟹ Bombieri–Vinogradov",
+    "Zero axioms, zero sorries, zero native_decide — only propext/Classical.choice/Quot.sound; EH itself not axiomatized"
+  ]
 }

--- a/src/data/research/problems/bounded-prime-gaps-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: level-monotonicity upgraded from hypothesis to theorem for the canonical concrete discrepancy functional; generally-nonzero model of the full hierarchy added (0 sorry/0 axiom). VERIFIED offline via `lake env lean` (full kernel check vs Mathlib oleans, EXIT 0; axioms = propext/Classical.choice/Quot.sound only); docker-build still blocked by host containerd corruption. EH itself remains OPEN.",
+    "progressSummary": "PROGRESS: sharpened the EH level hierarchy. (1) EXACT additive decomposition discrepancySum_eq_add_band: discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x, localizing inter-level growth to the band of new moduli ⌊x^θ₁⌋<q≤⌊x^θ₂⌋ (monotonicity now a corollary). (2) EH-bound functional class is a CONVEX CONE: EHAtLevel_add, EHAtLevel_smul (0≤c), EHAtLevel_nonneg_linear. (3) Quantitative converse EHAtLevel_discrepancySum_up: EH at θ₁ + EH-type band bound ⟹ EH at θ₂ — the band is exactly the extra analytic input to raise the level. VERIFIED offline via lake env lean (full kernel check vs Mathlib oleans, EXIT 0; axioms = propext/Classical.choice/Quot.sound only); docker-build still host-blocked. 20 thm / 7 def, 0 axiom/0 sorry. EH itself remains OPEN.",
     "builtItems": [
       "EHAtLevel, LevelMonotone (defs) in BoundedPrimeGapsOQ02.lean:68,75",
       "EHAtLevel_of_le (level hierarchy) BoundedPrimeGapsOQ02.lean:81",
@@ -39,7 +39,11 @@
       "EHAtLevel_zero / levelMonotone_zero / elliottHalberstam_zero (non-vacuity) BoundedPrimeGapsOQ02.lean:138,148,153",
       "Gallery entry src/data/proofs/bounded-prime-gaps-oq-02/{meta,annotations}.json",
       "discrepancySum + discrepancySum_mono_level (x≥1) in BoundedPrimeGapsOQ02.lean",
-      "discrepancySumClamped + discrepancySumClamped_eq + levelMonotone_discrepancySumClamped + EHAtLevel_of_le_discrepancySumClamped (concrete nonzero model feeding the hierarchy)"
+      "discrepancySumClamped + discrepancySumClamped_eq + levelMonotone_discrepancySumClamped + EHAtLevel_of_le_discrepancySumClamped (concrete nonzero model feeding the hierarchy)",
+      "discrepancyBand f θ₁ θ₂ x := ∑ q ∈ Finset.Ioc ⌊x^θ₁⌋₊ ⌊x^θ₂⌋₊, f q x — the new-moduli band contribution",
+      "discrepancySum_eq_add_band (hx:1≤x)(hθ:θ₁≤θ₂): discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x — exact decomposition via Finset.sum_Ioc_consecutive after Icc 1 = Ioc 0 conversion",
+      "EHAtLevel_add / EHAtLevel_smul / EHAtLevel_nonneg_linear — EH-bound class is a convex cone (constants C₁+C₂ and c·C+1)",
+      "EHAtLevel_discrepancySum_up: EHAtLevel(discrepancySum f) θ₁ + band EH-bound ⟹ EHAtLevel(discrepancySum f) θ₂ — quantitative ascent converse to the descent hierarchy"
     ],
     "insights": [
       "EH is a conjecture, so formalize it as a logical skeleton over an abstract discrepancy functional D θ x — never axiomatize EH itself.",
@@ -47,7 +51,10 @@
       "EH ⟹ BV is the θ=1/2 instance; more strongly, any level ≥ 1/2 bound already gives BV, and EH is equivalent to its restriction to θ ∈ [1/2,1).",
       "The zero functional witnesses non-vacuity: it satisfies the full hierarchy with C=1, so the predicates are satisfiable, not vacuously empty.",
       "The LevelMonotone structural hypothesis is not an extra assumption: for the canonical discrepancy sum Σ_{q≤x^θ} f(q,x) with f≥0 it is a THEOREM, since x↦x^θ is monotone in θ for base x≥1, growing the modulus range Icc 1 ⌊x^θ⌋.",
-      "A base clamp (max 1 x) makes level-monotonicity hold for ALL real x, yielding a generally nonzero global model of LevelMonotone — strictly stronger non-vacuity than the zero functional."
+      "A base clamp (max 1 x) makes level-monotonicity hold for ALL real x, yielding a generally nonzero global model of LevelMonotone — strictly stronger non-vacuity than the zero functional.",
+      "The inter-level growth in the discrepancy sum is EXACTLY the discrepancy of the band of new moduli ⌊x^θ₁⌋<q≤⌊x^θ₂⌋ — proved by Finset.sum_Ioc_consecutive after rewriting Finset.Icc 1 m = Finset.Ioc 0 m (ext + omega). This turns the qualitative hierarchy into a quantitative one.",
+      "EHAtLevel at a fixed level is closed under +, nonneg scaling, hence a convex cone; the +1 in c·C+1 keeps the constant strictly positive when c=0, avoiding a case split.",
+      "Descent (higher⟹lower level) is free from monotonicity; ASCENT (raise the level) costs exactly an EH-type bound on the new-moduli band — formal statement of why EH beyond Bombieri–Vinogradov (θ=1/2) is hard."
     ],
     "mathlibGaps": [
       "No global Mathlib gap for the skeleton; instantiating D with the genuine von-Mangoldt discrepancy sum and proving its LevelMonotone is the analytic work (depends on Bombieri–Vinogradov, ~12000 lines, tracked in OQ-04)."


### PR DESCRIPTION
## Summary

Sharpens the axiom-free Elliott–Halberstam (EH) level-of-distribution hierarchy in `BoundedPrimeGapsOQ02.lean` (skeleton merged in #30641) with three theory-level additions. The abstract hierarchy answered "can EH's logical structure be formalized?"; this PR answers the natural follow-up — *quantitatively*, how do the levels relate, and what exactly does raising a level cost?

All results verified offline via `lake env lean` (full kernel check against the pinned Mathlib oleans, EXIT 0; `#print axioms` = `propext, Classical.choice, Quot.sound` only). `docker-build.sh` remains blocked by host containerd corruption.

## What's new

1. **Exact additive decomposition** `discrepancySum_eq_add_band`:
   `discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x`,
   where `discrepancyBand f θ₁ θ₂ x = ∑ q ∈ Ioc ⌊x^θ₁⌋ ⌊x^θ₂⌋, f q x` is the discrepancy of the **new moduli** `⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋` that the larger level admits. This upgrades the existing `discrepancySum_mono_level` from an inequality to an **identity** (monotonicity re-derived as the corollary `discrepancySum_mono_level_of_band`), localizing exactly where inter-level growth comes from.

2. **Convex-cone closure** of the EH-bound class at a fixed level:
   - `EHAtLevel_add` — closed under addition (constant `C₁ + C₂`)
   - `EHAtLevel_smul` — closed under nonnegative scaling (`0 ≤ c`, constant `c·C + 1`)
   - `EHAtLevel_nonneg_linear` — nonnegative linear combinations (the cone property)

   This matters for the analytic program: the genuine von-Mangoldt discrepancy is decomposed into pieces (dyadic modulus ranges, major/minor arcs), and these say bounding each piece suffices.

3. **Quantitative converse** `EHAtLevel_discrepancySum_up`: EH at level `θ₁` **plus** an EH-type bound on the new-moduli band ⟹ EH at the higher level `θ₂`. Combined with the existing descent `EHAtLevel_of_le`, this pins the band as *exactly* the extra analytic input needed to raise the level of distribution — the structural reason EH beyond Bombieri–Vinogradov (`θ = 1/2`) is hard.

## Counts

20 theorems / 7 definitions, **0 axioms, 0 sorries, 0 native_decide**. EH itself is **not** axiomatized and remains OPEN — every theorem is a purely logical/analytic consequence of `D`'s structural hypotheses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)