### PR TITLE
Enrich Orbit-Counting Index Identity over Nat.card (lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -2,7 +2,10 @@
   {
     "id": "ann-lag020201-context",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 6, "endLine": 64 },
+    "range": {
+      "startLine": 6,
+      "endLine": 64
+    },
     "type": "concept",
     "title": "Two Routes to the Index Identity — and Where Finiteness Hides",
     "content": "The open question asks to derive the orbit-counting index identity `Nat.card (orbit G x) = [G : stabilizer G x]` by *combining* the parent's orbit-stabilizer product with Lagrange's theorem. This file delivers exactly that, but also points out a subtlety: there are two genuinely different derivations and they differ precisely in their finiteness needs. The direct bijection proves the identity unconditionally; the literal combine-and-cancel route needs `Finite G`, because cancelling the common stabilizer factor in `ℕ` is only valid when that factor is nonzero.",
@@ -24,49 +27,92 @@
   {
     "id": "ann-lag020201-product",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 70, "endLine": 78 },
+    "range": {
+      "startLine": 70,
+      "endLine": 78
+    },
     "type": "technique",
     "title": "The Orbit-Stabilizer Product (Restated)",
     "content": "`card_orbit_mul_card_stabilizer` restates the parent's product identity `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G` locally, so this file stands alone. The proof is the same two rewrites: `← Nat.card_prod` folds the product into `Nat.card (orbit × stabilizer)`, then `Nat.card_congr (orbitProdStabilizerEquivGroup G x)` rewrites along Mathlib's finiteness-free bijection. No `Finite`/`Fintype` instance appears.",
     "mathContext": "This is one of the two products that get equated in the cancellation argument. It is itself unconditional, exactly because the bijection $\\mathrm{orbit}(x)\\times\\mathrm{Stab}(x)\\cong G$ requires no finiteness.",
-    "significance": "important",
-    "relatedConcepts": ["Nat.card_prod", "Nat.card_congr", "orbitProdStabilizerEquivGroup"],
-    "prerequisites": ["orbitProdStabilizerEquivGroup", "Nat.card transport lemmas"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.card_prod",
+      "Nat.card_congr",
+      "orbitProdStabilizerEquivGroup"
+    ],
+    "prerequisites": [
+      "orbitProdStabilizerEquivGroup",
+      "Nat.card transport lemmas"
+    ]
   },
   {
     "id": "ann-lag020201-direct",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 80, "endLine": 91 },
+    "range": {
+      "startLine": 80,
+      "endLine": 91
+    },
     "type": "technique",
     "title": "The Unconditional Index Identity",
     "content": "`card_orbit_eq_index_stabilizer` proves `Nat.card (orbit G x) = (stabilizer G x).index` directly: `Subgroup.index_eq_card` unfolds the index to `Nat.card (G ⧸ stabilizer G x)`, and `Nat.card_congr (orbitEquivQuotientStabilizer G x)` finishes via the orbit/coset bijection. No finiteness hypothesis is used — this is the strongest form of the result.",
     "mathContext": "Reading the bijection $\\mathrm{orbit}(x) \\cong G/\\mathrm{Stab}(x)$ as an equality of cardinals gives $|\\mathrm{orbit}(x)| = [G : \\mathrm{Stab}(x)]$. Because `Subgroup.index` is *defined* as `Nat.card (G ⧸ H)`, the index notation and the quotient cardinal are interchangeable, and the identity holds for any group action whatsoever.",
     "significance": "key",
-    "relatedConcepts": ["orbitEquivQuotientStabilizer", "Subgroup.index_eq_card", "stabilizer index"],
-    "prerequisites": ["orbitEquivQuotientStabilizer", "Subgroup.index_eq_card", "Nat.card_congr"]
+    "relatedConcepts": [
+      "orbitEquivQuotientStabilizer",
+      "Subgroup.index_eq_card",
+      "stabilizer index"
+    ],
+    "prerequisites": [
+      "orbitEquivQuotientStabilizer",
+      "Subgroup.index_eq_card",
+      "Nat.card_congr"
+    ]
   },
   {
     "id": "ann-lag020201-pos",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 93, "endLine": 98 },
