### PR TITLE
Enrich Horadam Cassini/d'Ocagne (fibonacci-identities-oq-04-oq-01-oq-02): add annotations.json

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-02/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-horadam-def",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 58 },
+    "type": "definition",
+    "title": "The Horadam Sequence and Its Recurrence",
+    "content": "`H p q a b : ℕ → ℤ` is defined by structural recursion on the two parameters p, q and the two seeds a = H 0, b = H 1, with H (n+2) = p·H(n+1) + q·H n. Because the recursion peels exactly two layers, Lean accepts it as a well-founded definition with no termination obligation beyond the structural one. The seed lemmas H_zero and H_one are `rfl` and tagged `@[simp]`; crucially, the recurrence lemma H_rec is also `rfl` (definitional), so every later proof can rewrite with it freely. The Horadam family (Horadam 1965) subsumes Fibonacci (1,1,0,1), Lucas (1,1,2,1), Pell (2,1,0,1) and Jacobsthal (1,2,0,1) as fixed parameter choices.",
+    "mathContext": "$$H(0)=a,\\quad H(1)=b,\\quad H(n+2)=p\\,H(n+1)+q\\,H(n)$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Horadam sequence", "second-order linear recurrence", "structural recursion", "Gibonacci sequences"],
+    "prerequisites": ["recursion on ℕ with two base cases", "definitional equality (rfl)"]
+  },
+  {
+    "id": "ann-docagne",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 77 },
+    "type": "insight",
+    "title": "The Master d'Ocagne Identity by a Single Induction",
+    "content": "`horadam_dOcagne` is the keystone: for every gap k and index n, H(n+k+1)·H(n) − H(n+k)·H(n+1) = (−q)ⁿ·(H(k+1)·a − H(k)·b). Keeping k a free parameter is the central design choice — it makes Cassini (k=1) and d'Ocagne (general k) the same theorem. The proof is one induction on n. The base n=0 is `simp` (the right side is by definition the n=0 value of the left). The step first normalizes the shifted indices with three `omega` facts (n+1+k+1 = (n+k)+2, etc.), then expands the two recurrence instances H((n+k)+2) and H(n+2) via H_rec, and finally closes with `linear_combination (-q) * ih`: expanding both recurrences cancels the p-terms so the new difference is exactly −q times the old one — D_k(n+1) = −q·D_k(n).",
+    "mathContext": "$$H(n{+}k{+}1)H(n) - H(n{+}k)H(n{+}1) = (-q)^n\\,(H(k{+}1)\\,a - H(k)\\,b),\\qquad D_k(n{+}1) = -q\\,D_k(n)$$",
+    "significance": "key",
+    "relatedConcepts": ["d'Ocagne's identity", "linear_combination tactic", "telescoping recurrence", "companion matrix determinant"],
+    "prerequisites": ["induction on ℕ", "the recurrence lemma H_rec", "linear_combination over a commutative ring"]
+  },
+  {
+    "id": "ann-cassini",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 94 },
+    "type": "technique",
+    "title": "Generalized Cassini as the k = 1 Specialization",
+    "content": "`horadam_cassini` is just horadam_dOcagne at k=1: H(n+2)·H(n) − H(n+1)² = (−q)ⁿ·(H 2·a − b²). The only work is `simpa [sq, H_one]` to rewrite H(n+1)·H(n+1) as the square H(n+1)². No new induction is needed — the master identity already contains Cassini. `horadam_cassini_const` then evaluates the constant explicitly: unfolding H 2 = p·b + q·a via H_rec at n=0 gives H 2·a − b² = (p·b + q·a)·a − b², the Horadam discriminant. This is the generalization the open question asked for: the fixed Cassini sign is replaced by the genuine discriminant of the recurrence.",
+    "mathContext": "$$H(n+2)H(n) - H(n+1)^2 = (-q)^n\\bigl((p\\,b + q\\,a)\\,a - b^2\\bigr)$$",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "Simson's identity", "Horadam discriminant", "specialization"],
+    "prerequisites": ["horadam_dOcagne", "simp lemma rewriting", "squaring sq"]
+  },
+  {
+    "id": "ann-fib-identification",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-02",
+    "range": { "startLine": 96, "endLine": 107 },
+    "type": "technique",
+    "title": "Identifying H 1 1 0 1 with the Fibonacci Numbers",
+    "content": "`H_fib` proves H 1 1 0 1 n = (Nat.fib n : ℤ) by strong induction (Nat.strong_induction_on). The `match n` splits into n=0, n=1 (both `simp`), and n=m+2, where the recurrence H_rec gives H(m+2) = 1·H(m+1) + 1·H(m), the two strong-induction hypotheses rewrite each to a Fibonacci cast, and Nat.fib_add_two = fib m + fib (m+1) matches; `push_cast; ring` reconciles the ℕ→ℤ casts. This is the bridge that lets the general Horadam result specialize to the classical Fibonacci numbers.",
+    "mathContext": "$$H_{1,1,0,1}(n) = F_n,\\quad\\text{since } H(m+2)=H(m+1)+H(m)\\text{ matches } F_{m+2}=F_m+F_{m+1}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.fib", "Nat.fib_add_two", "strong induction", "ℕ→ℤ cast (push_cast)"],
+    "prerequisites": ["Nat.strong_induction_on", "Nat.fib_add_two", "push_cast / ring"]
+  },
+  {
+    "id": "ann-fib-cassini",
+    "proofId": "fibonacci-identities-oq-04-oq-01-oq-02",
+    "range": { "startLine": 109, "endLine": 119 },
+    "type": "insight",
+    "title": "Recovering Classical Cassini as a Corollary",
+    "content": "`fib_cassini_shifted` derives the textbook Cassini identity F(n+2)·F(n) − F(n+1)² = (−1)ⁿ⁺¹ from the general Horadam result with zero new induction. Take horadam_cassini at (p,q,a,b)=(1,1,0,1), rewrite each H via H_fib, and evaluate the discriminant: fib 2 · 0 − 1² = −1 (norm_num). With q=1 the geometric factor (−q)ⁿ = (−1)ⁿ, so the constant is (−1)ⁿ·(−1) = (−1)ⁿ⁺¹ (pow_succ). This concretely demonstrates the entry's thesis: the famous Fibonacci sign is just the q=1 shadow of the companion-matrix determinant −q.",
+    "mathContext": "$$F(n+2)F(n) - F(n+1)^2 = (-1)^n\\cdot(-1) = (-1)^{n+1}$$",
+    "significance": "key",
+    "relatedConcepts": ["Cassini's identity", "Fibonacci numbers", "corollary by specialization", "pow_succ"],
+    "prerequisites": ["horadam_cassini", "H_fib", "norm_num", "pow_succ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-04-oq-01-oq-02` (Cassini and d'Ocagne for the Full Horadam Recurrence — the Geometric Constant (−q)ⁿ).

The entry had a rich `meta.json` (13.7 KB, under the cap) but an **empty `annotations.json` (`[]`)**. This PR adds 5 inline annotations covering: the Horadam sequence definition and `H_rec`, the master `horadam_dOcagne` induction (one induction proving both Cassini and d'Ocagne), the k=1 Cassini specialization `horadam_cassini`, the Fibonacci identification `H_fib`, and the classical Cassini corollary `fib_cassini_shifted`.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, and references the actual tactics/lemmas (`linear_combination`, `Nat.fib_add_two`, `Nat.strong_induction_on`). `meta.json` unchanged. Axiom integrity verified (0 axioms, 0 sorries, no native_decide). `pnpm build` passes.