### PR TITLE
Enrich Erdős #1023 LYM/Antichain Extremal Value: deepen all annotations

### DIFF
--- a/src/data/proofs/erdos-1023-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1023-oq-01-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "insight",
     "title": "One Line Unlocks the Whole LYM Toolbox",
-    "content": "The parent file defines `isAntichain F` as `∀ A B ∈ F, A ⊆ B → A = B` — distinct members are incomparable. That is definitionally Mathlib's `IsAntichain (· ⊆ ·) ↑F`. `toMathlibAntichain` is the one-line term `fun _ ha _ hb hne hsub => hne (h _ ha _ hb hsub)` that performs the bridge, after which Mathlib's entire LYM/Sperner development applies verbatim. Matching the parent's vocabulary to the library's is what makes the rest of the file short."
+    "content": "The parent file defines `isAntichain F` as `∀ A B ∈ F, A ⊆ B → A = B` — distinct members are incomparable. That is definitionally Mathlib's `IsAntichain (· ⊆ ·) ↑F`. `toMathlibAntichain` is the one-line term `fun _ ha _ hb hne hsub => hne (h _ ha _ hb hsub)` that performs the bridge, after which Mathlib's entire LYM/Sperner development applies verbatim. Matching the parent's vocabulary to the library's is what makes the rest of the file short.",
+    "mathContext": "Parent's $\\forall A,B\\in F,\\ A\\subseteq B \\Rightarrow A=B$ is the contrapositive of Mathlib's $\\texttt{IsAntichain}(\\subseteq)$: $A\\ne B \\Rightarrow \\neg(A\\subseteq B)$. The term takes $h_{ne}:A\\ne B$ and $h_{sub}:A\\subseteq B$ and derives $\\bot$ from $h\\,A\\,B\\,h_{sub}:A=B$.",
+    "significance": "key",
+    "relatedConcepts": ["IsAntichain", "order-theoretic vs combinatorial vocabulary", "definitional unfolding", "contrapositive"],
+    "prerequisites": ["Mathlib's IsAntichain on a partial order", "subset order on Finset (Fin n)"]
   },
   {
     "id": "ann-lym",
@@ -19,7 +23,11 @@
     },
     "type": "concept",
     "title": "The LYM Inequality — the Tool the OQ Names",
-    "content": "`lym_inequality` is exactly the inequality the open question asks to use: for an antichain F in 2^[n], ∑_{A∈F} 1/C(n,|A|) ≤ 1. Each member A 'spends' a 1/C(n,|A|) fraction of its layer, and the layers' budgets sum to at most 1. It is the `simpa [Fintype.card_fin]` image of Mathlib's `lubell_yamamoto_meshalkin_inequality_sum_inv_choose`, rewriting Fintype.card (Fin n) = n. Summed against the largest binomial coefficient C(n,⌊n/2⌋), it collapses to Sperner's bound."
+    "content": "`lym_inequality` is exactly the inequality the open question asks to use: for an antichain F in 2^[n], ∑_{A∈F} 1/C(n,|A|) ≤ 1. Each member A 'spends' a 1/C(n,|A|) fraction of its layer, and the layers' budgets sum to at most 1. It is the `simpa [Fintype.card_fin]` image of Mathlib's `lubell_yamamoto_meshalkin_inequality_sum_inv_choose`, rewriting Fintype.card (Fin n) = n. Summed against the largest binomial coefficient C(n,⌊n/2⌋), it collapses to Sperner's bound.",
+    "mathContext": "$\\sum_{A\\in F}\\binom{n}{|A|}^{-1}\\le 1$. Probabilistic reading: a uniformly random maximal chain in $2^{[n]}$ passes through each layer-$k$ set with probability $\\binom{n}{k}^{-1}$, and an antichain meets any chain at most once, so the events are disjoint and their probabilities sum to $\\le 1$ (Lubell's double-counting proof).",
+    "significance": "key",
+    "relatedConcepts": ["Lubell–Yamamoto–Meshalkin inequality", "maximal chains", "double counting", "Bollobás-type bounds"],
+    "prerequisites": ["binomial coefficients C(n,k)", "Mathlib's lubell_yamamoto_meshalkin_inequality_sum_inv_choose", "Fintype.card_fin"]
   },
   {
     "id": "ann-middle",
@@ -30,7 +38,11 @@
     },
     "type": "concept",
     "title": "The Middle Layer Is the Sharp Witness",
