### PR TITLE
Enrich Tschirnhaus Depression over a General Field of Characteristic ≠ 3 (solution-of-cubic-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-03/annotations.json
@@ -8,7 +8,11 @@
     },
     "type": "insight",
     "title": "Porting the Reduction: Numeral Nonzeroness from 3 ≠ 0",
-    "content": "cubic_depress is the parent's ℂ-identity ported to an arbitrary field K. Over ℂ, field_simp discharges the denominator side-conditions 9 ≠ 0 and 27 ≠ 0 by numeral computation. Over a general field that is no longer automatic: the two `have` lines derive them from the hypothesis (3 : K) ≠ 0 via 9 = 3², 27 = 3³ and pow_ne_zero. This is the single concrete obstacle to porting the proof verbatim — once supplied, field_simp + ring closes the identity exactly as before, pinning char K ≠ 3 as the minimal hypothesis."
+    "content": "cubic_depress is the parent's ℂ-identity ported to an arbitrary field K. Over ℂ, field_simp discharges the denominator side-conditions 9 ≠ 0 and 27 ≠ 0 by numeral computation. Over a general field that is no longer automatic: the two `have` lines derive them from the hypothesis (3 : K) ≠ 0 via 9 = 3², 27 = 3³ and pow_ne_zero. This is the single concrete obstacle to porting the proof verbatim — once supplied, field_simp + ring closes the identity exactly as before, pinning char K ≠ 3 as the minimal hypothesis.",
+    "mathContext": "From $(3:K)\\neq 0$: $9 = 3^2 \\neq 0$ and $27 = 3^3 \\neq 0$ (pow_ne_zero), the side-conditions field_simp needs to clear the depression denominators.",
+    "significance": "key",
+    "relatedConcepts": ["Tschirnhaus depression", "field characteristic", "numeral nonzeroness", "field_simp side-conditions"],
+    "prerequisites": ["field theory", "polynomial algebra", "characteristic of a field"]
   },
   {
     "id": "ann-soc-oq0103-bijection",
@@ -19,7 +23,11 @@
     },
     "type": "insight",
     "title": "Root Bijection over the General Field",
-    "content": "general_root_of_depressed_root and depressed_root_of_general_root establish that t ↦ t - b/(3a) carries roots of the depressed cubic to roots of the general cubic and back (inverse x ↦ x + b/(3a)). The lift direction uses a ≠ 0 to cancel the harmless factor a from a · depressed(t) = 0 via mul_eq_zero. The argument is identical to the parent's over ℂ; only the ambient field has changed."
+    "content": "general_root_of_depressed_root and depressed_root_of_general_root establish that t ↦ t - b/(3a) carries roots of the depressed cubic to roots of the general cubic and back (inverse x ↦ x + b/(3a)). The lift direction uses a ≠ 0 to cancel the harmless factor a from a · depressed(t) = 0 via mul_eq_zero. The argument is identical to the parent's over ℂ; only the ambient field has changed.",
+    "mathContext": "The shift $t \\mapsto t - \\dfrac{b}{3a}$ is a bijection between roots of the depressed and general cubics, with inverse $x \\mapsto x + \\dfrac{b}{3a}$.",
+    "significance": "key",
+    "relatedConcepts": ["root correspondence", "affine substitution", "mul_eq_zero", "leading coefficient a ≠ 0"],
+    "prerequisites": ["field theory", "polynomial roots", "bijections"]
   },
   {
     "id": "ann-soc-oq0103-universal-shift",
@@ -30,7 +38,11 @@
     },
     "type": "insight",
     "title": "The Universal Shift Identity (Any Commutative Ring)",
