### PR TITLE
Research: geometric-series-oq-07…-oq-02-oq-01-oq-01-oq-01 — descent-complementing involution & bijective Eulerian palindromy

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,141 @@
+import Mathlib
+
+/-
+# The descent-complementing involution and bijective Eulerian palindromy
+
+The grandparent **geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01** introduced the
+permutation descent statistic
+
+  `descentCount σ = |{i : Fin n | σ (i.succ) < σ (i.castSucc)}|`     (σ : Equiv.Perm (Fin (n+1)))
+
+and proved the **left border** `k = 0` of the still-open bijection
+`|{σ : descentCount σ = k}| = ⟨n+1,k⟩` (`descentCount σ = 0 ↔ σ = 1`). The sibling
+**…-oq-02-oq-01-oq-01** proved the **right border** `k = n` (`descentCount σ = n ↔ σ = Fin.revPerm`):
+the increasing and decreasing permutations are the unique extremes. Both borders give cardinality
+`1 = ⟨n+1,0⟩ = ⟨n+1,n⟩`.
+
+This entry proves the **symmetry that unifies the two borders and every interior column**: the
+*descent-complementing involution*
+
+  `Φ(σ) = Fin.revPerm * σ`,    i.e. `(Φ σ) i = (σ i).rev`   (reverse every **value**),
+
+satisfies
+
+  `descentCount_complement` :  `descentCount (Fin.revPerm * σ) = n − descentCount σ`,
+
+and is its own inverse (`Fin.revPerm` is an involution). Hence `Φ` is an explicit bijection between
+the descent classes `{σ : descentCount σ = k}` and `{σ : descentCount σ = n−k}`, giving the
+**permutation-level palindromy**
+
+  `card_descentClass_palindrome` :  `|{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}|`   (k ≤ n).
+
+The sibling **…-oq-02-oq-02** already proves the *algebraic* palindromy `⟨n+1,k⟩ = ⟨n+1,n−k⟩` of the
+Eulerian numbers from the closed alternating-sum form. This entry instead provides the
+**bijective** explanation — an honest involution on permutations whose action on descent counts is
+the reflection `k ↦ n−k`. Specialized to the borders it collapses to a single statement
+unifying the two sibling entries:
+
+  `card_descentFree_eq_card_descentMax` :  `|{descentCount = 0}| = |{descentCount = n}|`.
+
+## Method
+
+Reversing every value (`σ i ↦ (σ i).rev`) turns each adjacent comparison into its opposite, because
+`Fin.rev` is strictly antitone (`Fin.rev_lt_rev`): position `i` is a descent of `Φ σ` exactly when
+it is an *ascent* of `σ`. Since `σ` is injective the two strict inequalities are exhaustive on each
+of the `n` adjacent positions, so the descent set of `Φ σ` is the set-complement (inside
+`univ : Finset (Fin n)`) of the descent set of `σ`; taking cardinalities gives `n − descentCount σ`
+(`Finset.filter_not`, `Finset.card_sdiff`). The map `Φ` is left-multiplication by `Fin.revPerm`,
+hence injective (`mul_left_cancel`); its square is the identity (`Fin.rev_rev`), so the image of
+`{descentCount = k}` under `Φ` is exactly `{descentCount = n−k}` and the two finsets have equal
+cardinality (`Finset.card_image_of_injective`).
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free. The
+descent statistic is re-declared locally; only the parent Eulerian-number development is imported.
+-/
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01
+
+open Equiv Finset
+
+/-! ## The descent statistic (re-declared) -/
+
+/-- The **descent count** of a permutation `σ` of `Fin (n+1)`: the number of positions
+`i : Fin n` at which `σ` falls, `σ (i.succ) < σ (i.castSucc)`. -/
+def descentCount {n : ℕ} (σ : Equiv.Perm (Fin (n + 1))) : ℕ :=
+  (univ.filter (fun i : Fin n => σ i.succ < σ i.castSucc)).card
+
+/-! ## The descent-complementing involution `Φ σ = Fin.revPerm * σ` -/
+
+/-- **Value-reversal complements descents.** Reversing every value of `σ` (left-multiplying by
+`Fin.revPerm`) sends a permutation with `d` descents to one with `n − d` descents: each adjacent
+position that was an ascent becomes a descent and vice versa, and there are `n` positions in all. -/
+theorem descentCount_complement {n : ℕ} (σ : Equiv.Perm (Fin (n + 1))) :
+    descentCount (Fin.revPerm * σ) = n - descentCount σ := by
+  -- The descent set of `Fin.revPerm * σ` is the complement of the descent set of `σ`.
+  have hfilter : descentCount (Fin.revPerm * σ)
+      = (univ.filter (fun i : Fin n => ¬ (σ i.succ < σ i.castSucc))).card := by
+    unfold descentCount
+    congr 1
+    ext i
+    simp only [mem_filter, mem_univ, true_and]
+    -- `(Fin.revPerm * σ) j = (σ j).rev`, and `Fin.rev` is strictly antitone.
+    show ((σ i.succ).rev < (σ i.castSucc).rev) ↔ ¬ (σ i.succ < σ i.castSucc)
+    rw [Fin.rev_lt_rev]
+    constructor
+    · intro h
+      exact not_lt.mpr h.le
+    · intro h
+      rcases lt_trichotomy (σ i.castSucc) (σ i.succ) with hlt | heq | hgt
+      · exact hlt
+      · exact absurd (σ.injective heq) (Fin.castSucc_lt_succ (i := i)).ne
+      · exact absurd hgt h
+  rw [hfilter]
+  unfold descentCount
+  rw [Finset.filter_not, Finset.card_univ_diff, Fintype.card_fin]
+
+/-- `Fin.revPerm` is an involution: reversing values twice is the identity. -/
+theorem revPerm_mul_self {n : ℕ} :
+    (Fin.revPerm : Equiv.Perm (Fin (n + 1))) * Fin.revPerm = 1 := by
+  refine Equiv.ext (fun i => ?_)
+  show (i.rev).rev = i
+  exact Fin.rev_rev i
+
+/-! ## Bijective Eulerian palindromy at the permutation level -/
+
+/-- **Permutation-level palindromy of the descent statistic.** For every `k ≤ n` the descent class
+with `k` descents and the class with `n − k` descents have the same cardinality, exhibited by the
+explicit descent-complementing involution `σ ↦ Fin.revPerm * σ`. This is the bijective counterpart
+of the algebraic Eulerian palindromy `⟨n+1,k⟩ = ⟨n+1,n−k⟩` proved by the sibling …-oq-02-oq-02. -/
+theorem card_descentClass_palindrome {n k : ℕ} (hk : k ≤ n) :
+    (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = k)).card
+      = (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = n - k)).card := by
+  -- `Φ = (Fin.revPerm * ·)` is injective and carries `{= n−k}` onto `{= k}`.
+  have hinj : Function.Injective
+      (fun σ : Equiv.Perm (Fin (n + 1)) => Fin.revPerm * σ) :=
+    fun a b hab => mul_left_cancel hab
+  have himg : (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = n - k))
+      = (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = k)).image
+          (fun σ => Fin.revPerm * σ) := by
+    ext τ
+    simp only [Finset.mem_image, mem_filter, mem_univ, true_and]
+    constructor
+    · intro hτ
+      refine ⟨Fin.revPerm * τ, ?_, ?_⟩
+      · rw [descentCount_complement, hτ]
+        omega
+      · rw [← mul_assoc, revPerm_mul_self, one_mul]
+    · rintro ⟨σ, hσ, rfl⟩
+      rw [descentCount_complement, hσ]
+  rw [himg, Finset.card_image_of_injective _ hinj]
+
+/-- **The two extreme borders coincide, via one involution.** Specializing the palindromy to `k = 0`
+recovers `|{descentCount = 0}| = |{descentCount = n}|`: the increasing and decreasing permutations
+are exchanged by value-reversal, unifying the left border (`…-oq-02-oq-01`) and the right border
+(`…-oq-02-oq-01-oq-01`) of the Eulerian row. -/
+theorem card_descentFree_eq_card_descentMax {n : ℕ} :
+    (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = 0)).card
+      = (univ.filter (fun σ : Equiv.Perm (Fin (n + 1)) => descentCount σ = n)).card := by
+  have h := card_descentClass_palindrome (n := n) (k := 0) (Nat.zero_le n)
+  simpa using h
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,201 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Equiv",
+      "Finset"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Descent-Complementing Involution and Bijective Eulerian Palindromy",
+  "description": "Proves the symmetry that unifies the two border rungs of the permutation descent statistic and explains the Eulerian palindromy bijectively. The grandparent oq-02-oq-01 defined descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}| on σ : Equiv.Perm (Fin (n+1)) and proved the left border (descentCount σ = 0 ↔ σ = 1); the sibling oq-02-oq-01-oq-01 proved the right border (descentCount σ = n ↔ σ = Fin.revPerm). This entry introduces the descent-complementing involution Φ(σ) = Fin.revPerm * σ — reverse every value, (Φ σ) i = (σ i).rev — and proves descentCount_complement: descentCount (Fin.revPerm * σ) = n − descentCount σ. Because reversing values turns every adjacent ascent into a descent and vice versa (Fin.rev is strictly antitone, Fin.rev_lt_rev) and σ is injective, the descent set of Φ σ is the set-complement of that of σ inside univ : Finset (Fin n); taking cardinalities (Finset.filter_not, Finset.card_univ_diff) gives n − descentCount σ. Φ is left-multiplication by Fin.revPerm, hence injective (mul_left_cancel), and its own inverse (Fin.revPerm * Fin.revPerm = 1 from Fin.rev_rev), so it is a bijection between descent classes, yielding the permutation-level palindromy card_descentClass_palindrome: |{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}| for every k ≤ n (Finset.card_image_of_injective). Specialized to k = 0 it gives card_descentFree_eq_card_descentMax: |{descentCount = 0}| = |{descentCount = n}|, unifying the two sibling borders via a single involution. Where the sibling oq-02-oq-02 proves the algebraic palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩ from the closed alternating-sum form, this entry gives the bijective counterpart at the level of honest permutations. 141 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Eulerian number ⟨n,k⟩ counts permutations of {1,…,n} with exactly k descents, and the Eulerian triangle is palindromic: ⟨n,k⟩ = ⟨n,n−1−k⟩. Classically this symmetry is the reflection σ ↦ σ̄ that complements every value (or equivalently reverses the word), exchanging ascents and descents. The gallery's Eulerian lineage proves this palindromy analytically (the sibling oq-02-oq-02 derives ⟨n+1,k⟩ = ⟨n+1,n−k⟩ from the closed alternating-sum formula), and the descent statistic on honest permutations was introduced only in the oq-02-oq-01 sub-lineage, which pinned the two border columns k=0 (descent-free ⟺ identity) and k=n (maximal descents ⟺ reverse permutation). What was missing is the combinatorial reflection itself — an explicit involution on Equiv.Perm whose effect on the descent count is exactly k ↦ n−k. This entry supplies it.",
+    "problemStatement": "Exhibit an explicit involution on Equiv.Perm (Fin (n+1)) whose action on the descent statistic is the reflection k ↦ n−k, and use it to prove the bijective Eulerian palindromy |{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}| at the level of permutations, unifying the two proved border rungs (k=0 and k=n) of the open descent-count bijection.",
+    "proofStrategy": "Define the value-reversal map Φ(σ) = Fin.revPerm * σ, so (Φ σ) i = (σ i).rev. For each of the n adjacent positions i : Fin n, position i is a descent of Φ σ (i.e. (σ i.succ).rev < (σ i.castSucc).rev) iff σ i.castSucc < σ i.succ (Fin.rev_lt_rev), i.e. iff i is an ASCENT of σ; injectivity of σ makes the strict inequalities exhaustive (the equal case is impossible since i.castSucc ≠ i.succ), so {descents of Φ σ} = univ \\ {descents of σ}. Cardinalities give descentCount (Φ σ) = #univ − descentCount σ = n − descentCount σ (Finset.filter_not, Finset.card_univ_diff, Fintype.card_fin). Φ is injective (mul_left_cancel) and an involution (Fin.revPerm * Fin.revPerm = 1 via Fin.rev_rev), so the image of the descent class {descentCount = k} under Φ is exactly {descentCount = n−k}, and Finset.card_image_of_injective gives the equal-cardinality palindromy for every k ≤ n. The border corollary is the k=0 specialization (n − 0 = n).",
+    "keyInsights": [
+      "Reversing every value is left-multiplication by Fin.revPerm, and its effect on each adjacent comparison is governed by the strict antitonicity of Fin.rev (Fin.rev_lt_rev): a descent of σ becomes an ascent of Φ σ and conversely, so Φ complements the descent SET, not merely the descent COUNT.",
+      "Injectivity of σ is exactly what upgrades the non-strict complement (¬ descent) to the strict ascent inequality: at every adjacent position σ either strictly rises or strictly falls, never ties, so the descent set and its complement partition the n positions and descentCount Φσ = n − descentCount σ falls out by Finset.card_univ_diff.",
+      "Φ is its own inverse because Fin.rev is an involution (Fin.rev_rev gives Fin.revPerm * Fin.revPerm = 1); being left-multiplication by a group element it is automatically injective (mul_left_cancel), so no bespoke bijection bookkeeping is needed — Finset.card_image_of_injective converts the set identity {= n−k} = Φ '' {= k} into the cardinality palindromy.",
+      "This is the BIJECTIVE proof of the Eulerian palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩, complementary to the sibling oq-02-oq-02's ALGEBRAIC proof from the alternating-sum formula: an honest involution on permutations realizes the reflection, rather than an identity of binomial sums.",
+      "Specialized to the borders the single involution Φ exchanges the unique increasing permutation (descentCount 0) with the unique decreasing one (descentCount n), so card_descentFree_eq_card_descentMax unifies the two separate sibling entries (the k=0 and k=n rungs) as the two ends of one symmetry."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context, scope, and method",
+      "startLine": 3,
+      "endLine": 56,
+      "summary": "Docstring situating the entry as the symmetry unifying the two border rungs, recalling descentCount, stating the descent-complementing involution Φ(σ) = Fin.revPerm * σ and the three results (descentCount_complement, card_descentClass_palindrome, card_descentFree_eq_card_descentMax), and contrasting the bijective palindromy with the sibling oq-02-oq-02's algebraic one."
+    },
+    {
+      "id": "descent-statistic",
+      "title": "The descent statistic (descentCount)",
+      "startLine": 58,
+      "endLine": 66,
+      "summary": "Re-declares descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}|, the number of falls of a permutation of Fin (n+1), so the entry stands alone on Mathlib."
+    },
+    {
+      "id": "descent-complement",
+      "title": "Value-reversal complements descents (descentCount_complement)",
+      "startLine": 68,
+      "endLine": 95,
+      "summary": "descentCount (Fin.revPerm * σ) = n − descentCount σ: the descent set of Φ σ equals the complement (inside univ) of the descent set of σ, since reversing values exchanges adjacent ascents and descents (Fin.rev_lt_rev) and σ injective makes the comparison strict; cardinalities via Finset.filter_not and Finset.card_univ_diff."
+    },
+    {
+      "id": "revperm-involution",
+      "title": "Fin.revPerm is an involution (revPerm_mul_self)",
+      "startLine": 97,
+      "endLine": 107,
+      "summary": "Fin.revPerm * Fin.revPerm = 1, by Equiv.ext and Fin.rev_rev (reversing values twice is the identity) — the fact that makes Φ its own inverse."
+    },
+    {
+      "id": "palindrome",
+      "title": "Bijective palindromy of descent classes (card_descentClass_palindrome)",
+      "startLine": 109,
+      "endLine": 133,
+      "summary": "|{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}| for k ≤ n: the involution Φ = (Fin.revPerm * ·) is injective (mul_left_cancel) and carries {= n−k} onto {= k} (descentCount_complement and involution), so Finset.card_image_of_injective equates the two cardinalities."
+    },
+    {
+      "id": "border-corollary",
+      "title": "The two borders coincide via one involution (card_descentFree_eq_card_descentMax)",
+      "startLine": 135,
+      "endLine": 140,
+      "summary": "|{descentCount = 0}| = |{descentCount = n}|, the k=0 specialization of the palindromy — value-reversal exchanges the increasing and decreasing permutations, unifying the left (oq-02-oq-01) and right (oq-02-oq-01-oq-01) border entries."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ02OQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "descent-statistic",
+      "permutations",
+      "involution",
+      "bijective-proof",
+      "palindrome",
+      "cardinality",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 141,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "descentCount_complement: the descent-complement identity descentCount (Fin.revPerm * σ) = n − descentCount σ. Reversing every value of σ exchanges adjacent ascents and descents, so the descent set of Fin.revPerm * σ is the complement (inside the n-element index Fin n) of the descent set of σ; this is the first time the descent statistic is shown to transform by an explicit group action on Equiv.Perm.",
+      "card_descentClass_palindrome: the bijective Eulerian palindromy at the permutation level — |{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}| for every k ≤ n, realized by the explicit descent-complementing involution σ ↦ Fin.revPerm * σ. This is the combinatorial counterpart of the sibling oq-02-oq-02's algebraic palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩ derived from the alternating-sum formula.",
+      "card_descentFree_eq_card_descentMax: the unification of the two border rungs — |{descentCount = 0}| = |{descentCount = n}| — as the k=0 specialization of the palindromy, exhibiting value-reversal as the single involution that exchanges the unique increasing and unique decreasing permutations counted by the two sibling entries.",
+      "revPerm_mul_self: Fin.revPerm * Fin.revPerm = 1, the involution property of value-reversal on Equiv.Perm (Fin (n+1)) from Fin.rev_rev, used to make the descent-complementing map its own inverse."
+    ],
+    "prerequisites": [
+      "Grandparent: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01 — introduces the descentCount statistic and proves the k=0 left border; this entry supplies the symmetry k ↦ n−k that relates its border to the sibling's",
+      "Sibling: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01 — proves the k=n right border (descentCount σ = n ↔ σ = Fin.revPerm); the present involution carries that border's unique permutation Fin.revPerm to the identity of the k=0 border",
+      "Sibling: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02 — proves the algebraic Eulerian palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩ from the closed form; this entry gives the bijective explanation of that same symmetry",
+      "Mathlib order theory on Fin: Fin.rev_lt_rev (strict antitonicity), Fin.revPerm and Fin.rev_rev (the value-reversal involution), Fin.castSucc_lt_succ; Finset.filter_not, Finset.card_univ_diff, Finset.card_image_of_injective and the group lemma mul_left_cancel for the cardinality bijection"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Fin.rev_lt_rev",
+        "description": "i.rev < j.rev ↔ j < i: the strict order-reversing property of Fin.rev. Converts the descent condition of Fin.revPerm * σ at each adjacent pair into the ascent condition of σ, the heart of the descent-complement identity.",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Fin.rev_rev",
+        "description": "i.rev.rev = i: Fin.rev is an involution. Lifts to Fin.revPerm * Fin.revPerm = 1, making the descent-complementing map σ ↦ Fin.revPerm * σ its own inverse.",
+        "module": "Mathlib.Order.Fin.Basic"
+      },
+      {
+        "theorem": "Finset.card_univ_diff",
+        "description": "(univ \\ s).card = Fintype.card α − s.card. Turns the descent set of Fin.revPerm * σ (the complement of σ's descent set inside univ : Finset (Fin n)) into n − descentCount σ.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "(s.image f).card = s.card for injective f. With f = (Fin.revPerm * ·), injective by mul_left_cancel, converts the set identity {descentCount = n−k} = (Fin.revPerm * ·) '' {descentCount = k} into the cardinality palindromy.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "mul_left_cancel",
+        "description": "a * b = a * c → b = c in a group. Gives injectivity of the descent-complementing map σ ↦ Fin.revPerm * σ (left-multiplication by the fixed unit Fin.revPerm).",
+        "module": "Mathlib.Algebra.Group.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01",
+      "question": "Use the descent-complementing involution to halve the remaining interior columns of the open descent-count bijection: combined with a proof of |{σ : descentCount σ = k}| = ⟨n+1,k⟩ for k ≤ ⌊n/2⌋, the palindromy card_descentClass_palindrome would extend it to all k automatically, since ⟨n+1,k⟩ = ⟨n+1,n−k⟩ is already known (sibling oq-02-oq-02). Can the involution thereby reduce the interior recurrence to the lower half?",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+      "question": "Refine the descent-complement identity to a joint distribution statement: the involution σ ↦ Fin.revPerm * σ together with the inverse map σ ↦ σ⁻¹ generates a group action on Equiv.Perm permuting the four statistics (descents, ascents, descents of inverse, ascents of inverse). Does this recover the symmetry of the joint descent/inverse-descent (two-variable Eulerian) distribution at the permutation level?",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling proving the k=n right border (descentCount σ = n ↔ σ = Fin.revPerm). The present descent-complementing involution σ ↦ Fin.revPerm * σ carries that border's unique permutation Fin.revPerm to the identity (the k=0 border), exhibiting the two extremes as a single symmetry; the entry's card_descentFree_eq_card_descentMax is the bijective statement that the two borders are equinumerous."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent introducing the descentCount statistic and proving the k=0 left border (descent-free ⟺ identity). This entry adds the reflection k ↦ n−k of the descent count via an explicit involution, relating that border to the sibling's."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-02",
+      "relationship": "complements",
+      "description": "Sibling proving the algebraic Eulerian palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩ from the closed alternating-sum formula. This entry gives the bijective counterpart — an explicit involution on Equiv.Perm whose action on the descent statistic is the reflection k ↦ n−k — so the descent classes are equinumerous for the same combinatorial reason the Eulerian numbers are equal."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, descents, and the reflection symmetry)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers as descent counts and the palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩, classically explained by the value-complement (or word-reversal) involution exchanging ascents and descents — the map this entry formalizes on Equiv.Perm."
+    },
+    {
+      "title": "Combinatorics of Permutations",
+      "author": "Miklós Bóna",
+      "year": "2012",
+      "venue": "CRC Press",
+      "description": "Treatment of permutation statistics and their symmetries, including the complement/reverse involutions on the symmetric group that realize the Eulerian palindromy bijectively."
+    },
+    {
+      "title": "Mathlib4: Order.Fin.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Fin.rev_lt_rev, Fin.revPerm, and Fin.rev_rev used to build the descent-complementing involution and prove its effect on the descent statistic."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "This entry introduces the descent-complementing involution Φ(σ) = Fin.revPerm * σ (reverse every value) and proves descentCount_complement: descentCount (Fin.revPerm * σ) = n − descentCount σ — reversing values exchanges adjacent ascents and descents (Fin.rev strictly antitone) so the descent set of Φ σ is the complement of σ's inside the n-element index. Φ is injective (mul_left_cancel) and an involution (Fin.revPerm * Fin.revPerm = 1 from Fin.rev_rev), giving card_descentClass_palindrome: |{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}| for every k ≤ n, the bijective Eulerian palindromy at the level of permutations. Specialized to k=0 it unifies the two sibling border rungs as card_descentFree_eq_card_descentMax: |{descentCount = 0}| = |{descentCount = n}|. 141 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries; everything depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The entry supplies the combinatorial reflection underlying the Eulerian palindromy: where the sibling oq-02-oq-02 proves ⟨n+1,k⟩ = ⟨n+1,n−k⟩ by an identity of alternating binomial sums, this entry exhibits an honest involution on Equiv.Perm that maps each descent class onto its mirror, so the equinumerosity is realized bijectively. Combined with a future proof of the lower-half interior columns, the palindromy would extend the descent-count bijection to all k for free. The descent-complement identity also shows the descent statistic transforms predictably under the value-reversal group action, the first step toward the joint (two-variable) Eulerian symmetries.",
+    "openQuestions": [
+      "Use the involution to halve the open interior-column bijection, reducing |{descentCount = k}| = ⟨n+1,k⟩ to the lower half k ≤ ⌊n/2⌋ via the known palindromy.",
+      "Combine value-reversal with inversion σ ↦ σ⁻¹ to recover the joint descent / inverse-descent (two-variable Eulerian) symmetry at the permutation level."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

A new verified, **0-axiom**, original gallery entry building on the Eulerian descent-statistic lineage.

The grandparent `…-oq-02-oq-01` defined the permutation descent statistic `descentCount σ = |{i : Fin n | σ(i.succ) < σ(i.castSucc)}|` and proved the **left border** `descentCount σ = 0 ↔ σ = 1`; the sibling `…-oq-02-oq-01-oq-01` proved the **right border** `descentCount σ = n ↔ σ = Fin.revPerm`. This entry adds the **symmetry that unifies them and explains the Eulerian palindromy bijectively**.

### Results
- `descentCount_complement` : `descentCount (Fin.revPerm * σ) = n − descentCount σ` — value-reversal `Φ(σ) = Fin.revPerm * σ` exchanges every adjacent ascent and descent (`Fin.rev` strictly antitone, `Fin.rev_lt_rev`), so the descent set of `Φ σ` is the set-complement of σ's inside `univ : Finset (Fin n)` (`Finset.filter_not`, `Finset.card_univ_diff`).
- `revPerm_mul_self` : `Fin.revPerm * Fin.revPerm = 1` (involution, from `Fin.rev_rev`).
- `card_descentClass_palindrome` : `|{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}|` for `k ≤ n` — Φ is injective (`mul_left_cancel`) and its own inverse, so it bijects the two descent classes (`Finset.card_image_of_injective`). This is the **bijective** counterpart of the sibling `…-oq-02-oq-02`'s **algebraic** palindromy `⟨n+1,k⟩ = ⟨n+1,n−k⟩`.
- `card_descentFree_eq_card_descentMax` : `|{descentCount = 0}| = |{descentCount = n}|` — the `k=0` case, unifying the two sibling border entries via one involution.

### Verification
- Offline elaboration (`lake env lean`) against prebuilt Mathlib oleans: **EXIT 0**, no errors. (Docker build host had a transient containerd I/O fault.)
- `#print axioms` on all three theorems: `[propext, Classical.choice, Quot.sound]` only — **0-axiom**, 0 sorries.
- 141 lines, 4 theorems, 1 definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)