### PR TITLE
Enrich IVT OQ-02-OQ-02: complete annotation metadata (bisection vs Newton rates)

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-02/annotations.json
@@ -5,7 +5,19 @@
     "range": { "startLine": 1, "endLine": 53 },
     "type": "context",
     "title": "Answering the Parent's Open Question: How Fast?",
-    "content": "The bisection algorithm (parent intermediate-value-theorem-oq-02) and its exact-root recovery (sibling -oq-02-oq-01) settle that bisection converges; the sibling explicitly asked to 'quantify the convergence rate (one bit per step) and compare against Newton's quadratic convergence.' This file answers that. The design separates a reusable rate calculus (abstract lemmas about what recurrence the error satisfies) from two concrete instantiations: bisection (linear, ratio 1/2) and Newton's √A iteration (quadratic). Everything is elementary and 0-axiom — no completeness or limit axioms beyond Mathlib's reals."
+    "content": "The bisection algorithm (parent intermediate-value-theorem-oq-02) and its exact-root recovery (sibling -oq-02-oq-01) settle that bisection converges; the sibling explicitly asked to 'quantify the convergence rate (one bit per step) and compare against Newton's quadratic convergence.' This file answers that. The design separates a reusable rate calculus (abstract lemmas about what recurrence the error satisfies) from two concrete instantiations: bisection (linear, ratio 1/2) and Newton's √A iteration (quadratic). Everything is elementary and 0-axiom — no completeness or limit axioms beyond Mathlib's reals.",
+    "mathContext": "$e_n$ = error after step $n$. Bisection: $e_n \\le e_0/2^n$ (linear). Newton: $e_{n+1} \\le C e_n^2$ (quadratic). The file proves both and that quadratic dominates.",
+    "significance": "context",
+    "relatedConcepts": [
+      "rate of convergence",
+      "bisection method",
+      "Newton's method",
+      "root-finding"
+    ],
+    "prerequisites": [
+      "intermediate-value-theorem-oq-02",
+      "real analysis basics"
+    ]
   },
   {
     "id": "ivt-oq0202-ann-abstract-rates",
@@ -13,7 +25,19 @@
     "range": { "startLine": 56, "endLine": 93 },
     "type": "insight",
     "title": "Two Recurrences, Two Decay Laws",
-    "content": "The mathematical heart of any rate comparison: linear_rate shows a contraction eₙ₊₁ ≤ r·eₙ forces geometric decay eₙ ≤ rⁿ·e₀, while quadratic_rate shows eₙ₊₁ ≤ C·eₙ² forces doubly-exponential decay. The trick for the quadratic case is to rescale: with gₙ = C·eₙ the recurrence becomes pure squaring gₙ₊₁ ≤ gₙ², so by induction gₙ ≤ g₀^(2ⁿ). In 'correct digits' language, linear adds a fixed number per step while quadratic doubles them."
+    "content": "The mathematical heart of any rate comparison: linear_rate shows a contraction eₙ₊₁ ≤ r·eₙ forces geometric decay eₙ ≤ rⁿ·e₀, while quadratic_rate shows eₙ₊₁ ≤ C·eₙ² forces doubly-exponential decay. The trick for the quadratic case is to rescale: with gₙ = C·eₙ the recurrence becomes pure squaring gₙ₊₁ ≤ gₙ², so by induction gₙ ≤ g₀^(2ⁿ). In 'correct digits' language, linear adds a fixed number per step while quadratic doubles them.",
+    "mathContext": "$e_{n+1}\\le r e_n \\Rightarrow e_n \\le r^n e_0$. For the quadratic case set $g_n = C e_n$: then $g_{n+1}\\le g_n^2$ so $g_n \\le g_0^{2^n}$, i.e. $e_n \\le C^{-1}(Ce_0)^{2^n}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric decay",
+      "doubly-exponential decay",
+      "telescoping / induction",
+      "rescaling trick"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "geometric sequences"
+    ]
   },
   {
     "id": "ivt-oq0202-ann-quadratic-tendsto",
@@ -21,7 +45,19 @@
     "range": { "startLine": 95, "endLine": 106 },
     "type": "technique",
     "title": "Squeezing the Doubly-Exponential Bound to Zero",
-    "content": "Rather than reason about 2ⁿ → ∞ inside an exponential directly, quadratic_le_linear_bound observes the termwise inequality q^(2ⁿ) ≤ qⁿ (because n ≤ 2ⁿ and 0 ≤ q ≤ 1), and quadratic_tendsto_zero then squeezes 0 ≤ q^(2ⁿ) ≤ qⁿ between two sequences tending to 0. The geometric bound qⁿ → 0 does the heavy lifting; the squeeze transfers it to the faster quadratic bound."
+    "content": "Rather than reason about 2ⁿ → ∞ inside an exponential directly, quadratic_le_linear_bound observes the termwise inequality q^(2ⁿ) ≤ qⁿ (because n ≤ 2ⁿ and 0 ≤ q ≤ 1), and quadratic_tendsto_zero then squeezes 0 ≤ q^(2ⁿ) ≤ qⁿ between two sequences tending to 0. The geometric bound qⁿ → 0 does the heavy lifting; the squeeze transfers it to the faster quadratic bound.",
+    "mathContext": "$0\\le q\\le 1$ and $n\\le 2^n$ give $q^{2^n}\\le q^n$. Since $q^n\\to 0$ for $q<1$, the squeeze $0\\le q^{2^n}\\le q^n$ forces $q^{2^n}\\to 0$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "tendsto / filters",
+      "monotonicity of powers",
+      "n ≤ 2ⁿ"
+    ],
+    "prerequisites": [
+      "limits of sequences",
+      "Mathlib Filter.Tendsto"
+    ]
   },
   {
     "id": "ivt-oq0202-ann-bisection",
@@ -29,7 +65,19 @@
     "range": { "startLine": 107, "endLine": 179 },
     "type": "theorem",
     "title": "Bisection is Linear with Ratio 1/2",
-    "content": "Re-deriving the parent's width law (bisect f n (a,b)).2 - (bisect f n (a,b)).1 = (b-a)/2ⁿ self-contained, bisect_error_bound shows the midpoint sits within (b-a)/2^(n+1) of every point of the bracket — in particular of a true root, which earlier entries prove lies in the bracket. bisect_error_halves and bisect_error_linear_recurrence record that this bound is exactly a 1/2-contraction, so it plugs straight into linear_rate. One correct binary digit is gained per step."
+    "content": "Re-deriving the parent's width law (bisect f n (a,b)).2 - (bisect f n (a,b)).1 = (b-a)/2ⁿ self-contained, bisect_error_bound shows the midpoint sits within (b-a)/2^(n+1) of every point of the bracket — in particular of a true root, which earlier entries prove lies in the bracket. bisect_error_halves and bisect_error_linear_recurrence record that this bound is exactly a 1/2-contraction, so it plugs straight into linear_rate. One correct binary digit is gained per step.",
+    "mathContext": "Bracket width $w_n = (b-a)/2^n$; midpoint error $|m_n - \\text{root}| \\le (b-a)/2^{n+1}$. The recurrence $e_{n+1} = \\tfrac12 e_n$ is a contraction with $r = 1/2$, so $e_n \\le e_0/2^n$ — one bit per step.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "bisection method",
+      "linear convergence",
+      "binary digits",
+      "contraction ratio 1/2"
+    ],
+    "prerequisites": [
+      "intermediate-value-theorem-oq-02",
+      "interval bracketing"
+    ]
   },
   {
     "id": "ivt-oq0202-ann-newton-identity",
@@ -37,7 +85,19 @@
     "range": { "startLine": 180, "endLine": 232 },
     "type": "insight",
     "title": "The Exact Newton Error Identity for √A",
-    "content": "Newton's √A iteration is xₙ₊₁ = (xₙ + A/xₙ)/2. The exact algebraic identity sqrtNewtonStep_sub_sqrt: (x + A/x)/2 - √A = (x - √A)²/(2x) (proved by field_simp + nlinarith using (√A)² = A) is the engine of quadratic convergence. Because the right side is a square over a positive number, it shows in one stroke that every iterate lands ≥ √A and stays positive — the invariants sqrtNewtonSeq_ge_sqrt and sqrtNewtonSeq_pos — with no second-derivative or Taylor machinery."
+    "content": "Newton's √A iteration is xₙ₊₁ = (xₙ + A/xₙ)/2. The exact algebraic identity sqrtNewtonStep_sub_sqrt: (x + A/x)/2 - √A = (x - √A)²/(2x) (proved by field_simp + nlinarith using (√A)² = A) is the engine of quadratic convergence. Because the right side is a square over a positive number, it shows in one stroke that every iterate lands ≥ √A and stays positive — the invariants sqrtNewtonSeq_ge_sqrt and sqrtNewtonSeq_pos — with no second-derivative or Taylor machinery.",
+    "mathContext": "$x_{n+1}=\\tfrac12\\!\\left(x_n+\\dfrac{A}{x_n}\\right)$ and $\\tfrac12\\!\\left(x+\\dfrac{A}{x}\\right)-\\sqrt A=\\dfrac{(x-\\sqrt A)^2}{2x}\\ge 0$. Hence $x_n\\ge\\sqrt A$ and $x_n>0$ for all $n\\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Newton's method",
+      "Babylonian / Heron iteration",
+      "field_simp + nlinarith",
+      "completing the square"
+    ],
+    "prerequisites": [
+      "Real.sqrt and its square",
+      "algebraic manipulation in Lean"
+    ]
   },
   {
     "id": "ivt-oq0202-ann-newton-recurrence",
@@ -45,7 +105,17 @@
     "range": { "startLine": 233, "endLine": 252 },
     "type": "theorem",
     "title": "Deriving (not Assuming) the Quadratic Recurrence",
-    "content": "sqrtNewton_quadratic_recurrence turns the error identity into eₙ₊₁ ≤ eₙ²/(2√A): from step 1 the iterate satisfies xₙ ≥ √A, so the denominator 2xₙ ≥ 2√A and (xₙ-√A)²/(2xₙ) ≤ (xₙ-√A)²/(2√A). This is genuine quadratic convergence with C = 1/(2√A), derived from the iteration itself rather than posited as a hypothesis — exactly the input quadratic_rate consumes."
+    "content": "sqrtNewton_quadratic_recurrence turns the error identity into eₙ₊₁ ≤ eₙ²/(2√A): from step 1 the iterate satisfies xₙ ≥ √A, so the denominator 2xₙ ≥ 2√A and (xₙ-√A)²/(2xₙ) ≤ (xₙ-√A)²/(2√A). This is genuine quadratic convergence with C = 1/(2√A), derived from the iteration itself rather than posited as a hypothesis — exactly the input quadratic_rate consumes.",
+    "mathContext": "$x_n\\ge\\sqrt A \\Rightarrow e_{n+1}=\\dfrac{(x_n-\\sqrt A)^2}{2x_n}\\le\\dfrac{(x_n-\\sqrt A)^2}{2\\sqrt A}=\\dfrac{e_n^2}{2\\sqrt A}$, giving $C=\\dfrac{1}{2\\sqrt A}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "quadratic convergence",
+      "error recurrence",
+      "monotone denominator bound"
+    ],
+    "prerequisites": [
+      "the Newton error identity (previous section)"
+    ]
   },
   {
     "id": "ivt-oq0202-ann-comparison",
@@ -53,6 +123,18 @@
     "range": { "startLine": 253, "endLine": 289 },
     "type": "concept",
     "title": "Doubling Digits Beats Adding One",
-    "content": "quadratic_dominates_linear proves r^(2ⁿ) ≤ rⁿ for 0 ≤ r ≤ 1, and quadratic_strictly_dominates sharpens it to a strict inequality for n ≥ 1 when r < 1 (writing r^(2ⁿ) = rⁿ·r^(2ⁿ-n) with r^(2ⁿ-n) < 1). Started from the same contraction factor, the Newton error bound is never worse than the bisection bound and strictly better from the first step. rate_comparison_summary packages this with both convergence-to-zero statements — the precise formalization of 'linear vs quadratic.'"
+    "content": "quadratic_dominates_linear proves r^(2ⁿ) ≤ rⁿ for 0 ≤ r ≤ 1, and quadratic_strictly_dominates sharpens it to a strict inequality for n ≥ 1 when r < 1 (writing r^(2ⁿ) = rⁿ·r^(2ⁿ-n) with r^(2ⁿ-n) < 1). Started from the same contraction factor, the Newton error bound is never worse than the bisection bound and strictly better from the first step. rate_comparison_summary packages this with both convergence-to-zero statements — the precise formalization of 'linear vs quadratic.'",
+    "mathContext": "For $0\\le r\\le 1$: $r^{2^n}\\le r^n$. For $n\\ge 1,\\ r<1$: $r^{2^n}=r^n\\cdot r^{2^n-n}$ with $r^{2^n-n}<1$, so $r^{2^n}<r^n$ strictly — quadratic dominates linear from the first step.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linear vs quadratic convergence",
+      "asymptotic domination",
+      "strict inequality of powers",
+      "Newton vs bisection"
+    ],
+    "prerequisites": [
+      "power inequalities",
+      "the two rate lemmas above"
+    ]
   }
 ]

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-02/meta.json
@@ -124,5 +124,28 @@
       "summary": "quadratic_dominates_linear (r^(2ⁿ) ≤ rⁿ for 0 ≤ r ≤ 1) and quadratic_strictly_dominates (strict for n ≥ 1, r < 1), packaged with both convergence-to-zero statements in rate_comparison_summary: started from the same contraction factor, Newton's bound beats bisection's from the first step."
     }
   ],
