### PR TITLE
research(chinese-remainder-constructive-oq-03-oq-02): verify three-moduli RNS set, upgrade gallery to verified/original

### DIFF
--- a/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
@@ -20,7 +20,7 @@
   range of about 3n bits, with two of the three moduli admitting trivial
   hardware modular reduction (2^n is a bit-mask, 2^n - 1 is a Mersenne wrap).
 
-  ## What this file delivers (0 axioms, 0 sorries; NOT YET machine-checked)
+  ## What this file delivers (0 axioms, 0 sorries; machine-checked)
 
   * Pairwise coprimality of {2^n - 1, 2^n, 2^n + 1} for n ≥ 1, broken into the
     three constituent facts:
@@ -47,7 +47,8 @@
   remains the open parent question) — it formalizes why this specific, widely
   used base is valid and balanced.
 
-  Status: UNVERIFIED (build host down — containerd I/O error; not compiled)
+  Status: VERIFIED (compiles clean against Mathlib 4.26.0 via `lake env lean`;
+          `#print axioms` reports only [propext, Classical.choice, Quot.sound])
   Axioms: 0
   Sorries: 0
 

--- a/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
@@ -72,7 +72,7 @@ open Nat
 /-- Consecutive integers are coprime: gcd divides their difference, which is 1. -/
 theorem coprime_consecutive (a : ℕ) : Nat.Coprime a (a + 1) := by
   have hsub : Nat.gcd a (a + 1) ∣ (a + 1) - a :=
-    Nat.dvd_sub' (Nat.gcd_dvd_right a (a + 1)) (Nat.gcd_dvd_left a (a + 1))
+    Nat.dvd_sub (Nat.gcd_dvd_right a (a + 1)) (Nat.gcd_dvd_left a (a + 1))
   have he : (a + 1) - a = 1 := by omega
   rw [he] at hsub
   exact Nat.dvd_one.mp hsub
@@ -98,7 +98,7 @@ theorem coprime_low_high (n : ℕ) (hn : 1 ≤ n) :
   have hdl : Nat.gcd (2 ^ n - 1) (2 ^ n + 1) ∣ 2 ^ n - 1 := Nat.gcd_dvd_left _ _
   have hdr : Nat.gcd (2 ^ n - 1) (2 ^ n + 1) ∣ 2 ^ n + 1 := Nat.gcd_dvd_right _ _
   have hd2 : Nat.gcd (2 ^ n - 1) (2 ^ n + 1) ∣ 2 := by
-    have hsub := Nat.dvd_sub' hdr hdl
+    have hsub := Nat.dvd_sub hdr hdl
     have he : (2 ^ n + 1) - (2 ^ n - 1) = 2 := by omega
     rwa [he] at hsub
   have hodd : ¬ (2 ∣ (2 ^ n - 1)) := by
@@ -106,7 +106,8 @@ theorem coprime_low_high (n : ℕ) (hn : 1 ≤ n) :
     omega
   rcases (Nat.dvd_prime Nat.prime_two).mp hd2 with h1 | h2
   · exact h1
-  · exact absurd (h2 ▸ hdl) hodd
+  · rw [h2] at hdl
+    exact absurd hdl hodd
 
 -- ============================================================
 -- SECTION II: Dynamic range of the three-moduli set
@@ -209,7 +210,7 @@ theorem threeModuli_balanced (n : ℕ) (hn : 2 ≤ n) :
     then apply two-modulus CRT against `2^n + 1`. -/
 theorem threeModuli_crt_step (n : ℕ) (hn : 1 ≤ n) :
     Nat.Coprime ((2 ^ n - 1) * 2 ^ n) (2 ^ n + 1) :=
-  Nat.Coprime.mul (coprime_low_high n hn) (coprime_mid_high n)
+  Nat.Coprime.mul_left (coprime_low_high n hn) (coprime_mid_high n)
 
 -- ============================================================
 -- SECTION V: Concrete cross-checks (n = 2, 3, 4)

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/annotations.json
@@ -3,16 +3,16 @@
     "id": "ann-coprime-consecutive",
     "proofId": "chinese-remainder-constructive-oq-03-oq-02",
     "range": {
-      "startLine": 72,
-      "endLine": 88
+      "startLine": 73,
+      "endLine": 89
     },
     "type": "insight",
     "title": "Consecutive Integers Are Coprime — Two Channels for Free",
