### PR TITLE
Enrich Fermat two-square for primes (pythagorean-triples-oq-04): annotation depth

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-04/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-04/annotations.json
@@ -2,41 +2,116 @@
   {
     "id": "ann-pt04-obstruction",
     "proofId": "pythagorean-triples-oq-04",
-    "range": { "startLine": 33, "endLine": 60 },
+    "range": {
+      "startLine": 37,
+      "endLine": 60
+    },
     "type": "technique",
     "title": "The Elementary Mod-4 Obstruction",
-    "content": "sq_mod_four shows a perfect square is 0 or 1 modulo 4: rewriting n² % 4 as (n % 4)² % 4 via Nat.pow_mod reduces the claim to the four residues, dispatched by interval_cases. From this, sum_two_squares_mod_four_ne_three follows by casing on the two possible square residues and closing with omega — a sum of two squares lands in {0,1,2} mod 4, never 3. This is the 'only if' half of Fermat's theorem and is entirely elementary, requiring no Gaussian integers."
+    "content": "sq_mod_four shows a perfect square is 0 or 1 modulo 4: rewriting n² % 4 as (n % 4)² % 4 via Nat.pow_mod reduces the claim to the four residues, dispatched by interval_cases. From this, sum_two_squares_mod_four_ne_three follows by casing on the two possible square residues and closing with omega — a sum of two squares lands in {0,1,2} mod 4, never 3. This is the 'only if' half of Fermat's theorem and is entirely elementary, requiring no Gaussian integers.",
+    "mathContext": "$n^2 \\bmod 4 \\in \\{0,1\\}$ (via $n^2 \\equiv (n\\bmod4)^2$ and interval_cases), hence $a^2+b^2 \\bmod 4 \\in \\{0,1,2\\}$ — never $3$. The elementary \"only if\" half of Fermat.",
+    "significance": "key",
+    "relatedConcepts": [
+      "quadratic residues mod 4",
+      "Nat.pow_mod",
+      "interval_cases",
+      "sum of two squares"
+    ],
+    "prerequisites": [
+      "modular arithmetic mod 4",
+      "squares mod 4"
+    ]
   },
   {
     "id": "ann-pt04-biconditional",
     "proofId": "pythagorean-triples-oq-04",
-    "range": { "startLine": 61, "endLine": 86 },
+    "range": {
+      "startLine": 61,
+      "endLine": 86
+    },
     "type": "concept",
     "title": "Fermat's Theorem as a Biconditional",
-    "content": "prime_sq_add_sq_iff states: a prime p is a sum of two squares ⟺ p ≢ 3 (mod 4). The two halves have wildly different depth. The converse (right-to-left) is Mathlib's Nat.Prime.sq_add_sq, which routes through unique factorization in the Gaussian integers ℤ[i] and the fact that −1 is a quadratic residue mod p exactly when p ≢ 3 (mod 4). The forward direction (left-to-right) is just the mod-4 obstruction. Splitting the theorem this way isolates precisely where the mathematical content lives."
+    "content": "prime_sq_add_sq_iff states: a prime p is a sum of two squares ⟺ p ≢ 3 (mod 4). The two halves have wildly different depth. The converse (right-to-left) is Mathlib's Nat.Prime.sq_add_sq, which routes through unique factorization in the Gaussian integers ℤ[i] and the fact that −1 is a quadratic residue mod p exactly when p ≢ 3 (mod 4). The forward direction (left-to-right) is just the mod-4 obstruction. Splitting the theorem this way isolates precisely where the mathematical content lives.",
+    "mathContext": "For prime $p$: $(\\exists a,b.\\ a^2+b^2 = p) \\iff p \\not\\equiv 3 \\pmod 4$. Forward = mod-4 obstruction (elementary); converse = $\\texttt{Nat.Prime.sq\\_add\\_sq}$ via $\\mathbb{Z}[i]$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Fermat two-square theorem",
+      "Nat.Prime.sq_add_sq",
+      "Gaussian integers ℤ[i]",
+      "−1 as quadratic residue"
+    ],
+    "prerequisites": [
+      "the mod-4 obstruction",
+      "primes as sums of two squares"
+    ]
   },
   {
     "id": "ann-pt04-special",
     "proofId": "pythagorean-triples-oq-04",
-    "range": { "startLine": 87, "endLine": 102 },
+    "range": {
+      "startLine": 87,
+      "endLine": 102
+    },
     "type": "concept",
     "title": "Special Cases: 2 and Primes ≡ 1 (mod 4)",
-    "content": "two_eq_sq_add_sq records 2 = 1² + 1² (the ramified prime). prime_one_mod_four_sq_add_sq specializes the hard direction to odd primes p ≡ 1 (mod 4), the classical statement of Fermat's Christmas theorem, discharging the p % 4 ≠ 3 hypothesis with omega from p % 4 = 1."
+    "content": "two_eq_sq_add_sq records 2 = 1² + 1² (the ramified prime). prime_one_mod_four_sq_add_sq specializes the hard direction to odd primes p ≡ 1 (mod 4), the classical statement of Fermat's Christmas theorem, discharging the p % 4 ≠ 3 hypothesis with omega from p % 4 = 1.",
+    "mathContext": "$2 = 1^2 + 1^2$ (ramified prime); and $p \\equiv 1 \\pmod 4 \\implies p = a^2+b^2$ (discharge $p\\bmod4\\ne3$ by omega) — Fermat’s Christmas theorem for odd primes.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ramified prime 2",
+      "primes ≡ 1 (mod 4)",
+      "Fermat Christmas theorem",
+      "specialization"
+    ],
+    "prerequisites": [
+      "the prime biconditional",
+      "p % 4 = 1 ⟹ p % 4 ≠ 3"
+    ]
   },
   {
     "id": "ann-pt04-mult",
     "proofId": "pythagorean-triples-oq-04",
-    "range": { "startLine": 103, "endLine": 120 },
+    "range": {
+      "startLine": 103,
+      "endLine": 120
+    },
     "type": "technique",
     "title": "Brahmagupta–Fibonacci Multiplicativity",
-    "content": "mul_sum_two_squares packages Nat.sq_add_sq_mul: the product of two sums of two squares is again a sum of two squares, via (x²+y²)(u²+v²) = (xu−yv)² + (xv+yu)². This multiplicativity, discovered by Brahmagupta and rediscovered by Fibonacci, reflects the norm map on ℤ[i] being multiplicative. Together with the prime case it characterizes all sums of two squares through prime factorization."
+    "content": "mul_sum_two_squares packages Nat.sq_add_sq_mul: the product of two sums of two squares is again a sum of two squares, via (x²+y²)(u²+v²) = (xu−yv)² + (xv+yu)². This multiplicativity, discovered by Brahmagupta and rediscovered by Fibonacci, reflects the norm map on ℤ[i] being multiplicative. Together with the prime case it characterizes all sums of two squares through prime factorization.",
+    "mathContext": "$(x^2+y^2)(u^2+v^2) = (xu-yv)^2 + (xv+yu)^2$ — sums of two squares closed under product; the multiplicativity of the norm on $\\mathbb{Z}[i]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Brahmagupta–Fibonacci identity",
+      "Nat.sq_add_sq_mul",
+      "norm multiplicativity on ℤ[i]",
+      "closure under multiplication"
+    ],
+    "prerequisites": [
+      "the two-square identity",
+      "norm of a Gaussian integer"
+    ]
   },
   {
     "id": "ann-pt04-summary",
     "proofId": "pythagorean-triples-oq-04",
-    "range": { "startLine": 121, "endLine": 135 },
+    "range": {
+      "startLine": 121,
+      "endLine": 135
+    },
     "type": "concept",
     "title": "Summary and the Full Characterization",
-    "content": "The closing table situates the prime biconditional within the complete characterization of sums of two squares (Mathlib's Nat.eq_sq_add_sq_iff): a positive integer is a sum of two squares iff every prime ≡ 3 (mod 4) in its factorization occurs to an even power. The prime case proved here plus Brahmagupta–Fibonacci multiplicativity are exactly the ingredients that assemble into that global statement."
+    "content": "The closing table situates the prime biconditional within the complete characterization of sums of two squares (Mathlib's Nat.eq_sq_add_sq_iff): a positive integer is a sum of two squares iff every prime ≡ 3 (mod 4) in its factorization occurs to an even power. The prime case proved here plus Brahmagupta–Fibonacci multiplicativity are exactly the ingredients that assemble into that global statement.",
+    "mathContext": "Full characterization (Nat.eq_sq_add_sq_iff): $n$ is a sum of two squares $\\iff$ every prime $\\equiv 3 \\pmod 4$ divides $n$ to an even power — assembled from the prime case + Brahmagupta–Fibonacci.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Nat.eq_sq_add_sq_iff",
+      "prime factorization",
+      "even exponent condition",
+      "global characterization"
+    ],
+    "prerequisites": [
+      "the prime case",
+      "multiplicativity of sums of two squares"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-04` (Fermat's two-square theorem for primes: p = a²+b² ⟺ p ≢ 3 mod 4).

## Changes
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` — previously title/content only. Realigned the mod-4 obstruction annotation to its docstring. Resolver: 5 valid, 0 misaligned.

Quality 68 → 98. meta.json unchanged. Validated via resolver + JSON parse.