### PR TITLE
Enrich Horadam Cassini/d'Ocagne (fibonacci-identities-oq-04-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-02/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ04OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ04OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ04OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ04OQ01OQ02Data: ProofData = {
+  proof: fibonacciIdentitiesOQ04OQ01OQ02Proof,
+  annotations: fibonacciIdentitiesOQ04OQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-04-oq-01-oq-02` (Cassini/d'Ocagne for the full Horadam recurrence).

## Gaps addressed
- **Empty annotations** → added **6 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering:
  1. The Horadam sequence definition (structural recursion, rfl seed/recurrence lemmas)
  2. The master two-index d'Ocagne identity statement
  3. The single induction closed by `linear_combination (−q)·ih` (telescoping $D_k(n+1)=-q\,D_k(n)$)
  4. Cassini/Simson as the k=1 specialization + the Horadam discriminant constant
  5. Identifying `H 1 1 0 1` with `Nat.fib` via strong induction
  6. Recovering the classical Fibonacci Cassini identity as a corollary
- **Missing `index.ts`** → created it so the proof page loads on the live site (without it the page shows "proof not found").

meta.json was already rich (overview, sections, conclusion, cross-references) and well under the size cap (~13.7 KB) — left intact.

Verified with `pnpm build` ✓ (0 sorries, 0 axioms, no native_decide; status/badge unchanged).