### PR TITLE
Enrich Carmichael Function on Even Prime Powers: No Primitive Root mod 2ᵏ (euler-totient-oq-01-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-02/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "insight",
     "title": "The Non-Cyclic Mechanism",
-    "content": "not_isCyclic_units_two_pow is the structural engine of the entire entry, the exact opposite of the odd-prime-power case. Mathlib's ZMod.isCyclic_units_two_pow_iff states that (ℤ/2ⁿℤ)ˣ is cyclic iff n ≤ 2; negating it at k ≥ 3 gives ¬ IsCyclic (ℤ/2ᵏℤ)ˣ. The underlying reason is the structure (ℤ/2ᵏℤ)ˣ ≅ ℤ/2 × ℤ/2ᵏ⁻²: a product of two nontrivial cyclic groups can never be cyclic. From this single fact flow both the strict drop λ(2ᵏ) < φ(2ᵏ) and the absence of a primitive root."
+    "content": "not_isCyclic_units_two_pow is the structural engine of the entire entry, the exact opposite of the odd-prime-power case. Mathlib's ZMod.isCyclic_units_two_pow_iff states that (ℤ/2ⁿℤ)ˣ is cyclic iff n ≤ 2; negating it at k ≥ 3 gives ¬ IsCyclic (ℤ/2ᵏℤ)ˣ. The underlying reason is the structure (ℤ/2ᵏℤ)ˣ ≅ ℤ/2 × ℤ/2ᵏ⁻²: a product of two nontrivial cyclic groups can never be cyclic. From this single fact flow both the strict drop λ(2ᵏ) < φ(2ᵏ) and the absence of a primitive root.",
+    "mathContext": "$(\\mathbb{Z}/2^k\\mathbb{Z})^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2^{k-2}$ for $k\\ge 3$; a product of two nontrivial cyclic groups is never cyclic, so the unit group is non-cyclic.",
+    "significance": "critical",
+    "relatedConcepts": ["unit group structure", "cyclic groups", "direct product decomposition", "ZMod.isCyclic_units_two_pow_iff"],
+    "prerequisites": ["group theory", "structure of (ℤ/2ᵏℤ)ˣ", "cyclic vs non-cyclic groups"]
   },
   {
     "id": "ann-no-primitive-root",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "No Primitive Root mod 2ᵏ — the Dual Result",
-    "content": "no_primitiveRoot_two_pow is the headline new content and the precise dual of the odd-prime sibling's exists_primitiveRoot_odd_prime_pow. A primitive root mod 2ᵏ would be a unit g with orderOf g = φ(2ᵏ) = #(ℤ/2ᵏℤ)ˣ. But isCyclic_of_orderOf_eq_card says any element whose order equals the group's cardinality generates the whole group — forcing cyclicity. Since (ℤ/2ᵏℤ)ˣ is not cyclic for k ≥ 3, no such g can exist. Where odd prime powers always admit a primitive root, the high powers of two never do."
+    "content": "no_primitiveRoot_two_pow is the headline new content and the precise dual of the odd-prime sibling's exists_primitiveRoot_odd_prime_pow. A primitive root mod 2ᵏ would be a unit g with orderOf g = φ(2ᵏ) = #(ℤ/2ᵏℤ)ˣ. But isCyclic_of_orderOf_eq_card says any element whose order equals the group's cardinality generates the whole group — forcing cyclicity. Since (ℤ/2ᵏℤ)ˣ is not cyclic for k ≥ 3, no such g can exist. Where odd prime powers always admit a primitive root, the high powers of two never do.",
+    "mathContext": "A primitive root is a unit $g$ with $\\operatorname{ord}(g) = \\varphi(2^k) = |(\\mathbb{Z}/2^k\\mathbb{Z})^\\times|$; such $g$ would generate the group, contradicting non-cyclicity for $k\\ge 3$.",
+    "significance": "critical",
+    "relatedConcepts": ["primitive root", "order of an element", "generators", "isCyclic_of_orderOf_eq_card"],
+    "prerequisites": ["group theory", "order of group elements", "primitive roots modulo n"]
   },
   {
     "id": "ann-value-exponent",
@@ -30,7 +38,11 @@
     },
     "type": "concept",
     "title": "λ(2ᵏ) = 2ᵏ⁻² Is the Group Exponent",
