### PR TITLE
research(ballot-problem-oq-02-oq-03): arcsine density = CDF derivative + FTC normalization [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -299,6 +299,7 @@ import Proofs.BallotProblemOQ01OQ04OQ01
 import Proofs.BallotProblemOQ02
 import Proofs.BallotProblemOQ02OQ02
 import Proofs.BallotProblemOQ02OQ02OQ05
+import Proofs.BallotProblemOQ02OQ03
 import Proofs.BallotProblemOQ02OQ05
 import Proofs.BallotProblemOQ03
 import Proofs.BallotProblemOQ03OQ01OQ01

--- a/proofs/Proofs/BallotProblemOQ02OQ03.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ03.lean
@@ -1,0 +1,216 @@
+import Mathlib
+
+/-
+# The Arcsine Law — density, derivative, and FTC normalization
+
+## Research Problem: ballot-problem-oq-02-oq-03
+"Arcsine Law Axiomatization in Lean."
+
+## Context
+
+Lévy's Arcsine Law is the continuous-time culmination of the ballot problem.
+For a standard Brownian motion on `[0, 1]`, the occupation time of the positive
+half-line, the time of the maximum, and the time of the last zero all share the
+**arcsine distribution** on `[0, 1]`, with cumulative distribution function
+
+      F(x) = (2/π) · arcsin(√x),        x ∈ [0, 1],
+
+and density
+
+      f(x) = 1 / (π · √(x(1-x))),       x ∈ (0, 1).
+
+The graduated sibling `BallotProblemOQ02OQ04.lean` ("The Arcsine Distribution:
+verified core") establishes the *static* analytic facts about `F` and `f`:
+the endpoints `F 0 = 0`, `F 1 = 1`, the median `F (1/2) = 1/2`, monotonicity,
+the reflection symmetry `F x + F (1-x) = 1`, and the U-shape of `f`. In that file
+the density `f` and the CDF `F` are introduced as *separate* objects, and the
+fundamental link between them — that `f` is the derivative of `F`, hence that `f`
+integrates to the total probability mass `1` — is left unproved.
+
+## What this file adds (0 sorries, 0 axioms)
+
+This file supplies exactly that missing link, axiom-free:
+
+  * `arcsineCDF_hasDerivAt`        : `F' x = f x` for `x ∈ (0,1)` — the density is the
+                                     genuine derivative of the CDF (chain rule through
+                                     `Real.arcsin` and `Real.sqrt`);
+  * `arcsineDensity_continuousOn`  : `f` is continuous on every `[a,b] ⊂ (0,1)`;
+  * `arcsineDensity_intervalIntegral`
+                                   : `∫ x in a..b, f x = F b - F a` for `0 < a ≤ b < 1`
+                                     (Fundamental Theorem of Calculus);
+  * `arcsineCDF_continuous`        : `F` is continuous on all of `ℝ`;
+  * `arcsineDensity_symmetric_integral_tendsto_one`
+                                   : the symmetric exhausting integral
+                                     `∫ x in a..(1-a), f x → 1` as `a → 0⁺`.
+
+The last theorem is the **total-mass normalization**: it certifies that `f` is a
+genuine probability density — its (improper) integral over `(0,1)` equals `1` —
+obtained as the limit of the proper integrals over `[a, 1-a]` via the FTC and the
+continuity of `F` at the endpoints. The density itself is unbounded at `0` and `1`,
+so this is a genuinely improper integral; the symmetric exhaustion `[a, 1-a] ↑ (0,1)`
+is the standard way to make sense of it.
+
+The fully probabilistic statement (that these analytic facts describe the law of the
+occupation time of an actual Brownian motion) requires Brownian local-time theory,
+which Mathlib v4.26.0 does not yet contain; the parent `BallotProblemOQ02.lean`
+axiomatizes the Brownian-motion facts it needs. This file commits to no such axioms.
+
+## References
+- Lévy (1939): *Sur certains processus stochastiques homogènes*.
+- Karatzas–Shreve (1991): *Brownian Motion and Stochastic Calculus*, §6.3.
+- Mörters–Peres (2010): *Brownian Motion*, §5.2 and Thm 5.28.
+-/
+
+namespace ArcsineLawDensity
+
+open Real Set intervalIntegral
+open scoped Topology
+
+/-- The cumulative distribution function of the arcsine law on `[0,1]`:
+    `F(x) = (2/π) · arcsin(√x)`. -/
+noncomputable def arcsineCDF (x : ℝ) : ℝ := (2 / π) * arcsin (Real.sqrt x)
+
+/-- The arcsine density on `(0,1)`: `f(x) = 1 / (π · √(x(1-x)))`. -/
+noncomputable def arcsineDensity (x : ℝ) : ℝ := 1 / (π * Real.sqrt (x * (1 - x)))
+
+/-! ### The density is the derivative of the CDF -/
+
+/-- **The fundamental link**: on the open interval `(0,1)` the arcsine density `f`
+    is the derivative of the arcsine CDF `F`. This is the chain rule applied to
+    `F = (2/π) · arcsin ∘ √`, with `(arcsin)'(√x) = 1/√(1-x)` and `(√)'(x) = 1/(2√x)`,
+    recombined via `√x · √(1-x) = √(x(1-x))`. -/
+theorem arcsineCDF_hasDerivAt {x : ℝ} (hx0 : 0 < x) (hx1 : x < 1) :
+    HasDerivAt arcsineCDF (arcsineDensity x) x := by
+  have hxne : x ≠ 0 := ne_of_gt hx0
+  have hsqx_nonneg : (0 : ℝ) ≤ Real.sqrt x := Real.sqrt_nonneg x
+  have hsqx_pos : (0 : ℝ) < Real.sqrt x := Real.sqrt_pos.mpr hx0
+  -- `√x ≠ 1` because `x < 1`, and `√x ≠ -1` because `√x ≥ 0`.
+  have hsx_ne_one : Real.sqrt x ≠ 1 := by
+    intro h
+    have : x = 1 := by
+      have := Real.sq_sqrt hx0.le
+      rw [h] at this; simpa using this.symm
+    exact (ne_of_lt hx1) this
+  have hsx_ne_negone : Real.sqrt x ≠ -1 := by
+    intro h; rw [h] at hsqx_nonneg; norm_num at hsqx_nonneg
+  -- Derivative of `arcsin` at `√x`.
+  have harcsin : HasDerivAt arcsin (1 / Real.sqrt (1 - (Real.sqrt x) ^ 2)) (Real.sqrt x) :=
+    Real.hasDerivAt_arcsin hsx_ne_negone hsx_ne_one
+  -- Derivative of `√` at `x`.
+  have hsqrt : HasDerivAt (fun y => Real.sqrt y) (1 / (2 * Real.sqrt x)) x :=
+    Real.hasDerivAt_sqrt hxne
+  -- Compose, then scale by `2/π`.
+  have hcomp := harcsin.comp x hsqrt
+  have hscaled := hcomp.const_mul (2 / π)
+  -- `arcsineCDF` is definitionally `(2/π) * (arcsin ∘ √)`.
+  have hfun : arcsineCDF = fun y => (2 / π) * (arcsin ∘ fun y => Real.sqrt y) y := by
+    funext y; simp [arcsineCDF, Function.comp]
+  rw [hfun]
+  -- Now identify the derivative value with `arcsineDensity x`.
+  convert hscaled using 1
+  -- Goal: arcsineDensity x = (2/π) * ((1/√(1-(√x)^2)) * (1/(2√x)))
+  have hsq : (Real.sqrt x) ^ 2 = x := Real.sq_sqrt hx0.le
+  rw [hsq]
+  have h1x : (0 : ℝ) < 1 - x := by linarith
+  have hs1x_pos : (0 : ℝ) < Real.sqrt (1 - x) := Real.sqrt_pos.mpr h1x
+  have hpi : (0 : ℝ) < π := Real.pi_pos
+  have hprod : Real.sqrt (x * (1 - x)) = Real.sqrt x * Real.sqrt (1 - x) :=
+    Real.sqrt_mul hx0.le _
+  rw [arcsineDensity, hprod]
+  field_simp
+
+/-! ### Continuity and interval integrability of the density -/
+
+/-- The density `f` is continuous on every closed subinterval `[a,b] ⊂ (0,1)`.
+    (It blows up at the endpoints `0` and `1`, so global continuity fails there.) -/
+theorem arcsineDensity_continuousOn {a b : ℝ} (ha : 0 < a) (hab : a ≤ b) (hb : b < 1) :
+    ContinuousOn arcsineDensity (uIcc a b) := by
+  have huIcc : uIcc a b = Icc a b := Set.uIcc_of_le hab
+  rw [huIcc]
+  apply ContinuousOn.div continuousOn_const
+  · -- `x ↦ π * √(x(1-x))` is continuous
+    exact continuousOn_const.mul
+      ((Real.continuous_sqrt.comp
+        (continuous_id.mul (continuous_const.sub continuous_id))).continuousOn)
+  · -- and nonzero on `[a,b]`, since `x(1-x) > 0` there
+    intro x hx
+    obtain ⟨hxa, hxb⟩ := hx
+    have hx0 : 0 < x := lt_of_lt_of_le ha hxa
+    have hx1 : x < 1 := lt_of_le_of_lt hxb hb
+    have hpos : 0 < x * (1 - x) := mul_pos hx0 (by linarith)
+    have : 0 < Real.sqrt (x * (1 - x)) := Real.sqrt_pos.mpr hpos
+    positivity
+
+/-- The density `f` is interval-integrable on every `[a,b] ⊂ (0,1)`. -/
+theorem arcsineDensity_intervalIntegrable {a b : ℝ} (ha : 0 < a) (hab : a ≤ b) (hb : b < 1) :
+    IntervalIntegrable arcsineDensity MeasureTheory.volume a b :=
+  (arcsineDensity_continuousOn ha hab hb).intervalIntegrable
+
+/-! ### Fundamental Theorem of Calculus on subintervals -/
+
+/-- **FTC for the arcsine law**: on any `[a,b] ⊂ (0,1)`, the integral of the density
+    recovers the increment of the CDF, `∫ₐᵇ f = F b - F a`. -/
+theorem arcsineDensity_intervalIntegral {a b : ℝ}
+    (ha : 0 < a) (hab : a ≤ b) (hb : b < 1) :
+    ∫ x in a..b, arcsineDensity x = arcsineCDF b - arcsineCDF a := by
+  apply intervalIntegral.integral_eq_sub_of_hasDerivAt
+  · intro x hx
+    rw [Set.uIcc_of_le hab] at hx
+    obtain ⟨hxa, hxb⟩ := hx
+    exact arcsineCDF_hasDerivAt (lt_of_lt_of_le ha hxa) (lt_of_le_of_lt hxb hb)
+  · exact arcsineDensity_intervalIntegrable ha hab hb
+
+/-! ### Continuity of the CDF and total-mass normalization -/
+
+/-- The CDF `F = (2/π)·arcsin(√·)` is continuous on all of `ℝ`
+    (`Real.arcsin` and `Real.sqrt` are continuous everywhere). -/
+theorem arcsineCDF_continuous : Continuous arcsineCDF := by
+  unfold arcsineCDF
+  exact continuous_const.mul (Real.continuous_arcsin.comp Real.continuous_sqrt)
+
+@[simp] theorem arcsineCDF_zero : arcsineCDF 0 = 0 := by
+  simp [arcsineCDF]
+
+@[simp] theorem arcsineCDF_one : arcsineCDF 1 = 1 := by
+  rw [arcsineCDF, Real.sqrt_one, Real.arcsin_one]
+  field_simp
+
+/-- **Total-mass normalization (improper integral).** The density `f` is unbounded at
+    `0` and `1`, but its symmetric exhausting integral over `[a, 1-a]` converges to the
+    total probability mass `1` as `a → 0⁺`:
+
+        `∫ x in a..(1-a), f x  →  1`.
+
+    This certifies `f` as a genuine probability density of a law supported on `[0,1]`.
+    The proof combines the FTC increment `F (1-a) - F a` with the continuity of `F` at
+    the endpoints (`F 0 = 0`, `F 1 = 1`). -/
+theorem arcsineDensity_symmetric_integral_tendsto_one :
+    Filter.Tendsto (fun a => ∫ x in a..(1 - a), arcsineDensity x)
+      (𝓝[>] 0) (𝓝 1) := by
+  -- On `(0, 1/2)` the symmetric integral equals `F (1-a) - F a`.
+  have hEq : (fun a => ∫ x in a..(1 - a), arcsineDensity x)
+      =ᶠ[𝓝[>] 0] (fun a => arcsineCDF (1 - a) - arcsineCDF a) := by
+    have hmem : Set.Ioo (0 : ℝ) (1 / 2) ∈ 𝓝[>] (0 : ℝ) := by
+      rw [← Set.Ioi_inter_Iio]
+      exact Filter.inter_mem self_mem_nhdsWithin
+        (mem_nhdsWithin_of_mem_nhds (Iio_mem_nhds (by norm_num)))
+    filter_upwards [hmem] with a ha
+    obtain ⟨ha0, ha2⟩ := ha
+    exact arcsineDensity_intervalIntegral ha0 (by linarith) (by linarith)
+  rw [Filter.tendsto_congr' hEq]
+  -- `F (1-a) - F a → F 1 - F 0 = 1 - 0 = 1` by continuity of `F`.
+  have hlim : Filter.Tendsto (fun a => arcsineCDF (1 - a) - arcsineCDF a)
+      (𝓝[>] 0) (𝓝 (arcsineCDF 1 - arcsineCDF 0)) := by
+    apply Filter.Tendsto.mono_left _ nhdsWithin_le_nhds
+    have h1 : Filter.Tendsto (fun a : ℝ => arcsineCDF (1 - a)) (𝓝 0) (𝓝 (arcsineCDF 1)) := by
+      have hsub : Filter.Tendsto (fun a : ℝ => (1 : ℝ) - a) (𝓝 0) (𝓝 1) := by
+        have hc : Continuous (fun a : ℝ => (1 : ℝ) - a) := continuous_const.sub continuous_id
+        simpa using hc.tendsto 0
+      exact (arcsineCDF_continuous.tendsto 1).comp hsub
+    have h2 : Filter.Tendsto (fun a : ℝ => arcsineCDF a) (𝓝 0) (𝓝 (arcsineCDF 0)) :=
+      arcsineCDF_continuous.tendsto 0
+    exact h1.sub h2
+  rw [arcsineCDF_one, arcsineCDF_zero] at hlim
+  simpa using hlim
+
+end ArcsineLawDensity

--- a/src/data/proofs/ballot-problem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "ballot-problem-oq-02-oq-03",
+    "range": { "startLine": 3, "endLine": 62 },
+    "type": "context",
+    "title": "Scope: Closing the Density↔CDF Gap of the Arcsine Law",
+    "content": "The docstring states Lévy's Arcsine Law and explains the precise purpose of this entry. The graduated sibling ballot-problem-oq-02-oq-04 proved the static analytic facts about the arcsine CDF F(x)=(2/π)·arcsin(√x) and density f(x)=1/(π√(x(1−x))) — endpoints, median, monotonicity, reflection symmetry, U-shape — but introduced F and f as separate objects and left their connection (that f is the derivative of F, hence integrates to 1) as an explicit open question. This file supplies that link, axiom-free, using only Mathlib's existing derivative and interval-integral machinery. The fully probabilistic statement still needs Brownian local-time theory absent from Mathlib v4.26.0; this entry adds no axioms.",
+    "mathContext": "$F(x) = \\tfrac{2}{\\pi}\\arcsin\\sqrt{x}$, $f(x) = \\dfrac{1}{\\pi\\sqrt{x(1-x)}}$; goal: $F' = f$ on $(0,1)$ and $\\int_0^1 f = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Lévy's arcsine law", "probability density vs CDF", "fundamental theorem of calculus", "improper integral", "ballot problem"],
+    "prerequisites": ["the statement of the arcsine law", "the relationship between a density and its CDF"]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "ballot-problem-oq-02-oq-03",
+    "range": { "startLine": 64, "endLine": 74 },
+    "type": "definition",
+    "title": "The Arcsine CDF and Density (arcsineCDF, arcsineDensity)",
+    "content": "arcsineCDF x = (2/π)·arcsin(√x) and arcsineDensity x = 1/(π·√(x(1−x))) are restated self-contained in namespace ArcsineLawDensity so this entry verifies independently of the sibling file. Both are noncomputable (built from Real.arcsin and Real.sqrt). The whole file is the analytic statement that the second is the derivative of the first.",
+    "mathContext": "$\\mathrm{arcsineCDF}(x) = \\tfrac{2}{\\pi}\\arcsin\\sqrt{x}$, $\\mathrm{arcsineDensity}(x) = \\dfrac{1}{\\pi\\sqrt{x(1-x)}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.arcsin", "Real.sqrt", "noncomputable definitions"],
+    "prerequisites": ["the inverse sine function", "what a probability density is"]
+  },
+  {
+    "id": "ann-derivative",
+    "proofId": "ballot-problem-oq-02-oq-03",
+    "range": { "startLine": 76, "endLine": 121 },
+    "type": "theorem",
+    "title": "The Density is the Derivative of the CDF (arcsineCDF_hasDerivAt)",
+    "content": "The keystone result: for 0<x<1, HasDerivAt arcsineCDF (arcsineDensity x) x. The proof is the chain rule. Real.hasDerivAt_arcsin gives (arcsin)'(√x)=1/√(1−(√x)²), valid since √x≠1 (as x<1) and √x≠−1 (as √x≥0); Real.hasDerivAt_sqrt gives (√)'(x)=1/(2√x), valid since x≠0. HasDerivAt.comp composes them and HasDerivAt.const_mul scales by 2/π. The resulting derivative value is matched to arcsineDensity x by rewriting (√x)²=x (so √(1−(√x)²)=√(1−x)), combining √x·√(1−x)=√(x(1−x)) via Real.sqrt_mul, and clearing denominators with field_simp. This is precisely the antiderivative relation the sibling entry was missing — it is what makes f the density OF F rather than a second unrelated formula.",
+    "mathContext": "$F'(x) = \\tfrac{2}{\\pi}\\cdot\\dfrac{1}{\\sqrt{1-x}}\\cdot\\dfrac{1}{2\\sqrt{x}} = \\dfrac{1}{\\pi\\sqrt{x}\\sqrt{1-x}} = \\dfrac{1}{\\pi\\sqrt{x(1-x)}} = f(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.hasDerivAt_arcsin", "Real.hasDerivAt_sqrt", "HasDerivAt.comp (chain rule)", "Real.sqrt_mul", "antiderivative"],
+    "prerequisites": ["the chain rule", "derivatives of arcsin and sqrt", "(√x)² = x for x ≥ 0"]
+  },
+  {
+    "id": "ann-continuity-integrability",
+    "proofId": "ballot-problem-oq-02-oq-03",
+    "range": { "startLine": 122, "endLine": 148 },
+    "type": "theorem",
+    "title": "Continuity and Interval Integrability of the Density (arcsineDensity_continuousOn, arcsineDensity_intervalIntegrable)",
+    "content": "arcsineDensity_continuousOn shows f is continuous on every closed subinterval [a,b]⊂(0,1): it is ContinuousOn.div of the constant 1 by π·√(x(1−x)), whose denominator is continuous and strictly positive there because x(1−x)>0 for x∈(0,1) (so its square root is positive and the whole denominator nonzero — discharged by positivity). arcsineDensity_intervalIntegrable then upgrades continuity on the closed interval to interval-integrability via ContinuousOn.intervalIntegrable. Restricting to closed subintervals is essential: f is unbounded as x→0 or x→1, so it is NOT integrable on all of [0,1] in the proper sense.",
+    "mathContext": "On $[a,b]\\subset(0,1)$: $x(1-x) \\ge \\min(a(1-a), b(1-b)) > 0$, so $f$ is bounded and continuous, hence integrable.",
+    "significance": "supporting",
+    "relatedConcepts": ["ContinuousOn.div", "ContinuousOn.intervalIntegrable", "Real.sqrt_pos", "positivity"],
+    "prerequisites": ["continuity of quotients with nonvanishing denominator", "continuous functions are integrable on compact intervals"]
+  },
+  {
+    "id": "ann-ftc",
+    "proofId": "ballot-problem-oq-02-oq-03",
+    "range": { "startLine": 149, "endLine": 162 },
+    "type": "theorem",
+    "title": "Fundamental Theorem of Calculus on Subintervals (arcsineDensity_intervalIntegral)",
+    "content": "arcsineDensity_intervalIntegral proves ∫ₐᵇ f = F(b)−F(a) for 0<a≤b<1, by intervalIntegral.integral_eq_sub_of_hasDerivAt. The two hypotheses it requires are exactly the previous results: the pointwise derivative identity arcsineCDF_hasDerivAt holds at every x in uIcc a b = [a,b] (each such x lies in (0,1)), and arcsineDensity_intervalIntegrable supplies the integrability of the derivative. Because the integral is over a closed subinterval where f is bounded, this is a proper integral and the classical FTC applies directly.",
+    "mathContext": "$\\displaystyle\\int_a^b \\frac{dx}{\\pi\\sqrt{x(1-x)}} = \\frac{2}{\\pi}\\big(\\arcsin\\sqrt{b} - \\arcsin\\sqrt{a}\\big) = F(b) - F(a).$",
+    "significance": "key",
+    "relatedConcepts": ["intervalIntegral.integral_eq_sub_of_hasDerivAt", "fundamental theorem of calculus", "uIcc"],
+    "prerequisites": ["the FTC in HasDerivAt form", "interval integrals"]
+  },
+  {
+    "id": "ann-normalization",
+    "proofId": "ballot-problem-oq-02-oq-03",
+    "range": { "startLine": 163, "endLine": 215 },
+    "type": "theorem",
+    "title": "Total-Mass Normalization via Symmetric Exhaustion (arcsineCDF_continuous, arcsineDensity_symmetric_integral_tendsto_one)",
+    "content": "Because f diverges at both endpoints, its total integral over (0,1) is improper and cannot be obtained from the FTC on [0,1] directly. arcsineCDF_continuous establishes that F=(2/π)·arcsin(√·) is continuous on all of ℝ (arcsin and sqrt are continuous everywhere — even where f blows up), and the simp lemmas arcsineCDF_zero/arcsineCDF_one record F(0)=0, F(1)=1. The capstone arcsineDensity_symmetric_integral_tendsto_one then proves ∫ over [a,1−a] of f → 1 as a→0⁺: on (0,1/2) the integral equals the FTC increment F(1−a)−F(a) (an eventuallyEq on the filter 𝓝[>]0, transferred with Tendsto.congr'), and by continuity of F at the endpoints F(1−a)−F(a) → F(1)−F(0) = 1−0 = 1. This certifies f as a genuine probability density: its improper integral over (0,1) is the total mass 1.",
+    "mathContext": "$\\displaystyle\\lim_{a\\to 0^+}\\int_a^{1-a} f = \\lim_{a\\to 0^+}\\big(F(1-a)-F(a)\\big) = F(1)-F(0) = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["improper integral", "symmetric exhaustion", "Filter.Tendsto.congr'", "nhdsWithin", "Continuous.tendsto"],
+    "prerequisites": ["limits of functions / filters", "continuity at the endpoints", "improper integral as a limit of proper integrals"]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-03/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "ballot-problem-oq-02-oq-03",
+  "slug": "ballot-problem-oq-02-oq-03",
+  "title": "The Arcsine Law: density, derivative, and FTC normalization",
+  "description": "A self-contained, axiom-free Lean formalization that supplies the calculus link missing from the arcsine CDF entry: the arcsine density f(x)=1/(π√(x(1-x))) is the derivative of the CDF F(x)=(2/π)·arcsin(√x) on (0,1), f is continuous and interval-integrable on every [a,b]⊂(0,1), the FTC gives ∫ₐᵇ f = F(b)−F(a), and the symmetric improper integral ∫ over [a,1−a] tends to the total probability mass 1 as a→0⁺. This answers the open question raised by the sibling entry ballot-problem-oq-02-oq-04.",
+  "meta": {
+    "author": "Lévy (1939); formalization: Lean Genius researcher",
+    "sourceUrl": "http://www.numdam.org/item/CM_1940__7__283_0/",
+    "date": "1939",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/BallotProblemOQ02OQ03.lean",
+    "tags": [
+      "probability",
+      "arcsine-law",
+      "brownian-motion",
+      "ballot-problem",
+      "distribution",
+      "real-analysis",
+      "calculus",
+      "fundamental-theorem-of-calculus",
+      "research"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "scope": "Formalizes the calculus relating the arcsine density and CDF: the derivative identity F'=f on (0,1), continuity/interval-integrability of f on closed subintervals, the FTC increment ∫ₐᵇ f = F(b)−F(a), and the total-mass normalization as the limit of symmetric proper integrals. The full probabilistic statement (that f is the law of a Brownian occupation time) still requires Brownian local-time theory, absent from Mathlib v4.26.0; this entry adds no axioms. The density is genuinely unbounded at the endpoints, so the total mass is an improper integral handled by symmetric exhaustion."
+  },
+  "overview": {
+    "text": "The graduated sibling ballot-problem-oq-02-oq-04 ('The Arcsine Distribution: verified core') established the static analytic facts about the arcsine CDF F(x)=(2/π)·arcsin(√x) and density f(x)=1/(π√(x(1−x))): endpoints, median, monotonicity, reflection symmetry, U-shaped density. But in that file F and f were introduced as separate objects and never connected — the fundamental fact that f is the derivative of F (and hence that f integrates to total mass 1) was explicitly left as an open question. This entry supplies exactly that link, axiom-free. It proves the chain-rule derivative identity F'(x)=f(x) on (0,1) (differentiating (2/π)·arcsin∘√ and recombining √x·√(1−x)=√(x(1−x))), the continuity and interval-integrability of f on every closed subinterval [a,b]⊂(0,1), the Fundamental Theorem of Calculus increment ∫ₐᵇ f = F(b)−F(a), and finally the total-mass normalization: the symmetric exhausting integral ∫ over [a,1−a] tends to 1 as a→0⁺, certifying f as a genuine probability density. The density is unbounded at the endpoints, so the total mass is necessarily an improper integral, obtained here as a limit of the proper FTC increments via the continuity of F at 0 and 1.",
+    "historicalContext": "The discrete ballot problem (Bertrand 1887, Whitworth) is the combinatorial seed of fluctuation theory; Paul Lévy's 1939 memoir *Sur certains processus stochastiques homogènes* (Compositio Mathematica 7, 283–339) discovered its continuous-time limit, the arcsine law for Brownian motion. The arcsine density 1/(π√(x(1−x))) is the textbook example of a probability density that is unbounded yet integrable, with total integral 1 — the integral ∫₀¹ dx/(π√(x(1−x))) = 1 being the substitution x=sin²θ in disguise, the same substitution that makes (2/π)arcsin√x the antiderivative. Tying density to CDF by the Fundamental Theorem of Calculus is the routine analytic step textbooks gloss; doing it formally for a density that diverges at both endpoints requires the improper-integral care this entry provides.",
+    "problemStatement": "Given the arcsine CDF F(x)=(2/π)·arcsin(√x) and density f(x)=1/(π√(x(1−x))), prove inside Mathlib that f is the derivative of F on the open interval (0,1), that f is integrable on closed subintervals, that the Fundamental Theorem of Calculus yields ∫ₐᵇ f = F(b)−F(a) for 0<a≤b<1, and that the (improper) total integral of f over (0,1) equals 1.",
+    "proofStrategy": "The derivative identity arcsineCDF_hasDerivAt is the chain rule: HasDerivAt arcsin (1/√(1−x²)) (via Real.hasDerivAt_arcsin) composed with HasDerivAt √ (1/(2√x)) (Real.hasDerivAt_sqrt) at the point √x, then scaled by 2/π. Evaluating arcsin's derivative at √x uses (√x)²=x to turn √(1−(√x)²) into √(1−x); the value is matched to arcsineDensity x via Real.sqrt_mul (√x·√(1−x)=√(x(1−x))) and field_simp. Continuity on [a,b] is ContinuousOn.div of constant by π·√(x(1−x)), whose denominator is positive (hence nonzero) because x(1−x)>0 on (0,1); ContinuousOn.intervalIntegrable then gives integrability. The FTC increment arcsineDensity_intervalIntegral is intervalIntegral.integral_eq_sub_of_hasDerivAt, fed the pointwise derivative on the interval and the integrability hypothesis. The total-mass theorem rewrites ∫ over [a,1−a] as F(1−a)−F(a) (FTC, valid for a∈(0,1/2) via an eventuallyEq on 𝓝[>]0) and takes a→0⁺: by continuity of F (arcsineCDF_continuous, since arcsin∘√ is continuous everywhere), F(1−a)−F(a)→F(1)−F(0)=1−0=1.",
+    "keyInsights": [
+      "**The antiderivative relation is the missing keystone**: the sibling entry proved F is a CDF and f is U-shaped but never connected them. F'(x)=f(x) is what makes f the density OF F; without it the two objects are merely two formulas that happen to share a name.",
+      "**The total mass is genuinely improper**: f(x)=1/(π√(x(1−x))) diverges at both 0 and 1, so ∫₀¹ f is not a proper Riemann/Bochner integral. Proving normalization therefore cannot use the FTC directly on [0,1]; it must exhaust (0,1) by closed subintervals and pass to the limit, which is exactly the symmetric-integral construction here.",
+      "**Continuity of F bridges the improper limit**: because F=(2/π)arcsin(√·) is continuous on all of ℝ (arcsin and sqrt are continuous everywhere, even where f blows up), the FTC increments F(1−a)−F(a) converge to F(1)−F(0)=1 with no extra estimate — the singular density is tamed entirely through its (bounded, continuous) antiderivative.",
+      "**√x·√(1−x)=√(x(1−x)) is the algebraic hinge**: the chain rule produces the derivative as a product of two reciprocal square roots, while the density is written with a single square root of the product; Real.sqrt_mul (valid since x≥0) is what reconciles the two forms.",
+      "**Answers a stated open question**: ballot-problem-oq-02-oq-04 explicitly listed 'prove that the density f integrates to 1 and that F is its antiderivative (F'(x)=f(x) on (0,1))' as future work. This entry closes it, axiom-free, entirely within Mathlib's existing derivative and interval-integral framework."
+    ],
+    "prerequisites": [
+      "Real.hasDerivAt_arcsin (derivative 1/√(1−x²)) and Real.hasDerivAt_sqrt (derivative 1/(2√x))",
+      "HasDerivAt.comp (chain rule) and HasDerivAt.const_mul (scalar multiple)",
+      "intervalIntegral.integral_eq_sub_of_hasDerivAt (Fundamental Theorem of Calculus) and ContinuousOn.intervalIntegrable",
+      "Filter limits / nhdsWithin and Tendsto.congr' for the improper (symmetric-exhaustion) integral",
+      "Real.sqrt facts: sq_sqrt, sqrt_mul, sqrt_pos; continuity of arcsin and sqrt"
+    ]
+  },
+  "references": [
+    {
+      "title": "Sur certains processus stochastiques homogènes",
+      "author": "Paul Lévy",
+      "year": "1939",
+      "note": "Original arcsine law for Brownian motion occupation/last-zero/argmax times."
+    },
+    {
+      "title": "Brownian Motion and Stochastic Calculus, §6.3",
+      "author": "Karatzas, Shreve",
+      "year": "1991",
+      "note": "Arcsine laws via local times and the reflection principle."
+    },
+    {
+      "title": "Brownian Motion, §5.2 & Thm 5.28",
+      "author": "Mörters, Peres",
+      "year": "2010",
+      "note": "Local times and the arcsine law derivation."
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation and Scope",
+      "startLine": 3,
+      "endLine": 62,
+      "summary": "States Lévy's Arcsine Law, the CDF F and density f, and explains that the graduated sibling oq-02-oq-04 proved the static analytic facts but left the density↔CDF link (derivative, normalization) as future work. Lists exactly what this file adds and honestly scopes out the probabilistic local-time derivation absent from Mathlib v4.26.0."
+    },
+    {
+      "id": "definitions",
+      "title": "The Arcsine CDF and Density",
+      "startLine": 64,
+      "endLine": 74,
+      "summary": "arcsineCDF x = (2/π)·arcsin(√x) and arcsineDensity x = 1/(π·√(x(1−x))), restated self-contained in namespace ArcsineLawDensity so the entry verifies independently of the sibling file. Both noncomputable."
+    },
+    {
+      "id": "derivative",
+      "title": "The Density is the Derivative of the CDF",
+      "startLine": 76,
+      "endLine": 121,
+      "summary": "arcsineCDF_hasDerivAt: for 0<x<1, HasDerivAt arcsineCDF (arcsineDensity x) x. The chain rule through Real.hasDerivAt_arcsin (at √x, needing √x≠±1) and Real.hasDerivAt_sqrt (at x≠0), scaled by 2/π; the derivative value is identified with the density via (√x)²=x, Real.sqrt_mul, and field_simp. This is the fundamental link the sibling entry lacked."
+    },
+    {
+      "id": "continuity-integrability",
+      "title": "Continuity and Interval Integrability of the Density",
+      "startLine": 122,
+      "endLine": 148,
+      "summary": "arcsineDensity_continuousOn: f is continuous on every [a,b]⊂(0,1) (ContinuousOn.div with denominator π·√(x(1−x))>0 since x(1−x)>0 there). arcsineDensity_intervalIntegrable: continuity on the closed interval yields interval-integrability, the hypothesis the FTC needs."
+    },
+    {
+      "id": "ftc",
+      "title": "Fundamental Theorem of Calculus on Subintervals",
+      "startLine": 149,
+      "endLine": 162,
+      "summary": "arcsineDensity_intervalIntegral: for 0<a≤b<1, ∫ₐᵇ f = F(b)−F(a), via intervalIntegral.integral_eq_sub_of_hasDerivAt fed the pointwise derivative identity on the interval and the integrability lemma. The density on the closed subinterval is bounded, so this is a proper integral."
+    },
+    {
+      "id": "normalization",
+      "title": "Continuity of the CDF and Total-Mass Normalization",
+      "startLine": 163,
+      "endLine": 215,
+      "summary": "arcsineCDF_continuous (F is continuous on ℝ) plus the endpoint values F(0)=0, F(1)=1 drive arcsineDensity_symmetric_integral_tendsto_one: the symmetric improper integral ∫ over [a,1−a] of f tends to 1 as a→0⁺. The integral is rewritten as the FTC increment F(1−a)−F(a) on (0,1/2) (eventuallyEq on 𝓝[>]0) and the limit follows from continuity of F at the endpoints — certifying f as a genuine probability density despite its endpoint singularities."
+    }
+  ],
+  "conclusion": {
+    "summary": "An axiom-free, sorry-free formalization closing the analytic gap left by the arcsine-distribution entry: the arcsine density f(x)=1/(π√(x(1−x))) is proved to be the derivative of the CDF F(x)=(2/π)·arcsin(√x) on (0,1), continuous and interval-integrable on every closed subinterval, satisfying the FTC increment ∫ₐᵇ f = F(b)−F(a); and the total probability mass — an improper integral because f diverges at the endpoints — is recovered as the limit 1 of the symmetric proper integrals ∫ over [a,1−a] as a→0⁺. 8 theorems, 2 definitions, 0 axioms, depending only on Mathlib's derivative, interval-integral, and limit machinery.",
+    "implications": "Together with the sibling oq-02-oq-04 (CDF/density static properties), this gives a complete, machine-checked real-analytic account of the arcsine law's density: it is the derivative of the CDF and integrates to 1. Once Mathlib gains Brownian motion and stochastic local time, the occupation-time random variable can be tied directly to this F/f pair — the law's normalization and antiderivative relation are now available off the shelf, no longer needing re-derivation.",
+    "openQuestions": [
+      "Compute the mean ∫₀¹ x·f(x) dx = 1/2 and the variance of the arcsine law as improper integrals via the same symmetric-exhaustion technique.",
+      "Once Brownian motion and stochastic local time enter Mathlib, identify the occupation time A⁺ of the positive half-line as a random variable and prove ℙ(A⁺ ≤ x) = F(x), completing the probabilistic statement."
+    ]
+  },
+  "crossReferences": [
+    "ballot-problem-oq-02",
+    "ballot-problem-oq-02-oq-04"
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Real", "Set", "intervalIntegral"],
+    "namespace": "ArcsineLawDensity",
+    "lineCount": 216,
+    "mainTheorems": [
+      "arcsineCDF_hasDerivAt",
+      "arcsineDensity_continuousOn",
+      "arcsineDensity_intervalIntegrable",
+      "arcsineDensity_intervalIntegral",
+      "arcsineCDF_continuous",
+      "arcsineCDF_zero",
+      "arcsineCDF_one",
+      "arcsineDensity_symmetric_integral_tendsto_one"
+    ],
+    "mainDefinitions": [
+      "arcsineCDF",
+      "arcsineDensity"
+    ],
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/BallotProblemOQ02OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/ballot-problem-oq-02-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-03.json
@@ -1,0 +1,80 @@
+{
+  "slug": "ballot-problem-oq-02-oq-03",
+  "title": "The Arcsine Law: density, derivative, and FTC normalization",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Given the arcsine CDF $F(x)=\\tfrac{2}{\\pi}\\arcsin\\sqrt{x}$ and density $f(x)=1/(\\pi\\sqrt{x(1-x)})$ on $[0,1]$, prove inside Mathlib that $f$ is the derivative of $F$ on $(0,1)$, that $f$ is continuous and interval-integrable on every closed subinterval $[a,b]\\subset(0,1)$, that the Fundamental Theorem of Calculus gives $\\int_a^b f = F(b)-F(a)$, and that the (improper) total integral of $f$ over $(0,1)$ equals $1$.",
+    "plain": "A self-contained, axiom-free Lean formalization that supplies the calculus link missing from the arcsine CDF entry: the arcsine density f(x)=1/(π√(x(1-x))) is the derivative of the CDF F(x)=(2/π)·arcsin(√x) on (0,1), f is continuous/interval-integrable on every [a,b]⊂(0,1), the FTC gives ∫ₐᵇ f = F(b)−F(a), and the symmetric improper integral over [a,1−a] tends to the total probability mass 1 as a→0⁺. Answers the open question raised by sibling ballot-problem-oq-02-oq-04.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [
+      "F'(x)=f(x) on (0,1) (chain rule through Real.arcsin and Real.sqrt), axiom-free.",
+      "f continuous and interval-integrable on every closed [a,b]⊂(0,1).",
+      "FTC increment ∫ₐᵇ f = F(b)−F(a) for 0<a≤b<1.",
+      "Total-mass normalization: ∫ over [a,1−a] of f → 1 as a→0⁺ (improper integral via symmetric exhaustion)."
+    ],
+    "open": [],
+    "goal": "Connect the arcsine density and CDF by the Fundamental Theorem of Calculus and prove the density integrates to the total probability mass 1, closing the open question left by ballot-problem-oq-02-oq-04."
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-27T00:00:00Z",
+    "iteration": 1,
+    "focus": "Verified deliverable: proofs/Proofs/BallotProblemOQ02OQ03.lean (8 theorems, 2 defs, 0 sorries, 0 axioms; #print axioms shows only propext/Classical.choice/Quot.sound) and gallery entry ballot-problem-oq-02-oq-03 (status verified, badge original)."
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETED and verified via local `lake env lean` build (0 sorries, axiomCount 0, badge 'original'). Supplies the density↔CDF link the sibling oq-02-oq-04 left as future work: F'=f on (0,1), continuity/interval-integrability of f on closed subintervals, the FTC increment ∫ₐᵇ f = F(b)−F(a), and the total-mass normalization as the limit 1 of symmetric proper integrals (the density is unbounded at the endpoints, so the total mass is a genuinely improper integral handled by symmetric exhaustion). The probabilistic local-time derivation remains out of scope (Mathlib v4.26.0 has no Brownian local time); this entry adds no axioms.",
+    "builtItems": [
+      "Lean source proofs/Proofs/BallotProblemOQ02OQ03.lean (namespace ArcsineLawDensity).",
+      "Gallery entry src/data/proofs/ballot-problem-oq-02-oq-03 (meta.json + annotations.json)."
+    ],
+    "insights": [
+      "**The antiderivative relation is the missing keystone**: the sibling entry proved F is a CDF and f is U-shaped but never connected them. F'(x)=f(x) is what makes f the density OF F.",
+      "**The total mass is genuinely improper**: f diverges at 0 and 1, so ∫₀¹ f is not a proper integral; normalization must exhaust (0,1) by closed subintervals and pass to the limit.",
+      "**Continuity of F bridges the improper limit**: F=(2/π)arcsin(√·) is continuous everywhere (even where f blows up), so the FTC increments F(1−a)−F(a) converge to F(1)−F(0)=1 with no extra estimate.",
+      "**√x·√(1−x)=√(x(1−x)) (Real.sqrt_mul) is the algebraic hinge** reconciling the chain-rule product form of the derivative with the single-square-root density.",
+      "**Answers a stated open question** of ballot-problem-oq-02-oq-04 ('prove f integrates to 1 and that F is its antiderivative'), entirely within Mathlib's existing derivative/interval-integral framework."
+    ],
+    "mathlibGaps": [
+      "No Brownian motion / stochastic local time / arcsine-distribution object in Mathlib v4.26.0, so the probabilistic statement P(A⁺ ≤ x) = F(x) cannot yet be derived from primitives."
+    ],
+    "nextSteps": [
+      "Compute the mean ∫₀¹ x·f = 1/2 and variance via the same symmetric-exhaustion technique.",
+      "Once Brownian local time enters Mathlib, identify the occupation-time random variable and prove P(A⁺ ≤ x) = F(x)."
+    ]
+  },
+  "tags": [
+    "probability",
+    "arcsine-law",
+    "brownian-motion",
+    "ballot-problem",
+    "distribution",
+    "real-analysis",
+    "calculus",
+    "fundamental-theorem-of-calculus",
+    "research"
+  ],
+  "leanFiles": [
+    {
+      "path": "Proofs/BallotProblemOQ02OQ03.lean",
+      "filename": "BallotProblemOQ02OQ03.lean",
+      "lineCount": 216,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02OQ03.lean"
+    }
+  ],
+  "relatedProofs": [
+    "ballot-problem",
+    "ballot-problem-oq-02",
+    "ballot-problem-oq-02-oq-02",
+    "ballot-problem-oq-02-oq-04"
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **ballot-problem-oq-02-oq-03** ("Arcsine Law Axiomatization in Lean") by closing the analytic gap explicitly left open by the graduated sibling **ballot-problem-oq-02-oq-04** ("The Arcsine Distribution: verified core").

That sibling proved the *static* facts about the arcsine CDF `F(x)=(2/π)·arcsin(√x)` and density `f(x)=1/(π√(x(1-x)))` (endpoints, median, monotonicity, reflection symmetry, U-shape) but introduced `F` and `f` as **separate** objects and listed as future work: *"prove that the density f integrates to 1 and that F is its antiderivative (F'(x)=f(x) on (0,1))."* This PR supplies exactly that link, axiom-free.

## What is proved (`proofs/Proofs/BallotProblemOQ02OQ03.lean`)

- `arcsineCDF_hasDerivAt` — **F'(x) = f(x) on (0,1)** (chain rule through `Real.hasDerivAt_arcsin` and `Real.hasDerivAt_sqrt`, recombined via `√x·√(1-x)=√(x(1-x))`).
- `arcsineDensity_continuousOn` / `arcsineDensity_intervalIntegrable` — `f` is continuous and interval-integrable on every closed `[a,b] ⊂ (0,1)`.
- `arcsineDensity_intervalIntegral` — **FTC**: `∫ₐᵇ f = F(b) − F(a)` for `0 < a ≤ b < 1`.
- `arcsineCDF_continuous` (+ `arcsineCDF_zero`, `arcsineCDF_one`) and `arcsineDensity_symmetric_integral_tendsto_one` — **total-mass normalization**: the symmetric improper integral `∫` over `[a, 1−a]` of `f` tends to `1` as `a → 0⁺`. The density diverges at both endpoints, so the total mass is genuinely improper; it is obtained by symmetric exhaustion via the continuity of `F`.

**8 theorems, 2 definitions, 0 sorries, 0 axioms.**

## Verification

Built locally with `lake env lean Proofs/BallotProblemOQ02OQ03.lean` against the pinned Mathlib (Docker host unavailable). `#print axioms` on all four main theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Gallery `status: verified`, `badge: original`.

## Scope

The fully probabilistic statement (`P(A⁺ ≤ x) = F(x)` for a Brownian occupation time) still requires Brownian local-time theory, absent from Mathlib v4.26.0. This entry adds **no axioms** for it; the parent `ballot-problem-oq-02` axiomatizes the Brownian facts separately.

## Files
- `proofs/Proofs/BallotProblemOQ02OQ03.lean` (new), registered in `proofs/Proofs.lean`
- `src/data/proofs/ballot-problem-oq-02-oq-03/{meta.json,annotations.json}` (new gallery entry)
- `src/data/research/problems/ballot-problem-oq-02-oq-03.json` (new tracking record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)