### PR TITLE
Enrich Pascal-from-powerset (subset-count-oq-02-oq-02): conclusion + annotation depth

### DIFF
--- a/src/data/proofs/subset-count-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/subset-count-oq-02-oq-02/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "ann-header-two-decompositions",
+    "proofId": "subset-count-oq-02-oq-02",
+    "range": {
+      "startLine": 3,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "Two Powerset Decompositions, Two Identities",
+    "content": "The module docstring frames the open question inherited from the parent: the parent counted distinct submultisets via the product formula ∏_a (mₐ+1); can the *binomial* recurrences be recovered the same way — combinatorially, from the structure of the powerset — rather than by unfolding the recursive `Nat.choose`? The file answers YES through the two canonical ways to organize a powerset: (1) **fix an element** x, partitioning subsets by whether they contain x (→ Pascal), and (2) **fix the size** k, partitioning the powerset into its cardinality layers (→ row sum). Mathlib already has `Nat.choose_succ_succ` and `Nat.sum_range_choose`, but those are proved by recursion on `choose`; the point here is to derive the *same* identities bijectively, off `powersetCard_cons`, `powersetCard_succ_insert`, and `powerset_card_disjiUnion`.",
+    "mathContext": "One finite family $\\mathcal{P}(S)$, two organizations: by membership of a fixed $x$ ($\\to \\binom{n+1}{k+1} = \\binom{n}{k+1} + \\binom{n}{k}$) and by cardinality ($\\to \\sum_k \\binom{n}{k} = 2^n$). Arithmetic read off structure, never off $\\mathrm{Nat.rec}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "powerset",
+      "bijective proof",
+      "Pascal's recurrence",
+      "binomial row sum"
+    ],
+    "prerequisites": [
+      "binomial coefficients as subset counts",
+      "the parent submultiset product formula"
+    ]
+  },
+  {
     "id": "ann-powersetcard-cons-is-pascal",
     "proofId": "subset-count-oq-02-oq-02",
     "range": {
@@ -51,7 +74,7 @@
     "id": "ann-fix-size-row-sum",
     "proofId": "subset-count-oq-02-oq-02",
     "range": {
-      "startLine": 121,
+      "startLine": 125,
       "endLine": 144
     },
     "type": "insight",
@@ -69,6 +92,29 @@
       "Finsets",
       "Disjoint unions over an index",
       "Cardinality of the powerset"
+    ]
+  },
+  {
+    "id": "ann-sanity-rebuild-triangle",
+    "proofId": "subset-count-oq-02-oq-02",
+    "range": {
+      "startLine": 151,
+      "endLine": 161
+    },
+    "type": "example",
+    "title": "Sanity Checks: Rebuilding Pascal's Triangle",
+    "content": "The closing examples confirm the combinatorial lemmas reproduce the familiar arithmetic. Two interior triangle entries are recomputed through the derived recurrence — `(4).choose 2 = 3 + 3` and `(5).choose 3 = 6 + 4` via `choose_succ_succ_comb` — rather than by evaluation. The n = 4 row sum `∑_{k<5} (4).choose k = 16` is checked by kernel `decide` (note: ordinary `decide`, not `native_decide`, so no `Lean.ofReduceBool` enters the axiom set). Finally the two boundary edges `(0).choose (k+1) = 0` and `m.choose 0 = 1` are recorded, since together with Pascal they generate the entire triangle — making explicit that the recurrence proved here is exactly the rule that builds the triangle.",
+    "mathContext": "$\\binom{4}{2} = 3+3$, $\\binom{5}{3} = 6+4$, $\\sum_{k=0}^{4}\\binom{4}{k} = 16$; boundary edges $\\binom{0}{k+1} = 0$, $\\binom{m}{0} = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Pascal's triangle",
+      "kernel decide vs native_decide",
+      "boundary conditions",
+      "recurrence as triangle-builder"
+    ],
+    "prerequisites": [
+      "the derived Pascal recurrence",
+      "decidable evaluation of choose"
     ]
   }
 ]

