### PR TITLE
research(puiseux-theorem-oq-03): Newton-polygon edge layer + convexity [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -142,4 +142,83 @@ theorem ysqMinusX_leading_exponent :
       = PuiseuxTheorem.leadingExponentFromSlope 1 2 (by norm_num) := by
   norm_num [edgeSlope, PuiseuxTheorem.leadingExponentFromSlope]
 
+/-! ### Edges and convexity of the lower hull
+
+The vertex API above identifies the *corners* of the Newton polygon.  Its edges
+carry the arithmetic: the negative of an edge slope is the valuation of a root.
+We now give the edge predicate and prove the polygon is **convex** — adjacent
+edge slopes are non-decreasing — which is the combinatorial reason a
+polynomial's root valuations form a sorted list. -/
+
+/-- The slope of a supporting line through two support points of **distinct**
+index is forced to equal their `edgeSlope`.  (A non-vertical line is determined
+by any two of its points.) -/
+theorem slope_eq_edgeSlope {p q : SupportPoint} {m b : ℚ}
+    (hp : p.2 = m * (p.1 : ℚ) + b) (hq : q.2 = m * (q.1 : ℚ) + b)
+    (hne : p.1 ≠ q.1) : m = edgeSlope p q := by
+  have hd : (q.1 : ℚ) - (p.1 : ℚ) ≠ 0 :=
+    sub_ne_zero.mpr fun h => hne (Nat.cast_injective h).symm
+  have hnum : q.2 - p.2 = m * ((q.1 : ℚ) - (p.1 : ℚ)) := by rw [hp, hq]; ring
+  rw [edgeSlope, hnum, mul_div_assoc, div_self hd, mul_one]
+
+/-- `(p, q)` is a **lower edge** of the Newton polygon of `pts`: `p` lies
+strictly left of `q`, and a single supporting line passes through both `p` and
+`q` while lying weakly below every support point.  By `slope_eq_edgeSlope` that
+line necessarily has slope `edgeSlope p q`. -/
+def IsLowerEdge (pts : List SupportPoint) (p q : SupportPoint) : Prop :=
+  p ∈ pts ∧ q ∈ pts ∧ p.1 < q.1 ∧
+    ∃ m b : ℚ, p.2 = m * (p.1 : ℚ) + b ∧ q.2 = m * (q.1 : ℚ) + b ∧
+      ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2
+
+/-- The left endpoint of a lower edge is a lower vertex. -/
+theorem IsLowerEdge.isLowerVertex_left {pts : List SupportPoint}
+    {p q : SupportPoint} (h : IsLowerEdge pts p q) : IsLowerVertex pts p := by
+  obtain ⟨hp, _, _, m, b, hp1, _, hsup⟩ := h
+  exact ⟨hp, m, b, hp1, hsup⟩
+
+/-- The right endpoint of a lower edge is a lower vertex. -/
+theorem IsLowerEdge.isLowerVertex_right {pts : List SupportPoint}
+    {p q : SupportPoint} (h : IsLowerEdge pts p q) : IsLowerVertex pts q := by
+  obtain ⟨_, hq, _, m, b, _, hq1, hsup⟩ := h
+  exact ⟨hq, m, b, hq1, hsup⟩
+
+/-- **Convexity of the Newton polygon.**  Two lower edges sharing the middle
+vertex `q` have non-decreasing slope: the left edge `p → q` is no steeper than
+the right edge `q → r`.
+
+The proof is the textbook one-line convexity argument.  The left edge's
+supporting line `ℓ₁` lies weakly below `r`, while the right edge's line `ℓ₂`
+passes through `r`; both lines meet at `q`.  Subtracting the two relations at the
+points `q` and `r` gives `(slope ℓ₁ − slope ℓ₂)·(r.1 − q.1) ≤ 0`, and
+`r.1 > q.1` forces `slope ℓ₁ ≤ slope ℓ₂`. -/
+theorem edgeSlope_mono {pts : List SupportPoint} {p q r : SupportPoint}
+    (hpq : IsLowerEdge pts p q) (hqr : IsLowerEdge pts q r) :
+    edgeSlope p q ≤ edgeSlope q r := by
+  obtain ⟨_, _, hpq_lt, m₁, b₁, hp1, hq1, hsup1⟩ := hpq
+  obtain ⟨_, hr_mem, hqr_lt, m₂, b₂, hq2, hr2, _⟩ := hqr
+  have e1 : m₁ = edgeSlope p q := slope_eq_edgeSlope hp1 hq1 (ne_of_lt hpq_lt)
+  have e2 : m₂ = edgeSlope q r := slope_eq_edgeSlope hq2 hr2 (ne_of_lt hqr_lt)
+  rw [← e1, ← e2]
+  -- ℓ₁ supports r; ℓ₂ passes through r
+  have hbelow : m₁ * (r.1 : ℚ) + b₁ ≤ m₂ * (r.1 : ℚ) + b₂ := by
+    have h := hsup1 r hr_mem; rwa [hr2] at h
+  -- both lines meet at q
+  have hq_eq : m₁ * (q.1 : ℚ) + b₁ = m₂ * (q.1 : ℚ) + b₂ := by rw [← hq1, ← hq2]
+  have hgt : (q.1 : ℚ) < (r.1 : ℚ) := by exact_mod_cast hqr_lt
+  nlinarith [hbelow, hq_eq, hgt]
+
+/-- The **root valuations are sorted**: since valuations are the negatives of
+edge slopes, convexity (`edgeSlope_mono`) says the valuation read off the left
+edge is at least the one read off the right edge. -/
+theorem rootValuation_antitone {pts : List SupportPoint} {p q r : SupportPoint}
+    (hpq : IsLowerEdge pts p q) (hqr : IsLowerEdge pts q r) :
+    -edgeSlope q r ≤ -edgeSlope p q :=
+  neg_le_neg (edgeSlope_mono hpq hqr)
+
+/-- The single segment of `Y² − x` is a genuine lower edge. -/
+theorem ysqMinusX_isLowerEdge : IsLowerEdge YsqMinusX (0, 1) (2, 0) := by
+  refine ⟨by simp [YsqMinusX], by simp [YsqMinusX], by norm_num,
+    -1/2, 1, by norm_num, by norm_num, fun r hr => ?_⟩
+  fin_cases hr <;> norm_num
+
 end PuiseuxTheoremOQ03

--- a/research/problems/puiseux-theorem-oq-03/knowledge.md
+++ b/research/problems/puiseux-theorem-oq-03/knowledge.md
@@ -81,3 +81,40 @@ metadata). The parent olean was produced single-file via
 `./bin/lake env lean Proofs/PuiseuxTheorem.lean -o <olean>` (the parent imports
 only Mathlib, so no full `lake build` is needed). `#print axioms` on all 7
 theorems lists only the foundational axioms.