+  "references": [
+    {
+      "author": "Burden, R. L. and Faires, J. D.",
+      "year": 2010,
+      "title": "Numerical Analysis",
+      "venue": "Brooks/Cole, 9th edition, Ch. 2",
+      "note": "Standard reference for the bisection method (linear convergence, one bit per step) and Newton's method (quadratic convergence), including the error recurrences formalized here."
+    },
+    {
+      "author": "Heron of Alexandria",
+      "year": 60,
+      "title": "Metrica",
+      "venue": "c. 60 CE",
+      "note": "The iteration xₙ₊₁ = (xₙ + A/xₙ)/2 for √A — the Babylonian/Heron method — is the special case of Newton's method whose exact error identity drives the quadratic-convergence proof in this file."
+    },
+    {
+      "author": "The Mathlib Community",
+      "year": 2026,
+      "title": "Mathlib.Analysis.SpecificLimits.Basic, Filter.Tendsto",
+      "venue": "Mathlib4 (accessed 2026)",
+      "note": "Supplies the geometric-limit lemma qⁿ → 0 and the squeeze (tendsto_of_tendsto_of_tendsto_of_le_of_le) used to push the doubly-exponential Newton bound q^(2ⁿ) to zero."
+    }
+  ],
   "sorries": []
 }


### PR DESCRIPTION
Enrichment pass for `intermediate-value-theorem-oq-02-oq-02` (quality 68, 0 prior passes).

