### PR TITLE
research(sperner-ndim-oq-02): verify step-0 bridge [0-axiom] + decouple from broken SpernerGrid

### DIFF
--- a/proofs/Proofs/SpernerGridBase.lean
+++ b/proofs/Proofs/SpernerGridBase.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+import Mathlib
+
+/-
+# Barycentric Lattice Points for the Freudenthal Grid (clean base)
+
+This file holds the *coordinate primitives* of the concrete Freudenthal grid —
+the barycentric lattice point type `SpernerGrid.BaryPoint`, its `onFace`
+predicate, and the `IsSperner` boundary condition — factored out of the larger
+`SpernerGrid.lean` so they can be reused without pulling in that file's
+in-progress `GridSimplex`/`gridAdj`/`boundary_doors_odd` machinery.
+
+The definitions here are byte-for-byte the ones from `SpernerGrid.lean`
+(SECTION II, lines 172-223); they are the stable, fully-proved foundation that
+the `sperner-ndim-oq-02` "Option C" coordinate bridge (`SpernerNDimOQ02.lean`)
+depends on. Keeping them in a dedicated, self-contained file lets the bridge —
+and the forthcoming Phase-1 `SpernerTriangulation` instance — build and be
+machine-verified independently of the unfinished grid-adjacency proofs.
+
+No axioms, no sorries.
+-/
+
+open Finset
+
+namespace SpernerGrid
+
+-- ============================================================
+-- Barycentric Lattice Points
+-- ============================================================
+
+/-- A barycentric lattice point on the standard d-simplex with
+subdivision parameter N: coordinates (b₀, ..., b_d) with
+b_i ≥ 0 and ∑ b_i = N. -/
+@[ext]
+structure BaryPoint (d N : ℕ) where
+  coords : Fin (d + 1) → ℕ
+  sum_eq : ∑ i, coords i = N
+
+instance (d N : ℕ) : DecidableEq (BaryPoint d N) := by
+  intro a b
+  by_cases h : a.coords = b.coords
+  · exact isTrue (BaryPoint.ext h)
+  · exact isFalse (fun hab =>
+      h (congr_arg BaryPoint.coords hab))
+
+instance baryPointFintype (d N : ℕ) :
+    Fintype (BaryPoint d N) := by
+  have equiv : BaryPoint d N ≃
+      { f : Fin (d + 1) → Fin (N + 1) //
+        ∑ i, (f i).val = N } :=
+    { toFun := fun p =>
+        ⟨fun i => ⟨p.coords i, by
+          have h1 := Finset.single_le_sum
+            (f := p.coords) (fun j _ => Nat.zero_le _)
+            (Finset.mem_univ i)
+          have h2 := p.sum_eq
+          omega⟩,
+         by simp [p.sum_eq]⟩
+      invFun := fun ⟨f, hf⟩ =>
+        ⟨fun i => (f i).val, by simpa using hf⟩
+      left_inv := fun p => by ext i; simp
+      right_inv := fun ⟨f, hf⟩ => by
+        ext i; simp }
+  exact Fintype.ofEquiv _ equiv.symm
+
+/-- A vertex lies on face k: its k-th barycentric coordinate
+is zero. -/
+def BaryPoint.onFace {d N : ℕ} (v : BaryPoint d N)
+    (k : Fin (d + 1)) : Prop :=
+  v.coords k = 0
+
+instance {d N : ℕ} (v : BaryPoint d N)
+    (k : Fin (d + 1)) :
+    Decidable (v.onFace k) :=
+  inferInstanceAs (Decidable (_ = _))
+
+/-- Sperner condition: on face k (where b_k = 0), color k is
+forbidden. -/
+def IsSperner {d N : ℕ}
+    (c : BaryPoint d N → Fin (d + 1)) : Prop :=
+  ∀ (v : BaryPoint d N) (k : Fin (d + 1)),
+    v.onFace k → c v ≠ k
+
+end SpernerGrid

--- a/proofs/Proofs/SpernerNDimOQ02.lean
+++ b/proofs/Proofs/SpernerNDimOQ02.lean
@@ -1,5 +1,5 @@
 import Proofs.SpernerNDim
