### PR TITLE
Enrich Weighted AM–HM Inequality (jensen-inequality-oq-01-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 52 },
     "type": "concept",
     "title": "Goal: the weighted AM–HM inequality, a gap in Mathlib",
-    "content": "Mathlib formalizes the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but not the harmonic-mean rung M₋₁ ≤ M₁ or its equality case. This file supplies both: for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, the weighted harmonic mean (∑ wᵢ·xᵢ⁻¹)⁻¹ is at most the weighted arithmetic mean ∑ wᵢ·xᵢ, with equality iff all xᵢ are equal. The header sets up the base chain H ≤ G ≤ A of the power-mean ladder and the strategy of bracketing the geometric mean G via two applications of the parent's weighted AM–GM."
+    "content": "Mathlib formalizes the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but not the harmonic-mean rung M₋₁ ≤ M₁ or its equality case. This file supplies both: for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, the weighted harmonic mean (∑ wᵢ·xᵢ⁻¹)⁻¹ is at most the weighted arithmetic mean ∑ wᵢ·xᵢ, with equality iff all xᵢ are equal. The header sets up the base chain H ≤ G ≤ A of the power-mean ladder and the strategy of bracketing the geometric mean G via two applications of the parent's weighted AM–GM.",
+    "mathContext": "Power means $M_r(x;w) = \\big(\\sum_i w_i x_i^{r}\\big)^{1/r}$ with $M_{-1}=H$, $M_0=G$, $M_1=A$. The claim is $M_{-1}\\le M_1$: $\\big(\\sum_i w_i x_i^{-1}\\big)^{-1} \\le \\sum_i w_i x_i$, equality iff all $x_i$ equal.",
+    "significance": "key",
+    "relatedConcepts": ["power means", "arithmetic mean", "harmonic mean", "geometric mean", "weighted AM–GM"],
+    "prerequisites": ["real analysis", "inequalities", "convexity"]
   },
   {
     "id": "ann-prod-rpow-inv",
@@ -13,7 +17,11 @@
     "range": { "startLine": 53, "endLine": 60 },
     "type": "lemma",
     "title": "Reciprocal of the weighted geometric mean",
-    "content": "prod_rpow_inv proves ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹. Pointwise, Real.inv_rpow (valid since each xᵢ > 0) gives (xᵢ⁻¹)^{wᵢ} = (xᵢ^{wᵢ})⁻¹; Finset.prod_inv_distrib then pulls the inverse out of the product. This is exactly what lets the second AM–GM application — applied to the reciprocals — bound G⁻¹ rather than some unrelated quantity."
+    "content": "prod_rpow_inv proves ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹. Pointwise, Real.inv_rpow (valid since each xᵢ > 0) gives (xᵢ⁻¹)^{wᵢ} = (xᵢ^{wᵢ})⁻¹; Finset.prod_inv_distrib then pulls the inverse out of the product. This is exactly what lets the second AM–GM application — applied to the reciprocals — bound G⁻¹ rather than some unrelated quantity.",
+    "mathContext": "$\\prod_i (x_i^{-1})^{w_i} = \\prod_i (x_i^{w_i})^{-1} = \\big(\\prod_i x_i^{w_i}\\big)^{-1} = G^{-1}$, using $\\,(x^{-1})^{w} = (x^{w})^{-1}$ for $x>0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["real power (rpow)", "finite products", "inverse-distributes-over-product", "geometric mean"],
+    "prerequisites": ["real analysis", "Mathlib rpow library"]
   },
   {
     "id": "ann-harm-le-geom",
@@ -21,7 +29,11 @@
     "range": { "startLine": 61, "endLine": 75 },
     "type": "lemma",
     "title": "Harmonic mean ≤ geometric mean",
-    "content": "harm_le_geom applies the parent's weighted_amgm_le to the reciprocal data xᵢ⁻¹, yielding G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D. Because the geometric mean G > 0 (a product of positive rpow values, Real.rpow_pos_of_pos + Finset.prod_pos), the bound G⁻¹ ≤ D inverts via inv_anti₀ to D⁻¹ ≤ (G⁻¹)⁻¹ = G. This is the H ≤ G half of the base chain."
+    "content": "harm_le_geom applies the parent's weighted_amgm_le to the reciprocal data xᵢ⁻¹, yielding G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D. Because the geometric mean G > 0 (a product of positive rpow values, Real.rpow_pos_of_pos + Finset.prod_pos), the bound G⁻¹ ≤ D inverts via inv_anti₀ to D⁻¹ ≤ (G⁻¹)⁻¹ = G. This is the H ≤ G half of the base chain.",
+    "mathContext": "AM–GM on $x_i^{-1}$: $G^{-1} \\le \\sum_i w_i x_i^{-1} = D$. Since $G>0$, $\\,t\\mapsto t^{-1}$ is antitone on $(0,\\infty)$, so $D^{-1} \\le G$, i.e. $H \\le G$.",
+    "significance": "key",
+    "relatedConcepts": ["harmonic mean", "geometric mean", "monotonicity of inversion", "positivity of products"],
+    "prerequisites": ["real analysis", "ordered fields", "weighted AM–GM"]
   },
   {
     "id": "ann-amhm-le",
@@ -29,7 +41,11 @@
     "range": { "startLine": 76, "endLine": 89 },
     "type": "theorem",
     "title": "The weighted AM–HM inequality",
-    "content": "weighted_amhm_le chains the two halves: H ≤ G (harm_le_geom) and G ≤ A (the parent's weighted_amgm_le applied to the data xᵢ), giving (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ. The whole inequality is thus two applications of one parent lemma joined at the common pivot G — no fresh convexity argument."
+    "content": "weighted_amhm_le chains the two halves: H ≤ G (harm_le_geom) and G ≤ A (the parent's weighted_amgm_le applied to the data xᵢ), giving (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ. The whole inequality is thus two applications of one parent lemma joined at the common pivot G — no fresh convexity argument.",
+    "mathContext": "$H = \\big(\\sum_i w_i x_i^{-1}\\big)^{-1} \\le G = \\prod_i x_i^{w_i} \\le A = \\sum_i w_i x_i$. Transitivity of $\\le$ across the shared pivot $G$ closes the chain.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic mean", "harmonic mean", "transitivity of order", "power-mean ladder"],
+    "prerequisites": ["real analysis", "inequalities", "weighted AM–GM"]
   },
   {
     "id": "ann-amhm-eq-iff",
@@ -37,7 +53,11 @@
     "range": { "startLine": 90, "endLine": 115 },
     "type": "theorem",
     "title": "Equality case: harmonic = arithmetic iff data constant",
-    "content": "weighted_amhm_eq_iff characterizes equality. Forward: if H = A then the squeeze H ≤ G ≤ A forces G = A, and the parent's weighted_amgm_eq_iff converts G = A into the constancy of the xᵢ. Backward: constancy makes both AM–GM applications equalities (weighted_amgm_eq_iff in the mpr direction, applied to xᵢ and to xᵢ⁻¹), so D = G⁻¹ and hence H = D⁻¹ = G = A. The squeeze structure makes the harmonic equality case fall out of the geometric one with no extra strict-convexity work."
+    "content": "weighted_amhm_eq_iff characterizes equality. Forward: if H = A then the squeeze H ≤ G ≤ A forces G = A, and the parent's weighted_amgm_eq_iff converts G = A into the constancy of the xᵢ. Backward: constancy makes both AM–GM applications equalities (weighted_amgm_eq_iff in the mpr direction, applied to xᵢ and to xᵢ⁻¹), so D = G⁻¹ and hence H = D⁻¹ = G = A. The squeeze structure makes the harmonic equality case fall out of the geometric one with no extra strict-convexity work.",
+    "mathContext": "$H = A \\iff \\forall j\\,k,\\ x_j = x_k$. Forward via the squeeze $H\\le G\\le A$ collapsing both inequalities; backward because constant data make every weighted AM–GM an equality.",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "squeeze argument", "strict convexity", "AM–GM equality"],
+    "prerequisites": ["real analysis", "inequalities", "weighted AM–GM equality case"]
   },
   {
     "id": "ann-amhm-lt",
@@ -45,6 +65,10 @@
     "range": { "startLine": 116, "endLine": 124 },
     "type": "theorem",
     "title": "Strict inequality when data differ",
-    "content": "weighted_amhm_lt_of_ne upgrades the inequality to strict: if two data values xⱼ ≠ xₖ, then (∑ wᵢ·xᵢ⁻¹)⁻¹ < ∑ wᵢ·xᵢ. Proof: lt_of_le_of_ne from weighted_amhm_le, with the equality ruled out by the contrapositive of weighted_amhm_eq_iff."
+    "content": "weighted_amhm_lt_of_ne upgrades the inequality to strict: if two data values xⱼ ≠ xₖ, then (∑ wᵢ·xᵢ⁻¹)⁻¹ < ∑ wᵢ·xᵢ. Proof: lt_of_le_of_ne from weighted_amhm_le, with the equality ruled out by the contrapositive of weighted_amhm_eq_iff.",
+    "mathContext": "If $\\exists j\\,k,\\ x_j \\ne x_k$ then $H < A$: combine $H \\le A$ with $H \\ne A$ (contrapositive of the equality case) via $a\\le b \\wedge a\\ne b \\Rightarrow a<b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict inequality", "contrapositive", "equality case", "non-constant data"],
+    "prerequisites": ["real analysis", "inequalities", "logic"]
   }
 ]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const jensenInequalityOQ01OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const jensenInequalityOQ01OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const jensenInequalityOQ01OQ01OQ01OQ02Data: ProofData = {
+  proof: jensenInequalityOQ01OQ01OQ01OQ02Proof,
+  annotations: jensenInequalityOQ01OQ01OQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01-oq-02`.

- **Created missing `index.ts`** — the proof page was not loading on the live site (no Vite entry point); now fixed.
- **Deepened all 6 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` fields.

meta.json was already rich (overview, 6 sections, conclusion, cross-references); left under all size caps (~11 KB). Math content (weighted AM–HM via two AM–GM applications) verified against the Lean source.