### PR TITLE
research(godel-incompleteness-oq-03): independence ⇔ two splitting completions

### DIFF
--- a/proofs/Proofs/GodelIncompletenessOQ03.lean
+++ b/proofs/Proofs/GodelIncompletenessOQ03.lean
@@ -41,6 +41,10 @@ are all sentences `φ` with `PA ⊭ φ` and `PA ⊭ ¬φ`.
   `Independent.mono` / `not_independent_of_not_isSatisfiable` — the structural calculus
   of the relation: independence implies consistency, is symmetric under negation,
   descends to subtheories, and holds for some sentence iff `T` is consistent.
+* `Independent.exists_isComplete_extensions` — an independent sentence **splits `T` into
+  two disagreeing completions**: there are complete theories `T₁, T₂ ⊇ T` with `T₁ ⊨ φ`,
+  `T₂ ⊨ ¬φ`, `T₁ ≠ T₂`, built constructively as the complete theories of explicit models
+  (no Zorn/Lindenbaum).  This is the converse face of `Independent.not_isComplete`.
 
 ## What remains genuinely open / out of scope
 
@@ -189,5 +193,48 @@ so it decides every sentence and none is independent. -/
 theorem not_independent_of_not_isSatisfiable {T : L.Theory} {φ : L.Sentence}
     (h : ¬ T.IsSatisfiable) : ¬ Independent T φ :=
   fun hind => h hind.isSatisfiable
+
+/-- **Independence splits `T` into two disagreeing completions.**  If `φ` is independent
+of `T`, then `T` has (at least) two *complete* extensions that decide `φ` oppositely:
+there exist complete theories `T₁ ⊇ T` and `T₂ ⊇ T` with `T₁ ⊨ᵇ φ`, `T₂ ⊨ᵇ ¬φ`, and
+hence `T₁ ≠ T₂`.
+
+This is the model-theoretic substance of "`φ` is undecided": the two one-sentence
+extensions `T ∪ {φ}` and `T ∪ {¬φ}` (both satisfiable, by
+`independent_iff_satisfiable_both`) each have a model `M`, `N`, whose *complete theories*
+`Th(M) = L.completeTheory M` and `Th(N)` are maximal consistent extensions of `T` that
+sit on opposite sides of `φ`.  Conversely a *complete* theory leaves nothing
+independent (`Independent.not_isComplete`), so the existence of two splitting
+completions is exactly what independence buys.
+
+The completions are produced *constructively* as the theories of explicit models, with
+no appeal to Zorn/Lindenbaum: every satisfiable theory already has a model, and the
+complete theory of a model is automatically maximal (`completeTheory.isComplete`). -/
+theorem Independent.exists_isComplete_extensions (h : Independent T φ) :
+    ∃ T₁ T₂ : L.Theory,
+      T ⊆ T₁ ∧ T ⊆ T₂ ∧ T₁.IsComplete ∧ T₂.IsComplete ∧
+        T₁ ⊨ᵇ φ ∧ T₂ ⊨ᵇ φ.not ∧ T₁ ≠ T₂ := by
+  -- A model `M` of `T ∪ {φ}` and a model `N` of `T ∪ {¬φ}`.
+  obtain ⟨M⟩ := h.satisfiable_insert
+  obtain ⟨N⟩ := h.satisfiable_insert_not
+  -- Split each bundled model's `⊨ (T ∪ {…})` into the `T` part and the sentence part.
+  have hM := M.is_model; have hN := N.is_model
+  rw [Theory.model_union_iff, Theory.model_singleton_iff] at hM hN
+  haveI : (M : Type _) ⊨ T := hM.1
+  haveI : (N : Type _) ⊨ T := hN.1
+  have hc1 : (L.completeTheory M).IsComplete := completeTheory.isComplete L M
+  refine ⟨L.completeTheory M, L.completeTheory N,
+    Theory.completeTheory.subset, Theory.completeTheory.subset,
+    hc1, completeTheory.isComplete L N,
+    Theory.models_sentence_of_mem (mem_completeTheory.2 hM.2),
+    Theory.models_sentence_of_mem (mem_completeTheory.2 hN.2), ?_⟩
+  -- Distinctness: `Th(M) ⊨ φ` while `Th(N) ⊨ ¬φ`; were they equal, the (complete, hence
+  -- consistent) theory `Th(M)` would entail both `φ` and `¬φ`.
+  intro heq
+  have hφ : (L.completeTheory M) ⊨ᵇ φ :=
+    Theory.models_sentence_of_mem (mem_completeTheory.2 hM.2)
+  have hnφ : (L.completeTheory M) ⊨ᵇ φ.not := by
+    rw [heq]; exact Theory.models_sentence_of_mem (mem_completeTheory.2 hN.2)
+  exact (hc1.models_not_iff φ).1 hnφ hφ
 
 end GodelIncompletenessOQ03

