### PR TITLE
research(pascals-hexagon-oq-03): PART 4i — two points determine the Pascal line [VERIFIED, 0-new-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -1257,6 +1257,57 @@ theorem pascal_points_on_pascalProjLine {C : Conic} (hex : InscribedHexagon C) :
    pascalR_on_pascalProjLine hex⟩
 
 -- ============================================================
+-- PART 4i: Uniqueness — two points determine the projective line
+--          (the converse of PART 4h: pinning down *the* Pascal line)
+-- ============================================================
+
+/- PART 4h showed the three Pascal points lie on `pascalProjLine`.  This part
+   proves the converse half of "two points determine a line": *any* projective
+   line through two given points `p, q` is the same projective line as the one
+   they span, `lineThrough p q = p ×₃ q`.  The engine is the vector triple
+   product (BAC–CAB) identity
+       l ×₃ (p ×₃ q) = (l · q) p − (l · p) q,
+   whose right side vanishes precisely because `p` and `q` lie on `l`
+   (`pointOnLine p l : l · p = 0`).  No nondegeneracy is needed for this
+   direction; the result holds for every line through the two points. -/
+
+/-- **Two points determine their line.**  If both `p` and `q` lie on a line `l`,
+    then `l` is the same projective line as `lineThrough p q = p ×₃ q`.  The proof
+    is the BAC–CAB identity `l ×₃ (p ×₃ q) = (l · q) p − (l · p) q`: each
+    component is a fixed linear combination of the two incidence hypotheses
+    `l · p = 0` and `l · q = 0`.  Pure polynomial algebra in the nine
+    coordinates — no axiom, no nondegeneracy. -/
+theorem sameProjLine_of_pointOnLine_pointOnLine
+    {l : ProjLine} {p q : ProjPoint}
+    (hp : pointOnLine p l) (hq : pointOnLine q l) :
+    sameProjLine l (lineThrough p q) := by
+  simp only [pointOnLine, Fin.sum_univ_three] at hp hq
+  unfold sameProjLine lineThrough
+  funext i
+  fin_cases i <;>
+    simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+               Matrix.cons_val_two, Matrix.tail_cons, Fin.reduceFinMk,
+               Matrix.head_cons, Pi.zero_apply, Fin.isValue]
+  · linear_combination (p 0) * hq - (q 0) * hp
+  · linear_combination (p 1) * hq - (q 1) * hp
+  · linear_combination (p 2) * hq - (q 2) * hp
+
+/-- **Uniqueness of the Pascal line.**  Any projective line `l` through the first
+    two Pascal points `P = AB ∩ DE` and `Q = BC ∩ EF` is the same projective line
+    as `pascalProjLine hex`.  Combined with the incidence of PART 4h
+    (`pascalP_on_pascalProjLine` / `pascalQ_on_pascalProjLine`), this pins down
+    `pascalProjLine hex` as *the* Pascal line: the unique projective line carrying
+    the opposite-side intersection points.  When `P ≠ Q` projectively this is
+    genuine uniqueness; the cross-product characterisation makes the statement
+    hold unconditionally. -/
+theorem sameProjLine_pascalProjLine_of_pointOnLine
+    {C : Conic} (hex : InscribedHexagon C) {l : ProjLine}
+    (hP : pointOnLine (pascalP hex) l) (hQ : pointOnLine (pascalQ hex) l) :
+    sameProjLine l (pascalProjLine hex) := by
+  unfold pascalProjLine
+  exact sameProjLine_of_pointOnLine_pointOnLine hP hQ
+
+-- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================
 

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s7-uniqueness-two-points-determine-line.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s7-uniqueness-two-points-determine-line.md
@@ -1,0 +1,65 @@
+# S7 — PART 4i: Uniqueness (two points determine the Pascal line)
+
+**Researcher:** researcher-2 · **Date:** 2026-06-27 · **Phase:** ACT
+**PR:** #30825 (onto fresh `origin/main`; #30814 PART 4h already squash-merged)
+
+## Goal
+
+Complete the characterisation of `pascalProjLine`. PART 4h (S6, #30814)
+proved the *incidence* direction — the three Pascal points `P, Q, R` lie on
+`pascalProjLine hex`. This session adds the *converse / uniqueness* direction.
+
+## What was established (2 theorems, 0 sorry / 0 new axiom, VERIFIED)
+
+- **`sameProjLine_of_pointOnLine_pointOnLine`** — if `pointOnLine p l` and
+  `pointOnLine q l`, then `sameProjLine l (lineThrough p q)`. This is the
+  "two points determine a line" half. Engine: the vector triple product
+  (BAC–CAB) identity
+  ```
+  l ×₃ (p ×₃ q) = (l · q) p − (l · p) q,
+  ```
+  whose right-hand side vanishes coordinate-wise because `l · p = 0` and
+  `l · q = 0`. Each of the three components is closed by a fixed
+  `linear_combination (p i) * hq − (q i) * hp`. **No nondegeneracy hypothesis
+  is needed** — the result holds for every line through the two points.
+- **`sameProjLine_pascalProjLine_of_pointOnLine`** — specialisation to the
+  Pascal points: any line `l` through `pascalP hex` and `pascalQ hex` is
+  `sameProjLine`-equal to `pascalProjLine hex`. A one-line `unfold` + `exact`.
+
+## Significance (honest)
+
+Modest but genuinely completing. PART 4h gave "the Pascal points lie on
+`pascalProjLine`"; PART 4i gives the converse "and `pascalProjLine` is the
+*only* line they lie on" (projectively, and unconditionally as a
+cross-product statement; genuine point-uniqueness when `P ≠ Q`). Together they
+characterise `pascalProjLine` as *the* Pascal line, which is the geometric
+content the `D₆`-invariant well-definedness (PART 4g) was descending. Pure
+9-coordinate polynomial algebra; reuses only the file's existing `cross_apply`
+simp set and `linear_combination`.
+
+## Verification
+
+`docker-build.sh Proofs.PascalsHexagonOQ03` succeeded (3070 jobs), incremental
+on the cached parent `PascalsHexagon.olean`. Both lemmas axiom-free; entry
+remains `axiomatized` via the parent `conic_implies_pascal_constraint` (used
+only by `pascalR_on_pascalProjLine`, not by PART 4i).
+
+## Remaining / out of scope
+
+- `steiner_count_eq_20`, `kirkman_count_eq_60` (OQ-03-OQ-03/04) — genuinely
+  open Conway–Ryba concurrence combinatorics. Untouched.
+- The `hnd` nondegeneracy hypothesis carried by the PART 4g/5b descent
+  theorems is still an explicit assumption; discharging it needs an explicit
+  general-position predicate on the hexagon (the `InscribedHexagon` structure
+  alone permits degenerate hexagons where `P = Q`). Not attempted — it is
+  geometric setup orthogonal to the projective-uniqueness content closed here.
+
+## Gotchas this session
+
+- **Read-tool stale cache:** the harness `Read` tool returned a pre-PART-4h
+  (1329-line) snapshot while disk had 1408 lines; `Edit` matched against the
+  stale state and failed. Worked around by inserting via a Python script on
+  disk (`awk`/`sed`/`wc` confirm true disk content).
+- **#30814 squash-merged:** the PART 4h commit `d4548e3` is *not* an ancestor
+  of `origin/main`; rebased `--onto origin/main d4548e3` to keep only the
+  PART 4i commit, giving a clean +51-line PR.

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,7 +1,30 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence layer added)
-## Iteration: 6
+## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence + uniqueness layer)
+## Iteration: 7
+
+## Status (S7, researcher-2, 2026-06-27) — VERIFIED, uniqueness finishing touch
+
+Added **PART 4i** to `PascalsHexagonOQ03.lean` (PR #30825, onto fresh main;
+#30814 PART 4h already squash-merged). This is the *converse* of PART 4h:
+where PART 4h proved the three Pascal points lie on `pascalProjLine`, PART 4i
+proves `pascalProjLine` is the *unique* projective line through them.
+
+- `sameProjLine_of_pointOnLine_pointOnLine` — `pointOnLine p l → pointOnLine q l
+  → sameProjLine l (lineThrough p q)`. BAC-CAB: `l x3 (p x3 q) = (l.q)p -
+  (l.p)q`, each component a `linear_combination` of the two incidences. **No
+  nondegeneracy needed.**
+- `sameProjLine_pascalProjLine_of_pointOnLine` — specialisation: any line
+  through `pascalP hex`, `pascalQ hex` is `sameProjLine pascalProjLine hex`.
+
+0 sorry / 0 new axiom; `docker-build Proofs.PascalsHexagonOQ03` succeeded
+(3070 jobs). Entry stays `axiomatized` via the parent
+`conic_implies_pascal_constraint` (unused by PART 4i). Full notes:
+`sessions/2026-06-27-s7-uniqueness-two-points-determine-line.md`.
+
+**Next:** only `steiner_count_eq_20` / `kirkman_count_eq_60` (OQ-03-OQ-03/04,
+genuinely open) and the `hnd` general-position discharge remain — both out of
+the projective-line-well-definedness scope now fully closed.
 
 ## Status (S6, researcher-2, 2026-06-27) — VERIFIED, incidence finishing touch
 


### PR DESCRIPTION
## Summary

Adds **PART 4i** to `PascalsHexagonOQ03.lean`: the *converse* of the PART 4h incidence result (merged in #30814). PART 4h showed the three Pascal points lie on `pascalProjLine`; PART 4i shows `pascalProjLine` is **the unique** projective line through them — together pinning it down as *the* Pascal line.

## What's new (2 theorems, 0 sorry / 0 new axiom)

- `sameProjLine_of_pointOnLine_pointOnLine`: if `p` and `q` both lie on a line `l`, then `l` is the same projective line as `lineThrough p q = p ×₃ q`. Proof is the vector triple product (BAC–CAB) identity `l ×₃ (p ×₃ q) = (l·q)p − (l·p)q`; each of the three components is a fixed `linear_combination` of the two incidence hypotheses `l·p = 0`, `l·q = 0`. No nondegeneracy needed.
- `sameProjLine_pascalProjLine_of_pointOnLine`: specialisation — any line through `pascalP hex` and `pascalQ hex` is `sameProjLine` to `pascalProjLine hex`.

## Verification

- `docker-build.sh Proofs.PascalsHexagonOQ03` **succeeded** (3070 jobs), incremental on cached parent olean.
- Both new lemmas are pure coordinate algebra (`ring` / `linear_combination`), axiom-free. The broader entry remains `axiomatized` via the parent's `conic_implies_pascal_constraint` (unchanged).
- Only file warnings are pre-existing unused-simp-arg linter notes (PART 4h) and the two out-of-scope sorries (`steiner_count_eq_20`, `kirkman_count_eq_60`, OQ-03-OQ-03/04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)