### PR TITLE
research(puiseux-theorem-oq-03): Newton-polygon lower-hull edge + convexity layer [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -142,4 +142,100 @@ theorem ysqMinusX_leading_exponent :
       = PuiseuxTheorem.leadingExponentFromSlope 1 2 (by norm_num) := by
   norm_num [edgeSlope, PuiseuxTheorem.leadingExponentFromSlope]
 
+/-! ### Lower-hull edges and convexity
+
+The supporting-line predicate `IsLowerVertex` extends to **edges** of the lower
+hull: an edge is a single supporting line that touches two distinct support
+points.  The slope of that line is the `edgeSlope` of its endpoints, and — the
+combinatorial heart of the Newton polygon — that slope bounds the slopes from
+either endpoint to every other support point.  This is the convexity that makes
+the lower hull's edge slopes the candidate root valuations and guarantees the
+polygon never dips below an edge. -/
+
+/-- `p` and `q` span a **lower edge** of the Newton polygon of `pts` when a single
+(non-vertical) line passes through both and lies weakly below every support point.
+Both endpoints are then lower vertices and the line's slope is `edgeSlope p q`. -/
+def IsLowerEdge (pts : List SupportPoint) (p q : SupportPoint) : Prop :=
+  p ∈ pts ∧ q ∈ pts ∧ ∃ m b : ℚ,
+    p.2 = m * (p.1 : ℚ) + b ∧ q.2 = m * (q.1 : ℚ) + b ∧
+    ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2
+
+/-- The left endpoint of a lower edge is a lower vertex (the same supporting line
+witnesses it). -/
+theorem IsLowerEdge.left_isVertex {pts : List SupportPoint} {p q : SupportPoint}
+    (h : IsLowerEdge pts p q) : IsLowerVertex pts p := by
+  obtain ⟨hp, _, m, b, hpe, _, hsupp⟩ := h
+  exact ⟨hp, m, b, hpe, hsupp⟩
+
+/-- The right endpoint of a lower edge is a lower vertex. -/
+theorem IsLowerEdge.right_isVertex {pts : List SupportPoint} {p q : SupportPoint}
+    (h : IsLowerEdge pts p q) : IsLowerVertex pts q := by
+  obtain ⟨_, hq, m, b, _, hqe, hsupp⟩ := h
+  exact ⟨hq, m, b, hqe, hsupp⟩
+
+/-- `IsLowerEdge` is symmetric in its endpoints. -/
+theorem IsLowerEdge.symm {pts : List SupportPoint} {p q : SupportPoint}
+    (h : IsLowerEdge pts p q) : IsLowerEdge pts q p := by
+  obtain ⟨hp, hq, m, b, hpe, hqe, hsupp⟩ := h
+  exact ⟨hq, hp, m, b, hqe, hpe, hsupp⟩
+
+/-- **The slope of a lower edge equals its supporting line's slope.**  When the
+endpoints have distinct `i`-coordinates, `edgeSlope p q` is the unique slope `m`
+of the supporting line through both, and that line still lies below every point. -/
+theorem IsLowerEdge.edgeSlope_eq {pts : List SupportPoint} {p q : SupportPoint}
+    (h : IsLowerEdge pts p q) (hne : (p.1 : ℚ) ≠ q.1) :
+    ∃ m b : ℚ, edgeSlope p q = m ∧
+      p.2 = m * (p.1 : ℚ) + b ∧ q.2 = m * (q.1 : ℚ) + b ∧
+      ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2 := by
+  obtain ⟨_, _, m, b, hpe, hqe, hsupp⟩ := h
+  refine ⟨m, b, ?_, hpe, hqe, hsupp⟩
+  rw [edgeSlope, div_eq_iff (sub_ne_zero.mpr (Ne.symm hne)), hpe, hqe]
+  ring
+
+/-- **Supporting-slope lower bound (rightward).**  If a supporting line of slope
+`m` passes through `p` and lies below every support point, then every point `q`
+strictly to the right of `p` has slope `m ≤ edgeSlope p q`.  Thus the supporting
+slope is the *smallest* slope leaving `p` — the dominant edge of the lower hull. -/
+theorem edgeSlope_ge_of_supportingLine {pts : List SupportPoint} {p q : SupportPoint}
+    {m b : ℚ} (hpe : p.2 = m * (p.1 : ℚ) + b) (hq : q ∈ pts)
+    (hsupp : ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2)
+    (hlt : (p.1 : ℚ) < q.1) : m ≤ edgeSlope p q := by
+  have hpos : (0 : ℚ) < (q.1 : ℚ) - p.1 := by linarith
+  have hq2 : m * (q.1 : ℚ) + b ≤ q.2 := hsupp q hq
+  rw [edgeSlope, le_div_iff₀ hpos]
+  have hexp : m * ((q.1 : ℚ) - p.1) = m * (q.1 : ℚ) - m * (p.1 : ℚ) := by ring
+  rw [hexp]; linarith [hpe, hq2]
+
+/-- **Supporting-slope upper bound (leftward).**  Symmetrically, every support
+point `q` strictly to the left of `p` has slope `edgeSlope q p ≤ m`. -/
+theorem edgeSlope_le_of_supportingLine {pts : List SupportPoint} {p q : SupportPoint}
+    {m b : ℚ} (hpe : p.2 = m * (p.1 : ℚ) + b) (hq : q ∈ pts)
+    (hsupp : ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2)
+    (hlt : (q.1 : ℚ) < p.1) : edgeSlope q p ≤ m := by
+  have hpos : (0 : ℚ) < (p.1 : ℚ) - q.1 := by linarith
+  have hq2 : m * (q.1 : ℚ) + b ≤ q.2 := hsupp q hq
+  rw [edgeSlope, div_le_iff₀ hpos]
+  have hexp : m * ((p.1 : ℚ) - q.1) = m * (p.1 : ℚ) - m * (q.1 : ℚ) := by ring
+  rw [hexp]; linarith [hpe, hq2]
+
+/-- **A lower edge is convex from below.**  For any support point `r` strictly
+between the endpoints `p` and `q` of a lower edge, the right sub-slope is at most
+the left sub-slope: `edgeSlope r q ≤ edgeSlope p r`.  Equivalently the polygon
+never dips below the edge line — the defining property of a lower-hull edge. -/
+theorem IsLowerEdge.interior_slopes {pts : List SupportPoint} {p q r : SupportPoint}
+    (h : IsLowerEdge pts p q) (hr : r ∈ pts)
+    (hpr : (p.1 : ℚ) < r.1) (hrq : (r.1 : ℚ) < q.1) :
+    edgeSlope r q ≤ edgeSlope p r := by
+  obtain ⟨_, _, m, b, hpe, hqe, hsupp⟩ := h
+  have h1 : m ≤ edgeSlope p r := edgeSlope_ge_of_supportingLine hpe hr hsupp hpr
+  have h2 : edgeSlope r q ≤ m := edgeSlope_le_of_supportingLine hqe hr hsupp hrq
+  linarith
+
+/-- The single Newton-polygon edge of `Y² − x` is a genuine lower edge, witnessed
+by the line `y = -½ i + 1` through `(0,1)` and `(2,0)`. -/
+theorem ysqMinusX_isLowerEdge : IsLowerEdge YsqMinusX (0, 1) (2, 0) := by
+  refine ⟨by simp [YsqMinusX], by simp [YsqMinusX], -1/2, 1, by norm_num, by norm_num,
+    fun r hr => ?_⟩
+  fin_cases hr <;> norm_num
+
 end PuiseuxTheoremOQ03

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "puiseux-theorem-oq-03",
   "title": "Puiseux Theorem OQ-03: A Combinatorial Newton Polygon",
   "slug": "puiseux-theorem-oq-03",
-  "description": "First Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex), proves the minimum-valuation point is always a vertex (isLowerVertex_of_minimal) and that every nonempty support set has one (exists_lowerVertex via List.argmin), and works the canonical Y²−x example: both support points are vertices, the single edge has slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. Also fixes a parse error in the parent file (a dangling /-- doc comment).",
+  "description": "Lean deliverable for the computational sub-question of Puiseux's theorem (\"Can the Newton–Puiseux algorithm be made efficient enough for computational algebraic geometry at scale?\"). Introduces the Newton polygon of a polynomial over a valued field via the supporting-line characterization of lower-hull vertices (IsLowerVertex) — the minimum-valuation point is always a vertex and every nonempty support set has one (via List.argmin) — and then develops the lower-hull EDGE and CONVEXITY layer (IsLowerEdge): an edge's slope equals its supporting line's slope, both endpoints are vertices, the supporting slope bounds the slopes to every other support point (edgeSlope_ge/le_of_supportingLine), and a lower edge is convex from below (no support point dips below it: edgeSlope r q ≤ edgeSlope p r for interior r). The canonical Y²−x example is carried through: both support points are vertices, the single segment is a genuine lower edge of slope −1/2, and the leading exponent 1/2 matches the parent's leadingExponentFromSlope. Also fixes a parse error in the parent file (a dangling /-- doc comment).",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Newton_polygon",
@@ -21,20 +21,25 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 7 theorems and 3 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 15 theorems and 4 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
       "exists_lowerVertex: every nonempty support set has a lower vertex (via List.argmin)",
       "IsLowerVertex.mem: lower vertices are genuine support points",
       "edgeSlope: slope of the segment joining two support points",
-      "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
+      "IsLowerEdge: supporting-line characterization of a lower-hull EDGE (one line through two support points, below all)",
+      "IsLowerEdge.left_isVertex / right_isVertex / symm: each edge endpoint is a vertex; edges are symmetric",
+      "IsLowerEdge.edgeSlope_eq: an edge's slope equals its supporting line's slope m (for distinct i-coordinates)",
+      "edgeSlope_ge_of_supportingLine / edgeSlope_le_of_supportingLine: the supporting slope bounds slopes to every other support point (rightward ≥ m, leftward ≤ m) — the convexity inequalities",
+      "IsLowerEdge.interior_slopes: a lower edge is convex from below — for interior r, edgeSlope r q ≤ edgeSlope p r (the polygon never dips below the edge)",
+      "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, the segment is a genuine lower edge, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
       "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 145,
-    "theoremCount": 7,
-    "definitionCount": 3,
+    "lineCount": 241,
+    "theoremCount": 15,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -93,6 +98,34 @@
       "statement": "$-\\text{edgeSlope}((0,1),(2,0)) = \\text{leadingExponentFromSlope}(1,2) = 1/2$",
       "significance": "Closes the loop to the parent: the negative edge slope recovers the leading exponent 1/2 of the root x^{1/2} of Y²−x, exactly the parent's leadingExponentFromSlope definition.",
       "description": "Unfolds edgeSlope and the parent definition; both sides equal 1/2 by norm_num."
+    },
+    {
+      "name": "IsLowerEdge",
+      "type": "definition",
+      "statement": "$\\text{IsLowerEdge}(\\text{pts}, p, q) := p,q \\in \\text{pts} \\wedge \\exists m\\,b,\\; p_2 = m p_1 + b \\wedge q_2 = m q_1 + b \\wedge \\forall r \\in \\text{pts},\\; m r_1 + b \\le r_2$",
+      "significance": "Supporting-line characterization of an EDGE of the lower hull: a single line touching two support points and lying below all of them. The edge layer above IsLowerVertex.",
+      "description": "Both endpoints lie on one supporting line; that line's slope is edgeSlope p q."
+    },
+    {
+      "name": "IsLowerEdge.edgeSlope_eq",
+      "type": "theorem",
+      "statement": "$\\text{IsLowerEdge}(\\text{pts},p,q) \\wedge p_1 \\ne q_1 \\Rightarrow \\exists m\\,b,\\; \\text{edgeSlope}(p,q) = m \\wedge \\dots$",
+      "significance": "The slope of a lower edge is exactly the slope m of its supporting line — identifies the abstract edge with the concrete edgeSlope of its endpoints.",
+      "description": "From p₂ = m·p₁+b and q₂ = m·q₁+b, div_eq_iff and ring give (q₂−p₂)/(q₁−p₁) = m."
+    },
+    {
+      "name": "edgeSlope_ge_of_supportingLine",
+      "type": "theorem",
+      "statement": "$p_2 = m p_1 + b \\wedge (\\forall r \\in \\text{pts}, m r_1 + b \\le r_2) \\wedge p_1 < q_1 \\Rightarrow m \\le \\text{edgeSlope}(p,q)$",
+      "significance": "Convexity inequality (rightward): the supporting slope m is a lower bound on the slope to any point on the right, so m is the smallest slope leaving p — the dominant edge of the lower hull.",
+      "description": "Clear the positive denominator with le_div_iff₀; the supporting inequality at q minus the line equation at p gives m·(q₁−p₁) ≤ q₂−p₂ by linarith."
+    },
+    {
+      "name": "IsLowerEdge.interior_slopes",
+      "type": "theorem",
+      "statement": "$\\text{IsLowerEdge}(\\text{pts},p,q) \\wedge r \\in \\text{pts} \\wedge p_1 < r_1 < q_1 \\Rightarrow \\text{edgeSlope}(r,q) \\le \\text{edgeSlope}(p,r)$",
+      "significance": "A lower edge is convex from below: every support point strictly between the endpoints lies on or above the edge line, so the right sub-slope never exceeds the left sub-slope. This is the defining certificate of a genuine lower-hull edge and the structural fact behind the Newton polygon theorem.",
+      "description": "Combines edgeSlope_ge_of_supportingLine (m ≤ edgeSlope p r) with edgeSlope_le_of_supportingLine (edgeSlope r q ≤ m) via linarith."
     }
   ],
   "references": [
@@ -150,18 +183,19 @@
       "Mathlib.Data.List.MinMax"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 145,
+    "lineCount": 241,
     "axiomCount": 0,
-    "theoremCount": 7,
-    "definitionCount": 3,
+    "theoremCount": 15,
+    "definitionCount": 4,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
   },
   "conclusion": {
-    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, and the worked Y²−x example tying the edge slope to the parent's leadingExponentFromSlope. All 7 theorems and 3 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
-    "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
+    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks, in two layers. The VERTEX layer: the supporting-line predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, and an existence lemma for nonempty supports. The EDGE/CONVEXITY layer: IsLowerEdge (one supporting line through two points, below all), the fact that an edge's slope is its supporting line's slope, that both endpoints are vertices, the supporting-slope bounds edgeSlope_ge/le_of_supportingLine, and the convexity certificate IsLowerEdge.interior_slopes (a lower edge is never undercut by an interior support point). The worked Y²−x example is carried through both layers and tied to the parent's leadingExponentFromSlope. All 15 theorems and 4 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
+    "implications": "The convexity inequalities are the structural heart of the Newton polygon theorem (negatives of edge slopes = root valuations): they certify that lower-hull edge slopes are the extremal/candidate valuations and that the polygon is genuinely convex from below. This algorithm-independent data layer is now rich enough that, given a valuation API on K((x))[Y], the Newton polygon theorem and Newton–Puiseux termination measures can be stated directly on top of it.",
     "openQuestions": [
       "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y])",
+      "Prove slope monotonicity across consecutive lower-hull edges (slopes strictly increase left to right), giving the finite list of candidate root valuations",
       "Define a termination measure for one Newton–Puiseux reduction step and prove the Y-degree strictly decreases (S2-B)",
       "State and bound the arithmetic complexity of the algorithm (Poteaux–Weimann Õ(d·δ)) — blocked on the absence of an arithmetic-complexity model in Mathlib (S2-C, moonshot)"
     ]

--- a/src/data/research/problems/puiseux-theorem-oq-03.json
+++ b/src/data/research/problems/puiseux-theorem-oq-03.json
@@ -19,7 +19,7 @@
     "phase": "ACT",
     "since": "2026-05-12T13:53:16-07:00",
     "iteration": 2,
-    "focus": "Shipped combinatorial Newton polygon (S2-A): IsLowerVertex predicate + structure lemmas + Y^2-x example, verified 0-sorry 0-axiom.",
+    "focus": "Extended the combinatorial Newton polygon with the lower-hull EDGE/CONVEXITY layer (researcher-2, 2026-06-27): IsLowerEdge predicate, edge-slope = supporting-line slope, endpoints are vertices, supporting-slope bounds (edgeSlope_ge/le_of_supportingLine), and convexity certificate IsLowerEdge.interior_slopes. File now 241 lines, 15 theorems, 4 defs, verified 0-sorry 0-axiom.",
     "blockers": [],
     "nextAction": "S2-A harder half: Newton polygon theorem (edge slopes = root valuations) once a valuation API on K((x))[Y] exists; then S2-B termination measure.",
     "attemptCounts": {
@@ -29,13 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Delivered the first Lean file Proofs/PuiseuxTheoremOQ03.lean (145 lines, 7 theorems, 3 defs, verified, 0 sorries, 0 axioms): a combinatorial Newton polygon via the supporting-line lower-vertex predicate IsLowerVertex, with the seed lemma (min-valuation point is a vertex), an existence lemma (List.argmin), and the worked Y^2-x example tying edge slope -1/2 to the parent leadingExponentFromSlope 1 2. Also fixed a parse error in the parent PuiseuxTheorem.lean (dangling /-- doc comment). PR #30757.",
+    "progressSummary": "S2-A combinatorial Newton polygon now has both a vertex layer (IsLowerVertex, seed + existence) and an edge/convexity layer (IsLowerEdge): an edge's slope equals its supporting line's slope, both endpoints are lower vertices, the supporting slope bounds slopes to all other points (the convexity inequalities), and a lower edge is convex from below (interior_slopes: edgeSlope r q <= edgeSlope p r). Worked Y^2-x example carried through. Verified 0-sorry 0-axiom (#print axioms: only propext/Classical.choice/Quot.sound). The Newton polygon theorem proper (slopes = root valuations) still needs a valuation API on K((x))[Y] absent from Mathlib 4.26.0.",
     "builtItems": [
       "IsLowerVertex: supporting-line characterization of a Newton-polygon lower-hull vertex (algorithm-independent Prop)",
       "isLowerVertex_of_minimal: the min-valuation support point is always a lower vertex (horizontal supporting line)",
       "exists_lowerVertex: every nonempty support set has a lower vertex (via List.argmin)",
       "edgeSlope + worked Y^2-x example: both support points are vertices, edge slope -1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
-      "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)"
+      "Parent fix: corrected dangling /-- doc comment in PuiseuxTheorem.lean (file did not parse on main)",
+      "Edge/convexity layer in Proofs/PuiseuxTheoremOQ03.lean: IsLowerEdge + left/right_isVertex + symm + edgeSlope_eq + edgeSlope_ge/le_of_supportingLine + interior_slopes + ysqMinusX_isLowerEdge (researcher-2, 2026-06-27)."
     ],
     "insights": [
       "Supporting-line predicate beats a verified convex-hull construction: same downstream value, far less proof burden, algorithm-agnostic.",
@@ -48,9 +49,9 @@
       "No arithmetic-complexity model (Bürgisser-Clausen-Shokrollahi style) to state the Poteaux-Weimann Õ(d·δ) bound."
     ],
     "nextSteps": [
-      "Prove the Newton polygon theorem: negatives of lower-hull edge slopes = root valuations in an alg-closed valued extension.",
-      "S2-B: termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases).",
-      "S2-C (moonshot): state and bound arithmetic complexity once an arithmetic-cost model exists."
+      "Prove slope monotonicity across consecutive lower-hull edges (slopes strictly increase left to right) -> finite candidate root-valuation list.",
+      "Newton polygon theorem: negatives of lower-hull edge slopes = root valuations in an alg-closed valued extension (needs valuation API on K((x))[Y]).",
+      "S2-B: termination measure for one Newton-Puiseux reduction step (Y-degree strictly decreases)."
     ],
     "markdown": "# Knowledge Base: puiseux-theorem-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "archivedSessions": [


### PR DESCRIPTION
## Summary

Depth-first extension of **puiseux-theorem-oq-03** ("A Combinatorial Newton Polygon", PR #30757). The existing file gave the **vertex** layer (`IsLowerVertex`, seed lemma, existence via `List.argmin`). This PR adds the **edge / convexity** layer on top of it — the structural content behind the Newton polygon theorem — all verified axiom-free.

## New results (`proofs/Proofs/PuiseuxTheoremOQ03.lean`)

- `IsLowerEdge` — supporting-line predicate for a lower-hull **edge**: one line through two support points lying weakly below all of them.
- `IsLowerEdge.left_isVertex` / `right_isVertex` / `symm` — edge endpoints are lower vertices; edges are symmetric.
- `IsLowerEdge.edgeSlope_eq` — an edge's slope **equals** its supporting line's slope `m` (for distinct `i`-coordinates), identifying the abstract edge with the concrete `edgeSlope`.
- `edgeSlope_ge_of_supportingLine` / `edgeSlope_le_of_supportingLine` — the **convexity inequalities**: the supporting slope `m` bounds the slope to every other support point (`m ≤ edgeSlope p q` rightward, `edgeSlope q p ≤ m` leftward). So `m` is the smallest slope leaving the vertex — the dominant edge.
- `IsLowerEdge.interior_slopes` — **a lower edge is convex from below**: for any support point `r` strictly between the endpoints, `edgeSlope r q ≤ edgeSlope p r` — the polygon never dips below the edge line. This is the defining certificate of a genuine lower-hull edge.
- `ysqMinusX_isLowerEdge` — the `Y²−x` segment `(0,1)`–`(2,0)` is a genuine lower edge.

**File now: 241 lines, 15 theorems, 4 definitions, 0 sorries, 0 axioms.**

## Verification

Built locally with `lake env lean Proofs/PuiseuxTheoremOQ03.lean` against the pinned Mathlib (Docker host unavailable). `#print axioms` on the new theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

## Scope

The Newton polygon theorem proper (negatives of edge slopes = root valuations) still requires a valuation API on `K((x))[Y]` absent from Mathlib v4.26.0. The convexity lemmas here are the combinatorial groundwork it will sit on; next natural step is slope-monotonicity across consecutive edges.

## Files
- `proofs/Proofs/PuiseuxTheoremOQ03.lean` (extended; already registered in `proofs/Proofs.lean`)
- `src/data/proofs/puiseux-theorem-oq-03/meta.json` (updated counts, theorems, conclusion)
- `src/data/research/problems/puiseux-theorem-oq-03.json` (session progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)