### PR TITLE
Enrich Kummer OQ-04-OQ-01-OQ-01: C(2n,n) Divisible by Exactly 4 (kummer-theorem-oq-04-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/kummer-theorem-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/KummerTheoremOQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const kummerTheoremOq04Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const kummerTheoremOq04Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const kummerTheoremOq04Oq01Oq01Data: ProofData = {
+  proof: kummerTheoremOq04Oq01Oq01Proof,
+  annotations: kummerTheoremOq04Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `kummer-theorem-oq-04-oq-01-oq-01`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (overview with prerequisites, 7 sections covering the full file, conclusion, 3 cross-references, references); left under all size caps (~14 KB). Math content (popcount-2 ⟺ two distinct powers of two; v₂(C(2n,n)) = 2) verified against the Lean source.