### PR TITLE
audit: repair conflict markers in audit-tracker.json (restores 4051/4051)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25160,17 +25160,11 @@
     },
     "hilbert-3-oq-04": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "issues": [],
-      "lastAudited": "2026-06-27T13:42:02Z",
-      "result": "issues-fixed"
-=======
       "lastAudited": "2026-06-27T13:51:27Z",
       "result": "clean",
       "issues": []
->>>>>>> Stashed changes
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-27T13:42:02Z"
+  "lastUpdated": "2026-06-27T13:51:27Z"
 }


### PR DESCRIPTION
## Integrity Issue

**File**: `src/data/proofs/audit-tracker.json`
**Problem**: Committed git merge-conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) in the `hilbert-3-oq-04` entry made the tracker unparseable JSON.

## Impact

`find-targets.ts --stats` reported **0/4051 audited** — a false "reset" of the entire audit queue. This is a recurrence of the corruption fixed in #30771; the markers came back on main at HEAD `5521e14d82d`.

## Evidence

```
src/data/proofs/audit-tracker.json:25163:<<<<<<< Updated upstream
src/data/proofs/audit-tracker.json:25167:=======
src/data/proofs/audit-tracker.json:25171:>>>>>>> Stashed changes
```

`python3 -c "json.load(...)"` → `JSONDecodeError`.

## Fix

Resolved the `hilbert-3-oq-04` entry to the later **clean** re-audit (`2026-06-27T13:51:27Z`, `result: "clean"`), matching the merged re-audit #30765. Both conflict sides recorded the same passing audit; kept the later/clean side and bumped `lastUpdated`.

## Verification

- JSON parses cleanly (4062 entries)
- 0 conflict markers remain
- `find-targets.ts --stats` → **4051/4051 audited, 0 unaudited**

(The "2 with issues" are the long-standing conservative-understate false positives erdos-156 / erdos-1090 — safe, no action.)

---
Discovered during gallery integrity audit.