+    "range": {
+      "startLine": 93,
+      "endLine": 98
+    },
     "type": "technique",
     "title": "Positivity of the Stabilizer Card — Where Finiteness Enters",
     "content": "`card_stabilizer_pos` records `0 < Nat.card (stabilizer G x)` under `Finite G`, discharged by `Nat.card_pos` (the stabilizer is a finite, nonempty subgroup). This single lemma isolates exactly the hypothesis the cancellation route depends on: it is the `c > 0` side condition of ℕ right-cancellation.",
     "mathContext": "`Nat.card_pos` needs `[Nonempty α]` and `[Finite α]`. The stabilizer contains the identity (Nonempty) and is finite as a subtype of a finite group, so its cardinal is at least $1$. Without finiteness `Nat.card` could be $0$, and the cancellation below would be unjustified.",
-    "significance": "important",
-    "relatedConcepts": ["Nat.card_pos", "finite subgroup", "cancellation side condition"],
-    "prerequisites": ["Nat.card_pos", "Finite instances for subgroups"]
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.card_pos",
+      "finite subgroup",
+      "cancellation side condition"
+    ],
+    "prerequisites": [
+      "Nat.card_pos",
+      "Finite instances for subgroups"
+    ]
   },
   {
     "id": "ann-lag020201-cancel",
     "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
-    "range": { "startLine": 100, "endLine": 120 },
+    "range": {
+      "startLine": 100,
+      "endLine": 120
+    },
     "type": "technique",
     "title": "The Combine-and-Cancel Derivation (the OQ's Literal Route)",
     "content": "`card_orbit_eq_index_stabilizer_via_cancellation` is the derivation the open question describes. It pairs the orbit-stabilizer product `Nat.card (orbit G x) * s = Nat.card G` with Lagrange's `Subgroup.index_mul_card`, `[G : stabilizer G x] * s = Nat.card G` (here `s = Nat.card (stabilizer G x)`), rewrites both to expose `Nat.card (orbit G x) * s = [G : stabilizer G x] * s`, and concludes by `Nat.eq_of_mul_eq_mul_right (card_stabilizer_pos …)`. The `Finite G` hypothesis is exactly what powers the positivity feeding that cancellation.",
     "mathContext": "Right-cancellation $a c = b c \\Rightarrow a = b$ in $\\mathbb{N}$ holds iff $c > 0$. Both products equal $|G|$, so equating them and cancelling $|\\mathrm{Stab}(x)|$ yields $|\\mathrm{orbit}(x)| = [G:\\mathrm{Stab}(x)]$ — but only once $|\\mathrm{Stab}(x)| > 0$ is known. Contrast this with the bijection-based proof above, which needs no such hypothesis: the cancellation, not the statement, is what introduces finiteness.",
     "significance": "key",
-    "relatedConcepts": ["Subgroup.index_mul_card", "Nat.eq_of_mul_eq_mul_right", "Lagrange's theorem", "cancellation"],
-    "prerequisites": ["Subgroup.index_mul_card", "Nat.eq_of_mul_eq_mul_right", "card_stabilizer_pos"]
+    "relatedConcepts": [
+      "Subgroup.index_mul_card",
+      "Nat.eq_of_mul_eq_mul_right",
+      "Lagrange's theorem",
+      "cancellation"
+    ],
+    "prerequisites": [
+      "Subgroup.index_mul_card",
+      "Nat.eq_of_mul_eq_mul_right",
+      "card_stabilizer_pos"
+    ]
   }
 ]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeTheoremOq02Oq02Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeTheoremOq02Oq02Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeTheoremOq02Oq02Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: lagrangeTheoremOq02Oq02Oq01Oq01Oq01Oq01Proof,
+  annotations: lagrangeTheoremOq02Oq02Oq01Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -20,6 +20,7 @@
     "sorries": 0
   },
   "title": "The Orbit-Counting Index Identity over Nat.card",
