### PR TITLE
research(collatz-structured-oq-02-oq-03): repair broken mod-128 density floor (VERIFIED axiom-free)

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -272,6 +272,100 @@ theorem mod_thirtytwo_twentythree_attainsBelow {n : ℕ} (h : n % 32 = 23) : Att
           Function.iterate_zero_apply, s1, s2, s3, s4, s5, s6, s7, s8])
     h
 
+/-- Every `n ≡ 7 (mod 128)` drops below itself in exactly eleven residue-determined steps:
+`128m+7 ↦ 384m+22 ↦ 192m+11 ↦ 576m+34 ↦ 288m+17 ↦ 864m+52 ↦ 432m+26 ↦ 216m+13 ↦ 648m+40
+↦ 324m+20 ↦ 162m+10 ↦ 81m+5`, and `81m+5 < 128m+7` for every `m ≥ 0`.  All eleven parities
+are forced by the residue `mod 128` alone.  This is the first of *three* new residues that
+stabilise only at level `128`: its class `7 (mod 32)` was unstable at level `32` (and stayed
+unstable at level `64`), but the finer split at level `128` isolates the stable half `7`. -/
+theorem mod_onetwentyeight_seven_attainsBelow {n : ℕ} (h : n % 128 = 7) : AttainsBelow n :=
+  -- M = 128, r = 7, k = 11, c = 81, d = 5; here a = 4 odd steps, b = 7 halvings,
+  -- and `c = 81 = 3^4 < 128` is `3^4 < 2^7`.
+  affine_residue_attainsBelow (M := 128) (r := 7) (k := 11) (c := 81) (d := 5)
+    (by norm_num) (by norm_num) (by norm_num)
+    (fun m => by
+      have s1 : collatz (128 * m + 7) = 384 * m + 22 := by rw [collatz_odd (by omega)]; ring
+      have s2 : collatz (384 * m + 22) = 192 * m + 11 := by rw [collatz_even (by omega)]; omega
+      have s3 : collatz (192 * m + 11) = 576 * m + 34 := by rw [collatz_odd (by omega)]; ring
+      have s4 : collatz (576 * m + 34) = 288 * m + 17 := by rw [collatz_even (by omega)]; omega
+      have s5 : collatz (288 * m + 17) = 864 * m + 52 := by rw [collatz_odd (by omega)]; ring
+      have s6 : collatz (864 * m + 52) = 432 * m + 26 := by rw [collatz_even (by omega)]; omega
+      have s7 : collatz (432 * m + 26) = 216 * m + 13 := by rw [collatz_even (by omega)]; omega
+      have s8 : collatz (216 * m + 13) = 648 * m + 40 := by rw [collatz_odd (by omega)]; ring
+      have s9 : collatz (648 * m + 40) = 324 * m + 20 := by rw [collatz_even (by omega)]; omega
+      have s10 : collatz (324 * m + 20) = 162 * m + 10 := by rw [collatz_even (by omega)]; omega
+      have s11 : collatz (162 * m + 10) = 81 * m + 5 := by rw [collatz_even (by omega)]; omega
+      rw [Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_zero_apply,
+          s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11])
+    h
+
+/-- Every `n ≡ 15 (mod 128)` drops below itself in exactly eleven residue-determined steps:
+`128m+15 ↦ 384m+46 ↦ 192m+23 ↦ 576m+70 ↦ 288m+35 ↦ 864m+106 ↦ 432m+53 ↦ 1296m+160 ↦ 648m+80
+↦ 324m+40 ↦ 162m+20 ↦ 81m+10`, and `81m+10 < 128m+15` for every `m ≥ 0`.  All eleven parities
+are forced by the residue `mod 128` alone.  This is the second new residue stabilising only at
+level `128`: its class `15 (mod 32)` was unstable at levels `32` and `64`. -/
+theorem mod_onetwentyeight_fifteen_attainsBelow {n : ℕ} (h : n % 128 = 15) : AttainsBelow n :=
+  -- M = 128, r = 15, k = 11, c = 81, d = 10; a = 4 odd steps, b = 7 halvings, `3^4 < 2^7`.
+  affine_residue_attainsBelow (M := 128) (r := 15) (k := 11) (c := 81) (d := 10)
+    (by norm_num) (by norm_num) (by norm_num)
+    (fun m => by
+      have s1 : collatz (128 * m + 15) = 384 * m + 46 := by rw [collatz_odd (by omega)]; ring
+      have s2 : collatz (384 * m + 46) = 192 * m + 23 := by rw [collatz_even (by omega)]; omega
+      have s3 : collatz (192 * m + 23) = 576 * m + 70 := by rw [collatz_odd (by omega)]; ring
+      have s4 : collatz (576 * m + 70) = 288 * m + 35 := by rw [collatz_even (by omega)]; omega
+      have s5 : collatz (288 * m + 35) = 864 * m + 106 := by rw [collatz_odd (by omega)]; ring
+      have s6 : collatz (864 * m + 106) = 432 * m + 53 := by rw [collatz_even (by omega)]; omega
+      have s7 : collatz (432 * m + 53) = 1296 * m + 160 := by rw [collatz_odd (by omega)]; ring
+      have s8 : collatz (1296 * m + 160) = 648 * m + 80 := by rw [collatz_even (by omega)]; omega
+      have s9 : collatz (648 * m + 80) = 324 * m + 40 := by rw [collatz_even (by omega)]; omega
+      have s10 : collatz (324 * m + 40) = 162 * m + 20 := by rw [collatz_even (by omega)]; omega
+      have s11 : collatz (162 * m + 20) = 81 * m + 10 := by rw [collatz_even (by omega)]; omega
+      rw [Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_zero_apply,
+          s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11])
+    h
+
+/-- Every `n ≡ 59 (mod 128)` drops below itself in exactly eleven residue-determined steps:
+`128m+59 ↦ 384m+178 ↦ 192m+89 ↦ 576m+268 ↦ 288m+134 ↦ 144m+67 ↦ 432m+202 ↦ 216m+101 ↦ 648m+304
+↦ 324m+152 ↦ 162m+76 ↦ 81m+38`, and `81m+38 < 128m+59` for every `m ≥ 0`.  All eleven parities
+are forced by the residue `mod 128` alone.  This is the third new residue stabilising only at
+level `128`: its class `27 (mod 32)` was unstable at levels `32` and `64`.  The remaining odd
+classes mod `128` that refine `{7, 15, 27, 31} (mod 32)` still have `m`-dependent stopping
+times and need a finer modulus. -/
+theorem mod_onetwentyeight_fiftynine_attainsBelow {n : ℕ} (h : n % 128 = 59) : AttainsBelow n :=
+  -- M = 128, r = 59, k = 11, c = 81, d = 38; a = 4 odd steps, b = 7 halvings, `3^4 < 2^7`.
+  affine_residue_attainsBelow (M := 128) (r := 59) (k := 11) (c := 81) (d := 38)
+    (by norm_num) (by norm_num) (by norm_num)
+    (fun m => by
+      have s1 : collatz (128 * m + 59) = 384 * m + 178 := by rw [collatz_odd (by omega)]; ring
+      have s2 : collatz (384 * m + 178) = 192 * m + 89 := by rw [collatz_even (by omega)]; omega
+      have s3 : collatz (192 * m + 89) = 576 * m + 268 := by rw [collatz_odd (by omega)]; ring
+      have s4 : collatz (576 * m + 268) = 288 * m + 134 := by rw [collatz_even (by omega)]; omega
+      have s5 : collatz (288 * m + 134) = 144 * m + 67 := by rw [collatz_even (by omega)]; omega
+      have s6 : collatz (144 * m + 67) = 432 * m + 202 := by rw [collatz_odd (by omega)]; ring
+      have s7 : collatz (432 * m + 202) = 216 * m + 101 := by rw [collatz_even (by omega)]; omega
+      have s8 : collatz (216 * m + 101) = 648 * m + 304 := by rw [collatz_odd (by omega)]; ring
+      have s9 : collatz (648 * m + 304) = 324 * m + 152 := by rw [collatz_even (by omega)]; omega
+      have s10 : collatz (324 * m + 152) = 162 * m + 76 := by rw [collatz_even (by omega)]; omega
+      have s11 : collatz (162 * m + 76) = 81 * m + 38 := by rw [collatz_even (by omega)]; omega
+      rw [Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_succ_apply',
+          Function.iterate_succ_apply', Function.iterate_zero_apply,
+          s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11])
+    h
+
 /-- Packaging: every positive `n` that is **even** or lies in `1 + 4ℕ` (with `n ≥ 5`)
 attains a value below itself.  Together these cover three-quarters of the integers,
 all handled by elementary dynamics with no appeal to Tao's axiom. -/
