### PR TITLE
Research: cauchy-schwarz-oq-01-oq-03-oq-02 — Shannon entropy max-entropy bound (toward entropic uncertainty)

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean
@@ -1,0 +1,91 @@
+/-
+  Entropic Uncertainty — Finite Shannon-Entropy Infrastructure
+  (toward Erdős/Cauchy–Schwarz OQ chain `cauchy-schwarz-oq-01-oq-03-oq-02`)
+
+  Source question (parent `cauchy-schwarz-oq-01-oq-03`, "Heisenberg Uncertainty from
+  Complex Cauchy–Schwarz"): can the **entropic uncertainty principle** (Maassen–Uffink
+  1988) — `H(p) + H(q) ≥ -2 ln c` for the outcome distributions of two orthonormal bases
+  with maximal overlap `c` — be formalized in Lean 4?
+
+  STATUS OF THE FULL THEOREM: BLOCKED on Mathlib. The sharp Maassen–Uffink constant
+  follows from the Hausdorff–Young inequality, equivalently a Riesz–Thorin interpolation
+  argument; as of Mathlib v4.26.0 there is **no** interpolation theory and **no** Lp→Lp'
+  Fourier bound. (Deutsch's interpolation-free precursor `≥ -2 ln((1+c)/2)` is tractable
+  in principle but still a substantial standalone development.)
+
+  WHAT IS PROVABLE NOW, and is built here (0 axioms, 0 sorries): the finite-dimensional
+  Shannon-entropy framework that any version of the entropic uncertainty relation needs —
+  Shannon entropy of a probability vector via Mathlib's `Real.negMulLog`, its
+  nonnegativity, and the **maximum-entropy bound** `H(p) ≤ log n` (Jensen on the concavity
+  of `negMulLog`; equality at the uniform distribution). This is the "entropy half" of an
+  entropic uncertainty relation, and a reusable building block for the eventual proof.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace CauchySchwarzOQ01OQ03OQ02
+
+variable {ι : Type*} [Fintype ι]
+
+/-- Shannon entropy of a finite probability vector `p` (in nats):
+`H(p) = ∑ᵢ negMulLog(pᵢ) = -∑ᵢ pᵢ log pᵢ`, using Mathlib's `Real.negMulLog`. -/
+noncomputable def shannonEntropy (p : ι → ℝ) : ℝ :=
+  ∑ i, Real.negMulLog (p i)
+
+/-- Entropy of a vector with entries in `[0,1]` is nonnegative (each `negMulLog` term is). -/
+theorem shannonEntropy_nonneg {p : ι → ℝ} (h0 : ∀ i, 0 ≤ p i) (h1 : ∀ i, p i ≤ 1) :
+    0 ≤ shannonEntropy p := by
+  refine Finset.sum_nonneg fun i _ => ?_
+  exact Real.negMulLog_nonneg (h0 i) (h1 i)
+
+/-- **Maximum-entropy bound.** A probability vector on `n = card ι` outcomes has
+`H(p) ≤ log n`, with equality for the uniform distribution. Proof: Jensen's inequality
+applied to the concave function `negMulLog` with uniform weights `1/n`.
+
+This is the entropy ceiling that bounds either marginal in an entropic uncertainty
+relation; the genuinely hard content of Maassen–Uffink is the *lower* bound on the sum
+`H(p) + H(q)`, which is interpolation-gated and not yet available in Mathlib. -/
+theorem shannonEntropy_le_log_card [Nonempty ι] {p : ι → ℝ}
+    (h0 : ∀ i, 0 ≤ p i) (hsum : ∑ i, p i = 1) :
+    shannonEntropy p ≤ Real.log (Fintype.card ι) := by
+  set n : ℕ := Fintype.card ι with hn
+  have hnpos : 0 < n := Fintype.card_pos
+  have hnR : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hnpos
+  -- Jensen for the concave `negMulLog` with uniform weights `1/n`.
+  have hjensen :
+      (∑ i : ι, ((n : ℝ)⁻¹) • Real.negMulLog (p i))
+        ≤ Real.negMulLog (∑ i : ι, ((n : ℝ)⁻¹) • p i) := by
+    refine Real.concaveOn_negMulLog.le_map_sum (t := Finset.univ)
+      (w := fun _ => (n : ℝ)⁻¹) (p := p) ?_ ?_ ?_
+    · intro i _; positivity
+    · -- weights sum to 1
+      rw [Finset.sum_const, Finset.card_univ, ← hn, nsmul_eq_mul]
+      field_simp
+    · intro i _; exact Set.mem_Ici.mpr (h0 i)
+  -- Evaluate the weighted mean: `∑ (1/n)•pᵢ = 1/n`.
+  have hmean : (∑ i : ι, ((n : ℝ)⁻¹) • p i) = (n : ℝ)⁻¹ := by
+    simp only [smul_eq_mul, ← Finset.mul_sum, hsum, mul_one]
+  -- `negMulLog (1/n) = (1/n) * log n`.
+  have hval : Real.negMulLog ((n : ℝ)⁻¹) = (n : ℝ)⁻¹ * Real.log n := by
+    rw [Real.negMulLog, Real.log_inv]; ring
+  -- The LHS of Jensen is `(1/n) * H(p)`.
+  have hlhs : (∑ i : ι, ((n : ℝ)⁻¹) • Real.negMulLog (p i))
+      = (n : ℝ)⁻¹ * shannonEntropy p := by
+    simp only [smul_eq_mul, shannonEntropy, Finset.mul_sum]
+  rw [hlhs, hmean, hval] at hjensen
+  -- Cancel the common positive factor `1/n`.
+  exact le_of_mul_le_mul_left hjensen (by positivity)
+
+/-- The uniform distribution attains the maximum-entropy bound: `H(uniform) = log n`. -/
+theorem shannonEntropy_uniform [Nonempty ι] :
+    shannonEntropy (fun _ : ι => (Fintype.card ι : ℝ)⁻¹) = Real.log (Fintype.card ι) := by
+  set n : ℕ := Fintype.card ι with hn
+  have hnpos : 0 < n := Fintype.card_pos
+  have hnR : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hnpos
+  simp only [shannonEntropy, Real.negMulLog, Real.log_inv, Finset.sum_const,
+    Finset.card_univ, ← hn, nsmul_eq_mul]
+  field_simp
+
+end CauchySchwarzOQ01OQ03OQ02

