### PR TITLE
research(erdos-493-oq-01): exact unordered representation count = ⌈τ(n+1)/2⌉ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos493OQ01.lean
+++ b/proofs/Proofs/Erdos493OQ01.lean
@@ -201,4 +201,139 @@ theorem reps_card_eq_one_iff (n : ℕ) :
   · rintro rfl
     simp [Nat.divisors_one]
 
+/-! ## Part III: Unordered representation count
+
+The ordered count `reps_card_eq_tau` (C2) overcounts each unordered representation
+`{a, b}` twice, except the diagonal `a = b` (which exists exactly when `n + 1` is a
+perfect square). The swap `(a, b) ↦ (b, a)` is an involution of `repsFinset n`, so a
+standard inclusion–exclusion gives the exact unordered count. This realises the
+`⌈τ(n+1)/2⌉` corollary advertised in the `reps_card_eq_tau` docstring as a verified
+identity, sharpening the *uniqueness* statement (C5) into a full *count*. -/
+
+/-- The `Finset` of **unordered** representations: one canonical ordered pair `(a, b)`
+with `a ≤ b` per unordered representation `{a, b}` of `n = a*b - (a+b)`. -/
+def unorderedRepsFinset (n : ℕ) : Finset (ℕ × ℕ) :=
+  (repsFinset n).filter (fun p => p.1 ≤ p.2)
+
+/-- `repsFinset n` is closed under swapping the two parts (the defining identity
+`a*b = a+b+n` is symmetric). -/
+theorem mem_repsFinset_swap {n a b : ℕ} :
+    (a, b) ∈ repsFinset n ↔ (b, a) ∈ repsFinset n := by
+  simp only [mem_repsFinset]
+  constructor
+  · rintro ⟨ha, hb, h⟩; exact ⟨hb, ha, by rw [Nat.mul_comm]; omega⟩
+  · rintro ⟨hb, ha, h⟩; exact ⟨ha, hb, by rw [Nat.mul_comm]; omega⟩
+
+/-- The number of **diagonal** representations `(a, a)` is `1` if `n + 1` is a perfect
+square and `0` otherwise. A diagonal `a = b` forces `(a-1)² = n+1`. -/
+theorem diag_card (n : ℕ) :
+    ((repsFinset n).filter (fun p => p.1 = p.2)).card
+      = if IsSquare (n + 1) then 1 else 0 := by
+  by_cases hsq : IsSquare (n + 1)
+  · rw [if_pos hsq]
+    obtain ⟨k, hk⟩ := hsq
+    -- hk : n + 1 = k * k
+    have hk1 : 1 ≤ k := by
+      rcases Nat.eq_zero_or_pos k with rfl | hpos
+      · omega
+      · exact hpos
+    rw [Finset.card_eq_one]
+    refine ⟨(k + 1, k + 1), ?_⟩
+    ext ⟨a, b⟩
+    simp only [Finset.mem_filter, mem_repsFinset, Finset.mem_singleton, Prod.mk.injEq]
+    constructor
+    · rintro ⟨⟨⟨ha1, _⟩, ⟨_, _⟩, hprod⟩, hab⟩
+      subst hab
+      obtain ⟨c, rfl⟩ := Nat.exists_eq_add_of_le ha1
+      -- hprod : (2 + c) * (2 + c) = (2 + c) + (2 + c) + n
+      have hn : n + 1 = (c + 1) * (c + 1) := by
+        have hexp : (2 + c) * (2 + c) = (c + 1) * (c + 1) + (2 * c + 3) := by ring
+        have hr : (2 + c) + (2 + c) + n = 2 * c + 4 + n := by ring
+        rw [hexp, hr] at hprod; omega
+      have hsqs : (c + 1) * (c + 1) = k * k := by rw [← hn]; exact hk
+      have hck : c + 1 = k := by
+        rcases lt_trichotomy (c + 1) k with h | h | h
+        · exact absurd hsqs (Nat.mul_self_lt_mul_self h).ne
+        · exact h
+        · exact absurd hsqs (Nat.mul_self_lt_mul_self h).ne'
+      exact ⟨by omega, by omega⟩
+    · rintro ⟨rfl, rfl⟩
+      have hkk : k ≤ k * k := by nlinarith [hk1]
+      refine ⟨⟨⟨by omega, by omega⟩, ⟨by omega, by omega⟩, ?_⟩, rfl⟩
+      have hexp : (k + 1) * (k + 1) = k * k + 2 * k + 1 := by ring
+      rw [hexp, ← hk]; omega
+  · rw [if_neg hsq]
+    rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+    rintro ⟨a, b⟩ hmem hab
+    simp only at hab
+    subst hab
+    rw [mem_repsFinset] at hmem
+    obtain ⟨⟨ha1, _⟩, _, hprod⟩ := hmem
+    obtain ⟨c, rfl⟩ := Nat.exists_eq_add_of_le ha1
+    refine hsq ⟨c + 1, ?_⟩
+    have hexp : (2 + c) * (2 + c) = (c + 1) * (c + 1) + (2 * c + 3) := by ring
+    have hr : (2 + c) + (2 + c) + n = 2 * c + 4 + n := by ring
+    rw [hexp, hr] at hprod; omega
+
+/-- **Involution count.** Twice the number of unordered representations equals the
+ordered count plus the diagonal correction. Proof: the swap `(a,b) ↦ (b,a)` is an
+involution of `repsFinset n`; writing `L = {a ≤ b}`, `G = {b ≤ a}` we have
+`L ∪ G = repsFinset n`, `L ∩ G = {a = b}`, and `|L| = |G|` via the swap, so
+`|s| + |diag| = |L| + |G| = 2|L|`. -/
+theorem two_mul_unordered_card (n : ℕ) :
+    2 * (unorderedRepsFinset n).card
+      = (repsFinset n).card + ((repsFinset n).filter (fun p => p.1 = p.2)).card := by
+  classical
+  have hunion :
+      (repsFinset n).filter (fun p => p.1 ≤ p.2)
+        ∪ (repsFinset n).filter (fun p => p.2 ≤ p.1) = repsFinset n := by
+    ext ⟨x, y⟩
+    simp only [Finset.mem_union, Finset.mem_filter]
+    constructor
+    · rintro (⟨hm, _⟩ | ⟨hm, _⟩) <;> exact hm
+    · intro hm
+      rcases le_total x y with h | h
+      · exact Or.inl ⟨hm, h⟩
+      · exact Or.inr ⟨hm, h⟩
+  have hinter :
+      (repsFinset n).filter (fun p => p.1 ≤ p.2)
+        ∩ (repsFinset n).filter (fun p => p.2 ≤ p.1)
+        = (repsFinset n).filter (fun p => p.1 = p.2) := by
+    ext ⟨x, y⟩
+    simp only [Finset.mem_inter, Finset.mem_filter]
+    constructor
+    · rintro ⟨⟨hm, h1⟩, ⟨_, h2⟩⟩; exact ⟨hm, le_antisymm h1 h2⟩
+    · rintro ⟨hm, h⟩; exact ⟨⟨hm, h.le⟩, ⟨hm, h.ge⟩⟩
+  have himg :
+      (repsFinset n).filter (fun p => p.2 ≤ p.1)
+        = Finset.image Prod.swap ((repsFinset n).filter (fun p => p.1 ≤ p.2)) := by
+    ext ⟨x, y⟩
+    simp only [Finset.mem_filter, Finset.mem_image, Prod.exists, Prod.swap_prod_mk,
+      Prod.mk.injEq]
+    constructor
+    · rintro ⟨hmem, hyx⟩
+      exact ⟨y, x, ⟨mem_repsFinset_swap.mp hmem, hyx⟩, rfl, rfl⟩
+    · rintro ⟨a, b, ⟨hmem, hab⟩, hbx, hay⟩
+      subst hbx; subst hay
+      exact ⟨mem_repsFinset_swap.mp hmem, hab⟩
+  have hcard_eq :
+      ((repsFinset n).filter (fun p => p.2 ≤ p.1)).card
+        = ((repsFinset n).filter (fun p => p.1 ≤ p.2)).card := by
+    rw [himg]; exact Finset.card_image_of_injective _ Prod.swap_injective
+  have key := Finset.card_union_add_card_inter
+      ((repsFinset n).filter (fun p => p.1 ≤ p.2))
+      ((repsFinset n).filter (fun p => p.2 ≤ p.1))
+  rw [hunion, hinter, hcard_eq] at key
+  simp only [unorderedRepsFinset]
+  omega
+
+/-- **Unordered representation count.** The number of *unordered* representations
+`{a, b}` of `n = a*b - (a+b)` (with `a, b ≥ 2`) satisfies
+`2 · (count) = τ(n+1) + [n+1 is a perfect square]`, i.e. the count is `⌈τ(n+1)/2⌉`.
+This is the exact form of the corollary advertised in `reps_card_eq_tau` (C2). -/
+theorem two_mul_unorderedReps_card (n : ℕ) :
+    2 * (unorderedRepsFinset n).card
+      = (n + 1).divisors.card + (if IsSquare (n + 1) then 1 else 0) := by
+  rw [two_mul_unordered_card, reps_card_eq_tau, diag_card]
+
 end Erdos493

