### PR TITLE
Enrich Erdős #396 Exact Wallis Constant 1/√π: add sections, deepen annotations

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01/annotations.json
@@ -9,7 +9,10 @@
     "type": "key-step",
     "title": "The binomial identity (2n)! = C(2n,n)·(n!)²",
     "content": "Specialising $\\texttt{Nat.choose\\_mul\\_factorial\\_mul\\_factorial}$ at $\\binom{2n}{n}$ (using $2n - n = n$) and the definitional $C(2n,n) = \\binom{2n}{n}$ gives $C(2n,n)\\cdot(n!)^2 = (2n)!$ over $\\mathbb{N}$; $\\texttt{exact\\_mod\\_cast}$ lifts it to $\\mathbb{R}$. This is the only number-theoretic input — everything else is real analysis.",
-    "mathContext": "$(2n)! = \\binom{2n}{n}\\,(n!)^2 = C(2n,n)\\,(n!)^2.$"
+    "mathContext": "$(2n)! = \\binom{2n}{n}\\,(n!)^2 = C(2n,n)\\,(n!)^2.$",
+    "significance": "supporting",
+    "relatedConcepts": ["central binomial coefficient", "Nat.choose_mul_factorial_mul_factorial", "factorial identities", "ℕ → ℝ cast"],
+    "prerequisites": ["the choose·factorial·factorial = factorial identity", "definitional centralBinom n = (2n).choose n", "exact_mod_cast"]
   },
   {
     "id": "ann-e396-cbexact-bridge",
@@ -21,7 +24,10 @@
     "type": "key-step",
     "title": "The square-root-free bridge identity",
     "content": "For $n \\ge 1$, $C(2n,n)^2\\,n/16^n = \\operatorname{stirlingSeq}(2n)^2/\\operatorname{stirlingSeq}(n)^4$. The two closed-form $\\texttt{have}$s ($\\texttt{hSn}$, $\\texttt{hS2n}$) compute the squared/fourth-power Stirling expressions: squaring turns $(\\sqrt{4n})^2 = 4n$ and $(\\sqrt{2n})^4 = (2n)^2$, so no square root survives. After substituting $(2n)! = C(2n,n)(n!)^2$ and $((2n)/e)^{2n} = 16^n\\,((n/e)^n)^2$, the identity is a rational function of $\\{C(2n,n), n!, n, 16^n, (n/e)^{4n}\\}$ that $\\texttt{field\\_simp}$ closes outright.",
-    "mathContext": "$\\dfrac{C(2n,n)^2\\,n}{16^n} = \\dfrac{\\operatorname{stirlingSeq}(2n)^2}{\\operatorname{stirlingSeq}(n)^4},\\qquad \\operatorname{stirlingSeq}(n) = \\dfrac{n!}{\\sqrt{2n}\\,(n/e)^n}.$"
+    "mathContext": "$\\dfrac{C(2n,n)^2\\,n}{16^n} = \\dfrac{\\operatorname{stirlingSeq}(2n)^2}{\\operatorname{stirlingSeq}(n)^4},\\qquad \\operatorname{stirlingSeq}(n) = \\dfrac{n!}{\\sqrt{2n}\\,(n/e)^n}.$",
+    "significance": "key",
+    "relatedConcepts": ["Stirling sequence stirlingSeq", "square-root-free algebra", "field_simp", "rational-function identity"],
+    "prerequisites": ["definition of stirlingSeq n = n!/(√(2n)·(n/e)ⁿ)", "Real.sq_sqrt to clear squared roots", "the factorial identity (2n)! = C(2n,n)(n!)²"]
   },
   {
     "id": "ann-e396-cbexact-stirlinglimit",
@@ -33,7 +39,10 @@
     "type": "key-step",
     "title": "Reducing to Mathlib's Stirling limit",
     "content": "Composing $\\texttt{tendsto\\_stirlingSeq\\_sqrt\\_pi}$ with $n \\mapsto 2n$ gives $\\operatorname{stirlingSeq}(2n) \\to \\sqrt{\\pi}$. Then $\\texttt{Tendsto.pow}$ gives $\\operatorname{stirlingSeq}(2n)^2 \\to \\pi$ and $\\operatorname{stirlingSeq}(n)^4 \\to \\pi^2$, and $\\texttt{Tendsto.div}$ gives the ratio $\\to \\pi/\\pi^2 = 1/\\pi$. The bridge identity (on $n \\ge 1$, via $\\texttt{Tendsto.congr'}$) transfers this to $\\bigl(C(2n,n)\\sqrt{n}/4^n\\bigr)^2 \\to 1/\\pi$.",
-    "mathContext": "$\\dfrac{\\operatorname{stirlingSeq}(2n)^2}{\\operatorname{stirlingSeq}(n)^4} \\to \\dfrac{(\\sqrt\\pi)^2}{(\\sqrt\\pi)^4} = \\dfrac{\\pi}{\\pi^2} = \\dfrac1\\pi.$"
+    "mathContext": "$\\dfrac{\\operatorname{stirlingSeq}(2n)^2}{\\operatorname{stirlingSeq}(n)^4} \\to \\dfrac{(\\sqrt\\pi)^2}{(\\sqrt\\pi)^4} = \\dfrac{\\pi}{\\pi^2} = \\dfrac1\\pi.$",
+    "significance": "key",
+    "relatedConcepts": ["Stirling.tendsto_stirlingSeq_sqrt_pi", "Tendsto.pow / Tendsto.div / Tendsto.comp", "Tendsto.congr' (eventual equality)", "Wallis product"],
+    "prerequisites": ["Mathlib's Stirling limit stirlingSeq → √π", "limit arithmetic (products, quotients, composition)", "transferring a limit along an eventual identity"]
   },
   {
     "id": "ann-e396-cbexact-sqrt",
@@ -45,7 +54,10 @@
     "type": "key-step",
     "title": "The final square root: 1/√π",
     "content": "The target sequence is non-negative, so it equals the square root of its square. Applying $\\texttt{Filter.Tendsto.sqrt}$ to $\\bigl(C(2n,n)\\sqrt{n}/4^n\\bigr)^2 \\to 1/\\pi$ and using $\\sqrt{(\\cdot)^2} = \\cdot$ ($\\texttt{Real.sqrt\\_sq}$) together with $\\sqrt{1/\\pi} = 1/\\sqrt{\\pi}$ ($\\texttt{Real.sqrt\\_inv}$) delivers the exact Wallis limit $C(2n,n)\\sqrt{n}/4^n \\to 1/\\sqrt{\\pi}$.",
-    "mathContext": "$\\dfrac{C(2n,n)\\,\\sqrt{n}}{4^n} \\longrightarrow \\dfrac{1}{\\sqrt{\\pi}},\\qquad\\text{i.e.}\\quad C(2n,n) \\sim \\dfrac{4^n}{\\sqrt{\\pi n}}.$"
+    "mathContext": "$\\dfrac{C(2n,n)\\,\\sqrt{n}}{4^n} \\longrightarrow \\dfrac{1}{\\sqrt{\\pi}},\\qquad\\text{i.e.}\\quad C(2n,n) \\sim \\dfrac{4^n}{\\sqrt{\\pi n}}.$",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto.sqrt (continuity of √)", "Real.sqrt_sq", "Real.sqrt_inv", "central binomial asymptotic"],
+    "prerequisites": ["continuity of √ at the limit point", "non-negativity of the normalised sequence", "Real.sqrt_sq / Real.sqrt_inv"]
   },
   {
     "id": "ann-e396-cbexact-bracket",
@@ -57,6 +69,9 @@
     "type": "remark",
     "title": "Recovering the parent's bracket",
     "content": "The exact constant lies inside the parent's elementary bracket: $1/2 \\le 1/\\sqrt{\\pi} \\le 1/\\sqrt{3}$. This is just $\\sqrt{\\pi} \\le \\sqrt{4} = 2$ (from $\\pi < 4$, $\\texttt{Real.pi\\_lt\\_four}$) and $\\sqrt{3} \\le \\sqrt{\\pi}$ (from $3 < \\pi$, $\\texttt{Real.pi\\_gt\\_three}$), via $\\texttt{one\\_div\\_le\\_one\\_div\\_of\\_le}$. The parent could only sandwich the limit between these endpoints; here the single value $1/\\sqrt{\\pi}$ between them is pinned exactly.",
-    "mathContext": "$\\tfrac12 \\le \\tfrac{1}{\\sqrt\\pi} \\le \\tfrac{1}{\\sqrt3} \\iff 3 \\le \\pi \\le 4.$"
+    "mathContext": "$\\tfrac12 \\le \\tfrac{1}{\\sqrt\\pi} \\le \\tfrac{1}{\\sqrt3} \\iff 3 \\le \\pi \\le 4.$",
+    "significance": "supporting",
+    "relatedConcepts": ["bracket recovery / consistency check", "Real.pi_lt_four", "Real.pi_gt_three", "monotonicity of 1/√x"],
+    "prerequisites": ["π bounds 3 < π < 4", "monotonicity of √ and of x ↦ 1/x on positives", "one_div_le_one_div_of_le"]
   }
 ]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01/meta.json
