### PR TITLE
Enrich Explicit Derived Series of S₃ and S₄

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-01/annotations.json
@@ -1,0 +1,129 @@
+[
+  {
+    "id": "abelruffini-s3s4-overview",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-01",
+    "range": { "startLine": 4, "endLine": 59 },
+    "type": "context",
+    "title": "Why the Derived Series of S₃ and S₄ Matters",
+    "content": "The module docstring states the goal: write down the derived series of S₃ and S₄ explicitly with every factor identified. Galois's criterion makes solvability-by-radicals equivalent to solvability of the Galois group, and the generic degree-n polynomial has Galois group Sₙ; so the positive half of Abel–Ruffini is exactly that S₃ and S₄ have short derived series with abelian, prime-power-order factors. The chains are S₃ ⊵ A₃ ⊵ {e} and S₄ ⊵ A₄ ⊵ V₄ ⊵ {e}. The file's distinctive contribution over a bare composition series is proving the derived-subgroup identities [Sₙ,Sₙ] = Aₙ, which certifies these are the genuine derived series.",
+    "mathContext": "$G$ solvable $\\iff$ derived series $G \\supseteq [G,G] \\supseteq [[G,G],[G,G]] \\supseteq \\cdots$ reaches $\\{e\\}$ with abelian quotients. Here $S_3^{(1)} = A_3,\\ S_4^{(1)} = A_4,\\ A_4^{(1)} = V_4$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "solvable group",
+      "derived series",
+      "Galois theory",
+      "Abel–Ruffini theorem",
+      "composition series"
+    ],
+    "prerequisites": [
+      "group theory",
+      "symmetric and alternating groups",
+      "commutator subgroup",
+      "solvability by radicals"
+    ]
+  },
+  {
+    "id": "abelruffini-s3s4-witness",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-01",
+    "range": { "startLine": 84, "endLine": 96 },
+    "type": "technique",
+    "title": "A Commutator That Is a Three-Cycle (via decide)",
+    "content": "These two witness lemmas exhibit the single commutator the whole reverse inclusion rests on: ⁅(0 1),(0 2)⁆ equals the three-cycle (0 2)(0 1) in both Perm (Fin 3) and Perm (Fin 4). The equality of explicit permutations is closed by ordinary kernel `decide`, and `isThreeCycle_swap_mul_swap_same` certifies the product of two transpositions sharing a point is a three-cycle. Crucially these live *outside* the later `open scoped Classical` block: Classical would shadow the computable Decidable instances that `decide` needs. Using kernel `decide` (not `native_decide`) is what keeps the file's axiom set to the three foundational axioms only.",
+    "mathContext": "$\\lceil (0\\,1), (0\\,2) \\rceil = (0\\,1)(0\\,2)(0\\,1)(0\\,2) = (0\\,2)(0\\,1) = (0\\,1\\,2)$, a 3-cycle.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "commutator of transpositions",
+      "three-cycle",
+      "decide tactic",
+      "Decidable instances",
+      "Classical shadowing"
+    ],
+    "prerequisites": [
+      "permutation notation",
+      "commutator bracket ⁅·,·⁆",
+      "kernel decide vs native_decide"
+    ]
+  },
+  {
+    "id": "abelruffini-s3s4-reverse-inclusion",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-01",
+    "range": { "startLine": 98, "endLine": 113 },
+    "type": "insight",
+    "title": "The Reverse Inclusion Aₙ ≤ [Sₙ,Sₙ] Without 5 ≤ n",
+    "content": "This is the mathematical heart. Mathlib only states commutator (Perm α) = alternatingGroup α under 5 ≤ card α, because its proof routes through perfectness of Aₙ — which is false for A₃ and A₄. But the *reverse* inclusion needs no perfectness. The argument: rewrite Aₙ as the closure of all three-cycles (closure_three_cycles_eq_alternating) and reduce to showing each three-cycle τ lies in [Sₙ,Sₙ]. Every three-cycle has the same cycle type, so τ is conjugate to the witness σ₀ (isConj_iff_cycleType_eq); write τ = c σ₀ c⁻¹. Since σ₀ is a commutator it lies in [Sₙ,Sₙ], and the commutator subgroup is normal, so its conjugate τ lies there too. One explicit commutator three-cycle, spread over its conjugacy class by normality, covers all of Aₙ.",
+    "mathContext": "$A_n = \\langle \\text{3-cycles}\\rangle$; all 3-cycles are $S_n$-conjugate; $[S_n,S_n] \\trianglelefteq S_n$. So $\\sigma_0 \\in [S_n,S_n] \\Rightarrow c\\sigma_0 c^{-1} \\in [S_n,S_n]$ for every conjugate, hence $A_n \\le [S_n,S_n]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "closure_three_cycles_eq_alternating",
+      "conjugacy and cycle type",
+      "normality of the commutator subgroup",
+      "perfect group"
+    ],
+    "prerequisites": [
+      "generators of the alternating group",
+      "conjugacy classes in Sₙ",
+      "normal subgroups closed under conjugation"
+    ]
+  },
+  {
+    "id": "abelruffini-s3s4-equality",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-01",
+    "range": { "startLine": 115, "endLine": 133 },
+    "type": "concept",
+    "title": "[S₃,S₃] = A₃ and [S₄,S₄] = A₄",
+    "content": "The two derived-subgroup identities follow by le_antisymm: the forward inclusion [Sₙ,Sₙ] ≤ Aₙ is Mathlib's hypothesis-free alternatingGroup.commutator_perm_le (the sign of any commutator is +1), and the reverse inclusion is the general lemma above, fed the witness three-cycle plus a proof that it lies in the commutator set. These equalities are exactly what upgrade the towers from composition series to the genuine derived series — the layers Aₙ are literally the first derived subgroups Sₙ⁽¹⁾.",
+    "mathContext": "$[S_3,S_3] = A_3$ and $[S_4,S_4] = A_4$, by $[S_n,S_n] \\le A_n$ (signs) and $A_n \\le [S_n,S_n]$ (three-cycles).",
+    "significance": "key",
+    "relatedConcepts": [
+      "derived subgroup",
+      "le_antisymm",
+      "alternatingGroup.commutator_perm_le",
+      "sign homomorphism"
+    ],
+    "prerequisites": [
+      "antisymmetry of subgroup inclusion",
+      "the sign character"
+    ]
+  },
+  {
+    "id": "abelruffini-s3s4-cardinality",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-01",
+    "range": { "startLine": 137, "endLine": 167 },
+    "type": "technique",
+    "title": "Cardinality Helpers Pin Down the Factors",
+    "content": "A block of small cardinality facts supplies the inputs to the factor isomorphisms: |A₃| = 3 (from |Aₙ| = n!/2), |Sₙ/Aₙ| = 2 (the index of the alternating group, alternatingGroup.index_eq_two), and |Multiplicative (ZMod 2)| = 2, |Multiplicative (ZMod 3)| = 3. Each quotient or subgroup of prime order is thereby matched against its ℤ/p target by cardinality alone. The Nontrivial (Fin n) instances are introduced locally because Mathlib's alternating-group cardinality lemmas require the underlying type to have at least two elements.",
+    "mathContext": "$|A_3| = 3! / 2 = 3$, $\\ [S_n : A_n] = 2$, $\\ |\\mathrm{Multiplicative}(\\mathbb{Z}/p)| = p$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "nat_card_alternatingGroup",
+      "Subgroup.index_eq_card",
+      "Multiplicative (ZMod n)",
+      "Nontrivial instance"
+    ],
+    "prerequisites": [
+      "Lagrange / index of a subgroup",
+      "order of the alternating group"
+    ]
+  },
+  {
+    "id": "abelruffini-s3s4-series",
+    "proofId": "abel-ruffini-oq-04-oq-02-oq-01",
+    "range": { "startLine": 169, "endLine": 240 },
+    "type": "concept",
+    "title": "Packaging the Two Derived Series with Identified Factors",
+    "content": "The final sections assemble the towers. Each prime-order factor is identified with ℤ/p via mulEquivOfPrimeCardEq, which turns 'this group has prime cardinality p' into an explicit isomorphism with Multiplicative (ZMod p) — no generator needed, since a group of prime order is cyclic. derived_series_S3 bundles A₃ ◁ S₃ with the two factor isos; derived_series_S4 bundles A₄ ◁ S₄, V₄ ◁ A₄ and the three factor isos S₄/A₄ ≅ ℤ/2, A₄/V₄ ≅ ℤ/3, V₄ ≅ (ℤ/2)², reusing the A₄-layer results from the sibling Klein-four file. The companion theorems derived_layers_S3 / derived_layers_S4 record the commutator data ([Sₙ,Sₙ] ≤ Aₙ, and [A₄,A₄] = V₄) that, with the reverse inclusions, certify these as derived series.",
+    "mathContext": "$S_3/A_3 \\cong \\mathbb{Z}/2,\\ A_3 \\cong \\mathbb{Z}/3$; $\\ S_4/A_4 \\cong \\mathbb{Z}/2,\\ A_4/V_4 \\cong \\mathbb{Z}/3,\\ V_4 \\cong (\\mathbb{Z}/2)^2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "mulEquivOfPrimeCardEq",
+      "Klein four-group",
+      "group of prime order is cyclic",
+      "composition factors"
+    ],
+    "prerequisites": [
+      "quotient groups",
+      "group isomorphisms (≃*)",
+      "cyclic groups of prime order"
+    ]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-01/meta.json
@@ -36,7 +36,19 @@
       "abel-ruffini-oq-04-oq-02-oq-02"
     ]
   },
