### PR TITLE
research(erdos-156-incomplete-01): fill 3 Sidon-shadow counting sorries (UNVERIFIED)

### DIFF
--- a/proofs/Proofs/Erdos156Problem.lean
+++ b/proofs/Proofs/Erdos156Problem.lean
@@ -392,7 +392,7 @@ theorem sidon_sumset_size (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
     (hfin.prod hfin).subset (fun p hp => ⟨hp.1, hp.2.1⟩)
   rw [Set.ncard_image_of_injOn (sidon_sum_injOn A hA) hpairs_fin]
   -- Convert Set.ncard to Finset.card
-  rw [hpairs_fin.ncard_eq_toFinset_card', hfin.ncard_eq_toFinset_card']
+  rw [Set.ncard_eq_toFinset_card _ hpairs_fin, Set.ncard_eq_toFinset_card _ hfin]
   -- Show the pair set's toFinset equals the filtered product
   have h_eq : hpairs_fin.toFinset =
       (hfin.toFinset ×ˢ hfin.toFinset).filter (fun p : ℕ × ℕ => p.1 ≤ p.2) := by
@@ -413,7 +413,7 @@ theorem sidon_of_sumset_size (A : Set ℕ) (hfin : A.Finite)
   have hS_fin : S.Finite := (hfin.prod hfin).subset fun p hp => ⟨hp.1, hp.2.1⟩
   -- |S| = n(n+1)/2
   have h_S : S.ncard = A.ncard * (A.ncard + 1) / 2 := by
-    rw [hS_fin.ncard_eq_toFinset_card', hfin.ncard_eq_toFinset_card']
+    rw [Set.ncard_eq_toFinset_card _ hS_fin, Set.ncard_eq_toFinset_card _ hfin]
     convert card_upper_tri hfin.toFinset using 1
     congr 1; ext ⟨a, b⟩
     simp only [Set.Finite.mem_toFinset, Set.mem_setOf_eq,
@@ -619,19 +619,62 @@ lemma greedySidon_complement_in_shadow (N k : ℕ) (hkN : k ∈ Interval N)
       greedySidon_mono k' N (by omega) hcA,
       heq⟩
 
-/-- The diffShadow of A has size at most |A| * |sumset A| -/
+/-- The sumset of any finite set has size at most |A|*(|A|+1)/2.
+    (For Sidon sets this is an equality; here we only need the upper bound,
+    which holds for every finite set since the sumset is the image of the
+    upper-triangular pairs.) -/
+lemma sumset_ncard_le (A : Set ℕ) (hfin : A.Finite) :
+    (sumset A).ncard ≤ A.ncard * (A.ncard + 1) / 2 := by
+  classical
+  have hscard : (hfin.toFinset).card = A.ncard := (Set.ncard_eq_toFinset_card A hfin).symm
+  -- The coercion of the upper-triangular filtered product equals the index set
+  have hFP : (↑((hfin.toFinset ×ˢ hfin.toFinset).filter (fun p : ℕ × ℕ => p.1 ≤ p.2))
+      : Set (ℕ × ℕ)) = {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2} := by
+    ext p
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_product,
+               Set.Finite.mem_toFinset, Set.mem_setOf_eq]
+    tauto
+  rw [sumset_eq_image]
+  calc ((fun p : ℕ × ℕ => p.1 + p.2) '' {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2}).ncard
+      ≤ ({p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2}).ncard := by
+        apply Set.ncard_image_le
+        rw [← hFP]; exact Finset.finite_toSet _
+    _ = ((hfin.toFinset ×ˢ hfin.toFinset).filter (fun p : ℕ × ℕ => p.1 ≤ p.2)).card := by
+        rw [← hFP, Set.ncard_coe_finset]
+    _ = (hfin.toFinset).card * ((hfin.toFinset).card + 1) / 2 := card_upper_tri _
+    _ = A.ncard * (A.ncard + 1) / 2 := by rw [hscard]
+
+/-- The diffShadow of A has size at most |A| * |sumset A| ≤ |A| * (|A|*(|A|+1)/2).
+    Every element of diffShadow A is `σ - a` for some `a ∈ A` and `σ ∈ sumset A`,
+    so diffShadow A is contained in the image of `A ×ˢ sumset A`. -/
 lemma diffShadow_ncard_le (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
     (diffShadow A).ncard ≤ A.ncard * (A.ncard * (A.ncard + 1) / 2) := by
-  -- diffShadow A ⊆ ⋃ a ∈ A, {σ - a | σ ∈ sumset A, σ > a}
-  -- Each fiber has size ≤ |sumset A| = |A|*(|A|+1)/2 (by sidon_sumset_size)
-  sorry
+  have hsfin : (sumset A).Finite := sumset_finite A hfin
+  have hprodfin : (A ×ˢ sumset A).Finite := hfin.prod hsfin
+  have hsub : diffShadow A ⊆ (fun p : ℕ × ℕ => p.2 - p.1) '' (A ×ˢ sumset A) := by
+    rintro x ⟨a, b, c, haA, hbA, hcA, heq⟩
+    exact ⟨(a, b + c), ⟨haA, b, c, hbA, hcA, rfl⟩, by show b + c - a = x; omega⟩
+  calc (diffShadow A).ncard
+      ≤ ((fun p : ℕ × ℕ => p.2 - p.1) '' (A ×ˢ sumset A)).ncard :=
+        Set.ncard_le_ncard hsub (hprodfin.image _)
+    _ ≤ (A ×ˢ sumset A).ncard := Set.ncard_image_le hprodfin
+    _ = A.ncard * (sumset A).ncard := Set.ncard_prod
+    _ ≤ A.ncard * (A.ncard * (A.ncard + 1) / 2) := by
+        gcongr; exact sumset_ncard_le A hfin
 
-/-- The midShadow of A has size at most |A|*(|A|+1)/2 -/
+/-- The midShadow of A has size at most |A|*(|A|+1)/2.
+    Every midpoint `x` satisfies `2x = σ ∈ sumset A`, so `x = σ / 2`; thus
+    midShadow A is contained in the image of sumset A under `σ ↦ σ / 2`. -/
 lemma midShadow_ncard_le (A : Set ℕ) (hfin : A.Finite) :
     (midShadow A).ncard ≤ A.ncard * (A.ncard + 1) / 2 := by
-  -- midShadow A ⊆ image of sumset A under λ σ, σ/2 (for even σ)
-  -- size ≤ |sumset A|, and |sumset A| ≤ |A|*(|A|+1)/2
-  sorry
+  have hsfin : (sumset A).Finite := sumset_finite A hfin
+  have hsub : midShadow A ⊆ (fun σ : ℕ => σ / 2) '' sumset A := by
+    rintro x ⟨b, c, hbA, hcA, heq⟩
+    exact ⟨b + c, ⟨b, c, hbA, hcA, rfl⟩, by show (b + c) / 2 = x; omega⟩
+  calc (midShadow A).ncard
+      ≤ ((fun σ : ℕ => σ / 2) '' sumset A).ncard := Set.ncard_le_ncard hsub (hsfin.image _)
+    _ ≤ (sumset A).ncard := Set.ncard_image_le hsfin
+    _ ≤ A.ncard * (A.ncard + 1) / 2 := sumset_ncard_le A hfin
 
 /--
 Greedy Sidon N^{1/3} lower bound (framework):
@@ -647,6 +690,52 @@ theorem greedySidon_cube_lower_bound (N n : ℕ)
     N ≤ n + n * (n * (n + 1) / 2) + n * (n + 1) / 2 := by
   -- Counting: Interval N ⊆ greedySidon N ∪ diffShadow(greedySidon N) ∪ midShadow(greedySidon N)
   -- |Interval N| = N, |greedySidon N| = n, |diffShadow| ≤ n*(n*(n+1)/2), |midShadow| ≤ n*(n+1)/2
-  sorry
+  set A := greedySidon N with hA_def
+  have hAfin : A.Finite := greedySidon_finite N
+  have hsidon : IsSidonSet A := greedySidon_is_sidon N
+  have hsfin : (sumset A).Finite := sumset_finite A hAfin
+  -- n = |A|
+  have hn' : n = A.ncard := by
+    have hsz : size A = A.ncard := by
+      unfold size; rw [dif_pos hAfin, ← Set.ncard_eq_toFinset_card A hAfin]
+    rw [hn, hsz]
+  -- diffShadow and midShadow are finite
+  have hdfin : (diffShadow A).Finite := by
+    apply Set.Finite.subset ((hAfin.prod hsfin).image (fun p : ℕ × ℕ => p.2 - p.1))
+    rintro x ⟨a, b, c, haA, hbA, hcA, heq⟩
+    exact ⟨(a, b + c), ⟨haA, b, c, hbA, hcA, rfl⟩, by show b + c - a = x; omega⟩
+  have hmfin : (midShadow A).Finite := by
+    apply Set.Finite.subset (hsfin.image (fun σ : ℕ => σ / 2))
+    rintro x ⟨b, c, hbA, hcA, heq⟩
+    exact ⟨b + c, ⟨b, c, hbA, hcA, rfl⟩, by show (b + c) / 2 = x; omega⟩
+  -- The interval is covered by A and its two shadows
+  have hcover : Interval N ⊆ A ∪ diffShadow A ∪ midShadow A := by
+    intro k hk
+    by_cases hkA : k ∈ A
+    · exact Or.inl (Or.inl hkA)
+    · rcases greedySidon_complement_in_shadow N k hk hkA with h1 | h2
+      · exact Or.inl (Or.inr h1)
+      · exact Or.inr h2
+  -- |Interval N| = N
+  have hIcard : (Interval N).ncard = N := by
+    have heq : Interval N = ↑(Finset.Icc 1 N) := by
+      ext x
+      simp only [Interval, Set.mem_setOf_eq, Finset.coe_Icc, Set.mem_Icc]
+    rw [heq, Set.ncard_coe_finset, Nat.card_Icc]; omega
+  -- Shadow bounds, rewritten in terms of n
+  have hd : (diffShadow A).ncard ≤ n * (n * (n + 1) / 2) := by
+    rw [hn']; exact diffShadow_ncard_le A hsidon hAfin
+  have hm : (midShadow A).ncard ≤ n * (n + 1) / 2 := by
+    rw [hn']; exact midShadow_ncard_le A hAfin
+  -- Count
+  calc N = (Interval N).ncard := hIcard.symm
+    _ ≤ (A ∪ diffShadow A ∪ midShadow A).ncard :=
+        Set.ncard_le_ncard hcover ((hAfin.union hdfin).union hmfin)
+    _ ≤ (A ∪ diffShadow A).ncard + (midShadow A).ncard := Set.ncard_union_le _ _
+    _ ≤ A.ncard + (diffShadow A).ncard + (midShadow A).ncard :=
+        Nat.add_le_add_right (Set.ncard_union_le A (diffShadow A)) _
+    _ ≤ n + n * (n * (n + 1) / 2) + n * (n + 1) / 2 := by
+        rw [← hn']
+        exact Nat.add_le_add (Nat.add_le_add (le_refl n) hd) hm
 
 end Erdos156

--- a/research/problems/erdos-156-incomplete-01/knowledge.md
+++ b/research/problems/erdos-156-incomplete-01/knowledge.md
@@ -6,16 +6,65 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Goal of this research problem: fill the 3 remaining `sorry`s in
+`proofs/Proofs/Erdos156Problem.lean`. The three were all *counting* lemmas
+supporting the greedy `Ω(N^{1/3})` lower bound:
+
+1. `diffShadow_ncard_le` — `|diffShadow A| ≤ |A| · (|A|(|A|+1)/2)`
+2. `midShadow_ncard_le` — `|midShadow A| ≤ |A|(|A|+1)/2`
+3. `greedySidon_cube_lower_bound` — `N ≤ n + n·(n(n+1)/2) + n(n+1)/2` where
+   `n = size(greedySidon N)`.
+
+The file already had the structural heavy lifting done (the "every complement
+element lands in one of the two shadows" lemma `greedySidon_complement_in_shadow`,
+the exact Sidon sumset size `sidon_sumset_size`, and the upper-triangular pair
+count `card_upper_tri`). What remained was purely cardinality bookkeeping.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **One reusable helper does all three.** Added
+  `sumset_ncard_le : (sumset A).ncard ≤ A.ncard * (A.ncard + 1) / 2` for *every*
+  finite set (no Sidon hypothesis needed). It is the image of the
+  upper-triangular pair set under `(a,b) ↦ a+b`, so `ncard_image_le` plus the
+  in-file `card_upper_tri` gives the bound. Both shadow lemmas then reduce to it.
+
+- **The shadows are images of small index sets.**
+  - `diffShadow A ⊆ (fun (a,σ) ↦ σ - a) '' (A ×ˢ sumset A)`, since `x ∈ diffShadow`
+    means `a + x = b + c =: σ ∈ sumset A`, i.e. `x = σ - a`. Then
+    `ncard ≤ |A ×ˢ sumset A| = |A|·|sumset A| ≤ |A|·(|A|(|A|+1)/2)`
+    via `Set.ncard_prod`, `Set.ncard_image_le`, `Set.ncard_le_ncard`.
+    The Sidon hypothesis is *not* required — the general `sumset_ncard_le`
+    upper bound suffices (Sidon only makes it an equality).
+  - `midShadow A ⊆ (fun σ ↦ σ / 2) '' (sumset A)`, since `2x = σ ∈ sumset A`,
+    i.e. `x = σ / 2`. `omega` proves `σ/2 = x` from `σ = 2x` (it understands
+    division by the literal 2).
+
+- **The cube bound is a 3-set cover count.** `Interval N ⊆ A ∪ diffShadow A ∪
+  midShadow A` (from `greedySidon_complement_in_shadow`), `|Interval N| = N`
+  (`Interval N = ↑(Finset.Icc 1 N)`, `Nat.card_Icc`), and subadditivity of
+  `ncard` over unions (`Set.ncard_union_le`, twice) yields the stated bound.
+  `size (greedySidon N) = (greedySidon N).ncard` via
+  `Set.ncard_eq_toFinset_card`.
 
 ---
 
-## Dead Ends
+## Dead Ends / Gotchas
 
-[Approaches known not to work will be documented here]
+- **`Set.Finite.ncard_eq_toFinset_card'` (the dot-notation prime form) is gone
+  in the currently pinned Mathlib.** The file (and ~33 other repo files) used
+  `hfin.ncard_eq_toFinset_card'`. The current replacement is
+  `Set.ncard_eq_toFinset_card s hs` (Finite-arg form, no prime), which produces
+  `Set.Finite.toFinset` — matching the downstream `hfin.toFinset` usages
+  (`card_upper_tri hfin.toFinset`, the `h_eq` lemma). Updated the two
+  pre-existing occurrences in this file accordingly.
+
+- **`Set.ncard_coe_Finset` → `Set.ncard_coe_finset`** (capital-F is a deprecated
+  alias since 2025-07-05).
+
+- **Build host was DOWN this session** (host disk 100% full + Docker
+  containerd blob store reporting I/O errors), so the file could **not** be
+  compiled. The proofs only reference Mathlib lemmas whose existence and
+  signatures were verified by source inspection, but this work is **UNVERIFIED**
+  pending host recovery and a `docker-build.sh Proofs.Erdos156Problem` run.

--- a/research/problems/erdos-156-incomplete-01/state.md
+++ b/research/problems/erdos-156-incomplete-01/state.md
@@ -1,25 +1,39 @@
 # Research State: erdos-156-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT (sorries filled; pending build verification)
 **Path**: full
-**Since**: 2026-04-03T00:52:22-07:00
-**Iteration**: 1
+**Since**: 2026-06-27
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Completed all 3 `sorry`s in `proofs/Proofs/Erdos156Problem.lean`:
+- `diffShadow_ncard_le`
+- `midShadow_ncard_le`
+- `greedySidon_cube_lower_bound`
+
+Added one reusable helper `sumset_ncard_le` (general finite-set sumset bound).
+Repaired two pre-existing stale `Set.Finite.ncard_eq_toFinset_card'` references
+(removed from the pinned Mathlib) to `Set.ncard_eq_toFinset_card`.
 
 ## Active Approach
-None yet.
+Cardinality counting: both shadows are images of small index sets
+(`A ×ˢ sumset A` and `sumset A`); the cube bound is a 3-set cover count of
+`Interval N`. See knowledge.md.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+**Build host down** — host disk 100% full and Docker containerd blob store
+returning I/O errors, so `docker-build.sh` could not compile the file. Work is
+UNVERIFIED pending host recovery. Lemma names/signatures statically checked
+against the pinned Mathlib source.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Once the build host recovers, run
+`./proofs/scripts/docker-build.sh Proofs.Erdos156Problem` and confirm 0 sorries,
+0 axioms, 0 errors. If it builds clean, promote gallery entry `erdos-156` from
+`formalized` (3 sorries) to `verified`/`original`.


### PR DESCRIPTION
## Summary

Fills the **3 remaining `sorry`s** in `proofs/Proofs/Erdos156Problem.lean` (gallery entry `erdos-156`, previously `formalized` / 3 sorries). These were the counting lemmas underpinning the greedy **Ω(N^{1/3})** lower bound for the minimum size of a maximal Sidon set.

| Lemma | Statement |
|-------|-----------|
| `diffShadow_ncard_le` | `\|diffShadow A\| ≤ \|A\|·(\|A\|(\|A\|+1)/2)` |
| `midShadow_ncard_le` | `\|midShadow A\| ≤ \|A\|(\|A\|+1)/2` |
| `greedySidon_cube_lower_bound` | `N ≤ n + n·(n(n+1)/2) + n(n+1)/2`, `n = size(greedySidon N)` |

## Approach (pure cardinality counting)

- New helper **`sumset_ncard_le`**: for *any* finite `A`, `\|sumset A\| ≤ \|A\|(\|A\|+1)/2` — the sumset is the image of the upper-triangular pairs under `(a,b) ↦ a+b`, so `ncard_image_le` + the in-file `card_upper_tri` gives it. No Sidon hypothesis needed (Sidon only upgrades it to equality).
- Each shadow is the image of a small index set:
  - `diffShadow A ⊆ (a,σ) ↦ σ-a` over `A ×ˢ sumset A` (since `a+x = b+c =: σ ∈ sumset A`), bounded via `Set.ncard_prod` / `ncard_image_le` / `ncard_le_ncard`.
  - `midShadow A ⊆ σ ↦ σ/2` over `sumset A` (since `2x = σ ∈ sumset A`).
- The cube bound is a **3-set cover count** of `Interval N`: `Interval N ⊆ A ∪ diffShadow A ∪ midShadow A` (existing `greedySidon_complement_in_shadow`), `\|Interval N\| = N` (`Nat.card_Icc`), and `Set.ncard_union_le` twice.

## Incidental repair

Two pre-existing references to `Set.Finite.ncard_eq_toFinset_card'` (a dot-notation lemma **removed from the currently pinned Mathlib**, ~33 repo files still use it) are replaced with the current `Set.ncard_eq_toFinset_card s hs` (Finite-arg form), which is internally consistent with the file's downstream `Set.Finite.toFinset` usage. Also `ncard_coe_Finset` → `ncard_coe_finset`.

## ⚠️ UNVERIFIED — build host down

The build host was unavailable this session: **host disk 100% full** and **Docker containerd blob store returning I/O errors** (the Lean docker image could not be built, so the file never compiled). All Mathlib lemma names/signatures were verified against the pinned Mathlib source, and the file statically shows **0 sorries / 0 axioms**, but a `./proofs/scripts/docker-build.sh Proofs.Erdos156Problem` run is still required before promoting `erdos-156` to `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)