### PR TITLE
Enrich Circuit Removal Preserves Balance in Directed Graphs (konigsberg-oq-01-oq-02-incomplete-01)

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02-incomplete-01/annotations.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02-incomplete-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "definition",
     "title": "Degrees and the CircuitBalanced property",
-    "content": "A directed graph is just a `Finset (V × V)` of edges. `outDeg E v` and `inDeg E v` are `Finset.filter` cardinalities on the source/target component, so every later argument is pure Finset arithmetic — no graph structure or Fintype needed (only `DecidableEq V`). `CircuitBalanced S` abstracts the defining property of a directed circuit: every vertex is entered and left the same number of times *within S*. Stating the hypothesis this way keeps the main theorem walk-free and reusable for any edge-disjoint union of circuits."
+    "content": "A directed graph is just a `Finset (V × V)` of edges. `outDeg E v` and `inDeg E v` are `Finset.filter` cardinalities on the source/target component, so every later argument is pure Finset arithmetic — no graph structure or Fintype needed (only `DecidableEq V`). `CircuitBalanced S` abstracts the defining property of a directed circuit: every vertex is entered and left the same number of times *within S*. Stating the hypothesis this way keeps the main theorem walk-free and reusable for any edge-disjoint union of circuits.",
+    "mathContext": "$\\mathrm{outDeg}_E(v) = |\\{(a,b)\\in E : a=v\\}|$, $\\mathrm{inDeg}_E(v) = |\\{(a,b)\\in E : b=v\\}|$; $\\mathrm{CircuitBalanced}(S) \\equiv \\forall v,\\ \\mathrm{outDeg}_S(v) = \\mathrm{inDeg}_S(v)$.",
+    "significance": "key",
+    "relatedConcepts": ["directed graph as edge Finset", "in/out degree", "circuit balance", "Eulerian circuits"],
+    "prerequisites": ["graph theory", "Finset cardinality", "DecidableEq"]
   },
   {
     "id": "ann-koe02inc-filter-sdiff",
@@ -19,7 +23,11 @@
     },
     "type": "technique",
     "title": "The Finset.sdiff distributivity step the parent flagged",
-    "content": "The parent file recorded its `sorry` as 'blocked on a Finset.sdiff distributivity step'. That step is `filter_sdiff`: `(E \\ S).filter p = E.filter p \\ S.filter p`, proved in three lines by `ext` + `tauto` on memberships. With it, `outDeg_sdiff` rewrites the out-degree of `E \\ S` as a set-difference of filtered sets; since the S-filter is a subset of the E-filter, `Finset.card_sdiff_of_subset` gives the clean subtraction `outDeg (E \\ S) v = outDeg E v − outDeg S v` (and symmetrically for in-degree)."
+    "content": "The parent file recorded its `sorry` as 'blocked on a Finset.sdiff distributivity step'. That step is `filter_sdiff`: `(E \\ S).filter p = E.filter p \\ S.filter p`, proved in three lines by `ext` + `tauto` on memberships. With it, `outDeg_sdiff` rewrites the out-degree of `E \\ S` as a set-difference of filtered sets; since the S-filter is a subset of the E-filter, `Finset.card_sdiff_of_subset` gives the clean subtraction `outDeg (E \\ S) v = outDeg E v − outDeg S v` (and symmetrically for in-degree).",
+    "mathContext": "$(E\\setminus S).\\mathrm{filter}\\,p = E.\\mathrm{filter}\\,p \\setminus S.\\mathrm{filter}\\,p$, hence $\\mathrm{outDeg}_{E\\setminus S}(v) = \\mathrm{outDeg}_E(v) - \\mathrm{outDeg}_S(v)$ (truncated ℕ subtraction, valid as $S$-filter ⊆ $E$-filter).",
+    "significance": "critical",
+    "relatedConcepts": ["filter/sdiff distributivity", "Finset.card_sdiff_of_subset", "degree subtraction", "discharging a sorry"],
+    "prerequisites": ["Finset set difference", "filter on Finsets", "ℕ subtraction"]
   },
   {
     "id": "ann-koe02inc-corrected",
@@ -30,7 +38,11 @@
     },
     "type": "insight",
     "title": "The corrected theorem: balance is required",
