### PR TITLE
research(bezout-identity-oq-02-oq-02-oq-01-oq-03): sharp Lamé input bound — Fibonacci are the exact minimal inputs

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ03.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ03.lean
@@ -207,4 +207,93 @@ theorem steps_fib_theta (n : ℕ) (hn : 1 ≤ n) :
   ⟨log_le_steps_fib n hn,
     steps_le_log (Nat.fib (n + 1)) (Nat.fib_pos.mpr (by omega)) (Nat.fib (n + 2))⟩
 
+/-
+## Part VI: The sharp Lamé bound — Fibonacci inputs are the smallest
+
+Parts III–V pin the step count to `Θ(log b)` but only *up to the constant 2*:
+the upper bound is `2⌊log₂ b⌋ + 2`, while the Fibonacci family forces about
+`log_φ b ≈ 1.44 log₂ b`. The classical *sharp* form of Lamé's theorem closes
+this gap from the input side. If the algorithm takes `steps a b = n` divisions
+and `b > 0`, then `b ≥ fib (n+1)`: consecutive Fibonacci numbers are the
+**smallest inputs requiring a given number of steps**. `steps_fib` exhibits the
+attaining family (`b = fib (n+1)`, `a = fib (n+2)`); the bound below shows
+nothing smaller can reach `n` steps.
+
+The proof is a genuine two-step descent. One Euclidean step sends `(a, b)` to
+`(b, r)` with `r = a % b`; a second sends it to `(r, s)` with `s = b % r`. The
+quotient `b / r ≥ 1` forces `r + s ≤ b`, exactly mirroring the Fibonacci
+recurrence `fib (j+3) = fib (j+2) + fib (j+1)` that drives the worst case.
+-/
+
+/-- **Lamé's theorem, sharp form (input lower bound).** Whenever `b > 0`, the
+    Euclidean step count satisfies `fib (steps a b + 1) ≤ b`. Hence consecutive
+    Fibonacci numbers are the *smallest* inputs attaining a given step count
+    (`steps_fib` realizes equality with `b = fib (n+1)`). This is strictly
+    sharper than `steps_le_log`: it is the exact characterization of the worst
+    case rather than a bound up to the factor-of-2 slack in `2⌊log₂ b⌋ + 2`. -/
+theorem fib_succ_le : ∀ b, 0 < b → ∀ a, Nat.fib (steps a b + 1) ≤ b := by
+  intro b
+  induction b using Nat.strongRecOn with
+  | ind b ih =>
+    intro hb a
+    rw [steps_pos _ _ hb]
+    set r := a % b with hr_def
+    have hrb : r < b := Nat.mod_lt a hb
+    rcases Nat.eq_zero_or_pos r with hr0 | hr0
+    · -- one step: `r = 0`, so `steps a b = 1` and `fib 2 = 1 ≤ b`
+      rw [hr0, steps_zero]
+      simpa using hb
+    · -- `r > 0`: descend a second step to `(r, s)` with `s = b % r`
+      have hk : steps b r = steps r (b % r) + 1 := steps_pos b r hr0
+      set s := b % r with hs_def
+      have hsr : s < r := Nat.mod_lt b hr0
+      -- `r + s ≤ b`, the arithmetic shadow of `fib (j+3) = fib (j+2) + fib (j+1)`
+      have hsum : r + s ≤ b := by
+        have hdm : r * (b / r) + s = b := by
+          have h := Nat.div_add_mod b r
+          rwa [← hs_def] at h
+        have hq : 1 ≤ b / r := (Nat.one_le_div_iff hr0).mpr (le_of_lt hrb)
+        have hge : r * 1 ≤ r * (b / r) := Nat.mul_le_mul_left r hq
+        rw [Nat.mul_one] at hge
+        omega
+      rcases Nat.eq_zero_or_pos s with hs0 | hs0
+      · -- two steps: `s = 0`, so `steps a b = 2` and `fib 3 = 2 ≤ b`
+        rw [hk, hs0, steps_zero]
+        have hb2 : 2 ≤ b := by omega
+        calc Nat.fib (0 + 1 + 1 + 1) = 2 := by decide
+          _ ≤ b := hb2
+      · -- general case: `fib (k+2) = fib k + fib (k+1) ≤ s + r ≤ b`
+        have hA : Nat.fib (steps b r + 1) ≤ r := ih r hrb hr0 b
+        have hB : Nat.fib (steps r s + 1) ≤ s := ih s (lt_trans hsr hrb) hs0 r
+        have hBk : Nat.fib (steps b r) ≤ s := by rw [hk]; exact hB
+        have hfib : Nat.fib (steps b r + 1 + 1)
+            = Nat.fib (steps b r) + Nat.fib (steps b r + 1) := Nat.fib_add_two
+        omega
+
+/-- **Contrapositive: small inputs cannot force many steps.** If `b < fib (n+1)`
+    then the Euclidean algorithm on `(a, b)` finishes in fewer than `n` steps.
+    Equivalently, reaching `n` steps *requires* `b ≥ fib (n+1)`. -/
+theorem steps_lt_of_lt_fib (a b n : ℕ) (hb : 0 < b) (h : b < Nat.fib (n + 1)) :
+    steps a b < n := by
+  by_contra hcon
+  push_neg at hcon
+  have hmono : Nat.fib (n + 1) ≤ Nat.fib (steps a b + 1) :=
+    Nat.fib_mono (by omega)
+  have hle := fib_succ_le b hb a
+  omega
+
+/-- **Fibonacci numbers are the exact minimal inputs (the sharp Lamé theorem).**
+    For `n ≥ 1`, `fib (n+1)` is the smallest positive second argument for which
+    some first argument makes the extended Euclidean algorithm take exactly `n`
+    division steps: it is *attained* by `(fib (n+2), fib (n+1))` (`steps_fib`),
+    and no smaller `b > 0` admits any `a` reaching `n` steps (`fib_succ_le`).
+    This upgrades the Θ(log) characterization to an exact worst-case identity. -/
+theorem fib_isLeast_input (n : ℕ) (hn : 1 ≤ n) :
+    steps (Nat.fib (n + 2)) (Nat.fib (n + 1)) = n ∧
+      ∀ a b, 0 < b → steps a b = n → Nat.fib (n + 1) ≤ b := by
+  refine ⟨steps_fib n hn, fun a b hb hstep => ?_⟩
+  have hle := fib_succ_le b hb a
+  rw [hstep] at hle
+  exact hle
+
 end BezoutIdentityOQ02OQ02OQ01OQ03

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "bezout-identity-oq-02-oq-02-oq-01-oq-03",
   "title": "Lamé's Theorem: Θ(log) Complexity of the Extended Euclidean Algorithm",
   "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-03",
