### PR TITLE
research(sperner-ndim-oq-02): reconstruction theorem — GridSimplex determined by (verts 0, miss, incDir)

### DIFF
--- a/proofs/Proofs/SpernerGridBase.lean
+++ b/proofs/Proofs/SpernerGridBase.lean
@@ -457,4 +457,75 @@ theorem GridSimplex.last_coord_miss (s : GridSimplex d N) :
     (s.verts 0).coords s.miss - d := by
   simpa using s.miss_coord_at (Fin.last d)
 
+-- ============================================================
+-- SECTION VII: Full coordinate formula & reconstruction
+-- ============================================================
+-- `last_coord_non_miss`/`last_coord_miss` above only pin the LAST
+-- vertex. Here we give the general per-vertex formula for a
+-- non-miss coordinate at an ARBITRARY vertex, and then the
+-- reconstruction theorem: a `GridSimplex` is uniquely determined
+-- by the triple `(verts 0, miss, incDir)`. This is the arithmetic
+-- backbone making the Phase-1 canonical-representative predicate
+-- well-posed — per-geometry uniqueness reduces to it.
+
+/-- General formula for a non-miss coordinate at an arbitrary
+vertex `m`: coordinate `incDir k` equals its base value, plus one
+exactly when step `k` has already occurred (`k.val < m.val`).
+Specializes to `last_coord_non_miss` at `m = Fin.last d` (where
+`k.val < d` always holds). -/
+theorem GridSimplex.coord_incDir_at (s : GridSimplex d N)
+    (k : Fin d) (m : Fin (d + 1)) :
+    (s.verts m).coords (s.incDir k) =
+    (s.verts 0).coords (s.incDir k) + (if k.val < m.val then 1 else 0) := by
+  by_cases h : k.val < m.val
+  · -- m ≥ k.succ: value = value at k.succ = value at k.castSucc + 1 = base + 1.
+    simp only [h, if_true]
+    have hge : k.succ ≤ m := by
+      rw [Fin.le_def, Fin.val_succ]; omega
+    have hafter := s.incDir_const_after k m hge
+    have hbefore := s.incDir_const_before k k.castSucc le_rfl
+    rw [hafter, s.step_inc k, hbefore]
+  · -- m ≤ k.castSucc: coordinate not yet incremented, value = base.
+    simp only [h, if_false, Nat.add_zero]
+    have hle : m ≤ k.castSucc := by
+      rw [Fin.le_def, Fin.coe_castSucc]; omega
+    exact s.incDir_const_before k m hle
+
+/-- **Reconstruction theorem.** A `GridSimplex` is uniquely
+determined by its base vertex `verts 0`, its `miss` direction, and
+its increment-direction function `incDir`: every coordinate of
+every vertex is fixed by these three (miss coordinate via
+`miss_coord_at`, every other coordinate via `coord_incDir_at`).
+This is what makes the Phase-1 canonical-representative predicate
+well-posed — distinct canonical encodings of the same geometric
+cell are ruled out by reducing to equality of `(verts 0, miss,
+incDir)`. -/
+theorem GridSimplex.eq_of_base_miss_incDir (s t : GridSimplex d N)
+    (hbase : s.verts 0 = t.verts 0)
+    (hmiss : s.miss = t.miss)
+    (hinc : s.incDir = t.incDir) :
+    s = t := by
+  have hverts : s.verts = t.verts := by
+    funext m
+    apply BaryPoint.ext
+    funext j
+    by_cases hj : j = s.miss
+    · -- miss coordinate: determined by `miss_coord_at` + base + miss.
+      subst hj
+      rw [s.miss_coord_at m, hmiss, t.miss_coord_at m, hbase]
+    · -- non-miss coordinate: pick the unique step `k` with `incDir k = j`
+      -- and apply the general formula on both sides.
+      obtain ⟨k, hk⟩ := s.incDir_surj_complement j hj
+      have hL : (s.verts m).coords j
+          = (s.verts 0).coords j + (if k.val < m.val then 1 else 0) := by
+        rw [← hk]; exact s.coord_incDir_at k m
+      have htk : t.incDir k = j := by rw [← hinc]; exact hk
+      have hR : (t.verts m).coords j
+          = (t.verts 0).coords j + (if k.val < m.val then 1 else 0) := by
+        rw [← htk]; exact t.coord_incDir_at k m
+      rw [hL, hR, hbase]
+  cases s; cases t
+  simp only at hverts hmiss hinc
+  subst hverts; subst hmiss; subst hinc; rfl
+
 end SpernerGrid

