### PR TITLE
Enrich Ceva's Theorem Non-Euclidean OQ-03 (cevas-theorem-non-euclidean-oq-03)

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-03/annotations.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-03/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "The hexagon closure relation: P·P' = 1",
     "content": "The six measures of a GeneralizedCevianConfig are the six sides of the Pappus hexagon. The Ceva product P reads them in one alternating order; the dual product P' = (dc/ce)(ea/af)(fb/bd) reads the complementary order. Multiplying P·P' writes every measure once in a numerator and once in a denominator, so the whole thing telescopes to 1 (ceva_dual_reciprocal). Discharged by `field_simp` once the parent's positivity fields give the nonzero denominators — no `ring` needed, field_simp closes it. This single telescoping identity is the geometry-independent invariant of the hexagon.",
-    "mathContext": "$P\\cdot P' = \\frac{bd}{dc}\\frac{ce}{ea}\\frac{af}{fb}\\cdot\\frac{dc}{ce}\\frac{ea}{af}\\frac{fb}{bd}=1.$"
+    "mathContext": "$P\\cdot P' = \\frac{bd}{dc}\\frac{ce}{ea}\\frac{af}{fb}\\cdot\\frac{dc}{ce}\\frac{ea}{af}\\frac{fb}{bd}=1.$",
+    "significance": "key",
+    "relatedConcepts": ["Ceva's theorem", "Pappus hexagon", "telescoping product", "projective invariant"],
+    "prerequisites": ["ratio of directed measures", "field_simp with nonzero hypotheses"]
   },
   {
     "id": "cevaoq03-ann-02",
@@ -15,7 +18,10 @@
     "type": "result",
     "title": "Ceva–Brianchon duality at the abstract level",
     "content": "From P·P' = 1 it is immediate that P = 1 ↔ P' = 1 (ceva_iff_dual): the Ceva concurrence condition and its hexagon dual are equivalent. This is the projective Ceva–Brianchon duality appearing already in the abstract ratio framework, before any incidence geometry — and, being a fact about the configuration, it holds in Euclidean, spherical, and hyperbolic geometry alike.",
-    "mathContext": "$P=1 \\iff P'=1$ (Ceva $\\iff$ its hexagon dual)."
+    "mathContext": "$P=1 \\iff P'=1$ (Ceva $\\iff$ its hexagon dual).",
+    "significance": "key",
+    "relatedConcepts": ["projective duality", "Brianchon's theorem", "concurrence condition"],
+    "prerequisites": ["the closure relation P·P' = 1", "equivalence reasoning over an ordered field"]
   },
   {
     "id": "cevaoq03-ann-03",
@@ -24,7 +30,10 @@
     "type": "technique",
     "title": "Composition: the chaining engine of the Pappus proof",
     "content": "`comp` multiplies two configurations measure-by-measure. Both alternating products are multiplicative under it (cevaProduct_comp, dualProduct_comp, each closed by field_simp), so if two configurations satisfy the Ceva condition so does their composite (ceva_comp_of_ceva). This is exactly the algebraic step in the classical proof of Pappus's theorem, which multiplies several Menelaus/transversal ratio relations and lets the shared factors cancel — here captured as a clean composition law inside the framework.",
-    "mathContext": "$P(c_1 \\ast c_2) = P(c_1)P(c_2)$; closure: $1\\cdot 1 = 1$."
+    "mathContext": "$P(c_1 \\ast c_2) = P(c_1)P(c_2)$; closure: $1\\cdot 1 = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Pappus's theorem", "Menelaus's theorem", "multiplicative homomorphism", "composition law"],
+    "prerequisites": ["pointwise product of configurations", "multiplicativity of the ratio product"]
   },
   {
     "id": "cevaoq03-ann-04",
@@ -33,7 +42,10 @@
     "type": "result",
     "title": "Non-Euclidean instances via sin and sinh",
     "content": "Because the closure relation is a statement about the abstract configuration, it transfers verbatim to the sphere and the hyperbolic plane by feeding geodesic-arc measures through the parent's measure builders: spherical_ceva_dual_reciprocal uses `sin`, hyperbolic_ceva_dual_reciprocal uses `sinh`. These are the non-Euclidean Pappus–Brianchon hexagon closure relations — one abstract theorem, three geometries.",
-    "mathContext": "Closure for $\\rho=\\sin$ (sphere) and $\\rho=\\sinh$ (hyperbolic plane)."
+    "mathContext": "Closure for $\\rho=\\sin$ (sphere) and $\\rho=\\sinh$ (hyperbolic plane).",
+    "significance": "supporting",
+    "relatedConcepts": ["spherical geometry", "hyperbolic geometry", "geodesic arc length", "law of sines / sinh"],
+    "prerequisites": ["non-Euclidean trigonometry (sin / sinh measures)", "instantiation of an abstract theorem"]
   },
   {
     "id": "cevaoq03-ann-05",
@@ -42,6 +54,9 @@
     "type": "caveat",
     "title": "Scope: the hexagon invariant, not the full incidence theorem",
     "content": "This entry formalizes the geometry-independent algebraic invariant of the Pappus hexagon — the closure reciprocity and the composition law — entirely inside GeneralizedCevianConfig. It does NOT derive the full projective incidence statement of Pappus/Brianchon (collinearity of the three diagonal points), which requires the combinatorics of lines and intersection points; that is future work that can build on the composition law here. #print axioms shows only propext / Classical.choice / Quot.sound — genuinely 0-axiom.",
-    "mathContext": "Proved: hexagon ratio invariant. Not proved: full projective incidence statement."
+    "mathContext": "Proved: hexagon ratio invariant. Not proved: full projective incidence statement.",
+    "significance": "context",
+    "relatedConcepts": ["projective incidence geometry", "collinearity of diagonal points", "proof scope", "axiom-free formalization"],
+    "prerequisites": ["#print axioms", "projective vs metric formulations of Pappus's theorem"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `cevas-theorem-non-euclidean-oq-03`.

## Changes
- Added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations.

## Not done (intentional)
- meta.json unchanged — already rich and within the 60 KB cap (verified, original, 0 axioms, 0 sorries — consistent).
- No per-proof `index.ts`: vestigial since phase-2 discovery refactor (#20993).

## Verification
- JSON valid; meta within size caps.