### PR TITLE
research: maximal-descent rung of the Eulerian bijection (⟨n+1,n⟩ = 1) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,154 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-
+# The maximal-descent rung of the Eulerian bijection
+
+The sibling entry **geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01** introduced the
+permutation descent statistic
+
+  `descentCount σ = |{i : Fin n | σ (i.succ) < σ (i.castSucc)}|`     (σ : Equiv.Perm (Fin (n+1)))
+
+and proved the **left border** `k = 0` of the still-open bijection
+`|{σ : descentCount σ = k}| = ⟨n+1,k⟩`:
+
+  `descentCount σ = 0 ↔ σ = 1`,   `|{σ : descentCount σ = 0}| = ⟨n+1,0⟩ = 1`.
+
+The increasing permutation is the unique descent-free one. This entry proves the **opposite
+border**, the open question `…-oq-02-oq-01-oq-01` — the maximal rung `k = n`:
+
+  `descentCount_eq_n_iff` :  `descentCount σ = n ↔ σ = Fin.revPerm`,
+  `card_descentMax`       :  `|{σ : descentCount σ = n}| = ⟨n+1, n⟩  (= 1)`.
+
+Combinatorially: a permutation of `Fin (n+1)` realizes the **maximum** possible `n` descents iff
+it is *strictly decreasing*, and the decreasing arrangement `Fin.revPerm : i ↦ rev i` is unique —
+so the maximally-descending permutations are counted by `⟨n+1,n⟩ = 1`, the **right** border of the
+Eulerian triangle, dual to the `⟨n+1,0⟩ = 1` left border. Together the two entries pin down both
+ends of the Eulerian row by honest cardinalities of descent classes.
+
+## Method
+
+There are exactly `n` adjacent positions, so `descentCount σ = n` forces *every* adjacent pair to
+be a descent: `σ (i.succ) < σ (i.castSucc)` for all `i`. Equivalently `rev ∘ σ` is strictly
+*increasing* at every adjacent pair (`Fin.rev` is antitone, `Fin.rev_lt_rev`), hence strictly
+monotone (`Fin.strictMono_iff_lt_succ`). A strictly monotone self-equivalence of `Fin (n+1)` is
+the identity (`perm_eq_one_of_strictMono`, the subsingleton `Fin m ≃o Fin m` argument reused from
+the sibling), so `σ.trans Fin.revPerm = 1`, i.e. `(σ i).rev = i`, i.e. `σ = Fin.revPerm`. The
+converse is immediate from `Fin.castSucc_lt_succ` and antitonicity of `rev`.
+
+The cardinality then follows from `Finset.card_eq_one`, the unique maximal-descent permutation
+being `Fin.revPerm`, and `eulerian_succ_pred : ⟨n+1,n⟩ = 1` (a short induction off the Eulerian
+recurrence and `eulerian_succ_self`).
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+The descent statistic is re-declared locally (the sibling's compiled artifact is not imported) so
+this entry stands alone on top of the parent Eulerian-number development.
+-/
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01
+
+open Equiv Finset GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-! ## A strictly monotone permutation of `Fin n` is the identity -/
+
+/-- A strictly monotone self-equivalence of `Fin n` is the identity. The monotone equivalence is
+an `OrderIso`, and `Fin n ≃o Fin n` is a subsingleton (its only element is the identity). -/
+private theorem perm_eq_one_of_strictMono {n : ℕ} (σ : Equiv.Perm (Fin n))
+    (hσ : StrictMono σ) : σ = 1 := by
+  have hmono : Monotone (σ : Fin n → Fin n) := hσ.monotone
+  have hmono' : Monotone (σ.symm : Fin n → Fin n) := by
+    intro a b hab
+    by_contra h
+    push_neg at h
+    have h2 := hσ h
+    simp only [Equiv.apply_symm_apply] at h2
+    exact absurd hab (not_le.2 h2)
+  let e : Fin n ≃o Fin n := σ.toOrderIso hmono hmono'
+  have he : e = OrderIso.refl _ := Subsingleton.elim _ _
+  have key : ∀ i, σ i = i := by
+    intro i
+    have hei : e i = i := by rw [he]; rfl
+    simpa [e, Equiv.toOrderIso] using hei
+  exact Equiv.ext key
+
+/-! ## The descent statistic (re-declared) -/
+
+/-- The **descent count** of a permutation `σ` of `Fin (n+1)`: the number of positions
+`i : Fin n` at which `σ` falls, `σ (i.succ) < σ (i.castSucc)`. -/
+def descentCount {n : ℕ} (σ : Equiv.Perm (Fin (n + 1))) : ℕ :=
+  (univ.filter (fun i : Fin n => σ i.succ < σ i.castSucc)).card
+
+/-! ## The right border `⟨n+1,n⟩ = 1` of the Eulerian triangle -/
+
+/-- The next-to-last Eulerian number on each row is `1`: `⟨n+1,n⟩ = 1`. A short induction using
+the Eulerian recurrence and the vanishing diagonal `eulerian_succ_self`. -/
+theorem eulerian_succ_pred (n : ℕ) : eulerian (n + 1) n = 1 := by
+  induction n with
+  | zero => rfl
+  | succ k ih =>
+    rw [eulerian_succ_succ, eulerian_succ_self, mul_zero, zero_add,
+      show (k + 1) - k = 1 from by omega, one_mul, ih]
+
+/-! ## The maximal-descent rung `k = n` -/
+
+/-- **Maximal descents ⟺ reverse permutation.** A permutation of `Fin (n+1)` attains the maximum
+possible `n` descents exactly when it is the strictly decreasing arrangement `Fin.revPerm`. -/
+theorem descentCount_eq_n_iff {n : ℕ} (σ : Equiv.Perm (Fin (n + 1))) :
+    descentCount σ = n ↔ σ = Fin.revPerm := by
+  constructor
+  · intro hn
+    -- `n` descents over `n` adjacent positions ⟹ every adjacent pair is a descent.
+    have hfull : (univ.filter (fun i : Fin n => σ i.succ < σ i.castSucc)) = univ := by
+      apply Finset.eq_univ_of_card
+      rw [Fintype.card_fin]
+      exact hn
+    have hall : ∀ i : Fin n, σ i.succ < σ i.castSucc := by
+      intro i
+      have hi : i ∈ univ.filter (fun i : Fin n => σ i.succ < σ i.castSucc) := by
+        rw [hfull]; exact mem_univ i
+      exact (Finset.mem_filter.mp hi).2
+    -- `rev ∘ σ` is strictly monotone, hence the identity.
+    have hg : StrictMono (σ.trans Fin.revPerm) := by
+      apply Fin.strictMono_iff_lt_succ.mpr
+      intro i
+      show (σ i.castSucc).rev < (σ i.succ).rev
+      rw [Fin.rev_lt_rev]
+      exact hall i
+    have h1 : σ.trans Fin.revPerm = 1 := perm_eq_one_of_strictMono _ hg
+    have hrev : ∀ a : Fin (n + 1), (Fin.revPerm : Equiv.Perm (Fin (n + 1))) a = a.rev :=
+      fun _ => rfl
+    apply Equiv.ext
+    intro i
+    have h2 := Equiv.ext_iff.mp h1 i
+    rw [Equiv.Perm.one_apply, Equiv.trans_apply, hrev] at h2
+    -- h2 : (σ i).rev = i
+    rw [hrev, ← Fin.rev_rev (σ i), h2]
+  · intro hrev
+    subst hrev
+    -- Every adjacent pair of `Fin.revPerm` is a descent.
+    have hfull : (univ.filter (fun i : Fin n =>
+        (Fin.revPerm : Equiv.Perm (Fin (n + 1))) i.succ
+          < (Fin.revPerm : Equiv.Perm (Fin (n + 1))) i.castSucc)) = univ := by
+      rw [Finset.filter_eq_self]
+      intro i _
+      show (i.succ).rev < (i.castSucc).rev
+      rw [Fin.rev_lt_rev]
+      exact Fin.castSucc_lt_succ (i := i)
+    show (univ.filter (fun i : Fin n =>
+        (Fin.revPerm : Equiv.Perm (Fin (n + 1))) i.succ
+          < (Fin.revPerm : Equiv.Perm (Fin (n + 1))) i.castSucc)).card = n
+    rw [hfull, Finset.card_univ, Fintype.card_fin]
+
+/-- **The maximal-descent rung of the Eulerian bijection.** The permutations of `Fin (n+1)` with
+the maximum number of descents number exactly the Eulerian number `⟨n+1,n⟩ = 1`: the decreasing
+permutation is the unique one. This is the `k = n` case of the open claim
+`|{σ : descentCount σ = k}| = ⟨n+1,k⟩`, dual to the `k = 0` border. -/
+theorem card_descentMax {n : ℕ} :
+    (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = n)).card
+      = eulerian (n + 1) n := by
+  rw [eulerian_succ_pred, Finset.card_eq_one]
+  refine ⟨Fin.revPerm, ?_⟩
+  ext σ
+  simp only [mem_filter, mem_univ, true_and, mem_singleton, descentCount_eq_n_iff]
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 47 },
+    "type": "context",
+    "title": "The Dual Border of the Eulerian Triangle",
+    "content": "The sibling entry introduced the permutation descent statistic descentCount σ and proved the LEFT border of the descent-count bijection: descent-free permutations are exactly the identity, counted by ⟨n+1,0⟩ = 1. Every Eulerian row is symmetric, ⟨n,0⟩ = ⟨n,n−1⟩ = 1, so the RIGHT border counts the unique permutation with the MAXIMUM number of descents — the strictly decreasing one. This entry proves that dual statement: descentCount σ = n ↔ σ = Fin.revPerm, hence |{σ : descentCount σ = n}| = ⟨n+1,n⟩ = 1. Together the two entries match both ends of every Eulerian row to honest cardinalities of descent classes. The interior columns 1 ≤ k ≤ n−1 (the full bijection via the insertion recurrence) remain open.",
+    "mathContext": "$\\langle n{+}1,n\\rangle = \\#\\{\\sigma : \\mathrm{des}(\\sigma) = n\\} = 1,$ the unique maximally-descending permutation being $i \\mapsto \\mathrm{rev}\\,i$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Eulerian numbers",
+      "permutation descents",
+      "Eulerian triangle border symmetry",
+      "reverse permutation"
+    ],
+    "prerequisites": [
+      "the sibling's descentCount statistic",
+      "permutations Equiv.Perm (Fin n)"
+    ]
+  },
+  {
+    "id": "ann-strictmono",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 52, "endLine": 73 },
+    "type": "technique",
+    "title": "A Strictly Monotone Permutation Is the Identity",
+    "content": "perm_eq_one_of_strictMono (carried over from the sibling): a strictly monotone self-equivalence of Fin n must be the identity. σ is monotone by hypothesis, its inverse is monotone too (a short by_contra using strict monotonicity), so σ.toOrderIso gives an element of Fin n ≃o Fin n. That type is a subsingleton — a finite linear order has exactly one order automorphism — so Subsingleton.elim forces e = OrderIso.refl, hence σ = 1. Here it is applied not to σ but to rev∘σ, which is what lets the same monotone lemma settle the strictly ANTITONE extreme.",
+    "mathContext": "$\\sigma \\text{ strictly monotone} \\Rightarrow \\sigma = \\mathrm{id},$ since $\\mathrm{Fin}\\,n \\simeq_o \\mathrm{Fin}\\,n$ is a subsingleton.",
+    "significance": "key",
+    "relatedConcepts": [
+      "order isomorphism",
+      "subsingleton",
+      "strict monotonicity",
+      "Equiv.toOrderIso"
+    ],
+    "prerequisites": [
+      "order isomorphisms on finite linear orders",
+      "monotone equivalences"
+    ]
+  },
+  {
+    "id": "ann-descentcount",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 74, "endLine": 79 },
+    "type": "definition",
+    "title": "The Descent Statistic",
+    "content": "descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}|, the number of adjacent positions where the permutation σ : Equiv.Perm (Fin (n+1)) falls. Re-declared locally so the entry stands alone on the parent Eulerian-number development rather than importing the sibling's compiled artifact. There are exactly n adjacent positions, so descentCount σ ranges in {0,…,n}, with the extremes 0 and n realized by the identity and the reversal respectively.",
+    "mathContext": "$\\mathrm{des}(\\sigma) = \\#\\{i : \\sigma(i{+}1) < \\sigma(i)\\} \\in \\{0,\\dots,n\\}.$",
+    "significance": "standard",
+    "relatedConcepts": [
+      "descent set",
+      "Finset.filter cardinality",
+      "adjacent transpositions"
+    ],
+    "prerequisites": [
+      "permutations of Fin (n+1)",
+      "Finset.filter and Finset.card"
+    ]
+  },
+  {
+    "id": "ann-eulerian-pred",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 90 },
+    "type": "technique",
+    "title": "The Right Border ⟨n+1,n⟩ = 1",
+    "content": "eulerian_succ_pred: a short induction proving ⟨n+1,n⟩ = 1 from the Eulerian recurrence and the vanishing diagonal eulerian_succ_self (⟨n+1,n+1⟩ = 0). The inductive step computes ⟨k+2,k+1⟩ = (k+2)·⟨k+1,k+1⟩ + ((k+1)−k)·⟨k+1,k⟩ = (k+2)·0 + 1·⟨k+1,k⟩ = ⟨k+1,k⟩, which is 1 by the inductive hypothesis. This is the dual of the parent's eulerian_succ_zero (⟨n+1,0⟩ = 1) and supplies the right-border value the maximal-descent cardinality is matched against.",
+    "mathContext": "$\\langle k{+}2,k{+}1\\rangle = (k{+}2)\\langle k{+}1,k{+}1\\rangle + \\langle k{+}1,k\\rangle = \\langle k{+}1,k\\rangle = 1.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Eulerian triangle recurrence",
+      "vanishing diagonal",
+      "induction on rows"
+    ],
+    "prerequisites": [
+      "the Eulerian recurrence eulerian_succ_succ",
+      "the vanishing diagonal eulerian_succ_self"
+    ]
+  },
+  {
+    "id": "ann-descentmax-iff",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 144 },
+    "type": "key-step",
+    "title": "Maximal Descents ⟺ Reverse Permutation",
+    "content": "descentCount σ = n ↔ σ = Fin.revPerm. Forward: n descents over the n adjacent positions force the descent set to be ALL of univ (Finset.eq_univ_of_card), so σ(i.succ) < σ(i.castSucc) for every i. Applying the order-reversing rev (Fin.rev_lt_rev) gives rev(σ(i.castSucc)) < rev(σ(i.succ)) on each adjacent pair, so the permutation σ.trans Fin.revPerm (i.e. i ↦ rev(σ i)) is strictly monotone by Fin.strictMono_iff_lt_succ, hence equals 1 by perm_eq_one_of_strictMono. Thus (σ i).rev = i for all i, which rearranges to σ i = i.rev = Fin.revPerm i. Converse: for σ = Fin.revPerm, every adjacent pair is a descent because i.castSucc < i.succ (Fin.castSucc_lt_succ) and rev reverses order, so the descent set is univ with cardinality n. The strictly antitone extreme is thus settled by the SAME monotone lemma, composed with rev.",
+    "mathContext": "$\\mathrm{des}(\\sigma) = n \\iff \\sigma = \\mathrm{rev} \\iff \\mathrm{rev}\\circ\\sigma = \\mathrm{id}.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "strict antitonicity",
+      "order reversal Fin.rev",
+      "full descent set",
+      "Finset.eq_univ_of_card"
+    ],
+    "prerequisites": [
+      "Fin.rev_lt_rev and Fin.strictMono_iff_lt_succ",
+      "perm_eq_one_of_strictMono"
+    ]
+  },
+  {
+    "id": "ann-card-descentmax",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 146, "endLine": 152 },
+    "type": "key-step",
+    "title": "The Maximal-Descent Rung",
+    "content": "card_descentMax: |{σ : Equiv.Perm (Fin (n+1)) | descentCount σ = n}| = ⟨n+1,n⟩ = 1. After rewriting the Eulerian number with eulerian_succ_pred, Finset.card_eq_one reduces the goal to exhibiting Fin.revPerm as the unique maximal-descent permutation, the singleton equality discharged by descentCount_eq_n_iff. This is the right-border dual of the sibling's card_descentFree, completing both ends of the Eulerian row at the level of actual permutation cardinalities.",
+    "mathContext": "$\\#\\{\\sigma : \\mathrm{des}(\\sigma) = n\\} = \\langle n{+}1,n\\rangle = 1.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.card_eq_one",
+      "unique witness",
+      "Eulerian border value"
+    ],
+    "prerequisites": [
+      "descentCount_eq_n_iff",
+      "eulerian_succ_pred"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Equiv",
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Maximal-Descent Rung of the Eulerian Bijection",
+  "description": "Answers the sibling entry's open question oq-01 by proving the right border of the descent-count bijection, dual to its k=0 left border. The sibling defined the permutation descent statistic descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}| on σ : Equiv.Perm (Fin (n+1)) and proved descentCount σ = 0 ↔ σ = 1 with |{σ : descentCount σ = 0}| = ⟨n+1,0⟩ = 1. This entry proves the maximal rung k = n: descentCount σ = n ↔ σ = Fin.revPerm (a permutation attains the maximum possible n descents iff it is the strictly decreasing arrangement i ↦ rev i), and hence |{σ : descentCount σ = n}| = ⟨n+1,n⟩ = 1. The forward direction observes that n descents over the n adjacent positions force every pair to be a descent, so rev∘σ is strictly increasing at each adjacent pair (rev is antitone, Fin.rev_lt_rev), hence strictly monotone (Fin.strictMono_iff_lt_succ), hence the identity (perm_eq_one_of_strictMono, the subsingleton Fin m ≃o Fin m argument), giving σ = Fin.revPerm. A short induction off the Eulerian recurrence and the vanishing diagonal eulerian_succ_self proves the new arithmetic fact eulerian_succ_pred : ⟨n+1,n⟩ = 1, the right border of the triangle. Together the two entries pin down both ends of every Eulerian row by honest cardinalities of descent classes. 154 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Eulerian number ⟨n,k⟩ counts permutations of {1,…,n} with exactly k descents. The gallery's Eulerian lineage builds these numbers analytically (triangle recurrence, Eulerian polynomial, row sum, inclusion–exclusion formula, palindromy, and descent moments) but the descent statistic on actual permutations was introduced only in the sibling entry oq-02-oq-01, which proved the k=0 rung (descent-free ⟺ identity, counted by ⟨n+1,0⟩ = 1, the left border of the triangle). The two borders of an Eulerian row are equal and symmetric: ⟨n,0⟩ = ⟨n,n−1⟩ = 1. The right border corresponds to the unique permutation with the maximum number of descents, namely the strictly decreasing one. This entry proves that dual statement directly, completing both ends of the row at the level of permutations.",
+    "problemStatement": "Prove the maximal-descent rung of the open descent-count bijection |{σ : descentCount σ = k}| = ⟨n+1,k⟩: characterize the permutations of Fin (n+1) with the maximum number n of descents (descentCount σ = n ↔ σ = Fin.revPerm) and show the resulting cardinality equals the Eulerian number ⟨n+1,n⟩ = 1.",
+    "proofStrategy": "The descent count ranges over the n adjacent positions of Fin (n+1), so descentCount σ = n forces the descent set to be all of univ (Finset.eq_univ_of_card with Fintype.card_fin), i.e. σ(i.succ) < σ(i.castSucc) for every i. Composing with the antitone reversal rev turns this into rev(σ(i.castSucc)) < rev(σ(i.succ)) for each adjacent pair (Fin.rev_lt_rev), so the permutation σ.trans Fin.revPerm (the map i ↦ rev(σ i)) is strictly monotone by Fin.strictMono_iff_lt_succ. A strictly monotone self-equivalence of Fin (n+1) is the identity (perm_eq_one_of_strictMono, reused from the sibling: the monotone equivalence is an OrderIso and Fin m ≃o Fin m is a subsingleton), so σ.trans Fin.revPerm = 1, i.e. (σ i).rev = i, i.e. σ i = i.rev = Fin.revPerm i for all i. The converse is immediate: Fin.castSucc_lt_succ and antitonicity of rev make every adjacent pair of Fin.revPerm a descent, so the descent set is univ with card n. The cardinality card_descentMax follows from Finset.card_eq_one with Fin.revPerm the unique maximal-descent permutation, and the new lemma eulerian_succ_pred : ⟨n+1,n⟩ = 1 — proved by a one-line induction using eulerian_succ_succ and the vanishing diagonal eulerian_succ_self.",
+    "keyInsights": [
+      "The maximal possible descent count is n (there are exactly n adjacent positions in Fin (n+1)), and attaining it forces the descent set to be the whole index set — Finset.eq_univ_of_card turns the cardinality equation directly into a universally-quantified adjacent-descent condition.",
+      "Strict antitonicity is handled without any new infrastructure: rev∘σ is strictly monotone because rev is order-reversing (Fin.rev_lt_rev), so the sibling's perm_eq_one_of_strictMono applies verbatim to σ.trans Fin.revPerm and identifies it with 1 — hence σ with Fin.revPerm.",
+      "The right border value ⟨n+1,n⟩ = 1 is a new arithmetic fact (eulerian_succ_pred), proved by a short induction off the triangle recurrence and the vanishing diagonal eulerian_succ_self: ⟨k+2,k+1⟩ = (k+2)·⟨k+1,k+1⟩ + 1·⟨k+1,k⟩ = ⟨k+1,k⟩.",
+      "Together with the sibling's k=0 rung this matches BOTH border entries of every Eulerian row to genuine descent-class cardinalities ⟨n+1,0⟩ = ⟨n+1,n⟩ = 1, the unique increasing and unique decreasing permutations respectively — the symmetric extremes of the descent distribution.",
+      "The interior columns 1 ≤ k ≤ n−1 remain open: they require a descent insertion recurrence on permutations matched to the Eulerian triangle, which neither this entry nor the sibling addresses."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context, scope, and method",
+      "startLine": 4,
+      "endLine": 47,
+      "summary": "Docstring situating the entry as the dual of the sibling's k=0 rung, recalling the descentCount definition, stating the two proved results (descentCount_eq_n_iff and card_descentMax) and the new arithmetic lemma eulerian_succ_pred, and outlining the rev∘σ strictly-monotone method. Honest scope note that interior columns remain open."
+    },
+    {
+      "id": "strictmono-id",
+      "title": "A strictly monotone permutation is the identity (perm_eq_one_of_strictMono)",
+      "startLine": 52,
+      "endLine": 73,
+      "summary": "The reusable lemma (carried over from the sibling): a strictly monotone σ : Equiv.Perm (Fin n) equals 1, since its monotone forward and inverse maps give an OrderIso via Equiv.toOrderIso and Fin n ≃o Fin n is a subsingleton."
+    },
+    {
+      "id": "descent-statistic",
+      "title": "The descent statistic (descentCount)",
+      "startLine": 74,
+      "endLine": 79,
+      "summary": "Re-declares descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}|, the number of falls of a permutation of Fin (n+1), so the entry stands alone on the parent Eulerian development."
+    },
+    {
+      "id": "eulerian-right-border",
+      "title": "The right border ⟨n+1,n⟩ = 1 (eulerian_succ_pred)",
+      "startLine": 81,
+      "endLine": 90,
+      "summary": "A short induction proving eulerian (n+1) n = 1 from the Eulerian recurrence eulerian_succ_succ and the vanishing diagonal eulerian_succ_self — the right-border value the maximal-descent cardinality is matched against."
+    },
+    {
+      "id": "descentmax-iff",
+      "title": "Maximal descents ⟺ reverse permutation (descentCount_eq_n_iff)",
+      "startLine": 92,
+      "endLine": 144,
+      "summary": "descentCount σ = n ↔ σ = Fin.revPerm: forward via full descent set (Finset.eq_univ_of_card) → rev∘σ strictly monotone (Fin.rev_lt_rev, Fin.strictMono_iff_lt_succ) → perm_eq_one_of_strictMono → σ = Fin.revPerm; converse from Fin.castSucc_lt_succ and antitonicity of rev."
+    },
+    {
+      "id": "card-descentmax",
+      "title": "The maximal-descent rung (card_descentMax)",
+      "startLine": 146,
+      "endLine": 152,
+      "summary": "|{σ : descentCount σ = n}| = ⟨n+1,n⟩ = 1, by Finset.card_eq_one with Fin.revPerm the unique maximal-descent permutation and eulerian_succ_pred."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "descent-statistic",
+      "permutations",
+      "order-isomorphism",
+      "cardinality",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 154,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "descentCount_eq_n_iff: the maximal-descent characterization descentCount σ = n ↔ σ = Fin.revPerm — a permutation of Fin (n+1) attains the maximum possible n descents iff it is the strictly decreasing arrangement i ↦ rev i. The forward direction reads the full descent set (forced by the cardinality) as σ(i.succ) < σ(i.castSucc) on every adjacent pair, makes rev∘σ strictly monotone by order-reversal of rev, and concludes σ = Fin.revPerm via perm_eq_one_of_strictMono.",
+      "card_descentMax: the k = n rung of the open Eulerian bijection — |{σ : Equiv.Perm (Fin (n+1)) | descentCount σ = n}| = ⟨n+1,n⟩ = 1. Together with the sibling's k = 0 rung this matches BOTH borders of every Eulerian row to genuine descent-class cardinalities, the unique increasing and unique decreasing permutations.",
+      "eulerian_succ_pred: the right-border arithmetic identity ⟨n+1,n⟩ = 1, proved by a short induction off the Eulerian triangle recurrence eulerian_succ_succ and the vanishing diagonal eulerian_succ_self — the dual of the parent's eulerian_succ_zero (⟨n+1,0⟩ = 1)."
+    ],
+    "prerequisites": [
+      "Sibling: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01 — introduces the descentCount statistic and the reusable lemma perm_eq_one_of_strictMono, and proves the dual k = 0 rung; this entry answers its open question oq-01 (the k = n rung)",
+      "Grandparent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers) — supplies eulerian, the recurrence eulerian_succ_succ, and the vanishing diagonal eulerian_succ_self used to prove eulerian_succ_pred",
+      "Mathlib order theory on Fin: Fin.rev_lt_rev, Fin.revPerm, Fin.rev_rev, Fin.strictMono_iff_lt_succ, Equiv.toOrderIso and the OrderIso subsingleton on Fin n, Fin.castSucc_lt_succ; Finset.eq_univ_of_card / Finset.card_eq_one / Finset.filter_eq_self for the cardinality"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.rev_lt_rev",
+        "description": "i.rev < j.rev ↔ j < i: the order-reversing property of Fin.rev. Turns the adjacent descents σ(i.succ) < σ(i.castSucc) into strict increase of rev∘σ, and converts the maximal-descent property of Fin.revPerm back to Fin.castSucc_lt_succ.",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Fin.strictMono_iff_lt_succ",
+        "description": "StrictMono f ↔ ∀ i, f i.castSucc < f i.succ for f : Fin (n+1) → α. Promotes the adjacent-pair increase of rev∘σ to strict monotonicity, feeding perm_eq_one_of_strictMono.",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.eq_univ_of_card",
+        "description": "s.card = Fintype.card α → s = univ. Converts descentCount σ = n (a cardinality over the n-element index Fin n) into the statement that every adjacent pair is a descent.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_eq_one",
+        "description": "s.card = 1 ↔ ∃ a, s = {a}. Reduces card_descentMax to exhibiting Fin.revPerm as the unique maximal-descent permutation, the singleton equality discharged by descentCount_eq_n_iff.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01.eulerian",
+        "description": "The grandparent's combinatorial Eulerian-number triangle, with the recurrence eulerian_succ_succ and vanishing diagonal eulerian_succ_self used to prove eulerian_succ_pred : ⟨n+1,n⟩ = 1, the target value the maximal-descent cardinality is matched against.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-02",
+      "question": "Establish the full bijection |{σ : descentCount σ = k}| = ⟨n+1,k⟩ for the interior columns 1 ≤ k ≤ n−1 by proving the descent insertion recurrence on permutations — inserting the largest element into a permutation of {1,…,n} either splits an existing ascent/descent — and matching it to the Eulerian triangle recurrence; this is the substantial remaining half of the parent's claim (2), now bracketed on both sides by the proved k=0 and k=n borders.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Sibling that introduced the descentCount statistic and proved the k=0 rung (descent-free ⟺ identity, |{σ : descentCount σ = 0}| = ⟨n+1,0⟩ = 1). This entry answers its open question oq-01: the dual k=n rung (maximal descents ⟺ reverse permutation, |{σ : descentCount σ = n}| = ⟨n+1,n⟩ = 1), reusing its perm_eq_one_of_strictMono lemma."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent (the combinatorial Eulerian numbers). Supplies the Eulerian triangle, the recurrence eulerian_succ_succ, and the vanishing diagonal eulerian_succ_self used to prove the new right-border value eulerian_succ_pred (⟨n+1,n⟩ = 1)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers and the descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers as descent counts of permutations, including the border symmetry ⟨n,0⟩ = ⟨n,n−1⟩ = 1 (unique increasing and decreasing permutations) this entry formalizes at the level of Equiv.Perm."
+    },
+    {
+      "title": "Mathlib4: Order.Fin.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Fin.rev_lt_rev, Fin.revPerm, Fin.strictMono_iff_lt_succ, and Fin.castSucc_lt_succ used to characterize the maximal-descent permutation as the order reversal."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "This entry answers the sibling's open question oq-01 by proving the right border of the descent-count bijection. It shows descentCount σ = n ↔ σ = Fin.revPerm — a permutation of Fin (n+1) realizes the maximum possible n descents exactly when it is the strictly decreasing arrangement — and concludes card_descentMax: |{σ : descentCount σ = n}| = ⟨n+1,n⟩ = 1. The crux is that n descents force the descent set to be the whole index, so rev∘σ is strictly monotone (rev order-reversing) and therefore the identity by the sibling's perm_eq_one_of_strictMono, pinning σ to Fin.revPerm; the right-border value ⟨n+1,n⟩ = 1 is the new lemma eulerian_succ_pred, a one-line induction off the triangle recurrence and the vanishing diagonal. 154 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Together with the sibling's k=0 rung, this entry matches BOTH borders of every Eulerian row — ⟨n+1,0⟩ = ⟨n+1,n⟩ = 1 — to genuine cardinalities of descent classes, the unique increasing and unique decreasing permutations, the symmetric extremes of the descent distribution. The reuse of perm_eq_one_of_strictMono for the strictly-antitone case (via rev∘σ) shows the sibling's lemma already covers both monotone and antitone extremes without new infrastructure. The interior columns 1 ≤ k ≤ n−1 stay open: they need a descent insertion recurrence on permutations matched to the Eulerian triangle, a substantial further development not currently supported by Mathlib.",
+    "openQuestions": [
+      "Establish the full descent-count bijection for the interior columns 1 ≤ k ≤ n−1 via a descent insertion recurrence on permutations matched to the Eulerian triangle, now bracketed by the proved k=0 and k=n borders."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **oq-01** of `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01` — the **maximal-descent rung** of the still-open descent-count bijection, dual to that entry's already-proved `k=0` left border.

The sibling defined the permutation descent statistic `descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}|` on `σ : Equiv.Perm (Fin (n+1))` and proved `descentCount σ = 0 ↔ σ = 1` with `|{σ : descentCount σ = 0}| = ⟨n+1,0⟩ = 1`. This entry proves the opposite border, `k = n`:

- `descentCount_eq_n_iff` : `descentCount σ = n ↔ σ = Fin.revPerm` — a permutation attains the maximum possible `n` descents iff it is the strictly decreasing arrangement `i ↦ rev i`.
- `card_descentMax` : `|{σ : descentCount σ = n}| = ⟨n+1,n⟩ = 1`.
- `eulerian_succ_pred` : `⟨n+1,n⟩ = 1` — new right-border arithmetic identity, a short induction off the Eulerian recurrence and the vanishing diagonal `eulerian_succ_self` (dual to the parent's `eulerian_succ_zero`).

## Method

`n` descents over the `n` adjacent positions force the descent set to be all of `univ` (`Finset.eq_univ_of_card`). Applying the order-reversing `rev` (`Fin.rev_lt_rev`) makes `rev∘σ = σ.trans Fin.revPerm` strictly monotone (`Fin.strictMono_iff_lt_succ`), hence the identity via the sibling's reusable `perm_eq_one_of_strictMono` (the subsingleton `Fin m ≃o Fin m` argument). So `(σ i).rev = i`, i.e. `σ = Fin.revPerm`. The converse is immediate from `Fin.castSucc_lt_succ` and antitonicity of `rev`. **The strictly-antitone extreme is settled by the same monotone lemma, composed with `rev` — no new infrastructure.**

Together with the sibling, both borders of every Eulerian row — `⟨n+1,0⟩ = ⟨n+1,n⟩ = 1` — are now matched to genuine descent-class cardinalities (the unique increasing and unique decreasing permutations). Interior columns `1 ≤ k ≤ n−1` remain open (descent insertion recurrence).

## Verification

- Offline-verified with `lake env lean` (docker build path unavailable): **EXIT 0**, no errors/warnings.
- `#print axioms` on all theorems: `propext, Classical.choice, Quot.sound` only — **0-axiom, 0-sorry**.
- 154 lines, 4 theorems, 1 definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)