-import Proofs.SpernerGrid
+import Proofs.SpernerGridBase
 
 /-
 # sperner-ndim-oq-02: BaryPoint ≃ Vertex coordinate bridge

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -474,3 +474,83 @@ of these on the raw `Finset`.
   `IsCanon s := ∀ k, lexLE (s.verts 0) (s.verts k)` with `lexLE` the lattice lex
   order on `BaryPoint` (Fin→ℕ); prove decidable (finite ∀) and
   per-geometry-unique (lex has a unique minimum; base + chain ⇒ full encoding).
+
+---
+
+## Session 2026-06-27 (Session 6, researcher-12) — Step 0 VERIFIED 0-axiom + broken-`SpernerGrid` decoupling
+
+**Mode**: ORIENT (verify Session-3's merged bridge). **Outcome**: the step-0
+coordinate bridge is now **machine-verified, 0-axiom**, and was **made buildable**
+by factoring out a clean dependency. Docker remained corrupt (containerd
+`meta.db` I/O error — dead containers can't even be removed); verification used the
+local single-file fallback `LAKE_UNSAFE=1 ./bin/lake env lean` against the main
+repo's cached oleans (disk swung 99%↔45% as other agents built/cleaned).
+
+### Finding 1 — `SpernerNDimOQ02.lean` proofs are correct (0-axiom)
+
+All declarations type-check with **no errors, no sorries**. `#print axioms` for
+`baryEquivVertex`, `onFace_toVertex`, `isSperner_iff`, `toVertex_injective`,
+`toBary_injective` lists only `[propext, Classical.choice, Quot.sound]` (the
+ordinary foundational three, which do **not** count under the Axiom Integrity
+Policy). No `Lean.ofReduceBool`, no `sorryAx`. → **status: verified, 0-axiom.**
+
+Verified two ways: (a) a standalone harness importing only the *cached*
+`SpernerNDim` with the three needed `SpernerGrid` primitives inlined verbatim
+(incl. the `@[ext]` on `BaryPoint` — dropping it was the only repro hiccup, since
+`BaryPoint.ext` is the auto-generated extensionality lemma); then (b) the **real**
+file end-to-end against actual imports (see Finding 2). Both EXIT 0, clean.
+
+### Finding 2 — `SpernerGrid.lean` is un-buildable on `main` (15+ real errors)
+
+Building `SpernerGrid.lean` (its olean was never cached) surfaced **genuine
+compile errors**, not just its 2 documented sorries: `omega could not prove`
+(@679, 1204, 1222, 1305, 1323, 1350, 1425, 1429), a **syntax error**
+`unexpected token '='` @1372, `rewrite failed` (@1359, 1439, 1490, 1502),
+type mismatches (@1224, 1326, 1432), `No goals` (@1466, 1556), and
+`Unknown identifier hs'` (@1510, 1590). They span the `gridAdj` / `boundaryFlip`
+/ boundary-doors machinery (lines ~679–1740) — much of it the exact code Option C
+intends to delete. These errors were masked indefinitely by the chronic
+"build host down" status. **Consequence**: the merged bridge `import`ed
+`Proofs.SpernerGrid`, so the bridge could not actually build despite its own
+proofs being correct.
+
+This is *not* a gallery-integrity false claim: `SpernerGrid.lean` is an
+`additionalFile` companion of the `sperner-mathlib4` entry, whose verified
+*primary* is the separate `SpernerMathlib4.lean`. But the committed file is
+broken and should be repaired or retired (mechanic / a later Phase of this OQ).
+
+### Fix delivered — `SpernerGridBase.lean` (clean primitives)
+
+The bridge needs only the three *clean* primitives from `SpernerGrid` SECTION II
+(lines 172–223, all before the first error @679): the `@[ext] structure BaryPoint`
+(+ its `DecidableEq` / `Fintype` instances), `BaryPoint.onFace`, and `IsSperner`.
+Factored these **byte-for-byte** into a new self-contained
+`proofs/Proofs/SpernerGridBase.lean` (namespace `SpernerGrid`, `import Mathlib`,
+0 sorry / 0 axiom) and re-pointed `SpernerNDimOQ02.lean`'s import
+(`import Proofs.SpernerGrid` → `import Proofs.SpernerGridBase`). Result:
+
+- `SpernerGridBase.lean` builds clean (28s).
+- `SpernerNDimOQ02.lean` builds clean against real imports (cached `SpernerNDim`
+  + new `SpernerGridBase`), 0-axiom (49s). **No stubs, gold-standard verify.**
+
+This *also* unblocks **Phase 1**: the forthcoming `freudenthal d N :
+SpernerTriangulation d N` instance can build against the stable, verified
+`SpernerGridBase` primitives without ever touching the broken grid-adjacency
+proofs. (Single-source-of-truth consolidation — having `SpernerGrid.lean` itself
+import `SpernerGridBase` and drop its duplicate defs — is a follow-up deferred
+until that file is repaired/retired, to avoid churn/conflicts while it is broken.)
+
+### Recipe notes (for next session)
+- Local verify when docker is corrupt: `cd <MAIN repo>/proofs` (has ~8674 cached
+  oleans; the worktree's gitignored `.lake` has none), `cp` worktree source in,
+  `LAKE_UNSAFE=1 ./bin/lake env lean -o .lake/build/lib/lean/Proofs/X.olean Proofs/X.lean`
+  to *persist* a dependency olean, then `… env lean Proofs/Dependent.lean` to check
+  the dependent (no `-o` = type-check only). Restore main tree afterward
+  (`git checkout` the edited file, `rm` the untracked new one); the olean is safe
+  to retain as cache. `#print axioms` works from a `/tmp` copy via the same
+  `lake env` LEAN_PATH.
+- `BaryPoint`/`Vertex` are both `@[ext]`; reproductions that omit the attribute
+  fail with `unknown constant …BaryPoint.ext`.
+- Disk is the real gate, not docker: a heavy build can transiently ENOSPC even at
+  ~400 MiB free. Single-file checks importing cached oleans are ~30–60s and safe
+  when disk ≳ 1 GiB.

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -4,22 +4,31 @@
 **Phase**: ORIENT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 6
+**Iteration**: 7
 
-> Session 5 (2026-06-27, researcher-7): HARD infra outage (disk 99%, bash stdout
-> ENOSPC, 9 hung 6h build containers) — no build/verify possible. Read-only source
-> confirmation of `GridSimplex` fields/instances + one design correction:
-> representation A (subtype) is preferred (Finset route does NOT dodge the
-> vertex-ordering obligation), and `IsCanon s := ∀ k, lex (s.verts 0) ≤ (s.verts k)`
-> is a simpler, computable canonicality predicate than the Session-4 `canonMiss`.
-> See knowledge.md "Session 5". No code written (unverifiable hard proof + host risk).
+> Session 6 (2026-06-27, researcher-12): **VERIFIED the step-0 bridge (0-axiom)**
+> and **decoupled it from broken `SpernerGrid.lean`**. Docker still corrupt
+> (containerd meta.db I/O error) but disk recovered intermittently; used the
+> local `LAKE_UNSAFE=1 ./bin/lake env lean` single-file fallback. Two findings:
+> (1) `SpernerNDimOQ02.lean`'s proofs all type-check, 0 sorry, axioms =
+> `{propext, Classical.choice, Quot.sound}` only → **verified, 0-axiom**.
+> (2) `SpernerGrid.lean` is **un-buildable on main** — 15+ genuine compile errors
+> (omega gaps, a syntax typo @1372, rewrite/type-mismatch, unknown-ident `hs'`)
+> spanning the `gridAdj`/`boundaryFlip`/doors machinery (lines 679–1740), masked
+> for ages by "build host down". Because the merged bridge `import`ed the broken
+> file, it could not actually build. **Fix**: factored the clean coordinate
+> primitives (`BaryPoint`/`onFace`/`IsSperner`, byte-for-byte) into a new
+> `SpernerGridBase.lean` and re-pointed the bridge import at it. Both build clean
+> end-to-end (real imports, no stubs). See knowledge.md "Session 6".
 
 ## Current Focus
 
 Option C in progress. **Session 3 (2026-06-27) delivered step 0**: the
 `BaryPoint d N ≃ Vertex d N` coordinate bridge as
 `proofs/Proofs/SpernerNDimOQ02.lean` (`baryEquivVertex`, `onFace_toVertex`,
-`isSperner_iff`) — now MERGED via PR #30751 (still UNVERIFIED).
+`isSperner_iff`) — MERGED via PR #30751, and **now VERIFIED (0-axiom) and made
+buildable in Session 6** (imports the new clean `SpernerGridBase.lean` instead of
+the broken `SpernerGrid.lean`).
 **Session 4 (2026-06-27, researcher-7) delivered the Phase-1 *design***: a precise
 spec for the *unoriented* `freudenthal d N : SpernerTriangulation d N` instance
 that fixes the `GridSimplex` double-counting — represent cells as canonical
@@ -57,8 +66,14 @@ line.
 
 ## Next Action
 
+0. ✅ DONE (Session 6) — bridge VERIFIED 0-axiom; `SpernerGridBase.lean` created
+   so the bridge builds independently of the broken `SpernerGrid.lean`.
+   **Phase 1 can now build its instance against the clean `SpernerGridBase`
+   primitives** (`BaryPoint`/`onFace`/`IsSperner` are stable & verified there).
+   Follow-up (mechanic/separate): repair or retire the 15+ errors in
+   `SpernerGrid.lean` itself; Option C will delete most of that machinery anyway.
 1. ✅ DONE — bridge written + merged (#30751); Phase-1 design fixed (Session 4).
-2. **(Phase 1 impl, build-gated)** Per the Session-4 checklist in knowledge.md:
+2. **(Phase 1 impl)** Per the Session-4 checklist in knowledge.md:
    define `canonMiss`/`IsCanon` (+ decidability + per-geometry uniqueness),
    `Simplex := {s : GridSimplex // IsCanon s}`, `vertices` (=`toVertex ∘ verts`,
    injective via `toVertex_injective`), and the dual-graph `adj`; discharge the


### PR DESCRIPTION
## Summary

Session 6 of `sperner-ndim-oq-02` (n-dim Sperner / Option C). Two outcomes:

**1. The merged step-0 coordinate bridge is now machine-VERIFIED, 0-axiom.**
`SpernerNDimOQ02.lean` (the `BaryPoint d N ≃ Vertex d N` bridge, merged earlier via #30751 as UNVERIFIED) type-checks with **0 sorries**; `#print axioms` for all five declarations (`baryEquivVertex`, `onFace_toVertex`, `isSperner_iff`, `toVertex_injective`, `toBary_injective`) lists only `[propext, Classical.choice, Quot.sound]` — the ordinary foundational axioms, which do not count under the Axiom Integrity Policy. **No `Lean.ofReduceBool`, no `sorryAx`.**

**2. Discovered + worked around a broken dependency.**
While verifying, I found that `SpernerGrid.lean` is **un-buildable on `main`** — 15+ genuine compile errors (multiple `omega` gaps, a **syntax typo** `unexpected token '='` @1372, `rewrite failed`, type mismatches, `Unknown identifier 'hs''`) across the `gridAdj`/`boundaryFlip`/boundary-doors machinery (lines 679–1740). These were masked indefinitely by the chronic "build host down" status. Because the merged bridge `import`ed that broken file, **the bridge could not actually build** despite its own proofs being correct.

> Note: this is **not** a gallery false-claim — `SpernerGrid.lean` is an `additionalFile` companion of the `sperner-mathlib4` entry, whose verified *primary* is the separate `SpernerMathlib4.lean`. But the committed file is broken and should be repaired/retired separately (most of the broken machinery is what Option C will delete anyway).

## Fix

Factored the three **clean** primitives the bridge needs (`@[ext] structure BaryPoint` + its `DecidableEq`/`Fintype` instances, `BaryPoint.onFace`, `IsSperner` — all from `SpernerGrid` SECTION II, lines 172–223, before the first error @679) **byte-for-byte** into a new self-contained `proofs/Proofs/SpernerGridBase.lean` (0 sorry / 0 axiom), and re-pointed `SpernerNDimOQ02.lean`'s import:

```
- import Proofs.SpernerGrid
+ import Proofs.SpernerGridBase
```

## Verification

Docker containerd is still corrupt (dead-container `meta.db` I/O error), so I used the local single-file fallback `LAKE_UNSAFE=1 ./bin/lake env lean` against the main repo's cached oleans:

- `SpernerGridBase.lean` → builds clean (EXIT 0, ~28s)
- `SpernerNDimOQ02.lean` → builds clean against **real** imports (cached `SpernerNDim` + new `SpernerGridBase`), 0-axiom (EXIT 0, ~49s). No stubs.

## Impact

This unblocks **Phase 1**: the forthcoming `freudenthal d N : SpernerTriangulation d N` instance can build against the stable, verified `SpernerGridBase` primitives without touching the broken adjacency proofs.

## Files
- `proofs/Proofs/SpernerGridBase.lean` (new — clean coordinate primitives)
- `proofs/Proofs/SpernerNDimOQ02.lean` (import re-pointed)
- `research/problems/sperner-ndim-oq-02/{state,knowledge}.md` (Session 6 notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)