### PR TITLE
Enrich Puiseux Theorem OQ-03: combinatorial Newton polygon annotations + sections

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-03/annotations.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-support-point-edgeslope",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 70,
+      "endLine": 77
+    },
+    "type": "definition",
+    "title": "Support Points and the Edge Slope",
+    "content": "A `SupportPoint` is an `ℕ × ℚ` pair `(i, v)`: the exponent `i` of `Yⁱ` together with the valuation `v = v(aᵢ) ∈ ℚ` of its coefficient. Indices where `aᵢ = 0` (valuation `+∞`) are simply dropped from the support list, so the data is finite and computable. `edgeSlope p q = (q.2 − p.2)/(q.1 − p.1)` is the ordinary slope of the segment joining two support points; the Newton polygon theorem will identify the *negatives* of these edge slopes with root valuations. Using ℚ-valued valuations (not the WithTop ℤ of a discrete valuation) is exactly what lets fractional exponents like 1/2 appear.",
+    "mathContext": "$\\text{support}(P)=\\{(i,\\,v(a_i)) : a_i\\neq 0\\}\\subset\\mathbb N\\times\\mathbb Q$; $\\text{edgeSlope}(p,q)=\\dfrac{v_q-v_p}{i_q-i_p}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "valuation",
+      "Newton polygon support",
+      "Laurent/Puiseux series order",
+      "rational slope"
+    ],
+    "prerequisites": [
+      "valued fields",
+      "order of a series"
+    ]
+  },
+  {
+    "id": "ann-is-lower-vertex",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 79,
+      "endLine": 89
+    },
+    "type": "definition",
+    "title": "The Supporting-Line Vertex Predicate",
+    "content": "`IsLowerVertex pts p` is the heart of the file. Rather than constructing the lower convex hull algorithmically, it characterizes a vertex by a **supporting line**: `p ∈ pts` and there exist `m, b : ℚ` such that the line `y = m·i + b` passes through `p` (`p.2 = m·p.1 + b`) and lies weakly below every support point (`∀ q ∈ pts, m·q.1 + b ≤ q.2`). Phrasing the definition as a `Prop` keeps the API honest about the mathematical content while sidestepping the need for a verified convex-hull routine — a deliberate design choice given Mathlib 4.26.0 has no Newton-polygon API. `IsLowerVertex.mem` is the trivial projection recording that a vertex is a genuine support point.",
+    "mathContext": "$\\text{IsLowerVertex}(\\text{pts},p)\\iff p\\in\\text{pts}\\,\\wedge\\,\\exists m,b:\\; v_p=m\\,i_p+b\\,\\wedge\\,\\forall q\\in\\text{pts},\\; m\\,i_q+b\\le v_q.$ A line below all points, touching $p$ — the dual (supporting-hyperplane) description of a lower-hull vertex.",
+    "significance": "key",
+    "relatedConcepts": [
+      "supporting hyperplane",
+      "lower convex hull",
+      "Prop-valued specification",
+      "convex geometry duality"
+    ],
+    "prerequisites": [
+      "convex hulls and supporting lines",
+      "existential propositions in Lean"
+    ]
+  },
+  {
+    "id": "ann-minimal-seed",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 91,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "The Lowest Point Seeds the Polygon",
+    "content": "`isLowerVertex_of_minimal` proves that any support point of globally minimum valuation is a lower vertex, witnessed by the **horizontal** supporting line `y = v(p)` — i.e. `m = 0`, `b = p.2`. The supporting condition `0·q.1 + p.2 ≤ q.2` then reduces verbatim to the minimality hypothesis `p.2 ≤ q.2`, closed by `simpa`. This is the constructive starting vertex of the Newton–Puiseux algorithm: the polygon is always anchored at its lowest point, and one walks the lower hull rightward from there.",
+    "mathContext": "$m=0,\\ b=v_p$: the horizontal line $y=v_p$ is a supporting line precisely when $v_p=\\min_q v_q$. Hence the minimum-valuation point is always a vertex.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "horizontal supporting line",
+      "minimum valuation",
+      "Newton–Puiseux seed vertex"
+    ],
+    "prerequisites": [
+      "minimality arguments"
+    ]
+  },
+  {
+    "id": "ann-exists-argmin",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 100,
+      "endLine": 107
+    },
+    "type": "technique",
+    "title": "Existence for Free via List.argmin",
+    "content": "`exists_lowerVertex` turns the seed lemma into an existence guarantee: every nonempty support list has a lower vertex. The proof case-splits on `pts.argmin (·.2)` (the minimum-valuation element). The `none` branch is impossible — `List.argmin_eq_none` says the list would be empty, contradicting the hypothesis — and the `some m` branch feeds `List.argmin_mem` (membership) and `List.le_of_mem_argmin` (minimality over all elements) directly into `isLowerVertex_of_minimal`. Reusing Mathlib's argmin API means no bespoke induction on lists is needed; the existence theorem any hull construction must satisfy comes essentially for free.",
+    "mathContext": "$\\text{pts}\\neq[]\\Rightarrow\\exists p,\\ \\text{IsLowerVertex}(\\text{pts},p)$, via $p=\\arg\\min_{q\\in\\text{pts}} v_q$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "List.argmin",
+      "argmin_mem",
+      "le_of_mem_argmin",
+      "existence proof"
+    ],
+    "prerequisites": [
+      "Mathlib.Data.List.MinMax",
+      "argmin / argmax API"
+    ]
+  },
+  {
+    "id": "ann-worked-example-vertices",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 109,
+      "endLine": 130
+    },
+    "type": "context",
+    "title": "Worked Example: Both Endpoints of Y²−x Are Vertices",
+    "content": "The canonical test case is `Y² − x` over `K((x))`: its coefficients are `a₀ = −x` (valuation 1), `a₁ = 0` (omitted), `a₂ = 1` (valuation 0), so the support is `YsqMinusX = [(0,1), (2,0)]`. Both `ysqMinusX_vertex_const` and `ysqMinusX_vertex_lead` exhibit the *same* edge line `y = −½·i + 1` (here `m = −1/2`, `b = 1`) as the supporting line through each endpoint. The membership obligation is closed by `simp [YsqMinusX]` and the supporting inequalities by `fin_cases hq <;> norm_num`, which checks the line against each of the two points: it passes through both with equality, so the single edge from (0,1) to (2,0) IS the entire Newton polygon.",
+    "mathContext": "$Y^2-x$: support $\\{(0,1),(2,0)\\}$; the line $y=-\\tfrac12 i+1$ gives $-\\tfrac12\\cdot0+1=1$ and $-\\tfrac12\\cdot2+1=0$, touching both points — both are lower vertices.",
+    "significance": "context",
+    "relatedConcepts": [
+      "fin_cases",
+      "norm_num",
+      "single-edge Newton polygon",
+      "ramified root x^{1/2}"
+    ],
+    "prerequisites": [
+      "the Newton polygon of a quadratic"
+    ]
+  },
+  {
+    "id": "ann-leading-exponent-loop",
+    "proofId": "puiseux-theorem-oq-03",
+    "range": {
+      "startLine": 132,
+      "endLine": 143
+    },
+    "type": "insight",
+    "title": "Closing the Loop: Edge Slope → Leading Exponent",
+    "content": "`ysqMinusX_edge_slope` computes `edgeSlope (0,1) (2,0) = (0−1)/(2−0) = −1/2` by `norm_num`. `ysqMinusX_leading_exponent` then ties the combinatorial object back to the parent gallery entry: the **negation** of the edge slope, `−(−1/2) = 1/2`, equals `PuiseuxTheorem.leadingExponentFromSlope 1 2`, the parent's definition of the leading exponent of the root `x^{1/2}` of `Y² − x`. This is the concrete instance of the Newton polygon theorem (negatives of edge slopes = root valuations) and validates that this file's combinatorial layer correctly feeds the parent's algorithm — even though the general theorem awaits a valuation API on `K((x))[Y]`.",
+    "mathContext": "$-\\text{edgeSlope}((0,1),(2,0)) = -(-\\tfrac12) = \\tfrac12 = \\text{leadingExponentFromSlope}(1,2)$ — the leading exponent of the root $x^{1/2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Newton polygon theorem",
+      "leadingExponentFromSlope",
+      "root valuation",
+      "puiseux-theorem"
+    ],
+    "prerequisites": [
+      "puiseux-theorem (parent entry)",
+      "edge slope ↔ root valuation"
+    ]
+  }
+]

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -58,6 +58,40 @@
       "The Newton–Puiseux algorithm outline (edges → leading exponents → recurse)"
     ]
   },
