### PR TITLE
research(sum-of-divisors-oq-01): Euler's odd-perfect form — verified local prime-power engine [0-axiom]

### DIFF
--- a/proofs/Proofs/SumOfDivisorsOQ01.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ01.lean
@@ -28,8 +28,13 @@ facts plus a parity reduction of the perfect equation:
 * **`geom_sum_odd_eq_factor`.**  For odd `a`, `∑_{j≤a} p^j = (1 + p)·∑_{k} p^{2k}`,
   the pairing identity underlying the mod-4 refinement on the special prime.
 
-* **L2 — `sigma_prime_pow_two_adic_eq_one_iff`.**  For an odd prime `p` and
-  odd `a`, `v₂(σ(p^a)) = 1 ⟺ p ≡ 1 (mod 4) ∧ a ≡ 1 (mod 4)`.
+* **`even_geom_sum_parity`.**  For odd `p`, `∑_{k<m} p^{2k}` has the parity
+  of `m` — the parity bookkeeping for the right factor above.
+
+* **L2 — `sigma_prime_pow_mod_four`.**  For an odd prime `p` and odd `a`,
+  `σ(p^a) ≡ 2 (mod 4)` — equivalently `v₂(σ(p^a)) = 1` — exactly when
+  `p ≡ 1 (mod 4)` and `a ≡ 1 (mod 4)`.  (Phrased via `mod 4` rather than the
+  2-adic valuation to keep the proof `omega`-closable and `padicValNat`-free.)
 
 These are exactly the lemmas whose mod-4 / parity bookkeeping is "most at risk
 of an off-by-one" in the classical proof (Hardy–Wright Thm 277); they are
@@ -87,5 +92,42 @@ theorem geom_sum_odd_eq_factor (p t : ℕ) :
       Finset.sum_range_succ, Finset.sum_range_succ, ih]
     conv_rhs => rw [Finset.sum_range_succ]
     ring
+
+/-- Parity of the "even-index" geometric sum `∑_{k<m} p^{2k}` for odd `p`:
+it has the parity of its number of terms `m` (each summand `p^{2k}` is odd). -/
+theorem even_geom_sum_parity {p : ℕ} (hodd : Odd p) (m : ℕ) :
+    (∑ k ∈ Finset.range m, p ^ (2 * k)) % 2 = m % 2 := by
+  rw [Finset.sum_nat_mod]
+  have hk : ∀ k ∈ Finset.range m, p ^ (2 * k) % 2 = 1 := by
+    intro k _; exact Nat.odd_iff.mp hodd.pow
+  rw [Finset.sum_congr rfl hk, Finset.sum_const, Finset.card_range, smul_eq_mul, mul_one]
+
+/-- **L2 (mod-4 refinement on the special prime), valuation-free form.**
+For an odd prime `p` and an *odd* exponent `a`, `σ(p^a) ≡ 2 (mod 4)` — i.e.
+`v₂(σ(p^a)) = 1` — exactly when `p ≡ 1 (mod 4)` and `a ≡ 1 (mod 4)`.
+
+Proof: with `a = 2t+1`, the pairing identity gives `σ(p^a) = (1+p)·S` with
+`S = ∑_{k≤t} p^{2k}`.  Modulo 4, `1+p ≡ 2` (if `p≡1`) or `≡ 0` (if `p≡3`), and
+`S` has the parity of `t+1`; a finite `omega` case analysis closes the iff. -/
+theorem sigma_prime_pow_mod_four {p : ℕ} (hp : p.Prime) (hodd : Odd p) {a : ℕ}
+    (ha : Odd a) :
+    sigma 1 (p ^ a) % 4 = 2 ↔ p % 4 = 1 ∧ a % 4 = 1 := by
+  obtain ⟨t, rfl⟩ := ha
+  rw [sigma_one_apply_prime_pow hp, show 2 * t + 1 + 1 = 2 * t + 2 by ring,
+    geom_sum_odd_eq_factor]
+  have hSpar : (∑ k ∈ Finset.range (t + 1), p ^ (2 * k)) % 2 = (t + 1) % 2 :=
+    even_geom_sum_parity hodd (t + 1)
+  set S := ∑ k ∈ Finset.range (t + 1), p ^ (2 * k) with hS
+  have hp4 : p % 4 = 1 ∨ p % 4 = 3 := by
+    have := Nat.odd_iff.mp hodd; omega
+  rw [Nat.mul_mod]
+  rcases hp4 with h1 | h3
+  · have hu : (1 + p) % 4 = 2 := by omega
+    rw [hu]
+    have hv : S % 4 % 2 = S % 2 := Nat.mod_mod_of_dvd S (by norm_num)
+    omega
+  · have hu : (1 + p) % 4 = 0 := by omega
+    rw [hu]
+    omega
 
 end SumOfDivisorsOQ01

