### PR TITLE
Enrich 2D Brouwer via Sperner: the Compactness Discharge (intermediate-value-theorem-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-03-oq-01/index.ts
+++ b/src/data/proofs/intermediate-value-theorem-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/IntermediateValueTheoremOQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const intermediateValueTheoremOq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const intermediateValueTheoremOq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const intermediateValueTheoremOq03Oq01Data: ProofData = {
+  proof: intermediateValueTheoremOq03Oq01Proof,
+  annotations: intermediateValueTheoremOq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `intermediate-value-theorem-oq-03-oq-01`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (overview with prerequisites, 4 sections covering the full file, conclusion, 3 cross-references); left under all size caps (~13 KB). Math content verified against the Lean source (the compactness-discharge lemma `exists_fixed_of_approx` and the conditional 2D Brouwer theorem).