### PR TITLE
Enrich Linnik Critical Exponent (dirichlets-theorem-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,183 @@
+[
+  {
+    "id": "ann-structural-vs-analytic",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "concept",
+    "title": "Separating Structure from Analysis",
+    "content": "The header states the file's organizing idea: the deep, unproved analytic content of Linnik's theorem (existence of a small prime in every reduced residue class) can be cleanly separated from the elementary order-theoretic content that makes 'the Linnik constant' a meaningful object at all. The parent entry carries that analytic input as 2 axioms and 3 sorries; this file proves the entire surrounding skeleton — ray, lower bound, sandwich, monotonicity — axiom-free, for an abstract growth function over an arbitrary base ≥ 1. The number theory survives only as a nonemptiness hypothesis on the admissible set.",
+    "mathContext": "Linnik's constant is $L^* = \\inf\\{L>0 : \\exists c>0,\\ \\forall (a,q),\\ p(a,q) \\le c\\,q^{L}\\}$, where $p(a,q)$ is the least prime $\\equiv a \\pmod q$. The claim 'this inf is a well-defined critical exponent' is logically independent of the value of $L^*$: it only needs (i) the set is bounded below and (ii) it is upward closed. Both follow from $L \\mapsto q^{L}$ being monotone for $q \\ge 1$, not from any property of primes.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Linnik's theorem",
+      "critical exponent",
+      "abstraction over hypotheses",
+      "axiom-free formalization"
+    ],
+    "prerequisites": [
+      "primes in arithmetic progressions",
+      "infimum of a set of reals"
+    ]
+  },
+  {
+    "id": "ann-admissible-def",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 38, "endLine": 42 },
+    "type": "definition",
+    "title": "The Admissible-Exponent Set",
+    "content": "`admissible f b` collects every positive exponent `L` for which the growth bound `f i ≤ c · (b i)^L` holds uniformly in `i` for some single positive constant `c`. The uniform constant `c` is existentially quantified inside the set, so admissibility is a property of `L` alone. Specializing to `f = leastPrimeInAP`, `b = q` recovers exactly the parent file's set of Linnik exponents, but the definition commits to nothing about primes — `f` and `b` are arbitrary real-valued functions on an arbitrary index type `I`.",
+    "mathContext": "$\\mathrm{admissible}(f,b) = \\{\\,L \\in \\mathbb{R} : 0 < L \\ \\wedge\\ \\exists c>0,\\ \\forall i,\\ f(i) \\le c\\,(b(i))^{L}\\,\\}.$ The power $b(i)^{L}$ is `Real.rpow`, defined for real exponents, which is what lets `L` range over all of $\\mathbb{R}_{>0}$ rather than just integers.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow",
+      "uniform bound",
+      "growth function",
+      "order of magnitude"
+    ],
+    "prerequisites": [
+      "real exponentiation rpow",
+      "set-builder notation in Lean",
+      "existential quantifiers"
+    ]
+  },
+  {
+    "id": "ann-bddBelow",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 44, "endLine": 46 },
+    "type": "technique",
+    "title": "Bounded Below by Zero",
+    "content": "Because every admissible exponent is positive by definition, `0` is a lower bound, so the set is `BddBelow` and its infimum exists as a real number. This is the minimal hypothesis required before `sInf` is meaningful in a conditionally complete lattice like ℝ: without boundedness, `sInf` of an unbounded-below set would default to a junk value. The one-line proof `⟨0, fun _ hL => le_of_lt hL.1⟩` supplies the witness `0` together with the proof that it bounds the set.",
+    "mathContext": "$L \\in \\mathrm{admissible}(f,b) \\Rightarrow 0 < L \\Rightarrow 0 \\le L$, so $0 \\in \\mathrm{lowerBounds}(\\mathrm{admissible}(f,b))$, giving $\\mathrm{BddBelow}$. In a conditionally complete lattice, $\\inf S$ is well-behaved exactly when $S$ is nonempty and bounded below.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "BddBelow",
+      "conditionally complete lattice",
+      "infimum existence"
+    ],
+    "prerequisites": [
+      "lower bounds",
+      "order completeness of ℝ"
+    ]
+  },
+  {
+    "id": "ann-upward-closed",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 48, "endLine": 56 },
+    "type": "insight",
+    "title": "Upward Closure: the Admissible Set is a Ray",
+    "content": "The crux of the whole development. If `L` is admissible with constant `c` and `L ≤ L'`, then the same `c` witnesses admissibility of `L'`, because the base satisfies `b i ≥ 1` and so `b i ^ L ≤ b i ^ L'`. This is the only place the hypothesis `1 ≤ b i` is essential: for a base below 1 the power would be decreasing in the exponent and the set would not be a ray. The `calc` block chains the original bound `f i ≤ c · b i ^ L` with `Real.rpow_le_rpow_of_exponent_le`, which is monotonicity of `x ↦ x^t` in the exponent `t` for `x ≥ 1`.",
+    "mathContext": "For $x \\ge 1$ and $L \\le L'$, $x^{L} \\le x^{L'}$ (`Real.rpow_le_rpow_of_exponent_le`). Hence $f(i) \\le c\\,(b(i))^{L} \\le c\\,(b(i))^{L'}$, so the larger exponent is admissible with the same $c$. Upward closure plus boundedness below is precisely the statement 'admissible is an interval unbounded above', i.e. a ray.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.rpow_le_rpow_of_exponent_le",
+      "monotonicity of exponentiation",
+      "upward-closed set",
+      "ray"
+    ],
+    "prerequisites": [
+      "monotonicity of rpow in the exponent",
+      "calc proofs in Lean",
+      "mul_le_mul_of_nonneg_left"
+    ]
+  },
+  {
+    "id": "ann-criticalExponent-def",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 58, "endLine": 70 },
+    "type": "definition",
+    "title": "The Critical Exponent as an Infimum",
+    "content": "`criticalExponent f b := sInf (admissible f b)` is the infimum of the admissible ray — the Linnik constant in the arithmetic-progression instance. Two immediate consequences follow from the conditional-infimum API: `criticalExponent_le` (the infimum is below every admissible exponent, via `csInf_le` using boundedness) and `criticalExponent_nonneg` (the infimum is ≥ 0 when the set is nonempty, via `le_csInf` since 0 bounds the set below). The function is marked `noncomputable` because `sInf` over ℝ is not algorithmic.",
+    "mathContext": "$\\mathrm{criticalExponent}(f,b) = \\inf\\,\\mathrm{admissible}(f,b)$. From `csInf_le`: $L \\in S \\Rightarrow \\inf S \\le L$. From `le_csInf`: if $S \\ne \\varnothing$ and $\\forall x\\in S,\\ 0\\le x$, then $0 \\le \\inf S$. Together these place the critical exponent in $[0,\\infty)$ and below the whole admissible set.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sInf",
+      "csInf_le",
+      "le_csInf",
+      "greatest lower bound"
+    ],
+    "prerequisites": [
+      "conditional infimum API",
+      "noncomputable definitions"
+    ]
+  },
+  {
+    "id": "ann-ray-property",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 72, "endLine": 90 },
+    "type": "insight",
+    "title": "Ray Property: Everything Above the Infimum is Admissible",
+    "content": "`mem_admissible_of_gt` is the converse direction that turns 'lower bound' into 'the answer'. If `L` lies strictly above the critical exponent, then `exists_lt_of_csInf_lt` produces an actual admissible witness `L₀` with `criticalExponent < L₀ < L`; upward closure then promotes `L₀` to `L`. This needs nonemptiness (otherwise the infimum is junk and the witness need not exist). Packaged as `Ioi_subset_admissible`, while `admissible_subset_Ici` is just `criticalExponent_le` restated, setting up the sandwich.",
+    "mathContext": "`exists_lt_of_csInf_lt`: if $S \\ne \\varnothing$ and $\\inf S < L$, then $\\exists L_0 \\in S,\\ L_0 < L$. Combined with upward closure: $\\inf S < L \\Rightarrow L \\in S$, i.e. $\\mathrm{Ioi}(\\inf S) \\subseteq S$. The strictness matters: at $L = \\inf S$ itself, membership is undetermined by these lemmas alone.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exists_lt_of_csInf_lt",
+      "Ioi",
+      "Ici",
+      "infimum approximation"
+    ],
+    "prerequisites": [
+      "characterization of infimum by approximating elements",
+      "set rays Ioi / Ici"
+    ]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 92, "endLine": 99 },
+    "type": "insight",
+    "title": "The Sandwich Theorem",
+    "content": "`admissible_sandwich` bundles the two inclusions into `Ioi c ⊆ admissible ⊆ Ici c` for `c = criticalExponent`. This is the precise statement that the critical exponent answers the parent question: the admissible set is completely determined by the single real number `c`, up to the one boundary point `c` itself, which may or may not be admissible. Every Linnik-type bound `p(a,q) ≤ c·q^L` with `L > L*` is therefore valid, and none with `L < L*` is.",
+    "mathContext": "$\\mathrm{Ioi}(c) \\subseteq \\mathrm{admissible}(f,b) \\subseteq \\mathrm{Ici}(c)$ with $c = \\mathrm{criticalExponent}(f,b)$. So $\\mathrm{admissible}(f,b)$ equals either $(c,\\infty)$ or $[c,\\infty)$; the entire structural ambiguity collapses to the question 'is $c$ attained?'.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squeeze characterization",
+      "Dedekind cut",
+      "critical exponent",
+      "attainment of infimum"
+    ],
+    "prerequisites": [
+      "set inclusions",
+      "open vs closed rays"
+    ]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 101, "endLine": 114 },
+    "type": "technique",
+    "title": "Monotonicity under Domination",
+    "content": "`admissible_mono` shows that pointwise shrinking the growth function enlarges (or preserves) the admissible set: if `f i ≤ g i` everywhere, any bound `g i ≤ c · b i^L` transitively bounds `f i` with the same constant, so `admissible g b ⊆ admissible f b`. Taking infima with `csInf_le_csInf` then gives `criticalExponent f b ≤ criticalExponent g b`. The number-theoretic reading: every sharpened upper bound on the least prime `p(a,q)` can only lower the Linnik constant, never raise it — monotonicity that the historical sequence of bounds (Pan → … → Xylouris) relies on implicitly.",
+    "mathContext": "$f \\le g$ pointwise $\\Rightarrow \\mathrm{admissible}(g,b) \\subseteq \\mathrm{admissible}(f,b)$ $\\Rightarrow \\inf\\,\\mathrm{admissible}(f,b) \\le \\inf\\,\\mathrm{admissible}(g,b)$. The infimum step is `csInf_le_csInf` (antitone of $\\inf$ under $\\subseteq$, given boundedness below of the smaller set and nonemptiness of the larger).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "csInf_le_csInf",
+      "monotonicity of infimum",
+      "pointwise domination",
+      "transitivity of inequalities"
+    ],
+    "prerequisites": [
+      "antitone behavior of inf under set inclusion",
+      "transitivity le_trans"
+    ]
+  },
+  {
+    "id": "ann-linnik-specialization",
+    "proofId": "dirichlets-theorem-oq-03-oq-01",
+    "range": { "startLine": 116, "endLine": 138 },
+    "type": "concept",
+    "title": "Specializing to the Linnik Constant",
+    "content": "The final block instantiates the abstract theory at the arithmetic-progression data without re-introducing axioms. `linnikConstantOf p` is `criticalExponent p (fun i => i.2)` — the base is the modulus `q = i.2`. `linnik_threshold` then states the sharp-threshold property directly for the Linnik constant: given Linnik's theorem as the single hypothesis that one admissible exponent exists (`hne`), and `q ≥ 1`, every exponent above the Linnik constant is admissible. The least-prime function `p` is kept abstract so the file remains fully machine-checked; supplying the genuine `leastPrimeInAP` and a concrete witness (e.g. Xylouris's `L = 5`) would discharge `hne` from the parent's analytic input.",
+    "mathContext": "$\\mathrm{linnikConstantOf}(p) = \\mathrm{criticalExponent}(p, q)$ with $q(a,q)=q$. `linnik_threshold`: $\\mathrm{linnikConstantOf}(p) < L \\Rightarrow L \\in \\mathrm{admissible}(p,q)$, i.e. $p(a,q) \\le c\\,q^{L}$ holds for some $c$. Feeding the unconditional witness $L = 5$ (Xylouris 2011) into `hne` yields the full ray of valid exponents $> L^*$ with $L^* \\le 5$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Linnik's theorem",
+      "Xylouris bound",
+      "instantiation",
+      "leastPrimeInAP"
+    ],
+    "prerequisites": [
+      "arithmetic-progression instance I = (a,q)",
+      "the parent Linnik-constant framework"
+    ]
+  }
+]

