### PR TITLE
Enrich Catalan Log-Convexity (Turán Inequality): add sections, deepen annotations

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/annotations.json
@@ -6,7 +6,22 @@
     "type": "key-step",
     "title": "The deficit descends monotonically",
     "content": "The parent showed only $\\delta\\,n = 6/(n+2) \\to 0$. Here it is upgraded to a strict descent: for $a < b$ one has $a+2 < b+2$, and $\\texttt{div\\_lt\\_div\\_of\\_pos\\_left}$ gives $6/(b+2) < 6/(a+2)$. Since $r\\,n = 4 - \\delta\\,n$, this is exactly the strict increase of the recurrence ratio toward its supremum $4$.",
-    "mathContext": "$\\delta$ strictly antitone $\\iff$ $r = 4 - \\delta$ strictly monotone."
+    "mathContext": "$\\delta$ strictly antitone $\\iff$ $r = 4 - \\delta$ strictly monotone.",
+    "significance": "key",
+    "relatedConcepts": ["strict antitonicity", "harmonic deficit", "monotone convergence to a supremum"],
+    "prerequisites": ["order of division div_lt_div_of_pos_left", "casting ℕ inequalities to ℝ"]
+  },
+  {
+    "id": "ann-e396oq04oq01oq01oq03-ratiolt",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-03",
+    "range": { "startLine": 60, "endLine": 62 },
+    "type": "definition",
+    "title": "One-step ratio increment",
+    "content": "$\\texttt{ratio\\_lt\\_succ}$ specialises the grandparent's $\\texttt{ratio\\_strictMono}$ to consecutive indices, $r\\,n < r(n+1)$. This single inequality is the entire analytic content the rest of the file consumes: every downstream theorem reduces to the positivity of $r(n+1) - r\\,n$.",
+    "mathContext": "$r\\,n < r(n+1)$, the instance $\\texttt{ratio\\_strictMono}\\,(n < n+1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict monotonicity", "consecutive-ratio test for log-convexity"],
+    "prerequisites": ["Nat.lt_succ_self", "the upstream ratio_strictMono"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq03-turanreal",
@@ -15,7 +30,10 @@
     "type": "key-step",
     "title": "The Turán gap is the ratio increment, scaled",
     "content": "Rewriting $C(n+1) = r\\,n\\cdot C n$ and $C(n+2) = r(n+1)\\cdot r\\,n\\cdot C n$, both sides become multiples of $C(n)^2$. The difference $C n\\cdot C(n+2) - C(n+1)^2$ factors as $r\\,n\\cdot C(n)^2\\cdot(r(n+1) - r\\,n)$ — supplied to $\\texttt{nlinarith}$ as the positive witness $\\texttt{key}$. Each factor is positive (catalan positivity, ratio positivity, and the upstream strict monotonicity), so the whole gap is positive.",
-    "mathContext": "$C n\\,C(n+2) - C(n+1)^2 = r\\,n\\,C(n)^2\\,(r(n+1) - r\\,n) > 0$."
+    "mathContext": "$C n\\,C(n+2) - C(n+1)^2 = r\\,n\\,C(n)^2\\,(r(n+1) - r\\,n) > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Turán inequality", "log-convexity", "recurrence substitution", "nlinarith certificate"],
+    "prerequisites": ["catalan_succ_eq_ratio_mul recurrence bridge", "positivity of Catalan numbers", "mul_pos / sub_pos"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq03-turannat",
@@ -24,7 +42,10 @@
     "type": "key-step",
     "title": "Integer form by casting",
     "content": "Catalan numbers are natural numbers, so the real Turán inequality transfers verbatim to $\\mathbb{N}$ via $\\texttt{exact\\_mod\\_cast}$: $\\text{catalan}(n+1)^2 < \\text{catalan}\\,n\\cdot\\text{catalan}(n+2)$. This is the cleanest, foundation-free phrasing of log-convexity.",
-    "mathContext": "$\\text{catalan}(n+1)^2 < \\text{catalan}\\,n\\cdot\\text{catalan}(n+2)$ over $\\mathbb{N}$."
+    "mathContext": "$\\text{catalan}(n+1)^2 < \\text{catalan}\\,n\\cdot\\text{catalan}(n+2)$ over $\\mathbb{N}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["order-preserving cast ℕ ↔ ℝ", "integer Turán inequality"],
+    "prerequisites": ["exact_mod_cast", "injectivity of the ℕ → ℝ cast on order"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq03-hankel",
@@ -33,7 +54,10 @@
     "type": "insight",
     "title": "Determinant phrasing: positive Hankel minor",
     "content": "The Turán inequality is positivity of the $2\\times2$ minor $\\det\\begin{psmallmatrix} C n & C(n+1) \\\\ C(n+1) & C(n+2)\\end{psmallmatrix} = C n\\,C(n+2) - C(n+1)^2$ of the shifted Catalan moment (Hankel) matrix — obtained immediately as $\\texttt{sub\\_pos.mpr}$ of the Turán inequality.",
-    "mathContext": "$0 < C n\\,C(n+2) - C(n+1)^2$."
+    "mathContext": "$0 < C n\\,C(n+2) - C(n+1)^2$.",
+    "significance": "context",
+    "relatedConcepts": ["Hankel determinant", "moment matrices", "total positivity", "2×2 minors"],
+    "prerequisites": ["sub_pos", "determinant of a 2×2 matrix"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq03-logconvex",
@@ -42,6 +66,9 @@
     "type": "key-step",
     "title": "Literal log-convexity by taking logs",
     "content": "Applying $\\texttt{Real.log\\_lt\\_log}$ to the strictly positive Turán inequality, then $\\texttt{Real.log\\_pow}$ ($\\log x^2 = 2\\log x$) and $\\texttt{Real.log\\_mul}$ ($\\log(xy) = \\log x + \\log y$), yields the midpoint convexity of $n \\mapsto \\log\\text{catalan}\\,n$: $2\\log\\text{catalan}(n+1) < \\log\\text{catalan}\\,n + \\log\\text{catalan}(n+2)$.",
-    "mathContext": "$2\\log C(n+1) < \\log C n + \\log C(n+2)$, i.e. $\\log\\circ\\,\\text{catalan}$ is strictly midpoint-convex."
+    "mathContext": "$2\\log C(n+1) < \\log C n + \\log C(n+2)$, i.e. $\\log\\circ\\,\\text{catalan}$ is strictly midpoint-convex.",
+    "significance": "key",
+    "relatedConcepts": ["midpoint convexity", "logarithm of a convex sequence", "strict monotonicity of log"],
+    "prerequisites": ["Real.log_lt_log on positives", "Real.log_pow", "Real.log_mul"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-03/meta.json
@@ -48,6 +48,43 @@
       "Strict monotonicity of log on positives, with log(x²) = 2 log x and log(xy) = log x + log y"
     ]
   },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Docstring tracing the descent from the grandparent ratio identity r n = (4n+2)/(n+2) = 4 − 6/(n+2) and its strict monotonicity (ratio_strictMono) through the parent deficit δ n = 6/(n+2) to this entry's structural reading: a strictly increasing ratio of consecutive terms is exactly strict log-convexity. Imports all of Mathlib and the parent Proofs.Erdos396OQ04OQ01OQ01, opening the namespaces Erdos396OQ01 and Erdos396OQ01OQ01 to reuse catalanRatio, catalanDeficit, catalan_succ_eq_ratio_mul, ratio_pos, ratio_strictMono and deficit_eq."
+    },
+    {
+      "id": "deficit-monotone",
+      "title": "§ The Deficit Descends Monotonically",
+      "startLine": 47,
+      "endLine": 56,
+      "summary": "deficit_strictAnti upgrades the parent's δ n → 0 to a strict descent: rewriting both sides via deficit_eq, the cast a+2 < b+2 feeds div_lt_div_of_pos_left to give 6/(b+2) < 6/(a+2). Since r n = 4 − δ n, this is exactly the strict increase of the recurrence ratio toward its supremum 4."
+    },
+    {
+      "id": "turan-inequality",
+      "title": "§ The Turán Inequality (Strict Log-Convexity)",
+      "startLine": 58,
+      "endLine": 99,
+      "summary": "ratio_lt_succ specialises ratio_strictMono to the one-step increment r n < r(n+1). turan_real proves catalan(n+1)² < catalan n · catalan(n+2) over ℝ: rewriting C(n+1) = r n · C n and C(n+2) = r(n+1)·r n·C n makes both sides multiples of C(n)², and the gap r n · C(n)² · (r(n+1) − r n) — supplied to nlinarith as the positive witness — is positive factor-by-factor. turan_nat casts this to ℕ via exact_mod_cast; hankel_det_pos restates it as positivity of the 2×2 Catalan Hankel minor via sub_pos.mpr."
+    },
+    {
+      "id": "log-convexity",
+      "title": "§ Literal Log-Convexity",
+      "startLine": 101,
+      "endLine": 118,
+      "summary": "catalan_logConvex takes logarithms of the positive Turán inequality: Real.log_lt_log on the strictly positive sides, then Real.log_pow (log x² = 2 log x) and Real.log_mul (log xy = log x + log y), yields the midpoint convexity of n ↦ log catalan n, namely 2·log catalan(n+1) < log catalan n + log catalan(n+2)."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "§ Sanity Checks",
+      "startLine": 120,
+      "endLine": 128,
+      "summary": "Three example instantiations of turan_nat at n = 0, 1, 2 confirm the inequality at small indices. Because catalan does not kernel-reduce under decide, these are discharged by applying the proven theorem rather than by evaluation."
+    }
+  ],
   "conclusion": {
     "summary": "Because the Catalan recurrence ratio r n strictly increases (upstream ratio_strictMono), the Catalan numbers are strictly log-convex: the Turán inequality catalan(n+1)² < catalan n · catalan(n+2) holds over both ℝ and ℕ, with gap r n · catalan(n)² · (r(n+1) − r n) > 0. Equivalent phrasings are positivity of the 2×2 Hankel minor catalan n · catalan(n+2) − catalan(n+1)² and the literal log-convexity 2·log catalan(n+1) < log catalan n + log catalan(n+2). The deficit δ n = 6/(n+2) is correspondingly strictly decreasing, refining the parent's δ n → 0. All six theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The entry exhibits a named structural property of the Catalan numbers — log-convexity / the Turán inequality — as a direct consequence of the recurrence-ratio monotonicity established upstream, complementing the sibling entries that study the growth rate and the 3/2 critical exponent. The factored gap localises the whole phenomenon in the single increment r(n+1) − r n, and the Hankel-minor phrasing connects it to determinant positivity of the Catalan moment sequence.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-03` (quality 68, pass 0).

## Changes
- **Added a `sections` array** (was missing — the sibling `-oq-02` already had one): 5 sections covering the full 128-line Lean file — module header/imports, the monotone deficit descent, the Turán inequality block (ratio increment → real → ℕ → Hankel minor), literal log-convexity, and the sanity checks.
- **Deepened all 5 annotations** with `significance`, `relatedConcepts`, and `prerequisites` fields (previously only `content` + `mathContext`).
- **Added one annotation** for the previously-uncovered `ratio_lt_succ` one-step increment lemma (lines 60–62), the single analytic input the rest of the file consumes.

## Integrity
- No claim changes: `status: verified`, `axiomCount: 0`, `sorries: 0` left intact and consistent with the Lean source (foundational axioms only, no `native_decide`/`sorryAx`).
- meta.json 10.6 KB → 13.3 KB, well within the 60 KB cap; JSON validated; gallery enrichment build step passes.