+
+---
+
+## Session 2 (2026-06-27, researcher-9): edge layer + convexity
+
+Extended the file from 145→224 lines, 7→13 theorems, 3→4 defs (all still 0
+sorries / 0 axioms; `#print axioms` on the new results lists only
+propext/Classical.choice/Quot.sound).
+
+New content — the **edge layer** the vertex API was missing:
+
+* `slope_eq_edgeSlope`: a supporting line through two distinct-index support
+  points has slope forced to equal their `edgeSlope` (a non-vertical line is
+  determined by two of its points). Proof: `q.2 − p.2 = m·(q.1 − p.1)`, divide
+  by the nonzero cast index gap (`Nat.cast_injective`), `mul_div_cancel`.
+* `IsLowerEdge pts p q`: `p.1 < q.1`, both in `pts`, and one supporting line
+  passes through both while lying below all of `pts`.
+* `IsLowerEdge.isLowerVertex_left/_right`: edge endpoints are vertices — the
+  edge↔vertex bridge.
+* **`edgeSlope_mono` (convexity)**: two lower edges sharing the middle vertex
+  `q` have non-decreasing slope. This is the combinatorial heart. One-line
+  supporting-line argument: ℓ₁ (left edge) lies below `r`, ℓ₂ (right edge)
+  passes through `r`, both meet at `q`; subtracting at `q` and `r` gives
+  `(m₁ − m₂)(r.1 − q.1) ≤ 0`, and `r.1 > q.1` ⇒ `m₁ ≤ m₂` (`nlinarith`).
+* `rootValuation_antitone`: negated edge slopes (root valuations) are sorted —
+  immediate `neg_le_neg`.
+* `ysqMinusX_isLowerEdge`: the Y²−x segment is a genuine lower edge.
+
+**Why this matters.** Convexity is precisely the structural fact that makes the
+Newton–Puiseux recursion read root valuations off in sorted order. Once a
+valuation API on `K((x))[Y]` lands in Mathlib, the Newton polygon theorem
+(slopes = root valuations) composes with `edgeSlope_mono` to give sorted root
+valuations for free.
+
+Verification recipe unchanged: `cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean
+Proofs/PuiseuxTheoremOQ03.lean` exits 0 (worktree `.lake` symlinks the main
+repo's prebuilt oleans; the wrapper blocks even `env lean` without LAKE_UNSAFE=1).

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "puiseux-theorem-oq-03",
   "title": "Puiseux Theorem OQ-03: A Combinatorial Newton Polygon",
   "slug": "puiseux-theorem-oq-03",
-  "description": "First Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex), proves the minimum-valuation point is always a vertex (isLowerVertex_of_minimal) and that every nonempty support set has one (exists_lowerVertex via List.argmin), and works the canonical Y²−x example: both support points are vertices, the single edge has slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. Also fixes a parse error in the parent file (a dangling /-- doc comment).",
+  "description": "Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex), proves the minimum-valuation point is always a vertex (isLowerVertex_of_minimal) and that every nonempty support set has one (exists_lowerVertex via List.argmin). It then builds the edge layer: a lower-edge predicate (IsLowerEdge), the fact that a supporting line through two distinct-index points has the forced edge slope (slope_eq_edgeSlope), that edge endpoints are vertices, and — the combinatorial heart — convexity of the Newton polygon (edgeSlope_mono): adjacent edge slopes are non-decreasing, hence the root valuations come sorted (rootValuation_antitone). Validated on the canonical Y²−x example: both support points are vertices, the single segment is a genuine lower edge of slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. Also fixes a parse error in the parent file (a dangling /-- doc comment).",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Newton_polygon",
@@ -21,32 +21,38 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 7 theorems and 3 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 13 theorems and 4 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
       "exists_lowerVertex: every nonempty support set has a lower vertex (via List.argmin)",
       "IsLowerVertex.mem: lower vertices are genuine support points",
       "edgeSlope: slope of the segment joining two support points",
-      "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
+      "IsLowerEdge: lower-edge predicate — a supporting line through two strictly-ordered support points lying below all of pts",
+      "slope_eq_edgeSlope: a supporting line through two distinct-index points has slope forced to equal their edgeSlope",
+      "IsLowerEdge.isLowerVertex_left / _right: the endpoints of a lower edge are lower vertices (edge ↔ vertex bridge)",
+      "edgeSlope_mono: CONVEXITY of the Newton polygon — adjacent lower edges sharing a vertex have non-decreasing slope (the one-line supporting-line argument)",
+      "rootValuation_antitone: consequently the root valuations (negated edge slopes) are sorted across the polygon",
+      "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, the segment is a genuine lower edge, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
       "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 145,
-    "theoremCount": 7,
-    "definitionCount": 3,
+    "lineCount": 224,
+    "theoremCount": 13,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Newton (1676) introduced the fractional-exponent root-finding procedure that bears his name; Puiseux (1850) gave the first rigorous proof that it produces all roots. The central combinatorial object is the Newton polygon: for a polynomial P(Y) = Σ aᵢ Yⁱ with coefficients in a valued field K((x)), it is the lower convex hull of the support points (i, v(aᵢ)). The Newton polygon theorem states that the negatives of its edge slopes are exactly the valuations of the roots of P in any algebraically closed valued extension — the fact that feeds the parent's leadingExponentFromSlope.\n\nThe computational story (Chudnovsky–Chudnovsky 1986, Duval 1989, Walsh 2000, Poteaux–Rybowicz 2008–15, Poteaux–Weimann 2021) tightens the cost of computing Puiseux expansions to quasi-linear Õ(d·δ) in the discriminant valuation δ. Every such bound is phrased on the Newton polygon as a data structure, so a computable combinatorial Newton polygon is the natural first formal step.",
     "problemStatement": "**Open Question (OQ-03 from Puiseux's Theorem)**: Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\n\n**This deliverable**: Mathlib 4.26.0 has no Newton polygon API. This file supplies the combinatorial core — the lower-hull vertex predicate and its basic structure theory, validated on the canonical Y²−x example — as the foundation on which termination and complexity bounds can later be stated.",
-    "text": "A 145-line, fully-verified Lean file. The Newton polygon is captured not by a hull-construction algorithm but by the standard supporting-line predicate IsLowerVertex: a support point p is a lower vertex when some line y = m·i + b lies weakly below every support point and passes through p. General lemmas (minimum-valuation point is a vertex; existence of a vertex for nonempty supports) plus the worked Y²−x example (both endpoints are vertices, edge slope −1/2, leading exponent 1/2) connect the construction to the parent's leadingExponentFromSlope. The file also repairs a parse error in the parent PuiseuxTheorem.lean.",
+    "text": "A 224-line, fully-verified Lean file. The Newton polygon is captured not by a hull-construction algorithm but by the standard supporting-line predicates: a support point p is a lower vertex (IsLowerVertex) when some line y = m·i + b lies weakly below every support point and passes through p, and a pair (p,q) with p strictly left of q is a lower edge (IsLowerEdge) when one supporting line passes through both. General lemmas (minimum-valuation point is a vertex; existence of a vertex; edge endpoints are vertices; a supporting line's slope is forced by its two distinct points) build up to convexity (edgeSlope_mono): adjacent edge slopes are non-decreasing, so the root valuations come sorted (rootValuation_antitone). The worked Y²−x example (both endpoints are vertices, the segment is a genuine lower edge of slope −1/2, leading exponent 1/2) connects the construction to the parent's leadingExponentFromSlope. The file also repairs a parse error in the parent PuiseuxTheorem.lean.",
     "proofStrategy": "**Predicate, not algorithm**: IsLowerVertex states existence of a supporting line through p below all support points. This is the math definition of a lower-hull vertex and keeps the API independent of any verified convex-hull routine.\n\n**General structure**: isLowerVertex_of_minimal uses the horizontal line y = v(p) — the lowest support point is always a vertex. exists_lowerVertex extracts the argmin of the valuations from a nonempty support list (Mathlib List.argmin + le_of_mem_argmin).\n\n**Example**: For Y²−x the support is {(0,1),(2,0)}; the line y = −½i + 1 passes through both and lies (with equality) below them, so both are vertices. edgeSlope (0,1) (2,0) = −1/2 by norm_num, and −(−1/2) = 1/2 = leadingExponentFromSlope 1 2.",
     "keyInsights": [
       "**Supporting lines beat algorithms**: Phrasing a Newton-polygon vertex as 'some line lies below all points and touches this one' captures the exact mathematical content without forcing a verified convex-hull construction — the API stays honest and small.",
       "**The lowest point seeds the polygon**: The global minimum valuation is always a vertex (horizontal supporting line), giving a constructive starting vertex for any support set.",
       "**List.argmin gives existence for free**: Nonempty support lists have a minimum-valuation element, and Mathlib's argmin lemmas turn that into an immediate existence proof for a lower vertex.",
       "**The example closes the loop to the parent**: Recovering leadingExponentFromSlope 1 2 = 1/2 from the Y²−x Newton polygon's single edge of slope −1/2 ties the combinatorial object directly to the parent's root-exponent definition.",
+      "**Convexity is a one-line supporting-line argument**: Two lower edges sharing a vertex q have non-decreasing slope because the left edge's line lies below the right endpoint while the right edge's line passes through it — subtracting the two relations at q and r and dividing by the positive index gap gives the inequality. This is the combinatorial reason root valuations come sorted, and it needs no convex-hull construction, only the supporting-line predicate.",
       "**Mathlib gaps stay explicit**: The Newton polygon theorem (slopes = root valuations), a termination measure, and the Poteaux–Weimann complexity bound all remain open for stated infrastructural reasons (valuation API on K((x))[Y]; arithmetic-complexity model) rather than being papered over."
     ],
     "prerequisites": [
@@ -81,11 +87,32 @@
       "description": "Take the point of minimum valuation via List.argmin; List.argmin_mem and List.le_of_mem_argmin discharge the hypotheses of isLowerVertex_of_minimal."
     },
     {
-      "name": "ysqMinusX_edge_slope",
+      "name": "slope_eq_edgeSlope",
       "type": "theorem",
-      "statement": "$\\text{edgeSlope}((0,1),(2,0)) = -1/2$",
-      "significance": "The single Newton-polygon edge of Y²−x has slope −1/2, the canonical worked example of the construction.",
-      "description": "Direct norm_num computation of (0 − 1)/(2 − 0)."
+      "statement": "$p_2 = m p_1 + b \\wedge q_2 = m q_1 + b \\wedge p_1 \\ne q_1 \\Rightarrow m = \\text{edgeSlope}(p,q)$",
+      "significance": "A non-vertical line is determined by any two of its points: a supporting line through two distinct-index support points must have slope equal to their edgeSlope. This pins the abstract supporting line of a lower edge to the concrete edge slope.",
+      "description": "q.2 − p.2 = m·(q.1 − p.1); divide by the nonzero index gap (Nat.cast_injective gives the cast gap nonzero)."
+    },
+    {
+      "name": "edgeSlope_mono",
+      "type": "theorem",
+      "statement": "$\\text{IsLowerEdge}(\\text{pts}, p, q) \\wedge \\text{IsLowerEdge}(\\text{pts}, q, r) \\Rightarrow \\text{edgeSlope}(p,q) \\le \\text{edgeSlope}(q,r)$",
+      "significance": "CONVEXITY of the Newton polygon — the combinatorial heart of the construction. Two lower edges sharing a middle vertex have non-decreasing slope. This is exactly why a polynomial's root valuations come out sorted, and what makes the Newton–Puiseux recursion well-founded edge-by-edge.",
+      "description": "The left edge's supporting line ℓ₁ lies weakly below r while the right edge's line ℓ₂ passes through r; both meet at q. Subtracting at q and r gives (slope ℓ₁ − slope ℓ₂)·(r.1 − q.1) ≤ 0, and r.1 > q.1 forces the inequality (nlinarith)."
+    },
+    {
+      "name": "rootValuation_antitone",
+      "type": "theorem",
+      "statement": "$\\text{IsLowerEdge}(\\text{pts}, p, q) \\wedge \\text{IsLowerEdge}(\\text{pts}, q, r) \\Rightarrow -\\text{edgeSlope}(q,r) \\le -\\text{edgeSlope}(p,q)$",
+      "significance": "Root valuations are the negatives of edge slopes, so convexity says they are sorted (non-increasing left-to-right) across the Newton polygon — the structural fact behind reading off root valuations in order.",
+      "description": "Immediate from edgeSlope_mono via neg_le_neg."
+    },
+    {
+      "name": "ysqMinusX_isLowerEdge",
+      "type": "theorem",
+      "statement": "$\\text{IsLowerEdge}(\\text{YsqMinusX}, (0,1), (2,0))$",
+      "significance": "The single segment of Y²−x is a genuine lower edge: the line y = −½i + 1 passes through both endpoints and lies below all support points, instantiating the edge layer on the canonical example.",
+      "description": "refine the IsLowerEdge structure with m = −1/2, b = 1; fin_cases over the two support points, norm_num."
     },
     {
       "name": "ysqMinusX_leading_exponent",
@@ -150,18 +177,18 @@
       "Mathlib.Data.List.MinMax"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 145,
+    "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 3,
+    "theoremCount": 13,
+    "definitionCount": 4,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
   },
   "conclusion": {
-    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, and the worked Y²−x example tying the edge slope to the parent's leadingExponentFromSlope. All 7 theorems and 3 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
+    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone), all validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 13 theorems and 4 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
     "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
     "openQuestions": [
-      "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y])",
+      "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y]) — the edge layer and its convexity (edgeSlope_mono) are now in place, so the valuations would automatically come out sorted",
       "Define a termination measure for one Newton–Puiseux reduction step and prove the Y-degree strictly decreases (S2-B)",
       "State and bound the arithmetic complexity of the algorithm (Poteaux–Weimann Õ(d·δ)) — blocked on the absence of an arithmetic-complexity model in Mathlib (S2-C, moonshot)"
     ]


### PR DESCRIPTION
## Summary

Extends the combinatorial Newton polygon file (`Proofs/PuiseuxTheoremOQ03.lean`) from the **vertex** API to the **edge** layer that carries the arithmetic of Puiseux's theorem — the negative of an edge slope is the valuation of a root — and proves the polygon is **convex**.

Builds directly on the merged OQ-03 vertex work (#30757).

## What's new

145→224 lines, 7→13 theorems, 3→4 defs. Fully verified, **0 sorries / 0 axioms** (`#print axioms` on every new result lists only `propext` / `Classical.choice` / `Quot.sound`).

- **`slope_eq_edgeSlope`** — a supporting line through two distinct-index support points has slope forced to equal their `edgeSlope` (a non-vertical line is determined by any two of its points).
- **`IsLowerEdge`** — lower-edge predicate: `p` strictly left of `q`, both in support, one supporting line through both lying below all support points.
- **`IsLowerEdge.isLowerVertex_left` / `_right`** — edge endpoints are vertices (the edge↔vertex bridge).
- **`edgeSlope_mono`** — **convexity of the Newton polygon**: two lower edges sharing a middle vertex have non-decreasing slope. The combinatorial heart, proved by the textbook one-line supporting-line argument (`nlinarith`).
- **`rootValuation_antitone`** — consequently the root valuations (negated edge slopes) come sorted across the polygon.
- **`ysqMinusX_isLowerEdge`** — the canonical `Y²−x` segment is a genuine lower edge.

## Why it matters

Convexity is precisely the structural fact that makes the Newton–Puiseux recursion read root valuations off in sorted order. Once a valuation API on `K((x))[Y]` lands in Mathlib, the Newton polygon theorem (slopes = root valuations) composes with `edgeSlope_mono` to give sorted root valuations for free.

## Verification

```
cd proofs && LAKE_UNSAFE=1 ./bin/lake env lean Proofs/PuiseuxTheoremOQ03.lean
# exits 0, no diagnostics
```

(Host toolchain; the Docker build host has corrupted containerd metadata. The worktree `.lake` symlinks the main repo's prebuilt oleans.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)