### PR TITLE
Fix: orphaned doc comments breaking Erdos1003Problem.lean parse

### DIFF
--- a/proofs/Proofs/Erdos1003Problem.lean
+++ b/proofs/Proofs/Erdos1003Problem.lean
@@ -147,7 +147,7 @@ Count of n ≤ N where φ(n) = φ(n+1).
 def countConsecutiveEqual (N : ℕ) : ℕ :=
   (Finset.filter (fun n => φ n = φ (n + 1)) (Finset.range (N + 1))).card
 
-/--
+/-
 The EPS upper bound: eventually, the count of n ≤ x with φ(n) = φ(n+1)
 is at most x/exp((log x)^(1/3)).
 
@@ -164,7 +164,7 @@ Note: 5186 and 5187 are consecutive members, meaning
 φ(5186) = φ(5187) = φ(5188).
 -/
 
-/--
+/-
 The sequence A001274 contains at least the first few known values.
 -/
 /-
@@ -236,10 +236,10 @@ A remarkable fact: there exist three consecutive integers with equal totient.
 - 5188 = 2² × 1297
 -/
 
-/--
+/-
 There exist three consecutive integers with equal totient value.
 -/
-/--
+/-
 5186 ∈ ConsecutiveKEqualTotients 2 means
 φ(5186) = φ(5187) = φ(5188).
 -/
@@ -254,7 +254,7 @@ However, the full question of whether the set is infinite remains
 formally open.
 -/
 
-/--
+/-
 Ford-Luca-Pomerance result: there are many solutions.
 For any ε > 0, eventually the count exceeds x^(1-ε).
 -/


### PR DESCRIPTION
## Fix

Convert five orphaned `/-- ... -/` documentation comments in `proofs/Proofs/Erdos1003Problem.lean` to plain `/- ... -/` block comments.

## Evidence

**Before**: The file contained free-floating doc comments not attached to any declaration. In Lean 4, a `/-- -/` doc comment must immediately precede a declaration; otherwise it is a parse error. The broken cases:
- A doc comment before `end Erdos1003` (Ford-Luca-Pomerance note).
- Two consecutive doc comments before `end Erdos1003` (the 5186/5187/5188 triple notes).
- Stacked doc comments (EPS upper bound + A001274 notes) separated from the next `def` only by block comments.

**After**: All five orphans are now `/-` block comments. Every remaining `/--` doc comment is correctly attached to its `def`/`example`. No semantic Lean change — only comment delimiters.

## Validation

Local Docker build (`./proofs/scripts/docker-build.sh Proofs.Erdos1003Problem`) could **not** be run: the Docker host's containerd content store is returning `input/output error` (corrupted blobs / disk pressure), so the Lean image fails to build locally. The change is a comment-delimiter-only repair with no effect on proof terms; CI/deployer build will confirm.

---
Automated fix by lean-mechanic agent.