-    "content": "`coprime_consecutive a : Nat.Coprime a (a+1)` proves any two consecutive integers are coprime: `Nat.gcd a (a+1)` divides their difference `(a+1) − a = 1` (via `Nat.dvd_sub'` on the two `Nat.gcd_dvd_*` facts), so by `Nat.dvd_one` the gcd is 1. This single lemma immediately discharges two of the three coprimality obligations: `coprime_low_mid` (2ⁿ−1 and 2ⁿ) and `coprime_mid_high` (2ⁿ and 2ⁿ+1), since each pair is consecutive. `coprime_low_mid` only needs to rewrite `(2ⁿ−1)+1` back to `2ⁿ` using `Nat.sub_add_cancel` with `1 ≤ 2ⁿ`.",
+    "content": "`coprime_consecutive a : Nat.Coprime a (a+1)` proves any two consecutive integers are coprime: `Nat.gcd a (a+1)` divides their difference `(a+1) − a = 1` (via `Nat.dvd_sub` on the two `Nat.gcd_dvd_*` facts), so by `Nat.dvd_one` the gcd is 1. This single lemma immediately discharges two of the three coprimality obligations: `coprime_low_mid` (2ⁿ−1 and 2ⁿ) and `coprime_mid_high` (2ⁿ and 2ⁿ+1), since each pair is consecutive. `coprime_low_mid` only needs to rewrite `(2ⁿ−1)+1` back to `2ⁿ` using `Nat.sub_add_cancel` with `1 ≤ 2ⁿ`.",
     "mathContext": "For the Chinese Remainder Theorem to give a unique residue representative in $[0, M)$ the moduli must be pairwise coprime. In the set $\\{2^n-1, 2^n, 2^n+1\\}$ the middle modulus is consecutive with each neighbor, so $\\gcd(2^n-1, 2^n) = \\gcd(2^n, 2^n+1) = 1$ is automatic — only the two odd ends require a genuine argument.",
     "significance": "key",
     "relatedConcepts": [
-      "Nat.dvd_sub'",
+      "Nat.dvd_sub",
       "Nat.dvd_one",
       "Nat.gcd_dvd_left",
       "Nat.sub_add_cancel"
@@ -26,19 +26,19 @@
     "id": "ann-coprime-low-high",
     "proofId": "chinese-remainder-constructive-oq-03-oq-02",
     "range": {
-      "startLine": 90,
-      "endLine": 109
+      "startLine": 91,
+      "endLine": 111
     },
     "type": "insight",
     "title": "The Only Hard Pair: 2ⁿ−1 and 2ⁿ+1",
-    "content": "`coprime_low_high n (hn : 1 ≤ n)` proves `Nat.Coprime (2ⁿ−1) (2ⁿ+1)`, the one nontrivial coprimality. The two moduli differ by 2, so `g = gcd(2ⁿ−1, 2ⁿ+1)` divides 2 (via `Nat.dvd_sub'` on the difference `(2ⁿ+1) − (2ⁿ−1) = 2`). But `g` cannot be 2: since `2 ∣ 2ⁿ` (from `dvd_pow_self`, n ≠ 0), `omega` derives `¬ 2 ∣ (2ⁿ−1)`. With `g ∣ 2` and 2 prime, `Nat.dvd_prime Nat.prime_two` forces `g = 1`. The `n ≥ 1` hypothesis is essential — it makes `2ⁿ` even and `2ⁿ−1` odd.",
+    "content": "`coprime_low_high n (hn : 1 ≤ n)` proves `Nat.Coprime (2ⁿ−1) (2ⁿ+1)`, the one nontrivial coprimality. The two moduli differ by 2, so `g = gcd(2ⁿ−1, 2ⁿ+1)` divides 2 (via `Nat.dvd_sub` on the difference `(2ⁿ+1) − (2ⁿ−1) = 2`). But `g` cannot be 2: since `2 ∣ 2ⁿ` (from `dvd_pow_self`, n ≠ 0), `omega` derives `¬ 2 ∣ (2ⁿ−1)`. With `g ∣ 2` and 2 prime, `Nat.dvd_prime Nat.prime_two` forces `g = 1`. The `n ≥ 1` hypothesis is essential — it makes `2ⁿ` even and `2ⁿ−1` odd.",
     "mathContext": "Two odd numbers differing by 2 (twin-like) share a common divisor only if it divides their difference 2 and is itself odd, hence 1. This is the modular-arithmetic reason the outer two channels of the balanced base never collide, completing pairwise coprimality of the whole triple.",
     "significance": "key",
     "relatedConcepts": [
       "Nat.dvd_prime",
       "Nat.prime_two",
       "dvd_pow_self",
-      "Nat.dvd_sub'"
+      "Nat.dvd_sub"
     ],
     "prerequisites": [
       "coprime_consecutive",
@@ -49,8 +49,8 @@
     "id": "ann-dynamic-range-formula",
     "proofId": "chinese-remainder-constructive-oq-03-oq-02",
     "range": {
-      "startLine": 115,
-      "endLine": 129
+      "startLine": 117,
+      "endLine": 131
     },
     "type": "computation",
     "title": "Exact Dynamic Range: 2^(3n) − 2ⁿ",
@@ -72,8 +72,8 @@
     "id": "ann-three-moduli-base",
     "proofId": "chinese-remainder-constructive-oq-03-oq-02",
     "range": {
-      "startLine": 135,
-      "endLine": 189
+      "startLine": 137,
+      "endLine": 191
     },
     "type": "definition",
     "title": "threeModuliBase: A Genuine RNS Base",
@@ -95,13 +95,13 @@
     "id": "ann-balance-crt-step",
     "proofId": "chinese-remainder-constructive-oq-03-oq-02",
     "range": {
-      "startLine": 195,
-      "endLine": 212
+      "startLine": 197,
+      "endLine": 214
     },
     "type": "insight",
     "title": "Balance and the Two-Modulus CRT Reduction Step",
-    "content": "`threeModuli_balanced n (hn : 2 ≤ n) : 2ⁿ+1 ≤ 2·(2ⁿ−1)` shows the widest channel is below twice the narrowest (closed by `omega` from `4 ≤ 2ⁿ`) — the balance property that minimizes critical-path channel width per unit of dynamic range. `threeModuli_crt_step n (hn : 1 ≤ n) : Nat.Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1)` packages the low–high and mid–high facts with `Nat.Coprime.mul`, giving precisely the coprimality needed to fold the first two residues into one modulo `(2ⁿ−1)·2ⁿ` and then reconstruct against `2ⁿ+1` by two-modulus CRT (the kernel of Garner's iterated algorithm).",
-    "mathContext": "Hardware RNS reconstruction proceeds pair-by-pair: combine channels 1 and 2 (coprime, so $\\gcd = 1$ and CRT applies) into a single residue mod $(2^n-1)2^n$, then combine with channel 3. The required hypothesis is $\\gcd((2^n-1)2^n,\\,2^n+1) = 1$, which `Nat.Coprime.mul` derives from the two underlying pair coprimalities. Balance ensures every such step has comparable channel widths, keeping the carry/critical path short.",
+    "content": "`threeModuli_balanced n (hn : 2 ≤ n) : 2ⁿ+1 ≤ 2·(2ⁿ−1)` shows the widest channel is below twice the narrowest (closed by `omega` from `4 ≤ 2ⁿ`) — the balance property that minimizes critical-path channel width per unit of dynamic range. `threeModuli_crt_step n (hn : 1 ≤ n) : Nat.Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1)` packages the low–high and mid–high facts with `Nat.Coprime.mul_left`, giving precisely the coprimality needed to fold the first two residues into one modulo `(2ⁿ−1)·2ⁿ` and then reconstruct against `2ⁿ+1` by two-modulus CRT (the kernel of Garner's iterated algorithm).",
+    "mathContext": "Hardware RNS reconstruction proceeds pair-by-pair: combine channels 1 and 2 (coprime, so $\\gcd = 1$ and CRT applies) into a single residue mod $(2^n-1)2^n$, then combine with channel 3. The required hypothesis is $\\gcd((2^n-1)2^n,\\,2^n+1) = 1$, which `Nat.Coprime.mul_left` derives from the two underlying pair coprimalities. Balance ensures every such step has comparable channel widths, keeping the carry/critical path short.",
     "significance": "important",
     "relatedConcepts": [
       "Nat.Coprime.mul",
@@ -118,8 +118,8 @@
     "id": "ann-cross-checks",
     "proofId": "chinese-remainder-constructive-oq-03-oq-02",
     "range": {
-      "startLine": 214,
-      "endLine": 239
+      "startLine": 216,
+      "endLine": 241
     },
     "type": "example",
     "title": "Concrete Instances: {3,4,5}, {7,8,9}, {15,16,17}",

--- a/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Researcher",
     "sourceUrl": "",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ03OQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "coprimality",
       "computer-arithmetic"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 239,
-    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. The proof is elementary and complete, but NOT YET machine-checked: at authoring time both verification channels were down (Docker build host has a corrupted containerd store — input/output error on content blobs at 95–98% disk; Aristotle API returns 'Resource not found'). Marked status=formalized / badge=wip pending compilation against Mathlib 4.26.0; an auditor/mechanic should upgrade to verified once the build host recovers and the file compiles clean. The proof relies only on standard current Mathlib lemmas (Nat.dvd_sub', Nat.gcd_dvd_left/right, Nat.dvd_prime, Nat.prime_two, Nat.sub_add_cancel, Nat.Coprime.mul, List.Pairwise.cons, omega/ring/decide/norm_num). Global optimality over all bases is NOT claimed — that remains the open parent question; this entry formalizes why this specific widely-used base is valid and balanced.",
+    "lineCount": 241,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. VERIFIED: compiles clean against Mathlib 4.26.0 via `lake env lean Proofs/ChineseRemainderConstructiveOQ03OQ02.lean` (no errors, no warnings); `#print axioms` on all top-level results reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool (the n=2,3,4 cross-checks use kernel `decide`, not `native_decide`). The proof relies only on standard current Mathlib lemmas (Nat.dvd_sub, Nat.gcd_dvd_left/right, Nat.dvd_prime, Nat.prime_two, Nat.sub_add_cancel, Nat.Coprime.mul_left, List.Pairwise.cons, omega/ring/decide/norm_num). Global optimality over all bases is NOT claimed — that remains the open parent question; this entry formalizes why this specific widely-used base is valid and balanced.",
     "mathlib_version": "4.26.0",
     "theoremCount": 20,
     "dateAdded": "2026-06-27",
@@ -29,13 +29,13 @@
   "overview": {
     "historicalContext": "Residue Number Systems were introduced by Harvey Garner in 1959 for parallel computer arithmetic and developed by Szabó and Tanaka (1967). For practical hardware the dominant choice is the balanced three-moduli set {2ⁿ−1, 2ⁿ, 2ⁿ+1}, popularized by Soderstrand et al. in 'Residue Number System Arithmetic' (IEEE Press, 1986). It is favored because two of the three moduli admit trivial modular reduction: 2ⁿ is a bit-mask (x mod 2ⁿ = low n bits) and 2ⁿ−1 is a Mersenne wrap (x mod (2ⁿ−1) folds the high and low halves), while the three channels are nearly equal in width so the critical path is close to minimal. The parent entry ChineseRemainderConstructiveOQ03 formalized the general efficiency criteria for RNS bases (dynamic range, channel width, Mersenne-friendliness) but did not formalize this canonical concrete base; sibling OQ-03-OQ-01 handled prime-base growth for all k and OQ-03-OQ-03 handled a single power-of-2 channel alongside odd moduli.",
     "problemStatement": "What concrete RNS base is the canonical 'most efficient' choice for computer arithmetic, and can its defining properties be verified in Lean? Specifically: prove that {2ⁿ−1, 2ⁿ, 2ⁿ+1} is pairwise coprime (so CRT applies), compute its exact dynamic range, exhibit it as a genuine RNS base, prove it is balanced (the widest and narrowest channels differ by less than a factor of 2), and isolate the coprimality fact driving iterated two-modulus CRT reconstruction.",
-    "proofStrategy": "Coprimality splits into three elementary facts. Low–mid (2ⁿ−1, 2ⁿ) and mid–high (2ⁿ, 2ⁿ+1) are consecutive integers, coprime because gcd divides their difference 1 (coprime_consecutive via Nat.dvd_sub' + Nat.dvd_one). Low–high (2ⁿ−1, 2ⁿ+1) differ by 2 with both ends odd: any common divisor divides 2 (Nat.dvd_sub') yet cannot be 2 (2 ∤ 2ⁿ−1 since 2 ∣ 2ⁿ), so by Nat.dvd_prime Nat.prime_two it is 1. The dynamic-range identity (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ is the polynomial a(a−1)(a+1) = a³−a with a = 2ⁿ; natural-number subtraction is handled by writing 2ⁿ = k+1 and discharging k·(k+1)·(k+2) + (k+1) = (k+1)³ with ring, then Nat.eq_sub_of_add_eq. A self-contained RNSBase structure (pairwise-coprime moduli ≥ 2) packages the moduli list, with pairwise coprimality assembled by List.Pairwise.cons. Balance (2ⁿ+1 ≤ 2·(2ⁿ−1) for n ≥ 2) and the CRT step (Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1) via Nat.Coprime.mul) close with omega and a single lemma application. Concrete n = 2,3,4 instances are confirmed by decide / norm_num.",
+    "proofStrategy": "Coprimality splits into three elementary facts. Low–mid (2ⁿ−1, 2ⁿ) and mid–high (2ⁿ, 2ⁿ+1) are consecutive integers, coprime because gcd divides their difference 1 (coprime_consecutive via Nat.dvd_sub + Nat.dvd_one). Low–high (2ⁿ−1, 2ⁿ+1) differ by 2 with both ends odd: any common divisor divides 2 (Nat.dvd_sub) yet cannot be 2 (2 ∤ 2ⁿ−1 since 2 ∣ 2ⁿ), so by Nat.dvd_prime Nat.prime_two it is 1. The dynamic-range identity (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ is the polynomial a(a−1)(a+1) = a³−a with a = 2ⁿ; natural-number subtraction is handled by writing 2ⁿ = k+1 and discharging k·(k+1)·(k+2) + (k+1) = (k+1)³ with ring, then Nat.eq_sub_of_add_eq. A self-contained RNSBase structure (pairwise-coprime moduli ≥ 2) packages the moduli list, with pairwise coprimality assembled by List.Pairwise.cons. Balance (2ⁿ+1 ≤ 2·(2ⁿ−1) for n ≥ 2) and the CRT step (Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1) via Nat.Coprime.mul) close with omega and a single lemma application. Concrete n = 2,3,4 instances are confirmed by decide / norm_num.",
     "keyInsights": [
-      "Two of the three coprimality obligations are free: 2ⁿ−1, 2ⁿ and 2ⁿ, 2ⁿ+1 are consecutive integers, so the single lemma coprime_consecutive (gcd divides the difference 1) discharges both — no number theory beyond Nat.dvd_sub' is needed.",
+      "Two of the three coprimality obligations are free: 2ⁿ−1, 2ⁿ and 2ⁿ, 2ⁿ+1 are consecutive integers, so the single lemma coprime_consecutive (gcd divides the difference 1) discharges both — no number theory beyond Nat.dvd_sub is needed.",
       "The only nontrivial coprimality is between the two odd ends 2ⁿ−1 and 2ⁿ+1: they differ by 2, so a common divisor divides 2, but it must be odd (2 ∣ 2ⁿ ⟹ 2 ∤ 2ⁿ−1), hence equals 1. This is where Nat.dvd_prime Nat.prime_two does the work.",
       "The dynamic range is exactly 2^(3n) − 2ⁿ, i.e. one 2ⁿ short of a full 3n-bit word — the natural-subtraction identity a(a−1)(a+1) = a³−a, proved cleanly by substituting 2ⁿ = k+1 so that ring applies over ℕ without truncation.",
       "Balance, the property that actually makes the base 'efficient' in hardware, is the crisp inequality 2ⁿ+1 ≤ 2·(2ⁿ−1) (n ≥ 2): the widest channel is below twice the narrowest, so the critical-path channel width is near-minimal for the achieved dynamic range.",
-      "Iterated two-modulus CRT reconstruction needs exactly one coprimality fact beyond pairwise coprimality: that the product of the first two channels (2ⁿ−1)·2ⁿ is coprime to the third 2ⁿ+1. This follows from Nat.Coprime.mul applied to the low–high and mid–high facts, and is isolated as threeModuli_crt_step."
+      "Iterated two-modulus CRT reconstruction needs exactly one coprimality fact beyond pairwise coprimality: that the product of the first two channels (2ⁿ−1)·2ⁿ is coprime to the third 2ⁿ+1. This follows from Nat.Coprime.mul_left applied to the low–high and mid–high facts, and is isolated as threeModuli_crt_step."
     ]
   },
   "sections": [
@@ -43,35 +43,35 @@
       "id": "coprimality",
       "title": "Pairwise Coprimality of the Three Moduli",
       "startLine": 66,
-      "endLine": 109,
+      "endLine": 111,
       "summary": "coprime_consecutive (gcd divides the difference 1) gives low–mid and mid–high coprimality directly, since 2ⁿ−1, 2ⁿ and 2ⁿ, 2ⁿ+1 are consecutive. coprime_low_high handles the two odd ends 2ⁿ−1, 2ⁿ+1 (difference 2, both odd) via Nat.dvd_prime Nat.prime_two and the oddness of 2ⁿ−1."
     },
     {
       "id": "dynamic-range",
       "title": "Exact Dynamic-Range Formula",
-      "startLine": 111,
-      "endLine": 129,
+      "startLine": 113,
+      "endLine": 131,
       "summary": "dynamicRange_formula: (2ⁿ−1)·2ⁿ·(2ⁿ+1) = 2^(3n) − 2ⁿ. The polynomial identity a(a−1)(a+1) = a³−a with a = 2ⁿ, with natural subtraction handled by writing 2ⁿ = k+1 and closing k·(k+1)·(k+2)+(k+1) = (k+1)³ with ring."
     },
     {
       "id": "rns-base",
       "title": "The Three-Moduli Set as a Genuine RNS Base",
-      "startLine": 131,
-      "endLine": 189,
+      "startLine": 133,
+      "endLine": 191,
       "summary": "A self-contained RNSBase structure (pairwise-coprime moduli ≥ 2; the parent RNS file has bit-rotted against Mathlib 4.26.0). threeModuli_pairwise_coprime assembles pairwise coprimality via List.Pairwise.cons; threeModuliBase (n ≥ 2) is the base with channels = 3 and dynamicRange = 2^(3n) − 2ⁿ."
     },
     {
       "id": "balance-crt",
       "title": "Balance and CRT Reconstruction Step",
-      "startLine": 191,
-      "endLine": 212,
+      "startLine": 193,
+      "endLine": 214,
       "summary": "threeModuli_balanced: 2ⁿ+1 ≤ 2·(2ⁿ−1) for n ≥ 2 (the widest channel is below twice the narrowest). threeModuli_crt_step: Coprime ((2ⁿ−1)·2ⁿ) (2ⁿ+1), the fact that lets one fold the first two channels and reconstruct against the third by two-modulus CRT."
     },
     {
       "id": "cross-checks",
       "title": "Concrete Cross-Checks (n = 2, 3, 4)",
-      "startLine": 214,
-      "endLine": 239,
+      "startLine": 216,
+      "endLine": 241,
       "summary": "n = 2 gives {3,4,5} (range 60), n = 3 gives {7,8,9} (range 504), n = 4 gives {15,16,17} (range 4080), each confirmed pairwise coprime and matching the 2^(3n) − 2ⁿ formula by decide / norm_num."
     }
   ],
@@ -102,7 +102,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 239,
+    "lineCount": 241,
     "path": "Proofs/ChineseRemainderConstructiveOQ03OQ02.lean",
     "axiomCount": 0,
     "sorries": 0,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-02.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "chinese-remainder-constructive-oq-03-oq-02",
   "title": "The classic three-moduli RNS set {2^n-1, 2^n, 2^n+1} for computer arithmetic",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "VERIFIED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -33,14 +33,15 @@
     "iteration": 1,
     "focus": "Formalized the three-moduli set {2^n-1, 2^n, 2^n+1}: coprimality, exact dynamic range, balance, RNSBase instance, CRT step.",
     "blockers": [
-      "UNVERIFIED: Docker build host down (containerd I/O error + disk ~94% full, only ~815Mi free, no cached Lean image). Could not run lake/docker build. Proof constructed and manually reviewed but NOT machine-checked this session."
+      "None — verified. Earlier Docker/containerd outage resolved by compiling with `lake env lean` against the prebuilt Mathlib oleans."
     ],
-    "nextAction": "Re-run ./proofs/scripts/docker-build.sh Proofs.ChineseRemainderConstructiveOQ03OQ02 once the build host recovers; then add gallery meta.json if verified.",
+    "nextAction": "Done. Verified clean against Mathlib 4.26.0 (lake env lean; #print axioms = propext/Classical.choice/Quot.sound only). Gallery entry upgraded to status=verified, badge=original.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
       "approachesTried": 1
-    }
+    },
+    "progressSummary": "VERIFIED: 20-theorem self-contained file (0 sorry/axiom) compiles clean against Mathlib 4.26.0 via `lake env lean`; #print axioms reports only the three standard foundational axioms. Fixed two pre-existing compile errors before verifying: Nat.dvd_sub' (removed upstream) -> Nat.dvd_sub, and an ambiguous `h2 ▸ hdl` rewrite -> explicit `rw [h2] at hdl`. Gallery entry verified/original."
   },
   "knowledge": {
     "progressSummary": "PROGRESS: 20-theorem self-contained file complete (0 sorry/axiom), PR #30734 open. Manually reviewed sound but UNVERIFIED — Docker containerd corrupted (operator restart needed). Awaiting build host recovery to compile.",


### PR DESCRIPTION
## Summary

The merged Lean file for the balanced three-moduli RNS set `{2ⁿ−1, 2ⁿ, 2ⁿ+1}` (added UNVERIFIED in #30734, gallery entry in #30744 marked `formalized`/`wip`) did **not** compile against pinned Mathlib 4.26.0. This PR repairs the compile errors, **machine-verifies** the file, and upgrades the gallery entry to `verified`/`original`.

## Compile fixes (`ChineseRemainderConstructiveOQ03OQ02.lean`)

- `Nat.dvd_sub'` was removed upstream → replaced with the current 2-arg `Nat.dvd_sub` (used throughout Mathlib, e.g. `Mathlib/NumberTheory/FrobeniusNumber.lean`).
- The ambiguous term `h2 ▸ hdl` (Lean inferred the wrong motive, trying to rewrite the `2` inside `2^n`, producing the spurious goal `… ∣ gcd … ^ n - 1`) → replaced with an explicit `rw [h2] at hdl; exact absurd hdl hodd`.
- Deprecated `Nat.Coprime.mul` → `Nat.Coprime.mul_left`.

## Verification

```
lake env lean Proofs/ChineseRemainderConstructiveOQ03OQ02.lean
```
compiles **clean** (no errors, no warnings). `#print axioms` on every top-level result reports only:

```
[propext, Classical.choice, Quot.sound]
```

No `sorryAx`, no `Lean.ofReduceBool` — the `n = 2,3,4` cross-checks use kernel `decide`, not `native_decide`. Genuinely **0-axiom verified**.

(Verified via `lake env lean` against the prebuilt Mathlib oleans because the Docker build host's containerd store is corrupted — operator restart pending.)

## Metadata

- `meta.json`: `status` formalized→verified, `badge` wip→original, `lineCount` 239→241, corrected lemma names, refreshed `assumptions`.
- `annotations.json`: shifted line ranges (+1/+2 from the fix) and corrected lemma-name references.
- research problem json: `status` → completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)