--- a/proofs/Proofs/SumOfDivisorsOQ01.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ01.lean
@@ -1,0 +1,91 @@
+/-
+# Euler's Prime-Factor Constraint on Odd Perfect Numbers (Local Engine Lemmas)
+
+## The target (Euler, 1747)
+
+If `N` is odd and perfect (`σ(N) = 2N`), then
+```
+        N = p^a · m²
+```
+with `p` prime, `p ≡ 1 (mod 4)`, `a ≡ 1 (mod 4)`, `gcd(p, m) = 1`.  The prime
+`p` is the **special** (or **Euler**) prime; every other prime divides `N` to
+an even power.  This is a *conditional* structural theorem — it does **not**
+assert that any odd perfect number exists (that question is open).
+
+## What this file proves (the local prime-power engine)
+
+The theorem reduces to the cleaner statement that an odd `N` with
+`v₂(σ(N)) = 1` has Euler form, and that reduction is fed by two prime-power
+facts plus a parity reduction of the perfect equation:
+
+* **L1 — `sigma_prime_pow_odd_iff`.**  For an odd prime `p`,
+  `σ(p^a)` is odd ⟺ `a` is even.  (σ(p^a) = 1 + p + ⋯ + p^a is a sum of
+  `a+1` odd terms, so it has the parity of `a+1`.)
+
+* **`odd_perfect_sigma_eq_two_mul`.**  An odd perfect `N` satisfies
+  `σ(N) = 2N`; since `N` is odd this is the source of `v₂(σ(N)) = 1`.
+
+* **`geom_sum_odd_eq_factor`.**  For odd `a`, `∑_{j≤a} p^j = (1 + p)·∑_{k} p^{2k}`,
+  the pairing identity underlying the mod-4 refinement on the special prime.
+
+* **L2 — `sigma_prime_pow_two_adic_eq_one_iff`.**  For an odd prime `p` and
+  odd `a`, `v₂(σ(p^a)) = 1 ⟺ p ≡ 1 (mod 4) ∧ a ≡ 1 (mod 4)`.
+
+These are exactly the lemmas whose mod-4 / parity bookkeeping is "most at risk
+of an off-by-one" in the classical proof (Hardy–Wright Thm 277); they are
+verified here.  The remaining *global* assembly — summing `v₂` over the
+factorization to isolate the unique odd-exponent prime and package the rest as
+a square `m²` — is the multiplicative-bookkeeping step left for follow-up.
+
+All results are conditional structure theorems and assume nothing about the
+existence of odd perfect numbers.
+-/
+import Mathlib
+
+open ArithmeticFunction Finset
+open scoped ArithmeticFunction.sigma
+
+namespace SumOfDivisorsOQ01
+
+/-- **L1 (parity of σ on prime powers).**  For an odd prime `p`,
+`σ(p^a)` is odd iff `a` is even.
+
+Proof: `σ(p^a) = ∑_{j=0}^{a} p^j` (Mathlib's `sigma_one_apply_prime_pow`); each
+`p^j` is odd because `p` is odd, so modulo 2 the sum collapses to `a+1`. -/
+theorem sigma_prime_pow_odd_iff {p : ℕ} (hp : p.Prime) (hodd : Odd p) (a : ℕ) :
+    Odd (sigma 1 (p ^ a)) ↔ Even a := by
+  rw [Nat.odd_iff, sigma_one_apply_prime_pow hp, Finset.sum_nat_mod]
+  have hpj : ∀ j ∈ Finset.range (a + 1), p ^ j % 2 = 1 := by
+    intro j _
+    exact Nat.odd_iff.mp (hodd.pow)
+  rw [Finset.sum_congr rfl hpj, Finset.sum_const, Finset.card_range, smul_eq_mul,
+    mul_one]
+  rw [Nat.even_iff]
+  omega
+
+/-- The perfect-number equation `σ(N) = 2N`, extracted in `σ = sigma 1` form.
+For an odd `N` this is the source of `v₂(σ(N)) = v₂(2N) = 1`. -/
+theorem odd_perfect_sigma_eq_two_mul {N : ℕ} (hperf : Nat.Perfect N) :
+    sigma 1 N = 2 * N := by
+  have h0 : 0 < N := hperf.2
+  rw [sigma_one_apply]
+  exact (Nat.perfect_iff_sum_divisors_eq_two_mul h0).mp hperf
+
+/-- **Pairing identity (Step 3 infrastructure for the mod-4 refinement).**
+For an odd exponent `a = 2t+1`, the geometric sum `∑_{j≤a} p^j` factors as
+`(1 + p)·∑_{k≤t} p^{2k}`.  This is the algebraic core of the L2 valuation
+analysis: `v₂` of the left factor `1 + p` contributes the `p ≡ 1 (mod 4)`
+condition, and parity of the right sum (its number of terms `t+1`) contributes
+`a ≡ 1 (mod 4)`. -/
+theorem geom_sum_odd_eq_factor (p t : ℕ) :
+    ∑ j ∈ Finset.range (2 * t + 2), p ^ j
+      = (1 + p) * ∑ k ∈ Finset.range (t + 1), p ^ (2 * k) := by
+  induction t with
+  | zero => simp [Finset.sum_range_succ]
+  | succ n ih =>
+    rw [show 2 * (n + 1) + 2 = (2 * n + 2) + 2 by ring,
+      Finset.sum_range_succ, Finset.sum_range_succ, ih]
+    conv_rhs => rw [Finset.sum_range_succ]
+    ring
+
+end SumOfDivisorsOQ01

--- a/research/problems/sum-of-divisors-oq-01/knowledge.md
+++ b/research/problems/sum-of-divisors-oq-01/knowledge.md
@@ -91,3 +91,47 @@ bulk; steps 2 and 4 are short congruence arguments).
   proof plan, and a populated numerical certificate. No Lean file written
   (dual-backend blackout: Docker down, Aristotle "Resource not found") to
   avoid shipping an unbuildable stub.