-    "content": "carmichael_two_pow records the open question's target value λ(2ᵏ) = 2ᵏ⁻² (k ≥ 3) via Mathlib's carmichael_two_pow_of_ne_two. exponent_units_two_pow then makes explicit that this number is literally the exponent of the unit group: using carmichael_eq_exponent' (λ is by definition that exponent), Monoid.exponent (ℤ/2ᵏℤ)ˣ = 2ᵏ⁻². This is the universal exponent — aᵐ = 1 for every unit a at m = 2ᵏ⁻² — even though, as the previous section shows, no single element's order reaches it."
+    "content": "carmichael_two_pow records the open question's target value λ(2ᵏ) = 2ᵏ⁻² (k ≥ 3) via Mathlib's carmichael_two_pow_of_ne_two. exponent_units_two_pow then makes explicit that this number is literally the exponent of the unit group: using carmichael_eq_exponent' (λ is by definition that exponent), Monoid.exponent (ℤ/2ᵏℤ)ˣ = 2ᵏ⁻². This is the universal exponent — aᵐ = 1 for every unit a at m = 2ᵏ⁻² — even though, as the previous section shows, no single element's order reaches it.",
+    "mathContext": "$\\lambda(2^k) = 2^{k-2}$ for $k\\ge 3$ equals $\\operatorname{Monoid.exponent}\\,(\\mathbb{Z}/2^k\\mathbb{Z})^\\times$: the least $m$ with $a^m = 1$ for all units $a$.",
+    "significance": "key",
+    "relatedConcepts": ["Carmichael function λ(n)", "group exponent", "universal exponent", "Monoid.exponent"],
+    "prerequisites": ["group theory", "Carmichael function", "exponent of a group"]
   },
   {
     "id": "ann-strict-gap",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "The Strict Divisor Phenomenon λ < φ",
-    "content": "carmichael_lt_totient sharpens the parent's 2·λ(2ᵏ) = φ(2ᵏ) into the strict inequality λ(2ᵏ) = 2ᵏ⁻² < 2ᵏ⁻¹ = φ(2ᵏ). With totient_two_pow giving φ(2ᵏ) = 2ᵏ⁻¹ (via Nat.totient_prime_pow), the gap is just 2ᵏ⁻² < 2ᵏ⁻¹ (Nat.pow_lt_pow_right). This strictness is the quantitative witness that Euler's exponent φ(2ᵏ) is not optimal for moduli 2ᵏ — every unit already dies at the strictly smaller exponent λ(2ᵏ) — and it holds precisely because there is no primitive root."
+    "content": "carmichael_lt_totient sharpens the parent's 2·λ(2ᵏ) = φ(2ᵏ) into the strict inequality λ(2ᵏ) = 2ᵏ⁻² < 2ᵏ⁻¹ = φ(2ᵏ). With totient_two_pow giving φ(2ᵏ) = 2ᵏ⁻¹ (via Nat.totient_prime_pow), the gap is just 2ᵏ⁻² < 2ᵏ⁻¹ (Nat.pow_lt_pow_right). This strictness is the quantitative witness that Euler's exponent φ(2ᵏ) is not optimal for moduli 2ᵏ — every unit already dies at the strictly smaller exponent λ(2ᵏ) — and it holds precisely because there is no primitive root.",
+    "mathContext": "$\\lambda(2^k) = 2^{k-2} < 2^{k-1} = \\varphi(2^k)$ for $k\\ge 3$; Euler's exponent is non-optimal exactly when no primitive root exists.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient φ(n)", "Carmichael function", "strict inequality", "non-optimal exponent"],
+    "prerequisites": ["number theory", "Euler's theorem", "Carmichael function"]
   },
   {
     "id": "ann-boundary",
@@ -52,7 +68,11 @@
     },
     "type": "concept",
     "title": "The Sharp Boundary at k = 2",
