### PR TITLE
audit: drain queue 4055/4055 — clean re-audit of abel-ruffini-oq-04-oq-02-oq-01

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25181,6 +25181,12 @@
       "lastAudited": "2026-06-27T15:02:49Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T15:21:48Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

Audited the last remaining unaudited gallery proof, **abel-ruffini-oq-04-oq-02-oq-01** (freshly merged in #30783), bringing the queue to **4055/4055**.

### Verdict: CLEAN ✅

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status / badge | `verified` / `verified` | Tier A (0 axioms, 0 sorries) | ✅ |
| sorries | 0 | 0 (main + companion) | ✅ |
| axiomCount | 0 | 0 axiom declarations | ✅ |
| lineCount | 242 | 242 | ✅ |
| theoremCount | 18 | 18 | ✅ |
| True stubs | — | 0 | ✅ |

**Files**: `Proofs/AbelRuffiniOQ04OQ02OQ01.lean` + companion `Proofs/AbelRuffiniOQ04OQ02OQ02OQ01.lean`.

Substantive formalization of the solvability structure of S₃/S₄ (commutator subgroup = alternating group, derived-series layers, ZMod isomorphisms) — not a single deep-Mathlib wrapper and not a `True` stub. The `assumptions` field is honest and detailed, citing `#print axioms` evidence (only `propext`/`Classical.choice`/`Quot.sound`; no `sorryAx`, no `Lean.ofReduceBool`).

### Standing false positives re-verified (NO ACTION)
The 3 heuristic `--issues` flags are all standing FPs, re-confirmed this cycle:
- **erdos-57-oq-04**: shared-file axiom `erdos_57` belongs to the parent erdos-57 problem; oq-04's contributed lemmas are axiom-free and the host axiom is disclosed in `assumptions`. axiomCount:0 CORRECT.
- **erdos-1090**: claims 1 sorry, actual 0 — conservative over-statement; status `axiomatized`/badge `axiom` correctly reflects its 2 axioms.
- **erdos-156**: claims 3 sorries, actual 0 in-file (dep chain has sorries); status `formalized`/badge `wip` is conservative. No overclaim.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)