### PR TITLE
Enrich Davenport constant D(ℤ/nℤ)=n (erdos-ginzburg-ziv-oq-01-oq-01): overview + sections

### DIFF
--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/annotations.json
@@ -13,7 +13,8 @@
       "zero-sum sequences",
       "additive combinatorics",
       "pigeonhole principle"
-    ]
+    ],
+    "prerequisites": ["finite abelian groups", "zero-sum subsequences", "the Erdős–Ginzburg–Ziv constant for contrast"]
   },
   {
     "id": "ann-davenport-set",
@@ -24,7 +25,8 @@
     "content": "DavenportSet n is the set of lengths d for which every sequence a : Fin d → ℤ/nℤ has a nonempty subset summing to 0. The Davenport constant is by definition the LEAST element of this set, so proving D(ℤ/nℤ) = n becomes the IsLeast statement IsLeast (DavenportSet n) n — packaging the invariant exactly as in the textbook definition rather than as two separate inequalities.",
     "mathContext": "$\\mathrm{DavenportSet}(n) = \\{ d : \\forall a \\in (\\mathbb{Z}/n\\mathbb{Z})^d,\\ \\exists \\emptyset \\neq S,\\ \\sum_{i\\in S} a_i = 0 \\}$.",
     "significance": "core",
-    "relatedConcepts": ["IsLeast", "minimum", "zero-sum subsequence"]
+    "relatedConcepts": ["IsLeast", "minimum", "zero-sum subsequence"],
+    "prerequisites": ["set-builder definitions in Lean", "IsLeast / least element of a set", "sequences a : Fin d → ℤ/nℤ"]
   },
   {
     "id": "ann-davenport-prefixsum",
@@ -35,7 +37,8 @@
     "content": "prefixSum a k is the sum of the entries with index < k. The key algebraic fact prefixSum_split says that for u ≤ v, the first v entries split as the first u entries plus the block [u, v): P(v) = P(u) + (∑ over the block). This is proved by Finset.sum_union after exhibiting the index filter for [0,v) as the disjoint union of the filters for [0,u) and [u,v) — pure index bookkeeping discharged by omega. The split is the engine that turns a coincidence of two prefix sums into a zero-sum block.",
     "mathContext": "$P(v) = P(u) + \\sum_{u \\le k < v} a_k$ for $u \\le v$.",
     "significance": "core",
-    "relatedConcepts": ["telescoping", "partial sums", "Finset.sum_union"]
+    "relatedConcepts": ["telescoping", "partial sums", "Finset.sum_union"],
+    "prerequisites": ["finite sums over Finset", "disjoint-union decomposition of an index range", "omega for index arithmetic"]
   },
   {
     "id": "ann-davenport-upper",
@@ -46,7 +49,8 @@
     "content": "exists_nonempty_zerosum proves that any n elements of ℤ/nℤ contain a nonempty — in fact CONSECUTIVE — zero-sum block. There are n+1 prefix sums P(0), …, P(n) but only n residues in ℤ/nℤ, so by the pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to) two of them coincide: P(u) = P(v) with u < v. The intervening block {k : u ≤ k < v} is nonempty (the index valued u lies in Fin n since u < v ≤ n) and sums to P(v) − P(u) = 0 by prefixSum_split. A wlog reduces the symmetric u, v case. This is the classical n-consecutive-integers argument.",
     "mathContext": "$n+1$ prefix sums in an $n$-element group must collide: $P(u)=P(v)$, $u<v$, giving $\\sum_{u\\le k<v} a_k = 0$.",
     "significance": "core",
-    "relatedConcepts": ["pigeonhole principle", "consecutive subsequence", "ZMod.card"]
+    "relatedConcepts": ["pigeonhole principle", "consecutive subsequence", "ZMod.card"],
+    "prerequisites": ["pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)", "Fintype.card (ZMod n) = n", "prefixSum_split"]
   },
   {
     "id": "ann-davenport-sharp",
@@ -57,6 +61,7 @@
     "content": "davenport_sharp exhibits the extremal zero-sum-free sequence: n−1 copies of the generator 1. Any nonempty sub-block S sums to ∑_{i∈S} 1 = (S.card : ℤ/nℤ); since 1 ≤ S.card ≤ n−1 < n, the cardinality is not divisible by n (ZMod.natCast_eq_zero_iff), so the sum is nonzero. davenport_lower_bound upgrades this to: every admissible length is ≥ n, because the all-ones sequence of any length d < n is a counterexample. Together with the upper bound, n is the LEAST admissible length, giving davenport_zmod : IsLeast (DavenportSet n) n.",
     "mathContext": "The sequence $1^{n-1}$ has every nonempty sub-block summing to $c \\in \\{1,\\dots,n-1\\}$, never $0 \\bmod n$; hence $D(\\mathbb{Z}/n\\mathbb{Z}) \\ge n$.",
     "significance": "core",
-    "relatedConcepts": ["sharpness", "extremal configuration", "zero-sum-free sequence"]
+    "relatedConcepts": ["sharpness", "extremal configuration", "zero-sum-free sequence"],
+    "prerequisites": ["Finset.sum_const (∑ c = card • c)", "(a : ZMod n) = 0 ↔ n ∣ a", "antisymmetry combining the two bounds into IsLeast"]
   }
 ]