+
+## Session 2026-06-27 (researcher-7, Session 2) — ACT: local prime-power engine verified
+
+**Mode**: FRESH (claimed; was OBSERVE) · **Outcome**: progress (verified, 0-sorry/0-axiom)
+
+### What I Did
+- Created `proofs/Proofs/SumOfDivisorsOQ01.lean` (133 LOC, 5 theorems, 0 sorry, 0 axiom),
+  built green in Docker (`Proofs.SumOfDivisorsOQ01`, mathlib 4.26.0).
+- Proved the **local prime-power engine** of Euler's odd-perfect form:
+  - `sigma_prime_pow_odd_iff` (L1): odd prime `p` ⇒ (`σ(p^a)` odd ⟺ `a` even).
+  - `odd_perfect_sigma_eq_two_mul`: odd `Perfect N` ⇒ `σ(N) = 2N` (source of `v₂=1`).
+  - `geom_sum_odd_eq_factor`: `∑_{j≤2t+1} p^j = (1+p)·∑_{k≤t} p^{2k}` (pairing identity).
+  - `even_geom_sum_parity`: `∑_{k<m} p^{2k} ≡ m (mod 2)` for odd `p`.
+  - `sigma_prime_pow_mod_four` (**L2, headline**): odd prime `p`, odd `a` ⇒
+    `σ(p^a) ≡ 2 (mod 4) ⟺ p ≡ 1 (mod 4) ∧ a ≡ 1 (mod 4)`.
+- Added gallery entry `src/data/proofs/sum-of-divisors-oq-01/{meta.json,annotations.json}`
+  (status verified, badge mathlib, 5 annotations).
+
+### Key Findings
+- **L2 without `padicValNat`**: stating `v₂=1` as `σ(p^a) ≡ 2 (mod 4)` turns the whole
+  characterization into `omega`-closable modular arithmetic once `(1+p)·S` is exposed and
+  `p mod 4` is case-split. This dodged the entire finicky `padicValNat` API (risk R1).
+- **`conv_rhs` for the pairing induction**: a bare `sum_range_succ` rewrote the LHS
+  `ih`-sum (creating `range n`) and `ring` failed; `conv_rhs => rw [sum_range_succ]` fixes it.
+- Aristotle MCP was DOWN this session ("Resource not found") — all proofs done manually
+  via Docker builds. Docker host itself was UP (image `lean4-arm64:v4.26.0`).
+- Build gotcha: oleans are NOT written back to the host worktree path (sibling oleans also
+  absent); judge build success by the script's `=== Build succeeded ===` line + exit code,
+  not by an olean file. Backgrounding the build with `&` makes the wrapper exit 0
+  prematurely — capture `echo EXITCODE=$?` inside the same subshell instead.
+
+### Files Modified
+- proofs/Proofs/SumOfDivisorsOQ01.lean (new)
+- src/data/proofs/sum-of-divisors-oq-01/meta.json (new)
+- src/data/proofs/sum-of-divisors-oq-01/annotations.json (new)
+- src/data/research/problems/sum-of-divisors-oq-01.json (knowledge accumulation)
+
+### Next Steps
+- **Global assembly** (the remaining gap): `v₂(σ N) = Σ_{p∈N.primeFactors} v₂(σ(p^{N.factorization p}))`
+  via `isMultiplicative_sigma`; each summand ≥1 ⟺ exponent odd (L1); total `=1` isolates a
+  unique odd-exponent special prime `p₀`; remaining factor is `IsSquare`. Then L2 supplies
+  `p₀ ≡ a₀ ≡ 1 (mod 4)`.
+- Submit that assembly sorry to Aristotle as a HARD job once the MCP is back (known classical
+  result — Hardy–Wright Thm 277).

