### PR TITLE
Enrich Zolotarev Quadratic Reciprocity: deepen all 8 annotations

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 167, "endLine": 182 },
     "type": "definition",
     "title": "The grid transpose (perfect-shuffle) permutation",
-    "content": "gridTranspose m n is the row-major ↔ column-major reindexing of Fin (m*n), realized as a permutation. It sends the row-major index n·i+j (cell in row i, column j) to the column-major index m·j+i. This is the permutation γ whose sign carries the reciprocity factor in Zolotarev's argument."
+    "content": "gridTranspose m n is the row-major ↔ column-major reindexing of Fin (m*n), realized as a permutation. It sends the row-major index n·i+j (cell in row i, column j) to the column-major index m·j+i. This is the permutation γ whose sign carries the reciprocity factor in Zolotarev's argument.",
+    "mathContext": "$\\gamma : \\mathrm{Fin}(mn)\\to\\mathrm{Fin}(mn)$, $n\\cdot i + j \\mapsto m\\cdot j + i$ for $i<m,\\ j<n$ — the transpose of the $m\\times n$ grid read as $\\mathbb{Z}/mn$. Equivalently $\\gamma$ is the 'perfect shuffle' / riffle permutation on $mn$ cards.",
+    "significance": "key",
+    "relatedConcepts": ["perfect shuffle", "row-major/column-major indexing", "Equiv.Perm", "transpose of a rectangular array"],
+    "prerequisites": ["Euclidean division Fin (m*n) ≅ Fin m × Fin n", "permutations as Equiv.Perm"]
   },
   {
     "id": "ann-eqr-zqr-signgridtranspose",
@@ -13,7 +17,11 @@
     "range": { "startLine": 297, "endLine": 394 },
     "type": "theorem",
     "title": "Sign of the grid transpose = (-1)^(C(m,2)·C(n,2)) — the combinatorial gap closed",
-    "content": "sign_gridTranspose: the single ingredient every sibling had delegated to Mathlib's legendreSym.quadratic_reciprocity. Proved by Equiv.Perm.sign_eq_prod_prod_Iio (sign as a product over inversions) and a Finset.card_bij' bijection counting the C(m,2)·C(n,2) inversion pairs (i,j),(i',j') with i<i' but j>j'. No number theory — pure combinatorics of the shuffle."
+    "content": "sign_gridTranspose: the single ingredient every sibling had delegated to Mathlib's legendreSym.quadratic_reciprocity. Proved by Equiv.Perm.sign_eq_prod_prod_Iio (sign as a product over inversions) and a Finset.card_bij' bijection counting the C(m,2)·C(n,2) inversion pairs (i,j),(i',j') with i<i' but j>j'. No number theory — pure combinatorics of the shuffle.",
+    "mathContext": "$\\mathrm{sgn}(\\gamma) = (-1)^{\\binom{m}{2}\\binom{n}{2}}$. An inversion of $\\gamma$ is a pair of cells $(i,j),(i',j')$ with $i<i'$ (row-major earlier) but $m j + i > m j' + i'$ (column-major later), forcing $j>j'$; the count is $\\binom{m}{2}\\binom{n}{2}$ (choose the two rows and the two columns).",
+    "significance": "key",
+    "relatedConcepts": ["sign as parity of inversions", "Equiv.Perm.sign_eq_prod_prod_Iio", "Finset.card_bij'", "Zolotarev's lemma"],
+    "prerequisites": ["sign of a permutation via inversions", "counting inversions by a bijection", "binomial coefficient C(·,2)"]
   },
   {
     "id": "ann-eqr-zqr-paritybridge",
@@ -21,7 +29,11 @@
     "range": { "startLine": 395, "endLine": 428 },
     "type": "theorem",
     "title": "Parity bridge: inversion count → textbook reciprocity exponent",
-    "content": "neg_one_pow_choose_two_mul_odd: for odd m,n, (-1)^(C(m,2)·C(n,2)) = (-1)^(((m-1)/2)·((n-1)/2)). The elementary number-theory step that converts Zolotarev's inversion count into the classical reciprocity exponent. Independent of sign_gridTranspose; together they give sign_gridTranspose_odd."
+    "content": "neg_one_pow_choose_two_mul_odd: for odd m,n, (-1)^(C(m,2)·C(n,2)) = (-1)^(((m-1)/2)·((n-1)/2)). The elementary number-theory step that converts Zolotarev's inversion count into the classical reciprocity exponent. Independent of sign_gridTranspose; together they give sign_gridTranspose_odd.",
+    "mathContext": "For odd $m$, $\\binom{m}{2} = \\tfrac{m(m-1)}{2} \\equiv \\tfrac{m-1}{2} \\pmod 2$ (since $m$ is odd), so $\\binom{m}{2}\\binom{n}{2} \\equiv \\tfrac{m-1}{2}\\cdot\\tfrac{n-1}{2}\\pmod 2$ and the two signs agree.",
+    "significance": "supporting",
+    "relatedConcepts": ["parity of binomial coefficients", "reciprocity exponent (p-1)/2·(q-1)/2", "mod-2 arithmetic"],
+    "prerequisites": ["C(m,2) = m(m-1)/2", "parity reasoning for odd m, n"]
   },
   {
     "id": "ann-eqr-zqr-skeleton",
@@ -29,7 +41,11 @@
     "range": { "startLine": 491, "endLine": 521 },
     "type": "theorem",
     "title": "The three-transition skeleton: QR from a sign tautology",
-    "content": "quadratic_reciprocity_of_transition_signs: for any diagonal order D and the per-line hypotheses sign(rowOrder∘D⁻¹) = (q/p), sign(colOrder∘D⁻¹) = (p/q), the tautological composition τ_cd⁻¹∘τ_rd = τ_rc plus multiplicativity of sign and sign_gridTranspose_odd give (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2). The abstract heart of the argument: QR is what a sign identity becomes once the three transition signs are known."
+    "content": "quadratic_reciprocity_of_transition_signs: for any diagonal order D and the per-line hypotheses sign(rowOrder∘D⁻¹) = (q/p), sign(colOrder∘D⁻¹) = (p/q), the tautological composition τ_cd⁻¹∘τ_rd = τ_rc plus multiplicativity of sign and sign_gridTranspose_odd give (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2). The abstract heart of the argument: QR is what a sign identity becomes once the three transition signs are known.",
+    "mathContext": "Three reindexings of $\\mathbb{Z}/pq$ — row order, column order, diagonal (CRT) order — satisfy $\\tau_{cd}^{-1}\\circ\\tau_{rd} = \\tau_{rc}$ (the grid transpose). Applying $\\mathrm{sgn}$ (a homomorphism) gives $\\big(\\tfrac{q}{p}\\big)\\big(\\tfrac{p}{q}\\big) = \\mathrm{sgn}(\\tau_{rc}) = (-1)^{\\frac{p-1}{2}\\frac{q-1}{2}}$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicativity of sign (group homomorphism)", "CRT reindexing of ℤ/pq", "composition of transitions", "Legendre symbol"],
+    "prerequisites": ["sign : Equiv.Perm → ℤˣ is a homomorphism", "the three grid orders and their composition identity", "sign_gridTranspose_odd"]
   },
   {
     "id": "ann-eqr-zqr-signaddleftodd",
@@ -37,7 +53,11 @@
     "range": { "startLine": 551, "endLine": 557 },
     "type": "theorem",
     "title": "Translation is an even permutation on an odd-order group (absent from Mathlib)",
-    "content": "sign_addLeft_odd: for odd n, the translation x ↦ b+x of ℤ/n has sign +1. Its order divides n (since n•b = 0), hence is odd, while sign lands in the order-2 group ℤˣ; an odd power of the sign equals the sign, and that power is sign 1 = 1. This lets the affine line sign reduce to the multiplication sign."
+    "content": "sign_addLeft_odd: for odd n, the translation x ↦ b+x of ℤ/n has sign +1. Its order divides n (since n•b = 0), hence is odd, while sign lands in the order-2 group ℤˣ; an odd power of the sign equals the sign, and that power is sign 1 = 1. This lets the affine line sign reduce to the multiplication sign.",
+    "mathContext": "For $b\\in\\mathbb{Z}/n$, the translation $\\tau_b$ has order dividing $n$ (odd). Since $\\mathrm{sgn}(\\tau_b)\\in\\{\\pm1\\}$ has order dividing $\\gcd(n,2)=1$, $\\mathrm{sgn}(\\tau_b)=+1$: an odd-order element maps to the identity of an order-2 group.",
+    "significance": "supporting",
+    "relatedConcepts": ["order of a group element", "translation/regular representation", "sign homomorphism into ℤˣ", "coprime orders"],
+    "prerequisites": ["element order divides group order", "homomorphism kills odd-order elements into ℤ/2", "Equiv.Perm.sign of addLeft"]
   },
   {
     "id": "ann-eqr-zqr-affineline",
@@ -45,7 +65,11 @@
     "range": { "startLine": 576, "endLine": 583 },
     "type": "theorem",
     "title": "Per-line Zolotarev sign: sign(x ↦ a·x + b on ℤ/p) = (A/p)",
-    "content": "sign_affineLine_eq_legendreSym: for an odd prime p, unit a, translation b, and integer A ≡ a (mod p), the sign of the affine permutation is the Legendre symbol (A/p). Combines sign_addLeft_odd (translation is even) with the parent's Zolotarev/Frobenius identity sign(x ↦ a·x on ℤ/n) = J(A|n). This is the sign of a single residue line of the CRT transitions."
+    "content": "sign_affineLine_eq_legendreSym: for an odd prime p, unit a, translation b, and integer A ≡ a (mod p), the sign of the affine permutation is the Legendre symbol (A/p). Combines sign_addLeft_odd (translation is even) with the parent's Zolotarev/Frobenius identity sign(x ↦ a·x on ℤ/n) = J(A|n). This is the sign of a single residue line of the CRT transitions.",
+    "mathContext": "$\\mathrm{sgn}(x\\mapsto ax+b) = \\mathrm{sgn}(x\\mapsto ax)\\cdot\\mathrm{sgn}(x\\mapsto x+b) = \\big(\\tfrac{A}{p}\\big)\\cdot 1 = \\big(\\tfrac{A}{p}\\big)$ — Zolotarev's lemma: multiplication by $a$ is even iff $a$ is a quadratic residue mod $p$.",
+    "significance": "important",
+    "relatedConcepts": ["Zolotarev's lemma", "affine group of ℤ/p", "Legendre symbol as a sign", "Frobenius / multiplication permutation"],
+    "prerequisites": ["sign_addLeft_odd", "parent identity sign(mulLeft a) = Jacobi/Legendre symbol", "factoring an affine map into linear ∘ translation"]
   },
   {
     "id": "ann-eqr-zqr-crtorder",
@@ -53,7 +77,11 @@
     "range": { "startLine": 667, "endLine": 725 },
     "type": "definition",
     "title": "Closing the gap: the concrete CRT order discharges the transition signs",
-    "content": "crtOrder is the diagonal order whose inverse is the Chinese-remainder map z ↦ (z mod p, z mod q) through ZMod.finEquiv. sign_rowTransition conjugates crtOrder⁻¹∘rowOrder by arrEquiv to realize it literally as Equiv.prodCongrLeft of the affine line map x ↦ q·x + j, then sign_prodCongrLeft_affineLine collapses the q-fold product to the single Legendre symbol (q/p) (q odd). sign_colTransition is dual, giving (p/q)."
+    "content": "crtOrder is the diagonal order whose inverse is the Chinese-remainder map z ↦ (z mod p, z mod q) through ZMod.finEquiv. sign_rowTransition conjugates crtOrder⁻¹∘rowOrder by arrEquiv to realize it literally as Equiv.prodCongrLeft of the affine line map x ↦ q·x + j, then sign_prodCongrLeft_affineLine collapses the q-fold product to the single Legendre symbol (q/p) (q odd). sign_colTransition is dual, giving (p/q).",
+    "mathContext": "CRT: $\\mathbb{Z}/pq \\cong \\mathbb{Z}/p \\times \\mathbb{Z}/q$. The row transition is a product of $q$ parallel copies of the affine line $x\\mapsto qx+j$ on $\\mathbb{Z}/p$; $\\mathrm{sgn}$ of a $\\texttt{prodCongrLeft}$ of identical odd-indexed factors is the single factor's sign $\\big(\\tfrac{q}{p}\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "ZMod.finEquiv / ZMod.chineseRemainder", "Equiv.prodCongrLeft", "sign of a product permutation"],
+    "prerequisites": ["CRT isomorphism ℤ/pq ≅ ℤ/p × ℤ/q", "conjugation invariance of sign", "sign_affineLine_eq_legendreSym", "sign of prodCongrLeft"]
   },
   {
     "id": "ann-eqr-zqr-capstone",
@@ -61,6 +89,10 @@
     "range": { "startLine": 787, "endLine": 798 },
     "type": "theorem",
     "title": "Quadratic reciprocity, unconditional, à la Zolotarev",
-    "content": "zolotarev_quadratic_reciprocity: for distinct odd primes p, q, legendreSym q p · legendreSym p q = (-1)^(((p-1)/2)·((q-1)/2)). Assembled from the parent's Frobenius identity (per-line signs), the inversion count of the grid transpose, and the three-transition skeleton, with crtOrder discharging both transition-sign hypotheses. 0 sorries, axioms [propext, Classical.choice, Quot.sound] only, and NO appeal to Mathlib's legendreSym.quadratic_reciprocity."
+    "content": "zolotarev_quadratic_reciprocity: for distinct odd primes p, q, legendreSym q p · legendreSym p q = (-1)^(((p-1)/2)·((q-1)/2)). Assembled from the parent's Frobenius identity (per-line signs), the inversion count of the grid transpose, and the three-transition skeleton, with crtOrder discharging both transition-sign hypotheses. 0 sorries, axioms [propext, Classical.choice, Quot.sound] only, and NO appeal to Mathlib's legendreSym.quadratic_reciprocity.",
+    "mathContext": "$\\big(\\tfrac{q}{p}\\big)\\big(\\tfrac{p}{q}\\big) = (-1)^{\\frac{p-1}{2}\\cdot\\frac{q-1}{2}}$ — the law of quadratic reciprocity (Gauss), here via Zolotarev/Frobenius (permutation signs) rather than Gauss sums or Eisenstein lattice-point counting.",
+    "significance": "key",
+    "relatedConcepts": ["law of quadratic reciprocity", "Zolotarev's proof", "Legendre symbol multiplicativity", "self-contained alternative to Mathlib's QR"],
+    "prerequisites": ["all preceding lemmas (grid transpose sign, parity bridge, transition skeleton, crtOrder)", "Legendre symbol legendreSym", "distinct odd primes"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02` (quality 70, pass 0).

## Changes
The `meta` side was already complete (description, overview, 5 sections, conclusion, references, crossReferences) for this 817-line Zolotarev permutation-sign proof of quadratic reciprocity — but the **8 annotations carried only `content`**.

- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 8 annotations:
  - the grid-transpose (perfect-shuffle) permutation, its sign = (-1)^(C(m,2)·C(n,2)) via inversion counting, the parity bridge to the textbook exponent, the three-transition sign skeleton, translation-is-even on odd groups, the per-line affine Zolotarev sign, the CRT order discharging the transition signs, and the unconditional capstone.

## Integrity
- No claim changes: `status: verified`, `axiomCount: 0`, `sorries: 0`; the entry's notable point — no appeal to Mathlib's `legendreSym.quadratic_reciprocity` — is preserved in the annotations.
- JSON validated; meta.json unchanged and within the 60 KB cap.