@@ -51,6 +51,50 @@
       "The bounds Real.pi_gt_three and Real.pi_lt_four for the bracket-recovery corollary"
     ]
   },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring placing the entry at the end of the central-binomial thread: the grandparent fixed the 1/2 exponent, its child bracketed the leading constant between 1/2 and 1/√3 (i.e. 3 < π < 4), and this file closes the bracket to the exact Wallis constant 1/√π. Explains the method — route through Mathlib's Stirling sequence via a single square-root-free identity. Imports Mathlib and opens the Stirling namespace."
+    },
+    {
+      "id": "factorial-identity",
+      "title": "§ The Factorial Identity (2n)! = C(2n,n)·(n!)²",
+      "startLine": 50,
+      "endLine": 61,
+      "summary": "two_mul_factorial_eq specialises Nat.choose_mul_factorial_mul_factorial at the central binomial coefficient (using 2n − n = n and centralBinom n = (2n).choose n) and casts to ℝ. This is the lone number-theoretic input feeding the otherwise purely-analytic proof."
+    },
+    {
+      "id": "bridge-identity",
+      "title": "§ The Square-Root-Free Bridge Identity",
+      "startLine": 63,
+      "endLine": 103,
+      "summary": "cb_sq_identity proves, for n ≥ 1, C(2n,n)²·n/16^n = stirlingSeq(2n)²/stirlingSeq(n)⁴. Two closed-form computations (hSn, hS2n) square/fourth-power the Stirling expressions so that (√(4n))² = 4n and (√(2n))⁴ = (2n)² eliminate every root; substituting the factorial identity and ((2n)/e)^{2n} = 16^n·((n/e)^n)² leaves a rational identity that field_simp closes."
+    },
+    {
+      "id": "exact-limit",
+      "title": "§ The Exact Limit 1/√π",
+      "startLine": 104,
+      "endLine": 140,
+      "summary": "centralBinom_mul_sqrt_div_tendsto proves C(2n,n)·√n/4^n → 1/√π. Composing tendsto_stirlingSeq_sqrt_pi with n ↦ 2n and taking powers/quotients gives stirlingSeq(2n)²/stirlingSeq(n)⁴ → π/π² = 1/π; the bridge identity (via Tendsto.congr' eventually for n ≥ 1) transfers this to (C(2n,n)√n/4^n)² → 1/π, and a final Tendsto.sqrt (sequence non-negative, Real.sqrt_sq, Real.sqrt_inv) gives the 1/√π limit."
+    },
+    {
+      "id": "consequences",
+      "title": "§ Consequences: Normalisation and Bracket Recovery",
+      "startLine": 142,
+      "endLine": 155,
+      "summary": "centralBinom_mul_sqrt_pi_div_tendsto_one rescales to C(2n,n)·√(πn)/4^n → 1, the textbook form C(2n,n) ∼ 4^n/√(πn), by multiplying the limit by the constant √π."
+    },
+    {
+      "id": "bracket-recovery",
+      "title": "§ Bracket Recovery",
+      "startLine": 156,
+      "endLine": 167,
+      "summary": "sqrt_pi_inv_mem_bracket shows the exact constant 1/√π lies in the parent's elementary bracket [1/2, 1/√3], equivalently 3 ≤ π ≤ 4, from Real.pi_lt_four and Real.pi_gt_three via monotonicity of √ and of x ↦ 1/x. The parent could only sandwich; this entry pins the single value between the endpoints."
+    }
+  ],
   "conclusion": {
     "summary": "The normalised central binomial coefficient converges to the exact Wallis constant: C(2n,n)·√n/4^n → 1/√π, equivalently C(2n,n) ∼ 4^n/√(πn). The proof rests on a single square-root-free identity C(2n,n)²·n/16^n = stirlingSeq(2n)²/stirlingSeq(n)⁴ that reduces the asymptotic to Mathlib's Stirling limit stirlingSeq → √π; squaring the target sequence is what eliminates the square roots in the Stirling expression, leaving a polynomial identity closed by field_simp. The right side tends to π/π² = 1/π and a final square root yields 1/√π. The parent's elementary bracket 1/2 ≤ 1/√π ≤ 1/√3 (i.e. 3 ≤ π ≤ 4) is recovered as a corollary. All five theorems are fully machine-checked with no axioms or sorries.",
     "implications": "The entry closes the parent's open question on the exact value of the leading constant: the recurrence-only thread bracketed it in [1/2, 1/√3] without analytic input, and this file pins the single point 1/√π using exactly one analytic ingredient — the Wallis product, packaged in Mathlib's tendsto_stirlingSeq_sqrt_pi. The square-root-free bridge identity is a reusable device: any asymptotic of the shape a_n ∼ c/√n can be attacked by squaring to a_n²·n → c² before invoking a Stirling-type limit, sidestepping square-root manipulation in the algebraic core.",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-02-oq-01` (quality 70, pass 0).

## Changes
The entry had description, overview, and conclusion, and 5 annotations with `content`+`mathContext` — but **no `sections` array** and the annotations lacked the depth fields.

- **Added `sections`**: 6 sections mapping the full 167-line Lean file (header, factorial identity, the square-root-free Stirling bridge, the exact 1/√π limit, the C(2n,n) ∼ 4ⁿ/√(πn) normalisation, and bracket recovery).
- **Deepened all 5 annotations** with `significance`, `relatedConcepts`, and `prerequisites`.

## Integrity
- No claim changes: `status: verified`, `axiomCount: 0`, `sorries: 0`. The framing (closing the parent's [1/2, 1/√3] bracket to the exact Wallis constant via Mathlib's Stirling limit, no hand-rolled estimate) is preserved.
- meta.json 13.3 KB → 16.2 KB, within the 60 KB cap; JSON validated.