### PR TITLE
research(lifting-the-exponent-oq-02-oq-01): p=2 sum LTE v₂(xⁿ+yⁿ) + unified all-primes dispatch [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/LiftingTheExponentOQ02OQ01.lean
+++ b/proofs/Proofs/LiftingTheExponentOQ02OQ01.lean
@@ -1,0 +1,183 @@
+import Mathlib.NumberTheory.Multiplicity
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Tactic
+
+/-
+# Lifting the Exponent for the *sum* `xⁿ + yⁿ` at the even prime `p = 2`
+
+The odd-prime Lifting the Exponent Lemma (LTE) for sums states, for an odd prime
+`p` with `p ∣ x + y`, `p ∤ x` and **odd** `n`,
+
+  vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n).
+
+Mathlib proves this `emultiplicity` form for odd primes only
+(`Int.emultiplicity_pow_add_pow`, which carries the hypothesis `Odd p`); the
+sibling entry `LiftingTheExponentOQ01` re-exports the `padicValNat` shape.  The
+companion `LiftingTheExponentOQ02` handles the *difference* `xⁿ - yⁿ` at `p = 2`,
+where the even prime behaves differently.  Neither Mathlib nor the gallery records
+the **sum** `xⁿ + yⁿ` at `p = 2`.  This file fills that gap and packages the
+all-primes dispatch.
+
+The `p = 2` analysis splits on the parity of the exponent:
+
+* **`n` odd.**  Writing `xⁿ + yⁿ = xⁿ - (-y)ⁿ` (valid since `n` is odd) reduces
+  the sum to a difference with `2 ∤ n`, and Mathlib's *prime-generic*
+  `emultiplicity_pow_sub_pow_of_prime` (no oddness on `p`) gives
+  `v₂(xⁿ + yⁿ) = v₂(x + y)`.  This is exactly the odd-prime formula with the
+  vanishing `v₂(n) = 0` term, so for odd `n` the LTE-for-sums identity holds for
+  **every** prime, including `2` — recorded as `emultiplicity_pow_add_pow_odd`.
+
+* **`n` even** (with `x, y` odd).  Odd squares are `1 (mod 4)`, so for even `n`
+  both `xⁿ ≡ 1` and `yⁿ ≡ 1 (mod 4)`, whence `xⁿ + yⁿ ≡ 2 (mod 4)`: the
+  valuation is pinned to exactly `1`, independent of everything else
+  (`two_emultiplicity_pow_add_pow_even`).  This is the additive twin of the
+  difference lemma's even-exponent special value.
+
+Results:
+* `odd_pow_even_emod_four` — `Odd x → Even n → xⁿ % 4 = 1`.
+* `two_emultiplicity_pow_add_pow_odd` — `v₂(xⁿ + yⁿ) = v₂(x + y)` for odd `n`.
+* `two_emultiplicity_pow_add_pow_even` — `v₂(xⁿ + yⁿ) = 1` for even `n`, `x,y` odd.
+* `two_padicValInt_pow_add_pow_odd` / `_even` — schoolbook integer-`v₂` forms.
+* `emultiplicity_pow_add_pow_odd` — the unified all-primes dispatch for odd `n`.
+
+The mathematical core (`emultiplicity_pow_sub_pow_of_prime`, the odd-prime LTE,
+the `mod 4` fact for odd squares) is Mathlib's; the contribution is the reduction
+of the sum at `p = 2` to those facts, the even-exponent value, and the uniform
+all-primes statement.
+
+Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+namespace LiftingTheExponentOQ02OQ01
+
+variable {x y : ℤ} {n : ℕ}
+
+/-- For odd `x` and even `n`, `xⁿ ≡ 1 (mod 4)`.  Odd squares are `1 (mod 4)`
+(`Int.sq_mod_four_eq_one_of_odd`), and an even power is a power of the square, so
+the residue is carried by `Int.ModEq.pow`. -/
+theorem odd_pow_even_emod_four (hx : Odd x) (hn : Even n) :
+    x ^ n % 4 = 1 := by
+  obtain ⟨m, rfl⟩ := hn
+  have hsq : x ^ 2 % 4 = 1 := Int.sq_mod_four_eq_one_of_odd hx
+  have hmod : (x ^ 2) ≡ 1 [ZMOD 4] := by
+    show x ^ 2 % 4 = 1 % 4; omega
+  have hpow : (x ^ 2) ^ m ≡ 1 ^ m [ZMOD 4] := hmod.pow m
+  have hrw : x ^ (m + m) = (x ^ 2) ^ m := by rw [← two_mul, pow_mul]
+  rw [hrw]
+  have : (x ^ 2) ^ m % 4 = 1 ^ m % 4 := hpow
+  simpa using this
+
+/-- **LTE for the sum at `p = 2`, odd exponent.** For `2 ∣ x + y`, `2 ∤ x` and
+**odd** `n`, `v₂(xⁿ + yⁿ) = v₂(x + y)`.  Reduces the sum to the difference
+`xⁿ - (-y)ⁿ` (legal for odd `n`) and applies the prime-generic
+`emultiplicity_pow_sub_pow_of_prime`, which — unlike the odd-prime LTE — places no
+parity restriction on `p`. -/
+theorem two_emultiplicity_pow_add_pow_odd
+    (hxy : (2 : ℤ) ∣ x + y) (hx : ¬(2 : ℤ) ∣ x) (hn : Odd n) :
+    emultiplicity (2 : ℤ) (x ^ n + y ^ n) = emultiplicity (2 : ℤ) (x + y) := by
+  have hp : Prime (2 : ℤ) := Int.prime_two
+  have hrw : x ^ n + y ^ n = x ^ n - (-y) ^ n := by rw [Odd.neg_pow hn]; ring
+  have hxy' : (2 : ℤ) ∣ x - (-y) := by simpa [sub_neg_eq_add] using hxy
+  have hnn : ¬(2 : ℤ) ∣ (n : ℤ) := by
+    have hnat : ¬(2 : ℕ) ∣ n := by have h := Nat.odd_iff.mp hn; omega
+    exact_mod_cast hnat
+  rw [hrw, emultiplicity_pow_sub_pow_of_prime hp hxy' hx hnn, sub_neg_eq_add]
+
+/-- **LTE for the sum at `p = 2`, even exponent.** For odd `x, y` and **even** `n`,
+`v₂(xⁿ + yⁿ) = 1`.  Both `xⁿ` and `yⁿ` are `1 (mod 4)`, so the sum is `2 (mod 4)`:
+divisible by `2` but not by `4`. -/
+theorem two_emultiplicity_pow_add_pow_even
+    (hx : Odd x) (hy : Odd y) (hn : Even n) :
+    emultiplicity (2 : ℤ) (x ^ n + y ^ n) = 1 := by
+  have hxm : x ^ n % 4 = 1 := odd_pow_even_emod_four hx hn
+  have hym : y ^ n % 4 = 1 := odd_pow_even_emod_four hy hn
+  set s := x ^ n + y ^ n with hsdef
+  have hsum : s % 4 = 2 := by rw [hsdef]; omega
+  have hdvd : (2 : ℤ) ∣ s := by omega
+  have hndvd : ¬(4 : ℤ) ∣ s := by omega
+  have hcoe : emultiplicity (2 : ℤ) s = ((1 : ℕ) : ℕ∞) := by
+    rw [emultiplicity_eq_coe]
+    refine ⟨by simpa using hdvd, ?_⟩
+    have h4 : (2 : ℤ) ^ (1 + 1) = 4 := by norm_num
+    rw [h4]; exact hndvd
+  simpa using hcoe
+
+/-- **Schoolbook integer form, odd exponent.** `v₂(xⁿ + yⁿ) = v₂(x + y)` with
+`padicValInt`, carrying the nonzero hypotheses needed to descend from the extended
+valuation to the finite `multiplicity`. -/
+theorem two_padicValInt_pow_add_pow_odd
+    (hxy : (2 : ℤ) ∣ x + y) (hx : ¬(2 : ℤ) ∣ x) (hn : Odd n)
+    (hadd : x + y ≠ 0) (hne : x ^ n + y ^ n ≠ 0) :
+    padicValInt 2 (x ^ n + y ^ n) = padicValInt 2 (x + y) := by
+  have hem := two_emultiplicity_pow_add_pow_odd hxy hx hn
+  have hf1 : FiniteMultiplicity (2 : ℤ) (x ^ n + y ^ n) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hne⟩
+  have hf2 : FiniteMultiplicity (2 : ℤ) (x + y) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hadd⟩
+  rw [hf1.emultiplicity_eq_multiplicity, hf2.emultiplicity_eq_multiplicity] at hem
+  have hmm : multiplicity (2 : ℤ) (x ^ n + y ^ n) = multiplicity (2 : ℤ) (x + y) := by
+    exact_mod_cast hem
+  rw [padicValInt.of_ne_one_ne_zero (by decide) hne,
+      padicValInt.of_ne_one_ne_zero (by decide) hadd]
+  exact hmm
+
+/-- **Schoolbook integer form, even exponent.** `v₂(xⁿ + yⁿ) = 1` for odd `x, y`
+and even `n`.  No nonzero hypothesis is needed: `xⁿ + yⁿ ≡ 2 (mod 4)` is never
+zero. -/
+theorem two_padicValInt_pow_add_pow_even
+    (hx : Odd x) (hy : Odd y) (hn : Even n) :
+    padicValInt 2 (x ^ n + y ^ n) = 1 := by
+  have hxm : x ^ n % 4 = 1 := odd_pow_even_emod_four hx hn
+  have hym : y ^ n % 4 = 1 := odd_pow_even_emod_four hy hn
+  have hne : x ^ n + y ^ n ≠ 0 := by omega
+  have hem := two_emultiplicity_pow_add_pow_even hx hy hn
+  have hf : FiniteMultiplicity (2 : ℤ) (x ^ n + y ^ n) :=
+    Int.finiteMultiplicity_iff.mpr ⟨by decide, hne⟩
+  rw [hf.emultiplicity_eq_multiplicity] at hem
+  rw [padicValInt.of_ne_one_ne_zero (by decide) hne]
+  exact_mod_cast hem
+
+/-- **Unified all-primes dispatch (odd exponent).** For *every* prime `p` with
+`p ∣ x + y`, `p ∤ x`, and **odd** `n`,
+`vₚ(xⁿ + yⁿ) = vₚ(x + y) + vₚ(n)`.  For odd `p` this is Mathlib's
+`Int.emultiplicity_pow_add_pow`; for `p = 2` the extra term `v₂(n) = 0` (odd `n`)
+collapses it to `two_emultiplicity_pow_add_pow_odd`.  So the single odd-exponent
+formula governs all primes at once. -/
+theorem emultiplicity_pow_add_pow_odd {p : ℕ} (hp : p.Prime)
+    (hxy : (p : ℤ) ∣ x + y) (hx : ¬(p : ℤ) ∣ x) (hn : Odd n) :
+    emultiplicity (p : ℤ) (x ^ n + y ^ n)
+      = emultiplicity (p : ℤ) (x + y) + emultiplicity p n := by
+  rcases eq_or_ne p 2 with hp2 | hp2
+  · subst hp2
+    have hzero : emultiplicity (2 : ℕ) n = 0 := by
+      rw [emultiplicity_eq_zero]
+      have h := Nat.odd_iff.mp hn; omega
+    rw [hzero, add_zero]
+    have hxy' : (2 : ℤ) ∣ x + y := by exact_mod_cast hxy
+    have hx' : ¬(2 : ℤ) ∣ x := by exact_mod_cast hx
+    have := two_emultiplicity_pow_add_pow_odd hxy' hx' hn
+    exact_mod_cast this
+  · have hpodd : Odd p := hp.odd_of_ne_two hp2
+    exact Int.emultiplicity_pow_add_pow hp hpodd hxy hx hn
+
+/-! ### Concrete confirmations
+
+Numerical witnesses, all by kernel `decide` (no `native_decide`, hence no
+`Lean.ofReduceBool`). -/
+
+/-- Odd exponent, `n = 3`: `v₂(3³ + 5³) = v₂(152) = 3 = v₂(8) = v₂(3 + 5)`.
+The valuation `3` is witnessed by `8 ∣ 152 ∧ ¬16 ∣ 152`. -/
+theorem check_odd_three : padicValInt 2 (3 ^ 3 + 5 ^ 3) = padicValInt 2 (3 + 5) :=
+  two_padicValInt_pow_add_pow_odd (by decide) (by decide) (by decide) (by decide) (by decide)
+
+theorem check_odd_three_value : (2 : ℤ) ^ 3 ∣ (3 ^ 3 + 5 ^ 3) ∧ ¬(2 : ℤ) ^ 4 ∣ (3 ^ 3 + 5 ^ 3) := by
+  decide
+
+/-- Even exponent, `n = 2`: `v₂(3² + 5²) = v₂(34) = 1`. -/
+theorem check_even_two : padicValInt 2 (3 ^ 2 + 5 ^ 2) = 1 :=
+  two_padicValInt_pow_add_pow_even (by decide) (by decide) (by decide)
+
+theorem check_even_two_value : (2 : ℤ) ^ 1 ∣ (3 ^ 2 + 5 ^ 2) ∧ ¬(2 : ℤ) ^ 2 ∣ (3 ^ 2 + 5 ^ 2) := by
+  decide
+
+end LiftingTheExponentOQ02OQ01

--- a/src/data/proofs/lifting-the-exponent-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/lifting-the-exponent-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-lte2sum-overview",
+    "proofId": "lifting-the-exponent-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "The p = 2 sum case, and why it is missing",
+    "content": "Lifting the Exponent computes v_p(xⁿ ± yⁿ). For odd primes the sum case reduces to the difference case by sending y to −y (valid for odd n). Mathlib's packaged sum-LTE (Int.emultiplicity_pow_add_pow) bakes in the hypothesis Odd p, so it is silent at the even prime. This entry supplies v₂(xⁿ + yⁿ): for odd n it equals v₂(x + y); for even n with odd bases it is exactly 1. The odd-n result turns out to be the universal formula v_p(x+y) + v_p(n) read at p = 2, where v₂(n) = 0.",
+    "mathContext": "Odd $n$: $v_2(x^n+y^n)=v_2(x+y)$. Even $n$, $x,y$ odd: $v_2(x^n+y^n)=1$.",
+    "significance": "context",
+    "relatedConcepts": ["lifting the exponent", "p-adic valuation", "even prime", "multiplicity"],
+    "prerequisites": ["p-adic valuation", "modular arithmetic"]
+  },
+  {
+    "id": "ann-lte2sum-mod4",
+    "proofId": "lifting-the-exponent-oq-02-oq-01",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "technique",
+    "title": "Even powers of odd integers are 1 mod 4",
+    "content": "odd_pow_even_emod_four proves Odd x → Even n → xⁿ % 4 = 1. The seed is Mathlib's Int.sq_mod_four_eq_one_of_odd (x² ≡ 1 mod 4 for odd x); writing n = m + m gives xⁿ = (x²)^m, and Int.ModEq.pow carries the residue 1 through the m-th power. This is the entire arithmetic content of the even-exponent case.",
+    "mathContext": "$x$ odd $\\Rightarrow x^2\\equiv1\\ (4)\\Rightarrow x^{2m}=(x^2)^m\\equiv1\\ (4)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.ModEq", "quadratic residues", "modular exponentiation"],
+    "prerequisites": ["modular arithmetic"]
+  },
+  {
+    "id": "ann-lte2sum-odd",
+    "proofId": "lifting-the-exponent-oq-02-oq-01",
+    "range": { "startLine": 74, "endLine": 89 },
+    "type": "technique",
+    "title": "Sum as a disguised difference; the prime-generic lemma",
+    "content": "two_emultiplicity_pow_add_pow_odd rewrites xⁿ + yⁿ = xⁿ − (−y)ⁿ (Odd.neg_pow, legal for odd n) and applies emultiplicity_pow_sub_pow_of_prime. The decisive feature of that Mathlib lemma is that it needs only a prime p with p ∤ n — NO oddness on p — so it works verbatim at p = 2, where the packaged LTE refuses. The 2 ∤ n side condition is exactly n odd.",
+    "mathContext": "$x^n+y^n=x^n-(-y)^n$, and $v_2(x^n-(-y)^n)=v_2(x-(-y))=v_2(x+y)$ since $2\\nmid n$.",
+    "significance": "key",
+    "relatedConcepts": ["Odd.neg_pow", "emultiplicity_pow_sub_pow_of_prime", "valuation of differences"],
+    "prerequisites": ["lifting the exponent"]
+  },
+  {
+    "id": "ann-lte2sum-even",
+    "proofId": "lifting-the-exponent-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 113 },
+    "type": "technique",
+    "title": "Pinning the valuation to one",
+    "content": "two_emultiplicity_pow_add_pow_even shows v₂(xⁿ + yⁿ) = 1 for odd x, y and even n. Both powers are 1 (mod 4), so the sum is 2 (mod 4): divisible by 2 but not 4. emultiplicity_eq_coe turns 'emultiplicity equals 1' into '2 ∣ sum ∧ ¬4 ∣ sum', and omega discharges both divisibility facts from the single congruence sum % 4 = 2.",
+    "mathContext": "$x^n+y^n\\equiv2\\ (4)\\Rightarrow 2\\mid\\text{sum},\\ 4\\nmid\\text{sum}\\Rightarrow v_2=1$.",
+    "significance": "key",
+    "relatedConcepts": ["emultiplicity_eq_coe", "omega", "exact valuation"],
+    "prerequisites": ["p-adic valuation"]
+  },
+  {
+    "id": "ann-lte2sum-dispatch",
+    "proofId": "lifting-the-exponent-oq-02-oq-01",
+    "range": { "startLine": 154, "endLine": 167 },
+    "type": "concept",
+    "title": "One formula for every prime at odd exponents",
+    "content": "emultiplicity_pow_add_pow_odd states v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n) for ALL primes p (odd exponent). The proof dispatches: for odd p it is Mathlib's Int.emultiplicity_pow_add_pow; for p = 2 the term v₂(n) vanishes (n odd) and the statement collapses to the reduction above. So the even prime is not an exception at odd exponents — it is the same law with a zero correction.",
+    "mathContext": "$\\forall p\\ \\text{prime},\\ n\\ \\text{odd}:\\ v_p(x^n+y^n)=v_p(x+y)+v_p(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["case analysis", "unified theorems", "lifting the exponent"],
+    "prerequisites": ["lifting the exponent"]
+  }
+]

