### PR TITLE
Enrich Erdős #396 OQ-04→OQ-01→OQ-01→OQ-02 (3/2 critical exponent)

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/annotations.json
@@ -9,7 +9,18 @@
     "type": "key-step",
     "title": "The 3/2 appears in one normalised step",
     "content": "Dividing the parent's ratio identity $r\\,k = 4 - 6/(k+2)$ by the limiting rate $4$ gives $r\\,k/4 = 1 - (3/2)/(k+2)$ — a single $\\texttt{ring}$ rewrite. The coefficient $3/2$ of the harmonic correction is *exactly* the critical exponent of the Catalan asymptotic $\\text{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt{\\pi})$, exposed here before any summation or limit.",
-    "mathContext": "$\\dfrac{r\\,k}{4} = \\dfrac{1}{4}\\left(4 - \\dfrac{6}{k+2}\\right) = 1 - \\dfrac{3/2}{k+2}$."
+    "mathContext": "$\\dfrac{r\\,k}{4} = \\dfrac{1}{4}\\left(4 - \\dfrac{6}{k+2}\\right) = 1 - \\dfrac{3/2}{k+2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "critical exponent",
+      "Catalan recurrence ratio",
+      "normalisation by limiting rate",
+      "harmonic correction term"
+    ],
+    "prerequisites": [
+      "parent ratio identity r n = 4 − 6/(n+2)",
+      "the ring tactic"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-logle",
@@ -21,7 +32,18 @@
     "type": "key-step",
     "title": "Elementary log bound on each step",
     "content": "The single Mathlib inequality $\\log y \\le y - 1$ (valid for $y > 0$) at $y = r\\,k/4$ gives $\\log(r\\,k/4) \\le r\\,k/4 - 1 = -(3/2)/(k+2)$ — exactly a quarter of the parent's deficit $\\delta\\,k = 6/(k+2)$. This is the only analytic ingredient; everything downstream is summation and exponentiation.",
-    "mathContext": "$\\log\\frac{r\\,k}{4} \\le \\frac{r\\,k}{4} - 1 = -\\frac{3/2}{k+2} = -\\frac{1}{4}\\,\\delta\\,k.$"
+    "mathContext": "$\\log\\frac{r\\,k}{4} \\le \\frac{r\\,k}{4} - 1 = -\\frac{3/2}{k+2} = -\\frac{1}{4}\\,\\delta\\,k.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.log_le_sub_one_of_pos",
+      "tangent-line bound for log",
+      "harmonic deficit δ k = 6/(k+2)",
+      "per-step estimate"
+    ],
+    "prerequisites": [
+      "the inequality log y ≤ y − 1 for y > 0",
+      "positivity of the normalised step"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-logge",
@@ -33,7 +55,18 @@
     "type": "observation",
     "title": "Reciprocal gives a matching lower bound",
     "content": "Applying the *same* inequality to $(r\\,k/4)^{-1} = 4/r\\,k$ and using $\\log(x^{-1}) = -\\log x$ yields $\\log(r\\,k/4) \\ge -3/(2k+1)$. Both bounds carry leading coefficient $3/2$, so the exponent is pinned from both sides — it is intrinsic to the recurrence, not an artefact of one estimate.",
-    "mathContext": "$-\\log\\frac{r\\,k}{4} = \\log\\frac{4}{r\\,k} \\le \\frac{4}{r\\,k} - 1 = \\frac{3}{2k+1}.$"
+    "mathContext": "$-\\log\\frac{r\\,k}{4} = \\log\\frac{4}{r\\,k} \\le \\frac{4}{r\\,k} - 1 = \\frac{3}{2k+1}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.log_inv",
+      "reciprocal estimate",
+      "two-sided bound",
+      "field_simp normalisation"
+    ],
+    "prerequisites": [
+      "log(x⁻¹) = −log x",
+      "applying log y ≤ y − 1 to the reciprocal"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-telescope",
@@ -45,7 +78,18 @@
     "type": "key-step",
     "title": "Telescoping through the logarithm",
     "content": "Because each Catalan step multiplies by $r\\,m$, normalising by $4$ at every step makes the product collapse: $\\log(\\text{catalan}\\,n/4^n) = \\sum_{k<n} \\log(r\\,k/4)$. The induction's successor step factors $\\text{catalan}(m{+}1)/4^{m+1} = (r\\,m/4)\\cdot(\\text{catalan}\\,m/4^m)$ and splits the logarithm with $\\texttt{Real.log\\_mul}$ (both factors positive). This exact finite identity is the bridge from the integer recurrence to the asymptotic.",
-    "mathContext": "$\\log\\frac{\\text{catalan}\\,n}{4^n} = \\sum_{k=0}^{n-1} \\log\\frac{r\\,k}{4}.$"
+    "mathContext": "$\\log\\frac{\\text{catalan}\\,n}{4^n} = \\sum_{k=0}^{n-1} \\log\\frac{r\\,k}{4}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping product",
+      "Real.log_mul",
+      "induction on n",
+      "Finset.sum_range_succ"
+    ],
+    "prerequisites": [
+      "catalan(n+1) = r n · catalan n",
+      "log of a product splits over positive factors"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-normlogle",
@@ -57,7 +101,18 @@
     "type": "key-step",
     "title": "Summing to the harmonic deficit",
     "content": "Summing the per-step bound and recognising each comparison term $-(3/2)/(k+2)$ as $-(1/4)\\,\\delta\\,k$, the parent's deficit sum $\\sum_{k<n}\\delta\\,k = 6\\,(H_{n+1}-1)$ collapses the right-hand side to $-(3/2)\\,(H_{n+1}-1)$. The log of the normalised Catalan number is thus controlled by a harmonic number with the critical coefficient $3/2$.",
-    "mathContext": "$\\log\\frac{\\text{catalan}\\,n}{4^n} \\le \\sum_{k<n}\\left(-\\tfrac{1}{4}\\delta\\,k\\right) = -\\tfrac{3}{2}\\,(H_{n+1}-1).$"
+    "mathContext": "$\\log\\frac{\\text{catalan}\\,n}{4^n} \\le \\sum_{k<n}\\left(-\\tfrac{1}{4}\\delta\\,k\\right) = -\\tfrac{3}{2}\\,(H_{n+1}-1).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_le_sum",
+      "harmonic number H_{n+1}",
+      "parent deficit_sum_eq",
+      "Finset.mul_sum"
+    ],
+    "prerequisites": [
+      "termwise comparison of finite sums",
+      "the deficit running-sum 6·(H_{n+1} − 1)"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-headline",
@@ -69,7 +124,18 @@
     "type": "key-step",
     "title": "Headline: the 3/2-exponent decay bound",
     "content": "Exponentiating via $x = \\exp(\\log x)$ (for $x > 0$) and monotonicity of $\\exp$ gives the headline bound $\\text{catalan}\\,n / 4^n \\le \\exp\\!\\big(-(3/2)\\,(H_{n+1}-1)\\big)$. Since $H_{n+1}-1 \\sim \\log n$, the right side is $\\sim n^{-3/2}$: the recurrence alone forces the critical exponent $3/2$ of $\\text{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt\\pi)$, with no Stirling estimate.",
-    "mathContext": "$\\dfrac{\\text{catalan}\\,n}{4^n} \\le \\exp\\!\\Big(-\\tfrac{3}{2}(H_{n+1}-1)\\Big) \\sim n^{-3/2}.$"
+    "mathContext": "$\\dfrac{\\text{catalan}\\,n}{4^n} \\le \\exp\\!\\Big(-\\tfrac{3}{2}(H_{n+1}-1)\\Big) \\sim n^{-3/2}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.exp_log",
+      "monotonicity of exp",
+      "critical exponent 3/2",
+      "Catalan asymptotic"
+    ],
+    "prerequisites": [
+      "x = exp(log x) for x > 0",
+      "H_{n+1} − 1 ∼ log n"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-bracket",
@@ -81,7 +147,18 @@
     "type": "observation",
     "title": "Two-sided log bracket",
     "content": "Combining the per-step upper and lower bounds, the recurrence pins $\\log(\\text{catalan}\\,n/4^n)$ between $-\\sum_{k<n} 3/(2k+1)$ and $-(3/2)(H_{n+1}-1)$ — two harmonic-type sums both with leading coefficient $3/2$. The exponent $3/2$ is therefore forced from both directions.",
-    "mathContext": "$-\\sum_{k<n}\\frac{3}{2k+1} \\le \\log\\frac{\\text{catalan}\\,n}{4^n} \\le -\\frac{3}{2}(H_{n+1}-1).$"
+    "mathContext": "$-\\sum_{k<n}\\frac{3}{2k+1} \\le \\log\\frac{\\text{catalan}\\,n}{4^n} \\le -\\frac{3}{2}(H_{n+1}-1).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "two-sided estimate",
+      "harmonic-type sum",
+      "Finset.sum_neg_distrib",
+      "intrinsic exponent"
+    ],
+    "prerequisites": [
+      "the per-step upper and lower log bounds",
+      "the log-telescoping identity"
+    ]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02-squeeze",
@@ -93,6 +170,17 @@
     "type": "observation",
     "title": "Independent, rate-quantified vanishing",
     "content": "The bound $\\exp(-(3/2)(H_{n+1}-1)) \\to 0$ because the parent's harmonic deficit sum diverges. Squeezing $0 \\le \\text{catalan}\\,n/4^n \\le \\exp(-(3/2)(H_{n+1}-1))$ then proves $\\text{catalan}\\,n/4^n \\to 0$ — an independent proof of the vanishing, driven by harmonic divergence rather than Stirling, with the decay rate made explicit.",