-  "description": "Answers open question 3 of the constructive divisibility algorithm: can the complexity bound O(log min(a,b)) for extGcd be formalized in Lean? Answer: yes, and tightly. Defines a step counter `steps` mirroring the parent's extGcd recursion (a,b+1) ↦ (b+1, a%(b+1)), then proves both sides of a Θ(log) characterization. Upper bound (Lamé, the O direction): steps a b ≤ 2·⌊log₂ b⌋ + 2, from the fact that the remainder more than halves every two steps (2·(a%b) < a when 0<b≤a). Lower bound / tightness: consecutive Fibonacci numbers are the exact worst case, steps (fib (n+2)) (fib (n+1)) = n, and since fib (n+1) ≤ 2ⁿ one gets ⌊log₂ b⌋ ≤ steps, so the algorithm is Θ(log b) and the O(log) bound cannot be improved to o(log). 10 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "description": "Answers open question 3 of the constructive divisibility algorithm: can the complexity bound O(log min(a,b)) for extGcd be formalized in Lean? Answer: yes, and tightly. Defines a step counter `steps` mirroring the parent's extGcd recursion (a,b+1) ↦ (b+1, a%(b+1)), then proves both sides of a Θ(log) characterization. Upper bound (Lamé, the O direction): steps a b ≤ 2·⌊log₂ b⌋ + 2, from the fact that the remainder more than halves every two steps (2·(a%b) < a when 0<b≤a). Lower bound / tightness: consecutive Fibonacci numbers are the exact worst case, steps (fib (n+2)) (fib (n+1)) = n, and since fib (n+1) ≤ 2ⁿ one gets ⌊log₂ b⌋ ≤ steps, so the algorithm is Θ(log b) and the O(log) bound cannot be improved to o(log). Part VI then sharpens this from the input side, proving the classical exact form of Lamé's theorem: fib (steps a b + 1) ≤ b, so consecutive Fibonacci numbers are the SMALLEST inputs forcing a given step count (steps_fib attains equality at b = fib (n+1)). This upgrades the Θ(log) bound — tight only up to the factor 2 — to an exact worst-case characterization. 13 theorems, 1 definition, 0 axioms, 0 sorries.",
   "leanFile": {
     "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ03.lean",
     "namespace": "BezoutIdentityOQ02OQ02OQ01OQ03",
@@ -15,8 +15,8 @@
     "opens": [],
     "axiomCount": 0,
     "sorries": 0,
-    "lineCount": 210,
-    "theoremCount": 10,
+    "lineCount": 299,
+    "theoremCount": 13,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -30,7 +30,9 @@
     "Halving lemma: the remainder more than halves every two steps — 2·(a%b) < a when 0 < b ≤ a",
     "Fibonacci worst case: steps (fib (n+2)) (fib (n+1)) = exactly n",
     "Tightness: fib (n+1) ≤ 2ⁿ gives ⌊log₂ b⌋ ≤ steps, so the O(log) bound is order-optimal",
-    "Two-sided sandwich steps_fib_theta: ⌊log₂ b⌋ ≤ steps ≤ 2⌊log₂ b⌋ + 2 for the Fibonacci family"
+    "Two-sided sandwich steps_fib_theta: ⌊log₂ b⌋ ≤ steps ≤ 2⌊log₂ b⌋ + 2 for the Fibonacci family",
+    "Sharp Lamé bound (input lower bound): fib (steps a b + 1) ≤ b for b > 0 — Fibonacci numbers are the exact minimal inputs",
+    "Capstone fib_isLeast_input: fib (n+1) is provably the least b > 0 reaching n steps (attained, and no smaller b works)"
   ],
   "implications": [
     {
@@ -43,6 +45,14 @@
     },
     {
       "statement": "Nat.log 2 (Nat.fib (n+1)) ≤ steps (Nat.fib (n+2)) (Nat.fib (n+1)) (matching lower bound)",
+      "type": "theorem"
+    },
+    {
+      "statement": "fib (steps a b + 1) ≤ b for all a and all b > 0 (sharp Lamé input lower bound)",
+      "type": "theorem"
+    },
+    {
+      "statement": "b < fib (n+1) → steps a b < n (small inputs cannot force n steps)",
       "type": "theorem"
     }
   ],