-    "content": "shift_quadratic_coeff expands (t+s)³ + b(t+s)² + c(t+s) + d and reads off the t²-coefficient as exactly 3s + b — proved by a single `ring`, with no hypothesis on 3 and over an arbitrary commutative ring R. This cleanly separates the universal algebra (the degree-3 expansion) from the characteristic-dependent conclusion (which shifts can actually remove the quadratic term)."
+    "content": "shift_quadratic_coeff expands (t+s)³ + b(t+s)² + c(t+s) + d and reads off the t²-coefficient as exactly 3s + b — proved by a single `ring`, with no hypothesis on 3 and over an arbitrary commutative ring R. This cleanly separates the universal algebra (the degree-3 expansion) from the characteristic-dependent conclusion (which shifts can actually remove the quadratic term).",
+    "mathContext": "$(t+s)^3 + b(t+s)^2 + c(t+s) + d$ has $t^2$-coefficient $3s + b$, over any commutative ring.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial expansion", "shift substitution", "ring tactic", "universal vs conditional algebra"],
+    "prerequisites": ["commutative ring theory", "polynomial algebra"]
   },
   {
     "id": "ann-soc-oq0103-char3-boundary",
@@ -41,7 +53,11 @@
     },
     "type": "insight",
     "title": "The Sharp Characteristic-3 Boundary",
-    "content": "charThree_quadratic_coeff_invariant specializes the universal identity to 3 = 0: the quadratic coefficient 3s + b collapses to b for every shift s. So in characteristic 3 the quadratic term is shift-invariant and a cubic with b ≠ 0 can never be depressed. This is not a proof artifact but a theorem — the exact analogue of needing 2 invertible to complete the square for the quadratic ('completing the cube')."
+    "content": "charThree_quadratic_coeff_invariant specializes the universal identity to 3 = 0: the quadratic coefficient 3s + b collapses to b for every shift s. So in characteristic 3 the quadratic term is shift-invariant and a cubic with b ≠ 0 can never be depressed. This is not a proof artifact but a theorem — the exact analogue of needing 2 invertible to complete the square for the quadratic ('completing the cube').",
+    "mathContext": "If $3 = 0$ then $3s + b = b$ for all $s$: the $t^2$-coefficient is shift-invariant, so $b \\neq 0$ cubics cannot be depressed.",
+    "significance": "critical",
+    "relatedConcepts": ["characteristic 3", "shift invariance", "completing the cube", "sharp boundary"],
+    "prerequisites": ["field characteristic", "polynomial algebra"]
   },
   {
     "id": "ann-soc-oq0103-dichotomy",
@@ -52,6 +68,10 @@
     },
     "type": "insight",
     "title": "The Existence Dichotomy",
-    "content": "depress_iff_three_ne_zero crystallizes the result: a quadratic-killing shift (one with 3s + b = 0) exists iff b = 0 or (3 : K) ≠ 0. For a generic cubic (b ≠ 0) depression is possible exactly when 3 is a unit; in characteristic 3 only the already-depressed cubics qualify. The proof is elementary case analysis on whether 3 = 0, with the witness s = -b/3 supplied by monic_shift_kills_quadratic when 3 is invertible."
+    "content": "depress_iff_three_ne_zero crystallizes the result: a quadratic-killing shift (one with 3s + b = 0) exists iff b = 0 or (3 : K) ≠ 0. For a generic cubic (b ≠ 0) depression is possible exactly when 3 is a unit; in characteristic 3 only the already-depressed cubics qualify. The proof is elementary case analysis on whether 3 = 0, with the witness s = -b/3 supplied by monic_shift_kills_quadratic when 3 is invertible.",
+    "mathContext": "$\\exists s,\\ 3s + b = 0 \\iff b = 0 \\lor (3:K) \\neq 0$; the depressing shift is $s = -b/3$ when $3$ is a unit.",
+    "significance": "critical",
+    "relatedConcepts": ["existence dichotomy", "depression criterion", "case analysis", "unit 3"],
+    "prerequisites": ["field theory", "characteristic", "solvability conditions"]
   }
 ]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-03/index.ts
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SolutionOfCubicOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const solutionOfCubicOq01Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const solutionOfCubicOq01Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const solutionOfCubicOq01Oq03Data: ProofData = {
+  proof: solutionOfCubicOq01Oq03Proof,
+  annotations: solutionOfCubicOq01Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-01-oq-03`.

- **Created missing `index.ts`** — proof page had no Vite entry point and was not loading on the live site; now fixed.
- **Deepened all 5 annotations** with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

meta.json was already rich (description, overview, 6 sections, conclusion, 3 cross-references); left under all size caps. Math content (depression needs 3 invertible; char-3 shift-invariance of the quadratic coefficient; existence dichotomy) verified against the Lean source.