### PR TITLE
audit: record hilbert-3-oq-04 audit (tracker bookkeeping)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25157,8 +25157,14 @@
       "lastAudited": "2026-06-27T12:59:48Z",
       "result": "clean",
       "issues": []
+    },
+    "hilbert-3-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-27T13:42:02Z",
+      "result": "issues-fixed"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T11:27:32Z"
+  "lastUpdated": "2026-06-27T13:42:02Z"
 }


### PR DESCRIPTION
Records the hilbert-3-oq-04 gallery audit in audit-tracker.json (result: issues-fixed). The badge precision fix (original→mathlib) landed in #30754; this is the tracker bookkeeping follow-up, separated because the deployer merged #30754 before the tracker entry could be appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)