### PR TITLE
Enrich Shannon Entropy Maximum-Entropy Bound (cauchy-schwarz-oq-01-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-entropy-def",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02",
+    "range": { "startLine": 32, "endLine": 35 },
+    "type": "definition",
+    "title": "Shannon Entropy via negMulLog",
+    "content": "`shannonEntropy p` is defined as ∑ᵢ Real.negMulLog (p i), where Mathlib's Real.negMulLog t = −t·log t. This is the entropy in nats (natural logarithm). Building on Mathlib's negMulLog rather than rolling a bespoke −∑ pᵢ log pᵢ is the key design choice: it immediately grants access to the library's concavity lemma concaveOn_negMulLog and the nonnegativity lemma negMulLog_nonneg, which are exactly what the two main theorems consume. The definition is `noncomputable` because Real.log is.",
+    "mathContext": "$$H(p) = \\sum_i \\operatorname{negMulLog}(p_i) = -\\sum_i p_i \\log p_i$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Shannon entropy", "Real.negMulLog", "information theory", "finite probability vector"],
+    "prerequisites": ["finite sums over a Fintype", "the function t ↦ −t log t"]
+  },
+  {
+    "id": "ann-nonneg",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02",
+    "range": { "startLine": 37, "endLine": 41 },
+    "type": "technique",
+    "title": "Nonnegativity, Termwise",
+    "content": "`shannonEntropy_nonneg` shows H(p) ≥ 0 whenever every entry lies in [0,1]. The proof is a one-liner: Finset.sum_nonneg reduces the goal to each summand, and Real.negMulLog_nonneg gives −t·log t ≥ 0 for t ∈ [0,1] (because log t ≤ 0 there). Note this is weaker than requiring a probability vector — it only needs entries bounded by 1, so it applies to sub-distributions too.",
+    "mathContext": "$$0 \\le p_i \\le 1 \\implies \\operatorname{negMulLog}(p_i) = -p_i\\log p_i \\ge 0 \\implies H(p) \\ge 0$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_nonneg", "Real.negMulLog_nonneg", "monotonicity of log on (0,1]"],
+    "prerequisites": ["sum of nonnegative terms is nonnegative", "sign of log on [0,1]"]
+  },
+  {
+    "id": "ann-max-entropy",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02",
+    "range": { "startLine": 43, "endLine": 79 },
+    "type": "insight",
+    "title": "Maximum-Entropy Bound by Jensen on a Concave Function",
+    "content": "`shannonEntropy_le_log_card` is the headline: H(p) ≤ log n for a probability vector on n = card ι outcomes. The argument is Jensen's inequality for the CONCAVE negMulLog (Real.concaveOn_negMulLog.le_map_sum) with uniform weights wᵢ = 1/n. Jensen gives ∑ᵢ (1/n)·negMulLog(pᵢ) ≤ negMulLog(∑ᵢ (1/n)·pᵢ). The three side goals are: weights are nonnegative (positivity), weights sum to 1 (n·(1/n)=1 via Finset.sum_const + field_simp), and each pᵢ lies in the domain [0,∞). Then the right side simplifies: the weighted mean ∑ (1/n)·pᵢ = 1/n (since ∑pᵢ=1), and negMulLog(1/n) = (1/n)·log n. The left side is (1/n)·H(p). Cancelling the positive factor 1/n with le_of_mul_le_mul_left yields H(p) ≤ log n.",
+    "mathContext": "$$\\tfrac1n H(p) = \\sum_i \\tfrac1n\\operatorname{negMulLog}(p_i) \\le \\operatorname{negMulLog}\\!\\Big(\\sum_i \\tfrac1n p_i\\Big) = \\operatorname{negMulLog}(\\tfrac1n) = \\tfrac1n\\log n$$",
+    "significance": "key",
+    "relatedConcepts": ["Jensen's inequality", "concavity (ConcaveOn.le_map_sum)", "maximum-entropy principle", "uniform distribution"],
+    "prerequisites": ["concavity of negMulLog", "Jensen for finite convex/concave combinations", "le_of_mul_le_mul_left"]
+  },
+  {
+    "id": "ann-uniform-sharp",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02",
+    "range": { "startLine": 81, "endLine": 89 },
+    "type": "insight",
+    "title": "Sharpness: the Uniform Distribution Attains log n",
+    "content": "`shannonEntropy_uniform` confirms the bound is tight: the uniform distribution pᵢ = 1/n has entropy exactly log n. The computation is direct — every term is negMulLog(1/n) = (1/n)·log n, there are n of them, and Finset.sum_const collapses the constant sum to n·(1/n)·log n = log n (closed by field_simp). Together with the bound, this pins the maximum entropy: H is maximized precisely at the uniform distribution, the maximum-entropy principle in finite dimensions. This sharpness is what makes log n the genuine ceiling, not merely an upper bound.",
+    "mathContext": "$$H(\\text{uniform}) = \\sum_{i=1}^{n} \\operatorname{negMulLog}(\\tfrac1n) = n\\cdot\\tfrac1n\\log n = \\log n$$",
+    "significance": "key",
+    "relatedConcepts": ["maximum-entropy principle", "uniform distribution", "tightness of a bound", "Finset.sum_const"],
+    "prerequisites": ["evaluating negMulLog at 1/n", "constant finite sums", "field_simp"]
+  },
+  {
+    "id": "ann-blocker-context",
+    "proofId": "cauchy-schwarz-oq-01-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 22 },
+    "type": "context",
+    "title": "Scope: the Provable Half of Entropic Uncertainty",
+    "content": "The module docstring scopes the entry honestly. The parent open question asks for the full Maassen–Uffink entropic uncertainty principle H(p) + H(q) ≥ −2 ln c. That sharp constant flows from the Hausdorff–Young inequality (a Riesz–Thorin interpolation / (2→∞) operator-norm argument), which Mathlib v4.26.0 does not provide — so the full theorem is genuinely BLOCKED, not merely unattempted. What IS provable now, and is built here, is the entropy ceiling H(p) ≤ log n that bounds either marginal; the hard, interpolation-gated content is the LOWER bound on the sum. Deutsch's interpolation-free precursor H(p)+H(q) ≥ −2 ln((1+c)/2) is flagged as the natural next target once this infrastructure exists. The `mathlib` badge reflects that the substance rides on Mathlib's negMulLog concavity and Jensen.",
+    "mathContext": "$$\\text{Full: } H(p)+H(q) \\ge -2\\ln c \\;\\;(\\text{blocked});\\qquad \\text{Here: } H(p) \\le \\log n \\;\\;(\\text{proved})$$",
+    "significance": "context",
+    "relatedConcepts": ["Maassen–Uffink inequality", "Hausdorff–Young inequality", "Riesz–Thorin interpolation", "Deutsch's bound", "entropic uncertainty principle"],
+    "prerequisites": ["the entropic uncertainty principle", "why interpolation gives the sharp constant"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03-oq-02/meta.json
@@ -76,7 +76,10 @@
     "summary": "The finite-dimensional Shannon-entropy framework and the maximum-entropy bound H(p) ≤ log n are formalized and fully machine-checked (0 axioms, 0 sorries), built directly on Mathlib's negMulLog concavity and Jensen's inequality. This is the provable entropy half of an entropic uncertainty relation.",
     "implications": "Provides reusable infrastructure for any future formalization of the entropic uncertainty principle. The full Maassen–Uffink bound is documented as blocked on Mathlib's absent interpolation theory (Hausdorff–Young / Riesz–Thorin); Deutsch's interpolation-free bound is the recommended next step once this infrastructure is extended.",
     "openQuestions": [
-      "Can Deutsch's entropic uncertainty bound H(p) + H(q) ≥ -2 ln((1+c)/2) — which avoids interpolation — be formalized on top of this entropy infrastructure?"
+      "Can Deutsch's entropic uncertainty bound H(p) + H(q) ≥ -2 ln((1+c)/2) — which avoids interpolation — be formalized on top of this entropy infrastructure?",
+      "Formalize the equality case of the maximum-entropy bound: prove that H(p) = log n forces p to be the uniform distribution (strict concavity of negMulLog), upgrading the ≤ to a characterization.",
+      "Once Mathlib gains Riesz–Thorin / Hausdorff–Young interpolation, complete the sharp Maassen–Uffink constant -2 ln c, closing the parent's full open question.",
+      "Relate this entropic ceiling to the parent's variance-based Robertson/Heisenberg bound: derive the qubit (n=2) entropic uncertainty relation explicitly and compare its strength to the variance product bound."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-01-oq-03-oq-02` (Shannon Entropy: Maximum-Entropy Bound, toward Entropic Uncertainty).

This entry had a modest `meta.json` (6.7 KB) and **no `annotations.json`**.

## Added
- **annotations.json** — 5 substantive inline annotations covering all four declarations plus the scope/blocker context:
  1. `shannonEntropy` via Mathlib's negMulLog (supporting)
  2. Termwise nonnegativity `shannonEntropy_nonneg` (supporting)
  3. The maximum-entropy bound `shannonEntropy_le_log_card` — Jensen on concave negMulLog with uniform weights (key)
  4. Sharpness: `shannonEntropy_uniform` attains log n (key)
  5. Context: the full Maassen–Uffink bound is blocked on Mathlib's missing Hausdorff–Young/Riesz–Thorin interpolation (context)
- **meta.json** — expanded `conclusion.openQuestions` from 1 to 4 (equality-case characterization, Riesz–Thorin completion, qubit comparison to the parent's variance bound).

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Axiom integrity verified: 0 axioms, 0 sorries, `mathlib` badge accurate (substance rides on negMulLog concavity + Jensen). `pnpm build` passes.