### PR TITLE
research(sperner-ndim-oq-02): BaryPoint ≃ Vertex coordinate bridge (Option C step 0)

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1,0 +1,153 @@
+import Proofs.SpernerNDim
+import Proofs.SpernerGrid
+
+/-
+# sperner-ndim-oq-02: BaryPoint ≃ Vertex coordinate bridge
+
+The abstract Sperner framework `SpernerNDim` indexes grid points by
+`SpernerNDim.Vertex d N` — *Kuhn coordinates*: a function `Fin d → ℕ` with
+`∑ ≤ N`, where the last (omitted) barycentric coordinate is the slack `N - ∑`.
+The concrete Freudenthal grid in `SpernerGrid` uses *full barycentric
+coordinates* `SpernerGrid.BaryPoint d N` — a function `Fin (d+1) → ℕ` with
+`∑ = N`.
+
+These two coordinate systems are canonically isomorphic:
+
+* drop the last barycentric coordinate to obtain a Kuhn vertex
+  (`toVertex`), and
+* append the slack `N - ∑` as the last coordinate to recover the
+  barycentric point (`toBary`).
+
+This file establishes that `Equiv` (`baryEquivVertex`) together with the
+matching `onFace` correspondence (`onFace_toVertex`). It is the foundational
+bridge of "Option C" for `sperner-ndim-oq-02`: it lets the complete (0-sorry)
+`SpernerNDim` framework be reused over `BaryPoint` without re-deriving it. See
+`research/problems/sperner-ndim-oq-02/` for the full plan.
+
+No new axioms or sorries are introduced.
+-/
+
+open Finset BigOperators
+
+namespace SpernerNDimOQ02
+
+variable {d N : ℕ}
+
+/-- Forward map: drop the last barycentric coordinate.
+    A barycentric point `(b₀, …, b_d)` with `∑ = N` maps to the Kuhn vertex
+    `(b₀, …, b_{d-1})`, whose coordinate sum is `N - b_d ≤ N`. -/
+def toVertex (b : SpernerGrid.BaryPoint d N) : SpernerNDim.Vertex d N where
+  coords := fun i => b.coords i.castSucc
+  valid := by
+    have hsum : ∑ i : Fin (d + 1), b.coords i = N := b.sum_eq
+    rw [Fin.sum_univ_castSucc] at hsum
+    have : ∑ i : Fin d, b.coords i.castSucc ≤ N := by omega
+    exact this
+
+/-- Backward map: append the slack `N - ∑` as the last barycentric coordinate.
+    A Kuhn vertex `(x₀, …, x_{d-1})` with `∑ ≤ N` maps to the barycentric point
+    `(x₀, …, x_{d-1}, N - ∑)`, whose coordinate sum is exactly `N`. -/
+def toBary (v : SpernerNDim.Vertex d N) : SpernerGrid.BaryPoint d N where
+  coords := Fin.snoc v.coords (N - ∑ i, v.coords i)
+  sum_eq := by
+    have hv : ∑ i, v.coords i ≤ N := v.valid
+    rw [Fin.sum_univ_castSucc]
+    simp only [Fin.snoc_castSucc, Fin.snoc_last]
+    omega
+
+@[simp]
+theorem toVertex_coords (b : SpernerGrid.BaryPoint d N) (i : Fin d) :
+    (toVertex b).coords i = b.coords i.castSucc := rfl
+
+@[simp]
+theorem toBary_coords_castSucc (v : SpernerNDim.Vertex d N) (i : Fin d) :
+    (toBary v).coords i.castSucc = v.coords i := by
+  simp [toBary]
+
+@[simp]
+theorem toBary_coords_last (v : SpernerNDim.Vertex d N) :
+    (toBary v).coords (Fin.last d) = N - ∑ i, v.coords i := by
+  simp [toBary]
+
+/-- `toBary` is a left inverse of `toVertex` (round-trip on barycentric points).
+    Recovering the dropped last coordinate from `∑ = N` reconstructs `b`. -/
+theorem toBary_toVertex (b : SpernerGrid.BaryPoint d N) :
+    toBary (toVertex b) = b := by
+  apply SpernerGrid.BaryPoint.ext
+  funext i
+  cases i using Fin.lastCases with
+  | last =>
+    have hsum : ∑ i : Fin (d + 1), b.coords i = N := b.sum_eq
+    rw [Fin.sum_univ_castSucc] at hsum
+    simp only [toBary_coords_last, toVertex_coords]
+    omega
+  | cast j => simp
+
+/-- `toBary` is a right inverse of `toVertex` (round-trip on Kuhn vertices).
+    Dropping the appended slack coordinate reconstructs `v`. -/
+theorem toVertex_toBary (v : SpernerNDim.Vertex d N) :
+    toVertex (toBary v) = v := by
+  apply SpernerNDim.Vertex.ext
+  funext i
+  simp
+
+/-- **The coordinate bridge.** Barycentric lattice points on the `d`-simplex
+    are in canonical bijection with Kuhn vertices, via dropping/appending the
+    last barycentric coordinate. -/
+def baryEquivVertex (d N : ℕ) : SpernerGrid.BaryPoint d N ≃ SpernerNDim.Vertex d N where
+  toFun := toVertex
+  invFun := toBary
+  left_inv := toBary_toVertex
+  right_inv := toVertex_toBary
+
+@[simp] theorem baryEquivVertex_apply (b : SpernerGrid.BaryPoint d N) :
+    baryEquivVertex d N b = toVertex b := rfl
+
+@[simp] theorem baryEquivVertex_symm_apply (v : SpernerNDim.Vertex d N) :
+    (baryEquivVertex d N).symm v = toBary v := rfl
+
+/-- **Face correspondence.** A barycentric point lies on face `k` of the
+    `d`-simplex exactly when its image Kuhn vertex does. For `k < d` both
+    conditions say "the `k`-th coordinate is `0`"; for `k = d` (the last face)
+    the barycentric condition `b_d = 0` matches the Kuhn condition `∑ = N`. -/
+theorem onFace_toVertex (b : SpernerGrid.BaryPoint d N) (k : Fin (d + 1)) :
+    SpernerNDim.onFace (toVertex b) k ↔ b.onFace k := by
+  unfold SpernerNDim.onFace SpernerGrid.BaryPoint.onFace
+  split
+  · -- k < d : both sides are "the k-th coordinate is 0"
+    rename_i h
+    have hcast : (⟨(k : ℕ), h⟩ : Fin d).castSucc = k := by
+      apply Fin.ext
+      simp
+    simp only [toVertex_coords, hcast]
+  · -- k = last d : ∑ = N  ↔  b_d = 0
+    rename_i h
+    simp_rw [toVertex_coords]
+    have hsum : ∑ i : Fin (d + 1), b.coords i = N := b.sum_eq
+    rw [Fin.sum_univ_castSucc] at hsum
+    have hk : k = Fin.last d := by
+      apply Fin.ext
+      have hlt := k.isLt
+      simp only [Fin.val_last]
+      omega
+    rw [hk]
+    omega
+
+/-- The bridge transports Sperner colorings: a coloring of the barycentric grid
+    is Sperner iff the corresponding coloring of Kuhn vertices is. -/
+theorem isSperner_iff (c : SpernerNDim.Vertex d N → Fin (d + 1)) :
+    SpernerNDim.IsSperner c ↔
+      SpernerGrid.IsSperner (fun b => c (toVertex b)) := by
+  constructor
+  · intro hc b k hbk
+    exact hc (toVertex b) k ((onFace_toVertex b k).mpr hbk)
+  · intro hc v k hvk
+    have hb : (toBary v).onFace k := by
+      have hov : SpernerNDim.onFace (toVertex (toBary v)) k := by
+        rw [toVertex_toBary]; exact hvk
+      exact (onFace_toVertex (toBary v) k).mp hov
+    have h2 := hc (toBary v) k hb
+    simp only [toVertex_toBary] at h2
+    exact h2
+
+end SpernerNDimOQ02

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -250,3 +250,59 @@ Phase 1, then Phase 2.
 **Status flag**: not BLOCKED (path is concrete and the abstract finish line exists),
 but **large + infra-gated**. Treat as a staged build for a session with healthy
 build infra; start with step 1.
