### PR TITLE
Enrich Erdős #396 Central-Binomial 1/2-Exponent: add sections, deepen annotations

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -9,7 +9,10 @@
     "type": "key-step",
     "title": "Mathlib's recurrence as a ratio step",
     "content": "Mathlib's $\\texttt{Nat.succ\\_mul\\_centralBinom\\_succ}$ states $(n+1)\\,C(2(n+1),n+1) = 2(2n+1)\\,C(2n,n)$. Casting to $\\mathbb{R}$, clearing the denominator with $\\texttt{field\\_simp}$, and closing with $\\texttt{linear\\_combination}$ gives the multiplicative reading $C(2(n+1),n+1) = s\\,n \\cdot C(2n,n)$ with $s\\,n = (4n+2)/(n+1) = 4 - 2/(n+1)$. This is the exact analogue of the Catalan ratio $r\\,n = 4 - 6/(n+2)$.",
-    "mathContext": "$s\\,n = \\dfrac{2(2n+1)}{n+1} = \\dfrac{4n+2}{n+1} = 4 - \\dfrac{2}{n+1}$."
+    "mathContext": "$s\\,n = \\dfrac{2(2n+1)}{n+1} = \\dfrac{4n+2}{n+1} = 4 - \\dfrac{2}{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient C(2n,n)", "consecutive-ratio of a recurrence", "Nat.succ_mul_centralBinom_succ", "linear_combination tactic"],
+    "prerequisites": ["Mathlib's central binomial recurrence", "casting ℕ identities to ℝ (push_cast)", "field_simp / linear_combination"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-ratioquarter",
@@ -21,7 +24,10 @@
     "type": "key-step",
     "title": "The 1/2 appears in one normalised step",
     "content": "Dividing the ratio by the limiting rate $4$ gives $s\\,k/4 = 1 - (1/2)/(k+1)$. The coefficient $1/2$ of the harmonic correction is *exactly* the critical exponent of the central-binomial asymptotic $C(2n,n) \\sim 4^n/\\sqrt{\\pi n}$, exposed before any summation or limit. Compare the Catalan coefficient $3/2$ from the shifted tail $6/(k+2)$: here the deficit $2/(k+1)$ is the *un-shifted* harmonic tail.",
-    "mathContext": "$\\dfrac{s\\,k}{4} = \\dfrac{1}{4}\\left(4 - \\dfrac{2}{k+1}\\right) = 1 - \\dfrac{1/2}{k+1}$."
+    "mathContext": "$\\dfrac{s\\,k}{4} = \\dfrac{1}{4}\\left(4 - \\dfrac{2}{k+1}\\right) = 1 - \\dfrac{1/2}{k+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["critical exponent 1/2", "harmonic deficit", "normalisation by the limiting growth rate 4", "comparison with Catalan 3/2"],
+    "prerequisites": ["the ratio identity s n = 4 − 2/(n+1)", "field_simp / ring"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-logle",
@@ -33,7 +39,10 @@
     "type": "key-step",
     "title": "Elementary log bound on each step",
     "content": "The single Mathlib inequality $\\log y \\le y - 1$ (valid for $y > 0$, $\\texttt{Real.log\\_le\\_sub\\_one\\_of\\_pos}$) at $y = s\\,k/4$ gives $\\log(s\\,k/4) \\le s\\,k/4 - 1 = -(1/2)/(k+1)$. No analytic estimate is used — just one elementary convexity inequality applied termwise.",
-    "mathContext": "$\\log\\!\\left(\\dfrac{s\\,k}{4}\\right) \\le \\dfrac{s\\,k}{4} - 1 = -\\dfrac{1/2}{k+1}$."
+    "mathContext": "$\\log\\!\\left(\\dfrac{s\\,k}{4}\\right) \\le \\dfrac{s\\,k}{4} - 1 = -\\dfrac{1/2}{k+1}$.",
+    "significance": "important",
+    "relatedConcepts": ["log y ≤ y − 1", "concavity of log / tangent-line bound", "Real.log_le_sub_one_of_pos", "termwise estimation"],
+    "prerequisites": ["the elementary inequality log y ≤ y − 1 for y > 0", "positivity of the normalised step"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-logge",
@@ -45,7 +54,10 @@
     "type": "key-step",
     "title": "Matching lower bound from the reciprocal",
     "content": "Applying the *same* inequality to the reciprocal $(s\\,k/4)^{-1}$ and using $\\log(x^{-1}) = -\\log x$ gives $\\log(s\\,k/4) \\ge -((s\\,k/4)^{-1} - 1) = -1/(2k+1)$, since $(s\\,k/4)^{-1} - 1 = 1/(2k+1)$ by $\\texttt{field\\_simp}$. The log step is thus pinned from both sides by harmonic-type terms with the same leading coefficient $1/2$.",
-    "mathContext": "$\\left(\\dfrac{s\\,k}{4}\\right)^{-1} - 1 = \\dfrac{2(k+1)}{2k+1} - 1 = \\dfrac{1}{2k+1}$."
+    "mathContext": "$\\left(\\dfrac{s\\,k}{4}\\right)^{-1} - 1 = \\dfrac{2(k+1)}{2k+1} - 1 = \\dfrac{1}{2k+1}$.",
+    "significance": "important",
+    "relatedConcepts": ["reciprocal trick log(x⁻¹) = −log x", "two-sided harmonic bracketing", "Real.log_inv", "leading coefficient 1/2"],
+    "prerequisites": ["log y ≤ y − 1 applied to (s k/4)⁻¹", "Real.log_inv", "field_simp identity for the reciprocal deficit"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-telescope",
@@ -57,7 +69,10 @@
     "type": "key-step",
     "title": "Telescoping the recurrence through the logarithm",
     "content": "Because each step multiplies by $s\\,k$, the normalised value $C(2m,m)/4^m$ obeys $C(2(m+1),m+1)/4^{m+1} = (s\\,m/4)\\cdot(C(2m,m)/4^m)$. Induction with $\\texttt{Real.log\\_mul}$ (both factors positive) collapses the product into the exact finite sum $\\log(C(2n,n)/4^n) = \\sum_{k<n} \\log(s\\,k/4)$.",
-    "mathContext": "$\\log\\!\\left(\\dfrac{C(2n,n)}{4^n}\\right) = \\sum_{k<n} \\log\\!\\left(\\dfrac{s\\,k}{4}\\right)$."
+    "mathContext": "$\\log\\!\\left(\\dfrac{C(2n,n)}{4^n}\\right) = \\sum_{k<n} \\log\\!\\left(\\dfrac{s\\,k}{4}\\right)$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping product → sum", "Real.log_mul", "induction on n", "Finset.sum_range_succ"],
+    "prerequisites": ["log of a product is the sum of logs (positive factors)", "the normalised recurrence step", "induction with Finset.range"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-normlogle",
@@ -69,7 +84,10 @@
     "type": "key-step",
     "title": "Summing to the harmonic bound −(1/2)·Hₙ",
     "content": "Summing the per-step bound with $\\texttt{Finset.sum\\_le\\_sum}$ and recognising $\\sum_{k<n} (1/2)/(k+1) = (1/2)\\,H_n$ (via $\\texttt{Finset.mul\\_sum}$ against the parent's $\\texttt{realHarmonic}$) gives $\\log(C(2n,n)/4^n) \\le -(1/2)\\,H_n$. Here the harmonic sum appears *un-shifted* as $H_n = \\sum_{k<n} 1/(k+1)$, where the Catalan version produced $H_{n+1} - 1$.",
-    "mathContext": "$\\log\\!\\left(\\dfrac{C(2n,n)}{4^n}\\right) \\le -\\tfrac{1}{2}\\,H_n,\\quad H_n = \\sum_{k<n}\\dfrac{1}{k+1}$."
+    "mathContext": "$\\log\\!\\left(\\dfrac{C(2n,n)}{4^n}\\right) \\le -\\tfrac{1}{2}\\,H_n,\\quad H_n = \\sum_{k<n}\\dfrac{1}{k+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["harmonic number Hₙ", "Finset.sum_le_sum", "Finset.mul_sum", "realHarmonic (parent definition)"],
+    "prerequisites": ["monotonicity of finite sums", "the parent's realHarmonic = ∑_{k<n} 1/(k+1)", "the per-step log upper bound"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-headline",
@@ -81,7 +99,10 @@
     "type": "insight",
     "title": "Headline: the 1/2-exponent decay bound",
     "content": "Exponentiating via $x = \\exp(\\log x)$ and monotonicity gives the headline $C(2n,n)/4^n \\le \\exp(-(1/2)\\,H_n)$. Since $H_n \\sim \\log n$, the right side is $\\sim n^{-1/2}$: the recurrence *alone* forces the critical exponent $1/2$ of $C(2n,n) \\sim 4^n/\\sqrt{\\pi n}$, with no Stirling estimate anywhere in the chain.",
-    "mathContext": "$\\dfrac{C(2n,n)}{4^n} \\le \\exp\\!\\left(-\\tfrac{1}{2}H_n\\right) \\sim n^{-1/2}.$"
+    "mathContext": "$\\dfrac{C(2n,n)}{4^n} \\le \\exp\\!\\left(-\\tfrac{1}{2}H_n\\right) \\sim n^{-1/2}.$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial asymptotic 4ⁿ/√(πn)", "Hₙ ∼ log n", "exp ∘ log monotonicity", "Stirling-free derivation"],
+    "prerequisites": ["Real.exp_log and Real.exp_le_exp", "the harmonic log bound", "asymptotic Hₙ ∼ log n (context, not used in the proof)"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-bridge",
@@ -93,7 +114,10 @@
     "type": "insight",
     "title": "One linear factor separates 3/2 from 1/2",
     "content": "The identity $C(2n,n) = (n+1)\\,\\text{catalan}\\,n$ ($\\texttt{succ\\_mul\\_catalan\\_eq\\_centralBinom}$) means the two normalised sequences differ by exactly the factor $n+1$. That single linear factor is the *entire* difference between the exponents: $3/2 = 1/2 + 1$. The recurrence-level analysis makes the relationship between the two classical asymptotics fully transparent.",
-    "mathContext": "$\\dfrac{\\text{catalan}\\,n}{4^n} = \\dfrac{1}{n+1}\\cdot\\dfrac{C(2n,n)}{4^n}\\ \\Longrightarrow\\ n^{-3/2} = (n+1)^{-1}\\,n^{-1/2}.$"
+    "mathContext": "$\\dfrac{\\text{catalan}\\,n}{4^n} = \\dfrac{1}{n+1}\\cdot\\dfrac{C(2n,n)}{4^n}\\ \\Longrightarrow\\ n^{-3/2} = (n+1)^{-1}\\,n^{-1/2}.$",
+    "significance": "insight",
+    "relatedConcepts": ["C(2n,n) = (n+1)·catalan n", "polynomial decay exponents 1/2 vs 3/2", "succ_mul_catalan_eq_centralBinom", "sibling Catalan entry"],
+    "prerequisites": ["the Catalan ↔ central binomial identity", "the sibling 3/2-exponent result for catalan n"]
   },
   {
     "id": "ann-e396oq04oq01oq01oq02oq02-squeeze",
@@ -105,6 +129,9 @@
     "type": "key-step",
     "title": "Independent, rate-quantified convergence",
     "content": "The bound $\\exp(-(1/2)H_n) \\to 0$ holds purely because the harmonic series diverges ($\\texttt{realHarmonic\\_tendsto\\_atTop}$, times $-1/2 < 0 \\to \\texttt{atBot}$, then $\\texttt{Real.tendsto\\_exp\\_atBot}$). Squeezing $0 \\le C(2n,n)/4^n \\le \\exp(-(1/2)H_n)$ gives $C(2n,n)/4^n \\to 0$ with an explicit rate, independently of Stirling.",
-    "mathContext": "$0 \\le \\dfrac{C(2n,n)}{4^n} \\le \\exp\\!\\left(-\\tfrac{1}{2}H_n\\right) \\to 0.$"
+    "mathContext": "$0 \\le \\dfrac{C(2n,n)}{4^n} \\le \\exp\\!\\left(-\\tfrac{1}{2}H_n\\right) \\to 0.$",
+    "significance": "important",
+    "relatedConcepts": ["squeeze theorem (squeeze_zero)", "divergence of the harmonic series", "Real.tendsto_exp_atBot", "Tendsto.const_mul_atTop_of_neg"],
+    "prerequisites": ["realHarmonic_tendsto_atTop (parent)", "Real.tendsto_exp_atBot", "squeeze_zero"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -50,6 +50,64 @@
       "The identity C(2n,n) = (n+1)·catalan n (succ_mul_catalan_eq_centralBinom) and the squeeze theorem for sequences"
     ]
   },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Docstring framing the entry as the central-binomial analogue of the sibling Catalan 3/2-exponent file: Mathlib's recurrence (n+1)·C(2(n+1),n+1) = 2(2n+1)·C(2n,n) reads as the ratio s n = 4 − 2/(n+1), whose normalised step s k/4 = 1 − (1/2)/(k+1) exposes the critical exponent 1/2. Imports Mathlib and the parent Proofs.Erdos396OQ04OQ01OQ01, opening its namespace to reuse realHarmonic and realHarmonic_tendsto_atTop."
+    },
+    {
+      "id": "ratio-step",
+      "title": "§ The Central-Binomial Recurrence Ratio s n",
+      "startLine": 56,
+      "endLine": 76,
+      "summary": "cbRatio n = (4n+2)/(n+1) defines the ratio of consecutive central binomial coefficients; cbRatio_pos gives positivity. centralBinom_succ_eq_ratio_mul casts Mathlib's Nat.succ_mul_centralBinom_succ to ℝ and, via field_simp and linear_combination, proves the multiplicative reading C(2(n+1),n+1) = s n · C(2n,n)."
+    },
+    {
+      "id": "normalised-step",
+      "title": "§ The Normalised Step s k / 4 and Its Logarithm",
+      "startLine": 78,
+      "endLine": 120,
+      "summary": "cbRatioQuarter_eq rewrites the step as s k/4 = 1 − (1/2)/(k+1) (positivity via cbRatioQuarter_pos). log_cbRatioQuarter_le applies Real.log_le_sub_one_of_pos to get log(s k/4) ≤ −(1/2)/(k+1); log_cbRatioQuarter_ge applies the same inequality to the reciprocal (Real.log_inv, field_simp) for the matching lower bound −1/(2k+1)."
+    },
+    {
+      "id": "telescoping",
+      "title": "§ Telescoping the Recurrence Through the Logarithm",
+      "startLine": 121,
+      "endLine": 144,
+      "summary": "normLog_eq_sum proves the exact identity log(C(2n,n)/4^n) = ∑_{k<n} log(s k/4) by induction: each step factors as (s m/4)·(C(2m,m)/4^m), and Real.log_mul (positive factors) turns the product into the sum over Finset.range."
+    },
+    {
+      "id": "exponent-bound",
+      "title": "§ The 1/2-Exponent Bound",
+      "startLine": 145,
+      "endLine": 192,
+      "summary": "normLog_le sums the per-step bound (Finset.sum_le_sum, Finset.mul_sum against realHarmonic) to log(C(2n,n)/4^n) ≤ −(1/2)·H_n. centralBinom_div_le_exp exponentiates to the headline C(2n,n)/4^n ≤ exp(−(1/2)·H_n) ∼ n^{−1/2}; centralBinom_le_exp_mul is the multiplicative form; normLog_bracket pins the log between two harmonic-type sums both with coefficient 1/2."
+    },
+    {
+      "id": "catalan-link",
+      "title": "§ Structural Link to the Catalan 3/2 Exponent",
+      "startLine": 194,
+      "endLine": 213,
+      "summary": "centralBinom_eq_succ_mul_catalan proves C(2n,n) = (n+1)·catalan n over ℝ, and catalan_div_eq_centralBinom_div divides through by the linear factor. The factor n+1 is exactly the difference between the 1/2 exponent here and the sibling's 3/2 exponent (3/2 = 1/2 + 1 at the level of polynomial decay)."
+    },
+    {
+      "id": "convergence",
+      "title": "§ Independent Convergence with Explicit Rate",
+      "startLine": 214,
+      "endLine": 231,
+      "summary": "expBound_tendsto_zero shows exp(−(1/2)·H_n) → 0 from the divergence of the harmonic series (realHarmonic_tendsto_atTop, const_mul_atTop_of_neg, Real.tendsto_exp_atBot). centralBinom_div_tendsto_zero then squeezes 0 ≤ C(2n,n)/4^n ≤ exp(−(1/2)·H_n) to prove the normalised central binomials vanish — Stirling-free, with explicit rate."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "§ Sanity Checks",
+      "startLine": 232,
+      "endLine": 248,
+      "summary": "Four example instantiations confirm the formulas at small indices: s 0/4 = 1/2, the per-step bound at k=0 is −1/2, and the structural identity C(2n,n) = (n+1)·catalan n at n = 0 (1 = 1·1) and n = 1 (2 = 2·1)."
+    }
+  ],
   "conclusion": {
     "summary": "The central-binomial recurrence, normalised by its limiting rate, forces C(2n,n)/4^n ≤ exp(−(1/2)·H_n), equivalently C(2n,n) ≤ 4^n·exp(−(1/2)·H_n). Since H_n ∼ log n the bound is ∼ n^{−1/2}, exhibiting the critical exponent 1/2 of C(2n,n) ∼ 4^n/√(πn) at the level of the integer recurrence. A reciprocal estimate brackets log(C(2n,n)/4^n) between two harmonic-type sums both with coefficient 1/2, and a squeeze gives an independent proof that C(2n,n)/4^n → 0. The identity C(2n,n) = (n+1)·catalan n ties the result to the sibling's 3/2 exponent: the linear factor n+1 is exactly the difference 3/2 = 1/2 + 1. All fifteen theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The entry closes the sibling's second open question: the same one-line logarithm inequality plus harmonic divergence that produced the Catalan 3/2 exponent produces the central-binomial 1/2 exponent, with no Stirling estimate. Making the structural identity C(2n,n) = (n+1)·catalan n explicit shows the two classical asymptotics are a single recurrence-level phenomenon separated by one linear factor, and the matching reciprocal bound shows each exponent is two-sided.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02` (quality 70, pass 0).

## Changes
The entry had description, overview, and conclusion, and 9 annotations with `content`+`mathContext` — but **no `sections` array** and the annotations lacked the depth fields.

- **Added `sections`**: 8 sections mapping the full 248-line Lean file (header, ratio step, normalised step + log bounds, telescoping, the 1/2-exponent bound, the Catalan 3/2 link, independent convergence, sanity checks).
- **Deepened all 9 annotations** with `significance`, `relatedConcepts`, and `prerequisites`.

## Integrity
- No claim changes: `status: verified`, `axiomCount: 0`, `sorries: 0`. The Stirling-free framing and the 3/2 = 1/2 + 1 structural link are preserved.
- meta.json 12.1 KB → 15.9 KB, within the 60 KB cap; JSON validated.