### PR TITLE
Enrich Davenport constant D(ℤ/nℤ)=n (erdos-ginzburg-ziv-oq-01-oq-01): add overview, sections

### DIFF
--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/annotations.json
@@ -13,7 +13,8 @@
       "zero-sum sequences",
       "additive combinatorics",
       "pigeonhole principle"
-    ]
+    ],
+    "prerequisites": ["finite abelian groups", "additive combinatorics", "Erdős–Ginzburg–Ziv constant"]
   },
   {
     "id": "ann-davenport-set",
@@ -23,8 +24,9 @@
     "title": "Admissible Lengths: the Minimum-Definition of D(G)",
     "content": "DavenportSet n is the set of lengths d for which every sequence a : Fin d → ℤ/nℤ has a nonempty subset summing to 0. The Davenport constant is by definition the LEAST element of this set, so proving D(ℤ/nℤ) = n becomes the IsLeast statement IsLeast (DavenportSet n) n — packaging the invariant exactly as in the textbook definition rather than as two separate inequalities.",
     "mathContext": "$\\mathrm{DavenportSet}(n) = \\{ d : \\forall a \\in (\\mathbb{Z}/n\\mathbb{Z})^d,\\ \\exists \\emptyset \\neq S,\\ \\sum_{i\\in S} a_i = 0 \\}$.",
-    "significance": "core",
-    "relatedConcepts": ["IsLeast", "minimum", "zero-sum subsequence"]
+    "significance": "critical",
+    "relatedConcepts": ["IsLeast", "minimum", "zero-sum subsequence"],
+    "prerequisites": ["set-builder definitions", "IsLeast on ℕ", "zero-sum subsequences"]
   },
   {
     "id": "ann-davenport-prefixsum",
@@ -34,8 +36,9 @@
     "title": "Prefix Sums and their Additive Split",
     "content": "prefixSum a k is the sum of the entries with index < k. The key algebraic fact prefixSum_split says that for u ≤ v, the first v entries split as the first u entries plus the block [u, v): P(v) = P(u) + (∑ over the block). This is proved by Finset.sum_union after exhibiting the index filter for [0,v) as the disjoint union of the filters for [0,u) and [u,v) — pure index bookkeeping discharged by omega. The split is the engine that turns a coincidence of two prefix sums into a zero-sum block.",
     "mathContext": "$P(v) = P(u) + \\sum_{u \\le k < v} a_k$ for $u \\le v$.",
-    "significance": "core",
-    "relatedConcepts": ["telescoping", "partial sums", "Finset.sum_union"]
+    "significance": "critical",
+    "relatedConcepts": ["telescoping", "partial sums", "Finset.sum_union"],
+    "prerequisites": ["finite sums over Finsets", "disjoint-union splitting", "index arithmetic (omega)"]
   },
   {
     "id": "ann-davenport-upper",
@@ -45,8 +48,9 @@
     "title": "The Crux: Prefix-Sum Pigeonhole (Upper Bound)",
     "content": "exists_nonempty_zerosum proves that any n elements of ℤ/nℤ contain a nonempty — in fact CONSECUTIVE — zero-sum block. There are n+1 prefix sums P(0), …, P(n) but only n residues in ℤ/nℤ, so by the pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to) two of them coincide: P(u) = P(v) with u < v. The intervening block {k : u ≤ k < v} is nonempty (the index valued u lies in Fin n since u < v ≤ n) and sums to P(v) − P(u) = 0 by prefixSum_split. A wlog reduces the symmetric u, v case. This is the classical n-consecutive-integers argument.",
     "mathContext": "$n+1$ prefix sums in an $n$-element group must collide: $P(u)=P(v)$, $u<v$, giving $\\sum_{u\\le k<v} a_k = 0$.",
-    "significance": "core",
-    "relatedConcepts": ["pigeonhole principle", "consecutive subsequence", "ZMod.card"]
+    "significance": "critical",
+    "relatedConcepts": ["pigeonhole principle", "consecutive subsequence", "ZMod.card"],
+    "prerequisites": ["pigeonhole principle", "ZMod n cardinality", "wlog reductions"]
   },
   {
     "id": "ann-davenport-sharp",
@@ -56,7 +60,8 @@
     "title": "Sharpness: the All-Ones Extremal Sequence (Lower Bound)",
     "content": "davenport_sharp exhibits the extremal zero-sum-free sequence: n−1 copies of the generator 1. Any nonempty sub-block S sums to ∑_{i∈S} 1 = (S.card : ℤ/nℤ); since 1 ≤ S.card ≤ n−1 < n, the cardinality is not divisible by n (ZMod.natCast_eq_zero_iff), so the sum is nonzero. davenport_lower_bound upgrades this to: every admissible length is ≥ n, because the all-ones sequence of any length d < n is a counterexample. Together with the upper bound, n is the LEAST admissible length, giving davenport_zmod : IsLeast (DavenportSet n) n.",
     "mathContext": "The sequence $1^{n-1}$ has every nonempty sub-block summing to $c \\in \\{1,\\dots,n-1\\}$, never $0 \\bmod n$; hence $D(\\mathbb{Z}/n\\mathbb{Z}) \\ge n$.",
-    "significance": "core",
-    "relatedConcepts": ["sharpness", "extremal configuration", "zero-sum-free sequence"]
+    "significance": "critical",
+    "relatedConcepts": ["sharpness", "extremal configuration", "zero-sum-free sequence"],
+    "prerequisites": ["ZMod.natCast_eq_zero_iff", "Finset.sum_const", "extremal / sharpness arguments"]
   }
 ]

