### PR TITLE
Enrich Sum of Two Squares: General-n Characterization via p-adic Valuation (pythagorean-triples-oq-04-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01-oq-01/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "concept",
     "title": "The Full General-n Characterization",
-    "content": "`sum_two_squares_iff` states the complete classification: n is a sum of two squares iff every prime p ≡ 3 (mod 4) divides n to an even power, written `Even (padicValNat p n)`. The proof rewrites with Mathlib's `Nat.eq_sq_add_sq_iff`, which quantifies only over `q ∈ n.primeFactors`. The forward direction is extended to an arbitrary prime p ≡ 3 (mod 4): if p does not divide n (or n = 0), then `padicValNat p n = 0`, which is even, so no condition is imposed; otherwise p is a genuine prime factor and Mathlib's lemma applies directly. This all-primes form is the statement a number theorist quotes."
+    "content": "`sum_two_squares_iff` states the complete classification: n is a sum of two squares iff every prime p ≡ 3 (mod 4) divides n to an even power, written `Even (padicValNat p n)`. The proof rewrites with Mathlib's `Nat.eq_sq_add_sq_iff`, which quantifies only over `q ∈ n.primeFactors`. The forward direction is extended to an arbitrary prime p ≡ 3 (mod 4): if p does not divide n (or n = 0), then `padicValNat p n = 0`, which is even, so no condition is imposed; otherwise p is a genuine prime factor and Mathlib's lemma applies directly. This all-primes form is the statement a number theorist quotes.",
+    "mathContext": "$n = a^2 + b^2 \\iff \\forall p \\equiv 3 \\pmod 4,\\ 2 \\mid v_p(n)$ — the sum-of-two-squares theorem (Fermat–Euler) in general-$n$ form.",
+    "significance": "critical",
+    "relatedConcepts": ["sum of two squares theorem", "p-adic valuation", "primes ≡ 3 mod 4", "prime factorization"],
+    "prerequisites": ["number theory", "p-adic valuation", "Gaussian integers"]
   },
   {
     "id": "ann-necessity",
@@ -19,7 +23,11 @@
     },
     "type": "technique",
     "title": "The Odd-Power Obstruction",
-    "content": "`not_sum_two_squares_of_odd_padicValNat` is the necessity half phrased as an obstruction: if a single prime p ≡ 3 (mod 4) divides n to an *odd* power, n is not a sum of two squares. The proof assumes a representation, extracts `Even (padicValNat p n)` from the characterization, and contradicts it with `Nat.even_iff_not_odd`. Crucially there is no hypothesis on n modulo 4 — this is exactly what lifts the elementary mod-4 obstruction to composite numbers such as 21, which is ≡ 1 (mod 4)."
+    "content": "`not_sum_two_squares_of_odd_padicValNat` is the necessity half phrased as an obstruction: if a single prime p ≡ 3 (mod 4) divides n to an *odd* power, n is not a sum of two squares. The proof assumes a representation, extracts `Even (padicValNat p n)` from the characterization, and contradicts it with `Nat.even_iff_not_odd`. Crucially there is no hypothesis on n modulo 4 — this is exactly what lifts the elementary mod-4 obstruction to composite numbers such as 21, which is ≡ 1 (mod 4).",
+    "mathContext": "If $\\exists\\, p \\equiv 3 \\pmod 4$ with $v_p(n)$ odd, then $n \\ne a^2+b^2$ — an obstruction with no hypothesis on $n \\bmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["necessity / obstruction", "odd valuation", "contrapositive", "composite counterexamples"],
+    "prerequisites": ["number theory", "p-adic valuation", "parity"]
   },
   {
     "id": "ann-prime-case",
@@ -30,7 +38,11 @@
     },
     "type": "concept",
     "title": "Recovering Fermat's Prime Case",
-    "content": "`prime_sum_two_squares_iff` shows a prime p is a sum of two squares iff p % 4 ≠ 3, recovered in one specialization. For a prime, the only prime factor is p itself, and `padicValNat.self` gives `padicValNat p p = 1`, which is odd — so if p ≡ 3 (mod 4) the criterion is violated. Conversely, any prime q ≡ 3 (mod 4) other than p fails to divide p (via `Nat.prime_dvd_prime_iff_eq`), hence has valuation 0. This is Fermat's two-squares theorem as a corollary of the general criterion."
+    "content": "`prime_sum_two_squares_iff` shows a prime p is a sum of two squares iff p % 4 ≠ 3, recovered in one specialization. For a prime, the only prime factor is p itself, and `padicValNat.self` gives `padicValNat p p = 1`, which is odd — so if p ≡ 3 (mod 4) the criterion is violated. Conversely, any prime q ≡ 3 (mod 4) other than p fails to divide p (via `Nat.prime_dvd_prime_iff_eq`), hence has valuation 0. This is Fermat's two-squares theorem as a corollary of the general criterion.",
+    "mathContext": "For prime $p$: $p = a^2+b^2 \\iff p \\not\\equiv 3 \\pmod 4$ (Fermat), since $v_p(p)=1$ is odd while every other prime has valuation $0$.",
+    "significance": "key",
+    "relatedConcepts": ["Fermat's two-squares theorem", "prime specialization", "padicValNat.self", "corollary"],
+    "prerequisites": ["number theory", "primes", "modular arithmetic"]
   },
   {
     "id": "ann-valuation-compute",
@@ -41,7 +53,11 @@
     },
     "type": "technique",
     "title": "Computing a p-adic Valuation by Hand",