--- a/src/data/proofs/subset-count-oq-02-oq-02/meta.json
+++ b/src/data/proofs/subset-count-oq-02-oq-02/meta.json
@@ -43,6 +43,14 @@
   },
   "sections": [
     {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Docstring framing the open question — can the binomial recurrences be recovered by decomposing the powerset rather than unfolding Nat.choose? — and listing the two decompositions (fix an element → Pascal, fix the size → row sum) plus the 0-sorry/0-axiom status. Imports Mathlib and opens the Multiset and Finset namespaces.",
+      "mathContext": "Both $\\binom{n+1}{k+1} = \\binom{n}{k+1} + \\binom{n}{k}$ and $\\sum_k \\binom{n}{k} = 2^n$ derived from powerset structure, not from $\\mathrm{Nat.rec}$."
+    },
+    {
       "id": "decomp-element",
       "title": "Part I: Fix an Element → Pascal's Recurrence",
       "startLine": 46,
@@ -66,5 +74,14 @@
       "summary": "Pascal triangle entries via the recurrence, the n=4 row sum by kernel decide, and the two boundary edges choose 0 (k+1) = 0 and choose m 0 = 1.",
       "mathContext": "$\\binom{4}{2} = 3+3$; $\\sum_{k} \\binom{4}{k} = 16$; boundary edges of the triangle"
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Both canonical binomial identities are obtained combinatorially, by counting one finite family of sets organized two ways. Fixing an element splits the (k+1)-subsets of a set into those omitting it and those using it, and taking cardinalities of Multiset.powersetCard_cons (resp. Finset.powersetCard_succ_insert) gives Pascal's recurrence (m+1).choose(k+1) = m.choose(k+1) + m.choose k. Fixing the size writes the powerset as the disjoint union of its cardinality layers, and counting Finset.powerset_card_disjiUnion gives the row sum ∑_k m.choose k = 2^m. All six theorems are fully machine-checked (0 sorries, 0 axioms, no native_decide), and crucially none touches the Nat.rec definition of choose — the proofs are bijective in both spirit and mechanism.",
+    "implications": "This answers the parent's open question affirmatively: the binomial recurrences, like the submultiset product formula, are recoverable purely from the structure of the powerset, not from the recursive definition of the coefficient. The Finset proof of Pascal is fully honest — it exhibits the disjointness (avoid x vs contain x) and the relabelling bijection (insert x, inverse erase x) explicitly, rather than hiding them inside an induction. The pattern 'decompose the indexing set, then take cardinalities' is the reusable lesson: it generalises to other coefficient identities (e.g. Vandermonde from a two-part split of the ground set, or the hockey-stick identity from a layered powerset) wherever a clean structural decomposition is available in Mathlib.",
+    "openQuestions": [
+      "Can Vandermonde's identity ∑_j (m.choose j)(n.choose (k−j)) = (m+n).choose k be derived the same way, by splitting an (m+n)-set into an m-part and an n-part and counting the k-subsets layer by layer?",
+      "Does the hockey-stick identity ∑_{i=r}^{n} i.choose r = (n+1).choose (r+1) admit a powerset-decomposition proof, classifying (r+1)-subsets by their largest element?",
+      "Can the explicit bijection in choose_succ_succ_finset (insert x / erase x) be packaged as a reusable Equiv between the (k+1)-subsets of insert x s and the disjoint union, so the cardinality identity becomes a corollary of an equivalence rather than a card computation?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `subset-count-oq-02-oq-02` (Pascal's recurrence and the row sum derived from powerset decompositions).

## Changes
- **Added a `conclusion` block** (previously absent): summary, implications, and 3 openQuestions (Vandermonde / hockey-stick via the same powerset-decomposition method, and packaging the insert/erase bijection as a reusable `Equiv`).
- **Added 2 annotations** — a module-header context annotation framing the two decompositions, and a Part III sanity-checks annotation (noting kernel `decide`, not `native_decide`) — bringing the count 3 → 5.
- **Added a header-imports section** (3 → 4 sections).
- All 5 annotations carry mathContext/significance/relatedConcepts/prerequisites and are resolver-valid (0 misaligned).

Quality 68 → 98. meta.json stays ~11 KB, well under cap. Build (`pnpm build`) passes.