### PR TITLE
Enrich 2D Brouwer via Sperner (intermediate-value-theorem-oq-03-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-03-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 3, "endLine": 55 },
     "type": "context",
     "title": "What this entry discharges — and what it does not",
-    "content": "The parent entry intermediate-value-theorem-oq-03 proves 1D Brouwer from the IVT and then posits the 2D case as the axiom brouwer_2d, naming 'Sperner's lemma + simplicial approximation' as one route to remove it. That route has two halves: a combinatorial half (Sperner's lemma produces arbitrarily fine approximate fixed points) and an analytic half (compactness upgrades them to an exact fixed point). This file supplies the analytic half with full machine verification and states 2D Brouwer as a theorem conditional only on the combinatorial half. It is therefore a verified IMPLICATION, not an unconditional proof — the docstring says so explicitly. The combinatorial half is the verified content of SpernerNDim.lean; assembling it for d = 2 is the next open question."
+    "content": "The parent entry intermediate-value-theorem-oq-03 proves 1D Brouwer from the IVT and then posits the 2D case as the axiom brouwer_2d, naming 'Sperner's lemma + simplicial approximation' as one route to remove it. That route has two halves: a combinatorial half (Sperner's lemma produces arbitrarily fine approximate fixed points) and an analytic half (compactness upgrades them to an exact fixed point). This file supplies the analytic half with full machine verification and states 2D Brouwer as a theorem conditional only on the combinatorial half. It is therefore a verified IMPLICATION, not an unconditional proof — the docstring says so explicitly. The combinatorial half is the verified content of SpernerNDim.lean; assembling it for d = 2 is the next open question.",
+    "mathContext": "Brouwer (1911): every continuous $f : \\Delta^d \\to \\Delta^d$ on the standard $d$-simplex has a fixed point $f(x)=x$. Sperner route factors as $\\text{Sperner lemma} \\Rightarrow (\\forall \\varepsilon>0\\ \\exists x,\\ \\|f(x)-x\\|<\\varepsilon) \\xRightarrow{\\text{compactness}} \\exists x,\\ f(x)=x$. This file is exactly the second arrow.",
+    "significance": "context",
+    "relatedConcepts": ["Brouwer fixed point theorem", "Sperner's lemma", "axiom discharge / conditional theorem", "topological degree"],
+    "prerequisites": ["statement of Brouwer's theorem", "what a Sperner colouring yields", "the distinction between a verified implication and an unconditional proof"]
   },
   {
     "id": "ivt-oq0301-ann-compactness",
@@ -13,7 +17,11 @@
     "range": { "startLine": 67, "endLine": 96 },
     "type": "key-step",
     "title": "The compactness discharge — the analytic core",
-    "content": "exists_fixed_of_approx is the mathematical heart of Sperner ⟹ Brouwer beyond the combinatorics. The displacement g(x) = dist(f x) x is continuous, so on the compact set K it attains a minimum at x₀ (extreme value theorem, IsCompact.exists_isMinOn). The contradiction is the whole point: if dist(f x₀) x₀ > 0, instantiate the ε-approximate hypothesis at ε = dist(f x₀) x₀ to get y ∈ K with dist(f y) y < dist(f x₀) x₀, contradicting that x₀ minimises g. Hence the minimum is 0, i.e. f x₀ = x₀. The lemma is stated for arbitrary dimension d and any nonempty compact K, so it is the approximate-to-exact step for Brouwer in every dimension."
+    "content": "exists_fixed_of_approx is the mathematical heart of Sperner ⟹ Brouwer beyond the combinatorics. The displacement g(x) = dist(f x) x is continuous, so on the compact set K it attains a minimum at x₀ (extreme value theorem, IsCompact.exists_isMinOn). The contradiction is the whole point: if dist(f x₀) x₀ > 0, instantiate the ε-approximate hypothesis at ε = dist(f x₀) x₀ to get y ∈ K with dist(f y) y < dist(f x₀) x₀, contradicting that x₀ minimises g. Hence the minimum is 0, i.e. f x₀ = x₀. The lemma is stated for arbitrary dimension d and any nonempty compact K, so it is the approximate-to-exact step for Brouwer in every dimension.",
+    "mathContext": "Let $g(x)=\\mathrm{dist}(f(x),x)$, continuous on compact $K\\neq\\varnothing$, so $g$ attains a minimum $m=g(x_0)$. If $m>0$, the hypothesis at $\\varepsilon=m$ gives $y\\in K$ with $g(y)<m$ — contradiction. Hence $m=0$ and $\\mathrm{dist}(f(x_0),x_0)=0 \\Rightarrow f(x_0)=x_0$.",
+    "significance": "key",
+    "relatedConcepts": ["extreme value theorem (IsCompact.exists_isMinOn)", "displacement function dist(f x) x", "minimality contradiction", "approximate fixed point"],
+    "prerequisites": ["compact + continuous ⟹ minimum is attained", "dist_nonneg and dist_eq_zero", "Continuous.dist for x ↦ dist (f x) x"]
   },
   {
     "id": "ivt-oq0301-ann-simplex",
@@ -21,7 +29,11 @@
     "range": { "startLine": 102, "endLine": 131 },
     "type": "technique",
     "title": "The simplex compactly, with elementary topology only",
-    "content": "InSimplex d collects the two defining inequalities (all coordinates ≥ 0, total ≤ 1). simplex_isCompact realises the simplex as a closed subset of the compact cube [0,1]^d: it is the intersection of the closed half-spaces {x | 0 ≤ x i} with {x | ∑ x i ≤ 1}, and any simplex point has each coordinate ≤ its total ≤ 1, so it lies in the cube. Compactness then follows from IsCompact.of_isClosed_subset. No manifold structure or degree theory is used — the analytic half of Brouwer needs only that the domain is compact."
+    "content": "InSimplex d collects the two defining inequalities (all coordinates ≥ 0, total ≤ 1). simplex_isCompact realises the simplex as a closed subset of the compact cube [0,1]^d: it is the intersection of the closed half-spaces {x | 0 ≤ x i} with {x | ∑ x i ≤ 1}, and any simplex point has each coordinate ≤ its total ≤ 1, so it lies in the cube. Compactness then follows from IsCompact.of_isClosed_subset. No manifold structure or degree theory is used — the analytic half of Brouwer needs only that the domain is compact.",
+    "mathContext": "$\\Delta^d = \\{x\\in(\\mathrm{Fin}\\,d\\to\\mathbb{R}) : x_i\\ge 0,\\ \\textstyle\\sum_i x_i \\le 1\\}$. Each $x_i \\le \\sum_j x_j \\le 1$, so $\\Delta^d \\subseteq [0,1]^d$, which is compact ($\\prod$ of compact intervals). $\\Delta^d$ is closed (intersection of closed half-spaces), hence compact by closed-subset-of-compact.",
+    "significance": "supporting",
+    "relatedConcepts": ["closed subset of a compact set is compact", "products of compact intervals (isCompact_univ_pi, isCompact_Icc)", "closed half-spaces", "standard d-simplex"],
+    "prerequisites": ["Tychonoff/finite product compactness", "preimages of closed sets under continuous coordinate maps are closed", "IsCompact.of_isClosed_subset"]
   },
   {
     "id": "ivt-oq0301-ann-brouwer2d",
@@ -29,7 +41,11 @@
     "range": { "startLine": 137, "endLine": 173 },
     "type": "key-step",
     "title": "Conditional 2D Brouwer: reducing the axiom to Sperner",
-    "content": "brouwer_2d_of_sperner_approx is the axiom discharge. Its hypothesis happrox — for every ε > 0 a simplex point with each coordinate moved less than ε — is exactly the output of the Sperner displacement colouring. The proof converts that coordinatewise bound into the sup-metric statement dist(f x) x < ε using dist_pi_lt_iff (the metric on Fin 2 → ℝ is the sup metric), then applies exists_fixed_of_approx on the compact, nonempty 2-simplex. The result is a genuine fixed point, with the parent's brouwer_2d axiom now reduced to the combinatorial Sperner property."
+    "content": "brouwer_2d_of_sperner_approx is the axiom discharge. Its hypothesis happrox — for every ε > 0 a simplex point with each coordinate moved less than ε — is exactly the output of the Sperner displacement colouring. The proof converts that coordinatewise bound into the sup-metric statement dist(f x) x < ε using dist_pi_lt_iff (the metric on Fin 2 → ℝ is the sup metric), then applies exists_fixed_of_approx on the compact, nonempty 2-simplex. The result is a genuine fixed point, with the parent's brouwer_2d axiom now reduced to the combinatorial Sperner property.",
+    "mathContext": "On $\\mathrm{Fin}\\,2\\to\\mathbb{R}$ the product metric is the sup metric: $\\mathrm{dist}(f(x),x) = \\max_i |f(x)_i - x_i|$, so $(\\forall i\\,|f(x)_i-x_i|<\\varepsilon) \\iff \\mathrm{dist}(f(x),x)<\\varepsilon$ (dist_pi_lt_iff). Feeding this to exists_fixed_of_approx on the compact $\\Delta^2$ yields $f(x_0)=x_0$.",
+    "significance": "key",
+    "relatedConcepts": ["sup metric on Fin n → ℝ (dist_pi_lt_iff)", "Sperner displacement colouring", "approximate-to-exact upgrade", "conditional theorem / hypothesis discharge"],
+    "prerequisites": ["exists_fixed_of_approx", "compactness and nonemptiness of the 2-simplex", "equivalence of coordinatewise and sup-metric bounds"]
   },
   {
     "id": "ivt-oq0301-ann-brouwer1d",
@@ -37,6 +53,10 @@
     "range": { "startLine": 179, "endLine": 200 },
     "type": "context",
     "title": "Why dimension 1 is different",
-    "content": "brouwer_1d_via_ivt obtains the 1D fixed point with no Sperner lemma at all: g(x) = f(x) − x satisfies g(1) ≤ 0 ≤ g(0), so intermediate_value_Icc' places 0 in the image of g over [0,1], giving c with f(c) = c. The IVT detects sign changes — a one-dimensional phenomenon — which is precisely why it suffices in 1D but fails from dimension 2, where the combinatorial detour of the rest of this file becomes necessary."
+    "content": "brouwer_1d_via_ivt obtains the 1D fixed point with no Sperner lemma at all: g(x) = f(x) − x satisfies g(1) ≤ 0 ≤ g(0), so intermediate_value_Icc' places 0 in the image of g over [0,1], giving c with f(c) = c. The IVT detects sign changes — a one-dimensional phenomenon — which is precisely why it suffices in 1D but fails from dimension 2, where the combinatorial detour of the rest of this file becomes necessary.",
+    "mathContext": "For $f:[0,1]\\to[0,1]$ set $g(x)=f(x)-x$. Then $g(0)=f(0)\\ge 0$ and $g(1)=f(1)-1\\le 0$, so by the IVT (intermediate_value_Icc') there is $c$ with $g(c)=0$, i.e. $f(c)=c$. The argument is intrinsically 1D: it reads a sign change of $g$, which has no $d\\ge 2$ analogue.",
+    "significance": "supporting",
+    "relatedConcepts": ["intermediate value theorem (intermediate_value_Icc')", "sign change of f(x) − x", "1D vs higher-dimensional fixed points", "why IVT fails to prove Brouwer in d ≥ 2"],
+    "prerequisites": ["the IVT on a closed interval", "continuity of f(x) − x", "boundary evaluation g(0) ≥ 0 ≥ g(1)"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `intermediate-value-theorem-oq-03-oq-01` (the compactness discharge of 2D Brouwer via Sperner's lemma).

The meta.json was already deep (full overview, 4 key insights, 5 sections covering the whole 202-line file, conclusion with 3 open questions). The gap was in **annotations**: all 5 had rich `content` but were missing the prescribed enrichment fields.

- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations.
- `mathContext` now states each step in formula form: the displacement-minimum contradiction (exists_fixed_of_approx), the simplex ⊆ cube compactness route, the sup-metric bridge dist_pi_lt_iff for the conditional 2D theorem, and the 1D IVT sign-change argument.

No prose inflation of the already-complete meta.json; annotations.json grew 4.3 KB → 7.7 KB. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)