### PR TITLE
Enrich Furstenberg's Infinitude of Primes (infinitude-primes-oq-01)

### DIFF
--- a/src/data/proofs/infinitude-primes-oq-01/annotations.json
+++ b/src/data/proofs/infinitude-primes-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-topology",
+    "proofId": "infinitude-primes-oq-01",
+    "range": { "startLine": 53, "endLine": 86 },
+    "type": "definition",
+    "title": "The Evenly Spaced Integer Topology",
+    "content": "`IsOpenAP U` declares U open when every point x ∈ U is surrounded by a full two-sided arithmetic progression x + dℤ ⊆ U (d > 0); IsClosedAP C means Cᶜ is open. The entry deliberately works with this open-set PREDICATE rather than a TopologicalSpace ℤ instance, to avoid clashing with Mathlib's standard topology on ℤ — purely cosmetic, since the three axioms are verified: isOpenAP_univ, isOpenAP_sUnion (arbitrary unions), and the only non-trivial one, isOpenAP_inter, which handles a binary intersection by MULTIPLYING the two spacings (d₁·d₂ divides y−x ⟹ both d₁ and d₂ do).",
+    "mathContext": "$$\\mathrm{IsOpenAP}(U) := \\forall x \\in U,\\ \\exists d > 0,\\ x + d\\mathbb{Z} \\subseteq U;\\qquad \\text{finite }\\cap\\text{ via } d = d_1 d_2$$",
+    "significance": "supporting",
+    "relatedConcepts": ["arithmetic progression topology", "open-set axioms", "Furstenberg topology", "basis of clopen sets"],
+    "prerequisites": ["point-set topology axioms", "divisibility in ℤ", "finite intersections of opens"]
+  },
+  {
+    "id": "ann-nonempty-infinite",
+    "proofId": "infinitude-primes-oq-01",
+    "range": { "startLine": 88, "endLine": 102 },
+    "type": "insight",
+    "title": "Nonempty Open Sets Are Infinite — the Whole Obstruction",
+    "content": "`IsOpenAP.infinite_of_nonempty` is the engine of the contradiction: a nonempty open U contains an entire progression x + dℤ, which is the injective image of n ↦ x + n·d (injective because d ≠ 0, via mul_right_cancel₀), so U is infinite (infinite_range_of_injective + .mono). The consequence that drives everything: NO nonempty finite set can be open. Furstenberg's proof needs nothing more topological than this single principle.",
+    "mathContext": "$$U \\text{ open},\\ U \\ne \\emptyset \\;\\Rightarrow\\; \\{x + nd : n \\in \\mathbb{Z}\\} \\subseteq U,\\ \\text{injective in } n \\;\\Rightarrow\\; U \\text{ infinite}$$",
+    "significance": "key",
+    "relatedConcepts": ["infinite_range_of_injective", "arithmetic progression", "injectivity", "Set.Infinite.mono"],
+    "prerequisites": ["injective image of an infinite set is infinite", "mul_right_cancel₀"]
+  },
+  {
+    "id": "ann-clopen-residue",
+    "proofId": "infinitude-primes-oq-01",
+    "range": { "startLine": 104, "endLine": 126 },
+    "type": "insight",
+    "title": "Residue Classes Are Clopen",
+    "content": "The residue class R a d = {y | d ∣ (y−a)} is the basic open set. `isOpenAP_residue` proves it open: if d ∣ (y−x) and d ∣ (x−a) then d ∣ (y−a) (dvd_add), so the progression x + dℤ stays inside. `isClosedAP_residue` proves it CLOSED by the symmetric observation — being OUTSIDE R a d (¬ d ∣ (x−a)) is also stable under shifting by multiples of d, since d ∣ (y−a) and d ∣ (y−x) would force d ∣ (x−a) (dvd_sub). This clopen-ness — open and closed simultaneously — is exactly what lets a finite union of residue classes be closed.",
+    "mathContext": "$$R(a,d) = \\{y : d \\mid (y-a)\\};\\quad \\text{open: } d\\mid(y{-}x)\\wedge d\\mid(x{-}a) \\Rightarrow d\\mid(y{-}a);\\quad \\text{closed dually}$$",
+    "significance": "key",
+    "relatedConcepts": ["clopen set", "residue class", "congruence stability", "dvd_add / dvd_sub"],
+    "prerequisites": ["divisibility arithmetic", "complement of an open set", "congruence mod d"]
+  },
+  {
+    "id": "ann-finite-union-closed",
+    "proofId": "infinitude-primes-oq-01",
+    "range": { "startLine": 128, "endLine": 149 },
+    "type": "technique",
+    "title": "Finite Unions of Closed Sets Are Closed",
+    "content": "`isClosedAP_union` proves a binary union closed via De Morgan: (C ∪ D)ᶜ = Cᶜ ∩ Dᶜ, an intersection of opens (isOpenAP_inter). `isClosedAP_biUnion` then extends this to any finite (Finset-indexed) union by induction on the Finset, with isClosedAP_empty as the base. This is what makes 'finitely many primes' bite: a finite union of the clopen residue classes R 0 p is closed, so its complement is open.",
+    "mathContext": "$$(C \\cup D)^c = C^c \\cap D^c;\\qquad \\bigcup_{i \\in s} C_i \\text{ closed by induction on the Finset } s$$",
+    "significance": "supporting",
+    "relatedConcepts": ["De Morgan's laws", "Finset.induction", "finite union", "closedness"],
+    "prerequisites": ["complement of a union", "isOpenAP_inter", "induction over a Finset"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "infinitude-primes-oq-01",
+    "range": { "startLine": 151, "endLine": 202 },
+    "type": "insight",
+    "title": "Furstenberg's Contradiction",
+    "content": "`infinitude_of_primes` proves {p | p.Prime}.Infinite topologically. Assume the prime set is finite, as a Finset P. Then A = ⋃_{p∈P} R 0 p is a finite union of clopen residue classes, hence closed (hAclosed). The key identification hcompl: Aᶜ = {x | x.natAbs = 1}, proved both ways using Nat.exists_prime_and_dvd (every n ≠ 1 has a prime factor) and Int.natAbs_dvd_natAbs — the integers with NO prime factor are exactly ±1. So Aᶜ is open (complement of closed) and nonempty (1 ∈ Aᶜ), hence INFINITE by infinite_of_nonempty. But Aᶜ = {1, −1} is finite (Set.Finite.subset). Contradiction. Notably the proof never invokes Mathlib's Nat.infinite_setOf_prime, so it is an independent topological argument, not a repackaging of Euclid.",
+    "mathContext": "$$A = \\bigcup_{p \\in P} R(0,p) \\text{ closed} \\Rightarrow A^c = \\{-1,1\\} \\text{ open} \\Rightarrow \\text{infinite},\\ \\text{but } |\\{-1,1\\}| = 2 \\;\\Rightarrow\\; \\bot$$",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "Nat.exists_prime_and_dvd", "Int.natAbs", "Furstenberg's theorem", "proofs from THE BOOK"],
+    "prerequisites": ["existence of prime factors", "clopen residue classes", "nonempty opens are infinite", "Finset of a finite set"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `infinitude-primes-oq-01` (Furstenberg's Topological Proof of the Infinitude of Primes). The meta.json was already excellent (detailed overview, sections, references); the only gap was a **missing annotations.json**.

## Added
- **annotations.json** — 5 inline annotations covering: the evenly spaced integer topology (`IsOpenAP` + the three axioms, finite ∩ via d₁·d₂), `IsOpenAP.infinite_of_nonempty` (nonempty opens are infinite — the entire obstruction), clopen residue classes `R a d` (open and closed by congruence stability), finite unions of closed sets (De Morgan + Finset induction), and `infinitude_of_primes` (the contradiction: Aᶜ = {±1} would be a nonempty finite open set; never uses Mathlib's Nat.infinite_setOf_prime).

Each carries `mathContext` (LaTeX), a valid `significance` enum, `relatedConcepts`, and `prerequisites`.

**Validation:** JSON valid; `gallery:check-size` passes (meta 14.6 KB, under cap); `annotations:build` confirms all 5 line ranges resolve to Lean constructs with no warnings. (Full `tsc/vite` build constrained by host disk pressure; change is pure JSON and every JSON-relevant step passed.) Axiom integrity unchanged: `verified`/`original`, 0 axioms, 0 sorries.