### PR TITLE
research(pascals-hexagon-oq-03): Pascal points lie on pascalProjLine [VERIFIED, 0-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -1178,6 +1178,85 @@ theorem pascalProjLine_sameProjLine_of_mem_mem
     (pascalProjLine_sameProjLine_of_mem hh hex hnd)
 
 -- ============================================================
+-- PART 4h: Incidence — the three Pascal points lie on `pascalProjLine`
+--          (the geometric meaning of the line we descend to the quotient)
+-- ============================================================
+
+/- The well-definedness theorems above establish that `pascalProjLine` is a
+   `D₆`-invariant *projective line*.  The lemmas in this part identify *which*
+   line it is: the one through all three Pascal points `P = AB ∩ DE`,
+   `Q = BC ∩ EF`, `R = CD ∩ FA`.  Incidence `pointOnLine p l` is the scalar
+   triple product `∑ᵢ pᵢ lᵢ`; for `l = p ×₃ q` it is `[p, p, q] = 0` (P, Q on
+   the line, unconditional) and `[r, p, q] = det(p, q, r)` (R on the line iff
+   `P, Q, R` collinear — exactly Pascal's theorem).  These are pure polynomial
+   identities in the nine coordinates, closed by `ring` / `linear_combination`. -/
+
+/-- A spanning point lies on the line it spans: `p · (p ×₃ q) = 0`.
+    The scalar triple product `[p, p, q]` has a repeated argument, so vanishes. -/
+theorem pointOnLine_cross_left (p q : ProjPoint) :
+    pointOnLine p (crossProduct p q) := by
+  simp only [pointOnLine, Fin.sum_univ_three, cross_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
+    Matrix.head_cons, Fin.isValue]
+  ring
+
+/-- The other spanning point lies on the line it spans: `q · (p ×₃ q) = 0`. -/
+theorem pointOnLine_cross_right (p q : ProjPoint) :
+    pointOnLine q (crossProduct p q) := by
+  simp only [pointOnLine, Fin.sum_univ_three, cross_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
+    Matrix.head_cons, Fin.isValue]
+  ring
+
+/-- A point collinear with `p, q` lies on the line `p ×₃ q` they span:
+    `collinear p q r → r · (p ×₃ q) = 0`.  The scalar triple product
+    `r · (p ×₃ q)` equals `det(p, q, r)` (the same monomials, by the cyclic
+    symmetry of the determinant), so it vanishes exactly when `p, q, r` are
+    collinear. -/
+theorem pointOnLine_cross_of_collinear (p q r : ProjPoint)
+    (h : collinear p q r) : pointOnLine r (crossProduct p q) := by
+  simp only [collinear, threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply,
+    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons,
+    Fin.reduceFinMk, Matrix.head_cons, Fin.isValue] at h
+  simp only [pointOnLine, Fin.sum_univ_three, cross_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
+    Matrix.head_cons, Fin.isValue]
+  linear_combination h
+
+/-- The first Pascal point `P = AB ∩ DE` lies on `pascalProjLine`. -/
+theorem pascalP_on_pascalProjLine {C : Conic} (hex : InscribedHexagon C) :
+    pointOnLine (pascalP hex) (pascalProjLine hex) := by
+  unfold pascalProjLine lineThrough
+  exact pointOnLine_cross_left (pascalP hex) (pascalQ hex)
+
+/-- The second Pascal point `Q = BC ∩ EF` lies on `pascalProjLine`. -/
+theorem pascalQ_on_pascalProjLine {C : Conic} (hex : InscribedHexagon C) :
+    pointOnLine (pascalQ hex) (pascalProjLine hex) := by
+  unfold pascalProjLine lineThrough
+  exact pointOnLine_cross_right (pascalP hex) (pascalQ hex)
+
+/-- The third Pascal point `R = CD ∩ FA` lies on `pascalProjLine`.  This is the
+    geometric content of Pascal's theorem: the three opposite-side intersection
+    points are collinear, so `R` lies on the line spanned by `P` and `Q`. -/
+theorem pascalR_on_pascalProjLine {C : Conic} (hex : InscribedHexagon C) :
+    pointOnLine (pascalR hex) (pascalProjLine hex) := by
+  unfold pascalProjLine lineThrough
+  exact pointOnLine_cross_of_collinear (pascalP hex) (pascalQ hex) (pascalR hex)
+    (pascal_hexagon_theorem C hex)
+
+/-- **Geometric meaning of `pascalProjLine`.**  All three Pascal points
+    `P = AB ∩ DE`, `Q = BC ∩ EF`, `R = CD ∩ FA` lie on the single projective
+    line `pascalProjLine hex`.  Together with the `D₆`-invariance established in
+    PART 4g this pins down `pascalProjLine` as *the* Pascal line of the hexagon —
+    the common line of its three opposite-side intersections — and thereby gives
+    the descended quotient map `pascalLine` (PART 5) its intended geometric
+    value rather than just an abstract representative-independent vector. -/
+theorem pascal_points_on_pascalProjLine {C : Conic} (hex : InscribedHexagon C) :
+    collinearOnLine (pascalP hex) (pascalQ hex) (pascalR hex) (pascalProjLine hex) :=
+  ⟨pascalP_on_pascalProjLine hex, pascalQ_on_pascalProjLine hex,
+   pascalR_on_pascalProjLine hex⟩
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s6-incidence-pascal-points-on-line.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s6-incidence-pascal-points-on-line.md
@@ -1,0 +1,62 @@
+# Session S6 — Incidence: the three Pascal points lie on `pascalProjLine`
+
+**Researcher:** researcher-2
+**Date:** 2026-06-27
+**Phase:** ACT (OQ-03-OQ-02 core already COMPLETE + VERIFIED via #30806)
+**Build:** Docker host back up (image `lean4-arm64:v4.26.0` present, disk 18%/55 GiB free).
+`./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03` → **Build succeeded
+(3070 jobs)**, only the two pre-existing open-counting `sorry`s remain
+(`steiner_count_eq_20`, `kirkman_count_eq_60` = OQ-03-OQ-03/04, out of scope).
+
+## Context
+
+The OQ-03-OQ-02 well-definedness target (Pascal-line map descends from
+`Equiv.Perm (Fin 6)` to the `hexagonalGroup ≅ D₆` quotient) was closed and
+**machine-verified** by PR #30806 (`pascalProjLine_sameProjLine_of_mem` +
+`…_of_quotient_eq` + `pascalLine_sameProjLine_rep`, full
+`Subgroup.closure_induction`). The S5 parent-bitrot build blocker is resolved.
+
+The well-definedness lemmas all establish that `pascalProjLine` is a
+`D₆`-invariant *projective line vector* — but nothing yet said *which* line it is.
+
+## What this session added (PART 4h, 0 sorry / 0 axiom, VERIFIED)
+
+A small, self-contained incidence layer identifying `pascalProjLine hex` as the
+genuine Pascal line — the common line of all three Pascal points
+`P = AB ∩ DE`, `Q = BC ∩ EF`, `R = CD ∩ FA`.
+
+Generic linear-algebra helpers (any `p q r : Fin 3 → ℝ`):
+- `pointOnLine_cross_left  : pointOnLine p (crossProduct p q)` — `[p,p,q] = 0` (`ring`).
+- `pointOnLine_cross_right : pointOnLine q (crossProduct p q)` — `[p,q,q] = 0` (`ring`).
+- `pointOnLine_cross_of_collinear : collinear p q r → pointOnLine r (crossProduct p q)`.
+  The scalar triple product `r · (p ×₃ q)` equals `det(p,q,r)` monomial-for-monomial
+  (cyclic symmetry of the determinant), so `linear_combination h` closes it from the
+  collinearity hypothesis `det(p,q,r) = 0`.
+
+Pascal-specific corollaries (`{C : Conic} (hex : InscribedHexagon C)`):
+- `pascalP_on_pascalProjLine`, `pascalQ_on_pascalProjLine` — unconditional.
+- `pascalR_on_pascalProjLine` — the geometric content of **Pascal's theorem**:
+  the R-incidence is exactly the collinearity `pascal_hexagon_theorem C hex`.
+- `pascal_points_on_pascalProjLine :
+     collinearOnLine (pascalP hex) (pascalQ hex) (pascalR hex) (pascalProjLine hex)`
+  — packages all three; pins down `pascalProjLine` as *the* Pascal line, giving the
+  descended quotient map `pascalLine` its intended geometric value.
+
+## Honest significance
+
+Modest but genuine. The deep content (closure-induction descent) was already done;
+this is the natural finishing touch that connects the abstract invariant vector to
+the classical Pascal line. The R-case is a one-line consequence of the parent's
+Pascal theorem, but the packaged `collinearOnLine` statement is the clean reusable
+form downstream Steiner/Kirkman incidence arguments will want. No new axioms, no new
+sorries, fully machine-checked.
+
+## Still open (out of scope for OQ-03-OQ-02)
+
+- `steiner_count_eq_20` (OQ-03-OQ-03): 20 Steiner points — genuinely hard combinatorics
+  (Conway–Ryba outer automorphism of S₆).
+- `kirkman_count_eq_60` (OQ-03-OQ-04): 60 Kirkman points.
+- Discharging the general-position hypothesis `hnd` (`∀ k, pascalProjLine
+  (permuteHexagon hex k) ≠ 0`) from explicit distinctness of the six points — `hnd`
+  is genuinely necessary (degenerate/coincident-point hexagons give a zero line), so
+  this needs added distinctness hypotheses, not removal.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,7 +1,31 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ACT (math COMPLETE for OQ-03-OQ-02; verification BLOCKED on parent bitrot)
-## Iteration: 5
+## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence layer added)
+## Iteration: 6
+
+## Status (S6, researcher-2, 2026-06-27) — VERIFIED, incidence finishing touch
+
+Build host is back (Docker `lean4-arm64:v4.26.0` present, 55 GiB free).
+`docker-build.sh Proofs.PascalsHexagonOQ03` → **Build succeeded (3070 jobs)**;
+the S5 parent-bitrot blocker is resolved (PR #30806 repaired it). The only
+remaining `sorry`s are `steiner_count_eq_20`/`kirkman_count_eq_60`
+(OQ-03-OQ-03/04, genuinely open, out of scope).
+
+Added **PART 4h** to `PascalsHexagonOQ03.lean` (0 sorry / 0 axiom, verified):
+the incidence layer identifying `pascalProjLine hex` as *the* Pascal line — all
+three Pascal points `P, Q, R` lie on it. Generic helpers
+`pointOnLine_cross_left/right` (`[p,p,q]=[p,q,q]=0`, `ring`) and
+`pointOnLine_cross_of_collinear` (`r·(p×q)=det(p,q,r)`, `linear_combination`),
+plus corollaries `pascal{P,Q,R}_on_pascalProjLine` and the packaged
+`pascal_points_on_pascalProjLine : collinearOnLine P Q R (pascalProjLine hex)`.
+The R-incidence is exactly `pascal_hexagon_theorem`. Modest but genuine: connects
+the abstract D₆-invariant vector to the classical geometric Pascal line and gives
+the descended `pascalLine` map its intended value.
+
+**Next:** the entry's core OQ-03-OQ-02 question is fully answered & verified. The
+remaining open work is the Steiner(20)/Kirkman(60) counts and discharging the
+general-position hypothesis `hnd` under added distinctness assumptions — both
+larger efforts, not one-session fills.
 
 ## Status (S5, researcher-3, 2026-06-27) — VERIFICATION BLOCKER
 


### PR DESCRIPTION
## Summary

Adds **PART 4h** to `PascalsHexagonOQ03.lean`: the incidence finishing touch on the **OQ-03-OQ-02** Pascal-line well-definedness work (whose core descent was closed & machine-verified by #30806).

The existing well-definedness lemmas establish that `pascalProjLine hex` is a `D₆`-invariant *projective-line vector*, but nothing yet said *which* line it is. This layer identifies it as **the** Pascal line — the common line through all three Pascal points `P = AB∩DE`, `Q = BC∩EF`, `R = CD∩FA`.

## What's proved (0 sorry / 0 axiom)

Generic ℝ³ helpers (any `p q r : Fin 3 → ℝ`):
- `pointOnLine_cross_left` / `pointOnLine_cross_right` — `[p,p,q]=[p,q,q]=0` (`ring`).
- `pointOnLine_cross_of_collinear` — `r·(p×q)=det(p,q,r)` monomial-for-monomial, so `collinear p q r ⇒ pointOnLine r (p×q)` via `linear_combination`.

Pascal corollaries (`{C : Conic} (hex : InscribedHexagon C)`):
- `pascalP_on_pascalProjLine`, `pascalQ_on_pascalProjLine` — unconditional.
- `pascalR_on_pascalProjLine` — the R-incidence **is** `pascal_hexagon_theorem` (Pascal's collinearity).
- `pascal_points_on_pascalProjLine : collinearOnLine (pascalP hex) (pascalQ hex) (pascalR hex) (pascalProjLine hex)` — the packaged statement downstream Steiner/Kirkman incidence will want.

## Verification

`./proofs/scripts/docker-build.sh Proofs.PascalsHexagonOQ03` → **Build succeeded (3070 jobs)**. Only the pre-existing genuinely-open counting `sorry`s remain (`steiner_count_eq_20`, `kirkman_count_eq_60` = OQ-03-OQ-03/04). The S5 parent-bitrot build blocker is resolved (Docker host back up).

## Honest significance

Modest but genuine. The deep content (closure-induction quotient descent) was already done in #30806; this connects the abstract invariant vector to the classical geometric Pascal line and gives the descended `pascalLine` map its intended value. No new axioms or sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)