### PR TITLE
research(pascals-hexagon-oq-03): PART 4j — nondegeneracy meaning + uniqueness capstone [VERIFIED, 0-new-axiom]

### DIFF
--- a/proofs/Proofs/PascalsHexagonOQ03.lean
+++ b/proofs/Proofs/PascalsHexagonOQ03.lean
@@ -1307,6 +1307,100 @@ theorem sameProjLine_pascalProjLine_of_pointOnLine
   unfold pascalProjLine
   exact sameProjLine_of_pointOnLine_pointOnLine hP hQ
 
+/-- **Uniqueness capstone — `pascalProjLine` is *the* Pascal line.**  Combining
+    the incidence of PART 4h (all three Pascal points lie on `pascalProjLine`)
+    with the uniqueness of PART 4i (two points determine their line), *any*
+    projective line `l` carrying all three opposite-side intersection points
+    `P, Q, R` is the same projective line as `pascalProjLine hex`.  This is the
+    precise geometric characterisation the descent map descends *to*: the Pascal
+    line of a hexagon is the unique projective line on which its three
+    opposite-side intersections lie. -/
+theorem pascalProjLine_unique
+    {C : Conic} (hex : InscribedHexagon C) {l : ProjLine}
+    (hl : collinearOnLine (pascalP hex) (pascalQ hex) (pascalR hex) l) :
+    sameProjLine l (pascalProjLine hex) :=
+  sameProjLine_pascalProjLine_of_pointOnLine hex hl.1 hl.2.1
+
+-- ============================================================
+-- PART 4j: Geometric Meaning of the Non-Degeneracy Hypothesis `hnd`
+--          (when the spanning line `P ×₃ Q` is genuine)
+-- ============================================================
+
+/- The well-definedness theorems of PART 4g–5b all carry the general-position
+   hypothesis `hnd : ∀ k, pascalProjLine (permuteHexagon hex k) ≠ 0`.  Since
+   `pascalProjLine hex = lineThrough (pascalP hex) (pascalQ hex) =
+   crossProduct (pascalP hex) (pascalQ hex)`, this is a statement purely about
+   the two spanning Pascal points.  The lemmas here unpack `≠ 0` into its
+   concrete coordinate meaning: a cross product of two vectors in `ℝ³` vanishes
+   exactly when all three of their `2×2` minors vanish — i.e. the two points are
+   projectively *equal*.  So `hnd` says no more and no less than "for every
+   relabeling the two opposite-side intersection points `P = AB ∩ DE` and
+   `Q = BC ∩ EF` spanning the line are projectively distinct". -/
+
+/-- **Cross product vanishes iff the three `2×2` minors vanish.**  For `u, v` in
+    `ℝ³`, `u ×₃ v = 0` exactly when each component — a `2×2` minor of the
+    `2×3` matrix `[u; v]` — is zero.  Geometrically this is precisely linear
+    dependence of `u` and `v` (the two vectors are proportional), the honest
+    statement of "`u` and `v` are the same projective point".  Pure coordinate
+    algebra: each direction is the three component equations read off via
+    `cross_apply`. -/
+theorem crossProduct_eq_zero_iff (u v : ProjPoint) :
+    crossProduct u v = 0 ↔
+      u 1 * v 2 = u 2 * v 1 ∧ u 2 * v 0 = u 0 * v 2 ∧ u 0 * v 1 = u 1 * v 0 := by
+  constructor
+  · intro h
+    refine ⟨?_, ?_, ?_⟩
+    · have h0 := congrFun h 0
+      simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+        Matrix.tail_cons, Matrix.head_cons, Pi.zero_apply, Fin.isValue] at h0
+      linarith
+    · have h1 := congrFun h 1
+      simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+        Matrix.tail_cons, Matrix.head_cons, Pi.zero_apply, Fin.isValue] at h1
+      linarith
+    · have h2 := congrFun h 2
+      simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+        Matrix.tail_cons, Matrix.head_cons, Pi.zero_apply, Fin.isValue] at h2
+      linarith
+  · rintro ⟨h0, h1, h2⟩
+    funext i
+    fin_cases i <;>
+      simp only [cross_apply, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+        Matrix.tail_cons, Matrix.head_cons, Pi.zero_apply, Fin.isValue, Fin.reduceFinMk] <;>
+      linarith
+
+/-- **The non-degeneracy hypothesis, made concrete.**  `pascalProjLine hex = 0`
+    — the failure of general position that `hnd` rules out — holds *exactly*
+    when the two spanning Pascal points `P = AB ∩ DE` and `Q = BC ∩ EF` have all
+    three `2×2` minors equal, i.e. are projectively the same point.  Equivalently
+    (contrapositive), `pascalProjLine hex ≠ 0` iff some minor of `P, Q` is
+    nonzero — a genuine, checkable witness that the line is honest. -/
+theorem pascalProjLine_eq_zero_iff {C : Conic} (hex : InscribedHexagon C) :
+    pascalProjLine hex = 0 ↔
+      (pascalP hex) 1 * (pascalQ hex) 2 = (pascalP hex) 2 * (pascalQ hex) 1 ∧
+      (pascalP hex) 2 * (pascalQ hex) 0 = (pascalP hex) 0 * (pascalQ hex) 2 ∧
+      (pascalP hex) 0 * (pascalQ hex) 1 = (pascalP hex) 1 * (pascalQ hex) 0 := by
+  unfold pascalProjLine lineThrough
+  exact crossProduct_eq_zero_iff (pascalP hex) (pascalQ hex)
+
+/-- **A checkable sufficient condition for general position.**  If even one
+    `2×2` minor of the two spanning Pascal points is nonzero, the Pascal line is
+    genuine (`pascalProjLine hex ≠ 0`).  This is the practical handle for
+    discharging the per-relabeling side of `hnd`: one need not verify the full
+    projective distinctness abstractly, only exhibit a single nonvanishing
+    determinant of two coordinates. -/
+theorem pascalProjLine_ne_zero_of_minor {C : Conic} (hex : InscribedHexagon C)
+    (h : (pascalP hex) 0 * (pascalQ hex) 1 ≠ (pascalP hex) 1 * (pascalQ hex) 0 ∨
+         (pascalP hex) 1 * (pascalQ hex) 2 ≠ (pascalP hex) 2 * (pascalQ hex) 1 ∨
+         (pascalP hex) 2 * (pascalQ hex) 0 ≠ (pascalP hex) 0 * (pascalQ hex) 2) :
+    pascalProjLine hex ≠ 0 := by
+  rw [Ne, pascalProjLine_eq_zero_iff]
+  rintro ⟨m12, m20, m01⟩
+  rcases h with h | h | h
+  · exact h m01
+  · exact h m12
+  · exact h m20
+
 -- ============================================================
 -- PART 5: Pascal-Line Map
 -- ============================================================

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s8-nondegeneracy-meaning-uniqueness-capstone.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/sessions/2026-06-27-s8-nondegeneracy-meaning-uniqueness-capstone.md
@@ -1,0 +1,57 @@
+# S8 ACT — non-degeneracy meaning + uniqueness capstone (PART 4j)
+
+**Agent:** researcher-2 · **Date:** 2026-06-27 · **Phase:** ACT · **Status:** VERIFIED
+
+## Summary
+
+Added **PART 4j** to `PascalsHexagonOQ03.lean`. Two complementary increments,
+both 0-sorry / 0-new-axiom, `docker-build Proofs.PascalsHexagonOQ03` succeeded
+(3070 jobs):
+
+1. **`pascalProjLine_unique`** — uniqueness *capstone*. Combines PART 4h
+   (incidence: the three Pascal points lie on `pascalProjLine`) with PART 4i
+   (uniqueness: two points determine their line). Any projective line `l`
+   carrying all three opposite-side intersections `P, Q, R` is
+   `sameProjLine l (pascalProjLine hex)`. One-line corollary of
+   `sameProjLine_pascalProjLine_of_pointOnLine hex hl.1 hl.2.1`.
+
+2. **Geometric meaning of the non-degeneracy hypothesis `hnd`.** Every
+   well-definedness theorem of PART 4g–5b carries
+   `hnd : ∀ k, pascalProjLine (permuteHexagon hex k) ≠ 0`. Since
+   `pascalProjLine hex = crossProduct (pascalP hex) (pascalQ hex)`, this is
+   purely a statement about the two spanning Pascal points. PART 4j unpacks it:
+   - `crossProduct_eq_zero_iff` — for `u, v : ℝ³`, `u ×₃ v = 0` iff all three
+     `2×2` minors vanish (`u1 v2 = u2 v1 ∧ u2 v0 = u0 v2 ∧ u0 v1 = u1 v0`).
+     This is exactly linear dependence / projective coincidence of `u, v`.
+     Forward: `congrFun` on each component + `linarith`; backward: `funext` +
+     `fin_cases` + `linarith`.
+   - `pascalProjLine_eq_zero_iff` — specialisation to `P = AB ∩ DE`,
+     `Q = BC ∩ EF`: `pascalProjLine hex = 0` iff those three minors vanish, i.e.
+     `P` and `Q` are projectively the same point. So `hnd` says **exactly** "for
+     every relabeling the two opposite-side intersection points spanning the
+     line are projectively distinct" — no more, no less.
+   - `pascalProjLine_ne_zero_of_minor` — checkable *sufficient* condition: one
+     nonvanishing `2×2` minor of `P, Q` already gives `pascalProjLine hex ≠ 0`.
+     This is the practical handle for discharging the per-relabeling side of
+     `hnd` without abstract projective-distinctness reasoning.
+
+## Significance (honest)
+
+The OQ-03-OQ-02 well-definedness backbone was already complete in prior sessions
+(PART 4c–5b: generator action, sameProjLine PER, quotient descent, incidence,
+uniqueness). This session does **not** discharge `hnd` (that needs the conic /
+general-position theory, a large effort) and does **not** touch the genuinely
+open Steiner-20 / Kirkman-60 counts (out of scope, 2 remaining sorries). What it
+adds is a precise *reading* of the non-degeneracy hypothesis the whole descent
+rides on — turning the opaque `∀ k, pascalProjLine … ≠ 0` into the concrete,
+checkable "the two spanning Pascal points are distinct" — plus the uniqueness
+capstone that names `pascalProjLine` as *the* Pascal line. Routine coordinate
+algebra; modest but genuine clarification of the file's standing assumption.
+
+## Next steps
+
+- Discharge `hnd` under `C.nondegenerate` + distinct vertices: needs that
+  `AB ∩ DE` and `BC ∩ EF` are distinct projective points for six points in
+  general position on a non-degenerate conic. `pascalProjLine_ne_zero_of_minor`
+  is the target lemma to feed.
+- Steiner-20 / Kirkman-60 remain genuinely OPEN (Conway–Ryba combinatorics).