--- a/src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "lifting-the-exponent-oq-02-oq-01",
+  "title": "Lifting the Exponent for the sum xⁿ + yⁿ at p = 2, and the unified all-primes dispatch for odd exponents",
+  "slug": "lifting-the-exponent-oq-02-oq-01",
+  "description": "Fills the p = 2 sum case of the Lifting the Exponent Lemma, missing from both Mathlib and the gallery. Mathlib's LTE for sums (Int.emultiplicity_pow_add_pow) carries the hypothesis Odd p, so it says nothing about the even prime; the sibling oq-01 re-exports only the odd-prime padicValNat form, and oq-02 handles the difference xⁿ − yⁿ at p = 2. This entry treats the sum xⁿ + yⁿ at p = 2, splitting on the parity of the exponent. For odd n, the identity xⁿ + yⁿ = xⁿ − (−y)ⁿ (valid because n is odd) turns the sum into a difference with 2 ∤ n, where Mathlib's PRIME-GENERIC emultiplicity_pow_sub_pow_of_prime (which places no oddness restriction on p) gives v₂(xⁿ + yⁿ) = v₂(x + y). Since this is exactly the odd-prime formula v_p(x+y) + v_p(n) with the vanishing term v₂(n) = 0 (n odd), the LTE-for-sums identity in fact holds for EVERY prime at odd exponents — packaged as emultiplicity_pow_add_pow_odd, which dispatches to the odd-prime lemma when p is odd and to the p = 2 reduction when p = 2. For even n with x, y odd, both xⁿ and yⁿ are 1 (mod 4) (odd squares are 1 mod 4, carried through Int.ModEq.pow), so xⁿ + yⁿ ≡ 2 (mod 4): the valuation is pinned to exactly 1, the additive twin of the difference lemma's even-exponent special value. Both shapes are given in emultiplicity (ℕ∞) and schoolbook padicValInt forms. The mathematical core is Mathlib's; the contribution is the reduction of the p = 2 sum to those facts, the even-exponent value, and the uniform all-primes statement — none of which exist in Mathlib. Verified with 0 axioms, 0 sorries, no native_decide (numerical witnesses use kernel decide).",
+  "meta": {
+    "author": "Classical (Lifting the Exponent Lemma, sum form at p = 2); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LiftingTheExponentOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "p-adic-valuation",
+      "lifting-the-exponent",
+      "multiplicity",
+      "even-prime",
+      "modular-arithmetic",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "emultiplicity_pow_sub_pow_of_prime",
+        "description": "For a prime p with p ∣ x − y, p ∤ x and p ∤ n, emultiplicity p (xⁿ − yⁿ) = emultiplicity p (x − y). The crucial point is that this lemma is prime-generic — it carries NO oddness hypothesis on p — so it applies at p = 2. Specialised at the difference xⁿ − (−y)ⁿ it yields the odd-exponent sum result at the even prime.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "Int.emultiplicity_pow_add_pow",
+        "description": "The odd-prime LTE for sums: for Odd p, p ∣ x + y, p ∤ x and Odd n, emultiplicity p (xⁿ + yⁿ) = emultiplicity p (x + y) + emultiplicity p n. Used as the odd-prime branch of the unified all-primes dispatch; its Odd p hypothesis is exactly why the p = 2 case had to be supplied separately.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "Int.sq_mod_four_eq_one_of_odd",
+        "description": "Odd x → x² % 4 = 1. The seed for the even-exponent case: an even power xⁿ = (x²)^(n/2) inherits the residue 1 (mod 4) via Int.ModEq.pow, forcing xⁿ + yⁿ ≡ 2 (mod 4) for odd x, y.",
+        "module": "Mathlib.NumberTheory.Multiplicity"
+      },
+      {
+        "theorem": "Odd.neg_pow",
+        "description": "Odd n → (−a)ⁿ = −aⁿ. The algebraic identity that rewrites the sum xⁿ + yⁿ as the difference xⁿ − (−y)ⁿ when n is odd, the move that unlocks the difference-based machinery.",
+        "module": "Mathlib.Algebra.Ring.Parity"
+      },
+      {
+        "theorem": "padicValInt.of_ne_one_ne_zero",
+        "description": "For p ≠ 1 and z ≠ 0, padicValInt p z = multiplicity (↑p) z. The descent from the extended (ℕ∞) valuation to the finite padicValInt used to phrase the schoolbook integer forms.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+      },
+      {
+        "theorem": "emultiplicity_eq_coe",
+        "description": "emultiplicity a b = ↑k ↔ aᵏ ∣ b ∧ ¬a^(k+1) ∣ b. Used to pin emultiplicity 2 (xⁿ + yⁿ) = 1 from 2 ∣ sum and ¬4 ∣ sum in the even-exponent case.",
+        "module": "Mathlib.RingTheory.Multiplicity"
+      }
+    ],
+    "originalContributions": [
+      "two_emultiplicity_pow_add_pow_odd: v₂(xⁿ + yⁿ) = v₂(x + y) for 2 ∣ x + y, 2 ∤ x and odd n. The p = 2 sum case of LTE, which Mathlib does not provide (its sum-LTE requires Odd p). Proved by reducing the sum to the difference xⁿ − (−y)ⁿ and invoking the prime-generic difference lemma.",
+      "two_emultiplicity_pow_add_pow_even: v₂(xⁿ + yⁿ) = 1 for odd x, y and even n. The even-exponent special value, the additive analogue of the difference lemma's behaviour at even exponents; proved from xⁿ + yⁿ ≡ 2 (mod 4).",
+      "emultiplicity_pow_add_pow_odd: the unified all-primes dispatch — for EVERY prime p with p ∣ x + y, p ∤ x and odd n, v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n). It exhibits the p = 2 sum result as the same formula with v₂(n) = 0, so a single statement covers all primes at odd exponents.",
+      "two_padicValInt_pow_add_pow_odd and two_padicValInt_pow_add_pow_even: the schoolbook integer-v₂ forms via padicValInt, with the finiteness descent handled explicitly (and noting that the even case needs no nonzero hypothesis, since xⁿ + yⁿ ≡ 2 (mod 4) is never zero).",
+      "odd_pow_even_emod_four: Odd x → Even n → xⁿ % 4 = 1, the reusable mod-4 lemma underlying the even-exponent value."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. No native_decide (numerical confirmations use kernel decide, not native_decide, so no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound (confirmed by #print axioms on every theorem).",
+    "lineCount": 183,
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Lifting the Exponent Lemma (LTE) is a staple of olympiad and elementary number theory: it computes the exact p-adic valuation of xⁿ ± yⁿ in terms of the valuations of x ± y and of n. For odd primes the difference and sum cases are clean and symmetric (the sum reduces to the difference via y ↦ −y for odd n). The prime p = 2 is the notorious exception, where an extra v₂(x + y) term and a parity-dependent shift appear for the difference at even exponents. Mathlib formalizes the odd-prime LTE in full and the p = 2 DIFFERENCE (Int.two_pow_sub_pow), but stops short of the p = 2 SUM. This entry closes that small but real gap and observes that, for odd exponents, the even prime needs no special treatment at all once the right prime-generic lemma is used.",
+    "problemStatement": "Determine v₂(xⁿ + yⁿ), the 2-adic valuation of a sum of equal powers, for 2 ∣ x + y and 2 ∤ x. The answer splits on the parity of n: for odd n it equals v₂(x + y) (with no v₂(n) correction, since 2 ∤ n); for even n with x, y odd it is exactly 1. The companion question is whether the odd-exponent formula can be stated once for all primes — it can.",
+    "keyIdea": "Two observations. (1) The sum at an ODD exponent is a difference in disguise: xⁿ + yⁿ = xⁿ − (−y)ⁿ. Applying Mathlib's emultiplicity_pow_sub_pow_of_prime — which, unlike the LTE proper, requires only that the prime not divide the exponent, with NO oddness restriction on the prime itself — gives v₂(xⁿ + yⁿ) = v₂(x + y) directly. This is the odd-prime sum formula with the term v₂(n) = 0, so the single identity v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n) holds for every prime at odd exponents. (2) At an EVEN exponent, odd bases give odd squares ≡ 1 (mod 4), so xⁿ + yⁿ ≡ 2 (mod 4): divisible by 2 but not 4, hence valuation exactly 1."
+  },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: the p = 2 sum case and the all-primes dispatch",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring positioning the entry against Mathlib's odd-prime sum-LTE and p = 2 difference-LTE, and the sibling gallery entries oq-01 (odd-prime padicValNat form) and oq-02 (p = 2 difference). Outlines the parity split: odd n reduces to a prime-generic difference lemma (giving the all-primes formula), even n is pinned to valuation 1 by a mod-4 computation."
+    },
+    {
+      "id": "mod-four",
+      "title": "Odd bases at even exponents are 1 mod 4",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "odd_pow_even_emod_four: Odd x → Even n → xⁿ % 4 = 1. Writes n = m + m, uses Int.sq_mod_four_eq_one_of_odd to get x² ≡ 1 (mod 4), and propagates the residue through (x²)^m by Int.ModEq.pow."
+    },
+    {
+      "id": "odd-exponent",
+      "title": "Odd exponent: sum as a disguised difference",
+      "startLine": 74,
+      "endLine": 89,
+      "summary": "two_emultiplicity_pow_add_pow_odd: v₂(xⁿ + yⁿ) = v₂(x + y) for odd n. Rewrites xⁿ + yⁿ = xⁿ − (−y)ⁿ via Odd.neg_pow, checks 2 ∣ x − (−y) and 2 ∤ n, and applies the prime-generic emultiplicity_pow_sub_pow_of_prime."
+    },
+    {
+      "id": "even-exponent",
+      "title": "Even exponent: valuation pinned to one",
+      "startLine": 91,
+      "endLine": 113,
+      "summary": "two_emultiplicity_pow_add_pow_even: v₂(xⁿ + yⁿ) = 1 for odd x, y and even n. From xⁿ ≡ yⁿ ≡ 1 (mod 4) it derives xⁿ + yⁿ ≡ 2 (mod 4), so 2 ∣ sum and ¬4 ∣ sum; emultiplicity_eq_coe converts this to emultiplicity 2 sum = 1, with omega discharging the divisibility facts."
+    },
+    {
+      "id": "padicvalint-forms",
+      "title": "Schoolbook integer-v₂ forms",
+      "startLine": 115,
+      "endLine": 152,
+      "summary": "two_padicValInt_pow_add_pow_odd and two_padicValInt_pow_add_pow_even restate both results with padicValInt, descending from the extended valuation via FiniteMultiplicity and padicValInt.of_ne_one_ne_zero. The odd form carries x + y ≠ 0 and xⁿ + yⁿ ≠ 0; the even form needs no nonzero hypothesis since the sum is ≡ 2 (mod 4)."
+    },
+    {
+      "id": "dispatch",
+      "title": "The unified all-primes dispatch",
+      "startLine": 154,
+      "endLine": 167,
+      "summary": "emultiplicity_pow_add_pow_odd: for any prime p, p ∣ x + y, p ∤ x and odd n, v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n). Case-splits on p = 2 (where v₂(n) = 0 collapses to the reduction above) versus odd p (Int.emultiplicity_pow_add_pow)."
+    },
+    {
+      "id": "checks",
+      "title": "Numerical confirmations",
+      "startLine": 169,
+      "endLine": 183,
+      "summary": "Kernel-decide witnesses: v₂(3³ + 5³) = v₂(152) = 3 = v₂(8) = v₂(3 + 5) (odd exponent, via 8 ∣ 152 ∧ ¬16 ∣ 152) and v₂(3² + 5²) = v₂(34) = 1 (even exponent). No native_decide is used."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Parvardi, Amir Hossein",
+      "title": "Lifting the Exponent Lemma (LTE)",
+      "year": "2011",
+      "note": "Standard olympiad exposition stating both the difference and sum forms and the special behaviour of the prime 2, including the even-exponent valuation = 1 for sums of odd powers."
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Mathlib.NumberTheory.Multiplicity",
+      "year": "2024",
+      "note": "Source of emultiplicity_pow_sub_pow_of_prime, Int.emultiplicity_pow_add_pow and Int.two_pow_sub_pow; provides the odd-prime LTE and the p = 2 difference but not the p = 2 sum filled in here."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "lifting-the-exponent-oq-02",
+      "relationship": "parent",
+      "description": "Parent entry: LTE for the difference xⁿ − yⁿ at p = 2 (integer v₂ form). This leaf is the additive companion, treating the sum xⁿ + yⁿ at the same prime."
+    },
+    {
+      "proofId": "lifting-the-exponent-oq-01",
+      "relationship": "sibling",
+      "description": "Odd-prime LTE in padicValNat form, including the odd-prime sum case v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n). The all-primes dispatch here calls the odd-prime branch and supplies the missing p = 2 branch."
+    },
+    {
+      "proofId": "lifting-the-exponent-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Further LTE leaf in the same family; shares the multiplicity/valuation API used throughout."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the p = 2 case of Lifting the Exponent for sums xⁿ + yⁿ — absent from Mathlib — in both emultiplicity and padicValInt forms: v₂ = v₂(x + y) at odd exponents and v₂ = 1 at even exponents (odd bases). The odd-exponent result is shown to be an instance of a single all-primes formula v_p(xⁿ + yⁿ) = v_p(x + y) + v_p(n), valid for p = 2 because the v₂(n) term vanishes for odd n. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Completes the LTE-for-sums picture across all primes in the gallery and isolates the only genuinely 2-specific phenomenon (the even-exponent value 1). The reduction technique — rewrite a sum at odd exponent as a difference via y ↦ −y and apply the prime-generic difference lemma — is the cleanest route to sum-valuation results and sidesteps the Odd p restriction of the packaged LTE.",
+    "openQuestions": [
+      "Give the fully explicit even-prime sum law for arbitrary (not necessarily odd) bases, classifying v₂(xⁿ + yⁿ) by the 2-adic data of x, y and the parity of n in a single statement.",
+      "Formalize the analogous all-primes dispatch for the difference xⁿ − yⁿ, unifying the odd-prime LTE with the p = 2 even/odd-exponent cases into one indexed theorem."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Multiplicity",
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "LiftingTheExponentOQ02OQ01",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/LiftingTheExponentOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Fills the **p = 2 case of Lifting the Exponent for sums** `xⁿ + yⁿ`, which is missing from both Mathlib and the gallery. Mathlib's packaged sum-LTE (`Int.emultiplicity_pow_add_pow`) carries the hypothesis `Odd p`, so it says nothing about the even prime; the sibling `lifting-the-exponent-oq-01` re-exports only the odd-prime form, and `lifting-the-exponent-oq-02` handles the *difference* `xⁿ − yⁿ` at p = 2.

## Results (`Proofs/LiftingTheExponentOQ02OQ01.lean`)

- **`two_emultiplicity_pow_add_pow_odd`** — odd `n`: `v₂(xⁿ + yⁿ) = v₂(x + y)`. Proved by rewriting `xⁿ + yⁿ = xⁿ − (−y)ⁿ` (valid for odd `n`) and applying Mathlib's **prime-generic** `emultiplicity_pow_sub_pow_of_prime`, which — unlike the LTE proper — places no oddness restriction on `p`, so it works at 2.
- **`two_emultiplicity_pow_add_pow_even`** — even `n`, odd bases: `v₂(xⁿ + yⁿ) = 1`, from `xⁿ + yⁿ ≡ 2 (mod 4)`.
- **`emultiplicity_pow_add_pow_odd`** — the **unified all-primes dispatch**: for *every* prime `p` with `p ∣ x+y`, `p ∤ x`, odd `n`, `v_p(xⁿ + yⁿ) = v_p(x+y) + v_p(n)`. The even prime is not an exception at odd exponents — it is the same law with the `v₂(n) = 0` term.
- **`two_padicValInt_pow_add_pow_odd` / `_even`** — schoolbook integer-`v₂` forms.
- Numerical witnesses by **kernel `decide`** (no `native_decide`).

## Verification

Offline-verified (`lake env lean`, docker host build unavailable): **0 sorries, 0 axioms**, no `native_decide`. `#print axioms` on every theorem lists only `propext`, `Classical.choice`, `Quot.sound`.

Status `verified`, badge `original` — the statements (p=2 sum LTE, even-exponent value, all-primes dispatch) do not exist in Mathlib; the proofs assemble them from Mathlib's multiplicity API, mirroring the sibling `catalan-numbers-oq-01-oq-04` framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)