### PR TITLE
research(collatz-structured-oq-02-oq-03): density floor 13/16 → 7/8 via n ≡ 11, 23 (mod 32)

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -38,14 +38,18 @@ algebraic core and isolated the finite-check residue), this file:
   * proves, **unconditionally and axiom-free**, that several large explicit families
     of starting values already satisfy the "drops below itself" conclusion — the
     even numbers, the powers of two, the odd residue class `n ≡ 1 (mod 4)`
-    (`n ≥ 5`), and the odd residue class `n ≡ 3 (mod 16)` — so the elementary part of
-    the almost-all picture is real Lean content, not scaffolding on the axiom.  The
-    evens together with `1 + 4ℕ` and `3 + 16ℕ` cover **thirteen-sixteenths** of the
-    integers via elementary residue dynamics (`attainsBelow_density_lower_16`, a
-    machine-checked `≥ 13/16` lower density), and the `mod 4`/`mod 16` families
-    exercise the non-trivial `3n+1` branch of the map.  Of the odd classes
-    `n ≡ 3 (mod 4)`, `n ≡ 3 (mod 16)` is precisely the one that drops within its
-    residue-determined window; `7, 11, 15 (mod 16)` have `m`-dependent stopping times.
+    (`n ≥ 5`), the odd residue class `n ≡ 3 (mod 16)`, and the two odd residue classes
+    `n ≡ 11, 23 (mod 32)` — so the elementary part of the almost-all picture is real
+    Lean content, not scaffolding on the axiom.  The evens together with `1 + 4ℕ`,
+    `3 + 16ℕ`, `11 + 32ℕ`, and `23 + 32ℕ` cover **seven-eighths** of the integers via
+    elementary residue dynamics (`attainsBelow_density_lower_32`, a machine-checked
+    `≥ 7/8` lower density, sharpening the earlier `≥ 13/16` floor
+    `attainsBelow_density_lower_16`), and the `mod 4`/`mod 16`/`mod 32` families
+    exercise the non-trivial `3n+1` branch of the map.  The residue-determined drop
+    stabilises modulus-by-modulus: of the odd classes `n ≡ 3 (mod 4)`, exactly
+    `n ≡ 3 (mod 16)` drops at level `16`, and exactly the lifts `n ≡ 11, 23 (mod 32)`
+    become newly determined at level `32`; the classes `7, 15, 27, 31 (mod 32)` still
+    have `m`-dependent stopping times and need a finer modulus.
 
 References:
 - Tao, T. (2019). "Almost all orbits of the Collatz map attain almost bounded
@@ -172,6 +176,57 @@ theorem mod_sixteen_three_attainsBelow {n : ℕ} (h : n % 16 = 3) : AttainsBelow
       Function.iterate_zero_apply, s1, s2, s3, s4, s5, s6]
   omega
 