--- a/src/data/proofs/godel-incompleteness-oq-03/meta.json
+++ b/src/data/proofs/godel-incompleteness-oq-03/meta.json
@@ -23,8 +23,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 145,
-    "theoremCount": 11,
+    "lineCount": 240,
+    "theoremCount": 12,
     "definitionCount": 1,
     "assumptions": "None beyond Mathlib's first-order model theory. All results are universally quantified over an arbitrary Language L, theory T : L.Theory and sentence φ : L.Sentence; semantic consequence T ⊨ᵇ φ (ModelsBoundedFormula), satisfiability (Theory.IsSatisfiable) and completeness (Theory.IsComplete) are Mathlib's own definitions. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
     "mathlibDependencies": [
@@ -60,7 +60,8 @@
       "isSatisfiable_insert_not_not_iff: IsSatisfiable (T ∪ {¬¬φ}) ↔ IsSatisfiable (T ∪ {φ}). Proved by a reusable model-transfer: a semantic implication M ⊨ ψ → M ⊨ χ holding in every structure lifts a model of T ∪ {ψ} to a model of T ∪ {χ}; instantiated both ways at the realize-equivalence ¬¬φ ↔ φ. This is the bookkeeping needed to phrase the characterization in terms of T ∪ {φ} rather than the syntactic ¬¬φ produced by the Completeness Theorem.",
       "Independent.satisfiable_insert_not and Independent.satisfiable_insert: independence yields two genuinely different model classes — a model of T refuting φ (T ∪ {¬φ} satisfiable) and a model of T satisfying φ (T ∪ {φ} satisfiable). These are the two 'witnesses' that make φ undecidable in T.",
       "independent_iff_satisfiable_both: φ is independent of T iff both T ∪ {¬φ} and T ∪ {φ} are satisfiable — the clean model-theoretic characterization of independence, obtained from the Completeness Theorem plus the double-negation bridge.",
-      "isComplete_iff_forall_not_independent: for a satisfiable theory T, T.IsComplete ↔ ∀ φ, ¬ Independent T φ. Packages the contrapositive of not_isComplete as an equivalence, exhibiting completeness as exactly the absence of independent sentences."
+      "isComplete_iff_forall_not_independent: for a satisfiable theory T, T.IsComplete ↔ ∀ φ, ¬ Independent T φ. Packages the contrapositive of not_isComplete as an equivalence, exhibiting completeness as exactly the absence of independent sentences.",
+      "Independent.exists_isComplete_extensions: an independent sentence φ splits T into two disagreeing completions — there exist complete theories T₁,T₂ ⊇ T with T₁ ⊨ᵇ φ, T₂ ⊨ᵇ ¬φ, and T₁ ≠ T₂. Built constructively (no Zorn/Lindenbaum) as the complete theories Th(M), Th(N) of explicit models of the satisfiable extensions T ∪ {φ} and T ∪ {¬φ}, using that the complete theory of a model is automatically maximal (completeTheory.isComplete). This is the converse face of not_isComplete: completeness is the absence of independent sentences, and independence is exactly the existence of two completions that split on φ."
     ],
     "prerequisites": [
       "godel-incompleteness (parent: the conceptual incompleteness theorems and the placeholder this entry replaces with real model theory)",
@@ -79,7 +80,7 @@
     ],
     "namespace": "GodelIncompletenessOQ03",
     "lineCount": 193,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "axiomCount": 0,
     "definitionCount": 1,
     "sorries": 0,


### PR DESCRIPTION
## Summary

Extends the abstract independence framework `godel-incompleteness-oq-03` with one new fully-verified theorem completing the model-theoretic picture of independence.

**`Independent.exists_isComplete_extensions`** — an independent sentence `φ` *splits `T` into two disagreeing completions*: there exist **complete** theories `T₁, T₂ ⊇ T` with `T₁ ⊨ᵇ φ`, `T₂ ⊨ᵇ ¬φ`, and `T₁ ≠ T₂`.

### Why this matters

The file already had `Independent.not_isComplete` (independence ⇒ incompleteness) and `isComplete_iff_forall_not_independent` (completeness = no independent sentence). This new theorem supplies the **converse, constructive face**: independence is *exactly* the existence of two maximal-consistent extensions of `T` that sit on opposite sides of `φ`. That is the genuine model-theoretic substance of "`φ` is undecided."

### How

- From `independent_iff_satisfiable_both`, both `T ∪ {φ}` and `T ∪ {¬φ}` are satisfiable, so each has an explicit model `M`, `N`.
- The completions are realised **constructively** as `Th(M) = L.completeTheory M` and `Th(N)` — no Zorn / Lindenbaum. Mathlib's `completeTheory.isComplete` gives that the complete theory of any model is automatically maximal (hence complete); `completeTheory.subset` gives `T ⊆ Th(M)`.
- Distinctness: `Th(M) ⊨ φ` while `Th(N) ⊨ ¬φ`; if they were equal the complete (hence consistent) theory `Th(M)` would entail both `φ` and `¬φ`, contradicting `IsComplete.models_not_iff`.

### Verification

- Offline-verified against Mathlib v4.26.0: `lake env lean` **EXIT 0** (docker build path is down; used cached oleans).
- `#print axioms Independent.exists_isComplete_extensions` → `{propext, Classical.choice, Quot.sound}` only. **0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.** Entry remains `verified` / `original`.

File grows 14 → 15 declarations (one new theorem); meta counts updated.