### PR TITLE
Enrich Chebyshev polynomials compose: T_{mn}=T_m∘T_n (chebyshev-polynomials-oq-01)

### DIFF
--- a/src/data/proofs/chebyshev-polynomials-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/annotations.json
@@ -33,7 +33,7 @@
     "title": "The composition law T_{m·n} = T_m ∘ T_n",
     "content": "The foundation of the entry: T_comp is Mathlib's Polynomial.Chebyshev.T_mul, stating that the (m·n)-th Chebyshev polynomial is the composite of the m-th and n-th. This is a polynomial identity valid over any commutative ring and for all integer indices.",
     "mathContext": "$T_{m \\cdot n} = T_m \\circ T_n$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "Chebyshev polynomials",
       "polynomial composition"
@@ -74,7 +74,7 @@
     "title": "Chebyshev polynomials commute under composition (headline)",
     "content": "The original contribution of the entry: T_m ∘ T_n = T_n ∘ T_m. Rewriting both composites back to T_{m·n} and T_{n·m} via the composition law reduces the claim to commutativity of integer multiplication. This is exactly what makes the Tₙ a commuting family — the property at the heart of Ritt's classification of commuting polynomials — and it is not recorded in Mathlib.",
     "mathContext": "$T_m \\circ T_n = T_{mn} = T_{nm} = T_n \\circ T_m$.",