--- a/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
+++ b/research/problems/pascals-hexagon-oq-03-incomplete-01/state.md
@@ -1,7 +1,25 @@
 # State: pascals-hexagon-oq-03-incomplete-01
 
-## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence + uniqueness layer)
-## Iteration: 7
+## Current Phase: ACT (OQ-03-OQ-02 COMPLETE + VERIFIED; incidence + uniqueness + nondeg-meaning)
+## Iteration: 8
+
+## Status (S8, researcher-2, 2026-06-27) — VERIFIED, nondegeneracy meaning + uniqueness capstone
+
+Added **PART 4j** to `PascalsHexagonOQ03.lean` (0 sorry / 0 new axiom;
+`docker-build Proofs.PascalsHexagonOQ03` succeeded, 3070 jobs):
+- `pascalProjLine_unique` — capstone: any line through all three Pascal points
+  is `sameProjLine pascalProjLine hex` (4h incidence + 4i uniqueness).
+- `crossProduct_eq_zero_iff` — `u ×₃ v = 0 ↔` three `2×2` minors vanish
+  (linear dependence / projective coincidence of `u, v`).
+- `pascalProjLine_eq_zero_iff` — `pascalProjLine hex = 0 ↔` the two spanning
+  Pascal points `P, Q` are projectively equal. Gives the `hnd` hypothesis its
+  exact geometric meaning: "every relabeling's two spanning points are distinct."
+- `pascalProjLine_ne_zero_of_minor` — checkable sufficient condition (one
+  nonvanishing minor ⟹ genuine line); the handle for discharging `hnd`.
+
+Does NOT discharge `hnd` (needs conic general-position theory) and does NOT
+touch open Steiner-20/Kirkman-60 (2 remaining sorries). See
+`sessions/2026-06-27-s8-nondegeneracy-meaning-uniqueness-capstone.md`.
 
 ## Status (S7, researcher-2, 2026-06-27) — VERIFIED, uniqueness finishing touch
 


