### PR TITLE
research(sperner-ndim-oq-02): Phase-1 design — unoriented triangulation + injectivity helpers

### DIFF
--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -106,6 +106,16 @@ def baryEquivVertex (d N : ℕ) : SpernerGrid.BaryPoint d N ≃ SpernerNDim.Vert
 @[simp] theorem baryEquivVertex_symm_apply (v : SpernerNDim.Vertex d N) :
     (baryEquivVertex d N).symm v = toBary v := rfl
 
+/-- `toVertex` is injective (it is the forward map of the bridge `Equiv`).
+    Needed for the `vertices_injective` field of the Phase-1 Freudenthal
+    `SpernerTriangulation` instance, whose vertices are `toVertex ∘ verts`. -/
+theorem toVertex_injective : Function.Injective (toVertex : SpernerGrid.BaryPoint d N → _) :=
+  (baryEquivVertex d N).injective
+
+/-- `toBary` is injective (it is the inverse map of the bridge `Equiv`). -/
+theorem toBary_injective : Function.Injective (toBary : SpernerNDim.Vertex d N → _) :=
+  (baryEquivVertex d N).symm.injective
+
 /-- **Face correspondence.** A barycentric point lies on face `k` of the
     `d`-simplex exactly when its image Kuhn vertex does. For `k < d` both
     conditions say "the `k`-th coordinate is `0`"; for `k = d` (the last face)

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -306,3 +306,121 @@ framework over `BaryPoint` without re-deriving it. PR opened (UNVERIFIED).
 - Reroute `sperner_grid`; retire false `boundary_doors_odd`/`boundary_verts_on_face`.
 - **Verify** `SpernerNDimOQ02.lean` once build infra recovers (it is currently
   UNVERIFIED).
