### PR TITLE
Enrich Dihedral Groups Are Solvable: add annotation coverage

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-04/annotations.json
@@ -1,5 +1,51 @@
 [
   {
+    "id": "ann-parity-hom",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
+    "range": {
+      "startLine": 54,
+      "endLine": 64
+    },
+    "type": "definition",
+    "title": "The Parity Homomorphism via the Multiplication Table",
+    "content": "`parity : Dₙ →* ℤ/2` is defined by pattern-matching on the two constructors of `DihedralGroup`: a rotation `r _` maps to `1` (the identity of `Multiplicative (ZMod 2)`) and a reflection `sr _` maps to `Multiplicative.ofAdd 1` (the generator). The only non-trivial obligation is `map_mul'`, and it is discharged uniformly: `cases x <;> cases y` splits into the four products `r·r`, `r·sr`, `sr·r`, `sr·sr`, each rewritten by the corresponding Mathlib multiplication-table lemma (`r_mul_r`, `r_mul_sr`, `sr_mul_r`, `sr_mul_sr`) and then closed by `rfl`. The four cases mirror the addition table of `ℤ/2`: `0+0, 0+1, 1+0, 1+1 = 0,1,1,0`, which is exactly why parity is multiplicative.",
+    "mathContext": "$\\text{parity}(r_i r_j)=\\text{parity}(r_{i+j})=0,\\ \\text{parity}(r_i\\,s r_j)=\\text{parity}(s r_{j-i})=1,\\ \\text{parity}(s r_i\\,s r_j)=\\text{parity}(r_{j-i})=0$ — the products realize addition in $\\mathbb Z/2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "DihedralGroup multiplication table",
+      "MonoidHom",
+      "Multiplicative ZMod 2",
+      "sign / determinant character"
+    ],
+    "prerequisites": [
+      "group homomorphisms",
+      "dihedral group presentation"
+    ]
+  },
+  {
+    "id": "ann-rotation-inclusion",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
+    "range": {
+      "startLine": 66,
+      "endLine": 79
+    },
+    "type": "definition",
+    "title": "The Rotation Inclusion ℤ/n → Dₙ",
+    "content": "`rotation : Multiplicative (ZMod n) →* DihedralGroup n` sends `i ↦ r (toAdd i)`, embedding the cyclic group of rotations into `Dₙ`. The homomorphism law is a one-liner: `r_mul_r` says `r i · r j = r (i + j)`, so `map_mul'` is just `(r_mul_r _ _).symm`. The three `@[simp]` lemmas (`parity_r`, `parity_sr`, `rotation_apply`) are all `rfl` and exist purely to let later `simp` calls compute parities and rotation values automatically — they are the computational interface that makes the kernel/range proof short. Note the use of `Multiplicative (ZMod n)`: the additive group `ℤ/n` is re-tagged as multiplicative so that `r i · r j = r (i+j)` reads as a genuine `MonoidHom`.",
+    "mathContext": "$\\text{rotation}: \\mathbb Z/n \\hookrightarrow D_n,\\ i\\mapsto r_i$, with $\\operatorname{im}(\\text{rotation})=\\langle r\\rangle\\cong\\mathbb Z/n$ the cyclic rotation subgroup. Multiplicativity is $r_i r_j = r_{i+j}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic group",
+      "Multiplicative type tag",
+      "MonoidHom.range",
+      "r_mul_r"
+    ],
+    "prerequisites": [
+      "ZMod n",
+      "subgroup as homomorphism range"
+    ]
+  },
+  {
     "id": "ann-metabelian-is-the-proof",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
     "range": {
@@ -22,6 +68,29 @@
     ]
   },
   {
+    "id": "ann-ofadd-eq-one-reflection",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
+    "range": {
+      "startLine": 91,
+      "endLine": 99
+    },
+    "type": "technique",
+    "title": "Excluding Reflections: ofAdd 1 ≠ 1 in ℤ/2",
+    "content": "The substance of `parity_ker_eq_rotation_range` is the reflection case. To show no reflection lies in `ker(parity)`, one must rule out `parity (sr i) = 1`, i.e. `Multiplicative.ofAdd 1 = 1`. The lemma `ofAdd_eq_one` translates this multiplicative equation back to the additive statement `(1 : ZMod 2) = 0`, which `decide` refutes by finite computation on `ZMod 2`. Symmetrically, no reflection is in `range(rotation)` because `r _ = sr _` is impossible (the constructors of `DihedralGroup` are distinct), closed by `simp`. The rotation case is the easy direction: every `r i` is parity-trivial and visibly equals `rotation (ofAdd i)`. This decide call is *kernel* `decide` on `ZMod 2`, not `native_decide`, so it introduces no `Lean.ofReduceBool` axiom.",
+    "mathContext": "$\\text{ofAdd}(1)=1 \\iff (1:\\mathbb Z/2)=0$, false; and $r_i\\neq s r_j$ for all $i,j$. Hence the reflections form the non-trivial coset and $\\ker(\\text{parity})$ is exactly $\\{r_i\\}$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "ofAdd_eq_one",
+      "decide vs native_decide",
+      "MonoidHom.mem_ker",
+      "constructor injectivity"
+    ],
+    "prerequisites": [
+      "ZMod 2 arithmetic",
+      "Multiplicative.ofAdd"
+    ]
+  },
+  {
     "id": "ann-contrast-with-sn",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-04",
     "range": {
@@ -32,7 +101,7 @@
     "title": "Why Abel–Ruffini Is Special to Sₙ",
     "content": "The companion theorem `S5_not_isSolvable_but_dihedral_is` states the contrast bluntly: `Sym (Fin 5)` is **not** solvable (Mathlib's `Equiv.Perm.fin_5_not_solvable`), yet **every** `DihedralGroup n` is. Both Sₙ and Dₙ are infinite families of finite non-abelian groups, and they even agree (both solvable) for n ≤ 4 — but at n = 5 the symmetric group acquires the simple subgroup A₅ and loses solvability, while the dihedral group keeps its index-2 cyclic structure for all n and stays solvable. The Abel–Ruffini obstruction is therefore a feature of the symmetric groups specifically, not a generic consequence of growing an infinite family. The proof also works uniformly at n = 0, so even the infinite dihedral group D∞ is solvable.",
     "mathContext": "$S_n$ solvable $\\iff n\\le4$; $D_n$ solvable for all $n$ (including $n=0$, $D_\\infty$). The divergence at $n=5$ is exactly the appearance of the simple group $A_5$.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": [
       "Equiv.Perm.fin_5_not_solvable",
       "A₅ simple",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-04` (quality 67, 0 prior passes).

## Changes
The entry had only 2 annotations covering lines 83–112, leaving the two homomorphism definitions and the kernel-equality proof unannotated. Added 3 annotations and fixed a schema bug:

- **ann-parity-hom** (54–64): the parity homomorphism `Dₙ →* ℤ/2` and its uniform four-case `map_mul'` check against the Mathlib dihedral multiplication table (`r_mul_r`, `r_mul_sr`, `sr_mul_r`, `sr_mul_sr`), mirroring addition in ℤ/2.
- **ann-rotation-inclusion** (66–79): the rotation inclusion `ℤ/n →* Dₙ`, `i ↦ r i`, plus the three `@[simp]` `rfl` lemmas that form the computational interface for the kernel/range proof.
- **ann-ofadd-eq-one-reflection** (91–99): the reflection-exclusion technique — `ofAdd_eq_one` reduces `parity (sr i) = 1` to the false `(1 : ZMod 2) = 0`, refuted by kernel `decide` (not `native_decide`, so no `Lean.ofReduceBool`).
- Fixed invalid `significance: "important"` → `"key"` (schema allows `key|supporting|technical|context`).

Annotations now span lines 54–112 (was 83–112); 5 total, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

## Notes
- `meta.json` unchanged and already within all size caps (12,128 bytes; 4 keyInsights, 3 crossRefs, 2 refs).
- No `index.ts` created — obsolete since the phase-2 runtime-fetch refactor (#20993); `listings.json`/`data-manifest.json` are build-generated.
- JSON validated via `scripts/gallery/check-meta-size.ts` (within caps) and `python json.load`. Full `pnpm build` skipped — no `node_modules` in the worktree and this is a JSON-only change.