-    "content": "`remove_circuitBalanced_preserves` adds the hypothesis the parent omitted: `∀ v, Balanced E v`. The proof rewrites both degrees of `E \\ S` via the subtraction lemmas; circuit-balance of `S` makes the two subtrahends (outDeg S v, inDeg S v) equal and balance of `E` makes the two minuends equal, so the truncated Nat differences agree by `omega`. Conceptually: removing a balanced circuit subtracts equally from in- and out-degree everywhere, so it preserves whatever imbalance `E` had — it can never manufacture balance."
+    "content": "`remove_circuitBalanced_preserves` adds the hypothesis the parent omitted: `∀ v, Balanced E v`. The proof rewrites both degrees of `E \\ S` via the subtraction lemmas; circuit-balance of `S` makes the two subtrahends (outDeg S v, inDeg S v) equal and balance of `E` makes the two minuends equal, so the truncated Nat differences agree by `omega`. Conceptually: removing a balanced circuit subtracts equally from in- and out-degree everywhere, so it preserves whatever imbalance `E` had — it can never manufacture balance.",
+    "mathContext": "If $\\mathrm{outDeg}_E = \\mathrm{inDeg}_E$ and $\\mathrm{outDeg}_S = \\mathrm{inDeg}_S$ at $v$, then $\\mathrm{outDeg}_E - \\mathrm{outDeg}_S = \\mathrm{inDeg}_E - \\mathrm{inDeg}_S$, so $E\\setminus S$ is balanced at $v$.",
+    "significance": "critical",
+    "relatedConcepts": ["balance preservation", "missing hypothesis", "Hierholzer induction step", "omega"],
+    "prerequisites": ["graph theory", "degree arithmetic", "Eulerian theory"]
   },
   {
     "id": "ann-koe02inc-witness",
@@ -41,7 +53,11 @@
     },
     "type": "application",
     "title": "A real circuit satisfies the abstract hypothesis",
-    "content": "`triangle_circuitBalanced` checks by `decide` that the directed 3-cycle 0→1→2→0 has in-degree = out-degree = 1 at every vertex, i.e. it is `CircuitBalanced`. `triangle_remove_self_balanced` then instantiates the corrected theorem to recover Hierholzer's base case: deleting the whole circuit from itself leaves the empty (vacuously balanced) graph."
+    "content": "`triangle_circuitBalanced` checks by `decide` that the directed 3-cycle 0→1→2→0 has in-degree = out-degree = 1 at every vertex, i.e. it is `CircuitBalanced`. `triangle_remove_self_balanced` then instantiates the corrected theorem to recover Hierholzer's base case: deleting the whole circuit from itself leaves the empty (vacuously balanced) graph.",
+    "mathContext": "The 3-cycle $0\\to1\\to2\\to0$ has $\\mathrm{inDeg} = \\mathrm{outDeg} = 1$ at each vertex (CircuitBalanced); removing it from itself yields $\\emptyset$, vacuously balanced.",
+    "significance": "supporting",
+    "relatedConcepts": ["directed 3-cycle", "decide tactic", "Hierholzer base case", "concrete witness"],
+    "prerequisites": ["graph theory", "decidable computation", "Eulerian circuits"]
   },
   {
     "id": "ann-koe02inc-refutation",
@@ -52,6 +68,10 @@
     },
     "type": "insight",
     "title": "Refuting the unconditional claim",
-    "content": "Over `Fin 4`, `unbalancedG` is the triangle plus a pendant edge 0→3, which is unbalanced (vertex 0 has out-degree 2, in-degree 1). The triangle `triangle4 ⊆ unbalancedG` is a genuine circuit (`triangle4_circuitBalanced`), yet `unbalancedG \\ triangle4 = {(0,3)}` is still unbalanced (`parent_statement_false`, by `decide` at vertex 3). `circuit_removal_needs_base_balance` packages this as an existence statement: any theorem deriving balance of `E \\ S` from `S` alone is unprovable. This is a fully kernel-checked (`decide`, no `native_decide`) refutation of the parent's hypothesis-free `remove_circuit_balanced`."
+    "content": "Over `Fin 4`, `unbalancedG` is the triangle plus a pendant edge 0→3, which is unbalanced (vertex 0 has out-degree 2, in-degree 1). The triangle `triangle4 ⊆ unbalancedG` is a genuine circuit (`triangle4_circuitBalanced`), yet `unbalancedG \\ triangle4 = {(0,3)}` is still unbalanced (`parent_statement_false`, by `decide` at vertex 3). `circuit_removal_needs_base_balance` packages this as an existence statement: any theorem deriving balance of `E \\ S` from `S` alone is unprovable. This is a fully kernel-checked (`decide`, no `native_decide`) refutation of the parent's hypothesis-free `remove_circuit_balanced`.",
+    "mathContext": "Counterexample over $\\mathrm{Fin}\\,4$: $E = \\{0\\to1,1\\to2,2\\to0,0\\to3\\}$ is unbalanced ($\\mathrm{outDeg}(0)=2 \\ne 1 = \\mathrm{inDeg}(0)$); the circuit $S$ (triangle) is balanced, yet $E\\setminus S = \\{0\\to3\\}$ remains unbalanced.",
+    "significance": "critical",
+    "relatedConcepts": ["counterexample", "refutation by decide", "necessity of hypothesis", "kernel-checked (not native_decide)"],
+    "prerequisites": ["graph theory", "decidable computation", "counterexample construction"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `konigsberg-oq-01-oq-02-incomplete-01`.

- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

index.ts already present; meta.json was already rich (overview, 5 sections, conclusion, 3 cross-references), left under all size caps (~14 KB). Math content (degree subtraction via filter/sdiff distributivity, corrected balance-preservation theorem, decide-checked counterexample) verified against the Lean source.