### PR TITLE
Research: cayley-hamilton-minpoly-oq-01-oq-01 — exactness of the generalized-eigenspace index

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean
@@ -24,8 +24,19 @@
   annihilates f. Hence the product is a multiple of the minimal polynomial.
 
   This converts the parent's `minpoly_product_formula` axiom into a one-sided
-  gap: only the reverse divisibility (`∏ ∣ minpoly`, equivalently the exactness
-  `maxGenEigenspaceIndex_exact`) still requires the largest-Jordan-block witness.
+  gap: only the reverse divisibility (`∏ ∣ minpoly`) still requires assembling the
+  primary decomposition.
+
+  This file additionally supplies the **exactness** ingredient that reverse
+  divisibility needs (previously the documented blocker `maxGenEigenspaceIndex_exact`):
+
+    * `genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex` — below the limit index the
+      generalized-eigenspace chain strictly increases, so `maxGenEigenspaceIndex` is
+      the *exact* nilpotency index of `f - μ`, not just an upper bound.  Proved from
+      Mathlib's `Module.End.ker_pow_constant` plus the least-index characterization
+      of `maxGenEigenspaceIndex` (= `monotonicSequenceLimitIndex`).
+    * `exists_mem_maxGenEigenspace_pow_pred_ne_zero` — the concrete witness: a vector
+      in the maximal generalized eigenspace not killed by `(f - μ)^{e-1}`.
 
   Status: 0 sorries, 0 axioms. Fully verified against Mathlib 4.26.0.
 
@@ -104,5 +115,82 @@ theorem minpoly_dvd_maxGenEigenspace_product [IsAlgClosed K] [FiniteDimensional 
         rw [← maxGenEigenspace_eq_bot_of_not_hasEigenvalue hnev]; exact hv
       simpa using this
     rw [hv0, map_zero]
+
+/-- **Exactness of the generalized-eigenspace index.**
+
+    Below `maxGenEigenspaceIndex` the generalized-eigenspace chain is *strictly*
+    increasing: for every `k < f.maxGenEigenspaceIndex μ`,
+
+        `f.genEigenspace μ k < f.genEigenspace μ (k + 1)`.
+
+    Equivalently `maxGenEigenspaceIndex f μ` is the *exact* nilpotency index of
+    `f - μ` on the maximal generalized eigenspace, not merely an upper bound: the
+    chain cannot already be constant strictly below its limit index.
+
+    This is the missing ingredient (`maxGenEigenspaceIndex_exact`) that the reverse
+    divisibility `∏ (X - μ)^{e_μ} ∣ minpoly K f` requires.  It follows from
+    Mathlib's one-step kernel-stabilization lemma `Module.End.ker_pow_constant`
+    (equality of two consecutive kernels of a power forces the chain constant
+    afterwards) together with the fact that `maxGenEigenspaceIndex` is, by
+    definition, the *least* index at which the chain stabilizes. -/
+theorem genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex [FiniteDimensional K V]
+    (f : Module.End K V) (μ : K) {k : ℕ} (hk : k < f.maxGenEigenspaceIndex μ) :
+    f.genEigenspace μ (k : ℕ∞) < f.genEigenspace μ ((k : ℕ∞) + 1) := by
+  -- The chain is monotone, so it suffices to rule out equality at this step.
+  refine lt_of_le_of_ne ((f.genEigenspace μ).monotone (by exact_mod_cast Nat.le_succ k)) ?_
+  intro heq
+  -- Equality of two consecutive generalized eigenspaces = equality of two
+  -- consecutive kernels of powers of `f - μ`.
+  have hker : LinearMap.ker ((f - μ • 1) ^ k)
+      = LinearMap.ker ((f - μ • 1) ^ k.succ) := by
+    have h1 : f.genEigenspace μ (k : ℕ∞) = LinearMap.ker ((f - μ • 1) ^ k) :=
+      genEigenspace_nat
+    have h2 : f.genEigenspace μ ((k + 1 : ℕ) : ℕ∞)
+        = LinearMap.ker ((f - μ • 1) ^ (k + 1)) := genEigenspace_nat
+    have hcast : ((k + 1 : ℕ) : ℕ∞) = (k : ℕ∞) + 1 := by push_cast; ring
+    rw [Nat.succ_eq_add_one, ← h1, ← h2, hcast]
+    exact heq
+  -- `ker_pow_constant` then makes the kernel chain constant from `k` onwards, so
+  -- the generalized-eigenspace chain is constant from `k` onwards too.
+  have hstab : ∀ d : ℕ,
+      f.genEigenspace μ (k : ℕ∞) = f.genEigenspace μ ((k + d : ℕ) : ℕ∞) := by
+    intro d
+    have hk' := Module.End.ker_pow_constant (f := f - μ • 1) (k := k) hker d
+    rw [(genEigenspace_nat : f.genEigenspace μ (k : ℕ∞) = _),
+        (genEigenspace_nat : f.genEigenspace μ ((k + d : ℕ) : ℕ∞) = _)]
+    exact hk'
+  -- Hence `k` is a stabilization index of the defining monotone sequence.
+  have hmem : ∀ m : ℕ, k ≤ m →
+      ((f.genEigenspace μ).comp WithTop.coeOrderHom.toOrderHom) k
+        = ((f.genEigenspace μ).comp WithTop.coeOrderHom.toOrderHom) m := by
+    intro m hm
+    obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hm
+    simpa using hstab d
+  -- But `maxGenEigenspaceIndex` is the *least* such index, contradicting `k < it`.
+  have hle : f.maxGenEigenspaceIndex μ ≤ k := Nat.sInf_le hmem
+  exact absurd hk (not_lt.mpr hle)
+
+/-- **The index is the exact nilpotency degree.**  When `maxGenEigenspaceIndex f μ`
+    is positive there is a vector `v` in the maximal generalized eigenspace with
+    `(f - μ)^{e-1} v ≠ 0` (while `(f - μ)^e v = 0`).  This is the concrete witness
+    that distinguishes the *exact* product formula from the forward divisibility:
+    no smaller exponent than `e_μ = maxGenEigenspaceIndex f μ` annihilates the
+    whole `μ`-summand. -/
+theorem exists_mem_maxGenEigenspace_pow_pred_ne_zero [FiniteDimensional K V]
+    (f : Module.End K V) (μ : K) (hpos : 0 < f.maxGenEigenspaceIndex μ) :
+    ∃ v ∈ f.maxGenEigenspace μ,
+      ((f - μ • 1) ^ (f.maxGenEigenspaceIndex μ - 1)) v ≠ 0 := by
+  set e := f.maxGenEigenspaceIndex μ with he
+  have hlt := genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex f μ (k := e - 1) (by omega)
+  have hcast : ((e - 1 : ℕ) : ℕ∞) + 1 = ((e : ℕ) : ℕ∞) := by
+    have hsub : e - 1 + 1 = e := by omega
+    calc ((e - 1 : ℕ) : ℕ∞) + 1 = (((e - 1) + 1 : ℕ) : ℕ∞) := by push_cast; ring
+      _ = ((e : ℕ) : ℕ∞) := by rw [hsub]
+  rw [hcast] at hlt
+  obtain ⟨v, hv_mem, hv_not⟩ := SetLike.exists_of_lt hlt
+  refine ⟨v, ?_, ?_⟩
+  · rw [maxGenEigenspace_eq]; exact hv_mem
+  · rw [genEigenspace_nat, LinearMap.mem_ker] at hv_not
+    exact hv_not
 
 end JordanMinpolyOQ01OQ01

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -35,13 +35,16 @@
       "maxGenEigenspace_eq_bot_of_not_hasEigenvalue",
       "aeval_linear_factor_pow"
     ],
