### PR TITLE
research(de-moivre-oq-02-oq-03-oq-02-oq-02): real roots of Chebyshev Tₙ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/DeMoivreOQ02OQ03OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ03OQ02.lean
@@ -1,0 +1,126 @@
+/-
+# Degree and Leading Coefficient of the Chebyshev Polynomials Tₙ
+
+For the first-kind Chebyshev polynomials `T n` (Mathlib's `Polynomial.Chebyshev.T`)
+over `ℤ`, this file proves the two facts that Mathlib's `Chebyshev` file lists as
+open TODOs ("Compute zeroes and extrema", which presuppose the degree):
+
+* `natDegree (T ℤ n) = n`;
+* `leadingCoeff (T ℤ n) = 2 ^ (n - 1)`  (so `Tₙ` has leading coefficient `2ⁿ⁻¹`
+  for `n ≥ 1`, and `T₀ = 1`).
+
+Mathlib provides the defining three-term recurrence
+`T (n+2) = 2·X·T (n+1) − T n` with `T 0 = 1`, `T 1 = X`, but records no degree
+or leading-coefficient lemma; both results here are fresh.
+
+## Strategy
+
+A single two-step induction on `n` tracking `natDegree` and `leadingCoeff`
+simultaneously.  Base cases `T 0 = 1` (degree 0, leading coeff `1 = 2⁰`) and
+`T 1 = X` (degree 1, leading coeff `1 = 2⁰`).  For the step, write
+`T (n+2) = 2·X·T (n+1) − T n`.  Over the domain `ℤ`:
+
+* `2·X·T (n+1)` has degree `1 + (n+1) = n+2` and leading coefficient
+  `2 · 2ⁿ = 2ⁿ⁺¹` (degree and leading coefficient are additive/multiplicative
+  on products of nonzero polynomials);
+* `T n` has degree `n < n+2`, so subtracting it changes neither the degree
+  nor the leading coefficient of the `n+2` term.
+
+Hence `natDegree (T (n+2)) = n+2` and `leadingCoeff (T (n+2)) = 2ⁿ⁺¹`, completing
+the induction.  Using `ℕ`-subtraction in the exponent `2 ^ (n-1)` makes the
+formula uniform across `n = 0` (`2⁰ = 1`) without a special case.
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.
+-/
+import Mathlib
+
+open Polynomial Polynomial.Chebyshev
+
+namespace DeMoivreOQ02OQ03OQ02
+
+/-- `2 * X` over `ℤ` has `natDegree` one and leading coefficient `2`. -/
+theorem natDegree_two_mul_X : (2 * X : ℤ[X]).natDegree = 1 := by
+  have : (2 * X : ℤ[X]) = C 2 * X := by simp
+  rw [this, natDegree_C_mul (by norm_num : (2 : ℤ) ≠ 0), natDegree_X]
+
+theorem leadingCoeff_two_mul_X : (2 * X : ℤ[X]).leadingCoeff = 2 := by
+  have : (2 * X : ℤ[X]) = C 2 * X := by simp
+  rw [this, leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X, mul_one]
+
+theorem two_mul_X_ne_zero : (2 * X : ℤ[X]) ≠ 0 := by
+  intro h
+  have := congrArg natDegree h
+  rw [natDegree_two_mul_X, natDegree_zero] at this
+  exact one_ne_zero this
+
+/-- **Degree and leading coefficient of `Tₙ`.**  Over `ℤ`, the `n`-th first-kind
+Chebyshev polynomial has degree `n` and leading coefficient `2 ^ (n-1)`. -/
+theorem T_natDegree_leadingCoeff (n : ℕ) :
+    (T ℤ (n : ℤ)).natDegree = n ∧ (T ℤ (n : ℤ)).leadingCoeff = 2 ^ (n - 1) := by
+  induction n using Nat.twoStepInduction with
+  | zero =>
+      constructor
+      · simp
+      · simp
+  | one =>
+      constructor
+      · simp [T_one]
+      · simp [T_one]
+  | more n ih0 ih1 =>
+      obtain ⟨hd0, hl0⟩ := ih0
+      obtain ⟨hd1, hl1⟩ := ih1
+      -- The defining recurrence, with the index cast through ℕ.
+      have hrec : T ℤ ((n + 2 : ℕ) : ℤ)
+          = 2 * X * T ℤ ((n + 1 : ℕ) : ℤ) - T ℤ ((n : ℕ) : ℤ) := by
+        have h := T_add_two ℤ (n : ℤ)
+        push_cast
+        push_cast at h
+        linear_combination h
+      -- `T (n+1) ≠ 0` since its leading coefficient `2ⁿ` is nonzero.
+      have hTn1_ne : T ℤ ((n + 1 : ℕ) : ℤ) ≠ 0 := by
+        intro h0
+        rw [h0, leadingCoeff_zero] at hl1
+        have : (2 : ℤ) ^ (n + 1 - 1) ≠ 0 := pow_ne_zero _ (by norm_num)
+        exact this hl1.symm
+      -- Degree and leading coefficient of `A := 2·X·T (n+1)`.
+      have hdA : (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).natDegree = n + 2 := by
+        rw [natDegree_mul two_mul_X_ne_zero hTn1_ne, natDegree_two_mul_X, hd1]
+        omega
+      have hlA : (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ (n + 1) := by
+        rw [leadingCoeff_mul, leadingCoeff_two_mul_X, hl1]
+        have : n + 1 - 1 = n := by omega
+        rw [this]; ring
+      -- `T n` has strictly smaller degree.
+      have hdeg_lt : (T ℤ ((n : ℕ) : ℤ)).natDegree
+          < (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).natDegree := by
+        rw [hdA, hd0]; omega
+      constructor
+      · rw [hrec, natDegree_sub_eq_left_of_natDegree_lt hdeg_lt, hdA]
+      · rw [hrec]
+        have hsub : (2 * X * T ℤ ((n + 1 : ℕ) : ℤ) - T ℤ ((n : ℕ) : ℤ)).leadingCoeff
+            = (2 * X * T ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff := by
+          rw [sub_eq_add_neg]
+          rw [leadingCoeff_add_of_degree_lt']
+          rw [degree_neg]
+          exact degree_lt_degree hdeg_lt
+        rw [hsub, hlA]
+        have : n + 2 - 1 = n + 1 := by omega
+        rw [this]
+
+/-- **Degree of `Tₙ`.**  `natDegree (T ℤ n) = n`. -/
+theorem T_natDegree (n : ℕ) : (T ℤ (n : ℤ)).natDegree = n :=
+  (T_natDegree_leadingCoeff n).1
+
+/-- **Leading coefficient of `Tₙ`.**  `leadingCoeff (T ℤ n) = 2 ^ (n-1)`
+(so `Tₙ` has leading coefficient `2ⁿ⁻¹` for `n ≥ 1`, and `T₀ = 1`). -/
+theorem T_leadingCoeff (n : ℕ) : (T ℤ (n : ℤ)).leadingCoeff = 2 ^ (n - 1) :=
+  (T_natDegree_leadingCoeff n).2
+
+/-- For `n ≥ 1`, the leading coefficient of `Tₙ` is `2ⁿ⁻¹`, written without
+truncated subtraction. -/
+theorem T_leadingCoeff_succ (n : ℕ) :
+    (T ℤ ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ n := by
+  have := T_leadingCoeff (n + 1)
+  simpa using this
+
+end DeMoivreOQ02OQ03OQ02

--- a/proofs/Proofs/DeMoivreOQ02OQ03OQ02OQ02.lean
+++ b/proofs/Proofs/DeMoivreOQ02OQ03OQ02OQ02.lean
@@ -1,0 +1,200 @@
+/-
+# The Real Roots of the Chebyshev Polynomials Tₙ
+
+Building on the degree/leading-coefficient pair `natDegree (T ℤ n) = n`,
+`leadingCoeff (T ℤ n) = 2^(n-1)` (parent entry `de-moivre-oq-02-oq-03-oq-02`),
+this file answers that entry's second open question: it locates *all* the real
+roots of the first-kind Chebyshev polynomial `Tₙ` and shows there are exactly
+`n` of them, all simple, all in `[-1, 1]`.
+
+For `n ≥ 1` the **Chebyshev nodes**
+`xₖ = cos((2k+1)·π / (2n))`,  `k = 0, …, n-1`
+are `n` distinct numbers in `(-1, 1)`, each a root of `Tₙ`; and because `Tₙ`
+has degree exactly `n` (re-derived here over `ℝ`), these are *all* of its roots.
+Concretely we prove the multiset identity
+
+* `(T ℝ n).roots = (Finset.image (fun k : Fin n => cos ((2k+1)π/(2n))) univ).val`,
+
+from which we read off: `Multiset.card (T ℝ n).roots = n`, the roots are
+`Nodup` (all simple), and every root lies in `[-1, 1]`.  This is the first
+concrete step toward Mathlib's open "compute zeroes and extrema" Chebyshev TODO
+and the location half of the classical minimax theorem.
+
+## Strategy
+
+* **Degree over any domain.** The same two-step induction as the parent, but
+  stated for an arbitrary integral domain `R` with `(2 : R) ≠ 0`, strictly
+  generalizing the parent's `ℤ`-only statement; instantiating at `ℝ` gives
+  `natDegree (T ℝ n) = n` and `T ℝ n ≠ 0` for `n ≥ 1`.
+* **The nodes are roots.** Mathlib's `T_real_cos : (T ℝ n).eval (cos θ) = cos (n·θ)`
+  turns `eval (Tₙ) (cos θ)` into `cos (n·θ)`; at `θ = (2k+1)π/(2n)` we get
+  `cos((2k+1)π/2) = 0`.
+* **The nodes are distinct.** The angles `(2k+1)π/(2n)` lie in `[0, π]` and are
+  injective in `k`; since `cos` is injective on `[0, π]` (`injOn_cos`), the
+  cosines are distinct.
+* **They are all the roots.** `n` distinct roots of a degree-`n` polynomial over
+  a field exhaust the root multiset (`roots_eq_of_natDegree_le_card_of_ne_zero`).
+
+No axioms beyond Lean/Mathlib's foundations; `0` sorries.
+-/
+import Mathlib
+
+open Polynomial Polynomial.Chebyshev Real Set
+
+namespace DeMoivreOQ02OQ03OQ02OQ02
+
+/-! ## Degree and leading coefficient over an arbitrary integral domain -/
+
+/-- **Degree and leading coefficient of `Tₙ` over any integral domain.**  When
+`(2 : R) ≠ 0`, the `n`-th first-kind Chebyshev polynomial over `R` has degree `n`
+and leading coefficient `2 ^ (n-1)`.  This strictly generalizes the parent entry's
+`ℤ`-only statement (the proof is identical: a single two-step induction). -/
+theorem T_natDegree_leadingCoeff {R : Type*} [CommRing R] [IsDomain R]
+    (h2 : (2 : R) ≠ 0) (n : ℕ) :
+    (T R (n : ℤ)).natDegree = n ∧ (T R (n : ℤ)).leadingCoeff = 2 ^ (n - 1) := by
+  have hC2 : (C (2 : R)) = (2 : R[X]) := map_ofNat (C : R →+* R[X]) 2
+  have hCX_deg : (2 * X : R[X]).natDegree = 1 := by
+    rw [← hC2, natDegree_C_mul h2, natDegree_X]
+  have hCX_lead : (2 * X : R[X]).leadingCoeff = 2 := by
+    rw [← hC2, leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X, mul_one]
+  have hCX_ne : (2 * X : R[X]) ≠ 0 := by
+    intro h
+    have := congrArg natDegree h
+    rw [hCX_deg, natDegree_zero] at this
+    exact one_ne_zero this
+  induction n using Nat.twoStepInduction with
+  | zero => constructor <;> simp
+  | one => constructor <;> simp [T_one]
+  | more n ih0 ih1 =>
+      obtain ⟨hd0, hl0⟩ := ih0
+      obtain ⟨hd1, hl1⟩ := ih1
+      have hrec : T R ((n + 2 : ℕ) : ℤ)
+          = 2 * X * T R ((n + 1 : ℕ) : ℤ) - T R ((n : ℕ) : ℤ) := by
+        have h := T_add_two R (n : ℤ)
+        push_cast
+        push_cast at h
+        linear_combination h
+      have hTn1_ne : T R ((n + 1 : ℕ) : ℤ) ≠ 0 := by
+        intro h0
+        rw [h0, leadingCoeff_zero] at hl1
+        have : (2 : R) ^ (n + 1 - 1) ≠ 0 := pow_ne_zero _ h2
+        exact this hl1.symm
+      have hdA : (2 * X * T R ((n + 1 : ℕ) : ℤ)).natDegree = n + 2 := by
+        rw [natDegree_mul hCX_ne hTn1_ne, hCX_deg, hd1]; omega
+      have hlA : (2 * X * T R ((n + 1 : ℕ) : ℤ)).leadingCoeff = 2 ^ (n + 1) := by
+        rw [leadingCoeff_mul, hCX_lead, hl1]
+        have : n + 1 - 1 = n := by omega
+        rw [this]; ring
+      have hdeg_lt : (T R ((n : ℕ) : ℤ)).natDegree
+          < (2 * X * T R ((n + 1 : ℕ) : ℤ)).natDegree := by
+        rw [hdA, hd0]; omega
+      constructor
+      · rw [hrec, natDegree_sub_eq_left_of_natDegree_lt hdeg_lt, hdA]
+      · rw [hrec]
+        have hsub : (2 * X * T R ((n + 1 : ℕ) : ℤ) - T R ((n : ℕ) : ℤ)).leadingCoeff
+            = (2 * X * T R ((n + 1 : ℕ) : ℤ)).leadingCoeff := by
+          rw [sub_eq_add_neg, leadingCoeff_add_of_degree_lt']
+          rw [degree_neg]
+          exact degree_lt_degree hdeg_lt
+        rw [hsub, hlA, show n + 2 - 1 = n + 1 from by omega]
+
+/-- **Degree of `Tₙ` over `ℝ`.** `natDegree (T ℝ n) = n`. -/
+theorem T_real_natDegree (n : ℕ) : (T ℝ (n : ℤ)).natDegree = n :=
+  (T_natDegree_leadingCoeff (by norm_num : (2 : ℝ) ≠ 0) n).1
+
+/-- For `n ≥ 1`, `Tₙ` is a nonzero polynomial over `ℝ` (it has degree `n ≥ 1`). -/
+theorem T_real_ne_zero {n : ℕ} (hn : 1 ≤ n) : T ℝ (n : ℤ) ≠ 0 := by
+  intro h
+  have hd := T_real_natDegree n
+  rw [h, natDegree_zero] at hd
+  omega
+
+/-! ## The Chebyshev nodes are roots -/
+
+/-- **The Chebyshev nodes are roots of `Tₙ`.**  For `n ≥ 1` and any `k`, the
+node `cos((2k+1)π/(2n))` is a root of `Tₙ`, because
+`eval (Tₙ) (cos θ) = cos (n·θ)` and `cos((2k+1)π/2) = 0`. -/
+theorem T_eval_node_eq_zero {n : ℕ} (hn : 1 ≤ n) (k : ℕ) :
+    (T ℝ (n : ℤ)).eval (cos ((2 * (k : ℝ) + 1) * π / (2 * n))) = 0 := by
+  have hn0 : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  rw [T_real_cos, Real.cos_eq_zero_iff]
+  refine ⟨(k : ℤ), ?_⟩
+  push_cast
+  field_simp
+  try ring
+
+/-! ## The Chebyshev nodes are distinct -/
+
+/-- **The Chebyshev nodes are distinct.**  For `n ≥ 1` the map
+`k ↦ cos((2k+1)π/(2n))` is injective on `Fin n`: the angles lie in `[0, π]`,
+are injective in `k`, and `cos` is injective on `[0, π]`. -/
+theorem node_injective {n : ℕ} (hn : 1 ≤ n) :
+    Function.Injective
+      (fun k : Fin n => cos ((2 * (k.val : ℝ) + 1) * π / (2 * n))) := by
+  have hn0 : (0 : ℝ) < n := by exact_mod_cast hn
+  have hπ : (0 : ℝ) < π := pi_pos
+  have h2n : (0 : ℝ) < 2 * n := by positivity
+  -- each angle lies in `[0, π]`
+  have mem : ∀ k : Fin n,
+      (2 * (k.val : ℝ) + 1) * π / (2 * n) ∈ Set.Icc (0 : ℝ) π := by
+    intro k
+    have hk : (k.val : ℝ) + 1 ≤ n := by exact_mod_cast Nat.succ_le_of_lt k.isLt
+    refine ⟨by positivity, ?_⟩
+    rw [div_le_iff₀ h2n]
+    have h1 : (2 * (k.val : ℝ) + 1) ≤ 2 * n := by linarith
+    calc (2 * (k.val : ℝ) + 1) * π ≤ (2 * n) * π :=
+            mul_le_mul_of_nonneg_right h1 hπ.le
+      _ = π * (2 * n) := by ring
+  intro i j hij
+  have hg : (2 * (i.val : ℝ) + 1) * π / (2 * n)
+      = (2 * (j.val : ℝ) + 1) * π / (2 * n) :=
+    injOn_cos (mem i) (mem j) hij
+  -- `field_simp` clears the common positive factor `π / (2n)`, leaving `2i+1 = 2j+1`
+  have hπ0 : π ≠ 0 := pi_ne_zero
+  have h2n' : (2 * (n : ℝ)) ≠ 0 := ne_of_gt h2n
+  field_simp at hg
+  have : (i.val : ℝ) = (j.val : ℝ) := by linarith
+  exact Fin.ext (by exact_mod_cast this)
+
+/-! ## Main theorem: the complete root set -/
+
+/-- **The real roots of `Tₙ`.**  For `n ≥ 1`, the root multiset of the first-kind
+Chebyshev polynomial `Tₙ` over `ℝ` is exactly the set of `n` Chebyshev nodes
+`cos((2k+1)π/(2n))`, `k = 0, …, n-1`.  (Equality of `(T ℝ n).roots` with the
+underlying multiset of the image `Finset`.) -/
+theorem T_roots_eq {n : ℕ} (hn : 1 ≤ n) :
+    (T ℝ (n : ℤ)).roots
+      = (Finset.image (fun k : Fin n => cos ((2 * (k.val : ℝ) + 1) * π / (2 * n)))
+          Finset.univ).val := by
+  refine roots_eq_of_natDegree_le_card_of_ne_zero ?_ ?_ (T_real_ne_zero hn)
+  · intro x hx
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hx
+    obtain ⟨k, rfl⟩ := hx
+    exact T_eval_node_eq_zero hn k.val
+  · rw [T_real_natDegree,
+      Finset.card_image_of_injective _ (node_injective hn),
+      Finset.card_univ, Fintype.card_fin]
+
+/-- **`Tₙ` has exactly `n` real roots (with multiplicity).** -/
+theorem T_card_roots {n : ℕ} (hn : 1 ≤ n) :
+    Multiset.card (T ℝ (n : ℤ)).roots = n := by
+  rw [T_roots_eq hn]
+  show (Finset.image (fun k : Fin n => cos ((2 * (k.val : ℝ) + 1) * π / (2 * n)))
+        Finset.univ).card = n
+  rw [Finset.card_image_of_injective _ (node_injective hn),
+    Finset.card_univ, Fintype.card_fin]
+
+/-- **All roots of `Tₙ` are simple.** The root multiset has no repeats. -/
+theorem T_roots_nodup {n : ℕ} (hn : 1 ≤ n) : (T ℝ (n : ℤ)).roots.Nodup := by
+  rw [T_roots_eq hn]
+  exact (Finset.image _ _).nodup
+
+/-- **Every real root of `Tₙ` lies in `[-1, 1]`.**  Each root is a cosine. -/
+theorem T_roots_mem_Icc {n : ℕ} (hn : 1 ≤ n) :
+    ∀ x ∈ (T ℝ (n : ℤ)).roots, x ∈ Set.Icc (-1 : ℝ) 1 := by
+  intro x hx
+  rw [T_roots_eq hn, ← Finset.mem_def, Finset.mem_image] at hx
+  obtain ⟨k, -, rfl⟩ := hx
+  exact ⟨neg_one_le_cos _, cos_le_one _⟩
+
+end DeMoivreOQ02OQ03OQ02OQ02

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-02/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-dm-oq02030202-setup",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Setup: Locating the Zeros of Chebyshev Tₙ",
+    "content": "The file proves that for n ≥ 1 the first-kind Chebyshev polynomial Tₙ over ℝ has exactly n simple real roots, the Chebyshev nodes cos((2k+1)π/(2n)) for k = 0,…,n−1, all in [−1,1]. Because Tₙ(cos θ) = cos(nθ), the zeros come from cos(nθ) = 0; the parent entry's fact deg Tₙ = n then upgrades 'these n points are roots' to 'these are ALL the roots'. Mathlib lists 'Compute zeroes and extrema of Chebyshev polynomials' as an open TODO and records neither the degree nor the zeros. The headline statement is the exact root-multiset identity, with count, simplicity, and [−1,1]-membership read off as corollaries.",
+    "mathContext": "$T_n(\\cos\\theta) = \\cos(n\\theta)$, so the zeros of $T_n$ are the nodes $\\cos\\frac{(2k+1)\\pi}{2n}$, $k = 0,\\dots,n-1$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Polynomial.Chebyshev.T",
+      "Polynomial.roots",
+      "Chebyshev nodes",
+      "Polynomial.Chebyshev.T_real_cos"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first kind",
+      "roots of a polynomial over a field",
+      "the identity Tₙ(cos θ) = cos(nθ)"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030202-degree",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+    "range": { "startLine": 49, "endLine": 110 },
+    "type": "technique",
+    "title": "Degree of Tₙ over an Arbitrary Integral Domain",
+    "content": "T_natDegree_leadingCoeff re-proves natDegree (T R n) = n ∧ leadingCoeff (T R n) = 2^(n−1) for any integral domain R with (2:R) ≠ 0 — the same simultaneous two-step induction as the parent entry, but generalized from ℤ so it can serve over ℝ at no extra cost. The numeral 2 in R[X] is identified with C 2 via map_ofNat. Specializations record what the roots argument needs: T_real_natDegree (natDegree (T ℝ n) = n) and T_real_ne_zero (T ℝ n ≠ 0 for n ≥ 1, since its degree is n ≥ 1).",
+    "mathContext": "$\\deg T_n = n$ and $\\mathrm{lc}(T_n) = 2^{n-1}$ over any integral domain with $2 \\ne 0$; the degree fact is the load-bearing input downstream.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.twoStepInduction",
+      "Polynomial.natDegree_mul",
+      "Polynomial.leadingCoeff_add_of_degree_lt'",
+      "Polynomial.map_ofNat"
+    ],
+    "prerequisites": [
+      "degree and leading-coefficient calculus over an integral domain",
+      "two-step induction on ℕ",
+      "the Chebyshev recurrence T(n+2) = 2·X·T(n+1) − T n"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030202-roots",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+    "range": { "startLine": 112, "endLine": 132 },
+    "type": "technique",
+    "title": "The Nodes Are Roots: Tₙ(cos θ) = cos(nθ)",
+    "content": "T_eval_node_eq_zero shows each node cos((2k+1)π/(2n)) is a root of Tₙ. Mathlib's T_real_cos rewrites eval(T ℝ n)(cos θ) as cos(n·θ); at θ = (2k+1)π/(2n) the argument is n·(2k+1)π/(2n) = (2k+1)π/2, an odd multiple of π/2 (field_simp clears the denominator using n ≠ 0). Real.cos_eq_zero_iff, which characterizes cos x = 0 as x = (2m+1)π/2 for some integer m, closes it with witness m = k.",
+    "mathContext": "$\\cos\\!\\big(n \\cdot \\tfrac{(2k+1)\\pi}{2n}\\big) = \\cos\\!\\big(\\tfrac{(2k+1)\\pi}{2}\\big) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.Chebyshev.T_real_cos",
+      "Real.cos_eq_zero_iff",
+      "Polynomial.eval"
+    ],
+    "prerequisites": [
+      "the evaluation identity Tₙ(cos θ) = cos(nθ)",
+      "zeros of cosine at odd multiples of π/2"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030202-distinct",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+    "range": { "startLine": 133, "endLine": 168 },
+    "type": "insight",
+    "title": "The Nodes Are Distinct via Injectivity of cos on [0,π]",
+    "content": "node_injective proves the map k : Fin n ↦ cos((2k+1)π/(2n)) is injective — the crux that gives n distinct roots. The node angles lie in [0,π]: the lower bound is positivity, and the upper bound (2k+1)π/(2n) ≤ π follows from 2k+1 ≤ 2n, i.e. k < n. Since cos is strictly decreasing — hence injective — on [0,π] (Real.injOn_cos), equality of two cosines forces equality of the angles; field_simp cancels the common positive factor π/(2n), reducing the angle equation to 2k+1 = 2j+1, so k = j. Composing 'angle map injective into [0,π]' with 'cos injective on [0,π]' avoids any direct comparison of cosine values.",
+    "mathContext": "$\\frac{(2k+1)\\pi}{2n} \\in [0,\\pi]$ is injective in $k$, and $\\cos$ is injective on $[0,\\pi]$, so the nodes are distinct.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Real.injOn_cos",
+      "Real.strictAntiOn_cos",
+      "Function.Injective",
+      "Set.InjOn"
+    ],
+    "prerequisites": [
+      "cos is strictly decreasing on [0,π]",
+      "injectivity through a composition with an injection-on-a-set"
+    ]
+  },
+  {
+    "id": "ann-dm-oq02030202-main",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+    "range": { "startLine": 169, "endLine": 200 },
+    "type": "key-step",
+    "title": "Main Theorem: n Distinct Roots Exhaust a Degree-n Polynomial",
+    "content": "T_roots_eq assembles the pieces into the exact identity (T ℝ n).roots = (Finset.image node univ).val. Mathlib's roots_eq_of_natDegree_le_card_of_ne_zero needs three inputs: every element of the image is a root (T_eval_node_eq_zero), natDegree (T ℝ n) ≤ |image| (here equality, since Finset.card_image_of_injective with node_injective gives |image| = n = natDegree), and T ℝ n ≠ 0. The corollaries are immediate: T_card_roots reads Multiset.card = n off the image cardinality; T_roots_nodup notes a Finset's underlying multiset is Nodup, so all roots are simple; T_roots_mem_Icc observes every root is a cosine, hence in [−1,1] (neg_one_le_cos, cos_le_one). This is the principle 'a degree-n polynomial over a field has at most n roots, so n distinct roots are all of them' made into an exact statement.",
+    "mathContext": "$|\\{\\text{distinct roots}\\}| = n = \\deg T_n$ forces $(T_{\\mathbb{R}}\\,n).\\mathrm{roots}$ to be exactly the $n$ Chebyshev nodes, each simple.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Polynomial.roots_eq_of_natDegree_le_card_of_ne_zero",
+      "Finset.card_image_of_injective",
+      "Multiset.Nodup",
+      "Real.cos_le_one"
+    ],
+    "prerequisites": [
+      "a degree-n polynomial over a field has at most n roots",
+      "cardinality of the image of an injective map",
+      "range of cosine is [−1,1]"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02-oq-02/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+  "title": "The Real Roots of the Chebyshev Polynomials Tₙ",
+  "slug": "de-moivre-oq-02-oq-03-oq-02-oq-02",
+  "description": "A direct answer to the second open question recorded with the parent entry (degree and leading coefficient of Tₙ), and the location half of Mathlib's open 'compute zeroes and extrema' Chebyshev TODO: for n ≥ 1 the first-kind Chebyshev polynomial Tₙ over ℝ has exactly n simple real roots, the Chebyshev nodes cos((2k+1)π/(2n)) for k = 0, …, n−1, all lying in [−1,1]. The result is stated as the exact multiset identity (T ℝ n).roots = (Finset.image (fun k : Fin n => cos((2k+1)π/(2n))) univ).val, from which the count (Multiset.card = n), simplicity (Nodup), and membership in [−1,1] are read off. The proof rests on the degree fact from the parent entry — re-derived here over an arbitrary integral domain, strictly generalizing the parent's ℤ-only statement — and three observations: (i) eval(Tₙ)(cos θ) = cos(nθ) (Mathlib's T_real_cos) makes each node a root because cos((2k+1)π/2) = 0; (ii) the node angles (2k+1)π/(2n) lie in [0,π] and are injective in k, so the nodes are distinct because cos is injective on [0,π] (injOn_cos); (iii) n distinct roots of a degree-n polynomial over a field exhaust the root multiset (roots_eq_of_natDegree_le_card_of_ne_zero). Mathlib supplies T_real_cos, injOn_cos, cos_eq_zero_iff and the root-counting calculus but records neither the degree of Tₙ nor the location/count of its zeros.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib); classical facts about Chebyshev polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ02OQ03OQ02OQ02.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "polynomial-roots",
+      "chebyshev-nodes",
+      "trigonometric-polynomials",
+      "polynomials",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 200,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lean Proofs/DeMoivreOQ02OQ03OQ02OQ02.lean` against prebuilt Mathlib oleans, exit 0; `#print axioms T_roots_eq` lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). No native_decide. Mathlib supplies the Chebyshev recurrence and base cases (`Polynomial.Chebyshev.T_add_two`, `T_zero`, `T_one`), the evaluation identity `Polynomial.Chebyshev.T_real_cos`, the trigonometric facts `Real.cos_eq_zero_iff` / `Real.injOn_cos` / `Real.cos_le_one` / `Real.neg_one_le_cos`, and the root-counting lemma `Polynomial.roots_eq_of_natDegree_le_card_of_ne_zero`; it records neither the degree of Tₙ nor the location, count, or simplicity of its real zeros, all of which are proved here.",
+    "dateAdded": "2026-06-27",
+    "originalContributions": [
+      "T_roots_eq: the exact root-multiset identity (T ℝ n).roots = (Finset.image (fun k : Fin n => cos((2k+1)π/(2n))) univ).val for n ≥ 1 — Mathlib lists 'compute zeroes and extrema' of Chebyshev polynomials as an open TODO and contains no such statement.",
+      "T_card_roots / T_roots_nodup: Tₙ has exactly n real roots (counted with multiplicity) and they are all simple (the root multiset is Nodup).",
+      "T_roots_mem_Icc: every real root of Tₙ lies in [−1,1], the location half of the classical minimax picture.",
+      "node_injective: the n Chebyshev node angles (2k+1)π/(2n) lie in [0,π] and the cosine nodes are distinct, via injOn_cos.",
+      "T_natDegree_leadingCoeff over an arbitrary integral domain with 2 ≠ 0: a strict generalization of the parent entry's ℤ-only degree/leading-coefficient induction, instantiated here at ℝ."
+    ],
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Because Tₙ(cos θ) = cos(nθ), the zeros of the first-kind Chebyshev polynomial are immediate from the zeros of cosine: cos(nθ) = 0 exactly when nθ is an odd multiple of π/2, giving the Chebyshev nodes xₖ = cos((2k+1)π/(2n)). These n points, all in (−1,1), are the interpolation nodes that minimize the Runge phenomenon and underlie Gauss–Chebyshev quadrature and the minimax property treated in the ancestor entry. Mathlib formalizes the Chebyshev recurrence, the cos/cosh evaluation identities, and many derivative formulas, but its source file lists 'Compute zeroes and extrema of Chebyshev polynomials' as an open TODO and records neither the degree of Tₙ nor the location of its zeros. This entry supplies the zero-location result, building on the degree lemma from the parent entry.",
+    "problemStatement": "Prove that for $n \\ge 1$ the first-kind Chebyshev polynomial $T_n$ over $\\mathbb{R}$ has exactly $n$ simple real roots, namely the Chebyshev nodes $x_k = \\cos\\!\\big(\\tfrac{(2k+1)\\pi}{2n}\\big)$ for $k = 0,\\dots,n-1$, all lying in $[-1,1]$.",
+    "text": "The headline result `T_roots_eq (hn : 1 ≤ n) : (T ℝ n).roots = (Finset.image (fun k : Fin n => cos ((2k+1)π/(2n))) univ).val` pins the entire root multiset. Its corollaries `T_card_roots` (Multiset.card = n), `T_roots_nodup` (all roots simple), and `T_roots_mem_Icc` (every root in [−1,1]) read off the count, simplicity, and location.",
+    "proofStrategy": "Three ingredients. (1) Degree: T_natDegree_leadingCoeff re-proves natDegree (T R n) = n ∧ leadingCoeff = 2^(n−1) for any integral domain R with 2 ≠ 0 (same two-step induction as the parent, generalized), giving natDegree (T ℝ n) = n and T ℝ n ≠ 0 for n ≥ 1. (2) The nodes are roots: T_eval_node_eq_zero uses Mathlib's T_real_cos to rewrite eval(Tₙ)(cos θ) = cos(n·θ); at θ = (2k+1)π/(2n) one has n·θ = (2k+1)π/2, so cos = 0 by cos_eq_zero_iff. (3) The nodes are distinct: node_injective shows the angles (2k+1)π/(2n) lie in [0,π] (lower bound by positivity, upper bound (2k+1) ≤ 2n from k < n) and are injective in k, so injOn_cos makes the cosines distinct; field_simp cancels the common factor π/(2n). With n distinct roots and natDegree = n, roots_eq_of_natDegree_le_card_of_ne_zero forces the root multiset to equal the image Finset's underlying multiset; card, Nodup, and the Icc membership follow.",
+    "keyInsights": [
+      "The degree lemma from the parent entry is the load-bearing input: without natDegree (T ℝ n) = n one could exhibit the n nodes as roots but not conclude they are ALL the roots. roots_eq_of_natDegree_le_card_of_ne_zero converts 'n distinct roots' + 'degree n' into the exact root set.",
+      "Generalizing the degree/leading-coefficient induction from ℤ to an arbitrary integral domain (with 2 ≠ 0) costs nothing and is exactly what lets the same proof serve over ℝ.",
+      "Distinctness is cleanest as a composition: the angle map k ↦ (2k+1)π/(2n) is injective into [0,π], and cos is injective there (injOn_cos), so the node map is injective — no need to compare cosine values directly.",
+      "Phrasing the conclusion as a multiset equality (T ℝ n).roots = S.val packages count (card), simplicity (Nodup), and the explicit node list in one statement, from which the individual corollaries are one-liners."
+    ],
+    "prerequisites": [
+      "The first-kind Chebyshev polynomials and the identity Tₙ(cos θ) = cos(nθ) (Mathlib's Polynomial.Chebyshev.T_real_cos)",
+      "Degree of Tₙ over an integral domain (the parent entry's induction, generalized here)",
+      "Roots of a polynomial over a field: a degree-n polynomial has at most n roots (roots_eq_of_natDegree_le_card_of_ne_zero)",
+      "Injectivity of cos on [0,π] (Real.injOn_cos) and cos_eq_zero_iff"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring stating the root-location result for Tₙ: exactly n simple real roots at the Chebyshev nodes cos((2k+1)π/(2n)), all in [−1,1], expressed as a root-multiset identity. Notes the dependence on the parent entry's degree lemma and Mathlib's open 'compute zeroes and extrema' TODO. Opens Polynomial, Polynomial.Chebyshev, Real, and Set.",
+      "mathContext": "Targets the zero set of $T_n$ over $\\mathbb{R}$: the $n$ nodes $\\cos\\frac{(2k+1)\\pi}{2n}$."
+    },
+    {
+      "id": "degree-domain",
+      "title": "Degree and Leading Coefficient over Any Integral Domain",
+      "startLine": 49,
+      "endLine": 110,
+      "summary": "T_natDegree_leadingCoeff: for any integral domain R with (2:R) ≠ 0, natDegree (T R n) = n ∧ leadingCoeff (T R n) = 2^(n−1), by the same simultaneous two-step induction as the parent entry (generalized from ℤ). Specializations T_real_natDegree and T_real_ne_zero record natDegree (T ℝ n) = n and T ℝ n ≠ 0 for n ≥ 1.",
+      "mathContext": "$\\deg T_n = n$, $\\mathrm{lc}(T_n) = 2^{n-1}$ over any integral domain with $2 \\ne 0$; in particular over $\\mathbb{R}$."
+    },
+    {
+      "id": "nodes-roots",
+      "title": "The Chebyshev Nodes Are Roots",
+      "startLine": 112,
+      "endLine": 132,
+      "summary": "T_eval_node_eq_zero: for n ≥ 1 and any k, eval(T ℝ n)(cos((2k+1)π/(2n))) = 0. Mathlib's T_real_cos rewrites the evaluation as cos(n·θ); with θ = (2k+1)π/(2n) the argument simplifies to (2k+1)π/2, an odd multiple of π/2, so cos_eq_zero_iff gives 0.",
+      "mathContext": "$T_n(\\cos\\theta) = \\cos(n\\theta)$ and $\\cos\\frac{(2k+1)\\pi}{2} = 0$."
+    },
+    {
+      "id": "nodes-distinct",
+      "title": "The Chebyshev Nodes Are Distinct",
+      "startLine": 133,
+      "endLine": 168,
+      "summary": "node_injective: for n ≥ 1 the map k : Fin n ↦ cos((2k+1)π/(2n)) is injective. The angles lie in [0,π] (lower bound by positivity; upper bound from (2k+1) ≤ 2n since k < n), and cos is injective on [0,π] (injOn_cos); field_simp cancels the common factor π/(2n), reducing equality of angles to 2k+1 = 2j+1, hence k = j.",
+      "mathContext": "$\\frac{(2k+1)\\pi}{2n} \\in [0,\\pi]$, injective in $k$, and $\\cos$ injective on $[0,\\pi]$."
+    },
+    {
+      "id": "main-roots",
+      "title": "Main Theorem: The Complete Root Set",
+      "startLine": 169,
+      "endLine": 200,
+      "summary": "T_roots_eq: (T ℝ n).roots = (Finset.image node univ).val for n ≥ 1, via roots_eq_of_natDegree_le_card_of_ne_zero — the nodes are roots (T_eval_node_eq_zero), their count equals natDegree = n (Finset.card_image_of_injective with node_injective), and T ℝ n ≠ 0. Corollaries: T_card_roots (Multiset.card = n), T_roots_nodup (all simple), T_roots_mem_Icc (every root in [−1,1], since each is a cosine).",
+      "mathContext": "$n$ distinct roots of a degree-$n$ polynomial exhaust the root multiset: $T_n$ has exactly the $n$ Chebyshev nodes as simple roots."
+    }
+  ],
+  "conclusion": {
+    "summary": "For n ≥ 1 the first-kind Chebyshev polynomial Tₙ over ℝ has exactly n simple real roots, the Chebyshev nodes cos((2k+1)π/(2n)) for k = 0,…,n−1, all in [−1,1]; this is captured by the exact root-multiset identity (T ℝ n).roots = (Finset.image node univ).val, with 0 axioms and 0 sorries. The proof consumes the parent entry's degree lemma (generalized to any integral domain) together with Mathlib's evaluation identity Tₙ(cos θ) = cos(nθ) and the root-counting calculus. It answers the parent entry's second open question and supplies the location half of Mathlib's open 'compute zeroes and extrema' Chebyshev TODO.",
+    "openQuestions": [
+      "Compute the n−1 interior extrema of Tₙ on [−1,1] (where Tₙ = ±1, the Chebyshev points cos(kπ/n)), via Tₙ′ = n·Uₙ₋₁ and the zeros of Uₙ₋₁ — completing the 'extrema' half of Mathlib's TODO.",
+      "Combine the degree (2ⁿ⁻¹ leading coefficient) and root location to prove that the monic rescaling 2¹⁻ⁿ·Tₙ factors as ∏ₖ (X − cos((2k+1)π/(2n))) over ℝ, giving the explicit linear factorization of the minimax polynomial."
+    ],
+    "implications": "Knowing the exact zeros of Tₙ — that they are n simple points in (−1,1) given in closed form — is the entry point to the entire Chebyshev approximation toolkit: Chebyshev interpolation nodes, Gauss–Chebyshev quadrature, and the equioscillation/minimax characterization (whose root-location half this entry now formalizes). Recorded as a multiset identity with explicit nodes, it gives the gallery and a prospective Mathlib contribution a usable statement of the long-open 'zeroes' TODO."
+  },
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-02-oq-03-oq-02",
+      "relationship": "extends",
+      "description": "Answers the second open question of the parent entry ('use natDegree (T n) = n and leadingCoeff (T n) = 2^(n−1) to prove that the monic rescaling Tₙ/2ⁿ⁻¹ has all n roots in [−1,1], the Chebyshev nodes cos((2k−1)π/2n)'). It re-uses and generalizes the parent's degree induction and goes further, pinning the exact root multiset, its cardinality, and simplicity."
+    }
+  ],
+  "references": [
+    {
+      "author": "Rivlin, T. J.",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory",
+      "year": 1990,
+      "note": "Zeros of Tₙ are cos((2k−1)π/2n); minimax and interpolation theory"
+    },
+    {
+      "author": "Mason, J. C.; Handscomb, D. C.",
+      "title": "Chebyshev Polynomials",
+      "year": 2002,
+      "note": "Chebyshev nodes, the relation Tₙ(cos θ) = cos(nθ), and the zero/extremum structure"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DeMoivreOQ02OQ03OQ02OQ02",
+    "lineCount": 200,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ02OQ03OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-dm-oq020302-setup",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "Setup: The Missing Degree Lemma for Chebyshev Tₙ",
+    "content": "The file proves natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1) for the first-kind Chebyshev polynomials over ℤ. Mathlib defines T via the recurrence T(n+2) = 2·X·T(n+1) − T n with T 0 = 1, T 1 = X, and even lists 'Compute zeroes and extrema' and 'Prove minimax properties' as TODOs — but records neither the degree nor the leading coefficient, which those TODOs silently presuppose. The parent gallery entry (the Chebyshev minimax theorem, which normalizes by 2ⁿ⁻¹) lists exactly these as an open question. The strategy is one simultaneous two-step induction carrying both quantities.",
+    "mathContext": "$T_n(\\cos\\theta) = \\cos(n\\theta)$ has degree $n$ and leading coefficient $2^{n-1}$ for $n \\ge 1$; $T_0 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.Chebyshev.T",
+      "natDegree",
+      "leadingCoeff",
+      "Chebyshev recurrence"
+    ],
+    "prerequisites": [
+      "Chebyshev polynomials of the first kind",
+      "polynomial degree and leading coefficient",
+      "two-step induction"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-twox",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 42, "endLine": 54 },
+    "type": "technique",
+    "title": "Degree Bookkeeping for the Factor 2·X",
+    "content": "Three short helpers over ℤ[X] isolate the arithmetic of the recurrence's multiplier 2·X: natDegree (2·X) = 1 (rewriting 2·X = C 2 · X and using natDegree_C_mul with 2 ≠ 0, then natDegree_X), leadingCoeff (2·X) = 2 (via leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X), and 2·X ≠ 0 (a nonzero polynomial cannot have natDegree 1 and be 0). Keeping these separate makes the inductive step's product computation a single natDegree_mul / leadingCoeff_mul application.",
+    "mathContext": "$\\deg(2X) = 1$, $\\mathrm{lc}(2X) = 2$, $2X \\neq 0$ over $\\mathbb{Z}[X]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Polynomial.natDegree_C_mul",
+      "Polynomial.leadingCoeff_mul",
+      "Polynomial.leadingCoeff_C",
+      "Polynomial.natDegree_X"
+    ],
+    "prerequisites": [
+      "degree and leading coefficient of a constant times X",
+      "ℤ[X] is an integral domain"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-induction",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 56, "endLine": 109 },
+    "type": "key-step",
+    "title": "Simultaneous Two-Step Induction on Degree and Leading Coefficient",
+    "content": "T_natDegree_leadingCoeff proves the conjunction natDegree (T ℤ n) = n ∧ leadingCoeff (T ℤ n) = 2^(n−1) by Nat.twoStepInduction. Base cases (T 0 = 1, T 1 = X) are discharged by simp with T_one. In the step, the recurrence T(n+2) = 2·X·T(n+1) − T n is obtained from Mathlib's T_add_two with the index cast through ℕ (push_cast + linear_combination). The leading-coefficient hypothesis from the previous step doubles as the proof that T(n+1) ≠ 0 (its leading coefficient 2ⁿ is nonzero), which natDegree_mul needs. Then 2·X·T(n+1) has degree 1 + (n+1) = n+2 and leading coefficient 2·2ⁿ = 2ⁿ⁺¹, while T n has degree n < n+2, so natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' (after sub_eq_add_neg, degree_lt_degree) carry both facts to T(n+2).",
+    "mathContext": "Step: $T_{n+2} = 2X\\,T_{n+1} - T_n$; $\\deg(2X\\,T_{n+1}) = n+2$, $\\mathrm{lc} = 2^{n+1}$, and $\\deg T_n = n < n+2$ leaves them unchanged.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.twoStepInduction",
+      "Polynomial.natDegree_mul",
+      "Polynomial.natDegree_sub_eq_left_of_natDegree_lt",
+      "Polynomial.leadingCoeff_add_of_degree_lt'",
+      "Polynomial.Chebyshev.T_add_two"
+    ],
+    "prerequisites": [
+      "the Chebyshev recurrence",
+      "degree/leading-coefficient calculus over a domain",
+      "two-step induction with two inductive hypotheses"
+    ]
+  },
+  {
+    "id": "ann-dm-oq020302-corollaries",
+    "proofId": "de-moivre-oq-02-oq-03-oq-02",
+    "range": { "startLine": 111, "endLine": 126 },
+    "type": "concept",
+    "title": "Extracted Theorems for Downstream Use",
+    "content": "T_natDegree and T_leadingCoeff project the two conjuncts of the induction into standalone statements. T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as the clean 2ⁿ (without truncated subtraction), which is the form the minimax/extremal theory uses when normalizing Tₙ to the monic Tₙ/2ⁿ⁻¹.",
+    "mathContext": "$\\deg T_n = n$, $\\mathrm{lc}(T_n) = 2^{n-1}$, and $\\mathrm{lc}(T_{n+1}) = 2^{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "leadingCoeff",
+      "monic normalization",
+      "Chebyshev minimax"
+    ],
+    "prerequisites": [
+      "projecting a conjunction",
+      "truncated vs ordinary subtraction in exponents"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-03-oq-02/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "de-moivre-oq-02-oq-03-oq-02",
+  "title": "Degree and Leading Coefficient of the Chebyshev Polynomials Tₙ",
+  "slug": "de-moivre-oq-02-oq-03-oq-02",
+  "description": "A direct answer to the open question recorded with the parent Chebyshev minimax entry, and a gap in Mathlib itself: for the first-kind Chebyshev polynomials T n (Mathlib's Polynomial.Chebyshev.T) over ℤ, natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1). Equivalently, Tₙ is a degree-n polynomial whose leading coefficient is 2ⁿ⁻¹ for n ≥ 1 (and T₀ = 1, T₁ = X). Mathlib supplies the defining three-term recurrence T(n+2) = 2·X·T(n+1) − T n with base cases T 0 = 1, T 1 = X, and explicitly lists 'Compute zeroes and extrema of Chebyshev polynomials' and the minimax property as TODOs — both of which presuppose exactly the degree and leading-coefficient facts proved here, neither of which Mathlib currently records. The proof is a single two-step induction tracking natDegree and leadingCoeff simultaneously: in the step, T(n+2) = 2·X·T(n+1) − T n, and over the integral domain ℤ the product 2·X·T(n+1) has degree 1 + (n+1) = n+2 and leading coefficient 2·2ⁿ = 2ⁿ⁺¹, while the subtracted T n has strictly smaller degree n, so it perturbs neither the degree nor the leading coefficient of the top term. Writing the exponent with truncated subtraction 2^(n−1) makes the leading-coefficient formula uniform across n = 0 without a special case.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib); classical facts about Chebyshev polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ02OQ03OQ02.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "polynomial-degree",
+      "leading-coefficient",
+      "polynomials",
+      "induction",
+      "ring-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 126,
+    "assumptions": "0 axioms, 0 sorries; kernel-checked at Mathlib (single-file elaboration via `lean Proofs/DeMoivreOQ02OQ03OQ02.lean` against prebuilt Mathlib oleans, exit 0; `#print axioms T_natDegree_leadingCoeff` lists only propext / Classical.choice / Quot.sound, the ordinary foundational axioms, so the entry is axiom-free per the project's axiom-integrity policy). No native_decide. Mathlib supplies the Chebyshev recurrence and base cases (`Polynomial.Chebyshev.T_add_two`, `T_zero`, `T_one`) and the polynomial degree/leading-coefficient calculus used (`Polynomial.natDegree_mul`, `Polynomial.leadingCoeff_mul`, `Polynomial.natDegree_C_mul`, `Polynomial.natDegree_sub_eq_left_of_natDegree_lt`, `Polynomial.leadingCoeff_add_of_degree_lt'`, `Polynomial.degree_lt_degree`) but does NOT record the degree or leading coefficient of Tₙ; both are proved here.",
+    "dateAdded": "2026-06-27",
+    "originalContributions": [
+      "T_natDegree: natDegree (T ℤ n) = n for the first-kind Chebyshev polynomial over ℤ — a fact Mathlib's Chebyshev development does not contain, despite listing the dependent 'zeroes and extrema' computation as a TODO.",
+      "T_leadingCoeff: leadingCoeff (T ℤ n) = 2^(n−1) (truncated subtraction, uniform at n = 0), with the n ≥ 1 form T_leadingCoeff_succ giving leadingCoeff (T ℤ (n+1)) = 2ⁿ.",
+      "A clean simultaneous two-step induction (T_natDegree_leadingCoeff) that carries degree and leading coefficient together, so the lower-degree subtraction in the recurrence is dispatched once via natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt'."
+    ],
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Chebyshev polynomials of the first kind, defined by Tₙ(cos θ) = cos(nθ) (the de Moivre connection — expanding cos(nθ) via (cos θ + i sin θ)ⁿ produces Tₙ), are central to approximation theory: the monic scaling Tₙ/2ⁿ⁻¹ is the degree-n monic polynomial of least sup-norm on [−1,1] (the minimax property treated in the parent entry). That extremal statement, and the location of the zeros and extrema, all rest on the elementary fact that Tₙ has degree n with leading coefficient 2ⁿ⁻¹. Mathlib formalizes the Chebyshev recurrence and many trigonometric/derivative identities but, as of this writing, records neither the degree nor the leading coefficient; its source file lists 'Compute zeroes and extrema' and 'Prove minimax properties' as open TODOs. This entry supplies the missing degree/leading-coefficient lemmas.",
+    "problemStatement": "Prove that for every natural number $n$, the first-kind Chebyshev polynomial $T_n$ over $\\mathbb{Z}$ satisfies $\\deg T_n = n$ and (for $n \\ge 1$) has leading coefficient $2^{n-1}$, with $T_0 = 1$.",
+    "text": "The headline results `T_natDegree (n : ℕ) : (T ℤ n).natDegree = n` and `T_leadingCoeff (n : ℕ) : (T ℤ n).leadingCoeff = 2 ^ (n − 1)`, both extracted from the simultaneous induction `T_natDegree_leadingCoeff`. A succinct n ≥ 1 form `T_leadingCoeff_succ : (T ℤ (n+1)).leadingCoeff = 2 ^ n` is also provided.",
+    "proofStrategy": "Two-step induction (`Nat.twoStepInduction`) on n, proving the conjunction natDegree (T ℤ n) = n ∧ leadingCoeff (T ℤ n) = 2^(n−1). Base cases: T 0 = 1 has degree 0 and leading coefficient 1 = 2⁰; T 1 = X has degree 1 and leading coefficient 1 = 2⁰. Step: rewrite T(n+2) = 2·X·T(n+1) − T n (from Mathlib's T_add_two, with the index cast through ℕ). Set A = 2·X·T(n+1). Over the domain ℤ, natDegree A = natDegree(2·X) + natDegree(T(n+1)) = 1 + (n+1) = n+2 (natDegree_mul, with 2·X ≠ 0 and T(n+1) ≠ 0 because its leading coefficient 2ⁿ ≠ 0), and leadingCoeff A = leadingCoeff(2·X)·leadingCoeff(T(n+1)) = 2·2ⁿ = 2ⁿ⁺¹ (leadingCoeff_mul). Since natDegree (T n) = n < n+2, subtracting T n preserves both: natDegree (A − T n) = natDegree A by natDegree_sub_eq_left_of_natDegree_lt, and leadingCoeff (A − T n) = leadingCoeff A by leadingCoeff_add_of_degree_lt' (after sub_eq_add_neg and degree_lt_degree). This closes the induction with natDegree (T(n+2)) = n+2 and leadingCoeff (T(n+2)) = 2ⁿ⁺¹ = 2^((n+2)−1).",
+    "keyInsights": [
+      "Tracking natDegree and leadingCoeff together is what makes the induction go through: the leading-coefficient hypothesis (2ⁿ ≠ 0) is exactly the witness that T(n+1) ≠ 0, which the degree calculus for the product 2·X·T(n+1) requires.",
+      "Working over the integral domain ℤ keeps degree additive and leading coefficient multiplicative on products (natDegree_mul / leadingCoeff_mul) with no monic hypotheses — the Chebyshev polynomials are not monic for n ≥ 2, so a monic-based argument would not apply.",
+      "The subtracted lower-degree term T n is handled once, generically: natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt' encapsulate 'a strictly-lower-degree perturbation changes neither the degree nor the leading coefficient'.",
+      "Writing the leading coefficient as 2^(n−1) with truncated natural subtraction absorbs the n = 0 base case (2⁰ = 1) into the same formula used for all n, avoiding a separate statement for T₀."
+    ],
+    "prerequisites": [
+      "The first-kind Chebyshev polynomials and their recurrence T(n+2) = 2·X·T(n+1) − T n (Mathlib's Polynomial.Chebyshev.T)",
+      "Degree and leading-coefficient calculus over an integral domain (natDegree_mul, leadingCoeff_mul, natDegree_sub_eq_left_of_natDegree_lt)",
+      "Two-step induction on ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "§0: Module Setup and Statement",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring stating the degree and leading-coefficient results for Tₙ, noting that Mathlib records the recurrence but lists the dependent 'zeroes and extrema'/minimax computations as TODOs, and outlining the simultaneous two-step induction. Opens Polynomial and Polynomial.Chebyshev under the namespace.",
+      "mathContext": "Targets $\\deg T_n = n$ and $\\mathrm{lc}(T_n) = 2^{n-1}$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "two-x-helpers",
+      "title": "Degree Facts for 2·X",
+      "startLine": 42,
+      "endLine": 54,
+      "summary": "Small helper lemmas over ℤ[X]: natDegree (2·X) = 1 (via natDegree_C_mul and natDegree_X), leadingCoeff (2·X) = 2 (via leadingCoeff_mul, leadingCoeff_C, leadingCoeff_X), and 2·X ≠ 0. These feed the product-degree computation in the inductive step.",
+      "mathContext": "$\\deg(2X) = 1$, $\\mathrm{lc}(2X) = 2$, $2X \\ne 0$."
+    },
+    {
+      "id": "main-induction",
+      "title": "Simultaneous Degree/Leading-Coefficient Induction",
+      "startLine": 56,
+      "endLine": 109,
+      "summary": "T_natDegree_leadingCoeff: by Nat.twoStepInduction, proves natDegree (T ℤ n) = n ∧ leadingCoeff (T ℤ n) = 2^(n−1). Base cases use T_zero / T_one. The step rewrites the recurrence (T_add_two with ℕ-cast index), shows 2·X·T(n+1) has degree n+2 and leading coefficient 2ⁿ⁺¹, and uses that T n has strictly smaller degree to conclude via natDegree_sub_eq_left_of_natDegree_lt and leadingCoeff_add_of_degree_lt'.",
+      "mathContext": "Inductive step: $T_{n+2} = 2X\\,T_{n+1} - T_n$, with $\\deg(2X\\,T_{n+1}) = n+2 > n = \\deg T_n$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Extracted Degree and Leading-Coefficient Theorems",
+      "startLine": 111,
+      "endLine": 126,
+      "summary": "T_natDegree and T_leadingCoeff project the two halves of the induction; T_leadingCoeff_succ restates the leading coefficient for n ≥ 1 as 2ⁿ (no truncated subtraction), the form most convenient for downstream minimax/extremal use.",
+      "mathContext": "$\\deg T_n = n$; $\\mathrm{lc}(T_n) = 2^{n-1}$; $\\mathrm{lc}(T_{n+1}) = 2^{n}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Over ℤ, the first-kind Chebyshev polynomial Tₙ is shown to have degree n and leading coefficient 2^(n−1), with 0 axioms and 0 sorries, by a single two-step induction tracking both quantities through the recurrence T(n+2) = 2·X·T(n+1) − T n. These are exactly the facts Mathlib's Chebyshev file leaves as the unstated prerequisites of its open 'zeroes and extrema' and minimax TODOs, and the parent gallery entry lists them as an open question; neither is currently in Mathlib.",
+    "openQuestions": [
+      "Establish the analogous degree/leading-coefficient pair for the second-kind Chebyshev polynomials Uₙ: natDegree (U ℤ n) = n and leadingCoeff (U ℤ n) = 2ⁿ, from the same recurrence U(n+2) = 2·X·U(n+1) − U n with U 0 = 1, U 1 = 2·X.",
+      "Use natDegree (T ℤ n) = n and leadingCoeff (T ℤ n) = 2^(n−1) to prove that the monic rescaling Tₙ/2ⁿ⁻¹ has all n roots in [−1,1] (the Chebyshev nodes cos((2k−1)π/2n)), the first concrete step toward Mathlib's 'compute zeroes and extrema' TODO."
+    ],
+    "implications": "The degree and leading coefficient of Tₙ are the foundation for every quantitative statement about Chebyshev polynomials: the monic normalization Tₙ/2ⁿ⁻¹ used in the minimax theorem, the count and location of roots/extrema, and the explicit power-sum expansions. Recording them as standalone, domain-level lemmas gives the gallery (and a prospective Mathlib contribution) the missing base layer beneath the Chebyshev extremal theory."
+  },
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Answers the open question listed in the parent Chebyshev minimax entry ('Upstream natDegree(Tₙ) = n, leadingCoeff(Tₙ) = 2^(n−1) … to Mathlib'). The minimax theorem there uses the monic normalization Tₙ/2ⁿ⁻¹, whose validity rests on the leading-coefficient fact proved here."
+    }
+  ],
+  "references": [
+    {
+      "author": "Rivlin, T. J.",
+      "title": "Chebyshev Polynomials: From Approximation Theory to Algebra and Number Theory",
+      "year": 1990,
+      "note": "Standard reference: Tₙ has degree n and leading coefficient 2ⁿ⁻¹; minimax property"
+    },
+    {
+      "author": "Mason, J. C.; Handscomb, D. C.",
+      "title": "Chebyshev Polynomials",
+      "year": 2002,
+      "note": "Recurrence Tₙ₊₁ = 2x Tₙ − Tₙ₋₁ and elementary degree/coefficient facts"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DeMoivreOQ02OQ03OQ02",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ02OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary
Research entry **de-moivre-oq-02-oq-03-oq-02-oq-02** — answers the parent entry's second open question and the *location* half of Mathlib's open "compute zeroes and extrema of Chebyshev polynomials" TODO.

For $n \ge 1$, the first-kind Chebyshev polynomial $T_n$ over $\mathbb{R}$ has exactly $n$ simple real roots, the Chebyshev nodes $\cos\!\big(\tfrac{(2k+1)\pi}{2n}\big)$, all in $[-1,1]$. Stated as the exact root-multiset identity
`(T ℝ n).roots = (Finset.image (fun k : Fin n => cos ((2k+1)π/(2n))) univ).val`,
with `T_card_roots` (card = n), `T_roots_nodup` (all simple), `T_roots_mem_Icc` (each root in [−1,1]) as one-line corollaries.

## Proof shape
- `T_natDegree_leadingCoeff` — re-derives `natDegree (T R n) = n ∧ leadingCoeff = 2^(n−1)` over **any** integral domain with `2 ≠ 0` (strict generalization of the parent's ℤ-only induction).
- nodes are roots via `T_real_cos` (Tₙ(cos θ)=cos nθ) + `cos_eq_zero_iff`;
- nodes distinct via `injOn_cos` on `[0,π]`;
- `roots_eq_of_natDegree_le_card_of_ne_zero` closes the exact root set.

## Note on verification
This was untracked prior-session work whose meta.json claimed "verified" but **did not actually compile**. I fixed three genuine build errors (ambiguous-hom `map_ofNat`, an un-normalized exponent `n+2-1`, and a `ring` invoked on no goals) and re-verified.

## Status
**Outcome**: completed — `lean` single-file elaboration EXIT 0, 0 sorries, 9 theorems; `#print axioms` on the four root theorems lists only `propext / Classical.choice / Quot.sound`. (Docker build host has a containerd I/O error; verified via single-file elaboration against prebuilt Mathlib oleans.)

🤖 Generated by researcher-7