### PR TITLE
Enrich Euler Criterion k-th Power Residues: annotation metadata

### DIFF
--- a/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-criterion-squares-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 23 },
     "type": "context",
     "title": "From Quadratic to k-th Power Residues",
-    "content": "The docstring frames the generalization: the parent counted quadratic residues by computing the squaring map's kernel {1, −1} by hand. Here the exponent is an arbitrary $k$ dividing $p-1$, and the count $(p-1)/k$ is read off the cyclic structure of $(\\mathbb{Z}/p)^\\times$. The $k$-th power map $u \\mapsto u^k$ has kernel of size $\\gcd(p-1,k)=k$ (the $k$-th roots of unity) and image of size $(p-1)/\\gcd(p-1,k)=(p-1)/k$, so there are exactly $(p-1)/k$ nonzero $k$-th power residues."
+    "content": "The docstring frames the generalization: the parent counted quadratic residues by computing the squaring map's kernel {1, −1} by hand. Here the exponent is an arbitrary $k$ dividing $p-1$, and the count $(p-1)/k$ is read off the cyclic structure of $(\\mathbb{Z}/p)^\\times$. The $k$-th power map $u \\mapsto u^k$ has kernel of size $\\gcd(p-1,k)=k$ (the $k$-th roots of unity) and image of size $(p-1)/\\gcd(p-1,k)=(p-1)/k$, so there are exactly $(p-1)/k$ nonzero $k$-th power residues.",
+    "mathContext": "$\\#\\{a \\in (\\mathbb{Z}/p)^\\times : \\exists x,\\ x^k = a\\} = \\dfrac{p-1}{k}$ whenever $k \\mid p-1$, from $|\\ker| \\cdot |\\mathrm{im}| = |G|$ for the endomorphism $u \\mapsto u^k$ of the cyclic group $G = (\\mathbb{Z}/p)^\\times$ of order $p-1$.",
+    "significance": "context",
+    "relatedConcepts": ["k-th power residue", "cyclic group", "Euler's criterion", "first isomorphism theorem", "roots of unity"],
+    "prerequisites": ["modular arithmetic", "structure of (ℤ/p)ˣ", "group homomorphisms"]
   },
   {
     "id": "ecsoq010101-ann-params",
@@ -13,7 +17,11 @@
     "range": { "startLine": 27, "endLine": 33 },
     "type": "definition",
     "title": "Parameters and the Unit Count",
-    "content": "Two parameters: the prime $p$ (with $[\\mathrm{Fact}\\,p.\\mathrm{Prime}]$, $[\\mathrm{Fact}\\,(2<p)]$) and the exponent $k$. card_units_eq records $|(\\mathbb{Z}/p)^\\times| = p-1$ via ZMod.card_units — the order of the cyclic group whose index-$k$ subgroup of $k$-th powers we are counting. The omit clause drops the unused $2<p$ hypothesis here."
+    "content": "Two parameters: the prime $p$ (with $[\\mathrm{Fact}\\,p.\\mathrm{Prime}]$, $[\\mathrm{Fact}\\,(2<p)]$) and the exponent $k$. card_units_eq records $|(\\mathbb{Z}/p)^\\times| = p-1$ via ZMod.card_units — the order of the cyclic group whose index-$k$ subgroup of $k$-th powers we are counting. The omit clause drops the unused $2<p$ hypothesis here.",
+    "mathContext": "$|(\\mathbb{Z}/p)^\\times| = p - 1$ (ZMod.card_units), the order of the cyclic group $G$ in which all counting takes place.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod.card_units", "Fact typeclass", "unit group order", "Euler's totient φ(p) = p−1"],
+    "prerequisites": ["finite fields ZMod p", "Lean Fact instances"]
   },
   {
     "id": "ecsoq010101-ann-gcd",
@@ -21,7 +29,11 @@
     "range": { "startLine": 36, "endLine": 41 },
     "type": "proof",
     "title": "The gcd Collapse",
-    "content": "gcd_eq proves $\\gcd(p-1, k) = k$ whenever $k \\mid p-1$ (Nat.gcd_comm then Nat.gcd_eq_left). This is where the divisibility hypothesis does its work: the general cyclic count is $(p-1)/\\gcd(p-1,k)$, and it collapses to the clean $(p-1)/k$ exactly under $k \\mid p-1$. Needs neither Fact, so both are omitted."
+    "content": "gcd_eq proves $\\gcd(p-1, k) = k$ whenever $k \\mid p-1$ (Nat.gcd_comm then Nat.gcd_eq_left). This is where the divisibility hypothesis does its work: the general cyclic count is $(p-1)/\\gcd(p-1,k)$, and it collapses to the clean $(p-1)/k$ exactly under $k \\mid p-1$. Needs neither Fact, so both are omitted.",
+    "mathContext": "$k \\mid (p-1) \\Rightarrow \\gcd(p-1, k) = k$, so $(p-1)/\\gcd(p-1,k) = (p-1)/k$.",
+    "significance": "key",
+    "relatedConcepts": ["greatest common divisor", "divisibility", "Nat.gcd_eq_left", "index of a subgroup"],
+    "prerequisites": ["gcd properties", "divisibility in ℕ"]
   },
   {
     "id": "ecsoq010101-ann-ker",
@@ -29,7 +41,11 @@
     "range": { "startLine": 43, "endLine": 49 },
     "type": "proof",
     "title": "Kernel = the k-th Roots of Unity",
-    "content": "card_kHom_ker: the kernel of $u \\mapsto u^k$ has cardinality exactly $k$. The proof is a one-line rewrite chaining Mathlib's IsCyclic.card_powMonoidHom_ker (which gives $\\gcd(|G|, k)$ for a finite cyclic group $G$), card_units_eq, and gcd_eq. The cyclic instance $\\mathrm{IsCyclic}\\,R^\\times$ for finite integral-domain units is found automatically. Equivalently: ZMod $p$ has exactly $k$ solutions of $x^k = 1$ when $k \\mid p-1$."
+    "content": "card_kHom_ker: the kernel of $u \\mapsto u^k$ has cardinality exactly $k$. The proof is a one-line rewrite chaining Mathlib's IsCyclic.card_powMonoidHom_ker (which gives $\\gcd(|G|, k)$ for a finite cyclic group $G$), card_units_eq, and gcd_eq. The cyclic instance $\\mathrm{IsCyclic}\\,R^\\times$ for finite integral-domain units is found automatically. Equivalently: ZMod $p$ has exactly $k$ solutions of $x^k = 1$ when $k \\mid p-1$.",
+    "mathContext": "$|\\ker(u \\mapsto u^k)| = \\gcd(|G|, k) = \\gcd(p-1, k) = k$ — the group of $k$-th roots of unity $\\{u : u^k = 1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["kernel of a homomorphism", "k-th roots of unity", "IsCyclic", "cyclic group endomorphism"],
+    "prerequisites": ["group kernels", "cyclic group structure theory"]
   },
   {
     "id": "ecsoq010101-ann-range",
@@ -37,7 +53,11 @@
     "range": { "startLine": 51, "endLine": 53 },
     "type": "proof",
     "title": "Image = the k-th Power Residues",
-    "content": "card_kHom_range: the image of $u \\mapsto u^k$ has cardinality $(p-1)/k$, again a single rewrite using IsCyclic.card_powMonoidHom_range ($= |G|/\\gcd(|G|,k)$), the unit count, and the gcd collapse. This is the structural heart of the result — the $k$-th power residues among the units number exactly $(p-1)/k$ by the first isomorphism theorem for the cyclic power map."
+    "content": "card_kHom_range: the image of $u \\mapsto u^k$ has cardinality $(p-1)/k$, again a single rewrite using IsCyclic.card_powMonoidHom_range ($= |G|/\\gcd(|G|,k)$), the unit count, and the gcd collapse. This is the structural heart of the result — the $k$-th power residues among the units number exactly $(p-1)/k$ by the first isomorphism theorem for the cyclic power map.",
+    "mathContext": "$|\\mathrm{im}(u \\mapsto u^k)| = |G|/\\gcd(|G|,k) = (p-1)/k$ — by $G/\\ker \\cong \\mathrm{im}$ (first isomorphism theorem).",
+    "significance": "key",
+    "relatedConcepts": ["image of a homomorphism", "first isomorphism theorem", "k-th power residues", "Lagrange's theorem"],
+    "prerequisites": ["quotient groups", "first isomorphism theorem"]
   },
   {
     "id": "ecsoq010101-ann-bridge",
@@ -45,7 +65,11 @@
     "range": { "startLine": 55, "endLine": 77 },
     "type": "proof",
     "title": "Bridge: Field k-th Powers vs Image Membership",
-    "content": "isKthPower_coe_iff_mem_range shows that for a unit $u$, $\\uparrow u$ is a $k$-th power in the field iff $u$ lies in the image of the unit power map. Forward: a witness $x$ with $x^k = \\uparrow u \\ne 0$ must be nonzero (else $0^k = 0$, using $k \\ne 0$ via zero_pow), so it lifts to a unit $w$ with $w^k = u$. Backward is immediate. This transports the unit-group count to field $k$-th powers."
+    "content": "isKthPower_coe_iff_mem_range shows that for a unit $u$, $\\uparrow u$ is a $k$-th power in the field iff $u$ lies in the image of the unit power map. Forward: a witness $x$ with $x^k = \\uparrow u \\ne 0$ must be nonzero (else $0^k = 0$, using $k \\ne 0$ via zero_pow), so it lifts to a unit $w$ with $w^k = u$. Backward is immediate. This transports the unit-group count to field $k$-th powers.",
+    "mathContext": "For $u \\in G$: $(\\exists x \\in \\mathbb{Z}/p,\\ x^k = \\uparrow u) \\iff u \\in \\mathrm{im}(v \\mapsto v^k)$. A nonzero $k$-th-power witness lifts uniquely to a unit since $\\mathbb{Z}/p$ is a field.",
+    "significance": "supporting",
+    "relatedConcepts": ["units vs nonzero elements", "field of a domain", "zero_pow", "lifting to the unit group"],
+    "prerequisites": ["units in a field", "ZMod p is a field"]
   },
   {
     "id": "ecsoq010101-ann-main",
@@ -53,7 +77,11 @@
     "range": { "startLine": 79, "endLine": 98 },
     "type": "proof",
     "title": "The Main Count",
-    "content": "card_nonzero_kth_power_residues: $\\mathrm{Nat.card}\\,\\{a \\ne 0 \\wedge \\exists x,\\ x^k = a\\} = (p-1)/k$. After deriving $k \\ne 0$ from $k \\mid p-1$ and $p-1 > 0$, it rewrites the goal to $|\\operatorname{range}|$ and builds an Equiv chain: subtypeEquivRight (via the bridge lemma), subtypeEquiv (via unitsEquivNeZero turning 'unit' into 'nonzero'), and subtypeSubtypeEquivSubtypeInter to merge the two subtype conditions. Nat.card_congr finishes."
+    "content": "card_nonzero_kth_power_residues: $\\mathrm{Nat.card}\\,\\{a \\ne 0 \\wedge \\exists x,\\ x^k = a\\} = (p-1)/k$. After deriving $k \\ne 0$ from $k \\mid p-1$ and $p-1 > 0$, it rewrites the goal to $|\\operatorname{range}|$ and builds an Equiv chain: subtypeEquivRight (via the bridge lemma), subtypeEquiv (via unitsEquivNeZero turning 'unit' into 'nonzero'), and subtypeSubtypeEquivSubtypeInter to merge the two subtype conditions. Nat.card_congr finishes.",
+    "mathContext": "$\\mathrm{Nat.card}\\,\\{a : a \\ne 0 \\wedge \\exists x,\\ x^k = a\\} = (p-1)/k$, via a chain of Equivs reducing the nonzero-$k$-th-power subtype to $\\mathrm{im}(u \\mapsto u^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card", "Equiv composition", "subtype equivalences", "unitsEquivNeZero"],
+    "prerequisites": ["cardinality via equivalences", "subtype manipulation in Lean"]
   },
   {
     "id": "ecsoq010101-ann-quadratic",
@@ -61,7 +89,11 @@
     "range": { "startLine": 100, "endLine": 105 },
     "type": "proof",
     "title": "Quadratic Corollary (k = 2)",
-    "content": "card_nonzero_quadratic_residues recovers the parent entry's $(p-1)/2$ count by specializing to $k = 2$. The hypothesis $2 \\mid p-1$ comes from $p$ being an odd prime: Nat.Prime.odd_of_ne_two gives $p = 2m+1$, so $p - 1 = 2m$. This confirms the generalization specializes correctly to the classical quadratic case."
+    "content": "card_nonzero_quadratic_residues recovers the parent entry's $(p-1)/2$ count by specializing to $k = 2$. The hypothesis $2 \\mid p-1$ comes from $p$ being an odd prime: Nat.Prime.odd_of_ne_two gives $p = 2m+1$, so $p - 1 = 2m$. This confirms the generalization specializes correctly to the classical quadratic case.",
+    "mathContext": "$k = 2$: there are exactly $(p-1)/2$ nonzero quadratic residues mod an odd prime $p$ — the classical Euler-criterion count, with $2 \\mid p-1$ from $p$ odd.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic residues", "Legendre symbol", "odd prime", "specialization of a general theorem"],
+    "prerequisites": ["quadratic residues mod p", "parity of primes"]
   },
   {
     "id": "ecsoq010101-ann-modseven",
@@ -69,6 +101,10 @@
     "range": { "startLine": 107, "endLine": 117 },
     "type": "context",
     "title": "Concrete Check: Cubic Residues Modulo 7",
-    "content": "card_cubic_residues_mod_seven instantiates the general theorem at $p = 7$, $k = 3$ (with $3 \\mid 6$), yielding $(7-1)/3 = 2$ nonzero cubic residues — namely $\\{1, 6\\}$, since $1^3, 3^3 \\equiv 1, 6 \\pmod 7$. Because this is the general theorem specialized rather than a decide computation, the file introduces no native_decide and no Lean.ofReduceBool: it remains 0-axiom."
+    "content": "card_cubic_residues_mod_seven instantiates the general theorem at $p = 7$, $k = 3$ (with $3 \\mid 6$), yielding $(7-1)/3 = 2$ nonzero cubic residues — namely $\\{1, 6\\}$, since $1^3, 3^3 \\equiv 1, 6 \\pmod 7$. Because this is the general theorem specialized rather than a decide computation, the file introduces no native_decide and no Lean.ofReduceBool: it remains 0-axiom.",
+    "mathContext": "$p=7,\\ k=3$: $(7-1)/3 = 2$ nonzero cubic residues mod $7$, namely $\\{1,6\\}$. Derived by instantiation, so no native_decide and no Lean.ofReduceBool — the file stays 0-axiom.",
+    "significance": "context",
+    "relatedConcepts": ["cubic residues", "worked example", "axiom integrity", "native_decide avoidance"],
+    "prerequisites": ["modular exponentiation", "instantiating a universal theorem"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `euler-criterion-squares-oq-01-oq-01-oq-01` ("Counting k-th Power Residues: exactly (p−1)/k nonzero residues when k ∣ p−1").

## What changed
All 9 annotations were content-only. Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to each, preserving the existing rich `content` verbatim. The annotations now trace the full cyclic-group counting argument:
- the gcd collapse $\gcd(p-1,k)=k$ under $k\mid p-1$
- kernel of $u\mapsto u^k$ = the $k$-th roots of unity (size $k$)
- image = the $k$-th power residues (size $(p-1)/k$) via the first isomorphism theorem
- the unit ↔ nonzero bridge transporting the count to field $k$-th powers
- the $k=2$ quadratic corollary and the $p=7,k=3$ concrete check

## Verification
- JSON valid; meta.json 19 KB (under 60 KB cap), no collection caps exceeded
- All 9 annotations carry full metadata, using the gallery's standard field vocabulary
- Axiom integrity preserved: status `verified`, 0 axioms (the mod-7 check is by instantiation, not native_decide — noted in its annotation)