### PR TITLE
Enrich Gaussian Area Integral (Fubini + Polar Coordinates): add description, overview, sections

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-04-oq-01/meta.json
@@ -22,6 +22,7 @@
     "sorries": 0
   },
   "title": "The Gaussian Area Integral via Fubini + Polar Coordinates: (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)} = π/b",
+  "description": "The classical 'Gaussian polar trick' formalized for real b > 0: the square of the one-dimensional Gaussian integral is realized as a genuine two-dimensional area integral. Fubini (gaussian_sq_eq_integral_plane) turns (∫_ℝ e^{-b x²})² into the planar integral of the product Gaussian ∫_{ℝ²} e^{-b(x²+y²)} via integral_prod_mul and Real.exp_add; the polar change of variables (integral_plane_radial_eq), with Jacobian r from integral_comp_polarCoord_symm, collapses the radially symmetric integrand to r·e^{-b r²}, factoring out the angular length 2π of (-π, π) and the radial primitive ∫_{0}^{∞} r e^{-b r²} = 1/(2b) to give π/b. The b = 1 case yields (∫_ℝ e^{-x²})² = π. Unlike the parent area-of-circle-oq-07-oq-04, which squares Mathlib's closed form (π/b)^{1/2}, this entry exhibits π/b as the literal area integral of the Gaussian over the plane. 122 lines, 5 theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -83,6 +84,67 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The evaluation ∫_ℝ e^{-x²} dx = √π has no elementary antiderivative; the standard trick — attributed to Poisson and a staple of every analysis course (Stein–Shakarchi, *Fourier Analysis*, 2003) — is to square the integral, read the product as a double integral over the plane, and switch to polar coordinates, where the Jacobian r tames the integrand. The same r is the area-distortion factor dx dy = r dr dθ that produces the area πR² of a disc, which is why this computation sits in the area-of-circle family. Mathlib already proves ∫_ℝ e^{-b x²} = (π/b)^{1/2} internally by this very polar argument; the parent area-of-circle-oq-07-oq-04 then squares that closed form. This entry instead reconstructs the trick step by step, making the intermediate planar area integral ∫_{ℝ²} e^{-b(x²+y²)} an explicit object rather than a hidden lemma.",
+    "problemStatement": "For real b > 0, derive (∫_ℝ e^{-b x²})² = π/b by the genuinely two-dimensional route: first (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)} (Fubini), then ∫_{ℝ²} e^{-b(x²+y²)} = π/b (polar change of variables with Jacobian r), so that π/b appears as the literal area integral of the radially symmetric Gaussian over the plane — not as the algebraic square of the one-dimensional value (π/b)^{1/2}.",
+    "proofStrategy": "Two independent halves chained at the end. (Fubini) gaussian_sq_eq_integral_plane expands the square with pow_two and applies integral_prod_mul in reverse, fusing e^{-b x²}·e^{-b y²} into e^{-b(x²+y²)} via Real.exp_add and ring. (Radial primitive) integral_Ioi_mul_exp_neg_mul_sq evaluates ∫_{0}^{∞} r e^{-b r²} = (2b)⁻¹ by transporting Mathlib's complex integral_mul_cexp_neg_mul_sq along ℝ ↪ ℂ (integral_ofReal, setIntegral_congr_fun, exact_mod_cast). (Polar) integral_plane_radial_eq applies integral_comp_polarCoord_symm (Jacobian r) over polarCoord.target = Ioi 0 ×ˢ Ioo (-π) π, uses sin²+cos² = 1 to reduce x²+y² to r², splits radial × angular with setIntegral_prod_mul, and multiplies the radial value (2b)⁻¹ by the angular length 2π (setIntegral_const, volume_real_Ioo_of_le). (Chain) gaussian_sq_eq_pi_div_b composes the two rewrites; gaussian_sq_eq_pi specializes b = 1 with simpa.",
+    "keyInsights": [
+      "**π/b is an area, not an algebraic square.** Squaring the one-dimensional value gives ((π/b)^{1/2})² = π/b only formally; this entry instead produces π/b as the honest Lebesgue integral of e^{-b(x²+y²)} over ℝ², so the rational value (no fractional power) is the *natural* output of the two-dimensional argument rather than an artifact of cancelling a square root.",
+      "**The polar Jacobian r is the whole trick.** The weight p.1 • f(polarCoord.symm p) in integral_comp_polarCoord_symm is exactly the area element dx dy = r dr dθ. It both makes the radial integral ∫ r e^{-b r²} convergent in closed form and is the same r that integrates to the area of a disc — tying the Gaussian normalization constant to the area-of-circle geometry.",
+      "**Reuse over recomputation: ℝ ↪ ℂ transport.** Rather than redo the elementary substitution u = r², the radial primitive is imported from Mathlib's complex integral_mul_cexp_neg_mul_sq and pushed through the field embedding ℝ ↪ ℂ, which preserves the real value of an integrable real integrand — a recurring formalization pattern for borrowing complex-analytic results in real statements.",
+      "**Radial symmetry is the bridge between the two halves.** Fubini produces the product Gaussian e^{-b x²}e^{-b y²}, which equals the radially symmetric e^{-b r²} with r² = x²+y² precisely because the exponent is additive (Real.exp_add). That symmetry is exactly what the polar substitution needs, so the two otherwise-unrelated theorems compose with a single rewrite."
+    ],
+    "prerequisites": [
+      "Lebesgue integration over ℝ and ℝ², the product measure, and Fubini/Tonelli (integral_prod_mul)",
+      "Mathlib's polar change of variables integral_comp_polarCoord_symm with Jacobian r",
+      "Mathlib's complex radial integral integral_mul_cexp_neg_mul_sq for ∫ r e^{-b r²} = 1/(2b)",
+      "Parent area-of-circle-oq-07-oq-04 (the square (∫_ℝ e^{-b x²})² = π/b via the closed form) and grandparent area-of-circle-oq-07 (∫_ℝ e^{-x²} = √π)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header, Imports, and the Open Question",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Imports Mathlib's Gaussian integral, polar-coordinate, and product-integral modules plus Tactic. The docstring states the open question — re-derive (∫_ℝ e^{-b x²})² = π/b through the literal planar integral ∫_{ℝ²} e^{-b(x²+y²)} rather than by squaring (π/b)^{1/2} — and previews the five theorems and the Fubini-then-polar strategy."
+    },
+    {
+      "id": "namespace-setup",
+      "title": "Namespace and Variable",
+      "startLine": 42,
+      "endLine": 46,
+      "summary": "Opens Real, MeasureTheory, Set, enters namespace AreaOfCircleOQ07OQ04OQ01, and fixes the variable b : ℝ shared by all five theorems (the positive Gaussian rate parameter)."
+    },
+    {
+      "id": "radial-primitive",
+      "title": "§ The Radial Primitive ∫ r e^{-b r²} = 1/(2b)",
+      "startLine": 48,
+      "endLine": 66,
+      "summary": "integral_Ioi_mul_exp_neg_mul_sq proves ∫_{0}^{∞} r·e^{-b r²} dr = (2b)⁻¹ for b > 0 by transporting Mathlib's complex integral_mul_cexp_neg_mul_sq through the embedding ℝ ↪ ℂ: integral_ofReal lifts the real integral, setIntegral_congr_fun matches the integrands pointwise (push_cast, ring), the complex value (2b)⁻¹ is substituted, and exact_mod_cast descends back to ℝ."
+    },
+    {
+      "id": "fubini-step",
+      "title": "§ Fubini: Squared Line Integral → Planar Integral",
+      "startLine": 68,
+      "endLine": 79,
+      "summary": "gaussian_sq_eq_integral_plane proves (∫_ℝ e^{-b x²})² = ∫_{ℝ²} e^{-b(x²+y²)}. pow_two expands the square; integral_prod_mul (in reverse) rewrites the product of one-dimensional integrals as the planar integral of the product integrand; a pointwise congr fuses e^{-b x²}·e^{-b y²} into e^{-b(x²+y²)} via Real.exp_add and ring."
+    },
+    {
+      "id": "polar-step",
+      "title": "§ Polar Change of Variables → π/b",
+      "startLine": 81,
+      "endLine": 106,
+      "summary": "integral_plane_radial_eq evaluates ∫_{ℝ²} e^{-b(x²+y²)} = π/b. integral_comp_polarCoord_symm supplies the Jacobian-r form over polarCoord.target = Ioi 0 ×ˢ Ioo (-π) π; sin²+cos² = 1 (nlinarith [Real.sin_sq_add_cos_sq]) reduces x²+y² to r²; setIntegral_prod_mul separates the radial factor r·e^{-b r²} from the constant 1; the radial integral (2b)⁻¹ times the angular length 2π (setIntegral_const, volume_real_Ioo_of_le) gives π/b after field_simp and ring."
+    },
+    {
+      "id": "chain-and-specialize",
+      "title": "§ Chaining to π/b and the b = 1 Constant",
+      "startLine": 108,
+      "endLine": 122,
+      "summary": "gaussian_sq_eq_pi_div_b composes the Fubini and polar rewrites to conclude (∫_ℝ e^{-b x²})² = π/b, routed through the 2-D area integral. gaussian_sq_eq_pi specializes b = 1 with simpa to recover (∫_ℝ e^{-x²})² = π, the area-of-disc constant realized as a planar Gaussian integral."
+    }
+  ],
   "openQuestions": [
     {
       "id": "area-of-circle-oq-07-oq-04-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-04-oq-01` (quality 70, pass 0).

## Changes
This entry had a rich `meta` block (originalContributions, mathlibDependencies), complete annotations, conclusion, references, and openQuestions — but was **missing the top-level `description`, the `overview` block, and the `sections` array** that the gallery renders prominently.

- **Added `description`**: a self-contained summary of the Gaussian polar trick and how this entry differs from its parent (area integral vs. squaring the closed form).
- **Added `overview`**: `historicalContext` (Poisson / Stein–Shakarchi), `problemStatement`, `proofStrategy` (radial primitive → Fubini → polar → chain), `prerequisites`, and 4 `keyInsights` (π/b as a literal area, the polar Jacobian r as the crux, ℝ↪ℂ transport reuse, radial symmetry bridging the two halves).
- **Added `sections`**: 6 sections mapping the full 122-line Lean file (header, namespace, radial primitive, Fubini step, polar step, chain/specialize).
- Annotations left intact — they were already complete (5 with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`).

## Integrity
- No claim changes: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` consistent with the Lean source (foundational axioms only).
- meta.json 9.4 KB → 17.8 KB, well within the 60 KB cap; JSON validated; size guardrail passes.