### PR TITLE
research(bounded-prime-gaps-oq-02): finite-chain dyadic ascent (abstract + von-Mangoldt) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ02.lean
@@ -62,6 +62,11 @@ work documented in the sibling `BoundedPrimeGapsOQ04`.
       the level decomposition that licenses dyadic decomposition of the modulus range
 - [x] Subdivided ascent `EHAtLevel_discrepancySum_up_split`: raising the level only needs
       EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure
+- [x] Finite-chain ascent `EHAtLevel_discrepancySum_up_chain` (and its genuine specialization
+      `EHAtLevel_vonMangoldt_up_chain`): iterating the single-band ascent along an arbitrary
+      monotone level chain `L 0 ≤ L 1 ≤ ⋯`, EH at the base plus an EH-type bound on every
+      consecutive band lifts EH to every level `L n` — the arbitrarily-many-blocks form of
+      dyadic decomposition of the modulus range (the `n = 2` case is the split lemma above)
 - [x] Genuine von-Mangoldt instantiation: the concrete weight
       `vonMangoldtWeight q x = max_{(a,q)=1} |ψ(x;q,a) − x/φ(q)|` (built from Mathlib's
       `ArithmeticFunction.vonMangoldt` and `Nat.totient`) is *proved* nonnegative, so the
@@ -417,6 +422,37 @@ theorem EHAtLevel_discrepancySum_up_split (f : ℕ → ℝ → ℝ) {θ₁ θ₂
         linarith [hb₁ x hx, hb₂ x hx]
     _ = (C₁ + C₂) * x / (Real.log x) ^ A := by ring
 
+/-! ## Finite dyadic chain: ascent over arbitrarily many sub-bands
+
+`EHAtLevel_discrepancySum_up_split` raises the level of distribution across *two*
+consecutive sub-bands.  But the genuine analytic dyadic decomposition splits the modulus
+range `q ≤ x^θ` into `≍ log x` dyadic blocks, not two — so the two-band statement is only
+the first nontrivial instance of the real strategy.  Here we iterate the single-band ascent
+along an arbitrary finite increasing chain of levels `L 0 ≤ L 1 ≤ ⋯ ≤ L n`: an EH bound at
+the base level together with an EH-type bound on every consecutive band raises the level of
+distribution all the way to the top `L n`.  This is the full-strength formal statement that
+Elliott–Halberstam may be attacked by dyadic decomposition of the modulus range into any
+number of blocks. -/
+
+/-- **Finite-chain ascent.**  For a monotone level sequence `L : ℕ → ℝ`, if the canonical
+discrepancy sum satisfies the Elliott–Halberstam bound at the base level `L 0` and each
+consecutive band `L k → L (k+1)` independently satisfies an EH-type bound, then EH holds at
+*every* level `L n` of the chain.  The proof iterates `EHAtLevel_discrepancySum_up` along the
+chain; `n = 1` is exactly the single-band ascent and the `n = 2` case recovers
+`EHAtLevel_discrepancySum_up_split`.  This is the arbitrarily-many-blocks form of dyadic
+decomposition. -/
+theorem EHAtLevel_discrepancySum_up_chain (f : ℕ → ℝ → ℝ) {L : ℕ → ℝ}
+    (hmono : Monotone L)
+    (hlow : EHAtLevel (discrepancySum f) (L 0))
+    (hband : ∀ k : ℕ, ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand f (L k) (L (k + 1)) x ≤ C * x / (Real.log x) ^ A) :
+    ∀ n : ℕ, EHAtLevel (discrepancySum f) (L n) := by
+  intro n
+  induction n with
+  | zero => exact hlow
+  | succ k ih =>
+      exact EHAtLevel_discrepancySum_up f (hmono (Nat.le_succ k)) ih (hband k)
+
 /-! ## Grounding the hierarchy in the genuine von-Mangoldt discrepancy
 
 Everything above treats the per-modulus weight `f` abstractly, requiring only
@@ -532,5 +568,18 @@ theorem EHAtLevel_vonMangoldt_up_split {θ₁ θ₂ θ₃ : ℝ} (h₁₂ : θ�
         discrepancyBand vonMangoldtWeight θ₂ θ₃ x ≤ C * x / (Real.log x) ^ A) :
     EHAtLevel vonMangoldtDiscrepancySum θ₃ :=
   EHAtLevel_discrepancySum_up_split vonMangoldtWeight h₁₂ h₂₃ hlow hband₁ hband₂
+
+/-- **Finite dyadic chain for the genuine sum.**  To raise the genuine level of
+distribution from the base of a monotone level chain `L` all the way to any level `L n`, it
+suffices to bound the real worst-case von-Mangoldt discrepancy on each consecutive sub-band
+`L k → L (k+1)`.  This is `EHAtLevel_discrepancySum_up_chain` specialized to the actual
+Elliott–Halberstam weight — the arbitrarily-many-blocks dyadic attack on the genuine
+object, of which `EHAtLevel_vonMangoldt_up_split` is the two-block case. -/
+theorem EHAtLevel_vonMangoldt_up_chain {L : ℕ → ℝ} (hmono : Monotone L)
+    (hlow : EHAtLevel vonMangoldtDiscrepancySum (L 0))
+    (hband : ∀ k : ℕ, ∀ A : ℝ, 0 < A → ∃ C : ℝ, 0 < C ∧ ∀ x : ℝ, 2 ≤ x →
+        discrepancyBand vonMangoldtWeight (L k) (L (k + 1)) x ≤ C * x / (Real.log x) ^ A) :
+    ∀ n : ℕ, EHAtLevel vonMangoldtDiscrepancySum (L n) :=
+  EHAtLevel_discrepancySum_up_chain vonMangoldtWeight hmono hlow hband
 
 end BoundedPrimeGapsOQ02

--- a/research/problems/bounded-prime-gaps-oq-02/knowledge.md
+++ b/research/problems/bounded-prime-gaps-oq-02/knowledge.md
@@ -1,0 +1,40 @@
+# bounded-prime-gaps-oq-02 — knowledge
+
+Elliott–Halberstam conjecture, formalized axiom-free as a level-of-distribution
+hierarchy (`Proofs/BoundedPrimeGapsOQ02.lean`). Verified: 0 axioms, 0 sorries,
+0 native_decide. EH itself is NOT axiomatized — the discrepancy functional and its
+structural properties enter only as per-theorem hypotheses.
+
+## Session 2026-06-27 (researcher-1) — phase ACT, SOLVED entry, looked outward
+
+Added the **finite dyadic chain** generalization of the two-band ascent:
+
+- `EHAtLevel_discrepancySum_up_chain` (abstract weight `f`): for a monotone level
+  sequence `L : ℕ → ℝ`, EH at base `L 0` + an EH-type bound on every consecutive band
+  `L k → L (k+1)` ⟹ EH at every `L n`. Proof: induction on `n`, iterating the
+  single-band `EHAtLevel_discrepancySum_up` via `hmono (Nat.le_succ k)`.
+- `EHAtLevel_vonMangoldt_up_chain`: the genuine specialization to `vonMangoldtWeight`
+  (matching the file's abstract+genuine pairing pattern).
+
+The `n = 2` case recovers `EHAtLevel_discrepancySum_up_split`. This is the
+arbitrarily-many-blocks form of dyadic decomposition of the modulus range — the genuine
+analytic strategy uses `≍ log x` blocks, not two, so the prior two-band lemma was only
+the first nontrivial instance.
+
+File now: 585 lines, 34 theorems, 12 defs, 0 axioms/sorries.
+
+## Verification gotchas (this session)
+- Docker build infra was DOWN (containerd `meta.db` I/O error). Verified instead via
+  `cd proofs && LAKE_UNSAFE=1 lake env lean Proofs/BoundedPrimeGapsOQ02.lean` (EXIT 0).
+  Local oleans live at `proofs/.lake/packages/mathlib/.lake/build/lib/lean/`; toolchain
+  v4.26.0 matches local `lean`.
+- The remote `feature/researcher-1` branch is badly stale/divergent (501 commits, and the
+  BPG files are DELETED on it). PR from a fresh branch off `origin/main` instead.
+- The worktree's checked-out file was an OLDER version than `main` (main already had the
+  whole `vonMangoldtWeight` section). Re-apply edits onto main's current file, not the
+  worktree's stale copy.
+
+## Possible further outward directions (not done)
+- Bridge the band-bound hypothesis form to `EHAtLevel (fun _ x => discrepancyBand …) ·`
+  to unify it with the convex-cone lemmas.
+- Finset/list-indexed (non-ℕ) chain version; explicit dyadic chain `L k = log2`-spaced.

--- a/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-02/meta.json
@@ -81,13 +81,15 @@
       "EHAtLevel_of_le_discrepancySumClamped: the level hierarchy instantiated at the concrete nonzero model",
       "discrepancyBand_self: the empty band — from a level to itself there are no new moduli, so the band discrepancy vanishes (base case for subdivision)",
       "discrepancyBand_add_consecutive: the additive cocycle (Chasles) identity for the band — for θ₁≤θ₂≤θ₃ on x≥1, discrepancyBand θ₁ θ₃ = discrepancyBand θ₁ θ₂ + discrepancyBand θ₂ θ₃, subdividing the new-moduli band at any intermediate level",
-      "EHAtLevel_discrepancySum_up_split: subdivided ascent — raising the level from θ₁ to θ₃ needs only EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure; the formal statement that the modulus range may be attacked dyadically"
+      "EHAtLevel_discrepancySum_up_split: subdivided ascent — raising the level from θ₁ to θ₃ needs only EH-type bounds on each consecutive sub-band, recombined via the convex-cone closure; the formal statement that the modulus range may be attacked dyadically",
+      "EHAtLevel_discrepancySum_up_chain: finite-chain ascent — for a monotone level sequence L : ℕ → ℝ, EH at base level L 0 plus an EH-type bound on every consecutive band L k → L (k+1) lifts EH to every level L n (induction iterating the single-band ascent); the arbitrarily-many-blocks form of dyadic decomposition of the modulus range, of which EHAtLevel_discrepancySum_up_split is the n=2 case",
+      "EHAtLevel_vonMangoldt_up_chain: the finite-chain dyadic ascent specialized to the genuine von-Mangoldt EH weight — raising the genuine level of distribution to any L n by bounding the real worst-case discrepancy on each consecutive sub-band"
     ],
