### PR TITLE
Enrich Explicit Isomorphisms for Groups of Order p²

### DIFF
--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01-oq-02/annotations.json
@@ -8,7 +8,20 @@
     },
     "type": "technique",
     "title": "The Cyclic Isomorphism via zmodCyclicMulEquiv",
-    "content": "**`cyclicMulEquiv`**: a cyclic group of order `p²` is `G ≃* Multiplicative (ZMod (p²))`.\n\nMathlib's `zmodCyclicMulEquiv` provides, for any cyclic group, the canonical isomorphism\n```\nMultiplicative (ZMod (Nat.card G)) ≃* G.\n```\nThe entire proof is to rewrite `Nat.card G = p²` inside this equivalence and invert it. Note that **primality is not used** — only the cardinality *value* `p²` matters — so the hypothesis is stated as `Nat.card G = p ^ 2` with no `p.Prime`. This is the easy half of the structure theorem; all the work is in the elementary-abelian case."
+    "content": "**`cyclicMulEquiv`**: a cyclic group of order `p²` is `G ≃* Multiplicative (ZMod (p²))`.\n\nMathlib's `zmodCyclicMulEquiv` provides, for any cyclic group, the canonical isomorphism\n```\nMultiplicative (ZMod (Nat.card G)) ≃* G.\n```\nThe entire proof is to rewrite `Nat.card G = p²` inside this equivalence and invert it. Note that **primality is not used** — only the cardinality *value* `p²` matters — so the hypothesis is stated as `Nat.card G = p ^ 2` with no `p.Prime`. This is the easy half of the structure theorem; all the work is in the elementary-abelian case.",
+    "mathContext": "$G$ cyclic of order $p^2 \\Rightarrow G \\simeq^* \\mathrm{Multiplicative}(\\mathbb{Z}/p^2)$, via $\\mathrm{Multiplicative}(\\mathbb{Z}/\\mathrm{Nat.card}\\,G) \\simeq^* G$ with $\\mathrm{Nat.card}\\,G = p^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic group",
+      "zmodCyclicMulEquiv",
+      "ZMod p²",
+      "group isomorphism (≃*)"
+    ],
+    "prerequisites": [
+      "cyclic groups and their canonical generator",
+      "Nat.card",
+      "Mathlib's zmodCyclicMulEquiv"
+    ]
   },
   {
     "id": "ann-zmod-module",
@@ -19,7 +32,21 @@
     },
     "type": "insight",
     "title": "The Non-Cyclic Group is a 𝔽_p-Vector Space",
-    "content": "The non-cyclic case rests on a reinterpretation: the predicate `gᵖ = 1 for all g` (imported as `pow_prime_eq_one_of_not_isCyclic`) says exactly that the additive group `Additive G` is **annihilated by `p`**, hence carries a module structure over the field `ZMod p`.\n\n`AddCommMonoid.zmodModule` builds this module from the `p`-torsion proof; the `calc` discharges `p • x = 0` by translating it through the `Additive`/`Multiplicative` bridge `ofMul_pow : ofMul (a^p) = p • ofMul a` and the imported relation `(toMul x)^p = 1`. Once `Additive G` is a vector space, the classification of the non-cyclic group becomes pure linear algebra."
+    "content": "The non-cyclic case rests on a reinterpretation: the predicate `gᵖ = 1 for all g` (imported as `pow_prime_eq_one_of_not_isCyclic`) says exactly that the additive group `Additive G` is **annihilated by `p`**, hence carries a module structure over the field `ZMod p`.\n\n`AddCommMonoid.zmodModule` builds this module from the `p`-torsion proof; the `calc` discharges `p • x = 0` by translating it through the `Additive`/`Multiplicative` bridge `ofMul_pow : ofMul (a^p) = p • ofMul a` and the imported relation `(toMul x)^p = 1`. Once `Additive G` is a vector space, the classification of the non-cyclic group becomes pure linear algebra.",
+    "mathContext": "$\\forall g,\\ g^p = 1 \\iff \\mathrm{Additive}\\,G$ is $p$-torsion $\\Rightarrow$ it is a $\\mathbb{Z}/p$-module; $\\mathrm{ofMul}(a^p) = p \\cdot \\mathrm{ofMul}(a)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "elementary abelian group",
+      "𝔽_p-vector space",
+      "AddCommMonoid.zmodModule",
+      "Additive/Multiplicative bridge",
+      "p-torsion"
+    ],
+    "prerequisites": [
+      "module over a field",
+      "Additive G / ofMul / toMul",
+      "exponent-p groups"
+    ]
   },
   {
     "id": "ann-instance-threading",
@@ -30,7 +57,21 @@
     },
     "type": "technique",
     "title": "Threading the Module Instance Explicitly",
