### PR TITLE
research(abel-ruffini-galois-extensions-oq-02-oq-01): FTGT part (ii) — normal subgroups ↔ Galois subextensions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean
@@ -1,0 +1,129 @@
+/-
+  The normal refinement of the Galois correspondence, completed
+  (Open Question OQ-02-OQ-01 of abel-ruffini-galois-extensions, a follow-up to
+   OQ-02 "Prove the Galois Correspondence Theorem (Subfields ↔ Subgroups)").
+
+  ## What this file establishes (0 sorry, 0 axiom)
+
+  `AbelRuffiniGaloisExtensionsOQ02` packaged the Fundamental Theorem of Galois Theory and,
+  in its Part VI, *one half* of the normal refinement: a **normal** subgroup `H` corresponds
+  to a **Galois** subextension `fixedField H`, with `Gal(fixedField H / F) ≃* Gal(E/F) ⧸ H`.
+
+  This file completes that refinement into the full **second part of the FTGT**: the Galois
+  correspondence restricts to a bijection between the *normal* subgroups of `Gal(E/F)` and the
+  intermediate fields that are themselves *Galois* (equivalently *normal*) over the base.
+
+  Mathlib supplies the two implications as type-class instances
+  (`IsGalois.fixingSubgroup_normal_of_isGalois`: a Galois subextension has a normal fixing
+  subgroup, and `IsGalois.of_fixedField_normal_subgroup`: a normal subgroup has a Galois fixed
+  field), but it does **not** state the biconditional, nor the restricted bijection. Assembling
+  them is the new content here:
+
+    * `isGalois_iff_fixingSubgroup_normal` — the **biconditional**: an intermediate field `K` is
+      Galois over `F` **iff** its fixing subgroup `K.fixingSubgroup` is normal in `Gal(E/F)`.
+      The `←` direction is not a Mathlib instance; it goes through the round trip
+      `fixedField K.fixingSubgroup = K`.
+    * `normal_iff_fixingSubgroup_normal` — the same statement phrased with `Normal F K`
+      (separability of `K/F` is automatic, since `E/F` is separable).
+    * `normalCorrespondence` — the **restricted bijection**
+      `{K // IsGalois F K} ≃ {H : Subgroup (E ≃ₐ[F] E) // H.Normal}`, i.e. the Galois
+      correspondence carries Galois subextensions exactly onto normal subgroups. This is FTGT
+      part (ii) as a single equivalence, which is not a Mathlib declaration.
+    * `card_isGalois_intermediateField_eq_card_normal_subgroup` — the counting corollary: a
+      finite Galois extension has exactly as many Galois subextensions as its Galois group has
+      normal subgroups.
+
+  ## Concrete instantiation (links to OQ-01 / OQ-02)
+
+  Applied to the Abel–Ruffini witness `q = X⁵ − 4X + 2` (OQ-01), whose splitting field is a
+  finite Galois extension of `ℚ` with Galois group `S₅`: the Galois subextensions of the
+  splitting field are in bijection with the normal subgroups of `S₅`
+  (`quintic_card_isGalois_intermediateField_eq_card_normal_subgroup`).
+
+  ## Provenance
+
+  The two implications are Mathlib's `Mathlib/FieldTheory/Galois/Basic.lean`
+  (`IsGalois.fixingSubgroup_normal_of_isGalois`, `IsGalois.of_fixedField_normal_subgroup`). The
+  biconditional, the `Normal F K` rephrasing, the restricted bijection, the counting corollary,
+  and the quintic instantiation are new.
+
+  ## References
+  - Mathlib, `Mathlib/FieldTheory/Galois/Basic.lean`.
+  - Stacks project, tag 09DW (Fundamental theorem of Galois theory), part (2).
+-/
+
+import Mathlib.FieldTheory.Galois.Basic
+import Proofs.AbelRuffiniGaloisExtensionsOQ02
+
+namespace AbelRuffiniGaloisExtensionsOQ02OQ01
+
+open IntermediateField AbelRuffiniGaloisExtensionsOQ02
+
+variable {F E : Type*} [Field F] [Field E] [Algebra F E] [FiniteDimensional F E] [IsGalois F E]
+
+/-! ## Part I — the biconditional (FTGT part (ii)) -/
+
+/-- **The second part of the Fundamental Theorem of Galois Theory.** An intermediate field `K`
+of a finite Galois extension `E / F` is itself Galois over `F` **iff** its fixing subgroup is a
+normal subgroup of `Gal(E/F)`. The `→` direction is Mathlib's instance
+`IsGalois.fixingSubgroup_normal_of_isGalois`; the `←` direction uses the round trip
+`fixedField K.fixingSubgroup = K` to turn the Galois fixed field of a normal subgroup back into
+a statement about `K`. -/
+theorem isGalois_iff_fixingSubgroup_normal (K : IntermediateField F E) :
+    IsGalois F K ↔ K.fixingSubgroup.Normal := by
+  constructor
+  · intro h
+    haveI := h
+    infer_instance
+  · intro h
+    haveI := h
+    have hg : IsGalois F (fixedField K.fixingSubgroup) := inferInstance
+    rwa [IsGalois.fixedField_fixingSubgroup] at hg
+
+/-- The biconditional phrased with `Normal F K`: an intermediate field is **normal** over the
+base iff its fixing subgroup is normal in the Galois group. Separability of `K / F` is
+automatic, so `Normal F K` and `IsGalois F K` coincide here. -/
+theorem normal_iff_fixingSubgroup_normal (K : IntermediateField F E) :
+    Normal F K ↔ K.fixingSubgroup.Normal := by
+  haveI : Algebra.IsSeparable F K :=
+    Algebra.isSeparable_tower_bot_of_isSeparable F K E
+  rw [← isGalois_iff_fixingSubgroup_normal]
+  exact ⟨fun h => { to_isSeparable := inferInstance, to_normal := h }, fun h => h.to_normal⟩
+
+/-! ## Part II — the restricted bijection -/
+
+/-- **The normal refinement of the Galois correspondence.** The bijection of OQ-02 restricts to
+a bijection between the intermediate fields that are Galois over `F` and the normal subgroups of
+`Gal(E/F)`. Concretely, `K ↦ K.fixingSubgroup` is a bijection
+`{K // IsGalois F K} ≃ {H // H.Normal}`, by `intermediateFieldEquivSubgroup'` together with the
+biconditional `isGalois_iff_fixingSubgroup_normal`. -/
+noncomputable def normalCorrespondence :
+    {K : IntermediateField F E // IsGalois F K} ≃
+      {H : Subgroup (E ≃ₐ[F] E) // H.Normal} :=
+  Equiv.subtypeEquiv intermediateFieldEquivSubgroup'
+    (fun K => isGalois_iff_fixingSubgroup_normal K)
+
+/-- Counting corollary: a finite Galois extension has exactly as many Galois subextensions as its
+Galois group has normal subgroups. -/
+theorem card_isGalois_intermediateField_eq_card_normal_subgroup :
+    Nat.card {K : IntermediateField F E // IsGalois F K}
+      = Nat.card {H : Subgroup (E ≃ₐ[F] E) // H.Normal} :=
+  Nat.card_congr normalCorrespondence
+
+/-! ## Part III — concrete instantiation: the Abel–Ruffini quintic `X⁵ − 4X + 2` -/
+
+section Quintic
+
+open AbelRuffiniGaloisExtensionsOQ01
+
+/-- **The normal Galois correspondence for the Abel–Ruffini witness.** The Galois subextensions
+of the splitting field of `X⁵ − 4X + 2` are in bijection with the normal subgroups of its Galois
+group — which is `S₅` by `AbelRuffiniGaloisExtensionsOQ01.galEquivS5`. -/
+theorem quintic_card_isGalois_intermediateField_eq_card_normal_subgroup :
+    Nat.card {K : IntermediateField ℚ q.SplittingField // IsGalois ℚ K}
+      = Nat.card {H : Subgroup (q.SplittingField ≃ₐ[ℚ] q.SplittingField) // H.Normal} :=
+  card_isGalois_intermediateField_eq_card_normal_subgroup
+
+end Quintic
+
+end AbelRuffiniGaloisExtensionsOQ02OQ01

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/meta.json
@@ -1,0 +1,193 @@
+{
+  "id": "abel-ruffini-galois-extensions-oq-02-oq-01",
+  "title": "The Normal Refinement of the Galois Correspondence — Normal Subgroups ↔ Galois Subextensions",
+  "slug": "abel-ruffini-galois-extensions-oq-02-oq-01",
+  "description": "A follow-up to OQ-02 (the Fundamental Theorem of Galois Theory) that completes the second part of the FTGT: the Galois correspondence restricts to a bijection between the *normal* subgroups of `Gal(E/F)` and the intermediate fields that are themselves *Galois* (equivalently *normal*) over the base. OQ-02's Part VI packaged only one direction (a normal subgroup `H` gives a Galois subextension `fixedField H`); this entry proves the biconditional `IsGalois F K ↔ K.fixingSubgroup.Normal` (the `←` direction goes through the round trip `fixedField K.fixingSubgroup = K` and is not a Mathlib instance), its `Normal F K` rephrasing, the restricted bijection `{K // IsGalois F K} ≃ {H // H.Normal}` (`normalCorrespondence`), and the counting corollary that a finite Galois extension has as many Galois subextensions as its Galois group has normal subgroups. A final section instantiates this on the Abel–Ruffini witness `X⁵ − 4X + 2` from OQ-01: its Galois subextensions biject with the normal subgroups of its Galois group S₅.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://stacks.math.columbia.edu/tag/09DW",
+    "date": "2026-06-27",
+    "status": "verified",
+    "tags": [
+      "galois-theory",
+      "abel-ruffini",
+      "fundamental-theorem-of-galois-theory",
+      "normal-subgroup",
+      "field-theory",
+      "group-theory",
+      "advanced"
+    ],
+    "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 129,
+    "dateAdded": "06/27/26",
+    "buildStatus": "verified — type-checked with `lake env lean Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean` (clean, 0 errors, 0 warnings) against the pinned Mathlib v4.26 oleans; `#print axioms` on all five results lists only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsGalois.fixingSubgroup_normal_of_isGalois",
+        "description": "Instance: if an intermediate field `E` of a finite Galois extension `L/K` is itself Galois over `K`, then `E.fixingSubgroup` is a normal subgroup of `Gal(L/K)`. Supplies the `→` direction of the biconditional.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IsGalois.of_fixedField_normal_subgroup",
+        "description": "Instance: if `H` is a normal subgroup of the Galois group, then `fixedField H` is Galois over the base. Combined with the round trip to supply the `←` direction of the biconditional.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "IsGalois.fixedField_fixingSubgroup",
+        "description": "Round trip `fixedField K.fixingSubgroup = K`; rewrites the Galois-ness of `fixedField K.fixingSubgroup` back to a statement about `K`.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "Algebra.isSeparable_tower_bot_of_isSeparable",
+        "description": "Separability descends to the bottom of a tower; used to show `K/F` is separable (so `IsGalois F K ↔ Normal F K`) since `E/F` is separable.",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      },
+      {
+        "theorem": "Equiv.subtypeEquiv",
+        "description": "Restricts an equivalence `α ≃ β` to subtypes given a predicate biconditional; turns `intermediateFieldEquivSubgroup'` plus the biconditional into the restricted bijection on normals.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Nat.card_congr",
+        "description": "Transports cardinality across an `Equiv`; yields the counting corollaries.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ],
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-galois-extensions-oq-02",
+        "relationship": "**Parent.** OQ-02 packages the full Galois correspondence and, in its Part VI, the one-way normal refinement (`isGalois_fixedField_of_normal`, `normalQuotientEquiv`). This entry imports OQ-02, completes the refinement into the biconditional `IsGalois F K ↔ K.fixingSubgroup.Normal`, and restricts OQ-02's bijection `intermediateFieldEquivSubgroup'` to a bijection between Galois subextensions and normal subgroups."
+      },
+      {
+        "id": "abel-ruffini-galois-extensions-oq-01",
+        "relationship": "**Concrete witness (transitively).** OQ-01 builds `(X⁵ − 4X + 2).Gal ≃* S₅`. Via OQ-02's `IsGalois ℚ (X⁵−4X+2).SplittingField` instance, the final section instantiates the normal correspondence on this quintic: its Galois subextensions biject with the normal subgroups of S₅."
+      }
+    ],
+    "originalContributions": [
+      "isGalois_iff_fixingSubgroup_normal: the biconditional form of FTGT part (ii), `IsGalois F K ↔ K.fixingSubgroup.Normal`. Mathlib provides the two implications only as separate type-class instances; the `←` direction is assembled here via the round trip `fixedField K.fixingSubgroup = K`, and the iff itself is not a Mathlib declaration.",
+      "normal_iff_fixingSubgroup_normal: the same statement phrased with `Normal F K`, using automatic separability of `K/F` (`Algebra.isSeparable_tower_bot_of_isSeparable`) so that `Normal F K` and `IsGalois F K` coincide in the ambient finite Galois extension.",
+      "normalCorrespondence: the restricted bijection `{K // IsGalois F K} ≃ {H : Subgroup (E ≃ₐ[F] E) // H.Normal}` — FTGT part (ii) as a single equivalence — obtained by `Equiv.subtypeEquiv` from OQ-02's `intermediateFieldEquivSubgroup'` and the biconditional.",
+      "card_isGalois_intermediateField_eq_card_normal_subgroup: a finite Galois extension has exactly as many Galois subextensions as its Galois group has normal subgroups.",
+      "quintic_card_isGalois_intermediateField_eq_card_normal_subgroup: the concrete instantiation on OQ-01's Abel–Ruffini witness X⁵ − 4X + 2, whose Galois subextensions biject with the normal subgroups of S₅."
+    ],
+    "assumptions": "None mathematically: the file has 0 `sorry` and 0 `axiom` declarations and uses no `native_decide`. `#print axioms` on all five results reports only the standard foundational axioms `propext`, `Classical.choice`, `Quot.sound`. The content assembles Mathlib's already-machine-checked two implications of the normal refinement into the biconditional and the restricted bijection.",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Fundamental Theorem of Galois Theory has two parts. Part (i) is the order-reversing bijection between intermediate fields and subgroups of the Galois group (packaged in OQ-02). Part (ii) singles out which subextensions are themselves Galois over the base: precisely those whose corresponding subgroup is normal, and then the quotient group is the Galois group of the subextension. This normal refinement is the engine of the solvable-by-radicals criterion — a subnormal series of the Galois group with abelian quotients corresponds, step by step, to a tower of Galois subextensions, each governed by the quotient at that step.",
+    "problemStatement": "Complete the normal part of the Galois correspondence for a finite Galois extension E/F: prove that an intermediate field K is Galois (equivalently normal) over F if and only if its fixing subgroup is normal in Gal(E/F), package this as a bijection between Galois subextensions and normal subgroups, and instantiate it on a concrete Abel–Ruffini witness.",
+    "proofStrategy": "**Biconditional.** `isGalois_iff_fixingSubgroup_normal`: the `→` direction is the Mathlib instance `IsGalois.fixingSubgroup_normal_of_isGalois` (found by `infer_instance` once `IsGalois F K` is in scope); the `←` direction takes `IsGalois F (fixedField K.fixingSubgroup)` from `IsGalois.of_fixedField_normal_subgroup` and rewrites along the round trip `IsGalois.fixedField_fixingSubgroup` to land on `IsGalois F K`.\n\n**Normal rephrasing.** `normal_iff_fixingSubgroup_normal` adds `Algebra.IsSeparable F K` (from `Algebra.isSeparable_tower_bot_of_isSeparable`, since E/F is separable), making `Normal F K` and `IsGalois F K` interchangeable.\n\n**Restricted bijection.** `normalCorrespondence` applies `Equiv.subtypeEquiv` to OQ-02's plain bijection `intermediateFieldEquivSubgroup'` (K ↦ K.fixingSubgroup) with the biconditional as the predicate-matching hypothesis; `card_isGalois_intermediateField_eq_card_normal_subgroup` is `Nat.card_congr` of it.\n\n**Concrete.** The Quintic section reuses OQ-02's `IsGalois ℚ (X⁵−4X+2).SplittingField` instance and specializes the counting corollary.",
+    "keyInsights": [
+      "**Normality is the half of the FTGT that decides which subextensions are Galois.** The bijection of part (i) does not respect Galois-ness automatically; `fixedField H` is Galois over the base *exactly* when `H` is normal. Stating this as a biconditional (not two separate instances) makes the criterion directly usable.",
+      "**The reverse direction needs the round trip, not just an instance.** Mathlib gives `H normal ⟹ fixedField H Galois`. To get `K.fixingSubgroup normal ⟹ K Galois` one must recognize `K` as `fixedField K.fixingSubgroup` — the round-trip identity — and transport Galois-ness back. This is why the iff is genuinely assembled rather than read off.",
+      "**Restricting the correspondence to normals is a clean `subtypeEquiv`.** Once the predicate `IsGalois F K ↔ K.fixingSubgroup.Normal` holds pointwise, the order-forgetting bijection of OQ-02 restricts mechanically to a bijection between Galois subextensions and normal subgroups, and counting follows.",
+      "**The quotient at each normal step is itself a Galois group.** Combined with OQ-02's `normalQuotientEquiv`, the normal correspondence says a normal subextension K is Galois with `Gal(K/F) ≅ Gal(E/F) ⧸ K.fixingSubgroup` — the structural fact that turns a subnormal series into a chain of Galois steps."
+    ],
+    "prerequisites": [
+      "abel-ruffini-galois-extensions-oq-02 (the Galois correspondence and the one-way normal refinement)",
+      "Mathlib.FieldTheory.Galois.Basic (fixingSubgroup_normal_of_isGalois, of_fixedField_normal_subgroup, fixedField_fixingSubgroup)",
+      "The notion of a normal/Galois subextension; fixed fields and fixing subgroups",
+      "Equiv.subtypeEquiv and Nat.card_congr for the bijection and counting"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: statement, provenance, imports",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Module docstring explaining that OQ-02 packaged only one direction of the normal refinement, and that this file completes FTGT part (ii) into a biconditional and a restricted bijection; provenance and imports (Mathlib Galois Basic + OQ-02).",
+      "mathContext": "FTGT part (ii): normal subgroups correspond to Galois subextensions."
+    },
+    {
+      "id": "biconditional",
+      "title": "Part I: the biconditional (FTGT part (ii))",
+      "startLine": 61,
+      "endLine": 92,
+      "summary": "`isGalois_iff_fixingSubgroup_normal` (`IsGalois F K ↔ K.fixingSubgroup.Normal`, the `←` direction via the round trip) and `normal_iff_fixingSubgroup_normal` (the `Normal F K` rephrasing using automatic separability).",
+      "mathContext": "An intermediate field is Galois/normal over the base iff its fixing subgroup is normal in the Galois group."
+    },
+    {
+      "id": "restricted-bijection",
+      "title": "Part II: the restricted bijection and counting",
+      "startLine": 93,
+      "endLine": 111,
+      "summary": "`normalCorrespondence` (`{K // IsGalois F K} ≃ {H // H.Normal}` via `Equiv.subtypeEquiv`) and `card_isGalois_intermediateField_eq_card_normal_subgroup` (equal counts of Galois subextensions and normal subgroups).",
+      "mathContext": "The Galois correspondence restricts to a bijection between Galois subextensions and normal subgroups; the counts agree."
+    },
+    {
+      "id": "quintic",
+      "title": "Part III: the X⁵ − 4X + 2 instantiation",
+      "startLine": 112,
+      "endLine": 129,
+      "summary": "`quintic_card_isGalois_intermediateField_eq_card_normal_subgroup`: the Galois subextensions of the splitting field of X⁵ − 4X + 2 biject with the normal subgroups of its Galois group (S₅ by OQ-01's galEquivS5).",
+      "mathContext": "Concrete instantiation on the Abel–Ruffini witness from OQ-01."
+    }
+  ],
+  "conclusion": {
+    "summary": "A self-contained Lean file completing the second part of the Fundamental Theorem of Galois Theory for a finite Galois extension E/F: the biconditional `IsGalois F K ↔ K.fixingSubgroup.Normal` (and its `Normal F K` form), the restricted bijection `{K // IsGalois F K} ≃ {H // H.Normal}`, the counting corollary, and a concrete instantiation on the Abel–Ruffini quintic X⁵ − 4X + 2 (0 sorries, 0 axioms; type-checked with `lake env lean`, `#print axioms` clean).",
+    "implications": "OQ-02 supplied the order-reversing dictionary but only the one-way normal refinement. By turning that into a biconditional and a bijection on normals, this entry makes explicit which subextensions are themselves Galois — the precise fact that lets a subnormal series of the Galois group be read as a chain of Galois subextensions with quotient Galois groups, the structural backbone of the solvable-by-radicals criterion at the heart of Abel–Ruffini.",
+    "openQuestions": [
+      "Combine `normalCorrespondence` with OQ-02's `normalQuotientEquiv` into a single packaged statement: for a Galois subextension K, an isomorphism `Gal(K/F) ≃* Gal(E/F) ⧸ K.fixingSubgroup` indexed directly by K (rather than by a normal subgroup H).",
+      "Transport `quintic_card_isGalois_intermediateField_eq_card_normal_subgroup` to a concrete count by classifying the normal subgroups of S₅ ({1}, A₅, S₅ — exactly three), giving that the splitting field of X⁵ − 4X + 2 has exactly three subextensions that are Galois over ℚ."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Galois, É.",
+      "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
+      "year": "1846",
+      "note": "Posthumously published (written 1832); the origin of the correspondence between subfields and subgroups, including the role of normality."
+    },
+    {
+      "authors": "The mathlib Community",
+      "title": "Mathlib/FieldTheory/Galois/Basic.lean",
+      "year": "2026",
+      "note": "Contains the two implications of the normal refinement (`fixingSubgroup_normal_of_isGalois`, `of_fixedField_normal_subgroup`) assembled here into the biconditional and the restricted bijection."
+    },
+    {
+      "authors": "Stacks Project",
+      "title": "Fundamental theorem of Galois theory (tag 09DW)",
+      "year": "2026",
+      "note": "Part (2) is the normal-subgroup ↔ Galois-subextension correspondence formalized here."
+    },
+    {
+      "authors": "Dummit, D. S. and Foote, R. M.",
+      "title": "Abstract Algebra (3rd edition)",
+      "year": "2004",
+      "note": "John Wiley & Sons. §14.2, Theorem 14 (the Fundamental Theorem), part (ii): the correspondence between normal subgroups and Galois subextensions."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isGalois_iff_fixingSubgroup_normal",
+      "statement": "IsGalois F K ↔ K.fixingSubgroup.Normal",
+      "description": "FTGT part (ii), biconditional form: an intermediate field K of a finite Galois extension E/F is itself Galois over F iff its fixing subgroup is normal in Gal(E/F). The ← direction uses the round trip fixedField K.fixingSubgroup = K."
+    },
+    {
+      "name": "normal_iff_fixingSubgroup_normal",
+      "statement": "Normal F K ↔ K.fixingSubgroup.Normal",
+      "description": "The biconditional phrased with Normal F K; separability of K/F is automatic since E/F is separable, so Normal F K and IsGalois F K coincide."
+    },
+    {
+      "name": "normalCorrespondence",
+      "statement": "{K : IntermediateField F E // IsGalois F K} ≃ {H : Subgroup (E ≃ₐ[F] E) // H.Normal}",
+      "description": "The Galois correspondence restricted to a bijection between Galois subextensions and normal subgroups — FTGT part (ii) as a single equivalence, via Equiv.subtypeEquiv on OQ-02's intermediateFieldEquivSubgroup'."
+    },
+    {
+      "name": "card_isGalois_intermediateField_eq_card_normal_subgroup",
+      "statement": "Nat.card {K : IntermediateField F E // IsGalois F K} = Nat.card {H : Subgroup (E ≃ₐ[F] E) // H.Normal}",
+      "description": "A finite Galois extension has exactly as many Galois subextensions as its Galois group has normal subgroups."
+    },
+    {
+      "name": "quintic_card_isGalois_intermediateField_eq_card_normal_subgroup",
+      "statement": "Nat.card {K : IntermediateField ℚ (X⁵−4X+2).SplittingField // IsGalois ℚ K} = Nat.card {H : Subgroup ((X⁵−4X+2).SplittingField ≃ₐ[ℚ] (X⁵−4X+2).SplittingField) // H.Normal}",
+      "description": "Concrete instantiation on the Abel–Ruffini witness from OQ-01: the Galois subextensions of the splitting field of X⁵ − 4X + 2 biject with the normal subgroups of its Galois group (which is S₅ by OQ-01's galEquivS5)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **OQ-02** (the Fundamental Theorem of Galois Theory, subfields ↔ subgroups). OQ-02's Part VI packaged only **one** direction of the normal refinement (a normal subgroup `H` gives a Galois subextension `fixedField H`). This entry completes **part (ii) of the FTGT**: the Galois correspondence restricts to a bijection between the *normal* subgroups of `Gal(E/F)` and the intermediate fields that are themselves *Galois* (equivalently *normal*) over the base.

Two new files, no edits to existing ones. Depends on `AbelRuffiniGaloisExtensionsOQ02.lean` (already on `main`).

## New content (`Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean`, 129 lines)

- `isGalois_iff_fixingSubgroup_normal` — the **biconditional** `IsGalois F K ↔ K.fixingSubgroup.Normal`. Mathlib supplies the two implications only as separate instances; the `←` direction is assembled here via the round trip `fixedField K.fixingSubgroup = K`, and the iff itself is not a Mathlib declaration.
- `normal_iff_fixingSubgroup_normal` — the `Normal F K` rephrasing (separability of `K/F` automatic).
- `normalCorrespondence` — the **restricted bijection** `{K // IsGalois F K} ≃ {H : Subgroup (E ≃ₐ[F] E) // H.Normal}`, FTGT part (ii) as a single equivalence (via `Equiv.subtypeEquiv` on OQ-02's `intermediateFieldEquivSubgroup'`).
- `card_isGalois_intermediateField_eq_card_normal_subgroup` — counting corollary.
- `quintic_card_isGalois_intermediateField_eq_card_normal_subgroup` — instantiation on OQ-01's Abel–Ruffini witness `X⁵ − 4X + 2` (Galois group `S₅`).

## Verification

- Type-checked with `lake env lean Proofs/AbelRuffiniGaloisExtensionsOQ02OQ01.lean` (Docker-free, against pinned Mathlib v4.26 oleans) — clean, **0 errors, 0 warnings, 0 sorries**.
- `#print axioms` on all five results lists only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. So `axiomCount: 0`, `status: verified`.

## Honesty note

Focused, genuine packaging: Mathlib provides the two implications as instances, but the **biconditional**, the **restricted bijection on normals**, and the **counting corollary** are not single Mathlib declarations, and the `←` direction requires the round-trip argument. Modest in scope, but real FTGT-part-(ii) content rather than a rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)