+/-- Every `n ≡ 11 (mod 32)` drops below itself in exactly eight steps:
+`32m+11 ↦ 96m+34 ↦ 48m+17 ↦ 144m+52 ↦ 72m+26 ↦ 36m+13 ↦ 108m+40 ↦ 54m+20 ↦ 27m+10`,
+and `27m+10 < 32m+11` for every `m ≥ 0`.  All eight parities are forced by the residue
+`mod 32` alone (each intermediate `am+b` has `a` even at the decision point), so this is a
+genuine residue-class drop.  Together with `n ≡ 23 (mod 32)` it captures the *new* residues
+that first stabilise at level `32`: among the odd classes `n ≡ 3 (mod 4)`, the lifts
+`11, 23 (mod 32)` drop within their residue-determined windows, whereas `7, 15, 27, 31
+(mod 32)` still have `m`-dependent stopping times.  (The classes `3, 19 (mod 32)` are already
+covered by `n ≡ 3 (mod 16)`.)  Adjoining `11, 23 (mod 32)` lifts the unconditional density
+floor from `13/16` to `7/8`. -/
+theorem mod_thirtytwo_eleven_attainsBelow {n : ℕ} (h : n % 32 = 11) : AttainsBelow n := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = 32 * m + 11 := ⟨n / 32, by omega⟩
+  refine ⟨8, by norm_num, ?_⟩
+  have s1 : collatz (32 * m + 11) = 96 * m + 34 := by rw [collatz_odd (by omega)]; ring
+  have s2 : collatz (96 * m + 34) = 48 * m + 17 := by rw [collatz_even (by omega)]; omega
+  have s3 : collatz (48 * m + 17) = 144 * m + 52 := by rw [collatz_odd (by omega)]; ring
+  have s4 : collatz (144 * m + 52) = 72 * m + 26 := by rw [collatz_even (by omega)]; omega
+  have s5 : collatz (72 * m + 26) = 36 * m + 13 := by rw [collatz_even (by omega)]; omega
+  have s6 : collatz (36 * m + 13) = 108 * m + 40 := by rw [collatz_odd (by omega)]; ring
+  have s7 : collatz (108 * m + 40) = 54 * m + 20 := by rw [collatz_even (by omega)]; omega
+  have s8 : collatz (54 * m + 20) = 27 * m + 10 := by rw [collatz_even (by omega)]; omega
+  rw [Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_zero_apply, s1, s2, s3, s4, s5, s6, s7, s8]
+  omega
+
+/-- Every `n ≡ 23 (mod 32)` drops below itself in exactly eight steps:
+`32m+23 ↦ 96m+70 ↦ 48m+35 ↦ 144m+106 ↦ 72m+53 ↦ 216m+160 ↦ 108m+80 ↦ 54m+40 ↦ 27m+20`,
+and `27m+20 < 32m+23` for every `m ≥ 0`.  As with `n ≡ 11 (mod 32)`, all eight parities are
+forced by the residue `mod 32`, and this is the second new residue first stabilising at level
+`32`. -/
+theorem mod_thirtytwo_twentythree_attainsBelow {n : ℕ} (h : n % 32 = 23) : AttainsBelow n := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = 32 * m + 23 := ⟨n / 32, by omega⟩
+  refine ⟨8, by norm_num, ?_⟩
+  have s1 : collatz (32 * m + 23) = 96 * m + 70 := by rw [collatz_odd (by omega)]; ring
+  have s2 : collatz (96 * m + 70) = 48 * m + 35 := by rw [collatz_even (by omega)]; omega
+  have s3 : collatz (48 * m + 35) = 144 * m + 106 := by rw [collatz_odd (by omega)]; ring
+  have s4 : collatz (144 * m + 106) = 72 * m + 53 := by rw [collatz_even (by omega)]; omega
+  have s5 : collatz (72 * m + 53) = 216 * m + 160 := by rw [collatz_odd (by omega)]; ring
+  have s6 : collatz (216 * m + 160) = 108 * m + 80 := by rw [collatz_even (by omega)]; omega
+  have s7 : collatz (108 * m + 80) = 54 * m + 40 := by rw [collatz_even (by omega)]; omega
+  have s8 : collatz (54 * m + 40) = 27 * m + 20 := by rw [collatz_even (by omega)]; omega
+  rw [Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_succ_apply', Function.iterate_succ_apply',
+      Function.iterate_zero_apply, s1, s2, s3, s4, s5, s6, s7, s8]
+  omega
+
 /-- Packaging: every positive `n` that is **even** or lies in `1 + 4ℕ` (with `n ≥ 5`)
 attains a value below itself.  Together these cover three-quarters of the integers,
 all handled by elementary dynamics with no appeal to Tao's axiom. -/
