### PR TITLE
Enrich Sperner's Lemma Bridge for Mathlib's SimplicialComplex (sperner-simplicial-bridge-oq-02)

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge-oq-02/index.ts
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpernerSimplicialBridgeOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spernerSimplicialBridgeOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spernerSimplicialBridgeOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spernerSimplicialBridgeOq02Data: ProofData = {
+  proof: spernerSimplicialBridgeOq02Proof,
+  annotations: spernerSimplicialBridgeOq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `sperner-simplicial-bridge-oq-02`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 6 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (overview with 5 keyInsights, 4 sections, conclusion with 4 open questions, 3 cross-references); left under all size caps (~18 KB). Math content (facet extraction, affine-independence dimension bound, panchromatic facet) verified against the Lean source.