### PR TITLE
Enrich Quantitative 1D Edge-Isoperimetric Stability: Boundary = 2·Runs (isoperimetric-theorem-oq-02-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "From Rigidity to Quantitative Stability",
-    "content": "The parent rigidity entry (OQ-02 → OQ-03) proved |∂_vertex S| = 2 ⟺ S is an interval and explicitly posed the quantitative follow-up: if the boundary is 2 + 2k, S should have k+1 maximal runs, with a bound on |S △ Icc(min S, max S)|. It also warned that the VERTEX boundary is not 2·(runs) — S = {0,2} has |∂_vertex S| = 3 but two runs. This file resolves the open question with the correct object: the EDGE boundary count (lattice edges crossing between S and its complement), which equals 2·(number of maximal runs) exactly. The proof is telescoping-free, resting on a single translation bijection."
+    "content": "The parent rigidity entry (OQ-02 → OQ-03) proved |∂_vertex S| = 2 ⟺ S is an interval and explicitly posed the quantitative follow-up: if the boundary is 2 + 2k, S should have k+1 maximal runs, with a bound on |S △ Icc(min S, max S)|. It also warned that the VERTEX boundary is not 2·(runs) — S = {0,2} has |∂_vertex S| = 3 but two runs. This file resolves the open question with the correct object: the EDGE boundary count (lattice edges crossing between S and its complement), which equals 2·(number of maximal runs) exactly. The proof is telescoping-free, resting on a single translation bijection.",
+    "mathContext": "Edge boundary: $|\\partial_{\\mathrm{edge}} S| = 2\\,\\#\\mathrm{runs}(S)$, replacing the vertex boundary which fails this identity (e.g. $S=\\{0,2\\}$: vertex boundary $3$, runs $2$).",
+    "significance": "context",
+    "relatedConcepts": ["edge vs vertex boundary", "isoperimetric stability", "rigidity", "maximal runs"],
+    "prerequisites": ["combinatorics", "discrete isoperimetry", "lattice ℤ"]
   },
   {
     "id": "ann-definitions",
@@ -19,7 +23,11 @@
     },
     "type": "definition",
     "title": "Runs, Endpoints, and the Edge Count",
-    "content": "A maximal run is a maximal block of consecutive integers inside S. Runs are counted by their left endpoints leftEnds S = {x ∈ S : x − 1 ∉ S} (so numRuns S = |leftEnds S|) or right endpoints rightEnds S = {x ∈ S : x + 1 ∉ S}. The interior elements split into the has-predecessor set internalL = {x ∈ S : x − 1 ∈ S} and the has-successor set internalR = {x ∈ S : x + 1 ∈ S}. The edge boundary count edgeBoundaryCount S = |(S − 1) \\ S| + |(S + 1) \\ S| sums the rising edges (x ∉ S, x+1 ∈ S) and falling edges (x ∈ S, x+1 ∉ S)."
+    "content": "A maximal run is a maximal block of consecutive integers inside S. Runs are counted by their left endpoints leftEnds S = {x ∈ S : x − 1 ∉ S} (so numRuns S = |leftEnds S|) or right endpoints rightEnds S = {x ∈ S : x + 1 ∉ S}. The interior elements split into the has-predecessor set internalL = {x ∈ S : x − 1 ∈ S} and the has-successor set internalR = {x ∈ S : x + 1 ∈ S}. The edge boundary count edgeBoundaryCount S = |(S − 1) \\ S| + |(S + 1) \\ S| sums the rising edges (x ∉ S, x+1 ∈ S) and falling edges (x ∈ S, x+1 ∉ S).",
+    "mathContext": "$\\mathrm{leftEnds}(S) = \\{x\\in S : x-1\\notin S\\}$, $\\mathrm{numRuns}(S) = |\\mathrm{leftEnds}(S)|$; $\\mathrm{edgeBoundaryCount}(S) = |(S-1)\\setminus S| + |(S+1)\\setminus S|$.",
+    "significance": "key",
+    "relatedConcepts": ["maximal runs", "left/right endpoints", "edge boundary", "Finset operations"],
+    "prerequisites": ["set theory", "Finset filters", "combinatorics"]
   },
   {
     "id": "ann-shift-bijection",
@@ -30,7 +38,11 @@
     },
     "type": "technique",
     "title": "The Shift Bijection (heart of the proof)",
