### PR TITLE
Enrich spectral trace power-sum (spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -2,57 +2,162 @@
   {
     "id": "ann-spectral-trace-oq01010202-00-header",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 4, "endLine": 63 },
+    "range": {
+      "startLine": 4,
+      "endLine": 63
+    },
     "type": "context",
     "title": "From per-dimension Vieta to a dimension-free spectral mapping",
-    "content": "The parent line proved Newton's power-sum identity one (power, dimension) pair at a time — tr(A²)=Σλ² for 2×2 and tr(A³)=Σλ³ for 3×3 — each by matching a dimension-specific matrix identity (closed by ring on the entries) against a multiset identity via Vieta. That route is intrinsically bounded. This file removes both restrictions at once for diagonalizable matrices: writing A = M·diag(d)·M⁻¹, the power Aᵏ = M·diag(d)ᵏ·M⁻¹ = M·diag(dᵏ)·M⁻¹ is transparent, so conjugation invariance of the trace reads tr(Aᵏ) off the diagonal, while conjugation invariance of the characteristic polynomial identifies the eigenvalue multiset with the diagonal. The honesty note records that the fully general (non-diagonalizable) case still needs matrix triangularization, absent from this Mathlib snapshot."
+    "content": "The parent line proved Newton's power-sum identity one (power, dimension) pair at a time — tr(A²)=Σλ² for 2×2 and tr(A³)=Σλ³ for 3×3 — each by matching a dimension-specific matrix identity (closed by ring on the entries) against a multiset identity via Vieta. That route is intrinsically bounded. This file removes both restrictions at once for diagonalizable matrices: writing A = M·diag(d)·M⁻¹, the power Aᵏ = M·diag(d)ᵏ·M⁻¹ = M·diag(dᵏ)·M⁻¹ is transparent, so conjugation invariance of the trace reads tr(Aᵏ) off the diagonal, while conjugation invariance of the characteristic polynomial identifies the eigenvalue multiset with the diagonal. The honesty note records that the fully general (non-diagonalizable) case still needs matrix triangularization, absent from this Mathlib snapshot.",
+    "mathContext": "For diagonalizable $A = M\\,\\mathrm{diag}(d)\\,M^{-1}$: $A^k = M\\,\\mathrm{diag}(d^k)\\,M^{-1}$, so $\\operatorname{tr}(A^k) = \\sum_i d_i^k = \\sum_j \\lambda_j^k$ for every $k$ and every dimension $n$ — no per-dimension Vieta.",
+    "significance": "context",
+    "relatedConcepts": [
+      "diagonalization",
+      "similarity invariance",
+      "Newton power-sum identities",
+      "spectral mapping"
+    ],
+    "prerequisites": [
+      "eigenvalues and the characteristic polynomial",
+      "matrix conjugation A = M·diag(d)·M⁻¹"
+    ]
   },
   {
     "id": "ann-spectral-trace-oq01010202-01-diagpow",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 72, "endLine": 79 },
+    "range": {
+      "startLine": 72,
+      "endLine": 79
+    },
     "type": "key-step",
     "title": "trace_diagonal_pow: the diagonal power sum",
-    "content": "tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ over any commutative ring. The whole proof rests on two Mathlib facts: diagonal_pow (diag(d)ᵏ = diag(dᵏ), since the diagonal embedding is a ring homomorphism) and trace_diagonal (the trace of a diagonal matrix is the sum of its entries). The entrywise power (dᵏ)ᵢ = (dᵢ)ᵏ is Pi.pow_apply. This is the only place a power sum is computed — everything else is conjugation invariance."
+    "content": "tr(diag(d)ᵏ) = Σᵢ(dᵢ)ᵏ over any commutative ring. The whole proof rests on two Mathlib facts: diagonal_pow (diag(d)ᵏ = diag(dᵏ), since the diagonal embedding is a ring homomorphism) and trace_diagonal (the trace of a diagonal matrix is the sum of its entries). The entrywise power (dᵏ)ᵢ = (dᵢ)ᵏ is Pi.pow_apply. This is the only place a power sum is computed — everything else is conjugation invariance.",
+    "mathContext": "$\\operatorname{tr}(\\mathrm{diag}(d)^k) = \\sum_i d_i^k$, using $\\mathrm{diag}(d)^k = \\mathrm{diag}(d^k)$ (diagonal embedding is a ring hom) and $\\operatorname{tr}(\\mathrm{diag}(e)) = \\sum_i e_i$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.diagonal_pow",
+      "Matrix.trace_diagonal",
+      "Pi.pow_apply",
+      "ring homomorphism"
+    ],
+    "prerequisites": [
+      "trace of a diagonal matrix",
+      "entrywise powers of a diagonal"
+    ]
   },
   {
     "id": "ann-spectral-trace-oq01010202-02-conjpow",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 83, "endLine": 104 },
+    "range": {
+      "startLine": 84,
+      "endLine": 104
+    },
     "type": "key-step",
     "title": "Conjugation commutes with powers, so the power-trace is similarity-invariant",