@@ -108,10 +118,10 @@
     }
   ],
   "conclusion": {
-    "summary": "The complexity of the extended Euclidean algorithm is formalized as a genuine Θ(log) bound. The step counter `steps` reproduces extGcd's recursion exactly; steps_le_log proves the O direction steps a b ≤ 2·⌊log₂ b⌋ + 2 via a two-step halving argument; steps_fib proves consecutive Fibonacci numbers attain exactly n steps; and fib_succ_le_two_pow → log_le_steps_fib supplies the matching ⌊log₂ b⌋ ≤ steps lower bound, sandwiched together in steps_fib_theta. 0 axioms, 0 sorries.",
-    "implications": "This completes the parent's open question 3 not merely with the requested O(log) upper bound but with a tight two-sided characterization, formalizing Lamé's 1844 theorem in full. The Fibonacci family is shown to be the exact extremal input, so the constant in the upper bound is optimal up to a factor of 2.",
+    "summary": "The complexity of the extended Euclidean algorithm is formalized as a genuine Θ(log) bound. The step counter `steps` reproduces extGcd's recursion exactly; steps_le_log proves the O direction steps a b ≤ 2·⌊log₂ b⌋ + 2 via a two-step halving argument; steps_fib proves consecutive Fibonacci numbers attain exactly n steps; and fib_succ_le_two_pow → log_le_steps_fib supplies the matching ⌊log₂ b⌋ ≤ steps lower bound, sandwiched together in steps_fib_theta. Part VI adds the sharp input lower bound fib_succ_le (fib (steps a b + 1) ≤ b), its contrapositive steps_lt_of_lt_fib, and fib_isLeast_input proving fib (n+1) is the exact minimal input for n steps. 0 axioms, 0 sorries.",
+    "implications": "This completes the parent's open question 3 not merely with the requested O(log) upper bound but with a tight two-sided characterization, formalizing Lamé's 1844 theorem in full. The Fibonacci family is shown to be the exact extremal input, so the constant in the upper bound is optimal up to a factor of 2. Part VI sharpens this further: fib (n+1) is the exact minimal input attaining n steps, so the Fibonacci worst case is characterized exactly, not merely up to a constant.",
     "openQuestions": [
-      "Sharpen the upper bound to the exact constant: prove steps a b ≤ ⌊log_φ b⌋ + O(1) with the golden ratio φ, matching the Fibonacci worst case without the factor-of-2 slack.",
+      "Convert the sharp input bound fib (steps a b + 1) ≤ b (now proved, Part VI) into the explicit real-valued constant ⌊log_φ b⌋ + O(1): this requires the analytic lower bound fib (n) ≥ φⁿ⁻² over ℝ, removing the remaining factor-of-2 slack in the integer-only statement.",
       "Bound the bit-complexity (not just the step count) by tracking the cost of each division, giving the classical O(log²) or M(log) total running time.",
       "Formalize the average-case analysis: the expected number of steps on random inputs is (12 ln 2 / π²)·log b (Heilbronn/Dixon), a finer result than the worst-case Θ(log)."
     ]
@@ -147,8 +157,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 210,
-    "theoremCount": 10,
+    "lineCount": 299,
+    "theoremCount": 13,
     "definitionCount": 1,
     "originalContributions": [
       "steps: a step counter mirroring the parent extGcd recursion, with steps_pos uniform unfolding",
@@ -156,11 +166,14 @@
       "steps_le_log: the O(log) upper bound steps a b ≤ 2·⌊log₂ b⌋ + 2 by strong induction",
       "steps_fib: consecutive Fibonacci numbers are the exact worst case (steps = n)",
       "fib_succ_le_two_pow + log_le_steps_fib: the matching ⌊log₂ b⌋ ≤ steps lower bound",
-      "steps_fib_theta: the two-sided Θ(log) sandwich for the Fibonacci family"
+      "steps_fib_theta: the two-sided Θ(log) sandwich for the Fibonacci family",
+      "fib_succ_le: the sharp Lamé input bound fib (steps a b + 1) ≤ b, via a two-step Euclidean descent (r + s ≤ b mirroring fib (j+3) = fib (j+2) + fib (j+1))",
+      "steps_lt_of_lt_fib: contrapositive — b < fib (n+1) forces fewer than n steps",
+      "fib_isLeast_input: fib (n+1) is the exact minimal input for n steps (attained by steps_fib, minimal by fib_succ_le)"
     ],
     "proofStrategy": "Define a step counter mirroring extGcd. Prove the O direction by strong induction on b using a two-step halving lemma and Nat.log bookkeeping. Prove the Ω/tightness direction by showing Fibonacci pairs attain exactly n steps and that fib (n+1) ≤ 2ⁿ, giving a matching logarithmic lower bound, then package both as a two-sided sandwich.",
     "openQuestions": [
-      "Sharpen to the exact golden-ratio constant ⌊log_φ b⌋ + O(1)",
+      "Convert the proved sharp input bound fib (steps a b + 1) ≤ b to the explicit real ⌊log_φ b⌋ + O(1) constant (needs fib (n) ≥ φⁿ⁻² over ℝ)",
       "Bound the total bit-complexity, not just the step count",
       "Formalize the average-case (12 ln 2 / π²)·log b analysis"
     ],
@@ -198,13 +211,24 @@
           "log_le_steps_fib",
           "steps_fib_theta"
         ]
