### PR TITLE
research(bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01): Lamé's sharp golden-ratio bound ⌊log_φ b⌋ + O(1) [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ03OQ01.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ03OQ01.lean
@@ -1,0 +1,216 @@
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.NumberTheory.Real.GoldenRatio
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+import Mathlib.Tactic
+
+/-
+# Sharpening Lamé's Bound to the Golden-Ratio Constant
+
+## Open Question Origin
+
+From `bezout-identity-oq-02-oq-02-oq-01-oq-03`
+("Lamé's Theorem: Θ(log) Complexity of the Extended Euclidean Algorithm"),
+open question 1:
+
+  "Sharpen to the exact golden-ratio constant ⌊log_φ b⌋ + O(1)."
+
+## What the parent entry already proved
+
+The parent counts division steps with `steps a b` and gives:
+
+* an upper bound `steps a b ≤ 2 log₂ b + 2` (the `O(log)` direction), and
+* a worst-case family `steps (fib (n+2)) (fib (n+1)) = n` showing the bound
+  is attained (the `Ω(log)` direction).
+
+Together these pin the step count to `Θ(log b)` — but only up to the constant
+`2` in front of `log₂`, i.e. the *base* of the logarithm is not yet sharp.
+
+## What this entry adds: the sharp constant
+
+The genuinely sharp statement of Lamé's theorem is a *lower bound on the input*:
+to force `n` division steps the smaller argument must be at least the
+`(n+2)`-nd Fibonacci number.
+
+* **`lame_fib_lower`** : `n + 1 ≤ steps a b → fib (n + 2) ≤ b`.
+
+This is the converse direction missing from the parent (which only exhibited
+*one* worst-case family). Because the Fibonacci numbers grow like `φⁿ`
+(`φ = (1+√5)/2` the golden ratio), it converts directly into the exact
+golden-ratio constant:
+
+* **`golden_pow_le_fib`** : `φ ^ n ≤ fib (n + 2)`  (a clean real inequality), and
+* **`steps_le_logb_golden`** : `steps a b ≤ log_φ b + 1`  for `b ≥ 1`.
+
+The last line is exactly the `⌊log_φ b⌋ + O(1)` bound the open question asked
+for: the number of Euclidean division steps never exceeds the base-`φ`
+logarithm of the smaller input, plus one. Since the Fibonacci family attains
+`steps (fib (n+2)) (fib (n+1)) = n` with `fib (n+1) ≤ φⁿ`, the constant `1`
+in front of `log_φ` is optimal — no logarithm to a larger base can bound the
+step count.
+
+Zero axioms, zero sorries. The step counter `steps` and its one-step unfolding
+lemmas are reproduced here (mirroring the parent entry) so this file verifies
+standalone.
+-/
+
+namespace BezoutIdentityOQ02OQ02OQ01OQ03OQ01
+
+open scoped goldenRatio
+
+/-
+## Part 0: The step counter (mirrored from the parent entry)
+
+`steps a b` counts the division steps of the extended Euclidean algorithm,
+whose recursion `(a, b+1) ↦ (b+1, a % (b+1))` it follows exactly.
+-/
+
+/-- Number of division steps the extended Euclidean algorithm performs on
+    `(a, b)`. Identical to the parent entry's `steps`. -/
+def steps : ℕ → ℕ → ℕ
+  | _, 0 => 0
+  | a, b + 1 =>
+    have : a % (b + 1) < b + 1 := Nat.mod_lt a (Nat.succ_pos b)
+    steps (b + 1) (a % (b + 1)) + 1
+
+@[simp] theorem steps_zero (a : ℕ) : steps a 0 = 0 := by simp [steps]
+
+theorem steps_succ (a b : ℕ) :
+    steps a (b + 1) = steps (b + 1) (a % (b + 1)) + 1 := by
+  simp [steps]
+
+/-- One-step unfolding for any positive second argument. -/
+theorem steps_pos (a b : ℕ) (hb : 0 < b) :
+    steps a b = steps b (a % b) + 1 := by
+  obtain ⟨c, rfl⟩ : ∃ c, b = c + 1 := ⟨b - 1, by omega⟩
+  exact steps_succ a c
+
+/-
+## Part I: Lamé's input lower bound (the sharp form)
+
+`steps a b ≥ n + 1` forces `b ≥ fib (n + 2)`. The proof is the natural
+two-step induction matching the Fibonacci recurrence: peeling off two Euclidean
+steps `a → b → (a % b) → (b % (a % b))` exposes two remainders bounded below by
+`fib (n + 1)` and `fib n`, and `b` is at least their sum.
+-/
+
+/-- **Lamé's theorem, sharp form.** If the Euclidean algorithm on `(a, b)`
+    performs at least `n + 1` division steps, then the smaller input satisfies
+    `fib (n + 2) ≤ b`. Equivalently: the worst case (smallest `b` for a given
+    step count) is exactly consecutive Fibonacci numbers, matching
+    `steps_fib` from the parent entry. -/
+theorem lame_fib_lower : ∀ n a b, n + 1 ≤ steps a b → Nat.fib (n + 2) ≤ b := by
+  intro n
+  induction n using Nat.twoStepInduction with
+  | zero =>
+    intro a b h
+    rcases Nat.eq_zero_or_pos b with h0 | h0
+    · subst h0; rw [steps_zero] at h; omega
+    · have hf : Nat.fib (0 + 2) = 1 := by decide
+      omega
+  | one =>
+    intro a b h
+    rcases Nat.eq_zero_or_pos b with h0 | h0
+    · subst h0; rw [steps_zero] at h; omega
+    · rw [steps_pos a b h0] at h
+      have hr : 0 < a % b := by
+        rcases Nat.eq_zero_or_pos (a % b) with hr0 | hr0
+        · rw [hr0, steps_zero] at h; omega
+        · exact hr0
+      have hlt : a % b < b := Nat.mod_lt a h0
+      have hf : Nat.fib (1 + 2) = 2 := by decide
+      omega
+  | more n ih1 ih2 =>
+    intro a b h
+    have hb : 0 < b := by
+      rcases Nat.eq_zero_or_pos b with h0 | h0
+      · subst h0; rw [steps_zero] at h; omega
+      · exact h0
+    rw [steps_pos a b hb] at h
+    set r := a % b with hr_def
+    have hrb : r < b := Nat.mod_lt a hb
+    have hsteps_br : n + 2 ≤ steps b r := by omega
+    have hfr : Nat.fib (n + 3) ≤ r := ih2 b r (by omega)
+    have hr_pos : 0 < r := by
+      rcases Nat.eq_zero_or_pos r with h0 | h0
+      · rw [h0, steps_zero] at hsteps_br; omega
+      · exact h0
+    rw [steps_pos b r hr_pos] at hsteps_br
+    set s := b % r with hs_def
+    have hsteps_rs : n + 1 ≤ steps r s := by omega
+    have hfs : Nat.fib (n + 2) ≤ s := ih1 r s (by omega)
+    have hdm : r * (b / r) + b % r = b := Nat.div_add_mod b r
+    have hdivpos : 1 ≤ b / r := (Nat.one_le_div_iff hr_pos).mpr (le_of_lt hrb)
+    have hge : r ≤ r * (b / r) := le_mul_of_one_le_right (Nat.zero_le r) hdivpos
+    have hfibsum : Nat.fib (n + 2 + 2) = Nat.fib (n + 2) + Nat.fib (n + 3) :=
+      Nat.fib_add_two
+    omega
+
+/-
+## Part II: Fibonacci numbers dominate powers of the golden ratio
+
+`φ ^ n ≤ fib (n + 2)`. A two-step induction using the defining relations
+`φ² = φ + 1` and `fib (n+4) = fib (n+2) + fib (n+3)`: the golden ratio and the
+Fibonacci sequence satisfy the *same* second-order recurrence, and the base
+cases `φ⁰ = 1 = fib 2`, `φ¹ = φ < 2 = fib 3` start the dominance.
+-/
+
+/-- **The golden ratio is the growth rate of Fibonacci.** For every `n`,
+    `φ ^ n ≤ fib (n + 2)`. This is the bridge that turns the integer worst-case
+    bound `lame_fib_lower` into an explicit base-`φ` logarithm. -/
+theorem golden_pow_le_fib (n : ℕ) :
+    Real.goldenRatio ^ n ≤ (Nat.fib (n + 2) : ℝ) := by
+  induction n using Nat.twoStepInduction with
+  | zero =>
+    have hf : Nat.fib (0 + 2) = 1 := by decide
+    rw [hf]; norm_num
+  | one =>
+    have hf : Nat.fib (1 + 2) = 2 := by decide
+    rw [hf, pow_one]; push_cast; linarith [Real.goldenRatio_lt_two]
+  | more n ih1 ih2 =>
+    have hnat : Nat.fib (n + 2 + 2) = Nat.fib (n + 2) + Nat.fib (n + 3) :=
+      Nat.fib_add_two
+    have hfib : (Nat.fib (n + 2 + 2) : ℝ)
+        = (Nat.fib (n + 2) : ℝ) + (Nat.fib (n + 3) : ℝ) := by exact_mod_cast hnat
+    have hexp : Real.goldenRatio ^ (n + 2)
+        = Real.goldenRatio ^ (n + 1) + Real.goldenRatio ^ n := by
+      have h1 : Real.goldenRatio ^ (n + 2)
+          = Real.goldenRatio ^ n * Real.goldenRatio ^ 2 := by rw [← pow_add]
+      rw [h1, Real.goldenRatio_sq]; ring
+    rw [hexp, hfib]
+    linarith [ih1, ih2]
+
+/-
+## Part III: The exact golden-ratio bound (answering the open question)
+
+Combining Parts I and II: `steps a b ≤ log_φ b + 1`. The number of Euclidean
+division steps never exceeds the base-`φ` logarithm of the smaller input plus
+one — the sharp `⌊log_φ b⌋ + O(1)` form Lamé's theorem is famous for.
+-/
+
+/-- **Lamé's theorem with the sharp golden-ratio constant.** For `b ≥ 1` the
+    extended Euclidean algorithm performs at most `log_φ b + 1` division steps,
+    where `φ = (1 + √5)/2`. Because `fib (n+1) ≤ φⁿ`, the worst-case Fibonacci
+    family `steps (fib (n+2)) (fib (n+1)) = n` shows the base `φ` cannot be
+    enlarged: this is the exact `⌊log_φ b⌋ + O(1)` characterization. -/
+theorem steps_le_logb_golden (a b : ℕ) (hb : 1 ≤ b) :
+    (steps a b : ℝ) ≤ Real.logb Real.goldenRatio b + 1 := by
+  have hk1 : 1 ≤ steps a b := by
+    obtain ⟨b', rfl⟩ : ∃ b', b = b' + 1 := ⟨b - 1, by omega⟩
+    rw [steps_succ]; omega
+  set k := steps a b with hk
+  obtain ⟨n, hn⟩ : ∃ n, k = n + 1 := ⟨k - 1, by omega⟩
+  have hfib : Nat.fib (n + 2) ≤ b := lame_fib_lower n a b (by omega)
+  have hgolden : Real.goldenRatio ^ n ≤ (b : ℝ) :=
+    le_trans (golden_pow_le_fib n) (by exact_mod_cast hfib)
+  have hxpos : (0 : ℝ) < Real.goldenRatio ^ n := pow_pos Real.goldenRatio_pos n
+  have hmono : Real.logb Real.goldenRatio (Real.goldenRatio ^ n)
+      ≤ Real.logb Real.goldenRatio b :=
+    Real.logb_le_logb_of_le Real.one_lt_goldenRatio hxpos hgolden
+  have hval : Real.logb Real.goldenRatio (Real.goldenRatio ^ n) = (n : ℝ) := by
+    rw [Real.logb_pow, Real.logb_self_eq_one Real.one_lt_goldenRatio, mul_one]
+  rw [hval] at hmono
+  have hcast : (k : ℝ) = (n : ℝ) + 1 := by rw [hn]; push_cast; ring
+  rw [hcast]; linarith [hmono]
+
+end BezoutIdentityOQ02OQ02OQ01OQ03OQ01

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+  "title": "Lamé's Theorem, Sharp: the Golden-Ratio Constant ⌊log_φ b⌋ + O(1)",
+  "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+  "description": "Answers open question 1 of the Lamé Θ(log) entry: sharpen the Euclidean-algorithm step bound to the exact golden-ratio constant ⌊log_φ b⌋ + O(1). The parent proved Θ(log) but only up to the base of the logarithm (a factor 2 in front of log₂). This entry supplies the missing sharp half — Lamé's theorem in its true form, a lower bound on the input: if the algorithm performs at least n+1 division steps then the smaller argument satisfies fib(n+2) ≤ b (lame_fib_lower), proved by a two-step induction matching the Fibonacci recurrence. Bridging through golden_pow_le_fib (φⁿ ≤ fib(n+2), since φ and the Fibonacci sequence obey the same recurrence φ² = φ + 1) yields the headline steps_le_logb_golden: for b ≥ 1 the algorithm performs at most log_φ b + 1 steps. Because the Fibonacci worst case attains steps = n with fib(n+1) ≤ φⁿ, the base φ is optimal — exactly the ⌊log_φ b⌋ + O(1) characterization. 0 axioms, 0 sorries.",
+  "leanFile": {
+    "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ03OQ01.lean",
+    "namespace": "BezoutIdentityOQ02OQ02OQ01OQ03OQ01",
+    "imports": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.NumberTheory.Real.GoldenRatio",
+      "Mathlib.Analysis.SpecialFunctions.Log.Base",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["goldenRatio (scoped)"],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 216,
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "openQuestion": {
+    "id": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+    "parentId": "bezout-identity-oq-02-oq-02-oq-01-oq-03",
+    "question": "Can Lamé's Θ(log) step bound be sharpened to the exact golden-ratio constant ⌊log_φ b⌋ + O(1)?",
+    "answer": "Yes. The parent entry pinned the Euclidean step count to Θ(log b) but only up to the base of the logarithm. The sharp form of Lamé's theorem is a lower bound on the input: to force n+1 division steps the smaller argument must satisfy fib(n+2) ≤ b. This entry proves exactly that (lame_fib_lower) by the two-step induction matching the Fibonacci recurrence — the converse direction the parent lacked, having exhibited only one worst-case family. Since the golden ratio φ = (1+√5)/2 and the Fibonacci sequence satisfy the same second-order recurrence (φ² = φ + 1), one gets φⁿ ≤ fib(n+2) (golden_pow_le_fib), and combining the two yields steps a b ≤ log_φ b + 1 for b ≥ 1 (steps_le_logb_golden). The Fibonacci worst case steps (fib (n+2)) (fib (n+1)) = n with fib(n+1) ≤ φⁿ shows the base φ cannot be enlarged: this is the exact ⌊log_φ b⌋ + O(1) characterization. 0 axioms, 0 sorries."
+  },
+  "highlights": [
+    "Sharp Lamé lower bound: n+1 ≤ steps a b → fib(n+2) ≤ b — the worst case is exactly Fibonacci (lame_fib_lower)",
+    "Two-step induction matching the Fibonacci recurrence: peel off two Euclidean steps a → b → a%b → b%(a%b) and bound b below by the sum of two Fibonacci numbers",
+    "Golden-ratio growth: φⁿ ≤ fib(n+2), because φ and Fibonacci obey the same recurrence φ² = φ + 1 (golden_pow_le_fib)",
+    "Headline: steps a b ≤ log_φ b + 1 for b ≥ 1 — the exact ⌊log_φ b⌋ + O(1) bound (steps_le_logb_golden)",
+    "Optimality of the base: the Fibonacci family with fib(n+1) ≤ φⁿ forbids any larger logarithm base, so φ is sharp"
+  ],
+  "implications": [
+    {
+      "statement": "n + 1 ≤ steps a b → Nat.fib (n + 2) ≤ b (Lamé's sharp input lower bound)",
+      "type": "theorem"
+    },
+    {
+      "statement": "Real.goldenRatio ^ n ≤ (Nat.fib (n + 2) : ℝ) (golden ratio is the Fibonacci growth rate)",
+      "type": "theorem"
+    },
+    {
+      "statement": "(steps a b : ℝ) ≤ Real.logb Real.goldenRatio b + 1 for b ≥ 1 (sharp ⌊log_φ b⌋ + O(1) bound)",
+      "type": "theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Gabriel Lamé's 1844 analysis of the Euclidean algorithm is celebrated for two reasons: it was the first running-time bound proved for any algorithm, and it is sharp — the bound it gives is attained, on the nose, by consecutive Fibonacci numbers. The sharpness is what produces the famous golden-ratio constant: the algorithm on inputs of size b takes at most about log_φ b steps, where φ = (1+√5)/2 ≈ 1.618, and the Fibonacci inputs realize this. The parent entry formalized the Θ(log) shape of the bound but left the exact base of the logarithm — the heart of Lamé's result — as an open question. This entry closes it.",
+    "problemStatement": "The parent (bezout-identity-oq-02-oq-02-oq-01-oq-03) proved steps a b ≤ 2⌊log₂ b⌋ + 2 and exhibited the Fibonacci worst case steps (fib (n+2)) (fib (n+1)) = n, but did not prove the matching input lower bound that fixes the logarithm base. Open question 1 asks: can the bound be sharpened to the exact golden-ratio constant ⌊log_φ b⌋ + O(1)?",
+    "proofStrategy": "Prove the sharp form of Lamé's theorem as a lower bound on the input, lame_fib_lower: n+1 ≤ steps a b → fib(n+2) ≤ b, by Nat.twoStepInduction mirroring the Fibonacci recurrence — two Euclidean steps expose remainders r = a%b ≥ fib(n+3) and s = b%r ≥ fib(n+2), and b ≥ r + s ≥ fib(n+4). Then prove golden_pow_le_fib: φⁿ ≤ fib(n+2) by a parallel two-step induction using φ² = φ + 1 (the golden ratio and Fibonacci share the same recurrence). Compose them and take base-φ logarithms (monotonicity of Real.logb for base > 1, with logb φ (φⁿ) = n) to obtain steps_le_logb_golden: steps a b ≤ log_φ b + 1.",
+    "keyInsights": [
+      "Lamé's theorem is fundamentally a statement about minimal inputs: the smallest b that forces n steps is a Fibonacci number, not a halving-style bound.",
+      "The golden ratio enters because φ and the Fibonacci sequence are the two canonical solutions of the same linear recurrence xₙ₊₂ = xₙ₊₁ + xₙ; the identity φ² = φ + 1 is all that is needed to compare them.",
+      "Sharpening from 'base 2' to 'base φ' is exactly the content the parent's halving argument cannot see — it requires the converse (input lower) bound, not the forward (step upper) bound."
+    ],
+    "prerequisites": [
+      "The Euclidean algorithm and its remainder recurrence a % b",
+      "Fibonacci numbers and the recurrence fib(n+2) = fib(n) + fib(n+1)",
+      "The golden ratio φ = (1+√5)/2 and φ² = φ + 1",
+      "Base-b logarithm Real.logb and its monotonicity for base > 1"
+    ]
+  },
+  "sections": [
+    {
+      "id": "step-counter",
+      "title": "Step Counter (mirrored from the parent)",
+      "startLine": 61,
+      "endLine": 86,
+      "summary": "Reproduces the parent's steps : ℕ → ℕ → ℕ and the one-step unfolding lemmas steps_zero, steps_succ, steps_pos, so the file verifies standalone.",
+      "mathContext": "steps a b counts the division steps of the extended Euclidean algorithm whose recursion (a, b+1) ↦ (b+1, a % (b+1)) it follows exactly."
+    },
+    {
+      "id": "lame-lower",
+      "title": "Lamé's Sharp Input Lower Bound",
+      "startLine": 88,
+      "endLine": 147,
+      "summary": "lame_fib_lower: n+1 ≤ steps a b → fib(n+2) ≤ b, by Nat.twoStepInduction. Peeling two Euclidean steps gives remainders bounded below by fib(n+3) and fib(n+2), whose sum bounds b.",
+      "mathContext": "This is the genuinely sharp form of Lamé's theorem — the converse of the parent's worst-case family — and it is what fixes the base of the logarithm."
+    },
+    {
+      "id": "golden-growth",
+      "title": "Golden Ratio Dominates by Fibonacci",
+      "startLine": 149,
+      "endLine": 181,
+      "summary": "golden_pow_le_fib: φⁿ ≤ fib(n+2), by a two-step induction using φ² = φ + 1 and the Fibonacci recurrence, with base cases φ⁰ = 1 = fib 2 and φ¹ = φ < 2 = fib 3.",
+      "mathContext": "φ and Fibonacci solve the same recurrence; this inequality is the bridge from the integer worst case to an explicit base-φ logarithm."
+    },
+    {
+      "id": "sharp-bound",
+      "title": "The Exact Golden-Ratio Bound",
+      "startLine": 183,
+      "endLine": 214,
+      "summary": "steps_le_logb_golden: for b ≥ 1, steps a b ≤ log_φ b + 1. Combine lame_fib_lower and golden_pow_le_fib so φ^(steps−1) ≤ b, then take base-φ logs.",
+      "mathContext": "This is the ⌊log_φ b⌋ + O(1) bound the open question asked for; the Fibonacci worst case shows the base φ is optimal."
+    }
+  ],
+  "conclusion": {
+    "summary": "Open question 1 of the Lamé entry is resolved: the Euclidean-algorithm step count is bounded by log_φ b + 1 for b ≥ 1, the exact golden-ratio constant. The sharp ingredient is lame_fib_lower (n+1 ≤ steps a b → fib(n+2) ≤ b), the input lower bound that the parent's halving argument could not produce; the bridge golden_pow_le_fib (φⁿ ≤ fib(n+2)) carries it to the logarithm. 0 axioms, 0 sorries.",
+    "implications": "Together with the parent's upper bound and Fibonacci worst case, this gives Lamé's theorem in full: steps a b ≤ log_φ b + 1, with the constant 1 in front of log_φ optimal because the Fibonacci family attains it. It sharpens the parent's Θ(log) characterization from 'logarithmic up to a constant factor' to 'logarithmic with the correct base φ'.",
+    "openQuestions": [
+      "Determine the exact additive constant: is steps a b ≤ ⌊log_φ b⌋ + 1 with the floor, or can the +1 be tightened on specific residue classes?",
+      "Bound the total bit-complexity, not just the step count (the second open question of the parent entry)",
+      "Formalize the average-case (12 ln 2 / π²)·log b analysis (the third open question of the parent entry)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-02-oq-01-oq-03",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-02-oq-01",
+      "relationship": "related"
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-27",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ03OQ01.lean",
+    "tags": [
+      "euclidean-algorithm",
+      "complexity",
+      "lame-theorem",
+      "fibonacci",
+      "golden-ratio",
+      "logarithm",
+      "bezout-identity",
+      "open-question"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 216,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "lame_fib_lower: the sharp form of Lamé's theorem — n+1 ≤ steps a b → fib(n+2) ≤ b — the input lower bound (converse worst-case direction) the parent lacked, by Nat.twoStepInduction",
+      "golden_pow_le_fib: φⁿ ≤ fib(n+2), the golden-ratio/Fibonacci growth comparison from the shared recurrence φ² = φ + 1",
+      "steps_le_logb_golden: the headline steps a b ≤ log_φ b + 1 for b ≥ 1 — the exact ⌊log_φ b⌋ + O(1) characterization",
+      "Self-contained reproduction of the step counter (steps, steps_zero/steps_succ/steps_pos) so the entry verifies standalone"
+    ],
+    "proofStrategy": "Prove Lamé's input lower bound lame_fib_lower by two-step induction mirroring the Fibonacci recurrence, then prove φⁿ ≤ fib(n+2) by the parallel two-step induction using φ² = φ + 1, and compose them with base-φ logarithm monotonicity to obtain steps a b ≤ log_φ b + 1.",
+    "openQuestions": [
+      "Determine the exact additive constant in ⌊log_φ b⌋ + O(1)",
+      "Bound the total bit-complexity, not just the step count",
+      "Formalize the average-case (12 ln 2 / π²)·log b analysis"
+    ],
+    "sections": [
+      {
+        "title": "Step Counter (mirrored)",
+        "content": "steps definition with steps_zero/steps_succ/steps_pos unfolding lemmas, reproduced so the file is standalone.",
+        "startLine": 61,
+        "endLine": 86,
+        "theorems": ["steps_zero", "steps_succ", "steps_pos"]
+      },
+      {
+        "title": "Lamé's Sharp Input Lower Bound",
+        "content": "lame_fib_lower: n+1 ≤ steps a b → fib(n+2) ≤ b, by Nat.twoStepInduction matching the Fibonacci recurrence.",
+        "startLine": 88,
+        "endLine": 147,
+        "theorems": ["lame_fib_lower"]
+      },
+      {
+        "title": "Golden Ratio / Fibonacci Growth",
+        "content": "golden_pow_le_fib: φⁿ ≤ fib(n+2), two-step induction using φ² = φ + 1.",
+        "startLine": 149,
+        "endLine": 181,
+        "theorems": ["golden_pow_le_fib"]
+      },
+      {
+        "title": "The Exact Golden-Ratio Bound",
+        "content": "steps_le_logb_golden: steps a b ≤ log_φ b + 1 for b ≥ 1, the sharp ⌊log_φ b⌋ + O(1) characterization.",
+        "startLine": 183,
+        "endLine": 214,
+        "theorems": ["steps_le_logb_golden"]
+      }
+    ],
+    "mathContext": {
+      "field": "Analysis of Algorithms / Number Theory",
+      "keyTheorem": "The extended Euclidean algorithm performs at most log_φ b + 1 division steps for b ≥ 1, where φ = (1+√5)/2; the bound is sharp because the Fibonacci worst case steps (fib (n+2)) (fib (n+1)) = n with fib(n+1) ≤ φⁿ forbids any larger logarithm base.",
+      "historicalBackground": "Gabriel Lamé (1844) gave the first running-time analysis of any algorithm. Its sharpness — Fibonacci numbers as the extremal inputs — is what produces the golden-ratio constant log_φ that this entry formalizes."
+    }
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question 1** of `bezout-identity-oq-02-oq-02-oq-01-oq-03` ("Lamé's Theorem: Θ(log) Complexity of the Extended Euclidean Algorithm"):

> *Sharpen to the exact golden-ratio constant ⌊log_φ b⌋ + O(1).*

The parent proved the step count is `Θ(log b)` but only up to the **base** of the logarithm (a factor 2 in front of `log₂`). The missing piece — the heart of Lamé's 1844 theorem — is a **lower bound on the input**, which this entry supplies.

## New theorems (file `Proofs/BezoutIdentityOQ02OQ02OQ01OQ03OQ01.lean`)

| Theorem | Statement |
|---|---|
| `lame_fib_lower` | `n + 1 ≤ steps a b → Nat.fib (n + 2) ≤ b` — Lamé's sharp form (input lower bound) |
| `golden_pow_le_fib` | `φ ^ n ≤ (Nat.fib (n + 2) : ℝ)` — golden ratio is the Fibonacci growth rate |
| `steps_le_logb_golden` | `(steps a b : ℝ) ≤ Real.logb φ b + 1` for `b ≥ 1` — the **⌊log_φ b⌋ + O(1)** bound |

**Proof idea.** `lame_fib_lower` is a two-step induction (`Nat.twoStepInduction`) matching the Fibonacci recurrence: peeling two Euclidean steps `a → b → a%b → b%(a%b)` exposes remainders `r = a%b ≥ fib(n+3)` and `s = b%r ≥ fib(n+2)`, and `b ≥ r + s ≥ fib(n+4)`. Since `φ` and Fibonacci solve the same recurrence (`φ² = φ + 1`), `golden_pow_le_fib` follows by a parallel induction; composing and taking base-`φ` logarithms gives `steps_le_logb_golden`. The Fibonacci worst case (`steps (fib (n+2)) (fib (n+1)) = n` with `fib(n+1) ≤ φⁿ`, from the parent) shows the base `φ` is **optimal**.

## Verification

- Offline `lake env lean` (docker unavailable): **EXIT 0**, 0 errors, 0 warnings, 0 sorries.
- `#print axioms` on all three theorems: `{propext, Classical.choice, Quot.sound}` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Status: **verified**, badge **original**, `axiomCount: 0`.

The step counter `steps` and its unfolding lemmas are reproduced in-file (mirroring the parent) so the entry verifies standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)