-    "insights": [],
+    "insights": [
+      "maxGenEigenspaceIndex = monotonicSequenceLimitIndex = sInf{n | chain constant from n}; strictness below it follows from Module.End.ker_pow_constant + Nat.sInf_le. Proven as genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex (PR #30664).",
+      "Exact nilpotency witness: exists_mem_maxGenEigenspace_pow_pred_ne_zero gives v in maxGenEigenspace with (f-μ)^{e-1} v ≠ 0."
+    ],
     "mathlibGaps": [
       "Explicit Jordan block matrix decomposition with labeled basis indexing (not in Mathlib 4.26.0); needed only for the exactness/reverse direction, not the forward divisibility."
     ],
     "nextSteps": [
-      "Re-run Docker build once host disk pressure relieved to confirm verified status",
-      "Attempt reverse divisibility ∏ ∣ minpoly (needs strictness of genEigenspace chain at maxGenEigenspaceIndex = maxGenEigenspaceIndex_exact)"
+      "Assemble reverse divisibility ∏ (X-μ)^{e_μ} ∣ minpoly from the new exactness lemma: needs primary decomposition V = ⨁ maxGenEigenspace and coprime-factor invertibility on each summand",
+      "Combine forward + reverse to discharge the parent minpoly_product_formula axiom"
     ],
     "markdown": "# Knowledge Base: cayley-hamilton-minpoly-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -486,5 +489,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ07OQ01.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-06-27T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

This research problem already had the **forward** divisibility `minpoly K f ∣ ∏_μ (X-μ)^{e_μ}` proved (`minpoly_dvd_maxGenEigenspace_product`), with the **reverse** direction documented as blocked on `maxGenEigenspaceIndex_exact` (the exactness/strictness of the generalized-eigenspace chain). This PR supplies exactly that ingredient — `0 sorry / 0 axiom`:

- **`genEigenspace_lt_succ_of_lt_maxGenEigenspaceIndex`** — below the limit index the chain is *strictly* increasing: `f.genEigenspace μ k < f.genEigenspace μ (k+1)` for every `k < f.maxGenEigenspaceIndex μ`. Hence `maxGenEigenspaceIndex f μ` is the **exact** nilpotency index of `f - μ` on the maximal generalized eigenspace, not merely an upper bound.

  *Proof:* equality of two consecutive generalized eigenspaces is equality of two consecutive kernels of powers of `f - μ`; Mathlib's `Module.End.ker_pow_constant` then forces the kernel chain constant from `k` onwards, making `k` a stabilization index. But `maxGenEigenspaceIndex = monotonicSequenceLimitIndex = sInf {n | chain constant from n}` is the *least* such index (`Nat.sInf_le`), contradicting `k < it`.

- **`exists_mem_maxGenEigenspace_pow_pred_ne_zero`** — the concrete witness: when the index is positive, a vector in the maximal generalized eigenspace on which `(f - μ)^{e-1}` does not vanish. This is what distinguishes the exact product formula from forward divisibility.

`theoremCount` 3 → 5 in `CayleyHamiltonMinpolyOQ01OQ01.lean`; header docstring updated.

## Verification

- `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CayleyHamiltonMinpolyOQ01OQ01.lean` → **EXIT 0** (docker build infra remains containerd-corrupt on this host).
- `#print axioms` for both new lemmas → `[propext, Classical.choice, Quot.sound]` only.

## Scope note

This is the *exactness ingredient* for reverse divisibility, not the full reverse divisibility theorem. Assembling `∏ (X-μ)^{e_μ} ∣ minpoly K f` from it additionally requires the primary decomposition and the coprime-factor invertibility argument on each generalized eigenspace — left as the documented remaining step. The strictness lemma was the previously-blocking piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)