### PR TITLE
research(pascals-hexagon-oq-03): repair subsystem bit-rot + prove OQ-03-OQ-02 quotient well-definedness [VERIFIED]

### DIFF
--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -365,7 +365,8 @@ theorem pascal_std_conic_parametrized (a b c d e f : ℝ) :
   -- Unfold to cross products and determinant (same pattern as DesarguesTheorem.lean)
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   -- The resulting degree-12 polynomial in 6 variables is identically 0
   -- (verified independently via sympy: ~3500 terms cancel)
@@ -477,7 +478,8 @@ theorem crossProduct_projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (u v : Fin 3
   fin_cases i <;>
   simp only [cross_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_three, Fin.isValue,
              Matrix.adjugate_fin_three, Matrix.transpose_apply, Matrix.of_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons,
              Nat.reduceAdd, Fin.reduceFinMk] <;>
   ring
 
@@ -542,10 +544,11 @@ theorem stdConicInfinity_on_conic : pointOnConic stdConicInfinity stdConic := by
 theorem stdConic_infinity_char (p : ProjPoint) (hp : pointOnConic p stdConic)
     (h02 : p 0 + p 2 = 0) : p 1 = 0 := by
   unfold pointOnConic conicQuadraticForm stdConic at hp
-  simp only [Fin.sum_univ_three, Fin.isValue, Matrix.of_apply, mul_comm, mul_one,
+  simp only [Fin.sum_univ_three, Fin.isValue, Matrix.of_apply, one_mul, neg_mul,
              zero_mul, mul_zero, add_zero, zero_add] at hp
   have h : p 2 = -(p 0) := by linarith
-  nlinarith [sq_nonneg (p 1), sq_nonneg (p 0), mul_self_nonneg (p 1)]
+  rw [h] at hp
+  nlinarith [sq_nonneg (p 1), hp]
 
 /-- **Parametric coverage**: Every point on stdConic with p₀+p₂ ≠ 0 is a scalar
     multiple of stdConicPoint(p₁/(p₀+p₂)).
@@ -559,7 +562,16 @@ theorem stdConicPoint_covers (p : ProjPoint) (hp : pointOnConic p stdConic)
     unfold pointOnConic conicQuadraticForm stdConic at hp
     simp only [Fin.sum_univ_three, Fin.isValue, Matrix.of_apply] at hp
     nlinarith
-  intro i; fin_cases i <;> simp only [stdConicPoint] <;> field_simp <;> nlinarith [hconic]
+  have h0 : p 0 = (p 0 + p 2) / 2 * stdConicPoint (p 1 / (p 0 + p 2)) 0 := by
+    simp only [stdConicPoint, Fin.isValue]; field_simp; nlinarith [hconic]
+  have h1 : p 1 = (p 0 + p 2) / 2 * stdConicPoint (p 1 / (p 0 + p 2)) 1 := by
+    simp only [stdConicPoint, Fin.isValue]; field_simp
+  have h2 : p 2 = (p 0 + p 2) / 2 * stdConicPoint (p 1 / (p 0 + p 2)) 2 := by
+    simp only [stdConicPoint, Fin.isValue]; field_simp; nlinarith [hconic]
+  intro i; fin_cases i
+  · exact h0
+  · exact h1
+  · exact h2
 
 /-
 ### Roadmap for Full Axiom Elimination
@@ -598,15 +610,11 @@ theorem stdConicPoint_covers (p : ProjPoint) (hp : pointOnConic p stdConic)
 
 theorem crossProduct_smul_left (c : ℝ) (u v : Fin 3 → ℝ) :
     crossProduct (c • u) v = c • crossProduct u v := by
-  ext i; fin_cases i <;>
-    simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-               Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;> ring
+  rw [map_smul, LinearMap.smul_apply]
 
 theorem crossProduct_smul_right (c : ℝ) (u v : Fin 3 → ℝ) :
     crossProduct u (c • v) = c • crossProduct u v := by
-  ext i; fin_cases i <;>
-    simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-               Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;> ring
+  rw [map_smul]
 
 -- ============================================================
 -- PART 15: Pascal's Theorem — Point at Infinity Cases
@@ -628,7 +636,8 @@ theorem pascal_std_conic_infinity_F (a b c d e : ℝ) :
       (stdConicPoint d) (stdConicPoint e) stdConicInfinity := by
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint stdConicInfinity
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -638,7 +647,8 @@ theorem pascal_std_conic_infinity_A (b c d e f : ℝ) :
       (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint stdConicInfinity
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -648,7 +658,8 @@ theorem pascal_std_conic_infinity_B (a c d e f : ℝ) :
       (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint stdConicInfinity
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -658,7 +669,8 @@ theorem pascal_std_conic_infinity_C (a b d e f : ℝ) :
       (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint stdConicInfinity
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -668,7 +680,8 @@ theorem pascal_std_conic_infinity_D (a b c e f : ℝ) :
       stdConicInfinity (stdConicPoint e) (stdConicPoint f) := by
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint stdConicInfinity
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -678,7 +691,8 @@ theorem pascal_std_conic_infinity_E (a b c d f : ℝ) :
       (stdConicPoint d) stdConicInfinity (stdConicPoint f) := by
   unfold pascalConstraint lineIntersection lineThrough stdConicPoint stdConicInfinity
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -717,13 +731,9 @@ theorem pascalConstraint_smul
   rw [det_threeVectorMatrix_smul]
   constructor
   · intro h
-    have hprod : k₁ * k₂ * (k₄ * k₅) * (k₂ * k₃ * (k₅ * k₆)) *
-      (k₃ * k₄ * (k₆ * k₁)) ≠ 0 := by
-      apply mul_ne_zero; apply mul_ne_zero
-      · exact mul_ne_zero (mul_ne_zero h1 h2) (mul_ne_zero h4 h5)
-      · exact mul_ne_zero (mul_ne_zero h2 h3) (mul_ne_zero h5 h6)
-      · exact mul_ne_zero (mul_ne_zero h3 h4) (mul_ne_zero h6 h1)
-    exact (mul_eq_zero.mp h).resolve_left hprod
+    refine (mul_eq_zero.mp h).resolve_left ?_
+    simp only [mul_eq_zero, not_or, ne_eq]
+    tauto
   · intro h; rw [h, mul_zero]
 
 -- ============================================================
@@ -774,9 +784,17 @@ theorem stdConic_point_classification (p : ProjPoint) (hp : pointOnConic p stdCo
       intro h0
       apply hv
       ext i; fin_cases i <;> simp_all
-    exact ⟨p 0, hp0_ne, fun i => by fin_cases i <;>
-      simp only [stdConicInfinity, Fin.isValue, mul_one, mul_zero, mul_neg] <;>
-      linarith⟩
+    have e0 : p 0 = p 0 * stdConicInfinity 0 := by
+      simp only [stdConicInfinity, Fin.isValue, mul_one]
+    have e1 : p 1 = p 0 * stdConicInfinity 1 := by
+      simp only [stdConicInfinity, Fin.isValue, mul_zero]; exact hp1
+    have e2 : p 2 = p 0 * stdConicInfinity 2 := by
+      simp only [stdConicInfinity, Fin.isValue, mul_neg, mul_one]; linarith [hp2]
+    refine ⟨p 0, hp0_ne, fun i => ?_⟩
+    fin_cases i
+    · exact e0
+    · exact e1
+    · exact e2
   · left; exact stdConicPoint_covers p hp h02
 
 /-- **Pascal for stdConic (all finite vertices)**: When all 6 points have
@@ -828,7 +846,8 @@ private theorem pascalConstraint_A_eq_D (A B C E F : ProjPoint) :
     pascalConstraint A B C A E F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -836,7 +855,8 @@ private theorem pascalConstraint_B_eq_E (A B C D F : ProjPoint) :
     pascalConstraint A B C D B F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -844,7 +864,8 @@ private theorem pascalConstraint_C_eq_F (A B C D E : ProjPoint) :
     pascalConstraint A B C D E C := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -853,7 +874,8 @@ private theorem pascalConstraint_A_eq_B (A C D E F : ProjPoint) :
     pascalConstraint A A C D E F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -861,7 +883,8 @@ private theorem pascalConstraint_B_eq_C (A B D E F : ProjPoint) :
     pascalConstraint A B B D E F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -869,7 +892,8 @@ private theorem pascalConstraint_C_eq_D (A B C E F : ProjPoint) :
     pascalConstraint A B C C E F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -877,7 +901,8 @@ private theorem pascalConstraint_D_eq_E (A B C D F : ProjPoint) :
     pascalConstraint A B C D D F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -885,7 +910,8 @@ private theorem pascalConstraint_E_eq_F (A B C D E : ProjPoint) :
     pascalConstraint A B C D E E := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -893,7 +919,8 @@ private theorem pascalConstraint_F_eq_A (A B C D E : ProjPoint) :
     pascalConstraint A B C D E A := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -902,7 +929,8 @@ private theorem pascalConstraint_A_eq_C (A B D E F : ProjPoint) :
     pascalConstraint A B A D E F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -910,7 +938,8 @@ private theorem pascalConstraint_B_eq_D (A B C E F : ProjPoint) :
     pascalConstraint A B C B E F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -918,7 +947,8 @@ private theorem pascalConstraint_C_eq_E (A B C D F : ProjPoint) :
     pascalConstraint A B C D C F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -926,7 +956,8 @@ private theorem pascalConstraint_D_eq_F (A B C D E : ProjPoint) :
     pascalConstraint A B C D E D := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -934,7 +965,8 @@ private theorem pascalConstraint_E_eq_A (A B C D F : ProjPoint) :
     pascalConstraint A B C D A F := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -942,7 +974,8 @@ private theorem pascalConstraint_F_eq_B (A B C D E : ProjPoint) :
     pascalConstraint A B C D E B := by
   unfold pascalConstraint lineIntersection lineThrough
   simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, cross_apply,
-             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue,
+             Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+             Matrix.head_cons, Matrix.tail_cons, Fin.isValue,
              Nat.reduceAdd, Fin.reduceFinMk]
   ring
 
@@ -1154,7 +1187,7 @@ private lemma mathlibQF_separatingLeft (C : Conic) (hC_sym : C.symmetric)
   -- Step 1: Show associated Q = Matrix.toLinearMap₂' ℝ C using symmetry of C
   have h_assoc : QuadraticMap.associated (Matrix.toQuadraticMap' C) = Matrix.toLinearMap₂' ℝ C := by
     unfold Matrix.toQuadraticMap'
-    exact QuadraticMap.associated_left_inverse (fun x y => by
+    exact QuadraticMap.associated_left_inverse ℝ (fun x y => by
       -- Prove: (Matrix.toLinearMap₂' ℝ C) x y = (Matrix.toLinearMap₂' ℝ C) y x
       -- i.e., x ⬝ᵥ (C *ᵥ y) = y ⬝ᵥ (C *ᵥ x), using symmetry of C
       simp only [Matrix.toLinearMap₂'_apply', dotProduct, Matrix.mulVec]

--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -64,7 +64,7 @@ Mysticum):
 * `card_hexagon_labelings = 60` — follows from the previous two by
   Lagrange (proved).
 * `pascalLine` — Pascal-line map from labelings, **OQ-03-OQ-02**: total,
-  defined via the canonical coset representative `lbl.out'` (the
+  defined via the canonical coset representative `lbl.out` (the
   representative-independence / full well-definedness remains future work).
 * `SteinerPoint`, `KirkmanPoint` — structures encoding the
   concurrence-triple data.
@@ -217,6 +217,12 @@ theorem orderOf_hexRot : orderOf hexRot = 6 := by
   apply (orderOf_eq_iff (by norm_num)).mpr
   exact ⟨hexRot_pow_six, hexRot_pow_lt_six_ne_one⟩
 
+/-- `hexRev` is not the identity. (Sanity check: reversal swaps `0` and `5`.) -/
+theorem hexRev_ne_one : hexRev ≠ 1 := by
+  intro h
+  have : hexRev 0 = (1 : Equiv.Perm (Fin 6)) 0 := by rw [h]
+  simp [hexRev, Fin.rev] at this
+
 /-- **`orderOf hexRev = 2`** — the reversal is an involution distinct from 1.
     Uses `hexRev_mul_self` (from `pow_two`) and `hexRev_ne_one`. -/
 theorem orderOf_hexRev : orderOf hexRev = 2 := by
@@ -308,10 +314,9 @@ theorem hexRev_hexRot_pow_hexRev (n : ℕ) :
     S3c homomorphism. -/
 private lemma hexRot_pow_zmod_val_add (i j : ZMod 6) :
     hexRot ^ (i + j).val = hexRot ^ i.val * hexRot ^ j.val := by
-  rw [← pow_add]
-  -- `ZMod.val_add` gives `(i + j).val = (i.val + j.val) % 6`; then
-  -- `pow_mod_orderOf` with `orderOf_hexRot = 6` collapses the `% 6`.
-  rw [ZMod.val_add i j, ← orderOf_hexRot, pow_mod_orderOf]
+  rw [← pow_add, pow_eq_pow_iff_modEq, orderOf_hexRot, ZMod.val_add]
+  -- `(i.val + j.val) % 6 ≡ i.val + j.val [MOD 6]`.
+  exact Nat.mod_modEq _ _
 
 /-- **Negation form**: `(hexRot ^ i.val)⁻¹ = hexRot ^ (-i).val`.
     Equivalent to saying that the map `i ↦ hexRot ^ i.val` respects
@@ -322,7 +327,7 @@ private lemma hexRot_pow_zmod_val_neg (i : ZMod 6) :
   have h := hexRot_pow_zmod_val_add i (-i)
   rw [add_neg_cancel, ZMod.val_zero, pow_zero] at h
   -- `h : 1 = hexRot ^ i.val * hexRot ^ (-i).val`
-  exact (eq_inv_of_mul_eq_one_left h.symm).symm
+  exact mul_eq_one_iff_inv_eq.mp h.symm
 
 /-- **Subtractive form**:
     `(hexRot ^ i.val)⁻¹ * hexRot ^ j.val = hexRot ^ (j - i).val`.
@@ -449,7 +454,7 @@ theorem dihedralHomToSym6_injective :
     -- `hg : hexRev * hexRot ^ i.val = 1` ⇒ contradiction.
     exfalso
     have h1 : hexRev = (hexRot ^ i.val)⁻¹ :=
-      eq_inv_of_mul_eq_one_right hg
+      mul_eq_one_iff_eq_inv.mp hg
     rw [hexRot_pow_zmod_val_neg] at h1
     exact hexRev_ne_hexRot_pow_of_lt (-i).val (ZMod.val_lt _) h1
 
@@ -690,7 +695,7 @@ theorem pascalP_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
   ext i
   fin_cases i <;>
     simp only [lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
-               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;>
+               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Fin.isValue] <;>
     ring
 
 /-- `hexRev` sends the second Pascal point to the negated first: `Q' = -P`. -/
@@ -706,7 +711,7 @@ theorem pascalQ_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
   ext i
   fin_cases i <;>
     simp only [lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
-               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;>
+               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Fin.isValue] <;>
     ring
 
 /-- `hexRev` fixes the third Pascal point: `R' = R`.  The two inner sign flips
@@ -723,7 +728,7 @@ theorem pascalR_permuteHexagon_hexRev {C : Conic} (hex : InscribedHexagon C) :
   ext i
   fin_cases i <;>
     simp only [lineIntersection, lineThrough, cross_apply, Pi.neg_apply,
-               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Fin.isValue] <;>
+               Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Fin.isValue] <;>
     ring
 
 -- ============================================================
@@ -756,7 +761,7 @@ theorem sameProjLine_refl (l : ProjLine) : sameProjLine l l := by
   unfold sameProjLine
   funext i
   fin_cases i <;>
-    simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                Pi.zero_apply, Fin.isValue] <;>
     ring
 
@@ -765,7 +770,7 @@ theorem sameProjLine_neg_right (l : ProjLine) : sameProjLine l (-l) := by
   unfold sameProjLine
   funext i
   fin_cases i <;>
-    simp only [cross_apply, Pi.neg_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+    simp only [cross_apply, Pi.neg_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
                Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
     ring
 
@@ -778,7 +783,7 @@ theorem sameProjLine_smul_right (c : ℝ) (l : ProjLine) : sameProjLine l (c •
   funext i
   fin_cases i <;>
     simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-               Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
+               Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
     ring
 
 /-- **BAC–CAB specialisation.** For any three vectors in `ℝ³`,
@@ -792,7 +797,7 @@ theorem cross_cross_eq_det_smul (P Q R : ProjPoint) :
   funext i
   fin_cases i <;>
     simp only [cross_apply, threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply,
-               Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero, Matrix.cons_val_one,
+               Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
                Matrix.head_cons, Fin.isValue, Nat.reduceAdd, Fin.reduceFinMk] <;>
     ring
 
@@ -834,7 +839,7 @@ theorem pascalLine_hexRev_sameProjLine {C : Conic} (hex : InscribedHexagon C) :
   unfold sameProjLine lineThrough
   funext i
   fin_cases i <;>
-    simp only [cross_apply, Pi.neg_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+    simp only [cross_apply, Pi.neg_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
                Matrix.head_cons, Pi.zero_apply, Fin.isValue] <;>
     ring
 
@@ -891,17 +896,17 @@ theorem sameProjLine_symm {l m : ProjLine} (h : sameProjLine l m) :
   have h0 := congrFun h 0
   have h1 := congrFun h 1
   have h2 := congrFun h 2
-  simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+  simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
              Pi.zero_apply, Fin.isValue] at h0 h1 h2
   funext i
   fin_cases i
-  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                Pi.zero_apply, Fin.isValue]
     linear_combination -h0
-  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                Pi.zero_apply, Fin.isValue]
     linear_combination -h1
-  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+  · simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                Pi.zero_apply, Fin.isValue]
     linear_combination -h2
 
@@ -924,64 +929,64 @@ theorem sameProjLine_trans {l m n : ProjLine} (hm : m ≠ 0)
   -- Component equations of `l ×₃ m = 0` and `m ×₃ n = 0`.
   have a0 : l 1 * m 2 - l 2 * m 1 = 0 := by
     have := congrFun h1 0
-    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                 Pi.zero_apply, Fin.isValue] using this
   have a1 : l 2 * m 0 - l 0 * m 2 = 0 := by
     have := congrFun h1 1
-    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                 Pi.zero_apply, Fin.isValue] using this
   have a2 : l 0 * m 1 - l 1 * m 0 = 0 := by
     have := congrFun h1 2
-    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                 Pi.zero_apply, Fin.isValue] using this
   have b0 : m 1 * n 2 - m 2 * n 1 = 0 := by
     have := congrFun h2 0
-    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                 Pi.zero_apply, Fin.isValue] using this
   have b1 : m 2 * n 0 - m 0 * n 2 = 0 := by
     have := congrFun h2 1
-    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                 Pi.zero_apply, Fin.isValue] using this
   have b2 : m 0 * n 1 - m 1 * n 0 = 0 := by
     have := congrFun h2 2
-    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons,
+    simpa only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons,
                 Pi.zero_apply, Fin.isValue] using this
   -- Each coordinate of `m` annihilates `l ×₃ n`.
   have key0 : m 0 • crossProduct l n = 0 := by
     funext i
     fin_cases i
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 0) * b0 - (n 2) * a2 - (n 1) * a1
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 0) * b1 + (n 0) * a1
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 0) * b2 + (n 0) * a2
   have key1 : m 1 • crossProduct l n = 0 := by
     funext i
     fin_cases i
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 1) * b0 + (n 1) * a0
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 1) * b1 - (n 0) * a0 - (n 2) * a2
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 1) * b2 + (n 1) * a2
   have key2 : m 2 • crossProduct l n = 0 := by
     funext i
     fin_cases i
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 2) * b0 + (n 2) * a0
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 2) * b1 + (n 2) * a1
     · simp only [cross_apply, Pi.smul_apply, smul_eq_mul, Matrix.cons_val_zero,
-                 Matrix.cons_val_one, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+                 Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk, Matrix.head_cons, Pi.zero_apply, Fin.isValue]
       linear_combination (l 2) * b2 - (n 1) * a1 - (n 0) * a0
   -- `m ≠ 0` ⟹ some coordinate is nonzero ⟹ `l ×₃ n = 0`.
   obtain ⟨k, hk⟩ := Function.ne_iff.mp hm
