### PR TITLE
research(three-place-identity-oq-01): sharp round-trip — Foundation is necessary, not just sufficient [UNVERIFIED]

### DIFF
--- a/proofs/Proofs/ThreePlaceIdentityOQ01.lean
+++ b/proofs/Proofs/ThreePlaceIdentityOQ01.lean
@@ -1,0 +1,164 @@
+import Proofs.ThreePlaceIdentity
+
+/-
+# Three-Place Identity — The Role of Foundation in the Round-Trip
+
+## The Question (OQ-01)
+The base file `ThreePlaceIdentity.lean` proves the Round-Trip Theorem
+(`ThreePlaceIdentity.roundtrip`) *under the assumption* that the membership
+relation satisfies the Foundation (Regularity) axiom `∀ x, ¬ mem x x`. The
+prose there asserts Foundation is "essential" and that "without it, the
+round-trip breaks down" — but this is only *asserted*, never proved.
+
+OQ-01 makes that claim precise:
+
+  1. Is Foundation actually **necessary**, or merely sufficient?
+  2. What *exactly* happens to the round-trip when Foundation fails?
+
+## Answer
+We give a **sharp** characterization. Let `D` denote the derived membership
+obtained by going `mem ─D2→ identity ─D1→ mem'`. Then for every viewpoint `x`
+and element `y`:
+
+      D(mem) y x  ↔  ¬ (mem y x ↔ mem x x)
+
+From this single identity everything follows:
+
+  * **Sufficiency (recovers `roundtrip`)**: if `¬ mem x x` then `D y x ↔ mem y x`.
+  * **Necessity**: the round-trip holds at viewpoint `x` *for all* `y`
+    **iff** Foundation holds at `x` (`¬ mem x x`). So Foundation is exactly
+    the right hypothesis — not stronger than needed.
+  * **Inversion**: if `mem x x` (Foundation fails at `x`), the round-trip does
+    not merely "break"; it **inverts**: `D y x ↔ ¬ mem y x`.
+  * **Self-regularization**: the derived membership `D(mem)` *always* satisfies
+    Foundation, no matter how badly `mem` violates it. Hence `D` is an
+    idempotent "regularization": `D(D(mem)) = D(mem)`.
+
+Everything is pure classical propositional logic — 0 axioms, 0 sorries — and
+reuses the definitions from `ThreePlaceIdentity.lean` unchanged.
+
+## References
+- T. Etter, "Three-place Identity," Boundary Institute, 2006.
+- See `ThreePlaceIdentity.lean` (universality) and `ThreePlaceIdentityOQ02.lean`
+  (stereo equality) for the surrounding development.
+-/
+
+namespace ThreePlaceIdentity.OQ01
+
+open ThreePlaceIdentity
+
+variable {U : Type}
+
+/-- The derived membership relation: start from a raw membership `mem`, build the
+    relative identity via bridge **D2**, then read membership back off via bridge
+    **D1**. This is the composite `D2 ; D1` whose fixed points the Round-Trip
+    Theorem studies. No Foundation hypothesis is imposed on `mem`. -/
+def derivedMem (mem : U → U → Prop) (y x : U) : Prop :=
+  MemFromId (IdFromMem.toRelativeIdentity mem) y x
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: The Sharp Round-Trip Identity
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Sharp Round-Trip Identity.** Unconditionally (no Foundation assumed),
+
+      `derivedMem mem y x  ↔  ¬ (mem y x ↔ mem x x)`.
+
+    Reading: `y` is a derived-member of `x` exactly when `y` and `x` have
+    *different* membership-status in `x`. The whole behaviour of the round-trip
+    is governed by the single bit `mem x x`. -/
+theorem derivedMem_iff (mem : U → U → Prop) (y x : U) :
+    derivedMem mem y x ↔ ¬ (mem y x ↔ mem x x) := by
+  unfold derivedMem MemFromId IdFromMem.toRelativeIdentity IdFromMem
+  tauto
+
+/-- The derived membership relation **always** satisfies Foundation, regardless of
+    whether the input `mem` does. (`derivedMem mem x x` is `¬ Id x x x`, and the
+    relative identity is reflexive, so `Id x x x` always holds.) Thus the
+    composite bridge `D2 ; D1` lands inside the well-founded membership relations:
+    it is a *regularization* operator. -/
+theorem derivedMem_irrefl (mem : U → U → Prop) (x : U) :
+    ¬ derivedMem mem x x :=
+  MemFromId.irrefl (IdFromMem.toRelativeIdentity mem) x
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: Foundation is Sufficient (recovering `roundtrip`)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Sufficiency.** If Foundation holds at the viewpoint `x` (`¬ mem x x`),
+    the round-trip recovers membership exactly: `derivedMem mem y x ↔ mem y x`.
+    This is the pointwise content of `ThreePlaceIdentity.roundtrip`, here proved
+    from the sharp identity without needing a global `WellFoundedMembership`. -/
+theorem derivedMem_of_foundation (mem : U → U → Prop) (y x : U)
+    (hx : ¬ mem x x) : derivedMem mem y x ↔ mem y x := by
+  rw [derivedMem_iff]
+  simp [hx]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: Foundation is Necessary (the converse)
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Necessity / sharpness.** The round-trip holds at viewpoint `x` *for every*
+    `y` **iff** Foundation holds at `x`. So Foundation is not just sufficient —
+    it is exactly the hypothesis the round-trip requires. -/
+theorem roundtrip_iff_foundation (mem : U → U → Prop) (x : U) :
+    (∀ y, derivedMem mem y x ↔ mem y x) ↔ ¬ mem x x := by
+  constructor
+  · -- If the round-trip holds for all y, instantiate at y := x. The derived
+    -- relation is always irreflexive, so `mem x x` must be False.
+    intro h hxx
+    exact (derivedMem_irrefl mem x) ((h x).mpr hxx)
+  · -- Foundation at x ⇒ round-trip at x for all y.
+    intro hx y
+    exact derivedMem_of_foundation mem y x hx
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: Without Foundation, the Round-Trip Inverts
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **Inversion.** When Foundation *fails* at `x` (`mem x x` holds), the round-trip
+    does not merely break — it flips membership to its negation:
+    `derivedMem mem y x ↔ ¬ mem y x`. -/
+theorem derivedMem_of_not_foundation (mem : U → U → Prop) (y x : U)
+    (hx : mem x x) : derivedMem mem y x ↔ ¬ mem y x := by
+  rw [derivedMem_iff]
+  simp [hx]
+
+/-- A concrete, non-vacuous witness that the round-trip genuinely fails without
+    Foundation: take `U = Unit` with the *total* membership relation. Here
+    `mem x x` always holds, and the derived membership is everywhere `False`,
+    so it disagrees with the original `mem` (which is everywhere `True`). -/
+theorem roundtrip_fails_example :
+    ∃ (mem : Unit → Unit → Prop) (y x : Unit),
+      ¬ (derivedMem mem y x ↔ mem y x) := by
+  refine ⟨fun _ _ => True, (), (), ?_⟩
+  rw [derivedMem_of_not_foundation (fun _ _ => True) () () trivial]
+  simp
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART V: Self-Regularization and Idempotence
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Package the derived membership as a `WellFoundedMembership`, using the fact
+    that it is always irreflexive. This makes the regularization explicit. -/
+def derivedWFM (mem : U → U → Prop) : WellFoundedMembership U where
+  mem := derivedMem mem
+  foundation := derivedMem_irrefl mem
+
+/-- **Idempotence.** Because `derivedMem mem` is already well-founded, applying
+    the round-trip a second time changes nothing: the derivation is an idempotent
+    projection onto well-founded membership relations. -/
+theorem derivedMem_idempotent (mem : U → U → Prop) (y x : U) :
+    derivedMem (derivedMem mem) y x ↔ derivedMem mem y x :=
+  roundtrip (derivedWFM mem) y x
+
+-- ═══════════════════════════════════════════════════════════════
+-- Final verification
+-- ═══════════════════════════════════════════════════════════════
+
+#check @derivedMem_iff
+#check @roundtrip_iff_foundation
+#check @derivedMem_of_not_foundation
+#check @derivedMem_idempotent
+
+end ThreePlaceIdentity.OQ01

