### PR TITLE
Enrich Geometric Series OQ-07-OQ-02: complete annotation metadata (geometric RV moments)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-02/annotations.json
@@ -5,7 +5,19 @@
     "range": { "startLine": 63, "endLine": 68 },
     "type": "theorem",
     "title": "Normalisation: P is a probability mass function",
-    "content": "`geometric_pmf_hasSum` proves $\\sum_{n} (1-r)\\,r^n = 1$, so $P(X=n) = (1-r)\\,r^n$ is a genuine probability mass function on $\\mathbb{N}$ (the geometric law with success probability $p = 1-r$). The proof is one line of structure: take Mathlib's $\\sum_n r^n = (1-r)^{-1}$ (`hasSum_geometric_of_norm_lt_one`), scale by $(1-r)$ with `HasSum.mul_left`, and simplify the value $(1-r)(1-r)^{-1}=1$ via `mul_inv_cancel₀` (using $1-r\\neq 0$ from $r<1$)."
+    "content": "`geometric_pmf_hasSum` proves $\\sum_{n} (1-r)\\,r^n = 1$, so $P(X=n) = (1-r)\\,r^n$ is a genuine probability mass function on $\\mathbb{N}$ (the geometric law with success probability $p = 1-r$). The proof is one line of structure: take Mathlib's $\\sum_n r^n = (1-r)^{-1}$ (`hasSum_geometric_of_norm_lt_one`), scale by $(1-r)$ with `HasSum.mul_left`, and simplify the value $(1-r)(1-r)^{-1}=1$ via `mul_inv_cancel₀` (using $1-r\\neq 0$ from $r<1$).",
+    "mathContext": "$\\sum_{n=0}^{\\infty} (1-r)\\,r^n = (1-r)\\cdot\\frac{1}{1-r} = 1$. With $p=1-r$ this is the geometric pmf $P(X=n)=p(1-p)^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "geometric distribution",
+      "probability mass function",
+      "hasSum_geometric_of_norm_lt_one",
+      "HasSum.mul_left"
+    ],
+    "prerequisites": [
+      "convergent geometric series",
+      "probability axioms (total mass 1)"
+    ]
   },
   {
     "id": "geom-rv-mean",
@@ -13,7 +25,19 @@
     "range": { "startLine": 72, "endLine": 84 },
     "type": "theorem",
     "title": "Mean: E[X] = r/(1−r)",
-    "content": "`geometric_expectation` proves the first moment $E[X] = \\sum_n n\\,(1-r)\\,r^n = \\dfrac{r}{1-r}$. It is Mathlib's first weighted geometric sum $\\sum_n n\\,r^n = \\dfrac{r}{(1-r)^2}$ (`hasSum_coe_mul_geometric_of_norm_lt_one`) scaled by the success probability $(1-r)$: the summand $n\\big((1-r)r^n\\big)$ is matched to $(1-r)\\big(n\\,r^n\\big)$ by `ring`, and the value $(1-r)\\cdot\\dfrac{r}{(1-r)^2}=\\dfrac{r}{1-r}$ collapses under `field_simp`. With $p = 1-r$ this is the familiar $E[X]=\\dfrac{1-p}{p}$."
+    "content": "`geometric_expectation` proves the first moment $E[X] = \\sum_n n\\,(1-r)\\,r^n = \\dfrac{r}{1-r}$. It is Mathlib's first weighted geometric sum $\\sum_n n\\,r^n = \\dfrac{r}{(1-r)^2}$ (`hasSum_coe_mul_geometric_of_norm_lt_one`) scaled by the success probability $(1-r)$: the summand $n\\big((1-r)r^n\\big)$ is matched to $(1-r)\\big(n\\,r^n\\big)$ by `ring`, and the value $(1-r)\\cdot\\dfrac{r}{(1-r)^2}=\\dfrac{r}{1-r}$ collapses under `field_simp`. With $p = 1-r$ this is the familiar $E[X]=\\dfrac{1-p}{p}$.",
+    "mathContext": "$E[X]=\\sum_n n(1-r)r^n=(1-r)\\cdot\\dfrac{r}{(1-r)^2}=\\dfrac{r}{1-r}=\\dfrac{1-p}{p}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "expected value",
+      "first moment",
+      "weighted geometric sum",
+      "hasSum_coe_mul_geometric_of_norm_lt_one"
+    ],
+    "prerequisites": [
+      "expectation of a discrete random variable",
+      "differentiated geometric series Σ n rⁿ"
+    ]
   },
   {
     "id": "geom-rv-second-moment",
@@ -21,7 +45,19 @@
     "range": { "startLine": 88, "endLine": 100 },
     "type": "theorem",
     "title": "Second moment: E[X²] = r(1+r)/(1−r)²",
-    "content": "`geometric_second_moment` proves $E[X^2] = \\sum_n n^2\\,(1-r)\\,r^n = \\dfrac{r(1+r)}{(1-r)^2}$. This is the parent entry's analytic second moment $\\sum_n n^2 r^n = \\dfrac{r(1+r)}{(1-r)^3}$ (`GeometricSeriesOQ07.hasSum_sq_mul_geometric`) scaled by $(1-r)$ via `HasSum.mul_left`, with the summand reconciled by `ring` and the value $(1-r)\\cdot\\dfrac{r(1+r)}{(1-r)^3}=\\dfrac{r(1+r)}{(1-r)^2}$ simplified by `field_simp`."
+    "content": "`geometric_second_moment` proves $E[X^2] = \\sum_n n^2\\,(1-r)\\,r^n = \\dfrac{r(1+r)}{(1-r)^2}$. This is the parent entry's analytic second moment $\\sum_n n^2 r^n = \\dfrac{r(1+r)}{(1-r)^3}$ (`GeometricSeriesOQ07.hasSum_sq_mul_geometric`) scaled by $(1-r)$ via `HasSum.mul_left`, with the summand reconciled by `ring` and the value $(1-r)\\cdot\\dfrac{r(1+r)}{(1-r)^3}=\\dfrac{r(1+r)}{(1-r)^2}$ simplified by `field_simp`.",
+    "mathContext": "$E[X^2]=\\sum_n n^2(1-r)r^n=(1-r)\\cdot\\dfrac{r(1+r)}{(1-r)^3}=\\dfrac{r(1+r)}{(1-r)^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "second moment",
+      "Σ n² rⁿ closed form",
+      "GeometricSeriesOQ07 (parent)",
+      "HasSum.mul_left"
+    ],
+    "prerequisites": [
+      "higher moments of a distribution",
+      "second-order weighted geometric sum"
+    ]
   },
   {
     "id": "geom-rv-variance-identity",
@@ -29,7 +65,18 @@
     "range": { "startLine": 104, "endLine": 108 },
     "type": "theorem",
     "title": "Variance, algebraic form: E[X²] − E[X]² = r/(1−r)²",
-    "content": "`geometric_variance_identity` records the bookkeeping cancellation $\\dfrac{r(1+r)}{(1-r)^2} - \\Big(\\dfrac{r}{1-r}\\Big)^2 = \\dfrac{r}{(1-r)^2}$, i.e. $E[X^2] - E[X]^2 = \\dfrac{r}{(1-r)^2}$. The numerator simplifies as $r(1+r) - r^2 = r$, so the variance is $\\dfrac{r}{(1-r)^2}$ — with $p=1-r$ the textbook $\\mathrm{Var}(X)=\\dfrac{1-p}{p^2}$. A pure field identity, discharged by `field_simp; ring` using $1-r\\neq 0$."
+    "content": "`geometric_variance_identity` records the bookkeeping cancellation $\\dfrac{r(1+r)}{(1-r)^2} - \\Big(\\dfrac{r}{1-r}\\Big)^2 = \\dfrac{r}{(1-r)^2}$, i.e. $E[X^2] - E[X]^2 = \\dfrac{r}{(1-r)^2}$. The numerator simplifies as $r(1+r) - r^2 = r$, so the variance is $\\dfrac{r}{(1-r)^2}$ — with $p=1-r$ the textbook $\\mathrm{Var}(X)=\\dfrac{1-p}{p^2}$. A pure field identity, discharged by `field_simp; ring` using $1-r\\neq 0$.",
+    "mathContext": "$\\dfrac{r(1+r)}{(1-r)^2}-\\dfrac{r^2}{(1-r)^2}=\\dfrac{r(1+r)-r^2}{(1-r)^2}=\\dfrac{r}{(1-r)^2}=\\dfrac{1-p}{p^2}$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "König–Huygens identity Var = E[X²]−E[X]²",
+      "field_simp; ring",
+      "variance of geometric law"
+    ],
+    "prerequisites": [
+      "variance via the second moment",
+      "rational-function algebra"
+    ]
   },
   {
     "id": "geom-rv-variance",
@@ -37,6 +84,18 @@
     "range": { "startLine": 113, "endLine": 138 },
     "type": "theorem",
     "title": "Variance as the centred second moment",
-    "content": "`geometric_variance` proves the honest definition of the variance, $\\sum_n \\big(n - E[X]\\big)^2 (1-r)\\,r^n = \\dfrac{r}{(1-r)^2}$, where $E[X]=\\mu=\\dfrac{r}{1-r}$. Expanding $(n-\\mu)^2 = n^2 - 2\\mu n + \\mu^2$, the centred series is the linear combination $E[X^2] - 2\\mu\\,E[X] + \\mu^2\\cdot 1$ of the second, first and zeroth moment sums, assembled by `HasSum.sub`, `HasSum.add` and `HasSum.mul_left` (no new convergence argument — the three series are summable). The combined summand rewrites to $(n-\\mu)^2 P(n)$ by `ring`, and the combined value $\\dfrac{r(1+r)}{(1-r)^2} - 2\\mu\\cdot\\dfrac{r}{1-r} + \\mu^2 = \\dfrac{r}{(1-r)^2}$ collapses by `field_simp; ring`, agreeing with the algebraic form."
+    "content": "`geometric_variance` proves the honest definition of the variance, $\\sum_n \\big(n - E[X]\\big)^2 (1-r)\\,r^n = \\dfrac{r}{(1-r)^2}$, where $E[X]=\\mu=\\dfrac{r}{1-r}$. Expanding $(n-\\mu)^2 = n^2 - 2\\mu n + \\mu^2$, the centred series is the linear combination $E[X^2] - 2\\mu\\,E[X] + \\mu^2\\cdot 1$ of the second, first and zeroth moment sums, assembled by `HasSum.sub`, `HasSum.add` and `HasSum.mul_left` (no new convergence argument — the three series are summable). The combined summand rewrites to $(n-\\mu)^2 P(n)$ by `ring`, and the combined value $\\dfrac{r(1+r)}{(1-r)^2} - 2\\mu\\cdot\\dfrac{r}{1-r} + \\mu^2 = \\dfrac{r}{(1-r)^2}$ collapses by `field_simp; ring`, agreeing with the algebraic form.",
+    "mathContext": "$\\sum_n (n-\\mu)^2(1-r)r^n = E[X^2]-2\\mu E[X]+\\mu^2 = \\dfrac{r}{(1-r)^2}$, with $\\mu=\\dfrac{r}{1-r}$ — linearity over the second/first/zeroth moments.",
+    "significance": "key",
+    "relatedConcepts": [
+      "centred second moment",
+      "linearity of HasSum (sub/add/mul_left)",
+      "variance definition Σ(n−μ)²P(n)",
+      "summability"
+    ],
+    "prerequisites": [
+      "the three moment sums above",
+      "HasSum algebra (sub, add, mul_left)"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-02` (quality 68, 0 prior passes).

## Gap closed
The entry had 5 detailed annotations (full LaTeX in `content`) and a rich meta.json (7 sections, 4 keyInsights, conclusion, 2 references), but **every annotation was missing the structured metadata fields** `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`.

Added all four to each of the 5 annotations covering the geometric random variable's moments:
- **pmf normalisation** — `Σ (1-r)rⁿ = 1`, the geometric law `P(X=n)=p(1-p)ⁿ`;
- **mean** — `E[X] = r/(1-r) = (1-p)/p`;
- **second moment** — `E[X²] = r(1+r)/(1-r)²`;
- **variance (algebraic)** — `E[X²] - E[X]² = r/(1-r)² = (1-p)/p²`;
- **variance (centred)** — `Σ (n-μ)²(1-r)rⁿ` via `HasSum` linearity over the three moment sums.

All existing content, titles, types, and ranges left unchanged.

## Notes
- Branch `feature/enricher-5-geomrv` to avoid clobbering open PRs.
- JSON validated via `scripts/gallery/check-meta-size.ts` (within caps) and python enum checks. `pnpm build` skipped (no node_modules; JSON-only change).