### PR TITLE
research(cassini-identity-oq-01-oq-01): Catalan's identity — r-step generalization of Cassini [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/CassiniIdentityOQ01OQ01.lean
+++ b/proofs/Proofs/CassiniIdentityOQ01OQ01.lean
@@ -1,0 +1,114 @@
+/-
+# Catalan's Identity (the `r`-step generalization of Cassini)
+
+Catalan's identity states that for the Fibonacci numbers `F` and `r ≤ n`,
+
+  `Fₙ² − F_{n−r}·F_{n+r} = (−1)^{n−r} · Fᵣ²`.
+
+It is the genuine generalization of the parent file's **Cassini identity**
+(`CassiniIdentityOQ01.cassini`), which is exactly the step `r = 1`:
+`F_{n+1}² − Fₙ·F_{n+2} = (−1)ⁿ`. Where Cassini compares two *consecutive*
+Fibonacci numbers, Catalan compares the three numbers `F_{n−r}, Fₙ, F_{n+r}`
+that sit in arithmetic progression of step `r`, and measures the failure of the
+"middle square equals the product of the outer terms" by the square `Fᵣ²`.
+
+Mathlib records neither Catalan's identity nor the general Vajda/d'Ocagne
+bilinear identities for `Nat.fib`; it has only the integer-indexed Cassini
+specialization. We give a short, fully elementary proof:
+
+* `cassini_sub` — the Cassini identity in the normalized algebraic form
+  `F_{m+1}² − Fₘ·F_{m+1} − Fₘ² = (−1)ᵐ`, proved by a one-line induction off the
+  defining recurrence `Nat.fib_add_two`.
+
+* `catalan_aux` — the subtraction-free reindexing
+  `F_{m+r}² − Fₘ·F_{m+2r} = (−1)ᵐ · Fᵣ²` (set `m = n − r`). Its proof is pure
+  algebra: expand `F_{m+r}` and `F_{m+2r}` with Mathlib's **addition formula**
+  `Nat.fib_add`, then collapse the result with Cassini. No second induction.
+
+* `catalan` — the classical signed form `Fₙ² − F_{n−r}F_{n+r} = (−1)^{n−r}Fᵣ²`
+  for `r ≤ n`, obtained from `catalan_aux` by `m := n − r`.
+
+No axioms, no `native_decide`, no sorries.
+-/
+import Mathlib
+
+namespace CassiniIdentityOQ01OQ01
+
+/-- **Cassini's identity, normalized algebraic form.**
+`F_{m+1}² − Fₘ·F_{m+1} − Fₘ² = (−1)ᵐ`. This is the `r = 1` core that drives the
+general Catalan identity. Proved by induction off `Nat.fib_add_two`. -/
+theorem cassini_sub (m : ℕ) :
+    (Nat.fib (m + 1) : ℤ) ^ 2 - Nat.fib m * Nat.fib (m + 1) - (Nat.fib m : ℤ) ^ 2
+      = (-1) ^ m := by
+  induction m with
+  | zero => norm_num [Nat.fib_one, Nat.fib_zero]
+  | succ k ih =>
+    have hrec : (Nat.fib (k + 1 + 1) : ℤ) = Nat.fib k + Nat.fib (k + 1) := by
+      exact_mod_cast (Nat.fib_add_two (n := k))
+    rw [hrec]
+    have hsign : (-1 : ℤ) ^ (k + 1) = -((-1) ^ k) := by ring
+    rw [hsign]
+    linear_combination -ih
+
+/-- **Catalan's identity (subtraction-free form).**
+`F_{m+r}² − Fₘ·F_{m+2r} = (−1)ᵐ · Fᵣ²`. The classical statement is recovered by
+`m = n − r` (see `catalan`). The proof expands `F_{m+r}` and `F_{m+2r}` by the
+Fibonacci addition formula `Nat.fib_add` and finishes with Cassini. -/
+theorem catalan_aux (m r : ℕ) :
+    (Nat.fib (m + r) : ℤ) ^ 2 - Nat.fib m * Nat.fib (m + 2 * r)
+      = (-1) ^ m * (Nat.fib r : ℤ) ^ 2 := by
+  cases r with
+  | zero => simp only [Nat.mul_zero, Nat.add_zero, Nat.fib_zero]; ring
+  | succ s =>
+    have e1 : m + (s + 1) = m + s + 1 := by ring
+    have e2 : m + 2 * (s + 1) = m + s + 1 + s + 1 := by ring
+    rw [e1, e2]
+    -- Addition-formula expansions (all indices in the normal form `· + 1`).
+    have hA : (Nat.fib (m + s + 1) : ℤ)
+        = Nat.fib m * Nat.fib s + Nat.fib (m + 1) * Nat.fib (s + 1) := by
+      exact_mod_cast Nat.fib_add m s
+    have hB : (Nat.fib (m + s + 1 + 1) : ℤ)
+        = Nat.fib m * Nat.fib (s + 1) + Nat.fib (m + 1) * Nat.fib (s + 2) := by
+      exact_mod_cast Nat.fib_add m (s + 1)
+    have hC : (Nat.fib (m + s + 1 + s + 1) : ℤ)
+        = Nat.fib (m + s + 1) * Nat.fib s + Nat.fib (m + s + 1 + 1) * Nat.fib (s + 1) := by
+      exact_mod_cast Nat.fib_add (m + s + 1) s
+    have hb2 : (Nat.fib (s + 2) : ℤ) = Nat.fib s + Nat.fib (s + 1) := by
+      exact_mod_cast (Nat.fib_add_two (n := s))
+    have hcas := cassini_sub m
+    rw [hC, hA, hB, hb2]
+    linear_combination (Nat.fib (s + 1) : ℤ) ^ 2 * hcas
+
+/-- **Catalan's identity** (classical signed form).
+For `r ≤ n`, `Fₙ² − F_{n−r}·F_{n+r} = (−1)^{n−r} · Fᵣ²`. The `r = 1` case is
+Cassini's identity. -/
+theorem catalan (n r : ℕ) (h : r ≤ n) :
+    (Nat.fib n : ℤ) ^ 2 - Nat.fib (n - r) * Nat.fib (n + r)
+      = (-1) ^ (n - r) * (Nat.fib r : ℤ) ^ 2 := by
+  have key := catalan_aux (n - r) r
+  rw [Nat.sub_add_cancel h] at key
+  have e : n - r + 2 * r = n + r := by omega
+  rw [e] at key
+  exact key
+
+/-! ### Sanity checks against the classical statement -/
+
+/-- `r = 1` recovers Cassini: `Fₙ² − F_{n−1}F_{n+1} = (−1)^{n−1}`. -/
+theorem catalan_one (n : ℕ) (h : 1 ≤ n) :
+    (Nat.fib n : ℤ) ^ 2 - Nat.fib (n - 1) * Nat.fib (n + 1) = (-1) ^ (n - 1) := by
+  have := catalan n 1 h
+  simpa using this
+
+/-- `n = 5, r = 2`: `F₅² − F₃·F₇ = 25 − 2·13 = −1 = (−1)³·F₂² = (−1)³·1`. -/
+theorem catalan_5_2 :
+    (Nat.fib 5 : ℤ) ^ 2 - Nat.fib 3 * Nat.fib 7 = (-1) ^ 3 * (Nat.fib 2 : ℤ) ^ 2 := by
+  have := catalan 5 2 (by norm_num)
+  norm_num at this ⊢
+
+/-- `n = 6, r = 2`: `F₆² − F₄·F₈ = 64 − 3·21 = 1 = (−1)⁴·F₂²`. -/
+theorem catalan_6_2 :
+    (Nat.fib 6 : ℤ) ^ 2 - Nat.fib 4 * Nat.fib 8 = (-1) ^ 4 * (Nat.fib 2 : ℤ) ^ 2 := by
+  have := catalan 6 2 (by norm_num)
+  norm_num at this ⊢
+
+end CassiniIdentityOQ01OQ01