--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01-oq-01/meta.json
@@ -79,6 +79,67 @@
     "theoremCount": 6,
     "definitionCount": 2
   },
+  "overview": {
+    "historicalContext": "The Davenport constant is named after Harold Davenport, who highlighted the invariant at the 1966 Midwestern Conference on Group Theory and Number Theory (Ohio State) in connection with the arithmetic of algebraic number fields: D(G) for the ideal class group G bounds the maximal length of a factorization into irreducibles in the ring of integers, making it a central quantity in non-unique factorization theory (Geroldinger–Halter-Koch). For a finite abelian group, D(G) is the least d forcing every length-d sequence to contain a nonempty zero-sum subsequence. The cyclic value D(ℤ/nℤ) = n is the foundational case — classical folklore established by the prefix-sum pigeonhole — while the general problem (e.g. the rank-2 value D(ℤ/nℤ × ℤ/mℤ) = n + m − 1, proved by Olson) is much harder and open beyond rank 2. The constant sits beside the Erdős–Ginzburg–Ziv constant s(G); for the cyclic group the two are genuinely different numbers, n versus 2n − 1.",
+    "problemStatement": "Compute and formally verify the Davenport constant of the cyclic group: prove D(ℤ/nℤ) = n, i.e. that n is the least length d such that every sequence of d elements of ℤ/nℤ admits a nonempty zero-sum subsequence, packaged as IsLeast (DavenportSet n) n.",
+    "proofStrategy": "Two matching bounds meet at n. Upper bound (n is admissible): given any n elements a₀,…,a_{n−1}, form the n+1 prefix sums P(0),…,P(n) ∈ ℤ/nℤ; by pigeonhole (n+1 values in an n-element group) two coincide, P(u) = P(v) with u < v, and the consecutive block [u,v) is a nonempty subsequence summing to P(v) − P(u) = 0. Lower bound (sharpness): the all-ones sequence of length n−1 (n−1 copies of a generator) has every nonempty sub-block summing to its cardinality c with 1 ≤ c ≤ n−1, never 0 mod n, so no length below n is admissible. Antisymmetry of the two bounds yields the IsLeast statement.",
+    "keyInsights": [
+      "The Davenport constant is the *minimum-definition* invariant: phrasing it as IsLeast (DavenportSet n) n makes 'least admissible length' literal, splitting the proof cleanly into membership (upper bound) and a lower bound on the whole set.",
+      "The upper bound is pure prefix-sum pigeonhole: n+1 partial sums cannot be distinct in an n-element group, and a repeated partial sum exhibits a *consecutive* zero-sum block — no Chevalley–Warning or EGZ machinery is needed, so the proof is independent of the gallery's EGZ entry.",
+      "Sharpness is witnessed by a single extremal sequence: n−1 copies of a generator. Every nonempty sub-block sums to its cardinality, which ranges over 1,…,n−1 and is never divisible by n — the cleanest possible certificate that n−1 lengths fail.",
+      "D(ℤ/nℤ) = n and s(ℤ/nℤ) = 2n−1 are distinct invariants of the same group, separating two notions of 'forced zero-sum': any nonempty zero-sum (Davenport) versus a zero-sum of length exactly |G| (Erdős–Ginzburg–Ziv)."
+    ],
+    "prerequisites": [
+      "Sequences over a finite abelian group and the notion of a (nonempty) zero-sum subsequence",
+      "The pigeonhole principle for maps between finite sets (Finset.exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "Arithmetic in ℤ/nℤ: Fintype.card (ZMod n) = n and (a : ZMod n) = 0 ↔ n ∣ a",
+      "IsLeast and the least-element formulation of a minimum"
+    ]
+  },
+  "sections": [
+    {
+      "id": "statement-context",
+      "title": "Statement and context",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Module docstring: defines the Davenport constant D(G) as the least length forcing a nonempty zero-sum subsequence, states the cyclic value D(ℤ/nℤ) = n, contrasts it with the EGZ constant s(ℤ/nℤ) = 2n−1, and notes that neither the constant nor the prefix-sum lemma is in Mathlib. Imports ZMod and Tactic; opens Finset; fixes n with [NeZero n]."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions: prefix sums and admissible lengths",
+      "startLine": 56,
+      "endLine": 66,
+      "summary": "prefixSum a k = sum of the first k entries of the sequence a; DavenportSet n = the set of lengths d such that every length-d sequence over ℤ/nℤ has a nonempty zero-sum subsequence — the minimum-definition set whose least element is D(ℤ/nℤ)."
+    },
+    {
+      "id": "prefix-split",
+      "title": "The prefix-sum split",
+      "startLine": 68,
+      "endLine": 81,
+      "summary": "prefixSum_split: for u ≤ v, P(v) = P(u) + (sum over the block [u,v)), via Finset.sum_union on the disjoint decomposition of [0,v). This additive split is the engine that turns a coincidence of prefix sums into a zero-sum block."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The crux: prefix-sum pigeonhole (upper bound)",
+      "startLine": 83,
+      "endLine": 108,
+      "summary": "exists_nonempty_zerosum: any n elements of ℤ/nℤ contain a nonempty consecutive zero-sum block. The n+1 prefix sums P(0),…,P(n) map into the n-element ℤ/nℤ, so pigeonhole gives P(u) = P(v) with u < v; prefixSum_split shows the block [u,v) sums to 0."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness and the lower bound",
+      "startLine": 110,
+      "endLine": 147,
+      "summary": "n_mem_DavenportSet records the upper bound as membership; davenport_sharp exhibits the all-ones sequence of length n−1 whose every nonempty sub-block sums to its cardinality 1 ≤ c ≤ n−1 (never 0 mod n); davenport_lower_bound concludes every admissible length is ≥ n."
+    },
+    {
+      "id": "capstone",
+      "title": "The Davenport constant of the cyclic group",
+      "startLine": 149,
+      "endLine": 154,
+      "summary": "davenport_zmod: the headline IsLeast (DavenportSet n) n, i.e. D(ℤ/nℤ) = n, assembled from the upper-bound membership and the lower bound by antisymmetry."
+    }
+  ],
   "conclusion": {
     "summary": "The Davenport constant of the cyclic group is computed and verified: D(ℤ/nℤ) = n, stated as IsLeast (DavenportSet n) n (davenport_zmod). The upper bound (exists_nonempty_zerosum) is the prefix-sum pigeonhole — the n+1 partial sums P(0),…,P(n) cannot be distinct in the n-element group ℤ/nℤ, so a coincidence P(u) = P(v) with u < v exhibits the intervening block as a nonempty zero-sum subsequence. The lower bound (davenport_lower_bound, davenport_sharp) uses the all-ones extremal sequence of length n−1, whose nonempty sub-block sums equal their cardinalities 1,…,n−1, none divisible by n. All results are verified with 0 axioms and 0 sorries.",
     "implications": "Computes the second fundamental zero-sum invariant of ℤ/nℤ, complementing the gallery's Erdős–Ginzburg–Ziv constant s(ℤ/nℤ) = 2n−1 and exhibiting the two as distinct numbers (n vs 2n−1). Directly answers the open question recorded in the EGZ entry (erdos-ginzburg-ziv-oq-01) on whether the Davenport constant admits a packaged formalization. Mathlib has neither the Davenport constant nor the prefix-sum zero-sum lemma; the proof is independent of EGZ (prefix-sum pigeonhole, not Chevalley–Warning).",


### PR DESCRIPTION
Enrichment pass for `erdos-ginzburg-ziv-oq-01-oq-01` (the Davenport constant of the cyclic group, D(ℤ/nℤ) = n).

Unlike the other recent passes, this entry's gap was in **meta.json**, which had no `overview` and no `sections` at all (only description, conclusion, references, mathlibDependencies).

- Added a full `overview`: historicalContext (Davenport's 1966 origin, the factorization-theory motivation, Olson's rank-2 result, contrast with EGZ), problemStatement, proofStrategy, 4 keyInsights, and prerequisites.
- Added a 6-entry `sections` array covering the whole 154-line file (statement/context, definitions, prefix-sum split, the pigeonhole upper bound, sharpness/lower bound, capstone).
- Added `prerequisites` to all 5 annotations (which already carried mathContext/significance/relatedConcepts).

meta.json 7.1 KB → 13.0 KB, well under cap. `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)