--- a/research/problems/sperner-ndim-oq-02/knowledge.md
+++ b/research/problems/sperner-ndim-oq-02/knowledge.md
@@ -636,3 +636,76 @@ lemmas (base + miss + the increasing incDir determine all vertices).
    (transport `onFace` via `SpernerNDimOQ02.onFace_toVertex`).
 4. Phase 2: last-face-door-oddness by induction; apply `sperner_ndim`.
 5. Retire false `boundary_doors_odd`/`boundary_verts_on_face`.
+
+---
+
+## Session 2026-06-27 (Session 8, researcher-3) — Reconstruction theorem (Phase-1 backbone)
+
+**Mode**: ACT (CONTINUE Phase-1). **Outcome**: PROGRESS — added the general
+per-vertex coordinate formula and the **reconstruction theorem** to
+`SpernerGridBase.lean` (now SECTION VII). **Type-check VERIFIED (EXIT 0)** of the
+full file with the additions; **0-axiom by construction**. The `#print axioms`
+confirmation was environmentally blocked (see Infra) but the proofs demonstrably
+elaborate and the bridge file built against them.
+
+### What was delivered (`proofs/Proofs/SpernerGridBase.lean`, SECTION VII, +70 L)
+
+Sessions 6–7 pinned only the LAST vertex (`last_coord_non_miss`,
+`last_coord_miss`). The canonical-representative uniqueness needs every vertex
+fixed. Two new theorems close that:
+
+- `GridSimplex.coord_incDir_at (s) (k m)`:
+  `(verts m).coords (incDir k) = (verts 0).coords (incDir k) + (if k.val < m.val then 1 else 0)`.
+  The general non-miss-coordinate formula at an arbitrary vertex `m` (specializes
+  to `last_coord_non_miss` at `m = last`). Proof: `by_cases k.val < m.val`; the
+  `<` branch chains `incDir_const_after` + `step_inc` + `incDir_const_before`, the
+  `≥` branch is `incDir_const_before` alone. `Fin.le_def`/`Fin.val_succ`/
+  `Fin.coe_castSucc` + `omega` discharge the index arithmetic.
+
+- `GridSimplex.eq_of_base_miss_incDir (s t)`:
+  `verts 0 = ∧ miss = ∧ incDir = ⟹ s = t`. **The reconstruction theorem.**
+  Proof: `funext m; apply BaryPoint.ext; funext j`; split `j = miss`
+  (use `miss_coord_at` both sides) vs `j ≠ miss` (use `incDir_surj_complement`
+  to get `k` with `incDir k = j`, then `coord_incDir_at` both sides); finish the
+  structure equality by `cases s; cases t; subst …; rfl` (mirrors `gridSimplexDecEq`).
+
+**Why this matters (Phase-1 unblock).** Per Sessions 4–5 the `Simplex` carrier is
+`{s : GridSimplex // IsCanon s}` with one canonical encoding per geometric cell.
+The hard obligation is **per-geometry uniqueness** (two canonical cells with the
+same vertex set are equal). With `eq_of_base_miss_incDir`, uniqueness now reduces
+to "same vertex set ⟹ same `(verts 0, miss, incDir)`" — i.e. the geometric
+lex-min-base argument no longer has to also re-derive the chain coordinate-by-
+coordinate; the reconstruction theorem supplies that half outright.
+
+### Verification status (honest)
+
+- **Type-check**: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/SpernerGridBase.lean`
+  → **EXIT 0, clean** (with SECTION VII present). Confirmed early in session.
+- **Bridge**: `SpernerNDimOQ02.lean` built **EXIT 0** importing the olean built
+  from the SECTION-VII source (same session, before host degraded).
+- **`#print axioms`**: NOT obtained this session. The host degraded mid-session
+  (load avg ~10–21 from concurrent agent builds); olean *writes* (`-o`) and
+  fresh full-Mathlib *re-elaborations* began crashing with SIGSEGV/SIGBUS
+  (exit 138/139, **empty logs — no Lean diagnostics**, i.e. environmental, not
+  proof errors). 5+ retry attempts all crashed identically.
+- **0-axiom by construction**: the two proofs use only `omega`, `rw`, `simp only`,
+  `funext`, `by_cases`, `obtain`, `cases`, `subst`, `apply BaryPoint.ext`, `exact`
+  — no `sorry`, no `axiom`, no `decide`/`native_decide`. They build solely on
+  SECTION VI lemmas already verified `{propext, Classical.choice, Quot.sound}`-only
+  in Session 7. So the additions cannot introduce `Lean.ofReduceBool`/`sorryAx`.
+
+### Gotcha (concurrency)
+- A concurrent agent `git checkout`-reverted MAIN's `proofs/Proofs/SpernerGridBase.lean`
+  mid-session (my staged copy → back to HEAD), so a subsequent olean rebuild
+  produced a no-SECTION-VII olean and `#print axioms` reported unknownIdentifier.
+  The edit is safe in the WORKTREE; re-cp before any verify. Source of truth =
+  worktree, never main's working tree (other agents reset it).
+
+### Next steps (unchanged ordering)
+1. **(next)** Define `IsCanon`/`lexLE` (lex order on `BaryPoint`, decidable) and
+   prove per-geometry uniqueness via `eq_of_base_miss_incDir` (now available).
+2. `Simplex := {s : GridSimplex // IsCanon s}`; `vertices`/`vertices_injective`.
+3. `adj` finite facet-search; 5 adjacency fields + `boundary_face`.
+4. Phase 2: last-face-door-oddness by induction; apply `sperner_ndim`.
+5. Re-run `#print axioms` on SECTION VII once host recovers (expected
+   `{propext, Classical.choice, Quot.sound}` only).


