### PR TITLE
Auditor: record 4 clean audits (bisection, godel-independence, wilsons-converse, prob-method)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25027,6 +25027,12 @@
       "lastAudited": "2026-06-27T09:27:10Z",
       "result": "clean",
       "issues": []
+    },
+    "prob-method-applications-wip-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T09:29:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25009,6 +25009,24 @@
       "lastAudited": "2026-06-27T09:12:28Z",
       "result": "clean",
       "issues": []
+    },
+    "descartes-rule-of-signs-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T09:27:10Z",
+      "result": "clean",
+      "issues": []
+    },
+    "godel-incompleteness-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T09:27:10Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T09:27:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 4 clean

Audited four never-audited gallery entries. All confirmed CLEAN and offline-verified (`lake env lean`, RC=0; `#print axioms` shows only `[propext, Classical.choice, Quot.sound]`).

| Entry | Badge | Checks |
|-------|-------|--------|
| `descartes-rule-of-signs-oq-02-oq-01-oq-03` | verified/original | 8 thm + 1 def; Vincent bisection termination core; `assumptions` honestly defers the Descartes sign-variation step |
| `godel-incompleteness-oq-03` | verified/original | 8 thm + 1 def abstract independence framework; Mathlib Completeness Theorem used as a **disclosed** supporting lemma (no hidden imports); `original` consistent with gallery convention (886 verified/original entries carry ≥2 mathlibDependencies) |
| `wilsons-theorem-oq-03-oq-02` | verified/original | composite converse n∣(n−1)! for composite n≠4; n=4 base case via kernel `decide` (no `Lean.ofReduceBool`) |
| `prob-method-applications-wip-01` | verified/verified | probabilistic-method first-moment existence engine; 6 thm (union bound + `ramsey_avoidance`); `wip` is only a slug artifact, title accurately scoped as infrastructure |

### Notes
- `godel-incompleteness-oq-03`: reviewed the `original` vs `mathlib` badge question carefully. Core characterizations rely on Mathlib's completeness theorem, but the entry proves 8 genuinely new theorems + a new `Independent` definition (none in Mathlib) and discloses the Mathlib reliance thoroughly in title/description/conclusion/originalContributions/assumptions. None of the five narrative failure modes triggered → `original` retained, consistent with gallery convention.
- The separately-tracked `pascals-hexagon-oq-03` sorry-count fix merged this cycle (#30654); audit queue now shows 0 issues.

Records audits in `audit-tracker.json` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)