-    "mathContext": "$0 \\le \\dfrac{\\text{catalan}\\,n}{4^n} \\le \\exp\\!\\Big(-\\tfrac{3}{2}(H_{n+1}-1)\\Big) \\to 0.$"
+    "mathContext": "$0 \\le \\dfrac{\\text{catalan}\\,n}{4^n} \\le \\exp\\!\\Big(-\\tfrac{3}{2}(H_{n+1}-1)\\Big) \\to 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "squeeze_zero",
+      "Real.tendsto_exp_atBot",
+      "harmonic divergence",
+      "explicit decay rate"
+    ],
+    "prerequisites": [
+      "the squeeze theorem for sequences",
+      "divergence of the harmonic series"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -48,6 +48,50 @@
       "Divergence of the harmonic series and the squeeze theorem for sequences"
     ]
   },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Docstring narrating the descent from the grandparent ratio identity r n = 4 − 6/(n+2) and the parent deficit δ n = 6/(n+2) to this entry's extraction of the critical exponent 3/2. Imports all of Mathlib and the parent Proofs.Erdos396OQ04OQ01OQ01, opening its namespaces to reuse catalanRatio, catalanDeficit, deficit_sum_eq and realHarmonic."
+    },
+    {
+      "id": "normalised-step",
+      "title": "§ The Normalised Step r k / 4 and Its Logarithm",
+      "startLine": 51,
+      "endLine": 90,
+      "summary": "ratioQuarter_eq rewrites the step as r k / 4 = 1 − (3/2)/(k+2) by ring, exposing the exponent 3/2; ratioQuarter_pos gives positivity. log_ratioQuarter_le applies Real.log_le_sub_one_of_pos to obtain log(r k/4) ≤ −(3/2)/(k+2), and log_ratioQuarter_ge applies the same inequality to the reciprocal (via Real.log_inv and field_simp) for the matching lower bound −3/(2k+1)."
+    },
+    {
+      "id": "telescoping",
+      "title": "§ Telescoping the Recurrence Through the Logarithm",
+      "startLine": 92,
+      "endLine": 114,
+      "summary": "normLog_eq_sum proves the exact identity log(catalan n / 4^n) = ∑_{k<n} log(r k/4) by induction: the successor step factors catalan(m+1)/4^(m+1) = (r m/4)·(catalan m/4^m) via catalan_succ_eq_ratio_mul and field_simp, then splits the logarithm with Real.log_mul since both factors are positive."
+    },
+    {
+      "id": "exponent-bound",
+      "title": "§ The 3/2-Exponent Bound",
+      "startLine": 116,
+      "endLine": 175,
+      "summary": "normLog_le sums the per-step bound and collapses the comparison sum to −(3/2)·(H_{n+1}−1) using the parent's deficit_sum_eq. catalan_div_le_exp exponentiates this (via Real.exp_log and Real.exp_le_exp) into the headline catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1}−1)); catalan_le_exp_mul is its multiplicative form; normLog_bracket adds the reciprocal lower bound, pinning the log between two harmonic-type sums both with coefficient 3/2."
+    },
+    {
+      "id": "convergence",
+      "title": "§ Independent Convergence with Explicit Rate",
+      "startLine": 177,
+      "endLine": 197,
+      "summary": "expBound_tendsto_zero shows exp(−(3/2)·(H_{n+1}−1)) → 0, driven by the divergence of the parent's harmonic deficit sum (realHarmonic_tendsto_atTop composed with const_mul_atTop_of_neg and tendsto_exp_atBot). catalan_div_tendsto_zero then squeezes 0 ≤ catalan n / 4^n ≤ exp(…) to conclude catalan n / 4^n → 0 independently of Stirling."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "§ Sanity Checks",
+      "startLine": 199,
+      "endLine": 213,
+      "summary": "Three example checks pinning down the constants: r 0 / 4 = 1/4, the per-step bound −(3/2)/(0+2) = −3/4 at k = 0, and the n = 1 instance −(3/2)·(H₂ − 1) = −3/4 (with H₂ = 1 + 1/2), confirming the bound is sharp at small indices."
+    }
+  ],
   "conclusion": {
     "summary": "Exponentiating the parent's harmonic deficit sum, the recurrence alone forces catalan n / 4^n ≤ exp(−(3/2)·(H_{n+1} − 1)), equivalently catalan n ≤ 4^n·exp(−(3/2)·(H_{n+1} − 1)). Since H_{n+1} − 1 ∼ log n the bound is ∼ n^{−3/2}, exhibiting the critical exponent 3/2 of catalan n ∼ 4^n/(n^{3/2}√π) at the level of the integer recurrence. A reciprocal estimate brackets log(catalan n / 4^n) between two harmonic-type sums both with coefficient 3/2, and a squeeze gives an independent proof that catalan n / 4^n → 0. All eleven theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The entry answers the upper-bound half of the parent's first open question: the polynomial factor below 4^n is not merely sub-exponential but carries the specific exponent 3/2, and that exponent is extracted by purely recurrence-level reasoning (one elementary logarithm inequality plus the harmonic deficit sum), with no Stirling estimate. The matching reciprocal bound shows the exponent is two-sided, and the squeeze proof reframes the convergence catalan n / 4^n → 0 as a direct consequence of the harmonic divergence established by the parent.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02`.

## Changes
- **Added a `sections` array** (previously absent) with 6 entries covering the full 213-line Lean file: module header/imports, the normalised step r k/4 and its logarithm, telescoping through the logarithm, the 3/2-exponent bound, independent convergence with explicit rate, and the sanity checks.
- **Deepened all 8 annotations** with the previously-missing `significance`, `relatedConcepts`, and `prerequisites` fields (mathContext was already present).

meta.json grows from 10.8 KB to 13.9 KB — comfortably under the 60 KB cap. Existing overview/keyInsights/conclusion/crossReferences were left intact. Build (`pnpm build`) passes.