-    "lineCount": 414,
+    "lineCount": 585,
     "erdosUrl": null,
     "dateAdded": "2026-06-27",
-    "theoremCount": 23,
-    "definitionCount": 7
+    "theoremCount": 34,
+    "definitionCount": 12
   },
   "overview": {
     "historicalContext": "The Elliott–Halberstam conjecture (1968) strengthens the Bombieri–Vinogradov theorem (1965), which established that primes equidistribute in arithmetic progressions on average over moduli up to √x — a 'Riemann Hypothesis quality' result obtained unconditionally. EH conjectures the same averaged equidistribution up to x^θ for every θ < 1. It is the analytic input that sharpens the Maynard–Tao bounded-gap bound: H ≤ 12 under EH versus H ≤ 246 unconditionally. EH remains open.",
@@ -199,10 +201,10 @@
       "Real"
     ],
     "namespace": "BoundedPrimeGapsOQ02",
-    "lineCount": 414,
+    "lineCount": 585,
     "axiomCount": 0,
-    "theoremCount": 23,
-    "definitionCount": 7,
+    "theoremCount": 34,
+    "definitionCount": 12,
     "path": "Proofs/BoundedPrimeGapsOQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Extends the Elliott–Halberstam level-of-distribution skeleton (`BoundedPrimeGapsOQ02.lean`) with the **finite dyadic chain** generalization of the existing two-band ascent.

