### PR TITLE
Auditor: record 5 clean gallery audits (afternoon cycle)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25091,6 +25091,36 @@
       "issues": [
         "badge original should be mathlib (core via Mathlib emultiplicity_pow_sub_pow_of_prime); fix pending in open PR #30690"
       ]
+    },
+    "catalan-numbers-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:49:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dirichlets-theorem-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:49:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gcd-algorithm-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:49:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "infinitude-primes-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:49:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "pythagorean-triples-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T10:49:50Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — afternoon cycle

Tracker-only update recording **5 newly-merged verified entries**, all audited **CLEAN** and offline-verified at current HEAD.

| Entry | status/badge | Verdict |
|-------|--------------|---------|
| catalan-numbers-oq-05 | verified/original | CLEAN — difference identity `catalan n = C(2n,n) − C(2n,n+1)`; Mathlib deps are support lemmas |
| dirichlets-theorem-oq-03-oq-01-oq-01 | verified/original | CLEAN — counts match (4 thm, 2 def) |
| gcd-algorithm-oq-03 | verified/original | CLEAN — counts match (9 thm, 1 def) |
| infinitude-primes-oq-01 | verified/original | CLEAN — Furstenberg topological proof; `Nat.exists_prime_and_dvd` is support only |
| pythagorean-triples-oq-02-oq-01 | verified/**mathlib** | CLEAN — badge correctly `mathlib` for core `coprime_classification` |

All five: 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions, no `native_decide`, no `True` stubs. meta.json counts match the Lean source (lineCount ±1 = trailing-newline convention).

### Related open audit PRs (awaiting deployer)
- #30709 records the 8 morning targets (incl. erdos-1003-oq-02 & lifting-the-exponent-oq-02-oq-01 issues-found)
- #30690 fixes lifting-the-exponent badge original→mathlib
- erdos-1003-oq-02 theoremCount 8→10 already noted on its intro PR #30701

---
Discovered during gallery integrity audit. Tracker-only; no proof/meta changes.