### PR TITLE
Enrich Lamé sharp golden-ratio bound (bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01): annotations + keyInsights

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "ann-lame-sharp-overview",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+    "range": { "startLine": 7, "endLine": 55 },
+    "type": "context",
+    "title": "From Θ(log) to the Sharp Golden-Ratio Base",
+    "content": "The module docstring states exactly what the parent left open and what this file adds. The parent pinned the Euclidean step count to Θ(log b) — an upper bound steps a b ≤ 2 log₂ b + 2 plus a Fibonacci worst-case family attaining it — but only up to the constant in front of the logarithm, i.e. the *base* was not sharp. Lamé's theorem in its true form is a lower bound on the input: forcing n+1 steps requires the smaller argument b ≥ fib(n+2). Since fib(n+2) grows like φⁿ, that converts to the famous base-φ logarithm. The file is self-contained, reproducing the step counter so it verifies standalone.",
+    "mathContext": "Parent: $\\operatorname{steps}(a,b) = \\Theta(\\log b)$ up to the base. This entry: $\\operatorname{steps}(a,b) \\le \\log_\\varphi b + 1$, the sharp $\\lfloor\\log_\\varphi b\\rfloor + O(1)$ with $\\varphi = \\tfrac{1+\\sqrt5}{2}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lamé's theorem",
+      "Euclidean algorithm complexity",
+      "golden ratio",
+      "logarithm base sharpness"
+    ],
+    "prerequisites": [
+      "the parent Θ(log) step bound",
+      "Fibonacci numbers as Euclidean worst case"
+    ]
+  },
+  {
+    "id": "ann-step-counter",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+    "range": { "startLine": 68, "endLine": 86 },
+    "type": "definition",
+    "title": "The Step Counter and Its Unfolding",
+    "content": "steps a b counts the division steps of the extended Euclidean algorithm, following the recursion (a, b+1) ↦ (b+1, a % (b+1)) exactly; the recursive call is justified by the termination measure a % (b+1) < b+1. Three unfolding lemmas are reproduced from the parent so the file stands alone: steps_zero (steps a 0 = 0), steps_succ (the raw successor unfolding), and steps_pos — the workhorse — which rewrites steps a b = steps b (a % b) + 1 for any b > 0. Every later induction peels steps using steps_pos.",
+    "mathContext": "$\\operatorname{steps}(a,0) = 0$ and for $b > 0$, $\\operatorname{steps}(a,b) = \\operatorname{steps}(b,\\, a \\bmod b) + 1$ — one division step then recurse on the remainder.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "well-founded recursion",
+      "Nat.mod_lt termination",
+      "remainder recurrence",
+      "extended Euclidean algorithm"
+    ],
+    "prerequisites": [
+      "the Euclidean remainder a % b",
+      "structural/well-founded recursion in Lean"
+    ]
+  },
+  {
+    "id": "ann-lame-fib-lower",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+    "range": { "startLine": 97, "endLine": 147 },
+    "type": "key-step",
+    "title": "Lamé's Sharp Input Lower Bound",
+    "content": "lame_fib_lower: n+1 ≤ steps a b → fib(n+2) ≤ b is the genuinely sharp form of Lamé's theorem — the converse direction the parent lacked. The proof is a two-step induction (Nat.twoStepInduction) mirroring the Fibonacci recurrence. In the inductive case, two Euclidean steps a → b → r = a%b → s = b%r expose remainders bounded below by the inductive hypotheses: fib(n+3) ≤ r (from ih2) and fib(n+2) ≤ s (from ih1). Since b = r·(b/r) + s ≥ r + s ≥ fib(n+3) + fib(n+2) = fib(n+4), the bound closes via omega with fib_add_two. The two base cases (n=0,1) handle the short algorithms directly.",
+    "mathContext": "$n+1 \\le \\operatorname{steps}(a,b) \\implies \\operatorname{fib}(n+2) \\le b$. The minimal $b$ forcing $n+1$ steps is exactly a Fibonacci number: $b \\ge r + s \\ge \\operatorname{fib}(n{+}3) + \\operatorname{fib}(n{+}2) = \\operatorname{fib}(n{+}4)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.twoStepInduction",
+      "Fibonacci recurrence fib(n+2)=fib(n)+fib(n+1)",
+      "Nat.div_add_mod",
+      "converse worst-case bound"
+    ],
+    "prerequisites": [
+      "two-step (strong) induction",
+      "the division identity b = r·(b/r) + b%r"
+    ]
+  },
+  {
+    "id": "ann-golden-pow-le-fib",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+    "range": { "startLine": 158, "endLine": 181 },
+    "type": "insight",
+    "title": "Golden Ratio Dominated by Fibonacci",
+    "content": "golden_pow_le_fib: φⁿ ≤ fib(n+2) is the bridge from the integer worst case to a real logarithm. The key observation is that φ and the Fibonacci sequence are the two canonical solutions of the same second-order recurrence x_{n+2} = x_{n+1} + x_n: the only algebraic fact needed is φ² = φ + 1 (Real.goldenRatio_sq). The two-step induction rewrites φ^(n+2) = φ^(n+1) + φⁿ (via φ²) against fib(n+4) = fib(n+2) + fib(n+3) and closes by linarith on the two inductive hypotheses. Base cases: φ⁰ = 1 = fib 2 and φ¹ = φ < 2 = fib 3.",
+    "mathContext": "$\\varphi^n \\le \\operatorname{fib}(n+2)$, because $\\varphi^2 = \\varphi + 1$ gives $\\varphi^{n+2} = \\varphi^{n+1} + \\varphi^n$ — the same recurrence the Fibonacci numbers obey, so dominance propagates from the base cases.",
+    "significance": "key",
+    "relatedConcepts": [
+      "golden ratio φ² = φ + 1",
+      "Real.goldenRatio_sq",
+      "shared linear recurrence",
+      "Fibonacci growth rate"
+    ],
+    "prerequisites": [
+      "the identity φ² = φ + 1",
+      "two-step induction over a real inequality"
+    ]
+  },
+  {
+    "id": "ann-steps-le-logb-golden",
+    "proofId": "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01",
+    "range": { "startLine": 191, "endLine": 214 },
+    "type": "key-step",
+    "title": "Headline: the Exact ⌊log_φ b⌋ + O(1) Bound",
+    "content": "steps_le_logb_golden composes the two parts into the answer. Writing k = steps a b = n + 1 (k ≥ 1 for b ≥ 1), lame_fib_lower gives fib(n+2) ≤ b and golden_pow_le_fib gives φⁿ ≤ fib(n+2) ≤ b. Taking base-φ logarithms — monotone since φ > 1 (Real.logb_le_logb_of_le), with logb φ (φⁿ) = n (logb_pow + logb_self_eq_one) — yields n ≤ logb φ b, hence steps a b = n + 1 ≤ log_φ b + 1. Because the Fibonacci family attains steps = n with fib(n+1) ≤ φⁿ, the base φ is optimal: no larger logarithm base can bound the step count.",
+    "mathContext": "$\\varphi^{\\,\\operatorname{steps}(a,b)-1} \\le b \\implies \\operatorname{steps}(a,b) \\le \\log_\\varphi b + 1$ for $b \\ge 1$ — the sharp $\\lfloor\\log_\\varphi b\\rfloor + O(1)$ form, with base $\\varphi$ proven optimal.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.logb monotonicity",
+      "Real.logb_self_eq_one",
+      "composition of bounds",
+      "optimality of the base"
+    ],
+    "prerequisites": [
+      "base-φ logarithm and its monotonicity for base > 1",
+      "lame_fib_lower and golden_pow_le_fib"
+    ]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
@@ -54,7 +54,9 @@
     "keyInsights": [
       "Lamé's theorem is fundamentally a statement about minimal inputs: the smallest b that forces n steps is a Fibonacci number, not a halving-style bound.",
       "The golden ratio enters because φ and the Fibonacci sequence are the two canonical solutions of the same linear recurrence xₙ₊₂ = xₙ₊₁ + xₙ; the identity φ² = φ + 1 is all that is needed to compare them.",
-      "Sharpening from 'base 2' to 'base φ' is exactly the content the parent's halving argument cannot see — it requires the converse (input lower) bound, not the forward (step upper) bound."
+      "Sharpening from 'base 2' to 'base φ' is exactly the content the parent's halving argument cannot see — it requires the converse (input lower) bound, not the forward (step upper) bound.",
+      "The whole proof is two parallel two-step inductions on the same recurrence: lame_fib_lower descends the Euclidean recursion two steps at a time so the remainders line up with fib(n+2) and fib(n+3), and golden_pow_le_fib climbs powers of φ two at a time using φ² = φ + 1 — the structural echo between them is why the golden ratio appears at all.",
+      "Optimality is not an afterthought but the point: the parent's Fibonacci family steps (fib (n+2)) (fib (n+1)) = n with fib(n+1) ≤ φⁿ shows the bound is attained, so steps a b ≤ log_φ b + 1 cannot be improved to any larger base — the constant in front of log is genuinely 1, not merely O(1)."
     ],
     "prerequisites": [
       "The Euclidean algorithm and its remainder recurrence a % b",


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01` (Lamé's theorem sharpened to the golden-ratio constant ⌊log_φ b⌋ + O(1)).

## Changes
- **Created `annotations.json`** (previously absent) with 5 annotations anchored to the Lean constructs: the docstring overview, the step counter, `lame_fib_lower` (the sharp input lower bound), `golden_pow_le_fib` (φⁿ ≤ fib(n+2)), and the headline `steps_le_logb_golden`. Each carries mathContext (LaTeX), significance, relatedConcepts, prerequisites. Resolver: 5 valid, 0 misaligned.
- **Added 2 keyInsights** (the two parallel two-step inductions on the shared recurrence; the genuine optimality of base φ), 3 → 5.

Quality 39 → 98. meta.json (rich overview/sections/conclusion) was already strong and otherwise unchanged. Build (`pnpm build`) passes.