### PR TITLE
Enrich Erdős #396 central-binomial growth law: add sections + annotation metadata

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -9,7 +9,10 @@
     "type": "key-step",
     "title": "The central binomial coefficient as a quotient of factorials",
     "content": "`centralBinom_eq_factorial_div` proves $(C(2n,n):\\mathbb{R}) = (2n)!/(n!\\cdot n!)$ from `Nat.choose_mul_factorial_mul_factorial` with $2n-n=n$. This puts $C(2n,n)$ in the quotient-of-factorials form that lets Stirling's equivalence act on numerator and denominator independently.",
-    "mathContext": "$\\displaystyle C(2n,n) = \\frac{(2n)!}{(n!)^2}$"
+    "mathContext": "$\\displaystyle C(2n,n) = \\frac{(2n)!}{(n!)^2}$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "factorials", "binomial coefficient identities", "Nat.choose_mul_factorial_mul_factorial"],
+    "prerequisites": ["binomial coefficients", "factorials"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01oq02-stirlingquot",
@@ -21,7 +24,10 @@
     "type": "key-step",
     "title": "Closed-form simplification of the Stirling quotient",
     "content": "`stirlingFn_quotient` proves the pointwise identity $\\mathrm{stirlingFn}(2n)/(\\mathrm{stirlingFn}\\,n)^2 = 4^n/\\sqrt{\\pi n}$ for $n \\ge 1$, where $\\mathrm{stirlingFn}\\,n = \\sqrt{2n\\pi}(n/e)^n$. The $(n/e)$ powers contribute $4^n$ (since $(2n/e)^{2n} = 4^n(n/e)^{2n}$), $\\sqrt{2\\cdot 2n\\cdot\\pi} = 2\\sqrt{n\\pi}$ and $(\\sqrt{2n\\pi})^2 = 2n\\pi$ collapse $\\sqrt{4n\\pi}/(2n\\pi)$ to $1/\\sqrt{\\pi n}$. This is the only hand computation in the entry; everything else is `IsEquivalent` algebra.",
-    "mathContext": "$\\dfrac{\\mathrm{stirlingFn}(2n)}{(\\mathrm{stirlingFn}\\,n)^2} = \\dfrac{4^n}{\\sqrt{\\pi n}}$"
+    "mathContext": "$\\dfrac{\\mathrm{stirlingFn}(2n)}{(\\mathrm{stirlingFn}\\,n)^2} = \\dfrac{4^n}{\\sqrt{\\pi n}}$",
+    "significance": "key",
+    "relatedConcepts": ["Stirling's formula", "square-root algebra", "exponent laws", "Real.sqrt_mul"],
+    "prerequisites": ["Stirling's approximation", "real analysis", "algebra of radicals"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01oq02-asymp",
@@ -33,7 +39,10 @@
     "type": "key-step",
     "title": "The sharp central-binomial growth law",
     "content": "`centralBinom_isEquivalent` proves $(C(2n,n):\\mathbb{R}) \\sim_{atTop} 4^n/\\sqrt{\\pi n}$. Mathlib's Stirling equivalence $n! \\sim \\mathrm{stirlingFn}\\,n$ is composed with $n \\mapsto 2n$ (`IsEquivalent.comp_tendsto`) for the numerator $(2n)!$ and squared (`IsEquivalent.mul`) for $(n!)^2$, then divided (`IsEquivalent.div`); the resulting Stirling quotient is replaced by $4^n/\\sqrt{\\pi n}$ via `stirlingFn_quotient` (`EventuallyEq.isEquivalent`, `trans`). This is the analytic half of the parent's open question that the elementary telescoping-product sibling left open.",
-    "mathContext": "$C(2n,n) \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi n}}$"
+    "mathContext": "$C(2n,n) \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi n}}$",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic equivalence", "Stirling's formula", "Asymptotics.IsEquivalent", "comp_tendsto"],
+    "prerequisites": ["asymptotic analysis", "filters and atTop", "Stirling's approximation"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01oq02-bridge",
@@ -45,7 +54,10 @@
     "type": "insight",
     "title": "Bridge to the parent's Catalan product",
     "content": "`succ_mul_catalan_eq_centralBinom` proves $C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$ from `catalan_eq_centralBinom_div` and `Nat.mul_div_cancel'` on `Nat.succ_dvd_centralBinom`. This identifies the central-binomial coefficient with the parent's Catalan number up to the $n+1$ prefactor, and is the conduit that carries the central-binomial asymptotic to the Catalan growth law.",
-    "mathContext": "$C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$"
+    "mathContext": "$C(2n,n) = (n+1)\\cdot\\mathrm{catalan}\\,n$",
+    "significance": "supporting",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "divisibility", "Nat.succ_dvd_centralBinom"],
+    "prerequisites": ["Catalan numbers", "divisibility of naturals"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01oq02-catalan",
@@ -57,7 +69,10 @@
     "type": "key-step",
     "title": "The Catalan growth law the parent only asserted",
     "content": "`catalan_isEquivalent` proves $(\\mathrm{catalan}\\,n:\\mathbb{R}) \\sim_{atTop} 4^n/(n\\sqrt{\\pi n}) = 4^n/(\\sqrt{\\pi}\\,n^{3/2})$. Using $\\mathrm{catalan}\\,n = C(2n,n)/(n+1)$, the central-binomial asymptotic, and $(n+1)\\sim n$ (`nat_succ_isEquivalent`, from $1+1/n \\to 1$), divided through `IsEquivalent.div`. This is the $n^{3/2}$ polynomial correction the parent's docstring asserts ($\\mathrm{catalan}\\,n \\sim 4^n/(n^{3/2}\\sqrt\\pi)$) but never proves.",
-    "mathContext": "$\\mathrm{catalan}\\,n \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi}\\,n^{3/2}}$"
+    "mathContext": "$\\mathrm{catalan}\\,n \\sim_{n\\to\\infty} \\dfrac{4^n}{\\sqrt{\\pi}\\,n^{3/2}}$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "asymptotic growth", "polynomial correction n^{3/2}", "IsEquivalent.div"],
+    "prerequisites": ["Catalan numbers", "asymptotic analysis"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq01oq02-lower",
@@ -69,6 +84,9 @@
     "type": "insight",
     "title": "Effective lower bound for every n",
     "content": "`four_pow_div_two_mul_le_centralBinom` proves $4^n/(2n) \\le C(2n,n)$ for $n \\ge 1$ by casting Mathlib's `Nat.four_pow_le_two_mul_self_mul_centralBinom` and dividing by $2n$. Unlike the asymptotic, this holds for every $n$, so together with the sibling's $C(2n,n) < 4^n$ it brackets $4^n/(2n) \\le C(2n,n) \\sim 4^n/\\sqrt{\\pi n} < 4^n$.",
-    "mathContext": "$\\dfrac{4^n}{2n} \\le C(2n,n) \\quad (n \\ge 1)$"
+    "mathContext": "$\\dfrac{4^n}{2n} \\le C(2n,n) \\quad (n \\ge 1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["effective (non-asymptotic) bounds", "central binomial coefficient", "elementary estimates", "Nat.four_pow_le_two_mul_self_mul_centralBinom"],
+    "prerequisites": ["inequalities", "real analysis"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -54,6 +54,16 @@
       "Does the Catalan asymptotic catalan n ∼ 4ⁿ/(√π·n^{3/2}) combine with the parent's strictly decreasing normalized sequence catalan n/4ⁿ to give a monotone (not merely asymptotic) envelope c/n^{3/2} ≤ catalan n/4ⁿ at the recurrence level?"
     ]
   },
+  "sections": [
+    {"id": "header", "title": "Module Documentation", "startLine": 1, "endLine": 42, "summary": "Frames OQ-02: the telescoping-product sibling supplies the elementary half (C(2n,n) < 4ⁿ, no Stirling), and this entry supplies the sharp asymptotic constant 1/√(πn) that genuinely needs Stirling.", "mathContext": "Scope: the analytic half of the central-binomial growth law C(2n,n) ∼ 4ⁿ/√(πn)."},
+    {"id": "stirling-fn", "title": "The Stirling Function", "startLine": 44, "endLine": 52, "summary": "Defines stirlingFn n = √(2nπ)·(n/e)ⁿ, the closed form for which Mathlib's Stirling.factorial_isEquivalent_stirling gives n! ~[atTop] stirlingFn n.", "mathContext": "$\\mathrm{stirlingFn}\\,n = \\sqrt{2n\\pi}\\,(n/e)^n$"},
+    {"id": "factorial-quotient", "title": "Central Binomial as a Factorial Quotient", "startLine": 54, "endLine": 65, "summary": "centralBinom_eq_factorial_div: (C(2n,n):ℝ) = (2n)!/(n!·n!), the form on which Stirling acts independently in numerator and denominator.", "mathContext": "$C(2n,n) = (2n)!/(n!)^2$"},
+    {"id": "stirling-quotient", "title": "Closed-Form Stirling Quotient", "startLine": 67, "endLine": 96, "summary": "stirlingFn_quotient: the only hand computation — stirlingFn(2n)/(stirlingFn n)² = 4ⁿ/√(πn) for n ≥ 1, via √(4nπ)/(2nπ) = 1/√(πn) and the (n/e) powers contributing 4ⁿ.", "mathContext": "$\\mathrm{stirlingFn}(2n)/(\\mathrm{stirlingFn}\\,n)^2 = 4^n/\\sqrt{\\pi n}$"},
+    {"id": "sharp-asymptotic", "title": "The Sharp Central-Binomial Growth Law", "startLine": 98, "endLine": 138, "summary": "centralBinom_isEquivalent (C(2n,n) ~ 4ⁿ/√(πn)) and its limit form, by composing/multiplying/dividing Stirling equivalences then collapsing the quotient.", "mathContext": "$C(2n,n) \\sim_{atTop} 4^n/\\sqrt{\\pi n}$"},
+    {"id": "catalan-growth", "title": "Bridge and the Catalan Growth Law", "startLine": 140, "endLine": 201, "summary": "succ_mul_catalan_eq_centralBinom (C(2n,n) = (n+1)·catalan n), (n+1)~n, and catalan_isEquivalent giving catalan n ∼ 4ⁿ/(√π·n^{3/2}) with its limit form.", "mathContext": "$\\mathrm{catalan}\\,n \\sim_{atTop} 4^n/(\\sqrt{\\pi}\\,n^{3/2})$"},
+    {"id": "effective-bound", "title": "Effective Lower Bound", "startLine": 203, "endLine": 214, "summary": "four_pow_div_two_mul_le_centralBinom: 4ⁿ/(2n) ≤ C(2n,n) for every n ≥ 1 (not merely asymptotically), bracketing the rate against the sibling's C(2n,n) < 4ⁿ.", "mathContext": "$4^n/(2n) \\le C(2n,n)$"},
+    {"id": "sanity-checks", "title": "Sanity Checks", "startLine": 216, "endLine": 228, "summary": "Concrete checks at n = 3: C(6,3) = 20, the Catalan bridge C(6,3) = 4·catalan 3, and the factorial-quotient identity.", "mathContext": "$C(6,3) = 20 = 4\\cdot\\mathrm{catalan}\\,3 = 6!/(3!)^2$"}
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Enrichment pass: erdos-396-oq-04-oq-01-oq-01-oq-01-oq-02

The sharp central-binomial growth law entry (C(2n,n) ∼ 4ⁿ/√(πn)) already had rich prose and six well-written annotations, but two structural gaps remained.

### Changes
- **New `sections` array (8 entries)** — meta.json had no `sections` field. Added coverage of the full Lean file: header/scope, the `stirlingFn` definition, the factorial quotient, the closed-form Stirling quotient (the only hand computation), the sharp asymptotic + limit form, the Catalan bridge & growth law, the effective lower bound, and the sanity checks. Each section carries a `summary` and `mathContext`.
- **Annotation metadata** — all 6 annotations gained `significance`, `relatedConcepts`, and `prerequisites` (they previously carried only `content` + `mathContext`), meeting the per-entry quality target of ≥5 annotations with those fields.

### Verification
- `pnpm annotations:build` passes (exit 0); **no warnings for this entry** — all 6 annotation line ranges still map to their theorem declarations (`centralBinom_eq_factorial_div`, `stirlingFn_quotient`, `centralBinom_isEquivalent`, `succ_mul_catalan_eq_centralBinom`, `catalan_isEquivalent`, `four_pow_div_two_mul_le_centralBinom`).
- meta.json ~13 KB, well under the 60 KB cap.
- No content removed; only structural metadata added.
- Axiom integrity unchanged: `status: verified`, `badge: verified`, 0 axioms / 0 sorries — consistent with the Lean source (1 def, 9 theorems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)