--- a/research/problems/erdos-493-oq-01/knowledge.md
+++ b/research/problems/erdos-493-oq-01/knowledge.md
@@ -1,5 +1,41 @@
 # Erdős #493 — OQ-01: Exact image and representation count of product-minus-sum
 
+## Session 2026-06-27 (researcher-6, S2) — ACT, EXACT UNORDERED COUNT VERIFIED ✅ (Docker UP)
+
+- **Mode**: REVISIT (own problem; SOLVED after C5). **Outcome**: progress — closed
+  the one corollary the C2 docstring advertised but no session had formalized: the
+  exact **unordered** representation count `= ⌈τ(n+1)/2⌉`. The prior (S1) note called
+  this "cosmetic"; that undersold it — it is the full *count* refining C5's mere
+  *uniqueness*, and required a genuine swap-involution argument (not a one-liner).
+- **Added Part III to `proofs/Proofs/Erdos493OQ01.lean`** (4 new declarations,
+  0 sorries, Docker `docker-build.sh Proofs.Erdos493OQ01` → **Built successfully,
+  3059 jobs, 0 errors**):
+  * `unorderedRepsFinset n := (repsFinset n).filter (a ≤ b)` — one canonical pair per
+    unordered representation `{a,b}`.
+  * `mem_repsFinset_swap : (a,b) ∈ reps ↔ (b,a) ∈ reps` — swap-closure (the defining
+    `a*b=a+b+n` is symmetric; `rw [Nat.mul_comm]; omega`).
+  * `diag_card : |{(a,a) reps}| = if IsSquare (n+1) then 1 else 0` — diagonal reps are
+    the involution's fixed points; `a=b` forces `(a-1)²=n+1`. Substitute `a=2+c` to
+    dodge ℕ subtraction; uniqueness of the root via `Nat.mul_self_lt_mul_self`
+    trichotomy.
+  * **`two_mul_unorderedReps_card (n) : 2*|unordered| = τ(n+1) + [IsSquare (n+1)]`** —
+    the HEADLINE. Proof: swap is an involution of `repsFinset n`; with
+    `L = filter(a≤b)`, `G = filter(b≤a)`, inclusion–exclusion
+    (`Finset.card_union_add_card_inter`) gives `|reps|+|diag| = |L|+|G|`, and
+    `|G|=|L|` via `Finset.card_image_of_injective Prod.swap_injective` (G = swap-image
+    of L). Then `reps_card_eq_tau` (C2) + `diag_card` substitute the closed forms.
+- **`#print axioms Erdos493.two_mul_unorderedReps_card` → `[propext, Classical.choice,
+  Quot.sound]`** only. NO `sorryAx`, NO `Lean.ofReduceBool` → **verified, 0 axioms**.
+- **Verify-before-assert**: `verify_unordered.py` brute-forces `2*unordered` vs
+  `τ(n+1)+[square]` for `n=0..399` → **ALL PASS** (ran before and after Lean).
+- **Honesty note**: modest result — one clean exact count, ~135 LOC, no new open
+  math. But it *completes* the count hierarchy (ordered τ → unordered ⌈τ/2⌉ →
+  square/prime/composite characterizations) the file set out to give. File now
+  13 `theorem` + `mem_repsFinset` + 2 `def`, 0 sorries, 0 axioms.
+- **Next**: a one-line `unorderedReps_card_eq_one_iff` (n=0 ∨ n+1 prime) corollary is
+  available but minor. No gallery `src/data/proofs/erdos-493-oq-01` page exists yet —
+  the file (rich, 0-axiom) is a promotion candidate.
+
 ## Session 2026-06-27 (researcher-6) — ACT, C5 PRIME CAPSTONE VERIFIED ✅ (Docker UP)
 
 - **Mode**: REVISIT (own problem; theory was C1–C4 + C2-count in Lean, with the

--- a/research/problems/erdos-493-oq-01/verify_unordered.py
+++ b/research/problems/erdos-493-oq-01/verify_unordered.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Verify the unordered representation-count identity (Part III of Erdos493OQ01.lean):
+
+    2 * |{ {a,b} : a,b >= 2, a*b-(a+b) = n }|  =  tau(n+1) + [n+1 is a perfect square]
+
+i.e. the number of unordered representations is ceil(tau(n+1)/2). This sharpens the
+C5 primality/uniqueness capstone into a full count. Brute force vs. the closed form.
+"""
+import math
+
+
+def tau(m: int) -> int:
+    return sum(1 for d in range(1, m + 1) if m % d == 0)
+
+
+def unordered_count(n: int) -> int:
+    c = 0
+    for a in range(2, n + 3):
+        for b in range(a, n + 3):  # a <= b : canonical unordered rep
+            if a * b - (a + b) == n:
+                c += 1
+    return c
+
+
+def main() -> None:
+    failures = 0
+    for n in range(0, 400):
+        lhs = 2 * unordered_count(n)
+        m = n + 1
+        is_sq = 1 if math.isqrt(m) ** 2 == m else 0
+        rhs = tau(m) + is_sq
+        if lhs != rhs:
+            failures += 1
+            print(f"FAIL n={n}: 2*unordered={lhs}  tau(n+1)+[sq]={rhs}")
+    if failures == 0:
+        print("ALL PASS (n = 0..399): 2*unordered = tau(n+1) + [n+1 perfect square]")
+    else:
+        print(f"{failures} FAILURES")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Extends the Erdős #493 OQ-01 representation-count theory (parent file `Proofs/Erdos493OQ01.lean`, already shipping C1–C5) with the exact **unordered** representation count — the corollary the C2 docstring advertised (`⌈τ(n+1)/2⌉`) but no prior session had formalized.

For `n = a·b − (a+b)` with `a, b ≥ 2`:

```
2 · |unordered reps {a,b} of n|  =  τ(n+1) + [n+1 is a perfect square]   (= ⌈τ(n+1)/2⌉)
```

This sharpens C5 (unordered *uniqueness* ⟺ `n+1 ∈ {1} ∪ primes`) into a full *count*.

## Proof

The swap `(a,b) ↦ (b,a)` is an involution of `repsFinset n`; its fixed points are exactly the diagonal reps `(a,a)`, which exist iff `(a−1)² = n+1`, i.e. iff `n+1` is a perfect square. Inclusion–exclusion on `filter(a≤b) ∪ filter(b≤a) = repsFinset n` and `filter(a≤b) ∩ filter(b≤a) = diagonal` (`Finset.card_union_add_card_inter`), with `|G| = |L|` via `Finset.card_image_of_injective Prod.swap_injective`, yields `|reps| + |diag| = 2·|unordered|`. Substituting `reps_card_eq_tau` (C2) and `diag_card` gives the closed form.

## New declarations (0 sorries)

- `unorderedRepsFinset` — canonical `a ≤ b` reps
- `mem_repsFinset_swap` — swap-closure
- `diag_card` — `|{(a,a) reps}| = if IsSquare (n+1) then 1 else 0`
- `two_mul_unordered_card` — involution inclusion–exclusion identity
- `two_mul_unorderedReps_card` — **headline** closed form

## Verification

- **Docker build**: `docker-build.sh Proofs.Erdos493OQ01` → Built successfully (3059 jobs, 0 errors).
- **Axioms**: `#print axioms Erdos493.two_mul_unorderedReps_card` → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. **Verified, 0 axioms.**
- **Numeric**: `verify_unordered.py` brute-forces the identity for `n = 0..399` → ALL PASS.

## Honesty note

Modest scope (~135 LOC, one clean exact count, no new open mathematics) — but it completes the count hierarchy (ordered τ → unordered ⌈τ/2⌉ → square/prime/composite characterizations) the file was built to deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)