### PR TITLE
Enrich Probabilistic Method First-Moment Engine (prob-method-applications-wip-01)

### DIFF
--- a/src/data/proofs/prob-method-applications-wip-01/annotations.json
+++ b/src/data/proofs/prob-method-applications-wip-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-exists-avoiding",
+    "proofId": "prob-method-applications-wip-01",
+    "range": { "startLine": 32, "endLine": 50 },
+    "type": "insight",
+    "title": "First-Moment Existence as a Counting Union Bound",
+    "content": "`exists_avoiding_all` is the combinatorial heart of the probabilistic method, stated with no measure theory at all. If finitely many bad sets A i ⊆ Ω satisfy ∑ᵢ |A i| < |Ω|, then their union has card < |Ω| (Finset.card_biUnion_le bounds the union by the sum), so its complement is nonempty (card_compl + omega), and any point of the complement avoids every A i. Over a finite sample space the first-moment principle 'a rare-on-average bad event is avoidable' is therefore a pure pigeonhole statement about cardinalities.",
+    "mathContext": "$$\\sum_{i\\in s} |A_i| < |\\Omega| \\;\\implies\\; \\Big|\\bigcup_{i\\in s} A_i\\Big| < |\\Omega| \\;\\implies\\; \\exists\\,\\omega,\\ \\forall i,\\ \\omega \\notin A_i$$",
+    "significance": "critical",
+    "relatedConcepts": ["first moment method", "union bound", "probabilistic method", "pigeonhole principle", "Finset.card_biUnion_le"],
+    "prerequisites": ["cardinality of a union", "complement cardinality", "finite sample spaces"]
+  },
+  {
+    "id": "ann-uniform-bound",
+    "proofId": "prob-method-applications-wip-01",
+    "range": { "startLine": 52, "endLine": 63 },
+    "type": "technique",
+    "title": "The Uniform Union Bound Used in Applications",
+    "content": "`exists_good_of_card_bound` is the form most applications actually invoke: if every bad set has size ≤ B and |s|·B < |Ω|, a good point exists. It is a one-line consequence of exists_avoiding_all — the sum ∑ᵢ |A i| is bounded termwise by ∑ᵢ B = |s|·B (Finset.sum_le_sum + sum_const), which is < |Ω| by hypothesis. Packaging the uniform case separately means callers supply a single per-event size bound plus one arithmetic inequality.",
+    "mathContext": "$$(\\forall i,\\ |A_i| \\le B)\\ \\wedge\\ |s|\\cdot B < |\\Omega| \\;\\implies\\; \\exists\\,\\omega,\\ \\forall i,\\ \\omega \\notin A_i$$",
+    "significance": "key",
+    "relatedConcepts": ["union bound", "Finset.sum_le_sum", "first moment method"],
+    "prerequisites": ["exists_avoiding_all", "summing a constant over a Finset"]
+  },
+  {
+    "id": "ann-mono-supersets",
+    "proofId": "prob-method-applications-wip-01",
+    "range": { "startLine": 75, "endLine": 99 },
+    "type": "technique",
+    "title": "Counting All-True Colourings by an Injection",
+    "content": "A 2-colouring of edge set E is modelled as S : Finset E (the true edges); a block K is monochromatic under S iff K ⊆ S or Disjoint K S (the `Mono` predicate, marked @[reducible] so DecidablePred is found automatically). `card_supersets_le` bounds the colourings containing K (all-true on K) by 2^(|E|−|K|). The trick is an injection S ↦ S \\ K from {S : K ⊆ S} into the powerset of univ \\ K: injectivity holds because (S\\K) ∪ K = S recovers S (sdiff_union_of_subset). No exact bijection is needed — an injection into a set of known size suffices.",
+    "mathContext": "$$|\\{S : K \\subseteq S\\}| \\le |\\mathcal{P}(E \\setminus K)| = 2^{|E| - |K|},\\quad \\text{via } S \\mapsto S \\setminus K$$",
+    "significance": "key",
+    "relatedConcepts": ["powerset cardinality", "injection counting", "Finset.card_le_card_of_injOn", "monochromatic colouring"],
+    "prerequisites": ["Finset.card_powerset", "sdiff_union_of_subset", "injective cardinality bound"]
+  },
+  {
+    "id": "ann-mono-disjoint",
+    "proofId": "prob-method-applications-wip-01",
+    "range": { "startLine": 101, "endLine": 118 },
+    "type": "technique",
+    "title": "Counting All-False Colourings by Inclusion",
+    "content": "`card_disjoint_le` bounds the colourings disjoint from K (all-false on K) by 2^(|E|−|K|). Here the argument is even simpler: any S disjoint from K is a subset of Kᶜ, so the filtered set is contained in the powerset of Kᶜ (card_le_card on the subset), whose size is 2^(|E|−|K|) by card_powerset + card_compl. The two symmetric bounds — all-true and all-false — are what feed the union for the full monochromatic count.",
+    "mathContext": "$$|\\{S : \\mathrm{Disjoint}\\,K\\,S\\}| \\le |\\mathcal{P}(K^c)| = 2^{|E| - |K|}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["powerset cardinality", "Finset.card_le_card", "complement", "monochromatic colouring"],
+    "prerequisites": ["Finset.card_powerset", "card_compl", "disjointness as subset of complement"]
+  },
+  {
+    "id": "ann-mono-total",
+    "proofId": "prob-method-applications-wip-01",
+    "range": { "startLine": 120, "endLine": 140 },
+    "type": "insight",
+    "title": "Total Monochromatic Count: 2^(|E|−|K|+1)",
+    "content": "`card_mono_le` combines the two halves: the monochromatic colourings are the union of the all-true and all-false families (filter_or), so by card_union_le the count is at most 2^(|E|−|K|) + 2^(|E|−|K|) = 2^(|E|−|K|+1) (pow_succ). This single per-block bound is the quantity the union bound consumes in the Ramsey application — exactly 2^(|E|−m+1) for a block of size m.",
+    "mathContext": "$$|\\{S : \\mathrm{Mono}\\,K\\,S\\}| \\le 2^{|E|-|K|} + 2^{|E|-|K|} = 2^{|E|-|K|+1}$$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_union_le", "filter_or", "pow_succ", "monochromatic colouring"],
+    "prerequisites": ["card_supersets_le", "card_disjoint_le", "cardinality of a union of filters"]
+  },
+  {
+    "id": "ann-ramsey",
+    "proofId": "prob-method-applications-wip-01",
+    "range": { "startLine": 142, "endLine": 177 },
+    "type": "insight",
+    "title": "Honest Ramsey Avoidance — Every Hypothesis Does Work",
+    "content": "`ramsey_avoidance` is the genuine payoff. Over the sample space Finset E (with |Finset E| = 2^|E| via Fintype.card_finset), each block K ∈ cliques of size m contributes ≤ 2^(|E|−m+1) monochromatic colourings (card_mono_le specialized by hm). If |cliques|·2^(|E|−m+1) < 2^|E|, the uniform union bound exists_good_of_card_bound yields a colouring S monochromatic on no block. Instantiating E as the edge set of Kₙ (|E| = C(n,2)) and cliques as the C(n,m) copies of Kₘ recovers the classical Erdős (1947) bound R(m,m) > n. Crucially — unlike the vacuous placeholder ramsey_lower_bound it replaces — every hypothesis (the block size m via hm, the counting inequality h) is genuinely consumed.",
+    "mathContext": "$$|\\mathrm{cliques}|\\cdot 2^{|E|-m+1} < 2^{|E|} \\implies \\exists S,\\ \\forall K,\\ \\neg\\,\\mathrm{Mono}\\,K\\,S;\\qquad \\text{on } K_n:\\ R(m,m) > n$$",
+    "significance": "critical",
+    "relatedConcepts": ["Ramsey numbers", "Erdős 1947 bound", "first moment method", "Fintype.card_finset", "non-vacuous formalization"],
+    "prerequisites": ["card_mono_le", "exists_good_of_card_bound", "Ramsey lower bounds"]
+  }
+]

