### PR TITLE
Enrich Multiset.bell non-uniform bridge (uniformbell-multinomial-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/uniformbell-multinomial-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/uniformbell-multinomial-oq-01-oq-01/annotations.json
@@ -5,15 +5,39 @@
     "range": { "startLine": 1, "endLine": 54 },
     "type": "concept",
     "title": "Block-Size Profiles and Multiset.bell",
-    "content": "For a multiset s : Multiset ℕ of prescribed block sizes, Multiset.bell s counts the partitions of an s.sum-element set into unordered blocks whose sizes are exactly s. Mathlib records the cornerstone bell s · (s.map (·!)).prod · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = s.sum!. The parent entry handled the constant profile s = replicate m n (uniformBell m n) and asked whether the bridge to the multinomial coefficient generalises. It does, for any profile."
+    "content": "For a multiset s : Multiset ℕ of prescribed block sizes, Multiset.bell s counts the partitions of an s.sum-element set into unordered blocks whose sizes are exactly s. Mathlib records the cornerstone bell s · (s.map (·!)).prod · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = s.sum!. The parent entry handled the constant profile s = replicate m n (uniformBell m n) and asked whether the bridge to the multinomial coefficient generalises. It does, for any profile.",
+    "mathContext": "$\\operatorname{bell}(s)\\cdot\\Big(\\textstyle\\prod_{j\\in s} j!\\Big)\\cdot\\!\\!\\prod_{j\\in s.\\mathrm{toFinset}\\setminus\\{0\\}}\\!\\!(\\operatorname{count}_j s)! \\;=\\; \\big(\\textstyle\\sum s\\big)!$, where $\\operatorname{bell}(s)$ is the number of unordered set-partitions whose block-size multiset is exactly $s$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Multiset.bell",
+      "set partition",
+      "block-size profile",
+      "Bell number"
+    ],
+    "prerequisites": [
+      "multisets and Multiset.sum",
+      "set partitions counted by block sizes"
+    ]
   },
   {
     "id": "ann-bookkeeping",
     "proofId": "uniformbell-multinomial-oq-01-oq-01",
-    "range": { "startLine": 55, "endLine": 80 },
+    "range": { "startLine": 57, "endLine": 80 },
     "type": "technique",
     "title": "Reading the Multinomial off toEnumFinset",
-    "content": "Indexing the |s| blocks by s.toEnumFinset and reading each size with Prod.fst keeps equal sizes distinct. sum_fst_toEnumFinset (via Multiset.sum_eq_sum_toEnumFinset) gives ∑ i.1 = s.sum; prod_factorial_fst_toEnumFinset (via map_toEnumFinset_fst + map_map) gives ∏ (i.1)! = (s.map (·!)).prod. Feeding these into Nat.multinomial_spec yields factorialProd_mul_multinomial: (s.map (·!)).prod · multinomial s.toEnumFinset Prod.fst = s.sum! — the ordered non-uniform count."
+    "content": "Indexing the |s| blocks by s.toEnumFinset and reading each size with Prod.fst keeps equal sizes distinct. sum_fst_toEnumFinset (via Multiset.sum_eq_sum_toEnumFinset) gives ∑ i.1 = s.sum; prod_factorial_fst_toEnumFinset (via map_toEnumFinset_fst + map_map) gives ∏ (i.1)! = (s.map (·!)).prod. Feeding these into Nat.multinomial_spec yields factorialProd_mul_multinomial: (s.map (·!)).prod · multinomial s.toEnumFinset Prod.fst = s.sum! — the ordered non-uniform count.",
+    "mathContext": "With the blocks indexed by $s.\\mathrm{toEnumFinset}$ and valued by $\\mathrm{Prod.fst}$: $\\sum_i i_1 = \\sum s$ and $\\prod_i (i_1)! = \\prod_{j\\in s} j!$, so $\\big(\\prod_{j\\in s} j!\\big)\\cdot\\binom{\\sum s}{s} = (\\sum s)!$ where $\\binom{\\sum s}{s} = \\operatorname{multinomial}(s.\\mathrm{toEnumFinset},\\mathrm{Prod.fst})$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Multiset.toEnumFinset",
+      "Nat.multinomial_spec",
+      "multinomial coefficient",
+      "Multiset.sum_eq_sum_toEnumFinset"
+    ],
+    "prerequisites": [
+      "toEnumFinset as a distinct index of multiset elements",
+      "the multinomial specification (·!).prod · multinomial = sum!"
+    ]
   },
   {
     "id": "ann-bridge",
@@ -21,7 +45,19 @@
     "range": { "startLine": 81, "endLine": 130 },
     "type": "key-step",
     "title": "The Non-Uniform Bridge",
-    "content": "Both Multiset.bell_mul_eq and factorialProd_mul_multinomial pin s.sum! as (s.map (·!)).prod times a cofactor. Since the factorial product is positive (factorialProd_pos), left-cancellation in ℕ (Nat.eq_of_mul_eq_mul_left) gives bell_mul_count_eq_multinomial: bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = multinomial s.toEnumFinset Prod.fst. Corollaries: bell s ∣ multinomial, (s.map (·!)).prod ∣ s.sum!, and 0 < bell s. Forgetting the order of equal-size blocks divides the ordered count by exactly the product of block-multiplicity factorials."
+    "content": "Both Multiset.bell_mul_eq and factorialProd_mul_multinomial pin s.sum! as (s.map (·!)).prod times a cofactor. Since the factorial product is positive (factorialProd_pos), left-cancellation in ℕ (Nat.eq_of_mul_eq_mul_left) gives bell_mul_count_eq_multinomial: bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = multinomial s.toEnumFinset Prod.fst. Corollaries: bell s ∣ multinomial, (s.map (·!)).prod ∣ s.sum!, and 0 < bell s. Forgetting the order of equal-size blocks divides the ordered count by exactly the product of block-multiplicity factorials.",
+    "mathContext": "$\\operatorname{bell}(s)\\cdot\\!\\!\\prod_{j\\in s.\\mathrm{toFinset}\\setminus\\{0\\}}\\!\\!(\\operatorname{count}_j s)! \\;=\\; \\operatorname{multinomial}(s.\\mathrm{toEnumFinset},\\mathrm{Prod.fst})$. Proven by cancelling the common positive factor $\\prod_{j\\in s} j!$ from the two expressions for $(\\sum s)!$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.eq_of_mul_eq_mul_left",
+      "ordered vs unordered count",
+      "divisibility of multinomial",
+      "block-multiplicity factorial"
+    ],
+    "prerequisites": [
+      "left-cancellation by a positive natural",
+      "Multiset.bell_mul_eq cornerstone identity"
+    ]
   },
   {
     "id": "ann-recover-uniform",
@@ -29,14 +65,38 @@
     "range": { "startLine": 131, "endLine": 167 },
     "type": "key-step",
     "title": "Recovering the Equal-Block Bridge",
-    "content": "For the constant profile replicate m n with n, m ≠ 0, Multiset.toFinset_replicate collapses the multiplicity product to (count n)! = m! (count_prod_replicate). The general bridge then specialises to uniformBell m n · m! = multinomial (replicate m n).toEnumFinset Prod.fst (bell_mul_factorial_recovers_uniform), recovering the parent entry's identity as the constant-profile case."
+    "content": "For the constant profile replicate m n with n, m ≠ 0, Multiset.toFinset_replicate collapses the multiplicity product to (count n)! = m! (count_prod_replicate). The general bridge then specialises to uniformBell m n · m! = multinomial (replicate m n).toEnumFinset Prod.fst (bell_mul_factorial_recovers_uniform), recovering the parent entry's identity as the constant-profile case.",
+    "mathContext": "For $s = \\operatorname{replicate}(m,n)$ with $m,n\\neq 0$, the single nonzero size $n$ has multiplicity $m$, so $\\prod_j (\\operatorname{count}_j s)! = m!$ and the bridge becomes $\\operatorname{uniformBell}(m,n)\\cdot m! = \\operatorname{multinomial}$ — the parent's equal-block identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.uniformBell",
+      "Multiset.replicate",
+      "Multiset.toFinset_replicate",
+      "specialisation to constant profile"
+    ],
+    "prerequisites": [
+      "the general non-uniform bridge",
+      "bell(replicate m n) = uniformBell m n by definition"
+    ]
   },
   {
     "id": "ann-instance",
     "proofId": "uniformbell-multinomial-oq-01-oq-01",
-    "range": { "startLine": 168, "endLine": 188 },
+    "range": { "startLine": 172, "endLine": 188 },
     "type": "example",
     "title": "Worked Instance {1,1,2}",
-    "content": "Partitions of a 4-element set into two singletons and one pair: choose the pair (C(4,2) = 6), the remaining two elements are forced singletons, so bell {1,1,2} = 6 (kernel decide). The ordered count is multinomial = 4!/(1!·1!·2!) = 12, and indeed 6 · (count 1)! = 6 · 2! = 12 (multinomial_one_one_two via the bridge)."
+    "content": "Partitions of a 4-element set into two singletons and one pair: choose the pair (C(4,2) = 6), the remaining two elements are forced singletons, so bell {1,1,2} = 6 (kernel decide). The ordered count is multinomial = 4!/(1!·1!·2!) = 12, and indeed 6 · (count 1)! = 6 · 2! = 12 (multinomial_one_one_two via the bridge).",
+    "mathContext": "Profile $s = \\{1,1,2\\}$, $\\sum s = 4$: $\\operatorname{bell}(s) = \\binom{4}{2} = 6$, $\\operatorname{multinomial} = \\frac{4!}{1!\\,1!\\,2!} = 12$, and the bridge reads $6\\cdot(\\operatorname{count}_1 s)! = 6\\cdot 2! = 12$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "decide tactic",
+      "binomial coefficient",
+      "multiplicity factorial"
+    ],
+    "prerequisites": [
+      "evaluating bell and multinomial on a concrete profile",
+      "the bridge identity bell · ∏count! = multinomial"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `uniformbell-multinomial-oq-01-oq-01` (the non-uniform bridge `Multiset.bell s · ∏ count! = multinomial`).

## Changes
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` — they previously carried only `title`/`content`, so the three annotation-derived quality components (mathContext, significance, relatedConcepts) all scored 0.
- **Realigned two ranges** to their actual Lean constructs: `ann-bookkeeping` 55→57 (the first theorem's docstring rather than the `variable` line) and `ann-instance` 168→172 (the concrete-instance section header rather than the prior theorem body). Resolver: 5 valid, 0 misaligned.

Quality 68 → 98. meta.json (overview/sections/conclusion/crossReferences) was already complete and left unchanged. Build (`pnpm build`) passes.