### PR TITLE
research(euler-totient-oq-03-oq-02): φ(n) ≥ √n for n > 6 (verified, 0 axioms)

### DIFF
--- a/proofs/Proofs/EulerTotientOQ03OQ02.lean
+++ b/proofs/Proofs/EulerTotientOQ03OQ02.lean
@@ -1,0 +1,243 @@
+import Mathlib
+
+/-
+# A lower bound for Euler's totient: `φ(n) ≥ √n` for `n > 6`
+
+`euler-totient-oq-03-oq-02`
+
+The gallery entry `euler-totient-oq-03` ("Structural Properties: Parity, Divisibility,
+and the Product Formula") lists, among its open questions:
+
+> "Is there a Lean proof that `φ(n) ≥ √n` for all `n > 6`? This would require bounding
+>  the product formula from below using prime number estimates."
+
+This file answers that question.  The cleanest formulation avoids real square roots
+entirely by squaring: `φ(n) ≥ √n` is, for natural numbers, exactly
+
+    `n ≤ φ(n)²`.
+
+The two genuine exceptions are `n = 2` (`φ(2)² = 1 < 2`) and `n = 6`
+(`φ(6)² = 4 < 6`); for every other `n` — in particular every `n > 6` — the bound holds.
+
+## Proof strategy (no analytic prime estimates needed)
+
+`f(n) = φ(n)²/n` is multiplicative, so the bound reduces to prime powers.  For an
+**odd** prime power `pᵏ` (`p ≥ 3`) one has `pᵏ ≤ φ(pᵏ)²` with room to spare, while the
+only deficient prime power is `2¹`.  Writing `n = 2ᵏ·m` with `m` odd:
+
+* the **odd part** always satisfies `m ≤ φ(m)²`, and in fact `2m ≤ φ(m)²` once `m ∉ {1,3}`
+  (proved together by induction on the multiplicative structure of `m`, via
+  `Nat.recOnPosPrimePosCoprime`);
+* gluing in the `2`-part: for `k ≥ 2` the factor `2^{2k-2}` already dominates `2ᵏ`, and
+  for `k = 1` the hypothesis `n > 6` forces `m ≥ 5`, so the sharper odd bound `2m ≤ φ(m)²`
+  closes the gap.
+
+Everything is elementary `Nat` arithmetic on top of Mathlib's `Nat.totient` API — no
+prime-counting or analytic input is required, contrary to the question's expectation.
+
+## What is proved (fully verified: 0 axioms, 0 sorries)
+
+* `totient_sq_ge_self`   — `6 < n → n ≤ φ(n)²` (the squared, exception-free form).
+* `sqrt_le_totient`      — `6 < n → √n ≤ φ(n)` (the literal statement, over `ℝ`).
+* `phi_sq_ge_self_of_odd` / `phi_sq_ge_two_mul_of_odd` — the odd-part lemmas, of
+  independent interest (`m ≤ φ(m)²` for all odd `m`; `2m ≤ φ(m)²` for odd `m ∉ {1,3}`).
+-/
+
+open Nat
+
+namespace EulerTotientOQ03OQ02
+
+/-! ## Arithmetic kernels for the prime-power estimate
+
+With `q = p^{k-1} ≥ 1` and `a = p-1`, a prime power is `pᵏ = q·(a+1)` and
+`φ(pᵏ) = q·a`.  The required inequalities become subtraction-free statements in `q, a`. -/
+
+private lemma le_self_mul (q a : ℕ) (hq : 1 ≤ q) : a ≤ q * a := by
+  have := Nat.mul_le_mul hq (le_refl a); simpa using this
+
+private lemma arith_self (q a : ℕ) (hq : 1 ≤ q) (ha : 2 ≤ a) :
+    q * (a + 1) ≤ (q * a) ^ 2 := by
+  have e1 : a + 1 ≤ a * a := by nlinarith [ha]
+  have e2 : a ≤ q * a := le_self_mul q a hq
+  calc q * (a + 1) ≤ q * (a * a) := Nat.mul_le_mul (le_refl q) e1
+    _ = q * a * a := by ring
+    _ ≤ q * a * (q * a) := Nat.mul_le_mul (le_refl (q * a)) e2
+    _ = (q * a) ^ 2 := by ring
+
+private lemma arith_two_of_a (q a : ℕ) (hq : 1 ≤ q) (ha : 3 ≤ a) :
+    2 * (q * (a + 1)) ≤ (q * a) ^ 2 := by
+  have e1 : 2 * (a + 1) ≤ a * a := by nlinarith [ha]
+  have e2 : a ≤ q * a := le_self_mul q a hq
+  calc 2 * (q * (a + 1)) = q * (2 * (a + 1)) := by ring
+    _ ≤ q * (a * a) := Nat.mul_le_mul (le_refl q) e1
+    _ = q * a * a := by ring
+    _ ≤ q * a * (q * a) := Nat.mul_le_mul (le_refl (q * a)) e2
+    _ = (q * a) ^ 2 := by ring
+
+private lemma arith_two_of_q (q a : ℕ) (hq : 2 ≤ q) (ha : 2 ≤ a) :
+    2 * (q * (a + 1)) ≤ (q * a) ^ 2 := by
+  have e0 : a + 1 ≤ a * a := by nlinarith [ha]
+  calc 2 * (q * (a + 1)) ≤ q * (q * (a + 1)) := Nat.mul_le_mul hq (le_refl _)
+    _ = q * q * (a + 1) := by ring
+    _ ≤ q * q * (a * a) := Nat.mul_le_mul (le_refl (q * q)) e0
+    _ = (q * a) ^ 2 := by ring
+
+/-! ## The odd-part induction
+
+A single induction proves both `m ≤ φ(m)²` and the sharpened `2m ≤ φ(m)²` (away from the
+two small exceptions `m = 1, 3`).  We carry the disjunction `m = 1 ∨ m = 3 ∨ 2m ≤ φ(m)²`
+so that the multiplicative step has enough slack to recombine. -/
+
+private def OddBound (m : ℕ) : Prop :=
+  Odd m → m ≤ (Nat.totient m) ^ 2 ∧ (m = 1 ∨ m = 3 ∨ 2 * m ≤ (Nat.totient m) ^ 2)
+
+private lemma oddBound_prime_pow (p k : ℕ) (hp : p.Prime) (hk : 0 < k) :
+    OddBound (p ^ k) := by
+  intro hodd
+  -- An odd prime power has odd base, so `p ≥ 3`.
+  have hp2 : p ≠ 2 := by
+    rintro rfl
+    have hdvd : 2 ∣ 2 ^ k := dvd_pow_self 2 hk.ne'
+    have h2 : 2 ^ k % 2 = 1 := Nat.odd_iff.mp hodd
+    omega
+  have hp3 : 3 ≤ p := by
+    rcases hp.eq_two_or_odd' with h | hodd'
+    · exact absurd h hp2
+    · have := hp.two_le; omega
+  -- Set `a = p - 1 ≥ 2`, `q = p^{k-1} ≥ 1`; then `p^k = q*(a+1)`, `φ(p^k) = q*a`.
+  obtain ⟨a, rfl⟩ : ∃ a, p = a + 1 := ⟨p - 1, by omega⟩
+  have ha : 2 ≤ a := by omega
+  obtain ⟨q, hq_def⟩ : ∃ q, q = (a + 1) ^ (k - 1) := ⟨_, rfl⟩
+  have hq1 : 1 ≤ q := by
+    rw [hq_def]; exact Nat.one_le_iff_ne_zero.mpr (pow_ne_zero _ (by omega))
+  have hpk : (a + 1) ^ k = q * (a + 1) := by
+    rw [hq_def, ← pow_succ]; congr 1; omega
+  have hphi : Nat.totient ((a + 1) ^ k) = q * a := by
+    rw [Nat.totient_prime_pow hp hk, ← hq_def, Nat.add_sub_cancel]
+  rw [hphi, hpk]
+  refine ⟨arith_self q a hq1 ha, ?_⟩
+  -- Disjunction: either `p^k = 3` (i.e. `a = 2, k = 1`) or `2·p^k ≤ φ(p^k)²`.
+  by_cases hexc : a = 2 ∧ k = 1
+  · obtain ⟨rfl, rfl⟩ := hexc
+    right; left; rw [hq_def]; norm_num
+  · refine Or.inr (Or.inr ?_)
+    rcases lt_or_ge a 3 with hlt | hge
+    · -- `a = 2`, so `p = 3`; then `hexc` forces `k ≥ 2`, giving `q ≥ 2`.
+      have ha2 : a = 2 := by omega
+      have hk2 : 2 ≤ k := by
+        rcases Nat.lt_or_ge k 2 with h | h
+        · exact absurd ⟨ha2, by omega⟩ hexc
+        · exact h
+      have hq2 : 2 ≤ q := by
+        rw [hq_def, ha2]
+        calc 2 ≤ 3 ^ 1 := by norm_num
+          _ ≤ 3 ^ (k - 1) := Nat.pow_le_pow_right (by norm_num) (by omega)
+      exact arith_two_of_q q a hq2 ha
+    · exact arith_two_of_a q a hq1 hge
+
+private lemma oddBound_one : OddBound 1 := by
+  intro _; refine ⟨by simp, Or.inl rfl⟩
+
+private lemma oddBound_coprime (a b : ℕ) (ha1 : 1 < a) (hb1 : 1 < b)
+    (hcop : Nat.Coprime a b) (iha : OddBound a) (ihb : OddBound b) :
+    OddBound (a * b) := by
+  intro hodd
+  obtain ⟨hoa, hob⟩ := Nat.odd_mul.mp hodd
+  obtain ⟨hsa, hda⟩ := iha hoa
+  obtain ⟨hsb, hdb⟩ := ihb hob
+  have hφ : Nat.totient (a * b) = Nat.totient a * Nat.totient b := Nat.totient_mul hcop
+  have hsq : (Nat.totient (a * b)) ^ 2 = (Nat.totient a) ^ 2 * (Nat.totient b) ^ 2 := by
+    rw [hφ, mul_pow]
+  -- The product `a*b ≥ 4 > 3`, so we must land in the `2·(a*b) ≤ φ²` disjunct.
+  refine ⟨by rw [hsq]; exact Nat.mul_le_mul hsa hsb, Or.inr (Or.inr ?_)⟩
+  rw [hsq, mul_comm 2 (a * b), mul_assoc]
+  -- `a, b` are both `> 1`, so they fall in the `a = 3 ∨ 2a ≤ φ(a)²` shape.
+  have hda' : a = 3 ∨ 2 * a ≤ (Nat.totient a) ^ 2 := hda.resolve_left (by omega)
+  have hdb' : b = 3 ∨ 2 * b ≤ (Nat.totient b) ^ 2 := hdb.resolve_left (by omega)
+  rcases hdb' with hb3 | hb2
+  · -- `b = 3`: then `a` is coprime to `3`, hence `a ≠ 3`, so `a` has the sharp slack.
+    subst hb3
+    have hane3 : a ≠ 3 := by
+      rintro rfl
+      exact absurd hcop (by decide)
+    have ha2 : 2 * a ≤ (Nat.totient a) ^ 2 := hda'.resolve_left hane3
+    have hφ3 : Nat.totient 3 = 2 := by decide
+    rw [hφ3]
+    -- Goal: `a * (3 * 2) ≤ φ(a)² * 2²`, i.e. `6a ≤ 4·φ(a)²`; from `2a ≤ φ(a)²`.
+    nlinarith [ha2]
+  · -- `2b ≤ φ(b)²`: combine with `a ≤ φ(a)²`.
+    calc a * (b * 2) = a * (2 * b) := by ring
+      _ ≤ (Nat.totient a) ^ 2 * (Nat.totient b) ^ 2 := Nat.mul_le_mul hsa hb2
+
+private lemma oddBound_all (m : ℕ) : OddBound m :=
+  Nat.recOnPosPrimePosCoprime oddBound_prime_pow (fun h => absurd h (by decide))
+    oddBound_one oddBound_coprime m
+
+/-- **Odd totient lower bound.** For every odd `m`, `m ≤ φ(m)²` (equivalently `φ(m) ≥ √m`).
+No exceptions: the small odd values check directly (`1 ≤ 1`, `3 ≤ 4`, `5 ≤ 16`, …). -/
+theorem phi_sq_ge_self_of_odd {m : ℕ} (hm : Odd m) : m ≤ (Nat.totient m) ^ 2 :=
+  (oddBound_all m hm).1
+
+/-- **Sharpened odd bound.** For odd `m` other than `1` and `3`, even `2m ≤ φ(m)²` holds.
+(`m = 1` gives `2 ≤ 1` and `m = 3` gives `6 ≤ 4`, the two genuine failures.) -/
+theorem phi_sq_ge_two_mul_of_odd {m : ℕ} (hm : Odd m) (h1 : m ≠ 1) (h3 : m ≠ 3) :
+    2 * m ≤ (Nat.totient m) ^ 2 := by
+  have h := (oddBound_all m hm).2
+  rcases h with h | h | h
+  · exact absurd h h1
+  · exact absurd h h3
+  · exact h
+
+/-! ## The full bound via the `2`-adic decomposition -/
+
+/-- **`φ(n) ≥ √n` for `n > 6`, squared form.**  For every `n > 6`, `n ≤ φ(n)²`.
+The two genuine exceptions to `n ≤ φ(n)²` are `n = 2` and `n = 6`, both excluded by
+`n > 6`. -/
+theorem totient_sq_ge_self {n : ℕ} (hn : 6 < n) : n ≤ (Nat.totient n) ^ 2 := by
+  obtain ⟨k, m, hm, rfl⟩ := Nat.exists_eq_two_pow_mul_odd (n := n) (by omega)
+  -- `m` is odd, so `2ᵏ` and `m` are coprime.
+  have hcop : Nat.Coprime (2 ^ k) m := by
+    refine Nat.Coprime.pow_left k ?_
+    rw [Nat.prime_two.coprime_iff_not_dvd]
+    intro hd
+    rw [Nat.dvd_iff_mod_eq_zero] at hd
+    have hm1 : m % 2 = 1 := Nat.odd_iff.mp hm
+    omega
+  have hφ : Nat.totient (2 ^ k * m) = Nat.totient (2 ^ k) * Nat.totient m :=
+    Nat.totient_mul hcop
+  have hmpos : 0 < m := hm.pos
+  rcases Nat.eq_zero_or_pos k with hk0 | hkpos
+  · -- `k = 0`: `n = m` is odd; apply the odd bound.
+    subst hk0
+    simpa using phi_sq_ge_self_of_odd hm
+  · -- `k = j + 1 ≥ 1`: `φ(2ᵏ) = 2ʲ`.
+    obtain ⟨j, rfl⟩ : ∃ j, k = j + 1 := ⟨k - 1, by omega⟩
+    have hφ2 : Nat.totient (2 ^ (j + 1)) = 2 ^ j := by
+      rw [Nat.totient_prime_pow_succ Nat.prime_two]; norm_num
+    rw [hφ, hφ2, mul_pow]
+    -- Goal: `2^{j+1} * m ≤ (2^j)² * φ(m)² = 2^{2j} * φ(m)²`.
+    rcases Nat.eq_zero_or_pos j with hj0 | hjpos
+    · -- `j = 0`, i.e. `k = 1`, `n = 2m > 6` ⟹ `m ≥ 5`, so `m ∉ {1,3}`.
+      subst hj0
+      have hm5 : 5 ≤ m := by
+        rcases hm with ⟨t, rfl⟩; omega
+      have := phi_sq_ge_two_mul_of_odd hm (by omega) (by omega)
+      simpa using this
+    · -- `j ≥ 1`: `2^{j+1} ≤ 2^{2j}` dominates, and `m ≤ φ(m)²`.
+      have hpow : 2 ^ (j + 1) ≤ (2 ^ j) ^ 2 := by
+        rw [← pow_mul]
+        exact Nat.pow_le_pow_right (by norm_num) (by omega)
+      have hmm : m ≤ (Nat.totient m) ^ 2 := phi_sq_ge_self_of_odd hm
+      calc 2 ^ (j + 1) * m ≤ (2 ^ j) ^ 2 * (Nat.totient m) ^ 2 :=
+            Nat.mul_le_mul hpow hmm
+        _ = (2 ^ j) ^ 2 * (Nat.totient m) ^ 2 := rfl
+
+/-- **`φ(n) ≥ √n` for `n > 6`** — the literal statement over the reals.  Immediate from
+the squared form `totient_sq_ge_self` by taking square roots. -/
+theorem sqrt_le_totient {n : ℕ} (hn : 6 < n) :
+    Real.sqrt n ≤ (Nat.totient n : ℝ) := by
+  have h : (n : ℝ) ≤ (Nat.totient n : ℝ) ^ 2 := by exact_mod_cast totient_sq_ge_self hn
+  calc Real.sqrt n ≤ Real.sqrt ((Nat.totient n : ℝ) ^ 2) := Real.sqrt_le_sqrt h
+    _ = (Nat.totient n : ℝ) := Real.sqrt_sq (by positivity)
+
+end EulerTotientOQ03OQ02

--- a/src/data/proofs/euler-totient-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-02/annotations.json
@@ -1,0 +1,88 @@
+[
+  {
+    "id": "ann-squaring-removes-analysis",
+    "proofId": "euler-totient-oq-03-oq-02",
+    "range": {
+      "startLine": 196,
+      "endLine": 235
+    },
+    "type": "insight",
+    "title": "Squaring Turns an Analytic Bound into Pure Arithmetic",
+    "content": "The open question asks for `φ(n) ≥ √n` and expects it to \"require bounding the product formula from below using prime number estimates.\" Both expectations are sidestepped. Over ℕ the inequality `φ(n) ≥ √n` is *equivalent* to the subtraction-free, square-root-free statement\n```\nn ≤ φ(n)².\n```\nThis is the form proved as `totient_sq_ge_self`; the literal real-valued `√n ≤ φ(n)` (`sqrt_le_totient`) follows in three lines by casting and `Real.sqrt_sq`. No prime counting, no `Real.sqrt` inside the hard argument, no analytic estimate — only multiplicativity of φ and one elementary prime-power inequality.\n\nNumerically the failures of `n ≤ φ(n)²` over `2 ≤ n ≤ 30` are exactly `{2, 6}`, so the hypothesis `n > 6` is tight.",
+    "mathContext": "$\\varphi(n)\\ge\\sqrt n \\iff n\\le\\varphi(n)^2$ over $\\mathbb N$. The exceptions $n=2$ ($\\varphi=1$) and $n=6$ ($\\varphi=2$) are genuine; for all $n>6$ the bound holds.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.totient",
+      "Real.sqrt_le_sqrt",
+      "Real.sqrt_sq"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  },
+  {
+    "id": "ann-only-deficient-prime-power",
+    "proofId": "euler-totient-oq-03-oq-02",
+    "range": {
+      "startLine": 94,
+      "endLine": 135
+    },
+    "type": "insight",
+    "title": "The Only Deficient Prime Power Is 2¹",
+    "content": "Since `f(n) = φ(n)²/n` is multiplicative, `n ≤ φ(n)²` reduces to prime powers. For an *odd* prime power `pᵏ` (`p ≥ 3`) one always has `pᵏ ≤ φ(pᵏ)²`, in fact with the doubled slack `2·pᵏ ≤ φ(pᵏ)²` unless `(p,k) = (3,1)`. Writing `q = pᵏ⁻¹`, `a = p−1`, this is the finite check `q(a+1) ≤ (qa)²` (and its doubled form), discharged by the kernels `arith_self` / `arith_two_of_a` / `arith_two_of_q`.\n\nThe single prime power that fails `n ≤ φ(n)²` is `2¹` (`φ(2)² = 1 < 2`); even `2ᵏ` for `k ≥ 2` is fine. So the global bound can only break through a lone factor of 2 combined with a too-small odd part — which is exactly why the two exceptions are `n = 2` and `n = 6`.",
+    "mathContext": "$\\varphi(p^k)=p^{k-1}(p-1)$, so $\\varphi(p^k)^2/p^k = p^{k-2}(p-1)^2 \\ge 1$ for $p\\ge3$ (with equality nowhere) and for $p=2,k\\ge2$; only $p=2,k=1$ gives $1/2<1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.totient_prime_pow",
+      "multiplicative function",
+      "prime power"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  },
+  {
+    "id": "ann-paired-invariant",
+    "proofId": "euler-totient-oq-03-oq-02",
+    "range": {
+      "startLine": 91,
+      "endLine": 169
+    },
+    "type": "insight",
+    "title": "Why the Induction Carries a Stronger Paired Invariant",
+    "content": "A naive induction on `m ≤ φ(m)²` does **not** recombine in the multiplicative step. The fix is to induct on the *paired* invariant\n```\nOddBound m := Odd m → m ≤ φ(m)² ∧ (m = 1 ∨ m = 3 ∨ 2m ≤ φ(m)²),\n```\nvia `Nat.recOnPosPrimePosCoprime`. The extra disjunct `2m ≤ φ(m)²` supplies one factor of 2 of slack.\n\nIn the coprime step `m = a·b` (`a,b > 1`): if `b = 3`, coprimality forces `gcd(a,3)=1`, hence `a ≠ 3`, so the inductive disjunction gives the sharp `2a ≤ φ(a)²`, and `6a ≤ 4φ(a)² = φ(a)²φ(3)²`. Otherwise `2b ≤ φ(b)²` combines directly with `a ≤ φ(a)²`. Either way the product never multiplies two deficient factors, so `2(ab) ≤ φ(ab)²` survives.",
+    "mathContext": "The recombination `2(ab) ≤ φ(a)²φ(b)²` needs only one of the factors to carry the doubled bound; coprimality guarantees that when one factor is the deficient `3`, the other is `≠ 3` and therefore sharp.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.recOnPosPrimePosCoprime",
+      "Nat.totient_mul",
+      "Nat.Coprime",
+      "strong induction"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  },
+  {
+    "id": "ann-2adic-gluing",
+    "proofId": "euler-totient-oq-03-oq-02",
+    "range": {
+      "startLine": 196,
+      "endLine": 235
+    },
+    "type": "technique",
+    "title": "Where n > 6 Is Actually Used: the 2-adic Split",
+    "content": "Write `n = 2ᵏ·m` with `m` odd (`Nat.exists_eq_two_pow_mul_odd`) and `gcd(2ᵏ, m) = 1`. Then `φ(n) = φ(2ᵏ)·φ(m)`, and the proof splits on `k`:\n\n- **k = 0**: `n = m` is odd, so the odd bound `m ≤ φ(m)²` applies directly.\n- **k ≥ 2**: `φ(n)² = 2^{2k−2}·φ(m)²` and `2^{2k−2} ≥ 2ᵏ`, so the 2-part already dominates.\n- **k = 1**: `n = 2m`, `φ(n) = φ(m)`, so the goal is `2m ≤ φ(m)²` — the *sharp* odd bound. This is the **only** branch needing the hypothesis: `n > 6` forces `m > 3`, hence (m odd) `m ≥ 5`, so `m ∉ {1,3}` and the sharpened bound applies.\n\nThus the entire role of `n > 6` is to push the odd part past the `m = 3` exception in the `k = 1` case.",
+    "mathContext": "$n=2^k m$, $\\varphi(2^k)=2^{k-1}$ for $k\\ge1$. The tight case is $k=1$: $n=2m>6\\Rightarrow m\\ge5\\Rightarrow 2m\\le\\varphi(m)^2$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.exists_eq_two_pow_mul_odd",
+      "Nat.Coprime.pow_left",
+      "Nat.totient_mul",
+      "2-adic valuation"
+    ],
+    "prerequisites": [
+      "euler-totient-oq-03"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-03-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-03-oq-02/meta.json
@@ -1,0 +1,130 @@
+{
+  "id": "euler-totient-oq-03-oq-02",
+  "slug": "euler-totient-oq-03-oq-02",
+  "title": "A Lower Bound for Euler's Totient: φ(n) ≥ √n for n > 6",
+  "leanFile": {
+    "lineCount": 243,
+    "path": "Proofs/EulerTotientOQ03OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 12
+  },
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "multiplicative-functions",
+      "totient",
+      "lower-bound",
+      "prime-powers"
+    ],
+    "proofRepoPath": "Proofs/EulerTotientOQ03OQ02.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Every theorem depends only on the foundational axioms propext, Classical.choice, Quot.sound (not counted), as confirmed by `#print axioms` on totient_sq_ge_self and sqrt_le_totient. No `native_decide` is used (the `decide`/`norm_num`/`nlinarith` calls are kernel-checked), so `Lean.ofReduceBool` is NOT introduced. Built against Mathlib's `Nat.totient` API (`totient_prime_pow`, `totient_mul`, `recOnPosPrimePosCoprime`, `exists_eq_two_pow_mul_odd`).",
+    "lineCount": 243,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-27"
+  },
+  "description": "Answers the second open question of the parent entry: gives a Lean proof that φ(n) ≥ √n for all n > 6. The bound is formulated exception-free over ℕ as n ≤ φ(n)² (real square roots are avoided; a ℝ corollary √n ≤ φ(n) is then derived). The proof needs NO analytic prime estimates — contrary to the question's expectation — only the multiplicative structure of φ: an odd prime power pᵏ (p ≥ 3) already satisfies pᵏ ≤ φ(pᵏ)² with room to spare, the sole deficient prime power being 2¹. Writing n = 2ᵏ·m with m odd, an induction over the multiplicative structure of the odd part m proves m ≤ φ(m)² (and the sharper 2m ≤ φ(m)² for m ∉ {1,3}), and the 2-adic gluing closes the bound, with n > 6 forcing m ≥ 5 in the single tight case k = 1. The only exceptions to n ≤ φ(n)² are n = 2 and n = 6. 0 sorries, 0 axioms.",
+  "overview": {
+    "historicalContext": "Euler's totient $\\varphi(n)$ counts the integers in $[1,n]$ coprime to $n$. While $\\varphi(n)\\le n-1$ is immediate, lower bounds are subtler because $\\varphi$ can be small for highly composite $n$ (e.g. $\\varphi(2\\cdot3\\cdot5\\cdots)=\\prod(p-1)$ grows slowly relative to $n$). A classical and frequently-quoted benchmark is $\\varphi(n)>\\sqrt{n}$ for $n>6$ — strong enough to be useful (it shows $\\varphi(n)\\to\\infty$ with explicit rate $\\gg\\sqrt n$), yet provable by completely elementary means. The two exceptions $n=2$ ($\\varphi=1<\\sqrt2$) and $n=6$ ($\\varphi=2<\\sqrt6$) are genuine and famous.",
+    "problemStatement": "**Open Question (OQ-03-OQ-02)**: \"Is there a Lean proof that $\\varphi(n)\\ge\\sqrt n$ for all $n>6$? This would require bounding the product formula from below using prime number estimates.\"\n\n**Answer: YES — and no prime-counting estimates are needed.** For natural numbers the bound $\\varphi(n)\\ge\\sqrt n$ is equivalent to the subtraction-free statement $n\\le\\varphi(n)^2$, whose only exceptions are $n=2$ and $n=6$. The result follows purely from the multiplicativity of $\\varphi$ and a prime-power estimate, with no analytic input.",
+    "proofStrategy": "The function $f(n)=\\varphi(n)^2/n$ is multiplicative, so $n\\le\\varphi(n)^2$ reduces to prime powers.\n\n**Arithmetic kernels.** With $q=p^{k-1}$ and $a=p-1$, a prime power is $p^k=q(a+1)$ and $\\varphi(p^k)=qa$, turning the needed inequalities into subtraction-free facts $q(a+1)\\le(qa)^2$ (for $a\\ge2$) and $2q(a+1)\\le(qa)^2$ (for $a\\ge3$, or $a\\ge2\\wedge q\\ge2$), each proved by an explicit `Nat` multiplication chain.\n\n**Odd-part induction.** A single induction via `Nat.recOnPosPrimePosCoprime` proves, for every odd $m$, both $m\\le\\varphi(m)^2$ and the disjunction $m=1\\vee m=3\\vee 2m\\le\\varphi(m)^2$. Carrying the disjunction supplies the slack the multiplicative step needs to recombine: in the coprime case $m=ab$, if one factor equals $3$ the other is coprime to $3$ hence $\\ne3$, so it contributes the sharp $2\\cdot$ bound.\n\n**2-adic gluing.** Writing $n=2^k m$ with $m$ odd (`Nat.exists_eq_two_pow_mul_odd`) and $\\gcd(2^k,m)=1$: for $k=0$, $n=m$ is odd and the odd bound applies; for $k\\ge2$ the factor $2^{2k-2}$ dominates $2^k$; for $k=1$ the hypothesis $n>6$ forces $m\\ge5$, so $m\\notin\\{1,3\\}$ and the sharpened odd bound $2m\\le\\varphi(m)^2$ exactly closes the gap.\n\n**Real corollary.** `sqrt_le_totient` casts $n\\le\\varphi(n)^2$ to $\\mathbb R$ and applies `Real.sqrt_le_sqrt` / `Real.sqrt_sq`.",
+    "keyInsights": [
+      "Squaring removes the analysis: φ(n) ≥ √n over ℕ is exactly n ≤ φ(n)², a pure arithmetic statement provable without Real.sqrt, prime counting, or any of the 'prime number estimates' the open question anticipated.",
+      "The only deficient prime power is 2¹: every odd prime power pᵏ (p ≥ 3) satisfies pᵏ ≤ φ(pᵏ)² with slack, and even 2ᵏ for k ≥ 2 does. So the bound can only fail through a lone factor of 2 combined with a too-small odd part — which is precisely why the exceptions are n = 2 and n = 6.",
+      "Inducting on the STRONGER paired invariant (m ≤ φ(m)² together with the m ∉ {1,3} sharpening 2m ≤ φ(m)²) is what makes the multiplicative step go through: a bare m ≤ φ(m)² does not recombine, but the extra factor of 2 of slack in one coprime factor compensates the deficient b = 3 factor in the other.",
+      "Coprimality does the bookkeeping at b = 3: when one coprime factor is exactly 3, the other is automatically coprime to 3 and hence ≠ 3, so by the inductive disjunction it must carry the sharp 2·-bound — the case analysis closes without ever multiplying two deficient factors.",
+      "The hypothesis n > 6 is needed in exactly one branch: k = 1 (n = 2m), where it upgrades m > 3 to m ≥ 5 so the odd part avoids the m = 3 exception. Numerically the failures of n ≤ φ(n)² are exactly {2, 6}, confirming the bound is tight."
+    ],
+    "prerequisites": [
+      "Euler's totient function: multiplicativity Nat.totient_mul and the prime-power formula Nat.totient_prime_pow / totient_prime_pow_succ",
+      "Multiplicative induction over ℕ: Nat.recOnPosPrimePosCoprime (prime powers + coprime gluing)",
+      "The 2-adic decomposition Nat.exists_eq_two_pow_mul_odd (n = 2ᵏ·m, m odd)",
+      "Coprimality of a power: Nat.Coprime.pow_left and Nat.Prime.coprime_iff_not_dvd",
+      "Square roots over ℝ: Real.sqrt_le_sqrt and Real.sqrt_sq for the analytic corollary"
+    ]
+  },
+  "sections": [
+    {
+      "id": "arithmetic-kernels",
+      "title": "Arithmetic Kernels for the Prime-Power Estimate",
+      "startLine": 50,
+      "endLine": 83,
+      "summary": "Subtraction-free Nat inequalities arith_self (q(a+1) ≤ (qa)²), arith_two_of_a and arith_two_of_q (2q(a+1) ≤ (qa)²), proved by explicit multiplication chains. With q = pᵏ⁻¹, a = p−1 these encode the prime-power bound and its sharpening.",
+      "mathContext": "For $q\\ge1,a\\ge2$: $q(a+1)\\le(qa)^2$ since $a+1\\le a^2$ and $a\\le qa$. The doubled forms need $a\\ge3$ (so $2(a+1)\\le a^2$) or $q\\ge2$ (so $2\\le q$ absorbs the factor). Writing a prime power as $p^k=q(a+1)$ with $\\varphi(p^k)=qa$ turns the analytic-looking bound into these finite checks."
+    },
+    {
+      "id": "odd-part-induction",
+      "title": "The Odd-Part Induction",
+      "startLine": 85,
+      "endLine": 169,
+      "summary": "OddBound m := Odd m → m ≤ φ(m)² ∧ (m = 1 ∨ m = 3 ∨ 2m ≤ φ(m)²). Proved for all m by Nat.recOnPosPrimePosCoprime: the prime-power case uses the kernels (odd ⟹ p ≥ 3), and the coprime case recombines using the disjunction, with coprimality forcing the non-3 factor to carry the sharp bound.",
+      "mathContext": "An odd prime power $p^k$ has $p\\ge3$, so $p^k\\le\\varphi(p^k)^2$ always and $2p^k\\le\\varphi(p^k)^2$ unless $(p,k)=(3,1)$ (i.e. $m=3$). In the coprime step $m=ab$ with $a,b>1$: if $b=3$ then $\\gcd(a,3)=1\\Rightarrow a\\ne3$, so $2a\\le\\varphi(a)^2$, and $6a\\le4\\varphi(a)^2=\\varphi(a)^2\\varphi(3)^2$; otherwise $2b\\le\\varphi(b)^2$ combines directly with $a\\le\\varphi(a)^2$."
+    },
+    {
+      "id": "odd-lemmas",
+      "title": "The Odd Lower Bounds",
+      "startLine": 171,
+      "endLine": 189,
+      "summary": "phi_sq_ge_self_of_odd: m ≤ φ(m)² for every odd m (no exceptions). phi_sq_ge_two_mul_of_odd: 2m ≤ φ(m)² for odd m ∉ {1,3}. Both extracted from the OddBound induction.",
+      "mathContext": "$m\\le\\varphi(m)^2$ for all odd $m$ (e.g. $1\\le1$, $3\\le4$, $5\\le16$), and the sharpened $2m\\le\\varphi(m)^2$ away from the genuine small failures $m=1$ ($2\\le1$) and $m=3$ ($6\\le4$)."
+    },
+    {
+      "id": "full-bound",
+      "title": "The Full Bound via the 2-adic Decomposition",
+      "startLine": 191,
+      "endLine": 240,
+      "summary": "totient_sq_ge_self: 6 < n ⟹ n ≤ φ(n)². Splits n = 2ᵏ·m (m odd, coprime), then cases on k: k = 0 (n odd), k ≥ 2 (2^{2k−2} dominates), k = 1 (n > 6 ⟹ m ≥ 5, use the sharp odd bound). sqrt_le_totient: the ℝ statement √n ≤ φ(n).",
+      "mathContext": "$n=2^k m$, $\\varphi(n)=\\varphi(2^k)\\varphi(m)$. For $k\\ge1$, $\\varphi(2^k)=2^{k-1}$ so $\\varphi(n)^2=2^{2k-2}\\varphi(m)^2$; $k\\ge2$ gives $2^{2k-2}\\ge2^k$, and $k=1$ reduces to $2m\\le\\varphi(m)^2$ which holds once $m\\ge5$. Taking square roots yields $\\sqrt n\\le\\varphi(n)$ over $\\mathbb R$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's second open question is answered affirmatively with a fully machine-checked proof: φ(n) ≥ √n for all n > 6, formulated exception-free over ℕ as n ≤ φ(n)² (the only failures being n = 2 and n = 6) and packaged as √n ≤ φ(n) over ℝ. Notably the proof requires NO prime-counting or analytic estimates — only multiplicativity of φ and an elementary prime-power inequality — answering the question's parenthetical expectation in the negative. All theorems are verified with 0 sorries and 0 axioms.",
+    "implications": "The bound gives an explicit elementary rate φ(n) ≫ √n, enough to recover φ(n) → ∞ and to bound the number of units modulo n from below without any sieve or prime-counting machinery. The reusable intermediate results — m ≤ φ(m)² for odd m, and 2m ≤ φ(m)² for odd m ∉ {1,3} — isolate exactly where the deficient prime power 2¹ matters, and the squared formulation (n ≤ φ(n)²) is the natural ℕ-native target for any further sharpening.",
+    "openQuestions": [
+      "Can the bound be sharpened to the known φ(n) ≥ √(n/2) for ALL n (no exceptions), or to asymptotic forms such as φ(n) ≫ n / log log n, within Lean?",
+      "Does the odd-part invariant generalize to a clean lower bound φ(n)² ≥ c·n with explicit constant c depending only on the smallest prime factor of n?",
+      "Can phi_sq_ge_self_of_odd and the general prime-power slack be repackaged as a Mathlib contribution (a reusable totient lower-bound lemma), complementing Nat.totient_prime_pow?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-03",
+      "relationship": "extends",
+      "description": "Answers the second open question of the parent ('Is there a Lean proof that φ(n) ≥ √n for all n > 6?') with the exception-free squared form n ≤ φ(n)² and an ℝ corollary."
+    },
+    {
+      "targetId": "euler-totient-oq-03-oq-03",
+      "relationship": "complements",
+      "description": "The sibling entry sharpens super-multiplicativity into the exact GCD–totient identity; this entry instead derives a lower bound on the SIZE of φ from the same multiplicative structure."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "uses",
+      "description": "Builds on the basic totient API (positivity, multiplicativity, prime-power formula) established by the root entry."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G.H. and Wright, E.M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1938",
+      "venue": "Oxford University Press",
+      "note": "Theorem 327 and surrounding discussion give φ(n)/n¹⁻ᵟ → ∞ and the elementary lower bounds for φ; the benchmark φ(n) > √n for n > 6 is a standard exercise-level consequence."
+    },
+    {
+      "authors": "mathlib community",
+      "title": "Nat.totient_prime_pow, Nat.totient_mul, Nat.recOnPosPrimePosCoprime, Nat.exists_eq_two_pow_mul_odd",
+      "year": "2025",
+      "venue": "Mathlib4, Mathlib/Data/Nat/Totient.lean and Mathlib/Data/Nat/Factorization",
+      "note": "The prime-power totient formula, multiplicativity, the multiplicative-structure induction principle, and the 2-adic decomposition that this proof combines."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent gallery entry `euler-totient-oq-03`:

> "Is there a Lean proof that `φ(n) ≥ √n` for all `n > 6`? This would require bounding the product formula from below using prime number estimates."

**Answer: yes — and no analytic prime estimates are needed.** New verified gallery entry `euler-totient-oq-03-oq-02`.

## Results (all 0 sorries / 0 axioms)

- **`totient_sq_ge_self`** — `6 < n → n ≤ φ(n)²` (the exception-free, square-root-free form of `φ(n) ≥ √n`).
- **`sqrt_le_totient`** — `6 < n → √n ≤ φ(n)` (the literal statement over `ℝ`).
- **`phi_sq_ge_self_of_odd`** / **`phi_sq_ge_two_mul_of_odd`** — reusable odd-part bounds: `m ≤ φ(m)²` for every odd `m`, and `2m ≤ φ(m)²` for odd `m ∉ {1,3}`.

The only `n` with `n > φ(n)²` are `n = 2` and `n = 6` (verified numerically over `2 ≤ n ≤ 30` → exactly `{2,6}`), so the hypothesis `n > 6` is tight.

## Why no prime-counting is needed

`f(n) = φ(n)²/n` is multiplicative, so `n ≤ φ(n)²` reduces to prime powers. Every odd prime power `pᵏ` (`p ≥ 3`) satisfies `pᵏ ≤ φ(pᵏ)²` with slack; the *only* deficient prime power is `2¹`. The proof:

1. **Arithmetic kernels** — with `q = pᵏ⁻¹`, `a = p−1`, the bound becomes the subtraction-free `q(a+1) ≤ (qa)²` (+ a doubled form), proved by explicit `Nat` multiplication chains.
2. **Odd-part induction** (`Nat.recOnPosPrimePosCoprime`) on the *paired* invariant `m ≤ φ(m)² ∧ (m=1 ∨ m=3 ∨ 2m ≤ φ(m)²)`. The disjunction supplies the slack the multiplicative step needs; when one coprime factor is the deficient `3`, coprimality forces the other to be `≠ 3` and hence carry the sharp doubled bound.
3. **2-adic gluing** — split `n = 2ᵏ·m` (`m` odd, `Nat.exists_eq_two_pow_mul_odd`). For `k ≥ 2` the factor `2^{2k−2}` dominates `2ᵏ`; for `k = 1` the hypothesis `n > 6` forces `m ≥ 5`, so the odd part avoids the `m = 3` exception and the sharp bound closes the gap.

## Verification

- Offline-verified against Mathlib v4.26.0: `lake env lean` **EXIT 0** (docker build path down; cached oleans).
- `#print axioms` on both public theorems → `{propext, Classical.choice, Quot.sound}` only. No `native_decide` (so no `Lean.ofReduceBool`), no `sorryAx`. Entry status `verified` / badge `verified`.

Includes `meta.json` (full overview/sections/conclusion) and `annotations.json`.