### PR TITLE
research(erdos-671): Lebesgue constant Λ_n ≥ 1 + λ_n continuity (UNVERIFIED — build host down)

### DIFF
--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -183,6 +183,36 @@ theorem lebesgueFunction_ge_one (pts : InterpolationPoints n) (hn : 0 < n) (x : 
 noncomputable def lebesgueConstant (pts : InterpolationPoints n) : ℝ :=
   ⨆ x ∈ Set.Icc (-1 : ℝ) 1, lebesgueFunction pts x
 
+/-- The Lebesgue function is continuous: it is a finite sum of `|p_i(x)|`, each of
+which is continuous (the absolute value composed with polynomial evaluation). -/
+theorem lebesgueFunction_continuous (pts : InterpolationPoints n) :
+    Continuous (lebesgueFunction pts) := by
+  unfold lebesgueFunction
+  exact continuous_finset_sum _ (fun i _ => (Polynomial.continuous _).abs)
+
+/-- The Lebesgue constant is always at least 1: Λ_n ≥ 1 for n ≥ 1.
+
+This is a fundamental lower bound in approximation theory. It follows from the
+partition-of-unity bound λ_n(x) ≥ 1 (`lebesgueFunction_ge_one`) together with the
+fact that, by continuity of λ_n on the compact interval [-1,1], the supremum
+defining Λ_n is a genuine supremum of a bounded-above set (not the junk value 0). -/
+theorem lebesgueConstant_ge_one (pts : InterpolationPoints n) (hn : 0 < n) :
+    lebesgueConstant pts ≥ 1 := by
+  -- The image of [-1,1] under the continuous λ_n is bounded above (compactness).
+  have hbdd : BddAbove (lebesgueFunction pts '' Set.Icc (-1 : ℝ) 1) :=
+    isCompact_Icc.bddAbove_image (lebesgueFunction_continuous pts).continuousOn
+  -- 0 ∈ [-1,1], so λ_n(0) lies in that image.
+  have h0 : (0 : ℝ) ∈ Set.Icc (-1 : ℝ) 1 := by norm_num [Set.mem_Icc]
+  have hmem : lebesgueFunction pts 0 ∈ lebesgueFunction pts '' Set.Icc (-1 : ℝ) 1 :=
+    ⟨0, h0, rfl⟩
+  -- Hence λ_n(0) ≤ Λ_n, while λ_n(0) ≥ 1.
+  have hle : lebesgueFunction pts 0 ≤ lebesgueConstant pts := by
+    unfold lebesgueConstant
+    rw [← sSup_image]
+    exact le_csSup hbdd hmem
+  calc (1 : ℝ) ≤ lebesgueFunction pts 0 := lebesgueFunction_ge_one pts hn 0
+    _ ≤ lebesgueConstant pts := hle
+
 /-
 **Error bound**: |L^n f(x) - f(x)| ≤ (1 + Λ_n) · best_approx_n(f).
 This shows Lebesgue constant controls interpolation quality.

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -65,12 +65,14 @@
       "q2_implies_q1 (proved): Question2 implies Question1",
       "q2_fails_implies (proved): negation gives explicit divergence",
       "faber theorem: no universal convergent sequence (sorry)",
-      "MainConjecture definition: Q1 iff Q2?"
+      "MainConjecture definition: Q1 iff Q2?",
+      "lebesgueFunction_continuous (proved): lambda_n is continuous (finite sum of |polynomial evals|)",
+      "lebesgueConstant_ge_one (proved): Lambda_n >= 1 always, via lambda_n >= 1 + compactness/continuity (BddAbove of the supremum)"
     ],
     "axiomCount": 3,
