### PR TITLE
Enrich Catalan/central-binomial Wallis telescoping product (erdos-396 chain)

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -2,73 +2,181 @@
   {
     "id": "ann-e396wallis-ratio",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 53, "endLine": 57 },
+    "range": {
+      "startLine": 53,
+      "endLine": 57
+    },
     "type": "definition",
     "title": "The recurrence ratio s n",
     "content": "The factor by which the central binomial coefficient grows in one step, read off Mathlib's recurrence $(n+1)\\binom{2(n+1)}{n+1} = 2(2n+1)\\binom{2n}{n}$: $s\\,n = \\dfrac{4n+2}{n+1}$. It is strictly positive and tends to $4$ as $n \\to \\infty$.",
-    "mathContext": "$s\\,n = (4n+2)/(n+1) \\to 4$."
+    "mathContext": "$s\\,n = (4n+2)/(n+1) \\to 4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "two-term recurrence",
+      "growth ratio"
+    ],
+    "prerequisites": [
+      "Nat.succ_mul_centralBinom_succ",
+      "rational functions"
+    ]
   },
   {
     "id": "ann-e396wallis-ratiomul",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 61, "endLine": 73 },
-    "type": "lemma",
+    "range": {
+      "startLine": 61,
+      "endLine": 73
+    },
+    "type": "theorem",
     "title": "The recurrence as a ratio",
     "content": "Casting Mathlib's `Nat.succ_mul_centralBinom_succ` to $\\mathbb{R}$ and clearing the denominator $n+1$ gives the normalised reading $\\binom{2(n+1)}{n+1} = s\\,n \\cdot \\binom{2n}{n}$. The cast is closed by `congrArg`, `push_cast`, then `field_simp` and `linear_combination`.",
-    "mathContext": "$\\binom{2(n+1)}{n+1} = s\\,n \\cdot \\binom{2n}{n}$."
+    "mathContext": "$\\binom{2(n+1)}{n+1} = s\\,n \\cdot \\binom{2n}{n}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ℕ-to-ℝ cast",
+      "field_simp",
+      "linear_combination",
+      "recurrence normalisation"
+    ],
+    "prerequisites": [
+      "push_cast / exact_mod_cast",
+      "clearing denominators in ℝ"
+    ]
   },
   {
     "id": "ann-e396wallis-prod",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 76, "endLine": 84 },
+    "range": {
+      "startLine": 76,
+      "endLine": 84
+    },
     "type": "theorem",
     "title": "Telescoping product: C(2n,n) = ∏ s k",
     "content": "Because each step multiplies by one ratio, the recurrence collapses to a finite product: $\\binom{2n}{n} = \\prod_{k<n} s\\,k$. The induction is one line — `Finset.prod_range_succ` peels off the last factor and the ratio lemma supplies it. This is the multiplicative counterpart of the parent's additive log-sum.",
-    "mathContext": "$\\binom{2n}{n} = \\prod_{k<n}\\frac{4k+2}{k+1}$."
+    "mathContext": "$\\binom{2n}{n} = \\prod_{k<n}\\frac{4k+2}{k+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping product",
+      "Finset.prod_range_succ",
+      "induction on n",
+      "multiplicative vs additive view"
+    ],
+    "prerequisites": [
+      "finite products over Finset.range",
+      "the ratio lemma above"
+    ]
   },
   {
     "id": "ann-e396wallis-logbridge",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 88, "endLine": 92 },
-    "type": "lemma",
+    "range": {
+      "startLine": 88,
+      "endLine": 92
+    },
+    "type": "theorem",
     "title": "Log bridge to the additive view",
     "content": "Taking $\\log$ of the telescoping product turns it into the sum $\\log\\binom{2n}{n} = \\sum_{k<n}\\log(s\\,k)$ (via `Real.log_prod`, each factor positive). This is exactly the additive object that the parent file telescopes through $\\log y \\le y - 1$ to reach the $1/2$-exponent bound; the two entries are the same identity read multiplicatively versus additively.",
-    "mathContext": "$\\log\\binom{2n}{n} = \\sum_{k<n}\\log(s\\,k)$."
+    "mathContext": "$\\log\\binom{2n}{n} = \\sum_{k<n}\\log(s\\,k)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Real.log_prod",
+      "log of a product",
+      "additive–multiplicative duality",
+      "parent log-sum bound"
+    ],
+    "prerequisites": [
+      "logarithm of a finite product",
+      "positivity of each factor"
+    ]
   },
   {
     "id": "ann-e396wallis-factor",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 98, "endLine": 116 },