--- a/src/data/proofs/sum-of-divisors-oq-01/annotations.json
+++ b/src/data/proofs/sum-of-divisors-oq-01/annotations.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "sum-of-divisors-oq-01",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Euler's Odd-Perfect Form and Its Local Prime-Power Engine",
+    "content": "Euler (1747) proved that any odd perfect number must factor as N = p^a·m² with a single special prime p satisfying p ≡ a ≡ 1 (mod 4), every other prime occurring to an even power. The whole theorem is driven by a 2-adic valuation count of σ over the prime factorization. This file formalizes the local engine of that count — the parity and mod-4 behaviour of σ on a single prime power — fully verified with no axioms. The header lists the four contributed facts and is explicit that the result is conditional: it assumes nothing about whether odd perfect numbers exist (that question is open).",
+    "mathContext": "$N$ odd, $\\sigma(N)=2N \\Rightarrow v_2(\\sigma(N)) = v_2(2N) = 1$. Since $\\sigma$ is multiplicative, $v_2(\\sigma(N)) = \\sum_{p\\mid N} v_2(\\sigma(p^{a_p}))$, so the global structure is decided by per-prime-power facts.",
+    "significance": "context",
+    "relatedConcepts": [
+      "odd perfect numbers",
+      "special (Euler) prime",
+      "2-adic valuation",
+      "multiplicative functions"
+    ],
+    "prerequisites": [
+      "divisor-sum function σ",
+      "perfect numbers",
+      "prime factorization"
+    ]
+  },
+  {
+    "id": "ann-l1-parity",
+    "proofId": "sum-of-divisors-oq-01",
+    "range": { "startLine": 55, "endLine": 69 },
+    "type": "key-step",
+    "title": "L1 — Parity of σ on a Prime Power",
+    "content": "For an odd prime p, σ(p^a) = 1 + p + ⋯ + p^a is a sum of a+1 odd terms, so it has the parity of a+1: σ(p^a) is odd exactly when a is even. The Lean proof rewrites σ(p^a) to the explicit range-sum via `sigma_one_apply_prime_pow`, pushes the modulus inside with `Finset.sum_nat_mod`, replaces each pᵏ % 2 by 1 (since p is odd), collapses the constant sum to a+1, and closes with `omega`. This is the parity half of the classification: globalized over the factorization it says σ(N) is odd ⟺ N is a perfect square.",
+    "mathContext": "$\\sigma(p^a) = \\sum_{j=0}^{a} p^j \\equiv a+1 \\pmod 2$ because each $p^j$ is odd.",
+    "significance": "high",
+    "relatedConcepts": ["geometric sum", "parity argument", "prime powers"],
+    "prerequisites": ["σ on prime powers", "modular arithmetic of sums"]
+  },
+  {
+    "id": "ann-reduction",
+    "proofId": "sum-of-divisors-oq-01",
+    "range": { "startLine": 71, "endLine": 77 },
+    "type": "key-step",
+    "title": "Perfection as σ(N) = 2N",
+    "content": "The bridge from 'perfect' to the valuation count: an odd perfect N satisfies σ(N) = 2N. Combined with N odd this gives v₂(σ(N)) = v₂(2N) = 1, the single unit of 2-adic valuation that the prime-power analysis must account for. The proof rewrites σ to the divisor-sum form and quotes Mathlib's `Nat.perfect_iff_sum_divisors_eq_two_mul`.",
+    "mathContext": "$\\sigma(N) = 2N$ with $N$ odd $\\Rightarrow v_2(\\sigma(N)) = 1$.",
+    "significance": "medium",
+    "relatedConcepts": ["perfect numbers", "σ-form of perfection"],
+    "prerequisites": ["definition of perfect number"]
+  },
+  {
+    "id": "ann-pairing",
+    "proofId": "sum-of-divisors-oq-01",
+    "range": { "startLine": 79, "endLine": 94 },
+    "type": "key-step",
+    "title": "The Pairing Identity for Odd Exponents",
+    "content": "For an odd exponent a = 2t+1, the geometric sum factors as ∑_{j≤a} p^j = (1+p)·∑_{k≤t} p^{2k}, obtained by pairing consecutive terms p^{2k} + p^{2k+1} = p^{2k}(1+p). This is the algebraic heart of the mod-4 refinement: the left factor (1+p) carries the p ≡ 1 (mod 4) condition, and the parity of the right factor (its number of terms t+1) carries the a ≡ 1 (mod 4) condition. Proved by induction on t with `conv_rhs` to expand the correct sum before `ring`.",
+    "mathContext": "$\\sum_{j=0}^{2t+1} p^j = (1+p)\\sum_{k=0}^{t} p^{2k}$.",
+    "significance": "high",
+    "relatedConcepts": ["geometric series", "factorization", "induction"],
+    "prerequisites": ["finite sums over ranges", "ring identities"]
+  },
+  {
+    "id": "ann-l2-modfour",
+    "proofId": "sum-of-divisors-oq-01",
+    "range": { "startLine": 105, "endLine": 132 },
+    "type": "key-step",
+    "title": "L2 — The mod-4 Characterization of the Special Prime",
+    "content": "The headline result: for an odd prime p and odd exponent a, σ(p^a) ≡ 2 (mod 4) — equivalently v₂(σ(p^a)) = 1 — if and only if p ≡ 1 (mod 4) and a ≡ 1 (mod 4). This is the fact that pins Euler's special prime, and it is the step in the classical proof most prone to an off-by-one in the mod-4 conditions. The proof writes a = 2t+1, applies the pairing identity to get σ(p^a) = (1+p)·S, supplies the parity of S (via `even_geom_sum_parity`), reduces the product modulo 4 with `Nat.mul_mod`, and case-splits on p mod 4 so that `omega` closes each branch. It is phrased in mod-4 arithmetic rather than `padicValNat` precisely so the bookkeeping stays `omega`-closable.",
+    "mathContext": "$v_2(\\sigma(p^a)) = v_2(1+p) + v_2(S)$ with $S=\\sum_k p^{2k}$; equals $1$ iff $p\\equiv 1$ and $a\\equiv 1 \\pmod 4$.",
+    "significance": "high",
+    "relatedConcepts": ["2-adic valuation", "special prime", "mod-4 conditions", "case analysis"],
+    "prerequisites": ["the pairing identity", "parity of geometric sums", "modular arithmetic"]
+  }
+]

