### PR TITLE
research(erdos-458): repair broken-on-main parse error (VERIFIED clean build)

### DIFF
--- a/proofs/Proofs/Erdos458Problem.lean
+++ b/proofs/Proofs/Erdos458Problem.lean
@@ -194,7 +194,7 @@ between n² and (n+1)².
 def LegendreConjecture : Prop :=
   ∀ n : ℕ, n ≥ 1 → ∃ p : ℕ, p.Prime ∧ n^2 < p ∧ p < (n + 1)^2
 
-/--
+/-
 **Conditional Result**: If Legendre's conjecture holds, the prime gap
 p_{k+1} - p_k is bounded, which helps control the LCM growth.
 -/
@@ -229,7 +229,7 @@ theorem erdos458_conjecture_at_two :
 
 /- ## Asymptotic Perspective -/
 
-/--
+/-
 **Chebyshev's Result**: log(lcm_upto n) ~ n as n → ∞
 
 This means lcm_upto n ≈ e^n asymptotically. The conjecture essentially

--- a/src/data/proofs/erdos-458/meta.json
+++ b/src/data/proofs/erdos-458/meta.json
@@ -22,8 +22,8 @@
     "erdosUrl": "https://erdosproblems.com/458",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 237,
-    "assumptions": "1 axiom: `Lean.ofReduceBool`. There are 0 literal `axiom` declarations and 0 sorries, but the credited small-value theorems (lcm_upto_two/three/four/five/six) and the verified small cases erdos458_k1/erdos458_k2 are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` to `#print axioms`; per the project's native_decide policy these credited theorems are counted in meta.axiomCount. The concrete prime-value theorems (nthPrime_zero..four) are proved from the `Nat.nth Nat.Prime` definition via `Nat.nth_count` with kernel `decide` (NOT native_decide), so they add no `Lean.ofReduceBool` dependency. The ordinary foundational axioms propext / Classical.choice / Quot.sound are not counted. Open conjecture; supporting lemmas verified (free of mathematical axioms, depending only on `Lean.ofReduceBool` via native_decide).",
+    "lineCount": 239,
+    "assumptions": "1 axiom: `Lean.ofReduceBool` (with `Lean.trustCompiler`). There are 0 literal `axiom` declarations and 0 sorries, but the credited small-value theorems (lcm_upto_two/three/four/five/six) and the verified small cases erdos458_k1/erdos458_k2 are discharged by `native_decide`, which trusts the Lean compiler's kernel reduction and so adds `Lean.ofReduceBool` (and `Lean.trustCompiler`) to `#print axioms`; per the project's native_decide policy these credited theorems are counted in meta.axiomCount. The concrete prime-value theorems (nthPrime_zero..four) are proved from the `Nat.nth Nat.Prime` definition via `Nat.nth_count` with kernel `decide` (NOT native_decide), so they add no `Lean.ofReduceBool` dependency. The ordinary foundational axioms propext / Classical.choice / Quot.sound are not counted. Open conjecture; supporting lemmas verified (free of mathematical axioms, depending only on `Lean.ofReduceBool` via native_decide).",
     "mathlib_version": "4.26.0",
     "theoremCount": 21,
     "definitionCount": 4
@@ -109,11 +109,11 @@
       "Nat"
     ],
     "namespace": "Erdos458",
-    "lineCount": 176,
+    "lineCount": 239,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 4,
-    "theoremCount": 14
+    "theoremCount": 21
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

`proofs/Proofs/Erdos458Problem.lean` (Erdős Problem #458, LCM inequality for primes) was merged **UNVERIFIED** in #30740 while the build host was down, and **did not parse** against Mathlib v4.26.0.

Two free-floating `/-- … -/` doc comments — the "Conditional Result" prose block and the "Chebyshev's Result" prose block — were not attached to any declaration, which is a parse error in Lean 4:

```
Proofs/Erdos458Problem.lean:200:2: error: unexpected token '/--'; expected 'lemma'
Proofs/Erdos458Problem.lean:237:2: error: unexpected token 'end'; expected 'lemma'
```

## Fix

Converted both orphan doc comments to plain `/- … -/` block comments (same dangling-`/--` pattern seen previously in the Puiseux parent file).

## Verification

`lake env lean Proofs/Erdos458Problem.lean` → exit 0, **no errors, no `sorryAx`**.

`#print axioms`:
- `nthPrime_zero..four`: `[propext, Classical.choice, Quot.sound]` — concrete prime values are axiom-clean (proved from `Nat.nth Nat.Prime` via `Nat.nth_count` + kernel `decide`, **not** `native_decide`).
- `erdos458_k1`/`erdos458_k2` (verified small cases): additionally carry `Lean.ofReduceBool` / `Lean.trustCompiler` via `native_decide` — pre-existing and already disclosed in `meta.json`.

## meta.json

- Refreshed stale `leanFile` stats: `lineCount` 176→239, `theoremCount` 14→21 (these predated #30740's `nthPrime` additions).
- Noted `Lean.trustCompiler` alongside `Lean.ofReduceBool` in `assumptions`.
- `axiomCount` unchanged (1); status remains `axiomatized` (open conjecture, supporting lemmas verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)