@@ -1184,7 +1189,7 @@ theorem pascalProjLine_sameProjLine_of_mem_mem
     line through two of those three Pascal points.
 
     The map is made *total* by evaluating it at the canonical coset
-    representative `lbl.out' : Equiv.Perm (Fin 6)` (`Quotient.out'`). The
+    representative `lbl.out : Equiv.Perm (Fin 6)` (`Quotient.out'`). The
     `D_6`-invariance of the resulting projective line — i.e. that the value
     is independent of the choice of representative — is the genuine
     "well-definedness" content of **OQ-03-OQ-02**; its geometric backbone is
@@ -1194,8 +1199,8 @@ theorem pascalProjLine_sameProjLine_of_mem_mem
     a nondegeneracy hypothesis, and is deferred. -/
 noncomputable def pascalLine
     (C : Conic) (hex : InscribedHexagon C) (lbl : HexagonLabeling) : ProjLine :=
-  lineThrough (pascalP (permuteHexagon hex lbl.out'))
-              (pascalQ (permuteHexagon hex lbl.out'))
+  lineThrough (pascalP (permuteHexagon hex lbl.out))
+              (pascalQ (permuteHexagon hex lbl.out))
 
 /-- **Hexagrammum Mysticum (existence statement)**: the assignment
     `HexagonLabeling → ProjLine` from a hexagon labeling to its Pascal
@@ -1209,6 +1214,53 @@ theorem hexagrammum_mysticum_pascal_lines
     (C : Conic) (hex : InscribedHexagon C) :
     ∃ (lines : HexagonLabeling → ProjLine), lines = pascalLine C hex :=
   ⟨pascalLine C hex, rfl⟩
+
+-- ============================================================
+-- PART 5b: Quotient-Level Well-Definedness of the Pascal Line
+--          (OQ-03-OQ-02: descent through the coset representative)
+-- ============================================================
+
+/- PART 4g proved that relabeling `hex` by any element of `hexagonalGroup`
+   leaves its Pascal line projectively unchanged (`…_of_mem`).  `pascalLine`
+   (PART 5) makes the labeling-indexed map total by evaluating at the canonical
+   representative `lbl.out`.  The two theorems below close the gap between these:
+   they show the *value* of `pascalLine` does not depend on the choice of coset
+   representative — the genuine well-definedness content of OQ-03-OQ-02. -/
+
+/-- **OQ-03-OQ-02 — coset well-definedness.**  Two permutations representing the
+    *same* `HexagonLabeling` coset relabel `hex` to the same projective Pascal
+    line (under the general-position hypothesis `hnd`).  This lifts the
+    group-level invariance `pascalProjLine_sameProjLine_of_mem` to the quotient:
+    representatives `π₁, π₂` of one coset differ by `π₁⁻¹ * π₂ ∈ hexagonalGroup`,
+    so the single-coset descent applies at `permuteHexagon hex π₁`. -/
+theorem pascalProjLine_sameProjLine_of_quotient_eq
+    {C : Conic} (hex : InscribedHexagon C) {π₁ π₂ : Equiv.Perm (Fin 6)}
+    (hquot : (π₁ : HexagonLabeling) = (π₂ : HexagonLabeling))
+    (hnd : ∀ k : Equiv.Perm (Fin 6), pascalProjLine (permuteHexagon hex k) ≠ 0) :
+    sameProjLine (pascalProjLine (permuteHexagon hex π₁))
+                 (pascalProjLine (permuteHexagon hex π₂)) := by
+  have hmem : π₁⁻¹ * π₂ ∈ hexagonalGroup := QuotientGroup.eq.mp hquot
+  have hnd' : ∀ k : Equiv.Perm (Fin 6),
+      pascalProjLine (permuteHexagon (permuteHexagon hex π₁) k) ≠ 0 := by
+    intro k; rw [permuteHexagon_mul]; exact hnd (π₁ * k)
+  have hstep := pascalProjLine_sameProjLine_of_mem hmem (permuteHexagon hex π₁) hnd'
+  rwa [permuteHexagon_mul, mul_inv_cancel_left] at hstep
+
+/-- **OQ-03-OQ-02 — `pascalLine` well-definedness.**  The total `pascalLine` map
+    — defined via the canonical representative `lbl.out` — agrees, as a
+    projective line, with the Pascal line computed from *any* representative `π`
+    of `lbl`.  Equivalently, the projective Pascal line of a coset is independent
+    of the representative used to compute it: precisely the well-definedness the
+    `Quotient.out`-based definition leaves implicit. -/
+theorem pascalLine_sameProjLine_rep
+    {C : Conic} (hex : InscribedHexagon C) (lbl : HexagonLabeling)
+    {π : Equiv.Perm (Fin 6)} (hπ : (π : HexagonLabeling) = lbl)
+    (hnd : ∀ k : Equiv.Perm (Fin 6), pascalProjLine (permuteHexagon hex k) ≠ 0) :
+    sameProjLine (pascalLine C hex lbl) (pascalProjLine (permuteHexagon hex π)) := by
+  have hout : ((lbl.out : Equiv.Perm (Fin 6)) : HexagonLabeling) = lbl := Quotient.out_eq lbl
+  have hpl : pascalLine C hex lbl = pascalProjLine (permuteHexagon hex lbl.out) := rfl
+  rw [hpl]
+  exact pascalProjLine_sameProjLine_of_quotient_eq hex (hout.trans hπ.symm) hnd
 
 -- ============================================================
 -- PART 6: Steiner Points
@@ -1272,12 +1324,6 @@ theorem kirkman_count_eq_60
 theorem hexRot_ne_one : hexRot ≠ 1 := by
   intro h
   have : hexRot 0 = (1 : Equiv.Perm (Fin 6)) 0 := by rw [h]
-  simp [hexRot, finRotate] at this
-
-/-- `hexRev` is not the identity. (Sanity check: reversal swaps `0` and `5`.) -/
-theorem hexRev_ne_one : hexRev ≠ 1 := by
-  intro h
-  have : hexRev 0 = (1 : Equiv.Perm (Fin 6)) 0 := by rw [h]
-  simp [hexRev, Fin.rev] at this
+  simp [hexRot, finRotate_succ_apply] at this
 
 end PascalsHexagonOQ03


### PR DESCRIPTION
## Summary

The entire **Pascal's Hexagon** subsystem was broken on `main` against Mathlib 4.26.0. This PR repairs it and adds new mathematics for the claimed problem **`pascals-hexagon-oq-03-incomplete-01`** (Hexagrammum Mysticum — Pascal-line map well-definedness, OQ-03-OQ-02).

Both files now build cleanly via `lake env lean` (exit 0). The only remaining `sorry`s are the pre-existing, genuinely-open **Steiner (20) / Kirkman (60) count** theorems; the only substantive axiom remains `conic_implies_pascal_constraint` (Pascal collinearity). **No new axioms or sorries are introduced.**

## `PascalsHexagon.lean` — repair (~35 errors → 0)

Flagship file; every Pascal entry imports it. Mathlib-drift fixes:
- `![…] 2` / `(c ::ᵥ …) 2` index-2 access no longer reduced → added `Matrix.cons_val_two`, `Matrix.tail_cons` to the ~22 `simp; ring` blocks (std-conic + 15 coincident-vertex lemmas).
- `crossProduct_smul_left/right`: replaced fragile coordinate bash with `map_smul` (cross product is a Mathlib bilinear `LinearMap`).
- `fin_cases i` now yields `⟨k,⋯⟩`, breaking `linarith` atom-matching with `p 0/1/2` → `stdConicPoint_covers` / `stdConic_point_classification` rewritten to prove explicit `p 0/1/2` lemmas and discharge each case with `exact` (defeq).
- `stdConic_infinity_char`: dropped looping `mul_comm`; substitute `p 2 = -p 0` before `nlinarith`.
- `pascalConstraint_smul`: order-independent nonzero-coefficient discharge.
- `mathlibQF_separatingLeft`: `QuadraticMap.associated_left_inverse` now takes the scalar `S` explicitly → pass `ℝ`.

## `PascalsHexagonOQ03.lean` — repair (~32 errors → 0) + new theorems

**Repair (Mathlib drift):**
- `Fin.reduceFinMk` + `Matrix.cons_val_two` + `Matrix.tail_cons` across the ~27 cross-product / `linear_combination` coordinate blocks (the `sameProjLine` PER certificates, hexRev generator-action lemmas, BAC–CAB identity).
- `Quotient.out'` removed → `Quotient.out`.
- `eq_inv_of_mul_eq_one_{left,right}` → `mul_eq_one_iff_{eq_inv,inv_eq}`.
- `hexRot_pow_zmod_val_add` reformulated via `pow_eq_pow_iff_modEq` + `Nat.mod_modEq`.
- `hexRot_ne_one` via `finRotate_succ_apply`; moved `hexRev_ne_one` above its first use.

**New mathematics (OQ-03-OQ-02 — Pascal-line map well-definedness):**
- `pascalProjLine_sameProjLine_of_quotient_eq` — two permutations in the **same** `HexagonLabeling` coset yield the same projective Pascal line, lifting the group-level `pascalProjLine_sameProjLine_of_mem` to the quotient via `QuotientGroup.eq`.
- `pascalLine_sameProjLine_rep` — the total `pascalLine` map (computed at the canonical `lbl.out`) agrees, as a projective line, with the Pascal line of **any** representative of the coset — the genuine well-definedness content the `Quotient.out`-based definition leaves implicit.

Both new results are conditional on the general-position nondegeneracy hypothesis `hnd` (an explicit argument, exactly as the existing descent lemmas), and `#print axioms` confirms they add only `conic_implies_pascal_constraint` (+ standard `propext`/`Classical.choice`/`Quot.sound`).

## Verification

```
lake env lean Proofs/PascalsHexagon.lean      # exit 0
lake env lean Proofs/PascalsHexagonOQ03.lean  # exit 0
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)