-    "content": "A formalization subtlety: `AddCommMonoid.zmodModule` is a *reducible non-instance* (it is an `abbrev`, deliberately not registered as a global instance to avoid runaway search). Consequently the local `Module (ZMod p) (Additive G)` it produces cannot be rediscovered by typeclass resolution when downstream lemmas (`Module.Finite`, `Module.Free`, `Module.natCard_eq_pow_finrank`, `Module.finBasisOfFinrankEq`) demand it — search gets *stuck on metavariables*.\n\nThe fix is to **name the instance** (`letI inst := …`) and pass it (together with the derived `hmf : Module.Finite` and `hfree : Module.Free`) explicitly via `@`. This is the difference between a stuck proof and a clean one."
+    "content": "A formalization subtlety: `AddCommMonoid.zmodModule` is a *reducible non-instance* (it is an `abbrev`, deliberately not registered as a global instance to avoid runaway search). Consequently the local `Module (ZMod p) (Additive G)` it produces cannot be rediscovered by typeclass resolution when downstream lemmas (`Module.Finite`, `Module.Free`, `Module.natCard_eq_pow_finrank`, `Module.finBasisOfFinrankEq`) demand it — search gets *stuck on metavariables*.\n\nThe fix is to **name the instance** (`letI inst := …`) and pass it (together with the derived `hmf : Module.Finite` and `hfree : Module.Free`) explicitly via `@`. This is the difference between a stuck proof and a clean one.",
+    "mathContext": "$\\mathrm{Module}\\,(\\mathbb{Z}/p)\\,(\\mathrm{Additive}\\,G)$ from a reducible non-instance (`abbrev`) must be named with `letI` and passed via `@` to `Module.Finite`/`Module.Free`/`finBasisOfFinrankEq`.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "typeclass resolution",
+      "reducible non-instance",
+      "letI",
+      "explicit @-application",
+      "metavariable stuck search"
+    ],
+    "prerequisites": [
+      "Lean instance resolution",
+      "abbrev vs instance",
+      "Module.Finite / Module.Free"
+    ]
   },
   {
     "id": "ann-dimension-count",
@@ -41,7 +82,19 @@
     },
     "type": "insight",
     "title": "Cardinality Forces Dimension 2",
-    "content": "For a finite module over a finite field, `Module.natCard_eq_pow_finrank` gives `Nat.card V = (Nat.card K)^(finrank K V)`. With `K = ZMod p` (so `Nat.card K = p`) and `V = Additive G` (so `Nat.card V = Nat.card G = p²`), this reads\n```\np² = p ^ finrank (ZMod p) (Additive G).\n```\nSince `m ↦ p^m` is injective for `p ≥ 2` (`Nat.pow_right_injective`), the dimension is forced to be exactly `2`. This single numerical step is what pins the isomorphism type: a 2-dimensional 𝔽_p-vector space is `(ℤ/p)²`."
+    "content": "For a finite module over a finite field, `Module.natCard_eq_pow_finrank` gives `Nat.card V = (Nat.card K)^(finrank K V)`. With `K = ZMod p` (so `Nat.card K = p`) and `V = Additive G` (so `Nat.card V = Nat.card G = p²`), this reads\n```\np² = p ^ finrank (ZMod p) (Additive G).\n```\nSince `m ↦ p^m` is injective for `p ≥ 2` (`Nat.pow_right_injective`), the dimension is forced to be exactly `2`. This single numerical step is what pins the isomorphism type: a 2-dimensional 𝔽_p-vector space is `(ℤ/p)²`.",
+    "mathContext": "$\\mathrm{Nat.card}\\,V = (\\mathrm{Nat.card}\\,K)^{\\mathrm{finrank}_K V}$; with $K=\\mathbb{Z}/p,\\ V=\\mathrm{Additive}\\,G$: $p^2 = p^{\\,\\mathrm{finrank}}$, and injectivity of $m\\mapsto p^m$ forces $\\mathrm{finrank}=2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "finrank",
+      "Module.natCard_eq_pow_finrank",
+      "Nat.pow_right_injective",
+      "dimension count"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces over a finite field",
+      "injectivity of n ↦ pⁿ"
+    ]
   },
   {
     "id": "ann-transport",
@@ -52,7 +105,20 @@
     },
     "type": "technique",
     "title": "Basis, finTwoArrow, and the Additive/Multiplicative Transport",
