### PR TITLE
Enrich Normal-Distribution Normalization Family (area-of-circle-oq-05-incomplete-01)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "Base case and the area identity",
     "content": "gaussian_unit re-derives the parent's ∫ e^{-x²} = √π from Mathlib's integral_gaussian at rate b = 1 (the integrand -x² is matched to -1·x² by a pointwise ring rewrite, and √(π/1) = √π). gaussian_unit_sq squares it: (∫ e^{-x²})² = π — the area-of-circle identity, the value the polar-coordinate proof computes as a 2D integral.",
-    "mathContext": "$\\int e^{-x^2} = \\sqrt\\pi$, so $\\left(\\int e^{-x^2}\\right)^2 = \\pi$."
+    "mathContext": "$\\int e^{-x^2} = \\sqrt\\pi$, so $\\left(\\int e^{-x^2}\\right)^2 = \\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian integral", "polar coordinates", "area of a circle", "square root of pi"],
+    "prerequisites": ["improper integrals", "Mathlib integral_gaussian"]
   },
   {
     "id": "aoc05inc-ann-02",
@@ -15,7 +18,10 @@
     "type": "technique",
     "title": "√(2π) is just √π at rate 1/2",
     "content": "gaussian_half takes integral_gaussian at b = 1/2: √(π/(1/2)) = √(2π). The integrand -x²/2 is matched to integral_gaussian's -b·x² form by a pointwise ring rewrite inside the exponent (a `congr 1; ring` after a `funext`). std_normal_normalization then pulls the constant 1/√(2π) out with integral_const_mul and cancels it against √(2π) via inv_mul_cancel₀ — the standard-normal density integrates to 1.",
-    "mathContext": "$\\int e^{-x^2/2} = \\sqrt{\\pi/(1/2)} = \\sqrt{2\\pi}$; $\\frac{1}{\\sqrt{2\\pi}}\\cdot\\sqrt{2\\pi}=1$."
+    "mathContext": "$\\int e^{-x^2/2} = \\sqrt{\\pi/(1/2)} = \\sqrt{2\\pi}$; $\\frac{1}{\\sqrt{2\\pi}}\\cdot\\sqrt{2\\pi}=1$.",
+    "significance": "key",
+    "relatedConcepts": ["standard normal distribution", "probability density", "rate parameter", "constant multiple of an integral"],
+    "prerequisites": ["linearity of the integral (integral_const_mul)", "field cancellation (inv_mul_cancel₀)"]
   },
   {
     "id": "aoc05inc-ann-03",
@@ -24,7 +30,10 @@
     "type": "result",
     "title": "General variance via √(σ²·2π) = σ√(2π)",
     "content": "gaussian_variance takes integral_gaussian at b = 1/(2σ²): √(π/(1/(2σ²))) = √(σ²·2π). Splitting the square root (Real.sqrt_mul) and using √(σ²) = σ for σ ≥ 0 (Real.sqrt_sq) gives σ√(2π). gaussian_variance_normalization pulls out 1/(σ√(2π)) and cancels (positivity of the constant via `positivity`), so the N(0,σ²) density integrates to 1.",
-    "mathContext": "$\\int e^{-x^2/(2\\sigma^2)} = \\sqrt{\\sigma^2\\cdot 2\\pi} = \\sigma\\sqrt{2\\pi}$."
+    "mathContext": "$\\int e^{-x^2/(2\\sigma^2)} = \\sqrt{\\sigma^2\\cdot 2\\pi} = \\sigma\\sqrt{2\\pi}$.",
+    "significance": "key",
+    "relatedConcepts": ["variance", "N(0,σ²) distribution", "square-root multiplicativity", "positivity"],
+    "prerequisites": ["√(ab) = √a·√b (Real.sqrt_mul)", "√(a²) = a for a ≥ 0 (Real.sqrt_sq)"]
   },
   {
     "id": "aoc05inc-ann-04",
@@ -33,7 +42,10 @@
     "type": "technique",
     "title": "Mean independence via translation invariance",
     "content": "gaussian_mean_shift uses translation invariance of the Lebesgue integral (integral_sub_right_eq_self): ∫ f(x-μ) = ∫ f(x). Applied to f = e^{-x²/2}, the mass ∫ e^{-(x-μ)²/2} = √(2π) is the same for every mean μ — so fixing σ normalizes the entire N(μ,σ²) family at once.",
-    "mathContext": "$\\int e^{-(x-\\mu)^2/2} = \\int e^{-x^2/2} = \\sqrt{2\\pi}$ for all $\\mu$."
+    "mathContext": "$\\int e^{-(x-\\mu)^2/2} = \\int e^{-x^2/2} = \\sqrt{2\\pi}$ for all $\\mu$.",
+    "significance": "supporting",
+    "relatedConcepts": ["translation invariance", "Lebesgue measure", "location parameter", "mean of a distribution"],
+    "prerequisites": ["shift-invariance of the integral (integral_sub_right_eq_self)"]
   },
   {
     "id": "aoc05inc-ann-05",
@@ -42,6 +54,9 @@
     "type": "caveat",
     "title": "Scope: a genuinely uncovered strand, not a patch",
     "content": "The parent area-of-circle-oq-05 is already complete (0 sorries, 0 axioms). This entry, claimed as a 'completion' task, supplies the genuinely uncovered normal-density normalization strand — the rescalings of √π that make the Gaussian a probability density — rather than patching the parent. Siblings handle the polar, multivariate, and complex Gaussian; none handle these 1D normalizations. #print axioms shows only propext / Classical.choice / Quot.sound.",
-    "mathContext": "Parent: $\\int e^{-x^2}=\\sqrt\\pi$. Here: the $\\sqrt{2\\pi},\\ \\sigma\\sqrt{2\\pi}$ normalizations."
+    "mathContext": "Parent: $\\int e^{-x^2}=\\sqrt\\pi$. Here: the $\\sqrt{2\\pi},\\ \\sigma\\sqrt{2\\pi}$ normalizations.",
+    "significance": "context",
+    "relatedConcepts": ["axiom-free formalization", "gallery lineage", "proof scope"],
+    "prerequisites": ["#print axioms", "the area-of-circle Gaussian-integral lineage"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-05-incomplete-01`.

## Changes
- Added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations (previously had only `content` + `mathContext`), meeting the quality target of ≥5 fully-fielded annotations.

## Deliberately not done
- **No `index.ts` created.** The phase-2 build refactor (#20993) switched proof discovery to `readdirSync` over `src/data/proofs/*/meta.json` with runtime fetch from a build-generated manifest. Per-proof `index.ts` shims are vestigial; adding one would be dead code.
- **meta.json unchanged.** Already comprehensive (rich overview, sections, conclusion, crossReferences, references, mainTheorems) and within the 60 KB cap. No bloat added — quality is curation, not accretion.

## Verification
- `pnpm annotations:build` passes (exit 0), no warnings for this entry
- JSON validates; meta.json within size caps