-    "lineCount": 397,
+    "lineCount": 427,
     "assumptions": "3 axiom(s) and 7 sorry(s). See the Lean source for details.",
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 13,
     "additionalFiles": [
       "Proofs/Erdos671Aristotle.lean",
@@ -127,87 +129,87 @@
       "id": "lebesgue-function",
       "title": "Part III: The Lebesgue Function",
       "startLine": 115,
-      "endLine": 190,
+      "endLine": 220,
       "summary": "Defines `lebesgueFunction pts x` $=\\sum_i|p_i(x)|$ and `lebesgueConstant` $=\\sup_{x\\in[-1,1]}\\lambda_n(x)$. PROVES the private partition-of-unity lemma `lagrangeBasis_sum_one` ($\\sum_i p_i(x)=1$, via a degree-$\\leq n-1$ polynomial with $n$ roots being zero) and `lebesgueFunction_ge_one` ($\\lambda_n(x)\\geq1$, from $|\\sum p_i|\\leq\\sum|p_i|$). A note records the error bound $|L^nf-f|\\leq(1+\\Lambda_n)\\cdot E_n(f)$.",
       "mathContext": "$\\sum_i p_i(x)=1$ (partition of unity) $\\Rightarrow\\lambda_n(x)\\geq1$; $\\Lambda_n=\\max_{[-1,1]}\\lambda_n$."
     },
     {
       "id": "bernstein",
       "title": "Part IV: Bernstein's Theorem",
-      "startLine": 191,
-      "endLine": 208,
+      "startLine": 221,
+      "endLine": 238,
       "summary": "Defines `LebesgueUnbounded` ($\\limsup\\lambda_n(x)=\\infty$). States Bernstein's 1931 theorem `bernstein` (some $x_0$ has unbounded Lebesgue function — `sorry`) and `lebesgueConstant_growth` ($\\Lambda_n\\geq(2/\\pi)\\log n - 1$ — `sorry`). A note records that Chebyshev nodes attain the optimal $\\sim(2/\\pi)\\log n$ growth.",
       "mathContext": "Bernstein: $\\exists x_0,\\ \\limsup_n\\lambda_n(x_0)=\\infty$. $\\Lambda_n\\geq(2/\\pi)\\log n - 1$."
     },
     {
       "id": "erdos-vertesi",
       "title": "Part V: Erdős-Vértesi Theorem",
-      "startLine": 209,
-      "endLine": 223,
+      "startLine": 239,
+      "endLine": 253,
       "summary": "Defines `InterpUnbounded` ($|L^nf(x)|\\to\\infty$ frequently). States the Erdős–Vértesi 1980 theorem `erdos_vertesi`: for any nodes there is a continuous $f$ with $|L^nf(x)|\\to\\infty$ for a.e. $x$ (`sorry`). A note: divergence is generic (Baire category).",
       "mathContext": "Erdős–Vértesi: $\\exists f\\in C[-1,1]$ with $|L^nf(x)|\\to\\infty$ for a.e. $x$."
     },
     {
       "id": "question1",
       "title": "Part VI: Question 1",
-      "startLine": 224,
-      "endLine": 235,
+      "startLine": 254,
+      "endLine": 265,
       "summary": "Formalizes `Question1`: there is a node sequence such that for every continuous $f$ some $x$ has $\\limsup\\lambda_n(x)=\\infty$ yet $L^nf(x)\\to f(x)$. Declared OPEN via the axiom `question1_open`.",
       "mathContext": "Q1: $\\exists$ seq, $\\forall f\\,\\exists x$: $\\lambda_n(x)$ unbounded $\\wedge\\ L^nf(x)\\to f(x)$."
     },
     {
       "id": "question2",
       "title": "Part VII: Question 2",
-      "startLine": 236,
-      "endLine": 255,
+      "startLine": 266,
+      "endLine": 285,
       "summary": "Formalizes `Question2`: a node sequence with $\\limsup\\lambda_n(x)=\\infty$ for ALL $x\\in[-1,1]$, yet for every continuous $f$ some $x$ has $L^nf(x)\\to f(x)$. Declared OPEN via the axiom `question2_open`. PROVES `q2_implies_q1` (Question 2 is strictly stronger).",
       "mathContext": "Q2 (all-$x$ unboundedness) $\\Rightarrow$ Q1."
     },
     {
       "id": "special-sequences",
       "title": "Part VIII: Special Point Sequences",
-      "startLine": 256,
-      "endLine": 318,
+      "startLine": 286,
+      "endLine": 348,
       "summary": "Concrete node families. Defines `chebyshevNodes` ($x_k=\\cos\\frac{(2k+1)\\pi}{2n}$) and `equidistantNodes` ($x_k=-1+2k/(n-1)$), each with the distinctness obligation FULLY PROVED (via injectivity of $\\cos$ on $[0,\\pi]$ / linear node spacing). States `equidistant_diverges` ($\\Lambda_n\\geq2^{n-1}/n^2$ for equidistant nodes — `sorry`).",
       "mathContext": "Chebyshev $x_k=\\cos\\frac{(2k+1)\\pi}{2n}$; equidistant $x_k=-1+\\frac{2k}{n-1}$ with $\\Lambda_n\\geq2^{n-1}/n^2$."
     },
     {
       "id": "convergence-conditions",
       "title": "Part IX: Convergence Conditions",
-      "startLine": 319,
-      "endLine": 327,
+      "startLine": 349,
+      "endLine": 357,
       "summary": "A docstring summarizing classical convergence criteria: uniform convergence iff $\\Lambda_n\\cdot\\omega(f,1/n)\\to0$; Lipschitz functions converge when $\\Lambda_n=O(\\log n)$; analytic functions converge for any node sequence. No declarations.",
       "mathContext": "Uniform $L^nf\\to f$ iff $\\Lambda_n\\,\\omega(f,1/n)\\to0$; analytic $f$ always converge."
     },
     {
       "id": "pointwise-uniform",
       "title": "Part X: Pointwise vs Uniform Convergence",
-      "startLine": 328,
-      "endLine": 338,
+      "startLine": 358,
+      "endLine": 368,
       "summary": "States Faber's theorem `faber`: no node sequence yields convergence for all continuous $f$ (`sorry`). A note contrasts pointwise vs uniform convergence.",
       "mathContext": "Faber: no node sequence gives convergence for every $f\\in C[-1,1]$."
     },
     {
       "id": "measure-theoretic",
       "title": "Part XI: Measure-Theoretic Aspects",
-      "startLine": 339,
-      "endLine": 354,
+      "startLine": 369,
+      "endLine": 384,
       "summary": "States two measure-theoretic results (both `sorry`): `positive_measure_divergence` (for some $f$, the divergence set has positive measure) and `full_measure_convergence` (for some sequence and $f$, the convergence set has full measure).",
       "mathContext": "Divergence on positive-measure sets vs convergence on full-measure sets (both stated, sorry)."
     },
     {
       "id": "main-conjecture",
       "title": "Part XII: The Main Conjecture",
-      "startLine": 355,
-      "endLine": 377,
+      "startLine": 385,
+      "endLine": 408,
       "summary": "Defines `MainConjecture` ($\\text{Question1}\\leftrightarrow\\text{Question2}$), declared OPEN via the axiom `main_conjecture_open`. PROVES `q2_fails_implies`: if Question 2 fails, then every all-$x$-unbounded sequence admits a continuous $f$ with no convergence point.",
       "mathContext": "Main conjecture: Q1 $\\leftrightarrow$ Q2 (open). $\\neg$Q2 $\\Rightarrow$ full divergence for some $f$."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 378,
-      "endLine": 397,
+      "startLine": 409,
+      "endLine": 427,
       "summary": "Closing docstring recapping the problem (OPEN, $250 prize), the two questions, the known Bernstein/Erdős–Vértesi results, and the key remaining sorries (`bernstein`, `erdos_vertesi`) and open-question axioms (`question1_open`, `question2_open`).",
       "mathContext": "Recap: 7 sorries (classical/measure results) + 3 axioms (the open questions/conjecture)."
     }