-  "overview": "Both symmetric groups S₃ and S₄ are solvable, and their derived series are short towers with abelian factors of prime-power order:\n\n* S₃: S₃ ⊵ A₃ ⊵ {e}, with top factor S₃/A₃ ≅ ℤ/2 (the sign quotient, index 2) and bottom factor A₃ ≅ ℤ/3 (cyclic of prime order 3).\n* S₄: S₄ ⊵ A₄ ⊵ V₄ ⊵ {e}, with top factor S₄/A₄ ≅ ℤ/2, middle factor A₄/V₄ ≅ ℤ/3, and bottom factor V₄ ≅ (ℤ/2)² (the Klein four-group).\n\nEvery factor isomorphism is exhibited explicitly. The A₄ ⊵ V₄ ⊵ {e} tail is reused from the sibling Klein-four composition-series file; this entry adds the new top layer Sₙ ⊵ Aₙ and the complete S₃ tower, and — going beyond a bare composition series — proves the displayed chains literally equal the derived series.",
+  "overview": {
+    "historicalContext": "The derived series is the central object of Galois's 1830s criterion: a polynomial is solvable by radicals exactly when the Galois group of its splitting field is *solvable*, i.e. its derived series terminates at the trivial group with abelian successive quotients. Because the generic degree-n polynomial has Galois group Sₙ, the Abel–Ruffini theorem reduces to the group-theoretic fact that Sₙ is solvable iff n ≤ 4 — the failure at n = 5 (where A₅ is simple and nonabelian) is precisely why the general quintic has no radical formula. Camille Jordan (1870) systematized composition and derived series of permutation groups. S₃ and S₄ are the two nontrivial solvable symmetric groups, so writing down their derived series explicitly — with each abelian factor named — is the concrete positive half of the Abel–Ruffini classification.",
+    "problemStatement": "**Open Question** (from `abel-ruffini-oq-04-oq-02`, *Alternating Groups: Aₙ Solvable iff n ≤ 4*): exhibit the derived series of S₃ and S₄ explicitly. Going beyond a bare composition series, show the displayed chains are literally the *derived* series — i.e. prove the derived-subgroup identities [Sₙ,Sₙ] = Aₙ — and identify every successive quotient with its standard abelian model.",
+    "proofStrategy": "Most of the work is pure assembly from Mathlib's alternating-group infrastructure: alternatingGroup α = sign.ker is normal of index 2, giving Sₙ/Aₙ ≅ ℤ/2 via mulEquivOfPrimeCardEq; |Aₙ| = n!/2 makes A₃ ≅ ℤ/3; and the A₄ ⊵ V₄ ⊵ {e} tail (with A₄/V₄ ≅ ℤ/3 and V₄ ≅ (ℤ/2)²) is imported from the sibling Klein-four file. The genuinely new ingredient is the reverse inclusion Aₙ ≤ [Sₙ,Sₙ]: Mathlib only proves commutator (Perm α) = alternatingGroup α under 5 ≤ card α (via perfectness), but the reverse inclusion needs no such hypothesis. Since three-cycles generate Aₙ, are all conjugate, and [Sₙ,Sₙ] is normal, a single explicit commutator three-cycle ⁅(0 1),(0 2)⁆ = (0 2)(0 1) — verified by kernel decide — spreads over its whole conjugacy class to cover all of Aₙ. Combined with the hypothesis-free [Sₙ,Sₙ] ≤ Aₙ this yields [S₃,S₃] = A₃ and [S₄,S₄] = A₄ unconditionally.",
+    "keyInsights": [
+      "**The reverse inclusion dodges the 5 ≤ n barrier**: Mathlib packages [Sₙ,Sₙ] = Aₙ only for 5 ≤ n because it routes through perfectness of Aₙ (which fails for A₃, A₄). But Aₙ ≤ [Sₙ,Sₙ] alone needs no perfectness — it follows from three-cycles generating Aₙ — so the small cases are recovered cleanly.",
+      "**One commutator three-cycle suffices**: Because all three-cycles share a cycle type they are a single Sₙ-conjugacy class, and the commutator subgroup is normal. So exhibiting ⁅(0 1),(0 2)⁆ as one three-cycle, then closing under conjugation, covers the entire generating set of Aₙ at once.",
+      "**Derived series, not just composition series**: Identifying [Sₙ,Sₙ] = Aₙ (rather than merely Aₙ ◁ Sₙ with abelian quotient) is what makes the displayed chains the canonical *derived* series, the object Galois's solvability criterion actually quantifies over.",
+      "**Prime-order quotients are forced to be cyclic**: Each factor of order p (S₃/A₃, A₃, S₄/A₄, A₄/V₄) is identified with ℤ/p purely from its cardinality via mulEquivOfPrimeCardEq — no explicit generator needed, since a group of prime order is cyclic.",
+      "**Kernel decide keeps the proof axiom-free**: The three-cycle witnesses use ordinary decide (depending only on propext/Classical.choice/Quot.sound), not native_decide (which would pull in Lean.ofReduceBool). The whole development is genuinely 0-axiom, including the imported A₄ layer.",
+      "**S₃ and S₄ exhaust the nontrivial solvable Sₙ**: Together with S₁, S₂ (abelian) these are every solvable symmetric group; the chain abruptly fails at S₅ where A₅ is simple — the exact boundary of radical solvability."
+    ]
+  },
   "sections": [
     {
       "id": "header",
@@ -74,7 +86,15 @@
       "summary": "Top factor S₄/A₄ ≅ ℤ/2; the A₄/V₄ ≅ ℤ/3 and V₄ ≅ (ℤ/2)² layers imported from the companion file. Packaged into derived_series_S4 with commutator data derived_layers_S4 ([S₄,S₄] ≤ A₄ and [A₄,A₄] = V₄)."
     }
   ],