+      },
+      {
+        "title": "The Sharp Lamé Bound — Fibonacci Inputs Are the Smallest",
+        "content": "fib_succ_le (fib (steps a b + 1) ≤ b, the sharp input lower bound by two-step descent), steps_lt_of_lt_fib (contrapositive), and fib_isLeast_input (fib (n+1) is the exact minimal input attaining n steps).",
+        "startLine": 211,
+        "endLine": 297,
+        "theorems": [
+          "fib_succ_le",
+          "steps_lt_of_lt_fib",
+          "fib_isLeast_input"
+        ]
       }
     ],
     "mathContext": {
       "field": "Analysis of Algorithms / Number Theory",
       "keyTheorem": "The extended Euclidean algorithm performs Θ(log b) division steps: steps a b ≤ 2⌊log₂ b⌋ + 2, with consecutive Fibonacci numbers attaining exactly n steps and ⌊log₂ b⌋ ≤ steps, so the bound is tight.",
       "historicalBackground": "Gabriel Lamé (1844) gave the first running-time analysis of any algorithm, bounding Euclidean-algorithm steps by O(log) and identifying Fibonacci numbers as the worst case. The parent entry posed formalizing this complexity bound as open question 3.",
-      "significance": "Formalizes Lamé's theorem as a tight two-sided Θ(log) bound rather than a one-sided O(log) estimate, with the Fibonacci family proved to be the exact extremal input, completing the parent's open question with the constant optimal up to a factor of 2."
+      "significance": "Formalizes Lamé's theorem as a tight two-sided Θ(log) bound rather than a one-sided O(log) estimate, with the Fibonacci family proved to be the exact extremal input, completing the parent's open question with the constant optimal up to a factor of 2. Part VI proves the sharp input form fib (steps a b + 1) ≤ b, identifying consecutive Fibonacci numbers as the exact minimal inputs for any given step count."
     }
   },
   "sorries": 0

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-03.json
@@ -11,7 +11,7 @@
     "whyMatters": []
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Θ(log) characterization of extGcd verified offline (lake env lean, EXIT 0, 0 axioms). O direction steps_le_log, Ω/tightness via Fibonacci worst case + fib(n+1)≤2ⁿ. 10 thm / 1 def. Gallery entry created.",
+    "progressSummary": "COMPLETE+SHARPENED: Θ(log) characterization (Parts I–V) plus Part VI sharp Lamé input bound fib(steps a b+1)≤b (fib_succ_le) — Fibonacci numbers proved to be the EXACT minimal inputs (fib_isLeast_input), upgrading tight-up-to-constant-2 to an exact worst-case identity. 13 thm / 1 def, 0 ax / 0 sorry, verified offline (lake env lean EXIT 0; axioms propext/choice/Quot only).",
     "builtItems": [
       "steps : ℕ → ℕ → ℕ — division-step counter mirroring extGcd's recursion (a,b+1)↦(b+1,a%(b+1))",
       "two_mul_mod_lt {a b} (hb : 0 < b) (hab : b ≤ a) : 2 * (a % b) < a — the remainder more-than-halves; two-case split on 2*b ≤ a vs a/2 < b",
@@ -20,20 +20,25 @@
       "steps_fib : ∀ n, 1 ≤ n → steps (Nat.fib (n+2)) (Nat.fib (n+1)) = n — Fibonacci worst case (Ω direction), via fib(n+3)%fib(n+2)=fib(n+1)",
       "fib_succ_le_two_pow (BezoutIdentityOQ02OQ02OQ01OQ03.lean:174): fib(n+1) ≤ 2ⁿ via Nat.twoStepInduction",
       "log_le_steps_fib (line 194): matching lower bound ⌊log₂(fib(n+1))⌋ ≤ steps via Nat.log_mono_right + Nat.log_pow",
-      "steps_fib_theta (line 204): two-sided Θ(log) sandwich for the Fibonacci worst case"
+      "steps_fib_theta (line 204): two-sided Θ(log) sandwich for the Fibonacci worst case",
+      "fib_succ_le (BezoutIdentityOQ02OQ02OQ01OQ03.lean:234): the SHARP Lamé input bound — 0<b → fib (steps a b + 1) ≤ b, via two-step Euclidean descent (r=a%b, s=b%r, r+s≤b from b/r≥1) mirroring fib(j+3)=fib(j+2)+fib(j+1). Strictly sharper than steps_le_log.",
+      "steps_lt_of_lt_fib (line 276): contrapositive — b < fib (n+1) → steps a b < n",
+      "fib_isLeast_input (line 291): capstone — fib (n+1) is the EXACT minimal positive second argument reaching n steps (attained by steps_fib, minimal by fib_succ_le)"
     ],
     "insights": [
       "The remainder more-than-halves every two steps, not every step: a single step can leave a%b just below b, but two steps force 2·(a%b)<a (two_mul_mod_lt). This is why the Lamé constant is 2·log₂ b, not log₂ b.",
       "Nat.log_mul_base (log b (n*b) = log b n + 1) + Nat.log_mono_right turn the arithmetic halving 2·r''<b into the logarithmic decrement log₂ r'' + 1 ≤ log₂ b that drives the induction.",
       "Consecutive Fibonacci numbers reduce to the previous pair in exactly one step (fib(n+3)%fib(n+2)=fib(n+1) since fib(n+3)=fib(n+1)+fib(n+2) and fib(n+1)<fib(n+2)), giving the sharp Ω-direction worst case with a clean Nat.le_induction.",
       "The inline well-founded `steps` def (termination via `have : a%(b+1)<b+1`) unfolds cleanly under `simp [steps]` — the same pattern the verified parent entry BezoutIdentityOQ02OQ02OQ01OQ01 uses for `extGcd` with `simp [extGcd]`.",
-      "Tightness needs fib(n+1) ≤ 2ⁿ: then Nat.log 2 (fib(n+1)) ≤ n = steps, upgrading the one-sided O(log) bound to a genuine Θ(log) sandwich ⌊log₂ b⌋ ≤ steps ≤ 2⌊log₂ b⌋ + 2 for the Fibonacci family"
+      "Tightness needs fib(n+1) ≤ 2ⁿ: then Nat.log 2 (fib(n+1)) ≤ n = steps, upgrading the one-sided O(log) bound to a genuine Θ(log) sandwich ⌊log₂ b⌋ ≤ steps ≤ 2⌊log₂ b⌋ + 2 for the Fibonacci family",
+      "The sharp form of Lamé needs the INPUT lower bound fib(steps+1)≤b, not just the step upper bound. Single-level induction loses a Fibonacci level (gives fib(steps)≤b, off by one); the fix is a genuine TWO-step descent invoking the IH at both r=a%b and s=b%r, with the arithmetic r+s≤b (from b=r·(b/r)+s, b/r≥1) exactly matching fib(j+3)=fib(j+2)+fib(j+1).",
+      "fib_succ_le subsumes steps_fib as the tightness witness: steps_fib gives one attaining family, fib_succ_le proves NO smaller input attains the count — together = exact worst-case characterization (fib_isLeast_input)."
     ],
     "mathlibGaps": [
       "Mathlib has Nat.gcd, the Euclidean recursion, and Nat.log, but no formalized complexity/step-count bound for the Euclidean algorithm (Lamé's theorem); this entry supplies steps_le_log and the Fibonacci worst case."
     ],
     "nextSteps": [
-      "Sharpen to exact golden-ratio constant ⌊log_φ b⌋ + O(1) (remove factor-of-2 slack)",
+      "Convert fib_succ_le to the explicit real constant ⌊log_φ b⌋ + O(1): needs analytic fib(n) ≥ φ^(n-2) over ℝ (Mathlib: Nat.fib and goldenRatio). This removes the last factor-of-2 slack.",
       "Bound total bit-complexity, not just step count (O(log²) / M(log))",
       "Formalize average-case (12 ln 2 / π²)·log b analysis (Heilbronn/Dixon)"
     ]


