### PR TITLE
Enrich Kummer v₂(C(2n,n))=2 (kummer-theorem-oq-04-oq-01-oq-01): annotation depth

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "insight",
     "title": "Core New Lemma: s₂(n) = 2 ⟺ Two Distinct Powers of Two",
-    "content": "`sum_digits_two_eq_two_iff` is the combinatorial heart: a natural number has binary digit sum (popcount) 2 exactly when it is a sum of two distinct powers of two, n = 2^a + 2^b with a > b. Mathlib has no popcount-2 characterisation; this advances the parent's popcount-1 (powers-of-two) result one level up the ladder."
+    "content": "`sum_digits_two_eq_two_iff` is the combinatorial heart: a natural number has binary digit sum (popcount) 2 exactly when it is a sum of two distinct powers of two, n = 2^a + 2^b with a > b. Mathlib has no popcount-2 characterisation; this advances the parent's popcount-1 (powers-of-two) result one level up the ladder.",
+    "mathContext": "$s_2(n) = 2 \\iff \\exists\\, a > b,\\ n = 2^a + 2^b$, where $s_2(n) = \\sum_i b_i$ is the binary digit sum (popcount) of $n = \\sum_i b_i 2^i$. The two-bit numbers are exactly the level set $s_2^{-1}(2)$.",
+    "significance": "key",
+    "relatedConcepts": ["binary digit sum / popcount", "level sets of popcount", "powers of two", "Hamming weight"],
+    "prerequisites": ["base-2 representation of ℕ", "the parent popcount-1 characterisation s₂(n)=1 ⟺ n=2^k"]
   },
   {
     "id": "ann-kummer-oq040101-descent",
@@ -19,7 +23,11 @@
     },
     "type": "technique",
     "title": "Parity Descent: Popcount-2 Reduces to Popcount-1",
-    "content": "The forward direction is strong induction on n peeling the lowest bit via s₂(n) = (n%2) + s₂(n/2). An even n inherits both bits from n/2 (recurse, doubling both exponents); an odd n spends one bit on 2^0 and the remaining digit sum 1 lands exactly on the parent's popcount-one lemma `sum_digits_two_eq_one_imp`. The popcount ladder climbs by feeding level k into level k-1."
+    "content": "The forward direction is strong induction on n peeling the lowest bit via s₂(n) = (n%2) + s₂(n/2). An even n inherits both bits from n/2 (recurse, doubling both exponents); an odd n spends one bit on 2^0 and the remaining digit sum 1 lands exactly on the parent's popcount-one lemma `sum_digits_two_eq_one_imp`. The popcount ladder climbs by feeding level k into level k-1.",
+    "mathContext": "$s_2(n) = (n \\bmod 2) + s_2(\\lfloor n/2 \\rfloor)$ from `Nat.digits_def'`. Even $n$: low bit $0 \\Rightarrow s_2(n/2)=2$, IH gives $n/2 = 2^a+2^b$, so $n = 2^{a+1}+2^{b+1}$. Odd $n$: low bit $1 \\Rightarrow s_2(n/2)=1$, popcount-1 gives $n/2 = 2^k$, so $n = 2^{k+1}+2^0$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction (Nat.strongRecOn)", "lowest-bit peel recursion", "parity case split", "reduction to a smaller invariant"],
+    "prerequisites": ["digits 2 n = n%2 :: digits 2 (n/2)", "strong induction on ℕ", "the popcount-1 base lemma"]
   },
   {
     "id": "ann-kummer-oq040101-converse",
@@ -30,7 +38,11 @@
     },
     "type": "technique",
     "title": "Converse by a Single Factorisation",
