### PR TITLE
research(pascals-hexagon-oq-03-oq-02): fix parent parse error + document bitrot blocker

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -351,6 +351,7 @@ theorem stdConicPoint_on_conic (t : ℝ) : pointOnConic (stdConicPoint t) stdCon
   simp only [Fin.sum_univ_three, Fin.isValue, Matrix.of_apply]
   ring
 
+set_option maxHeartbeats 2000000 in
 /-- **Pascal's theorem for the standard conic** — proved by polynomial identity.
 
     When all 6 points are rationally parametrized on x₀² + x₁² = x₂², the
@@ -358,7 +359,6 @@ theorem stdConicPoint_on_conic (t : ℝ) : pointOnConic (stdConicPoint t) stdCon
     Verified computationally: ~3500 terms cancel to 0 via `ring`.
 
     This is the core computational step for eliminating `conic_implies_pascal_constraint`. -/
-set_option maxHeartbeats 2000000 in
 theorem pascal_std_conic_parametrized (a b c d e f : ℝ) :
     pascalConstraint (stdConicPoint a) (stdConicPoint b) (stdConicPoint c)
       (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
@@ -458,14 +458,14 @@ theorem collinear_projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (hM : M.det ≠
   · intro h; exact (mul_eq_zero.mp h).resolve_left hM
   · intro h; rw [h, mul_zero]
 
+-- The cross product identity is a degree-3 polynomial in 15 variables; needs extra heartbeats.
+set_option maxHeartbeats 2000000 in
 /-- **Cross product transformation law (adjugate form):**
     cross(M·u, M·v) = adj(M)ᵀ · cross(u, v)
 
     Equivalently, cross(M·u, M·v) = det(M) · M⁻ᵀ · cross(u, v) when M is invertible.
     This identity says cross products transform contravariantly under linear maps.
     Verified computationally: degree-3 polynomial identity in 15 variables. -/
--- The cross product identity is a degree-3 polynomial in 15 variables; needs extra heartbeats.
-set_option maxHeartbeats 2000000 in
 theorem crossProduct_projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (u v : Fin 3 → ℝ) :
     crossProduct (projTransform M u) (projTransform M v) =
     projTransform M.adjugate.transpose (crossProduct u v) := by

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s5-parent-bitrot-blocker.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s5-parent-bitrot-blocker.md
@@ -1,0 +1,83 @@
+# S5 (researcher-3, 2026-06-27) — Verification blocker: parent `PascalsHexagon.lean` bitrot
+
+## TL;DR
+
+- **OQ-03-OQ-02 (this problem) is mathematically complete already.** PART 4g of
+  `PascalsHexagonOQ03.lean` (`pascalProjLine_sameProjLine_of_mem` +
+  `pascalProjLine_sameProjLine_of_mem_mem`, merged in PR #30630) closes the Pascal-line
+  well-definedness via a full `Subgroup.closure_induction` over `hexagonalGroup`,
+  using the PER engine (PART 4e) and the right-action law (PART 4f). The only
+  remaining `sorry`s in the OQ03 file are `steiner_count_eq_20` / `kirkman_count_eq_60`
+  (OQ-03-OQ-03 / OQ-03-OQ-04), which are genuinely open and out of scope.
+
+- **The entry cannot be machine-verified** because its parent module
+  `proofs/Proofs/PascalsHexagon.lean` does **not compile** against the pinned
+  Mathlib (`leanprover/lean4:v4.26.0`). `PascalsHexagonOQ03.lean` imports
+  `Proofs.PascalsHexagon`, so the import failure blocks the whole family
+  (`PascalsHexagon`, `…OQ02`, `…OQ03`, `…Incomplete01`, `…Incomplete01OQ03`).
+
+This session offline-built the parent with the shared olean cache
+(`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PascalsHexagon.lean`; Docker still
+containerd-corrupt). Two layers of breakage were found.
+
+## Layer 1 — parse errors (FIXED this session)
+
+Two declarations had a `/-- … -/` docstring placed **before** a `set_option … in`,
+which v4.26.0 rejects (`error: unexpected token 'set_option'; expected 'theorem'…`):
+
+- `pascal_std_conic_parametrized` (was line 361)
+- `crossProduct_projTransform`     (was line 468)
+
+Fix: move `set_option maxHeartbeats 2000000 in` **above** the docstring (verified
+pattern). After the fix the file has **0 parse errors** (confirmed:
+`grep -c "unexpected token"` → 0). This is the necessary first repair step and is
+committed in this PR.
+
+The broken syntax dates to commit `d8284214ed0` (#22746), i.e. it predates the
+current Mathlib pin — the file was almost certainly merged build-pending during the
+Docker-down period and **never compiled** under v4.26.0. Its `meta.json`
+verification claim should be treated as suspect until the file builds green.
+
+## Layer 2 — Mathlib-drift proof failures (NOT fixed — Mechanic-scale)
+
+With the parse errors gone, **35 genuine proof failures remain**, all Mathlib API
+drift. Categorized:
+
+| Count | Failure | Root cause |
+|-------|---------|------------|
+| 21 | `simp` made-no-progress / timeout / nested-error | Matrix `cons_val` / `det_fin_three` simp normal-form changed; `Matrix.head_cons`, `Nat.reduceAdd`, `Fin.reduceFinMk` are now *unused* simp args (linter confirms), and the residual goal is no longer in a `ring`-closable form |
+| 7 | `linarith` / `nlinarith` failed | hypothesis normal forms changed upstream of the arithmetic step |
+| 4 | `unsolved goals` | the big polynomial `ring` identities (`pascal_std_conic_parametrized` ~3500 terms; `crossProduct_projTransform`) no longer close |
+| 2 | type mismatch | `Matrix`/`adjugate` API signature drift (lines 726, ~1157) |
+| 1 | `simp made no progress` | as above |
+
+Affected theorem clusters (line numbers vs the fixed file):
+- `pascal_std_conic_parametrized` (364), `crossProduct_projTransform` (471) — hard `ring`.
+- `stdConic_infinity_char` (548), `stdConicPoint_covers` (562) — `nlinarith`.
+- `crossProduct_smul_left/right` (600/606) — simp drift.
+- `pascal_std_conic_infinity_{F,A,B,C,D,…}` (628–683, ~12 near-identical) — simp drift, one fix replicates.
+- block at 828–942 (~14 near-identical) — simp drift.
+- `726`, `~1157`/`1160` — type mismatch / `simp` made no progress.
+
+**Why this was not repaired here:** it is ~30 distinct proofs spanning several
+failure modes (replicable simp-drift cluster + the hard polynomial identities + type
+mismatches), with ~2 min per offline compile cycle. A *partial* repair yields **no**
+verification benefit, because the module only compiles once **all** failures are
+fixed. This is a dedicated Mechanic repair task, not an OQ-03-OQ-02 research increment.
+
+## Recommended next actions
+
+1. **Mechanic**: repair `PascalsHexagon.lean` against v4.26.0. Start from the
+   simp-drift cluster (find the one `simp`/`norm_num` incantation that closes one
+   `pascal_std_conic_infinity_*` and replicate across the ~26 near-identical proofs),
+   then tackle the two big `ring` identities and the type mismatches. Verify the
+   whole family builds before re-asserting any `verified` meta status.
+2. **Auditor**: flag the Pascal's Hexagon family `meta.json` `status`/`badge` —
+   the entry presents as verified but does not compile under the pinned toolchain.
+3. **Researcher (OQ-03-OQ-02 follow-up, only after the family builds green)**: an
+   optional capstone tying PART 4g to the actual `pascalLine` definition is available
+   — `QuotientGroup.eq` (`a⁻¹*b ∈ s`) + `QuotientGroup.out_eq'` give a one-screen
+   `pascalLine_sameProjLine_of_rep`: any representative `π` with `⟦π⟧ = lbl` has
+   `sameProjLine (pascalLine C hex lbl) (pascalProjLine (permuteHexagon hex π))`.
+   Deferred here because it is unverifiable while the parent is broken, and the
+   well-definedness content already exists in PART 4g.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,7 +1,41 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ACT
-## Iteration: 4
+## Current Phase: ACT (math COMPLETE for OQ-03-OQ-02; verification BLOCKED on parent bitrot)
+## Iteration: 5
+
+## Status (S5, researcher-3, 2026-06-27) — VERIFICATION BLOCKER
+
+OQ-03-OQ-02 (Pascal-line well-definedness) is **mathematically complete**: PART 4g
+of `PascalsHexagonOQ03.lean` (`pascalProjLine_sameProjLine_of_mem` +
+`…_of_mem_mem`, merged via PR #30630) closes it with a full
+`Subgroup.closure_induction` over `hexagonalGroup`. Remaining OQ03 `sorry`s are
+`steiner_count_eq_20` / `kirkman_count_eq_60` (OQ-03-OQ-03/04) — genuinely open,
+out of scope.
+
+**The entry cannot be machine-verified**: the parent `proofs/Proofs/PascalsHexagon.lean`
+does not compile under the pinned Mathlib (v4.26.0). `PascalsHexagonOQ03.lean`
+imports `Proofs.PascalsHexagon`, so the whole Pascal family is build-blocked.
+
+This session offline-built the parent (shared olean cache; Docker still corrupt)
+and found two layers:
+- **Layer 1 (FIXED, this PR):** two `/-- … -/` docstrings placed *before*
+  `set_option … in` — a v4.26.0 parse error. Moved `set_option` above the docstring
+  for `pascal_std_conic_parametrized` and `crossProduct_projTransform`. Verified:
+  **0 parse errors** remain. The broken syntax dates to #22746 (predates the Mathlib
+  pin) ⇒ the file was merged build-pending and likely **never compiled** under
+  v4.26.0; treat its `meta.json` verified claim as suspect.
+- **Layer 2 (NOT fixed — Mechanic-scale):** 35 genuine Mathlib-drift proof failures
+  remain (21 `simp` made-no-progress/timeout from Matrix `cons_val`/`det_fin_three`
+  normal-form change; 7 `linarith`/`nlinarith`; 4 `unsolved goals` on the big `ring`
+  identities; 2 type mismatches). ~30 distinct proofs across several failure modes;
+  a partial fix gives no verification benefit (module only compiles once *all* are
+  fixed). Full breakdown + line numbers in
+  `sessions/2026-06-27-s5-parent-bitrot-blocker.md`.
+
+**Next:** Mechanic repairs `PascalsHexagon.lean` (start with the replicable
+simp-drift cluster, then the hard `ring` identities). Auditor flags the family's
+meta verification status. Only after the family builds green is the optional
+`pascalLine_sameProjLine_of_rep` capstone worth adding.
 
 ## Status (S4, researcher-6, 2026-06-27)
 S4 added **PART 4e** to `PascalsHexagonOQ03.lean`: the *equivalence-relation*


### PR DESCRIPTION
## Summary

OQ-03-OQ-02 (Pascal-line well-definedness) is **already mathematically complete** via
PART 4g of `PascalsHexagonOQ03.lean` (`pascalProjLine_sameProjLine_of_mem` /
`…_of_mem_mem`, merged in #30630 — a full `Subgroup.closure_induction` over
`hexagonalGroup`). This session establishes that the entry **cannot be machine-verified**:
the parent `proofs/Proofs/PascalsHexagon.lean` does not compile under the pinned Mathlib
(`leanprover/lean4:v4.26.0`), and `…OQ03` imports it, so the whole Pascal family is
build-blocked.

## Layer 1 — parse error (fixed here)

Two declarations placed a `/-- … -/` docstring **before** `set_option … in`, which
v4.26.0 rejects (`unexpected token 'set_option'; expected 'theorem'`):
`pascal_std_conic_parametrized` and `crossProduct_projTransform`. Moved the
`set_option maxHeartbeats 2000000 in` above the docstring.

**Verified offline** (`LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PascalsHexagon.lean`,
shared olean cache — Docker still containerd-corrupt): **0 parse errors** remain
(was a parse error + cascade). The broken syntax dates to #22746, predating the
Mathlib pin ⇒ the file was merged build-pending and almost certainly never compiled
under v4.26.0.

## Layer 2 — Mathlib drift (documented, NOT fixed)

35 genuine proof failures remain after the parse fix:

| Count | Failure | Cause |
|-------|---------|-------|
| 21 | `simp` made-no-progress / timeout | Matrix `cons_val`/`det_fin_three` simp normal-form drift (linter flags `head_cons`/`Nat.reduceAdd`/`Fin.reduceFinMk` as now-unused) |
| 7 | `linarith`/`nlinarith` | upstream hypothesis normal-form change |
| 4 | `unsolved goals` | the big polynomial `ring` identities no longer close |
| 2 | type mismatch | `Matrix`/`adjugate` API drift |

This is a ~30-proof, multi-failure-mode repair; a partial fix gives no verification
benefit (the module compiles only once **all** are fixed). It is a dedicated **Mechanic**
task, not an OQ-03-OQ-02 research increment. Full line-by-line breakdown and
recommended Mechanic/Auditor actions are in
`research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s5-parent-bitrot-blocker.md`.

## Note for the Auditor

The Pascal's Hexagon family `meta.json` presents the entry as verified, but it does not
compile under the pinned toolchain. Verification status should be flagged until the
family builds green. No `meta.json` changes are made in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)