### PR TITLE
research(hilbert-3-oq-04): discharge tetrahedral-angle axiom via Niven [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3327,6 +3327,7 @@ import Proofs.Hilbert22Uniformization
 import Proofs.Hilbert23CalculusVariations
 import Proofs.Hilbert23CalculusVariationsOQ01
 import Proofs.Hilbert3OQ02
+import Proofs.Hilbert3OQ04NivenTetrahedron
 import Proofs.Hilbert3ScissorsCongruence
 import Proofs.Hilbert4Geodesics
 import Proofs.Hilbert5LieGroups

--- a/proofs/Proofs/Hilbert3OQ04NivenTetrahedron.lean
+++ b/proofs/Proofs/Hilbert3OQ04NivenTetrahedron.lean
@@ -1,0 +1,91 @@
+/-
+# Hilbert's Third Problem (oq-04): The Tetrahedral Angle is an Irrational Multiple of π
+
+The dihedral angle of a regular tetrahedron is `θ = arccos(1/3) ≈ 70.53°`.  A key
+step in Hilbert's third problem (the negative solution to the scissors-congruence
+question for the cube and the regular tetrahedron) is that this angle is **not** a
+rational multiple of `π`.  Equivalently, `arccos(1/3) / π` is irrational.
+
+In the gallery's main Hilbert-3 development
+(`Proofs/Hilbert3ScissorsCongruence.lean`) this fact was taken as an axiom:
+
+  `axiom tetrahedron_angle_not_rational_pi : ¬ isRationalMultipleOfPi tetrahedronDihedralAngle`
+
+This file **eliminates that axiom**.  Mathlib now contains Niven's theorem
+(`niven`, in `Mathlib.NumberTheory.Niven`), which states that the only rational
+values taken by `cos` at rational multiples of `π` are `{-1, -1/2, 0, 1/2, 1}`.
+Since `cos (arccos (1/3)) = 1/3` is rational and lies outside that set, the angle
+`arccos (1/3)` cannot be a rational multiple of `π`.
+
+Everything below is fully machine-checked with no `axiom`/`sorry` and no
+structure-encoded assumptions; the proof rests only on Mathlib (which proves
+Niven's theorem via the integrality of `2 cos(qπ)`).
+
+## Results
+* `cos_arccos_one_third` : `cos (arccos (1/3)) = 1/3`.
+* `arccos_one_third_not_rat_mul_pi` : `arccos (1/3)` is not of the form `r * π` for `r : ℚ`.
+* `irrational_arccos_one_third_div_pi` : `arccos (1/3) / π` is irrational.
+* `tetrahedron_angle_not_rational_pi` : the discharged Hilbert-3 axiom, stated against
+  the same predicate `isRationalMultipleOfPi` used there.
+
+## References
+* I. Niven, *Irrational Numbers*, Carus Mathematical Monographs 11 (1956).
+* Hilbert's third problem; Dehn invariant.
+-/
+
+import Mathlib.NumberTheory.Niven
+import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+
+namespace Hilbert3OQ04
+
+open Real
+
+/-- The cosine of the tetrahedral dihedral angle is `1/3`. -/
+theorem cos_arccos_one_third : Real.cos (Real.arccos (1 / 3)) = 1 / 3 := by
+  rw [Real.cos_arccos] <;> norm_num
+
+/-- **Niven applied to the tetrahedral angle.**  The dihedral angle `arccos (1/3)`
+of a regular tetrahedron is not a rational multiple of `π`.
+
+If it were, `cos (arccos (1/3)) = 1/3` would be one of the five Niven values
+`{-1, -1/2, 0, 1/2, 1}`, which it is not. -/
+theorem arccos_one_third_not_rat_mul_pi :
+    ¬ ∃ r : ℚ, Real.arccos (1 / 3) = (r : ℝ) * Real.pi := by
+  intro hθ
+  have hcos : ∃ q : ℚ, Real.cos (Real.arccos (1 / 3)) = (q : ℝ) :=
+    ⟨1 / 3, by rw [cos_arccos_one_third]; norm_num⟩
+  have hmem := niven hθ hcos
+  rw [cos_arccos_one_third] at hmem
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmem
+  rcases hmem with h | h | h | h | h <;> norm_num at h
+
+/-- The dihedral angle of a regular tetrahedron, measured in units of `π`, is
+irrational:  `arccos (1/3) / π ∉ ℚ`. -/
+theorem irrational_arccos_one_third_div_pi :
+    Irrational (Real.arccos (1 / 3) / Real.pi) := by
+  rintro ⟨r, hr⟩
+  -- `hr : (r : ℝ) = arccos (1/3) / π`
+  refine arccos_one_third_not_rat_mul_pi ⟨r, ?_⟩
+  have hpi : Real.pi ≠ 0 := Real.pi_ne_zero
+  rw [eq_comm, div_eq_iff hpi] at hr
+  exact hr
+
+/-- The scissors-congruence predicate used in `Proofs/Hilbert3ScissorsCongruence.lean`:
+`θ` is a rational multiple of `π` when `θ * q = p * π` for integers `p`, `q` with `q ≠ 0`. -/
+def isRationalMultipleOfPi (θ : ℝ) : Prop :=
+  ∃ (p : ℤ) (q : ℤ), q ≠ 0 ∧ θ * q = p * Real.pi
+
+/-- **Axiom elimination.**  The Hilbert-3 axiom
+`tetrahedron_angle_not_rational_pi` is in fact a theorem: the tetrahedral angle
+`arccos (1/3)` is not a rational multiple of `π`. -/
+theorem tetrahedron_angle_not_rational_pi :
+    ¬ isRationalMultipleOfPi (Real.arccos (1 / 3)) := by
+  rintro ⟨p, q, hq, hpq⟩
+  refine arccos_one_third_not_rat_mul_pi ⟨(p : ℚ) / (q : ℚ), ?_⟩
+  have hqR : (q : ℝ) ≠ 0 := Int.cast_ne_zero.mpr hq
+  push_cast
+  rw [div_mul_eq_mul_div, eq_div_iff hqR]
+  linear_combination hpq
+
+end Hilbert3OQ04

--- a/src/data/proofs/hilbert-3-oq-04/annotations.json
+++ b/src/data/proofs/hilbert-3-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "hilbert-3-oq-04",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Scope: discharging the parent Hilbert-3 tetrahedral-angle axiom via Niven",
+    "content": "The header frames the entry against the parent Hilbert-3 development (Proofs/Hilbert3ScissorsCongruence.lean), which took the transcendence fact `¬ isRationalMultipleOfPi tetrahedronDihedralAngle` as the axiom `tetrahedron_angle_not_rational_pi`. The tetrahedral dihedral angle is θ = arccos(1/3) ≈ 70.53°. Mathlib now carries Niven's theorem (`niven`, in Mathlib.NumberTheory.Niven), which states the only rational values of cos at rational multiples of π are {-1, -1/2, 0, 1/2, 1}. Since cos θ = 1/3 lies outside that set, θ cannot be a rational multiple of π. The three imports are Niven, Real.Irrational (for the `Irrational` corollary), and Trigonometric.Inverse (for `Real.cos_arccos`).",
+    "mathContext": "$\\theta = \\arccos(1/3)$ is the dihedral angle of a regular tetrahedron; the Dehn-invariant obstruction needs $\\theta/\\pi \\notin \\mathbb{Q}$.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's Third Problem", "Dehn invariant", "Niven's theorem", "scissors congruence", "transcendence"],
+    "prerequisites": ["arccos and cos(arccos x) = x on [-1,1]", "rational multiples of π"]
+  },
+  {
+    "id": "ann-cosine-value",
+    "proofId": "hilbert-3-oq-04",
+    "range": { "startLine": 44, "endLine": 46 },
+    "type": "lemma",
+    "title": "Pinning the cosine value: cos(arccos(1/3)) = 1/3",
+    "content": "`cos_arccos_one_third` is the only computational input. It applies `Real.cos_arccos`, whose hypotheses -1 ≤ 1/3 and 1/3 ≤ 1 are discharged by `norm_num` via the `<;>` combinator. This identifies the rational number (1/3) that Niven's theorem will subsequently reject as a possible cosine of a rational multiple of π.",
+    "mathContext": "$\\cos(\\arccos(1/3)) = 1/3$, valid because $-1 \\le 1/3 \\le 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["arccosine", "Real.cos_arccos"],
+    "prerequisites": ["inverse trigonometric functions"]
+  },
+  {
+    "id": "ann-niven-application",
+    "proofId": "hilbert-3-oq-04",
+    "range": { "startLine": 47, "endLine": 73 },
+    "type": "keystep",
+    "title": "Niven's theorem applied: arccos(1/3) is not a rational multiple of π",
+    "content": "`arccos_one_third_not_rat_mul_pi` is the transcendence core. Assuming arccos(1/3) = r·π for some r : ℚ, the hypotheses of `niven` are met (the angle is a rational multiple of π, and its cosine 1/3 is rational), so `niven` forces cos(arccos(1/3)) ∈ {-1, -1/2, 0, 1/2, 1}. Rewriting cos(arccos(1/3)) = 1/3 and unfolding the finite-set membership produces a five-way disjunction of false numeric equalities, each closed by `norm_num`. The corollary `irrational_arccos_one_third_div_pi` repackages this as `Irrational (arccos(1/3)/π)`: a rational value r of the quotient would give arccos(1/3) = r·π (using π ≠ 0 and `div_eq_iff`), contradicting the previous theorem.",
+    "mathContext": "Niven: if $\\theta = r\\pi$ ($r \\in \\mathbb{Q}$) and $\\cos\\theta \\in \\mathbb{Q}$ then $\\cos\\theta \\in \\{-1,-\\tfrac12,0,\\tfrac12,1\\}$. Here $\\cos\\theta = 1/3$ is excluded.",
+    "significance": "central",
+    "relatedConcepts": ["Niven's theorem", "rational multiples of π", "irrationality", "algebraic integers"],
+    "prerequisites": ["Niven's theorem", "2cos(qπ) is an algebraic integer"]
+  },
+  {
+    "id": "ann-axiom-elimination",
+    "proofId": "hilbert-3-oq-04",
+    "range": { "startLine": 74, "endLine": 91 },
+    "type": "keystep",
+    "title": "Discharging the parent axiom against its own predicate",
+    "content": "`isRationalMultipleOfPi θ := ∃ p q : ℤ, q ≠ 0 ∧ θ·q = p·π` is copied verbatim from Hilbert3ScissorsCongruence.lean, so `tetrahedron_angle_not_rational_pi : ¬ isRationalMultipleOfPi (arccos(1/3))` is a drop-in replacement for the parent's axiom, not a morally-equivalent restatement. The proof converts the integer-pair witness (p, q) to the rational r = p/q and feeds it to `arccos_one_third_not_rat_mul_pi`; the algebra (push_cast, eq_div_iff with q ≠ 0, linear_combination) reconciles θ·q = p·π with θ = (p/q)·π.",
+    "mathContext": "The parent's predicate $\\exists p,q \\in \\mathbb{Z},\\ q \\neq 0 \\wedge \\theta q = p\\pi$ is equivalent to $\\exists r \\in \\mathbb{Q},\\ \\theta = r\\pi$ via $r = p/q$.",
+    "significance": "central",
+    "relatedConcepts": ["axiom elimination", "Dehn invariant", "scissors congruence"],
+    "prerequisites": ["field algebra with π ≠ 0"]
+  }
+]