-    "content": "units_conj_pow proves (M·N·M⁻¹)ᵏ = M·Nᵏ·M⁻¹ by induction on k: the successor step reassociates and telescopes the interior M⁻¹·M = 1 (Units.inv_mul). trace_pow_units_conj then composes this with the cyclic trace law trace_units_conj to give tr((M·N·M⁻¹)ᵏ) = tr(Nᵏ). This is the trace half of the similarity invariance of the spectrum, and it is what lets a diagonalization A = M·diag(d)·M⁻¹ pass the trace computation down to the diagonal."
+    "content": "units_conj_pow proves (M·N·M⁻¹)ᵏ = M·Nᵏ·M⁻¹ by induction on k: the successor step reassociates and telescopes the interior M⁻¹·M = 1 (Units.inv_mul). trace_pow_units_conj then composes this with the cyclic trace law trace_units_conj to give tr((M·N·M⁻¹)ᵏ) = tr(Nᵏ). This is the trace half of the similarity invariance of the spectrum, and it is what lets a diagonalization A = M·diag(d)·M⁻¹ pass the trace computation down to the diagonal.",
+    "mathContext": "$(M N M^{-1})^k = M\\,N^k\\,M^{-1}$ (telescoping $M^{-1}M = 1$), hence by the cyclic trace law $\\operatorname{tr}((M N M^{-1})^k) = \\operatorname{tr}(N^k)$ — the power-trace is similarity-invariant.",
+    "significance": "key",
+    "relatedConcepts": [
+      "similarity invariance",
+      "Matrix.trace_units_conj",
+      "cyclic property of trace",
+      "induction on k"
+    ],
+    "prerequisites": [
+      "Units.inv_mul telescoping",
+      "the cyclic trace law tr(ABC)=tr(BCA)"
+    ]
   },
   {
     "id": "ann-spectral-trace-oq01010202-03-rootsdiag",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 112, "endLine": 121 },
+    "range": {
+      "startLine": 112,
+      "endLine": 121
+    },
     "type": "key-step",
     "title": "roots_charpoly_diagonal: eigenvalues of a diagonal matrix, with multiplicity",
-    "content": "(diag d).charpoly.roots = univ.val.map d. From charpoly_diagonal the characteristic polynomial is ∏ᵢ(X − dᵢ); rewriting this as a multiset product and applying roots_multiset_prod_X_sub_C gives the multiset of diagonal entries. The MULTISET form (not the Finset form roots_prod_X_sub_C) is essential: a repeated diagonal entry must appear as a repeated eigenvalue, so diag(2,2,3) has eigenvalue multiset {2,2,3}, not the set {2,3}."
+    "content": "(diag d).charpoly.roots = univ.val.map d. From charpoly_diagonal the characteristic polynomial is ∏ᵢ(X − dᵢ); rewriting this as a multiset product and applying roots_multiset_prod_X_sub_C gives the multiset of diagonal entries. The MULTISET form (not the Finset form roots_prod_X_sub_C) is essential: a repeated diagonal entry must appear as a repeated eigenvalue, so diag(2,2,3) has eigenvalue multiset {2,2,3}, not the set {2,3}.",
+    "mathContext": "$(\\mathrm{diag}\\,d).\\mathrm{charpoly} = \\prod_i (X - d_i)$, so its root **multiset** is $\\{d_i\\}_i$ with multiplicity: $\\mathrm{diag}(2,2,3)$ has eigenvalues $\\{2,2,3\\}$, not $\\{2,3\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix.charpoly_diagonal",
+      "Polynomial.roots_multiset_prod_X_sub_C",
+      "algebraic multiplicity",
+      "multiset vs finset of roots"
+    ],
+    "prerequisites": [
+      "characteristic polynomial of a diagonal matrix",
+      "roots of ∏(X − cᵢ) as a multiset"
+    ]
   },
   {
     "id": "ann-spectral-trace-oq01010202-04-main",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 134, "endLine": 145 },
+    "range": {
+      "startLine": 134,
+      "endLine": 145
+    },
     "type": "key-step",
     "title": "trace_pow_eq_sum_pow_eigenvalues: the headline, uniform in k and n",
