### PR TITLE
Enrich Toward a Berry–Esseen Rate for α-Stable Laws (central-limit-theorem-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-04/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "The real symmetric α-stable characteristic function",
     "content": "By symmetry the standard α-stable characteristic function is real: `stablePhi α t = exp(−|t|^α)`, where `|t|^α` is the real power `Real.rpow`. This is the real-axis form of the parent file's `stableCharFun`. Two specializations anchor it: α = 2 gives the Gaussian `exp(−t²)` (`stablePhi_two`, via `Real.rpow_natCast` and `sq_abs`), and α = 1 gives the Cauchy law `exp(−|t|)` (`stablePhi_one`). It is normalized (`φ_α(0)=1`) and strictly positive.",
-    "mathContext": "$\\varphi_\\alpha(t) = e^{-|t|^\\alpha}$; $\\varphi_2 = e^{-t^2}$, $\\varphi_1 = e^{-|t|}$."
+    "mathContext": "$\\varphi_\\alpha(t) = e^{-|t|^\\alpha}$; $\\varphi_2 = e^{-t^2}$, $\\varphi_1 = e^{-|t|}$.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic function", "stable distribution", "Gaussian distribution", "Cauchy distribution", "real power (rpow)"],
+    "prerequisites": ["Fourier transform of a probability law", "Real.rpow and natCast powers"]
   },
   {
     "id": "cltoq0104-ann-02",
@@ -15,7 +18,10 @@
     "type": "technique",
     "title": "Exponent monotonicity: the crossover at |t| = 1",
     "content": "The comparison of α-stable and Gaussian reduces to comparing the exponents `|t|^α` and `t²`. For a base in (0,1), a *smaller* exponent gives a *larger* power, so `t² < t^α` when α < 2 (`exponent_gt_sq`, from `Real.rpow_lt_rpow_of_exponent_gt`). For a base above 1 the order flips: `t^α < t²` (`exponent_lt_sq`, from `Real.rpow_lt_rpow_of_exponent_lt`). At `t = 1` both equal 1 (`exponent_crossover_at_one`). The single crossover at |t|=1 is the whole story.",
-    "mathContext": "base $<1$: $t^2 < t^\\alpha$; base $>1$: $t^\\alpha < t^2$; equal at $t=1$."
+    "mathContext": "base $<1$: $t^2 < t^\\alpha$; base $>1$: $t^\\alpha < t^2$; equal at $t=1$.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity of real powers", "exponent comparison", "crossover point"],
+    "prerequisites": ["Real.rpow_lt_rpow_of_exponent_gt / _lt", "behaviour of x^a for base ≶ 1"]
   },
   {
     "id": "cltoq0104-ann-03",
@@ -24,7 +30,10 @@
     "type": "result",
     "title": "Sub-quadratic deviation: the obstruction for α < 2",
     "content": "Exponentiating the exponent inequalities through the strictly monotone `exp` gives the crossover of the characteristic functions themselves: near 0 (`0<t<1`) `stablePhi α t < stablePhi 2 t` — the α-stable law decays faster there because `|t|^α > t²` — while beyond `t=1` it lies above the Gaussian. The deviation near 0 is of order `|t|^α`, *below* the quadratic order that a second-order Taylor (Berry–Esseen) expansion controls. This sub-quadratic deviation is the frequency-domain signature of infinite variance and the precise reason the classical rate argument has no finite α < 2 analogue.",
-    "mathContext": "$0<t<1 \\Rightarrow \\varphi_\\alpha(t) < \\varphi_2(t)$; deviation $\\sim |t|^\\alpha$, sub-quadratic for $\\alpha<2$."
+    "mathContext": "$0<t<1 \\Rightarrow \\varphi_\\alpha(t) < \\varphi_2(t)$; deviation $\\sim |t|^\\alpha$, sub-quadratic for $\\alpha<2$.",
+    "significance": "key",
+    "relatedConcepts": ["infinite variance", "Taylor expansion order", "heavy-tailed distributions", "frequency-domain analysis"],
+    "prerequisites": ["strict monotonicity of exp (Real.exp_lt_exp)", "second-order Taylor expansion of the characteristic function"]
   },
   {
     "id": "cltoq0104-ann-04",
@@ -33,7 +42,10 @@
     "type": "technique",
     "title": "The Berry–Esseen kernel: where the third moment enters",
     "content": "`charFun_kernel_second` restates Mathlib's `Complex.norm_exp_sub_one_sub_id_le` for the integrand `e^{ia}` (a = t·x): `‖e^{ia} − (1 + ia)‖ ≤ a²`. In the classical proof one integrates this against the law of X; the `a²` remainder becomes a variance term and the next-order cubic correction a third-moment term, which is exactly how a finite `ρ = E|X|³` produces the `C·ρ/(σ³√n)` rate. For α-stable laws with α < 2 the corresponding moment is infinite, so this remainder cannot be integrated to a finite constant — the analytic counterpart of the crossover above.",
-    "mathContext": "$\\|e^{ia}-(1+ia)\\| \\le a^2$; integrated $\\Rightarrow$ variance/third-moment term $\\Rightarrow$ $O(1/\\sqrt n)$."
+    "mathContext": "$\\|e^{ia}-(1+ia)\\| \\le a^2$; integrated $\\Rightarrow$ variance/third-moment term $\\Rightarrow$ $O(1/\\sqrt n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["complex exponential Taylor remainder", "third absolute moment", "rate of convergence", "Berry–Esseen inequality"],
+    "prerequisites": ["Complex.norm_exp_sub_one_sub_id_le", "‖a·I‖ = |a| (Complex.norm_I)"]
   },
   {
     "id": "cltoq0104-ann-05",
@@ -42,6 +54,9 @@
     "type": "caveat",
     "title": "Scope: the obstruction is formalized, not the rate",
     "content": "This entry does NOT prove an α-stable Berry–Esseen rate — that is the open question and is genuinely hard. It formalizes, axiom-free, the analytic mechanism of the classical theorem and the precise obstruction to extending it below α = 2 (the sub-quadratic |t|^α deviation). The kernel bounds are attributed Mathlib wrappers; the crossover analysis is the new content. #print axioms shows only propext / Classical.choice / Quot.sound.",
-    "mathContext": "Goal: isolate why a Gaussian-rate expansion fails for $\\alpha<2$, not to derive the stable rate."
+    "mathContext": "Goal: isolate why a Gaussian-rate expansion fails for $\\alpha<2$, not to derive the stable rate.",
+    "significance": "context",
+    "relatedConcepts": ["open problem framing", "axiom-free formalization", "proof scope"],
+    "prerequisites": ["#print axioms", "the infinite-variance CLT and α-stable limit laws"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `central-limit-theorem-oq-01-oq-04`.

## Changes
- Added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations (previously `content` + `mathContext` only).

## Not done (intentional)
- meta.json unchanged — already rich (full overview, sections, conclusion, crossRefs, references, mainTheorems) and within the 60 KB cap.
- No per-proof `index.ts`: proof discovery is `readdirSync`+`meta.json` since phase-2 refactor (#20993); shims are vestigial.

## Verification
- `pnpm annotations:build` exit 0, no warnings for this entry; JSON valid; within size caps.