@@ -191,6 +246,21 @@ theorem even_or_mod_four_one_or_mod_sixteen_three_attainsBelow {n : ℕ} (hn : 1
   · exact even_attainsBelow hn he
   · exact mod_four_one_attainsBelow h1.1 h1.2
   · exact mod_sixteen_three_attainsBelow h3
+
+/-- Full packaging at level `32`: every positive `n` that is **even**, lies in `1 + 4ℕ`
+(`n ≥ 5`), `3 + 16ℕ`, `11 + 32ℕ`, or `23 + 32ℕ` attains a value below itself.  These five
+elementary families together cover **seven-eighths** of the integers — the current
+unconditional floor beneath Tao's density-one theorem, with no appeal to the axiom. -/
+theorem even_or_mod_four_one_or_mod_sixteen_three_or_mod_thirtytwo_attainsBelow {n : ℕ}
+    (hn : 1 ≤ n)
+    (h : n % 2 = 0 ∨ (5 ≤ n ∧ n % 4 = 1) ∨ n % 16 = 3 ∨ n % 32 = 11 ∨ n % 32 = 23) :
+    AttainsBelow n := by
+  rcases h with he | h1 | h3 | h11 | h23
+  · exact even_attainsBelow hn he
+  · exact mod_four_one_attainsBelow h1.1 h1.2
+  · exact mod_sixteen_three_attainsBelow h3
+  · exact mod_thirtytwo_eleven_attainsBelow h11
+  · exact mod_thirtytwo_twentythree_attainsBelow h23
 
 /-! ## Part II.5: A quantitative density floor of 3/4
 
@@ -331,6 +401,135 @@ theorem attainsBelow_density_lower_16 (N : ℕ) :
     _ = (E ∪ O1 ∪ O3).card := hcard.symm
     _ ≤ _ := Finset.card_le_card hsub
 
+open Classical in
+/-- **Sharpened quantitative density lower bound (`7/8`).**  Adjoining the residue classes
+`11 + 32ℕ` and `23 + 32ℕ` to the evens, `1 + 4ℕ`, and `3 + 16ℕ` lifts the count: among the
+integers in `[1, 32N]`, at least `28N - 1` already attain a value below themselves — the
+`16N` evens, the `8N - 1` members of `1 + 4ℕ` that are `≥ 5`, the `2N` members of `3 + 16ℕ`,
+the `N` members of `11 + 32ℕ`, and the `N` members of `23 + 32ℕ`.  The five families are
+pairwise disjoint (evens by parity; `1 + 4ℕ` by residue `1` mod `4`; the remaining three by
+their distinct residues `3, 11, 23` mod `32`), giving
+`16N + (8N - 1) + 2N + N + N = 28N - 1` distinct drop-below starts.  Dividing by `32N` and
+letting `N → ∞`, the drop-below set has **lower natural density `≥ 7/8`** — strictly above the
+previous `13/16` floor. -/
+theorem attainsBelow_density_lower_32 (N : ℕ) :
+    28 * N - 1 ≤
+      ((Finset.Icc 1 (32 * N)).filter (fun n => AttainsBelow n)).card := by
+  classical
+  rcases Nat.eq_zero_or_pos N with hN0 | hNpos
+  · subst hN0; simp
+  -- The five residue families, as injective images of intervals.
+  set E : Finset ℕ := (Finset.Icc 1 (16 * N)).image (fun j => 2 * j) with hE
+  set O1 : Finset ℕ := (Finset.Icc 1 (8 * N - 1)).image (fun j => 4 * j + 1) with hO1
+  set O3 : Finset ℕ := (Finset.Icc 0 (2 * N - 1)).image (fun j => 16 * j + 3) with hO3
+  set O11 : Finset ℕ := (Finset.Icc 0 (N - 1)).image (fun j => 32 * j + 11) with hO11
+  set O23 : Finset ℕ := (Finset.Icc 0 (N - 1)).image (fun j => 32 * j + 23) with hO23
+  have hEinj : Function.Injective (fun j : ℕ => 2 * j) :=
+    fun a b h => by have h' : 2 * a = 2 * b := h; omega
+  have hO1inj : Function.Injective (fun j : ℕ => 4 * j + 1) :=
+    fun a b h => by have h' : 4 * a + 1 = 4 * b + 1 := h; omega
+  have hO3inj : Function.Injective (fun j : ℕ => 16 * j + 3) :=
+    fun a b h => by have h' : 16 * a + 3 = 16 * b + 3 := h; omega
+  have hO11inj : Function.Injective (fun j : ℕ => 32 * j + 11) :=
+    fun a b h => by have h' : 32 * a + 11 = 32 * b + 11 := h; omega
+  have hO23inj : Function.Injective (fun j : ℕ => 32 * j + 23) :=
+    fun a b h => by have h' : 32 * a + 23 = 32 * b + 23 := h; omega
+  have hEcard : E.card = 16 * N := by
+    rw [hE, Finset.card_image_of_injective _ hEinj, Nat.card_Icc]; omega
+  have hO1card : O1.card = 8 * N - 1 := by
+    rw [hO1, Finset.card_image_of_injective _ hO1inj, Nat.card_Icc]; omega
+  have hO3card : O3.card = 2 * N := by
+    rw [hO3, Finset.card_image_of_injective _ hO3inj, Nat.card_Icc]; omega
+  have hO11card : O11.card = N := by
+    rw [hO11, Finset.card_image_of_injective _ hO11inj, Nat.card_Icc]; omega
+  have hO23card : O23.card = N := by
+    rw [hO23, Finset.card_image_of_injective _ hO23inj, Nat.card_Icc]; omega
+  -- Residues separate the five families.
+  have hEeven : ∀ x ∈ E, x % 2 = 0 := by
+    intro x hx; rw [hE, Finset.mem_image] at hx
+    obtain ⟨i, -, rfl⟩ := hx; show 2 * i % 2 = 0; omega
+  have hO1mod4 : ∀ x ∈ O1, x % 4 = 1 := by
+    intro x hx; rw [hO1, Finset.mem_image] at hx
+    obtain ⟨i, -, rfl⟩ := hx; show (4 * i + 1) % 4 = 1; omega
+  have hO3mod16 : ∀ x ∈ O3, x % 16 = 3 := by
+    intro x hx; rw [hO3, Finset.mem_image] at hx
+    obtain ⟨i, -, rfl⟩ := hx; show (16 * i + 3) % 16 = 3; omega
+  have hO11mod32 : ∀ x ∈ O11, x % 32 = 11 := by
+    intro x hx; rw [hO11, Finset.mem_image] at hx
+    obtain ⟨i, -, rfl⟩ := hx; show (32 * i + 11) % 32 = 11; omega
+  have hO23mod32 : ∀ x ∈ O23, x % 32 = 23 := by
+    intro x hx; rw [hO23, Finset.mem_image] at hx
+    obtain ⟨i, -, rfl⟩ := hx; show (32 * i + 23) % 32 = 23; omega
+  -- The ten pairwise disjointnesses.
+  have dE_O1 : Disjoint E O1 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hEeven a ha; have := hO1mod4 a hb; omega
+  have dE_O3 : Disjoint E O3 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hEeven a ha; have := hO3mod16 a hb; omega
+  have dE_O11 : Disjoint E O11 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hEeven a ha; have := hO11mod32 a hb; omega
+  have dE_O23 : Disjoint E O23 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hEeven a ha; have := hO23mod32 a hb; omega
+  have dO1_O3 : Disjoint O1 O3 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hO1mod4 a ha; have := hO3mod16 a hb; omega
+  have dO1_O11 : Disjoint O1 O11 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hO1mod4 a ha; have := hO11mod32 a hb; omega
+  have dO1_O23 : Disjoint O1 O23 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hO1mod4 a ha; have := hO23mod32 a hb; omega
+  have dO3_O11 : Disjoint O3 O11 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hO3mod16 a ha; have := hO11mod32 a hb; omega
+  have dO3_O23 : Disjoint O3 O23 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hO3mod16 a ha; have := hO23mod32 a hb; omega
+  have dO11_O23 : Disjoint O11 O23 := Finset.disjoint_left.mpr fun a ha hb => by
+    have := hO11mod32 a ha; have := hO23mod32 a hb; omega
+  -- Assemble disjointness of the growing unions.
+  have dEO1_O3 : Disjoint (E ∪ O1) O3 := Finset.disjoint_union_left.mpr ⟨dE_O3, dO1_O3⟩
+  have dEO1_O11 : Disjoint (E ∪ O1) O11 := Finset.disjoint_union_left.mpr ⟨dE_O11, dO1_O11⟩
+  have dEO1O3_O11 : Disjoint (E ∪ O1 ∪ O3) O11 :=
+    Finset.disjoint_union_left.mpr ⟨dEO1_O11, dO3_O11⟩
+  have dEO1_O23 : Disjoint (E ∪ O1) O23 := Finset.disjoint_union_left.mpr ⟨dE_O23, dO1_O23⟩
+  have dEO1O3_O23 : Disjoint (E ∪ O1 ∪ O3) O23 :=
+    Finset.disjoint_union_left.mpr ⟨dEO1_O23, dO3_O23⟩
+  have dEO1O3O11_O23 : Disjoint (E ∪ O1 ∪ O3 ∪ O11) O23 :=
+    Finset.disjoint_union_left.mpr ⟨dEO1O3_O23, dO11_O23⟩
+  have hcard : (E ∪ O1 ∪ O3 ∪ O11 ∪ O23).card =
+      E.card + O1.card + O3.card + O11.card + O23.card := by
+    rw [Finset.card_union_of_disjoint dEO1O3O11_O23,
+        Finset.card_union_of_disjoint dEO1O3_O11,
+        Finset.card_union_of_disjoint dEO1_O3,
+        Finset.card_union_of_disjoint dE_O1]
+  -- All five families consist of drop-below starts in range.
+  have hsub : E ∪ O1 ∪ O3 ∪ O11 ∪ O23 ⊆
+      (Finset.Icc 1 (32 * N)).filter (fun n => AttainsBelow n) := by
+    intro x hx
+    rw [Finset.mem_filter, Finset.mem_Icc]
+    rw [Finset.mem_union, Finset.mem_union, Finset.mem_union, Finset.mem_union] at hx
+    rcases hx with ((((hxE | hxO1) | hxO3) | hxO11) | hxO23)
+    · rw [hE, Finset.mem_image] at hxE
+      obtain ⟨j, hj, rfl⟩ := hxE; rw [Finset.mem_Icc] at hj
+      show (1 ≤ 2 * j ∧ 2 * j ≤ 32 * N) ∧ AttainsBelow (2 * j)
+      exact ⟨⟨by omega, by omega⟩, even_attainsBelow (by omega) (by omega)⟩
+    · rw [hO1, Finset.mem_image] at hxO1
+      obtain ⟨j, hj, rfl⟩ := hxO1; rw [Finset.mem_Icc] at hj
+      show (1 ≤ 4 * j + 1 ∧ 4 * j + 1 ≤ 32 * N) ∧ AttainsBelow (4 * j + 1)
+      exact ⟨⟨by omega, by omega⟩, mod_four_one_attainsBelow (by omega) (by omega)⟩
+    · rw [hO3, Finset.mem_image] at hxO3
+      obtain ⟨j, hj, rfl⟩ := hxO3; rw [Finset.mem_Icc] at hj
+      show (1 ≤ 16 * j + 3 ∧ 16 * j + 3 ≤ 32 * N) ∧ AttainsBelow (16 * j + 3)
+      exact ⟨⟨by omega, by omega⟩, mod_sixteen_three_attainsBelow (by omega)⟩
+    · rw [hO11, Finset.mem_image] at hxO11
+      obtain ⟨j, hj, rfl⟩ := hxO11; rw [Finset.mem_Icc] at hj
+      show (1 ≤ 32 * j + 11 ∧ 32 * j + 11 ≤ 32 * N) ∧ AttainsBelow (32 * j + 11)
+      exact ⟨⟨by omega, by omega⟩, mod_thirtytwo_eleven_attainsBelow (by omega)⟩
+    · rw [hO23, Finset.mem_image] at hxO23
+      obtain ⟨j, hj, rfl⟩ := hxO23; rw [Finset.mem_Icc] at hj
+      show (1 ≤ 32 * j + 23 ∧ 32 * j + 23 ≤ 32 * N) ∧ AttainsBelow (32 * j + 23)
+      exact ⟨⟨by omega, by omega⟩, mod_thirtytwo_twentythree_attainsBelow (by omega)⟩
+  calc 28 * N - 1
+      ≤ E.card + O1.card + O3.card + O11.card + O23.card := by
+        rw [hEcard, hO1card, hO3card, hO11card, hO23card]; omega
+    _ = (E ∪ O1 ∪ O3 ∪ O11 ∪ O23).card := hcard.symm
+    _ ≤ _ := Finset.card_le_card hsub
+
 /-! ## Part III: The orbit minimum and logarithmic density -/
 
 /-- The **orbit minimum** of `n`: the infimum of the values visited by the
@@ -396,6 +595,22 @@ has orbit minimum strictly below the start. -/
 theorem even_or_mod_four_one_or_mod_sixteen_three_colMin_lt {n : ℕ} (hn : 1 ≤ n)
     (h : n % 2 = 0 ∨ (5 ≤ n ∧ n % 4 = 1) ∨ n % 16 = 3) : colMin n < n :=
   attainsBelow_colMin_lt (even_or_mod_four_one_or_mod_sixteen_three_attainsBelow hn h)
+
+/-- The two new residue classes `11 + 32ℕ` and `23 + 32ℕ` likewise have orbit minimum
+strictly below their start, unconditionally and without Tao's axiom. -/
+theorem mod_thirtytwo_colMin_lt {n : ℕ} (h : n % 32 = 11 ∨ n % 32 = 23) : colMin n < n := by
+  rcases h with h11 | h23
+  · exact attainsBelow_colMin_lt (mod_thirtytwo_eleven_attainsBelow h11)
+  · exact attainsBelow_colMin_lt (mod_thirtytwo_twentythree_attainsBelow h23)
+
+/-- The full seven-eighths family — evens, `1 + 4ℕ` (`n ≥ 5`), `3 + 16ℕ`, `11 + 32ℕ`, and
+`23 + 32ℕ` — has orbit minimum strictly below the start. -/
+theorem even_or_mod_four_one_or_mod_sixteen_three_or_mod_thirtytwo_colMin_lt {n : ℕ}
+    (hn : 1 ≤ n)
+    (h : n % 2 = 0 ∨ (5 ≤ n ∧ n % 4 = 1) ∨ n % 16 = 3 ∨ n % 32 = 11 ∨ n % 32 = 23) :
+    colMin n < n :=
+  attainsBelow_colMin_lt
+    (even_or_mod_four_one_or_mod_sixteen_three_or_mod_thirtytwo_attainsBelow hn h)
 
 /-- The logarithmic-density partial average of a set `S` up to `N`:
 `(∑_{n≤N, n∈S} 1/n) / (∑_{n≤N} 1/n)`. -/

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -87,3 +87,43 @@ containerd meta.db still I/O-corrupt): `cd proofs && LAKE_UNSAFE=1 ./bin/lake en
 lean Proofs/CollatzStructuredOQ02OQ03.lean` → EXIT 0 (oleans under
 `.lake/packages/mathlib/.lake/build/lib/lean/`, 7382 present). `#print axioms` on
 the four new colMin lemmas → only `[propext, Classical.choice, Quot.sound]`.
