### PR TITLE
research(de-moivre-oq-02-oq-03-oq-02): degree & leading coeff of Chebyshev Tₙ [verified, 0-axiom, original]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ03OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ03OQ02.lean
@@ -1,0 +1,126 @@
+/-
+# Degree and Leading Coefficient of the Chebyshev Polynomials Tₙ
+
+For the first-kind Chebyshev polynomials `T n` (Mathlib's `Polynomial.Chebyshev.T`)
+over `ℤ`, this file proves the two facts that Mathlib's `Chebyshev` file lists as
+open TODOs ("Compute zeroes and extrema", which presuppose the degree):
+
+* `natDegree (T ℤ n) = n`;
+* `leadingCoeff (T ℤ n) = 2 ^ (n - 1)`  (so `Tₙ` has leading coefficient `2ⁿ⁻¹`
+  for `n ≥ 1`, and `T₀ = 1`).
+
+Mathlib provides the defining three-term recurrence
+`T (n+2) = 2·X·T (n+1) − T n` with `T 0 = 1`, `T 1 = X`, but records no degree
+or leading-coefficient lemma; both results here are fresh.
+
+## Strategy
+
+A single two-step induction on `n` tracking `natDegree` and `leadingCoeff`
+simultaneously.  Base cases `T 0 = 1` (degree 0, leading coeff `1 = 2⁰`) and
+`T 1 = X` (degree 1, leading coeff `1 = 2⁰`).  For the step, write
+`T (n+2) = 2·X·T (n+1) − T n`.  Over the domain `ℤ`:
+
+* `2·X·T (n+1)` has degree `1 + (n+1) = n+2` and leading coefficient
+  `2 · 2ⁿ = 2ⁿ⁺¹` (degree and leading coefficient are additive/multiplicative
+  on products of nonzero polynomials);
+* `T n` has degree `n < n+2`, so subtracting it changes neither the degree
+  nor the leading coefficient of the `n+2` term.
+
+Hence `natDegree (T (n+2)) = n+2` and `leadingCoeff (T (n+2)) = 2ⁿ⁺¹`, completing
+the induction.  Using `ℕ`-subtraction in the exponent `2 ^ (n-1)` makes the
+formula uniform across `n = 0` (`2⁰ = 1`) without a special case.
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.
+-/
+import Mathlib
+
+open Polynomial Polynomial.Chebyshev
+
+namespace DeMoivreOQ02OQ03OQ02
+
+/-- `2 * X` over `ℤ` has `natDegree` one and leading coefficient `2`. -/
+theorem natDegree_two_mul_X : (2 * X : ℤ[X]).natDegree = 1 := by
+  have : (2 * X : ℤ[X]) = C 2 * X := by simp
+  rw [this, natDegree_C_mul (by norm_num : (2 : ℤ) ≠ 0), natDegree_X]
+
+theorem leadingCoeff_two_mul_X : (2 * X : ℤ[X]).leadingCoeff = 2 := by
+  have : (2 * X : ℤ[X]) = C 2 * X := by simp
+  rw [this, leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X, mul_one]
+
+theorem two_mul_X_ne_zero : (2 * X : ℤ[X]) ≠ 0 := by
+  intro h
+  have := congrArg natDegree h
+  rw [natDegree_two_mul_X, natDegree_zero] at this
+  exact one_ne_zero this
+
+/-- **Degree and leading coefficient of `Tₙ`.**  Over `ℤ`, the `n`-th first-kind
+Chebyshev polynomial has degree `n` and leading coefficient `2 ^ (n-1)`. -/
+theorem T_natDegree_leadingCoeff (n : ℕ) :
+    (T ℤ (n : ℤ)).natDegree = n ∧ (T ℤ (n : ℤ)).leadingCoeff = 2 ^ (n - 1) := by
+  induction n using Nat.twoStepInduction with
+  | zero =>
+      constructor
+      · simp
+      · simp
+  | one =>
+      constructor
+      · simp [T_one]
+      · simp [T_one]
+  | more n ih0 ih1 =>
+      obtain ⟨hd0, hl0⟩ := ih0
+      obtain ⟨hd1, hl1⟩ := ih1
+      -- The defining recurrence, with the index cast through ℕ.
+      have hrec : T ℤ ((n + 2 : ℕ) : ℤ)
+          = 2 * X * T ℤ ((n + 1 : ℕ) : ℤ) - T ℤ ((n : ℕ) : ℤ) := by
+        have h := T_add_two ℤ (n : ℤ)
+        push_cast
+        push_cast at h
+        linear_combination h
+      -- `T (n+1) ≠ 0` since its leading coefficient `2ⁿ` is nonzero.
+      have hTn1_ne : T ℤ ((n + 1 : ℕ) : ℤ) ≠ 0 := by
+        intro h0
+        rw [h0, leadingCoeff_zero] at hl1
+        have : (2 : ℤ) ^ (n + 1 - 1) ≠ 0 := pow_ne_zero _ (by norm_num)
+        exact this hl1.symm
+      -- Degree and leading coefficient of `A := 2·X·T (n+1)`.
+      have hdA : (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).natDegree = n + 2 := by
+        rw [natDegree_mul two_mul_X_ne_zero hTn1_ne, natDegree_two_mul_X, hd1]
+        omega
+      have hlA : (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ (n + 1) := by
+        rw [leadingCoeff_mul, leadingCoeff_two_mul_X, hl1]
+        have : n + 1 - 1 = n := by omega
+        rw [this]; ring
+      -- `T n` has strictly smaller degree.
+      have hdeg_lt : (T ℤ ((n : ℕ) : ℤ)).natDegree
+          < (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).natDegree := by
+        rw [hdA, hd0]; omega
+      constructor
+      · rw [hrec, natDegree_sub_eq_left_of_natDegree_lt hdeg_lt, hdA]
+      · rw [hrec]
+        have hsub : (2 * X * T ℤ ((n + 1 : ℕ) : ℤ) - T ℤ ((n : ℕ) : ℤ)).leadingCoeff
+            = (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff := by
+          rw [sub_eq_add_neg]
+          rw [leadingCoeff_add_of_degree_lt']
+          rw [degree_neg]
+          exact degree_lt_degree hdeg_lt
+        rw [hsub, hlA]
+        have : n + 2 - 1 = n + 1 := by omega
+        rw [this]
+
+/-- **Degree of `Tₙ`.**  `natDegree (T ℤ n) = n`. -/
+theorem T_natDegree (n : ℕ) : (T ℤ (n : ℤ)).natDegree = n :=
+  (T_natDegree_leadingCoeff n).1
+
+/-- **Leading coefficient of `Tₙ`.**  `leadingCoeff (T ℤ n) = 2 ^ (n-1)`
+(so `Tₙ` has leading coefficient `2ⁿ⁻¹` for `n ≥ 1`, and `T₀ = 1`). -/
+theorem T_leadingCoeff (n : ℕ) : (T ℤ (n : ℤ)).leadingCoeff = 2 ^ (n - 1) :=
+  (T_natDegree_leadingCoeff n).2
+
+/-- For `n ≥ 1`, the leading coefficient of `Tₙ` is `2ⁿ⁻¹`, written without
+truncated subtraction. -/
+theorem T_leadingCoeff_succ (n : ℕ) :
+    (T ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ n := by
+  have := T_leadingCoeff (n + 1)
+  simpa using this
+
+end DeMoivreOQ02OQ03OQ02

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-dm-oq020302-setup",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Setup: The Missing Degree Lemma for Chebyshev Tₙ",
+    "content": "The file proves natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1) for the first-kind Chebyshev polynomials over ℤ. Mathlib defines T via the recurrence T(n+2) = 2·X·T(n+1) − T n with T 0 = 1, T 1 = X, and even lists 'Compute zeroes and extrema' and 'Prove minimax properties' as TODOs — but records neither the degree nor the leading coefficient, which those TODOs silently presuppose. The parent gallery entry (the Chebyshev minimax theorem, which normalizes by 2ⁿ⁻¹) lists exactly these as an open question. The strategy is one simultaneous two-step induction carrying both quantities.",
+    "mathContext": "$T_n(\\cos\\theta) = \\cos(n\\theta)$ has degree $n$ and leading coefficient $2^{n-1}$ for $n \\ge 1$; $T_0 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.Chebyshev.T",
+      "natDegree",
+      "leadingCoeff",
+      "Chebyshev recurrence"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first kind",
+      "polynomial degree and leading coefficient",
+      "two-step induction"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-twox",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 42, "endLine": 54 },
+    "type": "technique",
+    "title": "Degree Bookkeeping for the Factor 2·X",
+    "content": "Three short helpers over ℤ[X] isolate the arithmetic of the recurrence's multiplier 2·X: natDegree (2·X) = 1 (rewriting 2·X = C 2 · X and using natDegree_C_mul with 2 ≠ 0, then natDegree_X), leadingCoeff (2·X) = 2 (via leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X), and 2·X ≠ 0 (a nonzero polynomial cannot have natDegree 1 and be 0). Keeping these separate makes the inductive step's product computation a single natDegree_mul / leadingCoeff_mul application.",
+    "mathContext": "$\\deg(2X) = 1$, $\\mathrm{lc}(2X) = 2$, $2X \\neq 0$ over $\\mathbb{Z}[X]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.natDegree_C_mul",
+      "Polynomial.leadingCoeff_mul",
+      "Polynomial.leadingCoeff_C",
+      "Polynomial.natDegree_X"
+    ],
+    "prerequisites": [
+      "degree and leading coefficient of a constant times X",
+      "ℤ[X] is an integral domain"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-induction",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 56, "endLine": 109 },
+    "type": "key-step",
+    "title": "Simultaneous Two-Step Induction on Degree and Leading Coefficient",
+    "content": "T_natDegree_leadingCoeff proves the conjunction natDegree (T ℤ n) = n ∧ leadingCoeff (T ℤ n) = 2^(n−1) by Nat.twoStepInduction. Base cases (T 0 = 1, T 1 = X) are discharged by simp with T_one. In the step, the recurrence T(n+2) = 2·X·T(n+1) − T n is obtained from Mathlib's T_add_two with the index cast through ℕ (push_cast + linear_combination). The leading-coefficient hypothesis from the previous step doubles as the proof that T(n+1) ≠ 0 (its leading coefficient 2ⁿ is nonzero), which natDegree_mul needs. Then 2·X·T(n+1) has degree 1 + (n+1) = n+2 and leading coefficient 2·2ⁿ = 2ⁿ⁺¹, while T n has degree n < n+2, so natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' (after sub_eq_add_neg, degree_lt_degree) carry both facts to T(n+2).",
+    "mathContext": "Step: $T_{n+2} = 2X\\,T_{n+1} - T_n$; $\\deg(2X\\,T_{n+1}) = n+2$, $\\mathrm{lc} = 2^{n+1}$, and $\\deg T_n = n < n+2$ leaves them unchanged.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.twoStepInduction",
+      "Polynomial.natDegree_mul",
+      "Polynomial.natDegree_sub_eq_left_of_natDegree_lt",
+      "Polynomial.leadingCoeff_add_of_degree_lt'",
+      "Polynomial.Chebyshev.T_add_two"
+    ],
+    "prerequisites": [
+      "the Chebyshev recurrence",
+      "degree/leading-coefficient calculus over a domain",
+      "two-step induction with two inductive hypotheses"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-corollaries",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 111, "endLine": 126 },
+    "type": "concept",
+    "title": "Extracted Theorems for Downstream Use",
+    "content": "T_natDegree and T_leadingCoeff project the two conjuncts of the induction into standalone statements. T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as the clean 2ⁿ (without truncated subtraction), which is the form the minimax/extremal theory uses when normalizing Tₙ to the monic Tₙ/2ⁿ⁻¹.",
+    "mathContext": "$\\deg T_n = n$, $\\mathrm{lc}(T_n) = 2^{n-1}$, and $\\mathrm{lc}(T_{n+1}) = 2^{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "leadingCoeff",
+      "monic normalization",
+      "Chebyshev minimax"
+    ],
+    "prerequisites": [
+      "projecting a conjunction",
+      "truncated vs ordinary subtraction in exponents"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "de-moivre-oq-02-oq-03-oq-02",
+  "title": "Degree and Leading Coefficient of the Chebyshev Polynomials Tₙ",
+  "slug": "de-moivre-oq-02-oq-03-oq-02",
+  "description": "A direct answer to the open question recorded with the parent Chebyshev minimax entry, and a gap in Mathlib itself: for the first-kind Chebyshev polynomials T n (Mathlib's Polynomial.Chebyshev.T) over ℤ, natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1). Equivalently, Tₙ is a degree-n polynomial whose leading coefficient is 2ⁿ⁻¹ for n ≥ 1 (and T₀ = 1, T₁ = X). Mathlib supplies the defining three-term recurrence T(n+2) = 2·X·T(n+1) − T n with base cases T 0 = 1, T 1 = X, and explicitly lists 'Compute zeroes and extrema of Chebyshev polynomials' and the minimax property as TODOs — both of which presuppose exactly the degree and leading-coefficient facts proved here, neither of which Mathlib currently records. The proof is a single two-step induction tracking natDegree and leadingCoeff simultaneously: in the step, T(n+2) = 2·X·T(n+1) − T n, and over the integral domain ℤ the product 2·X·T(n+1) has degree 1 + (n+1) = n+2 and leading coefficient 2·2ⁿ = 2ⁿ⁺¹, while the subtracted T n has strictly smaller degree n, so it perturbs neither the degree nor the leading coefficient of the top term. Writing the exponent with truncated subtraction 2^(n−1) makes the leading-coefficient formula uniform across n = 0 without a special case.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib); classical facts about Chebyshev polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ02OQ03OQ02.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "polynomial-degree",
+      "leading-coefficient",
+      "polynomials",
+      "induction",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lean Proofs/DeMoivreOQ02OQ03OQ02.lean` against prebuilt Mathlib oleans, exit 0; `#print axioms T_natDegree_leadingCoeff` lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). No native_decide. Mathlib supplies the Chebyshev recurrence and base cases (`Polynomial.Chebyshev.T_add_two`, `T_zero`, `T_one`) and the polynomial degree/leading-coefficient calculus used (`Polynomial.natDegree_mul`, `Polynomial.leadingCoeff_mul`, `Polynomial.natDegree_C_mul`, `Polynomial.natDegree_sub_eq_left_of_natDegree_lt`, `Polynomial.leadingCoeff_add_of_degree_lt'`, `Polynomial.degree_lt_degree`) but does NOT record the degree or leading coefficient of Tₙ; both are proved here.",
+    "dateAdded": "2026-06-27",
+    "originalContributions": [
+      "T_natDegree: natDegree (T ℤ n) = n for the first-kind Chebyshev polynomial over ℤ — a fact Mathlib's Chebyshev development does not contain, despite listing the dependent 'zeroes and extrema' computation as a TODO.",
+      "T_leadingCoeff: leadingCoeff (T ℤ n) = 2^(n−1) (truncated subtraction, uniform at n = 0), with the n ≥ 1 form T_leadingCoeff_succ giving leadingCoeff (T ℤ (n+1)) = 2ⁿ.",
+      "A clean simultaneous two-step induction (T_natDegree_leadingCoeff) that carries degree and leading coefficient together, so the lower-degree subtraction in the recurrence is dispatched once via natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt'."
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Chebyshev polynomials of the first kind, defined by Tₙ(cos θ) = cos(nθ) (the de Moivre connection — expanding cos(nθ) via (cos θ + i sin θ)ⁿ produces Tₙ), are central to approximation theory: the monic scaling Tₙ/2ⁿ⁻¹ is the degree-n monic polynomial of least sup-norm on [−1,1] (the minimax property treated in the parent entry). That extremal statement, and the location of the zeros and extrema, all rest on the elementary fact that Tₙ has degree n with leading coefficient 2ⁿ⁻¹. Mathlib formalizes the Chebyshev recurrence and many trigonometric/derivative identities but, as of this writing, records neither the degree nor the leading coefficient; its source file lists 'Compute zeroes and extrema' and 'Prove minimax properties' as open TODOs. This entry supplies the missing degree/leading-coefficient lemmas.",
+    "problemStatement": "Prove that for every natural number $n$, the first-kind Chebyshev polynomial $T_n$ over $\\mathbb{Z}$ satisfies $\\deg T_n = n$ and (for $n \\ge 1$) has leading coefficient $2^{n-1}$, with $T_0 = 1$.",
+    "text": "The headline results `T_natDegree (n : ℕ) : (T ℤ n).natDegree = n` and `T_leadingCoeff (n : ℕ) : (T ℤ n).leadingCoeff = 2 ^ (n − 1)`, both extracted from the simultaneous induction `T_natDegree_leadingCoeff`. A succinct n ≥ 1 form `T_leadingCoeff_succ : (T ℤ (n+1)).leadingCoeff = 2 ^ n` is also provided.",
+    "proofStrategy": "Two-step induction (`Nat.twoStepInduction`) on n, proving the conjunction natDegree (T ℤ n) = n ∧ leadingCoeff (T ℤ n) = 2^(n−1). Base cases: T 0 = 1 has degree 0 and leading coefficient 1 = 2⁰; T 1 = X has degree 1 and leading coefficient 1 = 2⁰. Step: rewrite T(n+2) = 2·X·T(n+1) − T n (from Mathlib's T_add_two, with the index cast through ℕ). Set A = 2·X·T(n+1). Over the domain ℤ, natDegree A = natDegree(2·X) + natDegree(T(n+1)) = 1 + (n+1) = n+2 (natDegree_mul, with 2·X ≠ 0 and T(n+1) ≠ 0 because its leading coefficient 2ⁿ ≠ 0), and leadingCoeff A = leadingCoeff(2·X)·leadingCoeff(T(n+1)) = 2·2ⁿ = 2ⁿ⁺¹ (leadingCoeff_mul). Since natDegree (T n) = n < n+2, subtracting T n preserves both: natDegree (A − T n) = natDegree A by natDegree_sub_eq_left_of_natDegree_lt, and leadingCoeff (A − T n) = leadingCoeff A by leadingCoeff_add_of_degree_lt' (after sub_eq_add_neg and degree_lt_degree). This closes the induction with natDegree (T(n+2)) = n+2 and leadingCoeff (T(n+2)) = 2ⁿ⁺¹ = 2^((n+2)−1).",
+    "keyInsights": [
+      "Tracking natDegree and leadingCoeff together is what makes the induction go through: the leading-coefficient hypothesis (2ⁿ ≠ 0) is exactly the witness that T(n+1) ≠ 0, which the degree calculus for the product 2·X·T(n+1) requires.",
+      "Working over the integral domain ℤ keeps degree additive and leading coefficient multiplicative on products (natDegree_mul / leadingCoeff_mul) with no monic hypotheses — the Chebyshev polynomials are not monic for n ≥ 2, so a monic-based argument would not apply.",
+      "The subtracted lower-degree term T n is handled once, generically: natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' encapsulate 'a strictly-lower-degree perturbation changes neither the degree nor the leading coefficient'.",
+      "Writing the leading coefficient as 2^(n−1) with truncated natural subtraction absorbs the n = 0 base case (2⁰ = 1) into the same formula used for all n, avoiding a separate statement for T₀."
+    ],
+    "prerequisites": [
+      "The first-kind Chebyshev polynomials and their recurrence T(n+2) = 2·X·T(n+1) − T n (Mathlib's Polynomial.Chebyshev.T)",
+      "Degree and leading-coefficient calculus over an integral domain (natDegree_mul, leadingCoeff_mul, natDegree_sub_eq_left_of_natDegree_lt)",
+      "Two-step induction on ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring stating the degree and leading-coefficient results for Tₙ, noting that Mathlib records the recurrence but lists the dependent 'zeroes and extrema'/minimax computations as TODOs, and outlining the simultaneous two-step induction. Opens Polynomial and Polynomial.Chebyshev under the namespace.",
+      "mathContext": "Targets $\\deg T_n = n$ and $\\mathrm{lc}(T_n) = 2^{n-1}$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "two-x-helpers",
+      "title": "Degree Facts for 2·X",
+      "startLine": 42,
+      "endLine": 54,
+      "summary": "Small helper lemmas over ℤ[X]: natDegree (2·X) = 1 (via natDegree_C_mul and natDegree_X), leadingCoeff (2·X) = 2 (via leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X), and 2·X ≠ 0. These feed the product-degree computation in the inductive step.",
+      "mathContext": "$\\deg(2X) = 1$, $\\mathrm{lc}(2X) = 2$, $2X \\ne 0$."
+    },
+    {
+      "id": "main-induction",
+      "title": "Simultaneous Degree/Leading-Coefficient Induction",
+      "startLine": 56,
+      "endLine": 109,
+      "summary": "T_natDegree_leadingCoeff: by Nat.twoStepInduction, proves natDegree (T ℤ n) = n ∧ leadingCoeff (T ℤ n) = 2^(n−1). Base cases use T_zero / T_one. The step rewrites the recurrence (T_add_two with ℕ-cast index), shows 2·X·T(n+1) has degree n+2 and leading coefficient 2ⁿ⁺¹, and uses that T n has strictly smaller degree to conclude via natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt'.",
+      "mathContext": "Inductive step: $T_{n+2} = 2X\\,T_{n+1} - T_n$, with $\\deg(2X\\,T_{n+1}) = n+2 > n = \\deg T_n$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Extracted Degree and Leading-Coefficient Theorems",
+      "startLine": 111,
+      "endLine": 126,
+      "summary": "T_natDegree and T_leadingCoeff project the two halves of the induction; T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as 2ⁿ (no truncated subtraction), the form most convenient for downstream minimax/extremal use.",
+      "mathContext": "$\\deg T_n = n$; $\\mathrm{lc}(T_n) = 2^{n-1}$; $\\mathrm{lc}(T_{n+1}) = 2^{n}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over ℤ, the first-kind Chebyshev polynomial Tₙ is shown to have degree n and leading coefficient 2^(n−1), with 0 axioms and 0 sorries, by a single two-step induction tracking both quantities through the recurrence T(n+2) = 2·X·T(n+1) − T n. These are exactly the facts Mathlib's Chebyshev file leaves as the unstated prerequisites of its open 'zeroes and extrema' and minimax TODOs, and the parent gallery entry lists them as an open question; neither is currently in Mathlib.",
+    "openQuestions": [
+      "Establish the analogous degree/leading-coefficient pair for the second-kind Chebyshev polynomials Uₙ: natDegree (U ℤ n) = n and leadingCoeff (U ℤ n) = 2ⁿ, from the same recurrence U(n+2) = 2·X·U(n+1) − U n with U 0 = 1, U 1 = 2·X.",
+      "Use natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1) to prove that the monic rescaling Tₙ/2ⁿ⁻¹ has all n roots in [−1,1] (the Chebyshev nodes cos((2k−1)π/2n)), the first concrete step toward Mathlib's 'compute zeroes and extrema' TODO."
+    ],
+    "implications": "The degree and leading coefficient of Tₙ are the foundation for every quantitative statement about Chebyshev polynomials: the monic normalization Tₙ/2ⁿ⁻¹ used in the minimax theorem, the count and location of roots/extrema, and the explicit power-sum expansions. Recording them as standalone, domain-level lemmas gives the gallery (and a prospective Mathlib contribution) the missing base layer beneath the Chebyshev extremal theory."
+  },
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Answers the open question listed in the parent Chebyshev minimax entry ('Upstream natDegree(Tₙ) = n, leadingCoeff(Tₙ) = 2^(n−1) … to Mathlib'). The minimax theorem there uses the monic normalization Tₙ/2ⁿ⁻¹, whose validity rests on the leading-coefficient fact proved here."
+    }
+  ],
+  "references": [
+    {
+      "author": "Rivlin, T. J.",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory",
+      "year": 1990,
+      "note": "Standard reference: Tₙ has degree n and leading coefficient 2ⁿ⁻¹; minimax property"
+    },
+    {
+      "author": "Mason, J. C.; Handscomb, D. C.",
+      "title": "Chebyshev Polynomials",
+      "year": 2002,
+      "note": "Recurrence Tₙ₊₁ = 2x Tₙ − Tₙ₋₁ and elementary degree/coefficient facts"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DeMoivreOQ02OQ03OQ02",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ02OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves, for the first-kind Chebyshev polynomials `T n` (Mathlib's `Polynomial.Chebyshev.T`) over ℤ:

- **`T_natDegree`** : `natDegree (T ℤ n) = n`
- **`T_leadingCoeff`** : `leadingCoeff (T ℤ n) = 2^(n-1)` (and `T_leadingCoeff_succ` : `leadingCoeff (T ℤ (n+1)) = 2^n`)

This answers the open question recorded with the parent entry `de-moivre-oq-02-oq-03` (the Chebyshev minimax theorem, which normalizes by `2^(n-1)`), and fills a genuine gap in Mathlib: Mathlib records the Chebyshev recurrence and base cases but **no** degree or leading-coefficient lemma, while its source file lists "Compute zeroes and extrema" and "Prove minimax properties" as TODOs — both of which silently presuppose exactly these facts.

## Proof

A single two-step induction (`Nat.twoStepInduction`) tracking `natDegree` and `leadingCoeff` simultaneously through `T(n+2) = 2·X·T(n+1) − T n`. Over the domain ℤ, `2·X·T(n+1)` has degree `n+2` and leading coefficient `2^(n+1)`, while `T n` has strictly smaller degree `n`, so the subtraction changes neither the degree nor the leading coefficient of the top term. Truncated subtraction in the exponent `2^(n-1)` makes the formula uniform at `n = 0`.

## Verification

- **Status:** `verified`, badge `original`
- **Offline build:** single-file elaboration `lean Proofs/DeMoivreOQ02OQ03OQ02.lean` against prebuilt Mathlib oleans, exit 0 (Docker host unavailable this session — containerd I/O error).
- **Axioms:** `#print axioms T_natDegree_leadingCoeff` → `propext, Classical.choice, Quot.sound` only → **0 axioms** per the project policy. No `native_decide`, 0 sorries.
- 7 theorems, 126 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)