-    "content": "`middle n = univ.powersetCard (n/2)` is the family of all ⌊n/2⌋-element subsets. It has size C(n,⌊n/2⌋) (`card_powersetCard`), and it is an antichain because two distinct sets of equal cardinality can never satisfy A ⊆ B (`eq_of_subset_of_card_le`). This makes Sperner's upper bound tight, so the antichain maximum is an exact equality rather than just an inequality."
+    "content": "`middle n = univ.powersetCard (n/2)` is the family of all ⌊n/2⌋-element subsets. It has size C(n,⌊n/2⌋) (`card_powersetCard`), and it is an antichain because two distinct sets of equal cardinality can never satisfy A ⊆ B (`eq_of_subset_of_card_le`). This makes Sperner's upper bound tight, so the antichain maximum is an exact equality rather than just an inequality.",
+    "mathContext": "$|\\,\\binom{[n]}{\\lfloor n/2\\rfloor}\\,| = \\binom{n}{\\lfloor n/2\\rfloor}$, the maximum of $k\\mapsto\\binom{n}{k}$. Equal-cardinality sets are incomparable: $A\\subseteq B$ with $|A|=|B|$ forces $A=B$ (a subset of equal size is the whole set), so the layer is an antichain attaining Sperner's bound.",
+    "significance": "key",
+    "relatedConcepts": ["middle binomial layer", "powersetCard", "tightness / extremal witness", "unimodality of binomial coefficients"],
+    "prerequisites": ["Finset.powersetCard and card_powersetCard", "Finset.eq_of_subset_of_card_le", "max of the binomial coefficient at the central layer"]
   },
   {
     "id": "ann-extremal",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "The Antichain Analogue of Problem 447, Axiom-Free",
-    "content": "`antichainMax_eq` proves the maximum antichain size in 2^[n] is exactly C(n,⌊n/2⌋): `le_antisymm` of Sperner (every antichain is ≤ the bound) and the middle layer (an antichain achieving it). This is the axiom-free analogue of the parent's axiomatized `problem_447_solution` — but for antichains rather than the broader 2-union-free families."
+    "content": "`antichainMax_eq` proves the maximum antichain size in 2^[n] is exactly C(n,⌊n/2⌋): `le_antisymm` of Sperner (every antichain is ≤ the bound) and the middle layer (an antichain achieving it). This is the axiom-free analogue of the parent's axiomatized `problem_447_solution` — but for antichains rather than the broader 2-union-free families.",
+    "mathContext": "$\\max\\{|F| : F\\ \\text{antichain in } 2^{[n]}\\} = \\binom{n}{\\lfloor n/2\\rfloor}$ (Sperner's theorem). Proved by $\\texttt{le\\_antisymm}$: the $\\le$ direction is $\\texttt{csSup\\_le}$ over all antichains (each $\\le$ the bound), the $\\ge$ direction is $\\texttt{le\\_csSup}$ exhibiting the middle layer as a witness in the size set.",
+    "significance": "key",
+    "relatedConcepts": ["Sperner's theorem", "extremal set theory", "sSup over a bounded family", "le_antisymm"],
+    "prerequisites": ["sSup / csSup_le / le_csSup on bounded-above subsets of ℕ", "the antichain size set is nonempty and bddAbove"]
   },
   {
     "id": "ann-gap",
@@ -52,6 +68,10 @@
     },
     "type": "insight",
     "title": "How Far LYM Reaches — and Where Erdős–Kleitman Begins",
-    "content": "`antichain_twoUnionFree` shows antichains are 2-union-free: if A = B ∪ C with B ≠ A, then B ⊊ A ∈ F contradicts the antichain property. Hence `twoUnionFree_max_ge_middle`: C(n,⌊n/2⌋) ≤ sup{2-union-free sizes}, the lower-bound half of `problem_447_solution`, axiom-free. But the converse fails — a 2-union-free family may contain comparable pairs (it need not be an antichain) and can be larger. The statement that no 2-union-free family exceeds C(n,⌊n/2⌋) is the genuinely deeper Erdős–Kleitman theorem, NOT a corollary of LYM, and so remains the open analytic core of the parent axiom."
+    "content": "`antichain_twoUnionFree` shows antichains are 2-union-free: if A = B ∪ C with B ≠ A, then B ⊊ A ∈ F contradicts the antichain property. Hence `twoUnionFree_max_ge_middle`: C(n,⌊n/2⌋) ≤ sup{2-union-free sizes}, the lower-bound half of `problem_447_solution`, axiom-free. But the converse fails — a 2-union-free family may contain comparable pairs (it need not be an antichain) and can be larger. The statement that no 2-union-free family exceeds C(n,⌊n/2⌋) is the genuinely deeper Erdős–Kleitman theorem, NOT a corollary of LYM, and so remains the open analytic core of the parent axiom.",
+    "mathContext": "Antichain $\\subseteq$ 2-union-free, so $\\binom{n}{\\lfloor n/2\\rfloor} \\le \\sup\\{|F| : F\\ \\text{2-union-free}\\}$ (the $\\ge$ half of Problem 447). The reverse inequality $\\sup \\le \\binom{n}{\\lfloor n/2\\rfloor}$ is Erdős–Kleitman and is strictly stronger: 2-union-free families can contain chains, so LYM/Sperner do not bound them.",
+    "significance": "supporting",
+    "relatedConcepts": ["2-union-free families", "Erdős–Kleitman theorem", "Problem 447", "scope of LYM", "axiom-free lower bound"],
+    "prerequisites": ["subset_union_left and strict containment", "the parent's isTwoUnionFree definition", "why antichain ⊊ 2-union-free as classes"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-1023-oq-01-oq-01` (quality 70, pass 0).

## Changes
The `meta` side was already complete (description, overview, 5 sections, conclusion, mainTheorems, references) — but the **5 annotations carried only `content`**, missing the depth fields.

- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations:
  - the `IsAntichain` bridge, the LYM inequality (with Lubell's chain-counting reading), the middle-layer sharp witness, the axiom-free antichain extremal value, and the honest LYM-vs-Erdős–Kleitman scope gap.

## Integrity
- No claim changes: `status: verified`, `axiomCount: 0`, `sorries: 0`. The entry is careful to mark the 2-union-free upper bound as the *open* Erdős–Kleitman core (not closed by LYM); annotations preserve that honest framing.
- JSON validated; meta.json unchanged and within the 60 KB cap.