### PR TITLE
Enrich Erdős #57 OQ-04: annotation metadata + setup section

### DIFF
--- a/src/data/proofs/erdos-57-oq-04/annotations.json
+++ b/src/data/proofs/erdos-57-oq-04/annotations.json
@@ -1,11 +1,27 @@
 [
   {
+    "id": "ann-57oq04-setup",
+    "proofId": "erdos-57-oq-04",
+    "range": { "startLine": 33, "endLine": 119 },
+    "type": "definition",
+    "title": "Problem setup: odd cycle lengths and the Erdős–Hajnal axiom",
+    "content": "The framing layer. `cycleLengths` and `oddCycleLengths` collect the lengths of (odd) cycles via Mathlib's `Walk.IsCycle`; `IsColorable`/`HasInfiniteChromaticNumber` give the chromatic-number side, and `oddCycleHarmonicSum` is the ENNReal series ∑ 1/aᵢ over odd cycle lengths. The Erdős–Hajnal conjecture — that infinite chromatic number forces ∑ 1/aᵢ = ∞, solved by Liu–Montgomery (2020) — is recorded as the `axiom erdos_57` (the file is therefore `axiomatized`, not because of the OQ-04 crux work but because of this deep input). `finite_reciprocal_sum_ne_top` and `oddCycleLengths_pos` then power the corollary `infinite_odd_cycle_lengths`: a graph of infinite chromatic number has infinitely many distinct odd cycle lengths (a finite set of positive reciprocals cannot sum to ⊤).",
+    "mathContext": "$\\text{oddCycleLengths}(G)=\\{n\\in\\text{cycleLengths}(G): n\\text{ odd}\\}$; Erdős–Hajnal: $\\chi(G)=\\infty \\Rightarrow \\sum_{a_i\\text{ odd cycle len}} 1/a_i = \\infty$.",
+    "significance": "context",
+    "relatedConcepts": ["chromatic number", "Erdős–Hajnal conjecture", "harmonic series divergence", "ENNReal tsum", "Liu–Montgomery theorem"],
+    "prerequisites": ["graph coloring", "infinite series in ENNReal", "Mathlib SimpleGraph.Walk"]
+  },
+  {
     "id": "ann-57oq04-rotate",
     "proofId": "erdos-57-oq-04",
     "range": { "startLine": 160, "endLine": 169 },
     "type": "technique",
     "title": "Rotation preserves walk length",
-    "content": "`aux_length_rotate` proves `(c.rotate h).length = c.length`. Mathlib's `rotate` re-bases a closed walk `c : Walk y y` at any vertex `z` of its support as `(c.dropUntil z h).append (c.takeUntil z h)`. Using `take_spec` (the take/drop pieces recombine to `c`) and `length_append`, both arrangements have the same total length. Mathlib provides `support_rotate` but no length lemma; this one is needed so that rotating before splitting does not disturb the strong-induction measure (the walk length)."
+    "content": "`aux_length_rotate` proves `(c.rotate h).length = c.length`. Mathlib's `rotate` re-bases a closed walk `c : Walk y y` at any vertex `z` of its support as `(c.dropUntil z h).append (c.takeUntil z h)`. Using `take_spec` (the take/drop pieces recombine to `c`) and `length_append`, both arrangements have the same total length. Mathlib provides `support_rotate` but no length lemma; this one is needed so that rotating before splitting does not disturb the strong-induction measure (the walk length).",
+    "mathContext": "$\\operatorname{len}(\\operatorname{rotate}(c,z)) = \\operatorname{len}(c)$, since $c = \\operatorname{takeUntil}(c,z)\\mathbin{+\\!\\!+}\\operatorname{dropUntil}(c,z)$ and append adds lengths.",
+    "significance": "supporting",
+    "relatedConcepts": ["closed walk rotation", "Walk.append", "takeUntil/dropUntil", "induction measure"],
+    "prerequisites": ["Mathlib SimpleGraph.Walk API"]
   },
   {
     "id": "ann-57oq04-edge-case",
@@ -13,7 +29,11 @@
     "range": { "startLine": 170, "endLine": 192 },
     "type": "technique",
     "title": "Ruling out the closing-edge degenerate case",
-    "content": "`isPath_length_one_of_mem_edges`: if a path from v to u contains the edge s(u,v) joining its own endpoints, it must be the single-edge path. The proof case-splits on the first edge. If the first edge IS s(u,v), the remainder is a path-loop (`isPath_iff_eq_nil`), hence `nil`, so the walk has length 1. Otherwise s(u,v) lies deeper, so `snd_mem_support_of_mem_edges` puts the start vertex v back in the interior support, contradicting the path's `Nodup` support. This eliminates the `cons_isCycle_iff` failure mode where the closing edge already occurs in the tail — so for an odd non-cycle walk only the genuine repeated-vertex case survives."
+    "content": "`isPath_length_one_of_mem_edges`: if a path from v to u contains the edge s(u,v) joining its own endpoints, it must be the single-edge path. The proof case-splits on the first edge. If the first edge IS s(u,v), the remainder is a path-loop (`isPath_iff_eq_nil`), hence `nil`, so the walk has length 1. Otherwise s(u,v) lies deeper, so `snd_mem_support_of_mem_edges` puts the start vertex v back in the interior support, contradicting the path's `Nodup` support. This eliminates the `cons_isCycle_iff` failure mode where the closing edge already occurs in the tail — so for an odd non-cycle walk only the genuine repeated-vertex case survives.",
+    "mathContext": "If a path $p: v \\to u$ has $s(u,v)\\in E(p)$ then $\\operatorname{len}(p)=1$; otherwise $v$ would repeat in the interior, breaking $\\operatorname{Nodup}(p.\\text{support})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsPath", "Nodup support", "cons_isCycle_iff", "edge membership"],
+    "prerequisites": ["paths vs cycles in SimpleGraph", "case analysis on Walk.cons"]
   },
   {
     "id": "ann-57oq04-induction",
@@ -21,7 +41,11 @@
     "range": { "startLine": 193, "endLine": 287 },
     "type": "technique",
     "title": "Strong induction: rotate to a repeated vertex and split",
-    "content": "`exists_odd_cycle_aux` runs strong induction on `n = w.length`. If `w.IsCycle`, it is the desired odd cycle. Otherwise, being odd, `w = cons h p` is not a cycle, so by `cons_isCycle_iff` (after discharging the edge case) `p` is not a path: its support repeats a vertex `z`. Rotating `w` to base at `z` and writing the result as `cons e r'`, the vertex `z` occurs at least twice in `r'.support`. Splitting `r'` at the first occurrence of `z` (`takeUntil`/`dropUntil`, recombined by `take_spec`) gives two closed walks at `z` whose lengths sum to `n`. `count_support_takeUntil_eq_one` (the prefix meets `z` exactly once) forces the suffix to be non-trivial, so BOTH pieces are strictly shorter than `n`. Since `n` is odd, `Nat.odd_add` makes exactly one piece odd, and the induction hypothesis applies to it."
+    "content": "`exists_odd_cycle_aux` runs strong induction on `n = w.length`. If `w.IsCycle`, it is the desired odd cycle. Otherwise, being odd, `w = cons h p` is not a cycle, so by `cons_isCycle_iff` (after discharging the edge case) `p` is not a path: its support repeats a vertex `z`. Rotating `w` to base at `z` and writing the result as `cons e r'`, the vertex `z` occurs at least twice in `r'.support`. Splitting `r'` at the first occurrence of `z` (`takeUntil`/`dropUntil`, recombined by `take_spec`) gives two closed walks at `z` whose lengths sum to `n`. `count_support_takeUntil_eq_one` (the prefix meets `z` exactly once) forces the suffix to be non-trivial, so BOTH pieces are strictly shorter than `n`. Since `n` is odd, `Nat.odd_add` makes exactly one piece odd, and the induction hypothesis applies to it.",
+    "mathContext": "Odd closed walk $w$, $\\operatorname{len}(w)=n$ odd. Split at a repeated vertex: $n = n_1 + n_2$ with $n_1,n_2 < n$; $n$ odd $\\Rightarrow$ exactly one $n_i$ odd (Nat.odd_add) $\\Rightarrow$ strong IH gives an odd cycle.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction on length", "Walk.rotate", "takeUntil/dropUntil split", "parity of a sum", "odd cycle extraction"],
+    "prerequisites": ["Nat.strong_induction", "parity arithmetic", "Mathlib Walk splitting lemmas"]
   },
   {
     "id": "ann-57oq04-crux",
@@ -29,6 +53,10 @@
     "range": { "startLine": 288, "endLine": 330 },
     "type": "concept",
     "title": "Crux lemma and the completed bipartite characterization",
-    "content": "`exists_odd_cycle_of_odd_closed_walk` is the auxiliary specialized to `n = w.length` (with `classical` supplying `DecidableEq V`). It is precisely the combinatorial step Mathlib's `SimpleGraph.Bipartite` lists as a TODO: every odd closed walk contains an odd cycle. With it, the parent's `bipartite_iff_no_odd_cycles` reverse direction completes — route through `two_colorable_iff_forall_loop_even`, and an odd loop would yield an odd cycle contradicting `oddCycleLengths G = ∅` — and `colorable_two_no_odd_cycles` follows. Both are now sorry-free; `#print axioms` on the crux lemma and on `bipartite_iff_no_odd_cycles` reports only `propext`, `Classical.choice`, `Quot.sound`. This drops `Erdos57Problem.lean` from 1 sorry to 0 (it remains `axiomatized` only because of the deep open axiom `erdos_57`)."
+    "content": "`exists_odd_cycle_of_odd_closed_walk` is the auxiliary specialized to `n = w.length` (with `classical` supplying `DecidableEq V`). It is precisely the combinatorial step Mathlib's `SimpleGraph.Bipartite` lists as a TODO: every odd closed walk contains an odd cycle. With it, the parent's `bipartite_iff_no_odd_cycles` reverse direction completes — route through `two_colorable_iff_forall_loop_even`, and an odd loop would yield an odd cycle contradicting `oddCycleLengths G = ∅` — and `colorable_two_no_odd_cycles` follows. Both are now sorry-free; `#print axioms` on the crux lemma and on `bipartite_iff_no_odd_cycles` reports only `propext`, `Classical.choice`, `Quot.sound`. This drops `Erdos57Problem.lean` from 1 sorry to 0 (it remains `axiomatized` only because of the deep open axiom `erdos_57`).",
+    "mathContext": "Every odd closed walk contains an odd cycle $\\Rightarrow$ $G$ bipartite $\\iff$ $\\text{oddCycleLengths}(G)=\\varnothing$ $\\iff$ $G$ is 2-colorable (König-style characterization).",
+    "significance": "key",
+    "relatedConcepts": ["bipartite characterization", "2-colorability", "König's theorem", "SimpleGraph.Bipartite TODO", "axiom auditing"],
+    "prerequisites": ["bipartite graphs", "graph 2-coloring", "the strong-induction crux lemma"]
   }
 ]