## Gap closed
The entry had 7 well-written annotations and 5 sections, but **every annotation was missing the structured metadata fields** (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`) and the entry had **no references**.

### annotations.json — added all four fields to each of the 7 annotations
LaTeX `mathContext` now captures the actual mathematics:
- contraction → geometric decay `e_{n+1} ≤ r e_n ⇒ e_n ≤ rⁿ e_0`;
- the rescaling `g_n = C e_n ⇒ g_{n+1} ≤ g_n²` giving `g_n ≤ g_0^{2ⁿ}`;
- the squeeze `q^{2ⁿ} ≤ qⁿ → 0`;
- bisection `e_{n+1} = ½ e_n`;
- Newton's exact identity `½(x + A/x) − √A = (x − √A)²/(2x) ≥ 0` and the derived recurrence `e_{n+1} ≤ e_n²/(2√A)`;
- strict domination `r^{2ⁿ} < rⁿ` for `n ≥ 1, r < 1`.

`significance` assigned (context/key/supporting/technical), plus `relatedConcepts` and `prerequisites` per annotation. All existing content, titles, types, and ranges left unchanged.

### meta.json
- Added a `references` array (Burden & Faires *Numerical Analysis*; Heron/Babylonian √A iteration; Mathlib limits + squeeze lemmas). Now 13,806 bytes, within all caps.

## Notes
- Branch `feature/enricher-5-ivt` to avoid clobbering open PRs #30766/#30767.
- JSON validated via `scripts/gallery/check-meta-size.ts` and python enum checks. `pnpm build` skipped (no node_modules; JSON-only change).