### PR TITLE
audit(hilbert-3-oq-04): badge original→mathlib (Tier-B, core via Mathlib niven)

### DIFF
--- a/src/data/proofs/hilbert-3-oq-04/meta.json
+++ b/src/data/proofs/hilbert-3-oq-04/meta.json
@@ -157,7 +157,7 @@
       "scissors-congruence",
       "formalization"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: hilbert-3-oq-04 (newly merged, previously unaudited)

### Mechanical checks — all clean ✓
- 0 sorries (matches meta), 0 `axiom` declarations, 0 `True` stubs
- 4 theorems + 1 def (matches meta `theoremCount`/`definitionCount`)
- status `verified` is legitimate: fully machine-checked, no axioms/sorries/structure-encoded assumptions

### Finding (MEDIUM — badge precision)
The entry's **core mathematical content** — that `arccos(1/3)` is an irrational multiple of π — is obtained **entirely from Mathlib's `niven` theorem**. The file's own work is a *bridge*: compute `cos(arccos(1/3)) = 1/3`, apply `niven`, eliminate the 5-value disjunction by `norm_num`, then discharge the parent entry's `isRationalMultipleOfPi` predicate by field algebra.

Per the auditor Tier table this is **Tier B** (*"Formalized using Mathlib theorem … Core argument relies on a Mathlib theorem; our file provides definitions, bridge, or infrastructure"*), whose badge is `mathlib` — not the Tier-A `original` (*"no imported deep theorem doing the core work"*).

### Fix
`meta.badge`: `original` → `mathlib`.

This is a **badge-precision change only**. The prose is already exemplary — the description leads with *"deriving it from Mathlib's Niven theorem"*, the title ends with *"(Niven)"*, and `originalContributions` states *"the only Mathlib transcendence dependency is `niven`"* — so there is no delegation opacity. `status: verified` is unchanged (the result is genuinely machine-checked with 0 assumptions).

---
Discovered during gallery integrity audit.