### PR TITLE
research(sperner-ndim-oq-02): Option C inductive decomposition + instance build plan

### DIFF
--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -106,3 +106,147 @@ Beyond the false `boundary_doors_odd`, there are 2 other provable sorries:
 2. If Option C: define `SpernerTriangulation` instance for Freudenthal grid and apply SpernerNDim.sperner
 3. Optionally prove `gridAdj_symm` and `gridAdj_vertex` (useful for any gridComplex application)
 4. Remove or replace `boundary_doors_odd` and `boundary_verts_on_face` with correct formulations
+
+---
+
+## Session 2026-06-27 (Session 2) — Option C locked + inductive decomposition
+
+**Mode**: ORIENT (build on Session 1). **Outcome**: ANALYSIS — confirmed scope,
+produced the concrete inductive proof structure the next session can execute.
+No verified Lean written this session (rationale below).
+
+### Re-survey of current code state
+
+Since Session 1 the `SpernerGrid.lean` file was refactored. Current `sorry` count = 2:
+
+| Line | Decl | Status |
+|------|------|--------|
+| 164  | `CellComplex.sperner` | intentionally `sorry`'d — duplicate of `SpernerMathlib4.sperner`, kept so the file builds standalone. NOT our target. |
+| 1740 | `boundary_doors_odd` | the OQ target — `sorry` with a full counterexample comment block (d=1,N=1 → count 2, EVEN). Still FALSE as stated. |
+
+The two earlier "provable" auxiliary sorries (`gridAdj_symm`, `gridAdj_vertex`,
+`boundary_verts_on_face`) are no longer present as sorries — already resolved or
+removed in the refactor. So the ONLY mathematical gap is the false
+`boundary_doors_odd` and its consumer `sperner_grid` (line 1757).
+
+### The abstract framework already gives us the finish line (Option C confirmed)
+
+`SpernerNDim.lean` is **complete, 0 sorries, 669 lines**. Relevant API:
+
+- `structure SpernerTriangulation (d N : ℕ)` (line 99) — **8 fields**:
+  `Simplex`, `simplex_decidableEq`, `simplex_fintype`, `vertices`,
+  `vertices_injective`, `adj`, `adj_symm`, `adj_vertices`, `adj_ne`,
+  `adj_unique_facet`, `boundary_face`.
+- `theorem sperner_ndim (c) (K : SpernerTriangulation d N) (hc : IsSperner c)`
+  `(hbdry : Odd #{(s,k) | isDoorAt c K s k ∧ K.adj s k = none ∧ k = Fin.last d})`
+  `: ∃ s, IsFC c K s` (line 654). **This is exactly what `sperner_grid` needs.**
+
+So Option C = "construct a `SpernerTriangulation d N` instance for the unoriented
+Freudenthal grid, supply the `hbdry` oddness, apply `sperner_ndim`." Two real
+deliverables remain: the **instance** (Phase 1) and the **`hbdry` oddness by
+induction on d** (Phase 2). Phase 2 is literally the OQ title
+("Boundary-Door Oddness by Dimensional Induction").
+
+### Coordinate-system note (important gotcha for the bridge)
+
+The abstract framework uses `SpernerNDim.Vertex d N` = `{coords : Fin d → ℕ // ∑ ≤ N}`
+(Kuhn cube-corner coordinates, implicit last bary coord = N − ∑).
+`SpernerGrid` uses `BaryPoint d N` = `{coords : Fin (d+1) → ℕ // ∑ = N}`
+(full barycentric). These are **canonically isomorphic**:
+`BaryPoint d N ≃ Vertex d N` via `bary ↦ (i ↦ bary.coords i.castSucc)` (drop last)
+and `vtx ↦ (append (N − ∑ vtx) as last coord)`. Proving this `Equiv` (≈30–50 lines,
+self-contained, no hard adjacency) is the cleanest standalone first PR and lets the
+entire `SpernerNDim` framework be reused over `BaryPoint` without re-deriving it.
+
+### Phase 2 — the inductive door-oddness, worked out precisely
+
+Target: `Odd #{(s,k) | isDoorAt c K s k ∧ K.adj s k = none ∧ k = Fin.last d}`
+for the Freudenthal instance `K` and any Sperner `c`. **Induction on d.**
+
+**Last-face doors ↔ panchromatic (d−1)-simplices.** Decode the three conjuncts
+for a pair `(s, k)` with `k = Fin.last d`:
+- `K.adj s (Fin.last d) = none` ⟹ (by the `boundary_face` field) every vertex
+  `vertices s j` with `j ≠ last` satisfies `onFace · (Fin.last d)`, i.e. lies on
+  **face d** (last bary coord 0 / `∑ coords = N`). So the facet is one of the
+  `d`-vertex simplices sitting inside face d.
+- The d vertices on face d are exactly a top-dimensional simplex of the induced
+  triangulation **of face d**, which is itself the Freudenthal grid of the
+  **(d−1)-simplex** with the same parameter N (this is the OQ's stated geometric
+  fact: "the face-d restriction of the Freudenthal triangulation is a
+  lower-dimensional Freudenthal grid").
+- `isDoorAt c K s (Fin.last d)` ⟹ those d vertices carry **all** colors
+  `{Fin.castSucc j : j : Fin d} = {0,…,d−1}`. Color d cannot appear there: by
+  `IsSperner`, any vertex `onFace (Fin.last d)` has `c v ≠ Fin.last d`. Hence the
+  restricted coloring `c' : Coloring (d−1) N` is well-defined into `Fin d`, is
+  Sperner, and the facet is **panchromatic** (`IsFC c' K'`) for the (d−1)-grid `K'`.
+
+This correspondence is a **bijection** between
+`{last-face boundary doors of the d-grid}` and `{IsFC simplices of the (d−1)-grid K'}`.
+Therefore
+`#{last-face doors of K} = #{IsFC of K'}`.
+
+**Close by induction.** By `sperner_parity c' K' (Sperner c')` at dimension d−1,
+`#{IsFC of K'} ≡ #{last-face doors of K'} (mod 2)`, and by the inductive hypothesis
+the latter is **odd**. Hence `#{last-face doors of K}` is odd.
+
+**Base case d = 0.** `Fin (d+1) = Fin 1`; the door color set `{0,…,d−1}` is empty,
+so `isDoorAt` is vacuously true and `Fin.last 0 = 0`. The 0-grid has exactly one
+simplex with one boundary facet ⟹ count = 1, odd. ✓
+
+(Equivalently one can run the induction directly through `sperner_ndim` at d−1 to
+get an FC simplex and `sperner_parity` for the count; the parity version above is
+what feeds `hbdry`.)
+
+### Phase 1 — the instance, field-by-field plan
+
+Construct `freudenthal d N : SpernerTriangulation d N` (Kuhn/Freudenthal
+triangulation, **unoriented**, one simplex per geometric cell — this is what kills
+the orientation-doubling bug from Session 1):
+
+- `Simplex` := a Kuhn cell = (base lattice point `b`) + (permutation π of `Fin d`
+  giving the order in which unit coordinates are incremented). Vertices are the
+  monotone chain `b = v₀ ⊂ v₁ ⊂ … ⊂ v_d` where `v_{m} = b + ∑_{i<m} e_{π(i)}`.
+  Encode so that **each geometric d-cell has exactly one representative** (do NOT
+  carry a free `miss`/orientation flag — that was the Session-1 bug).
+- `vertices`, `vertices_injective` — chain is strictly increasing ⟹ injective.
+- `adj` — facet `k` (drop vertex `v_k`) pairs with the neighbour obtained by the
+  standard Kuhn pivot (swap adjacent transposition / step base point); `none` iff
+  the pivot leaves the simplex (geometric boundary).
+- `adj_symm`, `adj_ne`, `adj_unique_facet` — standard Kuhn-pivot involution facts.
+- `adj_vertices` — pivot preserves the shared facet's vertex set.
+- `boundary_face` — the crux linking `adj = none` to `onFace`: a dropped facet is on
+  the boundary exactly when its d vertices share a zero/saturated coordinate, i.e.
+  lie on a face of the big simplex. This field is what Phase 2 consumes.
+
+Estimated size: Phase 1 ≈ 250–400 lines, Phase 2 ≈ 150–250 lines. Multi-session.
+Recommend landing the `BaryPoint ≃ Vertex` Equiv first (small, verifiable), then
+Phase 1, then Phase 2.
+
+### Why no verified Lean this session
+
+1. The OQ target is provably FALSE as stated (Session 1); the real work is the
+   Phase-1 instance + Phase-2 induction above, which is a multi-session,
+   ~400–650-line build that must be machine-checked to have value (the role
+   explicitly discourages adding unverifiable scaffolding).
+2. Build infrastructure was degraded at session time: root filesystem at 97%
+   (~420 MiB free) with two ~5-hour-old `lean-build-*` docker containers still
+   running. Triggering a fresh Mathlib docker build under those conditions risks
+   filling the disk; new Lean could not be safely verified. Producing the precise
+   decomposition above is the honest increment until infra recovers.
+
+### Revised Next Steps (supersede Session 1's list)
+
+1. **(small, do first)** Prove `BaryPoint d N ≃ Vertex d N` in a bridge file;
+   verify it builds. Self-contained, no adjacency.
+2. **(Phase 1)** Define `freudenthal d N : SpernerTriangulation d N` (unoriented
+   Kuhn cells, one per geometric simplex); discharge the 8 structure fields.
+3. **(Phase 2)** Prove last-face-door-oddness by induction on d using the
+   door ↔ panchromatic bijection above; feed it to `sperner_ndim`.
+4. Replace `SpernerGrid.boundary_doors_odd`/`sperner_grid` to route through the new
+   instance (or restate `sperner_grid` directly via `sperner_ndim` over `BaryPoint`).
+5. Delete the false `boundary_doors_odd`/`boundary_verts_on_face` once `sperner_grid`
+   no longer depends on them.
+
+**Status flag**: not BLOCKED (path is concrete and the abstract finish line exists),
+but **large + infra-gated**. Treat as a staged build for a session with healthy
+build infra; start with step 1.

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,34 +4,41 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
-Architecture decision and approach implementation. Previous session (2026-04-22) discovered
-`boundary_doors_odd` is **false as stated** due to oriented vs unoriented simplex issue.
-Recommendation: Option C — define `SpernerTriangulation` instance for Freudenthal grid
-using unoriented simplices, apply abstract `SpernerNDim.sperner`.
+Option C locked. Session 2 (2026-06-27) produced the concrete inductive proof
+structure for the Phase-2 oddness and a field-by-field plan for the Phase-1
+`SpernerTriangulation` instance. The abstract `SpernerNDim.sperner_ndim`
+(0-sorry, line 654) is the finish line; it needs an unoriented Freudenthal
+`SpernerTriangulation d N` instance plus an odd last-face-door count.
 
 ## Active Approach
 
-**Option C: SpernerTriangulation instance**
-- Define `FreudenthalComplex d N` with unoriented simplices (vertex sets)
-- Prove the three `SpernerTriangulation` axioms
-- Apply `SpernerNDim.sperner`
+**Option C: SpernerTriangulation instance + inductive door-oddness**
+- (step 0) Prove `BaryPoint d N ≃ Vertex d N` bridge (small, verifiable first PR)
+- (Phase 1) Define `freudenthal d N : SpernerTriangulation d N` — unoriented Kuhn
+  cells, one per geometric simplex; discharge 8 structure fields
+- (Phase 2) Prove last-face-door-oddness by induction on d via the
+  door ↔ panchromatic-(d−1)-simplex bijection (see knowledge.md Session 2)
+- Apply `sperner_ndim`; retire false `boundary_doors_odd`/`boundary_verts_on_face`
 
 ## Attempt Count
-- Total attempts: 1 (prior analysis session, no proof code written)
-- Current approach attempts: 0
-- Approaches tried: 1 (analysis revealed Option A/B/C)
+- Total attempts: 2 (both analysis/planning; no proof code written yet)
+- Current approach attempts: 0 implementation
+- Approaches tried: 1 (Option C; A/B documented as alternatives)
 
 ## Blockers
-None (architectural path is clear from knowledge.md).
+- Not mathematically blocked: path is concrete and the abstract finish line exists.
+- **Infra-gated**: large (~400–650 line) build; needs healthy build infra to verify.
+  At session 2 the root FS was at 97% (~420 MiB free) with 2 stale lean-build
+  containers — unsafe to launch a fresh Mathlib docker build.
 
 ## Next Action
 
-1. Read `proofs/Proofs/SpernerNDim.lean` — understand `SpernerTriangulation` structure definition
-2. Read `proofs/Proofs/SpernerGrid.lean` — understand existing `Vertex`, `GridSimplex`, adjacency
-3. Define unoriented Freudenthal simplex type (as `Finset (Vertex d N)`)
-4. Verify `SpernerTriangulation` axioms are provable for this type
-5. Write the companion `SpernerNDimFreudenthal.lean` or extend `SpernerGrid.lean`
+1. **(small, do first)** Prove `BaryPoint d N ≃ Vertex d N` in a bridge file; build it.
+2. **(Phase 1)** Define `freudenthal d N : SpernerTriangulation d N` (unoriented Kuhn
+   cells, one per geometric cell — no free orientation flag); prove the 8 fields.
+3. **(Phase 2)** Prove last-face-door-oddness by induction on d; feed to `sperner_ndim`.
+4. Reroute `sperner_grid` through the instance; delete the false lemmas.

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "sperner-ndim-oq-02",
   "title": "n-Dimensional Sperner: Boundary-Door Oddness by Dimensional Induction",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "ORIENT",
+  "status": "in-progress",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,24 +16,36 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T13:03:46.382Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ORIENT",
+    "since": "2026-06-27T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Option C locked: build an unoriented Freudenthal SpernerTriangulation instance and supply odd last-face doors to the complete abstract sperner_ndim. Session 2 produced the inductive door-oddness decomposition and a field-by-field instance plan.",
+    "blockers": [
+      "Infra-gated: the full Option C build is ~400-650 lines and must be machine-checked; at session 2 the root FS was at 97% (~420 MiB free) with stale lean-build containers, so a fresh Mathlib docker build was unsafe."
+    ],
+    "nextAction": "Step 1 (small/verifiable first): prove BaryPoint d N ≃ Vertex d N bridge and build it. Then Phase 1 (instance, 8 fields), Phase 2 (inductive last-face-door oddness), apply sperner_ndim.",
     "attemptCounts": {
-      "total": 0,
+      "total": 2,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "boundary_doors_odd (the OQ target) is provably FALSE as stated: the oriented GridSimplex double-counts each geometric cell by orientation, forcing all door/panchromatic counts even (Session 1 counterexample d=1,N=1 -> count 2). Resolution is Option C: instantiate the complete (0-sorry) abstract SpernerNDim.SpernerTriangulation framework with an UNORIENTED Freudenthal grid (one cell per geometric simplex) and feed odd last-face doors to sperner_ndim. Session 2 worked out the inductive oddness and an instance build plan.",
     "builtItems": [],
-    "insights": [],
+    "insights": [
+      "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
+      "Last-face boundary doors of the d-grid are in bijection with panchromatic (d-1)-simplices of the induced (d-1)-Freudenthal grid on face d: adj=none + boundary_face puts the facet on face d; the Sperner condition forbids color d there; isDoorAt = all colors {0..d-1} present = IsFC for the (d-1)-grid. Induction + sperner_parity at d-1 gives oddness. Base d=0: count 1.",
+      "Coordinate bridge: abstract framework uses Vertex d N (Fin d -> N, sum<=N, Kuhn coords); SpernerGrid uses BaryPoint d N (Fin (d+1) -> N, sum=N). They are canonically isomorphic; proving BaryPoint d N ≃ Vertex d N (~30-50 lines, no adjacency) is the cleanest standalone first deliverable and unlocks reuse of the whole framework.",
+      "Phase-1 instance must use unoriented Kuhn cells (base point + permutation of increment order, one representative per geometric cell). The Session-1 orientation-doubling bug came from carrying a free miss/orientation flag in GridSimplex; the instance must NOT."
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Prove BaryPoint d N ≃ Vertex d N in a bridge file and build it (small, verifiable).",
+      "Phase 1: define freudenthal d N : SpernerTriangulation d N (unoriented Kuhn cells) and discharge the 8 structure fields (adj_symm/adj_ne/adj_unique_facet/adj_vertices/boundary_face via the standard Kuhn pivot).",
+      "Phase 2: prove last-face-door-oddness by induction on d using the door <-> panchromatic-(d-1)-simplex bijection; supply it as hbdry to sperner_ndim.",
+      "Reroute sperner_grid through the instance; delete false boundary_doors_odd / boundary_verts_on_face."
+    ]
   },
   "tags": [
     "combinatorics",
@@ -51,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.382Z",
-  "lastUpdate": "2026-04-22T13:03:46.382Z",
+  "lastUpdate": "2026-06-27T00:00:00.000Z",
   "significance": 8,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary

Session 2 (analysis) on `sperner-ndim-oq-02` ("n-Dimensional Sperner: Boundary-Door Oddness by Dimensional Induction"). This is a **planning/analysis** PR — no Lean written this session, for the reasons below.

Session 1 established that the OQ target `SpernerGrid.boundary_doors_odd` is **provably FALSE as stated**: the oriented `GridSimplex` double-counts each geometric cell by orientation, forcing all door/panchromatic counts even (counterexample d=1, N=1 → count 2). This session locks **Option C** and produces the concrete path to a verified `sperner_grid`.

## What's new this session

- **Finish line confirmed.** `SpernerNDim.lean` is complete (669 lines, 0 sorries). Its `sperner_ndim` (line 654) yields a fully-colored simplex from an *odd count of last-face boundary doors* — exactly what `sperner_grid` needs. So Option C = construct an unoriented Freudenthal `SpernerTriangulation d N` instance + supply odd last-face doors.
- **Inductive door-oddness, worked out.** Last-face boundary doors of the d-grid are in **bijection** with panchromatic (d−1)-simplices of the induced (d−1)-Freudenthal grid on face d: `adj = none` + the `boundary_face` field place the facet on face d; `IsSperner` forbids color d there; `isDoorAt` = all colors {0..d−1} present = `IsFC` for the (d−1)-grid. Induction + `sperner_parity` at d−1 give oddness. Base case d=0 → count 1.
- **Field-by-field Phase-1 plan** for the unoriented Kuhn-cell instance (base point + permutation, **one representative per geometric cell** — no orientation flag, which is what fixes the Session-1 doubling bug).
- **Small verifiable first step identified:** prove `BaryPoint d N ≃ Vertex d N` (the barycentric ↔ Kuhn-coordinate bridge, ~30–50 lines, no adjacency) to unlock reuse of the whole abstract framework.

## Why no Lean this session

1. The OQ target is false-as-stated; the real work is a multi-session **~400–650 line** build (Phase-1 instance + Phase-2 induction) that must be machine-checked to have value.
2. Build infra was degraded at session time: root FS at 97% (~420 MiB free) with two ~5h-old `lean-build-*` containers running — unsafe to launch a fresh Mathlib docker build, so new Lean could not be verified.

## Files

- `research/problems/sperner-ndim-oq-02/knowledge.md` — Session 2 entry (decomposition + plan)
- `research/problems/sperner-ndim-oq-02/state.md` — phase ORIENT, revised next steps
- `src/data/research/problems/sperner-ndim-oq-02.json` — insights/nextSteps, status in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)