### PR TITLE
research(chinese-remainder-constructive-oq-03-oq-02): gallery entry for balanced three-moduli RNS set {2ⁿ−1, 2ⁿ, 2ⁿ+1}

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/annotations.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": "ann-coprime-consecutive",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-02",
+    "range": {
+      "startLine": 72,
+      "endLine": 88
+    },
+    "type": "insight",
+    "title": "Consecutive Integers Are Coprime — Two Channels for Free",
+    "content": "`coprime_consecutive a : Nat.Coprime a (a+1)` proves any two consecutive integers are coprime: `Nat.gcd a (a+1)` divides their difference `(a+1) − a = 1` (via `Nat.dvd_sub'` on the two `Nat.gcd_dvd_*` facts), so by `Nat.dvd_one` the gcd is 1. This single lemma immediately discharges two of the three coprimality obligations: `coprime_low_mid` (2ⁿ−1 and 2ⁿ) and `coprime_mid_high` (2ⁿ and 2ⁿ+1), since each pair is consecutive. `coprime_low_mid` only needs to rewrite `(2ⁿ−1)+1` back to `2ⁿ` using `Nat.sub_add_cancel` with `1 ≤ 2ⁿ`.",
+    "mathContext": "For the Chinese Remainder Theorem to give a unique residue representative in $[0, M)$ the moduli must be pairwise coprime. In the set $\\{2^n-1, 2^n, 2^n+1\\}$ the middle modulus is consecutive with each neighbor, so $\\gcd(2^n-1, 2^n) = \\gcd(2^n, 2^n+1) = 1$ is automatic — only the two odd ends require a genuine argument.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.dvd_sub'",
+      "Nat.dvd_one",
+      "Nat.gcd_dvd_left",
+      "Nat.sub_add_cancel"
+    ],
+    "prerequisites": [
+      "Nat.Coprime definition (gcd = 1)",
+      "Mathlib.Data.Nat.GCD.Basic"
+    ]
+  },
+  {
+    "id": "ann-coprime-low-high",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-02",
+    "range": {
+      "startLine": 90,
+      "endLine": 109
+    },
+    "type": "insight",
+    "title": "The Only Hard Pair: 2ⁿ−1 and 2ⁿ+1",
+    "content": "`coprime_low_high n (hn : 1 ≤ n)` proves `Nat.Coprime (2ⁿ−1) (2ⁿ+1)`, the one nontrivial coprimality. The two moduli differ by 2, so `g = gcd(2ⁿ−1, 2ⁿ+1)` divides 2 (via `Nat.dvd_sub'` on the difference `(2ⁿ+1) − (2ⁿ−1) = 2`). But `g` cannot be 2: since `2 ∣ 2ⁿ` (from `dvd_pow_self`, n ≠ 0), `omega` derives `¬ 2 ∣ (2ⁿ−1)`. With `g ∣ 2` and 2 prime, `Nat.dvd_prime Nat.prime_two` forces `g = 1`. The `n ≥ 1` hypothesis is essential — it makes `2ⁿ` even and `2ⁿ−1` odd.",
+    "mathContext": "Two odd numbers differing by 2 (twin-like) share a common divisor only if it divides their difference 2 and is itself odd, hence 1. This is the modular-arithmetic reason the outer two channels of the balanced base never collide, completing pairwise coprimality of the whole triple.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.dvd_prime",
+      "Nat.prime_two",
+      "dvd_pow_self",
+      "Nat.dvd_sub'"
+    ],
+    "prerequisites": [
+      "coprime_consecutive",
+      "Parity of powers of two"
+    ]
+  },
+  {
+    "id": "ann-dynamic-range-formula",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-02",
+    "range": {
+      "startLine": 115,
+      "endLine": 129
+    },
+    "type": "computation",
+    "title": "Exact Dynamic Range: 2^(3n) − 2ⁿ",
+    "content": "`dynamicRange_formula n : (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ` is the polynomial identity `a(a−1)(a+1) = a³−a` with `a = 2ⁿ`, where `2^(3n) = (2ⁿ)³` (via `pow_mul`). The obstacle is natural-number subtraction (`2ⁿ−1` truncates if mishandled). The proof sidesteps it by writing `2ⁿ = k+1` (legal since `1 ≤ 2ⁿ`), reducing the goal to `k·(k+1)·(k+2) = (k+1)³ − (k+1)`, then proves the truncation-free `key : k·(k+1)·(k+2) + (k+1) = (k+1)³` with `ring` and converts via `Nat.eq_sub_of_add_eq`.",
+    "mathContext": "The dynamic range $M = \\prod m_i = (2^n-1)\\,2^n\\,(2^n+1) = 2^{3n} - 2^n$ is exactly one $2^n$ short of a full $3n$-bit word $2^{3n}$. So three $n$-bit channels deliver just under $3n$ bits of representable range — the quantitative efficiency statement for the base.",
+    "significance": "key",
+    "relatedConcepts": [
+      "pow_mul",
+      "Nat.eq_sub_of_add_eq",
+      "ring",
+      "Natural number subtraction"
+    ],
+    "prerequisites": [
+      "Nat.one_le_pow",
+      "Polynomial identity a(a-1)(a+1) = a^3 - a"
+    ]
+  },
+  {
+    "id": "ann-three-moduli-base",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-02",
+    "range": {
+      "startLine": 135,
+      "endLine": 189
+    },
+    "type": "definition",
+    "title": "threeModuliBase: A Genuine RNS Base",
+    "content": "A self-contained `RNSBase` structure (fields: `moduli : List ℕ`, `coprime : moduli.Pairwise Nat.Coprime`, `ge_two : ∀ m ∈ moduli, 2 ≤ m`) is re-declared locally because the parent `ChineseRemainderConstructiveOQ03` no longer compiles against Mathlib 4.26.0. `threeModuli_pairwise_coprime` assembles pairwise coprimality of `[2ⁿ−1, 2ⁿ, 2ⁿ+1]` from the three pair facts via nested `List.Pairwise.cons`. `threeModuliBase n (hn : 2 ≤ n)` is then the base with `channels = 3` (`rfl`) and `dynamicRange = 2^(3n) − 2ⁿ` (`threeModuliBase_dynamicRange`, from `List.prod_cons` + `dynamicRange_formula`). The `n ≥ 2` bound ensures the smallest modulus `2ⁿ−1 ≥ 3 ≥ 2`.",
+    "mathContext": "Bundling the moduli, a proof of pairwise coprimality, and the lower bound on each modulus is exactly the data the CRT needs to guarantee a bijection between residue vectors and integers in $[0, M)$. Exhibiting $\\{2^n-1, 2^n, 2^n+1\\}$ as such a structure certifies it is a legitimate RNS base, not merely a coprime list.",
+    "significance": "key",
+    "relatedConcepts": [
+      "List.Pairwise.cons",
+      "List.prod_cons",
+      "RNSBase",
+      "Chinese Remainder Theorem"
+    ],
+    "prerequisites": [
+      "coprime_low_mid, coprime_mid_high, coprime_low_high",
+      "dynamicRange_formula"
+    ]
+  },
+  {
+    "id": "ann-balance-crt-step",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-02",
+    "range": {
+      "startLine": 195,
+      "endLine": 212
+    },
+    "type": "insight",
+    "title": "Balance and the Two-Modulus CRT Reduction Step",
+    "content": "`threeModuli_balanced n (hn : 2 ≤ n) : 2ⁿ+1 ≤ 2·(2ⁿ−1)` shows the widest channel is below twice the narrowest (closed by `omega` from `4 ≤ 2ⁿ`) — the balance property that minimizes critical-path channel width per unit of dynamic range. `threeModuli_crt_step n (hn : 1 ≤ n) : Nat.Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1)` packages the low–high and mid–high facts with `Nat.Coprime.mul`, giving precisely the coprimality needed to fold the first two residues into one modulo `(2ⁿ−1)·2ⁿ` and then reconstruct against `2ⁿ+1` by two-modulus CRT (the kernel of Garner's iterated algorithm).",
+    "mathContext": "Hardware RNS reconstruction proceeds pair-by-pair: combine channels 1 and 2 (coprime, so $\\gcd = 1$ and CRT applies) into a single residue mod $(2^n-1)2^n$, then combine with channel 3. The required hypothesis is $\\gcd((2^n-1)2^n,\\,2^n+1) = 1$, which `Nat.Coprime.mul` derives from the two underlying pair coprimalities. Balance ensures every such step has comparable channel widths, keeping the carry/critical path short.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.Coprime.mul",
+      "Garner's algorithm",
+      "Critical path width",
+      "Iterated CRT reconstruction"
+    ],
+    "prerequisites": [
+      "coprime_low_high, coprime_mid_high",
+      "omega"
+    ]
+  },
+  {
+    "id": "ann-cross-checks",
+    "proofId": "chinese-remainder-constructive-oq-03-oq-02",
+    "range": {
+      "startLine": 214,
+      "endLine": 239
+    },
+    "type": "example",
+    "title": "Concrete Instances: {3,4,5}, {7,8,9}, {15,16,17}",
+    "content": "The abstract base is pinned to concrete numbers for n = 2, 3, 4. `threeModuliBase_two_eq` evaluates `(threeModuliBase 2 _).moduli = [3,4,5]` by `decide`. For each n the moduli list is confirmed pairwise coprime by `decide` ([3,4,5], [7,8,9], [15,16,17]) and the product is checked against the formula by `norm_num`: range 60 = 2⁶−2², 504 = 2⁹−2³, 4080 = 2¹²−2⁴. These ground the general theorems in checkable arithmetic.",
+    "mathContext": "The n = 4 base $\\{15, 16, 17\\}$ is a standard textbook RNS example: 16 = 2⁴ is a pure bit-mask channel, 15 = 2⁴−1 a Mersenne-wrap channel, and 17 = 2⁴+1 a Fermat-style channel, together giving dynamic range 4080, just short of the 4096 = 2¹² full 12-bit word.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide",
+      "norm_num",
+      "Mersenne and Fermat moduli"
+    ],
+    "prerequisites": [
+      "threeModuliBase",
+      "dynamicRange_formula"
+    ]
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "chinese-remainder-constructive-oq-03-oq-02",
+  "title": "CRT RNS: The Balanced Three-Moduli Set {2ⁿ−1, 2ⁿ, 2ⁿ+1}",
+  "slug": "chinese-remainder-constructive-oq-03-oq-02",
+  "description": "Formalizes the single most-cited efficient RNS base in the computer-arithmetic literature: the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1}. Proves pairwise coprimality for n ≥ 1 (decomposed into low–mid, mid–high, low–high facts), the exact dynamic-range formula (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ, packages it into a genuine RNSBase with 3 channels, proves the balance bound 2ⁿ+1 ≤ 2·(2ⁿ−1), and supplies the CRT-reconstruction coprimality step gcd((2ⁿ−1)·2ⁿ, 2ⁿ+1) = 1 needed to fold the first two channels before reconstructing against the third. Cross-checks n = 2,3,4 against {3,4,5}, {7,8,9}, {15,16,17}.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ03OQ02.lean",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "rns",
+      "coprimality",
+      "computer-arithmetic"
+    ],
+    "badge": "wip",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 239,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The proof is elementary and complete, but NOT YET machine-checked: at authoring time both verification channels were down (Docker build host has a corrupted containerd store — input/output error on content blobs at 95–98% disk; Aristotle API returns 'Resource not found'). Marked status=formalized / badge=wip pending compilation against Mathlib 4.26.0; an auditor/mechanic should upgrade to verified once the build host recovers and the file compiles clean. The proof relies only on standard current Mathlib lemmas (Nat.dvd_sub', Nat.gcd_dvd_left/right, Nat.dvd_prime, Nat.prime_two, Nat.sub_add_cancel, Nat.Coprime.mul, List.Pairwise.cons, omega/ring/decide/norm_num). Global optimality over all bases is NOT claimed — that remains the open parent question; this entry formalizes why this specific widely-used base is valid and balanced.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 20,
+    "dateAdded": "2026-06-27",
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic and developed by Szabó and Tanaka (1967). For practical hardware the dominant choice is the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1}, popularized by Soderstrand et al. in 'Residue Number System Arithmetic' (IEEE Press, 1986). It is favored because two of the three moduli admit trivial modular reduction: 2ⁿ is a bit-mask (x mod 2ⁿ = low n bits) and 2ⁿ−1 is a Mersenne wrap (x mod (2ⁿ−1) folds the high and low halves), while the three channels are nearly equal in width so the critical path is close to minimal. The parent entry ChineseRemainderConstructiveOQ03 formalized the general efficiency criteria for RNS bases (dynamic range, channel width, Mersenne-friendliness) but did not formalize this canonical concrete base; sibling OQ-03-OQ-01 handled prime-base growth for all k and OQ-03-OQ-03 handled a single power-of-2 channel alongside odd moduli.",
+    "problemStatement": "What concrete RNS base is the canonical 'most efficient' choice for computer arithmetic, and can its defining properties be verified in Lean? Specifically: prove that {2ⁿ−1, 2ⁿ, 2ⁿ+1} is pairwise coprime (so CRT applies), compute its exact dynamic range, exhibit it as a genuine RNS base, prove it is balanced (the widest and narrowest channels differ by less than a factor of 2), and isolate the coprimality fact driving iterated two-modulus CRT reconstruction.",
+    "proofStrategy": "Coprimality splits into three elementary facts. Low–mid (2ⁿ−1, 2ⁿ) and mid–high (2ⁿ, 2ⁿ+1) are consecutive integers, coprime because gcd divides their difference 1 (coprime_consecutive via Nat.dvd_sub' + Nat.dvd_one). Low–high (2ⁿ−1, 2ⁿ+1) differ by 2 with both ends odd: any common divisor divides 2 (Nat.dvd_sub') yet cannot be 2 (2 ∤ 2ⁿ−1 since 2 ∣ 2ⁿ), so by Nat.dvd_prime Nat.prime_two it is 1. The dynamic-range identity (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ is the polynomial a(a−1)(a+1) = a³−a with a = 2ⁿ; natural-number subtraction is handled by writing 2ⁿ = k+1 and discharging k·(k+1)·(k+2) + (k+1) = (k+1)³ with ring, then Nat.eq_sub_of_add_eq. A self-contained RNSBase structure (pairwise-coprime moduli ≥ 2) packages the moduli list, with pairwise coprimality assembled by List.Pairwise.cons. Balance (2ⁿ+1 ≤ 2·(2ⁿ−1) for n ≥ 2) and the CRT step (Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1) via Nat.Coprime.mul) close with omega and a single lemma application. Concrete n = 2,3,4 instances are confirmed by decide / norm_num.",
+    "keyInsights": [
+      "Two of the three coprimality obligations are free: 2ⁿ−1, 2ⁿ and 2ⁿ, 2ⁿ+1 are consecutive integers, so the single lemma coprime_consecutive (gcd divides the difference 1) discharges both — no number theory beyond Nat.dvd_sub' is needed.",
+      "The only nontrivial coprimality is between the two odd ends 2ⁿ−1 and 2ⁿ+1: they differ by 2, so a common divisor divides 2, but it must be odd (2 ∣ 2ⁿ ⟹ 2 ∤ 2ⁿ−1), hence equals 1. This is where Nat.dvd_prime Nat.prime_two does the work.",
+      "The dynamic range is exactly 2^(3n) − 2ⁿ, i.e. one 2ⁿ short of a full 3n-bit word — the natural-subtraction identity a(a−1)(a+1) = a³−a, proved cleanly by substituting 2ⁿ = k+1 so that ring applies over ℕ without truncation.",
+      "Balance, the property that actually makes the base 'efficient' in hardware, is the crisp inequality 2ⁿ+1 ≤ 2·(2ⁿ−1) (n ≥ 2): the widest channel is below twice the narrowest, so the critical-path channel width is near-minimal for the achieved dynamic range.",
+      "Iterated two-modulus CRT reconstruction needs exactly one coprimality fact beyond pairwise coprimality: that the product of the first two channels (2ⁿ−1)·2ⁿ is coprime to the third 2ⁿ+1. This follows from Nat.Coprime.mul applied to the low–high and mid–high facts, and is isolated as threeModuli_crt_step."
+    ]
+  },
+  "sections": [
+    {
+      "id": "coprimality",
+      "title": "Pairwise Coprimality of the Three Moduli",
+      "startLine": 66,
+      "endLine": 109,
+      "summary": "coprime_consecutive (gcd divides the difference 1) gives low–mid and mid–high coprimality directly, since 2ⁿ−1, 2ⁿ and 2ⁿ, 2ⁿ+1 are consecutive. coprime_low_high handles the two odd ends 2ⁿ−1, 2ⁿ+1 (difference 2, both odd) via Nat.dvd_prime Nat.prime_two and the oddness of 2ⁿ−1."
+    },
+    {
+      "id": "dynamic-range",
+      "title": "Exact Dynamic-Range Formula",
+      "startLine": 111,
+      "endLine": 129,
+      "summary": "dynamicRange_formula: (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ. The polynomial identity a(a−1)(a+1) = a³−a with a = 2ⁿ, with natural subtraction handled by writing 2ⁿ = k+1 and closing k·(k+1)·(k+2)+(k+1) = (k+1)³ with ring."
+    },
+    {
+      "id": "rns-base",
+      "title": "The Three-Moduli Set as a Genuine RNS Base",
+      "startLine": 131,
+      "endLine": 189,
+      "summary": "A self-contained RNSBase structure (pairwise-coprime moduli ≥ 2; the parent RNS file has bit-rotted against Mathlib 4.26.0). threeModuli_pairwise_coprime assembles pairwise coprimality via List.Pairwise.cons; threeModuliBase (n ≥ 2) is the base with channels = 3 and dynamicRange = 2^(3n) − 2ⁿ."
+    },
+    {
+      "id": "balance-crt",
+      "title": "Balance and CRT Reconstruction Step",
+      "startLine": 191,
+      "endLine": 212,
+      "summary": "threeModuli_balanced: 2ⁿ+1 ≤ 2·(2ⁿ−1) for n ≥ 2 (the widest channel is below twice the narrowest). threeModuli_crt_step: Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1), the fact that lets one fold the first two channels and reconstruct against the third by two-modulus CRT."
+    },
+    {
+      "id": "cross-checks",
+      "title": "Concrete Cross-Checks (n = 2, 3, 4)",
+      "startLine": 214,
+      "endLine": 239,
+      "summary": "n = 2 gives {3,4,5} (range 60), n = 3 gives {7,8,9} (range 504), n = 4 gives {15,16,17} (range 4080), each confirmed pairwise coprime and matching the 2^(3n) − 2ⁿ formula by decide / norm_num."
+    }
+  ],
+  "conclusion": {
+    "summary": "The canonical efficient RNS base for computer arithmetic — the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1} — is fully formalized: pairwise coprime for n ≥ 1, with exact dynamic range 2^(3n) − 2ⁿ, realized as a genuine 3-channel RNS base, balanced (2ⁿ+1 ≤ 2·(2ⁿ−1)), and equipped with the precise coprimality fact gcd((2ⁿ−1)·2ⁿ, 2ⁿ+1) = 1 that drives iterated two-modulus CRT reconstruction. Two of the three coprimality obligations are free (consecutive integers); only the odd–odd pair needs the prime-2 argument.",
+    "implications": "This pins down, with machine-checkable proofs, why the textbook three-moduli base is valid (CRT applies) and balanced (near-minimal critical-path channel width per unit of dynamic range) — the two properties hardware designers rely on when choosing 2ⁿ−1, 2ⁿ, 2ⁿ+1 for its bit-mask and Mersenne-wrap reductions. The dynamic-range identity 2^(3n) − 2ⁿ quantifies the (small) shortfall from a full 3n-bit word.",
+    "openQuestions": [
+      "Does any 3-channel base of total width ~3n bits beat {2ⁿ−1, 2ⁿ, 2ⁿ+1} in dynamic range while remaining pairwise coprime and equally balanced — i.e. is this base optimal within its width class, not merely valid?",
+      "Can the iterated two-modulus CRT reconstruction map (Garner's algorithm specialized to {2ⁿ−1, 2ⁿ, 2ⁿ+1}) be formalized with the bit-mask and Mersenne-wrap reductions made explicit and proved correct?",
+      "How does the balanced set generalize to more channels, e.g. {2ⁿ−1, 2ⁿ, 2ⁿ+1, 2^(2n)+1}, while preserving pairwise coprimality and a bounded width ratio?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry: efficient RNS bases. This entry formalizes the canonical concrete base {2ⁿ−1, 2ⁿ, 2ⁿ+1} that the parent's general criteria describe but do not instantiate."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry extending the same RNS framework with the all-k prime-base growth bound; this entry instead pins down the canonical three-moduli hardware base."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-03-oq-03",
+      "relationship": "related",
+      "description": "Sibling entry on a single power-of-2 channel alongside odd moduli; this entry uses the same power-of-2-channel idea inside the specific balanced triple."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 239,
+    "path": "Proofs/ChineseRemainderConstructiveOQ03OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 4,
+    "theoremCount": 20
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the missing **gallery entry** (`meta.json` + `annotations.json`) for `chinese-remainder-constructive-oq-03-oq-02`. The Lean proof file `Proofs/ChineseRemainderConstructiveOQ03OQ02.lean` was already merged to `main` via #30734 but had no gallery presentation.

The proof formalizes the canonical efficient RNS base from the computer-arithmetic literature (Soderstrand et al. 1986), the **balanced three-moduli set** `{2ⁿ−1, 2ⁿ, 2ⁿ+1}`:

- **Pairwise coprimality** for n ≥ 1 — two pairs free (consecutive integers), the odd–odd pair via the prime-2 argument.
- **Exact dynamic range** `(2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ` (the identity a(a−1)(a+1)=a³−a over ℕ).
- A genuine **3-channel `RNSBase`** instance.
- **Balance bound** `2ⁿ+1 ≤ 2·(2ⁿ−1)` (n ≥ 2).
- The **two-modulus CRT reduction step** `gcd((2ⁿ−1)·2ⁿ, 2ⁿ+1) = 1`.
- Concrete cross-checks for n = 2,3,4: {3,4,5}, {7,8,9}, {15,16,17}.

20 theorems, 4 definitions, **0 sorries, 0 axioms**.

## ⚠️ Verification status: formalized / wip (NOT verified)

Both verification channels were **down** this session and the proof could **not** be machine-checked:
- **Docker build host**: corrupted containerd store — `input/output error` on content blobs, disk at 95–98% full, 9+ zombie `lean-build` containers.
- **Aristotle API**: returns `Resource not found`.

The proof is elementary and uses only standard current Mathlib lemmas (`Nat.dvd_sub'`, `Nat.dvd_prime`, `Nat.prime_two`, `Nat.Coprime.mul`, `List.Pairwise.cons`, `omega`/`ring`/`decide`/`norm_num`). I reviewed every theorem by hand and am confident it compiles against Mathlib 4.26.0, but per the project's honesty policy I have marked it `status: formalized`, `badge: wip` rather than overclaiming `verified`. **An auditor/mechanic should upgrade to `verified` once the build host recovers and the file compiles clean.**

Global optimality over all bases is not claimed — that remains the open parent question; this entry formalizes why this specific widely-used base is valid and balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)