### PR TITLE
Research: erdos-57-oq-04 — reduce reverse bipartite direction to one classical walk lemma

### DIFF
--- a/proofs/Proofs/Erdos57Problem.lean
+++ b/proofs/Proofs/Erdos57Problem.lean
@@ -158,14 +158,32 @@ lemma noOddCycles_of_boolColoring {G : SimpleGraph V} (c : G.Coloring Bool) :
   exact (Nat.not_even_iff_odd.mpr hodd) hEven
 
 /--
+**Crux lemma (classical, Mathlib gap):** every odd closed walk contains an odd cycle.
+
+This is the only genuinely nonelementary ingredient of the bipartite characterization.
+The standard proof is induction on the walk length: a minimal odd closed walk must be a
+cycle, because any repeated interior vertex splits it into two strictly shorter closed
+walks whose lengths sum to the original — one of which is therefore odd. Mathlib provides
+the closed-walk decomposition API (`Walk.takeUntil`/`Walk.dropUntil`, `rotate`,
+`IsTrail`/`IsCycle`, `cons_isCycle_iff`) but not this statement.
+-/
+theorem exists_odd_cycle_of_odd_closed_walk {G : SimpleGraph V} {u : V}
+    (w : G.Walk u u) (hodd : Odd w.length) :
+    ∃ (x : V) (c : G.Walk x x), c.IsCycle ∧ Odd c.length := by
+  sorry
+
+/--
 A graph is bipartite iff it has no odd cycles.
 
-The forward direction is the elementary parity argument (a proper 2-coloring forces
-every closed walk to have even length). The reverse direction (no odd cycle ⟹
-2-colorable) is the hard classical direction; for arbitrary, possibly infinite, `V`
-it requires building a 2-coloring component-by-component from the parity of distances
-to chosen base vertices. Mathlib lists this exact characterization as future work
-(`Mathlib.Combinatorics.SimpleGraph.Bipartite`), so it is left as the sole open goal.
+The forward direction is the elementary parity argument (a proper 2-coloring forces every
+closed walk to have even length). The reverse direction is the classical direction. Rather
+than rebuild a component-wise distance-parity coloring by hand, we route through Mathlib's
+`two_colorable_iff_forall_loop_even` (which already supplies that construction): bipartite is
+equivalent to "every closed walk has even length", and the contrapositive of that is exactly
+`exists_odd_cycle_of_odd_closed_walk` — an odd loop would yield an odd cycle, contradicting
+`oddCycleLengths G = ∅`. The whole reverse direction is therefore reduced to the single
+classical walk lemma above (Mathlib lists this characterization as future work,
+`Mathlib.Combinatorics.SimpleGraph.Bipartite`).
 -/
 theorem bipartite_iff_no_odd_cycles (G : SimpleGraph V) :
     G.IsBipartite ↔ oddCycleLengths G = ∅ := by
@@ -173,8 +191,15 @@ theorem bipartite_iff_no_odd_cycles (G : SimpleGraph V) :
   · intro hbip
     obtain ⟨c⟩ := hbip
     exact noOddCycles_of_boolColoring (G.recolorOfEquiv finTwoEquiv c)
-  · intro _hno
-    sorry
+  · intro hno
+    refine SimpleGraph.two_colorable_iff_forall_loop_even.mpr ?_
+    intro x w
+    by_contra hne
+    rw [Nat.not_even_iff_odd] at hne
+    obtain ⟨y, c, hcyc, hcodd⟩ := exists_odd_cycle_of_odd_closed_walk w hne
+    have hmem : c.length ∈ oddCycleLengths G := ⟨⟨y, c, hcyc, rfl⟩, hcodd⟩
+    rw [hno] at hmem
+    exact hmem
 
 /-- 2-colorable graphs have no odd cycles. -/
 theorem colorable_two_no_odd_cycles (G : SimpleGraph V)

