### PR TITLE
research(collatz-structured-oq-02-oq-03): reusable affine step-composition lemmas (Terras leading-coefficient law) [verified, axiom-free]

### DIFF
--- a/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
+++ b/proofs/Proofs/CollatzStructuredOQ02OQ03.lean
@@ -190,6 +190,73 @@ theorem affine_residue_attainsBelow {M r k c d : ℕ}
   have hcm : c * m ≤ M * m := Nat.mul_le_mul_right m hc.le
   omega
 
+/-! ### Reusable affine step-composition lemmas (Terras leading-coefficient law)
+
+The per-residue trajectory chases above all share the same skeleton: track the
+orbit of a residue class `M·m + r` as an **affine function** `c·m + d`, and at
+each Collatz step read the parity off the *constant* coefficient `d` because the
+leading coefficient `c` is held **even** (so the parity of `c·m + d` is `d mod 2`,
+independent of `m`).  The two lemmas below package one such step each, turning the
+hand-written `collatz_odd …; ring` / `collatz_even …; omega` boilerplate into a
+reusable composition primitive.
+
+This is exactly the affine recurrence of the Terras parity-vector law
+(`collatz^[b] n = (3^a · n + C_v)/2^b` with leading coefficient `3^a/2^b`): an
+even step halves `(c, d) ↦ (c/2, d/2)`, an odd step maps `(c, d) ↦ (3c, 3d+1)`,
+and the window drops below its start exactly when the accumulated `c < M`, i.e.
+`3^a < 2^b`.  Both lemmas are axiom-free. -/
+
+/-- **Affine even step.**  If after `i` Collatz steps the residue class `M·m + r`
+has reached the affine form `c·m + d` with `c = 2c'` and `d = 2d'` both even, then
+`c·m + d` is even for every `m`, so the next step halves it to `c'·m + d'`. -/
+theorem affine_step_even {M r c d c' d' i : ℕ}
+    (hc : c = 2 * c') (hd : d = 2 * d')
+    (hi : ∀ m : ℕ, collatz^[i] (M * m + r) = c * m + d) :
+    ∀ m : ℕ, collatz^[i + 1] (M * m + r) = c' * m + d' := by
+  subst hc hd
+  intro m
+  rw [Function.iterate_succ_apply', hi m]
+  have he : (2 * c' * m + 2 * d') % 2 = 0 := by
+    rw [show 2 * c' * m + 2 * d' = 2 * (c' * m + d') from by ring]; omega
+  rw [collatz_even he, show 2 * c' * m + 2 * d' = 2 * (c' * m + d') from by ring]
+  omega
+
+/-- **Affine odd step.**  If after `i` Collatz steps the residue class `M·m + r`
+has reached the affine form `c·m + d` with `c = 2c'` even and `d` odd, then
+`c·m + d` is odd for every `m`, so the next step maps it to `(3c)·m + (3d+1)`.
+The caller supplies the normalised next coefficients `cn = 3c`, `dn = 3d + 1`. -/
+theorem affine_step_odd {M r c d c' cn dn i : ℕ}
+    (hc : c = 2 * c') (hd : d % 2 = 1) (hcn : cn = 3 * c) (hdn : dn = 3 * d + 1)
+    (hi : ∀ m : ℕ, collatz^[i] (M * m + r) = c * m + d) :
+    ∀ m : ℕ, collatz^[i + 1] (M * m + r) = cn * m + dn := by
+  subst hc hcn hdn
+  intro m
+  rw [Function.iterate_succ_apply', hi m]
+  have ho : (2 * c' * m + d) % 2 = 1 := by
+    rw [show 2 * c' * m + d = 2 * (c' * m) + d from by ring]; omega
+  rw [collatz_odd ho]
+  ring
+
+/-- **Worked template / validation** for the affine step-composition lemmas: the
+`n ≡ 3 (mod 16)` trajectory `16m+3 ↦ 48m+10 ↦ 24m+5 ↦ 72m+16 ↦ 36m+8 ↦ 18m+4 ↦
+9m+2` derived purely by chaining `affine_step_odd`/`affine_step_even` (parities
+odd, even, odd, even, even, even), with no per-step `ring`/`omega` bookkeeping —
+each step only names the next `(c, d)` and discharges the arithmetic side
+conditions by `rfl`.  Used below to give `mod_sixteen_three_attainsBelow` a
+one-line `hiter`. -/
+theorem mod_sixteen_three_trajectory (m : ℕ) :
+    collatz^[6] (16 * m + 3) = 9 * m + 2 := by
+  have h0 : ∀ m : ℕ, collatz^[0] (16 * m + 3) = 16 * m + 3 := fun _ => rfl
+  have h1 := affine_step_odd  (c := 16) (c' := 8)  (cn := 48) (dn := 10) (d := 3)
+              rfl rfl rfl rfl h0
+  have h2 := affine_step_even (c := 48) (c' := 24) (d := 10) (d' := 5)  rfl rfl h1
+  have h3 := affine_step_odd  (c := 24) (c' := 12) (cn := 72) (dn := 16) (d := 5)
+              rfl rfl rfl rfl h2
+  have h4 := affine_step_even (c := 72) (c' := 36) (d := 16) (d' := 8) rfl rfl h3
+  have h5 := affine_step_even (c := 36) (c' := 18) (d := 8)  (d' := 4) rfl rfl h4
+  have h6 := affine_step_even (c := 18) (c' := 9)  (d := 4)  (d' := 2) rfl rfl h5
+  exact h6 m
+
 /-- Every `n ≡ 3 (mod 16)` drops below itself in exactly six steps:
 `16m+3 ↦ 48m+10 ↦ 24m+5 ↦ 72m+16 ↦ 36m+8 ↦ 18m+4 ↦ 9m+2`, and `9m+2 < 16m+3` for
 every `m ≥ 0`.  All six parities are forced by the residue `mod 16` alone (independent
@@ -204,18 +271,7 @@ theorem mod_sixteen_three_attainsBelow {n : ℕ} (h : n % 16 = 3) : AttainsBelow
   -- and `c = 9 = 3^2 < 16` is `3^2 < 2^4`.
   affine_residue_attainsBelow (M := 16) (r := 3) (k := 6) (c := 9) (d := 2)
     (by norm_num) (by norm_num) (by norm_num)
-    (fun m => by
-      have s1 : collatz (16 * m + 3) = 48 * m + 10 := by rw [collatz_odd (by omega)]; ring
-      have s2 : collatz (48 * m + 10) = 24 * m + 5 := by rw [collatz_even (by omega)]; omega
-      have s3 : collatz (24 * m + 5) = 72 * m + 16 := by rw [collatz_odd (by omega)]; ring
-      have s4 : collatz (72 * m + 16) = 36 * m + 8 := by rw [collatz_even (by omega)]; omega
-      have s5 : collatz (36 * m + 8) = 18 * m + 4 := by rw [collatz_even (by omega)]; omega
-      have s6 : collatz (18 * m + 4) = 9 * m + 2 := by rw [collatz_even (by omega)]; omega
-      rw [Function.iterate_succ_apply', Function.iterate_succ_apply',
-          Function.iterate_succ_apply', Function.iterate_succ_apply',
-          Function.iterate_succ_apply', Function.iterate_succ_apply',
-          Function.iterate_zero_apply, s1, s2, s3, s4, s5, s6])
-    h
+    mod_sixteen_three_trajectory h
 
 /-- Every `n ≡ 11 (mod 32)` drops below itself in exactly eight residue-determined steps:
 `32m+11 ↦ 96m+34 ↦ 48m+17 ↦ 144m+52 ↦ 72m+26 ↦ 36m+13 ↦ 108m+40 ↦ 54m+20 ↦ 27m+10`,

--- a/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
+++ b/research/problems/collatz-structured-oq-02-oq-03/knowledge.md
@@ -242,3 +242,66 @@ recurrence `c_{i+1}, d_{i+1}` from `(c_i, d_i)` per step (odd: `c·3, d·3+2^i`;
 This turns every `mod 2^b` drop lemma into a corollary of one inductive theorem and is the
 right lever before re-attacking the natural-density stopping-time statement. (Design note only;
 **unverified** — no Lean authored.)
+
+## Session 2026-06-27 (researcher-1, cycle 3) — ACT: reusable affine step-composition lemmas (Terras law, components 2+3)
+
+**Mode**: BUILD (Docker UP). **Outcome**: progress — axiom-free, build-verified
+(`docker-build.sh Proofs.CollatzStructuredOQ02OQ03` EXIT 0).
+
+### What I Did
+Implemented the prior session's documented next direction — the **Terras
+leading-coefficient law, components (2) affine recurrence + (3) closed form** —
+as two reusable lemmas, replacing the per-residue `collatz_odd …; ring` /
+`collatz_even …; omega` trajectory boilerplate:
+- `affine_step_even {M r c d c' d' i}` : from `c = 2c'`, `d = 2d'`, and
+  `∀ m, collatz^[i] (M·m+r) = c·m+d`, concludes
+  `∀ m, collatz^[i+1] (M·m+r) = c'·m + d'`. (Even leading coeff ⇒ parity = `d mod 2`,
+  independent of `m`; the step halves.)
+- `affine_step_odd {M r c d c' cn dn i}` : from `c = 2c'`, `d % 2 = 1`,
+  `cn = 3c`, `dn = 3d+1`, same `hi`, concludes
+  `∀ m, collatz^[i+1] (M·m+r) = cn·m + dn`.
+- `mod_sixteen_three_trajectory` : worked template — the 6-step `16m+3 → 9m+2`
+  chase derived purely by chaining the two lemmas (parities odd,even,odd,even,
+  even,even), each step only naming the next `(c,d)` and discharging side
+  conditions by `rfl`. No per-step `ring`/`omega`.
+- Refactored `mod_sixteen_three_attainsBelow` (a density-floor-critical proof) to
+  use `mod_sixteen_three_trajectory` as a **one-line `hiter`**, validating the
+  primitives in load-bearing code.
+
+### Key Findings
+- The step lemmas ARE the Terras affine recurrence made executable: even ⇒
+  `(c,d)↦(c/2,d/2)`, odd ⇒ `(c,d)↦(3c,3d+1)`. The window drops below its start
+  exactly when the accumulated `c < M`, i.e. `3^a < 2^b` (the existing 115/128
+  lemmas all use `3^4 = 81 < 128`).
+- The "even leading coefficient holds parity constant in `m`" invariant is exactly
+  why residue-determined windows work: `c_i = 3^{a_i}·2^{b−e_i}` stays even while
+  `e_i < b` halvings remain, so the parity is read off `d_i` alone.
+
+### Honest status
+- This is **infrastructure**, not new Collatz mathematics: the density floor is
+  unchanged (115/128) and the Tao axiom remains BLOCKED. Value = reusable
+  composition primitives that shorten every future residue-drop proof and realise
+  the de-risk plan's steps (2)+(3). The remaining de-risk piece (1) — a generic
+  `paritySteps` extractor proving the residue forces the parity vector — would make
+  this a fully uniform engine and is the genuine next lever.
+
+### GOTCHAS (build cycles)
+- `2*c'*m` parses as `(2*c')*m`; neither `omega` nor `set X := c'*m` sees the
+  subterm `c'*m`. Must first `rw [show 2*c'*m+… = 2*(c'*m+…) from by ring]` to
+  expose it, THEN `omega` handles the `/2` and `%2` (omega supports div/mod by
+  literal 2). Avoid `Nat.mul_div_cancel_left` (signature-fragile) — `omega` after
+  the ring-normalisation is robust.
+- Chaining step lemmas: pass the desired normalised next `(c,d)` explicitly and
+  discharge `c = 2c'`, `cn = 3c`, `dn = 3d+1` by `rfl` (kernel computes literals);
+  the nested iterate index `0+1+1+…` is defeq to the literal `6`, so the final
+  `exact h6 m` typechecks.
+
+### Files Modified
+- proofs/Proofs/CollatzStructuredOQ02OQ03.lean (+3 theorems 39→42, 1052→1107 lines; 1 axiom unchanged, 0 sorries)
+- src/data/proofs/collatz-structured-oq-02-oq-03/meta.json (counts + highlight)
+- src/data/research/problems/collatz-structured-oq-02-oq-03.json (leanFiles counts)
+
+### Next Steps (unchanged genuine lever)
+- de-risk component (1): `paritySteps n b : Fin b → Bool` + proof that `n mod 2^b`
+  forces it, turning per-residue lemmas into corollaries of one inductive theorem.
+- Then re-attack Terras/Korec natural-density-1 stopping time (Tao axiom stays BLOCKED).

--- a/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1052,
+    "lineCount": 1107,
     "assumptions": "1 axiom: tao_2019 — the precise statement of Tao (2019, Forum Math. Pi), that for every f : ℕ → ℝ with f n → ∞ the set {n : 0 < n ∧ Col_min(n) < f n} has logarithmic density one. This is the deep analytic result the open question asks about; it is recorded, not proved, because its proof (3-adic transport/concentration estimates plus a Fourier-analytic input) is far beyond current Mathlib. No theorem in the file is derived from this axiom — the proven Parts II–III are independently machine-verified and depend only on the standard foundational axioms propext / Classical.choice / Quot.sound.",
     "dateAdded": "2026-06-25",
     "mathlib_version": "4.26.0",
@@ -133,15 +133,16 @@
       "Mathlib"
     ],
     "namespace": "CollatzStructuredOQ02OQ03",
-    "lineCount": 1052,
+    "lineCount": 1107,
     "axiomCount": 1,
-    "theoremCount": 39,
+    "theoremCount": 42,
     "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
     "sorries": 0,
     "definitionCount": 5
   },
   "sorries": 0,
   "highlights": [
+    "Reusable affine step-composition lemmas (Terras leading-coefficient law): affine_step_even (c,d)↦(c/2,d/2) and affine_step_odd (c,d)↦(3c,3d+1) track a residue class M·m+r as an affine map c·m+d, reading each parity off the even leading coefficient — replacing the per-step ring/omega trajectory boilerplate. mod_sixteen_three_attainsBelow now uses them for a one-line hiter; axiom-free",
     "Machine-checked density floor raised 7/8 → 115/128: attainsBelow_density_lower_128 shows ≥ 115N−1 of [1,128N] drop below themselves (64N evens + (32N−1) of 1+4ℕ + 8N of 3+16ℕ + 4N of 11+32ℕ + 4N of 23+32ℕ + N each of 7,15,59 (mod 128), eight pairwise-disjoint residue families)",
     "Three new odd classes n ≡ 7, 15, 59 (mod 128) each drop below themselves in exactly 11 residue-determined steps to 81m+d (81 = 3^4 < 2^7 = 128), axiom-free",
     "Dyadic structure made precise: level 64 adds NO new stable residue class (floor stays 7/8), but level 128 stabilises exactly three of the mod-32 unstable classes 7,15,27,31 — namely 7,15,59 (mod 128)",

--- a/src/data/research/problems/collatz-structured-oq-02-oq-03.json
+++ b/src/data/research/problems/collatz-structured-oq-02-oq-03.json
@@ -74,7 +74,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T18:39:05.245Z",
-  "lastUpdate": "2026-03-30T18:39:05.258Z",
+  "lastUpdate": "2026-06-27T18:05:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/CollatzStructured.lean",
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/CollatzStructuredOQ02OQ03.lean",
       "filename": "CollatzStructuredOQ02OQ03.lean",
-      "lineCount": 1052,
-      "theoremCount": 39,
+      "lineCount": 1107,
+      "theoremCount": 42,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Implements the prior session's documented next direction for the OQ
`collatz-structured-oq-02-oq-03` — the **Terras leading-coefficient law**,
components (2) affine recurrence + (3) closed form — as two reusable lemmas that
replace the per-residue `collatz_odd …; ring` / `collatz_even …; omega`
trajectory boilerplate. Axiom-free; build-verified
(`docker-build.sh Proofs.CollatzStructuredOQ02OQ03` → exit 0).

## New lemmas (axiom-free)

Track a residue class `M·m + r` as an **affine map** `c·m + d`, reading each
parity off the *constant* `d` because the leading coefficient `c` is held even:

- `affine_step_even` — from `c = 2c'`, `d = 2d'` and
  `∀ m, collatz^[i] (M·m+r) = c·m+d`, the next step halves to `c'·m + d'`.
- `affine_step_odd` — from `c = 2c'`, `d` odd, `cn = 3c`, `dn = 3d+1`, the next
  step maps to `cn·m + dn`.
- `mod_sixteen_three_trajectory` — worked template: the 6-step `16m+3 → 9m+2`
  chase derived **purely** by chaining the two lemmas (parities
  odd,even,odd,even,even,even), each step only naming the next `(c,d)` and
  discharging side conditions by `rfl` — no per-step `ring`/`omega`.

`mod_sixteen_three_attainsBelow` (a density-floor-critical proof) is refactored to
use the trajectory lemma as a **one-line `hiter`**, validating the primitives in
load-bearing code.

## Why this is the right increment

The step lemmas *are* the Terras affine recurrence made executable: even ⇒
`(c,d)↦(c/2,d/2)`, odd ⇒ `(c,d)↦(3c,3d+1)`, and a residue-determined window drops
below its start exactly when the accumulated `c < M`, i.e. `3^a < 2^b` (the
existing 115/128 lemmas all use `3^4 = 81 < 128`).

## Honest scope

**Infrastructure, not new Collatz mathematics.** The unconditional density floor is
unchanged (115/128) and the deep `tao_2019` axiom remains BLOCKED (a multi-thousand
-line formalization out of near-term reach). The value is reusable composition
primitives that shorten every future residue-drop proof and realise de-risk-plan
steps (2)+(3). The remaining piece — a generic `paritySteps` extractor proving the
residue forces the parity vector (step (1)) — would make this a fully uniform engine
and is the genuine next lever (documented in the knowledge base).

## Counts

`Proofs/CollatzStructuredOQ02OQ03.lean`: 39→**42 theorems**, 1052→**1107 lines**,
**1 axiom** (`tao_2019`) unchanged, **0 sorries**. Gallery + research metadata synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)