### PR TITLE
research(bezout-identity-oq-02-oq-01-oq-03): extended-Euclid Bézout coefficient uniqueness (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -391,6 +391,7 @@ import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02OQ03
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ03
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ04
+import Proofs.BezoutIdentityOQ02OQ01OQ03
 import Proofs.BezoutIdentityOQ02OQ02
 import Proofs.BezoutIdentityOQ02OQ02OQ01
 import Proofs.BezoutIdentityOQ02OQ02OQ01OQ01

--- a/proofs/Proofs/BezoutIdentityOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ01OQ03.lean
@@ -1,0 +1,122 @@
+/-
+  Bézout Identity — OQ-02-OQ-01-OQ-03:
+  Constructive Bézout coefficients via the extended Euclidean algorithm,
+  and their uniqueness modulo the homogeneous lattice.
+
+  ## Question
+  The parent line develops Bézout's identity and its consequences (Euclid's
+  Lemma, the Fundamental Theorem of Arithmetic). Bézout's identity asserts the
+  *existence* of integers s, t with  a · s + b · t = gcd(a, b).
+
+  Mathlib's extended Euclidean algorithm (`Nat.gcdA`, `Nat.gcdB`) produces one
+  concrete such pair. But the coefficients are NOT unique: if (s, t) works, so
+  does (s + k·(b/g), t − k·(a/g)) for every integer k. This file settles the
+  converse — the *uniqueness* / classification: those are the ONLY pairs, so the
+  solution set of a·x + b·y = g is exactly one coset of the lattice ℤ·(b/g, −a/g).
+
+  ## What this file delivers (0 axioms, 0 sorries)
+  * `bezout_identity` — extended-gcd Bézout identity over ℤ (from `Nat.gcd_eq_gcd_ab`).
+  * `coprime_homogeneous` — core lemma: for coprime a, b (b ≠ 0), every solution
+    of a·u + b·v = 0 is u = k·b, v = −(k·a).
+  * `coprime_bezout_unique` — uniqueness: two solutions of a·x + b·y = c differ by
+    one lattice step (k·b, −k·a).
+  * `coprime_bezout_param` — converse: every lattice step is again a solution.
+  * `gcdA_gcdB_unique` — the extended-Euclid coefficients (gcdA, gcdB) are unique
+    modulo (b, −a) for coprime a, b.
+  * Concrete worked instances for the coprime pair (3, 5).
+
+  References:
+  [Bez1779]  Bézout, "Théorie générale des équations algébriques" (1779)
+  [Knuth2]   Knuth, TAOCP Vol. 2, §4.5.2 (extended Euclidean algorithm)
+
+  Tags: number-theory, bezout, euclidean-algorithm, diophantine, classical
+-/
+
+import Mathlib
+
+namespace BezoutExtGcdUnique
+
+-- ============================================================
+-- SECTION I: Existence — the extended-Euclid Bézout identity
+-- ============================================================
+
+/-- Bézout's identity from Mathlib's extended Euclidean coefficients
+    `Nat.gcdA`, `Nat.gcdB`: over ℤ, `gcd a b = a · gcdA a b + b · gcdB a b`. -/
+theorem bezout_identity (a b : ℕ) :
+    (Nat.gcd a b : ℤ) = a * Nat.gcdA a b + b * Nat.gcdB a b :=
+  Nat.gcd_eq_gcd_ab a b
+
+-- ============================================================
+-- SECTION II: Homogeneous solutions for coprime a, b
+-- ============================================================
+
+/-- **Core lemma.** For coprime integers `a, b` with `b ≠ 0`, every solution of
+    the homogeneous equation `a·u + b·v = 0` is a lattice multiple of `(b, −a)`. -/
+theorem coprime_homogeneous {a b u v : ℤ} (hab : IsCoprime a b) (hb : b ≠ 0)
+    (h : a * u + b * v = 0) : ∃ k : ℤ, u = k * b ∧ v = -(k * a) := by
+  have hbav : b ∣ a * u := ⟨-v, by linear_combination h⟩
+  have hbu : b ∣ u := (hab.symm).dvd_of_dvd_mul_left hbav
+  obtain ⟨k, hk⟩ := hbu
+  refine ⟨k, by rw [hk]; ring, ?_⟩
+  have hz : b * (a * k + v) = 0 := by rw [hk] at h; linear_combination h
+  have hzero : a * k + v = 0 := (mul_eq_zero.mp hz).resolve_left hb
+  linear_combination hzero
+
+-- ============================================================
+-- SECTION III: Uniqueness and parametrization
+-- ============================================================
+
+/-- **Uniqueness.** For coprime `a, b` with `b ≠ 0`, any two solutions of
+    `a·x + b·y = c` differ by exactly one lattice step `(k·b, −k·a)`. -/
+theorem coprime_bezout_unique {a b x₁ y₁ x₂ y₂ : ℤ} (hab : IsCoprime a b)
+    (hb : b ≠ 0) (h : a * x₁ + b * y₁ = a * x₂ + b * y₂) :
+    ∃ k : ℤ, x₂ - x₁ = k * b ∧ y₂ - y₁ = -(k * a) := by
+  have h0 : a * (x₂ - x₁) + b * (y₂ - y₁) = 0 := by linear_combination -h
+  exact coprime_homogeneous hab hb h0
+
+/-- **Parametrization (converse).** Every lattice step from a solution is again
+    a solution: `a·(x + k·b) + b·(y − k·a) = a·x + b·y`. -/
+theorem coprime_bezout_param (a b x y k : ℤ) :
+    a * (x + k * b) + b * (y - k * a) = a * x + b * y := by ring
+
+-- ============================================================
+-- SECTION IV: Specialization to the extended-Euclid coefficients
+-- ============================================================
+
+/-- For coprime naturals `a, b` with `b ≠ 0`, the extended-Euclid coefficients
+    `(gcdA a b, gcdB a b)` are unique modulo `(b, −a)`. -/
+theorem gcdA_gcdB_unique {a b : ℕ} (hab : Nat.Coprime a b) (hb : b ≠ 0)
+    {x y : ℤ} (h : (a : ℤ) * x + b * y = 1) :
+    ∃ k : ℤ, x - Nat.gcdA a b = k * b ∧ y - Nat.gcdB a b = -(k * a) := by
+  have hcop : IsCoprime (a : ℤ) (b : ℤ) := Nat.isCoprime_iff_coprime.mpr hab
+  have hb' : (b : ℤ) ≠ 0 := by exact_mod_cast hb
+  have hg : (a : ℤ) * Nat.gcdA a b + b * Nat.gcdB a b = 1 := by
+    have hbez := Nat.gcd_eq_gcd_ab a b
+    rw [hab.gcd_eq_one] at hbez
+    exact_mod_cast hbez.symm
+  exact coprime_bezout_unique hcop hb' (by rw [hg, h])
+
+-- ============================================================
+-- SECTION V: Concrete worked instances (coprime pair 3, 5)
+-- ============================================================
+
+/-- `(2, −1)` is a Bézout pair for `(3, 5)`: `3·2 + 5·(−1) = 1`. -/
+theorem ex35_a : (3 : ℤ) * 2 + 5 * (-1) = 1 := by norm_num
+
+/-- `(−3, 2)` is another Bézout pair for `(3, 5)`: `3·(−3) + 5·2 = 1`. -/
+theorem ex35_b : (3 : ℤ) * (-3) + 5 * 2 = 1 := by norm_num
+
+/-- The two pairs differ by exactly one lattice step `k = −1`. -/
+theorem ex35_step : ((-3 : ℤ) = 2 + (-1) * 5) ∧ ((2 : ℤ) = -1 - (-1) * 3) := by
+  constructor <;> norm_num
+
+/-- The whole one-parameter family for `(3, 5)`: every `k` gives a solution. -/
+theorem ex35_family (k : ℤ) : (3 : ℤ) * (2 + k * 5) + 5 * (-1 - k * 3) = 1 := by
+  ring
+
+#check @coprime_homogeneous
+#check @coprime_bezout_unique
+#check @coprime_bezout_param
+#check @gcdA_gcdB_unique
+
+end BezoutExtGcdUnique

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-bezout-identity",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-03",
+    "range": { "startLine": 44, "endLine": 48 },
+    "type": "insight",
+    "title": "Existence from the Extended Euclidean Algorithm",
+    "content": "`bezout_identity a b : (Nat.gcd a b : ℤ) = a * Nat.gcdA a b + b * Nat.gcdB a b` is a direct repackaging of Mathlib's `Nat.gcd_eq_gcd_ab`. `Nat.gcdA` and `Nat.gcdB` are the coefficients computed by the extended Euclidean algorithm (`Nat.xgcd`), so this is a *constructive* witness, not a mere existence proof. It supplies the concrete pair whose uniqueness the rest of the file characterizes.",
+    "mathContext": "Bézout's identity: for $a,b\\in\\mathbb{N}$ there exist $s,t\\in\\mathbb{Z}$ with $as+bt=\\gcd(a,b)$. The extended Euclidean algorithm produces one such $(s,t)=(\\mathrm{gcdA}\\,a\\,b,\\ \\mathrm{gcdB}\\,a\\,b)$.",
+    "significance": "foundational",
+    "relatedConcepts": ["Nat.gcd_eq_gcd_ab", "Nat.gcdA", "Nat.gcdB", "Nat.xgcd"],
+    "prerequisites": ["Extended Euclidean algorithm", "Mathlib.Data.Int.GCD"]
+  },
+  {
+    "id": "ann-coprime-homogeneous",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 64 },
+    "type": "insight",
+    "title": "The Core Lemma: Homogeneous Solutions Are a Rank-1 Lattice",
+    "content": "`coprime_homogeneous` is where all the number theory lives. From `a*u + b*v = 0` we read off `a*u = b*(-v)`, so `b ∣ a*u`; because `a` and `b` are coprime, `IsCoprime.dvd_of_dvd_mul_left` (applied to `IsCoprime b a`) sharpens this to `b ∣ u`. Writing `u = b*k` and substituting gives `b*(a*k + v) = 0`, and `b ≠ 0` forces `a*k + v = 0`, i.e. `v = -(k*a)`. So every homogeneous solution is the lattice point `(k*b, -(k*a))`. Each divisibility/cancellation step is certified by a single `linear_combination`, avoiding brittle rewriting.",
+    "mathContext": "The solutions of $au+bv=0$ with $\\gcd(a,b)=1$ are exactly $\\{(kb,-ka):k\\in\\mathbb{Z}\\}$, the rank-1 lattice $\\mathbb{Z}\\cdot(b,-a)$. This is the kernel of the map $(u,v)\\mapsto au+bv$ on $\\mathbb{Z}^2$.",
+    "significance": "key",
+    "relatedConcepts": ["IsCoprime.dvd_of_dvd_mul_left", "IsCoprime.symm", "mul_eq_zero", "linear_combination"],
+    "prerequisites": ["IsCoprime over ℤ", "Divisibility in ℤ"]
+  },
+  {
+    "id": "ann-coprime-bezout-unique",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-03",
+    "range": { "startLine": 70, "endLine": 81 },
+    "type": "insight",
+    "title": "Uniqueness by Differencing; the Converse Is a Ring Identity",
+    "content": "`coprime_bezout_unique` shows any two solutions of `a*x + b*y = c` differ by one lattice step: subtracting `a*x₁ + b*y₁ = a*x₂ + b*y₂` yields `a*(x₂-x₁) + b*(y₂-y₁) = 0`, and `coprime_homogeneous` finishes. The converse `coprime_bezout_param` is the one-line ring identity `a*(x + k*b) + b*(y - k*a) = a*x + b*y`. Together they say the solution set is a *full coset* of `ℤ·(b,-a)` — uniqueness and existence are the two halves of one classification.",
+    "mathContext": "For $\\gcd(a,b)=1$ the solution set of $ax+by=c$ is a coset $\\{(x_0+kb,\\ y_0-ka):k\\in\\mathbb{Z}\\}$ of the homogeneous lattice. Differencing reduces uniqueness to the homogeneous case.",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination", "ring", "coprime_homogeneous"],
+    "prerequisites": ["Affine vs. linear solution sets"]
+  },
+  {
+    "id": "ann-gcdA-gcdB-unique",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 98 },
+    "type": "insight",
+    "title": "Specializing Uniqueness to the Algorithm's Output",
+    "content": "`gcdA_gcdB_unique` applies the classification to Mathlib's actual extended-Euclid coefficients. For coprime `a, b` the gcd is `1`, so `Nat.gcd_eq_gcd_ab` together with `Nat.Coprime.gcd_eq_one` shows `a*gcdA + b*gcdB = 1`; `Nat.isCoprime_iff_coprime` transports coprimality to `IsCoprime (a:ℤ) (b:ℤ)`. Any other integer solution of `a*x + b*y = 1` then differs from `(gcdA, gcdB)` by a single lattice step `k`. This is the precise sense in which the extended Euclidean algorithm's output is unique.",
+    "mathContext": "$(\\mathrm{gcdA}\\,a\\,b,\\ \\mathrm{gcdB}\\,a\\,b)$ is one solution of $ax+by=1$; all others are $(\\mathrm{gcdA}+kb,\\ \\mathrm{gcdB}-ka)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.isCoprime_iff_coprime", "Nat.Coprime.gcd_eq_one", "Nat.gcd_eq_gcd_ab"],
+    "prerequisites": ["ℕ↔ℤ casting of coprimality"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-03",
+    "range": { "startLine": 100, "endLine": 122 },
+    "type": "example",
+    "title": "The Family for (3, 5) Made Explicit",
+    "content": "For the coprime pair `(3,5)`, both `(2,-1)` and `(-3,2)` solve `3x + 5y = 1`, and they differ by the single lattice step `k = -1`: `(-3,2) = (2 + (-1)·5, -1 - (-1)·3)`. `ex35_family` exhibits the whole one-parameter family `3·(2 + k·5) + 5·(-1 - k·3) = 1`, closed by `ring`. These concretize the abstract coset description.",
+    "mathContext": "All integer solutions of $3x+5y=1$ are $(2+5k,\\ -1-3k)$, $k\\in\\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring", "norm_num"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "bezout-identity-oq-02-oq-01-oq-03",
+  "title": "Bézout Coefficient Uniqueness via the Extended Euclidean Algorithm",
+  "slug": "bezout-identity-oq-02-oq-01-oq-03",
+  "description": "Bézout's identity guarantees integers s, t with a·s + b·t = gcd(a,b), and Mathlib's extended Euclidean algorithm (Nat.gcdA, Nat.gcdB) produces one concrete pair — but the pair is not unique. This entry settles the converse classification: for coprime a, b the full solution set of a·x + b·y = c is exactly one coset of the rank-1 lattice ℤ·(b, −a). It proves the core homogeneous lemma (a·u + b·v = 0 ⟹ (u,v) = (k·b, −k·a)), the uniqueness statement (any two Bézout pairs differ by one lattice step), the converse parametrization (every lattice step is again a solution), and specializes uniqueness to the extended-Euclid coefficients (gcdA, gcdB). Worked instances for the coprime pair (3,5).",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "bezout",
+      "euclidean-algorithm",
+      "diophantine",
+      "classical"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. VERIFIED: compiles clean against Mathlib 4.26.0 via `lake env lean Proofs/BezoutIdentityOQ02OQ01OQ03.lean` (no errors, no warnings); `#print axioms` on all five top-level results reports only [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Relies on standard Mathlib lemmas (Nat.gcd_eq_gcd_ab, IsCoprime.dvd_of_dvd_mul_left, Nat.isCoprime_iff_coprime) plus linear_combination/ring. The uniqueness results are stated for coprime a, b (the gcd = 1 case, which carries all the content); the general case rescales by g = gcd(a,b).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "dateAdded": "2026-06-27",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Bézout's identity — that gcd(a,b) is an integer combination of a and b — was stated by Bézout (1779) and is implicit in Euclid's algorithm. The extended Euclidean algorithm (Knuth, TAOCP Vol. 2, §4.5.2) computes a witnessing pair of coefficients constructively; Mathlib exposes it as Nat.gcdA and Nat.gcdB with the identity Nat.gcd_eq_gcd_ab. The parent line of this gallery develops Bézout → Euclid's Lemma → the Fundamental Theorem of Arithmetic. A point those entries leave open is that the Bézout coefficients are not canonical: solving a·x + b·y = g is a linear Diophantine problem whose solution set, classically, is a one-parameter family. This entry formalizes that classification, which is the precise statement of 'uniqueness' for the extended-gcd output.",
+    "problemStatement": "Mathlib's extended Euclidean algorithm returns one Bézout pair (gcdA a b, gcdB a b) with a·gcdA + b·gcdB = gcd(a,b). The coefficients are evidently non-unique: (s + k·(b/g), t − k·(a/g)) works for every k. Are these the ONLY solutions? Formalize, for coprime a, b, that the solution set of a·x + b·y = c is exactly the single coset {(x₀ + k·b, y₀ − k·a) : k ∈ ℤ} — both that every solution has this form (uniqueness) and that every member of the form is a solution (parametrization) — and specialize the uniqueness to the extended-Euclid coefficients.",
+    "proofStrategy": "The content is the homogeneous lemma coprime_homogeneous: if a·u + b·v = 0 with IsCoprime a b and b ≠ 0, then a·u = b·(−v) gives b ∣ a·u, and coprimality of (b,a) upgrades this to b ∣ u via IsCoprime.dvd_of_dvd_mul_left; writing u = b·k and substituting, b·(a·k + v) = 0, so b ≠ 0 forces v = −(k·a). Uniqueness (coprime_bezout_unique) is the homogeneous lemma applied to the difference of two solutions: subtracting a·x₁ + b·y₁ = a·x₂ + b·y₂ gives a·(x₂−x₁) + b·(y₂−y₁) = 0. The converse coprime_bezout_param is a one-line ring identity a·(x + k·b) + b·(y − k·a) = a·x + b·y, so the solution set is a full coset. gcdA_gcdB_unique specializes: the extended-Euclid pair solves a·x + b·y = 1 (since gcd = 1 for coprime a, b, via Nat.gcd_eq_gcd_ab and Nat.Coprime.gcd_eq_one), and IsCoprime over ℤ comes from Nat.isCoprime_iff_coprime, so any other solution differs from (gcdA, gcdB) by one lattice step. The divisibility cancellations are discharged uniformly by linear_combination.",
+    "keyInsights": [
+      "The entire ambiguity in 'the' Bézout coefficients is captured by a single rank-1 lattice ℤ·(b, −a): there is exactly one free integer parameter, no more and no less. coprime_homogeneous is the precise statement and the only place number theory enters.",
+      "Coprimality is used in exactly one step: from b ∣ a·u to b ∣ u via IsCoprime.dvd_of_dvd_mul_left. Everything else is the ring identity a·(b·k) + b·v = b·(a·k + v) and cancellation of b ≠ 0.",
+      "Uniqueness and existence are dual: subtracting two solutions kills the inhomogeneous term, so classifying Bézout pairs reduces to solving the homogeneous equation a·u + b·v = 0 — exactly what coprime_homogeneous does.",
+      "The coprime (gcd = 1) case carries all the content. For general a, b the same statement holds after dividing through by g = gcd(a,b), with the lattice generated by (b/g, −a/g) and a/g, b/g coprime.",
+      "linear_combination turns each divisibility/cancellation obligation into a single certified ring identity, making the proof robust to associativity/commutativity reshuffling and avoiding brittle rewrite chains."
+    ]
+  },
+  "sections": [
+    {
+      "id": "existence",
+      "title": "Existence: the Extended-Euclid Bézout Identity",
+      "startLine": 38,
+      "endLine": 48,
+      "summary": "bezout_identity wraps Mathlib's Nat.gcd_eq_gcd_ab: over ℤ, gcd a b = a·gcdA a b + b·gcdB a b. This is the existence half; the rest of the file is the uniqueness/classification of such pairs."
+    },
+    {
+      "id": "homogeneous",
+      "title": "Core Lemma: Homogeneous Solutions for Coprime a, b",
+      "startLine": 50,
+      "endLine": 64,
+      "summary": "coprime_homogeneous: for IsCoprime a b and b ≠ 0, every solution of a·u + b·v = 0 is (u,v) = (k·b, −k·a). Proof: b ∣ a·u (since a·u = b·(−v)), coprimality gives b ∣ u via IsCoprime.dvd_of_dvd_mul_left, and cancelling b ≠ 0 from b·(a·k + v) = 0 fixes v."
+    },
+    {
+      "id": "uniqueness-param",
+      "title": "Uniqueness and Parametrization",
+      "startLine": 66,
+      "endLine": 81,
+      "summary": "coprime_bezout_unique: two solutions of a·x + b·y = c differ by one lattice step (k·b, −k·a), obtained by applying the homogeneous lemma to their difference. coprime_bezout_param: the converse ring identity a·(x + k·b) + b·(y − k·a) = a·x + b·y, so the solution set is a full coset of ℤ·(b, −a)."
+    },
+    {
+      "id": "extgcd-specialization",
+      "title": "Specialization to the Extended-Euclid Coefficients",
+      "startLine": 83,
+      "endLine": 98,
+      "summary": "gcdA_gcdB_unique: for coprime a, b (b ≠ 0), the pair (gcdA a b, gcdB a b) is unique modulo (b, −a); every integer solution of a·x + b·y = 1 has the form (gcdA + k·b, gcdB − k·a). Uses Nat.isCoprime_iff_coprime and Nat.Coprime.gcd_eq_one to connect the ℕ and ℤ statements."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Worked Instances (3, 5)",
+      "startLine": 100,
+      "endLine": 122,
+      "summary": "Two Bézout pairs for (3,5): (2,−1) and (−3,2), differing by the single lattice step k = −1; and the full one-parameter family 3·(2 + k·5) + 5·(−1 − k·3) = 1, all closed by norm_num / ring."
+    }
+  ],
+  "conclusion": {
+    "summary": "For coprime integers a, b the solution set of the Bézout equation a·x + b·y = c is exactly one coset of the rank-1 lattice ℤ·(b, −a): the homogeneous lemma classifies a·u + b·v = 0, uniqueness follows by differencing, and the converse parametrization is a ring identity. Specialized to Mathlib's extended Euclidean coefficients, the pair (gcdA a b, gcdB a b) is therefore determined up to the single free parameter k. Fully machine-checked, 0 axioms.",
+    "implications": "This pins down precisely how non-unique 'the' Bézout coefficients are: a one-parameter family and nothing more. It is the missing classification behind the parent line's Bézout → Euclid's Lemma → FTA development, and supplies a reusable homogeneous-solution lemma for linear Diophantine reasoning over ℤ.",
+    "openQuestions": [
+      "Generalize the classification from coprime a, b to arbitrary a, b by dividing through by g = gcd(a,b): the solution set of a·x + b·y = g is the coset generated by (b/g, −a/g), with a/g, b/g coprime (Nat.coprime_div_gcd_div_gcd).",
+      "Identify the canonical/minimal Bézout pair (the unique solution with |t| < |a/g|/2 or the reduced representative), and prove the extended Euclidean algorithm returns it.",
+      "Extend the lattice description to k-variable linear Diophantine systems a₁x₁ + … + a_kx_k = c, whose solution set is a coset of a rank-(k−1) lattice."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry develops Bézout → Euclid's Lemma → FTA uniqueness. This entry classifies the non-uniqueness of the Bézout coefficients themselves, the linear-Diophantine layer underneath that chain."
+    },
+    {
+      "targetId": "bezout-identity",
+      "relationship": "related",
+      "description": "Root Bézout entry (existence of coefficients). This entry adds the uniqueness/classification half via the extended Euclidean algorithm coefficients."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 122,
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ03.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 9
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-03.json
@@ -1,0 +1,54 @@
+{
+  "slug": "bezout-identity-oq-02-oq-01-oq-03",
+  "title": "Constructive Bézout coefficients via extGcd uniqueness",
+  "phase": "VERIFIED",
+  "status": "completed",
+  "tier": "B",
+  "path": "Proofs/BezoutIdentityOQ02OQ01OQ03.lean",
+  "problemStatement": "Mathlib's extended Euclidean algorithm (Nat.gcdA, Nat.gcdB) produces one Bézout pair with a·gcdA + b·gcdB = gcd(a,b), but the coefficients are non-unique. Classify the ambiguity: prove that for coprime a, b the solution set of a·x + b·y = c is exactly one coset of the rank-1 lattice ℤ·(b, −a), and specialize the uniqueness to the extended-Euclid coefficients.",
+  "knownResults": [
+    "Bézout's identity (existence) is Mathlib's Nat.gcd_eq_gcd_ab.",
+    "Classically the solution set of a linear Diophantine equation a·x + b·y = c (gcd a b | c) is a one-parameter family / coset of ℤ·(b/g, −a/g).",
+    "Mathlib lacks a packaged linear-Diophantine solution-set parametrization, so the classification is genuine new content."
+  ],
+  "currentState": {
+    "goal": "A verified classification of Bézout-coefficient ambiguity via the extended Euclidean algorithm.",
+    "focus": "Proved coprime_homogeneous (a·u+b·v=0 ⟹ (u,v)=(k·b,−k·a)), coprime_bezout_unique, coprime_bezout_param, and gcdA_gcdB_unique; worked instances for (3,5).",
+    "blockers": ["None — verified."],
+    "nextAction": "Done. Compiles clean against Mathlib 4.26.0 (lake env lean); #print axioms on all five results = [propext, Classical.choice, Quot.sound] only. Gallery entry added (status=verified, badge=original).",
+    "progressSummary": "VERIFIED: 9-theorem self-contained file (0 sorry/axiom) classifying Bézout-coefficient uniqueness as a single coset of the rank-1 lattice ℤ·(b,−a). Core lemma coprime_homogeneous via IsCoprime.dvd_of_dvd_mul_left; uniqueness by differencing; converse by a ring identity; specialization to Nat.gcdA/Nat.gcdB. Gallery entry + Lean import added."
+  },
+  "knowledge": {
+    "keyLemmas": [
+      "Nat.gcd_eq_gcd_ab (Bézout via gcdA/gcdB)",
+      "IsCoprime.dvd_of_dvd_mul_left (the one coprimality step)",
+      "Nat.isCoprime_iff_coprime (ℕ Coprime ↔ ℤ IsCoprime)",
+      "Nat.Coprime.gcd_eq_one"
+    ],
+    "techniques": [
+      "Reduce uniqueness to the homogeneous equation by differencing two solutions.",
+      "Discharge each divisibility/cancellation obligation with a single linear_combination.",
+      "Coprime case (gcd=1) carries all content; general case rescales by g."
+    ]
+  },
+  "tags": ["number-theory", "bezout", "euclidean-algorithm", "diophantine", "classical"],
+  "relatedProofs": ["bezout-identity-oq-02-oq-01", "bezout-identity"],
+  "references": [
+    "Bézout, Théorie générale des équations algébriques (1779)",
+    "Knuth, TAOCP Vol. 2, §4.5.2 (extended Euclidean algorithm)"
+  ],
+  "started": "2026-06-27",
+  "lastUpdate": "2026-06-27",
+  "significance": 5,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ03.lean",
+      "lineCount": 122,
+      "axiomCount": 0,
+      "sorries": 0,
+      "theoremCount": 9,
+      "definitionCount": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

New gallery entry classifying the **uniqueness** of Bézout coefficients produced by the extended Euclidean algorithm. Bézout's identity gives *existence* of `s, t` with `a·s + b·t = gcd(a,b)`, and Mathlib's `Nat.gcdA`/`Nat.gcdB` produce one concrete pair — but the pair is non-unique. This entry settles the converse: for coprime `a, b` the solution set of `a·x + b·y = c` is **exactly one coset** of the rank-1 lattice `ℤ·(b, −a)`.

## Results (`Proofs/BezoutIdentityOQ02OQ01OQ03.lean`, 9 theorems, 0 axioms, 0 sorries)

- `bezout_identity` — existence, from `Nat.gcd_eq_gcd_ab`.
- `coprime_homogeneous` — **core lemma**: for coprime `a, b` (`b ≠ 0`), every solution of `a·u + b·v = 0` is `(k·b, −k·a)`. (b ∣ a·u → coprimality → b ∣ u → cancel.)
- `coprime_bezout_unique` — uniqueness: two solutions of `a·x + b·y = c` differ by one lattice step (homogeneous lemma applied to the difference).
- `coprime_bezout_param` — converse: every lattice step is again a solution (ring identity) ⇒ the solution set is a full coset.
- `gcdA_gcdB_unique` — specialization: the extended-Euclid pair `(gcdA, gcdB)` is unique modulo `(b, −a)`.
- Worked instances for the coprime pair `(3, 5)`.

## Verification

```
lake env lean Proofs/BezoutIdentityOQ02OQ01OQ03.lean   # clean, no errors/warnings
```
`#print axioms` on all five top-level results reports only:
```
[propext, Classical.choice, Quot.sound]
```
No `sorryAx`, no `Lean.ofReduceBool`. Genuinely **0-axiom verified**.

(Verified via `lake env lean` against prebuilt Mathlib oleans; the Docker build host's containerd store was intermittently corrupted/disk-full this session.)

## Files

- `proofs/Proofs/BezoutIdentityOQ02OQ01OQ03.lean` (new) + import in `proofs/Proofs.lean`
- `src/data/proofs/bezout-identity-oq-02-oq-01-oq-03/{meta.json, annotations.json}` (status `verified`, badge `original`)
- `src/data/research/problems/bezout-identity-oq-02-oq-01-oq-03.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)