### PR TITLE
research(halting-problem-oq-01): approximating the halting problem — schematic barrier + sharp arithmetical-hierarchy placement [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3880,6 +3880,7 @@ import Proofs.RearrangementChebyshevEqOQ01OQ02
 import Proofs.RearrangementChebyshevStrictOQ01OQ02
 import Proofs.RearrangementChebyshevStrictOQ01OQ02OQ01
 import Proofs.HaltingApproximation
+import Proofs.HaltingArithmeticalHierarchy
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge
 import Proofs.RepunitDivisibilityOQ01

--- a/proofs/Proofs/HaltingArithmeticalHierarchy.lean
+++ b/proofs/Proofs/HaltingArithmeticalHierarchy.lean
@@ -1,0 +1,177 @@
+/-
+# The Halting Problem in the Arithmetical Hierarchy: where the approximation gap lives
+
+## What This Proves
+The companion file `Proofs.HaltingApproximation` proves a *schematic* barrier for
+partial approximators `A : ℕ → ℕ → Option Bool`: every **sound** approximator
+(one that is correct wherever it commits) must **decline** (answer `none`) at its
+own diagonal point. That theorem is honest but coarse — it locates a *single*
+forced gap and uses no model of computation, so it cannot say how *large* the
+decline set is, nor where the halting problem sits in the arithmetical hierarchy.
+
+This file supplies the genuine computational-complexity reading (gallery open
+question **OQ-01c**) using Mathlib's computability library
+(`Nat.Partrec.Code`, `REPred`, `ComputablePred`). Fix an input `n` and let
+
+  `Halts n c  :=  (eval c n).Dom`            -- code `c` halts on input `n`
+
+be the parametrized halting set `K`. The results:
+
+* **Hierarchy placement.** `K` is recursively enumerable (`halts_re`, i.e. `Σ⁰₁`)
+  but *not* computable (`halts_not_computable`), and its complement is *not*
+  recursively enumerable (`halts_compl_not_re`). So `K` is **properly `Σ⁰₁`**:
+  the approximation gap lives exactly in `Π⁰₁ ∖ Σ⁰₁`. (These three repackage the
+  Mathlib theorems `ComputablePred.halting_problem_re / halting_problem /
+  halting_problem_not_re` under the gallery's framing.)
+
+* **The decline set is genuinely large — not a single point.** Model a *computable*
+  approximator as a **partial computable** function `f : Code →. Bool`
+  (`none`/undefined = decline). We prove:
+  - `re_confirmedFalse` — for any partial computable `f`, the set of codes on which
+    `f` *confirms non-halting* (commits `false`) is recursively enumerable.
+  - `no_sound_approx_confirms_all_nonhalting` — **no** sound computable approximator
+    can confirm non-halting on *all* of `Kᶜ`; if it did, `Kᶜ` would be r.e.,
+    contradicting `halts_compl_not_re`.
+  - `sound_approx_undefined_on_nonhalting` — consequently every sound computable
+    approximator **declines** (is undefined) on some genuinely non-halting input.
+    This is the real-model analog of the schematic
+    `HaltingApproximation.sound_approx_declines_on_diagonal`, and it is *not*
+    confined to a diagonal point: the obstruction is the asymmetry "`K` is r.e.,
+    `Kᶜ` is not", i.e. halting is *semi-decidable* (you can confirm halting, since
+    `K` is r.e.) but non-halting is *not* (no computable process confirms looping
+    on every looping input).
+
+## Approach
+- **Foundation (from Mathlib):** `Mathlib.Computability.Halting` — the universal
+  partial recursive function, `Nat.Partrec.Code.eval`, `REPred`, `ComputablePred`,
+  and the three halting-problem theorems. Unlike the zero-import schematic file,
+  this file *needs* a real model of computation, which is the whole point of
+  OQ-01c.
+- **Original Contributions:** The bridge from the schematic `Option Bool`
+  approximator to the partial-computable `Code →. Bool` approximator, the lemma
+  that the confirmed-non-halting set is r.e., and the strengthening of "declines
+  at the diagonal point" to "declines on a non-r.e. (hence infinite) set" via the
+  `Σ⁰₁`/`Π⁰₁` asymmetry.
+- **Proof Techniques Demonstrated:** recursive enumerability as "domain of a
+  partial computable function" (`Partrec.dom_re`), closure of `Partrec` under
+  `bind`/`cond`, and reduction (`REPred.of_eq`) to Mathlib's halting theorems.
+
+## Honesty Note
+The three hierarchy-placement theorems are thin wrappers over Mathlib results; the
+genuine new mathematical content of this session is the approximator bridge
+(`re_confirmedFalse`, `no_sound_approx_confirms_all_nonhalting`,
+`sound_approx_undefined_on_nonhalting`), which turns the schematic single-point
+gap into the precise statement that the gap is the non-r.e. set `Kᶜ`. We do *not*
+prove a density/measure ("generic-case complexity") statement — that is OQ-01b and
+is encoding-sensitive (see `knowledge.md`).
+-/
+
+import Mathlib.Computability.Halting
+
+namespace HaltingArithmeticalHierarchy
+
+open Nat.Partrec (Code)
+open Nat.Partrec.Code (eval)
+
+/-! ## The parametrized halting set `K` -/
+
+/-- The **halting predicate** at a fixed input `n`: code `c` halts on input `n`. -/
+def Halts (n : ℕ) (c : Code) : Prop := (eval c n).Dom
+
+/-! ### Arithmetical-hierarchy placement (repackaged from Mathlib)
+
+`K` is `Σ⁰₁` (r.e.) but neither computable (`Δ⁰₁`) nor co-r.e. (`Π⁰₁`); the
+approximation gap is therefore exactly `Kᶜ ∈ Π⁰₁ ∖ Σ⁰₁`. -/
+
+/-- `K` is **recursively enumerable** (semi-decidable / `Σ⁰₁`): one can confirm
+halting. -/
+theorem halts_re (n : ℕ) : REPred (Halts n) :=
+  ComputablePred.halting_problem_re n
+
+/-- `K` is **not computable**: there is no total decider for halting. -/
+theorem halts_not_computable (n : ℕ) : ¬ ComputablePred (Halts n) :=
+  ComputablePred.halting_problem n
+
+/-- The complement of `K` is **not** recursively enumerable: non-halting is *not*
+semi-decidable. This is the asymmetry that forces every sound approximator's gap. -/
+theorem halts_compl_not_re (n : ℕ) : ¬ REPred (fun c => ¬ Halts n c) :=
+  ComputablePred.halting_problem_not_re n
+
+/-! ## Computable approximators and the decline set -/
+
+/-- `f` is a **sound** approximator for halting at `n`: every value it *commits*
+(`b ∈ f c`) is correct. Where `f c` is undefined, `f` **declines**. We do not
+require `f` total or even computable in this predicate — computability is supplied
+separately as `Partrec f`. -/
+def Sound (n : ℕ) (f : Code →. Bool) : Prop :=
+  ∀ c b, b ∈ f c → (b = true ↔ Halts n c)
+
+/-- Soundness, specialized: confirming non-halting (`false ∈ f c`) is correct. -/
+theorem Sound.not_halts {n : ℕ} {f : Code →. Bool} (hs : Sound n f) {c : Code}
+    (h : false ∈ f c) : ¬ Halts n c := by
+  have := (hs c false h)
+  simpa using this
+
+/-- **The confirmed-non-halting set of a partial computable approximator is r.e.**
+
+For partial computable `f`, the set `{c | false ∈ f c}` of codes on which `f`
+commits `false` is the domain of the partial computable function
+`c ↦ (f c) >>= (fun b => bif b then none else some ())`, hence recursively
+enumerable. -/
+theorem re_confirmedFalse {f : Code →. Bool} (hf : Partrec f) :
+    REPred (fun c => false ∈ f c) := by
+  -- The witnessing partial computable function.
+  have hg : Partrec (fun c => (f c).bind
+      (fun b => cond b Part.none (Part.some ()))) :=
+    hf.bind (Partrec.cond Computable.snd Partrec.none (Partrec.const' (Part.some ())))
+  refine (hg.dom_re).of_eq (fun c => ?_)
+  -- Its domain is exactly `{c | false ∈ f c}`.
+  rw [Part.dom_iff_mem]
+  constructor
+  · rintro ⟨x, hx⟩
+    rw [Part.mem_bind_iff] at hx
+    obtain ⟨b, hb, hxb⟩ := hx
+    cases b with
+    | true  => simp at hxb
+    | false => exact hb
+  · intro hb
+    exact ⟨(), Part.mem_bind_iff.2 ⟨false, hb, by simp⟩⟩
+
+/-- **No sound computable approximator confirms non-halting on all of `Kᶜ`.**
+
+If a sound partial computable `f` committed `false` on *every* non-halting code,
+then `{c | false ∈ f c}` would equal `Kᶜ`; the former is r.e. (`re_confirmedFalse`)
+but the latter is not (`halts_compl_not_re`) — contradiction. So halting is
+semi-decidable while non-halting is not: the approximation gap cannot be closed. -/
+theorem no_sound_approx_confirms_all_nonhalting {n : ℕ} {f : Code →. Bool}
+    (hf : Partrec f) (hs : Sound n f) :
+    ¬ ∀ c, ¬ Halts n c → false ∈ f c := by
+  intro hall
+  have hre : REPred (fun c => ¬ Halts n c) :=
+    (re_confirmedFalse hf).of_eq fun c =>
+      ⟨fun h => hs.not_halts h, fun h => hall c h⟩
+  exact halts_compl_not_re n hre
+
+/-- **Every sound computable approximator declines on some genuinely non-halting
+input.**  The real-model analog of the schematic
+`HaltingApproximation.sound_approx_declines_on_diagonal`: there is a code `c` with
+`¬ Halts n c` on which `f` is *undefined* (declines). Such `c` cannot be confirmed
+`false` (else `Kᶜ` would be r.e.) and cannot be committed `true` (soundness forbids
+a wrong commit), so `f c` has no value at all. -/
+theorem sound_approx_undefined_on_nonhalting {n : ℕ} {f : Code →. Bool}
+    (hf : Partrec f) (hs : Sound n f) :
+    ∃ c, ¬ Halts n c ∧ ¬ (f c).Dom := by
+  -- Some non-halting `c` is not confirmed `false`.
+  obtain ⟨c, hc, hcf⟩ : ∃ c, ¬ Halts n c ∧ false ∉ f c := by
+    by_contra h
+    push_neg at h
+    exact no_sound_approx_confirms_all_nonhalting hf hs h
+  refine ⟨c, hc, ?_⟩
+  -- At such `c`, `f` cannot commit any value, so it declines.
+  rintro hdom
+  obtain ⟨b, hb⟩ := Part.dom_iff_mem.1 hdom
+  cases b with
+  | true  => exact hc ((hs c true hb).1 rfl)
+  | false => exact hcf hb
+
+end HaltingArithmeticalHierarchy

--- a/proofs/Proofs/HaltingArithmeticalHierarchy.lean
+++ b/proofs/Proofs/HaltingArithmeticalHierarchy.lean
@@ -40,6 +40,14 @@ be the parametrized halting set `K`. The results:
     `Kᶜ` is not", i.e. halting is *semi-decidable* (you can confirm halting, since
     `K` is r.e.) but non-halting is *not* (no computable process confirms looping
     on every looping input).
+  - `decline_set_on_nonhalting_not_re` — the sharp form: the decline set
+    *restricted to the non-halting inputs* is **itself not recursively
+    enumerable** (hence infinite), not merely nonempty. Since at a non-halting
+    code a sound approximator either declines or commits `false`,
+    `Kᶜ = {confirmed false} ∪ {non-halting ∧ declines}`; the first piece is r.e.,
+    so were the second r.e. the union `Kᶜ` would be r.e. (`REPred.or`),
+    contradicting `halts_compl_not_re`. The earlier nonempty statement is
+    recovered as the corollary `sound_approx_declines_nonempty`.
 
 ## Approach
 - **Foundation (from Mathlib):** `Mathlib.Computability.Halting` — the universal
@@ -49,21 +57,22 @@ be the parametrized halting set `K`. The results:
   OQ-01c.
 - **Original Contributions:** The bridge from the schematic `Option Bool`
   approximator to the partial-computable `Code →. Bool` approximator, the lemma
-  that the confirmed-non-halting set is r.e., and the strengthening of "declines
-  at the diagonal point" to "declines on a non-r.e. (hence infinite) set" via the
-  `Σ⁰₁`/`Π⁰₁` asymmetry.
+  that the confirmed-non-halting set is r.e., closure of `REPred` under union
+  (`REPred.or`, via Mathlib's `Partrec.merge'` dovetailing), and the strengthening
+  of "declines at the diagonal point" to "the decline set on `Kᶜ` is non-r.e.
+  (hence infinite)" via the `Σ⁰₁`/`Π⁰₁` asymmetry.
 - **Proof Techniques Demonstrated:** recursive enumerability as "domain of a
   partial computable function" (`Partrec.dom_re`), closure of `Partrec` under
   `bind`/`cond`, and reduction (`REPred.of_eq`) to Mathlib's halting theorems.
 
 ## Honesty Note
 The three hierarchy-placement theorems are thin wrappers over Mathlib results; the
-genuine new mathematical content of this session is the approximator bridge
-(`re_confirmedFalse`, `no_sound_approx_confirms_all_nonhalting`,
-`sound_approx_undefined_on_nonhalting`), which turns the schematic single-point
-gap into the precise statement that the gap is the non-r.e. set `Kᶜ`. We do *not*
-prove a density/measure ("generic-case complexity") statement — that is OQ-01b and
-is encoding-sensitive (see `knowledge.md`).
+genuine new mathematical content is the approximator bridge (`re_confirmedFalse`,
+`no_sound_approx_confirms_all_nonhalting`, `sound_approx_undefined_on_nonhalting`),
+the union closure `REPred.or`, and its consequence `decline_set_on_nonhalting_not_re`,
+which turns the schematic single-point gap into the precise statement that the gap
+is the non-r.e. set `Kᶜ`. We do *not* prove a density/measure ("generic-case
+complexity") statement — that is OQ-01b and is encoding-sensitive (see `knowledge.md`).
 -/
 
 import Mathlib.Computability.Halting
@@ -96,6 +105,28 @@ theorem halts_not_computable (n : ℕ) : ¬ ComputablePred (Halts n) :=
 semi-decidable. This is the asymmetry that forces every sound approximator's gap. -/
 theorem halts_compl_not_re (n : ℕ) : ¬ REPred (fun c => ¬ Halts n c) :=
   ComputablePred.halting_problem_not_re n
+
+/-! ## Recursive enumerability is closed under union
+
+The strengthening below (the decline set is *not* r.e., not merely nonempty)
+needs that `REPred` is closed under `∨`. Mathlib packages the dovetailing
+("run both in parallel, accept if either accepts") as `Partrec.merge'`, whose
+merged function halts iff *either* input halts — exactly the union of domains. -/
+
+/-- **`REPred` is closed under union.** If `p` and `q` are both recursively
+enumerable, so is `fun a => p a ∨ q a`: dovetail the two semi-deciders via
+`Partrec.merge'` and read off the domain, which is the union of the two domains. -/
+theorem REPred.or {α} [Primcodable α] {p q : α → Prop}
+    (hp : REPred p) (hq : REPred q) : REPred (fun a => p a ∨ q a) := by
+  -- `(Part.assert (r a) fun _ => some ()).Dom ↔ r a`: the domain of a semi-decider
+  -- for `r` is exactly `{a | r a}`.
+  have key : ∀ (r : α → Prop) (a : α),
+      (Part.assert (r a) fun _ => Part.some ()).Dom ↔ r a := fun r a => by
+    simp [Part.dom_iff_mem, Part.mem_assert_iff]
+  obtain ⟨k, hk, H⟩ := Partrec.merge' hp hq
+  -- `k` is partrec with `(k a).Dom ↔ p a ∨ q a`, so its domain predicate is `p ∨ q`.
+  refine hk.dom_re.of_eq fun a => ?_
+  rw [(H a).2, key p a, key q a]
 
 /-! ## Computable approximators and the decline set -/
 
@@ -173,5 +204,52 @@ theorem sound_approx_undefined_on_nonhalting {n : ℕ} {f : Code →. Bool}
   cases b with
   | true  => exact hc ((hs c true hb).1 rfl)
   | false => exact hcf hb
+
+/-- **The decline set on the non-halting inputs is itself not recursively
+enumerable** — the decline obstruction is not a single point (Session 1's
+schematic diagonal), nor merely nonempty (`sound_approx_undefined_on_nonhalting`),
+but a genuinely non-r.e. (hence infinite) set.
+
+*Proof.* At a non-halting code a sound approximator either declines or commits
+`false` (soundness forbids committing `true`), so the non-halting set splits as
+`Kᶜ = {confirmed false} ∪ {non-halting ∧ declines}`. The first piece is r.e.
+(`re_confirmedFalse`). If the second piece were r.e. too, then `Kᶜ` — a union of
+two r.e. sets (`REPred.or`) — would be r.e., contradicting `halts_compl_not_re`.
+So the decline-on-non-halting set is not r.e. -/
+theorem decline_set_on_nonhalting_not_re {n : ℕ} {f : Code →. Bool}
+    (hf : Partrec f) (hs : Sound n f) :
+    ¬ REPred (fun c => ¬ Halts n c ∧ ¬ (f c).Dom) := by
+  intro hdn
+  -- The two r.e. pieces cover exactly `Kᶜ`.
+  have hre : REPred (fun c => ¬ Halts n c) := by
+    refine (REPred.or (re_confirmedFalse hf) hdn).of_eq fun c => ?_
+    constructor
+    · rintro (hbf | ⟨hnh, _⟩)
+      · exact hs.not_halts hbf
+      · exact hnh
+    · intro hnh
+      by_cases hdom : (f c).Dom
+      · -- `f` commits at `c`; soundness forces the committed value to be `false`.
+        obtain ⟨b, hb⟩ := Part.dom_iff_mem.1 hdom
+        cases b with
+        | true  => exact absurd ((hs c true hb).1 rfl) hnh
+        | false => exact Or.inl hb
+      · exact Or.inr ⟨hnh, hdom⟩
+  exact halts_compl_not_re n hre
+
+/-- The earlier single-witness statement `sound_approx_undefined_on_nonhalting`
+is now a corollary: the empty predicate is r.e., so a *non*-r.e. set is nonempty.
+This records that `decline_set_on_nonhalting_not_re` strictly strengthens it. -/
+theorem sound_approx_declines_nonempty {n : ℕ} {f : Code →. Bool}
+    (hf : Partrec f) (hs : Sound n f) :
+    ∃ c, ¬ Halts n c ∧ ¬ (f c).Dom := by
+  by_contra hcon
+  rw [not_exists] at hcon
+  -- The empty predicate is r.e.; if the decline set were empty it would be r.e. too.
+  have emptyRe : REPred (fun _ : Code => False) :=
+    (Partrec.none : Partrec (fun _ : Code => (Part.none : Part Unit))).dom_re.of_eq
+      fun _ => by simp [Part.dom_iff_mem]
+  exact decline_set_on_nonhalting_not_re hf hs
+    (emptyRe.of_eq fun c => iff_of_false not_false (hcon c))
 
 end HaltingArithmeticalHierarchy

--- a/research/problems/halting-problem-oq-01/knowledge.md
+++ b/research/problems/halting-problem-oq-01/knowledge.md
@@ -144,3 +144,64 @@ Converted the *schematic* single-point decline barrier (Session 1) into the
   non-r.e. set" by proving `REPred` is closed under union, then the gap
   `Kᶜ ∖ {confirmed false}` is non-r.e. (currently only "nonempty" is extracted).
 - OQ-01b remains the only genuinely open sub-question and is infrastructure-blocked.
+
+---
+
+## Session 2026-06-27 (Session 3) — Sharp form: the decline set is non-r.e.
+
+**Mode**: REVISIT (executed the Session-2 optional next step)
+**Outcome**: progress — strengthened `HaltingArithmeticalHierarchy.lean`
+(still 0 sorry, 0 `axiom`, builds; imports `Mathlib.Computability.Halting`).
+
+### What I did
+Carried out the previously-deferred strengthening of
+`sound_approx_undefined_on_nonhalting` (which only gave a *nonempty* decline set)
+to the sharp statement that the decline set is **not recursively enumerable**.
+
+- `REPred.or` — **`REPred` is closed under union.** Built from Mathlib's
+  `Partrec.merge'` (dovetailing: the merged partial function halts iff either
+  input halts, so its domain is the union of the two domains). ~12 lines; the
+  helper `key` shows `(Part.assert (r a) fun _ => some ()).Dom ↔ r a`.
+- `decline_set_on_nonhalting_not_re` — the **headline strengthening**: for a sound
+  partial-computable `f`, the set `{c | ¬Halts n c ∧ f declines at c}` is **not
+  r.e.** Proof: at a non-halting code a sound `f` either declines or commits
+  `false` (soundness forbids `true`), so `Kᶜ = {confirmed false} ∪ {decline ∧
+  ¬halts}`; the first piece is r.e. (`re_confirmedFalse`), so if the second were
+  r.e. then `Kᶜ` = union of two r.e. sets would be r.e. (`REPred.or`),
+  contradicting `halts_compl_not_re`.
+- `sound_approx_declines_nonempty` — re-derives the old nonempty statement as a
+  one-line corollary (the empty predicate is r.e., so a non-r.e. set is nonempty),
+  documenting that the new theorem strictly subsumes Session 2's.
+
+### Key findings / insights
+- The Session-2 "declines somewhere" was an under-statement: the obstruction is a
+  genuinely **non-r.e. (hence infinite)** subset of `Kᶜ`, not a finite/diagonal
+  artifact. The decline set of any sound semi-decider must contain `Kᶜ` minus an
+  r.e. piece, and that difference is itself non-r.e.
+- The whole strengthening cost ~50 lines because Mathlib already packages the
+  hard part (`Partrec.merge'`); the only "new" infrastructure was the trivial
+  `REPred.or` wrapper. Earlier sessions over-estimated this as needing bespoke
+  union-closure machinery.
+- GOTCHA: dot notation `(h : REPred _).or` resolves through the `REPred → Partrec
+  → Nat.Partrec` unfolding and looks up `Nat.Partrec.or` (error). Call
+  `REPred.or h₁ h₂` explicitly. (`.of_eq` happens to resolve fine.)
+
+### Files modified
+- `proofs/Proofs/HaltingArithmeticalHierarchy.lean` (+~50 lines: `REPred.or`,
+  `decline_set_on_nonhalting_not_re`, `sound_approx_declines_nonempty`; header
+  updated). Builds clean (`docker-build.sh Proofs.HaltingArithmeticalHierarchy`).
+
+### Status of the three OQ-01 readings
+- **OQ-01a structural barrier** — DONE (Session 1).
+- **OQ-01c arithmetical-hierarchy placement** — DONE (Session 2) and now
+  **sharpened** (Session 3): the gap is the non-r.e. set `Kᶜ`, proven via
+  `REPred.or` + the r.e. confirmed-false set.
+- **OQ-01b density / generic-case complexity** — STILL OPEN / BLOCKED
+  (encoding-sensitive, > 1000 lines of machine-model infrastructure Mathlib does
+  not package).
+
+### Next steps
+- OQ-01b is the sole remaining sub-question and remains infrastructure-blocked.
+  No tractable Lean path without a concrete one-tape model + density measure on `ℕ`.
+- The OQ-01a/OQ-01c line is now complete and sharp; consider this thread DONE
+  pending OQ-01b infrastructure or a Mathlib density-of-RE-sets contribution.

--- a/research/problems/halting-problem-oq-01/knowledge.md
+++ b/research/problems/halting-problem-oq-01/knowledge.md
@@ -84,3 +84,63 @@ the zero-import `Proofs.HaltingProblem`).
   genuine non-`Σ⁰₁` statement. ~300–600 lines.
 - Optionally exhibit a *nontrivial sound approximator* (a "run k steps then
   decline" family) to demonstrate the decline-set is the only obstruction.
+
+---
+
+## Session 2026-06-27 (Session 2) — OQ-01c: genuine arithmetical-hierarchy placement
+
+**Mode**: REVISIT (pool empty; follow-up to the SOLVED schematic core)
+**Outcome**: progress — new verified file `HaltingArithmeticalHierarchy.lean`
+(0 sorry, 0 axiom beyond `propext/Classical.choice/Quot.sound`; imports
+`Mathlib.Computability.Halting`).
+
+### What I did
+Converted the *schematic* single-point decline barrier (Session 1) into the
+*genuine* computability statement, the previously-deferred OQ-01c. Using
+`Nat.Partrec.Code` / `eval` / `REPred` / `ComputablePred`, fixed input `n` and
+`Halts n c := (eval c n).Dom` (= the parametrized halting set `K`):
+
+- **Hierarchy placement** (repackaged Mathlib): `halts_re` (`K` is `Σ⁰₁`),
+  `halts_not_computable` (`K ∉ Δ⁰₁`), `halts_compl_not_re` (`Kᶜ ∉ Σ⁰₁`). So `K`
+  is **properly `Σ⁰₁`** and the approximation gap is exactly `Kᶜ ∈ Π⁰₁ ∖ Σ⁰₁`.
+- **Decline-set lemmas** (the genuine new content):
+  - `re_confirmedFalse` — for any *partial computable* `f : Code →. Bool`, the
+    confirmed-non-halting set `{c | false ∈ f c}` is r.e. (it is the domain of
+    `c ↦ (f c) >>= fun b => bif b then none else some ()`, partrec by
+    `Partrec.bind`/`Partrec.cond`, r.e. by `Partrec.dom_re`).
+  - `no_sound_approx_confirms_all_nonhalting` — no sound computable approximator
+    can confirm `false` on *all* of `Kᶜ`; else `{c | false ∈ f c} = Kᶜ` would be
+    r.e., contradicting `halts_compl_not_re`.
+  - `sound_approx_undefined_on_nonhalting` — hence every sound computable
+    approximator is *undefined* (declines) on some genuinely non-halting input.
+
+### Key findings / insights
+- The schematic "declines at the diagonal point" is *not* an artifact of the
+  no-computation-model setting: in the real model it strengthens to "declines on
+  a non-r.e. (hence infinite) set." The obstruction has a precise name — the
+  `Σ⁰₁`/`Π⁰₁` asymmetry: halting is semi-decidable (`K` r.e.: you can confirm a
+  halt by running), non-halting is not (`Kᶜ` not r.e.: no process confirms
+  looping on every looping input). The decline set of any sound semi-decider must
+  contain the non-r.e. set `Kᶜ` minus an r.e. piece.
+- The hierarchy-placement trio is a thin Mathlib wrapper (honest disclosure in
+  the file header); the *bridge* lemmas are the session's real content.
+
+### Files modified
+- `proofs/Proofs/HaltingArithmeticalHierarchy.lean` (new, ~185 lines incl. docs;
+  0 sorry, 0 axiom)
+- `proofs/Proofs.lean` (registered the new module)
+
+### Status of the three OQ-01 readings
+- **OQ-01a structural barrier** — DONE (Session 1, `HaltingApproximation.lean`).
+- **OQ-01c arithmetical-hierarchy placement** — DONE (this session). Came in far
+  under the earlier 300–600-line estimate: Mathlib already packages the three
+  halting theorems, so only the ~60-line approximator bridge was new.
+- **OQ-01b density / generic-case complexity** — STILL OPEN. Encoding-sensitive
+  (Hamkins–Miasnikov 2006 needs a concrete one-tape model + density/measure on
+  `ℕ`); > 1000 lines on infrastructure Mathlib does not package. BLOCKED.
+
+### Next steps
+- (Optional) Strengthen `sound_approx_undefined_on_nonhalting` to "declines on a
+  non-r.e. set" by proving `REPred` is closed under union, then the gap
+  `Kᶜ ∖ {confirmed false}` is non-r.e. (currently only "nonempty" is extracted).
+- OQ-01b remains the only genuinely open sub-question and is infrastructure-blocked.


### PR DESCRIPTION
## Summary

Three verified, zero-axiom sessions on gallery open question **halting-problem OQ-01** — *"What is the computational complexity of approximating the halting problem?"* — across two new Lean files.

### `HaltingApproximation.lean` (OQ-01a, schematic, zero Mathlib imports)
Generalizes the parent proof's `HaltingOracle = ℕ → ℕ → Bool` to a three-valued **approximator** `A : ℕ → ℕ → Option Bool` (commit-true / commit-false / decline). Headline: **every sound approximator must decline at its own diagonal point** (`sound_approx_declines_on_diagonal`) — the diagonal contradiction does not vanish when totality is dropped, it *relocates* into a forced `none`. Classical undecidability is recovered as the always-commit special case.

### `HaltingArithmeticalHierarchy.lean` (OQ-01c, genuine computability)
Converts the schematic barrier into the real-model statement using `Nat.Partrec.Code` / `REPred` / `ComputablePred`:
- **Hierarchy placement** (thin wrappers, honestly disclosed): `K` is properly `Σ⁰₁` — r.e. but not computable, complement not r.e. The approximation gap lives in `Π⁰₁ ∖ Σ⁰₁`.
- **Bridge lemmas** (the real content): `re_confirmedFalse` (a partial-computable approximator's confirmed-non-halting set is r.e.), `no_sound_approx_confirms_all_nonhalting`, and `sound_approx_undefined_on_nonhalting`.
- **Sharp form** (session 3): `REPred.or` (closure of `REPred` under union, via Mathlib's `Partrec.merge'` dovetailing) and `decline_set_on_nonhalting_not_re` — the decline set restricted to non-halting inputs is **itself not recursively enumerable** (hence infinite), not merely nonempty. The earlier nonempty result is re-derived as the corollary `sound_approx_declines_nonempty`.

## Verification
- Both files build via `./proofs/scripts/docker-build.sh` — `Proofs.HaltingArithmeticalHierarchy` builds clean (795 jobs).
- 0 sorries, 0 `axiom` declarations, no `native_decide`. Standard foundational axioms only (`propext` / `Classical.choice` / `Quot.sound`).

## Scope / honesty
- The three hierarchy-placement theorems repackage existing Mathlib results (disclosed in the file header); the approximator bridge + `REPred.or` + sharp non-r.e. statement are the new content.
- **OQ-01b** (density / generic-case complexity, Hamkins–Miasnikov) remains open and infrastructure-blocked: encoding-sensitive, needs a concrete one-tape model + density measure on `ℕ` that Mathlib does not package (>1000 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)