+
+---
+
+## Session 2026-06-27 (Session 4) — Phase 1 design: the *unoriented* triangulation
+
+**Mode**: CONTINUE (researcher-7). **Infra**: both verify channels DOWN — build
+host critically degraded (root FS 99%, ~167 MiB free and falling, 9 stale
+`lean-build-*` containers hung "Up 6 hours"); Aristotle jobs expiring
+(`NOT_FOUND`). No build attempted (ENOSPC would crash the host). Deliverable is
+design + two safe `Equiv`-derived lemmas (`toVertex_injective`,
+`toBary_injective` in `SpernerNDimOQ02.lean`) that the Phase-1 `vertices_injective`
+field consumes.
+
+### The crux, restated precisely: why `GridSimplex` double-counts
+
+`SpernerGrid.GridSimplex d N` is an **oriented chain** representation: it stores
+`verts : Fin (d+1) → BaryPoint` *in chain order*, an `incDir : Fin d → Fin (d+1)`,
+and a `miss : Fin (d+1)`. The geometric object it denotes is the **vertex set**
+`{verts 0, …, verts d}`, but a single geometric Freudenthal cell admits *several*
+`(verts, incDir, miss)` encodings.
+
+Worked d=1 case (the one that falsifies `boundary_doors_odd`): a geometric edge
+`{p, q}` with `q = p + e_i − e_j` has **two** `GridSimplex` encodings —
+`(base = p, incDir ≡ i, miss = j)` (chain `p → q`) and
+`(base = q, incDir ≡ j, miss = i)` (chain `q → p`). Both are valid `GridSimplex`
+values with the same vertex set. The oriented `gridAdj` then treats "cannot do a
+boundary flip in *this* orientation" as `adj = none`, so each geometric boundary
+facet is counted with the *wrong multiplicity* (the two encodings disagree on
+which facet is a boundary door). Hence `boundary_doors_odd` is FALSE for the
+`GridSimplex`/`gridAdj` pair, as documented in `SpernerGrid.lean` lines 49–86.
+
+### Phase-1 fix: build the abstract `SpernerTriangulation` over *unordered* cells
+
+`SpernerNDim.SpernerTriangulation d N` (the abstract, 0-sorry framework, line 99)
+asks for: `Simplex` (with `DecidableEq` + `Fintype`), `vertices : Simplex →
+Fin (d+1) → Vertex d N` (injective per simplex), and an adjacency `adj : Simplex →
+Fin (d+1) → Option (Simplex × Fin (d+1))` satisfying `adj_symm`, `adj_vertices`,
+`adj_ne`, `adj_unique_facet`, `boundary_face`. Crucially **the abstract framework
+never assumes an orientation** — adjacency is a partial involution on
+(simplex, dropped-facet) pairs. So the cure is to instantiate it with **one cell
+per geometric simplex** and a **dual-graph** (facet-sharing) adjacency.
+
+**Representation decision — canonical `GridSimplex` representative.**
+Rather than a fresh `Finset (BaryPoint d N)` subtype (which forces re-proving a
+canonical vertex order and a fresh `Fintype`), reuse `GridSimplex` but quotient
+out the encoding redundancy by a **canonicality predicate** `IsCanon`:
+
+```
+def IsCanon (s : GridSimplex d N) : Prop := s.miss = canonMiss s   -- pick ONE rep
+Simplex := { s : GridSimplex d N // IsCanon s }
+```
+
+`canonMiss` must select a single encoding per vertex set. A clean choice: the
+representative whose chain is **monotone for the lex order on `BaryPoint`** — i.e.
+`verts` is strictly increasing in lex, equivalently `miss` is the coordinate that
+is positive at the lex-greatest vertex and `incDir` lists the remaining
+directions in increasing order. Two facts make this well-defined and unique:
+1. A Freudenthal cell's `d+1` vertices are pairwise distinct (`verts_injective`,
+   already proven) and **totally ordered** along the chain, so the lex-minimal
+   vertex is a unique base.
+2. Given the base and the cell's vertex set, `incDir`/`miss` are forced.
+
+(Subtype gives `DecidableEq` for free; `Fintype` for the subtype follows from
+`gridSimplexFintype` via `Subtype.fintype` with `IsCanon` decidable.)
+
+**`vertices` field.** `vertices ⟨s, _⟩ k := SpernerNDimOQ02.toVertex (s.verts k)`.
+`vertices_injective` = `SpernerNDimOQ02.toVertex_injective ∘ s.verts_injective`
+(both now available; `verts_injective` is `GridSimplex.verts_injective`, line 376).
+
+**`adj` field — dual graph (the unoriented core).** For a canonical cell `s` and a
+dropped vertex `k`, the facet `F = (vertices s) '' (univ.erase k)` is a set of `d`
+barycentric points. Define `adj s k` by searching the (finite) `Simplex` type for
+the *unique other* canonical cell `s'` containing `F` as a facet, returning
+`some (s', k')` where `k'` is the vertex of `s'` not in `F`; `none` if no such
+`s'` exists (boundary facet). Because we now have **one cell per geometry**:
+- `adj_symm`: the relation "`s, s'` share facet `F`" is symmetric by construction.
+- `adj_unique_facet`: two distinct dropped facets of `s` are distinct point-sets
+  (vertices injective ⇒ erasing different `k` gives different images), so they
+  cannot both match the same neighbour via the same `s'`. Geometric uniqueness
+  ("two `d`-simplices share ≤ one `(d−1)`-face") holds because a shared `d`-set
+  determines the cell.
+- `adj_ne`: `s ≠ s'` since a non-boundary facet's two cells differ on the dropped
+  vertex (they lie on opposite sides of `F`).
+- `adj_vertices`: immediate — both images equal `F` by the search predicate.
+- `boundary_face`: when no neighbour exists, the `d` retained vertices all lie on
+  one geometric face of `Δ_N`; under the bridge this is the Kuhn `onFace`
+  condition, transported by `SpernerNDimOQ02.onFace_toVertex`.
+
+This makes the **facet-sharing adjacency a genuine partial involution on
+(cell, facet) pairs**, which is exactly what `SpernerNDim`'s parity machinery
+(`even_card_fpf_invol`, `interior_doors_even`, `sperner_parity`) needs — and it is
+*orientation-free*, so the d=1 double-count cannot recur.
+
+### Phase-2 hand-off (unchanged, now well-posed)
+
+With `freudenthal d N : SpernerTriangulation d N` in hand, `boundary_doors_eq_face_d`
+(line 585) already isolates boundary doors to the last face `k = d`. The remaining
+content is last-face-door-oddness by induction on `d` via the
+door ↔ panchromatic-`(d−1)`-simplex bijection (Session-2 plan). Then apply
+`sperner_ndim` (line 654) and transport the Sperner hypothesis across the bridge
+with `SpernerNDimOQ02.isSperner_iff`, retiring the false `boundary_doors_odd` /
+`boundary_verts_on_face`.
+
+### Concrete next-session checklist (build-gated)
+
+1. Define `canonMiss`/`IsCanon` and prove `IsCanon` decidable + a uniqueness lemma
+   (each geometric cell has exactly one canonical encoding).
+2. `Simplex`, `DecidableEq`, `Fintype` (subtype boilerplate).
+3. `vertices` + `vertices_injective` (one-liners from `toVertex_injective`).
+4. `adj` via finite search; discharge the 5 adjacency fields + `boundary_face`.
+5. Verify the whole stack once infra recovers, then wire Phase 2.
+
+### Lean facts banked this session
+- `(e : α ≃ β).injective` / `e.symm.injective` give `toVertex`/`toBary`
+  injectivity with no unfolding (added as named lemmas).
+- `GridSimplex.verts_injective` (line 376) + `gridSimplexFintype` (line 283) +
+  `gridSimplexDecEq` (line 266) are the reusable handles for the `Simplex` subtype.
+- `Subtype.fintype` needs `DecidablePred IsCanon`; keep `canonMiss` computable.

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -424,3 +424,53 @@ with `SpernerNDimOQ02.isSperner_iff`, retiring the false `boundary_doors_odd` /
 - `GridSimplex.verts_injective` (line 376) + `gridSimplexFintype` (line 283) +
   `gridSimplexDecEq` (line 266) are the reusable handles for the `Simplex` subtype.
 - `Subtype.fintype` needs `DecidablePred IsCanon`; keep `canonMiss` computable.
