### PR TITLE
Auditor: fix bezout-lame-golden theoremCount 5→6

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25033,6 +25033,12 @@
       "lastAudited": "2026-06-27T09:29:54Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:16:36Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "lineCount": 216,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 1
   },
   "openQuestion": {
@@ -139,7 +139,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
       "lame_fib_lower: the sharp form of Lamé's theorem — n+1 ≤ steps a b → fib(n+2) ≤ b — the input lower bound (converse worst-case direction) the parent lacked, by Nat.twoStepInduction",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `bezout-identity-oq-02-oq-02-oq-01-oq-03-oq-01` (Lamé's Theorem, Sharp: the Golden-Ratio Constant)
**Severity**: LOW (count field accuracy)

### Finding

The Lean source `Proofs/BezoutIdentityOQ02OQ02OQ01OQ03OQ01.lean` declares **6 theorems**:
`steps_zero`, `steps_succ`, `steps_pos`, `lame_fib_lower`, `golden_pow_le_fib`, `steps_le_logb_golden`.

But `meta.json` claimed `theoremCount: 5` in both `leanFile.theoremCount` and `meta.theoremCount`. The `@[simp]`-prefixed `steps_zero` was undercounted.

### Fix

Bump both `theoremCount` fields 5 → 6.

### Everything else verified accurate

- 0 sorries, 0 axioms, 0 `native_decide`, no `True` stubs ✓
- `definitionCount: 1` correct (`steps`) ✓
- `status: verified` / `badge: original` correct — **Tier A**. The inductive core (`lame_fib_lower` via `Nat.twoStepInduction`, `golden_pow_le_fib`) is genuine original work; the Mathlib lemmas used (`Real.goldenRatio_sq`, `Real.logb_*`, `Nat.fib_add_two`) are standard support, not a wrapped "Lamé theorem." No delegation opacity.

Tracker updated (`issues-fixed`).

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)