### PR TITLE
research(bounded-prime-gaps-oq-02): band cocycle (Chasles) identity + subdivided level ascent [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02.lean
@@ -56,6 +56,12 @@ work documented in the sibling `BoundedPrimeGapsOQ04`.
 - [x] Quantitative converse `EHAtLevel_discrepancySum_up`: EH at level `θ₁` plus an
       EH-type bound on the new-moduli band ⟹ EH at the higher level `θ₂` — pinning the
       band as exactly the extra analytic input needed to raise the level of distribution
+- [x] Band cocycle (Chasles) identity `discrepancyBand_add_consecutive`: the new-moduli
+      band subdivides at any intermediate level, `band θ₁ θ₃ = band θ₁ θ₂ + band θ₂ θ₃`,
+      with `discrepancyBand_self` the empty-band base case — the moduli-range analogue of
+      the level decomposition that licenses dyadic decomposition of the modulus range
+- [x] Subdivided ascent `EHAtLevel_discrepancySum_up_split`: raising the level only needs
+      EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure
 - [x] No `axiom`, no `sorry`, no `native_decide`
 -/
 
@@ -342,6 +348,65 @@ theorem EHAtLevel_discrepancySum_up (f : ℕ → ℝ → ℝ) {θ₁ θ₂ : ℝ
   refine ⟨C₁ + C₂, by linarith, fun x hx => ?_⟩
   rw [discrepancySum_eq_add_band f (by linarith) hθ]
   calc discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x
+      ≤ C₁ * x / (Real.log x) ^ A + C₂ * x / (Real.log x) ^ A := by
+        linarith [hb₁ x hx, hb₂ x hx]
+    _ = (C₁ + C₂) * x / (Real.log x) ^ A := by ring
+
+/-! ## Subdividing the level-increment band
+
+The exact decomposition `discrepancySum_eq_add_band` localizes the inter-level growth to
+the new-moduli band `⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋`.  That band is itself additive: at any
+intermediate level `θ₂` it splits into two consecutive sub-bands.  This is the additive
+cocycle (Chasles) identity for the band — the moduli-range analogue of the level
+decomposition — and it is exactly what licenses the *dyadic decomposition of the modulus
+range* used in the analytic treatment of Elliott–Halberstam: control the discrepancy on
+each dyadic block of moduli separately and recombine. -/
+
+/-- The **empty band**: from a level to itself there are no new moduli, so the band
+discrepancy vanishes. -/
+theorem discrepancyBand_self (f : ℕ → ℝ → ℝ) (θ x : ℝ) :
+    discrepancyBand f θ θ x = 0 := by
+  unfold discrepancyBand
+  rw [Finset.Ioc_self, Finset.sum_empty]
+
+/-- **Cocycle / Chasles identity for the band.**  For `θ₁ ≤ θ₂ ≤ θ₃` on the analytic
+regime `x ≥ 1`, the new-moduli band from level `θ₁` to `θ₃` is the disjoint union of the
+`θ₁ → θ₂` and `θ₂ → θ₃` sub-bands, so its discrepancy is the sum of theirs:
+`discrepancyBand f θ₁ θ₃ x = discrepancyBand f θ₁ θ₂ x + discrepancyBand f θ₂ θ₃ x`.
+This subdivides the level increment at any intermediate level. -/
+theorem discrepancyBand_add_consecutive (f : ℕ → ℝ → ℝ) {θ₁ θ₂ θ₃ x : ℝ}
+    (hx : 1 ≤ x) (h₁₂ : θ₁ ≤ θ₂) (h₂₃ : θ₂ ≤ θ₃) :
+    discrepancyBand f θ₁ θ₃ x
+      = discrepancyBand f θ₁ θ₂ x + discrepancyBand f θ₂ θ₃ x := by
+  have hf12 : ⌊x ^ θ₁⌋₊ ≤ ⌊x ^ θ₂⌋₊ :=
+    Nat.floor_le_floor (Real.rpow_le_rpow_of_exponent_le hx h₁₂)
+  have hf23 : ⌊x ^ θ₂⌋₊ ≤ ⌊x ^ θ₃⌋₊ :=
+    Nat.floor_le_floor (Real.rpow_le_rpow_of_exponent_le hx h₂₃)
+  unfold discrepancyBand
+  exact (Finset.sum_Ioc_consecutive (fun q => f q x) hf12 hf23).symm
+
+/-- **Subdivided ascent.**  Strengthening `EHAtLevel_discrepancySum_up`: to raise the
+level of distribution from `θ₁` to `θ₃` it suffices to bound the discrepancy on each of
+the two consecutive sub-bands `θ₁ → θ₂` and `θ₂ → θ₃` separately.  The band cocycle
+identity splits the full `θ₁ → θ₃` band into these pieces, and the EH-bound class being a
+convex cone (`EHAtLevel_add`) recombines the two sub-band bounds into one.  This is the
+formal statement that the modulus range may be attacked dyadically — the standard
+analytic strategy for Elliott–Halberstam. -/
+theorem EHAtLevel_discrepancySum_up_split (f : ℕ → ℝ → ℝ) {θ₁ θ₂ θ₃ : ℝ}
+    (h₁₂ : θ₁ ≤ θ₂) (h₂₃ : θ₂ ≤ θ₃)
+    (hlow : EHAtLevel (discrepancySum f) θ₁)
+    (hband₁ : ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand f θ₁ θ₂ x ≤ C * x / (Real.log x) ^ A)
+    (hband₂ : ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand f θ₂ θ₃ x ≤ C * x / (Real.log x) ^ A) :
+    EHAtLevel (discrepancySum f) θ₃ := by
+  refine EHAtLevel_discrepancySum_up f (le_trans h₁₂ h₂₃) hlow ?_
+  intro A hA
+  obtain ⟨C₁, hC₁, hb₁⟩ := hband₁ A hA
+  obtain ⟨C₂, hC₂, hb₂⟩ := hband₂ A hA
+  refine ⟨C₁ + C₂, by linarith, fun x hx => ?_⟩
+  rw [discrepancyBand_add_consecutive f (by linarith) h₁₂ h₂₃]
+  calc discrepancyBand f θ₁ θ₂ x + discrepancyBand f θ₂ θ₃ x
       ≤ C₁ * x / (Real.log x) ^ A + C₂ * x / (Real.log x) ^ A := by
         linarith [hb₁ x hx, hb₂ x hx]
     _ = (C₁ + C₂) * x / (Real.log x) ^ A := by ring

--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "bounded-prime-gaps-oq-02",
   "title": "Elliott–Halberstam Conjecture: Axiom-Free Level-of-Distribution Hierarchy",
   "slug": "bounded-prime-gaps-oq-02",
-  "description": "Formalizes the logical skeleton of the Elliott–Halberstam (EH) conjecture as an axiom-free level-of-distribution hierarchy. For an abstract discrepancy functional D θ x (modelling the worst-case prime-counting discrepancy summed over moduli q ≤ x^θ), we define the level-θ EH bound EHAtLevel, prove the level hierarchy (a bound at a higher level implies the bound at every lower level for a level-monotone D), define Bombieri–Vinogradov as the θ = 1/2 case and Elliott–Halberstam as all levels θ < 1, and prove EH ⟹ BV. A canonical concrete functional ∑_{q≤x^θ} f(q,x) realizes the hierarchy with level-monotonicity proved (not assumed). This session sharpens the hierarchy: (i) an EXACT additive decomposition discrepancySum θ₂ = discrepancySum θ₁ + discrepancyBand θ₁ θ₂, where the band is the discrepancy of the new moduli ⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋ that the larger level admits — upgrading monotonicity from inequality to identity; (ii) the EH-bound functional class at a fixed level is a CONVEX CONE (closed under addition and nonnegative scaling); and (iii) a quantitative converse EHAtLevel_discrepancySum_up — EH at level θ₁ plus an EH-type bound on the new-moduli band implies EH at the higher level θ₂, pinning the band as exactly the extra analytic input needed to raise the level of distribution. EH itself is NOT axiomatized; only D's structural properties enter as per-theorem hypotheses, so every result is a purely logical/analytic consequence with no axiom, sorry, or native_decide.",
+  "description": "Formalizes the logical skeleton of the Elliott–Halberstam (EH) conjecture as an axiom-free level-of-distribution hierarchy. For an abstract discrepancy functional D θ x (modelling the worst-case prime-counting discrepancy summed over moduli q ≤ x^θ), we define the level-θ EH bound EHAtLevel, prove the level hierarchy (a bound at a higher level implies the bound at every lower level for a level-monotone D), define Bombieri–Vinogradov as the θ = 1/2 case and Elliott–Halberstam as all levels θ < 1, and prove EH ⟹ BV. A canonical concrete functional ∑_{q≤x^θ} f(q,x) realizes the hierarchy with level-monotonicity proved (not assumed). This session sharpens the hierarchy: (i) an EXACT additive decomposition discrepancySum θ₂ = discrepancySum θ₁ + discrepancyBand θ₁ θ₂, where the band is the discrepancy of the new moduli ⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋ that the larger level admits — upgrading monotonicity from inequality to identity; (ii) the EH-bound functional class at a fixed level is a CONVEX CONE (closed under addition and nonnegative scaling); and (iii) a quantitative converse EHAtLevel_discrepancySum_up — EH at level θ₁ plus an EH-type bound on the new-moduli band implies EH at the higher level θ₂, pinning the band as exactly the extra analytic input needed to raise the level of distribution; and (iv) the BAND COCYCLE (Chasles) identity discrepancyBand θ₁ θ₃ = discrepancyBand θ₁ θ₂ + discrepancyBand θ₂ θ₃, subdividing the new-moduli band at any intermediate level, with subdivided ascent EHAtLevel_discrepancySum_up_split showing the level may be raised using only EH-type bounds on each consecutive sub-band — the formal license for dyadic decomposition of the modulus range. EH itself is NOT axiomatized; only D's structural properties enter as per-theorem hypotheses, so every result is a purely logical/analytic consequence with no axiom, sorry, or native_decide.",
   "meta": {
     "author": "Elliott–Halberstam (1968); Bombieri (1965), A.I. Vinogradov (1965); formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Elliott%E2%80%93Halberstam_conjecture",
@@ -52,6 +52,16 @@
         "theorem": "Finset.Icc_subset_Icc_right",
         "description": "Icc a b ⊆ Icc a c when b ≤ c",
         "module": "Mathlib.Order.Interval.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_Ioc_consecutive",
+        "description": "Additivity of a sum over consecutive half-open integer intervals: ∑ Ioc a b + ∑ Ioc b c = ∑ Ioc a c for a ≤ b ≤ c (the band cocycle / Chasles identity)",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.Ioc_self",
+        "description": "Ioc a a = ∅ — the empty half-open interval, base case for the empty band",
+        "module": "Mathlib.Order.Interval.Finset.Basic"
       }
     ],
     "originalContributions": [
@@ -68,13 +78,16 @@
       "discrepancySum_mono_level: level-monotonicity of the canonical functional PROVED (not assumed) on the analytic range x ≥ 1",
       "discrepancySumClamped + discrepancySumClamped_eq: base-clamped variant agreeing with the canonical sum on x ≥ 1",
       "levelMonotone_discrepancySumClamped: the clamped canonical functional is a (generally nonzero) global model of LevelMonotone",
-      "EHAtLevel_of_le_discrepancySumClamped: the level hierarchy instantiated at the concrete nonzero model"
+      "EHAtLevel_of_le_discrepancySumClamped: the level hierarchy instantiated at the concrete nonzero model",
+      "discrepancyBand_self: the empty band — from a level to itself there are no new moduli, so the band discrepancy vanishes (base case for subdivision)",
+      "discrepancyBand_add_consecutive: the additive cocycle (Chasles) identity for the band — for θ₁≤θ₂≤θ₃ on x≥1, discrepancyBand θ₁ θ₃ = discrepancyBand θ₁ θ₂ + discrepancyBand θ₂ θ₃, subdividing the new-moduli band at any intermediate level",
+      "EHAtLevel_discrepancySum_up_split: subdivided ascent — raising the level from θ₁ to θ₃ needs only EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure; the formal statement that the modulus range may be attacked dyadically"
     ],
-    "lineCount": 226,
+    "lineCount": 414,
     "erdosUrl": null,
     "dateAdded": "2026-06-27",
-    "theoremCount": 13,
-    "definitionCount": 6
+    "theoremCount": 23,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "The Elliott–Halberstam conjecture (1968) strengthens the Bombieri–Vinogradov theorem (1965), which established that primes equidistribute in arithmetic progressions on average over moduli up to √x — a 'Riemann Hypothesis quality' result obtained unconditionally. EH conjectures the same averaged equidistribution up to x^θ for every θ < 1. It is the analytic input that sharpens the Maynard–Tao bounded-gap bound: H ≤ 12 under EH versus H ≤ 246 unconditionally. EH remains open.",
@@ -186,15 +199,17 @@
       "Real"
     ],
     "namespace": "BoundedPrimeGapsOQ02",