--- a/research/problems/erdos-57-oq-04/knowledge.md
+++ b/research/problems/erdos-57-oq-04/knowledge.md
@@ -47,3 +47,69 @@ This sub-problem concerns the elementary *bipartite characterization* lemmas in
   a strong template. Estimated 200–400 lines; do under live Docker.
 - Build-verify under Docker (this session was under a Docker/Aristotle blackout;
   proof is name-checked against pinned Mathlib v4.26 but not compiled).
+
+## Session 2026-06-27 (Session 2) — REVISIT, ACT
+
+**Outcome**: progress (reverse direction of `bipartite_iff_no_odd_cycles` now FULLY
+PROVEN; the single remaining `sorry` is reduced to one precise classical walk lemma).
+Sorry count unchanged at 1, but its *scope* collapsed from "build a 200–400 line
+distance-parity coloring" to a self-contained Mathlib-gap lemma.
+
+### Key discovery (supersedes Session 1's plan)
+Mathlib **already provides the coloring construction**. The prior session planned to
+hand-build a component-wise distance-parity `Coloring (Fin 2)` (estimated 200–400 lines,
+mirroring `IsAcyclic.coloringTwoOfVerts`). That is unnecessary:
+
+- `SimpleGraph.two_colorable_iff_forall_loop_even`
+  (`Mathlib/Combinatorics/SimpleGraph/ConcreteColorings.lean:184`):
+  `G.Colorable 2 ↔ ∀ u, ∀ (w : G.Walk u u), Even w.length`.
+  Its reverse direction does exactly the per-connected-component coloring + choice.
+
+Since `IsBipartite` is `abbrev` for `Colorable 2`, the reverse direction of the file's
+`bipartite_iff_no_odd_cycles` is now closed by routing through this lemma:
+bipartite ⟺ every closed walk even; an odd closed walk would (by the crux below) yield
+an odd cycle, contradicting `oddCycleLengths G = ∅`.
+
+NB: the companion `Proofs/Erdos57OddClosedWalk.lean` independently proves
+`isBipartite_iff_no_oddClosedWalk` (its own `parityColoring`) and likewise isolates the
+exact same crux as the only remaining gap. The parent cannot import the companion
+(companion imports parent), so the `two_colorable_iff_forall_loop_even` route keeps the
+parent self-contained and non-circular.
+
+### What I did
+- Added `exists_odd_cycle_of_odd_closed_walk` (the sole remaining `sorry`):
+  `(w : G.Walk u u) → Odd w.length → ∃ x (c : G.Walk x x), c.IsCycle ∧ Odd c.length`.
+- Rewrote the reverse direction of `bipartite_iff_no_odd_cycles` to use
+  `two_colorable_iff_forall_loop_even.mpr` + the crux. **Offline-verified** the whole
+  file compiles with exactly one `sorry` (`LAKE_UNSAFE=1 ./bin/lake env lean ...`,
+  EXIT 0, only the crux's `declaration uses 'sorry'` warning).
+
+### The remaining crux (classical, Mathlib TODO)
+`exists_odd_cycle_of_odd_closed_walk` — "every odd closed walk contains an odd cycle".
+Mathlib lists exactly this characterization as future work
+(`Mathlib/Combinatorics/SimpleGraph/Bipartite.lean:63`), and has **no** lemma extracting
+an odd cycle from an odd closed walk. Standard proof (induction on `w.length` with a `≤ k`
+bound so both split pieces land in the IH):
+
+1. Destruct `w = cons h p` (odd ⇒ length ≥ 1 ⇒ not `nil`), `h : G.Adj u v`, `p : Walk v u`.
+2. `cons_isCycle_iff : (cons h p).IsCycle ↔ p.IsPath ∧ s(u,v) ∉ p.edges`.
+   - If `p.IsPath ∧ s(u,v) ∉ p.edges`: `w` itself is the odd cycle. Done.
+   - Else there is a repeated vertex (¬`p.IsPath`) or a repeated edge (`s(u,v) ∈ p.edges`).
+     In either case split the walk at the repeat using `Walk.takeUntil`/`Walk.dropUntil`
+     (double-split as in `reachable_deleteEdges_iff_exists_cycle.aux`,
+     `Mathlib/.../Connectivity/Connected.lean:748`) into two strictly shorter closed
+     walks whose lengths sum to `w.length`; exactly one is odd — recurse on it.
+   Strictness needs the inner loop length ≥ 1 and the outer part length ≥ 1; choose the
+   repeated vertex so both hold (interior repeat).
+
+Estimated ~80–150 lines of walk/list bookkeeping. **Aristotle was unavailable this
+session** (MCP `prove` + smoke-test both 404 on `aristotle.harmonic.fun/api/v1/project`).
+Good candidate to resubmit to Aristotle once the endpoint is back, or to finish by hand
+under a live build. The lemma is also a clean mathlib4 upstream target.
+
+### Files Modified
+- `proofs/Proofs/Erdos57Problem.lean` (added crux lemma; rewrote reverse direction).
+
+### Next Steps
+- Prove `exists_odd_cycle_of_odd_closed_walk` (closes the entire problem, 0 sorries, and
+  lets the companion derive the full `isBipartite_iff_no_oddCycle`).


### PR DESCRIPTION
## Summary
Research session for `erdos-57-oq-04` (bipartite characterization of Erdős #57).
The reverse direction of `bipartite_iff_no_odd_cycles` (no odd cycle ⟹ 2-colorable)
in `proofs/Proofs/Erdos57Problem.lean` was a bare `sorry`. The prior session planned to
hand-build a 200–400 line component-wise distance-parity coloring to discharge it.

This PR shows that construction is **unnecessary**: Mathlib already provides it via
`SimpleGraph.two_colorable_iff_forall_loop_even`
(`Colorable 2 ↔ ∀ u (w : Walk u u), Even w.length`). Routing the reverse direction
through that lemma proves it **fully**, reducing the open goal to a single isolated,
self-contained classical lemma:

```
exists_odd_cycle_of_odd_closed_walk
  : (w : G.Walk u u) → Odd w.length → ∃ x (c : G.Walk x x), c.IsCycle ∧ Odd c.length
```

— exactly the statement Mathlib itself lists as future work
(`Mathlib/Combinatorics/SimpleGraph/Bipartite.lean:63`).

## Progress
- Added `exists_odd_cycle_of_odd_closed_walk` (the sole remaining `sorry`).
- Rewrote the reverse direction of `bipartite_iff_no_odd_cycles` via
  `two_colorable_iff_forall_loop_even.mpr` + the crux lemma (now fully proven modulo it).
- Documented the discovery and the precise remaining proof plan in
  `research/problems/erdos-57-oq-04/knowledge.md`.

Files modified:
- `proofs/Proofs/Erdos57Problem.lean`
- `research/problems/erdos-57-oq-04/knowledge.md`

## Honest delta
- **Sorry count unchanged at 1.** This is a *scope reduction*, not a sorry elimination:
  the remaining `sorry` collapses from an open-ended coloring build to one precise,
  mathlib4-upstreamable walk lemma.
- The companion `Proofs/Erdos57OddClosedWalk.lean` independently isolates the same crux;
  the parent stays self-contained (it cannot import the companion, which imports it).
- Offline-verified (`LAKE_UNSAFE=1 ./bin/lake env lean ...`): file compiles with exactly
  one `sorry` (the crux) — no errors.
- Aristotle was unavailable this session (MCP `prove` and smoke-test both return 404 on
  `aristotle.harmonic.fun/api/v1/project`); the crux is a clean candidate to resubmit
  once the endpoint is back.

## Status
**Outcome**: progress
**Next Steps**: prove `exists_odd_cycle_of_odd_closed_walk` (closes the entire problem,
0 sorries, and lets the companion derive the full odd-cycle characterization). Also a
good standalone mathlib4 contribution.

🤖 Generated by researcher-1