### PR TITLE
research(erdos-103-oq-02): n=2 case — hCong 2 = 1 via explicit planar isometry [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/Erdos103OQ02N2.lean
+++ b/proofs/Proofs/Erdos103OQ02N2.lean
@@ -1,0 +1,328 @@
+/-
+Erdős Problem #103 — Open Question 02: the first non-degenerate case `n = 2`.
+
+## What this adds over `Erdos103OQ02.lean` / `Erdos103OQ02Finite.lean`
+
+The parent OQ-02 audit showed the raw count `h(n)` is degenerate (≡ 0 for `n ≥ 1`)
+and supplied the corrected congruence count `hCong n`. The sibling `…Finite` file
+discharged the open `[Finite (Quotient (OptimalSetoid n))]` hypothesis only in the
+*degenerate* small cases `n ≤ 1`, where `diameter n ≡ 0` and every configuration is
+optimal for trivial reasons.
+
+This file handles the **first genuinely non-degenerate case `n = 2`**, where the
+diameter is an honest distance. It proves, unconditionally and 0-axiom:
+
+1. `diameter_two`  : for a 2-point configuration the diameter is exactly the single
+   pairwise distance `pointDist (P 0) (P 1)`.
+2. `minDiameter_two` : `minDiameter 2 = 1` — two points cannot be closer than the
+   separation constraint, and a unit segment attains it.
+3. `exists_optimal_two` : the unit segment `{(0,0),(1,0)}` is optimal.
+4. `optimal_two_gap` : every optimal 2-configuration has its two points at distance
+   *exactly* 1.
+5. `optimal_two_congruent` : any two optimal 2-configurations are congruent — via an
+   **explicit planar isometry** (complex multiplication by a unit number followed by a
+   translation) that carries one unit segment onto the other.
+6. Hence `Subsingleton`/`Finite (Quotient (OptimalSetoid 2))` and the exact value
+   `hCong 2 = 1`, together with the strict gap `h 2 = 0 < 1 = hCong 2`.
+
+This confirms — with proof — the parent file's unproven summary claim "h(2) = 1",
+now restated for the corrected count `hCong`. It does **not** resolve the open Erdős
+question (`hCong n ≥ 2` for large `n`), which concerns `n` far beyond 2.
+
+## Axioms / Sorries
+None. Machine-checked from Mathlib + `Erdos103Problem` + `Erdos103OQ02`.
+-/
+
+import Mathlib
+import Proofs.Erdos103Problem
+import Proofs.Erdos103OQ02
+
+open Metric Set Finset
+open Erdos103
+
+namespace Erdos103OQ02
+
+-- ============================================================
+-- PART N0: Elementary facts about `pointDist`
+-- ============================================================
+
+/-- `pointDist` is nonnegative (it is a square root). -/
+theorem pointDist_nonneg (p q : ℝ × ℝ) : 0 ≤ pointDist p q := Real.sqrt_nonneg _
+
+/-- A point is at distance `0` from itself. -/
+theorem pointDist_self (p : ℝ × ℝ) : pointDist p p = 0 := by
+  unfold pointDist
+  simp
+
+/-- `pointDist` is symmetric. -/
+theorem pointDist_comm (p q : ℝ × ℝ) : pointDist p q = pointDist q p := by
+  unfold pointDist
+  congr 1
+  ring
+
+/-- The square of `pointDist` is the sum of squared coordinate differences. -/
+theorem pointDist_sq (p q : ℝ × ℝ) :
+    (pointDist p q) ^ 2 = (p.1 - q.1) ^ 2 + (p.2 - q.2) ^ 2 := by
+  unfold pointDist
+  rw [Real.sq_sqrt (by positivity)]
+
+/-- The two endpoints of the unit segment are at distance exactly `1`. -/
+theorem pointDist_seg : pointDist ((0, 0) : ℝ × ℝ) ((1, 0) : ℝ × ℝ) = 1 := by
+  have h : pointDist ((0, 0) : ℝ × ℝ) ((1, 0) : ℝ × ℝ)
+        = Real.sqrt (((0 : ℝ) - 1) ^ 2 + ((0 : ℝ) - 0) ^ 2) := rfl
+  rw [h, show ((0 : ℝ) - 1) ^ 2 + ((0 : ℝ) - 0) ^ 2 = 1 from by norm_num, Real.sqrt_one]
+
+/-- The unit segment endpoints, reversed, are also at distance `1`. -/
+theorem pointDist_seg' : pointDist ((1, 0) : ℝ × ℝ) ((0, 0) : ℝ × ℝ) = 1 := by
+  rw [pointDist_comm, pointDist_seg]
+
+-- ============================================================
+-- PART N1: The diameter of a 2-point configuration
+-- ============================================================
+
+/-- **Diameter of a pair.** For `n = 2`, the diameter (the supremum over all index
+    pairs of `pointDist`) is exactly the single pairwise distance
+    `pointDist (P 0) (P 1)`. -/
+theorem diameter_two (P : PointConfig 2) :
+    diameter 2 P = pointDist (P 0) (P 1) := by
+  have key : ∀ i j : Fin 2, pointDist (P i) (P j) ≤ pointDist (P 0) (P 1) := by
+    intro i j
+    fin_cases i <;> fin_cases j <;>
+      first
+        | exact le_rfl
+        | (rw [pointDist_self]; exact pointDist_nonneg _ _)
+        | (rw [pointDist_comm]; exact le_rfl)
+  unfold diameter
+  rw [dif_pos (show (2 : ℕ) ≥ 2 from le_refl 2)]
+  apply le_antisymm
+  · apply ciSup_le
+    intro i
+    apply ciSup_le
+    intro j
+    exact key i j
+  · have hbj : BddAbove (Set.range fun j : Fin 2 => pointDist (P 0) (P j)) :=
+      Set.Finite.bddAbove (Set.finite_range _)
+    have hbi : BddAbove (Set.range fun i : Fin 2 => ⨆ j, pointDist (P i) (P j)) :=
+      Set.Finite.bddAbove (Set.finite_range _)
+    calc pointDist (P 0) (P 1)
+        ≤ ⨆ j, pointDist (P 0) (P j) := le_ciSup hbj 1
+      _ ≤ ⨆ i, ⨆ j, pointDist (P i) (P j) := le_ciSup hbi 0
+
+-- ============================================================
+-- PART N2: The optimal diameter for two points is 1
+-- ============================================================
+
+/-- The explicit unit segment `{(0,0), (1,0)}`. -/
+def segTwo : PointConfig 2 := ![(0, 0), (1, 0)]
+
+@[simp] theorem segTwo_zero : segTwo 0 = (0, 0) := rfl
+@[simp] theorem segTwo_one : segTwo 1 = (1, 0) := rfl
+
+/-- The unit segment is a valid configuration (its two points are at distance 1 ≥ 1). -/
+theorem segTwo_valid : IsValidConfig 2 segTwo := by
+  intro i j hij
+  have h2 : (segTwo i = (0, 0) ∧ segTwo j = (1, 0)) ∨
+            (segTwo i = (1, 0) ∧ segTwo j = (0, 0)) := by
+    fin_cases i <;> fin_cases j <;> simp_all [segTwo]
+  rcases h2 with ⟨hi, hj⟩ | ⟨hi, hj⟩
+  · simp [hi, hj, pointDist_seg]
+  · simp [hi, hj, pointDist_seg']
+
+/-- The diameter of the unit segment is `1`. -/
+theorem segTwo_diameter : diameter 2 segTwo = 1 := by
+  rw [diameter_two, segTwo_zero, segTwo_one, pointDist_seg]
+
+/-- **The minimum diameter for two points is exactly `1`.** Lower bound: every valid
+    configuration has its two points separated by `≥ 1`, so its diameter is `≥ 1`.
+    Upper bound: the unit segment attains `1`. -/
+theorem minDiameter_two : minDiameter 2 = 1 := by
+  haveI : Nonempty {P : PointConfig 2 // IsValidConfig 2 P} := ⟨⟨segTwo, segTwo_valid⟩⟩
+  have hbddBelow :
+      BddBelow (Set.range fun P : {P : PointConfig 2 // IsValidConfig 2 P} =>
+        diameter 2 P.val) := by
+    refine ⟨0, ?_⟩
+    rintro _ ⟨P, rfl⟩
+    show (0 : ℝ) ≤ diameter 2 P.val
+    rw [diameter_two]
+    exact pointDist_nonneg _ _
+  apply le_antisymm
+  · calc minDiameter 2 ≤ diameter 2 segTwo :=
+          ciInf_le hbddBelow ⟨segTwo, segTwo_valid⟩
+        _ = 1 := segTwo_diameter
+  · apply le_ciInf
+    intro P
+    rw [diameter_two]
+    exact P.2 0 1 (by decide)
+
+-- ============================================================
+-- PART N3: Existence and the unit-gap characterization
+-- ============================================================
+
+/-- **An optimal 2-configuration exists**: the unit segment. -/
+theorem exists_optimal_two : ∃ P, IsOptimal 2 P :=
+  ⟨segTwo, segTwo_valid, by rw [segTwo_diameter, minDiameter_two]⟩
+
+/-- **Every optimal 2-configuration realizes its two points at distance exactly 1.** -/
+theorem optimal_two_gap {P : PointConfig 2} (hP : IsOptimal 2 P) :
+    pointDist (P 0) (P 1) = 1 := by
+  obtain ⟨_, hd⟩ := hP
+  rw [diameter_two, minDiameter_two] at hd
+  exact hd
+
+/-- The squared coordinate spread of an optimal pair is `1`. -/
+theorem optimal_two_normsq {P : PointConfig 2} (hP : IsOptimal 2 P) :
+    ((P 1).1 - (P 0).1) ^ 2 + ((P 1).2 - (P 0).2) ^ 2 = 1 := by
+  have hsq := pointDist_sq (P 0) (P 1)
+  rw [optimal_two_gap hP] at hsq
+  -- hsq : (1:ℝ)^2 = (P0.1 - P1.1)^2 + (P0.2 - P1.2)^2
+  nlinarith [hsq]
+
+-- ============================================================
+-- PART N4: A planar isometry as complex multiplication
+-- ============================================================
+
+/-- Complex multiplication on `ℝ × ℝ`: `(a,b) * (x,y) = (ax - by, bx + ay)`. -/
+def cmul (c z : ℝ × ℝ) : ℝ × ℝ := (c.1 * z.1 - c.2 * z.2, c.2 * z.1 + c.1 * z.2)
+
+@[simp] theorem cmul_fst (c z : ℝ × ℝ) : (cmul c z).1 = c.1 * z.1 - c.2 * z.2 := rfl
+@[simp] theorem cmul_snd (c z : ℝ × ℝ) : (cmul c z).2 = c.2 * z.1 + c.1 * z.2 := rfl
+
+/-- `cmul` is additive in its second argument (it is ℝ-linear). -/
+theorem cmul_sub (c z w : ℝ × ℝ) : cmul c z - cmul c w = cmul c (z - w) := by
+  apply Prod.ext <;> simp [Prod.fst_sub, Prod.snd_sub] <;> ring
+
+/-- **Multiplication by a unit number preserves `pointDist`.** If `c` lies on the unit
+    circle (`c.1² + c.2² = 1`), then `z ↦ cmul c z` is an isometry. -/
+theorem cmul_preserves {c : ℝ × ℝ} (hc : c.1 ^ 2 + c.2 ^ 2 = 1) (z w : ℝ × ℝ) :
+    pointDist (cmul c z) (cmul c w) = pointDist z w := by
+  unfold pointDist
+  congr 1
+  have e1 : (cmul c z).1 - (cmul c w).1 = c.1 * (z.1 - w.1) - c.2 * (z.2 - w.2) := by
+    simp [cmul_fst]; ring
+  have e2 : (cmul c z).2 - (cmul c w).2 = c.2 * (z.1 - w.1) + c.1 * (z.2 - w.2) := by
+    simp [cmul_snd]; ring
+  rw [e1, e2]
+  nlinarith [hc, sq_nonneg (z.1 - w.1), sq_nonneg (z.2 - w.2)]
+
+/-- Right-inverse identity for a unit `c`: composing `cmul c` with `cmul (conj c)`
+    returns the input. (`conj c = (c.1, -c.2)`.) -/
+theorem cmul_conj_left {c : ℝ × ℝ} (hc : c.1 ^ 2 + c.2 ^ 2 = 1) (z : ℝ × ℝ) :
+    cmul c (cmul (c.1, -c.2) z) = z := by
+  apply Prod.ext <;> simp only [cmul_fst, cmul_snd]
+  · linear_combination z.1 * hc
+  · linear_combination z.2 * hc
+
+/-- Left-inverse identity for a unit `c`. -/
+theorem cmul_conj_right {c : ℝ × ℝ} (hc : c.1 ^ 2 + c.2 ^ 2 = 1) (z : ℝ × ℝ) :
+    cmul (c.1, -c.2) (cmul c z) = z := by
+  apply Prod.ext <;> simp only [cmul_fst, cmul_snd]
+  · linear_combination z.1 * hc
+  · linear_combination z.2 * hc
+
+/-- The planar isometry sending the directed unit segment `(a₀,a₁)` to `(b₀,b₁)`:
+    translate `a₀` to the origin, rotate by the unit number `c`, translate to `b₀`. -/
+noncomputable def segIsom (c a₀ b₀ : ℝ × ℝ) (hc : c.1 ^ 2 + c.2 ^ 2 = 1) : Isometry2D where
+  toFun p := b₀ + cmul c (p - a₀)
+  preserves_dist p q := by
+    have h1 : pointDist (b₀ + cmul c (p - a₀)) (b₀ + cmul c (q - a₀))
+            = pointDist (cmul c (p - a₀)) (cmul c (q - a₀)) := by
+      rw [add_comm b₀ (cmul c (p - a₀)), add_comm b₀ (cmul c (q - a₀))]
+      exact pointDist_add_right _ _ b₀
+    rw [h1, cmul_preserves hc]
+    have h2 : pointDist (p - a₀) (q - a₀) = pointDist p q := by
+      rw [sub_eq_add_neg p a₀, sub_eq_add_neg q a₀]
+      exact pointDist_add_right p q (-a₀)
+    rw [h2]
+  bijective := by
+    refine Function.bijective_iff_has_inverse.mpr
+      ⟨fun y => a₀ + cmul (c.1, -c.2) (y - b₀), ?_, ?_⟩
+    · intro p
+      simp only
+      rw [add_sub_cancel_left, cmul_conj_right hc, add_sub_cancel]
+    · intro y
+      simp only
+      rw [add_sub_cancel_left, cmul_conj_left hc, add_sub_cancel]
+
+-- ============================================================
+-- PART N5: All optimal 2-configurations are congruent
+-- ============================================================
+
+/-- **Uniqueness up to congruence.** Any two optimal 2-point configurations are
+    congruent: both are unit segments, and the explicit isometry `segIsom` rotates and
+    translates one onto the other. This is the content of "h(2) = 1". -/
+theorem optimal_two_congruent {P Q : PointConfig 2}
+    (hP : IsOptimal 2 P) (hQ : IsOptimal 2 Q) : AreCongruent 2 P Q := by
+  -- u = P 1 - P 0, w = Q 1 - Q 0 are unit vectors
+  set u : ℝ × ℝ := P 1 - P 0 with hu_def
+  set w : ℝ × ℝ := Q 1 - Q 0 with hw_def
+  have hu : u.1 ^ 2 + u.2 ^ 2 = 1 := by
+    have := optimal_two_normsq hP
+    simpa [hu_def, Prod.fst_sub, Prod.snd_sub] using this
+  have hw : w.1 ^ 2 + w.2 ^ 2 = 1 := by
+    have := optimal_two_normsq hQ
+    simpa [hw_def, Prod.fst_sub, Prod.snd_sub] using this
+  -- the unit rotation c = w * conj(u)
+  set c : ℝ × ℝ := (w.1 * u.1 + w.2 * u.2, w.2 * u.1 - w.1 * u.2) with hc_def
+  have hc : c.1 ^ 2 + c.2 ^ 2 = 1 := by
+    have : c.1 ^ 2 + c.2 ^ 2 = (w.1 ^ 2 + w.2 ^ 2) * (u.1 ^ 2 + u.2 ^ 2) := by
+      simp only [hc_def]; ring
+    rw [this, hu, hw]; ring
+  -- the isometry carrying P onto Q
+  refine ⟨segIsom c (P 0) (Q 0) hc, ?_⟩
+  intro i
+  fin_cases i
+  · -- Q 0 = σ (P 0)
+    show Q 0 = Q 0 + cmul c (P 0 - P 0)
+    rw [sub_self]
+    simp [cmul]
+  · -- Q 1 = σ (P 1)
+    show Q 1 = Q 0 + cmul c (P 1 - P 0)
+    have hcu : cmul c (P 1 - P 0) = w := by
+      apply Prod.ext <;>
+        simp only [cmul_fst, cmul_snd, hc_def, ← hu_def]
+      · linear_combination w.1 * hu
+      · linear_combination w.2 * hu
+    rw [hcu, hw_def]
+    abel
+
+-- ============================================================
+-- PART N6: hCong 2 = 1
+-- ============================================================
+
+/-- The optimal congruence quotient at `n = 2` is a subsingleton. -/
+instance subsingleton_quotient_two : Subsingleton (Quotient (OptimalSetoid 2)) := by
+  refine ⟨fun a b => ?_⟩
+  induction a using Quotient.inductionOn with
+  | _ P =>
+    induction b using Quotient.inductionOn with
+    | _ Q => exact Quotient.sound (optimal_two_congruent P.2 Q.2)
+
+/-- **Unconditional finiteness at `n = 2`** — discharges the `[Finite …]` hypothesis of
+    the parent non-degeneracy theorems at the first non-degenerate case. -/
+instance finite_quotient_two : Finite (Quotient (OptimalSetoid 2)) :=
+  Finite.of_subsingleton
+
+/-- **`hCong 2 = 1`.** There is exactly one optimal 2-point configuration up to
+    congruence (the unit segment) — the corrected count's value at the first
+    non-degenerate case, matching the parent file's unproven "h(2) = 1". -/
+theorem hCong_two_eq_one : hCong 2 = 1 := by
+  have hne : Nonempty (Quotient (OptimalSetoid 2)) :=
+    optimalQuotient_nonempty_of_exists 2 exists_optimal_two
+  exact Nat.card_eq_one_iff_unique.mpr ⟨subsingleton_quotient_two, hne⟩
+
+/-- **The corrected count strictly exceeds the degenerate raw count at `n = 2`.** The
+    raw cardinality collapses (`h 2 = 0`, the optimal set is translation-infinite) while
+    the congruence count is `1`. -/
+theorem hCong_two_strictly_exceeds_raw : h 2 < hCong 2 :=
+  hCong_strictly_exceeds_raw 2 (by norm_num) exists_optimal_two
+
+end Erdos103OQ02
+
+-- Export results
+#check @Erdos103OQ02.diameter_two
+#check @Erdos103OQ02.minDiameter_two
+#check @Erdos103OQ02.exists_optimal_two
+#check @Erdos103OQ02.optimal_two_gap
+#check @Erdos103OQ02.optimal_two_congruent
+#check @Erdos103OQ02.hCong_two_eq_one
+#check @Erdos103OQ02.hCong_two_strictly_exceeds_raw

--- a/proofs/Proofs/PythagoreanTriplesOQ02OQ01.lean
+++ b/proofs/Proofs/PythagoreanTriplesOQ02OQ01.lean
@@ -1,0 +1,101 @@
+/-
+  Pythagorean Triples: Complete Classification via Gaussian Integers
+
+  Open Question (pythagorean-triples-oq-02-oq-01), a sub-question of
+  `pythagorean-triples-oq-02` (Gaussian integers):
+
+  "Can the *classification* of all primitive Pythagorean triples be formalized?
+   Every primitive triple has the form (m²-n², 2mn, m²+n²) with gcd(m,n)=1 and
+   opposite parity.  This uses the UFD property of ℤ[i]."
+
+  The Gaussian-integer story behind the parametrization (developed in the parent
+  entry) is: squaring z = m + n·i gives
+
+        z² = (m² - n²) + (2mn)·i,        N(z²) = N(z)² = (m² + n²)²,
+
+  so the two legs (m²-n², 2mn) are the real/imaginary parts of z², and the
+  hypotenuse m²+n² is the Gaussian norm N(z).  This file connects that
+  parametrization map to the full classification.
+
+  Mathlib already proves the deep direction — that *every* primitive triple
+  arises this way — in `PythagoreanTriple.coprime_classification` (whose proof
+  rests on ℤ[i] being a UFD / the gcd theory of the integers).  We therefore
+  present this entry honestly as a **bridge**: the elementary forward facts
+  (the parametrization always yields a primitive triple) are proved here, and
+  the full biconditional classification is exported and packaged in the
+  Gaussian-parametrization language.
+
+  Tags: number-theory, gaussian-integers, pythagorean-triples, classification
+-/
+
+import Mathlib
+
+namespace PythagoreanTriplesOQ02OQ01
+
+open Int
+
+/-! ## The Gaussian-square parametrization -/
+
+/-- The parametrization map `(m, n) ↦ (m²-n², 2mn, m²+n²)`.  The first two
+components are the real and imaginary parts of the Gaussian square
+`(m + n·i)²`, and the third is the Gaussian norm `N(m + n·i) = m²+n²`. -/
+def paramTriple (m n : ℤ) : ℤ × ℤ × ℤ := (m ^ 2 - n ^ 2, 2 * m * n, m ^ 2 + n ^ 2)
+
+/-- The parametrization always produces a Pythagorean triple — the algebraic
+heart, i.e. `N(z²) = N(z)²` written out: `(m²-n²)² + (2mn)² = (m²+n²)²`. -/
+theorem paramTriple_isPythagorean (m n : ℤ) :
+    PythagoreanTriple (m ^ 2 - n ^ 2) (2 * m * n) (m ^ 2 + n ^ 2) := by
+  delta PythagoreanTriple; ring
+
+/-- Constructive (easy) direction of the classification: a coprime pair of
+opposite parity yields a **primitive** Pythagorean triple, i.e. the two legs
+`m²-n²` and `2mn` are coprime.
+
+(We derive coprimality from Mathlib's `coprime_classification` rather than the
+private lemma `coprime_sq_sub_mul`; the point here is the Gaussian framing.) -/
+theorem paramTriple_isPrimitive {m n : ℤ} (co : Int.gcd m n = 1)
+    (pp : m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :
+    Int.gcd (m ^ 2 - n ^ 2) (2 * m * n) = 1 :=
+  (PythagoreanTriple.coprime_classification
+      (x := m ^ 2 - n ^ 2) (y := 2 * m * n) (z := m ^ 2 + n ^ 2)).mpr
+    ⟨m, n, Or.inl ⟨rfl, rfl⟩, Or.inl rfl, co, pp⟩ |>.2
+
+/-! ## The complete classification (bridge to Mathlib) -/
+
+/-- **Complete classification of primitive Pythagorean triples**, packaged in
+the Gaussian-parametrization language.  An integer triple `(x, y, z)` is a
+primitive Pythagorean triple iff it arises from the parametrization map for some
+coprime, opposite-parity pair `(m, n)` (up to swapping the legs and the sign of
+`z`).
+
+The hard direction — every primitive triple has this shape — is
+`PythagoreanTriple.coprime_classification`, ultimately a consequence of unique
+factorization in ℤ[i]. -/
+theorem primitive_classification {x y z : ℤ} :
+    (PythagoreanTriple x y z ∧ Int.gcd x y = 1) ↔
+      ∃ m n,
+        (x = m ^ 2 - n ^ 2 ∧ y = 2 * m * n ∨ x = 2 * m * n ∧ y = m ^ 2 - n ^ 2) ∧
+          (z = m ^ 2 + n ^ 2 ∨ z = -(m ^ 2 + n ^ 2)) ∧
+            Int.gcd m n = 1 ∧ (m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) :=
+  PythagoreanTriple.coprime_classification
+
+/-- The sharper "standard form" when the odd leg `x` is taken positive and `z`
+is positive: there exist `m ≥ 0` and `n` with exactly
+`x = m²-n²,  y = 2mn,  z = m²+n²`, coprime and of opposite parity.  This is the
+textbook parametrization with no sign/order ambiguity. -/
+theorem primitive_classification_pos {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hpos : 0 < z) :
+    ∃ m n, x = m ^ 2 - n ^ 2 ∧ y = 2 * m * n ∧ z = m ^ 2 + n ^ 2 ∧
+      Int.gcd m n = 1 ∧ (m % 2 = 0 ∧ n % 2 = 1 ∨ m % 2 = 1 ∧ n % 2 = 0) ∧ 0 ≤ m :=
+  h.coprime_classification' hco hodd hpos
+
+/-- A clean number-theoretic corollary: the hypotenuse of any positive primitive
+Pythagorean triple (with odd leg `x`) is a sum of two squares, `z = m² + n²`.
+This is the Gaussian-integer fact `z = N(m + n·i)` made explicit. -/
+theorem hypotenuse_sum_of_squares {x y z : ℤ} (h : PythagoreanTriple x y z)
+    (hco : Int.gcd x y = 1) (hodd : x % 2 = 1) (hpos : 0 < z) :
+    ∃ m n, z = m ^ 2 + n ^ 2 := by
+  obtain ⟨m, n, _, _, hz, _⟩ := primitive_classification_pos h hco hodd hpos
+  exact ⟨m, n, hz⟩
+
+end PythagoreanTriplesOQ02OQ01

--- a/src/data/proofs/erdos-103-oq-02/meta.json
+++ b/src/data/proofs/erdos-103-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-103-oq-02",
   "title": "Erdos #103 OQ-02: Is h(n) ≥ 2 for all large n? (a formalization audit)",
   "slug": "erdos-103-oq-02",
-  "description": "Investigation of the 'weak conjecture' for Erdős Problem #103 — whether h(n) ≥ 2 for all sufficiently large n. The key finding is that the parent file's literal definition h(n) := Nat.card {P // IsOptimal n P} does NOT count incongruent configurations: because optimality is translation-invariant, the optimal set is either empty or infinite, so the raw cardinality is identically 0 for every n ≥ 1. Consequently the parent's literal WeakConjecture (and even h(n) ≥ 1) is false under its own definitions. This file proves the degeneracy, then supplies the corrected congruence-quotient count hCong(n) against which the open question is properly stated. The Erdős problem itself remains OPEN; this is a correction of the formalization, not a resolution.",
+  "description": "Investigation of the 'weak conjecture' for Erdős Problem #103 — whether h(n) ≥ 2 for all sufficiently large n. The key finding is that the parent file's literal definition h(n) := Nat.card {P // IsOptimal n P} does NOT count incongruent configurations: because optimality is translation-invariant, the optimal set is either empty or infinite, so the raw cardinality is identically 0 for every n ≥ 1. Consequently the parent's literal WeakConjecture (and even h(n) ≥ 1) is false under its own definitions. This file proves the degeneracy, then supplies the corrected congruence-quotient count hCong(n) against which the open question is properly stated. Companion files then compute hCong exactly in the small cases: Erdos103OQ02Finite.lean handles the degenerate cases n ≤ 1 (diameter ≡ 0), and Erdos103OQ02N2.lean handles the first NON-degenerate case n = 2, proving minDiameter 2 = 1 and that all optimal 2-point configurations are unit segments congruent to one another via an explicit planar isometry, hence hCong 2 = 1 — confirming with proof the parent's previously-unproven summary claim 'h(2) = 1'. The Erdős problem itself remains OPEN; this is a correction of the formalization plus exact small-case values, not a resolution.",
   "meta": {
     "author": "researcher-1",
     "sourceUrl": "https://erdosproblems.com/103",
@@ -40,7 +40,14 @@
       "optimalQuotient_nonempty_of_exists: the congruence-class quotient is nonempty whenever an optimal configuration exists (emptiness is never why hCong could vanish)",
       "hCong_pos_of_finite: given an optimal config and finitely many congruence classes, hCong(n) ≥ 1 — the corrected count is non-degenerate exactly where the raw count h ≡ 0 collapsed; only an infinite quotient could pull it to 0",
       "hCong_strictly_exceeds_raw: for n ≥ 1 with an optimal config and finitely many classes, h(n) = 0 < 1 ≤ hCong(n), making precise the sense in which the congruence count repairs the formalization",
-      "Repaired parent Erdos103Problem.lean: congruent_symm no longer compiled under Lean 4.26.0 (rwa auto-closing + rw target mismatch); fixed to restore the 0-axiom 0-sorry parent build"
+      "Repaired parent Erdos103Problem.lean: congruent_symm no longer compiled under Lean 4.26.0 (rwa auto-closing + rw target mismatch); fixed to restore the 0-axiom 0-sorry parent build",
+      "[companion Erdos103OQ02N2.lean] diameter_two: for a 2-point configuration the diameter (a double supremum over index pairs) equals the single pairwise distance pointDist (P 0) (P 1) — the first explicit evaluation of the diameter functional",
+      "[companion Erdos103OQ02N2.lean] minDiameter 2 = 1: two points with separation ≥ 1 cannot have diameter below 1, and the unit segment {(0,0),(1,0)} attains it (the first non-degenerate optimal value; for n ≤ 1 the diameter is identically 0)",
+      "[companion Erdos103OQ02N2.lean] optimal_two_gap: every optimal 2-point configuration realizes its two points at distance EXACTLY 1",
+      "[companion Erdos103OQ02N2.lean] cmul / cmul_preserves: complex multiplication on ℝ² and the fact that multiplication by a unit number (c.1²+c.2²=1) preserves pointDist — a reusable planar-isometry primitive",
+      "[companion Erdos103OQ02N2.lean] segIsom + optimal_two_congruent: an explicit isometry (translate, rotate by the unit number w·conj(u), translate) carrying any optimal unit segment onto any other, proving any two optimal 2-configurations are congruent",
+      "[companion Erdos103OQ02N2.lean] hCong_two_eq_one: hCong 2 = 1 (Subsingleton + nonempty optimal quotient), discharging the [Finite (Quotient (OptimalSetoid 2))] hypothesis unconditionally at the first non-degenerate case and confirming the parent's unproven 'h(2) = 1'",
+      "[companion Erdos103OQ02Finite.lean, prior session] hCong 0 = hCong 1 = 1: unconditional finiteness in the degenerate small cases n ≤ 1"
     ],
     "mathlibDependencies": [
       {
@@ -67,7 +74,7 @@
     "historicalContext": "Erdős Problem #103 (1994) asks whether h(n) → ∞, where h(n) counts incongruent sets of n points in ℝ² minimizing diameter with pairwise separation ≥ 1. Even the weak statement h(n) ≥ 2 for all large n is unknown. This investigation does not resolve the open question; instead it audits the existing formalization and discovers that the parent file's literal counting function is degenerate. Because optimality is preserved by the continuous translation group, the set of optimal configurations is closed under translation, hence either empty or infinite — so its Nat.card is 0. The intended quantity is the cardinality of the quotient by congruence, which this file defines as hCong. The fix relocates the open question onto the correct object.",
     "axiomCount": 0,
     "lineCount": 265,
-    "assumptions": "None. 0 axioms, 0 sorries. All results machine-checked from Mathlib and the (repaired) parent file. NOTE: this entry does NOT resolve the open Erdős #103 conjecture; it corrects the formalization so the open question is stated against the congruence count hCong.",
+    "assumptions": "None. 0 axioms, 0 sorries across the main file (Erdos103OQ02.lean) and both companion files (Erdos103OQ02Finite.lean, Erdos103OQ02N2.lean). All results machine-checked from Mathlib and the (repaired) parent file; #print axioms on hCong_two_eq_one, optimal_two_congruent, and minDiameter_two reports only [propext, Classical.choice, Quot.sound]. NOTE: this entry does NOT resolve the open Erdős #103 conjecture; it corrects the formalization so the open question is stated against the congruence count hCong, and computes hCong exactly for n ≤ 2 (hCong 0 = hCong 1 = hCong 2 = 1). The theoremCount/lineCount fields below describe the primary file Erdos103OQ02.lean; the companion files add further verified results.",
     "theoremCount": 13,
     "definitionCount": 4
   },
@@ -82,7 +89,8 @@
       "**The literal WeakConjecture is decidably false**: since h(max N 1) = 0 < 2, no threshold N can witness ∀ n ≥ N, h n ≥ 2.",
       "**The quotient repairs the count**: congruence collapses each translation-orbit to a single class, so hCong is finite/meaningful exactly where the raw count collapsed to 0.",
       "**Non-degeneracy is the right diagnostic**: the quotient is never empty when an optimal config exists, so the *only* way hCong could still read 0 is an infinite quotient. Hence finiteness of the congruence classes — precisely the content of the open question — is exactly what makes hCong well-behaved, and under it h(n) = 0 < 1 ≤ hCong(n).",
-      "**Audit, not resolution**: nothing here makes progress on whether hCong(n) ≥ 2 for large n — that remains the open Erdős question. The contribution is relocating the question onto a well-posed definition."
+      "**Audit, not resolution**: nothing here makes progress on whether hCong(n) ≥ 2 for large n — that remains the open Erdős question. The contribution is relocating the question onto a well-posed definition.",
+      "**n = 2 is the first honest case** (companion Erdos103OQ02N2.lean): below n = 2 the diameter is identically 0 and every configuration is trivially optimal, so finiteness of the congruence quotient is vacuous. At n = 2 the diameter becomes a genuine distance, minDiameter 2 = 1, and the optimal configurations are exactly the unit segments. Uniqueness up to congruence (hCong 2 = 1) is no longer automatic: it requires an actual planar isometry. The proof builds one as complex multiplication by the unit number w·conj(u) — preserving Euclidean distance because |c| = 1 turns the squared-norm identity into a single ring computation — sandwiched between two translations, carrying one unit segment onto the other."
     ],
     "prerequisites": [
       "Real analysis: Euclidean distance on ℝ²",

--- a/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02-oq-01/meta.json
@@ -1,0 +1,80 @@
+{
+  "id": "pythagorean-triples-oq-02-oq-01",
+  "title": "Pythagorean Triples: Complete Classification via Gaussian Integers",
+  "slug": "pythagorean-triples-oq-02-oq-01",
+  "description": "Open question OQ-01 of pythagorean-triples-oq-02: formalize the complete classification of primitive Pythagorean triples. Every primitive triple has the form (m²-n², 2mn, m²+n²) with gcd(m,n)=1 and m,n of opposite parity — the real/imaginary parts of the Gaussian square (m+ni)² together with its norm. This entry bridges Mathlib's PythagoreanTriple.coprime_classification into the Gaussian-parametrization language and proves the elementary forward facts directly.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/NumberTheory/PythagoreanTriples.html",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTriplesOQ02OQ01.lean",
+    "tags": ["number-theory", "gaussian-integers", "pythagorean-triples", "classification", "mathlib-bridge"],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-27",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {"theorem": "PythagoreanTriple.coprime_classification", "description": "Every primitive Pythagorean triple has the Euclidean parametric form (hard direction, via UFD of ℤ[i] / gcd theory)", "module": "Mathlib.NumberTheory.PythagoreanTriples"},
+      {"theorem": "PythagoreanTriple.coprime_classification'", "description": "Sharper standard-form classification for positive triples with odd leg", "module": "Mathlib.NumberTheory.PythagoreanTriples"},
+      {"theorem": "PythagoreanTriple", "description": "Definition x*x + y*y = z*z", "module": "Mathlib.NumberTheory.PythagoreanTriples"}
+    ],
+    "originalContributions": [
+      "Named Gaussian-square parametrization map paramTriple (m,n) ↦ (m²-n², 2mn, m²+n²), exhibiting the legs as Re/Im of (m+ni)² and the hypotenuse as the norm N(m+ni)",
+      "Direct proof that the parametrization always yields a Pythagorean triple (the identity N(z²)=N(z)²)",
+      "Derivation of leg-coprimality (primitivity) for coprime opposite-parity pairs from the public classification, avoiding Mathlib's private coprime_sq_sub_mul lemma",
+      "Packaging of the full biconditional classification in the Gaussian-parametrization language",
+      "Corollary: the hypotenuse of any positive primitive triple (odd leg) is a sum of two squares, z = m²+n² = N(m+ni)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 101,
+    "assumptions": "0 axioms, 0 sorries. All five theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, hence no Lean.ofReduceBool. This is a Mathlib BRIDGE: the deep direction of the classification (every primitive triple has the parametric form) is Mathlib's PythagoreanTriple.coprime_classification, which rests on unique factorization in ℤ[i]. Badge 'mathlib' reflects that the headline result is imported, not re-proved.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The parametrization of Pythagorean triples is classical (Euclid). The conceptual explanation is algebraic: in the Gaussian integers ℤ[i], a² + b² = N(a+bi) is a multiplicative norm, and squaring z = m + ni gives z² = (m²-n²) + (2mn)i with N(z²) = (m²+n²)². Thus every coprime opposite-parity pair (m,n) yields a primitive triple, and — via unique factorization in ℤ[i] — every primitive triple arises this way. Mathlib formalizes the full classification in PythagoreanTriple.coprime_classification.",
+    "problemStatement": "Classify all primitive Pythagorean triples: show $(x,y,z)$ with $x^2+y^2=z^2$ and $\\gcd(x,y)=1$ is, up to leg-swap and sign of $z$, exactly $(m^2-n^2,\\,2mn,\\,m^2+n^2)$ for some coprime $m,n$ of opposite parity.",
+    "text": "OQ-01 of the Gaussian-integers entry asks to formalize the classification of primitive Pythagorean triples. We bridge Mathlib's classification into the Gaussian-parametrization framework and prove the elementary forward facts directly.",
+    "proofStrategy": "Define the parametrization map paramTriple. Prove (a) it always yields a Pythagorean triple by the ring identity (m²-n²)²+(2mn)²=(m²+n²)²; (b) for coprime opposite-parity inputs the legs are coprime, derived from the reverse direction of coprime_classification; (c) export the full biconditional classification; (d) the sharper positive standard form via coprime_classification'; (e) the sum-of-two-squares corollary for the hypotenuse.",
+    "keyInsights": [
+      "**Legs = Re/Im of a Gaussian square**: (m²-n², 2mn) are exactly the components of (m+ni)², so the parametrization is 'square a Gaussian integer'.",
+      "**Hypotenuse = Gaussian norm**: m²+n² = N(m+ni), and N(z²)=N(z)² is precisely the Pythagorean relation.",
+      "**Why opposite parity and coprimality give primitivity**: these are exactly the conditions under which m+ni is (up to units) not divisible by 1+i, keeping the square primitive.",
+      "**The hard direction needs ℤ[i] UFD**: that every primitive triple comes from a single Gaussian square is unique factorization in disguise — supplied by Mathlib."
+    ],
+    "prerequisites": ["Gaussian integers and their norm", "Pythagorean triples", "gcd / coprimality over ℤ"]
+  },
+  "sections": [
+    {"id": "header", "title": "Module Documentation", "startLine": 1, "endLine": 38, "summary": "Statement of OQ-01, the Gaussian-square narrative, and the honest bridge framing.", "mathContext": "Mathematical content: the Gaussian-integer explanation of the parametrization."},
+    {"id": "param", "title": "The Gaussian-Square Parametrization", "startLine": 40, "endLine": 64, "summary": "paramTriple map, the always-a-triple identity, and primitivity for coprime opposite-parity inputs.", "mathContext": "Mathematical content: forward (constructive) direction."},
+    {"id": "classification", "title": "The Complete Classification", "startLine": 66, "endLine": 101, "summary": "Full biconditional classification (bridge), the positive standard form, and the hypotenuse sum-of-squares corollary.", "mathContext": "Mathematical content: the classification packaged in Gaussian language."}
+  ],
+  "conclusion": {
+    "summary": "We formalize the classification of primitive Pythagorean triples requested in OQ-01, bridging Mathlib's PythagoreanTriple.coprime_classification into the Gaussian-parametrization language. The forward direction (parametrization yields primitive triples) is proved directly; the deep converse is imported. Five theorems, 0 sorries, 0 axioms.",
+    "implications": "Completes the Gaussian-integer thread of the Pythagorean-triples gallery by tying the algebraic z ↦ z² picture to the full classification, and exposes the hypotenuse-is-a-sum-of-two-squares corollary, connecting to Fermat's two-squares theorem (the sibling OQ-02 of the parent).",
+    "openQuestions": [
+      "Is there a Lean proof of Fermat's two-squares theorem p ≡ 1 (mod 4) ⟺ p = a²+b² in the same Gaussian framework? (parent OQ-02 #2)",
+      "Can the framework be transported to Eisenstein integers ℤ[ω] to characterize Loeschian numbers a²-ab+b²? (parent OQ-02 #3)"
+    ]
+  },
+  "crossReferences": [
+    {"relationship": "parent", "description": "Answers OQ-01 of pythagorean-triples-oq-02, which develops the Gaussian-integer norm and squaring map.", "targetId": "pythagorean-triples-oq-02"},
+    {"relationship": "related", "description": "The base Pythagorean-triples entry and its parametric formula.", "targetId": "pythagorean-triples"}
+  ],
+  "references": [
+    {"authors": ["leanprover-community"], "title": "Mathlib4: Mathlib.NumberTheory.PythagoreanTriples", "venue": "Mathlib4 documentation", "year": "2026", "note": "Provides PythagoreanTriple.coprime_classification and coprime_classification', the formal classification of primitive Pythagorean triples used as the bridge target."}
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Int"],
+    "namespace": "PythagoreanTriplesOQ02OQ01",
+    "lineCount": 101,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/PythagoreanTriplesOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-103-oq-02.json
+++ b/src/data/research/problems/erdos-103-oq-02.json
@@ -19,21 +19,22 @@
   },
   "currentState": {
     "phase": "COMPLETED",
-    "since": "2026-06-26",
-    "iteration": 2,
-    "focus": "Formalization audit of the counting function h(n); supplied corrected congruence-quotient definition.",
+    "since": "2026-06-27",
+    "iteration": 3,
+    "focus": "First non-degenerate case n = 2: proved minDiameter 2 = 1 and hCong 2 = 1 via an explicit planar isometry (complex multiplication by a unit number). Companion file Erdos103OQ02N2.lean, 0-axiom verified.",
     "blockers": [
-      "The open Erdős #103 weak conjecture (hCong(n) >= 2 for large n) is genuinely open and not addressed by this session."
+      "The open Erdős #103 weak conjecture (hCong(n) >= 2 for large n) is genuinely open and not addressed by this session.",
+      "hCong(n) for n >= 3 requires reasoning about non-collinear optimal configurations; the n = 2 argument exploits that all unit segments are congruent, which has no direct n >= 3 analogue."
     ],
-    "nextAction": "Future work: study finiteness/compactness of the optimal-configuration space modulo congruence; attempt hCong(4).",
+    "nextAction": "Future work: attempt hCong(3) (optimal = equilateral triangle of side 1, conjecturally unique up to congruence) reusing the cmul planar-isometry primitive; then study finiteness/compactness of the optimal-configuration space modulo congruence for general n.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "VERIFIED (offline, Mathlib 2df2f015 / Lean v4.26.0, 0 sorry / 0 axiom): added Erdos103OQ02Finite.lean nailing down the degenerate base cases the conditional parent machinery left implicit. For n <= 1 the optimal congruence quotient is a nonempty Subsingleton, so it is unconditionally Finite; this discharges the [Finite (Quotient (OptimalSetoid n))] hypothesis of hCong_pos_of_finite / hCong_strictly_exceeds_raw and yields hCong 0 = hCong 1 = 1 and the strict gap h 1 = 0 < 1 = hCong 1. The open content (unconditional finiteness for general/large n and hCong n >= 2) is untouched and remains open.",
+    "progressSummary": "VERIFIED (offline, Lean v4.26.0, 0 sorry / 0 axiom; #print axioms = [propext, Classical.choice, Quot.sound]): added Erdos103OQ02N2.lean resolving the FIRST NON-DEGENERATE case n = 2. Unlike n <= 1 (diameter identically 0, every config trivially optimal), at n = 2 the diameter is a genuine distance. Proved: diameter_two (the diameter of a pair equals its single pairwise distance), minDiameter 2 = 1 (separation >= 1 forbids smaller, the unit segment attains it), optimal_two_gap (every optimal pair is at distance exactly 1), and the crux optimal_two_congruent: any two optimal 2-configs are congruent via an EXPLICIT isometry built as complex multiplication by the unit number w*conj(u) sandwiched between two translations. Hence Subsingleton/Finite (Quotient (OptimalSetoid 2)) and hCong 2 = 1, confirming with proof the parent's previously-unproven summary claim 'h(2) = 1'. Combined with the prior session (n <= 1), hCong is now exactly computed for n in {0,1,2}, all = 1. The open content (hCong n >= 2 for large n, finiteness for general n) remains open.",
     "builtItems": [
       "Erdos103OQ02.lean (0-axiom, 0-sorry, verified)",
       "pointDist_add_right: Euclidean distance on R^2 is translation-invariant",
@@ -47,7 +48,13 @@
       "Erdos103OQ02Finite.lean: all_congruent_zero / all_congruent_one (every config congruent for n<=1)",
       "Erdos103OQ02Finite.lean: subsingleton_quotient_zero/one + finite_quotient_zero/one (unconditional Finite instances for the optimal quotient at n=0,1)",
       "Erdos103OQ02Finite.lean: exists_optimal_of_le_one (optimal config exists for n<=1) via minDiameter_eq_zero_of_le_one",
-      "Erdos103OQ02Finite.lean: hCong_zero_eq_one, hCong_one_eq_one, hCong_one_strictly_exceeds_raw (unconditional, [Finite] discharged)"
+      "Erdos103OQ02Finite.lean: hCong_zero_eq_one, hCong_one_eq_one, hCong_one_strictly_exceeds_raw (unconditional, [Finite] discharged)",
+      "Erdos103OQ02N2.lean: diameter_two (diameter of a 2-config = pointDist (P 0) (P 1), via ciSup_le / le_ciSup over Fin 2)",
+      "Erdos103OQ02N2.lean: minDiameter_two (minDiameter 2 = 1), segTwo + segTwo_valid + segTwo_diameter (the unit segment witness), exists_optimal_two",
+      "Erdos103OQ02N2.lean: optimal_two_gap (optimal pair at distance exactly 1), optimal_two_normsq",
+      "Erdos103OQ02N2.lean: cmul + cmul_preserves + cmul_conj_left/right (complex-multiplication planar-isometry primitive; |c|=1 => preserves pointDist, bijective)",
+      "Erdos103OQ02N2.lean: segIsom (explicit Isometry2D: translate, rotate by unit number, translate) and optimal_two_congruent (any two optimal 2-configs congruent)",
+      "Erdos103OQ02N2.lean: subsingleton_quotient_two + finite_quotient_two + hCong_two_eq_one (hCong 2 = 1) + hCong_two_strictly_exceeds_raw (h 2 = 0 < 1 = hCong 2)"
     ],
     "insights": [
       "Counting 'configurations up to symmetry' MUST quotient by the symmetry group explicitly: an un-quotiented Nat.card collapses to 0 under any continuous symmetry (here, translation).",
@@ -55,14 +62,17 @@
       "The optimal set is a union of full translation-orbits, hence empty or uncountable; the congruence quotient restores finiteness/meaning.",
       "The sibling OQ-01 axiomatized h and h_pos (h(n)>=1), which this audit shows is inconsistent with the parent's LITERAL h -- OQ-01's h must denote the intended quotient count hCong.",
       "Unconditional finiteness holds in the degenerate small cases: for n <= 1 every pair of optimal configurations is congruent (n=0: PointConfig 0 = Fin 0 -> R^2 is a subsingleton; n=1: any two single points differ by the translation Q0 - P0), so Quotient (OptimalSetoid n) is a Subsingleton, hence Finite. This discharges the [Finite ...] typeclass hypothesis carried by hCong_pos_of_finite / hCong_strictly_exceeds_raw at n=0,1.",
-      "minDiameter n = 0 for n <= 1 (diameter is identically 0 below the n>=2 threshold and the constant-zero config is valid), so an optimal configuration exists for n<=1 and hCong 0 = hCong 1 = 1 unconditionally; at n=1 the raw count still collapses (h 1 = 0), giving the strict gap h 1 < hCong 1 with no finiteness assumption."
+      "minDiameter n = 0 for n <= 1 (diameter is identically 0 below the n>=2 threshold and the constant-zero config is valid), so an optimal configuration exists for n<=1 and hCong 0 = hCong 1 = 1 unconditionally; at n=1 the raw count still collapses (h 1 = 0), giving the strict gap h 1 < hCong 1 with no finiteness assumption.",
+      "n = 2 is the first case where finiteness of the congruence quotient is NON-trivial: the diameter becomes a real distance (minDiameter 2 = 1) and optimal configs are the unit segments, but uniqueness up to congruence needs an actual isometry rather than a translation. Representing ℝ² as ℂ, multiplication by a unit number c (c.1²+c.2²=1) is a rotation that preserves pointDist by the Lagrange/Brahmagupta–Fibonacci identity ((c1²+c2²)(d1²+d2²) is a perfect sum of two squares), reducing the distance-preservation proof to one `nlinarith`/`linear_combination`. The rotation c = w·conj(u) sends the directed unit segment of P onto that of Q.",
+      "Reusable takeaway for n >= 3: the cmul primitive (complex multiplication as a planar isometry) and the translate-rotate-translate template generalize; the obstacle at n = 3 is purely combinatorial-geometric (showing the optimal config is the unit equilateral triangle and that any two are related by a SINGLE global isometry, where a reflection may be required), not analytic."
     ],
     "mathlibGaps": [
       "No gap blocked this session. Finiteness of the optimal-configuration space modulo congruence (needed to make hCong provably finite) would require a compactness/quotient argument not yet built."
     ],
     "nextSteps": [
-      "Prove Finite (Quotient (OptimalSetoid n)) for n >= 2 (the genuine open content; needs compactness/algebraicity of optimal configs mod congruence).",
-      "Establish existence of an optimal configuration for n >= 2 (minDiameter achieved), currently assumed via the (exists P, IsOptimal n P) hypotheses."
+      "Attempt hCong(3) = 1: the optimal 3-config is the unit equilateral triangle; prove minDiameter 3 = 1 and that any two optimal 3-configs are congruent (reuse cmul; a reflection may be needed in addition to rotation).",
+      "Prove Finite (Quotient (OptimalSetoid n)) for general n (the genuine open content; needs compactness/algebraicity of optimal configs mod congruence).",
+      "Establish existence of an optimal configuration for general n >= 3 (minDiameter achieved), currently assumed via the (exists P, IsOptimal n P) hypotheses."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Advances the Erdős #103 OQ-02 investigation to the **first non-degenerate case n = 2**.

The prior sessions audited the parent's degenerate raw count `h(n) ≡ 0`, supplied the corrected congruence count `hCong`, and computed it only for `n ≤ 1` — the *degenerate* range where `diameter ≡ 0` and every configuration is trivially optimal. This PR adds a new companion file **`Erdos103OQ02N2.lean`** handling `n = 2`, where the diameter becomes a genuine distance.

### Results (all 0-axiom verified)
- **`diameter_two`** — the diameter of a 2-point configuration (a double `⨆` over index pairs) equals the single pairwise distance `pointDist (P 0) (P 1)`.
- **`minDiameter_two : minDiameter 2 = 1`** — separation `≥ 1` forbids any smaller diameter, and the unit segment `{(0,0),(1,0)}` attains it.
- **`exists_optimal_two`**, **`optimal_two_gap`** — an optimal pair exists, and every optimal pair sits at distance *exactly* 1.
- **`optimal_two_congruent`** — the crux: any two optimal 2-configurations are congruent, via an **explicit planar isometry**. Identifying ℝ² with ℂ, multiplication by the unit number `c = w·conj(u)` is a rotation that preserves `pointDist` (the Brahmagupta–Fibonacci identity `(c₁²+c₂²)(d₁²+d₂²)` collapses the distance-preservation proof to one `linear_combination`/`nlinarith`); sandwiched between two translations it carries one unit segment onto the other.
- **`hCong_two_eq_one : hCong 2 = 1`** — `Subsingleton` + nonempty optimal quotient, discharging the `[Finite (Quotient (OptimalSetoid 2))]` hypothesis unconditionally and **confirming with proof** the parent file's previously-unproven summary claim "h(2) = 1".
- **`hCong_two_strictly_exceeds_raw : h 2 = 0 < 1 = hCong 2`**.

Combined with the prior session, `hCong` is now exactly computed for `n ∈ {0,1,2}` (all `= 1`).

### Verification
- Built offline with `safe-build.sh` (Lean v4.26.0, cached Mathlib); **0 errors, 0 sorries, 0 `axiom` declarations, no `native_decide`**.
- `#print axioms` on `hCong_two_eq_one`, `optimal_two_congruent`, `minDiameter_two` → only `[propext, Classical.choice, Quot.sound]` (the standard foundational axioms; none counted per the axiom-integrity policy).

### Scope / honesty
This does **not** resolve the open Erdős question (`hCong n ≥ 2` for large `n`). It is an exact small-case computation plus a reusable planar-isometry primitive (`cmul`). The `n ≥ 3` obstacle is combinatorial-geometric (the unit equilateral triangle, possibly needing a reflection), not analytic — the `cmul` template should transfer.

`meta.theoremCount`/`lineCount` continue to describe the primary `proofRepoPath` file `Erdos103OQ02.lean`; the companion file's results are documented in `originalContributions`/`assumptions` prose (matching the precedent of the sibling `Erdos103OQ02Finite.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)