### PR TITLE
Enrich Seed-Independence of the Lucas–Lehmer Recurrence (lucas-lehmer-test-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/lucas-lehmer-test-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01-oq-01/annotations.json
@@ -19,7 +19,7 @@
       "base change along ring homomorphisms",
       "Lucas sequences"
     ],
-    "significance": "Generalizes the test's arithmetic engine from the fixed seed 4 to an arbitrary seed over an arbitrary ring, and records the base-change property that ports the sequence into the rings where its closed form becomes visible."
+    "significance": "key"
   },
   {
     "id": "ann-doubling-closed-form",
@@ -41,7 +41,7 @@
       "norm-1 units (ω + ω⁻¹)",
       "closed forms for quadratic recurrences"
     ],
-    "significance": "Pinpoints exactly how the seed enters the Lucas–Lehmer recurrence — only through the unit it represents — making 'seed-independence' a precise structural statement rather than folklore."
+    "significance": "critical"
   },
   {
     "id": "ann-seed-shift",
@@ -62,7 +62,7 @@
       "shift equivariance",
       "orbit of the recurrence map"
     ],
-    "significance": "Shows the seeded family is internally consistent under the recurrence map, so a one-step change of seed is just a re-indexing."
+    "significance": "supporting"
   },
   {
     "id": "ann-classical-closed-form",
@@ -85,7 +85,7 @@
       "Binet-type closed form",
       "quadratic integers ℤ[√3]"
     ],
-    "significance": "Recovers the textbook closed form for the Lucas–Lehmer sequence and exhibits the seed 4 as forced by the fundamental unit 2+√3 of ℤ[√3]."
+    "significance": "key"
   },
   {
     "id": "ann-seed-ten",
@@ -107,6 +107,6 @@
       "norm-1 units in ℤ[√6]",
       "structural vs verdict independence"
     ],
-    "significance": "Directly answers the seed-10 part of the parent's open question by exhibiting 10 as the same ω + ω⁻¹ shape, while honestly delimiting structural from verdict independence."
+    "significance": "key"
   }
 ]

--- a/src/data/proofs/lucas-lehmer-test-oq-01-oq-01/index.ts
+++ b/src/data/proofs/lucas-lehmer-test-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LucasLehmerTestOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lucasLehmerTestOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lucasLehmerTestOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lucasLehmerTestOq01Oq01Data: ProofData = {
+  proof: lucasLehmerTestOq01Oq01Proof,
+  annotations: lucasLehmerTestOq01Oq01Annotations,
+}

--- a/src/data/proofs/lucas-lehmer-test-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-lehmer-test-oq-01-oq-01/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "Seed-Independence of the Lucas–Lehmer Recurrence: the Doubling Closed Form",
+  "description": "Isolates the algebraic mechanism behind the seed of the Lucas–Lehmer primality test. The recurrence x ↦ x²−2 is the Chebyshev doubling map: for any unit a (with a·b = 1) of a commutative ring, the iterate from seed a+b has the closed form a^(2ⁿ) + b^(2ⁿ) (llSeq_closed), so the seed enters only through the unit it represents (c = a + a⁻¹). Anchoring Mathlib's seed-4 LucasLehmer.s in the generic family and base-changing along ring homomorphisms (map_llSeq) specialises this to the classical formula s(n) = ((2+√3)^(2ⁿ) + (2−√3)^(2ⁿ)).re over ℤ[√3], since 4 = (2+√3)+(2−√3) with (2+√3)(2−√3) = 1. The alternative seed 10 singled out in the parent's open question is exhibited as the same ω + ω⁻¹ shape over ℤ[√6] (5+2√6 of norm 1). This establishes structural seed-independence (the shared closed form), honestly distinguished from verdict-independence (that seed 10 certifies primality over the same range), which is left as the lead follow-up. Fully verified: 0 axioms, 0 sorries, no native_decide.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -114,6 +115,74 @@
     }
   ],
   "sorries": 0,
