### PR TITLE
research(erdos-1090): fill ramsey_lower_bound sorry + fix broken ramseyNumber def (UNVERIFIED)

### DIFF
--- a/proofs/Proofs/Erdos1090Problem.lean
+++ b/proofs/Proofs/Erdos1090Problem.lean
@@ -229,15 +229,35 @@ What is the minimum |A| such that A has the Ramsey property for k?
 Let R(k) denote this minimum.
 -/
 noncomputable def ramseyNumber (k : ℕ) : ℕ :=
-  Nat.find (hunter_observation k (by omega : k ≥ 3) |>.choose_spec ▸ ⟨_, rfl⟩ : ∃ n : ℕ, True)
-  -- Simplified; actual definition would minimize over all valid sets
+  sInf {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k}
+
+/--
+**Ramsey Property Forces Size ≥ k:**
+Any finite set with the Ramsey property for `k` must contain at least `k`
+points. Indeed, applying the property to the constant coloring already yields
+a monochromatic `k`-collinear subset `S ⊆ A`, so `k ≤ |S| ≤ |A|`.
+-/
+theorem hasRamseyProperty_card_ge (A : Finset Point) (k : ℕ)
+    (h : HasRamseyProperty A k) : k ≤ A.card := by
+  obtain ⟨S, hSA, ⟨hSk, _⟩, _⟩ := h (fun _ => true)
+  exact le_trans hSk (Finset.card_le_card hSA)
 
 /--
 **Trivial Lower Bound:**
 R(k) ≥ k since we need at least k points to have k collinear.
+
+For `k ≥ 3` the existence of a witnessing set (`hunter_observation`) makes the
+defining set nonempty, so its infimum is attained by some set `A`, and that
+set has at least `k` points by `hasRamseyProperty_card_ge`.
 -/
 theorem ramsey_lower_bound (k : ℕ) (hk : k ≥ 3) : ramseyNumber k ≥ k := by
-  sorry
+  unfold ramseyNumber
+  have hne : {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k}.Nonempty := by
+    obtain ⟨A, hA⟩ := hunter_observation k hk
+    exact ⟨A.card, A, rfl, hA⟩
+  obtain ⟨A, hcard, hA⟩ := Nat.sInf_mem hne
+  rw [ge_iff_le, ← hcard]
+  exact hasRamseyProperty_card_ge A k hA
 
 /--
 **R(3) is Small:**


### PR DESCRIPTION
## Summary

Erdős #1090 (`erdos-1090`, gallery slug, file `Proofs/Erdos1090Problem.lean`) had **1 remaining sorry** (`ramsey_lower_bound`) that was **unprovable as written**, because the supporting `ramseyNumber` definition was broken:

```lean
noncomputable def ramseyNumber (k : ℕ) : ℕ :=
  Nat.find (hunter_observation k (by omega : k ≥ 3) |>.choose_spec ▸ ⟨_, rfl⟩ : ∃ n : ℕ, True)
```

`Nat.find` over the predicate `True` returns the least `n` satisfying `True`, i.e. **0**, so `ramseyNumber k = 0` for every `k`. The stated lower bound `ramseyNumber k ≥ k` then reduces to `0 ≥ k` for `k ≥ 3` — false, so the sorry could never be filled honestly.

## Changes

- **Fix the definition** to the genuine minimum set size:
  ```lean
  noncomputable def ramseyNumber (k : ℕ) : ℕ :=
    sInf {n : ℕ | ∃ A : Finset Point, A.card = n ∧ HasRamseyProperty A k}
  ```
- **Add helper** `hasRamseyProperty_card_ge`: any `A` with the Ramsey property for `k` satisfies `k ≤ |A|`. Apply the property to the constant coloring `fun _ => true` to obtain a monochromatic `k`-collinear subset `S ⊆ A`, then `k ≤ |S| ≤ |A|` via `Finset.card_le_card`.
- **Prove** `ramsey_lower_bound`: for `k ≥ 3`, `hunter_observation` makes the defining set nonempty, so `Nat.sInf_mem` gives a witnessing `A` with `A.card = ramseyNumber k`, and the helper gives `k ≤ A.card`.

Sorry count for this file: **1 → 0**. The two axioms (`graham_selfridge`, `hunter_observation`) are unchanged, so the entry remains **`axiomatized`** (badge `axiom`).

## ⚠️ UNVERIFIED

Both verification channels are currently down:
- **Docker build host**: containerd I/O error (`write .../meta.db: input/output error`); data volume at **100%** (475Mi free); multiple zombie `lean-build-*` containers hung ~5h.
- **Aristotle API**: returns `"Resource not found"`.

The proof logic was checked by hand (mirrors the standard Ramsey lower-bound argument). **Please re-verify with `./proofs/scripts/docker-build.sh Proofs.Erdos1090Problem` once the build host recovers**, and reconcile `src/data/proofs/erdos-1090/meta.json` (sorries 1→0; theoremCount 5→6 for the new `hasRamseyProperty_card_ge`; conclusion/section text that mentions the remaining sorry) in a follow-up. Meta is intentionally left untouched here to avoid claiming a verified state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)