-    "significance": "central",
+    "significance": "critical",
     "relatedConcepts": [
       "commuting polynomials",
       "Ritt's theorem",

--- a/src/data/proofs/chebyshev-polynomials-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ChebyshevPolynomialsOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevPolynomialsOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevPolynomialsOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevPolynomialsOq01Data: ProofData = {
+  proof: chebyshevPolynomialsOq01Proof,
+  annotations: chebyshevPolynomialsOq01Annotations,
+}

--- a/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-polynomials-oq-01/meta.json
@@ -106,5 +106,70 @@
       "The cosine multiple-angle identity"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: the composition law and the commuting family",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring framing the goal — package Mathlib's Chebyshev multiplicativity T_mul with its structural consequences (commutativity under composition, X = T₁ as compositional identity, associativity, trigonometric origin), none of which Mathlib records.",
+      "mathContext": "$T_{mn} = T_m \\circ T_n$ for all $m,n \\in \\mathbb{Z}$ over any commutative ring."
+    },
+    {
+      "id": "composition-law",
+      "title": "The composition law T_{m·n} = T_m ∘ T_n",
+      "startLine": 36,
+      "endLine": 47,
+      "summary": "T_comp records Mathlib's Polynomial.Chebyshev.T_mul: the (m·n)-th Chebyshev polynomial is the composite of the m-th and n-th — a polynomial identity over any commutative ring and all integer indices.",
+      "mathContext": "$T_{m\\cdot n} = T_m \\circ T_n$."
+    },
+    {
+      "id": "identity",
+      "title": "T₁ = X is the identity for composition",
+      "startLine": 48,
+      "endLine": 66,
+      "summary": "comp_T_one / T_one_comp / T_comp_one: since T₁ = X and X is the two-sided identity for polynomial composition, the index 1 is a compositional unit, exhibiting n ↦ Tₙ as a monoid morphism (ℤ, ·, 1) → (R[X], ∘, X).",
+      "mathContext": "$T_1 = X$, $p \\circ X = X \\circ p = p$, so $T_m \\circ T_1 = T_m$."
+    },
+    {
+      "id": "commutativity",
+      "title": "Commutativity under composition (headline)",
+      "startLine": 68,
+      "endLine": 75,
+      "summary": "T_comp_comm: the original contribution. Rewriting both composites to T_{m·n} and T_{n·m} via the composition law reduces T_m ∘ T_n = T_n ∘ T_m to commutativity of integer multiplication — the property at the heart of Ritt's classification, absent from Mathlib.",
+      "mathContext": "$T_m \\circ T_n = T_{mn} = T_{nm} = T_n \\circ T_m$."
+    },
+    {
+      "id": "associativity",
+      "title": "Associativity of the composition law",
+      "startLine": 77,
+      "endLine": 88,
+      "summary": "T_comp_assoc / T_comp_assoc': iterating the composition law unfolds T_{l·m·n} into a triple composite, with mul_assoc reconciling the two bracketings — completing the monoid laws.",
+      "mathContext": "$T_{lmn} = (T_l \\circ T_m) \\circ T_n = T_l \\circ (T_m \\circ T_n)$."
+    },
+    {
+      "id": "trig-origin",
+      "title": "The trigonometric origin and concrete instances",
+      "startLine": 89,
+      "endLine": 119,
+      "summary": "T_real_cos_comp / eval_T_comp_cos: over ℝ, Tₙ(cos θ) = cos(n θ), so T_m(T_n(cos θ)) = cos(m·n·θ) — the composition law as the polynomial shadow of the multiple-angle identity. Concrete T₆ = T₂ ∘ T₃ = T₃ ∘ T₂ over ℤ.",
+      "mathContext": "$T_m(T_n(\\cos\\theta)) = \\cos(mn\\theta)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry packages the Chebyshev composition law T_{m·n} = T_m ∘ T_n (Mathlib's Polynomial.Chebyshev.T_mul) with the structural consequences Mathlib omits. The headline result is that the Chebyshev polynomials commute under composition, T_m ∘ T_n = T_n ∘ T_m, immediate from the composition law and m·n = n·m. With T₁ = X the two-sided compositional identity and associativity established, n ↦ Tₙ is exhibited as a monoid morphism (ℤ, ·, 1) → (R[X], ∘, X), and over ℝ the whole picture is the polynomial form of cos(m·n·θ) = T_m(T_n(cos θ)). 119 lines, 10 theorems, 0 axioms, 0 sorries.",
+    "implications": "Commutativity under composition places the Chebyshev family, alongside the power maps xⁿ, at the centre of Ritt's 1923 classification of commuting polynomials. The monoid-morphism viewpoint makes the Chebyshev indexing a faithful translation of integer multiplication into polynomial composition, a structure exploited in iteration, approximation theory, and fast multiple-angle evaluation. Because the law is a polynomial identity over an arbitrary commutative ring, all of this holds beyond the trigonometric setting where Tₙ originates.",
+    "openQuestions": [
+      "Formalize the converse direction of Ritt's theorem: characterize all polynomials that commute with a fixed Chebyshev polynomial Tₙ (n ≥ 2) as exactly the other Chebyshev polynomials (up to conjugation by an affine map).",
+      "Establish the analogous composition/commutation theory for the Chebyshev polynomials of the second kind Uₙ and the Dickson polynomials, identifying which structural laws survive."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-polynomials",
+      "relationship": "extends",
+      "description": "Parent Chebyshev entry. This follow-up isolates the composition law T_{m·n} = T_m ∘ T_n and derives the structural consequences — commutativity under composition, the monoid-morphism picture, and the trigonometric origin — that Mathlib's bare multiplicativity lemma does not record."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `chebyshev-polynomials-oq-01`.

This entry had a rich overview and fully-populated annotations but was missing `sections`, `conclusion`, `crossReferences`, and `index.ts`, with two annotations using an invalid `significance` value.

- **Created missing `index.ts`** — proof page was not loading on the live site.
- **Added 6 `sections`** covering the full 119-line Lean file with per-section mathContext.
- **Added `conclusion`** (summary, implications, 2 open questions on Ritt's theorem and second-kind Chebyshev/Dickson polynomials).
- **Added a `crossReference`** to the parent chebyshev-polynomials entry.
- **Fixed `significance: "central"` → "critical"** on two annotations (type allows only critical/key/supporting).

meta.json under all caps. Math content (composition law, commutativity under composition, monoid morphism, trigonometric origin) verified against the Lean source.