### PR DESCRIPTION
## Summary

Phase-1 backbone for `sperner-ndim-oq-02` (boundary-door oddness via the unoriented Freudenthal `SpernerTriangulation` instance). Adds **SECTION VII** to `proofs/Proofs/SpernerGridBase.lean`:

- **`GridSimplex.coord_incDir_at`** — the general per-vertex formula for a non-miss coordinate:
  `(verts m).coords (incDir k) = (verts 0).coords (incDir k) + (if k.val < m.val then 1 else 0)`.
  Generalizes the Session-6/7 last-vertex lemmas (`last_coord_non_miss`) to an arbitrary vertex `m`.
- **`GridSimplex.eq_of_base_miss_incDir`** — the **reconstruction theorem**: a `GridSimplex` is uniquely determined by the triple `(verts 0, miss, incDir)` (every coordinate of every vertex is fixed by these three).

## Why this matters

The Phase-1 `Simplex` carrier is `{s : GridSimplex // IsCanon s}` (one canonical encoding per geometric cell — this is what kills the orientation double-count that makes the original `boundary_doors_odd` false). The hard obligation is **per-geometry uniqueness**. With `eq_of_base_miss_incDir`, that reduces to "same vertex set ⟹ same `(verts 0, miss, incDir)`", so the canonicalization argument no longer has to re-derive the chain coordinate-by-coordinate.

## Verification

- **Type-check VERIFIED**: `LAKE_UNSAFE=1 ./bin/lake env lean Proofs/SpernerGridBase.lean` → **EXIT 0, clean** with SECTION VII present; bridge `SpernerNDimOQ02.lean` built **EXIT 0** against the resulting olean.
- **0-axiom by construction**: proofs use only `omega`, `rw`, `simp only`, `funext`, `by_cases`, `obtain`, `cases`, `subst`, `apply BaryPoint.ext`, `exact` — no `sorry`/`axiom`/`decide`/`native_decide`. Built solely on SECTION VI lemmas already verified `{propext, Classical.choice, Quot.sound}`-only.
- `#print axioms` confirmation was blocked this session by host degradation (concurrent-build load → SIGSEGV on full-Mathlib elaboration, empty logs = environmental, not proof errors). Re-run expected to report the three foundational axioms only.

No sorries or axioms introduced. Pure addition (append-only to `SpernerGridBase.lean`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)