### PR TITLE
Enrich Relativistic Velocity Addition from Rapidity (pythagorean-theorem-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/pythagorean-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03-oq-02/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "insight",
     "title": "Why Rapidity-Velocities Are Always Sub-c",
-    "content": "tanh maps all of ℝ onto the open interval (−1, 1), so β = tanh φ is always strictly below the speed of light. The proof is one identity: cosh φ − sinh φ = exp(−φ) > 0 gives sinh φ < cosh φ, i.e. tanh φ < 1; and cosh φ + sinh φ = exp(φ) > 0 gives −1 < tanh φ. There is no finite rapidity for which the speed reaches c — that requires φ → ∞."
+    "content": "tanh maps all of ℝ onto the open interval (−1, 1), so β = tanh φ is always strictly below the speed of light. The proof is one identity: cosh φ − sinh φ = exp(−φ) > 0 gives sinh φ < cosh φ, i.e. tanh φ < 1; and cosh φ + sinh φ = exp(φ) > 0 gives −1 < tanh φ. There is no finite rapidity for which the speed reaches c — that requires φ → ∞.",
+    "mathContext": "$\\beta = \\tanh\\varphi \\in (-1,1)$ because $\\cosh\\varphi \\mp \\sinh\\varphi = e^{\\mp\\varphi} > 0$, so $|\\sinh\\varphi| < \\cosh\\varphi$.",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic tangent", "rapidity", "speed of light limit", "open interval (−1,1)"],
+    "prerequisites": ["hyperbolic functions", "exponential identities", "special relativity"]
   },
   {
     "id": "ann-velocity-addition",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "Einstein's Law Is tanh's Addition Formula",
-    "content": "The parent entry proves that boosts compose by ADDING rapidities (φ₁ + φ₂). Because tanh inherits an addition formula from sinh and cosh, that additivity becomes the relativistic velocity-addition law tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂). The Lean proof goes through the cross-multiplied identity tanh_add_mul; the trick is to keep sinh(φ₁+φ₂)/cosh(φ₁+φ₂) atomic so field_simp only clears the simple denominators cosh φᵢ, after which sinh_add/cosh_add and ring finish. The denominator 1 + β₁β₂ > 0 is free from |tanh| < 1."
+    "content": "The parent entry proves that boosts compose by ADDING rapidities (φ₁ + φ₂). Because tanh inherits an addition formula from sinh and cosh, that additivity becomes the relativistic velocity-addition law tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂). The Lean proof goes through the cross-multiplied identity tanh_add_mul; the trick is to keep sinh(φ₁+φ₂)/cosh(φ₁+φ₂) atomic so field_simp only clears the simple denominators cosh φᵢ, after which sinh_add/cosh_add and ring finish. The denominator 1 + β₁β₂ > 0 is free from |tanh| < 1.",
+    "mathContext": "$\\tanh(\\varphi_1+\\varphi_2) = \\dfrac{\\tanh\\varphi_1 + \\tanh\\varphi_2}{1 + \\tanh\\varphi_1\\tanh\\varphi_2} = \\dfrac{\\beta_1+\\beta_2}{1+\\beta_1\\beta_2}$ (Einstein velocity addition).",
+    "significance": "critical",
+    "relatedConcepts": ["tanh addition formula", "rapidity additivity", "Einstein velocity addition", "Lorentz boosts"],
+    "prerequisites": ["hyperbolic functions", "special relativity", "field_simp / ring tactics"]
   },
   {
     "id": "ann-closure",
@@ -30,7 +38,11 @@
     },
     "type": "concept",
     "title": "c Is an Unreachable Speed Limit",
