### PR TITLE
research(szemeredi-counting-oq-02): Cauchy–Schwarz defect = degree variance; cherry bound tight iff regular

### DIFF
--- a/proofs/Proofs/SzemerediCountingOQ02.lean
+++ b/proofs/Proofs/SzemerediCountingOQ02.lean
@@ -44,6 +44,15 @@
   * `cherryCount_ge_density_sq` — the same supersaturation bound divided through
     by `|α|`, giving the explicit hypothesis-free lower bound
     `d²·|α|·(|β|·|γ|)² ≤ cherryCount(H)`.
+  * `card_mul_cherryCount_sub_edgeCount_sq` — **the Cauchy–Schwarz defect is the
+    degree variance**: the gap in the cherry inequality is an exact sum of squares,
+    `|α|·cherryCount(H) − e(H)² = ½·∑_{a,b} (deg a − deg b)²` (Lagrange's identity
+    `sum_sq_sub_eq_two_mul_defect` for the degree sequence). This upgrades the
+    second-moment *inequality* to an *equality*.
+  * `card_mul_cherryCount_eq_edgeCount_sq_iff` — **tightness characterizes
+    regularity**: the cherry bound `e(H)² ≤ |α|·cherryCount(H)` is an equality iff
+    all first-part degrees are equal, pinning down exactly why "regularity" is the
+    hypothesis the full counting lemma needs.
 
   ## What remains open (the genuine NRS content)
 