+  "sections": [
+    {
+      "id": "support-points",
+      "title": "Support Points and Edge Slope",
+      "startLine": 70,
+      "endLine": 77,
+      "summary": "SupportPoint := ℕ × ℚ pairs an exponent i with the valuation v(aᵢ) of the coefficient; zero coefficients (valuation +∞) are omitted. edgeSlope p q is the slope (q.2 − p.2)/(q.1 − p.1) of the segment joining two support points.",
+      "mathContext": "$\\text{support}(P)=\\{(i,v(a_i)):a_i\\neq0\\}$; $\\text{edgeSlope}(p,q)=\\frac{v_q-v_p}{i_q-i_p}$."
+    },
+    {
+      "id": "lower-vertex-predicate",
+      "title": "The Supporting-Line Vertex Predicate",
+      "startLine": 79,
+      "endLine": 89,
+      "summary": "IsLowerVertex pts p: p ∈ pts and some line y = m·i + b passes through p and lies weakly below every support point — the supporting-line characterization of a lower-hull vertex, stated as a Prop to stay algorithm-independent. IsLowerVertex.mem records that a vertex is a genuine support point.",
+      "mathContext": "$\\exists m,b:\\ v_p=m\\,i_p+b\\ \\wedge\\ \\forall q\\in\\text{pts},\\ m\\,i_q+b\\le v_q.$"
+    },
+    {
+      "id": "structure-theory",
+      "title": "Seed Vertex and Existence",
+      "startLine": 91,
+      "endLine": 107,
+      "summary": "isLowerVertex_of_minimal: the minimum-valuation point is a vertex via the horizontal line y = v(p) (m = 0). exists_lowerVertex: every nonempty support list has a vertex, extracted as the List.argmin of the valuations using argmin_mem and le_of_mem_argmin.",
+      "mathContext": "Horizontal supporting line $y=v_p$ when $v_p=\\min_q v_q$; existence via $p=\\arg\\min_q v_q$."
+    },
+    {
+      "id": "worked-example",
+      "title": "Worked Example: Y²−x",
+      "startLine": 109,
+      "endLine": 145,
+      "summary": "Support of Y²−x is {(0,1),(2,0)}; both endpoints are lower vertices via the shared edge line y = −½i + 1 (ysqMinusX_vertex_const / _lead, fin_cases + norm_num). edgeSlope = −1/2, and its negation 1/2 = leadingExponentFromSlope 1 2 recovers the parent's leading exponent of the root x^{1/2}.",
+      "mathContext": "$-\\text{edgeSlope}((0,1),(2,0))=\\tfrac12=\\text{leadingExponentFromSlope}(1,2)$, the exponent of $x^{1/2}$."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "IsLowerVertex",


### PR DESCRIPTION
Enrichment pass for `puiseux-theorem-oq-03` (quality 35, 0 prior passes — the lowest-quality target available).

## Gaps closed
The entry had **no annotations.json** and **0 sections**, despite a rich meta.json. Both are now supplied.

### annotations.json (created — 6 annotations, lines 70–143)
- **support-points & edgeSlope** (70–77): `SupportPoint := ℕ × ℚ` and the segment slope.
- **IsLowerVertex predicate** (79–89): the supporting-line characterization of a lower-hull vertex, stated as a `Prop` to stay algorithm-independent (no verified convex-hull routine needed).
- **seed vertex** (91–98): the minimum-valuation point is a vertex via the horizontal line `y = v(p)`.
- **existence via List.argmin** (100–107): `argmin_mem` + `le_of_mem_argmin` give existence for free.
- **worked example Y²−x** (109–130): both `(0,1)` and `(2,0)` are vertices on the shared edge line `y = −½i + 1`.
- **edge slope → leading exponent** (132–143): `−edgeSlope = 1/2 = leadingExponentFromSlope 1 2`, closing the loop to the parent.

Each annotation carries `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

### meta.json
- Added a 4-entry `sections` array (was absent) covering the full 145-line file: support points, the vertex predicate, structure theory (seed + existence), and the Y²−x worked example.
- No other fields changed; `mainTheorems`, `overview`, `conclusion`, `references`, `crossReferences` left intact. File 16,310 bytes, within all caps.

## Notes
- Branch is `feature/enricher-5-puiseux` (not `feature/enricher-5`) to avoid clobbering the still-open dihedral PR #30766.
- JSON validated via `scripts/gallery/check-meta-size.ts` (within caps) and python (type/significance enum checks). Full `pnpm build` skipped — no `node_modules` in the worktree; JSON-only change.