+
+---
+
+## Session 2026-06-27 (Session 3) — Step 0 delivered: BaryPoint ≃ Vertex bridge
+
+**Mode**: ORIENT (execute Session-2 step 0). **Outcome**: WROTE the coordinate
+bridge as `proofs/Proofs/SpernerNDimOQ02.lean`. **UNVERIFIED** (build host down:
+root FS 98% with ~324 MiB free and dropping, stale `lean-build-*` containers,
+`SpernerGrid.olean` not cached → a fresh SpernerGrid+Mathlib build risks ENOSPC).
+Proofs hand-checked; no `sorry`, no new `axiom`.
+
+### What was built (`SpernerNDimOQ02.lean`, namespace `SpernerNDimOQ02`)
+
+The two coordinate systems are canonically isomorphic and this file proves it:
+
+- `SpernerNDim.Vertex d N` = `{coords : Fin d → ℕ // ∑ ≤ N}` (Kuhn; implicit last
+  bary coord `N − ∑`).
+- `SpernerGrid.BaryPoint d N` = `{coords : Fin (d+1) → ℕ // ∑ = N}` (full bary).
+
+Declarations:
+- `toVertex : BaryPoint d N → Vertex d N` — drop last coord
+  (`coords i := b.coords i.castSucc`); validity from `Fin.sum_univ_castSucc`.
+- `toBary : Vertex d N → BaryPoint d N` — append slack
+  (`coords := Fin.snoc v.coords (N − ∑ v.coords)`); `sum_eq` via
+  `Fin.snoc_castSucc`/`Fin.snoc_last`.
+- coord simp lemmas `toVertex_coords`, `toBary_coords_castSucc`,
+  `toBary_coords_last`.
+- `toBary_toVertex` / `toVertex_toBary` — the two round-trips (the BaryPoint
+  round-trip splits on `Fin.lastCases`; the last coordinate is recovered from
+  `∑ = N`).
+- `baryEquivVertex d N : BaryPoint d N ≃ Vertex d N` — **the bridge**, plus
+  `_apply` / `_symm_apply` simp lemmas.
+- `onFace_toVertex : onFace (toVertex b) k ↔ b.onFace k` — face correspondence
+  (`k < d`: both say "k-th coord = 0"; `k = last`: `∑ = N ↔ b_last = 0`).
+- `isSperner_iff` — the bridge transports the Sperner boundary condition
+  (`SpernerNDim.IsSperner c ↔ SpernerGrid.IsSperner (c ∘ toVertex)`).
+
+This is exactly Session-2 "step 0" and unlocks reuse of the whole `SpernerNDim`
+framework over `BaryPoint` without re-deriving it. PR opened (UNVERIFIED).
+
+### Key Lean facts used (for the next session)
+- `Fin.sum_univ_castSucc : ∑ i:Fin (n+1), f i = ∑ i:Fin n, f i.castSucc + f (Fin.last n)`.
+- `Fin.snoc_castSucc`, `Fin.snoc_last` (both `@[simp]`).
+- `cases i using Fin.lastCases with | last => | cast j =>`.
+- `omega` discharges the `↔` between linear coordinate equations (used in
+  `onFace_toVertex` last-face branch).
+
+### Remaining work (unchanged from Session 2, now starting at Phase 1)
+- **Phase 1**: `freudenthal d N : SpernerTriangulation d N` (unoriented Kuhn
+  cells, one per geometric cell — no orientation flag). The `baryEquivVertex`
+  bridge lets the instance's `vertices` field land in `Vertex d N` directly.
+- **Phase 2**: last-face-door-oddness by induction on d (door ↔ panchromatic
+  (d−1)-simplex bijection); feed `hbdry` to `sperner_ndim`.
+- Reroute `sperner_grid`; retire false `boundary_doors_odd`/`boundary_verts_on_face`.
+- **Verify** `SpernerNDimOQ02.lean` once build infra recovers (it is currently
+  UNVERIFIED).

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,20 +4,24 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
 