@@ -345,6 +354,91 @@ theorem cherryCount_ge_density_sq (H : Tri3Graph α β γ) :
           = H.density ^ 2 * (vertexTriples α β γ : ℚ) ^ 2 := by rw [hvt]; ring
         _ ≤ (Fintype.card α : ℚ) * (H.cherryCount : ℚ) := key
     exact le_of_mul_le_mul_left hmul hca
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VII: THE CAUCHY–SCHWARZ DEFECT IS THE DEGREE VARIANCE
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Lagrange's identity.** For any `f : α → ℚ`, the symmetric sum of squared
+    pairwise differences equals twice the Cauchy–Schwarz defect:
+
+    `∑_{a,b} (f a − f b)² = 2·(|α|·∑_a f a² − (∑_a f a)²)`.
+
+    This is the equality underlying the Cauchy–Schwarz inequality
+    `(∑ f)² ≤ |α|·∑ f²`: the right-hand side is manifestly `≥ 0`, and it vanishes
+    exactly when all the `f a` agree. -/
+theorem sum_sq_sub_eq_two_mul_defect (f : α → ℚ) :
+    ∑ a : α, ∑ b : α, (f a - f b) ^ 2
+      = 2 * ((Fintype.card α : ℚ) * (∑ a, f a ^ 2) - (∑ a, f a) ^ 2) := by
+  have h1 : ∀ a : α, ∑ b : α, (f a - f b) ^ 2
+      = (Fintype.card α : ℚ) * f a ^ 2 - 2 * (f a * ∑ b, f b) + ∑ b, f b ^ 2 := by
+    intro a
+    rw [Finset.sum_congr rfl (g := fun b => f a ^ 2 - 2 * (f a * f b) + f b ^ 2)
+          (fun b _ => by ring),
+      Finset.sum_add_distrib, Finset.sum_sub_distrib, Finset.sum_const,
+      Finset.card_univ, nsmul_eq_mul, ← Finset.mul_sum, ← Finset.mul_sum]
+  rw [Finset.sum_congr rfl (fun a _ => h1 a), Finset.sum_add_distrib,
+    Finset.sum_sub_distrib, ← Finset.mul_sum, Finset.sum_const, Finset.card_univ,
+    nsmul_eq_mul]
+  have h2 : ∑ a : α, 2 * (f a * ∑ b, f b) = 2 * (∑ a, f a) ^ 2 := by
+    rw [← Finset.mul_sum]; congr 1; rw [← Finset.sum_mul]; ring
+  rw [h2]; ring
+
+/-- **The Cauchy–Schwarz defect is the degree variance.** The gap in the cherry
+    inequality `e(H)² ≤ |α|·cherryCount(H)` is exactly half the symmetric sum of
+    squared degree differences:
+
+    `|α|·cherryCount(H) − e(H)² = ½·∑_{a,b} (deg a − deg b)²`.
+
+    Since `cherryCount = ∑_a deg(a)²` and `e(H) = ∑_a deg(a)`, this is Lagrange's
+    identity for the degree sequence. It promotes the second-moment *inequality*
+    that drives every regularity-based counting argument to an *equality*: the
+    deficit is a manifest sum of squares, so the inequality is tight precisely when
+    the first-coordinate degrees are constant — i.e. when `H` is first-coordinate
+    regular. -/
+theorem card_mul_cherryCount_sub_edgeCount_sq (H : Tri3Graph α β γ) :
+    (Fintype.card α : ℚ) * (H.cherryCount : ℚ) - (H.edgeCount : ℚ) ^ 2
+      = (1 / 2) * ∑ a : α, ∑ b : α, ((H.degA a : ℚ) - (H.degA b : ℚ)) ^ 2 := by
+  have hc : (H.cherryCount : ℚ) = ∑ a : α, (H.degA a : ℚ) ^ 2 := by
+    rw [cherryCount_eq_sum_sq_degA, Nat.cast_sum]; push_cast; rfl
+  have he : (H.edgeCount : ℚ) = ∑ a : α, (H.degA a : ℚ) := by
+    rw [← sum_degA, Nat.cast_sum]
+  rw [hc, he, sum_sq_sub_eq_two_mul_defect (fun a => (H.degA a : ℚ))]
+  ring
+
+/-- **Tightness of the cherry inequality characterizes first-coordinate
+    regularity.** The Cauchy–Schwarz cherry bound `e(H)² ≤ |α|·cherryCount(H)`
+    holds with equality if and only if every first-part vertex has the same degree:
+
+    `|α|·cherryCount(H) = e(H)² ↔ ∀ a b, deg a = deg b`.
+
+    This pins down exactly why "regularity" is the hypothesis the full counting
+    lemma needs: the deterministic second-moment engine is lossless precisely on
+    degree-regular 3-graphs, and the loss away from regularity is the degree
+    variance measured by `card_mul_cherryCount_sub_edgeCount_sq`. -/
+theorem card_mul_cherryCount_eq_edgeCount_sq_iff (H : Tri3Graph α β γ) :
+    (Fintype.card α : ℚ) * (H.cherryCount : ℚ) = (H.edgeCount : ℚ) ^ 2
+      ↔ ∀ a b : α, H.degA a = H.degA b := by
+  rw [← sub_eq_zero, card_mul_cherryCount_sub_edgeCount_sq]
+  constructor
+  · intro h a b
+    have hX : ∑ a : α, ∑ b : α, ((H.degA a : ℚ) - (H.degA b : ℚ)) ^ 2 = 0 := by
+      have h2 : (1 / 2 : ℚ) ≠ 0 := by norm_num
+      exact (mul_eq_zero.mp h).resolve_left h2
+    have hinner :=
+      (Finset.sum_eq_zero_iff_of_nonneg
+        (fun a _ => Finset.sum_nonneg (fun b _ => sq_nonneg _))).mp hX a (Finset.mem_univ a)
+    have hzero :=
+      (Finset.sum_eq_zero_iff_of_nonneg (fun b _ => sq_nonneg _)).mp hinner b (Finset.mem_univ b)
+    have hsub : (H.degA a : ℚ) - (H.degA b : ℚ) = 0 := by
+      have := pow_eq_zero_iff (n := 2) (by norm_num) |>.mp hzero
+      exact this
+    have : (H.degA a : ℚ) = (H.degA b : ℚ) := by linarith
+    exact_mod_cast this
+  · intro h
+    have : ∀ a : α, ∑ b : α, ((H.degA a : ℚ) - (H.degA b : ℚ)) ^ 2 = 0 := by
+      intro a; exact Finset.sum_eq_zero (fun b _ => by rw [h a b]; ring)
+    simp [this]
 
 end Tri3Graph
 

--- a/src/data/proofs/szemeredi-counting-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-counting-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "szemeredi-counting-oq-02",
   "title": "Hypergraph Counting Lemma: the Exact Base Term and the Cherry Engine",
   "slug": "szemeredi-counting-oq-02",