--- a/src/data/proofs/sum-of-divisors-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-01/meta.json
@@ -1,0 +1,78 @@
+{
+  "id": "sum-of-divisors-oq-01",
+  "title": "Euler's Odd-Perfect Form: The Local Prime-Power Theory of the Special Prime",
+  "slug": "sum-of-divisors-oq-01",
+  "description": "Euler's 1747 structural theorem says an odd perfect number must have the form N = p^a·m² with the special prime p ≡ a ≡ 1 (mod 4). This entry formalizes the local prime-power engine of that theorem — the parity and mod-4 facts about σ on prime powers that pin the special prime — fully verified with 0 axioms. L1: σ(p^a) is odd ⟺ a is even. The perfect equation σ(N)=2N (source of v₂(σ(N))=1). The pairing identity ∑_{j≤a} p^j = (1+p)·∑ p^{2k} for odd a. L2 (the headline): σ(p^a) ≡ 2 (mod 4) ⟺ p ≡ 1 (mod 4) ∧ a ≡ 1 (mod 4) — the mod-4 characterization of the special prime, the step 'most at risk of an off-by-one' in the classical proof. The result is conditional and assumes nothing about the existence of odd perfect numbers (open).",
+  "meta": {
+    "author": "classical (Euler 1747; formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Perfect_number#Odd_perfect_numbers",
+    "date": "1747",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-function",
+      "sigma",
+      "perfect-numbers",
+      "odd-perfect-numbers",
+      "euler",
+      "special-prime",
+      "prime-powers",
+      "2-adic-valuation",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.sigma_one_apply_prime_pow",
+        "description": "σ₁(pⁱ) = ∑_{k<i+1} pᵏ — the open geometric sum on a prime power, the entry point for both the parity (L1) and mod-4 (L2) analyses",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "Nat.perfect_iff_sum_divisors_eq_two_mul",
+        "description": "0 < n → (Perfect n ↔ ∑_{d∣n} d = 2n) — converts perfection into the σ(N)=2N equation that forces v₂(σ(N))=1 for odd N",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Finset.sum_nat_mod",
+        "description": "(∑ i in s, f i) % n = (∑ i in s, f i % n) % n — pushes the modulus inside the geometric sum for the parity computations",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Odd.pow",
+        "description": "Odd m → Odd (mⁿ) — every power of an odd prime is odd, so each summand pᵏ ≡ 1 (mod 2)",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      },
+      {
+        "theorem": "Nat.mul_mod",
+        "description": "a * b % n = (a % n) * (b % n) % n — reduces (1+p)·S mod 4 to a finite case analysis on p mod 4 and S mod 2",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.mod_mod_of_dvd",
+        "description": "m ∣ k → n % k % m = n % m — links S mod 4 back to S mod 2 so the omega case analysis closes",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "sigma_prime_pow_odd_iff (L1): for an odd prime p, σ(p^a) is odd ⟺ a is even",
+      "odd_perfect_sigma_eq_two_mul: an odd perfect N satisfies σ(N) = 2N (source of v₂(σ(N)) = 1)",
+      "geom_sum_odd_eq_factor: the pairing identity ∑_{j≤2t+1} p^j = (1+p)·∑_{k≤t} p^{2k}",
+      "even_geom_sum_parity: ∑_{k<m} p^{2k} has the parity of m for odd p",
+      "sigma_prime_pow_mod_four (L2): σ(p^a) ≡ 2 (mod 4) ⟺ p ≡ 1 (mod 4) ∧ a ≡ 1 (mod 4), the mod-4 characterization of Euler's special prime"
+    ],
+    "dateAdded": "2026-06-27",
+    "lineCount": 133,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The results are conditional structure theorems; they assume nothing about whether any odd perfect number exists (that question remains open).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Whether any odd perfect number exists is one of the oldest open problems in mathematics. Euler, around 1747, proved a strong necessary condition on their shape: if an odd N is perfect (σ(N) = 2N), then N = p^a·m² where p is a prime with p ≡ 1 (mod 4), the exponent a ≡ 1 (mod 4), and p ∤ m. The prime p is called the special (or Euler) prime; every other prime divides N to an even power. The proof is a parity-and-2-adic-valuation analysis of σ across the prime factorization: σ is multiplicative, so v₂(σ(N)) = Σ v₂(σ(pᵢ^{aᵢ})); for an odd perfect N this total equals v₂(2N) = 1, which forces exactly one prime power to contribute, and a finer mod-4 analysis on that prime power pins down the p ≡ a ≡ 1 (mod 4) conditions.",
+    "problemStatement": "**Open Question (sum-of-divisors-oq-01)**: Formalize Euler's prime-factor constraint on odd perfect numbers — if N is odd and perfect then N = p^a·m² with p prime, p ≡ a ≡ 1 (mod 4), p ∤ m.\n\n**This entry's result**: the verified *local* prime-power engine that drives the theorem. The mod-4 valuation characterization of the special prime (`sigma_prime_pow_mod_four`) and the parity law (`sigma_prime_pow_odd_iff`) — the two facts whose mod-4/parity bookkeeping is the part of the classical proof most prone to an off-by-one — are machine-checked, together with the perfect-equation reduction and the pairing identity that connects them. The remaining global step (summing v₂ over the factorization to isolate the unique odd-exponent special prime and package the rest as a square) is documented as follow-up.",
+    "text": "For an odd prime p: σ(p^a) is odd ⟺ a is even (L1); and for odd a, σ(p^a) ≡ 2 (mod 4) ⟺ p ≡ 1 (mod 4) ∧ a ≡ 1 (mod 4) (L2). An odd perfect N has σ(N) = 2N, whose 2-adic valuation 1 is exactly what these prime-power facts decode into Euler's special-prime structure."
+  }
+}

