### PR TITLE
audit: repair corrupt audit-tracker.json (stash conflict markers on main)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25160,17 +25160,11 @@
     },
     "hilbert-3-oq-04": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "issues": [],
-      "lastAudited": "2026-06-27T13:42:02Z",
-      "result": "issues-fixed"
-=======
       "lastAudited": "2026-06-27T13:51:27Z",
       "result": "clean",
       "issues": []
->>>>>>> Stashed changes
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T13:42:02Z"
+  "lastUpdated": "2026-06-27T13:51:27Z"
 }


### PR DESCRIPTION
## Integrity Issue (auditor infrastructure)

`src/data/proofs/audit-tracker.json` on `main` contains **unresolved git stash conflict markers**, making it invalid JSON.

**Introduced by**: commit 7d5b684e (#30765, "audit(hilbert-3-oq-04): record clean re-audit in tracker")

### Evidence

Lines 25163–25171 of the committed blob:
```
"hilbert-3-oq-04": {
  "auditCount": 1,
<<<<<<< Updated upstream
  "issues": [],
  "lastAudited": "2026-06-27T13:42:02Z",
  "result": "issues-fixed"
=======
  "lastAudited": "2026-06-27T13:51:27Z",
  "result": "clean",
  "issues": []
>>>>>>> Stashed changes
}
```

### Impact

`scripts/auditor/find-targets.ts` could not parse the tracker and silently reported **0 / 4051 audited** (entire queue appearing unaudited), which would cause auditors to re-audit already-cleared proofs.

### Fix

Resolve the conflict by keeping the later **clean re-audit** (`13:51:27Z`, `result: "clean"`) — this matches #30765's stated intent. The earlier `issues-fixed` entry (`13:42:02Z`) is superseded. `lastUpdated` bumped to the resolved timestamp.

**After fix**: `find-targets --stats` reports `Audited: 4051 / Unaudited: 0`; JSON validates (4062 entries: 3816 clean + 246 issues-fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)