### PR TITLE
Enrich sharp symmetric LLL (prob-method-lovasz-local-oq-02): sections + annotation depth

### DIFF
--- a/src/data/proofs/prob-method-lovasz-local-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-lovasz-local-oq-02/annotations.json
@@ -9,7 +9,18 @@
     "type": "definition",
     "title": "The Real Avoidance Threshold T(d)",
     "content": "```lean\nnoncomputable def lllThresholdReal (d : ℕ) : ℝ :=\n  (1 / ((d : ℝ) + 1)) * ((d : ℝ) / ((d : ℝ) + 1)) ^ d\n```\n\nThis is the symmetric Lovász Local Lemma threshold $T(d) = \\frac{1}{d+1}\\left(\\frac{d}{d+1}\\right)^d = \\frac{d^d}{(d+1)^{d+1}}$, written over ℝ so it can be compared directly with the irrational sharp threshold $1/(e(d+1))$. The sibling entry `lovasz-local-lemma-oq-02` proves the rational version of $T(d)$ is the algebraically optimal probability the symmetric LLL tolerates at maximum dependency degree $d$.",
-    "mathContext": "$T(d)$ is the maximum of $x \\mapsto x(1-x)^d$, attained at $x^\\star = 1/(d+1)$."
+    "mathContext": "$T(d)$ is the maximum of $x \\mapsto x(1-x)^d$, attained at $x^\\star = 1/(d+1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "symmetric Lovász Local Lemma",
+      "avoidance threshold T(d)",
+      "maximizing x(1−x)^d",
+      "d^d/(d+1)^{d+1}"
+    ],
+    "prerequisites": [
+      "the symmetric LLL statement",
+      "maximizing x(1−x)^d over x"
+    ]
   },
   {
     "id": "ann-lll-key-lemma",
@@ -21,19 +32,41 @@
     "type": "insight",
     "title": "Key Lemma: (1 + 1/d)^d ≤ e Without the Limit",
     "content": "The parent entry conjectured that connecting the LLL to the sharp constant $e$ would 'require formalizing $e = \\lim (1+1/n)^n$'. It does not. The entire analytic content is one Mathlib inequality:\n\n```lean\ntheorem one_add_inv_pow_le_exp_one {d : ℕ} (hd : 1 ≤ d) :\n    (1 + 1 / (d : ℝ)) ^ d ≤ Real.exp 1 := by\n  ...\n  have h1 : (1 : ℝ) + 1 / d ≤ Real.exp (1 / d) := by\n    have := Real.add_one_le_exp (1 / d); linarith\n  have h2 : (1 + 1 / d) ^ d ≤ (Real.exp (1 / d)) ^ d := pow_le_pow_left₀ hb h1 d\n  have h3 : (Real.exp (1 / d)) ^ d = Real.exp 1 := by\n    rw [← Real.exp_nat_mul, mul_one_div, div_self hdne]\n  rwa [h3] at h2\n```\n\nApply $1 + x \\le e^x$ at $x = 1/d$, raise to the $d$-th power (monotone, base nonneg), and collapse $(e^{1/d})^d = e^{d \\cdot (1/d)} = e$. No sequences, no limits.",
-    "mathContext": "$(1+1/d)^d \\le (e^{1/d})^d = e^{d \\cdot 1/d} = e^1 = e$."
+    "mathContext": "$(1+1/d)^d \\le (e^{1/d})^d = e^{d \\cdot 1/d} = e^1 = e$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Real.add_one_le_exp",
+      "(1+1/d)^d ≤ e",
+      "pow_le_pow_left₀",
+      "avoiding the limit definition of e"
+    ],
+    "prerequisites": [
+      "the inequality 1 + x ≤ eˣ",
+      "monotonicity of x ↦ xᵈ"
+    ]
   },
   {
     "id": "ann-lll-reciprocal",
     "proofId": "prob-method-lovasz-local-oq-02",
     "range": {
-      "startLine": 85,
+      "startLine": 75,
       "endLine": 96
     },
     "type": "step",
     "title": "Reciprocal Form: 1/e ≤ (d/(d+1))^d",
     "content": "Since $\\frac{d}{d+1} = \\frac{1}{1 + 1/d}$, the key lemma flips to a lower bound on the avoidance factor:\n\n```lean\ntheorem inv_exp_one_le {d : ℕ} (hd : 1 ≤ d) :\n    1 / Real.exp 1 ≤ ((d : ℝ) / ((d : ℝ) + 1)) ^ d\n```\n\nThe proof rewrites $(d/(d+1))^d = 1/(1+1/d)^d$ and applies `one_div_le_one_div_of_le` to the key lemma. This is the precise inequality that places the sharp threshold below the algebraic one.",
-    "mathContext": "$(1+1/d)^d \\le e \\iff 1/e \\le (d/(d+1))^d$."
+    "mathContext": "$(1+1/d)^d \\le e \\iff 1/e \\le (d/(d+1))^d$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reciprocal inequality",
+      "one_div_le_one_div_of_le",
+      "avoidance factor (d/(d+1))^d",
+      "1/e lower bound"
+    ],
+    "prerequisites": [
+      "the key lemma (1+1/d)^d ≤ e",
+      "d/(d+1) = 1/(1+1/d)"
+    ]
   },
   {
     "id": "ann-lll-headline-bridge",
@@ -45,7 +78,18 @@
     "type": "insight",
     "title": "Headline: The Sharp Criterion Implies the Avoidance Threshold",
     "content": "Multiplying the reciprocal bound by $1/(d+1)$ gives $1/(e(d+1)) \\le T(d)$ (`sharp_le_lllThresholdReal`). Hence the sharp criterion reduces to the avoidance condition the gallery already discharges:\n\n```lean\ntheorem sharp_criterion_implies_threshold {d : ℕ} (hd : 1 ≤ d) {p : ℝ}\n    (_hp : 0 ≤ p) (hsharp : Real.exp 1 * p * ((d : ℝ) + 1) ≤ 1) :\n    p ≤ lllThresholdReal d\n```\n\nFrom $e \\cdot p \\cdot (d+1) \\le 1$ we get $p \\le 1/(e(d+1)) \\le T(d)$. So no new induction is needed: the sharp constant $e$ is justified purely by reduction to the optimal rational threshold.",
-    "mathContext": "$e p (d+1) \\le 1 \\Rightarrow p \\le \\tfrac{1}{e(d+1)} \\le T(d)$."
+    "mathContext": "$e p (d+1) \\le 1 \\Rightarrow p \\le \\tfrac{1}{e(d+1)} \\le T(d)$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sharp LLL criterion e·p·(d+1) ≤ 1",
+      "reduction to the algebraic threshold",
+      "1/(e(d+1)) ≤ T(d)",
+      "no new induction"
+    ],
+    "prerequisites": [
+      "the reciprocal bound 1/e ≤ (d/(d+1))^d",
+      "the threshold definition T(d)"
+    ]
   },
   {
     "id": "ann-lll-strict-improvement",
@@ -57,18 +101,40 @@
     "type": "insight",
     "title": "Strict Improvement: e < 3 Beats the 1/3 Criterion",
     "content": "Because $e < 3$ (`exp_one_lt_three`, from `Real.exp_one_lt_d9`), the loose criterion $p(d+1) \\le 1/3$ implies the sharp $e p (d+1) \\le 1$ (`third_implies_sharp`) — replacing $1/3$ by $1/e$ only enlarges the admissible set. The improvement is strict:\n\n```lean\ntheorem exists_sharp_not_third {d : ℕ} (hd : 1 ≤ d) :\n    ∃ p : ℝ, 0 ≤ p ∧ Real.exp 1 * p * ((d : ℝ) + 1) ≤ 1\n      ∧ 1 / 3 < p * ((d : ℝ) + 1)\n```\n\nThe witness $p = 1/(e(d+1))$ saturates the sharp criterion ($e p (d+1) = 1$) yet has $p(d+1) = 1/e > 1/3$, so it is certified by the sharp criterion but rejected by the gallery's $1/3$ form. The improvement window is $\\tfrac{1}{3(d+1)} < p \\le \\tfrac{1}{e(d+1)}$.",
-    "mathContext": "$1/3 < 1/e$ since $e < 3$; the sharp threshold is the larger one."
+    "mathContext": "$1/3 < 1/e$ since $e < 3$; the sharp threshold is the larger one.",
+    "significance": "key",
+    "relatedConcepts": [
+      "e < 3 (Real.exp_one_lt_d9)",
+      "strict improvement over 1/3",
+      "admissible window 1/(3(d+1)) < p ≤ 1/(e(d+1))",
+      "saturating witness"
+    ],
+    "prerequisites": [
+      "the sharp criterion",
+      "the loose 1/3 criterion"
+    ]
   },
   {
     "id": "ann-lll-capstone",
     "proofId": "prob-method-lovasz-local-oq-02",
     "range": {
-      "startLine": 154,
+      "startLine": 155,
       "endLine": 163
     },
     "type": "step",
     "title": "Capstone: The Sharp Symmetric LLL",
     "content": "```lean\ntheorem sharp_symmetric_lll {d : ℕ} (hd : 1 ≤ d) {p : ℝ} (hp : 0 ≤ p)\n    (hsharp : Real.exp 1 * p * ((d : ℝ) + 1) ≤ 1) (n : ℕ) :\n    p ≤ lllThresholdReal d ∧ 0 < ((d : ℝ) / ((d : ℝ) + 1)) ^ n\n```\n\nThe textbook statement, now formally tied to $e$: under the sharp criterion, $p$ meets the LLL threshold and the avoidance product $(d/(d+1))^n$ is strictly positive — the bad events can all be simultaneously avoided.",
-    "mathContext": "$e p (d+1) \\le 1 \\Rightarrow p \\le T(d) \\text{ and } \\Pr[\\text{avoid all}] \\ge (d/(d+1))^n > 0$."
+    "mathContext": "$e p (d+1) \\le 1 \\Rightarrow p \\le T(d) \\text{ and } \\Pr[\\text{avoid all}] \\ge (d/(d+1))^n > 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "symmetric LLL (textbook form)",
+      "avoidance product (d/(d+1))^n > 0",
+      "simultaneous avoidance",
+      "the constant e"
+    ],
+    "prerequisites": [
+      "the headline reduction",
+      "positivity of the avoidance product"
+    ]
   }
 ]

