### PR TITLE
research(sperner-mathlib4-oq-02): n=1 Tucker / combinatorial 1-D Borsuk–Ulam [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -4006,6 +4006,7 @@ import Proofs.SpernerSimplicialInstanceOQ03Tower
 import Proofs.SpernerSimplicialInstanceOQ04
 import Proofs.SpernerSimplicialInstanceOQ05
 import Proofs.SpernerSimplicialInstanceOQ05Scarf1d
+import Proofs.SpernerTuckerOneDim
 import Proofs.SphericalExcessGirard
 import Proofs.SphericalLawOfCosines
 import Proofs.SphericalLawOfCosinesOQ03

--- a/proofs/Proofs/SpernerTuckerOneDim.lean
+++ b/proofs/Proofs/SpernerTuckerOneDim.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 RJ Walters. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: RJ Walters
+-/
+import Mathlib
+
+/-!
+# One-dimensional Tucker's Lemma (combinatorial 1-D Borsuk–Ulam)
+
+This file proves the `n = 1` case of **Tucker's lemma** — equivalently, the
+combinatorial core of the **1-dimensional Borsuk–Ulam theorem** — by a direct
+sign-change parity argument.
+
+## Setting
+
+The 1-ball `B¹ = [-m, m]` is triangulated by a path of `N + 1` vertices
+`0, 1, …, N`, with edges connecting consecutive vertices `i` and `i + 1`
+(here `N = 2m`). A *labelling* assigns each vertex a sign from `{+1, -1}`,
+which we encode as an element of `ZMod 2` (`+1 ↦ 0`, `-1 ↦ 1`). The labelling
+is **antipodal on the boundary** when the two endpoints `0` and `N` receive
+opposite signs; under the `ZMod 2` encoding this is exactly `lam 0 ≠ lam N`.
+
+An edge `i` (joining vertices `i` and `i + 1`) is **complementary** when its
+two endpoints carry opposite signs: `lam i.castSucc ≠ lam i.succ`.
+
+## Main results
+
+* `TuckerOneDim.complementary_count_cast`: the number of complementary edges,
+  cast into `ZMod 2`, equals `lam 0 + lam (Fin.last N)` (a telescoping
+  identity — the count of sign changes is the total "displacement" of the
+  sign along the path).
+* `TuckerOneDim.tucker_one_dim`: with an antipodal boundary, the number of
+  complementary edges is **odd**.
+* `TuckerOneDim.exists_complementary_edge`: **1-D Tucker** — with an antipodal
+  boundary, a complementary edge exists.
+
+## Relationship to the abstract door-counting engine
+
+The parent file `SpernerMathlib4.lean` proves Sperner's lemma for an abstract
+`CellComplex` via door-counting parity. For `n = 1` the present result is the
+*signed* analogue: complementary edges play the role of "doors", and the
+antipodal boundary condition forces an odd count, exactly as an odd boundary
+door count forces a panchromatic cell in Sperner.
+
+This is a faithful `n = 1` milestone toward the open question
+`sperner-mathlib4-oq-02` (Tucker from door-counting). It does **not** extend
+mechanically to `n ≥ 2`: there the complementary-edge count is *not* a parity
+invariant, and the standard remedy (Freund–Todd / Prescott–Su path-following
+on almost-complementary simplices) is a genuinely different parity engine.
+
+## References
+
+* A. W. Tucker, *Some topological properties of disk and sphere* (1946).
+* J. Matoušek, *Using the Borsuk–Ulam Theorem* (2003).
+
+## Tags
+
+Tucker, Borsuk-Ulam, combinatorics, parity, antipodal, sign-change
+-/
+
+open Finset
+
+namespace TuckerOneDim
+
+/-- In `ZMod 2`, an element is its own negation. -/
+private lemma neg_self : ∀ x : ZMod 2, -x = x := by decide
+
+/-- In `ZMod 2`, every element is its own additive inverse: `x + x = 0`. -/
+private lemma add_self : ∀ x : ZMod 2, x + x = 0 := by decide
+
+/-- The complementarity indicator equals the `ZMod 2` sum of the two endpoint
+labels: `1` when the signs differ, `0` when they agree. -/
+private lemma ite_ne_eq_add :
+    ∀ a b : ZMod 2, (if a ≠ b then (1 : ZMod 2) else 0) = a + b := by decide
+
+/-- An edge `i` of the path is **complementary** for the labelling `lam` when
+its two endpoints (vertices `i` and `i + 1`) carry opposite signs. -/
+def IsComplementary {N : ℕ} (lam : Fin (N + 1) → ZMod 2) (i : Fin N) : Prop :=
+  lam i.castSucc ≠ lam i.succ
+
+/-- **Sign-change parity (telescoping form).** The number of complementary
+edges, cast into `ZMod 2`, equals the sum of the two boundary labels. This is
+the discrete fundamental theorem of calculus: counting sign changes along the
+path equals the net change of the sign between the endpoints. -/
+theorem complementary_count_cast (N : ℕ) (lam : Fin (N + 1) → ZMod 2) :
+    ((univ.filter
+      (fun i : Fin N => lam i.castSucc ≠ lam i.succ)).card : ZMod 2)
+      = lam 0 + lam (Fin.last N) := by
+  -- Extend `lam` to a function on `ℕ` so we can telescope over `range N`.
+  set g : ℕ → ZMod 2 := fun k => if h : k < N + 1 then lam ⟨k, h⟩ else 0 with hg
+  have hg_cast : ∀ i : Fin N, g i.castSucc = lam i.castSucc := by
+    intro i
+    simp only [hg, Fin.coe_castSucc]
+    rw [dif_pos (by omega)]
+    rfl
+  have hg_succ : ∀ i : Fin N, g (i.castSucc + 1) = lam i.succ := by
+    intro i
+    simp only [hg, Fin.coe_castSucc]
+    rw [dif_pos (by omega)]
+    rfl
+  -- Rewrite the cardinality as a `ZMod 2` sum of indicators.
+  rw [Finset.card_filter, Nat.cast_sum]
+  have hstep : ∀ i : Fin N,
+      ((if lam i.castSucc ≠ lam i.succ then 1 else 0 : ℕ) : ZMod 2)
+        = g i.castSucc + g (i.castSucc + 1) := by
+    intro i
+    rw [hg_cast i, hg_succ i, ← ite_ne_eq_add]
+    split_ifs <;> simp
+  rw [Finset.sum_congr rfl (fun i _ => hstep i)]
+  -- Reindex `Fin N` to `range N`, then telescope.
+  have hreindex :
+      (∑ i : Fin N, (g i.castSucc + g (i.castSucc + 1)))
+        = ∑ i ∈ range N, (g i + g (i + 1)) := by
+    rw [← Fin.sum_univ_eq_sum_range (fun k => g k + g (k + 1)) N]
+    apply Finset.sum_congr rfl
+    intro i _
+    simp [Fin.coe_castSucc]
+  rw [hreindex]
+  -- In `ZMod 2`, `g i + g (i+1) = g (i+1) - g i`, so the sum telescopes.
+  have hsub : ∀ i, g i + g (i + 1) = g (i + 1) - g i := by
+    intro i
+    rw [sub_eq_add_neg, neg_self, add_comm]
+  rw [Finset.sum_congr rfl (fun i _ => hsub i), Finset.sum_range_sub g N]
+  -- Identify the boundary values.
+  have hg0 : g 0 = lam 0 := by
+    simp only [hg]; rw [dif_pos (by omega)]; rfl
+  have hgN : g N = lam (Fin.last N) := by
+    simp only [hg]; rw [dif_pos (by omega)]; rfl
+  rw [hg0, hgN, sub_eq_add_neg, neg_self, add_comm]
+
+/-- **1-D Tucker, parity form.** If the boundary labels are antipodal
+(`lam 0 ≠ lam (Fin.last N)`), the number of complementary edges is **odd**. -/
+theorem tucker_one_dim (N : ℕ) (lam : Fin (N + 1) → ZMod 2)
+    (hanti : lam 0 ≠ lam (Fin.last N)) :
+    Odd (univ.filter
+      (fun i : Fin N => lam i.castSucc ≠ lam i.succ)).card := by
+  have hcast := complementary_count_cast N lam
+  -- The antipodal condition pins the boundary sum to `1`.
+  have hone : lam 0 + lam (Fin.last N) = 1 := by
+    have h := ite_ne_eq_add (lam 0) (lam (Fin.last N))
+    rw [if_pos hanti] at h
+    exact h.symm
+  rw [hone] at hcast
+  -- `(card : ZMod 2) = 1` forces `card` odd.
+  rcases Nat.even_or_odd
+      (univ.filter (fun i : Fin N => lam i.castSucc ≠ lam i.succ)).card
+      with he | ho
+  · exfalso
+    obtain ⟨k, hk⟩ := he
+    rw [hk] at hcast
+    rw [Nat.cast_add, add_self] at hcast
+    exact zero_ne_one hcast
+  · exact ho
+
+/-- **One-dimensional Tucker's lemma** (combinatorial 1-D Borsuk–Ulam). For any
+sign labelling of a path that is antipodal on the boundary, some edge is
+complementary: its two endpoints carry opposite signs. -/
+theorem exists_complementary_edge (N : ℕ) (lam : Fin (N + 1) → ZMod 2)
+    (hanti : lam 0 ≠ lam (Fin.last N)) :
+    ∃ i : Fin N, lam i.castSucc ≠ lam i.succ := by
+  have hodd := tucker_one_dim N lam hanti
+  have hpos : 0 < (univ.filter
+      (fun i : Fin N => lam i.castSucc ≠ lam i.succ)).card := by
+    obtain ⟨k, hk⟩ := hodd; omega
+  obtain ⟨i, hi⟩ := Finset.card_pos.mp hpos
+  exact ⟨i, (mem_filter.mp hi).2⟩
+
+end TuckerOneDim

--- a/research/problems/sperner-mathlib4-oq-02/knowledge.md
+++ b/research/problems/sperner-mathlib4-oq-02/knowledge.md
@@ -120,3 +120,46 @@ a complementary edge.
 ### Next Steps
 - Docker up → port n=1 Tucker as a `CellComplex`-style parity lemma over `{±1}`.
 - Scope Freund–Todd path-following engine for n≥2 (BUILD vs Sperner-doubling).
+
+## Session 2026-06-27 (Session 3) — ACT: n=1 Tucker milestone shipped (verified)
+
+**Mode**: BUILD (Docker UP — the prior session's blocker is cleared)
+**Outcome**: progress (ACT) — new verified file, 0 sorries, 0 axioms
+
+### What I Did
+- Ported the n=1 Tucker milestone (Insight 2) to Lean as
+  `proofs/Proofs/SpernerTuckerOneDim.lean` (169 LOC). Built clean via
+  `docker-build.sh Proofs.SpernerTuckerOneDim` (exit 0).
+- Chose the **direct sign-change parity** proof over instantiating the abstract
+  `CellComplex`: the engine's panchromatic conclusion genuinely diverges from the
+  complementary-edge target (Insight 1), so a black-box instantiation is clunky and
+  no cleaner than the direct discrete-FTC argument.
+
+### Theorems (all verified, 0-axiom, kernel `decide` only)
+- `complementary_count_cast`: telescoping ZMod-2 identity — the number of
+  complementary edges, cast to `ZMod 2`, equals `lam 0 + lam (Fin.last N)`
+  (discrete fundamental theorem of calculus: #sign-changes = net sign change).
+- `tucker_one_dim`: antipodal boundary (`lam 0 ≠ lam (Fin.last N)`) ⟹ the
+  complementary-edge count is **odd**.
+- `exists_complementary_edge`: **1-D Tucker** — antipodal boundary ⟹ a
+  complementary edge exists. This is the combinatorial core of 1-D Borsuk–Ulam.
+
+### Encoding notes
+- Signs `{+1,-1}` encoded as `ZMod 2` (`+1↦0`, `-1↦1`). Path of `N+1` vertices
+  `Fin (N+1)`; edge `i : Fin N` joins `i.castSucc` and `i.succ`.
+- Antipodal boundary `λ(-v) = -λ(v)` at the two endpoints ⇔ `lam 0 ≠ lam (last)`.
+- Key Mathlib lever: `Finset.sum_range_sub` (telescoping over `range N`) after
+  extending `lam` to `g : ℕ → ZMod 2`; in `ZMod 2`, `-x = x` (proved by `decide`)
+  turns the additive indicator into a telescoping difference.
+
+### Files Modified
+- proofs/Proofs/SpernerTuckerOneDim.lean (new)
+- proofs/Proofs.lean (registered the module)
+- src/data/research/problems/sperner-mathlib4-oq-02.json (knowledge + leanFiles)
+- research/problems/sperner-mathlib4-oq-02/{knowledge.md, state.md}
+
+### Next Steps (unchanged for n≥2)
+- n≥2 Tucker needs the Freund–Todd / Prescott–Su path-following engine (the
+  complementary-edge count is NOT a parity invariant for n≥2 — Insight 3). Or the
+  Tucker-via-Sperner doubling/quotient reduction on RPⁿ.
+- Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (separate analytic phase).

--- a/research/problems/sperner-mathlib4-oq-02/state.md
+++ b/research/problems/sperner-mathlib4-oq-02/state.md
@@ -1,41 +1,36 @@
 # Research State: sperner-mathlib4-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-14T21:34:31-07:00
-**Iteration**: 2
+**Since**: 2026-06-27T10:30:00-07:00
+**Iteration**: 3
 
 ## Current Focus
-Assessed whether the parent's abstract `CellComplex` door-counting engine
-(`proofs/Proofs/SpernerMathlib4.lean`) generalizes to Tucker's lemma.
-Verdict: it ports cleanly to the n=1 case (where complementary-edge parity is
-an exact invariant) but NOT to n>=2 Tucker, which needs a path-following
-(Freund-Todd) engine because the complementary-edge count is no longer a
-parity invariant.
+n=1 Tucker milestone SHIPPED and verified (Docker is up — prior blocker cleared).
+New file `proofs/Proofs/SpernerTuckerOneDim.lean` (169 LOC, 0 sorries, 0 axioms)
+proves 1-D Tucker = the combinatorial core of 1-D Borsuk–Ulam via a direct
+sign-change parity (discrete fundamental theorem of calculus over `ZMod 2`).
 
 ## Active Approach
-1. **n=1 (immediate, build-gated)**: Tucker on B^1 IS a direct corollary of a
-   door-count parity over the 2-label set {+1,-1}. Brute force confirms the
-   complementary-edge count is ALWAYS ODD. This is a near-mechanical port of
-   the parent engine restricted to d=1 with a signed 2-label alphabet.
-2. **n>=2 (open infrastructure)**: requires a NEW combinatorial engine
-   (almost-complementary simplex path-following / Freund-Todd 1981), since
-   the direct complementary-edge count is not odd in general (verified n=2).
+Direct sign-change parity, not a `CellComplex` instantiation (the engine's
+panchromatic conclusion diverges from the complementary-edge target — Insight 1).
+- `complementary_count_cast`: #complementary-edges ≡ `lam 0 + lam (last)` (mod 2).
+- `tucker_one_dim`: antipodal boundary ⟹ odd count.
+- `exists_complementary_edge`: 1-D Tucker existence.
 
 ## Attempt Count
-- Total attempts: 1
+- Total attempts: 2
 - Current approach attempts: 1
-- Approaches tried: 1 (direct-parity-port assessment)
+- Approaches tried: 2 (engine-reusability assessment → direct-parity port)
 
 ## Blockers
-- Docker DOWN this session -> no `lake build`; no Lean written (avoid shipping
-  uncompilable .lean). Verification done in Python instead.
+- None for n=1 (done).
 - n>=2 Tucker engine is substantial (~500-1000+ LOC: path-following on
   almost-complementary simplices, antipodal pairing of boundary path-endpoints).
 
 ## Next Action
-- When Docker is up: attempt the n=1 Tucker port as a `CellComplex`-style
-  parity lemma over a 2-label alphabet (small, self-contained first milestone).
-- For n>=2: scope the Freund-Todd path-following engine; decide BUILD vs the
-  Tucker-via-Sperner-doubling reduction. Until then this is ORIENT, not ACT.
+- n>=2: scope/build the Freund-Todd / Prescott-Su path-following engine (the
+  complementary-edge count is NOT a parity invariant for n>=2 — Insight 3), or the
+  Tucker-via-Sperner doubling/quotient reduction on RP^n.
+- Tucker ⟹ Borsuk–Ulam: continuous mesh→0 + compactness (separate analytic phase).

--- a/src/data/research/problems/sperner-mathlib4-oq-02.json
+++ b/src/data/research/problems/sperner-mathlib4-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "sperner-mathlib4-oq-02",
   "title": "Tucker's Lemma (and Borsuk–Ulam) from Abstract Door-Counting",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "ACT",
+  "status": "progress",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,27 +16,37 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-06-14T21:34:31-07:00",
-    "iteration": 2,
-    "focus": "Assessed whether the parent's abstract `CellComplex` door-counting engine",
-    "activeApproach": "1. **n=1 (immediate, build-gated)**: Tucker on B^1 IS a direct corollary of a",
-    "blockers": [
-      "- Docker DOWN this session -> no `lake build`; no Lean written (avoid shipping"
-    ],
-    "nextAction": "- When Docker is up: attempt the n=1 Tucker port as a `CellComplex`-style",
+    "phase": "ACT",
+    "since": "2026-06-27T10:30:00-07:00",
+    "iteration": 3,
+    "focus": "Delivered the n=1 Tucker milestone: 1-D Tucker / combinatorial 1-D Borsuk–Ulam, fully verified (0 sorries, 0 axioms).",
+    "activeApproach": "Direct sign-change parity (discrete FTC over ZMod 2): the count of complementary edges equals the boundary sign sum; antipodal boundary forces it odd, hence ≥ 1.",
+    "blockers": [],
+    "nextAction": "Scope the n≥2 engine: Freund–Todd / Prescott–Su path-following on almost-complementary simplices (the complementary-edge count is NOT a parity invariant for n≥2, so the direct route does not lift).",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "n=1 Tucker milestone shipped as proofs/Proofs/SpernerTuckerOneDim.lean (169 LOC, 0 sorries, 0 axioms, kernel `decide` only). Proves the combinatorial core of 1-D Borsuk–Ulam: any sign labelling of a path that is antipodal on the boundary (endpoints differ) has a complementary edge. Method: a telescoping ZMod-2 identity (`complementary_count_cast`) shows the complementary-edge count ≡ boundary sign sum (mod 2); the antipodal condition pins that to 1, forcing an odd count (`tucker_one_dim`), hence existence (`exists_complementary_edge`). Confirms the OQ's positive direction for n=1 and the negative direction for the general engine: the direct parity route does NOT lift to n≥2.",
+    "builtItems": [
+      "proofs/Proofs/SpernerTuckerOneDim.lean — 1-D Tucker / combinatorial 1-D Borsuk–Ulam (verified, 0-axiom)",
+      "TuckerOneDim.complementary_count_cast — telescoping ZMod-2 identity: #complementary-edges ≡ lam 0 + lam (last) (mod 2)",
+      "TuckerOneDim.tucker_one_dim — antipodal boundary ⟹ odd #complementary-edges",
+      "TuckerOneDim.exists_complementary_edge — 1-D Tucker existence statement"
+    ],
+    "insights": [
+      "n=1 Tucker is provable directly as a discrete fundamental-theorem-of-calculus / sign-change-parity statement over ZMod 2 — cleaner than instantiating the abstract CellComplex (whose panchromatic conclusion genuinely diverges from the complementary-edge target, Insight 1).",
+      "The antipodal boundary condition lam(-v) = -lam(v) at the two endpoints becomes exactly `lam 0 ≠ lam (Fin.last N)` under the +1↦0 / -1↦1 ZMod-2 encoding; this is the sole hypothesis driving the odd count.",
+      "n≥2 does not lift: the complementary-edge count is not a parity invariant (B² distribution {1:48,2:72,3:48,4:48,5:24,6:8,9:8}); the standard remedy is Freund–Todd / Prescott–Su path-following, a different parity engine."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "n≥2 Tucker: build the Freund–Todd / Prescott–Su almost-complementary path-following engine with antipodal pairing of boundary path-endpoints (≈500–1000+ LOC), OR the Tucker-via-Sperner doubling/quotient reduction on RPⁿ.",
+      "Tucker ⟹ Borsuk–Ulam: the continuous mesh→0 + compactness limit (separate analytic phase)."
+    ],
     "markdown": "# Knowledge Base: sperner-mathlib4-oq-02\n\nTucker's lemma (and Borsuk–Ulam) from the parent's abstract door-counting engine.\n\n---\n\n## Problem Understanding\n\nParent `sperner-mathlib4` (`proofs/Proofs/SpernerMathlib4.lean`, 732 LOC, GREEN)\nproves Sperner's lemma abstractly:\n\n- `CellComplex V d`: `Cell` type, `vertex : Cell → Fin (d+1) → V`,\n  `adj : Cell → Fin (d+1) → Option (Cell × Fin (d+1))` with symmetry /\n  shared-face / distinctness axioms.\n- `IsPanchromatic c K s`  := `c ∘ vertex s` surjective onto `Fin (d+1)`.\n- `IsDoor c K s k`        := dropping vertex `k`, the other `d` vertices realize\n  all colors `{0,…,d-1}`.\n- `door_count_parity`: a coloring `f : Fin (d+1) → Fin (d+1)` has door count ≡ 1\n  (mod 2) iff `f` is surjective, else 0.\n- `sperner_parity`: `#panchromatic ≡ #boundary-doors (mod 2)`.\n- `sperner`: odd boundary doors ⟹ a panchromatic cell exists.\n\nThe OQ asks: does this engine extend to **Tucker's lemma** — antipodally\nsymmetric triangulation of `Bⁿ`, labelling `λ : V → {±1,…,±n}` antipodal on the\nboundary (`λ(-v) = -λ(v)`), conclusion: some edge is **complementary**\n(`λ(u) = -λ(v)`)? Tucker ⟹ Borsuk–Ulam.\n\n---\n\n## Insights\n\n### Insight 1 — the parent engine is hard-wired to the Sperner target\n`door_count_parity`, `IsPanchromatic`, `IsDoor` are all stated over an *unsigned*\ncolor alphabet `Fin (d+1)` with the conclusion \"a `d`-cell sees all `d+1` colors\".\nTucker's alphabet is *signed* with `2n` labels `{±1,…,±n}` and its conclusion is a\n**1-dimensional** object (a complementary edge), not a full-dimensional\npanchromatic cell. There is no black-box specialization of `CellComplex.sperner`\nthat yields Tucker — the *target object has the wrong arity and the wrong\nalgebraic structure*. (Engine-divergence probe, n=2 hexagon: 40 antipodal\nlabellings have a complementary edge but no \"rainbow-signed\" triangle — the two\nconclusions are not interchangeable.)\n\n### Insight 2 — n=1 Tucker IS a direct door-count corollary (PORTABLE)\nExhaustive check of `B¹ = [-m,m]` (3,5,7 vertices; labels `{+1,-1}`; antipodal\nendpoints `λ(m) = -λ(-m)`, interior free): the **complementary-edge count is\nALWAYS ODD** (distributions `{1:4}`, `{1:8,3:8}`, `{1:12,3:40,5:12}`). This is\nexactly a door-counting parity over a 2-label alphabet: complementary edges are\nthe \"doors\", antipodal boundary forces an odd boundary contribution, interior\npairing gives the rest. So **n=1 Tucker (= 1-D Borsuk–Ulam) is a near-mechanical\nport of the parent engine** restricted to `d=1` with a signed 2-symbol alphabet.\n\n### Insight 3 — n≥2 Tucker is NOT a one-step parity (needs path-following)\nExhaustive check of `B²` (hexagon + center, antipodally symmetric, 6 triangles,\nlabels `{±1,±2}`, 256 antipodal labellings): Tucker holds (0 labellings without a\ncomplementary edge) BUT the complementary-edge count is **not** a parity invariant\n— distribution `{1:48, 2:72, 3:48, 4:48, 5:24, 6:8, 9:8}`, only 128/256 odd.\nHence the parent's \"count the target object, show it's odd\" strategy does NOT lift\nto `n≥2`. The standard remedy is **Freund–Todd (1981) / Prescott–Su\npath-following on *almost-complementary* simplices**: paths run between\ncomplementary simplices and the boundary; the antipodal boundary condition pairs\nboundary path-endpoints, forcing an interior complementary simplex. This is a\ngenuinely different parity engine (parity of path endpoints, not of the target\nset itself).\n\n### Insight 4 — buildability split\n- **n=1 milestone**: small, self-contained `CellComplex`-style parity over\n  `{+1,-1}`. Estimated < 200 LOC. BUILD when Docker is up.\n- **General Tucker**: the Freund–Todd path-following engine + antipodal pairing of\n  boundary endpoints is substantial (≈ 500–1000+ LOC) and is the real content;\n  alternatively a Tucker-via-Sperner \"doubling/quotient\" reduction (problem.md\n  approach 2) trades the path-following for orientation bookkeeping on `ℝPⁿ`.\n- **Tucker ⟹ Borsuk–Ulam** (continuous, mesh→0 + compactness) is a separate\n  analytic phase, out of scope for the combinatorial engine.\n\n---\n\n## Dead Ends\n\n- **\"Adapt `door_count_parity` to complementary edges and show the boundary count\n  is odd\"** — fails for `n≥2`: the complementary-edge count is not odd in general\n  (verified, B² distribution above). Only works for `n=1`.\n\n---\n\n## Verification Artifact\n\n`verify_tucker.py` (this dir) — Docker-free, exhaustive. Confirms Tucker on\n`B¹` (3/5/7 vtx) and `B²` (hexagon+center), prints the complementary-edge-count\ndistributions (the parity evidence), and runs the engine-divergence probe. All\nassertions pass: every antipodal labelling on every enumerated triangulation has\na complementary edge.\n\n---\n\n## Session Log\n\n## Session 2026-06-14 (Session 2) — ORIENT: engine reusability assessment\n\n**Mode**: FRESH\n**Outcome**: progress (ORIENT) — Docker DOWN, no Lean written\n\n### What I Did\n- Read the full parent engine `SpernerMathlib4.lean` (abstract `CellComplex`\n  door-counting; `sperner_parity`, `sperner`).\n- Built `verify_tucker.py`: exhaustive Tucker check on `B¹`/`B²` + parity probe +\n  engine-divergence probe. All assertions pass.\n\n### Key Findings\n- Parent engine is specialized to the unsigned `Fin (d+1)` panchromatic target;\n  no black-box reduction yields Tucker (Insight 1).\n- n=1 Tucker = direct door-count parity (complementary edges always ODD) →\n  portable first milestone (Insight 2).\n- n≥2 Tucker complementary-edge count is NOT a parity invariant → needs\n  Freund–Todd path-following, a different engine (Insight 3).\n\n### Files Modified\n- research/problems/sperner-mathlib4-oq-02/{knowledge.md, state.md}\n- research/problems/sperner-mathlib4-oq-02/verify_tucker.py (new)\n\n### Next Steps\n- Docker up → port n=1 Tucker as a `CellComplex`-style parity lemma over `{±1}`.\n- Scope Freund–Todd path-following engine for n≥2 (BUILD vs Sperner-doubling).\n"
   },
   "tags": [
@@ -55,8 +65,19 @@
     "mathlib": []
   },
   "started": "2026-06-15T02:22:23.646Z",
-  "lastUpdate": "2026-06-15T02:22:23.820Z",
+  "lastUpdate": "2026-06-27T17:35:00.000Z",
   "leanFiles": [
+    {
+      "path": "Proofs/SpernerTuckerOneDim.lean",
+      "filename": "SpernerTuckerOneDim.lean",
+      "lineCount": 169,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SpernerTuckerOneDim.lean"
+    },
     {
       "path": "Proofs/SpernerMathlib4.lean",
       "filename": "SpernerMathlib4.lean",


### PR DESCRIPTION
## Summary

Ships the **n=1 milestone** for the open question `sperner-mathlib4-oq-02`
(*Tucker's lemma from abstract door-counting*), identified by prior sessions as
the portable first deliverable. Docker came up this session, clearing the build
blocker the previous (ORIENT) session was waiting on.

New file `proofs/Proofs/SpernerTuckerOneDim.lean` (169 LOC, **0 sorries, 0
axioms**, kernel `decide` only — no `native_decide`/`Lean.ofReduceBool`) proves
**1-D Tucker's lemma**, the combinatorial core of the **1-dimensional
Borsuk–Ulam theorem**.

## Setup

The 1-ball is triangulated by a path of `N+1` vertices `Fin (N+1)`. Signs
`{+1,-1}` are encoded in `ZMod 2` (`+1↦0`, `-1↦1`); an edge `i : Fin N` joins
vertices `i.castSucc` and `i.succ` and is **complementary** when its endpoints
carry opposite signs. The antipodal boundary condition `λ(-v) = -λ(v)` at the
two endpoints becomes exactly `lam 0 ≠ lam (Fin.last N)`.

## Results (all verified)

- `complementary_count_cast` — telescoping `ZMod 2` identity: the
  complementary-edge count, cast to `ZMod 2`, equals `lam 0 + lam (Fin.last N)`
  (a discrete fundamental theorem of calculus: #sign-changes = net sign change).
- `tucker_one_dim` — antipodal boundary ⟹ the complementary-edge count is **odd**.
- `exists_complementary_edge` — **1-D Tucker**: antipodal boundary ⟹ a
  complementary edge exists.

Method: extend `lam` to `g : ℕ → ZMod 2`, telescope with `Finset.sum_range_sub`,
and use `-x = x` in `ZMod 2` to turn the additive sign-change indicator into a
telescoping difference.

## Honest scope

This is a **milestone, not a full solution** of the OQ. It confirms:
- the **positive** direction for `n = 1` (a clean verified theorem), and
- the **negative** direction for the general engine — the direct parity route
  does **not** lift to `n ≥ 2`, where the complementary-edge count is not a
  parity invariant (the standard remedy is Freund–Todd / Prescott–Su
  path-following, a genuinely different engine; documented in the knowledge base).

Proved directly rather than by instantiating the parent `CellComplex` engine,
whose panchromatic conclusion genuinely diverges from the complementary-edge
target (recorded as Insight 1 in the problem's knowledge base).

## Verification

`./proofs/scripts/docker-build.sh Proofs.SpernerTuckerOneDim` → build succeeded
(exit 0). Registered in `proofs/Proofs.lean`; research JSON + knowledge/state
updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)