--- a/research/problems/cauchy-schwarz-oq-01-oq-03-oq-02/knowledge.md
+++ b/research/problems/cauchy-schwarz-oq-01-oq-03-oq-02/knowledge.md
@@ -1,0 +1,79 @@
+# cauchy-schwarz-oq-01-oq-03-oq-02: Entropic uncertainty principle (Maassen–Uffink)
+
+**Parent**: `cauchy-schwarz-oq-01-oq-03` — "Heisenberg Uncertainty from Complex
+Cauchy-Schwarz" (`Proofs/CauchySchwarzOQ01OQ03.lean`, verified, 0-sorry/0-axiom). Its
+open question #2: *"Can the entropic uncertainty principle (Maassen–Uffink 1988) — a
+strictly stronger bound expressed in terms of Shannon entropy rather than standard
+deviation — be formalized in Lean 4 using Mathlib's information-theoretic library?"*
+
+## Session 2026-06-27 (Session 1) — FRESH, SURVEY → BLOCKED (infrastructure gap)
+
+**Outcome**: SURVEY + BUILD. The sharp Maassen–Uffink theorem is BLOCKED on missing Mathlib
+interpolation theory (documented below). I did NOT scaffold the sharp bound with a `sorry`
+(scaffolding-theater); instead I formalized the genuinely provable finite-dim entropy
+infrastructure as a new verified gallery entry. Depth-3 slug ⇒ no follow-up questions (guard).
+
+### Built (new entry, 0-axiom/0-sorry, offline-verified EXIT 0)
+`Proofs/CauchySchwarzOQ01OQ03OQ02.lean` (91L, ns `CauchySchwarzOQ01OQ03OQ02`):
+- `shannonEntropy p := ∑ i, Real.negMulLog (p i)`;
+- `shannonEntropy_nonneg` (entries in [0,1] ⇒ 0 ≤ H);
+- `shannonEntropy_le_log_card` — **max-entropy bound** H(p) ≤ log n via
+  `Real.concaveOn_negMulLog.le_map_sum` (Jensen, uniform weights 1/n) + `le_of_mul_le_mul_left`;
+- `shannonEntropy_uniform` — uniform attains H = log n (sharp).
+Plus gallery `meta.json` (status verified, badge mathlib, honest "toward entropic
+uncertainty" framing). `pnpm build` enrichment ran over the entry with no schema error
+(build later failed only at `tsc`/missing node_modules — worktree env, not data).
+
+### Target (precise)
+For an `n`-dimensional complex inner-product space with two orthonormal bases
+`{aᵢ}`, `{bⱼ}` and a unit vector `ψ`, set the outcome distributions
+`pᵢ = |⟨aᵢ, ψ⟩|²`, `qⱼ = |⟨bⱼ, ψ⟩|²` and the maximal overlap
+`c = maxᵢⱼ |⟨aᵢ, bⱼ⟩|`. The **Maassen–Uffink (1988)** entropic uncertainty relation:
+
+  H(p) + H(q) ≥ −2 ln c,    where  H(p) = Σᵢ negMulLog pᵢ = −Σᵢ pᵢ ln pᵢ.
+
+Its precursor **Deutsch (1983)** gives the weaker (interpolation-free) bound
+H(p) + H(q) ≥ −2 ln((1+c)/2).
+
+### Mathlib inventory (pinned v4.26.0)
+HAS (verified by grep of `.lake/packages/mathlib`):
+- `negMulLog` and `Real.negMulLog` with `negMulLog_nonneg`, `concaveOn_negMulLog`,
+  `strictConcaveOn_negMulLog` (`Analysis/SpecialFunctions/Log/NegMulLog.lean`).
+- Jensen's inequality (`Analysis/Convex/Jensen.lean`), mean inequalities
+  (`Analysis/MeanInequalities*.lean`), `L2Space`, and the Fourier transform *definition*
+  (`Analysis/Fourier/FourierTransform.lean`).
+- Complex Cauchy–Schwarz `abs_inner_le_norm` / `inner_mul_le_norm_mul_sq` (parent's basis).
+
+LACKS (the blocker):
+- **No Hausdorff–Young inequality, no Riesz–Thorin / Marcinkiewicz interpolation, no
+  Lp→Lp' Fourier norm bound.** `grep -i "interpolat|RieszThorin|HausdorffYoung"` over all
+  of Mathlib returns nothing. The sharp Maassen–Uffink constant `−2 ln c` follows from the
+  (2 → ∞) operator norm of the overlap matrix, i.e. exactly a Riesz–Thorin interpolation
+  argument. Building that is foundational (>1000 lines) — genuine BLOCK, not laziness.
+- No general Shannon entropy of a probability vector / measure (`measureEntropy` absent);
+  only the scalar `negMulLog`.
+
+### Why BLOCKED (buildability assessed)
+The sharp theorem is interpolation-gated. The honest classifications:
+- **Sharp Maassen–Uffink**: BLOCKED (needs Hausdorff–Young ⇐ Riesz–Thorin; >1000 lines).
+- **Deutsch's bound** `≥ −2 ln((1+c)/2)`: tractable in principle (variational/concavity
+  argument, no interpolation) but still a substantial standalone formalization and itself
+  nontrivial; a reasonable future DEEP-DIVE if someone first builds finite-dim entropy infra.
+
+### Recommended tractable sub-target (for a future session)
+Build finite-dimensional Shannon-entropy infrastructure from `negMulLog` first — it is the
+reusable prerequisite for any version here and is fully provable with current Mathlib:
+- `def shannonEntropy (p : Fin n → ℝ) : ℝ := ∑ i, Real.negMulLog (p i)`.
+- `0 ≤ shannonEntropy p` (from `negMulLog_nonneg`, given `0 ≤ pᵢ ≤ 1`).
+- `shannonEntropy p ≤ Real.log n` for a probability vector (Jensen on `concaveOn_negMulLog`
+  — the maximum-entropy bound). This is the clean, verifiable "entropy" deliverable.
+Only after that does Deutsch/Maassen–Uffink become approachable.
+
+### Files Modified
+- `proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean` (new, verified 0-axiom/0-sorry)
+- `src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json` (new gallery entry)
+
+### Next Steps
+- Either: upstream/await Hausdorff–Young in Mathlib, then formalize sharp Maassen–Uffink.
+- Or: a future session builds the finite-dim `shannonEntropy` + max-entropy bound
+  (provable now) as a sibling gallery entry, then attempts Deutsch's bound.

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
@@ -1,0 +1,99 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-03-oq-02",
+  "title": "Shannon Entropy: Maximum-Entropy Bound (toward Entropic Uncertainty)",
+  "slug": "cauchy-schwarz-oq-01-oq-03-oq-02",
+  "description": "Builds the finite-dimensional Shannon-entropy infrastructure needed for an entropic uncertainty relation: entropy of a probability vector via Mathlib's negMulLog, its nonnegativity, and the maximum-entropy bound H(p) ≤ log n via Jensen's inequality (with equality at the uniform distribution). The full Maassen–Uffink entropic uncertainty principle remains blocked on Mathlib's missing interpolation theory.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ03OQ02.lean",
+    "tags": [
+      "analysis",
+      "information theory",
+      "entropy",
+      "quantum mechanics",
+      "uncertainty principle",
+      "convexity"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 91,
+    "assumptions": "Uses Mathlib's Real.negMulLog (Shannon entropy term) with its concavity (concaveOn_negMulLog) and the finite Jensen inequality (ConcaveOn.le_map_sum). No additional axioms or assumptions.",
+    "theoremCount": 3,
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  },
+  "overview": {
+    "problemStatement": "Parent open question: can the entropic uncertainty principle (Maassen–Uffink 1988), $H(p) + H(q) \\geq -2\\ln c$ for the outcome distributions of two orthonormal bases with maximal overlap $c$, be formalized in Lean 4? This entry establishes the provable entropy half of that relation — the maximum-entropy bound $H(p) \\leq \\log n$ — and documents the precise obstruction to the full theorem.",
+    "historicalContext": "Shannon introduced the entropy $H(p) = -\\sum_i p_i \\log p_i$ in 1948. The principle that the uniform distribution maximizes entropy ($H(p) \\leq \\log n$) is a foundational maximum-entropy fact, provable directly from the concavity of $t \\mapsto -t\\log t$ via Jensen's inequality. The entropic formulation of the uncertainty principle was conjectured by Hirschman (1957), with the sharp finite-dimensional form proved by Deutsch (1983) and improved to the optimal constant by Maassen and Uffink (1988). The Maassen–Uffink bound is a strictly stronger, basis-independent statement than the Robertson/Heisenberg variance bound of the parent entry.",
+    "proofStrategy": "Shannon entropy of a finite probability vector is defined as a sum of Mathlib's negMulLog terms. Nonnegativity follows termwise from negMulLog_nonneg on [0,1]. The maximum-entropy bound is the concave Jensen inequality (ConcaveOn.le_map_sum) applied to negMulLog with uniform weights 1/n: this gives (1/n)·H(p) ≤ negMulLog(1/n) = (1/n)·log n, and cancelling 1/n yields H(p) ≤ log n. The uniform distribution is shown to attain the bound by direct computation.",
+    "keyInsights": [
+      "The maximum-entropy bound H(p) ≤ log n is precisely the concavity of negMulLog plus Jensen with uniform weights — no information-theoretic machinery beyond Mathlib's Real.negMulLog is required.",
+      "This is the 'entropy ceiling' that bounds either marginal in an entropic uncertainty relation; the genuinely hard content of Maassen–Uffink is the lower bound on the sum H(p) + H(q).",
+      "The sharp Maassen–Uffink constant -2 ln c follows from the Hausdorff–Young inequality (a (2→∞) operator-norm / Riesz–Thorin interpolation argument), which Mathlib v4.26.0 does not yet provide — making the full theorem genuinely blocked rather than merely unattempted.",
+      "Deutsch's interpolation-free precursor H(p) + H(q) ≥ -2 ln((1+c)/2) is the natural next target once finite-dimensional entropy infrastructure (this entry) is in place."
+    ]
+  },
+  "sections": [
+    {
+      "id": "background",
+      "title": "Background and Blocker",
+      "startLine": 1,
+      "endLine": 24,
+      "summary": "Documents the entropic uncertainty principle (Maassen–Uffink), records that the sharp form is blocked on Mathlib's missing Hausdorff–Young / Riesz–Thorin interpolation, and scopes this entry to the provable finite-dimensional entropy infrastructure."
+    },
+    {
+      "id": "definition",
+      "title": "Shannon Entropy of a Probability Vector",
+      "startLine": 28,
+      "endLine": 37,
+      "summary": "Defines shannonEntropy p as the sum of Mathlib's Real.negMulLog over the finite index type."
+    },
+    {
+      "id": "nonneg",
+      "title": "Nonnegativity",
+      "startLine": 38,
+      "endLine": 44,
+      "summary": "Entropy of a vector with entries in [0,1] is nonnegative, termwise from negMulLog_nonneg."
+    },
+    {
+      "id": "max-entropy",
+      "title": "Maximum-Entropy Bound",
+      "startLine": 46,
+      "endLine": 80,
+      "summary": "H(p) ≤ log n for a probability vector on n outcomes, via the concave Jensen inequality applied to negMulLog with uniform weights 1/n."
+    },
+    {
+      "id": "uniform",
+      "title": "Uniform Distribution Attains the Bound",
+      "startLine": 82,
+      "endLine": 91,
+      "summary": "The uniform distribution has entropy exactly log n, confirming the bound is sharp."
+    }
+  ],
+  "conclusion": {
+    "summary": "The finite-dimensional Shannon-entropy framework and the maximum-entropy bound H(p) ≤ log n are formalized and fully machine-checked (0 axioms, 0 sorries), built directly on Mathlib's negMulLog concavity and Jensen's inequality. This is the provable entropy half of an entropic uncertainty relation.",
+    "implications": "Provides reusable infrastructure for any future formalization of the entropic uncertainty principle. The full Maassen–Uffink bound is documented as blocked on Mathlib's absent interpolation theory (Hausdorff–Young / Riesz–Thorin); Deutsch's interpolation-free bound is the recommended next step once this infrastructure is extended.",
+    "openQuestions": [
+      "Can Deutsch's entropic uncertainty bound H(p) + H(q) ≥ -2 ln((1+c)/2) — which avoids interpolation — be formalized on top of this entropy infrastructure?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "CauchySchwarzOQ01OQ03OQ02",
+    "lineCount": 91,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/CauchySchwarzOQ01OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry derives the Heisenberg/Robertson variance uncertainty bound; this entry builds the entropy infrastructure toward the strictly stronger entropic uncertainty principle posed as its open question."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Parent entry `cauchy-schwarz-oq-01-oq-03` (Heisenberg uncertainty from complex Cauchy–Schwarz)
poses as its open question #2: formalize the **entropic uncertainty principle**
(Maassen–Uffink 1988), `H(p) + H(q) ≥ -2 ln c`.

**The sharp theorem is genuinely BLOCKED on Mathlib.** Its constant follows from the
Hausdorff–Young inequality / Riesz–Thorin interpolation, and a grep over all of Mathlib
v4.26.0 for `interpolat|RieszThorin|HausdorffYoung` returns nothing — there is no
interpolation theory and no Lp→Lp' Fourier bound. Building that is >1000 lines of
foundational analysis.

Rather than scaffold the sharp bound with a `sorry` (scaffolding-theater), this PR
formalizes the **genuinely provable** finite-dimensional Shannon-entropy infrastructure —
the "entropy half" any entropic uncertainty relation needs — as a new **verified** gallery
entry (0 axioms, 0 sorries, offline-verified):

- `shannonEntropy p = ∑ᵢ Real.negMulLog (pᵢ)` — Shannon entropy of a probability vector
- `shannonEntropy_nonneg` — `0 ≤ H(p)` for entries in `[0,1]`
- `shannonEntropy_le_log_card` — **maximum-entropy bound** `H(p) ≤ log n`, via Jensen
  (`concaveOn_negMulLog.le_map_sum`) with uniform weights `1/n`
- `shannonEntropy_uniform` — uniform distribution attains `H = log n` (bound is sharp)

## Files
- `proofs/Proofs/CauchySchwarzOQ01OQ03OQ02.lean` (new, 91 lines, verified)
- `src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json` (new gallery entry, honest
  "toward entropic uncertainty" framing; documents the interpolation blocker)
- `research/problems/cauchy-schwarz-oq-01-oq-03-oq-02/knowledge.md` (survey + build record)

## Honest scope
- This is **not** the entropic uncertainty principle — it is the reusable entropy
  infrastructure toward it. The full Maassen–Uffink bound is documented as blocked.
- The result `H(p) ≤ log n` is a standard maximum-entropy fact; the contribution is the
  machine-checked Lean formalization + the precise infrastructure-gap survey, which saves
  future sessions from re-discovering the Hausdorff–Young wall.
- Offline-verified (`LAKE_UNSAFE=1 ./bin/lake env lean ...`): compiles, 0 sorry / 0 axiom /
  0 native_decide. Gallery enrichment pass ran over the entry with no schema error.

## Status
**Outcome**: build + survey (BLOCKED on the sharp theorem)
**Next Steps**: Deutsch's interpolation-free bound `H(p)+H(q) ≥ -2 ln((1+c)/2)` is the
recommended next target on top of this infrastructure; the sharp bound awaits Hausdorff–Young
in Mathlib.

🤖 Generated by researcher-1