-    "content": "`sum_digits_two_eq_two_of` factors 2^a + 2^b = 2^b·(2^(a-b)+1). Multiplying by a power of two only prepends zero digits (`sum_digits_two_pow_mul`), so the digit sum equals that of the odd part 2^m+1, whose binary string 1 0…0 1 has digit sum 2 (`sum_digits_two_pow_succ_add_one`)."
+    "content": "`sum_digits_two_eq_two_of` factors 2^a + 2^b = 2^b·(2^(a-b)+1). Multiplying by a power of two only prepends zero digits (`sum_digits_two_pow_mul`), so the digit sum equals that of the odd part 2^m+1, whose binary string 1 0…0 1 has digit sum 2 (`sum_digits_two_pow_succ_add_one`).",
+    "mathContext": "$2^a + 2^b = 2^b(2^{a-b}+1)$ with $a>b$. Doubling-invariance $s_2(2^c x) = s_2(x)$ strips the $2^b$, and $s_2(2^{m}+1) = 2$ for $m\\ge 1$ since the binary string is $1\\underbrace{0\\cdots0}_{m-1}1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["doubling-invariance of digit sum s₂(2^c·x)=s₂(x)", "factoring out the lowest power of two", "binary string 1 0…0 1"],
+    "prerequisites": ["sum_digits_two_pow_mul", "sum_digits_two_pow_succ_add_one", "Nat.sub arithmetic for a>b"]
   },
   {
     "id": "ann-kummer-oq040101-headline",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "Headline: v₂(C(2n,n)) = 2 ⟺ n Has Two 1-Bits",
-    "content": "`padicValNat_two_centralBinom_eq_two_iff` rewrites the valuation as the binary digit sum via the parent identity v₂(C(2n,n)) = s₂(n), then applies the popcount-2 classification. The binomial coefficient contributes only through that valuation formula."
+    "content": "`padicValNat_two_centralBinom_eq_two_iff` rewrites the valuation as the binary digit sum via the parent identity v₂(C(2n,n)) = s₂(n), then applies the popcount-2 classification. The binomial coefficient contributes only through that valuation formula.",
+    "mathContext": "$v_2\\!\\binom{2n}{n} = s_2(n)$ (Kummer/Legendre on the central diagonal: the carries adding $n+n$ in base 2 are the 1-bits of $n$). Hence $v_2\\!\\binom{2n}{n} = 2 \\iff s_2(n) = 2 \\iff \\exists\\, a>b,\\ n = 2^a+2^b$.",
+    "significance": "key",
+    "relatedConcepts": ["Kummer's carry-count theorem", "central binomial coefficient", "2-adic valuation", "Legendre's formula v_p(n!)"],
+    "prerequisites": ["the parent valuation formula v₂(C(2n,n)) = s₂(n)", "sum_digits_two_eq_two_iff"]
   },
   {
     "id": "ann-kummer-oq040101-exactdvd",
@@ -52,6 +68,10 @@
     },
     "type": "insight",
     "title": "Exact Divisibility as a Valuation Window",
-    "content": "`four_exactDvd_centralBinom_iff` recasts the result as 4 ∣ C(2n,n) ∧ 8 ∤ C(2n,n). The bridge `exactDvd_four_iff_padicValNat_two` uses `padicValNat_dvd_iff_le` on 4 = 2² and 8 = 2³ to bracket the valuation: 4 ∣ m ∧ 8 ∤ m is exactly 2 ≤ v₂(m) < 3, i.e. v₂(m) = 2."
+    "content": "`four_exactDvd_centralBinom_iff` recasts the result as 4 ∣ C(2n,n) ∧ 8 ∤ C(2n,n). The bridge `exactDvd_four_iff_padicValNat_two` uses `padicValNat_dvd_iff_le` on 4 = 2² and 8 = 2³ to bracket the valuation: 4 ∣ m ∧ 8 ∤ m is exactly 2 ≤ v₂(m) < 3, i.e. v₂(m) = 2.",
+    "mathContext": "For $m>0$: $4 \\mid m \\iff 2 \\le v_2(m)$ and $8 \\nmid m \\iff v_2(m) < 3$ (via $p^k \\mid m \\iff k \\le v_p(m)$). Together $2 \\le v_2(m) < 3 \\iff v_2(m) = 2$ — the two divisibilities pinch the integer-valued valuation to a single value.",
+    "significance": "supporting",
+    "relatedConcepts": ["exact divisibility p^k ‖ m", "padicValNat_dvd_iff_le", "integer pinching of a valuation", "centralBinom_pos (nonzero hypothesis)"],
+    "prerequisites": ["p^k ∣ a ↔ k ≤ v_p(a) for a ≠ 0", "C(2n,n) > 0", "the headline valuation characterisation"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `kummer-theorem-oq-04-oq-01-oq-01` (central binomial coefficient divisible by exactly 4 ⟺ n has two 1-bits).

meta.json was already comprehensive (4 key insights, 7 sections covering the whole 163-line file, conclusion with 3 open questions, references, mathlib dependencies). The gap was in **annotations**: all 5 had rich `content` but lacked the prescribed enrichment fields.

- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations.
- `mathContext` states each step in formula form: the popcount-2 level set s₂(n)=2 ⟺ ∃a>b, n=2^a+2^b; the parity-descent recursion s₂(n)=(n mod 2)+s₂(⌊n/2⌋); the converse factorisation 2^a+2^b=2^b(2^{a-b}+1); the Kummer headline v₂(C(2n,n))=s₂(n); and the divisibility window 4∣m ∧ 8∤m ⟺ v₂(m)=2.

annotations.json grew 2.5 KB → ~5.6 KB; meta.json untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)