-    "type": "lemma",
+    "range": {
+      "startLine": 98,
+      "endLine": 116
+    },
+    "type": "theorem",
     "title": "The normalised factor is the Wallis term",
     "content": "Normalising one ratio by the limiting rate $4$ gives the classical Wallis factor: $\\dfrac{s\\,k}{4} = \\dfrac{2k+1}{2k+2}$. Each such term lies strictly in $(0,1)$ — positive by inspection, and $<1$ because $2k+1 < 2k+2$. These two facts drive both the monotonicity and the $4^n$ bound below.",
-    "mathContext": "$s\\,k/4 = (2k+1)/(2k+2) \\in (0,1)$."
+    "mathContext": "$s\\,k/4 = (2k+1)/(2k+2) \\in (0,1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wallis factor",
+      "normalisation by the limiting rate",
+      "factors in (0,1)"
+    ],
+    "prerequisites": [
+      "elementary rational inequalities",
+      "the ratio s k"
+    ]
   },
   {
     "id": "ann-e396wallis-wallisprod",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 127, "endLine": 138 },
+    "range": {
+      "startLine": 127,
+      "endLine": 138
+    },
     "type": "theorem",
     "title": "Headline: the Wallis partial product",
     "content": "Writing $4^n = \\prod_{k<n} 4$ and distributing the quotient factor-by-factor (`Finset.prod_div_distrib`) converts the telescoping product into the **Wallis partial product** $\\dfrac{\\binom{2n}{n}}{4^n} = \\prod_{k<n}\\dfrac{2k+1}{2k+2} = \\dfrac{(2n-1)!!}{(2n)!!}$ — the truncation of Wallis' product for $2/\\pi$, exhibited purely from the integer recurrence.",
-    "mathContext": "$\\binom{2n}{n}/4^n = \\prod_{k<n}\\frac{2k+1}{2k+2} = (2n-1)!!/(2n)!!$."
+    "mathContext": "$\\binom{2n}{n}/4^n = \\prod_{k<n}\\frac{2k+1}{2k+2} = (2n-1)!!/(2n)!!$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wallis product",
+      "double factorials",
+      "Finset.prod_div_distrib",
+      "2/π"
+    ],
+    "prerequisites": [
+      "distributing a product over a quotient",
+      "the telescoping product"
+    ]
   },
   {
     "id": "ann-e396wallis-anti",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 146, "endLine": 165 },
+    "range": {
+      "startLine": 146,
+      "endLine": 165
+    },
     "type": "theorem",
     "title": "The normalised sequence is strictly decreasing",
     "content": "The multiplicative step from $n$ to $n+1$ is the Wallis factor $s\\,n/4 < 1$ acting on the positive quantity $\\binom{2n}{n}/4^n$, so the value strictly drops: $\\binom{2(n+1)}{n+1}/4^{n+1} < \\binom{2n}{n}/4^n$. `strictAnti_nat_of_succ_lt` upgrades the one-step inequality to strict antitonicity in $n$.",
