### PR TITLE
research(sperner-ndim-oq-02): Phase-1 foundation — extract GridSimplex into clean base + reconstruction lemmas [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SpernerGridBase.lean
+++ b/proofs/Proofs/SpernerGridBase.lean
@@ -85,4 +85,376 @@ def IsSperner {d N : ℕ}
   ∀ (v : BaryPoint d N) (k : Fin (d + 1)),
     v.onFace k → c v ≠ k
 
+-- ============================================================
+-- SECTION III: Grid Simplices
+-- ============================================================
+-- (factored verbatim from SpernerGrid.lean SECTION III-V, lines
+-- 241-513; these proofs are already machine-checked there and
+-- depend only on `BaryPoint` above, so they live here in the
+-- clean base to keep the Phase-1 `SpernerTriangulation` instance
+-- independent of the unfinished adjacency machinery.)
+
+/-- A d-simplex in the Freudenthal triangulation of Δ_N.
+
+A chain of d+1 barycentric lattice points where each step
+transfers one unit of mass from a fixed "miss" coordinate to
+a varying "incDir" coordinate. The d increase directions must
+be distinct (injective), and miss is not among them.
+
+This means the d+1 directions Fin(d+1) decompose as:
+- d directions in range(incDir): each increases exactly once
+- 1 direction (miss): decreases at every step
+
+This is the standard Freudenthal/Kuhn construction. -/
+structure GridSimplex (d N : ℕ) where
+  /-- The d+1 vertices in chain order. -/
+  verts : Fin (d + 1) → BaryPoint d N
+  /-- Which coordinate increases at step k. -/
+  incDir : Fin d → Fin (d + 1)
+  /-- The coordinate that decreases at every step. -/
+  miss : Fin (d + 1)
+  /-- The miss direction is not an increase direction. -/
+  miss_ne_inc : ∀ k : Fin d, incDir k ≠ miss
+  /-- The increased coordinate goes up by 1. -/
+  step_inc : ∀ k : Fin d,
+    (verts k.succ).coords (incDir k) =
+    (verts k.castSucc).coords (incDir k) + 1
+  /-- The miss coordinate goes down by 1. -/
+  step_dec : ∀ k : Fin d,
+    (verts k.castSucc).coords miss =
+    (verts k.succ).coords miss + 1
+  /-- All other coordinates are unchanged. -/
+  step_same : ∀ (k : Fin d) (j : Fin (d + 1)),
+    j ≠ incDir k → j ≠ miss →
+    (verts k.succ).coords j =
+    (verts k.castSucc).coords j
+  /-- The increased directions are all distinct. -/
+  inc_injective : Function.Injective incDir
+
+instance gridSimplexDecEq (d N : ℕ) :
+    DecidableEq (GridSimplex d N) := by
+  intro a b
+  by_cases hv : a.verts = b.verts
+  · by_cases hi : a.incDir = b.incDir
+    · by_cases hm : a.miss = b.miss
+      · exact isTrue (by
+          cases a; cases b
+          simp only at hv hi hm
+          subst hv; subst hi; subst hm; rfl)
+      · exact isFalse (fun h =>
+          hm (by cases h; rfl))
+    · exact isFalse (fun h =>
+        hi (by cases h; rfl))
+  · exact isFalse (fun h =>
+      hv (by cases h; rfl))
+
+noncomputable instance gridSimplexFintype (d N : ℕ) :
+    Fintype (GridSimplex d N) :=
+  Fintype.ofInjective
+    (fun s : GridSimplex d N => (s.verts, s.incDir, s.miss))
+    (fun a b h => by
+      cases a; cases b
+      simp only [Prod.mk.injEq] at h
+      obtain ⟨h1, h2, h3⟩ := h
+      subst h1; subst h2; subst h3; rfl)
+
+-- ============================================================
+-- SECTION IV: Basic Properties
+-- ============================================================
+
+variable {d N : ℕ}
+
+/-- Coordinate incDir(k) is unchanged at step k' ≠ k.
+Since incDir is injective, incDir(k') ≠ incDir(k). And
+miss ≠ incDir(k) by miss_ne_inc. So step_same applies. -/
+theorem GridSimplex.incDir_stable (s : GridSimplex d N)
+    (k k' : Fin d) (hne : k ≠ k') :
+    (s.verts k'.succ).coords (s.incDir k) =
+    (s.verts k'.castSucc).coords (s.incDir k) :=
+  s.step_same k' (s.incDir k)
+    (fun h => hne (s.inc_injective h))
+    (s.miss_ne_inc k)
+
+/-- Coordinate incDir(k) has the same value at vertex m as at
+vertex k.succ, for any m ≥ k.succ. This is because the only
+step that changes incDir(k) is step k, which occurs before m.
+
+Proved by strong induction on m.val. -/
+theorem GridSimplex.incDir_const_after (s : GridSimplex d N)
+    (k : Fin d) (m : Fin (d + 1))
+    (hm : k.succ ≤ m) :
+    (s.verts m).coords (s.incDir k) =
+    (s.verts k.succ).coords (s.incDir k) := by
+  -- Induction on m.val
+  have : ∀ p : ℕ, (hp : p < d + 1) → k.succ.val ≤ p →
+      (s.verts ⟨p, hp⟩).coords (s.incDir k) =
+      (s.verts k.succ).coords (s.incDir k) := by
+    intro p hp hkp
+    induction p with
+    | zero =>
+      -- k.succ.val ≥ 1, so k.succ.val ≤ 0 is impossible
+      simp [Fin.succ] at hkp
+    | succ p' ih =>
+      by_cases hbase : k.succ.val = p' + 1
+      · -- k.succ.val = p' + 1
+        have hkv : k.val = p' := by
+          have := k.isLt; simp [Fin.succ] at hbase; omega
+        have heq : (⟨p' + 1, hp⟩ : Fin (d + 1)) = k.succ := by
+          apply Fin.ext; simp [Fin.succ]; omega
+        rw [show s.verts ⟨p' + 1, hp⟩ = s.verts k.succ from
+          congr_arg s.verts heq]
+      · -- p' ≥ k.succ.val, so IH applies
+        have hp' : p' < d + 1 := by omega
+        have hkp' : k.succ.val ≤ p' := by omega
+        have ih_val := ih hp' hkp'
+        -- Step from p' to p'+1 uses step index ⟨p', _⟩
+        have hpd : p' < d := by omega
+        let step : Fin d := ⟨p', hpd⟩
+        have hstep_ne : k ≠ step := by
+          intro heq
+          simp [step, Fin.ext_iff] at heq
+          simp [Fin.succ] at *; omega
+        have hstable := s.incDir_stable k step hstep_ne
+        have hsc : step.castSucc = ⟨p', hp'⟩ := by
+          ext; simp [step, Fin.castSucc]
+        have hss : step.succ = ⟨p' + 1, hp⟩ := by
+          ext; simp [step, Fin.succ]
+        rw [hss, hsc] at hstable
+        rw [hstable, ih_val]
+  exact this m.val m.isLt (by exact hm)
+
+/-- Consecutive vertices in a GridSimplex are distinct. -/
+theorem GridSimplex.verts_succ_ne (s : GridSimplex d N)
+    (k : Fin d) :
+    s.verts k.succ ≠ s.verts k.castSucc := by
+  intro heq
+  have h := s.step_inc k
+  rw [show (s.verts k.succ).coords (s.incDir k) =
+    (s.verts k.castSucc).coords (s.incDir k) from
+    congr_arg (fun v => v.coords (s.incDir k)) heq] at h
+  omega
+
+/-- All d+1 vertices of a GridSimplex are pairwise distinct.
+
+With constant miss, coordinate incDir(k) increases exactly
+once (at step k) and never changes at other steps. So for
+i < j, taking k = ⟨i, _⟩, we get
+  v_j(incDir k) = v_i(incDir k) + 1
+since the +1 at step k is the only change, proving v_i ≠ v_j. -/
+theorem GridSimplex.verts_injective (s : GridSimplex d N) :
+    Function.Injective s.verts := by
+  intro i j heq
+  suffices i.val = j.val from Fin.val_injective this
+  by_contra hne
+  rcases Nat.lt_or_gt_of_ne hne with hlt | hgt
+  · -- i < j: track coordinate incDir(⟨i, _⟩)
+    have hid : i.val < d := by omega
+    let k : Fin d := ⟨i.val, hid⟩
+    -- After step k: incDir(k) has increased by 1
+    have h1 := s.step_inc k
+    -- k.castSucc = i
+    have hkc : k.castSucc = i := Fin.ext (by simp [k, Fin.castSucc])
+    -- k.succ ≤ j (since i < j means i+1 ≤ j)
+    have hksj : k.succ ≤ j := by
+      simp [Fin.le_iff_val_le_val, k, Fin.succ]; omega
+    -- By incDir_const_after: verts(j) and verts(k.succ) agree on incDir(k)
+    have h2 := s.incDir_const_after k j hksj
+    -- So verts(j).coords(incDir k) = verts(i).coords(incDir k) + 1
+    rw [hkc] at h1
+    have : (s.verts j).coords (s.incDir k) =
+        (s.verts i).coords (s.incDir k) + 1 := by
+      rw [h2, h1]
+    -- But heq says verts i = verts j
+    rw [congr_arg (fun v => v.coords (s.incDir k)) heq] at this
+    omega
+  · -- j < i: symmetric
+    have hjd : j.val < d := by omega
+    let k : Fin d := ⟨j.val, hjd⟩
+    have h1 := s.step_inc k
+    have hkc : k.castSucc = j := Fin.ext (by simp [k, Fin.castSucc])
+    have hksi : k.succ ≤ i := by
+      simp [Fin.le_iff_val_le_val, k, Fin.succ]; omega
+    have h2 := s.incDir_const_after k i hksi
+    rw [hkc] at h1
+    have : (s.verts i).coords (s.incDir k) =
+        (s.verts j).coords (s.incDir k) + 1 := by
+      rw [h2, h1]
+    rw [congr_arg (fun v => v.coords (s.incDir k)) heq] at this
+    omega
+
+/-- The vertex set (as a Finset) has cardinality d + 1. -/
+theorem GridSimplex.vertex_set_card (s : GridSimplex d N) :
+    (univ.image s.verts).card = d + 1 := by
+  rw [Finset.card_image_of_injective _ s.verts_injective]
+  simp [Fintype.card_fin]
+
+-- ============================================================
+-- SECTION V: Coordinate Tracking Lemmas
+-- ============================================================
+
+/-- The miss coordinate decreases by exactly 1 at each step,
+so at vertex m it equals v₀.coords(miss) - m. -/
+theorem GridSimplex.miss_coord_at (s : GridSimplex d N)
+    (m : Fin (d + 1)) :
+    (s.verts m).coords s.miss =
+    (s.verts 0).coords s.miss - m.val := by
+  induction m using Fin.induction with
+  | zero => simp
+  | succ k ih =>
+    have hsd := s.step_dec k
+    -- step_dec: verts(k.castSucc).coords miss =
+    --           verts(k.succ).coords miss + 1
+    -- So verts(k.succ).coords miss =
+    --    verts(k.castSucc).coords miss - 1
+    rw [ih] at hsd
+    have hcv : k.castSucc.val = k.val := rfl
+    have hsv : k.succ.val = k.val + 1 := rfl
+    omega
+
+/-- The base vertex's miss coordinate is at least d
+(since it decreases by 1 at each of d steps). -/
+theorem GridSimplex.base_miss_ge_d (s : GridSimplex d N) :
+    d ≤ (s.verts 0).coords s.miss := by
+  induction d with
+  | zero => omega
+  | succ n ih =>
+    -- At step n, coords = base - n, and step_dec says
+    -- verts(n.castSucc).coords miss = verts(n.succ).coords miss + 1
+    -- so base - n ≥ 1, i.e., base ≥ n + 1.
+    have hsd := s.step_dec ⟨n, by omega⟩
+    have hmca := s.miss_coord_at ⟨n, by omega⟩
+    have : (⟨n, by omega⟩ : Fin (n + 2)).val = n := rfl
+    rw [this] at hmca
+    -- hmca : verts(⟨n,...⟩).coords miss = base - n
+    -- hsd : verts(⟨n,...⟩.castSucc).coords miss = verts(⟨n,...⟩.succ).coords miss + 1
+    have hcv : (⟨n, by omega⟩ : Fin (n + 1)).castSucc.val = n := rfl
+    have hsv : (⟨n, by omega⟩ : Fin (n + 1)).succ.val = n + 1 := rfl
+    -- castSucc and the original Fin (n+2) element have same val
+    have : (⟨n, by omega⟩ : Fin (n + 1)).castSucc = (⟨n, by omega⟩ : Fin (n + 2)) := by
+      ext; simp
+    rw [this] at hsd
+    rw [hmca] at hsd
+    -- hsd : base - n = verts(⟨n,...⟩.succ).coords miss + 1
+    -- This means base - n ≥ 1, so base ≥ n + 1
+    omega
+
+/-- At vertex m, the miss coordinate is at least d - m. -/
+theorem GridSimplex.miss_coord_ge (s : GridSimplex d N)
+    (m : Fin (d + 1)) :
+    d - m.val ≤ (s.verts m).coords s.miss := by
+  rw [s.miss_coord_at m]
+  have := s.base_miss_ge_d
+  omega
+
+/-- incDir(k) is the unique complement of miss: incDir gives
+a bijection from Fin d to Fin(d+1) \ {miss}. This means
+every j ≠ miss is in the range of incDir. -/
+theorem GridSimplex.incDir_surj_complement (s : GridSimplex d N)
+    (j : Fin (d + 1)) (hj : j ≠ s.miss) :
+    ∃ k : Fin d, s.incDir k = j := by
+  -- incDir is injective from Fin d to Fin(d+1), avoiding miss.
+  -- Since |Fin d| = d = |Fin(d+1)| - 1 = |Fin(d+1) \ {miss}|,
+  -- it must be surjective onto the complement.
+  by_contra h
+  push_neg at h
+  -- All d values incDir(k) are in Fin(d+1) \ {miss, j}
+  -- which has d+1-2 = d-1 elements. But incDir is injective
+  -- with d values, contradiction.
+  have hcard : (Finset.univ.image s.incDir).card = d := by
+    rw [Finset.card_image_of_injective _ s.inc_injective]
+    simp
+  have hsub : Finset.univ.image s.incDir ⊆
+      (Finset.univ.erase s.miss).erase j := by
+    intro x hx
+    simp only [Finset.mem_image, Finset.mem_univ, true_and] at hx
+    obtain ⟨k, rfl⟩ := hx
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+    exact ⟨h k, s.miss_ne_inc k⟩
+  have hle := Finset.card_le_card hsub
+  rw [hcard] at hle
+  have hmiss_mem : s.miss ∈ (Finset.univ : Finset (Fin (d + 1))) := Finset.mem_univ _
+  have hj_mem : j ∈ (Finset.univ.erase s.miss) := by
+    rw [Finset.mem_erase]
+    exact ⟨hj, Finset.mem_univ _⟩
+  rw [Finset.card_erase_of_mem hj_mem, Finset.card_erase_of_mem hmiss_mem] at hle
+  simp at hle
+  omega
+
+-- ============================================================
+-- SECTION VI: Coordinate Reconstruction (new, for Phase-1)
+-- ============================================================
+-- These characterize every vertex's coordinates purely from the
+-- base vertex `verts 0`, `miss`, and `incDir`. They are the
+-- arithmetic backbone the Phase-1 canonical-representative
+-- predicate (`IsCanon`) and the facet-sharing adjacency need:
+-- the whole cell is determined by `(verts 0, miss, incDir)`.
+
+/-- Symmetric counterpart of `incDir_const_after`: coordinate
+incDir(k) is unchanged at every vertex m ≤ k.castSucc, since the
+only step touching it is step k (at index k, i.e. from
+k.castSucc to k.succ). -/
+theorem GridSimplex.incDir_const_before (s : GridSimplex d N)
+    (k : Fin d) (m : Fin (d + 1))
+    (hm : m ≤ k.castSucc) :
+    (s.verts m).coords (s.incDir k) =
+    (s.verts 0).coords (s.incDir k) := by
+  -- Induction on m.val (downward telescoping from 0 up to k.castSucc).
+  have : ∀ p : ℕ, (hp : p < d + 1) → p ≤ k.castSucc.val →
+      (s.verts ⟨p, hp⟩).coords (s.incDir k) =
+      (s.verts 0).coords (s.incDir k) := by
+    intro p hp hpk
+    induction p with
+    | zero => rfl
+    | succ p' ih =>
+      have hp' : p' < d + 1 := by omega
+      have hpk' : p' ≤ k.castSucc.val := by omega
+      have ih_val := ih hp' hpk'
+      -- Step from p' to p'+1 uses step index ⟨p', _⟩, which is ≠ k
+      -- because p' < k.castSucc.val = k.val, so ⟨p',_⟩ ≠ k.
+      have hpd : p' < d := by
+        have : k.castSucc.val = k.val := rfl
+        omega
+      let step : Fin d := ⟨p', hpd⟩
+      have hstep_ne : k ≠ step := by
+        intro heq
+        have : k.val = p' := by simpa [step, Fin.ext_iff] using congrArg Fin.val heq
+        have hkc : k.castSucc.val = k.val := rfl
+        omega
+      have hstable := s.incDir_stable k step hstep_ne
+      have hsc : step.castSucc = ⟨p', hp'⟩ := by
+        ext; simp [step, Fin.castSucc]
+      have hss : step.succ = ⟨p' + 1, hp⟩ := by
+        ext; simp [step, Fin.succ]
+      rw [hss, hsc] at hstable
+      rw [hstable, ih_val]
+  exact this m.val m.isLt (by simpa using hm)
+
+/-- Every non-miss coordinate `j` increases by exactly 1 across
+the whole chain: it equals its base value plus 1 at the last
+vertex. (It is incremented exactly once, at the unique step
+`k` with `incDir k = j`.) -/
+theorem GridSimplex.last_coord_non_miss (s : GridSimplex d N)
+    (j : Fin (d + 1)) (hj : j ≠ s.miss) :
+    (s.verts (Fin.last d)).coords j =
+    (s.verts 0).coords j + 1 := by
+  obtain ⟨k, hk⟩ := s.incDir_surj_complement j hj
+  subst hk
+  -- value at last = value at k.succ (const after), and
+  -- value at k.succ = value at k.castSucc + 1 (step_inc), and
+  -- value at k.castSucc = value at 0 (const before).
+  have hafter : (s.verts (Fin.last d)).coords (s.incDir k) =
+      (s.verts k.succ).coords (s.incDir k) :=
+    s.incDir_const_after k (Fin.last d) (Fin.le_last _)
+  have hbefore : (s.verts k.castSucc).coords (s.incDir k) =
+      (s.verts 0).coords (s.incDir k) :=
+    s.incDir_const_before k k.castSucc le_rfl
+  rw [hafter, s.step_inc k, hbefore]
+
+/-- The miss coordinate decreases by exactly `d` across the whole
+chain. (Specialization of `miss_coord_at` to the last vertex.) -/
+theorem GridSimplex.last_coord_miss (s : GridSimplex d N) :
+    (s.verts (Fin.last d)).coords s.miss =
+    (s.verts 0).coords s.miss - d := by
+  simpa using s.miss_coord_at (Fin.last d)
+
 end SpernerGrid

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -554,3 +554,85 @@ until that file is repaired/retired, to avoid churn/conflicts while it is broken
 - Disk is the real gate, not docker: a heavy build can transiently ENOSPC even at
   ~400 MiB free. Single-file checks importing cached oleans are ~30–60s and safe
   when disk ≳ 1 GiB.
+
+---
+
+## Session 2026-06-27 (Session 7) — Phase-1 foundation extracted + reconstruction lemmas
+
+**Mode**: ACT (researcher-12). **Outcome**: PROGRESS — verified, 0-axiom.
+**Infra**: docker still corrupt (4 stale `lean-build-*` containers "Up 7 hours");
+disk recovered to 47% (~14 GiB free). Used the local `LAKE_UNSAFE=1 ./bin/lake env
+lean` single-file fallback against the main repo's cached oleans.
+
+### What was delivered (extends `proofs/Proofs/SpernerGridBase.lean`, now 460 L)
+
+The bridge work (Session 6) extracted only `BaryPoint`/`onFace`/`IsSperner`. But
+the Phase-1 instance also needs the **`GridSimplex` foundation**, which was still
+trapped in the broken `SpernerGrid.lean` (un-importable). This session factored
+the *entire clean region* of `SpernerGrid` (SECTIONS III–V, lines 241–513 — all
+before the first compile error @679) into `SpernerGridBase.lean`:
+
+- `structure GridSimplex` (+ `gridSimplexDecEq`, `gridSimplexFintype`) — the
+  Simplex carrier with `DecidableEq`/`Fintype` the Phase-1 `Simplex :=
+  {s : GridSimplex // IsCanon s}` subtype reuses.
+- `incDir_stable`, `incDir_const_after`, `verts_succ_ne`, **`verts_injective`**
+  (the `vertices_injective` field), `vertex_set_card`.
+- coordinate trackers `miss_coord_at`, `base_miss_ge_d`, `miss_coord_ge`,
+  `incDir_surj_complement`.
+
+All copied **byte-for-byte** from the already-checked originals, so no new proof
+risk; the value is purely *de-coupling* — Phase-1 can now build its instance over
+a clean base with zero dependence on the broken adjacency machinery.
+
+### New lemmas (genuinely new, not extraction) — SECTION VI
+
+Toward the canonical-representative predicate `IsCanon` and the facet-sharing
+adjacency, the key fact is that **a cell is fully determined by
+`(verts 0, miss, incDir)`**. Proved the coordinate-reconstruction backbone:
+
+- `GridSimplex.incDir_const_before` — mirror of `incDir_const_after`: coord
+  `incDir k` is constant (= its base value) at every vertex `m ≤ k.castSucc`.
+- `GridSimplex.last_coord_non_miss` — every non-miss coord `j` satisfies
+  `(verts last).coords j = (verts 0).coords j + 1` (incremented exactly once).
+- `GridSimplex.last_coord_miss` — `(verts last).coords miss = (verts 0).coords
+  miss − d` (decremented every step).
+
+Together: `verts last = verts 0 + 𝟙_{≠miss} − d·e_miss`, i.e. the last vertex (and
+by the same tracking every vertex) is an explicit function of the base + miss.
+This is what makes `canonMiss`/`IsCanon` well-posed next session.
+
+### Verification (gold-standard, no stubs)
+
+`SpernerGridBase.lean` (460 L) builds clean end-to-end (EXIT 0) against real
+cached imports; `SpernerNDimOQ02.lean` (the bridge) still builds clean against the
+extended base. `#print axioms` on `verts_injective`, `last_coord_non_miss`,
+`last_coord_miss`, `incDir_const_before` = `{propext, Classical.choice, Quot.sound}`
+only → **verified, 0-axiom**. Main repo working tree restored clean afterward.
+
+### Encoding-uniqueness analysis (sharpens the Phase-1 `IsCanon` design)
+
+Confirmed the GridSimplex-rep needs canonicalization (cannot be skipped): a
+facet-sharing dual graph over *all* GridSimplices breaks `adj_unique_facet` /
+well-definedness, because a cell `s` and its reverse `s'` share the *same vertex
+set* hence the same facets — the "find the other cell containing facet F" search
+is ambiguous. So one-cell-per-geometry is mandatory. The cube-Kuhn trick (base =
+lex-min vertex ⇒ unique `(base, perm)` by construction) does **not** transfer: the
+corner-simplex `{x ≥ 0, ∑ ≤ N}` is not a union of full Kuhn cubes (cells near the
+`∑ = N` face would stick out), which is exactly why the bary `+e_a − e_b` model is
+used. Hence a separate `IsCanon` predicate over `GridSimplex` is the right tool.
+With `last_coord_*` in hand, a clean `canonMiss` choice: the representative whose
+chain is monotone for the lex order on `BaryPoint` (equivalently `verts 0` is the
+lex-minimal vertex and `incDir` lists the non-miss directions in increasing
+order). Uniqueness per geometry follows from `verts_injective` + the reconstruction
+lemmas (base + miss + the increasing incDir determine all vertices).
+
+### Next steps (unchanged ordering, now better-equipped)
+
+1. Define `canonMiss`/`IsCanon` (decidable) + per-geometry uniqueness, using
+   `last_coord_non_miss`/`last_coord_miss` + `verts_injective`.
+2. `Simplex := {s : GridSimplex // IsCanon s}`; `vertices := toVertex ∘ verts`,
+   `vertices_injective` from `toVertex_injective ∘ verts_injective`.
+3. `adj` via finite facet-search; discharge the 5 adjacency fields + `boundary_face`
+   (transport `onFace` via `SpernerNDimOQ02.onFace_toVertex`).
+4. Phase 2: last-face-door-oddness by induction; apply `sperner_ndim`.
+5. Retire false `boundary_doors_odd`/`boundary_verts_on_face`.

--- a/research/problems/sperner-ndim-oq-02/state.md
+++ b/research/problems/sperner-ndim-oq-02/state.md
@@ -1,10 +1,22 @@
 # Research State: sperner-ndim-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-04-23T00:00:00Z
-**Iteration**: 7
+**Iteration**: 8
+
+> Session 7 (2026-06-27, researcher-12): **Phase-1 foundation extracted +
+> reconstruction lemmas (verified, 0-axiom)**. Factored the entire *clean* region
+> of broken `SpernerGrid.lean` (SECTIONS III–V: `GridSimplex` + `DecidableEq`/
+> `Fintype` + `verts_injective` + coordinate trackers, lines 241–513, all before
+> the first error @679) into `SpernerGridBase.lean` (now 460 L), so the Phase-1
+> instance can build `Simplex`/`vertices`/`vertices_injective` over a clean base.
+> Added NEW SECTION VI reconstruction lemmas (`incDir_const_before`,
+> `last_coord_non_miss`, `last_coord_miss`): every vertex is an explicit function
+> of `(verts 0, miss, incDir)` — the backbone `IsCanon` needs. Build EXIT 0;
+> `#print axioms` = `{propext, Classical.choice, Quot.sound}` only. knowledge.md
+> "Session 7".
 
 > Session 6 (2026-06-27, researcher-12): **VERIFIED the step-0 bridge (0-axiom)**
 > and **decoupled it from broken `SpernerGrid.lean`**. Docker still corrupt

--- a/src/data/research/problems/sperner-ndim-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-oq-02.json
@@ -31,24 +31,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "boundary_doors_odd (the OQ target) is provably FALSE as stated: the oriented GridSimplex double-counts each geometric cell by orientation, forcing all door/panchromatic counts even (Session 1 counterexample d=1,N=1 -> count 2). Resolution is Option C: instantiate the complete (0-sorry) abstract SpernerNDim.SpernerTriangulation framework with an UNORIENTED Freudenthal grid (one cell per geometric simplex) and feed odd last-face doors to sperner_ndim. Session 2 worked out the inductive oddness and an instance build plan.",
+    "progressSummary": "PROGRESS: Phase-1 foundation (GridSimplex carrier + vertices_injective + coordinate-reconstruction lemmas) verified 0-axiom in clean SpernerGridBase; instance/adjacency still to build",
     "builtItems": [
-      "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, UNVERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0."
+      "proofs/Proofs/SpernerNDimOQ02.lean (Session 3, UNVERIFIED): baryEquivVertex d N : BaryPoint d N ≃ Vertex d N (toVertex drops last bary coord, toBary appends slack N-∑); coord simp lemmas; onFace_toVertex (face correspondence); isSperner_iff (transports Sperner condition). 0 sorries, 0 new axioms. This is Option C step 0.",
+      "SpernerGridBase.lean: factored GridSimplex foundation (structure+DecidableEq+Fintype+verts_injective+coord trackers, SpernerGrid lines 241-513) into clean base — verified 0-axiom",
+      "SpernerGridBase.GridSimplex.incDir_const_before / last_coord_non_miss / last_coord_miss: every vertex = explicit fn of (verts 0, miss, incDir) — verified 0-axiom"
     ],
     "insights": [
       "SpernerNDim.lean is complete (669 lines, 0 sorries): structure SpernerTriangulation (8 fields) + theorem sperner_ndim (line 654) which yields a fully-colored simplex from an odd count of last-face boundary doors. This is the exact finish line for sperner_grid.",
       "Last-face boundary doors of the d-grid are in bijection with panchromatic (d-1)-simplices of the induced (d-1)-Freudenthal grid on face d: adj=none + boundary_face puts the facet on face d; the Sperner condition forbids color d there; isDoorAt = all colors {0..d-1} present = IsFC for the (d-1)-grid. Induction + sperner_parity at d-1 gives oddness. Base d=0: count 1.",
       "Coordinate bridge: abstract framework uses Vertex d N (Fin d -> N, sum<=N, Kuhn coords); SpernerGrid uses BaryPoint d N (Fin (d+1) -> N, sum=N). They are canonically isomorphic; proving BaryPoint d N ≃ Vertex d N (~30-50 lines, no adjacency) is the cleanest standalone first deliverable and unlocks reuse of the whole framework.",
       "Phase-1 instance must use unoriented Kuhn cells (base point + permutation of increment order, one representative per geometric cell). The Session-1 orientation-doubling bug came from carrying a free miss/orientation flag in GridSimplex; the instance must NOT.",
-      "Session 5: representation A (GridSimplex subtype) preferred over Finset for the Phase-1 Simplex type — Finset does not dodge the canonical vertex-ordering obligation; IsCanon s := forall k, lex (s.verts 0) <= s.verts k is a simpler computable canonicality predicate (step_dec fixes chain direction from lex-min base)."
+      "Session 5: representation A (GridSimplex subtype) preferred over Finset for the Phase-1 Simplex type — Finset does not dodge the canonical vertex-ordering obligation; IsCanon s := forall k, lex (s.verts 0) <= s.verts k is a simpler computable canonicality predicate (step_dec fixes chain direction from lex-min base).",
+      "Phase-1 GridSimplex-rep REQUIRES canonicalization: a facet-sharing dual graph over all GridSimplices breaks adj_unique_facet (a cell and its reverse share the same vertex set/facets). Cube-Kuhn lex-min-base uniqueness does NOT transfer (corner-simplex is not a union of full Kuhn cubes), so a separate IsCanon predicate is mandatory."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "DONE (Session 3, UNVERIFIED): BaryPoint d N ≃ Vertex d N bridge in SpernerNDimOQ02.lean. VERIFY once build infra recovers.",
-      "Phase 1: define freudenthal d N : SpernerTriangulation d N (unoriented Kuhn cells, vertices via baryEquivVertex/toVertex) and discharge the 8 structure fields (adj_symm/adj_ne/adj_unique_facet/adj_vertices/boundary_face via the standard Kuhn pivot).",
-      "Phase 2: prove last-face-door-oddness by induction on d using the door <-> panchromatic-(d-1)-simplex bijection; supply it as hbdry to sperner_ndim.",
-      "Reroute sperner_grid through the instance; delete false boundary_doors_odd / boundary_verts_on_face.",
-      "Build-gated: define lex IsCanon predicate + decidability + per-geometry uniqueness; gridSimplexFintype is noncomputable so adj must use Finset.filter/choose not decide."
+      "Define canonMiss/IsCanon (decidable) + per-geometry uniqueness, using last_coord_non_miss/last_coord_miss + verts_injective",
+      "Simplex := {s : GridSimplex // IsCanon s}; vertices := toVertex∘verts; vertices_injective from toVertex_injective∘verts_injective",
+      "adj via finite facet-search; discharge 5 adjacency fields + boundary_face (transport onFace via SpernerNDimOQ02.onFace_toVertex)",
+      "Phase 2: last-face-door-oddness by induction on d; apply sperner_ndim",
+      "Retire false boundary_doors_odd/boundary_verts_on_face"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Continues **Option C** for `sperner-ndim-oq-02` (Boundary-Door Oddness by Dimensional Induction). Builds the verified foundation Phase 1 needs to construct the `SpernerTriangulation d N` instance, without depending on the **broken `SpernerGrid.lean`** (15+ genuine compile errors in its adjacency machinery, lines 679–1740).

Extends `SpernerGridBase.lean` (88 → 460 lines).

### (1) Decoupling — extract the clean GridSimplex foundation
Factored the entire *clean* region of `SpernerGrid.lean` (SECTIONS III–V, lines 241–513, all **before** the first compile error @679) byte-for-byte into the self-contained `SpernerGridBase.lean`:
- `structure GridSimplex` + `gridSimplexDecEq` + `gridSimplexFintype` (the `Simplex` carrier with `DecidableEq`/`Fintype`)
- `incDir_stable`, `incDir_const_after`, `verts_succ_ne`, **`verts_injective`** (the `vertices_injective` field), `vertex_set_card`
- coordinate trackers `miss_coord_at`, `base_miss_ge_d`, `miss_coord_ge`, `incDir_surj_complement`

These reuse already-checked proofs; the value is pure decoupling so Phase-1 can build `Simplex`/`vertices`/`vertices_injective` over a clean base.

### (2) New — coordinate-reconstruction lemmas (SECTION VI)
- `GridSimplex.incDir_const_before` (mirror of `incDir_const_after`)
- `GridSimplex.last_coord_non_miss`: `(verts last).coords j = (verts 0).coords j + 1` for `j ≠ miss`
- `GridSimplex.last_coord_miss`: `(verts last).coords miss = (verts 0).coords miss − d`

Together: **every vertex is an explicit function of `(verts 0, miss, incDir)`** — the backbone the canonical-representative predicate `IsCanon` needs to make one cell per geometry well-posed.

## Verification (gold-standard, no stubs)
- `SpernerGridBase.lean` (460 L) builds clean **EXIT 0** against real cached imports (local `lake env lean` fallback; docker still corrupt).
- The bridge `SpernerNDimOQ02.lean` still builds against the extended base.
- `#print axioms` on `verts_injective`, `last_coord_non_miss`, `last_coord_miss`, `incDir_const_before` = `{propext, Classical.choice, Quot.sound}` only → **verified, 0-axiom**.

## Design note
The PR also records (knowledge.md Session 7) that the GridSimplex-rep **provably requires** an `IsCanon` predicate: a facet-sharing dual graph over *all* GridSimplices breaks `adj_unique_facet` (a cell and its reverse share the same vertex set/facets), and the cube-Kuhn lex-min-base uniqueness trick does **not** transfer to the corner-simplex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)