### PR TITLE
Enrich Descent-Complementing Involution: add annotations

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,124 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 54 },
+    "type": "context",
+    "title": "Unifying the Two Eulerian Borders by an Involution",
+    "content": "The grandparent entry introduced the permutation descent statistic descentCount σ and proved the LEFT border k=0 (descent-free ⟺ identity); the sibling proved the RIGHT border k=n (maximal descents ⟺ the reverse permutation Fin.revPerm). Each border has cardinality 1 = ⟨n+1,0⟩ = ⟨n+1,n⟩. What unifies them — and in fact relates every column k to column n−k — is a single explicit involution Φ(σ) = Fin.revPerm · σ that REVERSES every value. This entry proves Φ sends a permutation with d descents to one with n−d descents, so it is a bijection between the descent class {descentCount = k} and {descentCount = n−k}, yielding the bijective Eulerian palindromy at the level of honest permutations. The companion sibling oq-02-oq-02 proves the same palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩ algebraically, from the closed alternating-sum form; here the equality is realized by an actual map.",
+    "mathContext": "$\\Phi(\\sigma) = \\mathrm{rev}\\cdot\\sigma,\\quad (\\Phi\\sigma)(i) = \\overline{\\sigma(i)},\\qquad \\mathrm{des}(\\Phi\\sigma) = n - \\mathrm{des}(\\sigma).$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Eulerian numbers",
+      "permutation descents",
+      "involution",
+      "bijective proof",
+      "palindrome symmetry"
+    ],
+    "prerequisites": [
+      "the descentCount statistic on Equiv.Perm (Fin (n+1))",
+      "Eulerian triangle row symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩"
+    ]
+  },
+  {
+    "id": "ann-descentcount-def",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 65 },
+    "type": "definition",
+    "title": "The Descent Count of a Permutation",
+    "content": "descentCount σ counts the adjacent positions i : Fin n at which σ falls, σ(i.succ) < σ(i.castSucc). On σ : Equiv.Perm (Fin (n+1)) there are exactly n adjacent comparisons (the n gaps between n+1 values), indexed by i : Fin n via the embeddings i.castSucc and i.succ. The statistic is re-declared locally so the entry depends only on Mathlib and stands alone from the parent Eulerian development. It is the central object: the permutation analogue of the descent statistic whose generating function over the symmetric group is the Eulerian polynomial Aₙ(t) = Σ ⟨n,k⟩ tᵏ.",
+    "mathContext": "$\\mathrm{des}(\\sigma) = \\#\\{\\, i \\in \\mathrm{Fin}\\,n : \\sigma(i{+}1) < \\sigma(i)\\,\\}, \\qquad \\sum_{\\sigma \\in S_{n+1}} t^{\\mathrm{des}(\\sigma)} = A_{n+1}(t).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "descent set",
+      "Eulerian polynomial",
+      "Finset.filter",
+      "Fin.castSucc / Fin.succ"
+    ],
+    "prerequisites": [
+      "permutations as Equiv.Perm",
+      "Finset cardinality"
+    ]
+  },
+  {
+    "id": "ann-descent-complement",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 94 },
+    "type": "insight",
+    "title": "Value-Reversal Complements the Descent Set",
+    "content": "The heart of the entry: descentCount (Fin.revPerm · σ) = n − descentCount σ. The proof shows position i is a descent of Φσ exactly when it is NOT a descent of σ. Since (Φσ) j = (σ j).rev and Fin.rev is strictly antitone (Fin.rev_lt_rev: i.rev < j.rev ↔ j < i), the comparison (σ i.succ).rev < (σ i.castSucc).rev is equivalent to σ i.castSucc < σ i.succ — an ASCENT of σ. The non-obvious direction uses injectivity of σ: lt_trichotomy splits into <, =, > , and the equal case is killed because σ.injective would force i.castSucc = i.succ, contradicting Fin.castSucc_lt_succ. So the strict inequalities are exhaustive — there are no ties — and the descent set of Φσ is the exact set-complement of σ's. Finset.filter_not then Finset.card_univ_diff with Fintype.card_fin convert |complement| into n − descentCount σ.",
+    "mathContext": "$i \\text{ is a descent of }\\Phi\\sigma \\iff \\overline{\\sigma(i{+}1)} < \\overline{\\sigma(i)} \\iff \\sigma(i) < \\sigma(i{+}1) \\iff i \\text{ is an ascent of }\\sigma.$ Injectivity removes ties, so $D(\\Phi\\sigma) = \\mathrm{univ}\\setminus D(\\sigma)$ and $|D(\\Phi\\sigma)| = n - |D(\\sigma)|.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict antitonicity (Fin.rev_lt_rev)",
+      "law of trichotomy",
+      "set complement inside univ",
+      "Finset.card_univ_diff"
+    ],
+    "prerequisites": [
+      "Fin.rev and its order-reversing property",
+      "injectivity of permutations",
+      "Finset complement cardinality"
+    ]
+  },
+  {
+    "id": "ann-revperm-involution",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 96, "endLine": 101 },
+    "type": "technique",
+    "title": "Fin.revPerm Is Its Own Inverse",
+    "content": "revPerm_mul_self: Fin.revPerm · Fin.revPerm = 1. Proved by Equiv.ext, reducing to the pointwise statement (i.rev).rev = i, which is exactly Fin.rev_rev — reversing values twice returns to the start. This is the algebraic fact that makes Φ(σ) = Fin.revPerm · σ an involution: Φ(Φ σ) = Fin.revPerm · (Fin.revPerm · σ) = (Fin.revPerm · Fin.revPerm) · σ = σ. Because Φ is left-multiplication by a group element it needs no bespoke inverse construction; the involution and injectivity both come for free from the group structure of Equiv.Perm.",
+    "mathContext": "$\\mathrm{rev}\\cdot\\mathrm{rev} = 1 \\quad\\text{from}\\quad \\overline{\\overline{i}} = i,\\qquad \\Phi\\circ\\Phi = \\mathrm{id}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "involution",
+      "Equiv.ext",
+      "Fin.rev_rev",
+      "group element of order 2"
+    ],
+    "prerequisites": [
+      "Equiv extensionality",
+      "the group Equiv.Perm (Fin (n+1))"
+    ]
+  },
+  {
+    "id": "ann-palindrome",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 103, "endLine": 129 },
+    "type": "insight",
+    "title": "Bijective Palindromy of the Descent Classes",
+    "content": "card_descentClass_palindrome: for k ≤ n, |{σ : descentCount σ = k}| = |{σ : descentCount σ = n−k}|. The proof packages the two preceding lemmas. First Φ = (Fin.revPerm · ·) is injective by mul_left_cancel (it is left-multiplication in a group). Second, the descent class {= n−k} is exactly the image of {= k} under Φ: for the forward inclusion, given descentCount τ = n−k, the preimage Fin.revPerm · τ has descentCount = n − (n−k) = k (descentCount_complement plus omega) and Φ maps it back to τ (revPerm_mul_self, mul_assoc, one_mul); the reverse inclusion is immediate from descentCount_complement. Finset.card_image_of_injective then equates the two cardinalities. The bound k ≤ n keeps n − k honest (truncated subtraction).",
+    "mathContext": "$\\#\\{\\sigma : \\mathrm{des}(\\sigma)=k\\} = \\#\\{\\sigma : \\mathrm{des}(\\sigma)=n-k\\} \\quad (k \\le n),\\qquad \\{= n-k\\} = \\Phi\\big[\\{= k\\}\\big].$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_image_of_injective",
+      "mul_left_cancel injectivity",
+      "image of a finset under an involution",
+      "Eulerian palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩"
+    ],
+    "prerequisites": [
+      "the descent-complement identity",
+      "injective images preserve cardinality",
+      "truncated natural subtraction"
+    ]
+  },
+  {
+    "id": "ann-border-corollary",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": { "startLine": 131, "endLine": 141 },
+    "type": "concept",
+    "title": "The Two Borders Coincide Through One Map",
+    "content": "card_descentFree_eq_card_descentMax: |{descentCount = 0}| = |{descentCount = n}|, obtained by specializing the palindromy to k=0 (since n − 0 = n) and discharging with simpa. Mathematically this says the same involution that realizes the whole symmetry also exchanges the two extreme permutations: the unique increasing one (no descents, the identity) and the unique decreasing one (all n descents, Fin.revPerm). Thus the two sibling border entries — the left border oq-02-oq-01 and the right border oq-02-oq-01-oq-01 — are not two isolated facts but the two ends of a single reflection, and their common value 1 = ⟨n+1,0⟩ = ⟨n+1,n⟩ is the k=0 case of the bijective palindromy.",
+    "mathContext": "$\\#\\{\\mathrm{des}=0\\} = \\#\\{\\mathrm{des}=n\\},\\qquad \\Phi(\\mathrm{id}) = \\mathrm{rev},\\ \\Phi(\\mathrm{rev}) = \\mathrm{id}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "extreme permutations (identity and reverse)",
+      "specialization of a general identity",
+      "border columns of the Eulerian triangle"
+    ],
+    "prerequisites": [
+      "card_descentClass_palindrome",
+      "the two sibling border entries"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01-oq-01` (The Descent-Complementing Involution and Bijective Eulerian Palindromy).

## Gap addressed
The entry had a comprehensive `meta.json` (overview, sections, conclusion, cross-references, references — all rich) but **no `annotations.json`**, so the proof page had zero inline commentary.

## Changes
Added `annotations.json` with **6 annotations** covering the full Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Docstring context** — unifying the two Eulerian borders by an involution
2. **descentCount definition** — the permutation descent statistic
3. **descentCount_complement** (key insight) — value-reversal complements the descent set; injectivity removes ties so `des(Φσ) = n − des(σ)`
4. **revPerm_mul_self** — `Fin.revPerm` is its own inverse (from `Fin.rev_rev`)
5. **card_descentClass_palindrome** (key insight) — bijective palindromy via `Finset.card_image_of_injective`
6. **Border corollary** — the k=0 specialization unifying the two sibling border entries

## Verification
- `pnpm annotations:build`: no warnings for this entry (annotation ranges align with Lean constructs)
- `check-meta-size`: within caps
- Annotations accurately track the 141-line, 4-theorem Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)