The file already had `EHAtLevel_discrepancySum_up_split`: raising the level of distribution across **two** consecutive sub-bands of moduli. But the genuine analytic dyadic decomposition splits the modulus range `q ≤ x^θ` into `≍ log x` blocks, not two — so the two-band lemma is only the first nontrivial instance of the real strategy. This PR closes that gap to arbitrarily many blocks.

## New theorems

- **`EHAtLevel_discrepancySum_up_chain`** (abstract nonnegative weight `f`): for a monotone level sequence `L : ℕ → ℝ`, EH at the base level `L 0` plus an EH-type bound on **every** consecutive band `L k → L (k+1)` lifts EH to **every** level `L n`. Proof: induction on `n`, iterating the single-band `EHAtLevel_discrepancySum_up` via `hmono (Nat.le_succ k)`.
- **`EHAtLevel_vonMangoldt_up_chain`**: the genuine specialization to `vonMangoldtWeight`, matching the file's established abstract+genuine pairing pattern.

The `n = 2` case recovers `EHAtLevel_discrepancySum_up_split`. This is the formal arbitrarily-many-blocks form of the dyadic attack on Elliott–Halberstam.

## Verification

- **0 axioms, 0 sorries, 0 `native_decide`**; status remains `verified`.
- File: 585 lines, 34 theorems, 12 defs.
- Checked clean via `lake env lean Proofs/BoundedPrimeGapsOQ02.lean` (EXIT 0) — the Docker build wrapper was hitting a containerd I/O error this session, so verification used the direct local Lean/Mathlib oleans (toolchain v4.26.0).
- `meta.json` line/theorem/def counts refreshed (they were stale on `main` at 414/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)