-  "description": "Builds the self-contained counting layer for tripartite 3-uniform hypergraphs that underlies the Nagle–Rödl–Schacht (2006) hypergraph counting lemma, and isolates exactly the part of that lemma that is deterministic — provable with no regularity hypothesis and no error term. A tripartite 3-graph is modeled as a ternary adjacency predicate Tri3Graph (adj : α → β → γ → Prop), making a labeled copy of the single-hyperedge pattern literally an edge of α × β × γ. The entry proves: (1) edgeCount_eq_density_mul — the EXACT counting identity e(H) = d · |α||β||γ| for the single-hyperedge pattern, the counting lemma's main term d^{e(F)}·∏|Vᵢ| in the base case e(F) = 1, holding with zero error; (2) edgeCount_sq_le — the Cauchy–Schwarz 'cherry' inequality e(H)² ≤ |α| · ∑_a deg(a)², the second-moment engine every regularity-based counting/removal argument iterates, obtained from Mathlib's sq_sum_le_card_mul_sum_sq after sum_degA decomposes the edge count over first-coordinate fibres; (3) cherryCount_eq_sum_sq_degA — the EXACT e(F) = 2 enumeration, counting labeled cherries (ordered edge pairs sharing a first coordinate) as ∑_a deg(a)² with no error, via card_eq_sum_card_fiberwise over the shared α-coordinate plus card_product on each fibre; and (4) edgeCount_sq_le_cherryCount — the same Cauchy–Schwarz bound rendered as e(H)² ≤ |α| · cherryCount(H), an inequality on an explicit count of two-edge configurations. The deliberate boundary: the approximate (1 ± f(ε)) NRS lemma for e(F) ≥ 2 needs RELATIVE (Gowers / Rödl–Skokan) regularity — density conditioned on the bipartite 2-skeletons — which is research-level and left open. What is exact (the e(F)=1 main term and the e(F)=2 cherry count) is separated cleanly from what needs regularity (the two-sided bound on the cherry count). 14 theorems + 10 definitions, 0 sorries, 0 axioms.",
+  "description": "Builds the self-contained counting layer for tripartite 3-uniform hypergraphs that underlies the Nagle–Rödl–Schacht (2006) hypergraph counting lemma, and isolates exactly the part of that lemma that is deterministic — provable with no regularity hypothesis and no error term. A tripartite 3-graph is modeled as a ternary adjacency predicate Tri3Graph (adj : α → β → γ → Prop), making a labeled copy of the single-hyperedge pattern literally an edge of α × β × γ. The entry proves: (1) edgeCount_eq_density_mul — the EXACT counting identity e(H) = d · |α||β||γ| for the single-hyperedge pattern, the counting lemma's main term d^{e(F)}·∏|Vᵢ| in the base case e(F) = 1, holding with zero error; (2) edgeCount_sq_le — the Cauchy–Schwarz 'cherry' inequality e(H)² ≤ |α| · ∑_a deg(a)², the second-moment engine every regularity-based counting/removal argument iterates, obtained from Mathlib's sq_sum_le_card_mul_sum_sq after sum_degA decomposes the edge count over first-coordinate fibres; (3) cherryCount_eq_sum_sq_degA — the EXACT e(F) = 2 enumeration, counting labeled cherries (ordered edge pairs sharing a first coordinate) as ∑_a deg(a)² with no error, via card_eq_sum_card_fiberwise over the shared α-coordinate plus card_product on each fibre; and (4) edgeCount_sq_le_cherryCount — the same Cauchy–Schwarz bound rendered as e(H)² ≤ |α| · cherryCount(H), an inequality on an explicit count of two-edge configurations. The deliberate boundary: the approximate (1 ± f(ε)) NRS lemma for e(F) ≥ 2 needs RELATIVE (Gowers / Rödl–Skokan) regularity — density conditioned on the bipartite 2-skeletons — which is research-level and left open. What is exact (the e(F)=1 main term and the e(F)=2 cherry count) is separated cleanly from what needs regularity (the two-sided bound on the cherry count). 14 theorems + 10 definitions, 0 sorries, 0 axioms. Part VII adds the equality behind the inequality: Lagrange's identity shows the Cauchy–Schwarz defect is exactly the degree variance, |α|·cherryCount(H) − e(H)² = ½·∑_{a,b}(deg a − deg b)², so the cherry bound is tight precisely when the first-part degrees are constant — i.e. when H is first-coordinate regular (card_mul_cherryCount_eq_edgeCount_sq_iff). This pins down why regularity is the hypothesis the full counting lemma needs.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -23,8 +23,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 252,
-    "theoremCount": 14,
+    "lineCount": 445,
+    "theoremCount": 17,
     "definitionCount": 10,
     "assumptions": "None beyond finite vertex parts. All results are universally quantified over a Tri3Graph H on Fintype parts α, β, γ; the adjacency predicate is an arbitrary Prop and decidability is supplied classically (open Classical), so edgeFinset/degA/cherryFinset are noncomputable Finset filters with no DecidableRel hypothesis. #print axioms reports only Lean/Mathlib's foundational propext, Classical.choice, Quot.sound; no sorryAx, no native_decide, no Lean.ofReduceBool.",
     "mathlibDependencies": [
@@ -91,7 +91,7 @@
     ]
   },
   "conclusion": {
-    "summary": "In 252 lines, 0 sorries, 0 axioms, the entry builds a tripartite 3-graph counting layer on a ternary adjacency predicate and proves the deterministic core of the Nagle–Rödl–Schacht counting lemma: the exact main term e(H) = d·|α||β||γ| (the e(F)=1 base case, no error), the Cauchy–Schwarz cherry inequality e(H)² ≤ |α|·∑_a deg(a)², and the exact e(F)=2 enumeration cherryCount = ∑_a deg(a)², combined into e(H)² ≤ |α|·cherryCount. The model makes a labeled single-edge copy literally an edge, so the base term is definitional, and the cherry count is computed by fibering over the shared first coordinate.",
+    "summary": "In 445 lines, 0 sorries, 0 axioms, the entry builds a tripartite 3-graph counting layer on a ternary adjacency predicate and proves the deterministic core of the Nagle–Rödl–Schacht counting lemma: the exact main term e(H) = d·|α||β||γ| (the e(F)=1 base case, no error), the Cauchy–Schwarz cherry inequality e(H)² ≤ |α|·∑_a deg(a)², and the exact e(F)=2 enumeration cherryCount = ∑_a deg(a)², combined into e(H)² ≤ |α|·cherryCount. The model makes a labeled single-edge copy literally an edge, so the base term is definitional, and the cherry count is computed by fibering over the shared first coordinate. Part VII promotes the second-moment inequality to an equality — Lagrange's identity makes the Cauchy–Schwarz defect |α|·cherryCount − e(H)² an exact degree variance ½∑_{a,b}(deg a − deg b)² — and shows the cherry bound is tight iff H is first-coordinate regular, isolating exactly why regularity is the right hypothesis.",
     "implications": "This isolates exactly which part of the hypergraph counting lemma is regularity-free: the e(F)=1 main term and the e(F)=2 cherry enumeration are both exact, and Cauchy–Schwarz supplies the one-sided second-moment bound. The genuine NRS content — the two-sided (1 ± f(ε)) count for e(F) ≥ 2 — is precisely the step that needs relative (Gowers / Rödl–Skokan) regularity, density conditioned on the bipartite 2-skeletons, which the entry leaves as the named next layer (relativeDensity / IsGowersRegular on Tri3Graph). It is the 3-graph companion to the verified graph counting lemma in SzemerediCounting.lean and the natural home for a future inductive counting argument over the uniformity.",
     "openQuestions": [
       "Build a relativeDensity layer on Tri3Graph: the 3-graph density conditioned on its three bipartite 2-skeletons (on α×β, β×γ, α×γ), and define IsGowersRegular relative to those skeletons — the missing hypothesis that turns the one-sided cherry inequality into a two-sided bound.",
@@ -139,6 +139,22 @@
       "endLine": 249,
       "summary": "edgeCount_mono (count monotone in adjacency), and the extreme cases: complete/empty tripartite 3-graphs with edgeCount_complete = vertexTriples, edgeCount_empty = 0, density_empty = 0.",
       "mathContext": "$0 = e(\\text{empty}) \\le e(H) \\le e(\\text{complete}) = |\\alpha||\\beta||\\gamma|$."
+    },
+    {
+      "id": "supersaturation",
+      "title": "Part VI — Supersaturation: Density Forces Cherries",
+      "startLine": 270,
+      "endLine": 347,
+      "summary": "cherryCount_ge_edgeCount (trivial second-moment floor e(H) ≤ cherryCount), density_mul_le_edgeCount (base-term identity as a hypothesis-free inequality), and the density engine cherry_supersaturation / cherryCount_ge_density_sq: a fixed density d forces d²·|α|·(|β||γ|)² cherries, with no positivity side conditions.",
+      "mathContext": "$d(H)^2\\,(|\\alpha||\\beta||\\gamma|)^2 \\le |\\alpha|\\cdot \\mathrm{cherryCount}(H)$."
+    },
+    {
+      "id": "defect-variance",
+      "title": "Part VII — The Cauchy–Schwarz Defect is the Degree Variance",
+      "startLine": 359,
+      "endLine": 444,
+      "summary": "sum_sq_sub_eq_two_mul_defect (Lagrange's identity ∑_{a,b}(f a − f b)² = 2(|α|∑ f² − (∑ f)²)) specialised to the degree sequence gives card_mul_cherryCount_sub_edgeCount_sq: |α|·cherryCount(H) − e(H)² = ½∑_{a,b}(deg a − deg b)². The deficit is a manifest sum of squares, so card_mul_cherryCount_eq_edgeCount_sq_iff characterises tightness of the cherry inequality as first-coordinate regularity (all α-degrees equal).",
+      "mathContext": "$|\\alpha|\\cdot\\mathrm{cherryCount}(H) - e(H)^2 = \\tfrac12\\sum_{a,b}(\\deg a-\\deg b)^2 \\ge 0$, with equality iff $H$ is degree-regular."
     }
   ],
   "crossReferences": [
@@ -183,8 +199,8 @@
       "Mathlib"
     ],
     "namespace": "Szemeredi.HypergraphCounting",