-  "conclusion": "The open question — exhibit the derived series of S₃ and S₄ explicitly, not just by decide — is answered constructively. The towers, every factor isomorphism, and the derived-subgroup identities [S₃,S₃] = A₃ and [S₄,S₄] = A₄ are all machine-checked and axiom-free.",
+  "conclusion": {
+    "summary": "The open question — exhibit the derived series of S₃ and S₄ explicitly, not just as composition series — is answered constructively. The towers S₃ ⊵ A₃ ⊵ {e} and S₄ ⊵ A₄ ⊵ V₄ ⊵ {e}, every factor isomorphism (S₃/A₃ ≅ ℤ/2, A₃ ≅ ℤ/3, S₄/A₄ ≅ ℤ/2, A₄/V₄ ≅ ℤ/3, V₄ ≅ (ℤ/2)²), and the derived-subgroup identities [S₃,S₃] = A₃ and [S₄,S₄] = A₄ are all machine-checked and axiom-free (0 sorries, 0 axioms, ordinary kernel decide).",
+    "implications": "This is the constructive, positive half of Abel–Ruffini: it makes fully explicit why the quartic and cubic *are* solvable by radicals — their Galois groups have abelian-factored derived series of prime-power layers. The reusable lemma alternatingGroup_le_commutator_perm (Aₙ ≤ [Sₙ,Sₙ] from a single commutator three-cycle) gives the derived-subgroup equality without Mathlib's 5 ≤ n hypothesis, a small gap-filler over the library's perfectness-based packaging.",
+    "openQuestions": [
+      "Generalize alternatingGroup_le_commutator_perm to a single statement [Sₙ,Sₙ] = Aₙ for all n ≥ 3 (the reverse inclusion is uniform; only Mathlib's forward packaging carries the 5 ≤ n hypothesis), unifying the small cases with the perfectness route.",
+      "Package the derived series as a formal Mathlib `CompositionSeries` / `derivedSeries` term and prove it equals `derivedSeries (Perm (Fin n))` definitionally, rather than recording the layers as a conjunction.",
+      "Connect the explicit factor data to a radical-tower extraction: turn the abelian quotients into an actual chain of radical field extensions resolving a degree-3 or degree-4 polynomial."
+    ]
+  },
   "leanFile": {
     "imports": [
       "Mathlib",


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-01` (quality 10, pass 0).

## Changes
- **Restructured `overview`** from a plain string to the typed `ProofOverview` object (the schema in `src/types/proof.ts`): `historicalContext` (Galois/Jordan, the Abel–Ruffini connection), `problemStatement`, `proofStrategy`, and **6 `keyInsights`** (the reverse-inclusion-dodges-5≤n trick, one-commutator-three-cycle argument, derived-vs-composition distinction, prime-order⇒cyclic, kernel-decide-keeps-it-axiom-free, S₃/S₄ as the boundary of radical solvability). Existing prose preserved and redistributed.
- **Restructured `conclusion`** from a string to the typed `ProofConclusion` object: `summary`, `implications`, and **3 `openQuestions`** (uniform [Sₙ,Sₙ]=Aₙ for n≥3, packaging as a formal `derivedSeries` term, radical-tower extraction).
- **New `annotations.json`** (was missing): 6 annotations spanning the file — overview, the `decide` witness three-cycles, the reverse-inclusion heart (Aₙ ≤ [Sₙ,Sₙ]), the [Sₙ,Sₙ]=Aₙ equalities, cardinality helpers, and the packaged series — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
- JSON valid (meta + annotations parse).
- `check-meta-size.ts`: within all caps (file 12.6 KB ≤ 60 KB).
- `pnpm annotations:build`: **0 errors for this entry** (line ranges land on real Lean constructs; types match).
- Axiom integrity unchanged: entry remains `verified` / `axiomCount: 0`, consistent with the Lean file (0 sorries, 0 axiom decls, ordinary kernel `decide` — no `native_decide`/`Lean.ofReduceBool`).