### PR TITLE
Enrich The Elementary Rich-Line Bound (erdos-733-oq-02): annotation depth

### DIFF
--- a/src/data/proofs/erdos-733-oq-02/annotations.json
+++ b/src/data/proofs/erdos-733-oq-02/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "Disjoint pairs: where linearity enters",
     "content": "`disjoint_pairs` is the only place the geometry is used. Each line `L` carries the family `L.powersetCard 2` of its two-element point-subsets. If a two-element set `s` belonged to both `L₁.powersetCard 2` and `L₂.powersetCard 2`, then `s ⊆ L₁ ∩ L₂` with `|s| = 2`, forcing `|L₁ ∩ L₂| ≥ 2`. But the linear-space hypothesis says two distinct lines meet in at most one point, so the families are disjoint. No point-pair lies on two lines — this is exactly the fact that makes the counting work.",
-    "mathContext": "$s \\subseteq L_1 \\cap L_2,\\ |s| = 2 \\Rightarrow |L_1 \\cap L_2| \\ge 2$, contradicting $|L_1 \\cap L_2| \\le 1$."
+    "mathContext": "$s \\subseteq L_1 \\cap L_2,\\ |s| = 2 \\Rightarrow |L_1 \\cap L_2| \\ge 2$, contradicting $|L_1 \\cap L_2| \\le 1$.",
+    "significance": "key",
+    "relatedConcepts": ["linear space (partial linear space)", "two-element subsets", "Finset.powersetCard", "pairwise disjointness"],
+    "prerequisites": ["the linear-space axiom: two lines meet in ≤ 1 point", "subsets and intersection cardinality"]
   },
   {
     "id": "e733rl-ann-02",
@@ -15,7 +18,10 @@
     "type": "technique",
     "title": "Double counting via a disjoint biUnion",
     "content": "`sum_choose_two_le` is the engine. Rewriting `C(|L|,2)` as `(L.powersetCard 2).card` (Finset.card_powersetCard) turns the sum over lines into a sum of cardinalities of pairwise-disjoint finsets. `Finset.card_biUnion` (using the disjointness from `disjoint_pairs`) collapses that sum into the cardinality of their union, and the union sits inside `P.powersetCard 2` because every line is a subset of `P`. Hence `∑_L C(|L|,2) ≤ C(n,2)`. This single inequality powers every rich-line bound below.",
-    "mathContext": "$\\sum_{L} \\binom{|L|}{2} = \\Big|\\bigsqcup_L \\binom{L}{2}\\Big| \\le \\Big|\\binom{P}{2}\\Big| = \\binom{n}{2}.$"
+    "mathContext": "$\\sum_{L} \\binom{|L|}{2} = \\Big|\\bigsqcup_L \\binom{L}{2}\\Big| \\le \\Big|\\binom{P}{2}\\Big| = \\binom{n}{2}.$",
+    "significance": "key",
+    "relatedConcepts": ["double counting", "Finset.card_biUnion", "disjoint union cardinality", "Finset.card_powersetCard", "handshake principle"],
+    "prerequisites": ["cardinality of a disjoint biUnion", "binomial coefficient as a count of 2-subsets"]
   },
   {
     "id": "e733rl-ann-03",
@@ -24,7 +30,10 @@
     "type": "concept",
     "title": "Charging rich lines to point-pairs",
     "content": "`rich_line_bound` is the headline. Over the k-rich lines, the constant estimate `C(k,2) ≤ C(|L|,2)` (Nat.choose_le_choose, since `k ≤ |L|`) sums to `#{k-rich lines} · C(k,2) ≤ ∑_L C(|L|,2) ≤ C(n,2)`. Read combinatorially: every k-rich line is charged the `C(k,2)` pairs it must contain, no pair is charged twice (disjointness), and there are only `C(n,2)` pairs to spend. The count of k-rich lines is therefore at most `C(n,2)/C(k,2) = O(n²/k²)`.",
-    "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}.$"
+    "mathContext": "$\\#\\{L : |L| \\ge k\\}\\cdot \\binom{k}{2} \\le \\sum_L \\binom{|L|}{2} \\le \\binom{n}{2}.$",
+    "significance": "key",
+    "relatedConcepts": ["rich lines", "monotonicity of binomial coefficients", "Nat.choose_le_choose", "amortized counting argument", "Szemerédi–Trotter baseline"],
+    "prerequisites": ["filtering a Finset by a predicate", "monotonicity C(k,2) ≤ C(m,2) for k ≤ m"]
   },
   {
     "id": "e733rl-ann-04",
@@ -33,7 +42,10 @@
     "type": "result",
     "title": "k = 2: bounding the number of proper lines",
     "content": "`num_proper_lines_le` specializes `rich_line_bound` at `k = 2`. Since `C(2,2) = 1`, the bound becomes `#{lines with ≥ 2 points} ≤ C(n,2)`: each proper line is charged to a distinct point-pair. This is the easy direction of de Bruijn–Erdős-style counting and shows that a linear space on n points has at most quadratically many lines.",
-    "mathContext": "$\\binom{2}{2} = 1 \\Rightarrow \\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}.$"
+    "mathContext": "$\\binom{2}{2} = 1 \\Rightarrow \\#\\{L : |L| \\ge 2\\} \\le \\binom{n}{2}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["de Bruijn–Erdős theorem", "proper lines", "linear space line count", "specialization k = 2"],
+    "prerequisites": ["C(2,2) = 1", "the rich_line_bound inequality"]
   },
   {
     "id": "e733rl-ann-05",
@@ -42,6 +54,9 @@
     "type": "caveat",
     "title": "Honest scope: weaker than Szemerédi–Trotter, but unconditional and 0-axiom",
     "content": "The bound here is `O(n²/k²)`; Szemerédi–Trotter improves the exponent on k from 2 to 3 (plus an `n/k` term): `O(n²/k³ + n/k)`. That improvement is the genuinely deep content the parent Erdős #733 file axiomatizes, and this entry does NOT discharge those axioms. What it does deliver is the elementary baseline, fully machine-checked with no incidence theorem. The linear-space conditions `hsub` and `hlin` are ordinary hypotheses, not structure-encoded axioms, so the file is genuinely 0-axiom under the project's axiom-integrity policy.",
-    "mathContext": "Elementary: $O(n^2/k^2)$. Szemerédi–Trotter: $O(n^2/k^3 + n/k)$."
+    "mathContext": "Elementary: $O(n^2/k^2)$. Szemerédi–Trotter: $O(n^2/k^3 + n/k)$.",
+    "significance": "context",
+    "relatedConcepts": ["Szemerédi–Trotter theorem", "incidence geometry", "axiom-integrity policy", "elementary vs deep bounds"],
+    "prerequisites": ["asymptotic comparison of O(n²/k²) and O(n²/k³ + n/k)", "what it means for a Lean result to be 0-axiom"]
   }
 ]


### PR DESCRIPTION
## Enrichment pass for `erdos-733-oq-02` (pass 0)

Rich, axiom-free entry (meta.json 14.9 KB, under cap). Quality gap was annotation depth — the 5 annotations had `content`/`mathContext` but lacked structured fields.

### Changes
- Added `significance`, `relatedConcepts`, `prerequisites` to all 5 annotations (key/supporting/context tiers; double-counting, linear-space, de Bruijn–Erdős, Szemerédi–Trotter links).

### Verification
- JSON valid; `annotations/build.ts`: zero warnings for this target.
- Axiom integrity unchanged: `verified` / `original` / axiomCount 0 (hypotheses are ordinary args, not structure-encoded).