### PR TITLE
research(erdos-83): eliminate ekr_achieved axiom — prove EKR star-family count [7→6 axioms]

### DIFF
--- a/proofs/Proofs/Erdos83Problem.lean
+++ b/proofs/Proofs/Erdos83Problem.lean
@@ -92,9 +92,44 @@ def ekrStarFamily (n k : ℕ) (x : Fin n) : Finset (Finset (Fin n)) :=
 /--
 **EKR is Achieved:**
 The star family achieves the EKR bound.
--/
-axiom ekr_achieved (n k : ℕ) (hn : n ≥ 2 * k) (hk : k ≥ 1) (x : Fin n) :
-  (ekrStarFamily n k x).card = Nat.choose (n - 1) (k - 1)
+
+This is the pure counting identity that the number of `k`-subsets of `[n]` containing a
+fixed element `x` equals `C(n-1, k-1)`: the bijection `T ↦ insert x T` matches them with
+the `(k-1)`-subsets of the remaining `n-1` points `univ.erase x`.  Previously an axiom;
+now proved from Mathlib (`card_powersetCard`, `card_erase_of_mem`). -/
+theorem ekr_achieved (n k : ℕ) (_hn : n ≥ 2 * k) (hk : k ≥ 1) (x : Fin n) :
+    (ekrStarFamily n k x).card = Nat.choose (n - 1) (k - 1) := by
+  have hxu : x ∈ (Finset.univ : Finset (Fin n)) := Finset.mem_univ x
+  -- The star family is exactly the image of the `(k-1)`-subsets of `univ.erase x`
+  -- under `insert x`.
+  have hset : ekrStarFamily n k x
+      = ((Finset.univ.erase x).powersetCard (k - 1)).image (insert x) := by
+    ext S
+    simp only [ekrStarFamily, Finset.mem_filter, Finset.mem_powerset, Finset.mem_image,
+      Finset.mem_powersetCard]
+    constructor
+    · rintro ⟨_hsub, hcard, hxS⟩
+      refine ⟨S.erase x, ⟨?_, ?_⟩, ?_⟩
+      · exact fun y hy =>
+          Finset.mem_erase.mpr ⟨(Finset.mem_erase.mp hy).1, Finset.mem_univ y⟩
+      · rw [Finset.card_erase_of_mem hxS, hcard]
+      · exact Finset.insert_erase hxS
+    · rintro ⟨T, ⟨hTsub, hTcard⟩, rfl⟩
+      have hxT : x ∉ T := fun h => (Finset.mem_erase.mp (hTsub h)).1 rfl
+      refine ⟨Finset.subset_univ _, ?_, Finset.mem_insert_self x T⟩
+      rw [Finset.card_insert_of_notMem hxT, hTcard]; exact Nat.sub_add_cancel hk
+  rw [hset]
+  have hinj : Set.InjOn (insert x)
+      (↑((Finset.univ.erase x).powersetCard (k - 1)) : Set (Finset (Fin n))) := by
+    intro T₁ hT₁ T₂ hT₂ hEq
+    have hx₁ : x ∉ T₁ := fun h =>
+      (Finset.mem_erase.mp ((Finset.mem_powersetCard.mp (Finset.mem_coe.mp hT₁)).1 h)).1 rfl
+    have hx₂ : x ∉ T₂ := fun h =>
+      (Finset.mem_erase.mp ((Finset.mem_powersetCard.mp (Finset.mem_coe.mp hT₂)).1 h)).1 rfl
+    have hkey := congrArg (fun s => Finset.erase s x) hEq
+    simpa only [Finset.erase_insert hx₁, Finset.erase_insert hx₂] using hkey
+  rw [Finset.card_image_of_injOn hinj, Finset.card_powersetCard,
+    Finset.card_erase_of_mem hxu, Finset.card_univ, Fintype.card_fin]
 
 /-
 ## Part III: The t-Intersecting Problem