--- a/src/data/proofs/prob-method-lovasz-local-oq-02/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local-oq-02/meta.json
@@ -71,6 +71,50 @@
       "Monotonicity of x ↦ x^n and reciprocals on the reals"
     ]
   },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Docstring framing the open question: does tying the symmetric Lovász Local Lemma to the sharp constant e require formalizing e = lim (1+1/n)ⁿ? The answer is no — one Mathlib inequality suffices. Imports and the namespace."
+    },
+    {
+      "id": "threshold-def",
+      "title": "The Avoidance Threshold T(d)",
+      "startLine": 51,
+      "endLine": 57,
+      "summary": "lllThresholdReal d = (1/(d+1))·(d/(d+1))ᵈ = dᵈ/(d+1)^{d+1}, the symmetric LLL threshold written over ℝ so it can be compared with the sharp 1/(e(d+1))."
+    },
+    {
+      "id": "key-lemma",
+      "title": "Key Lemma and Its Reciprocal",
+      "startLine": 58,
+      "endLine": 96,
+      "summary": "one_add_inv_pow_le_exp_one: (1+1/d)ᵈ ≤ e via 1+x ≤ eˣ at x=1/d raised to the d-th power (no limits). inv_exp_one_le flips it to 1/e ≤ (d/(d+1))ᵈ, and sharp_le_lllThresholdReal multiplies by 1/(d+1) to get 1/(e(d+1)) ≤ T(d)."
+    },
+    {
+      "id": "headline",
+      "title": "Headline: Sharp Criterion ⟹ Threshold",
+      "startLine": 98,
+      "endLine": 110,
+      "summary": "sharp_criterion_implies_threshold: e·p·(d+1) ≤ 1 gives p ≤ 1/(e(d+1)) ≤ T(d), reducing the sharp criterion to the avoidance condition the gallery already discharges — no new induction."
+    },
+    {
+      "id": "strict-improvement",
+      "title": "Strict Improvement over the 1/3 Criterion",
+      "startLine": 111,
+      "endLine": 146,
+      "summary": "exp_one_lt_three (e < 3 from Real.exp_one_lt_d9); third_implies_sharp shows p(d+1) ≤ 1/3 implies the sharp criterion; exists_sharp_not_third exhibits p = 1/(e(d+1)) admitted by the sharp criterion but rejected by 1/3 — the window 1/(3(d+1)) < p ≤ 1/(e(d+1))."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone: The Sharp Symmetric LLL",
+      "startLine": 147,
+      "endLine": 164,
+      "summary": "avoidance_pos and sharp_symmetric_lll: under e·p·(d+1) ≤ 1, p meets the threshold and the avoidance product (d/(d+1))ⁿ is strictly positive — the bad events can all be simultaneously avoided, now formally tied to e."
+    }
+  ],
   "conclusion": {
     "summary": "The sharp symmetric Lovász Local Lemma criterion e·p·(d+1) ≤ 1 is formally connected to Euler's number e and shown to imply the avoidance threshold T(d) the gallery already proves optimal. The crux is a single Mathlib inequality, 1 + x ≤ exp x, which gives (1+1/d)^d ≤ e without any limit. Since e < 3, the sharp criterion strictly improves the gallery's 1/3 criterion.",
     "implications": "This resolves the parent entry's open question with a method simpler than anticipated: no formalization of e = lim (1+1/n)^n is needed. The bridge to the already-formalized algebraic threshold means the full symmetric LLL machinery (avoidance positivity) transfers immediately to the sharp constant.",


### PR DESCRIPTION
Enrichment pass for `prob-method-lovasz-local-oq-02` (the symmetric Lovász Local Lemma tied to the sharp constant e, without the limit definition).

## Changes
- **Added a `sections` array** (previously absent) with 6 entries covering the full 164-line Lean file.
- **Deepened all 6 annotations** with `significance`, `relatedConcepts`, and `prerequisites` (mathContext was already present). Resolver: 6 valid, 0 misaligned.

Quality 68 → 98 (sections, significance, relatedConcepts now maxed). meta.json within size caps. Validated via resolver + JSON parse + size guard.