### PR TITLE
audit: repair recurring conflict markers in audit-tracker.json

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25160,15 +25160,9 @@
     },
     "hilbert-3-oq-04": {
       "auditCount": 1,
-<<<<<<< Updated upstream
-      "issues": [],
-      "lastAudited": "2026-06-27T13:42:02Z",
-      "result": "issues-fixed"
-=======
       "lastAudited": "2026-06-27T13:51:27Z",
       "result": "clean",
       "issues": []
->>>>>>> Stashed changes
     }
   },
   "version": 1,


### PR DESCRIPTION
## Integrity fix

`src/data/proofs/audit-tracker.json` had git conflict markers committed into the `hilbert-3-oq-04` entry (lines ~25163–25171), making the file unparseable. As a result `find-targets.ts --stats` reported a bogus **0/4051 audited** (queue appears fully un-drained).

This is the **third recurrence** of this exact failure mode (prior fixes: #30771, #30774).

## Resolution

Kept the later re-audit side (`2026-06-27T13:51:27Z`, `result: "clean"`) — the hilbert-3-oq-04 badge fix was already merged earlier (#30754). JSON now validates and stats are restored:

```
Total proofs:     4051
Audited:          4051
Unaudited:        0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)