### PR TITLE
Research: godel-incompleteness-oq-03 — calculus of independence (3 new lemmas)

### DIFF
--- a/proofs/Proofs/GodelIncompletenessOQ03.lean
+++ b/proofs/Proofs/GodelIncompletenessOQ03.lean
@@ -142,4 +142,31 @@ theorem isComplete_iff_forall_not_independent (hsat : T.IsSatisfiable) :
     push_neg at hcon
     exact h φ ⟨hcon.1, hcon.2⟩
 
+/-! ## A calculus of independence
+
+Two structural lemmas that make `Independent` easy to manipulate: independence
+implies the underlying theory is satisfiable, and independence is symmetric in
+`φ` and `¬φ`. -/
+
+namespace Independent
+
+/-- **Independence implies consistency.**  If some sentence is independent of `T`
+    then `T` has a model.  An *inconsistent* theory entails every sentence
+    vacuously (`T ⊨ᵇ φ` for all `φ`), so it cannot leave anything undecided;
+    contrapositively, leaving `φ` undecided forces `T` to be satisfiable. -/
+theorem isSatisfiable (h : Independent T φ) : T.IsSatisfiable :=
+  h.satisfiable_insert.mono Set.subset_union_left
+
+/-- **A sentence is independent iff its negation is.**  Independence is symmetric
+    in `φ` and `¬φ`: neither is decided exactly when the other is not. -/
+theorem neg_iff : Independent T φ.not ↔ Independent T φ := by
+  rw [independent_iff_satisfiable_both, independent_iff_satisfiable_both,
+      isSatisfiable_insert_not_not_iff]
+  exact and_comm
+
+/-- The negation of an independent sentence is independent. -/
+theorem neg (h : Independent T φ) : Independent T φ.not := neg_iff.mpr h
+
+end Independent
+
 end GodelIncompletenessOQ03

--- a/src/data/proofs/godel-incompleteness-oq-03/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-03/meta.json
@@ -24,7 +24,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 145,
-    "theoremCount": 8,
+    "theoremCount": 11,
     "definitionCount": 1,
     "assumptions": "None beyond Mathlib's first-order model theory. All results are universally quantified over an arbitrary Language L, theory T : L.Theory and sentence φ : L.Sentence; semantic consequence T ⊨ᵇ φ (ModelsBoundedFormula), satisfiability (Theory.IsSatisfiable) and completeness (Theory.IsComplete) are Mathlib's own definitions. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
     "mathlibDependencies": [
@@ -78,8 +78,8 @@
       "Mathlib"
     ],
     "namespace": "GodelIncompletenessOQ03",
-    "lineCount": 145,
-    "theoremCount": 8,
+    "lineCount": 172,
+    "theoremCount": 11,
     "axiomCount": 0,
     "definitionCount": 1,
     "sorries": 0,


### PR DESCRIPTION
## Summary

Extends the merged abstract independence framework (PR #30648, `GodelIncompletenessOQ03.lean`) with three structural "calculus of independence" lemmas — all `0 sorry / 0 axiom`, verified against Mathlib v4.26.0:

- **`Independent.isSatisfiable`** — *independence implies consistency*. An inconsistent theory entails every sentence vacuously (`T ⊨ᵇ φ` for all `φ`), so it cannot leave anything undecided; contrapositively, leaving any `φ` undecided forces `T` to be satisfiable. Proof: `satisfiable_insert` + `IsSatisfiable.mono`.
- **`Independent.neg_iff`** — *a sentence is independent iff its negation is*. Independence is symmetric in `φ` and `¬φ`. Proof: `independent_iff_satisfiable_both` + the existing `¬¬φ`/`φ` satisfiability bridge + `and_comm`.
- **`Independent.neg`** — the negation of an independent sentence is independent.

These make `Independent` easier to manipulate (e.g. `isSatisfiable` lets later results assume a model exists without a separate consistency hypothesis).

`theoremCount` 8 → 11; gallery `meta.json` updated.

## Verification

- `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/GodelIncompletenessOQ03.lean` → **EXIT 0** (docker build infra remains containerd-corrupt on this host).
- `#print axioms` for the new lemmas → `[propext, Classical.choice, Quot.sound]` only.

## Scope note

A general "independence is invariant under semantic equivalence" lemma was attempted but dropped: stating the hypothesis `∀ N [Structure N], (N ⊨ φ) ↔ (N ⊨ ψ)` introduces a universe parameter distinct from the model's, causing a universe mismatch when applied to `IsSatisfiable`'s model type. The three lemmas here avoid that and are the genuinely clean additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)