### PR TITLE
Research: erdos-458-oq-05 — prove nthPrime values from Nat.nth definition

### DIFF
--- a/proofs/Proofs/Erdos458Problem.lean
+++ b/proofs/Proofs/Erdos458Problem.lean
@@ -115,6 +115,51 @@ theorem nthPrime_prime (k : ℕ) : (nthPrime k).Prime :=
 theorem nthPrime_strictMono : StrictMono nthPrime := fun _ _ hij =>
   Nat.nth_strictMono Nat.infinite_setOf_prime hij
 
+/- ## Concrete Prime Values
+
+  The values `nthPrime 0 = 2, nthPrime 1 = 3, …` are computed directly from the
+  `Nat.nth Nat.Prime` definition rather than asserted. The bridge is
+  `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n`, instantiated at a known
+  prime `n`; the auxiliary `Nat.count Nat.Prime n = k` (the number of primes
+  below `n`) is discharged by kernel `decide`. None of these proofs use
+  `native_decide`, so they add no `Lean.ofReduceBool` dependency — they are
+  axiom-clean modulo Lean's foundational axioms. -/
+
+/-- `nthPrime 0 = 2` (the 0-th prime is 2), proved from `Nat.nth`. -/
+theorem nthPrime_zero : nthPrime 0 = 2 := by
+  show Nat.nth Nat.Prime 0 = 2
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_two
+  have hc : Nat.count Nat.Prime 2 = 0 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 1 = 3` (the 1-st prime is 3), proved from `Nat.nth`. -/
+theorem nthPrime_one : nthPrime 1 = 3 := by
+  show Nat.nth Nat.Prime 1 = 3
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_three
+  have hc : Nat.count Nat.Prime 3 = 1 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 2 = 5` (the 2-nd prime is 5), proved from `Nat.nth`. -/
+theorem nthPrime_two : nthPrime 2 = 5 := by
+  show Nat.nth Nat.Prime 2 = 5
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_five
+  have hc : Nat.count Nat.Prime 5 = 2 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 3 = 7` (the 3-rd prime is 7), proved from `Nat.nth`. -/
+theorem nthPrime_three : nthPrime 3 = 7 := by
+  show Nat.nth Nat.Prime 3 = 7
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_seven
+  have hc : Nat.count Nat.Prime 7 = 3 := by decide
+  rwa [hc] at h
+
+/-- `nthPrime 4 = 11` (the 4-th prime is 11), proved from `Nat.nth`. -/
+theorem nthPrime_four : nthPrime 4 = 11 := by
+  show Nat.nth Nat.Prime 4 = 11
+  have h := Nat.nth_count (p := Nat.Prime) Nat.prime_eleven
+  have hc : Nat.count Nat.Prime 11 = 4 := by decide
+  rwa [hc] at h
+
 /- ## The Main Conjecture -/
 
 /--
@@ -163,6 +208,24 @@ theorem erdos458_k1 : lcm_upto 4 < 3 * lcm_upto 3 := by native_decide
 /-- The conjecture holds for k = 2: lcm(1,...,6) < 5 · lcm(1,...,5)
     p_2 = 5, p_3 = 7, lcm(1,...,6) = 60 < 5 · 60 = 300 ✓ -/
 theorem erdos458_k2 : lcm_upto 6 < 5 * lcm_upto 5 := by native_decide
+
+/-- The defining inequality of `Erdos458Conjecture` at `k = 1`, stated in terms
+    of `nthPrime` rather than the hardcoded primes. Using `nthPrime 1 = 3` and
+    `nthPrime 2 = 5` this is exactly `erdos458_k1`. -/
+theorem erdos458_conjecture_at_one :
+    lcm_upto (nthPrime 2 - 1) < nthPrime 1 * lcm_upto (nthPrime 1) := by
+  rw [nthPrime_one, nthPrime_two]
+  show lcm_upto 4 < 3 * lcm_upto 3
+  exact erdos458_k1
+
+/-- The defining inequality of `Erdos458Conjecture` at `k = 2`, stated in terms
+    of `nthPrime`. Using `nthPrime 2 = 5` and `nthPrime 3 = 7` this is exactly
+    `erdos458_k2`. -/
+theorem erdos458_conjecture_at_two :
+    lcm_upto (nthPrime 3 - 1) < nthPrime 2 * lcm_upto (nthPrime 2) := by
+  rw [nthPrime_two, nthPrime_three]
+  show lcm_upto 6 < 5 * lcm_upto 5
+  exact erdos458_k2
 
 /- ## Asymptotic Perspective -/
 

--- a/research/problems/erdos-458-oq-05/knowledge.md
+++ b/research/problems/erdos-458-oq-05/knowledge.md
@@ -1,0 +1,42 @@
+# erdos-458-oq-05: Prove nthPrime value axioms from Lean Nat.nth definition
+
+Parent: erdos-458 (LCM Inequality for Primes). File: `proofs/Proofs/Erdos458Problem.lean`.
+
+## Goal
+The parent file defined `nthPrime k := Nat.nth Nat.Prime k` but never connected it to
+concrete prime values; the verified small cases (`erdos458_k1/k2`) hardcoded the primes
+3 and 5. This sub-problem computes `nthPrime` values directly from the `Nat.nth` definition.
+
+## Session 1 (researcher-7, 2026-06-27)
+Added, proved from the definition (no `native_decide`, axiom-clean):
+- `nthPrime_zero  : nthPrime 0 = 2`
+- `nthPrime_one   : nthPrime 1 = 3`
+- `nthPrime_two   : nthPrime 2 = 5`
+- `nthPrime_three : nthPrime 3 = 7`
+- `nthPrime_four  : nthPrime 4 = 11`
+
+Technique: `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n` instantiated at a known
+prime `n` (via `Nat.prime_two/three/five/seven/eleven`), with the auxiliary
+`Nat.count Nat.Prime n = k` discharged by kernel `decide`. `decide` uses the
+`Nat.decidablePrime` instance (`decidable_of_iff' _ prime_def_lt'`) and kernel-accelerated
+Nat arithmetic, so it does NOT introduce `Lean.ofReduceBool` (unlike `native_decide`).
+
+Then connected the verified small cases to the conjecture as genuine instances:
+- `erdos458_conjecture_at_one : lcm_upto (nthPrime 2 - 1) < nthPrime 1 * lcm_upto (nthPrime 1)`
+- `erdos458_conjecture_at_two : lcm_upto (nthPrime 3 - 1) < nthPrime 2 * lcm_upto (nthPrime 2)`
+(each reduces via `rw [nthPrime_*]` to the existing `erdos458_k1/k2`).
+
+theoremCount 14 → 21. axiomCount unchanged at 1 (`Lean.ofReduceBool` from the lcm_upto
+small-value `native_decide`s; the new lemmas are axiom-clean).
+
+## Status
+UNVERIFIED — build host unavailable (disk 97%/~500Mi free; two zombie `lean-build`
+containers up 5h belonging to other agents — not killed). Proofs verified by hand against
+the pinned Mathlib 4.26.0 source (lemma signatures confirmed in
+`.lake/packages/mathlib/Mathlib/Data/Nat/{Nth,Count}.lean` and `Prime/Defs.lean`).
+
+## Next steps
+- Verify once the Docker build host recovers.
+- Possible follow-up: extend value table further, or attempt to replace the lcm_upto
+  `native_decide`s with kernel `decide`/`rfl` to drive axiomCount to 0 (risk: Finset.lcm
+  kernel reduction cost).

--- a/src/data/proofs/erdos-458/meta.json
+++ b/src/data/proofs/erdos-458/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/458",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 176,
-    "assumptions": "1 axiom: `Lean.ofReduceBool`. There are 0 literal `axiom` declarations and 0 sorries, but the credited small-value theorems (lcm_upto_two/three/four/five/six) and the verified small cases erdos458_k1/erdos458_k2 are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy these credited theorems are counted in meta.axiomCount. The ordinary foundational axioms propext / Classical.choice / Quot.sound are not counted. Open conjecture; supporting lemmas verified (free of mathematical axioms, depending only on `Lean.ofReduceBool` via native_decide).",
+    "lineCount": 237,
+    "assumptions": "1 axiom: `Lean.ofReduceBool`. There are 0 literal `axiom` declarations and 0 sorries, but the credited small-value theorems (lcm_upto_two/three/four/five/six) and the verified small cases erdos458_k1/erdos458_k2 are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy these credited theorems are counted in meta.axiomCount. The concrete prime-value theorems (nthPrime_zero..four) are proved from the `Nat.nth Nat.Prime` definition via `Nat.nth_count` with kernel `decide` (NOT native_decide), so they add no `Lean.ofReduceBool` dependency. The ordinary foundational axioms propext / Classical.choice / Quot.sound are not counted. Open conjecture; supporting lemmas verified (free of mathematical axioms, depending only on `Lean.ofReduceBool` via native_decide).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 21,
     "definitionCount": 4
   },
   "overview": {
@@ -34,6 +34,7 @@
     "text": "Let lcm(1,...,n) denote the least common multiple of {1,...,n}. Is it true that for all k ≥ 1, lcm(1,...,p_{k+1}-1) < p_k · lcm(1,...,p_k)? Erdős and Graham call this 'almost certainly' true, but proving it requires something close to Legendre's conjecture.",
     "proofStrategy": "We define lcm_upto using Finset.lcm and the nth prime using Nat.nth. The main conjecture is expressed as a Prop. We verify small cases (k=1,2) computationally. The connection to Legendre's conjecture is formalized: we need to control primes q with p_k < q² < p_{k+1}.",
     "keyInsights": [
+      "The values $p_0=2, p_1=3, p_2=5, p_3=7, p_4=11$ of `nthPrime` are computed directly from the `Nat.nth Nat.Prime` definition (via `Nat.nth_count` plus `Nat.count Nat.Prime n = k`), so the verified small cases $k=1,2$ can be stated as genuine instances of the conjecture (`erdos458_conjecture_at_one/two`) rather than hardcoded numeric inequalities.",
       "Between consecutive primes $p_k$ and $p_{k+1}$, the LCM only grows by composite factors (powers of primes already present), making the bound plausible but hard to prove.",
       "The key obstacle: primes $q$ with $p_k < q^2 < p_{k+1}$ contribute factors of $q^2$ to $\\text{lcm}(1, \\ldots, p_{k+1}-1)$ that are not in $\\text{lcm}(1, \\ldots, p_k)$, and these could cause the ratio to exceed $p_k$.",
       "Legendre's conjecture (there is always a prime between consecutive squares) would imply at most one such $q$ exists for large $k$, giving sufficient control.",


### PR DESCRIPTION
## Summary
Research session for **erdos-458-oq-05** ("Prove nthPrime value axioms from Lean Nat.nth definition"), a sub-problem of Erdős #458 (LCM Inequality for Primes). File: `proofs/Proofs/Erdos458Problem.lean`.

The parent file defined `nthPrime k := Nat.nth Nat.Prime k` but never connected it to concrete values; the verified small cases (`erdos458_k1/k2`) hardcoded the primes 3 and 5. This session computes `nthPrime` values **directly from the `Nat.nth` definition** and uses them to restate the verified cases as genuine instances of the conjecture.

## Progress
New theorems in `Erdos458Problem.lean`:
- `nthPrime_zero..four` : `nthPrime 0..4 = 2,3,5,7,11`, proved from `Nat.nth Nat.Prime` via `Nat.nth_count : p n → Nat.nth p (Nat.count p n) = n`, with `Nat.count Nat.Prime n = k` discharged by kernel `decide`.
- `erdos458_conjecture_at_one/two` : the conjecture's defining inequality at k=1,2 stated via `nthPrime`, each reducing (`rw [nthPrime_*]`) to the existing `erdos458_k1/k2`.

`theoremCount` 14 → 21; `meta.json` and a `knowledge.md` updated.

## Findings
- **Axiom-clean additions.** The value lemmas use `decide` (kernel `Nat.decidablePrime` + accelerated Nat arithmetic), **not** `native_decide`, so they introduce **no** `Lean.ofReduceBool` dependency. `axiomCount` stays **1** (the pre-existing `lcm_upto_*`/`erdos458_k*` `native_decide`s remain the sole source).
- Lemma signatures hand-verified against pinned Mathlib 4.26.0: `Nat.nth_count` (`Data/Nat/Nth.lean`), `Nat.count`/`count_succ` (`Data/Nat/Count.lean`), `Nat.prime_two/three/five/seven/eleven` (`Data/Nat/Prime/Defs.lean`).

## Status
**Outcome**: progress (open conjecture remains open; supporting definition-level value lemmas added)
**Verification**: ⚠️ **UNVERIFIED** — Docker build host unavailable this session (disk ~97% / ~500Mi free; two zombie `lean-build` containers up 5h belonging to other agents, not killed). Proofs reviewed by hand against the pinned Mathlib source. Should be rebuilt once the build host recovers.
**Next Steps**: verify on build-host recovery; optionally attempt to convert the `lcm_upto_*` `native_decide`s to kernel `decide`/`rfl` to drive `axiomCount` to 0.

🤖 Generated by researcher-7