### PR TITLE
research(erdos-493-oq-01): C5 prime capstone — ordered rep count = 2 ⟺ n+1 prime [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos493OQ01.lean
+++ b/proofs/Proofs/Erdos493OQ01.lean
@@ -140,4 +140,65 @@ theorem reps_card_eq_tau (n : ℕ) :
       rw [← hst]; exact Nat.mul_div_cancel_left _ (by omega)
     simp only [Prod.mk.injEq, hdiv]; omega
 
+/-- A natural number has **exactly two divisors iff it is prime** — the two
+divisors being `1` and the number itself. This is the divisor-count form of
+primality; it lets us read primality directly off the representation count. -/
+theorem card_divisors_eq_two_iff_prime {N : ℕ} : N.divisors.card = 2 ↔ N.Prime := by
+  constructor
+  · intro h
+    have hN0 : N ≠ 0 := by rintro rfl; simp [Nat.divisors_zero] at h
+    have hN1 : N ≠ 1 := by rintro rfl; simp [Nat.divisors_one] at h
+    have h2 : 2 ≤ N := by omega
+    have hsub : ({1, N} : Finset ℕ) ⊆ N.divisors := by
+      intro x hx
+      rw [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl
+      · exact Nat.one_mem_divisors.mpr hN0
+      · exact Nat.mem_divisors_self _ hN0
+    have hpair : ({1, N} : Finset ℕ).card = 2 := Finset.card_pair (Ne.symm hN1)
+    have heq : N.divisors = {1, N} :=
+      (Finset.eq_of_subset_of_card_le hsub (by rw [hpair]; omega)).symm
+    rw [Nat.prime_def]
+    refine ⟨h2, fun m hm => ?_⟩
+    have hmem : m ∈ N.divisors := Nat.mem_divisors.mpr ⟨hm, hN0⟩
+    rw [heq, Finset.mem_insert, Finset.mem_singleton] at hmem
+    exact hmem
+  · intro hp
+    rw [Nat.Prime.divisors hp, Finset.card_pair hp.one_lt.ne]
+
+/-- **(C5) Primality capstone.** There are **exactly two** ordered
+representations `n = a*b - (a+b)` (with `a, b ≥ 2`) **iff** `n + 1` is prime.
+For prime `n + 1 = p` the two representations are `(2, n+2)` and `(n+2, 2)` — the
+single *unordered* representation `{2, n+2}` counted in both orders — so the
+representation is unordered-unique exactly when `n + 1` is prime. This is the
+quantitative reading of `hasNontrivialRep_iff_factor` (C4): no representation with
+both parts `≥ 3` exists iff `n + 1` has no nontrivial factorization. The proof is
+immediate from `reps_card_eq_tau` (C2): the ordered count is `τ(n+1)`, which equals
+`2` iff `n + 1` is prime. -/
+theorem reps_card_eq_two_iff_prime (n : ℕ) :
+    (repsFinset n).card = 2 ↔ (n + 1).Prime := by
+  rw [reps_card_eq_tau, card_divisors_eq_two_iff_prime]
+
+/-- The representation is *ordered-unique* (exactly one ordered pair) **iff**
+`n = 0`, the lone representation being `(2, 2)` since `n + 1 = 1` has the single
+divisor `1`. Together with `reps_card_eq_two_iff_prime`, the unordered
+representation of `n` is unique exactly when `n = 0` or `n + 1` is prime. -/
+theorem reps_card_eq_one_iff (n : ℕ) :
+    (repsFinset n).card = 1 ↔ n = 0 := by
+  rw [reps_card_eq_tau]
+  constructor
+  · intro h
+    by_contra hne
+    have hsub : ({1, n + 1} : Finset ℕ) ⊆ (n + 1).divisors := by
+      intro x hx
+      rw [Finset.mem_insert, Finset.mem_singleton] at hx
+      rcases hx with rfl | rfl
+      · exact Nat.one_mem_divisors.mpr (by omega)
+      · exact Nat.mem_divisors_self _ (by omega)
+    have hpair : ({1, n + 1} : Finset ℕ).card = 2 := Finset.card_pair (by omega)
+    have hge : 2 ≤ (n + 1).divisors.card := hpair ▸ Finset.card_le_card hsub
+    omega
+  · rintro rfl
+    simp [Nat.divisors_one]
+
 end Erdos493

--- a/research/problems/erdos-493-oq-01/knowledge.md
+++ b/research/problems/erdos-493-oq-01/knowledge.md
@@ -1,5 +1,42 @@
 # Erdős #493 — OQ-01: Exact image and representation count of product-minus-sum
 
+## Session 2026-06-27 (researcher-6) — ACT, C5 PRIME CAPSTONE VERIFIED ✅ (Docker UP)
+
+- **Mode**: REVISIT (own problem; theory was C1–C4 + C2-count in Lean, with the
+  "`n+1` prime ⟺ unordered-unique rep" bridge flagged by researcher-10 as the
+  **only un-Lean'd corollary**). **Outcome**: progress — that gap is now closed
+  and machine-checked under a real Docker build.
+- **Docker is back UP** (containerd store healthy, 41Gi free). Ran the canonical
+  `./proofs/scripts/docker-build.sh Proofs.Erdos493OQ01` → **Build completed
+  successfully (3059 jobs), 0 errors**. No offline `LAKE_UNSAFE` workaround needed.
+- **Added 3 elementary, verified theorems** to the registered file
+  `proofs/Proofs/Erdos493OQ01.lean` (now 9 `theorem` + `mem_repsFinset` + 1 def,
+  0 sorries):
+  * `card_divisors_eq_two_iff_prime {N : ℕ} : N.divisors.card = 2 ↔ N.Prime` —
+    reusable divisor-count form of primality (forward: `{1,N} ⊆ divisors N` with
+    matched card ⇒ `divisors N = {1,N}` via `Finset.eq_of_subset_of_card_le`, then
+    `Nat.prime_def`; converse: `Nat.Prime.divisors` + `Finset.card_pair`). Plausibly
+    mathlib-worthy as a standalone lemma.
+  * **`reps_card_eq_two_iff_prime (n) : (repsFinset n).card = 2 ↔ (n+1).Prime`** —
+    the **C5 primality capstone**: exactly two ordered representations
+    `n = a*b-(a+b)` iff `n+1` is prime. Two-line proof:
+    `rw [reps_card_eq_tau, card_divisors_eq_two_iff_prime]`. The literal bridge
+    the prior session left open.
+  * `reps_card_eq_one_iff (n) : (repsFinset n).card = 1 ↔ n = 0` — ordered count
+    is 1 iff `n = 0` (the `(2,2)` rep). Together with C5: unordered uniqueness ⟺
+    `n = 0 ∨ (n+1).Prime`.
+- `#print axioms` on all three → `[propext, Classical.choice, Quot.sound]` only.
+  **NO `sorryAx`, NO `Lean.ofReduceBool`** → genuinely **verified, 0 axioms**.
+- **Verify-before-assert**: brute-forced ordered-rep count vs `τ(n+1)` and both
+  iff's for `n = 0..299` in sympy → 0 mismatches before writing Lean.
+- **Gotcha logged**: `rcases hx with rfl | rfl` on `x = 1 ∨ x = N` substitutes
+  **N := x** in the `x = N` branch (eliminates the section variable, not `x`), so a
+  later `Nat.mem_divisors_self N …` fails with `unknown identifier N`. Use `_`.
+- **Next**: OQ-01 is now theory-complete in Lean (C1–C5). Only remaining cosmetic
+  item is an explicit *unordered* `Finset` count `= ⌈τ(n+1)/2⌉` (needs a
+  quotient-by-swap Finset; low marginal value — uniqueness is fully captured by
+  C5 + `reps_card_eq_one_iff`). Recommend marking COMPLETED on merge.
+
 ## Session 2026-06-27 (researcher-10) — ACT, C2 VERIFIED OFFLINE ✅
 
 - **Mode**: REVISIT (own problem, theory-complete C1–C5, only C2 build-gated).


### PR DESCRIPTION
## Summary

Closes the **only un-Lean'd corollary** of Erdős #493 OQ-01 (flagged by the prior researcher-10 session): the literal **`n+1` prime ⟺ unordered-unique representation** bridge.

The map `(a,b) ↦ a*b-(a+b)` over `a,b ≥ 2` has, for each value `n`, an ordered representation count equal to `τ(n+1)` (the existing C2 theorem `reps_card_eq_tau`). This PR reads primality directly off that count.

## New theorems (`proofs/Proofs/Erdos493OQ01.lean`)

| Theorem | Statement |
|---|---|
| `card_divisors_eq_two_iff_prime` | `N.divisors.card = 2 ↔ N.Prime` — reusable divisor-count form of primality |
| **`reps_card_eq_two_iff_prime`** | `(repsFinset n).card = 2 ↔ (n+1).Prime` — **C5 capstone** |
| `reps_card_eq_one_iff` | `(repsFinset n).card = 1 ↔ n = 0` |

Together: the unordered representation of `n` is unique **⟺ `n = 0 ∨ (n+1)` prime**.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos493OQ01` → **Build completed successfully (3059 jobs), 0 errors**.
- `#print axioms` on all three → `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`**. Genuinely **verified, 0 assumption-axioms**.
- Verify-before-assert: brute-forced ordered-rep count vs `τ(n+1)` and both iff's for `n = 0..299` in sympy → 0 mismatches before formalizing.

File now: 9 `theorem` + `mem_repsFinset` + 1 `def`, 0 sorries. C1–C5 theory-complete in Lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)