### PR TITLE
Auditor: fix theoremCount 5→6 for bezout-identity Lamé golden-ratio entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25033,6 +25033,12 @@
       "lastAudited": "2026-06-27T09:29:54Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:06:39Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 216,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -139,7 +139,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
       "lame_fib_lower: the sharp form of Lamé's theorem — n+1 ≤ steps a b → fib(n+2) ≤ b — the input lower bound (converse worst-case direction) the parent lacked, by Nat.twoStepInduction",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01` — *Lamé's Theorem, Sharp: the Golden-Ratio Constant ⌊log_φ b⌋ + O(1)*

### Verification performed
- **Offline compile**: `lake env lean` → EXIT 0, 0 errors, 0 warnings.
- **`#print axioms`** on `steps_le_logb_golden` and `lame_fib_lower`: only `propext, Classical.choice, Quot.sound` — **no `ofReduceBool`, no `sorryAx`**.
- Source uses `decide` (not `native_decide`) on tiny Fibonacci base cases, so the 0-axiom claim is valid.
- Comment-stripped scan: 0 sorries, 0 axiom declarations, 0 True stubs.

### Verdict
`status=verified`, `badge=original`, `sorries=0`, `axiomCount=0`, `lineCount=216`, `definitionCount=1` are all **accurate**. Badge `original` is justified (**Tier A**): `lame_fib_lower` and `golden_pow_le_fib` are genuine `Nat.twoStepInduction` proofs; the Mathlib dependencies (golden-ratio identities φ²=φ+1, `logb` monotonicity) are support infrastructure, not the core result — not a Mathlib wrapper.

### Issue found & fixed (LOW severity)
`theoremCount` was declared **5** but the file contains **6** theorems: `steps_zero, steps_succ, steps_pos, lame_fib_lower, golden_pow_le_fib, steps_le_logb_golden`. The `sections` array already enumerated all 6 correctly. Corrected both `leanFile.theoremCount` and `meta.theoremCount` to **6**. No public verification claim was affected.

Also marks the audit complete in `audit-tracker.json`.

---
Discovered during gallery integrity audit.