### PR TITLE
Enrich Catalan exponential growth rate (erdos-396 OQ chain)

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -6,7 +6,17 @@
     "type": "lemma",
     "title": "Positivity of the Catalan numbers",
     "content": "Every Catalan number is positive. The identity $(n+1)\\cdot\\mathrm{catalan}\\,n = \\binom{2n}{n} > 0$ forces $\\mathrm{catalan}\\,n \\neq 0$, since a zero factor would make the product vanish. Needed throughout to take logarithms.",
-    "mathContext": "$\\mathrm{catalan}\\,n > 0$ for all $n$."
+    "mathContext": "$\\mathrm{catalan}\\,n > 0$ for all $n$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "central binomial coefficient",
+      "positivity"
+    ],
+    "prerequisites": [
+      "the identity (n+1)·catalan n = centralBinom n",
+      "centralBinom_pos"
+    ]
   },
   {
     "id": "ann-e396growthrate-upper",
@@ -15,7 +25,19 @@
     "type": "lemma",
     "title": "Upper bracket: catalan n ≤ 4ⁿ",
     "content": "The central binomial coefficient $\\binom{2n}{n}$ is one term of row $2n$ of Pascal's triangle, whose entries sum to $2^{2n}$, so $\\binom{2n}{n} \\le 2^{2n} = 4^n$ (Mathlib's `Nat.choose_le_two_pow`). Combined with $\\mathrm{catalan}\\,n \\le (n+1)\\cdot\\mathrm{catalan}\\,n = \\binom{2n}{n}$, this gives $\\mathrm{catalan}\\,n \\le 4^n$ for every $n$.",
-    "mathContext": "$\\mathrm{catalan}\\,n \\le \\binom{2n}{n} \\le 2^{2n} = 4^n$."
+    "mathContext": "$\\mathrm{catalan}\\,n \\le \\binom{2n}{n} \\le 2^{2n} = 4^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "binomial row sum",
+      "Pascal's triangle",
+      "exponential upper bound"
+    ],
+    "prerequisites": [
+      "Nat.choose_le_two_pow",
+      "centralBinom_eq_two_mul_choose",
+      "monotonicity of casts to ℝ"
+    ]
   },
   {
     "id": "ann-e396growthrate-lower",
@@ -23,8 +45,20 @@
     "range": { "startLine": 74, "endLine": 89 },
     "type": "lemma",
     "title": "Lower bracket: 4ⁿ ≤ 2n²·catalan n",
-    "content": "Erdős's exponential lower bound on the central binomial coefficient, $4^n < n\\cdot\\binom{2n}{n}$ for $n \\ge 4$ (Mathlib's `Nat.four_pow_lt_mul_centralBinom`), rewrites via $\\binom{2n}{n} = (n+1)\\cdot\\mathrm{catalan}\\,n$ to $4^n < n(n+1)\\cdot\\mathrm{catalan}\\,n$. Since $n(n+1) \\le 2n^2$ for $n \\ge 1$ — the gap $2n^2 - n(n+1) = n(n-1)\\cdot\\mathrm{catalan}\\,n \\ge 0$ closes by `nlinarith` — we obtain $4^n \\le 2n^2\\cdot\\mathrm{catalan}\\,n$.",
-    "mathContext": "$4^n < n(n+1)\\,\\mathrm{catalan}\\,n \\le 2n^2\\,\\mathrm{catalan}\\,n$ for $n \\ge 4$."
+    "content": "Erdős's exponential lower bound on the central binomial coefficient, $4^n < n\\cdot\\binom{2n}{n}$ for $n \\ge 4$ (Mathlib's `Nat.four_pow_lt_mul_centralBinom`), rewrites via $\\binom{2n}{n} = (n+1)\\cdot\\mathrm{catalan}\\,n$ to $4^n < n(n+1)\\cdot\\mathrm{catalan}\\,n$. Since $n(n+1) \\le 2n^2$ for $n \\ge 1$ — the gap $2n^2 - n(n+1) = n(n-1) \\ge 0$ is supplied to `nlinarith` as a nonnegativity hint — we obtain $4^n \\le 2n^2\\cdot\\mathrm{catalan}\\,n$.",
+    "mathContext": "$4^n < n(n+1)\\,\\mathrm{catalan}\\,n \\le 2n^2\\,\\mathrm{catalan}\\,n$ for $n \\ge 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős's central-binomial lower bound",
+      "exponential lower bound",
+      "nlinarith",
+      "polynomial-factor slack"
+    ],
+    "prerequisites": [
+      "Nat.four_pow_lt_mul_centralBinom",
+      "the identity (n+1)·catalan n = centralBinom n",
+      "nonlinear arithmetic over ℝ"
+    ]
   },
   {
     "id": "ann-e396growthrate-main",
@@ -33,7 +67,20 @@
     "type": "theorem",
     "title": "The exponential growth rate is log 4",
     "content": "Taking logarithms of the two brackets and dividing by $n$ traps $(\\log \\mathrm{catalan}\\,n)/n$ between $\\log 4 - (\\log 2)/n - 2(\\log n)/n$ and $\\log 4$. Both flanks tend to $\\log 4$ because $(\\log n)/n \\to 0$ — Mathlib's `Real.isLittleO_log_id_atTop` composed with $n \\mapsto \\uparrow n \\to \\infty$. The squeeze theorem `tendsto_of_tendsto_of_tendsto_of_le_of_le'` then forces $(1/n)\\log(\\mathrm{catalan}\\,n) \\to \\log 4$.",
-    "mathContext": "$\\dfrac{1}{n}\\log(\\mathrm{catalan}\\,n) \\to \\log 4$."
+    "mathContext": "$\\dfrac{1}{n}\\log(\\mathrm{catalan}\\,n) \\to \\log 4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "squeeze theorem",
+      "logarithm of a product",
+      "(log n)/n → 0",
+      "exponential growth rate"
+    ],
+    "prerequisites": [
+      "Real.isLittleO_log_id_atTop",
+      "tendsto_of_tendsto_of_tendsto_of_le_of_le'",
+      "Filter.Tendsto and eventually_ge_atTop",
+      "log monotonicity (Real.log_le_log)"
+    ]
   },
   {
     "id": "ann-e396growthrate-rpow",
@@ -42,6 +89,18 @@
     "type": "theorem",
     "title": "n-th root form: (catalan n)^{1/n} → 4",
     "content": "Composing the logarithmic limit with the continuity of $\\exp$ gives $(\\mathrm{catalan}\\,n)^{1/n} = \\exp\\!\\big((\\log \\mathrm{catalan}\\,n)/n\\big) \\to \\exp(\\log 4) = 4$. This is the Cauchy–Hadamard statement that the Catalan generating function $\\sum \\mathrm{catalan}\\,n\\,x^n$ has radius of convergence exactly $1/4$.",
-    "mathContext": "$(\\mathrm{catalan}\\,n)^{1/n} \\to 4$; radius of convergence $= 1/4$."
+    "mathContext": "$(\\mathrm{catalan}\\,n)^{1/n} \\to 4$; radius of convergence $= 1/4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Hadamard theorem",
+      "radius of convergence",
+      "continuity of exp",
+      "rpow vs exp∘log"
+    ],
+    "prerequisites": [
+      "Real.continuous_exp / Real.exp_log",
+      "Real.rpow_def_of_pos",
+      "composition of limits with a continuous function"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -47,6 +47,36 @@
       "Logarithm monotonicity, the limit (log n)/n → 0, and the squeeze theorem for sequences"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview & Scope",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring: the parent pins the sub-exponential exponent 3/2; this entry pins the leading exponential rate 4 via (1/n)·log(catalan n) → log 4 and (catalan n)^{1/n} → 4, i.e. radius of convergence 1/4. Two elementary central-binomial brackets, no Stirling."
+    },
+    {
+      "id": "positivity-brackets",
+      "title": "Positivity and the Two Brackets",
+      "startLine": 49,
+      "endLine": 89,
+      "summary": "catalan_pos (Catalan numbers are positive), the upper bracket catalan n ≤ 4ⁿ (via (2n choose n) ≤ 2^{2n}), and the lower bracket 4ⁿ ≤ 2n²·catalan n for n ≥ 4 (via Erdős's 4ⁿ < n·centralBinom n and n(n+1) ≤ 2n²)."
+    },
+    {
+      "id": "growth-rate",
+      "title": "The Exponential Growth Rate",
+      "startLine": 91,
+      "endLine": 146,
+      "summary": "catalan_log_div_tendsto_log_four: log of the two brackets, divide by n, squeeze between log 4 − O((log n)/n) and log 4 using (log n)/n → 0 (Real.isLittleO_log_id_atTop) and the sequence squeeze theorem."
+    },
+    {
+      "id": "nth-root",
+      "title": "n-th Root Form and Radius of Convergence",
+      "startLine": 148,
+      "endLine": 160,
+      "summary": "catalan_rpow_tendsto_four: compose the log-limit with continuity of exp to get (catalan n)^{1/n} → 4, the Cauchy–Hadamard radius of convergence 1/4 for ∑ catalan n · xⁿ."
+    }
+  ],
   "conclusion": {
     "summary": "(1/n)·log(catalan n) → log 4, and equivalently (catalan n)^{1/n} → 4: the exponential growth rate of the Catalan numbers is exactly 4. The proof brackets catalan n between 4^n/(2n²) and 4^n using only central-binomial bounds, passes to logarithms, and squeezes with (log n)/n → 0. All five theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The result establishes, by elementary means, the leading exponential order of Catalan growth and hence that the Catalan generating function has radius of convergence exactly 1/4. Together with the parent entry — which pins the polynomial exponent 3/2 — it reconstructs both layers of the Stirling asymptotic catalan n ∼ 4^n/(n^{3/2}√π) except for the constant 1/√π, and does so without any factorial/Stirling input.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-01` (quality 68, pass 0).

This entry already had a strong overview/conclusion (object form, 4 keyInsights, 2 openQuestions) and 5 annotations with mathContext. The gaps were the missing `sections` array and incomplete annotation metadata.

## Changes
- **Add `sections` array** (was empty): 4 sections covering all 160 lines — overview, positivity & the two central-binomial brackets, the squeeze giving (1/n)·log(catalan n) → log 4, and the n-th-root / radius-of-convergence form.
- **Enrich all 5 annotations** with `significance`, `relatedConcepts`, and `prerequisites` (they previously carried only `content` + `mathContext`). Existing `type`/`content`/`mathContext` preserved verbatim.

## Validation
- JSON valid (meta + annotations parse).
- `check-meta-size.ts`: within all caps (file 10 KB ≤ 60 KB).
- `pnpm annotations:build`: exit 0, **0 errors for this entry**.
- No change to status/badge/axiomCount — entry remains `verified` / 0 axioms, consistent with the Lean file.