### PR TITLE
Enrich Erdős #823 σ-value computations (erdos-823-oq-05)

### DIFF
--- a/src/data/proofs/erdos-823-oq-05/annotations.json
+++ b/src/data/proofs/erdos-823-oq-05/annotations.json
@@ -6,7 +6,10 @@
     "type": "technique",
     "title": "σ on a prime: the only ingredient beyond multiplicativity",
     "content": "`sigma_one_prime` is the whole arithmetic content. For a prime `p`, Mathlib's `Nat.Prime.divisors` gives `divisors p = {1, p}`, so `σ 1 p = ∑ d ∈ {1,p}, d = 1 + p` by `Finset.sum_pair` (using `1 ≠ p`). `omega` flips `1 + p` to `p + 1`. Everything else in the file is coprime multiplicativity applied to this fact.",
-    "mathContext": "$\\sigma(p) = \\sum_{d \\mid p} d = 1 + p$ since divisors$(p) = \\{1, p\\}$."
+    "mathContext": "$\\sigma(p) = \\sum_{d \\mid p} d = 1 + p$ since divisors$(p) = \\{1, p\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["sum-of-divisors function σ", "prime divisors", "Finset.sum_pair"],
+    "prerequisites": ["divisors of a prime (Nat.Prime.divisors)", "summing over a two-element finset"]
   },
   {
     "id": "e823sv-ann-02",
@@ -15,7 +18,10 @@
     "type": "technique",
     "title": "Reading σ off the factorization, axiom-free",
     "content": "`sigma_14` is the template. Rewrite `14 = 2·7`; `isMultiplicative_sigma.map_mul_of_coprime` splits `σ(2·7) = σ(2)·σ(7)` once the gcd condition `gcd 2 7 = 1` is supplied (here by kernel `decide` — small, no compiled evaluator); `sigma_one_prime` evaluates each prime to `p+1`; `norm_num` finishes `3·8 = 24`. No `native_decide`, so no `Lean.ofReduceBool`. The same five lines, with a different factorization, give every other value.",
-    "mathContext": "$\\sigma(14) = \\sigma(2)\\,\\sigma(7) = (2{+}1)(7{+}1) = 3 \\cdot 8 = 24.$"
+    "mathContext": "$\\sigma(14) = \\sigma(2)\\,\\sigma(7) = (2{+}1)(7{+}1) = 3 \\cdot 8 = 24.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative arithmetic functions", "coprimality", "decide vs native_decide"],
+    "prerequisites": ["isMultiplicative_sigma.map_mul_of_coprime", "kernel decidability of gcd"]
   },
   {
     "id": "e823sv-ann-03",
@@ -24,7 +30,10 @@
     "type": "concept",
     "title": "Prime powers: σ(2²) and the perfect number 28",
     "content": "`sigma_28` needs the one prime power 2² in 28 = 2²·7. There `sigma_one_apply_prime_pow` gives `σ(2²) = ∑_{k<3} 2^k = 1+2+4 = 7`, expanded by `simp [Finset.sum_range_succ]`; multiplicativity then yields `7·8 = 56`. Since 56 = 2·28, `twentyeight_perfect` certifies 28 as the second perfect number — axiom-free.",
-    "mathContext": "$\\sigma(2^2) = 1+2+4 = 7,\\quad \\sigma(28) = 7 \\cdot 8 = 56 = 2 \\cdot 28.$"
+    "mathContext": "$\\sigma(2^2) = 1+2+4 = 7,\\quad \\sigma(28) = 7 \\cdot 8 = 56 = 2 \\cdot 28.$",
+    "significance": "key",
+    "relatedConcepts": ["prime-power formula for σ", "perfect numbers", "geometric series of divisors"],
+    "prerequisites": ["sigma_one_apply_prime_pow", "definition of a perfect number (σ(n) = 2n)"]
   },
   {
     "id": "e823sv-ann-04",
@@ -33,7 +42,10 @@
     "type": "result",
     "title": "Consecutive-integer σ-pairs: the base of Pollack's theorem",
     "content": "`sigma_pair_14_15` and `sigma_pair_957_958` record that 14,15 and 957,958 are pairs of consecutive integers with equal σ — value-collisions of the sum-of-divisors function. These are the simplest instances (ratio n/m ≈ 1) of the phenomenon Erdős #823 / Pollack push to arbitrary ratios α. `fiber_24` packages 14,15 ∈ σ⁻¹(24) as the concrete α = 1 witness.",
-    "mathContext": "$\\sigma(14)=\\sigma(15)=24,\\quad \\sigma(957)=\\sigma(958)=1440.$"
+    "mathContext": "$\\sigma(14)=\\sigma(15)=24,\\quad \\sigma(957)=\\sigma(958)=1440.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Erdős problem #823", "Pollack's theorem", "fibers of σ", "consecutive integers"],
+    "prerequisites": ["the σ-value collision phenomenon", "preimage (fiber) of an arithmetic function"]
   },
   {
     "id": "e823sv-ann-05",
@@ -42,6 +54,9 @@
     "type": "caveat",
     "title": "A false native_decide claim in the parent",
     "content": "While recomputing the parent's values, σ(206) and σ(210) come out 312 and 576 — so the parent's `sigma_206_210 : σ 206 = σ 210`, asserted by `native_decide`, is false. This entry does not reproduce it. The episode illustrates the policy point: a symbolic proof cannot close a false goal, but `native_decide` will happily certify whatever the compiled evaluator returns — another reason to prefer kernel-checked, axiom-free computation for facts presented as verified.",
-    "mathContext": "$\\sigma(206) = \\sigma(2\\cdot 103) = 3\\cdot 104 = 312 \\ne 576 = 3\\cdot 4\\cdot 6\\cdot 8 = \\sigma(210).$"
+    "mathContext": "$\\sigma(206) = \\sigma(2\\cdot 103) = 3\\cdot 104 = 312 \\ne 576 = 3\\cdot 4\\cdot 6\\cdot 8 = \\sigma(210).$",
+    "significance": "context",
+    "relatedConcepts": ["native_decide soundness", "Lean.ofReduceBool axiom", "axiom integrity", "verification trust"],
+    "prerequisites": ["how native_decide trusts the compiled evaluator", "kernel reduction vs compiled reduction"]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `erdos-823-oq-05`.

## Changes
- Added `significance`, `relatedConcepts`, and `prerequisites` to all 5 annotations.

## Not done (intentional)
- meta.json unchanged — already rich and within the 60 KB cap (verified, original, 0 axioms, 0 sorries — consistent with the axiom-free, no-native_decide Lean file).
- No per-proof `index.ts`: vestigial since phase-2 discovery refactor (#20993).

## Verification
- JSON valid; annotation ranges within the 132-line Lean file; meta within size caps.