-Option C locked. Session 2 (2026-06-27) produced the concrete inductive proof
-structure for the Phase-2 oddness and a field-by-field plan for the Phase-1
-`SpernerTriangulation` instance. The abstract `SpernerNDim.sperner_ndim`
-(0-sorry, line 654) is the finish line; it needs an unoriented Freudenthal
-`SpernerTriangulation d N` instance plus an odd last-face-door count.
+Option C in progress. **Session 3 (2026-06-27) delivered step 0**: the
+`BaryPoint d N ≃ Vertex d N` coordinate bridge as
+`proofs/Proofs/SpernerNDimOQ02.lean` (`baryEquivVertex`, plus `onFace_toVertex`
+and `isSperner_iff` correspondences). UNVERIFIED — build host down (FS 98%).
+Next is Phase 1 (the `freudenthal` instance). The abstract
+`SpernerNDim.sperner_ndim` (0-sorry, line 654) remains the finish line; it needs
+an unoriented Freudenthal `SpernerTriangulation d N` instance plus an odd
+last-face-door count.
 
 ## Active Approach
 
 **Option C: SpernerTriangulation instance + inductive door-oddness**
-- (step 0) Prove `BaryPoint d N ≃ Vertex d N` bridge (small, verifiable first PR)
+- (step 0) ✅ DONE (Session 3, UNVERIFIED) — `BaryPoint d N ≃ Vertex d N` bridge
+  in `SpernerNDimOQ02.lean` (`baryEquivVertex` + `onFace_toVertex` + `isSperner_iff`)
 - (Phase 1) Define `freudenthal d N : SpernerTriangulation d N` — unoriented Kuhn
   cells, one per geometric simplex; discharge 8 structure fields
 - (Phase 2) Prove last-face-door-oddness by induction on d via the