### PR DESCRIPTION
## Summary

Adds **PART 4j** to `PascalsHexagonOQ03.lean` (pascals-hexagon-oq-03-incomplete-01, OQ-03-OQ-02 well-definedness). **0 sorry / 0 new axiom**; `docker-build Proofs.PascalsHexagonOQ03` succeeds (3070 jobs). Only remaining sorries are the pre-existing, genuinely open Steiner-20 / Kirkman-60 count theorems.

Builds directly on the now-merged PART 4h (incidence, #30814) and PART 4i (uniqueness, #30825).

## What's new

- **`pascalProjLine_unique`** — uniqueness *capstone*. Combining PART 4h (the three Pascal points lie on `pascalProjLine`) with PART 4i (two points determine their line), *any* projective line carrying all three opposite-side intersections `P, Q, R` is `sameProjLine` to `pascalProjLine hex`. Names `pascalProjLine` as **the** Pascal line.

- **`crossProduct_eq_zero_iff`** — for `u, v : ℝ³`, `u ×₃ v = 0` iff all three `2×2` minors vanish: `u1 v2 = u2 v1 ∧ u2 v0 = u0 v2 ∧ u0 v1 = u1 v0`. This is exactly linear dependence / projective coincidence of the two vectors.

- **`pascalProjLine_eq_zero_iff`** — gives the non-degeneracy hypothesis `hnd : ∀ k, pascalProjLine (permuteHexagon hex k) ≠ 0` (threaded through the entire PART 4g–5b descent) its exact geometric meaning: `pascalProjLine hex = 0` iff the two spanning Pascal points `AB ∩ DE` and `BC ∩ EF` are projectively the *same* point. So `hnd` says precisely "every relabeling's two spanning points are distinct" — no more, no less.

- **`pascalProjLine_ne_zero_of_minor`** — a checkable *sufficient* condition: one nonvanishing `2×2` minor of `P, Q` already forces `pascalProjLine hex ≠ 0`. The practical handle for discharging the per-relabeling side of `hnd`.

## Scope / honesty

This **does not** discharge `hnd` (that needs the conic / general-position theory) and **does not** touch the open Steiner-20 / Kirkman-60 counts. It is a precise *reading* of the standing non-degeneracy assumption plus the uniqueness capstone — routine coordinate algebra, modest but genuine clarification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)