--- a/src/data/research/problems/sum-of-divisors-oq-01.json
+++ b/src/data/research/problems/sum-of-divisors-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "sum-of-divisors-oq-01",
   "title": "sum-of-divisors-oq-01 — Euler's prime-factor constraint on odd perfect numbers",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -29,11 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: verified the complete LOCAL prime-power theory (L1 parity, L2 mod-4 special-prime characterization, pairing identity, sigma=2N reduction), 0-sorry/0-axiom, in Proofs/SumOfDivisorsOQ01.lean. Remaining: GLOBAL factorization assembly.",
+    "builtItems": [
+      "sigma_prime_pow_odd_iff (L1): sigma(p^a) odd iff a even, odd prime p — Proofs/SumOfDivisorsOQ01.lean:60",
+      "odd_perfect_sigma_eq_two_mul: odd Perfect N implies sigma(N)=2N — SumOfDivisorsOQ01.lean:73",
+      "geom_sum_odd_eq_factor: pairing identity for odd exponent — SumOfDivisorsOQ01.lean:85",
+      "even_geom_sum_parity: even-index geometric sum has parity of term count — SumOfDivisorsOQ01.lean:98",
+      "sigma_prime_pow_mod_four (L2): sigma(p^a) congruent 2 mod 4 iff p,a both congruent 1 mod 4 — SumOfDivisorsOQ01.lean:112"
+    ],
+    "insights": [
+      "L2 (mod-4 special-prime characterization) is cleanly provable WITHOUT padicValNat: phrase v2=1 as sigma(p^a) congruent 2 mod 4, then the whole iff is omega-closable after the (1+p)*S pairing and a case split on p mod 4.",
+      "The pairing identity needs conv_rhs to expand the RIGHT sum before ring; a bare sum_range_succ rewrites the LHS ih-sum and ring fails.",
+      "Parity-of-sum lemmas (L1, even_geom_sum_parity) follow a uniform recipe: sigma_one_apply_prime_pow, Finset.sum_nat_mod, each summand p^k mod 2 = 1 via Odd.pow, sum_const + card_range, omega.",
+      "The sigma(N)=2N reduction is a 2-line quote of Nat.perfect_iff_sum_divisors_eq_two_mul; the mathematical content is entirely in the prime-power parity/mod-4 facts."
+    ],
+    "mathlibGaps": [
+      "No named odd-perfect-form / Euler-special-prime theorem in Mathlib or Archive; must be assembled from multiplicative + parity primitives (confirmed present this session)."
+    ],
+    "nextSteps": [
+      "GLOBAL ASSEMBLY: use isMultiplicative_sigma to write v2(sigma N) = sum over N.primeFactors of v2(sigma(p^(factorization p))); each summand >=1 iff exponent odd (L1); total=1 forces a unique odd-exponent prime p0; rest is a square m^2. Then L2 gives p0,a0 congruent 1 mod 4.",
+      "Package the m^2: product over even-exponent primes is IsSquare; use Nat.factorization_prod_pow_eq_self / Finsupp manipulation.",
+      "When Aristotle MCP is back up, submit the global-assembly sorry as a HARD job (known classical math, Hardy-Wright Thm 277).",
+      "Consider a padicValNat-based main statement so v2(sigma N)=1 is literal, then bridge to L2 via the fact that an even n has v2 n = 1 iff n mod 4 = 2."
+    ],
     "markdown": "# Knowledge — sum-of-divisors-oq-01 (Euler's odd-perfect-number form)\n\n## Target\n\nEuler's structural theorem: `N` odd & perfect ⇒ `N = p^a·m²`,\n`p` prime, `p ≡ a ≡ 1 (mod 4)`, `gcd(p, m) = 1`. See `problem.md` for the\nprecise statement, the `v₂(σ(N)) = 1` reduction, and the proof skeleton.\n\n## Mathlib bearer audit (S1 ORIENT, 2026-06-14)\n\nMathlib was **not** checked out locally this session (`proofs/.lake/packages`\nempty; Docker down ⇒ no fetch), so the audit below is from the gallery's own\nconfirmed usages plus standard Mathlib API. Re-verify exact lines under a\nDocker-up session before discharging.\n\n**Present and directly reused by sibling files** (confirmed via\n`SumOfDivisorsOQ02.lean`, `PerfectNumbers.lean`):\n\n- `ArithmeticFunction.sigma` — the σ function; `σ 1` is sum-of-divisors.\n- `Nat.ArithmeticFunction.isMultiplicative_sigma` with\n  `.map_mul_of_coprime` and `.pow_left` — multiplicativity over coprime\n  factors and on prime powers (this is the engine for\n  `σ(N) = ∏ σ(pᵢ^{aᵢ})`).\n- `Nat.Perfect` — definition `σ(n) = 2n ∧ 0 < n`.\n- `Archive.Wiedijk100Theorems.PerfectNumbers`\n  (`Theorems100.Nat.eq_two_pow_mul_prime_mersenne_of_even_perfect`) — the\n  **even** case; structurally analogous but NOT reusable for the odd case\n  (it pivots on the `2^k` factor).\n\n**Expected present (standard), to confirm at pin:**\n\n- Prime-power σ formula `σ(p^a) = (p^{a+1} − 1)/(p − 1)` or the geometric-sum\n  form `∑ i in range (a+1), p^i` (via `sigma_one_apply` / `Nat.sigma` lemmas).\n- `Nat.factorization`, `Nat.factorization_prod_pow_eq_self`,\n  `Nat.Coprime` API, `padicValNat` / `multiplicity` for the `v₂` bookkeeping.\n- Square-detection: `IsSquare`, `Nat.sq` lemmas for the `m²` packaging.\n\n**Expected ABSENT (the genuine gap):** no named \"odd perfect number form\" /\n\"Euler special prime\" theorem in Mathlib or Archive. The result must be\nassembled from the multiplicative + parity primitives above. (The even-case\nArchive theorem does not specialize to it.)\n\n## Proof-engine lemmas (verified numerically — see verify script)\n\n- **L1**: odd `p` ⇒ (`σ(p^a)` odd ⟺ `a` even). PASS.\n- **L2**: odd `p`, odd `a` ⇒ (`v₂(σ(p^a)) = 1` ⟺ `p ≡ 1 ∧ a ≡ 1 (mod 4)`).\n  PASS, 140 positive witnesses.\n- **Euler-form lemma** (corollary engine): odd `N`, `v₂(σ(N)) = 1` ⇒ Euler\n  form. PASS on **98 653** witnesses in `[3, 2·10⁶)`, 0 failures.\n\nThese were the claims most at risk of an off-by-one in the mod-4 condition;\nthey are now certified before any Lean attempt (verify-before-assert).\n\n## Suggested Lean formalization route (for a Docker-up ACT session)\n\nStatement to target (sketch):\n```lean\ntheorem odd_perfect_euler_form\n    {N : ℕ} (hodd : Odd N) (hperf : Nat.Perfect N) :\n    ∃ (p a : ℕ) (m : ℕ), p.Prime ∧ p % 4 = 1 ∧ a % 4 = 1 ∧\n      ¬ p ∣ m ∧ N = p ^ a * m ^ 2 := by\n  ...\n```\nDischarge plan:\n1. From `hperf`, `hodd`: `σ N = 2 * N`, `Odd (σ N)`'s 2-adic valuation is 1\n   (`v₂ (σ N) = v₂ (2*N) = 1`). Prove the standalone\n   **Euler-form lemma** keyed on `v₂ (σ N) = 1` (cleaner; reusable).\n2. L1 via the geometric-sum parity (`σ (p^a) ≡ a + 1 [MOD 2]`).\n3. Sum-of-valuations over the factorization (`isMultiplicative_sigma`)\n   to extract the unique odd-exponent prime → `m²` square packaging.\n4. L2 mod-4 refinement via the `(1 + p) ∣ σ(p^a)` pairing for odd `a`.\n\nLOC estimate: ~150–250 (the `v₂`/factorization bookkeeping in step 3 is the\nbulk; steps 2 and 4 are short congruence arguments).\n\n## Risk register\n\n- **R1 (medium)**: the `v₂`-over-factorization bookkeeping (step 3) is the\n  fiddly part in Lean — choosing between `Nat.factorization`,\n  `padicValNat`, and `ArithmeticFunction` sum lemmas. Budget time here.\n- **R2 (low)**: square-packaging (`m²` with `IsSquare`/`Nat.sqrt`) wiring.\n- **R3 (process)**: build-pending across sessions until Docker returns\n  (matches the even-case OQ-02's multi-session ACT cadence).\n\n## Decision log\n\n- **2026-06-14 S1 ORIENT (researcher-4)**: fresh seeker stub (EMPTY, no\n  problem.md). Defined OQ-01 = Euler's structural theorem (not the open\n  existence question); confirmed non-overlap with OQ-02 (even perfect) and\n  OQ-03 (Mersenne distribution). Produced precise statement, bearer audit,\n  proof plan, and a populated numerical certificate. No Lean file written\n  (dual-backend blackout: Docker down, Aristotle \"Resource not found\") to\n  avoid shipping an unbuildable stub.\n",
     "archivedSessions": [
       {
@@ -59,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-06-16T04:40:01.681Z",
-  "lastUpdate": "2026-06-16T04:40:01.734Z",
+  "lastUpdate": "2026-06-27",
   "leanFiles": [
     {
       "path": "Proofs/SumOfDivisors.lean",


### PR DESCRIPTION
## Summary

Formalizes the **local prime-power engine** of **Euler's structural theorem on odd perfect numbers** (1747): if `N` is odd and perfect, then `N = p^a · m²` with a special prime `p ≡ a ≡ 1 (mod 4)`. The theorem is a conditional structure result — it assumes **nothing** about whether odd perfect numbers exist (that question is open).

New file `proofs/Proofs/SumOfDivisorsOQ01.lean` — **133 LOC, 5 theorems, 0 sorries, 0 axioms**, builds green in Docker (mathlib 4.26.0).

## What's proved

| Lemma | Statement |
|-------|-----------|
| `sigma_prime_pow_odd_iff` (**L1**) | odd prime `p` ⇒ (`σ(p^a)` odd ⟺ `a` even) |
| `odd_perfect_sigma_eq_two_mul` | odd `Perfect N` ⇒ `σ(N) = 2N` (source of `v₂(σ N) = 1`) |
| `geom_sum_odd_eq_factor` | `∑_{j≤2t+1} p^j = (1+p)·∑_{k≤t} p^{2k}` (pairing identity) |
| `even_geom_sum_parity` | `∑_{k<m} p^{2k} ≡ m (mod 2)` for odd `p` |
| `sigma_prime_pow_mod_four` (**L2**) | odd prime `p`, odd `a` ⇒ `σ(p^a) ≡ 2 (mod 4) ⟺ p ≡ 1 ∧ a ≡ 1 (mod 4)` |

**L1** (parity) and **L2** (the mod-4 characterization of the special prime) are exactly the facts whose mod-4/parity bookkeeping is the part of the classical proof (Hardy–Wright Thm 277) *most prone to an off-by-one* — now machine-checked.

## Key idea

L2 is phrased via `mod 4` rather than `padicValNat`: stating `v₂ = 1` as `σ(p^a) ≡ 2 (mod 4)` makes the whole iff `omega`-closable once the pairing identity exposes `σ(p^a) = (1+p)·S` and `p mod 4` is case-split. This avoids the entire finicky `padicValNat` API.

## Scope / honesty

This is the **local** engine. The remaining **global assembly** — summing `v₂(σ)` over the prime factorization (via `isMultiplicative_sigma`) to isolate the unique odd-exponent special prime and package the rest as a square `m²` — is documented as the next step in the problem's `knowledge.md`. Status is `verified` for what this file proves; the full structural theorem is not yet assembled.

## Files
- `proofs/Proofs/SumOfDivisorsOQ01.lean` (new, verified)
- `src/data/proofs/sum-of-divisors-oq-01/{meta.json,annotations.json}` (gallery entry)
- `src/data/research/problems/sum-of-divisors-oq-01.json` (knowledge; phase OBSERVE → ACT)
- `research/problems/sum-of-divisors-oq-01/knowledge.md` (session log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)