@@ -227,9 +229,9 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 397,
+    "lineCount": 427,
     "axiomCount": 3,
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 13,
     "sorries": 7,
     "path": "Proofs/Erdos671Problem.lean",


### PR DESCRIPTION
## Summary

Adds two **fully-proved** (no `sorry`, no `axiom`) lemmas to the Lagrange-interpolation formalization of **Erdős Problem #671** (Lagrange interpolation convergence, OPEN, \$250):

- **`lebesgueFunction_continuous`** — the Lebesgue function λ_n is continuous (a finite sum of `|p_i(x)|`, each the absolute value of a polynomial evaluation).
- **`lebesgueConstant_ge_one`** — **Λ_n ≥ 1** for every node set with n ≥ 1. This is the fundamental lower bound on the Lebesgue constant in approximation theory.

### Proof idea for Λ_n ≥ 1
The existing `lebesgueFunction_ge_one` gives λ_n(x) ≥ 1 pointwise (from the partition-of-unity Σ p_i = 1). Λ_n is defined as `⨆ x ∈ [-1,1], λ_n(x)`. In ℝ a supremum of an unbounded-above family collapses to a junk value, so we must show the family is bounded above: continuity of λ_n + compactness of [-1,1] gives `BddAbove` of the image (`IsCompact.bddAbove_image`). Then via `sSup_image`/`le_csSup`, Λ_n ≥ λ_n(0) ≥ 1.

The continuity lemma is also reusable infrastructure toward the remaining open sorries (`bernstein`, `lebesgueConstant_growth`).

## Metadata
- `theoremCount` 15 → 17, `lineCount` 397 → 427, section line ranges shifted, `originalContributions` updated.
- Status remains **`axiomatized`**: the 3 open-question axioms (`question1_open`, `question2_open`, `main_conjecture_open`) and 7 classical sorries (Bernstein, Erdős–Vértesi, Faber, …) are **unchanged**. This PR only adds new verified content.

## ⚠️ Verification status: UNVERIFIED
Both verification channels were down at commit time:
- **Docker build** fails with a containerd `input/output error` (host disk at 98%, ~331Mi free).
- **Aristotle** returns `Resource not found`.

As a substitute, every Mathlib API call used was checked by name and signature against the **pinned local Mathlib source** (`proofs/.lake/packages/mathlib`):
`IsCompact.bddAbove_image`, `Polynomial.continuous`, `Continuous.abs` (additive of `Continuous.mabs`), `continuous_finset_sum`, `sSup_image`, `le_csSup`. All present with matching signatures. Please re-run `./proofs/scripts/docker-build.sh Proofs.Erdos671Problem` once the build host recovers before treating these lemmas as machine-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)