--- a/research/problems/erdos-83/knowledge.md
+++ b/research/problems/erdos-83/knowledge.md
@@ -1,0 +1,34 @@
+# erdos-83 — knowledge
+
+Erdős Problem #83: Complete Intersection Theorem (Ahlswede–Khachatrian 1997, $500 prize,
+SOLVED). `Proofs/Erdos83Problem.lean`. Gallery status: axiomatized.
+
+## Session 2026-06-27 (researcher-1) — AXIOM HUNT
+
+Eliminated 1 axiom (7 → 6): converted `ekr_achieved` from `axiom` to a **proved theorem**.
+It is the pure counting identity
+  |{ k-subsets of [n] containing a fixed x }| = C(n-1, k-1),
+proved via the bijection `T ↦ insert x T` between such subsets and the (k-1)-subsets of
+`univ.erase x` (n-1 points): set equality by `Finset.ext`, then
+`card_image_of_injOn` + `card_powersetCard` + `card_erase_of_mem` + `card_univ`/`card_fin`.
+The `n ≥ 2k` hypothesis is irrelevant to the count (renamed `_hn`).
+
+Verified EXIT 0 via `lake env lean` (Docker infra down). File now 343L/6thm/6ax/3sorry.
+
+## Remaining axioms (all genuinely deep — NOT routine Mathlib targets)
+- `erdos_ko_rado_bound`: the EKR theorem itself (max 1-intersecting k-family ≤ C(n-1,k-1)).
+  Mathlib has NO Erdős–Ko–Rado theorem (verified: only KruskalKatona in SetFamily). Deep.
+- `ahlswede_khachatrian_theorem`: the full Complete Intersection Theorem (pushing-pulling).
+  Very deep, not in Mathlib.
+- `starLikeFamily_achieves`, `starLikeFamily_valid`, `erdos83_from_ak`,
+  `erdos83_bound_asymptotic`: derivations/constructions on top of the deep results.
+
+## Remaining sorries (3) — all DEFINITION/construction sorries, NOT Aristotle-eligible
+- `starLikeFamily` (needs embedding Fin (2n) ↪ Fin (4n)), `criticalRatio`, `akFamily`
+  (general AK extremal family construction). These are `def ... := sorry` — must be
+  completed before any downstream theorem sorry is submittable.
+
+## Next-session ideas
+- Possibly prove `starLikeFamily_valid`/`achieves` IF `starLikeFamily` def is completed
+  first (real combinatorial work, the majority-family pigeonhole |A∩B| ≥ 2).
+- The EKR bound axiom would need a full EKR formalization (~Mathlib-PR-sized) — out of scope.

--- a/src/data/proofs/erdos-83/annotations.json
+++ b/src/data/proofs/erdos-83/annotations.json
@@ -169,7 +169,7 @@
     },
     "type": "definition",
     "title": "EKR Star Family and Tightness",
-    "content": "`ekrStarFamily n k x` constructs all $k$-subsets of $[n]$ containing a fixed element $x$. This 'star' or 'dictator' family is the unique (up to isomorphism) extremal family for the EKR theorem when $n > 2k$. The axiom `ekr_achieved` confirms it achieves $\\binom{n-1}{k-1}$. When $n = 2k$, there are additional extremal families (complementary pairs), but the star is always optimal.",
+    "content": "`ekrStarFamily n k x` constructs all $k$-subsets of $[n]$ containing a fixed element $x$. This 'star' or 'dictator' family is the unique (up to isomorphism) extremal family for the EKR theorem when $n > 2k$. The **theorem** `ekr_achieved` (proved from Mathlib, formerly an axiom) confirms it achieves $\\binom{n-1}{k-1}$, via the `insert x` bijection with the $(k-1)$-subsets of the remaining $n-1$ points. When $n = 2k$, there are additional extremal families (complementary pairs), but the star is always optimal.",
     "mathContext": "$\\mathcal{S}_x = \\{A \\in \\binom{[n]}{k} : x \\in A\\}$, $|\\mathcal{S}_x| = \\binom{n-1}{k-1}$",
     "significance": "supporting",
     "relatedConcepts": [

--- a/src/data/proofs/erdos-83/meta.json
+++ b/src/data/proofs/erdos-83/meta.json
@@ -71,10 +71,10 @@
       "erdos_83_summary: both directions (bound + tightness)",
       "erdos_83: final theorem statement"
     ],
