### PR TITLE
Auditor: record 2 clean gallery audits (geometric-series palindromy, ptolemys-complex)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25121,8 +25121,20 @@
       "lastAudited": "2026-06-27T10:49:50Z",
       "result": "clean",
       "issues": []
+    },
+    "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T11:27:32Z",
+      "result": "clean"
+    },
+    "ptolemys-complex-proof-oq-02-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T11:27:32Z",
+      "result": "clean"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T07:14:09Z"
+  "lastUpdated": "2026-06-27T11:27:32Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 2 clean

Re-verified two never-audited `verified/original` entries against their Lean sources at current `main`. Both are clean; no integrity issues. Tracker-only change.

| Slug | thm | sorry | axiom | native_decide | Tier | Verdict |
|------|-----|-------|-------|---------------|------|---------|
| geometric-series-oq-07-…-oq-01 | 4 | 0 | 0 | 0 | A | clean |
| ptolemys-complex-proof-oq-02-oq-02 | 9 (5 thm + 4 lemma) | 0 | 0 | 0 | A | clean |

**geometric-series-…**: descent-complement identity `descentCount (Fin.revPerm * σ) = n − descentCount σ` and bijective Eulerian palindromy via explicit involution. Mathlib deps (`Fin.rev_*`, `Finset.card_*`) are infrastructure, not a wrapper — `original` badge correct.

**ptolemys-complex-proof-oq-02-oq-02**: radius-r chord-length (Ptolemy crd) + law of cosines from complex exponentials. No Mathlib theorem doing the core work — `original` badge correct. theoremCount 9 matches 5 theorems + 4 lemmas.

meta.json claims (status/badge/sorries/axiomCount/theoremCount) match the source exactly for both. No fixes needed.

---
Discovered during gallery integrity audit loop.