### PR TITLE
Enrich Lawvere's Fixed-Point Theorem in a CCC: add description, overview, sections

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-01-oq-01/meta.json
@@ -23,6 +23,7 @@
     "sorries": 0
   },
   "title": "Lawvere's Fixed-Point Theorem in a Cartesian Closed Category",
+  "description": "Lawvere's 1969 fixed-point theorem proved at full categorical generality in any cartesian closed category, using Mathlib's CartesianClosed typeclass — a result Mathlib itself lacks. The argument is entirely point-free: global points 𝟙_C ⟶ X replace set elements, the categorical diagonal Δ = lift (𝟙 A) (𝟙 A) replaces the diagonal substitution, and the exponential transpose `name f = curry ((ρ_ A).hom ≫ f)` internalizes morphisms. If some φ : A ⟶ (A ⟹ B) is point-surjective (every f : A ⟶ B is named by a global point of A), then every endomorphism t : B ⟶ B has a fixed point s : 𝟙_C ⟶ B with s ≫ t = s; the proof closes via a β-reduction (lift a a ≫ uncurry φ = a ≫ f) from naturality of uncurry plus the unit coherence (ρ_ A).hom = fst, and a diagonal unfolding from comp_lift. The contrapositive lawvere_cantor packages the Cantor/Russell/Gödel/Tarski/Turing diagonal as a single categorical statement. This answers the headline open question of the parent setoid entry, which had conjectured the CCC reformulation was beyond Lean's term language. 120 lines, 3 theorems, 3 definitions, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -88,6 +89,61 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "In his 1969 paper *Diagonal arguments and cartesian closed categories*, F. William Lawvere distilled the common skeleton of a family of celebrated negative results — Cantor's theorem (|Y| < |2^Y|), Russell's paradox, Gödel's first incompleteness theorem, Tarski's undefinability of truth, and Turing's halting problem — into a single positive statement about cartesian closed categories. Each classical 'diagonal' argument is a contrapositive instance: a fixed-point-free endomorphism of an object B obstructs any sufficiently rich self-parametrization. Yanofsky (2003) gave an accessible re-exposition in the point-surjectivity language used here, and Goldblatt's *Topoi* situates it in elementary topos theory. Despite its foundational role, Mathlib has no Lawvere fixed-point theorem; the parent setoid entry (cantor-diagonalization-oq-04-oq-01) even conjectured that a genuine CCC formulation lay beyond Lean's term language and would need an internal-language layer Mathlib lacks. This entry refutes that, deriving the theorem from Mathlib's existing curry/uncurry adjunction and cartesian-monoidal coherence lemmas.",
+    "problemStatement": "Let C be a cartesian closed category (Mathlib's CartesianClosed) with terminal unit 𝟙_C, and A B : C. Call φ : A ⟶ (A ⟹ B) point-surjective if for every f : A ⟶ B there is a global point a : 𝟙_C ⟶ A with a ≫ φ = name f, where name f = curry ((ρ_ A).hom ≫ f). Theorem (Lawvere): if some φ is point-surjective, then every endomorphism t : B ⟶ B has a fixed point s : 𝟙_C ⟶ B with s ≫ t = s. Equivalently (contrapositive, lawvere_cantor): a fixed-point-free t forbids any point-surjective φ : A ⟶ (A ⟹ B).",
+    "proofStrategy": "Form the diagonal morphism f = lift (𝟙 A) (𝟙 A) ≫ uncurry φ ≫ t : A ⟶ B (the categorical 'f a = t(φ(a)(a))'). Point-surjectivity names it: obtain a : 𝟙_C ⟶ A with a ≫ φ = name f. The claimed fixed point is s = a ≫ f, closed by two equational lemmas. (★/β-reduction) uncurry_natural_left gives uncurry (a ≫ φ) = (A ◁ a) ≫ uncurry φ; rewriting with the naming equation and uncurry_curry yields (A ◁ a) ≫ uncurry φ = (ρ_ A).hom ≫ f, and a calc using lift_whiskerLeft, rightUnitor_hom = fst, and lift_fst collapses this to lift a a ≫ uncurry φ = a ≫ f. (Diagonal unfolding) comp_lift pushes a through Δ to give a ≫ f = (lift a a ≫ uncurry φ) ≫ t. Substituting β into the unfolding gives a ≫ f = (a ≫ f) ≫ t, i.e. s ≫ t = s. lawvere_cantor is then a one-line contrapositive.",
+    "keyInsights": [
+      "**Global points replace elements; point-surjectivity replaces surjectivity.** The single design choice that makes the whole argument formalizable in Mathlib without an internal-language layer is to take morphisms 𝟙_C ⟶ X as the stand-in for 'elements of X' and to phrase the richness hypothesis as point-surjectivity (a ≫ φ = name f) rather than as a Lean-level surjection. Everything else is existing categorical machinery.",
+      "**The exponential transpose `name` is the internalization functor.** name f = curry ((ρ_ A).hom ≫ f) turns a morphism f : A ⟶ B into a global point of the internal hom A ⟹ B. The right unitor ρ_ A is exactly the bookkeeping that lets a morphism out of A be curried into a point of the exponential, and rightUnitor_hom = fst is what later collapses it back to a projection.",
+      "**The whole proof is two equations meeting at a β-reduction.** lift a a ≫ uncurry φ = a ≫ f (evaluating φ(a) at a equals evaluating the diagonal f at a) and a ≫ f = (lift a a ≫ uncurry φ) ≫ t (unfolding the diagonal) are forced to coincide, yielding s ≫ t = s. No object is ever opened up into elements; uncurry_natural_left and comp_lift do all the work.",
+      "**One theorem, many paradoxes.** lawvere_cantor — a fixed-point-free t forbids any point-surjective φ — is the abstract diagonal. Instantiated in Type with t = not on Bool it is Cantor's theorem; in suitable categories the same statement is Russell's paradox, Gödel incompleteness, Tarski undefinability, and the halting problem. The categorical generality is what unifies them.",
+      "**Filling a genuine Mathlib gap.** Mathlib has the curry/uncurry adjunction and cartesian-monoidal coherence but no Lawvere fixed-point theorem; this self-contained 120-line proof is a candidate for upstreaming into CategoryTheory.Closed, and it shows the parent's 'unachievable maximal goal' conjecture was too pessimistic."
+    ],
+    "prerequisites": [
+      "Cartesian closed categories and Mathlib's CartesianClosed / MonoidalClosed typeclasses (Mathlib.CategoryTheory.Monoidal.Closed.Cartesian)",
+      "The curry/uncurry adjunction tensorLeft A ⊣ exp A, the evaluation morphism, and naturality (uncurry_natural_left, uncurry_curry)",
+      "Cartesian monoidal structure: lift, fst, whiskering A ◁ a, the terminal unit 𝟙_C, and the right unitor coherence rightUnitor_hom = fst",
+      "Parent CantorDiagonalizationOQ04OQ01 (the setoid generalization) and Lawvere's fixed-point theorem (1969)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-docstring",
+      "title": "Module Header and the Open Question",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Imports Mathlib's cartesian-closed monoidal module and Tactic. The docstring states the open question (lift the setoid version to any CCC via CartesianClosed), answers YES, and gives the full mathematical setup: the point-surjectivity definition, the statement of Lawvere's theorem, the point-free diagonal argument (β-reduction + diagonal unfolding), and the Cantor/Type corollaries."
+    },
+    {
+      "id": "namespace-setup",
+      "title": "Universes, Namespace, and Variables",
+      "startLine": 54,
+      "endLine": 63,
+      "summary": "Enters namespace LawvereCCC, opens the CategoryTheory monoidal/cartesian-closed namespaces, and fixes a cartesian closed category C with objects A B : C as the ambient setting for every definition and theorem."
+    },
+    {
+      "id": "definitions",
+      "title": "§ Definitions: name, PointSurjective, IsFixedPoint",
+      "startLine": 65,
+      "endLine": 77,
+      "summary": "name f = curry ((ρ_ A).hom ≫ f) is the exponential transpose internalizing a morphism as a global point of A ⟹ B (with the simp lemma name_def). PointSurjective φ asserts every f : A ⟶ B is the name of a global point factored through φ — the categorical replacement for surjectivity of a coding map. IsFixedPoint t s is s ≫ t = s."
+    },
+    {
+      "id": "lawvere-fixedpoint",
+      "title": "§ Lawvere's Fixed-Point Theorem",
+      "startLine": 79,
+      "endLine": 108,
+      "summary": "lawvere_fixedPoint builds the diagonal f = lift (𝟙 A) (𝟙 A) ≫ uncurry φ ≫ t, names it via point-surjectivity (a ≫ φ = name f), and proves s = a ≫ f is a fixed point. The (★) step derives (A ◁ a) ≫ uncurry φ = (ρ_ A).hom ≫ f from uncurry_natural_left and uncurry_curry; the beta calc collapses lift a a ≫ uncurry φ to a ≫ f using lift_whiskerLeft, rightUnitor_hom = fst, and lift_fst; the factI step unfolds the diagonal via comp_lift; substituting yields s ≫ t = s."
+    },
+    {
+      "id": "lawvere-cantor",
+      "title": "§ The Abstract Cantor / Lawvere Contrapositive",
+      "startLine": 110,
+      "endLine": 120,
+      "summary": "lawvere_cantor is the one-line contrapositive: if t : B ⟶ B is fixed-point free, then no φ : A ⟶ (A ⟹ B) is point-surjective. Instantiated with a fixed-point-free endomorphism (e.g. not on a two-element object) this is the abstract Cantor diagonal underlying Cantor, Russell, Gödel, Tarski, and Turing."
+    }
+  ],
   "openQuestions": [
     {
       "id": "cantor-diagonalization-oq-04-oq-01-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-04-oq-01-oq-01` (quality 70, pass 0).

## Changes
Rich `meta` (originalContributions, mathlibDependencies), 7 complete annotations, conclusion, references, and openQuestions were present — but the top-level **`description`, `overview` block, and `sections` array** were missing.

- **Added `description`**: self-contained summary of the point-free Lawvere fixed-point theorem and how it answers the parent's headline open question.
- **Added `overview`**: `historicalContext` (Lawvere 1969 unifying Cantor/Russell/Gödel/Tarski/Turing; Yanofsky, Goldblatt), `problemStatement`, `proofStrategy`, `prerequisites`, and 5 `keyInsights`.
- **Added `sections`**: 5 sections mapping the full 120-line Lean file.
- Annotations untouched (already complete).

## Integrity
- No claim changes: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`, consistent with the Lean source.
- meta.json 10.5 KB → 19.4 KB, within the 60 KB cap; JSON validated.