### PR TITLE
Enrich Vincent's Theorem (bisection isolation): add annotations.json

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "ann-vincent-bisect-mingap-def",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "definition",
+    "title": "minGap — minimum pairwise distance of a finite set",
+    "content": "minGap S is the smallest distance |x - y| between two distinct points of the finite set S. It is built as the Finset.min' of the image of S.offDiag (the set of ordered pairs (x, y) with x ≠ y) under (x, y) ↦ |x - y|. The dependent if-then-else returns the harmless default 1 when S has fewer than two elements, so the off-diagonal image is empty. Making minGap total (never undefined) is what lets minGap_pos be stated and used with no side hypothesis on the cardinality of S.",
+    "mathContext": "$\\operatorname{minGap}(S) = \\min\\{\\,|x - y| : x, y \\in S,\\ x \\neq y\\,\\}$, with $\\operatorname{minGap}(S) = 1$ by convention when $|S| < 2$. This is the separation distance (a.k.a. root gap) of the set.",
+    "significance": "key",
+    "relatedConcepts": [
+      "separation distance",
+      "Finset.offDiag",
+      "Finset.min'",
+      "root gap",
+      "noncomputable definition"
+    ],
+    "prerequisites": [
+      "Finset.min' and nonempty Finsets",
+      "Finset.offDiag and Finset.image"
+    ]
+  },
+  {
+    "id": "ann-vincent-bisect-mingap-pos",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 67, "endLine": 81 },
+    "type": "technique",
+    "title": "minGap_pos — the gap is strictly positive",
+    "content": "Positivity is proved by case-splitting on the dependent if. In the nonempty branch, Finset.lt_min'_iff reduces 0 < min' to 0 < y for every element y of the image; each such y equals |p.1 - p.2| for a pair on the off-diagonal, where p.1 ≠ p.2, so abs_pos gives strict positivity. In the empty branch minGap = 1 and one_pos closes it. The convention that distinct reals differ by a positive amount is exactly what makes the whole termination argument run.",
+    "mathContext": "For all finite $S$, $\\operatorname{minGap}(S) > 0$. Crucially this holds unconditionally: distinct points satisfy $x \\neq y \\implies |x - y| > 0$, and the empty case is covered by the default value $1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "abs_pos",
+      "Finset.lt_min'_iff",
+      "strict positivity",
+      "case analysis on dite"
+    ],
+    "prerequisites": [
+      "sub_ne_zero and abs_pos",
+      "splitting a dependent if-then-else"
+    ]
+  },
+  {
+    "id": "ann-vincent-bisect-mingap-le",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 83, "endLine": 92 },
+    "type": "technique",
+    "title": "minGap_le — the gap lower-bounds every distance",
+    "content": "The companion lower-bound lemma: for any two distinct points x, y ∈ S, minGap S ≤ |x - y|. The witness pair (x, y) lies on S.offDiag, so |x - y| is a member of the image whose minimum minGap takes; Finset.min'_le then gives the inequality. Together minGap_pos and minGap_le say the gap is a genuine, attained, positive lower bound on all pairwise separations — the only facts about S the isolation argument needs.",
+    "mathContext": "$x, y \\in S,\\ x \\neq y \\implies \\operatorname{minGap}(S) \\le |x - y|$. Combined with minGap_pos this characterizes minGap as the largest $\\delta > 0$ separating all distinct points of $S$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.min'_le",
+      "Finset.mem_offDiag",
+      "lower bound",
+      "separation distance"
+    ],
+    "prerequisites": [
+      "Finset.min'_le",
+      "membership in Finset.image"
+    ]
+  },
+  {
+    "id": "ann-vincent-bisect-subsingleton",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 94, "endLine": 110 },
+    "type": "insight",
+    "title": "A narrow interval isolates at most one root",
+    "content": "The geometric heart of the theorem. If two roots x, y both lie in an interval [c, c + s] of width s < minGap S, then on one hand |x - y| ≤ s (both inside an interval of width s, via abs_sub_le_iff), and on the other minGap S ≤ |x - y| (minGap_le). Chaining gives minGap S ≤ |x - y| ≤ s < minGap S, a contradiction, so the two roots must coincide — the set of roots in the interval is a Subsingleton. The bound is uniform in the interval's left endpoint c, which is precisely what later lets a single bisection level work for all dyadic subintervals at once.",
+    "mathContext": "If $s < \\operatorname{minGap}(S)$ then $|S \\cap [c, c+s]| \\le 1$ for every $c$. Pigeonhole on the separation distance: an interval narrower than the gap cannot hold two distinct roots.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Set.Subsingleton",
+      "abs_sub_le_iff",
+      "pigeonhole principle",
+      "proof by contradiction",
+      "uniform bound"
+    ],
+    "prerequisites": [
+      "Set.Subsingleton",
+      "abs_sub_le_iff and linarith"
+    ]
+  },
+  {
+    "id": "ann-vincent-bisect-width-pos",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 112, "endLine": 120 },
+    "type": "technique",
+    "title": "Bisection width stays positive",
+    "content": "width_after_bisect records the bookkeeping fact that k bisections of a width-w interval leave a subinterval of width w / 2^k (stated as a reflexive equality, the canonical normal form). width_pos confirms this width is strictly positive whenever w > 0, discharged by positivity since 2^k > 0. These mundane facts pin down the geometry so the Archimedean step below has a clean target.",
+    "mathContext": "After $k$ bisections a width-$w$ interval has width $w / 2^k$, and $w > 0 \\implies w / 2^k > 0$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "interval bisection",
+      "div_pos",
+      "positivity tactic",
+      "geometric subdivision"
+    ],
+    "prerequisites": [
+      "div_pos",
+      "the positivity tactic"
+    ]
+  },
+  {
+    "id": "ann-vincent-bisect-exists-width-lt",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 122, "endLine": 132 },
+    "type": "technique",
+    "title": "Archimedean termination — width drops below any bound",
+    "content": "The termination engine: for any δ > 0 there is a level k with w / 2^k < δ. The proof uses pow_unbounded_of_one_lt with base 2 to find k with w / δ < 2^k, then clears denominators with div_lt_iff₀ and finishes by linarith. This is the one place the Archimedean property of ℝ enters; everything else is order arithmetic. Applying it with δ = minGap S is what forces the subintervals below the separation distance after finitely many halvings.",
+    "mathContext": "$\\forall \\delta > 0,\\ \\exists k,\\ w / 2^k < \\delta$. Equivalent to $2^k \\to \\infty$ (Archimedean property): repeated halving makes the width arbitrarily small, so the process must terminate.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Archimedean property",
+      "pow_unbounded_of_one_lt",
+      "div_lt_iff₀",
+      "termination guarantee",
+      "geometric decay"
+    ],
+    "prerequisites": [
+      "Archimedean ordered fields",
+      "pow_unbounded_of_one_lt"
+    ]
+  },
+  {
+    "id": "ann-vincent-bisect-exists-level-isolates",
+    "proofId": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 144 },
+    "type": "insight",
+    "title": "exists_level_isolates — Vincent's bisection theorem (core)",
+    "content": "The headline result. Composing the two ingredients — exists_width_lt at δ = minGap S gives a level k with w / 2^k < minGap S, and subsingleton_of_width_lt_minGap then isolates every width-(w/2^k) interval — yields a single bisection level k at which every subinterval contains at most one root of S, regardless of where it sits (the ∀ c quantifier). This is exactly the termination claim of Vincent's bisection theorem: repeated subdivision *must* eventually isolate the real roots. The companion exists_level_isolates_each (lines 146–155) just instantiates c over the 2^k dyadic offsets of a concrete interval [a, b].",
+    "mathContext": "$\\exists k,\\ \\forall c,\\ |S \\cap [c, c + w/2^k]| \\le 1$. The bisection level $k$ works uniformly across all subintervals because the isolation bound is independent of the offset $c$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vincent's theorem",
+      "real-root isolation",
+      "VAS/VCA algorithms",
+      "termination",
+      "composition of lemmas"
+    ],
+    "prerequisites": [
+      "the minGap and Archimedean lemmas above",
+      "existential and universal quantifiers in Lean"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `descartes-rule-of-signs-oq-02-oq-01-oq-03` (Vincent's Theorem: Bisection Eventually Isolates Real Roots), which had no `annotations.json` (passes: 0).

## Changes
- Added `annotations.json` with 7 inline annotations mapped to the Lean source line ranges:
  - `minGap` definition (separation distance via Finset.offDiag/min')
  - `minGap_pos` (unconditional strict positivity) and `minGap_le` (lower bound)
  - the narrow-interval `Subsingleton` bound (geometric heart)
  - bisection width lemmas (`width_after_bisect`/`width_pos`)
  - `exists_width_lt` (Archimedean termination engine)
  - `exists_level_isolates` (headline isolation theorem)
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

meta.json was already rich (12.5 KB, well under the 60 KB cap) with good overview/sections/conclusion/crossReferences, so it was left unchanged. `index.ts` is intentionally not added — proof data is now fetched at runtime from the build-generated manifest (issue #20993), and sibling entries carry none.

Build (`pnpm build`) passes.