### PR TITLE
Enrich Schröder tripling step (schroder-numbers-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/schroder-numbers-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/schroder-numbers-oq-01-oq-01/annotations.json
@@ -2,41 +2,116 @@
   {
     "id": "ann-header",
     "proofId": "schroder-numbers-oq-01-oq-01",
-    "range": { "startLine": 1, "endLine": 48 },
+    "range": {
+      "startLine": 1,
+      "endLine": 48
+    },
     "type": "context",
     "title": "From Doubling to Tripling",
-    "content": "The parent entry proved the doubling step 2·L(n) ≤ L(n+1) by keeping only the i=0 term L(0)·L(n) = L(n) of the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i). That is wasteful for n ≥ 1: the recurrence is symmetric, so the i=n term L(n)·L(0) = L(n) is a second, distinct copy of L(n). Keeping both upgrades the sum's lower bound to 2·L(n) and hence L(n+1) ≥ 3·L(n). This file formalizes that tripling step and its exponential consequence L(n) ≥ 2·3^(n−1), answering the parent's first open question."
+    "content": "The parent entry proved the doubling step 2·L(n) ≤ L(n+1) by keeping only the i=0 term L(0)·L(n) = L(n) of the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i). That is wasteful for n ≥ 1: the recurrence is symmetric, so the i=n term L(n)·L(0) = L(n) is a second, distinct copy of L(n). Keeping both upgrades the sum's lower bound to 2·L(n) and hence L(n+1) ≥ 3·L(n). This file formalizes that tripling step and its exponential consequence L(n) ≥ 2·3^(n−1), answering the parent's first open question.",
+    "mathContext": "Recurrence $L(n+1) = L(n) + \\sum_{i\\le n} L(i)L(n-i)$. The parent kept only the $i=0$ term ($\\ge L(n)$, doubling); by symmetry the $i=n$ term is a second copy of $L(n)$, so the sum $\\ge 2L(n)$ and $L(n+1) \\ge 3L(n)$ for $n\\ge1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "large Schröder numbers",
+      "convolution recurrence",
+      "symmetry of the Cauchy product",
+      "tripling vs doubling"
+    ],
+    "prerequisites": [
+      "the Schröder convolution recurrence",
+      "the parent doubling step 2L(n) ≤ L(n+1)"
+    ]
   },
   {
     "id": "ann-two-term",
     "proofId": "schroder-numbers-oq-01-oq-01",
-    "range": { "startLine": 49, "endLine": 78 },
+    "range": {
+      "startLine": 49,
+      "endLine": 78
+    },
     "type": "key-step",
     "title": "Both Extreme Terms of the Convolution",
-    "content": "two_mul_largeSchroder_le_sum is the engine. For n ≥ 1 the indices 0 and n are distinct (hne), so {0, n} is a genuine two-element subset of Iic n. Finset.sum_pair evaluates the convolution over this pair: L(0)·L(n−0) + L(n)·L(n−n) = L(n) + L(n) = 2·L(n). Since ℕ is canonically ordered, Finset.sum_le_sum_of_subset bounds the full sum below by this pair contribution — no nonnegativity hypothesis is needed."
+    "content": "two_mul_largeSchroder_le_sum is the engine. For n ≥ 1 the indices 0 and n are distinct (hne), so {0, n} is a genuine two-element subset of Iic n. Finset.sum_pair evaluates the convolution over this pair: L(0)·L(n−0) + L(n)·L(n−n) = L(n) + L(n) = 2·L(n). Since ℕ is canonically ordered, Finset.sum_le_sum_of_subset bounds the full sum below by this pair contribution — no nonnegativity hypothesis is needed.",
+    "mathContext": "For $n\\ge1$, $0\\ne n$ so $\\{0,n\\}\\subseteq \\mathrm{Iic}\\,n$, and $\\sum_{i\\in\\{0,n\\}} L(i)L(n-i) = L(0)L(n) + L(n)L(0) = 2L(n)$; monotonicity over a subset (no nonnegativity needed in ℕ) gives $2L(n) \\le \\sum_{i\\le n} L(i)L(n-i)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_pair",
+      "Finset.sum_le_sum_of_subset",
+      "canonically ordered ℕ",
+      "two distinct extreme terms"
+    ],
+    "prerequisites": [
+      "summation over a two-element Finset",
+      "sub-sum lower bound in ℕ"
+    ]
   },
   {
     "id": "ann-tripling",
     "proofId": "schroder-numbers-oq-01-oq-01",
-    "range": { "startLine": 79, "endLine": 84 },
+    "range": {
+      "startLine": 79,
+      "endLine": 84
+    },
     "type": "key-step",
     "title": "The Sharp Tripling Step",
-    "content": "three_mul_largeSchroder_le_succ rewrites L(n+1) by the recurrence to L(n) + sum, then omega closes 3·L(n) ≤ L(n) + sum from the two-term bound 2·L(n) ≤ sum. The constant 3 is sharp: at n = 1 equality 3·L(1) = L(2) = 6 holds, so no larger constant works for all n ≥ 1. The asymptotic ratio L(n+1)/L(n) → 3 + 2√2 ≈ 5.828 is larger, but only because the discarded interior terms contribute."
+    "content": "three_mul_largeSchroder_le_succ rewrites L(n+1) by the recurrence to L(n) + sum, then omega closes 3·L(n) ≤ L(n) + sum from the two-term bound 2·L(n) ≤ sum. The constant 3 is sharp: at n = 1 equality 3·L(1) = L(2) = 6 holds, so no larger constant works for all n ≥ 1. The asymptotic ratio L(n+1)/L(n) → 3 + 2√2 ≈ 5.828 is larger, but only because the discarded interior terms contribute.",
+    "mathContext": "$L(n+1) = L(n) + \\sum \\ge L(n) + 2L(n) = 3L(n)$ for $n\\ge1$. Sharp: $3L(1) = L(2) = 6$. (The true ratio $L(n+1)/L(n) \\to 3+2\\sqrt2 \\approx 5.83$ uses the discarded interior terms.)",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.largeSchroder_succ",
+      "omega",
+      "sharp constant",
+      "asymptotic ratio 3+2√2"
+    ],
+    "prerequisites": [
+      "the two-term sum bound",
+      "the recurrence unfolding"
+    ]
   },
   {
     "id": "ann-exponential",
     "proofId": "schroder-numbers-oq-01-oq-01",
-    "range": { "startLine": 85, "endLine": 104 },
+    "range": {
+      "startLine": 85,
+      "endLine": 104
+    },
     "type": "key-step",
     "title": "Exponential Lower Bound L(n) ≥ 2·3^(n−1)",
-    "content": "two_mul_three_pow_le_largeSchroder_succ proves 2·3^n ≤ L(n+1) by induction: the step computes 2·3^(n+1) = 3·(2·3^n) ≤ 3·L(n+1) ≤ L(n+2) using gcongr and the tripling lemma. Working in the shift-indexed form avoids ℕ-truncated subtraction; two_mul_three_pow_pred_le_largeSchroder then restates it as the advertised 2·3^(n−1) ≤ L(n) for n ≥ 1 by substituting n = m+1. This beats the parent's 2^n bound."
+    "content": "two_mul_three_pow_le_largeSchroder_succ proves 2·3^n ≤ L(n+1) by induction: the step computes 2·3^(n+1) = 3·(2·3^n) ≤ 3·L(n+1) ≤ L(n+2) using gcongr and the tripling lemma. Working in the shift-indexed form avoids ℕ-truncated subtraction; two_mul_three_pow_pred_le_largeSchroder then restates it as the advertised 2·3^(n−1) ≤ L(n) for n ≥ 1 by substituting n = m+1. This beats the parent's 2^n bound.",
+    "mathContext": "$2\\cdot3^n \\le L(n+1)$ by induction: $2\\cdot3^{n+1} = 3(2\\cdot3^n) \\le 3L(n+1) \\le L(n+2)$ (gcongr + tripling). Restated: $2\\cdot3^{n-1} \\le L(n)$ for $n\\ge1$ — beating the parent’s $2^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction",
+      "gcongr",
+      "geometric lower bound",
+      "avoiding ℕ-truncated subtraction"
+    ],
+    "prerequisites": [
+      "the tripling step",
+      "shift-indexing n = m+1 to avoid n−1"
+    ]
   },
   {
     "id": "ann-sharpness",
     "proofId": "schroder-numbers-oq-01-oq-01",
-    "range": { "startLine": 105, "endLine": 111 },
+    "range": {
+      "startLine": 95,
+      "endLine": 111
+    },
     "type": "observation",
     "title": "Both the Constant and the Hypothesis Are Sharp",
-    "content": "Three witnesses, each a norm_num evaluation on Mathlib's named Schröder values: equality 3·L(1) = L(2) shows the tripling constant 3 cannot be raised; 2·3^(2−1) = L(2) shows the lower bound is attained; and ¬ 3·L(0) ≤ L(1) (since 3 > 2) shows the n ≥ 1 hypothesis is necessary — at n = 0 the indices 0 and n collapse to a single term."
+    "content": "Three witnesses, each a norm_num evaluation on Mathlib's named Schröder values: equality 3·L(1) = L(2) shows the tripling constant 3 cannot be raised; 2·3^(2−1) = L(2) shows the lower bound is attained; and ¬ 3·L(0) ≤ L(1) (since 3 > 2) shows the n ≥ 1 hypothesis is necessary — at n = 0 the indices 0 and n collapse to a single term.",
+    "mathContext": "Three norm_num witnesses on named values: $3L(1) = L(2)$ (constant 3 maximal), $2\\cdot3^{2-1} = L(2)$ (bound attained), and $3L(0) = 3 > 2 = L(1)$ (so $n\\ge1$ is necessary — at $n=0$ the indices $0,n$ coincide).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sharpness witnesses",
+      "Nat.largeSchroder_one/two",
+      "necessity of hypotheses",
+      "degenerate n=0 case"
+    ],
+    "prerequisites": [
+      "named Schröder values L(0..2)",
+      "why n=0 collapses the two extreme terms"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `schroder-numbers-oq-01-oq-01` (the sharp tripling step 3·L(n) ≤ L(n+1) and the 2·3^(n−1) lower bound).

## Changes
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — previously title/content only. Anchored the sharpness annotation on its section header. Resolver: 5 valid, 0 misaligned.

Quality 68 → 98. meta.json unchanged. Validated via resolver + JSON parse.