### PR TITLE
research(puiseux-theorem-oq-03): supporting-slope bounds + convex-from-below [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/PuiseuxTheoremOQ03.lean
+++ b/proofs/Proofs/PuiseuxTheoremOQ03.lean
@@ -221,4 +221,57 @@ theorem ysqMinusX_isLowerEdge : IsLowerEdge YsqMinusX (0, 1) (2, 0) := by
     -1/2, 1, by norm_num, by norm_num, fun r hr => ?_⟩
   fin_cases hr <;> norm_num
 
+/-! ### Supporting-slope bounds and convexity from below
+
+`edgeSlope_mono` above states convexity between two *edges sharing a vertex*.
+The lemmas here give the complementary, finer statement directly from a single
+supporting line: the supporting slope `m` through a vertex `p` bounds the slope
+to **every** other support point — `m` is a lower bound to the right and an upper
+bound to the left.  This yields the sharper convexity certificate
+`interior_slopes`: **no** support point — vertex or not — ever dips below a lower
+edge.  These are stated on the raw supporting-line data, so they apply to any
+vertex/edge regardless of whether the intermediate points happen to be vertices
+of further edges. -/
+
+/-- **Supporting-slope lower bound (rightward).**  If a line of slope `m` passes
+through `p` and lies weakly below every support point, then every support point
+`q` strictly to the right of `p` has `m ≤ edgeSlope p q`.  So the supporting
+slope is the *smallest* slope leaving `p` — the dominant edge of the lower hull. -/
+theorem edgeSlope_ge_of_supportingLine {pts : List SupportPoint} {p q : SupportPoint}
+    {m b : ℚ} (hpe : p.2 = m * (p.1 : ℚ) + b) (hq : q ∈ pts)
+    (hsupp : ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2)
+    (hlt : (p.1 : ℚ) < q.1) : m ≤ edgeSlope p q := by
+  have hpos : (0 : ℚ) < (q.1 : ℚ) - p.1 := by linarith
+  have hq2 : m * (q.1 : ℚ) + b ≤ q.2 := hsupp q hq
+  rw [edgeSlope, le_div_iff₀ hpos]
+  have hexp : m * ((q.1 : ℚ) - p.1) = m * (q.1 : ℚ) - m * (p.1 : ℚ) := by ring
+  rw [hexp]; linarith [hpe, hq2]
+
+/-- **Supporting-slope upper bound (leftward).**  Symmetrically, every support
+point `q` strictly to the left of `p` has `edgeSlope q p ≤ m`. -/
+theorem edgeSlope_le_of_supportingLine {pts : List SupportPoint} {p q : SupportPoint}
+    {m b : ℚ} (hpe : p.2 = m * (p.1 : ℚ) + b) (hq : q ∈ pts)
+    (hsupp : ∀ r ∈ pts, m * (r.1 : ℚ) + b ≤ r.2)
+    (hlt : (q.1 : ℚ) < p.1) : edgeSlope q p ≤ m := by
+  have hpos : (0 : ℚ) < (p.1 : ℚ) - q.1 := by linarith
+  have hq2 : m * (q.1 : ℚ) + b ≤ q.2 := hsupp q hq
+  rw [edgeSlope, div_le_iff₀ hpos]
+  have hexp : m * ((p.1 : ℚ) - q.1) = m * (p.1 : ℚ) - m * (q.1 : ℚ) := by ring
+  rw [hexp]; linarith [hpe, hq2]
+
+/-- **A lower edge is convex from below.**  For *any* support point `r` strictly
+between the endpoints `p` and `q` of a lower edge, the right sub-slope is at most
+the left sub-slope: `edgeSlope r q ≤ edgeSlope p r`.  Equivalently, `r` lies on
+or above the edge line — the polygon never dips below an edge.  Unlike
+`edgeSlope_mono`, `r` need not be a vertex of any edge; this is the full
+lower-hull convexity certificate. -/
+theorem IsLowerEdge.interior_slopes {pts : List SupportPoint} {p q r : SupportPoint}
+    (h : IsLowerEdge pts p q) (hr : r ∈ pts)
+    (hpr : (p.1 : ℚ) < r.1) (hrq : (r.1 : ℚ) < q.1) :
+    edgeSlope r q ≤ edgeSlope p r := by
+  obtain ⟨_, _, _, m, b, hpe, hqe, hsupp⟩ := h
+  have h1 : m ≤ edgeSlope p r := edgeSlope_ge_of_supportingLine hpe hr hsupp hpr
+  have h2 : edgeSlope r q ≤ m := edgeSlope_le_of_supportingLine hqe hr hsupp hrq
+  linarith
+
 end PuiseuxTheoremOQ03

--- a/src/data/proofs/puiseux-theorem-oq-03/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "infrastructure",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All 13 theorems and 4 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
+    "assumptions": "None. All 16 theorems and 4 definitions are fully verified with 0 sorries and 0 axioms (only the foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). The Newton polygon theorem proper (edge slopes = root valuations), a Newton–Puiseux termination measure, and the quasi-linear complexity bound remain open — they need valuation API on K((x))[Y] and an arithmetic-complexity model, neither in Mathlib 4.26.0.",
     "originalContributions": [
       "IsLowerVertex: supporting-line characterization of a lower-hull (Newton-polygon) vertex, algorithm-independent",
       "isLowerVertex_of_minimal: the minimum-valuation support point is always a lower vertex (horizontal supporting line)",
@@ -33,12 +33,14 @@
       "IsLowerEdge.isLowerVertex_left / _right: the endpoints of a lower edge are lower vertices (edge ↔ vertex bridge)",
       "edgeSlope_mono: CONVEXITY of the Newton polygon — adjacent lower edges sharing a vertex have non-decreasing slope (the one-line supporting-line argument)",
       "rootValuation_antitone: consequently the root valuations (negated edge slopes) are sorted across the polygon",
+      "edgeSlope_ge_of_supportingLine / edgeSlope_le_of_supportingLine: a vertex's supporting slope m bounds the slope to EVERY other support point (>= m to the right, <= m to the left) — the per-line convexity bounds complementing edgeSlope_mono",
+      "IsLowerEdge.interior_slopes: a lower edge is convex from below — for ANY interior support point r (vertex or not), edgeSlope r q <= edgeSlope p r, so the polygon never dips below an edge (sharper than the adjacent-edge edgeSlope_mono)",
       "Worked Y²−x example: both (0,1) and (2,0) are lower vertices, the segment is a genuine lower edge, edge slope = −1/2, leading exponent 1/2 = leadingExponentFromSlope 1 2",
       "Parent fix: corrected a dangling /-- doc comment in PuiseuxTheorem.lean that made the file fail to parse"
     ],
     "dateAdded": "2026-06-27",
-    "lineCount": 224,
-    "theoremCount": 13,
+    "lineCount": 277,
+    "theoremCount": 16,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
@@ -211,15 +213,15 @@
       "Mathlib.Data.List.MinMax"
     ],
     "namespace": "PuiseuxTheoremOQ03",