-    "axiomCount": 7,
-    "lineCount": 308,
-    "assumptions": "7 axioms: erdos_ko_rado_bound, ekr_achieved, starLikeFamily_achieves, starLikeFamily_valid, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 3 sorry(s).",
-    "theoremCount": 5,
+    "axiomCount": 6,
+    "lineCount": 343,
+    "assumptions": "6 axioms: erdos_ko_rado_bound, starLikeFamily_achieves, starLikeFamily_valid, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 3 sorry(s). (ekr_achieved was previously an axiom; it is now a proved theorem — the counting identity that the star family of k-subsets containing a fixed element has size C(n-1,k-1), via the insert-x bijection with (k-1)-subsets of the remaining n-1 points.)",
+    "theoremCount": 6,
     "definitionCount": 12,
     "additionalFiles": [
       "Proofs/Stubs/Erdos83Aristotle.lean"
@@ -204,9 +204,9 @@
       "Nat"
     ],
     "namespace": "Erdos83",
-    "lineCount": 308,
-    "axiomCount": 7,
-    "theoremCount": 5,
+    "lineCount": 343,
+    "axiomCount": 6,
+    "theoremCount": 6,
     "definitionCount": 12,
     "path": "Proofs/Erdos83Problem.lean",
     "sorries": 3,


### PR DESCRIPTION
## Summary

Axiom-elimination pass on **Erdős Problem #83** (Complete Intersection Theorem, Ahlswede–Khachatrian). Converts `ekr_achieved` from an `axiom` to a **proved theorem**, dropping the file's axiom count **7 → 6**.

`ekr_achieved` is not a deep result — it is the pure counting identity that the number of `k`-subsets of `[n]` containing a fixed element `x` equals `C(n-1, k-1)`. The proof:

- establishes the set equality `ekrStarFamily n k x = ((univ.erase x).powersetCard (k-1)).image (insert x)` by `Finset.ext` (forward `S ↦ S.erase x`, backward `T ↦ insert x T`);
- counts the image via `Finset.card_image_of_injOn` (injectivity of `insert x` off `x`), then `card_powersetCard`, `card_erase_of_mem`, `card_univ`, `Fintype.card_fin`.

The `n ≥ 2k` hypothesis is irrelevant to the count and is renamed `_hn`.

## What remains (honest scoping)

The other **6 axioms** are genuinely deep and **not** routine Mathlib targets:
- `erdos_ko_rado_bound` — the EKR theorem itself (Mathlib has **no** Erdős–Ko–Rado theorem; only Kruskal–Katona is present in `SetFamily`);
- `ahlswede_khachatrian_theorem` — the full Complete Intersection Theorem (pushing-pulling);
- `starLikeFamily_achieves`, `starLikeFamily_valid`, `erdos83_from_ak`, `erdos83_bound_asymptotic` — derivations on top of the deep results.

The **3 sorries** are pre-existing `def`-level construction sorries (`starLikeFamily`, `criticalRatio`, `akFamily`), unchanged here.

## Verification

- **0 new axioms; 6 axioms, 3 (pre-existing) sorries** — status remains `axiomatized`.
- 343 lines, 6 theorems.
- Checked clean via `lake env lean Proofs/Erdos83Problem.lean` (EXIT 0) — Docker build wrapper was hitting a containerd I/O error this session, so verification used the direct local Lean/Mathlib oleans (toolchain v4.26.0).
- `meta.json` (`.meta` + `.leanFile`) axiom/line/theorem counts synced; annotation updated to reflect the theorem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)