+
+---
+
+## Session 2026-06-27 (researcher-9) — mod 32: density floor 13/16 → 7/8
+
+**Mode**: REVISIT · **Outcome**: progress (axiom-free)
+
+### What I Did
+- Computed (symbolically) which odd residues `r ≡ 3 (mod 4)` mod 32 drop within their
+  residue-determined window. Of the 8 such classes, `{3,19}` (= `3 mod 16`, already covered)
+  plus the **new** `{11, 23}` drop; `{7,15,27,31}` still have `m`-dependent stopping times.
+- Added `mod_thirtytwo_eleven_attainsBelow` (`32m+11 → … → 27m+10`, 8 steps) and
+  `mod_thirtytwo_twentythree_attainsBelow` (`32m+23 → … → 27m+20`, 8 steps); every parity
+  is forced by `n mod 32` (each intermediate `am+b` has `a` even at the decision).
+- Added `attainsBelow_density_lower_32`: `≥ 28N−1` of `[1,32N]` drop below themselves, via
+  five pairwise-disjoint image families (`2j`, `4j+1`, `16j+3`, `32j+11`, `32j+23`).
+  `16N + (8N−1) + 2N + N + N = 28N−1` ⇒ lower natural density `≥ 7/8`.
+- Combined packaging + `colMin` corollaries (`mod_thirtytwo_colMin_lt`, full 7/8 packaging).
+
+### Key Findings
+- Determinism budget = power of 2 in the leading coefficient: starting `a = 32 = 2^5`
+  allows at most 5 halvings before parity decouples from the residue; that is exactly why
+  some lifts stabilise at level 32 and others need a finer modulus.
+- The unconditional floor climbs `3/4 → 13/16 → 7/8` at moduli `4, 16, 32`; each newly
+  determined residue mod `2^k` contributes `1/2^k` — the Terras stopping-time density
+  inching toward 1 by purely elementary residue dynamics.
+
+### Files Modified
+- `proofs/Proofs/CollatzStructuredOQ02OQ03.lean` (22 → 28 theorems; +7/8 density theorem)
+- `src/data/proofs/collatz-structured-oq-02-oq-03/meta.json` (counts, description, highlights)
+- `src/data/research/problems/collatz-structured-oq-02-oq-03.json` (knowledge)
+
+### Verification
+`cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → EXIT 0 (51s).
+`#print axioms` on the four new headline lemmas → only `[propext, Classical.choice, Quot.sound]`
+(no `tao_2019`, no `sorryAx`, no `ofReduceBool`).
+
+### Next Steps
+- Push to mod 64/128 (lifts of `7,15,27,31 mod 32`); expect floor `7/8 → ~15/16`.
+- Tao axiom remains BLOCKED (deep analytic, ≫1000 lines).

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "collatz-structured-oq-02-oq-03",
   "title": "Tao's 2019 Almost-All Collatz Bound — A Feasibility Anchor",
   "slug": "collatz-structured-oq-02-oq-03",