--- a/src/data/proofs/prob-method-applications-wip-01/meta.json
+++ b/src/data/proofs/prob-method-applications-wip-01/meta.json
@@ -3,6 +3,32 @@
   "title": "Probabilistic Method: First-Moment Existence Engine",
   "slug": "prob-method-applications-wip-01",
   "description": "The genuine counting form of the probabilistic method's first-moment principle, with an honest, non-vacuous Ramsey-style avoidance theorem proved from it. Completes the work-in-progress applications module, whose headline theorems were vacuous placeholders.",
+  "sections": [
+    {
+      "id": "first-moment",
+      "title": "The First-Moment / Union-Bound Existence Principle",
+      "startLine": 28,
+      "endLine": 63,
+      "summary": "exists_avoiding_all: if finitely many bad sets sum to fewer than |Ω| points, some point avoids all of them (union bound via card_biUnion_le + nonempty complement). exists_good_of_card_bound: the uniform corollary using |s|·B < |Ω|.",
+      "mathContext": "$\\sum_i |A_i| < |\\Omega| \\implies \\exists\\,\\omega,\\ \\forall i,\\ \\omega \\notin A_i$"
+    },
+    {
+      "id": "counting-colourings",
+      "title": "Counting Two-Colourings of a Finite Edge Set",
+      "startLine": 65,
+      "endLine": 140,
+      "summary": "Models a 2-colouring as S : Finset E and a block K as monochromatic when K ⊆ S or Disjoint K S (the Mono predicate). card_supersets_le and card_disjoint_le each bound their family by 2^(|E|−|K|) (via an injection and an inclusion respectively); card_mono_le unions them to 2^(|E|−|K|+1).",
+      "mathContext": "$|\\{S : \\mathrm{Mono}\\,K\\,S\\}| \\le 2^{|E|-|K|+1}$"
+    },
+    {
+      "id": "ramsey-avoidance",
+      "title": "Ramsey-Style Avoidance (Honest Probabilistic Existence)",
+      "startLine": 142,
+      "endLine": 179,
+      "summary": "ramsey_avoidance: if |cliques|·2^(|E|−m+1) < 2^|E| then a 2-colouring with no monochromatic block exists. Combines card_mono_le with exists_good_of_card_bound over the sample space Finset E; instantiating to K_n recovers Erdős's R(m,m) > n. Every hypothesis does real work.",
+      "mathContext": "$|\\mathrm{cliques}|\\cdot 2^{|E|-m+1} < 2^{|E|} \\implies \\exists S,\\ \\forall K,\\ \\neg\\,\\mathrm{Mono}\\,K\\,S$"
+    }
+  ],
   "meta": {
     "author": "Paul Erdős (1947), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",


### PR DESCRIPTION
Enrichment pass for `prob-method-applications-wip-01` (Probabilistic Method: First-Moment Existence Engine). The meta.json was already well-curated (overview, keyInsights, structured conclusion, references) but had two structural gaps:

## Added
- **annotations.json** (was missing entirely) — 6 inline annotations covering every declaration: `exists_avoiding_all` (the counting union bound), `exists_good_of_card_bound` (uniform corollary), `card_supersets_le` (injection count), `card_disjoint_le` (inclusion count), `card_mono_le` (their union → 2^(|E|−|K|+1)), and `ramsey_avoidance` (honest R(m,m) > n).
- **meta.sections** (was missing) — 3 sections covering the first-moment principle, the colouring-counting lemmas, and the Ramsey avoidance theorem.

Each annotation carries `mathContext` (LaTeX), a valid `significance` enum, `relatedConcepts`, and `prerequisites`. Axiom integrity verified: `verified`/`verified`, 0 axioms, 0 sorries. `pnpm build` passes.