-    "content": "The exception is sharp. carmichael_two (λ(2)=1) and carmichael_four (λ(4)=2=φ(4)) come from carmichael_two_pow_of_le_two, and isCyclic_units_four confirms (ℤ/4ℤ)ˣ is still cyclic. exists_primitiveRoot_four then exhibits a primitive root mod 4 — the generator 3 ≡ −1 of order φ(4) = 2 — via IsCyclic.exists_ofOrder_eq_natCard. So primitive roots exist for k ≤ 2 and vanish for k ≥ 3: the largest power of two with cyclic unit group is 4, and non-cyclicity begins at exactly k = 3 (λ(8) = 2 < 4 = φ(8))."
+    "content": "The exception is sharp. carmichael_two (λ(2)=1) and carmichael_four (λ(4)=2=φ(4)) come from carmichael_two_pow_of_le_two, and isCyclic_units_four confirms (ℤ/4ℤ)ˣ is still cyclic. exists_primitiveRoot_four then exhibits a primitive root mod 4 — the generator 3 ≡ −1 of order φ(4) = 2 — via IsCyclic.exists_ofOrder_eq_natCard. So primitive roots exist for k ≤ 2 and vanish for k ≥ 3: the largest power of two with cyclic unit group is 4, and non-cyclicity begins at exactly k = 3 (λ(8) = 2 < 4 = φ(8)).",
+    "mathContext": "$(\\mathbb{Z}/4\\mathbb{Z})^\\times$ is cyclic with primitive root $3\\equiv-1$ (order $\\varphi(4)=2$); cyclicity holds for $k\\le 2$ and fails from $k=3$ ($\\lambda(8)=2<4=\\varphi(8)$).",
+    "significance": "supporting",
+    "relatedConcepts": ["boundary case", "cyclic unit group of ℤ/4ℤ", "primitive root mod 4", "sharpness"],
+    "prerequisites": ["group theory", "modular arithmetic", "primitive roots"]
   },
   {
     "id": "ann-concrete",
@@ -63,6 +83,10 @@
     },
     "type": "example",
     "title": "Concrete Values in the Non-Cyclic Regime",
-    "content": "carmichael_eight (λ(8)=2), carmichael_sixteen (λ(16)=4), and carmichael_thirtytwo (λ(32)=8) instantiate λ(2ᵏ) = 2ᵏ⁻² at k = 3, 4, 5 and reduce the powers by norm_num. Each is strictly below the corresponding totient (φ(8)=4, φ(16)=8, φ(32)=16), illustrating the λ = φ/2 collapse across the first three non-cyclic powers of two."
+    "content": "carmichael_eight (λ(8)=2), carmichael_sixteen (λ(16)=4), and carmichael_thirtytwo (λ(32)=8) instantiate λ(2ᵏ) = 2ᵏ⁻² at k = 3, 4, 5 and reduce the powers by norm_num. Each is strictly below the corresponding totient (φ(8)=4, φ(16)=8, φ(32)=16), illustrating the λ = φ/2 collapse across the first three non-cyclic powers of two.",
+    "mathContext": "$\\lambda(8)=2,\\ \\lambda(16)=4,\\ \\lambda(32)=8$ versus $\\varphi(8)=4,\\ \\varphi(16)=8,\\ \\varphi(32)=16$: $\\lambda = \\varphi/2$ throughout the non-cyclic regime.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "Carmichael values", "norm_num evaluation", "λ = φ/2"],
+    "prerequisites": ["arithmetic", "Carmichael and totient values"]
   }
 ]

--- a/src/data/proofs/euler-totient-oq-01-oq-02-oq-02/index.ts
+++ b/src/data/proofs/euler-totient-oq-01-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ01OQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOq01Oq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOq01Oq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOq01Oq02Oq02Data: ProofData = {
+  proof: eulerTotientOq01Oq02Oq02Proof,
+  annotations: eulerTotientOq01Oq02Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-01-oq-02-oq-02`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 6 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (overview with 5 keyInsights, 6 sections, conclusion, 3 cross-references); left under all size caps (~16 KB). Math content (non-cyclic (ℤ/2ᵏℤ)ˣ, λ(2ᵏ)=2ᵏ⁻², no primitive root mod 2ᵏ for k≥3) verified against the Lean source.