--- a/src/data/proofs/cassini-identity-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01/annotations.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "ann-cassini-core",
+    "proofId": "cassini-identity-oq-01-oq-01",
+    "range": {
+      "startLine": 40,
+      "endLine": 54
+    },
+    "type": "theorem",
+    "title": "The Cassini core, normalized algebraic form",
+    "content": "`cassini_sub` proves $F_{m+1}^2 - F_m F_{m+1} - F_m^2 = (-1)^m$. This is Cassini's identity rearranged into the exact shape that will appear after the addition-formula expansion of Catalan. The induction is three lines: the base case is $1 - 0 - 0 = 1$, and the step substitutes $F_{k+2} = F_k + F_{k+1}$ and closes with `linear_combination -ih` once the sign is rewritten as $(-1)^{k+1} = -(-1)^k$.",
+    "mathContext": "$F_{m+1}^2 - F_m F_{m+1} - F_m^2 = (-1)^m$, equivalently $F_{m+1}^2 - F_m F_{m+2} = (-1)^m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "Fibonacci recurrence",
+      "Induction"
+    ]
+  },
+  {
+    "id": "ann-addition-formula",
+    "proofId": "cassini-identity-oq-01-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 83
+    },
+    "type": "theorem",
+    "title": "Subtraction-free Catalan via the addition formula",
+    "content": "`catalan_aux` proves $F_{m+r}^2 - F_m F_{m+2r} = (-1)^m F_r^2$. After splitting off $r = s+1$, three applications of Mathlib's addition formula `Nat.fib_add` ($F_{a+b+1} = F_a F_b + F_{a+1}F_{b+1}$) rewrite $F_{m+r}$, $F_{m+r+1}$ and $F_{m+2r}$ in terms of the four basis values $F_m, F_{m+1}, F_s, F_{s+1}$. The expanded left-hand side factors exactly as $F_{s+1}^2 (F_{m+1}^2 - F_m F_{m+1} - F_m^2)$, so a single `linear_combination (F_{s+1})^2 * hcas` against the Cassini core finishes it — there is no induction on the identity itself.",
+    "mathContext": "$F_{m+r}^2 - F_m F_{m+2r} = (-1)^m F_r^2$; the entire $m$-dependence collapses into the Cassini scalar $(-1)^m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fibonacci addition formula",
+      "linear_combination",
+      "Bilinear Fibonacci identities"
+    ]
+  },
+  {
+    "id": "ann-classical-form",
+    "proofId": "cassini-identity-oq-01-oq-01",
+    "range": {
+      "startLine": 85,
+      "endLine": 92
+    },
+    "type": "theorem",
+    "title": "Reindexing to the classical signed statement",
+    "content": "`catalan` recovers the textbook form $F_n^2 - F_{n-r}F_{n+r} = (-1)^{n-r}F_r^2$ for $r \\le n$ by instantiating `catalan_aux` at $m = n - r$. The two rewrites `Nat.sub_add_cancel` (turning $(n-r)+r$ into $n$) and an `omega`-proved $ (n-r)+2r = n+r$ convert the subtraction-free identity back to the one with $n-r$, where $r \\le n$ guarantees the natural-number subtraction behaves.",
+    "mathContext": "$F_n^2 - F_{n-r}F_{n+r} = (-1)^{n-r}F_r^2$ for $r \\le n$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Natural-number subtraction",
+      "Reindexing",
+      "Catalan's identity"
+    ]
+  },
+  {
+    "id": "ann-sanity-checks",
+    "proofId": "cassini-identity-oq-01-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 114
+    },
+    "type": "remark",
+    "title": "Cassini specialization and concrete instances",
+    "content": "`catalan_one` is the $r = 1$ case, which is Cassini's identity $F_n^2 - F_{n-1}F_{n+1} = (-1)^{n-1}$ (here $F_1^2 = 1$). The numeric checks `catalan_5_2` ($F_5^2 - F_3 F_7 = 25 - 26 = -1 = (-1)^3 F_2^2$) and `catalan_6_2` ($F_6^2 - F_4 F_8 = 64 - 63 = 1 = (-1)^4 F_2^2$) confirm the general theorem against hand computation off the diagonal $r = 1$.",
+    "mathContext": "$F_5^2 - F_3 F_7 = -1$, $F_6^2 - F_4 F_8 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cassini's identity",
+      "Worked examples"
+    ]
+  }
+]