@@ -305,6 +399,25 @@ theorem even_or_mod_four_one_or_mod_thirtytwo_attainsBelow {n : ℕ} (hn : 1 ≤
   · exact mod_sixteen_three_attainsBelow h3
   · exact mod_thirtytwo_eleven_attainsBelow h11
   · exact mod_thirtytwo_twentythree_attainsBelow h23
+
+/-- Maximally extended packaging: every positive `n` that is **even**, lies in `1 + 4ℕ`
+(`n ≥ 5`), `3 + 16ℕ`, `11 + 32ℕ`, `23 + 32ℕ`, `7 + 128ℕ`, `15 + 128ℕ`, or `59 + 128ℕ`
+attains a value below itself.  These eight elementary families together cover
+`115/128` of the integers — the current unconditional floor beneath Tao's density-one
+theorem, with no appeal to the axiom. -/
+theorem even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow {n : ℕ} (hn : 1 ≤ n)
+    (h : n % 2 = 0 ∨ (5 ≤ n ∧ n % 4 = 1) ∨ n % 16 = 3 ∨ n % 32 = 11 ∨ n % 32 = 23 ∨
+         n % 128 = 7 ∨ n % 128 = 15 ∨ n % 128 = 59) :
+    AttainsBelow n := by
+  rcases h with he | h1 | h3 | h11 | h23 | h7 | h15 | h59
+  · exact even_attainsBelow hn he
+  · exact mod_four_one_attainsBelow h1.1 h1.2
+  · exact mod_sixteen_three_attainsBelow h3
+  · exact mod_thirtytwo_eleven_attainsBelow h11
+  · exact mod_thirtytwo_twentythree_attainsBelow h23
+  · exact mod_onetwentyeight_seven_attainsBelow h7
+  · exact mod_onetwentyeight_fifteen_attainsBelow h15
+  · exact mod_onetwentyeight_fiftynine_attainsBelow h59
 
 /-! ## Part II.5: A quantitative density floor of 3/4
 

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -164,3 +164,39 @@ the four new colMin lemmas → only `[propext, Classical.choice, Quot.sound]`.
 - Genuine next direction (documented in nextSteps): formalize the leading-coefficient
   law `c = 3^a·M/2^b` from the forced parity vector (Terras structure), which would turn
   `affine_residue_attainsBelow` into a fully uniform residue-drop engine.
+
+## Session 2026-06-27 (researcher-1) — REPAIR: prior mod-128 commit was broken
+
+**Mode**: VERIFY/REPAIR (RICH knowledge tier)
+**Outcome**: progress — the 115/128 floor is now actually compiled & axiom-free
+
+### What was wrong
+The previous mod-128 commit (#30735, tagged "7/8 → 115/128, UNVERIFIED — build host down")
+committed a file that **does not compile**. It added the *references* to four theorems
+(`mod_onetwentyeight_{seven,fifteen,fiftynine}_attainsBelow` and the packaging
+`even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow`) inside `attainsBelow_density_lower_128`
+and the colMin corollaries, but **never wrote the theorems themselves**. Offline
+`lake env lean` → 7 `unknownIdentifier` errors. The "UNVERIFIED" tag hid a hard build break,
+not just a kernel-confidence gap. Lesson: a session that cannot build must not claim a new
+density floor — at minimum confirm every referenced lemma actually exists in the file.
+
+### What I did
+- Computed the three new mod-128 trajectories in Python (affine `a·m+b` tracking, parity
+  read from `b` since `a` stays even until the final halving) and confirmed each drops in
+  **11 residue-determined steps** to `81·m + d` (`81 = 3⁴ < 2⁷ = 128`), 4 odd + 7 even steps:
+  - `7 (mod 128)`:  128m+7  → … → **81m+5**
+  - `15 (mod 128)`: 128m+15 → … → **81m+10**  (passes through 1296m+160)
+  - `59 (mod 128)`: 128m+59 → … → **81m+38**  (its second halving comes one step earlier)
+- Wrote the three drop theorems via the shared `affine_residue_attainsBelow` helper
+  (same template as the mod-32 lemmas: `collatz_odd …; ring` / `collatz_even …; omega`
+  per step, 11× `iterate_succ_apply'` + `iterate_zero_apply`, `s1…s11`).
+- Wrote the 8-way packaging theorem `even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow`.
+- **Verified offline** (Docker recovered but disk at 99%; `LAKE_UNSAFE=1 ./bin/lake env lean`
+  against the worktree's own Mathlib oleans): whole file EXIT 0, 0 errors/warnings.
+- `#print axioms` on all three drop theorems, `attainsBelow_density_lower_128`, and the
+  packaging theorem → only `[propext, Classical.choice, Quot.sound]`. The 115/128 floor is
+  genuinely axiom-free and independent of `tao_2019`.
+
+### Status now
+`proofs/Proofs/CollatzStructuredOQ02OQ03.lean`: 1052 lines, **39 theorems**, 5 defs,
+1 deep axiom (`tao_2019`), 0 sorries. COMPILES. meta.json counts corrected 35→39, 938→1052.

--- a/research/problems/collatz-structured-oq-02-oq-03/state.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/state.md
@@ -4,46 +4,40 @@
 **Phase**: ACT
 **Path**: full
 **Since**: 2026-06-27T05:00:00-07:00
-**Iteration**: 3
+**Iteration**: 4
 
 ## Current Focus
-Pushed the unconditional, axiom-free density floor under Tao (2019) from **7/8** to
-**115/128** by analysing the next dyadic level. Computed (exhaustively, in Python) that
-level 64 adds *no* new stable residue class, but level 128 stabilises exactly three of the
-mod-32 unstable classes — `7, 15, 59 (mod 128)` — each dropping in eleven residue-determined
-steps to `81m + d` with `81 = 3^4 < 2^7`.
+Repaired and **verified** the previously-broken 115/128 density floor. The prior commit
+(#30735) referenced four mod-128 theorems that were never written, so the file did not
+compile. This session authored the three missing mod-128 drop theorems (`7, 15, 59 mod 128`,
+each dropping in 11 residue-determined steps to `81m+d`) plus the 8-way packaging theorem,
+and confirmed EXIT 0 with `#print axioms` showing only `propext/Classical.choice/Quot.sound`.
 
 ## Active Approach
-Same sibling pattern: deep result stays a single documented axiom (`tao_2019`); the
-elementary residue-dynamics core is extended one dyadic level via the shared
-`affine_residue_attainsBelow` helper, then assembled into a disjoint-family counting bound.
+Deep result stays a single documented axiom (`tao_2019`); the elementary residue-dynamics
+core is extended one dyadic level via the shared `affine_residue_attainsBelow` helper, then
+assembled into a disjoint-family counting bound (`attainsBelow_density_lower_128`).
 
 ## Attempt Count
-- Total attempts: 4
+- Total attempts: 5
 - Approaches tried: statement + explicit families; n≡1 mod 4 family; colMin bridge;
-  **mod-128 refinement (this session)**
+  mod-16/mod-32 refinements; mod-128 refinement (committed broken); **mod-128 repair + verify (this session)**
 
 ## Blockers
 - Full proof of Tao (2019) remains BLOCKED (3-adic transport/concentration + Fourier; >> 1000 lines).
-- **Build host DOWN this session**: disk at 99% (≈237Mi free), Docker image store corrupt
-  (`docker run` fails with containerd blob I/O error). Could NOT run `docker-build.sh`.
-  The new content is therefore **UNVERIFIED by the Lean kernel** — but the mathematics is
-  exhaustively checked in Python (all three trajectories for m=0..200; the 8 families are
-  pairwise disjoint and cover exactly 115 residues mod 128) and the Lean follows the exact
-  template of the already-compiled mod-32 theorems in the same file.
+- Build host: Docker is back up but disk at 99% (~190Mi free). Verified offline via
+  `LAKE_UNSAFE=1 ./bin/lake env lean` against the worktree's cached Mathlib oleans (EXIT 0).
 
 ## Next Action
-Re-run `./proofs/scripts/docker-build.sh Proofs.CollatzStructuredOQ02OQ03` once the build
-host recovers (disk freed, Docker image store repaired) to confirm EXIT 0. Future milestone:
-the next dyadic improvement past 115/128 is at level 256 (density 237/256); or formalize the
-Terras/Korec natural-density stopping-time result toward Tao's logarithmic-density bound.
+The next dyadic improvement past 115/128 is at level 256 (density 237/256), but this is
+diminishing returns — each level adds only a handful of residue classes and the path to
+density 1 is the Terras/Korec finite-stopping-time theorem, not finite residue computation.
+Future milestone: formalize Terras/Korec natural-density stopping-time toward Tao's bound.
 
 ## Deliverable (this session)
-`proofs/Proofs/CollatzStructuredOQ02OQ03.lean` — added, all axiom-free:
+`proofs/Proofs/CollatzStructuredOQ02OQ03.lean` — now COMPILES (was broken):
 - `mod_onetwentyeight_seven_attainsBelow`, `mod_onetwentyeight_fifteen_attainsBelow`,
-  `mod_onetwentyeight_fiftynine_attainsBelow` (the three new mod-128 drop theorems, 11 steps each);
-- `even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow` (8-way packaging);
-- `attainsBelow_density_lower_128` (machine-statement of the `≥ 115/128` counting floor);
-- four new `colMin_lt` corollaries bridging the new classes to Tao's `Col_min` predicate.
-Still 1 deep axiom (`tao_2019`), 0 sorries. UNVERIFIED pending build host recovery (see Blockers).
-Gallery `meta.json` updated (counts, description, highlights). 
+  `mod_onetwentyeight_fiftynine_attainsBelow` (the three missing 11-step drop theorems);
+- `even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow` (8-way packaging).
+Verified EXIT 0 offline; all new theorems axiom-free (`propext/Classical.choice/Quot.sound`).
+Still 1 deep axiom (`tao_2019`), 0 sorries, 39 theorems. meta.json counts corrected.

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,11 +20,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 938,
+    "lineCount": 1052,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
-    "theoremCount": 35,
+    "theoremCount": 39,
     "definitionCount": 5
   },
   "overview": {
@@ -133,9 +133,9 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 938,
+    "lineCount": 1052,
     "axiomCount": 1,
-    "theoremCount": 35,
+    "theoremCount": 39,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 5


### PR DESCRIPTION
## Summary

Repairs a **broken file** committed by the prior session (#30735, tagged "UNVERIFIED — build host down"). That commit referenced four theorems but never defined them, so `proofs/Proofs/CollatzStructuredOQ02OQ03.lean` failed to compile (7 `unknownIdentifier` errors). The "UNVERIFIED" tag hid a hard build break, not just a kernel-confidence gap.

## What was missing

`attainsBelow_density_lower_128` and the `colMin` corollaries referenced, but the file never defined:
- `mod_onetwentyeight_seven_attainsBelow`
- `mod_onetwentyeight_fifteen_attainsBelow`
- `mod_onetwentyeight_fiftynine_attainsBelow`
- `even_or_mod_four_one_or_mod_onetwentyeight_attainsBelow`

## What this PR adds

The four missing theorems, each via the existing `affine_residue_attainsBelow` helper (`M=128`, `k=11`, `c=81 = 3⁴ < 2⁷`, 4 odd + 7 even residue-determined steps):

| class | trajectory end | steps |
|-------|----------------|-------|
| `7 (mod 128)`  | `81m + 5`  | 11 |
| `15 (mod 128)` | `81m + 10` | 11 |
| `59 (mod 128)` | `81m + 38` | 11 |

plus the 8-way packaging theorem. Trajectories were re-derived in Python before encoding.

## Verification

- Offline build (`LAKE_UNSAFE=1 ./bin/lake env lean` against cached Mathlib oleans; Docker up but disk at 99%): **whole file EXIT 0, no errors/warnings**.
- `#print axioms` on the three drop theorems, `attainsBelow_density_lower_128`, and the packaging theorem → only `[propext, Classical.choice, Quot.sound]`. The **115/128 density floor is axiom-free** and independent of `tao_2019`.

## File status

1052 lines, **39 theorems**, 5 defs, **1 deep axiom** (`tao_2019`, the intentionally-axiomatized Tao 2019 statement), **0 sorries**. `meta.json` counts corrected (35→39, 938→1052).

🤖 Generated with [Claude Code](https://claude.com/claude-code)