### PR TITLE
research(bounded-prime-gaps-oq-02): instantiate genuine von-Mangoldt EH discrepancy [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02.lean
@@ -62,6 +62,12 @@ work documented in the sibling `BoundedPrimeGapsOQ04`.
       the level decomposition that licenses dyadic decomposition of the modulus range
 - [x] Subdivided ascent `EHAtLevel_discrepancySum_up_split`: raising the level only needs
       EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure
+- [x] Genuine von-Mangoldt instantiation: the concrete weight
+      `vonMangoldtWeight q x = max_{(a,q)=1} |ψ(x;q,a) − x/φ(q)|` (built from Mathlib's
+      `ArithmeticFunction.vonMangoldt` and `Nat.totient`) is *proved* nonnegative, so the
+      entire hierarchy — level monotonicity, exact band decomposition, EH ⟹ BV, and dyadic
+      ascent — specializes with no further hypotheses to the **actual** Elliott–Halberstam
+      sum `vonMangoldtDiscrepancySum θ x = Σ_{q ≤ x^θ} max_{(a,q)=1} |ψ(x;q,a) − x/φ(q)|`
 - [x] No `axiom`, no `sorry`, no `native_decide`
 -/
 
@@ -410,5 +416,121 @@ theorem EHAtLevel_discrepancySum_up_split (f : ℕ → ℝ → ℝ) {θ₁ θ₂
       ≤ C₁ * x / (Real.log x) ^ A + C₂ * x / (Real.log x) ^ A := by
         linarith [hb₁ x hx, hb₂ x hx]
     _ = (C₁ + C₂) * x / (Real.log x) ^ A := by ring
+
+/-! ## Grounding the hierarchy in the genuine von-Mangoldt discrepancy
+
+Everything above treats the per-modulus weight `f` abstractly, requiring only
+nonnegativity.  Here we instantiate `f` with the **genuine** Elliott–Halberstam weight
+
+  `f q x = max_{(a,q)=1} |ψ(x; q, a) − x/φ(q)|`,   `ψ(x; q, a) = Σ_{n ≤ x, n ≡ a (q)} Λ(n)`,
+
+built from Mathlib's von-Mangoldt function `ArithmeticFunction.vonMangoldt` and Euler
+totient `Nat.totient`.  The maximum of absolute values is automatically nonnegative, so
+the single structural hypothesis the whole framework needs is discharged outright — and
+the level hierarchy, the exact band decomposition, the convex-cone closure and the dyadic
+ascent all specialize, with no further work, to the *actual* Elliott–Halberstam sum.  This
+converts the abstract skeleton into statements about the genuine object of the conjecture. -/
+
+open scoped ArithmeticFunction in
+/-- The **Chebyshev ψ in an arithmetic progression** at a real cutoff `x`:
+`ψ(x; q, a) = Σ_{1 ≤ n ≤ ⌊x⌋, n ≡ a (q)} Λ(n)`, with `Λ` the von-Mangoldt function. -/
+noncomputable def psiAP (q a : ℕ) (x : ℝ) : ℝ :=
+  ∑ n ∈ (Finset.Icc 1 ⌊x⌋₊).filter (fun n => n % q = a % q),
+    ArithmeticFunction.vonMangoldt n
+
+/-- The **per-residue discrepancy** `|ψ(x; q, a) − x/φ(q)|` of the progression `a mod q`
+against its expected main term `x/φ(q)`.  Nonnegative by construction (an absolute value). -/
+noncomputable def apDiscrepancy (q a : ℕ) (x : ℝ) : ℝ :=
+  |psiAP q a x - x / (Nat.totient q : ℝ)|
+
+/-- The **genuine Elliott–Halberstam per-modulus weight**: the worst-case discrepancy
+`max_{(a,q)=1} |ψ(x; q, a) − x/φ(q)|` over residues `a` coprime to `q` (and `0` for the
+degenerate empty range `q = 0`).  This is exactly the summand of the real EH sum. -/
+noncomputable def vonMangoldtWeight (q : ℕ) (x : ℝ) : ℝ :=
+  if h : ((Finset.range q).filter (fun a => Nat.Coprime a q)).Nonempty then
+    ((Finset.range q).filter (fun a => Nat.Coprime a q)).sup' h
+      (fun a => apDiscrepancy q a x)
+  else 0
+
+/-- The genuine weight is nonnegative — the sole structural hypothesis the abstract
+hierarchy requires — because it is a maximum (or `0`) of absolute values. -/
+theorem vonMangoldtWeight_nonneg (q : ℕ) (x : ℝ) : 0 ≤ vonMangoldtWeight q x := by
+  unfold vonMangoldtWeight
+  split
+  · next h =>
+    obtain ⟨a, ha⟩ := h
+    have h0 : 0 ≤ apDiscrepancy q a x := abs_nonneg _
+    exact le_trans h0 (Finset.le_sup' (fun a => apDiscrepancy q a x) ha)
+  · exact le_refl 0
+
+/-- The **genuine Elliott–Halberstam discrepancy sum** at level `θ`:
+`Σ_{q ≤ x^θ} max_{(a,q)=1} |ψ(x; q, a) − x/φ(q)|`, the object whose `≪_A x/(log x)^A`
+bound *is* the level-of-distribution statement. -/
+noncomputable def vonMangoldtDiscrepancySum (θ x : ℝ) : ℝ :=
+  discrepancySum vonMangoldtWeight θ x
+
+/-- The clamped genuine sum (base `max 1 x`), level-monotone for *every* real `x`. -/
+noncomputable def vonMangoldtDiscrepancySumClamped (θ x : ℝ) : ℝ :=
+  discrepancySumClamped vonMangoldtWeight θ x
+
+/-- On the analytic regime `x ≥ 1` the clamp is inert. -/
+theorem vonMangoldtDiscrepancySumClamped_eq {θ x : ℝ} (hx : 1 ≤ x) :
+    vonMangoldtDiscrepancySumClamped θ x = vonMangoldtDiscrepancySum θ x :=
+  discrepancySumClamped_eq vonMangoldtWeight hx
+
+/-- **The genuine EH sum is level-monotone on `x ≥ 1`** — proved, not assumed.  Larger
+levels admit more moduli `q ≤ x^θ`, and each new worst-case discrepancy is nonnegative. -/
+theorem vonMangoldtDiscrepancySum_mono_level {θ₁ θ₂ x : ℝ} (hx : 1 ≤ x) (hθ : θ₁ ≤ θ₂) :
+    vonMangoldtDiscrepancySum θ₁ x ≤ vonMangoldtDiscrepancySum θ₂ x :=
+  discrepancySum_mono_level vonMangoldtWeight vonMangoldtWeight_nonneg hx hθ
+
+/-- The clamped genuine functional is globally level-monotone, hence a genuine (generally
+nonzero) model of `LevelMonotone` to which the level hierarchy `EHAtLevel_of_le` applies. -/
+theorem levelMonotone_vonMangoldtDiscrepancySumClamped :
+    LevelMonotone vonMangoldtDiscrepancySumClamped :=
+  levelMonotone_discrepancySumClamped vonMangoldtWeight vonMangoldtWeight_nonneg
+
+/-- **The level hierarchy for the genuine EH sum.**  If the real von-Mangoldt discrepancy
+sum satisfies the Elliott–Halberstam bound at some level `θ₂`, it satisfies it at every
+lower level `θ₁ ≤ θ₂`.  This is `EHAtLevel_of_le` at the actual object of the conjecture. -/
+theorem EHAtLevel_of_le_vonMangoldt {θ₁ θ₂ : ℝ} (h : θ₁ ≤ θ₂)
+    (hEH : EHAtLevel vonMangoldtDiscrepancySumClamped θ₂) :
+    EHAtLevel vonMangoldtDiscrepancySumClamped θ₁ :=
+  EHAtLevel_of_le _ levelMonotone_vonMangoldtDiscrepancySumClamped h hEH
+
+/-- **Elliott–Halberstam ⟹ Bombieri–Vinogradov, for the genuine functional.**  The full
+conjecture for the real von-Mangoldt discrepancy sum implies its proved `θ = 1/2` case. -/
+theorem bombieriVinogradov_of_EH_vonMangoldt
+    (hEH : ElliottHalberstam vonMangoldtDiscrepancySumClamped) :
+    BombieriVinogradov vonMangoldtDiscrepancySumClamped :=
+  bombieriVinogradov_of_elliottHalberstam _ hEH
+
+/-- For the genuine functional, the EH bound at **any** level `θ ≥ 1/2` already yields
+Bombieri–Vinogradov, via the hierarchy. -/
+theorem bombieriVinogradov_of_EHAtLevel_vonMangoldt {θ : ℝ} (hθ : 1 / 2 ≤ θ)
+    (hEH : EHAtLevel vonMangoldtDiscrepancySumClamped θ) :
+    BombieriVinogradov vonMangoldtDiscrepancySumClamped :=
+  bombieriVinogradov_of_EHAtLevel _ levelMonotone_vonMangoldtDiscrepancySumClamped hθ hEH
+
+/-- **Exact level increment for the genuine sum.**  On `x ≥ 1`, the real EH sum at level
+`θ₂` is its level-`θ₁` value plus exactly the worst-case discrepancy of the new moduli
+`⌊x^θ₁⌋ < q ≤ ⌊x^θ₂⌋` — the genuine instance of `discrepancySum_eq_add_band`. -/
+theorem vonMangoldtDiscrepancySum_eq_add_band {θ₁ θ₂ x : ℝ} (hx : 1 ≤ x) (hθ : θ₁ ≤ θ₂) :
+    vonMangoldtDiscrepancySum θ₂ x
+      = vonMangoldtDiscrepancySum θ₁ x + discrepancyBand vonMangoldtWeight θ₁ θ₂ x :=
+  discrepancySum_eq_add_band vonMangoldtWeight hx hθ
+
+/-- **Dyadic ascent for the genuine sum.**  To raise the genuine level of distribution
+from `θ₁` to `θ₃` it suffices to bound the real worst-case discrepancy on each consecutive
+sub-band of moduli `θ₁ → θ₂` and `θ₂ → θ₃` — the formal license for the dyadic attack on
+Elliott–Halberstam, now stated for the actual von-Mangoldt weight. -/
+theorem EHAtLevel_vonMangoldt_up_split {θ₁ θ₂ θ₃ : ℝ} (h₁₂ : θ₁ ≤ θ₂) (h₂₃ : θ₂ ≤ θ₃)
+    (hlow : EHAtLevel vonMangoldtDiscrepancySum θ₁)
+    (hband₁ : ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand vonMangoldtWeight θ₁ θ₂ x ≤ C * x / (Real.log x) ^ A)
+    (hband₂ : ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand vonMangoldtWeight θ₂ θ₃ x ≤ C * x / (Real.log x) ^ A) :
+    EHAtLevel vonMangoldtDiscrepancySum θ₃ :=
+  EHAtLevel_discrepancySum_up_split vonMangoldtWeight h₁₂ h₂₃ hlow hband₁ hband₂
 
 end BoundedPrimeGapsOQ02

--- a/src/data/research/problems/bounded-prime-gaps-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: sharpened the EH level hierarchy. (1) EXACT additive decomposition discrepancySum_eq_add_band: discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x, localizing inter-level growth to the band of new moduli ⌊x^θ₁⌋<q≤⌊x^θ₂⌋ (monotonicity now a corollary). (2) EH-bound functional class is a CONVEX CONE: EHAtLevel_add, EHAtLevel_smul (0≤c), EHAtLevel_nonneg_linear. (3) Quantitative converse EHAtLevel_discrepancySum_up: EH at θ₁ + EH-type band bound ⟹ EH at θ₂ — the band is exactly the extra analytic input to raise the level. VERIFIED offline via lake env lean (full kernel check vs Mathlib oleans, EXIT 0; axioms = propext/Classical.choice/Quot.sound only); docker-build still host-blocked. 20 thm / 7 def, 0 axiom/0 sorry. EH itself remains OPEN.",
+    "progressSummary": "PROGRESS: grounded the abstract EH level-hierarchy in the GENUINE von-Mangoldt discrepancy. Defined the real per-modulus weight max over coprime residues of |psi(x;q,a)-x/phi(q)| (psiAP via ArithmeticFunction.vonMangoldt, apDiscrepancy, vonMangoldtWeight) and proved it nonnegative — the sole structural hypothesis — so the full framework (level monotonicity, exact band decomposition, EH=>BV, dyadic ascent) now specializes to the actual Elliott-Halberstam sum vonMangoldtDiscrepancySum theta x with ZERO further hypotheses. 32 thm / 12 def, 0 axiom / 0 sorry, verified offline (lake env lean EXIT 0; axioms = propext/Classical.choice/Quot.sound only). EH/BV bound itself remains OPEN — the genuine analytic input is now isolated as a single bound on vonMangoldtWeight.",
     "builtItems": [
       "EHAtLevel, LevelMonotone (defs) in BoundedPrimeGapsOQ02.lean:68,75",
       "EHAtLevel_of_le (level hierarchy) BoundedPrimeGapsOQ02.lean:81",
@@ -43,7 +43,9 @@
       "discrepancyBand f θ₁ θ₂ x := ∑ q ∈ Finset.Ioc ⌊x^θ₁⌋₊ ⌊x^θ₂⌋₊, f q x — the new-moduli band contribution",
       "discrepancySum_eq_add_band (hx:1≤x)(hθ:θ₁≤θ₂): discrepancySum f θ₂ x = discrepancySum f θ₁ x + discrepancyBand f θ₁ θ₂ x — exact decomposition via Finset.sum_Ioc_consecutive after Icc 1 = Ioc 0 conversion",
       "EHAtLevel_add / EHAtLevel_smul / EHAtLevel_nonneg_linear — EH-bound class is a convex cone (constants C₁+C₂ and c·C+1)",
-      "EHAtLevel_discrepancySum_up: EHAtLevel(discrepancySum f) θ₁ + band EH-bound ⟹ EHAtLevel(discrepancySum f) θ₂ — quantitative ascent converse to the descent hierarchy"
+      "EHAtLevel_discrepancySum_up: EHAtLevel(discrepancySum f) θ₁ + band EH-bound ⟹ EHAtLevel(discrepancySum f) θ₂ — quantitative ascent converse to the descent hierarchy",
+      "psiAP/apDiscrepancy/vonMangoldtWeight + vonMangoldtDiscrepancySum(Clamped) in BoundedPrimeGapsOQ02.lean: genuine EH weight from ArithmeticFunction.vonMangoldt + Nat.totient; vonMangoldtWeight_nonneg via Finset.le_sup'+abs_nonneg",
+      "Capstones EHAtLevel_of_le_vonMangoldt, bombieriVinogradov_of_EH_vonMangoldt, bombieriVinogradov_of_EHAtLevel_vonMangoldt, vonMangoldtDiscrepancySum_mono_level, vonMangoldtDiscrepancySum_eq_add_band, EHAtLevel_vonMangoldt_up_split — full hierarchy/band/cone/ascent now applies to the genuine functional, 0-axiom"
     ],
     "insights": [
       "EH is a conjecture, so formalize it as a logical skeleton over an abstract discrepancy functional D θ x — never axiomatize EH itself.",
@@ -54,17 +56,17 @@
       "A base clamp (max 1 x) makes level-monotonicity hold for ALL real x, yielding a generally nonzero global model of LevelMonotone — strictly stronger non-vacuity than the zero functional.",
       "The inter-level growth in the discrepancy sum is EXACTLY the discrepancy of the band of new moduli ⌊x^θ₁⌋<q≤⌊x^θ₂⌋ — proved by Finset.sum_Ioc_consecutive after rewriting Finset.Icc 1 m = Finset.Ioc 0 m (ext + omega). This turns the qualitative hierarchy into a quantitative one.",
       "EHAtLevel at a fixed level is closed under +, nonneg scaling, hence a convex cone; the +1 in c·C+1 keeps the constant strictly positive when c=0, avoiding a case split.",
-      "Descent (higher⟹lower level) is free from monotonicity; ASCENT (raise the level) costs exactly an EH-type bound on the new-moduli band — formal statement of why EH beyond Bombieri–Vinogradov (θ=1/2) is hard."
+      "Descent (higher⟹lower level) is free from monotonicity; ASCENT (raise the level) costs exactly an EH-type bound on the new-moduli band — formal statement of why EH beyond Bombieri–Vinogradov (θ=1/2) is hard.",
+      "Genuine von-Mangoldt instantiation: the only structural hypothesis the abstract EH hierarchy needs from the per-modulus weight is NONNEGATIVITY; the worst-case discrepancy max over coprime residues of |psi(x;q,a) - x/phi(q)| is a max of absolute values, so nonnegativity is automatic and every structural theorem specializes to the real EH sum for free."
     ],
     "mathlibGaps": [
       "No global Mathlib gap for the skeleton; instantiating D with the genuine von-Mangoldt discrepancy sum and proving its LevelMonotone is the analytic work (depends on Bombieri–Vinogradov, ~12000 lines, tracked in OQ-04)."
     ],
     "nextSteps": [
-      "Re-confirm via docker-build.sh once host containerd corruption is repaired (offline `lake env lean` already passes; docker content store currently I/O-corrupt).",
-      "Instantiate D := von-Mangoldt discrepancy sum and prove LevelMonotone for it.",
-      "Formalize a strict/quantitative version of the hierarchy (constant improves as the level drops).",
-      "Instantiate f q x := max_{(a,q)=1} |ψ(x;q,a) − x/φ(q)| using Mathlib von Mangoldt (ArithmeticFunction.vonMangoldt) to connect discrepancySum to the genuine EH sum",
-      "Bridge to the Maynard–Tao bounded-gap consequence (DHL[k,m]) under EHAtLevel — assess Mathlib sieve infrastructure"
+      "Prove an ACTUAL bound on vonMangoldtWeight/vonMangoldtDiscrepancySum at theta=1/2 (Bombieri-Vinogradov) — the genuine analytic content; assess Mathlib BV/large-sieve infrastructure (likely absent -> scope a build)",
+      "Relate vonMangoldtDiscrepancySum to the Maynard-Tao DHL[k,m] bounded-gap consequence under EHAtLevel",
+      "Formalize a strict/quantitative version of the hierarchy (constant improves as level drops)",
+      "Connect psiAP to a prime-counting (pi) form via partial summation"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Grounds the abstract Elliott–Halberstam **level-of-distribution hierarchy** in `BoundedPrimeGapsOQ02.lean` into the **genuine** analytic object. Until now the per-modulus weight `f` was abstract, with only nonnegativity assumed. This PR instantiates it with the real EH weight

```
vonMangoldtWeight q x = max_{(a,q)=1} |ψ(x; q, a) − x/φ(q)|
ψ(x; q, a) = Σ_{1 ≤ n ≤ ⌊x⌋, n ≡ a (q)} Λ(n)
```

built from Mathlib's `ArithmeticFunction.vonMangoldt` (`Λ`) and `Nat.totient` (`φ`), via new defs `psiAP`, `apDiscrepancy`, `vonMangoldtWeight`.

**Key observation:** the *only* structural hypothesis the whole framework needs from the weight is **nonnegativity**, and a maximum of absolute values is automatically nonnegative (`vonMangoldtWeight_nonneg`, by `Finset.le_sup'` + `abs_nonneg`). So every structural theorem already in the file specializes — with *no further hypotheses* — to the actual EH sum `vonMangoldtDiscrepancySum θ x`:

- `EHAtLevel_of_le_vonMangoldt` — the level hierarchy for the genuine sum
- `bombieriVinogradov_of_EH_vonMangoldt`, `bombieriVinogradov_of_EHAtLevel_vonMangoldt` — EH ⟹ BV (and any level ≥ 1/2 ⟹ BV)
- `vonMangoldtDiscrepancySum_mono_level`, `vonMangoldtDiscrepancySum_eq_add_band` — proved level-monotonicity + exact new-moduli band decomposition
- `EHAtLevel_vonMangoldt_up_split` — dyadic ascent over consecutive sub-bands

This converts the abstract skeleton into statements about the genuine object of the conjecture, and isolates the remaining (open) analytic content as a *single* bound on `vonMangoldtWeight`.

## Verification

- **32 theorems / 12 defs, 0 `axiom` / 0 `sorry` / 0 `native_decide`**
- Verified offline via `lake env lean` (full kernel check vs Mathlib oleans, **EXIT 0**); `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
- `docker-build.sh` is currently host-blocked by containerd I/O corruption (`meta.db: input/output error`); offline kernel check stands in.

The EH / Bombieri–Vinogradov bound itself remains **OPEN** — unchanged, not axiomatized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)