--- a/research/problems/three-place-identity-oq-01/knowledge.md
+++ b/research/problems/three-place-identity-oq-01/knowledge.md
@@ -1,0 +1,86 @@
+# Knowledge Base: three-place-identity-oq-01
+
+Sharpening the Round-Trip Theorem of `proofs/Proofs/ThreePlaceIdentity.lean`:
+**is the Foundation axiom necessary, and what happens without it?**
+
+---
+
+## Problem Understanding
+
+The base file `ThreePlaceIdentity.lean` formalizes Tom Etter's two definitional
+bridges between membership and three-place relative identity:
+
+- **D1** `MemFromId RI y x := ¬ RI.Id x y x`  ("y is a member of x" = x distinguishes y from itself)
+- **D2** `IdFromMem mem x y z := (mem y x ∧ mem z x) ∨ (¬mem y x ∧ ¬mem z x)`  (same membership-status in x)
+
+The **Round-Trip Theorem** (`roundtrip`) proves that `mem ─D2→ Id ─D1→ mem'`
+recovers the original `mem`, **assuming** a global Foundation/Regularity axiom
+`∀ x, ¬ mem x x` packaged in the `WellFoundedMembership` structure. The prose
+asserts Foundation is "essential" and "without it the round-trip breaks down",
+but this is **only asserted, never proved**. OQ-01 closes that gap.
+
+---
+
+## Result (this session)
+
+New file `proofs/Proofs/ThreePlaceIdentityOQ01.lean` (imports the base file,
+reuses all its definitions unchanged). Core identity, proved with no Foundation
+hypothesis:
+
+> **Sharp Round-Trip Identity.** `derivedMem mem y x ↔ ¬ (mem y x ↔ mem x x)`
+
+where `derivedMem mem := MemFromId (IdFromMem.toRelativeIdentity mem)` is the
+composite D2;D1. The whole behaviour of the round-trip is controlled by the
+single bit `mem x x`. Corollaries:
+
+1. **Sufficiency** (`derivedMem_of_foundation`): `¬ mem x x ⇒ derivedMem y x ↔ mem y x`
+   — pointwise content of the original `roundtrip`, recovered locally.
+2. **Necessity** (`roundtrip_iff_foundation`): `(∀ y, derivedMem y x ↔ mem y x) ↔ ¬ mem x x`.
+   The round-trip holds at viewpoint `x` **iff** Foundation holds at `x`. So
+   Foundation is exactly the needed hypothesis, not stronger than needed.
+3. **Inversion** (`derivedMem_of_not_foundation`): `mem x x ⇒ derivedMem y x ↔ ¬ mem y x`.
+   Without Foundation the round-trip doesn't merely "break" — it *flips* membership
+   to its negation. Concrete witness `roundtrip_fails_example` on `U = Unit` with
+   the total relation.
+4. **Self-regularization / idempotence** (`derivedMem_irrefl`, `derivedMem_idempotent`):
+   `derivedMem mem` *always* satisfies Foundation (it inherits `MemFromId.irrefl`,
+   which holds for every relative identity by reflexivity). Hence D2;D1 is an
+   idempotent projection onto well-founded membership: `D(D(mem)) = D(mem)`.
+
+Counts: 4 theorems + 2 defs in the new namespace `ThreePlaceIdentity.OQ01`,
+plus the sharp identity. **0 sorries, 0 axioms** by construction (pure classical
+propositional logic — `tauto`/`simp` over the two atoms `mem y x`, `mem x x`).
+
+---
+
+## Build / verification status
+
+**UNVERIFIED this session — build host unavailable.** Docker is down, there is no
+real `lake`/`elan` on the host (only a version-mismatched homebrew `lake` 4.31 vs
+the project's pinned 4.26), and no Mathlib oleans are cached, so neither
+`docker-build.sh` nor `lake env lean` could run.
+
+Every tactic step was traced by hand:
+
+- `derivedMem_iff`: after `unfold ... IdFromMem` the goal is the propositional
+  tautology `¬((a∧b)∨(¬a∧¬b)) ↔ ¬(a↔b)` (atoms `a = mem y x`, `b = mem x x`),
+  closed by `tauto`. This mirrors the *already-verified* `roundtrip` proof in the
+  base file, which uses the identical `unfold … IdFromMem; tauto` pattern.
+- `derivedMem_of_foundation` / `_of_not_foundation`: `rw [derivedMem_iff]` then
+  `simp [hx]` using `iff_false`/`iff_true` + `not_not`.
+- `derivedMem_irrefl`: defeq to `MemFromId.irrefl (IdFromMem.toRelativeIdentity mem)`.
+- `derivedMem_idempotent`: defeq to `roundtrip (derivedWFM mem)` — all of
+  `derivedWFM.mem`, `RelativeIdentity.fromMembership`, `derivedMem` unfold
+  definitionally to match.
+
+**Next session with a working build must run** `./proofs/scripts/docker-build.sh
+Proofs.ThreePlaceIdentityOQ01` before any gallery promotion to `verified`.
+
+---
+
+## Pointers
+
+- Base: `proofs/Proofs/ThreePlaceIdentity.lean` (`roundtrip`, `MemFromId.irrefl`,
+  `IdFromMem.toRelativeIdentity`, `RelativeIdentity.fromMembership`, `WellFoundedMembership`).
+- Sibling: `proofs/Proofs/ThreePlaceIdentityOQ02.lean` (stereo equality).
+- Etter, "Three-place Identity," Boundary Institute, 2006.


### PR DESCRIPTION
## Summary

Closes the gap left by `proofs/Proofs/ThreePlaceIdentity.lean`: it proves the **Round-Trip Theorem** (`roundtrip`) only *under* a global Foundation/Regularity axiom (`∀ x, ¬ mem x x`), and the prose merely **asserts** Foundation is "essential" without proving it. This OQ-01 makes that precise.

New file `proofs/Proofs/ThreePlaceIdentityOQ01.lean` imports the base file and reuses its definitions unchanged. Let `derivedMem mem := MemFromId (IdFromMem.toRelativeIdentity mem)` be the composite of Etter's two bridges D2 then D1.

**Sharp Round-Trip Identity** (no Foundation assumed):
```
derivedMem mem y x  ↔  ¬ (mem y x ↔ mem x x)
```
The entire behaviour of the round-trip is governed by the single bit `mem x x`.

### Corollaries
| Theorem | Statement |
|---|---|
| `derivedMem_of_foundation` | **Sufficiency**: `¬ mem x x ⇒ derivedMem y x ↔ mem y x` (recovers `roundtrip` pointwise) |
| `roundtrip_iff_foundation` | **Necessity**: `(∀ y, derivedMem y x ↔ mem y x) ↔ ¬ mem x x` — Foundation is *exactly* the needed hypothesis |
| `derivedMem_of_not_foundation` | **Inversion**: `mem x x ⇒ derivedMem y x ↔ ¬ mem y x` (round-trip flips, doesn't merely break) |
| `roundtrip_fails_example` | Concrete `U = Unit` witness that the round-trip genuinely fails |
| `derivedMem_irrefl` / `derivedMem_idempotent` | **Self-regularization**: `derivedMem` always satisfies Foundation ⇒ D2;D1 is an idempotent projection onto well-founded membership |

**4 theorems + 2 defs + the sharp identity, 0 sorries, 0 axioms** by construction (pure classical propositional logic; `tauto`/`simp` over the two atoms `mem y x`, `mem x x`).

## ⚠️ Build status: UNVERIFIED

Docker is down this session, there is no real `lake`/`elan` on the host (only a version-mismatched homebrew `lake` 4.31 vs the pinned 4.26), and no Mathlib oleans are cached — so neither `docker-build.sh` nor `lake env lean` could run.

Every tactic step was traced by hand (see `research/problems/three-place-identity-oq-01/knowledge.md`). The core `unfold … IdFromMem; tauto` pattern is identical to the **already-verified** `roundtrip` proof in the base file. **A working build must run `./proofs/scripts/docker-build.sh Proofs.ThreePlaceIdentityOQ01` before gallery promotion to `verified`.** No gallery `meta.json` is added in this PR to avoid overclaiming.

## Files
- `proofs/Proofs/ThreePlaceIdentityOQ01.lean` (new)
- `research/problems/three-place-identity-oq-01/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)