### PR TITLE
Enrich Erdős #1003 OQ-02: add annotations + deepen insights

### DIFF
--- a/src/data/proofs/erdos-1003-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1003-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-erdos-1003-oq-02-definitions",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 44, "endLine": 59 },
+    "type": "definition",
+    "title": "The Totient-Run Family and Its Conjectures",
+    "content": "Four definitions set up the whole problem. `ConsecutiveEqualTotients` is the main Erdős #1003 set, the n with φ(n) = φ(n+1). `ConsecutiveKEqualTotients k` generalises this to a run of k+1 equal totients, encoded uniformly as `∀ i ≤ k, φ n = φ (n + i)`. The two `Prop`s name the conjectures: the main one (k = 1 set infinite) and Erdős's strong form (infinite for every k ≥ 1, which is OQ-02).",
+    "mathContext": "$\\mathrm{CKE}(k) = \\{\\, n \\mid \\forall\\, i \\le k,\\ \\phi(n) = \\phi(n+i) \\,\\} = \\{\\, n \\mid \\phi(n) = \\phi(n+1) = \\cdots = \\phi(n+k) \\,\\}$. The encoding `∀ i ≤ k` rather than an explicit chain of equalities is what makes monotonicity in $k$ a one-line proof.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient function", "set-builder notation", "universal quantification", "arithmetic functions"],
+    "prerequisites": ["Euler's totient function", "set theory"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-cke-zero",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 63, "endLine": 70 },
+    "type": "technique",
+    "title": "Base Case k = 0: The Chain's Anchor",
+    "content": "When k = 0 the only constraint is `∀ i ≤ 0`, i.e. just i = 0, giving φ(n) = φ(n+0) = φ(n), which holds for every n. Hence CKE(0) is all of ℕ. The proof extensionalises the set, reduces the quantifier to the single case i = 0 via `Nat.le_zero`, and closes with `simp`. This anchors the nested chain and makes the 'infinite for every k' reformulation work without a special case.",
+    "mathContext": "$\\mathrm{CKE}(0) = \\{\\, n \\mid \\phi(n) = \\phi(n) \\,\\} = \\mathbb{N} = \\mathtt{univ}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["vacuous quantification", "set extensionality", "reflexivity"],
+    "prerequisites": ["set theory", "natural number order"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-cke-one",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 72, "endLine": 83 },
+    "type": "concept",
+    "title": "Base Case k = 1: Recovering the Main #1003 Set",
+    "content": "For k = 1 the run condition collapses exactly to φ(n) = φ(n+1), so CKE(1) equals `ConsecutiveEqualTotients`, the original Erdős #1003 set. The forward direction instantiates the quantifier at i = 1; the reverse uses `interval_cases i` to dispatch i = 0 (reflexive) and i = 1 (the hypothesis). This identity is what lets the strong conjecture subsume the main one.",
+    "mathContext": "$\\mathrm{CKE}(1) = \\{\\, n \\mid \\phi(n) = \\phi(n+1) \\,\\} = \\mathrm{ConsecutiveEqualTotients}$.",
+    "significance": "key",
+    "relatedConcepts": ["case analysis", "interval_cases tactic", "set equality"],
+    "prerequisites": ["Euler's totient function", "bounded quantifiers"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-antitone",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 91, "endLine": 96 },
+    "type": "insight",
+    "title": "The Family Is a Nested Decreasing Chain",
+    "content": "The heart of the reduction: `ConsecutiveKEqualTotients` is `Antitone` in k. Demanding a longer run is a strictly stronger condition, so larger k yields a smaller set: CKE(l) ⊆ CKE(k) whenever k ≤ l. The proof is a single line — membership in CKE(l) means `∀ i ≤ l`, and since any i ≤ k also satisfies i ≤ l (by `hi.trans hkl`), the CKE(k) condition follows. Counterintuitively, the 'harder' (longer-run) sets sit inside the 'easier' ones.",
+    "mathContext": "$k \\le l \\;\\Rightarrow\\; \\mathrm{CKE}(l) \\subseteq \\mathrm{CKE}(k)$. A run of $l+1$ equal totients contains a run of $k+1$ equal totients as a prefix.",
+    "significance": "key",
+    "relatedConcepts": ["Antitone (order-reversing) maps", "monotonicity", "nested chains", "transitivity of ≤"],
+    "prerequisites": ["order theory", "monotonicity"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-infinite-downward",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 104, "endLine": 109 },
+    "type": "technique",
+    "title": "Infinitude Propagates Downward in k",
+    "content": "Because the chain is decreasing, infinitude flows from harder to easier problems: if CKE(l) is infinite for some l ≥ k, then its superset CKE(k) is infinite too. The proof is `Set.Infinite.mono` applied to the antitone subset relation. This is why a single construction at one large run length k automatically settles all shorter runs.",
+    "mathContext": "$k \\le l \\;\\wedge\\; |\\mathrm{CKE}(l)| = \\infty \\;\\Rightarrow\\; |\\mathrm{CKE}(k)| = \\infty$, since $\\mathrm{CKE}(l) \\subseteq \\mathrm{CKE}(k)$ and a superset of an infinite set is infinite.",
+    "significance": "key",
+    "relatedConcepts": ["infinite sets", "Set.Infinite.mono", "monotonicity of cardinality"],
+    "prerequisites": ["infinite vs finite sets", "subset relation"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-strong-imp-main",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 113, "endLine": 118 },
+    "type": "concept",
+    "title": "Strong Conjecture Implies the Main Conjecture",
+    "content": "Instantiating the strong conjecture at k = 1 and rewriting with `cke_one` yields infinitude of the main #1003 set. This makes explicit that OQ-02 is a genuine strengthening of the original problem: resolving the strong form 'for free' resolves the classical question of whether φ(n) = φ(n+1) infinitely often.",
+    "mathContext": "$\\big(\\forall k \\ge 1,\\ |\\mathrm{CKE}(k)| = \\infty\\big) \\;\\Rightarrow\\; |\\mathrm{CKE}(1)| = |\\{n \\mid \\phi(n) = \\phi(n+1)\\}| = \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["logical implication", "specialization", "rewriting"],
+    "prerequisites": ["propositional logic"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-cofinal",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 133, "endLine": 146 },
+    "type": "insight",
+    "title": "Cofinal Reformulation: Only Arbitrarily Long Runs Matter",
+    "content": "The sharpest packaging of OQ-02. Via `strong_iff_all_k`, the strong conjecture is equivalent to infinitude holding for cofinally many k — i.e. for arbitrarily large run lengths. The decreasing-chain structure then fills in every smaller k automatically through downward propagation. So the entire family of conjectures reduces to one task: produce infinitely many solutions for runs that are as long as desired.",
+    "mathContext": "$\\text{strong} \\iff \\big(\\forall N,\\ \\exists k \\ge N,\\ |\\mathrm{CKE}(k)| = \\infty\\big)$. Cofinality in $k$ suffices because $\\mathrm{CKE}$ is antitone.",
+    "significance": "key",
+    "relatedConcepts": ["cofinal sets", "logical equivalence", "reduction of conjectures", "directed downward closure"],
+    "prerequisites": ["order theory", "quantifier reasoning"]
+  },
+  {
+    "id": "ann-erdos-1003-oq-02-finite-upward",
+    "proofId": "erdos-1003-oq-02",
+    "range": { "startLine": 148, "endLine": 156 },
+    "type": "technique",
+    "title": "Contrapositive: Finiteness Propagates Upward",
+    "content": "The dual of downward infinitude. If the easier problem CKE(k) is finite, then every harder problem CKE(l) with l ≥ k is finite as well — a failure low in the chain forces failure all the way up. The proof argues by contradiction: were CKE(l) infinite, downward propagation would make CKE(k) infinite, contradicting finiteness. This closes the structural picture from both ends.",
+    "mathContext": "$k \\le l \\;\\wedge\\; |\\mathrm{CKE}(k)| < \\infty \\;\\Rightarrow\\; |\\mathrm{CKE}(l)| < \\infty$. Contrapositive of $\\mathrm{cke\\_infinite\\_of\\_le}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["proof by contradiction", "contrapositive", "finite sets"],
+    "prerequisites": ["finite vs infinite sets", "contradiction"]
+  }
+]

--- a/src/data/proofs/erdos-1003-oq-02/meta.json
+++ b/src/data/proofs/erdos-1003-oq-02/meta.json
@@ -46,7 +46,8 @@
       "**The family is decreasing, not increasing**: requiring a longer run of equal totients is a strictly stronger condition, so CKE(k+1) ⊆ CKE(k). This makes infinitude monotone — easy cases are implied by hard ones.",
       "**The hardest direction is k → ∞**: by the cofinal equivalence, proving the strong conjecture is equivalent to exhibiting infinitely many solutions for arbitrarily long runs; no separate argument per k is needed once that is achieved.",
       "**k = 1 is the main problem**: CKE(1) is literally the main #1003 set, so the strong conjecture subsumes the original infinitude question.",
-      "**k = 0 is trivial**: CKE(0) = univ because the only constraint `∀ i ≤ 0` is `φ n = φ(n+0)`, which always holds; this anchors the chain and the 'infinite for every k' reformulation."
+      "**k = 0 is trivial**: CKE(0) = univ because the only constraint `∀ i ≤ 0` is `φ n = φ(n+0)`, which always holds; this anchors the chain and the 'infinite for every k' reformulation.",
+      "**Finiteness propagates the other way**: the chain is monotone in both directions — infinitude flows down to shorter runs, while finiteness flows up to longer runs. A single finiteness result at any run length k would collapse every longer run CKE(l), l ≥ k, to a finite set."
     ],
     "prerequisites": ["Euler's totient function", "Basic set theory (infinite/finite sets, monotonicity)", "Number theory"]
   },


### PR DESCRIPTION
## Enrichment pass: erdos-1003-oq-02

The k-Consecutive Equal Totient Hierarchy entry had a rich `meta.json` but **no `annotations.json`** (the largest quality gap). This pass adds inline annotations and one keyInsight.

### Changes
- **New `annotations.json` (8 annotations)** covering every major part of the Lean file:
  - the totient-run family definitions and conjecture `Prop`s
  - both verified base cases — CKE(0) = univ and CKE(1) = the main #1003 set
  - the **antitone nested-chain** structure (CKE(l) ⊆ CKE(k) for k ≤ l)
  - downward propagation of infinitude (`Set.Infinite.mono`)
  - strong ⇒ main, and the **cofinal reformulation** (only arbitrarily long runs matter)
  - the upward finiteness contrapositive
  - Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **+1 keyInsight** capturing the finiteness-propagates-upward duality (rounds insights to 5).

### Verification
- `pnpm annotations:build` passes (exit 0); **no warnings for this entry** — all 8 annotation line ranges map to Lean constructs.
- Size: meta.json ~10 KB, well under the 60 KB cap.
- Axiom integrity unchanged: `status: verified`, `badge: original`, 0 axioms / 0 sorries — confirmed against the Lean source (4 defs, 10 theorems).

No `index.ts` added — per-proof shims are legacy; the loader is now fetch-by-slug (sibling `erdos-1003` has none either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)