-    "content": "card_internalL_eq_card_internalR shows the translation x ↦ x − 1 is a bijection from internalL onto internalR: if x ∈ S and x − 1 ∈ S, then x − 1 ∈ S and (x − 1) + 1 = x ∈ S, so x − 1 ∈ internalR; the map is injective (subtraction) and surjective (y ↦ y + 1 inverts it). This single bijection is what replaces the telescoping sum or induction one might expect for a 'boundary counts components' identity, and it is the only nontrivial combinatorial step."
+    "content": "card_internalL_eq_card_internalR shows the translation x ↦ x − 1 is a bijection from internalL onto internalR: if x ∈ S and x − 1 ∈ S, then x − 1 ∈ S and (x − 1) + 1 = x ∈ S, so x − 1 ∈ internalR; the map is injective (subtraction) and surjective (y ↦ y + 1 inverts it). This single bijection is what replaces the telescoping sum or induction one might expect for a 'boundary counts components' identity, and it is the only nontrivial combinatorial step.",
+    "mathContext": "$x \\mapsto x-1$ is a bijection $\\mathrm{internalL} \\to \\mathrm{internalR}$, so $|\\mathrm{internalL}| = |\\mathrm{internalR}|$.",
+    "significance": "critical",
+    "relatedConcepts": ["translation bijection", "injectivity / surjectivity", "interior elements", "telescoping-free counting"],
+    "prerequisites": ["combinatorics", "bijective proofs", "Finset cardinality"]
   },
   {
     "id": "ann-left-eq-right",
@@ -41,7 +53,11 @@
     },
     "type": "key-step",
     "title": "Run Starts Equal Run Ends",
-    "content": "Finset.filter_card_add_filter_neg_card_eq_card partitions S: |rightEnds| + |internalR| = |S| and |leftEnds| + |internalL| = |S|. Since |internalL| = |internalR| by the shift bijection, card_leftEnds_eq_card_rightEnds concludes |leftEnds| = |rightEnds| by omega — every maximal run starts exactly once and ends exactly once, with no telescoping."
+    "content": "Finset.filter_card_add_filter_neg_card_eq_card partitions S: |rightEnds| + |internalR| = |S| and |leftEnds| + |internalL| = |S|. Since |internalL| = |internalR| by the shift bijection, card_leftEnds_eq_card_rightEnds concludes |leftEnds| = |rightEnds| by omega — every maximal run starts exactly once and ends exactly once, with no telescoping.",
+    "mathContext": "$|\\mathrm{leftEnds}| + |\\mathrm{internalL}| = |S| = |\\mathrm{rightEnds}| + |\\mathrm{internalR}|$ and $|\\mathrm{internalL}| = |\\mathrm{internalR}|$ give $|\\mathrm{leftEnds}| = |\\mathrm{rightEnds}|$.",
+    "significance": "key",
+    "relatedConcepts": ["complementary counting", "partition of a finset", "run endpoints", "omega"],
+    "prerequisites": ["combinatorics", "Finset cardinality", "complement counting"]
   },
   {
     "id": "ann-edge-summands",
@@ -52,7 +68,11 @@
     },
     "type": "key-step",
     "title": "Boundary Edges Count Endpoints",
-    "content": "card_image_sub_one_sdiff shows the rising-edge set (S − 1) \\ S equals the injective image (leftEnds S).image (· − 1), so its cardinality is numRuns; symmetrically card_image_add_one_sdiff identifies the falling-edge set (S + 1) \\ S with rightEnds. Each maximal run thus contributes exactly two boundary edges — one rising at its left end, one falling at its right end."
+    "content": "card_image_sub_one_sdiff shows the rising-edge set (S − 1) \\ S equals the injective image (leftEnds S).image (· − 1), so its cardinality is numRuns; symmetrically card_image_add_one_sdiff identifies the falling-edge set (S + 1) \\ S with rightEnds. Each maximal run thus contributes exactly two boundary edges — one rising at its left end, one falling at its right end.",
+    "mathContext": "$|(S-1)\\setminus S| = |\\mathrm{leftEnds}| = \\mathrm{numRuns}$ and $|(S+1)\\setminus S| = |\\mathrm{rightEnds}|$: each run gives one rising and one falling boundary edge.",
+    "significance": "key",
+    "relatedConcepts": ["rising/falling edges", "injective image cardinality", "run endpoints", "set difference"],
+    "prerequisites": ["combinatorics", "Finset images", "cardinality of injective images"]
   },
   {
     "id": "ann-main-identity",
@@ -63,7 +83,11 @@
     },
     "type": "main-result",
     "title": "Boundary = 2·Runs and the Stability Equivalence",
