### PR TITLE
Auditor: badge original→mathlib for lifting-the-exponent-oq-02-oq-01 (Mathlib bridge)

### DIFF
--- a/src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json
+++ b/src/data/proofs/lifting-the-exponent-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "modular-arithmetic",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-27",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `lifting-the-exponent-oq-02-oq-01` — *LTE for the sum xⁿ + yⁿ at p = 2, and the unified all-primes dispatch for odd exponents*

### Verification performed
- **Offline compile**: `lake env lean` → EXIT 0, 0 errors, 0 warnings.
- **`#print axioms`** on `emultiplicity_pow_add_pow_odd`, `two_emultiplicity_pow_add_pow_even`, `two_padicValInt_pow_add_pow_odd`: only `propext, Classical.choice, Quot.sound` — **no `ofReduceBool`, no `sorryAx`**.
- Numerical witnesses use kernel `decide`, **not** `native_decide`.
- Counts all accurate: 10 theorems, 0 defs, 183 lines, 0 sorries, 0 axioms.

### Issue found & fixed (MEDIUM — badge overclaim)
Badge was `original`, but the **odd-exponent main result is a Mathlib bridge**, not an independent proof:
- `two_emultiplicity_pow_add_pow_odd` applies Mathlib's prime-generic `emultiplicity_pow_sub_pow_of_prime` after a one-line `xⁿ + yⁿ = xⁿ − (−y)ⁿ` rewrite.
- `emultiplicity_pow_add_pow_odd`'s odd-prime branch **is** `Int.emultiplicity_pow_add_pow` verbatim.

Per auditor rules #3 (Mathlib wrapper) and #5 (0-sorries with hidden imports), the core result obtained via a Mathlib call → badge `mathlib` (**Tier B**). The entry's prose already credits Mathlib correctly ("The mathematical core is Mathlib's") — only the machine-readable badge overclaimed.

**Fix**: `badge: original → mathlib`. This matches both sibling LTE entries `lifting-the-exponent-oq-01` and `-oq-02` (both `verified/mathlib`) and the 648 other `verified/mathlib` gallery entries.

`status` stays `verified` — the formalization genuinely is sorry-free and axiom-free, and the even-exponent case + all-primes packaging are original elementary work (retained in `originalContributions`).

Also marks the audit complete in `audit-tracker.json`.

---
Discovered during gallery integrity audit.