### PR TITLE
Enrich Pythagorean Triples Classification (pythagorean-triples-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-param-def",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": { "startLine": 37, "endLine": 42 },
+    "type": "definition",
+    "title": "The Gaussian-Square Parametrization Map",
+    "content": "`paramTriple (m, n) = (m²−n², 2mn, m²+n²)` names the classical Euclid parametrization, but the Lean docstring frames it through the Gaussian integers ℤ[i]: the first two components are exactly the real and imaginary parts of the square (m+ni)² = (m²−n²) + (2mn)i, and the third is the Gaussian norm N(m+ni) = m²+n². This 'square a Gaussian integer' viewpoint is the conceptual key that makes the whole classification transparent.",
+    "mathContext": "$$(m+ni)^2 = (m^2-n^2) + (2mn)i,\\qquad N(m+ni) = m^2+n^2$$",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian integers", "Euclid parametrization", "complex norm", "Pythagorean triples"],
+    "prerequisites": ["squaring a complex/Gaussian integer", "the norm N(a+bi)=a²+b²"]
+  },
+  {
+    "id": "ann-is-pythagorean",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": { "startLine": 44, "endLine": 48 },
+    "type": "technique",
+    "title": "The Parametrization Always Yields a Triple — One ring Call",
+    "content": "`paramTriple_isPythagorean` proves (m²−n²)² + (2mn)² = (m²+n²)² for all integers m, n. After `delta PythagoreanTriple` unfolds the definition x·x + y·y = z·z, the goal is a polynomial identity over ℤ closed by `ring`. Conceptually this single line IS the multiplicativity of the Gaussian norm, N(z²) = N(z)²: squaring a Gaussian integer automatically produces a Pythagorean relation among the parts and the norm.",
+    "mathContext": "$$(m^2-n^2)^2 + (2mn)^2 = (m^2+n^2)^2 \\;\\Longleftrightarrow\\; N(z^2) = N(z)^2$$",
+    "significance": "key",
+    "relatedConcepts": ["ring tactic", "norm multiplicativity", "polynomial identity"],
+    "prerequisites": ["PythagoreanTriple definition", "the ring tactic over ℤ"]
+  },
+  {
+    "id": "ann-is-primitive",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": { "startLine": 50, "endLine": 61 },
+    "type": "insight",
+    "title": "Coprime Opposite-Parity Inputs Give a Primitive Triple",
+    "content": "`paramTriple_isPrimitive` shows that if gcd(m,n)=1 and m,n have opposite parity then the legs m²−n² and 2mn are coprime — i.e. the triple is primitive. Rather than reach for Mathlib's private lemma coprime_sq_sub_mul, the proof invokes the EASY (reverse) direction of the public coprime_classification: it supplies the explicit witness ⟨m, n, …⟩ to the .mpr and projects out the leg-coprimality with .2. Geometrically, opposite parity and coprimality are exactly the conditions keeping m+ni (up to units) free of the factor 1+i, so its square stays primitive.",
+    "mathContext": "$$\\gcd(m,n)=1 \\ \\wedge\\ m\\not\\equiv n \\pmod 2 \\;\\implies\\; \\gcd(m^2-n^2,\\,2mn) = 1$$",
+    "significance": "key",
+    "relatedConcepts": ["primitivity", "coprimality", "opposite parity", "PythagoreanTriple.coprime_classification", "the prime 1+i in ℤ[i]"],
+    "prerequisites": ["gcd over ℤ", "the reverse direction of the classification", "parity"]
+  },
+  {
+    "id": "ann-classification",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": { "startLine": 63, "endLine": 80 },
+    "type": "context",
+    "title": "The Complete Classification — Bridged from Mathlib",
+    "content": "`primitive_classification` is the headline biconditional: (x,y,z) is a primitive Pythagorean triple iff it arises from paramTriple for some coprime opposite-parity (m,n), up to swapping legs and the sign of z. The entry is honest that the HARD direction — every primitive triple has this shape — is precisely Mathlib's PythagoreanTriple.coprime_classification, which rests on unique factorization in ℤ[i]. The theorem here is definitionally that import, repackaged in the Gaussian-parametrization language; hence the `mathlib` badge.",
+    "mathContext": "$$(x^2+y^2=z^2 \\wedge \\gcd(x,y)=1) \\iff \\exists\\,m,n\\ \\text{coprime, opp. parity},\\ (x,y,z) = \\pm\\,\\mathrm{paramTriple}(m,n)$$",
+    "significance": "critical",
+    "relatedConcepts": ["unique factorization in ℤ[i]", "complete classification", "Mathlib bridge", "biconditional"],
+    "prerequisites": ["ℤ[i] is a UFD", "PythagoreanTriple.coprime_classification"]
+  },
+  {
+    "id": "ann-standard-form",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": { "startLine": 82, "endLine": 90 },
+    "type": "technique",
+    "title": "The Sign/Order-Free Standard Form",
+    "content": "`primitive_classification_pos` removes the leg-swap and sign ambiguity: when the odd leg x and the hypotenuse z are positive, there exist m ≥ 0 and n with exactly x = m²−n², y = 2mn, z = m²+n², coprime and of opposite parity. This is the textbook parametrization with no qualifiers, obtained directly from Mathlib's sharper coprime_classification'. It is the form most useful for downstream numeric work.",
+    "mathContext": "$$x \\text{ odd},\\ z>0 \\implies \\exists\\,m\\ge 0,n:\\ x=m^2-n^2,\\ y=2mn,\\ z=m^2+n^2$$",
+    "significance": "supporting",
+    "relatedConcepts": ["standard form", "PythagoreanTriple.coprime_classification'", "positive parametrization"],
+    "prerequisites": ["the biconditional classification", "positivity normalization"]
+  },
+  {
+    "id": "ann-sum-of-squares",
+    "proofId": "pythagorean-triples-oq-02-oq-01",
+    "range": { "startLine": 92, "endLine": 99 },
+    "type": "insight",
+    "title": "Corollary: the Hypotenuse Is a Sum of Two Squares",
+    "content": "`hypotenuse_sum_of_squares` extracts a clean number-theoretic fact: the hypotenuse of any positive primitive triple (with odd leg) is a sum of two squares, z = m²+n². It follows immediately by destructuring the witness from primitive_classification_pos and keeping the z = m²+n² component. In Gaussian terms this is z = N(m+ni) made explicit, and it connects directly to Fermat's two-squares theorem (the sibling open question OQ-02 #2 of the parent).",
+    "mathContext": "$$z = m^2 + n^2 = N(m+ni)$$",
+    "significance": "key",
+    "relatedConcepts": ["sum of two squares", "Fermat's two-squares theorem", "Gaussian norm", "corollary"],
+    "prerequisites": ["primitive_classification_pos", "destructuring an existential witness"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-02-oq-01` (Pythagorean Triples: Complete Classification via Gaussian Integers). The meta.json was already well-curated; the gap was a **missing annotations.json**.

## Added
- **annotations.json** — 6 inline annotations covering all declarations: the Gaussian-square `paramTriple` map, the always-a-triple `ring` identity (= N(z²)=N(z)²), `paramTriple_isPrimitive` (coprime opposite-parity ⟹ primitive), the complete biconditional `primitive_classification` (honest Mathlib bridge to coprime_classification / ℤ[i] UFD), the sign-free `primitive_classification_pos` standard form, and the hypotenuse sum-of-two-squares corollary (link to Fermat's two-squares theorem).

Each carries `mathContext` (LaTeX), a valid `significance` enum, `relatedConcepts`, and `prerequisites`.

**Validation:** JSON valid; `gallery:check-size` passes (meta 8.4 KB, under cap); `annotations:build` confirms all 6 annotation line ranges resolve to Lean constructs with no warnings. The full `tsc -b && vite build` could not run in this worktree due to host disk exhaustion (100% full from concurrent agents), but the change is pure JSON and every JSON-relevant build step passed. Axiom integrity unchanged: `verified`/`mathlib`, 0 axioms, 0 sorries.