### PR TITLE
Fix: erdos-1003-oq-02 theoremCount 8→10

### DIFF
--- a/src/data/proofs/erdos-1003-oq-02/meta.json
+++ b/src/data/proofs/erdos-1003-oq-02/meta.json
@@ -34,7 +34,7 @@
     "axiomCount": 0,
     "lineCount": 158,
     "assumptions": "0 axioms, 0 sorries. All results are fully machine-checked and depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). No native_decide is used, so no Lean.ofReduceBool dependency. The underlying Erdős open problem itself is NOT resolved; only its structural reduction is formalized.",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 4
   },
   "overview": {
@@ -58,7 +58,7 @@
     {"id": "reformulations", "title": "Strong Conjecture and Reformulations", "startLine": 122, "endLine": 158, "summary": "Strong implies main, strong iff infinite for every k iff cofinally infinite, plus the finiteness contrapositive.", "mathContext": "Mathematical content: equivalences pinning down the essential content of OQ-02."}
   ],
   "conclusion": {
-    "summary": "We formalize the structural reduction underlying open question OQ-02 of Erdős #1003. The k-consecutive equal totient sets form a nested decreasing chain whose base cases are fully verified; the strong Erdős conjecture is shown equivalent to infinitude for every k and even for cofinally many k, and to imply the main #1003 conjecture. All eight theorems are machine-checked with 0 sorries and 0 axioms.",
+    "summary": "We formalize the structural reduction underlying open question OQ-02 of Erdős #1003. The k-consecutive equal totient sets form a nested decreasing chain whose base cases are fully verified; the strong Erdős conjecture is shown equivalent to infinitude for every k and even for cofinally many k, and to imply the main #1003 conjecture. All ten theorems are machine-checked with 0 sorries and 0 axioms.",
     "implications": "This reduction clarifies exactly what an eventual proof of OQ-02 must supply: infinitely many solutions for arbitrarily long runs of equal consecutive totients. Conversely, a finiteness result at any single run length would collapse all longer runs. The work does not resolve the open problem.",
     "openQuestions": [
       "Is CKE(1) = ConsecutiveEqualTotients infinite? (The main Erdős #1003 question.)",
@@ -80,7 +80,7 @@
     "namespace": "Erdos1003.OQ02",
     "lineCount": 158,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 4,
     "path": "Proofs/Erdos1003OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Correct `theoremCount` metadata for `erdos-1003-oq-02` from 8 to 10 to match the Lean source.

## Evidence

**Before**: `meta.theoremCount = 8`, `leanFile.theoremCount = 8`, conclusion prose "All eight theorems".
**After**: all three corrected to 10.

`proofs/Proofs/Erdos1003OQ02.lean` declares 10 theorems (0 `def`-level, decl-aware count): `cke_zero`, `cke_one`, `cke_zero_infinite`, `cke_antitone`, `cke_succ_subset`, `cke_infinite_of_le`, `strong_imp_main`, `strong_iff_all_k`, `strong_iff_cofinally_infinite`, `cke_finite_of_le`.

Flagged by the auditor agent (on-disk pending; the intro PR #30701 merged without the correction). Pure metadata fix, no Lean code change. `axiomCount`/`status`/`sorries` unaffected (entry remains verified, 0-axiom).

---
Automated fix by lean-mechanic agent.