-    "content": "edgeBoundaryCount_eq_two_mul_numRuns assembles the pieces: edgeBoundaryCount S = |leftEnds| + |rightEnds| = 2·|leftEnds| = 2·numRuns S. The corollary edgeBoundaryCount_eq_iff_numRuns turns this into the quantitative-stability equivalence edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1: each additional run (each gap) adds exactly two boundary edges, exactly the statement the parent entry conjectured for the (corrected) edge count."
+    "content": "edgeBoundaryCount_eq_two_mul_numRuns assembles the pieces: edgeBoundaryCount S = |leftEnds| + |rightEnds| = 2·|leftEnds| = 2·numRuns S. The corollary edgeBoundaryCount_eq_iff_numRuns turns this into the quantitative-stability equivalence edgeBoundaryCount S = 2 + 2k ⟺ numRuns S = k + 1: each additional run (each gap) adds exactly two boundary edges, exactly the statement the parent entry conjectured for the (corrected) edge count.",
+    "mathContext": "$\\mathrm{edgeBoundaryCount}(S) = 2\\,\\mathrm{numRuns}(S)$; hence $\\mathrm{edgeBoundaryCount}(S) = 2 + 2k \\iff \\mathrm{numRuns}(S) = k+1$.",
+    "significance": "critical",
+    "relatedConcepts": ["edge-isoperimetric identity", "quantitative stability", "runs and gaps", "main theorem"],
+    "prerequisites": ["combinatorics", "discrete isoperimetry"]
   },
   {
     "id": "ann-interval-case",
@@ -74,7 +98,11 @@
     },
     "type": "key-step",
     "title": "The Single-Run (Interval) Case",
-    "content": "min'_mem_leftEnds shows the minimum is always a run start, so one_le_numRuns gives numRuns ≥ 1 for nonempty S. numRuns_eq_one_iff_edgeBoundaryCount_eq_two records that one run ⟺ boundary 2, recovering the parent's rigidity threshold in edge-count language, and numRuns_Icc / edgeBoundaryCount_Icc compute that an interval [a,b] has exactly one run and edge boundary 2."
+    "content": "min'_mem_leftEnds shows the minimum is always a run start, so one_le_numRuns gives numRuns ≥ 1 for nonempty S. numRuns_eq_one_iff_edgeBoundaryCount_eq_two records that one run ⟺ boundary 2, recovering the parent's rigidity threshold in edge-count language, and numRuns_Icc / edgeBoundaryCount_Icc compute that an interval [a,b] has exactly one run and edge boundary 2.",
+    "mathContext": "Nonempty $S$ has $\\mathrm{numRuns}(S) \\ge 1$; $\\mathrm{numRuns}(S) = 1 \\iff \\mathrm{edgeBoundaryCount}(S) = 2$, and an interval $[a,b]$ realises this minimum.",
+    "significance": "key",
+    "relatedConcepts": ["interval (single run)", "rigidity threshold", "minimum element", "boundary = 2"],
+    "prerequisites": ["combinatorics", "order theory on ℤ", "intervals Icc"]
   },
   {
     "id": "ann-stability",
@@ -85,6 +113,10 @@
     },
     "type": "main-result",
     "title": "Discrete Fuglede-Type Lower Bound",
-    "content": "numRuns_sub_one_le_card_sdiff proves |Icc(min S, max S) \\ S| ≥ numRuns S − 1 by injecting each non-minimal run start x into its missing predecessor x − 1 (a point of the spanning interval not in S). Combined with the main identity, edgeBoundaryCount S = 2 + 2k forces S to differ from its spanning interval in at least k points — the discrete base case of Fuglede-type quantitative isoperimetric stability: more boundary edges than the interval minimum means provably farther from being an interval."
+    "content": "numRuns_sub_one_le_card_sdiff proves |Icc(min S, max S) \\ S| ≥ numRuns S − 1 by injecting each non-minimal run start x into its missing predecessor x − 1 (a point of the spanning interval not in S). Combined with the main identity, edgeBoundaryCount S = 2 + 2k forces S to differ from its spanning interval in at least k points — the discrete base case of Fuglede-type quantitative isoperimetric stability: more boundary edges than the interval minimum means provably farther from being an interval.",
+    "mathContext": "$|\\mathrm{Icc}(\\min S, \\max S) \\setminus S| \\ge \\mathrm{numRuns}(S) - 1$; with the main identity, $\\mathrm{edgeBoundaryCount}(S) = 2 + 2k \\Rightarrow |\\mathrm{Icc}\\setminus S| \\ge k$.",
+    "significance": "critical",
+    "relatedConcepts": ["Fuglede stability", "symmetric difference bound", "spanning interval", "quantitative isoperimetry"],
+    "prerequisites": ["combinatorics", "discrete isoperimetric stability", "injective lower bounds"]
   }
 ]

--- a/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/index.ts
+++ b/src/data/proofs/isoperimetric-theorem-oq-02-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/IsoperimetricTheoremOQ02OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const isoperimetricTheoremOq02Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const isoperimetricTheoremOq02Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const isoperimetricTheoremOq02Oq03Oq01Data: ProofData = {
+  proof: isoperimetricTheoremOq02Oq03Oq01Proof,
+  annotations: isoperimetricTheoremOq02Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `isoperimetric-theorem-oq-02-oq-03-oq-01`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 8 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (overview with 5 keyInsights, 8 sections, conclusion, 3 cross-references); left under all size caps (~16 KB). Math content (edge boundary = 2·runs via the shift bijection, discrete Fuglede-type stability bound) verified against the Lean source.