### PR TITLE
Research: infinitude-primes-oq-01 — Furstenberg's topological proof of the infinitude of primes

### DIFF
--- a/proofs/Proofs/InfinitudePrimesOQ01.lean
+++ b/proofs/Proofs/InfinitudePrimesOQ01.lean
@@ -1,0 +1,204 @@
+import Mathlib
+
+/-
+# Furstenberg's topological proof of the infinitude of primes
+
+In 1955 Hillel Furstenberg gave a strikingly short topological proof that there
+are infinitely many primes.  Equip `ℤ` with the **evenly spaced integer
+topology**: a set `U` is open when, around every point `x ∈ U`, some full
+two-sided arithmetic progression `x + dℤ` (`d > 0`) is contained in `U`.
+Equivalently, the residue classes `R a d = {y | d ∣ (y − a)}` form a basis.
+
+Two observations drive the proof:
+
+* every nonempty open set is **infinite** (it contains an entire arithmetic
+  progression), and
+* each residue class `R a d` (`d > 0`) is **clopen**: it is open by definition,
+  and its complement is open because being *outside* a residue class is also a
+  congruence condition stable under shifting by multiples of `d`.
+
+Now suppose there were only finitely many primes.  The set
+`A = ⋃_{p prime} R 0 p` of integers admitting a prime factor would then be a
+**finite union of closed sets, hence closed**, so its complement
+`Aᶜ = {x | x.natAbs = 1} = {−1, 1}` would be **open**.  But `{−1, 1}` is a
+nonempty *finite* open set — impossible, since nonempty opens are infinite.
+Contradiction; therefore the primes are infinite.
+
+## What is formalized
+
+To avoid clashing with the standard `TopologicalSpace ℤ` instance, we work with
+the open-set predicate `IsOpenAP` directly rather than registering a topology.
+This is purely cosmetic: `IsOpenAP` satisfies the three topology axioms
+(`isOpenAP_univ`, `isOpenAP_sInter` for finite intersections, `isOpenAP_sUnion`),
+so it *is* a topology in the usual sense; we simply never need the typeclass.
+
+* `IsOpenAP`, `IsClosedAP` — the topology.
+* `isOpenAP_residue`, `isClosedAP_residue` — residue classes are clopen.
+* `IsOpenAP.infinite_of_nonempty` — nonempty opens are infinite.
+* `isClosedAP_biUnion` — finite unions of closed sets are closed.
+* `infinitude_of_primes` — the topological proof: `{p : ℕ | p.Prime}.Infinite`.
+
+The argument is genuinely self-contained: it does **not** invoke Mathlib's
+`Nat.infinite_setOf_prime` (Euclid's theorem).  The only number-theoretic input
+is `Nat.exists_prime_and_dvd` (every `n ≠ 1` has a prime factor), which is the
+existence-of-prime-factors fact common to *all* proofs of infinitude.
+
+No axioms, no `native_decide`, no sorries.
+-/
+
+namespace InfinitudePrimesOQ01
+
+open Set
+
+/-- The **evenly spaced integer topology** on `ℤ`, given by its open sets:
+`U` is open when every point of `U` is surrounded by a full two-sided arithmetic
+progression `x + dℤ` lying inside `U`. -/
+def IsOpenAP (U : Set ℤ) : Prop :=
+  ∀ x ∈ U, ∃ d : ℤ, 0 < d ∧ ∀ y : ℤ, d ∣ (y - x) → y ∈ U
+
+/-- A set is **closed** when its complement is open. -/
+def IsClosedAP (C : Set ℤ) : Prop := IsOpenAP Cᶜ
+
+/-- The whole space is open. -/
+theorem isOpenAP_univ : IsOpenAP (univ : Set ℤ) := by
+  intro x _; exact ⟨1, one_pos, fun y _ => mem_univ y⟩
+
+/-- The empty set is open (vacuously). -/
+theorem isOpenAP_empty : IsOpenAP (∅ : Set ℤ) := by
+  intro x hx; exact absurd hx (Set.notMem_empty x)
+
+/-- Arbitrary unions of open sets are open. -/
+theorem isOpenAP_sUnion {𝒮 : Set (Set ℤ)} (h : ∀ U ∈ 𝒮, IsOpenAP U) :
+    IsOpenAP (⋃₀ 𝒮) := by
+  rintro x ⟨U, hU𝒮, hxU⟩
+  obtain ⟨d, hd, hsub⟩ := h U hU𝒮 x hxU
+  exact ⟨d, hd, fun y hy => ⟨U, hU𝒮, hsub y hy⟩⟩
+
+/-- Binary intersections of open sets are open: combine the two progression
+spacings multiplicatively. -/
+theorem isOpenAP_inter {U V : Set ℤ} (hU : IsOpenAP U) (hV : IsOpenAP V) :
+    IsOpenAP (U ∩ V) := by
+  rintro x ⟨hxU, hxV⟩
+  obtain ⟨d₁, hd₁, h₁⟩ := hU x hxU
+  obtain ⟨d₂, hd₂, h₂⟩ := hV x hxV
+  refine ⟨d₁ * d₂, mul_pos hd₁ hd₂, fun y hy => ?_⟩
+  exact ⟨h₁ y (dvd_trans (Dvd.intro d₂ rfl) hy),
+         h₂ y (dvd_trans (Dvd.intro_left d₁ rfl) hy)⟩
+
+/-- A **nonempty** open set is infinite: it contains a whole arithmetic
+progression `x + dℤ`, which is an infinite subset. -/
+theorem IsOpenAP.infinite_of_nonempty {U : Set ℤ} (hU : IsOpenAP U)
+    (hne : U.Nonempty) : U.Infinite := by
+  obtain ⟨x, hx⟩ := hne
+  obtain ⟨d, hd, hsub⟩ := hU x hx
+  -- The injection `n ↦ x + n * d` lands inside `U`.
+  have hmaps : range (fun n : ℤ => x + n * d) ⊆ U := by
+    rintro y ⟨n, rfl⟩
+    exact hsub _ ⟨n, by ring⟩
+  have hinj : Function.Injective (fun n : ℤ => x + n * d) := by
+    intro a b hab
+    have : a * d = b * d := by simpa using hab
+    exact mul_right_cancel₀ (ne_of_gt hd) this
+  exact (infinite_range_of_injective hinj).mono hmaps
+
+/-- The **residue class** `R a d = {y | d ∣ (y − a)}` — an arithmetic
+progression with common difference `d`. -/
+def R (a d : ℤ) : Set ℤ := {y : ℤ | d ∣ (y - a)}
+
+/-- For `d > 0` the residue class `R a d` is open. -/
+theorem isOpenAP_residue (a : ℤ) {d : ℤ} (hd : 0 < d) : IsOpenAP (R a d) := by
+  intro x hx
+  refine ⟨d, hd, fun y hy => ?_⟩
+  -- `d ∣ (y − x)` and `d ∣ (x − a)` give `d ∣ (y − a)`.
+  have : d ∣ ((y - x) + (x - a)) := dvd_add hy hx
+  simpa using this
+
+/-- For `d > 0` the residue class `R a d` is closed: its complement is open,
+because *not* being congruent to `a` mod `d` is also stable under shifting by
+multiples of `d`. -/
+theorem isClosedAP_residue (a : ℤ) {d : ℤ} (hd : 0 < d) : IsClosedAP (R a d) := by
+  intro x hx
+  refine ⟨d, hd, fun y hy => ?_⟩
+  -- `x ∉ R a d` means `¬ d ∣ (x − a)`; if `y` were in `R a d` then
+  -- `d ∣ (y − a)` and `d ∣ (y − x)` would force `d ∣ (x − a)`.
+  simp only [R, mem_compl_iff, mem_setOf_eq] at hx ⊢
+  intro hya
+  exact hx (by simpa using dvd_sub hya hy)
+
+/-- Binary unions of closed sets are closed. -/
+theorem isClosedAP_union {C D : Set ℤ} (hC : IsClosedAP C) (hD : IsClosedAP D) :
+    IsClosedAP (C ∪ D) := by
+  have : (C ∪ D)ᶜ = Cᶜ ∩ Dᶜ := by simp [compl_union]
+  rw [IsClosedAP, this]
+  exact isOpenAP_inter hC hD
+
+/-- The empty set is closed. -/
+theorem isClosedAP_empty : IsClosedAP (∅ : Set ℤ) := by
+  rw [IsClosedAP, compl_empty]; exact isOpenAP_univ
+
+/-- A **finite union** of closed sets is closed. -/
+theorem isClosedAP_biUnion {ι : Type*} {s : Finset ι} {C : ι → Set ℤ}
+    (hC : ∀ i ∈ s, IsClosedAP (C i)) : IsClosedAP (⋃ i ∈ s, C i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simpa using isClosedAP_empty
+  | @insert j t hjt ih =>
+    have hstep : IsClosedAP (C j ∪ ⋃ i ∈ t, C i) :=
+      isClosedAP_union (hC j (Finset.mem_insert_self j t))
+        (ih (fun i hi => hC i (Finset.mem_insert_of_mem hi)))
+    simpa [Finset.set_biUnion_insert] using hstep
+
+/-- **Furstenberg's theorem.** There are infinitely many primes, proved by the
+topological argument: if the prime set were finite, the integers with a prime
+factor would form a closed set whose complement `{−1, 1}` would be a nonempty
+finite open set — impossible. -/
+theorem infinitude_of_primes : {p : ℕ | p.Prime}.Infinite := by
+  intro hfin
+  -- Work with the finite set of primes as a `Finset ℕ`.
+  obtain ⟨P, hP⟩ := hfin.exists_finset
+  -- `hP : x ∈ P ↔ x.Prime`
+  -- `A` = integers divisible by some prime = integers with `natAbs ≠ 1`.
+  set A : Set ℤ := ⋃ p ∈ P, R 0 (p : ℤ) with hA
+  -- Each `R 0 p` (p prime, so `p ≥ 2 > 0`) is closed, hence the finite union is.
+  have hAclosed : IsClosedAP A := by
+    refine isClosedAP_biUnion (fun p hp => ?_)
+    have hp2 : 2 ≤ p := (hP p |>.mp hp).two_le
+    exact isClosedAP_residue 0 (by exact_mod_cast (lt_of_lt_of_le two_pos hp2))
+  -- Identify the complement of `A` with `{x | x.natAbs = 1}`.
+  have hcompl : Aᶜ = {x : ℤ | x.natAbs = 1} := by
+    ext x
+    simp only [hA, mem_compl_iff, mem_iUnion, R, mem_setOf_eq, sub_zero,
+      not_exists]
+    constructor
+    · -- no prime divides `x`  ⟹  `x.natAbs = 1`
+      intro hx
+      by_contra hne
+      obtain ⟨q, hq, hqdvd⟩ := Nat.exists_prime_and_dvd hne
+      have hqP : q ∈ P := (hP q).mpr hq
+      have : (q : ℤ) ∣ x :=
+        Int.dvd_natAbs.mp (Int.natCast_dvd_natCast.mpr hqdvd)
+      exact (hx q hqP) this
+    · -- `x.natAbs = 1` (i.e. `x = ±1`)  ⟹  no prime divides `x`
+      intro hx p hpP hpdvd
+      have hp2 : 2 ≤ p := (hP p |>.mp hpP).two_le
+      have hx1 : x.natAbs = 1 := hx
+      have hdvd : p ∣ x.natAbs := by
+        have := Int.natAbs_dvd_natAbs.mpr hpdvd
+        simpa using this
+      rw [hx1] at hdvd
+      have := Nat.le_of_dvd one_pos hdvd
+      omega
+  -- So `Aᶜ` is open (complement of a closed set) and nonempty (`1 ∈ Aᶜ`)…
+  have hAcompl_open : IsOpenAP Aᶜ := hAclosed
+  have hone : (1 : ℤ) ∈ Aᶜ := by rw [hcompl]; simp
+  have hinf : (Aᶜ).Infinite := hAcompl_open.infinite_of_nonempty ⟨1, hone⟩
+  -- …yet `Aᶜ = {−1, 1}` is finite.  Contradiction.
+  have hfin2 : (Aᶜ).Finite := by
+    rw [hcompl]
+    have hsub : {x : ℤ | x.natAbs = 1} ⊆ ({1, -1} : Set ℤ) := by
+      intro x hx
+      rcases Int.natAbs_eq_iff.mp hx with h | h <;> simp [h]
+    exact Set.Finite.subset ((Set.finite_singleton (-1 : ℤ)).insert 1) hsub
+  exact hinf hfin2
+
+end InfinitudePrimesOQ01

--- a/src/data/proofs/infinitude-primes-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-oq-01/meta.json
@@ -1,0 +1,230 @@
+{
+  "id": "infinitude-primes-oq-01",
+  "title": "Furstenberg's Topological Proof of the Infinitude of Primes",
+  "slug": "infinitude-primes-oq-01",
+  "description": "A self-contained Lean 4 formalization of Furstenberg's 1955 topological proof that there are infinitely many primes, via the evenly spaced integer topology on ℤ.",
+  "meta": {
+    "author": "Hillel Furstenberg (1955), formalized by Lean Genius Researcher",
+    "date": "1955",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InfinitudePrimesOQ01.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "topology",
+      "general-topology",
+      "furstenberg",
+      "proofs-from-the-book",
+      "original"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.exists_prime_and_dvd",
+        "description": "Every natural number n ≠ 1 has a prime divisor",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Int.natAbs_dvd_natAbs",
+        "description": "Divisibility in ℤ transfers to natAbs",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "Set.Infinite",
+        "description": "Infinite sets and infinite_range_of_injective",
+        "module": "Mathlib.Data.Set.Finite"
+      }
+    ],
+    "originalContributions": [
+      "Builds the evenly spaced integer topology directly as the open-set predicate IsOpenAP, avoiding any clash with Mathlib's standard TopologicalSpace ℤ instance",
+      "Proves residue classes R a d (d > 0) are clopen from a single shift-stability fact",
+      "Proves nonempty open sets are infinite via an explicit injection n ↦ x + n·d",
+      "Completes Furstenberg's contradiction: finitely many primes would make {x | x.natAbs = 1} = {-1, 1} a nonempty finite open set",
+      "Does NOT use Mathlib's Nat.infinite_setOf_prime — the only number-theoretic input is existence of prime factors, making the topological argument genuinely independent"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 204,
+    "prerequisites": [
+      "Divisibility in ℤ (Int.dvd, natAbs)",
+      "Basic point-set topology (open/closed sets, finite unions/intersections)",
+      "Prime numbers (Nat.Prime) and existence of prime divisors",
+      "Proof by contradiction"
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "In 1955, while still a graduate student, Hillel Furstenberg published a one-paragraph note in the American Mathematical Monthly giving a topological proof of the infinitude of primes. It is one of the most celebrated 'proofs from THE BOOK': it recasts an ancient number-theoretic fact as a statement about a cleverly chosen topology on the integers. The proof does not produce primes (as Euclid's does) but instead shows that finitely many primes are topologically impossible.",
+    "problemStatement": "Theorem (Furstenberg, 1955): There are infinitely many prime numbers, proved topologically.\n\nEquip ℤ with the evenly spaced integer topology, whose basic open sets are the two-sided arithmetic progressions (residue classes) R(a,d) = {x | d ∣ (x − a)} with d > 0. Each residue class is both open and closed, and every nonempty open set is infinite. Then the set A of integers with a prime factor equals ⋃_{p prime} R(0,p), and its complement is {−1, 1}. If there were finitely many primes, A would be closed, forcing {−1, 1} to be a nonempty finite open set — a contradiction.",
+    "text": "A 204-line, 0-axiom formalization of Furstenberg's topological proof (a 'Proof from THE BOOK'). Rather than registering an instance of TopologicalSpace ℤ — which would collide with Mathlib's standard one — the entry works with the open-set predicate IsOpenAP directly and verifies the three topology axioms (isOpenAP_univ, isOpenAP_inter, isOpenAP_sUnion). Residue classes R(a,d) are shown clopen (isOpenAP_residue, isClosedAP_residue) from a single shift-stability observation, and nonempty open sets are shown infinite (IsOpenAP.infinite_of_nonempty) by injecting the progression n ↦ x + n·d. The finale infinitude_of_primes identifies ⋃_{p∈P} R(0,p) with {x | x.natAbs ≠ 1}, so its complement {−1, 1} would be open and finite if the prime set P were finite — impossible. The argument deliberately avoids Mathlib's Nat.infinite_setOf_prime, using only Nat.exists_prime_and_dvd, so it is an independent proof of infinitude rather than a repackaging of Euclid's.",
+    "proofStrategy": "1. Define IsOpenAP U: every point of U is surrounded by a full residue class contained in U. Verify it is a topology (univ, binary intersection via d = d₁·d₂, arbitrary union).\n2. Show every residue class R(a,d) with d > 0 is open, and closed (its complement is open by the same congruence-stability argument).\n3. Show every nonempty open set is infinite: it contains {x + n·d : n ∈ ℤ}, the injective image of ℤ.\n4. Show finite unions of closed sets are closed (induction over the Finset of primes).\n5. Assume the prime set P is finite. Then A = ⋃_{p∈P} R(0,p) is closed. Identify A = {x | x.natAbs ≠ 1} using Nat.exists_prime_and_dvd, so Aᶜ = {x | x.natAbs = 1} = {−1, 1}.\n6. As the complement of a closed set, Aᶜ is open; being nonempty it must be infinite. But {−1, 1} is finite. Contradiction, so the primes are infinite.",
+    "keyInsights": [
+      "Arithmetic progressions form a basis for a genuine topology on ℤ — the only nontrivial axiom (finite intersection) is handled by multiplying the two common differences",
+      "A residue class is clopen because both 'congruent to a mod d' and 'not congruent to a mod d' are preserved under shifting by multiples of d",
+      "Nonempty open sets are infinite, so no nonempty finite set can be open — this is the entire obstruction",
+      "The integers with NO prime factor are exactly ±1, i.e. {x | x.natAbs = 1}; everything else lies in some R(0,p)",
+      "The proof is independent of Euclid's: it never enumerates or constructs primes, and avoids Mathlib's existing infinitude lemma, relying only on the existence of prime factors"
+    ],
+    "prerequisites": [
+      "Divisibility in ℤ (Int.dvd, Int.natAbs)",
+      "Open and closed sets, finite unions and intersections",
+      "Prime numbers and existence of prime divisors (Nat.exists_prime_and_dvd)",
+      "Proof by contradiction"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Documentation",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "Explains the evenly spaced integer topology, the clopen residue classes, the nonempty-open-is-infinite principle, and the contradiction from finitely many primes. Notes that the proof avoids Nat.infinite_setOf_prime.",
+      "mathContext": "Sets up Furstenberg's strategy: residue classes R(a,d) as a clopen basis, and the obstruction that nonempty opens are infinite while {−1,1} is finite."
+    },
+    {
+      "id": "topology-axioms",
+      "title": "The Topology",
+      "startLine": 53,
+      "endLine": 86,
+      "summary": "Defines IsOpenAP and IsClosedAP, and proves the topology axioms: univ open, empty open, arbitrary unions open, and binary intersections open (via d = d₁·d₂).",
+      "mathContext": "IsOpenAP U := ∀ x ∈ U, ∃ d > 0, x + dℤ ⊆ U. Finite intersection uses that d₁·d₂ ∣ (y−x) implies both d₁ ∣ (y−x) and d₂ ∣ (y−x)."
+    },
+    {
+      "id": "nonempty-infinite",
+      "title": "Nonempty Open Sets Are Infinite",
+      "startLine": 88,
+      "endLine": 102,
+      "summary": "IsOpenAP.infinite_of_nonempty: a nonempty open set contains the injective image of n ↦ x + n·d, hence is infinite.",
+      "mathContext": "A nonempty open U contains a full progression {x + n·d : n ∈ ℤ}; n ↦ x + n·d is injective because d ≠ 0, so U is infinite."
+    },
+    {
+      "id": "clopen-residue",
+      "title": "Residue Classes Are Clopen",
+      "startLine": 104,
+      "endLine": 127,
+      "summary": "Defines R(a,d) and proves it open (isOpenAP_residue) and closed (isClosedAP_residue) for d > 0, both from stability of congruence under shifts by multiples of d.",
+      "mathContext": "R(a,d) = {y | d ∣ (y−a)}. Open: d ∣ (y−x) and d ∣ (x−a) give d ∣ (y−a). Closed: the same shift sends non-members to non-members."
+    },
+    {
+      "id": "finite-union-closed",
+      "title": "Finite Unions of Closed Sets",
+      "startLine": 128,
+      "endLine": 149,
+      "summary": "isClosedAP_union (binary, via De Morgan and intersection of opens), isClosedAP_empty, and isClosedAP_biUnion (finite union closed, by induction on the Finset).",
+      "mathContext": "(C ∪ D)ᶜ = Cᶜ ∩ Dᶜ; induction over a Finset reduces the finite union to repeated binary unions."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Furstenberg's Theorem",
+      "startLine": 151,
+      "endLine": 204,
+      "summary": "infinitude_of_primes: {p | p.Prime}.Infinite. Assumes finiteness, forms A = ⋃_{p∈P} R(0,p) (closed), identifies Aᶜ with {x | x.natAbs = 1} = {−1,1}, and derives a contradiction since Aᶜ would be a nonempty finite open set.",
+      "mathContext": "A = {x | x.natAbs ≠ 1} is closed; Aᶜ = {−1,1} is open ⇒ infinite, but is finite. Uses Nat.exists_prime_and_dvd and Int.natAbs_dvd_natAbs; never Nat.infinite_setOf_prime."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry formalizes Furstenberg's topological proof of the infinitude of primes — a celebrated 'Proof from THE BOOK' — fully and with zero axioms. The topology is built directly as an open-set predicate to coexist with Mathlib's standard topology on ℤ, and every ingredient (clopen residue classes, infinitude of nonempty opens, closedness of finite unions) is proved from scratch. Crucially, the proof does not invoke Mathlib's existing infinitude lemma; its only number-theoretic input is the existence of prime factors, so it stands as an independent topological argument.",
+    "implications": "Furstenberg's proof answers open question #1 of the parent Infinitude of Primes entry. It demonstrates how a number-theoretic theorem can be recast topologically: the key fact is purely about the lattice of arithmetic progressions. The same evenly spaced integer topology underlies further results (e.g. it is a Hausdorff, metrizable, totally disconnected topology), and the clopen-basis technique recurs in profinite and adelic settings.",
+    "openQuestions": [
+      "Can the evenly spaced integer topology be packaged as a bona fide TopologicalSpace instance on a type synonym of ℤ, and shown to be Hausdorff and metrizable, recovering the standard general-topology characterization?",
+      "Furstenberg's argument shows ⋃_p R(0,p) is not closed; can one quantify the failure — e.g. formalize that the closure of the set of prime multiples is all of ℤ — to obtain a topological density statement about primes?",
+      "Does the same clopen-progression framework give a topological proof of the infinitude of primes in a fixed residue class (the easy cases of Dirichlet, such as 4k+3), by intersecting with a suitable open set?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Furstenberg, Harry",
+      "title": "On the infinitude of primes",
+      "year": "1955",
+      "venue": "American Mathematical Monthly, 62(5), 353",
+      "note": "The original one-paragraph topological proof"
+    },
+    {
+      "authors": "Aigner, Martin; Ziegler, Günter M.",
+      "title": "Proofs from THE BOOK",
+      "year": "1998",
+      "venue": "Springer",
+      "note": "Chapter 1 presents Furstenberg's topological proof among six proofs of the infinitude of primes"
+    },
+    {
+      "authors": "Euclid",
+      "title": "Elements, Book IX, Proposition 20",
+      "year": "c. 300 BCE",
+      "venue": "Classical geometry",
+      "note": "The original (constructive) proof that the primes are infinite"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "extends",
+      "description": "Answers open question #1 of the parent entry: formalize Furstenberg's 1955 topological proof, in contrast to Euclid's n!+1 construction"
+    },
+    {
+      "targetId": "fundamental-arithmetic",
+      "relationship": "foundational",
+      "description": "The identification of {x | x.natAbs ≠ 1} with the integers having a prime factor rests on existence of prime factorization"
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "Dirichlet's theorem on primes in arithmetic progressions concerns the same residue classes R(a,d) that serve as the basic open sets here"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "InfinitudePrimesOQ01",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "substantiveTheoremCount": 5,
+    "trivialSpecializations": 3,
+    "mainTheorems": [
+      {
+        "name": "infinitude_of_primes",
+        "type": "original",
+        "description": "Furstenberg's topological proof that there are infinitely many primes",
+        "leanType": "{p : ℕ | p.Prime}.Infinite"
+      },
+      {
+        "name": "isClosedAP_residue",
+        "type": "original",
+        "description": "Each residue class R(a,d) with d > 0 is closed in the evenly spaced integer topology",
+        "leanType": "∀ (a : ℤ) {d : ℤ}, 0 < d → IsClosedAP (R a d)"
+      },
+      {
+        "name": "IsOpenAP.infinite_of_nonempty",
+        "type": "original",
+        "description": "Every nonempty open set in the evenly spaced integer topology is infinite",
+        "leanType": "IsOpenAP U → U.Nonempty → U.Infinite"
+      }
+    ],
+    "path": "Proofs/InfinitudePrimesOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "infinitude_of_primes",
+      "type": "core",
+      "description": "Furstenberg's topological proof that there are infinitely many primes",
+      "leanType": "(setOf Nat.Prime).Infinite"
+    },
+    {
+      "name": "isClosedAP_residue",
+      "type": "core",
+      "description": "Each residue class R(a,d) with d > 0 is closed in the evenly spaced integer topology",
+      "leanType": "forall (a : Int) {d : Int}, 0 < d -> IsClosedAP (R a d)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **Furstenberg's 1955 topological proof** that there are infinitely many primes — a celebrated *Proof from THE BOOK*. This answers **open question #1** of the parent `infinitude-primes` entry ("Can we formalize Furstenberg's topological proof?").

- **Status:** `verified` / `original`
- **Axioms:** 0 (`#print axioms` → `[propext, Classical.choice, Quot.sound]`)
- **Sorries:** 0
- **Lines:** 204, 11 theorems, 3 definitions

## What it proves

Equip ℤ with the **evenly spaced integer topology**, whose basic open sets are the two-sided arithmetic progressions (residue classes) `R(a,d) = {x | d ∣ (x − a)}`, `d > 0`. Then:

- residue classes are **clopen** (`isOpenAP_residue`, `isClosedAP_residue`);
- every **nonempty open set is infinite** (`IsOpenAP.infinite_of_nonempty`);
- if there were finitely many primes, `A = ⋃_{p prime} R(0,p)` would be **closed**, so its complement `{x | x.natAbs = 1} = {−1, 1}` would be a **nonempty finite open set** — impossible.

Hence `infinitude_of_primes : {p : ℕ | p.Prime}.Infinite`.

## Design notes

- To avoid clashing with Mathlib's standard `TopologicalSpace ℤ` instance, the topology is built directly as the open-set predicate `IsOpenAP`; the three topology axioms are proved (`isOpenAP_univ`, `isOpenAP_inter`, `isOpenAP_sUnion`).
- The proof is **independent of Euclid's**: it does **not** use Mathlib's `Nat.infinite_setOf_prime`. The only number-theoretic input is `Nat.exists_prime_and_dvd` (existence of prime factors).

## Verification

Built offline against cached Mathlib v4.26.0 (Docker image build currently fails with a containerd I/O error on this host; verified via the memory-monitored `safe-build.sh`). Single-file build: `✔ Built Proofs.InfinitudePrimesOQ01`, 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)