### PR TITLE
Enrich Sperner SimplicialComplex bridge (sperner-simplicial-bridge-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/sperner-simplicial-bridge-oq-02/annotations.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-02/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 10, "endLine": 61 },
     "type": "concept",
     "title": "The open question and its resolution",
-    "content": "The module docstring states the parent's open question — does the pseudomanifold bridge extend to Mathlib's Geometry.SimplicialComplex? — and its answer. The reframing is the key idea: Mathlib stores faces as `Finset E` (vertex sets), the *same* encoding the bridge consumes. The affine data (AffineIndependent, convexHull gluing) is layered on top, not a rival encoding, so no translation is needed — only facet extraction plus purity and the pseudomanifold check."
+    "content": "The module docstring states the parent's open question — does the pseudomanifold bridge extend to Mathlib's Geometry.SimplicialComplex? — and its answer. The reframing is the key idea: Mathlib stores faces as `Finset E` (vertex sets), the *same* encoding the bridge consumes. The affine data (AffineIndependent, convexHull gluing) is layered on top, not a rival encoding, so no translation is needed — only facet extraction plus purity and the pseudomanifold check.",
+    "mathContext": "Mathlib's $K : \\text{SimplicialComplex}\\ \\Bbbk\\ E$ has $K.\\text{faces} \\subseteq \\text{Finset}\\ E$ with each face's vertices affinely independent and faces glued along shared subfaces. The combinatorial bridge consumes faces as vertex sets $\\text{Finset}\\ E$, so the two encodings coincide on the carrier; the affine axioms are extra structure, not a different representation.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib Geometry.SimplicialComplex", "faces as Finset E", "abstract vs geometric simplicial complex", "pseudomanifold bridge"],
+    "prerequisites": ["abstract simplicial complexes", "the parent pseudomanifold Sperner bridge", "affine independence of a finite point set"]
   },
   {
     "id": "ann-spc-oq02-facet-superset",
@@ -13,7 +17,11 @@
     "range": { "startLine": 80, "endLine": 93 },
     "type": "technique",
     "title": "exists_facet_superset: every face lies below a facet",
-    "content": "A genuinely new lemma. Mathlib only had `not_facet_iff_subface` (a non-facet has a strict superface). Here, for a *finite* complex, `Finite.exists_maximal` selects a face `t` of maximal cardinality among `{t ∈ K.faces | s ⊆ t}`; maximality plus antisymmetry of ⊆ (`le_antisymm`) forces `t` to satisfy the facet condition `∀ u ∈ faces, t ⊆ u → t = u`. This makes 'extract the facets' well-posed."
+    "content": "A genuinely new lemma. Mathlib only had `not_facet_iff_subface` (a non-facet has a strict superface). Here, for a *finite* complex, `Finite.exists_maximal` selects a face `t` of maximal cardinality among `{t ∈ K.faces | s ⊆ t}`; maximality plus antisymmetry of ⊆ (`le_antisymm`) forces `t` to satisfy the facet condition `∀ u ∈ faces, t ⊆ u → t = u`. This makes 'extract the facets' well-posed.",
+    "mathContext": "A facet is a $\\subseteq$-maximal face. For finite $K$ and any face $s$, $\\exists$ facet $t$ with $s \\subseteq t$: take $t$ maximal in $\\{t \\in K.\\text{faces} : s \\subseteq t\\}$ (Finite.exists_maximal); if $t \\subseteq u \\in K.\\text{faces}$ then $s \\subseteq u$, so maximality gives $u \\subseteq t$, hence $t = u$ by antisymmetry.",
+    "significance": "key",
+    "relatedConcepts": ["facet = ⊆-maximal face", "Finite.exists_maximal", "antisymmetry of subset order", "not_facet_iff_subface"],
+    "prerequisites": ["finiteness of the face set", "maximal elements of a finite poset", "le_antisymm for ⊆"]
   },
   {
     "id": "ann-spc-oq02-affine-indep",
@@ -21,7 +29,11 @@
     "range": { "startLine": 95, "endLine": 101 },
     "type": "insight",
     "title": "facet_affineIndependent: encoding reconciliation",
-    "content": "A facet is a face (`facets_subset`), so `K.indep` applies directly: the vertices of a facet are affinely independent. This one-line lemma is the precise statement that the bridge's combinatorial facets carry Mathlib's affine structure for free — the encodings are compatible, not competing."
+    "content": "A facet is a face (`facets_subset`), so `K.indep` applies directly: the vertices of a facet are affinely independent. This one-line lemma is the precise statement that the bridge's combinatorial facets carry Mathlib's affine structure for free — the encodings are compatible, not competing.",
+    "mathContext": "$K.\\text{indep} : \\forall s \\in K.\\text{faces},\\ \\text{AffineIndependent}\\ \\Bbbk\\ (\\text{coe} : s \\to E)$. Since $\\text{facets} \\subseteq \\text{faces}$, any facet's vertex set is affinely independent — the combinatorial maximal cell automatically inherits the geometric non-degeneracy axiom.",
+    "significance": "supporting",
+    "relatedConcepts": ["AffineIndependent", "facets_subset", "K.indep axiom", "compatibility of combinatorial and affine data"],
+    "prerequisites": ["affine independence", "the SimplicialComplex.indep field", "facets ⊆ faces"]
   },
   {
     "id": "ann-spc-oq02-dim-bound",
@@ -29,7 +41,11 @@
     "range": { "startLine": 117, "endLine": 134 },
     "type": "technique",
     "title": "Dimension bound: facet_card_le_finrank_succ",
-    "content": "Chains `AffineIndependent.card_le_finrank_succ` (card ≤ dim of the vertices' vectorSpan + 1) with `Submodule.finrank_le` (vectorSpan ⊆ E, so its finrank ≤ finrank E) and closes with `omega`. `Fintype.card_coe` rewrites `Fintype.card ↥s` to `s.card`. Corollary `facet_dim_le_ambient` reads off `d ≤ finrank 𝕜 E` for pure complexes — the affine encoding's quantitative grip on the combinatorial one."
+    "content": "Chains `AffineIndependent.card_le_finrank_succ` (card ≤ dim of the vertices' vectorSpan + 1) with `Submodule.finrank_le` (vectorSpan ⊆ E, so its finrank ≤ finrank E) and closes with `omega`. `Fintype.card_coe` rewrites `Fintype.card ↥s` to `s.card`. Corollary `facet_dim_le_ambient` reads off `d ≤ finrank 𝕜 E` for pure complexes — the affine encoding's quantitative grip on the combinatorial one.",
+    "mathContext": "For an affinely independent vertex set $s$: $|s| \\le \\dim(\\text{vectorSpan}\\ s) + 1 \\le \\operatorname{finrank}_{\\Bbbk} E + 1$, since $\\text{vectorSpan}\\ s \\le E$ gives $\\operatorname{finrank}(\\text{vectorSpan}\\ s) \\le \\operatorname{finrank} E$. Combinatorial dimension $d = |s|-1$, so $d \\le \\operatorname{finrank}_{\\Bbbk} E$.",
+    "significance": "key",
+    "relatedConcepts": ["AffineIndependent.card_le_finrank_succ", "vectorSpan and finrank", "Submodule.finrank_le", "simplex dimension = card − 1"],
+    "prerequisites": ["finrank of a submodule ≤ ambient finrank", "affine independence cardinality bound", "purity (all facets same dimension)"]
   },
   {
     "id": "ann-spc-oq02-bridge",
@@ -37,7 +53,11 @@
     "range": { "startLine": 151, "endLine": 189 },
     "type": "concept",
     "title": "exists_panchromatic_facet: the bridge fires",
-    "content": "Feeds an enumerating `Finset` of `K.facets` (hypothesis `htop`) into the parent's `exists_panchromatic`, using purity `hpure` as the vertexEnum cardinality witness. The returned witness `σ` is converted back to a genuine `K.facets` membership via `(htop σ.1).mp σ.2`, so the conclusion lives inside Mathlib's native facet API."
+    "content": "Feeds an enumerating `Finset` of `K.facets` (hypothesis `htop`) into the parent's `exists_panchromatic`, using purity `hpure` as the vertexEnum cardinality witness. The returned witness `σ` is converted back to a genuine `K.facets` membership via `(htop σ.1).mp σ.2`, so the conclusion lives inside Mathlib's native facet API.",
+    "mathContext": "Sperner's conclusion: a Sperner-coloured pure pseudomanifold has a *panchromatic* facet (one whose vertices realise all $d+1$ colours). The parent `exists_panchromatic` produces such a cell from a facet enumeration + purity; here the cell is repackaged as a bona fide element of $K.\\text{facets}$.",
+    "significance": "key",
+    "relatedConcepts": ["Sperner's lemma (panchromatic cell)", "pure pseudomanifold", "facet enumeration", "parent exists_panchromatic"],
+    "prerequisites": ["statement of Sperner's lemma", "purity of the complex", "the parent combinatorial bridge"]
   },
   {
     "id": "ann-spc-oq02-capstone",
@@ -45,6 +65,10 @@
     "range": { "startLine": 191, "endLine": 217 },
     "type": "insight",
     "title": "Capstone with certified dimension",
-    "content": "`exists_panchromatic_facet_of_finrank` specialises to a finite-dimensional field and bundles everything: the panchromatic witness is a genuine facet *and* its combinatorial dimension satisfies `d ≤ finrank 𝕜 E`, by applying `facet_dim_le_ambient` to the witness. One statement captures the full answer to the open question."
+    "content": "`exists_panchromatic_facet_of_finrank` specialises to a finite-dimensional field and bundles everything: the panchromatic witness is a genuine facet *and* its combinatorial dimension satisfies `d ≤ finrank 𝕜 E`, by applying `facet_dim_le_ambient` to the witness. One statement captures the full answer to the open question.",
+    "mathContext": "$\\exists\\, \\sigma \\in K.\\text{facets}$ panchromatic with $\\dim \\sigma \\le \\operatorname{finrank}_{\\Bbbk} E$: the existence (Sperner) and the dimension certificate (affine bound) are combined into a single theorem over a finite-dimensional ambient space, answering the parent's open question affirmatively for Mathlib's SimplicialComplex.",
+    "significance": "key",
+    "relatedConcepts": ["finite-dimensional ambient space", "facet_dim_le_ambient", "bundled existence + dimension certificate", "answer to the parent open question"],
+    "prerequisites": ["exists_panchromatic_facet", "facet_dim_le_ambient", "FiniteDimensional 𝕜 E"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `sperner-simplicial-bridge-oq-02` (bridging Sperner's lemma to Mathlib's Geometry.SimplicialComplex).

meta.json was already complete (5 key insights, 4 sections, conclusion with 4 open questions, 3 cross-references). The gap was in **annotations**: all 6 had rich `content` but lacked the prescribed enrichment fields.

- Added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` to all 6 annotations.
- `mathContext` makes explicit the faces-as-Finset encoding match, the ⊆-maximal facet existence (exists_facet_superset), affine-independence inheritance, the dimension bound |s| ≤ finrank(vectorSpan s)+1 ≤ finrank E + 1, the panchromatic-facet bridge, and the certified-dimension capstone d ≤ finrank 𝕜 E.

annotations.json only; meta.json untouched. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)