### PR DESCRIPTION
## Summary

Extends the Lamé's-theorem entry (`bezout-identity-oq-02-oq-02-oq-01-oq-03`) with **Part VI: the sharp form of Lamé's theorem**. The entry previously proved a `Θ(log)` characterization that was tight only *up to the constant 2* (`steps a b ≤ 2⌊log₂ b⌋ + 2`, with the Fibonacci family attaining `≈ log_φ b`). This PR closes that gap from the input side with the classical exact statement.

## New theorems (all 0-axiom, 0-sorry)

| Theorem | Statement |
|---|---|
| `fib_succ_le` | `0 < b → fib (steps a b + 1) ≤ b` — the sharp Lamé **input lower bound** |
| `steps_lt_of_lt_fib` | `b < fib (n+1) → steps a b < n` — contrapositive |
| `fib_isLeast_input` | `fib (n+1)` is the **exact minimal** `b > 0` reaching `n` steps |

`fib_succ_le` says consecutive Fibonacci numbers are the *smallest* inputs forcing a given number of Euclidean division steps. Combined with the existing `steps_fib` (which *attains* `n` steps at `b = fib (n+1)`), `fib_isLeast_input` gives the exact worst-case identity — not merely a bound up to a constant.

## Proof idea

A genuine **two-step Euclidean descent**: `(a, b) → (b, r)` with `r = a % b`, then `→ (r, s)` with `s = b % r`. The quotient `b / r ≥ 1` forces `r + s ≤ b`, which is exactly the arithmetic shadow of the Fibonacci recurrence `fib (j+3) = fib (j+2) + fib (j+1)`. (A single-level induction loses a Fibonacci level and is off by one — the two-step descent invoking the IH at both `r` and `s` is what makes it sharp.)

## Verification

- Compiled offline via `LAKE_UNSAFE=1 lake env lean` (Docker build host unavailable), **EXIT 0**, 0 errors/warnings.
- `#print axioms` on all three new theorems: `propext`, `Classical.choice`, `Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`. Entry remains `verified` / `original`, `axiomCount: 0`.
- File: 210 → 299 lines, 10 → 13 theorems. Gallery `meta.json` and research `knowledge.json` updated accordingly.

## Remaining open question (updated in entry)

Converting `fib (steps a b + 1) ≤ b` to the explicit real constant `⌊log_φ b⌋ + O(1)` (removing the final factor-of-2 slack) still requires the analytic bound `fib (n) ≥ φ^(n-2)` over ℝ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)