--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01/meta.json
@@ -160,6 +160,36 @@
       "description": "Another open-question branch of Dirichlet's theorem in the gallery."
     }
   ],
+  "references": [
+    {
+      "title": "On the least prime in an arithmetic progression",
+      "authors": "Yu. V. Linnik",
+      "year": 1944,
+      "venue": "Rec. Math. (Mat. Sbornik) N.S. 15(57)",
+      "note": "Original existence theorem: there is an absolute constant L with p(a,q) ≤ c·q^L. This is the analytic input the present file isolates as a nonemptiness hypothesis."
+    },
+    {
+      "title": "On Linnik's constant",
+      "authors": "T. Xylouris",
+      "year": 2011,
+      "venue": "Acta Arithmetica 150",
+      "note": "Best known unconditional bound L ≤ 5, via improved zero-free regions for Dirichlet L-functions. Supplies a concrete admissible exponent to discharge the nonemptiness hypothesis."
+    },
+    {
+      "title": "Zero-free regions for Dirichlet L-functions, and the least prime in an arithmetic progression",
+      "authors": "D. R. Heath-Brown",
+      "year": 1992,
+      "venue": "Proc. London Math. Soc. (3) 64",
+      "note": "Earlier landmark bound L ≤ 5.5 and the modern zero-free-region framework underlying subsequent improvements."
+    },
+    {
+      "title": "Conditionally complete lattices and the conditional infimum API",
+      "authors": "Mathlib contributors",
+      "year": 2026,
+      "venue": "Mathlib4 (Order.ConditionallyCompleteLattice)",
+      "note": "Source of csInf_le, le_csInf, exists_lt_of_csInf_lt, csInf_le_csInf — the order-theoretic backbone of every theorem in this file."
+    }
+  ],
   "conclusion": {
     "summary": "Eleven axiom-free, sorry-free theorems establishing that the Linnik constant is a well-defined critical exponent: the admissible-exponent set is an upward-closed, below-bounded ray, its infimum is non-negative and sandwiched between the open and closed rays at that value, and it decreases monotonically under domination of the growth function.",
     "implications": "The development is a reusable blueprint for any infimum-defined exponent in analytic number theory (abscissa of convergence, Landau–Siegel exponent, growth exponents of arithmetic functions): the ray/sandwich/monotonicity package is fully generic and machine-checked. It also cleanly delineates which parts of the parent's Linnik formalization are elementary scaffolding (everything here) and which require genuine analytic input (only nonemptiness, i.e. Linnik's theorem).",


### PR DESCRIPTION
Enrichment pass for `dirichlets-theorem-oq-03-oq-01` (0 prior passes, quality 40).

## Gaps addressed
- **annotations.json was missing entirely** — created with 9 substantive annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. They cover the whole Lean file:
  1. Structural-vs-analytic framing (header)
  2. `admissible` set definition
  3. `admissible_bddBelow` (bounded below by 0)
  4. `admissible_upward_closed` (rpow monotonicity → ray)
  5. `criticalExponent` + lower-bound / non-negativity lemmas
  6. Ray property (`mem_admissible_of_gt`, Ioi/Ici inclusions)
  7. Sandwich theorem
  8. Monotonicity under domination
  9. Linnik specialization (`linnikConstantOf`, `linnik_threshold`)
- **Added `references[]` to meta.json** — Linnik (1944), Xylouris (2011), Heath-Brown (1992), and the Mathlib conditional-infimum API.

## Notes
- meta.json was already rich and stays well under the size cap (13.7 KB ≤ 60 KB; `check-meta-size` passes).
- `index.ts` intentionally not added: proof data now loads at runtime via fetch from build-generated `public/data/proofs/` (issue #20992/#20993), so per-proof shim modules are legacy.
- Build's data-generation stages (`gallery:check-size`, `annotations:build`, `research:build`, `research:enrich`) all pass and regenerate the entry's public assets; only `tsc`/`vite` were skipped because `node_modules` is absent in the isolated worktree.
- Axiom integrity verified: entry is genuinely axiom-free/sorry-free (0 axiom decls, no assumption-carrying structures); `status: verified` / `badge: original` accurate.