### PR TITLE
Research: pythagorean-triples-oq-02-oq-01 — primitive-triple classification via Gaussian integers (verified)

### DIFF
--- a/proofs/Proofs/PythagoreanTriplesOQ02OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ02OQ01.lean
@@ -1,0 +1,101 @@
+/-
+  Pythagorean Triples: Complete Classification via Gaussian Integers
+
+  Open Question (pythagorean-triples-oq-02-oq-01), a sub-question of
+  `pythagorean-triples-oq-02` (Gaussian integers):
+
+  "Can the *classification* of all primitive Pythagorean triples be formalized?
+   Every primitive triple has the form (m²-n², 2mn, m²+n²) with gcd(m,n)=1 and
+   opposite parity.  This uses the UFD property of ℤ[i]."
+
+  The Gaussian-integer story behind the parametrization (developed in the parent
+  entry) is: squaring z = m + n·i gives
+
+        z² = (m² - n²) + (2mn)·i,        N(z²) = N(z)² = (m² + n²)²,
+
+  so the two legs (m²-n², 2mn) are the real/imaginary parts of z², and the
+  hypotenuse m²+n² is the Gaussian norm N(z).  This file connects that
+  parametrization map to the full classification.
+
+  Mathlib already proves the deep direction — that *every* primitive triple
+  arises this way — in `PythagoreanTriple.coprime_classification` (whose proof
+  rests on ℤ[i] being a UFD / the gcd theory of the integers).  We therefore
+  present this entry honestly as a **bridge**: the elementary forward facts
+  (the parametrization always yields a primitive triple) are proved here, and
+  the full biconditional classification is exported and packaged in the
+  Gaussian-parametrization language.
+
+  Tags: number-theory, gaussian-integers, pythagorean-triples, classification
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesOQ02OQ01
+
+open Int
+
+/-! ## The Gaussian-square parametrization -/
+
+/-- The parametrization map `(m, n) ↦ (m²-n², 2mn, m²+n²)`.  The first two
+components are the real and imaginary parts of the Gaussian square
+`(m + n·i)²`, and the third is the Gaussian norm `N(m + n·i) = m²+n²`. -/
+def paramTriple (m n : ℤ) : ℤ × ℤ × ℤ := (m ^ 2 - n ^ 2, 2 * m * n, m ^ 2 + n ^ 2)
+
+/-- The parametrization always produces a Pythagorean triple — the algebraic
+heart, i.e. `N(z²) = N(z)²` written out: `(m²-n²)² + (2mn)² = (m²+n²)²`. -/
+theorem paramTriple_isPythagorean (m n : ℤ) :
+    PythagoreanTriple (m ^ 2 - n ^ 2) (2 * m * n) (m ^ 2 + n ^ 2) := by
+  delta PythagoreanTriple; ring
+
+/-- Constructive (easy) direction of the classification: a coprime pair of
+opposite parity yields a **primitive** Pythagorean triple, i.e. the two legs
+`m²-n²` and `2mn` are coprime.
+
+(We derive coprimality from Mathlib's `coprime_classification` rather than the
+private lemma `coprime_sq_sub_mul`; the point here is the Gaussian framing.) -/
+theorem paramTriple_isPrimitive {m n : ℤ} (co : Int.gcd m n = 1)
+    (pp : m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :
+    Int.gcd (m ^ 2 - n ^ 2) (2 * m * n) = 1 :=
+  (PythagoreanTriple.coprime_classification
+      (x := m ^ 2 - n ^ 2) (y := 2 * m * n) (z := m ^ 2 + n ^ 2)).mpr
+    ⟨m, n, Or.inl ⟨rfl, rfl⟩, Or.inl rfl, co, pp⟩ |>.2
+
+/-! ## The complete classification (bridge to Mathlib) -/
+
+/-- **Complete classification of primitive Pythagorean triples**, packaged in
+the Gaussian-parametrization language.  An integer triple `(x, y, z)` is a
+primitive Pythagorean triple iff it arises from the parametrization map for some
+coprime, opposite-parity pair `(m, n)` (up to swapping the legs and the sign of
+`z`).
+
+The hard direction — every primitive triple has this shape — is
+`PythagoreanTriple.coprime_classification`, ultimately a consequence of unique
+factorization in ℤ[i]. -/
+theorem primitive_classification {x y z : ℤ} :
+    (PythagoreanTriple x y z ∧ Int.gcd x y = 1) ↔
+      ∃ m n,
+        (x = m ^ 2 - n ^ 2 ∧ y = 2 * m * n ∨ x = 2 * m * n ∧ y = m ^ 2 - n ^ 2) ∧
+          (z = m ^ 2 + n ^ 2 ∨ z = -(m ^ 2 + n ^ 2)) ∧
+            Int.gcd m n = 1 ∧ (m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :=
+  PythagoreanTriple.coprime_classification
+
+/-- The sharper "standard form" when the odd leg `x` is taken positive and `z`
+is positive: there exist `m ≥ 0` and `n` with exactly
+`x = m²-n²,  y = 2mn,  z = m²+n²`, coprime and of opposite parity.  This is the
+textbook parametrization with no sign/order ambiguity. -/
+theorem primitive_classification_pos {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hpos : 0 < z) :
+    ∃ m n, x = m ^ 2 - n ^ 2 ∧ y = 2 * m * n ∧ z = m ^ 2 + n ^ 2 ∧
+      Int.gcd m n = 1 ∧ (m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) ∧ 0 ≤ m :=
+  h.coprime_classification' hco hodd hpos
+
+/-- A clean number-theoretic corollary: the hypotenuse of any positive primitive
+Pythagorean triple (with odd leg `x`) is a sum of two squares, `z = m² + n²`.
+This is the Gaussian-integer fact `z = N(m + n·i)` made explicit. -/
+theorem hypotenuse_sum_of_squares {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hpos : 0 < z) :
+    ∃ m n, z = m ^ 2 + n ^ 2 := by
+  obtain ⟨m, n, _, _, hz, _⟩ := primitive_classification_pos h hco hodd hpos
+  exact ⟨m, n, hz⟩
+
+end PythagoreanTriplesOQ02OQ01

--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
@@ -1,0 +1,80 @@
+{
+  "id": "pythagorean-triples-oq-02-oq-01",
+  "title": "Pythagorean Triples: Complete Classification via Gaussian Integers",
+  "slug": "pythagorean-triples-oq-02-oq-01",
+  "description": "Open question OQ-01 of pythagorean-triples-oq-02: formalize the complete classification of primitive Pythagorean triples. Every primitive triple has the form (m²-n², 2mn, m²+n²) with gcd(m,n)=1 and m,n of opposite parity — the real/imaginary parts of the Gaussian square (m+ni)² together with its norm. This entry bridges Mathlib's PythagoreanTriple.coprime_classification into the Gaussian-parametrization language and proves the elementary forward facts directly.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/PythagoreanTriples.html",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ02OQ01.lean",
+    "tags": ["number-theory", "gaussian-integers", "pythagorean-triples", "classification", "mathlib-bridge"],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {"theorem": "PythagoreanTriple.coprime_classification", "description": "Every primitive Pythagorean triple has the Euclidean parametric form (hard direction, via UFD of ℤ[i] / gcd theory)", "module": "Mathlib.NumberTheory.PythagoreanTriples"},
+      {"theorem": "PythagoreanTriple.coprime_classification'", "description": "Sharper standard-form classification for positive triples with odd leg", "module": "Mathlib.NumberTheory.PythagoreanTriples"},
+      {"theorem": "PythagoreanTriple", "description": "Definition x*x + y*y = z*z", "module": "Mathlib.NumberTheory.PythagoreanTriples"}
+    ],
+    "originalContributions": [
+      "Named Gaussian-square parametrization map paramTriple (m,n) ↦ (m²-n², 2mn, m²+n²), exhibiting the legs as Re/Im of (m+ni)² and the hypotenuse as the norm N(m+ni)",
+      "Direct proof that the parametrization always yields a Pythagorean triple (the identity N(z²)=N(z)²)",
+      "Derivation of leg-coprimality (primitivity) for coprime opposite-parity pairs from the public classification, avoiding Mathlib's private coprime_sq_sub_mul lemma",
+      "Packaging of the full biconditional classification in the Gaussian-parametrization language",
+      "Corollary: the hypotenuse of any positive primitive triple (odd leg) is a sum of two squares, z = m²+n² = N(m+ni)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 101,
+    "assumptions": "0 axioms, 0 sorries. All five theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, hence no Lean.ofReduceBool. This is a Mathlib BRIDGE: the deep direction of the classification (every primitive triple has the parametric form) is Mathlib's PythagoreanTriple.coprime_classification, which rests on unique factorization in ℤ[i]. Badge 'mathlib' reflects that the headline result is imported, not re-proved.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parametrization of Pythagorean triples is classical (Euclid). The conceptual explanation is algebraic: in the Gaussian integers ℤ[i], a² + b² = N(a+bi) is a multiplicative norm, and squaring z = m + ni gives z² = (m²-n²) + (2mn)i with N(z²) = (m²+n²)². Thus every coprime opposite-parity pair (m,n) yields a primitive triple, and — via unique factorization in ℤ[i] — every primitive triple arises this way. Mathlib formalizes the full classification in PythagoreanTriple.coprime_classification.",
+    "problemStatement": "Classify all primitive Pythagorean triples: show $(x,y,z)$ with $x^2+y^2=z^2$ and $\\gcd(x,y)=1$ is, up to leg-swap and sign of $z$, exactly $(m^2-n^2,\\,2mn,\\,m^2+n^2)$ for some coprime $m,n$ of opposite parity.",
+    "text": "OQ-01 of the Gaussian-integers entry asks to formalize the classification of primitive Pythagorean triples. We bridge Mathlib's classification into the Gaussian-parametrization framework and prove the elementary forward facts directly.",
+    "proofStrategy": "Define the parametrization map paramTriple. Prove (a) it always yields a Pythagorean triple by the ring identity (m²-n²)²+(2mn)²=(m²+n²)²; (b) for coprime opposite-parity inputs the legs are coprime, derived from the reverse direction of coprime_classification; (c) export the full biconditional classification; (d) the sharper positive standard form via coprime_classification'; (e) the sum-of-two-squares corollary for the hypotenuse.",
+    "keyInsights": [
+      "**Legs = Re/Im of a Gaussian square**: (m²-n², 2mn) are exactly the components of (m+ni)², so the parametrization is 'square a Gaussian integer'.",
+      "**Hypotenuse = Gaussian norm**: m²+n² = N(m+ni), and N(z²)=N(z)² is precisely the Pythagorean relation.",
+      "**Why opposite parity and coprimality give primitivity**: these are exactly the conditions under which m+ni is (up to units) not divisible by 1+i, keeping the square primitive.",
+      "**The hard direction needs ℤ[i] UFD**: that every primitive triple comes from a single Gaussian square is unique factorization in disguise — supplied by Mathlib."
+    ],
+    "prerequisites": ["Gaussian integers and their norm", "Pythagorean triples", "gcd / coprimality over ℤ"]
+  },
+  "sections": [
+    {"id": "header", "title": "Module Documentation", "startLine": 1, "endLine": 38, "summary": "Statement of OQ-01, the Gaussian-square narrative, and the honest bridge framing.", "mathContext": "Mathematical content: the Gaussian-integer explanation of the parametrization."},
+    {"id": "param", "title": "The Gaussian-Square Parametrization", "startLine": 40, "endLine": 64, "summary": "paramTriple map, the always-a-triple identity, and primitivity for coprime opposite-parity inputs.", "mathContext": "Mathematical content: forward (constructive) direction."},
+    {"id": "classification", "title": "The Complete Classification", "startLine": 66, "endLine": 101, "summary": "Full biconditional classification (bridge), the positive standard form, and the hypotenuse sum-of-squares corollary.", "mathContext": "Mathematical content: the classification packaged in Gaussian language."}
+  ],
+  "conclusion": {
+    "summary": "We formalize the classification of primitive Pythagorean triples requested in OQ-01, bridging Mathlib's PythagoreanTriple.coprime_classification into the Gaussian-parametrization language. The forward direction (parametrization yields primitive triples) is proved directly; the deep converse is imported. Five theorems, 0 sorries, 0 axioms.",
+    "implications": "Completes the Gaussian-integer thread of the Pythagorean-triples gallery by tying the algebraic z ↦ z² picture to the full classification, and exposes the hypotenuse-is-a-sum-of-two-squares corollary, connecting to Fermat's two-squares theorem (the sibling OQ-02 of the parent).",
+    "openQuestions": [
+      "Is there a Lean proof of Fermat's two-squares theorem p ≡ 1 (mod 4) ⟺ p = a²+b² in the same Gaussian framework? (parent OQ-02 #2)",
+      "Can the framework be transported to Eisenstein integers ℤ[ω] to characterize Loeschian numbers a²-ab+b²? (parent OQ-02 #3)"
+    ]
+  },
+  "crossReferences": [
+    {"relationship": "parent", "description": "Answers OQ-01 of pythagorean-triples-oq-02, which develops the Gaussian-integer norm and squaring map.", "targetId": "pythagorean-triples-oq-02"},
+    {"relationship": "related", "description": "The base Pythagorean-triples entry and its parametric formula.", "targetId": "pythagorean-triples"}
+  ],
+  "references": [
+    {"authors": ["leanprover-community"], "title": "Mathlib4: Mathlib.NumberTheory.PythagoreanTriples", "venue": "Mathlib4 documentation", "year": "2026", "note": "Provides PythagoreanTriple.coprime_classification and coprime_classification', the formal classification of primitive Pythagorean triples used as the bridge target."}
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Int"],
+    "namespace": "PythagoreanTriplesOQ02OQ01",
+    "lineCount": 101,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/PythagoreanTriplesOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-01** of `pythagorean-triples-oq-02` (the Gaussian-integers entry):

> Formalize the complete classification of primitive Pythagorean triples — every primitive triple has the form $(m^2-n^2,\,2mn,\,m^2+n^2)$ with $\gcd(m,n)=1$ and $m,n$ of opposite parity.

New entry `Proofs/PythagoreanTriplesOQ02OQ01.lean` (5 theorems, 1 def, **0 sorries, 0 axioms** — only `propext`/`Classical.choice`/`Quot.sound`, no `native_decide`).

## Honest framing — this is a Mathlib **bridge** (badge `mathlib`)

The deep direction (every primitive triple has the parametric form) is Mathlib's `PythagoreanTriple.coprime_classification`, which rests on unique factorization in ℤ[i]. This entry imports it and re-packages it in the Gaussian-parametrization language; it does **not** re-prove it.

## What is proved here

- `paramTriple` — the named Gaussian-square map $(m,n)\mapsto(m^2-n^2,2mn,m^2+n^2)$: the legs are $\mathrm{Re}/\mathrm{Im}$ of $(m+ni)^2$, the hypotenuse is $N(m+ni)$.
- `paramTriple_isPythagorean` — the parametrization always yields a triple (the identity $N(z^2)=N(z)^2$), proved by `ring`.
- `paramTriple_isPrimitive` — for coprime opposite-parity inputs the legs are coprime; derived from the public classification (Mathlib's `coprime_sq_sub_mul` is `private`).
- `primitive_classification` — the full biconditional, exported in Gaussian language.
- `primitive_classification_pos` — the sharper positive standard form (odd leg $x$, $z>0$).
- `hypotenuse_sum_of_squares` — corollary: the hypotenuse of a positive primitive triple is a sum of two squares, tying into the parent's Fermat-two-squares OQ.

## Verification

Compiled with toolchain `lean` v4.26.0 (Docker host down — containerd blob corruption), exit 0. `#print axioms` on all 5 theorems lists only `[propext, Classical.choice, Quot.sound]` (`paramTriple_isPythagorean`: just `[propext, Quot.sound]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)