--- a/src/data/proofs/hilbert-3-oq-04/meta.json
+++ b/src/data/proofs/hilbert-3-oq-04/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "hilbert-3-oq-04",
+  "slug": "hilbert-3-oq-04",
+  "title": "Hilbert's 3rd Problem: the Tetrahedral Angle is an Irrational Multiple of π (Niven)",
+  "description": "Eliminates the `tetrahedron_angle_not_rational_pi` axiom of the parent Hilbert-3 entry by deriving it from Mathlib's Niven theorem. The dihedral angle of a regular tetrahedron is arccos(1/3); since cos(arccos(1/3)) = 1/3 is rational and lies outside the five Niven values {-1,-1/2,0,1/2,1}, the angle cannot be a rational multiple of π, i.e. arccos(1/3)/π is irrational. This is exactly the transcendence input the cube-vs-tetrahedron Dehn-invariant argument needs (and the open question the sibling tensor-product entry hilbert-3-oq-02 flagged as missing). Axiom-free and sorry-free.",
+  "overview": {
+    "historicalContext": "Hilbert's Third Problem (1900) asks whether two polyhedra of equal volume are scissors congruent. Dehn (1901) answered no via the Dehn invariant, which distinguishes the cube (all dihedral angles π/2, a rational multiple of π) from the regular tetrahedron (dihedral angle arccos(1/3)). The whole argument turns on one transcendence fact: arccos(1/3) is NOT a rational multiple of π. This is the standard application of Niven's theorem (Niven, Irrational Numbers, 1956): the only rational values cos takes at rational multiples of π are {-1, -1/2, 0, 1/2, 1}. The parent gallery entry hilbert-3 formalized Dehn's obstruction but took the tetrahedral fact as the axiom `tetrahedron_angle_not_rational_pi`, and the sibling entry hilbert-3-oq-02 explicitly listed it as an open question ('needs Niven's theorem only to know the coset is nonzero'). Mathlib now contains Niven's theorem (`niven`, Mathlib.NumberTheory.Niven), so the axiom can be discharged.",
+    "problemStatement": "Open question OQ-04: prove the tetrahedral-angle fact `¬ isRationalMultipleOfPi (arccos (1/3))` of the Hilbert-3 development as a theorem, eliminating the axiom `tetrahedron_angle_not_rational_pi`, using Mathlib's transcendence/Niven machinery.",
+    "text": "θ = arccos(1/3) is the dihedral angle of a regular tetrahedron. If θ were a rational multiple of π, Niven's theorem would force cos θ ∈ {-1,-1/2,0,1/2,1}. But cos θ = 1/3, so θ/π is irrational.",
+    "proofStrategy": "Set θ = arccos(1/3). First, cos θ = 1/3 by `Real.cos_arccos` (with -1 ≤ 1/3 ≤ 1). Suppose θ = r·π for some rational r. Mathlib's `niven` gives cos θ ∈ ({-1, -1/2, 0, 1/2, 1} : Set ℝ); rewriting cos θ = 1/3 and unfolding the finite-set membership yields a disjunction of false numeric equalities, closed by `norm_num`. This proves `arccos_one_third_not_rat_mul_pi : ¬ ∃ r : ℚ, arccos(1/3) = r·π`. Two corollaries follow by elementary algebra over a field with π ≠ 0: `irrational_arccos_one_third_div_pi : Irrational (arccos(1/3)/π)` (a rational value of the quotient would give θ = r·π), and `tetrahedron_angle_not_rational_pi : ¬ ∃ p q : ℤ, q ≠ 0 ∧ arccos(1/3)·q = p·π` — the exact predicate `isRationalMultipleOfPi` used in the parent entry, discharged by taking r = p/q.",
+    "keyInsights": [
+      "**The axiom was Niven's theorem all along**: the parent's `tetrahedron_angle_not_rational_pi` is precisely the statement that 1/3 is not a Niven cosine value; once Mathlib carries `niven`, the axiom becomes a three-line consequence",
+      "**One rational cosine outside five values**: the entire transcendence content reduces to `1/3 ∉ {-1,-1/2,0,1/2,1}`, a `norm_num` check, because `niven` has already done the algebraic-integer work (2cos(qπ) is an algebraic integer, hence — being rational — an integer in {-2,...,2})",
+      "**Matches the parent's exact predicate**: the theorem is stated against the same `isRationalMultipleOfPi θ := ∃ p q : ℤ, q ≠ 0 ∧ θ·q = p·π` used in Hilbert3ScissorsCongruence.lean, so it is a drop-in replacement for the axiom, not merely a morally-equivalent restatement",
+      "**Supplies the sibling's missing input**: hilbert-3-oq-02 built the genuine Dehn target group ℝ ⊗_ℤ (ℝ/πℚ) and flagged the tetrahedron's Dehn nonvanishing as open 'needing Niven's theorem to know the coset is nonzero' — this entry provides exactly that nonvanishing of the angle class"
+    ],
+    "prerequisites": [
+      "Niven's theorem: the only rational values of cos at rational multiples of π are {-1, -1/2, 0, 1/2, 1} (Mathlib `niven`)",
+      "arccos and the identity cos(arccos x) = x for x ∈ [-1,1] (`Real.cos_arccos`)",
+      "The definition of `Irrational` as 'not in the range of ℚ → ℝ'",
+      "Elementary field algebra with π ≠ 0 (`Real.pi_ne_zero`, `div_eq_iff`, `eq_div_iff`)",
+      "The Dehn invariant and the role of arccos(1/3) in Hilbert's Third Problem"
+    ]
+  },
+  "conclusion": {
+    "summary": "The tetrahedral-angle fact underlying Hilbert's Third Problem is derived from Mathlib's Niven theorem rather than assumed. `arccos_one_third_not_rat_mul_pi` shows arccos(1/3) is not of the form r·π (r rational); `irrational_arccos_one_third_div_pi` restates this as the irrationality of arccos(1/3)/π; and `tetrahedron_angle_not_rational_pi` discharges the parent Hilbert-3 entry's axiom against its own `isRationalMultipleOfPi` predicate. No axioms and no sorries are introduced.",
+    "implications": "Removes a transcendence axiom from the Hilbert-3 scissors-congruence development, turning the cube-vs-tetrahedron distinction into a fully derived consequence of Mathlib. Combined with the tensor-product Dehn group of hilbert-3-oq-02, it furnishes the nonvanishing of the tetrahedral angle class — the remaining ingredient for a fully axiom-free proof that the regular tetrahedron's Dehn invariant is nonzero.",
+    "openQuestions": [
+      "Assemble the end-to-end Dehn nonvanishing: in ℝ ⊗_ℤ (ℝ/πℚ) from hilbert-3-oq-02, combine angleClass(arccos(1/3)) ≠ 0 (a corollary of this entry) with a separating ℚ-linear functional to conclude length ⊗ angleClass(arccos(1/3)) ≠ 0, hence D(tetrahedron) ≠ 0, axiom-free",
+      "Refactor Proofs/Hilbert3ScissorsCongruence.lean to import this result and delete the `tetrahedron_angle_not_rational_pi` axiom, reducing the parent entry's axiom count"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "tetrahedron_angle_not_rational_pi",
+      "type": "core",
+      "description": "Axiom elimination: the regular tetrahedron's dihedral angle arccos(1/3) is not a rational multiple of π, stated against the parent entry's exact predicate isRationalMultipleOfPi",
+      "leanType": "¬ ∃ (p q : ℤ), q ≠ 0 ∧ Real.arccos (1/3) * q = p * Real.pi"
+    },
+    {
+      "name": "arccos_one_third_not_rat_mul_pi",
+      "type": "core",
+      "description": "Niven applied to the tetrahedral angle: arccos(1/3) is not of the form r·π for any rational r, because cos(arccos(1/3)) = 1/3 is not a Niven value",
+      "leanType": "¬ ∃ r : ℚ, Real.arccos (1/3) = (r : ℝ) * Real.pi"
+    },
+    {
+      "name": "irrational_arccos_one_third_div_pi",
+      "type": "core",
+      "description": "The tetrahedral angle measured in units of π is irrational: arccos(1/3)/π ∉ ℚ",
+      "leanType": "Irrational (Real.arccos (1/3) / Real.pi)"
+    },
+    {
+      "name": "cos_arccos_one_third",
+      "type": "supporting",
+      "description": "cos(arccos(1/3)) = 1/3, via Real.cos_arccos and -1 ≤ 1/3 ≤ 1",
+      "leanType": "Real.cos (Real.arccos (1/3)) = 1/3"
+    }
+  ],
+  "sections": [
+    {
+      "id": "docs-imports",
+      "title": "Documentation and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring framing the entry as the axiom-elimination of the Hilbert-3 tetrahedral-angle fact via Mathlib's Niven theorem. Three imports: Mathlib.NumberTheory.Niven, Mathlib.NumberTheory.Real.Irrational, and Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse.",
+      "mathContext": "Sets scope: derive ¬ isRationalMultipleOfPi(arccos(1/3)) from niven, eliminating the parent's axiom."
+    },
+    {
+      "id": "cosine-value",
+      "title": "The Cosine of the Tetrahedral Angle",
+      "startLine": 47,
+      "endLine": 52,
+      "summary": "cos_arccos_one_third: cos(arccos(1/3)) = 1/3 by Real.cos_arccos with the bounds -1 ≤ 1/3 ≤ 1 discharged by norm_num.",
+      "mathContext": "Pins the cosine value that Niven's theorem will reject as a rational multiple-of-π cosine."
+    },
+    {
+      "id": "niven-application",
+      "title": "Niven's Theorem Applied",
+      "startLine": 54,
+      "endLine": 72,
+      "summary": "arccos_one_third_not_rat_mul_pi: assuming arccos(1/3) = r·π, niven forces cos ∈ {-1,-1/2,0,1/2,1}; rewriting cos = 1/3 yields false numeric equalities closed by norm_num. irrational_arccos_one_third_div_pi: the quotient form, via pi_ne_zero and div_eq_iff.",
+      "mathContext": "The transcendence core: 1/3 is not a Niven cosine value, so the tetrahedral angle is an irrational multiple of π."
+    },
+    {
+      "id": "axiom-elimination",
+      "title": "Discharging the Parent Axiom",
+      "startLine": 74,
+      "endLine": 91,
+      "summary": "isRationalMultipleOfPi (the parent entry's predicate) and tetrahedron_angle_not_rational_pi, proved by reducing the integer-pair form (p, q) to the rational r = p/q form via push_cast / eq_div_iff / linear_combination.",
+      "mathContext": "Restates and discharges the exact axiom from Hilbert3ScissorsCongruence.lean."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Niven, Ivan",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs 11, Mathematical Association of America",
+      "note": "Niven's theorem on rational angles with rational cosine; the source of the transcendence input"
+    },
+    {
+      "authors": "Dehn, Max",
+      "title": "Ueber den Rauminhalt",
+      "year": "1901",
+      "venue": "Mathematische Annalen",
+      "note": "Solution of Hilbert's Third Problem; the cube-vs-tetrahedron distinction rests on arccos(1/3)/π being irrational"
+    }
+  ],
+  "crossReferences": [
+    {
+      "relationship": "Eliminates the `tetrahedron_angle_not_rational_pi` axiom of the parent Hilbert-3 scissors-congruence entry, deriving it from Mathlib's Niven theorem against the parent's own isRationalMultipleOfPi predicate.",
+      "sharedConcepts": [
+        "dehn-invariant",
+        "scissors-congruence",
+        "hilbert-problems",
+        "transcendence"
+      ],
+      "targetId": "hilbert-3"
+    },
+    {
+      "relationship": "Supplies the transcendence input the sibling tensor-product entry flagged as open: angleClass(arccos(1/3)) ≠ 0 in ℝ/πℚ follows from this entry's irrationality result, the missing ingredient for the tetrahedron's Dehn nonvanishing.",
+      "sharedConcepts": [
+        "dehn-invariant",
+        "hilbert-problems",
+        "transcendence"
+      ],
+      "targetId": "hilbert-3-oq-02"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/Hilbert3OQ04NivenTetrahedron.lean",
+    "lineCount": 91,
+    "theoremCount": 4,
+    "axiomCount": 0,
+    "definitionCount": 1,
+    "sorries": 0,
+    "imports": [
+      "import Mathlib.NumberTheory.Niven",
+      "import Mathlib.NumberTheory.Real.Irrational",
+      "import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse"
+    ],
+    "namespace": "Hilbert3OQ04"
+  },
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Niven%27s_theorem",
+    "date": "2026-06-27",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Hilbert3OQ04NivenTetrahedron.lean",
+    "tags": [
+      "geometry",
+      "number-theory",
+      "transcendence",
+      "hilbert-problems",
+      "dehn-invariant",
+      "scissors-congruence",
+      "formalization"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "niven",
+        "description": "Niven's theorem: cos θ ∈ {-1,-1/2,0,1/2,1} whenever θ is a rational multiple of π and cos θ is rational; the transcendence engine that rejects 1/3",
+        "module": "Mathlib.NumberTheory.Niven"
+      },
+      {
+        "theorem": "Real.cos_arccos",
+        "description": "cos(arccos x) = x for -1 ≤ x ≤ 1; gives cos(arccos(1/3)) = 1/3",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse"
+      },
+      {
+        "theorem": "Real.pi_ne_zero",
+        "description": "π ≠ 0; used to convert between θ = r·π and θ/π = r and to clear the denominator in the integer-pair form",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Eliminates the `tetrahedron_angle_not_rational_pi` axiom of the parent Hilbert-3 entry, deriving it from Mathlib's Niven theorem against the parent's exact `isRationalMultipleOfPi` predicate",
+      "`arccos_one_third_not_rat_mul_pi`: arccos(1/3) is not a rational multiple of π, reducing the transcendence content to the single norm_num check 1/3 ∉ {-1,-1/2,0,1/2,1}",
+      "`irrational_arccos_one_third_div_pi`: the irrationality of arccos(1/3)/π, the classic Hilbert-3 transcendence fact, stated with Mathlib's `Irrational`",
+      "Supplies the open transcendence input that the sibling tensor-product entry hilbert-3-oq-02 flagged as missing for the tetrahedron's Dehn nonvanishing",
+      "Axiom-free and sorry-free; the only Mathlib transcendence dependency is `niven`"
+    ],
+    "dateAdded": "2026-06-27",
+    "axiomCount": 0,
+    "lineCount": 91,
+    "assumptions": "None beyond Mathlib. The four theorems are sorry-free and contain no `axiom` declarations or structure-encoded assumptions; they depend only on Mathlib (notably `niven`, which is itself proved from the integrality of 2cos(qπ)) and the foundational propext / Classical.choice / Quot.sound. Scope: this entry proves only the tetrahedral-angle transcendence fact and discharges the parent's corresponding axiom; it does not by itself rebuild the full Dehn-invariant argument, and the parent file's other axioms (e.g. Dehn invariance under scissors congruence, Sydler completeness) remain untouched.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Summary

Eliminates the `tetrahedron_angle_not_rational_pi` **axiom** of the parent Hilbert-3 scissors-congruence entry (`Proofs/Hilbert3ScissorsCongruence.lean:303`) by deriving it from Mathlib's Niven theorem (`Mathlib.NumberTheory.Niven`).

The dihedral angle of a regular tetrahedron is `arccos(1/3)`. Since `cos(arccos(1/3)) = 1/3` is rational and lies outside the five Niven values `{-1, -1/2, 0, 1/2, 1}`, the angle cannot be a rational multiple of π — i.e. `arccos(1/3)/π` is irrational. This is exactly the transcendence input the cube-vs-tetrahedron Dehn-invariant distinction rests on, and the open question the sibling tensor-product entry `hilbert-3-oq-02` flagged as missing.

## Theorems (4, 0 sorries, 0 axioms)

- `cos_arccos_one_third : cos(arccos(1/3)) = 1/3`
- `arccos_one_third_not_rat_mul_pi : ¬ ∃ r : ℚ, arccos(1/3) = r·π`
- `irrational_arccos_one_third_div_pi : Irrational (arccos(1/3)/π)`
- `tetrahedron_angle_not_rational_pi : ¬ isRationalMultipleOfPi (arccos(1/3))` — the discharged axiom, stated against the parent's **exact** predicate, so it is a drop-in replacement.

## Verification

`lake env lean` against the prebuilt Mathlib (Docker host down). `#print axioms` on all four theorems shows only the foundational `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, no structure-encoded assumptions. Genuinely **verified / 0-axiom** (`status: verified`, `badge: original`).

## Files

- `proofs/Proofs/Hilbert3OQ04NivenTetrahedron.lean` (new, 91 lines)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/hilbert-3-oq-04/{meta.json,annotations.json}` (gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)