@@ -25,8 +29,8 @@ structure for the Phase-2 oddness and a field-by-field plan for the Phase-1
 - Apply `sperner_ndim`; retire false `boundary_doors_odd`/`boundary_verts_on_face`
 
 ## Attempt Count
-- Total attempts: 2 (both analysis/planning; no proof code written yet)
-- Current approach attempts: 0 implementation
+- Total attempts: 3 (2 analysis/planning + 1 implementation: step-0 bridge)
+- Current approach attempts: 1 implementation (step 0 of Option C)
 - Approaches tried: 1 (Option C; A/B documented as alternatives)
 
 ## Blockers
@@ -37,8 +41,10 @@ structure for the Phase-2 oddness and a field-by-field plan for the Phase-1
 
 ## Next Action
 
-1. **(small, do first)** Prove `BaryPoint d N ≃ Vertex d N` in a bridge file; build it.
+1. ✅ DONE — `BaryPoint d N ≃ Vertex d N` bridge written (`SpernerNDimOQ02.lean`,
+   UNVERIFIED). **Verify it once build infra recovers.**
 2. **(Phase 1)** Define `freudenthal d N : SpernerTriangulation d N` (unoriented Kuhn
    cells, one per geometric cell — no free orientation flag); prove the 8 fields.
+   Use `baryEquivVertex`/`toVertex` for the `vertices` field.
 3. **(Phase 2)** Prove last-face-door-oddness by induction on d; feed to `sperner_ndim`.
 4. Reroute `sperner_grid` through the instance; delete the false lemmas.

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -18,21 +18,23 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-06-27T00:00:00.000Z",
-    "iteration": 3,
-    "focus": "Option C locked: build an unoriented Freudenthal SpernerTriangulation instance and supply odd last-face doors to the complete abstract sperner_ndim. Session 2 produced the inductive door-oddness decomposition and a field-by-field instance plan.",
+    "iteration": 4,
+    "focus": "Option C in progress. Session 3 delivered step 0: the BaryPoint d N ≃ Vertex d N coordinate bridge as proofs/Proofs/SpernerNDimOQ02.lean (baryEquivVertex + onFace_toVertex + isSperner_iff). UNVERIFIED (build host down, FS 98%). Next is Phase 1: the unoriented Freudenthal SpernerTriangulation instance, whose vertices field can land in Vertex d N via toVertex.",
     "blockers": [
-      "Infra-gated: the full Option C build is ~400-650 lines and must be machine-checked; at session 2 the root FS was at 97% (~420 MiB free) with stale lean-build containers, so a fresh Mathlib docker build was unsafe."
+      "Infra-gated: build host down at session 3 (root FS 98%, ~324 MiB free and dropping, stale lean-build containers, SpernerGrid.olean not cached). SpernerNDimOQ02.lean is UNVERIFIED and must be machine-checked once infra recovers. The remaining Phase 1+2 build is ~400-650 lines."
     ],
-    "nextAction": "Step 1 (small/verifiable first): prove BaryPoint d N ≃ Vertex d N bridge and build it. Then Phase 1 (instance, 8 fields), Phase 2 (inductive last-face-door oddness), apply sperner_ndim.",
+    "nextAction": "Verify SpernerNDimOQ02.lean once infra recovers. Then Phase 1 (freudenthal d N : SpernerTriangulation d N, 8 fields; use baryEquivVertex/toVertex for vertices), Phase 2 (inductive last-face-door oddness), apply sperner_ndim; retire false boundary_doors_odd.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 0,
+      "total": 3,
+      "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
     "progressSummary": "boundary_doors_odd (the OQ target) is provably FALSE as stated: the oriented GridSimplex double-counts each geometric cell by orientation, forcing all door/panchromatic counts even (Session 1 counterexample d=1,N=1 -> count 2). Resolution is Option C: instantiate the complete (0-sorry) abstract SpernerNDim.SpernerTriangulation framework with an UNORIENTED Freudenthal grid (one cell per geometric simplex) and feed odd last-face doors to sperner_ndim. Session 2 worked out the inductive oddness and an instance build plan.",
