### PR TITLE
Research: puiseux-theorem-oq-03 — combinatorial Newton polygon (verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3805,6 +3805,7 @@ import Proofs.PtolemysTheoremOQ01OQ02
 import Proofs.PtolemysTheoremOQ04
 import Proofs.PuiseuxTheorem
 import Proofs.PuiseuxTheoremOQ02
+import Proofs.PuiseuxTheoremOQ03
 import Proofs.PvsNP
 import Proofs.PythagoreanTheorem
 import Proofs.PythagoreanTheoremOQ03

--- a/proofs/Proofs/PuiseuxTheorem.lean
+++ b/proofs/Proofs/PuiseuxTheorem.lean
@@ -279,7 +279,7 @@ theorem puiseux_nth_root_of_monomial {K : Type*} [Field K] (n : ℕ+) :
     · rw [nsmul_eq_mul]; push_cast; field_simp
     · rw [one_pow]
 
-/-- The Newton-Puiseux algorithm terminates and produces valid roots.
+/- The Newton-Puiseux algorithm terminates and produces valid roots.
 
 This is the constructive content of Puiseux's theorem: not only do roots exist,
 but they can be computed algorithmically.

--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -1,0 +1,145 @@
+/-
+# Puiseux's Theorem — OQ-03: a combinatorial Newton polygon
+
+This file is the first Lean deliverable for the open question
+
+  *"Can the Newton–Puiseux algorithm be made efficient enough for computational
+  algebraic geometry at scale?"*
+
+extracted from the gallery entry `puiseux-theorem` (Wiedijk #41 family).  Two
+earlier doc-only OBSERVE sessions surveyed the literature
+(Chudnovsky–Chudnovsky 1986, Duval 1989, Walsh 2000, Poteaux–Rybowicz 2008–15,
+Poteaux–Weimann 2017–21) and the Mathlib v4.26.0 state, and identified the
+**combinatorial Newton polygon** as the cleanest tractable entry point
+(their "S2-A").  This file delivers it.
+
+## What the Newton polygon is
+
+For a polynomial `P(Y) = Σ aᵢ Yⁱ` with coefficients `aᵢ` in a valued field
+`K((x))`, the Newton polygon is the lower convex hull of the *support points*
+
+    (i, v(aᵢ))   for the indices i with aᵢ ≠ 0,
+
+where `v(aᵢ) ∈ ℚ` is the valuation (the order of `aᵢ` as a Laurent/Puiseux
+series).  The crucial fact — the Newton polygon theorem — is that the negatives
+of the edge slopes are exactly the valuations of the roots of `P` in any
+algebraically closed valued extension, which is why the slopes feed the
+parent's `leadingExponentFromSlope`.
+
+## What this file proves (all machine-checked, 0 sorries, 0 axioms)
+
+We avoid committing to any particular hull-construction *algorithm* and instead
+use the standard **supporting-line** characterization of a lower-hull vertex:
+a support point `p` is a lower vertex when some line lies weakly below every
+support point and passes through `p`.  This is a `Prop`, so the API is honest
+about the combinatorial content without needing a verified convex-hull routine.
+
+* `IsLowerVertex` — the supporting-line predicate.
+* `isLowerVertex_of_minimal` — the minimum-valuation point is always a lower
+  vertex (horizontal supporting line).  This is the seed of the polygon.
+* `exists_lowerVertex` — every nonempty support set has a lower vertex
+  (via `List.argmin`).
+* `IsLowerVertex.mem` — lower vertices are genuine support points.
+* The worked example `Y² − x`: both `(0,1)` and `(2,0)` are lower vertices, the
+  single edge has slope `-1/2`, and the resulting leading exponent `1/2`
+  matches the parent's `leadingExponentFromSlope 1 2`.
+
+## What remains (honest scope)
+
+* **Newton polygon theorem** (slopes = root valuations): needs a valuation API
+  on `K((x))[Y]` not yet in Mathlib v4.26.0 — the harder half of S2-A.
+* **Termination measure** for one Newton–Puiseux reduction step (S2-B).
+* **Quasi-linear complexity bound** (Poteaux–Weimann `Õ(d·δ)`): the moonshot
+  S2-C, blocked on the absence of an arithmetic-complexity model in Mathlib.
+
+See `research/problems/puiseux-theorem-oq-03/` for the session notes.
+
+## References
+
+* I. Newton, *Method of Fluxions* (1676) — the fractional-exponent procedure.
+* V. Puiseux, *Recherches sur les fonctions algébriques* (1850).
+* R. Walker, *Algebraic Curves* (1950), Ch. IV.
+* A. Poteaux, M. Weimann, *Computing Puiseux series: a fast divide and conquer
+  algorithm*, Ann. Henri Lebesgue 4 (2021), 1061–1102.
+-/
+import Proofs.PuiseuxTheorem
+import Mathlib.Data.List.MinMax
+
+namespace PuiseuxTheoremOQ03
+
+/-- A **support point** `(i, v)` of a polynomial `P(Y) = Σ aᵢ Yⁱ` over a valued
+field: the exponent `i` of `Y` paired with the valuation `v = v(aᵢ) ∈ ℚ` of the
+coefficient.  Indices with `aᵢ = 0` (valuation `+∞`) are simply omitted from the
+support list. -/
+abbrev SupportPoint := ℕ × ℚ
+
+/-- The slope of the segment joining two support points. -/
+def edgeSlope (p q : SupportPoint) : ℚ := (q.2 - p.2) / ((q.1 : ℚ) - (p.1 : ℚ))
+
+/-- `p` is a **lower vertex** of the Newton polygon of `pts` when some
+(non-vertical) line `y = m·i + b` lies weakly below every support point of `pts`
+and passes through `p`.  This is the supporting-line characterization of a
+vertex of the lower convex hull; phrasing it as a predicate keeps the API
+independent of any particular hull-construction algorithm. -/
+def IsLowerVertex (pts : List SupportPoint) (p : SupportPoint) : Prop :=
+  p ∈ pts ∧ ∃ m b : ℚ, p.2 = m * (p.1 : ℚ) + b ∧ ∀ q ∈ pts, m * (q.1 : ℚ) + b ≤ q.2
+
+/-- A lower vertex is a genuine support point. -/
+theorem IsLowerVertex.mem {pts : List SupportPoint} {p : SupportPoint}
+    (h : IsLowerVertex pts p) : p ∈ pts := h.1
+
+/-- **The minimum-valuation point is always a lower vertex.**  A horizontal
+supporting line `y = v(p)` lies weakly below every support point and passes
+through `p`.  This is the seed of the Newton polygon: the lowest point is always
+a vertex. -/
+theorem isLowerVertex_of_minimal {pts : List SupportPoint} {p : SupportPoint}
+    (hp : p ∈ pts) (hmin : ∀ q ∈ pts, p.2 ≤ q.2) : IsLowerVertex pts p := by
+  refine ⟨hp, 0, p.2, by ring, fun q hq => ?_⟩
+  simpa using hmin q hq
+
+/-- **Every nonempty support set has a lower vertex.**  Take the point of
+minimum valuation via `List.argmin`. -/
+theorem exists_lowerVertex {pts : List SupportPoint} (h : pts ≠ []) :
+    ∃ p, IsLowerVertex pts p := by
+  rcases hm : pts.argmin (·.2) with _ | m
+  · exact absurd (List.argmin_eq_none.mp hm) h
+  · exact ⟨m, isLowerVertex_of_minimal (List.argmin_mem hm)
+      (fun q hq => List.le_of_mem_argmin hq hm)⟩
+
+/-! ### Worked example: `Y² − x`
+
+Over `K((x))`, the polynomial `Y² − x` has coefficients `a₀ = −x` (valuation
+`1`), `a₁ = 0` (omitted), and `a₂ = 1` (valuation `0`).  Its support is therefore
+`{(0, 1), (2, 0)}`, the Newton polygon is the single edge from `(0,1)` to
+`(2,0)` of slope `-1/2`, and the root is `x^{1/2}`. -/
+
+/-- Support points of `Y² − x`: `(0, 1)` from the constant term `−x` and
+`(2, 0)` from the leading term `1`. -/
+def YsqMinusX : List SupportPoint := [(0, 1), (2, 0)]
+
+/-- The constant-term support point `(0,1)` is a lower vertex of `Y² − x`,
+witnessed by the edge line `y = -½ i + 1`. -/
+theorem ysqMinusX_vertex_const : IsLowerVertex YsqMinusX (0, 1) := by
+  refine ⟨by simp [YsqMinusX], -1/2, 1, by norm_num, fun q hq => ?_⟩
+  fin_cases hq <;> norm_num
+
+/-- The leading-term support point `(2,0)` is a lower vertex of `Y² − x`,
+witnessed by the same edge line `y = -½ i + 1`. -/
+theorem ysqMinusX_vertex_lead : IsLowerVertex YsqMinusX (2, 0) := by
+  refine ⟨by simp [YsqMinusX], -1/2, 1, by norm_num, fun q hq => ?_⟩
+  fin_cases hq <;> norm_num
+
+/-- The single Newton-polygon edge of `Y² − x` has slope `-1/2`. -/
+theorem ysqMinusX_edge_slope : edgeSlope (0, 1) (2, 0) = -1/2 := by
+  norm_num [edgeSlope]
+
+/-- **The Newton polygon recovers the leading exponent of the root.**  The
+negative of the edge slope `-1/2` equals the parent's
+`leadingExponentFromSlope 1 2 = 1/2`, the leading exponent of the root
+`x^{1/2}` of `Y² − x`. -/
+theorem ysqMinusX_leading_exponent :
+    -edgeSlope (0, 1) (2, 0)
+      = PuiseuxTheorem.leadingExponentFromSlope 1 2 (by norm_num) := by
+  norm_num [edgeSlope, PuiseuxTheorem.leadingExponentFromSlope]
+
+end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -6,16 +6,78 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Open question: *"Can the Newton–Puiseux algorithm be made efficient enough for
+computational algebraic geometry at scale?"* (parent: `puiseux-theorem`,
+Wiedijk #41). Two earlier doc-only OBSERVE sessions (2026-05-12) surveyed the
+literature and Mathlib state and recommended the **combinatorial Newton polygon**
+("S2-A") as the cleanest tractable entry point, deferring the termination
+measure (S2-B) and the quasi-linear complexity bound (S2-C, moonshot).
+
+---
+
+## What was delivered (S2 ACT, 2026-06-27, researcher-1)
+
+First Lean file for the slug: `proofs/Proofs/PuiseuxTheoremOQ03.lean`
+(145 lines, **verified, 0 sorries, 0 axioms** — `#print axioms` shows only
+`propext`/`Classical.choice`/`Quot.sound`). Gallery entry
+`src/data/proofs/puiseux-theorem-oq-03/meta.json` added.
+
+Design choice: model the Newton polygon by the **supporting-line predicate**
+`IsLowerVertex pts p` (a line `y = m·i + b` lies weakly below every support
+point and passes through `p`) rather than by a hull-construction algorithm. This
+captures the exact mathematical content of a lower-hull vertex without requiring
+a verified convex-hull routine.
+
+Theorems:
+* `isLowerVertex_of_minimal` — the minimum-valuation support point is always a
+  vertex (horizontal supporting line `y = v(p)`); the seed of the polygon.
+* `exists_lowerVertex` — every nonempty support set has a vertex, via
+  `List.argmin` (`argmin_mem`, `le_of_mem_argmin`, `argmin_eq_none`).
+* `IsLowerVertex.mem` — vertices are genuine support points.
+* Worked `Y²−x` example: support `{(0,1),(2,0)}`, both are lower vertices
+  (line `y = −½i + 1`), `edgeSlope = −1/2`, and `−(−1/2) = 1/2 =
+  PuiseuxTheorem.leadingExponentFromSlope 1 2` — closing the loop to the parent.
+
+Also fixed a **parse error in the parent** `PuiseuxTheorem.lean`: line 282 had a
+dangling `/--` doc comment (a `/--` with no following declaration, immediately
+before `end NewtonPuiseux`), which makes the file fail to parse
+(`unexpected token 'end'; expected 'lemma'`). Changed `/--` → `/-`. The parent
+genuinely did not compile on `main` before this fix.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+* **Supporting-line predicate is the right abstraction.** Phrasing a vertex as
+  "∃ a line below all points touching this one" keeps the API algorithm-agnostic
+  and fully provable; a verified Graham-scan/lower-hull construction would be far
+  more work for the same downstream value.
+* **`List.argmin` gives existence cheaply.** Nonempty support lists have a
+  minimum-valuation element; Mathlib's argmin lemmas turn that into the
+  existence of a vertex in three lines.
+* **Use `ℕ × ℚ` (Prod), not a custom structure**, for support points: `fin_cases`
+  + `norm_num` then dispatch the example goals cleanly (projections of `Prod`
+  literals reduce well under `norm_num`).
 
 ---
 
-## Dead Ends
+## Dead Ends / Deferred
 
-[Approaches known not to work will be documented here]
+* A computable hull-construction `def newtonPolygon : … → List (ℚ × ℕ)` with a
+  correctness proof — significant convex-hull combinatorics; not needed for the
+  predicate-level API and deferred.
+* **Newton polygon theorem** (edge slopes = root valuations): needs a valuation
+  API on `K((x))[Y]` absent from Mathlib 4.26.0. The harder half of S2-A.
+* **S2-B** termination measure and **S2-C** complexity bound remain open; S2-C
+  is blocked on the lack of an arithmetic-complexity model in Mathlib.
+
+---
+
+## Verification
+
+`cd proofs && ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean` exits 0 with no
+diagnostics (host toolchain; Docker build host has corrupted containerd
+metadata). The parent olean was produced single-file via
+`./bin/lake env lean Proofs/PuiseuxTheorem.lean -o <olean>` (the parent imports
+only Mathlib, so no full `lake build` is needed). `#print axioms` on all 7
+theorems lists only the foundational axioms.

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "puiseux-theorem-oq-03",
+  "title": "Puiseux Theorem OQ-03: A Combinatorial Newton Polygon",
+  "slug": "puiseux-theorem-oq-03",
+  "description": "First Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex), proves the minimum-valuation point is always a vertex (isLowerVertex_of_minimal) and that every nonempty support set has one (exists_lowerVertex via List.argmin), and works the canonical Y²−x example: both support points are vertices, the single edge has slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. Also fixes a parse error in the parent file (a dangling /-- doc comment).",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Newton_polygon",
+    "date": "Newton 1676; Puiseux 1850; Poteaux–Weimann 2021; formalized 2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "series",
+      "newton-polygon",
+      "convex-hull",
+      "computational",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/PuiseuxTheoremOQ03.lean",
+    "badge": "infrastructure",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 7 theorems and 3 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "originalContributions": [
+      "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
+      "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
+      "exists_lowerVertex: every nonempty support set has a lower vertex (via List.argmin)",
+      "IsLowerVertex.mem: lower vertices are genuine support points",
+      "edgeSlope: slope of the segment joining two support points",
+      "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
+      "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse"
+    ],
+    "dateAdded": "2026-06-27",
+    "lineCount": 145,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton (1676) introduced the fractional-exponent root-finding procedure that bears his name; Puiseux (1850) gave the first rigorous proof that it produces all roots. The central combinatorial object is the Newton polygon: for a polynomial P(Y) = Σ aᵢ Yⁱ with coefficients in a valued field K((x)), it is the lower convex hull of the support points (i, v(aᵢ)). The Newton polygon theorem states that the negatives of its edge slopes are exactly the valuations of the roots of P in any algebraically closed valued extension — the fact that feeds the parent's leadingExponentFromSlope.\n\nThe computational story (Chudnovsky–Chudnovsky 1986, Duval 1989, Walsh 2000, Poteaux–Rybowicz 2008–15, Poteaux–Weimann 2021) tightens the cost of computing Puiseux expansions to quasi-linear Õ(d·δ) in the discriminant valuation δ. Every such bound is phrased on the Newton polygon as a data structure, so a computable combinatorial Newton polygon is the natural first formal step.",
+    "problemStatement": "**Open Question (OQ-03 from Puiseux's Theorem)**: Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\n\n**This deliverable**: Mathlib 4.26.0 has no Newton polygon API. This file supplies the combinatorial core — the lower-hull vertex predicate and its basic structure theory, validated on the canonical Y²−x example — as the foundation on which termination and complexity bounds can later be stated.",
+    "text": "A 145-line, fully-verified Lean file. The Newton polygon is captured not by a hull-construction algorithm but by the standard supporting-line predicate IsLowerVertex: a support point p is a lower vertex when some line y = m·i + b lies weakly below every support point and passes through p. General lemmas (minimum-valuation point is a vertex; existence of a vertex for nonempty supports) plus the worked Y²−x example (both endpoints are vertices, edge slope −1/2, leading exponent 1/2) connect the construction to the parent's leadingExponentFromSlope. The file also repairs a parse error in the parent PuiseuxTheorem.lean.",
+    "proofStrategy": "**Predicate, not algorithm**: IsLowerVertex states existence of a supporting line through p below all support points. This is the math definition of a lower-hull vertex and keeps the API independent of any verified convex-hull routine.\n\n**General structure**: isLowerVertex_of_minimal uses the horizontal line y = v(p) — the lowest support point is always a vertex. exists_lowerVertex extracts the argmin of the valuations from a nonempty support list (Mathlib List.argmin + le_of_mem_argmin).\n\n**Example**: For Y²−x the support is {(0,1),(2,0)}; the line y = −½i + 1 passes through both and lies (with equality) below them, so both are vertices. edgeSlope (0,1) (2,0) = −1/2 by norm_num, and −(−1/2) = 1/2 = leadingExponentFromSlope 1 2.",
+    "keyInsights": [
+      "**Supporting lines beat algorithms**: Phrasing a Newton-polygon vertex as 'some line lies below all points and touches this one' captures the exact mathematical content without forcing a verified convex-hull construction — the API stays honest and small.",
+      "**The lowest point seeds the polygon**: The global minimum valuation is always a vertex (horizontal supporting line), giving a constructive starting vertex for any support set.",
+      "**List.argmin gives existence for free**: Nonempty support lists have a minimum-valuation element, and Mathlib's argmin lemmas turn that into an immediate existence proof for a lower vertex.",
+      "**The example closes the loop to the parent**: Recovering leadingExponentFromSlope 1 2 = 1/2 from the Y²−x Newton polygon's single edge of slope −1/2 ties the combinatorial object directly to the parent's root-exponent definition.",
+      "**Mathlib gaps stay explicit**: The Newton polygon theorem (slopes = root valuations), a termination measure, and the Poteaux–Weimann complexity bound all remain open for stated infrastructural reasons (valuation API on K((x))[Y]; arithmetic-complexity model) rather than being papered over."
+    ],
+    "prerequisites": [
+      "Newton polygons and the lower convex hull of support points",
+      "Valuations / orders of Laurent and Puiseux series",
+      "Convex geometry: supporting lines of a convex hull",
+      "Mathlib List.argmin and its min lemmas (Mathlib.Data.List.MinMax)",
+      "Univariate Puiseux's theorem (parent gallery entry puiseux-theorem)",
+      "The Newton–Puiseux algorithm outline (edges → leading exponents → recurse)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "IsLowerVertex",
+      "type": "definition",
+      "statement": "$\\text{IsLowerVertex}(\\text{pts}, p) := p \\in \\text{pts} \\wedge \\exists m\\,b,\\; p_2 = m p_1 + b \\wedge \\forall q \\in \\text{pts},\\; m q_1 + b \\le q_2$",
+      "significance": "The supporting-line characterization of a vertex of the Newton polygon's lower convex hull. Stated as a Prop so the API commits to the mathematical content, not to a particular hull-construction algorithm.",
+      "description": "A support point p is a lower vertex when some non-vertical line lies weakly below every support point and passes through p."
+    },
+    {
+      "name": "isLowerVertex_of_minimal",
+      "type": "theorem",
+      "statement": "$p \\in \\text{pts} \\wedge (\\forall q \\in \\text{pts},\\, p_2 \\le q_2) \\Rightarrow \\text{IsLowerVertex}(\\text{pts}, p)$",
+      "significance": "The minimum-valuation support point is always a lower vertex, witnessed by the horizontal supporting line y = v(p). This is the seed of the Newton polygon.",
+      "description": "Proof supplies m = 0, b = p.2; the supporting condition reduces to the minimality hypothesis."
+    },
+    {
+      "name": "exists_lowerVertex",
+      "type": "theorem",
+      "statement": "$\\text{pts} \\ne [] \\Rightarrow \\exists p,\\; \\text{IsLowerVertex}(\\text{pts}, p)$",
+      "significance": "Every nonempty support set has at least one Newton-polygon vertex — the existence guarantee any hull construction must satisfy.",
+      "description": "Take the point of minimum valuation via List.argmin; List.argmin_mem and List.le_of_mem_argmin discharge the hypotheses of isLowerVertex_of_minimal."
+    },
+    {
+      "name": "ysqMinusX_edge_slope",
+      "type": "theorem",
+      "statement": "$\\text{edgeSlope}((0,1),(2,0)) = -1/2$",
+      "significance": "The single Newton-polygon edge of Y²−x has slope −1/2, the canonical worked example of the construction.",
+      "description": "Direct norm_num computation of (0 − 1)/(2 − 0)."
+    },
+    {
+      "name": "ysqMinusX_leading_exponent",
+      "type": "theorem",
+      "statement": "$-\\text{edgeSlope}((0,1),(2,0)) = \\text{leadingExponentFromSlope}(1,2) = 1/2$",
+      "significance": "Closes the loop to the parent: the negative edge slope recovers the leading exponent 1/2 of the root x^{1/2} of Y²−x, exactly the parent's leadingExponentFromSlope definition.",
+      "description": "Unfolds edgeSlope and the parent definition; both sides equal 1/2 by norm_num."
+    }
+  ],
+  "references": [
+    {
+      "author": "Newton, I.",
+      "year": 1676,
+      "title": "Method of Fluxions (De methodis serierum et fluxionum)",
+      "venue": "manuscript; published 1736",
+      "note": "First description of the fractional-exponent root-finding procedure via the Newton polygon."
+    },
+    {
+      "author": "Puiseux, V.",
+      "year": 1850,
+      "title": "Recherches sur les fonctions algébriques",
+      "venue": "Journal de Mathématiques Pures et Appliquées 15: 365–480",
+      "note": "First rigorous proof that the Newton–Puiseux procedure produces all roots. Parent gallery entry puiseux-theorem formalizes a Lean version."
+    },
+    {
+      "author": "Walker, R. J.",
+      "year": 1950,
+      "title": "Algebraic Curves",
+      "venue": "Princeton University Press, Ch. IV",
+      "note": "Standard textbook treatment of the Newton polygon and the Newton–Puiseux algorithm."
+    },
+    {
+      "author": "Poteaux, A. and Weimann, M.",
+      "year": 2021,
+      "title": "Computing Puiseux series: a fast divide and conquer algorithm",
+      "venue": "Annales Henri Lebesgue 4: 1061–1102",
+      "note": "State-of-the-art quasi-linear Õ(d·δ) algorithm whose complexity is phrased on the Newton polygon as a data structure — motivating a computable combinatorial Newton polygon as the first formal target."
+    },
+    {
+      "author": "The Mathlib Community",
+      "year": 2026,
+      "title": "Mathlib.Data.List.MinMax",
+      "venue": "Mathlib4 (accessed 2026)",
+      "note": "Provides List.argmin and the lemmas argmin_mem, le_of_mem_argmin, argmin_eq_none used to prove exists_lowerVertex."
+    }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "puiseux-theorem",
+      "relationship": "extends",
+      "description": "Parent univariate Puiseux formalization. This file supplies the combinatorial Newton polygon underlying the parent's Newton–Puiseux algorithm and connects the edge slope back to the parent's leadingExponentFromSlope. It also fixes a parse error (dangling /-- doc comment) in the parent file."
+    },
+    {
+      "proofId": "puiseux-theorem-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling open question (multivariate generalization via iterated Hahn series). OQ-02 covers the structural/algebraic-closure direction; OQ-03 covers the computational/Newton-polygon direction — disjoint facets of the parent."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.PuiseuxTheorem",
+      "Mathlib.Data.List.MinMax"
+    ],
+    "namespace": "PuiseuxTheoremOQ03",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/PuiseuxTheoremOQ03.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, and the worked Y²−x example tying the edge slope to the parent's leadingExponentFromSlope. All 7 theorems and 3 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
+    "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
+    "openQuestions": [
+      "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y])",
+      "Define a termination measure for one Newton–Puiseux reduction step and prove the Y-degree strictly decreases (S2-B)",
+      "State and bound the arithmetic complexity of the algorithm (Poteaux–Weimann Õ(d·δ)) — blocked on the absence of an arithmetic-complexity model in Mathlib (S2-C, moonshot)"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "puiseux-theorem-oq-03",
   "title": "Can the Newton-Puiseux algorithm be made efficient enough for computational a...",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "fast",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-05-12T13:53:16-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Shipped combinatorial Newton polygon (S2-A): IsLowerVertex predicate + structure lemmas + Y^2-x example, verified 0-sorry 0-axiom.",
     "blockers": [],
-    "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
+    "nextAction": "S2-A harder half: Newton polygon theorem (edge slopes = root valuations) once a valuation API on K((x))[Y] exists; then S2-B termination measure.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "Delivered the first Lean file Proofs/PuiseuxTheoremOQ03.lean (145 lines, 7 theorems, 3 defs, verified, 0 sorries, 0 axioms): a combinatorial Newton polygon via the supporting-line lower-vertex predicate IsLowerVertex, with the seed lemma (min-valuation point is a vertex), an existence lemma (List.argmin), and the worked Y^2-x example tying edge slope -1/2 to the parent leadingExponentFromSlope 1 2. Also fixed a parse error in the parent PuiseuxTheorem.lean (dangling /-- doc comment). PR #30757.",
+    "builtItems": [
+      "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
+      "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
+      "exists_lowerVertex: every nonempty support set has a lower vertex (via List.argmin)",
+      "edgeSlope + worked Y^2-x example: both support points are vertices, edge slope -1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
+      "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)"
+    ],
+    "insights": [
+      "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
+      "List.argmin + argmin_mem/le_of_mem_argmin gives vertex existence for nonempty support lists in a few lines.",
+      "Model support points as Prod (N x Q), not a custom structure: fin_cases + norm_num then dispatch example goals cleanly."
+    ],
+    "mathlibGaps": [
+      "No Newton polygon API in Mathlib 4.26.0 (no Polynomial.newtonPolygon / lowerConvexHull as combinatorial vertex data).",
+      "No valuation API on K((x))[Y] to state/prove the Newton polygon theorem (edge slopes = root valuations).",
+      "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
+    ],
+    "nextSteps": [
+      "Prove the Newton polygon theorem: negatives of lower-hull edge slopes = root valuations in an alg-closed valued extension.",
+      "S2-B: termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases).",
+      "S2-C (moonshot): state and bound arithmetic complexity once an arithmetic-cost model exists."
+    ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "archivedSessions": [
       {


### PR DESCRIPTION
## Summary

First Lean deliverable for the OQ-03 open question *"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?"* (parent: `puiseux-theorem`, Wiedijk #41). Two prior doc-only OBSERVE sessions recommended the **combinatorial Newton polygon** as the cleanest tractable entry point; this supplies it. Mathlib 4.26.0 has no Newton polygon API.

## New file `Proofs/PuiseuxTheoremOQ03.lean` (145 lines, **verified, 0 sorries, 0 axioms**)

Models the Newton polygon by the **supporting-line predicate** `IsLowerVertex` (a line lies weakly below every support point and passes through `p`) rather than a hull-construction algorithm — capturing the exact math content with no verified convex-hull routine.

- `isLowerVertex_of_minimal` — the min-valuation support point is always a vertex (the seed of the polygon)
- `exists_lowerVertex` — every nonempty support set has a vertex (via `List.argmin`)
- `IsLowerVertex.mem`, `edgeSlope`
- Worked `Y²−x` example: both `(0,1)` and `(2,0)` are vertices, edge slope `−1/2`, leading exponent `1/2 = PuiseuxTheorem.leadingExponentFromSlope 1 2` — closing the loop to the parent.

## Parent fix

`PuiseuxTheorem.lean` did **not parse** on `main`: line 282 had a dangling `/--` doc comment (no following declaration, immediately before `end NewtonPuiseux`), giving `unexpected token 'end'; expected 'lemma'`. Changed `/--` → `/-`.

## Verification

```
cd proofs && ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean   # exit 0, no diagnostics
```
`#print axioms` on all 7 theorems lists only `propext`/`Classical.choice`/`Quot.sound`. (Docker build host has corrupted containerd metadata; parent olean built single-file with `lean -o` since it imports only Mathlib.)

## Open (honest scope)

Newton polygon theorem (slopes = root valuations; needs valuation API on `K((x))[Y]`), a termination measure (S2-B), and the Poteaux–Weimann complexity bound (S2-C, blocked on no arithmetic-complexity model in Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)