-  "description": "Addresses OQ-03 of the Collatz cycle non-existence problem: can Tao's 2019 almost-all result (logarithmic density 1) be formalized in Lean using Mathlib's measure/ergodic theory? Tao's analytic proof (3-adic transport/concentration estimates) is out of reach today, so — mirroring the sibling OQ-02 entry — this file pins down the open question with a precise machine-checkable statement of Tao's theorem (logarithmic density of {n : Col_min(n) < f n} is 1 for every f → ∞) and proves, axiom-free, that several explicit residue families already satisfy the elementary 'drops below itself' conclusion: every positive even number (one step), every power of two (collapses to 1), every n ≡ 1 (mod 4) with n ≥ 5 (three steps, the 3n+1 branch), and every n ≡ 3 (mod 16) (six steps). The evens together with 1+4ℕ and 3+16ℕ give a machine-checked lower natural density of 13/16 (attainsBelow_density_lower_16: at least 13N−1 of [1,16N] drop below themselves), raising the previous 3/4 floor. Of the odd classes n ≡ 3 (mod 4), exactly n ≡ 3 (mod 16) drops within its residue-determined window; 7,11,15 (mod 16) have m-dependent stopping times. Single deep axiom (tao_2019); the proven content does not depend on it.",
+  "description": "Addresses OQ-03 of the Collatz cycle non-existence problem: can Tao's 2019 almost-all result (logarithmic density 1) be formalized in Lean using Mathlib's measure/ergodic theory? Tao's analytic proof (3-adic transport/concentration estimates) is out of reach today, so — mirroring the sibling OQ-02 entry — this file pins down the open question with a precise machine-checkable statement of Tao's theorem (logarithmic density of {n : Col_min(n) < f n} is 1 for every f → ∞) and proves, axiom-free, that several explicit residue families already satisfy the elementary 'drops below itself' conclusion: every positive even number (one step), every power of two (collapses to 1), every n ≡ 1 (mod 4) with n ≥ 5 (three steps, the 3n+1 branch), every n ≡ 3 (mod 16) (six steps), and every n ≡ 11 or 23 (mod 32) (eight steps each). The evens together with 1+4ℕ, 3+16ℕ, 11+32ℕ and 23+32ℕ give a machine-checked lower natural density of 7/8 (attainsBelow_density_lower_32: at least 28N−1 of [1,32N] drop below themselves), sharpening the earlier 13/16 floor (attainsBelow_density_lower_16). The residue-determined drop stabilises modulus-by-modulus: of the odd classes n ≡ 3 (mod 4), exactly n ≡ 3 (mod 16) drops at level 16, and exactly the lifts n ≡ 11, 23 (mod 32) become newly determined at level 32; 7,15,27,31 (mod 32) have m-dependent stopping times. Single deep axiom (tao_2019); the proven content does not depend on it.",
   "meta": {
     "author": "Research formalization 2026",
     "sourceUrl": "https://terrytao.wordpress.com/2019/09/10/almost-all-collatz-orbits-attain-almost-bounded-values/",
@@ -133,9 +133,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 427,
+    "lineCount": 642,
     "axiomCount": 1,
-    "theoremCount": 22,
+    "theoremCount": 28,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 5
@@ -145,6 +145,8 @@
     "New residue class n ≡ 3 (mod 16) drops below itself in exactly 6 residue-determined steps (16m+3 → 9m+2 < 16m+3), axiom-free",
     "Machine-checked density floor raised 3/4 → 13/16: attainsBelow_density_lower_16 shows ≥ 13N−1 of [1,16N] drop below themselves (8N evens + (4N−1) of 1+4ℕ + N of 3+16ℕ, pairwise disjoint)",
     "n ≡ 3 (mod 16) is precisely the one odd class mod 16 (among 3,7,11,15) that stabilises in its residue-determined window; 7,11,15 need a finer modulus",
-    "Tao 2019 stated precisely (tao_2019 axiom, HasLogDensityOne); deep analytic proof BLOCKED, all elementary content independent of the axiom"
+    "Tao 2019 stated precisely (tao_2019 axiom, HasLogDensityOne); deep analytic proof BLOCKED, all elementary content independent of the axiom",
+    "Machine-checked density floor sharpened 13/16 → 7/8: attainsBelow_density_lower_32 shows ≥ 28N−1 of [1,32N] drop below themselves (16N evens + (8N−1) of 1+4ℕ + 2N of 3+16ℕ + N of 11+32ℕ + N of 23+32ℕ, 5 pairwise-disjoint residue families)",
+    "New residues n ≡ 11, 23 (mod 32) drop in exactly 8 residue-determined steps — the two lifts of the hard classes 7,11 (mod 16) that first stabilise at modulus 32; all 8 parities forced by n mod 32 alone, axiom-free"
   ]
 }

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -29,24 +29,30 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: raised the unconditional axiom-free density floor from 3/4 to 13/16 by adding the odd residue class n ≡ 3 (mod 16), which drops below itself in exactly 6 residue-determined steps (16m+3 → 48m+10 → 24m+5 → 72m+16 → 36m+8 → 18m+4 → 9m+2 < 16m+3 for all m≥0). New: mod_sixteen_three_attainsBelow, extended packaging, attainsBelow_density_lower_16 (≥13N−1 of [1,16N] via 3 disjoint families: 8N evens + (4N−1) of 1+4ℕ + N of 3+16ℕ), colMin corollaries. Of the odd classes mod 16 (3,7,11,15), only n≡3 drops in its residue-determined window; 7,11,15 have m-dependent stopping times (verified numerically: 27,31 mod do not drop in 40 steps). 22 thm / 5 def, 1 axiom (tao_2019, unchanged). VERIFIED offline lake env lean EXIT 0; new theorems axiom-free (propext/Choice/Quot only, no tao_2019). Tao 2019 axiom remains BLOCKED (deep analytic, >>1000 lines).",
+    "progressSummary": "PROGRESS: raised unconditional axiom-free density floor 13/16 → 7/8 by adding odd residue classes n ≡ 11, 23 (mod 32), each dropping below itself in exactly 8 residue-determined steps (all parities forced by n mod 32). New: mod_thirtytwo_eleven/twentythree_attainsBelow, attainsBelow_density_lower_32 (≥28N-1 of [1,32N] via 5 disjoint families: 16N evens + (8N-1) of 1+4ℕ + 2N of 3+16ℕ + N of 11+32ℕ + N of 23+32ℕ), combined packaging + colMin corollaries. 28 thm / 5 def, 1 axiom (tao_2019 unchanged). VERIFIED offline lake env lean EXIT 0 (51s); new theorems axiom-free (propext/Choice/Quot only). Tao 2019 axiom remains BLOCKED.",
     "builtItems": [
       "collatz_odd helper (collatz n = 3n+1 for odd n) in CollatzStructuredOQ02OQ03.lean",
       "mod_four_one_attainsBelow: n≡1 mod 4, n≥5 ⇒ AttainsBelow n (axiom-free)",
       "even_or_mod_four_one_attainsBelow: packaging covering 3/4 of integers axiom-free",
       "mod_sixteen_three_attainsBelow (h : n%16=3) : AttainsBelow n — 6-step residue-determined drop, all parities forced by n mod 16",
       "attainsBelow_density_lower_16 (N) : 13*N-1 ≤ card (filter AttainsBelow (Icc 1 (16N))) — three disjoint image families (2j, 4j+1, 16j+3), card_union_of_disjoint twice",
-      "even_or_mod_four_one_or_mod_sixteen_three_attainsBelow / _colMin_lt — combined 13/16 packaging"
+      "even_or_mod_four_one_or_mod_sixteen_three_attainsBelow / _colMin_lt — combined 13/16 packaging",
+      "mod_thirtytwo_eleven_attainsBelow (h : n%32=11) : AttainsBelow n — 8-step residue-determined drop 32m+11→…→27m+10",
+      "mod_thirtytwo_twentythree_attainsBelow (h : n%32=23) : AttainsBelow n — 8-step residue-determined drop 32m+23→…→27m+20",
+      "attainsBelow_density_lower_32 (N) : 28N-1 ≤ card (filter AttainsBelow (Icc 1 (32N))) — five disjoint image families (2j, 4j+1, 16j+3, 32j+11, 32j+23)",
+      "even_or_mod_four_one_or_mod_sixteen_three_or_mod_thirtytwo_attainsBelow / _colMin_lt + mod_thirtytwo_colMin_lt — combined 7/8 packaging"
     ],
     "insights": [
       "The odd residue class n ≡ 1 (mod 4), n ≥ 5, deterministically drops below itself in 3 Collatz steps: 4m+1 → 12m+4 → 6m+2 → 3m+1, with 3m+1 < 4m+1 iff m ≥ 1. First elementary family exercising the 3n+1 branch (even/powers-of-two only touch the n/2 branch).",
-      "n ≡ 3 (mod 4) does NOT immediately drop: 4m+3 → 12m+10 → 6m+5 → 18m+16 → 9m+8 > 4m+3, confirming these are the genuinely hard residues (consistent with stopping-time theory)."
+      "n ≡ 3 (mod 4) does NOT immediately drop: 4m+3 → 12m+10 → 6m+5 → 18m+16 → 9m+8 > 4m+3, confirming these are the genuinely hard residues (consistent with stopping-time theory).",
+      "Among the 8 odd residues r ≡ 3 (mod 4) mod 32 ({3,7,11,15,19,23,27,31}), exactly {3,19} (=3 mod16, already covered) and the NEW {11,23} drop within their residue-determined window; {7,15,27,31} mod 32 still have m-dependent stopping times. Determinism is limited by the power of 2 in the leading coefficient: starting a=32=2^5 permits at most 5 halvings before parity decouples from the residue.",
+      "The determined-drop count per modulus 2^k grows 1(mod4=3)→1(mod8)... raising the unconditional floor 3/4→13/16→7/8 as k=2,4,5; each new residue contributes 1/2^k density. This is the Terras stopping-time density inching toward 1, purely elementarily."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Push to mod 32/64: among 7,11,15 mod 16, find which sub-residues mod 32 stabilise (unstopped-residue count grows ~ 3,4,6,9,13,19,27 mod 2^k, OEIS-style), inching the floor toward density 1.",
-      "Formalize the general Terras stopping-time density theorem (density of finite-stopping-time n is 1) as an intermediate milestone short of Tao.",
-      "Tao axiom genuinely blocked; no elementary path to logarithmic-density-1."
+      "Push to mod 64/128: among 7,15,27,31 (mod 32) find which lifts mod 64 stabilise within the (6-halving) window; expect ~2-4 new residues, floor 7/8 → 15/16-ish.",
+      "Consider a general lemma: a residue r mod 2^k drops deterministically iff its forced trajectory reaches coefficient ≤ 2^k with constant < r before exhausting the k available halvings — could mechanise the per-modulus search.",
+      "Tao axiom genuinely blocked (deep analytic, >>1000 lines); no elementary path to logarithmic-density-1."
     ],
     "markdown": "# Knowledge Base: collatz-structured-oq-02-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

