### PR TITLE
Enrich Normal Refinement of the Galois Correspondence

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-02-oq-01/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "ann-galois-normal-overview",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Completing Part (ii) of the Fundamental Theorem",
+    "content": "Part (i) of the Fundamental Theorem of Galois Theory (packaged in the parent OQ-02) is the order-reversing bijection between intermediate fields of E/F and subgroups of Gal(E/F). Part (ii) singles out which of those subextensions are themselves Galois over the base: exactly the ones whose corresponding subgroup is normal. OQ-02 proved only the one-way refinement (a normal subgroup gives a Galois fixed field). This file completes it into a biconditional, a restricted bijection, and a counting corollary, then instantiates it on the Abel–Ruffini quintic X⁵ − 4X + 2. Mathlib has the two implications as separate type-class instances but states neither the iff nor the bijection.",
+    "mathContext": "FTGT part (ii): $K$ is Galois over $F$ $\\iff$ $\\mathrm{Gal}(E/K) = K.\\mathrm{fixingSubgroup}$ is normal in $\\mathrm{Gal}(E/F)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Fundamental Theorem of Galois Theory",
+      "normal subgroup",
+      "Galois subextension",
+      "solvable-by-radicals criterion"
+    ],
+    "prerequisites": [
+      "the Galois correspondence (parent OQ-02)",
+      "normal field extensions",
+      "fixed fields and fixing subgroups"
+    ]
+  },
+  {
+    "id": "ann-galois-normal-biconditional",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 66, "endLine": 81 },
+    "type": "theorem",
+    "title": "The Biconditional: IsGalois F K ↔ K.fixingSubgroup.Normal",
+    "content": "The headline result. The forward direction is Mathlib's instance IsGalois.fixingSubgroup_normal_of_isGalois, discharged by infer_instance once IsGalois F K is in scope. The reverse direction is the genuinely assembled half: from a normal fixing subgroup, IsGalois.of_fixedField_normal_subgroup gives IsGalois F (fixedField K.fixingSubgroup), and the round-trip identity IsGalois.fixedField_fixingSubgroup rewrites fixedField K.fixingSubgroup back to K. Stating this as an iff (not two instances) is what makes the normality criterion directly usable.",
+    "mathContext": "$\\mathrm{IsGalois}\\,F\\,K \\iff K.\\mathrm{fixingSubgroup}.\\mathrm{Normal}$; the $\\Leftarrow$ direction uses $\\mathrm{fixedField}(K.\\mathrm{fixingSubgroup}) = K$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fixingSubgroup_normal_of_isGalois",
+      "of_fixedField_normal_subgroup",
+      "fixedField_fixingSubgroup round trip",
+      "infer_instance"
+    ],
+    "prerequisites": [
+      "fixed field of a subgroup",
+      "type-class instance resolution in Lean",
+      "rewriting along an equality (rwa)"
+    ]
+  },
+  {
+    "id": "ann-galois-normal-rephrasing",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 83, "endLine": 91 },
+    "type": "theorem",
+    "title": "The Normal F K Rephrasing",
+    "content": "Restates the biconditional with Normal F K in place of IsGalois F K. Because the ambient extension E/F is separable, separability of K/F is automatic — supplied by Algebra.isSeparable_tower_bot_of_isSeparable — so Normal F K and IsGalois F K coincide. The proof rewrites by the previous biconditional and bridges Normal ↔ IsGalois by bundling/projecting the separability and normality components.",
+    "mathContext": "$\\mathrm{Normal}\\,F\\,K \\iff K.\\mathrm{fixingSubgroup}.\\mathrm{Normal}$; here $\\mathrm{IsGalois}\\,F\\,K = \\mathrm{Normal}\\,F\\,K \\wedge \\mathrm{Separable}\\,F\\,K$ with separability free.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "separability descends in a tower",
+      "Normal vs IsGalois",
+      "isSeparable_tower_bot_of_isSeparable"
+    ],
+    "prerequisites": [
+      "separable extensions",
+      "IsGalois = Normal + Separable"
+    ]
+  },
+  {
+    "id": "ann-galois-normal-correspondence",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 95, "endLine": 104 },
+    "type": "definition",
+    "title": "The Restricted Bijection (normalCorrespondence)",
+    "content": "FTGT part (ii) as a single equivalence: {K // IsGalois F K} ≃ {H // H.Normal}. It is obtained by Equiv.subtypeEquiv applied to OQ-02's plain correspondence intermediateFieldEquivSubgroup' (K ↦ K.fixingSubgroup), with the biconditional supplying the required pointwise predicate match IsGalois F K ↔ K.fixingSubgroup.Normal. Once the predicate holds at every K, restricting the bijection to the two subtypes is mechanical — this is why the iff was worth isolating.",
+    "mathContext": "$\\{K : \\mathrm{IntermediateField}\\,F\\,E \\mid \\mathrm{IsGalois}\\,F\\,K\\} \\;\\simeq\\; \\{H : \\mathrm{Subgroup}\\,(E \\simeq_{\\mathrm{alg}[F]} E) \\mid H.\\mathrm{Normal}\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Equiv.subtypeEquiv",
+      "intermediateFieldEquivSubgroup'",
+      "restriction of a bijection to subtypes"
+    ],
+    "prerequisites": [
+      "the Galois correspondence bijection (OQ-02)",
+      "subtype equivalences",
+      "the biconditional above"
+    ]
+  },
+  {
+    "id": "ann-galois-normal-counting",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 111 },
+    "type": "theorem",
+    "title": "Counting Corollary",
+    "content": "Transporting cardinality across normalCorrespondence with Nat.card_congr gives that a finite Galois extension has exactly as many Galois subextensions as its Galois group has normal subgroups. A clean numerical shadow of the structural bijection.",
+    "mathContext": "$\\#\\{K \\mid \\mathrm{IsGalois}\\,F\\,K\\} = \\#\\{H \\mid H.\\mathrm{Normal}\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.card_congr",
+      "cardinality transport",
+      "counting subextensions"
+    ],
+    "prerequisites": [
+      "the restricted bijection",
+      "Nat.card of a subtype"
+    ]
+  },
+  {
+    "id": "ann-galois-normal-quintic",
+    "proofId": "abel-ruffini-galois-extensions-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 127 },
+    "type": "theorem",
+    "title": "Instantiation on the Abel–Ruffini Quintic X⁵ − 4X + 2",
+    "content": "Specializes the counting corollary to the OQ-01 witness q = X⁵ − 4X + 2, whose splitting field is a finite Galois extension of ℚ with Galois group S₅ (OQ-01's galEquivS5). The Galois subextensions of the splitting field biject with the normal subgroups of S₅. Since S₅ has exactly three normal subgroups ({1}, A₅, S₅), this pins the number of ℚ-Galois subextensions at three — the concrete payoff of the abstract correspondence and the link back to the Abel–Ruffini unsolvability chain.",
+    "mathContext": "For $q = X^5 - 4X + 2$: $\\#\\{K \\mid \\mathrm{IsGalois}\\,\\mathbb{Q}\\,K\\} = \\#\\{H \\trianglelefteq S_5\\} = 3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Abel–Ruffini quintic",
+      "S₅ normal subgroups ({1}, A₅, S₅)",
+      "galEquivS5",
+      "splitting field"
+    ],
+    "prerequisites": [
+      "OQ-01 (Gal(q) ≃ S₅)",
+      "the IsGalois ℚ splitting-field instance from OQ-02",
+      "normal subgroups of S₅"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-02-oq-01` (quality 41, pass 0).

This entry had a strong meta (object overview/conclusion, 4 sections, 5 mainTheorems, references, mathlibDependencies) but **no `annotations.json`** — that was the sole gap.

## Changes
- **Add `annotations.json`** (was missing): 6 annotations spanning the file — FTGT part (ii) overview, the biconditional `IsGalois F K ↔ K.fixingSubgroup.Normal` (with the round-trip `←` direction), the `Normal F K` rephrasing, the restricted bijection `normalCorrespondence`, the counting corollary, and the X⁵−4X+2 quintic instantiation (Galois subextensions ↔ normal subgroups of S₅). Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, with `type` matching the Lean construct (theorem/definition/context).

## Validation
- JSON valid; `check-meta-size.ts` within caps (17.6 KB ≤ 60 KB).
- `pnpm annotations:build`: **0 errors for this entry** (annotation ranges land on real Lean constructs; types match).
- No change to status/badge/axiomCount — remains `verified` / `mathlib` / 0 axioms. The parent's open PR #30372 does not touch this child file.