--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ErdosGinzburgZivOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdosGinzburgZivOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdosGinzburgZivOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdosGinzburgZivOq01Oq01Data: ProofData = {
+  proof: erdosGinzburgZivOq01Oq01Proof,
+  annotations: erdosGinzburgZivOq01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/meta.json
@@ -79,6 +79,73 @@
     "theoremCount": 6,
     "definitionCount": 2
   },
+  "overview": {
+    "historicalContext": "The Davenport constant is named after Harold Davenport, who in 1966 (Midwestern Conference on Group Theory and Number Theory, Ohio State) popularised the quantity D(G) — the least length d such that every sequence of d elements of a finite abelian group G has a nonempty zero-sum subsequence — in connection with the factorisation of algebraic integers: D(G) bounds the maximal number of prime ideals in the factorisation of an irreducible integer when G is the ideal class group. For the cyclic group the value D(ℤ/nℤ) = n is classical and elementary, yet it sits at the foundation of a deep theory: the general D(G) is unknown for groups of rank ≥ 3. It is the companion of the Erdős–Ginzburg–Ziv constant s(G) (which forces a zero-sum subsequence of length exactly |G|), and for ℤ/nℤ the two invariants take the distinct values n and 2n−1.",
+    "problemStatement": "For the cyclic group ℤ/nℤ, determine the Davenport constant D(ℤ/nℤ) — the least d such that every sequence a₀, …, a_{d−1} of elements of ℤ/nℤ admits a nonempty subset S with ∑_{i∈S} aᵢ = 0 — and verify the answer as an IsLeast statement.",
+    "proofStrategy": "Package the constant as IsLeast (DavenportSet n) n, where DavenportSet n is the set of admissible lengths. This splits into two halves. Upper bound (n is admissible): given n elements, form the n+1 prefix sums P(0), …, P(n); since ℤ/nℤ has only n elements, two prefix sums collide, P(u) = P(v) with u < v (pigeonhole), and the intervening block [u, v) is a nonempty consecutive subsequence summing to P(v) − P(u) = 0. Lower bound (nothing smaller works): the all-ones sequence of length n−1 is zero-sum-free, since every nonempty sub-block sums to its cardinality c ∈ {1, …, n−1}, which is never 0 mod n. Together n is the least admissible length.",
+    "keyInsights": [
+      "**The prefix-sum pigeonhole is the whole upper bound.** Encoding a sequence by its n+1 partial sums turns 'find a zero-sum block' into 'find two equal partial sums' — and n+1 values in an n-element group must repeat. The zero-sum block produced is even consecutive, a stronger conclusion than mere existence.",
+      "**Davenport vs Erdős–Ginzburg–Ziv are genuinely different invariants.** D(ℤ/nℤ) = n forces a zero-sum subsequence of *any* nonempty length, while s(ℤ/nℤ) = 2n−1 forces one of length *exactly* n. The proofs are independent: prefix-sum pigeonhole here, Chevalley–Warning for EGZ.",
+      "**The all-ones sequence is the unique obstruction shape.** Sharpness is witnessed by n−1 copies of a generator: its sub-block sums are exactly the cardinalities 1, …, n−1, none divisible by n. This both proves D ≥ n and identifies the extremal zero-sum-free sequence.",
+      "**Packaging as IsLeast matches the textbook definition.** Rather than proving two separate inequalities, the result is stated as IsLeast (DavenportSet n) n — n is admissible and is a lower bound for all admissible lengths — which is precisely the definition of the Davenport constant as a minimum."
+    ],
+    "prerequisites": [
+      "The pigeonhole principle (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "Modular arithmetic in ℤ/nℤ (ZMod n), in particular ZMod.card and ZMod.natCast_eq_zero_iff",
+      "Finite sums over Finsets and their splitting (Finset.sum_union, Finset.sum_const)",
+      "The notion of IsLeast (a least element of a set of naturals)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: the Davenport constant",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Docstring framing D(G) as the least length forcing a nonempty zero-sum subsequence, the target value D(ℤ/nℤ) = n, the two ingredients (prefix-sum pigeonhole upper bound, all-ones sharpness lower bound), and why neither the constant nor the prefix-sum lemma is in Mathlib.",
+      "mathContext": "$D(\\mathbb{Z}/n\\mathbb{Z}) = n$, the companion of the EGZ constant $s(\\mathbb{Z}/n\\mathbb{Z}) = 2n-1$."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions: prefix sums and admissible lengths",
+      "startLine": 51,
+      "endLine": 65,
+      "summary": "prefixSum a k = sum of the entries with index < k; DavenportSet n = the lengths d for which every length-d sequence has a nonempty zero-sum subset. The Davenport constant is the least element of DavenportSet n.",
+      "mathContext": "$P(k) = \\sum_{i < k} a_i$; $\\mathrm{DavenportSet}(n) = \\{d : \\forall a,\\ \\exists \\emptyset \\neq S,\\ \\sum_{i\\in S} a_i = 0\\}$."
+    },
+    {
+      "id": "prefix-split",
+      "title": "Prefix-sum split",
+      "startLine": 67,
+      "endLine": 81,
+      "summary": "prefixSum_split: for u ≤ v, P(v) = P(u) + (sum over the block [u, v)), proved by Finset.sum_union after splitting the index filter into the disjoint parts [0,u) and [u,v) (omega bookkeeping).",
+      "mathContext": "$P(v) = P(u) + \\sum_{u \\le k < v} a_k$."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Upper bound (the crux): prefix-sum pigeonhole",
+      "startLine": 83,
+      "endLine": 112,
+      "summary": "exists_nonempty_zerosum: the n+1 prefix sums collide in the n-element group ℤ/nℤ, P(u)=P(v) with u<v; the block [u,v) is nonempty (index u lies in Fin n) and sums to P(v)−P(u)=0. n_mem_DavenportSet records that n is admissible.",
+      "mathContext": "$n+1$ sums in an $n$-element group collide $\\Rightarrow$ a consecutive zero-sum block."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: the all-ones extremal sequence",
+      "startLine": 114,
+      "endLine": 147,
+      "summary": "davenport_sharp: the length n−1 all-ones sequence is zero-sum-free (every nonempty sub-block sums to its cardinality 1 ≤ c ≤ n−1, never 0 mod n, via ZMod.natCast_eq_zero_iff). davenport_lower_bound: hence every admissible length is ≥ n.",
+      "mathContext": "$1^{n-1}$ has sub-block sums $c \\in \\{1,\\dots,n-1\\}$, never $0 \\bmod n$, so $D \\ge n$."
+    },
+    {
+      "id": "headline",
+      "title": "Headline: D(ℤ/nℤ) = n",
+      "startLine": 149,
+      "endLine": 154,
+      "summary": "davenport_zmod bundles the two halves into IsLeast (DavenportSet n) n — n is admissible and is a lower bound for all admissible lengths — i.e. D(ℤ/nℤ) = n.",
+      "mathContext": "$\\mathrm{IsLeast}(\\mathrm{DavenportSet}(n))\\, n$, i.e. $D(\\mathbb{Z}/n\\mathbb{Z}) = n$."
+    }
+  ],
   "conclusion": {
     "summary": "The Davenport constant of the cyclic group is computed and verified: D(ℤ/nℤ) = n, stated as IsLeast (DavenportSet n) n (davenport_zmod). The upper bound (exists_nonempty_zerosum) is the prefix-sum pigeonhole — the n+1 partial sums P(0),…,P(n) cannot be distinct in the n-element group ℤ/nℤ, so a coincidence P(u) = P(v) with u < v exhibits the intervening block as a nonempty zero-sum subsequence. The lower bound (davenport_lower_bound, davenport_sharp) uses the all-ones extremal sequence of length n−1, whose nonempty sub-block sums equal their cardinalities 1,…,n−1, none divisible by n. All results are verified with 0 axioms and 0 sorries.",
     "implications": "Computes the second fundamental zero-sum invariant of ℤ/nℤ, complementing the gallery's Erdős–Ginzburg–Ziv constant s(ℤ/nℤ) = 2n−1 and exhibiting the two as distinct numbers (n vs 2n−1). Directly answers the open question recorded in the EGZ entry (erdos-ginzburg-ziv-oq-01) on whether the Davenport constant admits a packaged formalization. Mathlib has neither the Davenport constant nor the prefix-sum zero-sum lemma; the proof is independent of EGZ (prefix-sum pigeonhole, not Chevalley–Warning).",
@@ -88,7 +155,11 @@
     ]
   },
   "crossReferences": [
-    "erdos-ginzburg-ziv-oq-01"
+    {
+      "targetId": "erdos-ginzburg-ziv-oq-01",
+      "relationship": "extends",
+      "description": "Parent EGZ entry computing the Erdős–Ginzburg–Ziv constant s(ℤ/nℤ) = 2n−1. This file answers its recorded open question by computing the companion Davenport constant D(ℤ/nℤ) = n with an independent prefix-sum proof, exhibiting the two zero-sum invariants as distinct numbers."
+    }
   ],
   "references": [
     {


### PR DESCRIPTION
Enrichment pass for `erdos-ginzburg-ziv-oq-01-oq-01`.

This entry had strong description/conclusion/annotations but was **missing `overview` and `sections` entirely**, had no `index.ts`, and used a malformed bare-string `crossReferences`.

- **Created missing `index.ts`** — proof page was not loading on the live site.
- **Added full `overview`**: historicalContext (Davenport 1966, factorisation theory), problemStatement, proofStrategy, 4 keyInsights, prerequisites.
- **Added 6 `sections`** covering the full 154-line Lean file with per-section mathContext.
- **Fixed `crossReferences`** from a bare string array to the structured `{targetId, relationship, description}` format.
- **Annotations**: added `prerequisites` to all 5; fixed invalid `significance: "core"` → `"critical"` (the type allows only critical/key/supporting).

meta.json ~12 KB, well under all size caps. Math content (prefix-sum pigeonhole, all-ones sharpness) verified against the Lean source.