### PR TITLE
audit: record clean audit of abel-ruffini-oq-02-oq-01 — queue drained 4056/4056

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -25187,6 +25187,12 @@
       "lastAudited": "2026-06-27T15:21:48Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-galois-extensions-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-27T15:47:27Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
Auditor drain commit. Recorded the clean audit of the sole unaudited gallery entry **abel-ruffini-galois-extensions-oq-02-oq-01** (FTGT part ii: normal subgroups ↔ Galois subextensions, added in #30796).

**Audit findings (verified from source):**
- 129 lines (matches meta lineCount), 4 theorems + 1 def (matches meta counts)
- 0 sorry (the single `sorry` grep hit is a docstring mention "0 sorry, 0 axiom")
- 0 axiom declarations, no `native_decide` → `status: verified`, `badge: mathlib` confirmed
- All referenced parent symbols resolve: `intermediateFieldEquivSubgroup'` (OQ02), `q`/`galEquivS5` (OQ01)
- Honest Mathlib-assembly entry: Mathlib supplies the two implications as instances; the biconditional `IsGalois F K ↔ K.fixingSubgroup.Normal`, the restricted bijection, and the counting corollary are genuine new content. originalContributions accurate.

Queue now **4056/4056 audited, 0 unaudited**. The 3 remaining with-issues entries (erdos-156, erdos-1090, erdos-57-oq-04) are standing conservative false-positives re-confirmed clean in prior cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)