-    "lineCount": 224,
+    "lineCount": 277,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 16,
     "definitionCount": 4,
     "path": "Proofs/PuiseuxTheoremOQ03.lean",
     "sorries": 0
   },
   "conclusion": {
-    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone), all validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 13 theorems and 4 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
+    "summary": "Supplies the combinatorial Newton polygon Mathlib 4.26.0 lacks: the supporting-line vertex predicate IsLowerVertex, the seed lemma that the minimum-valuation point is a vertex, an existence lemma for nonempty supports, the lower-edge predicate IsLowerEdge with the edge↔vertex bridge and the slope-determination lemma slope_eq_edgeSlope, and — the combinatorial heart — convexity of the polygon (edgeSlope_mono) yielding sorted root valuations (rootValuation_antitone), all validated on the Y²−x example whose single segment is a genuine lower edge tying the slope to the parent's leadingExponentFromSlope. All 16 theorems and 4 definitions verify with 0 sorries and 0 axioms. Also repairs a parse error in the parent file.",
     "implications": "This is the algorithm-independent data layer on which Newton–Puiseux termination measures and the Poteaux–Weimann complexity bounds can later be phrased. With a valuation API on K((x))[Y], the Newton polygon theorem (slopes = root valuations) becomes the next provable target.",
     "openQuestions": [
       "Prove the Newton polygon theorem: the negatives of the lower-hull edge slopes equal the valuations of the roots in an algebraically closed valued extension (needs a valuation API on K((x))[Y]) — the edge layer and its convexity (edgeSlope_mono) are now in place, so the valuations would automatically come out sorted",


### PR DESCRIPTION
## Summary

Small **additive** extension of the Newton-polygon edge/convexity layer already on `main` (`edgeSlope_mono` covers convexity between two edges sharing a vertex). These lemmas add the complementary per-supporting-line bounds and the sharper interior-point convexity certificate. No existing declarations are touched or renamed.

## New results (`proofs/Proofs/PuiseuxTheoremOQ03.lean`)

- `edgeSlope_ge_of_supportingLine` / `edgeSlope_le_of_supportingLine` — from a vertex `p`'s supporting line of slope `m`, the slope to **every** other support point is bounded: `m ≤ edgeSlope p q` to the right, `edgeSlope q p ≤ m` to the left. So `m` is the smallest slope leaving the vertex.
- `IsLowerEdge.interior_slopes` — **a lower edge is convex from below**: for *any* support point `r` strictly between the endpoints of a lower edge (vertex or not), `edgeSlope r q ≤ edgeSlope p r`, i.e. `r` lies on or above the edge line and the polygon never dips below an edge. This is strictly more general than `edgeSlope_mono`, which only relates two edges meeting at a shared vertex.

**File: 224 → 277 lines, 13 → 16 theorems, 0 sorries, 0 axioms.**

## Verification

Built locally with `lake env lean Proofs/PuiseuxTheoremOQ03.lean` against the pinned Mathlib (Docker host unavailable). `#print axioms` on all three new lemmas reports only `[propext, Classical.choice, Quot.sound]`.

## Note

This replaces my earlier #30782 (closed), which was developed concurrently off the older 145-line `main` and would have clobbered the since-merged `edgeSlope_mono`/`rootValuation_antitone`. This PR keeps all merged work intact and only appends the genuinely non-overlapping lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)