-    "builtItems": [],
+    "builtItems": [
+      "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, UNVERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0."
+    ],
     "insights": [
       "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
       "Last-face boundary doors of the d-grid are in bijection with panchromatic (d-1)-simplices of the induced (d-1)-Freudenthal grid on face d: adj=none + boundary_face puts the facet on face d; the Sperner condition forbids color d there; isDoorAt = all colors {0..d-1} present = IsFC for the (d-1)-grid. Induction + sperner_parity at d-1 gives oddness. Base d=0: count 1.",
@@ -41,8 +43,8 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove BaryPoint d N ≃ Vertex d N in a bridge file and build it (small, verifiable).",
-      "Phase 1: define freudenthal d N : SpernerTriangulation d N (unoriented Kuhn cells) and discharge the 8 structure fields (adj_symm/adj_ne/adj_unique_facet/adj_vertices/boundary_face via the standard Kuhn pivot).",
+      "DONE (Session 3, UNVERIFIED): BaryPoint d N ≃ Vertex d N bridge in SpernerNDimOQ02.lean. VERIFY once build infra recovers.",
+      "Phase 1: define freudenthal d N : SpernerTriangulation d N (unoriented Kuhn cells, vertices via baryEquivVertex/toVertex) and discharge the 8 structure fields (adj_symm/adj_ne/adj_unique_facet/adj_vertices/boundary_face via the standard Kuhn pivot).",
       "Phase 2: prove last-face-door-oddness by induction on d using the door <-> panchromatic-(d-1)-simplex bijection; supply it as hbdry to sperner_ndim.",
       "Reroute sperner_grid through the instance; delete false boundary_doors_odd / boundary_verts_on_face."
     ]


### PR DESCRIPTION
## Summary

Implements **step 0 of "Option C"** for `sperner-ndim-oq-02` (*n-Dimensional Sperner: Boundary-Door Oddness by Dimensional Induction*): the canonical coordinate bridge between the two grid-point representations used by the project's Sperner work.

- The abstract framework `SpernerNDim` uses **Kuhn coordinates** `Vertex d N` (`Fin d → ℕ`, `∑ ≤ N`; implicit last barycentric coord = `N − ∑`).
- The concrete Freudenthal grid `SpernerGrid` uses **full barycentric coordinates** `BaryPoint d N` (`Fin (d+1) → ℕ`, `∑ = N`).

These are canonically isomorphic. New file `proofs/Proofs/SpernerNDimOQ02.lean` (namespace `SpernerNDimOQ02`):

| Declaration | Meaning |
|---|---|
| `toVertex` / `toBary` | drop / append the last barycentric coordinate |
| `baryEquivVertex d N : BaryPoint d N ≃ Vertex d N` | **the bridge** |
| `onFace_toVertex` | face-membership correspondence (`k<d`: k-th coord = 0; `k=d`: `∑=N ↔ b_d=0`) |
| `isSperner_iff` | the bridge transports the Sperner boundary condition |

This unlocks reuse of the complete (0-sorry) `SpernerNDim` framework over `BaryPoint` without re-deriving it — the prerequisite for Phase 1 (the unoriented Freudenthal `SpernerTriangulation` instance) and Phase 2 (inductive last-face-door oddness), which together retire the known-**false** `boundary_doors_odd` in `SpernerGrid.lean` (see `research/problems/sperner-ndim-oq-02/`).

- **0 sorries, 0 new axioms.**

## ⚠️ Verification status: UNVERIFIED

The build host is degraded (root FS at 98%, ~324 MiB free and dropping; stale `lean-build-*` containers; `SpernerGrid.olean` not cached). Triggering a fresh `SpernerGrid` + Mathlib docker build risks ENOSPC, so this file is **not yet machine-checked**. Proofs were hand-checked (standard `Fin.sum_univ_castSucc` / `Fin.snoc_*` / `Fin.lastCases` reasoning; `omega` for the linear coordinate arithmetic). **Please re-run the Lean build once infra recovers before relying on it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)