-    "lineCount": 252,
-    "theoremCount": 14,
+    "lineCount": 445,
+    "theoremCount": 17,
     "axiomCount": 0,
     "definitionCount": 10,
     "sorries": 0,


### PR DESCRIPTION
## Summary

Extends the verified/original entry **szemeredi-counting-oq-02** (deterministic core of the Nagle–Rödl–Schacht 3-graph counting lemma) with **Part VII**: the *equality* behind the Cauchy–Schwarz cherry inequality `e(H)² ≤ |α|·cherryCount(H)`.

The existing file proved the one-sided second-moment inequality and supersaturation but never *why* it holds or *when* it is tight. Part VII supplies exactly that:

- **`sum_sq_sub_eq_two_mul_defect`** — Lagrange's identity for any `f : α → ℚ`:
  `∑_{a,b} (f a − f b)² = 2·(|α|·∑ f² − (∑ f)²)`.
- **`card_mul_cherryCount_sub_edgeCount_sq`** — *the Cauchy–Schwarz defect is the degree variance*:
  `|α|·cherryCount(H) − e(H)² = ½·∑_{a,b}(deg a − deg b)²`. The deficit is a manifest sum of squares (so the inequality is recovered) and is an exact second moment.
- **`card_mul_cherryCount_eq_edgeCount_sq_iff`** — *tightness characterizes regularity*: the cherry bound is an equality **iff all first-part degrees are equal**, i.e. iff `H` is first-coordinate regular. This pins down precisely why 'regularity' is the hypothesis the full counting lemma needs — the deterministic engine is lossless exactly on degree-regular 3-graphs, and the loss away from regularity is the degree variance.

## Verification
- Offline-verified: `lake env lean SzemerediCountingOQ02.lean` → **EXIT 0** (Mathlib v4.26.0).
- `#print axioms` of both new headline theorems = `propext, Classical.choice, Quot.sound` only — **no `sorryAx`, no `ofReduceBool`**. Entry remains **verified / original / 0-axiom**.
- meta.json updated: theoremCount 14→17, lineCount 252→445, Part VI + VII sections added, description/conclusion updated.

## Relation to the open questions
This is the natural companion to OQ-01/OQ-02 (relative-regularity → two-sided bound): it identifies the exact algebraic obstruction (degree variance) that the regularity hypothesis is designed to kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)