--- a/src/data/proofs/erdos-57-oq-04/meta.json
+++ b/src/data/proofs/erdos-57-oq-04/meta.json
@@ -93,6 +93,14 @@
   },
   "sections": [
     {
+      "id": "problem-setup",
+      "title": "Problem setup: odd cycle lengths, the Erdős–Hajnal axiom, and bipartite framing",
+      "startLine": 33,
+      "endLine": 159,
+      "summary": "Defines cycleLengths / oddCycleLengths (via Walk.IsCycle), IsColorable / HasInfiniteChromaticNumber, and the ENNReal harmonic sum ∑ 1/aᵢ. Records the Erdős–Hajnal theorem (Liu–Montgomery 2020) as axiom erdos_57 and derives infinite_odd_cycle_lengths from it. Also states the open upper-density conjectures and the noOddCycles_of_boolColoring lemma that opens the bipartite characterization.",
+      "mathContext": "The OQ-04 crux is purely combinatorial; the only deep input is the axiomatized Erdős–Hajnal divergence ∑ 1/aᵢ = ∞ for χ(G) = ∞."
+    },
+    {
       "id": "aux-rotate",
       "title": "aux_length_rotate — rotation preserves walk length",
       "startLine": 160,


### PR DESCRIPTION
Enrichment pass for `erdos-57-oq-04`.

## What changed
- **Annotation metadata**: all 4 existing annotations were content-only. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to each, anchored to their existing Lean line ranges.
- **New 5th annotation** covering the previously-unannotated problem setup (lines 33–119): the odd-cycle-length definitions, the Erdős–Hajnal `axiom erdos_57`, and the `infinite_odd_cycle_lengths` corollary.
- **New section**: `sections` previously started at line 160, omitting all definitions and the axiom. Added a 'Problem setup' section spanning lines 33–159.

## Verification
- JSON valid; meta.json 19.6 KB (under 60 KB cap), no collection caps exceeded
- Annotations anchor cleanly (0 errors for this entry under `annotations/build.ts --strict`)
- All 5 annotations now carry full metadata
- Axiom integrity unchanged: status remains `axiomatized` (deep `erdos_57` axiom), 0 sorries — accurately described in the new setup annotation