-    "lineCount": 349,
+    "lineCount": 414,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 23,
     "definitionCount": 7,
     "path": "Proofs/BoundedPrimeGapsOQ02.lean",
     "sorries": 0
   },
   "sorries": 0,
   "highlights": [
+    "Band cocycle (Chasles) identity discrepancyBand_add_consecutive: discrepancyBand θ₁ θ₃ = discrepancyBand θ₁ θ₂ + discrepancyBand θ₂ θ₃ — the new-moduli band subdivides at any intermediate level, the moduli-range analogue of the level decomposition that licenses dyadic decomposition of the modulus range",
+    "Subdivided ascent EHAtLevel_discrepancySum_up_split: raising the level of distribution only needs EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure — the formal statement that Elliott–Halberstam's modulus range may be attacked dyadically",
     "Exact additive decomposition across levels: discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x (band = new moduli ⌊x^θ₁⌋<q≤⌊x^θ₂⌋), sharpening monotonicity to an identity",
     "The EH-bound functional class at a fixed level is a convex cone: closed under addition (EHAtLevel_add) and nonnegative scaling (EHAtLevel_smul)",
     "Quantitative converse (EHAtLevel_discrepancySum_up): EH at level θ₁ + EH-type bound on the new-moduli band ⟹ EH at higher level θ₂",


### PR DESCRIPTION
## Summary

Extends the axiom-free Elliott–Halberstam level-of-distribution hierarchy in `BoundedPrimeGapsOQ02.lean` by subdividing the **new-moduli band** that separates two consecutive levels of distribution. Three new theorems:

- **`discrepancyBand_self`** — the empty band: from a level to itself there are no new moduli, so the band discrepancy vanishes (base case for subdivision). Proof: `Finset.Ioc_self` + `Finset.sum_empty`.
- **`discrepancyBand_add_consecutive`** — the additive **cocycle / Chasles identity** for the band: for `θ₁ ≤ θ₂ ≤ θ₃` on the analytic regime `x ≥ 1`,
  `discrepancyBand f θ₁ θ₃ x = discrepancyBand f θ₁ θ₂ x + discrepancyBand f θ₂ θ₃ x`.
  The new-moduli band subdivides at any intermediate level — the moduli-range analogue of the level decomposition `discrepancySum_eq_add_band`. Proof reuses the same `Finset.sum_Ioc_consecutive` + floor-monotonicity pattern already proven in this file.
- **`EHAtLevel_discrepancySum_up_split`** — **subdivided ascent**: strengthening `EHAtLevel_discrepancySum_up`, raising the level of distribution from `θ₁` to `θ₃` needs only EH-type bounds on each of the two consecutive sub-bands `θ₁→θ₂` and `θ₂→θ₃` separately. The band cocycle splits the full band; the EH-bound class being a convex cone (`EHAtLevel_add`) recombines the two sub-band bounds. This is the formal statement that the modulus range may be attacked **dyadically** — the standard analytic strategy for Elliott–Halberstam.

## Why this matters

The exact level decomposition localized inter-level growth to a single new-moduli band; this PR shows that band is itself additive and may be split at any intermediate level, then recombined. That is precisely the licensing lemma for the dyadic decomposition of the modulus range used in the analytic treatment of EH: control the discrepancy on each dyadic block of moduli separately and sum.

## Verification

**Verified — 0-axiom, 0-sorry.** The Docker build host's containerd metadata is corrupted (`meta.db` I/O error), so verification used the local-toolchain fallback:

- `lake env lean Proofs/BoundedPrimeGapsOQ02.lean` (Lean `v4.26.0`) → **EXIT 0, compiles clean, 0 warnings** (no `sorry` warnings).
- `#print axioms` for all three new theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorry`, no `axiom`, no `native_decide`/`Lean.ofReduceBool`.

File now: 23 theorems, 7 definitions, 414 lines, 0 axioms. `meta.json` updated (counts, contributions, highlights, Mathlib deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)