--- a/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cassini-identity-oq-01-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "cassini-identity-oq-01-oq-01",
+  "slug": "cassini-identity-oq-01-oq-01",
+  "title": "Catalan's Identity: the r-step generalization of Cassini",
+  "leanFile": {
+    "path": "Proofs/CassiniIdentityOQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorryCount": 0
+  },
+  "sorries": [],
+  "mainTheorems": [
+    {
+      "name": "catalan",
+      "statement": "For r ≤ n, (F n)² − F (n−r) · F (n+r) = (−1)^(n−r) · (F r)² in ℤ.",
+      "description": "Catalan's identity in classical signed form, the r-step generalization of Cassini. Obtained from the subtraction-free catalan_aux by setting m = n − r."
+    },
+    {
+      "name": "catalan_aux",
+      "statement": "(F (m+r))² − F m · F (m+2r) = (−1)^m · (F r)² in ℤ, for all m, r.",
+      "description": "The subtraction-free reindexing that carries the proof: expand F_{m+r} and F_{m+2r} with the addition formula Nat.fib_add, then the whole expression factors as F_r² · (Cassini core) and a single linear_combination finishes it. Exhibits Catalan as Cassini scaled by F_r²."
+    },
+    {
+      "name": "cassini_sub",
+      "statement": "(F (m+1))² − F m · F (m+1) − (F m)² = (−1)^m in ℤ.",
+      "description": "Cassini's identity in the normalized algebraic form that appears after the addition-formula expansion. Proved by a three-line induction off Nat.fib_add_two; this is the only induction in the development."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "cassini-identity-oq-01",
+      "relationship": "parent",
+      "description": "The parent proves Cassini's identity F_{n+2}·F_n − F_{n+1}² = (−1)^{n+1} via the determinant of the Fibonacci companion matrix Q. Catalan is the r-step generalization (Cassini is r = 1); this entry directly answers the parent's first open question — whether the r-step identity follows elementarily — by the addition-formula route rather than Q-matrix bookkeeping."
+    }
+  ],
+  "references": [
+    {
+      "title": "Cassini and Catalan identities",
+      "url": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+      "type": "encyclopedia"
+    },
+    {
+      "title": "Vajda, Fibonacci and Lucas Numbers, and the Golden Section (identities)",
+      "url": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities",
+      "type": "book"
+    }
+  ],
+  "description": "A fully machine-checked proof of Catalan's identity F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² for the Fibonacci numbers and r ≤ n. Where Cassini's identity (the parent entry) compares two consecutive Fibonacci numbers, Catalan compares the three terms F_{n−r}, F_n, F_{n+r} in arithmetic progression of step r and measures the gap by the square F_r². The proof is purely elementary: after reindexing to the subtraction-free form F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r² (set m = n − r), the terms F_{m+r} and F_{m+2r} are expanded with Mathlib's Fibonacci addition formula Nat.fib_add and the result collapses to the Cassini core F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m, proved here by a one-line induction. Mathlib records neither Catalan's identity nor the general Vajda/d'Ocagne bilinear identities for Nat.fib. This directly answers the parent entry's first open question.",
+  "overview": {
+    "historicalContext": "**Catalan's Identity**\n\nEugène Catalan (1879) generalized Cassini's 1680 near-miss relation $F_{n+1}^2 - F_n F_{n+2} = (-1)^n$ from step $1$ to an arbitrary step $r$:\n$$F_n^2 - F_{n-r}\\,F_{n+r} = (-1)^{n-r}\\,F_r^2,\\qquad r \\le n.$$\nIt sits at the head of the Cassini–Catalan–Vajda family of Fibonacci identities. Cassini is exactly the case $r = 1$ (where $F_1^2 = 1$, recovering the bare sign). Mathlib contains only the integer-indexed Cassini specialization `Int.fib_succ_mul_fib_pred_sub_fib_sq` and no general bilinear Fibonacci identity, so the $r$-step law is new infrastructure here.",
+    "problemStatement": "**Catalan's Identity**\n\nFor Fibonacci numbers viewed inside $\\mathbb{Z}$ and any $r \\le n$,\n$$F_n^2 - F_{n-r}\\,F_{n+r} = (-1)^{n-r}\\,F_r^2.$$\nThe goal is a fully machine-checked, axiom-free proof. The $r=1$ instance must reduce to Cassini's identity $F_n^2 - F_{n-1}F_{n+1} = (-1)^{n-1}$.",
+    "proofStrategy": "**Reindex to kill the subtraction, then one addition formula plus Cassini**\n\nThe natural-number subtraction $n-r$ is removed first: substituting $m = n-r$ turns the claim into the subtraction-free\n$$F_{m+r}^2 - F_m\\,F_{m+2r} = (-1)^m\\,F_r^2.$$\nFor $r = s+1$ the two compound terms are expanded with Mathlib's addition formula $F_{a+b+1} = F_a F_b + F_{a+1}F_{b+1}$ (`Nat.fib_add`), applied three times so that every Fibonacci number is written in the four-element basis $F_m, F_{m+1}, F_s, F_{s+1}$. The whole left-hand side then factors as\n$$F_{s+1}^2\\,\\bigl(F_{m+1}^2 - F_m F_{m+1} - F_m^2\\bigr).$$\nThe parenthesised factor is the Cassini core, equal to $(-1)^m$; this is the one place an induction is used (a three-line induction off the recurrence $F_{n+2}=F_n+F_{n+1}$). A single `linear_combination` against the Cassini fact discharges the goal — no induction on the identity itself.",
+    "keyInsights": [
+      "**Reindexing beats subtraction.** Writing $m = n-r$ converts $F_n^2 - F_{n-r}F_{n+r}$ into the subtraction-free $F_{m+r}^2 - F_m F_{m+2r}$, sidestepping all the friction of truncated natural-number subtraction in the formal proof.",
+      "**One addition formula does the expansion.** Three applications of `Nat.fib_add` express $F_{m+r}$, $F_{m+r+1}$ and $F_{m+2r}$ in the basis $\\{F_m, F_{m+1}, F_s, F_{s+1}\\}$, after which the identity is pure polynomial algebra.",
+      "**Catalan = Cassini × F_r².** The entire dependence on $m$ collapses into the single Cassini scalar $F_{m+1}^2 - F_m F_{m+1} - F_m^2 = (-1)^m$; the step parameter $r$ contributes only the multiplicative factor $F_r^2$. So Catalan is literally Cassini scaled by $F_r^2$.",
+      "**Stay in ℤ.** Casting Fibonacci values into $\\mathbb{Z}$ up front makes the squared differences genuine and lets `linear_combination` and `ring` close the algebra in one step."
+    ],
+    "prerequisites": [
+      "Fibonacci numbers and the recurrence F_{n+2} = F_n + F_{n+1}",
+      "The Fibonacci addition formula F_{m+n+1} = F_m F_n + F_{m+1} F_{n+1}",
+      "Cassini's identity (the parent entry, the r = 1 case)",
+      "Mathematical induction and elementary polynomial algebra"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cassini-core",
+      "title": "The Cassini core (normalized form)",
+      "startLine": 40,
+      "endLine": 54,
+      "summary": "cassini_sub proves F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m by induction off Nat.fib_add_two. This is the r = 1 engine that the general identity scales by F_r²."
+    },
+    {
+      "id": "catalan-subtraction-free",
+      "title": "Catalan's identity, subtraction-free",
+      "startLine": 57,
+      "endLine": 83,
+      "summary": "catalan_aux proves F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r². Three applications of Nat.fib_add expand the compound terms into the basis {F_m, F_{m+1}, F_s, F_{s+1}}, and a single linear_combination against the Cassini core closes the goal."
+    },
+    {
+      "id": "catalan-classical",
+      "title": "Classical signed form and sanity checks",
+      "startLine": 85,
+      "endLine": 114,
+      "summary": "catalan reindexes catalan_aux by m = n − r to the classical F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² for r ≤ n. catalan_one recovers Cassini (r = 1); catalan_5_2 and catalan_6_2 check concrete instances (F₅²−F₃F₇=−1, F₆²−F₄F₈=1)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Catalan's identity $F_n^2 - F_{n-r}F_{n+r} = (-1)^{n-r}F_r^2$ ($r \\le n$) is proved by reindexing to the subtraction-free $F_{m+r}^2 - F_m F_{m+2r} = (-1)^m F_r^2$ (with $m = n-r$), expanding the compound terms via the addition formula `Nat.fib_add`, and collapsing the result with the Cassini core $F_{m+1}^2 - F_m F_{m+1} - F_m^2 = (-1)^m$. The step parameter $r$ enters only as the factor $F_r^2$, exhibiting Catalan as Cassini scaled by $F_r^2$. 0 axioms, 0 sorries.",
+    "implications": [
+      "Answers the parent Cassini entry's first open question — that the $r$-step Catalan identity does follow elementarily — though via the addition formula rather than direct Q-matrix bookkeeping.",
+      "Supplies the general bilinear Fibonacci identity F_{m+r}² − F_m F_{m+2r} = (−1)^m F_r² that Mathlib lacks, reusable for the wider Vajda/d'Ocagne family.",
+      "Isolates the structural fact that Catalan = Cassini × F_r²: every Cassini-type alternating identity of step r is the step-1 identity multiplied by F_r²."
+    ],
+    "openQuestions": [
+      "Does the same expand-then-Cassini method give the full Vajda identity F_{n+i}F_{n+j} − F_n F_{n+i+j} = (−1)^n F_i F_j, with Catalan the diagonal case i = j = r?",
+      "Is there a determinant proof of Catalan — writing F_{m+r}² − F_m F_{m+2r} as det of a 2×2 product of Q-powers — matching the parent entry's matrix proof of Cassini?"
+    ]
+  },
+  "meta": {
+    "author": "Eugène Catalan (1879); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "1879",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "catalan-identity",
+      "cassini",
+      "addition-formula",
+      "induction",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CassiniIdentityOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add",
+        "description": "The Fibonacci addition formula fib (m + n + 1) = fib m · fib n + fib (m+1) · fib (n+1). Applied three times, it expands F_{m+r}, F_{m+r+1} and F_{m+2r} into the four-element basis {F_m, F_{m+1}, F_s, F_{s+1}}, turning Catalan's identity into polynomial algebra.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "The Fibonacci recurrence fib (n+2) = fib n + fib (n+1), used in the inductive proof of the Cassini core and to rewrite F_{s+2}.",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.sub_add_cancel",
+        "description": "n - r + r = n for r ≤ n, the reindexing identity that converts the subtraction-free catalan_aux back into the classical n − r form.",
+        "module": "Mathlib.Algebra.Order.Sub.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Catalan's identity F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r² for Nat.fib (r ≤ n), the r-step generalization of Cassini — Mathlib has only the r = 1 integer-indexed Cassini specialization and no general bilinear Fibonacci identity",
+      "The subtraction-free reindexing catalan_aux: F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r², which exposes Catalan as the Cassini core scaled by F_r² and is proved by addition-formula expansion plus a single linear_combination, with no induction on the identity itself",
+      "The normalized Cassini core cassini_sub: F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m, the algebraic form that drives the general identity",
+      "Directly resolves the parent Cassini entry's first open question (whether the r-step Catalan identity follows elementarily)"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 114,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The proof uses only Mathlib's Fibonacci lemmas (Nat.fib_add, Nat.fib_add_two), induction, exact_mod_cast, linear_combination, and ring; no native_decide and no structure-encoded hypotheses. #print axioms CassiniIdentityOQ01OQ01.catalan reports only the foundational propext and Quot.sound, neither of which counts as an assumption.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

Adds a fully machine-checked, **0-axiom / 0-sorry** proof of **Catalan's identity**

> `F_n² − F_{n−r}·F_{n+r} = (−1)^{n−r}·F_r²`  for `r ≤ n`

the `r`-step generalization of the parent entry's **Cassini identity** (which is exactly the case `r = 1`). This **directly answers the parent Cassini entry's first open question** — whether the `r`-step Catalan identity follows elementarily.

## Proof (`proofs/Proofs/CassiniIdentityOQ01OQ01.lean`)

- **`cassini_sub`** — the normalized Cassini core `F_{m+1}² − F_m·F_{m+1} − F_m² = (−1)^m`, a three-line induction off `Nat.fib_add_two`. The only induction in the file.
- **`catalan_aux`** — the subtraction-free reindexing `F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r²`. The compound terms `F_{m+r}`, `F_{m+r+1}`, `F_{m+2r}` are expanded by three applications of Mathlib's addition formula `Nat.fib_add`; the result factors as `F_r² · (Cassini core)`, and a single `linear_combination` finishes it — **no induction on the identity itself**. This exhibits Catalan as *Cassini scaled by `F_r²`*.
- **`catalan`** — the classical signed form, obtained from `catalan_aux` by `m := n − r`.
- **`catalan_one` / `catalan_5_2` / `catalan_6_2`** — the `r = 1` Cassini specialization plus concrete numeric checks (`F₅²−F₃F₇ = −1`, `F₆²−F₄F₈ = 1`).

## Novelty

Mathlib records neither Catalan's identity nor the general Vajda/d'Ocagne bilinear Fibonacci identities — only the `r = 1` integer-indexed Cassini specialization (`Int.fib_succ_mul_fib_pred_sub_fib_sq`). The general bilinear identity `F_{m+r}² − F_m·F_{m+2r} = (−1)^m·F_r²` is new infrastructure.

## Verification

Offline-verified against Mathlib 4.26.0 (`lake env lean`, EXIT 0; docker build host currently unavailable). `#print axioms CassiniIdentityOQ01OQ01.catalan` reports only `[propext, Quot.sound]` — no `Classical.choice`, no `sorryAx`, no `native_decide`.

## Files

- `proofs/Proofs/CassiniIdentityOQ01OQ01.lean` (proof, 114 lines)
- `src/data/proofs/cassini-identity-oq-01-oq-01/meta.json` (gallery entry)
- `src/data/proofs/cassini-identity-oq-01-oq-01/annotations.json` (annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)