### PR TITLE
research(abel-ruffini-oq-04-oq-02-oq-04): DihedralGroup n is solvable for all n (verified, 0 axioms)

### DIFF
--- a/proofs/Proofs/AbelRuffiniOQ04OQ02OQ04.lean
+++ b/proofs/Proofs/AbelRuffiniOQ04OQ02OQ04.lean
@@ -1,0 +1,113 @@
+import Mathlib
+
+/-
+# Dihedral groups are solvable — an infinite solvable family beyond Sₙ
+
+`abel-ruffini-oq-04-oq-02-oq-04`
+
+The parent entry `abel-ruffini-oq-04-oq-02` ("S₂, S₃, S₄ Are Solvable") classifies
+solvability for the symmetric groups and asks, among its open questions:
+
+> "What about other infinite families? Can analogues be proved for dihedral groups
+>  `Dₙ` (solvable for all `n`, since they have cyclic subgroups of index 2), or for the
+>  general linear groups `GLₙ(𝔽ₚ)` (not solvable for `n ≥ 2`)?"
+
+This file settles the **dihedral half**: `DihedralGroup n` is solvable for *every* `n`
+(including `n = 0`, the infinite dihedral group).  Unlike `Sₙ`, which becomes
+non-solvable at `n = 5`, the dihedral family is solvable across the board — a clean
+contrast that illustrates how the Abel–Ruffini obstruction is special to the symmetric
+groups, not a generic feature of infinite families of finite groups.
+
+## The structural reason, formalized
+
+`Dₙ` is **metabelian**: it has the cyclic (hence abelian) rotation subgroup `⟨r⟩ ≅ ℤ/n`
+as a normal subgroup of index `2`, with abelian quotient `ℤ/2`.  Concretely we exhibit
+
+* an inclusion `rotation : Multiplicative (ZMod n) →* DihedralGroup n`, `i ↦ r i`, whose
+  range is the rotation subgroup, and
+* a parity homomorphism `parity : DihedralGroup n →* Multiplicative (ZMod 2)` sending
+  every rotation to `1` and every reflection to the generator,
+
+and observe `ker (parity) = range (rotation)`.  Both `Multiplicative (ZMod n)` and
+`Multiplicative (ZMod 2)` are abelian, hence solvable, so `solvable_of_ker_le_range`
+gives `IsSolvable (DihedralGroup n)`.  (Mathlib has no prior solvability result for
+`DihedralGroup`.)
+
+## What is proved (fully verified: 0 axioms, 0 sorries)
+
+* `DihedralGroup.parity` / `DihedralGroup.rotation` — the index-2 parity hom and the
+  rotation inclusion, with `parity_ker_eq_rotation_range`.
+* `DihedralGroup.isSolvable` — `IsSolvable (DihedralGroup n)` for all `n`.
+* `S5_not_isSolvable_but_dihedral_is` — the contrast packaged: `Sym (Fin 5)` is *not*
+  solvable while every `DihedralGroup n` is.
+
+The `GLₙ(𝔽ₚ)` non-solvability half of the open question is genuinely harder (it needs the
+simplicity of `PSL₂`) and is left open.
+-/
+
+open DihedralGroup
+
+namespace AbelRuffiniOQ04OQ02OQ04
+
+variable {n : ℕ}
+
+/-- The **parity homomorphism** `Dₙ → ℤ/2`: every rotation `r i` maps to `0` and every
+reflection `sr i` maps to `1`.  Its kernel is exactly the rotation subgroup. -/
+def parity : DihedralGroup n →* Multiplicative (ZMod 2) where
+  toFun x := match x with
+    | r _ => (1 : Multiplicative (ZMod 2))
+    | sr _ => Multiplicative.ofAdd 1
+  map_one' := by rw [one_def]
+  map_mul' x y := by
+    cases x <;> cases y <;>
+      simp only [r_mul_r, r_mul_sr, sr_mul_r, sr_mul_sr] <;>
+      · rfl
+
+/-- The **rotation inclusion** `ℤ/n → Dₙ`, `i ↦ r i`, a homomorphism since `r i · r j =
+r (i+j)`.  Its range is the rotation (cyclic) subgroup of `Dₙ`. -/
+def rotation : Multiplicative (ZMod n) →* DihedralGroup n where
+  toFun i := r (Multiplicative.toAdd i)
+  map_one' := by rw [one_def]; rfl
+  map_mul' i j := (r_mul_r _ _).symm
+
+@[simp] theorem parity_r (i : ZMod n) : parity (r i) = 1 := rfl
+
+@[simp] theorem parity_sr (i : ZMod n) :
+    parity (sr i) = Multiplicative.ofAdd 1 := rfl
+
+@[simp] theorem rotation_apply (i : Multiplicative (ZMod n)) :
+    rotation i = r (Multiplicative.toAdd i) := rfl
+
+/-- The kernel of the parity hom equals the range of the rotation inclusion: both are the
+rotation subgroup `{ r i : i }`.  This is the index-2 normal abelian subgroup witnessing
+that `Dₙ` is metabelian. -/
+theorem parity_ker_eq_rotation_range :
+    (parity (n := n)).ker = (rotation (n := n)).range := by
+  ext x
+  cases x with
+  | r i =>
+    simp only [MonoidHom.mem_ker, MonoidHom.mem_range, rotation_apply]
+    exact ⟨fun _ => ⟨Multiplicative.ofAdd i, by simp⟩, fun _ => rfl⟩
+  | sr i =>
+    simp only [MonoidHom.mem_ker, parity_sr, MonoidHom.mem_range, rotation_apply]
+    constructor
+    · intro h
+      -- `ofAdd 1 = 1` in `Multiplicative (ZMod 2)` would force `(1 : ZMod 2) = 0`.
+      rw [ofAdd_eq_one] at h
+      exact absurd h (by decide)
+    · rintro ⟨j, hj⟩
+      exact absurd hj (by simp)
+
+/-- **Dihedral groups are solvable.**  For every `n`, `DihedralGroup n` is solvable — it
+is metabelian, an abelian (cyclic) normal subgroup with abelian quotient.  Contrast with
+`Sym (Fin n)`, which is non-solvable for `n ≥ 5`. -/
+instance isSolvable : IsSolvable (DihedralGroup n) :=
+  solvable_of_ker_le_range rotation parity (parity_ker_eq_rotation_range.le)
+
+/-- The open question's contrast, packaged: the symmetric group `S₅` is **not** solvable,
+yet **every** dihedral group is.  Abel–Ruffini's obstruction is special to `Sₙ`. -/
+theorem S5_not_isSolvable_but_dihedral_is :
+    ¬ IsSolvable (Equiv.Perm (Fin 5)) ∧ ∀ m : ℕ, IsSolvable (DihedralGroup m) :=
+  ⟨Equiv.Perm.fin_5_not_solvable, fun _ => isSolvable⟩
+
+end AbelRuffiniOQ04OQ02OQ04

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-metabelian-is-the-proof",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
+    "range": {
+      "startLine": 83,
+      "endLine": 107
+    },
+    "type": "insight",
+    "title": "Metabelianness Made Formal: ker(parity) = range(rotation)",
+    "content": "The entire solvability proof is the single identity `ker(parity) = range(rotation)`. The rotation subgroup `{r i}` is abelian (it is `≅ ℤ/n`) and normal of index 2, with abelian quotient `ℤ/2` — `Dₙ` is **metabelian**. Mathlib's `solvable_of_ker_le_range` consumes exactly this: given `rotation : ℤ/n →* Dₙ`, `parity : Dₙ →* ℤ/2`, both source and target solvable (abelian), and `ker(parity) ≤ range(rotation)`, it concludes `IsSolvable (Dₙ)`. No derived-series computation, no `decide` over the whole group — just two homomorphisms and the observation that the reflections are precisely the non-trivial parity class.",
+    "mathContext": "$1 \\to \\langle r\\rangle \\to D_n \\xrightarrow{\\text{parity}} \\mathbb Z/2 \\to 1$ with $\\langle r\\rangle\\cong\\mathbb Z/n$ abelian. An extension of a solvable group by a solvable group is solvable.",
+    "significance": "key",
+    "relatedConcepts": [
+      "solvable_of_ker_le_range",
+      "metabelian group",
+      "CommGroup.isSolvable",
+      "DihedralGroup"
+    ],
+    "prerequisites": [
+      "abel-ruffini-oq-04-oq-02"
+    ]
+  },
+  {
+    "id": "ann-contrast-with-sn",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
+    "range": {
+      "startLine": 104,
+      "endLine": 112
+    },
+    "type": "insight",
+    "title": "Why Abel–Ruffini Is Special to Sₙ",
+    "content": "The companion theorem `S5_not_isSolvable_but_dihedral_is` states the contrast bluntly: `Sym (Fin 5)` is **not** solvable (Mathlib's `Equiv.Perm.fin_5_not_solvable`), yet **every** `DihedralGroup n` is. Both Sₙ and Dₙ are infinite families of finite non-abelian groups, and they even agree (both solvable) for n ≤ 4 — but at n = 5 the symmetric group acquires the simple subgroup A₅ and loses solvability, while the dihedral group keeps its index-2 cyclic structure for all n and stays solvable. The Abel–Ruffini obstruction is therefore a feature of the symmetric groups specifically, not a generic consequence of growing an infinite family. The proof also works uniformly at n = 0, so even the infinite dihedral group D∞ is solvable.",
+    "mathContext": "$S_n$ solvable $\\iff n\\le4$; $D_n$ solvable for all $n$ (including $n=0$, $D_\\infty$). The divergence at $n=5$ is exactly the appearance of the simple group $A_5$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Equiv.Perm.fin_5_not_solvable",
+      "A₅ simple",
+      "infinite dihedral group",
+      "Abel–Ruffini"
+    ],
+    "prerequisites": [
+      "abel-ruffini-oq-04-oq-02-oq-02"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "abel-ruffini-oq-04-oq-02-oq-04",
+  "slug": "abel-ruffini-oq-04-oq-02-oq-04",
+  "title": "Dihedral Groups Are Solvable: An Infinite Solvable Family Beyond Sₙ",
+  "leanFile": {
+    "lineCount": 113,
+    "path": "Proofs/AbelRuffiniOQ04OQ02OQ04.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 6
+  },
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "solvable-groups",
+      "dihedral-group",
+      "galois-theory",
+      "abel-ruffini"
+    ],
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ02OQ04.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 literal `axiom` declarations and 0 sorries. Every result depends only on the foundational axioms propext, Classical.choice, Quot.sound (not counted), as confirmed by `#print axioms` on isSolvable and S5_not_isSolvable_but_dihedral_is. No `native_decide` is used (the `decide` calls are kernel-evaluated on finite ZMod 2 / Fin 5 data), so `Lean.ofReduceBool` is NOT introduced. Built on Mathlib's `DihedralGroup`, `solvable_of_ker_le_range`, and `Equiv.Perm.fin_5_not_solvable`.",
+    "lineCount": 113,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-27"
+  },
+  "description": "Answers the dihedral half of the parent's fourth open question ('other infinite families: Dₙ solvable, GLₙ(𝔽ₚ) not solvable') by proving DihedralGroup n is solvable for EVERY n (including n = 0, the infinite dihedral group) — a result Mathlib does not provide. The proof exhibits Dₙ as metabelian: a parity homomorphism Dₙ → ℤ/2 (rotations ↦ 0, reflections ↦ 1) whose kernel is exactly the range of the rotation inclusion ℤ/n → Dₙ, both groups abelian, so `solvable_of_ker_le_range` applies. Packaged with the contrast S5_not_isSolvable_but_dihedral_is: Sym(Fin 5) is non-solvable while every dihedral group is solvable, showing the Abel–Ruffini obstruction is special to the symmetric groups, not generic to infinite families. The GLₙ(𝔽ₚ) non-solvability half (needing PSL₂ simplicity) is left open. 0 sorries, 0 axioms.",
+  "overview": {
+    "historicalContext": "Abel–Ruffini's impossibility of solving the general quintic by radicals rests on the *non-solvability* of the Galois group S₅. The parent chain `abel-ruffini-oq-04-oq-02` classifies solvability for the symmetric groups: Sₙ is solvable iff n ≤ 4, with A₅ ⊂ S₅ the minimal obstruction. A natural follow-up asks whether the same 'becomes non-solvable' phenomenon appears in other infinite families of groups. The dihedral groups Dₙ — symmetries of the regular n-gon — are the simplest such test: each has a cyclic rotation subgroup of index 2, the textbook reason they are solvable for all n. Establishing this in Lean isolates exactly why Sₙ is special.",
+    "problemStatement": "**Open Question (OQ-04-OQ-02-OQ-04)**: \"What about other infinite families? Can analogues [of the Sₙ solvability classification] be proved for dihedral groups Dₙ (solvable for all n, since they have cyclic subgroups of index 2), or for the general linear groups GLₙ(𝔽ₚ) (not solvable for n ≥ 2)?\"\n\n**Answer (dihedral half): YES.** `DihedralGroup n` is solvable for every n. Unlike Sₙ, the dihedral family never becomes non-solvable. The GLₙ(𝔽ₚ) half is genuinely harder (it requires the simplicity of PSL₂) and is left open.",
+    "proofStrategy": "Dₙ is **metabelian** — an abelian normal subgroup with abelian quotient — and Mathlib's `solvable_of_ker_le_range` turns exactly this data into solvability.\n\n**Two homomorphisms.** `rotation : Multiplicative (ZMod n) →* DihedralGroup n` sends `i ↦ r i`; it is a hom because `r i · r j = r (i+j)`, and its range is the rotation subgroup. `parity : DihedralGroup n →* Multiplicative (ZMod 2)` sends every rotation `r _` to `1` and every reflection `sr _` to the generator `ofAdd 1`; the homomorphism property is a four-case check against Mathlib's multiplication table (`r_mul_r`, `r_mul_sr`, `sr_mul_r`, `sr_mul_sr`).\n\n**The kernel = range identity.** `parity_ker_eq_rotation_range` proves `ker(parity) = range(rotation)`: a rotation lies in both (it is `parity`-trivial and equals `rotation (ofAdd i)`); a reflection lies in neither (its parity is `ofAdd 1 ≠ 1`, and `r _ ≠ sr _`).\n\n**Assembling solvability.** Both `Multiplicative (ZMod n)` and `Multiplicative (ZMod 2)` are abelian, hence solvable (`CommGroup.isSolvable`). Feeding `rotation`, `parity`, and `ker ≤ range` into `solvable_of_ker_le_range` yields `IsSolvable (DihedralGroup n)`.\n\n**The contrast.** `S5_not_isSolvable_but_dihedral_is` pairs Mathlib's `Equiv.Perm.fin_5_not_solvable` with the new instance to state plainly: S₅ is not solvable, yet every Dₙ is.",
+    "keyInsights": [
+      "Solvability of Dₙ is metabelianness made formal: the single relation ker(parity) = range(rotation) — an abelian normal subgroup (the rotations) with abelian quotient (ℤ/2) — is exactly the hypothesis of Mathlib's solvable_of_ker_le_range, so no derived-series computation is needed.",
+      "The result is uniform in n, including n = 0 (the INFINITE dihedral group D∞ = Dₙ at n = 0, where ZMod 0 = ℤ). The same parity hom and rotation inclusion work without any finiteness assumption, so D∞ is solvable too.",
+      "This is the sharp contrast to the parent classification: Sₙ becomes non-solvable at n = 5, but the dihedral family never does. Abel–Ruffini's obstruction is therefore a special feature of the symmetric groups (the abundance of A₅), not a generic property of infinite families — Dₙ and Sₙ agree only up to n ≤ 4.",
+      "The parity homomorphism is the orientation/determinant character of the dihedral group: rotations are orientation-preserving (parity 0), reflections orientation-reversing (parity 1). Its kernel is the rotation subgroup and its image is ℤ/2, the same index-2 structure that makes the rotation subgroup normal."
+    ],
+    "prerequisites": [
+      "DihedralGroup and its multiplication table (Mathlib SpecificGroups/Dihedral): r_mul_r, r_mul_sr, sr_mul_r, sr_mul_sr",
+      "Solvable groups and the extension lemma solvable_of_ker_le_range (Mathlib GroupTheory/Solvable)",
+      "CommGroup.isSolvable: abelian groups are solvable",
+      "Multiplicative type tags and ofAdd_eq_one for ZMod-valued characters",
+      "Equiv.Perm.fin_5_not_solvable: non-solvability of S₅ (the Abel–Ruffini obstruction)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "two-homomorphisms",
+      "title": "The Parity Hom and the Rotation Inclusion",
+      "startLine": 50,
+      "endLine": 81,
+      "summary": "parity : Dₙ →* ℤ/2 (rotations ↦ 0, reflections ↦ 1), proved a homomorphism by a four-case check on the dihedral multiplication table; rotation : ℤ/n →* Dₙ, i ↦ r i. simp lemmas record their values.",
+      "mathContext": "$\\text{parity}(r_i)=0,\\ \\text{parity}(s r_i)=1$; the products $r r=r,\\ r\\,sr=sr,\\ sr\\,r=sr,\\ sr\\,sr=r$ map to $0+0,\\,0+1,\\,1+0,\\,1+1=0$ in $\\mathbb Z/2$. $\\text{rotation}(i+j)=r_{i+j}=r_i r_j$."
+    },
+    {
+      "id": "kernel-range",
+      "title": "ker(parity) = range(rotation): The Index-2 Abelian Subgroup",
+      "startLine": 83,
+      "endLine": 102,
+      "summary": "parity_ker_eq_rotation_range: the kernel of parity equals the range of rotation, i.e. the rotation subgroup {r i}. A rotation is parity-trivial and equals rotation(ofAdd i); a reflection has parity ofAdd 1 ≠ 1 and is never of the form r _.",
+      "mathContext": "$\\ker(\\text{parity})=\\langle r\\rangle=\\{r_i\\}=\\operatorname{im}(\\text{rotation})$. This is the cyclic normal subgroup of index 2: abelian, with abelian quotient $\\mathbb Z/2$, the metabelian structure of $D_n$."
+    },
+    {
+      "id": "solvability",
+      "title": "Solvability and the Sₙ Contrast",
+      "startLine": 104,
+      "endLine": 112,
+      "summary": "isSolvable: IsSolvable (DihedralGroup n) for all n via solvable_of_ker_le_range (both ℤ/n and ℤ/2 abelian). S5_not_isSolvable_but_dihedral_is packages the contrast with Mathlib's Equiv.Perm.fin_5_not_solvable.",
+      "mathContext": "An extension of the solvable $\\mathbb Z/2$ by the solvable $\\langle r\\rangle\\cong\\mathbb Z/n$ is solvable. Compared with $S_5$, which is non-solvable: the dihedral family is solvable for all $n$, the symmetric family only for $n\\le4$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The dihedral half of the parent's fourth open question is answered affirmatively and verified: DihedralGroup n is solvable for every n, including the infinite dihedral group at n = 0. The proof realizes Dₙ as metabelian via a parity homomorphism whose kernel is the abelian rotation subgroup, then invokes Mathlib's solvable_of_ker_le_range. The companion theorem states the contrast with the non-solvable S₅, isolating the Abel–Ruffini obstruction as a feature special to symmetric groups. Mathlib had no prior solvability result for DihedralGroup. The GLₙ(𝔽ₚ) non-solvability half remains open.",
+    "implications": "Dihedral groups give an infinite family that, unlike Sₙ, is solvable throughout — concretely, every regular-polygon symmetry group has a radical-solvable associated Galois theory. The reusable pieces (the parity character Dₙ → ℤ/2 and the rotation inclusion) are the standard index-2 normal structure and could seed a Mathlib contribution. The metabelian template — exhibit an abelian normal subgroup as a kernel/range coincidence and apply solvable_of_ker_le_range — transfers verbatim to other split/metacyclic families.",
+    "openQuestions": [
+      "The GLₙ(𝔽ₚ) half: prove GLₙ(𝔽ₚ) is NOT solvable for n ≥ 2 and |𝔽ₚ| ≥ 4, which reduces to the non-solvability of SL₂(𝔽ₚ)/PSL₂(𝔽ₚ) (a simple group for q ≥ 4). This requires PSL₂ simplicity, not yet packaged for this purpose in Mathlib.",
+      "Can the derived series of Dₙ be exhibited explicitly: [Dₙ, Dₙ] = ⟨r²⟩ (the squares of rotations), giving derived length exactly 2 for n with 4 ∤ ... and the precise commutator subgroup?",
+      "Generalize to the metacyclic and, more broadly, supersolvable families: is every group with a cyclic normal subgroup of prime index solvable by the same parity-character argument?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02",
+      "relationship": "extends",
+      "description": "Answers the fourth open question of the parent ('other infinite families') for the dihedral case, complementing the Sₙ solvability classification with a family that is solvable for ALL n."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-02-oq-02",
+      "relationship": "complements",
+      "description": "That entry proves Aₙ solvable iff n ≤ 4 (the obstruction A₅); this entry exhibits a contrasting infinite family (dihedral) with no such obstruction."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04",
+      "relationship": "uses",
+      "description": "Part of the Abel–Ruffini proof chain; reuses the non-solvability of S₅ (Equiv.Perm.fin_5_not_solvable) that drives the impossibility theorem."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Dummit, D.S. and Foote, R.M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd edition",
+      "note": "Sections 3.4 and 6.1 treat solvable groups and the dihedral group; Dₙ is the standard first example of a non-abelian solvable group via its cyclic rotation subgroup of index 2."
+    },
+    {
+      "authors": "mathlib community",
+      "title": "DihedralGroup, solvable_of_ker_le_range, Equiv.Perm.fin_5_not_solvable",
+      "year": "2025",
+      "venue": "Mathlib4, Mathlib/GroupTheory/SpecificGroups/Dihedral.lean and Mathlib/GroupTheory/Solvable.lean",
+      "note": "The dihedral group with its multiplication table, the kernel-range solvability extension lemma, and the non-solvability of S₅ that this entry combines."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **dihedral half** of the fourth open question of `abel-ruffini-oq-04-oq-02`:

> "What about other infinite families? Can analogues be proved for dihedral groups `Dₙ` (solvable for all n), or for the general linear groups `GLₙ(𝔽ₚ)` (not solvable for n ≥ 2)?"

New verified gallery entry `abel-ruffini-oq-04-oq-02-oq-04` proving **`IsSolvable (DihedralGroup n)` for every `n`** — including `n = 0`, the infinite dihedral group. Mathlib has no prior solvability result for `DihedralGroup`.

## Approach: Dₙ is metabelian

- **`rotation : Multiplicative (ZMod n) →* DihedralGroup n`**, `i ↦ r i` — hom since `r i · r j = r (i+j)`; range = rotation subgroup.
- **`parity : DihedralGroup n →* Multiplicative (ZMod 2)`** — rotations ↦ `0`, reflections ↦ `1`; hom by a four-case check on the dihedral multiplication table.
- **`parity_ker_eq_rotation_range`** — `ker(parity) = range(rotation)`, the index-2 abelian normal subgroup.
- **`isSolvable`** — both `ℤ/n` and `ℤ/2` are abelian (solvable), so `solvable_of_ker_le_range` gives `IsSolvable (DihedralGroup n)`.

## The contrast (packaged)

**`S5_not_isSolvable_but_dihedral_is`** pairs Mathlib's `Equiv.Perm.fin_5_not_solvable` with the new instance: `Sym (Fin 5)` is **not** solvable, yet **every** `DihedralGroup m` is. The Abel–Ruffini obstruction is special to the symmetric groups (the appearance of `A₅`), not generic to infinite families — `Dₙ` and `Sₙ` agree only for `n ≤ 4`.

The **`GLₙ(𝔽ₚ)` non-solvability** half (needs `PSL₂` simplicity) is genuinely harder and left open, documented in the entry.

## Verification

- Offline-verified vs Mathlib v4.26.0: `lake env lean` **EXIT 0** (docker path down; cached oleans).
- `#print axioms` on `isSolvable` and `S5_not_isSolvable_but_dihedral_is` → `{propext, Classical.choice, Quot.sound}` only. No `native_decide` (so no `Lean.ofReduceBool`), no `sorryAx`. Status `verified`.

Includes `meta.json` (full overview/sections/conclusion) and `annotations.json`.