### PR TITLE
Enrich Zolotarev QR (elementary-quadratic-reciprocity ...oq-02): cross-refs + fix significance

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -67,7 +67,7 @@
     "title": "Per-line Zolotarev sign: sign(x ↦ a·x + b on ℤ/p) = (A/p)",
     "content": "sign_affineLine_eq_legendreSym: for an odd prime p, unit a, translation b, and integer A ≡ a (mod p), the sign of the affine permutation is the Legendre symbol (A/p). Combines sign_addLeft_odd (translation is even) with the parent's Zolotarev/Frobenius identity sign(x ↦ a·x on ℤ/n) = J(A|n). This is the sign of a single residue line of the CRT transitions.",
     "mathContext": "$\\mathrm{sgn}(x\\mapsto ax+b) = \\mathrm{sgn}(x\\mapsto ax)\\cdot\\mathrm{sgn}(x\\mapsto x+b) = \\big(\\tfrac{A}{p}\\big)\\cdot 1 = \\big(\\tfrac{A}{p}\\big)$ — Zolotarev's lemma: multiplication by $a$ is even iff $a$ is a quadratic residue mod $p$.",
-    "significance": "important",
+    "significance": "key",
     "relatedConcepts": ["Zolotarev's lemma", "affine group of ℤ/p", "Legendre symbol as a sign", "Frobenius / multiplication permutation"],
     "prerequisites": ["sign_addLeft_odd", "parent identity sign(mulLeft a) = Jacobi/Legendre symbol", "factoring an affine map into linear ∘ translation"]
   },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -124,6 +124,16 @@
       "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
       "relation": "ancestor",
       "note": "Defines ZolotarevCRT.ringMulPerm and the per-residue multiplication-permutation machinery used here through the parent Frobenius identity for the per-line signs."
+    },
+    {
+      "slug": "quadratic-reciprocity",
+      "relation": "related",
+      "note": "The same law (q/p)·(p/q) = (-1)^((p-1)/2·(q-1)/2) stated and proved as the gallery's canonical Law of Quadratic Reciprocity. This entry is a complementary, self-contained derivation via permutation signs (Zolotarev) that deliberately avoids Mathlib's legendreSym.quadratic_reciprocity."
+    },
+    {
+      "slug": "quadratic-gauss-sum-square",
+      "relation": "related",
+      "note": "An alternative analytic route to quadratic reciprocity through the quadratic Gauss sum g = Σ (a/p) ζ^a, whose square g² = (-1)^((p-1)/2) p underlies the Gauss-sum proof — contrast with the purely combinatorial sign/inversion-count argument used here."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02` (Zolotarev's unconditional permutation-sign proof of quadratic reciprocity).

The entry was already richly enriched by its author (deep overview, 5 key insights, 5 sections, full conclusion, 8 fully-fielded annotations, references) and comfortably under the size cap (18.7 KB). This pass makes two targeted, high-value improvements rather than inflating already-deep prose:

- **Cross-references (navigation):** added 2 `related` links to alternative gallery proofs of the *same* law — `quadratic-reciprocity` (the canonical statement) and `quadratic-gauss-sum-square` (the Gauss-sum route) — so readers can compare the permutation-sign, canonical, and analytic derivations. crossReferences now 4 (cap 20).
- **Correctness fix:** the per-line affine-sign annotation used an invalid `significance` value (`"important"`); normalized to `"key"` (allowed set: key|supporting|technical|context).

meta.json remains 18.7 KB (well under the ~60 KB cap); all per-entry quality minimums were already met. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)