### PR TITLE
Enrich Linnik Constant Lower Bound (dirichlets-theorem-oq-03-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-admissible-def",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "definition",
+    "title": "Admissible Exponents and the Critical Exponent",
+    "content": "`admissible f b` is the set of exponents L > 0 for which the growth function f obeys a uniform power-law bound f i ≤ c·(b i)^L over the base b (for some c > 0). `criticalExponent f b = sInf (admissible f b)` is its infimum. In the Linnik instance f i is the least prime ≡ a (mod q) and b i = q, so the critical exponent is exactly the parent's Linnik constant L*. Keeping f and b abstract is the design decision that makes the whole file axiom-free — the deep number theory enters only through the hypotheses fed to these definitions.",
+    "mathContext": "$$\\mathrm{admissible}(f,b) = \\{\\,L>0 : \\exists c>0,\\ \\forall i,\\ f_i \\le c\\,b_i^{\\,L}\\,\\},\\qquad \\mathrm{criticalExponent} = \\inf \\mathrm{admissible}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["critical exponent", "power-law bound", "infimum (sInf)", "Linnik constant"],
+    "prerequisites": ["set-builder definitions in Lean", "conditional infimum sInf"]
+  },
+  {
+    "id": "ann-admissible-ge-one",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 53, "endLine": 86 },
+    "type": "insight",
+    "title": "The Abstract Lower Bound — a Sub-Linear Power Law Is Impossible",
+    "content": "`admissible_ge_one` is the heart: if f dominates an unbounded base b ≥ 1, every admissible L is ≥ 1. Proof by contradiction. An admissible L gives b i ≤ f i ≤ c·b i^L, so dividing yields b i^(1−L) ≤ c for ALL i (the rpow_sub step e1 rewrites b i^(1−L) = b i / b i^L). If L < 1 then 1−L > 0, and the explicit threshold t = c^(1/(1−L)) satisfies t^(1−L) = c exactly (htc, via rpow_mul + one_div_mul_cancel). Choosing i with b i > max(t,1) — possible since the base is unbounded — gives t^(1−L) < b i^(1−L) by strict rpow monotonicity, i.e. c < b i^(1−L) ≤ c, the contradiction. This is a number-theory-free principle: a quantity dominating an unbounded base of size ≥ 1 cannot obey a power law with exponent below 1.",
+    "mathContext": "$$b_i \\le c\\,b_i^{\\,L} \\implies b_i^{\\,1-L} \\le c;\\quad L<1,\\ b_i > c^{1/(1-L)} \\implies b_i^{\\,1-L} > c \\;\\Rightarrow\\; \\bot$$",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "Real.rpow monotonicity", "rpow threshold c^(1/(1-L))", "unbounded growth"],
+    "prerequisites": ["Real.rpow_sub", "Real.rpow_mul", "Real.rpow_lt_rpow", "div_le_iff"]
+  },
+  {
+    "id": "ann-critical-ge-one",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 88, "endLine": 95 },
+    "type": "technique",
+    "title": "From Every Admissible Exponent to the Infimum",
+    "content": "`criticalExponent_ge_one` lifts the per-exponent bound to the infimum: since 1 is a lower bound for the admissible set (every member is ≥ 1 by admissible_ge_one), and the set is nonempty, le_csInf concludes 1 ≤ sInf (admissible f b). The nonemptiness hypothesis hne is exactly where Linnik/Dirichlet existence would be needed — the file takes it as an explicit assumption rather than proving it, preserving the axiom-free status.",
+    "mathContext": "$$(\\forall L \\in \\mathrm{admissible},\\ 1 \\le L)\\ \\wedge\\ \\mathrm{admissible} \\ne \\emptyset \\;\\Longrightarrow\\; 1 \\le \\inf \\mathrm{admissible}$$",
+    "significance": "key",
+    "relatedConcepts": ["le_csInf", "infimum lower bound", "nonemptiness hypothesis", "conditional completeness"],
+    "prerequisites": ["le_csInf from the csInf API", "admissible_ge_one"]
+  },
+  {
+    "id": "ann-prime-domination",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 101, "endLine": 108 },
+    "type": "insight",
+    "title": "The Elementary Number Theory: a Prime ≡ 1 (mod q) Exceeds q",
+    "content": "`prime_one_mod_ge` is the single number-theoretic input, and it is completely elementary: any prime p ≡ 1 (mod q) satisfies q ≤ p. From p ≡ 1 (mod q) one gets q ∣ p − 1 (Nat.modEq_iff_dvd'), and since p ≥ 2 (primality) p − 1 ≥ 1, so q ≤ p − 1 < p by Nat.le_of_dvd + omega. This is the crux of the entry's thesis: the lower bound L* ≥ 1 needs NO analytic depth — not Linnik's theorem, not zero-free regions, not Bertrand's postulate. The parent's comment invoking a 'Bertrand variant' overstates the requirement.",
+    "mathContext": "$$p \\equiv 1 \\pmod q \\;\\Rightarrow\\; q \\mid p-1 \\;\\Rightarrow\\; q \\le p-1 < p$$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.modEq_iff_dvd'", "divisibility", "Nat.le_of_dvd", "least prime in AP"],
+    "prerequisites": ["modular arithmetic ≡ [MOD q]", "q ∣ p−1", "omega"]
+  },
+  {
+    "id": "ann-synthesis",
+    "proofId": "dirichlets-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 114, "endLine": 137 },
+    "type": "insight",
+    "title": "Synthesis: the Linnik Constant Is ≥ 1, Axiom-Free",
+    "content": "`linnikConstant_ge_one` instantiates the abstract theorem at f = (q ↦ P(q+1)) and base b = (q ↦ q+1), where P is any selector of primes P(q+1) ≡ 1 (mod q+1). The three hypotheses of criticalExponent_ge_one are discharged: base ≥ 1 (q+1 ≥ 1, push_cast + linarith); domination b ≤ f, i.e. q+1 ≤ P(q+1), exactly prime_one_mod_ge applied to hP; and unboundedness via exists_nat_gt. This resolves the parent's linnikConstant_pos sorry with zero analytic input — the Dirichlet/Linnik existence survives only as the explicit selector hP and nonemptiness hne. Combined with the parent's Xylouris upper bound L* ≤ 5, the constant is pinned to [1, 5] with the lower endpoint now machine-checked.",
+    "mathContext": "$$f_q = P(q{+}1),\\ b_q = q{+}1:\\quad b_q \\le f_q \\text{ (prime}\\equiv 1),\\ b_q \\ge 1,\\ b_q \\to \\infty \\;\\Rightarrow\\; L^* \\ge 1$$",
+    "significance": "critical",
+    "relatedConcepts": ["Linnik constant", "Dirichlet's theorem", "Xylouris L* ≤ 5", "exists_nat_gt", "axiom-free synthesis"],
+    "prerequisites": ["criticalExponent_ge_one", "prime_one_mod_ge", "exists_nat_gt", "ℕ→ℝ cast (push_cast)"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `dirichlets-theorem-oq-03-oq-01-oq-01` (The Linnik Constant is at Least 1: the Lower Bound, Axiom-Free). The meta.json was already very rich (overview, keyInsights, structured conclusion, sections, references); the only gap was a **missing annotations.json**.

## Added
- **annotations.json** — 5 inline annotations covering all declarations: the abstract `admissible`/`criticalExponent` definitions, the contradiction-based `admissible_ge_one` (a quantity dominating an unbounded base ≥ 1 cannot obey a sub-linear power law — via the rpow threshold c^(1/(1−L))), the `le_csInf` lift `criticalExponent_ge_one`, the elementary domination `prime_one_mod_ge` (prime ≡ 1 mod q ⟹ q ≤ p), and the axiom-free synthesis `linnikConstant_ge_one` confining L* to [1,5].

Each carries `mathContext` (LaTeX), a valid `significance` enum, `relatedConcepts`, and `prerequisites`.

**Validation:** JSON valid; `gallery:check-size` passes (meta 12.5 KB, under cap); `annotations:build` confirms all 5 line ranges resolve to Lean constructs with no warnings. (Full `tsc/vite` build constrained by host disk pressure; change is pure JSON and every JSON-relevant step passed.) Axiom integrity unchanged: `verified`/`original`, 0 axioms, 0 sorries.