-    "mathContext": "$\\binom{2n}{n}/4^n$ is strictly decreasing."
+    "mathContext": "$\\binom{2n}{n}/4^n$ is strictly decreasing.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict antitonicity",
+      "strictAnti_nat_of_succ_lt",
+      "monotone sequences"
+    ],
+    "prerequisites": [
+      "one-step-to-global monotonicity",
+      "the Wallis factor lies in (0,1)"
+    ]
   },
   {
     "id": "ann-e396wallis-bound",
     "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01",
-    "range": { "startLine": 168, "endLine": 184 },
+    "range": {
+      "startLine": 168,
+      "endLine": 184
+    },
     "type": "theorem",
     "title": "C(2n,n) < 4ⁿ from the product alone",
     "content": "The normalised sequence equals $1$ at $n=0$ and strictly decreases, so $\\binom{2n}{n}/4^n < 1$ for every $n \\ge 1$, i.e. $\\binom{2n}{n} < 4^n$. The natural-number form follows by casting. Notably this elementary bound is obtained from the Wallis product with **no** appeal to the row-sum estimate $\\binom{2n}{n} \\le 2^{2n}$.",
-    "mathContext": "$\\binom{2n}{n} < 4^n$ for $n \\ge 1$."
+    "mathContext": "$\\binom{2n}{n} < 4^n$ for $n \\ge 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "exponential upper bound",
+      "strict decrease from 1",
+      "independence from the row-sum bound"
+    ],
+    "prerequisites": [
+      "the strictly-decreasing normalised sequence",
+      "ℝ-to-ℕ casting of a strict inequality"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -47,6 +47,43 @@
       "Strict monotonicity of natural-indexed sequences (strictAnti_nat_of_succ_lt) and the logarithm of a finite product (Real.log_prod)"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview & Scope",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring: the multiplicative twin of the parent's additive 1/2-exponent route. Keeping the product (not its log), the central-binomial recurrence collapses to a telescoping product whose normalisation is the Wallis partial product C(2n,n)/4^n = (2n−1)!!/(2n)!!, recovering C(2n,n) < 4^n with no row-sum estimate and no Stirling."
+    },
+    {
+      "id": "ratio-telescope",
+      "title": "The Recurrence Ratio and Telescoping Product",
+      "startLine": 48,
+      "endLine": 92,
+      "summary": "The ratio s n = (4n+2)/(n+1) read off Mathlib's recurrence; the normalised one-step lemma C(2(n+1),n+1) = s n · C(2n,n); the telescoping product C(2n,n) = ∏_{k<n} s k; and the log bridge log C(2n,n) = ∑_{k<n} log(s k) back to the parent's additive view."
+    },
+    {
+      "id": "wallis-product",
+      "title": "The Wallis Partial Product",
+      "startLine": 96,
+      "endLine": 138,
+      "summary": "The normalised factor s k/4 = (2k+1)/(2k+2) ∈ (0,1), and the headline identity C(2n,n)/4^n = ∏_{k<n} (2k+1)/(2k+2) = (2n−1)!!/(2n)!!, the truncation of Wallis' product for 2/π, distributed factor-by-factor from the telescoping product."
+    },
+    {
+      "id": "monotone-bound",
+      "title": "Strict Decrease and the 4ⁿ Bound",
+      "startLine": 140,
+      "endLine": 184,
+      "summary": "The normalised sequence C(2n,n)/4^n is strictly decreasing (each step multiplies by the Wallis factor < 1), so starting from 1 it stays below 1 for n ≥ 1, giving C(2n,n) < 4^n purely from the product — no appeal to (2n choose n) ≤ 2^{2n}."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Sanity Checks",
+      "startLine": 186,
+      "endLine": 206,
+      "summary": "Worked small cases: the empty product equals C(0,0)=1, the k=0 Wallis factor is 1/2, C(2,1)/4 = 1/2, the first strict drop, and C(4,2)=6 < 16."
+    }
+  ],
   "conclusion": {
     "summary": "The central-binomial recurrence collapses to the telescoping product C(2n,n) = ∏_{k<n} (4k+2)/(k+1), whose normalisation by 4^n is the Wallis partial product C(2n,n)/4^n = ∏_{k<n} (2k+1)/(2k+2) = (2n−1)!!/(2n)!!. Each Wallis factor lies strictly in (0,1), so the normalised sequence is strictly decreasing and, starting at 1, stays below 1 — recovering C(2n,n) < 4^n for n ≥ 1 from the product alone. All 13 theorems are fully machine-checked with no axioms or sorries.",
     "implications": "Together with the parent's additive 1/2-exponent bound, this gives the two classical readings of the same recurrence: the logarithm telescopes to a harmonic sum (additive, exponent 1/2), while the product telescopes to the Wallis partial product (multiplicative, closed form). The Wallis form is the natural bridge to the analytic identity ∏_{k≥1} (2k)(2k)/((2k−1)(2k+1)) = π/2, and the strict-monotonicity / 4^n bound are obtained without any factorial asymptotics.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01` (quality 68, pass 0).

This entry had a strong overview/conclusion (object form, 4 keyInsights, 2 openQuestions) and 8 annotations with content+mathContext. Gaps: no `sections`, no annotation metadata, and 3 stale type mismatches.

## Changes
- **Add `sections` array** (was missing): 5 sections over all 206 lines — overview, the recurrence ratio & telescoping product, the Wallis partial product, strict decrease & the 4ⁿ bound, and the sanity checks.
- **Enrich all 8 annotations** with `significance`, `relatedConcepts`, `prerequisites` (previously only `content` + `mathContext`).
- **Fix 3 annotation `type` mismatches** flagged by `annotations:build`: `ratiomul`/`logbridge`/`factor` were typed `lemma` but the Lean declarations use the `theorem` keyword (verified by inspection). Now `theorem`.

## Validation
- JSON valid; `check-meta-size.ts` within caps (11.3 KB ≤ 60 KB).
- `pnpm annotations:build`: exit 0, **0 errors for this entry** (was 3 before the type fix).
- No change to status/badge/axiomCount — remains `verified` / 0 axioms.