-    "content": "`padicValNat_three_twentyone` computes `padicValNat 3 21 = 1` without native_decide. Writing 21 = 3 · 7, `padicValNat.mul` splits the valuation additively (both factors nonzero), `padicValNat.self` evaluates `padicValNat 3 3 = 1`, and `padicValNat.eq_zero_of_not_dvd` gives `padicValNat 3 7 = 0` since 3 ∤ 7. The result 1 + 0 = 1 is the odd multiplicity that obstructs representability. The same recipe handles 147 = 3 · 49."
+    "content": "`padicValNat_three_twentyone` computes `padicValNat 3 21 = 1` without native_decide. Writing 21 = 3 · 7, `padicValNat.mul` splits the valuation additively (both factors nonzero), `padicValNat.self` evaluates `padicValNat 3 3 = 1`, and `padicValNat.eq_zero_of_not_dvd` gives `padicValNat 3 7 = 0` since 3 ∤ 7. The result 1 + 0 = 1 is the odd multiplicity that obstructs representability. The same recipe handles 147 = 3 · 49.",
+    "mathContext": "$v_3(21) = v_3(3\\cdot 7) = v_3(3) + v_3(7) = 1 + 0 = 1$ (odd), via additivity of $v_p$ over products.",
+    "significance": "supporting",
+    "relatedConcepts": ["valuation additivity", "padicValNat.mul", "kernel-checked computation", "no native_decide"],
+    "prerequisites": ["number theory", "p-adic valuation", "factorization"]
   },
   {
     "id": "ann-headline-21",
@@ -52,6 +68,10 @@
     },
     "type": "insight",
     "title": "21 versus 441: What the Modulus 4 Misses",
-    "content": "`twentyone_not_sum_two_squares` is the headline witness. Since 21 % 4 = 1, the congruence obstruction of fermat-two-squares-oq-05 says nothing — yet 21 = 3 · 7 is not a sum of two squares because the prime 3 ≡ 3 (mod 4) occurs to the odd power 1. The general criterion detects this where the single modulus 4 cannot. Squaring repairs the defect: `fourfortyone_sum_two_squares` exhibits 441 = 21² = 21² + 0², where every prime now appears to an even power. The pair 21 / 441 (both ≡ 1 mod 4) shows the general criterion strictly refining the elementary one."
+    "content": "`twentyone_not_sum_two_squares` is the headline witness. Since 21 % 4 = 1, the congruence obstruction of fermat-two-squares-oq-05 says nothing — yet 21 = 3 · 7 is not a sum of two squares because the prime 3 ≡ 3 (mod 4) occurs to the odd power 1. The general criterion detects this where the single modulus 4 cannot. Squaring repairs the defect: `fourfortyone_sum_two_squares` exhibits 441 = 21² = 21² + 0², where every prime now appears to an even power. The pair 21 / 441 (both ≡ 1 mod 4) shows the general criterion strictly refining the elementary one.",
+    "mathContext": "$21 \\equiv 1 \\pmod 4$ yet $21 \\ne a^2+b^2$ (since $v_3(21)=1$ odd); $441 = 21^2 = 21^2 + 0^2$ (all valuations even). The mod-4 test is blind to both.",
+    "significance": "key",
+    "relatedConcepts": ["counterexample 21", "refinement of mod-4 obstruction", "squaring repairs parity", "fermat-two-squares-oq-05"],
+    "prerequisites": ["number theory", "modular arithmetic", "p-adic valuation"]
   }
 ]

--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01-oq-01/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ04OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq04Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq04Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq04Oq01Oq01Data: ProofData = {
+  proof: pythagoreanTriplesOq04Oq01Oq01Proof,
+  annotations: pythagoreanTriplesOq04Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-04-oq-01-oq-01`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (description, overview, 6 sections, conclusion, 3 cross-references); left under all size caps. Math content (n = a²+b² ⟺ every p ≡ 3 mod 4 has even valuation; the 21 vs 441 witness refining the mod-4 obstruction) verified against the Lean source.