Sharpens the unconditional, axiom-free density floor beneath Tao's 2019 Collatz density-one theorem from **13/16** to **7/8**, by adding two new odd residue classes that drop below themselves in a fully residue-determined window.

## New residues (mod 32)

Among the 8 odd classes `r ≡ 3 (mod 4)` mod 32, exactly `{3, 19}` (= `3 mod 16`, already covered) plus the **new** `{11, 23}` drop within their residue-determined window; `{7, 15, 27, 31}` still have `m`-dependent stopping times.

```
32m+11 → 96m+34 → 48m+17 → 144m+52 → 72m+26 → 36m+13 → 108m+40 → 54m+20 → 27m+10  (< 32m+11)
32m+23 → 96m+70 → 48m+35 → 144m+106 → 72m+53 → 216m+160 → 108m+80 → 54m+40 → 27m+20  (< 32m+23)
```

All 8 parities are forced by `n mod 32` alone (each intermediate `am+b` has `a` even at the decision). The determinism budget is the power of 2 in the leading coefficient: starting `a = 32 = 2^5` permits at most 5 halvings before parity decouples — which is exactly why these lifts stabilise at modulus 32.

## New theorems (all axiom-free)

- `mod_thirtytwo_eleven_attainsBelow`, `mod_thirtytwo_twentythree_attainsBelow`
- `attainsBelow_density_lower_32`: `≥ 28N−1` of `[1, 32N]` drop below themselves, via **five pairwise-disjoint** image families (`2j`, `4j+1`, `16j+3`, `32j+11`, `32j+23`): `16N + (8N−1) + 2N + N + N = 28N−1` ⇒ lower natural density `≥ 7/8`.
- Combined packaging + `mod_thirtytwo_colMin_lt` + full 7/8 `colMin` packaging.

Theorem count 22 → 28. The `tao_2019` axiom is unchanged (deep analytic, BLOCKED ≫1000 lines); no proven content depends on it.

## Verification

- `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/CollatzStructuredOQ02OQ03.lean` → **EXIT 0** (51s), 0 sorries.
- `#print axioms` on the four new headline lemmas → only `[propext, Classical.choice, Quot.sound]` (no `tao_2019`, no `sorryAx`, no `ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)