+  "description": "Proves the orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] over Mathlib's total cardinal Nat.card, and pins down exactly where finiteness is needed. Two derivations are given: the direct route transports the finiteness-free bijection orbitEquivQuotientStabilizer through Nat.card and unfolds Subgroup.index, holding for ANY group action with no finiteness hypothesis; the literal combine-and-cancel route the open question asks for equates the orbit-stabilizer product with Lagrange's product and right-cancels the shared stabilizer factor, which needs Finite G because ℕ-cancellation requires the stabilizer card to be nonzero. The contrast makes precise why Mathlib builds orbit-stabilizer from equivalences rather than cardinal arithmetic. Fully verified: 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -112,6 +113,73 @@
     }
   ],
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The orbit-stabilizer theorem and Lagrange's theorem are the two pillars of finite group theory; together they say |orbit(x)|·|Stab(x)| = |G| and |H|·[G:H] = |G|. Classically both are stated for finite groups, where every cardinal is a positive natural number and cancellation is automatic. Mathlib re-engineered this corner around Nat.card — the total cardinal that returns 0 on infinite types — and around explicit equivalences (orbitEquivQuotientStabilizer, orbitProdStabilizerEquivGroup) that need no finiteness instance. This entry sits at the end of a long orbit-stabilizer-over-Nat.card lineage and addresses a deceptively simple question: can you get the orbit-counting index identity by literally combining the orbit-stabilizer product with Lagrange and cancelling?",
+    "problemStatement": "Derive the orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] over Nat.card by combining the parent's orbit-stabilizer product Nat.card (orbit G x)·Nat.card (stabilizer G x) = Nat.card G with Lagrange's theorem [G : stabilizer G x]·Nat.card (stabilizer G x) = Nat.card G — and determine what finiteness, if any, that derivation requires.",
+    "proofStrategy": "Give both derivations and contrast them. Direct (unconditional): card_orbit_eq_index_stabilizer unfolds Subgroup.index to Nat.card (G ⧸ stabilizer G x) via Subgroup.index_eq_card, then transports the finiteness-free bijection orbitEquivQuotientStabilizer through Nat.card_congr — no Finite/Fintype instance. Combine-and-cancel (the OQ's literal route): card_orbit_eq_index_stabilizer_via_cancellation sets the orbit-stabilizer product equal to Lagrange's product (both equal Nat.card G), exposing Nat.card (orbit G x)·s = [G : stabilizer G x]·s with s = Nat.card (stabilizer G x), and cancels s via Nat.eq_of_mul_eq_mul_right. That cancellation needs s > 0, supplied by card_stabilizer_pos under Finite G. The two proofs of the same statement differ exactly in this finiteness requirement.",
+    "keyInsights": [
+      "**The cancellation, not the statement, is what needs finiteness.** Over the total Nat.card (which is 0 on infinite types), right-cancelling the stabilizer factor is only valid when that factor is nonzero — so the combine-and-cancel route genuinely requires Finite G, while the bijection-based proof is unconditional.",
+      "**Subgroup.index is definitionally Nat.card (G ⧸ H).** Because of this, the orbit/coset bijection orbitEquivQuotientStabilizer transported through Nat.card immediately gives the index identity with no arithmetic — the index notation and the quotient cardinal are interchangeable.",
+      "**This explains a design choice in Mathlib.** Orbit-stabilizer is built from equivalences rather than from cardinal cancellation precisely because the equivalence removes the finiteness hypothesis that cancellation silently assumes.",
+      "**card_stabilizer_pos isolates the single finiteness fact used.** The whole dependence of the cancellation route on Finite G is concentrated in one positivity lemma (0 < Nat.card (stabilizer G x)), making the role of finiteness fully explicit."
+    ],
+    "prerequisites": [
+      "Group actions: orbit, stabilizer, the orbit space G ⧸ stabilizer (MulAction)",
+      "Subgroup index as Nat.card (G ⧸ H) and Lagrange's theorem in card form (Subgroup.index_mul_card)",
+      "Mathlib's finiteness-free bijections orbitEquivQuotientStabilizer and orbitProdStabilizerEquivGroup",
+      "ℕ right-cancellation (Nat.eq_of_mul_eq_mul_right) and Nat.card_pos for finite nonempty types"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: two routes and where finiteness hides",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Docstring stating the goal — the orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] over Nat.card — and the central observation that the direct bijection proves it unconditionally while the OQ's combine-and-cancel route needs Finite G, because ℕ-cancellation over the total Nat.card requires a nonzero stabilizer factor.",
+      "mathContext": "$|\\mathrm{orbit}(x)| = [G : \\mathrm{Stab}(x)]$ over `Nat.card`; the bijection route is finiteness-free, the cancellation route is not."
+    },
+    {
+      "id": "orbit-stabilizer-product",
+      "title": "The orbit-stabilizer product (restated)",
+      "startLine": 66,
+      "endLine": 78,
+      "summary": "card_orbit_mul_card_stabilizer restates the parent's product Nat.card (orbit G x)·Nat.card (stabilizer G x) = Nat.card G locally, via ← Nat.card_prod and Nat.card_congr (orbitProdStabilizerEquivGroup G x). Unconditional — no finiteness instance.",
+      "mathContext": "$|\\mathrm{orbit}(x)|\\cdot|\\mathrm{Stab}(x)| = |G|$ from $\\mathrm{orbit}(x)\\times\\mathrm{Stab}(x) \\cong G$."
+    },
+    {
+      "id": "direct-identity",
+      "title": "The unconditional index identity",
+      "startLine": 80,
+      "endLine": 91,
+      "summary": "card_orbit_eq_index_stabilizer proves Nat.card (orbit G x) = (stabilizer G x).index directly: Subgroup.index_eq_card unfolds the index to a quotient cardinal, and Nat.card_congr (orbitEquivQuotientStabilizer G x) finishes — no finiteness hypothesis.",
+      "mathContext": "$|\\mathrm{orbit}(x)| = \\mathrm{Nat.card}(G/\\mathrm{Stab}(x)) = [G : \\mathrm{Stab}(x)]$."
+    },
+    {
+      "id": "positivity",
+      "title": "Stabilizer-card positivity — where finiteness enters",
+      "startLine": 93,
+      "endLine": 98,
+      "summary": "card_stabilizer_pos records 0 < Nat.card (stabilizer G x) under Finite G (via Nat.card_pos), isolating the single positivity fact the cancellation route depends on.",
+      "mathContext": "$0 < |\\mathrm{Stab}(x)|$ for finite $G$: the $c>0$ side condition of ℕ right-cancellation."
+    },
+    {
+      "id": "combine-and-cancel",
+      "title": "The combine-and-cancel derivation (the OQ's literal route)",
+      "startLine": 100,
+      "endLine": 118,
+      "summary": "card_orbit_eq_index_stabilizer_via_cancellation pairs the orbit-stabilizer product with Lagrange's Subgroup.index_mul_card, both equal to Nat.card G, exposing a·s = b·s and cancelling s via Nat.eq_of_mul_eq_mul_right (card_stabilizer_pos …). Requires Finite G.",
+      "mathContext": "$a s = |G| = b s$ with $s = |\\mathrm{Stab}(x)| > 0$ gives $a = b$, i.e. $|\\mathrm{orbit}(x)| = [G:\\mathrm{Stab}(x)]$."
+    },
+    {
+      "id": "checks",
+      "title": "Signature checks",
+      "startLine": 120,
+      "endLine": 124,
+      "summary": "#check commands confirm the signatures of the three theorems and close the namespace OrbitCountingIndex.",
+      "mathContext": "Final sanity checks of the exported lemma signatures."
+    }
+  ],
   "conclusion": {
     "summary": "The orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] is proved two ways. The direct proof transports the finiteness-free bijection orbitEquivQuotientStabilizer through Nat.card and unfolds Subgroup.index, holding for any group action with no finiteness hypothesis. The combine-and-cancel proof — the literal route the open question describes — sets the orbit-stabilizer product equal to Lagrange's product and right-cancels the shared stabilizer factor; this needs Finite G, because ℕ-cancellation requires the stabilizer card to be nonzero. 124 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
     "implications": "The two derivations pin down exactly where finiteness is and is not needed: the bijection, not the cardinal arithmetic, is what removes the finiteness hypothesis from orbit-stabilizer counting. This is why Mathlib builds orbit-stabilizer from equivalences rather than from cancellation — the cancellation step silently assumes the stabilizer is finite, whereas the equivalence is unconditional. The unconditional index identity supplies a total, instance-free statement of 'orbit size = stabilizer index' for downstream use.",


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01`.

This entry was missing `description`, `overview`, `sections`, and `index.ts`, and had two annotations with an invalid `significance` value.

- **Created missing `index.ts`** — proof page was not loading on the live site.
- **Added top-level `description`** and a full **`overview`** (historicalContext, problemStatement, proofStrategy, 4 keyInsights, prerequisites).
- **Added 6 `sections`** covering the full 124-line Lean file with per-section mathContext.
- **Fixed `significance: "important"` → "supporting"** on two helper-lemma annotations (the type allows only critical/key/supporting).

Annotations already carried mathContext/relatedConcepts/prerequisites. meta.json ~10 KB, under all caps. Math content (unconditional bijection route vs Finite-requiring cancellation route) verified against the Lean source.