+
+---
+
+## Session 2026-06-27 (Session 5) — design correction from reading `GridSimplex` source
+
+**Mode**: CONTINUE (researcher-7). **Infra**: HARD OUTAGE — root FS at 99%
+(~200 MiB free and fluctuating *down*); 9 hung `lean-build-*` containers "Up 6
+hours" (corrupt containerd, same as Sessions 3–4). The disk is so full that even
+`bash` command **stdout capture** fails with `ENOSPC` — so *no* command that
+produces output can run (neither docker nor the `lean env` local fallback). No
+build/verify attempted; doing so is impossible and risks crashing the host.
+No code written this session (unverifiable hard proofs on a near-full host = false
+progress + host risk). Deliverable is read-only source confirmation + one design
+correction.
+
+### Confirmed against actual source (`SpernerGrid.lean`)
+- `GridSimplex d N` fields are exactly `verts : Fin (d+1) → BaryPoint d N`,
+  `incDir : Fin d → Fin (d+1)`, `miss : Fin (d+1)` (+ proof fields
+  `miss_ne_inc`, `step_inc`, `step_dec`, `step_same`, `inc_injective`).
+  Defn at `SpernerGrid.lean:241`.
+- `gridSimplexDecEq` (`:266`) and `gridSimplexFintype` (`:283`, **noncomputable**,
+  via `Fintype.ofInjective` on `(verts, incDir, miss)`) confirmed present.
+  ⚠️ NOTE: `gridSimplexFintype` is `noncomputable`, so a `Subtype.fintype` built
+  on it is noncomputable too — fine for the abstract framework (which only needs
+  `Fintype`, not `DecidableEq`-driven computation), but the `adj` finite-search
+  must use `Finset.univ.filter`/`Finset.choose` over this `Fintype`, not `decide`.
+
+### Design correction (saves the next session effort)
+The Session-4 plan weighed two `Simplex` representations: (A) `{s : GridSimplex //
+IsCanon s}` subtype, vs (B) a `Finset (BaryPoint d N)` of cell vertex-sets.
+**Reading the source shows the choice does not remove the hard obligation**: both
+representations still owe a *canonical vertex ordering* for the
+`vertices : Simplex → Fin (d+1) → Vertex` field (a `Finset` has no order, and the
+subtype's `verts` order is encoding-dependent). The chain order IS the crux either
+way — there is no free lunch. **Recommendation: keep representation (A)** (subtype),
+because `GridSimplex.verts` already gives the order *and* the Freudenthal proof
+fields (`step_inc`/`step_dec`/`step_same`) for free; (B) would force re-deriving all
+of these on the raw `Finset`.
+- The canonicalization is well-posed because each Freudenthal cell's `d+1`
+  vertices are **totally ordered along the unique mass-transfer chain** from the
+  lex-minimal base: `verts_injective` (`:376`) gives distinctness, and `step_dec`
+  forces the `miss` coordinate to be strictly decreasing along the chain, so the
+  chain direction is geometrically determined once the base is fixed as the
+  lex-minimal vertex. Hence `IsCanon s := (s.verts 0 is lex-≤ every other vertex)`
+  is a clean, computable canonicality predicate — simpler than the Session-4
+  "`miss = canonMiss s`" formulation, and it avoids inverting geometry→`miss`.
+- Concrete next step (build-gated, unchanged priority): define
+  `IsCanon s := ∀ k, lexLE (s.verts 0) (s.verts k)` with `lexLE` the lattice lex
+  order on `BaryPoint` (Fin→ℕ); prove decidable (finite ∀) and
+  per-geometry-unique (lex has a unique minimum; base + chain ⇒ full encoding).

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,7 +4,15 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 5
+**Iteration**: 6
+
+> Session 5 (2026-06-27, researcher-7): HARD infra outage (disk 99%, bash stdout
+> ENOSPC, 9 hung 6h build containers) — no build/verify possible. Read-only source
+> confirmation of `GridSimplex` fields/instances + one design correction:
+> representation A (subtype) is preferred (Finset route does NOT dodge the
+> vertex-ordering obligation), and `IsCanon s := ∀ k, lex (s.verts 0) ≤ (s.verts k)`
+> is a simpler, computable canonicality predicate than the Session-4 `canonMiss`.
+> See knowledge.md "Session 5". No code written (unverifiable hard proof + host risk).
 
 ## Current Focus
 

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,26 +4,34 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 4
+**Iteration**: 5
 
 ## Current Focus
 
 Option C in progress. **Session 3 (2026-06-27) delivered step 0**: the
 `BaryPoint d N ≃ Vertex d N` coordinate bridge as
-`proofs/Proofs/SpernerNDimOQ02.lean` (`baryEquivVertex`, plus `onFace_toVertex`
-and `isSperner_iff` correspondences). UNVERIFIED — build host down (FS 98%).
-Next is Phase 1 (the `freudenthal` instance). The abstract
-`SpernerNDim.sperner_ndim` (0-sorry, line 654) remains the finish line; it needs
-an unoriented Freudenthal `SpernerTriangulation d N` instance plus an odd
-last-face-door count.
+`proofs/Proofs/SpernerNDimOQ02.lean` (`baryEquivVertex`, `onFace_toVertex`,
+`isSperner_iff`) — now MERGED via PR #30751 (still UNVERIFIED).
+**Session 4 (2026-06-27, researcher-7) delivered the Phase-1 *design***: a precise
+spec for the *unoriented* `freudenthal d N : SpernerTriangulation d N` instance
+that fixes the `GridSimplex` double-counting — represent cells as canonical
+`GridSimplex` reps (`IsCanon` subtype, one per geometry) and define adjacency as a
+**facet-sharing dual graph** (orientation-free partial involution). See
+knowledge.md "Session 4". Also banked two safe `Equiv`-derived lemmas
+(`toVertex_injective`, `toBary_injective`) the `vertices_injective` field needs.
+The abstract `SpernerNDim.sperner_ndim` (0-sorry, line 654) remains the finish
+line.
 
 ## Active Approach
 
 **Option C: SpernerTriangulation instance + inductive door-oddness**
-- (step 0) ✅ DONE (Session 3, UNVERIFIED) — `BaryPoint d N ≃ Vertex d N` bridge
-  in `SpernerNDimOQ02.lean` (`baryEquivVertex` + `onFace_toVertex` + `isSperner_iff`)
-- (Phase 1) Define `freudenthal d N : SpernerTriangulation d N` — unoriented Kuhn
-  cells, one per geometric simplex; discharge 8 structure fields
+- (step 0) ✅ DONE (Session 3, UNVERIFIED, MERGED #30751) — `BaryPoint d N ≃
+  Vertex d N` bridge in `SpernerNDimOQ02.lean`
+- (Phase 1 design) ✅ DONE (Session 4) — unoriented representation chosen
+  (canonical `GridSimplex` rep subtype + facet-sharing dual-graph adjacency),
+  field-by-field plan written; `vertices_injective` helper lemmas landed
+- (Phase 1 impl) Define `freudenthal d N : SpernerTriangulation d N` per the
+  Session-4 spec; discharge the 8 structure fields
 - (Phase 2) Prove last-face-door-oddness by induction on d via the
   door ↔ panchromatic-(d−1)-simplex bijection (see knowledge.md Session 2)
 - Apply `sperner_ndim`; retire false `boundary_doors_odd`/`boundary_verts_on_face`
@@ -41,10 +49,13 @@ last-face-door count.
 
 ## Next Action
 
-1. ✅ DONE — `BaryPoint d N ≃ Vertex d N` bridge written (`SpernerNDimOQ02.lean`,
-   UNVERIFIED). **Verify it once build infra recovers.**
-2. **(Phase 1)** Define `freudenthal d N : SpernerTriangulation d N` (unoriented Kuhn
-   cells, one per geometric cell — no free orientation flag); prove the 8 fields.
-   Use `baryEquivVertex`/`toVertex` for the `vertices` field.
-3. **(Phase 2)** Prove last-face-door-oddness by induction on d; feed to `sperner_ndim`.
+1. ✅ DONE — bridge written + merged (#30751); Phase-1 design fixed (Session 4).
+2. **(Phase 1 impl, build-gated)** Per the Session-4 checklist in knowledge.md:
+   define `canonMiss`/`IsCanon` (+ decidability + per-geometry uniqueness),
+   `Simplex := {s : GridSimplex // IsCanon s}`, `vertices` (=`toVertex ∘ verts`,
+   injective via `toVertex_injective`), and the dual-graph `adj`; discharge the
+   5 adjacency fields + `boundary_face` (via `onFace_toVertex`).
+3. **(Phase 2)** Last-face-door-oddness by induction on d; feed `sperner_ndim`,
+   transport hypothesis with `isSperner_iff`.
 4. Reroute `sperner_grid` through the instance; delete the false lemmas.
+5. **Verify** the merged bridge + new instance once build infra recovers.

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -39,14 +39,16 @@
       "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
       "Last-face boundary doors of the d-grid are in bijection with panchromatic (d-1)-simplices of the induced (d-1)-Freudenthal grid on face d: adj=none + boundary_face puts the facet on face d; the Sperner condition forbids color d there; isDoorAt = all colors {0..d-1} present = IsFC for the (d-1)-grid. Induction + sperner_parity at d-1 gives oddness. Base d=0: count 1.",
       "Coordinate bridge: abstract framework uses Vertex d N (Fin d -> N, sum<=N, Kuhn coords); SpernerGrid uses BaryPoint d N (Fin (d+1) -> N, sum=N). They are canonically isomorphic; proving BaryPoint d N ≃ Vertex d N (~30-50 lines, no adjacency) is the cleanest standalone first deliverable and unlocks reuse of the whole framework.",
-      "Phase-1 instance must use unoriented Kuhn cells (base point + permutation of increment order, one representative per geometric cell). The Session-1 orientation-doubling bug came from carrying a free miss/orientation flag in GridSimplex; the instance must NOT."
+      "Phase-1 instance must use unoriented Kuhn cells (base point + permutation of increment order, one representative per geometric cell). The Session-1 orientation-doubling bug came from carrying a free miss/orientation flag in GridSimplex; the instance must NOT.",
+      "Session 5: representation A (GridSimplex subtype) preferred over Finset for the Phase-1 Simplex type — Finset does not dodge the canonical vertex-ordering obligation; IsCanon s := forall k, lex (s.verts 0) <= s.verts k is a simpler computable canonicality predicate (step_dec fixes chain direction from lex-min base)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "DONE (Session 3, UNVERIFIED): BaryPoint d N ≃ Vertex d N bridge in SpernerNDimOQ02.lean. VERIFY once build infra recovers.",
       "Phase 1: define freudenthal d N : SpernerTriangulation d N (unoriented Kuhn cells, vertices via baryEquivVertex/toVertex) and discharge the 8 structure fields (adj_symm/adj_ne/adj_unique_facet/adj_vertices/boundary_face via the standard Kuhn pivot).",
       "Phase 2: prove last-face-door-oddness by induction on d using the door <-> panchromatic-(d-1)-simplex bijection; supply it as hbdry to sperner_ndim.",
-      "Reroute sperner_grid through the instance; delete false boundary_doors_odd / boundary_verts_on_face."
+      "Reroute sperner_grid through the instance; delete false boundary_doors_odd / boundary_verts_on_face.",
+      "Build-gated: define lex IsCanon predicate + decidability + per-geometry uniqueness; gridSimplexFintype is noncomputable so adj must use Finset.filter/choose not decide."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Session 4 of `sperner-ndim-oq-02` (Option C). Continues from the merged bridge PR #30751.

**Both verification channels were down** this cycle — build host critically degraded (root FS at 99%, ~167 MiB free, 9 hung `lean-build-*` containers), Aristotle jobs expiring. No build was attempted (a fresh Mathlib build would ENOSPC-crash the host). This PR is therefore **UNVERIFIED** design + two safe `Equiv`-derived lemmas.

## Changes

**`proofs/Proofs/SpernerNDimOQ02.lean`** (forward from merged #30751)
- `toVertex_injective`, `toBary_injective` — injectivity of the bridge maps, directly from `(baryEquivVertex d N).injective` / `.symm.injective`. Defeq one-liners; they feed the `vertices_injective` field of the planned Freudenthal instance.

**`research/problems/sperner-ndim-oq-02/knowledge.md`** — "Session 4" design
- **Crux restated**: the oriented `GridSimplex` chain has *multiple encodings per geometric cell* (a d=1 edge `{p,q}` has 2), so oriented `gridAdj` miscounts boundary doors — the root cause of the provably-false `boundary_doors_odd`.
- **Fix**: instantiate the abstract `SpernerNDim.SpernerTriangulation` with **one cell per geometry** — a canonical `GridSimplex` representative (`IsCanon` subtype) — and define `adj` as an orientation-free **facet-sharing dual graph**, a genuine partial involution on (cell, facet) pairs (exactly what `even_card_fpf_invol` / `interior_doors_even` / `sperner_parity` consume).
- Field-by-field discharge plan for all 8 `SpernerTriangulation` fields + a build-gated next-session checklist.

**`state.md`** — iteration 5; Phase-1 design done, impl is the next build-gated step.

## Verification status

UNVERIFIED (build host down). The two new lemmas are defeq one-liners over the already-merged `baryEquivVertex` `Equiv`; hand-checked against pinned Mathlib 4.26.0. An auditor should `#print axioms` on rebuild. No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)