+  "overview": {
+    "historicalContext": "The Lucas–Lehmer test (Lucas 1878, made rigorous by Lehmer 1930) is the algorithm by which essentially all record Mersenne primes are found: 2^p − 1 is prime iff s_{p-2} ≡ 0 (mod 2^p − 1), where s₀ = 4 and s_{i+1} = s_i² − 2. The number 4 looks arbitrary, but it is the trace 4 = (2+√3) + (2−√3) of the fundamental unit 2+√3 of the real quadratic ring ℤ[√3], and the recurrence x ↦ x²−2 is the Chebyshev doubling map ω + ω⁻¹ ↦ ω² + ω⁻² on traces of norm-1 units. Folklore records that other seeds (e.g. 10) work too; this entry makes the algebraic content of that folklore precise and machine-checked, building on the parent entry that assembles the Lucas–Lehmer biconditional from Mathlib's halves.",
+    "problemStatement": "Explain the role of the seed in the Lucas–Lehmer recurrence: prove a closed form showing the recurrence depends on the seed only through the unit it represents, recover the classical explicit formula for the standard seed 4, and exhibit the alternative seed 10 (singled out in the parent's open question) as an instance of the same structure.",
+    "proofStrategy": "Define the generic seeded recurrence llSeq c (x ↦ x²−2 from seed c over any commutative ring) and anchor Mathlib's LucasLehmer.s as llSeq 4 over ℤ (llSeq_four_eq_s). Prove the base-change lemma map_llSeq (the recurrence commutes with every ring homomorphism) and the doubling closed form llSeq_closed: if a·b = 1 then llSeq (a+b) n = a^(2ⁿ) + b^(2ⁿ), by induction using the bilinear identity (X+Y)²−2 = X²+Y² when XY = 1 (linear_combination). Then transport the seed-4 sequence into ℤ[√3] and the seed-10 sequence into ℤ[√6] via map_llSeq, evaluate with llSeq_closed at the norm-1 units 2+√3 and 5+2√6, and read off the integer sequence as the real part of a sum of unit powers (s_closed_form, seed_ten_closed_form). A seed-shift lemma (llSeq_shift) records that advancing the index equals advancing the seed.",
+    "keyInsights": [
+      "**The recurrence x ↦ x²−2 is the Chebyshev doubling map on traces.** If c = a + a⁻¹ is the trace of a norm-1 unit a, then c² − 2 = a² + a⁻², so iterating doubles the exponent: llSeq c n = a^(2ⁿ) + a^(−2ⁿ). The seed enters only through the unit a it represents.",
+      "**The standard seed 4 is forced by a fundamental unit.** 4 = (2+√3)+(2−√3) with (2+√3)(2−√3) = 1, so the classical Lucas–Lehmer sequence is exactly ((2+√3)^(2ⁿ) + (2−√3)^(2ⁿ)).re over ℤ[√3] — a Binet-type closed form Mathlib does not carry.",
+      "**Base change is what makes the closed form visible.** The integer recurrence has no closed form over ℤ alone; transporting it via a ring homomorphism into ℤ[√d], where the seed becomes a sum of inverse units, is precisely what exposes the doubling structure (map_llSeq).",
+      "**Seed 10 is the same shape over a different ring.** 10 = (5+2√6)+(5−2√6) with norm 1 in ℤ[√6], giving llSeq 10 n = ((5+2√6)^(2ⁿ) + (5−2√6)^(2ⁿ)).re — confirming 10 as an admissible unit-trace seed exactly like 4 (structural, not yet verdict, independence)."
+    ],
+    "prerequisites": [
+      "Mathlib's LucasLehmer.s: the integer recurrence s₀ = 4, s_{i+1} = s_i² − 2",
+      "Mathlib's Zsqrtd (ℤ[√d]) with re/im projections and the CommRing instance",
+      "Ring homomorphisms and the map_sub / map_pow / map_ofNat interface (for base change)",
+      "Norm-1 units of real quadratic rings and their traces ω + ω⁻¹",
+      "The parent entry lucas-lehmer-test-oq-01 (the Lucas–Lehmer biconditional with seed 4)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview and imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Docstring framing the goal — explain the seed of the Lucas–Lehmer test via the Chebyshev doubling closed form, recover the classical ℤ[√3] formula, and exhibit seed 10 over ℤ[√6]. Imports Mathlib and the parent Proofs.LucasLehmerTestOQ01, opens LucasLehmer.",
+      "mathContext": "Seed $c = a + a^{-1}$ is the trace of a norm-1 unit; $x \\mapsto x^2-2$ doubles exponents."
+    },
+    {
+      "id": "generic-recurrence",
+      "title": "The generic seeded recurrence and its anchors",
+      "startLine": 48,
+      "endLine": 78,
+      "summary": "llSeq c (the x ↦ x²−2 iterate from an arbitrary seed over any commutative ring), llSeq_four_eq_s (identifies Mathlib's seed-4 LucasLehmer.s as llSeq 4 over ℤ), and map_llSeq (the recurrence commutes with every ring homomorphism — the base-change lemma).",
+      "mathContext": "$\\mathrm{llSeq}(c)_0 = c$, $\\mathrm{llSeq}(c)_{n+1} = \\mathrm{llSeq}(c)_n^2 - 2$; $f(\\mathrm{llSeq}(c)_n) = \\mathrm{llSeq}(f(c))_n$."
+    },
+    {
+      "id": "doubling-closed-form",
+      "title": "The doubling (Chebyshev) closed form",
+      "startLine": 80,
+      "endLine": 98,
+      "summary": "llSeq_closed: for a·b = 1 in a commutative ring, llSeq (a+b) n = a^(2ⁿ) + b^(2ⁿ), by induction on the bilinear identity (X+Y)²−2 = X²+Y² when XY = 1 (linear_combination). The structural heart: the seed enters only through the unit it represents.",
+      "mathContext": "$ab = 1 \\Rightarrow \\mathrm{llSeq}(a+b)_n = a^{2^n} + b^{2^n}$."
+    },
+    {
+      "id": "seed-shift",
+      "title": "Seed-shift independence",
+      "startLine": 100,
+      "endLine": 107,
+      "summary": "llSeq_shift: running one extra step from seed c equals running from the advanced seed c²−2, so the family is closed under the recurrence map acting on seeds.",
+      "mathContext": "$\\mathrm{llSeq}(c)_{n+1} = \\mathrm{llSeq}(c^2-2)_n$."
+    },
+    {
+      "id": "classical-closed-form",
+      "title": "The classical closed form over ℤ[√3]",
+      "startLine": 110,
+      "endLine": 146,
+      "summary": "alpha = 2+√3, beta = 2−√3 with αβ = 1 and α+β = 4; base-changing LucasLehmer.s into ℤ[√3] via map_llSeq and applying llSeq_closed gives s_closed_form: LucasLehmer.s n = ((2+√3)^(2ⁿ) + (2−√3)^(2ⁿ)).re.",
+      "mathContext": "$s(n) = \\big((2+\\sqrt3)^{2^n} + (2-\\sqrt3)^{2^n}\\big)_{\\mathrm{re}}$."
+    },
+    {
+      "id": "seed-ten",
+      "title": "The alternative seed 10 over ℤ[√6]",
+      "startLine": 147,
+      "endLine": 184,
+      "summary": "gamma = 5+2√6, delta = 5−2√6 with γδ = 1 and γ+δ = 10; the same base-change-then-closed-form argument gives seed_ten_closed_form: llSeq 10 n = ((5+2√6)^(2ⁿ) + (5−2√6)^(2ⁿ)).re, confirming 10 as an admissible unit-trace seed (structural, not yet verdict, independence).",
+      "mathContext": "$\\mathrm{llSeq}(10)_n = \\big((5+2\\sqrt6)^{2^n} + (5-2\\sqrt6)^{2^n}\\big)_{\\mathrm{re}}$."
+    }
+  ],
   "conclusion": {
     "summary": "This entry isolates the algebraic mechanism behind the choice of seed in the Lucas–Lehmer test. The recurrence x ↦ x²−2 is the Chebyshev doubling map: for any unit a (a*b = 1) of a commutative ring, the iterate from seed a+b has the closed form a^(2ⁿ) + b^(2ⁿ) (llSeq_closed). Hence the seed enters only through the unit it represents. Anchoring Mathlib's seed-4 LucasLehmer.s in the generic family (llSeq_four_eq_s) and base-changing via ring homomorphisms (map_llSeq), the closed form specializes to the classical formula s n = ((2+√3)^(2ⁿ) + (2−√3)^(2ⁿ)).re over ℤ[√3] (s_closed_form), since 4 = (2+√3)+(2−√3) with (2+√3)(2−√3) = 1. The alternative seed 10 singled out in the open question is exhibited as the same ω + ω⁻¹ shape over ℤ[√6] (seed_ten_closed_form). A seed-shift lemma (llSeq_shift) completes the picture. 184 lines, 12 theorems, 5 definitions, 0 axioms, 0 sorries.",
     "implications": "The closed form makes precise the sense in which the Lucas–Lehmer test is seed-independent: the standard seed 4 and the alternative seed 10 are both instances of the universal a^(2ⁿ) + a^(−2ⁿ) iterate, distinguished only by which norm-1 unit (2+√3 of ℤ[√3], or 5+2√6 of ℤ[√6]) they trace. The contribution is structural seed-independence (the closed form and the unit-trace characterization of seeds), not the full verdict-independence — proving the seed-10 residue certifies primality over the same range would require re-running Mathlib's group-order sufficiency/necessity argument with the ℤ[√6] unit, which is left as the lead follow-up question. The whole development is from the commutative-ring axioms and Mathlib's Zsqrtd; it uses no native_decide, hence no Lean.ofReduceBool, and is axiom-free in the foundational sense.",


### PR DESCRIPTION
Enrichment pass for `lucas-lehmer-test-oq-01-oq-01`.

This entry was missing `description`, `overview`, `sections`, and `index.ts`, and its annotations had a data bug: the `significance` field held full descriptive sentences instead of an enum value.

- **Created missing `index.ts`** — proof page was not loading on the live site.
- **Added top-level `description`** and a full **`overview`** (historicalContext, problemStatement, proofStrategy, 4 keyInsights, prerequisites).
- **Added 6 `sections`** covering the full 184-line Lean file with per-section mathContext.
- **Fixed `significance`** on all 5 annotations to valid `critical`/`key`/`supporting` values (the editorial framing they previously held is already present in each annotation's `content`).

Annotations already carried mathContext/relatedConcepts/prerequisites. meta.json under all caps. Math content (Chebyshev doubling closed form, ℤ[√3]/ℤ[√6] unit traces) verified against the Lean source.