### PR TITLE
Enrich weighted AM–HM (jensen-inequality-oq-01-oq-01-oq-01-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 52 },
     "type": "concept",
     "title": "Goal: the weighted AM–HM inequality, a gap in Mathlib",
-    "content": "Mathlib formalizes the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but not the harmonic-mean rung M₋₁ ≤ M₁ or its equality case. This file supplies both: for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, the weighted harmonic mean (∑ wᵢ·xᵢ⁻¹)⁻¹ is at most the weighted arithmetic mean ∑ wᵢ·xᵢ, with equality iff all xᵢ are equal. The header sets up the base chain H ≤ G ≤ A of the power-mean ladder and the strategy of bracketing the geometric mean G via two applications of the parent's weighted AM–GM."
+    "content": "Mathlib formalizes the weighted AM–GM inequality (Real.geom_mean_le_arith_mean_weighted) but not the harmonic-mean rung M₋₁ ≤ M₁ or its equality case. This file supplies both: for strictly positive data xᵢ and nonnegative weights wᵢ summing to 1, the weighted harmonic mean (∑ wᵢ·xᵢ⁻¹)⁻¹ is at most the weighted arithmetic mean ∑ wᵢ·xᵢ, with equality iff all xᵢ are equal. The header sets up the base chain H ≤ G ≤ A of the power-mean ladder and the strategy of bracketing the geometric mean G via two applications of the parent's weighted AM–GM.",
+    "mathContext": "Power means $M_p(x;w) = (\\sum_i w_i x_i^{p})^{1/p}$ are monotone in $p$; the rungs here are $M_{-1} = H = (\\sum_i w_i x_i^{-1})^{-1}$ (harmonic), $M_0 = G = \\prod_i x_i^{w_i}$ (geometric), $M_1 = A = \\sum_i w_i x_i$ (arithmetic). The target is $H \\le A$, the $p=-1 \\le p=1$ instance.",
+    "significance": "context",
+    "relatedConcepts": ["power means M_p", "weighted AM–GM–HM hierarchy", "harmonic mean", "convexity / Jensen's inequality"],
+    "prerequisites": ["weighted arithmetic, geometric, harmonic means", "the parent weighted AM–GM lemma", "weights wᵢ ≥ 0 with ∑ wᵢ = 1"]
   },
   {
     "id": "ann-prod-rpow-inv",
@@ -13,7 +17,11 @@
     "range": { "startLine": 53, "endLine": 60 },
     "type": "lemma",
     "title": "Reciprocal of the weighted geometric mean",
-    "content": "prod_rpow_inv proves ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹. Pointwise, Real.inv_rpow (valid since each xᵢ > 0) gives (xᵢ⁻¹)^{wᵢ} = (xᵢ^{wᵢ})⁻¹; Finset.prod_inv_distrib then pulls the inverse out of the product. This is exactly what lets the second AM–GM application — applied to the reciprocals — bound G⁻¹ rather than some unrelated quantity."
+    "content": "prod_rpow_inv proves ∏ᵢ (xᵢ⁻¹)^{wᵢ} = (∏ᵢ xᵢ^{wᵢ})⁻¹. Pointwise, Real.inv_rpow (valid since each xᵢ > 0) gives (xᵢ⁻¹)^{wᵢ} = (xᵢ^{wᵢ})⁻¹; Finset.prod_inv_distrib then pulls the inverse out of the product. This is exactly what lets the second AM–GM application — applied to the reciprocals — bound G⁻¹ rather than some unrelated quantity.",
+    "mathContext": "$\\prod_i (x_i^{-1})^{w_i} = \\prod_i (x_i^{w_i})^{-1} = \\big(\\prod_i x_i^{w_i}\\big)^{-1} = G^{-1}$, using $(x^{-1})^{w} = (x^{w})^{-1}$ for $x>0$ (Real.inv_rpow) and $\\prod a_i^{-1} = (\\prod a_i)^{-1}$.",
+    "significance": "technical",
+    "relatedConcepts": ["Real.inv_rpow", "Finset.prod_inv_distrib", "geometric mean of reciprocals", "rpow of a positive real"],
+    "prerequisites": ["real power xⁿ via rpow for x > 0", "distributing inverse over a finite product"]
   },
   {
     "id": "ann-harm-le-geom",
@@ -21,7 +29,11 @@
     "range": { "startLine": 61, "endLine": 75 },
     "type": "lemma",
     "title": "Harmonic mean ≤ geometric mean",
-    "content": "harm_le_geom applies the parent's weighted_amgm_le to the reciprocal data xᵢ⁻¹, yielding G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D. Because the geometric mean G > 0 (a product of positive rpow values, Real.rpow_pos_of_pos + Finset.prod_pos), the bound G⁻¹ ≤ D inverts via inv_anti₀ to D⁻¹ ≤ (G⁻¹)⁻¹ = G. This is the H ≤ G half of the base chain."
+    "content": "harm_le_geom applies the parent's weighted_amgm_le to the reciprocal data xᵢ⁻¹, yielding G⁻¹ = ∏ (xᵢ⁻¹)^{wᵢ} ≤ ∑ wᵢ·xᵢ⁻¹ = D. Because the geometric mean G > 0 (a product of positive rpow values, Real.rpow_pos_of_pos + Finset.prod_pos), the bound G⁻¹ ≤ D inverts via inv_anti₀ to D⁻¹ ≤ (G⁻¹)⁻¹ = G. This is the H ≤ G half of the base chain.",
+    "mathContext": "Apply AM–GM to $x_i^{-1}$: $G^{-1} = \\prod_i (x_i^{-1})^{w_i} \\le \\sum_i w_i x_i^{-1} = D$. Since $G>0$, inverting (order-reversing on positives) gives $H = D^{-1} \\le G$.",
+    "significance": "key",
+    "relatedConcepts": ["weighted AM–GM applied to reciprocals", "order-reversal of inverse on ℝ₊ (inv_anti₀)", "positivity of the geometric mean", "H ≤ G rung"],
+    "prerequisites": ["prod_rpow_inv", "the parent weighted_amgm_le", "x ↦ x⁻¹ is antitone on (0,∞)"]
   },
   {
     "id": "ann-amhm-le",
@@ -29,7 +41,11 @@
     "range": { "startLine": 76, "endLine": 89 },
     "type": "theorem",
     "title": "The weighted AM–HM inequality",
-    "content": "weighted_amhm_le chains the two halves: H ≤ G (harm_le_geom) and G ≤ A (the parent's weighted_amgm_le applied to the data xᵢ), giving (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ. The whole inequality is thus two applications of one parent lemma joined at the common pivot G — no fresh convexity argument."
+    "content": "weighted_amhm_le chains the two halves: H ≤ G (harm_le_geom) and G ≤ A (the parent's weighted_amgm_le applied to the data xᵢ), giving (∑ wᵢ·xᵢ⁻¹)⁻¹ ≤ ∑ wᵢ·xᵢ. The whole inequality is thus two applications of one parent lemma joined at the common pivot G — no fresh convexity argument.",
+    "mathContext": "$H = \\big(\\sum_i w_i x_i^{-1}\\big)^{-1} \\le G = \\prod_i x_i^{w_i} \\le A = \\sum_i w_i x_i$. Transitivity of the two AM–GM instances (on $x_i^{-1}$ and on $x_i$) at the shared pivot $G$ yields $H \\le A$.",
+    "significance": "key",
+    "relatedConcepts": ["transitivity through the geometric mean", "weighted AM–HM inequality", "power-mean monotonicity", "pivot bracketing"],
+    "prerequisites": ["harm_le_geom (H ≤ G)", "weighted_amgm_le (G ≤ A)", "transitivity of ≤"]
   },
   {
     "id": "ann-amhm-eq-iff",
@@ -37,7 +53,11 @@
     "range": { "startLine": 90, "endLine": 115 },
     "type": "theorem",
     "title": "Equality case: harmonic = arithmetic iff data constant",
-    "content": "weighted_amhm_eq_iff characterizes equality. Forward: if H = A then the squeeze H ≤ G ≤ A forces G = A, and the parent's weighted_amgm_eq_iff converts G = A into the constancy of the xᵢ. Backward: constancy makes both AM–GM applications equalities (weighted_amgm_eq_iff in the mpr direction, applied to xᵢ and to xᵢ⁻¹), so D = G⁻¹ and hence H = D⁻¹ = G = A. The squeeze structure makes the harmonic equality case fall out of the geometric one with no extra strict-convexity work."
+    "content": "weighted_amhm_eq_iff characterizes equality. Forward: if H = A then the squeeze H ≤ G ≤ A forces G = A, and the parent's weighted_amgm_eq_iff converts G = A into the constancy of the xᵢ. Backward: constancy makes both AM–GM applications equalities (weighted_amgm_eq_iff in the mpr direction, applied to xᵢ and to xᵢ⁻¹), so D = G⁻¹ and hence H = D⁻¹ = G = A. The squeeze structure makes the harmonic equality case fall out of the geometric one with no extra strict-convexity work.",
+    "mathContext": "$H = A \\iff \\forall i j,\\ w_i\\,w_j > 0 \\Rightarrow x_i = x_j$. From $H \\le G \\le A$, equality of the ends forces $G = A$; then AM–GM equality (strict convexity of $-\\log$) gives constancy, and conversely constancy collapses both rungs.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem on a chain of inequalities", "AM–GM equality case", "strict convexity of −log", "constancy of weighted data"],
+    "prerequisites": ["weighted_amhm_le (the squeeze)", "the parent weighted_amgm_eq_iff (both directions)", "antisymmetry of ≤"]
   },
   {
     "id": "ann-amhm-lt",
@@ -45,6 +65,10 @@
     "range": { "startLine": 116, "endLine": 124 },
     "type": "theorem",
     "title": "Strict inequality when data differ",
-    "content": "weighted_amhm_lt_of_ne upgrades the inequality to strict: if two data values xⱼ ≠ xₖ, then (∑ wᵢ·xᵢ⁻¹)⁻¹ < ∑ wᵢ·xᵢ. Proof: lt_of_le_of_ne from weighted_amhm_le, with the equality ruled out by the contrapositive of weighted_amhm_eq_iff."
+    "content": "weighted_amhm_lt_of_ne upgrades the inequality to strict: if two data values xⱼ ≠ xₖ, then (∑ wᵢ·xᵢ⁻¹)⁻¹ < ∑ wᵢ·xᵢ. Proof: lt_of_le_of_ne from weighted_amhm_le, with the equality ruled out by the contrapositive of weighted_amhm_eq_iff.",
+    "mathContext": "If $x_j \\ne x_k$ (with $w_j, w_k > 0$) then $H = A$ fails by weighted_amhm_eq_iff, so the non-strict $H \\le A$ sharpens to $H < A$ via $a \\le b \\wedge a \\ne b \\Rightarrow a < b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lt_of_le_of_ne", "strict vs non-strict inequality", "contrapositive of the equality case", "non-constant data"],
+    "prerequisites": ["weighted_amhm_le", "weighted_amhm_eq_iff", "partial order: ≤ and ≠ give <"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01-oq-02` (the weighted arithmetic–harmonic mean inequality and its equality case, a gap in Mathlib).

meta.json was already complete (4 key insights, 6 sections covering the full file, conclusion with 3 open questions, cross-references). The gap was in **annotations**: all 6 had rich `content` but lacked the prescribed enrichment fields.

- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 6 annotations.
- `mathContext` frames the power-mean ladder M₋₁ ≤ M₀ ≤ M₁, the reciprocal identity ∏(xᵢ⁻¹)^wᵢ = G⁻¹, the order-reversing inversion giving H ≤ G, transitivity through the geometric-mean pivot, and the squeeze that yields the equality and strict-inequality cases.

annotations.json only; meta.json untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)