-    "content": "With `finrank = 2`, `Module.finBasisOfFinrankEq` yields a `Basis (Fin 2) (ZMod p) (Additive G)`. Its coordinate equivalence `b.equivFun : Additive G ≃ₗ (Fin 2 → ZMod p)` composes with `LinearEquiv.finTwoArrow : (Fin 2 → ZMod p) ≃ₗ ZMod p × ZMod p` to give an additive identification `Additive G ≃+ ZMod p × ZMod p`.\n\nThe final step carries this back to the multiplicative world: `AddEquiv.toMultiplicativeRight` turns `Additive G ≃+ H` into `G ≃* Multiplicative H`, and `MulEquiv.prodMultiplicative` splits `Multiplicative (ZMod p × ZMod p)` into `Multiplicative (ZMod p) × Multiplicative (ZMod p)`. Working additively to use module theory and then transporting back is what keeps the multiplicative argument free of hand computation."
+    "content": "With `finrank = 2`, `Module.finBasisOfFinrankEq` yields a `Basis (Fin 2) (ZMod p) (Additive G)`. Its coordinate equivalence `b.equivFun : Additive G ≃ₗ (Fin 2 → ZMod p)` composes with `LinearEquiv.finTwoArrow : (Fin 2 → ZMod p) ≃ₗ ZMod p × ZMod p` to give an additive identification `Additive G ≃+ ZMod p × ZMod p`.\n\nThe final step carries this back to the multiplicative world: `AddEquiv.toMultiplicativeRight` turns `Additive G ≃+ H` into `G ≃* Multiplicative H`, and `MulEquiv.prodMultiplicative` splits `Multiplicative (ZMod p × ZMod p)` into `Multiplicative (ZMod p) × Multiplicative (ZMod p)`. Working additively to use module theory and then transporting back is what keeps the multiplicative argument free of hand computation.",
+    "mathContext": "$\\mathrm{finrank}=2 \\Rightarrow \\mathrm{Additive}\\,G \\simeq^+ (\\mathbb{Z}/p)^2$ via a basis; then $G \\simeq^* \\mathrm{Multiplicative}(\\mathbb{Z}/p)\\times\\mathrm{Multiplicative}(\\mathbb{Z}/p)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Module.finBasisOfFinrankEq",
+      "Basis.equivFun",
+      "LinearEquiv.finTwoArrow",
+      "AddEquiv.toMultiplicative",
+      "MulEquiv.prodMultiplicative"
+    ],
+    "prerequisites": [
+      "bases and coordinate equivalences",
+      "additive↔multiplicative transport of equivalences"
+    ]
   },
   {
     "id": "ann-structure-theorem",
@@ -63,6 +129,18 @@
     },
     "type": "concept",
     "title": "From Invariant to Structure Theorem",
-    "content": "`mulEquiv_zmod_sq_or_prod` is the classification proper: a `by_cases` on `IsCyclic G` dispatches to the two explicit isomorphisms, so every group of order `p²` is isomorphic to one of `ℤ/p²`, `(ℤ/p)²` (mutual exclusivity is the grandparent's sharp dichotomy).\n\n`mulEquiv_zmod_sq_of_exponent_sq` and `mulEquiv_prod_of_exponent_prime` then restate this through the **parent's exponent invariant**: composing with `exponent_eq_sq_iff_isCyclic` / `exponent_eq_prime_iff_not_isCyclic` maps the two exponent values `p²` and `p` to the two isomorphism types. This closes the parent chain — the exponent computation the parent introduced now delivers a concrete group identification."
+    "content": "`mulEquiv_zmod_sq_or_prod` is the classification proper: a `by_cases` on `IsCyclic G` dispatches to the two explicit isomorphisms, so every group of order `p²` is isomorphic to one of `ℤ/p²`, `(ℤ/p)²` (mutual exclusivity is the grandparent's sharp dichotomy).\n\n`mulEquiv_zmod_sq_of_exponent_sq` and `mulEquiv_prod_of_exponent_prime` then restate this through the **parent's exponent invariant**: composing with `exponent_eq_sq_iff_isCyclic` / `exponent_eq_prime_iff_not_isCyclic` maps the two exponent values `p²` and `p` to the two isomorphism types. This closes the parent chain — the exponent computation the parent introduced now delivers a concrete group identification.",
+    "mathContext": "Every group of order $p^2$ is $\\cong \\mathbb{Z}/p^2$ or $(\\mathbb{Z}/p)^2$ (by `by_cases IsCyclic G`); restated via exponent: $\\exp = p^2 \\iff$ cyclic, $\\exp = p \\iff$ not cyclic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "structure theorem for order-p² groups",
+      "exponent invariant",
+      "exponent_eq_sq_iff_isCyclic",
+      "by_cases dichotomy"
+    ],
+    "prerequisites": [
+      "the cyclic and elementary-abelian cases above",
+      "the parent's exponent computation"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `group-order-prime-squared-abelian-oq-01-oq-01-oq-02` (quality 68, pass 0).

This entry had a strong meta (object overview/conclusion, 4 sections) and 6 well-written annotations, but the annotations carried only `content` + `type` — no `mathContext`, `significance`, `relatedConcepts`, or `prerequisites`.

## Changes
- **Enrich all 6 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Existing `content`/`type`/`title`/`range` preserved verbatim. Covers: the cyclic case (zmodCyclicMulEquiv), the elementary-abelian 𝔽_p-module reinterpretation, the explicit instance-threading subtlety, the cardinality⇒dimension-2 count, the basis/finTwoArrow transport, and the final structure theorem via the exponent invariant.

## Validation
- JSON valid; `check-meta-size.ts` within caps (17.9 KB ≤ 60 KB).
- `pnpm annotations:build`: exit 0, **0 errors for this entry**.
- No change to status/badge/axiomCount.