-    "content": "For A = M·diag(d)·M⁻¹ the trace side rewrites via trace_pow_units_conj then trace_diagonal_pow to Σᵢ(dᵢ)ᵏ; the eigenvalue side rewrites via charpoly_units_conj then roots_charpoly_diagonal to give eigenvalues A = univ.val.map d, whose image under (·^k) sums to the same Σᵢ(dᵢ)ᵏ (Multiset.map_map, then both sides are the same Finset sum definitionally). No algebraic closure is used — the characteristic polynomial of a diagonalizable matrix already splits. Specialising k=1 recovers the grandparent's trace = Σλ."
+    "content": "For A = M·diag(d)·M⁻¹ the trace side rewrites via trace_pow_units_conj then trace_diagonal_pow to Σᵢ(dᵢ)ᵏ; the eigenvalue side rewrites via charpoly_units_conj then roots_charpoly_diagonal to give eigenvalues A = univ.val.map d, whose image under (·^k) sums to the same Σᵢ(dᵢ)ᵏ (Multiset.map_map, then both sides are the same Finset sum definitionally). No algebraic closure is used — the characteristic polynomial of a diagonalizable matrix already splits. Specialising k=1 recovers the grandparent's trace = Σλ.",
+    "mathContext": "$\\operatorname{tr}(A^k) = \\sum_i d_i^k$ and $\\sum_{\\lambda\\in\\mathrm{eig}(A)} \\lambda^k = \\sum_i d_i^k$, so $\\operatorname{tr}(A^k) = \\sum_\\lambda \\lambda^k$ uniformly in $k,n$. At $k=1$ this recovers $\\operatorname{tr}(A) = \\sum \\lambda$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Newton power-sum identity",
+      "Matrix.charpoly_units_conj",
+      "Multiset.map_map",
+      "spectral trace formula"
+    ],
+    "prerequisites": [
+      "trace_pow_units_conj and trace_diagonal_pow",
+      "roots_charpoly_diagonal"
+    ]
   },
   {
     "id": "ann-spectral-trace-oq01010202-05-card",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 146, "endLine": 151 },
-    "type": "observation",
+    "range": {
+      "startLine": 141,
+      "endLine": 151
+    },
+    "type": "insight",
     "title": "Exactly n eigenvalues over any field — no algebraic closure",
-    "content": "card_eigenvalues_diagonalizable reads Multiset.card (eigenvalues A) = Fintype.card n directly off eigenvalues A = univ.val.map d (Multiset.card_map, Finset.card_univ). The parent line needed IsAlgClosed for the eigenvalue count; here it is free, because diagonalizability forces the characteristic polynomial to split with the full count of roots."
+    "content": "card_eigenvalues_diagonalizable reads Multiset.card (eigenvalues A) = Fintype.card n directly off eigenvalues A = univ.val.map d (Multiset.card_map, Finset.card_univ). The parent line needed IsAlgClosed for the eigenvalue count; here it is free, because diagonalizability forces the characteristic polynomial to split with the full count of roots.",
+    "mathContext": "$|\\mathrm{eig}(A)| = |n| = \\dim$, directly from $\\mathrm{eig}(A) = \\mathrm{univ}.\\mathrm{val}.\\mathrm{map}\\,d$ — the full count over *any* field, with no $\\overline{\\mathbb F}$ needed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Multiset.card_map",
+      "Finset.card_univ",
+      "splitting of the characteristic polynomial",
+      "no algebraic closure"
+    ],
+    "prerequisites": [
+      "eigenvalue multiset of a diagonalizable matrix",
+      "cardinality of a mapped multiset"
+    ]
   },
   {
     "id": "ann-spectral-trace-oq01010202-06-example",
     "proofId": "spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02",
-    "range": { "startLine": 153, "endLine": 167 },
+    "range": {
+      "startLine": 153,
+      "endLine": 167
+    },
     "type": "example",
     "title": "diag(2,3): both sides equal 2³ + 3³ = 35",
-    "content": "trace_pow_diagonal_example computes tr(diag(2,3)³) = 35 via trace_diagonal_pow, and sum_pow_eigenvalues_example computes the eigenvalue cube sum ((eigenvalues (diag(2,3))).map(·^3)).sum = 35 via roots_charpoly_diagonal, exhibiting the headline identity concretely at k=3."
+    "content": "trace_pow_diagonal_example computes tr(diag(2,3)³) = 35 via trace_diagonal_pow, and sum_pow_eigenvalues_example computes the eigenvalue cube sum ((eigenvalues (diag(2,3))).map(·^3)).sum = 35 via roots_charpoly_diagonal, exhibiting the headline identity concretely at k=3.",
+    "mathContext": "$\\operatorname{tr}(\\mathrm{diag}(2,3)^3) = 2^3 + 3^3 = 35 = \\big(\\sum_{\\lambda} \\lambda^3\\big)$ — the headline identity at $k=3$, both sides computed independently.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked example",
+      "trace_diagonal_pow",
+      "roots_charpoly_diagonal",
+      "power-sum at k=3"
+    ],
+    "prerequisites": [
+      "the headline trace power-sum identity",
+      "evaluating trace and eigenvalues on diag(2,3)"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `spectral-trace-det-eigenvalues-oq-01-oq-01-oq-02-oq-02` (the dimension-free trace power-sum tr(Aᵏ) = Σλᵏ for diagonalizable matrices).

## Changes
- **Deepened all 7 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` — they previously carried only title/content, so the mathContext/significance/relatedConcepts quality components scored 0.
- **Realigned 2 ranges** to their Lean constructs (`units_conj_pow` docstring; the eigenvalue-count theorem) and fixed an invalid annotation `type` (`observation` → `insight` on a theorem). Resolver: 7 valid, 0 misaligned.

Quality 68 → 98. meta.json (rich overview/sections/conclusion) unchanged. Validated via the annotation resolver + JSON parse + size guard (all within caps).