### PR TITLE
Auditor: re-audit amgm Maclaurin cluster (5 clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -103,9 +103,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T09:38:32Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01": {
@@ -115,21 +115,21 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T09:38:32Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T09:38:32Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T09:38:32Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03": {
@@ -139,9 +139,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T20:24:34Z",
+      "lastAudited": "2026-06-27T09:38:32Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02-oq-03-oq-03-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Re-Audit

Re-audited the AM-GM / Maclaurin mean cluster — last audited **2026-05-03** (~7 weeks ago). Verified all claims still match the Lean source; **no drift or bitrot**.

| Slug | status/badge | Finding |
|------|--------------|---------|
| `amgm-inequality-oq-02-oq-03-oq-03` | axiomatized/axiom (1) | ✅ `maclaurin_step` genuinely an `axiom` in parent; `maclaurinMean` a real def; axiom dependency disclosed in description/assumptions/conclusion. 0 sorry/stub. |
| `amgm-inequality-oq-02-oq-01-oq-02-oq-01` | verified/mathlib | ✅ 0 sorry/axiom; mathlib badge appropriately scoped. |
| `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01` | verified/mathlib | ✅ 0 sorry/axiom. |
| `amgm-inequality-oq-02-oq-01-oq-02` | verified/original | ✅ 6 genuine combinatorial infra lemmas (offDiag decomposition, e₂ identities); not a hidden Mathlib AM-GM wrapper — `original` badge correct. |
| `amgm-inequality-oq-02` | axiomatized/axiom (2) | ✅ exactly 2 `axiom` declarations match `axiomCount: 2`; 0 sorry. |

All comment-stripped scans: 0 `sorry`/`admit`/`native_decide`/`True`-stub. Axiom counts and sorry counts match source. No overclaiming detected.

Updates `audit-tracker.json` (lastAudited + auditCount) for the 5 entries.

---
Discovered during gallery integrity audit.