-    "content": "Composing two sub-c velocities can never reach or exceed c. The proof is purely algebraic and needs no arctanh: 1 − velAdd β₁ β₂ = (1−β₁)(1−β₂)/(1+β₁β₂) and 1 + velAdd β₁ β₂ = (1+β₁)(1+β₂)/(1+β₁β₂). When |β₁|, |β₂| < 1 both numerators and the denominator are positive, so −1 < velAdd β₁ β₂ < 1. This is the kinematic statement that the speed of light is a closed, unattainable boundary."
+    "content": "Composing two sub-c velocities can never reach or exceed c. The proof is purely algebraic and needs no arctanh: 1 − velAdd β₁ β₂ = (1−β₁)(1−β₂)/(1+β₁β₂) and 1 + velAdd β₁ β₂ = (1+β₁)(1+β₂)/(1+β₁β₂). When |β₁|, |β₂| < 1 both numerators and the denominator are positive, so −1 < velAdd β₁ β₂ < 1. This is the kinematic statement that the speed of light is a closed, unattainable boundary.",
+    "mathContext": "$1 \\mp \\mathrm{velAdd}(\\beta_1,\\beta_2) = \\dfrac{(1\\mp\\beta_1)(1\\mp\\beta_2)}{1+\\beta_1\\beta_2} > 0$ for $|\\beta_i|<1$, so the sum stays in $(-1,1)$.",
+    "significance": "key",
+    "relatedConcepts": ["closure of (−1,1)", "speed limit", "sign analysis", "relativistic kinematics"],
+    "prerequisites": ["algebra of inequalities", "special relativity"]
   },
   {
     "id": "ann-invariance-limit-gamma",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "Invariance, the Classical Limit, and γ",
-    "content": "Three textbook facts fall out. velAdd β 1 = (β+1)/(1+β) = 1: adding any velocity to c returns c — the second postulate as an algebraic fixed point. velAdd β₁ β₂ − (β₁+β₂) is second-order in the velocities, so Galilean addition β ≈ β₁+β₂ is the low-speed limit. And the Lorentz factor γ = cosh φ satisfies γ² = 1/(1−β²), since 1 − tanh²φ = 1/cosh²φ from cosh²−sinh²=1."
+    "content": "Three textbook facts fall out. velAdd β 1 = (β+1)/(1+β) = 1: adding any velocity to c returns c — the second postulate as an algebraic fixed point. velAdd β₁ β₂ − (β₁+β₂) is second-order in the velocities, so Galilean addition β ≈ β₁+β₂ is the low-speed limit. And the Lorentz factor γ = cosh φ satisfies γ² = 1/(1−β²), since 1 − tanh²φ = 1/cosh²φ from cosh²−sinh²=1.",
+    "mathContext": "$\\mathrm{velAdd}(\\beta,1)=1$ (invariance of $c$); $\\gamma=\\cosh\\varphi$ with $\\gamma^2 = \\dfrac{1}{1-\\beta^2}$ from $1-\\tanh^2\\varphi = \\mathrm{sech}^2\\varphi$.",
+    "significance": "key",
+    "relatedConcepts": ["invariance of c", "Galilean limit", "Lorentz factor γ", "second postulate"],
+    "prerequisites": ["hyperbolic identities", "special relativity", "Taylor/low-speed expansion"]
   },
   {
     "id": "ann-concrete",
@@ -52,6 +68,10 @@
     },
     "type": "concept",
     "title": "Half-c Plus Half-c Is Four-Fifths c",
-    "content": "velAdd_half_half computes (½+½)/(1+¼) = ⅘: combining two half-light-speed velocities yields 0.8c, conspicuously not c — the hallmark of relativistic addition. velAdd_three_fifths_one confirms ⅗c ⊕ c = c. Both are proved by norm_num after unfolding velAdd, with no native_decide, so the file stays fully kernel-checked."
+    "content": "velAdd_half_half computes (½+½)/(1+¼) = ⅘: combining two half-light-speed velocities yields 0.8c, conspicuously not c — the hallmark of relativistic addition. velAdd_three_fifths_one confirms ⅗c ⊕ c = c. Both are proved by norm_num after unfolding velAdd, with no native_decide, so the file stays fully kernel-checked.",
+    "mathContext": "$\\mathrm{velAdd}(\\tfrac12,\\tfrac12) = \\dfrac{1}{1+\\tfrac14} = \\tfrac45 = 0.8$; $\\mathrm{velAdd}(\\tfrac35,1)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "norm_num evaluation", "relativistic vs Galilean addition"],
+    "prerequisites": ["arithmetic", "special relativity"]
   }
 ]

--- a/src/data/proofs/pythagorean-theorem-oq-03-oq-02/index.ts
+++ b/src/data/proofs/pythagorean-theorem-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTheoremOQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTheoremOq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTheoremOq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTheoremOq03Oq02Data: ProofData = {
+  proof: pythagoreanTheoremOq03Oq02Proof,
+  annotations: pythagoreanTheoremOq03Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pythagorean-theorem-oq-03-oq-02`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (description, overview, 5 sections, conclusion, cross-reference); left under all size caps (~15 KB). Math content (β = tanh φ ∈ (−1,1), Einstein addition as tanh's addition formula, c as unreachable limit, γ = cosh φ) verified against the Lean source.